### PR TITLE
Update documentation for compact function

### DIFF
--- a/website/docs/language/functions/compact.mdx
+++ b/website/docs/language/functions/compact.mdx
@@ -1,17 +1,17 @@
 ---
 page_title: compact - Functions - Configuration Language
-description: The compact function removes empty string elements from a list.
+description: The compact function removes null or empty string elements from a list.
 ---
 
 # `compact` Function
 
-`compact` takes a list of strings and returns a new list with any empty string
+`compact` takes a list of strings and returns a new list with any null or empty string
 elements removed.
 
 ## Examples
 
 ```
-> compact(["a", "", "b", "c"])
+> compact(["a", "", "b", null, "c"])
 [
   "a",
   "b",


### PR DESCRIPTION
Update the documentation for `compact` to indicate that it also accepts and filters out `null` values.

(previously #28285)