### PR TITLE
Documentation update for cli graph command

### DIFF
--- a/website/docs/cli/commands/graph.mdx
+++ b/website/docs/cli/commands/graph.mdx
@@ -53,5 +53,10 @@ by GraphViz:
 $ terraform graph | dot -Tsvg > graph.svg
 ```
 
+Alternatively, `dot` can export to other image file formats by changing the flag input:
+```shellsession
+$ terraform graph | dot -Tpng > graph.png
+```
+
 Here is an example graph output:
 ![Graph Example](/img/docs/graph-example.png)


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

This PR adds instruction for how to modify the `dot` command to export the graph to other image file formats instead of exporting to `.svg` and converting. 




<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->


The documentation for how to use the `terraform graph` command shows piping to `dot` and then exporting the file in `.svg` format which needs GraphViz to open. This made it difficult to share the image if the other person didn't also have the software installed. Conversing `.svg` to `.png` or other file formats wasn't immediately clear online or required you to upload to an online tool (which most companies wouldn't want to do) or resulting in rudimentary methods such as screen-shotting the opened `.svg` image. 
