### PR TITLE
Update configuration.mdx

### DIFF
--- a/website/docs/language/settings/backends/configuration.mdx
+++ b/website/docs/language/settings/backends/configuration.mdx
@@ -104,7 +104,32 @@ There are several ways to supply the remaining arguments:
 
 - **File**: A configuration file may be specified via the `init` command line.
   To specify a file, use the `-backend-config=PATH` option when running
-  `terraform init`. If the file contains secrets it may be kept in
+  `terraform init`. You need an existing backend configuration that you can override with
+  the config file you provide in PATH. The config file must contain only the key/value pairs
+  for your backend. For example, run `terraform init -backend-config="./state.config"` to 
+  override your backend configuration defined in `state.tf` with the values from `state.config`: 
+
+  ```hcl
+  # state.tf
+  terraform {
+    backend "s3" {
+      bucket = "" 
+      key    = ""
+      region = ""
+      profile= ""
+    }
+  }
+  ```
+
+  ```hcl
+  # state.config
+  bucket = "your-bucket" 
+  key    = "your-state.tfstate"
+  region = "eu-central-1"
+  profile= "Your_Profile"
+  ```
+
+  Important: If your config file contains secrets it may be kept in
   a secure data store, such as [Vault](https://www.vaultproject.io/),
   in which case it must be downloaded to the local disk before running Terraform.
 

--- a/website/docs/language/settings/backends/configuration.mdx
+++ b/website/docs/language/settings/backends/configuration.mdx
@@ -104,10 +104,10 @@ There are several ways to supply the remaining arguments:
 
 - **File**: A configuration file may be specified via the `init` command line.
   To specify a file, use the `-backend-config=PATH` option when running
-  `terraform init`. You need an existing backend configuration that you can override with
-  the config file you provide in PATH. The config file must contain only the key/value pairs
-  for your backend. For example, run `terraform init -backend-config="./state.config"` to 
-  override your backend configuration defined in `state.tf` with the values from `state.config`: 
+  `terraform init`. The partial configuration must have a `backend` block containing keys set to empty values. When you run the `terraform init -backend-config="<path-to-remaining-configuration>"` command, Terraform populates the keys in the partial `backend` configuration with matching key values from the specified configuration file. In the following example, the keys defined in the `backend` block of the `state.tf` configuration file are populated with values from the `state.config` configuration:  
+    ```
+    $ `terraform init -backend-config="./state.config"`
+    ```   
 
   ```hcl
   # state.tf

--- a/website/docs/language/settings/backends/configuration.mdx
+++ b/website/docs/language/settings/backends/configuration.mdx
@@ -129,7 +129,7 @@ There are several ways to supply the remaining arguments:
   profile= "Your_Profile"
   ```
 
-  Important: If your config file contains secrets it may be kept in
+  When your configuration file contains secrets, you can store them in
   a secure data store, such as [Vault](https://www.vaultproject.io/),
   in which case it must be downloaded to the local disk before running Terraform.
 


### PR DESCRIPTION
More details on how to use `-backend-config`

For me, using -backend-config was not straight-forward. On the Internet you find other people who had the same misconceptions. Therefore, I think the documentation on this feature needs more clarification.

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->



## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.5.x

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

ENHANCEMENTS

<!--

Write a short description of the user-facing change. Examples:

- `terraform show -json`: Fixed crash with sensitive set values.
- When rendering a diff, Terraform now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 


