### PR TITLE
plannable import: write generated config to out flag

### DIFF
--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -295,6 +295,11 @@ type Operation struct {
 	// Workspace is the name of the workspace that this operation should run
 	// in, which controls which named state is used.
 	Workspace string
+
+	// GenerateConfigOut tells the operation both that it should generate config
+	// for unmatched import targets and where any generated config should be
+	// written to.
+	GenerateConfigOut string
 }
 
 // HasConfig returns true if and only if the operation has a ConfigDir value

--- a/internal/backend/local/backend_local.go
+++ b/internal/backend/local/backend_local.go
@@ -190,11 +190,12 @@ func (b *Local) localRunDirect(op *backend.Operation, run *backend.LocalRun, cor
 	}
 
 	planOpts := &terraform.PlanOpts{
-		Mode:         op.PlanMode,
-		Targets:      op.Targets,
-		ForceReplace: op.ForceReplace,
-		SetVariables: variables,
-		SkipRefresh:  op.Type != backend.OperationTypeRefresh && !op.PlanRefresh,
+		Mode:           op.PlanMode,
+		Targets:        op.Targets,
+		ForceReplace:   op.ForceReplace,
+		SetVariables:   variables,
+		SkipRefresh:    op.Type != backend.OperationTypeRefresh && !op.PlanRefresh,
+		GenerateConfig: len(op.GenerateConfigOut) > 0,
 	}
 	run.PlanOpts = planOpts
 

--- a/internal/command/arguments/plan.go
+++ b/internal/command/arguments/plan.go
@@ -25,6 +25,11 @@ type Plan struct {
 	// OutPath contains an optional path to store the plan file
 	OutPath string
 
+	// GenerateConfigPath tells Terraform that config should be generated for
+	// unmatched import target paths and which path the generated file should
+	// be written to.
+	GenerateConfigPath string
+
 	// ViewType specifies which output format to use
 	ViewType ViewType
 }
@@ -44,6 +49,7 @@ func ParsePlan(args []string) (*Plan, tfdiags.Diagnostics) {
 	cmdFlags.BoolVar(&plan.DetailedExitCode, "detailed-exitcode", false, "detailed-exitcode")
 	cmdFlags.BoolVar(&plan.InputEnabled, "input", true, "input")
 	cmdFlags.StringVar(&plan.OutPath, "out", "", "out")
+	cmdFlags.StringVar(&plan.GenerateConfigPath, "generate-config-out", "", "generate-config-out")
 
 	var json bool
 	cmdFlags.BoolVar(&json, "json", false, "json")

--- a/internal/command/command_test.go
+++ b/internal/command/command_test.go
@@ -252,6 +252,24 @@ func testPlanFileNoop(t *testing.T) string {
 	return testPlanFile(t, snap, state, plan)
 }
 
+func testFileEquals(t *testing.T, got, want string) {
+	t.Helper()
+
+	actual, err := os.ReadFile(got)
+	if err != nil {
+		t.Fatalf("error reading %s", got)
+	}
+
+	expected, err := os.ReadFile(want)
+	if err != nil {
+		t.Fatalf("error reading %s", want)
+	}
+
+	if diff := cmp.Diff(string(actual), string(expected)); len(diff) > 0 {
+		t.Fatalf("got:\n%s\nwant:\n%s\ndiff:\n%s", actual, expected, diff)
+	}
+}
+
 func testReadPlan(t *testing.T, path string) *plans.Plan {
 	t.Helper()
 

--- a/internal/command/plan.go
+++ b/internal/command/plan.go
@@ -75,7 +75,7 @@ func (c *PlanCommand) Run(rawArgs []string) int {
 	}
 
 	// Build the operation request
-	opReq, opDiags := c.OperationRequest(be, view, args.ViewType, args.Operation, args.OutPath)
+	opReq, opDiags := c.OperationRequest(be, view, args.ViewType, args.Operation, args.OutPath, args.GenerateConfigPath)
 	diags = diags.Append(opDiags)
 	if diags.HasErrors() {
 		view.Diagnostics(diags)
@@ -144,6 +144,7 @@ func (c *PlanCommand) OperationRequest(
 	viewType arguments.ViewType,
 	args *arguments.Operation,
 	planOutPath string,
+	generateConfigOut string,
 ) (*backend.Operation, tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
 
@@ -154,6 +155,7 @@ func (c *PlanCommand) OperationRequest(
 	opReq.Hooks = view.Hooks()
 	opReq.PlanRefresh = args.Refresh
 	opReq.PlanOutPath = planOutPath
+	opReq.GenerateConfigOut = generateConfigOut
 	opReq.Targets = args.Targets
 	opReq.ForceReplace = args.ForceReplace
 	opReq.Type = backend.OperationTypePlan

--- a/internal/command/testdata/plan-import-config-gen/generated.tf.expected
+++ b/internal/command/testdata/plan-import-config-gen/generated.tf.expected
@@ -1,0 +1,8 @@
+# __generated__ by Terraform
+# Please review these resources and move them into your main configuration files.
+
+# __generated__ by Terraform from "bar"
+resource "test_instance" "foo" {
+  ami = null
+  id  = "bar"
+}

--- a/internal/command/testdata/plan-import-config-gen/main.tf
+++ b/internal/command/testdata/plan-import-config-gen/main.tf
@@ -1,0 +1,4 @@
+import {
+  id = "bar"
+  to = test_instance.foo
+}

--- a/internal/genconfig/generate_config_write.go
+++ b/internal/genconfig/generate_config_write.go
@@ -1,0 +1,81 @@
+package genconfig
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/hashicorp/terraform/internal/plans"
+	"github.com/hashicorp/terraform/internal/tfdiags"
+)
+
+func ValidateTargetFile(out string) tfdiags.Diagnostics {
+	var diags tfdiags.Diagnostics
+	if _, err := os.Stat(out); !os.IsNotExist(err) {
+		diags = diags.Append(tfdiags.Sourceless(
+			tfdiags.Error,
+			"Target generated file already exists",
+			"Terraform can only write generated config into a new file. Either choose a different target location or move all existing configuration out of the target file, delete it and try again."))
+
+	}
+	return diags
+}
+
+func MaybeWriteGeneratedConfig(plan *plans.Plan, out string) tfdiags.Diagnostics {
+	if len(out) == 0 {
+		// No specified out file, so don't write anything.
+		return nil
+	}
+
+	diags := ValidateTargetFile(out)
+	if diags.HasErrors() {
+		return diags
+	}
+
+	var writer io.Writer
+
+	for _, change := range plan.Changes.Resources {
+		if len(change.GeneratedConfig) > 0 {
+
+			if writer == nil {
+				// Lazily create the generated file, in case we have no
+				// generated config to create.
+				var err error
+				if writer, err = os.Create(out); err != nil {
+					if os.IsPermission(err) {
+						diags = diags.Append(tfdiags.Sourceless(
+							tfdiags.Error,
+							"Failed to create target generated file",
+							fmt.Sprintf("Terraform did not have permission to create the generated file (%s) in the target directory. Please modify permissions over the target directory, and try again.", out)))
+						return diags
+					}
+
+					diags = diags.Append(tfdiags.Sourceless(
+						tfdiags.Error,
+						"Failed to create target generated file",
+						fmt.Sprintf("Terraform could not create the generated file (%s) in the target directory: %v. Depending on the error message, this may be a bug in Terraform itself. If so, please report it!", out, err)))
+					return diags
+				}
+
+				header := "# __generated__ by Terraform\n# Please review these resources and move them into your main configuration files.\n"
+				// Missing the header from the file, isn't the end of the world
+				// so if this did return an error, then we will just ignore it.
+				_, _ = writer.Write([]byte(header))
+			}
+
+			header := "\n# __generated__ by Terraform"
+			if change.Importing != nil && len(change.Importing.ID) > 0 {
+				header += fmt.Sprintf(" from %q", change.Importing.ID)
+			}
+			header += "\n"
+			if _, err := writer.Write([]byte(fmt.Sprintf("%s%s\n", header, change.GeneratedConfig))); err != nil {
+				diags = diags.Append(tfdiags.Sourceless(
+					tfdiags.Warning,
+					"Failed to save generated config",
+					fmt.Sprintf("Terraform encountered an error while writing generated config: %v. The config for %s must be created manually before applying. Depending on the error message, this may be a bug in Terraform itself. If so, please report it!", err, change.Addr.String())))
+			}
+		}
+	}
+
+	return diags
+}

--- a/internal/terraform/context_plan.go
+++ b/internal/terraform/context_plan.go
@@ -77,6 +77,10 @@ type PlanOpts struct {
 	// ImportTargets is a list of target resources to import. These resources
 	// will be added to the plan graph.
 	ImportTargets []*ImportTarget
+
+	// GenerateConfig tells Terraform to generate configuration for any
+	// ImportTargets that do not have configuration already.
+	GenerateConfig bool
 }
 
 // Plan generates an execution plan by comparing the given configuration
@@ -626,6 +630,7 @@ func (c *Context) planGraph(config *configs.Config, prevRunState *states.State, 
 			preDestroyRefresh:  opts.PreDestroyRefresh,
 			Operation:          walkPlan,
 			ImportTargets:      opts.ImportTargets,
+			GenerateConfig:     opts.GenerateConfig,
 		}).Build(addrs.RootModuleInstance)
 		return graph, walkPlan, diags
 	case plans.RefreshOnlyMode:

--- a/internal/terraform/context_plan2_test.go
+++ b/internal/terraform/context_plan2_test.go
@@ -4419,7 +4419,10 @@ resource "test_object" "a" {
 		},
 	}
 
-	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	plan, diags := ctx.Plan(m, states.NewState(), &PlanOpts{
+		Mode:           plans.NormalMode,
+		GenerateConfig: true,
+	})
 	if diags.HasErrors() {
 		t.Fatalf("unexpected errors\n%s", diags.Err().Error())
 	}
@@ -4476,7 +4479,10 @@ import {
 		},
 	}
 
-	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	plan, diags := ctx.Plan(m, states.NewState(), &PlanOpts{
+		Mode:           plans.NormalMode,
+		GenerateConfig: true,
+	})
 	if diags.HasErrors() {
 		t.Fatalf("unexpected errors\n%s", diags.Err().Error())
 	}
@@ -4555,7 +4561,10 @@ import {
 		},
 	}
 
-	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	plan, diags := ctx.Plan(m, states.NewState(), &PlanOpts{
+		Mode:           plans.NormalMode,
+		GenerateConfig: true,
+	})
 	if diags.HasErrors() {
 		t.Fatalf("unexpected errors\n%s", diags.Err().Error())
 	}

--- a/internal/terraform/graph_builder_plan.go
+++ b/internal/terraform/graph_builder_plan.go
@@ -75,6 +75,10 @@ type PlanGraphBuilder struct {
 
 	// ImportTargets are the list of resources to import.
 	ImportTargets []*ImportTarget
+
+	// GenerateConfig tells Terraform to generate config for any import targets
+	// that do not already have configuration.
+	GenerateConfig bool
 }
 
 // See GraphBuilder
@@ -113,8 +117,7 @@ func (b *PlanGraphBuilder) Steps() []GraphTransformer {
 			importTargets: b.ImportTargets,
 
 			// We only want to generate config during a plan operation.
-			// TODO: add a dedicated flag for this?
-			generateConfigForImportTargets: b.Operation == walkPlan,
+			generateConfigForImportTargets: b.GenerateConfig,
 		},
 
 		// Add dynamic values

--- a/internal/terraform/node_resource_abstract.go
+++ b/internal/terraform/node_resource_abstract.go
@@ -78,6 +78,9 @@ type NodeAbstractResource struct {
 
 	// This resource may expand into instances which need to be imported.
 	importTargets []*ImportTarget
+
+	// generateConfig tells this node that it's okay for it to generate config.
+	generateConfig bool
 }
 
 var (

--- a/internal/terraform/node_resource_apply_instance.go
+++ b/internal/terraform/node_resource_apply_instance.go
@@ -274,7 +274,7 @@ func (n *NodeApplyableResourceInstance) managedResourceExecute(ctx EvalContext) 
 
 	// Make a new diff, in case we've learned new values in the state
 	// during apply which we can now incorporate.
-	diffApply, _, repeatData, planDiags := n.plan(ctx, diff, state, false, n.forceReplace, false)
+	diffApply, _, repeatData, planDiags := n.plan(ctx, diff, state, false, n.forceReplace)
 	diags = diags.Append(planDiags)
 	if diags.HasErrors() {
 		return diags

--- a/internal/terraform/node_resource_plan.go
+++ b/internal/terraform/node_resource_plan.go
@@ -336,6 +336,7 @@ func (n *nodeExpandPlannableResource) resourceInstanceSubgraph(ctx EvalContext, 
 		a.dependsOn = n.dependsOn
 		a.Dependencies = n.dependencies
 		a.preDestroyRefresh = n.preDestroyRefresh
+		a.generateConfig = n.generateConfig
 
 		m = &NodePlannableResourceInstance{
 			NodeAbstractResourceInstance: a,

--- a/internal/terraform/node_resource_plan_instance.go
+++ b/internal/terraform/node_resource_plan_instance.go
@@ -163,7 +163,7 @@ func (n *NodePlannableResourceInstance) managedResourceExecute(ctx EvalContext) 
 			diags = diags.Append(&hcl.Diagnostic{
 				Severity: hcl.DiagError,
 				Summary:  "Import block target does not exist",
-				Detail:   "The target for the given import block does not exist. If you wish to automatically generate config for this resource, use the -generate-config-out option within terraform plan. Otherwise, make sure the target resource exists within your configuration.",
+				Detail:   "The target for the given import block does not exist. If you wish to automatically generate config for this resource, use the -generate-config-out option within terraform plan. Otherwise, make sure the target resource exists within your configuration. For example:\n\n  terraform plan -generate-config-out=generated.tf",
 				Subject:  n.importTarget.Config.DeclRange.Ptr(),
 			})
 		} else {


### PR DESCRIPTION
- Adds a flag to the plan command: `gen-config-out`
- Uses the flag to decide whether generated config will be produced at all, and the location it will go to.
- If the location already exists, we fail and tell the user to choose a new one to avoid problems with concurrent writes or accidental deletions.
- Adds nice error messages detailing why an import fails if the target doesn't exist, and how to make it generate config for you.
- Refactor so the transform_config.go file decides when a node is created whether or not it will generate config instead of letting the node make the decision itself later. This makes it easier to tie it all back to presence of the new flag.