### PR TITLE
Experiment: type constraints for output values

### DIFF
--- a/internal/configs/experiments.go
+++ b/internal/configs/experiments.go
@@ -232,5 +232,18 @@ func checkModuleExperiments(m *Module) hcl.Diagnostics {
 		}
 	*/
 
+	if !m.ActiveExperiments.Has(experiments.OutputTypeConstraints) {
+		for _, oc := range m.Outputs {
+			if oc.TypeSet {
+				diags = append(diags, &hcl.Diagnostic{
+					Severity: hcl.DiagError,
+					Summary:  "Output value type constraints are experimental",
+					Detail:   "The \"type\" argument for output values is currently an opt-in experiment, subject to change in future releases based on feedback.\n\nActivate the feature for this module by adding output_type_constraints to the list of active experiments.",
+					Subject:  oc.TypeRange.Ptr(),
+				})
+			}
+		}
+	}
+
 	return diags
 }

--- a/internal/configs/named_values.go
+++ b/internal/configs/named_values.go
@@ -395,6 +395,21 @@ type Output struct {
 	DependsOn   []hcl.Traversal
 	Sensitive   bool
 
+	// ConstraintType is a type constraint which the result is guaranteed
+	// to conform to when used in the calling module.
+	ConstraintType cty.Type
+	// TypeDefaults describes any optional attribute defaults that should be
+	// applied to the Expr result before type conversion.
+	TypeDefaults *typeexpr.Defaults
+	// TypeSet is true if there was an explicit "type" argument in the
+	// configuration block. This is mainly to allow distinguish explicitly
+	// setting vs. just using the default type constraint when processing
+	// override files.
+	TypeSet bool
+	// TypeRange is the source range for the type constraint recorded in
+	// ConstraintType. This is valid only if TypeSet is true.
+	TypeRange hcl.Range
+
 	Preconditions []*CheckRule
 
 	DescriptionSet bool
@@ -436,6 +451,20 @@ func decodeOutputBlock(block *hcl.Block, override bool) (*Output, hcl.Diagnostic
 
 	if attr, exists := content.Attributes["value"]; exists {
 		o.Expr = attr.Expr
+	}
+
+	if attr, exists := content.Attributes["type"]; exists {
+		ty, defaults, moreDiags := typeexpr.TypeConstraintWithDefaults(attr.Expr)
+		diags = append(diags, moreDiags...)
+		o.ConstraintType = ty
+		o.TypeDefaults = defaults
+		o.TypeSet = true
+		o.TypeRange = attr.Expr.Range()
+	}
+	if o.ConstraintType == cty.NilType {
+		// If no constraint is given then the type will be inferred
+		// automatically from the value.
+		o.ConstraintType = cty.DynamicPseudoType
 	}
 
 	if attr, exists := content.Attributes["sensitive"]; exists {
@@ -554,6 +583,9 @@ var outputBlockSchema = &hcl.BodySchema{
 		{
 			Name:     "value",
 			Required: true,
+		},
+		{
+			Name: "type",
 		},
 		{
 			Name: "depends_on",

--- a/internal/configs/parser_config_dir_test.go
+++ b/internal/configs/parser_config_dir_test.go
@@ -30,6 +30,7 @@ func TestParserLoadConfigDirSuccess(t *testing.T) {
 		name := info.Name()
 		t.Run(name, func(t *testing.T) {
 			parser := NewParser(nil)
+			parser.AllowLanguageExperiments(true)
 			path := filepath.Join("testdata/valid-modules", name)
 
 			mod, diags := parser.LoadConfigDir(path)
@@ -91,6 +92,7 @@ func TestParserLoadConfigDirSuccess(t *testing.T) {
 			parser := testParser(map[string]string{
 				"mod/" + name: string(src),
 			})
+			parser.AllowLanguageExperiments(true)
 
 			_, diags := parser.LoadConfigDir("mod")
 			if diags.HasErrors() {

--- a/internal/configs/parser_config_test.go
+++ b/internal/configs/parser_config_test.go
@@ -37,8 +37,10 @@ func TestParserLoadConfigFileSuccess(t *testing.T) {
 			parser := testParser(map[string]string{
 				name: string(src),
 			})
+			parser.AllowLanguageExperiments(true)
 
 			_, diags := parser.LoadConfigFile(name)
+			diags = filterExperimentEnabledDiagnostics(t, diags)
 			if len(diags) != 0 {
 				t.Errorf("unexpected diagnostics")
 				for _, diag := range diags {

--- a/internal/configs/testdata/valid-files/output-type-constraint.tf
+++ b/internal/configs/testdata/valid-files/output-type-constraint.tf
@@ -1,0 +1,15 @@
+terraform {
+  experiments = [output_type_constraints]
+}
+
+output "string" {
+  type  = string
+  value = "Hello"
+}
+
+output "object" {
+  type  = object({
+    name = optional(string, "Ermintrude"),
+  })
+  value = {}
+}

--- a/internal/experiments/experiment.go
+++ b/internal/experiments/experiment.go
@@ -18,6 +18,7 @@ const (
 	SuppressProviderSensitiveAttrs = Experiment("provider_sensitive_attrs")
 	ConfigDrivenMove               = Experiment("config_driven_move")
 	PreconditionsPostconditions    = Experiment("preconditions_postconditions")
+	OutputTypeConstraints          = Experiment("output_type_constraints")
 )
 
 func init() {
@@ -28,6 +29,7 @@ func init() {
 	registerConcludedExperiment(ConfigDrivenMove, "Declarations of moved resource instances using \"moved\" blocks can now be used by default, without enabling an experiment.")
 	registerConcludedExperiment(PreconditionsPostconditions, "Condition blocks can now be used by default, without enabling an experiment.")
 	registerConcludedExperiment(ModuleVariableOptionalAttrs, "The final feature corresponding to this experiment differs from the experimental form and is available in the Terraform language from Terraform v1.3.0 onwards.")
+	registerCurrentExperiment(OutputTypeConstraints)
 }
 
 // GetCurrent takes an experiment name and returns the experiment value

--- a/internal/terraform/node_output_test.go
+++ b/internal/terraform/node_output_test.go
@@ -20,7 +20,7 @@ func TestNodeApplyableOutputExecute_knownValue(t *testing.T) {
 	ctx.RefreshStateState = states.NewState().SyncWrapper()
 	ctx.ChecksState = checks.NewState(nil)
 
-	config := &configs.Output{Name: "map-output"}
+	config := &configs.Output{Name: "map-output", ConstraintType: cty.DynamicPseudoType}
 	addr := addrs.OutputValue{Name: config.Name}.Absolute(addrs.RootModuleInstance)
 	node := &NodeApplyableOutput{Config: config, Addr: addr}
 	val := cty.MapVal(map[string]cty.Value{
@@ -50,7 +50,7 @@ func TestNodeApplyableOutputExecute_knownValue(t *testing.T) {
 func TestNodeApplyableOutputExecute_noState(t *testing.T) {
 	ctx := new(MockEvalContext)
 
-	config := &configs.Output{Name: "map-output"}
+	config := &configs.Output{Name: "map-output", ConstraintType: cty.DynamicPseudoType}
 	addr := addrs.OutputValue{Name: config.Name}.Absolute(addrs.RootModuleInstance)
 	node := &NodeApplyableOutput{Config: config, Addr: addr}
 	val := cty.MapVal(map[string]cty.Value{
@@ -78,6 +78,7 @@ func TestNodeApplyableOutputExecute_invalidDependsOn(t *testing.T) {
 				hcl.TraverseAttr{Name: "bar"},
 			},
 		},
+		ConstraintType: cty.DynamicPseudoType,
 	}
 	addr := addrs.OutputValue{Name: config.Name}.Absolute(addrs.RootModuleInstance)
 	node := &NodeApplyableOutput{Config: config, Addr: addr}
@@ -100,7 +101,7 @@ func TestNodeApplyableOutputExecute_sensitiveValueNotOutput(t *testing.T) {
 	ctx.StateState = states.NewState().SyncWrapper()
 	ctx.ChecksState = checks.NewState(nil)
 
-	config := &configs.Output{Name: "map-output"}
+	config := &configs.Output{Name: "map-output", ConstraintType: cty.DynamicPseudoType}
 	addr := addrs.OutputValue{Name: config.Name}.Absolute(addrs.RootModuleInstance)
 	node := &NodeApplyableOutput{Config: config, Addr: addr}
 	val := cty.MapVal(map[string]cty.Value{
@@ -123,8 +124,9 @@ func TestNodeApplyableOutputExecute_sensitiveValueAndOutput(t *testing.T) {
 	ctx.ChecksState = checks.NewState(nil)
 
 	config := &configs.Output{
-		Name:      "map-output",
-		Sensitive: true,
+		Name:           "map-output",
+		Sensitive:      true,
+		ConstraintType: cty.DynamicPseudoType,
 	}
 	addr := addrs.OutputValue{Name: config.Name}.Absolute(addrs.RootModuleInstance)
 	node := &NodeApplyableOutput{Config: config, Addr: addr}

--- a/internal/terraform/testdata/apply-output-type-constraint/apply-output-type-constraint.tf
+++ b/internal/terraform/testdata/apply-output-type-constraint/apply-output-type-constraint.tf
@@ -1,0 +1,24 @@
+terraform {
+  experiments = [output_type_constraints]
+}
+
+output "string" {
+  type  = string
+  value = true
+}
+
+output "object_default" {
+  type = object({
+    name = optional(string, "Ermintrude")
+  })
+  value = {}
+}
+
+output "object_override" {
+  type = object({
+    name = optional(string, "Ermintrude")
+  })
+  value = {
+    name = "Peppa"
+  }
+}


### PR DESCRIPTION
As requested in #30579, this PR introduces _experimental_ support for declaring explicit type constraints in `output` blocks, using the same type constraint syntax we already use for input variables. The experiment keyword is `output_type_constraints`.

```hcl
output "example" {
  type  = string
  value = local.example
}
```

The goal of merging this would be to be able to use subsequent alpha releases (once we update our release process to enable experiments for them) to be used as a vehicle both for evaluating the potential interest in a feature like this and for learning if a new argument inside the `output` block is the most ideal design for it. It would not be available in non-alpha releases until stabilized, and so merging this PR is not sufficient to close the associated issue.

---

I already have a few design questions just as a result of implementing the experiment:
* One of the goals expressed in #30579 is to use an output value's type constraint as part of its documentation, so that consumers of the module can clearly see what type of value will be returned.

    However, our type constraint syntax is oriented towards the person providing a value rather than the person consuming it. While I can certainly imagine it being convenient to the author of the module to use optional attributes and default values, it isn't clear to me that this information is useful as documentation for the _recipient_ of a value: the decision of whether to assign a value directly or to rely on automatic insertion during type conversion is an implementation detail of the module, not part of its interface.

    Would it make sense to exclude the ability to specify optional attributes and/or default values from output value type constraints? Or alternatively, could we build something in `terraform-config-inspect` (our main interface for use-cases such as docs generation) to "simplify" the specified type constraint to strip out all of the `optional` annotations and just describe the type?
* When we implemented optional attributes for input variables we were constrained by compatibility to still allow explicitly assigning `null` to an attribute not declared as optional, even though in all other senses we aim to treat "null" as exactly equivalent to unset.

    Since this is a green field feature, would it make sense to use a stricter interpretation of "optional" here such that we can guarantee to the recipient of the value that an output value which isn't declared as `optional` will _never_ be `null`? Although that would serve purely as documentation today, it could potentially benefit us down the road to have a static promise that a particular attribute can never be null as we work to reduce the number of situations where a derived expression is forced to return unknown.

    On the other hand, this would end up being just a special case for object attributes unless we accompanied it with some other features: we have no current syntax to declare that an output value as a whole is guaranteed not to be null, and no syntax to declare that elements of a collection cannot be null. We may just need to accept that our language is not one that is amenable to static analysis of the "nullable" property.
* Anything we add for output values always invites the question of whether we should also support it for local values, but in this case I think that would just reduce to the existing idea of having e.g. a `convert(value, typeexpr)` function which can be used in any context.

    I'm still keen on that idea, and it's true that if it were present then it could be used in output values as an alternative to this explicit `type` argument, so we should consider whether the `convert` function would be a more general/orthogonal answer to this problem.

    With that said: we still don't have a fully-specified plan for how to deal with making the keywords like `string`, `bool`, `any` valid in a function argument position without a breaking language change, and also an explicit `type` argument is more practical to extract using syntax-only analysis in `terraform-config-inspect` and other potential "shallow integrations" that aren't capable of full expression evaluation. I think if we were to adopt `convert` as the solution to this request then we'd need to at least show that it's viable for `terraform-config-inspect` to extract a type constraint for use in documentation.

As long as this remains an experiment I don't think answering these questions is a blocker. Indeed, if we move foward I expect that subsequent discussion will yield additional questions for us to consider.
