### PR TITLE
Apply defaults when processing variables for assertions

### DIFF
--- a/internal/backend/local/test.go
+++ b/internal/backend/local/test.go
@@ -1076,12 +1076,18 @@ func (runner *TestFileRunner) prepareInputVariablesForAssertions(config *configs
 				return variable, diags
 			}
 
+			given := variable.Value
+
 			// Normally, variable values would be converted during the Terraform
 			// graph processing. But, `terraform test` assertions are not
 			// executed during the graph but after. This means the variables we
 			// create for use in the assertions must be converted here.
 
-			converted, err := convert.Convert(variable.Value, config.Type)
+			if config.TypeDefaults != nil && !given.IsNull() {
+				given = config.TypeDefaults.Apply(given)
+			}
+
+			converted, err := convert.Convert(given, config.ConstraintType)
 			if err != nil {
 				var subject *hcl.Range
 				if reference != nil {

--- a/internal/command/test_test.go
+++ b/internal/command/test_test.go
@@ -175,6 +175,10 @@ func TestTest(t *testing.T) {
 			code:                  1,
 			expectedResourceCount: 1,
 		},
+		"default_optional_values": {
+			expected: "4 passed, 0 failed.",
+			code:     0,
+		},
 	}
 	for name, tc := range tcs {
 		t.Run(name, func(t *testing.T) {

--- a/internal/command/testdata/test/default_optional_values/main.tf
+++ b/internal/command/testdata/test/default_optional_values/main.tf
@@ -1,0 +1,26 @@
+
+variable "input" {
+
+  type = object({
+    required = string
+    optional = optional(string)
+    default = optional(string, "default")
+  })
+
+  default = {
+    required = "required"
+  }
+
+}
+
+resource "test_resource" "resource" {
+  value = var.input.default
+}
+
+output "computed" {
+  value = test_resource.resource.value
+}
+
+output "input" {
+  value = var.input
+}

--- a/internal/command/testdata/test/default_optional_values/main.tftest.hcl
+++ b/internal/command/testdata/test/default_optional_values/main.tftest.hcl
@@ -1,0 +1,47 @@
+
+run "stacked" {
+  variables {
+    input = {
+      required = "required"
+      optional = "optional"
+      default = "overridden"
+    }
+  }
+
+  assert {
+    condition = output.computed == "overridden"
+    error_message = "did not override default value"
+  }
+}
+
+run "defaults" {
+  assert {
+    condition = output.computed == "default"
+    error_message = "didn't set default value"
+  }
+}
+
+run "default_matches_last_output" {
+  assert {
+    condition = var.input == run.defaults.input
+    error_message = "output of last should match input of this"
+  }
+}
+
+run "custom_defined_apply_defaults" {
+  variables {
+    input = {
+      required = "required"
+    }
+  }
+
+  assert {
+    condition = output.computed == "default"
+    error_message = "didn't set default value"
+  }
+
+  assert {
+    condition = var.input == run.defaults.input
+    error_message = "output of last should match input of this"
+  }
+}


### PR DESCRIPTION
This PR makes the testing framework apply the defaults for input variables before using them in assertions.

Fixes #33864 

### Target Version

`v1.6.0-beta2`