### PR TITLE
testing framework: allow users to specify deeply nested testing directories

### DIFF
--- a/internal/command/arguments/test.go
+++ b/internal/command/arguments/test.go
@@ -1,6 +1,9 @@
 package arguments
 
-import "github.com/hashicorp/terraform/internal/tfdiags"
+import (
+	"github.com/hashicorp/terraform/internal/configs"
+	"github.com/hashicorp/terraform/internal/tfdiags"
+)
 
 // Test represents the command-line arguments for the test command.
 type Test struct {
@@ -36,7 +39,7 @@ func ParseTest(args []string) (*Test, tfdiags.Diagnostics) {
 	var jsonOutput bool
 	cmdFlags := extendedFlagSet("test", nil, nil, test.Vars)
 	cmdFlags.Var((*flagStringSlice)(&test.Filter), "filter", "filter")
-	cmdFlags.StringVar(&test.TestDirectory, "test-directory", "tests", "test-directory")
+	cmdFlags.StringVar(&test.TestDirectory, "test-directory", configs.DefaultTestDirectory, "test-directory")
 	cmdFlags.BoolVar(&jsonOutput, "json", false, "json")
 	cmdFlags.BoolVar(&test.Verbose, "verbose", false, "verbose")
 

--- a/internal/command/test_test.go
+++ b/internal/command/test_test.go
@@ -37,6 +37,17 @@ func TestTest(t *testing.T) {
 			expected: "1 passed, 0 failed.",
 			code:     0,
 		},
+		"simple_pass_very_nested": {
+			args:     []string{"-test-directory", "tests/subdir"},
+			expected: "1 passed, 0 failed.",
+			code:     0,
+		},
+		"simple_pass_very_nested_alternate": {
+			override: "simple_pass_very_nested",
+			args:     []string{"-test-directory", "./tests/subdir"},
+			expected: "1 passed, 0 failed.",
+			code:     0,
+		},
 		"pass_with_locals": {
 			expected: "1 passed, 0 failed.",
 			code:     0,

--- a/internal/command/testdata/test/simple_pass_very_nested/main.tf
+++ b/internal/command/testdata/test/simple_pass_very_nested/main.tf
@@ -1,0 +1,3 @@
+resource "test_resource" "foo" {
+  value = "bar"
+}

--- a/internal/command/testdata/test/simple_pass_very_nested/tests/subdir/main.tftest.hcl
+++ b/internal/command/testdata/test/simple_pass_very_nested/tests/subdir/main.tftest.hcl
@@ -1,0 +1,6 @@
+run "validate_test_resource" {
+  assert {
+    condition = test_resource.foo.value == "bar"
+    error_message = "invalid value"
+  }
+}

--- a/internal/configs/testdata/valid-modules/with-tests-very-nested/main.tf
+++ b/internal/configs/testdata/valid-modules/with-tests-very-nested/main.tf
@@ -1,0 +1,11 @@
+
+variable "input" {
+  type = string
+}
+
+
+resource "foo_resource" "a" {
+  value = var.input
+}
+
+resource "bar_resource" "c" {}

--- a/internal/configs/testdata/valid-modules/with-tests-very-nested/very/nested/test_case_one.tftest.hcl
+++ b/internal/configs/testdata/valid-modules/with-tests-very-nested/very/nested/test_case_one.tftest.hcl
@@ -1,0 +1,31 @@
+variables {
+  input = "default"
+}
+
+# test_run_one runs a partial plan
+run "test_run_one" {
+  command = plan
+
+  plan_options {
+    target = [
+      foo_resource.a
+    ]
+  }
+
+  assert {
+    condition = foo_resource.a.value == "default"
+    error_message = "invalid value"
+  }
+}
+
+# test_run_two does a complete apply operation
+run "test_run_two" {
+  variables {
+    input = "custom"
+  }
+
+  assert {
+    condition = foo_resource.a.value == "custom"
+    error_message = "invalid value"
+  }
+}

--- a/internal/configs/testdata/valid-modules/with-tests-very-nested/very/nested/test_case_two.tftest.hcl
+++ b/internal/configs/testdata/valid-modules/with-tests-very-nested/very/nested/test_case_two.tftest.hcl
@@ -1,0 +1,46 @@
+# test_run_one does a complete apply
+run "test_run_one" {
+  variables {
+    input = "test_run_one"
+  }
+
+  assert {
+    condition = foo_resource.a.value == "test_run_one"
+    error_message = "invalid value"
+  }
+}
+
+# test_run_two does a refresh only apply
+run "test_run_two" {
+  plan_options {
+    mode = refresh-only
+  }
+
+  variables {
+    input = "test_run_two"
+  }
+
+  assert {
+    # value shouldn't change, as we're doing a refresh-only apply.
+    condition = foo_resource.a.value == "test_run_one"
+    error_message = "invalid value"
+  }
+}
+
+# test_run_three does an apply with a replace operation
+run "test_run_three" {
+  variables {
+    input = "test_run_three"
+  }
+
+  plan_options {
+    replace = [
+      bar_resource.c
+    ]
+  }
+
+  assert {
+    condition = foo_resource.a.value == "test_run_three"
+    error_message = "invalid value"
+  }
+}


### PR DESCRIPTION
This PR updates the configuration loading process for testing files so that it loads the testing directory directly, instead of looking for it within the configuration directory. This allows users to specify deeply nested directories, or relative paths, as the testing directory.

We've had feedback from the alpha about this.

Fixes #33582 