### PR TITLE
Write safely to the shared plugin cache

### DIFF
--- a/internal/providercache/package_install.go
+++ b/internal/providercache/package_install.go
@@ -15,12 +15,7 @@ import (
 	"github.com/hashicorp/terraform/internal/httpclient"
 )
 
-// We borrow the "unpack a zip file into a target directory" logic from
-// go-getter, even though we're not otherwise using go-getter here.
-// (We don't need the same flexibility as we have for modules, because
-// providers _always_ come from provider registries, which have a very
-// specific protocol and set of expectations.)
-var unzip = getter.ZipDecompressor{}
+var unzip = ZipDecompressor{}
 
 func installFromHTTPURL(ctx context.Context, meta getproviders.PackageMeta, targetDir string, allowedHashes []getproviders.Hash) (*getproviders.PackageAuthenticationResult, error) {
 	url := meta.Location.String()

--- a/internal/providercache/package_install.go
+++ b/internal/providercache/package_install.go
@@ -15,8 +15,6 @@ import (
 	"github.com/hashicorp/terraform/internal/httpclient"
 )
 
-var unzip = ZipDecompressor{}
-
 func installFromHTTPURL(ctx context.Context, meta getproviders.PackageMeta, targetDir string, allowedHashes []getproviders.Hash) (*getproviders.PackageAuthenticationResult, error) {
 	url := meta.Location.String()
 
@@ -128,7 +126,7 @@ func installFromLocalArchive(ctx context.Context, meta getproviders.PackageMeta,
 	// match the allowed hashes and so our caller should catch that after
 	// we return if so.
 
-	err := unzip.Decompress(targetDir, filename, true, 0000)
+	err := unzip(targetDir, filename)
 	if err != nil {
 		return authResult, err
 	}

--- a/internal/providercache/package_install.go
+++ b/internal/providercache/package_install.go
@@ -126,7 +126,7 @@ func installFromLocalArchive(ctx context.Context, meta getproviders.PackageMeta,
 	// match the allowed hashes and so our caller should catch that after
 	// we return if so.
 
-	err := unzip(targetDir, filename)
+	err := safeUnzip(targetDir, filename)
 	if err != nil {
 		return authResult, err
 	}

--- a/internal/providercache/safe_unzip.go
+++ b/internal/providercache/safe_unzip.go
@@ -1,0 +1,168 @@
+package providercache
+
+import (
+	"archive/zip"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// Copied verbatim from https://github.com/hashicorp/go-getter
+
+// mode returns the file mode masked by the umask
+func mode(mode, umask os.FileMode) os.FileMode {
+	return mode & ^umask
+}
+
+// ZipDecompressor is an implementation of Decompressor that can
+// decompress zip files.
+type ZipDecompressor struct {
+	// FileSizeLimit limits the total size of all
+	// decompressed files.
+	//
+	// The zero value means no limit.
+	FileSizeLimit int64
+
+	// FilesLimit limits the number of files that are
+	// allowed to be decompressed.
+	//
+	// The zero value means no limit.
+	FilesLimit int
+}
+
+func (d *ZipDecompressor) Decompress(dst, src string, dir bool, umask os.FileMode) error {
+	// If we're going into a directory we should make that first
+	mkdir := dst
+	if !dir {
+		mkdir = filepath.Dir(dst)
+	}
+	if err := os.MkdirAll(mkdir, mode(0755, umask)); err != nil {
+		return err
+	}
+
+	// Open the zip
+	zipR, err := zip.OpenReader(src)
+	if err != nil {
+		return err
+	}
+	defer zipR.Close()
+
+	// Check the zip integrity
+	if len(zipR.File) == 0 {
+		// Empty archive
+		return fmt.Errorf("empty archive: %s", src)
+	}
+	if !dir && len(zipR.File) > 1 {
+		return fmt.Errorf("expected a single file: %s", src)
+	}
+
+	if d.FilesLimit > 0 && len(zipR.File) > d.FilesLimit {
+		return fmt.Errorf("zip archive contains too many files: %d > %d", len(zipR.File), d.FilesLimit)
+	}
+
+	var fileSizeTotal int64
+
+	// Go through and unarchive
+	for _, f := range zipR.File {
+		path := dst
+		if dir {
+			// Disallow parent traversal
+			if containsDotDot(f.Name) {
+				return fmt.Errorf("entry contains '..': %s", f.Name)
+			}
+
+			path = filepath.Join(path, f.Name)
+		}
+
+		fileInfo := f.FileInfo()
+
+		fileSizeTotal += fileInfo.Size()
+
+		if d.FileSizeLimit > 0 && fileSizeTotal > d.FileSizeLimit {
+			return fmt.Errorf("zip archive larger than limit: %d", d.FileSizeLimit)
+		}
+
+		if fileInfo.IsDir() {
+			if !dir {
+				return fmt.Errorf("expected a single file: %s", src)
+			}
+
+			// A directory, just make the directory and continue unarchiving...
+			if err := os.MkdirAll(path, mode(0755, umask)); err != nil {
+				return err
+			}
+
+			continue
+		}
+
+		// Create the enclosing directories if we must. ZIP files aren't
+		// required to contain entries for just the directories so this
+		// can happen.
+		if dir {
+			if err := os.MkdirAll(filepath.Dir(path), mode(0755, umask)); err != nil {
+				return err
+			}
+		}
+
+		// Open the file for reading
+		srcF, err := f.Open()
+		if err != nil {
+			if srcF != nil {
+				srcF.Close()
+			}
+			return err
+		}
+
+		// Size limit is tracked using the returned file info.
+		err = copyReader(path, srcF, f.Mode(), umask, 0)
+		srcF.Close()
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// copyReader copies from an io.Reader into a file, using umask to create the dst file
+// copied from https://github.com/hashicorp/go-getter get_file_copy.go
+func copyReader(dst string, src io.Reader, fmode, umask os.FileMode, fileSizeLimit int64) error {
+	dstF, err := os.OpenFile(dst, os.O_RDWR|os.O_CREATE|os.O_TRUNC, fmode)
+	if err != nil {
+		return err
+	}
+	defer dstF.Close()
+
+	if fileSizeLimit > 0 {
+		src = io.LimitReader(src, fileSizeLimit)
+	}
+
+	_, err = io.Copy(dstF, src)
+	if err != nil {
+		return err
+	}
+
+	// Explicitly chmod; the process umask is unconditionally applied otherwise.
+	// We'll mask the mode with our own umask, but that may be different than
+	// the process umask
+	return os.Chmod(dst, mode(fmode, umask))
+}
+
+// containsDotDot checks if the filepath value v contains a ".." entry.
+// This will check filepath components by splitting along / or \. This
+// function is copied directly from the Go net/http implementation.
+func containsDotDot(v string) bool {
+	if !strings.Contains(v, "..") {
+		return false
+	}
+	for _, ent := range strings.FieldsFunc(v, isSlashRune) {
+		if ent == ".." {
+			return true
+		}
+	}
+	return false
+}
+
+func isSlashRune(r rune) bool { return r == '/' || r == '\\' }

--- a/internal/providercache/safe_unzip.go
+++ b/internal/providercache/safe_unzip.go
@@ -9,39 +9,10 @@ import (
 	"strings"
 )
 
-// Copied verbatim from https://github.com/hashicorp/go-getter
+// Based on https://github.com/hashicorp/go-getter
+// Simplified, removed dead code
 
-// mode returns the file mode masked by the umask
-func mode(mode, umask os.FileMode) os.FileMode {
-	return mode & ^umask
-}
-
-// ZipDecompressor is an implementation of Decompressor that can
-// decompress zip files.
-type ZipDecompressor struct {
-	// FileSizeLimit limits the total size of all
-	// decompressed files.
-	//
-	// The zero value means no limit.
-	FileSizeLimit int64
-
-	// FilesLimit limits the number of files that are
-	// allowed to be decompressed.
-	//
-	// The zero value means no limit.
-	FilesLimit int
-}
-
-func (d *ZipDecompressor) Decompress(dst, src string, dir bool, umask os.FileMode) error {
-	// If we're going into a directory we should make that first
-	mkdir := dst
-	if !dir {
-		mkdir = filepath.Dir(dst)
-	}
-	if err := os.MkdirAll(mkdir, mode(0755, umask)); err != nil {
-		return err
-	}
-
+func unzip(dst, src string) error {
 	// Open the zip
 	zipR, err := zip.OpenReader(src)
 	if err != nil {
@@ -54,56 +25,29 @@ func (d *ZipDecompressor) Decompress(dst, src string, dir bool, umask os.FileMod
 		// Empty archive
 		return fmt.Errorf("empty archive: %s", src)
 	}
-	if !dir && len(zipR.File) > 1 {
-		return fmt.Errorf("expected a single file: %s", src)
-	}
-
-	if d.FilesLimit > 0 && len(zipR.File) > d.FilesLimit {
-		return fmt.Errorf("zip archive contains too many files: %d > %d", len(zipR.File), d.FilesLimit)
-	}
-
-	var fileSizeTotal int64
 
 	// Go through and unarchive
 	for _, f := range zipR.File {
-		path := dst
-		if dir {
-			// Disallow parent traversal
-			if containsDotDot(f.Name) {
-				return fmt.Errorf("entry contains '..': %s", f.Name)
-			}
-
-			path = filepath.Join(path, f.Name)
+		// Disallow parent traversal
+		if containsDotDot(f.Name) {
+			return fmt.Errorf("entry contains '..': %s", f.Name)
 		}
 
-		fileInfo := f.FileInfo()
+		path := filepath.Join(dst, f.Name)
 
-		fileSizeTotal += fileInfo.Size()
-
-		if d.FileSizeLimit > 0 && fileSizeTotal > d.FileSizeLimit {
-			return fmt.Errorf("zip archive larger than limit: %d", d.FileSizeLimit)
-		}
-
-		if fileInfo.IsDir() {
-			if !dir {
-				return fmt.Errorf("expected a single file: %s", src)
-			}
-
+		if f.FileInfo().IsDir() {
 			// A directory, just make the directory and continue unarchiving...
-			if err := os.MkdirAll(path, mode(0755, umask)); err != nil {
+			if err := os.MkdirAll(path, 0755); err != nil {
 				return err
 			}
-
 			continue
 		}
 
 		// Create the enclosing directories if we must. ZIP files aren't
 		// required to contain entries for just the directories so this
 		// can happen.
-		if dir {
-			if err := os.MkdirAll(filepath.Dir(path), mode(0755, umask)); err != nil {
-				return err
-			}
+		if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+			return err
 		}
 
 		// Open the file for reading
@@ -115,8 +59,7 @@ func (d *ZipDecompressor) Decompress(dst, src string, dir bool, umask os.FileMod
 			return err
 		}
 
-		// Size limit is tracked using the returned file info.
-		err = copyReader(path, srcF, f.Mode(), umask, 0)
+		err = copyReader(path, srcF, f.Mode())
 		srcF.Close()
 		if err != nil {
 			return err
@@ -124,30 +67,6 @@ func (d *ZipDecompressor) Decompress(dst, src string, dir bool, umask os.FileMod
 	}
 
 	return nil
-}
-
-// copyReader copies from an io.Reader into a file, using umask to create the dst file
-// copied from https://github.com/hashicorp/go-getter get_file_copy.go
-func copyReader(dst string, src io.Reader, fmode, umask os.FileMode, fileSizeLimit int64) error {
-	dstF, err := os.OpenFile(dst, os.O_RDWR|os.O_CREATE|os.O_TRUNC, fmode)
-	if err != nil {
-		return err
-	}
-	defer dstF.Close()
-
-	if fileSizeLimit > 0 {
-		src = io.LimitReader(src, fileSizeLimit)
-	}
-
-	_, err = io.Copy(dstF, src)
-	if err != nil {
-		return err
-	}
-
-	// Explicitly chmod; the process umask is unconditionally applied otherwise.
-	// We'll mask the mode with our own umask, but that may be different than
-	// the process umask
-	return os.Chmod(dst, mode(fmode, umask))
 }
 
 // containsDotDot checks if the filepath value v contains a ".." entry.
@@ -166,3 +85,23 @@ func containsDotDot(v string) bool {
 }
 
 func isSlashRune(r rune) bool { return r == '/' || r == '\\' }
+
+// copyReader copies from an io.Reader into a file, using umask to create the dst file
+// copied from https://github.com/hashicorp/go-getter get_file_copy.go
+func copyReader(dst string, src io.Reader, fmode os.FileMode) error {
+	dstF, err := os.OpenFile(dst, os.O_RDWR|os.O_CREATE|os.O_TRUNC, fmode)
+	if err != nil {
+		return err
+	}
+	defer dstF.Close()
+
+	_, err = io.Copy(dstF, src)
+	if err != nil {
+		return err
+	}
+
+	// Explicitly chmod; the process umask is unconditionally applied otherwise.
+	// We'll mask the mode with our own umask, but that may be different than
+	// the process umask
+	return os.Chmod(dst, fmode)
+}


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->
Change terraform to write safely to the shared plugin cache.  Also, if a write fails, but the existing contents are correct, we now consider that a success.

Terraform currently fails `terraform init` if an executable it is trying to write is running
("text file busy"), or if it cannot write to the file for some other reason. There is also a race condition while it is writing the files that other readers can get partial content, or that partial content is left in the cache.


<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Fixes #25849, #31964, #32901, #32915

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.4.x

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

### ENHANCEMENTS

<!--

Write a short description of the user-facing change. Examples:

- `terraform show -json`: Fixed crash with sensitive set values.
- When rendering a diff, Terraform now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 

-  The plugin cache now supports multiple simultaneous users
