### PR TITLE
The NETRC environment variable is honoured

### DIFF
--- a/website/docs/language/modules/sources.mdx
+++ b/website/docs/language/modules/sources.mdx
@@ -356,7 +356,9 @@ In either case, the result is interpreted as another module source address
 using one of the forms documented elsewhere on this page.
 
 If an HTTP/HTTPS URL requires authentication credentials, use a `.netrc`
-file in your home directory to configure these. For information on this format,
+to configure these. By default, Terraform will search for the `.netrc` file 
+in your HOME directory. However, that default filesystem location can be overriden 
+through the `NETRC` environment variable. For information on the `.netrc` format,
 see [the documentation for using it in `curl`](https://everything.curl.dev/usingcurl/netrc).
 
 ### Fetching archives over HTTP


### PR DESCRIPTION
The current documentation wording seems to suggest that the only `.netrc` file that will be considered by Terraform is the one sitting in the current user's HOME directory. However, unless I am missing something, Terraform uses `go-getter` to fetch remote modules which mean that the `NETRC` environment variable will also be respected and, in fact, will take precedence over any `.netrc` file on the user's home directory.

See: https://github.com/hashicorp/go-getter/blob/f7a8c48a1f863bcd167b51adcec00a18d10c85a5/netrc.go#L23-L36

Fixes https://github.com/hashicorp/terraform/issues/30136

## Draft CHANGELOG entry

### ENHANCEMENTS

-  The documentation now specifies that, when set, the environment variable `NETRC` will be honored.
