### PR TITLE
make sure the build fails if cgo isn't being set correctly

### DIFF
--- a/.github/workflows/build-terraform-cli.yml
+++ b/.github/workflows/build-terraform-cli.yml
@@ -10,7 +10,6 @@ on:
     inputs:
       cgo-enabled:
         type: string
-        default: 0
         required: true
       goos:
         required: true


### PR DESCRIPTION
This is a somewhat dangerous default - we didn't get alerted when cgo inputs were not being passed successfully. Let's make sure the build errors if `cgo` is not explicitly set for each matrix target.

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.4.x


