### PR TITLE
Implement updates to testing framework based on recent feedback

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -86,6 +86,7 @@ require (
 	go.opentelemetry.io/otel/sdk v1.16.0
 	go.opentelemetry.io/otel/trace v1.16.0
 	golang.org/x/crypto v0.10.0
+	golang.org/x/exp v0.0.0-20220303212507-bbda1eaf7a17
 	golang.org/x/mod v0.10.0
 	golang.org/x/net v0.11.0
 	golang.org/x/oauth2 v0.8.0
@@ -220,7 +221,6 @@ require (
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.16.0 // indirect
 	go.opentelemetry.io/otel/metric v1.16.0 // indirect
 	go.opentelemetry.io/proto/otlp v0.20.0 // indirect
-	golang.org/x/exp v0.0.0-20220303212507-bbda1eaf7a17 // indirect
 	golang.org/x/exp/typeparams v0.0.0-20221208152030-732eee02a75a // indirect
 	golang.org/x/sync v0.3.0 // indirect
 	golang.org/x/time v0.3.0 // indirect

--- a/internal/command/testdata/test/expect_failures_inputs/main.tftest.hcl
+++ b/internal/command/testdata/test/expect_failures_inputs/main.tftest.hcl
@@ -3,6 +3,8 @@ variables {
 }
 
 run "test" {
+  command = plan
+
   expect_failures = [
     var.input
   ]

--- a/internal/command/testdata/test/expect_failures_outputs/main.tftest.hcl
+++ b/internal/command/testdata/test/expect_failures_outputs/main.tftest.hcl
@@ -3,6 +3,9 @@ variables {
 }
 
 run "test" {
+
+  command = plan
+
   expect_failures = [
     output.output
   ]

--- a/internal/command/testdata/test/expect_failures_resources/main.tftest.hcl
+++ b/internal/command/testdata/test/expect_failures_resources/main.tftest.hcl
@@ -3,6 +3,8 @@ variables {
 }
 
 run "test" {
+  command = plan
+
   expect_failures = [
     test_resource.resource
   ]

--- a/internal/command/testdata/test/invalid_default_state/main.tftest.hcl
+++ b/internal/command/testdata/test/invalid_default_state/main.tftest.hcl
@@ -1,8 +1,4 @@
 run "test" {
-    variables {
-        input = "Hello, world!"
-    }
-
     assert {
         condition = test_resource.resource.value == "Hello, world!"
         error_message = "wrong condition"

--- a/internal/command/testdata/test/only_modules/example/main.tf
+++ b/internal/command/testdata/test/only_modules/example/main.tf
@@ -1,0 +1,9 @@
+
+variable "input" {
+  type = string
+}
+
+resource "test_resource" "module_resource" {
+  id = "df6h8as9"
+  value = var.input
+}

--- a/internal/command/testdata/test/only_modules/main.tf
+++ b/internal/command/testdata/test/only_modules/main.tf
@@ -1,0 +1,9 @@
+
+variable "input" {
+  type = string
+}
+
+resource "test_resource" "resource" {
+  id = "598318e0"
+  value = var.input
+}

--- a/internal/command/testdata/test/only_modules/main.tftest.hcl
+++ b/internal/command/testdata/test/only_modules/main.tftest.hcl
@@ -1,0 +1,23 @@
+# This is an example test file from a use case requested by a user. We only
+# refer to alternate modules and not the main configuration. This means we
+# shouldn't have to provide any data for the main configuration.
+
+run "first" {
+  module {
+    source = "./example"
+  }
+
+  variables {
+    input = "start"
+  }
+}
+
+run "second" {
+  module {
+    source = "./example"
+  }
+
+  variables {
+    input = "update"
+  }
+}

--- a/internal/command/testdata/test/partial_updates/main.tf
+++ b/internal/command/testdata/test/partial_updates/main.tf
@@ -1,0 +1,15 @@
+
+resource "test_resource" "resource" {}
+
+locals {
+  follow = {
+    (test_resource.resource.id): "follow"
+  }
+}
+
+resource "test_resource" "follow" {
+  for_each = local.follow
+
+  id = each.key
+  value = each.value
+}

--- a/internal/command/testdata/test/partial_updates/main.tftest.hcl
+++ b/internal/command/testdata/test/partial_updates/main.tftest.hcl
@@ -1,0 +1,10 @@
+
+run "first" {
+  plan_options {
+    target = [
+      test_resource.resource,
+    ]
+  }
+}
+
+run "second" {}

--- a/internal/command/testdata/test/state_propagation/example/main.tf
+++ b/internal/command/testdata/test/state_propagation/example/main.tf
@@ -1,0 +1,9 @@
+
+variable "input" {
+  type = string
+}
+
+resource "test_resource" "module_resource" {
+  id = "df6h8as9"
+  value = var.input
+}

--- a/internal/command/testdata/test/state_propagation/main.tf
+++ b/internal/command/testdata/test/state_propagation/main.tf
@@ -1,0 +1,9 @@
+
+variable "input" {
+  type = string
+}
+
+resource "test_resource" "resource" {
+  id = "598318e0"
+  value = var.input
+}

--- a/internal/command/testdata/test/state_propagation/main.tftest.hcl
+++ b/internal/command/testdata/test/state_propagation/main.tftest.hcl
@@ -1,0 +1,54 @@
+# Our test will run this in verbose mode and we should see the plan output for
+# the second run block showing the resource being updated as the state should
+# be propagated from the first one to the second one.
+#
+# We also interweave alternate modules to test the handling of multiple states
+# within the file.
+
+run "initial_apply_example" {
+  module {
+    source = "./example"
+  }
+
+  variables {
+    input = "start"
+  }
+}
+
+run "initial_apply" {
+  variables {
+    input = "start"
+  }
+}
+
+run "plan_second_example" {
+  command = plan
+
+  module {
+    source = "./second_example"
+  }
+
+  variables {
+    input = "start"
+  }
+}
+
+run "plan_update" {
+  command = plan
+
+  variables {
+    input = "update"
+  }
+}
+
+run "plan_update_example" {
+  command = plan
+
+  module {
+    source = "./example"
+  }
+
+  variables {
+    input = "update"
+  }
+}

--- a/internal/command/testdata/test/state_propagation/second_example/main.tf
+++ b/internal/command/testdata/test/state_propagation/second_example/main.tf
@@ -1,0 +1,9 @@
+
+variable "input" {
+  type = string
+}
+
+resource "test_resource" "second_module_resource" {
+  id = "b6a1d8cb"
+  value = var.input
+}


### PR DESCRIPTION
There are two pieces of feedback we've received from users during the testing alpha:

1. The requirement to have all variables defined at the file level has caused lots of confusion.
2. We have found a use case for having run blocks that call out to alternate modules share states.

This PR refactors the logic within the test command functionality to address both of the above pieces of feedback.

## Variables don't need to be defined at the file level any more

The requirement for this was that the final destroy operation needed values for the variables, and we didn't have a way of getting them otherwise. We now keep track of the last successful run block, this run block will have passed validation and will have defined values for all the variables. This means we can use the configuration and values for that run block to execute our destroy operation and we don't need values defined at the file level anymore. 

Note, users can still define values at the file level to be shared between the run blocks, they just don't have to be defined anymore.

This change means that we no longer need to perform a beginning test/validate step to ensure the later destroy operation can succeed. This is because we are now using the config/values from a successful run block, this means all the tests we did at the file level have now been applied at the beginning of that run block, so the resulting destroy is likely to succeed and we don't need the opening test anymore. This has changed the output of some test cases subtly in that it now reports the first run block of failing instead of the whole file. The produced diagnostics are the same, so there's no downside of this but just explains some of the changes to the tests.

## All run blocks share state with other run blocks that share configuration

Previously, for simplicities sake, all the run blocks executing against the main configuration shared a common state while all run blocks executing against alternate modules kept their state completely isolated. The reason for this is (a) we couldn't think of a use case and (b) it kept state cleanup much simpler. We have now received a use case for this (users wanting to test their example configurations from a common test directory), so I've updated the test command to support this.

Now, the test command maintains a mapping of configuration/module key to the state for the configuration/module. In this way, we've made it so that all run blocks with a common module share state between them instead of just the main configuration.

## Refactor

To support both of the above changes, I've done quite a large refactor of the functions in the test command file. The overall order of operations and outputs remain completely unchanged. But keeping track of the now more complicated state system was difficult with the old function and struct layout.

There are two main changes:

- Introduced a `TestSuiteRunner` and a `TestFileRunner` from the previous `TestRunner`.
  - This allows us to compartmentalise the state management for a single file in the TestFileRunner and deprecate the old state manager.
  - Now, the functions within TestFileRunner have direct access to the states instead of previously they needed to access the states through alternate functions.
  - This makes the more complex state management easier.
- I broke out the old `execute` function into dedicated `validate`, `destroy`, `plan`, and `apply` functions.
  - This gives more control to the external functions about what is happening when, and what should be validated when.
  - The config is now transformed at a higher level, which makes combining it with the state management system easier.
  - The separated action functions make it clearer what is happening in a test run vs a test cleanup, where previously both would just call into the complicated and long execute function.

I think that's it! Sorry for big PR!
