### PR TITLE
codify saved plan artifact contents

### DIFF
--- a/internal/cloud/backend_saved_plan.go
+++ b/internal/cloud/backend_saved_plan.go
@@ -1,0 +1,10 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package cloud
+
+type SavedPlanBookmark struct {
+	RemotePlanFormat int    `json:"remote_plan_format"`
+	RunID            string `json:"run_id"`
+	Hostname         string `json:"hostname"`
+}

--- a/internal/cloud/backend_saved_plan_test.go
+++ b/internal/cloud/backend_saved_plan_test.go
@@ -1,0 +1,4 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package cloud


### PR DESCRIPTION
To save and load remote plan bookmarks, Terraform CLI will need a predictable serialized (json) format, and an internal struct to load the data into.
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Fixes #

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.4.x

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

### NEW FEATURES | UPGRADE NOTES | ENHANCEMENTS | BUG FIXES | EXPERIMENTS

<!--

Write a short description of the user-facing change. Examples:

- `terraform show -json`: Fixed crash with sensitive set values.
- When rendering a diff, Terraform now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 

-  
