### PR TITLE
Add staticcheck.conf to reduce unactionable noise in IDEs

### DIFF
--- a/scripts/staticcheck.sh
+++ b/scripts/staticcheck.sh
@@ -13,9 +13,6 @@ skip=$skip"|internal/planproto|internal/tfplugin5|internal/tfplugin6"
 
 packages=$(go list ./... | egrep -v ${skip})
 
-# We are skipping style-related checks, since terraform intentionally breaks
-# some of these. The goal here is to find issues that reduce code clarity, or
-# may result in bugs. We also disable fucntion deprecation checks (SA1019)
-# because our policy is to update deprecated calls locally while making other
-# nearby changes, rather than to make cross-cutting changes to update them all.
-go run honnef.co/go/tools/cmd/staticcheck -checks 'all,-SA1019,-ST*' ${packages}
+# Note that we globally disable some checks. The list is controlled by the
+# top-level staticcheck.conf file in this repo.
+go run honnef.co/go/tools/cmd/staticcheck ${packages}

--- a/staticcheck.conf
+++ b/staticcheck.conf
@@ -1,2 +1,7 @@
-# Same settings as in scripts/staticcheck.sh / make staticcheck:
+# Our goal in using staticcheck is to find issues that reduce code clarity, or
+# may result in bugs. We are skipping style-related checks, since terraform
+# intentionally breaks some of these. We also disable function deprecation
+# checks (SA1019) because our policy is to update deprecated calls locally while
+# making other nearby changes, rather than to make cross-cutting changes to
+# update them all.
 checks = ["all", "-SA1019", "-ST*"]

--- a/staticcheck.conf
+++ b/staticcheck.conf
@@ -1,0 +1,2 @@
+# Same settings as in scripts/staticcheck.sh / make staticcheck:
+checks = ["all", "-SA1019", "-ST*"]


### PR DESCRIPTION
Turns out go-staticcheck will respect a config file and merge configs across subtrees of packages.

- [Staticcheck configuration methods](https://staticcheck.io/docs/configuration)
- [List of config options](https://staticcheck.io/docs/configuration/options/)

Since we already specify a list of staticcheck rules to ignore in the scripts/staticcheck.sh wrapper script, this hoists those preferences up to the top of the package tree, so they also affect the staticcheck integration in editors like VSCode. This avoids unnecessary yellow-squiggles for capitalized error messages, and makes integrated linting much more useful.

## The thing I'm trying to make it shut up about

![image](https://github.com/hashicorp/terraform/assets/484309/b239d008-c8fe-484c-97f9-0861863cb6ef)

## Target Release

1.7.x

## Draft CHANGELOG entry

N/A; this has no runtime effect on Terraform.
