### PR TITLE
website: Add link to plugin logging page on debugging page

### DIFF
--- a/website/docs/internals/debugging.mdx
+++ b/website/docs/internals/debugging.mdx
@@ -20,7 +20,7 @@ Setting `TF_LOG` to `JSON` outputs logs at the `TRACE` level or higher, and uses
 
 Logging can be enabled separately for terraform itself and the provider plugins
 using the `TF_LOG_CORE` or `TF_LOG_PROVIDER` environment variables. These take
-the same level arguments as `TF_LOG`, but only activate a subset of the logs.
+the same level arguments as `TF_LOG`, but only activate a subset of the logs. Refer to [Plugin Development - Managing Log Output](/terraform/plugin/log/managing) for additional information about all provider plugin environment variables.
 
 To persist logged output you can set `TF_LOG_PATH` in order to force the log to always be appended to a specific file when logging is enabled. Note that even when `TF_LOG_PATH` is set, `TF_LOG` must be set in order for any logging to be enabled.
 


### PR DESCRIPTION
Reference: https://github.com/hashicorp/terraform-plugin-framework/pull/710#issuecomment-1492507180

The goal here is to not burden the Terraform documentation with all the logging implementation details from the provider side of the protocol, but ensure the information is at least more discoverable.

## Target Release

1.5.x is fine

## Draft CHANGELOG entry

N/A