### PR TITLE
Update Cloud Block Docs

### DIFF
--- a/website/docs/language/settings/backends/remote.mdx
+++ b/website/docs/language/settings/backends/remote.mdx
@@ -7,7 +7,7 @@ description: >-
 
 # remote
 
--> **Note:** The remote backend was introduced in Terraform v0.11.13 and Terraform Enterprise v201809-1. As of Terraform v1.1.0 and Terraform Enterprise v202201-1, **we recommend using the Terraform Cloud's built-in [`cloud` integration](/cli/cloud/settings)** instead of this backend. The `cloud` option includes an improved user experience and more features.
+-> **Note:** We introduced the remote backend in Terraform v0.11.13 and Terraform Enterprise v201809-1. As of Terraform v1.1.0 and Terraform Enterprise v202201-1, **we recommend using the Terraform Cloud's built-in [`cloud` integration](/cli/cloud/settings)** instead of this backend. The `cloud` option includes an improved user experience and more features.
 
 The remote backend is unique among all other Terraform backends because it can both store state snapshots and execute operations for Terraform Cloud's [CLI-driven run workflow](/cloud-docs/run/cli). It used to be called an "enhanced" backend.
 

--- a/website/docs/language/settings/backends/remote.mdx
+++ b/website/docs/language/settings/backends/remote.mdx
@@ -7,7 +7,7 @@ description: >-
 
 # remote
 
--> **Note:** The remote backend was introduced in Terraform v0.11.13 and Terraform Enterprise v201809-1. As of Terraform v1.1.0 and Terraform Enterprise v202201-1, **we recommend using the Terraform Cloud's built-in [`cloud` integration](/language/settings/terraform-cloud)** instead of this backend. The `cloud` option includes an improved user experience and more features.
+-> **Note:** The remote backend was introduced in Terraform v0.11.13 and Terraform Enterprise v201809-1. As of Terraform v1.1.0 and Terraform Enterprise v202201-1, **we recommend using the Terraform Cloud's built-in [`cloud` integration](/cli/cloud/settings)** instead of this backend. The `cloud` option includes an improved user experience and more features.
 
 The remote backend is unique among all other Terraform backends because it can both store state snapshots and execute operations for Terraform Cloud's [CLI-driven run workflow](/cloud-docs/run/cli). It used to be called an "enhanced" backend.
 

--- a/website/docs/language/settings/terraform-cloud.mdx
+++ b/website/docs/language/settings/terraform-cloud.mdx
@@ -14,13 +14,16 @@ Terraform through version control or the API.
 
 ## Usage Example
 
-To configure the Terraform Cloud CLI integration, add a nested `cloud` block within the `terraform` block. Refer to [Using Terraform Cloud](/cli/cloud) in the Terraform CLI documentation for full configuration details, migration instructions, and command line arguments.
+To configure the Terraform Cloud CLI integration, add a nested `cloud` block within the `terraform` block. You cannot use the CLI integration and a [state backend](/language/settings/backends) in the same configuration.
+
+Refer to [Using Terraform Cloud](/cli/cloud) in the Terraform CLI documentation for full configuration details, migration instructions, and command line arguments.
 
 ```hcl
 terraform {
   cloud {
     organization = "example_corp"
-    hostname = "app.terraform.io" # Optional; defaults to app.terraform.io
+    ## Required for Terraform Enterprise; Defaults to app.terraform.io for Terraform Cloud
+    hostname = "app.terraform.io"
 
     workspaces {
       tags = ["app"]

--- a/website/docs/language/settings/terraform-cloud.mdx
+++ b/website/docs/language/settings/terraform-cloud.mdx
@@ -7,11 +7,14 @@ description: >-
 
 # Terraform Cloud Configuration
 
-The main module of a Terraform configuration can integrate with Terraform Cloud to enable its
-[CLI-driven run workflow](/cloud-docs/run/cli). You only need to configure these settings when you want to use Terraform CLI to interact with Terraform Cloud. Terraform Cloud ignores them when interacting with
+The main module of a Terraform configuration can integrate with Terraform Cloud to enable its [CLI-driven run workflow](/cloud-docs/run/cli). You only need to configure these settings when you want to use Terraform CLI to interact with Terraform Cloud. Terraform Cloud ignores them when interacting with
 Terraform through version control or the API.
 
 > **Hands On:** Try the [Migrate State to Terraform Cloud](https://learn.hashicorp.com/tutorials/terraform/cloud-migrate) tutorial on HashiCorp Learn.
+
+This page contains a brief `cloud` block example. Refer to Refer to [Using Terraform Cloud](/cli/cloud) in the Terraform CLI docs for full configuration details, migration instructions, and command line arguments.
+
+## Usage Example
 
 You can configure the Terraform Cloud CLI integration by adding a nested `cloud` block within the top-level
 `terraform` block:
@@ -29,8 +32,8 @@ terraform {
 }
 ```
 
-If you do not specify the `hostname`, it defaults to `app.terraform.io` for Terraform Cloud. For Terraform Enterprise installations, include the [hostname](/cli/cloud/settings#hostname) configuration argument.  
+If you do not specify the `hostname`, it defaults to `app.terraform.io` for Terraform Cloud. For Terraform Enterprise installations, include the [hostname](/cli/cloud/settings#hostname) configuration argument.
 
 You cannot use the CLI integration and a [state backend](/language/settings/backends) in the same configuration; they are mutually exclusive. A configuration can only provide one `cloud` block and the `cloud` block cannot refer to named values like input variables, locals, or data source attributes.
 
-Refer to [Using Terraform Cloud](/cli/cloud) in the Terraform CLI docs for more information.
+

--- a/website/docs/language/settings/terraform-cloud.mdx
+++ b/website/docs/language/settings/terraform-cloud.mdx
@@ -12,12 +12,9 @@ Terraform through version control or the API.
 
 > **Hands On:** Try the [Migrate State to Terraform Cloud](https://learn.hashicorp.com/tutorials/terraform/cloud-migrate) tutorial on HashiCorp Learn.
 
-This page contains a brief `cloud` block example. Refer to Refer to [Using Terraform Cloud](/cli/cloud) in the Terraform CLI docs for full configuration details, migration instructions, and command line arguments.
-
 ## Usage Example
 
-You can configure the Terraform Cloud CLI integration by adding a nested `cloud` block within the top-level
-`terraform` block:
+To configure the Terraform Cloud CLI integration, add a nested `cloud` block within the `terraform` block. Refer to [Using Terraform Cloud](/cli/cloud) in the Terraform CLI documentation for full configuration details, migration instructions, and command line arguments.
 
 ```hcl
 terraform {
@@ -32,8 +29,7 @@ terraform {
 }
 ```
 
-If you do not specify the `hostname`, it defaults to `app.terraform.io` for Terraform Cloud. For Terraform Enterprise installations, include the [hostname](/cli/cloud/settings#hostname) configuration argument.
 
-You cannot use the CLI integration and a [state backend](/language/settings/backends) in the same configuration; they are mutually exclusive. A configuration can only provide one `cloud` block and the `cloud` block cannot refer to named values like input variables, locals, or data source attributes.
+
 
 


### PR DESCRIPTION
Recently, a customer got confused by this page in the Language documentation: https://www.terraform.io/language/settings/terraform-cloud

They believed it was our only documentation about the new `cloud` block, and reached out to support for help and additional details. They did not know that this documentation existed: https://www.terraform.io/cli/cloud

This PR updates the Terraform Cloud page in the Language docs to hopefully make it clear that it's just a pointer and that the real information is in CLI docs. It also updates a link in the `remote` backends page to point to the CLI docs. I think this will be more helpful for users who want to learn to use the `cloud` block and potentially migrate to it.