### PR TITLE
backend/s3: Supports S3 buckets with Object Lock

### DIFF
--- a/internal/backend/remote-state/s3/backend_test.go
+++ b/internal/backend/remote-state/s3/backend_test.go
@@ -1809,6 +1809,30 @@ func TestBackendWrongRegion(t *testing.T) {
 	}
 }
 
+func TestBackendS3ObjectLock(t *testing.T) {
+	testACC(t)
+
+	ctx := context.TODO()
+
+	bucketName := fmt.Sprintf("terraform-remote-s3-test-%x", time.Now().Unix())
+	keyName := "testState"
+
+	b := backend.TestBackendConfig(t, New(), backend.TestWrapConfig(map[string]interface{}{
+		"bucket":  bucketName,
+		"key":     keyName,
+		"encrypt": true,
+		"region":  "us-west-1",
+	})).(*Backend)
+
+	createS3Bucket(ctx, t, b.s3Client, bucketName, b.awsConfig.Region,
+		s3BucketWithVersioning,
+		s3BucketWithObjectLock(s3types.ObjectLockRetentionModeCompliance),
+	)
+	defer deleteS3Bucket(ctx, t, b.s3Client, bucketName, b.awsConfig.Region)
+
+	backend.TestBackendStates(t, b)
+}
+
 func TestKeyEnv(t *testing.T) {
 	testACC(t)
 
@@ -2156,16 +2180,31 @@ func checkStateList(b backend.Backend, expected []string) error {
 	return nil
 }
 
-func createS3Bucket(ctx context.Context, t *testing.T, s3Client *s3.Client, bucketName, region string) {
+type createS3BucketOptions struct {
+	versioning     bool
+	objectLockMode s3types.ObjectLockRetentionMode
+}
+
+type createS3BucketOptionsFunc func(*createS3BucketOptions)
+
+func createS3Bucket(ctx context.Context, t *testing.T, s3Client *s3.Client, bucketName, region string, optFns ...createS3BucketOptionsFunc) {
 	t.Helper()
 
+	var opts createS3BucketOptions
+	for _, f := range optFns {
+		f(&opts)
+	}
+
 	createBucketReq := &s3.CreateBucketInput{
-		Bucket: &bucketName,
+		Bucket: aws.String(bucketName),
 	}
 	if region != "us-east-1" {
 		createBucketReq.CreateBucketConfiguration = &s3types.CreateBucketConfiguration{
 			LocationConstraint: s3types.BucketLocationConstraint(region),
 		}
+	}
+	if opts.objectLockMode != "" {
+		createBucketReq.ObjectLockEnabledForBucket = true
 	}
 
 	// Be clear about what we're doing in case the user needs to clean
@@ -2174,6 +2213,46 @@ func createS3Bucket(ctx context.Context, t *testing.T, s3Client *s3.Client, buck
 	_, err := s3Client.CreateBucket(ctx, createBucketReq, s3WithRegion(region))
 	if err != nil {
 		t.Fatal("failed to create test S3 bucket:", err)
+	}
+
+	if opts.versioning {
+		_, err := s3Client.PutBucketVersioning(ctx, &s3.PutBucketVersioningInput{
+			Bucket: aws.String(bucketName),
+			VersioningConfiguration: &s3types.VersioningConfiguration{
+				Status: s3types.BucketVersioningStatusEnabled,
+			},
+		})
+		if err != nil {
+			t.Fatalf("failed enabling versioning: %s", err)
+		}
+	}
+
+	if opts.objectLockMode != "" {
+		_, err = s3Client.PutObjectLockConfiguration(ctx, &s3.PutObjectLockConfigurationInput{
+			Bucket: aws.String(bucketName),
+			ObjectLockConfiguration: &s3types.ObjectLockConfiguration{
+				ObjectLockEnabled: s3types.ObjectLockEnabledEnabled,
+				Rule: &s3types.ObjectLockRule{
+					DefaultRetention: &s3types.DefaultRetention{
+						Days: 1,
+						Mode: opts.objectLockMode,
+					},
+				},
+			},
+		})
+		if err != nil {
+			t.Fatalf("failed enabling object locking: %s", err)
+		}
+	}
+}
+
+func s3BucketWithVersioning(opts *createS3BucketOptions) {
+	opts.versioning = true
+}
+
+func s3BucketWithObjectLock(mode s3types.ObjectLockRetentionMode) createS3BucketOptionsFunc {
+	return func(opts *createS3BucketOptions) {
+		opts.objectLockMode = mode
 	}
 }
 

--- a/internal/backend/remote-state/s3/client.go
+++ b/internal/backend/remote-state/s3/client.go
@@ -193,11 +193,11 @@ func (c *RemoteClient) Put(data []byte) error {
 	sum := md5.Sum(data)
 
 	input := &s3.PutObjectInput{
-		ContentType: aws.String(contentType),
-		Body:        bytes.NewReader(data),
-		Bucket:      aws.String(c.bucketName),
-		Key:         aws.String(c.path),
-		ContentMD5:  aws.String(base64.StdEncoding.EncodeToString(sum[:])),
+		ContentType:       aws.String(contentType),
+		Body:              bytes.NewReader(data),
+		Bucket:            aws.String(c.bucketName),
+		Key:               aws.String(c.path),
+		ChecksumAlgorithm: s3types.ChecksumAlgorithmSha256,
 	}
 
 	if c.serverSideEncryption {

--- a/internal/backend/remote-state/s3/client.go
+++ b/internal/backend/remote-state/s3/client.go
@@ -190,11 +190,14 @@ func (c *RemoteClient) Put(data []byte) error {
 
 	contentType := "application/json"
 
+	sum := md5.Sum(data)
+
 	input := &s3.PutObjectInput{
 		ContentType: aws.String(contentType),
 		Body:        bytes.NewReader(data),
 		Bucket:      aws.String(c.bucketName),
 		Key:         aws.String(c.path),
+		ContentMD5:  aws.String(base64.StdEncoding.EncodeToString(sum[:])),
 	}
 
 	if c.serverSideEncryption {
@@ -222,7 +225,6 @@ func (c *RemoteClient) Put(data []byte) error {
 		return fmt.Errorf("failed to upload state: %s", err)
 	}
 
-	sum := md5.Sum(data)
 	if err := c.putMD5(ctx, sum[:]); err != nil {
 		// if this errors out, we unfortunately have to error out altogether,
 		// since the next Get will inevitably fail.


### PR DESCRIPTION
Enables checksum in `PutObject` and `UploadPart` requests to support S3 buckets with Object Lock enabled.

Fixes #23127

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.6.0

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

### BUG FIXES

<!--

Write a short description of the user-facing change. Examples:

- `terraform show -json`: Fixed crash with sensitive set values.
- When rendering a diff, Terraform now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 

-  S3 Backend: Fixes error when storing state in S3 buckets with Object Locks enabled
