### PR TITLE
backend/s3: Adds tests for endpoint overrides and adds validation for parameters

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.13.11
 	github.com/aws/aws-sdk-go-v2/service/dynamodb v1.21.1
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.38.1
+	github.com/aws/smithy-go v1.14.2
 	github.com/bgentry/speakeasy v0.1.0
 	github.com/bmatcuk/doublestar v1.1.5
 	github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e
@@ -156,7 +157,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sso v1.13.6 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.15.6 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.21.5 // indirect
-	github.com/aws/smithy-go v1.14.2 // indirect
 	github.com/baiyubin/aliyun-sts-go-sdk v0.0.0-20180326062324-cfa1a18b161f // indirect
 	github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d // indirect
 	github.com/bmatcuk/doublestar/v4 v4.6.0 // indirect

--- a/internal/backend/remote-state/s3/backend.go
+++ b/internal/backend/remote-state/s3/backend.go
@@ -526,6 +526,10 @@ func (b *Backend) PrepareConfig(obj cty.Value) (cty.Value, tfdiags.Diagnostics) 
 			endpointValidators.ValidateAttr(val, attrPath, &diags)
 		}
 	}
+	if val := obj.GetAttr("ec2_metadata_service_endpoint"); !val.IsNull() {
+		attrPath := cty.GetAttrPath("ec2_metadata_service_endpoint")
+		endpointValidators.ValidateAttr(val, attrPath, &diags)
+	}
 
 	validateAttributesConflict(
 		cty.GetAttrPath("force_path_style"),

--- a/internal/backend/remote-state/s3/backend.go
+++ b/internal/backend/remote-state/s3/backend.go
@@ -28,6 +28,7 @@ import (
 	"github.com/hashicorp/terraform/version"
 	"github.com/zclconf/go-cty/cty"
 	"github.com/zclconf/go-cty/cty/gocty"
+	"golang.org/x/exp/maps"
 )
 
 func New() backend.Backend {
@@ -505,6 +506,27 @@ func (b *Backend) PrepareConfig(obj cty.Value) (cty.Value, tfdiags.Diagnostics) 
 		}
 	}
 
+	endpointValidators := validateString{
+		Validators: []stringValidator{
+			validateStringURL,
+		},
+	}
+	if val := obj.GetAttr("endpoints"); !val.IsNull() {
+		attrPath := cty.GetAttrPath("endpoints")
+		for _, k := range []string{"dynamodb", "iam", "s3", "sts"} {
+			if v := val.GetAttr(k); !v.IsNull() {
+				attrPath := attrPath.GetAttr(k)
+				endpointValidators.ValidateAttr(v, attrPath, &diags)
+			}
+		}
+	}
+	for _, k := range maps.Keys(endpointFields) {
+		if val := obj.GetAttr(k); !val.IsNull() {
+			attrPath := cty.GetAttrPath(k)
+			endpointValidators.ValidateAttr(val, attrPath, &diags)
+		}
+	}
+
 	validateAttributesConflict(
 		cty.GetAttrPath("force_path_style"),
 		cty.GetAttrPath("use_path_style"),
@@ -659,13 +681,14 @@ func (b *Backend) Configure(obj cty.Value) tfdiags.Diagnostics {
 		}
 	}
 
-	for envvar, replacement := range map[string]string{
+	endpointEnvvars := map[string]string{
 		"AWS_DYNAMODB_ENDPOINT": "AWS_ENDPOINT_URL_DYNAMODB",
 		"AWS_IAM_ENDPOINT":      "AWS_ENDPOINT_URL_IAM",
 		"AWS_S3_ENDPOINT":       "AWS_ENDPOINT_URL_S3",
 		"AWS_STS_ENDPOINT":      "AWS_ENDPOINT_URL_STS",
 		"AWS_METADATA_URL":      "AWS_EC2_METADATA_SERVICE_ENDPOINT",
-	} {
+	}
+	for envvar, replacement := range endpointEnvvars {
 		if val := os.Getenv(envvar); val != "" {
 			diags = diags.Append(deprecatedEnvVarDiag(envvar, replacement))
 		}

--- a/internal/backend/remote-state/s3/validate.go
+++ b/internal/backend/remote-state/s3/validate.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/url"
 	"regexp"
 	"strings"
 	"time"
@@ -253,6 +254,26 @@ The string content was valid JSON, your policy document may have been double-enc
 func validateStringKMSKey(val string, path cty.Path, diags *tfdiags.Diagnostics) {
 	ds := validateKMSKey(path, val)
 	*diags = diags.Append(ds)
+}
+
+func validateStringURL(val string, path cty.Path, diags *tfdiags.Diagnostics) {
+	u, err := url.Parse(val)
+	if err != nil {
+		*diags = diags.Append(attributeErrDiag(
+			"Invalid Value",
+			fmt.Sprintf("The value %q cannot be parsed as a URL: %s", val, err),
+			path,
+		))
+		return
+	}
+	if u.Scheme == "" || u.Host == "" {
+		*diags = diags.Append(attributeErrDiag(
+			"Invalid Value",
+			fmt.Sprintf("The value must be a valid URL containing at least a scheme and hostname. Had %q", val),
+			path,
+		))
+		return
+	}
 }
 
 // Using a val of `cty.ValueSet` would be better here, but we can't get an ElementIterator from a ValueSet

--- a/internal/backend/remote-state/s3/validate_test.go
+++ b/internal/backend/remote-state/s3/validate_test.go
@@ -657,3 +657,97 @@ func TestValidateDurationBetween(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateStringURL(t *testing.T) {
+	t.Parallel()
+
+	path := cty.GetAttrPath("field")
+
+	testcases := map[string]struct {
+		val      string
+		expected tfdiags.Diagnostics
+	}{
+		"no trailing slash": {
+			val: "https://domain.test",
+		},
+
+		"no path": {
+			val: "https://domain.test/",
+		},
+
+		"with path": {
+			val: "https://domain.test/path",
+		},
+
+		"with port no trailing slash": {
+			val: "https://domain.test:1234",
+		},
+
+		"with port no path": {
+			val: "https://domain.test:1234/",
+		},
+
+		"with port with path": {
+			val: "https://domain.test:1234/path",
+		},
+
+		"no scheme no trailing slash": {
+			val: "domain.test",
+			expected: tfdiags.Diagnostics{
+				attributeErrDiag(
+					"Invalid Value",
+					fmt.Sprintf("The value must be a valid URL containing at least a scheme and hostname. Had %q", "domain.test"),
+					path,
+				),
+			},
+		},
+
+		"no scheme no path": {
+			val: "domain.test/",
+			expected: tfdiags.Diagnostics{
+				attributeErrDiag(
+					"Invalid Value",
+					fmt.Sprintf("The value must be a valid URL containing at least a scheme and hostname. Had %q", "domain.test/"),
+					path,
+				),
+			},
+		},
+
+		"no scheme with path": {
+			val: "domain.test/path",
+			expected: tfdiags.Diagnostics{
+				attributeErrDiag(
+					"Invalid Value",
+					fmt.Sprintf("The value must be a valid URL containing at least a scheme and hostname. Had %q", "domain.test/path"),
+					path,
+				),
+			},
+		},
+
+		"no scheme with port": {
+			val: "domain.test:1234",
+			expected: tfdiags.Diagnostics{
+				attributeErrDiag(
+					"Invalid Value",
+					fmt.Sprintf("The value must be a valid URL containing at least a scheme and hostname. Had %q", "domain.test:1234"),
+					path,
+				),
+			},
+		},
+	}
+
+	for name, testcase := range testcases {
+		testcase := testcase
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			var diags tfdiags.Diagnostics
+			validateStringURL(testcase.val, path, &diags)
+
+			if diff := cmp.Diff(diags, testcase.expected, cmp.Comparer(diagnosticComparer)); diff != "" {
+				t.Errorf("unexpected diagnostics difference: %s", diff)
+			}
+		})
+	}
+
+}

--- a/website/docs/language/settings/backends/s3.mdx
+++ b/website/docs/language/settings/backends/s3.mdx
@@ -155,11 +155,14 @@ The following configuration is optional:
 * `access_key` - (Optional) AWS access key. If configured, must also configure `secret_key`. This can also be sourced from the `AWS_ACCESS_KEY_ID` environment variable, AWS shared credentials file (e.g. `~/.aws/credentials`), or AWS shared configuration file (e.g. `~/.aws/config`).
 * `allowed_account_ids` - (Optional) List of allowed AWS account IDs to prevent potential destruction of a live environment. Conflicts with `forbidden_account_ids`.
 * `custom_ca_bundle` - (Optional) File containing custom root and intermediate certificates. Can also be set using the `AWS_CA_BUNDLE` environment variable. Setting ca_bundle in the shared config file is not supported.
-* `ec2_metadata_service_endpoint` - (Optional) Address of the EC2 metadata service (IMDS) endpoint to use. Can also be set with the `AWS_EC2_METADATA_SERVICE_ENDPOINT` environment variable.
-* `ec2_metadata_service_endpoint_mode` - (Optional) Mode to use in communicating with the metadata service. Valid values are `IPv4` and `IPv6`. Can also be set with the `AWS_EC2_METADATA_SERVICE_ENDPOINT_MODE` environment variable.
+* `ec2_metadata_service_endpoint` - (Optional) Custom endpoint URL for the EC2 Instance Metadata Service (IMDS) API.
+  Can also be set with the `AWS_EC2_METADATA_SERVICE_ENDPOINT` environment variable.
+* `ec2_metadata_service_endpoint_mode` - (Optional) Mode to use in communicating with the metadata service.
+  Valid values are `IPv4` and `IPv6`.
+  Can also be set with the `AWS_EC2_METADATA_SERVICE_ENDPOINT_MODE` environment variable.
 * `forbidden_account_ids` - (Optional) List of forbidden AWS account IDs to prevent potential destruction of a live environment. Conflicts with `allowed_account_ids`.
 * `http_proxy` - (Optional) Address of an HTTP proxy to use when accessing the AWS API. Can also be set using the `HTTP_PROXY` or `HTTPS_PROXY` environment variables.
-* `iam_endpoint` - (Optional, **Deprecated**) Custom endpoint for the AWS Identity and Access Management (IAM) API.
+* `iam_endpoint` - (Optional, **Deprecated**) Custom endpoint URL for the AWS Identity and Access Management (IAM) API.
   Use `endpoints.iam` instead.
 * `insecure` - (Optional) Whether to explicitly allow the backend to perform "insecure" SSL requests. If omitted, the default value is `false`.
 * `max_retries` - (Optional) The maximum number of times an AWS API request is retried on retryable failure. Defaults to 5.
@@ -172,7 +175,7 @@ The following configuration is optional:
 * `skip_credentials_validation` - (Optional) Skip credentials validation via the STS API.
 * `skip_region_validation` - (Optional) Skip validation of provided region name.
 * `skip_metadata_api_check` - (Optional) Skip usage of EC2 Metadata API.
-* `sts_endpoint` - (Optional, **Deprecated**) Custom endpoint for the AWS Security Token Service (STS) API.
+* `sts_endpoint` - (Optional, **Deprecated**) Custom endpoint URL for the AWS Security Token Service (STS) API.
   Use `endpoints.sts` instead.
 * `sts_region` - (Optional) AWS region for STS. If unset, AWS will use the same region for STS as other non-STS operations.
 * `token` - (Optional) Multi-Factor Authentication (MFA) token. This can also be sourced from the `AWS_SESSION_TOKEN` environment variable.
@@ -184,13 +187,13 @@ The following configuration is optional:
 
 The optional argument `endpoints` contains the following arguments:
 
-* `dynamodb` - (Optional) Custom endpoint for the AWS DynamoDB API.
+* `dynamodb` - (Optional) Custom endpoint URL for the AWS DynamoDB API.
   This can also be sourced from the environment variable `AWS_ENDPOINT_URL_DYNAMODB` or the deprecated environment variable `AWS_DYNAMODB_ENDPOINT`.
-* `iam` - (Optional) Custom endpoint for the AWS IAM API.
+* `iam` - (Optional) Custom endpoint URL for the AWS IAM API.
   This can also be sourced from the environment variable `AWS_ENDPOINT_URL_IAM` or the deprecated environment variable `AWS_IAM_ENDPOINT`.
-* `s3` - (Optional) Custom endpoint for the AWS S3 API.
+* `s3` - (Optional) Custom endpoint URL for the AWS S3 API.
   This can also be sourced from the environment variable `AWS_ENDPOINT_URL_S3` or the deprecated environment variable `AWS_S3_ENDPOINT`.
-* `sts` - (Optional) Custom endpoint for the AWS STS API.
+* `sts` - (Optional) Custom endpoint URL for the AWS STS API.
   This can also be sourced from the environment variable `AWS_ENDPOINT_URL_STS` or the deprecated environment variable `AWS_STS_ENDPOINT`.
 
 #### Assume Role Configuration
@@ -291,7 +294,7 @@ The following configuration is optional:
 
 * `acl` - (Optional) [Canned ACL](https://docs.aws.amazon.com/AmazonS3/latest/userguide/acl-overview.html#canned-acl) to be applied to the state file.
 * `encrypt` - (Optional) Enable [server side encryption](https://docs.aws.amazon.com/AmazonS3/latest/userguide/UsingServerSideEncryption.html) of the state file.
-* `endpoint` - (Optional, **Deprecated**) Custom endpoint for the AWS S3 API.
+* `endpoint` - (Optional, **Deprecated**) Custom endpoint URL for the AWS S3 API.
   Use `endpoints.s3` instead.
 * `force_path_style` - (Optional, **Deprecated**) Enable path-style S3 URLs (`https://<HOST>/<BUCKET>` instead of `https://<BUCKET>.<HOST>`).
 * `kms_key_id` - (Optional) Amazon Resource Name (ARN) of a Key Management Service (KMS) Key to use for encrypting the state. Note that if this value is specified, Terraform will need `kms:Encrypt`, `kms:Decrypt` and `kms:GenerateDataKey` permissions on this KMS key.
@@ -303,7 +306,7 @@ The following configuration is optional:
 
 The following configuration is optional:
 
-* `dynamodb_endpoint` - (Optional, **Deprecated**) Custom endpoint for the AWS DynamoDB API.
+* `dynamodb_endpoint` - (Optional, **Deprecated**) Custom endpoint URL for the AWS DynamoDB API.
   Use `endpoints.dynamodb` instead.
 * `dynamodb_table` - (Optional) Name of DynamoDB Table to use for state locking and consistency. The table must have a partition key named `LockID` with type of `String`. If not configured, state locking will be disabled.
 


### PR DESCRIPTION
Adds acceptance tests for API endpoint overrides. Adds validation to endpoint parameters, since the endpoints must be specified as URLs.

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.6.0
