### PR TITLE
Fix panic when tests on TFC exit early

### DIFF
--- a/internal/cloud/test.go
+++ b/internal/cloud/test.go
@@ -232,6 +232,18 @@ func (runner *TestSuiteRunner) Test() (moduletest.Status, tfdiags.Diagnostics) {
 		return moduletest.Error, diags
 	}
 
+	if run.Status != tfe.TestRunFinished {
+		// The only reason we'd get here without the run being finished properly
+		// is because the run errored outside the scope of the tests, or because
+		// the run was cancelled. Either way, we can just mark it has having
+		// errored for the purpose of our return code.
+		return moduletest.Error, diags
+	}
+
+	// Otherwise the run has finished successfully, and we can look at the
+	// actual status of the test instead of the run to figure out what status we
+	// should return.
+
 	switch run.TestStatus {
 	case tfe.TestError:
 		return moduletest.Error, diags

--- a/internal/cloud/tfe_client_mock.go
+++ b/internal/cloud/tfe_client_mock.go
@@ -1685,6 +1685,7 @@ func (m *MockTestRuns) Read(ctx context.Context, moduleID tfe.RegistryModuleID, 
 			tr.Status = tfe.TestRunRunning
 		case tfe.TestRunRunning:
 			tr.Status = tfe.TestRunFinished
+			tr.TestStatus = tfe.TestPass
 		}
 
 		return tr, nil
@@ -1707,7 +1708,6 @@ func (m *MockTestRuns) Create(ctx context.Context, options tfe.TestRunCreateOpti
 		ID:         id,
 		LogReadURL: url,
 		Status:     tfe.TestRunQueued,
-		TestStatus: tfe.TestPass, // Default the test runs we create to passing.
 
 		ConfigurationVersion: options.ConfigurationVersion,
 		RegistryModule:       options.RegistryModule,
@@ -1753,6 +1753,7 @@ func (m *MockTestRuns) Logs(ctx context.Context, moduleID tfe.RegistryModuleID, 
 			// Update the status so that on the next call it thinks it's
 			// finished.
 			tr.Status = tfe.TestRunFinished
+			tr.TestStatus = tfe.TestPass
 			return false, nil
 
 		case tfe.TestRunFinished, tfe.TestRunCanceled:


### PR DESCRIPTION
In some cases, for example a cancellation before the tests start executing because the test run is still in the queue or because of an error in atlas or the agent of some kind, we don't set the `TestStatus` on run object returned by TFC.

Previously, we were only looking at this when trying to work out the overall status of the run. This was causing a panic as an empty status was entering an unknown default branch of a switch statement. Now we look at the overall status of the Terraform Cloud run, and only look at the specific test status if overall run has been marked as finished.

I've updated our local mocks to reflect this behaviour, and was able to replicate. So the mocks have been updated and we don't need to add a new test just for this.