### PR TITLE
remote-state/s3: Use S3 read-after-write consistency for state locking (#27070)

### DIFF
--- a/internal/backend/remote-state/s3/backend_test.go
+++ b/internal/backend/remote-state/s3/backend_test.go
@@ -466,13 +466,11 @@ func TestBackendExtraPaths(t *testing.T) {
 	// RemoteClient to Put things in various paths
 	client := &RemoteClient{
 		s3Client:             b.s3Client,
-		dynClient:            b.dynClient,
 		bucketName:           b.bucketName,
 		path:                 b.path("s1"),
 		serverSideEncryption: b.serverSideEncryption,
 		acl:                  b.acl,
 		kmsKeyID:             b.kmsKeyID,
-		ddbTable:             b.ddbTable,
 	}
 
 	// Write the first state

--- a/internal/backend/remote-state/s3/client_test.go
+++ b/internal/backend/remote-state/s3/client_test.go
@@ -16,7 +16,7 @@ import (
 
 func TestRemoteClient_impl(t *testing.T) {
 	var _ remote.Client = new(RemoteClient)
-	var _ remote.ClientLocker = new(RemoteClient)
+	var _ remote.ClientLocker = new(RemoteClientWithDDBLock)
 }
 
 func TestRemoteClient(t *testing.T) {
@@ -176,7 +176,7 @@ func TestRemoteClient_clientMD5(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	client := s.(*remote.State).Client.(*RemoteClient)
+	client := s.(*remote.State).Client.(*RemoteClientWithDDBLock)
 
 	sum := md5.Sum([]byte("test"))
 


### PR DESCRIPTION
The DynamoDB lock table is now unnecessary and the same approach as the GCS backend can be used here to write the lock file directly to S3.

This should simplify the usage of Terraform's S3 backend as it removes an extra component.
