### PR TITLE
Embed the schemas directly in the testing framework JSON verbose outputs

### DIFF
--- a/internal/command/jsonformat/plan.go
+++ b/internal/command/jsonformat/plan.go
@@ -26,13 +26,13 @@ const (
 
 type Plan struct {
 	PlanFormatVersion  string                     `json:"plan_format_version"`
-	OutputChanges      map[string]jsonplan.Change `json:"output_changes"`
-	ResourceChanges    []jsonplan.ResourceChange  `json:"resource_changes"`
-	ResourceDrift      []jsonplan.ResourceChange  `json:"resource_drift"`
-	RelevantAttributes []jsonplan.ResourceAttr    `json:"relevant_attributes"`
+	OutputChanges      map[string]jsonplan.Change `json:"output_changes,omitempty"`
+	ResourceChanges    []jsonplan.ResourceChange  `json:"resource_changes,omitempty"`
+	ResourceDrift      []jsonplan.ResourceChange  `json:"resource_drift,omitempty"`
+	RelevantAttributes []jsonplan.ResourceAttr    `json:"relevant_attributes,omitempty"`
 
 	ProviderFormatVersion string                            `json:"provider_format_version"`
-	ProviderSchemas       map[string]*jsonprovider.Provider `json:"provider_schemas"`
+	ProviderSchemas       map[string]*jsonprovider.Provider `json:"provider_schemas,omitempty"`
 }
 
 func (plan Plan) getSchema(change jsonplan.ResourceChange) *jsonprovider.Schema {

--- a/internal/command/jsonformat/state.go
+++ b/internal/command/jsonformat/state.go
@@ -17,11 +17,11 @@ import (
 
 type State struct {
 	StateFormatVersion string                      `json:"state_format_version"`
-	RootModule         jsonstate.Module            `json:"root"`
-	RootModuleOutputs  map[string]jsonstate.Output `json:"root_module_outputs"`
+	RootModule         jsonstate.Module            `json:"root,omitempty"`
+	RootModuleOutputs  map[string]jsonstate.Output `json:"root_module_outputs,omitempty"`
 
 	ProviderFormatVersion string                            `json:"provider_format_version"`
-	ProviderSchemas       map[string]*jsonprovider.Provider `json:"provider_schemas"`
+	ProviderSchemas       map[string]*jsonprovider.Provider `json:"provider_schemas,omitempty"`
 }
 
 func (state State) Empty() bool {

--- a/internal/command/jsonplan/module.go
+++ b/internal/command/jsonplan/module.go
@@ -3,17 +3,17 @@
 
 package jsonplan
 
-// Module is the representation of a module in state. This can be the root
+// module is the representation of a module in state. This can be the root
 // module or a child module.
-type Module struct {
+type module struct {
 	// Resources are sorted in a user-friendly order that is undefined at this
 	// time, but consistent.
-	Resources []Resource `json:"resources,omitempty"`
+	Resources []resource `json:"resources,omitempty"`
 
 	// Address is the absolute module address, omitted for the root module
 	Address string `json:"address,omitempty"`
 
 	// Each module object can optionally have its own nested "child_modules",
 	// recursively describing the full module tree.
-	ChildModules []Module `json:"child_modules,omitempty"`
+	ChildModules []module `json:"child_modules,omitempty"`
 }

--- a/internal/command/jsonplan/plan.go
+++ b/internal/command/jsonplan/plan.go
@@ -46,13 +46,13 @@ const (
 	ResourceInstanceReadBecauseCheckNested        = "read_because_check_nested"
 )
 
-// Plan is the top-level representation of the json format of a plan. It includes
+// plan is the top-level representation of the json format of a plan. It includes
 // the complete config and current state.
-type Plan struct {
+type plan struct {
 	FormatVersion    string      `json:"format_version,omitempty"`
 	TerraformVersion string      `json:"terraform_version,omitempty"`
-	Variables        Variables   `json:"variables,omitempty"`
-	PlannedValues    StateValues `json:"planned_values,omitempty"`
+	Variables        variables   `json:"variables,omitempty"`
+	PlannedValues    stateValues `json:"planned_values,omitempty"`
 	// ResourceDrift and ResourceChanges are sorted in a user-friendly order
 	// that is undefined at this time, but consistent.
 	ResourceDrift      []ResourceChange  `json:"resource_drift,omitempty"`
@@ -66,8 +66,8 @@ type Plan struct {
 	Errored            bool              `json:"errored"`
 }
 
-func newPlan() *Plan {
-	return &Plan{
+func newPlan() *plan {
+	return &plan{
 		FormatVersion: FormatVersion,
 	}
 }
@@ -150,17 +150,17 @@ type Importing struct {
 	ID string `json:"id,omitempty"`
 }
 
-type Output struct {
+type output struct {
 	Sensitive bool            `json:"sensitive"`
 	Type      json.RawMessage `json:"type,omitempty"`
 	Value     json.RawMessage `json:"value,omitempty"`
 }
 
-// Variables is the JSON representation of the variables provided to the current
+// variables is the JSON representation of the variables provided to the current
 // plan.
-type Variables map[string]*Variable
+type variables map[string]*variable
 
-type Variable struct {
+type variable struct {
 	Value json.RawMessage `json:"value,omitempty"`
 }
 
@@ -212,14 +212,13 @@ func MarshalForRenderer(
 	return output.OutputChanges, output.ResourceChanges, output.ResourceDrift, output.RelevantAttributes, nil
 }
 
-// MarshalForLog returns the original JSON compatible plan, ready for a logging
-// package to marshal further.
-func MarshalForLog(
+// Marshal returns the json encoding of a terraform plan.
+func Marshal(
 	config *configs.Config,
 	p *plans.Plan,
 	sf *statefile.File,
 	schemas *terraform.Schemas,
-) (*Plan, error) {
+) ([]byte, error) {
 	output := newPlan()
 	output.TerraformVersion = version.String()
 	output.Timestamp = p.Timestamp.Format(time.RFC3339)
@@ -294,26 +293,11 @@ func MarshalForLog(
 		return nil, fmt.Errorf("error marshaling config: %s", err)
 	}
 
-	return output, nil
-}
-
-// Marshal returns the json encoding of a terraform plan.
-func Marshal(
-	config *configs.Config,
-	p *plans.Plan,
-	sf *statefile.File,
-	schemas *terraform.Schemas,
-) ([]byte, error) {
-	output, err := MarshalForLog(config, p, sf, schemas)
-	if err != nil {
-		return nil, err
-	}
-
 	return json.Marshal(output)
 }
 
-func (p *Plan) marshalPlanVariables(vars map[string]plans.DynamicValue, decls map[string]*configs.Variable) error {
-	p.Variables = make(Variables, len(vars))
+func (p *plan) marshalPlanVariables(vars map[string]plans.DynamicValue, decls map[string]*configs.Variable) error {
+	p.Variables = make(variables, len(vars))
 
 	for k, v := range vars {
 		val, err := v.Decode(cty.DynamicPseudoType)
@@ -324,7 +308,7 @@ func (p *Plan) marshalPlanVariables(vars map[string]plans.DynamicValue, decls ma
 		if err != nil {
 			return err
 		}
-		p.Variables[k] = &Variable{
+		p.Variables[k] = &variable{
 			Value: valJSON,
 		}
 	}
@@ -353,7 +337,7 @@ func (p *Plan) marshalPlanVariables(vars map[string]plans.DynamicValue, decls ma
 			if err != nil {
 				return err
 			}
-			p.Variables[name] = &Variable{
+			p.Variables[name] = &variable{
 				Value: valJSON,
 			}
 		}
@@ -654,7 +638,7 @@ func MarshalOutputChanges(changes *plans.Changes) (map[string]Change, error) {
 	return outputChanges, nil
 }
 
-func (p *Plan) marshalPlannedValues(changes *plans.Changes, schemas *terraform.Schemas) error {
+func (p *plan) marshalPlannedValues(changes *plans.Changes, schemas *terraform.Schemas) error {
 	// marshal the planned changes into a module
 	plan, err := marshalPlannedValues(changes, schemas)
 	if err != nil {
@@ -672,7 +656,7 @@ func (p *Plan) marshalPlannedValues(changes *plans.Changes, schemas *terraform.S
 	return nil
 }
 
-func (p *Plan) marshalRelevantAttrs(plan *plans.Plan) error {
+func (p *plan) marshalRelevantAttrs(plan *plans.Plan) error {
 	for _, ra := range plan.RelevantAttributes {
 		addr := ra.Resource.String()
 		path, err := encodePath(ra.Attr)

--- a/internal/command/jsonplan/resource.go
+++ b/internal/command/jsonplan/resource.go
@@ -9,8 +9,8 @@ import (
 	"github.com/hashicorp/terraform/internal/addrs"
 )
 
-// Resource is the representation of a resource in the json plan
-type Resource struct {
+// resource is the representation of a resource in the json plan
+type resource struct {
 	// Address is the absolute resource address
 	Address string `json:"address,omitempty"`
 
@@ -37,7 +37,7 @@ type Resource struct {
 	// resource, whose structure depends on the resource type schema. Any
 	// unknown values are omitted or set to null, making them indistinguishable
 	// from absent values.
-	AttributeValues AttributeValues `json:"values,omitempty"`
+	AttributeValues attributeValues `json:"values,omitempty"`
 
 	// SensitiveValues is similar to AttributeValues, but with all sensitive
 	// values replaced with true, and all non-sensitive leaf values omitted.

--- a/internal/command/jsonplan/values_test.go
+++ b/internal/command/jsonplan/values_test.go
@@ -21,7 +21,7 @@ func TestMarshalAttributeValues(t *testing.T) {
 	tests := []struct {
 		Attr   cty.Value
 		Schema *configschema.Block
-		Want   AttributeValues
+		Want   attributeValues
 	}{
 		{
 			cty.NilVal,
@@ -59,7 +59,7 @@ func TestMarshalAttributeValues(t *testing.T) {
 					},
 				},
 			},
-			AttributeValues{"foo": json.RawMessage(`"bar"`)},
+			attributeValues{"foo": json.RawMessage(`"bar"`)},
 		},
 		{
 			cty.ObjectVal(map[string]cty.Value{
@@ -73,7 +73,7 @@ func TestMarshalAttributeValues(t *testing.T) {
 					},
 				},
 			},
-			AttributeValues{"foo": json.RawMessage(`null`)},
+			attributeValues{"foo": json.RawMessage(`null`)},
 		},
 		{
 			cty.ObjectVal(map[string]cty.Value{
@@ -97,7 +97,7 @@ func TestMarshalAttributeValues(t *testing.T) {
 					},
 				},
 			},
-			AttributeValues{
+			attributeValues{
 				"bar": json.RawMessage(`{"hello":"world"}`),
 				"baz": json.RawMessage(`["goodnight","moon"]`),
 			},
@@ -118,7 +118,7 @@ func TestMarshalPlannedOutputs(t *testing.T) {
 
 	tests := []struct {
 		Changes *plans.Changes
-		Want    map[string]Output
+		Want    map[string]output
 		Err     bool
 	}{
 		{
@@ -139,7 +139,7 @@ func TestMarshalPlannedOutputs(t *testing.T) {
 					},
 				},
 			},
-			map[string]Output{
+			map[string]output{
 				"bar": {
 					Sensitive: false,
 					Type:      json.RawMessage(`"string"`),
@@ -160,7 +160,7 @@ func TestMarshalPlannedOutputs(t *testing.T) {
 					},
 				},
 			},
-			map[string]Output{},
+			map[string]output{},
 			false,
 		},
 	}
@@ -188,7 +188,7 @@ func TestMarshalPlanResources(t *testing.T) {
 		Action plans.Action
 		Before cty.Value
 		After  cty.Value
-		Want   []Resource
+		Want   []resource
 		Err    bool
 	}{
 		"create with unknowns": {
@@ -198,7 +198,7 @@ func TestMarshalPlanResources(t *testing.T) {
 				"woozles": cty.UnknownVal(cty.String),
 				"foozles": cty.UnknownVal(cty.String),
 			}),
-			Want: []Resource{{
+			Want: []resource{{
 				Address:         "test_thing.example",
 				Mode:            "managed",
 				Type:            "test_thing",
@@ -206,7 +206,7 @@ func TestMarshalPlanResources(t *testing.T) {
 				Index:           addrs.InstanceKey(nil),
 				ProviderName:    "registry.terraform.io/hashicorp/test",
 				SchemaVersion:   1,
-				AttributeValues: AttributeValues{},
+				AttributeValues: attributeValues{},
 				SensitiveValues: json.RawMessage("{}"),
 			}},
 			Err: false,
@@ -241,7 +241,7 @@ func TestMarshalPlanResources(t *testing.T) {
 				"woozles": cty.StringVal("baz"),
 				"foozles": cty.StringVal("bat"),
 			}),
-			Want: []Resource{{
+			Want: []resource{{
 				Address:       "test_thing.example",
 				Mode:          "managed",
 				Type:          "test_thing",
@@ -249,7 +249,7 @@ func TestMarshalPlanResources(t *testing.T) {
 				Index:         addrs.InstanceKey(nil),
 				ProviderName:  "registry.terraform.io/hashicorp/test",
 				SchemaVersion: 1,
-				AttributeValues: AttributeValues{
+				AttributeValues: attributeValues{
 					"woozles": json.RawMessage(`"baz"`),
 					"foozles": json.RawMessage(`"bat"`),
 				},

--- a/internal/command/views/test_test.go
+++ b/internal/command/views/test_test.go
@@ -2607,28 +2607,8 @@ func TestTestJSON_Run(t *testing.T) {
 					"@testfile": "main.tftest.hcl",
 					"@testrun":  "run_block",
 					"test_plan": map[string]interface{}{
-						"configuration": map[string]interface{}{
-							"root_module": map[string]interface{}{},
-						},
-						"errored": false,
-						"planned_values": map[string]interface{}{
-							"root_module": map[string]interface{}{
-								"resources": []interface{}{
-									map[string]interface{}{
-										"address":          "test_resource.creating",
-										"mode":             "managed",
-										"name":             "creating",
-										"provider_name":    "registry.terraform.io/hashicorp/test",
-										"schema_version":   0.0,
-										"sensitive_values": map[string]interface{}{},
-										"type":             "test_resource",
-										"values": map[string]interface{}{
-											"value": "foobar",
-										},
-									},
-								},
-							},
-						},
+						"plan_format_version":     "1.2",
+						"provider_format_version": "1.0",
 						"resource_changes": []interface{}{
 							map[string]interface{}{
 								"address": "test_resource.creating",
@@ -2646,6 +2626,27 @@ func TestTestJSON_Run(t *testing.T) {
 								"name":          "creating",
 								"provider_name": "registry.terraform.io/hashicorp/test",
 								"type":          "test_resource",
+							},
+						},
+						"provider_schemas": map[string]interface{}{
+							"registry.terraform.io/hashicorp/test": map[string]interface{}{
+								"provider": map[string]interface{}{
+									"version": 0.0,
+								},
+								"resource_schemas": map[string]interface{}{
+									"test_resource": map[string]interface{}{
+										"block": map[string]interface{}{
+											"attributes": map[string]interface{}{
+												"value": map[string]interface{}{
+													"description_kind": "plain",
+													"type":             "string",
+												},
+											},
+											"description_kind": "plain",
+										},
+										"version": 0.0,
+									},
+								},
 							},
 						},
 					},
@@ -2731,20 +2732,41 @@ func TestTestJSON_Run(t *testing.T) {
 					"@testfile": "main.tftest.hcl",
 					"@testrun":  "run_block",
 					"test_state": map[string]interface{}{
-						"values": map[string]interface{}{
-							"root_module": map[string]interface{}{
-								"resources": []interface{}{
-									map[string]interface{}{
-										"address":          "test_resource.creating",
-										"mode":             "managed",
-										"name":             "creating",
-										"provider_name":    "registry.terraform.io/hashicorp/test",
-										"schema_version":   0.0,
-										"sensitive_values": map[string]interface{}{},
-										"type":             "test_resource",
-										"values": map[string]interface{}{
-											"value": "foobar",
+						"state_format_version":    "1.0",
+						"provider_format_version": "1.0",
+						"root": map[string]interface{}{
+							"resources": []interface{}{
+								map[string]interface{}{
+									"address":          "test_resource.creating",
+									"mode":             "managed",
+									"name":             "creating",
+									"provider_name":    "registry.terraform.io/hashicorp/test",
+									"schema_version":   0.0,
+									"sensitive_values": map[string]interface{}{},
+									"type":             "test_resource",
+									"values": map[string]interface{}{
+										"value": "foobar",
+									},
+								},
+							},
+						},
+						"provider_schemas": map[string]interface{}{
+							"registry.terraform.io/hashicorp/test": map[string]interface{}{
+								"provider": map[string]interface{}{
+									"version": 0.0,
+								},
+								"resource_schemas": map[string]interface{}{
+									"test_resource": map[string]interface{}{
+										"block": map[string]interface{}{
+											"attributes": map[string]interface{}{
+												"value": map[string]interface{}{
+													"description_kind": "plain",
+													"type":             "string",
+												},
+											},
+											"description_kind": "plain",
 										},
+										"version": 0.0,
 									},
 								},
 							},


### PR DESCRIPTION
This is going to be used when we integrate with TFC. We will consume JSON outputs and turn them back into human-readable output. Now, the verbose outputs are already in the format accepted by the renderer, whereas previously we would've had to load the schemas separately.

This PR also reverses the changes that made our JSON implementation more public in #33504. We don't need this anymore as we are just using the already public fields that our renderer requires.