### PR TITLE
Fix plugin directory bug

### DIFF
--- a/.vscode/configurationCache.log
+++ b/.vscode/configurationCache.log
@@ -1,1 +1,0 @@
-{"buildTargets":[".NOTPARALLEL",".PHONY","exhaustive","fmtcheck","generate","protobuf","staticcheck","website","website-test","website/build-local","website/local"],"launchTargets":[],"customConfigurationProvider":{"workspaceBrowse":{"browsePath":[],"compilerArgs":[]},"fileIndex":[]}}

--- a/.vscode/configurationCache.log
+++ b/.vscode/configurationCache.log
@@ -1,0 +1,1 @@
+{"buildTargets":[".NOTPARALLEL",".PHONY","exhaustive","fmtcheck","generate","protobuf","staticcheck","website","website-test","website/build-local","website/local"],"launchTargets":[],"customConfigurationProvider":{"workspaceBrowse":{"browsePath":[],"compilerArgs":[]},"fileIndex":[]}}

--- a/main.go
+++ b/main.go
@@ -170,7 +170,6 @@ func realMain() int {
 		return 1
 	}
 
-	//FJN here <<<<<<<<<<<<<<<<<<<<
 	// The arguments can begin with a -chdir option to ask Terraform to switch
 	// to a different working directory for the rest of its work. If that
 	// option is present then extractChdirOption returns a trimmed args with that option removed.

--- a/main.go
+++ b/main.go
@@ -159,6 +159,34 @@ func realMain() int {
 	}
 	services.SetUserAgent(httpclient.TerraformUserAgent(version.String()))
 
+	// Get the command line args.
+	binName := filepath.Base(os.Args[0])
+	args := os.Args[1:]
+
+	originalWd, err := os.Getwd()
+	if err != nil {
+		// It would be very strange to end up here
+		Ui.Error(fmt.Sprintf("Failed to determine current working directory: %s", err))
+		return 1
+	}
+
+	//FJN here <<<<<<<<<<<<<<<<<<<<
+	// The arguments can begin with a -chdir option to ask Terraform to switch
+	// to a different working directory for the rest of its work. If that
+	// option is present then extractChdirOption returns a trimmed args with that option removed.
+	overrideWd, args, err := extractChdirOption(args)
+	if err != nil {
+		Ui.Error(fmt.Sprintf("Invalid -chdir option: %s", err))
+		return 1
+	}
+	if overrideWd != "" {
+		err := os.Chdir(overrideWd)
+		if err != nil {
+			Ui.Error(fmt.Sprintf("Error handling -chdir option: %s", err))
+			return 1
+		}
+	}
+
 	providerSrc, diags := providerSource(config.ProviderInstallation, services)
 	if len(diags) > 0 {
 		Ui.Error("There are some problems with the provider_installation configuration:")
@@ -188,33 +216,6 @@ func realMain() int {
 
 	// Initialize the backends.
 	backendInit.Init(services)
-
-	// Get the command line args.
-	binName := filepath.Base(os.Args[0])
-	args := os.Args[1:]
-
-	originalWd, err := os.Getwd()
-	if err != nil {
-		// It would be very strange to end up here
-		Ui.Error(fmt.Sprintf("Failed to determine current working directory: %s", err))
-		return 1
-	}
-
-	// The arguments can begin with a -chdir option to ask Terraform to switch
-	// to a different working directory for the rest of its work. If that
-	// option is present then extractChdirOption returns a trimmed args with that option removed.
-	overrideWd, args, err := extractChdirOption(args)
-	if err != nil {
-		Ui.Error(fmt.Sprintf("Invalid -chdir option: %s", err))
-		return 1
-	}
-	if overrideWd != "" {
-		err := os.Chdir(overrideWd)
-		if err != nil {
-			Ui.Error(fmt.Sprintf("Error handling -chdir option: %s", err))
-			return 1
-		}
-	}
 
 	// In tests, Commands may already be set to provide mock commands
 	if Commands == nil {


### PR DESCRIPTION
Fixes Bug reported in https://github.com/hashicorp/terraform/issues/31442

The code to reset the current working directory was previously called after the local providers checked in `implicitProviderSource()` is called.

I simply moved up the block of code handling the reset of the current working directory ahead of `providerSource()` which subsequently calls `implicitProviderSource() `.

I have compiled and tested the code to verify it fixes the cited issue, but can not be 100% sure there are no other side effects from this change.  I cannot think of any situation where you need to maintain the CWD when specifying `-chdir`, but there could be some side effects I am not aware of.
