### PR TITLE
Enable OpenSSF Scorecard code scanning alert and badge

### DIFF
--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -1,0 +1,54 @@
+name: Scorecards supply-chain security
+on:
+  # Only the default branch is supported.
+  branch_protection_rule:
+  schedule:
+    - cron: '43 9 * * 2'
+  push:
+    branches: [ "main" ]
+
+# Declare default permissions as read only.
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecards analysis
+    runs-on: ubuntu-latest
+    permissions:
+      # Needed to upload the results to code-scanning dashboard.
+      security-events: write
+      # Used to receive a badge.
+      id-token: write
+    
+    steps:
+      - name: "Checkout code"
+        uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846 # tag=v3.0.0
+        with:
+          persist-credentials: false
+
+      - name: "Run analysis"
+        uses: ossf/scorecard-action@13ec8c77e8a5dae7e0a0d47bde3e3004df15d34f # tag=v2.0.0
+        with:
+          results_file: results.sarif
+          results_format: sarif
+
+          # Publish the results for public repositories to enable scorecard badges. For more details, see
+          # https://github.com/ossf/scorecard-action#publishing-results. 
+          # For private repositories, `publish_results` will automatically be set to `false`, regardless 
+          # of the value entered here.
+          publish_results: true
+
+      # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
+      # format to the repository Actions tab.
+      - name: "Upload artifact"
+        uses: actions/upload-artifact@6673cd052c4cd6fcf4b4e6e60ea986c889389535 # tag=v3.0.0
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+      
+      # Upload the results to GitHub's code scanning dashboard.
+      - name: "Upload to code-scanning"
+        uses: github/codeql-action/upload-sarif@5f532563584d71fdef14ee64d17bafb34f751ce5 # tag=v1.0.26
+        with:
+          sarif_file: results.sarif

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Terraform
 
+[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/joycebrum/terraform/badge)](https://api.securityscorecards.dev/projects/github.com/joycebrum/terraform)
+
 - Website: https://www.terraform.io
 - Forums: [HashiCorp Discuss](https://discuss.hashicorp.com/c/terraform-core)
 - Documentation: [https://www.terraform.io/docs/](https://www.terraform.io/docs/)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Terraform
 
-[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/joycebrum/terraform/badge)](https://api.securityscorecards.dev/projects/github.com/joycebrum/terraform)
+[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/hashicorp/terraform/badge)](https://api.securityscorecards.dev/projects/github.com/hashicorp/terraform)
 
 - Website: https://www.terraform.io
 - Forums: [HashiCorp Discuss](https://discuss.hashicorp.com/c/terraform-core)


### PR DESCRIPTION
Hi, I am Joyce Brum from Google and I am suggesting in this PR the use of the OpenSSF Scorecard, a tool to search and manage security risks in Github, which is developed by the OpenSSF, a non-profitable foundation dedicated to improve the overall security of the open source comunity.

The main benefit of the [Scorecard](https://github.com/ossf/scorecard) is the automatic security scanning that points out the security risks and its solutions, helping you to properly work on increase the security of the project. 

The criterias that are evaluated by the Scorecard can be seen at https://securityscorecards.dev/#the-checks.

The badge added at the README file is completely optional, if you want to know a little more about the scorecard badge and why you would want to show it, please take a look at [Show Off Your Security Score: Announcing Scorecards Badges](https://openssf.org/blog/2022/09/08/show-off-your-security-score-announcing-scorecards-badges/)