### PR TITLE
command: fix panic on show when state file is invalid or unavailable

### DIFF
--- a/internal/command/show.go
+++ b/internal/command/show.go
@@ -151,7 +151,7 @@ func (c *ShowCommand) showFromLatestStateSnapshot() (*statefile.File, tfdiags.Di
 	// Get the latest state snapshot from the backend for the current workspace
 	stateFile, stateErr := getStateFromBackend(b, workspace)
 	if stateErr != nil {
-		diags = diags.Append(stateErr.Error())
+		diags = diags.Append(stateErr)
 		return nil, diags
 	}
 

--- a/internal/command/show_test.go
+++ b/internal/command/show_test.go
@@ -905,6 +905,34 @@ func TestShow_planWithNonDefaultStateLineage(t *testing.T) {
 	}
 }
 
+func TestShow_corruptStatefile(t *testing.T) {
+	td := t.TempDir()
+	inputDir := "testdata/show-corrupt-statefile"
+	testCopyDir(t, inputDir, td)
+	defer testChdir(t, td)()
+
+	view, done := testView(t)
+	c := &ShowCommand{
+		Meta: Meta{
+			testingOverrides: metaOverridesForProvider(testProvider()),
+			View:             view,
+		},
+	}
+
+	code := c.Run([]string{})
+	output := done(t)
+
+	if code != 1 {
+		t.Fatalf("unexpected exit status %d; want 1\ngot: %s", code, output.Stdout())
+	}
+
+	got := output.Stderr()
+	want := `Unsupported state file format`
+	if !strings.Contains(got, want) {
+		t.Errorf("unexpected output\ngot: %s\nwant:\n%s", got, want)
+	}
+}
+
 // showFixtureSchema returns a schema suitable for processing the configuration
 // in testdata/show. This schema should be assigned to a mock provider
 // named "test".

--- a/internal/command/testdata/show-corrupt-statefile/terraform.tfstate
+++ b/internal/command/testdata/show-corrupt-statefile/terraform.tfstate
@@ -1,0 +1,1 @@
+invalid


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform/issues/31430.

This fixes a panic caused by passing a `string` to `diags.Append()`.
