### PR TITLE
cliconfig: Allow breaking the dependency lock file using the environment

### DIFF
--- a/internal/command/cliconfig/cliconfig_test.go
+++ b/internal/command/cliconfig/cliconfig_test.go
@@ -31,7 +31,7 @@ func TestLoadConfig(t *testing.T) {
 	}
 }
 
-func TestLoadConfig_env(t *testing.T) {
+func TestLoadConfig_envSubst(t *testing.T) {
 	defer os.Unsetenv("TFTEST")
 	os.Setenv("TFTEST", "hello")
 
@@ -53,6 +53,141 @@ func TestLoadConfig_env(t *testing.T) {
 	if !reflect.DeepEqual(c, expected) {
 		t.Fatalf("bad: %#v", c)
 	}
+}
+
+func TestEnvConfig(t *testing.T) {
+	tests := map[string]struct {
+		env  map[string]string
+		want *Config
+	}{
+		"no environment variables": {
+			nil,
+			&Config{},
+		},
+		"TF_PLUGIN_CACHE_DIR=boop": {
+			map[string]string{
+				"TF_PLUGIN_CACHE_DIR": "boop",
+			},
+			&Config{
+				PluginCacheDir: "boop",
+			},
+		},
+		"TF_PLUGIN_CACHE_MAY_BREAK_DEPENDENCY_LOCK_FILE=anything_except_zero": {
+			map[string]string{
+				"TF_PLUGIN_CACHE_MAY_BREAK_DEPENDENCY_LOCK_FILE": "anything_except_zero",
+			},
+			&Config{
+				PluginCacheMayBreakDependencyLockFile: true,
+			},
+		},
+		"TF_PLUGIN_CACHE_MAY_BREAK_DEPENDENCY_LOCK_FILE=0": {
+			map[string]string{
+				"TF_PLUGIN_CACHE_MAY_BREAK_DEPENDENCY_LOCK_FILE": "0",
+			},
+			&Config{},
+		},
+		"TF_PLUGIN_CACHE_DIR and TF_PLUGIN_CACHE_MAY_BREAK_DEPENDENCY_LOCK_FILE": {
+			map[string]string{
+				"TF_PLUGIN_CACHE_DIR":                            "beep",
+				"TF_PLUGIN_CACHE_MAY_BREAK_DEPENDENCY_LOCK_FILE": "1",
+			},
+			&Config{
+				PluginCacheDir:                        "beep",
+				PluginCacheMayBreakDependencyLockFile: true,
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := envConfig(test.env)
+			want := test.want
+
+			if diff := cmp.Diff(want, got); diff != "" {
+				t.Errorf("wrong result\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestMakeEnvMap(t *testing.T) {
+	tests := map[string]struct {
+		environ []string
+		want    map[string]string
+	}{
+		"nil": {
+			nil,
+			nil,
+		},
+		"one": {
+			[]string{
+				"FOO=bar",
+			},
+			map[string]string{
+				"FOO": "bar",
+			},
+		},
+		"many": {
+			[]string{
+				"FOO=1",
+				"BAR=2",
+				"BAZ=3",
+			},
+			map[string]string{
+				"FOO": "1",
+				"BAR": "2",
+				"BAZ": "3",
+			},
+		},
+		"conflict": {
+			[]string{
+				"FOO=1",
+				"BAR=1",
+				"FOO=2",
+			},
+			map[string]string{
+				"BAR": "1",
+				"FOO": "2", // Last entry of each name wins
+			},
+		},
+		"empty_val": {
+			[]string{
+				"FOO=",
+			},
+			map[string]string{
+				"FOO": "",
+			},
+		},
+		"no_equals": {
+			[]string{
+				"FOO=bar",
+				"INVALID",
+			},
+			map[string]string{
+				"FOO": "bar",
+			},
+		},
+		"multi_equals": {
+			[]string{
+				"FOO=bar=baz=boop",
+			},
+			map[string]string{
+				"FOO": "bar=baz=boop",
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := makeEnvMap(test.environ)
+			want := test.want
+
+			if diff := cmp.Diff(want, got); diff != "" {
+				t.Errorf("wrong result\n%s", diff)
+			}
+		})
+	}
+
 }
 
 func TestLoadConfig_hosts(t *testing.T) {
@@ -284,6 +419,7 @@ func TestConfig_Merge(t *testing.T) {
 				},
 			},
 		},
+		PluginCacheMayBreakDependencyLockFile: true,
 	}
 
 	expected := &Config{
@@ -338,6 +474,7 @@ func TestConfig_Merge(t *testing.T) {
 				},
 			},
 		},
+		PluginCacheMayBreakDependencyLockFile: true,
 	}
 
 	actual := c1.Merge(c2)


### PR DESCRIPTION
Since it's already possible to activate the dependency lock file using an environment variable, we should allow opting in to it having broken behavior using the environment too.

It's kinda odd in retrospect that `TF_PLUGIN_CACHE_DIR` is the only setting we allow to be configured both in the environment and the CLI configuration. That means that the infrastructure for dealing with that situation was relatively immature here and so I did some light refactoring to make it unit-testable without actually modifying the test program's environment. To reduce the risk of that I wrote what might be considered an excessive amount of tests for such a small change.

Closes #32656.
