### PR TITLE
docs: create_before_destroy meta-attribute propagation

### DIFF
--- a/website/docs/language/meta-arguments/lifecycle.mdx
+++ b/website/docs/language/meta-arguments/lifecycle.mdx
@@ -49,6 +49,13 @@ The arguments available within a `lifecycle` block are `create_before_destroy`,
   such features, so you must understand the constraints for each resource
   type before using `create_before_destroy` with it.
 
+  Note that Terraform propagates and applies `create_before_destroy` meta-attribute
+  behaviour to all resource dependencies. For example, if resource A with enabled
+  `create_before_destroy` depends on resource B with disabled `create_before_destroy`
+  (by default), then Terraform enables `create_before_destroy` for resource B
+  implicitly and stores it to the state file. You cannot override `create_before_destroy`
+  to `false` on resource B, because that would imply dependency cycles in the graph.
+
   Destroy provisioners of this resource do not run if `create_before_destroy`
   is set to `true`. This [GitHub issue](https://github.com/hashicorp/terraform/issues/13549) contains more details.
 

--- a/website/docs/language/meta-arguments/lifecycle.mdx
+++ b/website/docs/language/meta-arguments/lifecycle.mdx
@@ -49,7 +49,7 @@ The arguments available within a `lifecycle` block are `create_before_destroy`,
   such features, so you must understand the constraints for each resource
   type before using `create_before_destroy` with it.
 
-  Note that Terraform propagates and applies `create_before_destroy` meta-attribute
+  Note that Terraform propagates and applies the `create_before_destroy` meta-attribute
   behaviour to all resource dependencies. For example, if resource A with enabled
   `create_before_destroy` depends on resource B with disabled `create_before_destroy`
   (by default), then Terraform enables `create_before_destroy` for resource B

--- a/website/docs/language/meta-arguments/lifecycle.mdx
+++ b/website/docs/language/meta-arguments/lifecycle.mdx
@@ -50,11 +50,9 @@ The arguments available within a `lifecycle` block are `create_before_destroy`,
   type before using `create_before_destroy` with it.
 
   Note that Terraform propagates and applies the `create_before_destroy` meta-attribute
-  behaviour to all resource dependencies. For example, if resource A with enabled
-  `create_before_destroy` depends on resource B with disabled `create_before_destroy`
-  (by default), then Terraform enables `create_before_destroy` for resource B
-  implicitly and stores it to the state file. You cannot override `create_before_destroy`
-  to `false` on resource B, because that would imply dependency cycles in the graph.
+  behaviour to all resource dependencies. For example, if `create_before_destroy` is enabled on resource A but not on resource B, but resource A is dependent on resource B, then Terraform enables `create_before_destroy` for resource B 
+  implicitly by default and stores it to the state file. You cannot override `create_before_destroy`
+  to `false` on resource B because that would imply dependency cycles in the graph.
 
   Destroy provisioners of this resource do not run if `create_before_destroy`
   is set to `true`. This [GitHub issue](https://github.com/hashicorp/terraform/issues/13549) contains more details.


### PR DESCRIPTION
I've spent quite a lot of time to figure out the fact `create_before_destroy` meta-attribute propagates to all dependencies. Seems like I was not the only one who found this non-intuitive ([GitHub issue](https://github.com/hashicorp/terraform/issues/21610)). I think it's worth noting this behaviour in the documentation explicitly. I don't mind changing the text by maintainers if there is a better English variant.

Explains: https://github.com/hashicorp/terraform-provider-kubernetes/issues/1906

## CHANGELOG

- Document `create_before_destroy` meta-attribute propagation behaviour