### PR TITLE
10x faster cloud tests

### DIFF
--- a/internal/cloud/backend_taskStage_policyEvaluation_test.go
+++ b/internal/cloud/backend_taskStage_policyEvaluation_test.go
@@ -79,7 +79,7 @@ func TestCloud_runTaskStageWithPolicyEvaluation(t *testing.T) {
 		trs := policyEvaluationSummarizer{
 			cloud: b,
 		}
-		c.context.Poll(taskStageBackoffMin, taskStageBackoffMax, func(i int) (bool, error) {
+		c.context.Poll(0, 0, func(i int) (bool, error) {
 			cont, _, _ := trs.Summarize(c.context, c.writer, c.taskStage())
 			if cont {
 				return true, nil

--- a/internal/cloud/backend_taskStage_taskResults_test.go
+++ b/internal/cloud/backend_taskStage_taskResults_test.go
@@ -151,7 +151,7 @@ func TestCloud_runTasksWithTaskResults(t *testing.T) {
 		trs := taskResultSummarizer{
 			cloud: b,
 		}
-		c.context.Poll(taskStageBackoffMin, taskStageBackoffMax, func(i int) (bool, error) {
+		c.context.Poll(0, 0, func(i int) (bool, error) {
 			cont, _, _ := trs.Summarize(c.context, c.writer, c.taskStage())
 			if cont {
 				return true, nil

--- a/internal/cloud/testing.go
+++ b/internal/cloud/testing.go
@@ -466,6 +466,7 @@ func testDisco(s *httptest.Server) *disco.Disco {
 
 	d.ForceHostServices(svchost.Hostname(defaultHostname), services)
 	d.ForceHostServices(svchost.Hostname("localhost"), services)
+	d.ForceHostServices(svchost.Hostname("nontfe.local"), nil)
 	return d
 }
 


### PR DESCRIPTION
The cloud package tests were taking over 40s to execute, due to a couple of minor issues:

* Run tasks tests were using the real polling intervals between requests. This seems unimportant to test, and setting it to 0 saves 30s.
* Config tests were making a request to `nonexisting.local`, which was intended to fail. This also didn't seem like a specifically important error. I replaced it with a request to a mocked non-TFE host, which still executes the error handling path, but doesn't spin for 5–10s on a DNS failure.

Before:

```shellsession
$ go test -count=1 ./internal/cloud/
ok  	github.com/hashicorp/terraform/internal/cloud	41.957s
```

After:

```shellsession
$ go test -count=1 ./internal/cloud/
ok  	github.com/hashicorp/terraform/internal/cloud	4.690s
```

## Target Release

1.4.1

Backporting to 1.4 as it's a test only change which will make CI execute much faster.
