### PR TITLE
backend/s3: prevent keys containing double slashes

### DIFF
--- a/internal/backend/remote-state/s3/backend.go
+++ b/internal/backend/remote-state/s3/backend.go
@@ -386,6 +386,7 @@ func (b *Backend) PrepareConfig(obj cty.Value) (cty.Value, tfdiags.Diagnostics) 
 			Validators: []stringValidator{
 				validateStringNotEmpty,
 				validateStringS3Path,
+				validateStringDoesNotContain("//"),
 			},
 		}
 		keyValidators.ValidateAttr(val, attrPath, &diags)

--- a/internal/backend/remote-state/s3/backend_test.go
+++ b/internal/backend/remote-state/s3/backend_test.go
@@ -1137,6 +1137,20 @@ func TestBackendConfig_PrepareConfigValidation(t *testing.T) {
 				),
 			},
 		},
+		"key with double slash": {
+			config: cty.ObjectVal(map[string]cty.Value{
+				"bucket": cty.StringVal("test"),
+				"key":    cty.StringVal("test/with/double//slash"),
+				"region": cty.StringVal("us-west-2"),
+			}),
+			expectedDiags: tfdiags.Diagnostics{
+				attributeErrDiag(
+					"Invalid Value",
+					`Value must not contain "//"`,
+					cty.GetAttrPath("key"),
+				),
+			},
+		},
 
 		"null region": {
 			config: cty.ObjectVal(map[string]cty.Value{

--- a/internal/backend/remote-state/s3/validate.go
+++ b/internal/backend/remote-state/s3/validate.go
@@ -121,6 +121,18 @@ func validateStringMatches(re *regexp.Regexp, description string) stringValidato
 	}
 }
 
+func validateStringDoesNotContain(s string) stringValidator {
+	return func(val string, path cty.Path, diags *tfdiags.Diagnostics) {
+		if strings.Contains(val, s) {
+			*diags = diags.Append(attributeErrDiag(
+				"Invalid Value",
+				fmt.Sprintf(`Value must not contain "%s"`, s),
+				path,
+			))
+		}
+	}
+}
+
 func validateStringInSlice(sl []string) stringValidator {
 	return func(val string, path cty.Path, diags *tfdiags.Diagnostics) {
 		match := false


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->
With the AWS Go SDK V2, URI cleaning of S3 object URLs is no longer done by default. As such, `key` values containing double slashes (`//`) could introduce situations where an existing statefile cannot be read. This additional validation step disallows keys containing double slashes to prevent this.

Prevention of leading and trailing slashes (also potential failure points with AWS Go SDK v2) is already done via the `validateStringS3Path` validator.

```console
% TF_ACC=1 go test ./internal/backend/remote-state/s3/...
ok      github.com/hashicorp/terraform/internal/backend/remote-state/s3 122.148
```

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Relates #33687
Relates https://github.com/hashicorp/terraform-provider-aws/pull/33358 (changes to URI cleaning discovered during SDK upgrade of this resource in the AWS Provider)

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.6.x

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

<!--

Write a short description of the user-facing change. Examples:

- `terraform show -json`: Fixed crash with sensitive set values.
- When rendering a diff, Terraform now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 

N/A - validation change only.
