### PR TITLE
metadata_host param for AzureRM backend documentation

### DIFF
--- a/website/docs/language/settings/backends/azurerm.mdx
+++ b/website/docs/language/settings/backends/azurerm.mdx
@@ -249,7 +249,7 @@ The following configuration options are supported:
 
 ~> **NOTE:** An `endpoint` should only be configured when using Azure Stack.
 
-* 'metadata_host' - (Optional) The Hostname of the Azure Metadata Service (for example management.azure.com), used to obtain the Cloud Environment when using a Custom Azure Environment. This can also be sourced from the ARM_METADATA_HOSTNAME Environment Variable.
+* `metadata_host` - (Optional) The Hostname of the Azure Metadata Service (for example `management.azure.com`), used to obtain the Cloud Environment when using a Custom Azure Environment. This can also be sourced from the `ARM_METADATA_HOSTNAME` Environment Variable.
 
 * `snapshot` - (Optional) Should the Blob used to store the Terraform Statefile be snapshotted before use? Defaults to `false`. This value can also be sourced from the `ARM_SNAPSHOT` environment variable.
 

--- a/website/docs/language/settings/backends/azurerm.mdx
+++ b/website/docs/language/settings/backends/azurerm.mdx
@@ -249,6 +249,8 @@ The following configuration options are supported:
 
 ~> **NOTE:** An `endpoint` should only be configured when using Azure Stack.
 
+* 'metadata_host' - (Optional) The Hostname of the Azure Metadata Service (for example management.azure.com), used to obtain the Cloud Environment when using a Custom Azure Environment. This can also be sourced from the ARM_METADATA_HOSTNAME Environment Variable.
+
 * `snapshot` - (Optional) Should the Blob used to store the Terraform Statefile be snapshotted before use? Defaults to `false`. This value can also be sourced from the `ARM_SNAPSHOT` environment variable.
 
 ***


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Fixes #

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.4.x or later

## Draft CHANGELOG entry

Updated azurerm backend configuration:

* 'metadata_host' - (Optional) The Hostname of the Azure Metadata Service (for example management.azure.com), used to obtain the Cloud Environment when using a Custom Azure Environment. This can also be sourced from the ARM_METADATA_HOSTNAME Environment Variable.

<!--

Choose a category, delete the others:

-->

### ENHANCEMENTS 

- Documentation update for **'azurerm'** backend configuration doc. The **metadata_host** parameter is not included in the list of available / optional parameters for the backend configuration. This parameter is required when using the azurerm backend in certain custom Azure environments.

<!--

Write a short description of the user-facing change. Examples:

- `terraform show -json`: Fixed crash with sensitive set values.
- When rendering a diff, Terraform now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 

-  
