### PR TITLE
Propagate generated config filename into the Terraform graph

### DIFF
--- a/internal/backend/local/backend_local.go
+++ b/internal/backend/local/backend_local.go
@@ -190,12 +190,12 @@ func (b *Local) localRunDirect(op *backend.Operation, run *backend.LocalRun, cor
 	}
 
 	planOpts := &terraform.PlanOpts{
-		Mode:           op.PlanMode,
-		Targets:        op.Targets,
-		ForceReplace:   op.ForceReplace,
-		SetVariables:   variables,
-		SkipRefresh:    op.Type != backend.OperationTypeRefresh && !op.PlanRefresh,
-		GenerateConfig: len(op.GenerateConfigOut) > 0,
+		Mode:               op.PlanMode,
+		Targets:            op.Targets,
+		ForceReplace:       op.ForceReplace,
+		SetVariables:       variables,
+		SkipRefresh:        op.Type != backend.OperationTypeRefresh && !op.PlanRefresh,
+		GenerateConfigPath: op.GenerateConfigOut,
 	}
 	run.PlanOpts = planOpts
 

--- a/internal/terraform/context_plan.go
+++ b/internal/terraform/context_plan.go
@@ -78,9 +78,11 @@ type PlanOpts struct {
 	// will be added to the plan graph.
 	ImportTargets []*ImportTarget
 
-	// GenerateConfig tells Terraform to generate configuration for any
-	// ImportTargets that do not have configuration already.
-	GenerateConfig bool
+	// GenerateConfig tells Terraform where to write any generated configuration
+	// for any ImportTargets that do not have configuration already.
+	//
+	// If empty, then no config will be generated.
+	GenerateConfigPath string
 }
 
 // Plan generates an execution plan by comparing the given configuration
@@ -669,7 +671,7 @@ func (c *Context) planGraph(config *configs.Config, prevRunState *states.State, 
 			preDestroyRefresh:  opts.PreDestroyRefresh,
 			Operation:          walkPlan,
 			ImportTargets:      opts.ImportTargets,
-			GenerateConfig:     opts.GenerateConfig,
+			GenerateConfigPath: opts.GenerateConfigPath,
 		}).Build(addrs.RootModuleInstance)
 		return graph, walkPlan, diags
 	case plans.RefreshOnlyMode:

--- a/internal/terraform/context_plan2_test.go
+++ b/internal/terraform/context_plan2_test.go
@@ -4598,8 +4598,8 @@ resource "test_object" "a" {
 	}
 
 	plan, diags := ctx.Plan(m, states.NewState(), &PlanOpts{
-		Mode:           plans.NormalMode,
-		GenerateConfig: true,
+		Mode:               plans.NormalMode,
+		GenerateConfigPath: "generated.tf", // Actual value here doesn't matter, as long as it is not empty.
 	})
 	if diags.HasErrors() {
 		t.Fatalf("unexpected errors\n%s", diags.Err().Error())
@@ -4658,8 +4658,8 @@ import {
 	}
 
 	plan, diags := ctx.Plan(m, states.NewState(), &PlanOpts{
-		Mode:           plans.NormalMode,
-		GenerateConfig: true,
+		Mode:               plans.NormalMode,
+		GenerateConfigPath: "generated.tf", // Actual value here doesn't matter, as long as it is not empty.
 	})
 	if diags.HasErrors() {
 		t.Fatalf("unexpected errors\n%s", diags.Err().Error())
@@ -4740,8 +4740,8 @@ import {
 	}
 
 	plan, diags := ctx.Plan(m, states.NewState(), &PlanOpts{
-		Mode:           plans.NormalMode,
-		GenerateConfig: true,
+		Mode:               plans.NormalMode,
+		GenerateConfigPath: "generated.tf", // Actual value here doesn't matter, as long as it is not empty.
 	})
 	if diags.HasErrors() {
 		t.Fatalf("unexpected errors\n%s", diags.Err().Error())
@@ -4823,8 +4823,8 @@ import {
 	}
 
 	plan, diags := ctx.Plan(m, states.NewState(), &PlanOpts{
-		Mode:           plans.NormalMode,
-		GenerateConfig: true,
+		Mode:               plans.NormalMode,
+		GenerateConfigPath: "generated.tf", // Actual value here doesn't matter, as long as it is not empty.
 	})
 	if !diags.HasErrors() {
 		t.Fatal("expected error")

--- a/internal/terraform/graph_builder_plan.go
+++ b/internal/terraform/graph_builder_plan.go
@@ -76,9 +76,11 @@ type PlanGraphBuilder struct {
 	// ImportTargets are the list of resources to import.
 	ImportTargets []*ImportTarget
 
-	// GenerateConfig tells Terraform to generate config for any import targets
-	// that do not already have configuration.
-	GenerateConfig bool
+	// GenerateConfig tells Terraform where to write and generated config for
+	// any import targets that do not already have configuration.
+	//
+	// If empty, then config will not be generated.
+	GenerateConfigPath string
 }
 
 // See GraphBuilder
@@ -117,7 +119,7 @@ func (b *PlanGraphBuilder) Steps() []GraphTransformer {
 			importTargets: b.ImportTargets,
 
 			// We only want to generate config during a plan operation.
-			generateConfigForImportTargets: b.GenerateConfig,
+			generateConfigPathForImportTargets: b.GenerateConfigPath,
 		},
 
 		// Add dynamic values

--- a/internal/terraform/node_resource_abstract.go
+++ b/internal/terraform/node_resource_abstract.go
@@ -79,8 +79,9 @@ type NodeAbstractResource struct {
 	// This resource may expand into instances which need to be imported.
 	importTargets []*ImportTarget
 
-	// generateConfig tells this node that it's okay for it to generate config.
-	generateConfig bool
+	// generateConfigPath tells this node which file to write generated config
+	// into. If empty, then config should not be generated.
+	generateConfigPath string
 }
 
 var (

--- a/internal/terraform/node_resource_plan.go
+++ b/internal/terraform/node_resource_plan.go
@@ -336,7 +336,7 @@ func (n *nodeExpandPlannableResource) resourceInstanceSubgraph(ctx EvalContext, 
 		a.dependsOn = n.dependsOn
 		a.Dependencies = n.dependencies
 		a.preDestroyRefresh = n.preDestroyRefresh
-		a.generateConfig = n.generateConfig
+		a.generateConfigPath = n.generateConfigPath
 
 		m = &NodePlannableResourceInstance{
 			NodeAbstractResourceInstance: a,


### PR DESCRIPTION
Address the comment [here](https://github.com/hashicorp/terraform/pull/33232#discussion_r1203854544).

This PR actually passes the entire file path of the generated file into the Terraform graph, so the filename can be used properly for errors within the generated config.