### PR TITLE
import blocks are evaluated in the root module

### DIFF
--- a/internal/terraform/eval_import.go
+++ b/internal/terraform/eval_import.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/tfdiags"
 	"github.com/zclconf/go-cty/cty"
 	"github.com/zclconf/go-cty/cty/gocty"
@@ -14,6 +15,10 @@ import (
 
 func evaluateImportIdExpression(expr hcl.Expression, ctx EvalContext) (string, tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
+
+	// import blocks only exist in the root module, and must be evaluated in
+	// that context.
+	ctx = ctx.WithPath(addrs.RootModuleInstance)
 
 	if expr == nil {
 		return "", diags.Append(&hcl.Diagnostic{

--- a/internal/terraform/node_resource_abstract.go
+++ b/internal/terraform/node_resource_abstract.go
@@ -87,6 +87,7 @@ type NodeAbstractResource struct {
 var (
 	_ GraphNodeReferenceable               = (*NodeAbstractResource)(nil)
 	_ GraphNodeReferencer                  = (*NodeAbstractResource)(nil)
+	_ GraphNodeImportReferencer            = (*NodeAbstractResource)(nil)
 	_ GraphNodeProviderConsumer            = (*NodeAbstractResource)(nil)
 	_ GraphNodeProvisionerConsumer         = (*NodeAbstractResource)(nil)
 	_ GraphNodeConfigResource              = (*NodeAbstractResource)(nil)
@@ -205,11 +206,15 @@ func (n *NodeAbstractResource) References() []*addrs.Reference {
 		}
 	}
 
+	return result
+}
+
+func (n *NodeAbstractResource) ImportReferences() []*addrs.Reference {
+	var result []*addrs.Reference
 	for _, importTarget := range n.importTargets {
 		refs, _ := lang.ReferencesInExpr(addrs.ParseRef, importTarget.ID)
 		result = append(result, refs...)
 	}
-
 	return result
 }
 

--- a/internal/terraform/node_resource_plan.go
+++ b/internal/terraform/node_resource_plan.go
@@ -56,6 +56,7 @@ var (
 	_ GraphNodeDynamicExpandable    = (*nodeExpandPlannableResource)(nil)
 	_ GraphNodeReferenceable        = (*nodeExpandPlannableResource)(nil)
 	_ GraphNodeReferencer           = (*nodeExpandPlannableResource)(nil)
+	_ GraphNodeImportReferencer     = (*nodeExpandPlannableResource)(nil)
 	_ GraphNodeConfigResource       = (*nodeExpandPlannableResource)(nil)
 	_ GraphNodeAttachResourceConfig = (*nodeExpandPlannableResource)(nil)
 	_ GraphNodeAttachDependencies   = (*nodeExpandPlannableResource)(nil)

--- a/internal/terraform/testdata/import-id-variable/main.tf
+++ b/internal/terraform/testdata/import-id-variable/main.tf
@@ -9,3 +9,13 @@ import {
 
 resource "aws_instance" "foo" {
 }
+
+module "test" {
+  source = "./mod"
+}
+
+import {
+  to = module.test.aws_instance.foo
+  id = var.the_id
+}
+

--- a/internal/terraform/testdata/import-id-variable/mod/main.tf
+++ b/internal/terraform/testdata/import-id-variable/mod/main.tf
@@ -1,0 +1,2 @@
+resource "aws_instance" "foo" {
+}

--- a/internal/terraform/transform_reference.go
+++ b/internal/terraform/transform_reference.go
@@ -297,8 +297,9 @@ func (m ReferenceMap) References(v dag.Vertex) []dag.Vertex {
 
 	for _, ref := range rn.References() {
 		subject := ref.Subject
+		refPath := vertexReferencePath(v)
 
-		key := m.referenceMapKey(v, subject)
+		key := m.referenceMapKey(refPath, subject)
 		if _, exists := m[key]; !exists {
 			// If what we were looking for was a ResourceInstance then we
 			// might be in a resource-oriented graph rather than an
@@ -317,7 +318,7 @@ func (m ReferenceMap) References(v dag.Vertex) []dag.Vertex {
 				log.Printf("[INFO] ReferenceTransformer: reference not found: %q", subject)
 				continue
 			}
-			key = m.referenceMapKey(v, subject)
+			key = m.referenceMapKey(refPath, subject)
 		}
 		vertices := m[key]
 		for _, rv := range vertices {
@@ -352,7 +353,7 @@ func (m ReferenceMap) dependsOn(g *Graph, depender graphNodeDependsOn) ([]dag.Ve
 	for _, ref := range refs {
 		subject := ref.Subject
 
-		key := m.referenceMapKey(depender, subject)
+		key := m.referenceMapKey(vertexReferencePath(depender), subject)
 		vertices, ok := m[key]
 		if !ok {
 			// the ReferenceMap generates all possible keys, so any warning
@@ -521,8 +522,7 @@ func vertexReferencePath(v dag.Vertex) addrs.Module {
 //
 // Only GraphNodeModulePath implementations can be referrers, so this method will
 // panic if the given vertex does not implement that interface.
-func (m *ReferenceMap) referenceMapKey(referrer dag.Vertex, addr addrs.Referenceable) string {
-	path := vertexReferencePath(referrer)
+func (m *ReferenceMap) referenceMapKey(path addrs.Module, addr addrs.Referenceable) string {
 	return m.mapKey(path, addr)
 }
 

--- a/internal/terraform/transform_reference.go
+++ b/internal/terraform/transform_reference.go
@@ -42,6 +42,15 @@ type GraphNodeReferencer interface {
 	References() []*addrs.Reference
 }
 
+// GraphNodeReferencer must be implemented by nodes that import resources.
+type GraphNodeImportReferencer interface {
+	GraphNodeReferencer
+
+	// ImportReferences returns a list of references made by this node's
+	// associated import block.
+	ImportReferences() []*addrs.Reference
+}
+
 type GraphNodeAttachDependencies interface {
 	GraphNodeConfigResource
 	AttachDependencies([]addrs.ConfigResource)
@@ -288,38 +297,23 @@ type ReferenceMap map[string][]dag.Vertex
 // References returns the set of vertices that the given vertex refers to,
 // and any referenced addresses that do not have corresponding vertices.
 func (m ReferenceMap) References(v dag.Vertex) []dag.Vertex {
-	rn, ok := v.(GraphNodeReferencer)
-	if !ok {
-		return nil
+	var matches []dag.Vertex
+	var referenceKeys []string
+
+	if rn, ok := v.(GraphNodeReferencer); ok {
+		for _, ref := range rn.References() {
+			referenceKeys = append(referenceKeys, m.referenceMapKey(vertexReferencePath(v), ref.Subject))
+		}
 	}
 
-	var matches []dag.Vertex
-
-	for _, ref := range rn.References() {
-		subject := ref.Subject
-		refPath := vertexReferencePath(v)
-
-		key := m.referenceMapKey(refPath, subject)
-		if _, exists := m[key]; !exists {
-			// If what we were looking for was a ResourceInstance then we
-			// might be in a resource-oriented graph rather than an
-			// instance-oriented graph, and so we'll see if we have the
-			// resource itself instead.
-			switch ri := subject.(type) {
-			case addrs.ResourceInstance:
-				subject = ri.ContainingResource()
-			case addrs.ResourceInstancePhase:
-				subject = ri.ContainingResource()
-			case addrs.ModuleCallInstanceOutput:
-				subject = ri.ModuleCallOutput()
-			case addrs.ModuleCallInstance:
-				subject = ri.Call
-			default:
-				log.Printf("[INFO] ReferenceTransformer: reference not found: %q", subject)
-				continue
-			}
-			key = m.referenceMapKey(refPath, subject)
+	if rn, ok := v.(GraphNodeImportReferencer); ok {
+		for _, ref := range rn.ImportReferences() {
+			// import block references are always in the root module scope
+			referenceKeys = append(referenceKeys, m.referenceMapKey(addrs.RootModule, ref.Subject))
 		}
+	}
+
+	for _, key := range referenceKeys {
 		vertices := m[key]
 		for _, rv := range vertices {
 			// don't include self-references
@@ -329,7 +323,6 @@ func (m ReferenceMap) References(v dag.Vertex) []dag.Vertex {
 			matches = append(matches, rv)
 		}
 	}
-
 	return matches
 }
 
@@ -522,8 +515,30 @@ func vertexReferencePath(v dag.Vertex) addrs.Module {
 //
 // Only GraphNodeModulePath implementations can be referrers, so this method will
 // panic if the given vertex does not implement that interface.
-func (m *ReferenceMap) referenceMapKey(path addrs.Module, addr addrs.Referenceable) string {
-	return m.mapKey(path, addr)
+func (m ReferenceMap) referenceMapKey(path addrs.Module, addr addrs.Referenceable) string {
+	key := m.mapKey(path, addr)
+	if _, exists := m[key]; !exists {
+		// If what we were looking for was a ResourceInstance then we
+		// might be in a resource-oriented graph rather than an
+		// instance-oriented graph, and so we'll see if we have the
+		// resource itself instead.
+		switch ri := addr.(type) {
+		case addrs.ResourceInstance:
+			addr = ri.ContainingResource()
+		case addrs.ResourceInstancePhase:
+			addr = ri.ContainingResource()
+		case addrs.ModuleCallInstanceOutput:
+			addr = ri.ModuleCallOutput()
+		case addrs.ModuleCallInstance:
+			addr = ri.Call
+		default:
+			return key
+		}
+		// if we matched any of the resource node types above, generate a new
+		// key
+		key = m.mapKey(path, addr)
+	}
+	return key
 }
 
 // NewReferenceMap is used to create a new reference map for the


### PR DESCRIPTION
Even though import block evaluation is done in conjunction with their target resource block, their evaluation scope must always be the containing module of the import block. Since import blocks currently are only valid in the root module, that means the context must always always be the root module.

The references for the import evaluation must also be scoped to the root module where the block was written. In order to accomplish that without adding a new import node type to the graph, we instead can opt to add a new method (and associated `GraphNodeImportReferencer` interface) which separates the import references from the config references. The `ReferenceTransformer` can then use the correct root module path to lookup the referenced subjects when they come from `ImportReferences` as opposed to `References`.

Fixes #33896