### PR TITLE
backend/s3: support multiple shared config/credentials files

### DIFF
--- a/internal/backend/remote-state/s3/backend_complete_test.go
+++ b/internal/backend/remote-state/s3/backend_complete_test.go
@@ -210,14 +210,14 @@ aws_secret_access_key = ProfileSharedCredentialsSecretKey
 				servicemocks.MockStsGetCallerIdentityValidEndpoint,
 			},
 			SharedCredentialsFile: `
-		[default]
-		aws_access_key_id = DefaultSharedCredentialsAccessKey
-		aws_secret_access_key = DefaultSharedCredentialsSecretKey
+[default]
+aws_access_key_id = DefaultSharedCredentialsAccessKey
+aws_secret_access_key = DefaultSharedCredentialsSecretKey
 
-		[SharedCredentialsProfile]
-		aws_access_key_id = ProfileSharedCredentialsAccessKey
-		aws_secret_access_key = ProfileSharedCredentialsSecretKey
-		`,
+[SharedCredentialsProfile]
+aws_access_key_id = ProfileSharedCredentialsAccessKey
+aws_secret_access_key = ProfileSharedCredentialsSecretKey
+`,
 			ValidateDiags: ExpectNoDiags,
 		},
 
@@ -234,14 +234,14 @@ aws_secret_access_key = ProfileSharedCredentialsSecretKey
 				servicemocks.MockStsGetCallerIdentityValidEndpoint,
 			},
 			SharedCredentialsFile: `
-		[default]
-		aws_access_key_id = DefaultSharedCredentialsAccessKey
-		aws_secret_access_key = DefaultSharedCredentialsSecretKey
+[default]
+aws_access_key_id = DefaultSharedCredentialsAccessKey
+aws_secret_access_key = DefaultSharedCredentialsSecretKey
 
-		[SharedCredentialsProfile]
-		aws_access_key_id = ProfileSharedCredentialsAccessKey
-		aws_secret_access_key = ProfileSharedCredentialsSecretKey
-		`,
+[SharedCredentialsProfile]
+aws_access_key_id = ProfileSharedCredentialsAccessKey
+aws_secret_access_key = ProfileSharedCredentialsSecretKey
+`,
 			ValidateDiags: ExpectNoDiags,
 		},
 
@@ -541,10 +541,10 @@ region = us-east-1
 				"AWS_PROFILE": "no-such-profile",
 			},
 			SharedCredentialsFile: `
-		[some-profile]
-		aws_access_key_id = DefaultSharedCredentialsAccessKey
-		aws_secret_access_key = DefaultSharedCredentialsSecretKey
-		`,
+[some-profile]
+aws_access_key_id = DefaultSharedCredentialsAccessKey
+aws_secret_access_key = DefaultSharedCredentialsSecretKey
+`,
 			ValidateDiags: ExpectDiagMatching(
 				tfdiags.Error,
 				equalsMatcher("failed to get shared config profile, no-such-profile"),
@@ -557,10 +557,10 @@ region = us-east-1
 				"profile": "no-such-profile",
 			},
 			SharedCredentialsFile: `
-		[some-profile]
-		aws_access_key_id = DefaultSharedCredentialsAccessKey
-		aws_secret_access_key = DefaultSharedCredentialsSecretKey
-		`,
+[some-profile]
+aws_access_key_id = DefaultSharedCredentialsAccessKey
+aws_secret_access_key = DefaultSharedCredentialsSecretKey
+`,
 			ValidateDiags: ExpectDiagMatching(
 				tfdiags.Error,
 				equalsMatcher("failed to get shared config profile, no-such-profile"),
@@ -599,10 +599,10 @@ aws_secret_access_key = ProfileSharedCredentialsSecretKey
 				"AWS_PROFILE":           "no-such-profile",
 			},
 			SharedCredentialsFile: `
-		[some-profile]
-		aws_access_key_id = DefaultSharedCredentialsAccessKey
-		aws_secret_access_key = DefaultSharedCredentialsSecretKey
-		`,
+[some-profile]
+aws_access_key_id = DefaultSharedCredentialsAccessKey
+aws_secret_access_key = DefaultSharedCredentialsSecretKey
+`,
 			ValidateDiags: ExpectDiagMatching(
 				tfdiags.Error,
 				equalsMatcher("failed to get shared config profile, no-such-profile"),
@@ -708,7 +708,7 @@ aws_secret_access_key = ProfileSharedCredentialsSecretKey
 					t.Fatalf("unexpected error writing shared credentials file: %s", err)
 				}
 
-				tc.config["shared_credentials_file"] = file.Name()
+				tc.config["shared_credentials_files"] = []interface{}{file.Name()}
 				if tc.ExpectedCredentialsValue.Source == sharedConfigCredentialsProvider {
 					tc.ExpectedCredentialsValue.Source = sharedConfigCredentialsSource(file.Name())
 				}
@@ -1182,7 +1182,7 @@ aws_secret_access_key = DefaultSharedCredentialsSecretKey
 					t.Fatalf("unexpected error writing shared credentials file: %s", err)
 				}
 
-				tc.config["shared_credentials_file"] = file.Name()
+				tc.config["shared_credentials_files"] = []interface{}{file.Name()}
 				if tc.ExpectedCredentialsValue.Source == sharedConfigCredentialsProvider {
 					tc.ExpectedCredentialsValue.Source = sharedConfigCredentialsSource(file.Name())
 				}
@@ -1622,7 +1622,7 @@ aws_secret_access_key = DefaultSharedCredentialsSecretKey
 					t.Fatalf("unexpected error writing shared credentials file: %s", err)
 				}
 
-				tc.config["shared_credentials_file"] = file.Name()
+				tc.config["shared_credentials_files"] = []interface{}{file.Name()}
 				if tc.ExpectedCredentialsValue.Source == sharedConfigCredentialsProvider {
 					tc.ExpectedCredentialsValue.Source = sharedConfigCredentialsSource(file.Name())
 				}

--- a/internal/backend/remote-state/s3/backend_test.go
+++ b/internal/backend/remote-state/s3/backend_test.go
@@ -709,6 +709,28 @@ func TestBackendConfig_PrepareConfigValidation(t *testing.T) {
 				),
 			},
 		},
+
+		"shared credentials file conflict": {
+			config: cty.ObjectVal(map[string]cty.Value{
+				"bucket":                   cty.StringVal("test"),
+				"key":                      cty.StringVal("test"),
+				"region":                   cty.StringVal("us-west-2"),
+				"shared_credentials_file":  cty.StringVal("test"),
+				"shared_credentials_files": cty.SetVal([]cty.Value{cty.StringVal("test2")}),
+			}),
+			expectedDiags: tfdiags.Diagnostics{
+				attributeErrDiag(
+					"Invalid Attribute Combination",
+					`Only one of shared_credentials_file, shared_credentials_files can be set.`,
+					cty.Path{},
+				),
+				attributeWarningDiag(
+					"Deprecated Parameter",
+					`The shared_credentials_file parameter has been deprecated. Use shared_credentials_files instead.`,
+					cty.GetAttrPath("shared_credentials_file"),
+				),
+			},
+		},
 	}
 
 	for name, tc := range cases {

--- a/internal/backend/remote-state/s3/validate.go
+++ b/internal/backend/remote-state/s3/validate.go
@@ -346,6 +346,10 @@ func attributeErrDiag(summary, detail string, attrPath cty.Path) tfdiags.Diagnos
 	return tfdiags.AttributeValue(tfdiags.Error, summary, detail, attrPath.Copy())
 }
 
+func attributeWarningDiag(summary, detail string, attrPath cty.Path) tfdiags.Diagnostic {
+	return tfdiags.AttributeValue(tfdiags.Warning, summary, detail, attrPath.Copy())
+}
+
 func wholeBodyErrDiag(summary, detail string) tfdiags.Diagnostic {
 	return tfdiags.WholeContainingBody(tfdiags.Error, summary, detail)
 }

--- a/website/docs/language/settings/backends/s3.mdx
+++ b/website/docs/language/settings/backends/s3.mdx
@@ -157,7 +157,9 @@ The following configuration is optional:
 * `iam_endpoint` - (Optional) Custom endpoint for the AWS Identity and Access Management (IAM) API. This can also be sourced from the `AWS_IAM_ENDPOINT` environment variable.
 * `max_retries` - (Optional) The maximum number of times an AWS API request is retried on retryable failure. Defaults to 5.
 * `profile` - (Optional) Name of AWS profile in AWS shared credentials file (e.g. `~/.aws/credentials`) or AWS shared configuration file (e.g. `~/.aws/config`) to use for credentials and/or configuration. This can also be sourced from the `AWS_PROFILE` environment variable.
-* `shared_credentials_file`  - (Optional) Path to the AWS shared credentials file. Defaults to `~/.aws/credentials`.
+* `shared_config_files`  - (Optional) List of paths to AWS shared configuration files. Defaults to `~/.aws/config`.
+* `shared_credentials_file`  - (Optional, **Deprecated**, use `shared_credentials_files` instead) Path to the AWS shared credentials file. Defaults to `~/.aws/credentials`.
+* `shared_credentials_files`  - (Optional) List of paths to AWS shared credentials files. Defaults to `~/.aws/credentials`.
 * `skip_credentials_validation` - (Optional) Skip credentials validation via the STS API.
 * `skip_region_validation` - (Optional) Skip validation of provided region name.
 * `skip_metadata_api_check` - (Optional) Skip usage of EC2 Metadata API.


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->
Adds the `shared_config_files` and `shared_credentials_files` parameters and adds support for default AWS environment variables for credentials and configuration files, `AWS_CONFIG_FILE ` and `AWS_SHARED_CREDENTIALS_FILE`. This deprecates the `shared_credentials_file` parameter.

```console
% TF_ACC=1 go test -count=1 ./internal/backend/remote-state/s3/...
ok      github.com/hashicorp/terraform/internal/backend/remote-state/s3 102.007s
```

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Relates #30493

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.6.0

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

### UPGRADE NOTES 

<!--

Write a short description of the user-facing change. Examples:

- `terraform show -json`: Fixed crash with sensitive set values.
- When rendering a diff, Terraform now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 

-  Supports the default AWS environment variables for credentials and configuration files: `AWS_CONFIG_FILE ` and `AWS_SHARED_CREDENTIALS_FILE`. [GH-30493]
- Adds `shared_config_files` and `shared_credentials_files` parameters. This deprecates the `shared_credentials_file` parameter. [GH-30493]
