### PR TITLE
Correction in the State Backend Doc Path

### DIFF
--- a/website/docs/language/settings/terraform-cloud.mdx
+++ b/website/docs/language/settings/terraform-cloud.mdx
@@ -14,7 +14,7 @@ Terraform through version control or the API.
 
 ## Usage Example
 
-To configure the Terraform Cloud CLI integration, add a nested `cloud` block within the `terraform` block. You cannot use the CLI integration and a [state backend](/language/settings/backends) in the same configuration.
+To configure the Terraform Cloud CLI integration, add a nested `cloud` block within the `terraform` block. You cannot use the CLI integration and a [state backend](/language/state/backends) in the same configuration.
 
 Refer to [Using Terraform Cloud](/cli/cloud) in the Terraform CLI documentation for full configuration details, migration instructions, and command line arguments.
 


### PR DESCRIPTION
The path to "[state backend](https://developer.hashicorp.com/terraform/language/settings/backends)" (/language/settings/backends) redirects to a missing page. Updated the path to "[/language/state/backends](https://developer.hashicorp.com/terraform/language/state/backends)" which seems to be where it was supposed to be directed towards.  

![missingpage](https://user-images.githubusercontent.com/40513836/194053949-200eea90-4453-4349-8f0d-12b900328e18.png)

![Screenshot 2022-10-05 172629](https://user-images.githubusercontent.com/40513836/194054915-c2b03d7f-f902-4fd8-88f3-1bdbc7549961.png)


