### PR TITLE
Fix panic when planning orphaned deposed instances

### DIFF
--- a/internal/terraform/node_resource_plan_orphan.go
+++ b/internal/terraform/node_resource_plan_orphan.go
@@ -125,7 +125,7 @@ func (n *NodePlannableResourceInstanceOrphan) managedResourceExecute(ctx EvalCon
 	// refresh indicates the instance no longer exists, there is also nothing
 	// to plan because there is no longer any state and it doesn't exist in the
 	// config.
-	if n.skipPlanChanges || oldState.Value.IsNull() {
+	if n.skipPlanChanges || oldState == nil || oldState.Value.IsNull() {
 		return diags.Append(n.writeResourceInstanceState(ctx, oldState, workingState))
 	}
 


### PR DESCRIPTION
This is a highly local fix for a panic which seems to arise when planning orphaned deposed instances. There are two other things to investigate in response to this issue, likely addressing each in follow-up PRs:

- Fix the graph transformers so that we don't add orphan processing nodes when the instance is deposed;
- Investigate why `readResourceInstanceState` needs to return `nil, nil` in the first place, and redesign it if possible so that we don't have this class of bug elsewhere.

(I may have misunderstood an out-of-band discussion about this, and if we might not want to use this approach at all, in which case we'll probably just fix the graph transformers instead.)

Fixes #32645 (probably; we don't have a full reproduction to validate this)

## Target Release

1.3.x

This is a panic and a narrowly-scoped fix, so I think we should backport it.

## Draft CHANGELOG entry

### BUG FIXES

- Fix crash when planning to remove already-deposed resource instances.