### PR TITLE
set PRODUCT_VERSION for default docker build

### DIFF
--- a/.github/workflows/build-Dockerfile
+++ b/.github/workflows/build-Dockerfile
@@ -24,10 +24,10 @@ ARG TARGETARCH
 LABEL maintainer="HashiCorp Terraform Team <terraform@hashicorp.com>"
 
 # New standard version label.
-LABEL version=$VERSION
+LABEL version=$PRODUCT_VERSION
 
 # Historical Terraform-specific label preserved for backward compatibility.
-LABEL "com.hashicorp.terraform.version"="${VERSION}"
+LABEL "com.hashicorp.terraform.version"="${PRODUCT_VERSION}"
 
 RUN apk add --no-cache git openssh
 


### PR DESCRIPTION
Backport of #31663 to v1.2 to fix the Docker build on GitHub.