### PR TITLE
docs: Update command to match /cli/commands/taint -replace cmd

### DIFF
--- a/website/docs/cli/state/taint.mdx
+++ b/website/docs/cli/state/taint.mdx
@@ -22,7 +22,7 @@ using [the `-replace=...` planning option](/terraform/cli/commands/plan#replace-
 when you run either `terraform plan` or `terraform apply`:
 
 ```shellsession
-$ terraform apply -replace=aws_instance.example
+$ terraform apply -replace="aws_instance.example"
 # ...
 
   # aws_instance.example will be replaced, as requested


### PR DESCRIPTION
Update documentation to match the documentation on the deprecated taint command in /cli/commands/taint.


## Draft CHANGELOG entry

DOCS: Update `-replace=...` command on the replace command page.

## User-facing changes

-Updates the website documentation so that the `-replace=...` command matches between:
website/docs/cli/commands/taint.mdx 
website/docs/cli/state/taint.mdx
