### PR TITLE
Remove PATH from GetCommand helpText

### DIFF
--- a/internal/command/get.go
+++ b/internal/command/get.go
@@ -47,10 +47,10 @@ func (c *GetCommand) Run(args []string) int {
 
 func (c *GetCommand) Help() string {
 	helpText := `
-Usage: terraform [global options] get [options] PATH
+Usage: terraform [global options] get [options]
 
-  Downloads and installs modules needed for the configuration given by
-  PATH.
+  Downloads and installs modules needed for the configuration in the 
+  current working directory.
 
   This recursively downloads all modules needed, such as modules
   imported by modules imported by the root and so on. If a module is

--- a/website/docs/cli/commands/get.mdx
+++ b/website/docs/cli/commands/get.mdx
@@ -10,7 +10,7 @@ The `terraform get` command is used to download and update
 
 ## Usage
 
-Usage: `terraform get [options] PATH`
+Usage: `terraform get [options]`
 
 The modules are downloaded into a `.terraform` subdirectory of the current
 working directory. Don't commit this directory to your version control


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

GetCommand uses [`ModulePath()`](https://github.com/hashicorp/terraform/blob/3732bffe1397dd8c482a6515383d009fe2d6ec44/internal/command/command.go#L61-L74) to determine the path to configuration files, but `ModulePath()` doesn't accept any arguments.

When a user specifies a `PATH` per the documentation they will receive a ["Too many command line arguments. Did you mean to use -chdir?" error](https://github.com/hashicorp/terraform/blob/3732bffe1397dd8c482a6515383d009fe2d6ec44/internal/command/command.go#L64-L66)

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Fixes #29513

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.5.2

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

### BUG FIXES

<!--

Write a short description of the user-facing change. Examples:

- `terraform show -json`: Fixed crash with sensitive set values.
- When rendering a diff, Terraform now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 

- The `get` command help text now specifies the correct usage syntax
