### PR TITLE
Add S3 permissions for backend bucket

### DIFF
--- a/website/docs/language/settings/backends/s3.mdx
+++ b/website/docs/language/settings/backends/s3.mdx
@@ -44,6 +44,11 @@ the target backend bucket:
 * `s3:PutObject` on `arn:aws:s3:::mybucket/path/to/my/key`
 * `s3:DeleteObject` on `arn:aws:s3:::mybucket/path/to/my/key`
 
+In case the Bucket is versioned and encrypted also these are needed:
+* `s3:GetBucketVersioning` on `arn:aws:s3:::mybucket/path/to/my/key`
+* `s3:GetBucketPublicAccessBlock` on `arn:aws:s3:::mybucket/path/to/my/key`
+* `s3:GetBucketEncryption` on `arn:aws:s3:::mybucket/path/to/my/key`
+
 This is seen in the following AWS IAM Statement:
 
 ```json
@@ -57,7 +62,14 @@ This is seen in the following AWS IAM Statement:
     },
     {
       "Effect": "Allow",
-      "Action": ["s3:GetObject", "s3:PutObject", "s3:DeleteObject"],
+      "Action": [
+        "s3:GetObject", 
+        "s3:PutObject", 
+        "s3:DeleteObject",
+        "s3:GetBucketVersioning",
+        "s3:GetBucketPublicAccessBlock",
+        "s3:GetBucketEncryption"         
+      ],
       "Resource": "arn:aws:s3:::mybucket/path/to/my/key"
     }
   ]


### PR DESCRIPTION
In the terraform documentation I added S3 permissions that are needed for backend buckets that are versioned and encrypted. Without these accessing the backend bucket fails. 
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.4.x

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

### NEW FEATURES | UPGRADE NOTES | ENHANCEMENTS | BUG FIXES | EXPERIMENTS

<!--

Write a short description of the user-facing change. Examples:

- `terraform show -json`: Fixed crash with sensitive set values.
- When rendering a diff, Terraform now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 

-  
