### PR TITLE
Improve syntax docs

### DIFF
--- a/website/docs/language/resources/syntax.mdx
+++ b/website/docs/language/resources/syntax.mdx
@@ -133,7 +133,7 @@ resource "aws_instance" "example" {
 ```
 
 [Custom Condition Checks](/terraform/language/expressions/custom-conditions#preconditions-and-postconditions) 
-can help capture assumptions, helping future maintainers 
+can help capture assumptions so that future maintainers 
 understand the configuration design and intent. They also return useful 
 information about errors earlier and in context, helping consumers to diagnose 
 issues in their configuration.

--- a/website/docs/language/resources/syntax.mdx
+++ b/website/docs/language/resources/syntax.mdx
@@ -43,7 +43,7 @@ contain only letters, digits, underscores, and dashes.
 
 Resource declarations can include more advanced features, such as single 
 resource declarations that produce multiple similar remote objects, but only
-a small subset is required for initial use. You will learn more later in this page.
+a small subset is required for initial use. 
 
 ## Resource Types
 

--- a/website/docs/language/resources/syntax.mdx
+++ b/website/docs/language/resources/syntax.mdx
@@ -60,8 +60,8 @@ infrastructure platform. Providers are distributed separately from Terraform,
 but Terraform can automatically install most providers when initializing
 a working directory.
 
-To manage resources, a Terraform module must specify the required providers, see 
-[Provider Requirements](/terraform/language/providers/requirements).
+To manage resources, a Terraform module must specify the required providers. Refer to 
+[Provider Requirements](/terraform/language/providers/requirements) for additional information.
 
 Most providers need some configuration to access their remote API, 
 which is provided by the root module, see 

--- a/website/docs/language/resources/syntax.mdx
+++ b/website/docs/language/resources/syntax.mdx
@@ -91,9 +91,9 @@ and apply across all resource types.
 Every Terraform provider has its own documentation, describing its resource
 types and their arguments.
 
-Some provider documentation is still part of Terraform's core documentation 
+Some provider documentation is still part of Terraform's core documentation, 
 but the [Terraform Registry](https://registry.terraform.io/browse/providers) 
-is now the main home for all publicly available provider docs.
+is the main home for all publicly available provider docs.
 
 When viewing a provider's page on the Terraform
 Registry, you can click the "Documentation" link in the header to browse its

--- a/website/docs/language/resources/syntax.mdx
+++ b/website/docs/language/resources/syntax.mdx
@@ -83,7 +83,7 @@ The values for resource arguments can make full use of
 [expressions](/terraform/language/expressions) and other dynamic Terraform
 language features.
 
-[Meta-Arguments](#meta-arguments) are defined by Terraform itself
+[Meta-arguments](#meta-arguments) are defined by Terraform
 and apply across all resource types. 
 
 ### Documentation for Resource Types

--- a/website/docs/language/resources/syntax.mdx
+++ b/website/docs/language/resources/syntax.mdx
@@ -69,7 +69,7 @@ which is provided by the root module. Refer to
 
 Based on a resource type's name, Terraform can usually determine which provider to use. 
 By convention, resource type names start with their provider's preferred local name.
-When using multiple configurations of a provider (or non-preferred local provider names), 
+When using multiple configurations of a provider or non-preferred local provider names, 
 you must use [the `provider` meta-argument](/terraform/language/meta-arguments/resource-provider) 
 to manually choose a provider configuration.
 

--- a/website/docs/language/resources/syntax.mdx
+++ b/website/docs/language/resources/syntax.mdx
@@ -132,7 +132,7 @@ resource "aws_instance" "example" {
 }
 ```
 
-[Custom Condition Checks](/terraform/language/expressions/custom-conditions#preconditions-and-postconditions) 
+[Custom condition checks](/terraform/language/expressions/custom-conditions#preconditions-and-postconditions) 
 can help capture assumptions so that future maintainers 
 understand the configuration design and intent. They also return useful 
 information about errors earlier and in context, helping consumers to diagnose 

--- a/website/docs/language/resources/syntax.mdx
+++ b/website/docs/language/resources/syntax.mdx
@@ -96,9 +96,8 @@ but the [Terraform Registry](https://registry.terraform.io/browse/providers)
 is the main home for all publicly available provider docs.
 
 When viewing a provider's page on the Terraform
-Registry, you can click the "Documentation" link in the header to browse its
-documentation, which is versioned. Use the dropdown version menu in the header 
-to switch the version.
+Registry, you can click the **Documentation** link in the header to browse its
+documentation. The documentation is versioned. To choose a different version of the provider documentation, click on the version in the provider breadcrumbs to choose a version from the drop-down menu.
 
 ## Meta-Arguments
 

--- a/website/docs/language/resources/syntax.mdx
+++ b/website/docs/language/resources/syntax.mdx
@@ -64,8 +64,8 @@ To manage resources, a Terraform module must specify the required providers. Ref
 [Provider Requirements](/terraform/language/providers/requirements) for additional information.
 
 Most providers need some configuration to access their remote API, 
-which is provided by the root module, see 
-[Provider Configuration](/terraform/language/providers/configuration)
+which is provided by the root module. Refer to 
+[Provider Configuration](/terraform/language/providers/configuration) for additional information.
 
 Based on a resource type's name, Terraform can usually determine which provider to use. 
 By convention, resource type names start with their provider's preferred local name.

--- a/website/docs/language/resources/syntax.mdx
+++ b/website/docs/language/resources/syntax.mdx
@@ -20,12 +20,11 @@ For information about how Terraform manages resources after applying a configura
 
 ## Resource Syntax
 
-A "resource" block declares a resource of a specific type 
-with a specific local name. The name is used to refer to this resource 
-in the same Terraform module but has no meaning outside that module's scope.
+A `resource` block declares a resource of a specific type 
+with a specific local name. Terraform uses the name when referring to the resource 
+in the same module, but it has no meaning outside that module's scope.
 
-The resource type ("aws_instance") and name ("Web") together must be unique within a module because they
-serve as an identifier for a given resource.
+In the following example,  the `aws_instance` resource type is named `web`. The resource type and name must be unique within a module because they serve as an identifier for a given resource.
 
 ```hcl
 resource "aws_instance" "web" {

--- a/website/docs/language/resources/syntax.mdx
+++ b/website/docs/language/resources/syntax.mdx
@@ -15,7 +15,7 @@ Each resource block describes one or more infrastructure objects, such
 as virtual networks, compute instances, or higher-level components such
 as DNS records.
 
-To see how Terraform manages resources when applying a configuration, see
+For information about how Terraform manages resources after applying a configuration, refer to
 [Resource Behavior](/terraform/language/resources/behavior).
 
 ## Resource Syntax


### PR DESCRIPTION
New to Terraform, I was reading the docs to learn about the syntax.

My changes do not remove any information and include:

- minor text changes.
- some changes to the order of information to create a more logical flow.
- moving links to the sentence to which they refer.

I hope this makes the docs more readable and easier to understand.

I have read the [contributing guide](https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md). I guess and hope that I have not changed or removed something crucial.