### PR TITLE
typed null input should be reflected in output

### DIFF
--- a/internal/builtin/providers/terraform/resource_data.go
+++ b/internal/builtin/providers/terraform/resource_data.go
@@ -76,7 +76,7 @@ func planDataStoreResourceChange(req providers.PlanResourceChangeRequest) (resp 
 
 		// Output type must always match the input, even when it's null.
 		if input.IsNull() {
-			planned["output"] = cty.NullVal(input.Type())
+			planned["output"] = input
 		} else {
 			planned["output"] = cty.UnknownVal(input.Type())
 		}
@@ -92,7 +92,7 @@ func planDataStoreResourceChange(req providers.PlanResourceChangeRequest) (resp 
 		// We need to check the input for the replacement instance to compute a
 		// new output.
 		if input.IsNull() {
-			planned["output"] = cty.NullVal(input.Type())
+			planned["output"] = input
 		} else {
 			planned["output"] = cty.UnknownVal(input.Type())
 		}

--- a/internal/builtin/providers/terraform/resource_data.go
+++ b/internal/builtin/providers/terraform/resource_data.go
@@ -74,8 +74,10 @@ func planDataStoreResourceChange(req providers.PlanResourceChangeRequest) (resp 
 		// Set the id value to unknown.
 		planned["id"] = cty.UnknownVal(cty.String)
 
-		// Only compute a new output if input has a non-null value.
-		if !input.IsNull() {
+		// Output type must always match the input, even when it's null.
+		if input.IsNull() {
+			planned["output"] = cty.NullVal(input.Type())
+		} else {
 			planned["output"] = cty.UnknownVal(input.Type())
 		}
 
@@ -90,7 +92,7 @@ func planDataStoreResourceChange(req providers.PlanResourceChangeRequest) (resp 
 		// We need to check the input for the replacement instance to compute a
 		// new output.
 		if input.IsNull() {
-			planned["output"] = cty.NullVal(cty.DynamicPseudoType)
+			planned["output"] = cty.NullVal(input.Type())
 		} else {
 			planned["output"] = cty.UnknownVal(input.Type())
 		}

--- a/internal/builtin/providers/terraform/resource_data_test.go
+++ b/internal/builtin/providers/terraform/resource_data_test.go
@@ -125,6 +125,22 @@ func TestManagedDataPlan(t *testing.T) {
 			}),
 		},
 
+		"create-typed-null-input": {
+			prior: cty.NullVal(ty),
+			proposed: cty.ObjectVal(map[string]cty.Value{
+				"input":            cty.NullVal(cty.String),
+				"output":           cty.NullVal(cty.DynamicPseudoType),
+				"triggers_replace": cty.NullVal(cty.DynamicPseudoType),
+				"id":               cty.NullVal(cty.String),
+			}),
+			planned: cty.ObjectVal(map[string]cty.Value{
+				"input":            cty.NullVal(cty.String),
+				"output":           cty.NullVal(cty.String),
+				"triggers_replace": cty.NullVal(cty.DynamicPseudoType),
+				"id":               cty.UnknownVal(cty.String),
+			}),
+		},
+
 		"create-output": {
 			prior: cty.NullVal(ty),
 			proposed: cty.ObjectVal(map[string]cty.Value{


### PR DESCRIPTION
The configuration may be supplying a typed null value to the terraform_data.input attribute, which must be reflected in the output to have a valid plan. This wouldn't fail on an initial plan, but if an earlier plan contains an unknown input, then we need to match the resulting type of that prior plan.