### PR TITLE
structured renderer: fix closing json bracket when rendering with no symbols

### DIFF
--- a/internal/command/jsonformat/computed/renderers/primitive.go
+++ b/internal/command/jsonformat/computed/renderers/primitive.go
@@ -217,7 +217,7 @@ func (renderer primitiveRenderer) renderStringDiffAsJson(diff computed.Diff, ind
 	}
 
 	if strings.Contains(renderedJsonDiff, "\n") {
-		return fmt.Sprintf("jsonencode(%s\n%s%s%s%s\n%s)%s", whitespace, formatIndent(indent+1), writeDiffActionSymbol(action, opts), renderedJsonDiff, replace, formatIndent(indent+1), nullSuffix(diff.Action, opts))
+		return fmt.Sprintf("jsonencode(%s\n%s%s%s%s\n%s%s)%s", whitespace, formatIndent(indent+1), writeDiffActionSymbol(action, opts), renderedJsonDiff, replace, formatIndent(indent), writeDiffActionSymbol(plans.NoOp, opts), nullSuffix(diff.Action, opts))
 	}
 	return fmt.Sprintf("jsonencode(%s)%s%s", renderedJsonDiff, whitespace, replace)
 }

--- a/internal/command/jsonformat/computed/renderers/renderer_test.go
+++ b/internal/command/jsonformat/computed/renderers/renderer_test.go
@@ -2064,6 +2064,23 @@ jsonencode(
     ]
 `,
 		},
+		"json_string_no_symbols": {
+			diff: computed.Diff{
+				Renderer: Primitive("{\"key\":\"value\"}", "{\"key\":\"value\"}", cty.String),
+				Action:   plans.NoOp,
+			},
+			opts: computed.RenderHumanOpts{
+				HideDiffActionSymbols: true,
+				ShowUnchangedChildren: true,
+			},
+			expected: `
+jsonencode(
+    {
+        key = "value"
+    }
+)
+`,
+		},
 	}
 	for name, tc := range tcs {
 		t.Run(name, func(t *testing.T) {


### PR DESCRIPTION
I made a PR to add rendering the state to the equivalence tests (https://github.com/hashicorp/terraform-equivalence-testing/pull/17), and in doing so spotted that the closing json bracket when rendering json strings was indented improperly when rendering without symbols.

This PR fixes that by rendering the indents on the final line for JSON strings properly, that is considering that the symbol width and the indent length are not necessarily the same and now rendering the empty symbol instead of just increasing the indent by one.