### PR TITLE
Add envar AWS_STATE_BUCKET as default bucket

### DIFF
--- a/internal/backend/remote-state/s3/backend.go
+++ b/internal/backend/remote-state/s3/backend.go
@@ -25,6 +25,9 @@ func New() backend.Backend {
 				Type:        schema.TypeString,
 				Required:    true,
 				Description: "The name of the S3 bucket",
+				DefaultFunc: schema.MultiEnvDefaultFunc([]string{
+					"AWS_STATE_BUCKET",
+				}, nil),
 			},
 
 			"key": {


### PR DESCRIPTION
AWS_STATE_BUCKET is the missing env var.
Adding this allow to use S3 backend with only env var.