### PR TITLE
Backport of backend/s3: Add wrong bucket region handling to all of S3 client into v1.6

### DIFF
--- a/internal/backend/remote-state/s3/backend_state.go
+++ b/internal/backend/remote-state/s3/backend_state.go
@@ -55,7 +55,7 @@ func (b *Backend) Workspaces() ([]string, error) {
 
 	pages := s3.NewListObjectsV2Paginator(b.s3Client, params)
 	for pages.HasMorePages() {
-		page, err := pages.NextPage(ctx, s3.WithAPIOptions(addS3WrongRegionErrorMiddleware))
+		page, err := pages.NextPage(ctx)
 		if err != nil {
 			if IsA[*s3types.NoSuchBucket](err) {
 				return nil, fmt.Errorf(errS3NoSuchBucket, b.bucketName, err)

--- a/internal/backend/remote-state/s3/middleware.go
+++ b/internal/backend/remote-state/s3/middleware.go
@@ -1,0 +1,52 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package s3
+
+import (
+	"context"
+	"net/http"
+
+	awsmiddleware "github.com/aws/aws-sdk-go-v2/aws/middleware"
+	"github.com/aws/smithy-go"
+	"github.com/aws/smithy-go/middleware"
+	smithyhttp "github.com/aws/smithy-go/transport/http"
+)
+
+func addS3WrongRegionErrorMiddleware(stack *middleware.Stack) error {
+	return stack.Deserialize.Insert(
+		&s3WrongRegionErrorMiddleware{},
+		"ResponseErrorWrapper",
+		middleware.After,
+	)
+}
+
+var _ middleware.DeserializeMiddleware = &s3WrongRegionErrorMiddleware{}
+
+type s3WrongRegionErrorMiddleware struct{}
+
+func (m *s3WrongRegionErrorMiddleware) ID() string {
+	return "tf_S3WrongRegionErrorMiddleware"
+}
+
+func (m *s3WrongRegionErrorMiddleware) HandleDeserialize(ctx context.Context, in middleware.DeserializeInput, next middleware.DeserializeHandler) (
+	out middleware.DeserializeOutput, metadata middleware.Metadata, err error,
+) {
+	out, metadata, err = next.HandleDeserialize(ctx, in)
+	if err == nil || !IsA[*smithy.GenericAPIError](err) {
+		return out, metadata, err
+	}
+
+	resp, ok := out.RawResponse.(*smithyhttp.Response)
+	if !ok || resp.StatusCode != http.StatusMovedPermanently {
+		return out, metadata, err
+	}
+
+	reqRegion := awsmiddleware.GetRegion(ctx)
+
+	bucketRegion := resp.Header.Get("X-Amz-Bucket-Region")
+
+	err = newBucketRegionError(reqRegion, bucketRegion)
+
+	return out, metadata, err
+}

--- a/internal/backend/remote-state/s3/middleware.go
+++ b/internal/backend/remote-state/s3/middleware.go
@@ -13,6 +13,8 @@ import (
 	smithyhttp "github.com/aws/smithy-go/transport/http"
 )
 
+// This will not be needed once https://github.com/aws/aws-sdk-go-v2/issues/2282
+// is addressed
 func addS3WrongRegionErrorMiddleware(stack *middleware.Stack) error {
 	return stack.Deserialize.Insert(
 		&s3WrongRegionErrorMiddleware{},


### PR DESCRIPTION
Backport of #33885

---

Uses a middleware handler to return `bucketRegionError` for all S3 operations.

Works around https://github.com/aws/aws-sdk-go-v2/issues/2282

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.6.0

## Draft CHANGELOG entry

Not user facing