### PR TITLE
Fix SRO authorization bug when token is fetched from cloud config

### DIFF
--- a/internal/cloud/backend.go
+++ b/internal/cloud/backend.go
@@ -66,6 +66,9 @@ type Cloud struct {
 	// hostname of Terraform Cloud or Terraform Enterprise
 	hostname string
 
+	// token for Terraform Cloud or Terraform Enterprise
+	token string
+
 	// organization is the organization that contains the target workspaces.
 	organization string
 
@@ -250,7 +253,7 @@ func (b *Cloud) Configure(obj cty.Value) tfdiags.Diagnostics {
 	// Get the token from the CLI Config File in the credentials section
 	// if no token was not set in the configuration
 	if token == "" {
-		token, err = b.token()
+		token, err = b.cliConfigToken()
 		if err != nil {
 			diags = diags.Append(tfdiags.AttributeValue(
 				tfdiags.Error,
@@ -280,6 +283,7 @@ func (b *Cloud) Configure(obj cty.Value) tfdiags.Diagnostics {
 		return diags
 	}
 
+	b.token = token
 	b.configureGenericHostname()
 
 	if b.client == nil {
@@ -458,10 +462,10 @@ func (b *Cloud) discover() (*url.URL, error) {
 	return service, err
 }
 
-// token returns the token for this host as configured in the credentials
+// cliConfigToken returns the token for this host as configured in the credentials
 // section of the CLI Config File. If no token was configured, an empty
 // string will be returned instead.
-func (b *Cloud) token() (string, error) {
+func (b *Cloud) cliConfigToken() (string, error) {
 	hostname, err := svchost.ForComparison(b.hostname)
 	if err != nil {
 		return "", err

--- a/internal/cloud/backend_plan.go
+++ b/internal/cloud/backend_plan.go
@@ -432,12 +432,8 @@ func (b *Cloud) renderPlanLogs(ctx context.Context, op *backend.Operation, run *
 	// enabled. The plan output will have already been rendered when the logs
 	// were read if this wasn't the case.
 	if run.Workspace.StructuredRunOutputEnabled && b.renderer != nil {
-		token, err := b.token()
-		if err != nil {
-			return err
-		}
 		// Fetch the redacted plan.
-		redacted, err := readRedactedPlan(ctx, b.client.BaseURL(), token, run.Plan.ID)
+		redacted, err := readRedactedPlan(ctx, b.client.BaseURL(), b.token, run.Plan.ID)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

An authorization bug was reported: #32665 

In the cloud backend, we instantiate a new http client in order to fetch the redacted plan and generate the plan output. The auth token for this client was configured by calling `b.token()` which only sources the token from your CLI configuration, ignoring any token that was set in the cloud config itself. 

In order to make use of the token returned by the cloud config, I've added a new `token` field to the cloud backend, since the `Configure()` receiver is the only place we have access to the config. I've also renamed `b.token()` to be more descriptive about where the token is being fetched to avoid any further confusion. 

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.4.x

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

### BUG FIXES

<!--

Write a short description of the user-facing change. Examples:

- `terraform show -json`: Fixed crash with sensitive set values.
- When rendering a diff, Terraform now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 

-  
