### PR TITLE
Make the unknown attribute renderer consider the force replacement metadata

### DIFF
--- a/internal/command/jsonformat/computed/renderers/renderer_test.go
+++ b/internal/command/jsonformat/computed/renderers/renderer_test.go
@@ -408,6 +408,25 @@ jsonencode(
 			},
 			expected: "0 -> (known after apply)",
 		},
+		"computed_create_forces_replacement": {
+			diff: computed.Diff{
+				Renderer: Unknown(computed.Diff{}),
+				Action:   plans.Create,
+				Replace:  true,
+			},
+			expected: "(known after apply) # forces replacement",
+		},
+		"computed_update_forces_replacement": {
+			diff: computed.Diff{
+				Renderer: Unknown(computed.Diff{
+					Renderer: Primitive(0.0, nil, cty.Number),
+					Action:   plans.Delete,
+				}),
+				Action:  plans.Update,
+				Replace: true,
+			},
+			expected: "0 -> (known after apply) # forces replacement",
+		},
 		"object_created": {
 			diff: computed.Diff{
 				Renderer: Object(map[string]computed.Diff{}),

--- a/internal/command/jsonformat/computed/renderers/unknown.go
+++ b/internal/command/jsonformat/computed/renderers/unknown.go
@@ -24,10 +24,10 @@ type unknownRenderer struct {
 
 func (renderer unknownRenderer) RenderHuman(diff computed.Diff, indent int, opts computed.RenderHumanOpts) string {
 	if diff.Action == plans.Create {
-		return "(known after apply)"
+		return fmt.Sprintf("(known after apply)%s", forcesReplacement(diff.Replace, opts))
 	}
 
 	// Never render null suffix for children of unknown changes.
 	opts.OverrideNullSuffix = true
-	return fmt.Sprintf("%s -> (known after apply)", renderer.before.RenderHuman(indent, opts))
+	return fmt.Sprintf("%s -> (known after apply)%s", renderer.before.RenderHuman(indent, opts), forcesReplacement(diff.Replace, opts))
 }


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

This PR updates the unknown renderer to include the `# force replacement` suffix when necessary. I think that was missed initially as I couldn't think of any cases where a computed attribute would cause the replacement as something else would have to have triggered the attribute to be recomputed. As the issue demonstrates I think there is something happening within `import` commands that makes this assumption incorrect.

I've added tests into the renderer package to validate this, not much else needed as the data is already being made available it just wasn't being used.

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Fixes #33041 

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.4.6

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

### BUG FIXES

<!--

Write a short description of the user-facing change. Examples:

- `terraform show -json`: Fixed crash with sensitive set values.
- When rendering a diff, Terraform now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 

-  Fixes bug where computed attributes were not being rendered with the `# forces replacement` suffix.
