### PR TITLE
website: Document TF_PLUGIN_CACHE_MAY_BREAK_DEPENDENCY_LOCK_FILE env var

### DIFF
--- a/website/docs/cli/config/config-file.mdx
+++ b/website/docs/cli/config/config-file.mdx
@@ -387,7 +387,7 @@ grow to contain several unused versions which you must delete manually.
 safe. The provider installer's behavior in environments with multiple `terraform
 init` calls is undefined.
 
-## Allowing the Provider Plugin Cache to break the dependency lock file
+### Allowing the Provider Plugin Cache to break the dependency lock file
 
 ~> **Note:** The option described in is for unusual and exceptional situations
 only. Do not set this option unless you are sure you need it and you fully
@@ -414,6 +414,10 @@ to confirm it:
 ```hcl
 plugin_cache_may_break_dependency_lock_file = true
 ```
+
+Alternatively, you can set the environment variable
+`TF_PLUGIN_CACHE_MAY_BREAK_DEPENDENCY_LOCK_FILE` to any value other than the
+empty string or `0`, which is equivalent to the above setting.
 
 Setting this option gives Terraform CLI permission to create an incomplete
 dependency lock file entry for a provider if that would allow Terraform to

--- a/website/docs/cli/config/environment-variables.mdx
+++ b/website/docs/cli/config/environment-variables.mdx
@@ -151,6 +151,12 @@ The location of the [Terraform CLI configuration file](/terraform/cli/config/con
 export TF_CLI_CONFIG_FILE="$HOME/.terraformrc-custom"
 ```
 
+## TF_PLUGIN_CACHE_DIR
+
+The `TF_PLUGIN_CACHE_DIR` environment variable is an alternative way to set [the `plugin_cache_dir` setting in the CLI configuration](/terraform/cli/config/config-file#provider-plugin-cache).
+
+You can also use `TF_PLUGIN_CACHE_MAY_BREAK_DEPENDENCY_LOCK_FILE` to activate [the transitional compatibility setting `plugin_cache_may_break_dependency_lock_file`](/terraform/cli/config/config-file#allowing-the-provider-plugin-cache-to-break-the-dependency-lock-file).
+
 ## TF_IGNORE
 
 If `TF_IGNORE` is set to "trace", Terraform will output debug messages to display ignored files and folders. This is useful when debugging large repositories with `.terraformignore` files.


### PR DESCRIPTION
This is an alternative way to set the CLI configuration setting plugin_cache_may_break_dependency_lock_file to activate the transitional compatibility behavior that prefers to break the dependency lock file if that would create an additional opportunity to use the plugin cache.

This has been supported since #32726 but I forgot to update this particular doc section when I implemented it, despite @alisdair's attempt to prompt me which apparently I was too absent-minded to think about that day. :confounded: 

While here I also fixed a minor bug from #32494 (where this doc section originated) where the heading was at the wrong nesting level and so would've messed up the navigation tree as previously defined. The heading is now nested under "Provider Installation" as originally intended.
