### PR TITLE
make remote state initial behavior the same as local state

### DIFF
--- a/internal/backend/local/backend_local.go
+++ b/internal/backend/local/backend_local.go
@@ -284,10 +284,8 @@ func (b *Local) localRunForPlanFile(op *backend.Operation, pf *planfile.Reader, 
 		))
 		return nil, snap, diags
 	}
-	log.Printf("[DEBUG] backend/local: priorStateFile: %v", *priorStateFile)
 
 	if currentStateMeta != nil {
-		log.Printf("[DEBUG] backend/local: currentStateMeta: %v", *currentStateMeta)
 		// If the caller sets this, we require that the stored prior state
 		// has the same metadata, which is an extra safety check that nothing
 		// has changed since the plan was created. (All of the "real-world"

--- a/internal/backend/local/backend_local.go
+++ b/internal/backend/local/backend_local.go
@@ -284,7 +284,10 @@ func (b *Local) localRunForPlanFile(op *backend.Operation, pf *planfile.Reader, 
 		))
 		return nil, snap, diags
 	}
+	log.Printf("[DEBUG] backend/local: priorStateFile: %v", *priorStateFile)
+
 	if currentStateMeta != nil {
+		log.Printf("[DEBUG] backend/local: currentStateMeta: %v", *currentStateMeta)
 		// If the caller sets this, we require that the stored prior state
 		// has the same metadata, which is an extra safety check that nothing
 		// has changed since the plan was created. (All of the "real-world"

--- a/internal/states/remote/state.go
+++ b/internal/states/remote/state.go
@@ -3,6 +3,7 @@ package remote
 import (
 	"bytes"
 	"fmt"
+	"log"
 	"sync"
 
 	uuid "github.com/hashicorp/go-uuid"
@@ -158,6 +159,9 @@ func (s *State) PersistState(schemas *terraform.Schemas) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
+	log.Printf("[DEBUG] states/remote: state read serial is: %d; serial is: %d", s.readSerial, s.serial)
+	log.Printf("[DEBUG] states/remote: state read lineage is: %s; lineage is: %s", s.readLineage, s.lineage)
+
 	if s.readState != nil {
 		lineageUnchanged := s.readLineage != "" && s.lineage == s.readLineage
 		serialUnchanged := s.readSerial != 0 && s.serial == s.readSerial
@@ -175,13 +179,15 @@ func (s *State) PersistState(schemas *terraform.Schemas) error {
 		if err != nil {
 			return fmt.Errorf("failed checking for existing remote state: %s", err)
 		}
+		log.Printf("[DEBUG] states/remote: after refresh, state read serial is: %d; serial is: %d", s.readSerial, s.serial)
+		log.Printf("[DEBUG] states/remote: after refresh, state read lineage is: %s; lineage is: %s", s.readLineage, s.lineage)
 		if s.lineage == "" { // indicates that no state snapshot is present yet
 			lineage, err := uuid.GenerateUUID()
 			if err != nil {
 				return fmt.Errorf("failed to generate initial lineage: %v", err)
 			}
 			s.lineage = lineage
-			s.serial = 0
+			s.serial = 1
 		}
 	}
 

--- a/internal/states/remote/state.go
+++ b/internal/states/remote/state.go
@@ -187,7 +187,7 @@ func (s *State) PersistState(schemas *terraform.Schemas) error {
 				return fmt.Errorf("failed to generate initial lineage: %v", err)
 			}
 			s.lineage = lineage
-			s.serial = 1
+			s.serial++
 		}
 	}
 


### PR DESCRIPTION
This fixes #30670, which is due to how the remote state functionality previously had slightly different logic for the initial serial number of state. The local backend always generated initial state with a serial of `> 0`, whereas remote state would generate it with a serial of `0`. When combined with certain conditions (such as the one laid out in the referenced issue), this could result in Terraform over-writing remote state with stale state from a `plan` file and not throwing the expected `The given plan file can no longer be applied because the state was changed` error.

To support this change I also had to refactor the way in which the tests for the affected method were written, since previously the tests assumed one request per test case. I think I did this in a fairly idiomatic way that didn't depart too much from the rest of the test methods but I'm certainly open to suggestions on other ways to do so.

Fixes #30670

## Target Release

1.4.x
1.3-backport

## Draft CHANGELOG entry

### BUG FIXES
-  When using remote state and an initial `terraform apply` operation with a `plan` file specified partially succeeds, Terraform would allow the stale `plan` file to be used again and overwrite the remote state, due to a small difference in how remote state was initially created. Terraform now creates initial remote state in a manner consistent with local state, and will throw the expected `The given plan file can no longer be applied because the state was changed` error if a stale plan file is used again after the initial partially successful `apply` operation.
