### PR TITLE
New Terraform Workspace select flag: `-or-create`

### DIFF
--- a/internal/command/workspace_command.go
+++ b/internal/command/workspace_command.go
@@ -69,7 +69,7 @@ const (
 Workspace %q doesn't exist.
 
 You can create this workspace with the "new" subcommand 
-or inclde the "-or-create" flag to the "select" subcommand.`
+or include the "-or-create" flag with the "select" subcommand.`
 
 	envChanged = `[reset][green]Switched to workspace %q.`
 

--- a/internal/command/workspace_command.go
+++ b/internal/command/workspace_command.go
@@ -68,7 +68,8 @@ const (
 	envDoesNotExist = `
 Workspace %q doesn't exist.
 
-You can create this workspace with the "new" subcommand.`
+You can create this workspace with the "new" subcommand 
+or inclde the "-or-create" flag to the "select" subcommand.`
 
 	envChanged = `[reset][green]Switched to workspace %q.`
 

--- a/internal/command/workspace_command_test.go
+++ b/internal/command/workspace_command_test.go
@@ -435,3 +435,31 @@ func TestWorkspace_deleteWithState(t *testing.T) {
 		t.Fatal("env 'test' still exists!")
 	}
 }
+
+func TestWorkspace_selectWithOrCreate(t *testing.T) {
+	// Create a temporary working directory that is empty
+	td := t.TempDir()
+	os.MkdirAll(td, 0755)
+	defer testChdir(t, td)()
+
+	selectCmd := &WorkspaceSelectCommand{}
+
+	current, _ := selectCmd.Workspace()
+	if current != backend.DefaultStateName {
+		t.Fatal("current workspace should be 'default'")
+	}
+
+	args := []string{"-or-create", "test"}
+	ui := new(cli.MockUi)
+	view, _ := testView(t)
+	selectCmd.Meta = Meta{Ui: ui, View: view}
+	if code := selectCmd.Run(args); code != 0 {
+		t.Fatalf("bad: %d\n\n%s", code, ui.ErrorWriter)
+	}
+
+	current, _ = selectCmd.Workspace()
+	if current != "test" {
+		t.Fatalf("current workspace should be 'test', got %q", current)
+	}
+
+}

--- a/internal/command/workspace_select.go
+++ b/internal/command/workspace_select.go
@@ -97,6 +97,8 @@ func (c *WorkspaceSelectCommand) Run(args []string) int {
 		}
 	}
 
+	var newState bool
+
 	if !found {
 		if orCreate {
 			_, err = b.StateMgr(name)
@@ -104,6 +106,7 @@ func (c *WorkspaceSelectCommand) Run(args []string) int {
 				c.Ui.Error(err.Error())
 				return 1
 			}
+			newState = true
 		} else {
 			c.Ui.Error(fmt.Sprintf(envDoesNotExist, name))
 			return 1
@@ -116,11 +119,16 @@ func (c *WorkspaceSelectCommand) Run(args []string) int {
 		return 1
 	}
 
-	c.Ui.Output(
-		c.Colorize().Color(
-			fmt.Sprintf(envChanged, name),
-		),
-	)
+	if newState {
+		c.Ui.Output(c.Colorize().Color(fmt.Sprintf(
+			strings.TrimSpace(envCreated), name)))
+	} else {
+		c.Ui.Output(
+			c.Colorize().Color(
+				fmt.Sprintf(envChanged, name),
+			),
+		)
+	}
 
 	return 0
 }
@@ -141,6 +149,10 @@ func (c *WorkspaceSelectCommand) Help() string {
 Usage: terraform [global options] workspace select NAME
 
   Select a different Terraform workspace.
+
+Options:
+
+    -or-create=false    Create the terraform workspace if if it doesnt exist.
 
 `
 	return strings.TrimSpace(helpText)

--- a/internal/command/workspace_select.go
+++ b/internal/command/workspace_select.go
@@ -152,7 +152,7 @@ Usage: terraform [global options] workspace select NAME
 
 Options:
 
-    -or-create=false    Create the Terraform workspace if if it doesnt exist.
+    -or-create=false    Create the Terraform workspace if it doesn't exist.
 
 `
 	return strings.TrimSpace(helpText)

--- a/internal/command/workspace_select.go
+++ b/internal/command/workspace_select.go
@@ -20,7 +20,7 @@ func (c *WorkspaceSelectCommand) Run(args []string) int {
 
 	var orCreate bool
 	cmdFlags := c.Meta.defaultFlagSet("workspace select")
-	cmdFlags.BoolVar(&orCreate, "or-create", false, "create workspace if it doesnt exist")
+	cmdFlags.BoolVar(&orCreate, "or-create", false, "create workspace if it does not exist")
 	cmdFlags.Usage = func() { c.Ui.Error(c.Help()) }
 	if err := cmdFlags.Parse(args); err != nil {
 		c.Ui.Error(fmt.Sprintf("Error parsing command-line flags: %s\n", err.Error()))

--- a/internal/command/workspace_select.go
+++ b/internal/command/workspace_select.go
@@ -152,7 +152,7 @@ Usage: terraform [global options] workspace select NAME
 
 Options:
 
-    -or-create=false    Create the terraform workspace if if it doesnt exist.
+    -or-create=false    Create the Terraform workspace if if it doesnt exist.
 
 `
 	return strings.TrimSpace(helpText)


### PR DESCRIPTION
This adds the new terraform workspace select flag `-or-create`. This flag is intended to make managing workspaces easier in CI environments where auto creating or selecting a workspace is useful (especially when using remote backend). This flag will first attempt to select the provided workspace name. If this workspace is not found, it will then create and select it. 

Traditionally this functionality has been achieved through some sort of scripting. We currently get this behavior using the following script: `terraform workspace select test || terraform workspace new test`; however, this does not work well when attempting to use the official terraform docker image as it does not handle shell scripts by design. Having this functionality in the terraform cli itself would be very useful. We want to be able to provide the same functionally locally to our developers as exists in our CI environment. Using the terraform official docker image helps provide this, but missing this functionality is making it difficult to auto provision workspaces for new projects. Calling the `workspace new` command will error if it already exists, and calling the `workspace select` command will error if it does not exist. 

This will especially help when using `terraform` with https://dagger.io or any other docker based CI as it relies on docker for running pipelines where bash scripting my not be an option.

Closes: #16191