### PR TITLE
Update error message from an unknown Terraform Test condition

### DIFF
--- a/internal/terraform/test_context.go
+++ b/internal/terraform/test_context.go
@@ -140,8 +140,8 @@ func (ctx *TestContext) evaluate(state *states.SyncState, changes *plans.Changes
 			run.Status = run.Status.Merge(moduletest.Error)
 			run.Diagnostics = run.Diagnostics.Append(&hcl.Diagnostic{
 				Severity:    hcl.DiagError,
-				Summary:     "Unknown condition run",
-				Detail:      "Condition expression could not be evaluated at this time.",
+				Summary:     "Unknown condition value",
+				Detail:      "Condition expression could not be evaluated at this time. This means you have executed a `run` block with `command = plan` and one of the values your condition depended on is not known until after the plan has been applied. Either remove this value from your condition, or execute an `apply` command from this `run` block.",
 				Subject:     rule.Condition.Range().Ptr(),
 				Expression:  rule.Condition,
 				EvalContext: hclCtx,


### PR DESCRIPTION
We've had lots of users getting confused with this error message, and I agree it's pretty bad. This should make it a lot more clear.

eg. https://gist.github.com/alexharv074/addc4d3dd369d28378d519774a260ce4