### PR TITLE
don't re-set changes for refreshed outputs

### DIFF
--- a/internal/terraform/node_output.go
+++ b/internal/terraform/node_output.go
@@ -400,7 +400,8 @@ If you do intend to export this data, annotate the output value as sensitive by 
 	// If we were able to evaluate a new value, we can update that in the
 	// refreshed state as well.
 	if state = ctx.RefreshState(); state != nil && val.IsWhollyKnown() {
-		n.setValue(state, changes, val)
+		// we only need to update the state, do not pass in the changes again
+		n.setValue(state, nil, val)
 	}
 
 	return diags


### PR DESCRIPTION
When output values are updated in the refreshed state, we don't need to re-set the changes which were already set in conjunction with the current state. 

This is just a small change pulled for backport from the larger #32251 change set addressing output evaluation overall.
Helps address #32251 by not overwriting the change entry for every single output. 