### PR TITLE
ci: Smoke test docker builds

### DIFF
--- a/.github/scripts/verify_docker
+++ b/.github/scripts/verify_docker
@@ -1,0 +1,47 @@
+#!/bin/bash
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+
+set -euo pipefail
+
+# verify_docker invokes the given Docker image with the argument `version` and inspects its output.
+# If its output doesn't match the version given, the script will exit 1 and report why it failed.
+# This is meant to be run as part of the build workflow to verify the built image meets some basic
+# criteria for validity.
+#
+# Because this is meant to be run as the `smoke_test` for the docker-build workflow, the script expects
+# the image name parameter to be provided by the `IMAGE_NAME` environment variable, rather than a
+# positional argument.
+
+function usage {
+  echo "IMAGE_NAME=<image uri> ./verify_docker <expect_version>"
+}
+
+function main {
+  local image_name="${IMAGE_NAME:-}"
+  local expect_version="${1:-}"
+  local got_version
+
+  if [[ -z "${image_name}" ]]; then
+    echo "ERROR: IMAGE_NAME is not set"
+    usage
+    exit 1
+  fi
+
+  if [[ -z "${expect_version}" ]]; then
+    echo "ERROR: expected version argument is required"
+    usage
+    exit 1
+  fi
+
+  got_version="$( awk '{print $2}' <(head -n1 <(docker run --rm "${image_name}" version)) )"
+  if [ "${got_version}" != "${expect_version}" ]; then
+    echo "Test FAILED"
+    echo "Got: ${got_version}, Want: ${expect_version}"
+    exit 1
+  fi
+  echo "Test PASSED"
+}
+
+main "$@"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -147,6 +147,7 @@ jobs:
           target: default
           arch: ${{matrix.arch}}
           dockerfile: .github/workflows/build-Dockerfile
+          smoke_test: .github/scripts/verify_docker v${{ env.version }}
           tags: |
             docker.io/hashicorp/${{env.repo}}:${{env.version}}
             public.ecr.aws/hashicorp/${{env.repo}}:${{env.version}}


### PR DESCRIPTION
This adds a test to catch the glibc build issue that caused #32947. We check both the container executes and the version is correct.

## Target Release

1.5.x
1.4.x
