### PR TITLE
backend/oss: Ignore the getting oss endpoint error and using string concat instead; Improves the error message level

### DIFF
--- a/internal/backend/remote-state/oss/backend.go
+++ b/internal/backend/remote-state/oss/backend.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/aliyun/alibaba-cloud-sdk-go/sdk/endpoints"
 	"io/ioutil"
 	"log"
 	"net/http"
@@ -15,6 +14,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/aliyun/alibaba-cloud-sdk-go/sdk/endpoints"
 
 	"github.com/aliyun/alibaba-cloud-sdk-go/sdk"
 	"github.com/aliyun/alibaba-cloud-sdk-go/sdk/auth/credentials"
@@ -379,12 +380,13 @@ func (b *Backend) configure(ctx context.Context) error {
 	if endpoint == "" {
 		endpointsResponse, err := b.getOSSEndpointByRegion(accessKey, secretKey, securityToken, region)
 		if err != nil {
-			return err
-		}
-		for _, endpointItem := range endpointsResponse.Endpoints.Endpoint {
-			if endpointItem.Type == "openAPI" {
-				endpoint = endpointItem.Endpoint
-				break
+			log.Printf("[WARN] getting oss endpoint failed and using oss-%s.aliyuncs.com instead. Error: %#v.", region, err)
+		} else {
+			for _, endpointItem := range endpointsResponse.Endpoints.Endpoint {
+				if endpointItem.Type == "openAPI" {
+					endpoint = endpointItem.Endpoint
+					break
+				}
 			}
 		}
 		if endpoint == "" {

--- a/internal/backend/remote-state/oss/client.go
+++ b/internal/backend/remote-state/oss/client.go
@@ -180,23 +180,22 @@ func (c *RemoteClient) Lock(info *statemgr.LockInfo) (string, error) {
 		},
 	}
 
-	log.Printf("[DEBUG] Recording state lock in tablestore: %#v", putParams)
+	log.Printf("[DEBUG] Recording state lock in tablestore: %#v; LOCKID:%s", putParams, c.lockPath())
 
 	_, err := c.otsClient.PutRow(&tablestore.PutRowRequest{
 		PutRowChange: putParams,
 	})
 	if err != nil {
-		log.Printf("[WARN] Error storing state lock in tablestore: %#v", err)
+		err = fmt.Errorf("invoking PutRow got an error: %#v", err)
 		lockInfo, infoErr := c.getLockInfo()
 		if infoErr != nil {
-			log.Printf("[WARN] Error getting lock info: %#v", err)
-			err = multierror.Append(err, infoErr)
+			err = multierror.Append(err, fmt.Errorf("\ngetting lock info got an error: %#v", infoErr))
 		}
 		lockErr := &statemgr.LockError{
 			Err:  err,
 			Info: lockInfo,
 		}
-		log.Printf("[WARN] state lock error: %#v", lockErr)
+		log.Printf("[ERROR] state lock error: %s", lockErr.Error())
 		return "", lockErr
 	}
 
@@ -386,12 +385,10 @@ func (c *RemoteClient) Unlock(id string) error {
 				},
 			},
 			Condition: &tablestore.RowCondition{
-				RowExistenceExpectation: tablestore.RowExistenceExpectation_EXPECT_EXIST,
+				RowExistenceExpectation: tablestore.RowExistenceExpectation_IGNORE,
 			},
 		},
 	}
-
-	log.Printf("[DEBUG] Deleting state lock from tablestore: %#v", params)
 
 	_, err = c.otsClient.DeleteRow(params)
 


### PR DESCRIPTION
This PR aims to fix getting oss endpoint error caused by network connection failed and other reasons. This error will break oss backend process. Considering all of oss endpoints have followed up pattern `oss-<RegionId>.aliyuncs.com`, above error can be ignored.

<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Fixes #

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.4.x

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

###  ENHANCEMENTS 

<!--

Write a short description of the user-facing change. Examples:

- `terraform show -json`: Fixed crash with sensitive set values.
- When rendering a diff, Terraform now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 

-  backend/oss: Ignore the getting oss endpoint error and using string concat instead; Improves the error message level
