### PR TITLE
Fix error message for Import block with blank ID

### DIFF
--- a/internal/configs/import.go
+++ b/internal/configs/import.go
@@ -32,7 +32,14 @@ func decodeImportBlock(block *hcl.Block) (*Import, hcl.Diagnostics) {
 	if attr, exists := content.Attributes["id"]; exists {
 		attrDiags := gohcl.DecodeExpression(attr.Expr, nil, &imp.ID)
 		diags = append(diags, attrDiags...)
-
+		if (len(imp.ID) == 0) {
+			diags = append(diags, &hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  "Import ID cannot be blank",
+				Detail:   "The id argument of the import block must be a non-empty string. Please see the resource documentation for how to find the import ID.",
+				Subject:  attr.Range.Ptr(),
+			})
+		}
 	}
 
 	if attr, exists := content.Attributes["to"]; exists {

--- a/internal/configs/import_test.go
+++ b/internal/configs/import_test.go
@@ -143,6 +143,29 @@ func TestImportBlock_decode(t *testing.T) {
 			},
 			"Missing required argument",
 		},
+		"error: blank id argument": {
+			&hcl.Block{
+				Type: "import",
+				Body: hcltest.MockBody(&hcl.BodyContent{
+					Attributes: hcl.Attributes{
+						"to": {
+							Name: "to",
+							Expr: bar_expr,
+						},
+						"id": {
+							Name: "id",
+							Expr: blank_str_expr,
+						},
+					},
+				}),
+				DefRange: blockRange,
+			},
+			&Import{
+				ID:        mustAbsResourceInstanceAddr("test_instance.bar"),
+				DeclRange: blockRange,
+			},
+			"id argument is blank",
+		},
 	}
 
 	for name, test := range tests {


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->
These changes will add a friendly error message when an `import` block `id` is empty string `""`.

<b>Example Code</b>

```
import {
  to = null_resource.foo
  id = ""
}
```

<b>Error Message Before</b>

```
$ terraform plan                                                                                                                                                            ✔  22s  

Planning failed. Terraform encountered an error while generating this plan.

╷
│ Error: Resource has no configuration
│ 
│ Terraform attempted to process a resource at null_resource.foo that has no configuration. This is a bug in Terraform; please report it!
╵

```

<b>Error Message After</b>

```
$ terraform plan 

│ Error: Import ID cannot be blank
│ 
│   on temp.tf line 3, in import:
│    3:   id = ""
│ 
│ The id argument of the import block must be a non-empty string. Please see the resource documentation for how to find the import ID.
╵

```

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Fixes https://github.com/hashicorp/terraform/issues/33505
