### PR TITLE
Emit warnings for certain run events in cloud backend

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -39,7 +39,7 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-plugin v1.4.3
 	github.com/hashicorp/go-retryablehttp v0.7.2
-	github.com/hashicorp/go-tfe v1.18.0
+	github.com/hashicorp/go-tfe v1.21.0
 	github.com/hashicorp/go-uuid v1.0.3
 	github.com/hashicorp/go-version v1.6.0
 	github.com/hashicorp/hcl v0.0.0-20170504190234-a4b07c25de5f
@@ -147,7 +147,7 @@ require (
 	github.com/hashicorp/go-msgpack v0.5.4 // indirect
 	github.com/hashicorp/go-rootcerts v1.0.2 // indirect
 	github.com/hashicorp/go-safetemp v1.0.0 // indirect
-	github.com/hashicorp/go-slug v0.10.1 // indirect
+	github.com/hashicorp/go-slug v0.11.0 // indirect
 	github.com/hashicorp/golang-lru v0.5.1 // indirect
 	github.com/hashicorp/serf v0.9.5 // indirect
 	github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d // indirect

--- a/go.sum
+++ b/go.sum
@@ -537,13 +537,13 @@ github.com/hashicorp/go-rootcerts v1.0.2 h1:jzhAVGtqPKbwpyCPELlgNWhE1znq+qwJtW5O
 github.com/hashicorp/go-rootcerts v1.0.2/go.mod h1:pqUvnprVnM5bf7AOirdbb01K4ccR319Vf4pU3K5EGc8=
 github.com/hashicorp/go-safetemp v1.0.0 h1:2HR189eFNrjHQyENnQMMpCiBAsRxzbTMIgBhEyExpmo=
 github.com/hashicorp/go-safetemp v1.0.0/go.mod h1:oaerMy3BhqiTbVye6QuFhFtIceqFoDHxNAB65b+Rj1I=
-github.com/hashicorp/go-slug v0.10.1 h1:05SCRWCBpCxOeP7stQHvMgOz0raCBCekaytu8Rg/RZ4=
-github.com/hashicorp/go-slug v0.10.1/go.mod h1:Ib+IWBYfEfJGI1ZyXMGNbu2BU+aa3Dzu41RKLH301v4=
+github.com/hashicorp/go-slug v0.11.0 h1:l7cHWiBk8cnnskjheloW9h8PwXhihvwXbQiiFw2KqkY=
+github.com/hashicorp/go-slug v0.11.0/go.mod h1:Ib+IWBYfEfJGI1ZyXMGNbu2BU+aa3Dzu41RKLH301v4=
 github.com/hashicorp/go-sockaddr v1.0.0 h1:GeH6tui99pF4NJgfnhp+L6+FfobzVW3Ah46sLo0ICXs=
 github.com/hashicorp/go-sockaddr v1.0.0/go.mod h1:7Xibr9yA9JjQq1JpNB2Vw7kxv8xerXegt+ozgdvDeDU=
 github.com/hashicorp/go-syslog v1.0.0/go.mod h1:qPfqrKkXGihmCqbJM2mZgkZGvKG1dFdvsLplgctolz4=
-github.com/hashicorp/go-tfe v1.18.0 h1:AjyZe2KSAyGHD1kbGYlY64PVYQPnJJON24qr97IjIqA=
-github.com/hashicorp/go-tfe v1.18.0/go.mod h1:T76X7dHKNEPEugPCZI3gDdaDdxUU4P4sqMZO60W57cQ=
+github.com/hashicorp/go-tfe v1.21.0 h1:sTZXf/MaC/iQ8HxKwYSL0xJSEVDwY+h4ngh/+na8vdk=
+github.com/hashicorp/go-tfe v1.21.0/go.mod h1:jedlLiHHiDeBKKpON4aIpTdsKbc2OaVbklEPI7XEHiY=
 github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-uuid v1.0.1/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-uuid v1.0.2/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
@@ -762,7 +762,7 @@ github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
-github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
+github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.0.194/go.mod h1:7sCQWVkxcsR38nffDW057DRGk8mUjK1Ing/EFOK8s8Y=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.0.588 h1:DYtBXB7sVc3EOW5horg8j55cLZynhsLYhHrvQ/jXKKM=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.0.588/go.mod h1:7sCQWVkxcsR38nffDW057DRGk8mUjK1Ing/EFOK8s8Y=

--- a/internal/backend/remote/testing.go
+++ b/internal/backend/remote/testing.go
@@ -144,6 +144,7 @@ func testBackend(t *testing.T, obj cty.Value) (*Remote, func()) {
 	b.client.Plans = mc.Plans
 	b.client.PolicyChecks = mc.PolicyChecks
 	b.client.Runs = mc.Runs
+	b.client.RunEvents = mc.RunEvents
 	b.client.StateVersions = mc.StateVersions
 	b.client.Variables = mc.Variables
 	b.client.Workspaces = mc.Workspaces

--- a/internal/cloud/backend_plan.go
+++ b/internal/cloud/backend_plan.go
@@ -293,6 +293,11 @@ in order to capture the filesystem context the remote workspace expects:
 			runHeader, b.hostname, b.organization, op.Workspace, r.ID)) + "\n"))
 	}
 
+	// Render any warnings that were raised during run creation
+	if err := b.renderRunWarnings(stopCtx, b.client, r.ID); err != nil {
+		return r, err
+	}
+
 	// Retrieve the run to get task stages.
 	// Task Stages are calculated upfront so we only need to call this once for the run.
 	taskStages, err := b.runTaskStages(stopCtx, b.client, r.ID)

--- a/internal/cloud/backend_run_warning.go
+++ b/internal/cloud/backend_run_warning.go
@@ -1,0 +1,46 @@
+package cloud
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	tfe "github.com/hashicorp/go-tfe"
+)
+
+const (
+	changedPolicyEnforcementAction = "changed_policy_enforcements"
+	changedTaskEnforcementAction   = "changed_task_enforcements"
+	ignoredPolicySetAction         = "ignored_policy_sets"
+)
+
+func (b *Cloud) renderRunWarnings(ctx context.Context, client *tfe.Client, runId string) error {
+	if b.CLI == nil {
+		return nil
+	}
+
+	result, err := client.RunEvents.List(ctx, runId, nil)
+	if err != nil {
+		return err
+	}
+	if result == nil {
+		return nil
+	}
+
+	// We don't have to worry about paging as the API doesn't support it yet
+	for _, re := range result.Items {
+		switch re.Action {
+		case changedPolicyEnforcementAction, changedTaskEnforcementAction, ignoredPolicySetAction:
+			if re.Description != "" {
+				b.CLI.Warn(b.Colorize().Color(strings.TrimSpace(fmt.Sprintf(
+					runWarningHeader, re.Description)) + "\n"))
+			}
+		}
+	}
+
+	return nil
+}
+
+const runWarningHeader = `
+[reset][yellow]Warning:[reset] %s
+`

--- a/internal/cloud/backend_run_warning_test.go
+++ b/internal/cloud/backend_run_warning_test.go
@@ -1,0 +1,153 @@
+package cloud
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/golang/mock/gomock"
+	"github.com/hashicorp/go-tfe"
+	tfemocks "github.com/hashicorp/go-tfe/mocks"
+	"github.com/mitchellh/cli"
+)
+
+func MockAllRunEvents(t *testing.T, client *tfe.Client) (fullRunID string, emptyRunID string) {
+	ctrl := gomock.NewController(t)
+
+	fullRunID = "run-full"
+	emptyRunID = "run-empty"
+
+	mockRunEventsAPI := tfemocks.NewMockRunEvents(ctrl)
+
+	emptyList := tfe.RunEventList{
+		Items: []*tfe.RunEvent{},
+	}
+	fullList := tfe.RunEventList{
+		Items: []*tfe.RunEvent{
+			{
+				Action:      "created",
+				CreatedAt:   time.Now(),
+				Description: "",
+			},
+			{
+				Action:      "changed_task_enforcements",
+				CreatedAt:   time.Now(),
+				Description: "The enforcement level for task 'MockTask' was changed to 'advisory' because the run task limit was exceeded.",
+			},
+			{
+				Action:      "changed_policy_enforcements",
+				CreatedAt:   time.Now(),
+				Description: "The enforcement level for policy 'MockPolicy' was changed to 'advisory' because the policy limit was exceeded.",
+			},
+			{
+				Action:      "ignored_policy_sets",
+				CreatedAt:   time.Now(),
+				Description: "The policy set 'MockPolicySet' was ignored because the versioned policy set limit was exceeded.",
+			},
+			{
+				Action:      "queued",
+				CreatedAt:   time.Now(),
+				Description: "",
+			},
+		},
+	}
+	// Mock Full Request
+	mockRunEventsAPI.
+		EXPECT().
+		List(gomock.Any(), fullRunID, gomock.Any()).
+		Return(&fullList, nil).
+		AnyTimes()
+
+	// Mock Full Request
+	mockRunEventsAPI.
+		EXPECT().
+		List(gomock.Any(), emptyRunID, gomock.Any()).
+		Return(&emptyList, nil).
+		AnyTimes()
+
+	// Mock a bad Read response
+	mockRunEventsAPI.
+		EXPECT().
+		List(gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(nil, tfe.ErrInvalidRunID).
+		AnyTimes()
+
+	// Wire up the mock interfaces
+	client.RunEvents = mockRunEventsAPI
+	return
+}
+
+func TestRunEventWarningsAll(t *testing.T) {
+	b, bCleanup := testBackendWithName(t)
+	defer bCleanup()
+
+	config := &tfe.Config{
+		Token: "not-a-token",
+	}
+	client, _ := tfe.NewClient(config)
+	fullRunID, _ := MockAllRunEvents(t, client)
+
+	ctx := context.TODO()
+
+	err := b.renderRunWarnings(ctx, client, fullRunID)
+	if err != nil {
+		t.Fatalf("Expected to not error but received %s", err)
+	}
+
+	output := b.CLI.(*cli.MockUi).ErrorWriter.String()
+	testString := "The enforcement level for task 'MockTask'"
+	if !strings.Contains(output, testString) {
+		t.Fatalf("Expected %q to contain %q but it did not", output, testString)
+	}
+	testString = "The enforcement level for policy 'MockPolicy'"
+	if !strings.Contains(output, testString) {
+		t.Fatalf("Expected %q to contain %q but it did not", output, testString)
+	}
+	testString = "The policy set 'MockPolicySet'"
+	if !strings.Contains(output, testString) {
+		t.Fatalf("Expected %q to contain %q but it did not", output, testString)
+	}
+}
+
+func TestRunEventWarningsEmpty(t *testing.T) {
+	b, bCleanup := testBackendWithName(t)
+	defer bCleanup()
+
+	config := &tfe.Config{
+		Token: "not-a-token",
+	}
+	client, _ := tfe.NewClient(config)
+	_, emptyRunID := MockAllRunEvents(t, client)
+
+	ctx := context.TODO()
+
+	err := b.renderRunWarnings(ctx, client, emptyRunID)
+	if err != nil {
+		t.Fatalf("Expected to not error but received %s", err)
+	}
+
+	output := b.CLI.(*cli.MockUi).ErrorWriter.String()
+	if output != "" {
+		t.Fatalf("Expected %q to be empty but it was not", output)
+	}
+}
+
+func TestRunEventWarningsWithError(t *testing.T) {
+	b, bCleanup := testBackendWithName(t)
+	defer bCleanup()
+
+	config := &tfe.Config{
+		Token: "not-a-token",
+	}
+	client, _ := tfe.NewClient(config)
+	MockAllRunEvents(t, client)
+
+	ctx := context.TODO()
+
+	err := b.renderRunWarnings(ctx, client, "bad run id")
+
+	if err == nil {
+		t.Error("Expected to error but did not")
+	}
+}

--- a/internal/cloud/testing.go
+++ b/internal/cloud/testing.go
@@ -216,6 +216,7 @@ func testBackend(t *testing.T, obj cty.Value) (*Cloud, func()) {
 	b.client.PolicySetOutcomes = mc.PolicySetOutcomes
 	b.client.PolicyChecks = mc.PolicyChecks
 	b.client.Runs = mc.Runs
+	b.client.RunEvents = mc.RunEvents
 	b.client.StateVersions = mc.StateVersions
 	b.client.StateVersionOutputs = mc.StateVersionOutputs
 	b.client.Variables = mc.Variables
@@ -287,6 +288,7 @@ func testUnconfiguredBackend(t *testing.T) (*Cloud, func()) {
 	b.client.PolicySetOutcomes = mc.PolicySetOutcomes
 	b.client.PolicyChecks = mc.PolicyChecks
 	b.client.Runs = mc.Runs
+	b.client.RunEvents = mc.RunEvents
 	b.client.StateVersions = mc.StateVersions
 	b.client.Variables = mc.Variables
 	b.client.Workspaces = mc.Workspaces

--- a/internal/cloud/tfe_client_mock.go
+++ b/internal/cloud/tfe_client_mock.go
@@ -34,6 +34,7 @@ type MockClient struct {
 	RedactedPlans         *MockRedactedPlans
 	PolicyChecks          *MockPolicyChecks
 	Runs                  *MockRuns
+	RunEvents             *MockRunEvents
 	StateVersions         *MockStateVersions
 	StateVersionOutputs   *MockStateVersionOutputs
 	Variables             *MockVariables
@@ -51,6 +52,7 @@ func NewMockClient() *MockClient {
 	c.PolicySetOutcomes = newMockPolicySetOutcomes(c)
 	c.PolicyChecks = newMockPolicyChecks(c)
 	c.Runs = newMockRuns(c)
+	c.RunEvents = newMockRunEvents(c)
 	c.StateVersions = newMockStateVersions(c)
 	c.StateVersionOutputs = newMockStateVersionOutputs(c)
 	c.Variables = newMockVariables(c)
@@ -1166,6 +1168,31 @@ func (m *MockRuns) Discard(ctx context.Context, runID string, options tfe.RunDis
 	r.Status = tfe.RunDiscarded
 	r.Actions.IsConfirmable = false
 	return nil
+}
+
+type MockRunEvents struct{}
+
+func newMockRunEvents(_ *MockClient) *MockRunEvents {
+	return &MockRunEvents{}
+}
+
+// List all the runs events of the given run.
+func (m *MockRunEvents) List(ctx context.Context, runID string, options *tfe.RunEventListOptions) (*tfe.RunEventList, error) {
+	return &tfe.RunEventList{
+		Items: []*tfe.RunEvent{},
+	}, nil
+}
+
+func (m *MockRunEvents) Read(ctx context.Context, runEventID string) (*tfe.RunEvent, error) {
+	return m.ReadWithOptions(ctx, runEventID, nil)
+}
+
+func (m *MockRunEvents) ReadWithOptions(ctx context.Context, runEventID string, options *tfe.RunEventReadOptions) (*tfe.RunEvent, error) {
+	return &tfe.RunEvent{
+		ID:        GenerateID("re-"),
+		Action:    "created",
+		CreatedAt: time.Now(),
+	}, nil
 }
 
 type MockStateVersions struct {


### PR DESCRIPTION
The cloud backend, which communicates with TFC like APIs, can create
runs which may have one or more configuration parameters altered. These
alterations are emitted as run-events on the run so that API clients
can consume and display them to users. This commit adds a step in
plan operation to query the run-events once a run is created and then
emit specific run-event descriptions to the console as warnings for
the user.

[Jira](https://hashicorp.atlassian.net/browse/TF-5641)
[RFC](https://hashidocs.hashicorp.services/document/18gCqJdevTjMfbOfqosO8hTI90_1_WFbWIlcu32GWfVw)

## Target Release

1.4.x

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

### ENHANCEMENTS

- Shows warnings generated when creating a run in the cloud backend


##  Example Output

![image](https://user-images.githubusercontent.com/5819622/231372127-d54a0b4e-0426-4fc8-b06f-65f5c88f1ed2.png)

