### PR TITLE
Fixing s3.mdx on Delegating Access

### DIFF
--- a/website/docs/language/settings/backends/s3.mdx
+++ b/website/docs/language/settings/backends/s3.mdx
@@ -312,7 +312,7 @@ provider "aws" {
   # No credentials explicitly set here because they come from either the
   # environment or the global credentials file.
 
-  assume_role = {
+  assume_role {
     role_arn = "${var.workspace_iam_roles[terraform.workspace]}"
   }
 }


### PR DESCRIPTION
There was a syntax error on the example.  
`assume_role = {}` doesn't work, it should be `assume_role {}`

Fixes #

## Target Release

1.4.x

## Draft CHANGELOG entry

### ENHANCEMENTS

