### PR TITLE
Added a missing comma on backends.mdx

### DIFF
--- a/website/docs/language/state/backends.mdx
+++ b/website/docs/language/state/backends.mdx
@@ -28,7 +28,7 @@ sensitive values are in your state, using a remote backend allows you to use
 Terraform without that state ever being persisted to disk.
 
 In the case of an error persisting the state to the backend, Terraform will
-write the state locally. This is to prevent data loss. If this happens the
+write the state locally. This is to prevent data loss. If this happens, the
 end user must manually push the state to the remote backend once the error
 is resolved.
 


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Fixes #

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.4.x

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

### NEW FEATURES | UPGRADE NOTES | ENHANCEMENTS | BUG FIXES | EXPERIMENTS

<!--

Write a short description of the user-facing change. Examples:

- `terraform show -json`: Fixed crash with sensitive set values.
- When rendering a diff, Terraform now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 

-  
