### PR TITLE
Add warning when testing and combining expect_failures with apply operations

### DIFF
--- a/internal/backend/local/test.go
+++ b/internal/backend/local/test.go
@@ -406,6 +406,7 @@ func (runner *TestFileRunner) run(run *moduletest.Run, file *moduletest.File, st
 
 	// Otherwise any error during the planning prevents our apply from
 	// continuing which is an error.
+	planDiags = run.ExplainExpectedFailures(planDiags)
 	run.Diagnostics = run.Diagnostics.Append(planDiags)
 	if planDiags.HasErrors() {
 		run.Status = moduletest.Error

--- a/internal/command/test_test.go
+++ b/internal/command/test_test.go
@@ -1145,3 +1145,119 @@ the current run block.
 		t.Errorf("should have deleted all resources on completion but left %v", provider.ResourceString())
 	}
 }
+
+func TestTest_ExpectedFailuresDuringPlanning(t *testing.T) {
+	td := t.TempDir()
+	testCopyDir(t, testFixturePath(path.Join("test", "expected_failures_during_planning")), td)
+	defer testChdir(t, td)()
+
+	provider := testing_command.NewProvider(nil)
+	view, done := testView(t)
+
+	c := &TestCommand{
+		Meta: Meta{
+			testingOverrides: metaOverridesForProvider(provider.Provider),
+			View:             view,
+		},
+	}
+
+	code := c.Run([]string{"-no-color"})
+	output := done(t)
+
+	if code == 0 {
+		t.Errorf("expected status code 0 but got %d", code)
+	}
+
+	expectedOut := `check.tftest.hcl... in progress
+  run "check_passes"... pass
+check.tftest.hcl... tearing down
+check.tftest.hcl... pass
+input.tftest.hcl... in progress
+  run "input_failure"... fail
+
+Warning: Expected failure while planning
+
+A custom condition within var.input failed during the planning stage and
+prevented the requested apply operation. While this was an expected failure,
+the apply operation could not be executed and so the overall test case will
+be marked as a failure and the original diagnostic included in the test
+report.
+
+input.tftest.hcl... tearing down
+input.tftest.hcl... fail
+output.tftest.hcl... in progress
+  run "output_failure"... fail
+
+Warning: Expected failure while planning
+
+  on output.tftest.hcl line 13, in run "output_failure":
+  13:     output.output,
+
+A custom condition within output.output failed during the planning stage and
+prevented the requested apply operation. While this was an expected failure,
+the apply operation could not be executed and so the overall test case will
+be marked as a failure and the original diagnostic included in the test
+report.
+
+output.tftest.hcl... tearing down
+output.tftest.hcl... fail
+resource.tftest.hcl... in progress
+  run "resource_failure"... fail
+
+Warning: Expected failure while planning
+
+A custom condition within test_resource.resource failed during the planning
+stage and prevented the requested apply operation. While this was an expected
+failure, the apply operation could not be executed and so the overall test
+case will be marked as a failure and the original diagnostic included in the
+test report.
+
+resource.tftest.hcl... tearing down
+resource.tftest.hcl... fail
+
+Failure! 1 passed, 3 failed.
+`
+	actualOut := output.Stdout()
+	if diff := cmp.Diff(actualOut, expectedOut); len(diff) > 0 {
+		t.Errorf("output didn't match expected:\nexpected:\n%s\nactual:\n%s\ndiff:\n%s", expectedOut, actualOut, diff)
+	}
+
+	expectedErr := `
+Error: Invalid value for variable
+
+  on main.tf line 2:
+   2: variable "input" {
+    ├────────────────
+    │ var.input is "bcd"
+
+input must contain the character 'a'
+
+This was checked by the validation rule at main.tf:5,3-13.
+
+Error: Module output value precondition failed
+
+  on main.tf line 33, in output "output":
+  33:     condition = strcontains(test_resource.resource.value, "d")
+    ├────────────────
+    │ test_resource.resource.value is "abc"
+
+input must contain the character 'd'
+
+Error: Resource postcondition failed
+
+  on main.tf line 16, in resource "test_resource" "resource":
+  16:       condition = strcontains(self.value, "b")
+    ├────────────────
+    │ self.value is "acd"
+
+input must contain the character 'b'
+`
+	actualErr := output.Stderr()
+	if diff := cmp.Diff(actualErr, expectedErr); len(diff) > 0 {
+		t.Errorf("output didn't match expected:\nexpected:\n%s\nactual:\n%s\ndiff:\n%s", expectedErr, actualErr, diff)
+	}
+
+	if provider.ResourceCount() > 0 {
+		t.Errorf("should have deleted all resources on completion but left %v", provider.ResourceString())
+	}
+}

--- a/internal/command/testdata/test/expected_failures_during_planning/check.tftest.hcl
+++ b/internal/command/testdata/test/expected_failures_during_planning/check.tftest.hcl
@@ -1,0 +1,16 @@
+
+run "check_passes" {
+
+  variables {
+    input = "abd"
+  }
+
+  # Checks are a little different, as they only produce warnings. So in this
+  # case we actually expect the whole run block to be fine. It'll produce
+  # warnings during the plan, still execute the apply operation, and then
+  # validate the check block failed during the apply stage.
+  expect_failures = [
+    check.cchar,
+  ]
+
+}

--- a/internal/command/testdata/test/expected_failures_during_planning/input.tftest.hcl
+++ b/internal/command/testdata/test/expected_failures_during_planning/input.tftest.hcl
@@ -1,0 +1,16 @@
+
+run "input_failure" {
+
+  variables {
+    input = "bcd"
+  }
+
+  # While we do expect var.input to fail, we are asking this run block to
+  # execute an apply operation. It can't do that because our custom condition
+  # fails during the planning stage as well. Our test is going to make sure we
+  # add the helpful warning diagnostic explaining this.
+  expect_failures = [
+    var.input,
+  ]
+
+}

--- a/internal/command/testdata/test/expected_failures_during_planning/main.tf
+++ b/internal/command/testdata/test/expected_failures_during_planning/main.tf
@@ -1,0 +1,37 @@
+
+variable "input" {
+  type = string
+
+  validation {
+    condition = strcontains(var.input, "a")
+    error_message = "input must contain the character 'a'"
+  }
+}
+
+resource "test_resource" "resource" {
+  value = var.input
+
+  lifecycle {
+    postcondition {
+      condition = strcontains(self.value, "b")
+      error_message = "input must contain the character 'b'"
+    }
+  }
+}
+
+check "cchar" {
+  assert {
+    condition = strcontains(test_resource.resource.value, "c")
+    error_message = "input must contain the character 'c'"
+  }
+}
+
+output "output" {
+  value = test_resource.resource.value
+
+  precondition {
+    condition = strcontains(test_resource.resource.value, "d")
+    error_message = "input must contain the character 'd'"
+  }
+}
+

--- a/internal/command/testdata/test/expected_failures_during_planning/output.tftest.hcl
+++ b/internal/command/testdata/test/expected_failures_during_planning/output.tftest.hcl
@@ -1,0 +1,16 @@
+
+run "output_failure" {
+
+  variables {
+    input = "abc"
+  }
+
+  # While we do expect output.output to fail, we are asking this run block to
+  # execute an apply operation. It can't do that because our custom condition
+  # fails during the planning stage as well. Our test is going to make sure we
+  # add the helpful warning diagnostic explaining this.
+  expect_failures = [
+    output.output,
+  ]
+
+}

--- a/internal/command/testdata/test/expected_failures_during_planning/resource.tftest.hcl
+++ b/internal/command/testdata/test/expected_failures_during_planning/resource.tftest.hcl
@@ -1,0 +1,16 @@
+
+run "resource_failure" {
+
+  variables {
+    input = "acd"
+  }
+
+  # While we do expect test_resource.resource to fail, we are asking this run
+  # block to execute an apply operation. It can't do that because our custom
+  # condition fails during the planning stage as well. Our test is going to make
+  # sure we add the helpful warning diagnostic explaining this.
+  expect_failures = [
+    test_resource.resource,
+  ]
+
+}

--- a/internal/moduletest/run.go
+++ b/internal/moduletest/run.go
@@ -108,6 +108,122 @@ func (run *Run) GetReferences() ([]*addrs.Reference, tfdiags.Diagnostics) {
 	return references, diagnostics
 }
 
+// ExplainExpectedFailures is similar to ValidateExpectedFailures except it
+// looks for any diagnostics produced by custom conditions and are included in
+// the expected failures and adds an additional explanation that clarifies the
+// expected failures are being ignored this time round.
+//
+// Generally, this function is used during an `apply` operation to explain that
+// an expected failure during the planning stage will still result in the
+// overall test failing as the plan failed and we couldn't even execute the
+// apply stage.
+func (run *Run) ExplainExpectedFailures(originals tfdiags.Diagnostics) tfdiags.Diagnostics {
+
+	// We're going to capture all the checkable objects that are referenced
+	// from the expected failures.
+	expectedFailures := addrs.MakeMap[addrs.Referenceable, bool]()
+	sourceRanges := addrs.MakeMap[addrs.Referenceable, tfdiags.SourceRange]()
+
+	for _, traversal := range run.Config.ExpectFailures {
+		// Ignore the diagnostics returned from the reference parsing, these
+		// references will have been checked earlier in the process by the
+		// validate stage so we don't need to do that again here.
+		reference, _ := addrs.ParseRefFromTestingScope(traversal)
+		expectedFailures.Put(reference.Subject, false)
+		sourceRanges.Put(reference.Subject, reference.SourceRange)
+	}
+
+	var diags tfdiags.Diagnostics
+	for _, diag := range originals {
+		if diag.Severity() == tfdiags.Warning {
+			// Then it's fine, the test will carry on without us doing anything.
+			diags = diags.Append(diag)
+			continue
+		}
+
+		if rule, ok := addrs.DiagnosticOriginatesFromCheckRule(diag); ok {
+
+			var rng *hcl.Range
+			expected := false
+			switch rule.Container.CheckableKind() {
+			case addrs.CheckableOutputValue:
+				addr := rule.Container.(addrs.AbsOutputValue)
+				if !addr.Module.IsRoot() {
+					// failures can only be expected against checkable objects
+					// in the root module. This diagnostic will be added into
+					// returned set below.
+					break
+				}
+				if expectedFailures.Has(addr.OutputValue) {
+					expected = true
+					rng = sourceRanges.Get(addr.OutputValue).ToHCL().Ptr()
+				}
+
+			case addrs.CheckableInputVariable:
+				addr := rule.Container.(addrs.AbsInputVariableInstance)
+				if !addr.Module.IsRoot() {
+					// failures can only be expected against checkable objects
+					// in the root module. This diagnostic will be added into
+					// returned set below.
+					break
+				}
+				if expectedFailures.Has(addr.Variable) {
+					expected = true
+				}
+
+			case addrs.CheckableResource:
+				addr := rule.Container.(addrs.AbsResourceInstance)
+				if !addr.Module.IsRoot() {
+					// failures can only be expected against checkable objects
+					// in the root module. This diagnostic will be added into
+					// returned set below.
+					break
+				}
+				if expectedFailures.Has(addr.Resource) {
+					expected = true
+				}
+
+				if expectedFailures.Has(addr.Resource.Resource) {
+					expected = true
+				}
+
+			case addrs.CheckableCheck:
+				// Check blocks only produce warnings so this branch shouldn't
+				// ever be triggered anyway.
+			default:
+				panic("unrecognized CheckableKind: " + rule.Container.CheckableKind().String())
+			}
+
+			if expected {
+				// Then this diagnostic was produced by a custom condition that
+				// was expected to fail. But, it happened at the wrong time (eg.
+				// we're trying to run an apply operation and this condition
+				// failed during the plan so the overall test operation still
+				// fails).
+				//
+				// We'll add a warning diagnostic explaining why the overall
+				// test is still failing even though the error was expected, and
+				// then add the original error into our diagnostics directly
+				// after.
+
+				diags = diags.Append(&hcl.Diagnostic{
+					Severity: hcl.DiagWarning,
+					Summary:  "Expected failure while planning",
+					Detail:   fmt.Sprintf("A custom condition within %s failed during the planning stage and prevented the requested apply operation. While this was an expected failure, the apply operation could not be executed and so the overall test case will be marked as a failure and the original diagnostic included in the test report.", rule.Container.String()),
+					Subject:  rng,
+				})
+				diags = diags.Append(diag)
+				continue
+			}
+		}
+
+		// Otherwise, there is nothing special about this diagnostic so just
+		// carry it through.
+		diags = diags.Append(diag)
+	}
+	return diags
+}
+
 // ValidateExpectedFailures steps through the provided diagnostics (which should
 // be the result of a plan or an apply operation), and does 3 things:
 //  1. Removes diagnostics that match the expected failures from the config.


### PR DESCRIPTION
Currently if you mix `expect_failures` and `command = apply` you can get some confusing behaviour. Essentially the expected failure might happen during the planning stage, in which case Terraform doesn't produce a valid plan and the apply stage can't happen. This means the test fails, as the user asked for an apply operation, but the diagnostics can only really report the reason the test failed is because the thing the user expected to fail actually did fail. This is confusing as the user only really sees that the test failed even though they told it to expect the failure, while the test really failed because it could not execute the apply operation.

This PR adds a warning diagnostic that triggers in the described case. It adds a warning to the returned set of diagnostics that specifically says, this run failed because the plan failed and you asked for an apply regardless of which failures you did or didn't expect to happen. This should help clear up confusion.

Closes #33857 

### Target Version

`v1.6.0-beta2`