### PR TITLE
Add `prevent_removal` lifecycle flag as a stronger version of `prevent_destroy`

### DIFF
--- a/internal/configs/module_merge.go
+++ b/internal/configs/module_merge.go
@@ -252,6 +252,10 @@ func (r *Resource) merge(or *Resource, rps map[string]*RequiredProvider) hcl.Dia
 			r.Managed.PreventDestroy = or.Managed.PreventDestroy
 			r.Managed.PreventDestroySet = or.Managed.PreventDestroySet
 		}
+		if or.Managed.PreventRemovalSet {
+			r.Managed.PreventRemoval = or.Managed.PreventRemoval
+			r.Managed.PreventRemovalSet = or.Managed.PreventRemovalSet
+		}
 		if len(or.Managed.Provisioners) != 0 {
 			r.Managed.Provisioners = or.Managed.Provisioners
 		}

--- a/internal/configs/resource.go
+++ b/internal/configs/resource.go
@@ -58,11 +58,13 @@ type ManagedResource struct {
 
 	CreateBeforeDestroy bool
 	PreventDestroy      bool
+	PreventRemoval      bool
 	IgnoreChanges       []hcl.Traversal
 	IgnoreAllChanges    bool
 
 	CreateBeforeDestroySet bool
 	PreventDestroySet      bool
+	PreventRemovalSet      bool
 }
 
 func (r *Resource) moduleUniqueKey() string {
@@ -196,6 +198,12 @@ func decodeResourceBlock(block *hcl.Block, override bool) (*Resource, hcl.Diagno
 				valDiags := gohcl.DecodeExpression(attr.Expr, nil, &r.Managed.PreventDestroy)
 				diags = append(diags, valDiags...)
 				r.Managed.PreventDestroySet = true
+			}
+
+			if attr, exists := lcContent.Attributes["prevent_removal"]; exists {
+				valDiags := gohcl.DecodeExpression(attr.Expr, nil, &r.Managed.PreventRemoval)
+				diags = append(diags, valDiags...)
+				r.Managed.PreventRemovalSet = true
 			}
 
 			if attr, exists := lcContent.Attributes["replace_triggered_by"]; exists {
@@ -804,6 +812,9 @@ var resourceLifecycleBlockSchema = &hcl.BodySchema{
 		},
 		{
 			Name: "prevent_destroy",
+		},
+		{
+			Name: "prevent_removal",
 		},
 		{
 			Name: "ignore_changes",

--- a/internal/states/instance_object.go
+++ b/internal/states/instance_object.go
@@ -47,6 +47,13 @@ type ResourceInstanceObject struct {
 	// destroy operations, we need to record the status to ensure a resource
 	// removed from the config will still be destroyed in the same manner.
 	CreateBeforeDestroy bool
+
+	// PreventRemoval is a lifecycle option that can be set on a resource
+	// instance to prevent it from being removed from state. This is useful
+	// for preventing a stateful resource from being removed unexpectedly,
+	// regardless of whether it is still present in configuration.
+	// This can be thought of as a stronger version of prevent_destroy.
+	PreventRemoval bool
 }
 
 // ObjectStatus represents the status of a RemoteObject.
@@ -133,6 +140,7 @@ func (o *ResourceInstanceObject) Encode(ty cty.Type, schemaVersion uint64) (*Res
 		Status:              o.Status,
 		Dependencies:        dependencies,
 		CreateBeforeDestroy: o.CreateBeforeDestroy,
+		PreventRemoval:      o.PreventRemoval,
 	}, nil
 }
 

--- a/internal/states/instance_object_src.go
+++ b/internal/states/instance_object_src.go
@@ -62,6 +62,7 @@ type ResourceInstanceObjectSrc struct {
 	Status              ObjectStatus
 	Dependencies        []addrs.ConfigResource
 	CreateBeforeDestroy bool
+	PreventRemoval      bool
 }
 
 // Decode unmarshals the raw representation of the object attributes. Pass the
@@ -100,6 +101,7 @@ func (os *ResourceInstanceObjectSrc) Decode(ty cty.Type) (*ResourceInstanceObjec
 		Dependencies:        os.Dependencies,
 		Private:             os.Private,
 		CreateBeforeDestroy: os.CreateBeforeDestroy,
+		PreventRemoval:      os.PreventRemoval,
 	}, nil
 }
 

--- a/internal/states/state_deepcopy.go
+++ b/internal/states/state_deepcopy.go
@@ -177,6 +177,7 @@ func (os *ResourceInstanceObjectSrc) DeepCopy() *ResourceInstanceObjectSrc {
 		AttrSensitivePaths:  attrPaths,
 		Dependencies:        dependencies,
 		CreateBeforeDestroy: os.CreateBeforeDestroy,
+		PreventRemoval:      os.PreventRemoval,
 	}
 }
 
@@ -213,6 +214,7 @@ func (o *ResourceInstanceObject) DeepCopy() *ResourceInstanceObject {
 		Private:             private,
 		Dependencies:        dependencies,
 		CreateBeforeDestroy: o.CreateBeforeDestroy,
+		PreventRemoval:      o.PreventRemoval,
 	}
 }
 

--- a/internal/states/statefile/version4.go
+++ b/internal/states/statefile/version4.go
@@ -139,6 +139,7 @@ func prepareStateV4(sV4 *stateV4) (*File, tfdiags.Diagnostics) {
 			obj := &states.ResourceInstanceObjectSrc{
 				SchemaVersion:       isV4.SchemaVersion,
 				CreateBeforeDestroy: isV4.CreateBeforeDestroy,
+				PreventRemoval:      isV4.PreventRemoval,
 			}
 
 			{
@@ -510,6 +511,7 @@ func appendInstanceObjectStateV4(rs *states.Resource, is *states.ResourceInstanc
 		PrivateRaw:              privateRaw,
 		Dependencies:            deps,
 		CreateBeforeDestroy:     obj.CreateBeforeDestroy,
+		PreventRemoval:          obj.PreventRemoval,
 	}), diags
 }
 
@@ -715,6 +717,8 @@ type instanceObjectStateV4 struct {
 	Dependencies []string `json:"dependencies,omitempty"`
 
 	CreateBeforeDestroy bool `json:"create_before_destroy,omitempty"`
+
+	PreventRemoval bool `json:"prevent_removal,omitempty"`
 }
 
 type checkResultsV4 struct {

--- a/internal/terraform/node_resource_plan_instance.go
+++ b/internal/terraform/node_resource_plan_instance.go
@@ -216,6 +216,7 @@ func (n *NodePlannableResourceInstance) managedResourceExecute(ctx EvalContext) 
 	} else {
 		if instanceRefreshState != nil {
 			instanceRefreshState.CreateBeforeDestroy = n.Config.Managed.CreateBeforeDestroy || n.ForceCreateBeforeDestroy
+			instanceRefreshState.PreventRemoval = n.Config.Managed.PreventRemoval
 		}
 	}
 


### PR DESCRIPTION
#17599 has been a longstanding issue around the implementation of the `prevent_destroy` flag. Specifically, the flag does not prevent destroying resources for which the configuration has been removed. This PR addresses this need with a different flag, `prevent_removal`, which implements the desired behaviour. The desired behaviour is described in [this comment](https://github.com/hashicorp/terraform/issues/17599#issuecomment-373557799):

> Currently removing a resource from configuration is treated as intent to remove the resource, since that's an explicit action on your part rather than it happening as a part of some other action, such as resource replacement or a whole-configuration destroy.
> 
> However, your idea of retaining this in the state and requiring multiple steps to actually destroy is an interesting one:
> 
> 1. Leave resource in config but remove `prevent_destroy`
> 2. Run `terraform apply` to update the state to no longer have that flag set.
> 3. Remove the resource from configuration entirely.
> 4. Run `terraform apply` again to actually destroy it.


Fixes #17599 

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

Any

## Draft CHANGELOG entry


### NEW FEATURES

-  Introduced `prevent_removal` flag for preventing destroying resources even when the configuration is removed.
