### PR TITLE
Plannable import 3: Make import plannable

### DIFF
--- a/internal/plans/changes.go
+++ b/internal/plans/changes.go
@@ -301,9 +301,10 @@ func (rc *ResourceInstanceChange) Simplify(destroying bool) *ResourceInstanceCha
 				Private:      rc.Private,
 				ProviderAddr: rc.ProviderAddr,
 				Change: Change{
-					Action: Delete,
-					Before: rc.Before,
-					After:  cty.NullVal(rc.Before.Type()),
+					Action:    Delete,
+					Before:    rc.Before,
+					After:     cty.NullVal(rc.Before.Type()),
+					Importing: rc.Importing,
 				},
 			}
 		default:
@@ -313,9 +314,10 @@ func (rc *ResourceInstanceChange) Simplify(destroying bool) *ResourceInstanceCha
 				Private:      rc.Private,
 				ProviderAddr: rc.ProviderAddr,
 				Change: Change{
-					Action: NoOp,
-					Before: rc.Before,
-					After:  rc.Before,
+					Action:    NoOp,
+					Before:    rc.Before,
+					After:     rc.Before,
+					Importing: rc.Importing,
 				},
 			}
 		}
@@ -328,9 +330,10 @@ func (rc *ResourceInstanceChange) Simplify(destroying bool) *ResourceInstanceCha
 				Private:      rc.Private,
 				ProviderAddr: rc.ProviderAddr,
 				Change: Change{
-					Action: NoOp,
-					Before: rc.Before,
-					After:  rc.Before,
+					Action:    NoOp,
+					Before:    rc.Before,
+					After:     rc.Before,
+					Importing: rc.Importing,
 				},
 			}
 		case CreateThenDelete, DeleteThenCreate:
@@ -340,9 +343,10 @@ func (rc *ResourceInstanceChange) Simplify(destroying bool) *ResourceInstanceCha
 				Private:      rc.Private,
 				ProviderAddr: rc.ProviderAddr,
 				Change: Change{
-					Action: Create,
-					Before: cty.NullVal(rc.After.Type()),
-					After:  rc.After,
+					Action:    Create,
+					Before:    cty.NullVal(rc.After.Type()),
+					After:     rc.After,
+					Importing: rc.Importing,
 				},
 			}
 		}
@@ -548,5 +552,6 @@ func (c *Change) Encode(ty cty.Type) (*ChangeSrc, error) {
 		After:          afterDV,
 		BeforeValMarks: beforeVM,
 		AfterValMarks:  afterVM,
+		Importing:      c.Importing,
 	}, nil
 }

--- a/internal/plans/changes.go
+++ b/internal/plans/changes.go
@@ -37,6 +37,10 @@ func (c *Changes) Empty() bool {
 		if res.Action != NoOp || res.Moved() {
 			return false
 		}
+
+		if res.Importing {
+			return false
+		}
 	}
 
 	for _, out := range c.Outputs {

--- a/internal/plans/changes_src.go
+++ b/internal/plans/changes_src.go
@@ -230,8 +230,9 @@ func (cs *ChangeSrc) Decode(ty cty.Type) (*Change, error) {
 	}
 
 	return &Change{
-		Action: cs.Action,
-		Before: before.MarkWithPaths(cs.BeforeValMarks),
-		After:  after.MarkWithPaths(cs.AfterValMarks),
+		Action:    cs.Action,
+		Before:    before.MarkWithPaths(cs.BeforeValMarks),
+		After:     after.MarkWithPaths(cs.AfterValMarks),
+		Importing: cs.Importing,
 	}, nil
 }

--- a/internal/terraform/context_plan2_test.go
+++ b/internal/terraform/context_plan2_test.go
@@ -4098,3 +4098,69 @@ resource "test_object" "a" {
 		}
 	}
 }
+
+func TestContext2Plan_importResourceBasic(t *testing.T) {
+	addr := mustResourceInstanceAddr("test_object.a")
+	m := testModuleInline(t, map[string]string{
+		"main.tf": `
+			resource "test_object" "a" {
+                test_string = "foo"
+			}
+
+			import {
+				to   = test_object.a
+                id   = "123"
+			}
+		`,
+	})
+
+	p := simpleMockProvider()
+	ctx := testContext2(t, &ContextOpts{
+		Providers: map[addrs.Provider]providers.Factory{
+			addrs.NewDefaultProvider("test"): testProviderFuncFixed(p),
+		},
+	})
+	p.ReadResourceResponse = &providers.ReadResourceResponse{
+		NewState: cty.ObjectVal(map[string]cty.Value{
+			"test_string": cty.StringVal("foo"),
+		}),
+	}
+	p.ImportResourceStateResponse = &providers.ImportResourceStateResponse{
+		ImportedResources: []providers.ImportedResource{
+			{
+				TypeName: "test_object",
+				State: cty.ObjectVal(map[string]cty.Value{
+					"test_string": cty.StringVal("foo"),
+				}),
+			},
+		},
+	}
+
+	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	if diags.HasErrors() {
+		t.Fatalf("unexpected errors\n%s", diags.Err().Error())
+	}
+
+	t.Run(addr.String(), func(t *testing.T) {
+		instPlan := plan.Changes.ResourceInstance(addr)
+		if instPlan == nil {
+			t.Fatalf("no plan for %s at all", addr)
+		}
+
+		if got, want := instPlan.Addr, addr; !got.Equal(want) {
+			t.Errorf("wrong current address\ngot:  %s\nwant: %s", got, want)
+		}
+		if got, want := instPlan.PrevRunAddr, addr; !got.Equal(want) {
+			t.Errorf("wrong previous run address\ngot:  %s\nwant: %s", got, want)
+		}
+		if got, want := instPlan.Action, plans.NoOp; got != want {
+			t.Errorf("wrong planned action\ngot:  %s\nwant: %s", got, want)
+		}
+		if got, want := instPlan.ActionReason, plans.ResourceInstanceChangeNoReason; got != want {
+			t.Errorf("wrong action reason\ngot:  %s\nwant: %s", got, want)
+		}
+		if !instPlan.Importing {
+			t.Errorf("expected import change, got non-import change")
+		}
+	})
+}

--- a/internal/terraform/context_plan2_test.go
+++ b/internal/terraform/context_plan2_test.go
@@ -4103,15 +4103,15 @@ func TestContext2Plan_importResourceBasic(t *testing.T) {
 	addr := mustResourceInstanceAddr("test_object.a")
 	m := testModuleInline(t, map[string]string{
 		"main.tf": `
-			resource "test_object" "a" {
-                test_string = "foo"
-			}
+resource "test_object" "a" {
+  test_string = "foo"
+}
 
-			import {
-				to   = test_object.a
-                id   = "123"
-			}
-		`,
+import {
+  to   = test_object.a
+  id   = "123"
+}
+`,
 	})
 
 	p := simpleMockProvider()
@@ -4158,6 +4158,140 @@ func TestContext2Plan_importResourceBasic(t *testing.T) {
 		}
 		if got, want := instPlan.ActionReason, plans.ResourceInstanceChangeNoReason; got != want {
 			t.Errorf("wrong action reason\ngot:  %s\nwant: %s", got, want)
+		}
+		if !instPlan.Importing {
+			t.Errorf("expected import change, got non-import change")
+		}
+	})
+}
+
+func TestContext2Plan_importResourceUpdate(t *testing.T) {
+	addr := mustResourceInstanceAddr("test_object.a")
+	m := testModuleInline(t, map[string]string{
+		"main.tf": `
+resource "test_object" "a" {
+  test_string = "bar"
+}
+
+import {
+  to   = test_object.a
+  id   = "123"
+}
+`,
+	})
+
+	p := simpleMockProvider()
+	ctx := testContext2(t, &ContextOpts{
+		Providers: map[addrs.Provider]providers.Factory{
+			addrs.NewDefaultProvider("test"): testProviderFuncFixed(p),
+		},
+	})
+	p.ReadResourceResponse = &providers.ReadResourceResponse{
+		NewState: cty.ObjectVal(map[string]cty.Value{
+			"test_string": cty.StringVal("foo"),
+		}),
+	}
+	p.ImportResourceStateResponse = &providers.ImportResourceStateResponse{
+		ImportedResources: []providers.ImportedResource{
+			{
+				TypeName: "test_object",
+				State: cty.ObjectVal(map[string]cty.Value{
+					"test_string": cty.StringVal("foo"),
+				}),
+			},
+		},
+	}
+
+	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	if diags.HasErrors() {
+		t.Fatalf("unexpected errors\n%s", diags.Err().Error())
+	}
+
+	t.Run(addr.String(), func(t *testing.T) {
+		instPlan := plan.Changes.ResourceInstance(addr)
+		if instPlan == nil {
+			t.Fatalf("no plan for %s at all", addr)
+		}
+
+		if got, want := instPlan.Addr, addr; !got.Equal(want) {
+			t.Errorf("wrong current address\ngot:  %s\nwant: %s", got, want)
+		}
+		if got, want := instPlan.PrevRunAddr, addr; !got.Equal(want) {
+			t.Errorf("wrong previous run address\ngot:  %s\nwant: %s", got, want)
+		}
+		if got, want := instPlan.Action, plans.Update; got != want {
+			t.Errorf("wrong planned action\ngot:  %s\nwant: %s", got, want)
+		}
+		if got, want := instPlan.ActionReason, plans.ResourceInstanceChangeNoReason; got != want {
+			t.Errorf("wrong action reason\ngot:  %s\nwant: %s", got, want)
+		}
+		if !instPlan.Importing {
+			t.Errorf("expected import change, got non-import change")
+		}
+	})
+}
+
+func TestContext2Plan_importResourceReplace(t *testing.T) {
+	addr := mustResourceInstanceAddr("test_object.a")
+	m := testModuleInline(t, map[string]string{
+		"main.tf": `
+resource "test_object" "a" {
+  test_string = "bar"
+}
+
+import {
+  to   = test_object.a
+  id   = "123"
+}
+`,
+	})
+
+	p := simpleMockProvider()
+	ctx := testContext2(t, &ContextOpts{
+		Providers: map[addrs.Provider]providers.Factory{
+			addrs.NewDefaultProvider("test"): testProviderFuncFixed(p),
+		},
+	})
+	p.ReadResourceResponse = &providers.ReadResourceResponse{
+		NewState: cty.ObjectVal(map[string]cty.Value{
+			"test_string": cty.StringVal("foo"),
+		}),
+	}
+	p.ImportResourceStateResponse = &providers.ImportResourceStateResponse{
+		ImportedResources: []providers.ImportedResource{
+			{
+				TypeName: "test_object",
+				State: cty.ObjectVal(map[string]cty.Value{
+					"test_string": cty.StringVal("foo"),
+				}),
+			},
+		},
+	}
+
+	plan, diags := ctx.Plan(m, states.NewState(), &PlanOpts{
+		Mode: plans.NormalMode,
+		ForceReplace: []addrs.AbsResourceInstance{
+			addr,
+		},
+	})
+	if diags.HasErrors() {
+		t.Fatalf("unexpected errors\n%s", diags.Err().Error())
+	}
+
+	t.Run(addr.String(), func(t *testing.T) {
+		instPlan := plan.Changes.ResourceInstance(addr)
+		if instPlan == nil {
+			t.Fatalf("no plan for %s at all", addr)
+		}
+
+		if got, want := instPlan.Addr, addr; !got.Equal(want) {
+			t.Errorf("wrong current address\ngot:  %s\nwant: %s", got, want)
+		}
+		if got, want := instPlan.PrevRunAddr, addr; !got.Equal(want) {
+			t.Errorf("wrong previous run address\ngot:  %s\nwant: %s", got, want)
+		}
+		if got, want := instPlan.Action, plans.DeleteThenCreate; got != want {
+			t.Errorf("wrong planned action\ngot:  %s\nwant: %s", got, want)
 		}
 		if !instPlan.Importing {
 			t.Errorf("expected import change, got non-import change")

--- a/internal/terraform/graph_builder_plan.go
+++ b/internal/terraform/graph_builder_plan.go
@@ -309,6 +309,13 @@ func (b *PlanGraphBuilder) initImport() {
 			// as the new state, and users are not expecting the import process
 			// to update any other instances in state.
 			skipRefresh: true,
+
+			// If we get here, we know that we are in legacy import mode, and
+			// that the user has run the import command rather than plan.
+			// This flag must be propagated down to the
+			// NodePlannableResourceInstance so we can ignore the new import
+			// behaviour.
+			legacyImportMode: true,
 		}
 	}
 }

--- a/internal/terraform/graph_walk_context.go
+++ b/internal/terraform/graph_walk_context.go
@@ -27,12 +27,13 @@ type ContextGraphWalker struct {
 
 	// Configurable values
 	Context            *Context
-	State              *states.SyncState       // Used for safe concurrent access to state
-	RefreshState       *states.SyncState       // Used for safe concurrent access to state
-	PrevRunState       *states.SyncState       // Used for safe concurrent access to state
-	Changes            *plans.ChangesSync      // Used for safe concurrent writes to changes
-	Checks             *checks.State           // Used for safe concurrent writes of checkable objects and their check results
-	InstanceExpander   *instances.Expander     // Tracks our gradual expansion of module and resource instances
+	State              *states.SyncState   // Used for safe concurrent access to state
+	RefreshState       *states.SyncState   // Used for safe concurrent access to state
+	PrevRunState       *states.SyncState   // Used for safe concurrent access to state
+	Changes            *plans.ChangesSync  // Used for safe concurrent writes to changes
+	Checks             *checks.State       // Used for safe concurrent writes of checkable objects and their check results
+	InstanceExpander   *instances.Expander // Tracks our gradual expansion of module and resource instances
+	Imports            []configs.Import
 	MoveResults        refactoring.MoveResults // Read-only record of earlier processing of move statements
 	Operation          walkOperation
 	StopContext        context.Context

--- a/internal/terraform/node_resource_abstract.go
+++ b/internal/terraform/node_resource_abstract.go
@@ -131,10 +131,6 @@ func (n *NodeAbstractResource) ReferenceableAddrs() []addrs.Referenceable {
 	return []addrs.Referenceable{n.Addr.Resource}
 }
 
-func (n *NodeAbstractResource) Import(addr *ImportTarget) {
-
-}
-
 // GraphNodeReferencer
 func (n *NodeAbstractResource) References() []*addrs.Reference {
 	// If we have a config then we prefer to use that.

--- a/internal/terraform/node_resource_plan_instance.go
+++ b/internal/terraform/node_resource_plan_instance.go
@@ -152,99 +152,7 @@ func (n *NodePlannableResourceInstance) managedResourceExecute(ctx EvalContext) 
 	// If the resource is to be imported, we now ask the provider for an Import
 	// and a Refresh, and save the resulting state to instanceRefreshState.
 	if n.importTarget.ID != "" {
-		absAddr := addr.Resource.Absolute(ctx.Path())
-
-		diags = diags.Append(ctx.Hook(func(h Hook) (HookAction, error) {
-			return h.PreImportState(absAddr, n.importTarget.ID)
-		}))
-		if diags.HasErrors() {
-			return diags
-		}
-
-		resp := provider.ImportResourceState(providers.ImportResourceStateRequest{
-			TypeName: addr.Resource.Resource.Type,
-			ID:       n.importTarget.ID,
-		})
-		diags = diags.Append(resp.Diagnostics)
-		if diags.HasErrors() {
-			return diags
-		}
-
-		imported := resp.ImportedResources
-
-		if len(imported) == 0 {
-			diags = diags.Append(tfdiags.Sourceless(
-				tfdiags.Error,
-				"Import returned no resources",
-				fmt.Sprintf("While attempting to import with ID %s, the provider"+
-					"returned no instance states.",
-					n.importTarget.ID,
-				),
-			))
-			return diags
-		}
-		for _, obj := range imported {
-			log.Printf("[TRACE] graphNodeImportState: import %s %q produced instance object of type %s", absAddr.String(), n.importTarget.ID, obj.TypeName)
-		}
-		if len(imported) > 1 {
-			diags = diags.Append(tfdiags.Sourceless(
-				tfdiags.Error,
-				"Multiple import states not supported",
-				fmt.Sprintf("While attempting to import with ID %s, the provider "+
-					"returned multiple resource instance states. This "+
-					"is not currently supported.",
-					n.importTarget.ID,
-				),
-			))
-			return diags
-		}
-
-		// call post-import hook
-		diags = diags.Append(ctx.Hook(func(h Hook) (HookAction, error) {
-			return h.PostImportState(absAddr, imported)
-		}))
-
-		if imported[0].TypeName == "" {
-			diags = diags.Append(fmt.Errorf("import of %s didn't set type", n.importTarget.Addr.String()))
-			return diags
-		}
-
-		importedState := imported[0].AsInstanceObject()
-
-		// refresh
-		riNode := &NodeAbstractResourceInstance{
-			Addr: n.importTarget.Addr,
-			NodeAbstractResource: NodeAbstractResource{
-				ResolvedProvider: n.ResolvedProvider,
-			},
-		}
-		importedState, refreshDiags := riNode.refresh(ctx, states.NotDeposed, importedState)
-		diags = diags.Append(refreshDiags)
-		if diags.HasErrors() {
-			return diags
-		}
-
-		// verify the existence of the imported resource
-		if importedState.Value.IsNull() {
-			var diags tfdiags.Diagnostics
-			diags = diags.Append(tfdiags.Sourceless(
-				tfdiags.Error,
-				"Cannot import non-existent remote object",
-				fmt.Sprintf(
-					"While attempting to import an existing object to %q, "+
-						"the provider detected that no object exists with the given id. "+
-						"Only pre-existing objects can be imported; check that the id "+
-						"is correct and that it is associated with the provider's "+
-						"configured region or endpoint, or use \"terraform apply\" to "+
-						"create a new remote object for this resource.",
-					n.importTarget.Addr,
-				),
-			))
-			return diags
-		}
-
-		diags = diags.Append(riNode.writeResourceInstanceState(ctx, importedState, workingState))
-		instanceRefreshState = importedState
+		instanceRefreshState, diags = n.importState(ctx, addr, provider)
 	} else {
 		var readDiags tfdiags.Diagnostics
 		instanceRefreshState, readDiags = n.readResourceInstanceState(ctx, addr)
@@ -470,6 +378,103 @@ func (n *NodePlannableResourceInstance) replaceTriggered(ctx EvalContext, repDat
 	}
 
 	return diags
+}
+
+func (n *NodePlannableResourceInstance) importState(ctx EvalContext, addr addrs.AbsResourceInstance, provider providers.Interface) (instanceRefreshState *states.ResourceInstanceObject, diags tfdiags.Diagnostics) {
+	absAddr := addr.Resource.Absolute(ctx.Path())
+
+	diags = diags.Append(ctx.Hook(func(h Hook) (HookAction, error) {
+		return h.PreImportState(absAddr, n.importTarget.ID)
+	}))
+	if diags.HasErrors() {
+		return instanceRefreshState, diags
+	}
+
+	resp := provider.ImportResourceState(providers.ImportResourceStateRequest{
+		TypeName: addr.Resource.Resource.Type,
+		ID:       n.importTarget.ID,
+	})
+	diags = diags.Append(resp.Diagnostics)
+	if diags.HasErrors() {
+		return instanceRefreshState, diags
+	}
+
+	imported := resp.ImportedResources
+
+	if len(imported) == 0 {
+		diags = diags.Append(tfdiags.Sourceless(
+			tfdiags.Error,
+			"Import returned no resources",
+			fmt.Sprintf("While attempting to import with ID %s, the provider"+
+				"returned no instance states.",
+				n.importTarget.ID,
+			),
+		))
+		return instanceRefreshState, diags
+	}
+	for _, obj := range imported {
+		log.Printf("[TRACE] graphNodeImportState: import %s %q produced instance object of type %s", absAddr.String(), n.importTarget.ID, obj.TypeName)
+	}
+	if len(imported) > 1 {
+		diags = diags.Append(tfdiags.Sourceless(
+			tfdiags.Error,
+			"Multiple import states not supported",
+			fmt.Sprintf("While attempting to import with ID %s, the provider "+
+				"returned multiple resource instance states. This "+
+				"is not currently supported.",
+				n.importTarget.ID,
+			),
+		))
+		return instanceRefreshState, diags
+	}
+
+	// call post-import hook
+	diags = diags.Append(ctx.Hook(func(h Hook) (HookAction, error) {
+		return h.PostImportState(absAddr, imported)
+	}))
+
+	if imported[0].TypeName == "" {
+		diags = diags.Append(fmt.Errorf("import of %s didn't set type", n.importTarget.Addr.String()))
+		return instanceRefreshState, diags
+	}
+
+	importedState := imported[0].AsInstanceObject()
+
+	// refresh
+	riNode := &NodeAbstractResourceInstance{
+		Addr: n.importTarget.Addr,
+		NodeAbstractResource: NodeAbstractResource{
+			ResolvedProvider: n.ResolvedProvider,
+		},
+	}
+	importedState, refreshDiags := riNode.refresh(ctx, states.NotDeposed, importedState)
+	diags = diags.Append(refreshDiags)
+	if diags.HasErrors() {
+		return instanceRefreshState, diags
+	}
+
+	// verify the existence of the imported resource
+	if importedState.Value.IsNull() {
+		var diags tfdiags.Diagnostics
+		diags = diags.Append(tfdiags.Sourceless(
+			tfdiags.Error,
+			"Cannot import non-existent remote object",
+			fmt.Sprintf(
+				"While attempting to import an existing object to %q, "+
+					"the provider detected that no object exists with the given id. "+
+					"Only pre-existing objects can be imported; check that the id "+
+					"is correct and that it is associated with the provider's "+
+					"configured region or endpoint, or use \"terraform apply\" to "+
+					"create a new remote object for this resource.",
+				n.importTarget.Addr,
+			),
+		))
+		return instanceRefreshState, diags
+	}
+
+	diags = diags.Append(riNode.writeResourceInstanceState(ctx, importedState, workingState))
+	instanceRefreshState = importedState
+	return instanceRefreshState, diags
 }
 
 // mergeDeps returns the union of 2 sets of dependencies


### PR DESCRIPTION
Needs https://github.com/hashicorp/terraform/pull/33080.

During a plan, Terraform now checks for the presence of import blocks. 

For each resource in config, if an import block is present with a matching address, planning that node will now trigger an ImportResourceState and ReadResource. The resulting state is treated as the node's "refresh state", and planning proceeds as normal from there.