### PR TITLE
cloud: State upload verification and timeout

### DIFF
--- a/internal/backend/remote/backend_state.go
+++ b/internal/backend/remote/backend_state.go
@@ -9,9 +9,7 @@ import (
 	"crypto/md5"
 	"encoding/base64"
 	"encoding/json"
-	"errors"
 	"fmt"
-	"log"
 
 	tfe "github.com/hashicorp/go-tfe"
 
@@ -63,31 +61,6 @@ func (r *remoteClient) Get() (*remote.Payload, error) {
 	}, nil
 }
 
-func (r *remoteClient) uploadStateFallback(ctx context.Context, stateFile *statefile.File, state []byte, jsonStateOutputs []byte) error {
-	options := tfe.StateVersionCreateOptions{
-		Lineage:          tfe.String(stateFile.Lineage),
-		Serial:           tfe.Int64(int64(stateFile.Serial)),
-		MD5:              tfe.String(fmt.Sprintf("%x", md5.Sum(state))),
-		Force:            tfe.Bool(r.forcePush),
-		State:            tfe.String(base64.StdEncoding.EncodeToString(state)),
-		JSONStateOutputs: tfe.String(base64.StdEncoding.EncodeToString(jsonStateOutputs)),
-	}
-
-	// If we have a run ID, make sure to add it to the options
-	// so the state will be properly associated with the run.
-	if r.runID != "" {
-		options.Run = &tfe.Run{ID: r.runID}
-	}
-
-	// Create the new state.
-	_, err := r.client.StateVersions.Create(ctx, r.workspace.ID, options)
-	if err != nil {
-		r.stateUploadErr = true
-		return fmt.Errorf("error uploading state in compatibility mode: %v", err)
-	}
-	return err
-}
-
 // Put the remote state.
 func (r *remoteClient) Put(state []byte) error {
 	ctx := context.Background()
@@ -95,27 +68,25 @@ func (r *remoteClient) Put(state []byte) error {
 	// Read the raw state into a Terraform state.
 	stateFile, err := statefile.Read(bytes.NewReader(state))
 	if err != nil {
-		return fmt.Errorf("error reading state: %s", err)
+		return fmt.Errorf("Error reading state: %s", err)
 	}
 
 	ov, err := jsonstate.MarshalOutputs(stateFile.State.RootModule().OutputValues)
 	if err != nil {
-		return fmt.Errorf("error reading output values: %s", err)
+		return fmt.Errorf("Error reading output values: %s", err)
 	}
 	o, err := json.Marshal(ov)
 	if err != nil {
-		return fmt.Errorf("error converting output values to json: %s", err)
+		return fmt.Errorf("Error converting output values to json: %s", err)
 	}
 
-	options := tfe.StateVersionUploadOptions{
-		StateVersionCreateOptions: tfe.StateVersionCreateOptions{
-			Lineage:          tfe.String(stateFile.Lineage),
-			Serial:           tfe.Int64(int64(stateFile.Serial)),
-			MD5:              tfe.String(fmt.Sprintf("%x", md5.Sum(state))),
-			Force:            tfe.Bool(r.forcePush),
-			JSONStateOutputs: tfe.String(base64.StdEncoding.EncodeToString(o)),
-		},
-		RawState: state,
+	options := tfe.StateVersionCreateOptions{
+		Lineage:          tfe.String(stateFile.Lineage),
+		Serial:           tfe.Int64(int64(stateFile.Serial)),
+		MD5:              tfe.String(fmt.Sprintf("%x", md5.Sum(state))),
+		State:            tfe.String(base64.StdEncoding.EncodeToString(state)),
+		Force:            tfe.Bool(r.forcePush),
+		JSONStateOutputs: tfe.String(base64.StdEncoding.EncodeToString(o)),
 	}
 
 	// If we have a run ID, make sure to add it to the options
@@ -125,16 +96,10 @@ func (r *remoteClient) Put(state []byte) error {
 	}
 
 	// Create the new state.
-	// Create the new state.
-	_, err = r.client.StateVersions.Upload(ctx, r.workspace.ID, options)
-	if errors.Is(err, tfe.ErrStateVersionUploadNotSupported) {
-		// Create the new state with content included in the request (Terraform Enterprise v202306-1 and below)
-		log.Println("[INFO] Detected that state version upload is not supported. Retrying using compatibility state upload.")
-		return r.uploadStateFallback(ctx, stateFile, state, o)
-	}
+	_, err = r.client.StateVersions.Create(ctx, r.workspace.ID, options)
 	if err != nil {
 		r.stateUploadErr = true
-		return fmt.Errorf("error uploading state: %v", err)
+		return fmt.Errorf("Error uploading state: %v", err)
 	}
 
 	return nil
@@ -144,7 +109,7 @@ func (r *remoteClient) Put(state []byte) error {
 func (r *remoteClient) Delete() error {
 	err := r.client.Workspaces.Delete(context.Background(), r.organization, r.workspace.Name)
 	if err != nil && err != tfe.ErrResourceNotFound {
-		return fmt.Errorf("error deleting workspace %s: %v", r.workspace.Name, err)
+		return fmt.Errorf("Error deleting workspace %s: %v", r.workspace.Name, err)
 	}
 
 	return nil

--- a/internal/backend/remote/backend_state_test.go
+++ b/internal/backend/remote/backend_state_test.go
@@ -41,7 +41,7 @@ func TestRemoteClient_stateLock(t *testing.T) {
 	remote.TestRemoteLocks(t, s1.(*remote.State).Client, s2.(*remote.State).Client)
 }
 
-func TestRemoteClient_Put_withRunID(t *testing.T) {
+func TestRemoteClient_withRunID(t *testing.T) {
 	// Set the TFE_RUN_ID environment variable before creating the client!
 	if err := os.Setenv("TFE_RUN_ID", cloud.GenerateID("run-")); err != nil {
 		t.Fatalf("error setting env var TFE_RUN_ID: %v", err)

--- a/internal/cloud/testing.go
+++ b/internal/cloud/testing.go
@@ -397,7 +397,7 @@ func testServerWithHandlers(handlers map[string]func(http.ResponseWriter, *http.
 	return httptest.NewServer(mux)
 }
 
-func testServerWithSnapshotsEnabled(t *testing.T, enabled bool) *httptest.Server {
+func testServerWithSnapshotsEnabled(t *testing.T, enabled bool, status tfe.StateVersionStatus) *httptest.Server {
 	var serverURL string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		t.Log(r.Method, r.URL.String())
@@ -429,6 +429,7 @@ func testServerWithSnapshotsEnabled(t *testing.T, enabled bool) *httptest.Server
 				"attributes": map[string]any{
 					"hosted-state-download-url": serverURL + "/state-json",
 					"hosted-state-upload-url":   serverURL + "/state-json",
+					"status":                    status,
 				},
 			},
 		}

--- a/internal/cloud/tfe_client_mock.go
+++ b/internal/cloud/tfe_client_mock.go
@@ -1380,6 +1380,7 @@ func (m *MockStateVersions) Create(ctx context.Context, workspaceID string, opti
 		DownloadURL: url,
 		UploadURL:   fmt.Sprintf("/_archivist/upload/%s", id),
 		Serial:      *options.Serial,
+		Status:      tfe.StateVersionFinalized,
 	}
 
 	state, err := base64.StdEncoding.DecodeString(*options.State)


### PR DESCRIPTION
It's possible that state can be successfully uploaded to Terraform Cloud, but that the platform has an internal outage that prevents it from being acknowledged by the API.

This change verifies each state save arrives at the "finalized" state within 5 minutes. If that timeout is exceeded, an error is returned with detailed recovery instructions.

I also reverted [c95501c4c5](https://github.com/hashicorp/terraform/commit/c95501c4c50bf96a0e201131253517a2d5d54a35) "remote: when saving state, create a pending state version then upload" because this feature has reached a threshold of complexity I felt shouldn't be backported to the remote backend.

## Target Release

1.6.0

## Draft CHANGELOG

BUG FIXES: terraform will no longer exceed the 30 second gateway timeout when saving state to Terraform Cloud

![Screenshot 2023-08-31 at 11 33 26 AM](https://github.com/hashicorp/terraform/assets/174332/8332010f-eef4-4bd5-ad7b-36d00019948f)

