### PR TITLE
Ensure we have all references for output preconditions

### DIFF
--- a/internal/terraform/node_output.go
+++ b/internal/terraform/node_output.go
@@ -278,19 +278,21 @@ func (n *NodeApplyableOutput) ReferenceableAddrs() []addrs.Referenceable {
 }
 
 func referencesForOutput(c *configs.Output) []*addrs.Reference {
+	var refs []*addrs.Reference
+
 	impRefs, _ := lang.ReferencesInExpr(c.Expr)
 	expRefs, _ := lang.References(c.DependsOn)
-	l := len(impRefs) + len(expRefs)
-	if l == 0 {
-		return nil
-	}
-	refs := make([]*addrs.Reference, 0, l)
+
 	refs = append(refs, impRefs...)
 	refs = append(refs, expRefs...)
+
 	for _, check := range c.Preconditions {
-		checkRefs, _ := lang.ReferencesInExpr(check.Condition)
-		refs = append(refs, checkRefs...)
+		condRefs, _ := lang.ReferencesInExpr(check.Condition)
+		refs = append(refs, condRefs...)
+		errRefs, _ := lang.ReferencesInExpr(check.ErrorMessage)
+		refs = append(refs, errRefs...)
 	}
+
 	return refs
 }
 


### PR DESCRIPTION
Output references from `error_message` were not being tracked. Also fix the early return in `referencesForOutput`, which could skip preconditions altogether. The small slice allocation optimization is not really needed here, since this is not a hot path at all.

Fixes #32447
