### PR TITLE
redact sensitive output values in run logs

### DIFF
--- a/internal/command/views/apply_test.go
+++ b/internal/command/views/apply_test.go
@@ -246,7 +246,6 @@ func TestApplyJSON_outputs(t *testing.T) {
 				},
 				"password": map[string]interface{}{
 					"sensitive": true,
-					"value":     "horse-battery",
 					"type":      "string",
 				},
 			},

--- a/internal/command/views/json/output.go
+++ b/internal/command/views/json/output.go
@@ -42,10 +42,15 @@ func OutputsFromMap(outputValues map[string]*states.OutputValue) (Outputs, tfdia
 			return nil, diags
 		}
 
+		var redactedValue json.RawMessage
+		if !ov.Sensitive {
+			redactedValue = json.RawMessage(value)
+		}
+
 		outputs[name] = Output{
 			Sensitive: ov.Sensitive,
 			Type:      json.RawMessage(valueType),
-			Value:     json.RawMessage(value),
+			Value:     redactedValue,
 		}
 	}
 

--- a/internal/command/views/json/output_test.go
+++ b/internal/command/views/json/output_test.go
@@ -52,12 +52,10 @@ func TestOutputsFromMap(t *testing.T) {
 		"beep": {
 			Sensitive: true,
 			Type:      json.RawMessage(`"string"`),
-			Value:     json.RawMessage(`"horse-battery"`),
 		},
 		"blorp": {
 			Sensitive: true,
 			Type:      json.RawMessage(`["object",{"a":["object",{"b":["object",{"c":"string"}]}]}]`),
-			Value:     json.RawMessage(`{"a":{"b":{"c":"oh, hi"}}}`),
 		},
 		"honk": {
 			Sensitive: false,

--- a/internal/command/views/json_view.go
+++ b/internal/command/views/json_view.go
@@ -13,7 +13,7 @@ import (
 // This version describes the schema of JSON UI messages. This version must be
 // updated after making any changes to this view, the jsonHook, or any of the
 // command/views/json package.
-const JSON_UI_VERSION = "1.0"
+const JSON_UI_VERSION = "1.1"
 
 func NewJSONView(view *View) *JSONView {
 	log := hclog.New(&hclog.LoggerOptions{

--- a/internal/command/views/refresh_test.go
+++ b/internal/command/views/refresh_test.go
@@ -98,7 +98,6 @@ func TestRefreshJSON_outputs(t *testing.T) {
 				},
 				"password": map[string]interface{}{
 					"sensitive": true,
-					"value":     "horse-battery",
 					"type":      "string",
 				},
 			},


### PR DESCRIPTION
## Target Release

1.3.1

## Draft CHANGELOG entry

### BUG FIXES
* Previously, logs generated from running `terraform apply -json` contained plaintext value of sensitive outputs. With this fix, all sensitive output values will be omitted in the json logs when `terraform apply -json` is run.  To retrieve machine-readable output values, including those which are sensitive use `terraform output -json` instead. ([#31813](https://github.com/hashicorp/terraform/issues/31813))


# Description
Currently, sensitive output values are displayed as plain text in the run logs. This PR omits sensitive output values when logging. 

The fix targets both CLI and TFC workflows. In CLI, when running `terraform plan -json` and `terraform apply -json`, sensitive values should be omitted. Similarly, when downloading `raw log` for both plan and apply in TFC, sensitive values should be omitted as well.

Before, json logs:
```
				"secret": {
					"sensitive": true,
					"value":     "plain-text-secret",
					"type":      "string"
				}
```

After these changes:


```
                              "secret": {
					"sensitive": true,
					"type":      "string"
				}
```
