### PR TITLE
Gunzipbase64

### DIFF
--- a/internal/lang/funcs/descriptions.go
+++ b/internal/lang/funcs/descriptions.go
@@ -53,6 +53,10 @@ var DescriptionList = map[string]descriptionEntry{
 		Description:      "`base64gzip` compresses a string with gzip and then encodes the result in Base64 encoding.",
 		ParamDescription: []string{""},
 	},
+	"gunzipbase64": {
+		Description:      "`gunzipbase64` decodes a Base64 encoded string and uncompresses the result with gzip.",
+		ParamDescription: []string{""},
+	},
 	"base64sha256": {
 		Description:      "`base64sha256` computes the SHA256 hash of a given string and encodes it with Base64. This is not equivalent to `base64encode(sha256(\"test\"))` since `sha256()` returns hexadecimal representation.",
 		ParamDescription: []string{""},

--- a/internal/lang/funcs/encoding.go
+++ b/internal/lang/funcs/encoding.go
@@ -8,6 +8,7 @@ import (
 	"compress/gzip"
 	"encoding/base64"
 	"fmt"
+	"io"
 	"log"
 	"net/url"
 	"unicode/utf8"
@@ -178,6 +179,37 @@ var Base64GzipFunc = function.New(&function.Spec{
 	},
 })
 
+// GunzipBase64Func constructs a function that Bae64 decodes a string and decompresses the result with gunzip.
+var GunzipBase64Func = function.New(&function.Spec{
+	Params: []function.Parameter{
+		{
+			Name: "str",
+			Type: cty.String,
+		},
+	},
+	Type:         function.StaticReturnType(cty.String),
+	RefineResult: refineNotNull,
+	Impl: func(args []cty.Value, retType cty.Type) (cty.Value, error) {
+		str, strMarks := args[0].Unmark()
+		s := str.AsString()
+		sDec, err := base64.StdEncoding.DecodeString(s)
+		if err != nil {
+			return cty.UnknownVal(cty.String), fmt.Errorf("failed to decode base64 data %s", redactIfSensitive(s, strMarks))
+		}
+		sDecBuffer := bytes.NewReader(sDec)
+		gzipReader, err := gzip.NewReader(sDecBuffer)
+		if err != nil {
+			return cty.UnknownVal(cty.String), fmt.Errorf("failed to gunzip base64 decoded data: %w", err)
+		}
+		gunzip, err := io.ReadAll(gzipReader)
+		if err != nil {
+			return cty.UnknownVal(cty.String), fmt.Errorf("failed to read gunzip raw data: %w", err)
+		}
+
+		return cty.StringVal(string(gunzip)), nil
+	},
+})
+
 // URLEncodeFunc constructs a function that applies URL encoding to a given string.
 var URLEncodeFunc = function.New(&function.Spec{
 	Params: []function.Parameter{
@@ -226,6 +258,13 @@ func Base64Encode(str cty.Value) (cty.Value, error) {
 // as UTF-8, then apply gzip compression, and then finally apply Base64 encoding.
 func Base64Gzip(str cty.Value) (cty.Value, error) {
 	return Base64GzipFunc.Call([]cty.Value{str})
+}
+
+// GunzipBase64 decodes a Base64 encoded string and uncompresses the result with gzip.
+//
+// Terraform uses the "standard" Base64 alphabet as defined in RFC 4648 section 4.
+func GunzipBase64(str cty.Value) (cty.Value, error) {
+	return GunzipBase64Func.Call([]cty.Value{str})
 }
 
 // URLEncode applies URL encoding to a given string.

--- a/internal/lang/funcs/encoding_test.go
+++ b/internal/lang/funcs/encoding_test.go
@@ -159,6 +159,39 @@ func TestBase64Gzip(t *testing.T) {
 	}
 }
 
+func TestGunzipBase64(t *testing.T) {
+	tests := []struct {
+		String cty.Value
+		Want   cty.Value
+		Err    bool
+	}{
+		{
+			cty.StringVal("H4sIAAAAAAAA/ypJLS4BAAAA//8BAAD//wx+f9gEAAAA"),
+			cty.StringVal("test"),
+			false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("gunzipbase64(%#v)", test.String), func(t *testing.T) {
+			got, err := GunzipBase64(test.String)
+
+			if test.Err {
+				if err == nil {
+					t.Fatal("succeeded; want error")
+				}
+				return
+			} else if err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+
+			if !got.RawEquals(test.Want) {
+				t.Errorf("wrong result\ngot:  %#v\nwant: %#v", got, test.Want)
+			}
+		})
+	}
+}
+
 func TestURLEncode(t *testing.T) {
 	tests := []struct {
 		String cty.Value

--- a/internal/lang/functions.go
+++ b/internal/lang/functions.go
@@ -43,6 +43,7 @@ func (s *Scope) Functions() map[string]function.Function {
 			"base64decode":     funcs.Base64DecodeFunc,
 			"base64encode":     funcs.Base64EncodeFunc,
 			"base64gzip":       funcs.Base64GzipFunc,
+			"gunzipbase64":     funcs.GunzipBase64Func,
 			"base64sha256":     funcs.Base64Sha256Func,
 			"base64sha512":     funcs.Base64Sha512Func,
 			"bcrypt":           funcs.BcryptFunc,

--- a/internal/lang/functions_test.go
+++ b/internal/lang/functions_test.go
@@ -108,6 +108,13 @@ func TestFunctions(t *testing.T) {
 			},
 		},
 
+		"gunzipbase64": {
+			{
+				`gunzipbase64("H4sIAAAAAAAA/ypJLS4BAAAA//8BAAD//wx+f9gEAAAA")`,
+				cty.StringVal("test"),
+			},
+		},
+
 		"base64sha256": {
 			{
 				`base64sha256("test")`,


### PR DESCRIPTION
add terraform function gunzipbase64 as opposite of base64gzip similar to

- base64decode opposite of base64encode
- textdecodebase64 opposite of textencodebase64
- jsondecode opposite of jsonencode
- yamldecode opposite of yamlencode

<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Fixes #22568 

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.5.x

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

### NEW FEATURES

<!--

Write a short description of the user-facing change. Examples:

- `terraform show -json`: Fixed crash with sensitive set values.
- When rendering a diff, Terraform now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 

terraform function gunzipbase64 can be used as opposite of base64gzip, e.g.

- write base64gzip content to any storage, read it and decode it with gunzipbase64
