### PR TITLE
Backport 33108

### DIFF
--- a/internal/backend/remote-state/consul/client.go
+++ b/internal/backend/remote-state/consul/client.go
@@ -234,7 +234,11 @@ func (c *RemoteClient) Put(data []byte) error {
 		}
 		// transaction was rolled back
 		if !ok {
-			return fmt.Errorf("consul CAS failed with transaction errors: %v", resp.Errors)
+			var resultErr error
+			for _, respError := range resp.Errors {
+				resultErr = multierror.Append(resultErr, errors.New(respError.What))
+			}
+			return fmt.Errorf("consul CAS failed with transaction errors: %w", resultErr)
 		}
 
 		if len(resp.Results) != 1 {


### PR DESCRIPTION
1.5 backport of #33108. Original PR description:

---

Ran into this error while running terraform inside a container, after it applied my plans, terraform failed saving state to Consul. I suspect my policy needs tweaking, but it's near impossible to tell with an error like this:

```
╷
│ Error: Failed to save state
│ 
│ Error saving state: consul CAS failed with transaction errors:
│ [0xc0006e93c8]
╵
```

This PR changes the the rendering of the error instance to actually print the message, instead of the memory address of said error instance.


## Target Release

1.5.x

## Draft CHANGELOG entry

### BUG FIXES

- When using consul as a state backend and failing to save state, `consul CAS failed with transaction errors` no longer shows an error instance memory address but an actual error message.