### PR TITLE
Refactor cloud test run cancellation logic to always intercept signals

### DIFF
--- a/internal/cloud/test.go
+++ b/internal/cloud/test.go
@@ -437,8 +437,12 @@ func (runner *TestSuiteRunner) wait(ctx context.Context, client *tfe.Client, run
 
 	select {
 	case <-runner.StoppedCtx.Done():
+		// The StoppedCtx is passed in from the command package, which is
+		// listening for interrupts from the user. After the first interrupt the
+		// StoppedCtx is triggered.
 		handleStopped()
 	case <-runner.CancelledCtx.Done():
+		// After the second interrupt the CancelledCtx is triggered.
 		handleCancelled()
 	case <-ctx.Done():
 		// The remote run finished normally! Do nothing.


### PR DESCRIPTION
This PR updates the cancellation logic so that it continues listen for signals even while it is reading the logs from a cloud run.

Previously, we only listened for interrupt signal while we were waiting for the tests to start. Now, we are intercepting the signal at all times during the process. I've added a test that triggers the cancel signal during the log reading process, and then validates it still correctly marks the test run as being cancelled.