### PR TITLE
[TF-5829]add resource_drift JSONLogType

### DIFF
--- a/internal/command/jsonformat/renderer.go
+++ b/internal/command/jsonformat/renderer.go
@@ -29,20 +29,21 @@ type JSONLog struct {
 }
 
 const (
-	LogVersion           JSONLogType = "version"
+	LogApplyComplete     JSONLogType = "apply_complete"
+	LogApplyErrored      JSONLogType = "apply_errored"
+	LogApplyStart        JSONLogType = "apply_start"
+	LogChangeSummary     JSONLogType = "change_summary"
 	LogDiagnostic        JSONLogType = "diagnostic"
 	LogPlannedChange     JSONLogType = "planned_change"
-	LogRefreshStart      JSONLogType = "refresh_start"
-	LogRefreshComplete   JSONLogType = "refresh_complete"
-	LogApplyStart        JSONLogType = "apply_start"
-	LogApplyErrored      JSONLogType = "apply_errored"
-	LogApplyComplete     JSONLogType = "apply_complete"
-	LogChangeSummary     JSONLogType = "change_summary"
-	LogProvisionStart    JSONLogType = "provision_start"
-	LogProvisionProgress JSONLogType = "provision_progress"
 	LogProvisionComplete JSONLogType = "provision_complete"
 	LogProvisionErrored  JSONLogType = "provision_errored"
+	LogProvisionProgress JSONLogType = "provision_progress"
+	LogProvisionStart    JSONLogType = "provision_start"
 	LogOutputs           JSONLogType = "outputs"
+	LogRefreshComplete   JSONLogType = "refresh_complete"
+	LogRefreshStart      JSONLogType = "refresh_start"
+	LogResourceDrift     JSONLogType = "resource_drift"
+	LogVersion           JSONLogType = "version"
 )
 
 type Renderer struct {
@@ -101,7 +102,7 @@ func (r Renderer) RenderLog(log *JSONLog) error {
 		// We won't display these types of logs
 		return nil
 
-	case LogApplyStart, LogApplyComplete, LogRefreshStart, LogProvisionStart:
+	case LogApplyStart, LogApplyComplete, LogRefreshStart, LogProvisionStart, LogResourceDrift:
 		msg := fmt.Sprintf(r.Colorize.Color("[bold]%s[reset]"), log.Message)
 		r.Streams.Println(msg)
 


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Fixes #

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.4.x

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

### NEW FEATURES | UPGRADE NOTES | ENHANCEMENTS | BUG FIXES | EXPERIMENTS

<!--

Write a short description of the user-facing change. Examples:

- `terraform show -json`: Fixed crash with sensitive set values.
- When rendering a diff, Terraform now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 

-  Add new `resource_drift` JSONLogType and format output
