### PR TITLE
backend/s3(doc): s3 comptible storage support model

### DIFF
--- a/website/docs/language/settings/backends/s3.mdx
+++ b/website/docs/language/settings/backends/s3.mdx
@@ -593,3 +593,8 @@ By default, the underlying AWS client used by the Terraform AWS Provider creates
 ```sh
 $ export TF_APPEND_USER_AGENT="JenkinsAgent/i-12345678 BuildID/1234 (Optional Extra Information)"
 ```
+
+## Support for "S3 Compatible" Storage Providers
+
+Support for S3 Compatible storage providers is offered as “best effort”.
+HashiCorp only tests the `s3` backend against Amazon S3, so cannot offer any guarantees when using an alternate provider.


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->
Explicitly documents the `s3` backend support model for "S3 compatible" storage providers. This has always been "best effort" with no guaranteed support, but has not been formally stated in the backend documentation.

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Relates #34086 
Relates #34053 
Relates #33847
Relates #19733
Relates #34099


## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.6.x

## Draft CHANGELOG entry

N/a docs
