### PR TITLE
Exit CD when fail for a variety of reasons

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -11,7 +11,7 @@ while [ -h "$SOURCE" ] ; do SOURCE="$(readlink "$SOURCE")"; done
 DIR="$( cd -P "$( dirname "$SOURCE" )/.." && pwd )"
 
 # Change into that directory
-cd "$DIR"
+cd "$DIR" || exit
 
 # Determine the arch/os combos we're building for
 XC_ARCH=${XC_ARCH:-"386 amd64 arm"}


### PR DESCRIPTION
`cd` can fail for a variety of reasons: misspelled paths, missing directories, missing permissions, broken symlinks and more.

If/when it does, the script will keep going and do all its operations in the wrong directory. This can be messy, especially if the operations involve creating or deleting a lot of files. To avoid this, make sure you handle the cases when cd fails. Ways to do this include:

`cd foo || exit` as suggested to abort immediately, using exit code from failed cd command