### PR TITLE
Add skip_requesting_account_id Parameter to S3 Backend

### DIFF
--- a/internal/backend/remote-state/s3/backend.go
+++ b/internal/backend/remote-state/s3/backend.go
@@ -185,6 +185,11 @@ func (b *Backend) ConfigSchema() *configschema.Block {
 				Optional:    true,
 				Description: "Skip the credentials validation via STS API.",
 			},
+			"skip_requesting_account_id": {
+				Type:        cty.Bool,
+				Optional:    true,
+				Description: "Skip the requesting account ID. Useful for AWS API implementations that do not have the IAM, STS API, or metadata API.",
+			},
 			"skip_metadata_api_check": {
 				Type:        cty.Bool,
 				Optional:    true,
@@ -956,17 +961,18 @@ func (b *Backend) Configure(obj cty.Value) tfdiags.Diagnostics {
 	ctx, baselog := baselogging.NewHcLogger(ctx, log)
 
 	cfg := &awsbase.Config{
-		AccessKey:              stringAttr(obj, "access_key"),
-		APNInfo:                stdUserAgentProducts(),
-		CallerDocumentationURL: "https://www.terraform.io/docs/language/settings/backends/s3.html",
-		CallerName:             "S3 Backend",
-		Logger:                 baselog,
-		MaxRetries:             intAttrDefault(obj, "max_retries", 5),
-		Profile:                stringAttr(obj, "profile"),
-		Region:                 stringAttr(obj, "region"),
-		SecretKey:              stringAttr(obj, "secret_key"),
-		SkipCredsValidation:    boolAttr(obj, "skip_credentials_validation"),
-		Token:                  stringAttr(obj, "token"),
+		AccessKey:               stringAttr(obj, "access_key"),
+		APNInfo:                 stdUserAgentProducts(),
+		CallerDocumentationURL:  "https://www.terraform.io/docs/language/settings/backends/s3.html",
+		CallerName:              "S3 Backend",
+		Logger:                  baselog,
+		MaxRetries:              intAttrDefault(obj, "max_retries", 5),
+		Profile:                 stringAttr(obj, "profile"),
+		Region:                  stringAttr(obj, "region"),
+		SecretKey:               stringAttr(obj, "secret_key"),
+		SkipCredsValidation:     boolAttr(obj, "skip_credentials_validation"),
+		SkipRequestingAccountId: boolAttr(obj, "skip_requesting_account_id"),
+		Token:                   stringAttr(obj, "token"),
 	}
 
 	// The "legacy" authentication workflow used in aws-sdk-go-base V1 will be

--- a/website/docs/language/settings/backends/s3.mdx
+++ b/website/docs/language/settings/backends/s3.mdx
@@ -174,6 +174,7 @@ The following configuration is optional:
 * `shared_credentials_files`  - (Optional) List of paths to AWS shared credentials files. Defaults to `~/.aws/credentials`.
 * `skip_credentials_validation` - (Optional) Skip credentials validation via the STS API.
 * `skip_region_validation` - (Optional) Skip validation of provided region name.
+* `skip_requesting_account_id` - (Optional) Whether to skip requesting the account ID. Useful for AWS API implementations that do not have the IAM, STS API, or metadata API.
 * `skip_metadata_api_check` - (Optional) Skip usage of EC2 Metadata API.
 * `sts_endpoint` - (Optional, **Deprecated**) Custom endpoint URL for the AWS Security Token Service (STS) API.
   Use `endpoints.sts` instead.


### PR DESCRIPTION
As recent (1.6) changes to the s3 backend are breaking for anyone using an s3 api without STS API (like minio), this PR introduces a `skip_requesting_account_id` param analogously to the [aws provider](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#skip_requesting_account_id).

Fixes #33983

## Target Release

1.6.1

## Draft CHANGELOG entry

### ENHANCEMENTS

-  Add `skip_requesting_account_id` param to s3 backend for use with S3 APIs without STS.
