### PR TITLE
Update requirements.mdx

### DIFF
--- a/website/docs/language/providers/requirements.mdx
+++ b/website/docs/language/providers/requirements.mdx
@@ -117,7 +117,7 @@ primary location where Terraform can download it.
 Source addresses consist of three parts delimited by slashes (`/`), as
 follows:
 
-`[<HOSTNAME/>]<NAMESPACE>/<TYPE>`
+`[<HOSTNAME>/]<NAMESPACE>/<TYPE>`
 
 Examples of valid provider formats include 
 - `NAMESPACE/TYPE`

--- a/website/docs/language/providers/requirements.mdx
+++ b/website/docs/language/providers/requirements.mdx
@@ -121,7 +121,7 @@ follows:
 
 Examples of valid provider source address formats include:
 - `NAMESPACE/TYPE`
-- `HOSTNAME/NAMESPACE/TYPE` 
+- `HOSTNAME/NAMESPACE/TYPE`
 
 * **Hostname** (optional): The hostname of the Terraform registry that
   distributes the provider. If omitted, this defaults to

--- a/website/docs/language/providers/requirements.mdx
+++ b/website/docs/language/providers/requirements.mdx
@@ -117,7 +117,11 @@ primary location where Terraform can download it.
 Source addresses consist of three parts delimited by slashes (`/`), as
 follows:
 
-`[<HOSTNAME>]/<NAMESPACE>/<TYPE>`
+`[<HOSTNAME/>]<NAMESPACE>/<TYPE>`
+
+Examples of valid provider formats include 
+- `NAMESPACE/TYPE`
+- `HOSTNAME/NAMESPACE/TYPE`
 
 * **Hostname** (optional): The hostname of the Terraform registry that
   distributes the provider. If omitted, this defaults to

--- a/website/docs/language/providers/requirements.mdx
+++ b/website/docs/language/providers/requirements.mdx
@@ -121,7 +121,7 @@ follows:
 
 Examples of valid provider formats include 
 - `NAMESPACE/TYPE`
-- `HOSTNAME/NAMESPACE/TYPE`
+- `HOSTNAME/NAMESPACE/TYPE` 
 
 * **Hostname** (optional): The hostname of the Terraform registry that
   distributes the provider. If omitted, this defaults to

--- a/website/docs/language/providers/requirements.mdx
+++ b/website/docs/language/providers/requirements.mdx
@@ -117,7 +117,7 @@ primary location where Terraform can download it.
 Source addresses consist of three parts delimited by slashes (`/`), as
 follows:
 
-`[<HOSTNAME>/]<NAMESPACE>/<TYPE>`
+`[<HOSTNAME>]/<NAMESPACE>/<TYPE>`
 
 * **Hostname** (optional): The hostname of the Terraform registry that
   distributes the provider. If omitted, this defaults to

--- a/website/docs/language/providers/requirements.mdx
+++ b/website/docs/language/providers/requirements.mdx
@@ -119,7 +119,7 @@ follows:
 
 `[<HOSTNAME>/]<NAMESPACE>/<TYPE>`
 
-Examples of valid provider formats include 
+Examples of valid provider source address formats include:
 - `NAMESPACE/TYPE`
 - `HOSTNAME/NAMESPACE/TYPE` 
 


### PR DESCRIPTION
Provider source address delimiter separator / was within the hostname portion before closing bracket ']' and same has been corrected
file - /main/website/docs/language/providers/requirements.mdx

Original Line 120
`[<HOSTNAME>/]<NAMESPACE>/<TYPE>`

Updated
`[<HOSTNAME>]/<NAMESPACE>/<TYPE>`

<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Fixes #33911

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.5.x

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

### UPGRADE NOTES 

<!--

Write a short description of the user-facing change. Examples:

- `terraform show -json`: Fixed crash with sensitive set values.
- When rendering a diff, Terraform now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 

-  Provider source address delimiter placement correction from `[<HOSTNAME>/]<NAMESPACE>/<TYPE>` to `[<HOSTNAME>]/<NAMESPACE>/<TYPE>`
