### PR TITLE
Expand module subdirectory globs

### DIFF
--- a/internal/command/e2etest/module_archive_test.go
+++ b/internal/command/e2etest/module_archive_test.go
@@ -1,0 +1,32 @@
+package e2etest
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform/internal/e2e"
+)
+
+func TestInitModuleArchive(t *testing.T) {
+	t.Parallel()
+
+	// this fetches a module archive from github
+	skipIfCannotAccessNetwork(t)
+
+	fixturePath := filepath.Join("testdata", "module-archive")
+	tf := e2e.NewBinary(t, terraformBin, fixturePath)
+
+	stdout, stderr, err := tf.Run("init")
+	if err != nil {
+		t.Errorf("unexpected error: %s", err)
+	}
+
+	if stderr != "" {
+		t.Errorf("unexpected stderr output:\n%s", stderr)
+	}
+
+	if !strings.Contains(stdout, "Terraform has been successfully initialized!") {
+		t.Errorf("success message is missing from output:\n%s", stdout)
+	}
+}

--- a/internal/command/e2etest/testdata/module-archive/main.tf
+++ b/internal/command/e2etest/testdata/module-archive/main.tf
@@ -1,0 +1,5 @@
+// this should be able to unpack the tarball and change the module directory to
+// the archive directory regardless of its name.
+module "bucket" {
+  source = "https://github.com/terraform-aws-modules/terraform-aws-s3-bucket/archive/v3.3.0.tar.gz//*?archive=tar.gz"
+}

--- a/internal/initwd/module_install.go
+++ b/internal/initwd/module_install.go
@@ -587,8 +587,11 @@ func (i *ModuleInstaller) installGoGetterModule(ctx context.Context, req *earlyc
 		return nil, diags
 	}
 
-	subDir := filepath.FromSlash(addr.Subdir)
-	modDir := filepath.Join(instPath, subDir)
+	modDir, err := getmodules.ExpandSubdirGlobs(instPath, addr.Subdir)
+	if err != nil {
+		diags = diags.Append(err)
+		return nil, diags
+	}
 
 	log.Printf("[TRACE] ModuleInstaller: %s %q was downloaded to %s", key, addr, modDir)
 


### PR DESCRIPTION
At some point Terraform lost the ability to handle the go-getter subdirectory wildcard syntax of `//*`. While the registry no longer uses this type of path to locate module archives, it's still technically valid, and should be possible to use within terraform.