### PR TITLE
Adding provider constraint best practice statement

### DIFF
--- a/website/docs/language/providers/index.mdx
+++ b/website/docs/language/providers/index.mdx
@@ -55,7 +55,7 @@ see the [provider publishing documentation](/registry/providers/docs).
 
 ## How to Use Providers
 
-Providers are released on a separate rhythm from Terraform itself, and thus have their own version numbers. For production use, it is recommended to constrain the acceptable provider versions by pinning it via configuration, to ensure that new versions with breaking changes will not be automatically installed by `terraform init` in the future.
+Providers are released separately from Terraform itself, and have their own version numbers. In production we recommend constraining the acceptable provider versions in the configuration's provider requirements block, to make sure that `terraform init` does not install newer versions of the provider that are incompatible with the configuration.
 
 To use resources from a given provider, you need to include some information
 about it in your configuration. See the following pages for details:

--- a/website/docs/language/providers/index.mdx
+++ b/website/docs/language/providers/index.mdx
@@ -55,6 +55,8 @@ see the [provider publishing documentation](/registry/providers/docs).
 
 ## How to Use Providers
 
+Providers are released on a separate rhythm from Terraform itself, and thus have their own version numbers. For production use, it is recommended to constrain the acceptable provider versions by pinning it via configuration, to ensure that new versions with breaking changes will not be automatically installed by `terraform init` in the future.
+
 To use resources from a given provider, you need to include some information
 about it in your configuration. See the following pages for details:
 


### PR DESCRIPTION
[Originally communicated here,](https://developer.hashicorp.com/terraform/language/v1.1.x/configuration-0-11/providers?ajs_aid=3cf1bdca-a598-4dc5-b074-6064b276abb6&_gl=1*xuizrx*_ga*MTM1ODg4NTcyMi4xNjY2MTA5NjI1*_ga_P7S46ZYEKW*MTY3NjU2OTMzNS4zMi4wLjE2NzY1Njk0MDMuMC4wLjA.&product_intent=terraform#provider-versions) this statement is missing in newer docs.


> Providers are released on a separate rhythm from Terraform itself, and thus have their own version numbers. For production use, it is recommended to constrain the acceptable provider versions by pinning it via configuration, to ensure that new versions with breaking changes will not be automatically installed by `terraform init` in the future.