### PR TITLE
S3 Backend: Converts from `legacy/helper/schema` to `configschema`

### DIFF
--- a/internal/backend/remote-state/s3/backend.go
+++ b/internal/backend/remote-state/s3/backend.go
@@ -217,6 +217,16 @@ func (b *Backend) PrepareConfig(obj cty.Value) (cty.Value, tfdiags.Diagnostics) 
 		return obj, diags
 	}
 
+	if val := obj.GetAttr("bucket"); val.IsNull() || val.AsString() == "" {
+		diags = diags.Append(tfdiags.AttributeValue(
+			tfdiags.Error,
+			"Invalid bucket value",
+			// `The "bucket" attribute value must not be empty.`,
+			`"bucket": required field is not set`,
+			cty.Path{cty.GetAttrStep{Name: "bucket"}},
+		))
+	}
+
 	if val := obj.GetAttr("key"); val.IsNull() || val.AsString() == "" {
 		diags = diags.Append(tfdiags.AttributeValue(
 			tfdiags.Error,
@@ -237,7 +247,7 @@ func (b *Backend) PrepareConfig(obj cty.Value) (cty.Value, tfdiags.Diagnostics) 
 		))
 	}
 
-	if val := obj.GetAttr("region"); val.IsNull() {
+	if val := obj.GetAttr("region"); val.IsNull() || val.AsString() == "" {
 		if os.Getenv("AWS_REGION") == "" && os.Getenv("AWS_DEFAULT_REGION") == "" {
 			diags = diags.Append(tfdiags.AttributeValue(
 				tfdiags.Error,

--- a/internal/backend/remote-state/s3/backend.go
+++ b/internal/backend/remote-state/s3/backend.go
@@ -334,7 +334,6 @@ func (b *Backend) Configure(obj cty.Value) tfdiags.Diagnostics {
 	b.kmsKeyID = stringAttr(obj, "kms_key_id")
 	b.ddbTable = stringAttr(obj, "dynamodb_table")
 
-	// WarnOnEmptyString(), LenEquals(44), IsBase64Encoded()
 	if customerKey, ok := stringAttrOk(obj, "sse_customer_key"); ok {
 		if len(customerKey) != 44 {
 			diags = diags.Append(tfdiags.AttributeValue(

--- a/internal/backend/remote-state/s3/backend.go
+++ b/internal/backend/remote-state/s3/backend.go
@@ -314,7 +314,7 @@ func (b *Backend) Configure(obj cty.Value) tfdiags.Diagnostics {
 		region = v
 	}
 
-	if boolAttr(obj, "skip_region_validation") {
+	if region != "" && !boolAttr(obj, "skip_region_validation") {
 		if err := awsbase.ValidateRegion(region); err != nil {
 			diags = diags.Append(tfdiags.AttributeValue(
 				tfdiags.Error,

--- a/internal/backend/remote-state/s3/backend.go
+++ b/internal/backend/remote-state/s3/backend.go
@@ -130,15 +130,15 @@ func (b *Backend) ConfigSchema() *configschema.Block {
 				Optional:    true,
 				Description: "Skip the credentials validation via STS API.",
 			},
-			"skip_region_validation": {
-				Type:        cty.Bool,
-				Optional:    true,
-				Description: "Skip static validation of region name.",
-			},
 			"skip_metadata_api_check": {
 				Type:        cty.Bool,
 				Optional:    true,
 				Description: "Skip the AWS Metadata API check.",
+			},
+			"skip_region_validation": {
+				Type:        cty.Bool,
+				Optional:    true,
+				Description: "Skip static validation of region name.",
 			},
 			"sse_customer_key": {
 				Type:        cty.String,

--- a/internal/backend/remote-state/s3/backend.go
+++ b/internal/backend/remote-state/s3/backend.go
@@ -279,6 +279,8 @@ func (b *Backend) PrepareConfig(obj cty.Value) (cty.Value, tfdiags.Diagnostics) 
 				cty.Path{},
 			))
 		}
+
+		diags = diags.Append(validateKMSKey(cty.Path{cty.GetAttrStep{Name: "kms_key_id"}}, val.AsString()))
 	}
 
 	if val := obj.GetAttr("workspace_key_prefix"); !val.IsNull() {

--- a/internal/backend/remote-state/s3/backend.go
+++ b/internal/backend/remote-state/s3/backend.go
@@ -126,7 +126,7 @@ func (b *Backend) ConfigSchema() *configschema.Block {
 				Description: "MFA token",
 			},
 			"skip_credentials_validation": {
-				Type:        cty.String,
+				Type:        cty.Bool,
 				Optional:    true,
 				Description: "Skip the credentials validation via STS API.",
 			},

--- a/internal/backend/remote-state/s3/backend_state.go
+++ b/internal/backend/remote-state/s3/backend_state.go
@@ -203,10 +203,6 @@ func (b *Backend) StateMgr(name string) (statemgr.Full, error) {
 	return stateMgr, nil
 }
 
-func (b *Backend) client() *RemoteClient {
-	return &RemoteClient{}
-}
-
 func (b *Backend) path(name string) string {
 	if name == backend.DefaultStateName {
 		return b.keyName

--- a/internal/backend/remote-state/s3/backend_test.go
+++ b/internal/backend/remote-state/s3/backend_test.go
@@ -614,11 +614,17 @@ func TestBackendConfig_PrepareConfigValidation(t *testing.T) {
 			b := New()
 
 			_, valDiags := b.PrepareConfig(populateSchema(t, b.ConfigSchema(), tc.config))
-			if valDiags.Err() != nil && tc.expectedErr != "" {
-				actualErr := valDiags.Err().Error()
-				if !strings.Contains(actualErr, tc.expectedErr) {
-					t.Fatalf("unexpected validation result: %v", valDiags.Err())
+			if tc.expectedErr != "" {
+				if valDiags.Err() != nil {
+					actualErr := valDiags.Err().Error()
+					if !strings.Contains(actualErr, tc.expectedErr) {
+						t.Fatalf("unexpected validation result: %v", valDiags.Err())
+					}
+				} else {
+					t.Fatal("expected an error, got none")
 				}
+			} else if valDiags.Err() != nil {
+				t.Fatalf("expected no error, got %s", valDiags.Err())
 			}
 		})
 	}
@@ -666,11 +672,17 @@ func TestBackendConfig_PrepareConfigWithEnvVars(t *testing.T) {
 			})
 
 			_, valDiags := b.PrepareConfig(populateSchema(t, b.ConfigSchema(), tc.config))
-			if valDiags.Err() != nil && tc.expectedErr != "" {
-				actualErr := valDiags.Err().Error()
-				if !strings.Contains(actualErr, tc.expectedErr) {
-					t.Fatalf("unexpected validation result: %v", valDiags.Err())
+			if tc.expectedErr != "" {
+				if valDiags.Err() != nil {
+					actualErr := valDiags.Err().Error()
+					if !strings.Contains(actualErr, tc.expectedErr) {
+						t.Fatalf("unexpected validation result: %v", valDiags.Err())
+					}
+				} else {
+					t.Fatal("expected an error, got none")
 				}
+			} else if valDiags.Err() != nil {
+				t.Fatalf("expected no error, got %s", valDiags.Err())
 			}
 		})
 	}

--- a/internal/backend/remote-state/s3/backend_test.go
+++ b/internal/backend/remote-state/s3/backend_test.go
@@ -1038,7 +1038,9 @@ func TestBackendExtraPaths(t *testing.T) {
 
 	// Write the first state
 	stateMgr := &remote.State{Client: client}
-	stateMgr.WriteState(s1)
+	if err := stateMgr.WriteState(s1); err != nil {
+		t.Fatal(err)
+	}
 	if err := stateMgr.PersistState(nil); err != nil {
 		t.Fatal(err)
 	}
@@ -1048,7 +1050,9 @@ func TestBackendExtraPaths(t *testing.T) {
 	// states are equal, the state will not Put to the remote
 	client.path = b.path("s2")
 	stateMgr2 := &remote.State{Client: client}
-	stateMgr2.WriteState(s2)
+	if err := stateMgr2.WriteState(s2); err != nil {
+		t.Fatal(err)
+	}
 	if err := stateMgr2.PersistState(nil); err != nil {
 		t.Fatal(err)
 	}
@@ -1061,7 +1065,9 @@ func TestBackendExtraPaths(t *testing.T) {
 
 	// put a state in an env directory name
 	client.path = b.workspaceKeyPrefix + "/error"
-	stateMgr.WriteState(states.NewState())
+	if err := stateMgr.WriteState(states.NewState()); err != nil {
+		t.Fatal(err)
+	}
 	if err := stateMgr.PersistState(nil); err != nil {
 		t.Fatal(err)
 	}
@@ -1071,7 +1077,9 @@ func TestBackendExtraPaths(t *testing.T) {
 
 	// add state with the wrong key for an existing env
 	client.path = b.workspaceKeyPrefix + "/s2/notTestState"
-	stateMgr.WriteState(states.NewState())
+	if err := stateMgr.WriteState(states.NewState()); err != nil {
+		t.Fatal(err)
+	}
 	if err := stateMgr.PersistState(nil); err != nil {
 		t.Fatal(err)
 	}
@@ -1105,12 +1113,14 @@ func TestBackendExtraPaths(t *testing.T) {
 	if s2Mgr.(*remote.State).StateSnapshotMeta().Lineage == s2Lineage {
 		t.Fatal("state s2 was not deleted")
 	}
-	s2 = s2Mgr.State()
+	_ = s2Mgr.State() // We need the side-effect
 	s2Lineage = stateMgr.StateSnapshotMeta().Lineage
 
 	// add a state with a key that matches an existing environment dir name
 	client.path = b.workspaceKeyPrefix + "/s2/"
-	stateMgr.WriteState(states.NewState())
+	if err := stateMgr.WriteState(states.NewState()); err != nil {
+		t.Fatal(err)
+	}
 	if err := stateMgr.PersistState(nil); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/backend/remote-state/s3/backend_test.go
+++ b/internal/backend/remote-state/s3/backend_test.go
@@ -503,7 +503,7 @@ func TestBackendConfig_PrepareConfigValidation(t *testing.T) {
 				"key":    cty.StringVal("test"),
 				"region": cty.StringVal("us-west-2"),
 			}),
-			expectedErr: `"bucket": required field is not set`,
+			expectedErr: `The "bucket" attribute value must not be empty.`,
 		},
 		"empty bucket": {
 			config: cty.ObjectVal(map[string]cty.Value{
@@ -511,7 +511,7 @@ func TestBackendConfig_PrepareConfigValidation(t *testing.T) {
 				"key":    cty.StringVal("test"),
 				"region": cty.StringVal("us-west-2"),
 			}),
-			expectedErr: `"bucket": required field is not set`,
+			expectedErr: `The "bucket" attribute value must not be empty.`,
 		},
 		"null key": {
 			config: cty.ObjectVal(map[string]cty.Value{
@@ -519,7 +519,7 @@ func TestBackendConfig_PrepareConfigValidation(t *testing.T) {
 				"key":    cty.NullVal(cty.String),
 				"region": cty.StringVal("us-west-2"),
 			}),
-			expectedErr: `"key": required field is not set`,
+			expectedErr: `The "key" attribute value must not be empty.`,
 		},
 		"empty key": {
 			config: cty.ObjectVal(map[string]cty.Value{
@@ -527,7 +527,7 @@ func TestBackendConfig_PrepareConfigValidation(t *testing.T) {
 				"key":    cty.StringVal(""),
 				"region": cty.StringVal("us-west-2"),
 			}),
-			expectedErr: `"key": required field is not set`,
+			expectedErr: `The "key" attribute value must not be empty.`,
 		},
 		"key with leading slash": {
 			config: cty.ObjectVal(map[string]cty.Value{
@@ -535,7 +535,7 @@ func TestBackendConfig_PrepareConfigValidation(t *testing.T) {
 				"key":    cty.StringVal("/leading-slash"),
 				"region": cty.StringVal("us-west-2"),
 			}),
-			expectedErr: `key must not start or end with '/'`,
+			expectedErr: `The "key" attribute value must not start or end with with "/".`,
 		},
 		"key with trailing slash": {
 			config: cty.ObjectVal(map[string]cty.Value{
@@ -543,7 +543,7 @@ func TestBackendConfig_PrepareConfigValidation(t *testing.T) {
 				"key":    cty.StringVal("trailing-slash/"),
 				"region": cty.StringVal("us-west-2"),
 			}),
-			expectedErr: `key must not start or end with '/'`,
+			expectedErr: `The "key" attribute value must not start or end with with "/".`,
 		},
 		"null region": {
 			config: cty.ObjectVal(map[string]cty.Value{
@@ -551,7 +551,7 @@ func TestBackendConfig_PrepareConfigValidation(t *testing.T) {
 				"key":    cty.StringVal("test"),
 				"region": cty.NullVal(cty.String),
 			}),
-			expectedErr: `"region": required field is not set`,
+			expectedErr: `The "region" attribute or the "AWS_REGION" or "AWS_DEFAULT_REGION" environment variables must be set.`,
 		},
 		"empty region": {
 			config: cty.ObjectVal(map[string]cty.Value{
@@ -559,7 +559,7 @@ func TestBackendConfig_PrepareConfigValidation(t *testing.T) {
 				"key":    cty.StringVal("test"),
 				"region": cty.StringVal(""),
 			}),
-			expectedErr: `"region": required field is not set`,
+			expectedErr: `The "region" attribute or the "AWS_REGION" or "AWS_DEFAULT_REGION" environment variables must be set.`,
 		},
 		"workspace_key_prefix with leading slash": {
 			config: cty.ObjectVal(map[string]cty.Value{
@@ -568,7 +568,7 @@ func TestBackendConfig_PrepareConfigValidation(t *testing.T) {
 				"region":               cty.StringVal("us-west-2"),
 				"workspace_key_prefix": cty.StringVal("/env"),
 			}),
-			expectedErr: `workspace_key_prefix must not start or end with '/'`,
+			expectedErr: `The "workspace_key_prefix" attribute value must not start with "/".`,
 		},
 		"workspace_key_prefix with trailing slash": {
 			config: cty.ObjectVal(map[string]cty.Value{
@@ -577,7 +577,7 @@ func TestBackendConfig_PrepareConfigValidation(t *testing.T) {
 				"region":               cty.StringVal("us-west-2"),
 				"workspace_key_prefix": cty.StringVal("env/"),
 			}),
-			expectedErr: `workspace_key_prefix must not start or end with '/'`,
+			expectedErr: `The "workspace_key_prefix" attribute value must not start with "/".`,
 		},
 		"encyrption key conflict": {
 			config: cty.ObjectVal(map[string]cty.Value{

--- a/internal/backend/remote-state/s3/backend_test.go
+++ b/internal/backend/remote-state/s3/backend_test.go
@@ -584,7 +584,7 @@ func TestBackendConfig_PrepareConfigValidation(t *testing.T) {
 				"bucket":               cty.StringVal("test"),
 				"key":                  cty.StringVal("test"),
 				"region":               cty.StringVal("us-west-2"),
-				"workspace_key_prefix": cty.StringVal("env/"),
+				"workspace_key_prefix": cty.StringVal("env"),
 				"sse_customer_key":     cty.StringVal("1hwbcNPGWL+AwDiyGmRidTWAEVmCWMKbEHA+Es8w75o="),
 				"kms_key_id":           cty.StringVal("arn:aws:kms:us-west-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab"),
 			}),
@@ -641,6 +641,19 @@ func TestBackendConfig_PrepareConfigWithEnvVars(t *testing.T) {
 			vars: map[string]string{
 				"AWS_DEFAULT_REGION": "us-west-1",
 			},
+		},
+		"encyrption key conflict": {
+			config: cty.ObjectVal(map[string]cty.Value{
+				"bucket":               cty.StringVal("test"),
+				"key":                  cty.StringVal("test"),
+				"region":               cty.StringVal("us-west-2"),
+				"workspace_key_prefix": cty.StringVal("env"),
+				"kms_key_id":           cty.StringVal("arn:aws:kms:us-west-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab"),
+			}),
+			vars: map[string]string{
+				"AWS_SSE_CUSTOMER_KEY": "1hwbcNPGWL+AwDiyGmRidTWAEVmCWMKbEHA+Es8w75o=",
+			},
+			expectedErr: `Only one of "kms_key_id" and the environment variable "AWS_SSE_CUSTOMER_KEY" can be set`,
 		},
 	}
 
@@ -789,11 +802,11 @@ func TestBackendSSECustomerKeyEnvVar(t *testing.T) {
 	}{
 		"invalid length": {
 			customerKey: "test",
-			expectedErr: `AWS_SSE_CUSTOMER_KEY must be 44 characters in length`,
+			expectedErr: `The environment variable "AWS_SSE_CUSTOMER_KEY" must be 44 characters in length`,
 		},
 		"invalid encoding": {
 			customerKey: "====CT70aTYB2JGff7AjQtwbiLkwH4npICay1PWtmdka",
-			expectedErr: `AWS_SSE_CUSTOMER_KEY must be base64 encoded`,
+			expectedErr: `The environment variable "AWS_SSE_CUSTOMER_KEY" must be base64 encoded`,
 		},
 		"valid": {
 			customerKey: "4Dm1n4rphuFgawxuzY/bEfvLf6rYK0gIjfaDSLlfXNk=",

--- a/internal/backend/remote-state/s3/testing.go
+++ b/internal/backend/remote-state/s3/testing.go
@@ -18,11 +18,7 @@ func diagnosticComparer(l, r tfdiags.Diagnostic) bool {
 	if len(lp) != len(rp) {
 		return false
 	}
-	if !lp.Equals(rp) {
-		return false
-	}
-
-	return true
+	return lp.Equals(rp)
 }
 
 // diagnosticSummaryComparer is a Comparer function for use with cmp.Diff to compare
@@ -34,9 +30,5 @@ func diagnosticSummaryComparer(l, r tfdiags.Diagnostic) bool {
 
 	ld := l.Description()
 	rd := r.Description()
-	if ld.Summary != rd.Summary {
-		return false
-	}
-
-	return true
+	return ld.Summary == rd.Summary
 }

--- a/internal/backend/remote-state/s3/testing.go
+++ b/internal/backend/remote-state/s3/testing.go
@@ -24,3 +24,19 @@ func diagnosticComparer(l, r tfdiags.Diagnostic) bool {
 
 	return true
 }
+
+// diagnosticSummaryComparer is a Comparer function for use with cmp.Diff to compare
+// the Severity and Summary fields two tfdiags.Diagnostic values
+func diagnosticSummaryComparer(l, r tfdiags.Diagnostic) bool {
+	if l.Severity() != r.Severity() {
+		return false
+	}
+
+	ld := l.Description()
+	rd := r.Description()
+	if ld.Summary != rd.Summary {
+		return false
+	}
+
+	return true
+}

--- a/internal/backend/remote-state/s3/testing.go
+++ b/internal/backend/remote-state/s3/testing.go
@@ -1,0 +1,26 @@
+package s3
+
+import (
+	"github.com/hashicorp/terraform/internal/tfdiags"
+)
+
+// diagnosticComparer is a Comparer function for use with cmp.Diff to compare two tfdiags.Diagnostic values
+func diagnosticComparer(l, r tfdiags.Diagnostic) bool {
+	if l.Severity() != r.Severity() {
+		return false
+	}
+	if l.Description() != r.Description() {
+		return false
+	}
+
+	lp := tfdiags.GetAttribute(l)
+	rp := tfdiags.GetAttribute(r)
+	if len(lp) != len(rp) {
+		return false
+	}
+	if !lp.Equals(rp) {
+		return false
+	}
+
+	return true
+}

--- a/internal/backend/remote-state/s3/validate.go
+++ b/internal/backend/remote-state/s3/validate.go
@@ -37,7 +37,8 @@ func validateKMSKeyID(path cty.Path, s string) (diags tfdiags.Diagnostics) {
 }
 
 func validateKMSKeyARN(path cty.Path, s string) (diags tfdiags.Diagnostics) {
-	if _, err := arn.Parse(s); err != nil {
+	parsedARN, err := arn.Parse(s)
+	if err != nil {
 		diags = diags.Append(tfdiags.AttributeValue(
 			tfdiags.Error,
 			"Invalid KMS Key ARN",
@@ -47,7 +48,7 @@ func validateKMSKeyARN(path cty.Path, s string) (diags tfdiags.Diagnostics) {
 		return diags
 	}
 
-	if !isKeyARN(s) {
+	if !isKeyARN(parsedARN) {
 		diags = diags.Append(tfdiags.AttributeValue(
 			tfdiags.Error,
 			"Invalid KMS Key ARN",
@@ -60,13 +61,8 @@ func validateKMSKeyARN(path cty.Path, s string) (diags tfdiags.Diagnostics) {
 	return diags
 }
 
-func isKeyARN(s string) bool {
-	parsedARN, err := arn.Parse(s)
-	if err != nil {
-		return false
-	}
-
-	return keyIdFromARNResource(parsedARN.Resource) != ""
+func isKeyARN(arn arn.ARN) bool {
+	return keyIdFromARNResource(arn.Resource) != ""
 }
 
 func keyIdFromARNResource(s string) string {

--- a/internal/backend/remote-state/s3/validate.go
+++ b/internal/backend/remote-state/s3/validate.go
@@ -1,0 +1,80 @@
+package s3
+
+import (
+	"fmt"
+	"regexp"
+
+	"github.com/aws/aws-sdk-go/aws/arn"
+	"github.com/hashicorp/terraform/internal/tfdiags"
+	"github.com/zclconf/go-cty/cty"
+)
+
+const (
+	multiRegionKeyIdPattern = `mrk-[a-f0-9]{32}`
+	uuidRegexPattern        = `[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[ab89][a-f0-9]{3}-[a-f0-9]{12}`
+)
+
+func validateKMSKey(path cty.Path, s string) (diags tfdiags.Diagnostics) {
+	if arn.IsARN(s) {
+		return validateKMSKeyARN(path, s)
+	}
+	return validateKMSKeyID(path, s)
+}
+
+func validateKMSKeyID(path cty.Path, s string) (diags tfdiags.Diagnostics) {
+	keyIdRegex := regexp.MustCompile(`^` + uuidRegexPattern + `|` + multiRegionKeyIdPattern + `$`)
+	if !keyIdRegex.MatchString(s) {
+		diags = diags.Append(tfdiags.AttributeValue(
+			tfdiags.Error,
+			"Invalid KMS Key ID",
+			fmt.Sprintf("Value must be a valid KMS Key ID, got %q", s),
+			path,
+		))
+		return diags
+	}
+
+	return diags
+}
+
+func validateKMSKeyARN(path cty.Path, s string) (diags tfdiags.Diagnostics) {
+	if _, err := arn.Parse(s); err != nil {
+		diags = diags.Append(tfdiags.AttributeValue(
+			tfdiags.Error,
+			"Invalid KMS Key ARN",
+			fmt.Sprintf("Value must be a valid KMS Key ARN, got %q", s),
+			path,
+		))
+		return diags
+	}
+
+	if !isKeyARN(s) {
+		diags = diags.Append(tfdiags.AttributeValue(
+			tfdiags.Error,
+			"Invalid KMS Key ARN",
+			fmt.Sprintf("Value must be a valid KMS Key ARN, got %q", s),
+			path,
+		))
+		return diags
+	}
+
+	return diags
+}
+
+func isKeyARN(s string) bool {
+	parsedARN, err := arn.Parse(s)
+	if err != nil {
+		return false
+	}
+
+	return keyIdFromARNResource(parsedARN.Resource) != ""
+}
+
+func keyIdFromARNResource(s string) string {
+	keyIdResourceRegex := regexp.MustCompile(`^key/(` + uuidRegexPattern + `|` + multiRegionKeyIdPattern + `)$`)
+	matches := keyIdResourceRegex.FindStringSubmatch(s)
+	if matches == nil || len(matches) != 2 {
+		return ""
+	}
+
+	return matches[1]
+}

--- a/internal/backend/remote-state/s3/validate_test.go
+++ b/internal/backend/remote-state/s3/validate_test.go
@@ -1,0 +1,154 @@
+package s3
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform/internal/tfdiags"
+	"github.com/zclconf/go-cty/cty"
+)
+
+func TestValidateKMSKey(t *testing.T) {
+	t.Parallel()
+
+	path := cty.Path{cty.GetAttrStep{Name: "field"}}
+
+	testcases := map[string]struct {
+		in       string
+		expected tfdiags.Diagnostics
+	}{
+		"kms key id": {
+			in: "57ff7a43-341d-46b6-aee3-a450c9de6dc8",
+		},
+		"kms key arn": {
+			in: "arn:aws:kms:us-west-2:111122223333:key/57ff7a43-341d-46b6-aee3-a450c9de6dc8",
+		},
+		"kms multi-region key id": {
+			in: "mrk-f827515944fb43f9b902a09d2c8b554f",
+		},
+		"kms multi-region key arn": {
+			in: "arn:aws:kms:us-west-2:111122223333:key/mrk-a835af0b39c94b86a21a8fc9535df681",
+		},
+		"kms key alias": {
+			in: "alias/arbitrary-key",
+			expected: tfdiags.Diagnostics{
+				tfdiags.AttributeValue(
+					tfdiags.Error,
+					"Invalid KMS Key ID",
+					`Value must be a valid KMS Key ID, got "alias/arbitrary-key"`,
+					path,
+				),
+			},
+		},
+		"kms key alias arn": {
+			in: "arn:aws:kms:us-west-2:111122223333:alias/arbitrary-key",
+			expected: tfdiags.Diagnostics{
+				tfdiags.AttributeValue(
+					tfdiags.Error,
+					"Invalid KMS Key ARN",
+					`Value must be a valid KMS Key ARN, got "arn:aws:kms:us-west-2:111122223333:alias/arbitrary-key"`,
+					path,
+				),
+			},
+		},
+		"invalid key": {
+			in: "$%wrongkey",
+			expected: tfdiags.Diagnostics{
+				tfdiags.AttributeValue(
+					tfdiags.Error,
+					"Invalid KMS Key ID",
+					`Value must be a valid KMS Key ID, got "$%wrongkey"`,
+					path,
+				),
+			},
+		},
+		"non-kms arn": {
+			in: "arn:aws:lamda:foo:bar:key/xyz",
+			expected: tfdiags.Diagnostics{
+				tfdiags.AttributeValue(
+					tfdiags.Error,
+					"Invalid KMS Key ARN",
+					`Value must be a valid KMS Key ARN, got "arn:aws:lamda:foo:bar:key/xyz"`,
+					path,
+				),
+			},
+		},
+	}
+
+	for name, testcase := range testcases {
+		testcase := testcase
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			diags := validateKMSKey(path, testcase.in)
+
+			if diff := cmp.Diff(diags, testcase.expected, cmp.Comparer(diagnosticComparer)); diff != "" {
+				t.Errorf("unexpected diagnostics difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestValidateKeyARN(t *testing.T) {
+	t.Parallel()
+
+	path := cty.Path{cty.GetAttrStep{Name: "field"}}
+
+	testcases := map[string]struct {
+		in       string
+		expected tfdiags.Diagnostics
+	}{
+		"kms key id": {
+			in: "arn:aws:kms:us-west-2:123456789012:key/57ff7a43-341d-46b6-aee3-a450c9de6dc8",
+		},
+		"kms mrk key id": {
+			in: "arn:aws:kms:us-west-2:111122223333:key/mrk-a835af0b39c94b86a21a8fc9535df681",
+		},
+		"kms non-key id": {
+			in: "arn:aws:kms:us-west-2:123456789012:something/else",
+			expected: tfdiags.Diagnostics{
+				tfdiags.AttributeValue(
+					tfdiags.Error,
+					"Invalid KMS Key ARN",
+					`Value must be a valid KMS Key ARN, got "arn:aws:kms:us-west-2:123456789012:something/else"`,
+					path,
+				),
+			},
+		},
+		"non-kms arn": {
+			in: "arn:aws:iam::123456789012:user/David",
+			expected: tfdiags.Diagnostics{
+				tfdiags.AttributeValue(
+					tfdiags.Error,
+					"Invalid KMS Key ARN",
+					`Value must be a valid KMS Key ARN, got "arn:aws:iam::123456789012:user/David"`,
+					path,
+				),
+			},
+		},
+		"not an arn": {
+			in: "not an arn",
+			expected: tfdiags.Diagnostics{
+				tfdiags.AttributeValue(
+					tfdiags.Error,
+					"Invalid KMS Key ARN",
+					`Value must be a valid KMS Key ARN, got "not an arn"`,
+					path,
+				),
+			},
+		},
+	}
+
+	for name, testcase := range testcases {
+		testcase := testcase
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			diags := validateKMSKeyARN(path, testcase.in)
+
+			if diff := cmp.Diff(diags, testcase.expected, cmp.Comparer(diagnosticComparer)); diff != "" {
+				t.Errorf("unexpected diagnostics difference: %s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Convert S3 Backend implementation from `legacy/helper/schema` to `configschema` as part of modernization effort.

Relates #30443

## Target Release

This change should be invisible to practitioners

## Draft CHANGELOG entry

This change should be invisible to practitioners
