### PR TITLE
Use safe or force workspace delete for cloud backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ ENHANCEMENTS:
 * backend/gcs: Add `storage_custom_endpoint` argument, to allow communication with the backend via a Private Service Connect endpoint. ([#28856](https://github.com/hashicorp/terraform/issues/28856))
 * backend/gcs: Update documentation for usage of `gcs` with `terraform_remote_state` ([#32065](https://github.com/hashicorp/terraform/issues/32065))
 * backed/gcs: Update storage package to v1.28.0 ([#29656](https://github.com/hashicorp/terraform/issues/29656))
+* When removing a workspace from the `cloud` backend `terraform workspace delete` will use Terraform Cloud's [Safe Delete](https://developer.hashicorp.com/terraform/cloud-docs/api-docs/workspaces#safe-delete-a-workspace) API if the `-force` flag is not provided. ([#31949](https://github.com/hashicorp/terraform/pull/31949))
 
 EXPERIMENTS:
 

--- a/go.mod
+++ b/go.mod
@@ -39,7 +39,7 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-plugin v1.4.3
 	github.com/hashicorp/go-retryablehttp v0.7.1
-	github.com/hashicorp/go-tfe v1.10.0
+	github.com/hashicorp/go-tfe v1.12.0
 	github.com/hashicorp/go-uuid v1.0.3
 	github.com/hashicorp/go-version v1.6.0
 	github.com/hashicorp/hcl v0.0.0-20170504190234-a4b07c25de5f
@@ -175,7 +175,7 @@ require (
 	github.com/vmihailenco/tagparser v0.1.1 // indirect
 	go.opencensus.io v0.23.0 // indirect
 	golang.org/x/exp/typeparams v0.0.0-20220218215828-6cf2b201936e // indirect
-	golang.org/x/time v0.0.0-20220722155302-e5dcc9cfc0b9 // indirect
+	golang.org/x/time v0.1.0 // indirect
 	golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect

--- a/go.sum
+++ b/go.sum
@@ -376,8 +376,8 @@ github.com/hashicorp/go-slug v0.10.0/go.mod h1:Ib+IWBYfEfJGI1ZyXMGNbu2BU+aa3Dzu4
 github.com/hashicorp/go-sockaddr v1.0.0 h1:GeH6tui99pF4NJgfnhp+L6+FfobzVW3Ah46sLo0ICXs=
 github.com/hashicorp/go-sockaddr v1.0.0/go.mod h1:7Xibr9yA9JjQq1JpNB2Vw7kxv8xerXegt+ozgdvDeDU=
 github.com/hashicorp/go-syslog v1.0.0/go.mod h1:qPfqrKkXGihmCqbJM2mZgkZGvKG1dFdvsLplgctolz4=
-github.com/hashicorp/go-tfe v1.10.0 h1:mkEge/DSca8VQeBSAQbjEy8fWFHbrJA76M7dny5XlYc=
-github.com/hashicorp/go-tfe v1.10.0/go.mod h1:uSWi2sPw7tLrqNIiASid9j3SprbbkPSJ/2s3X0mMemg=
+github.com/hashicorp/go-tfe v1.12.0 h1:2l7emKW8rNTTbnxYHNVj6b46iJzOEp2G/3xIHfGSDnc=
+github.com/hashicorp/go-tfe v1.12.0/go.mod h1:thYtIxtgBpDDNdf/2yYPdBJ94Fz5yT5XCNZvGtTGHAU=
 github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-uuid v1.0.1/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-uuid v1.0.2/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
@@ -602,7 +602,7 @@ github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81P
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
+github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.0.194/go.mod h1:7sCQWVkxcsR38nffDW057DRGk8mUjK1Ing/EFOK8s8Y=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.0.232 h1:kwsWbh4rEw42ZDe9/812ebhbwNZxlQyZ2sTmxBOKhN4=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.0.232/go.mod h1:7sCQWVkxcsR38nffDW057DRGk8mUjK1Ing/EFOK8s8Y=
@@ -861,8 +861,8 @@ golang.org/x/time v0.0.0-20181108054448-85acf8d2951c/go.mod h1:tRJNPiyCQ0inRvYxb
 golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20191024005414-555d28b269f0/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20210723032227-1f47c861a9ac/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
-golang.org/x/time v0.0.0-20220722155302-e5dcc9cfc0b9 h1:ftMN5LMiBFjbzleLqtoBZk7KdJwhuybIU+FckUHgoyQ=
-golang.org/x/time v0.0.0-20220722155302-e5dcc9cfc0b9/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
+golang.org/x/time v0.1.0 h1:xYY+Bajn2a7VBmTM5GikTmnK8ZuX8YgnQCqZpbBNtmA=
+golang.org/x/time v0.1.0/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190114222345-bf090417da8b/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190226205152-f727befe758c/go.mod h1:9Yl7xja0Znq3iFh3HoIrodX9oNMXvdceNzlUR8zjMvY=

--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -109,7 +109,7 @@ type Backend interface {
 	// DeleteWorkspace cannot prevent deleting a state that is in use. It is
 	// the responsibility of the caller to hold a Lock for the state manager
 	// belonging to this workspace before calling this method.
-	DeleteWorkspace(name string) error
+	DeleteWorkspace(name string, force bool) error
 
 	// States returns a list of the names of all of the workspaces that exist
 	// in this backend.

--- a/internal/backend/local/backend.go
+++ b/internal/backend/local/backend.go
@@ -214,10 +214,10 @@ func (b *Local) Workspaces() ([]string, error) {
 // DeleteWorkspace removes a workspace.
 //
 // The "default" workspace cannot be removed.
-func (b *Local) DeleteWorkspace(name string) error {
+func (b *Local) DeleteWorkspace(name string, force bool) error {
 	// If we have a backend handling state, defer to that.
 	if b.Backend != nil {
-		return b.Backend.DeleteWorkspace(name)
+		return b.Backend.DeleteWorkspace(name, force)
 	}
 
 	if name == "" {

--- a/internal/backend/local/backend_local_test.go
+++ b/internal/backend/local/backend_local_test.go
@@ -190,7 +190,7 @@ func (b backendWithStateStorageThatFailsRefresh) Configure(cty.Value) tfdiags.Di
 	return nil
 }
 
-func (b backendWithStateStorageThatFailsRefresh) DeleteWorkspace(name string) error {
+func (b backendWithStateStorageThatFailsRefresh) DeleteWorkspace(name string, force bool) error {
 	return fmt.Errorf("unimplemented")
 }
 

--- a/internal/backend/local/backend_test.go
+++ b/internal/backend/local/backend_test.go
@@ -133,7 +133,7 @@ func TestLocal_addAndRemoveStates(t *testing.T) {
 		t.Fatalf("expected %q, got %q", expectedStates, states)
 	}
 
-	if err := b.DeleteWorkspace(expectedA); err != nil {
+	if err := b.DeleteWorkspace(expectedA, true); err != nil {
 		t.Fatal(err)
 	}
 
@@ -147,7 +147,7 @@ func TestLocal_addAndRemoveStates(t *testing.T) {
 		t.Fatalf("expected %q, got %q", expectedStates, states)
 	}
 
-	if err := b.DeleteWorkspace(expectedB); err != nil {
+	if err := b.DeleteWorkspace(expectedB, true); err != nil {
 		t.Fatal(err)
 	}
 
@@ -161,7 +161,7 @@ func TestLocal_addAndRemoveStates(t *testing.T) {
 		t.Fatalf("expected %q, got %q", expectedStates, states)
 	}
 
-	if err := b.DeleteWorkspace(dflt); err == nil {
+	if err := b.DeleteWorkspace(dflt, true); err == nil {
 		t.Fatal("expected error deleting default state")
 	}
 }
@@ -196,7 +196,7 @@ func (b *testDelegateBackend) Workspaces() ([]string, error) {
 	return []string{"default"}, nil
 }
 
-func (b *testDelegateBackend) DeleteWorkspace(name string) error {
+func (b *testDelegateBackend) DeleteWorkspace(name string, force bool) error {
 	if b.deleteErr {
 		return errTestDelegateDeleteState
 	}
@@ -220,7 +220,7 @@ func TestLocal_multiStateBackend(t *testing.T) {
 		t.Fatal("expected errTestDelegateStates, got:", err)
 	}
 
-	if err := b.DeleteWorkspace("test"); err != errTestDelegateDeleteState {
+	if err := b.DeleteWorkspace("test", true); err != errTestDelegateDeleteState {
 		t.Fatal("expected errTestDelegateDeleteState, got:", err)
 	}
 }

--- a/internal/backend/local/testing.go
+++ b/internal/backend/local/testing.go
@@ -135,7 +135,7 @@ func (b *TestLocalSingleState) Workspaces() ([]string, error) {
 	return nil, backend.ErrWorkspacesNotSupported
 }
 
-func (b *TestLocalSingleState) DeleteWorkspace(string) error {
+func (b *TestLocalSingleState) DeleteWorkspace(string, bool) error {
 	return backend.ErrWorkspacesNotSupported
 }
 
@@ -177,11 +177,11 @@ func (b *TestLocalNoDefaultState) Workspaces() ([]string, error) {
 	return filtered, nil
 }
 
-func (b *TestLocalNoDefaultState) DeleteWorkspace(name string) error {
+func (b *TestLocalNoDefaultState) DeleteWorkspace(name string, force bool) error {
 	if name == backend.DefaultStateName {
 		return backend.ErrDefaultWorkspaceNotSupported
 	}
-	return b.Local.DeleteWorkspace(name)
+	return b.Local.DeleteWorkspace(name, force)
 }
 
 func (b *TestLocalNoDefaultState) StateMgr(name string) (statemgr.Full, error) {

--- a/internal/backend/remote-state/azure/backend_state.go
+++ b/internal/backend/remote-state/azure/backend_state.go
@@ -58,7 +58,7 @@ func (b *Backend) Workspaces() ([]string, error) {
 	return result, nil
 }
 
-func (b *Backend) DeleteWorkspace(name string) error {
+func (b *Backend) DeleteWorkspace(name string, _ bool) error {
 	if name == backend.DefaultStateName || name == "" {
 		return fmt.Errorf("can't delete default state")
 	}

--- a/internal/backend/remote-state/consul/backend_state.go
+++ b/internal/backend/remote-state/consul/backend_state.go
@@ -49,7 +49,7 @@ func (b *Backend) Workspaces() ([]string, error) {
 	return result, nil
 }
 
-func (b *Backend) DeleteWorkspace(name string) error {
+func (b *Backend) DeleteWorkspace(name string, _ bool) error {
 	if name == backend.DefaultStateName || name == "" {
 		return fmt.Errorf("can't delete default state")
 	}

--- a/internal/backend/remote-state/cos/backend_state.go
+++ b/internal/backend/remote-state/cos/backend_state.go
@@ -57,7 +57,7 @@ func (b *Backend) Workspaces() ([]string, error) {
 }
 
 // DeleteWorkspace deletes the named workspaces. The "default" state cannot be deleted.
-func (b *Backend) DeleteWorkspace(name string) error {
+func (b *Backend) DeleteWorkspace(name string, _ bool) error {
 	log.Printf("[DEBUG] delete workspace, workspace: %v", name)
 
 	if name == backend.DefaultStateName || name == "" {

--- a/internal/backend/remote-state/gcs/backend_state.go
+++ b/internal/backend/remote-state/gcs/backend_state.go
@@ -55,7 +55,7 @@ func (b *Backend) Workspaces() ([]string, error) {
 }
 
 // DeleteWorkspace deletes the named workspaces. The "default" state cannot be deleted.
-func (b *Backend) DeleteWorkspace(name string) error {
+func (b *Backend) DeleteWorkspace(name string, _ bool) error {
 	if name == backend.DefaultStateName {
 		return fmt.Errorf("cowardly refusing to delete the %q state", name)
 	}

--- a/internal/backend/remote-state/http/backend.go
+++ b/internal/backend/remote-state/http/backend.go
@@ -195,6 +195,6 @@ func (b *Backend) Workspaces() ([]string, error) {
 	return nil, backend.ErrWorkspacesNotSupported
 }
 
-func (b *Backend) DeleteWorkspace(string) error {
+func (b *Backend) DeleteWorkspace(string, bool) error {
 	return backend.ErrWorkspacesNotSupported
 }

--- a/internal/backend/remote-state/inmem/backend.go
+++ b/internal/backend/remote-state/inmem/backend.go
@@ -101,7 +101,7 @@ func (b *Backend) Workspaces() ([]string, error) {
 	return workspaces, nil
 }
 
-func (b *Backend) DeleteWorkspace(name string) error {
+func (b *Backend) DeleteWorkspace(name string, _ bool) error {
 	states.Lock()
 	defer states.Unlock()
 

--- a/internal/backend/remote-state/kubernetes/backend_state.go
+++ b/internal/backend/remote-state/kubernetes/backend_state.go
@@ -60,7 +60,7 @@ func (b *Backend) Workspaces() ([]string, error) {
 	return states, nil
 }
 
-func (b *Backend) DeleteWorkspace(name string) error {
+func (b *Backend) DeleteWorkspace(name string, _ bool) error {
 	if name == backend.DefaultStateName || name == "" {
 		return fmt.Errorf("can't delete default state")
 	}

--- a/internal/backend/remote-state/oss/backend_state.go
+++ b/internal/backend/remote-state/oss/backend_state.go
@@ -96,7 +96,7 @@ func (b *Backend) Workspaces() ([]string, error) {
 	return result, nil
 }
 
-func (b *Backend) DeleteWorkspace(name string) error {
+func (b *Backend) DeleteWorkspace(name string, _ bool) error {
 	if name == backend.DefaultStateName || name == "" {
 		return fmt.Errorf("can't delete default state")
 	}

--- a/internal/backend/remote-state/pg/backend_state.go
+++ b/internal/backend/remote-state/pg/backend_state.go
@@ -35,7 +35,7 @@ func (b *Backend) Workspaces() ([]string, error) {
 	return result, nil
 }
 
-func (b *Backend) DeleteWorkspace(name string) error {
+func (b *Backend) DeleteWorkspace(name string, _ bool) error {
 	if name == backend.DefaultStateName || name == "" {
 		return fmt.Errorf("can't delete default state")
 	}

--- a/internal/backend/remote-state/s3/backend_state.go
+++ b/internal/backend/remote-state/s3/backend_state.go
@@ -90,7 +90,7 @@ func (b *Backend) keyEnv(key string) string {
 	return parts[0]
 }
 
-func (b *Backend) DeleteWorkspace(name string) error {
+func (b *Backend) DeleteWorkspace(name string, _ bool) error {
 	if name == backend.DefaultStateName || name == "" {
 		return fmt.Errorf("can't delete default state")
 	}

--- a/internal/backend/remote-state/s3/backend_test.go
+++ b/internal/backend/remote-state/s3/backend_test.go
@@ -537,7 +537,7 @@ func TestBackendExtraPaths(t *testing.T) {
 	}
 
 	// delete the real workspace
-	if err := b.DeleteWorkspace("s2"); err != nil {
+	if err := b.DeleteWorkspace("s2", true); err != nil {
 		t.Fatal(err)
 	}
 

--- a/internal/backend/remote/backend.go
+++ b/internal/backend/remote/backend.go
@@ -582,7 +582,7 @@ func (b *Remote) WorkspaceNamePattern() string {
 }
 
 // DeleteWorkspace implements backend.Enhanced.
-func (b *Remote) DeleteWorkspace(name string) error {
+func (b *Remote) DeleteWorkspace(name string, _ bool) error {
 	if b.workspace == "" && name == backend.DefaultStateName {
 		return backend.ErrDefaultWorkspaceNotSupported
 	}

--- a/internal/backend/remote/backend_test.go
+++ b/internal/backend/remote/backend_test.go
@@ -262,11 +262,11 @@ func TestRemote_addAndRemoveWorkspacesDefault(t *testing.T) {
 		t.Fatalf("expected error %v, got %v", backend.ErrWorkspacesNotSupported, err)
 	}
 
-	if err := b.DeleteWorkspace(backend.DefaultStateName); err != nil {
+	if err := b.DeleteWorkspace(backend.DefaultStateName, true); err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
 
-	if err := b.DeleteWorkspace("prod"); err != backend.ErrWorkspacesNotSupported {
+	if err := b.DeleteWorkspace("prod", true); err != backend.ErrWorkspacesNotSupported {
 		t.Fatalf("expected error %v, got %v", backend.ErrWorkspacesNotSupported, err)
 	}
 }
@@ -319,11 +319,11 @@ func TestRemote_addAndRemoveWorkspacesNoDefault(t *testing.T) {
 		t.Fatalf("expected %#+v, got %#+v", expectedWorkspaces, states)
 	}
 
-	if err := b.DeleteWorkspace(backend.DefaultStateName); err != backend.ErrDefaultWorkspaceNotSupported {
+	if err := b.DeleteWorkspace(backend.DefaultStateName, true); err != backend.ErrDefaultWorkspaceNotSupported {
 		t.Fatalf("expected error %v, got %v", backend.ErrDefaultWorkspaceNotSupported, err)
 	}
 
-	if err := b.DeleteWorkspace(expectedA); err != nil {
+	if err := b.DeleteWorkspace(expectedA, true); err != nil {
 		t.Fatal(err)
 	}
 
@@ -337,7 +337,7 @@ func TestRemote_addAndRemoveWorkspacesNoDefault(t *testing.T) {
 		t.Fatalf("expected %#+v got %#+v", expectedWorkspaces, states)
 	}
 
-	if err := b.DeleteWorkspace(expectedB); err != nil {
+	if err := b.DeleteWorkspace(expectedB, true); err != nil {
 		t.Fatal(err)
 	}
 

--- a/internal/backend/testing.go
+++ b/internal/backend/testing.go
@@ -219,12 +219,12 @@ func TestBackendStates(t *testing.T, b Backend) {
 	}
 
 	// Delete some workspaces
-	if err := b.DeleteWorkspace("foo"); err != nil {
+	if err := b.DeleteWorkspace("foo", true); err != nil {
 		t.Fatalf("err: %s", err)
 	}
 
 	// Verify the default state can't be deleted
-	if err := b.DeleteWorkspace(DefaultStateName); err == nil {
+	if err := b.DeleteWorkspace(DefaultStateName, true); err == nil {
 		t.Fatal("expected error")
 	}
 
@@ -242,7 +242,7 @@ func TestBackendStates(t *testing.T, b Backend) {
 		t.Fatalf("should be empty: %s", v)
 	}
 	// and delete it again
-	if err := b.DeleteWorkspace("foo"); err != nil {
+	if err := b.DeleteWorkspace("foo", true); err != nil {
 		t.Fatalf("err: %s", err)
 	}
 

--- a/internal/builtin/providers/terraform/data_source_state_test.go
+++ b/internal/builtin/providers/terraform/data_source_state_test.go
@@ -362,7 +362,7 @@ func (b backendFailsConfigure) StateMgr(workspace string) (statemgr.Full, error)
 	return nil, fmt.Errorf("StateMgr not implemented")
 }
 
-func (b backendFailsConfigure) DeleteWorkspace(name string) error {
+func (b backendFailsConfigure) DeleteWorkspace(name string, _ bool) error {
 	return fmt.Errorf("DeleteWorkspace not implemented")
 }
 

--- a/internal/cloud/backend.go
+++ b/internal/cloud/backend.go
@@ -516,7 +516,7 @@ func (b *Cloud) Workspaces() ([]string, error) {
 }
 
 // DeleteWorkspace implements backend.Enhanced.
-func (b *Cloud) DeleteWorkspace(name string) error {
+func (b *Cloud) DeleteWorkspace(name string, force bool) error {
 	if name == backend.DefaultStateName {
 		return backend.ErrDefaultWorkspaceNotSupported
 	}
@@ -525,11 +525,14 @@ func (b *Cloud) DeleteWorkspace(name string) error {
 		return backend.ErrWorkspacesNotSupported
 	}
 
+	workspace, err := b.client.Workspaces.Read(context.Background(), b.organization, name)
+	if err != nil {
+		return fmt.Errorf("failed to retrieve workspace %s: %v", name, err)
+	}
+
 	// Configure the remote workspace name.
-	State := &State{tfeClient: b.client, organization: b.organization, workspace: &tfe.Workspace{
-		Name: name,
-	}}
-	return State.Delete()
+	State := &State{tfeClient: b.client, organization: b.organization, workspace: workspace}
+	return State.Delete(force)
 }
 
 // StateMgr implements backend.Enhanced.

--- a/internal/cloud/backend.go
+++ b/internal/cloud/backend.go
@@ -526,6 +526,10 @@ func (b *Cloud) DeleteWorkspace(name string, force bool) error {
 	}
 
 	workspace, err := b.client.Workspaces.Read(context.Background(), b.organization, name)
+	if err == tfe.ErrResourceNotFound {
+		return nil // If the workspace does not exist, succeed
+	}
+
 	if err != nil {
 		return fmt.Errorf("failed to retrieve workspace %s: %v", name, err)
 	}

--- a/internal/cloud/backend_test.go
+++ b/internal/cloud/backend_test.go
@@ -1211,10 +1211,7 @@ func TestClodBackend_DeleteWorkspace_DoesNotExist(t *testing.T) {
 	defer bCleanup()
 
 	err := b.DeleteWorkspace("non-existent-workspace", false)
-	if err == nil {
-		t.Fatalf("expected deleting a workspace which does not exist to fail")
-	}
-	if !strings.Contains(err.Error(), "failed to retrieve workspace non-existent-workspace") {
-		t.Fatalf("expected deletion to fail with cannot find workspace error, but got %s", err.Error())
+	if err != nil {
+		t.Fatalf("expected deleting a workspace which does not exist to succeed")
 	}
 }

--- a/internal/cloud/backend_test.go
+++ b/internal/cloud/backend_test.go
@@ -40,11 +40,11 @@ func TestCloud_backendWithName(t *testing.T) {
 		t.Fatalf("expected fetching a state which is NOT the single configured workspace to have an ErrWorkspacesNotSupported error, but got: %v", err)
 	}
 
-	if err := b.DeleteWorkspace(testBackendSingleWorkspaceName); err != backend.ErrWorkspacesNotSupported {
+	if err := b.DeleteWorkspace(testBackendSingleWorkspaceName, true); err != backend.ErrWorkspacesNotSupported {
 		t.Fatalf("expected deleting the single configured workspace name to result in an error, but got: %v", err)
 	}
 
-	if err := b.DeleteWorkspace("foo"); err != backend.ErrWorkspacesNotSupported {
+	if err := b.DeleteWorkspace("foo", true); err != backend.ErrWorkspacesNotSupported {
 		t.Fatalf("expected deleting a workspace which is NOT the configured workspace name to result in an error, but got: %v", err)
 	}
 }
@@ -856,7 +856,7 @@ func TestCloud_addAndRemoveWorkspacesDefault(t *testing.T) {
 		t.Fatalf("expected no error, got %v", err)
 	}
 
-	if err := b.DeleteWorkspace(testBackendSingleWorkspaceName); err != backend.ErrWorkspacesNotSupported {
+	if err := b.DeleteWorkspace(testBackendSingleWorkspaceName, true); err != backend.ErrWorkspacesNotSupported {
 		t.Fatalf("expected error %v, got %v", backend.ErrWorkspacesNotSupported, err)
 	}
 }
@@ -1137,5 +1137,84 @@ func TestCloud_VerifyWorkspaceTerraformVersion_ignoreFlagSet(t *testing.T) {
 	wantDetail := "The local Terraform version (0.14.0) does not meet the version requirements for remote workspace hashicorp/app-prod (0.13.5)."
 	if got := diags[0].Description().Detail; got != wantDetail {
 		t.Errorf("wrong summary: got %s, want %s", got, wantDetail)
+	}
+}
+
+func TestClodBackend_DeleteWorkspace_SafeAndForce(t *testing.T) {
+	b, bCleanup := testBackendWithTags(t)
+	defer bCleanup()
+	safeDeleteWorkspaceName := "safe-delete-workspace"
+	forceDeleteWorkspaceName := "force-delete-workspace"
+
+	_, err := b.StateMgr(safeDeleteWorkspaceName)
+	if err != nil {
+		t.Fatalf("error: %s", err)
+	}
+
+	_, err = b.StateMgr(forceDeleteWorkspaceName)
+	if err != nil {
+		t.Fatalf("error: %s", err)
+	}
+
+	// sanity check that the mock now contains two workspaces
+	wl, err := b.Workspaces()
+	if err != nil {
+		t.Fatalf("error fetching workspace names: %v", err)
+	}
+	if len(wl) != 2 {
+		t.Fatalf("expected 2 workspaced but got %d", len(wl))
+	}
+
+	c := context.Background()
+	safeDeleteWorkspace, err := b.client.Workspaces.Read(c, b.organization, safeDeleteWorkspaceName)
+	if err != nil {
+		t.Fatalf("error fetching workspace: %v", err)
+	}
+
+	// Lock a workspace so that it should fail to be safe deleted
+	_, err = b.client.Workspaces.Lock(context.Background(), safeDeleteWorkspace.ID, tfe.WorkspaceLockOptions{Reason: tfe.String("test")})
+	if err != nil {
+		t.Fatalf("error locking workspace: %v", err)
+	}
+	err = b.DeleteWorkspace(safeDeleteWorkspaceName, false)
+	if err == nil {
+		t.Fatalf("workspace should have failed to safe delete")
+	}
+
+	// unlock the workspace and confirm that safe-delete now works
+	_, err = b.client.Workspaces.Unlock(context.Background(), safeDeleteWorkspace.ID)
+	if err != nil {
+		t.Fatalf("error unlocking workspace: %v", err)
+	}
+	err = b.DeleteWorkspace(safeDeleteWorkspaceName, false)
+	if err != nil {
+		t.Fatalf("error safe deleting workspace: %v", err)
+	}
+
+	// lock a workspace and then confirm that force deleting it works
+	forceDeleteWorkspace, err := b.client.Workspaces.Read(c, b.organization, forceDeleteWorkspaceName)
+	if err != nil {
+		t.Fatalf("error fetching workspace: %v", err)
+	}
+	_, err = b.client.Workspaces.Lock(context.Background(), forceDeleteWorkspace.ID, tfe.WorkspaceLockOptions{Reason: tfe.String("test")})
+	if err != nil {
+		t.Fatalf("error locking workspace: %v", err)
+	}
+	err = b.DeleteWorkspace(forceDeleteWorkspaceName, true)
+	if err != nil {
+		t.Fatalf("error force deleting workspace: %v", err)
+	}
+}
+
+func TestClodBackend_DeleteWorkspace_DoesNotExist(t *testing.T) {
+	b, bCleanup := testBackendWithTags(t)
+	defer bCleanup()
+
+	err := b.DeleteWorkspace("non-existent-workspace", false)
+	if err == nil {
+		t.Fatalf("expected deleting a workspace which does not exist to fail")
+	}
+	if !strings.Contains(err.Error(), "failed to retrieve workspace non-existent-workspace") {
+		t.Fatalf("expected deletion to fail with cannot find workspace error, but got %s", err.Error())
 	}
 }

--- a/internal/cloud/state_test.go
+++ b/internal/cloud/state_test.go
@@ -244,7 +244,7 @@ func TestDelete_SafeDelete(t *testing.T) {
 	if err = state.Delete(false); err != nil {
 		t.Fatalf("workspace safe-delete err: %s", err)
 	}
-	
+
 	workspace, err := state.tfeClient.Workspaces.ReadByID(context.Background(), workspaceId)
 	if workspace != nil || err != tfe.ErrResourceNotFound {
 		t.Fatalf("workspace %s not deleted", workspaceId)

--- a/internal/cloud/tfe_client_mock.go
+++ b/internal/cloud/tfe_client_mock.go
@@ -908,6 +908,10 @@ func (m *MockRuns) ForceCancel(ctx context.Context, runID string, options tfe.Ru
 	panic("not implemented")
 }
 
+func (m *MockRuns) ForceExecute(ctx context.Context, runID string) error {
+	panic("implement me")
+}
+
 func (m *MockRuns) Discard(ctx context.Context, runID string, options tfe.RunDiscardOptions) error {
 	m.Lock()
 	defer m.Unlock()

--- a/internal/cloud/tfe_client_mock.go
+++ b/internal/cloud/tfe_client_mock.go
@@ -1236,8 +1236,9 @@ func (m *MockWorkspaces) Create(ctx context.Context, organization string, option
 		ExecutionMode: *options.ExecutionMode,
 		Operations:    *options.Operations,
 		Permissions: &tfe.WorkspacePermissions{
-			CanQueueApply: true,
-			CanQueueRun:   true,
+			CanQueueApply:  true,
+			CanQueueRun:    true,
+			CanForceDelete: tfe.Bool(true),
 		},
 	}
 	if options.AutoApply != nil {
@@ -1368,6 +1369,41 @@ func (m *MockWorkspaces) DeleteByID(ctx context.Context, workspaceID string) err
 	}
 	delete(m.workspaceIDs, workspaceID)
 	return nil
+}
+
+func (m *MockWorkspaces) SafeDelete(ctx context.Context, organization, workspace string) error {
+	w, ok := m.client.Workspaces.workspaceNames[workspace]
+
+	if !ok {
+		return tfe.ErrResourceNotFound
+	}
+
+	if w.Locked {
+		return errors.New("cannot safe delete locked workspace")
+	}
+
+	if w.ResourceCount > 0 {
+		return fmt.Errorf("cannot safe delete workspace with %d resources", w.ResourceCount)
+	}
+
+	return m.Delete(ctx, organization, workspace)
+}
+
+func (m *MockWorkspaces) SafeDeleteByID(ctx context.Context, workspaceID string) error {
+	w, ok := m.client.Workspaces.workspaceIDs[workspaceID]
+	if !ok {
+		return tfe.ErrResourceNotFound
+	}
+
+	if w.Locked {
+		return errors.New("cannot safe delete locked workspace")
+	}
+
+	if w.ResourceCount > 0 {
+		return fmt.Errorf("cannot safe delete workspace with %d resources", w.ResourceCount)
+	}
+
+	return m.DeleteByID(ctx, workspaceID)
 }
 
 func (m *MockWorkspaces) RemoveVCSConnection(ctx context.Context, organization, workspace string) (*tfe.Workspace, error) {

--- a/internal/command/workspace_delete.go
+++ b/internal/command/workspace_delete.go
@@ -165,7 +165,7 @@ func (c *WorkspaceDeleteCommand) Run(args []string) int {
 	// be delegated from the Backend to the State itself.
 	stateLocker.Unlock()
 
-	err = b.DeleteWorkspace(workspace)
+	err = b.DeleteWorkspace(workspace, force)
 	if err != nil {
 		c.Ui.Error(err.Error())
 		return 1


### PR DESCRIPTION
Updates the cloud backend to call either workspace safe-delete or workspace force-delete 

These are new concepts to the Terraform Cloud workspace deletion APIs ([proposed documentation here](https://github.com/hashicorp/terraform-docs-common/pull/146)). Workspace safe delete will only remove a workspace if it does not have resources under management, to help prevent users from accidentally leaving managed resources orphaned from Terraform.

If a CLI user does not pass the `-force` option to `terraform workspace delete`, the cloud backend will attempt to use the new workspace safe-delete API (if we can detect that the TFC/E version contains this API). Otherwise it will continue using the existing API, which functions as a force delete.

The CLI [already has this concept](https://www.terraform.io/cli/commands/workspace/delete#force) of force workspace deletion, and will not remove a workspace if it detects it is managing resources (unless the user passes the `-force` flag). So this just acts as an extra set of guardrails around workspace deletion without the `-force` flag, since the safe delete API can make some additional checks around whether the workspace in question is locked, or if its state is in the process of being updated.

[Relevant RFC](https://docs.google.com/document/d/1SwO0PmgIu2KxQl6vr7Z55v3veLjcHBbv4YdhjL67lBs/edit#heading=h.4ppmvmimd1zt)

This depends on the [go-tfe change here](https://github.com/hashicorp/go-tfe/pull/539)


## Draft CHANGELOG entry

### ENHANCEMENTS

When using the cloud backend `terraform workspace delete` will now perform additional checks to ensure that the workspace being deleted is not managing state, such as checking if the workspace is locked or if its state is in the process of being updated, unless the `-force` option is passed.
