### PR TITLE
testing framework: finalise 'expected_failures' functionality

### DIFF
--- a/internal/command/test.go
+++ b/internal/command/test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/hashicorp/hcl/v2"
 
+	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/backend"
 	"github.com/hashicorp/terraform/internal/command/arguments"
 	"github.com/hashicorp/terraform/internal/command/views"
@@ -299,6 +300,7 @@ func (runner *TestRunner) ExecuteTestRun(run *moduletest.Run, file *moduletest.F
 		SkipRefresh:        !run.Config.Options.Refresh,
 		ExternalReferences: references,
 	}, run.Config.Command)
+	diags = run.ValidateExpectedFailures(diags)
 	run.Diagnostics = run.Diagnostics.Append(diags)
 
 	if runner.Cancelled {
@@ -413,6 +415,19 @@ func (runner *TestRunner) execute(run *moduletest.Run, file *moduletest.File, co
 		// stop the plan being applied and using more time.
 		return tfCtx, plan, state, diags
 	}
+
+	// We're also going to strip out any warnings from check blocks, as we do
+	// for normal executions. Since we're going to go ahead and execute the
+	// plan immediately, any warnings from the check block are just not relevant
+	// any more.
+	var filteredDiags tfdiags.Diagnostics
+	for _, diag := range diags {
+		if rule, ok := addrs.DiagnosticOriginatesFromCheckRule(diag); ok && rule.Container.CheckableKind() == addrs.CheckableCheck {
+			continue
+		}
+		filteredDiags = filteredDiags.Append(diag)
+	}
+	diags = filteredDiags
 
 	// Fourth, execute apply stage.
 	tfCtx, ctxDiags = terraform.NewContext(tfCtxOpts)

--- a/internal/command/test_test.go
+++ b/internal/command/test_test.go
@@ -49,30 +49,18 @@ func TestTest(t *testing.T) {
 		"expect_failures_checks": {
 			expected: "1 passed, 0 failed.",
 			code:     0,
-			// TODO(liamcervante): Enable this when support for expect_failures
-			//   has been added.
-			skip: true,
 		},
 		"expect_failures_inputs": {
 			expected: "1 passed, 0 failed.",
 			code:     0,
-			// TODO(liamcervante): Enable this when support for expect_failures
-			//   has been added.
-			skip: true,
 		},
 		"expect_failures_outputs": {
 			expected: "1 passed, 0 failed.",
 			code:     0,
-			// TODO(liamcervante): Enable this when support for expect_failures
-			//   has been added.
-			skip: true,
 		},
 		"expect_failures_resources": {
 			expected: "1 passed, 0 failed.",
 			code:     0,
-			// TODO(liamcervante): Enable this when support for expect_failures
-			//   has been added.
-			skip: true,
 		},
 		"simple_fail": {
 			expected: "0 passed, 1 failed.",
@@ -81,10 +69,6 @@ func TestTest(t *testing.T) {
 		"custom_condition_checks": {
 			expected: "0 passed, 1 failed.",
 			code:     1,
-			// TODO(liamcervante): Enable this, at the moment checks aren't
-			//   causing the tests to fail when they should. Also, it's not
-			//   skipping warnings during the plan when it should.
-			skip: true,
 		},
 		"custom_condition_inputs": {
 			expected: "0 passed, 1 failed.",

--- a/internal/command/testdata/test/expect_failures_resources/main.tftest
+++ b/internal/command/testdata/test/expect_failures_resources/main.tftest
@@ -3,12 +3,6 @@ variables {
 }
 
 run "test" {
-
-  assert {
-    condition = test_resource.resource.value == "some value"
-    error_message = "since we used a postcondition, it should still have actually created the resource"
-  }
-
   expect_failures = [
     test_resource.resource
   ]

--- a/internal/terraform/eval_variable.go
+++ b/internal/terraform/eval_variable.go
@@ -242,7 +242,7 @@ func evalVariableValidations(addr addrs.AbsInputVariableInstance, config *config
 	}
 
 	for ix, validation := range config.Validations {
-		result, ruleDiags := evalVariableValidation(validation, hclCtx, addr, config, expr)
+		result, ruleDiags := evalVariableValidation(validation, hclCtx, addr, config, expr, ix)
 		diags = diags.Append(ruleDiags)
 
 		log.Printf("[TRACE] evalVariableValidations: %s status is now %s", addr, result.Status)
@@ -256,7 +256,7 @@ func evalVariableValidations(addr addrs.AbsInputVariableInstance, config *config
 	return diags
 }
 
-func evalVariableValidation(validation *configs.CheckRule, hclCtx *hcl.EvalContext, addr addrs.AbsInputVariableInstance, config *configs.Variable, expr hcl.Expression) (checkResult, tfdiags.Diagnostics) {
+func evalVariableValidation(validation *configs.CheckRule, hclCtx *hcl.EvalContext, addr addrs.AbsInputVariableInstance, config *configs.Variable, expr hcl.Expression, ix int) (checkResult, tfdiags.Diagnostics) {
 	const errInvalidCondition = "Invalid variable validation result"
 	const errInvalidValue = "Invalid value for variable"
 	var diags tfdiags.Diagnostics
@@ -404,6 +404,9 @@ You can correct this by removing references to sensitive values, or by carefully
 			Subject:     expr.Range().Ptr(),
 			Expression:  validation.Condition,
 			EvalContext: hclCtx,
+			Extra: &addrs.CheckRuleDiagnosticExtra{
+				CheckRule: addr.CheckRule(addrs.InputValidation, ix),
+			},
 		})
 	} else {
 		// Since we don't have a source expression for a root module
@@ -416,6 +419,9 @@ You can correct this by removing references to sensitive values, or by carefully
 			Subject:     config.DeclRange.Ptr(),
 			Expression:  validation.Condition,
 			EvalContext: hclCtx,
+			Extra: &addrs.CheckRuleDiagnosticExtra{
+				CheckRule: addr.CheckRule(addrs.InputValidation, ix),
+			},
 		})
 	}
 


### PR DESCRIPTION
This PR finishes up the `expect_failures` functionality for the new testing framework.

I previously did most of the work in #33443, and onboarded input variables into the checkable objects framework in #33481. With those 2 PRs merged, and any queued PRs modifying the test command also merged I can finish the functionality now.

This PR:
1. Removes check block warnings from the set of diagnostics produced by the plan when the testing framework is performing an apply command. This matches the behaviour in the main Terraform program, and keeps the outputs simpler for users.
2. Updates the diagnostics produced by input validation to attach the `CheckRuleDiagnosticExtra` structure, this is only possible now as input validation matches the behaviour of other checkable objects.
3. Updates the `ValidateExpectedFailures` function so that it also processes input variables by looking at the extra information now attached to them.
4. Finally, it connects the `ValidateExpectedFailures` function back into the Terraform `test` command, and updates all the skipped tests that were waiting for this.