### PR TITLE
Documentation: Fix incorrect assertion that CIDR notation is only valid for ipv6

### DIFF
--- a/website/docs/language/functions/cidrnetmask.mdx
+++ b/website/docs/language/functions/cidrnetmask.mdx
@@ -20,7 +20,7 @@ cidrnetmask(prefix)
 The result is a subnet address formatted in the conventional dotted-decimal
 IPv4 address syntax, as expected by some software.
 
-CIDR notation is the only valid notation for IPv6 addresses, so `cidrnetmask`
+CIDR notation is the only valid notation for IPv4 addresses, so `cidrnetmask`
 produces an error if given an IPv6 address.
 
 -> **Note:** As a historical accident, this function interprets IPv4 address

--- a/website/docs/language/functions/cidrnetmask.mdx
+++ b/website/docs/language/functions/cidrnetmask.mdx
@@ -20,7 +20,7 @@ cidrnetmask(prefix)
 The result is a subnet address formatted in the conventional dotted-decimal
 IPv4 address syntax, as expected by some software.
 
-CIDR notation is the only valid notation for IPv4 addresses, so `cidrnetmask`
+Because CIDR notation is the only valid notation for IPv6 addresses, `cidrnetmask`
 produces an error if given an IPv6 address.
 
 -> **Note:** As a historical accident, this function interprets IPv4 address

--- a/website/docs/language/functions/cidrnetmask.mdx
+++ b/website/docs/language/functions/cidrnetmask.mdx
@@ -21,7 +21,6 @@ The result is a subnet address formatted in the conventional dotted-decimal
 IPv4 address syntax, as expected by some software.
 
  The `cidrnetmask` function only accepts IPv4 addresses in CIDR notation. If you use an IPv6 address, `cidrnetmask` returns an error. 
-produces an error if given an IPv6 address.
 
 -> **Note:** As a historical accident, this function interprets IPv4 address
 octets that have leading zeros as decimal numbers, which is contrary to some

--- a/website/docs/language/functions/cidrnetmask.mdx
+++ b/website/docs/language/functions/cidrnetmask.mdx
@@ -20,7 +20,7 @@ cidrnetmask(prefix)
 The result is a subnet address formatted in the conventional dotted-decimal
 IPv4 address syntax, as expected by some software.
 
-Because CIDR notation is the only valid notation for IPv6 addresses, `cidrnetmask`
+ The `cidrnetmask` function only accepts IPv4 addresses in CIDR notation. If you use an IPv6 address, `cidrnetmask` returns an error. 
 produces an error if given an IPv6 address.
 
 -> **Note:** As a historical accident, this function interprets IPv4 address


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

-  Fix incorrect comment in the docs that state CIDR is only valid for IPv6, which is both incorrect and conflicts with the rest of the docs.

![image](https://user-images.githubusercontent.com/39230492/234918368-4c08b5f9-766d-4611-8017-2b614a776664.png)

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

not needed?

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

### BUG FIXES 

<!--

Write a short description of the user-facing change. Examples:

- `terraform show -json`: Fixed crash with sensitive set values.
- When rendering a diff, Terraform now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 

- Docs only change

