### PR TITLE
Handle null outputs in Terraform test files

### DIFF
--- a/internal/backend/local/test.go
+++ b/internal/backend/local/test.go
@@ -1345,7 +1345,33 @@ func (runner *TestFileRunner) ctx(run *moduletest.Run, file *moduletest.File, av
 						},
 					})
 
-					if value.Sensitive {
+					if value == nil {
+						// Then this output returned null when the configuration
+						// executed. For now, we'll just skip this output.
+						//
+						// There are several things we could try to do, like
+						// figure out the type based on the variable that it
+						// is referencing and wrap it up as cty.Val(...) or we
+						// could not try and work anything out and return it as
+						// a cty.NilVal.
+						//
+						// Both of these mean the error would be raised later
+						// as non-optional variables would say they don't have
+						// a value. By just ignoring it here, we get an error
+						// quicker that says this output doesn't exist. I think
+						// that would prompt users to go look at the output and
+						// realise it might be returning null and make the
+						// connection. With the other approaches they'd look at
+						// their variable definitions and think they are
+						// assigning it a value since we would be telling them
+						// the output does exist.
+						//
+						// Let's do the simple thing now, and see what the
+						// future holds.
+						continue
+					}
+
+					if value.Sensitive || output.Sensitive {
 						outputs[output.Name] = value.Value.Mark(marks.Sensitive)
 						continue
 					}

--- a/internal/command/test_test.go
+++ b/internal/command/test_test.go
@@ -165,6 +165,10 @@ func TestTest(t *testing.T) {
 			args:     []string{"-var=number_input=0", "-var=string_input=Hello, world!", "-var=list_input=[\"Hello\",\"world\"]"},
 			code:     0,
 		},
+		"null-outputs": {
+			expected: "2 passed, 0 failed.",
+			code:     0,
+		},
 	}
 	for name, tc := range tcs {
 		t.Run(name, func(t *testing.T) {

--- a/internal/command/testdata/test/null-outputs/main.tf
+++ b/internal/command/testdata/test/null-outputs/main.tf
@@ -1,0 +1,8 @@
+
+variable "input" {
+  type = number
+}
+
+output "output" {
+  value = var.input > 5 ? var.input : null
+}

--- a/internal/command/testdata/test/null-outputs/main.tftest.hcl
+++ b/internal/command/testdata/test/null-outputs/main.tftest.hcl
@@ -1,0 +1,22 @@
+
+run "first" {
+  variables {
+    input = 2
+  }
+
+  assert {
+    condition = output.output == null
+    error_message = "output should have been null"
+  }
+}
+
+run "second" {
+  variables {
+    input = 8
+  }
+
+  assert {
+    condition = output.output == 8
+    error_message = "output should have been 8"
+  }
+}


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

This PR updates the test framework so it doesn't assume all outputs defined in the config are populated in the state. If an output returns null during a Terraform execution it is simply skipped and not added to the state instead of added as a null value. This was causing a panic as the test framework was assuming all outputs would be present in the state.

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Fixes #33780 

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.6.0-beta2
