### PR TITLE
prune unused providers within modules

### DIFF
--- a/internal/terraform/transform_destroy_edge.go
+++ b/internal/terraform/transform_destroy_edge.go
@@ -348,10 +348,18 @@ func (t *pruneUnusedNodesTransformer) Transform(g *Graph) error {
 					}
 
 				case GraphNodeProvider:
-					// Providers that may have been required by expansion nodes
-					// that we no longer need can also be removed.
-					if g.UpEdges(n).Len() > 0 {
-						return
+					// Only keep providers for evaluation if they have
+					// resources to handle.
+					// The provider transformers removed most unused providers
+					// earlier, however there may be more to prune now based on
+					// targeting or a destroy with no related instances in the
+					// state.
+					des, _ := g.Descendents(n)
+					for _, v := range des {
+						switch v.(type) {
+						case GraphNodeProviderConsumer:
+							return
+						}
 					}
 
 				default:


### PR DESCRIPTION
The logic used to prune unused providers was only taking into account the common case of providers in the root module. The quick check of looking for up edges doesn't work within a module, because the module structures will create non-resource nodes connected to the providers. Use a deeper check of looking for any dependent resources which may require that provider to be configured.