### PR TITLE
always evaluate module outputs during destroy

### DIFF
--- a/internal/terraform/node_output.go
+++ b/internal/terraform/node_output.go
@@ -108,10 +108,6 @@ func (n *nodeExpandOutput) DynamicExpand(ctx EvalContext) (*Graph, error) {
 				Planning: n.Planning,
 			}
 
-		case n.Destroying:
-			// nothing is done here for non-root outputs
-			continue
-
 		default:
 			node = &NodeApplyableOutput{
 				Addr:         absAddr,

--- a/internal/terraform/testdata/apply-destroy-provisider-refs/main.tf
+++ b/internal/terraform/testdata/apply-destroy-provisider-refs/main.tf
@@ -1,0 +1,15 @@
+provider "null" {
+  value = ""
+}
+
+module "mod" {
+  source = "./mod"
+}
+
+provider "test" {
+  value = module.mod.output
+}
+
+resource "test_instance" "bar" {
+}
+

--- a/internal/terraform/testdata/apply-destroy-provisider-refs/mod/main.tf
+++ b/internal/terraform/testdata/apply-destroy-provisider-refs/mod/main.tf
@@ -1,0 +1,9 @@
+data "null_data_source" "foo" {
+       count = 1
+}
+
+
+output "output" {
+  value = data.null_data_source.foo[0].output
+}
+


### PR DESCRIPTION
A module output is generally not used during destroy, however it must be evaluated when its value is used by a provider for configuration, because that configuration is not stored between walks.

There was an oversight in the output expansion node where the output node was not created because the operation was destroy, and module outputs have nothing to destroy. This however skipped evaluation when the output is needed by a provider as mentioned above. Because of the way an implied plan is stored internally when executing `terraform destroy`, this went unnoticed by the test.

Allowing the output to be evaluated during destroy fixes the issue, and should be acceptable because an output is classified as temporary in the graph, and will be pruned when not actually needed.

Update the existing test to serialize the plan, which triggers the failure.

Fixes #33455