### PR TITLE
core: Use DynamicExpand even for root module outputs

### DIFF
--- a/internal/plans/changes.go
+++ b/internal/plans/changes.go
@@ -116,6 +116,23 @@ func (c *Changes) OutputValue(addr addrs.AbsOutputValue) *OutputChangeSrc {
 	return nil
 }
 
+// RootOutputValues returns planned changes for all outputs of the root module.
+func (c *Changes) RootOutputValues() []*OutputChangeSrc {
+	var res []*OutputChangeSrc
+
+	for _, oc := range c.Outputs {
+		// we can't evaluate root module outputs
+		if !oc.Addr.Module.Equal(addrs.RootModuleInstance) {
+			continue
+		}
+
+		res = append(res, oc)
+
+	}
+
+	return res
+}
+
 // OutputValues returns planned changes for all outputs for all module
 // instances that reside in the parent path.  Returns nil if no changes are
 // planned.

--- a/internal/plans/changes_sync.go
+++ b/internal/plans/changes_sync.go
@@ -185,6 +185,22 @@ func (cs *ChangesSync) GetOutputChange(addr addrs.AbsOutputValue) *OutputChangeS
 	return cs.changes.OutputValue(addr)
 }
 
+// GetRootOutputChanges searches the set of output changes for any that reside
+// the root module. If no such changes exist, nil is returned.
+//
+// The returned objects are a deep copy of the change recorded in the plan, so
+// callers may mutate them although it's generally better (less confusing) to
+// treat planned changes as immutable after they've been initially constructed.
+func (cs *ChangesSync) GetRootOutputChanges() []*OutputChangeSrc {
+	if cs == nil {
+		panic("GetRootOutputChanges on nil ChangesSync")
+	}
+	cs.lock.Lock()
+	defer cs.lock.Unlock()
+
+	return cs.changes.RootOutputValues()
+}
+
 // GetOutputChanges searches the set of output changes for any that reside in
 // module instances beneath the given module. If no changes exist, nil
 // is returned.

--- a/internal/terraform/graph_builder_plan_test.go
+++ b/internal/terraform/graph_builder_plan_test.go
@@ -233,7 +233,7 @@ local.instance_id (expand)
   aws_instance.web (expand)
 openstack_floating_ip.random (expand)
   provider["registry.terraform.io/hashicorp/openstack"]
-output.instance_id
+output.instance_id (expand)
   local.instance_id (expand)
 provider["registry.terraform.io/hashicorp/aws"]
   openstack_floating_ip.random (expand)
@@ -243,7 +243,7 @@ provider["registry.terraform.io/hashicorp/openstack"]
 provider["registry.terraform.io/hashicorp/openstack"] (close)
   openstack_floating_ip.random (expand)
 root
-  output.instance_id
+  output.instance_id (expand)
   provider["registry.terraform.io/hashicorp/aws"] (close)
   provider["registry.terraform.io/hashicorp/openstack"] (close)
 var.foo

--- a/internal/terraform/node_output.go
+++ b/internal/terraform/node_output.go
@@ -59,8 +59,14 @@ func (n *nodeExpandOutput) DynamicExpand(ctx EvalContext) (*Graph, error) {
 
 		// Find any recorded change for this output
 		var change *plans.OutputChangeSrc
-		parent, call := module.Call()
-		for _, c := range changes.GetOutputChanges(parent, call) {
+		var outputChanges []*plans.OutputChangeSrc
+		if module.IsRoot() {
+			outputChanges = changes.GetRootOutputChanges()
+		} else {
+			parent, call := module.Call()
+			outputChanges = changes.GetOutputChanges(parent, call)
+		}
+		for _, c := range outputChanges {
 			if c.Addr.String() == absAddr.String() {
 				change = c
 				break

--- a/internal/terraform/transform_output.go
+++ b/internal/terraform/transform_output.go
@@ -71,8 +71,8 @@ func (t *OutputTransformer) transform(g *Graph, c *configs.Config) error {
 			destroy = rootChange.Action == plans.Delete
 		}
 
-		// If this is a root output, we add the apply or destroy node directly,
-		// as the root modules does not expand.
+		// If this is a root output and we're destroying, we add the destroy
+		// node directly, as there is no need to expand.
 
 		var node dag.Vertex
 		switch {
@@ -80,14 +80,6 @@ func (t *OutputTransformer) transform(g *Graph, c *configs.Config) error {
 			node = &NodeDestroyableOutput{
 				Addr:   addr.Absolute(addrs.RootModuleInstance),
 				Config: o,
-			}
-
-		case c.Path.IsRoot():
-			node = &NodeApplyableOutput{
-				Addr:        addr.Absolute(addrs.RootModuleInstance),
-				Config:      o,
-				Change:      rootChange,
-				RefreshOnly: t.RefreshOnly,
 			}
 
 		default:

--- a/internal/terraform/transform_targets_test.go
+++ b/internal/terraform/transform_targets_test.go
@@ -122,7 +122,7 @@ module.child.module.grandchild.output.id (expand)
   module.child.module.grandchild.aws_instance.foo
 module.child.output.grandchild_id (expand)
   module.child.module.grandchild.output.id (expand)
-output.grandchild_id
+output.grandchild_id (expand)
   module.child.output.grandchild_id (expand)
 	`)
 	if actual != expected {
@@ -193,7 +193,7 @@ module.child.module.grandchild.output.id (expand)
   module.child.module.grandchild.aws_instance.foo
 module.child.output.grandchild_id (expand)
   module.child.module.grandchild.output.id (expand)
-output.grandchild_id
+output.grandchild_id (expand)
   module.child.output.grandchild_id (expand)
 	`)
 	if actual != expected {


### PR DESCRIPTION
We previously had a special case in the graph transformer for output values where it would directly create an individual output value node instead of an "expand" node as we would do for output values in nested modules.

While it's true that we do always know that expanding a root module output value will always produce exactly one instance, treating this case as special creates the risk of those two codepaths diverging in other ways.

Instead, we'll let the expand node also deal with root modules and minimize the special case only to how we look up any changes for the output values, since the design of plans.Changes is a bit awkward and requires us to ask the question differently for root module output values. Otherwise, the behavior will now be consistent across all output values regardless of module.

There aren't any totally new tests here because the idea here is to implement the same effect in a different way. However, this does lightly change exactly what nodes are in our initial graphs to be the expand node rather than the expanded node, and so there are some light tweaks to the existing tests to account for that.

---

I'm continuing to hoist out the commits from #31268 that were just quirks I countered along the way rather than directly related to the task at hand, with the goal of the checks PR eventually being much more focused. I think this is a good change towards fewer special cases regardless of #31268, but that other PR does illustrate one reason why it's helpful: it allows us to register the expansion of the root modules in the check results tracker without having to treat the root module output variables differently than the others.
