### PR TITLE
Implement word wrapping in the terraform test view functions

### DIFF
--- a/internal/command/test_test.go
+++ b/internal/command/test_test.go
@@ -211,9 +211,11 @@ func TestTest_DoubleInterrupt(t *testing.T) {
 		t.Errorf("output didn't produce the right output:\n\n%s", output)
 	}
 
-	cleanupMessage := `Terraform was interrupted while executing main.tftest, and may not have performed the expected cleanup operations.
+	cleanupMessage := `Terraform was interrupted while executing main.tftest, and may not have
+performed the expected cleanup operations.
 
-Terraform has already created the following resources from the module under test:
+Terraform has already created the following resources from the module under
+test:
   - test_resource.primary
   - test_resource.secondary
   - test_resource.tertiary`

--- a/internal/command/views/test.go
+++ b/internal/command/views/test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/mitchellh/colorstring"
 
 	"github.com/hashicorp/terraform/internal/command/arguments"
+	"github.com/hashicorp/terraform/internal/command/format"
 	"github.com/hashicorp/terraform/internal/command/jsonformat"
 	"github.com/hashicorp/terraform/internal/command/jsonplan"
 	"github.com/hashicorp/terraform/internal/command/jsonprovider"
@@ -104,7 +105,7 @@ func (t *TestHuman) Conclusion(suite *moduletest.Suite) {
 
 	if suite.Status <= moduletest.Skip {
 		// Then no tests.
-		t.view.streams.Printf("Executed 0 tests")
+		t.view.streams.Print("Executed 0 tests")
 		if counts[moduletest.Skip] > 0 {
 			t.view.streams.Printf(", %d skipped.\n", counts[moduletest.Skip])
 		} else {
@@ -211,12 +212,12 @@ func (t *TestHuman) DestroySummary(diags tfdiags.Diagnostics, run *moduletest.Ru
 	}
 
 	if diags.HasErrors() {
-		t.view.streams.Eprintf("Terraform encountered an error destroying resources created while executing %s.\n", identifier)
+		t.view.streams.Eprint(format.WordWrap(fmt.Sprintf("Terraform encountered an error destroying resources created while executing %s.\n", identifier), t.view.errorColumns()))
 	}
 	t.Diagnostics(run, file, diags)
 
 	if state.HasManagedResourceInstanceObjects() {
-		t.view.streams.Eprintf("\nTerraform left the following resources in state after executing %s, they need to be cleaned up manually:\n", identifier)
+		t.view.streams.Eprint(format.WordWrap(fmt.Sprintf("\nTerraform left the following resources in state after executing %s, they need to be cleaned up manually:\n", identifier), t.view.errorColumns()))
 		for _, resource := range state.AllResourceInstanceObjectAddrs() {
 			if resource.DeposedKey != states.NotDeposed {
 				t.view.streams.Eprintf("  - %s (%s)\n", resource.Instance, resource.DeposedKey)
@@ -232,15 +233,15 @@ func (t *TestHuman) Diagnostics(_ *moduletest.Run, _ *moduletest.File, diags tfd
 }
 
 func (t *TestHuman) Interrupted() {
-	t.view.streams.Eprint(interrupted)
+	t.view.streams.Eprintln(format.WordWrap(interrupted, t.view.errorColumns()))
 }
 
 func (t *TestHuman) FatalInterrupt() {
-	t.view.streams.Eprint(fatalInterrupt)
+	t.view.streams.Eprintln(format.WordWrap(fatalInterrupt, t.view.errorColumns()))
 }
 
 func (t *TestHuman) FatalInterruptSummary(run *moduletest.Run, file *moduletest.File, existingStates map[*moduletest.Run]*states.State, created []*plans.ResourceInstanceChangeSrc) {
-	t.view.streams.Eprintf("\nTerraform was interrupted while executing %s, and may not have performed the expected cleanup operations.\n", file.Name)
+	t.view.streams.Eprint(format.WordWrap(fmt.Sprintf("\nTerraform was interrupted while executing %s, and may not have performed the expected cleanup operations.\n", file.Name), t.view.errorColumns()))
 
 	for run, state := range existingStates {
 		if state.Empty() {
@@ -250,7 +251,7 @@ func (t *TestHuman) FatalInterruptSummary(run *moduletest.Run, file *moduletest.
 
 		if run == nil {
 			// Then this is just the main state for the whole file.
-			t.view.streams.Eprintln("\nTerraform has already created the following resources from the module under test:")
+			t.view.streams.Eprint(format.WordWrap("\nTerraform has already created the following resources from the module under test:\n", t.view.errorColumns()))
 			for _, resource := range state.AllResourceInstanceObjectAddrs() {
 				if resource.DeposedKey != states.NotDeposed {
 					t.view.streams.Eprintf("  - %s (%s)\n", resource.Instance, resource.DeposedKey)
@@ -259,7 +260,7 @@ func (t *TestHuman) FatalInterruptSummary(run *moduletest.Run, file *moduletest.
 				t.view.streams.Eprintf("  - %s\n", resource.Instance)
 			}
 		} else {
-			t.view.streams.Eprintf("\nTerraform has already created the following resources for %s from %s:\n", run.Name, run.Config.Module.Source)
+			t.view.streams.Eprint(format.WordWrap(fmt.Sprintf("\nTerraform has already created the following resources for %q from %q:\n", run.Name, run.Config.Module.Source), t.view.errorColumns()))
 			for _, resource := range state.AllResourceInstanceObjectAddrs() {
 				if resource.DeposedKey != states.NotDeposed {
 					t.view.streams.Eprintf("  - %s (%s)\n", resource.Instance, resource.DeposedKey)
@@ -283,10 +284,10 @@ func (t *TestHuman) FatalInterruptSummary(run *moduletest.Run, file *moduletest.
 	if len(resources) > 0 {
 		module := "the module under test"
 		if run.Config.ConfigUnderTest != nil {
-			module = run.Config.Module.Source.String()
+			module = fmt.Sprintf("%q", run.Config.Module.Source.String())
 		}
 
-		t.view.streams.Eprintf("\nTerraform was in the process of creating the following resources for %s from %s, and they may not have been destroyed:\n", run.Name, module)
+		t.view.streams.Eprint(format.WordWrap(fmt.Sprintf("\nTerraform was in the process of creating the following resources for %q from %s, and they may not have been destroyed:\n", run.Name, module), t.view.errorColumns()))
 		for _, resource := range resources {
 			t.view.streams.Eprintf("  - %s\n", resource)
 		}

--- a/internal/command/views/test.go
+++ b/internal/command/views/test.go
@@ -217,7 +217,7 @@ func (t *TestHuman) DestroySummary(diags tfdiags.Diagnostics, run *moduletest.Ru
 	t.Diagnostics(run, file, diags)
 
 	if state.HasManagedResourceInstanceObjects() {
-		t.view.streams.Eprint(format.WordWrap(fmt.Sprintf("\nTerraform left the following resources in state after executing %s, they need to be cleaned up manually:\n", identifier), t.view.errorColumns()))
+		t.view.streams.Eprint(format.WordWrap(fmt.Sprintf("\nTerraform left the following resources in state after executing %s, and they need to be cleaned up manually:\n", identifier), t.view.errorColumns()))
 		for _, resource := range state.AllResourceInstanceObjectAddrs() {
 			if resource.DeposedKey != states.NotDeposed {
 				t.view.streams.Eprintf("  - %s (%s)\n", resource.Instance, resource.DeposedKey)

--- a/internal/command/views/test_test.go
+++ b/internal/command/views/test_test.go
@@ -844,7 +844,7 @@ some thing not very bad happened again
 `,
 			stderr: `
 Terraform left the following resources in state after executing main.tftest,
-they need to be cleaned up manually:
+and they need to be cleaned up manually:
   - test.bar
   - test.bar (0fcb640a)
   - test.foo
@@ -916,7 +916,7 @@ Error: first error
 this time it is very bad
 
 Terraform left the following resources in state after executing main.tftest,
-they need to be cleaned up manually:
+and they need to be cleaned up manually:
   - test.bar
   - test.bar (0fcb640a)
   - test.foo

--- a/internal/command/views/test_test.go
+++ b/internal/command/views/test_test.go
@@ -762,7 +762,8 @@ Warning: second warning
 
 some thing not very bad happened again
 `,
-			stderr: `Terraform encountered an error destroying resources created while executing main.tftest.
+			stderr: `Terraform encountered an error destroying resources created while executing
+main.tftest.
 
 Error: first error
 
@@ -776,7 +777,8 @@ this time it is very bad
 			run:   &moduletest.Run{Name: "run_block"},
 			file:  &moduletest.File{Name: "main.tftest"},
 			state: states.NewState(),
-			stderr: `Terraform encountered an error destroying resources created while executing main.tftest/run_block.
+			stderr: `Terraform encountered an error destroying resources created while executing
+main.tftest/run_block.
 
 Error: first error
 
@@ -841,7 +843,8 @@ Warning: second warning
 some thing not very bad happened again
 `,
 			stderr: `
-Terraform left the following resources in state after executing main.tftest, they need to be cleaned up manually:
+Terraform left the following resources in state after executing main.tftest,
+they need to be cleaned up manually:
   - test.bar
   - test.bar (0fcb640a)
   - test.foo
@@ -905,13 +908,15 @@ Warning: second warning
 
 some thing not very bad happened again
 `,
-			stderr: `Terraform encountered an error destroying resources created while executing main.tftest.
+			stderr: `Terraform encountered an error destroying resources created while executing
+main.tftest.
 
 Error: first error
 
 this time it is very bad
 
-Terraform left the following resources in state after executing main.tftest, they need to be cleaned up manually:
+Terraform left the following resources in state after executing main.tftest,
+they need to be cleaned up manually:
   - test.bar
   - test.bar (0fcb640a)
   - test.foo
@@ -985,9 +990,11 @@ func TestTestHuman_FatalInterruptSummary(t *testing.T) {
 				},
 			},
 			want: `
-Terraform was interrupted while executing main.tftest, and may not have performed the expected cleanup operations.
+Terraform was interrupted while executing main.tftest, and may not have
+performed the expected cleanup operations.
 
-Terraform was in the process of creating the following resources for run_block from the module under test, and they may not have been destroyed:
+Terraform was in the process of creating the following resources for
+"run_block" from the module under test, and they may not have been destroyed:
   - test_instance.one
   - test_instance.two
 `,
@@ -1026,9 +1033,11 @@ Terraform was in the process of creating the following resources for run_block f
 			},
 			created: nil,
 			want: `
-Terraform was interrupted while executing main.tftest, and may not have performed the expected cleanup operations.
+Terraform was interrupted while executing main.tftest, and may not have
+performed the expected cleanup operations.
 
-Terraform has already created the following resources from the module under test:
+Terraform has already created the following resources from the module under
+test:
   - test_instance.one
   - test_instance.two
 `,
@@ -1074,9 +1083,11 @@ Terraform has already created the following resources from the module under test
 			},
 			created: nil,
 			want: `
-Terraform was interrupted while executing main.tftest, and may not have performed the expected cleanup operations.
+Terraform was interrupted while executing main.tftest, and may not have
+performed the expected cleanup operations.
 
-Terraform has already created the following resources for setup_block from ../setup:
+Terraform has already created the following resources for "setup_block" from
+"../setup":
   - test_instance.one
   - test_instance.two
 `,
@@ -1186,17 +1197,21 @@ Terraform has already created the following resources for setup_block from ../se
 				Name:   "run_block",
 			},
 			want: `
-Terraform was interrupted while executing main.tftest, and may not have performed the expected cleanup operations.
+Terraform was interrupted while executing main.tftest, and may not have
+performed the expected cleanup operations.
 
-Terraform has already created the following resources for setup_block from ../setup:
+Terraform has already created the following resources for "setup_block" from
+"../setup":
   - test_instance.setup_one
   - test_instance.setup_two
 
-Terraform has already created the following resources from the module under test:
+Terraform has already created the following resources from the module under
+test:
   - test_instance.one
   - test_instance.two
 
-Terraform was in the process of creating the following resources for run_block from the module under test, and they may not have been destroyed:
+Terraform was in the process of creating the following resources for
+"run_block" from the module under test, and they may not have been destroyed:
   - test_instance.new_one
   - test_instance.new_two
 `,


### PR DESCRIPTION
This PR simply adds the `format.WordWrap` function around long lines of text produced by the `TestHuman` view struct used the test command.