### PR TITLE
Relocate localterraform.com aliasing to backend configurators 

### DIFF
--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -14,6 +14,7 @@ import (
 	"log"
 	"os"
 
+	svchost "github.com/hashicorp/terraform-svchost"
 	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/command/clistate"
 	"github.com/hashicorp/terraform/internal/command/views"
@@ -119,6 +120,13 @@ type Backend interface {
 	Workspaces() ([]string, error)
 }
 
+// HostAlias describes a list of aliases that should be used when initializing an
+// Enhanced Backend
+type HostAlias struct {
+	From svchost.Hostname
+	To   svchost.Hostname
+}
+
 // Enhanced implements additional behavior on top of a normal backend.
 //
 // 'Enhanced' backends are an implementation detail only, and are no longer reflected as an external
@@ -136,6 +144,10 @@ type Enhanced interface {
 	// responsibility of the Backend to lock the state for the duration of the
 	// running operation.
 	Operation(context.Context, *Operation) (*RunningOperation, error)
+
+	// ServiceDiscoveryAliases returns a mapping of Alias -> Target hosts to
+	// configure.
+	ServiceDiscoveryAliases() ([]HostAlias, error)
 }
 
 // Local implements additional behavior on a Backend that allows local

--- a/internal/backend/local/backend.go
+++ b/internal/backend/local/backend.go
@@ -183,6 +183,10 @@ func (b *Local) Configure(obj cty.Value) tfdiags.Diagnostics {
 	return diags
 }
 
+func (b *Local) ServiceDiscoveryAliases() ([]backend.HostAlias, error) {
+	return []backend.HostAlias{}, nil
+}
+
 func (b *Local) Workspaces() ([]string, error) {
 	// If we have a backend handling state, defer to that.
 	if b.Backend != nil {

--- a/internal/backend/remote/backend.go
+++ b/internal/backend/remote/backend.go
@@ -198,21 +198,26 @@ func (b *Remote) PrepareConfig(obj cty.Value) (cty.Value, tfdiags.Diagnostics) {
 	return obj, diags
 }
 
-// configureGenericHostname aliases the remote backend hostname configuration
-// as a generic "localterraform.com" hostname. This was originally added as a
-// Terraform Enterprise feature and is useful for re-using whatever the
-// Cloud/Enterprise backend host is in nested module sources in order
-// to prevent code churn when re-using config between multiple
-// Terraform Enterprise environments.
-func (b *Remote) configureGenericHostname() {
-	// This won't be an error for the given constant value
-	genericHost, _ := svchost.ForComparison(genericHostname)
+func (b *Remote) ServiceDiscoveryAliases() ([]backend.HostAlias, error) {
+	aliasHostname, err := svchost.ForComparison(genericHostname)
+	if err != nil {
+		// This should never happen because the hostname is statically defined.
+		return nil, fmt.Errorf("failed to create backend alias from alias %q. The hostname is not in the correct format. This is a bug in the backend", genericHostname)
+	}
 
-	// This won't be an error because, by this time, the hostname has been parsed and
-	// service discovery requests made against it.
-	targetHost, _ := svchost.ForComparison(b.hostname)
+	targetHostname, err := svchost.ForComparison(b.hostname)
+	if err != nil {
+		// This should never happen because the 'to' alias is the backend host, which has likely
+		// already been evaluated as a svchost.Hostname by now
+		return nil, fmt.Errorf("failed to create backend alias to target %q. The hostname is not in the correct format", b.hostname)
+	}
 
-	b.services.Alias(genericHost, targetHost)
+	return []backend.HostAlias{
+		{
+			From: aliasHostname,
+			To:   targetHostname,
+		},
+	}, nil
 }
 
 // Configure implements backend.Enhanced.
@@ -316,8 +321,6 @@ func (b *Remote) Configure(obj cty.Value) tfdiags.Diagnostics {
 		))
 		return diags
 	}
-
-	b.configureGenericHostname()
 
 	cfg := &tfe.Config{
 		Address:      service.String(),

--- a/internal/backend/remote/backend_test.go
+++ b/internal/backend/remote/backend_test.go
@@ -725,3 +725,29 @@ func TestRemote_VerifyWorkspaceTerraformVersion_ignoreFlagSet(t *testing.T) {
 		t.Errorf("wrong summary: got %s, want %s", got, wantDetail)
 	}
 }
+
+func TestRemote_ServiceDiscoveryAliases(t *testing.T) {
+	s := testServer(t)
+	b := New(testDisco(s))
+
+	diag := b.Configure(cty.ObjectVal(map[string]cty.Value{
+		"hostname":     cty.NullVal(cty.String), // Forces aliasing to test server
+		"organization": cty.StringVal("hashicorp"),
+		"token":        cty.NullVal(cty.String),
+		"workspaces": cty.ObjectVal(map[string]cty.Value{
+			"name":   cty.StringVal("prod"),
+			"prefix": cty.NullVal(cty.String),
+		}),
+	}))
+	if diag.HasErrors() {
+		t.Fatalf("expected no diagnostic errors, got %s", diag.Err())
+	}
+
+	aliases, err := b.ServiceDiscoveryAliases()
+	if err != nil {
+		t.Fatalf("expected no errors, got %s", err)
+	}
+	if len(aliases) != 1 {
+		t.Fatalf("expected 1 alias but got %d", len(aliases))
+	}
+}


### PR DESCRIPTION
Previously, remote and cloud backends would automatically alias localterraform.com as the configured hostname during configuration. This turned out to be an issue with how backends could potentially be used within the builtin terraform_remote_state data source. Those data sources each configure the same service discovery with different targets for localterraform.com, and do so simultaneously, creating an occasional concurrent map read & write panic when multiple data sources are defined.

localterraform.com is obviously not useful for every backend configuration. Therefore, I relocated the alias configuration to the callers, so they may specify when to use it. The modified design adds a new method to backend.Enhanced to allow configurators to ask which aliases should be defined.

Fixes #33333 

## Target Release

1.5.2

### BUG FIXES

- Fixed a panic when reading from terraform_remote_state data sources when multiple resources are defined
