### PR TITLE
Add a default value for networks variable for flatten example

### DIFF
--- a/website/docs/language/functions/flatten.mdx
+++ b/website/docs/language/functions/flatten.mdx
@@ -46,6 +46,38 @@ variable "networks" {
     cidr_block = string
     subnets    = map(object({ cidr_block = string }))
   }))
+  default = {
+    "private" = {
+      cidr_block = "10.1.0.0/16"
+      subnets = {
+        "db1" = {
+          cidr_block = "10.1.0.1/16"
+        }
+        "db2" = {
+          cidr_block = "10.1.0.2/16"
+        }
+      }
+    },
+    "public" = {
+      cidr_block = "10.1.1.0/16"
+      subnets = {
+        "webserver" = {
+          cidr_block = "10.1.1.1/16"
+        }
+        "email_server" = {
+          cidr_block = "10.1.1.2/16"
+        }
+      }
+    }
+    "dmz" = {
+      cidr_block = "10.1.2.0/16"
+      subnets = {
+        "firewall" = {
+          cidr_block = "10.1.2.1/16"
+        }
+      }
+    }
+  }
 }
 ```
 


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->
Add a sensible default value for `networks` variable for `flatten` function

Fixes #33017 

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.4.x

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

### ENHANCEMENTS

<!--

Write a short description of the user-facing change. Examples:

- `terraform show -json`: Fixed crash with sensitive set values.
- When rendering a diff, Terraform now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 

- Affects https://github.com/hashicorp/terraform/blob/main/website/docs/language/functions/flatten.mdx
- Expands [Flattening nested structures for `for_each`](https://developer.hashicorp.com/terraform/language/functions/flatten#flattening-nested-structures-for-for_each) section by adding a default value for `networks` variable example
- CIDR ranges are dummy
