### PR TITLE
Fix the spelling of network within the setproducts function documentation.

### DIFF
--- a/website/docs/language/functions/setproduct.mdx
+++ b/website/docs/language/functions/setproduct.mdx
@@ -224,7 +224,7 @@ subnets = {
 }
 ```
 
-The `nework_subnets` output would look similar to the following:
+The `network_subnets` output would look similar to the following:
 
 ```hcl
 [


### PR DESCRIPTION
This changes fixes a spelling error found on the `setproduct` function documentation page.

In `website/docs/language/functions/setproduct.mdx`, a misspelled word `nework_subnets` has been corrected to `network_subnets`, following a similar spelling within the same file and [following Merriam-Webster's spelling of the word](https://www.merriam-webster.com/dictionary/network).

Below is a screenshot showing the location of the misspelled word within the project's documentation:
<img width="965" alt="Screen Shot 2023-01-22 at 8 02 47 PM" src="https://user-images.githubusercontent.com/20607878/213950603-b2fc178c-0aa5-48fa-8446-80ec07059fe9.png">