### PR TITLE
Adds parseurl function

### DIFF
--- a/internal/lang/funcs/url.go
+++ b/internal/lang/funcs/url.go
@@ -1,0 +1,44 @@
+package funcs
+
+import (
+	u "net/url"
+
+	"github.com/zclconf/go-cty/cty"
+	"github.com/zclconf/go-cty/cty/function"
+)
+
+// ParseURLFunc takes a URL string and returns map[string]string
+// containing the URL's components https://www.rfc-editor.org/rfc/rfc3986#appendix-B
+var ParseURLFunc = function.New(&function.Spec{
+	Params: []function.Parameter{
+		{
+			Name: "url",
+			Type: cty.String,
+		},
+	},
+	Type: function.StaticReturnType(cty.Map(cty.String)),
+	Impl: func(args []cty.Value, retType cty.Type) (cty.Value, error) {
+
+		str := args[0].AsString()
+
+		url, err := u.Parse(str)
+
+		if err != nil {
+			return cty.Value{}, err
+		}
+
+		outMap := make(map[string]cty.Value)
+
+		password, _ := url.User.Password()
+
+		outMap["Password"] = cty.StringVal(password)
+		outMap["Username"] = cty.StringVal(url.User.Username())
+		outMap["Host"] = cty.StringVal(url.Host)
+		outMap["Fragment"] = cty.StringVal(url.Fragment)
+		outMap["Path"] = cty.StringVal(url.Path)
+		outMap["Scheme"] = cty.StringVal(url.Scheme)
+		outMap["RawQuery"] = cty.StringVal(url.RawQuery)
+
+		return cty.MapVal(outMap), nil
+	},
+})

--- a/internal/lang/functions.go
+++ b/internal/lang/functions.go
@@ -142,6 +142,7 @@ func (s *Scope) Functions() map[string]function.Function {
 			"urlencode":        funcs.URLEncodeFunc,
 			"uuid":             funcs.UUIDFunc,
 			"uuidv5":           funcs.UUIDV5Func,
+			"parseurl":         funcs.ParseURLFunc,
 			"values":           stdlib.ValuesFunc,
 			"yamldecode":       ctyyaml.YAMLDecodeFunc,
 			"yamlencode":       ctyyaml.YAMLEncodeFunc,

--- a/internal/lang/functions_test.go
+++ b/internal/lang/functions_test.go
@@ -56,6 +56,21 @@ func TestFunctions(t *testing.T) {
 			},
 		},
 
+		"parseurl": {
+			{
+				`parseurl("https://username:password@example.com/search?q=items#top")`,
+				cty.MapVal(map[string]cty.Value{
+					"Password": cty.StringVal("password"),
+					"RawQuery": cty.StringVal("q=items"),
+					"Username": cty.StringVal("username"),
+					"Host":     cty.StringVal("google.com"),
+					"Fragment": cty.StringVal("yea"),
+					"Path":     cty.StringVal("/asdf"),
+					"Scheme":   cty.StringVal("https"),
+				}),
+			},
+		},
+
 		"abspath": {
 			{
 				`abspath(".")`,

--- a/website/data/language-nav-data.json
+++ b/website/data/language-nav-data.json
@@ -290,9 +290,14 @@
           }
         ]
       },
+
       {
         "title": "String Functions",
         "routes": [
+          {
+            "title": "<code>parseurl</code>",
+            "href": "/language/functions/parseurl"
+          },
           {
             "title": "<code>chomp</code>",
             "href": "/language/functions/chomp"
@@ -740,6 +745,7 @@
       { "title": "can", "path": "functions/can", "hidden": true },
       { "title": "ceil", "path": "functions/ceil", "hidden": true },
       { "title": "chomp", "path": "functions/chomp", "hidden": true },
+      { "title": "parseurl", "path": "functions/parseurl" },
       { "title": "chunklist", "path": "functions/chunklist", "hidden": true },
       { "title": "cidrhost", "path": "functions/cidrhost", "hidden": true },
       {

--- a/website/docs/language/functions/parseurl.mdx
+++ b/website/docs/language/functions/parseurl.mdx
@@ -1,0 +1,35 @@
+---
+page_title: parseurl - Functions - Configuration Language
+description: The parseurl function parses the components of a URI reference.
+---
+
+# `parseurl` Function
+
+`parseurl` parses the components of a URI reference.
+
+This function identifies characters in the given string that would have a
+special meaning when included as a query string argument in a URL and
+escapes them using
+[RFC 3986 "percent encoding"](https://www.rfc-editor.org/rfc/rfc3986#appendix-B).
+
+The exact set of characters escaped may change over time, but the result
+is guaranteed to be interpolatable into a query string argument without
+inadvertently introducing additional delimiters.
+
+If the given string contains non-ASCII characters, these are first encoded as
+UTF-8 and then percent encoding is applied separately to each UTF-8 byte.
+
+## Examples
+
+```
+> parseurl("https://example.com/search?q=items#top")
+tomap({
+  "Fragment" = "top"
+  "Host" = "example.com"
+  "Opaque" = ""
+  "Path" = "/search"
+  "RawQuery" = ""
+  "Scheme" = "https"
+  "User" = "flynn:handley"
+})
+```

--- a/website/layouts/language.erb
+++ b/website/layouts/language.erb
@@ -365,7 +365,9 @@
           <li>
             <a href="#">String Functions</a>
             <ul class="nav">
-
+              <li>
+                <a href="/docs/language/functions/parseurl.html">parseurl</a>
+              </li>
               <li>
                 <a href="/docs/language/functions/chomp.html">chomp</a>
               </li>


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Fixes #

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.4.x

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

### NEW FEATURES | UPGRADE NOTES | ENHANCEMENTS | BUG FIXES | EXPERIMENTS

<!--

Write a short description of the user-facing change. Examples:

- `terraform show -json`: Fixed crash with sensitive set values.
- When rendering a diff, Terraform now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 

-  
