### PR TITLE
Fix crash on check blocks in modules with no other changes

### DIFF
--- a/internal/terraform/node_check.go
+++ b/internal/terraform/node_check.go
@@ -58,6 +58,7 @@ var (
 	_ GraphNodeModulePath        = (*nodeExpandCheck)(nil)
 	_ GraphNodeDynamicExpandable = (*nodeExpandCheck)(nil)
 	_ GraphNodeReferencer        = (*nodeExpandCheck)(nil)
+	_ graphNodeExpandsInstances  = (*nodeExpandCheck)(nil)
 )
 
 // nodeExpandCheck creates child nodes that actually execute the assertions for
@@ -74,6 +75,8 @@ type nodeExpandCheck struct {
 
 	makeInstance func(addrs.AbsCheck, *configs.Check) dag.Vertex
 }
+
+func (n *nodeExpandCheck) expandsInstances() {}
 
 func (n *nodeExpandCheck) ModulePath() addrs.Module {
 	return n.addr.Module

--- a/internal/terraform/transform_destroy_edge.go
+++ b/internal/terraform/transform_destroy_edge.go
@@ -307,6 +307,13 @@ func (t *pruneUnusedNodesTransformer) Transform(g *Graph) error {
 			func() {
 				n := nodes[i]
 				switch n := n.(type) {
+
+				case *nodeExpandCheck:
+					// We always execute check blocks, and they never have
+					// anything referencing them. We have to explicitly list
+					// them here otherwise they'll be deleted.
+					return
+
 				case graphNodeTemporaryValue:
 					// root module outputs indicate they are not temporary by
 					// returning false here.


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

The `nodeExpandCheck` node in the Terraform graph wasn't correctly marked as a `graphNodeExpandsInstances` object, which meant that when it was nested within a module that required expansion, and that module had no other changes to apply, we'd see the crash in the linked issue as the module would not apply its expansion logic.

This PR marks the `nodeExpandCheck` as `graphNodeExpandsInstances` so the graph will still expand modules that have check blocks in them. In addition, we need to then tell the `pruneUnusedNodesTransformer` to never prune check block nodes as we always want them to execute. Since they are now marked as `graphNodeExpandsInstances`, they would always be pruned as they have no references.

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Fixes #34062 

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.6.2

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

### BUG FIXES

<!--

Write a short description of the user-facing change. Examples:

- `terraform show -json`: Fixed crash with sensitive set values.
- When rendering a diff, Terraform now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 

-  `checks`: Fix a crash that occurs when checks blocks are within modules that have no other changes.
