### PR TITLE
Change release order of operations

### DIFF
--- a/.release/ci.hcl
+++ b/.release/ci.hcl
@@ -113,8 +113,21 @@ event "promote-production" {
   }
 }
 
-event "promote-production-docker" {
+event "crt-hook-tfc-upload" {
   depends = ["promote-production"]
+  action "crt-hook-tfc-upload" {
+    organization = "hashicorp"
+    repository = "terraform-releases"
+    workflow = "crt-hook-tfc-upload"
+  }
+
+  notification {
+    on = "always"
+  }
+}
+
+event "promote-production-docker" {
+  depends = ["crt-hook-tfc-upload"]
   action "promote-production-docker" {
     organization = "hashicorp"
     repository = "crt-workflows-common"
@@ -139,21 +152,8 @@ event "promote-production-packaging" {
   }
 }
 
-event "crt-hook-tfc-upload" {
-  depends = ["promote-production-packaging"]
-  action "crt-hook-tfc-upload" {
-    organization = "hashicorp"
-    repository = "terraform-releases"
-    workflow = "crt-hook-tfc-upload"
-  }
-
-  notification {
-    on = "always"
-  }
-}
-
 event "update-ironbank" {
-  depends = ["crt-hook-tfc-upload"]
+  depends = ["promote-production-packaging"]
   action "update-ironbank" {
     organization = "hashicorp"
     repository = "crt-workflows-common"


### PR DESCRIPTION
This PR moves the important TFC upload workflow higher up the release chain, so that it immediately happens after the binaries are published to the Releases Site, and the GitHub release is published. This will allow the team to perform other post-release steps (announcements, etc) without needing to wait for the more time-consuming linux packaging & docker publishing workflows to complete.

The team does have larger work in progress to reduce the amount of time it takes to publish the linux packages and docker images, but this is meant to help in the short term.

<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Fixes #

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.6.0
