### PR TITLE
Update linux package license to BUSL-1.1

### DIFF
--- a/.copywrite.hcl
+++ b/.copywrite.hcl
@@ -1,8 +1,8 @@
 schema_version = 1
 
 project {
-  license        = "MPL-2.0"
-  copyright_year = 2014
+  license        = "BUS-1.1"
+  copyright_year = 2023
 
   # (OPTIONAL) A list of globs that should not have copyright/license headers.
   # Supports doublestar glob patterns for more flexibility in defining which

--- a/.github/workflows/build-terraform-oss.yml
+++ b/.github/workflows/build-terraform-oss.yml
@@ -78,7 +78,7 @@ jobs:
           version: ${{ inputs.product-version }}
           maintainer: "HashiCorp"
           homepage: "https://terraform.io/"
-          license: "MPL-2.0"
+          license: "BUSL-1.1"
           binary: "dist/terraform"
           deb_depends: "git"
           rpm_depends: "git"


### PR DESCRIPTION
This updates the linux package license to BUSL-1.1.
This PR should be merged to main so that the change is included in the next minor release that is cut from main.
License changes are not required on release branches (ongoing patch releases of current minor releases).
