### PR TITLE
move `GetProviderSchemaOptional` check to correct block

### DIFF
--- a/internal/plugin/grpc_provider.go
+++ b/internal/plugin/grpc_provider.go
@@ -73,14 +73,15 @@ type GRPCProvider struct {
 	schema providers.GetProviderSchemaResponse
 }
 
-func (p *GRPCProvider) GetProviderSchema() (resp providers.GetProviderSchemaResponse) {
+func (p *GRPCProvider) GetProviderSchema() providers.GetProviderSchemaResponse {
 	logger.Trace("GRPCProvider: GetProviderSchema")
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
 	// check the global cache if we can
-	if !p.Addr.IsZero() && resp.ServerCapabilities.GetProviderSchemaOptional {
-		if resp, ok := providers.SchemaCache.Get(p.Addr); ok {
+	if !p.Addr.IsZero() {
+		if resp, ok := providers.SchemaCache.Get(p.Addr); ok && resp.ServerCapabilities.GetProviderSchemaOptional {
+			logger.Trace("GRPCProvider: returning cached schema", p.Addr.String())
 			return resp
 		}
 	}
@@ -90,6 +91,8 @@ func (p *GRPCProvider) GetProviderSchema() (resp providers.GetProviderSchemaResp
 	if p.schema.Provider.Block != nil {
 		return p.schema
 	}
+
+	var resp providers.GetProviderSchemaResponse
 
 	resp.ResourceTypes = make(map[string]providers.Schema)
 	resp.DataSources = make(map[string]providers.Schema)

--- a/internal/plugin/grpc_provider_test.go
+++ b/internal/plugin/grpc_provider_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/configs/hcl2shim"
 	"github.com/hashicorp/terraform/internal/providers"
 	"github.com/hashicorp/terraform/internal/tfdiags"
@@ -92,6 +93,9 @@ func providerProtoSchema() *proto.GetProviderSchema_Response {
 				},
 			},
 		},
+		ServerCapabilities: &proto.ServerCapabilities{
+			GetProviderSchemaOptional: true,
+		},
 	}
 }
 
@@ -101,6 +105,27 @@ func TestGRPCProvider_GetSchema(t *testing.T) {
 	}
 
 	resp := p.GetProviderSchema()
+	checkDiags(t, resp.Diagnostics)
+}
+
+// ensure that the global schema cache is used when the provider supports
+// GetProviderSchemaOptional
+func TestGRPCProvider_GetSchema_globalCache(t *testing.T) {
+	p := &GRPCProvider{
+		Addr:   addrs.ImpliedProviderForUnqualifiedType("test"),
+		client: mockProviderClient(t),
+	}
+
+	// first call primes the cache
+	resp := p.GetProviderSchema()
+
+	// create a new provider instance which does not expect a GetProviderSchemaCall
+	p = &GRPCProvider{
+		Addr:   addrs.ImpliedProviderForUnqualifiedType("test"),
+		client: mockproto.NewMockProviderClient(gomock.NewController(t)),
+	}
+
+	resp = p.GetProviderSchema()
 	checkDiags(t, resp.Diagnostics)
 }
 

--- a/internal/plugin6/grpc_provider.go
+++ b/internal/plugin6/grpc_provider.go
@@ -73,14 +73,15 @@ type GRPCProvider struct {
 	schema providers.GetProviderSchemaResponse
 }
 
-func (p *GRPCProvider) GetProviderSchema() (resp providers.GetProviderSchemaResponse) {
+func (p *GRPCProvider) GetProviderSchema() providers.GetProviderSchemaResponse {
 	logger.Trace("GRPCProvider.v6: GetProviderSchema")
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
 	// check the global cache if we can
-	if !p.Addr.IsZero() && resp.ServerCapabilities.GetProviderSchemaOptional {
-		if resp, ok := providers.SchemaCache.Get(p.Addr); ok {
+	if !p.Addr.IsZero() {
+		if resp, ok := providers.SchemaCache.Get(p.Addr); ok && resp.ServerCapabilities.GetProviderSchemaOptional {
+			logger.Trace("GRPCProvider.v6: returning cached schema", p.Addr.String())
 			return resp
 		}
 	}
@@ -90,6 +91,8 @@ func (p *GRPCProvider) GetProviderSchema() (resp providers.GetProviderSchemaResp
 	if p.schema.Provider.Block != nil {
 		return p.schema
 	}
+
+	var resp providers.GetProviderSchemaResponse
 
 	resp.ResourceTypes = make(map[string]providers.Schema)
 	resp.DataSources = make(map[string]providers.Schema)


### PR DESCRIPTION
A typo put the check for `GetProviderSchemaOptional` into the wrong `if` expression, and was missed partly because of the named return which we also remove here. We were also waiting for end-to-end tests with a new provider, but should have updated the mock tests to cover this logic.