### PR TITLE
backend/oss: Removes the deprecated warning for configuration variable assume_role

### DIFF
--- a/internal/backend/remote-state/oss/backend.go
+++ b/internal/backend/remote-state/oss/backend.go
@@ -40,10 +40,10 @@ import (
 // Deprecated in favor of flattening assume_role_* options
 func deprecatedAssumeRoleSchema() *schema.Schema {
 	return &schema.Schema{
-		Type:       schema.TypeSet,
-		Optional:   true,
-		MaxItems:   1,
-		Deprecated: "use assume_role_* options instead",
+		Type:     schema.TypeSet,
+		Optional: true,
+		MaxItems: 1,
+		//Deprecated: "use assume_role_* options instead",
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{
 				"role_arn": {


### PR DESCRIPTION
Terraform State OSS Backend has a deprecated configuration variable `assume_role`, and it has been marked as `Deprecated`, and there always throws a warning when using oss backend. This is uncomfortable for customers. This PR aims to remove the warning.

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.4.x

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

### ENHANCEMENTS
<!--

Write a short description of the user-facing change. Examples:

- `terraform show -json`: Fixed crash with sensitive set values.
- When rendering a diff, Terraform now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 

