### PR TITLE
internal/grpcwrap: Ensure GetProviderSchemaOptional server capability is passed through

### DIFF
--- a/internal/grpcwrap/provider.go
+++ b/internal/grpcwrap/provider.go
@@ -69,7 +69,8 @@ func (p *provider) GetSchema(_ context.Context, req *tfplugin5.GetProviderSchema
 	}
 
 	resp.ServerCapabilities = &tfplugin5.ServerCapabilities{
-		PlanDestroy: p.schema.ServerCapabilities.PlanDestroy,
+		GetProviderSchemaOptional: p.schema.ServerCapabilities.GetProviderSchemaOptional,
+		PlanDestroy:               p.schema.ServerCapabilities.PlanDestroy,
 	}
 
 	// include any diagnostics from the original GetSchema call


### PR DESCRIPTION
Reference: https://github.com/hashicorp/terraform/blob/7094517089e9a01d9aa94838f583898549e5a6de/internal/grpcwrap/provider6.go#L72

The server capability is passed through with version 6, but not version 5. (Sorry missed this with last change.)

## Target Release

1.6.x

## Draft CHANGELOG entry

N/A
