### PR TITLE
Fix typo in cloud backend's `TestCloud_setConfigurationFields`

### DIFF
--- a/internal/cloud/backend_test.go
+++ b/internal/cloud/backend_test.go
@@ -814,7 +814,7 @@ func TestCloud_setConfigurationFields(t *testing.T) {
 
 			for _, actual := range b.WorkspaceMapping.Tags {
 				if _, ok := expectedSet[actual]; !ok {
-					unexpected = append(missing, actual)
+					unexpected = append(unexpected, actual)
 				}
 			}
 


### PR DESCRIPTION
This was clearly wrong, but it was also harmless -- in the event of a failing test due to missing tags, they would get double-reported as both missing and unexpected. This commit separates out the reporting as intended.

## Target Release

1.4.x

## Draft CHANGELOG entry

-  none; it's a test-only fix.
