### PR TITLE
terraform test: parse mock and override blocks within test files

### DIFF
--- a/internal/addrs/module.go
+++ b/internal/addrs/module.go
@@ -66,6 +66,14 @@ func (m Module) Equal(other Module) bool {
 	return true
 }
 
+type moduleKey string
+
+func (m Module) UniqueKey() UniqueKey {
+	return moduleKey(m.String())
+}
+
+func (mk moduleKey) uniqueKeySigil() {}
+
 func (m Module) targetableSigil() {
 	// Module is targetable
 }

--- a/internal/addrs/targetable.go
+++ b/internal/addrs/targetable.go
@@ -6,6 +6,8 @@ package addrs
 // Targetable is an interface implemented by all address types that can be
 // used as "targets" for selecting sub-graphs of a graph.
 type Targetable interface {
+	UniqueKeyer
+
 	targetableSigil()
 
 	// TargetContains returns true if the receiver is considered to contain

--- a/internal/configs/mock_provider.go
+++ b/internal/configs/mock_provider.go
@@ -1,0 +1,383 @@
+package configs
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/gohcl"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/zclconf/go-cty/cty"
+
+	"github.com/hashicorp/terraform/internal/addrs"
+	"github.com/hashicorp/terraform/internal/tfdiags"
+)
+
+func decodeMockProviderBlock(block *hcl.Block) (*Provider, hcl.Diagnostics) {
+	var diags hcl.Diagnostics
+
+	content, config, moreDiags := block.Body.PartialContent(mockProviderSchema)
+	diags = append(diags, moreDiags...)
+
+	name := block.Labels[0]
+	nameDiags := checkProviderNameNormalized(name, block.DefRange)
+	diags = append(diags, nameDiags...)
+	if nameDiags.HasErrors() {
+		// If the name is invalid then we mustn't produce a result because
+		// downstream could try to use it as a provider type and then crash.
+		return nil, diags
+	}
+
+	provider := &Provider{
+		Name:      name,
+		NameRange: block.LabelRanges[0],
+		DeclRange: block.DefRange,
+
+		Config: config,
+
+		// Mark this provider as being mocked.
+		Mock: true,
+	}
+
+	if attr, exists := content.Attributes["alias"]; exists {
+		valDiags := gohcl.DecodeExpression(attr.Expr, nil, &provider.Alias)
+		diags = append(diags, valDiags...)
+		provider.AliasRange = attr.Expr.Range().Ptr()
+
+		if !hclsyntax.ValidIdentifier(provider.Alias) {
+			diags = append(diags, &hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  "Invalid provider configuration alias",
+				Detail:   fmt.Sprintf("An alias must be a valid name. %s", badIdentifierDetail),
+			})
+		}
+	}
+
+	var dataDiags hcl.Diagnostics
+	provider.MockData, dataDiags = decodeMockDataBody(config)
+	diags = append(diags, dataDiags...)
+
+	// TODO(liamcervante): Add support for the "source" attribute before the
+	//                     v1.7 release.
+
+	return provider, diags
+}
+
+// MockData packages up all the available mock and override data available to
+// a mocked provider.
+type MockData struct {
+	MockResources   map[string]*MockResource
+	MockDataSources map[string]*MockResource
+	Overrides       addrs.Map[addrs.Targetable, *Override]
+}
+
+// MockResource maps a resource or data source type and name to a set of values
+// for that resource.
+type MockResource struct {
+	Mode addrs.ResourceMode
+	Type string
+
+	Defaults cty.Value
+
+	Range         hcl.Range
+	TypeRange     hcl.Range
+	DefaultsRange hcl.Range
+}
+
+// Override targets a specific module, resource or data source with a set of
+// replacement values that should be used in place of whatever the underlying
+// provider would normally do.
+type Override struct {
+	Target *addrs.Target
+	Values cty.Value
+
+	Range       hcl.Range
+	TypeRange   hcl.Range
+	TargetRange hcl.Range
+	ValuesRange hcl.Range
+}
+
+func decodeMockDataBody(body hcl.Body) (*MockData, hcl.Diagnostics) {
+	var diags hcl.Diagnostics
+
+	content, contentDiags := body.Content(mockDataSchema)
+	diags = append(diags, contentDiags...)
+
+	data := &MockData{
+		MockResources:   make(map[string]*MockResource),
+		MockDataSources: make(map[string]*MockResource),
+		Overrides:       addrs.MakeMap[addrs.Targetable, *Override](),
+	}
+
+	for _, block := range content.Blocks {
+		switch block.Type {
+		case "mock_resource", "mock_data":
+			resource, resourceDiags := decodeMockResourceBlock(block)
+			diags = append(diags, resourceDiags...)
+
+			if resource != nil {
+				switch resource.Mode {
+				case addrs.ManagedResourceMode:
+					if previous, ok := data.MockResources[resource.Type]; ok {
+						diags = append(diags, &hcl.Diagnostic{
+							Severity: hcl.DiagError,
+							Summary:  "Duplicate mock_resource block",
+							Detail:   fmt.Sprintf("A mock_resource block for %s has already been defined at %s.", resource.Type, previous.Range),
+							Subject:  resource.TypeRange.Ptr(),
+						})
+						continue
+					}
+					data.MockResources[resource.Type] = resource
+				case addrs.DataResourceMode:
+					if previous, ok := data.MockDataSources[resource.Type]; ok {
+						diags = append(diags, &hcl.Diagnostic{
+							Severity: hcl.DiagError,
+							Summary:  "Duplicate mock_data block",
+							Detail:   fmt.Sprintf("A mock_data block for %s has already been defined at %s.", resource.Type, previous.Range),
+							Subject:  resource.TypeRange.Ptr(),
+						})
+						continue
+					}
+					data.MockDataSources[resource.Type] = resource
+				}
+			}
+		case "override_resource":
+			override, overrideDiags := decodeOverrideResourceBlock(block)
+			diags = append(diags, overrideDiags...)
+
+			if override != nil && override.Target != nil {
+				subject := override.Target.Subject
+				if previous, ok := data.Overrides.GetOk(subject); ok {
+					diags = append(diags, &hcl.Diagnostic{
+						Severity: hcl.DiagError,
+						Summary:  "Duplicate override_resource block",
+						Detail:   fmt.Sprintf("An override_resource block targeting %s has already been defined at %s.", subject, previous.Range),
+						Subject:  override.Range.Ptr(),
+					})
+					continue
+				}
+				data.Overrides.Put(subject, override)
+			}
+		case "override_data":
+			override, overrideDiags := decodeOverrideDataBlock(block)
+			diags = append(diags, overrideDiags...)
+
+			if override != nil && override.Target != nil {
+				subject := override.Target.Subject
+				if previous, ok := data.Overrides.GetOk(subject); ok {
+					diags = append(diags, &hcl.Diagnostic{
+						Severity: hcl.DiagError,
+						Summary:  "Duplicate override_data block",
+						Detail:   fmt.Sprintf("An override_data block targeting %s has already been defined at %s.", subject, previous.Range),
+						Subject:  override.Range.Ptr(),
+					})
+					continue
+				}
+				data.Overrides.Put(subject, override)
+			}
+		}
+	}
+
+	return data, diags
+}
+
+func decodeMockResourceBlock(block *hcl.Block) (*MockResource, hcl.Diagnostics) {
+	var diags hcl.Diagnostics
+
+	content, contentDiags := block.Body.Content(mockResourceSchema)
+	diags = append(diags, contentDiags...)
+
+	resource := &MockResource{
+		Type:      block.Labels[0],
+		Range:     block.DefRange,
+		TypeRange: block.LabelRanges[0],
+	}
+
+	switch block.Type {
+	case "mock_resource":
+		resource.Mode = addrs.ManagedResourceMode
+	case "mock_data":
+		resource.Mode = addrs.DataResourceMode
+	}
+
+	if defaults, exists := content.Attributes["defaults"]; exists {
+		var defaultDiags hcl.Diagnostics
+		resource.DefaultsRange = defaults.Range
+		resource.Defaults, defaultDiags = defaults.Expr.Value(nil)
+		diags = append(diags, defaultDiags...)
+	} else {
+		// It's fine if we don't have any defaults, just means we'll generate
+		// values for everything ourselves.
+		resource.Defaults = cty.NilVal
+	}
+
+	return resource, diags
+}
+
+func decodeOverrideModuleBlock(block *hcl.Block) (*Override, hcl.Diagnostics) {
+	override, diags := decodeOverrideBlock(block, "outputs", "override_module")
+
+	if override.Target != nil {
+		switch override.Target.Subject.AddrType() {
+		case addrs.ModuleAddrType, addrs.ModuleInstanceAddrType:
+			// Do nothing, we're good here.
+		default:
+			diags = diags.Append(&hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  "Invalid override target",
+				Detail:   fmt.Sprintf("You can only target modules from override_module blocks, not %s.", override.Target.Subject),
+				Subject:  override.TargetRange.Ptr(),
+			})
+			return nil, diags
+		}
+	}
+
+	return override, diags
+}
+
+func decodeOverrideResourceBlock(block *hcl.Block) (*Override, hcl.Diagnostics) {
+	override, diags := decodeOverrideBlock(block, "values", "override_resource")
+
+	if override.Target != nil {
+		var mode addrs.ResourceMode
+
+		switch override.Target.Subject.AddrType() {
+		case addrs.AbsResourceInstanceAddrType:
+			subject := override.Target.Subject.(addrs.AbsResourceInstance)
+			mode = subject.Resource.Resource.Mode
+		case addrs.AbsResourceAddrType:
+			subject := override.Target.Subject.(addrs.AbsResource)
+			mode = subject.Resource.Mode
+		default:
+			diags = diags.Append(&hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  "Invalid override target",
+				Detail:   fmt.Sprintf("You can only target resources from override_resource blocks, not %s.", override.Target.Subject),
+				Subject:  override.TargetRange.Ptr(),
+			})
+			return nil, diags
+		}
+
+		if mode != addrs.ManagedResourceMode {
+			diags = diags.Append(&hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  "Invalid override target",
+				Detail:   fmt.Sprintf("You can only target resources from override_resource blocks, not %s.", override.Target.Subject),
+				Subject:  override.TargetRange.Ptr(),
+			})
+			return nil, diags
+		}
+	}
+
+	return override, diags
+}
+
+func decodeOverrideDataBlock(block *hcl.Block) (*Override, hcl.Diagnostics) {
+	override, diags := decodeOverrideBlock(block, "values", "override_data")
+
+	if override.Target != nil {
+		var mode addrs.ResourceMode
+
+		switch override.Target.Subject.AddrType() {
+		case addrs.AbsResourceInstanceAddrType:
+			subject := override.Target.Subject.(addrs.AbsResourceInstance)
+			mode = subject.Resource.Resource.Mode
+		case addrs.AbsResourceAddrType:
+			subject := override.Target.Subject.(addrs.AbsResource)
+			mode = subject.Resource.Mode
+		default:
+			diags = diags.Append(&hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  "Invalid override target",
+				Detail:   fmt.Sprintf("You can only target data sources from override_data blocks, not %s.", override.Target.Subject),
+				Subject:  override.TargetRange.Ptr(),
+			})
+			return nil, diags
+		}
+
+		if mode != addrs.DataResourceMode {
+			diags = diags.Append(&hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  "Invalid override target",
+				Detail:   fmt.Sprintf("You can only target data sources from override_data blocks, not %s.", override.Target.Subject),
+				Subject:  override.TargetRange.Ptr(),
+			})
+			return nil, diags
+		}
+	}
+
+	return override, diags
+}
+
+func decodeOverrideBlock(block *hcl.Block, attributeName string, blockName string) (*Override, hcl.Diagnostics) {
+	var diags hcl.Diagnostics
+
+	content, contentDiags := block.Body.Content(&hcl.BodySchema{
+		Attributes: []hcl.AttributeSchema{
+			{Name: "target"},
+			{Name: attributeName},
+		},
+	})
+	diags = append(diags, contentDiags...)
+
+	override := &Override{
+		Range:     block.DefRange,
+		TypeRange: block.TypeRange,
+	}
+
+	if target, exists := content.Attributes["target"]; exists {
+		override.TargetRange = target.Range
+		traversal, traversalDiags := hcl.AbsTraversalForExpr(target.Expr)
+		diags = append(diags, traversalDiags...)
+		if traversal != nil {
+			var targetDiags tfdiags.Diagnostics
+			override.Target, targetDiags = addrs.ParseTarget(traversal)
+			diags = append(diags, targetDiags.ToHCL()...)
+		}
+	} else {
+		diags = diags.Append(&hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  "Missing target attribute",
+			Detail:   fmt.Sprintf("%s blocks must specify a target address.", blockName),
+			Subject:  override.Range.Ptr(),
+		})
+	}
+
+	if attribute, exists := content.Attributes[attributeName]; exists {
+		var valueDiags hcl.Diagnostics
+		override.ValuesRange = attribute.Range
+		override.Values, valueDiags = attribute.Expr.Value(nil)
+		diags = append(diags, valueDiags...)
+	} else {
+		// It's fine if we don't have any values, just means we'll generate
+		// values for everything ourselves.
+		override.Values = cty.NilVal
+	}
+
+	return override, diags
+}
+
+var mockProviderSchema = &hcl.BodySchema{
+	Attributes: []hcl.AttributeSchema{
+		{
+			Name: "alias",
+		},
+		{
+			Name: "source",
+		},
+	},
+}
+
+var mockDataSchema = &hcl.BodySchema{
+	Blocks: []hcl.BlockHeaderSchema{
+		{Type: "mock_resource", LabelNames: []string{"type"}},
+		{Type: "mock_data", LabelNames: []string{"type"}},
+		{Type: "override_resource"},
+		{Type: "override_data"},
+	},
+}
+
+var mockResourceSchema = &hcl.BodySchema{
+	Attributes: []hcl.AttributeSchema{
+		{Name: "defaults"},
+	},
+}

--- a/internal/configs/provider.go
+++ b/internal/configs/provider.go
@@ -35,6 +35,12 @@ type Provider struct {
 	// export this so providers don't need to be re-resolved.
 	// This same field is also added to the ProviderConfigRef struct.
 	providerType addrs.Provider
+
+	// Mock and MockData declare this provider as a "mock_provider", which means
+	// it should use the data in MockData instead of actually initialising the
+	// provider.
+	Mock     bool
+	MockData *MockData
 }
 
 func decodeProviderBlock(block *hcl.Block) (*Provider, hcl.Diagnostics) {
@@ -60,6 +66,10 @@ func decodeProviderBlock(block *hcl.Block) (*Provider, hcl.Diagnostics) {
 		NameRange: block.LabelRanges[0],
 		Config:    config,
 		DeclRange: block.DefRange,
+
+		// We'll just explicitly mark real providers as not being mocks even
+		// though this is the default.
+		Mock: false,
 	}
 
 	if attr, exists := content.Attributes["alias"]; exists {

--- a/internal/configs/testdata/invalid-test-files/duplicate_data_overrides.tftest.hcl
+++ b/internal/configs/testdata/invalid-test-files/duplicate_data_overrides.tftest.hcl
@@ -1,0 +1,33 @@
+mock_provider "aws" {
+  override_data {
+    target = data.aws_instance.test
+    values = {}
+  }
+
+  override_data {
+    target = data.aws_instance.test
+    values = {}
+  }
+}
+
+override_data {
+  target = data.aws_instance.test
+  values = {}
+}
+
+override_data {
+  target = data.aws_instance.test
+  values = {}
+}
+
+run "test" {
+  override_data {
+    target = data.aws_instance.test
+    values = {}
+  }
+
+  override_data {
+    target = data.aws_instance.test
+    values = {}
+  }
+}

--- a/internal/configs/testdata/invalid-test-files/duplicate_mixed_providers.tftest.hcl
+++ b/internal/configs/testdata/invalid-test-files/duplicate_mixed_providers.tftest.hcl
@@ -1,0 +1,13 @@
+provider "aws" {}
+
+mock_provider "aws" {}
+
+provider "aws" {
+  alias = "test"
+}
+
+mock_provider "aws" {
+  alias = "test"
+}
+
+run "test" {}

--- a/internal/configs/testdata/invalid-test-files/duplicate_mock_data_sources.tftest.hcl
+++ b/internal/configs/testdata/invalid-test-files/duplicate_mock_data_sources.tftest.hcl
@@ -1,0 +1,13 @@
+mock_provider "aws" {
+
+  mock_data "aws_instance" {
+    defaults = {}
+  }
+
+  mock_data "aws_instance" {
+    defaults = {}
+  }
+
+}
+
+run "test" {}

--- a/internal/configs/testdata/invalid-test-files/duplicate_mock_providers.tftest.hcl
+++ b/internal/configs/testdata/invalid-test-files/duplicate_mock_providers.tftest.hcl
@@ -1,0 +1,13 @@
+mock_provider "aws" {}
+
+mock_provider "aws" {}
+
+mock_provider "aws" {
+  alias = "test"
+}
+
+mock_provider "aws" {
+  alias = "test"
+}
+
+run "test" {}

--- a/internal/configs/testdata/invalid-test-files/duplicate_mock_resources.tftest.hcl
+++ b/internal/configs/testdata/invalid-test-files/duplicate_mock_resources.tftest.hcl
@@ -1,0 +1,13 @@
+mock_provider "aws" {
+
+  mock_resource "aws_instance" {
+    defaults = {}
+  }
+
+  mock_resource "aws_instance" {
+    defaults = {}
+  }
+
+}
+
+run "test" {}

--- a/internal/configs/testdata/invalid-test-files/duplicate_module_overrides.tftest.hcl
+++ b/internal/configs/testdata/invalid-test-files/duplicate_module_overrides.tftest.hcl
@@ -1,0 +1,22 @@
+
+override_module {
+  target = module.child
+  outputs = {}
+}
+
+override_module {
+  target = module.child
+  outputs = {}
+}
+
+run "test" {
+  override_module {
+    target = module.child
+    outputs = {}
+  }
+
+  override_module {
+    target = module.child
+    outputs = {}
+  }
+}

--- a/internal/configs/testdata/invalid-test-files/duplicate_providers.tftest.hcl
+++ b/internal/configs/testdata/invalid-test-files/duplicate_providers.tftest.hcl
@@ -1,0 +1,13 @@
+provider "aws" {}
+
+provider "aws" {}
+
+provider "aws" {
+  alias = "test"
+}
+
+provider "aws" {
+  alias = "test"
+}
+
+run "test" {}

--- a/internal/configs/testdata/invalid-test-files/duplicate_resource_overrides.tftest.hcl
+++ b/internal/configs/testdata/invalid-test-files/duplicate_resource_overrides.tftest.hcl
@@ -1,0 +1,33 @@
+mock_provider "aws" {
+  override_resource {
+    target = aws_instance.test
+    values = {}
+  }
+
+  override_resource {
+    target = aws_instance.test
+    values = {}
+  }
+}
+
+override_resource {
+  target = aws_instance.test
+  values = {}
+}
+
+override_resource {
+  target = aws_instance.test
+  values = {}
+}
+
+run "test" {
+  override_resource {
+    target = aws_instance.test
+    values = {}
+  }
+
+  override_resource {
+    target = aws_instance.test
+    values = {}
+  }
+}

--- a/internal/configs/testdata/invalid-test-files/invalid_data_override.tftest.hcl
+++ b/internal/configs/testdata/invalid-test-files/invalid_data_override.tftest.hcl
@@ -1,0 +1,10 @@
+
+override_data {
+  target = data.aws_instance.target
+}
+
+override_data {
+  values = {}
+}
+
+run "test" {}

--- a/internal/configs/testdata/invalid-test-files/invalid_data_override_target.tftest.hcl
+++ b/internal/configs/testdata/invalid-test-files/invalid_data_override_target.tftest.hcl
@@ -1,0 +1,12 @@
+
+override_data {
+  target = aws_instance.target
+  values = {}
+}
+
+override_data {
+  target = module.child
+  values = {}
+}
+
+run "test" {}

--- a/internal/configs/testdata/invalid-test-files/invalid_mock_data_sources.tftest.hcl
+++ b/internal/configs/testdata/invalid-test-files/invalid_mock_data_sources.tftest.hcl
@@ -1,0 +1,13 @@
+mock_provider "aws" {
+
+  mock_data "aws_instance" {}
+
+  mock_data "aws_ami_instance" {
+    defaults = {
+      ami = var.ami
+    }
+  }
+
+}
+
+run "test" {}

--- a/internal/configs/testdata/invalid-test-files/invalid_mock_resources.tftest.hcl
+++ b/internal/configs/testdata/invalid-test-files/invalid_mock_resources.tftest.hcl
@@ -1,0 +1,13 @@
+mock_provider "aws" {
+
+  mock_resource "aws_instance" {}
+
+  mock_resource "aws_ami_instance" {
+    defaults = {
+      ami = var.ami
+    }
+  }
+
+}
+
+run "test" {}

--- a/internal/configs/testdata/invalid-test-files/invalid_module_override.tftest.hcl
+++ b/internal/configs/testdata/invalid-test-files/invalid_module_override.tftest.hcl
@@ -1,0 +1,14 @@
+override_module {
+  target = module.child
+}
+
+override_module {
+  outputs = {}
+}
+
+override_module {
+  target = module.other
+  values = {}
+}
+
+run "test" {}

--- a/internal/configs/testdata/invalid-test-files/invalid_module_override_target.tftest.hcl
+++ b/internal/configs/testdata/invalid-test-files/invalid_module_override_target.tftest.hcl
@@ -1,0 +1,12 @@
+
+override_module {
+  target = aws_instance.target
+  outputs = {}
+}
+
+override_module {
+  target = data.aws_instance.target
+  outputs = {}
+}
+
+run "test" {}

--- a/internal/configs/testdata/invalid-test-files/invalid_resource_override.tftest.hcl
+++ b/internal/configs/testdata/invalid-test-files/invalid_resource_override.tftest.hcl
@@ -1,0 +1,10 @@
+
+override_resource {
+  target = aws_instance.target
+}
+
+override_resource {
+  values = {}
+}
+
+run "test" {}

--- a/internal/configs/testdata/invalid-test-files/invalid_resource_override_target.tftest.hcl
+++ b/internal/configs/testdata/invalid-test-files/invalid_resource_override_target.tftest.hcl
@@ -1,0 +1,12 @@
+
+override_resource {
+  target = data.aws_instance.target
+  values = {}
+}
+
+override_resource {
+  target = module.child
+  values = {}
+}
+
+run "test" {}

--- a/internal/configs/testdata/valid-modules/with-mocks/child/main.tf
+++ b/internal/configs/testdata/valid-modules/with-mocks/child/main.tf
@@ -1,0 +1,8 @@
+
+output "string" {
+  value = "Hello, world!"
+}
+
+output "number" {
+  value = 0
+}

--- a/internal/configs/testdata/valid-modules/with-mocks/main.tf
+++ b/internal/configs/testdata/valid-modules/with-mocks/main.tf
@@ -1,0 +1,19 @@
+terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
+}
+
+resource "aws_instance" "first" {}
+
+resource "aws_instance" "second" {}
+
+resource "aws_instance" "third" {}
+
+data "aws_secretsmanager_secret" "creds" {}
+
+module "child" {
+  source = "./child"
+}

--- a/internal/configs/testdata/valid-modules/with-mocks/test_case_one.tftest.hcl
+++ b/internal/configs/testdata/valid-modules/with-mocks/test_case_one.tftest.hcl
@@ -1,0 +1,48 @@
+
+mock_provider "aws" {
+
+  mock_resource "aws_instance" {
+    defaults = {
+      arn = "aws:instance"
+    }
+  }
+
+  mock_data "aws_secretsmanager_secret" {}
+
+  override_resource {
+    target = aws_instance.second
+    values = {}
+  }
+
+  override_data {
+    target = data.aws_secretsmanager_secret.creds
+    values = {
+      arn = "aws:secretsmanager"
+    }
+  }
+}
+
+override_module {
+  target = module.child
+  outputs = {
+    string = "testfile"
+    number = -1
+  }
+}
+
+run "test" {
+  override_resource {
+    target = aws_instance.first
+    values = {
+      arn = "aws:instance:first"
+    }
+  }
+
+  override_module {
+    target = module.child
+    outputs = {
+      string = "testrun"
+      number = -1
+    }
+  }
+}

--- a/internal/configs/testdata/valid-modules/with-mocks/test_case_two.tftest.hcl
+++ b/internal/configs/testdata/valid-modules/with-mocks/test_case_two.tftest.hcl
@@ -1,0 +1,25 @@
+
+provider "aws" {}
+
+override_data {
+  target = data.aws_secretsmanager_secret.creds
+  values = {
+    arn = "aws:secretsmanager"
+  }
+}
+
+run "test" {
+  override_resource {
+    target = aws_instance.first
+    values = {
+      arn = "aws:instance:first"
+    }
+  }
+
+  override_data {
+    target = data.aws_secretsmanager_secret.creds
+    values = {
+      arn = "aws:secretsmanager"
+    }
+  }
+}


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

This PR adds support for the new mocking HCL blocks into the configs package. It also updates the test files so they will load the mocking data when they are loaded for terraform test commands.

I've left out the `source` attribute from `mock_provider` blocks from the time being. I want to have `terraform init` load any dedicated mock data files alongside the modules and providers. So I'll come back and add support for this in both `init` and `test` at the same time. This PR unlocks all the required functionality for mocking without doing too many things.


## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.7.0

