### PR TITLE
Update test framework variable parsing to support complex types

### DIFF
--- a/internal/command/test.go
+++ b/internal/command/test.go
@@ -1144,7 +1144,7 @@ func (runner *TestFileRunner) prepareInputVariablesForAssertions(config *configs
 	inputs := make(terraform.InputValues, len(variables))
 	var diags tfdiags.Diagnostics
 	for name, variable := range variables {
-		value, valueDiags := variable.ParseVariableValue(configs.VariableParseLiteral)
+		value, valueDiags := variable.ParseVariableValue(configs.VariableParseHCL)
 		diags = diags.Append(valueDiags)
 		inputs[name] = value
 	}

--- a/internal/command/test_test.go
+++ b/internal/command/test_test.go
@@ -143,6 +143,11 @@ func TestTest(t *testing.T) {
 			expected: "2 passed, 0 failed.",
 			code:     0,
 		},
+		"variables_types": {
+			expected: "1 passed, 0 failed.",
+			args:     []string{"-var=number_input=0", "-var=string_input=\"Hello, world!\"", "-var=list_input=[\"Hello\",\"world\"]"},
+			code:     0,
+		},
 	}
 	for name, tc := range tcs {
 		t.Run(name, func(t *testing.T) {

--- a/internal/command/testdata/test/variables_types/main.tf
+++ b/internal/command/testdata/test/variables_types/main.tf
@@ -1,0 +1,11 @@
+variable "string_input" {
+  type    = string
+}
+
+variable "number_input" {
+  type = number
+}
+
+variable "list_input" {
+  type = list(string)
+}

--- a/internal/command/testdata/test/variables_types/main.tftest.hcl
+++ b/internal/command/testdata/test/variables_types/main.tftest.hcl
@@ -1,0 +1,20 @@
+run "variables" {
+
+  # This run block requires the following variables to have been defined as
+  # command line arguments.
+
+  assert {
+    condition = var.number_input == 0
+    error_message = "bad number value"
+  }
+
+  assert {
+    condition = var.string_input == "Hello, world!"
+    error_message = "bad string value"
+  }
+
+  assert {
+    condition = var.list_input == ["Hello", "world"]
+    error_message = "bad list value"
+  }
+}


### PR DESCRIPTION
Previously, when parsing variable values to be included in the test assertions we were using the `VariableParseLiteral` mode. This interprets all inputs as strings when using inputs from the CLI and environment variables. This meant that we potentially had failing assertions because variables were being marked as strings while values in the plan or state had their proper type.

This PR updates the `prepareInputVariablesForAssertions` function to use `VariableParseHCL` which loads variables from the CLI with their correct types.