### PR TITLE
Introduce dedicated validation functions for the testing scope

### DIFF
--- a/internal/addrs/output_value.go
+++ b/internal/addrs/output_value.go
@@ -19,13 +19,26 @@ import (
 // a module output from the perspective of its parent module. Since output
 // values cannot be represented from the module where they are defined,
 // OutputValue is not Referenceable, while ModuleCallOutput is.
+//
+// Outputs are, however, directly referenceable from the testing framework.
 type OutputValue struct {
+	referenceableFromTests
 	Name string
 }
 
 func (v OutputValue) String() string {
 	return "output." + v.Name
 }
+
+func (v OutputValue) Equal(o OutputValue) bool {
+	return v.Name == o.Name
+}
+
+func (v OutputValue) UniqueKey() UniqueKey {
+	return v // An OutputValue is its own UniqueKey
+}
+
+func (v OutputValue) uniqueKeySigil() {}
 
 // Absolute converts the receiver into an absolute address within the given
 // module instance.

--- a/internal/addrs/referenceable.go
+++ b/internal/addrs/referenceable.go
@@ -6,6 +6,9 @@ package addrs
 // Referenceable is an interface implemented by all address types that can
 // appear as references in configuration language expressions.
 type Referenceable interface {
+	// Everything referenceable is also referenceable from tests.
+	ReferenceableFromTests
+
 	// All implementations of this interface must be covered by the type switch
 	// in lang.Scope.buildEvalContext.
 	referenceableSigil()
@@ -20,7 +23,23 @@ type Referenceable interface {
 }
 
 type referenceable struct {
+	// Everything referenceable is also referencable from any tests.
+	referenceableFromTests
 }
 
 func (r referenceable) referenceableSigil() {
+}
+
+type ReferenceableFromTests interface {
+	referenceableFromTestsSigil()
+
+	UniqueKeyer
+
+	String() string
+}
+
+type referenceableFromTests struct {
+}
+
+func (r referenceableFromTests) referenceableFromTestsSigil() {
 }

--- a/internal/addrs/self.go
+++ b/internal/addrs/self.go
@@ -12,6 +12,9 @@ type selfT int
 func (s selfT) referenceableSigil() {
 }
 
+func (s selfT) referenceableFromTestsSigil() {
+}
+
 func (s selfT) String() string {
 	return "self"
 }

--- a/internal/lang/data.go
+++ b/internal/lang/data.go
@@ -4,9 +4,10 @@
 package lang
 
 import (
+	"github.com/zclconf/go-cty/cty"
+
 	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/tfdiags"
-	"github.com/zclconf/go-cty/cty"
 )
 
 // Data is an interface whose implementations can provide cty.Value
@@ -24,6 +25,7 @@ import (
 // cty.DynamicVal is returned along with errors describing the problem.
 type Data interface {
 	StaticValidateReferences(refs []*addrs.Reference, self addrs.Referenceable, source addrs.Referenceable) tfdiags.Diagnostics
+	StaticValidateReferencesFromTestingScope(refs []*addrs.TestReference) tfdiags.Diagnostics
 
 	GetCountAttr(addrs.CountAttr, tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics)
 	GetForEachAttr(addrs.ForEachAttr, tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics)
@@ -33,4 +35,6 @@ type Data interface {
 	GetPathAttr(addrs.PathAttr, tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics)
 	GetTerraformAttr(addrs.TerraformAttr, tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics)
 	GetInputVariable(addrs.InputVariable, tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics)
+	GetOutput(addrs.OutputValue, tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics)
+	GetCheckBlock(addrs.Check, tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics)
 }

--- a/internal/lang/data_test.go
+++ b/internal/lang/data_test.go
@@ -4,9 +4,10 @@
 package lang
 
 import (
+	"github.com/zclconf/go-cty/cty"
+
 	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/tfdiags"
-	"github.com/zclconf/go-cty/cty"
 )
 
 type dataForTests struct {
@@ -14,15 +15,21 @@ type dataForTests struct {
 	ForEachAttrs   map[string]cty.Value
 	Resources      map[string]cty.Value
 	LocalValues    map[string]cty.Value
+	OutputValues   map[string]cty.Value
 	Modules        map[string]cty.Value
 	PathAttrs      map[string]cty.Value
 	TerraformAttrs map[string]cty.Value
 	InputVariables map[string]cty.Value
+	CheckBlocks    map[string]cty.Value
 }
 
 var _ Data = &dataForTests{}
 
 func (d *dataForTests) StaticValidateReferences(refs []*addrs.Reference, self addrs.Referenceable, source addrs.Referenceable) tfdiags.Diagnostics {
+	return nil // does nothing in this stub implementation
+}
+
+func (d *dataForTests) StaticValidateReferencesFromTestingScope(refs []*addrs.TestReference) tfdiags.Diagnostics {
 	return nil // does nothing in this stub implementation
 }
 
@@ -62,4 +69,12 @@ func (d *dataForTests) GetPathAttr(addr addrs.PathAttr, rng tfdiags.SourceRange)
 
 func (d *dataForTests) GetTerraformAttr(addr addrs.TerraformAttr, rng tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics) {
 	return d.TerraformAttrs[addr.Name], nil
+}
+
+func (d *dataForTests) GetOutput(addr addrs.OutputValue, rng tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics) {
+	return d.OutputValues[addr.Name], nil
+}
+
+func (d *dataForTests) GetCheckBlock(addr addrs.Check, rng tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics) {
+	return d.CheckBlocks[addr.Name], nil
 }

--- a/internal/lang/references.go
+++ b/internal/lang/references.go
@@ -5,6 +5,7 @@ package lang
 
 import (
 	"github.com/hashicorp/hcl/v2"
+
 	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/configs/configschema"
 	"github.com/hashicorp/terraform/internal/lang/blocktoattr"
@@ -34,6 +35,28 @@ func References(traversals []hcl.Traversal) ([]*addrs.Reference, tfdiags.Diagnos
 
 	for _, traversal := range traversals {
 		ref, refDiags := addrs.ParseRef(traversal)
+		diags = diags.Append(refDiags)
+		if ref == nil {
+			continue
+		}
+		refs = append(refs, ref)
+	}
+
+	return refs, diags
+}
+
+// ReferencesForTest matches References but returns references retrieved from
+// the wider testing scope.
+func ReferencesForTest(traversals []hcl.Traversal) ([]*addrs.TestReference, tfdiags.Diagnostics) {
+	if len(traversals) == 0 {
+		return nil, nil
+	}
+
+	var diags tfdiags.Diagnostics
+	refs := make([]*addrs.TestReference, 0, len(traversals))
+
+	for _, traversal := range traversals {
+		ref, refDiags := addrs.ParseRefFromTestingScope(traversal)
 		diags = diags.Append(refDiags)
 		if ref == nil {
 			continue


### PR DESCRIPTION
This is one of two PRs with alternate approaches to adding separate scope for the testing framework.

This PR:

- Introduces a new `TestingReference` struct to the `addrs` package.
- Introduces new functions into the scope and data validation packages that reference and use the new testing scope.

This is an alternative to #33339 