### PR TITLE
Adding mention of no-code to Creating Modules section of TF Language docs

### DIFF
--- a/website/docs/language/modules/develop/index.mdx
+++ b/website/docs/language/modules/develop/index.mdx
@@ -70,6 +70,12 @@ your module is not creating any new abstraction and so the module is
 adding unnecessary complexity. Just use the resource type directly in the
 calling module instead.
 
+### No-Code Provisioning in Terraform Cloud
+
+You can also create no-code ready modules to enable the no-code provisioning workflow in Terraform Cloud. No-code provisioning lets users deploy a module's resources in Terraform Cloud without writing any Terraform configuration.
+
+No-code ready modules have additional requirements and considerations. Refer to [Designing No-Code Ready Modules](/cloud-docs/no-code-provisioning/module-design) in the Terraform Cloud documentation for details.
+
 ## Refactoring module resources
 
 You can include [refactoring blocks](/language/modules/develop/refactoring) to record how resource


### PR DESCRIPTION
**What*

Adding a mention of no-code provisioning to the [Creating Modules](https://www.terraform.io/language/modules/develop#when-to-write-a-module) section of the Terraform Language docs.

**Why**

Currently, new users need to understand Terraform and how to write configurations using HCL, which can be a huge barrier. No-code modules allow any user to provision infrastructure with Terraform, regardless of experience.