### PR TITLE
Imports should come before Adds in change summaries

### DIFF
--- a/internal/command/jsonformat/plan.go
+++ b/internal/command/jsonformat/plan.go
@@ -226,9 +226,9 @@ func (plan Plan) renderHuman(renderer Renderer, mode plans.Mode, opts ...PlanRen
 
 		if importingCount > 0 {
 			renderer.Streams.Printf(
-				renderer.Colorize.Color("\n[bold]Plan:[reset] %d to add, %d to import, %d to change, %d to destroy.\n"),
-				counts[plans.Create]+counts[plans.DeleteThenCreate]+counts[plans.CreateThenDelete],
+				renderer.Colorize.Color("\n[bold]Plan:[reset] %d to import, %d to add, %d to change, %d to destroy.\n"),
 				importingCount,
+				counts[plans.Create]+counts[plans.DeleteThenCreate]+counts[plans.CreateThenDelete],
 				counts[plans.Update],
 				counts[plans.Delete]+counts[plans.DeleteThenCreate]+counts[plans.CreateThenDelete])
 		} else {

--- a/internal/command/jsonformat/plan_test.go
+++ b/internal/command/jsonformat/plan_test.go
@@ -141,7 +141,7 @@ Terraform will perform the following actions:
         value = "Hello, World!"
     }
 
-Plan: 0 to add, 1 to import, 0 to change, 0 to destroy.
+Plan: 1 to import, 0 to add, 0 to change, 0 to destroy.
 `,
 		},
 		"import_and_move": {
@@ -181,7 +181,7 @@ Terraform will perform the following actions:
         value = "Hello, World!"
     }
 
-Plan: 0 to add, 1 to import, 0 to change, 0 to destroy.
+Plan: 1 to import, 0 to add, 0 to change, 0 to destroy.
 `,
 		},
 		"import_move_and_update": {
@@ -226,7 +226,7 @@ Terraform will perform the following actions:
       ~ value = "Hello, World!" -> "Hello, Universe!"
     }
 
-Plan: 0 to add, 1 to import, 1 to change, 0 to destroy.
+Plan: 1 to import, 0 to add, 1 to change, 0 to destroy.
 `,
 		},
 		"import_and_update": {
@@ -269,7 +269,7 @@ Terraform will perform the following actions:
       ~ value = "Hello, World!" -> "Hello, Universe!"
     }
 
-Plan: 0 to add, 1 to import, 1 to change, 0 to destroy.
+Plan: 1 to import, 0 to add, 1 to change, 0 to destroy.
 `,
 		},
 		"import_and_update_with_no_id": {
@@ -310,7 +310,7 @@ Terraform will perform the following actions:
       ~ value = "Hello, World!" -> "Hello, Universe!"
     }
 
-Plan: 0 to add, 1 to import, 1 to change, 0 to destroy.
+Plan: 1 to import, 0 to add, 1 to change, 0 to destroy.
 `,
 		},
 		"import_and_replace": {
@@ -356,7 +356,7 @@ Terraform will perform the following actions:
         value = "Hello, World!"
     }
 
-Plan: 1 to add, 1 to import, 0 to change, 1 to destroy.
+Plan: 1 to import, 1 to add, 0 to change, 1 to destroy.
 `,
 		},
 	}


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Fixes the ordering of import and add within the change summaries printed by the plan renderer.

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.5.0-alpha

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

### NEW FEATURES | UPGRADE NOTES | ENHANCEMENTS | BUG FIXES | EXPERIMENTS

<!--

Write a short description of the user-facing change. Examples:

- `terraform show -json`: Fixed crash with sensitive set values.
- When rendering a diff, Terraform now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 

-  N/A, plannable imports will have their own CHANGELOG entry
