### PR TITLE
fix(s3): allow aliases for kms key

### DIFF
--- a/internal/backend/remote-state/s3/validate.go
+++ b/internal/backend/remote-state/s3/validate.go
@@ -21,7 +21,7 @@ import (
 const (
 	multiRegionKeyIdPattern = `mrk-[a-f0-9]{32}`
 	uuidRegexPattern        = `[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[ab89][a-f0-9]{3}-[a-f0-9]{12}`
-	aliasRegexPattern       = `alias/(.*)`
+	aliasRegexPattern       = `alias/[a-zA-Z0-9/_-]+`
 )
 
 func validateKMSKey(path cty.Path, s string) (diags tfdiags.Diagnostics) {
@@ -86,7 +86,7 @@ func keyIdFromARNResource(s string) string {
 }
 
 func aliasIdFromARNResource(s string) string {
-	aliasIdResourceRegex := regexp.MustCompile(`^` + aliasRegexPattern + `$`)
+	aliasIdResourceRegex := regexp.MustCompile(`^(` + aliasRegexPattern + `)$`)
 	matches := aliasIdResourceRegex.FindStringSubmatch(s)
 	if matches == nil || len(matches) != 2 {
 		return ""

--- a/internal/backend/remote-state/s3/validate_test.go
+++ b/internal/backend/remote-state/s3/validate_test.go
@@ -38,25 +38,9 @@ func TestValidateKMSKey(t *testing.T) {
 		},
 		"kms key alias": {
 			in: "alias/arbitrary-key",
-			expected: tfdiags.Diagnostics{
-				tfdiags.AttributeValue(
-					tfdiags.Error,
-					"Invalid KMS Key ID",
-					`Value must be a valid KMS Key ID, got "alias/arbitrary-key"`,
-					path,
-				),
-			},
 		},
 		"kms key alias arn": {
 			in: "arn:aws:kms:us-west-2:111122223333:alias/arbitrary-key",
-			expected: tfdiags.Diagnostics{
-				tfdiags.AttributeValue(
-					tfdiags.Error,
-					"Invalid KMS Key ARN",
-					`Value must be a valid KMS Key ARN, got "arn:aws:kms:us-west-2:111122223333:alias/arbitrary-key"`,
-					path,
-				),
-			},
 		},
 		"invalid key": {
 			in: "$%wrongkey",


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->
Release 1.6.0 broke the ability to use s3 key aliases in the s3 backend. This change adjusts the tests, and validation of kms key arn's to look for aliases

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Fixes #33979
Fixes #34005 

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.6.1

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

###  BUG FIXES
- Fixes the ability to use KMS key aliases in the S3 backend

<!--

Write a short description of the user-facing change. Examples:

- `terraform show -json`: Fixed crash with sensitive set values.
- When rendering a diff, Terraform now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 
