### PR TITLE
[Docs] fix: update broken links to `checks` section in Custom Conditions documentation

### DIFF
--- a/website/docs/language/expressions/custom-conditions.mdx
+++ b/website/docs/language/expressions/custom-conditions.mdx
@@ -11,7 +11,7 @@ You can create conditions that produce custom error messages for several types o
 > **Hands On:** Try the [Validate Infrastructure Using Checks](/terraform/tutorials/configuration-language/checks) tutorial to learn how to use `check` blocks. Try the [Validate Modules with Custom Conditions](/terraform/tutorials/configuration-language/custom-conditions) tutorial to learn how to use other custom conditions.
 
 This page explains the following:
-  - Creating checks with [assertions](#check-assertions) to verify your infrastructure as a whole (Terraform v1.5.0 and later)
+  - Creating checks with [assertions](#checks-with-assertions) to verify your infrastructure as a whole (Terraform v1.5.0 and later)
   - Creating [validation conditions](#input-variable-validation) for input variables (Terraform v0.13.0 and later)
   - Creating [preconditions and postconditions](#preconditions-and-postconditions) for resources, data sources, and outputs (Terraform v1.2.0 and later)
   - Writing effective [condition expressions](#condition-expressions) and [error messages](#error-messages)
@@ -20,7 +20,7 @@ This page explains the following:
 ## Selecting a Custom Condition for your use case
 
 Terraform's different custom conditions are best suited to various situations. Use the following broad guidelines to select the best custom condition for your use case:
-1. [Check blocks with assertions](#check-assertions) validate your infrastructure as a whole. Additionally, check blocks do not prevent or block the overall execution of Terraform operations.
+1. [Check blocks with assertions](#checks-with-assertions) validate your infrastructure as a whole. Additionally, check blocks do not prevent or block the overall execution of Terraform operations.
 1. [Validation conditions](#input-variable-validation) or [output postconditions](#preconditions-and-postconditions) can ensure your configuration's inputs and outputs meet specific requirements.
 1. Resource [preconditions and postconditions](#preconditions-and-postconditions) can validate that Terraform produces your configuration with predictable results.
 
@@ -213,7 +213,7 @@ You should also consider the following questions when creating preconditions and
 - Which approach is more convenient? If a particular resource has many dependencies that all make an assumption about that resource, it can be pragmatic to declare that once as a post-condition of the resource, rather than declaring it many times as preconditions on each of the dependencies.
 - Is it helpful to declare the same or similar conditions as both preconditions and postconditions? This can be useful if the postcondition is in a different module than the precondition because it lets the modules verify one another as they evolve independently.
 
-## Checks with assertions
+## Checks with Assertions
 
 -> **Note:** Check blocks and their assertions are only available in Terraform v1.5.0 and later.
 


### PR DESCRIPTION
# Rationale

When browsing the docs for `checks` via https://developer.hashicorp.com/terraform/language/expressions/custom-conditions, the links to take you direct to this area are broken and do not work. This is because the markdown section link made does not equal the title given the page e.g.

- Creating checks with [assertions](https://developer.hashicorp.com/terraform/language/expressions/custom-conditions#check-assertions) to verify your infrastructure as a whole (Terraform v1.5.0 and later)

Additionally, I have capitalised the a in assertions for the section heading to keep it consistent with the rest of the doc, I can remove this though if by design, let me know.
 
## Target Release

N/A

## Draft CHANGELOG entry

### BUG FIXES

-  Fixed links to `check` block documentation in Custom Conditions
