### PR TITLE
views: fix wordwrap bug

### DIFF
--- a/internal/command/views/operation.go
+++ b/internal/command/views/operation.go
@@ -143,18 +143,25 @@ func (v *OperationHuman) PlanNextStep(planPath string, genConfigPath string) {
 
 	if genConfigPath != "" {
 		v.view.streams.Printf(
-			"\n"+strings.TrimSpace(format.WordWrap(planHeaderGenConfig, v.view.outputColumns()))+"\n", genConfigPath,
-		)
+			format.WordWrap(
+				"\n"+strings.TrimSpace(fmt.Sprintf(planHeaderGenConfig, genConfigPath)),
+				v.view.outputColumns(),
+			) + "\n")
 	}
 
 	if planPath == "" {
 		v.view.streams.Print(
-			"\n" + strings.TrimSpace(format.WordWrap(planHeaderNoOutput, v.view.outputColumns())) + "\n",
+			format.WordWrap(
+				"\n"+strings.TrimSpace(planHeaderNoOutput),
+				v.view.outputColumns(),
+			) + "\n",
 		)
 	} else {
 		v.view.streams.Printf(
-			"\n"+strings.TrimSpace(format.WordWrap(planHeaderYesOutput, v.view.outputColumns()))+"\n",
-			planPath, planPath,
+			format.WordWrap(
+				"\n"+strings.TrimSpace(fmt.Sprintf(planHeaderYesOutput, planPath, planPath)),
+				v.view.outputColumns(),
+			) + "\n",
 		)
 	}
 }


### PR DESCRIPTION
The plan next step text can vary in length depending on passed in path values. Word wrapping for this line must take place at the highest level.

Before:

<img width="1332" alt="image" src="https://github.com/hashicorp/terraform/assets/5575356/67a2843d-5728-48fc-9660-f967d3cb3d23">

After:

<img width="1333" alt="image" src="https://github.com/hashicorp/terraform/assets/5575356/8efc4129-aa8a-450a-b292-ac9ed9f8b4a4">
