### PR TITLE
backend/s3: Restore HTTP request/response logging

### DIFF
--- a/internal/backend/remote-state/s3/backend.go
+++ b/internal/backend/remote-state/s3/backend.go
@@ -11,7 +11,6 @@ import (
 	"regexp"
 	"sort"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -20,10 +19,8 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	awsbase "github.com/hashicorp/aws-sdk-go-base/v2"
 	baselogging "github.com/hashicorp/aws-sdk-go-base/v2/logging"
-	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/terraform/internal/backend"
 	"github.com/hashicorp/terraform/internal/configs/configschema"
-	"github.com/hashicorp/terraform/internal/logging"
 	"github.com/hashicorp/terraform/internal/tfdiags"
 	"github.com/hashicorp/terraform/version"
 	"github.com/zclconf/go-cty/cty"
@@ -608,6 +605,7 @@ func formatDeprecations(attrs map[string]string) string {
 func (b *Backend) Configure(obj cty.Value) tfdiags.Diagnostics {
 	ctx := context.TODO()
 	log := logger()
+	log = logWithOperation(log, operationBackendConfigure)
 
 	var diags tfdiags.Diagnostics
 	if obj.IsNull() {
@@ -1648,8 +1646,3 @@ func deprecatedEnvVarDiag(envvar, replacement string) tfdiags.Diagnostic {
 		fmt.Sprintf(`The environment variable "%s" is deprecated. Use environment variable "%s" instead.`, envvar, replacement),
 	)
 }
-
-var logger = sync.OnceValue(func() hclog.Logger {
-	l := logging.HCLogger()
-	return l.Named("backend-s3")
-})

--- a/internal/backend/remote-state/s3/backend.go
+++ b/internal/backend/remote-state/s3/backend.go
@@ -607,6 +607,7 @@ func formatDeprecations(attrs map[string]string) string {
 // via PrepareConfig.
 func (b *Backend) Configure(obj cty.Value) tfdiags.Diagnostics {
 	ctx := context.TODO()
+	log := logger()
 
 	var diags tfdiags.Diagnostics
 	if obj.IsNull() {
@@ -632,6 +633,12 @@ func (b *Backend) Configure(obj cty.Value) tfdiags.Diagnostics {
 
 	b.bucketName = stringAttr(obj, "bucket")
 	b.keyName = stringAttr(obj, "key")
+
+	log = log.With(
+		"tf_backend_s3.bucket", b.bucketName,
+		"tf_backend_s3.path", b.path,
+	)
+
 	b.acl = stringAttr(obj, "acl")
 	b.workspaceKeyPrefix = stringAttrDefault(obj, "workspace_key_prefix", "env:")
 	b.serverSideEncryption = boolAttr(obj, "encrypt")
@@ -697,8 +704,6 @@ func (b *Backend) Configure(obj cty.Value) tfdiags.Diagnostics {
 			diags = diags.Append(deprecatedEnvVarDiag(envvar, replacement))
 		}
 	}
-
-	log := logger()
 
 	ctx, baselog := baselogging.NewHcLogger(ctx, log)
 

--- a/internal/backend/remote-state/s3/backend.go
+++ b/internal/backend/remote-state/s3/backend.go
@@ -635,8 +635,8 @@ func (b *Backend) Configure(obj cty.Value) tfdiags.Diagnostics {
 	b.keyName = stringAttr(obj, "key")
 
 	log = log.With(
-		"tf_backend_s3.bucket", b.bucketName,
-		"tf_backend_s3.path", b.path,
+		logKeyBucket, b.bucketName,
+		logKeyPath, b.keyName,
 	)
 
 	b.acl = stringAttr(obj, "acl")

--- a/internal/backend/remote-state/s3/backend_state.go
+++ b/internal/backend/remote-state/s3/backend_state.go
@@ -15,6 +15,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
 
+	baselogging "github.com/hashicorp/aws-sdk-go-base/v2/logging"
 	"github.com/hashicorp/terraform/internal/backend"
 	"github.com/hashicorp/terraform/internal/states"
 	"github.com/hashicorp/terraform/internal/states/remote"
@@ -25,12 +26,21 @@ func (b *Backend) Workspaces() ([]string, error) {
 	const maxKeys = 1000
 
 	ctx := context.TODO()
+	log := logger()
+	log = logWithOperation(log, operationBackendWorkspaces)
+	log = log.With(
+		logKeyBucket, b.bucketName,
+	)
 
 	prefix := ""
 
 	if b.workspaceKeyPrefix != "" {
 		prefix = b.workspaceKeyPrefix + "/"
 	}
+
+	log = log.With(
+		logKeyBackendWorkspacePrefix, prefix,
+	)
 
 	params := &s3.ListObjectsV2Input{
 		Bucket:  aws.String(b.bucketName),
@@ -39,6 +49,9 @@ func (b *Backend) Workspaces() ([]string, error) {
 	}
 
 	wss := []string{backend.DefaultStateName}
+
+	ctx, baselog := baselogging.NewHcLogger(ctx, log)
+	ctx = baselogging.RegisterLogger(ctx, baselog)
 
 	pages := s3.NewListObjectsV2Paginator(b.s3Client, params)
 	for pages.HasMorePages() {
@@ -102,9 +115,17 @@ func (b *Backend) keyEnv(key string) string {
 }
 
 func (b *Backend) DeleteWorkspace(name string, _ bool) error {
+	log := logger()
+	log = logWithOperation(log, operationBackendDeleteWorkspace)
+	log = log.With(
+		logKeyBackendWorkspace, name,
+	)
+
 	if name == backend.DefaultStateName || name == "" {
 		return fmt.Errorf("can't delete default state")
 	}
+
+	log.Info("Deleting workspace")
 
 	client, err := b.remoteClient(name)
 	if err != nil {

--- a/internal/backend/remote-state/s3/backend_test.go
+++ b/internal/backend/remote-state/s3/backend_test.go
@@ -1328,7 +1328,7 @@ func TestBackendConfig_PrepareConfigWithEnvVars(t *testing.T) {
 	}
 }
 
-func TestBackend(t *testing.T) {
+func TestBackendBasic(t *testing.T) {
 	testACC(t)
 
 	ctx := context.TODO()

--- a/internal/backend/remote-state/s3/client.go
+++ b/internal/backend/remote-state/s3/client.go
@@ -63,7 +63,8 @@ var testChecksumHook func()
 
 func (c *RemoteClient) Get() (payload *remote.Payload, err error) {
 	ctx := context.TODO()
-	log := c.logger()
+	log := c.logger(operationClientGet)
+
 	ctx, baselog := baselogging.NewHcLogger(ctx, log)
 	ctx = baselogging.RegisterLogger(ctx, baselog)
 
@@ -182,7 +183,7 @@ func (c *RemoteClient) get(ctx context.Context) (*remote.Payload, error) {
 
 func (c *RemoteClient) Put(data []byte) error {
 	ctx := context.TODO()
-	log := c.logger()
+	log := c.logger(operationClientPut)
 
 	ctx, baselog := baselogging.NewHcLogger(ctx, log)
 	ctx = baselogging.RegisterLogger(ctx, baselog)
@@ -233,7 +234,7 @@ func (c *RemoteClient) Put(data []byte) error {
 
 func (c *RemoteClient) Delete() error {
 	ctx := context.TODO()
-	log := c.logger()
+	log := c.logger(operationClientDelete)
 
 	ctx, baselog := baselogging.NewHcLogger(ctx, log)
 	ctx = baselogging.RegisterLogger(ctx, baselog)
@@ -260,7 +261,7 @@ func (c *RemoteClient) Delete() error {
 
 func (c *RemoteClient) Lock(info *statemgr.LockInfo) (string, error) {
 	ctx := context.TODO()
-	log := c.logger()
+	log := c.logger(operationLockerLock)
 
 	if c.ddbTable == "" {
 		return "", nil
@@ -315,7 +316,7 @@ func (c *RemoteClient) Lock(info *statemgr.LockInfo) (string, error) {
 
 func (c *RemoteClient) Unlock(id string) error {
 	ctx := context.TODO()
-	log := c.logger()
+	log := c.logger(operationLockerUnlock)
 
 	log = logWithLockID(log, id)
 
@@ -489,12 +490,13 @@ func (c *RemoteClient) getSSECustomerKeyMD5() string {
 	return base64.StdEncoding.EncodeToString(b[:])
 }
 
-// logger returns the S3 backend logger configured with the client's bucket and path
-func (c *RemoteClient) logger() hclog.Logger {
-	return logger().With(
+// logger returns the S3 backend logger configured with the client's bucket and path and the operation
+func (c *RemoteClient) logger(operation string) hclog.Logger {
+	log := logger().With(
 		logKeyBucket, c.bucketName,
 		logKeyPath, c.path,
 	)
+	return logWithOperation(log, operation)
 }
 
 const errBadChecksumFmt = `state data in S3 does not have the expected content.

--- a/internal/backend/remote-state/s3/client.go
+++ b/internal/backend/remote-state/s3/client.go
@@ -22,6 +22,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
 	baselogging "github.com/hashicorp/aws-sdk-go-base/v2/logging"
+	"github.com/hashicorp/go-hclog"
 	multierror "github.com/hashicorp/go-multierror"
 	uuid "github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/terraform/internal/states/remote"
@@ -62,11 +63,7 @@ var testChecksumHook func()
 
 func (c *RemoteClient) Get() (payload *remote.Payload, err error) {
 	ctx := context.TODO()
-	log := logger()
-	log = log.With(
-		"tf_backend_s3.bucket", c.bucketName,
-		"tf_backend_s3.path", c.path,
-	)
+	log := c.logger()
 	ctx, baselog := baselogging.NewHcLogger(ctx, log)
 	ctx = baselogging.RegisterLogger(ctx, baselog)
 
@@ -185,11 +182,7 @@ func (c *RemoteClient) get(ctx context.Context) (*remote.Payload, error) {
 
 func (c *RemoteClient) Put(data []byte) error {
 	ctx := context.TODO()
-	log := logger()
-	log = log.With(
-		"tf_backend_s3.bucket", c.bucketName,
-		"tf_backend_s3.path", c.path,
-	)
+	log := c.logger()
 	ctx, baselog := baselogging.NewHcLogger(ctx, log)
 	ctx = baselogging.RegisterLogger(ctx, baselog)
 
@@ -239,11 +232,7 @@ func (c *RemoteClient) Put(data []byte) error {
 
 func (c *RemoteClient) Delete() error {
 	ctx := context.TODO()
-	log := logger()
-	log = log.With(
-		"tf_backend_s3.bucket", c.bucketName,
-		"tf_backend_s3.path", c.path,
-	)
+	log := c.logger()
 	ctx, baselog := baselogging.NewHcLogger(ctx, log)
 	ctx = baselogging.RegisterLogger(ctx, baselog)
 
@@ -479,6 +468,14 @@ func (c *RemoteClient) lockPath() string {
 func (c *RemoteClient) getSSECustomerKeyMD5() string {
 	b := md5.Sum(c.customerEncryptionKey)
 	return base64.StdEncoding.EncodeToString(b[:])
+}
+
+// logger returns the S3 backend logger configured with the client's bucket and path
+func (c *RemoteClient) logger() hclog.Logger {
+	return logger().With(
+		"tf_backend_s3.bucket", c.bucketName,
+		"tf_backend_s3.path", c.path,
+	)
 }
 
 const errBadChecksumFmt = `state data in S3 does not have the expected content.

--- a/internal/backend/remote-state/s3/client.go
+++ b/internal/backend/remote-state/s3/client.go
@@ -21,6 +21,7 @@ import (
 	dynamodbtypes "github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
+	baselogging "github.com/hashicorp/aws-sdk-go-base/v2/logging"
 	multierror "github.com/hashicorp/go-multierror"
 	uuid "github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/terraform/internal/states/remote"
@@ -61,6 +62,15 @@ var testChecksumHook func()
 
 func (c *RemoteClient) Get() (payload *remote.Payload, err error) {
 	ctx := context.TODO()
+	log := logger()
+	log = log.With(
+		"tf_backend_s3.bucket", c.bucketName,
+		"tf_backend_s3.path", c.path,
+	)
+	ctx, baselog := baselogging.NewHcLogger(ctx, log)
+	ctx = baselogging.RegisterLogger(ctx, baselog)
+
+	log.Info("Downloading remote state")
 
 	deadline := time.Now().Add(consistencyRetryTimeout)
 
@@ -82,9 +92,14 @@ func (c *RemoteClient) Get() (payload *remote.Payload, err error) {
 
 		// verify that this state is what we expect
 		if expected, err := c.getMD5(ctx); err != nil {
-			log.Printf("[WARN] failed to fetch state md5: %s", err)
+			log.Warn("failed to fetch state MD5",
+				"error", err,
+			)
 		} else if len(expected) > 0 && !bytes.Equal(expected, digest) {
-			log.Printf("[WARN] state md5 mismatch: expected '%x', got '%x'", expected, digest)
+			log.Warn("state MD5 mismatch",
+				"expected", expected,
+				"actual", digest,
+			)
 
 			if testChecksumHook != nil {
 				testChecksumHook()
@@ -92,7 +107,7 @@ func (c *RemoteClient) Get() (payload *remote.Payload, err error) {
 
 			if time.Now().Before(deadline) {
 				time.Sleep(consistencyRetryPollInterval)
-				log.Println("[INFO] retrying S3 RemoteClient.Get...")
+				log.Info("retrying S3 RemoteClient.Get")
 				continue
 			}
 
@@ -170,6 +185,13 @@ func (c *RemoteClient) get(ctx context.Context) (*remote.Payload, error) {
 
 func (c *RemoteClient) Put(data []byte) error {
 	ctx := context.TODO()
+	log := logger()
+	log = log.With(
+		"tf_backend_s3.bucket", c.bucketName,
+		"tf_backend_s3.path", c.path,
+	)
+	ctx, baselog := baselogging.NewHcLogger(ctx, log)
+	ctx = baselogging.RegisterLogger(ctx, baselog)
 
 	contentType := "application/json"
 
@@ -197,7 +219,7 @@ func (c *RemoteClient) Put(data []byte) error {
 		input.ACL = s3types.ObjectCannedACL(c.acl)
 	}
 
-	log.Printf("[DEBUG] Uploading remote state to S3: %#v", input)
+	log.Info("Uploading remote state")
 
 	uploader := manager.NewUploader(c.s3Client)
 	_, err := uploader.Upload(ctx, input)
@@ -217,6 +239,13 @@ func (c *RemoteClient) Put(data []byte) error {
 
 func (c *RemoteClient) Delete() error {
 	ctx := context.TODO()
+	log := logger()
+	log = log.With(
+		"tf_backend_s3.bucket", c.bucketName,
+		"tf_backend_s3.path", c.path,
+	)
+	ctx, baselog := baselogging.NewHcLogger(ctx, log)
+	ctx = baselogging.RegisterLogger(ctx, baselog)
 
 	_, err := c.s3Client.DeleteObject(ctx, &s3.DeleteObjectInput{
 		Bucket: aws.String(c.bucketName),
@@ -228,7 +257,9 @@ func (c *RemoteClient) Delete() error {
 	}
 
 	if err := c.deleteMD5(ctx); err != nil {
-		log.Printf("error deleting state md5: %s", err)
+		log.Error("deleting state MD5",
+			"error", err,
+		)
 	}
 
 	return nil

--- a/internal/backend/remote-state/s3/logging.go
+++ b/internal/backend/remote-state/s3/logging.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
 package s3
 
 import (

--- a/internal/backend/remote-state/s3/logging.go
+++ b/internal/backend/remote-state/s3/logging.go
@@ -1,0 +1,37 @@
+package s3
+
+import (
+	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/terraform/internal/states/statemgr"
+)
+
+const (
+	logKeyBucket = "tf_backend.s3.bucket"
+	logKeyPath   = "tf_backend.s3.path"
+)
+
+const (
+	logKeyBackendLockId        = "tf_backend.lock.id"
+	logKeyBackendLockOperation = "tf_backend.lock.operation"
+	logKeyBackendLockInfo      = "tf_backend.lock.info"
+	logKeyBackendLockWho       = "tf_backend.lock.who"
+	logKeyBackendLockVersion   = "tf_backend.lock.version"
+	logKeyBackendLockPath      = "tf_backend.lock.path"
+)
+
+func logWithLockInfo(in hclog.Logger, info *statemgr.LockInfo) hclog.Logger {
+	return in.With(
+		logKeyBackendLockId, info.ID,
+		logKeyBackendLockOperation, info.Operation,
+		logKeyBackendLockInfo, info.Info,
+		logKeyBackendLockWho, info.Who,
+		logKeyBackendLockVersion, info.Version,
+		logKeyBackendLockPath, info.Path,
+	)
+}
+
+func logWithLockID(in hclog.Logger, id string) hclog.Logger {
+	return in.With(
+		logKeyBackendLockId, id,
+	)
+}

--- a/internal/backend/remote-state/s3/logging.go
+++ b/internal/backend/remote-state/s3/logging.go
@@ -4,6 +4,7 @@ import (
 	"sync"
 
 	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/terraform/internal/logging"
 	"github.com/hashicorp/terraform/internal/states/statemgr"
 )
@@ -23,14 +24,17 @@ const (
 )
 
 const (
-	logKeyBackendOperation = "tf_backend.operation"
+	logKeyBackendOperation       = "tf_backend.operation"
+	logKeyBackendRequestId       = "tf_backend.req_id" // Using "req_id" to match pattern for provider logging
+	logKeyBackendWorkspace       = "tf_backend.workspace"
+	logKeyBackendWorkspacePrefix = "tf_backend.workspace-prefix"
 )
 
 const (
-	operationBackendConfigSchema    = "ConfigSchema"
-	operationBackendPrepareConfig   = "PrepareConfig"
-	operationBackendConfigure       = "Configure"
-	operationBackendStateMgr        = "StateMgr"
+	// operationBackendConfigSchema    = "ConfigSchema"
+	// operationBackendPrepareConfig   = "PrepareConfig"
+	operationBackendConfigure = "Configure"
+	// operationBackendStateMgr        = "StateMgr"
 	operationBackendDeleteWorkspace = "DeleteWorkspace"
 	operationBackendWorkspaces      = "Workspaces"
 )

--- a/internal/backend/remote-state/s3/logging.go
+++ b/internal/backend/remote-state/s3/logging.go
@@ -1,7 +1,10 @@
 package s3
 
 import (
+	"sync"
+
 	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/terraform/internal/logging"
 	"github.com/hashicorp/terraform/internal/states/statemgr"
 )
 
@@ -18,6 +21,41 @@ const (
 	logKeyBackendLockVersion   = "tf_backend.lock.version"
 	logKeyBackendLockPath      = "tf_backend.lock.path"
 )
+
+const (
+	logKeyBackendOperation = "tf_backend.operation"
+)
+
+const (
+	operationBackendConfigSchema    = "ConfigSchema"
+	operationBackendPrepareConfig   = "PrepareConfig"
+	operationBackendConfigure       = "Configure"
+	operationBackendStateMgr        = "StateMgr"
+	operationBackendDeleteWorkspace = "DeleteWorkspace"
+	operationBackendWorkspaces      = "Workspaces"
+)
+
+const (
+	operationClientGet    = "Get"
+	operationClientPut    = "Put"
+	operationClientDelete = "Delete"
+)
+
+const (
+	operationLockerLock   = "Lock"
+	operationLockerUnlock = "Unlock"
+)
+
+var logger = sync.OnceValue(func() hclog.Logger {
+	l := logging.HCLogger()
+	return l.Named("backend-s3")
+})
+
+func logWithOperation(in hclog.Logger, operation string) hclog.Logger {
+	return in.With(
+		logKeyBackendOperation, operation,
+	)
+}
 
 func logWithLockInfo(in hclog.Logger, info *statemgr.LockInfo) hclog.Logger {
 	return in.With(

--- a/internal/backend/remote-state/s3/logging.go
+++ b/internal/backend/remote-state/s3/logging.go
@@ -56,9 +56,16 @@ var logger = sync.OnceValue(func() hclog.Logger {
 })
 
 func logWithOperation(in hclog.Logger, operation string) hclog.Logger {
-	return in.With(
+	log := in.With(
 		logKeyBackendOperation, operation,
 	)
+	if id, err := uuid.GenerateUUID(); err == nil {
+		log = log.With(
+			logKeyBackendRequestId, id,
+		)
+
+	}
+	return log
 }
 
 func logWithLockInfo(in hclog.Logger, info *statemgr.LockInfo) hclog.Logger {


### PR DESCRIPTION
Restores HTTP request/response logging for the S3 backend.

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.6.0
