### PR TITLE
clarify types and link to Type Constraints pagedit types

### DIFF
--- a/website/docs/language/expressions/types.mdx
+++ b/website/docs/language/expressions/types.mdx
@@ -21,8 +21,7 @@ The Terraform language uses the following types for its values:
   numbers like `15` and fractional values like `6.283185`.
 * `bool`: a boolean value, either `true` or `false`. `bool` values can be used in conditional
   logic.
-* `list`: a sequence of values, like `["us-west-1a", "us-west-1c"]`. Elements in a list are
-  identified by consecutive whole numbers, starting with zero.
+* `list`: a sequence of values, like `["us-west-1a", "us-west-1c"]`. Identify elements in a list with consecutive whole numbers, starting with zero.
 * `set`: a collection of unique values that do not have any secondary identifiers or ordering.
 * `map`: a group of values identified by named labels, like
   `{name = "Mabel", age = 52}`.

--- a/website/docs/language/expressions/types.mdx
+++ b/website/docs/language/expressions/types.mdx
@@ -28,7 +28,7 @@ The Terraform language uses the following types for its values:
   `{name = "Mabel", age = 52}`.
 
 Strings, numbers, and bools are sometimes called _primitive types._ Lists and sets are forms
-of tuples. Maps are a form of objects. Tuples and maps are sometimes called _complex types,_ 
+of tuples. Maps are a form of objects. Tuples and objects are sometimes called _complex types,_ 
 _structural types,_ or _collection types._ See
 [Type Constraints](/terraform/language/expressions/type-constraints) for a more detailed
 description of complex types.

--- a/website/docs/language/expressions/types.mdx
+++ b/website/docs/language/expressions/types.mdx
@@ -21,13 +21,17 @@ The Terraform language uses the following types for its values:
   numbers like `15` and fractional values like `6.283185`.
 * `bool`: a boolean value, either `true` or `false`. `bool` values can be used in conditional
   logic.
-* `list` (or `tuple`): a sequence of values, like
-  `["us-west-1a", "us-west-1c"]`. Elements in a list or tuple are identified by
-  consecutive whole numbers, starting with zero.
-* `map` (or `object`): a group of values identified by named labels, like
+* `list`: a sequence of values, like `["us-west-1a", "us-west-1c"]`. Elements in a list are
+  identified by consecutive whole numbers, starting with zero.
+* `set`: a collection of unique values that do not have any secondary identifiers or ordering.
+* `map`: a group of values identified by named labels, like
   `{name = "Mabel", age = 52}`.
 
-Strings, numbers, and bools are sometimes called _primitive types._ Lists/tuples and maps/objects are sometimes called _complex types,_ _structural types,_ or _collection types._
+Strings, numbers, and bools are sometimes called _primitive types._ Lists and sets are forms
+of tuples. Maps are a form of objects. Tuples and maps are sometimes called _complex types,_ 
+_structural types,_ or _collection types._ See
+[Type Constraints](/terraform/language/expressions/type-constraints) for a more detailed
+description of complex types.
 
 Finally, there is one special value that has _no_ type:
 


### PR DESCRIPTION
- Add `set` to the types list on the `types.mdx` page.
- Clarify relationship between complex types.
- Link to Type Constraints page for more detailed information on types.

_Note: this definition of `set` is copied from the Type Constraints page, though that language may not be clear in this context. Rather than risk making a technical error, I opted to stay with the same text._
## Target Release

1.4.x

## Draft CHANGELOG entry

N/A