### PR TITLE
Alternate fix to mirror directory bug

### DIFF
--- a/.vscode/configurationCache.log
+++ b/.vscode/configurationCache.log
@@ -1,1 +1,0 @@
-{"buildTargets":[".NOTPARALLEL",".PHONY","exhaustive","fmtcheck","generate","protobuf","staticcheck","website","website-test","website/build-local","website/local"],"launchTargets":[],"customConfigurationProvider":{"workspaceBrowse":{"browsePath":[],"compilerArgs":[]},"fileIndex":[]}}

--- a/.vscode/configurationCache.log
+++ b/.vscode/configurationCache.log
@@ -1,0 +1,1 @@
+{"buildTargets":[".NOTPARALLEL",".PHONY","exhaustive","fmtcheck","generate","protobuf","staticcheck","website","website-test","website/build-local","website/local"],"launchTargets":[],"customConfigurationProvider":{"workspaceBrowse":{"browsePath":[],"compilerArgs":[]},"fileIndex":[]}}

--- a/main.go
+++ b/main.go
@@ -184,9 +184,24 @@ func realMain() int {
 			Ui.Error(fmt.Sprintf("Error handling -chdir option: %s", err))
 			return 1
 		}
+		fmt.Printf("Passed in value: %v\n", overrideWd)
+		// normalize the path of the override directory
+		overrideWd, err = os.Getwd()
+		if err != nil {
+			// It would be very strange to end up here
+			Ui.Error(fmt.Sprintf("Failed to determine current working directory: %s", err))
+			return 1
+		}
+		fmt.Printf("OS value: %v\n", overrideWd)
+		// set the directory back to original directory temporarily
+		err = os.Chdir(originalWd)
+		if err != nil {
+			Ui.Error(fmt.Sprintf("Error handling -chdir option for temporary reset: %s", err))
+			return 1
+		}
 	}
 
-	providerSrc, diags := providerSource(config.ProviderInstallation, services)
+	providerSrc, diags := providerSource(config.ProviderInstallation, services, overrideWd)
 	if len(diags) > 0 {
 		Ui.Error("There are some problems with the provider_installation configuration:")
 		for _, diag := range diags {
@@ -215,6 +230,15 @@ func realMain() int {
 
 	// Initialize the backends.
 	backendInit.Init(services)
+
+	// set the directory back to the override directory
+	if overrideWd != "" {
+		err := os.Chdir(overrideWd)
+		if err != nil {
+			Ui.Error(fmt.Sprintf("Error handling -chdir option: %s", err))
+			return 1
+		}
+	}
 
 	// In tests, Commands may already be set to provide mock commands
 	if Commands == nil {

--- a/main.go
+++ b/main.go
@@ -170,7 +170,6 @@ func realMain() int {
 		return 1
 	}
 
-	//FJN here <<<<<<<<<<<<<<<<<<<<
 	// The arguments can begin with a -chdir option to ask Terraform to switch
 	// to a different working directory for the rest of its work. If that
 	// option is present then extractChdirOption returns a trimmed args with that option removed.

--- a/main.go
+++ b/main.go
@@ -159,6 +159,34 @@ func realMain() int {
 	}
 	services.SetUserAgent(httpclient.TerraformUserAgent(version.String()))
 
+	// Get the command line args.
+	binName := filepath.Base(os.Args[0])
+	args := os.Args[1:]
+
+	originalWd, err := os.Getwd()
+	if err != nil {
+		// It would be very strange to end up here
+		Ui.Error(fmt.Sprintf("Failed to determine current working directory: %s", err))
+		return 1
+	}
+
+	//FJN here <<<<<<<<<<<<<<<<<<<<
+	// The arguments can begin with a -chdir option to ask Terraform to switch
+	// to a different working directory for the rest of its work. If that
+	// option is present then extractChdirOption returns a trimmed args with that option removed.
+	overrideWd, args, err := extractChdirOption(args)
+	if err != nil {
+		Ui.Error(fmt.Sprintf("Invalid -chdir option: %s", err))
+		return 1
+	}
+	if overrideWd != "" {
+		err := os.Chdir(overrideWd)
+		if err != nil {
+			Ui.Error(fmt.Sprintf("Error handling -chdir option: %s", err))
+			return 1
+		}
+	}
+
 	providerSrc, diags := providerSource(config.ProviderInstallation, services)
 	if len(diags) > 0 {
 		Ui.Error("There are some problems with the provider_installation configuration:")
@@ -188,33 +216,6 @@ func realMain() int {
 
 	// Initialize the backends.
 	backendInit.Init(services)
-
-	// Get the command line args.
-	binName := filepath.Base(os.Args[0])
-	args := os.Args[1:]
-
-	originalWd, err := os.Getwd()
-	if err != nil {
-		// It would be very strange to end up here
-		Ui.Error(fmt.Sprintf("Failed to determine current working directory: %s", err))
-		return 1
-	}
-
-	// The arguments can begin with a -chdir option to ask Terraform to switch
-	// to a different working directory for the rest of its work. If that
-	// option is present then extractChdirOption returns a trimmed args with that option removed.
-	overrideWd, args, err := extractChdirOption(args)
-	if err != nil {
-		Ui.Error(fmt.Sprintf("Invalid -chdir option: %s", err))
-		return 1
-	}
-	if overrideWd != "" {
-		err := os.Chdir(overrideWd)
-		if err != nil {
-			Ui.Error(fmt.Sprintf("Error handling -chdir option: %s", err))
-			return 1
-		}
-	}
 
 	// In tests, Commands may already be set to provide mock commands
 	if Commands == nil {

--- a/provider_source.go
+++ b/provider_source.go
@@ -20,12 +20,12 @@ import (
 // CLI configuration and some default search locations. This will be the
 // provider source used for provider installation in the "terraform init"
 // command, unless overridden by the special -plugin-dir option.
-func providerSource(configs []*cliconfig.ProviderInstallation, services *disco.Disco) (getproviders.Source, tfdiags.Diagnostics) {
+func providerSource(configs []*cliconfig.ProviderInstallation, services *disco.Disco, overrideWd string) (getproviders.Source, tfdiags.Diagnostics) {
 	if len(configs) == 0 {
 		// If there's no explicit installation configuration then we'll build
 		// up an implicit one with direct registry installation along with
 		// some automatically-selected local filesystem mirrors.
-		return implicitProviderSource(services), nil
+		return implicitProviderSource(services, overrideWd), nil
 	}
 
 	// There should only be zero or one configurations, which is checked by
@@ -86,7 +86,7 @@ func explicitProviderSource(config *cliconfig.ProviderInstallation, services *di
 // one version available in a local directory are implicitly excluded from
 // direct installation, as if the user had listed them explicitly in the
 // "exclude" argument in the direct provider source in the CLI config.
-func implicitProviderSource(services *disco.Disco) getproviders.Source {
+func implicitProviderSource(services *disco.Disco, overrideWd string) getproviders.Source {
 	// The local search directories we use for implicit configuration are:
 	// - The "terraform.d/plugins" directory in the current working directory,
 	//   which we've historically documented as a place to put plugins as a
@@ -140,7 +140,12 @@ func implicitProviderSource(services *disco.Disco) getproviders.Source {
 		}
 	}
 
-	addLocalDir("terraform.d/plugins") // our "vendor" directory
+	localMirror := "terraform.d/plugins"
+	// if user has applied -chdir re-home where to look for local mirror
+	if overrideWd != "" {
+		localMirror = filepath.Join(overrideWd, localMirror)
+	}
+	addLocalDir(localMirror) // our "vendor" directory
 	cliConfigDir, err := cliconfig.ConfigDir()
 	if err == nil {
 		addLocalDir(filepath.Join(cliConfigDir, "plugins"))


### PR DESCRIPTION
Fixes Bug reported in https://github.com/hashicorp/terraform/issues/31442

This PR is an alternate implementation of https://github.com/hashicorp/terraform/pull/31443

The code to reset the current working directory was previously called after the local providers checked in implicitProviderSource() is called.

In this implementation, I moved up the block of code handling the reset of the current working directory ahead of providerSource() which subsequently calls implicitProviderSource(), but after validating the -chdir and capturing that directory I reset the CWD back to the launch directory, to limit side effects of the change.

I then pass in `overrideWd` to providerSource() and implicitProviderSource() so that the overrideWd can be applied to the local mirror.