### PR TITLE
Plan correct optional and computed attributes in nested objects and sets

### DIFF
--- a/internal/plans/objchange/objchange_test.go
+++ b/internal/plans/objchange/objchange_test.go
@@ -915,6 +915,128 @@ func TestProposedNew(t *testing.T) {
 				}),
 			}),
 		},
+
+		"set with partial optional computed change": {
+			&configschema.Block{
+				BlockTypes: map[string]*configschema.NestedBlock{
+					"multi": {
+						Nesting: configschema.NestingSet,
+						Block: configschema.Block{
+							Attributes: map[string]*configschema.Attribute{
+								"opt": {
+									Type:     cty.String,
+									Optional: true,
+								},
+								"cmp": {
+									Type:     cty.String,
+									Optional: true,
+									Computed: true,
+								},
+							},
+						},
+					},
+				},
+			},
+			cty.ObjectVal(map[string]cty.Value{
+				"multi": cty.SetVal([]cty.Value{
+					cty.ObjectVal(map[string]cty.Value{
+						"opt": cty.StringVal("one"),
+						"cmp": cty.StringVal("OK"),
+					}),
+					cty.ObjectVal(map[string]cty.Value{
+						"opt": cty.StringVal("two"),
+						"cmp": cty.StringVal("OK"),
+					}),
+				}),
+			}),
+
+			cty.ObjectVal(map[string]cty.Value{
+				"multi": cty.SetVal([]cty.Value{
+					cty.ObjectVal(map[string]cty.Value{
+						"opt": cty.StringVal("one"),
+						"cmp": cty.NullVal(cty.String),
+					}),
+					cty.ObjectVal(map[string]cty.Value{
+						"opt": cty.StringVal("replaced"),
+						"cmp": cty.NullVal(cty.String),
+					}),
+				}),
+			}),
+			// "one" can be correlated because it is a non-computed value in
+			// the configuration.
+			cty.ObjectVal(map[string]cty.Value{
+				"multi": cty.SetVal([]cty.Value{
+					cty.ObjectVal(map[string]cty.Value{
+						"opt": cty.StringVal("one"),
+						"cmp": cty.StringVal("OK"),
+					}),
+					cty.ObjectVal(map[string]cty.Value{
+						"opt": cty.StringVal("replaced"),
+						"cmp": cty.NullVal(cty.String),
+					}),
+				}),
+			}),
+		},
+
+		"set without partial optional computed change": {
+			&configschema.Block{
+				BlockTypes: map[string]*configschema.NestedBlock{
+					"multi": {
+						Nesting: configschema.NestingSet,
+						Block: configschema.Block{
+							Attributes: map[string]*configschema.Attribute{
+								"opt": {
+									Type:     cty.String,
+									Optional: true,
+									Computed: true,
+								},
+								"req": {
+									Type:     cty.String,
+									Required: true,
+								},
+							},
+						},
+					},
+				},
+			},
+			cty.ObjectVal(map[string]cty.Value{
+				"multi": cty.SetVal([]cty.Value{
+					cty.ObjectVal(map[string]cty.Value{
+						"opt": cty.StringVal("one"),
+						"req": cty.StringVal("one"),
+					}),
+					cty.ObjectVal(map[string]cty.Value{
+						"opt": cty.StringVal("two"),
+						"req": cty.StringVal("two"),
+					}),
+				}),
+			}),
+			cty.ObjectVal(map[string]cty.Value{
+				"multi": cty.SetVal([]cty.Value{
+					cty.ObjectVal(map[string]cty.Value{
+						"opt": cty.NullVal(cty.String),
+						"req": cty.StringVal("one"),
+					}),
+					cty.ObjectVal(map[string]cty.Value{
+						"opt": cty.NullVal(cty.String),
+						"req": cty.StringVal("two"),
+					}),
+				}),
+			}),
+			cty.ObjectVal(map[string]cty.Value{
+				"multi": cty.SetVal([]cty.Value{
+					cty.ObjectVal(map[string]cty.Value{
+						"opt": cty.StringVal("one"),
+						"req": cty.StringVal("one"),
+					}),
+					cty.ObjectVal(map[string]cty.Value{
+						"opt": cty.StringVal("two"),
+						"req": cty.StringVal("two"),
+					}),
+				}),
+			}),
+		},
+
 		"sets differing only by unknown": {
 			&configschema.Block{
 				BlockTypes: map[string]*configschema.NestedBlock{
@@ -1886,10 +2008,10 @@ func TestProposedNew(t *testing.T) {
 		// optional+computed set. The nested computed values should be
 		// represented in the proposed new object, and correlated with state
 		// via the non-computed attributes.
-		"config within optional+computed set": {
+		"config add within optional+computed set": {
 			&configschema.Block{
 				Attributes: map[string]*configschema.Attribute{
-					"list_obj": {
+					"set_obj": {
 						Optional: true,
 						Computed: true,
 						NestedType: &configschema.Object{
@@ -1911,7 +2033,7 @@ func TestProposedNew(t *testing.T) {
 				},
 			},
 			cty.ObjectVal(map[string]cty.Value{
-				"list_obj": cty.SetVal([]cty.Value{
+				"set_obj": cty.SetVal([]cty.Value{
 					cty.ObjectVal(map[string]cty.Value{
 						"obj": cty.ObjectVal(map[string]cty.Value{
 							"optional": cty.StringVal("first"),
@@ -1927,7 +2049,7 @@ func TestProposedNew(t *testing.T) {
 				}),
 			}),
 			cty.ObjectVal(map[string]cty.Value{
-				"list_obj": cty.SetVal([]cty.Value{
+				"set_obj": cty.SetVal([]cty.Value{
 					cty.ObjectVal(map[string]cty.Value{
 						"obj": cty.ObjectVal(map[string]cty.Value{
 							"optional": cty.StringVal("first"),
@@ -1949,7 +2071,7 @@ func TestProposedNew(t *testing.T) {
 				}),
 			}),
 			cty.ObjectVal(map[string]cty.Value{
-				"list_obj": cty.SetVal([]cty.Value{
+				"set_obj": cty.SetVal([]cty.Value{
 					cty.ObjectVal(map[string]cty.Value{
 						"obj": cty.ObjectVal(map[string]cty.Value{
 							"optional": cty.StringVal("first"),
@@ -1967,6 +2089,353 @@ func TestProposedNew(t *testing.T) {
 							"optional": cty.StringVal("third"),
 							"computed": cty.NullVal(cty.String),
 						}),
+					}),
+				}),
+			}),
+		},
+
+		// A nested object with computed attributes, which is contained in a
+		// set. The nested computed values should be represented in the
+		// proposed new object, and correlated with state via the non-computed
+		// attributes.
+		"config add within set block": {
+			&configschema.Block{
+				BlockTypes: map[string]*configschema.NestedBlock{
+					"set_obj": {
+						Nesting: configschema.NestingSet,
+						Block: configschema.Block{
+							Attributes: map[string]*configschema.Attribute{
+								"obj": {
+									Optional: true,
+									NestedType: &configschema.Object{
+										Nesting: configschema.NestingSingle,
+										Attributes: map[string]*configschema.Attribute{
+											"optional": {Type: cty.String, Optional: true},
+											"computed": {Type: cty.String, Optional: true, Computed: true},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			cty.ObjectVal(map[string]cty.Value{
+				"set_obj": cty.SetVal([]cty.Value{
+					cty.ObjectVal(map[string]cty.Value{
+						"obj": cty.ObjectVal(map[string]cty.Value{
+							"optional": cty.StringVal("first"),
+							"computed": cty.StringVal("first computed"),
+						}),
+					}),
+					cty.ObjectVal(map[string]cty.Value{
+						"obj": cty.ObjectVal(map[string]cty.Value{
+							"optional": cty.StringVal("second"),
+							"computed": cty.StringVal("second computed"),
+						}),
+					}),
+				}),
+			}),
+			cty.ObjectVal(map[string]cty.Value{
+				"set_obj": cty.SetVal([]cty.Value{
+					cty.ObjectVal(map[string]cty.Value{
+						"obj": cty.ObjectVal(map[string]cty.Value{
+							"optional": cty.StringVal("first"),
+							"computed": cty.NullVal(cty.String),
+						}),
+					}),
+					cty.ObjectVal(map[string]cty.Value{
+						"obj": cty.ObjectVal(map[string]cty.Value{
+							"optional": cty.StringVal("second"),
+							"computed": cty.NullVal(cty.String),
+						}),
+					}),
+					cty.ObjectVal(map[string]cty.Value{
+						"obj": cty.ObjectVal(map[string]cty.Value{
+							"optional": cty.StringVal("third"),
+							"computed": cty.NullVal(cty.String),
+						}),
+					}),
+				}),
+			}),
+			cty.ObjectVal(map[string]cty.Value{
+				"set_obj": cty.SetVal([]cty.Value{
+					cty.ObjectVal(map[string]cty.Value{
+						"obj": cty.ObjectVal(map[string]cty.Value{
+							"optional": cty.StringVal("first"),
+							"computed": cty.StringVal("first computed"),
+						}),
+					}),
+					cty.ObjectVal(map[string]cty.Value{
+						"obj": cty.ObjectVal(map[string]cty.Value{
+							"optional": cty.StringVal("second"),
+							"computed": cty.StringVal("second computed"),
+						}),
+					}),
+					cty.ObjectVal(map[string]cty.Value{
+						"obj": cty.ObjectVal(map[string]cty.Value{
+							"optional": cty.StringVal("third"),
+							"computed": cty.NullVal(cty.String),
+						}),
+					}),
+				}),
+			}),
+		},
+
+		// A nested object with computed attributes, which is contained in a
+		// set. The nested computed values should be represented in the
+		// proposed new object, and correlated with state via the non-computed
+		// attributes.
+		"config change within set block": {
+			&configschema.Block{
+				BlockTypes: map[string]*configschema.NestedBlock{
+					"set_obj": {
+						Nesting: configschema.NestingSet,
+						Block: configschema.Block{
+							Attributes: map[string]*configschema.Attribute{
+								"obj": {
+									Optional: true,
+									NestedType: &configschema.Object{
+										Nesting: configschema.NestingSingle,
+										Attributes: map[string]*configschema.Attribute{
+											"optional": {Type: cty.String, Optional: true},
+											"computed": {Type: cty.String, Optional: true, Computed: true},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			cty.ObjectVal(map[string]cty.Value{
+				"set_obj": cty.SetVal([]cty.Value{
+					cty.ObjectVal(map[string]cty.Value{
+						"obj": cty.ObjectVal(map[string]cty.Value{
+							"optional": cty.StringVal("first"),
+							"computed": cty.StringVal("first computed"),
+						}),
+					}),
+					cty.ObjectVal(map[string]cty.Value{
+						"obj": cty.ObjectVal(map[string]cty.Value{
+							"optional": cty.StringVal("second"),
+							"computed": cty.StringVal("second computed"),
+						}),
+					}),
+				}),
+			}),
+			cty.ObjectVal(map[string]cty.Value{
+				"set_obj": cty.SetVal([]cty.Value{
+					cty.ObjectVal(map[string]cty.Value{
+						"obj": cty.ObjectVal(map[string]cty.Value{
+							"optional": cty.StringVal("first"),
+							"computed": cty.NullVal(cty.String),
+						}),
+					}),
+					cty.ObjectVal(map[string]cty.Value{
+						"obj": cty.ObjectVal(map[string]cty.Value{
+							"optional": cty.StringVal("changed"),
+							"computed": cty.NullVal(cty.String),
+						}),
+					}),
+				}),
+			}),
+			cty.ObjectVal(map[string]cty.Value{
+				"set_obj": cty.SetVal([]cty.Value{
+					cty.ObjectVal(map[string]cty.Value{
+						"obj": cty.ObjectVal(map[string]cty.Value{
+							"optional": cty.StringVal("first"),
+							"computed": cty.StringVal("first computed"),
+						}),
+					}),
+					cty.ObjectVal(map[string]cty.Value{
+						"obj": cty.ObjectVal(map[string]cty.Value{
+							"optional": cty.StringVal("changed"),
+							"computed": cty.NullVal(cty.String),
+						}),
+					}),
+				}),
+			}),
+		},
+
+		"set attr with partial optional computed change": {
+			&configschema.Block{
+				Attributes: map[string]*configschema.Attribute{
+					"multi": {
+						Optional: true,
+						NestedType: &configschema.Object{
+							Nesting: configschema.NestingSet,
+							Attributes: map[string]*configschema.Attribute{
+								"opt": {
+									Type:     cty.String,
+									Optional: true,
+								},
+								"oc": {
+									Type:     cty.String,
+									Optional: true,
+									Computed: true,
+								},
+							},
+						},
+					},
+				},
+			},
+			cty.ObjectVal(map[string]cty.Value{
+				"multi": cty.SetVal([]cty.Value{
+					cty.ObjectVal(map[string]cty.Value{
+						"opt": cty.StringVal("one"),
+						"oc":  cty.StringVal("OK"),
+					}),
+					cty.ObjectVal(map[string]cty.Value{
+						"opt": cty.StringVal("two"),
+						"oc":  cty.StringVal("OK"),
+					}),
+				}),
+			}),
+			cty.ObjectVal(map[string]cty.Value{
+				"multi": cty.SetVal([]cty.Value{
+					cty.ObjectVal(map[string]cty.Value{
+						"opt": cty.StringVal("one"),
+						"oc":  cty.NullVal(cty.String),
+					}),
+					cty.ObjectVal(map[string]cty.Value{
+						"opt": cty.StringVal("replaced"),
+						"oc":  cty.NullVal(cty.String),
+					}),
+				}),
+			}),
+			cty.ObjectVal(map[string]cty.Value{
+				"multi": cty.SetVal([]cty.Value{
+					cty.ObjectVal(map[string]cty.Value{
+						"opt": cty.StringVal("one"),
+						"oc":  cty.StringVal("OK"),
+					}),
+					cty.ObjectVal(map[string]cty.Value{
+						"opt": cty.StringVal("replaced"),
+						"oc":  cty.NullVal(cty.String),
+					}),
+				}),
+			}),
+		},
+
+		"set attr without optional computed change": {
+			&configschema.Block{
+				Attributes: map[string]*configschema.Attribute{
+					"multi": {
+						Optional: true,
+						NestedType: &configschema.Object{
+							Nesting: configschema.NestingSet,
+							Attributes: map[string]*configschema.Attribute{
+								"opt": {
+									Type:     cty.String,
+									Optional: true,
+								},
+								"oc": {
+									Type:     cty.String,
+									Optional: true,
+									Computed: true,
+								},
+							},
+						},
+					},
+				},
+			},
+			cty.ObjectVal(map[string]cty.Value{
+				"multi": cty.SetVal([]cty.Value{
+					cty.ObjectVal(map[string]cty.Value{
+						"opt": cty.StringVal("one"),
+						"oc":  cty.StringVal("OK"),
+					}),
+					cty.ObjectVal(map[string]cty.Value{
+						"opt": cty.StringVal("two"),
+						"oc":  cty.StringVal("OK"),
+					}),
+				}),
+			}),
+			cty.ObjectVal(map[string]cty.Value{
+				"multi": cty.SetVal([]cty.Value{
+					cty.ObjectVal(map[string]cty.Value{
+						"opt": cty.StringVal("one"),
+						"oc":  cty.NullVal(cty.String),
+					}),
+					cty.ObjectVal(map[string]cty.Value{
+						"opt": cty.StringVal("two"),
+						"oc":  cty.NullVal(cty.String),
+					}),
+				}),
+			}),
+			cty.ObjectVal(map[string]cty.Value{
+				"multi": cty.SetVal([]cty.Value{
+					cty.ObjectVal(map[string]cty.Value{
+						"opt": cty.StringVal("one"),
+						"oc":  cty.StringVal("OK"),
+					}),
+					cty.ObjectVal(map[string]cty.Value{
+						"opt": cty.StringVal("two"),
+						"oc":  cty.StringVal("OK"),
+					}),
+				}),
+			}),
+		},
+
+		// If there are no configured attributes which cannot be computed, the
+		// values cannot be correlated and will always produce a change.
+		"set attr with all optional computed": {
+			&configschema.Block{
+				Attributes: map[string]*configschema.Attribute{
+					"multi": {
+						Optional: true,
+						NestedType: &configschema.Object{
+							Nesting: configschema.NestingSet,
+							Attributes: map[string]*configschema.Attribute{
+								"opt": {
+									Type:     cty.String,
+									Optional: true,
+									Computed: true,
+								},
+								"oc": {
+									Type:     cty.String,
+									Optional: true,
+									Computed: true,
+								},
+							},
+						},
+					},
+				},
+			},
+			cty.ObjectVal(map[string]cty.Value{
+				"multi": cty.SetVal([]cty.Value{
+					cty.ObjectVal(map[string]cty.Value{
+						"opt": cty.StringVal("one"),
+						"oc":  cty.StringVal("OK"),
+					}),
+					cty.ObjectVal(map[string]cty.Value{
+						"opt": cty.StringVal("two"),
+						"oc":  cty.StringVal("OK"),
+					}),
+				}),
+			}),
+			cty.ObjectVal(map[string]cty.Value{
+				"multi": cty.SetVal([]cty.Value{
+					cty.ObjectVal(map[string]cty.Value{
+						"opt": cty.StringVal("one"),
+						"oc":  cty.NullVal(cty.String),
+					}),
+					cty.ObjectVal(map[string]cty.Value{
+						"opt": cty.StringVal("two"),
+						"oc":  cty.NullVal(cty.String),
+					}),
+				}),
+			}),
+			cty.ObjectVal(map[string]cty.Value{
+				"multi": cty.SetVal([]cty.Value{
+					cty.ObjectVal(map[string]cty.Value{
+						"opt": cty.StringVal("one"),
+						"oc":  cty.NullVal(cty.String),
+					}),
+					cty.ObjectVal(map[string]cty.Value{
+						"opt": cty.StringVal("two"),
+						"oc":  cty.NullVal(cty.String),
 					}),
 				}),
 			}),

--- a/internal/plans/objchange/objchange_test.go
+++ b/internal/plans/objchange/objchange_test.go
@@ -1378,12 +1378,14 @@ func TestProposedNew(t *testing.T) {
 						}),
 					}),
 					cty.ObjectVal(map[string]cty.Value{
-						"bar": cty.SetVal([]cty.Value{cty.ObjectVal(map[string]cty.Value{
-							"optional":          cty.StringVal("other_prior"),
-							"computed":          cty.StringVal("other_prior"),
-							"optional_computed": cty.StringVal("other_prior"),
-							"required":          cty.StringVal("other_prior"),
-						})}),
+						"bar": cty.SetVal([]cty.Value{
+							cty.ObjectVal(map[string]cty.Value{
+								"optional":          cty.StringVal("other_prior"),
+								"computed":          cty.StringVal("other_prior"),
+								"optional_computed": cty.StringVal("other_prior"),
+								"required":          cty.StringVal("other_prior"),
+							}),
+						}),
 					}),
 				}),
 			}),
@@ -1712,7 +1714,9 @@ func TestProposedNew(t *testing.T) {
 			}),
 		},
 
-		// data sources are planned with an unknown value
+		// Data sources are planned with an unknown value.
+		// Note that this plan fails AssertPlanValid, because for managed
+		// resources an instance would never be completely unknown.
 		"unknown prior nested objects": {
 			&configschema.Block{
 				Attributes: map[string]*configschema.Attribute{
@@ -1910,8 +1914,14 @@ func TestProposedNew(t *testing.T) {
 				"list_obj": cty.SetVal([]cty.Value{
 					cty.ObjectVal(map[string]cty.Value{
 						"obj": cty.ObjectVal(map[string]cty.Value{
-							"optional": cty.StringVal("prior"),
-							"computed": cty.StringVal("prior computed"),
+							"optional": cty.StringVal("first"),
+							"computed": cty.StringVal("first computed"),
+						}),
+					}),
+					cty.ObjectVal(map[string]cty.Value{
+						"obj": cty.ObjectVal(map[string]cty.Value{
+							"optional": cty.StringVal("second"),
+							"computed": cty.StringVal("second computed"),
 						}),
 					}),
 				}),
@@ -1920,7 +1930,19 @@ func TestProposedNew(t *testing.T) {
 				"list_obj": cty.SetVal([]cty.Value{
 					cty.ObjectVal(map[string]cty.Value{
 						"obj": cty.ObjectVal(map[string]cty.Value{
-							"optional": cty.StringVal("prior"),
+							"optional": cty.StringVal("first"),
+							"computed": cty.NullVal(cty.String),
+						}),
+					}),
+					cty.ObjectVal(map[string]cty.Value{
+						"obj": cty.ObjectVal(map[string]cty.Value{
+							"optional": cty.StringVal("second"),
+							"computed": cty.NullVal(cty.String),
+						}),
+					}),
+					cty.ObjectVal(map[string]cty.Value{
+						"obj": cty.ObjectVal(map[string]cty.Value{
+							"optional": cty.StringVal("third"),
 							"computed": cty.NullVal(cty.String),
 						}),
 					}),
@@ -1930,8 +1952,20 @@ func TestProposedNew(t *testing.T) {
 				"list_obj": cty.SetVal([]cty.Value{
 					cty.ObjectVal(map[string]cty.Value{
 						"obj": cty.ObjectVal(map[string]cty.Value{
-							"optional": cty.StringVal("prior"),
-							"computed": cty.StringVal("prior computed"),
+							"optional": cty.StringVal("first"),
+							"computed": cty.StringVal("first computed"),
+						}),
+					}),
+					cty.ObjectVal(map[string]cty.Value{
+						"obj": cty.ObjectVal(map[string]cty.Value{
+							"optional": cty.StringVal("second"),
+							"computed": cty.StringVal("second computed"),
+						}),
+					}),
+					cty.ObjectVal(map[string]cty.Value{
+						"obj": cty.ObjectVal(map[string]cty.Value{
+							"optional": cty.StringVal("third"),
+							"computed": cty.NullVal(cty.String),
 						}),
 					}),
 				}),

--- a/internal/plans/objchange/objchange_test.go
+++ b/internal/plans/objchange/objchange_test.go
@@ -2174,7 +2174,7 @@ func TestProposedNew(t *testing.T) {
 					cty.ObjectVal(map[string]cty.Value{
 						"obj": cty.ObjectVal(map[string]cty.Value{
 							"optional": cty.StringVal("second"),
-							"computed": cty.StringVal("second computed"),
+							"computed": cty.StringVal("second from config"),
 						}),
 					}),
 				}),
@@ -2190,9 +2190,10 @@ func TestProposedNew(t *testing.T) {
 					cty.ObjectVal(map[string]cty.Value{
 						"obj": cty.ObjectVal(map[string]cty.Value{
 							"optional": cty.StringVal("second"),
-							"computed": cty.NullVal(cty.String),
+							"computed": cty.StringVal("second from config"),
 						}),
 					}),
+					// new "third" value added
 					cty.ObjectVal(map[string]cty.Value{
 						"obj": cty.ObjectVal(map[string]cty.Value{
 							"optional": cty.StringVal("third"),
@@ -2212,7 +2213,7 @@ func TestProposedNew(t *testing.T) {
 					cty.ObjectVal(map[string]cty.Value{
 						"obj": cty.ObjectVal(map[string]cty.Value{
 							"optional": cty.StringVal("second"),
-							"computed": cty.StringVal("second computed"),
+							"computed": cty.StringVal("second from config"),
 						}),
 					}),
 					cty.ObjectVal(map[string]cty.Value{

--- a/internal/plans/objchange/objchange_test.go
+++ b/internal/plans/objchange/objchange_test.go
@@ -424,6 +424,49 @@ func TestProposedNew(t *testing.T) {
 				})),
 			}),
 		},
+
+		"prior optional computed nested single to null": {
+			&configschema.Block{
+				Attributes: map[string]*configschema.Attribute{
+					"bloop": {
+						NestedType: &configschema.Object{
+							Nesting: configschema.NestingSingle,
+							Attributes: map[string]*configschema.Attribute{
+								"blop": {
+									Type:     cty.String,
+									Required: true,
+								},
+								"bleep": {
+									Type:     cty.String,
+									Optional: true,
+								},
+							},
+						},
+						Optional: true,
+						Computed: true,
+					},
+				},
+			},
+			cty.ObjectVal(map[string]cty.Value{
+				"bloop": cty.ObjectVal(map[string]cty.Value{
+					"blop":  cty.StringVal("glub"),
+					"bleep": cty.NullVal(cty.String),
+				}),
+			}),
+			cty.ObjectVal(map[string]cty.Value{
+				"bloop": cty.NullVal(cty.Object(map[string]cty.Type{
+					"blop":  cty.String,
+					"bleep": cty.String,
+				})),
+			}),
+			cty.ObjectVal(map[string]cty.Value{
+				"bloop": cty.ObjectVal(map[string]cty.Value{
+					"blop":  cty.StringVal("glub"),
+					"bleep": cty.NullVal(cty.String),
+				}),
+			}),
+		},
+
 		"prior nested list": {
 			&configschema.Block{
 				BlockTypes: map[string]*configschema.NestedBlock{

--- a/internal/plans/objchange/objchange_test.go
+++ b/internal/plans/objchange/objchange_test.go
@@ -1877,6 +1877,66 @@ func TestProposedNew(t *testing.T) {
 				}),
 			}),
 		},
+
+		// A nested object with computed attributes, which is contained in an
+		// optional+computed set. The nested computed values should be
+		// represented in the proposed new object, and correlated with state
+		// via the non-computed attributes.
+		"config within optional+computed set": {
+			&configschema.Block{
+				Attributes: map[string]*configschema.Attribute{
+					"list_obj": {
+						Optional: true,
+						Computed: true,
+						NestedType: &configschema.Object{
+							Nesting: configschema.NestingSet,
+							Attributes: map[string]*configschema.Attribute{
+								"obj": {
+									Optional: true,
+									NestedType: &configschema.Object{
+										Nesting: configschema.NestingSingle,
+										Attributes: map[string]*configschema.Attribute{
+											"optional": {Type: cty.String, Optional: true},
+											"computed": {Type: cty.String, Computed: true},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			cty.ObjectVal(map[string]cty.Value{
+				"list_obj": cty.SetVal([]cty.Value{
+					cty.ObjectVal(map[string]cty.Value{
+						"obj": cty.ObjectVal(map[string]cty.Value{
+							"optional": cty.StringVal("prior"),
+							"computed": cty.StringVal("prior computed"),
+						}),
+					}),
+				}),
+			}),
+			cty.ObjectVal(map[string]cty.Value{
+				"list_obj": cty.SetVal([]cty.Value{
+					cty.ObjectVal(map[string]cty.Value{
+						"obj": cty.ObjectVal(map[string]cty.Value{
+							"optional": cty.StringVal("prior"),
+							"computed": cty.NullVal(cty.String),
+						}),
+					}),
+				}),
+			}),
+			cty.ObjectVal(map[string]cty.Value{
+				"list_obj": cty.SetVal([]cty.Value{
+					cty.ObjectVal(map[string]cty.Value{
+						"obj": cty.ObjectVal(map[string]cty.Value{
+							"optional": cty.StringVal("prior"),
+							"computed": cty.StringVal("prior computed"),
+						}),
+					}),
+				}),
+			}),
+		},
 	}
 
 	for name, test := range tests {

--- a/internal/plans/objchange/objchange_test.go
+++ b/internal/plans/objchange/objchange_test.go
@@ -1738,26 +1738,144 @@ func TestProposedNew(t *testing.T) {
 				},
 			},
 			cty.UnknownVal(cty.Object(map[string]cty.Type{
-				"List": cty.List(cty.Object(map[string]cty.Type{
+				"list": cty.List(cty.Object(map[string]cty.Type{
 					"list": cty.List(cty.Object(map[string]cty.Type{
 						"foo": cty.String,
 					})),
 				})),
 			})),
 			cty.NullVal(cty.Object(map[string]cty.Type{
-				"List": cty.List(cty.Object(map[string]cty.Type{
+				"list": cty.List(cty.Object(map[string]cty.Type{
 					"list": cty.List(cty.Object(map[string]cty.Type{
 						"foo": cty.String,
 					})),
 				})),
 			})),
 			cty.UnknownVal(cty.Object(map[string]cty.Type{
-				"List": cty.List(cty.Object(map[string]cty.Type{
+				"list": cty.List(cty.Object(map[string]cty.Type{
 					"list": cty.List(cty.Object(map[string]cty.Type{
 						"foo": cty.String,
 					})),
 				})),
 			})),
+		},
+
+		// A nested object with computed attributes, which is contained in an
+		// optional+computed container. The nested computed values should be
+		// represented in the proposed new object.
+		"config within optional+computed": {
+			&configschema.Block{
+				Attributes: map[string]*configschema.Attribute{
+					"list_obj": {
+						Optional: true,
+						Computed: true,
+						NestedType: &configschema.Object{
+							Nesting: configschema.NestingList,
+							Attributes: map[string]*configschema.Attribute{
+								"obj": {
+									Optional: true,
+									NestedType: &configschema.Object{
+										Nesting: configschema.NestingSingle,
+										Attributes: map[string]*configschema.Attribute{
+											"optional": {Type: cty.String, Optional: true},
+											"computed": {Type: cty.String, Computed: true},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			cty.ObjectVal(map[string]cty.Value{
+				"list_obj": cty.ListVal([]cty.Value{
+					cty.ObjectVal(map[string]cty.Value{
+						"obj": cty.ObjectVal(map[string]cty.Value{
+							"optional": cty.StringVal("prior"),
+							"computed": cty.StringVal("prior computed"),
+						}),
+					}),
+				}),
+			}),
+			cty.ObjectVal(map[string]cty.Value{
+				"list_obj": cty.ListVal([]cty.Value{
+					cty.ObjectVal(map[string]cty.Value{
+						"obj": cty.ObjectVal(map[string]cty.Value{
+							"optional": cty.StringVal("prior"),
+							"computed": cty.NullVal(cty.String),
+						}),
+					}),
+				}),
+			}),
+			cty.ObjectVal(map[string]cty.Value{
+				"list_obj": cty.ListVal([]cty.Value{
+					cty.ObjectVal(map[string]cty.Value{
+						"obj": cty.ObjectVal(map[string]cty.Value{
+							"optional": cty.StringVal("prior"),
+							"computed": cty.StringVal("prior computed"),
+						}),
+					}),
+				}),
+			}),
+		},
+
+		// A nested object with computed attributes, which is contained in an
+		// optional+computed container. The entire prior nested value should be
+		// represented in the proposed new object if the configuration is null.
+		"computed within optional+computed": {
+			&configschema.Block{
+				Attributes: map[string]*configschema.Attribute{
+					"list_obj": {
+						Optional: true,
+						Computed: true,
+						NestedType: &configschema.Object{
+							Nesting: configschema.NestingList,
+							Attributes: map[string]*configschema.Attribute{
+								"obj": {
+									Optional: true,
+									NestedType: &configschema.Object{
+										Nesting: configschema.NestingSingle,
+										Attributes: map[string]*configschema.Attribute{
+											"optional": {Type: cty.String, Optional: true},
+											"computed": {Type: cty.String, Computed: true},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			cty.ObjectVal(map[string]cty.Value{
+				"list_obj": cty.ListVal([]cty.Value{
+					cty.ObjectVal(map[string]cty.Value{
+						"obj": cty.ObjectVal(map[string]cty.Value{
+							"optional": cty.StringVal("prior"),
+							"computed": cty.StringVal("prior computed"),
+						}),
+					}),
+				}),
+			}),
+			cty.ObjectVal(map[string]cty.Value{
+				"list_obj": cty.NullVal(cty.List(
+					cty.Object(map[string]cty.Type{
+						"obj": cty.Object(map[string]cty.Type{
+							"optional": cty.String,
+							"computed": cty.String,
+						}),
+					}),
+				)),
+			}),
+			cty.ObjectVal(map[string]cty.Value{
+				"list_obj": cty.ListVal([]cty.Value{
+					cty.ObjectVal(map[string]cty.Value{
+						"obj": cty.ObjectVal(map[string]cty.Value{
+							"optional": cty.StringVal("prior"),
+							"computed": cty.StringVal("prior computed"),
+						}),
+					}),
+				}),
+			}),
 		},
 	}
 


### PR DESCRIPTION
When structural attributes were added, optional+computed attributes were not correctly handled when they contain nested values which could themselves be computed. This would cause terraform to ignore previously computed values from state when generating the proposed plan. The special case for optional+computed was incorrect, but isn't needed in the context of planning new values anyway -- attributes are either computed, or not computed depending on the existence of a configuration value. It is up to the provider to determine how and when to deal with any changes to that computed value.

We can also combine and simplify the set comparison functions for NestingSet blocks and attribute types. The set handling was not recursing into nested values, and once a simplified method for comparing set elements was devised for nested attributes, it turns out the same method could be applied to nested set blocks as well.

While it may be safer to leave the questionable set block behavior as-is to avoid possible regressions with legacy providers, the framework has added full support for nested blocks, which means that new providers now have access to the complete values and are no longer limited by the behaviors of the legacy SDK. A number of tests cases for nested set blocks were added here, which do fail without the accompanying changes.

Fixes #32522
