### PR TITLE
feat(ipincidr): add ipincidr function

### DIFF
--- a/internal/lang/funcs/cidr.go
+++ b/internal/lang/funcs/cidr.go
@@ -3,6 +3,7 @@ package funcs
 import (
 	"fmt"
 	"math/big"
+	"net"
 
 	"github.com/apparentlymart/go-cidr/cidr"
 	"github.com/hashicorp/terraform/internal/ipaddr"
@@ -190,6 +191,31 @@ var CidrSubnetsFunc = function.New(&function.Spec{
 	},
 })
 
+// IpInCIDRSubnetFunc returns true if a specified IP address is within a give CIDR subnet.
+var IpInCIDRSubnetFunc = function.New(&function.Spec{
+	Params: []function.Parameter{
+		{
+			Name: "ip",
+			Type: cty.String,
+		},
+		{
+			Name: "cidr_subnet",
+			Type: cty.String,
+		},
+	},
+	Type: function.StaticReturnType(cty.Bool),
+	Impl: func(args []cty.Value, retType cty.Type) (ret cty.Value, err error) {
+		_, cidr, err := net.ParseCIDR(args[1].AsString())
+		if err != nil {
+			return cty.UnknownVal(cty.Bool), function.NewArgErrorf(0, "invalid CIDR expression: %s", err)
+		}
+
+		ip := net.ParseIP(args[0].AsString())
+
+		return cty.BoolVal(cidr.Contains(ip)), nil
+	},
+})
+
 // CidrHost calculates a full host IP address within a given IP network address prefix.
 func CidrHost(prefix, hostnum cty.Value) (cty.Value, error) {
 	return CidrHostFunc.Call([]cty.Value{prefix, hostnum})
@@ -212,4 +238,9 @@ func CidrSubnets(prefix cty.Value, newbits ...cty.Value) (cty.Value, error) {
 	args[0] = prefix
 	copy(args[1:], newbits)
 	return CidrSubnetsFunc.Call(args)
+}
+
+// IpInCIDRSubnet returns true if a specified IP address is within a give CIDR subnet.
+func IpInCIDRSubnet(ip, cidrSubnet cty.Value) (cty.Value, error) {
+	return IpInCIDRSubnetFunc.Call([]cty.Value{ip, cidrSubnet})
 }

--- a/internal/lang/funcs/descriptions.go
+++ b/internal/lang/funcs/descriptions.go
@@ -228,6 +228,10 @@ var DescriptionList = map[string]descriptionEntry{
 		Description:      "`index` finds the element index for a given value in a list.",
 		ParamDescription: []string{"", ""},
 	},
+	"ipincidr": {
+		Description:      "`ipincidr` returns true if a given IP address is within a specified CIDR subnet.",
+		ParamDescription: []string{"", ""},
+	},
 	"join": {
 		Description: "`join` produces a string by concatenating together all elements of a given list of strings with the given delimiter.",
 		ParamDescription: []string{

--- a/internal/lang/functions.go
+++ b/internal/lang/functions.go
@@ -78,6 +78,7 @@ func (s *Scope) Functions() map[string]function.Function {
 			"formatlist":       stdlib.FormatListFunc,
 			"indent":           stdlib.IndentFunc,
 			"index":            funcs.IndexFunc, // stdlib.IndexFunc is not compatible
+			"ipincidr":         funcs.IpInCIDRSubnetFunc,
 			"join":             stdlib.JoinFunc,
 			"jsondecode":       stdlib.JSONDecodeFunc,
 			"jsonencode":       stdlib.JSONEncodeFunc,

--- a/internal/lang/functions_test.go
+++ b/internal/lang/functions_test.go
@@ -508,6 +508,17 @@ func TestFunctions(t *testing.T) {
 			},
 		},
 
+		"ipincidr": {
+			{
+				`ipincidr("10.100.33.100", "10.100.33.0/24")`,
+				cty.BoolVal(true),
+			},
+			{
+				`ipincidr("10.100.33.100", "10.100.35.0/24")`,
+				cty.BoolVal(false),
+			},
+		},
+
 		"join": {
 			{
 				`join(" ", ["Hello", "World"])`,


### PR DESCRIPTION
Hi guys, 

I wanted to hear your feedback about the function `ipincidr`, which checks whether a specified IP is in a given CIDR subnet.

This function would be especially useful for pre/postconditions, where you would check whether a valid subnet/ip combination is correct:

```hcl
terraform {}

locals {
    ip = "10.100.32.100"
    cidr = "172.16.0.0/16"
}

resource "null_resource" "ip_in_cidr" {

    lifecycle {
        precondition {
        condition     = ipincidr(local.ip, local.cidr)
        error_message = "The IP must be within the specified CIDR subnet."
        }
    }
}
```

which would fail in

```

Planning failed. Terraform encountered an error while generating this plan.

╷
│ Error: Resource precondition failed
│ 
│   on main.tf line 12, in resource "null_resource" "ooo":
│   12:         condition     = ipincidr(local.ip, local.cidr)
│     ├────────────────
│     │ local.cidr is "172.16.0.0/16"
│     │ local.ip is "10.100.32.100"
│ 
│ The IP must be within the specified CIDR subnet.
```

If that is something that would be interesting, I can finish the remaining documentional todos and changes.