### PR TITLE
evaluation of missing instances during import

### DIFF
--- a/internal/terraform/testdata/import-provider-resources/main.tf
+++ b/internal/terraform/testdata/import-provider-resources/main.tf
@@ -1,5 +1,5 @@
 provider "aws" {
-    value = "${test_instance.bar.value}"
+    value = "${test_instance.bar.id}"
 }
 
 resource "aws_instance" "foo" {


### PR DESCRIPTION
Because import does not yet plan new instances as part of the import process, we can end up evaluating references to resources which have no state at all, and the fallback for this situation could result in slightly better values. The count and for_each values were technically incorrect, since the length is not known to be zero, so we return a `DynamicVal` instead. The single instance case does have a concrete type which we can return as an unknown.

This whole process was meant as a step towards a complete import plan, but unfortunately is still contains a few similar edge cases which plagued the original import graph. While these new values will allow more expressions to evaluate correctly (mostly in count/for_each where known-ness is important), there are going to be situations which won't work until we have the complete planned values.  

Fixes #31852