### PR TITLE
Remove future-facing statement from import page

### DIFF
--- a/website/docs/cli/import/usage.mdx
+++ b/website/docs/cli/import/usage.mdx
@@ -9,10 +9,8 @@ description: The `terraform import` command is used to import existing infrastru
 
 The `terraform import` command is used to import existing infrastructure.
 
-The command currently can only import one resource at a time. This means
-you can't yet point Terraform import to an entire collection of resources
-such as an AWS VPC and import all of it. This workflow will be improved in a
-future version of Terraform.
+The command can only import one resource at a time. This means
+you cannnot import an entire collection of resources such as an AWS VPC at one time. 
 
 ~> Warning: Terraform expects that each remote object it is managing will be
 bound to only one resource address, which is normally guaranteed by Terraform

--- a/website/docs/cli/import/usage.mdx
+++ b/website/docs/cli/import/usage.mdx
@@ -9,8 +9,7 @@ description: The `terraform import` command is used to import existing infrastru
 
 The `terraform import` command is used to import existing infrastructure.
 
-The command can only import one resource at a time. This means
-you cannnot import an entire collection of resources such as an AWS VPC at one time. 
+The `terraform import` command can only import one resource at a time. It cannot simultaneously import an entire collection of resources, like an AWS VPC.
 
 ~> Warning: Terraform expects that each remote object it is managing will be
 bound to only one resource address, which is normally guaranteed by Terraform

--- a/website/docs/cli/import/usage.mdx
+++ b/website/docs/cli/import/usage.mdx
@@ -7,7 +7,7 @@ description: The `terraform import` command is used to import existing infrastru
 
 > **Hands-on:** Try the [Import Terraform Configuration](https://learn.hashicorp.com/tutorials/terraform/state-import?in=terraform/state&utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) tutorial on HashiCorp Learn.
 
-The `terraform import` command is used to import existing infrastructure.
+Use the `terraform import` command to import existing infrastructure to Terraform state.
 
 The `terraform import` command can only import one resource at a time. It cannot simultaneously import an entire collection of resources, like an AWS VPC.
 


### PR DESCRIPTION
A user recently pointed out that we make a vague statement about improving a workflow "in the future" on this docs page. Best practices and our style guide dictate that we do not include statements like this in documentation. This PR removes that statement and fixes a few style nits in the surrounding sentences.