### PR TITLE
DOC: Update supported options of command graph -type=...

### DIFF
--- a/website/docs/cli/commands/graph.mdx
+++ b/website/docs/cli/commands/graph.mdx
@@ -37,7 +37,7 @@ Options:
 * `-draw-cycles`    - Highlight any cycles in the graph with colored edges.
   This helps when diagnosing cycle errors.
 
-* `-type=plan`      - Type of graph to output. Can be: `plan`, `plan-refresh-only`, `plan-destroy`, `apply`
+* `-type=plan`      - Type of graph to output. Can be: `plan`, `plan-refresh-only`, `plan-destroy`, or `apply`.
 
 * `-module-depth=n` - (deprecated) In prior versions of Terraform, specified the
   depth of modules to show in the output.

--- a/website/docs/cli/commands/graph.mdx
+++ b/website/docs/cli/commands/graph.mdx
@@ -37,8 +37,7 @@ Options:
 * `-draw-cycles`    - Highlight any cycles in the graph with colored edges.
   This helps when diagnosing cycle errors.
 
-* `-type=plan`      - Type of graph to output. Can be: `plan`, `plan-destroy`, `apply`,
-  `validate`, `input`, `refresh`.
+* `-type=plan`      - Type of graph to output. Can be: `plan`, `plan-refresh-only`, `plan-destroy`, `apply`
 
 * `-module-depth=n` - (deprecated) In prior versions of Terraform, specified the
   depth of modules to show in the output.


### PR DESCRIPTION
Correct documentation page about graph -type= options that does not match current (at least v1.3.6) supported options.

## Target Release

At least 1.3.6 

## Draft CHANGELOG entry

N/A

###  ENHANCEMENTS

