### PR TITLE
Update remote-state-data.mdx

### DIFF
--- a/website/docs/language/state/remote-state-data.mdx
+++ b/website/docs/language/state/remote-state-data.mdx
@@ -14,7 +14,7 @@ from some other Terraform configuration.
 
 You can use the `terraform_remote_state` data source without requiring or configuring a provider. It is always available through a built-in provider with the [source address](/language/providers/requirements#source-addresses) `terraform.io/builtin/terraform`. That provider does not include any other resources or data sources.
 
-~> **Important:** We recommend using the [`tfe_outputs` data source](https://registry.terraform.io/providers/hashicorp/tfe/latest/docs/data-sources/outputs) in the [Terraform Cloud/Enterprise Provider](https://registry.terraform.io/providers/hashicorp/tfe/latest/docs) to access remote state outputs in Terraform Cloud or Terraform Enterprise. The `tfe_outputs` data source is more secure because it requires the Terraform Cloud/Enterprise Provider API token to have "Read outputs only" permission to fetch outputs.
+~> **Important:** We recommend using the [`tfe_outputs` data source](https://registry.terraform.io/providers/hashicorp/tfe/latest/docs/data-sources/outputs) in the [Terraform Cloud/Enterprise Provider](https://registry.terraform.io/providers/hashicorp/tfe/latest/docs) to access remote state outputs in Terraform Cloud or Terraform Enterprise. The tfe_outputs data source is more secure because it does not require write access to workspace state to fetch outputs.
 
 ## Alternative Ways to Share Data Between Configurations
 

--- a/website/docs/language/state/remote-state-data.mdx
+++ b/website/docs/language/state/remote-state-data.mdx
@@ -14,7 +14,7 @@ from some other Terraform configuration.
 
 You can use the `terraform_remote_state` data source without requiring or configuring a provider. It is always available through a built-in provider with the [source address](/language/providers/requirements#source-addresses) `terraform.io/builtin/terraform`. That provider does not include any other resources or data sources.
 
-~> **Important:** We recommend using the [`tfe_outputs` data source](https://registry.terraform.io/providers/hashicorp/tfe/latest/docs/data-sources/outputs) in the [Terraform Cloud/Enterprise Provider](https://registry.terraform.io/providers/hashicorp/tfe/latest/docs) to access remote state outputs in Terraform Cloud or Terraform Enterprise. The `tfe_outputs` data source is more secure because it does not require full access to workspace state to fetch outputs.
+~> **Important:** We recommend using the [`tfe_outputs` data source](https://registry.terraform.io/providers/hashicorp/tfe/latest/docs/data-sources/outputs) in the [Terraform Cloud/Enterprise Provider](https://registry.terraform.io/providers/hashicorp/tfe/latest/docs) to access remote state outputs in Terraform Cloud or Terraform Enterprise. The `tfe_outputs` data source is more secure because it requires the Terraform Cloud/Enterprise Provider API token to have "Read outputs only" permission to fetch outputs.
 
 ## Alternative Ways to Share Data Between Configurations
 


### PR DESCRIPTION
In order to be able to use the outputs from a workspace with the `tfe_outputs` data source, you can choose currently one of the following options:

1) Configure the "Remote state sharing" option in the "General Settings" of the source workspace. (TF Cloud relies on the short-lived Terraform Cloud API token used during the run)
2) Provide the "tfe" provider with an API token that has the "Read state outputs" permission for the source workspace.

The "important" section within documentation [here](https://github.com/hashicorp/terraform/edit/main/website/docs/language/state/remote-state-data.mdx#the-terraform_remote_state-data-source) states the opposite but this is required to use `tfe_outputs` in case of 1).