### PR TITLE
Added role_arn example usage to terraform_remote_state data source

### DIFF
--- a/website/docs/language/state/remote-state-data.mdx
+++ b/website/docs/language/state/remote-state-data.mdx
@@ -116,6 +116,36 @@ resource "aws_instance" "foo" {
 }
 ```
 
+### Example Usage (`remote` S3 Backend while assuming an IAM role)
+
+```hcl
+data "terraform_remote_state" "sso" {
+  backend = "s3"
+
+  config = {
+    encrypt      = true
+    bucket       = "<bucket name>"
+    key          = "<bucket key>"
+    region       = "us-west-2"
+    role_arn     = "arn:aws:iam::<account id>:role/TFStateRole"
+    session_name = "<session name>"
+    external_id  = "<external id>"
+  }
+}
+
+# Terraform >= 0.12
+resource "aws_instance" "foo" {
+  # ...
+  subnet_id = data.terraform_remote_state.vpc.outputs.subnet_id
+}
+
+# Terraform <= 0.11
+resource "aws_instance" "foo" {
+  # ...
+  subnet_id = "${data.terraform_remote_state.vpc.subnet_id}"
+}
+```
+
 ## Example Usage (`local` Backend)
 
 ```hcl

--- a/website/docs/language/state/remote-state-data.mdx
+++ b/website/docs/language/state/remote-state-data.mdx
@@ -119,7 +119,7 @@ resource "aws_instance" "foo" {
 ### Example Usage (`remote` S3 Backend while assuming an IAM role)
 
 ```hcl
-data "terraform_remote_state" "sso" {
+data "terraform_remote_state" "vpc" {
   backend = "s3"
 
   config = {


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

I had trouble finding an example of how to use a role_arn for reading the remote state in S3 using a role that had to be assumed. I thought this would make a good example in the documentation.

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Fixes #

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.5.x

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

### NEW FEATURES | UPGRADE NOTES | ENHANCEMENTS | BUG FIXES | EXPERIMENTS

<!--

Write a short description of the user-facing change. Examples:

- `terraform show -json`: Fixed crash with sensitive set values.
- When rendering a diff, Terraform now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 

-  
