### PR TITLE
Do not add orphan nodes for deposed instances

### DIFF
--- a/internal/terraform/transform_orphan_count.go
+++ b/internal/terraform/transform_orphan_count.go
@@ -33,7 +33,13 @@ func (t *OrphanResourceInstanceCountTransformer) Transform(g *Graph) error {
 	// number of instances of a single resource ought to always be small in any
 	// reasonable Terraform configuration.
 Have:
-	for key := range rs.Instances {
+	for key, inst := range rs.Instances {
+		// Instances which have no current objects (only one or more
+		// deposed objects) will be taken care of separately
+		if inst.Current == nil {
+			continue
+		}
+
 		thisAddr := rs.Addr.Instance(key)
 		for _, wantAddr := range t.InstanceAddrs {
 			if wantAddr.Equal(thisAddr) {

--- a/internal/terraform/transform_orphan_resource.go
+++ b/internal/terraform/transform_orphan_resource.go
@@ -87,7 +87,8 @@ func (t *OrphanResourceInstanceTransformer) transform(g *Graph, ms *states.Modul
 		}
 
 		for key, inst := range rs.Instances {
-			// deposed instances will be taken care of separately
+			// Instances which have no current objects (only one or more
+			// deposed objects) will be taken care of separately
 			if inst.Current == nil {
 				continue
 			}


### PR DESCRIPTION
Resource instances with no current object in state should not have orphan nodes added to the graph, as deposed objects are handled separately. This was previously handled correctly for the non-expanded case, but expanded resources were missing the appropriate check for a current object.

Also update the comment in the non-expanded case to hopefully clarify that we're checking for the presence of a current object, not the absence of any deposed objects. An instance may have both a current object and zero or more deposed objects in some circumstances, and if so, we still want an orphan node to be added if the instance is not in configuration.

Fixes #32645 (probably; we don't have a full reproduction to validate this)

See also #32663, for another approach to a fix for the same reported issue.

## Target Release

1.3.x

Since this also probably fixes the panic found in the above issue, it's worth considering for a future 1.3 release.

## Draft CHANGELOG entry

### BUG FIXES

- Fix crash when planning to remove already-deposed resource instances.