### PR TITLE
Fix the incorrect example

### DIFF
--- a/website/docs/language/functions/timecmp.mdx
+++ b/website/docs/language/functions/timecmp.mdx
@@ -53,7 +53,7 @@ the "apply" step:
 ```hcl
   lifecycle {
     postcondition {
-      condition     = timecmp(timestamp(), timeadd(self.expiration_timestamp, "-720h")) < 0
+      condition     = timecmp(timestamp(), timeadd(self.expiration_timestamp, "-720h")) > 0
       error_message = "Certificate will expire in less than 30 days."
     }
   }


### PR DESCRIPTION
The `timestamp()` should be after the `timeadd(self.expiration_timestamp, "-720h")`, then it means that `Certificate will expire in less than 30 days`.

<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Fixes #

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.4.x

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

### NEW FEATURES | UPGRADE NOTES | ENHANCEMENTS | BUG FIXES | EXPERIMENTS

<!--

Write a short description of the user-facing change. Examples:

- `terraform show -json`: Fixed crash with sensitive set values.
- When rendering a diff, Terraform now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 

-  
