### PR TITLE
plannable import: remove timeouts from genconfig schema

### DIFF
--- a/internal/terraform/node_resource_abstract_instance.go
+++ b/internal/terraform/node_resource_abstract_instance.go
@@ -1218,6 +1218,8 @@ func (n *NodeAbstractResource) generateHCLStringAttributes(addr addrs.AbsResourc
 		configschema.FilterOr(configschema.FilterReadOnlyAttributes, configschema.FilterDeprecatedAttribute),
 		configschema.FilterDeprecatedBlock)
 
+	delete(filteredSchema.BlockTypes, "timeouts")
+
 	providerAddr := addrs.LocalProviderConfig{
 		LocalName: n.ResolvedProvider.Provider.Type,
 		Alias:     n.ResolvedProvider.Alias,


### PR DESCRIPTION
If the schema contains `timeouts` but the state does not, generating config will panic.
There is no need to attempt to write the timeouts block in generated config, so remove it for now.