### PR TITLE
Fix the Terraform build after recent merges

### DIFF
--- a/internal/command/test.go
+++ b/internal/command/test.go
@@ -225,7 +225,7 @@ func (c *TestCommand) ExecuteTestFile(ctx *terraform.Context, file *moduletest.F
 	c.View.Diagnostics(diags)
 
 	for _, run := range file.Runs {
-		view.Run(run)
+		view.Run(run, file)
 	}
 }
 


### PR DESCRIPTION
My recent PRs managed to break the build when merging as they had dependencies I didn't realise. Sorry!