### PR TITLE
providercache: include host in provider installation error

### DIFF
--- a/internal/providercache/package_install.go
+++ b/internal/providercache/package_install.go
@@ -45,7 +45,7 @@ func installFromHTTPURL(ctx context.Context, meta getproviders.PackageMeta, targ
 			// so we'll return a more appropriate one here.
 			return nil, fmt.Errorf("provider download was interrupted")
 		}
-		return nil, err
+		return nil, fmt.Errorf("%s: %w", getproviders.HostFromRequest(req), err)
 	}
 	defer resp.Body.Close()
 


### PR DESCRIPTION
This is motivated by issues of the nature described in https://github.com/hashicorp/terraform/issues/31516 which we also noticed as part of our regular CI runs recently which runs `terraform init` for all ~250 official+verified providers.

https://github.com/hashicorp/terraform-ls/runs/7467545895?check_suite_focus=true#step:6:43

It aims to turn the following error:

> Error while installing bluecatlabs/bluecat v1.0.0: local error: tls: bad record MAC

into 

> Error while installing bluecatlabs/bluecat v1.0.0: github.com: local error: tls: bad record MAC

The aim here is to communicate the fact that (often) such networking issues are between the user and GitHub, rather than the Terraform Registry - and if it is in fact the Registry then should allow us (and the user) to tell the errors apart.

This is similar to https://github.com/hashicorp/terraform/pull/30810