### PR TITLE
Ignore remote version conflict for force-unlock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 1.7.0 (Unreleased)
 
+BUG FIXES:
+
+* Ignore potential remote terraform version mismatch when running force-unlock ([#28853](https://github.com/hashicorp/terraform/issues/28853))
+
 ## Previous Releases
 
 For information on prior major and minor releases, see their changelogs:

--- a/internal/command/unlock.go
+++ b/internal/command/unlock.go
@@ -68,6 +68,9 @@ func (c *UnlockCommand) Run(args []string) int {
 		return 1
 	}
 
+	// This is a read-only operation with respect to the state contents
+	c.ignoreRemoteVersionConflict(b)
+
 	env, err := c.Workspace()
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf("Error selecting workspace: %s", err))


### PR DESCRIPTION
`terraform force-unlock` should allow backends to ignore version conflicts since it does not write state.

Fixes #28853 

## Target Release

1.6.0
