### PR TITLE
fixed typo: `startsswith` -> `startswith`

### DIFF
--- a/website/docs/language/functions/startswith.mdx
+++ b/website/docs/language/functions/startswith.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: startsswith - Functions - Configuration Language
+page_title: startswith - Functions - Configuration Language
 description: |-
   The startswith function  takes two values: a string to check and a prefix string. It returns true if the string begins with that exact prefix.
 ---


### PR DESCRIPTION
The page title of the `startswith` function was `startsswith`.

https://developer.hashicorp.com/terraform/language/functions/startswith