### PR TITLE
Updating Supported Architectures in TF CLI Install

### DIFF
--- a/website/docs/cli/install/apt.mdx
+++ b/website/docs/cli/install/apt.mdx
@@ -58,12 +58,10 @@ sudo apt install terraform
 
 ## Supported Architectures
 
-The HashiCorp APT server currently has packages only for the `amd64`
-architecture, which is also sometimes known as `x86_64`.
-
-There are no official packages available for other architectures, such as
-`arm64`. If you wish to use Terraform on a non-`amd64` system,
-[download a normal release `.zip` file](/downloads) instead.
+You can [download a `.zip` file](/downloads) from the The HashiCorp Yum/DNF server for the following packages:
+* The `x86_64` architecture, which is also sometimes known as `amd64`
+* The `arm` architecture
+* The `arm64` architecture
 
 ## Supported Debian and Ubuntu Releases
 

--- a/website/docs/cli/install/yum.mdx
+++ b/website/docs/cli/install/yum.mdx
@@ -58,12 +58,10 @@ yum install terraform
 
 ## Supported Architectures
 
-The HashiCorp Yum/DNF server currently has packages only for the `x86_64`
-architecture, which is also sometimes known as `amd64`.
-
-There are no official packages available for other architectures, such as
-`aarch64`. If you wish to use Terraform on a non-`x86_64` system,
-[download a normal release `.zip` file](/downloads) instead.
+You can [download a `.zip` file](/downloads) from the The HashiCorp Yum/DNF server for the following packages:
+* The `x86_64` architecture, which is also sometimes known as `amd64`
+* The `arm` architecture
+* The `arm64` architecture
 
 ## Supported Distribution Releases
 


### PR DESCRIPTION
**What**

The list of supported architectures in the TF CLI Install section is missing some currently supported architectures that are listed on the TF Downloads page (https://www.terraform.io/downloads). 

**Why**

We want to provide customers with as complete a list as possible of architectures they can use to download Terraform.

