### PR TITLE
fix uuid documentation: it is not RFC compatible

### DIFF
--- a/website/docs/language/functions/uuid.mdx
+++ b/website/docs/language/functions/uuid.mdx
@@ -5,7 +5,7 @@ description: The uuid function generates a unique id.
 
 # `uuid` Function
 
-`uuid` generates UUID-format strings using high quality, purely random bytes.
+`uuid` generates UUID-format strings using random bytes.
 
 It is not intended to be RFC compliant, merely to use a well-understood string representation of a 128-bit value.
 

--- a/website/docs/language/functions/uuid.mdx
+++ b/website/docs/language/functions/uuid.mdx
@@ -5,12 +5,9 @@ description: The uuid function generates a unique id.
 
 # `uuid` Function
 
-`uuid` generates a unique identifier string.
+`uuid` generates UUID-format strings using high quality, purely random bytes.
 
-The id is a generated and formatted as required by
-[RFC 4122 section 4.4](https://tools.ietf.org/html/rfc4122#section-4.4),
-producing a Version 4 UUID. The result is a UUID generated only from
-pseudo-random numbers.
+It is not intended to be RFC compliant, merely to use a well-understood string representation of a 128-bit value.
 
 This function produces a new value each time it is called, and so using it
 directly in resource arguments will result in spurious diffs. We do not

--- a/website/docs/language/functions/uuid.mdx
+++ b/website/docs/language/functions/uuid.mdx
@@ -7,7 +7,7 @@ description: The uuid function generates a unique id.
 
 `uuid` generates UUID-format strings using random bytes.
 
-It is not intended to be RFC compliant, merely to use a well-understood string representation of a 128-bit value.
+The function generates a well-understood string representation of a 128-bit value, but the output is not RFC-compliant.
 
 This function produces a new value each time it is called, and so using it
 directly in resource arguments will result in spurious diffs. We do not


### PR DESCRIPTION
Documentation fix: the uuid function is not RFC compatible.

I copied over the relevant description and clarification from [go-uuid](https://github.com/hashicorp/go-uuid) which the uuid function is using.