### PR TITLE
providercache: Improve installation error message

### DIFF
--- a/internal/providercache/package_install.go
+++ b/internal/providercache/package_install.go
@@ -55,7 +55,7 @@ func installFromHTTPURL(ctx context.Context, meta getproviders.PackageMeta, targ
 
 	f, err := ioutil.TempFile("", "terraform-provider")
 	if err != nil {
-		return nil, fmt.Errorf("failed to open temporary file to download from %s", url)
+		return nil, fmt.Errorf("failed to open temporary file to download from %s: %w", url, err)
 	}
 	defer f.Close()
 	defer os.Remove(f.Name())


### PR DESCRIPTION
## Target Release

1.4.x

## Draft CHANGELOG entry

### ENHANCEMENTS

-  providercache: show why a provider couldn't be installed (e.g. lack of permissions)

--- 

## Context

On Windows, when Terraform doesn't have `TMP` or other environment variable which would hint where to create temporary files, the stdlib `ioutil.TempDir()` chooses `C:\Windows`. This directory in turn typically requires elevated privileges for writing which common user does not have.

See also https://github.com/hashicorp/terraform-exec/issues/337

## Before

```
Error: Failed to install provider

Error while installing hashicorp/local v2.2.3: failed to open temporary file
to download from
https://releases.hashicorp.com/terraform-provider-local/2.2.3/terraform-provider-local_2.2.3_windows_amd64.zip
```

## After

```
Error: Failed to install provider

Error while installing hashicorp/local v2.2.3: failed to open temporary file
to download from
https://releases.hashicorp.com/terraform-provider-local/2.2.3/terraform-provider-local_2.2.3_windows_amd64.zip:
open C:\Windows\terraform-provider1818936128: Access is denied.
```