### PR TITLE
plannable import: error if importing to a move source

### DIFF
--- a/internal/configs/testdata/invalid-modules/import-to-moved-from/main.tf
+++ b/internal/configs/testdata/invalid-modules/import-to-moved-from/main.tf
@@ -1,0 +1,12 @@
+import {
+  id = "foo/bar"
+  to = local_file.foo_bar
+}
+
+moved {
+  from = local_file.foo_bar
+  to   = local_file.bar_baz
+}
+
+resource "local_file" "bar_baz" {
+}


### PR DESCRIPTION
It is invalid for any import block to have a "to" argument matching any moved block's "from" argument.