### PR TITLE
Configure copywrite to ignore testdata

### DIFF
--- a/.copywrite.hcl
+++ b/.copywrite.hcl
@@ -9,5 +9,6 @@ project {
   # files or folders should be ignored
   header_ignore = [
     "**/*.tf",
+    "**/testdata/**",
   ]
 }


### PR DESCRIPTION
Trying to unblock #33003 by ignoring all files under `testdata`, as automated copyright headers on those files result in unwanted changes to test results.

## Target Release

n/a