### PR TITLE
Add support for Terraform Enterprise generic hostname localterraform.com

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -46,7 +46,7 @@ require (
 	github.com/hashicorp/hcl/v2 v2.15.0
 	github.com/hashicorp/terraform-config-inspect v0.0.0-20210209133302-4fd17a0faac2
 	github.com/hashicorp/terraform-registry-address v0.0.0-20220623143253-7d51757b572c
-	github.com/hashicorp/terraform-svchost v0.0.1
+	github.com/hashicorp/terraform-svchost v0.1.0
 	github.com/jmespath/go-jmespath v0.4.0
 	github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0
 	github.com/lib/pq v1.10.3

--- a/go.sum
+++ b/go.sum
@@ -410,8 +410,8 @@ github.com/hashicorp/terraform-config-inspect v0.0.0-20210209133302-4fd17a0faac2
 github.com/hashicorp/terraform-registry-address v0.0.0-20220623143253-7d51757b572c h1:D8aRO6+mTqHfLsK/BC3j5OAoogv1WLRWzY1AaTo3rBg=
 github.com/hashicorp/terraform-registry-address v0.0.0-20220623143253-7d51757b572c/go.mod h1:Wn3Na71knbXc1G8Lh+yu/dQWWJeFQEpDeJMtWMtlmNI=
 github.com/hashicorp/terraform-svchost v0.0.0-20200729002733-f050f53b9734/go.mod h1:kNDNcF7sN4DocDLBkQYz73HGKwN1ANB1blq4lIYLYvg=
-github.com/hashicorp/terraform-svchost v0.0.1 h1:Zj6fR5wnpOHnJUmLyWozjMeDaVuE+cstMPj41/eKmSQ=
-github.com/hashicorp/terraform-svchost v0.0.1/go.mod h1:ut8JaH0vumgdCfJaihdcZULqkAwHdQNwNH7taIDdsZM=
+github.com/hashicorp/terraform-svchost v0.1.0 h1:0+RcgZdZYNd81Vw7tu62g9JiLLvbOigp7QtyNh6CjXk=
+github.com/hashicorp/terraform-svchost v0.1.0/go.mod h1:ut8JaH0vumgdCfJaihdcZULqkAwHdQNwNH7taIDdsZM=
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d h1:kJCB4vdITiW1eC1vq2e6IsrXKrZit1bv/TDYFGMp4BQ=
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=

--- a/internal/command/init.go
+++ b/internal/command/init.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 
 	"github.com/hashicorp/hcl/v2"
-	"github.com/hashicorp/terraform-config-inspect/tfconfig"
 	svchost "github.com/hashicorp/terraform-svchost"
 	"github.com/posener/complete"
 	"github.com/zclconf/go-cty/cty"
@@ -155,39 +154,65 @@ func (c *InitCommand) Run(args []string) int {
 		return 0
 	}
 
-	// For Terraform v0.12 we introduced a special loading mode where we would
-	// use the 0.11-syntax-compatible "earlyconfig" package as a heuristic to
-	// identify situations where it was likely that the user was trying to use
-	// 0.11-only syntax that the upgrade tool might help with.
-	//
-	// However, as the language has moved on that is no longer a suitable
-	// heuristic in Terraform 0.13 and later: other new additions to the
-	// language can cause the main loader to disagree with earlyconfig, which
-	// would lead us to give poor advice about how to respond.
-	//
-	// For that reason, we no longer use a different error message in that
-	// situation, but for now we still use both codepaths because some of our
-	// initialization functionality remains built around "earlyconfig" and
-	// so we need to still load the module via that mechanism anyway until we
-	// can do some more invasive refactoring here.
-	rootModEarly, earlyConfDiags := c.loadSingleModuleEarly(path)
-	// If _only_ the early loader encountered errors then that's unusual
-	// (it should generally be a superset of the normal loader) but we'll
-	// return those errors anyway since otherwise we'll probably get
-	// some weird behavior downstream. Errors from the early loader are
-	// generally not as high-quality since it has less context to work with.
-	if earlyConfDiags.HasErrors() {
-		c.Ui.Error(c.Colorize().Color(strings.TrimSpace(errInitConfigError)))
-		// Errors from the early loader are generally not as high-quality since
-		// it has less context to work with.
+	// Load just the root module to begin backend and module initialization
+	rootModEarly, earlyConfDiags := c.loadSingleModule(path)
 
-		// TODO: It would be nice to check the version constraints in
-		// rootModEarly.RequiredCore and print out a hint if the module is
-		// declaring that it's not compatible with this version of Terraform,
-		// and that may be what caused earlyconfig to fail.
+	// There may be parsing errors in config loading but these will be shown later _after_
+	// checking for core version requirement errors. Not meeting the version requirement should
+	// be the first error displayed if that is an issue, but other operations are required
+	// before being able to check core version requirements.
+	if rootModEarly == nil {
+		c.Ui.Error(c.Colorize().Color(strings.TrimSpace(errInitConfigError)))
 		diags = diags.Append(earlyConfDiags)
 		c.showDiagnostics(diags)
+
 		return 1
+	}
+
+	var back backend.Backend
+
+	// There may be config errors or backend init errors but these will be shown later _after_
+	// checking for core version requirement errors.
+	var backDiags tfdiags.Diagnostics
+	var backendOutput bool
+
+	switch {
+	case flagCloud && rootModEarly.CloudConfig != nil:
+		back, backendOutput, backDiags = c.initCloud(rootModEarly, flagConfigExtra)
+	case flagBackend:
+		back, backendOutput, backDiags = c.initBackend(rootModEarly, flagConfigExtra)
+	default:
+		// load the previously-stored backend config
+		back, backDiags = c.Meta.backendFromState()
+	}
+	if backendOutput {
+		header = true
+	}
+
+	var state *states.State
+
+	// If we have a functional backend (either just initialized or initialized
+	// on a previous run) we'll use the current state as a potential source
+	// of provider dependencies.
+	if back != nil {
+		c.ignoreRemoteVersionConflict(back)
+		workspace, err := c.Workspace()
+		if err != nil {
+			c.Ui.Error(fmt.Sprintf("Error selecting workspace: %s", err))
+			return 1
+		}
+		sMgr, err := back.StateMgr(workspace)
+		if err != nil {
+			c.Ui.Error(fmt.Sprintf("Error loading state: %s", err))
+			return 1
+		}
+
+		if err := sMgr.RefreshState(); err != nil {
+			c.Ui.Error(fmt.Sprintf("Error refreshing state: %s", err))
+			return 1
+		}
+
+		state = sMgr.State()
 	}
 
 	if flagGet {
@@ -219,86 +244,19 @@ func (c *InitCommand) Run(args []string) int {
 		return 1
 	}
 
+	// If the core version is OK, show any underlying config errors uncovered when initializing
+	// the backend.
+	diags = diags.Append(backDiags)
+	if backDiags.HasErrors() {
+		c.showDiagnostics(diags)
+		return 1
+	}
+
 	diags = diags.Append(confDiags)
 	if confDiags.HasErrors() {
 		c.Ui.Error(strings.TrimSpace(errInitConfigError))
 		c.showDiagnostics(diags)
 		return 1
-	}
-
-	var back backend.Backend
-
-	switch {
-	case flagCloud && config.Module.CloudConfig != nil:
-		be, backendOutput, backendDiags := c.initCloud(config.Module, flagConfigExtra)
-		diags = diags.Append(backendDiags)
-		if backendDiags.HasErrors() {
-			c.showDiagnostics(diags)
-			return 1
-		}
-		if backendOutput {
-			header = true
-		}
-		back = be
-	case flagBackend:
-		be, backendOutput, backendDiags := c.initBackend(config.Module, flagConfigExtra)
-		diags = diags.Append(backendDiags)
-		if backendDiags.HasErrors() {
-			c.showDiagnostics(diags)
-			return 1
-		}
-		if backendOutput {
-			header = true
-		}
-		back = be
-	default:
-		// load the previously-stored backend config
-		be, backendDiags := c.Meta.backendFromState()
-		diags = diags.Append(backendDiags)
-		if backendDiags.HasErrors() {
-			c.showDiagnostics(diags)
-			return 1
-		}
-		back = be
-	}
-
-	if back == nil {
-		// If we didn't initialize a backend then we'll try to at least
-		// instantiate one. This might fail if it wasn't already initialized
-		// by a previous run, so we must still expect that "back" may be nil
-		// in code that follows.
-		var backDiags tfdiags.Diagnostics
-		back, backDiags = c.Backend(&BackendOpts{Init: true})
-		if backDiags.HasErrors() {
-			// This is fine. We'll proceed with no backend, then.
-			back = nil
-		}
-	}
-
-	var state *states.State
-
-	// If we have a functional backend (either just initialized or initialized
-	// on a previous run) we'll use the current state as a potential source
-	// of provider dependencies.
-	if back != nil {
-		c.ignoreRemoteVersionConflict(back)
-		workspace, err := c.Workspace()
-		if err != nil {
-			c.Ui.Error(fmt.Sprintf("Error selecting workspace: %s", err))
-			return 1
-		}
-		sMgr, err := back.StateMgr(workspace)
-		if err != nil {
-			c.Ui.Error(fmt.Sprintf("Error loading state: %s", err))
-			return 1
-		}
-
-		if err := sMgr.RefreshState(); err != nil {
-			c.Ui.Error(fmt.Sprintf("Error refreshing state: %s", err))
-			return 1
-		}
-
-		state = sMgr.State()
 	}
 
 	// Now that we have loaded all modules, check the module tree for missing providers.
@@ -343,7 +301,7 @@ func (c *InitCommand) Run(args []string) int {
 	return 0
 }
 
-func (c *InitCommand) getModules(path string, earlyRoot *tfconfig.Module, upgrade bool) (output bool, abort bool, diags tfdiags.Diagnostics) {
+func (c *InitCommand) getModules(path string, earlyRoot *configs.Module, upgrade bool) (output bool, abort bool, diags tfdiags.Diagnostics) {
 	if len(earlyRoot.ModuleCalls) == 0 {
 		// Nothing to do
 		return false, false, nil

--- a/internal/command/meta_config.go
+++ b/internal/command/meta_config.go
@@ -9,11 +9,9 @@ import (
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
-	"github.com/hashicorp/terraform-config-inspect/tfconfig"
 	"github.com/hashicorp/terraform/internal/configs"
 	"github.com/hashicorp/terraform/internal/configs/configload"
 	"github.com/hashicorp/terraform/internal/configs/configschema"
-	"github.com/hashicorp/terraform/internal/earlyconfig"
 	"github.com/hashicorp/terraform/internal/initwd"
 	"github.com/hashicorp/terraform/internal/registry"
 	"github.com/hashicorp/terraform/internal/terraform"
@@ -69,31 +67,6 @@ func (m *Meta) loadSingleModule(dir string) (*configs.Module, tfdiags.Diagnostic
 
 	module, hclDiags := loader.Parser().LoadConfigDir(dir)
 	diags = diags.Append(hclDiags)
-	return module, diags
-}
-
-// loadSingleModuleEarly is a variant of loadSingleModule that uses the special
-// "early config" loader that is more forgiving of unexpected constructs and
-// legacy syntax.
-//
-// Early-loaded config is not registered in the source code cache, so
-// diagnostics produced from it may render without source code snippets. In
-// practice this is not a big concern because the early config loader also
-// cannot generate detailed source locations, so it prefers to produce
-// diagnostics without explicit source location information and instead includes
-// approximate locations in the message text.
-//
-// Most callers should use loadConfig. This method exists to support early
-// initialization use-cases where the root module must be inspected in order
-// to determine what else needs to be installed before the full configuration
-// can be used.
-func (m *Meta) loadSingleModuleEarly(dir string) (*tfconfig.Module, tfdiags.Diagnostics) {
-	var diags tfdiags.Diagnostics
-	dir = m.normalizePath(dir)
-
-	module, moreDiags := earlyconfig.LoadModule(dir)
-	diags = diags.Append(moreDiags)
-
 	return module, diags
 }
 


### PR DESCRIPTION
## Overview

For a while, [Terraform Enterprise has supported](https://developer.hashicorp.com/terraform/cloud-docs/registry/using#generic-hostname-terraform-enterprise) `localterraform.com` as a generic alias for "whatever the platform hostname is" in order to allow developers to omit specific module source URLs when utilizing multiple Terraform Enterprise deployments.

This change extends support to Terraform CLI by aliasing `localterraform.com` during cloud configuration to be whatever the cloud hostname is, utilizing aliasing within service discovery. This allows module developers in particular to use the CLI to reference module sources in the same way the platform will without modifying hosts files or adding undocumented CLI config workarounds like `host{}` and `credentials{}` blocks.

## Important

- [x] ~Before merging this, https://github.com/hashicorp/terraform-svchost/pull/20 should be merged and released and the module version updated in this PR~

## Notes

To simplify this enhancement, I removed the early config loading stage from the init command and swapped the init order for backend and modules. The existence of the early config load was to allow 0.11 version syntax to be detected in order to better suggest the use of the `terraform 0.12upgrade` command, which was removed in version 0.13. Nowadays, we don't expect users to attempt an upgrade from 0.11 to 1.4 so there is not a lot of value in keeping this loader.

Once this version of config load was removed, I was able to switch the loading order of backend and modules because they use the same main config loader types. This was critical because the point of the generic hostname is to re-use the backend hostname config when initializing modules. I kept these changes separated into two commits to try and simplify review.

The only vexing aspect to the new config loading behavior was that I needed to defer the diagnostics from the config and backend init until after the terraform core version check, which requires that all modules be loaded (since any module can specify a minimum terraform version). I don't think this is a negative consequence, but it did require that I ignore certain diagnostics and revisit them later in the code path. I added comments where appropriate.

It should now be possible to modify the `earlyconfig` and `initwd` packages to use the main config loader types as well, and remove all the references to terraform-config-inspect. I'd be happy to take on this refactor unless there are other blocking concerns for this change.

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.4.0

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

### ENHANCEMENTS

<!--

Write a short description of the user-facing change. Examples:

- `terraform show -json`: Fixed crash with sensitive set values.
- When rendering a diff, Terraform now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 

-  Adds support for using the generic hostname `localterraform.com`, usually in module and provider sources, as a substitute for the currently configured cloud backend hostname.
