### PR TITLE
website: doc: Add another example to `~>` operator

### DIFF
--- a/website/docs/language/expressions/version-constraints.mdx
+++ b/website/docs/language/expressions/version-constraints.mdx
@@ -43,11 +43,11 @@ The following operators are valid:
   versions for which the comparison is true. "Greater-than" requests newer
   versions, and "less-than" requests older versions.
 
-- `~>`: Allows only the _rightmost_ version component to increment. For example,
+- `~>`: Allows only the _rightmost_ version component to increment. This format is referred to as the _pessimistic constraint_ operator. For example,
   to allow new patch releases within a specific minor release, use the full
-  version number: `~> 1.0.4` will allow installation of `1.0.5` and `1.0.10`
-  but not `1.1.0`. `~> 1.1` will allow installation of `1.2` and `1.10` but 
-  not `2.0`. This is usually called the pessimistic constraint operator.
+  version number: 
+  - `~> 1.0.4`: Allows Terraform to install `1.0.5` and `1.0.10` but not `1.1.0`. 
+  - `~> 1.1`: Allows Terraform to install `1.2` and `1.10` but not `2.0`. 
 
 ## Version Constraint Behavior
 

--- a/website/docs/language/expressions/version-constraints.mdx
+++ b/website/docs/language/expressions/version-constraints.mdx
@@ -46,7 +46,8 @@ The following operators are valid:
 - `~>`: Allows only the _rightmost_ version component to increment. For example,
   to allow new patch releases within a specific minor release, use the full
   version number: `~> 1.0.4` will allow installation of `1.0.5` and `1.0.10`
-  but not `1.1.0`. This is usually called the pessimistic constraint operator.
+  but not `1.1.0`. `~> 1.1` will allow installation of `1.2` and 1.10` but 
+  not `2.0`. This is usually called the pessimistic constraint operator.
 
 ## Version Constraint Behavior
 

--- a/website/docs/language/expressions/version-constraints.mdx
+++ b/website/docs/language/expressions/version-constraints.mdx
@@ -46,7 +46,7 @@ The following operators are valid:
 - `~>`: Allows only the _rightmost_ version component to increment. For example,
   to allow new patch releases within a specific minor release, use the full
   version number: `~> 1.0.4` will allow installation of `1.0.5` and `1.0.10`
-  but not `1.1.0`. `~> 1.1` will allow installation of `1.2` and 1.10` but 
+  but not `1.1.0`. `~> 1.1` will allow installation of `1.2` and `1.10` but 
   not `2.0`. This is usually called the pessimistic constraint operator.
 
 ## Version Constraint Behavior


### PR DESCRIPTION
Add another example to `~>` operator, following https://thoughtbot.com/blog/rubys-pessimistic-operator 

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.5.x

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

###  ENHANCEMENTS

-  Improve "Version Constraints" doc. 
