### PR TITLE
S3/f update endpoint arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ Update Notes
   This deprecates the arguments `role_arn`, `session_name`, `external_id`, `assume_role_duration_seconds`, `assume_role_policy`, `assume_role_policy_arns`, `assume_role_tags`, and `assume_role_transitive_tag_keys`. [GH-33630]
 * Supports the default AWS environment variables for overrding API endpoints: `AWS_ENDPOINT_URL_DYNAMODB`, `AWS_ENDPOINT_URL_IAM`, `AWS_ENDPOINT_URL_S3`, and `AWS_ENDPOINT_URL_STS`.
   This deprecates the environment variables `AWS_DYNAMODB_ENDPOINT`, `AWS_IAM_ENDPOINT`, `AWS_S3_ENDPOINT`, and `AWS_STS_ENDPOINT`. [GH-33715]
+* Moves arguments associated with overriding AWS API endpoints into nested block `endpoints`.
+  This deprecates the arguments `dynamodb_endpoint`, `iam_endpoint`, `endpoint` (S3), and `sts_endpoint`. [GH-33724]
 
 ## Previous Releases
 

--- a/internal/backend/remote-state/s3/backend.go
+++ b/internal/backend/remote-state/s3/backend.go
@@ -81,17 +81,17 @@ func (b *Backend) ConfigSchema() *configschema.Block {
 					Attributes: map[string]*configschema.Attribute{
 						"dynamodb": {
 							Type:        cty.String,
-							Required:    true,
+							Optional:    true,
 							Description: "A custom endpoint for the DynamoDB API",
 						},
 						"iam": {
 							Type:        cty.String,
-							Required:    true,
+							Optional:    true,
 							Description: "A custom endpoint for the IAM API",
 						},
 						"s3": {
 							Type:        cty.String,
-							Required:    true,
+							Optional:    true,
 							Description: "A custom endpoint for the S3 API",
 						},
 					},

--- a/internal/backend/remote-state/s3/backend.go
+++ b/internal/backend/remote-state/s3/backend.go
@@ -84,6 +84,11 @@ func (b *Backend) ConfigSchema() *configschema.Block {
 							Required:    true,
 							Description: "A custom endpoint for the DynamoDB API",
 						},
+						"iam": {
+							Type:        cty.String,
+							Required:    true,
+							Description: "A custom endpoint for the IAM API",
+						},
 						"s3": {
 							Type:        cty.String,
 							Required:    true,
@@ -96,6 +101,7 @@ func (b *Backend) ConfigSchema() *configschema.Block {
 				Type:        cty.String,
 				Optional:    true,
 				Description: "A custom endpoint for the IAM API",
+				Deprecated:  true,
 			},
 			"sts_endpoint": {
 				Type:        cty.String,
@@ -358,11 +364,12 @@ func (b *Backend) PrepareConfig(obj cty.Value) (cty.Value, tfdiags.Diagnostics) 
 
 	endpointFields := map[string]string{
 		"dynamodb_endpoint": "dynamodb",
+		"iam_endpoint":      "iam",
 		"endpoint":          "s3",
 	}
 	endpoints := make(map[string]string)
 	if val := obj.GetAttr("endpoints"); !val.IsNull() {
-		for _, k := range []string{"dynamodb", "s3"} {
+		for _, k := range []string{"dynamodb", "iam", "s3"} {
 			if v := val.GetAttr(k); !v.IsNull() {
 				endpoints[k] = v.AsString()
 			}
@@ -374,7 +381,7 @@ func (b *Backend) PrepareConfig(obj cty.Value) (cty.Value, tfdiags.Diagnostics) 
 			if _, ok := endpoints[v]; ok {
 				diags = diags.Append(wholeBodyErrDiag(
 					"Conflicting Parameters",
-					fmt.Sprintf(`The parameters "%s" and %s" cannot be configured together.`,
+					fmt.Sprintf(`The parameters "%s" and "%s" cannot be configured together.`,
 						pathString(cty.GetAttrPath(k)),
 						pathString(cty.GetAttrPath("endpoints").GetAttr(v)),
 					),

--- a/internal/backend/remote-state/s3/backend_complete_test.go
+++ b/internal/backend/remote-state/s3/backend_complete_test.go
@@ -26,6 +26,8 @@ func ExpectNoDiags(t *testing.T, diags tfdiags.Diagnostics) {
 }
 
 func expectDiagsCount(t *testing.T, diags tfdiags.Diagnostics, c int) {
+	t.Helper()
+
 	if l := len(diags); l != c {
 		t.Fatalf("Diagnostics: expected %d element, got %d\n%s", c, l, diagnosticsString(diags))
 	}
@@ -640,7 +642,9 @@ aws_secret_access_key = DefaultSharedCredentialsSecretKey
 			ts := servicemocks.MockAwsApiServer("STS", tc.MockStsEndpoints)
 			defer ts.Close()
 
-			tc.config["sts_endpoint"] = ts.URL
+			tc.config["endpoints"] = map[string]any{
+				"sts": ts.URL,
+			}
 
 			if tc.SharedConfigurationFile != "" {
 				file, err := os.CreateTemp("", "aws-sdk-go-base-shared-configuration-file")
@@ -1109,7 +1113,9 @@ aws_secret_access_key = DefaultSharedCredentialsSecretKey
 			ts := servicemocks.MockAwsApiServer("STS", tc.MockStsEndpoints)
 			defer ts.Close()
 
-			tc.config["sts_endpoint"] = ts.URL
+			tc.config["endpoints"] = map[string]any{
+				"sts": ts.URL,
+			}
 
 			if tc.SharedConfigurationFile != "" {
 				file, err := os.CreateTemp("", "aws-sdk-go-base-shared-configuration-file")
@@ -1544,7 +1550,9 @@ aws_secret_access_key = DefaultSharedCredentialsSecretKey
 			ts := servicemocks.MockAwsApiServer("STS", tc.MockStsEndpoints)
 			defer ts.Close()
 
-			tc.config["sts_endpoint"] = ts.URL
+			tc.config["endpoints"] = map[string]any{
+				"sts": ts.URL,
+			}
 
 			if tc.SharedConfigurationFile != "" {
 				file, err := os.CreateTemp("", "aws-sdk-go-base-shared-configuration-file")

--- a/internal/backend/remote-state/s3/backend_test.go
+++ b/internal/backend/remote-state/s3/backend_test.go
@@ -212,9 +212,9 @@ func TestBackendConfig_DynamoDBEndpoint(t *testing.T) {
 		},
 		"config": {
 			config: map[string]any{
-				"endpoints": populateEndpoints(map[string]string{
+				"endpoints": map[string]any{
 					"dynamodb": "dynamo.test",
-				}),
+				},
 			},
 			expectedEndpoint: "dynamo.test",
 		},
@@ -230,9 +230,9 @@ func TestBackendConfig_DynamoDBEndpoint(t *testing.T) {
 		"config conflict": {
 			config: map[string]any{
 				"dynamodb_endpoint": "dynamo.test",
-				"endpoints": populateEndpoints(map[string]string{
+				"endpoints": map[string]any{
 					"dynamodb": "dynamo.test",
-				}),
+				},
 			},
 			expectedEndpoint: "s3.test",
 			expectedDiags: tfdiags.Diagnostics{
@@ -314,9 +314,9 @@ func TestBackendConfig_IAMEndpoint(t *testing.T) {
 		"none": {},
 		"config": {
 			config: map[string]any{
-				"endpoints": populateEndpoints(map[string]string{
+				"endpoints": map[string]any{
 					"iam": "iam.test",
-				}),
+				},
 			},
 		},
 		"deprecated config": {
@@ -330,9 +330,9 @@ func TestBackendConfig_IAMEndpoint(t *testing.T) {
 		"config conflict": {
 			config: map[string]any{
 				"iam_endpoint": "iam.test",
-				"endpoints": populateEndpoints(map[string]string{
+				"endpoints": map[string]any{
 					"iam": "iam.test",
-				}),
+				},
 			},
 			expectedDiags: tfdiags.Diagnostics{
 				deprecatedAttrDiag(cty.GetAttrPath("iam_endpoint"), cty.GetAttrPath("endpoints").GetAttr("iam")),
@@ -407,9 +407,9 @@ func TestBackendConfig_S3Endpoint(t *testing.T) {
 		},
 		"config": {
 			config: map[string]any{
-				"endpoints": populateEndpoints(map[string]string{
+				"endpoints": map[string]any{
 					"s3": "s3.test",
-				}),
+				},
 			},
 			expectedEndpoint: "s3.test",
 		},
@@ -425,9 +425,9 @@ func TestBackendConfig_S3Endpoint(t *testing.T) {
 		"config conflict": {
 			config: map[string]any{
 				"endpoint": "s3.test",
-				"endpoints": populateEndpoints(map[string]string{
+				"endpoints": map[string]any{
 					"s3": "s3.test",
-				}),
+				},
 			},
 			expectedEndpoint: "s3.test",
 			expectedDiags: tfdiags.Diagnostics{
@@ -1874,16 +1874,4 @@ func testBackendConfigDiags(t *testing.T, b backend.Backend, c hcl.Body) (backen
 	confDiags := b.Configure(obj)
 
 	return b, diags.Append(confDiags)
-}
-
-func populateEndpoints(attrs map[string]string) map[string]any {
-	endpoints := map[string]any{
-		"dynamodb": nil,
-		"iam":      nil,
-		"s3":       nil,
-	}
-	for k, v := range attrs {
-		endpoints[k] = v
-	}
-	return endpoints
 }

--- a/internal/backend/remote-state/s3/backend_test.go
+++ b/internal/backend/remote-state/s3/backend_test.go
@@ -212,11 +212,9 @@ func TestBackendConfig_DynamoDBEndpoint(t *testing.T) {
 		},
 		"config": {
 			config: map[string]any{
-				"endpoints": map[string]any{
+				"endpoints": populateEndpoints(map[string]string{
 					"dynamodb": "dynamo.test",
-					"iam":      nil,
-					"s3":       nil,
-				},
+				}),
 			},
 			expectedEndpoint: "dynamo.test",
 		},
@@ -232,11 +230,9 @@ func TestBackendConfig_DynamoDBEndpoint(t *testing.T) {
 		"config conflict": {
 			config: map[string]any{
 				"dynamodb_endpoint": "dynamo.test",
-				"endpoints": map[string]any{
+				"endpoints": populateEndpoints(map[string]string{
 					"dynamodb": "dynamo.test",
-					"iam":      nil,
-					"s3":       nil,
-				},
+				}),
 			},
 			expectedEndpoint: "s3.test",
 			expectedDiags: tfdiags.Diagnostics{
@@ -318,11 +314,9 @@ func TestBackendConfig_IAMEndpoint(t *testing.T) {
 		"none": {},
 		"config": {
 			config: map[string]any{
-				"endpoints": map[string]any{
-					"dynamodb": nil,
-					"iam":      "iam.test",
-					"s3":       nil,
-				},
+				"endpoints": populateEndpoints(map[string]string{
+					"iam": "iam.test",
+				}),
 			},
 		},
 		"deprecated config": {
@@ -336,11 +330,9 @@ func TestBackendConfig_IAMEndpoint(t *testing.T) {
 		"config conflict": {
 			config: map[string]any{
 				"iam_endpoint": "iam.test",
-				"endpoints": map[string]any{
-					"dynamodb": nil,
-					"iam":      "iam.test",
-					"s3":       nil,
-				},
+				"endpoints": populateEndpoints(map[string]string{
+					"iam": "iam.test",
+				}),
 			},
 			expectedDiags: tfdiags.Diagnostics{
 				deprecatedAttrDiag(cty.GetAttrPath("iam_endpoint"), cty.GetAttrPath("endpoints").GetAttr("iam")),
@@ -415,11 +407,9 @@ func TestBackendConfig_S3Endpoint(t *testing.T) {
 		},
 		"config": {
 			config: map[string]any{
-				"endpoints": map[string]any{
-					"dynamodb": nil,
-					"iam":      nil,
-					"s3":       "s3.test",
-				},
+				"endpoints": populateEndpoints(map[string]string{
+					"s3": "s3.test",
+				}),
 			},
 			expectedEndpoint: "s3.test",
 		},
@@ -435,11 +425,9 @@ func TestBackendConfig_S3Endpoint(t *testing.T) {
 		"config conflict": {
 			config: map[string]any{
 				"endpoint": "s3.test",
-				"endpoints": map[string]any{
-					"dynamodb": nil,
-					"iam":      nil,
-					"s3":       "s3.test",
-				},
+				"endpoints": populateEndpoints(map[string]string{
+					"s3": "s3.test",
+				}),
 			},
 			expectedEndpoint: "s3.test",
 			expectedDiags: tfdiags.Diagnostics{
@@ -1886,4 +1874,16 @@ func testBackendConfigDiags(t *testing.T, b backend.Backend, c hcl.Body) (backen
 	confDiags := b.Configure(obj)
 
 	return b, diags.Append(confDiags)
+}
+
+func populateEndpoints(attrs map[string]string) map[string]any {
+	endpoints := map[string]any{
+		"dynamodb": nil,
+		"iam":      nil,
+		"s3":       nil,
+	}
+	for k, v := range attrs {
+		endpoints[k] = v
+	}
+	return endpoints
 }

--- a/internal/backend/remote-state/s3/backend_test.go
+++ b/internal/backend/remote-state/s3/backend_test.go
@@ -214,6 +214,7 @@ func TestBackendConfig_DynamoDBEndpoint(t *testing.T) {
 			config: map[string]any{
 				"endpoints": map[string]any{
 					"dynamodb": "dynamo.test",
+					"iam":      nil,
 					"s3":       nil,
 				},
 			},
@@ -233,6 +234,7 @@ func TestBackendConfig_DynamoDBEndpoint(t *testing.T) {
 				"dynamodb_endpoint": "dynamo.test",
 				"endpoints": map[string]any{
 					"dynamodb": "dynamo.test",
+					"iam":      nil,
 					"s3":       nil,
 				},
 			},
@@ -241,7 +243,7 @@ func TestBackendConfig_DynamoDBEndpoint(t *testing.T) {
 				deprecatedAttrDiag(cty.GetAttrPath("dynamodb_endpoint"), cty.GetAttrPath("endpoints").GetAttr("dynamodb")),
 				wholeBodyErrDiag(
 					"Conflicting Parameters",
-					fmt.Sprintf(`The parameters "%s" and %s" cannot be configured together.`,
+					fmt.Sprintf(`The parameters "%s" and "%s" cannot be configured together.`,
 						pathString(cty.GetAttrPath("dynamodb_endpoint")),
 						pathString(cty.GetAttrPath("endpoints").GetAttr("dynamodb")),
 					),
@@ -303,6 +305,102 @@ func TestBackendConfig_DynamoDBEndpoint(t *testing.T) {
 	}
 }
 
+func TestBackendConfig_IAMEndpoint(t *testing.T) {
+	testACC(t)
+
+	// Doesn't test for expected endpoint, since the IAM endpoint is used internally to `aws-sdk-go-base`
+	// The mocked tests won't work if the config parameter doesn't work
+	cases := map[string]struct {
+		config        map[string]any
+		vars          map[string]string
+		expectedDiags tfdiags.Diagnostics
+	}{
+		"none": {},
+		"config": {
+			config: map[string]any{
+				"endpoints": map[string]any{
+					"dynamodb": nil,
+					"iam":      "iam.test",
+					"s3":       nil,
+				},
+			},
+		},
+		"deprecated config": {
+			config: map[string]any{
+				"iam_endpoint": "iam.test",
+			},
+			expectedDiags: tfdiags.Diagnostics{
+				deprecatedAttrDiag(cty.GetAttrPath("iam_endpoint"), cty.GetAttrPath("endpoints").GetAttr("iam")),
+			},
+		},
+		"config conflict": {
+			config: map[string]any{
+				"iam_endpoint": "iam.test",
+				"endpoints": map[string]any{
+					"dynamodb": nil,
+					"iam":      "iam.test",
+					"s3":       nil,
+				},
+			},
+			expectedDiags: tfdiags.Diagnostics{
+				deprecatedAttrDiag(cty.GetAttrPath("iam_endpoint"), cty.GetAttrPath("endpoints").GetAttr("iam")),
+				wholeBodyErrDiag(
+					"Conflicting Parameters",
+					fmt.Sprintf(`The parameters "%s" and "%s" cannot be configured together.`,
+						pathString(cty.GetAttrPath("iam_endpoint")),
+						pathString(cty.GetAttrPath("endpoints").GetAttr("iam")),
+					),
+				)},
+		},
+		"envvar": {
+			vars: map[string]string{
+				"AWS_ENDPOINT_URL_IAM": "iam.test",
+			},
+		},
+		"deprecated envvar": {
+			vars: map[string]string{
+				"AWS_IAM_ENDPOINT": "iam.test",
+			},
+			expectedDiags: tfdiags.Diagnostics{
+				deprecatedEnvVarDiag("AWS_IAM_ENDPOINT", "AWS_ENDPOINT_URL_IAM"),
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			config := map[string]interface{}{
+				"region": "us-west-1",
+				"bucket": "tf-test",
+				"key":    "state",
+			}
+
+			if tc.vars != nil {
+				for k, v := range tc.vars {
+					os.Setenv(k, v)
+				}
+				t.Cleanup(func() {
+					for k := range tc.vars {
+						os.Unsetenv(k)
+					}
+				})
+			}
+
+			if tc.config != nil {
+				for k, v := range tc.config {
+					config[k] = v
+				}
+			}
+
+			_, diags := testBackendConfigDiags(t, New(), backend.TestWrapConfig(config))
+
+			if diff := cmp.Diff(diags, tc.expectedDiags, cmp.Comparer(diagnosticComparer)); diff != "" {
+				t.Errorf("unexpected diagnostics difference: %s", diff)
+			}
+		})
+	}
+}
+
 func TestBackendConfig_S3Endpoint(t *testing.T) {
 	testACC(t)
 
@@ -319,6 +417,7 @@ func TestBackendConfig_S3Endpoint(t *testing.T) {
 			config: map[string]any{
 				"endpoints": map[string]any{
 					"dynamodb": nil,
+					"iam":      nil,
 					"s3":       "s3.test",
 				},
 			},
@@ -338,6 +437,7 @@ func TestBackendConfig_S3Endpoint(t *testing.T) {
 				"endpoint": "s3.test",
 				"endpoints": map[string]any{
 					"dynamodb": nil,
+					"iam":      nil,
 					"s3":       "s3.test",
 				},
 			},
@@ -346,7 +446,7 @@ func TestBackendConfig_S3Endpoint(t *testing.T) {
 				deprecatedAttrDiag(cty.GetAttrPath("endpoint"), cty.GetAttrPath("endpoints").GetAttr("s3")),
 				wholeBodyErrDiag(
 					"Conflicting Parameters",
-					fmt.Sprintf(`The parameters "%s" and %s" cannot be configured together.`,
+					fmt.Sprintf(`The parameters "%s" and "%s" cannot be configured together.`,
 						pathString(cty.GetAttrPath("endpoint")),
 						pathString(cty.GetAttrPath("endpoints").GetAttr("s3")),
 					),

--- a/internal/backend/remote-state/s3/validate.go
+++ b/internal/backend/remote-state/s3/validate.go
@@ -349,6 +349,10 @@ func attributeErrDiag(summary, detail string, attrPath cty.Path) tfdiags.Diagnos
 	return tfdiags.AttributeValue(tfdiags.Error, summary, detail, attrPath.Copy())
 }
 
+func attributeWarningDiag(summary, detail string, attrPath cty.Path) tfdiags.Diagnostic {
+	return tfdiags.AttributeValue(tfdiags.Warning, summary, detail, attrPath.Copy())
+}
+
 func wholeBodyErrDiag(summary, detail string) tfdiags.Diagnostic {
 	return tfdiags.WholeContainingBody(tfdiags.Error, summary, detail)
 }

--- a/website/docs/language/settings/backends/s3.mdx
+++ b/website/docs/language/settings/backends/s3.mdx
@@ -154,7 +154,8 @@ The following configuration is optional:
 
 * `access_key` - (Optional) AWS access key. If configured, must also configure `secret_key`. This can also be sourced from the `AWS_ACCESS_KEY_ID` environment variable, AWS shared credentials file (e.g. `~/.aws/credentials`), or AWS shared configuration file (e.g. `~/.aws/config`).
 * `secret_key` - (Optional) AWS access key. If configured, must also configure `access_key`. This can also be sourced from the `AWS_SECRET_ACCESS_KEY` environment variable, AWS shared credentials file (e.g. `~/.aws/credentials`), or AWS shared configuration file (e.g. `~/.aws/config`).
-* `iam_endpoint` - (Optional) Custom endpoint for the AWS Identity and Access Management (IAM) API. This can also be sourced from the environment variable `AWS_ENDPOINT_URL_IAM` or the deprecated environment variable `AWS_IAM_ENDPOINT`.
+* `iam_endpoint` - (Optional, **Deprecated**) Custom endpoint for the AWS Identity and Access Management (IAM) API.
+  Use `endpoints.iam` instead.
 * `max_retries` - (Optional) The maximum number of times an AWS API request is retried on retryable failure. Defaults to 5.
 * `profile` - (Optional) Name of AWS profile in AWS shared credentials file (e.g. `~/.aws/credentials`) or AWS shared configuration file (e.g. `~/.aws/config`) to use for credentials and/or configuration. This can also be sourced from the `AWS_PROFILE` environment variable.
 * `shared_credentials_file`  - (Optional) Path to the AWS shared credentials file. Defaults to `~/.aws/credentials`.
@@ -170,6 +171,8 @@ The optional argument `endpoints` contains the following arguments:
 
 * `dynamodb` - (Optional) Custom endpoint for the AWS DynamoDB API.
   This can also be sourced from the environment variable `AWS_ENDPOINT_URL_DYNAMODB` or the deprecated environment variable `AWS_DYNAMODB_ENDPOINT`.
+* `iam` - (Optional) Custom endpoint for the AWS IAM API.
+  This can also be sourced from the environment variable `AWS_ENDPOINT_URL_IAM` or the deprecated environment variable `AWS_IAM_ENDPOINT`.
 * `s3` - (Optional) Custom endpoint for the AWS S3 API.
   This can also be sourced from the environment variable `AWS_ENDPOINT_URL_S3` or the deprecated environment variable `AWS_S3_ENDPOINT`.
 

--- a/website/docs/language/settings/backends/s3.mdx
+++ b/website/docs/language/settings/backends/s3.mdx
@@ -164,6 +164,13 @@ The following configuration is optional:
 * `sts_endpoint` - (Optional) Custom endpoint for the AWS Security Token Service (STS) API. This can also be sourced from the environment variable `AWS_ENDPOINT_URL_STS` or the deprecated environment variable `AWS_STS_ENDPOINT`.
 * `token` - (Optional) Multi-Factor Authentication (MFA) token. This can also be sourced from the `AWS_SESSION_TOKEN` environment variable.
 
+#### Overriding AWS API endpoints
+
+The optional argument `endpoints` contains the following arguments:
+
+* `s3` - (Optional) Custom endpoint for the AWS S3 API.
+  This can also be sourced from the environment variable `AWS_ENDPOINT_URL_S3` or the deprecated environment variable `AWS_S3_ENDPOINT`.
+
 #### Assume Role Configuration
 
 Assuming an IAM Role can be configured in two ways.
@@ -214,7 +221,8 @@ The following configuration is optional:
 
 * `acl` - (Optional) [Canned ACL](https://docs.aws.amazon.com/AmazonS3/latest/userguide/acl-overview.html#canned-acl) to be applied to the state file.
 * `encrypt` - (Optional) Enable [server side encryption](https://docs.aws.amazon.com/AmazonS3/latest/userguide/UsingServerSideEncryption.html) of the state file.
-* `endpoint` - (Optional) Custom endpoint for the AWS S3 API. This can also be sourced from the environment variable `AWS_ENDPOINT_URL_S3` or the deprecated environment variable `AWS_S3_ENDPOINT`.
+* `endpoint` - (Optional, **Deprecated**) Custom endpoint for the AWS S3 API.
+  Use `endpoints.s3` instead.
 * `force_path_style` - (Optional) Enable path-style S3 URLs (`https://<HOST>/<BUCKET>` instead of `https://<BUCKET>.<HOST>`).
 * `kms_key_id` - (Optional) Amazon Resource Name (ARN) of a Key Management Service (KMS) Key to use for encrypting the state. Note that if this value is specified, Terraform will need `kms:Encrypt`, `kms:Decrypt` and `kms:GenerateDataKey` permissions on this KMS key.
 * `sse_customer_key` - (Optional) The key to use for encrypting state with [Server-Side Encryption with Customer-Provided Keys (SSE-C)](https://docs.aws.amazon.com/AmazonS3/latest/userguide/ServerSideEncryptionCustomerKeys.html). This is the base64-encoded value of the key, which must decode to 256 bits. This can also be sourced from the `AWS_SSE_CUSTOMER_KEY` environment variable, which is recommended due to the sensitivity of the value. Setting it inside a terraform file will cause it to be persisted to disk in `terraform.tfstate`.

--- a/website/docs/language/settings/backends/s3.mdx
+++ b/website/docs/language/settings/backends/s3.mdx
@@ -162,7 +162,8 @@ The following configuration is optional:
 * `skip_credentials_validation` - (Optional) Skip credentials validation via the STS API.
 * `skip_region_validation` - (Optional) Skip validation of provided region name.
 * `skip_metadata_api_check` - (Optional) Skip usage of EC2 Metadata API.
-* `sts_endpoint` - (Optional) Custom endpoint for the AWS Security Token Service (STS) API. This can also be sourced from the environment variable `AWS_ENDPOINT_URL_STS` or the deprecated environment variable `AWS_STS_ENDPOINT`.
+* `sts_endpoint` - (Optional, **Deprecated**) Custom endpoint for the AWS Security Token Service (STS) API.
+  Use `endpoints.sts` instead.
 * `token` - (Optional) Multi-Factor Authentication (MFA) token. This can also be sourced from the `AWS_SESSION_TOKEN` environment variable.
 
 #### Overriding AWS API endpoints
@@ -175,6 +176,8 @@ The optional argument `endpoints` contains the following arguments:
   This can also be sourced from the environment variable `AWS_ENDPOINT_URL_IAM` or the deprecated environment variable `AWS_IAM_ENDPOINT`.
 * `s3` - (Optional) Custom endpoint for the AWS S3 API.
   This can also be sourced from the environment variable `AWS_ENDPOINT_URL_S3` or the deprecated environment variable `AWS_S3_ENDPOINT`.
+* `sts` - (Optional) Custom endpoint for the AWS STS API.
+  This can also be sourced from the environment variable `AWS_ENDPOINT_URL_STS` or the deprecated environment variable `AWS_STS_ENDPOINT`.
 
 #### Assume Role Configuration
 

--- a/website/docs/language/settings/backends/s3.mdx
+++ b/website/docs/language/settings/backends/s3.mdx
@@ -168,6 +168,8 @@ The following configuration is optional:
 
 The optional argument `endpoints` contains the following arguments:
 
+* `dynamodb` - (Optional) Custom endpoint for the AWS DynamoDB API.
+  This can also be sourced from the environment variable `AWS_ENDPOINT_URL_DYNAMODB` or the deprecated environment variable `AWS_DYNAMODB_ENDPOINT`.
 * `s3` - (Optional) Custom endpoint for the AWS S3 API.
   This can also be sourced from the environment variable `AWS_ENDPOINT_URL_S3` or the deprecated environment variable `AWS_S3_ENDPOINT`.
 
@@ -232,7 +234,8 @@ The following configuration is optional:
 
 The following configuration is optional:
 
-* `dynamodb_endpoint` - (Optional) Custom endpoint for the AWS DynamoDB API. This can also be sourced from the environment variable `AWS_ENDPOINT_URL_DYNAMODB` or the deprecated environment variable `AWS_DYNAMODB_ENDPOINT`.
+* `dynamodb_endpoint` - (Optional, **Deprecated**) Custom endpoint for the AWS DynamoDB API.
+  Use `endpoints.dynamodb` instead.
 * `dynamodb_table` - (Optional) Name of DynamoDB Table to use for state locking and consistency. The table must have a partition key named `LockID` with type of `String`. If not configured, state locking will be disabled.
 
 ## Multi-account AWS Architecture


### PR DESCRIPTION
Moves the arguments for overriding AWS API endpoints into the argument `endpoints`.

Deprecates the arguments `dynamodb_endpoint`, `iam_endpoint`, `endpoint` (S3), and `sts_endpoint`.

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Fixes #30492

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.6.0

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

### UPGRADE NOTES

<!--

Write a short description of the user-facing change. Examples:

- `terraform show -json`: Fixed crash with sensitive set values.
- When rendering a diff, Terraform now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 

-  Moves arguments associated with overriding AWS API endpoints into nested block `endpoints`. This deprecates the arguments `dynamodb_endpoint`, `iam_endpoint`, `endpoint` (S3), and `sts_endpoint`
