### PR TITLE
Begin cloud remote state with serial > 0

### DIFF
--- a/internal/cloud/state.go
+++ b/internal/cloud/state.go
@@ -140,6 +140,9 @@ func (s *State) PersistState(schemas *terraform.Schemas) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
+	log.Printf("[DEBUG] cloud/state: state read serial is: %d; serial is: %d", s.readSerial, s.serial)
+	log.Printf("[DEBUG] cloud/state: state read lineage is: %s; lineage is: %s", s.readLineage, s.lineage)
+
 	if s.readState != nil {
 		lineageUnchanged := s.readLineage != "" && s.lineage == s.readLineage
 		serialUnchanged := s.readSerial != 0 && s.serial == s.readSerial
@@ -157,13 +160,16 @@ func (s *State) PersistState(schemas *terraform.Schemas) error {
 		if err != nil {
 			return fmt.Errorf("failed checking for existing remote state: %s", err)
 		}
+		log.Printf("[DEBUG] cloud/state: after refresh, state read serial is: %d; serial is: %d", s.readSerial, s.serial)
+		log.Printf("[DEBUG] cloud/state: after refresh, state read lineage is: %s; lineage is: %s", s.readLineage, s.lineage)
+
 		if s.lineage == "" { // indicates that no state snapshot is present yet
 			lineage, err := uuid.GenerateUUID()
 			if err != nil {
 				return fmt.Errorf("failed to generate initial lineage: %v", err)
 			}
 			s.lineage = lineage
-			s.serial = 0
+			s.serial++
 		}
 	}
 

--- a/internal/cloud/state_test.go
+++ b/internal/cloud/state_test.go
@@ -250,3 +250,23 @@ func TestDelete_SafeDelete(t *testing.T) {
 		t.Fatalf("workspace %s not deleted", workspaceId)
 	}
 }
+
+func TestState_PersistState(t *testing.T) {
+	cloudState := testCloudState(t)
+
+	t.Run("Initial PersistState", func(t *testing.T) {
+		if cloudState.readState != nil {
+			t.Fatal("expected nil initial readState")
+		}
+
+		err := cloudState.PersistState(nil)
+		if err != nil {
+			t.Fatalf("expected no error, got %q", err)
+		}
+
+		var expectedSerial uint64 = 1
+		if cloudState.readSerial != expectedSerial {
+			t.Fatalf("expected initial state readSerial to be %d, got %d", expectedSerial, cloudState.readSerial)
+		}
+	})
+}


### PR DESCRIPTION
Duplicates the remote state bug fix in #32614 

State versions created by the cloud integration should begin with serial 1, which matches the local state serial. This can prevent certain types of state/plan mismatches as described in #30670 

Remote backend is not subject to this same bug because it uses the remote state package.

## Target Release

1.4.0, 1.3.8

