### PR TITLE
Make flaky 'TestTest_DoubleInterrupt' test more robust

### DIFF
--- a/internal/command/test_test.go
+++ b/internal/command/test_test.go
@@ -191,7 +191,7 @@ func TestTest_DoubleInterrupt(t *testing.T) {
 	c.Run(nil)
 	output := done(t).All()
 
-	if !strings.Contains(output, "Terraform Test Interrupted") {
+	if !strings.Contains(output, "Two interrupts received") {
 		t.Errorf("output didn't produce the right output:\n\n%s", output)
 	}
 


### PR DESCRIPTION
This test is attempting to check the interrupt behaviour works as expected.

It has failed on at least one execution in `main`: https://github.com/hashicorp/terraform/actions/runs/5511524526/jobs/10047189970

I think there's a race condition in there in which the order of execution might affect the output. I've modified the piece of text the test is looking into something that is rendered by the framework before the cancellation process is started so it is something that should be displayed every time.

I do have some more work to do on the interrupts so I'll look at the tests again as part of that. This should be an acceptable short term fix in the mean time.