### PR TITLE
Backport support for generic hostname to backend/remote

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,7 @@ ENHANCEMENTS:
 * backend/oss: More robustly handle endpoint retrieval error ([#32295](https://github.com/hashicorp/terraform/issues/32295))
 * local-exec provisioner: Added `quiet` argument. If `quiet` is set to `true`, Terraform will not print the entire command to stdout during plan. [GH-32116]
 * backend/http: Add support for mTLS authentication. [GH-31699]
-* cloud: Add support for using the [generic hostname](https://developer.hashicorp.com/terraform/cloud-docs/registry/using#generic-hostname-terraform-enterprise) localterraform.com in module and provider sources as a substitute for the currently configured cloud backend hostname.
+* cloud: Add support for using the [generic hostname](https://developer.hashicorp.com/terraform/cloud-docs/registry/using#generic-hostname-terraform-enterprise) localterraform.com in module and provider sources as a substitute for the currently configured cloud backend hostname. This enhancement was also applied to the remote backend.
 
 EXPERIMENTS:
 

--- a/internal/cloud/backend.go
+++ b/internal/cloud/backend.go
@@ -194,7 +194,7 @@ func (b *Cloud) PrepareConfig(obj cty.Value) (cty.Value, tfdiags.Diagnostics) {
 	return obj, diags
 }
 
-// configureGenericHost aliases the cloud backend hostname configuration
+// configureGenericHostname aliases the cloud backend hostname configuration
 // as a generic "localterraform.com" hostname. This was originally added as a
 // Terraform Enterprise feature and is useful for re-using whatever the
 // Cloud/Enterprise backend host is in nested module sources in order


### PR DESCRIPTION
Duplicates generic hostname enhancement to backend/remote. We don't have a history of sharing code between the cloud and remote backends and this was a very small change so I basically duplicated #32571 

My thinking is that this enhancement falls close to being a bug fix so it might not be worthwhile to insist on a migration to cloud backend to get it. I'm open to either a different implementation that shares code or not backporting it at all.

## Target Release

1.4.0
