### PR TITLE
Refactor handling of credential ENVs for GCS backend

### DIFF
--- a/internal/backend/remote-state/gcs/backend.go
+++ b/internal/backend/remote-state/gcs/backend.go
@@ -6,7 +6,6 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"os"
 	"strings"
 
 	"cloud.google.com/go/storage"
@@ -55,7 +54,10 @@ func New() backend.Backend {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Description: "Google Cloud JSON Account Key",
-				Default:     "",
+				DefaultFunc: schema.MultiEnvDefaultFunc([]string{
+					"GOOGLE_BACKEND_CREDENTIALS",
+					"GOOGLE_CREDENTIALS",
+				}, nil),
 			},
 
 			"access_token": {
@@ -149,10 +151,6 @@ func (b *Backend) configure(ctx context.Context) error {
 		})
 	} else if v, ok := data.GetOk("credentials"); ok {
 		creds = v.(string)
-	} else if v := os.Getenv("GOOGLE_BACKEND_CREDENTIALS"); v != "" {
-		creds = v
-	} else {
-		creds = os.Getenv("GOOGLE_CREDENTIALS")
 	}
 
 	if tokenSource != nil {

--- a/internal/backend/remote-state/gcs/backend_test.go
+++ b/internal/backend/remote-state/gcs/backend_test.go
@@ -370,7 +370,7 @@ func setupKmsKey(t *testing.T, keyDetails map[string]string) string {
 }
 
 // teardownBackend deletes all states from be except the default state.
-func teardownBackend(t *testing.T, be backend.Backend, prefix string) {
+func teardownBackend(t *testing.T, be backend.Backend) {
 	t.Helper()
 	gcsBE, ok := be.(*Backend)
 	if !ok {

--- a/internal/backend/remote-state/gcs/backend_test.go
+++ b/internal/backend/remote-state/gcs/backend_test.go
@@ -407,7 +407,7 @@ func bucketName(t *testing.T) string {
 	return strings.ToLower(name)
 }
 
-// getClientOptions returns the []option.ClientOption needed to configure Google API clients
+// testGetClientOptions returns the []option.ClientOption needed to configure Google API clients
 // that are required in acceptance tests but are not part of the gcs backend itself
 func testGetClientOptions(t *testing.T) ([]option.ClientOption, error) {
 	t.Helper()


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

This PR refactors existing code to use the `(schema.Backend).DefaultFunc` field instead of accessing and using ENVs with the `os` package and `if...else` in the configure function.

Not essential, but I think it's useful to use the same approach for all fields. Plus it helps people see all the relevant ENVs in the backend schema.

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

No linked issue.

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.4.0

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

### ~~NEW FEATURES | UPGRADE NOTES | ENHANCEMENTS | BUG FIXES | EXPERIMENTS~~

<!--

Write a short description of the user-facing change. Examples:

- `terraform show -json`: Fixed crash with sensitive set values.
- When rendering a diff, Terraform now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 

No CHANGELOG entry as it's not a user-facing change