### PR TITLE
comment out ironbank update in CI until it is set up

### DIFF
--- a/.release/ci.hcl
+++ b/.release/ci.hcl
@@ -136,21 +136,24 @@ event "promote-production-packaging" {
   }
 }
 
-event "update-ironbank" {
-  depends = ["promote-production-packaging"]
-  action "update-ironbank" {
-    organization = "hashicorp"
-    repository = "crt-workflows-common"
-    workflow = "update-ironbank"
-  }
+// commenting the ironbank update for now until it is all set up on the Ironbank side
 
-  notification {
-    on = "always"
-  }
-}
+// event "update-ironbank" {
+//   depends = ["promote-production-packaging"]
+//   action "update-ironbank" {
+//     organization = "hashicorp"
+//     repository = "crt-workflows-common"
+//     workflow = "update-ironbank"
+//   }
+
+//   notification {
+//     on = "always"
+//   }
+// }
 
 event "crt-hook-tfc-upload" {
-  depends = ["update-ironbank"]
+  // this will need to be changed back to update-ironbank once the Ironbank setup is done
+  depends = ["promote-production-packaging"]
   action "crt-hook-tfc-upload" {
     organization = "hashicorp"
     repository = "terraform-releases"


### PR DESCRIPTION
This PR comments out the `update-ironbank` job in the release pipeline until it is properly set up on the Ironbank side so it doesn't block the tfc update from kicking off. 

That work is being tracked in [RELENG-562](https://hashicorp.atlassian.net/browse/RELENG-562)