### PR TITLE
allow terraform_data to import

### DIFF
--- a/internal/builtin/providers/terraform/provider.go
+++ b/internal/builtin/providers/terraform/provider.go
@@ -119,7 +119,11 @@ func (p *Provider) ApplyResourceChange(req providers.ApplyResourceChangeRequest)
 }
 
 // ImportResourceState requests that the given resource be imported.
-func (p *Provider) ImportResourceState(providers.ImportResourceStateRequest) providers.ImportResourceStateResponse {
+func (p *Provider) ImportResourceState(req providers.ImportResourceStateRequest) providers.ImportResourceStateResponse {
+	if req.TypeName == "terraform_data" {
+		return importDataStore(req)
+	}
+
 	panic("unimplemented - terraform_remote_state has no resources")
 }
 

--- a/internal/builtin/providers/terraform/resource_data.go
+++ b/internal/builtin/providers/terraform/resource_data.go
@@ -146,3 +146,24 @@ func applyDataStoreResourceChange(req providers.ApplyResourceChangeRequest) (res
 
 	return resp
 }
+
+// TODO: This isn't very useful even for examples, because terraform_data has
+// no way to refresh the full resource value from only the import ID. This
+// minimal implementation allows the import to succeed, and can be extended
+// once the configuration is available during import.
+func importDataStore(req providers.ImportResourceStateRequest) (resp providers.ImportResourceStateResponse) {
+	schema := dataStoreResourceSchema()
+	v := cty.ObjectVal(map[string]cty.Value{
+		"id": cty.StringVal(req.ID),
+	})
+	state, err := schema.Block.CoerceValue(v)
+	resp.Diagnostics = resp.Diagnostics.Append(err)
+
+	resp.ImportedResources = []providers.ImportedResource{
+		{
+			TypeName: req.TypeName,
+			State:    state,
+		},
+	}
+	return resp
+}


### PR DESCRIPTION
The terraform provider was panicking on import, because it didn't previously have a resource type which could be imported at all. Add a stub import function for `terraform_data` as a placeholder to allow the call to complete successfully. While there's no need to actually import a `terraform_data` resource, users will inevitably use this to construct examples of import actions for learning purposes or bug reports.

This still isn't very useful even for examples however, because the state-only nature of the `terraform_data` resource type means that we can't fill in the state from only the import ID. This means that any value in `trigger_replace` or `input` will cause a change in the next plan. Once configuration data is available during import we can extend this to create a logical final state based on config.