### PR TITLE
update hcl v2.19.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -50,7 +50,7 @@ require (
 	github.com/hashicorp/go-uuid v1.0.3
 	github.com/hashicorp/go-version v1.6.0
 	github.com/hashicorp/hcl v1.0.0
-	github.com/hashicorp/hcl/v2 v2.19.0
+	github.com/hashicorp/hcl/v2 v2.19.1
 	github.com/hashicorp/jsonapi v0.0.0-20210826224640-ee7dae0fb22d
 	github.com/hashicorp/terraform-registry-address v0.2.0
 	github.com/hashicorp/terraform-svchost v0.1.1

--- a/go.sum
+++ b/go.sum
@@ -702,8 +702,8 @@ github.com/hashicorp/golang-lru v0.5.1 h1:0hERBMJE1eitiLkihrMvRVBYAkpHzc/J3QdDN+
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
-github.com/hashicorp/hcl/v2 v2.19.0 h1:vq9ncaL/+JtHe2JFQo6h/D7HqkfrYQn+nRYG/WDKmLo=
-github.com/hashicorp/hcl/v2 v2.19.0/go.mod h1:ThLC89FV4p9MPW804KVbe/cEXoQ8NZEh+JtMeeGErHE=
+github.com/hashicorp/hcl/v2 v2.19.1 h1://i05Jqznmb2EXqa39Nsvyan2o5XyMowW5fnCKW5RPI=
+github.com/hashicorp/hcl/v2 v2.19.1/go.mod h1:ThLC89FV4p9MPW804KVbe/cEXoQ8NZEh+JtMeeGErHE=
 github.com/hashicorp/jsonapi v0.0.0-20210826224640-ee7dae0fb22d h1:9ARUJJ1VVynB176G1HCwleORqCaXm/Vx0uUi0dL26I0=
 github.com/hashicorp/jsonapi v0.0.0-20210826224640-ee7dae0fb22d/go.mod h1:Yog5+CPEM3c99L1CL2CFCYoSzgWm5vTU58idbRUaLik=
 github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO+LraFDTW64=

--- a/internal/command/jsonconfig/config.go
+++ b/internal/command/jsonconfig/config.go
@@ -414,6 +414,7 @@ func marshalModuleCall(c *configs.Config, mc *configs.ModuleCall, schemas *terra
 	schema.Attributes = make(map[string]*configschema.Attribute)
 	for _, variable := range c.Module.Variables {
 		schema.Attributes[variable.Name] = &configschema.Attribute{
+			Type:     cty.DynamicPseudoType,
 			Required: variable.Default == cty.NilVal,
 		}
 	}

--- a/internal/configs/configschema/decoder_spec.go
+++ b/internal/configs/configschema/decoder_spec.go
@@ -184,11 +184,11 @@ func (b *Block) DecoderSpec() hcldec.Spec {
 }
 
 func (a *Attribute) decoderSpec(name string) hcldec.Spec {
-	ret := &hcldec.AttrSpec{Name: name}
-	if a == nil {
-		return ret
+	if a == nil || (a.Type == cty.NilType && a.NestedType == nil) {
+		panic("Invalid attribute schema: schema is nil.")
 	}
 
+	ret := &hcldec.AttrSpec{Name: name}
 	if a.NestedType != nil {
 		if a.Type != cty.NilType {
 			panic("Invalid attribute schema: NestedType and Type cannot both be set. This is a bug in the provider.")

--- a/internal/configs/configschema/decoder_spec_test.go
+++ b/internal/configs/configschema/decoder_spec_test.go
@@ -445,18 +445,6 @@ func TestAttributeDecoderSpec(t *testing.T) {
 		Want      cty.Value
 		DiagCount int
 	}{
-		"empty": {
-			&Attribute{},
-			hcl.EmptyBody(),
-			cty.NilVal,
-			0,
-		},
-		"nil": {
-			nil,
-			hcl.EmptyBody(),
-			cty.NilVal,
-			0,
-		},
 		"optional string (null)": {
 			&Attribute{
 				Type:     cty.String,
@@ -878,17 +866,33 @@ func TestAttributeDecoderSpec(t *testing.T) {
 // be removed when InternalValidate() is extended to validate Attribute specs
 // (and is used). See the #FIXME in decoderSpec.
 func TestAttributeDecoderSpec_panic(t *testing.T) {
-	attrS := &Attribute{
-		Type: cty.Object(map[string]cty.Type{
-			"nested_attribute": cty.String,
-		}),
-		NestedType: &Object{},
-		Optional:   true,
+	tests := map[string]struct {
+		Schema *Attribute
+	}{
+		"empty": {
+			Schema: &Attribute{},
+		},
+		"nil": {
+			Schema: nil,
+		},
+		"nested_attribute": {
+			Schema: &Attribute{
+				Type: cty.Object(map[string]cty.Type{
+					"nested_attribute": cty.String,
+				}),
+				NestedType: &Object{},
+				Optional:   true,
+			},
+		},
 	}
 
-	defer func() { recover() }()
-	attrS.decoderSpec("attr")
-	t.Errorf("expected panic")
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			defer func() { recover() }()
+			test.Schema.decoderSpec("attr")
+			t.Errorf("expected panic")
+		})
+	}
 }
 
 func TestListOptionalAttrsFromObject(t *testing.T) {


### PR DESCRIPTION
Update hcl to v2.19.1, which fixes an issue where the decoder can return null or unknown values which still contain optional attribute type constraints.

Remove invalid configschema tests. Schema attributes must have a type to be valid. These would have panicked anyway when used in other cases, but were passing within the limited test case. The update to hcl makes these panic earlier, so add our own panics to prevent invalid attribute schemas entirely.

We can be fairly certain these panics didn't affect actual functionality outside of the synthetic tests, because `hcldec` was returning an invalid `cty.NilVal` with no error, which itself would have panicked later if used.