### PR TITLE
plannable import: safer config generation and schema filters

### DIFF
--- a/internal/command/testdata/plan-import-config-gen/generated.tf.expected
+++ b/internal/command/testdata/plan-import-config-gen/generated.tf.expected
@@ -4,5 +4,4 @@
 # __generated__ by Terraform from "bar"
 resource "test_instance" "foo" {
   ami = null
-  id  = "bar"
 }

--- a/internal/configs/configschema/filter.go
+++ b/internal/configs/configschema/filter.go
@@ -7,6 +7,13 @@ var (
 		return attribute.Computed && !attribute.Optional
 	}
 
+	FilterHelperSchemaIdAttribute = func(name string, attribute *Attribute) bool {
+		if name == "id" && attribute.Computed && attribute.Optional {
+			return true
+		}
+		return false
+	}
+
 	FilterDeprecatedAttribute = func(name string, attribute *Attribute) bool {
 		return attribute.Deprecated
 	}

--- a/internal/configs/configschema/filter.go
+++ b/internal/configs/configschema/filter.go
@@ -3,7 +3,7 @@ package configschema
 type FilterT[T any] func(string, T) bool
 
 var (
-	FilterReadOnlyAttributes = func(name string, attribute *Attribute) bool {
+	FilterReadOnlyAttribute = func(name string, attribute *Attribute) bool {
 		return attribute.Computed && !attribute.Optional
 	}
 

--- a/internal/configs/configschema/filter.go
+++ b/internal/configs/configschema/filter.go
@@ -16,9 +16,14 @@ var (
 	}
 )
 
-func FilterOr[T any](one, two FilterT[T]) FilterT[T] {
+func FilterOr[T any](filters ...FilterT[T]) FilterT[T] {
 	return func(name string, value T) bool {
-		return one(name, value) || two(name, value)
+		for _, f := range filters {
+			if f(name, value) {
+				return true
+			}
+		}
+		return false
 	}
 }
 

--- a/internal/configs/configschema/filter.go
+++ b/internal/configs/configschema/filter.go
@@ -41,6 +41,10 @@ func (b *Block) Filter(filterAttribute FilterT[*Attribute], filterBlock FilterT[
 		if filterAttribute == nil || !filterAttribute(name, attrS) {
 			ret.Attributes[name] = attrS
 		}
+
+		if attrS.NestedType != nil {
+			ret.Attributes[name].NestedType = filterNestedType(attrS.NestedType, filterAttribute)
+		}
 	}
 
 	if b.BlockTypes != nil {
@@ -54,6 +58,28 @@ func (b *Block) Filter(filterAttribute FilterT[*Attribute], filterBlock FilterT[
 				Nesting:  blockS.Nesting,
 				MinItems: blockS.MinItems,
 				MaxItems: blockS.MaxItems,
+			}
+		}
+	}
+
+	return ret
+}
+
+func filterNestedType(obj *Object, filterAttribute FilterT[*Attribute]) *Object {
+	if obj == nil {
+		return nil
+	}
+
+	ret := &Object{
+		Attributes: map[string]*Attribute{},
+		Nesting:    obj.Nesting,
+	}
+
+	for name, attrS := range obj.Attributes {
+		if filterAttribute == nil || !filterAttribute(name, attrS) {
+			ret.Attributes[name] = attrS
+			if attrS.NestedType != nil {
+				ret.Attributes[name].NestedType = filterNestedType(attrS.NestedType, filterAttribute)
 			}
 		}
 	}

--- a/internal/configs/configschema/filter_test.go
+++ b/internal/configs/configschema/filter_test.go
@@ -1,0 +1,278 @@
+package configschema
+
+import (
+	"testing"
+
+	"github.com/zclconf/go-cty/cty"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+)
+
+func TestFilter(t *testing.T) {
+	testCases := map[string]struct {
+		schema          *Block
+		filterAttribute FilterT[*Attribute]
+		filterBlock     FilterT[*NestedBlock]
+		want            *Block
+	}{
+		"empty": {
+			schema:          &Block{},
+			filterAttribute: FilterDeprecatedAttribute,
+			filterBlock:     FilterDeprecatedBlock,
+			want:            &Block{},
+		},
+		"noop": {
+			schema: &Block{
+				Attributes: map[string]*Attribute{
+					"string": {
+						Type:     cty.String,
+						Required: true,
+					},
+				},
+				BlockTypes: map[string]*NestedBlock{
+					"list": {
+						Nesting: NestingList,
+						Block: Block{
+							Attributes: map[string]*Attribute{
+								"string": {
+									Type:     cty.String,
+									Required: true,
+								},
+							},
+						},
+					},
+				},
+			},
+			filterAttribute: nil,
+			filterBlock:     nil,
+			want: &Block{
+				Attributes: map[string]*Attribute{
+					"string": {
+						Type:     cty.String,
+						Required: true,
+					},
+				},
+				BlockTypes: map[string]*NestedBlock{
+					"list": {
+						Nesting: NestingList,
+						Block: Block{
+							Attributes: map[string]*Attribute{
+								"string": {
+									Type:     cty.String,
+									Required: true,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		"filter_deprecated": {
+			schema: &Block{
+				Attributes: map[string]*Attribute{
+					"string": {
+						Type:     cty.String,
+						Optional: true,
+					},
+					"deprecated_string": {
+						Type:       cty.String,
+						Deprecated: true,
+					},
+					"nested": {
+						NestedType: &Object{
+							Attributes: map[string]*Attribute{
+								"string": {
+									Type: cty.String,
+								},
+								"deprecated_string": {
+									Type:       cty.String,
+									Deprecated: true,
+								},
+							},
+							Nesting: NestingList,
+						},
+					},
+				},
+
+				BlockTypes: map[string]*NestedBlock{
+					"list": {
+						Nesting: NestingList,
+						Block: Block{
+							Attributes: map[string]*Attribute{
+								"string": {
+									Type:     cty.String,
+									Optional: true,
+								},
+							},
+							Deprecated: true,
+						},
+					},
+				},
+			},
+			filterAttribute: FilterDeprecatedAttribute,
+			filterBlock:     FilterDeprecatedBlock,
+			want: &Block{
+				Attributes: map[string]*Attribute{
+					"string": {
+						Type:     cty.String,
+						Optional: true,
+					},
+					"nested": {
+						NestedType: &Object{
+							Attributes: map[string]*Attribute{
+								"string": {
+									Type: cty.String,
+								},
+							},
+							Nesting: NestingList,
+						},
+					},
+				},
+			},
+		},
+		"filter_read_only": {
+			schema: &Block{
+				Attributes: map[string]*Attribute{
+					"string": {
+						Type:     cty.String,
+						Optional: true,
+					},
+					"read_only_string": {
+						Type:     cty.String,
+						Computed: true,
+					},
+					"nested": {
+						NestedType: &Object{
+							Attributes: map[string]*Attribute{
+								"string": {
+									Type:     cty.String,
+									Optional: true,
+								},
+								"read_only_string": {
+									Type:     cty.String,
+									Computed: true,
+								},
+								"deeply_nested": {
+									NestedType: &Object{
+										Attributes: map[string]*Attribute{
+											"number": {
+												Type:     cty.Number,
+												Required: true,
+											},
+											"read_only_number": {
+												Type:     cty.Number,
+												Computed: true,
+											},
+										},
+										Nesting: NestingList,
+									},
+								},
+							},
+							Nesting: NestingList,
+						},
+					},
+				},
+
+				BlockTypes: map[string]*NestedBlock{
+					"list": {
+						Nesting: NestingList,
+						Block: Block{
+							Attributes: map[string]*Attribute{
+								"string": {
+									Type:     cty.String,
+									Optional: true,
+								},
+								"read_only_string": {
+									Type:     cty.String,
+									Computed: true,
+								},
+							},
+						},
+					},
+				},
+			},
+			filterAttribute: FilterReadOnlyAttribute,
+			filterBlock:     nil,
+			want: &Block{
+				Attributes: map[string]*Attribute{
+					"string": {
+						Type:     cty.String,
+						Optional: true,
+					},
+					"nested": {
+						NestedType: &Object{
+							Attributes: map[string]*Attribute{
+								"string": {
+									Type:     cty.String,
+									Optional: true,
+								},
+								"deeply_nested": {
+									NestedType: &Object{
+										Attributes: map[string]*Attribute{
+											"number": {
+												Type:     cty.Number,
+												Required: true,
+											},
+										},
+										Nesting: NestingList,
+									},
+								},
+							},
+							Nesting: NestingList,
+						},
+					},
+				},
+				BlockTypes: map[string]*NestedBlock{
+					"list": {
+						Nesting: NestingList,
+						Block: Block{
+							Attributes: map[string]*Attribute{
+								"string": {
+									Type:     cty.String,
+									Optional: true,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		"filter_optional_computed_id": {
+			schema: &Block{
+				Attributes: map[string]*Attribute{
+					"id": {
+						Type:     cty.String,
+						Optional: true,
+						Computed: true,
+					},
+					"string": {
+						Type:     cty.String,
+						Optional: true,
+						Computed: true,
+					},
+				},
+			},
+			filterAttribute: FilterHelperSchemaIdAttribute,
+			filterBlock:     nil,
+			want: &Block{
+				Attributes: map[string]*Attribute{
+					"string": {
+						Type:     cty.String,
+						Optional: true,
+						Computed: true,
+					},
+				},
+			},
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			got := tc.schema.Filter(tc.filterAttribute, tc.filterBlock)
+			if !cmp.Equal(got, tc.want, cmp.Comparer(cty.Type.Equals), cmpopts.EquateEmpty()) {
+				t.Fatal(cmp.Diff(got, tc.want, cmp.Comparer(cty.Type.Equals), cmpopts.EquateEmpty()))
+			}
+		})
+	}
+}

--- a/internal/genconfig/generate_config_test.go
+++ b/internal/genconfig/generate_config_test.go
@@ -376,19 +376,6 @@ resource "tfcoremock_simple_resource" "empty" {
 						},
 					},
 				},
-				BlockTypes: map[string]*configschema.NestedBlock{
-					"nested_single": {
-						Nesting: configschema.NestingSingle,
-						Block: configschema.Block{
-							Attributes: map[string]*configschema.Attribute{
-								"nested_id": {
-									Type:     cty.String,
-									Optional: true,
-								},
-							},
-						},
-					},
-				},
 			},
 			addr: addrs.AbsResourceInstance{
 				Module: nil,
@@ -431,9 +418,6 @@ resource "tfcoremock_simple_resource" "empty" {
   list   = null
   map    = null
   single = null
-  nested_single {
-    nested_id = null
-  }
 }`,
 		},
 	}

--- a/internal/genconfig/generate_config_test.go
+++ b/internal/genconfig/generate_config_test.go
@@ -376,6 +376,19 @@ resource "tfcoremock_simple_resource" "empty" {
 						},
 					},
 				},
+				BlockTypes: map[string]*configschema.NestedBlock{
+					"nested_single": {
+						Nesting: configschema.NestingSingle,
+						Block: configschema.Block{
+							Attributes: map[string]*configschema.Attribute{
+								"nested_id": {
+									Type:     cty.String,
+									Optional: true,
+								},
+							},
+						},
+					},
+				},
 			},
 			addr: addrs.AbsResourceInstance{
 				Module: nil,
@@ -418,6 +431,9 @@ resource "tfcoremock_simple_resource" "empty" {
   list   = null
   map    = null
   single = null
+  nested_single {
+    nested_id = null
+  }
 }`,
 		},
 	}

--- a/internal/genconfig/generate_config_write.go
+++ b/internal/genconfig/generate_config_write.go
@@ -77,5 +77,12 @@ func MaybeWriteGeneratedConfig(plan *plans.Plan, out string) (wroteConfig bool, 
 		}
 	}
 
+	if wroteConfig {
+		diags = diags.Append(tfdiags.Sourceless(
+			tfdiags.Warning,
+			"Config generation is experimental",
+			"Generating configuration during import is currently experimental, and the generated configuration format may change in future versions."))
+	}
+
 	return wroteConfig, diags
 }

--- a/internal/terraform/node_resource_plan_instance.go
+++ b/internal/terraform/node_resource_plan_instance.go
@@ -272,7 +272,7 @@ func (n *NodePlannableResourceInstance) managedResourceExecute(ctx EvalContext) 
 		)
 		diags = diags.Append(planDiags)
 		if diags.HasErrors() {
-			// If we are importing an generating a configuration, we need to
+			// If we are importing and generating a configuration, we need to
 			// ensure the change is written out so the configuration can be
 			// captured.
 			if n.generateConfig {

--- a/internal/terraform/node_resource_plan_instance.go
+++ b/internal/terraform/node_resource_plan_instance.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/configs"
+	"github.com/hashicorp/terraform/internal/configs/configschema"
 	"github.com/hashicorp/terraform/internal/genconfig"
 	"github.com/hashicorp/terraform/internal/instances"
 	"github.com/hashicorp/terraform/internal/plans"
@@ -573,6 +574,37 @@ func (n *NodePlannableResourceInstance) importState(ctx EvalContext, addr addrs.
 
 	diags = diags.Append(riNode.writeResourceInstanceState(ctx, instanceRefreshState, refreshState))
 	return instanceRefreshState, diags
+}
+
+// generateHCLStringAttributes produces a string in HCL format for the given
+// resource state and schema without the surrounding block.
+func (n *NodePlannableResourceInstance) generateHCLStringAttributes(addr addrs.AbsResourceInstance, state *states.ResourceInstanceObject, schema *configschema.Block) (string, tfdiags.Diagnostics) {
+	filteredSchema := schema.Filter(
+		configschema.FilterOr(
+			configschema.FilterReadOnlyAttribute,
+			configschema.FilterDeprecatedAttribute,
+
+			// The legacy SDK adds an Optional+Computed "id" attribute to the
+			// resource schema even if not defined in provider code.
+			// During validation, however, the presence of an extraneous "id"
+			// attribute in config will cause an error.
+			// Remove this attribute so we do not generate an "id" attribute
+			// where there is a risk that it is not in the real resource schema.
+			//
+			// TRADEOFF: Resources in which there actually is an
+			// Optional+Computed "id" attribute in the schema will have that
+			// attribute missing from generated config.
+			configschema.FilterHelperSchemaIdAttribute,
+		),
+		configschema.FilterDeprecatedBlock,
+	)
+
+	providerAddr := addrs.LocalProviderConfig{
+		LocalName: n.ResolvedProvider.Provider.Type,
+		Alias:     n.ResolvedProvider.Alias,
+	}
+
+	return genconfig.GenerateResourceContents(addr, filteredSchema, providerAddr, state.Value)
 }
 
 // mergeDeps returns the union of 2 sets of dependencies


### PR DESCRIPTION
This PR fixes a number of issues with config generation during the plan.

 - Config generated during the plan may fail validation due to helper/schema behaviours such as `ConflictsWith`, which are not visible to Terraform. Do not fail planning due to this.
 - Detect the case where there could be an apparent `"id"` attribute in the schema added by helper/schema. In this case it is not safe to add `"id"` to generated config.
 - Fix a bug in which configschema filters were not applied to nested object types.
 - Fix a bug in which null NestingSingle blocks were written to generated config.
 - Add tests for configschema filters.

Please see individual commits for more details.