### PR TITLE
Add equivalence testing framework, and example test

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -63,6 +63,7 @@ require (
 	github.com/mitchellh/mapstructure v1.1.2
 	github.com/mitchellh/reflectwalk v1.0.2
 	github.com/nishanths/exhaustive v0.7.11
+	github.com/nsf/jsondiff v0.0.0-20210926074059-1e845ec5d249
 	github.com/packer-community/winrmcp v0.0.0-20180921211025-c76d91c1e7db
 	github.com/pkg/browser v0.0.0-20201207095918-0426ae3fba23
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -526,6 +526,8 @@ github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/nishanths/exhaustive v0.7.11 h1:xV/WU3Vdwh5BUH4N06JNUznb6d5zhRPOnlgCrpNYNKA=
 github.com/nishanths/exhaustive v0.7.11/go.mod h1:gX+MP7DWMKJmNa1HfMozK+u04hQd3na9i0hyqf3/dOI=
+github.com/nsf/jsondiff v0.0.0-20210926074059-1e845ec5d249 h1:NHrXEjTNQY7P0Zfx1aMrNhpgxHmow66XQtm0aQLY0AE=
+github.com/nsf/jsondiff v0.0.0-20210926074059-1e845ec5d249/go.mod h1:mpRZBD8SJ55OIICQ3iWH0Yz3cjzA61JdqMLoWXeB2+8=
 github.com/nu7hatch/gouuid v0.0.0-20131221200532-179d4d0c4d8d h1:VhgPp6v9qf9Agr/56bj7Y/xa04UccTW04VP0Qed4vnQ=
 github.com/nu7hatch/gouuid v0.0.0-20131221200532-179d4d0c4d8d/go.mod h1:YUTz3bUH2ZwIWBy3CJBeOBEugqcmXREj14T+iG/4k4U=
 github.com/nxadm/tail v1.4.4 h1:DQuhQpB1tVlglWS2hLQ5OV6B5r8aGxSrPc5Qo6uTN78=

--- a/tools/equivalence-tests/goldens/example/apply.json
+++ b/tools/equivalence-tests/goldens/example/apply.json
@@ -1,0 +1,78 @@
+[
+  {
+    "@level": "info",
+    "@message": "mock_simple_resource.integer: Plan to create",
+    "@module": "terraform.ui",
+    "change": {
+      "action": "create",
+      "resource": {
+        "addr": "mock_simple_resource.integer",
+        "implied_provider": "mock",
+        "module": "",
+        "resource": "mock_simple_resource.integer",
+        "resource_key": null,
+        "resource_name": "integer",
+        "resource_type": "mock_simple_resource"
+      }
+    },
+    "type": "planned_change"
+  },
+  {
+    "@level": "info",
+    "@message": "mock_simple_resource.integer: Creating...",
+    "@module": "terraform.ui",
+    "hook": {
+      "action": "create",
+      "resource": {
+        "addr": "mock_simple_resource.integer",
+        "implied_provider": "mock",
+        "module": "",
+        "resource": "mock_simple_resource.integer",
+        "resource_key": null,
+        "resource_name": "integer",
+        "resource_type": "mock_simple_resource"
+      }
+    },
+    "type": "apply_start"
+  },
+  {
+    "@level": "info",
+    "@message": "mock_simple_resource.integer: Creation complete after 0s [id=my_integer]",
+    "@module": "terraform.ui",
+    "hook": {
+      "action": "create",
+      "elapsed_seconds": 0,
+      "id_key": "id",
+      "id_value": "my_integer",
+      "resource": {
+        "addr": "mock_simple_resource.integer",
+        "implied_provider": "mock",
+        "module": "",
+        "resource": "mock_simple_resource.integer",
+        "resource_key": null,
+        "resource_name": "integer",
+        "resource_type": "mock_simple_resource"
+      }
+    },
+    "type": "apply_complete"
+  },
+  {
+    "@level": "info",
+    "@message": "Apply complete! Resources: 1 added, 0 changed, 0 destroyed.",
+    "@module": "terraform.ui",
+    "changes": {
+      "add": 1,
+      "change": 0,
+      "operation": "apply",
+      "remove": 0
+    },
+    "type": "change_summary"
+  },
+  {
+    "@level": "info",
+    "@message": "Outputs: 0",
+    "@module": "terraform.ui",
+    "outputs": {},
+    "type": "outputs"
+  }
+]

--- a/tools/equivalence-tests/goldens/example/plan.json
+++ b/tools/equivalence-tests/goldens/example/plan.json
@@ -1,0 +1,80 @@
+{
+  "configuration": {
+    "provider_config": {
+      "mock": {
+        "full_name": "registry.terraform.io/liamcervante/mock",
+        "name": "mock"
+      }
+    },
+    "root_module": {
+      "resources": [
+        {
+          "address": "mock_simple_resource.integer",
+          "expressions": {
+            "id": {
+              "constant_value": "my_integer"
+            },
+            "integer": {
+              "constant_value": 1
+            }
+          },
+          "mode": "managed",
+          "name": "integer",
+          "provider_config_key": "mock",
+          "schema_version": 0,
+          "type": "mock_simple_resource"
+        }
+      ]
+    }
+  },
+  "format_version": "1.1",
+  "planned_values": {
+    "root_module": {
+      "resources": [
+        {
+          "address": "mock_simple_resource.integer",
+          "mode": "managed",
+          "name": "integer",
+          "provider_name": "registry.terraform.io/liamcervante/mock",
+          "schema_version": 0,
+          "sensitive_values": {},
+          "type": "mock_simple_resource",
+          "values": {
+            "bool": null,
+            "float": null,
+            "id": "my_integer",
+            "integer": 1,
+            "number": null,
+            "string": null
+          }
+        }
+      ]
+    }
+  },
+  "resource_changes": [
+    {
+      "address": "mock_simple_resource.integer",
+      "change": {
+        "actions": [
+          "create"
+        ],
+        "after": {
+          "bool": null,
+          "float": null,
+          "id": "my_integer",
+          "integer": 1,
+          "number": null,
+          "string": null
+        },
+        "after_sensitive": {},
+        "after_unknown": {},
+        "before": null,
+        "before_sensitive": false
+      },
+      "mode": "managed",
+      "name": "integer",
+      "provider_name": "registry.terraform.io/liamcervante/mock",
+      "type": "mock_simple_resource"
+    }
+  ]
+}

--- a/tools/equivalence-tests/goldens/example/state.json
+++ b/tools/equivalence-tests/goldens/example/state.json
@@ -1,0 +1,26 @@
+{
+  "format_version": "1.0",
+  "values": {
+    "root_module": {
+      "resources": [
+        {
+          "address": "mock_simple_resource.integer",
+          "mode": "managed",
+          "name": "integer",
+          "provider_name": "registry.terraform.io/liamcervante/mock",
+          "schema_version": 0,
+          "sensitive_values": {},
+          "type": "mock_simple_resource",
+          "values": {
+            "bool": null,
+            "float": null,
+            "id": "my_integer",
+            "integer": 1,
+            "number": null,
+            "string": null
+          }
+        }
+      ]
+    }
+  }
+}

--- a/tools/equivalence-tests/goldens/example/terraform.resource/my_integer.json
+++ b/tools/equivalence-tests/goldens/example/terraform.resource/my_integer.json
@@ -1,0 +1,10 @@
+{
+  "values": {
+    "id": {
+      "string": "my_integer"
+    },
+    "integer": {
+      "number": "1"
+    }
+  }
+}

--- a/tools/equivalence-tests/internal/capture.go
+++ b/tools/equivalence-tests/internal/capture.go
@@ -1,0 +1,55 @@
+package internal
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+type capture struct {
+	stdout *bytes.Buffer
+	stderr *bytes.Buffer
+}
+
+func (c capture) ToJson(structured bool) (interface{}, error) {
+	var target []byte
+	if structured {
+		list := strings.Split(c.stdout.String(), "\n")
+		var filtered []string
+		for _, part := range list {
+			if len(part) > 0 {
+				filtered = append(filtered, part)
+			}
+		}
+		target = []byte(fmt.Sprintf("[%s]", strings.Join(filtered, ",")))
+	} else {
+		target = c.stdout.Bytes()
+	}
+
+	var data interface{}
+	if err := json.Unmarshal(target, &data); err != nil {
+		return data, err
+	}
+	return data, nil
+}
+
+func (c capture) ToError() error {
+	str := c.stderr.String()
+	if len(str) > 0 {
+		return errors.New(str)
+	}
+	return nil
+}
+
+func Capture(cmd *exec.Cmd) *capture {
+	out := capture{
+		stdout: &bytes.Buffer{},
+		stderr: &bytes.Buffer{},
+	}
+	cmd.Stdout = out.stdout
+	cmd.Stderr = out.stderr
+	return &out
+}

--- a/tools/equivalence-tests/internal/file.go
+++ b/tools/equivalence-tests/internal/file.go
@@ -1,0 +1,47 @@
+package internal
+
+import (
+	"io"
+	"io/fs"
+	"os"
+	"strings"
+)
+
+func cp(sourceDirectory, targetDirectory string, skipFiles []string) fs.WalkDirFunc {
+	return func(path string, entry fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		for _, skip := range skipFiles {
+			if skip == entry.Name() {
+				return nil
+			}
+		}
+
+		if path == sourceDirectory {
+			return nil
+		}
+
+		targetFile := strings.ReplaceAll(path, sourceDirectory, targetDirectory)
+
+		if entry.IsDir() {
+			return os.MkdirAll(targetFile, os.ModePerm)
+		}
+
+		source, err := os.Open(path)
+		if err != nil {
+			return err
+		}
+		defer source.Close()
+
+		target, err := os.Create(targetFile)
+		if err != nil {
+			return err
+		}
+		defer target.Close()
+
+		_, err = io.Copy(target, source)
+		return err
+	}
+}

--- a/tools/equivalence-tests/internal/json.go
+++ b/tools/equivalence-tests/internal/json.go
@@ -1,0 +1,136 @@
+package internal
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+const (
+	wildcard = "*"
+)
+
+// StripJson will parse a JSON object represented by data, remove all the
+// requested fields.
+//
+// The fields parameter should be a slice of strings, where each string is a
+// list of keys seperated by the '.' character. Each key should either be a
+// number representing an index in a JSON list, or a string representing an
+// actual key in JSON map.
+//
+// The wildcard character, '*', can also be used to represent all items in a
+// JSON list or map.
+//
+// Have a look at the json_test.go file for some examples.
+func StripJson(fields []string, data interface{}) (interface{}, error) {
+	for _, field := range fields {
+		var err error
+		data, err = strip(strings.Split(field, "."), data)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return data, nil
+}
+
+func strip(parts []string, current interface{}) (interface{}, error) {
+	if current == nil {
+		return nil, nil
+	}
+
+	if len(parts) == 1 {
+		return stripLeaf(parts[0], current)
+	}
+
+	return stripNode(parts, current)
+}
+
+func stripLeaf(part string, current interface{}) (interface{}, error) {
+	switch leaf := current.(type) {
+	case map[string]interface{}:
+		return stripMapLeaf(part, leaf), nil
+	case []interface{}:
+		return stripSliceLeaf(part, leaf)
+	default:
+		return nil, fmt.Errorf("unrecognised json type: %T", leaf)
+	}
+}
+
+func stripMapLeaf(part string, current map[string]interface{}) map[string]interface{} {
+	switch part {
+	case wildcard:
+		return map[string]interface{}{}
+	default:
+		delete(current, part)
+		return current
+	}
+}
+
+func stripSliceLeaf(part string, current []interface{}) ([]interface{}, error) {
+	switch part {
+	case wildcard:
+		return []interface{}{}, nil
+	default:
+		ix, err := strconv.Atoi(part)
+		if err != nil {
+			return nil, fmt.Errorf("must specify an integer when referencing json arrays, instead specified %s", part)
+		}
+		return append(current[:ix], current[ix+1:]...), nil
+	}
+}
+
+func stripNode(parts []string, current interface{}) (interface{}, error) {
+	switch node := current.(type) {
+	case map[string]interface{}:
+		return stripMapNode(parts, node)
+	case []interface{}:
+		return stripSliceNode(parts, node)
+	default:
+		return nil, fmt.Errorf("unrecognised json type: %T", node)
+	}
+}
+
+func stripMapNode(parts []string, current map[string]interface{}) (map[string]interface{}, error) {
+	switch parts[0] {
+	case wildcard:
+		ret := map[string]interface{}{}
+		for key, value := range current {
+			var err error
+			if ret[key], err = strip(parts[1:], value); err != nil {
+				return nil, err
+			}
+		}
+		return ret, nil
+	default:
+		var err error
+		if current[parts[0]], err = strip(parts[1:], current[parts[0]]); err != nil {
+			return nil, err
+		}
+		return current, nil
+	}
+}
+
+func stripSliceNode(parts []string, current []interface{}) ([]interface{}, error) {
+	switch parts[0] {
+	case wildcard:
+		var ret []interface{}
+		for _, item := range current {
+			stripped, err := strip(parts[1:], item)
+			if err != nil {
+				return nil, err
+			}
+			ret = append(ret, stripped)
+		}
+		return ret, nil
+	default:
+		ix, err := strconv.Atoi(parts[0])
+		if err != nil {
+			return nil, fmt.Errorf("must specify an integer when referencing json arrays, instead specified %s", parts[0])
+		}
+
+		if current[ix], err = strip(parts[1:], current[ix]); err != nil {
+			return nil, err
+		}
+		return current, nil
+	}
+}

--- a/tools/equivalence-tests/internal/json_test.go
+++ b/tools/equivalence-tests/internal/json_test.go
@@ -1,0 +1,311 @@
+package internal
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+)
+
+func TestStripJson(t *testing.T) {
+	tcs := []struct {
+		input    interface{}
+		expected interface{}
+		fields   []string
+	}{
+		{
+			input:    map[string]interface{}{},
+			expected: map[string]interface{}{},
+			fields:   []string{},
+		},
+		{
+			input: map[string]interface{}{
+				"map": map[string]interface{}{
+					"one": "one",
+					"two": "two",
+				},
+				"list": []interface{}{
+					map[string]interface{}{
+						"one": "one",
+						"two": "two",
+					},
+					map[string]interface{}{
+						"one": "one",
+						"two": "two",
+					},
+				},
+			},
+			expected: map[string]interface{}{
+				"map": map[string]interface{}{
+					"one": "one",
+					"two": "two",
+				},
+				"list": []interface{}{
+					map[string]interface{}{
+						"one": "one",
+						"two": "two",
+					},
+					map[string]interface{}{
+						"one": "one",
+						"two": "two",
+					},
+				},
+			},
+			fields: []string{},
+		},
+		{
+			input: map[string]interface{}{
+				"map": map[string]interface{}{
+					"one": "one",
+					"two": "two",
+				},
+				"list": []interface{}{
+					map[string]interface{}{
+						"one": "one",
+						"two": "two",
+					},
+					map[string]interface{}{
+						"one": "one",
+						"two": "two",
+					},
+				},
+			},
+			expected: map[string]interface{}{
+				"map": map[string]interface{}{
+					"one": "one",
+					"two": "two",
+				},
+			},
+			fields: []string{
+				"list",
+			},
+		},
+		{
+			input: map[string]interface{}{
+				"map": map[string]interface{}{
+					"one": "one",
+					"two": "two",
+				},
+				"list": []interface{}{
+					map[string]interface{}{
+						"one": "one",
+						"two": "two",
+					},
+					map[string]interface{}{
+						"one": "one",
+						"two": "two",
+					},
+				},
+			},
+			expected: map[string]interface{}{
+				"map": map[string]interface{}{
+					"one": "one",
+					"two": "two",
+				},
+				"list": []interface{}{},
+			},
+			fields: []string{
+				"list.*",
+			},
+		},
+		{
+			input: map[string]interface{}{
+				"map": map[string]interface{}{
+					"one": []interface{}{
+						"one",
+						"two",
+					},
+					"two": []interface{}{
+						"one",
+						"two",
+					},
+				},
+			},
+			expected: map[string]interface{}{
+				"map": map[string]interface{}{
+					"two": []interface{}{
+						"one",
+						"two",
+					},
+				},
+			},
+			fields: []string{
+				"map.one",
+			},
+		},
+		{
+			input: map[string]interface{}{
+				"map": map[string]interface{}{
+					"one": []interface{}{
+						"one",
+						"two",
+					},
+					"two": []interface{}{
+						"one",
+						"two",
+					},
+				},
+			},
+			expected: map[string]interface{}{
+				"map": map[string]interface{}{},
+			},
+			fields: []string{
+				"map.*",
+			},
+		},
+		{
+			input: map[string]interface{}{
+				"map": map[string]interface{}{
+					"one": []interface{}{
+						"one",
+						"two",
+					},
+					"two": []interface{}{
+						"one",
+						"two",
+					},
+				},
+			},
+			expected: map[string]interface{}{
+				"map": map[string]interface{}{
+					"one": []interface{}{},
+					"two": []interface{}{
+						"one",
+						"two",
+					},
+				},
+			},
+			fields: []string{
+				"map.one.*",
+			},
+		},
+		{
+			input: map[string]interface{}{
+				"map": map[string]interface{}{
+					"one": "one",
+					"two": "two",
+				},
+				"list": []interface{}{
+					map[string]interface{}{
+						"one": "one",
+						"two": "two",
+					},
+					map[string]interface{}{
+						"one": "one",
+						"two": "two",
+					},
+				},
+			},
+			expected: map[string]interface{}{
+				"map": map[string]interface{}{
+					"two": "two",
+				},
+				"list": []interface{}{
+					map[string]interface{}{
+						"two": "two",
+					},
+					map[string]interface{}{
+						"two": "two",
+					},
+				},
+			},
+			fields: []string{
+				"map.one",
+				"list.*.one",
+			},
+		},
+		{
+			input: map[string]interface{}{
+				"map": map[string]interface{}{
+					"one": "one",
+					"two": "two",
+				},
+				"list": []interface{}{
+					map[string]interface{}{
+						"one": "one",
+						"two": "two",
+					},
+					map[string]interface{}{
+						"one": "one",
+						"two": "two",
+					},
+				},
+			},
+			expected: map[string]interface{}{
+				"list": []interface{}{
+					map[string]interface{}{
+						"one": "one",
+						"two": "two",
+					},
+					map[string]interface{}{
+						"one": "one",
+						"two": "two",
+					},
+				},
+			},
+			fields: []string{
+				"map",
+			},
+		},
+		{
+			input: map[string]interface{}{
+				"map": map[string]interface{}{
+					"one": "one",
+					"two": "two",
+				},
+				"list": []interface{}{
+					map[string]interface{}{
+						"one": "one",
+						"two": "two",
+					},
+					map[string]interface{}{
+						"one": "one",
+						"two": "two",
+					},
+				},
+			},
+			expected: map[string]interface{}{
+				"map": map[string]interface{}{
+					"one": "one",
+					"two": "two",
+				},
+				"list": []interface{}{
+					map[string]interface{}{
+						"two": "two",
+					},
+					map[string]interface{}{
+						"one": "one",
+					},
+				},
+			},
+			fields: []string{
+				"list.0.one",
+				"list.1.two",
+			},
+		},
+	}
+	for ix, tc := range tcs {
+		t.Run(fmt.Sprintf("%d", ix), func(t *testing.T) {
+			actual, err := StripJson(tc.fields, tc.input)
+			if err != nil {
+				t.Logf("call to StripJson failed unexpectedly: %v", err)
+				t.Fail()
+				return
+			}
+
+			actualStr, err := json.Marshal(actual)
+			if err != nil {
+				t.Fatalf("could not convert actual into bytes: %v", err)
+			}
+
+			expectedStr, err := json.Marshal(tc.expected)
+			if err != nil {
+				t.Fatalf("could not convert expected into bytes: %v", err)
+			}
+
+			if string(actualStr) != string(expectedStr) {
+				t.Logf("actual does not equal expected\nexpected:\n\t%s\nactual:\n\t%s\n", string(expectedStr), string(actualStr))
+				t.Fail()
+			}
+		})
+	}
+}

--- a/tools/equivalence-tests/internal/tests.go
+++ b/tools/equivalence-tests/internal/tests.go
@@ -1,0 +1,319 @@
+package internal
+
+import (
+	"encoding/json"
+	"errors"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path"
+	"path/filepath"
+
+	"github.com/nsf/jsondiff"
+)
+
+var (
+	// defaultFields is the set of fields that are ignored by default for any
+	// files by the given names.
+	defaultFields = map[string][]string{
+		"apply.json": {
+			"0",
+			"*.@timestamp",
+		},
+		"plan.json": {
+			"terraform_version",
+		},
+		"state.json": {
+			"terraform_version",
+		},
+	}
+)
+
+// Test defines a single equivalence test within our framework.
+//
+// Each test has a Name that references the directory that contains our testing
+// data. Within this directory there should be a `spec.json` file which is
+// read in the TestSpecification object.
+//
+// The Directory variable references the parent directory of the test, so the
+// full path for a given test case is paths.Join(test.Directory, test.Name).
+type Test struct {
+	Name          string
+	Directory     string
+	Specification TestSpecification
+}
+
+// TestSpecification defines the specification for a given test case.
+//
+// For each test we have a set of GoldenFiles that we care about when comparing,
+// and we have a set of IgnoreFields for each golden file that we should ignore
+// when diffing.
+//
+// The GoldenFiles and IgnoreFields should be specified as in addition to the
+// defaults provided by the framework for each of these. The default golden
+// files are apply.json, state.json, and plan.json. The default ignored fields
+// for each of these are specified in the defaultFields variable at the top
+// of this file.
+type TestSpecification struct {
+	GoldenFiles  []string            `json:"golden-files"`
+	IgnoreFields map[string][]string `json:"ignore-fields"`
+}
+
+// TestOutput provides the output of executing a given test.
+//
+// The output is a map of filenames (from the golden file list in the
+// specification) to unmarshalled JSON data for that file.
+type TestOutput struct {
+	Test  Test
+	files map[string]interface{}
+}
+
+// ReadTests accepts a directory and returns the set of test cases specified
+// within this directory.
+func ReadTests(directory string) ([]Test, error) {
+	files, err := ioutil.ReadDir(directory)
+	if err != nil {
+		return nil, err
+	}
+
+	var tests []Test
+	for _, file := range files {
+		if file.IsDir() {
+			data, err := ioutil.ReadFile(path.Join(directory, file.Name(), "spec.json"))
+			if err != nil {
+				return nil, err
+			}
+
+			var specification TestSpecification
+			if err := json.Unmarshal(data, &specification); err != nil {
+				return nil, err
+			}
+
+			tests = append(tests, Test{
+				Name:          file.Name(),
+				Specification: specification,
+				Directory:     directory,
+			})
+		}
+	}
+	return tests, nil
+}
+
+// Run executes the given Test using the Terraform binary specified by the
+// parameter.
+//
+// The first error is any error reported by the Golang binary itself, the second
+// error will contain any stderr reported by the Terraform binary.
+func (test Test) Run(binary string) (TestOutput, error, error) {
+	tmp, err := os.MkdirTemp(test.Directory, test.Name)
+	if err != nil {
+		return TestOutput{}, err, nil
+	}
+	defer os.RemoveAll(tmp)
+
+	testDirectory := path.Join(test.Directory, test.Name)
+	if err = filepath.WalkDir(testDirectory, cp(testDirectory, tmp, []string{"spec.json"})); err != nil {
+		return TestOutput{}, err, nil
+	}
+
+	wd, err := os.Getwd()
+	if err != nil {
+		return TestOutput{}, err, nil
+	}
+
+	// We've got all our files copied into the temporary directory, so now we
+	// just have to execute terraform and get the golden files.
+	if err := os.Chdir(tmp); err != nil {
+		return TestOutput{}, err, nil
+	}
+	defer os.Chdir(wd)
+
+	init := exec.Command(binary, "init")
+	plan := exec.Command(binary, "plan", "-out=equivalence_test_plan")
+	apply := exec.Command(binary, "apply", "-json", "equivalence_test_plan")
+	showState := exec.Command(binary, "show", "-json")
+	showPlan := exec.Command(binary, "show", "-json", "equivalence_test_plan")
+
+	initCapture := Capture(init)
+	if err := init.Run(); err != nil {
+		return TestOutput{}, err, initCapture.ToError()
+	}
+
+	planCapture := Capture(plan)
+	if err := plan.Run(); err != nil {
+		return TestOutput{}, err, planCapture.ToError()
+	}
+
+	applyCapture := Capture(apply)
+	showStateCapture := Capture(showState)
+	showPlanCapture := Capture(showPlan)
+
+	if err := apply.Run(); err != nil {
+		return TestOutput{}, err, applyCapture.ToError()
+	}
+	if err := showState.Run(); err != nil {
+		return TestOutput{}, err, showStateCapture.ToError()
+	}
+	if err := showPlan.Run(); err != nil {
+		return TestOutput{}, err, showPlanCapture.ToError()
+	}
+
+	files := map[string]interface{}{}
+	if files["apply.json"], err = applyCapture.ToJson(true); err != nil {
+		return TestOutput{}, err, nil
+	}
+	if files["state.json"], err = showStateCapture.ToJson(false); err != nil {
+		return TestOutput{}, err, nil
+	}
+	if files["plan.json"], err = showPlanCapture.ToJson(false); err != nil {
+		return TestOutput{}, err, nil
+	}
+
+	for _, golden := range test.Specification.GoldenFiles {
+		var data interface{}
+		raw, err := os.ReadFile(golden)
+		if err != nil {
+			return TestOutput{}, err, nil
+		}
+		if err := json.Unmarshal(raw, &data); err != nil {
+
+		}
+		files[golden] = data
+	}
+
+	return TestOutput{
+		Test:  test,
+		files: files,
+	}, nil, nil
+}
+
+func (output TestOutput) GetFiles() (map[string]interface{}, error) {
+	ret := map[string]interface{}{}
+	for file, contents := range output.files {
+		var ignoreFields []string
+		ignoreFields = append(ignoreFields, defaultFields[file]...)
+		ignoreFields = append(ignoreFields, output.Test.Specification.IgnoreFields[file]...)
+
+		var err error
+		if ret[file], err = StripJson(ignoreFields, contents); err != nil {
+			return nil, err
+		}
+	}
+	return ret, nil
+}
+
+// Diff will report the difference between this TestOutput and the output
+// already stored in the golden directory specified by the parameter.
+func (output TestOutput) Diff(goldens string) (map[string]string, error) {
+	files, err := output.GetFiles()
+	if err != nil {
+		return nil, err
+	}
+
+	ret := map[string]string{}
+	for file, contents := range files {
+		target := path.Join(goldens, output.Test.Name, file)
+
+		golden, err := os.ReadFile(target)
+		if err != nil {
+			if !os.IsNotExist(err) {
+				return nil, err
+			}
+		}
+
+		actual, err := json.MarshalIndent(contents, "", "  ")
+		if err != nil {
+			return nil, err
+		}
+
+		if golden == nil {
+			// Then this means we don't have a golden file for this yet (as in
+			// this is the first time we are using it). Let's just pretend it
+			// was empty.
+			ret[file] = "  (new file)  "
+			continue
+		}
+
+		opts := jsondiff.DefaultJSONOptions()
+		opts.SkipMatches = true
+		opts.Indent = "  "
+
+		diff, pretty := jsondiff.Compare(golden, actual, &opts)
+		switch diff {
+		case jsondiff.BothArgsAreInvalidJson, jsondiff.SecondArgIsInvalidJson, jsondiff.FirstArgIsInvalidJson:
+			return nil, errors.New(pretty)
+		case jsondiff.FullMatch:
+			ret[file] = "  (no change)  "
+		default:
+			ret[file] = pretty
+		}
+	}
+	return ret, nil
+}
+
+func (output TestOutput) Update(goldens string) error {
+	tmp, err := os.MkdirTemp(goldens, output.Test.Name)
+	if err != nil {
+		return err
+	}
+
+	// We won't RemoveAll with tmp automatically, as there will be a point where
+	// the original file has been deleted and tmp is all we have in which case
+	// we don't want to delete tmp if anything goes wrong moving tmp into the
+	// original location. tmp can be used by the user to recover manually.
+
+	files, err := output.GetFiles()
+	if err != nil {
+		return err
+	}
+
+	for file, contents := range files {
+		data, err := json.MarshalIndent(contents, "", "  ")
+		if err != nil {
+			os.RemoveAll(tmp)
+			return err
+		}
+
+		target := path.Join(tmp, file)
+		if _, err := os.Stat(filepath.Dir(target)); os.IsNotExist(err) {
+			// This means the parent directory for the target file doesn't exist
+			// so let's make it.
+			if err := os.MkdirAll(filepath.Dir(target), os.ModePerm); err != nil {
+				os.RemoveAll(tmp)
+				return err
+			}
+		}
+
+		if err := os.WriteFile(target, data, os.ModePerm); err != nil {
+			os.RemoveAll(tmp)
+			return err
+		}
+	}
+
+	// Now we've copied all the new golden files into our temporary directory,
+	// we just need to move everything over to the original.
+	if err := os.RemoveAll(path.Join(goldens, output.Test.Name)); err != nil {
+		os.RemoveAll(tmp)
+		return err
+	}
+
+	// From now, any failures are bad. We have removed the old directory so we
+	// have lost the previous state of the golden files. If anything goes wrong
+	// at this point we won't delete the tmp directory so that the user can
+	// recover the failed test case manually by moving the tmp directory over
+	// themselves.
+
+	if err := os.Mkdir(path.Join(goldens, output.Test.Name), os.ModePerm); err != nil {
+		return err
+	}
+
+	if err = filepath.WalkDir(tmp, cp(tmp, path.Join(goldens, output.Test.Name), nil)); err != nil {
+		return err
+	}
+
+	if err := os.RemoveAll(tmp); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/tools/equivalence-tests/main.go
+++ b/tools/equivalence-tests/main.go
@@ -1,0 +1,148 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/mitchellh/cli"
+
+	"github.com/hashicorp/terraform/tools/equivalence-tests/internal"
+)
+
+var Ui cli.Ui
+
+func init() {
+	Ui = &cli.BasicUi{
+		Writer:      os.Stdout,
+		ErrorWriter: os.Stderr,
+		Reader:      os.Stdin,
+	}
+}
+
+// Args contains the arguments that we accept as part of the equivalence testing
+// framework.
+//
+// We are expecting three arguments:
+//   -goldens=/path/to/golden/files
+//   -tests=/path/to/tests
+//   -binary=/path/to/terraform/binary
+//
+// And an optional fourth argument: -update
+//
+// We do not have sensible defaults for the goldens or tests directory, but we
+// can default to just trying to run `terraform` for the binary.
+type Args struct {
+	GoldensPath string
+	TestsPath   string
+	BinaryPath  string
+
+	Update bool
+}
+
+func main() {
+	args, err := parseArgs()
+	if err != nil {
+		Ui.Error(err.Error())
+		os.Exit(1)
+	}
+
+	Ui.Info(fmt.Sprintf("reading tests from %s", args.TestsPath))
+	tests, err := internal.ReadTests(args.TestsPath)
+	if err != nil {
+		Ui.Error(fmt.Sprintf("failed to read tests from %s, error: %v", args.TestsPath, err))
+		os.Exit(1)
+	}
+	Ui.Info(fmt.Sprintf("read %d tests from %s", len(tests), args.TestsPath))
+	Ui.Info(fmt.Sprintf("executing tests from %s", args.TestsPath))
+
+	var failedTests []string
+	for _, test := range tests {
+		Ui.Info(fmt.Sprintf("executing test %s", test.Name))
+
+		output, err, tfErr := test.Run(args.BinaryPath)
+		if err != nil {
+			failedTests = append(failedTests, test.Name)
+			Ui.Warn(fmt.Sprintf("could not execute test %s, error: %v, tfErr:\n%v", test.Name, err, tfErr))
+			continue
+		}
+
+		if args.Update {
+			Ui.Info(fmt.Sprintf("updating golden files for test %s", test.Name))
+			if err := output.Update(args.GoldensPath); err != nil {
+				failedTests = append(failedTests, test.Name)
+				Ui.Warn(fmt.Sprintf("could not update golden files for test %s, error: %v", test.Name, err))
+				continue
+			}
+			Ui.Info(fmt.Sprintf("updated golden files for test %s", test.Name))
+		} else {
+			Ui.Info(fmt.Sprintf("comparing diffs for test %s", test.Name))
+			diffs, err := output.Diff(args.GoldensPath)
+			if err != nil {
+				failedTests = append(failedTests, test.Name)
+				Ui.Warn(fmt.Sprintf("could not compare diffs for test %s, error: %v", test.Name, err))
+				continue
+			}
+
+			Ui.Info(fmt.Sprintf("the following diffs for test %s were found", test.Name))
+			for file, diff := range diffs {
+				Ui.Output(fmt.Sprintf("\nfile: %s\ndiff: %s\n", file, diff))
+			}
+		}
+		Ui.Info(fmt.Sprintf("successfully executed test %s", test.Name))
+	}
+
+	if len(failedTests) > 0 {
+		if len(failedTests) == len(tests) {
+			Ui.Info("all tests failed execution")
+			os.Exit(1)
+		}
+		Ui.Info(fmt.Sprintf("the following tests failed, please check the stderr logs for errors: [%s]", strings.Join(failedTests, ", ")))
+		Ui.Info(fmt.Sprintf("every other test executed correctly"))
+	} else {
+		Ui.Info("all tests executed successfully")
+	}
+}
+
+func parseArgs() (Args, error) {
+	args := Args{
+		BinaryPath: "terraform",
+		Update:     false,
+	}
+
+	for _, arg := range os.Args[1:] {
+		parts := strings.Split(arg, "=")
+		if len(parts) > 2 {
+			return args, fmt.Errorf("could not parse arguments, invalid format: %s", arg)
+		}
+
+		if len(parts) == 1 {
+			if parts[0] == "-update" {
+				args.Update = true
+				continue
+			}
+			return args, fmt.Errorf("could not parse arguments, invalid format: %s", arg)
+		}
+
+		switch parts[0] {
+		case "-goldens":
+			args.GoldensPath = parts[1]
+		case "-tests":
+			args.TestsPath = parts[1]
+		case "-binary":
+			args.BinaryPath = parts[1]
+		default:
+			return args, fmt.Errorf("could not parse arguments, unrecognized argument: %s", arg)
+		}
+	}
+
+	if len(args.GoldensPath) == 0 {
+		return args, errors.New("could not parse arguments, must specify the -goldens argument")
+	}
+	if len(args.TestsPath) == 0 {
+		return args, errors.New("could not parse arguments, must specify the -tests argument")
+	}
+
+	return args, nil
+}

--- a/tools/equivalence-tests/testing/example/main.tf
+++ b/tools/equivalence-tests/testing/example/main.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_providers {
+    mock = {
+      source = "liamcervante/mock"
+    }
+  }
+}
+
+provider "mock" {}
+
+resource "mock_simple_resource" "integer" {
+  id = "my_integer"
+  integer = 1
+}

--- a/tools/equivalence-tests/testing/example/spec.json
+++ b/tools/equivalence-tests/testing/example/spec.json
@@ -1,0 +1,6 @@
+{
+  "golden-files": [
+    "terraform.resource/my_integer.json"
+  ],
+  "field-blocklist": {}
+}


### PR DESCRIPTION
This PR is a first attempt at making the equivalence testing framework. It contains a single example test, we can add more in later PRs.

There are 5 golang files introduced.

- main.go: is the entry point, it configures the program arguments and 
- file.go: contains a single function `cp` that can be used to copy a directory from one place to another.
- capture.go: contains a struct that helps with capturing stdout and stderr from the terraform binary as it executes the plan and apply functions for each test.
- json.go: contains a single public function `StripJson` that accepts a JSON object and a list of fields, the function then goes through and removes these fields from the json object. The aim here is to remove fields that change on every execution of terraform such as the version or the timestamp.
- tests.go: is where the magic happens. it defines a function that can read the tests from a given directory, execute the tests and then report diffs or update the golden files.