### PR TITLE
Use the apparentlymart/go-versions library to parse module constraints

### DIFF
--- a/internal/initwd/module_install.go
+++ b/internal/initwd/module_install.go
@@ -4,14 +4,15 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/apparentlymart/go-versions/versions"
 	"log"
 	"os"
 	"path"
 	"path/filepath"
 	"strings"
 
+	"github.com/apparentlymart/go-versions/versions"
 	version "github.com/hashicorp/go-version"
+
 	"github.com/hashicorp/terraform-config-inspect/tfconfig"
 	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/earlyconfig"

--- a/internal/initwd/module_install.go
+++ b/internal/initwd/module_install.go
@@ -4,13 +4,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/apparentlymart/go-versions/versions"
 	"log"
 	"os"
 	"path"
 	"path/filepath"
 	"strings"
 
+	"github.com/apparentlymart/go-versions/versions"
 	version "github.com/hashicorp/go-version"
 
 	"github.com/hashicorp/terraform-config-inspect/tfconfig"

--- a/internal/initwd/testdata/prerelease-version-constraint-match/root.tf
+++ b/internal/initwd/testdata/prerelease-version-constraint-match/root.tf
@@ -1,0 +1,7 @@
+# We expect this test to download the requested version because it is an exact
+# match for a prerelease version.
+
+module "acctest_exact" {
+  source = "hashicorp/module-installer-acctest/aws"
+  version = "=0.0.3-alpha.1"
+}

--- a/internal/initwd/testdata/prerelease-version-constraint/root.tf
+++ b/internal/initwd/testdata/prerelease-version-constraint/root.tf
@@ -1,0 +1,8 @@
+# We expect this test to download the version 0.0.2, the one before the
+# specified version even with the equality because the specified version is a
+# prerelease.
+
+module "acctest_partial" {
+  source = "hashicorp/module-installer-acctest/aws"
+  version = "<=0.0.3-alpha.1"
+}


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

Update the module constraint checking logic to use the apparentlymart/go-versions library instead of the hashicorp/go-versions library. This copies the logic of the provider installer which relies entirely on the apparentlymart implementation.

A further PR could look into completely stripping out the old version with the new version for all version processing (not just constraint checking). This is a lot of work though, so this PR could be viewed as a first step in that direction, or maybe we should decide that we should fix this only with a bigger migration and I can close this PR?

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Fixes #32356 

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.3.6

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

### BUG FIXES

<!--

Write a short description of the user-facing change. Examples:

- `terraform show -json`: Fixed crash with sensitive set values.
- When rendering a diff, Terraform now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 

-  Fix exact version constraint parsing for modules using prerelease versions.
