### PR TITLE
Process only relevant variables in the testing framework

### DIFF
--- a/internal/backend/local/backend_local.go
+++ b/internal/backend/local/backend_local.go
@@ -10,7 +10,6 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/hashicorp/hcl/v2"
 	"github.com/zclconf/go-cty/cty"
 
 	"github.com/hashicorp/terraform/internal/backend"
@@ -505,23 +504,4 @@ func (v unparsedUnknownVariableValue) ParseVariableValue(mode configs.VariablePa
 		Value:      cty.UnknownVal(v.WantType),
 		SourceType: terraform.ValueFromInput,
 	}, nil
-}
-
-type unparsedTestVariableValue struct {
-	expr hcl.Expression
-	ctx  *hcl.EvalContext
-}
-
-func (v unparsedTestVariableValue) ParseVariableValue(mode configs.VariableParsingMode) (*terraform.InputValue, tfdiags.Diagnostics) {
-	var diags tfdiags.Diagnostics
-	val, hclDiags := v.expr.Value(v.ctx) // nil because no function calls or variable references are allowed here
-	diags = diags.Append(hclDiags)
-
-	rng := tfdiags.SourceRangeFromHCL(v.expr.Range())
-
-	return &terraform.InputValue{
-		Value:       val,
-		SourceType:  terraform.ValueFromConfig, // Test variables always come from config.
-		SourceRange: rng,
-	}, diags
 }

--- a/internal/command/test_test.go
+++ b/internal/command/test_test.go
@@ -163,6 +163,14 @@ func TestTest(t *testing.T) {
 			args:     []string{"-var=global=\"triple\""},
 			code:     0,
 		},
+		"unreferenced_global_variable": {
+			override: "variable_references",
+			expected: "2 passed, 0 failed.",
+			// The other variable shouldn't pass validation, but it won't be
+			// referenced anywhere so should just be ignored.
+			args: []string{"-var=global=\"triple\"", "-var=other=bad"},
+			code: 0,
+		},
 		"variables_types": {
 			expected: "1 passed, 0 failed.",
 			args:     []string{"-var=number_input=0", "-var=string_input=Hello, world!", "-var=list_input=[\"Hello\",\"world\"]"},


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

This PR adds in the concept of "relevant variables" to the testing framework. Previously, each run block would process every available variable and attempt to parse even those they had no need for. This resulted in some edge case behaviour as seen in the linked issue. Now, each run block first calculates the variables it needs, and then exclusively processes the subset of required variables.

In addition, this PR does some refactoring of the variables processing. Previously, the variables were processed in their entirety twice: once for the test itself, and then once again for the assertions after the test has finished. Now, we only process the variables once at the beginning of each run and use mutator functions `FilterVariablesToConfig` and `AddVariablesToConfig` to achieve the required configurations for the test and for processing the assertions.

Also, previously we were duplicating the defaults and conversion logic while preparing the variables for assertions. I realised I can push that processing further down the stack into the `terraform` package, and then reuse the existing `prepareFinalInputVariableValue` function instead of duplicating that logic. 

*The refactoring here will make future PRs easier (such as #34069) where we need to pull the variables available to the whole file. We can reuse the new function added here instead of doing this refactor at that point or adding a new function.*

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Fixes #34070

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.6.2

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

### BUG FIXES

<!--

Write a short description of the user-facing change. Examples:

- `terraform show -json`: Fixed crash with sensitive set values.
- When rendering a diff, Terraform now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 

-  `terraform test`: Fix bug where `terraform test` was processing and including all available variables for every test rather than only the ones required for that particular test.
