### PR TITLE
cli init: hide warning about incomplete lock

### DIFF
--- a/internal/command/init.go
+++ b/internal/command/init.go
@@ -877,7 +877,7 @@ func (c *InitCommand) getProviders(config *configs.Config, state *states.State, 
 		}
 
 		// Jump in here and add a warning if any of the providers are incomplete.
-		if len(incompleteProviders) > 0 {
+		if len(incompleteProviders) > 0 && !inst.GlobalCacheDirMayBreakDependencyLockFile() {
 			// We don't really care about the order here, we just want the
 			// output to be deterministic.
 			sort.Slice(incompleteProviders, func(i, j int) bool {

--- a/internal/providercache/installer.go
+++ b/internal/providercache/installer.go
@@ -123,6 +123,14 @@ func (i *Installer) SetGlobalCacheDirMayBreakDependencyLockFile(mayBreak bool) {
 	i.globalCacheDirMayBreakDependencyLockFile = mayBreak
 }
 
+// GlobalCacheDirMayBreakDependencyLockFile returns true when
+// temporary exception to the rule that the global cache directory can be used
+// only when entries are confirmed by existing entries in the dependency lock
+// file is activated.
+func (i *Installer) GlobalCacheDirMayBreakDependencyLockFile() bool {
+	return i.globalCacheDirMayBreakDependencyLockFile
+}
+
 // HasGlobalCacheDir returns true if someone has previously called
 // SetGlobalCacheDir to configure a global cache directory for this installer.
 func (i *Installer) HasGlobalCacheDir() bool {


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->


when plugin_cache_may_break_dependency_lock_file is enabled 
don't show warning 
```
>terraform init
...
╷
│ Warning: Incomplete lock file information for providers
│ 
│ Due to your customized provider installation methods, Terraform was forced to calculate lock file checksums locally for the following providers:
│   - hashicorp/google
│ 
│ The current .terraform.lock.hcl file only includes checksums for linux_amd64, so Terraform running on another platform will fail to install these providers.
│ 
│ To calculate additional checksums for another platform, run:
│   terraform providers lock -platform=linux_amd64
│ (where linux_amd64 is the platform to generate)
```


<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Fixes #31856

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.4.x

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

### ENHANCEMENTS

<!--

Write a short description of the user-facing change. Examples:

- `terraform show -json`: Fixed crash with sensitive set values.
- When rendering a diff, Terraform now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 

-  `terraform init`: When `plugin_cache_may_break_dependency_lock_file` is enabled then don't show warning about incomplete lock file.
