### PR TITLE
fix the outputs of equivalence tests that were executed with the wrong version

### DIFF
--- a/testing/equivalence-tests/outputs/data_read/plan
+++ b/testing/equivalence-tests/outputs/data_read/plan
@@ -29,8 +29,8 @@ Terraform will perform the following actions:
   # module.create.random_integer.random will be created
   + resource "random_integer" "random" {
       + id     = (known after apply)
-      + max    = 9.999999e+06
-      + min    = 1e+06
+      + max    = 9999999
+      + min    = 1000000
       + result = (known after apply)
       + seed   = "F78CB410-BA01-44E1-82E1-37D61F7CB158"
     }

--- a/testing/equivalence-tests/outputs/drift_relevant_attributes/plan
+++ b/testing/equivalence-tests/outputs/drift_relevant_attributes/plan
@@ -10,6 +10,7 @@ last "terraform apply" which may have affected this plan:
   ~ resource "tfcoremock_simple_resource" "base" {
         id     = "f6f74ca6-e8ef-e51f-522c-433b9ed5038f"
       ~ string = "Hello, world!" -> "Hello, drift!"
+        # (1 unchanged attribute hidden)
     }
 
 
@@ -28,6 +29,7 @@ Terraform will perform the following actions:
   # tfcoremock_simple_resource.base will be updated in-place
   ~ resource "tfcoremock_simple_resource" "base" {
         id     = "f6f74ca6-e8ef-e51f-522c-433b9ed5038f"
+      ~ number = 1 -> 0
       ~ string = "Hello, drift!" -> "Hello, change!"
     }
 

--- a/testing/equivalence-tests/outputs/drift_relevant_attributes/plan.json
+++ b/testing/equivalence-tests/outputs/drift_relevant_attributes/plan.json
@@ -12,6 +12,9 @@
         {
           "address": "tfcoremock_simple_resource.base",
           "expressions": {
+            "number": {
+              "constant_value": 0
+            },
             "string": {
               "constant_value": "Hello, change!"
             }
@@ -58,7 +61,7 @@
             "float": null,
             "id": "f6f74ca6-e8ef-e51f-522c-433b9ed5038f",
             "integer": null,
-            "number": null,
+            "number": 0,
             "string": "Hello, change!"
           }
         },
@@ -100,7 +103,7 @@
               "float": null,
               "id": "f6f74ca6-e8ef-e51f-522c-433b9ed5038f",
               "integer": null,
-              "number": null,
+              "number": 1,
               "string": "Hello, drift!"
             }
           },
@@ -148,7 +151,7 @@
           "float": null,
           "id": "f6f74ca6-e8ef-e51f-522c-433b9ed5038f",
           "integer": null,
-          "number": null,
+          "number": 0,
           "string": "Hello, change!"
         },
         "after_sensitive": {},
@@ -158,7 +161,7 @@
           "float": null,
           "id": "f6f74ca6-e8ef-e51f-522c-433b9ed5038f",
           "integer": null,
-          "number": null,
+          "number": 1,
           "string": "Hello, drift!"
         },
         "before_sensitive": {}
@@ -212,7 +215,7 @@
           "float": null,
           "id": "f6f74ca6-e8ef-e51f-522c-433b9ed5038f",
           "integer": null,
-          "number": null,
+          "number": 1,
           "string": "Hello, drift!"
         },
         "after_sensitive": {},
@@ -222,7 +225,7 @@
           "float": null,
           "id": "f6f74ca6-e8ef-e51f-522c-433b9ed5038f",
           "integer": null,
-          "number": null,
+          "number": 0,
           "string": "Hello, world!"
         },
         "before_sensitive": {}

--- a/testing/equivalence-tests/outputs/drift_relevant_attributes/state.json
+++ b/testing/equivalence-tests/outputs/drift_relevant_attributes/state.json
@@ -16,7 +16,7 @@
             "float": null,
             "id": "f6f74ca6-e8ef-e51f-522c-433b9ed5038f",
             "integer": null,
-            "number": null,
+            "number": 0,
             "string": "Hello, change!"
           }
         },

--- a/testing/equivalence-tests/tests/drift_relevant_attributes/terraform.resource/f6f74ca6-e8ef-e51f-522c-433b9ed5038f.json
+++ b/testing/equivalence-tests/tests/drift_relevant_attributes/terraform.resource/f6f74ca6-e8ef-e51f-522c-433b9ed5038f.json
@@ -4,7 +4,7 @@
       "string": "f6f74ca6-e8ef-e51f-522c-433b9ed5038f"
     },
     "number": {
-      "number": "0"
+      "number": "1"
     },
     "string": {
       "string": "Hello, drift!"


### PR DESCRIPTION
the data read and drift plans have outputs that were produced by an incomplete renderer version, I didn't notice this until after I merged so this PR brings them up to speed.