### PR TITLE
backend/s3: Document need to reconfigure backend when updating Terraform

### DIFF
--- a/website/docs/language/settings/backends/s3.mdx
+++ b/website/docs/language/settings/backends/s3.mdx
@@ -16,7 +16,7 @@ A single DynamoDB table can be used to lock multiple remote state files. Terrafo
 [Bucket Versioning](https://docs.aws.amazon.com/AmazonS3/latest/userguide/manage-versioning-examples.html)
 on the S3 bucket to allow for state recovery in the case of accidental deletions and human error.
 
--> **Note:** Becuase of the changes to the S3 Backend in Terraform 1.6, you may need to run `terraform init -reconfigure`,
+-> **Note:** Because of the changes to the S3 Backend in Terraform 1.6, you may need to run `terraform init -reconfigure`,
 even if there have been no changes to your backend configuration.
 
 ## Example Configuration

--- a/website/docs/language/settings/backends/s3.mdx
+++ b/website/docs/language/settings/backends/s3.mdx
@@ -16,6 +16,9 @@ A single DynamoDB table can be used to lock multiple remote state files. Terrafo
 [Bucket Versioning](https://docs.aws.amazon.com/AmazonS3/latest/userguide/manage-versioning-examples.html)
 on the S3 bucket to allow for state recovery in the case of accidental deletions and human error.
 
+-> **Note:** Becuase of the changes to the S3 Backend in Terraform 1.6, you may need to run `terraform init -reconfigure`,
+even if there have been no changes to your backend configuration.
+
 ## Example Configuration
 
 ```hcl

--- a/website/docs/language/settings/backends/s3.mdx
+++ b/website/docs/language/settings/backends/s3.mdx
@@ -16,9 +16,6 @@ A single DynamoDB table can be used to lock multiple remote state files. Terrafo
 [Bucket Versioning](https://docs.aws.amazon.com/AmazonS3/latest/userguide/manage-versioning-examples.html)
 on the S3 bucket to allow for state recovery in the case of accidental deletions and human error.
 
--> **Note:** Because of the changes to the S3 Backend in Terraform 1.6, you may need to run `terraform init -reconfigure`,
-even if there have been no changes to your backend configuration.
-
 ## Example Configuration
 
 ```hcl

--- a/website/docs/language/upgrade-guides/index.mdx
+++ b/website/docs/language/upgrade-guides/index.mdx
@@ -145,7 +145,7 @@ even if there have been no changes to your backend configuration.
 ### Deprecations
 
 The major deprecations are discussed here.
-For more information, consult the [S3 Backend documentation](terraform/language/settings/backends/s3).
+For more information, consult the [S3 Backend documentation](/terraform/language/settings/backends/s3).
 
 Configuration for assuming an IAM Role has been moved from a number of top-level attributes into the attribute `assume_role`.
 Previously, the configuration to assume the IAM role `arn:aws:iam::123456789012:role/example` with a session name `example-session` and a session duration of 15 minutes was:

--- a/website/docs/language/upgrade-guides/index.mdx
+++ b/website/docs/language/upgrade-guides/index.mdx
@@ -15,6 +15,7 @@ but there are some behavior changes outside of those promises that may affect a
 small number of users. Specifically, the following updates may require
 additional upgrade steps:
 * [End of experimental period for `terraform test`](#terraform-test)
+* [S3 Backend may need to be reconfigured](#s3-backend)
 
 See [the full changelog](https://github.com/hashicorp/terraform/blob/v1.6/CHANGELOG.md)
 for more details. If you encounter any problems during upgrading which are not
@@ -132,3 +133,50 @@ run "test_defaults" {
 The above examples demonstrates the differences in layout, scope and access between the two approaches. In the experimental framework, access is granted as if the configuration was being called like a normal module call. In the released framework, assertions execute as if they are custom conditions defined within the main configuration directly.
 
 The `run` block also applies or plans the main configuration by default, there is no need for the specific module call seen in the experimental framework.
+
+## S3 Backend
+
+The S3 Backend has been updated, with a number of added and deprecated fields.
+These changes bring the S3 Backend configuration closer to the AWS Provider configuration.
+
+-> **Note:** Becuase of these changes, you may need to run `terraform init -reconfigure`,
+even if there have been no changes to your backend configuration.
+
+### Deprecations
+
+The major deprecations are discussed here.
+For more information, consult the [S3 Backend documentation](terraform/language/settings/backends/s3).
+
+Configuration for assuming an IAM Role has been moved from a number of top-level attributes into the attribute `assume_role`.
+Previously, the configuration to assume the IAM role `arn:aws:iam::123456789012:role/example` with a session name `example-session` and a session duration of 15 minutes was:
+
+```hcl
+terraform {
+  role_arn                     = "arn:aws:iam::123456789012:role/example"
+  session_name                 = "example-session"
+  assume_role_duration_seconds = 900
+}
+```
+
+The updated configuration is:
+
+```hcl
+terraform {
+  assume_role {
+    role_arn     = "arn:aws:iam::123456789012:role/example"
+    session_name = "example-session"
+    duration     = "15m"
+  }
+}
+```
+
+The AWS API endpoint override attributes
+`endpoint` (for S3),
+`dynamodb_endpoint`,
+`iam_endpoint`, and
+`sts_endpoint`
+have been replaced with the attributes `endpoints` and the corresponding nested attributes
+`s3`,
+`dynamodb`,
+`iam`, and
+`sts`.

--- a/website/docs/language/upgrade-guides/index.mdx
+++ b/website/docs/language/upgrade-guides/index.mdx
@@ -139,7 +139,7 @@ The `run` block also applies or plans the main configuration by default, there i
 The S3 Backend has been updated, with a number of added and deprecated fields.
 These changes bring the S3 Backend configuration closer to the AWS Provider configuration.
 
--> **Note:** Becuase of these changes, you may need to run `terraform init -reconfigure`,
+-> **Note:** Because of these changes, you may need to run `terraform init -reconfigure`,
 even if there have been no changes to your backend configuration.
 
 ### Deprecations

--- a/website/docs/language/upgrade-guides/index.mdx
+++ b/website/docs/language/upgrade-guides/index.mdx
@@ -15,7 +15,7 @@ but there are some behavior changes outside of those promises that may affect a
 small number of users. Specifically, the following updates may require
 additional upgrade steps:
 * [End of experimental period for `terraform test`](#terraform-test)
-* [S3 Backend may need to be reconfigured](#s3-backend)
+* [Deprecated parameters for the  S3 backend](#s3-backend)
 
 See [the full changelog](https://github.com/hashicorp/terraform/blob/v1.6/CHANGELOG.md)
 for more details. If you encounter any problems during upgrading which are not
@@ -138,9 +138,6 @@ The `run` block also applies or plans the main configuration by default, there i
 
 The S3 Backend has been updated, with a number of added and deprecated fields.
 These changes bring the S3 Backend configuration closer to the AWS Provider configuration.
-
--> **Note:** Because of these changes, you may need to run `terraform init -reconfigure`,
-even if there have been no changes to your backend configuration.
 
 ### Deprecations
 

--- a/website/docs/language/upgrade-guides/index.mdx
+++ b/website/docs/language/upgrade-guides/index.mdx
@@ -136,16 +136,16 @@ The `run` block also applies or plans the main configuration by default, there i
 
 ## S3 Backend
 
-The S3 Backend has been updated, with a number of added and deprecated fields.
-These changes bring the S3 Backend configuration closer to the AWS Provider configuration.
-
-### Deprecations
+We updated the S3 backend in Terraform 1.6.0 so that it more closely matches the AWS provider configuration.
+As a result, the backend has new and deprecated fields.
+Refer to the [release notes](https://github.com/hashicorp/terraform/releases/tag/v1.6.0) for additional information. 
 
 The major deprecations are discussed here.
-For more information, consult the [S3 Backend documentation](/terraform/language/settings/backends/s3).
+Refer to the [S3 backend documentation](/terraform/language/settings/backends/s3) for information about all deprecations.
 
-Configuration for assuming an IAM Role has been moved from a number of top-level attributes into the attribute `assume_role`.
-Previously, the configuration to assume the IAM role `arn:aws:iam::123456789012:role/example` with a session name `example-session` and a session duration of 15 minutes was:
+We removed the configuration for assuming an IAM role from several top-level attributes and consolidated them into the `assume_role` attribute.
+
+The following example shows the configuration in Terraform 1.5.6 and older for assuming the IAM role `arn:aws:iam::123456789012:role/example` with a session name `example-session` and a session duration of 15 minutes:
 
 ```hcl
 terraform {
@@ -158,7 +158,7 @@ terraform {
 }
 ```
 
-The updated configuration is:
+The configuration in Terraform 1.6.0 is:
 
 ```hcl
 terraform {
@@ -173,13 +173,17 @@ terraform {
 }
 ```
 
-The AWS API endpoint override attributes
-`endpoint` (for S3),
-`dynamodb_endpoint`,
-`iam_endpoint`, and
-`sts_endpoint`
-have been replaced with the attributes `endpoints` and the corresponding nested attributes
-`s3`,
-`dynamodb`,
-`iam`, and
-`sts`.
+We removed the configuration for overriding AWS API endpoints from several top-level attributes and consolidated them into the `endpoints` attribute.
+The following endpoint attributes are now nested under the `endpoint` attribute:
+
+- `s3`
+- `dynamodb`
+- `iam`
+- `sts`
+
+The `endpoint` attribute replaces the following top-level attributes:
+
+- `endpoint` (for S3),
+- `dynamodb_endpoint`,
+- `iam_endpoint`
+- `sts_endpoint`

--- a/website/docs/language/upgrade-guides/index.mdx
+++ b/website/docs/language/upgrade-guides/index.mdx
@@ -152,9 +152,12 @@ Previously, the configuration to assume the IAM role `arn:aws:iam::123456789012:
 
 ```hcl
 terraform {
-  role_arn                     = "arn:aws:iam::123456789012:role/example"
-  session_name                 = "example-session"
-  assume_role_duration_seconds = 900
+  backend "s3" {
+    # additional configuration omitted for brevity
+    role_arn                     = "arn:aws:iam::123456789012:role/example"
+    session_name                 = "example-session"
+    assume_role_duration_seconds = 900
+  }
 }
 ```
 
@@ -162,10 +165,13 @@ The updated configuration is:
 
 ```hcl
 terraform {
-  assume_role {
-    role_arn     = "arn:aws:iam::123456789012:role/example"
-    session_name = "example-session"
-    duration     = "15m"
+  backend "s3" {
+    # additional configuration omitted for brevity
+    assume_role = {
+      role_arn     = "arn:aws:iam::123456789012:role/example"
+      session_name = "example-session"
+      duration     = "15m"
+    }
   }
 }
 ```


### PR DESCRIPTION
Because of changes to the S3 Backend schema, some users are reporting that they need to reconfigure their backend when updating to Terraform 1.6, even if they have made no changes. Add this to the Upgrade Guide and S3 Backend documentation.

Relates #34022

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.6.2

## Draft CHANGELOG entry

Documentation change