### PR TITLE
emit a warning msg if invalid CLI configuration file location

### DIFF
--- a/internal/command/e2etest/init_test.go
+++ b/internal/command/e2etest/init_test.go
@@ -146,7 +146,7 @@ func TestInitProvidersLocalOnly(t *testing.T) {
 	// not work until you remove it.
 	//
 	// To avoid this, we will  "zero out" any existing cli config file.
-	tf.AddEnv("TF_CLI_CONFIG_FILE=\"\"")
+	tf.AddEnv("TF_CLI_CONFIG_FILE=")
 
 	// Our fixture dir has a generic os_arch dir, which we need to customize
 	// to the actual OS/arch where this test is running in order to get the


### PR DESCRIPTION
Fix-up and rebase of #32793

This Pull Request is about noticing people when `TF_CLI_CONFIG_FILE` environment variable points to a non existing file.

In such case, a warning message will be printed out like below;

```sh
There are some problems with the CLI configuration:
╷
│ Warning: Unable to open CLI configuration file
│
│ The CLI configuration file at
│ "/private/var/folders/7b/q4m7dd2x4fl8ltp731djsw940000gn/T/tmp.5TVZNsJu/.terraform.rcr"
│ specified does not exist.
╵
```

Fixes #32646

