### PR TITLE
Implement `plan -out` with cloud integration

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -41,7 +41,7 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-plugin v1.4.3
 	github.com/hashicorp/go-retryablehttp v0.7.4
-	github.com/hashicorp/go-tfe v1.28.0
+	github.com/hashicorp/go-tfe v1.29.0
 	github.com/hashicorp/go-uuid v1.0.3
 	github.com/hashicorp/go-version v1.6.0
 	github.com/hashicorp/hcl v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -621,8 +621,8 @@ github.com/hashicorp/go-sockaddr v1.0.0/go.mod h1:7Xibr9yA9JjQq1JpNB2Vw7kxv8xerX
 github.com/hashicorp/go-sockaddr v1.0.2 h1:ztczhD1jLxIRjVejw8gFomI1BQZOe2WoVOu0SyteCQc=
 github.com/hashicorp/go-sockaddr v1.0.2/go.mod h1:rB4wwRAUzs07qva3c5SdrY/NEtAUjGlgmH/UkBUC97A=
 github.com/hashicorp/go-syslog v1.0.0/go.mod h1:qPfqrKkXGihmCqbJM2mZgkZGvKG1dFdvsLplgctolz4=
-github.com/hashicorp/go-tfe v1.28.0 h1:YQNfHz5UPMiOD2idad4GCjzG3R2ExPww741PBPqMOIU=
-github.com/hashicorp/go-tfe v1.28.0/go.mod h1:z0182DGE/63AKUaWblUVBIrt+xdSmsuuXg5AoxGqDF4=
+github.com/hashicorp/go-tfe v1.29.0 h1:hVvgoKtLAWTkXl9p/8WnItCaW65VJwqpjLZkXe8R2AM=
+github.com/hashicorp/go-tfe v1.29.0/go.mod h1:z0182DGE/63AKUaWblUVBIrt+xdSmsuuXg5AoxGqDF4=
 github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-uuid v1.0.1/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-uuid v1.0.2/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
@@ -1175,6 +1175,7 @@ golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20220601150217-0de741cfad7f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20220929204114-8fcdb60fdcc0/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.1.0/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.3.0 h1:ftCYgMx6zT/asHUrPw8BLLscYtGznsLAnjq5RH9P66E=
 golang.org/x/sync v0.3.0/go.mod h1:FU7BRWz2tNW+3quACPkgCx/L+uEAv1htQ0V83Z9Rj+Y=
 golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/internal/cloud/backend_plan.go
+++ b/internal/cloud/backend_plan.go
@@ -100,6 +100,10 @@ func (b *Cloud) opPlan(stopCtx, cancelCtx context.Context, op *backend.Operation
 		}
 	}
 
+	// Cloud integration currently doesn't support genconfig, but we might have
+	// saved a cloud plan file.
+	op.View.PlanNextStep(op.PlanOutPath, "")
+
 	return run, err
 }
 

--- a/internal/cloud/backend_plan.go
+++ b/internal/cloud/backend_plan.go
@@ -93,10 +93,11 @@ func (b *Cloud) opPlan(stopCtx, cancelCtx context.Context, op *backend.Operation
 	if run != nil && run.ID != "" && op.PlanOutPath != "" {
 		bookmark := cloudplan.NewSavedPlanBookmark(run.ID, b.hostname)
 		saveErr := bookmark.Save(op.PlanOutPath)
-		if err == nil {
-			err = saveErr
-		} else {
+		// Maybe combine errors
+		if err != nil && saveErr != nil {
 			err = fmt.Errorf("%w\nAdditionally, an error occurred when saving the plan: %s", err, saveErr.Error())
+		} else if err == nil {
+			err = saveErr
 		}
 	}
 

--- a/internal/cloud/backend_plan.go
+++ b/internal/cloud/backend_plan.go
@@ -101,8 +101,7 @@ func (b *Cloud) opPlan(stopCtx, cancelCtx context.Context, op *backend.Operation
 
 	// Only display next steps if everything succeeded
 	if err == nil {
-		// Cloud currently supports plan -out but not genconfig
-		op.View.PlanNextStep(op.PlanOutPath, "")
+		op.View.PlanNextStep(op.PlanOutPath, op.GenerateConfigOut)
 	}
 
 	return run, err

--- a/internal/cloud/cloudplan/saved_plan.go
+++ b/internal/cloud/cloudplan/saved_plan.go
@@ -20,6 +20,14 @@ type SavedPlanBookmark struct {
 	Hostname         string `json:"hostname"`
 }
 
+func NewSavedPlanBookmark(runID, hostname string) SavedPlanBookmark {
+	return SavedPlanBookmark{
+		RemotePlanFormat: 1,
+		RunID:            runID,
+		Hostname:         hostname,
+	}
+}
+
 func LoadSavedPlanBookmark(filepath string) (SavedPlanBookmark, error) {
 	bookmark := SavedPlanBookmark{}
 


### PR DESCRIPTION
This is it! We can use `terraform plan -out my.tfplan` in cloud mode to create an arbitrary number of saved plan runs, and then `terraform apply my.tfplan` one of the resulting plans to make it the workspace's next apply. 

Because `save-plan` is a new attribute in the runs API, it requires an update to go-tfe — https://github.com/hashicorp/go-tfe/pull/724

**To smoke test this:** Make sure your TFC org has been added to the saved-cloud-plans feature flag.