### PR TITLE
testing dos2unix arg

### DIFF
--- a/internal/command/fmt.go
+++ b/internal/command/fmt.go
@@ -33,6 +33,7 @@ type FmtCommand struct {
 	diff      bool
 	check     bool
 	recursive bool
+	dos2unix  bool
 	input     io.Reader // STDIN if nil
 }
 
@@ -48,6 +49,7 @@ func (c *FmtCommand) Run(args []string) int {
 	cmdFlags.BoolVar(&c.diff, "diff", false, "diff")
 	cmdFlags.BoolVar(&c.check, "check", false, "check")
 	cmdFlags.BoolVar(&c.recursive, "recursive", false, "recursive")
+	cmdFlags.BoolVar(&c.dos2unix, "dos2unix", false, "dos2unix")
 	cmdFlags.Usage = func() { c.Ui.Error(c.Help()) }
 	if err := cmdFlags.Parse(args); err != nil {
 		c.Ui.Error(fmt.Sprintf("Error parsing command-line flags: %s\n", err.Error()))
@@ -273,10 +275,15 @@ func (c *FmtCommand) formatSourceCode(src []byte, filename string) []byte {
 	}
 
 	c.formatBody(f.Body(), nil)
+	c.dos2unix(f.Body(), nil)
 
 	return f.Bytes()
 }
 
+func (c *FmtCommand) dos2unix(body *hclwrite.Body, inBlocks []string) {
+	// Replace all occurrences of CRLF with LF
+	return outputBytes := bytes.ReplaceAll(body, []byte("\r\n"), []byte("\n"))
+}
 func (c *FmtCommand) formatBody(body *hclwrite.Body, inBlocks []string) {
 	attrs := body.Attributes()
 	for name, attr := range attrs {


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->
It would be nice if `terraform fmt` could allow for formatting files in accordance with other popular linters (besides tflint) like trunk for VSCode. The obvious workaround `# trunk-ignore-all(git-diff-check)` only kicks the can down the road. Developers may spend a considerable amount of time troubleshooting line terminations in herdoc blocks since it won't be obvious when/where certain tf resources (like aws lambda and codebuild) have unexpected EOF errors. For windows vscode users, `Remote extensions:connect to wsl` will also help but on larger teams this also only kicks the can. I'm new to terraform but it seems this issue has been mentioned previously. I tried making a fix for it myself but I'm not familiar enough with go or terraform to be able to test a PR. This may be better suited as a provider parameter since this use case may not apply to azure or other providers?

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Fixes #

- #10381
- #31003

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.4.x

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

### EXPERIMENTS

<!--

Write a short description of the user-facing change. Examples:

- `terraform show -json`: Fixed crash with sensitive set values.
- When rendering a diff, Terraform now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 

-  `terraform fmt -dos2unix