### PR TITLE
Fix regex pattern for more alternatives

### DIFF
--- a/website/docs/language/functions/regex.mdx
+++ b/website/docs/language/functions/regex.mdx
@@ -71,7 +71,7 @@ of the pattern must be escaped as `\\`.
 | `\PN`                  | The opposite of `\pN`                                                            |
 | `\P{Greek}`            | The opposite of `\p{Greek}`                                                      |
 | `xy`                   | `x` followed immediately by `y`                                                  |
-| `x|y`                  | either `x` or `y`, preferring `x`                                                |
+| `x&#124;y`             | either `x` or `y`, preferring `x`                                                |
 | `x*`                   | zero or more `x`, preferring more                                                |
 | `x*?`                  | zero or more `x`, preferring fewer                                               |
 | `x+`                   | one or more `x`, preferring more                                                 |

--- a/website/docs/language/functions/regex.mdx
+++ b/website/docs/language/functions/regex.mdx
@@ -71,7 +71,7 @@ of the pattern must be escaped as `\\`.
 | `\PN`                  | The opposite of `\pN`                                                            |
 | `\P{Greek}`            | The opposite of `\p{Greek}`                                                      |
 | `xy`                   | `x` followed immediately by `y`                                                  |
-| <code>x\&#124;y</code> | either `x` or `y`, preferring `x`                                                |
+| `x|y`                  | either `x` or `y`, preferring `x`                                                |
 | `x*`                   | zero or more `x`, preferring more                                                |
 | `x*?`                  | zero or more `x`, preferring fewer                                               |
 | `x+`                   | one or more `x`, preferring more                                                 |


### PR DESCRIPTION
During refactoring, there was a backslash added to `|` character in terraform regex. That doesn't actually work.

Fix that and return just `x|y` - that's the correct usage, that works.

<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Fixes #

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.1-backport
1.2-backport
1.3-backport
1.4.x

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

### BUG FIXES

- Terraform regex documentation of `x|y` included an extra backslash. Removed.

<!--

Write a short description of the user-facing change. Examples:

- `terraform show -json`: Fixed crash with sensitive set values.
- When rendering a diff, Terraform now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 
