### PR TITLE
Support import blocks in config

### DIFF
--- a/internal/addrs/resource.go
+++ b/internal/addrs/resource.go
@@ -334,6 +334,17 @@ func (r AbsResourceInstance) Less(o AbsResourceInstance) bool {
 	}
 }
 
+// InModule returns a new AbsResourceInstance with the module path
+// prefixed by module
+func (r AbsResourceInstance) InModule(module ModuleInstance) AbsResourceInstance {
+	modPath := make(ModuleInstance, 0, len(module)+len(r.Module))
+	modPath = append(modPath, module...)
+	modPath = append(modPath, r.Module...)
+	ret := r // copy address
+	ret.Module = modPath
+	return ret
+}
+
 // AbsResourceInstance is a Checkable
 func (r AbsResourceInstance) checkableSigil() {}
 

--- a/internal/configs/import.go
+++ b/internal/configs/import.go
@@ -1,0 +1,83 @@
+package configs
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/terraform/internal/addrs"
+	"github.com/zclconf/go-cty/cty"
+)
+
+type Import struct {
+	ID string
+	To addrs.AbsResourceInstance
+
+	DeclRange hcl.Range
+}
+
+func decodeImportBlock(block *hcl.Block) (*Import, hcl.Diagnostics) {
+	var diags hcl.Diagnostics
+	imp := &Import{
+		DeclRange: block.DefRange,
+	}
+
+	content, moreDiags := block.Body.Content(importBlockSchema)
+	diags = append(diags, moreDiags...)
+
+	if attr, exists := content.Attributes["id"]; exists {
+		id, idDiags := decodeId(attr.Expr)
+		diags = append(diags, idDiags...)
+		imp.ID = id
+	}
+
+	if attr, exists := content.Attributes["to"]; exists {
+		to, traversalDiags := hcl.AbsTraversalForExpr(attr.Expr)
+		diags = append(diags, traversalDiags...)
+		if !traversalDiags.HasErrors() {
+			to, toDiags := addrs.ParseAbsResourceInstance(to)
+			diags = append(diags, toDiags.ToHCL()...)
+			imp.To = to
+			if !toDiags.HasErrors() && to.Resource.Resource.Mode != addrs.ManagedResourceMode {
+				diags = append(diags, &hcl.Diagnostic{
+					Severity: hcl.DiagError,
+					Summary:  "Invalid Resource",
+					Detail:   fmt.Sprintf("%v is not a managed resource. Importing into a data source is not allowed.", to),
+					Subject:  attr.Expr.Range().Ptr(),
+				})
+			}
+		}
+	}
+
+	return imp, diags
+
+}
+
+func decodeId(expr hcl.Expression) (string, hcl.Diagnostics) {
+	id, diags := expr.Value(nil)
+	if diags.HasErrors() {
+		return "", diags
+	}
+	if id.Type() != cty.String {
+		diags = append(diags, &hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  "Invalid Attribute",
+			Detail:   fmt.Sprintf("Invalid attribute value for import id: %#v", id),
+			Subject:  expr.Range().Ptr(),
+		})
+		return "", diags
+	}
+	return id.AsString(), diags
+}
+
+var importBlockSchema = &hcl.BodySchema{
+	Attributes: []hcl.AttributeSchema{
+		{
+			Name:     "id",
+			Required: true,
+		},
+		{
+			Name:     "to",
+			Required: true,
+		},
+	},
+}

--- a/internal/configs/import_test.go
+++ b/internal/configs/import_test.go
@@ -1,0 +1,181 @@
+package configs
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hcltest"
+	"github.com/hashicorp/terraform/internal/addrs"
+	"github.com/zclconf/go-cty/cty"
+)
+
+func TestImportBlock_decode(t *testing.T) {
+	blockRange := hcl.Range{
+		Filename: "mock.tf",
+		Start:    hcl.Pos{Line: 3, Column: 12, Byte: 27},
+		End:      hcl.Pos{Line: 3, Column: 19, Byte: 34},
+	}
+
+	id := "test1"
+	id_expr := hcltest.MockExprLiteral(cty.StringVal(id))
+
+	res_expr := hcltest.MockExprTraversalSrc("test_instance.foo")
+
+	index_expr := hcltest.MockExprTraversalSrc("test_instance.foo[1]")
+
+	mod_expr := hcltest.MockExprTraversalSrc("module.foo.test_instance.this")
+
+	tests := map[string]struct {
+		input *hcl.Block
+		want  *Import
+		err   string
+	}{
+		"success": {
+			&hcl.Block{
+				Type: "import",
+				Body: hcltest.MockBody(&hcl.BodyContent{
+					Attributes: hcl.Attributes{
+						"id": {
+							Name: "id",
+							Expr: id_expr,
+						},
+						"to": {
+							Name: "to",
+							Expr: res_expr,
+						},
+					},
+				}),
+				DefRange: blockRange,
+			},
+			&Import{
+				ID:        id,
+				To:        mustImportEndpointFromExpr(res_expr),
+				DeclRange: blockRange,
+			},
+			``,
+		},
+		"indexed_resource": {
+			&hcl.Block{
+				Type: "import",
+				Body: hcltest.MockBody(&hcl.BodyContent{
+					Attributes: hcl.Attributes{
+						"id": {
+							Name: "id",
+							Expr: id_expr,
+						},
+						"to": {
+							Name: "to",
+							Expr: index_expr,
+						},
+					},
+				}),
+				DefRange: blockRange,
+			},
+			&Import{
+				ID:        id,
+				To:        mustImportEndpointFromExpr(index_expr),
+				DeclRange: blockRange,
+			},
+			``,
+		},
+		"module": {
+			&hcl.Block{
+				Type: "import",
+				Body: hcltest.MockBody(&hcl.BodyContent{
+					Attributes: hcl.Attributes{
+						"id": {
+							Name: "id",
+							Expr: id_expr,
+						},
+						"to": {
+							Name: "to",
+							Expr: mod_expr,
+						},
+					},
+				}),
+				DefRange: blockRange,
+			},
+			&Import{
+				ID:        id,
+				To:        mustImportEndpointFromExpr(mod_expr),
+				DeclRange: blockRange,
+			},
+			``,
+		},
+		"error: missing argument": {
+			&hcl.Block{
+				Type: "import",
+				Body: hcltest.MockBody(&hcl.BodyContent{
+					Attributes: hcl.Attributes{
+						"id": {
+							Name: "id",
+							Expr: id_expr,
+						},
+					},
+				}),
+				DefRange: blockRange,
+			},
+			&Import{
+				ID:        id,
+				DeclRange: blockRange,
+			},
+			"Missing required argument",
+		},
+		"error: type mismatch": {
+			&hcl.Block{
+				Type: "import",
+				Body: hcltest.MockBody(&hcl.BodyContent{
+					Attributes: hcl.Attributes{
+						"id": {
+							Name: "id",
+							Expr: hcltest.MockExprLiteral(cty.NumberIntVal(0)),
+						},
+						"to": {
+							Name: "to",
+							Expr: res_expr,
+						},
+					},
+				}),
+				DefRange: blockRange,
+			},
+			&Import{
+				To:        mustImportEndpointFromExpr(res_expr),
+				DeclRange: blockRange,
+			},
+			"Invalid Attribute",
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			got, diags := decodeImportBlock(test.input)
+
+			if diags.HasErrors() {
+				if test.err == "" {
+					t.Fatalf("unexpected error: %s", diags.Errs())
+				}
+				if gotErr := diags[0].Summary; gotErr != test.err {
+					t.Errorf("wrong error, got %q, want %q", gotErr, test.err)
+				}
+			} else if test.err != "" {
+				t.Fatalf("expected error")
+			}
+			if !cmp.Equal(got, test.want, cmp.AllowUnexported(addrs.AbsResourceInstance{})) {
+				t.Fatalf("wrong result: %s", cmp.Diff(got, test.want))
+			}
+		})
+	}
+}
+
+func mustImportEndpointFromExpr(expr hcl.Expression) addrs.AbsResourceInstance {
+	traversal, hcldiags := hcl.AbsTraversalForExpr(expr)
+	if hcldiags.HasErrors() {
+		panic(hcldiags.Errs())
+	}
+	ep, diags := addrs.ParseAbsResourceInstance(traversal)
+	if diags.HasErrors() {
+		panic(diags.Err())
+	}
+	return ep
+}

--- a/internal/configs/parser_config.go
+++ b/internal/configs/parser_config.go
@@ -162,6 +162,13 @@ func (p *Parser) loadConfigFile(path string, override bool) (*File, hcl.Diagnost
 				file.Moved = append(file.Moved, cfg)
 			}
 
+		case "import":
+			cfg, cfgDiags := decodeImportBlock(block)
+			diags = append(diags, cfgDiags...)
+			if cfg != nil {
+				file.Import = append(file.Import, cfg)
+			}
+
 		default:
 			// Should never happen because the above cases should be exhaustive
 			// for all block type names in our schema.
@@ -251,6 +258,9 @@ var configFileSchema = &hcl.BodySchema{
 		},
 		{
 			Type: "moved",
+		},
+		{
+			Type: "import",
 		},
 	},
 }


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

This adds a new block that looks like:


```
import {
    to = random_integer.foo
    id = "5,0,10"
 }
 ```
 
 To import a resource, when the change is applied. 

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Fixes #22219

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.4.x

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

### NEW FEATURES 

<!--

Write a short description of the user-facing change. Examples:

- `terraform show -json`: Fixed crash with sensitive set values.
- When rendering a diff, Terraform now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 

-  Add support for `import` statements that allow you to import resources as part of a normal apply.
