### PR TITLE
remove deprecated set-output call in gha

### DIFF
--- a/.github/actions/go-version/action.yml
+++ b/.github/actions/go-version/action.yml
@@ -23,4 +23,4 @@ runs:
       # complex for automation.
       run: |
         echo "Building with Go $(cat .go-version)"
-        echo "::set-output name=version::$(cat .go-version)"
+        echo "version=$(cat .go-version)" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
This removes usage of the soon-to-be deprecated set-output command in github actions.
Per: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/