### PR TITLE
Adding links to the Checks tutorial and fixing headers.

### DIFF
--- a/website/docs/language/checks/index.mdx
+++ b/website/docs/language/checks/index.mdx
@@ -10,9 +10,11 @@ description: >-
 
 The `check` block can validate your infrastructure outside the usual resource lifecycle. Check blocks address a gap between post-apply and functional validation of infrastructure.
 
+> **Hands-on:** Try the [Validate Infrastructure Using Checks](/terraform/tutorials/configuration-language/checks) tutorial.
+
 Check blocks allow you to define [custom conditions](/terraform/language/expressions/custom-conditions) that execute on every Terraform plan or apply operation without affecting the overall status of an operation. Check blocks execute as the last step of a plan or apply after Terraform has planned or provisioned your infrastructure.
 
-## Checks Syntax
+## Syntax
 
 You can declare a `check` block with a local name, zero-to-one scoped [data sources](#scoped-data-sources), and one-to-many [assertions](#assertions).
 
@@ -31,7 +33,7 @@ check "health_check" {
 }
 ```
 
-### Scoped Data Sources
+### Scoped data sources
 
 You can use any data source from any provider as a scoped data source within a `check` block.
 
@@ -69,7 +71,7 @@ Condition arguments within `assert` blocks can refer to scoped data sources with
 
 Check blocks do not currently support [meta-arguments](/terraform/language/resources/syntax#meta-arguments). We are still collecting feedback on this feature, so if your use case would benefit from check blocks supporting meta-arguments, please [let us know](https://github.com/hashicorp/terraform/issues/new/choose).
 
-## Continuous Validation in Terraform Cloud
+## Continuous validation in Terraform Cloud
 
 Terraform Cloud can automatically validate whether checks in a workspace’s configuration continue to pass after Terraform provisions new infrastructure. See [Continuous Validation](/terraform/cloud-docs/workspaces/health#continuous-validation) for details.
 
@@ -79,7 +81,7 @@ Check blocks offer the most _flexible_ validation solution within Terraform. You
 
 There are major behavioral differences between check block assertions and other custom conditions, the main one being that check blocks do _not_ affect Terraform's execution of an operation. You can use this non-blocking behavior to decide the best type of validation for your use case.
 
-### Outputs and Variables
+### Outputs and variables
 
 [Output postconditions](/terraform/language/expressions/custom-conditions#outputs) and [variable validations](/terraform/language/expressions/custom-conditions#input-variable-validation) both make assertions around inputs and outputs.
 

--- a/website/docs/language/expressions/custom-conditions.mdx
+++ b/website/docs/language/expressions/custom-conditions.mdx
@@ -8,7 +8,7 @@ description: >-
 
 You can create conditions that produce custom error messages for several types of objects in a configuration. For example, you can add a condition to an input variable that checks whether incoming image IDs are formatted properly. Custom conditions can capture assumptions, helping future maintainers understand the configuration design and intent. They also return useful information about errors earlier and in context, helping consumers more easily diagnose issues in their configurations.
 
-> **Hands On:** Try the [Validate Modules with Custom Conditions](/terraform/tutorials/configuration-language/custom-conditions) tutorial.
+> **Hands On:** Try the [Validate Infrastructure Using Checks](/terraform/tutorials/configuration-language/checks) tutorial to learn how to use `check` blocks. Try the [Validate Modules with Custom Conditions](/terraform/tutorials/configuration-language/custom-conditions) tutorial to learn how to use other custom conditions.
 
 This page explains the following:
   - Creating checks with [assertions](#check-assertions) to verify your infrastructure as a whole (Terraform v1.5.0 and later)
@@ -17,7 +17,7 @@ This page explains the following:
   - Writing effective [condition expressions](#condition-expressions) and [error messages](#error-messages)
   - When Terraform [evaluates custom conditions](#conditions-checked-only-during-apply) during the plan and apply cycle
 
-## Selecting a Custom Condition for Your Use Case
+## Selecting a Custom Condition for your use case
 
 Terraform's different custom conditions are best suited to various situations. Use the following broad guidelines to select the best custom condition for your use case:
 1. [Check blocks with assertions](#check-assertions) validate your infrastructure as a whole. Additionally, check blocks do not prevent or block the overall execution of Terraform operations.


### PR DESCRIPTION
Howdy! Small PR adding links to the Checks articles for the Checks tutorial. 

I also fixed my own small mistake from reviewing, I thought the style guide specified title case headers, which it does not, it requires sentence case headers. So I added those fixes in this PR as well!

@liamcervante Does this need a special backport tag as well? 