### PR TITLE
checks: don't raise diagnostics for checks during an auto approved plan operation

### DIFF
--- a/internal/backend/local/backend_local.go
+++ b/internal/backend/local/backend_local.go
@@ -192,6 +192,7 @@ func (b *Local) localRunDirect(op *backend.Operation, run *backend.LocalRun, cor
 		ForceReplace: op.ForceReplace,
 		SetVariables: variables,
 		SkipRefresh:  op.Type != backend.OperationTypeRefresh && !op.PlanRefresh,
+		AutoApprove:  op.AutoApprove,
 	}
 	run.PlanOpts = planOpts
 

--- a/internal/backend/remote/backend_context.go
+++ b/internal/backend/remote/backend_context.go
@@ -22,8 +22,9 @@ func (b *Remote) LocalRun(op *backend.Operation) (*backend.LocalRun, statemgr.Fu
 	var diags tfdiags.Diagnostics
 	ret := &backend.LocalRun{
 		PlanOpts: &terraform.PlanOpts{
-			Mode:    op.PlanMode,
-			Targets: op.Targets,
+			Mode:        op.PlanMode,
+			Targets:     op.Targets,
+			AutoApprove: op.AutoApprove,
 		},
 	}
 

--- a/internal/cloud/backend_context.go
+++ b/internal/cloud/backend_context.go
@@ -22,8 +22,9 @@ func (b *Cloud) LocalRun(op *backend.Operation) (*backend.LocalRun, statemgr.Ful
 	var diags tfdiags.Diagnostics
 	ret := &backend.LocalRun{
 		PlanOpts: &terraform.PlanOpts{
-			Mode:    op.PlanMode,
-			Targets: op.Targets,
+			Mode:        op.PlanMode,
+			Targets:     op.Targets,
+			AutoApprove: op.AutoApprove,
 		},
 	}
 

--- a/internal/terraform/context_plan.go
+++ b/internal/terraform/context_plan.go
@@ -33,6 +33,10 @@ type PlanOpts struct {
 	// instance using its corresponding provider.
 	SkipRefresh bool
 
+	// AutoApprove specifies that this plan is to be auto approved, so Terraform
+	// will not wait for user approval before applying the plan.
+	AutoApprove bool
+
 	// PreDestroyRefresh indicated that this is being passed to a plan used to
 	// refresh the state immediately before a destroy plan.
 	// FIXME: This is a temporary fix to allow the pre-destroy refresh to
@@ -610,6 +614,7 @@ func (c *Context) planGraph(config *configs.Config, prevRunState *states.State, 
 			Targets:            opts.Targets,
 			ForceReplace:       opts.ForceReplace,
 			skipRefresh:        opts.SkipRefresh,
+			autoApprove:        opts.AutoApprove,
 			preDestroyRefresh:  opts.PreDestroyRefresh,
 			Operation:          walkPlan,
 		}).Build(addrs.RootModuleInstance)
@@ -622,6 +627,7 @@ func (c *Context) planGraph(config *configs.Config, prevRunState *states.State, 
 			Plugins:            c.plugins,
 			Targets:            opts.Targets,
 			skipRefresh:        opts.SkipRefresh,
+			autoApprove:        opts.AutoApprove,
 			skipPlanChanges:    true, // this activates "refresh only" mode.
 			Operation:          walkPlan,
 		}).Build(addrs.RootModuleInstance)
@@ -634,6 +640,7 @@ func (c *Context) planGraph(config *configs.Config, prevRunState *states.State, 
 			Plugins:            c.plugins,
 			Targets:            opts.Targets,
 			skipRefresh:        opts.SkipRefresh,
+			autoApprove:        opts.AutoApprove,
 			Operation:          walkPlanDestroy,
 		}).Build(addrs.RootModuleInstance)
 		return graph, walkPlanDestroy, diags

--- a/internal/terraform/graph_builder_plan.go
+++ b/internal/terraform/graph_builder_plan.go
@@ -49,6 +49,9 @@ type PlanGraphBuilder struct {
 	// skipRefresh indicates that we should skip refreshing managed resources
 	skipRefresh bool
 
+	// autoApprove indicates that this plan will be auto approved.
+	autoApprove bool
+
 	// preDestroyRefresh indicates that we are executing the refresh which
 	// happens immediately before a destroy plan, which happens to use the
 	// normal planing mode so skipPlanChanges cannot be set.
@@ -130,8 +133,9 @@ func (b *PlanGraphBuilder) Steps() []GraphTransformer {
 		// Add nodes and edges for the check block assertions. Check block data
 		// sources were added earlier.
 		&checkTransformer{
-			Config:    b.Config,
-			Operation: b.Operation,
+			Config:           b.Config,
+			Operation:        b.Operation,
+			AutoApprovedPlan: b.autoApprove,
 		},
 
 		// Add orphan resources

--- a/internal/terraform/node_output.go
+++ b/internal/terraform/node_output.go
@@ -325,9 +325,9 @@ func (n *NodeApplyableOutput) Execute(ctx EvalContext, op walkOperation) (diags 
 	// Checks are not evaluated during a destroy. The checks may fail, may not
 	// be valid, or may not have been registered at all.
 	if !n.DestroyApply {
-		checkRuleSeverity := tfdiags.Error
+		checkRuleSeverity := CheckSeverityError
 		if n.RefreshOnly {
-			checkRuleSeverity = tfdiags.Warning
+			checkRuleSeverity = CheckSeverityWarning
 		}
 		checkDiags := evalCheckRules(
 			addrs.OutputPrecondition,

--- a/internal/terraform/node_resource_apply_instance.go
+++ b/internal/terraform/node_resource_apply_instance.go
@@ -200,7 +200,7 @@ func (n *NodeApplyableResourceInstance) dataResourceExecute(ctx EvalContext) (di
 		n.Config.Postconditions,
 		ctx, n.ResourceInstanceAddr(),
 		repeatData,
-		tfdiags.Error,
+		CheckSeverityError,
 	)
 	diags = diags.Append(checkDiags)
 
@@ -386,7 +386,7 @@ func (n *NodeApplyableResourceInstance) managedResourcePostconditions(ctx EvalCo
 		addrs.ResourcePostcondition,
 		n.Config.Postconditions,
 		ctx, n.ResourceInstanceAddr(), repeatData,
-		tfdiags.Error,
+		CheckSeverityError,
 	)
 	return diags.Append(checkDiags)
 }

--- a/internal/terraform/node_resource_plan_instance.go
+++ b/internal/terraform/node_resource_plan_instance.go
@@ -82,9 +82,9 @@ func (n *NodePlannableResourceInstance) dataResourceExecute(ctx EvalContext) (di
 		return diags
 	}
 
-	checkRuleSeverity := tfdiags.Error
+	checkRuleSeverity := CheckSeverityError
 	if n.skipPlanChanges || n.preDestroyRefresh {
-		checkRuleSeverity = tfdiags.Warning
+		checkRuleSeverity = CheckSeverityWarning
 	}
 
 	change, state, repeatData, planDiags := n.planDataSource(ctx, checkRuleSeverity, n.skipPlanChanges)
@@ -128,9 +128,9 @@ func (n *NodePlannableResourceInstance) managedResourceExecute(ctx EvalContext) 
 	var change *plans.ResourceInstanceChange
 	var instanceRefreshState *states.ResourceInstanceObject
 
-	checkRuleSeverity := tfdiags.Error
+	checkRuleSeverity := CheckSeverityError
 	if n.skipPlanChanges || n.preDestroyRefresh {
-		checkRuleSeverity = tfdiags.Warning
+		checkRuleSeverity = CheckSeverityWarning
 	}
 
 	_, providerSchema, err := getProvider(ctx, n.ResolvedProvider)

--- a/internal/terraform/transform_check.go
+++ b/internal/terraform/transform_check.go
@@ -62,6 +62,7 @@ func (t *checkTransformer) transform(g *Graph, cfg *configs.Config, allNodes []d
 					addr:          addr,
 					config:        cfg,
 					executeChecks: t.ExecuteChecks(),
+					raiseChecks:   !t.AutoApprovedPlan,
 				}
 			},
 		}
@@ -124,15 +125,21 @@ func (t *checkTransformer) ReportChecks() bool {
 func (t *checkTransformer) ExecuteChecks() bool {
 	switch t.Operation {
 	case walkPlan, walkApply:
-		// We normally execute the checks for plan and apply operations, but if
-		// a plan is being auto approved we don't get any benefit from executing
-		// the checks twice in a row with no opportunity for the user to process
-		// the check results.
-		return !t.AutoApprovedPlan
+		return true
 	default:
 		// For everything else, we still want to validate the checks make sense
 		// logically and syntactically, but we won't actually resolve the check
 		// conditions.
 		return false
 	}
+}
+
+// RaiseChecks returns true if this operation should report the results of the
+// checks as well as executing them.
+//
+// In practice, we don't show the check results during an auto approved plan
+// simply because the apply operation will happen immediately and also report
+// more relevant check results.
+func (t *checkTransformer) RaiseChecks() bool {
+	return !t.AutoApprovedPlan
 }


### PR DESCRIPTION
Quality of life improvement for the new check blocks.

Currently, when you execute `terraform apply -auto-approve` the checks are executed twice (once during the plan, and once during the apply). This pollutes the users view as the output now contains reports about both of these checks executions but they cannot respond to the results of plan operation as terraform is just going to execute the apply directly. 
The output of the checks during the plan operation is also just thrown away as no plan file is written. 

With this in mind, this PR makes the check blocks skip reporting diagnostics during the plan stage of auto-approved apply operation. The user will still see the check results after the apply stage, they just won't see an extra set of outputs from during the planning stage that is reporting on information that is no longer relevant.