### PR TITLE
checks: ensure checks are reported before executed

### DIFF
--- a/internal/terraform/transform_check.go
+++ b/internal/terraform/transform_check.go
@@ -66,6 +66,10 @@ func (t *checkTransformer) transform(g *Graph, cfg *configs.Config, allNodes []d
 			}
 			g.Add(report)
 
+			// Make sure we report our checks before we start executing the
+			// actual checks.
+			g.Connect(dag.BasicEdge(expand, report))
+
 			// This part ensures we report our checks before our nested data
 			// block executes and attempts to report on a check.
 			for _, other := range allNodes {


### PR DESCRIPTION
Might fix #32924 

I haven't been able to reproduce the flake locally so can't confirm this is definitely the cause. But I think it's likely triggered by a check block that doesn't have an embedded data source which means the graph isn't aware of any ordering between the expand and report check.