### PR TITLE
Fix race condition in no_providers_in_main test

### DIFF
--- a/internal/command/testdata/test/no_providers_in_main/main.tf
+++ b/internal/command/testdata/test/no_providers_in_main/main.tf
@@ -16,4 +16,8 @@ resource "test_resource" "primary" {
 resource "test_resource" "secondary" {
   provider = test.secondary
   value = "bar"
+
+  depends_on = [
+    test_resource.primary,
+  ]
 }


### PR DESCRIPTION
There's a race condition in the testing provider I built for the testing framework. where it can do concurrent reads/writes on the underlying data store. I've tried to fix it within the provider a couple of times but it's not been easy and I don't have time to spend ages on it right now. I will come back and revisit. However, a simple enough workaround is to just update the tests that use this provider so that they don't ever have a need for concurrent read/writes and so far this is not something the testing framework needs to worry about.

See here for an example failed test: https://github.com/hashicorp/terraform/actions/runs/5724121115/job/15509985171