### PR TITLE
do not print out the entire http req/resp in debug mode if using azure as a remote backend

### DIFF
--- a/internal/backend/remote-state/azure/sender.go
+++ b/internal/backend/remote-state/azure/sender.go
@@ -3,7 +3,6 @@ package azure
 import (
 	"log"
 	"net/http"
-	"net/http/httputil"
 
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/hashicorp/terraform/internal/logging"
@@ -33,13 +32,7 @@ func withRequestLogging() autorest.SendDecorator {
 				r.Header.Del(authHeaderName)
 			}
 
-			// dump request to wire format
-			if dump, err := httputil.DumpRequestOut(r, true); err == nil {
-				log.Printf("[DEBUG] Azure Backend Request: \n%s\n", dump)
-			} else {
-				// fallback to basic message
-				log.Printf("[DEBUG] Azure Backend Request: %s to %s\n", r.Method, r.URL)
-			}
+			log.Printf("[DEBUG] Azure Backend Request: %s to %s\n", r.Method, r.URL)
 
 			// add the auth header back
 			if auth != "" {
@@ -48,13 +41,7 @@ func withRequestLogging() autorest.SendDecorator {
 
 			resp, err := s.Do(r)
 			if resp != nil {
-				// dump response to wire format
-				if dump, err2 := httputil.DumpResponse(resp, true); err2 == nil {
-					log.Printf("[DEBUG] Azure Backend Response for %s: \n%s\n", r.URL, dump)
-				} else {
-					// fallback to basic message
-					log.Printf("[DEBUG] Azure Backend Response: %s for %s\n", resp.Status, r.URL)
-				}
+				log.Printf("[DEBUG] Azure Backend Response: %s for %s\n", resp.Status, r.URL)
 			} else {
 				log.Printf("[DEBUG] Request to %s completed with no response", r.URL)
 			}


### PR DESCRIPTION
This change is about logging **ONLY** http req/resp method and URL if debug mode enabled and using azure backend.

Because, currently, the entire http req/resp is printed out including the content of terraform state which might contain secrets.

It's related to this issue: https://github.com/hashicorp/terraform/issues/32382

## Draft CHANGELOG entry

### BUG FIXES

-  When enabling terraform debugging plus using azure backend, Terraform logs only http request/response method and URL instead of the entire http request/response to prevent printing out the terraform state including potential secrets.
