### PR TITLE
backend/s3: add ec2_metadata_service_endpoint argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Update Notes
 * Adds `shared_config_files` and `shared_credentials_files` arguments.
   This deprecates the `shared_credentials_file` argument. ([#30493](https://github.com/hashicorp/terraform/issues/30493))
 * Upgrades the S3 backend to use AWS SDK Go V2. ([#30443](https://github.com/hashicorp/terraform/issues/30443))
+* Adds `ec2_metadata_service_endpoint` and `ec2_metadata_service_endpoint_mode` arguments as well as support for the corresponding AWS environment variables, `AWS_EC2_METADATA_SERVICE_ENDPOINT` and `AWS_EC2_METADATA_SERVICE_ENDPOINT_MODE`. The environment variable `AWS_METADATA_URL` is also supported for compatibility with the AWS provider, but is deprecated. ([#30444](https://github.com/hashicorp/terraform/issues/30444))
 
 ## Previous Releases
 

--- a/internal/backend/remote-state/s3/backend.go
+++ b/internal/backend/remote-state/s3/backend.go
@@ -72,6 +72,16 @@ func (b *Backend) ConfigSchema() *configschema.Block {
 				Description: "A custom endpoint for the DynamoDB API",
 				Deprecated:  true,
 			},
+			"ec2_metadata_service_endpoint": {
+				Type:        cty.String,
+				Optional:    true,
+				Description: "Address of the EC2 metadata service (IMDS) endpoint to use.",
+			},
+			"ec2_metadata_service_endpoint_mode": {
+				Type:        cty.String,
+				Optional:    true,
+				Description: "Mode to use in communicating with the metadata service.",
+			},
 			"endpoint": {
 				Type:        cty.String,
 				Optional:    true,
@@ -562,6 +572,7 @@ func (b *Backend) Configure(obj cty.Value) tfdiags.Diagnostics {
 		"AWS_IAM_ENDPOINT":      "AWS_ENDPOINT_URL_IAM",
 		"AWS_S3_ENDPOINT":       "AWS_ENDPOINT_URL_S3",
 		"AWS_STS_ENDPOINT":      "AWS_ENDPOINT_URL_STS",
+		"AWS_METADATA_URL":      "AWS_EC2_METADATA_SERVICE_ENDPOINT",
 	} {
 		if val := os.Getenv(envvar); val != "" {
 			diags = diags.Append(deprecatedEnvVarDiag(envvar, replacement))
@@ -599,6 +610,21 @@ func (b *Backend) Configure(obj cty.Value) tfdiags.Diagnostics {
 		} else {
 			cfg.EC2MetadataServiceEnableState = imds.ClientEnabled
 		}
+	}
+
+	if v, ok := retrieveArgument(&diags,
+		newAttributeRetriever(obj, cty.GetAttrPath("ec2_metadata_service_endpoint")),
+		newEnvvarRetriever("AWS_EC2_METADATA_SERVICE_ENDPOINT"),
+		newEnvvarRetriever("AWS_METADATA_URL"),
+	); ok {
+		cfg.EC2MetadataServiceEndpoint = v
+	}
+
+	if v, ok := retrieveArgument(&diags,
+		newAttributeRetriever(obj, cty.GetAttrPath("ec2_metadata_service_endpoint_mode")),
+		newEnvvarRetriever("AWS_EC2_METADATA_SERVICE_ENDPOINT_MODE"),
+	); ok {
+		cfg.EC2MetadataServiceEndpointMode = v
 	}
 
 	if val, ok := stringAttrOk(obj, "shared_credentials_file"); ok {

--- a/internal/backend/remote-state/s3/backend_test.go
+++ b/internal/backend/remote-state/s3/backend_test.go
@@ -516,6 +516,82 @@ func TestBackendConfig_S3Endpoint(t *testing.T) {
 	}
 }
 
+func TestBackendConfig_EC2MetadataEndpoint(t *testing.T) {
+	testACC(t)
+
+	cases := map[string]struct {
+		config           map[string]any
+		vars             map[string]string
+		expectedEndpoint string
+		expectedDiags    tfdiags.Diagnostics
+	}{
+		"none": {
+			expectedEndpoint: "",
+		},
+		"config": {
+			config: map[string]any{
+				"ec2_metadata_service_endpoint": "ec2.test",
+			},
+			expectedEndpoint: "ec2.test",
+		},
+		"envvar": {
+			vars: map[string]string{
+				"AWS_EC2_METADATA_SERVICE_ENDPOINT": "ec2.test",
+			},
+			expectedEndpoint: "ec2.test",
+		},
+		"deprecated envvar": {
+			vars: map[string]string{
+				"AWS_METADATA_URL": "ec2.test",
+			},
+			expectedEndpoint: "ec2.test",
+			expectedDiags: tfdiags.Diagnostics{
+				deprecatedEnvVarDiag("AWS_METADATA_URL", "AWS_EC2_METADATA_SERVICE_ENDPOINT"),
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			config := map[string]interface{}{
+				"region": "us-west-1",
+				"bucket": "tf-test",
+				"key":    "state",
+			}
+
+			if tc.vars != nil {
+				for k, v := range tc.vars {
+					os.Setenv(k, v)
+				}
+				t.Cleanup(func() {
+					for k := range tc.vars {
+						os.Unsetenv(k)
+					}
+				})
+			}
+
+			if tc.config != nil {
+				for k, v := range tc.config {
+					config[k] = v
+				}
+			}
+
+			_, diags := testBackendConfigDiags(t, New(), backend.TestWrapConfig(config))
+			// raw, diags := testBackendConfigDiags(t, New(), backend.TestWrapConfig(config))
+			// b := raw.(*Backend)
+
+			if diff := cmp.Diff(diags, tc.expectedDiags, cmp.Comparer(diagnosticComparer)); diff != "" {
+				t.Errorf("unexpected diagnostics difference: %s", diff)
+			}
+
+			if !diags.HasErrors() {
+				// TODO: Convert to AWS SDK v2 equivalent
+				// checkClientEndpoint(t, b.s3Client.Config, tc.expectedEndpoint)
+			}
+		})
+	}
+}
+
 func TestBackendConfig_AssumeRole(t *testing.T) {
 	testACC(t)
 

--- a/website/docs/language/settings/backends/s3.mdx
+++ b/website/docs/language/settings/backends/s3.mdx
@@ -154,6 +154,8 @@ The following configuration is optional:
 
 * `access_key` - (Optional) AWS access key. If configured, must also configure `secret_key`. This can also be sourced from the `AWS_ACCESS_KEY_ID` environment variable, AWS shared credentials file (e.g. `~/.aws/credentials`), or AWS shared configuration file (e.g. `~/.aws/config`).
 * `secret_key` - (Optional) AWS access key. If configured, must also configure `access_key`. This can also be sourced from the `AWS_SECRET_ACCESS_KEY` environment variable, AWS shared credentials file (e.g. `~/.aws/credentials`), or AWS shared configuration file (e.g. `~/.aws/config`).
+* `ec2_metadata_service_endpoint` - (Optional) Address of the EC2 metadata service (IMDS) endpoint to use. Can also be set with the `AWS_EC2_METADATA_SERVICE_ENDPOINT` environment variable.
+* `ec2_metadata_service_endpoint_mode` - (Optional) Mode to use in communicating with the metadata service. Valid values are `IPv4` and `IPv6`. Can also be set with the `AWS_EC2_METADATA_SERVICE_ENDPOINT_MODE` environment variable.
 * `iam_endpoint` - (Optional, **Deprecated**) Custom endpoint for the AWS Identity and Access Management (IAM) API.
   Use `endpoints.iam` instead.
 * `max_retries` - (Optional) The maximum number of times an AWS API request is retried on retryable failure. Defaults to 5.


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->
Adds `ec2_metadata_service_endpoint` and `ec2_metadata_service_endpoint_mode` arguments to the S3 backend for parity with the AWS Provider.


```console
% TF_ACC=1 go test -count=1 ./internal/backend/remote-state/s3/...
ok      github.com/hashicorp/terraform/internal/backend/remote-state/s3 107.609s
```
<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Closes #30444
Relates #33687 

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.6.x

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

### UPGRADE NOTES 

<!--

Write a short description of the user-facing change. Examples:

- `terraform show -json`: Fixed crash with sensitive set values.
- When rendering a diff, Terraform now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 

* Adds `ec2_metadata_service_endpoint` and `ec2_metadata_service_endpoint_mode` arguments as well as support for the corresponding AWS environment variables, `AWS_EC2_METADATA_SERVICE_ENDPOINT` and `AWS_EC2_METADATA_SERVICE_ENDPOINT_MODE`. The environment variable `AWS_METADATA_URL` is also supported for compatibility with the AWS provider, but is deprecated. ([#30444](https://github.com/hashicorp/terraform/issues/30444))
