### PR TITLE
check walkDestroy to help DestroyEdgeTransformer

### DIFF
--- a/internal/terraform/graph_builder_apply.go
+++ b/internal/terraform/graph_builder_apply.go
@@ -144,7 +144,8 @@ func (b *ApplyGraphBuilder) Steps() []GraphTransformer {
 
 		// Destruction ordering
 		&DestroyEdgeTransformer{
-			Changes: b.Changes,
+			Changes:   b.Changes,
+			Operation: b.Operation,
 		},
 		&CBDEdgeTransformer{
 			Config: b.Config,


### PR DESCRIPTION
In a heavily-connected graph with lots of inter-dependent providers, the cycle checks for destroy edges across providers can seriously impact performance. Since the specific cases we need to avoid will involve create/update nodes, skip the extra checks during a full destroy operation. Once we find a way to better handle these dependencies*, the transformer will not need to do the complete cycle checks in the first place.

While probably not a complete solution to the increased plan+apply overhead, this should help recover some of the performance loss seen in #32234


\* tracking the dependencies may not be reasonable, and a simple "reachability" method for the graph may be all we need.