### PR TITLE
Use jsonb type to store state with pg backend

### DIFF
--- a/internal/backend/remote-state/pg/backend.go
+++ b/internal/backend/remote-state/pg/backend.go
@@ -112,7 +112,7 @@ func (b *Backend) configure(ctx context.Context) error {
 		query = `CREATE TABLE IF NOT EXISTS %s.%s (
 			id bigint NOT NULL DEFAULT nextval('public.global_states_id_seq') PRIMARY KEY,
 			name text UNIQUE,
-			data text
+			data jsonb
 			)`
 		if _, err := db.Exec(fmt.Sprintf(query, b.schemaName, statesTableName)); err != nil {
 			return err

--- a/internal/backend/remote-state/pg/backend_test.go
+++ b/internal/backend/remote-state/pg/backend_test.go
@@ -117,7 +117,7 @@ func TestBackendConfigSkipOptions(t *testing.T) {
 				_, err = db.Query(fmt.Sprintf(`CREATE TABLE %s.%s (
 					id SERIAL PRIMARY KEY,
 					name TEXT,
-					data TEXT
+					data JSONB
 					)`, schemaName, statesTableName))
 				if err != nil {
 					t.Fatal(err)
@@ -137,7 +137,7 @@ func TestBackendConfigSkipOptions(t *testing.T) {
 				_, err = db.Query(fmt.Sprintf(`CREATE TABLE %s.%s (
 					id SERIAL PRIMARY KEY,
 					name TEXT,
-					data TEXT
+					data JSONB
 					)`, schemaName, statesTableName))
 				if err != nil {
 					t.Fatal(err)


### PR DESCRIPTION
The main objective is to be able to extract information from the state via SQL queries.
The secondary objective is to validate the input JSON, practical in case of manual editing. 

This field is available in [Postgres database](https://www.postgresql.org/) version 10 or newer.
This transparent for the code and user with TEXT version.

cf. #32380 