### PR TITLE
Corrected example in documentation

### DIFF
--- a/website/docs/language/functions/timeadd.mdx
+++ b/website/docs/language/functions/timeadd.mdx
@@ -10,7 +10,7 @@ description: |-
 `timeadd` adds a duration to a timestamp, returning a new timestamp.
 
 ```hcl
-timeadd(timestamp, duration)
+timeadd(timestamp(), duration)
 ```
 
 In the Terraform language, timestamps are conventionally represented as


### PR DESCRIPTION
The `timestamp()` function missed the `()`