### PR TITLE
Add ability to specify Terraform Cloud Project in cloud block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ ENHANCEMENTS:
 * jsonplan: Added `errored` field to JSON plan output, indicating whether a plan errored. [GH-33372]
 * cloud: Remote plans on Terraform Cloud/Enterprise can now be saved using the `-out` flag, referenced in the `show` command, and applied by specifying the plan file name.
 
+
 BUG FIXES:
 * The upstream dependency that Terraform uses for service discovery of Terraform-native services such as Terraform Cloud/Enterprise state storage was previously not concurrency-safe, but Terraform was treating it as if it was in situations like when a configuration has multiple `terraform_remote_state` blocks all using the "remote" backend. Terraform is now using a newer version of that library which updates its internal caches in a concurrency-safe way. [GH-33364]
 * Transitive dependencies were lost during apply when the referenced resource expanded into zero instances [GH-33403]

--- a/internal/cloud/backend.go
+++ b/internal/cloud/backend.go
@@ -200,7 +200,7 @@ func (b *Cloud) PrepareConfig(obj cty.Value) (cty.Value, tfdiags.Diagnostics) {
 		if val := workspaces.GetAttr("tags"); !val.IsNull() {
 			err := gocty.FromCtyValue(val, &WorkspaceMapping.Tags)
 			if err != nil {
-				log.Panicf("An unxpected error occurred: %s", err)
+				log.Panicf("An unexpected error occurred: %s", err)
 			}
 		}
 	}
@@ -643,7 +643,7 @@ func (b *Cloud) StateMgr(name string) (statemgr.Full, error) {
 
 	if err == tfe.ErrResourceNotFound {
 
-		// Worksapce Create Options
+		// Workspace Create Options
 		workspaceCreateOptions := tfe.WorkspaceCreateOptions{
 			Name: tfe.String(name),
 			Tags: b.WorkspaceMapping.tfeTags(),

--- a/internal/cloud/backend_test.go
+++ b/internal/cloud/backend_test.go
@@ -1398,8 +1398,9 @@ func TestCloud_ServiceDiscoveryAliases(t *testing.T) {
 		"organization": cty.StringVal("hashicorp"),
 		"token":        cty.NullVal(cty.String),
 		"workspaces": cty.ObjectVal(map[string]cty.Value{
-			"name": cty.StringVal("prod"),
-			"tags": cty.NullVal(cty.Set(cty.String)),
+			"name":    cty.StringVal("prod"),
+			"tags":    cty.NullVal(cty.Set(cty.String)),
+			"project": cty.NullVal(cty.String),
 		}),
 	}))
 	if diag.HasErrors() {

--- a/internal/cloud/testing.go
+++ b/internal/cloud/testing.go
@@ -93,8 +93,9 @@ func testBackendAndMocksWithName(t *testing.T) (*Cloud, *MockClient, func()) {
 		"organization": cty.StringVal("hashicorp"),
 		"token":        cty.NullVal(cty.String),
 		"workspaces": cty.ObjectVal(map[string]cty.Value{
-			"name": cty.StringVal(testBackendSingleWorkspaceName),
-			"tags": cty.NullVal(cty.Set(cty.String)),
+			"name":    cty.StringVal(testBackendSingleWorkspaceName),
+			"tags":    cty.NullVal(cty.Set(cty.String)),
+			"project": cty.NullVal(cty.String),
 		}),
 	})
 	return testBackend(t, obj, defaultTFCPing)
@@ -112,6 +113,7 @@ func testBackendWithTags(t *testing.T) (*Cloud, func()) {
 					cty.StringVal("billing"),
 				},
 			),
+			"project": cty.NullVal(cty.String),
 		}),
 	})
 	b, _, c := testBackend(t, obj, nil)
@@ -124,8 +126,9 @@ func testBackendNoOperations(t *testing.T) (*Cloud, func()) {
 		"organization": cty.StringVal("no-operations"),
 		"token":        cty.NullVal(cty.String),
 		"workspaces": cty.ObjectVal(map[string]cty.Value{
-			"name": cty.StringVal(testBackendSingleWorkspaceName),
-			"tags": cty.NullVal(cty.Set(cty.String)),
+			"name":    cty.StringVal(testBackendSingleWorkspaceName),
+			"tags":    cty.NullVal(cty.Set(cty.String)),
+			"project": cty.NullVal(cty.String),
 		}),
 	})
 	b, _, c := testBackend(t, obj, nil)
@@ -138,8 +141,9 @@ func testBackendWithHandlers(t *testing.T, handlers map[string]func(http.Respons
 		"organization": cty.StringVal("hashicorp"),
 		"token":        cty.NullVal(cty.String),
 		"workspaces": cty.ObjectVal(map[string]cty.Value{
-			"name": cty.StringVal(testBackendSingleWorkspaceName),
-			"tags": cty.NullVal(cty.Set(cty.String)),
+			"name":    cty.StringVal(testBackendSingleWorkspaceName),
+			"tags":    cty.NullVal(cty.Set(cty.String)),
+			"project": cty.NullVal(cty.String),
 		}),
 	})
 	b, _, c := testBackend(t, obj, handlers)

--- a/website/docs/cli/cloud/settings.mdx
+++ b/website/docs/cli/cloud/settings.mdx
@@ -35,6 +35,7 @@ terraform {
     hostname = "app.terraform.io" # Optional; defaults to app.terraform.io
 
     workspaces {
+      project = "networking-development"
       tags = ["networking", "source:cli"]
     }
   }
@@ -75,6 +76,10 @@ The `cloud` block supports the following configuration arguments:
     directory, and cannot manage workspaces from the CLI (e.g. `terraform workspace select` or
     `terraform workspace new`). This option conflicts with `tags`.
 
+  - `project` - (Optional) The name of a Terraform Cloud project. Workspaces that need created will
+    will be created within this project. `terraform workspace list` will be filtered by workspaces
+    in the supplied project.
+
 - `hostname` - (Optional) The hostname of a Terraform Enterprise installation, if using Terraform
   Enterprise. Defaults to Terraform Cloud (app.terraform.io).
 
@@ -97,6 +102,8 @@ Use the following environment variables to configure the `cloud` block:
 - `TF_CLOUD_ORGANIZATION` - The name of the organization. Terraform reads this variable when `organization` omitted from the `cloud` block`. If both are specified, the configuration takes precedence.
 
 - `TF_CLOUD_HOSTNAME` - The hostname of a Terraform Enterprise installation. Terraform reads this when `hostname` is omitted from the `cloud` block. If both are specified, the configuration takes precedence.
+
+- `TF_CLOUD_PROJECT` - The name of a Terraform Cloud project. Terraform reads this when `workspaces.project` is omitted from the `cloud` block. If both are specified, the cloud block configuration takes precedence.
 
 - `TF_WORKSPACE` - The name of a single Terraform Cloud workspace. Terraform reads this when `workspaces` is omitted from the `cloud` block. Terraform Cloud will not create a new workspace from this variable; the workspace must exist in the specified organization. You can set `TF_WORKSPACE` if the `cloud` block uses tags. However, the value of `TF_WORKSPACE` must be included in the set of tags. This variable also selects the workspace in your local environment. Refer to [TF_WORKSPACE](/terraform/cli/config/environment-variables#tf_workspace) for details.
 


### PR DESCRIPTION
Adds project configuration to the workspaces section of the cloud block. Also configurable via the `TF_CLOUD_PROJECT` environment variable. When a project is configured, the following behaviors will occur:
- `terraform init` with workspaces.name configured will create the workspace in the given project
- `terraform workspace new <name>` with workspaces.tags configured will create workspaces in the given project
- `terraform workspace list` will list workspaces only from the given project

The following behaviors are NOT affected by project configuration
- `terraform workspace delete <name>` does not validate the workspace's inclusion in the given project
- When initializing a workspace that already exists in Terraform Cloud, the workspace's parent project is NOT validated against the given project

Adds tests for cloud block configuration of project 
Update changelog
Update docs


## Target Release


1.6.x

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

### ENHANCEMENTS
* cloud: Terraform now supports setting the Terraform Cloud project via the cloud block and `TF_CLOUD_PROJECT` environment variable. When a cloud configuration creates a new workspace it will be created in the given project. If the project does not exist it will be created. `terraform workspace list` will also respect listing matching workspaces in the configured project.

