### PR TITLE
plans/objchange: Support nested unknowns in our unrefinedValue shim

### DIFF
--- a/internal/plans/objchange/plan_valid.go
+++ b/internal/plans/objchange/plan_valid.go
@@ -465,9 +465,19 @@ func assertPlannedObjectValid(schema *configschema.Object, prior, config, planne
 
 // unrefinedValue returns the given value with any unknown value refinements
 // stripped away, making it a basic unknown value with only a type constraint.
+//
+// This function also considers unknown values nested inside a known container
+// such as a collection, which unfortunately makes it relatively expensive
+// for large data structures. Over time we should transition away from using
+// this trick and prefer to use cty's Equals and value range APIs instead of
+// of using Value.RawEquals, which is primarily intended for unit test code
+// rather than real application use.
 func unrefinedValue(v cty.Value) cty.Value {
-	if !v.IsKnown() {
-		return cty.UnknownVal(v.Type())
-	}
-	return v
+	ret, _ := cty.Transform(v, func(p cty.Path, v cty.Value) (cty.Value, error) {
+		if !v.IsKnown() {
+			return cty.UnknownVal(v.Type()), nil
+		}
+		return v, nil
+	})
+	return ret
 }


### PR DESCRIPTION
Several parts of the objchange logic incorrectly use cty.Value.RawEquals for value comparison, instead of more appropriate comparison methods like cty.Value.Equals or c.Value.Range().Includes. That makes them incorrectly consider two unknown values with the same type but different refinements as always non-equal, rather than evaluating based on the overlap between the refinements (if any).

As a short-term fix for that we previously added this unrefinedValue shim that just strips away the refinements for comparison, thus allowing callers to continue using RawEquals as long as they've already taken care of all of the other things that can make that go wrong, such as value marks. (Unfortunately the callers typically today handle that via a similar coarse technique: stripping out all of the marks before doing `RawEquals`! :grimacing: Hopefully we can revisit both together at a later time.)

Unfortunately the shim was too simplistic and only supported direct unknown values. Unknown values with refinements can also appear nested inside known container values such as collections, so the shim needs to recursively un-refine the entire data structure in that case.

This is still intended only as a temporary fix until we have time to revisit all of the callers and make them use cty's own logic for comparison. Using cty's own logic will make the results more precise, because e.g. it can notice if two unknown strings have different known prefixes and therefore cannot possibly be equal despite not being fully known. For now this shim will accept any pair of unknown values of the same type as equal, regardless of refinement.

Fixes #33385.
