### PR TITLE
Update azurerm.mdx for subscription_id parameter in Azure CLI

### DIFF
--- a/website/docs/language/settings/backends/azurerm.mdx
+++ b/website/docs/language/settings/backends/azurerm.mdx
@@ -22,9 +22,14 @@ terraform {
     storage_account_name = "abcd1234"
     container_name       = "tfstate"
     key                  = "prod.terraform.tfstate"
+    subscription_id = "00000000-0000-0000-0000-000000000000"
   }
 }
 ```
+-> **Note:** By explicitly specifying the `subscription_id` parameter, you can ensure that Terraform uses the desired subscription for authentication, even if it differs from the default subscription set in the Azure CLI context.
+
+Remember to replace the placeholder values with your actual resource group name, storage account name, container name, and key.
+
 
 ***
 


### PR DESCRIPTION
Issue> Remote state listing keys requires az default subscription set #29425

The subscription_id parameter is used to specify the Azure subscription ID where the storage account is located. When using Azure CLI-based authentication, this parameter can be set to the desired subscription ID, ensuring Terraform uses that subscription instead of the default one set in the Azure CLI context.

This would assist users in understanding how to avoid potential issues when Terraform attempts to retrieve keys from the default Azure CLI subscription, which might not have the necessary keys if they are located in a different subscription.

<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Fixes #

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.5.x

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

### NEW FEATURES | UPGRADE NOTES | ENHANCEMENTS | BUG FIXES | EXPERIMENTS

<!--

Write a short description of the user-facing change. Examples:

- `terraform show -json`: Fixed crash with sensitive set values.
- When rendering a diff, Terraform now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 

-  
