### PR TITLE
Return debuggable CAS errors on consul state put

### DIFF
--- a/internal/backend/remote-state/consul/client.go
+++ b/internal/backend/remote-state/consul/client.go
@@ -231,7 +231,11 @@ func (c *RemoteClient) Put(data []byte) error {
 		}
 		// transaction was rolled back
 		if !ok {
-			return fmt.Errorf("consul CAS failed with transaction errors: %v", resp.Errors)
+			message := ""
+			for _, respError := resp.Errors {
+				message += respError.What,
+			}
+			return fmt.Errorf("consul CAS failed with transaction errors: %s", message)
 		}
 
 		if len(resp.Results) != 1 {

--- a/internal/backend/remote-state/consul/client.go
+++ b/internal/backend/remote-state/consul/client.go
@@ -231,11 +231,11 @@ func (c *RemoteClient) Put(data []byte) error {
 		}
 		// transaction was rolled back
 		if !ok {
-			message := ""
+			var resultErr error
 			for _, respError := range resp.Errors {
-				message += respError.What
+				resultErr = append(resultErr, errors.New(respError.What))
 			}
-			return fmt.Errorf("consul CAS failed with transaction errors: %s", message)
+			return fmt.Errorf("consul CAS failed with transaction errors: %w", resultErr)
 		}
 
 		if len(resp.Results) != 1 {

--- a/internal/backend/remote-state/consul/client.go
+++ b/internal/backend/remote-state/consul/client.go
@@ -233,7 +233,7 @@ func (c *RemoteClient) Put(data []byte) error {
 		if !ok {
 			var resultErr error
 			for _, respError := range resp.Errors {
-				resultErr = append(resultErr, errors.New(respError.What))
+				resultErr = multierror.Append(resultErr, errors.New(respError.What))
 			}
 			return fmt.Errorf("consul CAS failed with transaction errors: %w", resultErr)
 		}

--- a/internal/backend/remote-state/consul/client.go
+++ b/internal/backend/remote-state/consul/client.go
@@ -232,8 +232,8 @@ func (c *RemoteClient) Put(data []byte) error {
 		// transaction was rolled back
 		if !ok {
 			message := ""
-			for _, respError := resp.Errors {
-				message += respError.What,
+			for _, respError := range resp.Errors {
+				message += respError.What
 			}
 			return fmt.Errorf("consul CAS failed with transaction errors: %s", message)
 		}


### PR DESCRIPTION
Ran into this error while running terraform inside a container, after it applied my plans, terraform failed saving state to Consul. I suspect my policy needs tweaking, but it's near impossible to tell with an error like this:

```
╷
│ Error: Failed to save state
│ 
│ Error saving state: consul CAS failed with transaction errors:
│ [0xc0006e93c8]
╵
```

This PR changes the the rendering of the error instance to actually print the message, instead of the memory address of said error instance.


## Target Release

1.15.x

## Draft CHANGELOG entry

### BUG FIXES

- When using consul as a state backend and failing to save state, `consul CAS failed with transaction errors` no longer shows an error instance memory address but an actual error message.