### PR TITLE
Feat: Add strcontains function and documentation

### DIFF
--- a/internal/lang/funcs/string.go
+++ b/internal/lang/funcs/string.go
@@ -103,3 +103,29 @@ var ReplaceFunc = function.New(&function.Spec{
 func Replace(str, substr, replace cty.Value) (cty.Value, error) {
 	return ReplaceFunc.Call([]cty.Value{str, substr, replace})
 }
+
+// StrContainsFunc constructs a function that checks if a string contains
+// a substring using strings.Contains
+var StrContainsFunc = function.New(&function.Spec{
+	Params: []function.Parameter{
+		{
+			Name: "str",
+			Type: cty.String,
+		},
+		{
+			Name: "substr",
+			Type: cty.String,
+		},
+	},
+	Type: function.StaticReturnType(cty.Bool),
+	Impl: func(args []cty.Value, retType cty.Type) (ret cty.Value, err error) {
+		str := args[0].AsString()
+		substr := args[1].AsString()
+
+		if strings.Contains(str, substr) {
+			return cty.True, nil
+		}
+
+		return cty.False, nil
+	},
+})

--- a/internal/lang/funcs/string_test.go
+++ b/internal/lang/funcs/string_test.go
@@ -71,3 +71,66 @@ func TestReplace(t *testing.T) {
 		})
 	}
 }
+
+func TestStrContains(t *testing.T) {
+	tests := []struct {
+		String cty.Value
+		Substr cty.Value
+		Want   cty.Value
+		Err    bool
+	}{
+		{
+			cty.StringVal("hello"),
+			cty.StringVal("hel"),
+			cty.BoolVal(true),
+			false,
+		},
+		{
+			cty.StringVal("hello"),
+			cty.StringVal("lo"),
+			cty.BoolVal(true),
+			false,
+		},
+		{
+			cty.StringVal("hello1"),
+			cty.StringVal("1"),
+			cty.BoolVal(true),
+			false,
+		},
+		{
+			cty.StringVal("hello1"),
+			cty.StringVal("heo"),
+			cty.BoolVal(false),
+			false,
+		},
+		{
+			cty.StringVal("hello1"),
+			cty.NumberIntVal(1),
+			cty.UnknownVal(cty.Bool),
+			true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("includes(%#v, %#v)", test.String, test.Substr), func(t *testing.T) {
+			got, err := StrContains(test.String, test.Substr)
+
+			if test.Err {
+				if err == nil {
+					t.Fatal("succeeded; want error")
+				}
+				return
+			} else if err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+
+			if !got.RawEquals(test.Want) {
+				t.Errorf("wrong result\ngot:  %#v\nwant: %#v", got, test.Want)
+			}
+		})
+	}
+}
+
+func StrContains(str, substr cty.Value) (cty.Value, error) {
+	return StrContainsFunc.Call([]cty.Value{str, substr})
+}

--- a/internal/lang/functions.go
+++ b/internal/lang/functions.go
@@ -117,6 +117,7 @@ func (s *Scope) Functions() map[string]function.Function {
 			"sort":             stdlib.SortFunc,
 			"split":            stdlib.SplitFunc,
 			"startswith":       funcs.StartsWithFunc,
+			"strcontains":      funcs.StrContainsFunc,
 			"strrev":           stdlib.ReverseFunc,
 			"substr":           stdlib.SubstrFunc,
 			"sum":              funcs.SumFunc,

--- a/internal/lang/functions_test.go
+++ b/internal/lang/functions_test.go
@@ -906,6 +906,13 @@ func TestFunctions(t *testing.T) {
 			},
 		},
 
+		"strcontains": {
+			{
+				`includes("hello", "llo")`,
+				cty.BoolVal(true),
+			},
+		},
+
 		"strrev": {
 			{
 				`strrev("hello world")`,

--- a/website/docs/language/functions/strcontains.mdx
+++ b/website/docs/language/functions/strcontains.mdx
@@ -1,0 +1,25 @@
+---
+page_title: strcontains - Functions - Configuration Language
+description: |-
+  The strcontains function checks whether a given string can be found within another string.
+---
+
+# `strcontains` Function
+
+`strcontains` function checks whether a substring is within another string.
+
+```hcl
+strcontains(string, substr)
+```
+
+## Examples
+
+```
+> strcontains("hello world", "wor")
+true
+```
+
+```
+> strcontains("hello world", "wod")
+false
+```

--- a/website/layouts/language.erb
+++ b/website/layouts/language.erb
@@ -419,6 +419,10 @@
               </li>
 
               <li>
+                <a href="/docs/language/functions/strcontains.html">strcontains</a>
+              </li>
+
+              <li>
                 <a href="/docs/language/functions/strrev.html">strrev</a>
               </li>
 


### PR DESCRIPTION
This PR is a continuation of #27518 and #27198 to complete the function for finding a string with in a string.
This new keyword functions as a contains function in terraform to allow users to find strings instead of using the workaround can(regrex(...)).