### PR TITLE
Evaluate resource preconditions and postconditions during apply even if they have no planned change

### DIFF
--- a/internal/terraform/transform_diff.go
+++ b/internal/terraform/transform_diff.go
@@ -65,7 +65,11 @@ func (t *DiffTransformer) Transform(g *Graph) error {
 		var update, delete, createBeforeDestroy bool
 		switch rc.Action {
 		case plans.NoOp:
-			continue
+			// For a no-op change we don't take any action but we still
+			// run any condition checks associated with the object, to
+			// make sure that they still hold when considering the
+			// results of other changes.
+			update = true
 		case plans.Delete:
 			delete = true
 		case plans.DeleteThenCreate, plans.CreateThenDelete:

--- a/internal/terraform/transform_diff_test.go
+++ b/internal/terraform/transform_diff_test.go
@@ -67,6 +67,62 @@ func TestDiffTransformer(t *testing.T) {
 	}
 }
 
+func TestDiffTransformer_noOpChange(t *testing.T) {
+	// "No-op" changes are how we record explicitly in a plan that we did
+	// indeed visit a particular resource instance during the planning phase
+	// and concluded that no changes were needed, as opposed to the resource
+	// instance not existing at all or having been excluded from planning
+	// entirely.
+	//
+	// We must include nodes for resource instances with no-op changes in the
+	// apply graph, even though they won't take any external actions, because
+	// there are some secondary effects such as precondition/postcondition
+	// checks that can refer to objects elsewhere and so might have their
+	// results changed even if the resource instance they are attached to
+	// didn't actually change directly itself.
+
+	g := Graph{Path: addrs.RootModuleInstance}
+
+	beforeVal, err := plans.NewDynamicValue(cty.StringVal(""), cty.String)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tf := &DiffTransformer{
+		Changes: &plans.Changes{
+			Resources: []*plans.ResourceInstanceChangeSrc{
+				{
+					Addr: addrs.Resource{
+						Mode: addrs.ManagedResourceMode,
+						Type: "aws_instance",
+						Name: "foo",
+					}.Instance(addrs.NoKey).Absolute(addrs.RootModuleInstance),
+					ProviderAddr: addrs.AbsProviderConfig{
+						Provider: addrs.NewDefaultProvider("aws"),
+						Module:   addrs.RootModule,
+					},
+					ChangeSrc: plans.ChangeSrc{
+						// A "no-op" change has the no-op action and has the
+						// same object as both Before and After.
+						Action: plans.NoOp,
+						Before: beforeVal,
+						After:  beforeVal,
+					},
+				},
+			},
+		},
+	}
+	if err := tf.Transform(&g); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	actual := strings.TrimSpace(g.String())
+	expected := strings.TrimSpace(testTransformDiffBasicStr)
+	if actual != expected {
+		t.Fatalf("bad:\n\n%s", actual)
+	}
+}
+
 const testTransformDiffBasicStr = `
 aws_instance.foo
 `


### PR DESCRIPTION
Preconditions and postconditions results can change due to changes to other upstream resources, even if the resource they are directly attached to doesn't have a change pending.

Therefore we need to still visit "no-op" resources during the apply walk and deal with the ancillary side-effects, skipping only the actual call to the provider to run `ApplyResourceChange`. If we don't, there can potentially be failures we won't catch until the next plan, which might be run by someone who has no context about whatever change broke the conditions.

This also makes the UI "see" no-op changes being applied via the hooks API. Rather than making another special case in Terraform Core for that, I concluded it's a UI-level concern to decide whether it's interesting to report a particular resource being "skipped" and so I put the special case in the UI layer instead.

Fixes #31261.

