### PR TITLE
Document new -or-create flag.

### DIFF
--- a/website/docs/cli/commands/workspace/select.mdx
+++ b/website/docs/cli/commands/workspace/select.mdx
@@ -15,6 +15,10 @@ Usage: `terraform workspace select NAME [DIR]`
 This command will select another workspace. The named workspace must already
 exist.
 
+The supported flags are:
+
+* `-or-create` - If the workspace that is being selected does not exist, create it. Default is `false`.
+
 ## Example
 
 ```


### PR DESCRIPTION
Since terraform `1.4.0`, `terraform workspace select` has got a new flag to create the workspace if it doesn't exist.

The documentation needs updating to reflect this.

https://github.com/hashicorp/terraform/pull/31633

Fixes #

## Target Release

1.4.x