### PR TITLE
Remove -local flag from goimports check

### DIFF
--- a/scripts/goimportscheck.sh
+++ b/scripts/goimportscheck.sh
@@ -8,11 +8,11 @@ if [[ -z ${target_files}  ]]; then
   exit 0
 fi
 
-goimports_files=$(goimports -w -l -local github.com/hashicorp/terraform/ ${target_files})
+goimports_files=$(goimports -w -l "${target_files}")
 if [[ -n ${goimports_files} ]]; then
   echo 'goimports needs running on the following files:'
   echo "${goimports_files}"
-  echo "You can use the command and flags \`goimports -w -l -local github.com/hashicorp/terraform/\` to reformat the code"
+  echo "You can use the command and flags \`goimports -w -l\` to reformat the code"
   exit 1
 fi
 


### PR DESCRIPTION
It's not easy to configure `goimports` with the flags in certain editors, so we can make it easier by keeping the CI check simple.