### PR TITLE
Clean up handling of check-related graph nodes

### DIFF
--- a/internal/plans/changes_sync.go
+++ b/internal/plans/changes_sync.go
@@ -21,24 +21,6 @@ type ChangesSync struct {
 	changes *Changes
 }
 
-// IsFullDestroy returns true if the set of changes indicates we are doing a
-// destroy of all resources.
-func (cs *ChangesSync) IsFullDestroy() bool {
-	if cs == nil {
-		panic("FullDestroy on nil ChangesSync")
-	}
-	cs.lock.Lock()
-	defer cs.lock.Unlock()
-
-	for _, c := range cs.changes.Resources {
-		if c.Action != Delete {
-			return false
-		}
-	}
-
-	return true
-}
-
 // AppendResourceInstanceChange records the given resource instance change in
 // the set of planned resource changes.
 //

--- a/internal/plans/plan.go
+++ b/internal/plans/plan.go
@@ -28,6 +28,11 @@ type Plan struct {
 	// to the end-user, and so it must not be used to influence apply-time
 	// behavior. The actions during apply must be described entirely by
 	// the Changes field, regardless of how the plan was created.
+	//
+	// FIXME: destroy operations still rely on DestroyMode being set, because
+	// there is no other source of this information in the plan. New behavior
+	// should not be added based on this flag, and changing the flag should be
+	// checked carefully against existing destroy behaviors.
 	UIMode Mode
 
 	VariableValues    map[string]DynamicValue

--- a/internal/terraform/context.go
+++ b/internal/terraform/context.go
@@ -15,8 +15,6 @@ import (
 	"github.com/hashicorp/terraform/internal/states"
 	"github.com/hashicorp/terraform/internal/tfdiags"
 	"github.com/zclconf/go-cty/cty"
-
-	_ "github.com/hashicorp/terraform/internal/logging"
 )
 
 // InputMode defines what sort of input will be asked for when Input

--- a/internal/terraform/context_apply2_test.go
+++ b/internal/terraform/context_apply2_test.go
@@ -1485,3 +1485,105 @@ resource "test_object" "y" {
 	_, diags = ctx.Apply(plan, m)
 	assertNoErrors(t, diags)
 }
+
+// Outputs should not cause evaluation errors during destroy
+// Check eval from both root level outputs and module outputs, which are
+// handled differently during apply.
+func TestContext2Apply_outputsNotToEvaluate(t *testing.T) {
+	m := testModuleInline(t, map[string]string{
+		"main.tf": `
+module "mod" {
+  source = "./mod"
+  cond = false
+}
+
+output "from_resource" {
+  value = module.mod.from_resource
+}
+
+output "from_data" {
+  value = module.mod.from_data
+}
+`,
+
+		"./mod/main.tf": `
+variable "cond" {
+  type = bool
+}
+
+module "mod" {
+  source = "../mod2/"
+  cond = var.cond
+}
+
+output "from_resource" {
+  value = module.mod.resource
+}
+
+output "from_data" {
+  value = module.mod.data
+}
+`,
+
+		"./mod2/main.tf": `
+variable "cond" {
+  type = bool
+}
+
+resource "test_object" "x" {
+  count = var.cond ? 0:1
+}
+
+data "test_object" "d" {
+  count = var.cond ? 0:1
+}
+
+output "resource" {
+  value = var.cond ? null : test_object.x.*.test_string[0]
+}
+
+output "data" {
+  value = one(data.test_object.d[*].test_string)
+}
+`})
+
+	p := simpleMockProvider()
+	p.ReadDataSourceFn = func(req providers.ReadDataSourceRequest) (resp providers.ReadDataSourceResponse) {
+		resp.State = req.Config
+		return resp
+	}
+
+	ctx := testContext2(t, &ContextOpts{
+		Providers: map[addrs.Provider]providers.Factory{
+			addrs.NewDefaultProvider("test"): testProviderFuncFixed(p),
+		},
+	})
+
+	// apply the state
+	opts := SimplePlanOpts(plans.NormalMode, nil)
+	plan, diags := ctx.Plan(m, states.NewState(), opts)
+	assertNoErrors(t, diags)
+
+	state, diags := ctx.Apply(plan, m)
+	assertNoErrors(t, diags)
+
+	// and destroy
+	opts = SimplePlanOpts(plans.DestroyMode, nil)
+	plan, diags = ctx.Plan(m, state, opts)
+	assertNoErrors(t, diags)
+
+	state, diags = ctx.Apply(plan, m)
+	assertNoErrors(t, diags)
+
+	// and destroy again with no state
+	if !state.Empty() {
+		t.Fatal("expected empty state, got", state)
+	}
+
+	opts = SimplePlanOpts(plans.DestroyMode, nil)
+	plan, diags = ctx.Plan(m, state, opts)
+	assertNoErrors(t, diags)
+
+	_, diags = ctx.Apply(plan, m)
+	assertNoErrors(t, diags)
+}

--- a/internal/terraform/context_plan.go
+++ b/internal/terraform/context_plan.go
@@ -336,9 +336,9 @@ func (c *Context) destroyPlan(config *configs.Config, prevRunState *states.State
 	// to work within our current structure.
 	if !opts.SkipRefresh && !prevRunState.Empty() {
 		log.Printf("[TRACE] Context.destroyPlan: calling Context.plan to get the effect of refreshing the prior state")
-		normalOpts := *opts
-		normalOpts.Mode = plans.RefreshOnlyMode
-		refreshPlan, refreshDiags := c.refreshOnlyPlan(config, prevRunState, &normalOpts)
+		refreshOpts := *opts
+		refreshOpts.Mode = plans.RefreshOnlyMode
+		refreshPlan, refreshDiags := c.refreshOnlyPlan(config, prevRunState, &refreshOpts)
 		if refreshDiags.HasErrors() {
 			// NOTE: Normally we'd append diagnostics regardless of whether
 			// there are errors, just in case there are warnings we'd want to

--- a/internal/terraform/context_plan.go
+++ b/internal/terraform/context_plan.go
@@ -334,11 +334,11 @@ func (c *Context) destroyPlan(config *configs.Config, prevRunState *states.State
 	// must coordinate with this by taking that action only when c.skipRefresh
 	// _is_ set. This coupling between the two is unfortunate but necessary
 	// to work within our current structure.
-	if !opts.SkipRefresh {
+	if !opts.SkipRefresh && !prevRunState.Empty() {
 		log.Printf("[TRACE] Context.destroyPlan: calling Context.plan to get the effect of refreshing the prior state")
 		normalOpts := *opts
-		normalOpts.Mode = plans.NormalMode
-		refreshPlan, refreshDiags := c.plan(config, prevRunState, &normalOpts)
+		normalOpts.Mode = plans.RefreshOnlyMode
+		refreshPlan, refreshDiags := c.refreshOnlyPlan(config, prevRunState, &normalOpts)
 		if refreshDiags.HasErrors() {
 			// NOTE: Normally we'd append diagnostics regardless of whether
 			// there are errors, just in case there are warnings we'd want to

--- a/internal/terraform/evaluate.go
+++ b/internal/terraform/evaluate.go
@@ -728,7 +728,7 @@ func (d *evaluationStateData) GetResource(addr addrs.Resource, rng tfdiags.Sourc
 
 	// Decode all instances in the current state
 	instances := map[addrs.InstanceKey]cty.Value{}
-	pendingDestroy := d.Evaluator.Changes.IsFullDestroy()
+	pendingDestroy := d.Operation == walkDestroy
 	for key, is := range rs.Instances {
 		if is == nil || is.Current == nil {
 			// Assume we're dealing with an instance that hasn't been created yet.

--- a/internal/terraform/graph.go
+++ b/internal/terraform/graph.go
@@ -106,7 +106,7 @@ func (g *Graph) walk(walker GraphWalker) tfdiags.Diagnostics {
 					diags = diags.Append(tfdiags.Sourceless(
 						tfdiags.Error,
 						"Graph node has invalid dynamic subgraph",
-						fmt.Sprintf("The internal logic for %q generated an invalid dynamic subgraph: the root node is %T, which is not a suitable root node type.\n\nThis is a bug in Terraform. Please report it!", dag.VertexName(v), v),
+						fmt.Sprintf("The internal logic for %q generated an invalid dynamic subgraph: the root node is %T, which is not a suitable root node type.\n\nThis is a bug in Terraform. Please report it!", dag.VertexName(v), n),
 					))
 					return
 				}

--- a/internal/terraform/graph_builder_apply.go
+++ b/internal/terraform/graph_builder_apply.go
@@ -97,7 +97,7 @@ func (b *ApplyGraphBuilder) Steps() []GraphTransformer {
 		&LocalTransformer{Config: b.Config},
 		&OutputTransformer{
 			Config:       b.Config,
-			destroyApply: b.Operation == walkDestroy,
+			DestroyApply: b.Operation == walkDestroy,
 		},
 
 		// Creates all the resource instances represented in the diff, along

--- a/internal/terraform/graph_builder_apply.go
+++ b/internal/terraform/graph_builder_apply.go
@@ -97,7 +97,6 @@ func (b *ApplyGraphBuilder) Steps() []GraphTransformer {
 		&LocalTransformer{Config: b.Config},
 		&OutputTransformer{
 			Config:       b.Config,
-			Changes:      b.Changes,
 			destroyApply: b.Operation == walkDestroy,
 		},
 

--- a/internal/terraform/graph_builder_apply.go
+++ b/internal/terraform/graph_builder_apply.go
@@ -46,6 +46,9 @@ type ApplyGraphBuilder struct {
 	// The apply step refers to these as part of verifying that the planned
 	// actions remain consistent between plan and apply.
 	ForceReplace []addrs.AbsResourceInstance
+
+	// Plan Operation this graph will be used for.
+	Operation walkOperation
 }
 
 // See GraphBuilder
@@ -92,7 +95,11 @@ func (b *ApplyGraphBuilder) Steps() []GraphTransformer {
 		&RootVariableTransformer{Config: b.Config, RawValues: b.RootVariableValues},
 		&ModuleVariableTransformer{Config: b.Config},
 		&LocalTransformer{Config: b.Config},
-		&OutputTransformer{Config: b.Config, Changes: b.Changes},
+		&OutputTransformer{
+			Config:       b.Config,
+			Changes:      b.Changes,
+			destroyApply: b.Operation == walkDestroy,
+		},
 
 		// Creates all the resource instances represented in the diff, along
 		// with dependency edges against the whole-resource nodes added by

--- a/internal/terraform/graph_builder_apply.go
+++ b/internal/terraform/graph_builder_apply.go
@@ -97,7 +97,7 @@ func (b *ApplyGraphBuilder) Steps() []GraphTransformer {
 		&LocalTransformer{Config: b.Config},
 		&OutputTransformer{
 			Config:       b.Config,
-			DestroyApply: b.Operation == walkDestroy,
+			ApplyDestroy: b.Operation == walkDestroy,
 		},
 
 		// Creates all the resource instances represented in the diff, along

--- a/internal/terraform/graph_builder_apply.go
+++ b/internal/terraform/graph_builder_apply.go
@@ -142,7 +142,9 @@ func (b *ApplyGraphBuilder) Steps() []GraphTransformer {
 		&ForcedCBDTransformer{},
 
 		// Destruction ordering
-		&DestroyEdgeTransformer{},
+		&DestroyEdgeTransformer{
+			Changes: b.Changes,
+		},
 		&CBDEdgeTransformer{
 			Config: b.Config,
 			State:  b.State,

--- a/internal/terraform/graph_builder_eval.go
+++ b/internal/terraform/graph_builder_eval.go
@@ -67,7 +67,10 @@ func (b *EvalGraphBuilder) Steps() []GraphTransformer {
 		&RootVariableTransformer{Config: b.Config, RawValues: b.RootVariableValues},
 		&ModuleVariableTransformer{Config: b.Config},
 		&LocalTransformer{Config: b.Config},
-		&OutputTransformer{Config: b.Config},
+		&OutputTransformer{
+			Config:   b.Config,
+			Planning: true,
+		},
 
 		// Attach the configuration to any resources
 		&AttachResourceConfigTransformer{Config: b.Config},

--- a/internal/terraform/graph_builder_plan.go
+++ b/internal/terraform/graph_builder_plan.go
@@ -110,9 +110,9 @@ func (b *PlanGraphBuilder) Steps() []GraphTransformer {
 		&ModuleVariableTransformer{Config: b.Config},
 		&LocalTransformer{Config: b.Config},
 		&OutputTransformer{
-			Config:            b.Config,
-			RefreshOnly:       b.skipPlanChanges,
-			removeRootOutputs: b.Operation == walkPlanDestroy,
+			Config:      b.Config,
+			RefreshOnly: b.skipPlanChanges,
+			DestroyPlan: b.Operation == walkPlanDestroy,
 
 			// NOTE: We currently treat anything built with the plan graph
 			// builder as "planning" for our purposes here, because we share

--- a/internal/terraform/graph_builder_plan.go
+++ b/internal/terraform/graph_builder_plan.go
@@ -112,7 +112,7 @@ func (b *PlanGraphBuilder) Steps() []GraphTransformer {
 		&OutputTransformer{
 			Config:      b.Config,
 			RefreshOnly: b.skipPlanChanges,
-			DestroyPlan: b.Operation == walkPlanDestroy,
+			PlanDestroy: b.Operation == walkPlanDestroy,
 
 			// NOTE: We currently treat anything built with the plan graph
 			// builder as "planning" for our purposes here, because we share

--- a/internal/terraform/node_output.go
+++ b/internal/terraform/node_output.go
@@ -23,8 +23,8 @@ type nodeExpandOutput struct {
 	Addr         addrs.OutputValue
 	Module       addrs.Module
 	Config       *configs.Output
-	DestroyPlan  bool
-	DestroyApply bool
+	PlanDestroy  bool
+	ApplyDestroy bool
 	RefreshOnly  bool
 
 	// Planning is set to true when this node is in a graph that was produced
@@ -100,12 +100,12 @@ func (n *nodeExpandOutput) DynamicExpand(ctx EvalContext) (*Graph, error) {
 
 		var node dag.Vertex
 		switch {
-		case module.IsRoot() && (n.DestroyPlan || n.DestroyApply):
+		case module.IsRoot() && (n.PlanDestroy || n.ApplyDestroy):
 			node = &NodeDestroyableOutput{
 				Addr: absAddr,
 			}
 
-		case n.DestroyPlan:
+		case n.PlanDestroy:
 			// nothing is done here for non-root outputs
 			continue
 
@@ -115,7 +115,7 @@ func (n *nodeExpandOutput) DynamicExpand(ctx EvalContext) (*Graph, error) {
 				Config:       n.Config,
 				Change:       change,
 				RefreshOnly:  n.RefreshOnly,
-				DestroyApply: n.DestroyApply,
+				DestroyApply: n.ApplyDestroy,
 			}
 		}
 
@@ -181,7 +181,7 @@ func (n *nodeExpandOutput) ReferenceOutside() (selfPath, referencePath addrs.Mod
 // GraphNodeReferencer
 func (n *nodeExpandOutput) References() []*addrs.Reference {
 	// DestroyNodes do not reference anything.
-	if n.Module.IsRoot() && n.DestroyApply {
+	if n.Module.IsRoot() && n.ApplyDestroy {
 		return nil
 	}
 

--- a/internal/terraform/transform_destroy_edge.go
+++ b/internal/terraform/transform_destroy_edge.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/dag"
+	"github.com/hashicorp/terraform/internal/plans"
 )
 
 // GraphNodeDestroyer must be implemented by nodes that destroy resources.
@@ -37,7 +38,15 @@ type GraphNodeCreator interface {
 // dependent resources will block parent resources from deleting. Concrete
 // example: VPC with subnets, the VPC can't be deleted while there are
 // still subnets.
-type DestroyEdgeTransformer struct{}
+type DestroyEdgeTransformer struct {
+	// FIXME: GraphNodeCreators are not always applying changes, and should not
+	// participate in the destroy graph if there are no operations which could
+	// interract with destroy nodes. We need Changes for now to detect the
+	// action type, but perhaps this should be indicated somehow by the
+	// DiffTransformer which was intended to be the only transformer operating
+	// from the change set.
+	Changes *plans.Changes
+}
 
 // tryInterProviderDestroyEdge checks if we're inserting a destroy edge
 // across a provider boundary, and only adds the edge if it results in no cycles.
@@ -144,8 +153,20 @@ func (t *DestroyEdgeTransformer) Transform(g *Graph) error {
 			resAddr := addr.ContainingResource().Config().String()
 			destroyersByResource[resAddr] = append(destroyersByResource[resAddr], n)
 		case GraphNodeCreator:
-			addr := n.CreateAddr().ContainingResource().Config().String()
-			creators[addr] = append(creators[addr], n)
+			addr := n.CreateAddr()
+			cfgAddr := addr.ContainingResource().Config().String()
+
+			if t.Changes == nil {
+				// unit tests may not have changes
+				creators[cfgAddr] = append(creators[cfgAddr], n)
+				break
+			}
+
+			// NoOp changes should not participate in the destroy dependencies.
+			rc := t.Changes.ResourceInstance(*addr)
+			if rc != nil && rc.Action != plans.NoOp {
+				creators[cfgAddr] = append(creators[cfgAddr], n)
+			}
 		}
 	}
 

--- a/internal/terraform/transform_destroy_edge_test.go
+++ b/internal/terraform/transform_destroy_edge_test.go
@@ -383,8 +383,7 @@ func TestPruneUnusedNodesTransformer_rootModuleOutputValues(t *testing.T) {
 				Config:   config,
 			},
 			&OutputTransformer{
-				Config:  config,
-				Changes: changes,
+				Config: config,
 			},
 			&DiffTransformer{
 				Concrete: concreteResourceInstance,

--- a/internal/terraform/transform_output.go
+++ b/internal/terraform/transform_output.go
@@ -92,12 +92,13 @@ func (t *OutputTransformer) transform(g *Graph, c *configs.Config) error {
 
 		default:
 			node = &nodeExpandOutput{
-				Addr:        addr,
-				Module:      c.Path,
-				Config:      o,
-				Destroy:     t.removeRootOutputs,
-				RefreshOnly: t.RefreshOnly,
-				Planning:    t.Planning,
+				Addr:         addr,
+				Module:       c.Path,
+				Config:       o,
+				DestroyPlan:  t.removeRootOutputs,
+				DestroyApply: t.destroyApply,
+				RefreshOnly:  t.RefreshOnly,
+				Planning:     t.Planning,
 			}
 		}
 

--- a/internal/terraform/transform_output.go
+++ b/internal/terraform/transform_output.go
@@ -26,11 +26,11 @@ type OutputTransformer struct {
 
 	// If this is a planned destroy, root outputs are still in the configuration
 	// so we need to record that we wish to remove them
-	DestroyPlan bool
+	PlanDestroy bool
 
-	// DestroyApply indicates that this is being added to an apply graph, which
+	// ApplyDestroy indicates that this is being added to an apply graph, which
 	// is the result of a destroy plan.
-	DestroyApply bool
+	ApplyDestroy bool
 }
 
 func (t *OutputTransformer) Transform(g *Graph) error {
@@ -59,8 +59,8 @@ func (t *OutputTransformer) transform(g *Graph, c *configs.Config) error {
 			Addr:         addr,
 			Module:       c.Path,
 			Config:       o,
-			DestroyPlan:  t.DestroyPlan,
-			DestroyApply: t.DestroyApply,
+			PlanDestroy:  t.PlanDestroy,
+			ApplyDestroy: t.ApplyDestroy,
 			RefreshOnly:  t.RefreshOnly,
 			Planning:     t.Planning,
 		}

--- a/internal/terraform/transform_output.go
+++ b/internal/terraform/transform_output.go
@@ -16,10 +16,6 @@ import (
 type OutputTransformer struct {
 	Config *configs.Config
 
-	// If this is a planned destroy, root outputs are still in the configuration
-	// so we need to record that we wish to remove them
-	removeRootOutputs bool
-
 	// Refresh-only mode means that any failing output preconditions are
 	// reported as warnings rather than errors
 	RefreshOnly bool
@@ -28,9 +24,13 @@ type OutputTransformer struct {
 	// It must be set to false whenever we're building an apply graph.
 	Planning bool
 
-	// destroyApply indicates that this is being added to an apply graph, which
+	// If this is a planned destroy, root outputs are still in the configuration
+	// so we need to record that we wish to remove them
+	DestroyPlan bool
+
+	// DestroyApply indicates that this is being added to an apply graph, which
 	// is the result of a destroy plan.
-	destroyApply bool
+	DestroyApply bool
 }
 
 func (t *OutputTransformer) Transform(g *Graph) error {
@@ -59,8 +59,8 @@ func (t *OutputTransformer) transform(g *Graph, c *configs.Config) error {
 			Addr:         addr,
 			Module:       c.Path,
 			Config:       o,
-			DestroyPlan:  t.removeRootOutputs,
-			DestroyApply: t.destroyApply,
+			DestroyPlan:  t.DestroyPlan,
+			DestroyApply: t.DestroyApply,
 			RefreshOnly:  t.RefreshOnly,
 			Planning:     t.Planning,
 		}

--- a/internal/terraform/transform_output.go
+++ b/internal/terraform/transform_output.go
@@ -30,6 +30,10 @@ type OutputTransformer struct {
 	// Planning must be set to true only when we're building a planning graph.
 	// It must be set to false whenever we're building an apply graph.
 	Planning bool
+
+	// destroyApply indicates that this is being added to an apply graph, which
+	// is the result of a destroy plan.
+	destroyApply bool
 }
 
 func (t *OutputTransformer) Transform(g *Graph) error {


### PR DESCRIPTION
This covers a number of various loosely related issues all stemming from the condition checks handling in outputs and NoOp resource nodes:

 - Optimally the apply graph operation should not need extra knowledge from how the plan was created, as normal, refresh, or destroy plan. The serialized plan however does not have the information necessary to make this a reality. With the addition of conditions on outputs, output nodes need to be aware of the current phase of operation to know whether to register, evaluate, or ignore the conditions in the config. Resource evaluation also requires knowing if a full destroy in effect to determine how to evaluate resources pending removal in a full destroy when a provider required them for configuration. The existing workaround of checking for only `Delete` actions no longer works, and we must again depend on the `walkOperation`. Add the plan's `walkOperation` via the plan to the graph builder, and make use of it as necessary in the various transformers. If we aim for a change set which retains the full fidelity of all objects used during the plan, then we can review the removal of the `walkOperation` based logic.

 - Output conditions should not be checked during a full destroy. The conditions may no longer be satisfied or even valid due to the overall destroy. We can use the new `walkOperation` information to determine when checks can be skipped. One thing which is not clear here is whether condition references should be skipped during destroy as well. It seems that they should be fine as the graph must have been correct initially, but because they don't participate in the data flow, there is chance that they could interfere with a full destroy which involves intermediary providers.

 - Replacing the root outputs with an expansion node was not complete, and singular nodes could have been inserted skipping the registrations of the condition checks. Outputs are the only type which accounts for most types of actions during all phases with a single node, so `nodeExpandOutput` must have all the same graph-building information to make the decision about what node types to return and how to evaluate checks.

 - Checks are not needed during console eval, but rather than inserting another exception path for their evaluation, we just make sure that they are registered to prevent panics.

- The `destroy` plan must refresh before creating the destroy graph, but was using a normal plan to do so. We can switch that to a `RefreshOnly` plan to prevent the unnecessary evaluation and planning of resources.

 - NoOp resource nodes should not be participating in destroy sequences. Now that they are always included in the graph, we need to check the change action to make sure not to introduce unneeded edges into the sequence. This is again especially important when destroy sequences have intermediary providers which are not at the graph root.

Fixes #31975
Fixes #31994
Fixes #32006
Fixes #32023