### PR TITLE
backend/s3: add custom_ca_bundle argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Update Notes
 * Adds `shared_config_files` and `shared_credentials_files` arguments.
   This deprecates the `shared_credentials_file` argument. ([#30493](https://github.com/hashicorp/terraform/issues/30493))
 * Upgrades the S3 backend to use AWS SDK Go V2. ([#30443](https://github.com/hashicorp/terraform/issues/30443))
+* Adds a `custom_ca_bundle` argument and support for the corresponding AWS environment variable, `AWS_CA_BUNDLE`. ([#33689](https://github.com/hashicorp/terraform/issues/33689))
 
 ## Previous Releases
 

--- a/internal/backend/remote-state/s3/backend.go
+++ b/internal/backend/remote-state/s3/backend.go
@@ -285,6 +285,12 @@ func (b *Backend) ConfigSchema() *configschema.Block {
 				Optional:    true,
 				Description: "Use the legacy authentication workflow, preferring environment variables over backend configuration.",
 			},
+
+			"custom_ca_bundle": {
+				Type:        cty.String,
+				Optional:    true,
+				Description: "File containing custom root and intermediate certificates.",
+			},
 		},
 	}
 }
@@ -611,6 +617,13 @@ func (b *Backend) Configure(obj cty.Value) tfdiags.Diagnostics {
 	}
 	if val, ok := stringSetAttrDefaultEnvVarOk(obj, "shared_config_files", "AWS_SHARED_CONFIG_FILE"); ok {
 		cfg.SharedConfigFiles = val
+	}
+
+	if v, ok := retrieveArgument(&diags,
+		newAttributeRetriever(obj, cty.GetAttrPath("custom_ca_bundle")),
+		newEnvvarRetriever("AWS_CA_BUNDLE"),
+	); ok {
+		cfg.CustomCABundle = v
 	}
 
 	if v, ok := retrieveArgument(&diags,

--- a/website/docs/language/settings/backends/s3.mdx
+++ b/website/docs/language/settings/backends/s3.mdx
@@ -153,6 +153,7 @@ The following configuration is required:
 The following configuration is optional:
 
 * `access_key` - (Optional) AWS access key. If configured, must also configure `secret_key`. This can also be sourced from the `AWS_ACCESS_KEY_ID` environment variable, AWS shared credentials file (e.g. `~/.aws/credentials`), or AWS shared configuration file (e.g. `~/.aws/config`).
+* `custom_ca_bundle` - (Optional) File containing custom root and intermediate certificates. Can also be set using the `AWS_CA_BUNDLE` environment variable. Setting ca_bundle in the shared config file is not supported.
 * `secret_key` - (Optional) AWS access key. If configured, must also configure `access_key`. This can also be sourced from the `AWS_SECRET_ACCESS_KEY` environment variable, AWS shared credentials file (e.g. `~/.aws/credentials`), or AWS shared configuration file (e.g. `~/.aws/config`).
 * `iam_endpoint` - (Optional, **Deprecated**) Custom endpoint for the AWS Identity and Access Management (IAM) API.
   Use `endpoints.iam` instead.


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->
Adds a `custom_ca_bundle` argument to the S3 backend for parity with the AWS Provider.

```console
% TF_ACC=1 go test -count=1 ./internal/backend/remote-state/s3/...
ok      github.com/hashicorp/terraform/internal/backend/remote-state/s3 107.640s
```
<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Closes #33689
Relates #33687

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.6.x

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

### UPGRADE NOTES 

<!--

Write a short description of the user-facing change. Examples:

- `terraform show -json`: Fixed crash with sensitive set values.
- When rendering a diff, Terraform now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 

* Adds a `custom_ca_bundle` argument and support for the corresponding AWS environment variable, `AWS_CA_BUNDLE`. ([#33689](https://github.com/hashicorp/terraform/issues/33689))
