### PR TITLE
plannable import: write generated config during plan operation

### DIFF
--- a/internal/cloud/backend_apply_test.go
+++ b/internal/cloud/backend_apply_test.go
@@ -124,10 +124,8 @@ func TestCloud_applyJSONBasic(t *testing.T) {
 
 	stream, close := terminal.StreamsForTesting(t)
 
-	b.renderer = &jsonformat.Renderer{
-		Streams:  stream,
-		Colorize: mockColorize(),
-	}
+	renderer := jsonformat.NewRenderer(stream, mockColorize())
+	b.renderer = &renderer
 
 	op, configCleanup, done := testOperationApply(t, "./testdata/apply-json")
 	defer configCleanup()
@@ -183,10 +181,8 @@ func TestCloud_applyJSONWithOutputs(t *testing.T) {
 
 	stream, close := terminal.StreamsForTesting(t)
 
-	b.renderer = &jsonformat.Renderer{
-		Streams:  stream,
-		Colorize: mockColorize(),
-	}
+	renderer := jsonformat.NewRenderer(stream, mockColorize())
+	b.renderer = &renderer
 
 	op, configCleanup, done := testOperationApply(t, "./testdata/apply-json-with-outputs")
 	defer configCleanup()
@@ -1271,10 +1267,8 @@ func TestCloud_applyJSONWithProvisioner(t *testing.T) {
 
 	stream, close := terminal.StreamsForTesting(t)
 
-	b.renderer = &jsonformat.Renderer{
-		Streams:  stream,
-		Colorize: mockColorize(),
-	}
+	renderer := jsonformat.NewRenderer(stream, mockColorize())
+	b.renderer = &renderer
 	input := testInput(t, map[string]string{
 		"approve": "yes",
 	})
@@ -1334,10 +1328,8 @@ func TestCloud_applyJSONWithProvisionerError(t *testing.T) {
 
 	stream, close := terminal.StreamsForTesting(t)
 
-	b.renderer = &jsonformat.Renderer{
-		Streams:  stream,
-		Colorize: mockColorize(),
-	}
+	renderer := jsonformat.NewRenderer(stream, mockColorize())
+	b.renderer = &renderer
 
 	op, configCleanup, done := testOperationApply(t, "./testdata/apply-json-with-provisioner-error")
 	defer configCleanup()
@@ -1697,10 +1689,8 @@ func TestCloud_applyJSONWithRemoteError(t *testing.T) {
 
 	stream, close := terminal.StreamsForTesting(t)
 
-	b.renderer = &jsonformat.Renderer{
-		Streams:  stream,
-		Colorize: mockColorize(),
-	}
+	renderer := jsonformat.NewRenderer(stream, mockColorize())
+	b.renderer = &renderer
 
 	op, configCleanup, done := testOperationApply(t, "./testdata/apply-json-with-error")
 	defer configCleanup()

--- a/internal/cloud/backend_cli.go
+++ b/internal/cloud/backend_cli.go
@@ -16,15 +16,14 @@ func (b *Cloud) CLIInit(opts *backend.CLIOpts) error {
 		}
 	}
 
+	renderer := jsonformat.NewRenderer(opts.Streams, opts.CLIColor)
+
 	b.CLI = opts.CLI
 	b.CLIColor = opts.CLIColor
 	b.ContextOpts = opts.ContextOpts
 	b.runningInAutomation = opts.RunningInAutomation
 	b.input = opts.Input
-	b.renderer = &jsonformat.Renderer{
-		Streams:  opts.Streams,
-		Colorize: opts.CLIColor,
-	}
+	b.renderer = &renderer
 
 	return nil
 }

--- a/internal/cloud/backend_plan_test.go
+++ b/internal/cloud/backend_plan_test.go
@@ -107,10 +107,8 @@ func TestCloud_planJSONBasic(t *testing.T) {
 
 	stream, close := terminal.StreamsForTesting(t)
 
-	b.renderer = &jsonformat.Renderer{
-		Streams:  stream,
-		Colorize: mockColorize(),
-	}
+	renderer := jsonformat.NewRenderer(stream, mockColorize())
+	b.renderer = &renderer
 
 	op, configCleanup, done := testOperationPlan(t, "./testdata/plan-json-basic")
 	defer configCleanup()
@@ -215,10 +213,8 @@ func TestCloud_planJSONFull(t *testing.T) {
 
 	stream, close := terminal.StreamsForTesting(t)
 
-	b.renderer = &jsonformat.Renderer{
-		Streams:  stream,
-		Colorize: mockColorize(),
-	}
+	renderer := jsonformat.NewRenderer(stream, mockColorize())
+	b.renderer = &renderer
 
 	op, configCleanup, done := testOperationPlan(t, "./testdata/plan-json-full")
 	defer configCleanup()
@@ -1200,10 +1196,8 @@ func TestCloud_planJSONWithRemoteError(t *testing.T) {
 	stream, close := terminal.StreamsForTesting(t)
 
 	// Initialize the plan renderer
-	b.renderer = &jsonformat.Renderer{
-		Streams:  stream,
-		Colorize: mockColorize(),
-	}
+	renderer := jsonformat.NewRenderer(stream, mockColorize())
+	b.renderer = &renderer
 
 	op, configCleanup, done := testOperationPlan(t, "./testdata/plan-json-error")
 	defer configCleanup()

--- a/internal/command/jsonformat/generated_config_writer.go
+++ b/internal/command/jsonformat/generated_config_writer.go
@@ -1,0 +1,86 @@
+package jsonformat
+
+import (
+	"fmt"
+	"io"
+)
+
+type generatedConfigWriter struct {
+	createGeneratedConfigWriter CreateGeneratedConfigWriterFn
+
+	writer    io.Writer
+	closer    func() error
+	writerErr error
+
+	failed map[string]error
+}
+
+func newGeneratedConfigWriter(renderer Renderer) *generatedConfigWriter {
+	return &generatedConfigWriter{
+		createGeneratedConfigWriter: renderer.CreateGeneratedConfigWriter,
+		failed:                      make(map[string]error),
+	}
+}
+
+// MaybeWriteGeneratedConfig checks the provided diff for any generated config
+// and attempts to write into the writer provided by the renderer.
+func (writer *generatedConfigWriter) MaybeWriteGeneratedConfig(diff diff) bool {
+	if len(diff.change.Change.GeneratedConfig) == 0 {
+		// Then we have nothing to write out, so for simplicity we'll just
+		// report this as a success.
+		return true
+	}
+
+	if writer.writerErr != nil {
+		// We couldn't create the writer previously, no point trying again just
+		// mark this as failed and move on.
+		writer.failed[diff.change.Address] = nil
+		return false
+	}
+
+	w, wErr := writer.GetWriter()
+	if wErr != nil {
+		// This means we tried to create the writer and couldn't. The error has
+		// been saved in the generatedConfigWriter so we'll just mark this
+		// change as failed without a reason and move on.
+		writer.failed[diff.change.Address] = nil
+		return false
+	}
+
+	var header string
+	if diff.change.Change.Importing != nil && len(diff.change.Change.Importing.ID) > 0 {
+		header = fmt.Sprintf("\n# __generated__ by Terraform from %q\n", diff.change.Change.Importing.ID)
+	} else {
+		header = fmt.Sprintf("\n# __generated__ by Terraform\n")
+	}
+
+	_, err := w.Write([]byte(fmt.Sprintf("%s%s\n", header, diff.change.Change.GeneratedConfig)))
+	if err != nil {
+		writer.failed[diff.change.Address] = err
+		return false
+	}
+
+	return true
+}
+
+func (writer *generatedConfigWriter) GetWriter() (io.Writer, error) {
+	if writer.writerErr != nil {
+		return nil, writer.writerErr
+	}
+	if writer.writer != nil {
+		return writer.writer, nil
+	}
+	writer.writer, writer.closer, writer.writerErr = writer.createGeneratedConfigWriter()
+	return writer.writer, writer.writerErr
+}
+
+func (writer *generatedConfigWriter) Close() error {
+	if writer.closer != nil {
+		return writer.closer()
+	}
+	return nil
+}
+
+func (writer *generatedConfigWriter) Failed() (map[string]error, error) {
+	return writer.failed, writer.writerErr
+}

--- a/internal/command/jsonformat/generated_config_writer.go
+++ b/internal/command/jsonformat/generated_config_writer.go
@@ -51,7 +51,7 @@ func (writer *generatedConfigWriter) MaybeWriteGeneratedConfig(diff diff) bool {
 	if diff.change.Change.Importing != nil && len(diff.change.Change.Importing.ID) > 0 {
 		header = fmt.Sprintf("\n# __generated__ by Terraform from %q\n", diff.change.Change.Importing.ID)
 	} else {
-		header = fmt.Sprintf("\n# __generated__ by Terraform\n")
+		header = "\n# __generated__ by Terraform\n"
 	}
 
 	_, err := w.Write([]byte(fmt.Sprintf("%s%s\n", header, diff.change.Change.GeneratedConfig)))

--- a/internal/command/state_show.go
+++ b/internal/command/state_show.go
@@ -157,13 +157,10 @@ func (c *StateShowCommand) Run(args []string) int {
 		ProviderSchemas:       jsonprovider.MarshalForRenderer(schemas),
 	}
 
-	renderer := jsonformat.Renderer{
-		Streams:             c.Streams,
-		Colorize:            c.Colorize(),
-		RunningInAutomation: c.RunningInAutomation,
-	}
-
+	renderer := jsonformat.NewRenderer(c.Streams, c.Colorize())
+	renderer.RunningInAutomation = c.RunningInAutomation
 	renderer.RenderHumanState(jstate)
+
 	return 0
 }
 

--- a/internal/command/views/operation.go
+++ b/internal/command/views/operation.go
@@ -98,11 +98,8 @@ func (v *OperationHuman) Plan(plan *plans.Plan, schemas *terraform.Schemas) {
 		return
 	}
 
-	renderer := jsonformat.Renderer{
-		Colorize:            v.view.colorize,
-		Streams:             v.view.streams,
-		RunningInAutomation: v.inAutomation,
-	}
+	renderer := jsonformat.NewRenderer(v.view.streams, v.view.colorize)
+	renderer.RunningInAutomation = v.inAutomation
 
 	jplan := jsonformat.Plan{
 		PlanFormatVersion:     jsonplan.FormatVersion,

--- a/internal/command/views/show.go
+++ b/internal/command/views/show.go
@@ -44,11 +44,8 @@ type ShowHuman struct {
 var _ Show = (*ShowHuman)(nil)
 
 func (v *ShowHuman) Display(config *configs.Config, plan *plans.Plan, stateFile *statefile.File, schemas *terraform.Schemas) int {
-	renderer := jsonformat.Renderer{
-		Colorize:            v.view.colorize,
-		Streams:             v.view.streams,
-		RunningInAutomation: v.view.runningInAutomation,
-	}
+	renderer := jsonformat.NewRenderer(v.view.streams, v.view.colorize)
+	renderer.RunningInAutomation = v.view.runningInAutomation
 
 	if plan != nil {
 		outputs, changed, drift, attrs, err := jsonplan.MarshalForRenderer(plan, schemas)


### PR DESCRIPTION
This is an alternative to #33166 

In this PR, the human renderer will create/append to the generated_config.tf file as it is writing out the plan. Effectively, this means the config will be generated during the planning stage as opposed to the apply stage.

The human renderer will also print a little explanation asking the users to file a bug in case anything goes wrong when writing out the generated config. It's very unlikely that something will go wrong at that stage, but the golang IO API returns errors for these operations and it felt better to handle them than ignore them.

I also did a small refactoring of the renderer to place its creation inside of a dedicated function, so callers can be sure they are setting all of the required fields.