### PR TITLE
chore(docs): Fix proper case

### DIFF
--- a/website/docs/internals/debugging.mdx
+++ b/website/docs/internals/debugging.mdx
@@ -18,7 +18,7 @@ Setting `TF_LOG` to `JSON` outputs logs at the `TRACE` level or higher, and uses
 
 ~> **Warning:** The JSON encoding of log files is not considered a stable interface. It may change at any time, without warning. It is meant to support tooling that will be forthcoming, and that tooling is the only supported way to interact with JSON formatted logs.
 
-Logging can be enabled separately for terraform itself and the provider plugins
+Logging can be enabled separately for Terraform itself and the provider plugins
 using the `TF_LOG_CORE` or `TF_LOG_PROVIDER` environment variables. These take
 the same level arguments as `TF_LOG`, but only activate a subset of the logs.
 


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

Fix a minor reference where Terraform should likely have been proper cased, as it's being used to refer to the product in a sentence.

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Fixes #

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.4.x

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

### NEW FEATURES | UPGRADE NOTES | ENHANCEMENTS | BUG FIXES | EXPERIMENTS

<!--

Write a short description of the user-facing change. Examples:

- `terraform show -json`: Fixed crash with sensitive set values.
- When rendering a diff, Terraform now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 

-  
