### PR TITLE
fix typo in scp upload size check

### DIFF
--- a/internal/communicator/ssh/communicator.go
+++ b/internal/communicator/ssh/communicator.go
@@ -418,7 +418,7 @@ func (c *Communicator) Upload(path string, input io.Reader) error {
 	switch src := input.(type) {
 	case *os.File:
 		fi, err := src.Stat()
-		if err != nil {
+		if err == nil {
 			size = fi.Size()
 		}
 	case *bytes.Buffer:
@@ -641,7 +641,13 @@ func checkSCPStatus(r *bufio.Reader) error {
 	return nil
 }
 
+var testUploadSizeHook func(size int64)
+
 func scpUploadFile(dst string, src io.Reader, w io.Writer, r *bufio.Reader, size int64) error {
+	if testUploadSizeHook != nil {
+		testUploadSizeHook(size)
+	}
+
 	if size == 0 {
 		// Create a temporary file where we can copy the contents of the src
 		// so that we can determine the length, since SCP is length-prefixed.

--- a/internal/communicator/ssh/communicator_test.go
+++ b/internal/communicator/ssh/communicator_test.go
@@ -577,10 +577,28 @@ func TestAccUploadFile(t *testing.T) {
 	}
 
 	tmpDir := t.TempDir()
+	source, err := os.CreateTemp(tmpDir, "tempfile.in")
+	if err != nil {
+		t.Fatal(err)
+	}
 
-	content := []byte("this is the file content")
-	source := bytes.NewReader(content)
+	content := "this is the file content"
+	if _, err := source.WriteString(content); err != nil {
+		t.Fatal(err)
+	}
+	source.Seek(0, io.SeekStart)
+
 	tmpFile := filepath.Join(tmpDir, "tempFile.out")
+
+	testUploadSizeHook = func(size int64) {
+		if size != int64(len(content)) {
+			t.Errorf("expected %d bytes, got %d\n", len(content), size)
+		}
+	}
+	defer func() {
+		testUploadSizeHook = nil
+	}()
+
 	err = c.Upload(tmpFile, source)
 	if err != nil {
 		t.Fatalf("error uploading file: %s", err)
@@ -591,7 +609,7 @@ func TestAccUploadFile(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if !bytes.Equal(data, content) {
+	if string(data) != content {
 		t.Fatalf("bad: %s", data)
 	}
 }


### PR DESCRIPTION
The scp upload size check had a typo preventing files from reporting their size, causing an extra temp file to be created.

Fixes #32168