### PR TITLE
docs: provisioners: fix formatting on a note

### DIFF
--- a/website/docs/language/resources/provisioners/syntax.mdx
+++ b/website/docs/language/resources/provisioners/syntax.mdx
@@ -234,7 +234,7 @@ fail, Terraform will error and rerun the provisioners again on the next
 `terraform apply`. Due to this behavior, care should be taken for destroy
 provisioners to be safe to run multiple times.
 
-~> **NOTE:** Destroy provisioners of this resource do not run if `create_before_destroy` is set to `true`. This [GitHub issue](https://github.com/hashicorp/terraform/issues/13549) contains more details.
+~> **Note**: Destroy provisioners of this resource do not run if `create_before_destroy` is set to `true`. This [GitHub issue](https://github.com/hashicorp/terraform/issues/13549) contains more details.
 
 Destroy-time provisioners can only run if they remain in the configuration
 at the time a resource is destroyed. If a resource block with a destroy-time

--- a/website/docs/language/resources/provisioners/syntax.mdx
+++ b/website/docs/language/resources/provisioners/syntax.mdx
@@ -234,10 +234,7 @@ fail, Terraform will error and rerun the provisioners again on the next
 `terraform apply`. Due to this behavior, care should be taken for destroy
 provisioners to be safe to run multiple times.
 
-```
-Destroy provisioners of this resource do not run if `create_before_destroy`
-is set to `true`. This [GitHub issue](https://github.com/hashicorp/terraform/issues/13549) contains more details.
-```
+~> **NOTE:** Destroy provisioners of this resource do not run if `create_before_destroy` is set to `true`. This [GitHub issue](https://github.com/hashicorp/terraform/issues/13549) contains more details.
 
 Destroy-time provisioners can only run if they remain in the configuration
 at the time a resource is destroyed. If a resource block with a destroy-time


### PR DESCRIPTION
The destroy-time provisioner note was formatted as a code block instead of an actual note.