### PR TITLE
Don't mark check results as experimental in JSON outputs.

### DIFF
--- a/internal/command/jsonchecks/checks.go
+++ b/internal/command/jsonchecks/checks.go
@@ -73,8 +73,6 @@ func MarshalCheckStates(results *states.CheckResults) []byte {
 // object in the configuration even if Terraform Core encountered an error
 // before being able to determine the dynamic instances of the checkable object.
 type checkResultStatic struct {
-	ExperimentalNote experimentalNote `json:"//"`
-
 	// Address is the address of the checkable object this result relates to.
 	Address staticObjectAddr `json:"address"`
 
@@ -118,10 +116,4 @@ type checkProblem struct {
 	// We don't currently have any other problem-related data, but this is
 	// intentionally an object to allow us to add other data over time, such
 	// as the source location where the failing condition was defined.
-}
-
-type experimentalNote struct{}
-
-func (n experimentalNote) MarshalJSON() ([]byte, error) {
-	return []byte(`"EXPERIMENTAL: see docs for details"`), nil
 }

--- a/internal/command/jsonchecks/checks_test.go
+++ b/internal/command/jsonchecks/checks_test.go
@@ -110,7 +110,6 @@ func TestMarshalCheckStates(t *testing.T) {
 			},
 			[]any{
 				map[string]any{
-					"//": "EXPERIMENTAL: see docs for details",
 					"address": map[string]any{
 						"kind":       "check",
 						"to_display": "check.a",
@@ -132,7 +131,6 @@ func TestMarshalCheckStates(t *testing.T) {
 					"status": "fail",
 				},
 				map[string]any{
-					"//": "EXPERIMENTAL: see docs for details",
 					"address": map[string]any{
 						"kind":       "output_value",
 						"module":     "module.child",
@@ -156,7 +154,6 @@ func TestMarshalCheckStates(t *testing.T) {
 					"status": "fail",
 				},
 				map[string]any{
-					"//": "EXPERIMENTAL: see docs for details",
 					"address": map[string]any{
 						"kind":       "resource",
 						"mode":       "managed",
@@ -182,7 +179,6 @@ func TestMarshalCheckStates(t *testing.T) {
 					"status": "fail",
 				},
 				map[string]any{
-					"//": "EXPERIMENTAL: see docs for details",
 					"address": map[string]any{
 						"kind":       "output_value",
 						"name":       "a",
@@ -199,7 +195,6 @@ func TestMarshalCheckStates(t *testing.T) {
 					"status": "fail",
 				},
 				map[string]any{
-					"//": "EXPERIMENTAL: see docs for details",
 					"address": map[string]any{
 						"kind":       "resource",
 						"mode":       "managed",


### PR DESCRIPTION
In preparation for 1.5, we're no longer marking the JSON output for checks as experimental. The new check blocks are fully supported and shouldn't be marked as experimental, so the rest of the checks get carried forward as well.