### PR TITLE
feat: check for presence of target resource in ChangedResources

### DIFF
--- a/internal/plans/changes_src.go
+++ b/internal/plans/changes_src.go
@@ -42,7 +42,7 @@ type ResourceInstanceChangeSrc struct {
 	// the current object is being replaced with the deposed.
 	DeposedKey states.DeposedKey
 
-	// Provider is the address of the provider configuration that was used
+	// ProviderAddr is the address of the provider configuration that was used
 	// to plan this change, and thus the configuration that must also be
 	// used to apply it.
 	ProviderAddr addrs.AbsProviderConfig

--- a/internal/terraform/context_plan.go
+++ b/internal/terraform/context_plan.go
@@ -9,12 +9,14 @@ import (
 	"log"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/zclconf/go-cty/cty"
 
 	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/configs"
+	"github.com/hashicorp/terraform/internal/didyoumean"
 	"github.com/hashicorp/terraform/internal/instances"
 	"github.com/hashicorp/terraform/internal/lang/globalref"
 	"github.com/hashicorp/terraform/internal/plans"
@@ -200,6 +202,46 @@ The -target option is not for routine use, and is provided only for exceptional 
 	// here because we'll still populate other metadata below on a best-effort
 	// basis to try to give the UI some extra context to return alongside the
 	// error messages.
+
+	// If we have a plan with changes, check if any of the targeted resources are
+	// not among the planned changes, likely due to a typo in resource address.
+	if plan != nil && plan.Changes != nil && len(opts.Targets) > 0 {
+		resourceMap := make(map[string]struct{}, len(plan.Changes.Resources))
+		for _, resource := range plan.Changes.Resources {
+			resourceMap[resource.Addr.String()] = struct{}{}
+		}
+
+		// We will build up suggestions if necessary based on previous state only once
+		var once sync.Once
+		var suggestions []string
+
+		for _, target := range opts.Targets {
+			if _, ok := resourceMap[target.String()]; ok {
+				continue
+			}
+
+			once.Do(func() {
+				if plan.PrevRunState == nil {
+					return
+				}
+				for _, resource := range plan.PrevRunState.AllResourceInstanceObjectAddrs() {
+					suggestions = append(suggestions, resource.Instance.Resource.Resource.String())
+				}
+			})
+
+			suggestion := didyoumean.NameSuggestion(target.String(), suggestions)
+			prompt := "Check for a typo."
+			if suggestion != "" {
+				prompt = fmt.Sprintf("Did you mean %s?", suggestion)
+			}
+
+			diags = diags.Append(tfdiags.Sourceless(
+				tfdiags.Warning,
+				"Failed to target resource",
+				fmt.Sprintf("%s is not a valid resource address. %s", target.String(), prompt),
+			))
+		}
+	}
 
 	// convert the variables into the format expected for the plan
 	varVals := make(map[string]plans.DynamicValue, len(opts.SetVariables))


### PR DESCRIPTION
Fixes #33200

## Target Release

1.5.x

## Draft CHANGELOG entry

`terraform <plan|apply> -target=<resource>`: warn if targeted resource is not present in state.

----

I have commented the logic choice I have made as to how I check for presence. If you prefer it to instead be something like

```go
		resourceMap := make(map[string]struct{}, len(plan.Changes.Resources))
		for _, resource := range plan.Changes.Resources {
			resourceMap[resource.Addr.String()] = struct{}{}
		}

		for _, target := range opts.Targets {
			if _, ok := resourceMap[target.String()]; !ok {
				diags = diags.Append(tfdiags.Sourceless(
					tfdiags.Warning,
					"Failed to target resource",
					fmt.Sprintf("%s is not a valid resource address. Check for a typo.", target),
				))
			}
		}
```

then I am happy to update it.

Example run:

```zsh
➜   cat test.tf
terraform {
  backend "local" {
    path = "terraform.tfstate"
  }
}


resource "random_string" "random" {
  length           = 16
  special          = true
  override_special = "/@£$"
}
➜   terraform plan -replace=random_string.random -target=random_string.rndom

No changes. Your infrastructure matches the configuration.

Terraform has compared your real infrastructure against your configuration and found no differences,
so no changes are needed.
╷
│ Warning: Resource targeting is in effect
│
│ You are creating a plan with the -target option, which means that the result of this plan may not
│ represent all of the changes requested by the current configuration.
│
│ The -target option is not for routine use, and is provided only for exceptional situations such as
│ recovering from errors or mistakes, or when Terraform specifically suggests to use it as part of
│ an error message.
╵
➜  "$(go env GOPATH)/bin/terraform" plan -replace=random_string.random -target=random_string.rndom

No changes. Your infrastructure matches the configuration.

Terraform has compared your real infrastructure against your configuration and found no differences,
so no changes are needed.
╷
│ Warning: Resource targeting is in effect
│
│ You are creating a plan with the -target option, which means that the result of this plan may not
│ represent all of the changes requested by the current configuration.
│
│ The -target option is not for routine use, and is provided only for exceptional situations such as
│ recovering from errors or mistakes, or when Terraform specifically suggests to use it as part of
│ an error message.
╵
╷
│ Warning: Failed to target resource
│
│ random_string.rndom is not a valid resource address. Check for a typo.
╵
➜   "$(go env GOPATH)/bin/terraform" apply -replace=random_string.random -target=random_string.rndom

No changes. Your infrastructure matches the configuration.

Terraform has compared your real infrastructure against your configuration and found no differences,
so no changes are needed.
╷
│ Warning: Resource targeting is in effect
│
│ You are creating a plan with the -target option, which means that the result of this plan may not
│ represent all of the changes requested by the current configuration.
│
│ The -target option is not for routine use, and is provided only for exceptional situations such as
│ recovering from errors or mistakes, or when Terraform specifically suggests to use it as part of
│ an error message.
╵
╷
│ Warning: Failed to target resource
│
│ random_string.rndom is not a valid resource address. Check for a typo.
╵
╷
│ Warning: Applied changes may be incomplete
│
│ The plan was created with the -target option in effect, so some changes requested in the
│ configuration may have been ignored and the output values may not be fully updated. Run the
│ following command to verify that no other changes are pending:
│     terraform plan
│
│ Note that the -target option is not suitable for routine use, and is provided only for exceptional
│ situations such as recovering from errors or mistakes, or when Terraform specifically suggests to
│ use it as part of an error message.
╵

Apply complete! Resources: 0 added, 0 changed, 0 destroyed.

➜   "$(go env GOPATH)/bin/terraform" apply -replace=random_string.random -target=random_string.random
random_string.random: Refreshing state... [id=8YireUSutoxZaFyi]

Terraform used the selected providers to generate the following execution plan. Resource actions are
indicated with the following symbols:
-/+ destroy and then create replacement

Terraform will perform the following actions:

  # random_string.random is tainted, so must be replaced
-/+ resource "random_string" "random" {
      ~ id               = "8YireUSutoxZaFyi" -> (known after apply)
      ~ result           = "8YireUSutoxZaFyi" -> (known after apply)
        # (11 unchanged attributes hidden)
    }

Plan: 1 to add, 0 to change, 1 to destroy.
╷
│ Warning: Resource targeting is in effect
│
│ You are creating a plan with the -target option, which means that the result of this plan may not
│ represent all of the changes requested by the current configuration.
│
│ The -target option is not for routine use, and is provided only for exceptional situations such as
│ recovering from errors or mistakes, or when Terraform specifically suggests to use it as part of
│ an error message.
╵

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

random_string.random: Destroying... [id=8YireUSutoxZaFyi]
random_string.random: Destruction complete after 0s
random_string.random: Creating...
random_string.random: Creation complete after 0s [id=i1CvW5L8nYqtMQUl]
╷
│ Warning: Applied changes may be incomplete
│
│ The plan was created with the -target option in effect, so some changes requested in the
│ configuration may have been ignored and the output values may not be fully updated. Run the
│ following command to verify that no other changes are pending:
│     terraform plan
│
│ Note that the -target option is not suitable for routine use, and is provided only for exceptional
│ situations such as recovering from errors or mistakes, or when Terraform specifically suggests to
│ use it as part of an error message.
╵

Apply complete! Resources: 1 added, 0 changed, 1 destroyed.
```