### PR TITLE
cloud: Fix typo & align `project` field description

### DIFF
--- a/internal/cloud/backend.go
+++ b/internal/cloud/backend.go
@@ -1274,5 +1274,6 @@ is the primary and recommended strategy to use.  This option conflicts with "nam
 	schemaDescriptionName = `The name of a single Terraform Cloud workspace to be used with this configuration.
 When configured, only the specified workspace can be used. This option conflicts with "tags".`
 
-	schemaDescriptionProject = `The name of a project that resulting workspace(s) will be created in.`
+	schemaDescriptionProject = `The name of a Terraform Cloud project. Workspaces that need creating
+will be created within this project.`
 )

--- a/website/docs/cli/cloud/settings.mdx
+++ b/website/docs/cli/cloud/settings.mdx
@@ -76,7 +76,7 @@ The `cloud` block supports the following configuration arguments:
     directory, and cannot manage workspaces from the CLI (e.g. `terraform workspace select` or
     `terraform workspace new`). This option conflicts with `tags`.
 
-  - `project` - (Optional) The name of a Terraform Cloud project. Workspaces that need created will
+  - `project` - (Optional) The name of a Terraform Cloud project. Workspaces that need creating
     will be created within this project. `terraform workspace list` will be filtered by workspaces
     in the supplied project.
 


### PR DESCRIPTION
This fixes a typo in the markdown docs and aligns the description in code with the description in markdown. AFAICT the description in code isn't currently used anywhere.

## Target Release

1.6.x
