### PR TITLE
backend/s3: Relax endpoint validation rule

### DIFF
--- a/internal/backend/remote-state/s3/backend.go
+++ b/internal/backend/remote-state/s3/backend.go
@@ -567,7 +567,7 @@ var endpointsSchema = singleNestedAttribute{
 			},
 			validateString{
 				Validators: []stringValidator{
-					validateStringURL,
+					validateStringLegacyURL,
 				},
 			},
 		},
@@ -580,7 +580,7 @@ var endpointsSchema = singleNestedAttribute{
 			},
 			validateString{
 				Validators: []stringValidator{
-					validateStringURL,
+					validateStringLegacyURL,
 				},
 			},
 		},
@@ -593,7 +593,7 @@ var endpointsSchema = singleNestedAttribute{
 			},
 			validateString{
 				Validators: []stringValidator{
-					validateStringURL,
+					validateStringLegacyURL,
 				},
 			},
 		},
@@ -606,7 +606,7 @@ var endpointsSchema = singleNestedAttribute{
 			},
 			validateString{
 				Validators: []stringValidator{
-					validateStringURL,
+					validateStringLegacyURL,
 				},
 			},
 		},
@@ -769,7 +769,7 @@ func (b *Backend) PrepareConfig(obj cty.Value) (cty.Value, tfdiags.Diagnostics) 
 
 	endpointValidators := validateString{
 		Validators: []stringValidator{
-			validateStringURL,
+			validateStringLegacyURL,
 		},
 	}
 	for _, k := range maps.Keys(endpointFields) {
@@ -778,9 +778,15 @@ func (b *Backend) PrepareConfig(obj cty.Value) (cty.Value, tfdiags.Diagnostics) 
 			endpointValidators.ValidateAttr(val, attrPath, &diags)
 		}
 	}
+
 	if val := obj.GetAttr("ec2_metadata_service_endpoint"); !val.IsNull() {
 		attrPath := cty.GetAttrPath("ec2_metadata_service_endpoint")
-		endpointValidators.ValidateAttr(val, attrPath, &diags)
+		ec2MetadataEndpointValidators := validateString{
+			Validators: []stringValidator{
+				validateStringValidURL,
+			},
+		}
+		ec2MetadataEndpointValidators.ValidateAttr(val, attrPath, &diags)
 	}
 
 	validateAttributesConflict(

--- a/internal/backend/remote-state/s3/backend_test.go
+++ b/internal/backend/remote-state/s3/backend_test.go
@@ -273,12 +273,9 @@ func TestBackendConfig_DynamoDBEndpoint(t *testing.T) {
 					"dynamodb": "dynamo.test",
 				},
 			},
+			expectedEndpoint: "dynamo.test/",
 			expectedDiags: tfdiags.Diagnostics{
-				attributeErrDiag(
-					"Invalid Value",
-					`The value must be a valid URL containing at least a scheme and hostname. Had "dynamo.test"`,
-					cty.GetAttrPath("endpoints").GetAttr("dynamodb"),
-				),
+				legacyIncompleteURLDiag("dynamo.test", cty.GetAttrPath("endpoints").GetAttr("dynamodb")),
 			},
 		},
 		"deprecated config URL": {
@@ -294,13 +291,10 @@ func TestBackendConfig_DynamoDBEndpoint(t *testing.T) {
 			config: map[string]any{
 				"dynamodb_endpoint": "dynamo.test",
 			},
+			expectedEndpoint: "dynamo.test/",
 			expectedDiags: tfdiags.Diagnostics{
 				deprecatedAttrDiag(cty.GetAttrPath("dynamodb_endpoint"), cty.GetAttrPath("endpoints").GetAttr("dynamodb")),
-				attributeErrDiag(
-					"Invalid Value",
-					`The value must be a valid URL containing at least a scheme and hostname. Had "dynamo.test"`,
-					cty.GetAttrPath("dynamodb_endpoint"),
-				),
+				legacyIncompleteURLDiag("dynamo.test", cty.GetAttrPath("dynamodb_endpoint")),
 			},
 		},
 		"config conflict": {
@@ -418,11 +412,7 @@ func TestBackendConfig_IAMEndpoint(t *testing.T) {
 				},
 			},
 			expectedDiags: tfdiags.Diagnostics{
-				attributeErrDiag(
-					"Invalid Value",
-					`The value must be a valid URL containing at least a scheme and hostname. Had "iam.test"`,
-					cty.GetAttrPath("endpoints").GetAttr("iam"),
-				),
+				legacyIncompleteURLDiag("iam.test", cty.GetAttrPath("endpoints").GetAttr("iam")),
 			},
 		},
 		"deprecated config URL": {
@@ -439,11 +429,7 @@ func TestBackendConfig_IAMEndpoint(t *testing.T) {
 			},
 			expectedDiags: tfdiags.Diagnostics{
 				deprecatedAttrDiag(cty.GetAttrPath("iam_endpoint"), cty.GetAttrPath("endpoints").GetAttr("iam")),
-				attributeErrDiag(
-					"Invalid Value",
-					`The value must be a valid URL containing at least a scheme and hostname. Had "iam.test"`,
-					cty.GetAttrPath("iam_endpoint"),
-				),
+				legacyIncompleteURLDiag("iam.test", cty.GetAttrPath("iam_endpoint")),
 			},
 		},
 		"config conflict": {
@@ -542,12 +528,9 @@ func TestBackendConfig_S3Endpoint(t *testing.T) {
 					"s3": "s3.test",
 				},
 			},
+			expectedEndpoint: "/s3.test",
 			expectedDiags: tfdiags.Diagnostics{
-				attributeErrDiag(
-					"Invalid Value",
-					`The value must be a valid URL containing at least a scheme and hostname. Had "s3.test"`,
-					cty.GetAttrPath("endpoints").GetAttr("s3"),
-				),
+				legacyIncompleteURLDiag("s3.test", cty.GetAttrPath("endpoints").GetAttr("s3")),
 			},
 		},
 		"deprecated config URL": {
@@ -563,13 +546,10 @@ func TestBackendConfig_S3Endpoint(t *testing.T) {
 			config: map[string]any{
 				"endpoint": "s3.test",
 			},
+			expectedEndpoint: "/s3.test",
 			expectedDiags: tfdiags.Diagnostics{
 				deprecatedAttrDiag(cty.GetAttrPath("endpoint"), cty.GetAttrPath("endpoints").GetAttr("s3")),
-				attributeErrDiag(
-					"Invalid Value",
-					`The value must be a valid URL containing at least a scheme and hostname. Had "s3.test"`,
-					cty.GetAttrPath("endpoint"),
-				),
+				legacyIncompleteURLDiag("s3.test", cty.GetAttrPath("endpoint")),
 			},
 		},
 		"config conflict": {


### PR DESCRIPTION
Relaxes endpoint URL validation for S3, DynamoDB, IAM, and STS to emit a warning rather than an error for incomplete URLs. The IMDS endpoint requires a complete URL, because [`url.Parse`](https://pkg.go.dev/net/url#Parse) places bare hostnames in the `Path` field of `url.URL` and the IMDS client overwrites the `Path`.

According to the [AWS documentation](https://docs.aws.amazon.com/general/latest/gr/rande.html), the endpoint parameters should be full URLs.

Fixes #33981

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.6.1

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

### BUG FIXES

<!--

Write a short description of the user-facing change. Examples:

- `terraform show -json`: Fixed crash with sensitive set values.
- When rendering a diff, Terraform now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 

- Relaxes validation for S3, DynamoDB, IAM, and STS endpoint parameters
