### PR TITLE
[docs] Add example for using cloud-config in place of file provisioners

### DIFF
--- a/website/docs/language/resources/provisioners/syntax.mdx
+++ b/website/docs/language/resources/provisioners/syntax.mdx
@@ -97,11 +97,9 @@ remote access credentials to be provided.
 
 ### Provisioning files using cloud-config
 
-Under some circumstances it may be feasible to
-[yamlencode](https://www.terraform.io/language/functions/yamlencode) your entire
-[cloud-config](https://registry.terraform.io/providers/hashicorp/cloudinit/latest/docs)
-file. In that case you could use the `write_files` section in place of file
-provisioners. For example:
+You can add the [`cloudinit_config`](https://registry.terraform.io/providers/hashicorp/cloudinit/latest/docs) data source to your Terraform configuration and specify the files you want to provision as `text/cloud-config` content. The `cloudinit_config` data source renders multi-part MIME configurations for use with [cloud-init](https://cloudinit.readthedocs.io/en/latest/). Pass the files in the `content` field as YAML-encoded configurations using the `write_files` block. 
+
+In the following example, the `my_cloud_config` data source specifies a `text/cloud-config` MIME part named `cloud.conf`. The `part.content` field is set to [`yamlencode`](/terraform/language/functions/yamlencode), which encodes the `write_files` JSON object as YAML so that the system can provision the referenced files.
 
 ```hcl
 data "cloudinit_config" "my_cloud_config" {

--- a/website/docs/language/resources/provisioners/syntax.mdx
+++ b/website/docs/language/resources/provisioners/syntax.mdx
@@ -95,6 +95,44 @@ data this way will allow faster boot times and simplify deployment by avoiding
 the need for direct network access from Terraform to the new server and for
 remote access credentials to be provided.
 
+### Provisioning files using cloud-config
+
+Under some circumstances it may be feasible to
+[yamlencode](https://www.terraform.io/language/functions/yamlencode) your entire
+[cloud-config](https://registry.terraform.io/providers/hashicorp/cloudinit/latest/docs)
+file. In that case you could use the `write_files` section in place of file
+provisioners. For example:
+
+```hcl
+data "cloudinit_config" "my_cloud_config" {
+  gzip          = false
+  base64_encode = false
+
+  part {
+    content_type = "text/cloud-config"
+    filename     = "cloud.conf"
+    content = yamlencode(
+      {
+        "write_files" : [
+          {
+            "path" : "/etc/foo.conf",
+            "content" : "foo contents",
+          },
+          {
+            "path" : "/etc/bar.conf",
+            "content" : file("bar.conf"),
+          },
+          {
+            "path" : "/etc/baz.conf",
+            "content" : templatefile("baz.tpl.conf", { SOME_VAR = "qux" }),
+          },
+        ],
+      }
+    )
+  }
+}
+```
+
 ### Running configuration management software
 
 As a convenience to users who are forced to use generic operating system


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->


## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.4.x

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

### ENHANCEMENTS

<!--

Write a short description of the user-facing change. Examples:

- `terraform show -json`: Fixed crash with sensitive set values.
- When rendering a diff, Terraform now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 

- Doc update: provide an example for using cloudinit and yamlencode in place of file provisioners. 
