### PR TITLE
data sources cannot be imported

### DIFF
--- a/internal/configs/import.go
+++ b/internal/configs/import.go
@@ -54,6 +54,16 @@ func decodeImportBlock(block *hcl.Block) (*Import, hcl.Diagnostics) {
 
 		addr, toDiags := parseConfigResourceFromExpression(imp.To)
 		diags = diags.Extend(toDiags.ToHCL())
+
+		if addr.Resource.Mode != addrs.ManagedResourceMode {
+			diags = append(diags, &hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  "Invalid import address",
+				Detail:   "Only managed resources can be imported.",
+				Subject:  attr.Range.Ptr(),
+			})
+		}
+
 		imp.ToResource = addr
 	}
 

--- a/internal/configs/import_test.go
+++ b/internal/configs/import_test.go
@@ -174,9 +174,9 @@ func TestImportBlock_decode(t *testing.T) {
 				Type: "import",
 				Body: hcltest.MockBody(&hcl.BodyContent{
 					Attributes: hcl.Attributes{
-						"id": {
-							Name: "id",
-							Expr: foo_str_expr,
+						"to": {
+							Name: "to",
+							Expr: bar_expr,
 						},
 					},
 				}),
@@ -187,6 +187,29 @@ func TestImportBlock_decode(t *testing.T) {
 				DeclRange: blockRange,
 			},
 			"Missing required argument",
+		},
+		"error: data source": {
+			&hcl.Block{
+				Type: "import",
+				Body: hcltest.MockBody(&hcl.BodyContent{
+					Attributes: hcl.Attributes{
+						"id": {
+							Name: "id",
+							Expr: foo_str_expr,
+						},
+						"to": {
+							Name: "to",
+							Expr: hcltest.MockExprTraversalSrc("data.test_instance.bar"),
+						},
+					},
+				}),
+				DefRange: blockRange,
+			},
+			&Import{
+				ID:        foo_str_expr,
+				DeclRange: blockRange,
+			},
+			"Invalid import address",
 		},
 	}
 


### PR DESCRIPTION
A data source should not be importable, and will crash if config generation is attempted. Validate the target type early to prevent errors during the plan.
