### PR TITLE
Fix crash when nested data blocks are mixed with the import command

### DIFF
--- a/internal/terraform/testdata/issue-33572/main.tf
+++ b/internal/terraform/testdata/issue-33572/main.tf
@@ -1,0 +1,14 @@
+provider "aws" {}
+
+resource "aws_instance" "foo" {}
+
+check "aws_instance_exists" {
+  data "aws_data_source" "bar" {
+    id = "baz"
+  }
+
+  assert {
+    condition     = data.aws_data_source.bar.foo == "Hello, world!"
+    error_message = "incorrect value"
+  }
+}

--- a/internal/terraform/transform_check.go
+++ b/internal/terraform/transform_check.go
@@ -116,10 +116,14 @@ func (t *checkTransformer) transform(g *Graph, cfg *configs.Config, allNodes []d
 // ReportChecks returns true if this operation should report any check blocks
 // that it is about to execute.
 //
-// This is generally only true for planning operations, as apply operations
-// recreate the expected checks from the plan.
+// This is true for planning operations, as apply operations recreate the
+// expected checks from the plan.
+//
+// We'll also report the checks during an import operation. We still execute
+// our check blocks during an import operation so they need to be reported
+// first.
 func (t *checkTransformer) ReportChecks() bool {
-	return t.Operation == walkPlan
+	return t.Operation == walkPlan || t.Operation == walkImport
 }
 
 // ExecuteChecks returns true if this operation should actually execute any
@@ -129,7 +133,7 @@ func (t *checkTransformer) ReportChecks() bool {
 // graph, but they will only validate things like references and syntax.
 func (t *checkTransformer) ExecuteChecks() bool {
 	switch t.Operation {
-	case walkPlan, walkApply:
+	case walkPlan, walkApply, walkImport:
 		// We only actually execute the checks for plan and apply operations.
 		return true
 	default:


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

This PR fixes a crash that occurs when the `terraform import` command is used against configuration that has a nested data block defined within a check block.

Essentially, the nested data block still tries to report its checkable status during an import operation. This results in the checks system panicking as it is not expecting that kind of check to be reported. 

The fix in this case is just to make the full check block also execute during an import operation. Note, that this behaviour matches the behaviour of other checkable objects. Resource pre and post conditions still execute during the validate operation, they just report warnings instead of errors. As check blocks already only report warnings, making all checkable objects consistent in this case is as simple as turning on check blocks during import.

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Fixes #33572 

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.5.4

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

### BUG FIXES

<!--

Write a short description of the user-facing change. Examples:

- `terraform show -json`: Fixed crash with sensitive set values.
- When rendering a diff, Terraform now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 

-  `check` blocks: Fixes crash when nested data sources are within configuration targeted by the `terraform import` command.
- `check` blocks: Check blocks now operate in line with other checkable objects by also executing during import operations.
