### PR TITLE
docs: Fix typo in connection.mdx

### DIFF
--- a/website/docs/language/resources/provisioners/connection.mdx
+++ b/website/docs/language/resources/provisioners/connection.mdx
@@ -72,7 +72,7 @@ Expressions in `connection` blocks cannot refer to their parent resource by name
 
 ### Argument Reference
 
-The `connection` block supports the following argments. Some arguments are only supported by either the SSH or the WinRM connection type.
+The `connection` block supports the following arguments. Some arguments are only supported by either the SSH or the WinRM connection type.
 
 
 | Argument | Connection Type | Description | Default |


### PR DESCRIPTION
Just a small fix in documentation file `connection.mdx`