### PR TITLE
Ensure nested data blocks execute last of all Terraform resources

### DIFF
--- a/internal/terraform/graph_builder_apply.go
+++ b/internal/terraform/graph_builder_apply.go
@@ -148,6 +148,10 @@ func (b *ApplyGraphBuilder) Steps() []GraphTransformer {
 		&ReferenceTransformer{},
 		&AttachDependenciesTransformer{},
 
+		// Nested data blocks should be loaded after every other resource has
+		// done its thing.
+		&checkStartTransformer{Config: b.Config, Operation: b.Operation},
+
 		// Detect when create_before_destroy must be forced on for a particular
 		// node due to dependency edges, to avoid graph cycles during apply.
 		&ForcedCBDTransformer{},

--- a/internal/terraform/graph_builder_plan.go
+++ b/internal/terraform/graph_builder_plan.go
@@ -197,10 +197,6 @@ func (b *PlanGraphBuilder) Steps() []GraphTransformer {
 
 		&AttachDependenciesTransformer{},
 
-		// Nested data blocks should be loaded after every other resource has
-		// done its thing.
-		&checkStartTransformer{Config: b.Config, Operation: b.Operation},
-
 		// Make sure data sources are aware of any depends_on from the
 		// configuration
 		&attachDataResourceDependsOnTransformer{},

--- a/internal/terraform/graph_builder_plan.go
+++ b/internal/terraform/graph_builder_plan.go
@@ -197,6 +197,10 @@ func (b *PlanGraphBuilder) Steps() []GraphTransformer {
 
 		&AttachDependenciesTransformer{},
 
+		// Nested data blocks should be loaded after every other resource has
+		// done its thing.
+		&checkStartTransformer{Config: b.Config, Operation: b.Operation},
+
 		// Make sure data sources are aware of any depends_on from the
 		// configuration
 		&attachDataResourceDependsOnTransformer{},

--- a/internal/terraform/node_check.go
+++ b/internal/terraform/node_check.go
@@ -183,3 +183,22 @@ func (n *nodeCheckAssert) Execute(ctx EvalContext, _ walkOperation) tfdiags.Diag
 func (n *nodeCheckAssert) Name() string {
 	return n.addr.String() + " (assertions)"
 }
+
+var (
+	_ GraphNodeExecutable = (*nodeCheckStart)(nil)
+)
+
+// We need to ensure that any nested data sources execute after all other
+// resource changes have been applied. This node acts as a single point of
+// dependency that can enforce this ordering.
+type nodeCheckStart struct{}
+
+func (n *nodeCheckStart) Execute(context EvalContext, operation walkOperation) tfdiags.Diagnostics {
+	// This node doesn't actually do anything, except simplify the underlying
+	// graph structure.
+	return nil
+}
+
+func (n *nodeCheckStart) Name() string {
+	return "(execute checks)"
+}

--- a/internal/terraform/testdata/apply-with-checks/main.tf
+++ b/internal/terraform/testdata/apply-with-checks/main.tf
@@ -1,0 +1,20 @@
+
+resource "aws_instance" "foo" {
+  test_string = "Hello, world!"
+}
+
+resource "aws_instance" "baz" {
+  test_string = aws_instance.foo.test_string
+}
+
+check "my_check" {
+  data "aws_data_source" "bar" {
+    id = "UI098L"
+  }
+
+  assert {
+    condition = data.aws_data_source.bar.foo == "valid value"
+    error_message = "invalid value"
+  }
+
+}

--- a/internal/terraform/transform_check.go
+++ b/internal/terraform/transform_check.go
@@ -93,7 +93,10 @@ func (t *checkTransformer) transform(g *Graph, cfg *configs.Config, allNodes []d
 							// Make sure we report our checks before we execute any
 							// embedded data resource.
 							g.Connect(dag.BasicEdge(other, report))
-							continue
+
+							// There's at most one embedded data source, and
+							// we've found it so stop looking.
+							break
 						}
 					}
 				}

--- a/internal/terraform/transform_check_starter.go
+++ b/internal/terraform/transform_check_starter.go
@@ -34,10 +34,10 @@ func (s *checkStartTransformer) Transform(graph *Graph) error {
 	// We're going to step through all the vertices and pull out the relevant
 	// resources and data sources.
 	for _, vertex := range graph.Vertices() {
-		if node, isResource := vertex.(GraphNodeConfigResource); isResource {
+		if node, isResource := vertex.(*NodeApplyableResourceInstance); isResource {
 			addr := node.ResourceAddr()
 
-			if addr.Resource.Mode != addrs.ManagedResourceMode {
+			if addr.Resource.Mode == addrs.ManagedResourceMode {
 				// This is a resource, so we want to make sure it executes
 				// before any nested data sources.
 
@@ -50,7 +50,7 @@ func (s *checkStartTransformer) Transform(graph *Graph) error {
 
 				leafResource := true
 				for _, other := range graph.UpEdges(vertex) {
-					if otherResource, isResource := other.(GraphNodeConfigResource); isResource {
+					if otherResource, isResource := other.(*NodeApplyableResourceInstance); isResource {
 						otherAddr := otherResource.ResourceAddr()
 						if otherAddr.Resource.Mode == addrs.ManagedResourceMode {
 							// Then this resource is referencing another one

--- a/internal/terraform/transform_check_starter.go
+++ b/internal/terraform/transform_check_starter.go
@@ -1,0 +1,126 @@
+package terraform
+
+import (
+	"github.com/hashicorp/terraform/internal/addrs"
+	"github.com/hashicorp/terraform/internal/configs"
+	"github.com/hashicorp/terraform/internal/dag"
+)
+
+var _ GraphTransformer = (*checkStartTransformer)(nil)
+
+// checkStartTransformer checks if the configuration has any data blocks nested
+// within check blocks, and if it does then it introduces a nodeCheckStart
+// vertex that ensures all resources have been applied before it starts loading
+// the nested data sources.
+type checkStartTransformer struct {
+	// Config for the entire module.
+	Config *configs.Config
+
+	// Operation is the current operation this node will be part of.
+	Operation walkOperation
+}
+
+func (s *checkStartTransformer) Transform(graph *Graph) error {
+	if s.Operation != walkApply && s.Operation != walkPlan {
+		// We only actually execute the checks during plan apply operations
+		// so if we are doing something else we can just skip this and
+		// leave the graph alone.
+		return nil
+	}
+
+	var resources []dag.Vertex
+	var nested []dag.Vertex
+
+	// We're going to step through all the vertices and pull out the relevant
+	// resources and data sources.
+	for _, vertex := range graph.Vertices() {
+		if node, isResource := vertex.(GraphNodeConfigResource); isResource {
+			addr := node.ResourceAddr()
+
+			if addr.Resource.Mode != addrs.ManagedResourceMode {
+				// This is a resource, so we want to make sure it executes
+				// before any nested data sources.
+
+				// We can reduce the number of additional edges we write into
+				// the graph by only including "leaf" resources, that is
+				// resources that don't reference other resources. If a resource
+				// references another resource then we know that it will execute
+				// before that resource so we only need to worry about the
+				// referenced resource.
+
+				leafResource := true
+				for _, other := range graph.UpEdges(vertex) {
+					if otherResource, isResource := other.(GraphNodeConfigResource); isResource {
+						otherAddr := otherResource.ResourceAddr()
+						if otherAddr.Resource.Mode == addrs.ManagedResourceMode {
+							// Then this resource is referencing another one
+							// so skip it.
+							leafResource = false
+							break
+						}
+					}
+				}
+
+				if leafResource {
+					resources = append(resources, vertex)
+				}
+
+				// We've handled the resource so move to the next vertex.
+				continue
+			}
+
+			// Now, we know we are processing a data block.
+
+			config := s.Config
+			if !addr.Module.IsRoot() {
+				config = s.Config.Descendent(addr.Module)
+			}
+			if config == nil {
+				// might have been deleted, so it won't be subject to any checks
+				// anyway.
+				continue
+			}
+
+			resource := config.Module.ResourceByAddr(addr.Resource)
+			if resource == nil {
+				// might have been deleted, so it won't be subject to any checks
+				// anyway.
+				continue
+			}
+
+			if _, ok := resource.Container.(*configs.Check); ok {
+				// Then this is a data source within a check block, so let's
+				// make a note of it.
+				nested = append(nested, vertex)
+			}
+
+			// Otherwise, it's just a normal data source. From a check block we
+			// don't really care when Terraform is loading non-nested data
+			// sources so we'll just forget about it and move on.
+		}
+	}
+
+	if len(nested) > 0 {
+
+		// We don't need to do any of this if we don't have any nested data
+		// sources, so we check that first.
+		//
+		// Otherwise we introduce a vertex that can act as a pauser between
+		// our nested data sources and leaf resources.
+
+		check := &nodeCheckStart{}
+		graph.Add(check)
+
+		// Finally, connect everything up so it all executes in order.
+
+		for _, vertex := range nested {
+			graph.Connect(dag.BasicEdge(vertex, check))
+		}
+
+		for _, vertex := range resources {
+			graph.Connect(dag.BasicEdge(check, vertex))
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
We have documented that checks should execute last, but due to nested data sources getting treated as regular data sources this was being missed for data sources that had no references. These could just execute whenever Terraform decided to let them.

This PR adds a new no-op node to the terraform graph, and ensures all resources execute before it with nested data sources executing after.