### PR TITLE
Plan renderer: Support users indexing integer paths with stringified numbers

### DIFF
--- a/internal/command/jsonformat/differ/differ_test.go
+++ b/internal/command/jsonformat/differ/differ_test.go
@@ -2742,6 +2742,115 @@ func TestSpecificCases(t *testing.T) {
 				}, plans.Create, false),
 			}, nil, nil, nil, nil, plans.Create, false),
 		},
+
+		// The following tests are from issue 33472. Basically Terraform allows
+		// callers to treat numbers as strings in references and expects us
+		// to coerce the strings into numbers. For example the following are
+		// equivalent.
+		//    - test_resource.resource.list[0].attribute
+		//    - test_resource.resource.list["0"].attribute
+		//
+		// We need our attribute_path package (used within the ReplacePaths and
+		// RelevantAttributes fields) to handle coercing strings into numbers
+		// when it's expected.
+
+		"issues/33472/expected": {
+			input: structured.Change{
+				Before: map[string]interface{}{
+					"list": []interface{}{
+						map[string]interface{}{
+							"number": -1,
+						},
+					},
+				},
+				After: map[string]interface{}{
+					"list": []interface{}{
+						map[string]interface{}{
+							"number": 2,
+						},
+					},
+				},
+				Unknown:         false,
+				BeforeSensitive: false,
+				AfterSensitive:  false,
+				ReplacePaths:    attribute_path.Empty(false),
+				RelevantAttributes: &attribute_path.PathMatcher{
+					Propagate: true,
+					Paths: [][]interface{}{
+						{
+							"list",
+							0.0, // This is normal and expected so easy case.
+							"number",
+						},
+					},
+				},
+			},
+			block: &jsonprovider.Block{
+				Attributes: map[string]*jsonprovider.Attribute{
+					"list": {
+						AttributeType: unmarshalType(t, cty.List(cty.Object(map[string]cty.Type{
+							"number": cty.Number,
+						}))),
+					},
+				},
+			},
+			validate: renderers.ValidateBlock(map[string]renderers.ValidateDiffFunction{
+				"list": renderers.ValidateList([]renderers.ValidateDiffFunction{
+					renderers.ValidateObject(map[string]renderers.ValidateDiffFunction{
+						"number": renderers.ValidatePrimitive(-1, 2, plans.Update, false),
+					}, plans.Update, false),
+				}, plans.Update, false),
+			}, nil, nil, nil, nil, plans.Update, false),
+		},
+
+		"issues/33472/coerce": {
+			input: structured.Change{
+				Before: map[string]interface{}{
+					"list": []interface{}{
+						map[string]interface{}{
+							"number": -1,
+						},
+					},
+				},
+				After: map[string]interface{}{
+					"list": []interface{}{
+						map[string]interface{}{
+							"number": 2,
+						},
+					},
+				},
+				Unknown:         false,
+				BeforeSensitive: false,
+				AfterSensitive:  false,
+				ReplacePaths:    attribute_path.Empty(false),
+				RelevantAttributes: &attribute_path.PathMatcher{
+					Propagate: true,
+					Paths: [][]interface{}{
+						{
+							"list",
+							"0", // Difficult but allowed, we need to handle this.
+							"number",
+						},
+					},
+				},
+			},
+			block: &jsonprovider.Block{
+				Attributes: map[string]*jsonprovider.Attribute{
+					"list": {
+						AttributeType: unmarshalType(t, cty.List(cty.Object(map[string]cty.Type{
+							"number": cty.Number,
+						}))),
+					},
+				},
+			},
+			validate: renderers.ValidateBlock(map[string]renderers.ValidateDiffFunction{
+				"list": renderers.ValidateList([]renderers.ValidateDiffFunction{
+					renderers.ValidateObject(map[string]renderers.ValidateDiffFunction{
+						"number": renderers.ValidatePrimitive(-1, 2, plans.Update, false),
+					}, plans.Update, false),
+				}, plans.Update, false),
+			}, nil, nil, nil, nil, plans.Update, false),
+		},
 	}
 	for name, tc := range tcs {
 		t.Run(name, func(t *testing.T) {

--- a/internal/command/jsonformat/structured/attribute_path/matcher.go
+++ b/internal/command/jsonformat/structured/attribute_path/matcher.go
@@ -3,7 +3,11 @@
 
 package attribute_path
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+)
 
 // Matcher provides an interface for stepping through changes following an
 // attribute path.
@@ -173,8 +177,32 @@ func (p *PathMatcher) GetChildWithIndex(index int) Matcher {
 			continue
 		}
 
-		if int(path[0].(float64)) == index {
-			child.Paths = append(child.Paths, path[1:])
+		// Terraform actually allows user to provide strings into indexes as
+		// long as the string can be interpreted into a number. For example, the
+		// following are equivalent and we need to support them.
+		//    - test_resource.resource.list[0].attribute
+		//    - test_resource.resource.list["0"].attribute
+		//
+		// Note, that Terraform will raise a validation error if the string
+		// can't be coerced into a number, so we will panic here if anything
+		// goes wrong safe in the knowledge the validation should stop this from
+		// happening.
+
+		switch val := path[0].(type) {
+		case float64:
+			if int(path[0].(float64)) == index {
+				child.Paths = append(child.Paths, path[1:])
+			}
+		case string:
+			f, err := strconv.ParseFloat(val, 64)
+			if err != nil {
+				panic(fmt.Errorf("found invalid type within path (%v:%T), the validation shouldn't have allowed this to happen; this is a bug in Terraform, please report it", val, val))
+			}
+			if int(f) == index {
+				child.Paths = append(child.Paths, path[1:])
+			}
+		default:
+			panic(fmt.Errorf("found invalid type within path (%v:%T), the validation shouldn't have allowed this to happen; this is a bug in Terraform, please report it", val, val))
 		}
 	}
 	return child


### PR DESCRIPTION

<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

Terraform allows users to specify indexes as strings as long as the string can be converted into a number. For example, the following are equivalent:

- `test_resource.resource.list[0].attribute`
- `test_resource.resource.list["0"].attribute`
- `test_resource.resource.list["0.0"].attribute`

While the following would all raise validation errors.

- `test_resource.resource.list[0.5].attribute`
- `test_resource.resource.list["not a number"].attribute`
- `test_resource.resource.list["0.5"].attribute`

The plan renderer currently makes an assumption that the indices will be the appropriate type. This causes a panic when attributes like those listed above are included in the relevant attributes data, as the renderer will attempt to cast them into the wrong type.

This PR updates the logic for parsing paths within the renderer so that it will attempt to convert strings into integers and panic if it can't. The panic should be okay and never triggered as Terraform will fail earlier if the index is actually invalid.

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Fixes #33472 

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.5.3

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

### BUG FIXES

<!--

Write a short description of the user-facing change. Examples:

- `terraform show -json`: Fixed crash with sensitive set values.
- When rendering a diff, Terraform now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 

-  Fixes crash when rendering the plan if a relevant attribute contains an integer index specified as a string.
