### PR TITLE
Fix cloud integration's handling of TF_WORKSPACE environment variable

### DIFF
--- a/internal/cloud/backend_test.go
+++ b/internal/cloud/backend_test.go
@@ -138,7 +138,7 @@ func TestCloud_PrepareConfig(t *testing.T) {
 	}
 }
 
-func WithEnvVars(t *testing.T) {
+func TestCloud_configWithEnvVars(t *testing.T) {
 	cases := map[string]struct {
 		setup                 func(b *Cloud)
 		config                cty.Value

--- a/internal/cloud/backend_test.go
+++ b/internal/cloud/backend_test.go
@@ -243,7 +243,7 @@ func TestCloud_configWithEnvVars(t *testing.T) {
 			vars: map[string]string{
 				"TF_WORKSPACE": "shire",
 			},
-			expectedWorkspaceName: "mt-doom",
+			expectedErr: `conflicts with TF_WORKSPACE environment variable`,
 		},
 		"env var workspace does not have specified tag": {
 			setup: func(b *Cloud) {
@@ -379,7 +379,10 @@ func TestCloud_configWithEnvVars(t *testing.T) {
 					"project": cty.StringVal("my-project"),
 				}),
 			}),
-			expectedProjectName: "another-project", // No error is raised, workspace is still in the original project
+			expectedProjectName: "my-project",
+			// No error is raised, and workspace is still in its original
+			// project, but the configured project for any future workspaces
+			// created with `terraform workspace new` is unaffected.
 		},
 		"with everything set as env vars": {
 			config: cty.ObjectVal(map[string]cty.Value{

--- a/internal/cloud/backend_test.go
+++ b/internal/cloud/backend_test.go
@@ -78,52 +78,14 @@ func TestCloud_backendWithTags(t *testing.T) {
 	}
 }
 
+// Test b.PrepareConfig, which actually does very little; most real validation
+// happens later in resolveCloudConfig.
 func TestCloud_PrepareConfig(t *testing.T) {
 	cases := map[string]struct {
 		config      cty.Value
 		expectedErr string
 	}{
-		"null organization": {
-			config: cty.ObjectVal(map[string]cty.Value{
-				"organization": cty.NullVal(cty.String),
-				"workspaces": cty.ObjectVal(map[string]cty.Value{
-					"name":    cty.StringVal("prod"),
-					"tags":    cty.NullVal(cty.Set(cty.String)),
-					"project": cty.NullVal(cty.String),
-				}),
-			}),
-			expectedErr: `Invalid or missing required argument: "organization" must be set in the cloud configuration or as an environment variable: TF_CLOUD_ORGANIZATION.`,
-		},
-		"null workspace": {
-			config: cty.ObjectVal(map[string]cty.Value{
-				"organization": cty.StringVal("org"),
-				"workspaces":   cty.NullVal(cty.String),
-			}),
-			expectedErr: `Invalid workspaces configuration: Missing workspace mapping strategy. Either workspace "tags" or "name" is required.`,
-		},
-		"workspace: empty tags, name": {
-			config: cty.ObjectVal(map[string]cty.Value{
-				"organization": cty.StringVal("org"),
-				"workspaces": cty.ObjectVal(map[string]cty.Value{
-					"name":    cty.NullVal(cty.String),
-					"tags":    cty.NullVal(cty.Set(cty.String)),
-					"project": cty.NullVal(cty.String),
-				}),
-			}),
-			expectedErr: `Invalid workspaces configuration: Missing workspace mapping strategy. Either workspace "tags" or "name" is required.`,
-		},
-		"workspace: name present": {
-			config: cty.ObjectVal(map[string]cty.Value{
-				"organization": cty.StringVal("org"),
-				"workspaces": cty.ObjectVal(map[string]cty.Value{
-					"name":    cty.StringVal("prod"),
-					"tags":    cty.NullVal(cty.Set(cty.String)),
-					"project": cty.NullVal(cty.String),
-				}),
-			}),
-			expectedErr: `Invalid workspaces configuration: Only one of workspace "tags" or "name" is allowed.`,
-		},
-		"workspace: name and tags present": {
+		"workspace: name and tags conflict": {
 			config: cty.ObjectVal(map[string]cty.Value{
 				"organization": cty.StringVal("org"),
 				"workspaces": cty.ObjectVal(map[string]cty.Value{
@@ -138,6 +100,18 @@ func TestCloud_PrepareConfig(t *testing.T) {
 			}),
 			expectedErr: `Invalid workspaces configuration: Only one of workspace "tags" or "name" is allowed.`,
 		},
+		"totally empty config block is ok": {
+			config: cty.ObjectVal(map[string]cty.Value{
+				"hostname":     cty.NullVal(cty.String),
+				"token":        cty.NullVal(cty.String),
+				"organization": cty.NullVal(cty.String),
+				"workspaces": cty.NullVal(cty.Object(map[string]cty.Type{
+					"name":    cty.String,
+					"tags":    cty.Set(cty.String),
+					"project": cty.String,
+				})),
+			}),
+		},
 	}
 
 	for name, tc := range cases {
@@ -146,126 +120,21 @@ func TestCloud_PrepareConfig(t *testing.T) {
 
 		// Validate
 		_, valDiags := b.PrepareConfig(tc.config)
-		if valDiags.Err() != nil && tc.expectedErr != "" {
-			actualErr := valDiags.Err().Error()
-			if !strings.Contains(actualErr, tc.expectedErr) {
-				t.Fatalf("%s: unexpected validation result: %v", name, valDiags.Err())
-			}
-		}
-	}
-}
 
-func TestCloud_PrepareConfigWithEnvVars(t *testing.T) {
-	cases := map[string]struct {
-		config      cty.Value
-		vars        map[string]string
-		expectedErr string
-	}{
-		"with no organization": {
-			config: cty.ObjectVal(map[string]cty.Value{
-				"organization": cty.NullVal(cty.String),
-				"workspaces": cty.ObjectVal(map[string]cty.Value{
-					"name":    cty.StringVal("prod"),
-					"tags":    cty.NullVal(cty.Set(cty.String)),
-					"project": cty.NullVal(cty.String),
-				}),
-			}),
-			vars: map[string]string{
-				"TF_CLOUD_ORGANIZATION": "example-org",
-			},
-		},
-		"with no organization attribute or env var": {
-			config: cty.ObjectVal(map[string]cty.Value{
-				"organization": cty.NullVal(cty.String),
-				"workspaces": cty.ObjectVal(map[string]cty.Value{
-					"name":    cty.StringVal("prod"),
-					"tags":    cty.NullVal(cty.Set(cty.String)),
-					"project": cty.NullVal(cty.String),
-				}),
-			}),
-			vars:        map[string]string{},
-			expectedErr: `Invalid or missing required argument: "organization" must be set in the cloud configuration or as an environment variable: TF_CLOUD_ORGANIZATION.`,
-		},
-		"null workspace": {
-			config: cty.ObjectVal(map[string]cty.Value{
-				"organization": cty.StringVal("hashicorp"),
-				"workspaces":   cty.NullVal(cty.String),
-			}),
-			vars: map[string]string{
-				"TF_WORKSPACE": "my-workspace",
-			},
-		},
-		"organization and workspace and project env var": {
-			config: cty.ObjectVal(map[string]cty.Value{
-				"organization": cty.NullVal(cty.String),
-				"workspaces":   cty.NullVal(cty.String),
-			}),
-			vars: map[string]string{
-				"TF_CLOUD_ORGANIZATION": "hashicorp",
-				"TF_WORKSPACE":          "my-workspace",
-				"TF_CLOUD_PROJECT":      "example-project",
-			},
-		},
-		"with no project": {
-			config: cty.ObjectVal(map[string]cty.Value{
-				"organization": cty.StringVal("organization"),
-				"workspaces": cty.ObjectVal(map[string]cty.Value{
-					"name":    cty.StringVal("prod"),
-					"tags":    cty.NullVal(cty.Set(cty.String)),
-					"project": cty.NullVal(cty.String),
-				}),
-			}),
-		},
-		"with null project": {
-			config: cty.ObjectVal(map[string]cty.Value{
-				"organization": cty.StringVal("organization"),
-				"workspaces": cty.ObjectVal(map[string]cty.Value{
-					"name":    cty.StringVal("prod"),
-					"tags":    cty.NullVal(cty.Set(cty.String)),
-					"project": cty.NullVal(cty.String),
-				}),
-			}),
-			vars: map[string]string{
-				"TF_CLOUD_PROJECT": "example-project",
-			},
-		},
-		"with project env var ovewrite config value": {
-			config: cty.ObjectVal(map[string]cty.Value{
-				"organization": cty.StringVal("organization"),
-				"workspaces": cty.ObjectVal(map[string]cty.Value{
-					"name":    cty.StringVal("prod"),
-					"tags":    cty.NullVal(cty.Set(cty.String)),
-					"project": cty.StringVal("project-name"),
-				}),
-			}),
-			vars: map[string]string{
-				"TF_CLOUD_PROJECT": "example-project",
-			},
-		},
-	}
-
-	for name, tc := range cases {
-		t.Run(name, func(t *testing.T) {
-			s := testServer(t)
-			b := New(testDisco(s))
-
-			for k, v := range tc.vars {
-				os.Setenv(k, v)
-			}
-			t.Cleanup(func() {
-				for k := range tc.vars {
-					os.Unsetenv(k)
-				}
-			})
-
-			_, valDiags := b.PrepareConfig(tc.config)
-			if valDiags.Err() != nil && tc.expectedErr != "" {
+		if tc.expectedErr != "" {
+			if valDiags.Err() == nil {
+				t.Fatalf("%s: expected validation error %q but didn't get one", name, tc.expectedErr)
+			} else {
 				actualErr := valDiags.Err().Error()
 				if !strings.Contains(actualErr, tc.expectedErr) {
-					t.Fatalf("%s: unexpected validation result: %v", name, valDiags.Err())
+					t.Fatalf("%s: expected validation error %q but instead got %q", name, tc.expectedErr, actualErr)
 				}
 			}
-		})
+		} else {
+			if valDiags.Err() != nil {
+				t.Fatalf("%s: expected validation to pass but got error %q", name, valDiags.Err().Error())
+			}
+		}
 	}
 }
 
@@ -856,6 +725,351 @@ func TestCloud_resolveCloudConfig(t *testing.T) {
 				},
 			},
 		},
+		"totally empty config block": {
+			config: cty.ObjectVal(map[string]cty.Value{
+				"hostname":     cty.NullVal(cty.String),
+				"token":        cty.NullVal(cty.String),
+				"organization": cty.NullVal(cty.String),
+				"workspaces": cty.NullVal(cty.Object(map[string]cty.Type{
+					"name":    cty.String,
+					"tags":    cty.Set(cty.String),
+					"project": cty.String,
+				})),
+			}),
+			vars: map[string]string{
+				"TF_CLOUD_HOSTNAME":     "app.staging.terraform.io",
+				"TF_CLOUD_ORGANIZATION": "examplecorp",
+				"TF_WORKSPACE":          "prod",
+				"TF_CLOUD_PROJECT":      "networking",
+			},
+			expectedResult: cloudConfig{
+				hostname:     "app.staging.terraform.io",
+				organization: "examplecorp",
+				token:        "",
+				workspaceMapping: WorkspaceMapping{
+					Name:    "prod",
+					Project: "networking",
+				},
+			},
+		},
+		"null organization": {
+			config: cty.ObjectVal(map[string]cty.Value{
+				"organization": cty.NullVal(cty.String),
+				"hostname":     cty.NullVal(cty.String),
+				"token":        cty.NullVal(cty.String),
+				"workspaces": cty.ObjectVal(map[string]cty.Value{
+					"name":    cty.StringVal("prod"),
+					"tags":    cty.NullVal(cty.Set(cty.String)),
+					"project": cty.NullVal(cty.String),
+				}),
+			}),
+			expectedErr: `Invalid or missing required argument: "organization" must be set in the cloud configuration or as an environment variable: TF_CLOUD_ORGANIZATION.`,
+		},
+		"null workspace": {
+			config: cty.ObjectVal(map[string]cty.Value{
+				"organization": cty.StringVal("org"),
+				"hostname":     cty.NullVal(cty.String),
+				"token":        cty.NullVal(cty.String),
+				"workspaces": cty.NullVal(cty.Object(map[string]cty.Type{
+					"name":    cty.String,
+					"tags":    cty.Set(cty.String),
+					"project": cty.String,
+				})),
+			}),
+			expectedErr: `Invalid workspaces configuration: Missing workspace mapping strategy. Either workspace "tags" or "name" is required.`,
+		},
+		"workspace: empty tags, name": {
+			config: cty.ObjectVal(map[string]cty.Value{
+				"organization": cty.StringVal("org"),
+				"hostname":     cty.NullVal(cty.String),
+				"token":        cty.NullVal(cty.String),
+				"workspaces": cty.ObjectVal(map[string]cty.Value{
+					"name":    cty.NullVal(cty.String),
+					"tags":    cty.NullVal(cty.Set(cty.String)),
+					"project": cty.NullVal(cty.String),
+				}),
+			}),
+			expectedErr: `Invalid workspaces configuration: Missing workspace mapping strategy. Either workspace "tags" or "name" is required.`,
+		},
+		"workspace: name and tags present": {
+			config: cty.ObjectVal(map[string]cty.Value{
+				"organization": cty.StringVal("org"),
+				"hostname":     cty.NullVal(cty.String),
+				"token":        cty.NullVal(cty.String),
+				"workspaces": cty.ObjectVal(map[string]cty.Value{
+					"name": cty.StringVal("prod"),
+					"tags": cty.SetVal(
+						[]cty.Value{
+							cty.StringVal("billing"),
+						},
+					),
+					"project": cty.NullVal(cty.String),
+				}),
+			}),
+			expectedErr: `Invalid workspaces configuration: Only one of workspace "tags" or "name" is allowed.`,
+		},
+		"organization from environment": {
+			config: cty.ObjectVal(map[string]cty.Value{
+				"organization": cty.NullVal(cty.String),
+				"hostname":     cty.NullVal(cty.String),
+				"token":        cty.NullVal(cty.String),
+				"workspaces": cty.ObjectVal(map[string]cty.Value{
+					"name":    cty.StringVal("prod"),
+					"tags":    cty.NullVal(cty.Set(cty.String)),
+					"project": cty.NullVal(cty.String),
+				}),
+			}),
+			vars: map[string]string{
+				"TF_CLOUD_ORGANIZATION": "example-org",
+			},
+			expectedResult: cloudConfig{
+				hostname:     defaultHostname,
+				organization: "example-org",
+				token:        "",
+				workspaceMapping: WorkspaceMapping{
+					Name: "prod",
+				},
+			},
+		},
+		"with no organization attribute or env var": {
+			config: cty.ObjectVal(map[string]cty.Value{
+				"organization": cty.NullVal(cty.String),
+				"hostname":     cty.NullVal(cty.String),
+				"token":        cty.NullVal(cty.String),
+				"workspaces": cty.ObjectVal(map[string]cty.Value{
+					"name":    cty.StringVal("prod"),
+					"tags":    cty.NullVal(cty.Set(cty.String)),
+					"project": cty.NullVal(cty.String),
+				}),
+			}),
+			vars:        map[string]string{},
+			expectedErr: `Invalid or missing required argument: "organization" must be set in the cloud configuration or as an environment variable: TF_CLOUD_ORGANIZATION.`,
+		},
+		"null workspace, TF_WORKSPACE present": {
+			config: cty.ObjectVal(map[string]cty.Value{
+				"organization": cty.StringVal("hashicorp"),
+				"hostname":     cty.NullVal(cty.String),
+				"token":        cty.NullVal(cty.String),
+				"workspaces": cty.NullVal(cty.Object(map[string]cty.Type{
+					"name":    cty.String,
+					"tags":    cty.Set(cty.String),
+					"project": cty.String,
+				})),
+			}),
+			vars: map[string]string{
+				"TF_WORKSPACE": "my-workspace",
+			},
+			expectedResult: cloudConfig{
+				hostname:     defaultHostname,
+				organization: "hashicorp",
+				token:        "",
+				workspaceMapping: WorkspaceMapping{
+					Name: "my-workspace",
+				},
+			},
+		},
+		"organization and workspace and project env var": {
+			config: cty.ObjectVal(map[string]cty.Value{
+				"hostname":     cty.NullVal(cty.String),
+				"token":        cty.NullVal(cty.String),
+				"organization": cty.NullVal(cty.String),
+				"workspaces": cty.NullVal(cty.Object(map[string]cty.Type{
+					"name":    cty.String,
+					"tags":    cty.Set(cty.String),
+					"project": cty.String,
+				})),
+			}),
+			vars: map[string]string{
+				"TF_CLOUD_ORGANIZATION": "hashicorp",
+				"TF_WORKSPACE":          "my-workspace",
+				"TF_CLOUD_PROJECT":      "example-project",
+			},
+			expectedResult: cloudConfig{
+				hostname:     defaultHostname,
+				organization: "hashicorp",
+				token:        "",
+				workspaceMapping: WorkspaceMapping{
+					Name:    "my-workspace",
+					Project: "example-project",
+				},
+			},
+		},
+		"with no project": {
+			config: cty.ObjectVal(map[string]cty.Value{
+				"organization": cty.StringVal("examplecorp"),
+				"hostname":     cty.NullVal(cty.String),
+				"token":        cty.NullVal(cty.String),
+				"workspaces": cty.ObjectVal(map[string]cty.Value{
+					"name":    cty.StringVal("prod"),
+					"tags":    cty.NullVal(cty.Set(cty.String)),
+					"project": cty.NullVal(cty.String),
+				}),
+			}),
+			expectedResult: cloudConfig{
+				hostname:     defaultHostname,
+				organization: "examplecorp",
+				token:        "",
+				workspaceMapping: WorkspaceMapping{
+					Name: "prod",
+				},
+			},
+		},
+		"with project from environment": {
+			config: cty.ObjectVal(map[string]cty.Value{
+				"organization": cty.StringVal("examplecorp"),
+				"hostname":     cty.NullVal(cty.String),
+				"token":        cty.NullVal(cty.String),
+				"workspaces": cty.ObjectVal(map[string]cty.Value{
+					"name":    cty.StringVal("prod"),
+					"tags":    cty.NullVal(cty.Set(cty.String)),
+					"project": cty.NullVal(cty.String),
+				}),
+			}),
+			vars: map[string]string{
+				"TF_CLOUD_PROJECT": "example-project",
+			},
+			expectedResult: cloudConfig{
+				hostname:     defaultHostname,
+				organization: "examplecorp",
+				token:        "",
+				workspaceMapping: WorkspaceMapping{
+					Name:    "prod",
+					Project: "example-project",
+				},
+			},
+		},
+		"with both project env var and config value": {
+			config: cty.ObjectVal(map[string]cty.Value{
+				"organization": cty.StringVal("examplecorp"),
+				"hostname":     cty.NullVal(cty.String),
+				"token":        cty.NullVal(cty.String),
+				"workspaces": cty.ObjectVal(map[string]cty.Value{
+					"name":    cty.StringVal("prod"),
+					"tags":    cty.NullVal(cty.Set(cty.String)),
+					"project": cty.StringVal("config-project"),
+				}),
+			}),
+			vars: map[string]string{
+				"TF_CLOUD_PROJECT": "env-project",
+			},
+			expectedResult: cloudConfig{
+				hostname:     defaultHostname,
+				organization: "examplecorp",
+				token:        "",
+				workspaceMapping: WorkspaceMapping{
+					Name:    "prod",
+					Project: "config-project", // config wins
+				},
+			},
+		},
+
+		// TODO: fix expectations from setConfigurationFields cases
+		"with hostname set": {
+			config: cty.ObjectVal(map[string]cty.Value{
+				"organization": cty.StringVal("hashicorp"),
+				"hostname":     cty.StringVal("hashicorp.com"),
+				"token":        cty.NullVal(cty.String),
+				"workspaces": cty.ObjectVal(map[string]cty.Value{
+					"name":    cty.StringVal("prod"),
+					"tags":    cty.NullVal(cty.Set(cty.String)),
+					"project": cty.NullVal(cty.String),
+				}),
+			}),
+			expectedResult: cloudConfig{
+				hostname:     "hashicorp.com",
+				organization: "hashicorp",
+				token:        "",
+				workspaceMapping: WorkspaceMapping{
+					Name: "prod",
+				},
+			},
+		},
+		"with hostname not set, set to default hostname": {
+			config: cty.ObjectVal(map[string]cty.Value{
+				"organization": cty.StringVal("hashicorp"),
+				"hostname":     cty.NullVal(cty.String),
+				"token":        cty.NullVal(cty.String),
+				"workspaces": cty.ObjectVal(map[string]cty.Value{
+					"name":    cty.StringVal("prod"),
+					"tags":    cty.NullVal(cty.Set(cty.String)),
+					"project": cty.NullVal(cty.String),
+				}),
+			}),
+			expectedResult: cloudConfig{
+				hostname:     defaultHostname,
+				organization: "hashicorp",
+				token:        "",
+				workspaceMapping: WorkspaceMapping{
+					Name: "prod",
+				},
+			},
+		},
+		"with workspace name set": {
+			config: cty.ObjectVal(map[string]cty.Value{
+				"organization": cty.StringVal("hashicorp"),
+				"hostname":     cty.StringVal("hashicorp.com"),
+				"token":        cty.NullVal(cty.String),
+				"workspaces": cty.ObjectVal(map[string]cty.Value{
+					"name":    cty.StringVal("prod"),
+					"tags":    cty.NullVal(cty.Set(cty.String)),
+					"project": cty.NullVal(cty.String),
+				}),
+			}),
+			expectedResult: cloudConfig{
+				hostname:     "hashicorp.com",
+				organization: "hashicorp",
+				token:        "",
+				workspaceMapping: WorkspaceMapping{
+					Name: "prod",
+				},
+			},
+		},
+		"with workspace tags set": {
+			config: cty.ObjectVal(map[string]cty.Value{
+				"organization": cty.StringVal("hashicorp"),
+				"hostname":     cty.StringVal("hashicorp.com"),
+				"token":        cty.NullVal(cty.String),
+				"workspaces": cty.ObjectVal(map[string]cty.Value{
+					"name": cty.NullVal(cty.String),
+					"tags": cty.SetVal(
+						[]cty.Value{
+							cty.StringVal("billing"),
+							cty.StringVal("applications"),
+						},
+					),
+					"project": cty.NullVal(cty.String),
+				}),
+			}),
+			expectedResult: cloudConfig{
+				hostname:     "hashicorp.com",
+				organization: "hashicorp",
+				token:        "",
+				workspaceMapping: WorkspaceMapping{
+					Tags: []string{"billing", "applications"},
+				},
+			},
+		},
+		"with project name set": {
+			config: cty.ObjectVal(map[string]cty.Value{
+				"organization": cty.StringVal("hashicorp"),
+				"hostname":     cty.StringVal("hashicorp.com"),
+				"token":        cty.NullVal(cty.String),
+				"workspaces": cty.ObjectVal(map[string]cty.Value{
+					"name":    cty.StringVal("prod"),
+					"tags":    cty.NullVal(cty.Set(cty.String)),
+					"project": cty.StringVal("my-project"),
+				}),
+			}),
+			expectedResult: cloudConfig{
+				hostname:     "hashicorp.com",
+				organization: "hashicorp",
+				token:        "",
+				workspaceMapping: WorkspaceMapping{
+					Name:    "prod",
+					Project: "my-project",
+				},
+			},
+		},
 	}
 
 	for name, tc := range cases {
@@ -894,183 +1108,38 @@ func TestCloud_resolveCloudConfig(t *testing.T) {
 	}
 }
 
-func TestCloud_setConfigurationFields(t *testing.T) {
-	originalForceBackendEnv := os.Getenv("TF_FORCE_LOCAL_BACKEND")
+func TestCloud_forceLocalBackend(t *testing.T) {
+	b, cleanup := testUnconfiguredBackend(t)
+	t.Cleanup(cleanup)
 
-	cases := map[string]struct {
-		obj                   cty.Value
-		expectedHostname      string
-		expectedOrganziation  string
-		expectedWorkspaceName string
-		expectedProjectName   string
-		expectedWorkspaceTags []string
-		expectedForceLocal    bool
-		setEnv                func()
-		resetEnv              func()
-		expectedErr           string
-	}{
-		"with hostname set": {
-			obj: cty.ObjectVal(map[string]cty.Value{
-				"organization": cty.StringVal("hashicorp"),
-				"hostname":     cty.StringVal("hashicorp.com"),
-				"workspaces": cty.ObjectVal(map[string]cty.Value{
-					"name":    cty.StringVal("prod"),
-					"tags":    cty.NullVal(cty.Set(cty.String)),
-					"project": cty.NullVal(cty.String),
-				}),
-			}),
-			expectedHostname:     "hashicorp.com",
-			expectedOrganziation: "hashicorp",
-		},
-		"with hostname not set, set to default hostname": {
-			obj: cty.ObjectVal(map[string]cty.Value{
-				"organization": cty.StringVal("hashicorp"),
-				"hostname":     cty.NullVal(cty.String),
-				"workspaces": cty.ObjectVal(map[string]cty.Value{
-					"name":    cty.StringVal("prod"),
-					"tags":    cty.NullVal(cty.Set(cty.String)),
-					"project": cty.NullVal(cty.String),
-				}),
-			}),
-			expectedHostname:     defaultHostname,
-			expectedOrganziation: "hashicorp",
-		},
-		"with workspace name set": {
-			obj: cty.ObjectVal(map[string]cty.Value{
-				"organization": cty.StringVal("hashicorp"),
-				"hostname":     cty.StringVal("hashicorp.com"),
-				"workspaces": cty.ObjectVal(map[string]cty.Value{
-					"name":    cty.StringVal("prod"),
-					"tags":    cty.NullVal(cty.Set(cty.String)),
-					"project": cty.NullVal(cty.String),
-				}),
-			}),
-			expectedHostname:      "hashicorp.com",
-			expectedOrganziation:  "hashicorp",
-			expectedWorkspaceName: "prod",
-		},
-		"with workspace tags set": {
-			obj: cty.ObjectVal(map[string]cty.Value{
-				"organization": cty.StringVal("hashicorp"),
-				"hostname":     cty.StringVal("hashicorp.com"),
-				"workspaces": cty.ObjectVal(map[string]cty.Value{
-					"name": cty.NullVal(cty.String),
-					"tags": cty.SetVal(
-						[]cty.Value{
-							cty.StringVal("billing"),
-						},
-					),
-					"project": cty.NullVal(cty.String),
-				}),
-			}),
-			expectedHostname:      "hashicorp.com",
-			expectedOrganziation:  "hashicorp",
-			expectedWorkspaceTags: []string{"billing"},
-		},
-		"with project name set": {
-			obj: cty.ObjectVal(map[string]cty.Value{
-				"organization": cty.StringVal("hashicorp"),
-				"hostname":     cty.StringVal("hashicorp.com"),
-				"workspaces": cty.ObjectVal(map[string]cty.Value{
-					"name":    cty.StringVal("prod"),
-					"tags":    cty.NullVal(cty.Set(cty.String)),
-					"project": cty.StringVal("my-project"),
-				}),
-			}),
-			expectedHostname:      "hashicorp.com",
-			expectedOrganziation:  "hashicorp",
-			expectedWorkspaceName: "prod",
-			expectedProjectName:   "my-project",
-		},
-		"with force local set": {
-			obj: cty.ObjectVal(map[string]cty.Value{
-				"organization": cty.StringVal("hashicorp"),
-				"hostname":     cty.StringVal("hashicorp.com"),
-				"workspaces": cty.ObjectVal(map[string]cty.Value{
-					"name":    cty.NullVal(cty.String),
-					"tags":    cty.NullVal(cty.Set(cty.String)),
-					"project": cty.NullVal(cty.String),
-				}),
-			}),
-			expectedHostname:     "hashicorp.com",
-			expectedOrganziation: "hashicorp",
-			setEnv: func() {
-				os.Setenv("TF_FORCE_LOCAL_BACKEND", "1")
-			},
-			resetEnv: func() {
-				os.Setenv("TF_FORCE_LOCAL_BACKEND", originalForceBackendEnv)
-			},
-			expectedForceLocal: true,
-		},
+	os.Setenv("TF_FORCE_LOCAL_BACKEND", "true")
+	t.Cleanup(func() {
+		os.Unsetenv("TF_FORCE_LOCAL_BACKEND")
+	})
+
+	obj := cty.ObjectVal(map[string]cty.Value{
+		"organization": cty.StringVal("hashicorp"),
+		"hostname":     cty.NullVal(cty.String),
+		"token":        cty.NullVal(cty.String),
+		"workspaces": cty.ObjectVal(map[string]cty.Value{
+			"name":    cty.StringVal("prod"),
+			"tags":    cty.NullVal(cty.Set(cty.String)),
+			"project": cty.NullVal(cty.String),
+		}),
+	})
+
+	obj, valDiags := b.PrepareConfig(obj)
+	if valDiags.Err() != nil {
+		t.Fatalf("unexpected validation result: %v", valDiags.Err())
 	}
 
-	for name, tc := range cases {
-		b := &Cloud{}
+	diags := b.Configure(obj)
+	if diags.Err() != nil {
+		t.Fatalf("unexpected configure result: %v", diags.Err())
+	}
 
-		// if `setEnv` is set, then we expect `resetEnv` to also be set
-		if tc.setEnv != nil {
-			tc.setEnv()
-			defer tc.resetEnv()
-		}
-
-		errDiags := b.setConfigurationFields(tc.obj)
-		if errDiags.HasErrors() || tc.expectedErr != "" {
-			actualErr := errDiags.Err().Error()
-			if !strings.Contains(actualErr, tc.expectedErr) {
-				t.Fatalf("%s: unexpected validation result: %v", name, errDiags.Err())
-			}
-		}
-
-		if tc.expectedHostname != "" && b.Hostname != tc.expectedHostname {
-			t.Fatalf("%s: expected hostname %s to match configured hostname %s", name, b.Hostname, tc.expectedHostname)
-		}
-		if tc.expectedOrganziation != "" && b.organization != tc.expectedOrganziation {
-			t.Fatalf("%s: expected organization (%s) to match configured organization (%s)", name, b.organization, tc.expectedOrganziation)
-		}
-		if tc.expectedWorkspaceName != "" && b.WorkspaceMapping.Name != tc.expectedWorkspaceName {
-			t.Fatalf("%s: expected workspace name mapping (%s) to match configured workspace name (%s)", name, b.WorkspaceMapping.Name, tc.expectedWorkspaceName)
-		}
-		if len(tc.expectedWorkspaceTags) > 0 {
-			presentSet := make(map[string]struct{})
-			for _, tag := range b.WorkspaceMapping.Tags {
-				presentSet[tag] = struct{}{}
-			}
-
-			expectedSet := make(map[string]struct{})
-			for _, tag := range tc.expectedWorkspaceTags {
-				expectedSet[tag] = struct{}{}
-			}
-
-			var missing []string
-			var unexpected []string
-
-			for _, expected := range tc.expectedWorkspaceTags {
-				if _, ok := presentSet[expected]; !ok {
-					missing = append(missing, expected)
-				}
-			}
-
-			for _, actual := range b.WorkspaceMapping.Tags {
-				if _, ok := expectedSet[actual]; !ok {
-					unexpected = append(unexpected, actual)
-				}
-			}
-
-			if len(missing) > 0 {
-				t.Fatalf("%s: expected workspace tag mapping (%s) to contain the following tags: %s", name, b.WorkspaceMapping.Tags, missing)
-			}
-
-			if len(unexpected) > 0 {
-				t.Fatalf("%s: expected workspace tag mapping (%s) to NOT contain the following tags: %s", name, b.WorkspaceMapping.Tags, unexpected)
-			}
-
-		}
-		if tc.expectedForceLocal != false && b.forceLocal != tc.expectedForceLocal {
-			t.Fatalf("%s: expected force local backend to be set ", name)
-		}
-		if tc.expectedProjectName != "" && b.WorkspaceMapping.Project != tc.expectedProjectName {
-			t.Fatalf("%s: expected project name mapping (%s) to match configured project name (%s)", name, b.WorkspaceMapping.Project, tc.expectedProjectName)
-		}
+	if b.forceLocal != true {
+		t.Fatalf("expected force local backend to be set due to env var")
 	}
 }
 

--- a/internal/cloud/backend_test.go
+++ b/internal/cloud/backend_test.go
@@ -834,20 +834,6 @@ func TestCloud_resolveCloudConfig(t *testing.T) {
 				},
 			},
 		},
-		"with no organization attribute or env var": {
-			config: cty.ObjectVal(map[string]cty.Value{
-				"organization": cty.NullVal(cty.String),
-				"hostname":     cty.NullVal(cty.String),
-				"token":        cty.NullVal(cty.String),
-				"workspaces": cty.ObjectVal(map[string]cty.Value{
-					"name":    cty.StringVal("prod"),
-					"tags":    cty.NullVal(cty.Set(cty.String)),
-					"project": cty.NullVal(cty.String),
-				}),
-			}),
-			vars:        map[string]string{},
-			expectedErr: `Invalid or missing required argument: "organization" must be set in the cloud configuration or as an environment variable: TF_CLOUD_ORGANIZATION.`,
-		},
 		"null workspace, TF_WORKSPACE present": {
 			config: cty.ObjectVal(map[string]cty.Value{
 				"organization": cty.StringVal("hashicorp"),
@@ -965,28 +951,6 @@ func TestCloud_resolveCloudConfig(t *testing.T) {
 				},
 			},
 		},
-
-		// TODO: fix expectations from setConfigurationFields cases
-		"with hostname set": {
-			config: cty.ObjectVal(map[string]cty.Value{
-				"organization": cty.StringVal("hashicorp"),
-				"hostname":     cty.StringVal("hashicorp.com"),
-				"token":        cty.NullVal(cty.String),
-				"workspaces": cty.ObjectVal(map[string]cty.Value{
-					"name":    cty.StringVal("prod"),
-					"tags":    cty.NullVal(cty.Set(cty.String)),
-					"project": cty.NullVal(cty.String),
-				}),
-			}),
-			expectedResult: cloudConfig{
-				hostname:     "hashicorp.com",
-				organization: "hashicorp",
-				token:        "",
-				workspaceMapping: WorkspaceMapping{
-					Name: "prod",
-				},
-			},
-		},
 		"with hostname not set, set to default hostname": {
 			config: cty.ObjectVal(map[string]cty.Value{
 				"organization": cty.StringVal("hashicorp"),
@@ -1000,26 +964,6 @@ func TestCloud_resolveCloudConfig(t *testing.T) {
 			}),
 			expectedResult: cloudConfig{
 				hostname:     defaultHostname,
-				organization: "hashicorp",
-				token:        "",
-				workspaceMapping: WorkspaceMapping{
-					Name: "prod",
-				},
-			},
-		},
-		"with workspace name set": {
-			config: cty.ObjectVal(map[string]cty.Value{
-				"organization": cty.StringVal("hashicorp"),
-				"hostname":     cty.StringVal("hashicorp.com"),
-				"token":        cty.NullVal(cty.String),
-				"workspaces": cty.ObjectVal(map[string]cty.Value{
-					"name":    cty.StringVal("prod"),
-					"tags":    cty.NullVal(cty.Set(cty.String)),
-					"project": cty.NullVal(cty.String),
-				}),
-			}),
-			expectedResult: cloudConfig{
-				hostname:     "hashicorp.com",
 				organization: "hashicorp",
 				token:        "",
 				workspaceMapping: WorkspaceMapping{
@@ -1049,27 +993,6 @@ func TestCloud_resolveCloudConfig(t *testing.T) {
 				token:        "",
 				workspaceMapping: WorkspaceMapping{
 					Tags: []string{"billing", "applications"},
-				},
-			},
-		},
-		"with project name set": {
-			config: cty.ObjectVal(map[string]cty.Value{
-				"organization": cty.StringVal("hashicorp"),
-				"hostname":     cty.StringVal("hashicorp.com"),
-				"token":        cty.NullVal(cty.String),
-				"workspaces": cty.ObjectVal(map[string]cty.Value{
-					"name":    cty.StringVal("prod"),
-					"tags":    cty.NullVal(cty.Set(cty.String)),
-					"project": cty.StringVal("my-project"),
-				}),
-			}),
-			expectedResult: cloudConfig{
-				hostname:     "hashicorp.com",
-				organization: "hashicorp",
-				token:        "",
-				workspaceMapping: WorkspaceMapping{
-					Name:    "prod",
-					Project: "my-project",
 				},
 			},
 		},

--- a/internal/cloud/backend_test.go
+++ b/internal/cloud/backend_test.go
@@ -522,7 +522,7 @@ func TestCloud_config(t *testing.T) {
 					"project": cty.NullVal(cty.String),
 				}),
 			}),
-			valErr: `Missing workspace mapping strategy.`,
+			confErr: `Missing workspace mapping strategy.`,
 		},
 		"with_both_a_name_and_tags": {
 			config: cty.ObjectVal(map[string]cty.Value{

--- a/internal/cloud/errors.go
+++ b/internal/cloud/errors.go
@@ -38,6 +38,13 @@ var (
 		fmt.Sprintf("Only one of workspace \"tags\" or \"name\" is allowed.\n\n%s", workspaceConfigurationHelp),
 		cty.Path{cty.GetAttrStep{Name: "workspaces"}},
 	)
+
+	invalidWorkspaceConfigNameConflict = tfdiags.AttributeValue(
+		tfdiags.Error,
+		"Invalid workspaces configuration",
+		fmt.Sprintf("Specified workspace \"name\" conflicts with TF_WORKSPACE environment variable.\n\n%s", workspaceConfigurationHelp),
+		cty.Path{cty.GetAttrStep{Name: "workspaces"}},
+	)
 )
 
 const ignoreRemoteVersionHelp = "If you're sure you want to upgrade the state, you can force Terraform to continue using the -ignore-remote-version flag. This may result in an unusable workspace."


### PR DESCRIPTION
Fixes #33976 

This bug was introduced in https://github.com/hashicorp/terraform/pull/33489 (adding `project` to the cloud config). Analyzing the flow of logic around config handling for the cloud backend took, a long time, which convinced me that a bug like this was honestly pretty inevitable — this code was too complex to safely edit. 

So, this PR refactors that whole zone to draw some sharper divisions of responsibility:

- `PrepareConfig` does almost nothing, as per the interface contract (which we were previously ignoring).
- Combining env vars with the received config block is now isolated in an immutable helper function, and the logic is now a bit more pedantic and obvious, hopefully making it harder to misunderstand in the future.
- `Configure` no longer delegates to the intensely side-effectful `setConfigurationFields` helper method to set fields on self; instead it just trades its cty config object for a dumb Go struct, sets a couple fields, and moves on. 

Notes for reviewers: 

- Probably easier to review this by-commit.
- LMK if you want these tests chopped down even further. I erred on the side of too much, since all the test cases already existed. 
- To test the behaviors interactively, you want to set TF_WORKSPACE with a variety of cloud block configs.
    - TF_WORKSPACE + name: Should error, with a newly added explanation instead of the old cryptic one ("workspaces not supported??")
    - TF_WORKSPACE + tags: Should work fine, and should select the active workspace from among the tagged ones.

## Target Release

1.6.1, as this bug was a disruptive regression. 

## Draft CHANGELOG entry

### BUG FIXES

- The `TF_WORKSPACE` environment variable once again works properly for selecting the active workspace when using the `cloud` block with workspace `tags`. 