### PR TITLE
Structured Plan Renderer: Read the data source schemas from the right place

### DIFF
--- a/internal/command/jsonformat/renderer.go
+++ b/internal/command/jsonformat/renderer.go
@@ -78,7 +78,7 @@ func (r Renderer) RenderHumanPlan(plan Plan, mode plans.Mode, opts ...RendererOp
 			// Don't show anything for NoOp changes.
 			continue
 		}
-		if action == plans.Delete && diff.change.Mode != "managed" {
+		if action == plans.Delete && diff.change.Mode != jsonplan.ManagedResourceMode {
 			// Don't render anything for deleted data sources.
 			continue
 		}
@@ -464,7 +464,7 @@ func resourceChangeComment(resource jsonplan.ResourceChange, action plans.Action
 
 func resourceChangeHeader(change jsonplan.ResourceChange) string {
 	mode := "resource"
-	if change.Mode != "managed" {
+	if change.Mode != jsonplan.ManagedResourceMode {
 		mode = "data"
 	}
 	return fmt.Sprintf("%s \"%s\" \"%s\"", mode, change.Type, change.Name)

--- a/internal/command/jsonplan/plan.go
+++ b/internal/command/jsonplan/plan.go
@@ -39,6 +39,9 @@ const (
 	ResourceInstanceDeleteBecauseNoMoveTarget     = "delete_because_no_move_target"
 	ResourceInstanceReadBecauseConfigUnknown      = "read_because_config_unknown"
 	ResourceInstanceReadBecauseDependencyPending  = "read_because_dependency_pending"
+
+	ManagedResourceMode = "resource"
+	DataResourceMode    = "data"
 )
 
 // Plan is the top-level representation of the json format of a plan. It includes
@@ -445,9 +448,9 @@ func MarshalResourceChanges(resources []*plans.ResourceInstanceChangeSrc, schema
 
 		switch addr.Resource.Resource.Mode {
 		case addrs.ManagedResourceMode:
-			r.Mode = "managed"
+			r.Mode = ManagedResourceMode
 		case addrs.DataResourceMode:
-			r.Mode = "data"
+			r.Mode = DataResourceMode
 		default:
 			return nil, fmt.Errorf("resource %s has an unsupported mode %s", r.Address, addr.Resource.Resource.Mode.String())
 		}


### PR DESCRIPTION
This fixes a panic when attempting to read the schema for a data source from the resources schemas map instead of the data sources schemas map.

Note, I still need to write some tests for this but just putting the fix out so anyone who wants to keep testing manually can do so.