### PR TITLE
Skip writing variable validations into the state file

### DIFF
--- a/internal/states/statefile/version4.go
+++ b/internal/states/statefile/version4.go
@@ -589,6 +589,19 @@ func encodeCheckResultsV4(in *states.CheckResults) []checkResultsV4 {
 	ret := make([]checkResultsV4, 0, in.ConfigResults.Len())
 
 	for _, configElem := range in.ConfigResults.Elems {
+
+		if configElem.Key.CheckableKind() == addrs.CheckableInputVariable {
+			// For the remainder of the v1.6 series we should not output
+			// checkable input variables into the state file.
+			//
+			// This is to work around the issues in earlier releases that was
+			// fixed by https://github.com/hashicorp/terraform/pull/33813.
+			//
+			// The aim here is to give people more time to upgrade before we
+			// make the latest version incompatible with earlier versions.
+			continue
+		}
+
 		configResultsOut := checkResultsV4{
 			ObjectKind: encodeCheckableObjectKindV4(configElem.Key.CheckableKind()),
 			ConfigAddr: configElem.Key.String(),


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

This PR skips variable validations when it comes time to write variables into the state file for the v1.6 series. This ensures that we won't see errors when earlier series try to read remote state from the v1.6 releases, and users can switch between Terraform versions.

This is intended to be a temporary workaround only, when v1.7 releases we will see the same errors again but we will have given users more time to update to either the 1.6 series or later, or to the latest patch release in their minor series.

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Fixes #34014 

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.6.2

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

### BUG FIXES

<!--

Write a short description of the user-facing change. Examples:

- `terraform show -json`: Fixed crash with sensitive set values.
- When rendering a diff, Terraform now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 

-  Fix interoperability issues between v1.6 series and earlier series by removing variable validations from the state file.
