### PR TITLE
website: Version-specific upgrade guides (v1.1 branch)

### DIFF
--- a/website/data/language-nav-data.json
+++ b/website/data/language-nav-data.json
@@ -1101,7 +1101,7 @@
         "path": "upgrade-guides/1-0"
       },
       {
-        "title": "v1.0 Compatibility Promises",
+        "title": "v1.x Compatibility Promises",
         "href": "/language/v1-compatibility-promises"
       },
       {

--- a/website/docs/language/upgrade-guides/1-1.mdx
+++ b/website/docs/language/upgrade-guides/1-1.mdx
@@ -17,7 +17,7 @@ latest v1.1 release, skipping the v1.0 series entirely, at any point where the
 v1.0 upgrade guide calls for upgrading to Terraform v1.0.
 
 Terraform v1.1 continues to honor
-[the Terraform v1.0 Compatibility Promises](/language/v1-compatibility-promises),
+[the Terraform v1.x Compatibility Promises](https://www.terraform.io/language/v1-compatibility-promises),
 but there are some behavior changes outside of those promises that may affect a
 small number of users, described in the following sections.
 

--- a/website/docs/language/upgrade-guides/index.mdx
+++ b/website/docs/language/upgrade-guides/index.mdx
@@ -5,6 +5,25 @@ description: Upgrade Guides
 
 # Upgrade Guides
 
-Terraform's major releases can include an upgrade guide to help upgrading users
-walk through backwards compatibility issues and changes to expect. See the
-navigation for the available upgrade guides.
+Terraform's major and minor releases each include an upgrade guide which
+discusses any special steps that might be needed when upgrading to that new
+version.
+
+This collection of upgrade guides is for Terraform v1.1 and earlier, due to
+the documentation version selected in the navigation bar. To see upgrade
+guides for later versions of Terraform, use the version selector in the
+navigation bar to select the version you are interested in.
+
+The following historical version upgrade guides are available here:
+
+* [Terraform v1.1](/language/upgrade-guides/1-1)
+* [Terraform v1.0](/language/upgrade-guides/1-0)
+* [Terraform v0.15](/language/upgrade-guides/0-15)
+* [Terraform v0.14](/language/upgrade-guides/0-14)
+* [Terraform v0.13](/language/upgrade-guides/0-13)
+* [Terraform v0.12](/language/upgrade-guides/0-12)
+* [Terraform v0.11](/language/upgrade-guides/0-11)
+* [Terraform v0.10](/language/upgrade-guides/0-10)
+* [Terraform v0.9](/language/upgrade-guides/0-9)
+* [Terraform v0.8](/language/upgrade-guides/0-8)
+* [Terraform v0.7](/language/upgrade-guides/0-7)

--- a/website/docs/language/v1-compatibility-promises.mdx
+++ b/website/docs/language/v1-compatibility-promises.mdx
@@ -1,12 +1,12 @@
 ---
-page_title: Terraform v1.0 Compatibility Promises
+page_title: Terraform v1.x Compatibility Promises
 description: |-
   From Terraform v1.0 onwards the Terraform team promises to preserve backward
   compatibility for most of the Terraform language and the primary CLI
   workflow, until the next major release.
 ---
 
-# Terraform v1.0 Compatibility Promises
+# Terraform v1.x Compatibility Promises
 
 The release of Terraform v1.0 represents an important milestone in the
 development of the Terraform language and workflow. Terraform v1.0 is a stable


### PR DESCRIPTION
See hashicorp/terraform-website#2414 for the bigger picture on what this is all about!

---

Before our website allowed selecting from older versions of Terraform to see older documentation we needed to preserve all of the historical upgrade guides in the latest release branch so that they'd stay available on the website.

However, our new strategy is for each release to have its own separate set of documentation selectable using a global version selector. We should therefore now have only the upgrade guide for the each minor release on its release branch, with the upgrade guides for earlier releases instead maintained on their own branches.

However, our v1.1 branch is, as a matter of pragmatism, serving as the home for the "v1.1 and earlier" documentation, and so there will continue to be multiple upgrade guides on that branch. For that reason, we're preserving the URL scheme "upgrade-guides" (plural) even though the URL now points to only a single version upgrade guide because that causes readers to land in the correct place if they are on a modern version's upgrade guide page and they use the version selector to choose the "v1.1 and earlier" option.

This retroactively renames the "Terraform v1.0 Compatibility Promises" to be "v1.x" compatibility promises instead, because we intend to preserve them throughout all of the releases whose major version is 1.