### PR TITLE
Add a GCS backend specific env var for impersonation

### DIFF
--- a/internal/backend/remote-state/gcs/backend.go
+++ b/internal/backend/remote-state/gcs/backend.go
@@ -71,6 +71,7 @@ func New() backend.Backend {
 				Type:     schema.TypeString,
 				Optional: true,
 				DefaultFunc: schema.MultiEnvDefaultFunc([]string{
+					"GOOGLE_BACKEND_IMPERSONATE_SERVICE_ACCOUNT",
 					"GOOGLE_IMPERSONATE_SERVICE_ACCOUNT",
 				}, nil),
 				Description: "The service account to impersonate for all Google API Calls",

--- a/website/docs/language/settings/backends/gcs.mdx
+++ b/website/docs/language/settings/backends/gcs.mdx
@@ -113,11 +113,9 @@ The following configuration options are supported:
   format. If unset, the path uses [Google Application Default Credentials](https://developers.google.com/identity/protocols/application-default-credentials).  The provided credentials must have the Storage Object Admin role on the bucket.
   **Warning**: if using the Google Cloud Platform provider as well, it will
   also pick up the `GOOGLE_CREDENTIALS` environment variable.
-- `impersonate_service_account` - (Optional) The service account to impersonate for accessing the State Bucket.
+- `impersonate_service_account` / `GOOGLE_BACKEND_IMPERSONATE_SERVICE_ACCOUNT` / `GOOGLE_IMPERSONATE_SERVICE_ACCOUNT` - (Optional) The service account to impersonate for accessing the State Bucket.
   You must have `roles/iam.serviceAccountTokenCreator` role on that account for the impersonation to succeed.
   If you are using a delegation chain, you can specify that using the `impersonate_service_account_delegates` field.
-  Alternatively, this can be specified using the `GOOGLE_IMPERSONATE_SERVICE_ACCOUNT` environment
-  variable.
 - `impersonate_service_account_delegates` - (Optional) The delegation chain for an impersonating a service account as described [here](https://cloud.google.com/iam/docs/creating-short-lived-service-account-credentials#sa-credentials-delegated).
 - `access_token` - (Optional) A temporary \[OAuth 2.0 access token] obtained
   from the Google Authorization server, i.e. the `Authorization: Bearer` token


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Fixes https://github.com/hashicorp/terraform/issues/32556

## Target Release

1.4.x

## Draft CHANGELOG entry


### ENHANCEMENTS

-  Added support for `GOOGLE_BACKEND_IMPERSONATE_SERVICE_ACCOUNT` env var to allow impersonating a different service account when `GOOGLE_IMPERSONATE_SERVICE_ACCOUNT` is configured for the GCP provider.