### PR TITLE
plannable import: improve gen config human plan output

### DIFF
--- a/internal/backend/local/backend_plan.go
+++ b/internal/backend/local/backend_plan.go
@@ -55,7 +55,6 @@ func (b *Local) opPlan(
 	}
 
 	if len(op.GenerateConfigOut) > 0 {
-
 		if op.PlanMode != plans.NormalMode {
 			diags = diags.Append(tfdiags.Sourceless(
 				tfdiags.Error,
@@ -192,7 +191,7 @@ func (b *Local) opPlan(
 	}
 
 	// Write out any generated config, before we render the plan.
-	moreDiags = genconfig.MaybeWriteGeneratedConfig(plan, op.GenerateConfigOut)
+	wroteConfig, moreDiags := genconfig.MaybeWriteGeneratedConfig(plan, op.GenerateConfigOut)
 	diags = diags.Append(moreDiags)
 	if moreDiags.HasErrors() {
 		op.ReportResult(runningOp, diags)
@@ -209,6 +208,10 @@ func (b *Local) opPlan(
 	op.ReportResult(runningOp, diags)
 
 	if !runningOp.PlanEmpty {
-		op.View.PlanNextStep(op.PlanOutPath)
+		if wroteConfig {
+			op.View.PlanNextStep(op.PlanOutPath, op.GenerateConfigOut)
+		} else {
+			op.View.PlanNextStep(op.PlanOutPath, "")
+		}
 	}
 }

--- a/internal/command/jsonformat/plan.go
+++ b/internal/command/jsonformat/plan.go
@@ -469,7 +469,7 @@ func resourceChangeComment(resource jsonplan.ResourceChange, action plans.Action
 		if resource.Change.Importing != nil {
 			buf.WriteString(fmt.Sprintf("[bold]  # %s[reset] will be imported", dispAddr))
 			if len(resource.Change.GeneratedConfig) > 0 {
-				buf.WriteString("\n  #[reset] (config will be written to generated_config.tf)")
+				buf.WriteString("\n  #[reset] (config will be generated)")
 			}
 			printedImported = true
 			break

--- a/internal/command/jsonformat/plan_test.go
+++ b/internal/command/jsonformat/plan_test.go
@@ -178,7 +178,7 @@ Plan: 1 to import, 0 to add, 0 to change, 0 to destroy.
 Terraform will perform the following actions:
 
   # test_resource.resource will be imported
-  # (config will be written to generated_config.tf)
+  # (config will be generated)
     resource "test_resource" "resource" {
         id    = "1D5F5E9E-F2E5-401B-9ED5-692A215AC67E"
         value = "Hello, World!"

--- a/internal/command/views/operation_test.go
+++ b/internal/command/views/operation_test.go
@@ -450,7 +450,7 @@ func TestOperation_planNextStep(t *testing.T) {
 			streams, done := terminal.StreamsForTesting(t)
 			v := NewOperation(arguments.ViewHuman, false, NewView(streams))
 
-			v.PlanNextStep(tc.path)
+			v.PlanNextStep(tc.path, "")
 
 			if got := done(t).Stdout(); !strings.Contains(got, tc.want) {
 				t.Errorf("wrong result\ngot:  %q\nwant: %q", got, tc.want)
@@ -465,7 +465,7 @@ func TestOperation_planNextStepInAutomation(t *testing.T) {
 	streams, done := terminal.StreamsForTesting(t)
 	v := NewOperation(arguments.ViewHuman, true, NewView(streams))
 
-	v.PlanNextStep("")
+	v.PlanNextStep("", "")
 
 	if got := done(t).Stdout(); got != "" {
 		t.Errorf("unexpected output\ngot: %q", got)


### PR DESCRIPTION
The config generation file path is now dynamic, so remove mentions of `generated_config.tf` from the human renderer. We may want to plumb the actual file name through, but not without a little more thought into whether we're going to truncate it in the resource change comment.

Also add a note to the plan next steps when the config is generated. This should only print if a file is actually written.