### PR TITLE
Propagate unknown and sensitive metadata to dynamic attributes

### DIFF
--- a/internal/command/jsonformat/collections/map.go
+++ b/internal/command/jsonformat/collections/map.go
@@ -7,7 +7,7 @@ import (
 
 type ProcessKey func(key string) computed.Diff
 
-func TransformMap[Input any](before, after map[string]Input, process ProcessKey) (map[string]computed.Diff, plans.Action) {
+func TransformMap[Input any](before, after map[string]Input, keys []string, process ProcessKey) (map[string]computed.Diff, plans.Action) {
 	current := plans.NoOp
 	if before != nil && after == nil {
 		current = plans.Delete
@@ -17,16 +17,7 @@ func TransformMap[Input any](before, after map[string]Input, process ProcessKey)
 	}
 
 	elements := make(map[string]computed.Diff)
-	for key := range before {
-		elements[key] = process(key)
-		current = CompareActions(current, elements[key].Action)
-	}
-
-	for key := range after {
-		if _, ok := elements[key]; ok {
-			// Then we've already processed this key in the before.
-			continue
-		}
+	for _, key := range keys {
 		elements[key] = process(key)
 		current = CompareActions(current, elements[key].Action)
 	}

--- a/internal/command/jsonformat/computed/renderers/json.go
+++ b/internal/command/jsonformat/computed/renderers/json.go
@@ -25,6 +25,12 @@ func RendererJsonOpts() jsondiff.JsonOpts {
 		Array: func(elements []computed.Diff, action plans.Action) computed.Diff {
 			return computed.NewDiff(List(elements), action, false)
 		},
+		Unknown: func(diff computed.Diff, action plans.Action) computed.Diff {
+			return computed.NewDiff(Unknown(diff), action, false)
+		},
+		Sensitive: func(diff computed.Diff, beforeSensitive bool, afterSensitive bool, action plans.Action) computed.Diff {
+			return computed.NewDiff(Sensitive(diff, beforeSensitive, afterSensitive), action, false)
+		},
 		TypeChange: func(before, after computed.Diff, action plans.Action) computed.Diff {
 			return computed.NewDiff(TypeChange(before, after), action, false)
 		},

--- a/internal/command/jsonformat/computed/renderers/primitive.go
+++ b/internal/command/jsonformat/computed/renderers/primitive.go
@@ -2,6 +2,7 @@ package renderers
 
 import (
 	"fmt"
+	"github.com/hashicorp/terraform/internal/command/jsonformat/structured"
 	"math/big"
 	"strings"
 
@@ -183,7 +184,17 @@ func (renderer primitiveRenderer) renderStringDiff(diff computed.Diff, indent in
 }
 
 func (renderer primitiveRenderer) renderStringDiffAsJson(diff computed.Diff, indent int, opts computed.RenderHumanOpts, before evaluatedString, after evaluatedString) string {
-	jsonDiff := RendererJsonOpts().Transform(before.Json, after.Json, diff.Action != plans.Create, diff.Action != plans.Delete, attribute_path.AlwaysMatcher())
+	jsonDiff := RendererJsonOpts().Transform(structured.Change{
+		BeforeExplicit:     diff.Action != plans.Create,
+		AfterExplicit:      diff.Action != plans.Delete,
+		Before:             before.Json,
+		After:              after.Json,
+		Unknown:            false,
+		BeforeSensitive:    false,
+		AfterSensitive:     false,
+		ReplacePaths:       attribute_path.Empty(false),
+		RelevantAttributes: attribute_path.AlwaysMatcher(),
+	})
 
 	action := diff.Action
 

--- a/internal/command/jsonformat/differ/output.go
+++ b/internal/command/jsonformat/differ/output.go
@@ -18,5 +18,5 @@ func ComputeDiffForOutput(change structured.Change) computed.Diff {
 	}
 
 	jsonOpts := renderers.RendererJsonOpts()
-	return jsonOpts.Transform(change.Before, change.After, change.BeforeExplicit, change.AfterExplicit, change.RelevantAttributes)
+	return jsonOpts.Transform(change)
 }

--- a/internal/command/jsonformat/differ/sensitive.go
+++ b/internal/command/jsonformat/differ/sensitive.go
@@ -13,66 +13,31 @@ import (
 type CreateSensitiveRenderer func(computed.Diff, bool, bool) computed.DiffRenderer
 
 func checkForSensitiveType(change structured.Change, ctype cty.Type) (computed.Diff, bool) {
-	return checkForSensitive(change, renderers.Sensitive, func(value structured.Change) computed.Diff {
-		return ComputeDiffForType(value, ctype)
-	})
+	return change.CheckForSensitive(
+		func(value structured.Change) computed.Diff {
+			return ComputeDiffForType(value, ctype)
+		}, func(inner computed.Diff, beforeSensitive, afterSensitive bool, action plans.Action) computed.Diff {
+			return computed.NewDiff(renderers.Sensitive(inner, beforeSensitive, afterSensitive), action, change.ReplacePaths.Matches())
+		},
+	)
 }
 
 func checkForSensitiveNestedAttribute(change structured.Change, attribute *jsonprovider.NestedType) (computed.Diff, bool) {
-	return checkForSensitive(change, renderers.Sensitive, func(value structured.Change) computed.Diff {
-		return computeDiffForNestedAttribute(value, attribute)
-	})
+	return change.CheckForSensitive(
+		func(value structured.Change) computed.Diff {
+			return computeDiffForNestedAttribute(value, attribute)
+		}, func(inner computed.Diff, beforeSensitive, afterSensitive bool, action plans.Action) computed.Diff {
+			return computed.NewDiff(renderers.Sensitive(inner, beforeSensitive, afterSensitive), action, change.ReplacePaths.Matches())
+		},
+	)
 }
 
 func checkForSensitiveBlock(change structured.Change, block *jsonprovider.Block) (computed.Diff, bool) {
-	return checkForSensitive(change, renderers.SensitiveBlock, func(value structured.Change) computed.Diff {
-		return ComputeDiffForBlock(value, block)
-	})
-}
-
-func checkForSensitive(change structured.Change, create CreateSensitiveRenderer, computedDiff func(value structured.Change) computed.Diff) (computed.Diff, bool) {
-	beforeSensitive := change.IsBeforeSensitive()
-	afterSensitive := change.IsAfterSensitive()
-
-	if !beforeSensitive && !afterSensitive {
-		return computed.Diff{}, false
-	}
-
-	// We are still going to give the change the contents of the actual change.
-	// So we create a new Change with everything matching the current value,
-	// except for the sensitivity.
-	//
-	// The change can choose what to do with this information, in most cases
-	// it will just be ignored in favour of printing `(sensitive value)`.
-
-	value := structured.Change{
-		BeforeExplicit:     change.BeforeExplicit,
-		AfterExplicit:      change.AfterExplicit,
-		Before:             change.Before,
-		After:              change.After,
-		Unknown:            change.Unknown,
-		BeforeSensitive:    false,
-		AfterSensitive:     false,
-		ReplacePaths:       change.ReplacePaths,
-		RelevantAttributes: change.RelevantAttributes,
-	}
-
-	inner := computedDiff(value)
-
-	action := inner.Action
-
-	sensitiveStatusChanged := beforeSensitive != afterSensitive
-
-	// nullNoOp is a stronger NoOp, where not only is there no change happening
-	// but the before and after values are not explicitly set and are both
-	// null. This will override even the sensitive state changing.
-	nullNoOp := change.Before == nil && !change.BeforeExplicit && change.After == nil && !change.AfterExplicit
-
-	if action == plans.NoOp && sensitiveStatusChanged && !nullNoOp {
-		// Let's override this, since it means the sensitive status has changed
-		// rather than the actual content of the value.
-		action = plans.Update
-	}
-
-	return computed.NewDiff(create(inner, beforeSensitive, afterSensitive), action, change.ReplacePaths.Matches()), true
+	return change.CheckForSensitive(
+		func(value structured.Change) computed.Diff {
+			return ComputeDiffForBlock(value, block)
+		}, func(inner computed.Diff, beforeSensitive, afterSensitive bool, action plans.Action) computed.Diff {
+			return computed.NewDiff(renderers.SensitiveBlock(inner, beforeSensitive, afterSensitive), action, change.ReplacePaths.Matches())
+		},
+	)
 }

--- a/internal/command/jsonformat/differ/unknown.go
+++ b/internal/command/jsonformat/differ/unknown.go
@@ -12,10 +12,14 @@ import (
 )
 
 func checkForUnknownType(change structured.Change, ctype cty.Type) (computed.Diff, bool) {
-	return checkForUnknown(change, false, func(value structured.Change) computed.Diff {
-		return ComputeDiffForType(value, ctype)
-	})
+	return change.CheckForUnknown(
+		false,
+		processUnknown,
+		createProcessUnknownWithBefore(func(value structured.Change) computed.Diff {
+			return ComputeDiffForType(value, ctype)
+		}))
 }
+
 func checkForUnknownNestedAttribute(change structured.Change, attribute *jsonprovider.NestedType) (computed.Diff, bool) {
 
 	// We want our child attributes to show up as computed instead of deleted.
@@ -25,9 +29,12 @@ func checkForUnknownNestedAttribute(change structured.Change, attribute *jsonpro
 		childUnknown[key] = true
 	}
 
-	return checkForUnknown(change, childUnknown, func(value structured.Change) computed.Diff {
-		return computeDiffForNestedAttribute(value, attribute)
-	})
+	return change.CheckForUnknown(
+		childUnknown,
+		processUnknown,
+		createProcessUnknownWithBefore(func(value structured.Change) computed.Diff {
+			return computeDiffForNestedAttribute(value, attribute)
+		}))
 }
 
 func checkForUnknownBlock(change structured.Change, block *jsonprovider.Block) (computed.Diff, bool) {
@@ -39,37 +46,20 @@ func checkForUnknownBlock(change structured.Change, block *jsonprovider.Block) (
 		childUnknown[key] = true
 	}
 
-	return checkForUnknown(change, childUnknown, func(value structured.Change) computed.Diff {
-		return ComputeDiffForBlock(value, block)
-	})
+	return change.CheckForUnknown(
+		childUnknown,
+		processUnknown,
+		createProcessUnknownWithBefore(func(value structured.Change) computed.Diff {
+			return ComputeDiffForBlock(value, block)
+		}))
 }
 
-func checkForUnknown(change structured.Change, childUnknown interface{}, computeDiff func(value structured.Change) computed.Diff) (computed.Diff, bool) {
-	unknown := change.IsUnknown()
+func processUnknown(current structured.Change) computed.Diff {
+	return asDiff(current, renderers.Unknown(computed.Diff{}))
+}
 
-	if !unknown {
-		return computed.Diff{}, false
+func createProcessUnknownWithBefore(computeDiff func(value structured.Change) computed.Diff) structured.ProcessUnknownWithBefore {
+	return func(current structured.Change, before structured.Change) computed.Diff {
+		return asDiff(current, renderers.Unknown(computeDiff(before)))
 	}
-
-	// No matter what we do here, we want to treat the after value as explicit.
-	// This is because it is going to be null in the value, and we don't want
-	// the functions in this package to assume this means it has been deleted.
-	change.AfterExplicit = true
-
-	if change.Before == nil {
-		return asDiff(change, renderers.Unknown(computed.Diff{})), true
-	}
-
-	// If we get here, then we have a before value. We're going to model a
-	// delete operation and our renderer later can render the overall change
-	// accurately.
-
-	beforeValue := structured.Change{
-		Before:             change.Before,
-		BeforeSensitive:    change.BeforeSensitive,
-		Unknown:            childUnknown,
-		ReplacePaths:       change.ReplacePaths,
-		RelevantAttributes: change.RelevantAttributes,
-	}
-	return asDiff(change, renderers.Unknown(computeDiff(beforeValue))), true
 }

--- a/internal/command/jsonformat/jsondiff/diff.go
+++ b/internal/command/jsonformat/jsondiff/diff.go
@@ -1,19 +1,21 @@
 package jsondiff
 
 import (
+	"github.com/hashicorp/terraform/internal/command/jsonformat/structured"
 	"reflect"
 
 	"github.com/zclconf/go-cty/cty"
 
 	"github.com/hashicorp/terraform/internal/command/jsonformat/collections"
 	"github.com/hashicorp/terraform/internal/command/jsonformat/computed"
-	"github.com/hashicorp/terraform/internal/command/jsonformat/structured/attribute_path"
 	"github.com/hashicorp/terraform/internal/plans"
 )
 
 type TransformPrimitiveJson func(before, after interface{}, ctype cty.Type, action plans.Action) computed.Diff
 type TransformObjectJson func(map[string]computed.Diff, plans.Action) computed.Diff
 type TransformArrayJson func([]computed.Diff, plans.Action) computed.Diff
+type TransformUnknownJson func(computed.Diff, plans.Action) computed.Diff
+type TransformSensitiveJson func(computed.Diff, bool, bool, plans.Action) computed.Diff
 type TransformTypeChangeJson func(before, after computed.Diff, action plans.Action) computed.Diff
 
 // JsonOpts defines the external callback functions that callers should
@@ -22,74 +24,64 @@ type JsonOpts struct {
 	Primitive  TransformPrimitiveJson
 	Object     TransformObjectJson
 	Array      TransformArrayJson
+	Unknown    TransformUnknownJson
+	Sensitive  TransformSensitiveJson
 	TypeChange TransformTypeChangeJson
 }
 
 // Transform accepts a generic before and after value that is assumed to be JSON
 // formatted and transforms it into a computed.Diff, using the callbacks
 // supplied in the JsonOpts class.
-func (opts JsonOpts) Transform(before, after interface{}, beforeExplicit, afterExplicit bool, relevantAttributes attribute_path.Matcher) computed.Diff {
-	beforeType := GetType(before)
-	afterType := GetType(after)
+func (opts JsonOpts) Transform(change structured.Change) computed.Diff {
+	if sensitive, ok := opts.processSensitive(change); ok {
+		return sensitive
+	}
 
-	deleted := afterType == Null && !afterExplicit
-	created := beforeType == Null && !beforeExplicit
+	if unknown, ok := opts.processUnknown(change); ok {
+		return unknown
+	}
+
+	beforeType := GetType(change.Before)
+	afterType := GetType(change.After)
+
+	deleted := afterType == Null && !change.AfterExplicit
+	created := beforeType == Null && !change.BeforeExplicit
 
 	if beforeType == afterType || (created || deleted) {
 		targetType := beforeType
 		if targetType == Null {
 			targetType = afterType
 		}
-		return opts.processUpdate(before, after, beforeExplicit, afterExplicit, targetType, relevantAttributes)
+		return opts.processUpdate(change, targetType)
 	}
 
-	b := opts.processUpdate(before, nil, beforeExplicit, false, beforeType, relevantAttributes)
-	a := opts.processUpdate(nil, after, false, afterExplicit, afterType, relevantAttributes)
+	b := opts.processUpdate(change.AsDelete(), beforeType)
+	a := opts.processUpdate(change.AsCreate(), afterType)
 	return opts.TypeChange(b, a, plans.Update)
 }
 
-func (opts JsonOpts) processUpdate(before, after interface{}, beforeExplicit, afterExplicit bool, jtype Type, relevantAttributes attribute_path.Matcher) computed.Diff {
+func (opts JsonOpts) processUpdate(change structured.Change, jtype Type) computed.Diff {
 	switch jtype {
 	case Null:
-		return opts.processPrimitive(before, after, beforeExplicit, afterExplicit, cty.NilType)
+		return opts.processPrimitive(change, cty.NilType)
 	case Bool:
-		return opts.processPrimitive(before, after, beforeExplicit, afterExplicit, cty.Bool)
+		return opts.processPrimitive(change, cty.Bool)
 	case String:
-		return opts.processPrimitive(before, after, beforeExplicit, afterExplicit, cty.String)
+		return opts.processPrimitive(change, cty.String)
 	case Number:
-		return opts.processPrimitive(before, after, beforeExplicit, afterExplicit, cty.Number)
+		return opts.processPrimitive(change, cty.Number)
 	case Object:
-		var b, a map[string]interface{}
-
-		if before != nil {
-			b = before.(map[string]interface{})
-		}
-
-		if after != nil {
-			a = after.(map[string]interface{})
-		}
-
-		return opts.processObject(b, a, relevantAttributes)
+		return opts.processObject(change.AsMap())
 	case Array:
-		var b, a []interface{}
-
-		if before != nil {
-			b = before.([]interface{})
-		}
-
-		if after != nil {
-			a = after.([]interface{})
-		}
-
-		return opts.processArray(b, a)
+		return opts.processArray(change.AsSlice())
 	default:
 		panic("unrecognized json type: " + jtype)
 	}
 }
 
-func (opts JsonOpts) processPrimitive(before, after interface{}, beforeExplicit, afterExplicit bool, ctype cty.Type) computed.Diff {
-	beforeMissing := before == nil && !beforeExplicit
-	afterMissing := after == nil && !afterExplicit
+func (opts JsonOpts) processPrimitive(change structured.Change, ctype cty.Type) computed.Diff {
+	beforeMissing := change.Before == nil && !change.BeforeExplicit
+	afterMissing := change.After == nil && !change.AfterExplicit
 
 	var action plans.Action
 	switch {
@@ -97,61 +89,60 @@ func (opts JsonOpts) processPrimitive(before, after interface{}, beforeExplicit,
 		action = plans.Create
 	case !beforeMissing && afterMissing:
 		action = plans.Delete
-	case reflect.DeepEqual(before, after):
+	case reflect.DeepEqual(change.Before, change.After):
 		action = plans.NoOp
 	default:
 		action = plans.Update
 	}
 
-	return opts.Primitive(before, after, ctype, action)
+	return opts.Primitive(change.Before, change.After, ctype, action)
 }
 
-func (opts JsonOpts) processArray(before, after []interface{}) computed.Diff {
+func (opts JsonOpts) processArray(change structured.ChangeSlice) computed.Diff {
 	processIndices := func(beforeIx, afterIx int) computed.Diff {
-		var b, a interface{}
-
-		beforeExplicit := false
-		afterExplicit := false
-
-		if beforeIx >= 0 && beforeIx < len(before) {
-			b = before[beforeIx]
-			beforeExplicit = true
-		}
-		if afterIx >= 0 && afterIx < len(after) {
-			a = after[afterIx]
-			afterExplicit = true
-		}
-
 		// It's actually really difficult to render the diffs when some indices
 		// within a list are relevant and others aren't. To make this simpler
-		// we just treat all children of a relevant list as also relevant.
+		// we just treat all children of a relevant list as also relevant, so we
+		// ignore the relevant attributes field.
 		//
 		// Interestingly the terraform plan builder also agrees with this, and
 		// never sets relevant attributes beneath lists or sets. We're just
 		// going to enforce this logic here as well. If the list is relevant
 		// (decided elsewhere), then every element in the list is also relevant.
-		return opts.Transform(b, a, beforeExplicit, afterExplicit, attribute_path.AlwaysMatcher())
+		return opts.Transform(change.GetChild(beforeIx, afterIx))
 	}
 
 	isObjType := func(value interface{}) bool {
 		return GetType(value) == Object
 	}
 
-	return opts.Array(collections.TransformSlice(before, after, processIndices, isObjType))
+	return opts.Array(collections.TransformSlice(change.Before, change.After, processIndices, isObjType))
 }
 
-func (opts JsonOpts) processObject(before, after map[string]interface{}, relevantAttributes attribute_path.Matcher) computed.Diff {
-	return opts.Object(collections.TransformMap(before, after, func(key string) computed.Diff {
-		beforeChild, beforeExplicit := before[key]
-		afterChild, afterExplicit := after[key]
-
-		childRelevantAttributes := relevantAttributes.GetChildWithKey(key)
-		if !childRelevantAttributes.MatchesPartial() {
-			// Mark non-relevant attributes as unchanged.
-			afterChild = beforeChild
-			afterExplicit = beforeExplicit
+func (opts JsonOpts) processObject(change structured.ChangeMap) computed.Diff {
+	return opts.Object(collections.TransformMap(change.Before, change.After, change.AllKeys(), func(key string) computed.Diff {
+		child := change.GetChild(key)
+		if !child.RelevantAttributes.MatchesPartial() {
+			child = child.AsNoOp()
 		}
 
-		return opts.Transform(beforeChild, afterChild, beforeExplicit, afterExplicit, childRelevantAttributes)
+		return opts.Transform(child)
 	}))
+}
+
+func (opts JsonOpts) processUnknown(change structured.Change) (computed.Diff, bool) {
+	return change.CheckForUnknown(
+		false,
+		func(current structured.Change) computed.Diff {
+			return opts.Unknown(computed.Diff{}, plans.Create)
+		}, func(current structured.Change, before structured.Change) computed.Diff {
+			return opts.Unknown(opts.Transform(before), plans.Update)
+		},
+	)
+}
+
+func (opts JsonOpts) processSensitive(change structured.Change) (computed.Diff, bool) {
+	return change.CheckForSensitive(opts.Transform, func(inner computed.Diff, beforeSensitive, afterSensitive bool, action plans.Action) computed.Diff {
+		return opts.Sensitive(inner, beforeSensitive, afterSensitive, action)
+	})
 }

--- a/internal/command/jsonformat/structured/change.go
+++ b/internal/command/jsonformat/structured/change.go
@@ -162,8 +162,6 @@ func FromJsonViewsOutput(output viewsjson.Output) Change {
 	}
 }
 
-// AsDiff
-
 // CalculateAction does a very simple analysis to make the best guess at the
 // action this change describes. For complex types such as objects, maps, lists,
 // or sets it is likely more efficient to work out the action directly instead
@@ -219,6 +217,40 @@ func (change Change) AsNoOp() Change {
 		Unknown:            false,
 		BeforeSensitive:    change.BeforeSensitive,
 		AfterSensitive:     change.BeforeSensitive,
+		ReplacePaths:       change.ReplacePaths,
+		RelevantAttributes: change.RelevantAttributes,
+	}
+}
+
+// AsDelete returns the current change as if it is a Delete operation.
+//
+// Basically it replaces all the after values with nil or false.
+func (change Change) AsDelete() Change {
+	return Change{
+		BeforeExplicit:     change.BeforeExplicit,
+		AfterExplicit:      false,
+		Before:             change.Before,
+		After:              nil,
+		Unknown:            nil,
+		BeforeSensitive:    change.BeforeSensitive,
+		AfterSensitive:     nil,
+		ReplacePaths:       change.ReplacePaths,
+		RelevantAttributes: change.RelevantAttributes,
+	}
+}
+
+// AsCreate returns the current change as if it is a Create operation.
+//
+// Basically it replaces all the before values with nil or false.
+func (change Change) AsCreate() Change {
+	return Change{
+		BeforeExplicit:     false,
+		AfterExplicit:      change.AfterExplicit,
+		Before:             nil,
+		After:              change.After,
+		Unknown:            change.Unknown,
+		BeforeSensitive:    nil,
+		AfterSensitive:     change.AfterSensitive,
 		ReplacePaths:       change.ReplacePaths,
 		RelevantAttributes: change.RelevantAttributes,
 	}

--- a/internal/command/jsonformat/structured/sensitive.go
+++ b/internal/command/jsonformat/structured/sensitive.go
@@ -1,5 +1,13 @@
 package structured
 
+import (
+	"github.com/hashicorp/terraform/internal/command/jsonformat/computed"
+	"github.com/hashicorp/terraform/internal/plans"
+)
+
+type ProcessSensitiveInner func(change Change) computed.Diff
+type CreateSensitiveDiff func(inner computed.Diff, beforeSensitive, afterSensitive bool, action plans.Action) computed.Diff
+
 func (change Change) IsBeforeSensitive() bool {
 	if sensitive, ok := change.BeforeSensitive.(bool); ok {
 		return sensitive
@@ -12,4 +20,70 @@ func (change Change) IsAfterSensitive() bool {
 		return sensitive
 	}
 	return false
+}
+
+// CheckForSensitive is a helper function that handles all common functionality
+// for processing a sensitive value.
+//
+// It returns the computed sensitive diff and true if this value was sensitive
+// and needs to be rendered as such, otherwise it returns the second return
+// value as false and the first value can be discarded.
+//
+// The actual processing of sensitive values happens within the
+// ProcessSensitiveInner and CreateSensitiveDiff functions. Callers should
+// implement these functions as appropriate when using this function.
+//
+// The ProcessSensitiveInner function should simply return a computed.Diff for
+// the provided Change. The provided Change will be the same as the original
+// change but with the sensitive metadata removed. The new inner diff is then
+// passed into the actual CreateSensitiveDiff function which should return the
+// actual sensitive diff.
+//
+// We include the inner change into the sensitive diff as a way to let the
+// sensitive renderer have as much information as possible, while still letting
+// it do the actual rendering.
+func (change Change) CheckForSensitive(processInner ProcessSensitiveInner, createDiff CreateSensitiveDiff) (computed.Diff, bool) {
+	beforeSensitive := change.IsBeforeSensitive()
+	afterSensitive := change.IsAfterSensitive()
+
+	if !beforeSensitive && !afterSensitive {
+		return computed.Diff{}, false
+	}
+
+	// We are still going to give the change the contents of the actual change.
+	// So we create a new Change with everything matching the current value,
+	// except for the sensitivity.
+	//
+	// The change can choose what to do with this information, in most cases
+	// it will just be ignored in favour of printing `(sensitive value)`.
+
+	value := Change{
+		BeforeExplicit:     change.BeforeExplicit,
+		AfterExplicit:      change.AfterExplicit,
+		Before:             change.Before,
+		After:              change.After,
+		Unknown:            change.Unknown,
+		BeforeSensitive:    false,
+		AfterSensitive:     false,
+		ReplacePaths:       change.ReplacePaths,
+		RelevantAttributes: change.RelevantAttributes,
+	}
+
+	inner := processInner(value)
+
+	action := inner.Action
+	sensitiveStatusChanged := beforeSensitive != afterSensitive
+
+	// nullNoOp is a stronger NoOp, where not only is there no change happening
+	// but the before and after values are not explicitly set and are both
+	// null. This will override even the sensitive state changing.
+	nullNoOp := change.Before == nil && !change.BeforeExplicit && change.After == nil && !change.AfterExplicit
+
+	if action == plans.NoOp && sensitiveStatusChanged && !nullNoOp {
+		// Let's override this, since it means the sensitive status has changed
+		// rather than the actual content of the value.
+		action = plans.Update
+	}
+
+	return createDiff(inner, beforeSensitive, afterSensitive, action), true
 }

--- a/internal/command/jsonformat/structured/unknown.go
+++ b/internal/command/jsonformat/structured/unknown.go
@@ -1,8 +1,62 @@
 package structured
 
+import (
+	"github.com/hashicorp/terraform/internal/command/jsonformat/computed"
+)
+
+type ProcessUnknown func(current Change) computed.Diff
+type ProcessUnknownWithBefore func(current Change, before Change) computed.Diff
+
 func (change Change) IsUnknown() bool {
 	if unknown, ok := change.Unknown.(bool); ok {
 		return unknown
 	}
 	return false
+}
+
+// CheckForUnknown is a helper function that handles all common functionality
+// for processing an unknown value.
+//
+// It returns the computed unknown diff and true if this value was unknown and
+// needs to be rendered as such, otherwise it returns the second return value as
+// false and the first return value should be discarded.
+//
+// The actual processing of unknown values happens in the ProcessUnknown and
+// ProcessUnknownWithBefore functions. If a value is unknown and is being
+// created, the ProcessUnknown function is called and the caller should decide
+// how to create the unknown value. If a value is being updated the
+// ProcessUnknownWithBefore function is called and the function provides the
+// before value as if it is being deleted for the caller to handle. Note that
+// values being deleted will never be marked as unknown so this case isn't
+// handled.
+//
+// The childUnknown argument is meant to allow callers with extra information
+// about the type being processed to provide a list of known children that might
+// not be present in the before or after values. These values will be propagated
+// as the unknown values in the before value should it be needed.
+func (change Change) CheckForUnknown(childUnknown interface{}, process ProcessUnknown, processBefore ProcessUnknownWithBefore) (computed.Diff, bool) {
+	unknown := change.IsUnknown()
+
+	if !unknown {
+		return computed.Diff{}, false
+	}
+
+	// No matter what we do here, we want to treat the after value as explicit.
+	// This is because it is going to be null in the value, and we don't want
+	// the functions in this package to assume this means it has been deleted.
+	change.AfterExplicit = true
+
+	if change.Before == nil {
+		return process(change), true
+	}
+
+	// If we get here, then we have a before value. We're going to model a
+	// delete operation and our renderer later can render the overall change
+	// accurately.
+	before := change.AsDelete()
+
+	// We also let our callers override the unknown values in any before, this
+	// is the renderers can display them as being computed instead of deleted.
+	before.Unknown = childUnknown
+	return processBefore(change, before), true
 }


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

This PR updates the jsonformat/jsondiff package to include and process the sensitive and computed metadata about the given change.

The package now handles Change objects directly, something that is only possible with the refactor in #33054. This is a good change because now it is actually processing all the information in the change instead of simple subset as it was previously.

The change also moves the logic for processing unknown and sensitive types into the shared structured package so that the differ and the jsondiff package can share the logic.

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Fixes #33056 

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.4.6

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

### BUG FIXES

<!--

Write a short description of the user-facing change. Examples:

- `terraform show -json`: Fixed crash with sensitive set values.
- When rendering a diff, Terraform now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 

-  Fix bug where the sensitive and unknown metadata wasn't being propagated to dynamic attribute types when rendering.
