### PR TITLE
docs: fix typo regarding unknown values

### DIFF
--- a/website/docs/language/expressions/references.mdx
+++ b/website/docs/language/expressions/references.mdx
@@ -318,12 +318,10 @@ values are decided dynamically by the remote system. For example, if a
 particular remote object type is assigned a generated unique id on creation,
 Terraform cannot predict the value of this id until the object has been created.
 
-To allow expressions to still be evaluated during the plan phase, Terraform
-uses special "unknown value" placeholders for these results. In most cases you
-don't need to do anything special to deal with these, since the Terraform
-language automatically handles unknown values in expressions, so that for
-example adding a known value to an unknown value automatically produces an
-unknown value as the result.
+Terraform uses special unknown value placeholders for information that it
+cannot predict during the plan phase. The Terraform language automatically
+handles unknown values in expressions. For example, adding a known value to an
+unknown value automatically produces an unknown value as a result.
 
 However, there are some situations where unknown values _do_ have a significant
 effect:

--- a/website/docs/language/expressions/references.mdx
+++ b/website/docs/language/expressions/references.mdx
@@ -321,9 +321,9 @@ Terraform cannot predict the value of this id until the object has been created.
 To allow expressions to still be evaluated during the plan phase, Terraform
 uses special "unknown value" placeholders for these results. In most cases you
 don't need to do anything special to deal with these, since the Terraform
-language automatically handles unknown values during expressions, so that
-for example adding a known value to an unknown value automatically produces
-an unknown value as the result.
+language automatically handles unknown values in expressions, so that for
+example adding a known value to an unknown value automatically produces an
+unknown value as the result.
 
 However, there are some situations where unknown values _do_ have a significant
 effect:
@@ -349,4 +349,4 @@ effect:
   types where possible, but incorrect use of such values may not be detected
   until the apply phase, causing the apply to fail.
 
-Unknown values appear in the `terraform plan` output as `(not yet known)`.
+Unknown values appear in the `terraform plan` output as `(known after apply)`.


### PR DESCRIPTION
In Terraform plans, unknown values are displayed as `(known after apply)`. This PR updates the docs to reflect this.
