### PR TITLE
Fix potential nil panic in azure remote state

### DIFF
--- a/internal/backend/remote-state/azure/client.go
+++ b/internal/backend/remote-state/azure/client.go
@@ -5,10 +5,10 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"log"
 	"net/http"
 
+	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/terraform/internal/states/remote"

--- a/internal/backend/remote-state/azure/client.go
+++ b/internal/backend/remote-state/azure/client.go
@@ -85,7 +85,7 @@ func (c *RemoteClient) Put(data []byte) error {
 
 	blob, err := c.giovanniBlobClient.GetProperties(ctx, c.accountName, c.containerName, c.keyName, getOptions)
 	if err != nil && blob.Response.Response != nil && blob.Response.Response.StatusCode != 404 {
-		return err		
+		return err
 	}
 
 	contentType := "application/json"

--- a/internal/backend/remote-state/azure/client.go
+++ b/internal/backend/remote-state/azure/client.go
@@ -84,10 +84,8 @@ func (c *RemoteClient) Put(data []byte) error {
 	}
 
 	blob, err := c.giovanniBlobClient.GetProperties(ctx, c.accountName, c.containerName, c.keyName, getOptions)
-	if err != nil {
-		if blob.StatusCode != 404 {
-			return err
-		}
+	if err != nil && blob.Response.Response != nil && blob.Response.Response.StatusCode != 404 {
+		return err		
 	}
 
 	contentType := "application/json"

--- a/internal/backend/remote-state/azure/client.go
+++ b/internal/backend/remote-state/azure/client.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"log"
 	"net/http"
 
@@ -84,8 +85,10 @@ func (c *RemoteClient) Put(data []byte) error {
 	}
 
 	blob, err := c.giovanniBlobClient.GetProperties(ctx, c.accountName, c.containerName, c.keyName, getOptions)
-	if err != nil && blob.Response.Response != nil && blob.Response.Response.StatusCode != 404 {
-		return err
+	if err != nil {
+		if !response.WasNotFound(blob.Response.Response) {
+			return err
+		}
 	}
 
 	contentType := "application/json"


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

Adding a nil check before reading Http status code from response returned by sdk.

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

[terraform-azurerm-provider hashicorp/terraform#32872](https://github.com/hashicorp/terraform/issues/32872)

Waiting for user create a new issue in this repo.

Fixes #

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.4.1

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

### BUG FIXES

Write a short description of the user-facing change. Examples:

- `terraform init`: Fixed crash when the storage account doesn't exist

-  
