### PR TITLE
test framework: add support for testing files to fmt command

### DIFF
--- a/internal/command/fmt.go
+++ b/internal/command/fmt.go
@@ -27,6 +27,14 @@ const (
 	stdinArg = "-"
 )
 
+var (
+	fmtSupportedExts = []string{
+		".tf",
+		".tfvars",
+		".tftest.hcl",
+	}
+)
+
 // FmtCommand is a Command implementation that rewrites Terraform config
 // files to a canonical format and style.
 type FmtCommand struct {
@@ -127,21 +135,31 @@ func (c *FmtCommand) fmt(paths []string, stdin io.Reader, stdout io.Writer) tfdi
 			dirDiags := c.processDir(path, stdout)
 			diags = diags.Append(dirDiags)
 		} else {
-			switch filepath.Ext(path) {
-			case ".tf", ".tfvars":
-				f, err := os.Open(path)
-				if err != nil {
-					// Open does not produce error messages that are end-user-appropriate,
-					// so we'll need to simplify here.
-					diags = diags.Append(fmt.Errorf("Failed to read file %s", path))
-					continue
-				}
+			fmtd := false
+			for _, ext := range fmtSupportedExts {
+				if strings.HasSuffix(path, ext) {
+					f, err := os.Open(path)
+					if err != nil {
+						// Open does not produce error messages that are end-user-appropriate,
+						// so we'll need to simplify here.
+						diags = diags.Append(fmt.Errorf("Failed to read file %s", path))
+						continue
+					}
 
-				fileDiags := c.processFile(c.normalizePath(path), f, stdout, false)
-				diags = diags.Append(fileDiags)
-				f.Close()
-			default:
-				diags = diags.Append(fmt.Errorf("Only .tf and .tfvars files can be processed with terraform fmt"))
+					fileDiags := c.processFile(c.normalizePath(path), f, stdout, false)
+					diags = diags.Append(fileDiags)
+					f.Close()
+
+					// Take note that we processed the file.
+					fmtd = true
+
+					// Don't check the remaining extensions.
+					break
+				}
+			}
+
+			if !fmtd {
+				diags = diags.Append(fmt.Errorf("Only .tf, .tfvars, and .tftest.hcl files can be processed with terraform fmt"))
 				continue
 			}
 		}
@@ -244,20 +262,23 @@ func (c *FmtCommand) processDir(path string, stdout io.Writer) tfdiags.Diagnosti
 			continue
 		}
 
-		ext := filepath.Ext(name)
-		switch ext {
-		case ".tf", ".tfvars":
-			f, err := os.Open(subPath)
-			if err != nil {
-				// Open does not produce error messages that are end-user-appropriate,
-				// so we'll need to simplify here.
-				diags = diags.Append(fmt.Errorf("Failed to read file %s", subPath))
-				continue
-			}
+		for _, ext := range fmtSupportedExts {
+			if strings.HasSuffix(name, ext) {
+				f, err := os.Open(subPath)
+				if err != nil {
+					// Open does not produce error messages that are end-user-appropriate,
+					// so we'll need to simplify here.
+					diags = diags.Append(fmt.Errorf("Failed to read file %s", subPath))
+					continue
+				}
 
-			fileDiags := c.processFile(c.normalizePath(subPath), f, stdout, false)
-			diags = diags.Append(fileDiags)
-			f.Close()
+				fileDiags := c.processFile(c.normalizePath(subPath), f, stdout, false)
+				diags = diags.Append(fileDiags)
+				f.Close()
+
+				// Don't need to check the remaining extensions.
+				break
+			}
 		}
 	}
 
@@ -528,9 +549,10 @@ func (c *FmtCommand) Help() string {
 	helpText := `
 Usage: terraform [global options] fmt [options] [target...]
 
-  Rewrites all Terraform configuration files to a canonical format. Both
-  configuration files (.tf) and variables files (.tfvars) are updated.
-  JSON files (.tf.json or .tfvars.json) are not modified.
+  Rewrites all Terraform configuration files to a canonical format. All
+  configuration files (.tf), variables files (.tfvars), and testing files 
+  (.tftest.hcl) are updated. JSON files (.tf.json, .tfvars.json, or 
+  .tftest.json) are not modified.
 
   By default, fmt scans the current directory for configuration files. If you
   provide a directory for the target argument, then fmt will scan that

--- a/internal/command/fmt_test.go
+++ b/internal/command/fmt_test.go
@@ -16,6 +16,70 @@ import (
 	"github.com/mitchellh/cli"
 )
 
+func TestFmt_TestFiles(t *testing.T) {
+	const inSuffix = "_in.tftest.hcl"
+	const outSuffix = "_out.tftest.hcl"
+	const gotSuffix = "_got.tftest.hcl"
+	entries, err := ioutil.ReadDir("testdata/tftest-fmt")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tmpDir, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, info := range entries {
+		if info.IsDir() {
+			continue
+		}
+		filename := info.Name()
+		if !strings.HasSuffix(filename, inSuffix) {
+			continue
+		}
+		testName := filename[:len(filename)-len(inSuffix)]
+		t.Run(testName, func(t *testing.T) {
+			inFile := filepath.Join("testdata", "tftest-fmt", testName+inSuffix)
+			wantFile := filepath.Join("testdata", "tftest-fmt", testName+outSuffix)
+			gotFile := filepath.Join(tmpDir, testName+gotSuffix)
+			input, err := ioutil.ReadFile(inFile)
+			if err != nil {
+				t.Fatal(err)
+			}
+			want, err := ioutil.ReadFile(wantFile)
+			if err != nil {
+				t.Fatal(err)
+			}
+			err = ioutil.WriteFile(gotFile, input, 0700)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			ui := cli.NewMockUi()
+			c := &FmtCommand{
+				Meta: Meta{
+					testingOverrides: metaOverridesForProvider(testProvider()),
+					Ui:               ui,
+				},
+			}
+			args := []string{gotFile}
+			if code := c.Run(args); code != 0 {
+				t.Fatalf("fmt command was unsuccessful:\n%s", ui.ErrorWriter.String())
+			}
+
+			got, err := ioutil.ReadFile(gotFile)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if diff := cmp.Diff(string(want), string(got)); diff != "" {
+				t.Errorf("wrong result\n%s", diff)
+			}
+		})
+	}
+}
+
 func TestFmt(t *testing.T) {
 	const inSuffix = "_in.tf"
 	const outSuffix = "_out.tf"

--- a/internal/command/testdata/tftest-fmt/main_in.tftest.hcl
+++ b/internal/command/testdata/tftest-fmt/main_in.tftest.hcl
@@ -1,0 +1,18 @@
+
+variables {
+  first = "value"
+second = "value"
+}
+
+run "some_run_block" {
+  command=plan
+
+  plan_options={
+    refresh=false
+  }
+
+  assert {
+    condition = var.input == 12
+    error_message = "something"
+  }
+}

--- a/internal/command/testdata/tftest-fmt/main_out.tftest.hcl
+++ b/internal/command/testdata/tftest-fmt/main_out.tftest.hcl
@@ -1,0 +1,18 @@
+
+variables {
+  first  = "value"
+  second = "value"
+}
+
+run "some_run_block" {
+  command = plan
+
+  plan_options = {
+    refresh = false
+  }
+
+  assert {
+    condition     = var.input == 12
+    error_message = "something"
+  }
+}


### PR DESCRIPTION
This PR just makes the `terraform fmt` command also load and process test files.