### PR TITLE
Update/correct GCS backend state docs in gcs.mdx

### DIFF
--- a/website/docs/language/settings/backends/gcs.mdx
+++ b/website/docs/language/settings/backends/gcs.mdx
@@ -2,7 +2,7 @@
 page_title: 'Backend Type: gcs'
 description: >-
   Terraform can store the state remotely, making it easier to version and work
-  with in a team.
+  within a team.
 ---
 
 # gcs
@@ -16,37 +16,41 @@ This backend supports [state locking](/language/state/locking).
 [Object Versioning](https://cloud.google.com/storage/docs/object-versioning)
 on the GCS bucket to allow for state recovery in the case of accidental deletions and human error.
 
-## Example Configuration
+## Set up the data source
 
 ```hcl
 terraform {
   backend "gcs" {
-    bucket  = "tf-state-prod"
-    prefix  = "terraform/state"
+    bucket = "tf-state-prod"
+    prefix = "terraform/state"
   }
+}
+
+output "greeting" {
+  value = "Hello, world!"
 }
 ```
 
-## Data Source Configuration
+## Reference the data source
 
 ```hcl
-data "terraform_remote_state" "foo" {
+data "terraform_remote_state" "my_remote_state" {
   backend = "gcs"
   config = {
-    bucket  = "terraform-state"
-    prefix  = "prod"
+    bucket = "tf-state-prod"
+    prefix = "terraform/state"
   }
 }
 
 # Terraform >= 0.12
-resource "local_file" "foo" {
-  content  = data.terraform_remote_state.foo.outputs.greeting
+resource "local_file" "my_local_file" {
+  content  = data.terraform_remote_state.my_remote_state.outputs.greeting
   filename = "${path.module}/outputs.txt"
 }
 
 # Terraform <= 0.11
-resource "local_file" "foo" {
-  content  = "${data.terraform_remote_state.foo.greeting}"
+resource "local_file" "my_local_file" {
+  content  = "${data.terraform_remote_state.my_remote_state.greeting}"
   filename = "${path.module}/outputs.txt"
 }
 ```


### PR DESCRIPTION
Fixes # _I searched and didn't see an existing issue_

## Target Release

1.4.x

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

BUG FIXES

<!--

Write a short description of the user-facing change. Examples:

- `terraform show -json`: Fixed crash with sensitive set values.
- When rendering a diff, Terraform now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 

Corrected GCS backend docs. The bucket name and prefix didn't match. Renamed sections and variables more explicitly because "data source configuration" seemed ambiguous. The one that defines the data source or uses it?

Replaced the `foo` name because it's duplicated and potentially confusing.

I tested the `Terraform >= 0.12` section with Terraform v1.3.3 on darwin_arm64 using my own bucket and prefix and followed the existing docs for the `Terraform <= 0.11` with find-replace, no testing because homebrew failed with `Error: terraform@0.11 has been disabled because it is not supported upstream!`. Hopefully, it doesn't require the `outputs` property.