### PR TITLE
cliconfig: more err detail when provider_installation has invalid provider source

### DIFF
--- a/internal/command/cliconfig/provider_installation.go
+++ b/internal/command/cliconfig/provider_installation.go
@@ -246,7 +246,7 @@ func decodeProviderInstallationFromConfig(hclFile *hclast.File) ([]*ProviderInst
 						diags = diags.Append(tfdiags.Sourceless(
 							tfdiags.Error,
 							"Invalid provider installation dev overrides",
-							fmt.Sprintf("The entry %q in %s is not a valid provider source string.", rawAddr, block.Pos()),
+							fmt.Sprintf("The entry %q in %s is not a valid provider source string.\n\n%s", rawAddr, block.Pos(), moreDiags.Err().Error()),
 						))
 						continue
 					}


### PR DESCRIPTION
Fixes #32716.

Error output beforehand:
```
$   terraform plan
There are some problems with the CLI configuration:
╷
│ Error: Invalid provider installation dev overrides
│
│ The entry "registry.terraform.io/joneshf/terraform-provider-foo" in 1:1 is
│ not a valid provider source string.
╵

As a result of the above problems, Terraform may not behave as intended.
```

Error output afterward:
```
$  terraform plan
There are some problems with the CLI configuration:
╷
│ Error: Invalid provider installation dev overrides
│
│ The entry "registry.terraform.io/joneshf/terraform-provider-foo" in 1:1 is
│ not a valid provider source string.
│ Invalid provider type: Provider source "joneshf/terraform-provider-foo" has
│ a type with the prefix "terraform-provider-", which isn't valid. Although
│ that prefix is often used in the names of version control repositories for
│ Terraform providers, provider source strings should not include it.
│
│ Did you mean "joneshf/foo"?
╵

As a result of the above problems, Terraform may not behave as intended.
```

I believe this is a valid use of the error message from `ParseProviderSourceString`, as cliconfig is parsing a hand-written provider source string. This should be the "user error" case in https://github.com/hashicorp/terraform-registry-address/blob/a459db791fcb28a1b93d9b7e0a46b5f1db027fa9/provider.go#L263.