### PR TITLE
Prevent errors from NoOp deposed changes

### DIFF
--- a/internal/terraform/transform_diff.go
+++ b/internal/terraform/transform_diff.go
@@ -80,7 +80,10 @@ func (t *DiffTransformer) Transform(g *Graph) error {
 			update = true
 		}
 
-		if dk != states.NotDeposed && update {
+		// A deposed instance may only have a change of Delete or NoOp. A NoOp
+		// can happen if the provider shows it no longer exists during the most
+		// recent ReadResource operation.
+		if dk != states.NotDeposed && !(rc.Action == plans.Delete || rc.Action == plans.NoOp) {
 			diags = diags.Append(tfdiags.Sourceless(
 				tfdiags.Error,
 				"Invalid planned change for deposed object",


### PR DESCRIPTION
If a previously deposed object is deleted outside of Terraform, the next plan will result in a NoOp change for the deposed object.

If that NoOp change was flagged as an update to run any associated condition checks, it would fail the following test to ensure a deposed change is only ever participating in a delete operation. Fix the check to verify that the deposed object has an acceptable action rather than use the `update` flag.

Fixes #31896