### PR TITLE
support json output for workspace list

### DIFF
--- a/internal/command/workspace_list.go
+++ b/internal/command/workspace_list.go
@@ -74,10 +74,9 @@ func (c *WorkspaceListCommand) Run(args []string) int {
 		c.jsonOutput(states, env)
 	} else {
 		c.defaultOutput(states, env)
-	}
-
-	if isOverridden {
-		c.Ui.Output(envIsOverriddenNote)
+		if isOverridden {
+			c.Ui.Output(envIsOverriddenNote)
+		}
 	}
 
 	return 0


### PR DESCRIPTION
The change adds a flag (-json) to terraform workspace list command which prints a json output instead of the standard output. 

Output example when -json is passed:

```json
[{"Name":"default","Selected":true}]
```

formatted with jq
```json
[
  {
    "Name": "default",
    "Selected": true
  }
]
```


This change solves 
https://github.com/hashicorp/terraform/issues/30506

It has no breaking change (if -json is not provided, output stays the same as before)

