### PR TITLE
backend/s3: add sts_region argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Update Notes
 * Adds `shared_config_files` and `shared_credentials_files` arguments.
   This deprecates the `shared_credentials_file` argument. ([#30493](https://github.com/hashicorp/terraform/issues/30493))
 * Upgrades the S3 backend to use AWS SDK Go V2. ([#30443](https://github.com/hashicorp/terraform/issues/30443))
+* Adds an `sts_region` argument. ([#33693](https://github.com/hashicorp/terraform/issues/33693))
 
 ## Previous Releases
 

--- a/internal/backend/remote-state/s3/backend.go
+++ b/internal/backend/remote-state/s3/backend.go
@@ -117,6 +117,11 @@ func (b *Backend) ConfigSchema() *configschema.Block {
 				Description: "A custom endpoint for the STS API",
 				Deprecated:  true,
 			},
+			"sts_region": {
+				Type:        cty.String,
+				Optional:    true,
+				Description: "AWS region for STS.",
+			},
 			"encrypt": {
 				Type:        cty.Bool,
 				Optional:    true,
@@ -629,6 +634,10 @@ func (b *Backend) Configure(obj cty.Value) tfdiags.Diagnostics {
 		newEnvvarRetriever("AWS_STS_ENDPOINT"),
 	); ok {
 		cfg.StsEndpoint = v
+	}
+
+	if v, ok := retrieveArgument(&diags, newAttributeRetriever(obj, cty.GetAttrPath("sts_region"))); ok {
+		cfg.StsRegion = v
 	}
 
 	if assumeRole := obj.GetAttr("assume_role"); !assumeRole.IsNull() {

--- a/website/docs/language/settings/backends/s3.mdx
+++ b/website/docs/language/settings/backends/s3.mdx
@@ -166,6 +166,7 @@ The following configuration is optional:
 * `skip_metadata_api_check` - (Optional) Skip usage of EC2 Metadata API.
 * `sts_endpoint` - (Optional, **Deprecated**) Custom endpoint for the AWS Security Token Service (STS) API.
   Use `endpoints.sts` instead.
+* `sts_region` - (Optional) AWS region for STS. If unset, AWS will use the same region for STS as other non-STS operations.
 * `token` - (Optional) Multi-Factor Authentication (MFA) token. This can also be sourced from the `AWS_SESSION_TOKEN` environment variable.
 * `use_legacy_workflow` - (Optional) Use the legacy authentication workflow, preferring environment variables over backend configuration. Defaults to `true`. This behavior does not align with the authentication flow of the AWS CLI or SDK's, and will be removed in the future.
 


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->
Adds an `sts_region` argument to the S3 backend for parity with the AWS Provider.

```console
% TF_ACC=1 go test -count=1 ./internal/backend/remote-state/s3/...
ok      github.com/hashicorp/terraform/internal/backend/remote-state/s3 107.215s
```

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Closes #33693
Relates #33687 

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.6.x

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

### UPGRADE NOTES

<!--

Write a short description of the user-facing change. Examples:

- `terraform show -json`: Fixed crash with sensitive set values.
- When rendering a diff, Terraform now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 

-  Adds an `sts_region` argument. ([#33693](https://github.com/hashicorp/terraform/issues/33693))
