### PR TITLE
Updating distro lists to be current as of 2022-11

### DIFF
--- a/website/docs/cli/install/apt.mdx
+++ b/website/docs/cli/install/apt.mdx
@@ -81,7 +81,6 @@ There are no official packages available for other architectures, such as
 The HashiCorp APT server currently contains release repositories for the
 following distribution releases:
 
-* Debian 8 (`jessie`)
 * Debian 9 (`stretch`)
 * Debian 10 (`buster`)
 * Debian 11 (`bullseye`)

--- a/website/docs/cli/install/yum.mdx
+++ b/website/docs/cli/install/yum.mdx
@@ -75,6 +75,7 @@ following distribution releases:
 * Fedora 34
 * Fedora 35
 * Fedora 36
+* Fedora 37
 * RHEL 7 (and CentOS 7)
 * RHEL 8 (and CentOS 8)
 * RHEL 9 (and CentOS 9)

--- a/website/docs/cli/install/yum.mdx
+++ b/website/docs/cli/install/yum.mdx
@@ -70,6 +70,7 @@ There are no official packages available for other architectures, such as
 The HashiCorp Yum server currently contains release repositories for the
 following distribution releases:
 
+* AmazonLinux 2 and "latest"
 * Fedora 33
 * Fedora 34
 * Fedora 35

--- a/website/docs/cli/install/yum.mdx
+++ b/website/docs/cli/install/yum.mdx
@@ -70,14 +70,13 @@ There are no official packages available for other architectures, such as
 The HashiCorp Yum server currently contains release repositories for the
 following distribution releases:
 
-* AmazonLinux 2
-* Fedora 29
-* Fedora 30
-* Fedora 31
-* Fedora 32
 * Fedora 33
+* Fedora 34
+* Fedora 35
+* Fedora 36
 * RHEL 7 (and CentOS 7)
 * RHEL 8 (and CentOS 8)
+* RHEL 9 (and CentOS 9)
 
 No repositories are available for other versions of these distributions or for
 any other RPM-based Linux distributions. If you add the repository using


### PR DESCRIPTION
Distro lists were out-of-date, just bringing them into sync with:
https://github.com/hashicorp/linux-packaging#current-support