### PR TITLE
Fix no-op outputs causing the plan renderer to skip the 'no changes' message

### DIFF
--- a/internal/command/jsonformat/plan.go
+++ b/internal/command/jsonformat/plan.go
@@ -84,7 +84,11 @@ func (plan Plan) renderHuman(renderer Renderer, mode plans.Mode, opts ...PlanRen
 		}
 	}
 
-	if len(changes) == 0 && len(diffs.outputs) == 0 {
+	// Precompute the outputs early, so we can make a decision about whether we
+	// display the "there are no changes messages".
+	outputs := renderHumanDiffOutputs(renderer, diffs.outputs)
+
+	if len(changes) == 0 && len(outputs) == 0 {
 		// If we didn't find any changes to report at all then this is a
 		// "No changes" plan. How we'll present this depends on whether
 		// the plan is "applyable" and, if so, whether it had refresh changes
@@ -219,10 +223,9 @@ func (plan Plan) renderHuman(renderer Renderer, mode plans.Mode, opts ...PlanRen
 			counts[plans.Delete]+counts[plans.DeleteThenCreate]+counts[plans.CreateThenDelete])
 	}
 
-	diff := renderHumanDiffOutputs(renderer, diffs.outputs)
-	if len(diff) > 0 {
+	if len(outputs) > 0 {
 		renderer.Streams.Print("\nChanges to Outputs:\n")
-		renderer.Streams.Printf("%s\n", diff)
+		renderer.Streams.Printf("%s\n", outputs)
 
 		if len(counts) == 0 {
 			// If we have output changes but not resource changes then we

--- a/internal/command/jsonformat/plan_test.go
+++ b/internal/command/jsonformat/plan_test.go
@@ -1,7 +1,9 @@
 package jsonformat
 
 import (
+	"encoding/json"
 	"fmt"
+	"github.com/hashicorp/terraform/internal/terminal"
 	"testing"
 
 	"github.com/hashicorp/terraform/internal/command/jsonformat/differ/attribute_path"
@@ -21,6 +23,59 @@ import (
 	"github.com/hashicorp/terraform/internal/states"
 	"github.com/hashicorp/terraform/internal/terraform"
 )
+
+func TestRenderHuman_EmptyPlan(t *testing.T) {
+	color := &colorstring.Colorize{Colors: colorstring.DefaultColors, Disable: true}
+	streams, done := terminal.StreamsForTesting(t)
+
+	plan := Plan{}
+
+	renderer := Renderer{Colorize: color, Streams: streams}
+	plan.renderHuman(renderer, plans.NormalMode)
+
+	want := `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`
+
+	got := done(t).Stdout()
+	if diff := cmp.Diff(want, got); len(diff) > 0 {
+		t.Errorf("unexpected output\ngot:\n%s\nwant:\n%s\ndiff:\n%s", got, want, diff)
+	}
+}
+
+func TestRenderHuman_EmptyOutputs(t *testing.T) {
+	color := &colorstring.Colorize{Colors: colorstring.DefaultColors, Disable: true}
+	streams, done := terminal.StreamsForTesting(t)
+
+	outputVal, _ := json.Marshal("some-text")
+	plan := Plan{
+		OutputChanges: map[string]jsonplan.Change{
+			"a_string": {
+				Actions: []string{"no-op"},
+				Before:  outputVal,
+				After:   outputVal,
+			},
+		},
+	}
+
+	renderer := Renderer{Colorize: color, Streams: streams}
+	plan.renderHuman(renderer, plans.NormalMode)
+
+	want := `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`
+
+	got := done(t).Stdout()
+	if diff := cmp.Diff(want, got); len(diff) > 0 {
+		t.Errorf("unexpected output\ngot:\n%s\nwant:\n%s\ndiff:\n%s", got, want, diff)
+	}
+}
 
 func TestResourceChange_primitiveTypes(t *testing.T) {
 	testCases := map[string]testCase{

--- a/internal/command/jsonformat/plan_test.go
+++ b/internal/command/jsonformat/plan_test.go
@@ -3,10 +3,7 @@ package jsonformat
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/hashicorp/terraform/internal/terminal"
 	"testing"
-
-	"github.com/hashicorp/terraform/internal/command/jsonformat/differ/attribute_path"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/mitchellh/colorstring"
@@ -14,6 +11,7 @@ import (
 
 	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/command/jsonformat/differ"
+	"github.com/hashicorp/terraform/internal/command/jsonformat/differ/attribute_path"
 	"github.com/hashicorp/terraform/internal/command/jsonplan"
 	"github.com/hashicorp/terraform/internal/command/jsonprovider"
 	"github.com/hashicorp/terraform/internal/configs/configschema"
@@ -21,6 +19,7 @@ import (
 	"github.com/hashicorp/terraform/internal/plans"
 	"github.com/hashicorp/terraform/internal/providers"
 	"github.com/hashicorp/terraform/internal/states"
+	"github.com/hashicorp/terraform/internal/terminal"
 	"github.com/hashicorp/terraform/internal/terraform"
 )
 


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

Currently, we are checking whether the output changes are empty before deciding to print the "no changes" message in the renderer. But, no-op changes do not print anything so any plan with no-op changes will make the renderer consider the output changes to be not empty so it won't print the nice message but then it also won't print any outputs.

This PR fixes this by computing the concrete output diffs earlier and then using them to decide whether to print the "no changes" message.

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Fixes #32815 

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.4.1

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

### BUG FIXES

- Fix the plan renderer skipping the "no changes" messages when there are no-op outputs within the plan.

<!--

Write a short description of the user-facing change. Examples:

- `terraform show -json`: Fixed crash with sensitive set values.
- When rendering a diff, Terraform now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 

