### PR TITLE
Fix punctuation and spelling errors in Basic CLI Features and Command: plan documentation

### DIFF
--- a/website/docs/cli/commands/index.mdx
+++ b/website/docs/cli/commands/index.mdx
@@ -57,7 +57,7 @@ All other commands:
 Global options (use these before the subcommand, if any):
   -chdir=DIR    Switch to a different working directory before executing the
                 given subcommand.
-  -help         Show this help output, or the help for a specified subcommand.
+  -help         Show this help output or the help for a specified subcommand.
   -version      An alias for the "version" subcommand.
 ```
 
@@ -68,7 +68,7 @@ To get specific help for any specific command, use the `-help` option with the
 relevant subcommand. For example, to see help about the "validate" subcommand
 you can run `terraform validate -help`.
 
-The inline help built in to Terraform CLI describes the most important
+The inline help built into Terraform CLI describes the most important
 characteristics of each command. For more detailed information, refer to each
 command's page for details.
 

--- a/website/docs/cli/commands/index.mdx
+++ b/website/docs/cli/commands/index.mdx
@@ -130,7 +130,7 @@ terraform -uninstall-autocomplete
 
 The Terraform CLI commands interact with the HashiCorp service
 [Checkpoint](https://checkpoint.hashicorp.com/) to check for the availability
-of new versions and for critical security bulletins about the current version.
+of new versions and critical security bulletins about the current version.
 
 One place where the effect of this can be seen is in `terraform version`, where
 it is used by default to indicate in the output when a newer version is

--- a/website/docs/cli/commands/plan.mdx
+++ b/website/docs/cli/commands/plan.mdx
@@ -31,7 +31,7 @@ to be taken.
 If you are using Terraform directly in an interactive terminal and you expect
 to apply the changes Terraform proposes, you can alternatively run
 [`terraform apply`](/terraform/cli/commands/apply) directly. By default, the "apply" command
-automatically generates a new plan and prompts for you to approve it.
+automatically generates a new plan and prompts you to approve it.
 
 You can use the optional `-out=FILE` option to save the generated plan to a
 file on disk, which you can later execute by passing the file to
@@ -127,10 +127,10 @@ In addition to alternate [planning modes](#planning-modes), there are several op
   Terraform state with remote objects before checking for configuration changes. This can make the planning operation faster by reducing the number of remote API requests. However, setting `refresh=false` causes Terraform to ignore external changes, which could result in an incomplete or incorrect plan. You cannot use `refresh=false` in refresh-only planning mode because it would effectively disable the entirety of the planning operation.
 
 - `-replace=ADDRESS` - Instructs Terraform to plan to replace the
-  resource instance with the given address. This is helpful when one or more remote objects have become degraded, and you can use replacement objects with the same configuratation to align with immutable infrastructure patterns. Terraform will use a "replace" action if the specified resource would normally cause an "update" action or no action at all. Include this option multiple times to replace several objects at once. You cannot use `-replace` with the `-destroy` option, and it is only available from Terraform v0.15.2 onwards. For earlier versions, use [`terraform taint`](/terraform/cli/commands/taint) to achieve a similar result.
+  resource instance with the given address. This is helpful when one or more remote objects have become degraded, and you can use replacement objects with the same configuration to align with immutable infrastructure patterns. Terraform will use a "replace" action if the specified resource would normally cause an "update" action or no action at all. Include this option multiple times to replace several objects at once. You cannot use `-replace` with the `-destroy` option, and it is only available from Terraform v0.15.2 onwards. For earlier versions, use [`terraform taint`](/terraform/cli/commands/taint) to achieve a similar result.
 
 - `-target=ADDRESS` - Instructs Terraform to focus its planning efforts only
-  on resource instances which match the given address and on any objects that
+  on resource instances that match the given address and on any objects that
   those instances depend on.
 
   -> **Note:** Use `-target=ADDRESS` in exceptional circumstances only, such as recovering from mistakes or working around Terraform limitations. Refer to [Resource Targeting](#resource-targeting) for more details.
@@ -159,8 +159,8 @@ root module.
 
 However, to do so will require writing a command line that is parsable both
 by your chosen command line shell _and_ Terraform, which can be complicated
-for expressions involving lots of quotes and escape sequences. In most cases
-we recommend using the `-var-file` option instead, and write your actual values
+for expressions involving lots of quotes and escape sequences. In most cases,
+we recommend using the `-var-file` option instead, and writing your actual values
 in a separate file so that Terraform can parse them directly, rather than
 interpreting the result of your shell's parsing.
 


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.




See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->
This PR changes mistakes in index.mdx and plan.mdx terraform docs.
Changes in the index.mdx
- Removed unnecessary comma in a compound object. Because a compound object with only two items requires no punctuation to separate them.
 - Corrected the spelling of "into" as it should be one word.
 - Eliminated redundant preposition "for" from the documentation.
 
Changes in the plan.mdx
 - Removed incorrect preposition "for".
 - Corrected the spelling of "configuratation" as it should be "configuration".
 - Corrected the pronoun "which match" as it should be "that match".
 - Added necessary commas.
 - Corrected the use of incorrect form of verb "write" as it should be "writing"
<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->


<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->


<!--

Choose a category, delete the others:

-->

### UPGRADE NOTES

<!--

Write a short description of the user-facing change. Examples:

- `terraform show -json`: Fixed crash with sensitive set values.
- When rendering a diff, Terraform now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 

