### PR TITLE
Bug Fix where CLI exits if run is not confirmable.

### DIFF
--- a/internal/cloud/backend_taskStages.go
+++ b/internal/cloud/backend_taskStages.go
@@ -98,8 +98,7 @@ func (b *Cloud) runTaskStage(ctx *IntegrationContext, output IntegrationOutputWr
 			// Waiting for it to start
 			return true, nil
 		case tfe.TaskStageRunning:
-			_, e := processSummarizers(ctx, output, stage, summarizers, errs)
-			if e != nil {
+			if _, e := processSummarizers(ctx, output, stage, summarizers, errs); e != nil {
 				errs = e
 			}
 			// not a terminal status so we continue to poll

--- a/internal/cloud/backend_taskStages.go
+++ b/internal/cloud/backend_taskStages.go
@@ -97,8 +97,15 @@ func (b *Cloud) runTaskStage(ctx *IntegrationContext, output IntegrationOutputWr
 		case tfe.TaskStagePending:
 			// Waiting for it to start
 			return true, nil
+		case tfe.TaskStageRunning:
+			_, e := processSummarizers(ctx, output, stage, summarizers, errs)
+			if e != nil {
+				errs = e
+			}
+			// not a terminal status so we continue to poll
+			return true, nil
 		// Note: Terminal statuses need to print out one last time just in case
-		case tfe.TaskStageRunning, tfe.TaskStagePassed:
+		case tfe.TaskStagePassed:
 			ok, e := processSummarizers(ctx, output, stage, summarizers, errs)
 			if e != nil {
 				errs = e
@@ -176,6 +183,8 @@ func (b *Cloud) processStageOverrides(context *IntegrationContext, output Integr
 	if err != errRunOverridden {
 		if _, err = b.client.TaskStages.Override(context.StopContext, taskStageID, tfe.TaskStageOverrideOptions{}); err != nil {
 			return false, generalError(fmt.Sprintf("Failed to override policy check.\n%s", runUrl), err)
+		} else {
+			return true, nil
 		}
 	} else {
 		output.Output(fmt.Sprintf("The run needs to be manually overridden or discarded.\n%s\n", runUrl))

--- a/internal/cloud/backend_taskStages_test.go
+++ b/internal/cloud/backend_taskStages_test.go
@@ -220,6 +220,7 @@ func TestTaskStageOverride(t *testing.T) {
 		isError     bool
 		errMsg      string
 		input       *mockInput
+		cont        bool
 	}{
 		"override-pass": {
 			taskStageID: "ts-pass",
@@ -228,6 +229,7 @@ func TestTaskStageOverride(t *testing.T) {
 				"→→ [bold]Override": "override",
 			}),
 			errMsg: "",
+			cont:   true,
 		},
 		"override-fail": {
 			taskStageID: "ts-err",
@@ -236,6 +238,7 @@ func TestTaskStageOverride(t *testing.T) {
 				"→→ [bold]Override": "override",
 			}),
 			errMsg: "",
+			cont:   false,
 		},
 		"skip-override": {
 			taskStageID: "ts-err",
@@ -244,11 +247,12 @@ func TestTaskStageOverride(t *testing.T) {
 			input: testInput(t, map[string]string{
 				"→→ [bold]Override": "no",
 			}),
+			cont: false,
 		},
 	}
 	for _, c := range cases {
 		integrationContext.Op.UIIn = c.input
-		_, err := b.processStageOverrides(integrationContext, writer, c.taskStageID)
+		cont, err := b.processStageOverrides(integrationContext, writer, c.taskStageID)
 		if c.isError {
 			if err == nil {
 				t.Fatalf("Expected to fail with some error")
@@ -263,6 +267,9 @@ func TestTaskStageOverride(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Expected to pass, got err: %s", err)
 			}
+		}
+		if c.cont != cont {
+			t.Fatalf("expected polling continue: %t, got: %t", c.cont, cont)
 		}
 	}
 }


### PR DESCRIPTION
Fixes an issue where the CLI exits early after a policy evaluation due to a race condition.
The CLI checks whether the run is [confirmable](https://github.com/hashicorp/terraform/blob/main/internal/cloud/backend_apply.go#L100) or not after a policy evaluation. Due to latency issues, the run is still in task_stage_running state since the status has not been updated yet and the CLI exits. This change allows the policy evaluation to keep polling until a final status has been reached. 
It continues to poll if the taskStage status is `running` or `awaiting_override` until the taskStage reaches a terminal status (either passed, failed, cancelled, errored or unreachable)

This PR also adds a missing CHANGELOG entry.

Fixes #

## Target Release

1.4.0

## Draft CHANGELOG entry

### NEW FEATURES
* When showing the progress of a remote operation running in Terraform Cloud, Terraform CLI will include information about OPA policy evaluation ([#32303](https://github.com/hashicorp/terraform/issues/32303))

### BUG FIXES
* Fixes a race condition where the Terraform CLI checks if a run is confirmable before the run status gets updated and exits early.

