### PR TITLE
Test files should be marked as skipped if all their run blocks were skipped

### DIFF
--- a/internal/command/testdata/test/with_interrupt_and_additional_file/main.tf
+++ b/internal/command/testdata/test/with_interrupt_and_additional_file/main.tf
@@ -1,0 +1,25 @@
+
+variable "interrupts" {
+  type = number
+}
+
+resource "test_resource" "primary" {
+  value = "primary"
+}
+
+resource "test_resource" "secondary" {
+  value = "secondary"
+  interrupt_count = var.interrupts
+
+  depends_on = [
+    test_resource.primary
+  ]
+}
+
+resource "test_resource" "tertiary" {
+  value = "tertiary"
+
+  depends_on = [
+    test_resource.secondary
+  ]
+}

--- a/internal/command/testdata/test/with_interrupt_and_additional_file/main.tftest.hcl
+++ b/internal/command/testdata/test/with_interrupt_and_additional_file/main.tftest.hcl
@@ -1,0 +1,17 @@
+variables {
+  interrupts = 0
+}
+
+run "primary" {
+
+}
+
+run "secondary" {
+  variables {
+    interrupts = 1
+  }
+}
+
+run "tertiary" {
+
+}

--- a/internal/command/testdata/test/with_interrupt_and_additional_file/skip_me.tftest.hcl
+++ b/internal/command/testdata/test/with_interrupt_and_additional_file/skip_me.tftest.hcl
@@ -1,0 +1,9 @@
+variables {
+  interrupts = 0
+}
+
+run "primary" {}
+
+run "secondary" {}
+
+run "tertiary" {}


### PR DESCRIPTION
This change will also explicitly mark test files that are fatally interrupted as having errored.