### PR TITLE
feat: Encoding - Add a Base36Encode function

### DIFF
--- a/internal/lang/funcs/encoding_test.go
+++ b/internal/lang/funcs/encoding_test.go
@@ -8,6 +8,49 @@ import (
 	"github.com/zclconf/go-cty/cty"
 )
 
+func TestBase36Encode(t *testing.T) {
+	tests := []struct {
+		String cty.Value
+		Want   cty.Value
+		Err    bool
+	}{
+		{
+			cty.StringVal("this-is-a-test-role-123"),
+			cty.StringVal("3RTNWHNTGJWKXO3AZ8RE3AL39Y0SX8F09LPV"),
+			false,
+		},
+		{
+			cty.StringVal("abc123-_"),
+			cty.StringVal("1HBAY8J4QS76N"),
+			false,
+		},
+		{
+			cty.StringVal("123"),
+			cty.StringVal("1X3QR"),
+			false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("base36encode(%#v)", test.String), func(t *testing.T) {
+			got, err := Base36Encode(test.String)
+
+			if test.Err {
+				if err == nil {
+					t.Fatal("succeeded; want error")
+				}
+				return
+			} else if err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+
+			if !got.RawEquals(test.Want) {
+				t.Errorf("wrong result\ngot:  %#v\nwant: %#v", got, test.Want)
+			}
+		})
+	}
+}
+
 func TestBase64Decode(t *testing.T) {
 	tests := []struct {
 		String cty.Value


### PR DESCRIPTION
The goal of this PR is to provide a Base36Encode function to encode a string to a base36 sequence.

This is particularly useful for places like the trust policy generation in AWS IAM Roles when using EMR on EKS. The current implementation requires an external call to `aws emr-containers update-role-trust-policy` outside of Terraform which creates a perpetual diff when managing IAM Roles via Terraform.

See: https://docs.aws.amazon.com/emr/latest/EMR-on-EKS-DevelopmentGuide/iam-execution-role.html

```
{
  "Version": "2012-10-17",
  "Statement": [
    {
      "Effect": "Allow",
      "Principal": {
        "Federated": "arn:aws:iam::AWS_ACCOUNT_ID:oidc-provider/OIDC_PROVIDER"
      },
      "Action": "sts:AssumeRoleWithWebIdentity",
      "Condition": {
        "StringLike": {
          "OIDC_PROVIDER:sub": "system:serviceaccount:NAMESPACE:emr-containers-sa-*-*-AWS_ACCOUNT_ID-BASE36_ENCODED_ROLE_NAME"
        }
      }
    }
  ]
}
```

