### PR TITLE
Document provider registry response property shasum

### DIFF
--- a/website/docs/internals/provider-registry-protocol.mdx
+++ b/website/docs/internals/provider-registry-protocol.mdx
@@ -319,6 +319,9 @@ A successful result is a JSON object with the following properties:
 * `shasums_signature_url` (required): a URL from which Terraform can retrieve
   a binary, detached GPG signature for the document at `shasums_url`, signed
   by one of the keys indicated in the `signing_keys` property.
+  
+* `shasum` (required): the SHA256 checksum for this provider's zip archive as
+  recorded in the "shasums" document.
 
 * `signing_keys` (required): an object describing signing keys for this
   provider package, one of which must have been used to produce the signature

--- a/website/docs/internals/provider-registry-protocol.mdx
+++ b/website/docs/internals/provider-registry-protocol.mdx
@@ -321,7 +321,7 @@ A successful result is a JSON object with the following properties:
   by one of the keys indicated in the `signing_keys` property.
   
 * `shasum` (required): the SHA256 checksum for this provider's zip archive as
-  recorded in the "shasums" document.
+  recorded in the shasums document.
 
 * `signing_keys` (required): an object describing signing keys for this
   provider package, one of which must have been used to produce the signature


### PR DESCRIPTION
Add a short summary of the `shasum` property in the Provider Registry Protocol's distribution package response documentation. The Response Properties section of the provider registry protocol does not mention the `shasum` property, but it is required and shown in the example.

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.4.x

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

### BUG FIXES

<!--

Write a short description of the user-facing change. Examples:

- `terraform show -json`: Fixed crash with sensitive set values.
- When rendering a diff, Terraform now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 

-  Added a description of the `shasum` object property to the registry protocol's documentation. This property is a required part of the response, but it was previously shown in the example response only without a corresponding reference.
