### PR TITLE
Add support for PG_CONN_STR ENV var

### DIFF
--- a/internal/backend/remote-state/pg/backend.go
+++ b/internal/backend/remote-state/pg/backend.go
@@ -23,7 +23,7 @@ func New() backend.Backend {
 				Type:        schema.TypeString,
 				Required:    true,
 				Description: "Postgres connection string; a `postgres://` URL",
-				DefaultFunc: schema.EnvDefaultFunc("PG_CONN_STR", ""),
+				DefaultFunc: schema.EnvDefaultFunc("PGDATABASE", nil),
 			},
 
 			"schema_name": {

--- a/internal/backend/remote-state/pg/backend.go
+++ b/internal/backend/remote-state/pg/backend.go
@@ -23,6 +23,7 @@ func New() backend.Backend {
 				Type:        schema.TypeString,
 				Required:    true,
 				Description: "Postgres connection string; a `postgres://` URL",
+				DefaultFunc: schema.EnvDefaultFunc("PG_CONN_STR", ""),
 			},
 
 			"schema_name": {

--- a/website/docs/language/settings/backends/pg.mdx
+++ b/website/docs/language/settings/backends/pg.mdx
@@ -68,7 +68,7 @@ data "terraform_remote_state" "network" {
 
 The following configuration options or environment variables are supported:
 
-- `conn_str` - (Required) Postgres connection string; a `postgres://` URL
+- `conn_str` - (Required) Postgres connection string; a `postgres://` URL. `conn_str` can also be set using the `PGDATABASE` environment variable.
 - `schema_name` - Name of the automatically-managed Postgres schema, default `terraform_remote_state`.
 - `skip_schema_creation` - If set to `true`, the Postgres schema must already exist. Terraform won't try to create the schema, this is useful when it has already been created by a database administrator.
 - `skip_table_creation` - If set to `true`, the Postgres table must already exist. Terraform won't try to create the table, this is useful when it has already been created by a database administrator.


### PR DESCRIPTION
Describe in detail the changes you are proposing, and the rationale.

Somwhat Fixes #32525 , but only the easy way, by supporting the whole `conn_str` as environment variable. Theoretically being able to build this using `DB_NAME`, `DB_USER`, `DB_PASSWORD` and `DB_HOSTANAME` (or so) would be even more interesting.



## Target Release

(not important, just convenient)

1.4.x


## ENHANCEMENTS 

A user can now (eg by the pipeline, which is running `terraform`) set the `conn_str` as environment variable, instead of having the requirement to set it inside the `backend` block. This mainly prevents the `backend` block from containing a secret (mostly the database password). 

In the [`backend_test.go`](https://github.com/hashicorp/terraform/blob/main/internal/backend/remote-state/pg/backend_test.go#L29-L31) this is basically done by setting `DATABASE_URL` (which imho is a somehow not nice variable name, that’s why I have called it `PG_CONN_STR`, `PG` for the Backend type and `CONN_STR` which is the name of the variable). I have not replaced `DATABASE_URL` in the tests with `PG_CONN_STR`, since I am not aware of where I would need to replace this and I avoid to break the tests (for no very good reason). 

