### PR TITLE
Remove Duplicate Divider for DevDot

### DIFF
--- a/website/data/cli-nav-data.json
+++ b/website/data/cli-nav-data.json
@@ -443,6 +443,5 @@
     ]
   },
   { "divider": true },
-  { "title": "Terraform Internals", "href": "/internals" },
-  { "divider": true }
+  { "title": "Terraform Internals", "href": "/internals" }
 ]

--- a/website/data/internals-nav-data.json
+++ b/website/data/internals-nav-data.json
@@ -57,6 +57,5 @@
   { "divider": true },
   { "title": "Terraform CLI", "href": "/cli" },
   { "divider": true },
-  { "title": "Configuration Language", "href": "/language" },
-  { "divider": true }
+  { "title": "Configuration Language", "href": "/language" }
 ]

--- a/website/data/language-nav-data.json
+++ b/website/data/language-nav-data.json
@@ -1155,6 +1155,5 @@
     ]
   },
   { "divider": true },
-  { "title": "Terraform Internals", "href": "/internals" },
-  { "divider": true }
+  { "title": "Terraform Internals", "href": "/internals" }
 ]


### PR DESCRIPTION
The Dev Portal UI is showing weird behavior where the divider between the last section in the layout file and the next section is duplicated. I believe that is because the devdot platform automatically adds dividers between sections --> no need to add them manually anymore. This PR removes the duplicate dividers from these  navigation sidebar layout files:
- Language 
- CLI
- Internals

<img width="281" alt="Screen Shot 2022-08-31 at 6 10 14 PM" src="https://user-images.githubusercontent.com/83350965/187794198-6dfed62e-444b-4a7b-a463-086b0eb9aa6e.png">
