### PR TITLE
Proof-of-concept only: replace "any" type constraint placeholder with "inferred"

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -43,7 +43,7 @@ require (
 	github.com/hashicorp/go-uuid v1.0.3
 	github.com/hashicorp/go-version v1.6.0
 	github.com/hashicorp/hcl v0.0.0-20170504190234-a4b07c25de5f
-	github.com/hashicorp/hcl/v2 v2.15.0
+	github.com/hashicorp/hcl/v2 v2.15.1-0.20230104181514-d3192537bcf4
 	github.com/hashicorp/terraform-config-inspect v0.0.0-20210209133302-4fd17a0faac2
 	github.com/hashicorp/terraform-registry-address v0.0.0-20220623143253-7d51757b572c
 	github.com/hashicorp/terraform-svchost v0.0.0-20200729002733-f050f53b9734

--- a/go.sum
+++ b/go.sum
@@ -397,6 +397,8 @@ github.com/hashicorp/hcl v0.0.0-20170504190234-a4b07c25de5f/go.mod h1:oZtUIOe8dh
 github.com/hashicorp/hcl/v2 v2.0.0/go.mod h1:oVVDG71tEinNGYCxinCYadcmKU9bglqW9pV3txagJ90=
 github.com/hashicorp/hcl/v2 v2.15.0 h1:CPDXO6+uORPjKflkWCCwoWc9uRp+zSIPcCQ+BrxV7m8=
 github.com/hashicorp/hcl/v2 v2.15.0/go.mod h1:JRmR89jycNkrrqnMmvPDMd56n1rQJ2Q6KocSLCMCXng=
+github.com/hashicorp/hcl/v2 v2.15.1-0.20230104181514-d3192537bcf4 h1:mt5hF48OVC43aHXLQCaIztVp5hnmUEkI+Y8+/4sEvUI=
+github.com/hashicorp/hcl/v2 v2.15.1-0.20230104181514-d3192537bcf4/go.mod h1:JRmR89jycNkrrqnMmvPDMd56n1rQJ2Q6KocSLCMCXng=
 github.com/hashicorp/jsonapi v0.0.0-20210826224640-ee7dae0fb22d h1:9ARUJJ1VVynB176G1HCwleORqCaXm/Vx0uUi0dL26I0=
 github.com/hashicorp/jsonapi v0.0.0-20210826224640-ee7dae0fb22d/go.mod h1:Yog5+CPEM3c99L1CL2CFCYoSzgWm5vTU58idbRUaLik=
 github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO+LraFDTW64=

--- a/internal/command/testdata/fmt/any_to_inferred_in.tf
+++ b/internal/command/testdata/fmt/any_to_inferred_in.tf
@@ -1,0 +1,39 @@
+variable "just_any" {
+  type = any
+}
+
+variable "map_of_any" {
+  type = map(any)
+}
+
+variable "list_of_any" {
+  type = list(any)
+}
+
+variable "set_of_any" {
+  type = list(any)
+}
+
+variable "object_attr_with_any" {
+  type = object({
+    any = any
+    not_any = string
+  })
+}
+
+variable "object_attr_with_optional_any" {
+  type = object({
+    any = optional(any)
+    not_any = optional(string)
+  })
+}
+
+variable "tuple_elem_with_any" {
+  type = tuple([any, string])
+}
+
+variable "map_of_object_with_any" {
+  type = map(object({
+    any = any
+  }))
+}

--- a/internal/command/testdata/fmt/any_to_inferred_out.tf
+++ b/internal/command/testdata/fmt/any_to_inferred_out.tf
@@ -1,0 +1,39 @@
+variable "just_any" {
+  type = inferred
+}
+
+variable "map_of_any" {
+  type = map(inferred)
+}
+
+variable "list_of_any" {
+  type = list(inferred)
+}
+
+variable "set_of_any" {
+  type = list(inferred)
+}
+
+variable "object_attr_with_any" {
+  type = object({
+    any     = inferred
+    not_any = string
+  })
+}
+
+variable "object_attr_with_optional_any" {
+  type = object({
+    any     = optional(inferred)
+    not_any = optional(string)
+  })
+}
+
+variable "tuple_elem_with_any" {
+  type = tuple([inferred, string])
+}
+
+variable "map_of_object_with_any" {
+  type = map(object({
+    any = inferred
+  }))
+}

--- a/internal/configs/testdata/valid-files/variables.tf
+++ b/internal/configs/testdata/valid-files/variables.tf
@@ -42,3 +42,7 @@ variable "nullable_default_null" {
   nullable = true
   default = null
 }
+
+variable "inferred" {
+  type = inferred
+}


### PR DESCRIPTION
These changes are just an experiment with the idea of renaming the "any" type constraint placeholder with another keyword "inferred" which has exactly the same functionality but is more explicit about what it represents.

Since adding `any` in Terraform v0.12 it's become a bit of an attractive nuisance, because its name makes people think it represents full dynamic typing but really it represents automatic inference of a single exact type. For simple situations the automatic inference does something essentially equivalent to full dynamic typing and so new module authors will often try it and see that it seems to work as they expected even though they have made an incorrect assumption about its purpose, and then only run into trouble later when their module is in real-world use but it's become hard to revise the design without breaking backward compatibility.

This PR is just trying out one possible idea for how to address this. It includes the following:
* Terraform will accept the keyword `inferred` in any location where the `any` placeholder was previously valid, with exactly the same meaning and resulting behavior.
* Terraform will emit a warning if a module uses `any`, recommending to adopt `inferred` instead.
* `terraform fmt` will automatically rewrite `any` to `inferred`, to make it easy to migrate and thus silence the warnings.

This is not viable to ship as-is and is not intended to be. The goal here is only to evaluate the technical complexity of making this change, which seems to be relatively light.

If we did want to do something in this direction in a future release, I expect we'd want to roll it out more gradually rather than all in one go like this.

Specifically, I'd recommend to make `any` and `inferred` exactly equivalent (no deprecation warnings) and include the `terraform fmt` change for at least one whole minor release before explicitly deprecating `any`, so that there is a suitable window for module authors to migrate before their modules start generating warnings. We may choose to increase that window over multiple minor releases to ease the tradeoff between ending support for earlier Terraform versions (that won't accept `inferred` at all) or generating noisy warnings on newer versions of Terraform.

Updating the docs to primarily describe `inferred` and to mention `any` only as a deprecated feature, along with the `terraform fmt` change, would hopefully go a long way to discourage using `any` for totally new modules. But we also know that new Terraform users often use existing public modules as a foundation for their learning and so long-deprecated patterns tend to stick around as long as there are highly-visible public modules still using them, and so the effectiveness of this change would be limited as long as there isn't an incentive to update existing modules to use the new keyword.

This is just here to illustrate one possible path forward.  There's no plan to do anything real with this right now, and a final plan in this area might involve doing something entirely different than what I tried here.
