### PR TITLE
checks: include the checks as part of the config within the JSON plan

### DIFF
--- a/internal/command/jsonconfig/config.go
+++ b/internal/command/jsonconfig/config.go
@@ -127,6 +127,7 @@ type check struct {
 // checkRule is a single assertion rule within a check block.
 type checkRule struct {
 	// Expressions represent the condition and error message expressions for a
+	// single check rule.
 	Expressions map[string]interface{} `json:"expressions,omitempty"`
 }
 


### PR DESCRIPTION
This PR adds the check blocks into the config section of the JSON plan.

For a check block with a single rule, it looks like this:

```json
      "checks": [
        {
          "address": "check.my_resource_creates_positive_number",
          "name": "my_resource_creates_positive_number",
          "rules": [
            {
              "expressions": {
                "condition": {
                  "references": [
                    "tfcoremock_simple_resource.my_resource.number",
                    "tfcoremock_simple_resource.my_resource",
                    "var.threshold"
                  ]
                },
                "error_message": {
                  "references": [
                    "var.value",
                    "var.threshold"
                  ]
                }
              }
            }
          ]
        }
      ]
```