### PR TITLE
Fix rendering unknown values in map and null string primitives

### DIFF
--- a/internal/command/jsonformat/computed/renderers/primitive.go
+++ b/internal/command/jsonformat/computed/renderers/primitive.go
@@ -88,7 +88,7 @@ func (renderer primitiveRenderer) renderStringDiff(diff computed.Diff, indent in
 		}
 
 		if !str.IsMultiline {
-			return fmt.Sprintf("%q%s", str.String, forcesReplacement(diff.Replace, opts))
+			return fmt.Sprintf("%s%s", str.RenderSimple(), forcesReplacement(diff.Replace, opts))
 		}
 
 		// We are creating a single multiline string, so let's split by the new
@@ -102,13 +102,18 @@ func (renderer primitiveRenderer) renderStringDiff(diff computed.Diff, indent in
 		lines[0] = fmt.Sprintf("%s%s%s", formatIndent(indent+1), writeDiffActionSymbol(plans.NoOp, opts), lines[0])
 	case plans.Delete:
 		str := evaluatePrimitiveString(renderer.before, opts)
+		if str.IsNull {
+			// We don't put the null suffix (-> null) here because the final
+			// render or null -> null would look silly.
+			return fmt.Sprintf("%s%s", str.RenderSimple(), forcesReplacement(diff.Replace, opts))
+		}
 
 		if str.Json != nil {
 			return renderer.renderStringDiffAsJson(diff, indent, opts, str, evaluatedString{})
 		}
 
 		if !str.IsMultiline {
-			return fmt.Sprintf("%q%s%s", str.String, nullSuffix(diff.Action, opts), forcesReplacement(diff.Replace, opts))
+			return fmt.Sprintf("%s%s%s", str.RenderSimple(), nullSuffix(diff.Action, opts), forcesReplacement(diff.Replace, opts))
 		}
 
 		// We are creating a single multiline string, so let's split by the new
@@ -141,7 +146,7 @@ func (renderer primitiveRenderer) renderStringDiff(diff computed.Diff, indent in
 		}
 
 		if !beforeString.IsMultiline && !afterString.IsMultiline {
-			return fmt.Sprintf("%q %s %q%s", beforeString.String, opts.Colorize.Color("[yellow]->[reset]"), afterString.String, forcesReplacement(diff.Replace, opts))
+			return fmt.Sprintf("%s %s %s%s", beforeString.RenderSimple(), opts.Colorize.Color("[yellow]->[reset]"), afterString.RenderSimple(), forcesReplacement(diff.Replace, opts))
 		}
 
 		beforeLines := strings.Split(beforeString.String, "\n")

--- a/internal/command/jsonformat/computed/renderers/renderer_test.go
+++ b/internal/command/jsonformat/computed/renderers/renderer_test.go
@@ -24,6 +24,103 @@ func TestRenderers_Human(t *testing.T) {
 		expected string
 		opts     computed.RenderHumanOpts
 	}{
+		// We're using the string "null" in these tests to demonstrate the
+		// difference between rendering an actual string and rendering a null
+		// value.
+		"primitive_create_string": {
+			diff: computed.Diff{
+				Renderer: Primitive(nil, "null", cty.String),
+				Action:   plans.Create,
+			},
+			expected: "\"null\"",
+		},
+		"primitive_delete_string": {
+			diff: computed.Diff{
+				Renderer: Primitive("null", nil, cty.String),
+				Action:   plans.Delete,
+			},
+			expected: "\"null\" -> null",
+		},
+		"primitive_update_string_to_null": {
+			diff: computed.Diff{
+				Renderer: Primitive("null", nil, cty.String),
+				Action:   plans.Update,
+			},
+			expected: "\"null\" -> null",
+		},
+		"primitive_update_string_from_null": {
+			diff: computed.Diff{
+				Renderer: Primitive(nil, "null", cty.String),
+				Action:   plans.Update,
+			},
+			expected: "null -> \"null\"",
+		},
+		"primitive_update_multiline_string_to_null": {
+			diff: computed.Diff{
+				Renderer: Primitive("nu\nll", nil, cty.String),
+				Action:   plans.Update,
+			},
+			expected: `
+<<-EOT
+      - nu
+      - ll
+      + null
+    EOT
+`,
+		},
+		"primitive_update_multiline_string_from_null": {
+			diff: computed.Diff{
+				Renderer: Primitive(nil, "nu\nll", cty.String),
+				Action:   plans.Update,
+			},
+			expected: `
+<<-EOT
+      - null
+      + nu
+      + ll
+    EOT
+`,
+		},
+		"primitive_update_json_string_to_null": {
+			diff: computed.Diff{
+				Renderer: Primitive("[null]", nil, cty.String),
+				Action:   plans.Update,
+			},
+			expected: `
+jsonencode(
+        [
+          - null,
+        ]
+    ) -> null
+`,
+		},
+		"primitive_update_json_string_from_null": {
+			diff: computed.Diff{
+				Renderer: Primitive(nil, "[null]", cty.String),
+				Action:   plans.Update,
+			},
+			expected: `
+null -> jsonencode(
+        [
+          + null,
+        ]
+    )
+`,
+		},
+		"primitive_create_null_string": {
+			diff: computed.Diff{
+				Renderer: Primitive(nil, nil, cty.String),
+				Action:   plans.Create,
+			},
+			expected: "null",
+		},
+		"primitive_delete_null_string": {
+			diff: computed.Diff{
+				Renderer: Primitive(nil, nil, cty.String),
+				Action:   plans.Delete,
+			},
+			expected: "null",
+		},
 		"primitive_create": {
 			diff: computed.Diff{
 				Renderer: Primitive(nil, 1.0, cty.Number),

--- a/internal/command/jsonformat/computed/renderers/string.go
+++ b/internal/command/jsonformat/computed/renderers/string.go
@@ -2,6 +2,7 @@ package renderers
 
 import (
 	"encoding/json"
+	"fmt"
 	"strings"
 
 	"github.com/hashicorp/terraform/internal/command/jsonformat/computed"
@@ -12,11 +13,15 @@ type evaluatedString struct {
 	Json   interface{}
 
 	IsMultiline bool
+	IsNull      bool
 }
 
 func evaluatePrimitiveString(value interface{}, opts computed.RenderHumanOpts) evaluatedString {
 	if value == nil {
-		return evaluatedString{String: opts.Colorize.Color("[dark_gray]null[reset]")}
+		return evaluatedString{
+			String: opts.Colorize.Color("[dark_gray]null[reset]"),
+			IsNull: true,
+		}
 	}
 
 	str := value.(string)
@@ -41,4 +46,11 @@ func evaluatePrimitiveString(value interface{}, opts computed.RenderHumanOpts) e
 	return evaluatedString{
 		String: str,
 	}
+}
+
+func (e evaluatedString) RenderSimple() string {
+	if e.IsNull {
+		return e.String
+	}
+	return fmt.Sprintf("%q", e.String)
 }

--- a/internal/command/jsonformat/differ/map.go
+++ b/internal/command/jsonformat/differ/map.go
@@ -31,14 +31,14 @@ func (change Change) computeAttributeDiffAsMap(elementType cty.Type) computed.Di
 	for key, value := range mapValue.After {
 		after[key] = value
 	}
-	for key, _ := range mapValue.Unknown {
+	for key := range mapValue.Unknown {
 		if _, ok := after[key]; ok {
 			// Then this unknown value was in after, this probably means it has
 			// a child that is unknown rather than being unknown itself. As
 			// such, we'll skip over it. Note, it doesn't particularly matter if
 			// an element is in both places - it's just important we actually
-			// do cover all the elements. We want a complete union and
-			// duplicates are no concern.
+			// do cover all the elements. We want a complete union and therefore
+			// duplicates are no cause for concern as long as we dedupe here.
 			continue
 		}
 		after[key] = nil


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

This PR fixes 2 issues in the new renderer:

1. Unknown values are removed from the set of after values by the json plan package for attributes. This affects maps as they are unaware of the values they are supposed to contain. This PR makes the renderer look at the planned unknown values and merge them back into the main after set before computing the diff.
2. Null strings were being rendered with the `%q` format which meant they were being encapsulated by quotation marks and the color encodings were being rendered as a string.

This PR fixes both of these issues. 

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Fixes #33016 

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.4.6

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

### BUG FIXES

<!--

Write a short description of the user-facing change. Examples:

- `terraform show -json`: Fixed crash with sensitive set values.
- When rendering a diff, Terraform now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 

- Fix bug when rendering plans that include null strings
- Fix bug when rendering plans that include unknown values in maps
