### PR TITLE
skip inter-provider cycle check in destroy plan

### DIFF
--- a/internal/terraform/graph_builder_plan.go
+++ b/internal/terraform/graph_builder_plan.go
@@ -191,7 +191,9 @@ func (b *PlanGraphBuilder) Steps() []GraphTransformer {
 
 		// DestroyEdgeTransformer is only required during a plan so that the
 		// TargetsTransformer can determine which nodes to keep in the graph.
-		&DestroyEdgeTransformer{},
+		&DestroyEdgeTransformer{
+			Operation: b.Operation,
+		},
 
 		&pruneUnusedNodesTransformer{
 			skip: b.Operation != walkPlanDestroy,

--- a/internal/terraform/transform_destroy_edge.go
+++ b/internal/terraform/transform_destroy_edge.go
@@ -88,7 +88,7 @@ func (t *DestroyEdgeTransformer) tryInterProviderDestroyEdge(g *Graph, from, to 
 
 	// If this is a complete destroy operation, then there are no create/update
 	// nodes to worry about and we can accept the edge without deeper inspection.
-	if t.Operation == walkDestroy {
+	if t.Operation == walkDestroy || t.Operation == walkPlanDestroy {
 		return
 	}
 


### PR DESCRIPTION
Just like when applying a destroy plan, we can skip the inter-provider cycle check when creating the destroy plan, which can be expensive when there are a lot of resource instances with dependencies from another provider.

Existing test coverage is sufficient, and multiple test cases hit this new condition.

Closes #33071