### PR TITLE
Ensure destroy plan contains valid state values

### DIFF
--- a/internal/terraform/context_plan2_test.go
+++ b/internal/terraform/context_plan2_test.go
@@ -3676,11 +3676,19 @@ output "out" {
 		},
 	})
 
-	_, diags := ctx.Plan(m, state, &PlanOpts{
+	plan, diags := ctx.Plan(m, state, &PlanOpts{
 		Mode: plans.DestroyMode,
 	})
 
 	assertNoErrors(t, diags)
+
+	// ensure that the given states are valid and can be serialized
+	if plan.PrevRunState == nil {
+		t.Fatal("nil plan.PrevRunState")
+	}
+	if plan.PriorState == nil {
+		t.Fatal("nil plan.PriorState")
+	}
 }
 
 // A deposed instances which no longer exists during ReadResource creates NoOp


### PR DESCRIPTION
Some prior refactors left the `destroyPlan` method a bit confusing, and ran into a case where the previous run state could be returned as `nil`. Get rid of the no longer used `pendingPlan` value, and track the prior and prev states directly, making sure we always have a value for both.

Fixes #32186