### PR TITLE
cloud: don't update snapshot interval unless response is from tfe.v2

### DIFF
--- a/internal/cloud/state.go
+++ b/internal/cloud/state.go
@@ -584,6 +584,13 @@ func clamp(val, min, max int64) int64 {
 }
 
 func (s *State) readSnapshotIntervalHeader(status int, header http.Header) {
+	// Only proceed if this came from tfe.v2 API
+	contentType := header.Get("Content-Type")
+	if !strings.Contains(contentType, tfe.ContentTypeJSONAPI) {
+		log.Printf("[TRACE] Skipping intermediate state interval because Content-Type was %q", contentType)
+		return
+	}
+
 	intervalStr := header.Get(HeaderSnapshotInterval)
 
 	if intervalSecs, err := strconv.ParseInt(intervalStr, 10, 64); err == nil {
@@ -600,6 +607,7 @@ func (s *State) readSnapshotIntervalHeader(status int, header http.Header) {
 	}
 
 	// We will only enable snapshots for intervals greater than zero
+	log.Printf("[TRACE] Intermediate state interval is set by header to %v", s.stateSnapshotInterval)
 	s.enableIntermediateSnapshots = s.stateSnapshotInterval > 0
 }
 

--- a/internal/cloud/testing.go
+++ b/internal/cloud/testing.go
@@ -437,7 +437,7 @@ func testServerWithSnapshotsEnabled(t *testing.T, enabled bool) *httptest.Server
 			t.Fatal(err)
 		}
 
-		w.Header().Set("content-type", "application/json")
+		w.Header().Set("content-type", tfe.ContentTypeJSONAPI)
 		w.Header().Set("content-length", strconv.FormatInt(int64(len(fakeBodyRaw)), 10))
 
 		switch r.Method {


### PR DESCRIPTION
Some go-tfe methods perform multiple requests, some of which are not expected to contain a `x-terraform-snapshot-interval` header. This leads to the interval becoming unset after it is set. I decided to use the response content-type header to signal that the absence of the header is intended to unset the interval.

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.5.x, 1.6.0, 1.70

I will manually backport this as I already have two relevant backport PRs: #33835 #33834

### Trace Log

```
2023-09-07T20:29:19.316Z [TRACE]  Intermediate state interval is set by header to 20s
2023-09-07T20:29:19.461Z [TRACE]  Skipping intermediate state interval because Content-Type was ""
2023-09-07T20:29:19.462Z [TRACE]  Skipping intermediate state interval because Content-Type was ""
2023-09-07T20:29:20.452Z [TRACE]  Intermediate state interval is set by header to 20s
```