### PR TITLE
Add note about module.path and local module sources

### DIFF
--- a/website/docs/language/expressions/references.mdx
+++ b/website/docs/language/expressions/references.mdx
@@ -120,8 +120,7 @@ to mark the reference as for a data resource.
 
 The following values are available:
 
-- `path.module` is the filesystem path of the module where the expression
-  is placed. You can use `path.module` in write operations, but we do not recommend this when using local module sources. Multiple invocations of local modules use the same source directory, overwriting the data in `path.module` during each call. This can lead to race conditions and unexpected results.
+- `path.module` is the filesystem path of the module where the expression is placed. We do not recommend using `path.module` in write operations because it can produce different behavior depending on whether you use remote or local module sources. Multiple invocations of local modules use the same source directory, overwriting the data in `path.module` during each call. This can lead to race conditions and unexpected results.
 - `path.root` is the filesystem path of the root module of the configuration.
 - `path.cwd` is the filesystem path of the current working directory. In
   normal use of Terraform this is the same as `path.root`, but some advanced

--- a/website/docs/language/expressions/references.mdx
+++ b/website/docs/language/expressions/references.mdx
@@ -118,14 +118,16 @@ to mark the reference as for a data resource.
 
 ### Filesystem and Workspace Info
 
-* `path.module` is the filesystem path of the module where the expression
-  is placed.
-* `path.root` is the filesystem path of the root module of the configuration.
-* `path.cwd` is the filesystem path of the current working directory. In
+The following values are available:
+
+- `path.module` is the filesystem path of the module where the expression
+  is placed. You can use `path.module` in write operations, but we do not recommend this when using local module sources. Multiple invocations of local modules use the same source directory, overwriting the data in `path.module` during each call. This can lead to race conditions and unexpected results.
+- `path.root` is the filesystem path of the root module of the configuration.
+- `path.cwd` is the filesystem path of the current working directory. In
   normal use of Terraform this is the same as `path.root`, but some advanced
   uses of Terraform run it from a directory other than the root module
   directory, causing these paths to be different.
-* `terraform.workspace` is the name of the currently selected
+- `terraform.workspace` is the name of the currently selected
   [workspace](/language/state/workspaces).
 
 Use the values in this section carefully, because they include information


### PR DESCRIPTION
Closes https://github.com/hashicorp/terraform/issues/31441

User has requested that we update [this page](https://www.terraform.io/language/expressions/references#filesystem-and-workspace-info) to call out the "the race conditions and inconsistent behavior that can result from using path.module and local module source for write operations" that Martin described in [this thread](https://github.com/hashicorp/terraform/issues/29503).

This PR adds a few sentences after the `path.module` value to explain this. It also changes * to - for bullets, per our style guide.