### PR TITLE
Apply optimizations for handling of condition checks

### DIFF
--- a/internal/states/statefile/version4.go
+++ b/internal/states/statefile/version4.go
@@ -414,9 +414,7 @@ func writeStateV4(file *File, w io.Writer) tfdiags.Diagnostics {
 		}
 	}
 
-	if file.State.CheckResults != nil {
-		sV4.CheckResults = encodeCheckResultsV4(file.State.CheckResults)
-	}
+	sV4.CheckResults = encodeCheckResultsV4(file.State.CheckResults)
 
 	sV4.normalize()
 
@@ -576,6 +574,11 @@ func decodeCheckResultsV4(in []checkResultsV4) (*states.CheckResults, tfdiags.Di
 }
 
 func encodeCheckResultsV4(in *states.CheckResults) []checkResultsV4 {
+	// normalize empty and nil sets in the serialized state
+	if in == nil || in.ConfigResults.Len() == 0 {
+		return nil
+	}
+
 	ret := make([]checkResultsV4, 0, in.ConfigResults.Len())
 
 	for _, configElem := range in.ConfigResults.Elems {

--- a/internal/terraform/context_apply.go
+++ b/internal/terraform/context_apply.go
@@ -25,6 +25,10 @@ func (c *Context) Apply(plan *plans.Plan, config *configs.Config) (*states.State
 
 	log.Printf("[DEBUG] Building and walking apply graph for %s plan", plan.UIMode)
 
+	// FIXME: refresh plans still store outputs as changes, so we can't use
+	// Empty()
+	possibleRefresh := len(plan.Changes.Resources) == 0
+
 	graph, operation, diags := c.applyGraph(plan, config, true)
 	if diags.HasErrors() {
 		return nil, diags
@@ -77,7 +81,7 @@ Note that the -target option is not suitable for routine use, and is provided on
 	// cleanup is going to be needed to make the plan state match what apply
 	// would do. For now we can copy the checks over which were overwritten
 	// during the apply walk.
-	if len(plan.Changes.Resources) == 0 {
+	if possibleRefresh {
 		newState.CheckResults = plan.Checks.DeepCopy()
 	}
 

--- a/internal/terraform/context_apply.go
+++ b/internal/terraform/context_apply.go
@@ -69,6 +69,18 @@ Note that the -target option is not suitable for routine use, and is provided on
 		))
 	}
 
+	// FIXME: we cannot check for an empty plan for refresh-only, because root
+	// outputs are always stored as changes. The final condition of the state
+	// also depends on some cleanup which happens during the apply walk. It
+	// would probably make more sense if applying a refresh-only plan were
+	// simply just returning the planned state and checks, but some extra
+	// cleanup is going to be needed to make the plan state match what apply
+	// would do. For now we can copy the checks over which were overwritten
+	// during the apply walk.
+	if len(plan.Changes.Resources) == 0 {
+		newState.CheckResults = plan.Checks.DeepCopy()
+	}
+
 	return newState, diags
 }
 

--- a/internal/terraform/graph_builder_apply.go
+++ b/internal/terraform/graph_builder_apply.go
@@ -107,6 +107,7 @@ func (b *ApplyGraphBuilder) Steps() []GraphTransformer {
 			Concrete: concreteResourceInstance,
 			State:    b.State,
 			Changes:  b.Changes,
+			Config:   b.Config,
 		},
 
 		// Attach the state

--- a/internal/terraform/node_resource_apply_instance.go
+++ b/internal/terraform/node_resource_apply_instance.go
@@ -271,7 +271,7 @@ func (n *NodeApplyableResourceInstance) managedResourceExecute(ctx EvalContext) 
 
 	// Make a new diff, in case we've learned new values in the state
 	// during apply which we can now incorporate.
-	diffApply, _, _, planDiags := n.plan(ctx, diff, state, false, n.forceReplace)
+	diffApply, _, repeatData, planDiags := n.plan(ctx, diff, state, false, n.forceReplace)
 	diags = diags.Append(planDiags)
 	if diags.HasErrors() {
 		return diags
@@ -294,12 +294,6 @@ func (n *NodeApplyableResourceInstance) managedResourceExecute(ctx EvalContext) 
 	diags = diags.Append(n.preApplyHook(ctx, diffApply))
 	if diags.HasErrors() {
 		return diags
-	}
-
-	var repeatData instances.RepetitionData
-	if n.Config != nil {
-		forEach, _ := evaluateForEachExpression(n.Config.ForEach, ctx)
-		repeatData = EvalDataForInstanceKey(n.ResourceInstanceAddr().Resource.Key, forEach)
 	}
 
 	// If there is no change, there was nothing to apply, and we don't need to

--- a/internal/terraform/node_resource_destroy.go
+++ b/internal/terraform/node_resource_destroy.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 
+	"github.com/hashicorp/terraform/internal/instances"
 	"github.com/hashicorp/terraform/internal/plans"
 	"github.com/hashicorp/terraform/internal/tfdiags"
 
@@ -210,7 +211,7 @@ func (n *NodeDestroyResourceInstance) managedResourceExecute(ctx EvalContext) (d
 	// Managed resources need to be destroyed, while data sources
 	// are only removed from state.
 	// we pass a nil configuration to apply because we are destroying
-	s, _, d := n.apply(ctx, state, changeApply, nil, false)
+	s, d := n.apply(ctx, state, changeApply, nil, instances.RepetitionData{}, false)
 	state, diags = s, diags.Append(d)
 	// we don't return immediately here on error, so that the state can be
 	// finalized

--- a/internal/terraform/node_resource_destroy_deposed.go
+++ b/internal/terraform/node_resource_destroy_deposed.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/dag"
+	"github.com/hashicorp/terraform/internal/instances"
 	"github.com/hashicorp/terraform/internal/plans"
 	"github.com/hashicorp/terraform/internal/states"
 	"github.com/hashicorp/terraform/internal/tfdiags"
@@ -249,7 +250,7 @@ func (n *NodeDestroyDeposedResourceInstanceObject) Execute(ctx EvalContext, op w
 	}
 
 	// we pass a nil configuration to apply because we are destroying
-	state, _, applyDiags := n.apply(ctx, state, change, nil, false)
+	state, applyDiags := n.apply(ctx, state, change, nil, instances.RepetitionData{}, false)
 	diags = diags.Append(applyDiags)
 	// don't return immediately on errors, we need to handle the state
 

--- a/internal/terraform/transform_reference.go
+++ b/internal/terraform/transform_reference.go
@@ -136,7 +136,7 @@ func (t *ReferenceTransformer) Transform(g *Graph) error {
 			if !graphNodesAreResourceInstancesInDifferentInstancesOfSameModule(v, parent) {
 				g.Connect(dag.BasicEdge(v, parent))
 			} else {
-				log.Printf("[TRACE] ReferenceTransformer: skipping %s => %s inter-module-instance dependency", v, parent)
+				log.Printf("[TRACE] ReferenceTransformer: skipping %s => %s inter-module-instance dependency", dag.VertexName(v), dag.VertexName(parent))
 			}
 		}
 


### PR DESCRIPTION
The handling of conditions during apply can have adverse affects on very large configs, due to the handling of all existing instances even when there are no changes. With extremely large configurations, the execution time can go from a few minutes to many hours only for minor changes.

The first step is to ensure empty `CheckResults` in the state are normalized to prevent the state from being re-written when there are no semantic differences. Empty and nil slices are not handled consistently overall, but we will use an empty slice in the state zero value to match the other top-level structures.

Next we can skip adding NoOp changes to the apply graph when there are no conditions at all to evaluate from the configuration. The nodes themselves can have significant processing overhead when assembling the graph, especially for steps like recalculating individual instance dependencies.

Finally we need to avoid re-planning each instance and re-writing the state for every NoOp change during apply. The whole process has gotten more convoluted with the addition of condition checks, as preconditions are done during the `NodeAbstractResourceInstance.plan` method, but postconditions are handled outside of the abstract instance in the `NodeApplyableResourceInstance.managedResourceExecute` method, and repetition data needs to be shared between all these. I pulled the repetition data out of `apply` to simplify the early return in the short-term, but there is definitely some more refactoring to be done in this area.

Fixes #32060
Fixes #32071