### PR TITLE
Updates the read symbol

### DIFF
--- a/internal/command/format/diff.go
+++ b/internal/command/format/diff.go
@@ -1990,7 +1990,7 @@ func DiffActionSymbol(action plans.Action) string {
 	case plans.Delete:
 		return "  [red]-[reset]"
 	case plans.Read:
-		return " [cyan]<=[reset]"
+		return " [cyan]<==[reset]"
 	case plans.Update:
 		return "  [yellow]~[reset]"
 	default:

--- a/internal/command/format/diff_test.go
+++ b/internal/command/format/diff_test.go
@@ -551,7 +551,7 @@ new line
 			},
 			ExpectedOutput: `  # data.test_instance.example will be read during apply
   # (config refers to values not yet known)
- <= data "test_instance" "example" {
+ <== data "test_instance" "example" {
         name = "name"
     }
 `,
@@ -573,7 +573,7 @@ new line
 			},
 			ExpectedOutput: `  # data.test_instance.example will be read during apply
   # (depends on a resource or a module with changes pending)
- <= data "test_instance" "example" {
+ <== data "test_instance" "example" {
         name = "name"
     }
 `,
@@ -593,7 +593,7 @@ new line
 				},
 			},
 			ExpectedOutput: `  # data.test_instance.example will be read during apply
- <= data "test_instance" "example" {
+ <== data "test_instance" "example" {
         name = "name"
     }
 `,


### PR DESCRIPTION
Use three chars <== to get an arrow instead of less or equal symbol on font with ligatures

![terraform-read-symbol-diff](https://user-images.githubusercontent.com/1905755/188598980-408f1dfe-9345-4e4f-99f6-b4f2613c9076.png)
