### PR TITLE
Backport of don't compare plan marks for missing values into v1.4

### DIFF
--- a/internal/terraform/marks.go
+++ b/internal/terraform/marks.go
@@ -7,6 +7,22 @@ import (
 	"github.com/zclconf/go-cty/cty"
 )
 
+// filterMarks removes any PathValueMarks from marks which cannot be applied to
+// the given value. When comparing existing marks to those from a map or other
+// dynamic value, we may not have values at the same paths and need to strip
+// out irrelevant marks.
+func filterMarks(val cty.Value, marks []cty.PathValueMarks) []cty.PathValueMarks {
+	var res []cty.PathValueMarks
+	for _, mark := range marks {
+		// any error here just means the path cannot apply to this value, so we
+		// don't need this mark for comparison.
+		if _, err := mark.Path.Apply(val); err == nil {
+			res = append(res, mark)
+		}
+	}
+	return res
+}
+
 // marksEqual compares 2 unordered sets of PathValue marks for equality, with
 // the comparison using the cty.PathValueMarks.Equal method.
 func marksEqual(a, b []cty.PathValueMarks) bool {

--- a/internal/terraform/node_resource_abstract_instance.go
+++ b/internal/terraform/node_resource_abstract_instance.go
@@ -1073,8 +1073,15 @@ func (n *NodeAbstractResourceInstance) plan(
 	}
 
 	// If we plan to write or delete sensitive paths from state,
-	// this is an Update action
-	if action == plans.NoOp && !marksEqual(unmarkedPaths, priorPaths) {
+	// this is an Update action.
+	//
+	// We need to filter out any marks which may not apply to the new planned
+	// value before comparison. The one case where a provider is allowed to
+	// return a different value from the configuration is when a config change
+	// is not functionally significant and the prior state can be returned. If a
+	// new mark was also discarded from that config change, it needs to be
+	// ignored here to prevent an errant update action.
+	if action == plans.NoOp && !marksEqual(filterMarks(plannedNewVal, unmarkedPaths), priorPaths) {
 		action = plans.Update
 	}
 


### PR DESCRIPTION
Backport of #32892

The below text is copied from the body of the original PR.

If a resource has a change in marks from the prior state, we need to notify the user that an update is going to be necessary to at least store that new value in the state. If the provider however returns a prior state value in lieu of a new config value, we need to be sure to filter any new marks for comparison as well. The comparison of the prior marks and new marks must take into account whether those new marks could even be applied, and if the value is unchanged, the new marks may be completely irrelevant.

Fixes https://github.com/hashicorp/terraform/issues/32864