### PR TITLE
a new method of `ProposedNew` set comparison

### DIFF
--- a/internal/plans/objchange/objchange_test.go
+++ b/internal/plans/objchange/objchange_test.go
@@ -2536,8 +2536,6 @@ func TestProposedNew(t *testing.T) {
 			}),
 		},
 
-		// If there are no configured attributes which cannot be computed, the
-		// values cannot be correlated and will always produce a change.
 		"set attr with all optional computed": {
 			&configschema.Block{
 				Attributes: map[string]*configschema.Attribute{
@@ -2573,6 +2571,10 @@ func TestProposedNew(t *testing.T) {
 					}),
 				}),
 			}),
+			// Each of these values can be correlated by the existence of the
+			// optional config attribute. Because "one" and "two" are set in
+			// the config, they must exist in the state regardless of
+			// optional&computed.
 			cty.ObjectVal(map[string]cty.Value{
 				"multi": cty.SetVal([]cty.Value{
 					cty.ObjectVal(map[string]cty.Value{
@@ -2589,11 +2591,135 @@ func TestProposedNew(t *testing.T) {
 				"multi": cty.SetVal([]cty.Value{
 					cty.ObjectVal(map[string]cty.Value{
 						"opt": cty.StringVal("one"),
-						"oc":  cty.NullVal(cty.String),
+						"oc":  cty.StringVal("OK"),
 					}),
 					cty.ObjectVal(map[string]cty.Value{
 						"opt": cty.StringVal("two"),
+						"oc":  cty.StringVal("OK"),
+					}),
+				}),
+			}),
+		},
+
+		"set block with all optional computed and nested object types": {
+			&configschema.Block{
+				BlockTypes: map[string]*configschema.NestedBlock{
+					"multi": {
+						Nesting: configschema.NestingSet,
+						Block: configschema.Block{
+							Attributes: map[string]*configschema.Attribute{
+								"opt": {
+									Type:     cty.String,
+									Optional: true,
+									Computed: true,
+								},
+								"oc": {
+									Type:     cty.String,
+									Optional: true,
+									Computed: true,
+								},
+								"attr": {
+									Optional: true,
+									NestedType: &configschema.Object{
+										Nesting: configschema.NestingSet,
+										Attributes: map[string]*configschema.Attribute{
+											"opt": {
+												Type:     cty.String,
+												Optional: true,
+												Computed: true,
+											},
+											"oc": {
+												Type:     cty.String,
+												Optional: true,
+												Computed: true,
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			cty.ObjectVal(map[string]cty.Value{
+				"multi": cty.SetVal([]cty.Value{
+					cty.ObjectVal(map[string]cty.Value{
+						"opt": cty.StringVal("one"),
+						"oc":  cty.StringVal("OK"),
+						"attr": cty.SetVal([]cty.Value{cty.ObjectVal(map[string]cty.Value{
+							"opt": cty.StringVal("one"),
+							"oc":  cty.StringVal("OK"),
+						})}),
+					}),
+					cty.ObjectVal(map[string]cty.Value{
+						"opt": cty.StringVal("two"),
+						"oc":  cty.StringVal("OK"),
+						"attr": cty.SetVal([]cty.Value{cty.ObjectVal(map[string]cty.Value{
+							"opt": cty.StringVal("two"),
+							"oc":  cty.StringVal("OK"),
+						})}),
+					}),
+				}),
+			}),
+			cty.ObjectVal(map[string]cty.Value{
+				"multi": cty.SetVal([]cty.Value{
+					cty.ObjectVal(map[string]cty.Value{
+						"opt": cty.StringVal("one"),
 						"oc":  cty.NullVal(cty.String),
+						"attr": cty.SetVal([]cty.Value{cty.ObjectVal(map[string]cty.Value{
+							"opt": cty.StringVal("one"),
+							"oc":  cty.StringVal("OK"),
+						})}),
+					}),
+					cty.ObjectVal(map[string]cty.Value{
+						"opt": cty.StringVal("two"),
+						"oc":  cty.StringVal("OK"),
+						"attr": cty.SetVal([]cty.Value{cty.ObjectVal(map[string]cty.Value{
+							"opt": cty.StringVal("two"),
+							"oc":  cty.NullVal(cty.String),
+						})}),
+					}),
+					cty.ObjectVal(map[string]cty.Value{
+						"opt": cty.StringVal("three"),
+						"oc":  cty.NullVal(cty.String),
+						"attr": cty.NullVal(cty.Set(cty.Object(map[string]cty.Type{
+							"opt": cty.String,
+							"oc":  cty.String,
+						}))),
+					}),
+				}),
+			}),
+			cty.ObjectVal(map[string]cty.Value{
+				"multi": cty.SetVal([]cty.Value{
+					// We can correlate this with prior from the outer object
+					// attributes, and the equal nested set.
+					cty.ObjectVal(map[string]cty.Value{
+						"opt": cty.StringVal("one"),
+						"oc":  cty.StringVal("OK"),
+						"attr": cty.SetVal([]cty.Value{cty.ObjectVal(map[string]cty.Value{
+							"opt": cty.StringVal("one"),
+							"oc":  cty.StringVal("OK"),
+						})}),
+					}),
+					// This value is overridden by config, because we can't
+					// correlate optional+computed config values within nested
+					// sets.
+					cty.ObjectVal(map[string]cty.Value{
+						"opt": cty.StringVal("two"),
+						"oc":  cty.StringVal("OK"),
+						"attr": cty.SetVal([]cty.Value{cty.ObjectVal(map[string]cty.Value{
+							"opt": cty.StringVal("two"),
+							"oc":  cty.NullVal(cty.String),
+						})}),
+					}),
+					// This value was taken only from config
+					cty.ObjectVal(map[string]cty.Value{
+						"opt": cty.StringVal("three"),
+						"oc":  cty.NullVal(cty.String),
+						"attr": cty.NullVal(cty.Set(cty.Object(map[string]cty.Type{
+							"opt": cty.String,
+							"oc":  cty.String,
+						}))),
 					}),
 				}),
 			}),


### PR DESCRIPTION
The existing `ProposedNew` set comparison method uses the prior elements with the computed portions nulled out to find candidates to match the configuration. This has the shortcoming of always removing optional+computed attributes, because we have not yet found the configuration to know if attribute was set or not.

Rather than having to take the most pessimistic value before comparison to precompute the nulled values, we can compare each candidate config and prior pair directly, walking the values in tandem. Each prior value is compared against the config and checked to see if it could have been derived from that configuration value, which allows us to treat optional+computed as optional if there is config and computed if there is not.

This removes the ambiguity from having optional+computed attributes within sets, giving us consistent plans when all values are known. Unknown values of course are still undecidable, as are edge cases were providers refresh with altered values or retained changed prior values plan that were deemed not functionally significant. We also cannot descend into nested sets, not only because the combinatorial problem of matching all possible nested values, but because we can't lookup nested blocks by paths nor can we use `path.Apply` when indexing through sets. The latter problems are possible to solve, through refactoring the schema and temporarily restructuring the set elements for comparison, but unless a compelling use case for such a structure arises the additional complexity has little benefit.
