### PR TITLE
command: correct suggested command text in provider cache miss

### DIFF
--- a/internal/command/init.go
+++ b/internal/command/init.go
@@ -772,7 +772,7 @@ func (c *InitCommand) getProviders(config *configs.Config, state *states.State, 
 				diags = diags.Append(tfdiags.Sourceless(
 					tfdiags.Error,
 					"Failed to install provider",
-					fmt.Sprintf("Error while installing %s v%s: %s\n\nYou can ensure the current platform, %s, is included in the dependency lock file by running: `terraform providers lock -provider=%s`.\n\nIf this does not fix the problem you may need to reset any provider caching present in your setup or make sure you are connecting to valid provider distributions.",
+					fmt.Sprintf("Error while installing %s v%s: %s\n\nYou can ensure the current platform, %s, is included in the dependency lock file by running: `terraform providers lock -platform=%s`.\n\nIf this does not fix the problem you may need to reset any provider caching present in your setup or make sure you are connecting to valid provider distributions.",
 						provider.ForDisplay(), version, err.Msg, err.Meta.TargetPlatform.String(), err.Meta.TargetPlatform.String(),
 					),
 				))


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform/issues/31709

I believe this error case was refactored out in v1.3 and therefore this fix only applies to the v1.2 branch. @liamcervante, can you confirm this?