### PR TITLE
website: doc: fmt: specify "no flag" action

### DIFF
--- a/website/docs/cli/commands/fmt.mdx
+++ b/website/docs/cli/commands/fmt.mdx
@@ -53,7 +53,11 @@ directory instead. If you provide a file, then `fmt` will process just that
 file. If you provide a single dash (`-`), then `fmt` will read from standard
 input (STDIN).
 
-The command-line flags are all optional. The following flags are available:
+
+The command-line flags are all optional. If no flag is given, `fmt` rewrites
+the Terraform configuration files to a canonical format and style.
+
+The following flags are available:
 
 * `-list=false` - Don't list the files containing formatting inconsistencies.
 * `-write=false` - Don't overwrite the input files. (This is implied by `-check` or when the input is STDIN.)


### PR DESCRIPTION

## Target Release


1.5.x

## Draft CHANGELOG entry


### DOCUMENTATION

Specify the action of `terraform fmt` without any flags
-  


Hi,

This trivial commit only specifies (again) what the default action of `terraform fmt` does as some coworkers didn't know how to use it.

Cheers