### PR TITLE
Skip variable validations during destroy plans

### DIFF
--- a/internal/terraform/context_apply2_test.go
+++ b/internal/terraform/context_apply2_test.go
@@ -2163,6 +2163,74 @@ import {
 	}
 }
 
+func TestContext2Apply_destroySkipsVariableValidations(t *testing.T) {
+	m := testModuleInline(t, map[string]string{
+		"main.tf": `
+variable "input" {
+	type = string
+
+	validation {
+        condition = var.input == "foo"
+        error_message = "bad input"
+    }
+}
+
+resource "test_object" "a" {
+	test_string = var.input
+}
+`,
+	})
+
+	p := simpleMockProvider()
+	ctx := testContext2(t, &ContextOpts{
+		Providers: map[addrs.Provider]providers.Factory{
+			addrs.NewDefaultProvider("test"): testProviderFuncFixed(p),
+		},
+	})
+
+	plan, diags := ctx.Plan(m, states.BuildState(func(state *states.SyncState) {
+		state.SetResourceInstanceCurrent(
+			mustResourceInstanceAddr("test_object.a"),
+			&states.ResourceInstanceObjectSrc{
+				Status:    states.ObjectReady,
+				AttrsJSON: []byte(`{"test_string":"foo"}`),
+			},
+			mustProviderConfig(`provider["registry.terraform.io/hashicorp/test"]`),
+		)
+	}), &PlanOpts{
+		Mode: plans.DestroyMode,
+		SetVariables: InputValues{
+			"input": {
+				Value:       cty.StringVal("foo"),
+				SourceType:  ValueFromCLIArg,
+				SourceRange: tfdiags.SourceRange{},
+			},
+		},
+	})
+	if diags.HasErrors() {
+		t.Errorf("expected no errors, but got %s", diags)
+	}
+
+	state, diags := ctx.Apply(plan, m)
+	if diags.HasErrors() {
+		t.Errorf("expected no errors, but got %s", diags)
+	}
+
+	results := state.CheckResults.ConfigResults.Get(addrs.ConfigInputVariable{
+		Variable: addrs.InputVariable{
+			Name: "input",
+		},
+	})
+
+	if results.Status != checks.StatusUnknown {
+		t.Errorf("expected checks to be unknown but was %s", results.Status)
+	}
+
+	if results.ObjectResults.Len() > 0 {
+		t.Errorf("shouldn't have processed any specific results but found %d", results.ObjectResults.Len())
+	}
+}
+
 func TestContext2Apply_noExternalReferences(t *testing.T) {
 	m := testModuleInline(t, map[string]string{
 		"main.tf": `

--- a/internal/terraform/graph_builder_apply.go
+++ b/internal/terraform/graph_builder_apply.go
@@ -101,13 +101,13 @@ func (b *ApplyGraphBuilder) Steps() []GraphTransformer {
 
 		// Add dynamic values
 		&RootVariableTransformer{
-			Config:     b.Config,
-			RawValues:  b.RootVariableValues,
-			Destroying: b.Operation == walkDestroy,
+			Config:       b.Config,
+			RawValues:    b.RootVariableValues,
+			DestroyApply: b.Operation == walkDestroy,
 		},
 		&ModuleVariableTransformer{
-			Config:     b.Config,
-			Destroying: b.Operation == walkDestroy,
+			Config:       b.Config,
+			DestroyApply: b.Operation == walkDestroy,
 		},
 		&LocalTransformer{Config: b.Config},
 		&OutputTransformer{

--- a/internal/terraform/graph_builder_apply.go
+++ b/internal/terraform/graph_builder_apply.go
@@ -100,8 +100,15 @@ func (b *ApplyGraphBuilder) Steps() []GraphTransformer {
 		},
 
 		// Add dynamic values
-		&RootVariableTransformer{Config: b.Config, RawValues: b.RootVariableValues},
-		&ModuleVariableTransformer{Config: b.Config},
+		&RootVariableTransformer{
+			Config:     b.Config,
+			RawValues:  b.RootVariableValues,
+			Destroying: b.Operation == walkDestroy,
+		},
+		&ModuleVariableTransformer{
+			Config:     b.Config,
+			Destroying: b.Operation == walkDestroy,
+		},
 		&LocalTransformer{Config: b.Config},
 		&OutputTransformer{
 			Config:     b.Config,

--- a/internal/terraform/graph_builder_plan.go
+++ b/internal/terraform/graph_builder_plan.go
@@ -135,8 +135,9 @@ func (b *PlanGraphBuilder) Steps() []GraphTransformer {
 			Destroying: b.Operation == walkPlanDestroy,
 		},
 		&ModuleVariableTransformer{
-			Config:   b.Config,
-			Planning: true,
+			Config:     b.Config,
+			Planning:   true,
+			Destroying: b.Operation == walkPlanDestroy,
 		},
 		&LocalTransformer{Config: b.Config},
 		&OutputTransformer{

--- a/internal/terraform/graph_builder_plan.go
+++ b/internal/terraform/graph_builder_plan.go
@@ -128,8 +128,16 @@ func (b *PlanGraphBuilder) Steps() []GraphTransformer {
 		},
 
 		// Add dynamic values
-		&RootVariableTransformer{Config: b.Config, RawValues: b.RootVariableValues, Planning: true},
-		&ModuleVariableTransformer{Config: b.Config, Planning: true},
+		&RootVariableTransformer{
+			Config:     b.Config,
+			RawValues:  b.RootVariableValues,
+			Planning:   true,
+			Destroying: b.Operation == walkPlanDestroy,
+		},
+		&ModuleVariableTransformer{
+			Config:   b.Config,
+			Planning: true,
+		},
 		&LocalTransformer{Config: b.Config},
 		&OutputTransformer{
 			Config:      b.Config,

--- a/internal/terraform/graph_builder_plan.go
+++ b/internal/terraform/graph_builder_plan.go
@@ -129,15 +129,15 @@ func (b *PlanGraphBuilder) Steps() []GraphTransformer {
 
 		// Add dynamic values
 		&RootVariableTransformer{
-			Config:     b.Config,
-			RawValues:  b.RootVariableValues,
-			Planning:   true,
-			Destroying: b.Operation == walkPlanDestroy,
+			Config:       b.Config,
+			RawValues:    b.RootVariableValues,
+			Planning:     true,
+			DestroyApply: false, // always false for planning
 		},
 		&ModuleVariableTransformer{
-			Config:     b.Config,
-			Planning:   true,
-			Destroying: b.Operation == walkPlanDestroy,
+			Config:       b.Config,
+			Planning:     true,
+			DestroyApply: false, // always false for planning
 		},
 		&LocalTransformer{Config: b.Config},
 		&OutputTransformer{

--- a/internal/terraform/node_module_variable.go
+++ b/internal/terraform/node_module_variable.go
@@ -29,6 +29,10 @@ type nodeExpandModuleVariable struct {
 	// Planning must be set to true when building a planning graph, and must be
 	// false when building an apply graph.
 	Planning bool
+
+	// Destroying must be set to true when planning or applying a destroy
+	// operation, and false otherwise.
+	Destroying bool
 }
 
 var (
@@ -54,7 +58,7 @@ func (n *nodeExpandModuleVariable) DynamicExpand(ctx EvalContext) (*Graph, tfdia
 	// We should only do this during planning as the apply phase starts with
 	// all the same checkable objects that were registered during the plan.
 	var checkableAddrs addrs.Set[addrs.Checkable]
-	if n.Planning {
+	if n.Planning && !n.Destroying {
 		if checkState := ctx.Checks(); checkState.ConfigHasChecks(n.Addr.InModule(n.Module)) {
 			checkableAddrs = addrs.MakeSet[addrs.Checkable]()
 		}
@@ -72,6 +76,7 @@ func (n *nodeExpandModuleVariable) DynamicExpand(ctx EvalContext) (*Graph, tfdia
 			Config:         n.Config,
 			Expr:           n.Expr,
 			ModuleInstance: module,
+			Destroying:     n.Destroying,
 		}
 		g.Add(o)
 	}
@@ -140,6 +145,10 @@ type nodeModuleVariable struct {
 	// ModuleInstance in order to create the appropriate context for evaluating
 	// ModuleCallArguments, ex. so count.index and each.key can resolve
 	ModuleInstance addrs.ModuleInstance
+
+	// Destroying must be set to true when planning or applying a destroy
+	// operation, and false otherwise.
+	Destroying bool
 }
 
 // Ensure that we are implementing all of the interfaces we think we are
@@ -195,7 +204,14 @@ func (n *nodeModuleVariable) Execute(ctx EvalContext, op walkOperation) (diags t
 	_, call := n.Addr.Module.CallInstance()
 	ctx.SetModuleCallArgument(call, n.Addr.Variable, val)
 
-	return evalVariableValidations(n.Addr, n.Config, n.Expr, ctx)
+	// Skip evalVariableValidations during destroy operations. We still want
+	// to evaluate the variable in case it is used to initialise providers
+	// or something downstream but we don't need to report on the success
+	// or failure of any validations.
+	if !n.Destroying {
+		diags = diags.Append(evalVariableValidations(n.Addr, n.Config, n.Expr, ctx))
+	}
+	return diags
 }
 
 // dag.GraphNodeDotter impl.

--- a/internal/terraform/node_module_variable.go
+++ b/internal/terraform/node_module_variable.go
@@ -30,9 +30,9 @@ type nodeExpandModuleVariable struct {
 	// false when building an apply graph.
 	Planning bool
 
-	// Destroying must be set to true when planning or applying a destroy
+	// DestroyApply must be set to true when planning or applying a destroy
 	// operation, and false otherwise.
-	Destroying bool
+	DestroyApply bool
 }
 
 var (
@@ -58,7 +58,7 @@ func (n *nodeExpandModuleVariable) DynamicExpand(ctx EvalContext) (*Graph, tfdia
 	// We should only do this during planning as the apply phase starts with
 	// all the same checkable objects that were registered during the plan.
 	var checkableAddrs addrs.Set[addrs.Checkable]
-	if n.Planning && !n.Destroying {
+	if n.Planning {
 		if checkState := ctx.Checks(); checkState.ConfigHasChecks(n.Addr.InModule(n.Module)) {
 			checkableAddrs = addrs.MakeSet[addrs.Checkable]()
 		}
@@ -76,7 +76,7 @@ func (n *nodeExpandModuleVariable) DynamicExpand(ctx EvalContext) (*Graph, tfdia
 			Config:         n.Config,
 			Expr:           n.Expr,
 			ModuleInstance: module,
-			Destroying:     n.Destroying,
+			DestroyApply:   n.DestroyApply,
 		}
 		g.Add(o)
 	}
@@ -146,9 +146,9 @@ type nodeModuleVariable struct {
 	// ModuleCallArguments, ex. so count.index and each.key can resolve
 	ModuleInstance addrs.ModuleInstance
 
-	// Destroying must be set to true when planning or applying a destroy
-	// operation, and false otherwise.
-	Destroying bool
+	// DestroyApply must be set to true when applying a destroy operation and
+	// false otherwise.
+	DestroyApply bool
 }
 
 // Ensure that we are implementing all of the interfaces we think we are
@@ -207,8 +207,8 @@ func (n *nodeModuleVariable) Execute(ctx EvalContext, op walkOperation) (diags t
 	// Skip evalVariableValidations during destroy operations. We still want
 	// to evaluate the variable in case it is used to initialise providers
 	// or something downstream but we don't need to report on the success
-	// or failure of any validations.
-	if !n.Destroying {
+	// or failure of any validations for destroy operations.
+	if !n.DestroyApply {
 		diags = diags.Append(evalVariableValidations(n.Addr, n.Config, n.Expr, ctx))
 	}
 	return diags

--- a/internal/terraform/node_root_variable.go
+++ b/internal/terraform/node_root_variable.go
@@ -30,9 +30,9 @@ type NodeRootVariable struct {
 	// false when building an apply graph.
 	Planning bool
 
-	// Destroying must be set to true when planning or applying a destroy
-	// operation, and false otherwise.
-	Destroying bool
+	// DestroyApply must be set to true when applying a destroy operation and
+	// false otherwise.
+	DestroyApply bool
 }
 
 var (
@@ -91,7 +91,7 @@ func (n *NodeRootVariable) Execute(ctx EvalContext, op walkOperation) tfdiags.Di
 		}
 	}
 
-	if n.Planning && !n.Destroying {
+	if n.Planning {
 		if checkState := ctx.Checks(); checkState.ConfigHasChecks(n.Addr.InModule(addrs.RootModule)) {
 			ctx.Checks().ReportCheckableObjects(
 				n.Addr.InModule(addrs.RootModule),
@@ -113,7 +113,7 @@ func (n *NodeRootVariable) Execute(ctx EvalContext, op walkOperation) tfdiags.Di
 
 	ctx.SetRootModuleArgument(addr.Variable, finalVal)
 
-	if !n.Destroying {
+	if !n.DestroyApply {
 		diags = diags.Append(evalVariableValidations(
 			addrs.RootModuleInstance.InputVariable(n.Addr.Name),
 			n.Config,

--- a/internal/terraform/node_root_variable.go
+++ b/internal/terraform/node_root_variable.go
@@ -29,6 +29,10 @@ type NodeRootVariable struct {
 	// Planning must be set to true when building a planning graph, and must be
 	// false when building an apply graph.
 	Planning bool
+
+	// Destroying must be set to true when planning or applying a destroy
+	// operation, and false otherwise.
+	Destroying bool
 }
 
 var (
@@ -87,7 +91,7 @@ func (n *NodeRootVariable) Execute(ctx EvalContext, op walkOperation) tfdiags.Di
 		}
 	}
 
-	if n.Planning {
+	if n.Planning && !n.Destroying {
 		if checkState := ctx.Checks(); checkState.ConfigHasChecks(n.Addr.InModule(addrs.RootModule)) {
 			ctx.Checks().ReportCheckableObjects(
 				n.Addr.InModule(addrs.RootModule),
@@ -109,13 +113,15 @@ func (n *NodeRootVariable) Execute(ctx EvalContext, op walkOperation) tfdiags.Di
 
 	ctx.SetRootModuleArgument(addr.Variable, finalVal)
 
-	moreDiags = evalVariableValidations(
-		addrs.RootModuleInstance.InputVariable(n.Addr.Name),
-		n.Config,
-		nil, // not set for root module variables
-		ctx,
-	)
-	diags = diags.Append(moreDiags)
+	if !n.Destroying {
+		diags = diags.Append(evalVariableValidations(
+			addrs.RootModuleInstance.InputVariable(n.Addr.Name),
+			n.Config,
+			nil, // not set for root module variables
+			ctx,
+		))
+	}
+
 	return diags
 }
 

--- a/internal/terraform/transform_module_variable.go
+++ b/internal/terraform/transform_module_variable.go
@@ -32,6 +32,10 @@ type ModuleVariableTransformer struct {
 	// Planning must be set to true when building a planning graph, and must be
 	// false when building an apply graph.
 	Planning bool
+
+	// Destroying must be set to true when planning or applying a destroy
+	// operation, and false otherwise.
+	Destroying bool
 }
 
 func (t *ModuleVariableTransformer) Transform(g *Graph) error {
@@ -110,10 +114,11 @@ func (t *ModuleVariableTransformer) transformSingle(g *Graph, parent, c *configs
 			Addr: addrs.InputVariable{
 				Name: v.Name,
 			},
-			Module:   c.Path,
-			Config:   v,
-			Expr:     expr,
-			Planning: t.Planning,
+			Module:     c.Path,
+			Config:     v,
+			Expr:       expr,
+			Planning:   t.Planning,
+			Destroying: t.Destroying,
 		}
 		g.Add(node)
 	}

--- a/internal/terraform/transform_module_variable.go
+++ b/internal/terraform/transform_module_variable.go
@@ -33,9 +33,9 @@ type ModuleVariableTransformer struct {
 	// false when building an apply graph.
 	Planning bool
 
-	// Destroying must be set to true when planning or applying a destroy
-	// operation, and false otherwise.
-	Destroying bool
+	// DestroyApply must be set to true when applying a destroy operation and
+	// false otherwise.
+	DestroyApply bool
 }
 
 func (t *ModuleVariableTransformer) Transform(g *Graph) error {
@@ -114,11 +114,11 @@ func (t *ModuleVariableTransformer) transformSingle(g *Graph, parent, c *configs
 			Addr: addrs.InputVariable{
 				Name: v.Name,
 			},
-			Module:     c.Path,
-			Config:     v,
-			Expr:       expr,
-			Planning:   t.Planning,
-			Destroying: t.Destroying,
+			Module:       c.Path,
+			Config:       v,
+			Expr:         expr,
+			Planning:     t.Planning,
+			DestroyApply: t.DestroyApply,
 		}
 		g.Add(node)
 	}

--- a/internal/terraform/transform_variable.go
+++ b/internal/terraform/transform_variable.go
@@ -22,6 +22,10 @@ type RootVariableTransformer struct {
 	// Planning must be set to true when building a planning graph, and must be
 	// false when building an apply graph.
 	Planning bool
+
+	// Destroying must be set to true when planning or applying a destroy
+	// operation, and false otherwise.
+	Destroying bool
 }
 
 func (t *RootVariableTransformer) Transform(g *Graph) error {
@@ -40,9 +44,10 @@ func (t *RootVariableTransformer) Transform(g *Graph) error {
 			Addr: addrs.InputVariable{
 				Name: v.Name,
 			},
-			Config:   v,
-			RawValue: t.RawValues[v.Name],
-			Planning: t.Planning,
+			Config:     v,
+			RawValue:   t.RawValues[v.Name],
+			Planning:   t.Planning,
+			Destroying: t.Destroying,
 		}
 		g.Add(node)
 	}

--- a/internal/terraform/transform_variable.go
+++ b/internal/terraform/transform_variable.go
@@ -23,9 +23,9 @@ type RootVariableTransformer struct {
 	// false when building an apply graph.
 	Planning bool
 
-	// Destroying must be set to true when planning or applying a destroy
-	// operation, and false otherwise.
-	Destroying bool
+	// DestroyApply must be set to true when applying a destroy operation and
+	// false otherwise.
+	DestroyApply bool
 }
 
 func (t *RootVariableTransformer) Transform(g *Graph) error {
@@ -44,10 +44,10 @@ func (t *RootVariableTransformer) Transform(g *Graph) error {
 			Addr: addrs.InputVariable{
 				Name: v.Name,
 			},
-			Config:     v,
-			RawValue:   t.RawValues[v.Name],
-			Planning:   t.Planning,
-			Destroying: t.Destroying,
+			Config:       v,
+			RawValue:     t.RawValues[v.Name],
+			Planning:     t.Planning,
+			DestroyApply: t.DestroyApply,
 		}
 		g.Add(node)
 	}


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

This PR makes Terraform skip variable validations during destroy plans and applys. This makes variable validations match the behaviour of other custom conditions which also do not execute during destroy operations.

This has the side effect of fixing the crash in the linked issue, as the variable validations will no longer attempt to sometimes execute during destroy-apply operations after having been skipped during the equivalent plan operation.

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Fixes #34052

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.6.2

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

### BUG FIXES

<!--

Write a short description of the user-facing change. Examples:

- `terraform show -json`: Fixed crash with sensitive set values.
- When rendering a diff, Terraform now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 

-  Fix occasional crash when destroying configurations with variables containing validations.
