### PR TITLE
Update codeowner of `gcs` backend to include Strategic Integrations team

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -8,7 +8,7 @@
 /internal/backend/remote-state/cos               @likexian
 /internal/backend/remote-state/etcdv2            Unmaintained
 /internal/backend/remote-state/etcdv3            Unmaintained
-/internal/backend/remote-state/gcs               @hashicorp/terraform-google
+/internal/backend/remote-state/gcs               @hashicorp/terraform-ecosystem-strategic
 /internal/backend/remote-state/http              @hashicorp/terraform-core
 /internal/backend/remote-state/manta             Unmaintained
 /internal/backend/remote-state/oss               @xiaozhu36

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -8,7 +8,7 @@
 /internal/backend/remote-state/cos               @likexian
 /internal/backend/remote-state/etcdv2            Unmaintained
 /internal/backend/remote-state/etcdv3            Unmaintained
-/internal/backend/remote-state/gcs               @hashicorp/terraform-ecosystem-strategic
+/internal/backend/remote-state/gcs               @hashicorp/terraform-google @hashicorp/terraform-ecosystem-strategic
 /internal/backend/remote-state/http              @hashicorp/terraform-core
 /internal/backend/remote-state/manta             Unmaintained
 /internal/backend/remote-state/oss               @xiaozhu36


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Updates codeowners of the `gcs` backend to @hashicorp/terraform-ecosystem-strategic team because we maintain the Google provider.

The existing code owner @hashicorp/terraform-google is an empty group. We could add everyone to that group, but it made more sense to just change the code owner.

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

N/A

## Draft CHANGELOG entry

N/A - not a user-facing change
