### PR TITLE
website: add missing Ubuntu apt repositories jammy and kinetic to the list

### DIFF
--- a/website/docs/cli/install/apt.mdx
+++ b/website/docs/cli/install/apt.mdx
@@ -91,6 +91,8 @@ following distribution releases:
 * Ubuntu 20.10 (`groovy`)
 * Ubuntu 21.04 (`hirsute`)
 * Ubuntu 21.10 (`impish`)
+* Ubuntu 22.04 (`jammy`)
+* Ubuntu 22.10 (`kinetic`)
 
 No repositories are available for other Debian or Ubuntu versions or
 any other APT-based Linux distributions. If you add the repository using


### PR DESCRIPTION
I tested both jammy and kinetic in docker and both of them have terraform packages. It's pretty bad that the list isn't updated because I almost did a bunch of unnecessary work because of it. And the person in #31826 was given bad advice since the packages were already published at that time (judging by #30974 which was opened earlier). You folks don't know what packages you publish yourselves?

Fixes #31826

Related: #30974

## Target Release

N/A

## Draft CHANGELOG entry

N/A
