### PR TITLE
Detailing `-chdir` behavior with `terraform.d/plugin` folders

### DIFF
--- a/website/docs/cli/config/config-file.mdx
+++ b/website/docs/cli/config/config-file.mdx
@@ -311,7 +311,9 @@ the operating system where you are running Terraform:
 
 If a `terraform.d/plugins` directory exists in the current working directory
 then Terraform will also include that directory, regardless of your operating
-system.
+system. *The behavior is slightly different when using `-chdir` with the `init` command,
+the launch directory, not the directory specified with `-chdir`, is used
+for checking for the existence of the `terraform.d/plugins` directory.*
 
 Terraform will check each of the paths above to see if it exists, and if so
 treat it as a filesystem mirror. The directory structure inside each one must

--- a/website/docs/cli/config/config-file.mdx
+++ b/website/docs/cli/config/config-file.mdx
@@ -311,9 +311,7 @@ the operating system where you are running Terraform:
 
 If a `terraform.d/plugins` directory exists in the current working directory
 then Terraform will also include that directory, regardless of your operating
-system. *The behavior is slightly different when using `-chdir` with the `init` command,
-the launch directory, not the directory specified with `-chdir`, is used
-for checking for the existence of the `terraform.d/plugins` directory.*
+system. This behavior changes when you use the `-chdir` option with the `init` command. In that case, Terraform checks for the `terraform.d/plugins` directory in the launch directory and not in the directory you specified with `-chdir`.
 
 Terraform will check each of the paths above to see if it exists, and if so
 treat it as a filesystem mirror. The directory structure inside each one must


### PR DESCRIPTION
Fixes Bug reported in https://github.com/hashicorp/terraform/issues/31442

This PR is a 4th alternate implementation - documentation change to match code behavior.

Use instead if the following PRs are not workable:
* https://github.com/hashicorp/terraform/pull/31456 
* https://github.com/hashicorp/terraform/pull/31452 
* https://github.com/hashicorp/terraform/pull/31443 