### PR TITLE
cli: ignore expired provider signing keys from registry during init

### DIFF
--- a/internal/getproviders/package_authentication_test.go
+++ b/internal/getproviders/package_authentication_test.go
@@ -11,23 +11,13 @@ import (
 	"os"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/google/go-cmp/cmp"
 
 	"github.com/ProtonMail/go-crypto/openpgp"
-	"github.com/ProtonMail/go-crypto/openpgp/packet"
 )
 
 func TestMain(m *testing.M) {
-	openpgpConfig = &packet.Config{
-		Time: func() time.Time {
-			// Scientifically chosen time that satisfies the validity periods of all
-			// of the keys and signatures used.
-			t, _ := time.Parse(time.RFC3339, "2021-04-25T16:00:00-07:00")
-			return t
-		},
-	}
 	os.Exit(m.Run())
 }
 

--- a/internal/getproviders/registry_client_test.go
+++ b/internal/getproviders/registry_client_test.go
@@ -6,7 +6,6 @@ package getproviders
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"log"
 	"net/http"
 	"net/http/httptest"
@@ -448,8 +447,6 @@ func TestFindClosestProtocolCompatibleVersion(t *testing.T) {
 			if test.wantErr != "" {
 				t.Fatalf("wrong error\ngot:  <nil>\nwant: %s", test.wantErr)
 			}
-
-			fmt.Printf("Got: %s, Want: %s\n", got, test.wantSuggestion)
 
 			if !got.Same(test.wantSuggestion) {
 				t.Fatalf("wrong result\ngot:  %s\nwant: %s", got.String(), test.wantSuggestion.String())


### PR DESCRIPTION
The community fork of the `openpgp` package chosen by Terraform added unconditional verification of key expiration when validating signatures, which under normal circumstances is a welcome hardening of the API. This impact of this change however was overlooked when migrating to the new package, and it interfered with the current workflow set by the Terraform Registry.

Provider developers are not currently required to keep the signing keys stored in the Registry up to date, and older releases may be signed with a key which has since expired. For our purposes here however, we are validating the key and signature used at the time of publishing, and given that the Registry has previously vouched for the validity of the key used, we can continue to trust that key returned by the Registry for installation.

This reverts the signature handling to that of the prior Terraform release, but new workflows with more fine-grained key handling may be developed in future versions of Terraform and the Registry.

Fixes #33984