### PR TITLE
Remove destroy-plan locals only referenced by root outputs

### DIFF
--- a/internal/terraform/graph_builder_apply.go
+++ b/internal/terraform/graph_builder_apply.go
@@ -99,8 +99,8 @@ func (b *ApplyGraphBuilder) Steps() []GraphTransformer {
 		&ModuleVariableTransformer{Config: b.Config},
 		&LocalTransformer{Config: b.Config},
 		&OutputTransformer{
-			Config:       b.Config,
-			ApplyDestroy: b.Operation == walkDestroy,
+			Config:     b.Config,
+			Destroying: b.Operation == walkDestroy,
 		},
 
 		// Creates all the resource instances represented in the diff, along

--- a/internal/terraform/graph_builder_plan.go
+++ b/internal/terraform/graph_builder_plan.go
@@ -127,7 +127,7 @@ func (b *PlanGraphBuilder) Steps() []GraphTransformer {
 		&OutputTransformer{
 			Config:      b.Config,
 			RefreshOnly: b.skipPlanChanges || b.preDestroyRefresh,
-			PlanDestroy: b.Operation == walkPlanDestroy,
+			Destroying:  b.Operation == walkPlanDestroy,
 
 			// NOTE: We currently treat anything built with the plan graph
 			// builder as "planning" for our purposes here, because we share

--- a/internal/terraform/node_output.go
+++ b/internal/terraform/node_output.go
@@ -23,12 +23,11 @@ import (
 // nodeExpandOutput is the placeholder for a non-root module output that has
 // not yet had its module path expanded.
 type nodeExpandOutput struct {
-	Addr         addrs.OutputValue
-	Module       addrs.Module
-	Config       *configs.Output
-	PlanDestroy  bool
-	ApplyDestroy bool
-	RefreshOnly  bool
+	Addr        addrs.OutputValue
+	Module      addrs.Module
+	Config      *configs.Output
+	Destroying  bool
+	RefreshOnly bool
 
 	// Planning is set to true when this node is in a graph that was produced
 	// by the plan graph builder, as opposed to the apply graph builder.
@@ -103,13 +102,13 @@ func (n *nodeExpandOutput) DynamicExpand(ctx EvalContext) (*Graph, error) {
 
 		var node dag.Vertex
 		switch {
-		case module.IsRoot() && (n.PlanDestroy || n.ApplyDestroy):
+		case module.IsRoot() && n.Destroying:
 			node = &NodeDestroyableOutput{
 				Addr:     absAddr,
 				Planning: n.Planning,
 			}
 
-		case n.PlanDestroy:
+		case n.Destroying:
 			// nothing is done here for non-root outputs
 			continue
 
@@ -119,7 +118,7 @@ func (n *nodeExpandOutput) DynamicExpand(ctx EvalContext) (*Graph, error) {
 				Config:       n.Config,
 				Change:       change,
 				RefreshOnly:  n.RefreshOnly,
-				DestroyApply: n.ApplyDestroy,
+				DestroyApply: n.Destroying,
 				Planning:     n.Planning,
 			}
 		}
@@ -186,7 +185,7 @@ func (n *nodeExpandOutput) ReferenceOutside() (selfPath, referencePath addrs.Mod
 // GraphNodeReferencer
 func (n *nodeExpandOutput) References() []*addrs.Reference {
 	// DestroyNodes do not reference anything.
-	if n.Module.IsRoot() && n.ApplyDestroy {
+	if n.Module.IsRoot() && n.Destroying {
 		return nil
 	}
 

--- a/internal/terraform/transform_output.go
+++ b/internal/terraform/transform_output.go
@@ -28,12 +28,8 @@ type OutputTransformer struct {
 	Planning bool
 
 	// If this is a planned destroy, root outputs are still in the configuration
-	// so we need to record that we wish to remove them
-	PlanDestroy bool
-
-	// ApplyDestroy indicates that this is being added to an apply graph, which
-	// is the result of a destroy plan.
-	ApplyDestroy bool
+	// so we need to record that we wish to remove them.
+	Destroying bool
 }
 
 func (t *OutputTransformer) Transform(g *Graph) error {
@@ -59,13 +55,12 @@ func (t *OutputTransformer) transform(g *Graph, c *configs.Config) error {
 		addr := addrs.OutputValue{Name: o.Name}
 
 		node := &nodeExpandOutput{
-			Addr:         addr,
-			Module:       c.Path,
-			Config:       o,
-			PlanDestroy:  t.PlanDestroy,
-			ApplyDestroy: t.ApplyDestroy,
-			RefreshOnly:  t.RefreshOnly,
-			Planning:     t.Planning,
+			Addr:        addr,
+			Module:      c.Path,
+			Config:      o,
+			Destroying:  t.Destroying,
+			RefreshOnly: t.RefreshOnly,
+			Planning:    t.Planning,
 		}
 
 		log.Printf("[TRACE] OutputTransformer: adding %s as %T", o.Name, node)


### PR DESCRIPTION
When planning a destroy operations, locals only referenced by root outputs do not need to be kept in the graph, because the root output does not get evaluated. Rather than try and prune the local based on this condition, we prevent the connection from being created by ensuring that a root output destroy node has no references.

When completing the pseudo-expansion of root outputs, the particular case where a plan expansion node which intends to only destroy root outputs should not have references was missed. This could cause locals which should not be kept in the graph due to a partial destroy to remain, even though they may have expressions that are no longer valid. This worked previously because root output destroy nodes were inserted directly, rather than via expansion.

The separate plan+apply destroy fields used for outputs can be simplified by combining, since they are only ever referenced together.

Fixes #33218