### PR TITLE
Add missing HCL syntax highlighting in `composition.mdx`

### DIFF
--- a/website/docs/language/modules/develop/composition.mdx
+++ b/website/docs/language/modules/develop/composition.mdx
@@ -344,7 +344,7 @@ we might write a shared module called `join-network-aws` which can be called
 by any configuration that needs information about the shared network when
 deployed in AWS:
 
-```
+```hcl
 module "network" {
   source = "./modules/join-network-aws"
 


### PR DESCRIPTION
Tiny documentation fix: A block of HCL was missing syntax highlighting on the "Best Practices: Module Composition" page.