### PR TITLE
Removing alternate functions for state and plan from `test_context.go`

### DIFF
--- a/internal/command/test.go
+++ b/internal/command/test.go
@@ -533,7 +533,7 @@ func (runner *TestFileRunner) ExecuteTestRun(run *moduletest.Run, file *modulete
 			run.Diagnostics = run.Diagnostics.Append(diags)
 		}
 
-		planCtx.TestContext(config, plan.PlannedState, plan, variables).EvaluateAgainstPlan(run)
+		planCtx.TestContext(config, plan.PlannedState, plan, variables).Evaluate(run)
 		return state, false
 	}
 
@@ -606,7 +606,7 @@ func (runner *TestFileRunner) ExecuteTestRun(run *moduletest.Run, file *modulete
 		run.Diagnostics = run.Diagnostics.Append(diags)
 	}
 
-	applyCtx.TestContext(config, updated, plan, variables).EvaluateAgainstState(run)
+	applyCtx.TestContext(config, updated, plan, variables).Evaluate(run)
 	return updated, true
 }
 


### PR DESCRIPTION
I've recently discovered that the `apply` operation removes changes from the plan as it executes. This means that we don't need the duplicate `EvaluateAgainstState` and `EvaluateAgainstPlan` functions. We can just have a single `Evaluate` function that accepts both the state and the plan safe in the knowledge the plan will have been updated if it was applied.