### PR TITLE
Include run block for JSON fatal interrupt test summaries

### DIFF
--- a/internal/command/views/test.go
+++ b/internal/command/views/test.go
@@ -532,11 +532,20 @@ func (t *TestJSON) FatalInterruptSummary(run *moduletest.Run, file *moduletest.F
 		return
 	}
 
-	t.view.log.Error(
-		"Terraform was interrupted during test execution, and may not have performed the expected cleanup operations.",
-		"type", json.MessageTestInterrupt,
-		json.MessageTestInterrupt, message,
-		"@testfile", file.Name)
+	if run != nil {
+		t.view.log.Error(
+			"Terraform was interrupted during test execution, and may not have performed the expected cleanup operations.",
+			"type", json.MessageTestInterrupt,
+			json.MessageTestInterrupt, message,
+			"@testfile", file.Name,
+			"@testrun", run.Name)
+	} else {
+		t.view.log.Error(
+			"Terraform was interrupted during test execution, and may not have performed the expected cleanup operations.",
+			"type", json.MessageTestInterrupt,
+			json.MessageTestInterrupt, message,
+			"@testfile", file.Name)
+	}
 }
 
 func colorizeTestStatus(status moduletest.Status, color *colorstring.Colorize) string {

--- a/internal/command/views/test_test.go
+++ b/internal/command/views/test_test.go
@@ -2816,6 +2816,7 @@ func TestTestJSON_FatalInterruptSummary(t *testing.T) {
 					"@message":  "Terraform was interrupted during test execution, and may not have performed the expected cleanup operations.",
 					"@module":   "terraform.ui",
 					"@testfile": "main.tftest.hcl",
+					"@testrun":  "run_block",
 					"test_interrupt": map[string]interface{}{
 						"planned": []interface{}{
 							"test_instance.one",
@@ -2865,6 +2866,7 @@ func TestTestJSON_FatalInterruptSummary(t *testing.T) {
 					"@message":  "Terraform was interrupted during test execution, and may not have performed the expected cleanup operations.",
 					"@module":   "terraform.ui",
 					"@testfile": "main.tftest.hcl",
+					"@testrun":  "run_block",
 					"test_interrupt": map[string]interface{}{
 						"state": []interface{}{
 							map[string]interface{}{
@@ -2918,6 +2920,7 @@ func TestTestJSON_FatalInterruptSummary(t *testing.T) {
 					"@message":  "Terraform was interrupted during test execution, and may not have performed the expected cleanup operations.",
 					"@module":   "terraform.ui",
 					"@testfile": "main.tftest.hcl",
+					"@testrun":  "run_block",
 					"test_interrupt": map[string]interface{}{
 						"states": map[string]interface{}{
 							"setup_block": []interface{}{
@@ -3033,6 +3036,7 @@ func TestTestJSON_FatalInterruptSummary(t *testing.T) {
 					"@message":  "Terraform was interrupted during test execution, and may not have performed the expected cleanup operations.",
 					"@module":   "terraform.ui",
 					"@testfile": "main.tftest.hcl",
+					"@testrun":  "run_block",
 					"test_interrupt": map[string]interface{}{
 						"state": []interface{}{
 							map[string]interface{}{


### PR DESCRIPTION
This PR updates the JSON message printed during a fatal interrupt of a test operation to include the run block metadata.

This is important for the cloud integration which has to recreate the human readable message from the JSON output.