### PR TITLE
configs: remove redundant provider reqs

### DIFF
--- a/internal/configs/config.go
+++ b/internal/configs/config.go
@@ -429,21 +429,6 @@ func (c *Config) addProviderRequirements(reqs getproviders.Requirements, recurse
 		}
 		reqs[fqn] = nil
 	}
-	for _, i := range c.Module.Import {
-		implied, err := addrs.ParseProviderPart(i.ToResource.Resource.ImpliedProvider())
-		if err == nil {
-			// FIXME: this will not resolve correctly if the target module uses
-			// a different local name from the root module.
-			provider := c.Module.ImpliedProviderForUnqualifiedType(implied)
-			if _, exists := reqs[provider]; exists {
-				// Explicit dependency already present
-				continue
-			}
-			reqs[provider] = nil
-		}
-		// We don't return a diagnostic here, because the invalid address will
-		// have been caught elsewhere.
-	}
 
 	// Import blocks that are generating config may also have a custom provider
 	// meta argument. Like the provider meta argument used in resource blocks,


### PR DESCRIPTION
Just dealing with another FIXME.
This block of code iterated through `import` blocks, adding to reqs the implied provider for each import target.
This is redundant, because for any `import` block, either there exists a corresponding `resource` block in config, or there does not and config will be generated.
If the `resource` block already exists, the provider requirement will be added by code earlier in `addProviderRequirements`. If the `resource` block does not exist, the provider requirement will be added by the code block directly following this one.
The above applies whether or not the target of the `import` block is in a child module. If a child module has a different local name for a provider, that provider must be in `required_providers`, so again it will be added to the provider requirements elsewhere in `addProviderRequirements`.

@jbardin @liamcervante perhaps you could check my reasoning here and suggest any further test cases. 