### PR TITLE
Make config errors more important during init operations

### DIFF
--- a/internal/command/init.go
+++ b/internal/command/init.go
@@ -265,16 +265,19 @@ func (c *InitCommand) Run(args []string) int {
 	// We've passed the core version check, now we can show errors from the
 	// configuration and backend initialisation.
 
-	// Now, we can check the diagnostics from the early configuration.
+	// Now, we can check the diagnostics from the early configuration and the
+	// backend.
 	diags = diags.Append(earlyConfDiags)
+	diags = diags.Append(backDiags)
 	if earlyConfDiags.HasErrors() {
 		c.Ui.Error(strings.TrimSpace(errInitConfigError))
 		c.showDiagnostics(diags)
 		return 1
 	}
 
-	// Now, we can show any errors from initializing the backend.
-	diags = diags.Append(backDiags)
+	// Now, we can show any errors from initializing the backend, but we won't
+	// show the errInitConfigError preamble as we didn't detect problems with
+	// the early configuration.
 	if backDiags.HasErrors() {
 		c.showDiagnostics(diags)
 		return 1
@@ -1185,7 +1188,8 @@ func (c *InitCommand) Synopsis() string {
 }
 
 const errInitConfigError = `
-[reset]There are some problems with the configuration, described below.
+[reset]Terraform encountered problems during initialisation, including problems
+with the configuration, described below.
 
 The Terraform configuration must be valid before initialization so that
 Terraform can determine which modules and providers need to be installed.

--- a/internal/command/init.go
+++ b/internal/command/init.go
@@ -262,24 +262,22 @@ func (c *InitCommand) Run(args []string) int {
 		return 1
 	}
 
-	// If we pass the core version check, we want to show any errors from initializing the backend next,
-	// which will include syntax errors from loading the configuration. However, there's a special case
-	// where we are unable to load the backend from configuration or state _and_ the configuration has
-	// errors. In that case, we want to show a slightly friendlier error message for newcomers.
-	showBackendDiags := back != nil || rootModEarly.Backend != nil || rootModEarly.CloudConfig != nil
-	if showBackendDiags {
-		diags = diags.Append(backDiags)
-		if backDiags.HasErrors() {
-			c.showDiagnostics(diags)
-			return 1
-		}
-	} else {
-		diags = diags.Append(earlyConfDiags)
-		if earlyConfDiags.HasErrors() {
-			c.Ui.Error(strings.TrimSpace(errInitConfigError))
-			c.showDiagnostics(diags)
-			return 1
-		}
+	// We've passed the core version check, now we can show errors from the
+	// configuration and backend initialisation.
+
+	// Now, we can check the diagnostics from the early configuration.
+	diags = diags.Append(earlyConfDiags)
+	if earlyConfDiags.HasErrors() {
+		c.Ui.Error(strings.TrimSpace(errInitConfigError))
+		c.showDiagnostics(diags)
+		return 1
+	}
+
+	// Now, we can show any errors from initializing the backend.
+	diags = diags.Append(backDiags)
+	if backDiags.HasErrors() {
+		c.showDiagnostics(diags)
+		return 1
 	}
 
 	// If everything is ok with the core version check and backend initialization,

--- a/internal/command/init_test.go
+++ b/internal/command/init_test.go
@@ -2642,7 +2642,7 @@ func TestInit_invalidSyntaxNoBackend(t *testing.T) {
 	}
 
 	errStr := ui.ErrorWriter.String()
-	if subStr := "There are some problems with the configuration, described below"; !strings.Contains(errStr, subStr) {
+	if subStr := "Terraform encountered problems during initialisation, including problems\nwith the configuration, described below."; !strings.Contains(errStr, subStr) {
 		t.Errorf("Error output should include preamble\nwant substr: %s\ngot:\n%s", subStr, errStr)
 	}
 	if subStr := "Error: Unsupported block type"; !strings.Contains(errStr, subStr) {
@@ -2671,7 +2671,7 @@ func TestInit_invalidSyntaxWithBackend(t *testing.T) {
 	}
 
 	errStr := ui.ErrorWriter.String()
-	if subStr := "There are some problems with the configuration, described below"; !strings.Contains(errStr, subStr) {
+	if subStr := "Terraform encountered problems during initialisation, including problems\nwith the configuration, described below."; !strings.Contains(errStr, subStr) {
 		t.Errorf("Error output should include preamble\nwant substr: %s\ngot:\n%s", subStr, errStr)
 	}
 	if subStr := "Error: Unsupported block type"; !strings.Contains(errStr, subStr) {
@@ -2700,14 +2700,14 @@ func TestInit_invalidSyntaxInvalidBackend(t *testing.T) {
 	}
 
 	errStr := ui.ErrorWriter.String()
-	if subStr := "There are some problems with the configuration, described below"; !strings.Contains(errStr, subStr) {
+	if subStr := "Terraform encountered problems during initialisation, including problems\nwith the configuration, described below."; !strings.Contains(errStr, subStr) {
 		t.Errorf("Error output should include preamble\nwant substr: %s\ngot:\n%s", subStr, errStr)
 	}
 	if subStr := "Error: Unsupported block type"; !strings.Contains(errStr, subStr) {
 		t.Errorf("Error output should mention syntax errors\nwant substr: %s\ngot:\n%s", subStr, errStr)
 	}
-	if subStr := "Error: Unsupported backend type"; strings.Contains(errStr, subStr) {
-		t.Errorf("Error output should not mention the invalid backend\nwant substr: %s\ngot:\n%s", subStr, errStr)
+	if subStr := "Error: Unsupported backend type"; !strings.Contains(errStr, subStr) {
+		t.Errorf("Error output should mention the invalid backend\nwant substr: %s\ngot:\n%s", subStr, errStr)
 	}
 }
 
@@ -2732,7 +2732,7 @@ func TestInit_invalidSyntaxBackendAttribute(t *testing.T) {
 	}
 
 	errStr := ui.ErrorWriter.String()
-	if subStr := "There are some problems with the configuration, described below"; !strings.Contains(errStr, subStr) {
+	if subStr := "Terraform encountered problems during initialisation, including problems\nwith the configuration, described below."; !strings.Contains(errStr, subStr) {
 		t.Errorf("Error output should include preamble\nwant substr: %s\ngot:\n%s", subStr, errStr)
 	}
 	if subStr := "Error: Invalid character"; !strings.Contains(errStr, subStr) {

--- a/internal/command/init_test.go
+++ b/internal/command/init_test.go
@@ -2700,14 +2700,46 @@ func TestInit_invalidSyntaxInvalidBackend(t *testing.T) {
 	}
 
 	errStr := ui.ErrorWriter.String()
-	if subStr := "There are some problems with the configuration, described below"; strings.Contains(errStr, subStr) {
-		t.Errorf("Error output should not include preamble\nwant substr: %s\ngot:\n%s", subStr, errStr)
+	if subStr := "There are some problems with the configuration, described below"; !strings.Contains(errStr, subStr) {
+		t.Errorf("Error output should include preamble\nwant substr: %s\ngot:\n%s", subStr, errStr)
 	}
-	if subStr := "Error: Unsupported block type"; strings.Contains(errStr, subStr) {
-		t.Errorf("Error output should not mention syntax errors\nwant substr: %s\ngot:\n%s", subStr, errStr)
+	if subStr := "Error: Unsupported block type"; !strings.Contains(errStr, subStr) {
+		t.Errorf("Error output should mention syntax errors\nwant substr: %s\ngot:\n%s", subStr, errStr)
 	}
-	if subStr := "Error: Unsupported backend type"; !strings.Contains(errStr, subStr) {
-		t.Errorf("Error output should mention the invalid backend\nwant substr: %s\ngot:\n%s", subStr, errStr)
+	if subStr := "Error: Unsupported backend type"; strings.Contains(errStr, subStr) {
+		t.Errorf("Error output should not mention the invalid backend\nwant substr: %s\ngot:\n%s", subStr, errStr)
+	}
+}
+
+func TestInit_invalidSyntaxBackendAttribute(t *testing.T) {
+	td := t.TempDir()
+	testCopyDir(t, testFixturePath("init-syntax-invalid-backend-attribute-invalid"), td)
+	defer testChdir(t, td)()
+
+	ui := cli.NewMockUi()
+	view, _ := testView(t)
+	m := Meta{
+		Ui:   ui,
+		View: view,
+	}
+
+	c := &InitCommand{
+		Meta: m,
+	}
+
+	if code := c.Run(nil); code == 0 {
+		t.Fatalf("succeeded, but was expecting error\nstdout:\n%s\nstderr:\n%s", ui.OutputWriter, ui.ErrorWriter)
+	}
+
+	errStr := ui.ErrorWriter.String()
+	if subStr := "There are some problems with the configuration, described below"; !strings.Contains(errStr, subStr) {
+		t.Errorf("Error output should include preamble\nwant substr: %s\ngot:\n%s", subStr, errStr)
+	}
+	if subStr := "Error: Invalid character"; !strings.Contains(errStr, subStr) {
+		t.Errorf("Error output should mention the invalid character\nwant substr: %s\ngot:\n%s", subStr, errStr)
+	}
+	if subStr := "Error: Invalid expression"; !strings.Contains(errStr, subStr) {
+		t.Errorf("Error output should mention the invalid expression\nwant substr: %s\ngot:\n%s", subStr, errStr)
 	}
 }
 

--- a/internal/command/meta_backend.go
+++ b/internal/command/meta_backend.go
@@ -19,6 +19,9 @@ import (
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hcldec"
+	"github.com/zclconf/go-cty/cty"
+	ctyjson "github.com/zclconf/go-cty/cty/json"
+
 	"github.com/hashicorp/terraform/internal/backend"
 	"github.com/hashicorp/terraform/internal/cloud"
 	"github.com/hashicorp/terraform/internal/command/arguments"
@@ -29,8 +32,6 @@ import (
 	"github.com/hashicorp/terraform/internal/states/statemgr"
 	"github.com/hashicorp/terraform/internal/terraform"
 	"github.com/hashicorp/terraform/internal/tfdiags"
-	"github.com/zclconf/go-cty/cty"
-	ctyjson "github.com/zclconf/go-cty/cty/json"
 
 	backendInit "github.com/hashicorp/terraform/internal/backend/init"
 	backendLocal "github.com/hashicorp/terraform/internal/backend/local"
@@ -1395,6 +1396,14 @@ func (m *Meta) backendInitFromConfig(c *configs.Backend) (backend.Backend, cty.V
 	configVal, hclDiags := hcldec.Decode(c.Config, decSpec, nil)
 	diags = diags.Append(hclDiags)
 	if hclDiags.HasErrors() {
+		return nil, cty.NilVal, diags
+	}
+
+	if !configVal.IsWhollyKnown() {
+		diags = diags.Append(tfdiags.Sourceless(
+			tfdiags.Error,
+			"Unknown values within backend definition",
+			"The `terraform` configuration block should contain only concrete and static values. Another diagnostic should contain more information about which part of the configuration is problematic."))
 		return nil, cty.NilVal, diags
 	}
 

--- a/internal/command/testdata/init-syntax-invalid-backend-attribute-invalid/main.tf
+++ b/internal/command/testdata/init-syntax-invalid-backend-attribute-invalid/main.tf
@@ -1,0 +1,10 @@
+
+terraform {
+  backend "local" {
+    path = $invalid
+  }
+}
+
+variable "input" {
+  type = string
+}


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

This PR updates the backend initialisation logic so that if the value returned by parsing the configuration isn't wholly known it returns an error diagnostic instead of crashing. This happens because we try to delay returning diagnostics until we can validate the `required_versions` conditions.

This PR also tweaks the ordering of which diagnostics are returned first. Previously if the backend initialisation returned diagnostics those diagnostics would be reported instead of the config parsing diagnostics. I can see the logic in that, but there is no way to differentiate between there is an error in the backend initialisation and there was an error in the backend initialisation caused by an error in the configuration. Therefore, I think it's better to simply return the configuration errors as higher priority since in the end, both will have to be fixed anyway.

@radditude - you put together the logic I'm moving around here so would be glad to hear your thoughts on my reasoning!

Another solution could be to simply return all the early config diagnostics and the backend diagnostics together instead of either/or?

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Fixes #33622 

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.5.5

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

### BUG FIXES 

<!--

Write a short description of the user-facing change. Examples:

- `terraform show -json`: Fixed crash with sensitive set values.
- When rendering a diff, Terraform now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 

-  init: Fix crash when using invalid configuration in `backend` blocks.
