### PR TITLE
cloud: Allow Terraform Cloud/Enterprise to apply backpressure to intermediate state snapshots

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -39,7 +39,7 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-plugin v1.4.3
 	github.com/hashicorp/go-retryablehttp v0.7.2
-	github.com/hashicorp/go-tfe v1.21.0
+	github.com/hashicorp/go-tfe v1.24.0
 	github.com/hashicorp/go-uuid v1.0.3
 	github.com/hashicorp/go-version v1.6.0
 	github.com/hashicorp/hcl v0.0.0-20170504190234-a4b07c25de5f
@@ -147,7 +147,7 @@ require (
 	github.com/hashicorp/go-msgpack v0.5.4 // indirect
 	github.com/hashicorp/go-rootcerts v1.0.2 // indirect
 	github.com/hashicorp/go-safetemp v1.0.0 // indirect
-	github.com/hashicorp/go-slug v0.11.0 // indirect
+	github.com/hashicorp/go-slug v0.11.1 // indirect
 	github.com/hashicorp/golang-lru v0.5.1 // indirect
 	github.com/hashicorp/serf v0.9.5 // indirect
 	github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d // indirect

--- a/go.sum
+++ b/go.sum
@@ -537,13 +537,13 @@ github.com/hashicorp/go-rootcerts v1.0.2 h1:jzhAVGtqPKbwpyCPELlgNWhE1znq+qwJtW5O
 github.com/hashicorp/go-rootcerts v1.0.2/go.mod h1:pqUvnprVnM5bf7AOirdbb01K4ccR319Vf4pU3K5EGc8=
 github.com/hashicorp/go-safetemp v1.0.0 h1:2HR189eFNrjHQyENnQMMpCiBAsRxzbTMIgBhEyExpmo=
 github.com/hashicorp/go-safetemp v1.0.0/go.mod h1:oaerMy3BhqiTbVye6QuFhFtIceqFoDHxNAB65b+Rj1I=
-github.com/hashicorp/go-slug v0.11.0 h1:l7cHWiBk8cnnskjheloW9h8PwXhihvwXbQiiFw2KqkY=
-github.com/hashicorp/go-slug v0.11.0/go.mod h1:Ib+IWBYfEfJGI1ZyXMGNbu2BU+aa3Dzu41RKLH301v4=
+github.com/hashicorp/go-slug v0.11.1 h1:c6lLdQnlhUWbS5I7hw8SvfymoFuy6EmiFDedy6ir994=
+github.com/hashicorp/go-slug v0.11.1/go.mod h1:Ib+IWBYfEfJGI1ZyXMGNbu2BU+aa3Dzu41RKLH301v4=
 github.com/hashicorp/go-sockaddr v1.0.0 h1:GeH6tui99pF4NJgfnhp+L6+FfobzVW3Ah46sLo0ICXs=
 github.com/hashicorp/go-sockaddr v1.0.0/go.mod h1:7Xibr9yA9JjQq1JpNB2Vw7kxv8xerXegt+ozgdvDeDU=
 github.com/hashicorp/go-syslog v1.0.0/go.mod h1:qPfqrKkXGihmCqbJM2mZgkZGvKG1dFdvsLplgctolz4=
-github.com/hashicorp/go-tfe v1.21.0 h1:sTZXf/MaC/iQ8HxKwYSL0xJSEVDwY+h4ngh/+na8vdk=
-github.com/hashicorp/go-tfe v1.21.0/go.mod h1:jedlLiHHiDeBKKpON4aIpTdsKbc2OaVbklEPI7XEHiY=
+github.com/hashicorp/go-tfe v1.24.0 h1:pkAKnPwV1FmpxRAy9NE0F5piaG2KaS2mODQ1Fvzihiw=
+github.com/hashicorp/go-tfe v1.24.0/go.mod h1:gyCSqwttvU8ro8vpJujGSHVT/tR/JrEDk75cx25aJHE=
 github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-uuid v1.0.1/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-uuid v1.0.2/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=

--- a/internal/backend/local/hook_state.go
+++ b/internal/backend/local/hook_state.go
@@ -33,8 +33,30 @@ type StateHook struct {
 	// and PersistInterval is ignored if this is nil.
 	Schemas *terraform.Schemas
 
-	lastPersist  time.Time
-	forcePersist bool
+	intermediatePersist IntermediateStatePersistInfo
+}
+
+type IntermediateStatePersistInfo struct {
+	// RequestedPersistInterval is the persist interval requested by whatever
+	// instantiated the StateHook.
+	//
+	// Implementations of [IntermediateStateConditionalPersister] should ideally
+	// respect this, but may ignore it if they use something other than the
+	// passage of time to make their decision.
+	RequestedPersistInterval time.Duration
+
+	// LastPersist is the time when the last intermediate state snapshot was
+	// persisted, or the time of the first report for Terraform Core if there
+	// hasn't yet been a persisted snapshot.
+	LastPersist time.Time
+
+	// ForcePersist is true when Terraform CLI has receieved an interrupt
+	// signal and is therefore trying to create snapshots more aggressively
+	// in anticipation of possibly being terminated ungracefully.
+	// [IntermediateStateConditionalPersister] implementations should ideally
+	// persist every snapshot they get when this flag is set, unless they have
+	// some external information that implies this shouldn't be necessary.
+	ForcePersist bool
 }
 
 var _ terraform.Hook = (*StateHook)(nil)
@@ -43,10 +65,12 @@ func (h *StateHook) PostStateUpdate(new *states.State) (terraform.HookAction, er
 	h.Lock()
 	defer h.Unlock()
 
-	if h.lastPersist.IsZero() {
+	h.intermediatePersist.RequestedPersistInterval = h.PersistInterval
+
+	if h.intermediatePersist.LastPersist.IsZero() {
 		// The first PostStateUpdate starts the clock for intermediate
 		// calls to PersistState.
-		h.lastPersist = time.Now()
+		h.intermediatePersist.LastPersist = time.Now()
 	}
 
 	if h.StateMgr != nil {
@@ -54,12 +78,14 @@ func (h *StateHook) PostStateUpdate(new *states.State) (terraform.HookAction, er
 			return terraform.HookActionHalt, err
 		}
 		if mgrPersist, ok := h.StateMgr.(statemgr.Persister); ok && h.PersistInterval != 0 && h.Schemas != nil {
-			if h.forcePersist || time.Since(h.lastPersist) >= h.PersistInterval {
+			if h.shouldPersist() {
 				err := mgrPersist.PersistState(h.Schemas)
 				if err != nil {
 					return terraform.HookActionHalt, err
 				}
-				h.lastPersist = time.Now()
+				h.intermediatePersist.LastPersist = time.Now()
+			} else {
+				log.Printf("[DEBUG] State storage %T declined to persist a state snapshot", h.StateMgr)
 			}
 		}
 	}
@@ -78,21 +104,72 @@ func (h *StateHook) Stopping() {
 	// do if they _do_ subsequently hard-kill Terraform during an apply.
 
 	if mgrPersist, ok := h.StateMgr.(statemgr.Persister); ok && h.Schemas != nil {
-		err := mgrPersist.PersistState(h.Schemas)
-		if err != nil {
-			// This hook can't affect Terraform Core's ongoing behavior,
-			// but it's a best effort thing anyway so we'll just emit a
-			// log to aid with debugging.
-			log.Printf("[ERROR] Failed to persist state after interruption: %s", err)
-		}
-
 		// While we're in the stopping phase we'll try to persist every
 		// new state update to maximize every opportunity we get to avoid
 		// losing track of objects that have been created or updated.
 		// Terraform Core won't start any new operations after it's been
 		// stopped, so at most we should see one more PostStateUpdate
 		// call per already-active request.
-		h.forcePersist = true
+		h.intermediatePersist.ForcePersist = true
+
+		if h.shouldPersist() {
+			err := mgrPersist.PersistState(h.Schemas)
+			if err != nil {
+				// This hook can't affect Terraform Core's ongoing behavior,
+				// but it's a best effort thing anyway so we'll just emit a
+				// log to aid with debugging.
+				log.Printf("[ERROR] Failed to persist state after interruption: %s", err)
+			}
+		} else {
+			log.Printf("[DEBUG] State storage %T declined to persist a state snapshot", h.StateMgr)
+		}
 	}
 
+}
+
+func (h *StateHook) shouldPersist() bool {
+	if m, ok := h.StateMgr.(IntermediateStateConditionalPersister); ok {
+		return m.ShouldPersistIntermediateState(&h.intermediatePersist)
+	}
+	return DefaultIntermediateStatePersistRule(&h.intermediatePersist)
+}
+
+// DefaultIntermediateStatePersistRule is the default implementation of
+// [IntermediateStateConditionalPersister.ShouldPersistIntermediateState] used
+// when the selected state manager doesn't implement that interface.
+//
+// Implementers of that interface can optionally wrap a call to this function
+// if they want to combine the default behavior with some logic of their own.
+func DefaultIntermediateStatePersistRule(info *IntermediateStatePersistInfo) bool {
+	return info.ForcePersist || time.Since(info.LastPersist) >= info.RequestedPersistInterval
+}
+
+// IntermediateStateConditionalPersister is an optional extension of
+// [statemgr.Persister] that allows an implementation to tailor the rules for
+// whether to create intermediate state snapshots when Terraform Core emits
+// events reporting that the state might have changed.
+//
+// For state managers that don't implement this interface, [StateHook] uses
+// a default set of rules that aim to be a good compromise between how long
+// a state change can be active before it gets committed as a snapshot vs.
+// how many intermediate snapshots will get created. That compromise is subject
+// to change over time, but a state manager can implement this interface to
+// exert full control over those rules.
+type IntermediateStateConditionalPersister interface {
+	// ShouldPersistIntermediateState will be called each time Terraform Core
+	// emits an intermediate state event that is potentially eligible to be
+	// persisted.
+	//
+	// The implemention should return true to signal that the state snapshot
+	// most recently provided to the object's WriteState should be persisted,
+	// or false if it should not be persisted. If this function returns true
+	// then the receiver will see a subsequent call to
+	// [statemgr.Persister.PersistState] to request persistence.
+	//
+	// The implementation must not modify anything reachable through the
+	// arguments, and must not retain pointers to anything reachable through
+	// them after the function returns. However, implementers can assume that
+	// nothing will write to anything reachable through the arguments while
+	// this function is active.
+	ShouldPersistIntermediateState(info *IntermediateStatePersistInfo) bool
 }

--- a/internal/backend/remote/backend.go
+++ b/internal/backend/remote/backend.go
@@ -694,7 +694,18 @@ func (b *Remote) StateMgr(name string) (statemgr.Full, error) {
 		runID: os.Getenv("TFE_RUN_ID"),
 	}
 
-	return &remote.State{Client: client}, nil
+	return &remote.State{
+		Client: client,
+
+		// client.runID will be set if we're running a the Terraform Cloud
+		// or Terraform Enterprise remote execution environment, in which
+		// case we'll disable intermediate snapshots to avoid extra storage
+		// costs for Terraform Enterprise customers.
+		// Other implementations of the remote state protocol should not run
+		// in contexts where there's a "TFE Run ID" and so are not affected
+		// by this special case.
+		DisableIntermediateSnapshots: client.runID != "",
+	}, nil
 }
 
 func isLocalExecutionMode(execMode string) bool {

--- a/internal/cloud/state.go
+++ b/internal/cloud/state.go
@@ -21,6 +21,8 @@ import (
 
 	tfe "github.com/hashicorp/go-tfe"
 	uuid "github.com/hashicorp/go-uuid"
+
+	"github.com/hashicorp/terraform/internal/backend/local"
 	"github.com/hashicorp/terraform/internal/command/jsonstate"
 	"github.com/hashicorp/terraform/internal/states"
 	"github.com/hashicorp/terraform/internal/states/remote"
@@ -66,6 +68,7 @@ remote state version.
 
 var _ statemgr.Full = (*State)(nil)
 var _ statemgr.Migrator = (*State)(nil)
+var _ local.IntermediateStateConditionalPersister = (*State)(nil)
 
 // statemgr.Reader impl.
 func (s *State) State() *states.State {
@@ -221,6 +224,14 @@ func (s *State) PersistState(schemas *terraform.Schemas) error {
 	s.readLineage = s.lineage
 	s.readSerial = s.serial
 	return nil
+}
+
+// ShouldPersistIntermediateState implements local.IntermediateStateConditionalPersister
+func (*State) ShouldPersistIntermediateState(info *local.IntermediateStatePersistInfo) bool {
+	// We currently don't create intermediate snapshots for Terraform Cloud or
+	// Terraform Enterprise at all, to avoid extra storage costs for Terraform
+	// Enterprise customers.
+	return false
 }
 
 func (s *State) uploadState(lineage string, serial uint64, isForcePush bool, state, jsonState, jsonStateOutputs []byte) error {


### PR DESCRIPTION
**NOTE:** The scope of this PR changed during discussion; see the commentary below to learn about the expanded scope.

The remaining text is the original PR writeup from before the scope increase.

---

We've seen some concern about the additional storage usage in Terraform Enterprise implied by creating intermediate state snapshots for particularly long apply phases that can arise when managing a large number of resource instances together in a single workspace.

This is an initial coarse approach to solving that concern, just restoring the original behavior when running inside Terraform Cloud or Enterprise for now and not creating intermediate snapshots at all.

This is here as a solution of last resort in case we do not find a better compromise before the v1.5.0 final release. Hopefully a future changeset will implement a more subtle take on this which still gets some of the benefits when running in a Terraform Enterprise environment but in a way that will hopefully be less concerning for Terraform Enterprise administrators, in which case the effects of this PR will not make it into any stable release.

This does not affect any other state storage implementation except the Terraform Cloud integration and the "remote" backend's state storage when running inside a TFC/TFE-driven remote execution environment.
