### PR TITLE
configschema: CoerceValue error for omitted attribute requirements

### DIFF
--- a/internal/configs/configschema/coerce_value.go
+++ b/internal/configs/configschema/coerce_value.go
@@ -67,8 +67,10 @@ func (b *Block) coerceValue(in cty.Value, path cty.Path) (cty.Value, error) {
 			val = in.GetAttr(name)
 		case attrS.Computed || attrS.Optional:
 			val = cty.NullVal(attrType)
-		default:
+		case attrS.Required:
 			return cty.UnknownVal(impliedType), path.NewErrorf("attribute %q is required", name)
+		default:
+			return cty.UnknownVal(impliedType), path.NewErrorf("attribute %q has none of required, optional, or computed set", name)
 		}
 
 		val, err := convert.Convert(val, attrConvType)

--- a/internal/configs/configschema/coerce_value_test.go
+++ b/internal/configs/configschema/coerce_value_test.go
@@ -446,6 +446,20 @@ func TestCoerceValue(t *testing.T) {
 			}),
 			``,
 		},
+		"omitted attribute requirements": {
+			&Block{
+				Attributes: map[string]*Attribute{
+					"foo": {
+						Type: cty.String,
+					},
+				},
+			},
+			cty.EmptyObjectVal,
+			cty.ObjectVal(map[string]cty.Value{
+				"foo": cty.UnknownVal(cty.String),
+			}),
+			`attribute "foo" has none of required, optional, or computed set`,
+		},
 		"dynamic value attributes": {
 			&Block{
 				BlockTypes: map[string]*NestedBlock{


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->
Adds a new error case to the `configschema.CoerceValue` function which provides improved messaging in cases where an attribute has none of `Required`, `Optional`, or `Computed` set to `true`. Previously this condition resulted in an error message like:

```
attribute "foo" is required
```

With this proposed change the messaging would change to:

```
attribute "foo" has none of required, optional, or computed set
```

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Relates #33884 - The S3 backend had misconfigured nested attributes which _should_ have been optional, but instead omitted requirements entirely. When referenced by the `terraform_remote_state` data source, this resulted in a failed value coercion and an error message stating these attributes were required. With this change the error message would have instead stated the real issue - that no requirements were defined for the attribute at all, resulting in insufficient information on how to coerce the value into the target.

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.6.x

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->


<!--

Write a short description of the user-facing change. Examples:

- `terraform show -json`: Fixed crash with sensitive set values.
- When rendering a diff, Terraform now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 

N/a - not a user facing change
