### PR TITLE
Configure copywrite to ignore protobuf, stringer, mockgen output

### DIFF
--- a/.copywrite.hcl
+++ b/.copywrite.hcl
@@ -11,5 +11,7 @@ project {
     "**/*.tf",
     "**/testdata/**",
     "**/*.pb.go",
+    "**/*_string.go",
+    "**/mock*.go",
   ]
 }

--- a/.copywrite.hcl
+++ b/.copywrite.hcl
@@ -10,5 +10,6 @@ project {
   header_ignore = [
     "**/*.tf",
     "**/testdata/**",
+    "**/*.pb.go",
   ]
 }


### PR DESCRIPTION
Yet another attempt to unblock #33003, this time ignoring all `*.pb.go` generated code, along with other `go generate` output from `stringer` and `mockgen`.
