### PR TITLE
Prevent nil Colorize options when rendering state outputs

### DIFF
--- a/internal/command/jsonformat/renderer.go
+++ b/internal/command/jsonformat/renderer.go
@@ -81,10 +81,9 @@ func (renderer Renderer) RenderHumanState(state State) {
 		return
 	}
 
-	opts := computed.RenderHumanOpts{
-		ShowUnchangedChildren: true,
-		HideDiffActionSymbols: true,
-	}
+	opts := computed.NewRenderHumanOpts(renderer.Colorize)
+	opts.ShowUnchangedChildren = true
+	opts.HideDiffActionSymbols = true
 
 	state.renderHumanStateModule(renderer, state.RootModule, opts, true)
 	state.renderHumanStateOutputs(renderer, opts)
@@ -119,11 +118,11 @@ func (r Renderer) RenderLog(log *JSONLog) error {
 					return err
 				}
 
+				opts := computed.NewRenderHumanOpts(r.Colorize)
+				opts.ShowUnchangedChildren = true
+
 				outputDiff := change.ComputeDiffForType(ctype)
-				outputStr := outputDiff.RenderHuman(0, computed.RenderHumanOpts{
-					Colorize:              r.Colorize,
-					ShowUnchangedChildren: true,
-				})
+				outputStr := outputDiff.RenderHuman(0, opts)
 
 				msg := fmt.Sprintf("%s = %s", name, outputStr)
 				r.Streams.Println(msg)

--- a/internal/command/show_test.go
+++ b/internal/command/show_test.go
@@ -447,6 +447,13 @@ func TestShow_plan_json(t *testing.T) {
 
 func TestShow_state(t *testing.T) {
 	originalState := testState()
+	root := originalState.RootModule()
+	root.SetOutputValue("test", cty.ObjectVal(map[string]cty.Value{
+		"attr": cty.NullVal(cty.DynamicPseudoType),
+		"null": cty.NullVal(cty.String),
+		"list": cty.ListVal([]cty.Value{cty.NullVal(cty.Number)}),
+	}), false)
+
 	statePath := testStateFile(t, originalState)
 	defer os.RemoveAll(filepath.Dir(statePath))
 


### PR DESCRIPTION
When rendering nested `nil` output values from state, the Colorize options could be set to `nil`. Ensure the `RenderHumanOpts` are always instantiated via their constructor. If a constructor is required, it would probably be safer to have no exported fields for the type, but that level of refactoring will have to be review separately.

Fixes #32833

## Target Release

v1.4.1