### PR TITLE
Added Quiet value

### DIFF
--- a/internal/builtin/provisioners/local-exec/resource_provisioner.go
+++ b/internal/builtin/provisioners/local-exec/resource_provisioner.go
@@ -171,7 +171,7 @@ func (p *provisioner) ProvisionResource(req provisioners.ProvisionResourceReques
 	// if quiet is set, output Executing: Suppressed by quiet=true
 	if quietVal := req.Config.GetAttr("quiet"); !quietVal.IsNull() && quietVal.True() {
 		// If quiet is true, don't output the command
-		req.UIOutput.Output(fmt.Sprint("local-exec: Executing: Suppressed by quiet=true"))
+		req.UIOutput.Output("local-exec: Executing: Suppressed by quiet=true")
 	} else {
 		req.UIOutput.Output(fmt.Sprintf("local-exec: Executing: %s", command))
 	}

--- a/internal/builtin/provisioners/local-exec/resource_provisioner.go
+++ b/internal/builtin/provisioners/local-exec/resource_provisioner.go
@@ -167,10 +167,7 @@ func (p *provisioner) ProvisionResource(req provisioners.ProvisionResourceReques
 	go copyUIOutput(req.UIOutput, tee, copyDoneCh)
 
 	// Output what we're about to run
-	// if quiet is not set, output the command we're about to run
-	// if quiet is set, output Executing: Suppressed by quiet=true
 	if quietVal := req.Config.GetAttr("quiet"); !quietVal.IsNull() && quietVal.True() {
-		// If quiet is true, don't output the command
 		req.UIOutput.Output("local-exec: Executing: Suppressed by quiet=true")
 	} else {
 		req.UIOutput.Output(fmt.Sprintf("Executing: %q", cmdargs))

--- a/internal/builtin/provisioners/local-exec/resource_provisioner.go
+++ b/internal/builtin/provisioners/local-exec/resource_provisioner.go
@@ -173,7 +173,7 @@ func (p *provisioner) ProvisionResource(req provisioners.ProvisionResourceReques
 		// If quiet is true, don't output the command
 		req.UIOutput.Output("local-exec: Executing: Suppressed by quiet=true")
 	} else {
-		req.UIOutput.Output(fmt.Sprintf("local-exec: Executing: %s", command))
+		req.UIOutput.Output(fmt.Sprintf("Executing: %q", cmdargs))
 	}
 
 	// Start the command


### PR DESCRIPTION
Added Quiet value in order to quiet the output from local-exec
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Fixes #32097 

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.4.x

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

### NEW FEATURES | UPGRADE NOTES | ENHANCEMENTS | BUG FIXES | EXPERIMENTS

<!--

Write a short description of the user-facing change. Examples:

- `terraform show -json`: Fixed crash with sensitive set values.
- When rendering a diff, Terraform now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 

-  
