### PR TITLE
Ss18/enhancement0

### DIFF
--- a/checkpoint.go
+++ b/checkpoint.go
@@ -32,7 +32,7 @@ func runCheckpoint(ctx context.Context, c *cliconfig.Config) {
 	}
 
 	ctx, span := tracer.Start(ctx, "HashiCorp Checkpoint")
-	_ = ctx // prevent staticcheck from complaining to avoid a maintenence hazard of having the wrong ctx in scope here
+	_ = ctx // prevent staticcheck from complaining to avoid a maintenance hazard of having the wrong ctx in scope here
 	defer span.End()
 
 	configDir, err := cliconfig.ConfigDir()

--- a/internal/addrs/instance_key.go
+++ b/internal/addrs/instance_key.go
@@ -49,7 +49,7 @@ func ParseInstanceKey(key cty.Value) (InstanceKey, error) {
 	}
 }
 
-// NoKey represents the absense of an InstanceKey, for the single instance
+// NoKey represents the absence of an InstanceKey, for the single instance
 // of a configuration object that does not use "count" or "for_each" at all.
 var NoKey InstanceKey
 

--- a/internal/addrs/instance_key_test.go
+++ b/internal/addrs/instance_key_test.go
@@ -71,7 +71,7 @@ func TestInstanceKeyString(t *testing.T) {
 			got := test.Key.String()
 			want := test.Want
 			if got != want {
-				t.Errorf("wrong result\nreciever: %s\ngot:      %s\nwant:     %s", testName, got, want)
+				t.Errorf("wrong result\nreceiver: %s\ngot:      %s\nwant:     %s", testName, got, want)
 			}
 		})
 	}

--- a/internal/addrs/module_call.go
+++ b/internal/addrs/module_call.go
@@ -126,7 +126,7 @@ func (c ModuleCallInstance) Absolute(moduleAddr ModuleInstance) ModuleInstance {
 
 // ModuleInstance returns the address of the module instance that corresponds
 // to the receiving call instance when resolved in the given calling module.
-// In other words, it returns the child module instance that the receving
+// In other words, it returns the child module instance that the receiving
 // call instance creates.
 func (c ModuleCallInstance) ModuleInstance(caller ModuleInstance) ModuleInstance {
 	return caller.Child(c.Call.Name, c.Key)
@@ -187,7 +187,7 @@ func (co ModuleCallInstanceOutput) UniqueKey() UniqueKey {
 func (co ModuleCallInstanceOutput) uniqueKeySigil() {}
 
 // AbsOutputValue returns the absolute output value address that corresponds
-// to the receving module call output address, once resolved in the given
+// to the receiving module call output address, once resolved in the given
 // calling module.
 func (co ModuleCallInstanceOutput) AbsOutputValue(caller ModuleInstance) AbsOutputValue {
 	moduleAddr := co.Call.ModuleInstance(caller)

--- a/internal/addrs/module_instance.go
+++ b/internal/addrs/module_instance.go
@@ -420,7 +420,7 @@ func (m ModuleInstance) CallInstance() (ModuleInstance, ModuleCallInstance) {
 // TargetContains implements Targetable by returning true if the given other
 // address either matches the receiver, is a sub-module-instance of the
 // receiver, or is a targetable absolute address within a module that
-// is contained within the reciever.
+// is contained within the receiver.
 func (m ModuleInstance) TargetContains(other Targetable) bool {
 	switch to := other.(type) {
 	case Module:

--- a/internal/addrs/module_source.go
+++ b/internal/addrs/module_source.go
@@ -121,7 +121,7 @@ func ParseModuleSource(raw string) (ModuleSource, error) {
 // and then create relative references within the same directory in order
 // to ensure all modules in the package are looking at a consistent filesystem
 // layout. We also assume that modules within a package are maintained together,
-// which means that cross-cutting maintenence across all of them would be
+// which means that cross-cutting maintenance across all of them would be
 // possible.
 //
 // The actual value of a ModuleSourceLocal is a normalized relative path using

--- a/internal/addrs/module_source.go
+++ b/internal/addrs/module_source.go
@@ -353,7 +353,7 @@ func (s ModuleSourceRemote) ForDisplay() string {
 // given path are both respected.
 //
 // This will return nonsense if given a registry address other than the one
-// that generated the reciever via a registry lookup.
+// that generated the receiver via a registry lookup.
 func (s ModuleSourceRemote) FromRegistry(given ModuleSourceRegistry) ModuleSourceRemote {
 	ret := s // not a pointer, so this is a shallow copy
 

--- a/internal/addrs/module_source_test.go
+++ b/internal/addrs/module_source_test.go
@@ -362,7 +362,7 @@ func TestModuleSourceRemoteFromRegistry(t *testing.T) {
 		}
 		gotAddr := remote.FromRegistry(registry)
 		if remote.Subdir != "foo" {
-			t.Errorf("FromRegistry modified the reciever; should be pure function")
+			t.Errorf("FromRegistry modified the receiver; should be pure function")
 		}
 		if registry.Subdir != "bar" {
 			t.Errorf("FromRegistry modified the given address; should be pure function")
@@ -381,7 +381,7 @@ func TestModuleSourceRemoteFromRegistry(t *testing.T) {
 		}
 		gotAddr := remote.FromRegistry(registry)
 		if remote.Subdir != "foo" {
-			t.Errorf("FromRegistry modified the reciever; should be pure function")
+			t.Errorf("FromRegistry modified the receiver; should be pure function")
 		}
 		if registry.Subdir != "" {
 			t.Errorf("FromRegistry modified the given address; should be pure function")
@@ -400,7 +400,7 @@ func TestModuleSourceRemoteFromRegistry(t *testing.T) {
 		}
 		gotAddr := remote.FromRegistry(registry)
 		if remote.Subdir != "" {
-			t.Errorf("FromRegistry modified the reciever; should be pure function")
+			t.Errorf("FromRegistry modified the receiver; should be pure function")
 		}
 		if registry.Subdir != "bar" {
 			t.Errorf("FromRegistry modified the given address; should be pure function")

--- a/internal/addrs/move_endpoint.go
+++ b/internal/addrs/move_endpoint.go
@@ -70,7 +70,7 @@ func (e *MoveEndpoint) Equal(other *MoveEndpoint) bool {
 }
 
 // MightUnifyWith returns true if it is possible that a later call to
-// UnifyMoveEndpoints might succeed if given the reciever and the other
+// UnifyMoveEndpoints might succeed if given the receiver and the other
 // given endpoint.
 //
 // This is intended for early static validation of obviously-wrong situations,
@@ -84,7 +84,7 @@ func (e *MoveEndpoint) MightUnifyWith(other *MoveEndpoint) bool {
 	return from != nil && to != nil
 }
 
-// ConfigMovable transforms the reciever into a ConfigMovable by resolving it
+// ConfigMovable transforms the receiver into a ConfigMovable by resolving it
 // relative to the given base module, which should be the module where
 // the MoveEndpoint expression was found.
 //

--- a/internal/addrs/move_endpoint_module.go
+++ b/internal/addrs/move_endpoint_module.go
@@ -82,7 +82,7 @@ func (e *MoveEndpointInModule) ObjectKind() MoveEndpointKind {
 }
 
 // String produces a string representation of the object matching pattern
-// represented by the reciever.
+// represented by the receiver.
 //
 // Since there is no direct syntax for representing such an object matching
 // pattern, this function uses a splat-operator-like representation to stand
@@ -111,7 +111,7 @@ func (e *MoveEndpointInModule) String() string {
 	return buf.String()
 }
 
-// Equal returns true if the reciever represents the same matching pattern
+// Equal returns true if the receiver represents the same matching pattern
 // as the other given endpoint, ignoring the source location information.
 //
 // This is not an optimized function and is here primarily to help with
@@ -243,7 +243,7 @@ func (e *MoveEndpointInModule) synthModuleInstance() ModuleInstance {
 	return inst
 }
 
-// SelectsModule returns true if the reciever directly selects either
+// SelectsModule returns true if the receiver directly selects either
 // the given module or a resource nested directly inside that module.
 //
 // This is a good function to use to decide which modules in a state
@@ -329,11 +329,11 @@ func moduleInstanceCanMatch(modA, modB ModuleInstance) bool {
 	return true
 }
 
-// CanChainFrom returns true if the reciever describes an address that could
+// CanChainFrom returns true if the receiver describes an address that could
 // potentially select an object that the other given address could select.
 //
 // In other words, this decides whether the move chaining rule applies, if
-// the reciever is the "to" from one statement and the other given address
+// the receiver is the "to" from one statement and the other given address
 // is the "from" of another statement.
 func (e *MoveEndpointInModule) CanChainFrom(other *MoveEndpointInModule) bool {
 	eMod := e.synthModuleInstance()
@@ -488,7 +488,7 @@ func (m ModuleInstance) MoveDestination(fromMatch, toMatch *MoveEndpointInModule
 		return nil, false
 	}
 
-	// The rest of our work will be against the part of the reciever that's
+	// The rest of our work will be against the part of the receiver that's
 	// relative to the declaration module. mRel is a weird abuse of
 	// ModuleInstance that represents a relative module address, similar to
 	// what we do for MoveEndpointInModule.relSubject.
@@ -582,7 +582,7 @@ func (r AbsResource) MoveDestination(fromMatch, toMatch *MoveEndpointInModule) (
 			return AbsResource{}, false
 		}
 
-		// fromMatch can only possibly match the reciever if the resource
+		// fromMatch can only possibly match the receiver if the resource
 		// portions are identical, regardless of the module paths.
 		if fromRelSubject.Resource != r.Resource {
 			return AbsResource{}, false
@@ -664,7 +664,7 @@ func (r AbsResourceInstance) MoveDestination(fromMatch, toMatch *MoveEndpointInM
 				return AbsResourceInstance{}, false
 			}
 
-			// fromMatch can only possibly match the reciever if the resource
+			// fromMatch can only possibly match the receiver if the resource
 			// portions are identical, regardless of the module paths.
 			if fromRelSubject.Resource != r.Resource {
 				return AbsResourceInstance{}, false

--- a/internal/addrs/move_endpoint_module_test.go
+++ b/internal/addrs/move_endpoint_module_test.go
@@ -284,7 +284,7 @@ func TestModuleInstanceMoveDestination(t *testing.T) {
 					var diags tfdiags.Diagnostics
 					receiverAddr, diags = ParseModuleInstanceStr(test.Receiver)
 					if diags.HasErrors() {
-						t.Fatalf("invalid reciever address: %s", diags.Err().Error())
+						t.Fatalf("invalid receiver address: %s", diags.Err().Error())
 					}
 				}
 				gotAddr, gotMatch := receiverAddr.MoveDestination(fromEP, toEP)
@@ -392,7 +392,7 @@ func TestAbsResourceInstanceMoveDestination(t *testing.T) {
 			`test_object.beep`,
 			`test_object.boop`,
 			`test_object.boop`,
-			false, // the reciever is already the "to" address
+			false, // the receiver is already the "to" address
 			``,
 		},
 		{
@@ -682,7 +682,7 @@ func TestAbsResourceInstanceMoveDestination(t *testing.T) {
 
 				receiverAddr, diags := ParseAbsResourceInstanceStr(test.Receiver)
 				if diags.HasErrors() {
-					t.Fatalf("invalid reciever address: %s", diags.Err().Error())
+					t.Fatalf("invalid receiver address: %s", diags.Err().Error())
 				}
 				gotAddr, gotMatch := receiverAddr.MoveDestination(fromEP, toEP)
 				if !test.WantMatch {
@@ -765,7 +765,7 @@ func TestAbsResourceMoveDestination(t *testing.T) {
 			`test_object.beep`,
 			`test_object.boop`,
 			`test_object.boop`,
-			false, // the reciever is already the "to" address
+			false, // the receiver is already the "to" address
 			``,
 		},
 		{
@@ -1052,10 +1052,10 @@ func TestAbsResourceMoveDestination(t *testing.T) {
 				// key.
 				receiverInstanceAddr, diags := ParseAbsResourceInstanceStr(test.Receiver)
 				if diags.HasErrors() {
-					t.Fatalf("invalid reciever address: %s", diags.Err().Error())
+					t.Fatalf("invalid receiver address: %s", diags.Err().Error())
 				}
 				if receiverInstanceAddr.Resource.Key != NoKey {
-					t.Fatalf("invalid reciever address: must be a resource, not a resource instance")
+					t.Fatalf("invalid receiver address: must be a resource, not a resource instance")
 				}
 				receiverAddr := receiverInstanceAddr.ContainingResource()
 				gotAddr, gotMatch := receiverAddr.MoveDestination(fromEP, toEP)

--- a/internal/addrs/parse_ref.go
+++ b/internal/addrs/parse_ref.go
@@ -23,7 +23,7 @@ type Reference struct {
 }
 
 // DisplayString returns a string that approximates the subject and remaining
-// traversal of the reciever in a way that resembles the Terraform language
+// traversal of the receiver in a way that resembles the Terraform language
 // syntax that could've produced it.
 //
 // It's not guaranteed to actually be a valid Terraform language expression,

--- a/internal/addrs/provider_config.go
+++ b/internal/addrs/provider_config.go
@@ -33,7 +33,7 @@ import (
 //
 // Recipients of a ProviderConfig value can assume it can contain only a
 // LocalProviderConfig value, an AbsProviderConfigValue, or nil to represent
-// the absense of a provider config in situations where that is meaningful.
+// the absence of a provider config in situations where that is meaningful.
 type ProviderConfig interface {
 	providerConfig()
 }

--- a/internal/addrs/provider_config.go
+++ b/internal/addrs/provider_config.go
@@ -349,7 +349,7 @@ func (pc AbsProviderConfig) providerConfig() {}
 // such inheritance is possible, and thus whether the returned address is valid.
 //
 // Inheritance is possible only for default (un-aliased) providers in modules
-// other than the root module. Even if a valid address is returned, inheritence
+// other than the root module. Even if a valid address is returned, inheritance
 // may not be performed for other reasons, such as if the calling module
 // provided explicit provider configurations within the call for this module.
 // The ProviderTransformer graph transform in the main terraform module has the

--- a/internal/addrs/resource.go
+++ b/internal/addrs/resource.go
@@ -274,7 +274,7 @@ func (m ModuleInstance) ResourceInstance(mode ResourceMode, typeName string, nam
 }
 
 // ContainingResource returns the address of the resource that contains the
-// receving resource instance. In other words, it discards the key portion
+// receiving resource instance. In other words, it discards the key portion
 // of the address to produce an AbsResource value.
 func (r AbsResourceInstance) ContainingResource() AbsResource {
 	return AbsResource{

--- a/internal/addrs/resource_phase.go
+++ b/internal/addrs/resource_phase.go
@@ -23,7 +23,7 @@ type ResourceInstancePhase struct {
 
 var _ Referenceable = ResourceInstancePhase{}
 
-// Phase returns a special "phase address" for the receving instance. See the
+// Phase returns a special "phase address" for the receiving instance. See the
 // documentation of ResourceInstancePhase for the limited situations where this
 // is intended to be used.
 func (r ResourceInstance) Phase(rpt ResourceInstancePhaseType) ResourceInstancePhase {
@@ -95,7 +95,7 @@ type ResourcePhase struct {
 
 var _ Referenceable = ResourcePhase{}
 
-// Phase returns a special "phase address" for the receving instance. See the
+// Phase returns a special "phase address" for the receiving instance. See the
 // documentation of ResourceInstancePhase for the limited situations where this
 // is intended to be used.
 func (r Resource) Phase(rpt ResourceInstancePhaseType) ResourcePhase {

--- a/internal/addrs/set.go
+++ b/internal/addrs/set.go
@@ -40,7 +40,7 @@ func (s Set[T]) Remove(addr T) {
 }
 
 // Union returns a new set which contains the union of all of the elements
-// of both the reciever and the given other set.
+// of both the receiver and the given other set.
 func (s Set[T]) Union(other Set[T]) Set[T] {
 	ret := make(Set[T])
 	for k, addr := range s {
@@ -53,7 +53,7 @@ func (s Set[T]) Union(other Set[T]) Set[T] {
 }
 
 // Intersection returns a new set which contains the intersection of all of the
-// elements of both the reciever and the given other set.
+// elements of both the receiver and the given other set.
 func (s Set[T]) Intersection(other Set[T]) Set[T] {
 	ret := make(Set[T])
 	for k, addr := range s {

--- a/internal/backend/unparsed_value.go
+++ b/internal/backend/unparsed_value.go
@@ -132,7 +132,7 @@ func ParseDeclaredVariableValues(vv map[string]UnparsedVariableValue, decls map[
 	return ret, diags
 }
 
-// Checks all given terraform.InputValues variable maps for the existance of
+// Checks all given terraform.InputValues variable maps for the existence of
 // a named variable
 func isDefinedAny(name string, maps ...terraform.InputValues) bool {
 	for _, m := range maps {

--- a/internal/command/apply.go
+++ b/internal/command/apply.go
@@ -289,7 +289,7 @@ func (c *ApplyCommand) GatherVariables(opReq *backend.Operation, args *arguments
 	var diags tfdiags.Diagnostics
 
 	// FIXME the arguments package currently trivially gathers variable related
-	// arguments in a heterogenous slice, in order to minimize the number of
+	// arguments in a heterogeneous slice, in order to minimize the number of
 	// code paths gathering variables during the transition to this structure.
 	// Once all commands that gather variables have been converted to this
 	// structure, we could move the variable gathering code to the arguments

--- a/internal/command/arguments/extended.go
+++ b/internal/command/arguments/extended.go
@@ -230,7 +230,7 @@ func extendedFlagSet(name string, state *State, operation *Operation, vars *Vars
 		f.Var((*flagStringSlice)(&operation.forceReplaceRaw), "replace", "replace")
 	}
 
-	// Gather all -var and -var-file arguments into one heterogenous structure
+	// Gather all -var and -var-file arguments into one heterogeneous structure
 	// to preserve the overall order.
 	if vars != nil {
 		varsFlags := newFlagNameValueSlice("-var")

--- a/internal/command/format/diagnostic.go
+++ b/internal/command/format/diagnostic.go
@@ -205,7 +205,7 @@ func DiagnosticWarningsCompact(diags tfdiags.Diagnostics, color *colorstring.Col
 				}
 			} else if len(sources) > 1 {
 				b.WriteString(fmt.Sprintf(
-					"  (%d occurences of this warning)\n",
+					"  (%d occurrences of this warning)\n",
 					len(sources),
 				))
 			}

--- a/internal/command/init.go
+++ b/internal/command/init.go
@@ -400,7 +400,7 @@ func (c *InitCommand) getModules(ctx context.Context, path, testsDir string, ear
 
 func (c *InitCommand) initCloud(ctx context.Context, root *configs.Module, extraConfig rawFlags) (be backend.Backend, output bool, diags tfdiags.Diagnostics) {
 	ctx, span := tracer.Start(ctx, "initialize Terraform Cloud")
-	_ = ctx // prevent staticcheck from complaining to avoid a maintenence hazard of having the wrong ctx in scope here
+	_ = ctx // prevent staticcheck from complaining to avoid a maintenance hazard of having the wrong ctx in scope here
 	defer span.End()
 
 	c.Ui.Output(c.Colorize().Color("\n[reset][bold]Initializing Terraform Cloud..."))
@@ -428,7 +428,7 @@ func (c *InitCommand) initCloud(ctx context.Context, root *configs.Module, extra
 
 func (c *InitCommand) initBackend(ctx context.Context, root *configs.Module, extraConfig rawFlags) (be backend.Backend, output bool, diags tfdiags.Diagnostics) {
 	ctx, span := tracer.Start(ctx, "initialize backend")
-	_ = ctx // prevent staticcheck from complaining to avoid a maintenence hazard of having the wrong ctx in scope here
+	_ = ctx // prevent staticcheck from complaining to avoid a maintenance hazard of having the wrong ctx in scope here
 	defer span.End()
 
 	c.Ui.Output(c.Colorize().Color("\n[reset][bold]Initializing the backend..."))

--- a/internal/command/meta_backend.go
+++ b/internal/command/meta_backend.go
@@ -433,7 +433,7 @@ func (m *Meta) Operation(b backend.Backend, vt arguments.ViewType) *backend.Oper
 		// should always have been called earlier to prepare the "ContextOpts"
 		// for the backend anyway, so we should never actually get here in
 		// a real situation. If we do get here then the backend will inevitably
-		// fail downstream somwhere if it tries to use the empty depLocks.
+		// fail downstream somewhere if it tries to use the empty depLocks.
 		log.Printf("[WARN] Failed to load dependency locks while preparing backend operation (ignored): %s", diags.Err().Error())
 	}
 

--- a/internal/command/plan.go
+++ b/internal/command/plan.go
@@ -175,7 +175,7 @@ func (c *PlanCommand) GatherVariables(opReq *backend.Operation, args *arguments.
 	var diags tfdiags.Diagnostics
 
 	// FIXME the arguments package currently trivially gathers variable related
-	// arguments in a heterogenous slice, in order to minimize the number of
+	// arguments in a heterogeneous slice, in order to minimize the number of
 	// code paths gathering variables during the transition to this structure.
 	// Once all commands that gather variables have been converted to this
 	// structure, we could move the variable gathering code to the arguments

--- a/internal/command/refresh.go
+++ b/internal/command/refresh.go
@@ -161,7 +161,7 @@ func (c *RefreshCommand) GatherVariables(opReq *backend.Operation, args *argumen
 	var diags tfdiags.Diagnostics
 
 	// FIXME the arguments package currently trivially gathers variable related
-	// arguments in a heterogenous slice, in order to minimize the number of
+	// arguments in a heterogeneous slice, in order to minimize the number of
 	// code paths gathering variables during the transition to this structure.
 	// Once all commands that gather variables have been converted to this
 	// structure, we could move the variable gathering code to the arguments

--- a/internal/command/views/view.go
+++ b/internal/command/views/view.go
@@ -54,7 +54,7 @@ func NewView(streams *terminal.Streams) *View {
 // instead for situations where the user isn't running Terraform directly.
 //
 // For convenient use during initialization (in conjunction with NewView),
-// SetRunningInAutomation returns the reciever after modifying it.
+// SetRunningInAutomation returns the receiver after modifying it.
 func (v *View) SetRunningInAutomation(new bool) *View {
 	v.runningInAutomation = new
 	return v

--- a/internal/command/workdir/dir.go
+++ b/internal/command/workdir/dir.go
@@ -14,7 +14,7 @@ import (
 // "Working directory" is unfortunately a slight misnomer, because non-default
 // options can potentially stretch the definition such that multiple working
 // directories end up appearing to share a data directory, or other similar
-// anomolies, but we continue to use this terminology both for historical
+// anomalies, but we continue to use this terminology both for historical
 // reasons and because it reflects the common case without any special
 // overrides.
 //

--- a/internal/command/workdir/dir.go
+++ b/internal/command/workdir/dir.go
@@ -82,7 +82,7 @@ func NewDir(mainPath string) *Dir {
 }
 
 // OverrideOriginalWorkingDir records a different path as the
-// "original working directory" for the reciever.
+// "original working directory" for the receiver.
 //
 // Use this only to record the original working directory when Terraform is run
 // with the -chdir=... global option. In that case, the directory given in
@@ -123,7 +123,7 @@ func (d *Dir) OriginalWorkingDir() string {
 	return d.originalDir
 }
 
-// DataDir returns the base path where the reciever keeps all of the settings
+// DataDir returns the base path where the receiver keeps all of the settings
 // and artifacts that must persist between consecutive commands in a single
 // session.
 //

--- a/internal/configs/backend.go
+++ b/internal/configs/backend.go
@@ -29,7 +29,7 @@ func decodeBackendBlock(block *hcl.Block) (*Backend, hcl.Diagnostics) {
 	}, nil
 }
 
-// Hash produces a hash value for the reciever that covers the type and the
+// Hash produces a hash value for the receiver that covers the type and the
 // portions of the config that conform to the given schema.
 //
 // If the config does not conform to the schema then the result is not

--- a/internal/configs/config.go
+++ b/internal/configs/config.go
@@ -210,7 +210,7 @@ func (c *Config) EntersNewPackage() bool {
 
 // VerifyDependencySelections checks whether the given locked dependencies
 // are acceptable for all of the version constraints reported in the
-// configuration tree represented by the reciever.
+// configuration tree represented by the receiver.
 //
 // This function will errors only if any of the locked dependencies are out of
 // range for corresponding constraints in the configuration. If there are

--- a/internal/dag/graph.go
+++ b/internal/dag/graph.go
@@ -235,13 +235,13 @@ func (g *Graph) Connect(edge Edge) {
 }
 
 // Subsume imports all of the nodes and edges from the given graph into the
-// reciever, leaving the given graph unchanged.
+// receiver, leaving the given graph unchanged.
 //
-// If any of the nodes in the given graph are already present in the reciever
+// If any of the nodes in the given graph are already present in the receiver
 // then the existing node will be retained and any new edges from the given
 // graph will be connected with it.
 //
-// If the given graph has edges in common with the reciever then they will be
+// If the given graph has edges in common with the receiver then they will be
 // ignored, because each pair of nodes can only be connected once.
 func (g *Graph) Subsume(other *Graph) {
 	// We're using Set.Filter just as a "visit each element" here, so we're

--- a/internal/depsfile/locks.go
+++ b/internal/depsfile/locks.go
@@ -125,7 +125,7 @@ func (l *Locks) RemoveProvider(addr addrs.Provider) {
 //
 // This is an in-memory-only annotation which lives only inside a particular
 // Locks object, and is never persisted as part of a saved lock file on disk.
-// It's valid to still use other methods of the reciever to access
+// It's valid to still use other methods of the receiver to access
 // already-stored lock information and to update lock information for an
 // overridden provider, but some callers may need to use ProviderIsOverridden
 // to selectively disregard stored lock information for overridden providers,
@@ -149,7 +149,7 @@ func (l *Locks) ProviderIsOverridden(addr addrs.Provider) bool {
 //
 // This allows propagating override information between different lock objects,
 // as if calling SetProviderOverridden for each address already overridden
-// in the other given locks. If the reciever already has overridden providers,
+// in the other given locks. If the receiver already has overridden providers,
 // SetSameOverriddenProviders will preserve them.
 func (l *Locks) SetSameOverriddenProviders(other *Locks) {
 	if other == nil {

--- a/internal/depsfile/locks_test.go
+++ b/internal/depsfile/locks_test.go
@@ -242,10 +242,10 @@ func TestProviderLockContainsAll(t *testing.T) {
 		})
 
 		if !original.ContainsAll(target) {
-			t.Errorf("orginal should contain all hashes in target")
+			t.Errorf("original should contain all hashes in target")
 		}
 		if target.ContainsAll(original) {
-			t.Errorf("target should not contain all hashes in orginal")
+			t.Errorf("target should not contain all hashes in original")
 		}
 	})
 
@@ -263,10 +263,10 @@ func TestProviderLockContainsAll(t *testing.T) {
 		})
 
 		if !original.ContainsAll(target) {
-			t.Errorf("orginal should contain all hashes in target")
+			t.Errorf("original should contain all hashes in target")
 		}
 		if !target.ContainsAll(original) {
-			t.Errorf("target should not contain all hashes in orginal")
+			t.Errorf("target should not contain all hashes in original")
 		}
 	})
 
@@ -278,7 +278,7 @@ func TestProviderLockContainsAll(t *testing.T) {
 		})
 
 		if !original.ContainsAll(nil) {
-			t.Fatalf("orginal should report true on nil")
+			t.Fatalf("original should report true on nil")
 		}
 	})
 
@@ -292,7 +292,7 @@ func TestProviderLockContainsAll(t *testing.T) {
 		target := NewProviderLock(provider, v2, v2EqConstraints, []getproviders.Hash{})
 
 		if !original.ContainsAll(target) {
-			t.Fatalf("orginal should report true on empty")
+			t.Fatalf("original should report true on empty")
 		}
 	})
 
@@ -306,7 +306,7 @@ func TestProviderLockContainsAll(t *testing.T) {
 		})
 
 		if original.ContainsAll(target) {
-			t.Fatalf("orginal should report false when empty")
+			t.Fatalf("original should report false when empty")
 		}
 	})
 }

--- a/internal/getproviders/errors.go
+++ b/internal/getproviders/errors.go
@@ -180,7 +180,7 @@ func (err ErrProtocolNotSupported) Error() string {
 // unexpected error.
 //
 // This is used for any error responses other than "Not Found", which would
-// indicate the absense of a provider and is thus reported using
+// indicate the absence of a provider and is thus reported using
 // ErrProviderNotKnown instead.
 type ErrQueryFailed struct {
 	Provider addrs.Provider

--- a/internal/getproviders/hash.go
+++ b/internal/getproviders/hash.go
@@ -399,7 +399,7 @@ func PackageHashV1(loc PackageLocation) (Hash, error) {
 }
 
 // Hash computes a hash of the contents of the package at the location
-// associated with the reciever, using whichever hash algorithm is the current
+// associated with the receiver, using whichever hash algorithm is the current
 // default.
 //
 // This method will change to use new hash versions as they are introduced

--- a/internal/getproviders/http_mirror_source.go
+++ b/internal/getproviders/http_mirror_source.go
@@ -413,7 +413,7 @@ func svchostFromURL(u *url.URL) (svchost.Hostname, error) {
 	// a network mirror over HTTP would potentially transmit any configured
 	// credentials in cleartext. Therefore we don't need to do any special
 	// handling of default ports here, because svchost.Hostname already
-	// considers the absense of a port to represent the standard HTTPS port
+	// considers the absence of a port to represent the standard HTTPS port
 	// 443, and will normalize away an explicit specification of port 443
 	// in svchost.ForComparison below.
 

--- a/internal/getproviders/multi_source.go
+++ b/internal/getproviders/multi_source.go
@@ -197,7 +197,7 @@ func ParseMultiSourceMatchingPatterns(strs []string) (MultiSourceMatchingPattern
 // is both included by the selector's include patterns and _not_ excluded
 // by its exclude patterns.
 //
-// The absense of any include patterns is treated the same as a pattern
+// The absence of any include patterns is treated the same as a pattern
 // that matches all addresses. Exclusions take priority over inclusions.
 func (s MultiSourceSelector) CanHandleProvider(addr addrs.Provider) bool {
 	switch {

--- a/internal/getproviders/types.go
+++ b/internal/getproviders/types.go
@@ -18,7 +18,7 @@ import (
 // Version represents a particular single version of a provider.
 type Version = versions.Version
 
-// UnspecifiedVersion is the zero value of Version, representing the absense
+// UnspecifiedVersion is the zero value of Version, representing the absence
 // of a version number.
 var UnspecifiedVersion Version = versions.Unspecified
 

--- a/internal/getproviders/types.go
+++ b/internal/getproviders/types.go
@@ -172,7 +172,7 @@ var CurrentPlatform = Platform{
 // provider package targeting a single platform.
 //
 // Package findproviders does no signature verification or protocol version
-// compatibility checking of its own. A caller receving a PackageMeta must
+// compatibility checking of its own. A caller receiving a PackageMeta must
 // verify that it has a correct signature and supports a protocol version
 // accepted by the current version of Terraform before trying to use the
 // described package.

--- a/internal/lang/funcs/crypto.go
+++ b/internal/lang/funcs/crypto.go
@@ -125,7 +125,7 @@ var BcryptFunc = function.New(&function.Spec{
 		input := args[0].AsString()
 		out, err := bcrypt.GenerateFromPassword([]byte(input), defaultCost)
 		if err != nil {
-			return cty.UnknownVal(cty.String), fmt.Errorf("error occured generating password %s", err.Error())
+			return cty.UnknownVal(cty.String), fmt.Errorf("error occurred generating password %s", err.Error())
 		}
 
 		return cty.StringVal(string(out)), nil

--- a/internal/lang/funcs/string.go
+++ b/internal/lang/funcs/string.go
@@ -89,7 +89,7 @@ var EndsWithFunc = function.New(&function.Spec{
 })
 
 // ReplaceFunc constructs a function that searches a given string for another
-// given substring, and replaces each occurence with a given replacement string.
+// given substring, and replaces each occurrence with a given replacement string.
 var ReplaceFunc = function.New(&function.Spec{
 	Params: []function.Parameter{
 		{
@@ -154,7 +154,7 @@ var StrContainsFunc = function.New(&function.Spec{
 })
 
 // Replace searches a given string for another given substring,
-// and replaces all occurences with a given replacement string.
+// and replaces all occurrences with a given replacement string.
 func Replace(str, substr, replace cty.Value) (cty.Value, error) {
 	return ReplaceFunc.Call([]cty.Value{str, substr, replace})
 }

--- a/internal/lang/globalref/analyzer_meta_references.go
+++ b/internal/lang/globalref/analyzer_meta_references.go
@@ -57,7 +57,7 @@ func (a *Analyzer) MetaReferences(ref Reference) []Reference {
 		// instance with an unknown key, but we don't have any representation
 		// of that. For the moment it's pretty immaterial since most of our
 		// other analysis ignores instance keys anyway, but maybe we'll revisit
-		// this latter to distingish these two cases better.
+		// this latter to distinguish these two cases better.
 		return a.metaReferencesModuleCall(moduleAddr, targetAddr.Instance(addrs.NoKey), remaining)
 	case addrs.CountAttr, addrs.ForEachAttr:
 		if resourceAddr, ok := ref.ResourceInstance(); ok {
@@ -73,7 +73,7 @@ func (a *Analyzer) MetaReferences(ref Reference) []Reference {
 		// with an unknown key, but we don't have any representation of that.
 		// For the moment it's pretty immaterial since most of our other
 		// analysis ignores instance keys anyway, but maybe we'll revisit this
-		// latter to distingish these two cases better.
+		// latter to distinguish these two cases better.
 		return a.metaReferencesResourceInstance(moduleAddr, targetAddr.Instance(addrs.NoKey), remaining)
 	default:
 		// For anything we don't explicitly support we'll just return no

--- a/internal/lang/globalref/reference.go
+++ b/internal/lang/globalref/reference.go
@@ -113,7 +113,7 @@ func (r Reference) ResourceInstance() (addrs.AbsResourceInstance, bool) {
 }
 
 // DebugString returns an internal (but still somewhat Terraform-language-like)
-// compact string representation of the reciever, which isn't an address that
+// compact string representation of the receiver, which isn't an address that
 // any of our usual address parsers could accept but still captures the
 // essence of what the reference represents.
 //

--- a/internal/lang/references.go
+++ b/internal/lang/references.go
@@ -19,7 +19,7 @@ import (
 // This function does not do any de-duplication of references, since references
 // have source location information embedded in them and so any invalid
 // references that are duplicated should have errors reported for each
-// occurence.
+// occurrence.
 //
 // If the returned diagnostics contains errors then the result may be
 // incomplete or invalid. Otherwise, the returned slice has one reference per

--- a/internal/legacy/helper/schema/schema.go
+++ b/internal/legacy/helper/schema/schema.go
@@ -872,24 +872,24 @@ func (m schemaMap) diff(
 	d resourceDiffer,
 	all bool) error {
 
-	unsupressedDiff := new(terraform.InstanceDiff)
-	unsupressedDiff.Attributes = make(map[string]*terraform.ResourceAttrDiff)
+	unsuppressedDiff := new(terraform.InstanceDiff)
+	unsuppressedDiff.Attributes = make(map[string]*terraform.ResourceAttrDiff)
 
 	var err error
 	switch schema.Type {
 	case TypeBool, TypeInt, TypeFloat, TypeString:
-		err = m.diffString(k, schema, unsupressedDiff, d, all)
+		err = m.diffString(k, schema, unsuppressedDiff, d, all)
 	case TypeList:
-		err = m.diffList(k, schema, unsupressedDiff, d, all)
+		err = m.diffList(k, schema, unsuppressedDiff, d, all)
 	case TypeMap:
-		err = m.diffMap(k, schema, unsupressedDiff, d, all)
+		err = m.diffMap(k, schema, unsuppressedDiff, d, all)
 	case TypeSet:
-		err = m.diffSet(k, schema, unsupressedDiff, d, all)
+		err = m.diffSet(k, schema, unsuppressedDiff, d, all)
 	default:
 		err = fmt.Errorf("%s: unknown type %#v", k, schema.Type)
 	}
 
-	for attrK, attrV := range unsupressedDiff.Attributes {
+	for attrK, attrV := range unsuppressedDiff.Attributes {
 		switch rd := d.(type) {
 		case *ResourceData:
 			if schema.DiffSuppressFunc != nil && attrV != nil &&

--- a/internal/legacy/terraform/diff.go
+++ b/internal/legacy/terraform/diff.go
@@ -1331,7 +1331,7 @@ func (d *InstanceDiff) Same(d2 *InstanceDiff) (bool, string) {
 				continue
 			}
 
-			// If the last diff was a computed value then the absense of
+			// If the last diff was a computed value then the absence of
 			// that value is allowed since it may mean the value ended up
 			// being the same.
 			if diffOld.NewComputed {

--- a/internal/legacy/terraform/state.go
+++ b/internal/legacy/terraform/state.go
@@ -812,7 +812,7 @@ func (s *BackendState) SetConfig(val cty.Value, schema *configschema.Block) erro
 	return nil
 }
 
-// ForPlan produces an alternative representation of the reciever that is
+// ForPlan produces an alternative representation of the receiver that is
 // suitable for storing in a plan. The current workspace must additionally
 // be provided, to be stored alongside the backend configuration.
 //

--- a/internal/plans/changes.go
+++ b/internal/plans/changes.go
@@ -249,7 +249,7 @@ type ResourceInstanceChange struct {
 	Private []byte
 }
 
-// Encode produces a variant of the reciever that has its change values
+// Encode produces a variant of the receiver that has its change values
 // serialized so it can be written to a plan file. Pass the implied type of the
 // corresponding resource type schema for correct operation.
 func (rc *ResourceInstanceChange) Encode(ty cty.Type) (*ResourceInstanceChangeSrc, error) {
@@ -486,7 +486,7 @@ type OutputChange struct {
 	Sensitive bool
 }
 
-// Encode produces a variant of the reciever that has its change values
+// Encode produces a variant of the receiver that has its change values
 // serialized so it can be written to a plan file.
 func (oc *OutputChange) Encode() (*OutputChangeSrc, error) {
 	cs, err := oc.Change.Encode(cty.DynamicPseudoType)
@@ -545,7 +545,7 @@ type Change struct {
 	GeneratedConfig string
 }
 
-// Encode produces a variant of the reciever that has its change values
+// Encode produces a variant of the receiver that has its change values
 // serialized so it can be written to a plan file. Pass the type constraint
 // that the values are expected to conform to; to properly decode the values
 // later an identical type constraint must be provided at that time.

--- a/internal/plans/dynamic_value.go
+++ b/internal/plans/dynamic_value.go
@@ -21,9 +21,9 @@ import (
 // the serialized form, whose format may change in future. Values of this
 // type must always be created by calling NewDynamicValue.
 //
-// The zero value of DynamicValue is nil, and represents the absense of a
+// The zero value of DynamicValue is nil, and represents the absence of a
 // value within the Go type system. This is distinct from a cty.NullVal
-// result, which represents the absense of a value within the cty type system.
+// result, which represents the absence of a value within the cty type system.
 type DynamicValue []byte
 
 // NewDynamicValue creates a DynamicValue by serializing the given value
@@ -36,14 +36,14 @@ type DynamicValue []byte
 // value, and then also pass cty.DynamicPseudoType to method Decode to recover
 // the original value.
 //
-// cty.NilVal can be used to represent the absense of a value, but callers
+// cty.NilVal can be used to represent the absence of a value, but callers
 // must be careful to distinguish values that are absent at the Go layer
 // (cty.NilVal) vs. values that are absent at the cty layer (cty.NullVal
 // results).
 func NewDynamicValue(val cty.Value, ty cty.Type) (DynamicValue, error) {
 	// If we're given cty.NilVal (the zero value of cty.Value, which is
 	// distinct from a typed null value created by cty.NullVal) then we'll
-	// assume the caller is trying to represent the _absense_ of a value,
+	// assume the caller is trying to represent the _absence_ of a value,
 	// and so we'll return a nil DynamicValue.
 	if val == cty.NilVal {
 		return DynamicValue(nil), nil
@@ -64,7 +64,7 @@ func NewDynamicValue(val cty.Value, ty cty.Type) (DynamicValue, error) {
 // used to create the receiver.
 //
 // A nil DynamicValue decodes to cty.NilVal, which is not a valid value and
-// instead represents the absense of a value.
+// instead represents the absence of a value.
 func (v DynamicValue) Decode(ty cty.Type) (cty.Value, error) {
 	if v == nil {
 		return cty.NilVal, nil

--- a/internal/plans/objchange/compatible.go
+++ b/internal/plans/objchange/compatible.go
@@ -57,7 +57,7 @@ func assertObjectCompatible(schema *configschema.Block, planned, actual cty.Valu
 		path := append(path, cty.GetAttrStep{Name: name})
 
 		// Unmark values here before checking value assertions,
-		// but save the marks so we can see if we should supress
+		// but save the marks so we can see if we should suppress
 		// exposing a value through errors
 		unmarkedActualV, marksA := actualV.UnmarkDeep()
 		unmarkedPlannedV, marksP := plannedV.UnmarkDeep()

--- a/internal/states/module.go
+++ b/internal/states/module.go
@@ -304,7 +304,7 @@ func (ms *Module) PruneResourceHusks() {
 	}
 }
 
-// empty returns true if the receving module state is contributing nothing
+// empty returns true if the receiving module state is contributing nothing
 // to the state. In other words, it returns true if the module could be
 // removed from the state altogether without changing the meaning of the state.
 //

--- a/internal/states/resource.go
+++ b/internal/states/resource.go
@@ -175,7 +175,7 @@ func (i *ResourceInstance) findUnusedDeposedKey() DeposedKey {
 type DeposedKey string
 
 // NotDeposed is a special invalid value of DeposedKey that is used to represent
-// the absense of a deposed key. It must not be used as an actual deposed key.
+// the absence of a deposed key. It must not be used as an actual deposed key.
 const NotDeposed = DeposedKey("")
 
 var deposedKeyRand = rand.New(rand.NewSource(time.Now().UnixNano()))

--- a/internal/states/resource.go
+++ b/internal/states/resource.go
@@ -204,7 +204,7 @@ func (k DeposedKey) GoString() string {
 }
 
 // Generation is a helper method to convert a DeposedKey into a Generation.
-// If the reciever is anything other than NotDeposed then the result is
+// If the receiver is anything other than NotDeposed then the result is
 // just the same value as a Generation. If the receiver is NotDeposed then
 // the result is CurrentGen.
 func (k DeposedKey) Generation() Generation {

--- a/internal/states/state.go
+++ b/internal/states/state.go
@@ -502,7 +502,7 @@ func (s *State) MoveAbsResourceInstance(src, dst addrs.AbsResourceInstance) {
 // MaybeMoveAbsResourceInstance moves the given src AbsResourceInstance's
 // current state to the new dst address. This function will succeed if both the
 // src address does not exist in state and the dst address does; the return
-// value indicates whether or not the move occured. This function will panic if
+// value indicates whether or not the move occurred. This function will panic if
 // either the src does not exist or the dst does exist (but not both).
 func (s *State) MaybeMoveAbsResourceInstance(src, dst addrs.AbsResourceInstance) bool {
 	// get the src and dst resource instances from state
@@ -568,7 +568,7 @@ func (s *State) MoveModuleInstance(src, dst addrs.ModuleInstance) {
 // MaybeMoveModuleInstance moves the given src ModuleInstance's current state to
 // the new dst address. This function will succeed if both the src address does
 // not exist in state and the dst address does; the return value indicates
-// whether or not the move occured. This function will panic if either the src
+// whether or not the move occurred. This function will panic if either the src
 // does not exist or the dst does exist (but not both).
 func (s *State) MaybeMoveModuleInstance(src, dst addrs.ModuleInstance) bool {
 	if src.IsRoot() || dst.IsRoot() {

--- a/internal/states/state_deepcopy.go
+++ b/internal/states/state_deepcopy.go
@@ -14,7 +14,7 @@ import (
 // in this file comprehensively copy all parts of the state data structure
 // that could be mutated via pointers.
 
-// DeepCopy returns a new state that contains equivalent data to the reciever
+// DeepCopy returns a new state that contains equivalent data to the receiver
 // but shares no backing memory in common.
 //
 // As with all methods on State, this method is not safe to use concurrently

--- a/internal/states/state_equal.go
+++ b/internal/states/state_equal.go
@@ -23,7 +23,7 @@ func (s *State) Equal(other *State) bool {
 }
 
 // ManagedResourcesEqual returns true if all of the managed resources tracked
-// in the reciever are functionally equivalent to the same tracked in the
+// in the receiver are functionally equivalent to the same tracked in the
 // other given state.
 //
 // This is a more constrained version of Equal that disregards other

--- a/internal/states/statefile/version4.go
+++ b/internal/states/statefile/version4.go
@@ -297,7 +297,7 @@ func prepareStateV4(sV4 *stateV4) (*File, tfdiags.Diagnostics) {
 	}
 
 	// Saved check results from the previous run, if any.
-	// We differentiate absense from an empty array here so that we can
+	// We differentiate absence from an empty array here so that we can
 	// recognize if the previous run was with a version of Terraform that
 	// didn't support checks yet, or if there just weren't any checkable
 	// objects to record, in case that's important for certain messaging.

--- a/internal/states/statefile/version4.go
+++ b/internal/states/statefile/version4.go
@@ -344,7 +344,7 @@ func writeStateV4(file *File, w io.Writer) tfdiags.Diagnostics {
 			diags = diags.Append(tfdiags.Sourceless(
 				tfdiags.Error,
 				"Failed to serialize output value in state",
-				fmt.Sprintf("An error occured while serializing output value %q: %s.", name, err),
+				fmt.Sprintf("An error occurred while serializing output value %q: %s.", name, err),
 			))
 			continue
 		}
@@ -354,7 +354,7 @@ func writeStateV4(file *File, w io.Writer) tfdiags.Diagnostics {
 			diags = diags.Append(tfdiags.Sourceless(
 				tfdiags.Error,
 				"Failed to serialize output value in state",
-				fmt.Sprintf("An error occured while serializing the type of output value %q: %s.", name, err),
+				fmt.Sprintf("An error occurred while serializing the type of output value %q: %s.", name, err),
 			))
 			continue
 		}
@@ -427,7 +427,7 @@ func writeStateV4(file *File, w io.Writer) tfdiags.Diagnostics {
 		diags = diags.Append(tfdiags.Sourceless(
 			tfdiags.Error,
 			"Failed to serialize state",
-			fmt.Sprintf("An error occured while serializing the state to save it. This is a bug in Terraform and should be reported: %s.", err),
+			fmt.Sprintf("An error occurred while serializing the state to save it. This is a bug in Terraform and should be reported: %s.", err),
 		))
 		return diags
 	}
@@ -438,7 +438,7 @@ func writeStateV4(file *File, w io.Writer) tfdiags.Diagnostics {
 		diags = diags.Append(tfdiags.Sourceless(
 			tfdiags.Error,
 			"Failed to write state",
-			fmt.Sprintf("An error occured while writing the serialized state: %s.", err),
+			fmt.Sprintf("An error occurred while writing the serialized state: %s.", err),
 		))
 		return diags
 	}

--- a/internal/terraform/context_input.go
+++ b/internal/terraform/context_input.go
@@ -21,7 +21,7 @@ import (
 // configurations.
 //
 // Unlike the other better-behaved operation methods, this one actually
-// modifies some internal state inside the receving context so that the
+// modifies some internal state inside the receiving context so that the
 // captured values will be implicitly available to a subsequent call to Plan,
 // or to some other operation entry point. Hopefully a future iteration of
 // this will change design to make that data flow more explicit.

--- a/internal/terraform/context_plan.go
+++ b/internal/terraform/context_plan.go
@@ -591,7 +591,7 @@ func (c *Context) planWalk(config *configs.Config, prevRunState *states.State, o
 	if moveResults.Blocked.Len() > 0 && !diags.HasErrors() {
 		// If we had blocked moves and we're not going to be returning errors
 		// then we'll report the blockers as a warning. We do this only in the
-		// absense of errors because invalid move statements might well be
+		// absence of errors because invalid move statements might well be
 		// the root cause of the blockers, and so better to give an actionable
 		// error message than a less-actionable warning.
 		diags = diags.Append(blockedMovesWarningDiag(moveResults))

--- a/internal/terraform/context_plan_test.go
+++ b/internal/terraform/context_plan_test.go
@@ -4341,7 +4341,7 @@ func TestContext2Plan_targetedModuleUntargetedVariable(t *testing.T) {
 	}
 }
 
-// ensure that outputs missing references due to targetting are removed from
+// ensure that outputs missing references due to targeting are removed from
 // the graph.
 func TestContext2Plan_outputContainsTargetedResource(t *testing.T) {
 	m := testModule(t, "plan-untargeted-resource-output")

--- a/internal/terraform/context_plan_test.go
+++ b/internal/terraform/context_plan_test.go
@@ -1715,7 +1715,7 @@ func TestContext2Plan_blockNestingGroup(t *testing.T) {
 		// This represents the situation where the remote service _always_ creates
 		// a single "blah", regardless of whether the block is present, but when
 		// the block _is_ present the user can override some aspects of it. The
-		// absense of the block means "use the defaults", in that case.
+		// absence of the block means "use the defaults", in that case.
 		Config: cty.ObjectVal(map[string]cty.Value{
 			"blah": cty.ObjectVal(map[string]cty.Value{
 				"baz": cty.NullVal(cty.String),

--- a/internal/terraform/node_resource_abstract_instance.go
+++ b/internal/terraform/node_resource_abstract_instance.go
@@ -1130,7 +1130,7 @@ func (n *NodeAbstractResourceInstance) plan(
 			Action: action,
 			Before: priorVal,
 			// Pass the marked planned value through in our change
-			// to propogate through evaluation.
+			// to propagate through evaluation.
 			// Marks will be removed when encoding.
 			After:           plannedNewVal,
 			GeneratedConfig: n.generatedConfigHCL,

--- a/internal/terraform/node_resource_import.go
+++ b/internal/terraform/node_resource_import.go
@@ -230,7 +230,7 @@ func (n *graphNodeImportStateSub) Execute(ctx EvalContext, op walkOperation) (di
 		return diags
 	}
 
-	// Verify the existance of the imported resource
+	// Verify the existence of the imported resource
 	if state.Value.IsNull() {
 		var diags tfdiags.Diagnostics
 		diags = diags.Append(tfdiags.Sourceless(

--- a/internal/terraform/node_resource_plan_instance.go
+++ b/internal/terraform/node_resource_plan_instance.go
@@ -359,7 +359,7 @@ func (n *NodePlannableResourceInstance) managedResourceExecute(ctx EvalContext) 
 
 		// Even if we don't plan changes, we do still need to at least update
 		// the working state to reflect the refresh result. If not, then e.g.
-		// any output values refering to this will not react to the drift.
+		// any output values referring to this will not react to the drift.
 		// (Even if we didn't actually refresh above, this will still save
 		// the result of any schema upgrading we did in readResourceInstanceState.)
 		diags = diags.Append(n.writeResourceInstanceState(ctx, instanceRefreshState, workingState))

--- a/internal/terraform/transform_provider.go
+++ b/internal/terraform/transform_provider.go
@@ -98,13 +98,13 @@ func (t *ProviderTransformer) Transform(g *Graph) error {
 	var diags tfdiags.Diagnostics
 
 	// To start, we'll collect the _requested_ provider addresses for each
-	// node, which we'll then resolve (handling provider inheritence, etc) in
+	// node, which we'll then resolve (handling provider inheritance, etc) in
 	// the next step.
 	// Our "requested" map is from graph vertices to string representations of
 	// provider config addresses (for deduping) to requests.
 	type ProviderRequest struct {
 		Addr  addrs.AbsProviderConfig
-		Exact bool // If true, inheritence from parent modules is not attempted
+		Exact bool // If true, inheritance from parent modules is not attempted
 	}
 	requested := map[dag.Vertex]map[string]ProviderRequest{}
 	needConfigured := map[string]addrs.AbsProviderConfig{}
@@ -297,7 +297,7 @@ func (t *CloseProviderTransformer) Transform(g *Graph) error {
 // This transformer may create extra nodes that are not needed in practice,
 // due to overriding provider configurations in child modules.
 // PruneProviderTransformer can then remove these once ProviderTransformer
-// has resolved all of the inheritence, etc.
+// has resolved all of the inheritance, etc.
 type MissingProviderTransformer struct {
 	// MissingProviderTransformer needs the config to rule out _implied_ default providers
 	Config *configs.Config

--- a/internal/terraform/variables.go
+++ b/internal/terraform/variables.go
@@ -115,13 +115,13 @@ func (v *InputValue) GoString() string {
 	}
 }
 
-// HasSourceRange returns true if the reciever has a source type for which
+// HasSourceRange returns true if the receiver has a source type for which
 // we expect the SourceRange field to be populated with a valid range.
 func (v *InputValue) HasSourceRange() bool {
 	return v.SourceType.HasSourceRange()
 }
 
-// HasSourceRange returns true if the reciever is one of the source types
+// HasSourceRange returns true if the receiver is one of the source types
 // that is used along with a valid SourceRange field when appearing inside an
 // InputValue object.
 func (v ValueSourceType) HasSourceRange() bool {
@@ -212,7 +212,7 @@ func (vv InputValues) SameValues(other InputValues) bool {
 	return true
 }
 
-// HasValues returns true if the reciever has the same values as in the given
+// HasValues returns true if the receiver has the same values as in the given
 // map, disregarding the source types and source ranges.
 //
 // Values are compared using the cty "RawEquals" method, which means that

--- a/internal/terraform/variables.go
+++ b/internal/terraform/variables.go
@@ -37,7 +37,7 @@ type InputValue struct {
 	//
 	// If a particular variable declared in the root module is _not_ set by
 	// the user then the caller must still provide an InputValue for it but
-	// must set Value to cty.NilVal to represent the absense of a value.
+	// must set Value to cty.NilVal to represent the absence of a value.
 	// This requirement is to help detect situations where the caller isn't
 	// correctly detecting and handling all of the declared variables.
 	//

--- a/internal/tfdiags/consolidate_warnings.go
+++ b/internal/tfdiags/consolidate_warnings.go
@@ -15,7 +15,7 @@ import "fmt"
 // particularly if they are going to be interpreted by software rather than
 // by a human reader.
 //
-// The returned slice always has a separate backing array from the reciever,
+// The returned slice always has a separate backing array from the receiver,
 // but some diagnostic values themselves might be shared.
 //
 // The definition of "unreasonable" is given as the threshold argument. At most

--- a/internal/tfdiags/diagnostic.go
+++ b/internal/tfdiags/diagnostic.go
@@ -21,7 +21,7 @@ type Diagnostic interface {
 
 	// ExtraInfo returns the raw extra information value. This is a low-level
 	// API which requires some work on the part of the caller to properly
-	// access associated information, so in most cases it'll be more convienient
+	// access associated information, so in most cases it'll be more convenient
 	// to use the package-level ExtraInfo function to try to unpack a particular
 	// specialized interface from this value.
 	ExtraInfo() interface{}

--- a/internal/tfdiags/diagnostic_extra.go
+++ b/internal/tfdiags/diagnostic_extra.go
@@ -93,7 +93,7 @@ func ExtraInfoNext[T any](previous interface{}) T {
 // tfdiags API, but that non-HCL uses of this will not need to implement HCL
 // just to get this interface.
 type DiagnosticExtraUnwrapper interface {
-	// If the reciever is wrapping another "diagnostic extra" value, returns
+	// If the receiver is wrapping another "diagnostic extra" value, returns
 	// that value. Otherwise returns nil to indicate dynamically that nothing
 	// is wrapped.
 	//

--- a/scripts/staticcheck.sh
+++ b/scripts/staticcheck.sh
@@ -15,7 +15,7 @@ packages=$(go list ./... | egrep -v ${skip})
 
 # We are skipping style-related checks, since terraform intentionally breaks
 # some of these. The goal here is to find issues that reduce code clarity, or
-# may result in bugs. We also disable fucntion deprecation checks (SA1019)
+# may result in bugs. We also disable function deprecation checks (SA1019)
 # because our policy is to update deprecated calls locally while making other
 # nearby changes, rather than to make cross-cutting changes to update them all.
 go run honnef.co/go/tools/cmd/staticcheck -checks 'all,-SA1019,-ST*' ${packages}

--- a/website/docs/internals/module-registry-protocol.mdx
+++ b/website/docs/internals/module-registry-protocol.mdx
@@ -147,7 +147,7 @@ $ curl 'https://registry.terraform.io/v1/modules/hashicorp/consul/aws/versions'
 The `modules` array in the response always includes the requested module as the
 first element.
 
-Terraform does not use the other elements of this list. However, third-party implementations should always use a single-element list for forward compatiblity.
+Terraform does not use the other elements of this list. However, third-party implementations should always use a single-element list for forward compatibility.
 
 Each returned module has an array of available versions, which Terraform
 matches against any version constraints given in configuration.

--- a/website/docs/language/functions/regex.mdx
+++ b/website/docs/language/functions/regex.mdx
@@ -121,7 +121,7 @@ The available flags are listed in the table below:
 | `i`  | Case insensitive: a literal letter in the pattern matches both lowercase and uppercase versions of that letter                                              |
 | `m`  | The `^` and `$` operators also match the beginning and end of lines within the string, marked by newline characters; behavior of `\A` and `\z` is unchanged |
 | `s`  | The `.` operator also matches newline                                                                                                                       |
-| `U`  | The meaning of presence or absense `?` after a repetition operator is inverted. For example, `x*` is interpreted like `x*?` and vice-versa.                 |
+| `U`  | The meaning of presence or absence `?` after a repetition operator is inverted. For example, `x*` is interpreted like `x*?` and vice-versa.                 |
 
 ## Examples
 

--- a/website/docs/language/resources/provisioners/file.mdx
+++ b/website/docs/language/resources/provisioners/file.mdx
@@ -100,7 +100,7 @@ your `destination` argument when using WinRM, because it can serve as a vector
 for arbitrary PowerShell code execution on the remote system.
 
 Modern Windows systems support running an OpenSSH server, so we strongly
-recommend choosing SSH over WinRM whereever possible, and using WinRM only as
+recommend choosing SSH over WinRM wherever possible, and using WinRM only as
 a last resort when working with obsolete Windows versions.
 
 ## Directory Uploads

--- a/website/docs/language/v1-compatibility-promises.mdx
+++ b/website/docs/language/v1-compatibility-promises.mdx
@@ -314,7 +314,7 @@ compatibility promises.
 ## Community-maintained State Storage Backends
 
 The `azurerm`, `consul`, `s3`, and `kubernetes` backends are maintained by
-other teams at HashiCorp. Those teams intend to continue basic maintenence at
+other teams at HashiCorp. Those teams intend to continue basic maintenance at
 the level of bug fixes through the v1.x releases, unless we implement a plugin
 protocol for backends at which point development of these backends is likely
 to continue in the external plugins only, which may require configuration
@@ -498,7 +498,7 @@ processing of logs by Terraform developers.
 All of the following commands and their subcommands/options are _not_ subject
 to compatibility promises, either because we have existing plans to improve
 them during the v1.x series or because we are aware of shortcomings in their
-design that might require breaking changes for ongoing maintenence.
+design that might require breaking changes for ongoing maintenance.
 
 While you can freely use these commands when running Terraform interactively
 as long as they remain supported, we don't recommend using them as part of


### PR DESCRIPTION
Fixed typos:

absense -> absence
anomolies -> anomalies
convienient -> convenient
compatiblity -> compatibility
existance -> existence
distingish -> distinguish
inheritence -> inheritance
heterogenous -> heterogeneous
fucntion -> function
orginal -> original
occurence -> occurrence
occured -> occurred
maintenence -> maintenance
refering -> referring
propogate -> propagate
receving -> receiving
reciever -> receiver
supress -> suppress
somwhere -> somewhere
whereever -> wherever
targetting -> targeting

Found with: https://github.com/ss18/grep-typos

