### PR TITLE
Remove outputs from the jsonplan that are not from the root module

### DIFF
--- a/internal/command/jsonplan/plan.go
+++ b/internal/command/jsonplan/plan.go
@@ -437,6 +437,15 @@ func (p *plan) marshalOutputChanges(changes *plans.Changes) error {
 
 	p.OutputChanges = make(map[string]Change, len(changes.Outputs))
 	for _, oc := range changes.Outputs {
+
+		// Skip output changes that are not from the root module.
+		// These are automatically stripped from plans that are written to disk
+		// elsewhere, we just need to duplicate the logic here in case anyone
+		// is converting this plan directly from memory.
+		if !oc.Addr.Module.IsRoot() {
+			continue
+		}
+
 		changeV, err := oc.Decode()
 		if err != nil {
 			return err


### PR DESCRIPTION
These outputs are already removed from the internal plan when it is saved to disk, but now we are starting to read from the jsonplan in memory so we just need to another check of this directly in the marshaller.