### PR TITLE
Update workspace delete command docs to reference RUM vs empty state

### DIFF
--- a/internal/command/workspace_delete.go
+++ b/internal/command/workspace_delete.go
@@ -210,7 +210,7 @@ Usage: terraform [global options] workspace delete [OPTIONS] NAME
 
 Options:
 
-  -force             Remove even a non-empty workspace.
+  -force             Remove even a workspace with resources under management.
 
   -lock=false        Don't hold a state lock during the operation. This is
                      dangerous if others might concurrently run commands

--- a/internal/command/workspace_delete.go
+++ b/internal/command/workspace_delete.go
@@ -210,7 +210,9 @@ Usage: terraform [global options] workspace delete [OPTIONS] NAME
 
 Options:
 
-  -force             Remove a workspace even if it is managing resources. Terraform can no longer track or manage the workspace's infrastructure. 
+  -force             Remove a workspace even if it is managing resources.
+                     Terraform can no longer track or manage the workspace's
+                     infrastructure.
 
   -lock=false        Don't hold a state lock during the operation. This is
                      dangerous if others might concurrently run commands

--- a/internal/command/workspace_delete.go
+++ b/internal/command/workspace_delete.go
@@ -210,7 +210,7 @@ Usage: terraform [global options] workspace delete [OPTIONS] NAME
 
 Options:
 
-  -force             Remove even a workspace with resources under management.
+  -force             Remove a workspace even if it is managing resources. Terraform can no longer track or manage the workspace's infrastructure. 
 
   -lock=false        Don't hold a state lock during the operation. This is
                      dangerous if others might concurrently run commands

--- a/website/docs/cli/commands/workspace/delete.mdx
+++ b/website/docs/cli/commands/workspace/delete.mdx
@@ -13,8 +13,8 @@ Usage: `terraform workspace delete [OPTIONS] NAME [DIR]`
 
 This command will delete the specified workspace.
 
-To delete a workspace, it must already exist, it must not have resources under management,
-and it must not be your current workspace. If the workspace has resources under management,
+To delete a workspace, it must already exist, it must not be tracking resources,
+and it must not be your current workspace. If the workspace is tracking resources,
 Terraform will not allow you to delete it unless the `-force` flag is specified.
 
 Workspaces with resources under management (RUM) are workspaces which manage resources that physically exist.

--- a/website/docs/cli/commands/workspace/delete.mdx
+++ b/website/docs/cli/commands/workspace/delete.mdx
@@ -31,7 +31,7 @@ from getting into this situation.
 
 The command-line flags are all optional. The only supported flags are:
 
-* `-force` - Delete the workspace even if it has resources under management. Defaults to false.
+* `-force` - Delete the workspace even if it has resources under management. After deletion, Terraform can no longer track or manage the workspace's infrastructure. Defaults to false.
 * `-lock=false` - Don't hold a state lock during the operation. This is
   dangerous if others might concurrently run commands against the same
   workspace.

--- a/website/docs/cli/commands/workspace/delete.mdx
+++ b/website/docs/cli/commands/workspace/delete.mdx
@@ -13,20 +13,25 @@ Usage: `terraform workspace delete [OPTIONS] NAME [DIR]`
 
 This command will delete the specified workspace.
 
-To delete an workspace, it must already exist, it must have an empty state,
-and it must not be your current workspace. If the workspace state is not empty,
+To delete a workspace, it must already exist, it must not have resources under management,
+and it must not be your current workspace. If the workspace has resources under management,
 Terraform will not allow you to delete it unless the `-force` flag is specified.
 
-If you delete a workspace with a non-empty state (via `-force`), then resources
+Workspaces with resources under management (RUM) are workspaces which manage resources that physically exist.
+This means that the workspace has a non-empty state.
+Additionally, different [backends](/language/settings/backends/configuration#backend-types) may implement other
+restrictions on whether a workspace is considered to have RUM, such as whether the workspace is locked.
+
+If you delete a workspace with resources under management (via `-force`), then resources
 may become "dangling". These are resources that physically exist but that
-Terraform can no longer manage. This is sometimes preferred: you want
-Terraform to stop managing resources so they can be managed some other way.
+Terraform can no longer manage. This is sometimes preferred: you may want
+Terraform to stop managing resources, so they can be managed some other way.
 Most of the time, however, this is not intended and so Terraform protects you
 from getting into this situation.
 
-The command-line flags are all optional. The only supported flag is:
+The command-line flags are all optional. The only supported flags are:
 
-* `-force` - Delete the workspace even if its state is not empty. Defaults to false.
+* `-force` - Delete the workspace even if it has resources under management. Defaults to false.
 * `-lock=false` - Don't hold a state lock during the operation. This is
   dangerous if others might concurrently run commands against the same
   workspace.

--- a/website/docs/cli/commands/workspace/delete.mdx
+++ b/website/docs/cli/commands/workspace/delete.mdx
@@ -17,12 +17,10 @@ To delete a workspace, it must already exist, it must not be tracking resources,
 and it must not be your current workspace. If the workspace is tracking resources,
 Terraform will not allow you to delete it unless the `-force` flag is specified.
 
-Workspaces with resources under management (RUM) are workspaces which manage resources that physically exist.
-This means that the workspace has a non-empty state.
 Additionally, different [backends](/language/settings/backends/configuration#backend-types) may implement other
-restrictions on whether a workspace is considered to have RUM, such as whether the workspace is locked.
+restrictions on whether a workspace is considered safe to delete without the `-force` flag, such as whether the workspace is locked.
 
-If you delete a workspace with resources under management (via `-force`), then resources
+If you delete a workspace which is tracking resources (via `-force`), then resources
 may become "dangling". These are resources that physically exist but that
 Terraform can no longer manage. This is sometimes preferred: you may want
 Terraform to stop managing resources, so they can be managed some other way.
@@ -31,7 +29,7 @@ from getting into this situation.
 
 The command-line flags are all optional. The only supported flags are:
 
-* `-force` - Delete the workspace even if it has resources under management. After deletion, Terraform can no longer track or manage the workspace's infrastructure. Defaults to false.
+* `-force` - Delete the workspace even if it is tracking resources. After deletion, Terraform can no longer track or manage the workspace's infrastructure. Defaults to false.
 * `-lock=false` - Don't hold a state lock during the operation. This is
   dangerous if others might concurrently run commands against the same
   workspace.


### PR DESCRIPTION
In terraform cloud we are adding some guardrails to help prevent users from accidentally deleting workspaces with resources under management (RUM).

The Terraform CLI already attempts to prevent the user from deleting workspaces with RUM, and requires the `-force` flag to remove a workspace with RUM. The docs + help text around this refer to workspaces which are dangerous to delete as "workspaces with non-empty state".

In order to bring the CLI experience up to date with the TFC/E experience, and standardize on an industry term rather than something terraform specific, this updates the docs/help to refer to "resources under management" instead.

Proposed doc change [here](https://github.com/hashicorp/terraform-docs-common/pull/146) and some changes to the CLI to utilize the Terraform Cloud enhancements [here](https://github.com/hashicorp/terraform/pull/31949)

