### PR TITLE
website: Tombstone callout for the v1.3 removed backends

### DIFF
--- a/website/docs/language/settings/backends/configuration.mdx
+++ b/website/docs/language/settings/backends/configuration.mdx
@@ -18,6 +18,8 @@ By default, Terraform uses a backend called [`local`](/language/settings/backend
 
 Some of these backends act like plain remote disks for state files, while others support locking the state while operations are being performed. This helps prevent conflicts and inconsistencies. The built-in backends listed are the only backends. You cannot load additional backends as plugins.
 
+-> **Note:** We removed the `artifactory`, `etcd`, `etcdv3`, `manta`, and `swift` backends in Terraform v1.3. Information about their behavior in older versions is still available in the [Terraform v1.2 documentation](/language/v1.2.x/settings/backends/configuration). For migration paths from these removed backends, refer to [Upgrading to Terraform v1.3](/language/v1.3.x/upgrade-guides).
+
 ## Using a Backend Block
 
 You do not need to configure a backend when using Terraform Cloud because


### PR DESCRIPTION
We've removed the main documentation pages for the backends that are removed in Terraform v1.3, but we'll leave a small callout note so that the backend names are still reachable through our search index once the v1.3 docs are the active version.

The primary goal here is to help folks who have inherited configurations using older versions of Terraform to learn about features they see in those configurations, so the main thing here is the link to the older release docs which include those. However, this is also a good opportunity to link to the upgrade guide content which describes some possible migration paths away from these removed backends.

(This goes along with hashicorp/terraform-website#2342, which puts redirects at the URLs where these backend pages used to be, sending the reader to the v1.2.x branch content instead. We'll merge that PR close to the v1.3.0 final release so that we minimize the window where the overall website content is inconsistent.)