### PR TITLE
build: Some small tweaks to the "goimports" check and to how we run these checks in general

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -180,10 +180,6 @@ jobs:
           restore-keys: |
             protobuf-tools-
 
-      - name: Install CI tooling
-        run: |
-          go install golang.org/x/tools/cmd/goimports@v0.1.11
-
       - name: "Code consistency checks"
         run: |
           make fmtcheck importscheck generate staticcheck exhaustive protobuf

--- a/Makefile
+++ b/Makefile
@@ -33,16 +33,16 @@ protobuf:
 	go run ./tools/protobuf-compile .
 
 fmtcheck:
-	@sh -c "'$(CURDIR)/scripts/gofmtcheck.sh'"
+	sh -c "'$(CURDIR)/scripts/gofmtcheck.sh'"
 
 importscheck:
-	@sh -c "'$(CURDIR)/scripts/goimportscheck.sh'"
+	sh -c "'$(CURDIR)/scripts/goimportscheck.sh'"
 
 staticcheck:
-	@sh -c "'$(CURDIR)/scripts/staticcheck.sh'"
+	sh -c "'$(CURDIR)/scripts/staticcheck.sh'"
 
 exhaustive:
-	@sh -c "'$(CURDIR)/scripts/exhaustive.sh'"
+	sh -c "'$(CURDIR)/scripts/exhaustive.sh'"
 
 # Default: run this if working on the website locally to run in watch mode.
 website:

--- a/Makefile
+++ b/Makefile
@@ -33,16 +33,16 @@ protobuf:
 	go run ./tools/protobuf-compile .
 
 fmtcheck:
-	sh -c "'$(CURDIR)/scripts/gofmtcheck.sh'"
+	"$(CURDIR)/scripts/gofmtcheck.sh"
 
 importscheck:
-	sh -c "'$(CURDIR)/scripts/goimportscheck.sh'"
+	"$(CURDIR)/scripts/goimportscheck.sh"
 
 staticcheck:
-	sh -c "'$(CURDIR)/scripts/staticcheck.sh'"
+	"$(CURDIR)/scripts/staticcheck.sh"
 
 exhaustive:
-	sh -c "'$(CURDIR)/scripts/exhaustive.sh'"
+	"$(CURDIR)/scripts/exhaustive.sh"
 
 # Default: run this if working on the website locally to run in watch mode.
 website:

--- a/scripts/goimportscheck.sh
+++ b/scripts/goimportscheck.sh
@@ -1,19 +1,61 @@
 #!/usr/bin/env bash
 
+set -euo pipefail
+
 # Check goimports
 echo "==> Checking the code complies with goimports requirements..."
-target_files=$(git diff --name-only origin/main --diff-filter=MA | grep "\.go")
 
-if [[ -z ${target_files}  ]]; then
+# We only require goimports to have been run on files that were changed
+# relative to the main branch, so that we can gradually create more consistency
+# rather than bulk-changing everything at once.
+
+declare -a target_files
+# "readarray" will return an "unbound variable" error if there isn't already
+# at least one element in the target array. "readarray" will overwrite this
+# item, though.
+target_files[0]=""
+
+base_branch="origin/main"
+readarray -t target_files < <(git diff --name-only ${base_branch} --diff-filter=MA | grep "\.go")
+
+if [[ "${#target_files[@]}" -eq 0 ]]; then
+  echo "No files have changed relative to branch ${base_branch}, so there's nothing to check!"
   exit 0
 fi
 
-goimports_files=$(goimports -w -l "${target_files}")
-if [[ -n ${goimports_files} ]]; then
-  echo 'goimports needs running on the following files:'
-  echo "${goimports_files}"
-  echo "You can use the command and flags \`goimports -w -l\` to reformat the code"
+declare -a incorrect_files
+# Array must have at least one item before we can append to it. Code below must
+# work around this extra empty-string element at the beginning of the array.
+incorrect_files[0]=""
+
+for filename in "${target_files[@]}"; do
+  if [[ -z "$filename" ]]; then
+    continue
+  fi
+
+  output=$(go run golang.org/x/tools/cmd/goimports -l "${filename}")
+  if [[ $? -ne 0 ]]; then
+    echo >&2 goimports failed for "$filename"
+    exit 1
+  fi
+
+  if [[ -n "$output" ]]; then
+    incorrect_files+=("$filename")
+  fi
+done
+
+if [[ "${#incorrect_files[@]}" -gt 1 ]]; then
+  echo >&2 'The following files have import statements that disagree with "goimports"':
+  for filename in "${incorrect_files[@]}"; do
+    if [[ -z "$filename" ]]; then
+      continue
+    fi
+
+    echo >&2 ' - ' "${filename}"
+  done
+  echo >&2 'Use `go run golang.org/x/tools/cmd/goimports -w -l` on each of these files to update these files.'
   exit 1
 fi
 
+echo 'All of the changed files look good!'
 exit 0

--- a/scripts/goimportscheck.sh
+++ b/scripts/goimportscheck.sh
@@ -16,6 +16,13 @@ declare -a target_files
 target_files[0]=""
 
 base_branch="origin/main"
+
+# HACK: If we seem to be running inside a GitHub Actions pull request check
+# then we'll use the PR's target branch from this variable instead.
+if [[ -n "${GITHUB_BASE_REF:-}" ]]; then
+  base_branch="origin/$GITHUB_BASE_REF"
+fi
+
 readarray -t target_files < <(git diff --name-only ${base_branch} --diff-filter=MA | grep "\.go")
 
 if [[ "${#target_files[@]}" -eq 0 ]]; then

--- a/scripts/goimportscheck.sh
+++ b/scripts/goimportscheck.sh
@@ -23,6 +23,12 @@ if [[ -n "${GITHUB_BASE_REF:-}" ]]; then
   base_branch="origin/$GITHUB_BASE_REF"
 fi
 
+# FIXME: "readarray' is a Bash 4 feature, which means that currently this script
+# can't work on macOS which (at the time of writing this) ships with only Bash 3.
+# We can probably replace this with something more clunky using an overridden
+# "IFS" environment variable, but the primary place we want to run this right
+# now is in our "quick checks" workflow and that _does_ have a reasonably
+# modern version of Bash.
 readarray -t target_files < <(git diff --name-only ${base_branch} --diff-filter=MA | grep "\.go")
 
 if [[ "${#target_files[@]}" -eq 0 ]]; then


### PR DESCRIPTION
The original prompt to start working on this was that the `goimports` check script was generating confusing errors if there were too many files changed in a particular PR.

But while there I also made some other small tweaks in the hope of making these "quick checks" easier to follow in the GitHub Actions logs, since in the common case that's the main place we make use of them.

There are more details about the motivations for these changes in the commit messages of the individual commits, in case you're interested.