### PR TITLE
plannable import: correct plumbing when using a plan output file

### DIFF
--- a/internal/plans/planfile/tfplan.go
+++ b/internal/plans/planfile/tfplan.go
@@ -427,6 +427,13 @@ func changeFromTfplan(rawChange *planproto.Change) (*plans.ChangeSrc, error) {
 		}
 	}
 
+	if rawChange.Importing != nil {
+		ret.Importing = &plans.ImportingSrc{
+			ID: rawChange.Importing.Id,
+		}
+	}
+	ret.GeneratedConfig = rawChange.GeneratedConfig
+
 	sensitive := cty.NewValueMarks(marks.Sensitive)
 	beforeValMarks, err := pathValueMarksFromTfplan(rawChange.BeforeSensitivePaths, sensitive)
 	if err != nil {
@@ -758,6 +765,14 @@ func changeToTfplan(change *plans.ChangeSrc) (*planproto.Change, error) {
 	}
 	ret.BeforeSensitivePaths = beforeSensitivePaths
 	ret.AfterSensitivePaths = afterSensitivePaths
+
+	if change.Importing != nil {
+		ret.Importing = &planproto.Importing{
+			Id: change.Importing.ID,
+		}
+
+	}
+	ret.GeneratedConfig = change.GeneratedConfig
 
 	switch change.Action {
 	case plans.NoOp:

--- a/internal/plans/planfile/tfplan_test.go
+++ b/internal/plans/planfile/tfplan_test.go
@@ -122,6 +122,33 @@ func TestTFPlanRoundTrip(t *testing.T) {
 						}), objTy),
 					},
 				},
+				{
+					Addr: addrs.Resource{
+						Mode: addrs.ManagedResourceMode,
+						Type: "test_thing",
+						Name: "importing",
+					}.Instance(addrs.IntKey(1)).Absolute(addrs.RootModuleInstance),
+					PrevRunAddr: addrs.Resource{
+						Mode: addrs.ManagedResourceMode,
+						Type: "test_thing",
+						Name: "importing",
+					}.Instance(addrs.IntKey(1)).Absolute(addrs.RootModuleInstance),
+					ProviderAddr: addrs.AbsProviderConfig{
+						Provider: addrs.NewDefaultProvider("test"),
+						Module:   addrs.RootModule,
+					},
+					ChangeSrc: plans.ChangeSrc{
+						Action: plans.NoOp,
+						Before: mustNewDynamicValue(cty.ObjectVal(map[string]cty.Value{
+							"id": cty.StringVal("testing"),
+						}), objTy),
+						After: mustNewDynamicValue(cty.ObjectVal(map[string]cty.Value{
+							"id": cty.StringVal("testing"),
+						}), objTy),
+						Importing:       &plans.ImportingSrc{ID: "testing"},
+						GeneratedConfig: "resource \\\"test_thing\\\" \\\"importing\\\" {}",
+					},
+				},
 			},
 		},
 		DriftedResources: []*plans.ResourceInstanceChangeSrc{


### PR DESCRIPTION
We missed a bit of plumbing to allow importing info and generated config to be persisted correctly in the plan output file when using `terraform plan -out <planfile>` so that it can be read back later by `terraform apply` or `terraform show`.

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.5.x
