### PR TITLE
docs: Explicitly mention Computed-only attribute behavior for Proposed New State

### DIFF
--- a/docs/resource-instance-change-lifecycle.md
+++ b/docs/resource-instance-change-lifecycle.md
@@ -33,9 +33,11 @@ The various object values used in different parts of this process are:
   which a provider may use as a starting point for its planning operation.
 
     The built-in logic primarily deals with the expected behavior for attributes
-    marked in the schema as both "optional" _and_ "computed", which means that
-    the user may either set it or may leave it unset to allow the provider
-    to choose a value instead.
+    marked in the schema as "computed". If an attribute is only "computed",
+    Terraform expects the value to only be chosen by the provider and it will
+    preserve any Prior State. If an attribute is marked as "computed" and
+    "optional", this means that the user may either set it or may leave it
+    unset to allow the provider to choose a value.
 
     Terraform Core therefore constructs the proposed new state by taking the
     attribute value from Configuration if it is non-null, and then using the


### PR DESCRIPTION
Reference: https://github.com/hashicorp/terraform/blob/21bb677db706111d634d1b49ea0845ace67651b3/internal/plans/objchange/objchange.go#L289-L292

Previously, the resource lifecycle documentation for Proposed New State only mentioned special behavior for Optional and Computed attributes. This minor documentation update mentions that Terraform also imposes special behavior on Computed-only attributes (preserving any Prior State value).

## Target Release

N/A (main)


