### PR TITLE
Introduce 'run' keyword for referencing outputs from earlier run blocks

### DIFF
--- a/internal/addrs/parse_ref.go
+++ b/internal/addrs/parse_ref.go
@@ -111,6 +111,14 @@ func ParseRefFromTestingScope(traversal hcl.Traversal) (*Reference, tfdiags.Diag
 			Remaining:   remain,
 		}
 		diags = checkDiags
+	case "run":
+		name, rng, remain, runDiags := parseSingleAttrRef(traversal)
+		reference = &Reference{
+			Subject:     Run{Name: name},
+			SourceRange: tfdiags.SourceRangeFromHCL(rng),
+			Remaining:   remain,
+		}
+		diags = runDiags
 	}
 
 	if reference != nil {

--- a/internal/addrs/parse_ref_test.go
+++ b/internal/addrs/parse_ref_test.go
@@ -67,6 +67,51 @@ func TestParseRefInTestingScope(t *testing.T) {
 			nil,
 			`The "check" object does not support this operation.`,
 		},
+		{
+			`run.zero`,
+			&Reference{
+				Subject: Run{
+					Name: "zero",
+				},
+				SourceRange: tfdiags.SourceRange{
+					Start: tfdiags.SourcePos{Line: 1, Column: 1, Byte: 0},
+					End:   tfdiags.SourcePos{Line: 1, Column: 9, Byte: 8},
+				},
+			},
+			``,
+		},
+		{
+			`run.zero.value`,
+			&Reference{
+				Subject: Run{
+					Name: "zero",
+				},
+				SourceRange: tfdiags.SourceRange{
+					Start: tfdiags.SourcePos{Line: 1, Column: 1, Byte: 0},
+					End:   tfdiags.SourcePos{Line: 1, Column: 9, Byte: 8},
+				},
+				Remaining: hcl.Traversal{
+					hcl.TraverseAttr{
+						Name: "value",
+						SrcRange: hcl.Range{
+							Start: hcl.Pos{Line: 1, Column: 9, Byte: 8},
+							End:   hcl.Pos{Line: 1, Column: 15, Byte: 14},
+						},
+					},
+				},
+			},
+			``,
+		},
+		{
+			`run`,
+			nil,
+			`The "run" object cannot be accessed directly. Instead, access one of its attributes.`,
+		},
+		{
+			`run["foo"]`,
+			nil,
+			`The "run" object does not support this operation.`,
+		},
 
 		// Sanity check at least one of the others works to verify it does
 		// fall through to the core function.
@@ -827,7 +872,7 @@ func TestParseRef(t *testing.T) {
 			`A reference to a resource type must be followed by at least one attribute access, specifying the resource name.`,
 		},
 
-		// Should interpret checks and outputs as resource types.
+		// Should interpret checks, outputs, and runs as resource types.
 		{
 			`output.value`,
 			&Reference{
@@ -854,6 +899,21 @@ func TestParseRef(t *testing.T) {
 				SourceRange: tfdiags.SourceRange{
 					Start: tfdiags.SourcePos{Line: 1, Column: 1, Byte: 0},
 					End:   tfdiags.SourcePos{Line: 1, Column: 13, Byte: 12},
+				},
+			},
+			``,
+		},
+		{
+			`run.zero`,
+			&Reference{
+				Subject: Resource{
+					Mode: ManagedResourceMode,
+					Type: "run",
+					Name: "zero",
+				},
+				SourceRange: tfdiags.SourceRange{
+					Start: tfdiags.SourcePos{Line: 1, Column: 1, Byte: 0},
+					End:   tfdiags.SourcePos{Line: 1, Column: 9, Byte: 8},
 				},
 			},
 			``,

--- a/internal/addrs/run.go
+++ b/internal/addrs/run.go
@@ -1,0 +1,27 @@
+package addrs
+
+import "fmt"
+
+// Run is the address of a run block within a testing file.
+//
+// Run blocks are only accessible from within the same testing file, and they
+// do not support any meta-arguments like "count" or "for_each". So this address
+// uniquely describes a run block from within a single testing file.
+type Run struct {
+	referenceable
+	Name string
+}
+
+func (r Run) String() string {
+	return fmt.Sprintf("run.%s", r.Name)
+}
+
+func (r Run) Equal(run Run) bool {
+	return r.Name == run.Name
+}
+
+func (r Run) UniqueKey() UniqueKey {
+	return r // A Run is its own UniqueKey
+}
+
+func (r Run) uniqueKeySigil() {}

--- a/internal/command/meta_vars.go
+++ b/internal/command/meta_vars.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 	hcljson "github.com/hashicorp/hcl/v2/json"
+
 	"github.com/hashicorp/terraform/internal/backend"
 	"github.com/hashicorp/terraform/internal/configs"
 	"github.com/hashicorp/terraform/internal/terraform"
@@ -264,5 +265,24 @@ func (v unparsedVariableValueString) ParseVariableValue(mode configs.VariablePar
 	return &terraform.InputValue{
 		Value:      val,
 		SourceType: v.sourceType,
+	}, diags
+}
+
+type unparsedTestVariableValue struct {
+	expr hcl.Expression
+	ctx  *hcl.EvalContext
+}
+
+func (v unparsedTestVariableValue) ParseVariableValue(mode configs.VariableParsingMode) (*terraform.InputValue, tfdiags.Diagnostics) {
+	var diags tfdiags.Diagnostics
+	val, hclDiags := v.expr.Value(v.ctx) // nil because no function calls or variable references are allowed here
+	diags = diags.Append(hclDiags)
+
+	rng := tfdiags.SourceRangeFromHCL(v.expr.Range())
+
+	return &terraform.InputValue{
+		Value:       val,
+		SourceType:  terraform.ValueFromConfig, // Test variables always come from config.
+		SourceRange: rng,
 	}, diags
 }

--- a/internal/command/testdata/test/shared_state/main.tf
+++ b/internal/command/testdata/test/shared_state/main.tf
@@ -1,0 +1,12 @@
+
+variable "input" {
+  type = string
+}
+
+resource "test_resource" "foo" {
+  value = var.input
+}
+
+output "value" {
+  value = test_resource.foo.value
+}

--- a/internal/command/testdata/test/shared_state/main.tftest.hcl
+++ b/internal/command/testdata/test/shared_state/main.tftest.hcl
@@ -1,0 +1,37 @@
+
+variables {
+  foo = "foo"
+}
+
+
+run "setup" {
+  module {
+    source = "./setup"
+  }
+
+  variables {
+    input = "foo"
+  }
+
+  assert {
+    condition = output.value == var.foo
+    error_message = "bad"
+  }
+}
+
+run "test" {
+
+  variables {
+    input = run.setup.value
+  }
+
+  assert {
+    condition = output.value == var.foo
+    error_message = "double bad"
+  }
+
+  assert {
+    condition = run.setup.value == var.foo
+    error_message = "triple bad"
+  }
+}

--- a/internal/command/testdata/test/shared_state/setup/main.tf
+++ b/internal/command/testdata/test/shared_state/setup/main.tf
@@ -1,0 +1,12 @@
+
+variable "input" {
+  type = string
+}
+
+resource "test_resource" "foo" {
+  value = var.input
+}
+
+output "value" {
+  value = test_resource.foo.value
+}

--- a/internal/command/testdata/test/shared_state_object/main.tf
+++ b/internal/command/testdata/test/shared_state_object/main.tf
@@ -1,0 +1,12 @@
+
+variable "input" {
+  type = string
+}
+
+resource "test_resource" "foo" {
+  value = var.input
+}
+
+output "value" {
+  value = test_resource.foo.value
+}

--- a/internal/command/testdata/test/shared_state_object/main.tftest.hcl
+++ b/internal/command/testdata/test/shared_state_object/main.tftest.hcl
@@ -1,0 +1,37 @@
+
+variables {
+  foo = "foo"
+}
+
+
+run "setup" {
+  module {
+    source = "./setup"
+  }
+
+  variables {
+    input = "foo"
+  }
+
+  assert {
+    condition     = output.value == var.foo
+    error_message = "bad"
+  }
+}
+
+run "test" {
+
+  variables {
+    input = run.setup.value
+  }
+
+  assert {
+    condition     = output.value == var.foo
+    error_message = "double bad"
+  }
+
+  assert {
+    condition     = run.setup == { value : "foo" }
+    error_message = "triple bad"
+  }
+}

--- a/internal/command/testdata/test/shared_state_object/setup/main.tf
+++ b/internal/command/testdata/test/shared_state_object/setup/main.tf
@@ -1,0 +1,12 @@
+
+variable "input" {
+  type = string
+}
+
+resource "test_resource" "foo" {
+  value = var.input
+}
+
+output "value" {
+  value = test_resource.foo.value
+}

--- a/internal/lang/data.go
+++ b/internal/lang/data.go
@@ -36,4 +36,5 @@ type Data interface {
 	GetInputVariable(addrs.InputVariable, tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics)
 	GetOutput(addrs.OutputValue, tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics)
 	GetCheckBlock(addrs.Check, tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics)
+	GetRunBlock(addrs.Run, tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics)
 }

--- a/internal/lang/data_test.go
+++ b/internal/lang/data_test.go
@@ -21,6 +21,7 @@ type dataForTests struct {
 	TerraformAttrs map[string]cty.Value
 	InputVariables map[string]cty.Value
 	CheckBlocks    map[string]cty.Value
+	RunBlocks      map[string]cty.Value
 }
 
 var _ Data = &dataForTests{}
@@ -73,4 +74,8 @@ func (d *dataForTests) GetOutput(addr addrs.OutputValue, rng tfdiags.SourceRange
 
 func (d *dataForTests) GetCheckBlock(addr addrs.Check, rng tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics) {
 	return d.CheckBlocks[addr.Name], nil
+}
+
+func (d *dataForTests) GetRunBlock(addr addrs.Run, rng tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics) {
+	return d.RunBlocks[addr.Name], nil
 }

--- a/internal/terraform/evaluate.go
+++ b/internal/terraform/evaluate.go
@@ -65,6 +65,13 @@ type Evaluator struct {
 	// ensures they can be safely accessed and modified concurrently.
 	Changes *plans.ChangesSync
 
+	// AlternateStates allows callers to reference states from outside this
+	// evaluator.
+	//
+	// The main use case here is for the testing framework to call into other
+	// run blocks.
+	AlternateStates map[string]*evaluationStateData
+
 	PlanTimestamp time.Time
 }
 
@@ -1003,6 +1010,33 @@ func (d *evaluationStateData) GetCheckBlock(addr addrs.Check, rng tfdiags.Source
 		Subject:  rng.ToHCL().Ptr(),
 	})
 	return cty.NilVal, diags
+}
+
+func (d *evaluationStateData) GetRunBlock(run addrs.Run, rng tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics) {
+	var diags tfdiags.Diagnostics
+
+	data, exists := d.Evaluator.AlternateStates[run.Name]
+	if !exists {
+		diags = diags.Append(&hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  "Reference to unavailable run block",
+			Detail:   fmt.Sprintf("The current test file either contains no %s, or hasn't executed it yet.", run),
+			Subject:  rng.ToHCL().Ptr(),
+		})
+		return cty.DynamicVal, diags
+	}
+
+	outputs := make(map[string]cty.Value)
+	for _, outputCfg := range data.Evaluator.Config.Module.Outputs {
+		output, outputDiags := data.GetOutput(outputCfg.Addr(), rng)
+		diags = diags.Append(outputDiags)
+		if outputDiags.HasErrors() {
+			continue
+		}
+		outputs[outputCfg.Name] = output
+	}
+
+	return cty.ObjectVal(outputs), diags
 }
 
 // moduleDisplayAddr returns a string describing the given module instance

--- a/internal/terraform/evaluate_test.go
+++ b/internal/terraform/evaluate_test.go
@@ -634,3 +634,95 @@ func evaluatorForModule(stateSync *states.SyncState, changesSync *plans.ChangesS
 		Changes: changesSync,
 	}
 }
+
+func TestGetRunBlocks(t *testing.T) {
+	evaluator := &Evaluator{
+		AlternateStates: map[string]*evaluationStateData{
+			"zero": {
+				Evaluator: &Evaluator{
+					State: states.BuildState(func(state *states.SyncState) {
+						state.SetOutputValue(addrs.AbsOutputValue{
+							Module: addrs.RootModuleInstance,
+							OutputValue: addrs.OutputValue{
+								Name: "value",
+							},
+						}, cty.StringVal("Hello, world!"), false)
+					}).SyncWrapper(),
+					Config: &configs.Config{
+						Module: &configs.Module{
+							Outputs: map[string]*configs.Output{
+								"value": {
+									Name: "value",
+								},
+							},
+						},
+					},
+				},
+			},
+			"one": {
+				Evaluator: &Evaluator{
+					State: states.BuildState(func(state *states.SyncState) {
+						state.SetOutputValue(addrs.AbsOutputValue{
+							Module: addrs.RootModuleInstance,
+							OutputValue: addrs.OutputValue{
+								Name: "value",
+							},
+						}, cty.StringVal("Hello, universe!"), false)
+					}).SyncWrapper(),
+					Config: &configs.Config{
+						Module: &configs.Module{
+							Outputs: map[string]*configs.Output{
+								"value": {
+									Name: "value",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	data := &evaluationStateData{
+		Evaluator:       evaluator,
+		ModulePath:      nil,
+		InstanceKeyData: EvalDataForNoInstanceKey,
+	}
+
+	scope := evaluator.Scope(data, nil, nil)
+	got, diags := scope.Data.GetRunBlock(addrs.Run{Name: "zero"}, tfdiags.SourceRange{})
+	want := cty.ObjectVal(map[string]cty.Value{
+		"value": cty.StringVal("Hello, world!"),
+	})
+
+	if diags.HasErrors() {
+		t.Fatalf("unexpected diagnostics: %s", diags.Err())
+	}
+
+	if !got.RawEquals(want) {
+		t.Errorf("\ngot: %#v\nwant: %#v", got, want)
+	}
+
+	got, diags = scope.Data.GetRunBlock(addrs.Run{Name: "one"}, tfdiags.SourceRange{})
+	want = cty.ObjectVal(map[string]cty.Value{
+		"value": cty.StringVal("Hello, universe!"),
+	})
+
+	if diags.HasErrors() {
+		t.Fatalf("unexpected diagnostics: %s", diags.Err())
+	}
+
+	if !got.RawEquals(want) {
+		t.Errorf("\ngot: %#v\nwant: %#v", got, want)
+	}
+
+	got, diags = scope.Data.GetRunBlock(addrs.Run{Name: "two"}, tfdiags.SourceRange{})
+
+	if !diags.HasErrors() {
+		t.Fatalf("expected some diags but got none")
+	}
+
+	if diags[0].Description().Summary != "Reference to unavailable run block" {
+		t.Errorf("retrieved unexpected diagnostic: %s", diags[0].Description().Summary)
+	}
+}

--- a/internal/terraform/evaluate_test.go
+++ b/internal/terraform/evaluate_test.go
@@ -716,7 +716,7 @@ func TestGetRunBlocks(t *testing.T) {
 		t.Errorf("\ngot: %#v\nwant: %#v", got, want)
 	}
 
-	got, diags = scope.Data.GetRunBlock(addrs.Run{Name: "two"}, tfdiags.SourceRange{})
+	_, diags = scope.Data.GetRunBlock(addrs.Run{Name: "two"}, tfdiags.SourceRange{})
 
 	if !diags.HasErrors() {
 		t.Fatalf("expected some diags but got none")

--- a/internal/terraform/test_context_test.go
+++ b/internal/terraform/test_context_test.go
@@ -9,6 +9,7 @@ import (
 	ctymsgpack "github.com/zclconf/go-cty/cty/msgpack"
 
 	"github.com/hashicorp/terraform/internal/addrs"
+	"github.com/hashicorp/terraform/internal/configs"
 	"github.com/hashicorp/terraform/internal/configs/configschema"
 	"github.com/hashicorp/terraform/internal/moduletest"
 	"github.com/hashicorp/terraform/internal/plans"
@@ -19,11 +20,12 @@ import (
 
 func TestTestContext_Evaluate(t *testing.T) {
 	tcs := map[string]struct {
-		configs   map[string]string
-		state     *states.State
-		plan      *plans.Plan
-		variables InputValues
-		provider  *MockProvider
+		configs     map[string]string
+		state       *states.State
+		plan        *plans.Plan
+		variables   InputValues
+		provider    *MockProvider
+		priorStates map[string]func(config *configs.Config) *TestContext
 
 		expectedDiags  []tfdiags.Description
 		expectedStatus moduletest.Status
@@ -532,6 +534,94 @@ run "test_case" {
 				},
 			},
 		},
+		"with_prior_state": {
+			configs: map[string]string{
+				"main.tf": `
+resource "test_resource" "a" {
+	value = "Hello, world!"
+}
+`,
+				"main.tftest.hcl": `
+run "setup" {}
+
+run "test_case" {
+	assert {
+		condition = test_resource.a.value == run.setup.value
+		error_message = "invalid value"
+	}
+}
+`,
+			},
+			plan: &plans.Plan{
+				Changes: plans.NewChanges(),
+			},
+			state: states.BuildState(func(state *states.SyncState) {
+				state.SetResourceInstanceCurrent(
+					addrs.Resource{
+						Mode: addrs.ManagedResourceMode,
+						Type: "test_resource",
+						Name: "a",
+					}.Instance(addrs.NoKey).Absolute(addrs.RootModuleInstance),
+					&states.ResourceInstanceObjectSrc{
+						Status: states.ObjectReady,
+						AttrsJSON: encodeCtyValue(t, cty.ObjectVal(map[string]cty.Value{
+							"value": cty.StringVal("Hello, world!"),
+						})),
+					},
+					addrs.AbsProviderConfig{
+						Module:   addrs.RootModule,
+						Provider: addrs.NewDefaultProvider("test"),
+					})
+			}),
+			priorStates: map[string]func(config *configs.Config) *TestContext{
+				"setup": func(config *configs.Config) *TestContext {
+					return &TestContext{
+						Context: &Context{},
+						Run: &moduletest.Run{
+							Config: config.Module.Tests["main.tftest.hcl"].Runs[0],
+							Name:   "setup",
+						},
+						Config: &configs.Config{
+							Module: &configs.Module{
+								Outputs: map[string]*configs.Output{
+									"value": {
+										Name: "value",
+									},
+								},
+							},
+						},
+						Plan: &plans.Plan{
+							Changes: plans.NewChanges(),
+						},
+						State: states.BuildState(func(state *states.SyncState) {
+							state.SetOutputValue(addrs.AbsOutputValue{
+								Module: addrs.RootModuleInstance,
+								OutputValue: addrs.OutputValue{
+									Name: "value",
+								},
+							}, cty.StringVal("Hello, world!"), false)
+						}),
+					}
+				},
+			},
+			provider: &MockProvider{
+				GetProviderSchemaResponse: &providers.GetProviderSchemaResponse{
+					ResourceTypes: map[string]providers.Schema{
+						"test_resource": {
+							Block: &configschema.Block{
+								Attributes: map[string]*configschema.Attribute{
+									"value": {
+										Type:     cty.String,
+										Required: true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedStatus: moduletest.Pass,
+		},
 	}
 	for name, tc := range tcs {
 		t.Run(name, func(t *testing.T) {
@@ -542,13 +632,19 @@ run "test_case" {
 				},
 			})
 
-			run := moduletest.Run{
-				Config: config.Module.Tests["main.tftest.hcl"].Runs[0],
-				Name:   "test_case",
+			priorStates := make(map[string]*TestContext)
+			for run, ps := range tc.priorStates {
+				priorStates[run] = ps(config)
 			}
 
-			tctx := ctx.TestContext(config, tc.state, tc.plan, tc.variables)
-			tctx.Evaluate(&run)
+			file := config.Module.Tests["main.tftest.hcl"]
+			run := moduletest.Run{
+				Config: file.Runs[len(file.Runs)-1], // We always simulate the last run block.
+				Name:   "test_case",                 // and it should be named test_case
+			}
+
+			tctx := ctx.TestContext(&run, config, tc.state, tc.plan, tc.variables)
+			tctx.Evaluate(priorStates)
 
 			if expected, actual := tc.expectedStatus, run.Status; expected != actual {
 				t.Errorf("expected status \"%s\" but got \"%s\"", expected, actual)


### PR DESCRIPTION
This PR updates the evaluation context for Terraform so that assertions and variable blocks within testing files can access the outputs of earlier run blocks.

### Quick Example

The following example demonstrates how this is helpful to users who want to create temporary infrastructure to be used within their tests, but that infrastructure isn't something the module they are writing wants to manage themselves.

```hcl
# main.tftest.hcl

run "setup" {
  module {
    source = "./create_vpc"
  }
}

run "test" {
  variables {
    vpc_id = run.setup.vpc_id
  }

  assert {
    condition = aws_security_group.primary.vpc_id == run.setup.vpc_id
    error_message = "security group was assigned to the wrong VPC"
  }
}
```

## State management

A big part of this change is the need to make "alternate state files" available to the evaluation context. As part of this, the `evaluationStateData` now contains a nested reference to itself allowing the caller to pass in alternate states. The run block part of the evaluation can then look into the alternate states to see if has any keyed by the run block id and load the outputs from the alternate state.

This alternate state is now tracked in the test command, and passed into the `TestContext` when it comes time to evaluate the assertion conditions for a given test run.

## Variable management

You can also refer to prior run blocks from within the `variables` blocks inside run blocks. Previously, variable expressions were also evaluated without any context. I created a new kind of variable evaluator called `unparsedTestVariableValue` which contains an `hcl.EvalContext` which contains all the outputs from the previous run blocks.

## Additional Changes

- I created an `addr.Run` structure to handle parsing references to the run blocks.
- I updated the `ParseRefFromTestingScope` so it handles run blocks.
  - This is what ensures that run blocks can't be referenced from inside and prevents any breaking changes. Only the testing evaluators use `ParseRefFromTestingScope` so attempting to reference a run block from the main configuration will cause it to treat it as an attempt to reference a resource which is the existing behaviour.