### PR TITLE
internal/plugin+internal/plugin6: Fix provider schema caching

### DIFF
--- a/internal/plugin/grpc_provider.go
+++ b/internal/plugin/grpc_provider.go
@@ -79,7 +79,7 @@ func (p *GRPCProvider) GetProviderSchema() (resp providers.GetProviderSchemaResp
 	defer p.mu.Unlock()
 
 	// check the global cache if we can
-	if !p.Addr.IsZero() && resp.ServerCapabilities.GetProviderSchemaOptional {
+	if !p.Addr.IsZero() {
 		if resp, ok := providers.SchemaCache.Get(p.Addr); ok {
 			return resp
 		}
@@ -141,7 +141,7 @@ func (p *GRPCProvider) GetProviderSchema() (resp providers.GetProviderSchemaResp
 	}
 
 	// set the global cache if we can
-	if !p.Addr.IsZero() {
+	if !p.Addr.IsZero() && resp.ServerCapabilities.GetProviderSchemaOptional {
 		providers.SchemaCache.Set(p.Addr, resp)
 	}
 

--- a/internal/plugin6/grpc_provider.go
+++ b/internal/plugin6/grpc_provider.go
@@ -79,7 +79,7 @@ func (p *GRPCProvider) GetProviderSchema() (resp providers.GetProviderSchemaResp
 	defer p.mu.Unlock()
 
 	// check the global cache if we can
-	if !p.Addr.IsZero() && resp.ServerCapabilities.GetProviderSchemaOptional {
+	if !p.Addr.IsZero() {
 		if resp, ok := providers.SchemaCache.Get(p.Addr); ok {
 			return resp
 		}
@@ -141,7 +141,7 @@ func (p *GRPCProvider) GetProviderSchema() (resp providers.GetProviderSchemaResp
 	}
 
 	// set the global cache if we can
-	if !p.Addr.IsZero() {
+	if !p.Addr.IsZero() && resp.ServerCapabilities.GetProviderSchemaOptional {
 		providers.SchemaCache.Set(p.Addr, resp)
 	}
 


### PR DESCRIPTION
Reference: https://github.com/hashicorp/terraform/pull/33486

The intention of this logic is to use the global provider schema cache if it is available for a given provider address based on the `GetProviderSchemaOptional` server capability. Previously the logic was errantly checking the named return early, which was not populated yet with the server response. This flips the logic to properly use the server response to determine whether the cache should be set, thereby still gating the caching based on the server capability.

In a configuration with 19 `hashicorp/aws` provider instances and an associated data source, this drops the received `GetProviderSchema` calls from 39 calls to 1 call with this change. Maximum RSS dropped from 1.22 GB to 189 MB.

## Target Release

1.6.x

## Draft CHANGELOG entry

N/A (already changelog'd as #33486)
