### PR TITLE
Allow referencing higher level variables from run blocks

### DIFF
--- a/internal/command/testdata/test/bad-references/main.tf
+++ b/internal/command/testdata/test/bad-references/main.tf
@@ -1,0 +1,16 @@
+
+variable "input_one" {
+  type = string
+}
+
+variable "input_two" {
+  type = string
+}
+
+resource "test_resource" "resource" {
+  value = "${var.input_one} - ${var.input_two}"
+}
+
+output "response" {
+  value = test_resource.resource.value
+}

--- a/internal/command/testdata/test/bad-references/main.tftest.hcl
+++ b/internal/command/testdata/test/bad-references/main.tftest.hcl
@@ -1,0 +1,26 @@
+
+variables {
+  default = "double"
+}
+
+run "setup" {
+  variables {
+    input_one = var.default
+    input_two = var.default
+  }
+}
+
+run "test" {
+  variables {
+    input_one = var.notreal
+    input_two = run.finalise.response
+    input_three = run.madeup.response
+  }
+}
+
+run "finalise" {
+  variables {
+    input_one = var.default
+    input_two = var.default
+  }
+}

--- a/internal/command/testdata/test/variable_references/main.tf
+++ b/internal/command/testdata/test/variable_references/main.tf
@@ -1,0 +1,12 @@
+
+variable "input_one" {
+  type = string
+}
+
+variable "input_two" {
+  type = string
+}
+
+resource "test_resource" "resource" {
+  value = "${var.input_one} - ${var.input_two}"
+}

--- a/internal/command/testdata/test/variable_references/main.tftest.hcl
+++ b/internal/command/testdata/test/variable_references/main.tftest.hcl
@@ -1,0 +1,27 @@
+variables {
+  default = "double"
+}
+
+run "primary" {
+  variables {
+    input_one = var.default
+    input_two = var.default
+  }
+
+  assert {
+    condition = test_resource.resource.value == "${var.default} - ${var.input_two}"
+    error_message = "bad concatenation"
+  }
+}
+
+run "secondary" {
+  variables {
+    input_one = var.default
+    input_two = var.global # This test requires this passed in as a global var.
+  }
+
+  assert {
+    condition = test_resource.resource.value == "double - ${var.global}"
+    error_message = "bad concatenation"
+  }
+}

--- a/internal/command/testdata/test/variables_types/main.tf
+++ b/internal/command/testdata/test/variables_types/main.tf
@@ -1,0 +1,11 @@
+variable "string_input" {
+  type    = string
+}
+
+variable "number_input" {
+  type = number
+}
+
+variable "list_input" {
+  type = list(string)
+}

--- a/internal/command/testdata/test/variables_types/main.tftest.hcl
+++ b/internal/command/testdata/test/variables_types/main.tftest.hcl
@@ -1,0 +1,20 @@
+run "variables" {
+
+  # This run block requires the following variables to have been defined as
+  # command line arguments.
+
+  assert {
+    condition = var.number_input == 0
+    error_message = "bad number value"
+  }
+
+  assert {
+    condition = var.string_input == "Hello, world!"
+    error_message = "bad string value"
+  }
+
+  assert {
+    condition = var.list_input == tolist(["Hello", "world"])
+    error_message = "bad list value"
+  }
+}


### PR DESCRIPTION
This PR updates the testing framework to support variable references from inside run variable blocks. For example:

```hcl
# main.tftest.hcl

variables {
  shared_resource_id = "... some value ..."
}

run "setup_resources" {
  module = {
    source = "./setup
  }

  variables {
    id_for_resource_to_be_created = var.shared_resource_id
  }
}

run "actual_test" {
  variables {
    is_for_resource_that_is_supposed_to_exist = var.shared_resource_id
  }
}
```

This allows users to share variable values between run blocks even if the modules they are referencing don't share variables with the same name.

In addition, this PR adds some validation into the `EvalCtx` and variable functions so the errors and diagnostics they produce are customised to the testing framework. For example now they will reference the actual run block where the error occurred, and give more specific instructions on how to fix compared to previously where the error might be a generic "this value is missing".