### PR TITLE
Add skeleton action for executing the new equivalence tests

### DIFF
--- a/.github/workflows/equivalence-test.yml
+++ b/.github/workflows/equivalence-test.yml
@@ -1,0 +1,27 @@
+name: Terraform Equivalence Tests
+
+# This action will execute the suite of Terraform equivalence tests after a
+# tag has been pushed for a new version.
+#
+# For now, it is just a skeleton action that will be populated shortly.
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        required: true
+        description: "the Terraform version to equivalence test, eg. v1.3.1"
+      run-id:
+        required: true
+        description: "the run identifier of a successful `Build Terraform CLI Packages` action that contains artifacts for the target version"
+
+permissions:
+  contents: read
+
+jobs:
+  skeleton-job:
+    name: "Temporary job to be released with real work"
+    runs-on: ubuntu-latest
+
+    steps:
+      - run: echo "Hello, world!"


### PR DESCRIPTION
For more information, see this pull request: https://github.com/hashicorp/terraform/pull/31928

In particular [this comment](https://github.com/hashicorp/terraform/pull/31928#issuecomment-1268135664) discusses moving the equivalence tests into their own action. This PR creates a skeleton of this action that adds the workflow dispatch event. Having this skeleton in place makes it easier to test the new action in development, as Github only registers the workflow dispatch event for an action if it is in the default branch.

More PRs will follow making this action do something interesting.