### PR TITLE
[Plannable Import] Implement the plannable import plan rendering

### DIFF
--- a/internal/command/format/diff.go
+++ b/internal/command/format/diff.go
@@ -164,7 +164,7 @@ func ResourceChange(
 	if change.Moved() && change.Action == plans.NoOp {
 		buf.WriteString("    ")
 	} else {
-		buf.WriteString(color.Color(DiffActionSymbol(change.Action)) + " ")
+		buf.WriteString(color.Color(DiffActionSymbol(change.Action, false)) + " ")
 	}
 
 	switch addr.Resource.Resource.Mode {
@@ -2002,7 +2002,7 @@ func ctyNullBlockSetAsEmpty(in cty.Value) cty.Value {
 // colorstring.Colorize, will produce a result that can be written
 // to a terminal to produce a symbol made of three printable
 // characters, possibly interspersed with VT100 color codes.
-func DiffActionSymbol(action plans.Action) string {
+func DiffActionSymbol(action plans.Action, importing bool) string {
 	switch action {
 	case plans.DeleteThenCreate:
 		return "[red]-[reset]/[green]+[reset]"
@@ -2017,6 +2017,9 @@ func DiffActionSymbol(action plans.Action) string {
 	case plans.Update:
 		return "  [yellow]~[reset]"
 	case plans.NoOp:
+		if importing {
+			return "  [magenta]&[reset]"
+		}
 		return "   "
 	default:
 		return "  ?"

--- a/internal/command/jsonformat/computed/diff.go
+++ b/internal/command/jsonformat/computed/diff.go
@@ -22,21 +22,29 @@ type Diff struct {
 	// update, etc.).
 	Action plans.Action
 
-	// Replace tells the Change that it should add the `# forces replacement`
+	// Replace tells the Diff that it should add the `# forces replacement`
 	// suffix.
 	//
 	// Every single change could potentially add this suffix, so we embed it in
-	// the change as common functionality instead of in the specific renderers.
+	// the diff as common functionality instead of in the specific renderers.
 	Replace bool
+
+	// Importing tells the Diff that it should be rendered in full and replace
+	// the action symbol with the ampersand: '&'.
+	//
+	// Every kind of change can be imported, so we embed it in the diff as
+	// common functionality instead of in the specific renderers.
+	Importing bool
 }
 
 // NewDiff creates a new Diff object with the provided renderer, action and
 // replace context.
-func NewDiff(renderer DiffRenderer, action plans.Action, replace bool) Diff {
+func NewDiff(renderer DiffRenderer, action plans.Action, replace, importing bool) Diff {
 	return Diff{
-		Renderer: renderer,
-		Action:   action,
-		Replace:  replace,
+		Renderer:  renderer,
+		Action:    action,
+		Replace:   replace,
+		Importing: importing,
 	}
 }
 

--- a/internal/command/jsonformat/computed/renderers/block.go
+++ b/internal/command/jsonformat/computed/renderers/block.go
@@ -79,10 +79,10 @@ func (renderer blockRenderer) RenderHuman(diff computed.Diff, indent int, opts c
 			for _, warning := range attribute.WarningsHuman(indent+1, importantAttributeOpts) {
 				buf.WriteString(fmt.Sprintf("%s%s\n", formatIndent(indent+1), warning))
 			}
-			buf.WriteString(fmt.Sprintf("%s%s%-*s = %s\n", formatIndent(indent+1), writeDiffActionSymbol(attribute.Action, importantAttributeOpts), maximumAttributeKeyLen, key, attribute.RenderHuman(indent+1, importantAttributeOpts)))
+			buf.WriteString(fmt.Sprintf("%s%s%-*s = %s\n", formatIndent(indent+1), writeDiffActionSymbol(attribute, importantAttributeOpts), maximumAttributeKeyLen, key, attribute.RenderHuman(indent+1, importantAttributeOpts)))
 			continue
 		}
-		if attribute.Action == plans.NoOp && !opts.ShowUnchangedChildren {
+		if attribute.Action == plans.NoOp && !showUnchangedChildren(attribute, opts) {
 			unchangedAttributes++
 			continue
 		}
@@ -90,11 +90,11 @@ func (renderer blockRenderer) RenderHuman(diff computed.Diff, indent int, opts c
 		for _, warning := range attribute.WarningsHuman(indent+1, opts) {
 			buf.WriteString(fmt.Sprintf("%s%s\n", formatIndent(indent+1), warning))
 		}
-		buf.WriteString(fmt.Sprintf("%s%s%-*s = %s\n", formatIndent(indent+1), writeDiffActionSymbol(attribute.Action, attributeOpts), maximumAttributeKeyLen, escapedAttributeKeys[key], attribute.RenderHuman(indent+1, attributeOpts)))
+		buf.WriteString(fmt.Sprintf("%s%s%-*s = %s\n", formatIndent(indent+1), writeDiffActionSymbol(attribute, attributeOpts), maximumAttributeKeyLen, escapedAttributeKeys[key], attribute.RenderHuman(indent+1, attributeOpts)))
 	}
 
 	if unchangedAttributes > 0 {
-		buf.WriteString(fmt.Sprintf("%s%s%s\n", formatIndent(indent+1), writeDiffActionSymbol(plans.NoOp, opts), unchanged("attribute", unchangedAttributes, opts)))
+		buf.WriteString(fmt.Sprintf("%s%s%s\n", formatIndent(indent+1), writeNoOpSymbol(opts), unchanged("attribute", unchangedAttributes, opts)))
 	}
 
 	blockKeys := renderer.blocks.GetAllKeys()
@@ -118,7 +118,7 @@ func (renderer blockRenderer) RenderHuman(diff computed.Diff, indent int, opts c
 				diff = computed.NewDiff(SensitiveBlock(diff, renderer.blocks.BeforeSensitiveBlocks[key], renderer.blocks.AfterSensitiveBlocks[key]), action, diff.Replace, diff.Importing)
 			}
 
-			if diff.Action == plans.NoOp && !opts.ShowUnchangedChildren {
+			if diff.Action == plans.NoOp && !showUnchangedChildren(diff, opts) {
 				unchangedBlocks++
 				return
 			}
@@ -140,7 +140,7 @@ func (renderer blockRenderer) RenderHuman(diff computed.Diff, indent int, opts c
 			for _, warning := range diff.WarningsHuman(indent+1, blockOpts) {
 				buf.WriteString(fmt.Sprintf("%s%s\n", formatIndent(indent+1), warning))
 			}
-			buf.WriteString(fmt.Sprintf("%s%s%s%s %s\n", formatIndent(indent+1), writeDiffActionSymbol(diff.Action, blockOpts), EnsureValidAttributeName(key), mapKey, diff.RenderHuman(indent+1, blockOpts)))
+			buf.WriteString(fmt.Sprintf("%s%s%s%s %s\n", formatIndent(indent+1), writeDiffActionSymbol(diff, blockOpts), EnsureValidAttributeName(key), mapKey, diff.RenderHuman(indent+1, blockOpts)))
 
 		}
 
@@ -173,9 +173,9 @@ func (renderer blockRenderer) RenderHuman(diff computed.Diff, indent int, opts c
 	}
 
 	if unchangedBlocks > 0 {
-		buf.WriteString(fmt.Sprintf("\n%s%s%s\n", formatIndent(indent+1), writeDiffActionSymbol(plans.NoOp, opts), unchanged("block", unchangedBlocks, opts)))
+		buf.WriteString(fmt.Sprintf("\n%s%s%s\n", formatIndent(indent+1), writeNoOpSymbol(opts), unchanged("block", unchangedBlocks, opts)))
 	}
 
-	buf.WriteString(fmt.Sprintf("%s%s}", formatIndent(indent), writeDiffActionSymbol(plans.NoOp, opts)))
+	buf.WriteString(fmt.Sprintf("%s%s}", formatIndent(indent), writeNoOpSymbol(opts)))
 	return buf.String()
 }

--- a/internal/command/jsonformat/computed/renderers/block.go
+++ b/internal/command/jsonformat/computed/renderers/block.go
@@ -115,7 +115,7 @@ func (renderer blockRenderer) RenderHuman(diff computed.Diff, indent int, opts c
 					action = plans.Update
 				}
 
-				diff = computed.NewDiff(SensitiveBlock(diff, renderer.blocks.BeforeSensitiveBlocks[key], renderer.blocks.AfterSensitiveBlocks[key]), action, diff.Replace)
+				diff = computed.NewDiff(SensitiveBlock(diff, renderer.blocks.BeforeSensitiveBlocks[key], renderer.blocks.AfterSensitiveBlocks[key]), action, diff.Replace, diff.Importing)
 			}
 
 			if diff.Action == plans.NoOp && !opts.ShowUnchangedChildren {

--- a/internal/command/jsonformat/computed/renderers/json.go
+++ b/internal/command/jsonformat/computed/renderers/json.go
@@ -16,23 +16,23 @@ import (
 // our JSON string rendering here.
 func RendererJsonOpts() jsondiff.JsonOpts {
 	return jsondiff.JsonOpts{
-		Primitive: func(before, after interface{}, ctype cty.Type, action plans.Action) computed.Diff {
-			return computed.NewDiff(Primitive(before, after, ctype), action, false)
+		Primitive: func(before, after interface{}, ctype cty.Type, action plans.Action, importing bool) computed.Diff {
+			return computed.NewDiff(Primitive(before, after, ctype), action, false, importing)
 		},
-		Object: func(elements map[string]computed.Diff, action plans.Action) computed.Diff {
-			return computed.NewDiff(Object(elements), action, false)
+		Object: func(elements map[string]computed.Diff, action plans.Action, importing bool) computed.Diff {
+			return computed.NewDiff(Object(elements), action, false, importing)
 		},
-		Array: func(elements []computed.Diff, action plans.Action) computed.Diff {
-			return computed.NewDiff(List(elements), action, false)
+		Array: func(elements []computed.Diff, action plans.Action, importing bool) computed.Diff {
+			return computed.NewDiff(List(elements), action, false, importing)
 		},
-		Unknown: func(diff computed.Diff, action plans.Action) computed.Diff {
-			return computed.NewDiff(Unknown(diff), action, false)
+		Unknown: func(diff computed.Diff, action plans.Action, importing bool) computed.Diff {
+			return computed.NewDiff(Unknown(diff), action, false, importing)
 		},
-		Sensitive: func(diff computed.Diff, beforeSensitive bool, afterSensitive bool, action plans.Action) computed.Diff {
-			return computed.NewDiff(Sensitive(diff, beforeSensitive, afterSensitive), action, false)
+		Sensitive: func(diff computed.Diff, beforeSensitive bool, afterSensitive bool, action plans.Action, importing bool) computed.Diff {
+			return computed.NewDiff(Sensitive(diff, beforeSensitive, afterSensitive), action, false, importing)
 		},
-		TypeChange: func(before, after computed.Diff, action plans.Action) computed.Diff {
-			return computed.NewDiff(TypeChange(before, after), action, false)
+		TypeChange: func(before, after computed.Diff, action plans.Action, importing bool) computed.Diff {
+			return computed.NewDiff(TypeChange(before, after), action, false, importing)
 		},
 	}
 }

--- a/internal/command/jsonformat/computed/renderers/list.go
+++ b/internal/command/jsonformat/computed/renderers/list.go
@@ -51,7 +51,7 @@ func (renderer listRenderer) RenderHuman(diff computed.Diff, indent int, opts co
 	var buf bytes.Buffer
 	buf.WriteString(fmt.Sprintf("[%s\n", forcesReplacement(diff.Replace, opts)))
 	for _, element := range renderer.elements {
-		if element.Action == plans.NoOp && !renderNext && !opts.ShowUnchangedChildren {
+		if element.Action == plans.NoOp && !renderNext && !showUnchangedChildren(element, opts) {
 			unchangedElements = append(unchangedElements, element)
 			continue
 		}
@@ -71,14 +71,14 @@ func (renderer listRenderer) RenderHuman(diff computed.Diff, indent int, opts co
 			// minus 1 as the most recent unchanged element will be printed out
 			// in full.
 			if len(unchangedElements) > 1 {
-				buf.WriteString(fmt.Sprintf("%s%s%s\n", formatIndent(indent+1), writeDiffActionSymbol(plans.NoOp, opts), unchanged("element", len(unchangedElements)-1, opts)))
+				buf.WriteString(fmt.Sprintf("%s%s%s\n", formatIndent(indent+1), writeNoOpSymbol(opts), unchanged("element", len(unchangedElements)-1, opts)))
 			}
 			// If our list of unchanged elements contains at least one entry,
 			// we're going to print out the most recent change in full. That's
 			// what happens here.
 			if len(unchangedElements) > 0 {
 				lastElement := unchangedElements[len(unchangedElements)-1]
-				buf.WriteString(fmt.Sprintf("%s%s%s,\n", formatIndent(indent+1), writeDiffActionSymbol(lastElement.Action, unchangedElementOpts), lastElement.RenderHuman(indent+1, unchangedElementOpts)))
+				buf.WriteString(fmt.Sprintf("%s%s%s,\n", formatIndent(indent+1), writeDiffActionSymbol(lastElement, unchangedElementOpts), lastElement.RenderHuman(indent+1, unchangedElementOpts)))
 			}
 			// We now reset the unchanged elements list, we've printed out a
 			// count of all the elements we skipped so we start counting from
@@ -106,7 +106,7 @@ func (renderer listRenderer) RenderHuman(diff computed.Diff, indent int, opts co
 		for _, warning := range element.WarningsHuman(indent+1, opts) {
 			buf.WriteString(fmt.Sprintf("%s%s\n", formatIndent(indent+1), warning))
 		}
-		buf.WriteString(fmt.Sprintf("%s%s%s,\n", formatIndent(indent+1), writeDiffActionSymbol(element.Action, opts), element.RenderHuman(indent+1, opts)))
+		buf.WriteString(fmt.Sprintf("%s%s%s,\n", formatIndent(indent+1), writeDiffActionSymbol(element, opts), element.RenderHuman(indent+1, opts)))
 	}
 
 	// If we were not displaying any context alongside our changes then the
@@ -116,9 +116,9 @@ func (renderer listRenderer) RenderHuman(diff computed.Diff, indent int, opts co
 	// If we were displaying context, then this will contain any unchanged
 	// elements since our last change, so we should also print it out.
 	if len(unchangedElements) > 0 {
-		buf.WriteString(fmt.Sprintf("%s%s%s\n", formatIndent(indent+1), writeDiffActionSymbol(plans.NoOp, opts), unchanged("element", len(unchangedElements), opts)))
+		buf.WriteString(fmt.Sprintf("%s%s%s\n", formatIndent(indent+1), writeNoOpSymbol(opts), unchanged("element", len(unchangedElements), opts)))
 	}
 
-	buf.WriteString(fmt.Sprintf("%s%s]%s", formatIndent(indent), writeDiffActionSymbol(plans.NoOp, opts), nullSuffix(diff.Action, opts)))
+	buf.WriteString(fmt.Sprintf("%s%s]%s", formatIndent(indent), writeNoOpSymbol(opts), nullSuffix(diff.Action, opts)))
 	return buf.String()
 }

--- a/internal/command/jsonformat/computed/renderers/map.go
+++ b/internal/command/jsonformat/computed/renderers/map.go
@@ -75,7 +75,7 @@ func (renderer mapRenderer) RenderHuman(diff computed.Diff, indent int, opts com
 	for _, key := range keys {
 		element := renderer.elements[key]
 
-		if element.Action == plans.NoOp && !opts.ShowUnchangedChildren {
+		if element.Action == plans.NoOp && !showUnchangedChildren(element, opts) {
 			// Don't render NoOp operations when we are compact display.
 			unchangedElements++
 			continue
@@ -91,17 +91,17 @@ func (renderer mapRenderer) RenderHuman(diff computed.Diff, indent int, opts com
 		}
 
 		if renderer.alignKeys {
-			buf.WriteString(fmt.Sprintf("%s%s%-*s = %s%s\n", formatIndent(indent+1), writeDiffActionSymbol(element.Action, elementOpts), maximumKeyLen, escapedKeys[key], element.RenderHuman(indent+1, elementOpts), comma))
+			buf.WriteString(fmt.Sprintf("%s%s%-*s = %s%s\n", formatIndent(indent+1), writeDiffActionSymbol(element, elementOpts), maximumKeyLen, escapedKeys[key], element.RenderHuman(indent+1, elementOpts), comma))
 		} else {
-			buf.WriteString(fmt.Sprintf("%s%s%s = %s%s\n", formatIndent(indent+1), writeDiffActionSymbol(element.Action, elementOpts), escapedKeys[key], element.RenderHuman(indent+1, elementOpts), comma))
+			buf.WriteString(fmt.Sprintf("%s%s%s = %s%s\n", formatIndent(indent+1), writeDiffActionSymbol(element, elementOpts), escapedKeys[key], element.RenderHuman(indent+1, elementOpts), comma))
 		}
 
 	}
 
 	if unchangedElements > 0 {
-		buf.WriteString(fmt.Sprintf("%s%s%s\n", formatIndent(indent+1), writeDiffActionSymbol(plans.NoOp, opts), unchanged("element", unchangedElements, opts)))
+		buf.WriteString(fmt.Sprintf("%s%s%s\n", formatIndent(indent+1), writeNoOpSymbol(opts), unchanged("element", unchangedElements, opts)))
 	}
 
-	buf.WriteString(fmt.Sprintf("%s%s}%s", formatIndent(indent), writeDiffActionSymbol(plans.NoOp, opts), nullSuffix(diff.Action, opts)))
+	buf.WriteString(fmt.Sprintf("%s%s}%s", formatIndent(indent), writeNoOpSymbol(opts), nullSuffix(diff.Action, opts)))
 	return buf.String()
 }

--- a/internal/command/jsonformat/computed/renderers/object.go
+++ b/internal/command/jsonformat/computed/renderers/object.go
@@ -70,11 +70,11 @@ func (renderer objectRenderer) RenderHuman(diff computed.Diff, indent int, opts 
 			for _, warning := range attribute.WarningsHuman(indent+1, importantAttributeOpts) {
 				buf.WriteString(fmt.Sprintf("%s%s\n", formatIndent(indent+1), warning))
 			}
-			buf.WriteString(fmt.Sprintf("%s%s%-*s = %s\n", formatIndent(indent+1), writeDiffActionSymbol(attribute.Action, importantAttributeOpts), maximumKeyLen, escapedKeys[key], attribute.RenderHuman(indent+1, importantAttributeOpts)))
+			buf.WriteString(fmt.Sprintf("%s%s%-*s = %s\n", formatIndent(indent+1), writeDiffActionSymbol(attribute, importantAttributeOpts), maximumKeyLen, escapedKeys[key], attribute.RenderHuman(indent+1, importantAttributeOpts)))
 			continue
 		}
 
-		if attribute.Action == plans.NoOp && !opts.ShowUnchangedChildren {
+		if attribute.Action == plans.NoOp && !showUnchangedChildren(attribute, opts) {
 			// Don't render NoOp operations when we are compact display.
 			unchangedAttributes++
 			continue
@@ -83,13 +83,13 @@ func (renderer objectRenderer) RenderHuman(diff computed.Diff, indent int, opts 
 		for _, warning := range attribute.WarningsHuman(indent+1, opts) {
 			buf.WriteString(fmt.Sprintf("%s%s\n", formatIndent(indent+1), warning))
 		}
-		buf.WriteString(fmt.Sprintf("%s%s%-*s = %s\n", formatIndent(indent+1), writeDiffActionSymbol(attribute.Action, attributeOpts), maximumKeyLen, escapedKeys[key], attribute.RenderHuman(indent+1, attributeOpts)))
+		buf.WriteString(fmt.Sprintf("%s%s%-*s = %s\n", formatIndent(indent+1), writeDiffActionSymbol(attribute, attributeOpts), maximumKeyLen, escapedKeys[key], attribute.RenderHuman(indent+1, attributeOpts)))
 	}
 
 	if unchangedAttributes > 0 {
-		buf.WriteString(fmt.Sprintf("%s%s%s\n", formatIndent(indent+1), writeDiffActionSymbol(plans.NoOp, opts), unchanged("attribute", unchangedAttributes, opts)))
+		buf.WriteString(fmt.Sprintf("%s%s%s\n", formatIndent(indent+1), writeNoOpSymbol(opts), unchanged("attribute", unchangedAttributes, opts)))
 	}
 
-	buf.WriteString(fmt.Sprintf("%s%s}%s", formatIndent(indent), writeDiffActionSymbol(plans.NoOp, opts), nullSuffix(diff.Action, opts)))
+	buf.WriteString(fmt.Sprintf("%s%s}%s", formatIndent(indent), writeNoOpSymbol(opts), nullSuffix(diff.Action, opts)))
 	return buf.String()
 }

--- a/internal/command/jsonformat/computed/renderers/primitive.go
+++ b/internal/command/jsonformat/computed/renderers/primitive.go
@@ -95,12 +95,12 @@ func (renderer primitiveRenderer) renderStringDiff(diff computed.Diff, indent in
 		// We are creating a single multiline string, so let's split by the new
 		// line character. While we are doing this, we are going to insert our
 		// indents and make sure each line is formatted correctly.
-		lines = strings.Split(strings.ReplaceAll(str.String, "\n", fmt.Sprintf("\n%s%s", formatIndent(indent+1), writeDiffActionSymbol(plans.NoOp, opts))), "\n")
+		lines = strings.Split(strings.ReplaceAll(str.String, "\n", fmt.Sprintf("\n%s%s", formatIndent(indent+1), writeNoOpSymbol(opts))), "\n")
 
 		// We now just need to do the same for the first entry in lines, because
 		// we split on the new line characters which won't have been at the
 		// beginning of the first line.
-		lines[0] = fmt.Sprintf("%s%s%s", formatIndent(indent+1), writeDiffActionSymbol(plans.NoOp, opts), lines[0])
+		lines[0] = fmt.Sprintf("%s%s%s", formatIndent(indent+1), writeNoOpSymbol(opts), lines[0])
 	case plans.Delete:
 		str := evaluatePrimitiveString(renderer.before, opts)
 		if str.IsNull {
@@ -120,12 +120,12 @@ func (renderer primitiveRenderer) renderStringDiff(diff computed.Diff, indent in
 		// We are creating a single multiline string, so let's split by the new
 		// line character. While we are doing this, we are going to insert our
 		// indents and make sure each line is formatted correctly.
-		lines = strings.Split(strings.ReplaceAll(str.String, "\n", fmt.Sprintf("\n%s%s", formatIndent(indent+1), writeDiffActionSymbol(plans.NoOp, opts))), "\n")
+		lines = strings.Split(strings.ReplaceAll(str.String, "\n", fmt.Sprintf("\n%s%s", formatIndent(indent+1), writeNoOpSymbol(opts))), "\n")
 
 		// We now just need to do the same for the first entry in lines, because
 		// we split on the new line characters which won't have been at the
 		// beginning of the first line.
-		lines[0] = fmt.Sprintf("%s%s%s", formatIndent(indent+1), writeDiffActionSymbol(plans.NoOp, opts), lines[0])
+		lines[0] = fmt.Sprintf("%s%s%s", formatIndent(indent+1), writeNoOpSymbol(opts), lines[0])
 	default:
 		beforeString := evaluatePrimitiveString(renderer.before, opts)
 		afterString := evaluatePrimitiveString(renderer.after, opts)
@@ -156,16 +156,16 @@ func (renderer primitiveRenderer) renderStringDiff(diff computed.Diff, indent in
 
 		processIndices := func(beforeIx, afterIx int) {
 			if beforeIx < 0 || beforeIx >= len(beforeLines) {
-				lines = append(lines, fmt.Sprintf("%s%s%s", formatIndent(indent+1), writeDiffActionSymbol(plans.Create, opts), afterLines[afterIx]))
+				lines = append(lines, fmt.Sprintf("%s%s%s", formatIndent(indent+1), writeActionSymbol(plans.Create, diff.Importing, opts), afterLines[afterIx]))
 				return
 			}
 
 			if afterIx < 0 || afterIx >= len(afterLines) {
-				lines = append(lines, fmt.Sprintf("%s%s%s", formatIndent(indent+1), writeDiffActionSymbol(plans.Delete, opts), beforeLines[beforeIx]))
+				lines = append(lines, fmt.Sprintf("%s%s%s", formatIndent(indent+1), writeActionSymbol(plans.Delete, diff.Importing, opts), beforeLines[beforeIx]))
 				return
 			}
 
-			lines = append(lines, fmt.Sprintf("%s%s%s", formatIndent(indent+1), writeDiffActionSymbol(plans.NoOp, opts), beforeLines[beforeIx]))
+			lines = append(lines, fmt.Sprintf("%s%s%s", formatIndent(indent+1), writeNoOpSymbol(opts), beforeLines[beforeIx]))
 		}
 		isObjType := func(_ string) bool {
 			return false
@@ -180,7 +180,7 @@ func (renderer primitiveRenderer) renderStringDiff(diff computed.Diff, indent in
 		forcesReplacement(diff.Replace, opts),
 		strings.Join(lines, "\n"),
 		formatIndent(indent),
-		writeDiffActionSymbol(plans.NoOp, opts),
+		writeNoOpSymbol(opts),
 		nullSuffix(diff.Action, opts))
 }
 
@@ -234,7 +234,7 @@ func (renderer primitiveRenderer) renderStringDiffAsJson(diff computed.Diff, ind
 	}
 
 	if strings.Contains(renderedJsonDiff, "\n") {
-		return fmt.Sprintf("jsonencode(%s\n%s%s%s%s\n%s%s)%s", whitespace, formatIndent(indent+1), writeDiffActionSymbol(action, opts), renderedJsonDiff, replace, formatIndent(indent), writeDiffActionSymbol(plans.NoOp, opts), nullSuffix(diff.Action, opts))
+		return fmt.Sprintf("jsonencode(%s\n%s%s%s%s\n%s%s)%s", whitespace, formatIndent(indent+1), writeActionSymbol(action, diff.Importing, opts), renderedJsonDiff, replace, formatIndent(indent), writeNoOpSymbol(opts), nullSuffix(diff.Action, opts))
 	}
 	return fmt.Sprintf("jsonencode(%s)%s%s", renderedJsonDiff, whitespace, replace)
 }

--- a/internal/command/jsonformat/computed/renderers/primitive.go
+++ b/internal/command/jsonformat/computed/renderers/primitive.go
@@ -140,10 +140,11 @@ func (renderer primitiveRenderer) renderStringDiff(diff computed.Diff, indent in
 			// renderer for this so let's keep it simple.
 			return computed.NewDiff(
 				TypeChange(
-					computed.NewDiff(Primitive(renderer.before, nil, cty.String), plans.Delete, false),
-					computed.NewDiff(Primitive(nil, renderer.after, cty.String), plans.Create, false)),
+					computed.NewDiff(Primitive(renderer.before, nil, cty.String), plans.Delete, false, diff.Importing),
+					computed.NewDiff(Primitive(nil, renderer.after, cty.String), plans.Create, false, diff.Importing)),
 				diff.Action,
-				diff.Replace).RenderHuman(indent, opts)
+				diff.Replace,
+				diff.Importing).RenderHuman(indent, opts)
 		}
 
 		if !beforeString.IsMultiline && !afterString.IsMultiline {

--- a/internal/command/jsonformat/computed/renderers/renderer_test.go
+++ b/internal/command/jsonformat/computed/renderers/renderer_test.go
@@ -2197,6 +2197,337 @@ jsonencode(
 )
 `,
 		},
+		"import_primitive": {
+			diff: computed.Diff{
+				Renderer:  Primitive("value", "value", cty.String),
+				Action:    plans.NoOp,
+				Importing: true,
+			},
+			expected: "\"value\"",
+		},
+		"import_primitive_create": {
+			diff: computed.Diff{
+				Renderer:  Primitive(nil, "value", cty.String),
+				Action:    plans.Create,
+				Importing: true,
+			},
+			expected: "\"value\"",
+		},
+		"import_primitive_update": {
+			diff: computed.Diff{
+				Renderer:  Primitive("old", "new", cty.String),
+				Action:    plans.Update,
+				Importing: true,
+			},
+			expected: "\"old\" -> \"new\"",
+		},
+		"import_primitive_delete": {
+			diff: computed.Diff{
+				Renderer:  Primitive("value", nil, cty.String),
+				Action:    plans.Delete,
+				Importing: true,
+			},
+			expected: "\"value\" -> null",
+		},
+		"import_list": {
+			diff: computed.Diff{
+				Renderer: List([]computed.Diff{
+					{
+						Renderer:  Primitive(0.0, 0.0, cty.Number),
+						Action:    plans.NoOp,
+						Importing: true,
+					},
+					{
+						Renderer:  Primitive(-1.0, 1.0, cty.Number),
+						Action:    plans.Update,
+						Importing: true,
+					},
+					{
+						Renderer:  Primitive(2.0, nil, cty.Number),
+						Action:    plans.Delete,
+						Importing: true,
+					},
+					{
+						Renderer:  Primitive(nil, 3.0, cty.Number),
+						Action:    plans.Create,
+						Importing: true,
+					},
+				}),
+				Action:    plans.Update,
+				Importing: true,
+			},
+			expected: `
+[
+      & 0,
+      ~ -1 -> 1,
+      - 2,
+      + 3,
+    ]
+`,
+		},
+		"import_set": {
+			diff: computed.Diff{
+				Renderer: Set([]computed.Diff{
+					{
+						Renderer:  Primitive(0.0, 0.0, cty.Number),
+						Action:    plans.NoOp,
+						Importing: true,
+					},
+					{
+						Renderer:  Primitive(-1.0, 1.0, cty.Number),
+						Action:    plans.Update,
+						Importing: true,
+					},
+					{
+						Renderer:  Primitive(2.0, nil, cty.Number),
+						Action:    plans.Delete,
+						Importing: true,
+					},
+					{
+						Renderer:  Primitive(nil, 3.0, cty.Number),
+						Action:    plans.Create,
+						Importing: true,
+					},
+				}),
+				Action:    plans.Update,
+				Importing: true,
+			},
+			expected: `
+[
+      & 0,
+      ~ -1 -> 1,
+      - 2,
+      + 3,
+    ]
+`,
+		},
+		"import_object": {
+			diff: computed.Diff{
+				Renderer: Object(map[string]computed.Diff{
+					"aa": {
+						Renderer:  Primitive("aa", "aa", cty.String),
+						Action:    plans.NoOp,
+						Importing: true,
+					},
+					"ab": {
+						Renderer:  Primitive(nil, "ab", cty.String),
+						Action:    plans.Create,
+						Importing: true,
+					},
+					"bb": {
+						Renderer:  Primitive("bb", "ac", cty.String),
+						Action:    plans.Update,
+						Importing: true,
+					},
+					"ba": {
+						Renderer:  Primitive("ba", nil, cty.String),
+						Action:    plans.Delete,
+						Importing: true,
+					},
+				}),
+				Action:    plans.Update,
+				Importing: true,
+			},
+			expected: `
+{
+      & aa = "aa"
+      + ab = "ab"
+      - ba = "ba"
+      ~ bb = "bb" -> "ac"
+    }
+`,
+		},
+		"import_map": {
+			diff: computed.Diff{
+				Renderer: Map(map[string]computed.Diff{
+					"aa": {
+						Renderer:  Primitive("aa", "aa", cty.String),
+						Action:    plans.NoOp,
+						Importing: true,
+					},
+					"ab": {
+						Renderer:  Primitive(nil, "ab", cty.String),
+						Action:    plans.Create,
+						Importing: true,
+					},
+					"bb": {
+						Renderer:  Primitive("bb", "ac", cty.String),
+						Action:    plans.Update,
+						Importing: true,
+					},
+					"ba": {
+						Renderer:  Primitive("ba", nil, cty.String),
+						Action:    plans.Delete,
+						Importing: true,
+					},
+				}),
+				Action:    plans.Update,
+				Importing: true,
+			},
+			expected: `
+{
+      & "aa" = "aa"
+      + "ab" = "ab"
+      - "ba" = "ba" -> null
+      ~ "bb" = "bb" -> "ac"
+    }
+`,
+		},
+		"import_block": {
+			diff: computed.Diff{
+				Renderer: Block(map[string]computed.Diff{
+					"aa": {
+						Renderer:  Primitive("aa", "aa", cty.String),
+						Action:    plans.NoOp,
+						Importing: true,
+					},
+					"ab": {
+						Renderer:  Primitive(nil, "ab", cty.String),
+						Action:    plans.Create,
+						Importing: true,
+					},
+					"bb": {
+						Renderer:  Primitive("bb", "ac", cty.String),
+						Action:    plans.Update,
+						Importing: true,
+					},
+					"ba": {
+						Renderer:  Primitive("ba", nil, cty.String),
+						Action:    plans.Delete,
+						Importing: true,
+					},
+				}, Blocks{
+					SingleBlocks: map[string]computed.Diff{
+						"block_aa": {
+							Renderer: Block(map[string]computed.Diff{
+								"aa": {
+									Renderer:  Primitive("aa", "aa", cty.String),
+									Action:    plans.NoOp,
+									Importing: true,
+								},
+								"ab": {
+									Renderer:  Unknown(computed.Diff{}),
+									Action:    plans.Create,
+									Importing: true,
+								},
+								"bb": {
+									Renderer:  Primitive("bb", "ac", cty.String),
+									Action:    plans.Update,
+									Importing: true,
+								},
+								"ba": {
+									Renderer:  Primitive("ba", nil, cty.String),
+									Action:    plans.Delete,
+									Importing: true,
+								},
+							}, Blocks{}),
+							Action:    plans.Update,
+							Importing: true,
+						},
+					},
+					ListBlocks: map[string][]computed.Diff{
+						"block_ab": {
+							{
+								Renderer: Block(map[string]computed.Diff{
+									"aa": {
+										Renderer:  Primitive("aa", "aa", cty.String),
+										Action:    plans.NoOp,
+										Importing: true,
+									},
+								}, Blocks{}),
+								Action:    plans.NoOp,
+								Importing: true,
+							},
+							{
+								Renderer: Block(map[string]computed.Diff{
+									"aa": {
+										Renderer:  Primitive("ab", "ab", cty.String),
+										Action:    plans.Update,
+										Importing: true,
+									},
+								}, Blocks{}),
+								Action:    plans.Update,
+								Importing: true,
+							},
+						},
+					},
+					SetBlocks: map[string][]computed.Diff{
+						"block_ac": {
+							{
+								Renderer: Block(map[string]computed.Diff{
+									"aa": {
+										Renderer:  Primitive("aa", "aa", cty.String),
+										Action:    plans.NoOp,
+										Importing: true,
+									},
+								}, Blocks{}),
+								Action:    plans.NoOp,
+								Importing: true,
+							},
+							{
+								Renderer: Block(map[string]computed.Diff{
+									"aa": {
+										Renderer:  Primitive("ab", "ab", cty.String),
+										Action:    plans.Update,
+										Importing: true,
+									},
+								}, Blocks{}),
+								Action:    plans.Update,
+								Importing: true,
+							},
+						},
+					},
+					MapBlocks:     map[string]map[string]computed.Diff{},
+					ReplaceBlocks: map[string]bool{},
+					BeforeSensitiveBlocks: map[string]bool{
+						"block_ab": true,
+					},
+					AfterSensitiveBlocks: map[string]bool{
+						"block_ab": true,
+						"block_ac": true,
+					},
+				}),
+				Action:    plans.Update,
+				Importing: true,
+			},
+			expected: `
+{
+      & aa = "aa"
+      + ab = "ab"
+      - ba = "ba" -> null
+      ~ bb = "bb" -> "ac"
+
+      ~ block_aa {
+          & aa = "aa"
+          + ab = (known after apply)
+          - ba = "ba" -> null
+          ~ bb = "bb" -> "ac"
+        }
+
+      & block_ab {
+          # At least one attribute in this block is (or was) sensitive,
+          # so its contents will not be displayed.
+        }
+      ~ block_ab {
+          # At least one attribute in this block is (or was) sensitive,
+          # so its contents will not be displayed.
+        }
+
+      # Warning: this block will be marked as sensitive and will not
+      # display in UI output after applying this change.
+      ~ block_ac {
+          # At least one attribute in this block is (or was) sensitive,
+          # so its contents will not be displayed.
+        }
+      # Warning: this block will be marked as sensitive and will not
+      # display in UI output after applying this change.
+      ~ block_ac {
+          # At least one attribute in this block is (or was) sensitive,
+          # so its contents will not be displayed.
+        }
+    }
+`,
+		},
 	}
 	for name, tc := range tcs {
 		t.Run(name, func(t *testing.T) {

--- a/internal/command/jsonformat/computed/renderers/sensitive_block.go
+++ b/internal/command/jsonformat/computed/renderers/sensitive_block.go
@@ -23,7 +23,7 @@ type sensitiveBlockRenderer struct {
 }
 
 func (renderer sensitiveBlockRenderer) RenderHuman(diff computed.Diff, indent int, opts computed.RenderHumanOpts) string {
-	cachedLinePrefix := fmt.Sprintf("%s%s", formatIndent(indent), writeDiffActionSymbol(plans.NoOp, opts))
+	cachedLinePrefix := fmt.Sprintf("%s%s", formatIndent(indent), writeNoOpSymbol(opts))
 	return fmt.Sprintf("{%s\n%s  # At least one attribute in this block is (or was) sensitive,\n%s  # so its contents will not be displayed.\n%s}",
 		forcesReplacement(diff.Replace, opts), cachedLinePrefix, cachedLinePrefix, cachedLinePrefix)
 }

--- a/internal/command/jsonformat/computed/renderers/set.go
+++ b/internal/command/jsonformat/computed/renderers/set.go
@@ -52,7 +52,7 @@ func (renderer setRenderer) RenderHuman(diff computed.Diff, indent int, opts com
 	var buf bytes.Buffer
 	buf.WriteString(fmt.Sprintf("[%s\n", forcesReplacement(displayForcesReplacementInSelf, opts)))
 	for _, element := range renderer.elements {
-		if element.Action == plans.NoOp && !opts.ShowUnchangedChildren {
+		if element.Action == plans.NoOp && !showUnchangedChildren(element, opts) {
 			unchangedElements++
 			continue
 		}
@@ -60,13 +60,13 @@ func (renderer setRenderer) RenderHuman(diff computed.Diff, indent int, opts com
 		for _, warning := range element.WarningsHuman(indent+1, opts) {
 			buf.WriteString(fmt.Sprintf("%s%s\n", formatIndent(indent+1), warning))
 		}
-		buf.WriteString(fmt.Sprintf("%s%s%s,\n", formatIndent(indent+1), writeDiffActionSymbol(element.Action, elementOpts), element.RenderHuman(indent+1, elementOpts)))
+		buf.WriteString(fmt.Sprintf("%s%s%s,\n", formatIndent(indent+1), writeDiffActionSymbol(element, elementOpts), element.RenderHuman(indent+1, elementOpts)))
 	}
 
 	if unchangedElements > 0 {
-		buf.WriteString(fmt.Sprintf("%s%s%s\n", formatIndent(indent+1), writeDiffActionSymbol(plans.NoOp, opts), unchanged("element", unchangedElements, opts)))
+		buf.WriteString(fmt.Sprintf("%s%s%s\n", formatIndent(indent+1), writeNoOpSymbol(opts), unchanged("element", unchangedElements, opts)))
 	}
 
-	buf.WriteString(fmt.Sprintf("%s%s]%s", formatIndent(indent), writeDiffActionSymbol(plans.NoOp, opts), nullSuffix(diff.Action, opts)))
+	buf.WriteString(fmt.Sprintf("%s%s]%s", formatIndent(indent), writeNoOpSymbol(opts), nullSuffix(diff.Action, opts)))
 	return buf.String()
 }

--- a/internal/command/jsonformat/computed/renderers/testing.go
+++ b/internal/command/jsonformat/computed/renderers/testing.go
@@ -12,15 +12,15 @@ import (
 
 type ValidateDiffFunction func(t *testing.T, diff computed.Diff)
 
-func validateDiff(t *testing.T, diff computed.Diff, expectedAction plans.Action, expectedReplace bool) {
-	if diff.Replace != expectedReplace || diff.Action != expectedAction {
-		t.Errorf("\nreplace:\n\texpected:%t\n\tactual:%t\naction:\n\texpected:%s\n\tactual:%s", expectedReplace, diff.Replace, expectedAction, diff.Action)
+func validateDiff(t *testing.T, diff computed.Diff, expectedAction plans.Action, expectedReplace bool, expectedImporting bool) {
+	if diff.Replace != expectedReplace || diff.Action != expectedAction || diff.Importing != expectedImporting {
+		t.Errorf("\nreplace:\n\texpected:%t\n\tactual:%t\naction:\n\texpected:%s\n\tactual:%s\nimporting:\n\texpected:%t\n\tactual:%t", expectedReplace, diff.Replace, expectedAction, diff.Action, expectedImporting, diff.Importing)
 	}
 }
 
-func ValidatePrimitive(before, after interface{}, action plans.Action, replace bool) ValidateDiffFunction {
+func ValidatePrimitive(before, after interface{}, action plans.Action, replace, importing bool) ValidateDiffFunction {
 	return func(t *testing.T, diff computed.Diff) {
-		validateDiff(t, diff, action, replace)
+		validateDiff(t, diff, action, replace, importing)
 
 		primitive, ok := diff.Renderer.(*primitiveRenderer)
 		if !ok {
@@ -37,9 +37,9 @@ func ValidatePrimitive(before, after interface{}, action plans.Action, replace b
 	}
 }
 
-func ValidateObject(attributes map[string]ValidateDiffFunction, action plans.Action, replace bool) ValidateDiffFunction {
+func ValidateObject(attributes map[string]ValidateDiffFunction, action plans.Action, replace bool, importing bool) ValidateDiffFunction {
 	return func(t *testing.T, diff computed.Diff) {
-		validateDiff(t, diff, action, replace)
+		validateDiff(t, diff, action, replace, importing)
 
 		object, ok := diff.Renderer.(*objectRenderer)
 		if !ok {
@@ -55,9 +55,9 @@ func ValidateObject(attributes map[string]ValidateDiffFunction, action plans.Act
 	}
 }
 
-func ValidateNestedObject(attributes map[string]ValidateDiffFunction, action plans.Action, replace bool) ValidateDiffFunction {
+func ValidateNestedObject(attributes map[string]ValidateDiffFunction, action plans.Action, replace bool, importing bool) ValidateDiffFunction {
 	return func(t *testing.T, diff computed.Diff) {
-		validateDiff(t, diff, action, replace)
+		validateDiff(t, diff, action, replace, importing)
 
 		object, ok := diff.Renderer.(*objectRenderer)
 		if !ok {
@@ -73,9 +73,9 @@ func ValidateNestedObject(attributes map[string]ValidateDiffFunction, action pla
 	}
 }
 
-func ValidateMap(elements map[string]ValidateDiffFunction, action plans.Action, replace bool) ValidateDiffFunction {
+func ValidateMap(elements map[string]ValidateDiffFunction, action plans.Action, replace bool, importing bool) ValidateDiffFunction {
 	return func(t *testing.T, diff computed.Diff) {
-		validateDiff(t, diff, action, replace)
+		validateDiff(t, diff, action, replace, importing)
 
 		m, ok := diff.Renderer.(*mapRenderer)
 		if !ok {
@@ -119,9 +119,9 @@ func validateKeys[C, V any](t *testing.T, actual map[string]C, expected map[stri
 	}
 }
 
-func ValidateList(elements []ValidateDiffFunction, action plans.Action, replace bool) ValidateDiffFunction {
+func ValidateList(elements []ValidateDiffFunction, action plans.Action, replace bool, importing bool) ValidateDiffFunction {
 	return func(t *testing.T, diff computed.Diff) {
-		validateDiff(t, diff, action, replace)
+		validateDiff(t, diff, action, replace, importing)
 
 		list, ok := diff.Renderer.(*listRenderer)
 		if !ok {
@@ -137,9 +137,9 @@ func ValidateList(elements []ValidateDiffFunction, action plans.Action, replace 
 	}
 }
 
-func ValidateNestedList(elements []ValidateDiffFunction, action plans.Action, replace bool) ValidateDiffFunction {
+func ValidateNestedList(elements []ValidateDiffFunction, action plans.Action, replace bool, importing bool) ValidateDiffFunction {
 	return func(t *testing.T, diff computed.Diff) {
-		validateDiff(t, diff, action, replace)
+		validateDiff(t, diff, action, replace, importing)
 
 		list, ok := diff.Renderer.(*listRenderer)
 		if !ok {
@@ -155,9 +155,9 @@ func ValidateNestedList(elements []ValidateDiffFunction, action plans.Action, re
 	}
 }
 
-func ValidateSet(elements []ValidateDiffFunction, action plans.Action, replace bool) ValidateDiffFunction {
+func ValidateSet(elements []ValidateDiffFunction, action plans.Action, replace bool, importing bool) ValidateDiffFunction {
 	return func(t *testing.T, diff computed.Diff) {
-		validateDiff(t, diff, action, replace)
+		validateDiff(t, diff, action, replace, importing)
 
 		set, ok := diff.Renderer.(*setRenderer)
 		if !ok {
@@ -187,9 +187,10 @@ func ValidateBlock(
 	mapBlocks map[string]map[string]ValidateDiffFunction,
 	setBlocks map[string][]ValidateDiffFunction,
 	action plans.Action,
-	replace bool) ValidateDiffFunction {
+	replace bool,
+	importing bool) ValidateDiffFunction {
 	return func(t *testing.T, diff computed.Diff) {
-		validateDiff(t, diff, action, replace)
+		validateDiff(t, diff, action, replace, importing)
 
 		block, ok := diff.Renderer.(*blockRenderer)
 		if !ok {
@@ -259,9 +260,9 @@ func ValidateBlock(
 	}
 }
 
-func ValidateTypeChange(before, after ValidateDiffFunction, action plans.Action, replace bool) ValidateDiffFunction {
+func ValidateTypeChange(before, after ValidateDiffFunction, action plans.Action, replace, importing bool) ValidateDiffFunction {
 	return func(t *testing.T, diff computed.Diff) {
-		validateDiff(t, diff, action, replace)
+		validateDiff(t, diff, action, replace, importing)
 
 		typeChange, ok := diff.Renderer.(*typeChangeRenderer)
 		if !ok {
@@ -274,9 +275,9 @@ func ValidateTypeChange(before, after ValidateDiffFunction, action plans.Action,
 	}
 }
 
-func ValidateSensitive(inner ValidateDiffFunction, beforeSensitive, afterSensitive bool, action plans.Action, replace bool) ValidateDiffFunction {
+func ValidateSensitive(inner ValidateDiffFunction, beforeSensitive, afterSensitive bool, action plans.Action, replace, importing bool) ValidateDiffFunction {
 	return func(t *testing.T, diff computed.Diff) {
-		validateDiff(t, diff, action, replace)
+		validateDiff(t, diff, action, replace, importing)
 
 		sensitive, ok := diff.Renderer.(*sensitiveRenderer)
 		if !ok {
@@ -292,9 +293,9 @@ func ValidateSensitive(inner ValidateDiffFunction, beforeSensitive, afterSensiti
 	}
 }
 
-func ValidateUnknown(before ValidateDiffFunction, action plans.Action, replace bool) ValidateDiffFunction {
+func ValidateUnknown(before ValidateDiffFunction, action plans.Action, replace bool, importing bool) ValidateDiffFunction {
 	return func(t *testing.T, diff computed.Diff) {
-		validateDiff(t, diff, action, replace)
+		validateDiff(t, diff, action, replace, importing)
 
 		unknown, ok := diff.Renderer.(*unknownRenderer)
 		if !ok {

--- a/internal/command/jsonformat/computed/renderers/util.go
+++ b/internal/command/jsonformat/computed/renderers/util.go
@@ -76,15 +76,32 @@ func hclEscapeString(str string) string {
 	return fmt.Sprintf("%q", str)
 }
 
-// writeDiffActionSymbol writes out the symbols for the associated action, and
+// writeDiffActionSymbol is a shortcut for writeActionSymbol, allowing the
+// caller to directly supply a computed.Diff object to simplify the external
+// functions.
+func writeDiffActionSymbol(diff computed.Diff, opts computed.RenderHumanOpts) string {
+	return writeActionSymbol(diff.Action, diff.Importing, opts)
+}
+
+// writeNoOpSymbol is a shortcut for writeActionSymbol, automatically supplying
+// the values for a NoOp action.
+func writeNoOpSymbol(opts computed.RenderHumanOpts) string {
+	return writeActionSymbol(plans.NoOp, false, opts)
+}
+
+// writeActionSymbol writes out the symbols for the associated action, and
 // handles localized colorization of the symbol as well as indenting the symbol
 // to be 4 spaces wide.
 //
 // If the opts has HideDiffActionSymbols set then this function returns an empty
 // string.
-func writeDiffActionSymbol(action plans.Action, opts computed.RenderHumanOpts) string {
+func writeActionSymbol(action plans.Action, importing bool, opts computed.RenderHumanOpts) string {
 	if opts.HideDiffActionSymbols {
 		return ""
 	}
-	return fmt.Sprintf("%s ", opts.Colorize.Color(format.DiffActionSymbol(action)))
+	return fmt.Sprintf("%s ", opts.Colorize.Color(format.DiffActionSymbol(action, importing)))
+}
+
+func showUnchangedChildren(diff computed.Diff, opts computed.RenderHumanOpts) bool {
+	return diff.Importing || opts.ShowUnchangedChildren
 }

--- a/internal/command/jsonformat/diff.go
+++ b/internal/command/jsonformat/diff.go
@@ -97,3 +97,7 @@ type diff struct {
 func (d diff) Moved() bool {
 	return len(d.change.PreviousAddress) > 0 && d.change.PreviousAddress != d.change.Address
 }
+
+func (d diff) Imported() bool {
+	return d.diff.Importing
+}

--- a/internal/command/jsonformat/differ/block.go
+++ b/internal/command/jsonformat/differ/block.go
@@ -114,5 +114,5 @@ func ComputeDiffForBlock(change structured.Change, block *jsonprovider.Block) co
 		}
 	}
 
-	return computed.NewDiff(renderers.Block(attributes, blocks), current, change.ReplacePaths.Matches())
+	return computed.NewDiff(renderers.Block(attributes, blocks), current, change.ReplacePaths.Matches(), change.Importing)
 }

--- a/internal/command/jsonformat/differ/differ.go
+++ b/internal/command/jsonformat/differ/differ.go
@@ -8,5 +8,5 @@ import (
 // asDiff is a helper function to abstract away some simple and common
 // functionality when converting a renderer into a concrete diff.
 func asDiff(change structured.Change, renderer computed.DiffRenderer) computed.Diff {
-	return computed.NewDiff(renderer, change.CalculateAction(), change.ReplacePaths.Matches())
+	return computed.NewDiff(renderer, change.CalculateAction(), change.ReplacePaths.Matches(), change.Importing)
 }

--- a/internal/command/jsonformat/differ/list.go
+++ b/internal/command/jsonformat/differ/list.go
@@ -46,7 +46,7 @@ func computeAttributeDiffAsList(change structured.Change, elementType cty.Type) 
 	}
 
 	elements, current := collections.TransformSlice(sliceValue.Before, sliceValue.After, processIndices, isObjType)
-	return computed.NewDiff(renderers.List(elements), current, change.ReplacePaths.Matches())
+	return computed.NewDiff(renderers.List(elements), current, change.ReplacePaths.Matches(), change.Importing)
 }
 
 func computeAttributeDiffAsNestedList(change structured.Change, attributes map[string]*jsonprovider.Attribute) computed.Diff {
@@ -60,7 +60,7 @@ func computeAttributeDiffAsNestedList(change structured.Change, attributes map[s
 		elements = append(elements, element)
 		current = collections.CompareActions(current, element.Action)
 	})
-	return computed.NewDiff(renderers.NestedList(elements), current, change.ReplacePaths.Matches())
+	return computed.NewDiff(renderers.NestedList(elements), current, change.ReplacePaths.Matches(), change.Importing)
 }
 
 func computeBlockDiffsAsList(change structured.Change, block *jsonprovider.Block) ([]computed.Diff, plans.Action) {

--- a/internal/command/jsonformat/differ/map.go
+++ b/internal/command/jsonformat/differ/map.go
@@ -21,7 +21,7 @@ func computeAttributeDiffAsMap(change structured.Change, elementType cty.Type) c
 		}
 		return ComputeDiffForType(value, elementType)
 	})
-	return computed.NewDiff(renderers.Map(elements), current, change.ReplacePaths.Matches())
+	return computed.NewDiff(renderers.Map(elements), current, change.ReplacePaths.Matches(), change.Importing)
 }
 
 func computeAttributeDiffAsNestedMap(change structured.Change, attributes map[string]*jsonprovider.Attribute) computed.Diff {
@@ -37,7 +37,7 @@ func computeAttributeDiffAsNestedMap(change structured.Change, attributes map[st
 			NestingMode: "single",
 		})
 	})
-	return computed.NewDiff(renderers.NestedMap(elements), current, change.ReplacePaths.Matches())
+	return computed.NewDiff(renderers.NestedMap(elements), current, change.ReplacePaths.Matches(), change.Importing)
 }
 
 func computeBlockDiffsAsMap(change structured.Change, block *jsonprovider.Block) (map[string]computed.Diff, plans.Action) {

--- a/internal/command/jsonformat/differ/object.go
+++ b/internal/command/jsonformat/differ/object.go
@@ -15,14 +15,14 @@ func computeAttributeDiffAsObject(change structured.Change, attributes map[strin
 	attributeDiffs, action := processObject(change, attributes, func(value structured.Change, ctype cty.Type) computed.Diff {
 		return ComputeDiffForType(value, ctype)
 	})
-	return computed.NewDiff(renderers.Object(attributeDiffs), action, change.ReplacePaths.Matches())
+	return computed.NewDiff(renderers.Object(attributeDiffs), action, change.ReplacePaths.Matches(), change.Importing)
 }
 
 func computeAttributeDiffAsNestedObject(change structured.Change, attributes map[string]*jsonprovider.Attribute) computed.Diff {
 	attributeDiffs, action := processObject(change, attributes, func(value structured.Change, attribute *jsonprovider.Attribute) computed.Diff {
 		return ComputeDiffForAttribute(value, attribute)
 	})
-	return computed.NewDiff(renderers.NestedObject(attributeDiffs), action, change.ReplacePaths.Matches())
+	return computed.NewDiff(renderers.NestedObject(attributeDiffs), action, change.ReplacePaths.Matches(), change.Importing)
 }
 
 // processObject steps through the children of value as if it is an object and

--- a/internal/command/jsonformat/differ/sensitive.go
+++ b/internal/command/jsonformat/differ/sensitive.go
@@ -17,7 +17,7 @@ func checkForSensitiveType(change structured.Change, ctype cty.Type) (computed.D
 		func(value structured.Change) computed.Diff {
 			return ComputeDiffForType(value, ctype)
 		}, func(inner computed.Diff, beforeSensitive, afterSensitive bool, action plans.Action) computed.Diff {
-			return computed.NewDiff(renderers.Sensitive(inner, beforeSensitive, afterSensitive), action, change.ReplacePaths.Matches())
+			return computed.NewDiff(renderers.Sensitive(inner, beforeSensitive, afterSensitive), action, change.ReplacePaths.Matches(), change.Importing)
 		},
 	)
 }
@@ -27,7 +27,7 @@ func checkForSensitiveNestedAttribute(change structured.Change, attribute *jsonp
 		func(value structured.Change) computed.Diff {
 			return computeDiffForNestedAttribute(value, attribute)
 		}, func(inner computed.Diff, beforeSensitive, afterSensitive bool, action plans.Action) computed.Diff {
-			return computed.NewDiff(renderers.Sensitive(inner, beforeSensitive, afterSensitive), action, change.ReplacePaths.Matches())
+			return computed.NewDiff(renderers.Sensitive(inner, beforeSensitive, afterSensitive), action, change.ReplacePaths.Matches(), change.Importing)
 		},
 	)
 }
@@ -37,7 +37,7 @@ func checkForSensitiveBlock(change structured.Change, block *jsonprovider.Block)
 		func(value structured.Change) computed.Diff {
 			return ComputeDiffForBlock(value, block)
 		}, func(inner computed.Diff, beforeSensitive, afterSensitive bool, action plans.Action) computed.Diff {
-			return computed.NewDiff(renderers.SensitiveBlock(inner, beforeSensitive, afterSensitive), action, change.ReplacePaths.Matches())
+			return computed.NewDiff(renderers.SensitiveBlock(inner, beforeSensitive, afterSensitive), action, change.ReplacePaths.Matches(), change.Importing)
 		},
 	)
 }

--- a/internal/command/jsonformat/differ/set.go
+++ b/internal/command/jsonformat/differ/set.go
@@ -22,7 +22,7 @@ func computeAttributeDiffAsSet(change structured.Change, elementType cty.Type) c
 		elements = append(elements, element)
 		current = collections.CompareActions(current, element.Action)
 	})
-	return computed.NewDiff(renderers.Set(elements), current, change.ReplacePaths.Matches())
+	return computed.NewDiff(renderers.Set(elements), current, change.ReplacePaths.Matches(), change.Importing)
 }
 
 func computeAttributeDiffAsNestedSet(change structured.Change, attributes map[string]*jsonprovider.Attribute) computed.Diff {
@@ -36,7 +36,7 @@ func computeAttributeDiffAsNestedSet(change structured.Change, attributes map[st
 		elements = append(elements, element)
 		current = collections.CompareActions(current, element.Action)
 	})
-	return computed.NewDiff(renderers.NestedSet(elements), current, change.ReplacePaths.Matches())
+	return computed.NewDiff(renderers.NestedSet(elements), current, change.ReplacePaths.Matches(), change.Importing)
 }
 
 func computeBlockDiffsAsSet(change structured.Change, block *jsonprovider.Block) ([]computed.Diff, plans.Action) {

--- a/internal/command/jsonformat/differ/tuple.go
+++ b/internal/command/jsonformat/differ/tuple.go
@@ -23,5 +23,5 @@ func computeAttributeDiffAsTuple(change structured.Change, elementTypes []cty.Ty
 		elements = append(elements, element)
 		current = collections.CompareActions(current, element.Action)
 	}
-	return computed.NewDiff(renderers.List(elements), current, change.ReplacePaths.Matches())
+	return computed.NewDiff(renderers.List(elements), current, change.ReplacePaths.Matches(), change.Importing)
 }

--- a/internal/command/jsonformat/renderer_test.go
+++ b/internal/command/jsonformat/renderer_test.go
@@ -1,0 +1,56 @@
+package jsonformat
+
+import (
+	"github.com/hashicorp/terraform/internal/command/jsonplan"
+	"github.com/hashicorp/terraform/internal/command/jsonprovider"
+	"github.com/hashicorp/terraform/internal/command/jsonstate"
+	"testing"
+)
+
+func TestIncompatibleVersions(t *testing.T) {
+	tcs := map[string]struct {
+		local    string
+		remote   string
+		expected bool
+	}{
+		"matching": {
+			local:    "1.1",
+			remote:   "1.1",
+			expected: false,
+		},
+		"local_latest": {
+			local:    "1.2",
+			remote:   "1.1",
+			expected: false,
+		},
+		"local_earliest": {
+			local:    "1.1",
+			remote:   "1.2",
+			expected: true,
+		},
+		"parses_state_version": {
+			local:    jsonstate.FormatVersion,
+			remote:   jsonstate.FormatVersion,
+			expected: false,
+		},
+		"parses_provider_version": {
+			local:    jsonprovider.FormatVersion,
+			remote:   jsonprovider.FormatVersion,
+			expected: false,
+		},
+		"parses_plan_version": {
+			local:    jsonplan.FormatVersion,
+			remote:   jsonplan.FormatVersion,
+			expected: false,
+		},
+	}
+
+	for name, tc := range tcs {
+		t.Run(name, func(t *testing.T) {
+			actual := incompatibleVersions(tc.local, tc.remote)
+			if actual != tc.expected {
+				t.Errorf("expected %t but found %t", tc.expected, actual)
+			}
+		})
+	}
+}

--- a/internal/command/jsonformat/structured/change.go
+++ b/internal/command/jsonformat/structured/change.go
@@ -86,6 +86,10 @@ type Change struct {
 	// that we should display. Any element/attribute not matched by this Matcher
 	// should be skipped.
 	RelevantAttributes attribute_path.Matcher
+
+	// Importing is true if the overall change describes a resource being
+	// imported during the operation.
+	Importing bool
 }
 
 // FromJsonChange unmarshals the raw []byte values in the jsonplan.Change
@@ -99,6 +103,7 @@ func FromJsonChange(change jsonplan.Change, relevantAttributes attribute_path.Ma
 		AfterSensitive:     unmarshalGeneric(change.AfterSensitive),
 		ReplacePaths:       attribute_path.Parse(change.ReplacePaths, false),
 		RelevantAttributes: relevantAttributes,
+		Importing:          change.Importing,
 	}
 }
 
@@ -119,6 +124,10 @@ func FromJsonResource(resource jsonstate.Resource) Change {
 		// are relevant.
 		ReplacePaths:       attribute_path.Empty(false),
 		RelevantAttributes: attribute_path.AlwaysMatcher(),
+
+		// Importing is only relevant during a resource change, we'll explicitly
+		// set this to false here.
+		Importing: false,
 	}
 }
 
@@ -139,6 +148,10 @@ func FromJsonOutput(output jsonstate.Output) Change {
 		// are relevant.
 		ReplacePaths:       attribute_path.Empty(false),
 		RelevantAttributes: attribute_path.AlwaysMatcher(),
+
+		// Importing is only relevant during a resource change, we'll explicitly
+		// set this to false here.
+		Importing: false,
 	}
 }
 
@@ -159,6 +172,10 @@ func FromJsonViewsOutput(output viewsjson.Output) Change {
 		// are relevant.
 		ReplacePaths:       attribute_path.Empty(false),
 		RelevantAttributes: attribute_path.AlwaysMatcher(),
+
+		// Importing is only relevant during a resource change, we'll explicitly
+		// set this to false here.
+		Importing: false,
 	}
 }
 

--- a/internal/command/jsonformat/structured/change.go
+++ b/internal/command/jsonformat/structured/change.go
@@ -222,55 +222,54 @@ func (change Change) GetDefaultActionForIteration() plans.Action {
 	return plans.NoOp
 }
 
+func (change Change) Copy() Change {
+	return Change{
+		BeforeExplicit:     change.BeforeExplicit,
+		AfterExplicit:      change.AfterExplicit,
+		Before:             change.Before,
+		After:              change.After,
+		Unknown:            change.Unknown,
+		BeforeSensitive:    change.BeforeSensitive,
+		AfterSensitive:     change.AfterSensitive,
+		ReplacePaths:       change.ReplacePaths,
+		RelevantAttributes: change.RelevantAttributes,
+		Importing:          change.Importing,
+	}
+}
+
 // AsNoOp returns the current change as if it is a NoOp operation.
 //
 // Basically it replaces all the after values with the before values.
 func (change Change) AsNoOp() Change {
-	return Change{
-		BeforeExplicit:     change.BeforeExplicit,
-		AfterExplicit:      change.BeforeExplicit,
-		Before:             change.Before,
-		After:              change.Before,
-		Unknown:            false,
-		BeforeSensitive:    change.BeforeSensitive,
-		AfterSensitive:     change.BeforeSensitive,
-		ReplacePaths:       change.ReplacePaths,
-		RelevantAttributes: change.RelevantAttributes,
-	}
+	cp := change.Copy()
+	cp.AfterExplicit = cp.BeforeExplicit
+	cp.AfterSensitive = cp.BeforeSensitive
+	cp.After = cp.Before
+	cp.Unknown = false
+	return cp
 }
 
 // AsDelete returns the current change as if it is a Delete operation.
 //
 // Basically it replaces all the after values with nil or false.
 func (change Change) AsDelete() Change {
-	return Change{
-		BeforeExplicit:     change.BeforeExplicit,
-		AfterExplicit:      false,
-		Before:             change.Before,
-		After:              nil,
-		Unknown:            nil,
-		BeforeSensitive:    change.BeforeSensitive,
-		AfterSensitive:     nil,
-		ReplacePaths:       change.ReplacePaths,
-		RelevantAttributes: change.RelevantAttributes,
-	}
+	cp := change.Copy()
+	cp.AfterExplicit = false
+	cp.AfterSensitive = nil
+	cp.After = nil
+	cp.Unknown = nil
+	return cp
 }
 
 // AsCreate returns the current change as if it is a Create operation.
 //
 // Basically it replaces all the before values with nil or false.
 func (change Change) AsCreate() Change {
-	return Change{
-		BeforeExplicit:     false,
-		AfterExplicit:      change.AfterExplicit,
-		Before:             nil,
-		After:              change.After,
-		Unknown:            change.Unknown,
-		BeforeSensitive:    nil,
-		AfterSensitive:     change.AfterSensitive,
-		ReplacePaths:       change.ReplacePaths,
-		RelevantAttributes: change.RelevantAttributes,
-	}
+	cp := change.Copy()
+	cp.BeforeExplicit = false
+	cp.BeforeSensitive = nil
+	cp.Before = nil
+	return cp
 }
 
 func unmarshalGeneric(raw json.RawMessage) interface{} {

--- a/internal/command/jsonformat/structured/map.go
+++ b/internal/command/jsonformat/structured/map.go
@@ -30,6 +30,9 @@ type ChangeMap struct {
 
 	// RelevantAttributes matches the same attributes in Change exactly.
 	RelevantAttributes attribute_path.Matcher
+
+	// Importing matches the same attribute in Change exactly.
+	Importing bool
 }
 
 // AsMap converts the Change into an object or map representation by converting
@@ -44,6 +47,7 @@ func (change Change) AsMap() ChangeMap {
 		AfterSensitive:     genericToMap(change.AfterSensitive),
 		ReplacePaths:       change.ReplacePaths,
 		RelevantAttributes: change.RelevantAttributes,
+		Importing:          change.Importing,
 	}
 }
 
@@ -66,6 +70,10 @@ func (m ChangeMap) GetChild(key string) Change {
 		AfterSensitive:     afterSensitive,
 		ReplacePaths:       m.ReplacePaths.GetChildWithKey(key),
 		RelevantAttributes: m.RelevantAttributes.GetChildWithKey(key),
+
+		// Importing cascades, so if a parent is importing then all children
+		// are as well.
+		Importing: m.Importing,
 	}
 }
 

--- a/internal/command/jsonformat/structured/sensitive.go
+++ b/internal/command/jsonformat/structured/sensitive.go
@@ -57,17 +57,9 @@ func (change Change) CheckForSensitive(processInner ProcessSensitiveInner, creat
 	// The change can choose what to do with this information, in most cases
 	// it will just be ignored in favour of printing `(sensitive value)`.
 
-	value := Change{
-		BeforeExplicit:     change.BeforeExplicit,
-		AfterExplicit:      change.AfterExplicit,
-		Before:             change.Before,
-		After:              change.After,
-		Unknown:            change.Unknown,
-		BeforeSensitive:    false,
-		AfterSensitive:     false,
-		ReplacePaths:       change.ReplacePaths,
-		RelevantAttributes: change.RelevantAttributes,
-	}
+	value := change.Copy()
+	value.BeforeSensitive = false
+	value.AfterSensitive = false
 
 	inner := processInner(value)
 

--- a/internal/command/jsonformat/structured/slice.go
+++ b/internal/command/jsonformat/structured/slice.go
@@ -29,6 +29,9 @@ type ChangeSlice struct {
 
 	// RelevantAttributes matches the same attributes in Change exactly.
 	RelevantAttributes attribute_path.Matcher
+
+	// Importing matches the same attribute in Change exactly.
+	Importing bool
 }
 
 // AsSlice converts the Change into a slice representation by converting the
@@ -43,6 +46,7 @@ func (change Change) AsSlice() ChangeSlice {
 		AfterSensitive:     genericToSlice(change.AfterSensitive),
 		ReplacePaths:       change.ReplacePaths,
 		RelevantAttributes: change.RelevantAttributes,
+		Importing:          change.Importing,
 	}
 }
 
@@ -70,6 +74,10 @@ func (s ChangeSlice) GetChild(beforeIx, afterIx int) Change {
 		AfterSensitive:     afterSensitive,
 		ReplacePaths:       s.ReplacePaths.GetChildWithIndex(mostRelevantIx),
 		RelevantAttributes: s.RelevantAttributes.GetChildWithIndex(mostRelevantIx),
+
+		// Importing cascades, so if a parent is importing then all children
+		// are as well.
+		Importing: s.Importing,
 	}
 }
 

--- a/internal/command/jsonplan/plan.go
+++ b/internal/command/jsonplan/plan.go
@@ -26,7 +26,7 @@ import (
 // incremented for any change to this format that requires changes to a
 // consuming parser.
 const (
-	FormatVersion = "1.1"
+	FormatVersion = "1.2"
 
 	ResourceInstanceReplaceBecauseCannotUpdate    = "replace_because_cannot_update"
 	ResourceInstanceReplaceBecauseTainted         = "replace_because_tainted"
@@ -122,6 +122,12 @@ type Change struct {
 	// consists of one or more steps, each of which will be a number or a
 	// string.
 	ReplacePaths json.RawMessage `json:"replace_paths,omitempty"`
+
+	// Importing indicates this change is being imported as part of this
+	// operation. This works in tandem with the Actions field to fully describe
+	// the change. For example, if importing is true and the action is a no-op
+	// then this resource is being imported without any changes.
+	Importing bool `json:"importing,omitempty"`
 }
 
 type output struct {
@@ -442,6 +448,7 @@ func MarshalResourceChanges(resources []*plans.ResourceInstanceChangeSrc, schema
 			BeforeSensitive: json.RawMessage(beforeSensitive),
 			AfterSensitive:  json.RawMessage(afterSensitive),
 			ReplacePaths:    replacePaths,
+			Importing:       rc.Importing,
 		}
 
 		if rc.DeposedKey != states.NotDeposed {
@@ -593,6 +600,10 @@ func MarshalOutputChanges(changes *plans.Changes) (map[string]Change, error) {
 			AfterUnknown:    a,
 			BeforeSensitive: json.RawMessage(sensitive),
 			AfterSensitive:  json.RawMessage(sensitive),
+
+			// Just to be explicit, outputs cannot be imported so this is always
+			// false.
+			Importing: false,
 		}
 
 		outputChanges[oc.Addr.OutputValue.Name] = c


### PR DESCRIPTION
This PR implements the plannable import rendering logic within the plan renderer. I will do a follow up PR which implements the rendering logic for the JSON streamed logs.

To see some examples of this working e2e have a look at the changes in the internal/command/jsonformat/plan_test.go file.

Essentially the import logic overrides the symbols for the change headers and for NoOp changes so they display the `&` import symbol instead of displaying as if nothing changed. It also makes any resource that is imported render in full rather than skipping NoOp changes.

For ease of reviewing, reviewers can look at the four commits separately:

- [Update jsonplan package](https://github.com/hashicorp/terraform/commit/6b367d8b33a5ba122f5e207349b2de2bcd236622)
- [Compute the diff](https://github.com/hashicorp/terraform/commit/64d693c52b96d2996914148ae6a921bb2297e20f)
- [Do the rendering](https://github.com/hashicorp/terraform/commit/56380e7e71f9fb30d5afe61e7fddf4587dcb912e)
- [Add tests](https://github.com/hashicorp/terraform/commit/f27d25a48b1945fb05dc229cd662ffb57fbd6606)

## Target Release

v1.5.0-alpha

## Proposed Changelog

N/A, there will be a general entry in the changelog for all plannable import changes.