### PR TITLE
Reverse the order of conversion/defaults, and update HCL with more flexible defaults package

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,5 @@
 module github.com/hashicorp/terraform
 
-// replace github.com/hashicorp/hcl/v2 => ../../liamcervante/hcl
-// TODO(liamcervante): Update HCL before merging this PR, that will make the
-//                     tests pass again.
-
 require (
 	cloud.google.com/go/kms v1.6.0
 	cloud.google.com/go/storage v1.28.0

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/hashicorp/terraform
 
+replace github.com/hashicorp/hcl/v2 => ../../liamcervante/hcl
+
 require (
 	cloud.google.com/go/kms v1.6.0
 	cloud.google.com/go/storage v1.28.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/hashicorp/terraform
 
-replace github.com/hashicorp/hcl/v2 => ../../liamcervante/hcl
+// replace github.com/hashicorp/hcl/v2 => ../../liamcervante/hcl
+// TODO(liamcervante): Update HCL before merging this PR, that will make the
+//                     tests pass again.
 
 require (
 	cloud.google.com/go/kms v1.6.0

--- a/go.mod
+++ b/go.mod
@@ -47,7 +47,7 @@ require (
 	github.com/hashicorp/go-uuid v1.0.3
 	github.com/hashicorp/go-version v1.6.0
 	github.com/hashicorp/hcl v0.0.0-20170504190234-a4b07c25de5f
-	github.com/hashicorp/hcl/v2 v2.15.0
+	github.com/hashicorp/hcl/v2 v2.16.0
 	github.com/hashicorp/terraform-config-inspect v0.0.0-20210209133302-4fd17a0faac2
 	github.com/hashicorp/terraform-registry-address v0.0.0-20220623143253-7d51757b572c
 	github.com/hashicorp/terraform-svchost v0.0.0-20200729002733-f050f53b9734

--- a/go.sum
+++ b/go.sum
@@ -395,8 +395,8 @@ github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ
 github.com/hashicorp/hcl v0.0.0-20170504190234-a4b07c25de5f h1:UdxlrJz4JOnY8W+DbLISwf2B8WXEolNRA8BGCwI9jws=
 github.com/hashicorp/hcl v0.0.0-20170504190234-a4b07c25de5f/go.mod h1:oZtUIOe8dh44I2q6ScRibXws4Ajl+d+nod3AaR9vL5w=
 github.com/hashicorp/hcl/v2 v2.0.0/go.mod h1:oVVDG71tEinNGYCxinCYadcmKU9bglqW9pV3txagJ90=
-github.com/hashicorp/hcl/v2 v2.15.0 h1:CPDXO6+uORPjKflkWCCwoWc9uRp+zSIPcCQ+BrxV7m8=
-github.com/hashicorp/hcl/v2 v2.15.0/go.mod h1:JRmR89jycNkrrqnMmvPDMd56n1rQJ2Q6KocSLCMCXng=
+github.com/hashicorp/hcl/v2 v2.16.0 h1:MPq1q615H+9wBAdE3EbwEd6imSohElrIguuasbQruB0=
+github.com/hashicorp/hcl/v2 v2.16.0/go.mod h1:JRmR89jycNkrrqnMmvPDMd56n1rQJ2Q6KocSLCMCXng=
 github.com/hashicorp/jsonapi v0.0.0-20210826224640-ee7dae0fb22d h1:9ARUJJ1VVynB176G1HCwleORqCaXm/Vx0uUi0dL26I0=
 github.com/hashicorp/jsonapi v0.0.0-20210826224640-ee7dae0fb22d/go.mod h1:Yog5+CPEM3c99L1CL2CFCYoSzgWm5vTU58idbRUaLik=
 github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO+LraFDTW64=

--- a/internal/terraform/eval_variable.go
+++ b/internal/terraform/eval_variable.go
@@ -90,6 +90,14 @@ func prepareFinalInputVariableValue(addr addrs.AbsInputVariableInstance, raw *In
 		given = defaultVal // must be set, because we checked above that the variable isn't required
 	}
 
+	// Apply defaults from the variable's type constraint to the converted value,
+	// unless the converted value is null. We do not apply defaults to top-level
+	// null values, as doing so could prevent assigning null to a nullable
+	// variable.
+	if cfg.TypeDefaults != nil && !given.IsNull() {
+		given = cfg.TypeDefaults.Apply(given)
+	}
+
 	val, err := convert.Convert(given, convertTy)
 	if err != nil {
 		log.Printf("[ERROR] prepareFinalInputVariableValue: %s has unsuitable type\n  got:  %s\n  want: %s", addr, given.Type(), convertTy)
@@ -130,14 +138,6 @@ func prepareFinalInputVariableValue(addr addrs.AbsInputVariableInstance, raw *In
 		// We'll return a placeholder unknown value to avoid producing
 		// redundant downstream errors.
 		return cty.UnknownVal(cfg.Type), diags
-	}
-
-	// Apply defaults from the variable's type constraint to the converted value,
-	// unless the converted value is null. We do not apply defaults to top-level
-	// null values, as doing so could prevent assigning null to a nullable
-	// variable.
-	if cfg.TypeDefaults != nil && !val.IsNull() {
-		val = cfg.TypeDefaults.Apply(val)
 	}
 
 	// By the time we get here, we know:

--- a/internal/terraform/eval_variable_test.go
+++ b/internal/terraform/eval_variable_test.go
@@ -522,6 +522,39 @@ func TestPrepareFinalInputVariableValue(t *testing.T) {
 			cty.UnknownVal(cty.String),
 			``,
 		},
+		{
+			"list_with_nested_collections_dynamic_with_default",
+			cty.TupleVal([]cty.Value{
+				cty.ObjectVal(map[string]cty.Value{
+					"name": cty.StringVal("default"),
+				}),
+				cty.ObjectVal(map[string]cty.Value{
+					"name": cty.StringVal("complex"),
+					"taints": cty.ListVal([]cty.Value{
+						cty.MapVal(map[string]cty.Value{
+							"key":   cty.StringVal("my_key"),
+							"value": cty.StringVal("my_value"),
+						}),
+					}),
+				}),
+			}),
+			cty.ListVal([]cty.Value{
+				cty.ObjectVal(map[string]cty.Value{
+					"name":   cty.StringVal("default"),
+					"taints": cty.ListValEmpty(cty.Map(cty.String)),
+				}),
+				cty.ObjectVal(map[string]cty.Value{
+					"name": cty.StringVal("complex"),
+					"taints": cty.ListVal([]cty.Value{
+						cty.MapVal(map[string]cty.Value{
+							"key":   cty.StringVal("my_key"),
+							"value": cty.StringVal("my_value"),
+						}),
+					}),
+				}),
+			}),
+			``,
+		},
 
 		// complex types
 

--- a/internal/terraform/eval_variable_test.go
+++ b/internal/terraform/eval_variable_test.go
@@ -180,6 +180,18 @@ func TestPrepareFinalInputVariableValue(t *testing.T) {
 				}
 			]
 		}
+		// https://github.com/hashicorp/terraform/issues/32396
+		// This variable was originally introduced to test the behaviour of the
+        // dynamic type constraint. You should be able to set primitive types in
+        // the list consistently.
+        variable "list_with_nested_collections_dynamic_with_default" {
+			type = list(
+				object({
+					name = optional(string, "default")
+					taints = optional(list(map(any)), [])
+				})
+			)
+		}
 	`
 	cfg := testModuleInline(t, map[string]string{
 		"main.tf": cfgSrc,
@@ -709,6 +721,39 @@ func TestPrepareFinalInputVariableValue(t *testing.T) {
 					"a": cty.StringVal("b"),
 					"b": cty.ListVal([]cty.Value{
 						cty.NumberIntVal(1),
+					}),
+				}),
+			}),
+			``,
+		},
+		{
+			"list_with_nested_collections_dynamic_with_default",
+			cty.TupleVal([]cty.Value{
+				cty.ObjectVal(map[string]cty.Value{
+					"name": cty.StringVal("default"),
+				}),
+				cty.ObjectVal(map[string]cty.Value{
+					"name": cty.StringVal("complex"),
+					"taints": cty.ListVal([]cty.Value{
+						cty.MapVal(map[string]cty.Value{
+							"key":   cty.StringVal("my_key"),
+							"value": cty.StringVal("my_value"),
+						}),
+					}),
+				}),
+			}),
+			cty.ListVal([]cty.Value{
+				cty.ObjectVal(map[string]cty.Value{
+					"name":   cty.StringVal("default"),
+					"taints": cty.ListValEmpty(cty.Map(cty.String)),
+				}),
+				cty.ObjectVal(map[string]cty.Value{
+					"name": cty.StringVal("complex"),
+					"taints": cty.ListVal([]cty.Value{
+						cty.MapVal(map[string]cty.Value{
+							"key":   cty.StringVal("my_key"),
+							"value": cty.StringVal("my_value"),
+						}),
 					}),
 				}),
 			}),


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

- Update to latest version of HCL, with flexible defaults package.
- Add test case that demonstrates failure of conversion before defaults with `any` type constraint.
- Apply defaults before conversion, in line with new HCL version.

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->


Fixes #32396 

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.3.8 / 1.3.9 / 1.4.0

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

### BUG FIXES

<!--

Write a short description of the user-facing change. Examples:

- `terraform show -json`: Fixed crash with sensitive set values.
- When rendering a diff, Terraform now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 

-  Fix terraform crash when applying defaults into a collection with dynamic type constraint.
