### PR TITLE
fix: pre allocate for composite literal

### DIFF
--- a/internal/backend/remote-state/gcs/backend.go
+++ b/internal/backend/remote-state/gcs/backend.go
@@ -180,7 +180,7 @@ func (b *Backend) configure(ctx context.Context) error {
 		if v, ok := data.GetOk("impersonate_service_account_delegates"); ok {
 			d := v.([]interface{})
 			if len(delegates) > 0 {
-				delegates = make([]string, len(d))
+				delegates = make([]string, 0, len(d))
 			}
 			for _, delegate := range d {
 				delegates = append(delegates, delegate.(string))

--- a/internal/cloud/backend_plan.go
+++ b/internal/cloud/backend_plan.go
@@ -235,7 +235,7 @@ in order to capture the filesystem context the remote workspace expects:
 		return nil, varDiags.Err()
 	}
 
-	runVariables := make([]*tfe.RunVariable, len(variables))
+	runVariables := make([]*tfe.RunVariable, 0, len(variables))
 	for name, value := range variables {
 		runVariables = append(runVariables, &tfe.RunVariable{
 			Key:   name,

--- a/internal/e2e/e2e.go
+++ b/internal/e2e/e2e.go
@@ -150,8 +150,8 @@ func (b *binary) Run(args ...string) (stdout, stderr string, err error) {
 // Path returns a file path within the temporary working directory by
 // appending the given arguments as path segments.
 func (b *binary) Path(parts ...string) string {
-	args := make([]string, len(parts)+1)
-	args[0] = b.workDir
+	args := make([]string, 0, len(parts)+1)
+	args = append(args, b.workDir)
 	args = append(args, parts...)
 	return filepath.Join(args...)
 }

--- a/internal/plugin6/convert/schema.go
+++ b/internal/plugin6/convert/schema.go
@@ -259,7 +259,7 @@ func configschemaObjectToProto(b *configschema.Object) *proto.Schema_Object {
 		nesting = proto.Schema_Object_INVALID
 	}
 
-	attributes := make([]*proto.Schema_Attribute, len(b.Attributes))
+	attributes := make([]*proto.Schema_Attribute, 0, len(b.Attributes))
 
 	for _, name := range sortedKeys(b.Attributes) {
 		a := b.Attributes[name]


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Fixes #

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.3.x

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

### NEW FEATURES | UPGRADE NOTES | ENHANCEMENTS | BUG FIXES | EXPERIMENTS

<!--

Write a short description of the user-facing change. Examples:

- `terraform show -json`: Fixed crash with sensitive set values.
- When rendering a diff, Terraform now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 

-  BUG FIXES: fix pre allocate for composite literal
