### PR TITLE
Make the test command fail if resources could not be cleaned up

### DIFF
--- a/internal/backend/local/test.go
+++ b/internal/backend/local/test.go
@@ -883,8 +883,6 @@ func (runner *TestFileRunner) cleanup(file *moduletest.File) {
 
 		reset()
 	}
-
-	return
 }
 
 // buildInputVariablesForTest creates a terraform.InputValues mapping for

--- a/internal/backend/local/test.go
+++ b/internal/backend/local/test.go
@@ -769,6 +769,7 @@ func (runner *TestFileRunner) wait(ctx *terraform.Context, runningCtx context.Co
 }
 
 func (runner *TestFileRunner) cleanup(file *moduletest.File) {
+	var diags tfdiags.Diagnostics
 
 	log.Printf("[TRACE] TestStateManager: cleaning up state for %s", file.Name)
 
@@ -781,7 +782,6 @@ func (runner *TestFileRunner) cleanup(file *moduletest.File) {
 	// First, we'll clean up the main state.
 	main := runner.RelevantStates[MainStateIdentifier]
 
-	var diags tfdiags.Diagnostics
 	updated := main.State
 	if main.Run == nil {
 		if !main.State.Empty() {
@@ -799,6 +799,12 @@ func (runner *TestFileRunner) cleanup(file *moduletest.File) {
 		}
 
 		reset()
+	}
+
+	if !updated.Empty() {
+		// Then we failed to adequately clean up the state, so mark success
+		// as false.
+		file.Status = moduletest.Error
 	}
 	runner.Suite.View.DestroySummary(diags, main.Run, file, updated)
 
@@ -830,6 +836,7 @@ func (runner *TestFileRunner) cleanup(file *moduletest.File) {
 
 			var diags tfdiags.Diagnostics
 			diags = diags.Append(tfdiags.Sourceless(tfdiags.Error, "Inconsistent state", fmt.Sprintf("Found inconsistent state while cleaning up %s. This is a bug in Terraform - please report it", file.Name)))
+			file.Status = moduletest.Error
 			runner.Suite.View.DestroySummary(diags, nil, file, state.State)
 			continue
 		}
@@ -866,10 +873,18 @@ func (runner *TestFileRunner) cleanup(file *moduletest.File) {
 			updated, destroyDiags = runner.destroy(state.Run.Config.ConfigUnderTest, state.State, state.Run, file)
 			diags = diags.Append(destroyDiags)
 		}
+
+		if !updated.Empty() {
+			// Then we failed to adequately clean up the state, so mark success
+			// as false.
+			file.Status = moduletest.Error
+		}
 		runner.Suite.View.DestroySummary(diags, state.Run, file, updated)
 
 		reset()
 	}
+
+	return
 }
 
 // buildInputVariablesForTest creates a terraform.InputValues mapping for

--- a/internal/command/testdata/test/destroy_fail/main.tf
+++ b/internal/command/testdata/test/destroy_fail/main.tf
@@ -1,0 +1,5 @@
+
+resource "test_resource" "resource" {
+  value        = "Hello, world!"
+  destroy_fail = true
+}

--- a/internal/command/testdata/test/destroy_fail/main.tftest.hcl
+++ b/internal/command/testdata/test/destroy_fail/main.tftest.hcl
@@ -1,0 +1,2 @@
+
+run "single" {}


### PR DESCRIPTION
This PR fixes an oversight in the testing framework. Previously, if the testing framework failed to clean up created resources it would still report the overall operation as a success. This means that CI pipelines and TFC could fail to sufficiently warn the user that the resources were not cleaned up. This PR marks a test file has having errored if it cannot clean up the resources, this is in turn ensures the overall command will return an error code of 1 if a test cleanup fails.