### PR TITLE
Correct heading of usecase

### DIFF
--- a/website/docs/language/resources/provisioners/syntax.mdx
+++ b/website/docs/language/resources/provisioners/syntax.mdx
@@ -118,7 +118,7 @@ so that it can register itself with the configuration management server
 immediately on boot, without the need to accept commands from Terraform over
 SSH or WinRM.
 
-### First-class Terraform provider functionality may be available
+### First-class Terraform provider functionality may be unavailable
 
 It is technically possible to use the `local-exec` provisioner to run the CLI
 for your target system in order to create, update, or otherwise interact with


### PR DESCRIPTION
You would be looking to use `local-exec` in the absence of first-class support. The title was therefore the wrong way round.

### BUG FIXES

Correct heading of an use-case for provisioners. 
