### PR TITLE
backend/s3: set required or optional for single nested attributes

### DIFF
--- a/internal/backend/remote-state/s3/backend.go
+++ b/internal/backend/remote-state/s3/backend.go
@@ -1647,6 +1647,7 @@ var _ schemaAttribute = singleNestedAttribute{}
 
 type singleNestedAttribute struct {
 	Attributes objectSchema
+	Required   bool
 	validateObject
 }
 
@@ -1656,6 +1657,8 @@ func (a singleNestedAttribute) SchemaAttribute() *configschema.Attribute {
 			Nesting:    configschema.NestingSingle,
 			Attributes: a.Attributes.SchemaAttributes(),
 		},
+		Required: a.Required,
+		Optional: !a.Required,
 	}
 }
 


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->
Adjusts the `singleNestedAttribute` struct such that one of `Required` or `Optional` is always set to `true` on the underlying schema. Defaults to optional. Previously the single nested attribute type arguments (`assume_role`, `assume_role_with_web_identity`, and `endpoints`) did not set either `Required` or `Optional` to `true`. This resulted in failures coercing the `terraform_remote_state` data sources `config` argument to the updated backend schema in 1.6.0. See the linked issue for additional context.

Before:
```console
% go test ./internal/backend/remote-state/s3/... -run="^TestBackend_CoerceValue/basic$"
--- FAIL: TestBackend_CoerceValue (0.00s)
    --- FAIL: TestBackend_CoerceValue/basic (0.00s)
        backend_test.go:2129: wrong error
            got:  attribute "assume_role_with_web_identity" is required
            want:
FAIL
FAIL    github.com/hashicorp/terraform/internal/backend/remote-state/s3 0.448s
FAIL
```

After:

```console
% go test ./internal/backend/remote-state/s3/... -run="^TestBackend_CoerceValue/basic$"
ok      github.com/hashicorp/terraform/internal/backend/remote-state/s3 0.498s
```

Full acceptance test suite:

```console
% TF_ACC=1 go test ./internal/backend/remote-state/s3/...
ok      github.com/hashicorp/terraform/internal/backend/remote-state/s3 129.561s
```


<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Fixes #33884
Relates #33872
Relates #33687

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.6.x

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->



<!--

Write a short description of the user-facing change. Examples:

- `terraform show -json`: Fixed crash with sensitive set values.
- When rendering a diff, Terraform now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 

N/a - fixes existing functionality.
