### PR TITLE
Add more context about local backend configuration state file

### DIFF
--- a/website/docs/language/settings/backends/configuration.mdx
+++ b/website/docs/language/settings/backends/configuration.mdx
@@ -77,7 +77,7 @@ or state operations.
 
 After you initialize, Terraform creates `.terraform/terraform.tfstate` locally. This file contains the most recent backend configuration, including any authentication parameters you provided to the Terraform CLI. Do not check `.terraform/terraform.tfstate` into Git, as it may contain sensitive credentials for your remote backend.
 
-The local backend configuration file is different and entirely separate from the `terraform.tfstate` file that contains [state data](/language/state) about your real-world infrastruture. Terraform stores the `terraform.tfstate` file in your remote backend.
+The local backend configuration is different and entirely separate from the `terraform.tfstate` file that contains [state data](/language/state) about your real-world infrastruture. Terraform stores the `terraform.tfstate` file in your remote backend.
 
 When you change backends, Terraform gives you the option to migrate
 your state to the new backend. This lets you adopt backends without losing

--- a/website/docs/language/settings/backends/configuration.mdx
+++ b/website/docs/language/settings/backends/configuration.mdx
@@ -71,18 +71,20 @@ If a configuration includes no backend block, Terraform defaults to using the `l
 
 ## Initialization
 
-Whenever a configuration's backend changes, you must run `terraform init` again
+When you change a backend's configuration, you must run `terraform init` again
 to validate and configure the backend before you can perform any plans, applies,
 or state operations.
 
-When changing backends, Terraform will give you the option to migrate
+After you initialize, Terraform creates `.terraform/terraform.tfstate` locally. This file contains the most recent backend configuration, including any authentication parameters you provided to the Terraform CLI. Do not check `.terraform/terraform.tfstate` into Git, as it may contain sensitive credentials for your remote backend.
+
+The local backend configuration file is different and entirely separate from the `terraform.tfstate` file that contains [state data](/language/state) about your real-world infrastruture. Terraform stores the `terraform.tfstate` file in your remote backend.
+
+When you change backends, Terraform gives you the option to migrate
 your state to the new backend. This lets you adopt backends without losing
 any existing state.
 
-To be extra careful, we always recommend manually backing up your state
-as well. You can do this by simply copying your `terraform.tfstate` file
-to another location. The initialization process should create a backup
-as well, but it never hurts to be safe!
+~> **Important:** Before migrating to a new backend, we strongly recommend manually backing up your state by copying your `terraform.tfstate` file
+to another location.
 
 ## Partial Configuration
 

--- a/website/docs/language/settings/backends/configuration.mdx
+++ b/website/docs/language/settings/backends/configuration.mdx
@@ -75,7 +75,7 @@ When you change a backend's configuration, you must run `terraform init` again
 to validate and configure the backend before you can perform any plans, applies,
 or state operations.
 
-After you initialize, Terraform creates `.terraform/terraform.tfstate` locally. This file contains the most recent backend configuration, including any authentication parameters you provided to the Terraform CLI. Do not check `.terraform/terraform.tfstate` into Git, as it may contain sensitive credentials for your remote backend.
+After you initialize, Terraform creates a `.terraform/` directory locally. This directory contains the most recent backend configuration, including any authentication parameters you provided to the Terraform CLI. Do not check this directory into Git, as it may contain sensitive credentials for your remote backend.
 
 The local backend configuration is different and entirely separate from the `terraform.tfstate` file that contains [state data](/language/state) about your real-world infrastruture. Terraform stores the `terraform.tfstate` file in your remote backend.
 


### PR DESCRIPTION
Closes https://github.com/hashicorp/terraform/issues/24510

 Users are wondering if we can differentiate between the "state" that gets stored on your local machine for remote backends and the actual state of your real-world infrastructure. This PR clarifies that when you set up a remote backend, Terraform stores the backend configuration in a local directory called `.terraform/terraform.tfstate`. The only content included in this file is the backend configuration, including any credentials you passed to the CLI for the backend. 

We clarify that we do not recommend checking this file into Git, as it may contain sensitive credentials. We also do a couple of fixes for this subsection of the page to better align with our style guide and to make the note about backing up your state before migrating to a new backend more salient. Hopefully this way it will stand out to users and they won't miss it!