### PR TITLE
set PRODUCT_VERSION for default docker build

### DIFF
--- a/.github/workflows/build-Dockerfile
+++ b/.github/workflows/build-Dockerfile
@@ -24,10 +24,10 @@ ARG TARGETARCH
 LABEL maintainer="HashiCorp Terraform Team <terraform@hashicorp.com>"
 
 # New standard version label.
-LABEL version=$VERSION
+LABEL version=$PRODUCT_VERSION
 
 # Historical Terraform-specific label preserved for backward compatibility.
-LABEL "com.hashicorp.terraform.version"="${VERSION}"
+LABEL "com.hashicorp.terraform.version"="${PRODUCT_VERSION}"
 
 RUN apk add --no-cache git openssh
 


### PR DESCRIPTION
In `actions-docker-build` we [pass](https://github.com/hashicorp/actions-docker-build/blob/05c370a26e61b06be46c5095d6e914c9f0ea4f3d/scripts/docker_build#L49) `PRODUCT_VERSION` to the docker build command. This fixes it to set the label properly with the build-arg which is used in a comparison to determine the `minor-latest` and `latest` docker image tags. 