### PR TITLE
Fix goimports discrepancies

### DIFF
--- a/internal/backend/remote/backend_context_test.go
+++ b/internal/backend/remote/backend_context_test.go
@@ -2,10 +2,11 @@ package remote
 
 import (
 	"context"
-	"github.com/hashicorp/terraform/internal/terraform"
-	"github.com/hashicorp/terraform/internal/tfdiags"
 	"reflect"
 	"testing"
+
+	"github.com/hashicorp/terraform/internal/terraform"
+	"github.com/hashicorp/terraform/internal/tfdiags"
 
 	tfe "github.com/hashicorp/go-tfe"
 	"github.com/hashicorp/terraform/internal/backend"

--- a/internal/registry/regsrc/friendly_host.go
+++ b/internal/registry/regsrc/friendly_host.go
@@ -4,7 +4,7 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/hashicorp/terraform-svchost"
+	svchost "github.com/hashicorp/terraform-svchost"
 )
 
 var (


### PR DESCRIPTION
Once again trying to unblock #33003. This time we have [failing goimports consistency checks](https://github.com/hashicorp/terraform/actions/runs/4811956825/jobs/8566600883) triggered because copywrite modified some files we haven't touched in a while.