### PR TITLE
backend/azurerm: add support for generic OIDC authentication

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/hashicorp/consul/api v1.9.1
 	github.com/hashicorp/consul/sdk v0.8.0
 	github.com/hashicorp/errwrap v1.1.0
-	github.com/hashicorp/go-azure-helpers v0.31.1
+	github.com/hashicorp/go-azure-helpers v0.43.0
 	github.com/hashicorp/go-checkpoint v0.5.0
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-getter v1.6.2

--- a/go.sum
+++ b/go.sum
@@ -332,6 +332,8 @@ github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brv
 github.com/hashicorp/go-azure-helpers v0.12.0/go.mod h1:Zc3v4DNeX6PDdy7NljlYpnrdac1++qNW0I4U+ofGwpg=
 github.com/hashicorp/go-azure-helpers v0.31.1 h1:lgwZLcyMheoLUj7dJfsrsa7ZpRvOIbsfFhttLi6ml78=
 github.com/hashicorp/go-azure-helpers v0.31.1/go.mod h1:gcutZ/Hf/O7YN9M3UIvyZ9l0Rxv7Yrc9x5sSfM9cuSw=
+github.com/hashicorp/go-azure-helpers v0.43.0 h1:larj4ZgwO3hKzA9xIOTXRW4NBpI6F3K8wpig8eikNOw=
+github.com/hashicorp/go-azure-helpers v0.43.0/go.mod h1:ofh+59GPB8g/lWI08711STfrIPSPOlXQkuMc8rovpBk=
 github.com/hashicorp/go-checkpoint v0.5.0 h1:MFYpPZCnQqQTE18jFwSII6eUQrD/oxMFp3mlgcqk5mU=
 github.com/hashicorp/go-checkpoint v0.5.0/go.mod h1:7nfLNL10NsxqO4iWuW6tWW0HjZuDrwkBuEQsVcpCOgg=
 github.com/hashicorp/go-cleanhttp v0.5.0/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=

--- a/go.sum
+++ b/go.sum
@@ -330,8 +330,6 @@ github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brv
 github.com/hashicorp/errwrap v1.1.0 h1:OxrOeh75EUXMY8TBjag2fzXGZ40LB6IKw45YeGUDY2I=
 github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-azure-helpers v0.12.0/go.mod h1:Zc3v4DNeX6PDdy7NljlYpnrdac1++qNW0I4U+ofGwpg=
-github.com/hashicorp/go-azure-helpers v0.31.1 h1:lgwZLcyMheoLUj7dJfsrsa7ZpRvOIbsfFhttLi6ml78=
-github.com/hashicorp/go-azure-helpers v0.31.1/go.mod h1:gcutZ/Hf/O7YN9M3UIvyZ9l0Rxv7Yrc9x5sSfM9cuSw=
 github.com/hashicorp/go-azure-helpers v0.43.0 h1:larj4ZgwO3hKzA9xIOTXRW4NBpI6F3K8wpig8eikNOw=
 github.com/hashicorp/go-azure-helpers v0.43.0/go.mod h1:ofh+59GPB8g/lWI08711STfrIPSPOlXQkuMc8rovpBk=
 github.com/hashicorp/go-checkpoint v0.5.0 h1:MFYpPZCnQqQTE18jFwSII6eUQrD/oxMFp3mlgcqk5mU=

--- a/internal/backend/remote-state/azure/arm_client.go
+++ b/internal/backend/remote-state/azure/arm_client.go
@@ -81,6 +81,8 @@ func buildArmClient(ctx context.Context, config BackendConfig) (*ArmClient, erro
 		MsiEndpoint: config.MsiEndpoint,
 
 		// OIDC
+		IDToken:             config.OIDCToken,
+		IDTokenFilePath:     config.OIDCTokenFilePath,
 		IDTokenRequestURL:   config.OIDCRequestURL,
 		IDTokenRequestToken: config.OIDCRequestToken,
 

--- a/internal/backend/remote-state/azure/backend.go
+++ b/internal/backend/remote-state/azure/backend.go
@@ -142,19 +142,29 @@ func New() backend.Backend {
 				DefaultFunc: schema.EnvDefaultFunc("ARM_USE_OIDC", false),
 				Description: "Allow OIDC to be used for authentication",
 			},
-
+			"oidc_token": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("ARM_OIDC_TOKEN", false),
+				Description: "A generic JWT token that can be used for OIDC authentication. Should not be used in conjunction with `oidc_request_token`.",
+			},
+			"oidc_token_file_path": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("ARM_OIDC_TOKEN_FILE_PATH", false),
+				Description: "Path to file containing a generic JWT token that can be used for OIDC authentication. Should not be used in conjunction with `oidc_request_token`.",
+			},
 			"oidc_request_url": {
 				Type:        schema.TypeString,
 				Optional:    true,
 				DefaultFunc: schema.MultiEnvDefaultFunc([]string{"ARM_OIDC_REQUEST_URL", "ACTIONS_ID_TOKEN_REQUEST_URL"}, ""),
-				Description: "The URL for the OIDC provider from which to request an ID token",
+				Description: "The URL of the OIDC provider from which to request an ID token. Needs to be used in conjunction with `oidc_request_token`. This is meant to be used for Github Actions.",
 			},
-
 			"oidc_request_token": {
 				Type:        schema.TypeString,
 				Optional:    true,
 				DefaultFunc: schema.MultiEnvDefaultFunc([]string{"ARM_OIDC_REQUEST_TOKEN", "ACTIONS_ID_TOKEN_REQUEST_TOKEN"}, ""),
-				Description: "The bearer token for the request to the OIDC provider",
+				Description: "The bearer token to use for the request to the OIDC providers `oidc_request_url` URL to fetch an ID token. Needs to be used in conjunction with `oidc_request_url`. This is meant to be used for Github Actions.",
 			},
 
 			// Feature Flags
@@ -197,6 +207,8 @@ type BackendConfig struct {
 	MetadataHost                  string
 	Environment                   string
 	MsiEndpoint                   string
+	OIDCToken                     string
+	OIDCTokenFilePath             string
 	OIDCRequestURL                string
 	OIDCRequestToken              string
 	ResourceGroupName             string
@@ -230,6 +242,8 @@ func (b *Backend) configure(ctx context.Context) error {
 		MetadataHost:                  data.Get("metadata_host").(string),
 		Environment:                   data.Get("environment").(string),
 		MsiEndpoint:                   data.Get("msi_endpoint").(string),
+		OIDCToken:                     data.Get("oidc_token").(string),
+		OIDCTokenFilePath:             data.Get("oidc_token_file_path").(string),
 		OIDCRequestURL:                data.Get("oidc_request_url").(string),
 		OIDCRequestToken:              data.Get("oidc_request_token").(string),
 		ResourceGroupName:             data.Get("resource_group_name").(string),

--- a/internal/backend/remote-state/azure/backend.go
+++ b/internal/backend/remote-state/azure/backend.go
@@ -145,13 +145,13 @@ func New() backend.Backend {
 			"oidc_token": {
 				Type:        schema.TypeString,
 				Optional:    true,
-				DefaultFunc: schema.EnvDefaultFunc("ARM_OIDC_TOKEN", false),
+				DefaultFunc: schema.EnvDefaultFunc("ARM_OIDC_TOKEN", ""),
 				Description: "A generic JWT token that can be used for OIDC authentication. Should not be used in conjunction with `oidc_request_token`.",
 			},
 			"oidc_token_file_path": {
 				Type:        schema.TypeString,
 				Optional:    true,
-				DefaultFunc: schema.EnvDefaultFunc("ARM_OIDC_TOKEN_FILE_PATH", false),
+				DefaultFunc: schema.EnvDefaultFunc("ARM_OIDC_TOKEN_FILE_PATH", ""),
 				Description: "Path to file containing a generic JWT token that can be used for OIDC authentication. Should not be used in conjunction with `oidc_request_token`.",
 			},
 			"oidc_request_url": {

--- a/website/docs/language/settings/backends/azurerm.mdx
+++ b/website/docs/language/settings/backends/azurerm.mdx
@@ -273,6 +273,10 @@ When authenticating using a Service Principal with OpenID Connect (OIDC) - the f
 
 * `oidc_request_token` - (Optional) The bearer token for the request to the OIDC provider. This can also be sourced from the `ARM_OIDC_REQUEST_TOKEN` or `ACTIONS_ID_TOKEN_REQUEST_TOKEN` environment variables.
 
+* `oidc_token` - (Optional) The ID token when authenticating using OpenID Connect (OIDC). This can also be sourced from the `ARM_OIDC_TOKEN` environment variable.
+
+* `oidc_token_file_path` - (Optional) The path to a file containing an ID token when authenticating using OpenID Connect (OIDC). This can also be sourced from the `ARM_OIDC_TOKEN_FILE_PATH` environment variable.
+
 * `use_oidc` - (Optional) Should OIDC authentication be used? This can also be sourced from the `ARM_USE_OIDC` environment variable.
 
 ***


### PR DESCRIPTION
Support for generic OIDC authentication (eg. for Gitlab or Kubernetes) has been added to azurerm provider as well as in the go-azure-helpers already:
https://github.com/hashicorp/terraform-provider-azurerm/issues/16901
https://github.com/hashicorp/go-azure-helpers/blob/main/authentication/auth_method_oidc.go#L41

Currently the remote state backend only supports Github Actions. This pull requests added the support for generic OIDC as in the provider. Also, the documentation has been updated to reflect the usage.

Info: This pull request upgrades the dependency of go-azure-helpers to the latest available version.

Fixes #31802

## Target Release

1.4.x

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

### NEW FEATURES

<!--

Write a short description of the user-facing change. Examples:

- `terraform show -json`: Fixed crash with sensitive set values.
- When rendering a diff, Terraform now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 

-  Added support for generic OIDC authentication in azurerm remote state backend (eg. Gitlab or Kubernetes)
