### PR TITLE
Modifies permissions needed to use s3 with dynamoDb locks

### DIFF
--- a/website/docs/language/settings/backends/s3.mdx
+++ b/website/docs/language/settings/backends/s3.mdx
@@ -76,6 +76,7 @@ documentation about
 If you are using state locking, Terraform will need the following AWS IAM
 permissions on the DynamoDB table (`arn:aws:dynamodb:::table/mytable`):
 
+* `dynamodb:DescribeTable`
 * `dynamodb:GetItem`
 * `dynamodb:PutItem`
 * `dynamodb:DeleteItem`
@@ -89,6 +90,7 @@ This is seen in the following AWS IAM Statement:
     {
       "Effect": "Allow",
       "Action": [
+        "dynamodb:DescribeTable",
         "dynamodb:GetItem",
         "dynamodb:PutItem",
         "dynamodb:DeleteItem"


### PR DESCRIPTION
The website documentation was missing a permission causing the example to not work. 
This PR aims in fixing that documentation issue.