### PR TITLE
Plannable import: Make the streamed logs more consistent during planning

### DIFF
--- a/internal/command/import.go
+++ b/internal/command/import.go
@@ -193,7 +193,7 @@ func (c *ImportCommand) Run(args []string) int {
 		c.showDiagnostics(diags)
 		return 1
 	}
-	opReq.Hooks = []terraform.Hook{c.uiHook()}
+	opReq.Hooks = []terraform.Hook{c.uiHook(views.TerraformOperationImport)}
 	{
 		var moreDiags tfdiags.Diagnostics
 		opReq.Variables, moreDiags = c.collectVariableValues()

--- a/internal/command/meta.go
+++ b/internal/command/meta.go
@@ -605,8 +605,8 @@ func (m *Meta) process(args []string) []string {
 }
 
 // uiHook returns the UiHook to use with the context.
-func (m *Meta) uiHook() *views.UiHook {
-	return views.NewUiHook(m.View)
+func (m *Meta) uiHook(operation views.TerraformOperation) *views.UiHook {
+	return views.NewUiHook(m.View, operation)
 }
 
 // confirm asks a yes/no confirmation.

--- a/internal/command/views/apply.go
+++ b/internal/command/views/apply.go
@@ -94,7 +94,7 @@ func (v *ApplyHuman) Operation() Operation {
 func (v *ApplyHuman) Hooks() []terraform.Hook {
 	return []terraform.Hook{
 		v.countHook,
-		NewUiHook(v.view),
+		NewUiHook(v.view, TerraformOperationApply),
 	}
 }
 

--- a/internal/command/views/plan.go
+++ b/internal/command/views/plan.go
@@ -53,7 +53,7 @@ func (v *PlanHuman) Operation() Operation {
 
 func (v *PlanHuman) Hooks() []terraform.Hook {
 	return []terraform.Hook{
-		NewUiHook(v.view),
+		NewUiHook(v.view, TerraformOperationPlan),
 	}
 }
 

--- a/internal/command/views/refresh.go
+++ b/internal/command/views/refresh.go
@@ -35,7 +35,6 @@ func NewRefresh(vt arguments.ViewType, view *View) Refresh {
 		return &RefreshHuman{
 			view:         view,
 			inAutomation: view.RunningInAutomation(),
-			countHook:    &countHook{},
 		}
 	default:
 		panic(fmt.Sprintf("unknown view type %v", vt))
@@ -48,8 +47,6 @@ type RefreshHuman struct {
 	view *View
 
 	inAutomation bool
-
-	countHook *countHook
 }
 
 var _ Refresh = (*RefreshHuman)(nil)
@@ -67,8 +64,7 @@ func (v *RefreshHuman) Operation() Operation {
 
 func (v *RefreshHuman) Hooks() []terraform.Hook {
 	return []terraform.Hook{
-		v.countHook,
-		NewUiHook(v.view),
+		NewUiHook(v.view, TerraformOperationRefresh),
 	}
 }
 


### PR DESCRIPTION
Currently, the UI hooks print the same messages for importing statements during a direct import command and during a plan with plannable imports. This means the output for the UI doesn't entirely make sense during a plan and the produced logs are rendered inconsistently. 

This is quick PR that just updates the hooks to print different messages during a plan and an import. 

I wonder if an argument could be made that there should be no import streamed logs during a plan? Given that it already prints the message for the refresh? Maybe that is enough, if so I'd be happy to change this to just go and delete where those hooks are called.

Before:
```
tfcoremock_simple_resource.generated: Importing from ID "k-9"...
tfcoremock_simple_resource.generated: Import prepared!
  Prepared tfcoremock_simple_resource for import
tfcoremock_simple_resource.generated: Refreshing state... [id=k-9]

Terraform will perform the following actions:

  # tfcoremock_simple_resource.generated will be imported
    resource "tfcoremock_simple_resource" "generated" {
        id = "k-9"
    }

Plan: 1 to import, 0 to add, 0 to change, 0 to destroy.

────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

Note: You didn't use the -out option to save this plan, so Terraform can't guarantee to take exactly these actions if you
run "terraform apply" now.
```

After:
```
tfcoremock_simple_resource.generated: Importing state... [id=k-9]
tfcoremock_simple_resource.generated: Refreshing state... [id=k-9]

Terraform will perform the following actions:

  # tfcoremock_simple_resource.generated will be imported
    resource "tfcoremock_simple_resource" "generated" {
        id = "k-9"
    }

Plan: 1 to import, 0 to add, 0 to change, 0 to destroy.

────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

Note: You didn't use the -out option to save this plan, so Terraform can't guarantee to take exactly these actions if you
run "terraform apply" now.
```

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.5.0-alpha

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

<!--

Write a short description of the user-facing change. Examples:

- `terraform show -json`: Fixed crash with sensitive set values.
- When rendering a diff, Terraform now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 

-  N/A
