### PR TITLE
Get rid of Github Action warning

### DIFF
--- a/.github/actions/go-version/action.yml
+++ b/.github/actions/go-version/action.yml
@@ -20,4 +20,4 @@ runs:
       # complex for automation.
       run: |
         echo "Building with Go $(cat .go-version)"
-        echo "::set-output name=version::$(cat .go-version)"
+        echo "version=$(cat .go-version)" >> $GITHUB_OUTPUT

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,7 +64,7 @@ jobs:
           echo "
           
           Raw version is ${RAW_VERSION}"
-          echo "::set-output name=raw-version::${RAW_VERSION}"
+          echo "raw-version=${RAW_VERSION}" >> $GITHUB_OUTPUT
       - name: Decide version number
         id: get-product-version
         shell: bash


### PR DESCRIPTION
GithubActions gives warnings that set-output is deprecated.  This change gets rid of these warnings:

```
The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
```
## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.4.x

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

###  BUG FIXES 

After this change GithubAction shouldn't warn.
<!--

Write a short description of the user-facing change. Examples:

- `terraform show -json`: Fixed crash with sensitive set values.
- When rendering a diff, Terraform now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 

-  
