### PR TITLE
plannable import: disallow import blocks in child modules

### DIFF
--- a/internal/configs/config_build.go
+++ b/internal/configs/config_build.go
@@ -4,6 +4,7 @@
 package configs
 
 import (
+	"fmt"
 	"sort"
 
 	version "github.com/hashicorp/go-version"
@@ -98,6 +99,15 @@ func buildChildModules(parent *Config, walker ModuleWalker) (map[string]*Config,
 				Summary:  "Backend configuration ignored",
 				Detail:   "Any selected backend applies to the entire configuration, so Terraform expects provider configurations only in the root module.\n\nThis is a warning rather than an error because it's sometimes convenient to temporarily call a root module as a child module for testing purposes, but this backend configuration block will have no effect.",
 				Subject:  mod.Backend.DeclRange.Ptr(),
+			})
+		}
+
+		if len(mod.Import) > 0 {
+			diags = diags.Append(&hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  "Invalid import configuration",
+				Detail:   fmt.Sprintf("An import block was detected in %q. Import blocks are only allowed in the root module.", child.Path),
+				Subject:  mod.Import[0].DeclRange.Ptr(),
 			})
 		}
 

--- a/internal/configs/testdata/config-diagnostics/import-in-child-module/child/main.tf
+++ b/internal/configs/testdata/config-diagnostics/import-in-child-module/child/main.tf
@@ -1,0 +1,6 @@
+resource "aws_instance" "web" {}
+
+import {
+  to = aws_instance.web
+  id = "test"
+}

--- a/internal/configs/testdata/config-diagnostics/import-in-child-module/errors
+++ b/internal/configs/testdata/config-diagnostics/import-in-child-module/errors
@@ -1,0 +1,1 @@
+import-in-child-module/child/main.tf:3,1-7: Invalid import configuration; An import block was detected in "module.child". Import blocks are only allowed in the root module.

--- a/internal/configs/testdata/config-diagnostics/import-in-child-module/root.tf
+++ b/internal/configs/testdata/config-diagnostics/import-in-child-module/root.tf
@@ -1,0 +1,10 @@
+resource "aws_instance" "web" {}
+
+import {
+  to = aws_instance.web
+  id = "test"
+}
+
+module "child" {
+  source = "./child"
+}


### PR DESCRIPTION
We currently only allow `import` blocks in the root module. If a child module contains an import block, we error.

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.5.x

