### PR TITLE
Add depends block for promote-staging + add promote-staging-packaging

### DIFF
--- a/.release/ci.hcl
+++ b/.release/ci.hcl
@@ -13,7 +13,6 @@ project "terraform" {
     release_branches = [
       "main",
       "release/**",
-      "releng/**",
       "v**.**",
     ]
   }
@@ -54,6 +53,7 @@ event "trigger-staging" {
 }
 
 event "promote-staging" {
+  depends = ["trigger-staging"]
   action "promote-staging" {
     organization = "hashicorp"
     repository = "crt-workflows-common"
@@ -72,6 +72,19 @@ event "promote-staging-docker" {
     organization = "hashicorp"
     repository = "crt-workflows-common"
     workflow = "promote-staging-docker"
+  }
+
+  notification {
+    on = "always"
+  }
+}
+
+event "promote-staging-packaging" {
+  depends = ["promote-staging-docker"]
+  action "promote-staging-packaging" {
+    organization = "hashicorp"
+    repository = "crt-workflows-common"
+    workflow = "promote-staging-packaging"
   }
 
   notification {
@@ -124,7 +137,7 @@ event "promote-production-packaging" {
 }
 
 event "update-ironbank" {
-  depends = ["bump-version-patch"]
+  depends = ["promote-production-packaging"]
   action "update-ironbank" {
     organization = "hashicorp"
     repository = "crt-workflows-common"


### PR DESCRIPTION
Pipeline is unable to run past `trigger-staging` because the `promote-staging` is missing a `depends` line - pipeline is hung after trigger staging: https://github.com/hashicorp/crt-workflows-common/actions/runs/4557006479. 


## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.4.x

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

### NEW FEATURES | UPGRADE NOTES | ENHANCEMENTS | BUG FIXES | EXPERIMENTS


<!--

Write a short description of the user-facing change. Examples:

- `terraform show -json`: Fixed crash with sensitive set values.
- When rendering a diff, Terraform now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 

-  Add `depends` statement to `promote-staging`
-  Add `promote-staging-packaging` to opt in to linux packaging staging buckets
-  Remove `releng/` branch from pipeline triggers
