### PR TITLE
fix: don't reveal nested attributes with sensitive schema

### DIFF
--- a/internal/command/console_test.go
+++ b/internal/command/console_test.go
@@ -172,8 +172,8 @@ func TestConsole_variables(t *testing.T) {
 	commands := map[string]string{
 		"var.foo\n":          "\"bar\"\n",
 		"var.snack\n":        "\"popcorn\"\n",
-		"var.secret_snack\n": "(sensitive)\n",
-		"local.snack_bar\n":  "[\n  \"popcorn\",\n  (sensitive),\n]\n",
+		"var.secret_snack\n": "(sensitive value)\n",
+		"local.snack_bar\n":  "[\n  \"popcorn\",\n  (sensitive value),\n]\n",
 	}
 
 	args := []string{}

--- a/internal/command/format/diff.go
+++ b/internal/command/format/diff.go
@@ -274,7 +274,10 @@ type blockBodyDiffResult struct {
 	skippedBlocks     int
 }
 
-const forcesNewResourceCaption = " [red]# forces replacement[reset]"
+const (
+	forcesNewResourceCaption = " [red]# forces replacement[reset]"
+	sensitiveCaption         = "(sensitive value)"
+)
 
 // writeBlockBodyDiff writes attribute or block differences
 // and returns true if any differences were found and written
@@ -416,7 +419,7 @@ func (p *blockBodyDiffPrinter) writeAttrDiff(name string, attrS *configschema.At
 	p.buf.WriteString(" = ")
 
 	if attrS.Sensitive {
-		p.buf.WriteString("(sensitive)")
+		p.buf.WriteString(sensitiveCaption)
 		if p.pathForcesNewResource(path) {
 			p.buf.WriteString(p.color.Color(forcesNewResourceCaption))
 		}
@@ -459,7 +462,8 @@ func (p *blockBodyDiffPrinter) writeNestedAttrDiff(
 	// Then schema of the attribute itself can be marked sensitive, or the values assigned
 	sensitive := attrWithNestedS.Sensitive || old.HasMark(marks.Sensitive) || new.HasMark(marks.Sensitive)
 	if sensitive {
-		p.buf.WriteString(" = (sensitive)")
+		p.buf.WriteString(" = ")
+		p.buf.WriteString(sensitiveCaption)
 
 		if p.pathForcesNewResource(path) {
 			p.buf.WriteString(p.color.Color(forcesNewResourceCaption))
@@ -742,7 +746,7 @@ func (p *blockBodyDiffPrinter) writeNestedBlockDiffs(name string, blockS *config
 
 	// If either the old or the new value is marked,
 	// Display a special diff because it is irrelevant
-	// to list all obfuscated attributes as (sensitive)
+	// to list all obfuscated attributes as (sensitive value)
 	if old.HasMark(marks.Sensitive) || new.HasMark(marks.Sensitive) {
 		p.writeSensitiveNestedBlockDiff(name, old, new, indent, blankBefore, path)
 		return 0
@@ -1025,7 +1029,7 @@ func (p *blockBodyDiffPrinter) writeNestedBlockDiff(name string, label *string, 
 func (p *blockBodyDiffPrinter) writeValue(val cty.Value, action plans.Action, indent int) {
 	// Could check specifically for the sensitivity marker
 	if val.HasMark(marks.Sensitive) {
-		p.buf.WriteString("(sensitive)")
+		p.buf.WriteString(sensitiveCaption)
 		return
 	}
 
@@ -1193,7 +1197,7 @@ func (p *blockBodyDiffPrinter) writeValueDiff(old, new cty.Value, indent int, pa
 	// values are known and non-null.
 	if old.IsKnown() && new.IsKnown() && !old.IsNull() && !new.IsNull() && typesEqual {
 		if old.HasMark(marks.Sensitive) || new.HasMark(marks.Sensitive) {
-			p.buf.WriteString("(sensitive)")
+			p.buf.WriteString(sensitiveCaption)
 			if p.pathForcesNewResource(path) {
 				p.buf.WriteString(p.color.Color(forcesNewResourceCaption))
 			}
@@ -1564,7 +1568,7 @@ func (p *blockBodyDiffPrinter) writeValueDiff(old, new cty.Value, indent int, pa
 				case plans.Create, plans.NoOp:
 					v := new.Index(kV)
 					if v.HasMark(marks.Sensitive) {
-						p.buf.WriteString("(sensitive)")
+						p.buf.WriteString(sensitiveCaption)
 					} else {
 						p.writeValue(v, action, indent+4)
 					}
@@ -1574,7 +1578,7 @@ func (p *blockBodyDiffPrinter) writeValueDiff(old, new cty.Value, indent int, pa
 					p.writeValueDiff(oldV, newV, indent+4, path)
 				default:
 					if oldV.HasMark(marks.Sensitive) || newV.HasMark(marks.Sensitive) {
-						p.buf.WriteString("(sensitive)")
+						p.buf.WriteString(sensitiveCaption)
 					} else {
 						p.writeValueDiff(oldV, newV, indent+4, path)
 					}

--- a/internal/command/format/diff_test.go
+++ b/internal/command/format/diff_test.go
@@ -411,11 +411,11 @@ new line
 			ExpectedOutput: `  # test_instance.example will be created
   + resource "test_instance" "example" {
       + conn_info = {
-          + password = (sensitive)
+          + password = (sensitive value)
           + user     = "not-secret"
         }
       + id        = (known after apply)
-      + password  = (sensitive)
+      + password  = (sensitive value)
     }
 `,
 		},
@@ -3048,7 +3048,7 @@ func TestResourceChange_nestedSet(t *testing.T) {
 			ExpectedOutput: `  # test_instance.example will be created
   + resource "test_instance" "example" {
       + ami   = "ami-AFTER"
-      + disks = (sensitive)
+      + disks = (sensitive value)
       + id    = "i-02ae66f368e8518a9"
 
       + root_block_device {
@@ -3146,7 +3146,7 @@ func TestResourceChange_nestedSet(t *testing.T) {
       ~ ami   = "ami-BEFORE" -> "ami-AFTER"
       # Warning: this attribute value will be marked as sensitive and will not
       # display in UI output after applying this change.
-      ~ disks = (sensitive)
+      ~ disks = (sensitive value)
         id    = "i-02ae66f368e8518a9"
 
       + root_block_device {
@@ -3197,7 +3197,7 @@ func TestResourceChange_nestedSet(t *testing.T) {
       ~ ami   = "ami-BEFORE" -> "ami-AFTER"
       # Warning: this attribute value will be marked as sensitive and will not
       # display in UI output after applying this change. The value is unchanged.
-      ~ disks = (sensitive)
+      ~ disks = (sensitive value)
         id    = "i-02ae66f368e8518a9"
     }
 `,
@@ -3965,7 +3965,7 @@ func TestResourceChange_nestedMap(t *testing.T) {
       ~ ami   = "ami-BEFORE" -> "ami-AFTER"
       ~ disks = {
           + "disk_a" = {
-              + mount_point = (sensitive)
+              + mount_point = (sensitive value)
               + size        = "50GB"
             },
         }
@@ -5728,18 +5728,18 @@ func TestResourceChange_sensitiveVariable(t *testing.T) {
 			},
 			ExpectedOutput: `  # test_instance.example will be created
   + resource "test_instance" "example" {
-      + ami        = (sensitive)
+      + ami        = (sensitive value)
       + id         = "i-02ae66f368e8518a9"
       + list_field = [
           + "hello",
-          + (sensitive),
+          + (sensitive value),
           + "!",
         ]
       + map_key    = {
           + "breakfast" = 800
-          + "dinner"    = (sensitive)
+          + "dinner"    = (sensitive value)
         }
-      + map_whole  = (sensitive)
+      + map_whole  = (sensitive value)
 
       + nested_block_list {
           # At least one attribute in this block is (or was) sensitive,
@@ -5882,29 +5882,29 @@ func TestResourceChange_sensitiveVariable(t *testing.T) {
   ~ resource "test_instance" "example" {
       # Warning: this attribute value will no longer be marked as sensitive
       # after applying this change.
-      ~ ami         = (sensitive)
+      ~ ami         = (sensitive value)
         id          = "i-02ae66f368e8518a9"
       ~ list_field  = [
             # (1 unchanged element hidden)
             "friends",
-          - (sensitive),
+          - (sensitive value),
           + ".",
         ]
       ~ map_key     = {
           # Warning: this attribute value will no longer be marked as sensitive
           # after applying this change.
-          ~ "dinner"    = (sensitive)
+          ~ "dinner"    = (sensitive value)
             # (1 unchanged element hidden)
         }
       # Warning: this attribute value will no longer be marked as sensitive
       # after applying this change.
-      ~ map_whole   = (sensitive)
+      ~ map_whole   = (sensitive value)
       # Warning: this attribute value will no longer be marked as sensitive
       # after applying this change.
-      ~ some_number = (sensitive)
+      ~ some_number = (sensitive value)
       # Warning: this attribute value will no longer be marked as sensitive
       # after applying this change.
-      ~ special     = (sensitive)
+      ~ special     = (sensitive value)
 
       # Warning: this block will no longer be marked as sensitive
       # after applying this change.
@@ -6007,18 +6007,18 @@ func TestResourceChange_sensitiveVariable(t *testing.T) {
         id         = "i-02ae66f368e8518a9"
       ~ list_field = [
           - "hello",
-          + (sensitive),
+          + (sensitive value),
             "friends",
         ]
       ~ map_key    = {
           ~ "breakfast" = 800 -> 700
           # Warning: this attribute value will be marked as sensitive and will not
           # display in UI output after applying this change.
-          ~ "dinner"    = (sensitive)
+          ~ "dinner"    = (sensitive value)
         }
       # Warning: this attribute value will be marked as sensitive and will not
       # display in UI output after applying this change.
-      ~ map_whole  = (sensitive)
+      ~ map_whole  = (sensitive value)
 
       # Warning: this block will be marked as sensitive and will not
       # display in UI output after applying this change.
@@ -6143,15 +6143,15 @@ func TestResourceChange_sensitiveVariable(t *testing.T) {
       ~ ami        = (sensitive value)
         id         = "i-02ae66f368e8518a9"
       ~ list_field = [
-          - (sensitive),
-          + (sensitive),
+          - (sensitive value),
+          + (sensitive value),
             "friends",
         ]
       ~ map_key    = {
-          ~ "dinner"    = (sensitive)
+          ~ "dinner"    = (sensitive value)
             # (1 unchanged element hidden)
         }
-      ~ map_whole  = (sensitive)
+      ~ map_whole  = (sensitive value)
 
       ~ nested_block_map {
           # At least one attribute in this block is (or was) sensitive,
@@ -6289,29 +6289,29 @@ func TestResourceChange_sensitiveVariable(t *testing.T) {
   ~ resource "test_instance" "example" {
       # Warning: this attribute value will no longer be marked as sensitive
       # after applying this change. The value is unchanged.
-      ~ ami         = (sensitive)
+      ~ ami         = (sensitive value)
         id          = "i-02ae66f368e8518a9"
       ~ list_field  = [
             # (1 unchanged element hidden)
             "friends",
-          - (sensitive),
+          - (sensitive value),
           + "!",
         ]
       ~ map_key     = {
           # Warning: this attribute value will no longer be marked as sensitive
           # after applying this change. The value is unchanged.
-          ~ "dinner"    = (sensitive)
+          ~ "dinner"    = (sensitive value)
             # (1 unchanged element hidden)
         }
       # Warning: this attribute value will no longer be marked as sensitive
       # after applying this change. The value is unchanged.
-      ~ map_whole   = (sensitive)
+      ~ map_whole   = (sensitive value)
       # Warning: this attribute value will no longer be marked as sensitive
       # after applying this change. The value is unchanged.
-      ~ some_number = (sensitive)
+      ~ some_number = (sensitive value)
       # Warning: this attribute value will no longer be marked as sensitive
       # after applying this change. The value is unchanged.
-      ~ special     = (sensitive)
+      ~ special     = (sensitive value)
 
       # Warning: this block will no longer be marked as sensitive
       # after applying this change.
@@ -6410,17 +6410,17 @@ func TestResourceChange_sensitiveVariable(t *testing.T) {
 			},
 			ExpectedOutput: `  # test_instance.example will be destroyed
   - resource "test_instance" "example" {
-      - ami        = (sensitive) -> null
+      - ami        = (sensitive value) -> null
       - id         = "i-02ae66f368e8518a9" -> null
       - list_field = [
           - "hello",
-          - (sensitive),
+          - (sensitive value),
         ] -> null
       - map_key    = {
           - "breakfast" = 800
-          - "dinner"    = (sensitive)
+          - "dinner"    = (sensitive value)
         } -> null
-      - map_whole  = (sensitive) -> null
+      - map_whole  = (sensitive value) -> null
 
       - nested_block_set {
           # At least one attribute in this block is (or was) sensitive,
@@ -6492,7 +6492,7 @@ func TestResourceChange_sensitiveVariable(t *testing.T) {
 			),
 			ExpectedOutput: `  # test_instance.example must be replaced
 -/+ resource "test_instance" "example" {
-      ~ ami = (sensitive) # forces replacement
+      ~ ami = (sensitive value) # forces replacement
         id  = "i-02ae66f368e8518a9"
 
       ~ nested_block_set { # forces replacement
@@ -6524,7 +6524,7 @@ func TestResourceChange_sensitiveVariable(t *testing.T) {
 			),
 			ExpectedOutput: `  # test_instance.example must be replaced
 -/+ resource "test_instance" "example" {
-      ~ ami = (sensitive) # forces replacement
+      ~ ami = (sensitive value) # forces replacement
         id  = "i-02ae66f368e8518a9"
     }
 `,
@@ -6567,7 +6567,7 @@ func TestResourceChange_sensitiveVariable(t *testing.T) {
 			ExpectedOutput: `  # test_instance.example must be replaced
 -/+ resource "test_instance" "example" {
       ~ conn_info = { # forces replacement
-          ~ password = (sensitive)
+          ~ password = (sensitive value)
             # (1 unchanged attribute hidden)
         }
         id        = "i-02ae66f368e8518a9"
@@ -6824,7 +6824,7 @@ func TestOutputChanges(t *testing.T) {
 			},
 			`
   ~ a = 1 -> 2
-  ~ b = (sensitive)
+  ~ b = (sensitive value)
   ~ c = false -> true`,
 		},
 	}

--- a/internal/repl/format.go
+++ b/internal/repl/format.go
@@ -18,7 +18,7 @@ func FormatValue(v cty.Value, indent int) string {
 		return "(known after apply)"
 	}
 	if v.HasMark(marks.Sensitive) {
-		return "(sensitive)"
+		return "(sensitive value)"
 	}
 	if v.IsNull() {
 		ty := v.Type()

--- a/internal/repl/format_test.go
+++ b/internal/repl/format_test.go
@@ -171,8 +171,8 @@ EOT_`,
 			`toset([])`,
 		},
 		{
-			cty.StringVal("sensitive value").Mark(marks.Sensitive),
-			"(sensitive)",
+			cty.StringVal("a sensitive value").Mark(marks.Sensitive),
+			"(sensitive value)",
 		},
 	}
 

--- a/website/docs/language/expressions/function-calls.mdx
+++ b/website/docs/language/expressions/function-calls.mdx
@@ -63,11 +63,11 @@ the `keys()` function will result in a list that is sensitive:
 ```shell
 > local.baz
 {
-  "a" = (sensitive)
+  "a" = (sensitive value)
   "b" = "dog"
 }
 > keys(local.baz)
-(sensitive)
+(sensitive value)
 ```
 
 ## When Terraform Calls Functions

--- a/website/docs/language/expressions/references.mdx
+++ b/website/docs/language/expressions/references.mdx
@@ -292,7 +292,7 @@ Note that unlike `count`, splat expressions are _not_ directly applicable to res
 
 When defining the schema for a resource type, a provider developer can mark
 certain attributes as _sensitive_, in which case Terraform will show a
-placeholder marker `(sensitive)` instead of the actual value when rendering
+placeholder marker `(sensitive value)` instead of the actual value when rendering
 a plan involving that attribute.
 
 A provider attribute marked as sensitive behaves similarly to an

--- a/website/docs/language/functions/nonsensitive.mdx
+++ b/website/docs/language/functions/nonsensitive.mdx
@@ -91,11 +91,11 @@ the local value `mixed_content`, with a valid JSON string assigned to
 
 ```
 > var.mixed_content_json
-(sensitive)
+(sensitive value)
 > local.mixed_content
-(sensitive)
+(sensitive value)
 > local.mixed_content["password"]
-(sensitive)
+(sensitive value)
 > nonsensitive(local.mixed_content["username"])
 "zqb"
 > nonsensitive("clear")

--- a/website/docs/language/functions/sensitive.mdx
+++ b/website/docs/language/functions/sensitive.mdx
@@ -34,9 +34,9 @@ because they may be exposed in other ways outside of Terraform's control.
 
 ```
 > sensitive(1)
-(sensitive)
+(sensitive value)
 > sensitive("hello")
-(sensitive)
+(sensitive value)
 > sensitive([])
-(sensitive)
+(sensitive value)
 ```

--- a/website/docs/language/values/outputs.mdx
+++ b/website/docs/language/values/outputs.mdx
@@ -159,7 +159,7 @@ Terraform will perform the following actions:
 
   # test_instance.x will be created
   + resource "test_instance" "x" {
-      + some_attribute    = (sensitive)
+      + some_attribute    = (sensitive value)
     }
 
 Plan: 1 to add, 0 to change, 0 to destroy.

--- a/website/docs/language/values/variables.mdx
+++ b/website/docs/language/values/variables.mdx
@@ -218,8 +218,8 @@ Terraform will perform the following actions:
 
   # some_resource.a will be created
   + resource "some_resource" "a" {
-      + name    = (sensitive)
-      + address = (sensitive)
+      + name    = (sensitive value)
+      + address = (sensitive value)
     }
 
 Plan: 1 to add, 0 to change, 0 to destroy.
@@ -262,7 +262,7 @@ If a resource attribute is used as, or part of, the provider-defined resource id
   + resource "random_pet" "animal" {
       + id        = (known after apply)
       + length    = 2
-      + prefix    = (sensitive)
+      + prefix    = (sensitive value)
       + separator = "-"
     }
 


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->
## Description

Fixes several bugs in the plan diff rendering of nested attributes 

- When a schema attribute is sensitive, but also contains nested attributes, terraform reveals the nested attributes. The renderer checks for sensitive _values_ at this nesting level, but ignores sensitive _schema_.
- There is a mixture of "(sensitive)" and "(sensitive value)" output in the plan diff and I changed them all to "(sensitive value)"
- Certain nested attribute modes don't output consistent new values for delete plans or unknown values

I also added a lot more test coverage for single nested attribute mode and sensitive schema nested attributes

<details>
<summary>Sample Config</summary>

```hcl


terraform {
  required_providers {
    nested = {
      source = "alisdair/nested"
    }
  }
}

resource "nested_single" "example" {
  name = "my_nested_single"

  sensitive_value = {
    string = "secret"
  }
}

resource "nested_list" "example" {
  name = "my_nested_list"

  sensitive_values = [{
    string = "secret"
  }]
}

resource "nested_blocks" "example" {
  name = "my_nested_list"

  list {
    sensitive_value = {
      string = "secret"
    }
  }
}

```
</details>

Before:

![Screen Shot 2022-10-12 at 3 02 10 PM](https://user-images.githubusercontent.com/174332/195447375-67c5697e-e3c5-40eb-80bc-a449ece3c5d0.png)

After:

![Screen Shot 2022-10-21 at 9 40 56 AM](https://user-images.githubusercontent.com/174332/197235309-7659449f-33b0-49e6-8863-971caa8a4425.png)

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.4.0, 1.3.5

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

### BUG FIXES

<!--

Write a short description of the user-facing change. Examples:
--> 

When rendering a diff of nested attributes, Terraform now hides the entire nested object if it is marked sensitive by the provider schema