### PR TITLE
prune unused nodes from a destroy plan graph

### DIFF
--- a/internal/terraform/graph_builder_plan.go
+++ b/internal/terraform/graph_builder_plan.go
@@ -170,6 +170,10 @@ func (b *PlanGraphBuilder) Steps() []GraphTransformer {
 		// TargetsTransformer can determine which nodes to keep in the graph.
 		&DestroyEdgeTransformer{},
 
+		&pruneUnusedNodesTransformer{
+			skip: b.Operation != walkPlanDestroy,
+		},
+
 		// Target
 		&TargetsTransformer{Targets: b.Targets},
 

--- a/internal/terraform/node_resource_plan.go
+++ b/internal/terraform/node_resource_plan.go
@@ -53,10 +53,14 @@ var (
 	_ GraphNodeAttachResourceConfig = (*nodeExpandPlannableResource)(nil)
 	_ GraphNodeAttachDependencies   = (*nodeExpandPlannableResource)(nil)
 	_ GraphNodeTargetable           = (*nodeExpandPlannableResource)(nil)
+	_ graphNodeExpandsInstances     = (*nodeExpandPlannableResource)(nil)
 )
 
 func (n *nodeExpandPlannableResource) Name() string {
 	return n.NodeAbstractResource.Name() + " (expand)"
+}
+
+func (n *nodeExpandPlannableResource) expandsInstances() {
 }
 
 // GraphNodeAttachDependencies

--- a/internal/terraform/transform_destroy_edge.go
+++ b/internal/terraform/transform_destroy_edge.go
@@ -170,9 +170,18 @@ func (t *DestroyEdgeTransformer) Transform(g *Graph) error {
 // closers also need to disable their use of expansion if the module itself is
 // no longer present.
 type pruneUnusedNodesTransformer struct {
+	// The plan graph builder will skip this transformer except during a full
+	// destroy. Planing normally involves all nodes, but during a destroy plan
+	// we may need to prune things which are in the configuration but do not
+	// exist in state to evaluate.
+	skip bool
 }
 
 func (t *pruneUnusedNodesTransformer) Transform(g *Graph) error {
+	if t.skip {
+		return nil
+	}
+
 	// We need a reverse depth first walk of modules, processing them in order
 	// from the leaf modules to the root. This allows us to remove unneeded
 	// dependencies from child modules, freeing up nodes in the parent module


### PR DESCRIPTION
We may need to prune nodes from a full destroy plan graph which cannot be evaluated if there is no current state. This is the same method used during apply, however for planning we are only going to encounter evaluation problems during a full destroy, so we can skip the pruning process for normal plans.

Add missing `expandsInstances()` method to `nodeExpandPlannableResource` to ensure planned resources are handled correctly when pruning nodes.

Fixes #31838