### PR TITLE
checks: don't consolidate warnings produced by checks

### DIFF
--- a/internal/terraform/eval_conditions.go
+++ b/internal/terraform/eval_conditions.go
@@ -134,6 +134,7 @@ func evalCheckRule(typ addrs.CheckRuleType, rule *configs.CheckRule, ctx EvalCon
 				Subject:     rule.Condition.Range().Ptr(),
 				Expression:  rule.Condition,
 				EvalContext: hclCtx,
+				Extra:       tfdiags.SkipConsolidateWarnings,
 			})
 		}
 
@@ -196,6 +197,7 @@ func evalCheckRule(typ addrs.CheckRuleType, rule *configs.CheckRule, ctx EvalCon
 		Subject:     rule.Condition.Range().Ptr(),
 		Expression:  rule.Condition,
 		EvalContext: hclCtx,
+		Extra:       tfdiags.SkipConsolidateWarnings,
 	})
 
 	return checkResult{

--- a/internal/tfdiags/consolidate_warnings.go
+++ b/internal/tfdiags/consolidate_warnings.go
@@ -2,6 +2,12 @@ package tfdiags
 
 import "fmt"
 
+type ExtraSkipConsolidateWarnings string
+
+const (
+	SkipConsolidateWarnings ExtraSkipConsolidateWarnings = "__skip_consolidate__"
+)
+
 // ConsolidateWarnings checks if there is an unreasonable amount of warnings
 // with the same summary in the receiver and, if so, returns a new diagnostics
 // with some of those warnings consolidated into a single warning in order
@@ -39,6 +45,13 @@ func (diags Diagnostics) ConsolidateWarnings(threshold int) Diagnostics {
 			// our primary goal here is to deal with the situation where
 			// some configuration language feature is producing a warning
 			// each time it's used across a potentially-large config.
+			newDiags = newDiags.Append(diag)
+			continue
+		}
+
+		if extra, ok := diag.ExtraInfo().(ExtraSkipConsolidateWarnings); ok && extra == SkipConsolidateWarnings {
+			// Some warnings can also be marked such that they should not get
+			// consolidated.
 			newDiags = newDiags.Append(diag)
 			continue
 		}

--- a/internal/tfdiags/consolidate_warnings_test.go
+++ b/internal/tfdiags/consolidate_warnings_test.go
@@ -23,6 +23,17 @@ func TestConsolidateWarnings(t *testing.T) {
 			},
 		})
 		diags = diags.Append(&hcl.Diagnostic{
+			Severity: hcl.DiagWarning,
+			Summary:  "Warning 5",
+			Detail:   fmt.Sprintf("This one has a subject %d but shouldn't consolidate", i),
+			Subject: &hcl.Range{
+				Filename: "foo.tf",
+				Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+				End:      hcl.Pos{Line: 1, Column: 1, Byte: 0},
+			},
+			Extra: SkipConsolidateWarnings,
+		})
+		diags = diags.Append(&hcl.Diagnostic{
 			Severity: hcl.DiagError,
 			Summary:  "Error 1",
 			Detail:   fmt.Sprintf("This one has a subject %d", i),
@@ -67,6 +78,16 @@ func TestConsolidateWarnings(t *testing.T) {
 			},
 		},
 		&rpcFriendlyDiag{
+			Severity_: Warning,
+			Summary_:  "Warning 5",
+			Detail_:   "This one has a subject 0 but shouldn't consolidate",
+			Subject_: &SourceRange{
+				Filename: "foo.tf",
+				Start:    SourcePos{Line: 1, Column: 1, Byte: 0},
+				End:      SourcePos{Line: 1, Column: 1, Byte: 0},
+			},
+		},
+		&rpcFriendlyDiag{
 			Severity_: Error,
 			Summary_:  "Error 1",
 			Detail_:   "This one has a subject 0",
@@ -98,6 +119,16 @@ func TestConsolidateWarnings(t *testing.T) {
 			},
 		},
 		&rpcFriendlyDiag{
+			Severity_: Warning,
+			Summary_:  "Warning 5",
+			Detail_:   "This one has a subject 1 but shouldn't consolidate",
+			Subject_: &SourceRange{
+				Filename: "foo.tf",
+				Start:    SourcePos{Line: 1, Column: 1, Byte: 0},
+				End:      SourcePos{Line: 1, Column: 1, Byte: 0},
+			},
+		},
+		&rpcFriendlyDiag{
 			Severity_: Error,
 			Summary_:  "Error 1",
 			Detail_:   "This one has a subject 1",
@@ -119,6 +150,16 @@ func TestConsolidateWarnings(t *testing.T) {
 
 		// Third set (no more Warning 1, because it's consolidated)
 		&rpcFriendlyDiag{
+			Severity_: Warning,
+			Summary_:  "Warning 5",
+			Detail_:   "This one has a subject 2 but shouldn't consolidate",
+			Subject_: &SourceRange{
+				Filename: "foo.tf",
+				Start:    SourcePos{Line: 1, Column: 1, Byte: 0},
+				End:      SourcePos{Line: 1, Column: 1, Byte: 0},
+			},
+		},
+		&rpcFriendlyDiag{
 			Severity_: Error,
 			Summary_:  "Error 1",
 			Detail_:   "This one has a subject 2",
@@ -139,6 +180,16 @@ func TestConsolidateWarnings(t *testing.T) {
 		},
 
 		// Fourth set (still no warning 1)
+		&rpcFriendlyDiag{
+			Severity_: Warning,
+			Summary_:  "Warning 5",
+			Detail_:   "This one has a subject 3 but shouldn't consolidate",
+			Subject_: &SourceRange{
+				Filename: "foo.tf",
+				Start:    SourcePos{Line: 1, Column: 1, Byte: 0},
+				End:      SourcePos{Line: 1, Column: 1, Byte: 0},
+			},
+		},
 		&rpcFriendlyDiag{
 			Severity_: Error,
 			Summary_:  "Error 1",


### PR DESCRIPTION
This is a qualify of life change for checks I'm not 100% sure about. I've left this in draft while I think of other potentials changes that could also address this issue.

Currently, if two or more checks fail the messages get consolidated since they have the same summary. This doesn't make sense for checks as each check is for a specific data source/resource and by creating the checks the users have specifically said they want to be warned.

This PR makes use of the diagnostics extras function to include a type in there that tells the consolidate logic to avoid consolidating diagnostics that have been marked with a specific extra.