### PR TITLE
command: "terraform web" command

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -295,6 +295,12 @@ func initCommands(
 			}, nil
 		},
 
+		"web": func() (cli.Command, error) {
+			return &command.WebCommand{
+				Meta: meta,
+			}, nil
+		},
+
 		"workspace": func() (cli.Command, error) {
 			return &command.WorkspaceCommand{
 				Meta: meta,

--- a/internal/cloud/backend_web.go
+++ b/internal/cloud/backend_web.go
@@ -1,0 +1,103 @@
+package cloud
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+
+	"github.com/hashicorp/go-tfe"
+	"github.com/hashicorp/terraform/internal/command/webcommand"
+	"github.com/hashicorp/terraform/internal/tfdiags"
+)
+
+// WebURLForObject implements command.WebCommandURLProvider, which makes
+// this backend support the "terraform web" command.
+func (b *Cloud) WebURLForObject(ctx context.Context, workspaceName string, targetObj webcommand.TargetObject) (*url.URL, tfdiags.Diagnostics) {
+	var diags tfdiags.Diagnostics
+
+	// The Terraform Cloud API doesn't currently return any information about
+	// the web UI URLs corresponding to API objects, so for now we'll be
+	// using hard-coded URL patterns here. These URL patterns will need to be
+	// preserved (e.g. by redirects) if the web UI URL design changes in future.
+
+	remoteWorkspaceName := b.getRemoteWorkspaceName(workspaceName)
+	baseURL := &url.URL{
+		Scheme: "https",
+		Host:   b.hostname,
+		Path:   "/app/",
+	}
+	ws, err := b.client.Workspaces.Read(ctx, b.organization, remoteWorkspaceName)
+	if err != nil {
+		diags = diags.Append(tfdiags.Sourceless(
+			tfdiags.Error,
+			"Failed to fetch Terraform Cloud workspace",
+			fmt.Sprintf("Error reading Terraform Cloud workspace %q: %s.", remoteWorkspaceName, err),
+		))
+		return nil, diags
+	}
+
+	switch targetObj {
+
+	case webcommand.TargetObjectCurrentWorkspace:
+		return baseURL.JoinPath(
+			ws.Organization.Name,
+			"workspaces", ws.Name,
+		), diags
+
+	case webcommand.TargetObjectLatestRun:
+		if ws.CurrentRun == nil {
+			diags = diags.Append(tfdiags.Sourceless(
+				tfdiags.Error,
+				"No Current Run for Workspace",
+				fmt.Sprintf("Terraform Cloud workspace %q does not have a current run.", ws.Name),
+			))
+			return nil, diags
+		}
+		return baseURL.JoinPath(
+			ws.Organization.Name,
+			"workspaces", ws.Name,
+			"runs", ws.CurrentRun.ID,
+		), diags
+	}
+
+	if targetObj, ok := targetObj.(webcommand.TargetObjectRun); ok {
+		run, err := b.client.Runs.ReadWithOptions(ctx, targetObj.RunID, &tfe.RunReadOptions{
+			Include: []tfe.RunIncludeOpt{
+				"workspace",
+			},
+		})
+		if err != nil {
+			diags = diags.Append(tfdiags.Sourceless(
+				tfdiags.Error,
+				"Failed to Fetch Requested Run",
+				fmt.Sprintf("Cannot read Terraform Cloud run %q: %s.", targetObj.RunID, err),
+			))
+			return nil, diags
+		}
+		if run.Workspace.ID != ws.ID {
+			// If the user specified a run from elsewhere then we'll do what
+			// they asked but also warn about it in case that was an accident
+			// and they end up confused about where they ended up.
+			diags = diags.Append(tfdiags.Sourceless(
+				tfdiags.Warning,
+				"Run Belongs to Another Workspace",
+				fmt.Sprintf("The selected run belongs to workspace %q in organization %q, which is not the currently-selected workspace.", run.Workspace.Name, run.Workspace.Organization.Name),
+			))
+		}
+		return baseURL.JoinPath(
+			run.Workspace.Organization.Name,
+			"workspaces", run.Workspace.Name,
+			"runs", run.ID,
+		), diags
+	}
+
+	// NOTE: This is a fallback for robustness but we should typcially
+	// avoid entering this fallback by ensuring that the cases above
+	// always cover all of the possible values of arguments.WebTargetObject.
+	diags = diags.Append(tfdiags.Sourceless(
+		tfdiags.Error,
+		"Cannot view the selected object",
+		fmt.Sprintf("The Terraform Cloud integration cannot open %s in your browser.", targetObj.UIDescription()),
+	))
+	return nil, diags
+}

--- a/internal/cloud/backend_web_test.go
+++ b/internal/cloud/backend_web_test.go
@@ -1,0 +1,140 @@
+package cloud
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	tfe "github.com/hashicorp/go-tfe"
+	"github.com/hashicorp/terraform/internal/command/webcommand"
+)
+
+// TestCloudWebURLForObject tests the CloudWebURLForObject method of type Cloud.
+func TestCloudWebURLForObject(t *testing.T) {
+	b, bCleanup := testBackendWithName(t)
+	defer bCleanup()
+
+	orgName := b.organization
+	ws, err := b.client.Workspaces.Read(context.Background(), orgName, testBackendSingleWorkspaceName)
+	if err != nil {
+		t.Fatalf("failed to read the mock workspace: %s", err)
+	}
+
+	// This is _just enough_ run to make this test work.
+	run := &tfe.Run{
+		ID: "mock-run-id",
+		// NOTE: Workspace must not be a pointer to ws because ws.CurrentRun
+		// will point back at this same run, which will create a circular
+		// reference that interferes with the operation of the mock client.
+		Workspace: &tfe.Workspace{
+			ID:   ws.ID,
+			Name: ws.Name,
+			Organization: &tfe.Organization{
+				Name: ws.Organization.Name,
+			},
+		},
+	}
+	b.client.Runs.(*MockRuns).Runs[run.ID] = run
+
+	// Modifying "ws" here works because the mock client returns a pointer
+	// directly to the object its mock workspace table refers to. Future
+	// calls to b.client.Workspaces.Read will expose these modifications.
+	ws.CurrentRun = run
+
+	withoutCurrentRunName := "without-current-run"
+	_, err = b.client.Workspaces.Create(context.Background(), orgName, tfe.WorkspaceCreateOptions{
+		Name: &withoutCurrentRunName,
+	})
+	if err != nil {
+		t.Fatalf("failed to create the without-current-run workspace: %s", err)
+	}
+
+	tests := []struct {
+		workspaceName   string
+		targetObject    webcommand.TargetObject
+		wantURL         string
+		wantDiagSummary string
+		wantErr         bool
+	}{
+		{
+			workspaceName:   testBackendSingleWorkspaceName,
+			targetObject:    webcommand.TargetObjectCurrentWorkspace,
+			wantURL:         "https://app.terraform.io/app/" + orgName + "/workspaces/" + testBackendSingleWorkspaceName,
+			wantDiagSummary: ``,
+			wantErr:         false,
+		},
+		{
+			workspaceName:   "nonexist",
+			targetObject:    webcommand.TargetObjectCurrentWorkspace,
+			wantURL:         "",
+			wantDiagSummary: `Failed to fetch Terraform Cloud workspace`,
+			wantErr:         true,
+		},
+		{
+			workspaceName:   testBackendSingleWorkspaceName,
+			targetObject:    webcommand.TargetObjectLatestRun,
+			wantURL:         "https://app.terraform.io/app/" + orgName + "/workspaces/" + testBackendSingleWorkspaceName + "/runs/" + run.ID,
+			wantDiagSummary: ``,
+			wantErr:         false,
+		},
+		{
+			workspaceName:   withoutCurrentRunName,
+			targetObject:    webcommand.TargetObjectLatestRun,
+			wantURL:         "",
+			wantDiagSummary: `No Current Run for Workspace`,
+			wantErr:         true,
+		},
+		{
+			workspaceName:   testBackendSingleWorkspaceName,
+			targetObject:    webcommand.TargetObjectRun{RunID: run.ID},
+			wantURL:         "https://app.terraform.io/app/" + orgName + "/workspaces/" + testBackendSingleWorkspaceName + "/runs/" + run.ID,
+			wantDiagSummary: ``,
+			wantErr:         false,
+		},
+		{
+			workspaceName:   testBackendSingleWorkspaceName,
+			targetObject:    webcommand.TargetObjectRun{RunID: "nonexist"},
+			wantURL:         "",
+			wantDiagSummary: `Failed to Fetch Requested Run`,
+			wantErr:         true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(
+			fmt.Sprintf("%s with %s", test.targetObject.UIDescription(), test.workspaceName),
+			func(t *testing.T) {
+				gotURL, diags := b.WebURLForObject(context.Background(), test.workspaceName, test.targetObject)
+
+				if test.wantErr != diags.HasErrors() {
+					if test.wantErr {
+						t.Errorf("succeeded; want error")
+					} else {
+						t.Errorf("failed; want success\n%s", diags.Err().Error())
+					}
+				}
+
+				var gotURLStr string
+				if gotURL != nil {
+					gotURLStr = gotURL.String()
+				}
+				if gotURLStr != test.wantURL {
+					t.Errorf("wrong result\ngot:  %s\nwant: %s", gotURLStr, test.wantURL)
+				}
+
+				if test.wantDiagSummary != "" {
+					found := false
+					for _, diag := range diags {
+						if diag.Description().Summary == test.wantDiagSummary {
+							found = true
+							break
+						}
+					}
+					if !found {
+						t.Errorf("missing expected diagnostic with summary %q", test.wantDiagSummary)
+					}
+				}
+			},
+		)
+	}
+}

--- a/internal/command/arguments/web.go
+++ b/internal/command/arguments/web.go
@@ -1,0 +1,70 @@
+package arguments
+
+import (
+	"github.com/hashicorp/terraform/internal/command/webcommand"
+	"github.com/hashicorp/terraform/internal/tfdiags"
+)
+
+// Web represents the command-line arguments for the "web" command.
+type Web struct {
+	// TargetObject represents the object that the user wishes to view on the
+	// web.
+	TargetObject webcommand.TargetObject
+}
+
+// ParseWeb processes CLI arguments for the "web" command, returning a Web value
+// and diagnostics.
+//
+// In case of errors, the Web object may still be partially populated with
+// a subset of the settings that were parsable, but some fields may be
+// incomplete or invalid.
+func ParseWeb(args []string) (*Web, tfdiags.Diagnostics) {
+	var diags tfdiags.Diagnostics
+	ret := &Web{}
+
+	// The structure of this command is a bit different than most others in
+	// that it expects zero or one of its "object selection" options, which
+	// we'll then reduce into a single target object to return.
+	//
+	// The "flag" package's approach is a bit awkward for this design but at
+	// least we can encapsulate all of this awkwardness in here.
+
+	cmdFlags := defaultFlagSet("web")
+	pLatestRun := cmdFlags.Bool("latest-run", false, "")
+	pRun := cmdFlags.String("run", "", "")
+	if err := cmdFlags.Parse(args); err != nil {
+		diags = diags.Append(tfdiags.Sourceless(
+			tfdiags.Error,
+			"Failed to parse command-line flags",
+			err.Error(),
+		))
+		return ret, diags
+	}
+
+	if *pLatestRun && *pRun != "" {
+		diags = diags.Append(tfdiags.Sourceless(
+			tfdiags.Error,
+			"Invalid combination of options",
+			"Cannot use multiple object selection options in the same command.",
+		))
+		return ret, diags
+	}
+	if len(cmdFlags.Args()) != 0 {
+		diags = diags.Append(tfdiags.Sourceless(
+			tfdiags.Error,
+			"Unexpected argument",
+			"The 'web' command does not expect any positional arguments.",
+		))
+	}
+
+	switch {
+	case *pLatestRun:
+		ret.TargetObject = webcommand.TargetObjectLatestRun
+	case *pRun != "":
+		ret.TargetObject = webcommand.TargetObjectRun{RunID: *pRun}
+	default:
+		ret.TargetObject = webcommand.TargetObjectCurrentWorkspace
+	}
+
+	return ret, diags
+}

--- a/internal/command/arguments/web_test.go
+++ b/internal/command/arguments/web_test.go
@@ -1,0 +1,115 @@
+package arguments
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/davecgh/go-spew/spew"
+	"github.com/hashicorp/terraform/internal/command/webcommand"
+	"github.com/hashicorp/terraform/internal/tfdiags"
+)
+
+func TestParseWeb_valid(t *testing.T) {
+	testCases := map[string]struct {
+		args []string
+		want *Web
+	}{
+		"defaults": {
+			nil,
+			&Web{
+				TargetObject: webcommand.TargetObjectCurrentWorkspace,
+			},
+		},
+		"latest run": {
+			[]string{"-latest-run"},
+			&Web{
+				TargetObject: webcommand.TargetObjectLatestRun,
+			},
+		},
+		"specified run": {
+			[]string{"-run=abc123"},
+			&Web{
+				TargetObject: webcommand.TargetObjectRun{RunID: "abc123"},
+			},
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			got, diags := ParseWeb(tc.args)
+			if len(diags) > 0 {
+				t.Fatalf("unexpected diags: %v", diags)
+			}
+			if *got != *tc.want {
+				t.Fatalf("unexpected result\n got: %#v\nwant: %#v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestParseWeb_invalid(t *testing.T) {
+	testCases := map[string]struct {
+		args      []string
+		want      *Web
+		wantDiags tfdiags.Diagnostics
+	}{
+		"unknown flag": {
+			[]string{"-boop"},
+			&Web{},
+			tfdiags.Diagnostics{
+				tfdiags.Sourceless(
+					tfdiags.Error,
+					"Failed to parse command-line flags",
+					"flag provided but not defined: -boop",
+				),
+			},
+		},
+		"both latest run and specified run": {
+			[]string{"-latest-run", "-run=abc123"},
+			&Web{},
+			tfdiags.Diagnostics{
+				tfdiags.Sourceless(
+					tfdiags.Error,
+					"Invalid combination of options",
+					"Cannot use multiple object selection options in the same command.",
+				),
+			},
+		},
+		"specified run with no ID": {
+			[]string{"-run"},
+			&Web{},
+			tfdiags.Diagnostics{
+				tfdiags.Sourceless(
+					tfdiags.Error,
+					"Failed to parse command-line flags",
+					"flag needs an argument: -run",
+				),
+			},
+		},
+		"positional arguments": {
+			[]string{"blah"},
+			&Web{
+				TargetObject: webcommand.TargetObjectCurrentWorkspace,
+			},
+			tfdiags.Diagnostics{
+				tfdiags.Sourceless(
+					tfdiags.Error,
+					"Unexpected argument",
+					"The 'web' command does not expect any positional arguments.",
+				),
+			},
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			got, gotDiags := ParseWeb(tc.args)
+			if *got != *tc.want {
+				t.Fatalf("unexpected result\n got: %#v\nwant: %#v", got, tc.want)
+			}
+			if !reflect.DeepEqual(gotDiags, tc.wantDiags) {
+				t.Errorf("wrong result\ngot: %s\nwant: %s", spew.Sdump(gotDiags), spew.Sdump(tc.wantDiags))
+			}
+		})
+	}
+}

--- a/internal/command/meta.go
+++ b/internal/command/meta.go
@@ -150,6 +150,14 @@ type Meta struct {
 	// flag is set, to reinforce that experiments are not for production use.
 	AllowExperimentalFeatures bool
 
+	// FakeBackendForTesting is a testing-only setting to force the Meta.Backend
+	// method to return a particular value, skipping the usual interactions
+	// with the working directory state.
+	//
+	// [Meta.Backend] will return this value exactly if set to anything other
+	// than nil. DO NOT SET THIS OUTSIDE OF TESTS.
+	FakeBackendForTesting backend.Enhanced
+
 	//----------------------------------------------------------
 	// Protected: commands can set these
 	//----------------------------------------------------------

--- a/internal/command/meta_backend.go
+++ b/internal/command/meta_backend.go
@@ -82,6 +82,11 @@ type BackendWithRemoteTerraformVersion interface {
 // the final resolved backend configuration after dealing with overrides from
 // the "terraform init" command line, etc.
 func (m *Meta) Backend(opts *BackendOpts) (backend.Enhanced, tfdiags.Diagnostics) {
+	if m.FakeBackendForTesting != nil {
+		// For use in test cases only.
+		return m.FakeBackendForTesting, nil
+	}
+
 	var diags tfdiags.Diagnostics
 
 	// If no opts are set, then initialize

--- a/internal/command/web.go
+++ b/internal/command/web.go
@@ -1,0 +1,139 @@
+package command
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform/internal/command/arguments"
+	"github.com/hashicorp/terraform/internal/command/webcommand"
+	"github.com/hashicorp/terraform/internal/tfdiags"
+	"github.com/posener/complete"
+)
+
+type WebCommand struct {
+	Meta
+}
+
+func (c *WebCommand) Run(rawArgs []string) int {
+	common, rawArgs := arguments.ParseView(rawArgs)
+	c.View.Configure(common)
+
+	args, diags := arguments.ParseWeb(rawArgs)
+	if diags.HasErrors() {
+		c.View.Diagnostics(diags)
+		c.View.HelpPrompt("web")
+		return 1
+	}
+
+	// The backend is responsible for deciding the specific URL to open.
+	b, backendDiags := c.Backend(nil)
+	diags = diags.Append(backendDiags)
+	if backendDiags.HasErrors() {
+		c.showDiagnostics(diags)
+		return 1
+	}
+
+	urlProvider, ok := b.(webcommand.URLProvider)
+	if !ok {
+		diags = diags.Append(tfdiags.Sourceless(
+			tfdiags.Error,
+			"Command requires Terraform Cloud",
+			"This command is available only for root modules which include a 'cloud' block for Terraform Cloud.",
+		))
+		c.showDiagnostics(diags)
+		return 1
+	}
+
+	workspaceName, err := c.Workspace()
+	if err != nil {
+		diags = diags.Append(tfdiags.Sourceless(
+			tfdiags.Error,
+			"Cannot determine current workspace",
+			fmt.Sprintf("Failed to determine the currently-selected workspace: %s.", err),
+		))
+		c.showDiagnostics(diags)
+		return 1
+	}
+
+	ctx, cancel := c.InterruptibleContext()
+	defer cancel()
+	url, moreDiags := urlProvider.WebURLForObject(ctx, workspaceName, args.TargetObject)
+	diags = diags.Append(moreDiags)
+	if moreDiags.HasErrors() {
+		c.showDiagnostics(diags)
+		return 1
+	}
+
+	launchBrowserManually := false
+	if c.BrowserLauncher != nil {
+		// NOTE: On some platforms we launch URLs by running external helper
+		// commands that then in turn know how to launch the appropriate
+		// browser. Those commands tend to produce output on stderr if they
+		// fail, so if err isn't nil here then it's typical for there to
+		// already be some arbitrary chatter on stderr describing that problem
+		// in a platform-specific way.
+		err := c.BrowserLauncher.OpenURL(url.String())
+		if err != nil {
+			// Assume we're on a platform where opening a browser isn't possible.
+			launchBrowserManually = true
+		}
+	} else {
+		launchBrowserManually = true
+	}
+
+	if launchBrowserManually {
+		c.Ui.Output(fmt.Sprintf(
+			"Terraform cannot automatically launch a web browser on this system.\n\nThe following is the URL for %s:\n    %s\n",
+			args.TargetObject.UIDescription(),
+			url.String(),
+		))
+	} else {
+		c.Ui.Output(fmt.Sprintf(
+			"Terraform is attempting to open %s in your browser:\n    %s\n",
+			args.TargetObject.UIDescription(),
+			url.String(),
+		))
+	}
+
+	c.showDiagnostics(diags)
+	if diags.HasErrors() {
+		return 1
+	}
+	return 0
+}
+
+func (c *WebCommand) AutocompleteArgs() complete.Predictor {
+	return complete.PredictNothing
+}
+
+func (c *WebCommand) AutocompleteFlags() complete.Flags {
+	return complete.Flags{
+		"-latest-run": complete.PredictNothing,
+		"-run":        complete.PredictAnything,
+	}
+}
+
+func (c *WebCommand) Help() string {
+	helpText := `
+Usage: terraform [global options] web [options]
+
+  Launches your web browser to view a web UI representation of a selected
+  object relevant to your current context.
+
+  With no options at all the selected object is your currently-selected
+  workspace. Use one of the following options to select a different object:
+
+    -latest-run  The most recent run in the currently-selected workspace.
+
+    -run=ID      The run with the given run ID from the currently-selected
+                 workspace, if any.
+
+  This command is available only when using Terraform Cloud, with the "cloud"
+  block in your root module.
+`
+	return strings.TrimSpace(helpText)
+}
+
+func (c *WebCommand) Synopsis() string {
+	return "View something in your web browser"
+}

--- a/internal/command/web_test.go
+++ b/internal/command/web_test.go
@@ -1,0 +1,147 @@
+package command
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/hashicorp/terraform/internal/backend"
+	"github.com/hashicorp/terraform/internal/backend/remote-state/inmem"
+	"github.com/hashicorp/terraform/internal/command/views"
+	"github.com/hashicorp/terraform/internal/command/webbrowser"
+	"github.com/hashicorp/terraform/internal/command/webcommand"
+	"github.com/hashicorp/terraform/internal/terminal"
+	"github.com/hashicorp/terraform/internal/tfdiags"
+	"github.com/mitchellh/cli"
+)
+
+func TestWeb(t *testing.T) {
+	t.Parallel()
+
+	type TestDeps struct {
+		Backend         *backendForTestWeb
+		BrowserLauncher *webbrowser.MockLauncher
+		UI              *cli.MockUi
+		TestServerURL   string
+	}
+
+	newWebCommand := func(t *testing.T) (*WebCommand, TestDeps, func()) {
+		ctx := context.Background()
+
+		testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+			w.Header().Set("content-length", "0")
+			w.Header().Set("content-type", "text/html")
+			w.WriteHeader(200)
+		}))
+
+		testServerURL, err := url.Parse(testServer.URL)
+		if err != nil {
+			t.Fatalf("httptest.NewServer returned invalid URL: %s", err)
+		}
+
+		innerBackend := inmem.New().(*inmem.Backend)
+		backend := &backendForTestWeb{
+			Backend: innerBackend,
+			retURL:  testServerURL,
+		}
+		browserLauncher := webbrowser.NewMockLauncher(ctx)
+		ui := cli.NewMockUi()
+
+		deps := TestDeps{
+			Backend:         backend,
+			BrowserLauncher: browserLauncher,
+			UI:              ui,
+			TestServerURL:   testServer.URL,
+		}
+
+		streams, closeStreams := terminal.StreamsForTesting(t)
+
+		close := func() {
+			closeStreams(t)
+			testServer.Close()
+		}
+
+		return &WebCommand{
+			Meta: Meta{
+				Ui:                    ui,
+				BrowserLauncher:       browserLauncher,
+				FakeBackendForTesting: backend,
+				View:                  views.NewView(streams),
+			},
+		}, deps, close
+	}
+
+	tests := map[string]struct {
+		args             []string
+		wantTargetObject webcommand.TargetObject
+	}{
+		"no options": {
+			nil,
+			webcommand.TargetObjectCurrentWorkspace,
+		},
+		"-latest-run": {
+			[]string{"-latest-run"},
+			webcommand.TargetObjectLatestRun,
+		},
+		"-run=foo": {
+			[]string{"-run=foo"},
+			webcommand.TargetObjectRun{RunID: "foo"},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			c, deps, close := newWebCommand(t)
+			defer close()
+
+			result := c.Run(test.args)
+			if result != 0 {
+				t.Fatalf("failed; expected success")
+			}
+			deps.BrowserLauncher.Wait()
+
+			if got, want := deps.Backend.givenWorkspaceName, "default"; got != want {
+				t.Errorf("wrong workspace name in URL request\ngot:  %s\nwant: %s", got, want)
+			}
+			if got, want := deps.Backend.givenTargetObject, test.wantTargetObject; got != want {
+				t.Errorf("wrong target object in URL request\ngot:  %s\nwant: %s", got, want)
+			}
+
+			// One response in the mock browser launcher means one call to
+			// the OpenURL method.
+			if got, want := len(deps.BrowserLauncher.Responses), 1; got != want {
+				t.Fatalf("wrong number of responses %d; want %d", got, want)
+			}
+			if got, want := deps.BrowserLauncher.Responses[0].Request.URL.String(), deps.TestServerURL; got != want {
+				t.Errorf("wrong URL\ngot:  %s\nwant: %s", got, want)
+			}
+		})
+	}
+}
+
+type backendForTestWeb struct {
+	// This is mostly just the inmem backend, but with the web URL provider
+	// API implemented too.
+	*inmem.Backend
+
+	retURL *url.URL
+
+	givenWorkspaceName string
+	givenTargetObject  webcommand.TargetObject
+}
+
+var _ webcommand.URLProvider = (*backendForTestWeb)(nil)
+
+func (b *backendForTestWeb) Operation(context.Context, *backend.Operation) (*backend.RunningOperation, error) {
+	panic("not implemented")
+}
+
+func (b *backendForTestWeb) WebURLForObject(ctx context.Context, workspaceName string, targetObject webcommand.TargetObject) (*url.URL, tfdiags.Diagnostics) {
+	b.givenWorkspaceName = workspaceName
+	b.givenTargetObject = targetObject
+	return b.retURL, nil
+}

--- a/internal/command/webcommand/doc.go
+++ b/internal/command/webcommand/doc.go
@@ -1,0 +1,4 @@
+// Package webcommand contains some glue code used to coordinate between
+// different subsystems that collaborate to provide the "terraform web"
+// CLI command.
+package webcommand

--- a/internal/command/webcommand/target_object.go
+++ b/internal/command/webcommand/target_object.go
@@ -1,0 +1,51 @@
+package webcommand
+
+import (
+	"fmt"
+)
+
+type TargetObject interface {
+	targetObjectSigil()
+
+	// UIDescription is a short string describing what was selected for use
+	// in error messages in the UI reporting when the target object is not
+	// supported by the backend.
+	UIDescription() string
+}
+
+type targetObjectSimple string
+
+func (to targetObjectSimple) targetObjectSigil() {}
+
+var (
+	TargetObjectCurrentWorkspace TargetObject
+	TargetObjectLatestRun        TargetObject
+)
+
+func init() {
+	TargetObjectCurrentWorkspace = targetObjectSimple("current_workspace")
+	TargetObjectLatestRun = targetObjectSimple("latest_run")
+}
+
+func (to targetObjectSimple) UIDescription() string {
+	switch to {
+	case TargetObjectCurrentWorkspace:
+		return "the currently-selected workspace"
+	case TargetObjectLatestRun:
+		return "the latest run for the current workspace"
+	default:
+		// We should not get here because the above should be exhaustive
+		// for all of our exported webTargetObjectSimple values.
+		return "the selected object"
+	}
+}
+
+type TargetObjectRun struct {
+	RunID string
+}
+
+func (wto TargetObjectRun) targetObjectSigil() {}
+
+func (wto TargetObjectRun) UIDescription() string {
+	return fmt.Sprintf("run %q", wto.RunID)
+}

--- a/internal/command/webcommand/url_provider.go
+++ b/internal/command/webcommand/url_provider.go
@@ -1,0 +1,19 @@
+package webcommand
+
+import (
+	"context"
+	"net/url"
+
+	"github.com/hashicorp/terraform/internal/tfdiags"
+)
+
+// URLProvider is an optional interface that a backend can implement to support
+// the "terraform web" command.
+//
+// Currently only the Terraform Cloud integration supports this interface and
+// the UI code in command.WebCommand assumes that in its error messaging. If
+// any other backend supports this in future that error messaging must be
+// updated.
+type URLProvider interface {
+	WebURLForObject(ctx context.Context, workspaceName string, targetObject TargetObject) (*url.URL, tfdiags.Diagnostics)
+}


### PR DESCRIPTION
This is a small utility command to help bridge from Terraform CLI to the Terraform Cloud web UI.

When used in a configuration that has a Terraform Cloud configuration, it will ask the Cloud integration for a URL that represents a requested "target object" and then try to open that URL in a web browser. If launching a browser isn't possible for any reason then it'll just print out the URL it would've opened to, so that the user can hopefully still follow the link from their terminal or copy it into their browser's URL bar.

* `terraform web` opens the main landing page for the currently-selected workspace
* `terraform web -latest-run` opens the run details page for the most recent run in the currently-selected workspace
* `terraform web -run=ID` opens the run details page for the specified run ID

I imagine there are other "target objects" that could be useful to support here later too, but since each one of these imposes a new compatibility constraint on Terraform Cloud's web UI (because of the hard-coded URL patterns and the need to keep offering a suitable page to link to) I've kept this minimal to start, mainly just to have something to play with and gather feedback on.

## Draft CHANGELOG entry

NEW FEATURES:

- `terraform web`: Open pages related to the current working directory in the Terraform Cloud web UI.

