### PR TITLE
docs: add HTTP backend mTLS attributes

### DIFF
--- a/website/docs/language/settings/backends/http.mdx
+++ b/website/docs/language/settings/backends/http.mdx
@@ -67,3 +67,9 @@ The following configuration options / environment variables are supported:
   seconds to wait between HTTP request attempts. Defaults to `1`.
 - `retry_wait_max` / `TF_HTTP_RETRY_WAIT_MAX` – (Optional) The maximum time in
   seconds to wait between HTTP request attempts. Defaults to `30`.
+
+For mTLS authentication, the following three options may be set:
+
+ - `client_certificate_pem` / `TF_HTTP_CLIENT_CERTIFICATE_PEM` - (Optional) A PEM-encoded certificate used by the server to verify the client during mutual TLS (mTLS) authentication.
+ - `client_private_key_pem` /`TF_HTTP_CLIENT_PRIVATE_KEY_PEM` - (Optional) A PEM-encoded private key, required if client_certificate_pem is specified.
+ - `client_ca_certificate_pem` / `TF_HTTP_CLIENT_CA_CERTIFICATE_PEM` - (Optional) A PEM-encoded CA certificate chain used by the client to verify server certificates during TLS authentication.


### PR DESCRIPTION
Update the HTTP backend docs page with the new attributes added in https://github.com/hashicorp/terraform/pull/31699.