### PR TITLE
plannable import: error if importing to invalid keyed address

### DIFF
--- a/internal/terraform/context_plan.go
+++ b/internal/terraform/context_plan.go
@@ -513,6 +513,33 @@ func (c *Context) postPlanValidateMoves(config *configs.Config, stmts []refactor
 	return refactoring.ValidateMoves(stmts, config, allInsts)
 }
 
+// All import target addresses with a key must already exist in config.
+// When we are able to generate config for expanded resources, this rule can be
+// relaxed.
+func (c *Context) postPlanValidateImports(config *configs.Config, importTargets []*ImportTarget, allInst instances.Set) tfdiags.Diagnostics {
+	var diags tfdiags.Diagnostics
+	for _, it := range importTargets {
+		// We only care about import target addresses that have a key.
+		// If the address does not have a key, we don't need it to be in config
+		// because are able to generate config.
+		if it.Addr.Resource.Key == nil {
+			continue
+		}
+
+		if !allInst.HasResourceInstance(it.Addr) {
+			diags = diags.Append(tfdiags.Sourceless(
+				tfdiags.Error,
+				"Cannot import to non-existent resource address",
+				fmt.Sprintf(
+					"Importing to resource address %s is not possible, because that address does not exist in configuration. Please ensure that the resource key is correct, or remove this import block.",
+					it.Addr,
+				),
+			))
+		}
+	}
+	return diags
+}
+
 // findImportTargets builds a list of import targets by taking the import blocks
 // in the config and filtering out any that target a resource already in state.
 func (c *Context) findImportTargets(config *configs.Config, priorState *states.State) []*ImportTarget {
@@ -566,7 +593,15 @@ func (c *Context) planWalk(config *configs.Config, prevRunState *states.State, o
 	})
 	diags = diags.Append(walker.NonFatalDiagnostics)
 	diags = diags.Append(walkDiags)
-	moveValidateDiags := c.postPlanValidateMoves(config, moveStmts, walker.InstanceExpander.AllInstances())
+
+	allInsts := walker.InstanceExpander.AllInstances()
+
+	importValidateDiags := c.postPlanValidateImports(config, opts.ImportTargets, allInsts)
+	if importValidateDiags.HasErrors() {
+		return nil, importValidateDiags
+	}
+
+	moveValidateDiags := c.postPlanValidateMoves(config, moveStmts, allInsts)
 	if moveValidateDiags.HasErrors() {
 		// If any of the move statements are invalid then those errors take
 		// precedence over any other errors because an incomplete move graph


### PR DESCRIPTION
Import addresses targeting expanded resource instances must target instances that already exist in configuration.

For example, an import block targeting `aws_instance.example["foo"]` is not valid if there is not already a configuration block for `aws_instance.example` with `for_each` and the key `"foo"`.
