### PR TITLE
Correct docs on Configuration Directory

### DIFF
--- a/website/docs/cli/commands/init.mdx
+++ b/website/docs/cli/commands/init.mdx
@@ -189,8 +189,8 @@ Terraform v0.13 and earlier also accepted a directory path in place of the
 plan file argument to `terraform apply`, in which case Terraform would use
 that directory as the root module instead of the current working directory.
 
-That usage is still supported in Terraform v0.14, but is now deprecated and we
-plan to remove it in Terraform v0.15. If your workflow relies on overriding
+That usage is still supported in Terraform v0.14, but is now deprecated and removed in
+Terraform v0.15. If your workflow relies on overriding
 the root module directory, use
 [the `-chdir` global option](/terraform/cli/commands#switching-working-directory-with-chdir)
 instead, which works across all commands and makes Terraform consistently look


### PR DESCRIPTION
The option was removed in v0.15 and so is no-longer "plan[ed]" https://newreleases.io/project/github/hashicorp/terraform/release/v0.15.0