### PR TITLE
Plannable import 1: Add import block (configs)

### DIFF
--- a/internal/configs/import.go
+++ b/internal/configs/import.go
@@ -2,6 +2,7 @@ package configs
 
 import (
 	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/gohcl"
 	"github.com/hashicorp/terraform/internal/addrs"
 )
 
@@ -10,4 +11,45 @@ type Import struct {
 	To addrs.AbsResourceInstance
 
 	DeclRange hcl.Range
+}
+
+func decodeImportBlock(block *hcl.Block) (*Import, hcl.Diagnostics) {
+	var diags hcl.Diagnostics
+	imp := &Import{
+		DeclRange: block.DefRange,
+	}
+
+	content, moreDiags := block.Body.Content(importBlockSchema)
+	diags = append(diags, moreDiags...)
+
+	if attr, exists := content.Attributes["id"]; exists {
+		attrDiags := gohcl.DecodeExpression(attr.Expr, nil, &imp.ID)
+		diags = append(diags, attrDiags...)
+
+	}
+
+	if attr, exists := content.Attributes["to"]; exists {
+		traversal, traversalDiags := hcl.AbsTraversalForExpr(attr.Expr)
+		diags = append(diags, traversalDiags...)
+		if !traversalDiags.HasErrors() {
+			to, toDiags := addrs.ParseAbsResourceInstance(traversal)
+			diags = append(diags, toDiags.ToHCL()...)
+			imp.To = to
+		}
+	}
+
+	return imp, diags
+}
+
+var importBlockSchema = &hcl.BodySchema{
+	Attributes: []hcl.AttributeSchema{
+		{
+			Name:     "id",
+			Required: true,
+		},
+		{
+			Name:     "to",
+			Required: true,
+		},
+	},
 }

--- a/internal/configs/import_test.go
+++ b/internal/configs/import_test.go
@@ -1,0 +1,173 @@
+package configs
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hcltest"
+	"github.com/hashicorp/terraform/internal/addrs"
+	"github.com/zclconf/go-cty/cty"
+)
+
+func TestImportBlock_decode(t *testing.T) {
+	blockRange := hcl.Range{
+		Filename: "mock.tf",
+		Start:    hcl.Pos{Line: 3, Column: 12, Byte: 27},
+		End:      hcl.Pos{Line: 3, Column: 19, Byte: 34},
+	}
+
+	foo_str_expr := hcltest.MockExprLiteral(cty.StringVal("foo"))
+	bar_expr := hcltest.MockExprTraversalSrc("test_instance.bar")
+
+	bar_index_expr := hcltest.MockExprTraversalSrc("test_instance.bar[\"one\"]")
+
+	mod_bar_expr := hcltest.MockExprTraversalSrc("module.bar.test_instance.bar")
+
+	tests := map[string]struct {
+		input *hcl.Block
+		want  *Import
+		err   string
+	}{
+		"success": {
+			&hcl.Block{
+				Type: "import",
+				Body: hcltest.MockBody(&hcl.BodyContent{
+					Attributes: hcl.Attributes{
+						"id": {
+							Name: "id",
+							Expr: foo_str_expr,
+						},
+						"to": {
+							Name: "to",
+							Expr: bar_expr,
+						},
+					},
+				}),
+				DefRange: blockRange,
+			},
+			&Import{
+				To:        mustAbsResourceInstanceAddr("test_instance.bar"),
+				ID:        "foo",
+				DeclRange: blockRange,
+			},
+			``,
+		},
+		"indexed resources": {
+			&hcl.Block{
+				Type: "import",
+				Body: hcltest.MockBody(&hcl.BodyContent{
+					Attributes: hcl.Attributes{
+						"id": {
+							Name: "id",
+							Expr: foo_str_expr,
+						},
+						"to": {
+							Name: "to",
+							Expr: bar_index_expr,
+						},
+					},
+				}),
+				DefRange: blockRange,
+			},
+			&Import{
+				To:        mustAbsResourceInstanceAddr("test_instance.bar[\"one\"]"),
+				ID:        "foo",
+				DeclRange: blockRange,
+			},
+			``,
+		},
+		"resource inside module": {
+			&hcl.Block{
+				Type: "import",
+				Body: hcltest.MockBody(&hcl.BodyContent{
+					Attributes: hcl.Attributes{
+						"id": {
+							Name: "id",
+							Expr: foo_str_expr,
+						},
+						"to": {
+							Name: "to",
+							Expr: mod_bar_expr,
+						},
+					},
+				}),
+				DefRange: blockRange,
+			},
+			&Import{
+				To:        mustAbsResourceInstanceAddr("module.bar.test_instance.bar"),
+				ID:        "foo",
+				DeclRange: blockRange,
+			},
+			``,
+		},
+		"error: missing id argument": {
+			&hcl.Block{
+				Type: "import",
+				Body: hcltest.MockBody(&hcl.BodyContent{
+					Attributes: hcl.Attributes{
+						"to": {
+							Name: "to",
+							Expr: bar_expr,
+						},
+					},
+				}),
+				DefRange: blockRange,
+			},
+			&Import{
+				To:        mustAbsResourceInstanceAddr("test_instance.bar"),
+				DeclRange: blockRange,
+			},
+			"Missing required argument",
+		},
+		"error: missing to argument": {
+			&hcl.Block{
+				Type: "import",
+				Body: hcltest.MockBody(&hcl.BodyContent{
+					Attributes: hcl.Attributes{
+						"id": {
+							Name: "id",
+							Expr: foo_str_expr,
+						},
+					},
+				}),
+				DefRange: blockRange,
+			},
+			&Import{
+				ID:        "foo",
+				DeclRange: blockRange,
+			},
+			"Missing required argument",
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			got, diags := decodeImportBlock(test.input)
+
+			if diags.HasErrors() {
+				if test.err == "" {
+					t.Fatalf("unexpected error: %s", diags.Errs())
+				}
+				if gotErr := diags[0].Summary; gotErr != test.err {
+					t.Errorf("wrong error, got %q, want %q", gotErr, test.err)
+				}
+			} else if test.err != "" {
+				t.Fatal("expected error")
+			}
+
+			if !cmp.Equal(got, test.want, cmp.AllowUnexported(addrs.MoveEndpoint{})) {
+				t.Fatalf("wrong result: %s", cmp.Diff(got, test.want))
+			}
+		})
+	}
+}
+
+func mustAbsResourceInstanceAddr(str string) addrs.AbsResourceInstance {
+	addr, diags := addrs.ParseAbsResourceInstanceStr(str)
+	if diags.HasErrors() {
+		panic(fmt.Sprintf("invalid absolute resource instance address: %s", diags.Err()))
+	}
+	return addr
+}

--- a/internal/configs/module.go
+++ b/internal/configs/module.go
@@ -399,10 +399,11 @@ func (m *Module) appendFile(file *File) hcl.Diagnostics {
 		}
 	}
 
-	// "Moved" blocks just append, because they are all independent
+	// "Moved" and "import" blocks just append, because they are all independent
 	// of one another at this level. (We handle any references between
 	// them at runtime.)
 	m.Moved = append(m.Moved, file.Moved...)
+	m.Import = append(m.Import, file.Import...)
 
 	return diags
 }
@@ -581,6 +582,15 @@ func (m *Module) mergeFile(file *File) hcl.Diagnostics {
 			Severity: hcl.DiagError,
 			Summary:  "Cannot override 'moved' blocks",
 			Detail:   "Records of moved objects can appear only in normal files, not in override files.",
+			Subject:  m.DeclRange.Ptr(),
+		})
+	}
+
+	for _, m := range file.Import {
+		diags = append(diags, &hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  "Cannot override 'import' blocks",
+			Detail:   "Import blocks can appear only in normal files, not in override files.",
 			Subject:  m.DeclRange.Ptr(),
 		})
 	}

--- a/internal/configs/parser_config.go
+++ b/internal/configs/parser_config.go
@@ -30,7 +30,6 @@ func (p *Parser) LoadConfigFileOverride(path string) (*File, hcl.Diagnostics) {
 }
 
 func (p *Parser) loadConfigFile(path string, override bool) (*File, hcl.Diagnostics) {
-
 	body, diags := p.LoadHCLFile(path)
 	if body == nil {
 		return nil, diags
@@ -162,6 +161,13 @@ func (p *Parser) loadConfigFile(path string, override bool) (*File, hcl.Diagnost
 				file.Moved = append(file.Moved, cfg)
 			}
 
+		case "import":
+			cfg, cfgDiags := decodeImportBlock(block)
+			diags = append(diags, cfgDiags...)
+			if cfg != nil {
+				file.Import = append(file.Import, cfg)
+			}
+
 		case "check":
 			cfg, cfgDiags := decodeCheckBlock(block, override)
 			diags = append(diags, cfgDiags...)
@@ -258,6 +264,9 @@ var configFileSchema = &hcl.BodySchema{
 		},
 		{
 			Type: "moved",
+		},
+		{
+			Type: "import",
 		},
 		{
 			Type:       "check",


### PR DESCRIPTION
Needs https://github.com/hashicorp/terraform/pull/33080.

This PR adds an `import` block type with the following shape:
```hcl
import {
  id = "123"
  to = my_resource.foo
}
```

The implementation is very similar to `moved` blocks at this point.

The following two features will be added in future PRs:
 - `provider` field in import block
 - validation: import blocks cannot appear in child modules
 - validation: only one import block per addr

| # | Description | Package(s) | Pull Request |
|---|---| --- | ---|
| 0 | Add plannable import types | `configs`,`plans` | #33080   |
| 1 | Add import block | `configs` | #33081   |
| 2 | Render import changes | `command/views`,`command/jsonformat` | WIP #33082   |
| 3 | Make import plannable | `terraform` | WIP #33085  |
| 4 | Make import changes applyable | `terraform` | WIP   |