### PR TITLE
Structured Plan Renderer: Escape object and block keys that don't match HCL syntax

### DIFF
--- a/internal/command/jsonformat/change/block.go
+++ b/internal/command/jsonformat/change/block.go
@@ -47,7 +47,7 @@ func (renderer blockRenderer) Render(change Change, indent int, opts RenderOpts)
 	escapedAttributeKeys := make(map[string]string)
 	for key := range renderer.attributes {
 		attributeKeys = append(attributeKeys, key)
-		escapedKey := change.escapeAttributeName(key)
+		escapedKey := change.ensureValidAttributeName(key)
 		escapedAttributeKeys[key] = escapedKey
 		if maximumAttributeKeyLen < len(escapedKey) {
 			maximumAttributeKeyLen = len(escapedKey)
@@ -107,7 +107,7 @@ func (renderer blockRenderer) Render(change Change, indent int, opts RenderOpts)
 			for _, warning := range block.Warnings(indent + 1) {
 				buf.WriteString(fmt.Sprintf("%s%s\n", change.indent(indent+1), warning))
 			}
-			buf.WriteString(fmt.Sprintf("%s%s %s %s\n", change.indent(indent+1), format.DiffActionSymbol(block.action), change.escapeAttributeName(key), block.Render(indent+1, opts)))
+			buf.WriteString(fmt.Sprintf("%s%s %s %s\n", change.indent(indent+1), format.DiffActionSymbol(block.action), change.ensureValidAttributeName(key), block.Render(indent+1, opts)))
 		}
 	}
 

--- a/internal/command/jsonformat/change/block.go
+++ b/internal/command/jsonformat/change/block.go
@@ -25,45 +25,43 @@ func importantAttribute(attr string) bool {
 }
 
 func Block(attributes map[string]Change, blocks map[string][]Change) Renderer {
-	maximumKeyLen := 0
-	for key := range attributes {
-		if len(key) > maximumKeyLen {
-			maximumKeyLen = len(key)
-		}
-	}
-
 	return &blockRenderer{
-		attributes:    attributes,
-		blocks:        blocks,
-		maximumKeyLen: maximumKeyLen,
+		attributes: attributes,
+		blocks:     blocks,
 	}
 }
 
 type blockRenderer struct {
 	NoWarningsRenderer
 
-	attributes    map[string]Change
-	blocks        map[string][]Change
-	maximumKeyLen int
+	attributes map[string]Change
+	blocks     map[string][]Change
 }
 
 func (renderer blockRenderer) Render(change Change, indent int, opts RenderOpts) string {
 	unchangedAttributes := 0
 	unchangedBlocks := 0
 
+	maximumAttributeKeyLen := 0
+	var attributeKeys []string
+	escapedAttributeKeys := make(map[string]string)
+	for key := range renderer.attributes {
+		attributeKeys = append(attributeKeys, key)
+		escapedKey := change.escapeAttributeName(key)
+		escapedAttributeKeys[key] = escapedKey
+		if maximumAttributeKeyLen < len(escapedKey) {
+			maximumAttributeKeyLen = len(escapedKey)
+		}
+	}
+	sort.Strings(attributeKeys)
+
 	var buf bytes.Buffer
 	buf.WriteString(fmt.Sprintf("{%s\n", change.forcesReplacement()))
 	for _, importantKey := range importantAttributes {
 		if attribute, ok := renderer.attributes[importantKey]; ok {
-			buf.WriteString(fmt.Sprintf("%s%s %-*s = %s\n", change.indent(indent+1), format.DiffActionSymbol(attribute.action), renderer.maximumKeyLen, importantKey, attribute.Render(indent+1, opts)))
+			buf.WriteString(fmt.Sprintf("%s%s %-*s = %s\n", change.indent(indent+1), format.DiffActionSymbol(attribute.action), maximumAttributeKeyLen, importantKey, attribute.Render(indent+1, opts)))
 		}
 	}
-
-	var attributeKeys []string
-	for key := range renderer.attributes {
-		attributeKeys = append(attributeKeys, key)
-	}
-	sort.Strings(attributeKeys)
 
 	for _, key := range attributeKeys {
 		if importantAttribute(key) {
@@ -78,7 +76,7 @@ func (renderer blockRenderer) Render(change Change, indent int, opts RenderOpts)
 		for _, warning := range attribute.Warnings(indent + 1) {
 			buf.WriteString(fmt.Sprintf("%s%s\n", change.indent(indent+1), warning))
 		}
-		buf.WriteString(fmt.Sprintf("%s%s %-*s = %s\n", change.indent(indent+1), format.DiffActionSymbol(attribute.action), renderer.maximumKeyLen, key, attribute.Render(indent+1, opts)))
+		buf.WriteString(fmt.Sprintf("%s%s %-*s = %s\n", change.indent(indent+1), format.DiffActionSymbol(attribute.action), maximumAttributeKeyLen, escapedAttributeKeys[key], attribute.Render(indent+1, opts)))
 	}
 
 	if unchangedAttributes > 0 {
@@ -109,7 +107,7 @@ func (renderer blockRenderer) Render(change Change, indent int, opts RenderOpts)
 			for _, warning := range block.Warnings(indent + 1) {
 				buf.WriteString(fmt.Sprintf("%s%s\n", change.indent(indent+1), warning))
 			}
-			buf.WriteString(fmt.Sprintf("%s%s %s %s\n", change.indent(indent+1), format.DiffActionSymbol(block.action), key, block.Render(indent+1, opts)))
+			buf.WriteString(fmt.Sprintf("%s%s %s %s\n", change.indent(indent+1), format.DiffActionSymbol(block.action), change.escapeAttributeName(key), block.Render(indent+1, opts)))
 		}
 	}
 

--- a/internal/command/jsonformat/change/change.go
+++ b/internal/command/jsonformat/change/change.go
@@ -2,6 +2,7 @@ package change
 
 import (
 	"fmt"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"strings"
 
 	"github.com/hashicorp/terraform/internal/plans"
@@ -104,4 +105,13 @@ func (change Change) unchanged(keyword string, count int) string {
 		return fmt.Sprintf("[dark_gray]# (%d unchanged %s hidden)[reset]", count, keyword)
 	}
 	return fmt.Sprintf("[dark_gray]# (%d unchanged %ss hidden)[reset]", count, keyword)
+}
+
+// escapeAttributeName checks if `name` contains any HCL syntax and returns it
+// surrounded by quotation marks if it does.
+func (change Change) escapeAttributeName(name string) string {
+	if !hclsyntax.ValidIdentifier(name) {
+		return fmt.Sprintf("%q", name)
+	}
+	return name
 }

--- a/internal/command/jsonformat/change/change.go
+++ b/internal/command/jsonformat/change/change.go
@@ -2,8 +2,9 @@ package change
 
 import (
 	"fmt"
-	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"strings"
+
+	"github.com/hashicorp/hcl/v2/hclsyntax"
 
 	"github.com/hashicorp/terraform/internal/plans"
 )
@@ -107,9 +108,9 @@ func (change Change) unchanged(keyword string, count int) string {
 	return fmt.Sprintf("[dark_gray]# (%d unchanged %ss hidden)[reset]", count, keyword)
 }
 
-// escapeAttributeName checks if `name` contains any HCL syntax and returns it
-// surrounded by quotation marks if it does.
-func (change Change) escapeAttributeName(name string) string {
+// ensureValidAttributeName checks if `name` contains any HCL syntax and returns
+// it surrounded by quotation marks if it does.
+func (change Change) ensureValidAttributeName(name string) string {
 	if !hclsyntax.ValidIdentifier(name) {
 		return fmt.Sprintf("%q", name)
 	}

--- a/internal/command/jsonformat/change/object.go
+++ b/internal/command/jsonformat/change/object.go
@@ -10,31 +10,15 @@ import (
 )
 
 func Object(attributes map[string]Change) Renderer {
-	maximumKeyLen := 0
-	for key := range attributes {
-		if maximumKeyLen < len(key) {
-			maximumKeyLen = len(key)
-		}
-	}
-
 	return &objectRenderer{
 		attributes:         attributes,
-		maximumKeyLen:      maximumKeyLen,
 		overrideNullSuffix: true,
 	}
 }
 
 func NestedObject(attributes map[string]Change) Renderer {
-	maximumKeyLen := 0
-	for key := range attributes {
-		if maximumKeyLen < len(key) {
-			maximumKeyLen = len(key)
-		}
-	}
-
 	return &objectRenderer{
 		attributes:         attributes,
-		maximumKeyLen:      maximumKeyLen,
 		overrideNullSuffix: false,
 	}
 }
@@ -43,7 +27,6 @@ type objectRenderer struct {
 	NoWarningsRenderer
 
 	attributes         map[string]Change
-	maximumKeyLen      int
 	overrideNullSuffix bool
 }
 
@@ -55,9 +38,20 @@ func (renderer objectRenderer) Render(change Change, indent int, opts RenderOpts
 	attributeOpts := opts.Clone()
 	attributeOpts.overrideNullSuffix = renderer.overrideNullSuffix
 
+	// We need to keep track of our keys in two ways. The first is the order in
+	// which we will display them. The second is a mapping to their safely
+	// escaped equivalent.
+
+	maximumKeyLen := 0
 	var keys []string
+	escapedKeys := make(map[string]string)
 	for key := range renderer.attributes {
 		keys = append(keys, key)
+		escapedKey := change.escapeAttributeName(key)
+		escapedKeys[key] = escapedKey
+		if maximumKeyLen < len(escapedKey) {
+			maximumKeyLen = len(escapedKey)
+		}
 	}
 	sort.Strings(keys)
 
@@ -76,7 +70,7 @@ func (renderer objectRenderer) Render(change Change, indent int, opts RenderOpts
 		for _, warning := range attribute.Warnings(indent + 1) {
 			buf.WriteString(fmt.Sprintf("%s%s\n", change.indent(indent+1), warning))
 		}
-		buf.WriteString(fmt.Sprintf("%s%s %-*s = %s\n", change.indent(indent+1), format.DiffActionSymbol(attribute.action), renderer.maximumKeyLen, key, attribute.Render(indent+1, attributeOpts)))
+		buf.WriteString(fmt.Sprintf("%s%s %-*s = %s\n", change.indent(indent+1), format.DiffActionSymbol(attribute.action), maximumKeyLen, escapedKeys[key], attribute.Render(indent+1, attributeOpts)))
 	}
 
 	if unchangedAttributes > 0 {

--- a/internal/command/jsonformat/change/object.go
+++ b/internal/command/jsonformat/change/object.go
@@ -47,7 +47,7 @@ func (renderer objectRenderer) Render(change Change, indent int, opts RenderOpts
 	escapedKeys := make(map[string]string)
 	for key := range renderer.attributes {
 		keys = append(keys, key)
-		escapedKey := change.escapeAttributeName(key)
+		escapedKey := change.ensureValidAttributeName(key)
 		escapedKeys[key] = escapedKey
 		if maximumKeyLen < len(escapedKey) {
 			maximumKeyLen = len(escapedKey)

--- a/internal/command/jsonformat/differ/tuple.go
+++ b/internal/command/jsonformat/differ/tuple.go
@@ -1,8 +1,9 @@
 package differ
 
 import (
-	"github.com/hashicorp/terraform/internal/command/jsonformat/change"
 	"github.com/zclconf/go-cty/cty"
+
+	"github.com/hashicorp/terraform/internal/command/jsonformat/change"
 )
 
 func (v Value) computeAttributeChangeAsTuple(elementTypes []cty.Type) change.Change {


### PR DESCRIPTION
This PR adds functionality so that keys of objects and blocks that fail the HCL syntax check will be rendered within quotation marks.

This matches the checks and behaviour of the old renderer.