### PR TITLE
docs: update splat expressions in directives

### DIFF
--- a/website/docs/language/expressions/strings.mdx
+++ b/website/docs/language/expressions/strings.mdx
@@ -180,7 +180,7 @@ The following directives are supported:
 
   ```hcl
   <<EOT
-  %{ for ip in aws_instance.example.*.private_ip }
+  %{ for ip in aws_instance.example[*].private_ip }
   server ${ip}
   %{ endfor }
   EOT
@@ -201,7 +201,7 @@ marker appears at the end):
 
 ```hcl
 <<EOT
-%{ for ip in aws_instance.example.*.private_ip ~}
+%{ for ip in aws_instance.example[*].private_ip ~}
 server ${ip}
 %{ endfor ~}
 EOT


### PR DESCRIPTION
Updates the `Expressions > Strings and Templates` docs to use the recommend [splat expression](https://developer.hashicorp.com/terraform/language/expressions/splat) syntax, with square brackets. While Terraform continues to support the `.*` syntax for resources with `count`, the docs describe them as "legacy 'attribute-only' splat expressions."

For good measure, I tested to confirm this works:

```tf
output "ips" {
  value = <<-EOF
    %{ for ip in aws_instance.example[*].private_ip }
    server ${ip}
    %{ endfor }
  EOF
}

resource "aws_instance" "example" {
  count = 2
  instance_type = "t3.nano"
  ami = "ami-0d593311db5abb72b"
}
```

```
Apply complete! Resources: 2 added, 0 changed, 0 destroyed.

Outputs:

ips = <<EOT

server 172.31.52.27

server 172.31.53.123


EOT
```