### PR TITLE
docs: remove [DIR] from force-unlock docs

### DIFF
--- a/website/docs/cli/commands/force-unlock.mdx
+++ b/website/docs/cli/commands/force-unlock.mdx
@@ -16,7 +16,7 @@ process.
 
 ## Usage
 
-Usage: `terraform force-unlock [options] LOCK_ID [DIR]`
+Usage: `terraform force-unlock [options] LOCK_ID`
 
 Manually unlock the state for the defined configuration.
 


### PR DESCRIPTION
The `force-unlock` command does not accept an optional `[DIR]` argument.