### PR TITLE
[docs] Add warning about prefix loss when migrating

### DIFF
--- a/website/docs/cli/cloud/migrating.mdx
+++ b/website/docs/cli/cloud/migrating.mdx
@@ -82,4 +82,5 @@ terraform {
    }
  }
 ```
-~> **Warning:** Because the `cloud` block does not support the `prefix` argument, once you migrate, you must refer to workspaces by their full name when using the Terraform CLI. For example, rather than `terraform workspace select prod`, you must run the command `terraform workspace select my-app-prod`.
+
+~> **Warning**: Because the `cloud` block does not support the `prefix` argument, once you migrate, you must refer to workspaces by their full name when using the Terraform CLI. For example, rather than `terraform workspace select prod`, you must run the command `terraform workspace select my-app-prod`.

--- a/website/docs/cli/cloud/migrating.mdx
+++ b/website/docs/cli/cloud/migrating.mdx
@@ -82,4 +82,4 @@ terraform {
    }
  }
 ```
-~> **Warning:** Because the `cloud` block does not support the `prefix` argument, once you migrate you will need to refer to workspaces by their full name when using the Terraform CLI. For example, rather than `terraform workspace select prod`, you would need to run the command `terraform workspace select my-app-prod`.
+~> **Warning:** Because the `cloud` block does not support the `prefix` argument, once you migrate, you must refer to workspaces by their full name when using the Terraform CLI. For example, rather than `terraform workspace select prod`, you must run the command `terraform workspace select my-app-prod`.

--- a/website/docs/cli/cloud/migrating.mdx
+++ b/website/docs/cli/cloud/migrating.mdx
@@ -82,3 +82,4 @@ terraform {
    }
  }
 ```
+~> **Warning:** Because the `cloud` provider does not support the `prefix` argument, once you migrate you will need to refer to workspaces by their full name when using the Terraform CLI. For example, rather than `terraform workspace select prod`, you would need to run the command `terraform workspace select my-app-prod`.

--- a/website/docs/cli/cloud/migrating.mdx
+++ b/website/docs/cli/cloud/migrating.mdx
@@ -82,4 +82,4 @@ terraform {
    }
  }
 ```
-~> **Warning:** Because the `cloud` provider does not support the `prefix` argument, once you migrate you will need to refer to workspaces by their full name when using the Terraform CLI. For example, rather than `terraform workspace select prod`, you would need to run the command `terraform workspace select my-app-prod`.
+~> **Warning:** Because the `cloud` block does not support the `prefix` argument, once you migrate you will need to refer to workspaces by their full name when using the Terraform CLI. For example, rather than `terraform workspace select prod`, you would need to run the command `terraform workspace select my-app-prod`.


### PR DESCRIPTION
This adds a warning about the consequences of switching to the `cloud` block, in terms of losing `prefix` support, and the impact that has on CLI usage. Specifically, after switching from the `remote` backend to the `cloud` block, CLI users lose the ability to run e.g. `terraform workspace select prod`, and must instead run e.g. `terraform workspace select my-app-prod`. This has the potential to impact previously written scripts, as well, but was until now not actually noted in the migration documentation.
