### PR TITLE
Fixes overriding modules which have depends_on attribute set

### DIFF
--- a/internal/configs/module_merge.go
+++ b/internal/configs/module_merge.go
@@ -190,12 +190,12 @@ func (mc *ModuleCall) merge(omc *ModuleCall) hcl.Diagnostics {
 
 	// We don't allow depends_on to be overridden because that is likely to
 	// cause confusing misbehavior.
-	if len(mc.DependsOn) != 0 {
+	if len(omc.DependsOn) != 0 {
 		diags = append(diags, &hcl.Diagnostic{
 			Severity: hcl.DiagError,
 			Summary:  "Unsupported override",
 			Detail:   "The depends_on argument may not be overridden.",
-			Subject:  mc.DependsOn[0].SourceRange().Ptr(), // the first item is the closest range we have
+			Subject:  omc.DependsOn[0].SourceRange().Ptr(), // the first item is the closest range we have
 		})
 	}
 

--- a/internal/configs/module_merge_test.go
+++ b/internal/configs/module_merge_test.go
@@ -117,6 +117,26 @@ func TestModuleOverrideModule(t *testing.T) {
 				Byte:   17,
 			},
 		},
+		DependsOn: []hcl.Traversal{
+			{
+				hcl.TraverseRoot{
+					Name: "null_resource",
+					SrcRange: hcl.Range{
+						Filename: "testdata/valid-modules/override-module/primary.tf",
+						Start:    hcl.Pos{Line: 11, Column: 17, Byte: 149},
+						End:      hcl.Pos{Line: 11, Column: 30, Byte: 162},
+					},
+				},
+				hcl.TraverseAttr{
+					Name: "test",
+					SrcRange: hcl.Range{
+						Filename: "testdata/valid-modules/override-module/primary.tf",
+						Start:    hcl.Pos{Line: 11, Column: 30, Byte: 162},
+						End:      hcl.Pos{Line: 11, Column: 35, Byte: 167},
+					},
+				},
+			},
+		},
 		Providers: []PassedProviderConfig{
 			{
 				InChild: &ProviderConfigRef{

--- a/internal/configs/testdata/valid-modules/override-module/primary.tf
+++ b/internal/configs/testdata/valid-modules/override-module/primary.tf
@@ -8,4 +8,6 @@ module "example" {
   providers = {
     test = test.foo
   }
+  depends_on = [null_resource.test]
 }
+resource "null_resource" "test" {}


### PR DESCRIPTION
Fixes #32795

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.4.x

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->
BUG FIXES

- Enables overriding modules that have `depends_on` attribute set (although still doesn't allow to override `depends_on` , which is the intended behaviour)
<!--

Write a short description of the user-facing change. Examples:

- `terraform show -json`: Fixed crash with sensitive set values.
- When rendering a diff, Terraform now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 
