### PR TITLE
[cloud] Add interval header check to enable snapshots

### DIFF
--- a/internal/cloud/backend.go
+++ b/internal/cloud/backend.go
@@ -575,7 +575,7 @@ func (b *Cloud) DeleteWorkspace(name string, force bool) error {
 	}
 
 	// Configure the remote workspace name.
-	State := &State{tfeClient: b.client, organization: b.organization, workspace: workspace}
+	State := &State{tfeClient: b.client, organization: b.organization, workspace: workspace, disableIntermediateSnapshots: true}
 	return State.Delete(force)
 }
 
@@ -661,7 +661,7 @@ func (b *Cloud) StateMgr(name string) (statemgr.Full, error) {
 		}
 	}
 
-	return &State{tfeClient: b.client, organization: b.organization, workspace: workspace}, nil
+	return &State{tfeClient: b.client, organization: b.organization, workspace: workspace, disableIntermediateSnapshots: true}, nil
 }
 
 // Operation implements backend.Enhanced.

--- a/internal/cloud/backend.go
+++ b/internal/cloud/backend.go
@@ -575,7 +575,7 @@ func (b *Cloud) DeleteWorkspace(name string, force bool) error {
 	}
 
 	// Configure the remote workspace name.
-	State := &State{tfeClient: b.client, organization: b.organization, workspace: workspace, disableIntermediateSnapshots: true}
+	State := &State{tfeClient: b.client, organization: b.organization, workspace: workspace, enableIntermediateSnapshots: false}
 	return State.Delete(force)
 }
 
@@ -661,7 +661,7 @@ func (b *Cloud) StateMgr(name string) (statemgr.Full, error) {
 		}
 	}
 
-	return &State{tfeClient: b.client, organization: b.organization, workspace: workspace, disableIntermediateSnapshots: true}, nil
+	return &State{tfeClient: b.client, organization: b.organization, workspace: workspace, enableIntermediateSnapshots: false}, nil
 }
 
 // Operation implements backend.Enhanced.

--- a/internal/cloud/state.go
+++ b/internal/cloud/state.go
@@ -69,6 +69,9 @@ type State struct {
 	// not effect final snapshots after an operation, which will always
 	// be written to the remote API.
 	stateSnapshotInterval time.Duration
+	// If the header, X-Terraform-Snapshot-Interval is not present then
+	// we will disable snapshots
+	disableIntermediateSnapshots bool
 }
 
 var ErrStateVersionUnauthorizedUpgradeState = errors.New(strings.TrimSpace(`
@@ -244,6 +247,10 @@ func (s *State) ShouldPersistIntermediateState(info *local.IntermediateStatePers
 		return true
 	}
 
+	if s.disableIntermediateSnapshots && info.RequestedPersistInterval == time.Duration(0) {
+		return false
+	}
+
 	// Our persist interval is the largest of either the caller's requested
 	// interval or the server's requested interval.
 	wantInterval := info.RequestedPersistInterval
@@ -278,25 +285,7 @@ func (s *State) uploadState(lineage string, serial uint64, isForcePush bool, sta
 	// The server is allowed to dynamically request a different time interval
 	// than we'd normally use, for example if it's currently under heavy load
 	// and needs clients to backoff for a while.
-	ctx = tfe.ContextWithResponseHeaderHook(ctx, func(status int, header http.Header) {
-		intervalStr := header.Get("x-terraform-snapshot-interval")
-
-		if intervalSecs, err := strconv.ParseInt(intervalStr, 10, 64); err == nil {
-			if intervalSecs > 3600 {
-				// More than an hour is an unreasonable delay, so we'll just
-				// saturate at one hour.
-				intervalSecs = 3600
-			} else if intervalSecs < 0 {
-				intervalSecs = 0
-			}
-			s.stateSnapshotInterval = time.Duration(intervalSecs) * time.Second
-		} else {
-			// If the header field is either absent or invalid then we'll
-			// just choose zero, which effectively means that we'll just use
-			// the caller's requested interval instead.
-			s.stateSnapshotInterval = time.Duration(0)
-		}
-	})
+	ctx = tfe.ContextWithResponseHeaderHook(ctx, s.readSnapshotIntervalHeader)
 
 	// Create the new state.
 	_, err := s.tfeClient.StateVersions.Create(ctx, s.workspace.ID, options)
@@ -376,6 +365,10 @@ func (s *State) refreshState() error {
 
 func (s *State) getStatePayload() (*remote.Payload, error) {
 	ctx := context.Background()
+
+	// Check the x-terraform-snapshot-interval header to see if it has a non-empty
+	// value which would indicate snapshots are enabled
+	ctx = tfe.ContextWithResponseHeaderHook(ctx, s.readSnapshotIntervalHeader)
 
 	sv, err := s.tfeClient.StateVersions.ReadCurrent(ctx, s.workspace.ID)
 	if err != nil {
@@ -540,6 +533,33 @@ func (s *State) GetRootOutputValues() (map[string]*states.OutputValue, error) {
 	}
 
 	return result, nil
+}
+
+func (s *State) readSnapshotIntervalHeader(status int, header http.Header) {
+	intervalStr := header.Get("x-terraform-snapshot-interval")
+
+	if intervalSecs, err := strconv.ParseInt(intervalStr, 10, 64); err == nil {
+		if intervalSecs > 3600 {
+			// More than an hour is an unreasonable delay, so we'll just
+			// saturate at one hour.
+			intervalSecs = 3600
+		} else if intervalSecs < 0 {
+			intervalSecs = 0
+		}
+		s.stateSnapshotInterval = time.Duration(intervalSecs) * time.Second
+
+		// We will only enable snapshots for intervals greater than zero
+		if intervalSecs > 0 {
+			s.disableIntermediateSnapshots = false
+		}
+	} else {
+		// If the header field is either absent or invalid then we'll
+		// just choose zero, which effectively means that we'll just use
+		// the caller's requested interval instead. If the caller has no
+		// requested interval or it is zero, then we will disable snapshots.
+		s.stateSnapshotInterval = time.Duration(0)
+		s.disableIntermediateSnapshots = true
+	}
 }
 
 // tfeOutputToCtyValue decodes a combination of TFE output value and detailed-type to create a

--- a/internal/cloud/state_test.go
+++ b/internal/cloud/state_test.go
@@ -290,7 +290,7 @@ func TestState_PersistState(t *testing.T) {
 			t.Error("state manager already has a nonzero snapshot interval")
 		}
 
-		if !cloudState.disableIntermediateSnapshots {
+		if cloudState.enableIntermediateSnapshots {
 			t.Error("expected state manager to have disabled snapshots")
 		}
 
@@ -352,7 +352,7 @@ func TestState_PersistState(t *testing.T) {
 				t.Errorf("wrong state snapshot interval after PersistState\ngot:  %s\nwant: %s", got, testCase.expectedInterval)
 			}
 
-			if got, want := cloudState.disableIntermediateSnapshots, !testCase.snapshotsEnabled; got != want {
+			if got, want := cloudState.enableIntermediateSnapshots, testCase.snapshotsEnabled; got != want {
 				t.Errorf("expected disable intermediate snapshots to be\ngot: %t\nwant: %t", got, want)
 			}
 		}

--- a/internal/cloud/state_test.go
+++ b/internal/cloud/state_test.go
@@ -6,11 +6,7 @@ package cloud
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"io/ioutil"
-	"net/http"
-	"net/http/httptest"
-	"strconv"
 	"testing"
 	"time"
 
@@ -294,98 +290,71 @@ func TestState_PersistState(t *testing.T) {
 			t.Error("state manager already has a nonzero snapshot interval")
 		}
 
+		if !cloudState.disableIntermediateSnapshots {
+			t.Error("expected state manager to have disabled snapshots")
+		}
+
 		// For this test we'll use a real client talking to a fake server,
 		// since HTTP-level concerns like headers are out of scope for the
 		// mock client we typically use in other tests in this package, which
 		// aim to abstract away HTTP altogether.
 		var serverURL string
-		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			t.Log(r.Method, r.URL.String())
 
-			if r.URL.Path == "/state-json" {
-				t.Log("pretending to be Archivist")
-				fakeState := states.NewState()
-				fakeStateFile := statefile.New(fakeState, "boop", 1)
-				var buf bytes.Buffer
-				statefile.Write(fakeStateFile, &buf)
-				respBody := buf.Bytes()
-				w.Header().Set("content-type", "application/json")
-				w.Header().Set("content-length", strconv.FormatInt(int64(len(respBody)), 10))
-				w.WriteHeader(http.StatusOK)
-				w.Write(respBody)
-				return
-			}
-			if r.URL.Path == "/api/ping" {
-				t.Log("pretending to be Ping")
-				w.WriteHeader(http.StatusNoContent)
-				return
-			}
+		// Didn't want to repeat myself here
+		for _, testCase := range []struct {
+			expectedInterval time.Duration
+			snapshotsEnabled bool
+		}{
+			{
+				expectedInterval: 300 * time.Second,
+				snapshotsEnabled: true,
+			},
+			{
+				expectedInterval: 0 * time.Second,
+				snapshotsEnabled: false,
+			},
+		} {
+			server := testServerWithSnapshotsEnabled(t, serverURL, testCase.snapshotsEnabled)
 
-			fakeBody := map[string]any{
-				"data": map[string]any{
-					"type": "state-versions",
-					"attributes": map[string]any{
-						"hosted-state-download-url": serverURL + "/state-json",
-					},
-				},
+			defer server.Close()
+			serverURL = server.URL
+			cfg := &tfe.Config{
+				Address:  server.URL,
+				BasePath: "api",
+				Token:    "placeholder",
 			}
-			fakeBodyRaw, err := json.Marshal(fakeBody)
+			client, err := tfe.NewClient(cfg)
+			if err != nil {
+				t.Fatal(err)
+			}
+			cloudState.tfeClient = client
+
+			err = cloudState.RefreshState()
+			if err != nil {
+				t.Fatal(err)
+			}
+			cloudState.WriteState(states.BuildState(func(s *states.SyncState) {
+				s.SetOutputValue(
+					addrs.OutputValue{Name: "boop"}.Absolute(addrs.RootModuleInstance),
+					cty.StringVal("beep"), false,
+				)
+			}))
+
+			err = cloudState.PersistState(nil)
 			if err != nil {
 				t.Fatal(err)
 			}
 
-			w.Header().Set("content-type", "application/json")
-			w.Header().Set("content-length", strconv.FormatInt(int64(len(fakeBodyRaw)), 10))
-
-			switch r.Method {
-			case "POST":
-				t.Log("pretending to be Create a State Version")
-				w.Header().Set("x-terraform-snapshot-interval", "300")
-				w.WriteHeader(http.StatusAccepted)
-			case "GET":
-				t.Log("pretending to be Fetch the Current State Version for a Workspace")
-				w.WriteHeader(http.StatusOK)
-			default:
-				t.Fatal("don't know what API operation this was supposed to be")
+			// The PersistState call above should have sent a request to the test
+			// server and got back the x-terraform-snapshot-interval header, whose
+			// value should therefore now be recorded in the relevant field.
+			if got := cloudState.stateSnapshotInterval; got != testCase.expectedInterval {
+				t.Errorf("wrong state snapshot interval after PersistState\ngot:  %s\nwant: %s", got, testCase.expectedInterval)
 			}
 
-			w.WriteHeader(http.StatusOK)
-			w.Write(fakeBodyRaw)
-		}))
-		defer server.Close()
-		serverURL = server.URL
-		cfg := &tfe.Config{
-			Address:  server.URL,
-			BasePath: "api",
-			Token:    "placeholder",
-		}
-		client, err := tfe.NewClient(cfg)
-		if err != nil {
-			t.Fatal(err)
-		}
-		cloudState.tfeClient = client
-
-		err = cloudState.RefreshState()
-		if err != nil {
-			t.Fatal(err)
-		}
-		cloudState.WriteState(states.BuildState(func(s *states.SyncState) {
-			s.SetOutputValue(
-				addrs.OutputValue{Name: "boop"}.Absolute(addrs.RootModuleInstance),
-				cty.StringVal("beep"), false,
-			)
-		}))
-
-		err = cloudState.PersistState(nil)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		// The PersistState call above should have sent a request to the test
-		// server and got back the x-terraform-snapshot-interval header, whose
-		// value should therefore now be recorded in the relevant field.
-		if got, want := cloudState.stateSnapshotInterval, 300*time.Second; got != want {
-			t.Errorf("wrong state snapshot interval after PersistState\ngot:  %s\nwant: %s", got, want)
+			if got, want := cloudState.disableIntermediateSnapshots, !testCase.snapshotsEnabled; got != want {
+				t.Errorf("expected disable intermediate snapshots to be\ngot: %t\nwant: %t", got, want)
+			}
 		}
 	})
 }


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->
Adding a null check for `x-terraform-snapshot-interval`, which if not present, disables intermediate snapshots in the cloud backend's state manager. The first check will occur when we read the current state version in the workspace,  Any TFC/E instance that does not emit this header in the State Version API does not support handling state snapshots. 


## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.5.0

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

### NEW FEATURES | UPGRADE NOTES | ENHANCEMENTS | BUG FIXES | EXPERIMENTS

<!--

Write a short description of the user-facing change. Examples:

- `terraform show -json`: Fixed crash with sensitive set values.
- When rendering a diff, Terraform now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 

-  
