### PR TITLE
fix grammar: subject-verb agreement

### DIFF
--- a/website/docs/cli/commands/fmt.mdx
+++ b/website/docs/cli/commands/fmt.mdx
@@ -50,7 +50,7 @@ Usage: `terraform fmt [options] [TARGET]`
 By default, `fmt` scans the current directory for configuration files. If
 you provide a directory for the `target` argument, then `fmt` will scan that directory instead. If you provide a file, then `fmt` will process just that file. If you provide a single dash (`-`), then `fmt` will read from standard input (STDIN).
 
-The command-line flags are all optional. The available flags are:
+The command-line flags are all optional. The following flags are available:
 
 * `-list=false` - Don't list the files containing formatting inconsistencies.
 * `-write=false` - Don't overwrite the input files. (This is implied by `-check` or when the input is STDIN.)

--- a/website/docs/cli/commands/fmt.mdx
+++ b/website/docs/cli/commands/fmt.mdx
@@ -50,7 +50,7 @@ Usage: `terraform fmt [options] [TARGET]`
 By default, `fmt` scans the current directory for configuration files. If
 you provide a directory for the `target` argument, then `fmt` will scan that directory instead. If you provide a file, then `fmt` will process just that file. If you provide a single dash (`-`), then `fmt` will read from standard input (STDIN).
 
-The command-line flags are all optional. The list of available flags are:
+The command-line flags are all optional. The available flags are:
 
 * `-list=false` - Don't list the files containing formatting inconsistencies.
 * `-write=false` - Don't overwrite the input files. (This is implied by `-check` or when the input is STDIN.)

--- a/website/docs/cli/commands/import.mdx
+++ b/website/docs/cli/commands/import.mdx
@@ -36,7 +36,7 @@ If you import the same object multiple times, Terraform may exhibit unwanted
 behavior. For more information on this assumption, see
 [the State section](/language/state).
 
-The command-line flags are all optional. The available flags are:
+The command-line flags are all optional. The following flags are available:
 
 - `-config=path` - Path to directory of Terraform configuration files that
   configure the provider for import. This defaults to your working directory.

--- a/website/docs/cli/commands/import.mdx
+++ b/website/docs/cli/commands/import.mdx
@@ -36,7 +36,7 @@ If you import the same object multiple times, Terraform may exhibit unwanted
 behavior. For more information on this assumption, see
 [the State section](/language/state).
 
-The command-line flags are all optional. The list of available flags are:
+The command-line flags are all optional. The available flags are:
 
 - `-config=path` - Path to directory of Terraform configuration files that
   configure the provider for import. This defaults to your working directory.

--- a/website/docs/cli/commands/output.mdx
+++ b/website/docs/cli/commands/output.mdx
@@ -18,7 +18,7 @@ With no additional arguments, `output` will display all the outputs for
 the root module. If an output `NAME` is specified, only the value of that
 output is printed.
 
-The command-line flags are all optional. The list of available flags are:
+The command-line flags are all optional. The available flags are:
 
 * `-json` - If specified, the outputs are formatted as a JSON object, with
   a key per output. If `NAME` is specified, only the output specified will be

--- a/website/docs/cli/commands/output.mdx
+++ b/website/docs/cli/commands/output.mdx
@@ -18,7 +18,7 @@ With no additional arguments, `output` will display all the outputs for
 the root module. If an output `NAME` is specified, only the value of that
 output is printed.
 
-The command-line flags are all optional. The available flags are:
+The command-line flags are all optional. The following flags are available:
 
 * `-json` - If specified, the outputs are formatted as a JSON object, with
   a key per output. If `NAME` is specified, only the output specified will be

--- a/website/docs/cli/commands/providers/schema.mdx
+++ b/website/docs/cli/commands/providers/schema.mdx
@@ -17,7 +17,7 @@ The `terraform providers schema` command is used to print detailed schemas for t
 
 Usage: `terraform providers schema [options]`
 
-The list of available flags are:
+The available flags are:
 
 - `-json` - Displays the schemas in a machine-readable, JSON format.
 

--- a/website/docs/cli/commands/providers/schema.mdx
+++ b/website/docs/cli/commands/providers/schema.mdx
@@ -17,7 +17,7 @@ The `terraform providers schema` command is used to print detailed schemas for t
 
 Usage: `terraform providers schema [options]`
 
-The available flags are:
+The following flags are available:
 
 - `-json` - Displays the schemas in a machine-readable, JSON format.
 

--- a/website/docs/cli/commands/state/list.mdx
+++ b/website/docs/cli/commands/state/list.mdx
@@ -26,7 +26,7 @@ For complex infrastructures, the state can contain thousands of resources.
 To filter these, provide one or more patterns to the command. Patterns are
 in [resource addressing format](/cli/state/resource-addressing).
 
-The command-line flags are all optional. The list of available flags are:
+The command-line flags are all optional. The available flags are:
 
 * `-state=path` - Path to the state file. Defaults to "terraform.tfstate".
   Ignored when [remote state](/language/state/remote) is used.

--- a/website/docs/cli/commands/state/list.mdx
+++ b/website/docs/cli/commands/state/list.mdx
@@ -26,7 +26,7 @@ For complex infrastructures, the state can contain thousands of resources.
 To filter these, provide one or more patterns to the command. Patterns are
 in [resource addressing format](/cli/state/resource-addressing).
 
-The command-line flags are all optional. The available flags are:
+The command-line flags are all optional. The following flags are available:
 
 * `-state=path` - Path to the state file. Defaults to "terraform.tfstate".
   Ignored when [remote state](/language/state/remote) is used.

--- a/website/docs/cli/commands/state/show.mdx
+++ b/website/docs/cli/commands/state/show.mdx
@@ -22,7 +22,7 @@ This command requires an address that points to a single resource in the
 state. Addresses are
 in [resource addressing format](/cli/state/resource-addressing).
 
-The command-line flags are all optional. The list of available flags are:
+The command-line flags are all optional. The available flags are:
 
 * `-state=path` - Path to the state file. Defaults to "terraform.tfstate".
   Ignored when [remote state](/language/state/remote) is used.

--- a/website/docs/cli/commands/state/show.mdx
+++ b/website/docs/cli/commands/state/show.mdx
@@ -22,7 +22,7 @@ This command requires an address that points to a single resource in the
 state. Addresses are
 in [resource addressing format](/cli/state/resource-addressing).
 
-The command-line flags are all optional. The available flags are:
+The command-line flags are all optional. The following flags are available:
 
 * `-state=path` - Path to the state file. Defaults to "terraform.tfstate".
   Ignored when [remote state](/language/state/remote) is used.


### PR DESCRIPTION
`The list of available flags are` does not conform to [subject-verb agreement](https://www.grammarbook.com/grammar/subjectVerbAgree.asp) rules. We may either write: _The list of available flags is_ or _The available flags are_, but not both.