### PR TITLE
validate duplicate import blocks

### DIFF
--- a/internal/command/testdata/validate-invalid/duplicate_import_ids/main.tf
+++ b/internal/command/testdata/validate-invalid/duplicate_import_ids/main.tf
@@ -1,0 +1,15 @@
+resource "aws_instance" "web" {
+}
+
+resource "aws_instance" "other_web" {
+}
+
+import {
+  to = aws_instance.web
+  id = "test"
+}
+
+import {
+  to = aws_instance.other_web
+  id = "test"
+}

--- a/internal/command/testdata/validate-invalid/duplicate_import_ids/output.json
+++ b/internal/command/testdata/validate-invalid/duplicate_import_ids/output.json
@@ -1,0 +1,34 @@
+{
+  "format_version": "1.0",
+  "valid": false,
+  "error_count": 1,
+  "warning_count": 0,
+  "diagnostics": [
+    {
+      "severity": "error",
+      "summary": "Duplicate import for ID \"test\"",
+      "detail": "An import block for the ID \"test\" and a resource of type \"aws_instance\" was already declared at testdata/validate-invalid/duplicate_import_ids/main.tf:7,1-7. The same resource cannot be imported twice.",
+      "range": {
+        "filename": "testdata/validate-invalid/duplicate_import_ids/main.tf",
+        "start": {
+          "line": 12,
+          "column": 1,
+          "byte": 126
+        },
+        "end": {
+          "line": 12,
+          "column": 7,
+          "byte": 132
+        }
+      },
+      "snippet": {
+        "context": null,
+        "code": "import {",
+        "start_line": 12,
+        "highlight_start_offset": 0,
+        "highlight_end_offset": 6,
+        "values": []
+      }
+    }
+  ]
+}

--- a/internal/command/testdata/validate-invalid/duplicate_import_targets/main.tf
+++ b/internal/command/testdata/validate-invalid/duplicate_import_targets/main.tf
@@ -1,0 +1,12 @@
+resource "aws_instance" "web" {
+}
+
+import {
+  to = aws_instance.web
+  id = "test"
+}
+
+import {
+  to = aws_instance.web
+  id = "test2"
+}

--- a/internal/command/testdata/validate-invalid/duplicate_import_targets/output.json
+++ b/internal/command/testdata/validate-invalid/duplicate_import_targets/output.json
@@ -1,0 +1,34 @@
+{
+  "format_version": "1.0",
+  "valid": false,
+  "error_count": 1,
+  "warning_count": 0,
+  "diagnostics": [
+    {
+      "severity": "error",
+      "summary": "Duplicate import configuration for \"aws_instance.web\"",
+      "detail": "An import block for the resource \"aws_instance.web\" was already declared at testdata/validate-invalid/duplicate_import_targets/main.tf:4,1-7. A resource can have only one import block.",
+      "range": {
+        "filename": "testdata/validate-invalid/duplicate_import_targets/main.tf",
+        "start": {
+          "line": 9,
+          "column": 1,
+          "byte": 85
+        },
+        "end": {
+          "line": 9,
+          "column": 7,
+          "byte": 91
+        }
+      },
+      "snippet": {
+        "context": null,
+        "code": "import {",
+        "start_line": 9,
+        "highlight_start_offset": 0,
+        "highlight_end_offset": 6,
+        "values": []
+      }
+    }
+  ]
+}

--- a/internal/command/validate_test.go
+++ b/internal/command/validate_test.go
@@ -150,6 +150,28 @@ func TestSameResourceMultipleTimesShouldFail(t *testing.T) {
 	}
 }
 
+func TestSameImportTargetMultipleTimesShouldFail(t *testing.T) {
+	output, code := setupTest(t, "validate-invalid/duplicate_import_targets")
+	if code != 1 {
+		t.Fatalf("Should have failed: %d\n\n%s", code, output.Stderr())
+	}
+	wantError := `Error: Duplicate import configuration for "aws_instance.web"`
+	if !strings.Contains(output.Stderr(), wantError) {
+		t.Fatalf("Missing error string %q\n\n'%s'", wantError, output.Stderr())
+	}
+}
+
+func TestSameImportIDMultipleTimesShouldFail(t *testing.T) {
+	output, code := setupTest(t, "validate-invalid/duplicate_import_ids")
+	if code != 1 {
+		t.Fatalf("Should have failed: %d\n\n%s", code, output.Stderr())
+	}
+	wantError := `Error: Duplicate import for ID "test"`
+	if !strings.Contains(output.Stderr(), wantError) {
+		t.Fatalf("Missing error string %q\n\n'%s'", wantError, output.Stderr())
+	}
+}
+
 func TestOutputWithoutValueShouldFail(t *testing.T) {
 	output, code := setupTest(t, "validate-invalid/outputs")
 	if code != 1 {
@@ -218,6 +240,8 @@ func TestValidate_json(t *testing.T) {
 		{"validate-invalid/multiple_providers", false},
 		{"validate-invalid/multiple_modules", false},
 		{"validate-invalid/multiple_resources", false},
+		{"validate-invalid/duplicate_import_targets", false},
+		{"validate-invalid/duplicate_import_ids", false},
 		{"validate-invalid/outputs", false},
 		{"validate-invalid/incorrectmodulename", false},
 		{"validate-invalid/interpolation", false},


### PR DESCRIPTION
Importing to the same target address twice or attempting to import the same ID to two different resources of the same type will lead only to sadness and shouldn't be possible.

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.5.x

