### PR TITLE
fix: validate implied provider names in submodules

### DIFF
--- a/internal/configs/configload/loader_load_test.go
+++ b/internal/configs/configload/loader_load_test.go
@@ -105,6 +105,33 @@ func TestLoaderLoadConfig_loadDiags(t *testing.T) {
 	}
 }
 
+func TestLoaderLoadConfig_loadDiagsFromSubmodules(t *testing.T) {
+	// building a config which didn't load correctly may cause configs to panic
+	fixtureDir := filepath.Clean("testdata/invalid-names-in-submodules")
+	loader, err := NewLoader(&Config{
+		ModulesDir: filepath.Join(fixtureDir, ".terraform/modules"),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error from NewLoader: %s", err)
+	}
+
+	cfg, diags := loader.LoadConfig(fixtureDir)
+	if !diags.HasErrors() {
+		t.Fatalf("loading succeeded; want an error")
+	}
+	if got, want := diags.Error(), " Invalid provider local name"; !strings.Contains(got, want) {
+		t.Errorf("missing expected error\nwant substring: %s\ngot: %s", want, got)
+	}
+
+	if cfg == nil {
+		t.Fatal("partial config not returned with diagnostics")
+	}
+
+	if cfg.Module == nil {
+		t.Fatal("expected config module")
+	}
+}
+
 func TestLoaderLoadConfig_childProviderGrandchildCount(t *testing.T) {
 	// This test is focused on the specific situation where:
 	// - A child module contains a nested provider block, which is no longer

--- a/internal/configs/configload/testdata/invalid-names-in-submodules/.terraform/modules/modules.json
+++ b/internal/configs/configload/testdata/invalid-names-in-submodules/.terraform/modules/modules.json
@@ -1,0 +1,14 @@
+{
+	"Modules": [
+		{
+			"Key": "test",
+			"Source": "./sub",
+			"Dir": "testdata/invalid-names-in-submodules/sub"
+		},
+		{
+			"Key": "",
+			"Source": "",
+			"Dir": "."
+		}
+	]
+}

--- a/internal/configs/configload/testdata/invalid-names-in-submodules/main.tf
+++ b/internal/configs/configload/testdata/invalid-names-in-submodules/main.tf
@@ -1,0 +1,3 @@
+module "test" {
+	source = "./sub"
+}

--- a/internal/configs/configload/testdata/invalid-names-in-submodules/sub/main.tf
+++ b/internal/configs/configload/testdata/invalid-names-in-submodules/sub/main.tf
@@ -1,0 +1,7 @@
+resource "aws-_foo" "test" {
+
+}
+
+data "aws-_bar" "test" {
+
+}

--- a/internal/configs/provider_validation.go
+++ b/internal/configs/provider_validation.go
@@ -153,6 +153,18 @@ func validateProviderConfigs(parentCall *ModuleCall, cfg *Config, noProviderConf
 			}
 
 			localName := r.Addr().ImpliedProvider()
+
+			_, err := addrs.ParseProviderPart(localName)
+			if err != nil {
+				diags = append(diags, &hcl.Diagnostic{
+					Severity: hcl.DiagError,
+					Summary:  "Invalid provider local name",
+					Detail:   fmt.Sprintf("%q is an invalid implied provider local name: %s", localName, err),
+					Subject:  r.DeclRange.Ptr(),
+				})
+				continue
+			}
+
 			if _, ok := localNames[localName]; ok {
 				// OK, this was listed directly in the required_providers
 				continue


### PR DESCRIPTION
Fixes #31572

## Example config

(which triggers the bug)

**`./main.tf`**
```hcl
module "test" {
  source = "./sub"
}
```
**`./sub/main.tf`**
```hcl
resource "-test_test" "name" {
}
```

## Before
![Screenshot 2022-08-04 at 19 50 48](https://user-images.githubusercontent.com/287584/182930523-ab176fab-ba7a-438d-8c00-55327fe47f04.png)

## After
![Screenshot 2022-08-04 at 19 51 26](https://user-images.githubusercontent.com/287584/182930637-76252e5e-2bd9-4254-bc4c-d82e4467c319.png)

## Notes

There are also cases which may produce an extra error - assuming that the provider name is also invalid for HCL:

![Screenshot 2022-08-04 at 19 54 37](https://user-images.githubusercontent.com/287584/182931200-2d007de0-f859-4911-bed6-5a9efb55c729.png)

I didn't spend much time on deduplicating it though as I'd expect/hope this is generally an error people will see quite rarely.

I chose to quote the original provider name in the error message, although the other existing diagnostic doesn't do that (uses `%s` instead of `%q`) - let me know if you prefer either. My preference for `%q` was primarily driven by making empty name and other short names with just special characters more visible and obvious.