### PR TITLE
Add some clarification on Cloud workspace names and workspace tags

### DIFF
--- a/website/docs/cli/cloud/migrating.mdx
+++ b/website/docs/cli/cloud/migrating.mdx
@@ -28,10 +28,14 @@ multiple environments associated with the same configuration (e.g. production, s
 Terraform Cloud workspaces can represent totally independent configurations, and must have unique names within the Terraform Cloud organization.
 
 Because of this, Terraform will prompt you to rename the working directory's workspaces
-according to a pattern relative to their existing names. This can indicate the fact that these specific workspaces share configuration. A typical strategy is
-`<COMPONENT>-<ENVIRONMENT>-<REGION>` (e.g.,  `networking-prod-us-east`,
-`networking-staging-us-east`). Refer to [Workspace
-Naming](/cloud-docs/workspaces/naming) in the Terraform Cloud documentation for more detail.
+according to a pattern relative to their existing names. This name pattern can indicate the fact that
+these specific workspaces share a common configuration within the organization. But the main purpose is
+to ensure unique workspaces within the organization. A typical strategy is `<COMPONENT>-<ENVIRONMENT>-<REGION>`
+(e.g.,  `networking-prod-us-east`, `networking-staging-us-east`). The role of [Terraform Cloud workspace tags](/cli/cloud/settings#tags) on the
+other hand, is for grouping the Terraform Cloud workspaces, as presented by [the `terraform workspace list` command](/cli/commands/workspace/list).
+This relation between workspace names and workspace tags allow the possibility of two workspaces from
+different configurations to be shown under the same workspace list. `Refer to [Workspace Naming](/cloud-docs/workspaces/naming)
+in the Terraform Cloud documentation for more detail.
 
 ## Migrating from the `remote` Backend
 

--- a/website/docs/cli/cloud/migrating.mdx
+++ b/website/docs/cli/cloud/migrating.mdx
@@ -28,14 +28,14 @@ multiple environments associated with the same configuration (e.g. production, s
 Terraform Cloud workspaces can represent totally independent configurations, and must have unique names within the Terraform Cloud organization.
 
 Because of this, Terraform will prompt you to rename the working directory's workspaces
-according to a pattern relative to their existing names. This name pattern can indicate the fact that
-these specific workspaces share a common configuration within the organization. But the main purpose is
-to ensure unique workspaces within the organization. A typical strategy is `<COMPONENT>-<ENVIRONMENT>-<REGION>`
-(e.g.,  `networking-prod-us-east`, `networking-staging-us-east`). The role of [Terraform Cloud workspace tags](/cli/cloud/settings#tags) on the
-other hand, is for grouping the Terraform Cloud workspaces, as presented by [the `terraform workspace list` command](/cli/commands/workspace/list).
-This relation between workspace names and workspace tags allow the possibility of two workspaces from
-different configurations to be shown under the same workspace list. `Refer to [Workspace Naming](/cloud-docs/workspaces/naming)
-in the Terraform Cloud documentation for more detail.
+ to ensure that all workspaces in the organization are unique. You should implement a naming convention based on their existing names or purposes. The following example workspace names follow a common `<COMPONENT>-<ENVIRONMENT>-<REGION>` pattern:
+
+- `networking-prod-us-east`
+- `networking-staging-us-east`
+
+You can also apply tags to group Terraform Cloud workspaces. Tagging workspaces enables Terraform to present related workspaces when they are called with the [`terraform workspace list` command](/cli/commands/workspace/list). 
+
+The combination of workspace tags and workspace names allows Terraform to present two workspaces with different configurations within the same workspace list. `Refer to [Workspace Naming](/cloud-docs/workspaces/naming) in the Terraform Cloud documentation for additional information.
 
 ## Migrating from the `remote` Backend
 

--- a/website/docs/cli/cloud/settings.mdx
+++ b/website/docs/cli/cloud/settings.mdx
@@ -64,11 +64,12 @@ The `cloud` block supports the following configuration arguments:
   use for the current configuration. The `workspaces` block must contain **exactly one** of the
   following arguments, each denoting a strategy for how workspaces should be mapped:
 
-  - `tags` - (Optional) A set of Terraform Cloud workspace tags. You will be able to use
-    this working directory with any workspaces that have all of the specified tags,
-    and can use [the `terraform workspace` commands](/cli/workspaces)
-    to switch between them or create new workspaces. New workspaces will automatically have
-    the specified tags. This option conflicts with `name`.
+  - `tags` - (Optional) A set of Terraform Cloud workspace tags. It is used to group Terrform
+    Cloud workspaces, regardless of their names, and more importantly their configurations.
+    You will be able to use this working directory with any workspaces that have all of the specified tags,
+    and can use [the `terraform workspace` commands](/cli/workspaces) to switch between them or
+    create new workspaces. New workspaces will automatically have the specified tags. These tags should
+    have a strong correlation with the underlying configuration. This option conflicts with `name`.
 
   - `name` - (Optional) The name of a single Terraform Cloud workspace. You will
     only be able to use the workspace specified in the configuration with this working

--- a/website/docs/cli/cloud/settings.mdx
+++ b/website/docs/cli/cloud/settings.mdx
@@ -64,12 +64,9 @@ The `cloud` block supports the following configuration arguments:
   use for the current configuration. The `workspaces` block must contain **exactly one** of the
   following arguments, each denoting a strategy for how workspaces should be mapped:
 
-  - `tags` - (Optional) A set of Terraform Cloud workspace tags. It is used to group Terrform
-    Cloud workspaces, regardless of their names, and more importantly their configurations.
-    You will be able to use this working directory with any workspaces that have all of the specified tags,
-    and can use [the `terraform workspace` commands](/cli/workspaces) to switch between them or
-    create new workspaces. New workspaces will automatically have the specified tags. These tags should
-    have a strong correlation with the underlying configuration. This option conflicts with `name`.
+  - `tags` - (Optional) Specifies set of Terraform Cloud workspace tags. Terraform uses the tags to group Terraform
+    Cloud workspaces, regardless of their names and configurations.
+    You can use a working directory with any workspace that has all of the specified tags. To switch between workspaces or create new workspaces, use the [`terraform workspace` commands](/cli/workspaces). New workspaces created inherit any tags that have been applied to the current workspace. We recommend applying tags when a workspace has a strong correlation with the underlying configuration. This option conflicts with `name`.
 
   - `name` - (Optional) The name of a single Terraform Cloud workspace. You will
     only be able to use the workspace specified in the configuration with this working


### PR DESCRIPTION
It wasn't clear during migration that the tags are the driver in workspace grouping, and since it isn't possible to rename a workspace after the fact, regrets can happen.

I have a repository with two related configurations, one existed as a sub-directory and has a couple of local workspaces with states. The top-level configuration only has the default workspace with state. I attempted a migration, because I would like to share the states with my colleague, and started with the sub-directory. Then when I started the migration at the parent directory, because of the lack of other local workspaces, the flow was different and I didn't get to set a name pattern based on the existing workspace. So, I ended up with a very generic name that I cannot change (I should submit a feature request on that).

In hindsight, all of it makes sense since the `cloud` setting is tied to the repository, and should be configuration-specific. But if the documentation has been a bit more forthright, perhaps I won't be in this predicament.

1.4.x

## Draft CHANGELOG entry
Clarify the loose relation between Cloud workspace names and tags in the documentation.

### DOCUMENTATION
