### PR TITLE
plannable import: write out generated config during apply stage

### DIFF
--- a/internal/terraform/context_apply.go
+++ b/internal/terraform/context_apply.go
@@ -64,6 +64,14 @@ func (c *Context) Apply(plan *plans.Plan, config *configs.Config) (*states.State
 	// check result data as part of the new state.
 	walker.State.RecordCheckResults(walker.Checks)
 
+	// Also after walk is finished, we can write out any generated config.
+	// As of 2020/05/09, it's only import actions that are generating config and
+	// config generated actions can only be of type NoOp. This means that even
+	// if the overall apply operation failed the state for these actions will
+	// still have been imported. Therefore, we always write out any generated
+	// config.
+	diags = diags.Append(c.GenerateConfig(plan))
+
 	newState := walker.State.Close()
 	if plan.UIMode == plans.DestroyMode && !diags.HasErrors() {
 		// NOTE: This is a vestigial violation of the rule that we mustn't

--- a/internal/terraform/context_generate.go
+++ b/internal/terraform/context_generate.go
@@ -2,6 +2,7 @@ package terraform
 
 import (
 	"fmt"
+
 	"github.com/hashicorp/terraform/internal/plans"
 	"github.com/hashicorp/terraform/internal/tfdiags"
 )
@@ -24,13 +25,15 @@ func (c *Context) GenerateConfig(plan *plans.Plan) tfdiags.Diagnostics {
 		}
 	}
 
+	if len(changes) == 0 {
+		return diags
+	}
+
 	if c.generatedConfigWriter == nil {
 		diags = diags.Append(tfdiags.Sourceless(
 			tfdiags.Warning,
 			"Failed to generate config for imported state",
-			fmt.Sprintf(
-				"Terraform had no way of writing the generated config into any destination, all imported config must be created manually.\n\nThis is a bug in Terraform; please report it!",
-			),
+			"Terraform had no way of writing the generated config into any destination, all imported config must be created manually.\n\nThis is a bug in Terraform; please report it!",
 		))
 		return diags
 	}
@@ -68,7 +71,7 @@ func (c *Context) GenerateConfig(plan *plans.Plan) tfdiags.Diagnostics {
 				continue
 			}
 		} else {
-			if _, err := writer.Write([]byte(fmt.Sprintf("\n# __generated__ by Terraform\n"))); err != nil {
+			if _, err := writer.Write([]byte("\n# __generated__ by Terraform\n")); err != nil {
 				diags = diags.Append(diag(err))
 				continue
 			}

--- a/internal/terraform/context_generate.go
+++ b/internal/terraform/context_generate.go
@@ -1,0 +1,83 @@
+package terraform
+
+import (
+	"fmt"
+	"github.com/hashicorp/terraform/internal/plans"
+	"github.com/hashicorp/terraform/internal/tfdiags"
+)
+
+// GenerateConfig will write any generated config from the plan into the writer
+// returned by Context.generatedConfigWriter.
+//
+// This function returns diagnostics, but these will only be warnings. The
+// failure states in here are unlikely provided everything has been set up
+// correctly elsewhere. It is also possible for users to recover from errors in
+// here by writing out the config themselves, so we don't consider errors to be
+// showstopping.
+func (c *Context) GenerateConfig(plan *plans.Plan) tfdiags.Diagnostics {
+	var diags tfdiags.Diagnostics
+
+	var changes []*plans.ResourceInstanceChangeSrc
+	for _, change := range plan.Changes.Resources {
+		if len(change.GeneratedConfig) > 0 {
+			changes = append(changes, change)
+		}
+	}
+
+	if c.generatedConfigWriter == nil {
+		diags = diags.Append(tfdiags.Sourceless(
+			tfdiags.Warning,
+			"Failed to generate config for imported state",
+			fmt.Sprintf(
+				"Terraform had no way of writing the generated config into any destination, all imported config must be created manually.\n\nThis is a bug in Terraform; please report it!",
+			),
+		))
+		return diags
+	}
+
+	writer, closer, err := c.generatedConfigWriter()
+	if err != nil {
+		diags = diags.Append(tfdiags.Sourceless(
+			tfdiags.Warning,
+			"Failed to generate config for imported state",
+			fmt.Sprintf(
+				"Terraform could not create a destination for the generated config (%v), all imported config must be created manually.\n\nThis is a bug in Terraform; please report it!",
+				err,
+			),
+		))
+		return diags
+	}
+	defer closer()
+
+	for _, change := range changes {
+
+		diag := func(err error) tfdiags.Diagnostic {
+			return tfdiags.Sourceless(
+				tfdiags.Warning,
+				"Failed to generate config for imported state",
+				fmt.Sprintf(
+					"Terraform encountered an error (%v) while writing generated config, the config for %s must be created manually.\n\n`terraform state show %s` will print the existing state to help with this.\n\nThis is a bug in Terraform; please report it!",
+					err, change.Addr, change.Addr,
+				),
+			)
+		}
+
+		if change.Importing != nil && len(change.Importing.ID) > 0 {
+			if _, err := writer.Write([]byte(fmt.Sprintf("\n# __generated__ by Terraform from %q\n", change.Importing.ID))); err != nil {
+				diags = diags.Append(diag(err))
+				continue
+			}
+		} else {
+			if _, err := writer.Write([]byte(fmt.Sprintf("\n# __generated__ by Terraform\n"))); err != nil {
+				diags = diags.Append(diag(err))
+				continue
+			}
+		}
+		if _, err := writer.Write([]byte(fmt.Sprintln(change.GeneratedConfig))); err != nil {
+			diags = diags.Append(diag(err))
+			continue
+		}
+	}
+
+	return diags
+}


### PR DESCRIPTION
Follow on from #33153, and writes out any planned generated config during the apply stage.