### PR TITLE
command: test plan -refresh= arg ordering

### DIFF
--- a/internal/command/plan_test.go
+++ b/internal/command/plan_test.go
@@ -527,6 +527,42 @@ func TestPlan_refreshTrue(t *testing.T) {
 	}
 }
 
+// A consumer relies on the fact that running
+// terraform plan -refresh=false -refresh=true gives the same result as
+// terraform plan -refresh=true.
+// While the flag logic itself is handled by the stdlib flags package (and code
+// in main() that is tested elsewhere), we verify the overall plan command
+// behaviour here in case we accidentally break this with additional logic.
+func TestPlan_refreshFalseRefreshTrue(t *testing.T) {
+	// Create a temporary working directory that is empty
+	td := t.TempDir()
+	testCopyDir(t, testFixturePath("plan-existing-state"), td)
+	defer testChdir(t, td)()
+
+	p := planFixtureProvider()
+	view, done := testView(t)
+	c := &PlanCommand{
+		Meta: Meta{
+			testingOverrides: metaOverridesForProvider(p),
+			View:             view,
+		},
+	}
+
+	args := []string{
+		"-refresh=false",
+		"-refresh=true",
+	}
+	code := c.Run(args)
+	output := done(t)
+	if code != 0 {
+		t.Fatalf("bad: %d\n\n%s", code, output.Stderr())
+	}
+
+	if !p.ReadResourceCalled {
+		t.Fatal("ReadResource should have been called")
+	}
+}
+
 func TestPlan_state(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()

--- a/internal/command/plan_test.go
+++ b/internal/command/plan_test.go
@@ -472,7 +472,7 @@ func TestPlan_outBackend(t *testing.T) {
 func TestPlan_refreshFalse(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
-	testCopyDir(t, testFixturePath("plan"), td)
+	testCopyDir(t, testFixturePath("plan-existing-state"), td)
 	defer testChdir(t, td)()
 
 	p := planFixtureProvider()
@@ -495,6 +495,35 @@ func TestPlan_refreshFalse(t *testing.T) {
 
 	if p.ReadResourceCalled {
 		t.Fatal("ReadResource should not have been called")
+	}
+}
+
+func TestPlan_refreshTrue(t *testing.T) {
+	// Create a temporary working directory that is empty
+	td := t.TempDir()
+	testCopyDir(t, testFixturePath("plan-existing-state"), td)
+	defer testChdir(t, td)()
+
+	p := planFixtureProvider()
+	view, done := testView(t)
+	c := &PlanCommand{
+		Meta: Meta{
+			testingOverrides: metaOverridesForProvider(p),
+			View:             view,
+		},
+	}
+
+	args := []string{
+		"-refresh=true",
+	}
+	code := c.Run(args)
+	output := done(t)
+	if code != 0 {
+		t.Fatalf("bad: %d\n\n%s", code, output.Stderr())
+	}
+
+	if !p.ReadResourceCalled {
+		t.Fatalf("ReadResource should have been called")
 	}
 }
 

--- a/internal/command/testdata/plan-existing-state/main.tf
+++ b/internal/command/testdata/plan-existing-state/main.tf
@@ -1,0 +1,13 @@
+resource "test_instance" "foo" {
+  ami = "bar"
+
+  # This is here because at some point it caused a test failure
+  network_interface {
+    device_index = 0
+    description  = "Main network interface"
+  }
+}
+
+data "test_data_source" "a" {
+  id = "zzzzz"
+}

--- a/internal/command/testdata/plan-existing-state/terraform.tfstate
+++ b/internal/command/testdata/plan-existing-state/terraform.tfstate
@@ -1,0 +1,23 @@
+{
+  "version": 4,
+  "terraform_version": "1.6.0",
+  "serial": 1,
+  "lineage": "d496625c-bde2-aebc-f5f4-ebbf54eabed2",
+  "outputs": {},
+   "resources": [
+      {
+        "module": "module.child",
+        "mode": "managed",
+        "type": "test_instance",
+        "name": "test",
+        "provider": "provider[\"registry.terraform.io/hashicorp/test\"]",
+        "instances": [
+          {
+            "schema_version": 0,
+            "attributes": {}
+          }
+        ]
+      }
+    ],
+  "check_results": null
+}

--- a/main_test.go
+++ b/main_test.go
@@ -49,8 +49,8 @@ func TestMain_cliArgsFromEnv(t *testing.T) {
 		{
 			"both env var and CLI",
 			[]string{testCommandName, "foo", "bar"},
-			"-foo bar",
-			[]string{"-foo", "bar", "foo", "bar"},
+			"-foo baz",
+			[]string{"-foo", "baz", "foo", "bar"},
 			false,
 		},
 
@@ -143,7 +143,7 @@ func TestMain_cliArgsFromEnv(t *testing.T) {
 
 			// Verify
 			if !reflect.DeepEqual(testCommand.Args, tc.Expected) {
-				t.Fatalf("bad: %#v", testCommand.Args)
+				t.Fatalf("expected args %#v but got %#v", tc.Expected, testCommand.Args)
 			}
 		})
 	}


### PR DESCRIPTION
A consumer relies on the fact that running `terraform plan -refresh=false -refresh=true` gives the same result as `terraform plan -refresh=true`. This depends on stdlib `flags` behaviour, handling of `TF_CLI_ARGS` in `main()`, and anything extra we do in `command`. Testing at `PlanCommand` seems appropriate to catch future regressions.

While adding this test I discovered the `TestPlan_refreshFalse` was non-functional: with the existing fixture, `ReadResource` would never be called, even with `-refresh=true`. Fixed this and also made the `main()` arg test more robust.