### PR TITLE
Fix crashes with NestingMap values

### DIFF
--- a/internal/plans/objchange/objchange_test.go
+++ b/internal/plans/objchange/objchange_test.go
@@ -752,6 +752,120 @@ func TestProposedNew(t *testing.T) {
 				}),
 			}),
 		},
+
+		"prior optional computed nested map elem to null": {
+			&configschema.Block{
+				Attributes: map[string]*configschema.Attribute{
+					"bloop": {
+						NestedType: &configschema.Object{
+							Nesting: configschema.NestingMap,
+							Attributes: map[string]*configschema.Attribute{
+								"blop": {
+									Type:     cty.String,
+									Optional: true,
+								},
+								"bleep": {
+									Type:     cty.String,
+									Optional: true,
+									Computed: true,
+								},
+							},
+						},
+						Optional: true,
+					},
+				},
+			},
+			cty.ObjectVal(map[string]cty.Value{
+				"bloop": cty.MapVal(map[string]cty.Value{
+					"a": cty.ObjectVal(map[string]cty.Value{
+						"blop":  cty.StringVal("glub"),
+						"bleep": cty.StringVal("computed"),
+					}),
+					"b": cty.ObjectVal(map[string]cty.Value{
+						"blop":  cty.StringVal("blub"),
+						"bleep": cty.StringVal("computed"),
+					}),
+				}),
+			}),
+			cty.ObjectVal(map[string]cty.Value{
+				"bloop": cty.MapVal(map[string]cty.Value{
+					"a": cty.NullVal(cty.Object(map[string]cty.Type{
+						"blop":  cty.String,
+						"bleep": cty.String,
+					})),
+					"c": cty.ObjectVal(map[string]cty.Value{
+						"blop":  cty.StringVal("blub"),
+						"bleep": cty.NullVal(cty.String),
+					}),
+				}),
+			}),
+			cty.ObjectVal(map[string]cty.Value{
+				"bloop": cty.MapVal(map[string]cty.Value{
+					"a": cty.NullVal(cty.Object(map[string]cty.Type{
+						"blop":  cty.String,
+						"bleep": cty.String,
+					})),
+					"c": cty.ObjectVal(map[string]cty.Value{
+						"blop":  cty.StringVal("blub"),
+						"bleep": cty.NullVal(cty.String),
+					}),
+				}),
+			}),
+		},
+
+		"prior optional computed nested map to null": {
+			&configschema.Block{
+				Attributes: map[string]*configschema.Attribute{
+					"bloop": {
+						NestedType: &configschema.Object{
+							Nesting: configschema.NestingMap,
+							Attributes: map[string]*configschema.Attribute{
+								"blop": {
+									Type:     cty.String,
+									Optional: true,
+								},
+								"bleep": {
+									Type:     cty.String,
+									Optional: true,
+									Computed: true,
+								},
+							},
+						},
+						Optional: true,
+						Computed: true,
+					},
+				},
+			},
+			cty.ObjectVal(map[string]cty.Value{
+				"bloop": cty.MapVal(map[string]cty.Value{
+					"a": cty.ObjectVal(map[string]cty.Value{
+						"blop":  cty.StringVal("glub"),
+						"bleep": cty.StringVal("computed"),
+					}),
+					"b": cty.ObjectVal(map[string]cty.Value{
+						"blop":  cty.StringVal("blub"),
+						"bleep": cty.StringVal("computed"),
+					}),
+				}),
+			}),
+			cty.ObjectVal(map[string]cty.Value{
+				"bloop": cty.NullVal(cty.Map(
+					cty.Object(map[string]cty.Type{
+						"blop":  cty.String,
+						"bleep": cty.String,
+					}),
+				)),
+			}),
+			cty.ObjectVal(map[string]cty.Value{
+				"bloop": cty.NullVal(cty.Map(
+					cty.Object(map[string]cty.Type{
+						"blop":  cty.String,
+						"bleep": cty.String,
+					}),
+				)),
+			}),
+		},
+
 		"prior nested map with dynamic": {
 			&configschema.Block{
 				BlockTypes: map[string]*configschema.NestedBlock{


### PR DESCRIPTION
We could panic in many situations when nulls crop up in `NestingBlock`values. Fix the test cases and start refactoring best we can. This probably won't go so far as making all the objchange functions generic over Block and Object, but we can simplify a lot and verify parity in implementations, and avoid other problems with `cty.NilVal` and empty maps.