### PR TITLE
fix typo in terraform/internal/command /init.go

### DIFF
--- a/internal/command/init.go
+++ b/internal/command/init.go
@@ -638,7 +638,7 @@ func (c *InitCommand) getProviders(config *configs.Config, state *states.State, 
 					diags = diags.Append(tfdiags.Sourceless(
 						tfdiags.Error,
 						"Invalid provider registry host",
-						fmt.Sprintf("The host %q given in in provider source address %q does not offer a Terraform provider registry that is compatible with this Terraform version, but it may be compatible with a different Terraform version.",
+						fmt.Sprintf("The host %q given in provider source address %q does not offer a Terraform provider registry that is compatible with this Terraform version, but it may be compatible with a different Terraform version.",
 							errorTy.Hostname, provider.String(),
 						),
 					))
@@ -647,7 +647,7 @@ func (c *InitCommand) getProviders(config *configs.Config, state *states.State, 
 					diags = diags.Append(tfdiags.Sourceless(
 						tfdiags.Error,
 						"Invalid provider registry host",
-						fmt.Sprintf("The host %q given in in provider source address %q does not offer a Terraform provider registry.",
+						fmt.Sprintf("The host %q given in provider source address %q does not offer a Terraform provider registry.",
 							errorTy.Hostname, provider.String(),
 						),
 					))


### PR DESCRIPTION
Small typo in error message.