### PR TITLE
Add TFC to state doc

### DIFF
--- a/website/docs/language/state/index.mdx
+++ b/website/docs/language/state/index.mdx
@@ -16,7 +16,7 @@ This state is stored by default in a local file named "terraform.tfstate",
 but we recommend [storing it in Terraform Cloud](/terraform/cloud-docs/migrate)
 to version, encrypt, and securely share it with your team.
 
-Terraform uses state to create plans and make changes to your
+Terraform uses state to determine which changes to make to your
 infrastructure. Prior to any operation, Terraform does a
 [refresh](/terraform/cli/commands/refresh) to update the state with the
 real infrastructure.

--- a/website/docs/language/state/index.mdx
+++ b/website/docs/language/state/index.mdx
@@ -13,9 +13,10 @@ resources to your configuration, keep track of metadata, and to improve
 performance for large infrastructures.
 
 This state is stored by default in a local file named "terraform.tfstate",
-but it can also be stored remotely, which works better in a team environment.
+but we recommend [storing it in Terraform Cloud](/terraform/cloud-docs/migrate)
+to version, encrypt, and securely share it with your team.
 
-Terraform uses this local state to create plans and make changes to your
+Terraform uses state to create plans and make changes to your
 infrastructure. Prior to any operation, Terraform does a
 [refresh](/terraform/cli/commands/refresh) to update the state with the
 real infrastructure.


### PR DESCRIPTION
Add TFC to state docs page. 

Fixes #

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.4.x

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

### NEW FEATURES | UPGRADE NOTES | ENHANCEMENTS | BUG FIXES | EXPERIMENTS

<!--

Write a short description of the user-facing change. Examples:

- `terraform show -json`: Fixed crash with sensitive set values.
- When rendering a diff, Terraform now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 

-  
