### PR TITLE
backend/s3(doc): fix assume_role example syntax

### DIFF
--- a/website/docs/language/settings/backends/s3.mdx
+++ b/website/docs/language/settings/backends/s3.mdx
@@ -243,7 +243,7 @@ terraform {
     bucket = "terraform-state-prod"
     key    = "network/terraform.tfstate"
     region = "us-east-1"
-    assume_role {
+    assume_role = {
       role_arn = "arn:aws:iam::PRODUCTION-ACCOUNT-ID:role/Terraform"
     }
   }
@@ -277,7 +277,7 @@ terraform {
     bucket = "terraform-state-prod"
     key    = "network/terraform.tfstate"
     region = "us-east-1"
-    assume_role_with_web_identity {
+    assume_role_with_web_identity = {
       role_arn           = "arn:aws:iam::PRODUCTION-ACCOUNT-ID:role/Terraform"
       web_identity_token = "<token value>"
     }
@@ -425,7 +425,7 @@ provider "aws" {
   # No credentials explicitly set here because they come from either the
   # environment or the global credentials file.
 
-  assume_role {
+  assume_role = {
     role_arn = "${var.workspace_iam_roles[terraform.workspace]}"
   }
 }


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->
Updates the S3 backend documentation examples for the `assume_role` and `assume_role_with_web_identity` arguments to use the correct syntax for single nested objects.
<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Fixes #33994 

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.6.x

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

N/a - docs
