### PR TITLE
Update CONTRIBUTING.md

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -2,14 +2,6 @@
 
 This repository contains only Terraform core, which includes the command line interface and the main graph engine. Providers are implemented as plugins that each have their own repository linked from the [Terraform Registry index](https://registry.terraform.io/browse/providers). Instructions for developing each provider are usually in the associated README file. For more information, see [the provider development overview](https://www.terraform.io/docs/plugins/provider.html).
 
----
-
-**Note:** Due to current low staffing on the Terraform Core team at HashiCorp, **we are not routinely reviewing and merging community-submitted pull requests**. We do hope to begin processing them again soon once we're back up to full staffing again, but for the moment we need to ask for patience. Thanks!
-
-**Additional note:**  The intent of the prior comment was to provide clarity for the community around what to expect for a small part of the work related to Terraform. This does not affect other PR reviews, such as those for Terraform providers. We expect that the relevant team will be appropriately staffed within the coming weeks, which should allow us to get back to normal community PR review practices. For the broader context and information on HashiCorp’s continued commitment to and investment in Terraform, see [this blog post](https://www.hashicorp.com/blog/terraform-community-contributions).
-
----
-
 **All communication on GitHub, the community forum, and other HashiCorp-provided communication channels is subject to [the HashiCorp community guidelines](https://www.hashicorp.com/community-guidelines).**
 
 This document provides guidance on Terraform contribution recommended practices. It covers what we're looking for in order to help set some expectations and help you get the most out of participation in this project. 


### PR DESCRIPTION
The Terraform team has removed a [statement from Aug 2021](https://github.com/hashicorp/terraform/commit/ad634f60a5acbaade1eb8c225564e17ad2267f00) from our CONTRIBUTORS.md, which does not reflect the current status for reviews of community-contributed pull requests.

The HashiCorp team actively encourages contributions, and the Terraform core team has been actively reviewing community-contributed pull requests, as well as reviewing every issue, working actively to close reported bugs, and use the list of the most-voted feature requests to inform our roadmap planning. We deeply value your comments, issues, and code contributions, and are committed to making sure your voice is heard.