### PR TITLE
Mention shell injection in local provisioner documentation

### DIFF
--- a/website/docs/language/resources/provisioners/local-exec.mdx
+++ b/website/docs/language/resources/provisioners/local-exec.mdx
@@ -40,7 +40,10 @@ The following arguments are supported:
 * `command` - (Required) This is the command to execute. It can be provided
   as a relative path to the current working directory or as an absolute path.
   It is evaluated in a shell, and can use environment variables or Terraform
-  variables.
+  variables. Note that direct use of Terraform variables within a command
+  should be avoided, as doing so can lead to [shell injection](https://en.wikipedia.org/wiki/Code_injection#Shell_injection)
+  vulnerabilities. Instead, one should pass Terraform variables to a command
+  through the `environment` parameter whenever possible.
 
 * `working_dir` - (Optional) If provided, specifies the working directory where
   `command` will be executed. It can be provided as a relative path to the

--- a/website/docs/language/resources/provisioners/local-exec.mdx
+++ b/website/docs/language/resources/provisioners/local-exec.mdx
@@ -39,11 +39,12 @@ The following arguments are supported:
 
 * `command` - (Required) This is the command to execute. It can be provided
   as a relative path to the current working directory or as an absolute path.
-  It is evaluated in a shell, and can use environment variables or Terraform
-  variables. Note that direct use of Terraform variables within a command
-  should be avoided, as doing so can lead to [shell injection](https://en.wikipedia.org/wiki/Code_injection#Shell_injection)
+  It is evaluated in a shell, and as such can use environment variables for
+  variable substitution. While Terraform variables may also be used for variable
+  substitution, doing so should be avoided as it can lead to [shell injection](https://en.wikipedia.org/wiki/Code_injection#Shell_injection)
   vulnerabilities. Instead, one should pass Terraform variables to a command
-  through the `environment` parameter whenever possible.
+  through the `environment` parameter and use environment variable substitution
+  instead.
 
 * `working_dir` - (Optional) If provided, specifies the working directory where
   `command` will be executed. It can be provided as a relative path to the

--- a/website/docs/language/resources/provisioners/local-exec.mdx
+++ b/website/docs/language/resources/provisioners/local-exec.mdx
@@ -39,12 +39,11 @@ The following arguments are supported:
 
 * `command` - (Required) This is the command to execute. It can be provided
   as a relative path to the current working directory or as an absolute path.
-  It is evaluated in a shell, and as such can use environment variables for
-  variable substitution. While Terraform variables may also be used for variable
-  substitution, doing so should be avoided as it can lead to [shell injection](https://en.wikipedia.org/wiki/Code_injection#Shell_injection)
-  vulnerabilities. Instead, one should pass Terraform variables to a command
+  The `command` is is evaluated in a shell and can use environment variables for
+  variable substitution. We do not recommend using Terraform variables for variable
+  substitution because doing so can lead to shell injection vulnerabilities. Instead, you should pass Terraform variables to a command
   through the `environment` parameter and use environment variable substitution
-  instead.
+  instead. Refer to the following OWASP article for additional information about injection flaws: [Code Injection](https://owasp.org/www-community/attacks/Code_Injection).
 
 * `working_dir` - (Optional) If provided, specifies the working directory where
   `command` will be executed. It can be provided as a relative path to the


### PR DESCRIPTION
While direct injection of Terraform variables in the `local-exec` provisioner's `command` parameter is _possible_, it should be avoided due to its possibility of creating shell injection vulnerabilities. This PR adds mention of this to the documentation, and suggests the alternative of passing Terraform variables to a command as environment variables.

I can add a "do this/not that" example to the documentation as well, if that is desired.

## Target Release

1.5.x

