### PR TITLE
Upload ECR image to correct ECR repo

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -149,7 +149,7 @@ jobs:
           dockerfile: .github/workflows/build-Dockerfile
           tags: |
             docker.io/hashicorp/${{env.repo}}:${{env.version}}
-            986891699432.dkr.ecr.us-east-1.amazonaws.com/hashicorp/${{env.repo}}:${{env.version}}
+            public.ecr.aws/hashicorp/${{env.repo}}:${{env.version}}
 
   e2etest-build:
     name: Build e2etest for ${{ matrix.goos }}_${{ matrix.goarch }}


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Terraform `v1.4.3` was not properly pushed to ECR during a CRT release because the tag was wrong (private instead of public).

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.4.x

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

### NEW FEATURES | UPGRADE NOTES | ENHANCEMENTS | BUG FIXES | EXPERIMENTS

<!--

Write a short description of the user-facing change. Examples:

- `terraform show -json`: Fixed crash with sensitive set values.
- When rendering a diff, Terraform now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 

-  Updated ECR tag from private facing ECR repo to public
