### PR TITLE
Remove planned data source objects from state on error

### DIFF
--- a/internal/terraform/context_plan2_test.go
+++ b/internal/terraform/context_plan2_test.go
@@ -3947,3 +3947,37 @@ output "out" {
 	})
 	assertNoErrors(t, diags)
 }
+
+// Make sure the data sources in the prior state are serializeable even if
+// there were an error in the plan.
+func TestContext2Plan_dataSourceReadPlanError(t *testing.T) {
+	m, snap := testModuleWithSnapshot(t, "data-source-read-with-plan-error")
+	awsProvider := testProvider("aws")
+	testProvider := testProvider("test")
+
+	testProvider.PlanResourceChangeFn = func(req providers.PlanResourceChangeRequest) (resp providers.PlanResourceChangeResponse) {
+		resp.PlannedState = req.ProposedNewState
+		resp.Diagnostics = resp.Diagnostics.Append(errors.New("oops"))
+		return resp
+	}
+
+	state := states.NewState()
+
+	ctx := testContext2(t, &ContextOpts{
+		Providers: map[addrs.Provider]providers.Factory{
+			addrs.NewDefaultProvider("aws"):  testProviderFuncFixed(awsProvider),
+			addrs.NewDefaultProvider("test"): testProviderFuncFixed(testProvider),
+		},
+	})
+
+	plan, diags := ctx.Plan(m, state, DefaultPlanOpts)
+	if !diags.HasErrors() {
+		t.Fatalf("expected plan error")
+	}
+
+	// make sure we can serialize the plan even if there were an error
+	_, _, _, err := contextOptsForPlanViaFile(t, snap, plan)
+	if err != nil {
+		t.Fatalf("failed to round-trip through planfile: %s", err)
+	}
+}

--- a/internal/terraform/testdata/data-source-read-with-plan-error/main.tf
+++ b/internal/terraform/testdata/data-source-read-with-plan-error/main.tf
@@ -1,0 +1,12 @@
+resource "aws_instance" "foo" {
+}
+
+// this will be postponed until apply
+data "aws_data_source" "foo" {
+  foo = aws_instance.foo.id
+}
+
+// this will cause an error in the final plan
+resource "test_instance" "bar" {
+  foo = "error"
+}


### PR DESCRIPTION
When planning encounters an error we were returning early without cleaning out any planed data sources which cannot be serialized. Move the cleanup to the common `walkPlan` method where the `PriorState` is assigned so that it cannot be missed.

Fixes #32865