### PR TITLE
removes EnableForcePush and other unrelated code

### DIFF
--- a/internal/cloud/state.go
+++ b/internal/cloud/state.go
@@ -92,19 +92,13 @@ func (s *State) WriteStateForMigration(f *statefile.File, force bool) error {
 		}
 	}
 
-	// The remote backend needs to pass the `force` flag through to its client.
-	// For backends that support such operations, inform the client
-	// that a force push has been requested
-	if force {
-		s.EnableForcePush()
-	}
-
 	// We create a deep copy of the state here, because the caller also has
 	// a reference to the given object and can potentially go on to mutate
 	// it after we return, but we want the snapshot at this point in time.
 	s.state = f.State.DeepCopy()
 	s.lineage = f.Lineage
 	s.serial = f.Serial
+	s.forcePush = force
 
 	return nil
 }
@@ -136,6 +130,7 @@ func (s *State) WriteState(state *states.State) error {
 	// a reference to the given object and can potentially go on to mutate
 	// it after we return, but we want the snapshot at this point in time.
 	s.state = state.DeepCopy()
+	s.forcePush = false
 
 	return nil
 }
@@ -412,12 +407,6 @@ func (s *State) Delete() error {
 	}
 
 	return nil
-}
-
-// EnableForcePush to allow the remote client to overwrite state
-// by implementing remote.ClientForcePusher
-func (s *State) EnableForcePush() {
-	s.forcePush = true
 }
 
 // GetRootOutputValues fetches output values from Terraform Cloud

--- a/internal/command/command_test.go
+++ b/internal/command/command_test.go
@@ -138,9 +138,6 @@ func metaOverridesForProvider(p providers.Interface) *testingOverrides {
 		Providers: map[addrs.Provider]providers.Factory{
 			addrs.NewDefaultProvider("test"):                                           providers.FactoryFixed(p),
 			addrs.NewProvider(addrs.DefaultProviderRegistryHost, "hashicorp2", "test"): providers.FactoryFixed(p),
-			addrs.NewLegacyProvider("null"):                                            providers.FactoryFixed(p),
-			addrs.NewLegacyProvider("azurerm"):                                         providers.FactoryFixed(p),
-			addrs.NewProvider(addrs.DefaultProviderRegistryHost, "acmecorp", "aws"):    providers.FactoryFixed(p),
 		},
 	}
 }


### PR DESCRIPTION
Addresses the outstanding comments from my last PR: https://github.com/hashicorp/terraform/pull/31698

I'm not sure if there are any repercussions to removing `EnableForcePush`, but we won't be using it anywhere within State anymore so I removed it, let me know if that needs to be added back in.