### PR TITLE
backend/s3: Adds `singleNestedAttribute` to internal schema

### DIFF
--- a/internal/backend/remote-state/s3/backend.go
+++ b/internal/backend/remote-state/s3/backend.go
@@ -304,19 +304,9 @@ func (b *Backend) ConfigSchema() *configschema.Block {
 				Description: "The maximum number of times an AWS API request is retried on retryable failure.",
 			},
 
-			"assume_role": {
-				NestedType: &configschema.Object{
-					Nesting:    configschema.NestingSingle,
-					Attributes: assumeRoleFullSchema().SchemaAttributes(),
-				},
-			},
+			"assume_role": assumeRoleSchema.SchemaAttribute(),
 
-			"assume_role_with_web_identity": {
-				NestedType: &configschema.Object{
-					Nesting:    configschema.NestingSingle,
-					Attributes: assumeRoleWithWebIdentityFullSchema().SchemaAttributes(),
-				},
-			},
+			"assume_role_with_web_identity": assumeRoleWithWebIdentitySchema.SchemaAttribute(),
 
 			"use_legacy_workflow": {
 				Type:        cty.Bool,
@@ -352,6 +342,249 @@ func (b *Backend) ConfigSchema() *configschema.Block {
 			},
 		},
 	}
+}
+
+var assumeRoleSchema = singleNestedAttribute{
+	Attributes: map[string]schemaAttribute{
+		"role_arn": stringAttribute{
+			configschema.Attribute{
+				Type:        cty.String,
+				Required:    true,
+				Description: "The role to be assumed.",
+			},
+			validateString{
+				Validators: []stringValidator{
+					validateARN(
+						validateIAMRoleARN,
+					),
+				},
+			},
+		},
+
+		"duration": stringAttribute{
+			configschema.Attribute{
+				Type:        cty.String,
+				Optional:    true,
+				Description: "The duration, between 15 minutes and 12 hours, of the role session. Valid time units are ns, us (or µs), ms, s, h, or m.",
+			},
+			validateString{
+				Validators: []stringValidator{
+					validateDuration(
+						validateDurationBetween(15*time.Minute, 12*time.Hour),
+					),
+				},
+			},
+		},
+
+		"external_id": stringAttribute{
+			configschema.Attribute{
+				Type:        cty.String,
+				Optional:    true,
+				Description: "The external ID to use when assuming the role",
+			},
+			validateString{
+				Validators: []stringValidator{
+					validateStringLenBetween(2, 1224),
+					validateStringMatches(
+						regexp.MustCompile(`^[\w+=,.@:\/\-]*$`),
+						`Value can only contain letters, numbers, or the following characters: =,.@/-`,
+					),
+				},
+			},
+		},
+
+		"policy": stringAttribute{
+			configschema.Attribute{
+				Type:        cty.String,
+				Optional:    true,
+				Description: "IAM Policy JSON describing further restricting permissions for the IAM Role being assumed.",
+			},
+			validateString{
+				Validators: []stringValidator{
+					validateStringNotEmpty,
+					validateIAMPolicyDocument,
+				},
+			},
+		},
+
+		"policy_arns": setAttribute{
+			configschema.Attribute{
+				Type:        cty.Set(cty.String),
+				Optional:    true,
+				Description: "Amazon Resource Names (ARNs) of IAM Policies describing further restricting permissions for the IAM Role being assumed.",
+			},
+			validateSet{
+				Validators: []setValidator{
+					validateSetStringElements(
+						validateARN(
+							validateIAMPolicyARN,
+						),
+					),
+				},
+			},
+		},
+
+		"session_name": stringAttribute{
+			configschema.Attribute{
+				Type:        cty.String,
+				Optional:    true,
+				Description: "The session name to use when assuming the role.",
+			},
+			validateString{
+				Validators: []stringValidator{
+					validateStringLenBetween(2, 64),
+					validateStringMatches(
+						regexp.MustCompile(`^[\w+=,.@\-]*$`),
+						`Value can only contain letters, numbers, or the following characters: =,.@-`,
+					),
+				},
+			},
+		},
+
+		// NOT SUPPORTED by `aws-sdk-go-base/v1`
+		// "source_identity": stringAttribute{
+		// 	configschema.Attribute{
+		// 		Type:         cty.String,
+		// 		Optional:     true,
+		// 		Description:  "Source identity specified by the principal assuming the role.",
+		// 		ValidateFunc: validAssumeRoleSourceIdentity,
+		// 	},
+		// },
+
+		"tags": mapAttribute{
+			configschema.Attribute{
+				Type:        cty.Map(cty.String),
+				Optional:    true,
+				Description: "Assume role session tags.",
+			},
+			validateMap{},
+		},
+
+		"transitive_tag_keys": setAttribute{
+			configschema.Attribute{
+				Type:        cty.Set(cty.String),
+				Optional:    true,
+				Description: "Assume role session tag keys to pass to any subsequent sessions.",
+			},
+			validateSet{},
+		},
+	},
+}
+
+var assumeRoleWithWebIdentitySchema = singleNestedAttribute{
+	Attributes: map[string]schemaAttribute{
+		"role_arn": stringAttribute{
+			configschema.Attribute{
+				Type:        cty.String,
+				Required:    true,
+				Description: "The role to be assumed.",
+			},
+			validateString{
+				Validators: []stringValidator{
+					validateARN(
+						validateIAMRoleARN,
+					),
+				},
+			},
+		},
+
+		"duration": stringAttribute{
+			configschema.Attribute{
+				Type:        cty.String,
+				Optional:    true,
+				Description: "The duration, between 15 minutes and 12 hours, of the role session. Valid time units are ns, us (or µs), ms, s, h, or m.",
+			},
+			validateString{
+				Validators: []stringValidator{
+					validateDuration(
+						validateDurationBetween(15*time.Minute, 12*time.Hour),
+					),
+				},
+			},
+		},
+
+		"policy": stringAttribute{
+			configschema.Attribute{
+				Type:        cty.String,
+				Optional:    true,
+				Description: "IAM Policy JSON describing further restricting permissions for the IAM Role being assumed.",
+			},
+			validateString{
+				Validators: []stringValidator{
+					validateStringNotEmpty,
+					validateIAMPolicyDocument,
+				},
+			},
+		},
+
+		"policy_arns": setAttribute{
+			configschema.Attribute{
+				Type:        cty.Set(cty.String),
+				Optional:    true,
+				Description: "Amazon Resource Names (ARNs) of IAM Policies describing further restricting permissions for the IAM Role being assumed.",
+			},
+			validateSet{
+				Validators: []setValidator{
+					validateSetStringElements(
+						validateARN(
+							validateIAMPolicyARN,
+						),
+					),
+				},
+			},
+		},
+
+		"session_name": stringAttribute{
+			configschema.Attribute{
+				Type:        cty.String,
+				Optional:    true,
+				Description: "The session name to use when assuming the role.",
+			},
+			validateString{
+				Validators: []stringValidator{
+					validateStringLenBetween(2, 64),
+					validateStringMatches(
+						regexp.MustCompile(`^[\w+=,.@\-]*$`),
+						`Value can only contain letters, numbers, or the following characters: =,.@-`,
+					),
+				},
+			},
+		},
+
+		"web_identity_token": stringAttribute{
+			configschema.Attribute{
+				Type:        cty.String,
+				Optional:    true,
+				Description: "Value of a web identity token from an OpenID Connect (OIDC) or OAuth provider.",
+			},
+			validateString{
+				Validators: []stringValidator{
+					validateStringLenBetween(4, 20000),
+				},
+			},
+		},
+
+		"web_identity_token_file": stringAttribute{
+			configschema.Attribute{
+				Type:        cty.String,
+				Optional:    true,
+				Description: "File containing a web identity token from an OpenID Connect (OIDC) or OAuth provider.",
+			},
+			validateString{
+				Validators: []stringValidator{
+					validateStringLenBetween(4, 20000),
+				},
+			},
+		},
+	},
+	validateObject: validateObject{
+		Validators: []objectValidator{
+			validateExactlyOneOfAttributes(
+				cty.GetAttrPath("web_identity_token"),
+				cty.GetAttrPath("web_identity_token_file"),
+			),
+		},
+	},
 }
 
 // PrepareConfig checks the validity of the values in the given
@@ -440,7 +673,7 @@ func (b *Backend) PrepareConfig(obj cty.Value) (cty.Value, tfdiags.Diagnostics) 
 	}
 
 	if val := obj.GetAttr("assume_role"); !val.IsNull() {
-		diags = diags.Append(prepareAssumeRoleConfig(val, cty.GetAttrPath("assume_role")))
+		diags = diags.Append(validateNestedAttribute(assumeRoleSchema, val, cty.GetAttrPath("assume_role")))
 
 		if defined := findDeprecatedFields(obj, assumeRoleDeprecatedFields); len(defined) != 0 {
 			diags = diags.Append(tfdiags.WholeContainingBody(
@@ -461,7 +694,7 @@ func (b *Backend) PrepareConfig(obj cty.Value) (cty.Value, tfdiags.Diagnostics) 
 	}
 
 	if val := obj.GetAttr("assume_role_with_web_identity"); !val.IsNull() {
-		diags = diags.Append(prepareAssumeRoleWithWebIdentityConfig(val, cty.GetAttrPath("assume_role_with_web_identity")))
+		diags = diags.Append(validateNestedAttribute(assumeRoleWithWebIdentitySchema, val, cty.GetAttrPath("assume_role_with_web_identity")))
 	}
 
 	validateAttributesConflict(
@@ -1196,13 +1429,22 @@ The "kms_key_id" is used for encryption with KMS-Managed Keys (SSE-KMS)
 while "AWS_SSE_CUSTOMER_KEY" is used for encryption with customer-managed keys (SSE-C).
 Please choose one or the other.`
 
-func prepareAssumeRoleConfig(obj cty.Value, objPath cty.Path) tfdiags.Diagnostics {
+// TODO: make diags a parameter
+func validateNestedAttribute(objSchema schemaAttribute, obj cty.Value, objPath cty.Path) tfdiags.Diagnostics {
 	var diags tfdiags.Diagnostics
 	if obj.IsNull() {
 		return diags
 	}
 
-	for name, attrSchema := range assumeRoleFullSchema() {
+	na, ok := objSchema.(singleNestedAttribute)
+	if !ok {
+		return diags
+	}
+
+	validator := objSchema.Validator()
+	validator.ValidateAttr(obj, objPath, &diags)
+
+	for name, attrSchema := range na.Attributes {
 		attrPath := objPath.GetAttr(name)
 		attrVal := obj.GetAttr(name)
 
@@ -1225,43 +1467,6 @@ func prepareAssumeRoleConfig(obj cty.Value, objPath cty.Path) tfdiags.Diagnostic
 		validator := attrSchema.Validator()
 		validator.ValidateAttr(attrVal, attrPath, &diags)
 	}
-
-	return diags
-}
-func prepareAssumeRoleWithWebIdentityConfig(obj cty.Value, objPath cty.Path) tfdiags.Diagnostics {
-	var diags tfdiags.Diagnostics
-	if obj.IsNull() {
-		return diags
-	}
-
-	for name, attrSchema := range assumeRoleWithWebIdentityFullSchema() {
-		attrPath := objPath.GetAttr(name)
-		attrVal := obj.GetAttr(name)
-
-		if a, e := attrVal.Type(), attrSchema.SchemaAttribute().Type; a != e {
-			diags = diags.Append(attributeErrDiag(
-				"Internal Error",
-				fmt.Sprintf(`Expected type to be %s, got: %s`, e.FriendlyName(), a.FriendlyName()),
-				attrPath,
-			))
-			continue
-		}
-
-		if attrVal.IsNull() {
-			if attrSchema.SchemaAttribute().Required {
-				diags = diags.Append(requiredAttributeErrDiag(attrPath))
-			}
-			continue
-		}
-
-		validator := attrSchema.Validator()
-		validator.ValidateAttr(attrVal, attrPath, &diags)
-	}
-
-	validateExactlyOneOfAttributes(
-		cty.GetAttrPath("web_identity_token"),
-		cty.GetAttrPath("web_identity_token_file"),
-	)(obj, objPath, &diags)
 
 	return diags
 }
@@ -1343,10 +1548,22 @@ func (v validateSet) ValidateAttr(val cty.Value, attrPath cty.Path, diags *tfdia
 	}
 }
 
+type validateObject struct {
+	Validators []objectValidator
+}
+
+func (v validateObject) ValidateAttr(val cty.Value, attrPath cty.Path, diags *tfdiags.Diagnostics) {
+	for _, validator := range v.Validators {
+		validator(val, attrPath, diags)
+	}
+}
+
 type schemaAttribute interface {
 	SchemaAttribute() *configschema.Attribute
 	Validator() validateSchema
 }
+
+var _ schemaAttribute = stringAttribute{}
 
 type stringAttribute struct {
 	configschema.Attribute
@@ -1361,6 +1578,8 @@ func (a stringAttribute) Validator() validateSchema {
 	return a.validateString
 }
 
+var _ schemaAttribute = setAttribute{}
+
 type setAttribute struct {
 	configschema.Attribute
 	validateSet
@@ -1373,6 +1592,8 @@ func (a setAttribute) SchemaAttribute() *configschema.Attribute {
 func (a setAttribute) Validator() validateSchema {
 	return a.validateSet
 }
+
+var _ schemaAttribute = mapAttribute{}
 
 type mapAttribute struct {
 	configschema.Attribute
@@ -1397,239 +1618,24 @@ func (s objectSchema) SchemaAttributes() map[string]*configschema.Attribute {
 	return m
 }
 
-func assumeRoleFullSchema() objectSchema {
-	return map[string]schemaAttribute{
-		"role_arn": stringAttribute{
-			configschema.Attribute{
-				Type:        cty.String,
-				Required:    true,
-				Description: "The role to be assumed.",
-			},
-			validateString{
-				Validators: []stringValidator{
-					validateARN(
-						validateIAMRoleARN,
-					),
-				},
-			},
-		},
+var _ schemaAttribute = singleNestedAttribute{}
 
-		"duration": stringAttribute{
-			configschema.Attribute{
-				Type:        cty.String,
-				Optional:    true,
-				Description: "The duration, between 15 minutes and 12 hours, of the role session. Valid time units are ns, us (or µs), ms, s, h, or m.",
-			},
-			validateString{
-				Validators: []stringValidator{
-					validateDuration(
-						validateDurationBetween(15*time.Minute, 12*time.Hour),
-					),
-				},
-			},
-		},
+type singleNestedAttribute struct {
+	Attributes objectSchema
+	validateObject
+}
 
-		"external_id": stringAttribute{
-			configschema.Attribute{
-				Type:        cty.String,
-				Optional:    true,
-				Description: "The external ID to use when assuming the role",
-			},
-			validateString{
-				Validators: []stringValidator{
-					validateStringLenBetween(2, 1224),
-					validateStringMatches(
-						regexp.MustCompile(`^[\w+=,.@:\/\-]*$`),
-						`Value can only contain letters, numbers, or the following characters: =,.@/-`,
-					),
-				},
-			},
-		},
-
-		"policy": stringAttribute{
-			configschema.Attribute{
-				Type:        cty.String,
-				Optional:    true,
-				Description: "IAM Policy JSON describing further restricting permissions for the IAM Role being assumed.",
-			},
-			validateString{
-				Validators: []stringValidator{
-					validateStringNotEmpty,
-					validateIAMPolicyDocument,
-				},
-			},
-		},
-
-		"policy_arns": setAttribute{
-			configschema.Attribute{
-				Type:        cty.Set(cty.String),
-				Optional:    true,
-				Description: "Amazon Resource Names (ARNs) of IAM Policies describing further restricting permissions for the IAM Role being assumed.",
-			},
-			validateSet{
-				Validators: []setValidator{
-					validateSetStringElements(
-						validateARN(
-							validateIAMPolicyARN,
-						),
-					),
-				},
-			},
-		},
-
-		"session_name": stringAttribute{
-			configschema.Attribute{
-				Type:        cty.String,
-				Optional:    true,
-				Description: "The session name to use when assuming the role.",
-			},
-			validateString{
-				Validators: []stringValidator{
-					validateStringLenBetween(2, 64),
-					validateStringMatches(
-						regexp.MustCompile(`^[\w+=,.@\-]*$`),
-						`Value can only contain letters, numbers, or the following characters: =,.@-`,
-					),
-				},
-			},
-		},
-
-		// NOT SUPPORTED by `aws-sdk-go-base/v1`
-		// "source_identity": stringAttribute{
-		// 	configschema.Attribute{
-		// 		Type:         cty.String,
-		// 		Optional:     true,
-		// 		Description:  "Source identity specified by the principal assuming the role.",
-		// 		ValidateFunc: validAssumeRoleSourceIdentity,
-		// 	},
-		// },
-
-		"tags": mapAttribute{
-			configschema.Attribute{
-				Type:        cty.Map(cty.String),
-				Optional:    true,
-				Description: "Assume role session tags.",
-			},
-			validateMap{},
-		},
-
-		"transitive_tag_keys": setAttribute{
-			configschema.Attribute{
-				Type:        cty.Set(cty.String),
-				Optional:    true,
-				Description: "Assume role session tag keys to pass to any subsequent sessions.",
-			},
-			validateSet{},
+func (a singleNestedAttribute) SchemaAttribute() *configschema.Attribute {
+	return &configschema.Attribute{
+		NestedType: &configschema.Object{
+			Nesting:    configschema.NestingSingle,
+			Attributes: a.Attributes.SchemaAttributes(),
 		},
 	}
 }
 
-func assumeRoleWithWebIdentityFullSchema() objectSchema {
-	return map[string]schemaAttribute{
-		"role_arn": stringAttribute{
-			configschema.Attribute{
-				Type:        cty.String,
-				Required:    true,
-				Description: "The role to be assumed.",
-			},
-			validateString{
-				Validators: []stringValidator{
-					validateARN(
-						validateIAMRoleARN,
-					),
-				},
-			},
-		},
-
-		"duration": stringAttribute{
-			configschema.Attribute{
-				Type:        cty.String,
-				Optional:    true,
-				Description: "The duration, between 15 minutes and 12 hours, of the role session. Valid time units are ns, us (or µs), ms, s, h, or m.",
-			},
-			validateString{
-				Validators: []stringValidator{
-					validateDuration(
-						validateDurationBetween(15*time.Minute, 12*time.Hour),
-					),
-				},
-			},
-		},
-
-		"policy": stringAttribute{
-			configschema.Attribute{
-				Type:        cty.String,
-				Optional:    true,
-				Description: "IAM Policy JSON describing further restricting permissions for the IAM Role being assumed.",
-			},
-			validateString{
-				Validators: []stringValidator{
-					validateStringNotEmpty,
-					validateIAMPolicyDocument,
-				},
-			},
-		},
-
-		"policy_arns": setAttribute{
-			configschema.Attribute{
-				Type:        cty.Set(cty.String),
-				Optional:    true,
-				Description: "Amazon Resource Names (ARNs) of IAM Policies describing further restricting permissions for the IAM Role being assumed.",
-			},
-			validateSet{
-				Validators: []setValidator{
-					validateSetStringElements(
-						validateARN(
-							validateIAMPolicyARN,
-						),
-					),
-				},
-			},
-		},
-
-		"session_name": stringAttribute{
-			configschema.Attribute{
-				Type:        cty.String,
-				Optional:    true,
-				Description: "The session name to use when assuming the role.",
-			},
-			validateString{
-				Validators: []stringValidator{
-					validateStringLenBetween(2, 64),
-					validateStringMatches(
-						regexp.MustCompile(`^[\w+=,.@\-]*$`),
-						`Value can only contain letters, numbers, or the following characters: =,.@-`,
-					),
-				},
-			},
-		},
-
-		"web_identity_token": stringAttribute{
-			configschema.Attribute{
-				Type:        cty.String,
-				Optional:    true,
-				Description: "Value of a web identity token from an OpenID Connect (OIDC) or OAuth provider.",
-			},
-			validateString{
-				Validators: []stringValidator{
-					validateStringLenBetween(4, 20000),
-				},
-			},
-		},
-
-		"web_identity_token_file": stringAttribute{
-			configschema.Attribute{
-				Type:        cty.String,
-				Optional:    true,
-				Description: "File containing a web identity token from an OpenID Connect (OIDC) or OAuth provider.",
-			},
-			validateString{
-				Validators: []stringValidator{
-					validateStringLenBetween(4, 20000),
-				},
-			},
-		},
-	}
+func (a singleNestedAttribute) Validator() validateSchema {
+	return a.validateObject
 }
 
 func deprecatedAttrDiag(attr, replacement cty.Path) tfdiags.Diagnostic {

--- a/internal/backend/remote-state/s3/backend.go
+++ b/internal/backend/remote-state/s3/backend.go
@@ -705,7 +705,7 @@ func (b *Backend) PrepareConfig(obj cty.Value) (cty.Value, tfdiags.Diagnostics) 
 	}
 
 	if val := obj.GetAttr("assume_role"); !val.IsNull() {
-		diags = diags.Append(validateNestedAttribute(assumeRoleSchema, val, cty.GetAttrPath("assume_role")))
+		validateNestedAttribute(assumeRoleSchema, val, cty.GetAttrPath("assume_role"), &diags)
 
 		if defined := findDeprecatedFields(obj, assumeRoleDeprecatedFields); len(defined) != 0 {
 			diags = diags.Append(tfdiags.WholeContainingBody(
@@ -726,7 +726,7 @@ func (b *Backend) PrepareConfig(obj cty.Value) (cty.Value, tfdiags.Diagnostics) 
 	}
 
 	if val := obj.GetAttr("assume_role_with_web_identity"); !val.IsNull() {
-		diags = diags.Append(validateNestedAttribute(assumeRoleWithWebIdentitySchema, val, cty.GetAttrPath("assume_role_with_web_identity")))
+		validateNestedAttribute(assumeRoleWithWebIdentitySchema, val, cty.GetAttrPath("assume_role_with_web_identity"), &diags)
 	}
 
 	validateAttributesConflict(
@@ -769,7 +769,7 @@ func (b *Backend) PrepareConfig(obj cty.Value) (cty.Value, tfdiags.Diagnostics) 
 	}
 
 	if val := obj.GetAttr("endpoints"); !val.IsNull() {
-		diags = diags.Append(validateNestedAttribute(endpointsSchema, val, cty.GetAttrPath("endpoints")))
+		validateNestedAttribute(endpointsSchema, val, cty.GetAttrPath("endpoints"), &diags)
 	}
 
 	endpointValidators := validateString{
@@ -1456,27 +1456,25 @@ The "kms_key_id" is used for encryption with KMS-Managed Keys (SSE-KMS)
 while "AWS_SSE_CUSTOMER_KEY" is used for encryption with customer-managed keys (SSE-C).
 Please choose one or the other.`
 
-// TODO: make diags a parameter
-func validateNestedAttribute(objSchema schemaAttribute, obj cty.Value, objPath cty.Path) tfdiags.Diagnostics {
-	var diags tfdiags.Diagnostics
+func validateNestedAttribute(objSchema schemaAttribute, obj cty.Value, objPath cty.Path, diags *tfdiags.Diagnostics) {
 	if obj.IsNull() {
-		return diags
+		return
 	}
 
 	na, ok := objSchema.(singleNestedAttribute)
 	if !ok {
-		return diags
+		return
 	}
 
 	validator := objSchema.Validator()
-	validator.ValidateAttr(obj, objPath, &diags)
+	validator.ValidateAttr(obj, objPath, diags)
 
 	for name, attrSchema := range na.Attributes {
 		attrPath := objPath.GetAttr(name)
 		attrVal := obj.GetAttr(name)
 
 		if a, e := attrVal.Type(), attrSchema.SchemaAttribute().Type; a != e {
-			diags = diags.Append(attributeErrDiag(
+			*diags = diags.Append(attributeErrDiag(
 				"Internal Error",
 				fmt.Sprintf(`Expected type to be %s, got: %s`, e.FriendlyName(), a.FriendlyName()),
 				attrPath,
@@ -1486,16 +1484,14 @@ func validateNestedAttribute(objSchema schemaAttribute, obj cty.Value, objPath c
 
 		if attrVal.IsNull() {
 			if attrSchema.SchemaAttribute().Required {
-				diags = diags.Append(requiredAttributeErrDiag(attrPath))
+				*diags = diags.Append(requiredAttributeErrDiag(attrPath))
 			}
 			continue
 		}
 
 		validator := attrSchema.Validator()
-		validator.ValidateAttr(attrVal, attrPath, &diags)
+		validator.ValidateAttr(attrVal, attrPath, diags)
 	}
-
-	return diags
 }
 
 func requiredAttributeErrDiag(path cty.Path) tfdiags.Diagnostic {

--- a/internal/backend/remote-state/s3/backend_complete_test.go
+++ b/internal/backend/remote-state/s3/backend_complete_test.go
@@ -1869,7 +1869,6 @@ web_identity_token_file = no-such-file
 			config: map[string]any{
 				"assume_role_with_web_identity": map[string]any{},
 			},
-			ExpectedCredentialsValue: mockdata.MockStsAssumeRoleWithWebIdentityCredentials,
 			ValidateDiags: ExpectDiagsEqual(tfdiags.Diagnostics{
 				attributeErrDiag(
 					"Missing Required Value",
@@ -1891,11 +1890,28 @@ web_identity_token_file = no-such-file
 					"role_arn": servicemocks.MockStsAssumeRoleWithWebIdentityArn,
 				},
 			},
-			ExpectedCredentialsValue: mockdata.MockStsAssumeRoleWithWebIdentityCredentials,
 			ValidateDiags: ExpectDiagsEqual(tfdiags.Diagnostics{
 				attributeErrDiag(
 					"Missing Required Value",
 					`Exactly one of web_identity_token, web_identity_token_file must be set.`,
+					cty.GetAttrPath("assume_role_with_web_identity"),
+				),
+			}),
+		},
+
+		"invalid token config conflict": {
+			config: map[string]any{
+				"assume_role_with_web_identity": map[string]any{
+					"role_arn":           servicemocks.MockStsAssumeRoleWithWebIdentityArn,
+					"session_name":       servicemocks.MockStsAssumeRoleWithWebIdentitySessionName,
+					"web_identity_token": servicemocks.MockWebIdentityToken,
+				},
+			},
+			SetConfig: true,
+			ValidateDiags: ExpectDiagsEqual(tfdiags.Diagnostics{
+				attributeErrDiag(
+					"Invalid Attribute Combination",
+					`Only one of web_identity_token, web_identity_token_file can be set.`,
 					cty.GetAttrPath("assume_role_with_web_identity"),
 				),
 			}),

--- a/internal/backend/remote-state/s3/backend_complete_test.go
+++ b/internal/backend/remote-state/s3/backend_complete_test.go
@@ -1872,14 +1872,14 @@ web_identity_token_file = no-such-file
 			ValidateDiags: ExpectDiagsEqual(tfdiags.Diagnostics{
 				attributeErrDiag(
 					"Missing Required Value",
-					`The attribute "assume_role_with_web_identity.role_arn" is required by the backend.`+"\n\n"+
-						"Refer to the backend documentation for additional information which attributes are required.",
-					cty.GetAttrPath("assume_role_with_web_identity").GetAttr("role_arn"),
+					`Exactly one of web_identity_token, web_identity_token_file must be set.`,
+					cty.GetAttrPath("assume_role_with_web_identity"),
 				),
 				attributeErrDiag(
 					"Missing Required Value",
-					`Exactly one of web_identity_token, web_identity_token_file must be set.`,
-					cty.GetAttrPath("assume_role_with_web_identity"),
+					`The attribute "assume_role_with_web_identity.role_arn" is required by the backend.`+"\n\n"+
+						"Refer to the backend documentation for additional information which attributes are required.",
+					cty.GetAttrPath("assume_role_with_web_identity").GetAttr("role_arn"),
 				),
 			}),
 		},

--- a/internal/backend/remote-state/s3/backend_test.go
+++ b/internal/backend/remote-state/s3/backend_test.go
@@ -1971,7 +1971,7 @@ func TestAssumeRole_PrepareConfigValidation(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			schema := assumeRoleFullSchema()
+			schema := assumeRoleSchema.Attributes
 			vals := make(map[string]cty.Value, len(schema))
 			for name, attrSchema := range schema {
 				if val, ok := tc.config[name]; ok {
@@ -1982,7 +1982,7 @@ func TestAssumeRole_PrepareConfigValidation(t *testing.T) {
 			}
 			config := cty.ObjectVal(vals)
 
-			diags := prepareAssumeRoleConfig(config, path)
+			diags := validateNestedAttribute(assumeRoleSchema, config, path)
 
 			if diff := cmp.Diff(diags, tc.expectedDiags, cmp.Comparer(diagnosticComparer)); diff != "" {
 				t.Errorf("unexpected diagnostics difference: %s", diff)

--- a/internal/backend/remote-state/s3/backend_test.go
+++ b/internal/backend/remote-state/s3/backend_test.go
@@ -1982,7 +1982,8 @@ func TestAssumeRole_PrepareConfigValidation(t *testing.T) {
 			}
 			config := cty.ObjectVal(vals)
 
-			diags := validateNestedAttribute(assumeRoleSchema, config, path)
+			var diags tfdiags.Diagnostics
+			validateNestedAttribute(assumeRoleSchema, config, path, &diags)
 
 			if diff := cmp.Diff(diags, tc.expectedDiags, cmp.Comparer(diagnosticComparer)); diff != "" {
 				t.Errorf("unexpected diagnostics difference: %s", diff)


### PR DESCRIPTION
Updates internal schema to include `singleNestedAttribute` type and updates backend schema to use it for nested attributes.

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.6.0

## Draft CHANGELOG entry

No user facing change