### PR TITLE
Support conditionally auto loading tfvars on workspace

### DIFF
--- a/internal/command/meta.go
+++ b/internal/command/meta.go
@@ -793,12 +793,6 @@ func (m *Meta) SetWorkspace(name string) error {
 	return nil
 }
 
-// isAutoVarFile determines if the file ends with .auto.tfvars or .auto.tfvars.json
-func isAutoVarFile(path string) bool {
-	return strings.HasSuffix(path, ".auto.tfvars") ||
-		strings.HasSuffix(path, ".auto.tfvars.json")
-}
-
 // FIXME: as an interim refactoring step, we apply the contents of the state
 // arguments directly to the Meta object. Future work would ideally update the
 // code paths which use these arguments to be passed them directly for clarity.

--- a/internal/command/test_test.go
+++ b/internal/command/test_test.go
@@ -175,6 +175,10 @@ func TestTest(t *testing.T) {
 			code:                  1,
 			expectedResourceCount: 1,
 		},
+		"variables_tfvars": {
+			expected: "1 passed, 0 failed.",
+			code:     0,
+		},
 	}
 	for name, tc := range tcs {
 		t.Run(name, func(t *testing.T) {

--- a/internal/command/testdata/test/variables_tfvars/a.auto.default.tfvars
+++ b/internal/command/testdata/test/variables_tfvars/a.auto.default.tfvars
@@ -1,0 +1,2 @@
+from_auto_workspace_tfvars="foobar"
+from_auto_workspace_overridden="cban"

--- a/internal/command/testdata/test/variables_tfvars/a.auto.dev.tfvars
+++ b/internal/command/testdata/test/variables_tfvars/a.auto.dev.tfvars
@@ -1,0 +1,1 @@
+from_auto_workspace_tfvars="baz"

--- a/internal/command/testdata/test/variables_tfvars/a.auto.tfvars
+++ b/internal/command/testdata/test/variables_tfvars/a.auto.tfvars
@@ -1,0 +1,3 @@
+from_auto_tfvars="bar"
+from_auto_tfvars_overridden="abar"
+from_auto_workspace_overridden="aban"

--- a/internal/command/testdata/test/variables_tfvars/b.auto.tfvars
+++ b/internal/command/testdata/test/variables_tfvars/b.auto.tfvars
@@ -1,0 +1,2 @@
+from_auto_tfvars_overridden="bbar"
+from_auto_workspace_overridden="bban"

--- a/internal/command/testdata/test/variables_tfvars/main.tf
+++ b/internal/command/testdata/test/variables_tfvars/main.tf
@@ -1,0 +1,39 @@
+variable "from_terraform_tfvars" {
+  type = string
+}
+
+variable "from_auto_tfvars" {
+  type = string
+}
+
+variable "from_auto_tfvars_overridden" {
+  type = string
+}
+
+variable "from_auto_workspace_tfvars" {
+  type = string
+}
+
+variable "from_auto_workspace_overridden" {
+  type = string
+}
+
+resource "test_resource" "terraform_tfvars_resource" {
+  value = var.from_terraform_tfvars
+}
+
+resource "test_resource" "auto_tfvars_resource" {
+  value = var.from_auto_tfvars
+}
+
+resource "test_resource" "auto_tfvars_overridden_resource" {
+  value = var.from_auto_tfvars_overridden
+}
+
+resource "test_resource" "auto_workspace_resource" {
+  value = var.from_auto_workspace_tfvars
+}
+
+resource "test_resource" "auto_workspace_overridden_resource" {
+  value = var.from_auto_workspace_overridden
+}

--- a/internal/command/testdata/test/variables_tfvars/main.tftest.hcl
+++ b/internal/command/testdata/test/variables_tfvars/main.tftest.hcl
@@ -1,0 +1,26 @@
+run "check_variables_set" {
+  assert {
+    condition = test_resource.terraform_tfvars_resource.value == "foo"
+    error_message = "Not able to read from terraform.tfvars"
+  }
+
+  assert {
+    condition = test_resource.auto_tfvars_resource.value == "bar"
+    error_message = "Not able to read from *.auto.tfvars"
+  }
+
+  assert {
+    condition = test_resource.auto_tfvars_overridden_resource.value == "bbar"
+    error_message = "Value not overridden loading from *.auto.tfvars"
+  }
+
+  assert {
+    condition = test_resource.auto_workspace_resource.value == "foobar"
+    error_message = "Not able to read from *.auto.default.tfvars"
+  }
+
+  assert {
+    condition = test_resource.auto_workspace_overridden_resource.value == "cban"
+    error_message = "Value not overridden loading from *.auto.default.tfvars"
+  }
+}

--- a/internal/command/testdata/test/variables_tfvars/terraform.tfvars
+++ b/internal/command/testdata/test/variables_tfvars/terraform.tfvars
@@ -1,0 +1,1 @@
+from_terraform_tfvars="foo"


### PR DESCRIPTION
Automatically loads variable definitions files ending with .auto.\<workspace\>.tfvars and .auto.\<workspace\>.tfvars.json. \<workspace\> is the name of the active workspace.

Fixes #15966

## Target Release
1.6.x

### ENHANCEMENTS
- Support conditionally auto loading tfvars on workspace  
