### PR TITLE
bugfix(cliconfig.go): emit a warning msg if invalid CLI configuration file location

### DIFF
--- a/internal/command/cliconfig/cliconfig.go
+++ b/internal/command/cliconfig/cliconfig.go
@@ -9,7 +9,9 @@
 package cliconfig
 
 import (
+	"errors"
 	"fmt"
+	"io/fs"
 	"io/ioutil"
 	"log"
 	"os"
@@ -102,12 +104,14 @@ func LoadConfig() (*Config, tfdiags.Diagnostics) {
 	configVal := BuiltinConfig // copy
 	config := &configVal
 
-	if mainFilename, err := cliConfigFile(); err == nil {
+	if mainFilename, mainFileDiags := cliConfigFile(); len(mainFileDiags) == 0 {
 		if _, err := os.Stat(mainFilename); err == nil {
 			mainConfig, mainDiags := loadConfigFile(mainFilename)
 			diags = diags.Append(mainDiags)
 			config = config.Merge(mainConfig)
 		}
+	} else {
+		diags = diags.Append(mainFileDiags)
 	}
 
 	// Unless the user has specifically overridden the configuration file
@@ -407,7 +411,8 @@ func (c *Config) Merge(c2 *Config) *Config {
 	return &result
 }
 
-func cliConfigFile() (string, error) {
+func cliConfigFile() (string, tfdiags.Diagnostics) {
+	var diags tfdiags.Diagnostics
 	mustExist := true
 
 	configFilePath := cliConfigFileOverride()
@@ -427,15 +432,19 @@ func cliConfigFile() (string, error) {
 	f, err := os.Open(configFilePath)
 	if err == nil {
 		f.Close()
-		return configFilePath, nil
+		return configFilePath, diags
 	}
 
-	if mustExist || !os.IsNotExist(err) {
-		return "", err
+	if mustExist || !errors.Is(err, fs.ErrNotExist) {
+		diags = append(diags, tfdiags.Sourceless(
+			tfdiags.Warning,
+			"Unable to open CLI configuration file",
+			fmt.Sprintf("The CLI configuration file at %q specified does not exist.", configFilePath),
+		))
 	}
 
 	log.Println("[DEBUG] File doesn't exist, but doesn't need to. Ignoring.")
-	return "", nil
+	return "", diags
 }
 
 func cliConfigFileOverride() string {

--- a/internal/command/e2etest/init_test.go
+++ b/internal/command/e2etest/init_test.go
@@ -146,7 +146,7 @@ func TestInitProvidersLocalOnly(t *testing.T) {
 	// not work until you remove it.
 	//
 	// To avoid this, we will  "zero out" any existing cli config file.
-	tf.AddEnv("TF_CLI_CONFIG_FILE=\"\"")
+	tf.AddEnv("TF_CLI_CONFIG_FILE=")
 
 	// Our fixture dir has a generic os_arch dir, which we need to customize
 	// to the actual OS/arch where this test is running in order to get the


### PR DESCRIPTION

This Pull Request is about noticing people when `TF_CLI_CONFIG_FILE` environment variable points to a non existing file.

In such case, a warning message will be printed out like below;

```sh
There are some problems with the CLI configuration:
╷
│ Warning: Unable to open CLI configuration file
│
│ The CLI configuration file at
│ "/private/var/folders/7b/q4m7dd2x4fl8ltp731djsw940000gn/T/tmp.5TVZNsJu/.terraform.rcr"
│ specified does not exist.
╵
```

Fixes #32646

## Target Release

1.4.x

## Draft CHANGELOG entry

### BUG FIXES

- When setting an invalid CLI configuration file location, emit a warning message
