### PR TITLE
Implement double cancel instead of force cancel for test cloud runs

### DIFF
--- a/internal/cloud/test.go
+++ b/internal/cloud/test.go
@@ -400,11 +400,11 @@ func (runner *TestSuiteRunner) wait(ctx context.Context, client *tfe.Client, run
 	var diags tfdiags.Diagnostics
 
 	handleCancelled := func() {
-		if err := client.TestRuns.ForceCancel(context.Background(), moduleId, run.ID); err != nil {
+		if err := client.TestRuns.Cancel(context.Background(), moduleId, run.ID); err != nil {
 			diags = diags.Append(tfdiags.Sourceless(
 				tfdiags.Error,
-				"Could not force cancel the test run",
-				fmt.Sprintf("Terraform could not force cancel the test run, you will have to navigate to the Terraform Cloud console and cancel the test run manually.\n\nThe error message received when cancelling the test run was %s", err)))
+				"Could not cancel the test run",
+				fmt.Sprintf("Terraform could not cancel the test run, you will have to navigate to the Terraform Cloud console and cancel the test run manually.\n\nThe error message received when cancelling the test run was %s", err)))
 			return
 		}
 
@@ -419,8 +419,8 @@ func (runner *TestSuiteRunner) wait(ctx context.Context, client *tfe.Client, run
 		if err := client.TestRuns.Cancel(context.Background(), moduleId, run.ID); err != nil {
 			diags = diags.Append(tfdiags.Sourceless(
 				tfdiags.Error,
-				"Could not cancel the test run",
-				fmt.Sprintf("Terraform could not cancel the test run, you will have to navigate to the Terraform Cloud console and cancel the test run manually.\n\nThe error message received when cancelling the test run was %s", err)))
+				"Could not stop the test run",
+				fmt.Sprintf("Terraform could not stop the test run, you will have to navigate to the Terraform Cloud console and cancel the test run manually.\n\nThe error message received when stopping the test run was %s", err)))
 			return
 		}
 
@@ -441,9 +441,6 @@ func (runner *TestSuiteRunner) wait(ctx context.Context, client *tfe.Client, run
 		// listening for interrupts from the user. After the first interrupt the
 		// StoppedCtx is triggered.
 		handleStopped()
-	case <-runner.CancelledCtx.Done():
-		// After the second interrupt the CancelledCtx is triggered.
-		handleCancelled()
 	case <-ctx.Done():
 		// The remote run finished normally! Do nothing.
 	}

--- a/internal/cloud/test_test.go
+++ b/internal/cloud/test_test.go
@@ -416,6 +416,10 @@ func TestTest_Cancel(t *testing.T) {
 		clientOverride: client,
 	}
 
+	// We're only going to be able to finish this if the cancellation calls
+	// are done correctly.
+	mock.TestRuns.targetCancels = 1
+
 	var diags tfdiags.Diagnostics
 	go func() {
 		defer done()
@@ -457,6 +461,10 @@ Success! 1 passed, 0 failed, 1 skipped.
 	if tr.Status != tfe.TestRunCanceled {
 		t.Errorf("expected test run to have been cancelled but was %s", tr.Status)
 	}
+
+	if mock.TestRuns.cancels != 1 {
+		t.Errorf("incorrect number of cancels, expected 1 but was %d", mock.TestRuns.cancels)
+	}
 }
 
 // TestTest_DelayedCancel just makes sure that if we trigger the cancellation
@@ -497,6 +505,10 @@ func TestTest_DelayedCancel(t *testing.T) {
 	stopContext, stop := context.WithCancel(context.Background())
 
 	mock.TestRuns.delayedCancel = stop
+
+	// We're only going to be able to finish this if the cancellation calls
+	// are done correctly.
+	mock.TestRuns.targetCancels = 1
 
 	runner := TestSuiteRunner{
 		// Configuration data.
@@ -613,6 +625,7 @@ func TestTest_ForceCancel(t *testing.T) {
 	}
 
 	doneContext, done := context.WithCancel(context.Background())
+	stopContext, stop := context.WithCancel(context.Background())
 	cancelContext, cancel := context.WithCancel(context.Background())
 
 	runner := TestSuiteRunner{
@@ -626,7 +639,7 @@ func TestTest_ForceCancel(t *testing.T) {
 		// test.
 		Stopped:      false,
 		Cancelled:    false,
-		StoppedCtx:   context.Background(),
+		StoppedCtx:   stopContext,
 		CancelledCtx: cancelContext,
 
 		// Test Options, empty for this test.
@@ -648,13 +661,18 @@ func TestTest_ForceCancel(t *testing.T) {
 		clientOverride: client,
 	}
 
+	// We're only going to be able to finish this if the cancellation calls
+	// are done correctly.
+	mock.TestRuns.targetCancels = 2
+
 	var diags tfdiags.Diagnostics
 	go func() {
 		defer done()
 		_, diags = runner.Test()
 	}()
 
-	cancel() // immediately cancel
+	stop()
+	cancel()
 
 	// Wait for finish!
 	<-doneContext.Done()
@@ -729,5 +747,9 @@ Failure! 1 passed, 1 failed.
 	tr := mock.TestRuns.modules[module.ID][0]
 	if tr.Status != tfe.TestRunCanceled {
 		t.Errorf("expected test run to have been cancelled but was %s", tr.Status)
+	}
+
+	if mock.TestRuns.cancels != 2 {
+		t.Errorf("incorrect number of cancels, expected 2 but was %d", mock.TestRuns.cancels)
 	}
 }


### PR DESCRIPTION
This PR changes the cancellation signal to send a second `Cancel` request instead of a `ForceCancel` request.

This should make the TFC API send a second SIGINT signal instead of a SIGTERM signal which will Terraform to still handle the cancel properly within the agent.

As part of this, the cloud implementation no longer allows skipping the stopped signal to trigger the cancel signal directly (otherwise, we'd never allow two cancel signals to be triggered). I also tweaked the tests so the test runs for the cancel tests won't ever finish naturally, but must be cancelled. This makes them more robust against any potential race conditions.