### PR TITLE
statefile: Ignore unknown check results on decode

### DIFF
--- a/internal/states/statefile/version4.go
+++ b/internal/states/statefile/version4.go
@@ -525,7 +525,11 @@ func decodeCheckResultsV4(in []checkResultsV4) (*states.CheckResults, tfdiags.Di
 	for _, aggrIn := range in {
 		objectKind := decodeCheckableObjectKindV4(aggrIn.ObjectKind)
 		if objectKind == addrs.CheckableKindInvalid {
-			diags = diags.Append(fmt.Errorf("unsupported checkable object kind %q", aggrIn.ObjectKind))
+			// We cannot decode a future unknown check result kind, but
+			// for forwards compatibility we need not treat this as an
+			// error. Eliding unknown check results will not result in
+			// significant data loss and allows us to maintain state file
+			// interoperability in the 1.x series.
 			continue
 		}
 


### PR DESCRIPTION
Terraform 1.5 introduced a new check result kind, which causes a decode failure when read by Terraform 1.3 and 1.4. This means that a 1.5+ state file cannot be read by the `terraform_remote_state` data source in 1.3 or 1.4 series.

Aborting state decode at this point isn't strictly necessary, as we don't stand to lose important data by failing to round-trip these check results. Instead we can ignore those check results, allowing decode to elide them from the state.

This has no negative effect on the remote state data source, which only exposes root module outputs anyway.

Manual backport of #33815 because the robot failed.

## Target Release

1.6.0

## Draft CHANGELOG entry

### BUG FIXES

- `terraform_remote_state`: prevent future possible incompatibility with states which include unknown `check` block result kinds.