### PR TITLE
backend/s3: Adds parameter `skip_s3_checksum` to skip checksum on upload

### DIFF
--- a/internal/backend/remote-state/s3/backend.go
+++ b/internal/backend/remote-state/s3/backend.go
@@ -45,6 +45,7 @@ type Backend struct {
 	kmsKeyID              string
 	ddbTable              string
 	workspaceKeyPrefix    string
+	skipS3Checksum        bool
 }
 
 // ConfigSchema returns a description of the expected configuration
@@ -183,7 +184,7 @@ func (b *Backend) ConfigSchema() *configschema.Block {
 			"skip_credentials_validation": {
 				Type:        cty.Bool,
 				Optional:    true,
-				Description: "Skip the credentials validation via STS API.",
+				Description: "Skip the credentials validation via STS API. Useful for testing and for AWS API implementations that do not have STS available.",
 			},
 			"skip_requesting_account_id": {
 				Type:        cty.Bool,
@@ -199,6 +200,11 @@ func (b *Backend) ConfigSchema() *configschema.Block {
 				Type:        cty.Bool,
 				Optional:    true,
 				Description: "Skip static validation of region name.",
+			},
+			"skip_s3_checksum": {
+				Type:        cty.Bool,
+				Optional:    true,
+				Description: "Do not include checksum when uploading S3 Objects. Useful for some S3-Compatible APIs.",
 			},
 			"sse_customer_key": {
 				Type:        cty.String,
@@ -903,6 +909,7 @@ func (b *Backend) Configure(obj cty.Value) tfdiags.Diagnostics {
 	b.serverSideEncryption = boolAttr(obj, "encrypt")
 	b.kmsKeyID = stringAttr(obj, "kms_key_id")
 	b.ddbTable = stringAttr(obj, "dynamodb_table")
+	b.skipS3Checksum = boolAttr(obj, "skip_s3_checksum")
 
 	if _, ok := stringAttrOk(obj, "kms_key_id"); ok {
 		if customerKey := os.Getenv("AWS_SSE_CUSTOMER_KEY"); customerKey != "" {

--- a/internal/backend/remote-state/s3/backend_state.go
+++ b/internal/backend/remote-state/s3/backend_state.go
@@ -151,6 +151,7 @@ func (b *Backend) remoteClient(name string) (*RemoteClient, error) {
 		acl:                   b.acl,
 		kmsKeyID:              b.kmsKeyID,
 		ddbTable:              b.ddbTable,
+		skipS3Checksum:        b.skipS3Checksum,
 	}
 
 	return client, nil

--- a/internal/backend/remote-state/s3/backend_test.go
+++ b/internal/backend/remote-state/s3/backend_test.go
@@ -61,6 +61,15 @@ func TestBackend_impl(t *testing.T) {
 	var _ backend.Backend = new(Backend)
 }
 
+func TestBackend_InternalValidate(t *testing.T) {
+	b := New()
+
+	schema := b.ConfigSchema()
+	if err := schema.InternalValidate(); err != nil {
+		t.Fatalf("failed InternalValidate: %s", err)
+	}
+}
+
 func TestBackendConfig_original(t *testing.T) {
 	testACC(t)
 

--- a/internal/backend/remote-state/s3/client.go
+++ b/internal/backend/remote-state/s3/client.go
@@ -231,13 +231,13 @@ func (c *RemoteClient) put(data []byte, optFns ...func(*s3.Options)) error {
 	})
 	_, err := uploader.Upload(ctx, input)
 	if err != nil {
-		return fmt.Errorf("failed to upload state: %s", err)
+		return fmt.Errorf("failed to upload state: %w", err)
 	}
 
 	if err := c.putMD5(ctx, sum[:]); err != nil {
 		// if this errors out, we unfortunately have to error out altogether,
 		// since the next Get will inevitably fail.
-		return fmt.Errorf("failed to store state MD5: %s", err)
+		return fmt.Errorf("failed to store state MD5: %w", err)
 	}
 
 	return nil

--- a/internal/backend/remote-state/s3/client.go
+++ b/internal/backend/remote-state/s3/client.go
@@ -47,6 +47,7 @@ type RemoteClient struct {
 	acl                   string
 	kmsKeyID              string
 	ddbTable              string
+	skipS3Checksum        bool
 }
 
 var (
@@ -182,6 +183,10 @@ func (c *RemoteClient) get(ctx context.Context) (*remote.Payload, error) {
 }
 
 func (c *RemoteClient) Put(data []byte) error {
+	return c.put(data)
+}
+
+func (c *RemoteClient) put(data []byte, optFns ...func(*s3.Options)) error {
 	ctx := context.TODO()
 	log := c.logger(operationClientPut)
 
@@ -193,11 +198,13 @@ func (c *RemoteClient) Put(data []byte) error {
 	sum := md5.Sum(data)
 
 	input := &s3.PutObjectInput{
-		ContentType:       aws.String(contentType),
-		Body:              bytes.NewReader(data),
-		Bucket:            aws.String(c.bucketName),
-		Key:               aws.String(c.path),
-		ChecksumAlgorithm: s3types.ChecksumAlgorithmSha256,
+		ContentType: aws.String(contentType),
+		Body:        bytes.NewReader(data),
+		Bucket:      aws.String(c.bucketName),
+		Key:         aws.String(c.path),
+	}
+	if !c.skipS3Checksum {
+		input.ChecksumAlgorithm = s3types.ChecksumAlgorithmSha256
 	}
 
 	if c.serverSideEncryption {
@@ -219,7 +226,9 @@ func (c *RemoteClient) Put(data []byte) error {
 
 	log.Info("Uploading remote state")
 
-	uploader := manager.NewUploader(c.s3Client)
+	uploader := manager.NewUploader(c.s3Client, func(u *manager.Uploader) {
+		u.ClientOptions = optFns
+	})
 	_, err := uploader.Upload(ctx, input)
 	if err != nil {
 		return fmt.Errorf("failed to upload state: %s", err)

--- a/internal/backend/remote-state/s3/client_test.go
+++ b/internal/backend/remote-state/s3/client_test.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/md5"
+	"errors"
 	"fmt"
 	"io"
 	"testing"
@@ -452,8 +453,10 @@ func TestRemoteClientSkipS3Checksum(t *testing.T) {
 					addCancelRequestMiddleware(),
 				)
 			})
-			if err != nil {
-				t.Fatal(err)
+			if err == nil {
+				t.Fatal("Expected an error, got none")
+			} else if !errors.Is(err, errCancelOperation) {
+				t.Fatalf("Unexpected error: %s", err)
 			}
 
 			if a, e := header, testcase.expected; a != e {

--- a/website/docs/language/settings/backends/s3.mdx
+++ b/website/docs/language/settings/backends/s3.mdx
@@ -173,9 +173,13 @@ The following configuration is optional:
 * `shared_credentials_file`  - (Optional, **Deprecated**, use `shared_credentials_files` instead) Path to the AWS shared credentials file. Defaults to `~/.aws/credentials`.
 * `shared_credentials_files`  - (Optional) List of paths to AWS shared credentials files. Defaults to `~/.aws/credentials`.
 * `skip_credentials_validation` - (Optional) Skip credentials validation via the STS API.
+  Useful for testing and for AWS API implementations that do not have STS available.
 * `skip_region_validation` - (Optional) Skip validation of provided region name.
-* `skip_requesting_account_id` - (Optional) Whether to skip requesting the account ID. Useful for AWS API implementations that do not have the IAM, STS API, or metadata API.
+* `skip_requesting_account_id` - (Optional) Whether to skip requesting the account ID.
+  Useful for AWS API implementations that do not have the IAM, STS API, or metadata API.
 * `skip_metadata_api_check` - (Optional) Skip usage of EC2 Metadata API.
+* `skip_s3_checksum` - (Optional) Do not include checksum when uploading S3 Objects.
+  Useful for some S3-Compatible APIs.
 * `sts_endpoint` - (Optional, **Deprecated**) Custom endpoint URL for the AWS Security Token Service (STS) API.
   Use `endpoints.sts` instead.
 * `sts_region` - (Optional) AWS region for STS. If unset, AWS will use the same region for STS as other non-STS operations.


### PR DESCRIPTION
Some "S3-compatible" APIs do not support the header `x-amz-sdk-checksum-algorithm`. In the S3 API, a checksum is recommended and is required when Object Lock is enabled.

Allow users to disable the header.

Fixes #34099
Fixes #34086
Relates https://github.com/hashicorp/terraform/issues/34053#issuecomment-1767392693

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.6.2

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

### ENHANCEMENTS

<!--

Write a short description of the user-facing change. Examples:

- `terraform show -json`: Fixed crash with sensitive set values.
- When rendering a diff, Terraform now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 

- backend/s3: Allows users to disable checksum on S3 uploads for compatibility with "S3-compatible" APIs
