### PR TITLE
testing framework: add warnings for override blocks with invalid targets

### DIFF
--- a/internal/backend/local/test.go
+++ b/internal/backend/local/test.go
@@ -240,6 +240,10 @@ func (runner *TestFileRunner) Test(file *moduletest.File) {
 	// First thing, initialise the global variables for the file
 	runner.initVariables(file)
 
+	// The file validation only returns warnings so we'll just add them without
+	// checking anything about them.
+	file.Diagnostics = file.Diagnostics.Append(file.Config.Validate(runner.Suite.Config))
+
 	// We'll execute the tests in the file. First, mark the overall status as
 	// being skipped. This will ensure that if we've cancelled and the files not
 	// going to do anything it'll be marked as skipped.
@@ -343,7 +347,7 @@ func (runner *TestFileRunner) run(run *moduletest.Run, file *moduletest.File, st
 	start := time.Now().UTC().UnixMilli()
 	runner.Suite.View.Run(run, file, moduletest.Starting, 0)
 
-	run.Diagnostics = run.Diagnostics.Append(run.Config.Validate())
+	run.Diagnostics = run.Diagnostics.Append(run.Config.Validate(config))
 	if run.Diagnostics.HasErrors() {
 		run.Status = moduletest.Error
 		return state, false

--- a/internal/command/test_test.go
+++ b/internal/command/test_test.go
@@ -1690,3 +1690,97 @@ func TestTest_LongRunningTestJSON(t *testing.T) {
 		t.Errorf("unexpected output\n\nexpected:\n%s\nactual:\n%s\ndiff:\n%s", strings.Join(expected, "\n"), strings.Join(messages, "\n"), diff)
 	}
 }
+
+func TestTest_InvalidOverrides(t *testing.T) {
+	td := t.TempDir()
+	testCopyDir(t, testFixturePath(path.Join("test", "invalid-overrides")), td)
+	defer testChdir(t, td)()
+
+	provider := testing_command.NewProvider(nil)
+
+	providerSource, close := newMockProviderSource(t, map[string][]string{
+		"test": {"1.0.0"},
+	})
+	defer close()
+
+	streams, done := terminal.StreamsForTesting(t)
+	view := views.NewView(streams)
+	ui := new(cli.MockUi)
+
+	meta := Meta{
+		testingOverrides: metaOverridesForProvider(provider.Provider),
+		Ui:               ui,
+		View:             view,
+		Streams:          streams,
+		ProviderSource:   providerSource,
+	}
+
+	init := &InitCommand{
+		Meta: meta,
+	}
+
+	if code := init.Run(nil); code != 0 {
+		t.Fatalf("expected status code 0 but got %d: %s", code, ui.ErrorWriter)
+	}
+
+	c := &TestCommand{
+		Meta: meta,
+	}
+
+	code := c.Run([]string{"-no-color"})
+	output := done(t)
+
+	if code != 0 {
+		t.Errorf("expected status code 0 but got %d", code)
+	}
+
+	expected := `main.tftest.hcl... in progress
+  run "setup"... pass
+
+Warning: Invalid override target
+
+  on main.tftest.hcl line 39, in run "setup":
+  39:     target = test_resource.absent_five
+
+The override target test_resource.absent_five does not exist within the
+configuration under test. This could indicate or a typo in the target address
+or an unnecessary override.
+
+  run "test"... pass
+
+Warning: Invalid override target
+
+  on main.tftest.hcl line 45, in run "test":
+  45:     target = module.setup.test_resource.absent_six
+
+The override target module.setup.test_resource.absent_six does not exist
+within the configuration under test. This could indicate or a typo in the
+target address or an unnecessary override.
+
+main.tftest.hcl... tearing down
+main.tftest.hcl... pass
+
+Warning: Invalid override target
+
+  on main.tftest.hcl line 4, in mock_provider "test":
+   4:     target = test_resource.absent_one
+
+The override target test_resource.absent_one does not exist within the
+configuration under test. This could indicate or a typo in the target address
+or an unnecessary override.
+
+(and 3 more similar warnings elsewhere)
+
+Success! 2 passed, 0 failed.
+`
+
+	actual := output.All()
+
+	if diff := cmp.Diff(actual, expected); len(diff) > 0 {
+		t.Errorf("output didn't match expected:\nexpected:\n%s\nactual:\n%s\ndiff:\n%s", expected, actual, diff)
+	}
+
+	if provider.ResourceCount() > 0 {
+		t.Errorf("should have deleted all resources on completion but left %v", provider.ResourceString())
+	}
+}

--- a/internal/command/test_test.go
+++ b/internal/command/test_test.go
@@ -1743,8 +1743,8 @@ Warning: Invalid override target
   39:     target = test_resource.absent_five
 
 The override target test_resource.absent_five does not exist within the
-configuration under test. This could indicate or a typo in the target address
-or an unnecessary override.
+configuration under test. This could indicate a typo in the target address or
+an unnecessary override.
 
   run "test"... pass
 
@@ -1754,8 +1754,8 @@ Warning: Invalid override target
   45:     target = module.setup.test_resource.absent_six
 
 The override target module.setup.test_resource.absent_six does not exist
-within the configuration under test. This could indicate or a typo in the
-target address or an unnecessary override.
+within the configuration under test. This could indicate a typo in the target
+address or an unnecessary override.
 
 main.tftest.hcl... tearing down
 main.tftest.hcl... pass
@@ -1766,8 +1766,8 @@ Warning: Invalid override target
    4:     target = test_resource.absent_one
 
 The override target test_resource.absent_one does not exist within the
-configuration under test. This could indicate or a typo in the target address
-or an unnecessary override.
+configuration under test. This could indicate a typo in the target address or
+an unnecessary override.
 
 (and 3 more similar warnings elsewhere)
 

--- a/internal/command/testdata/test/invalid-overrides/main.tf
+++ b/internal/command/testdata/test/invalid-overrides/main.tf
@@ -1,0 +1,6 @@
+
+resource "test_resource" "resource" {}
+
+module "setup" {
+  source = "./setup"
+}

--- a/internal/command/testdata/test/invalid-overrides/main.tftest.hcl
+++ b/internal/command/testdata/test/invalid-overrides/main.tftest.hcl
@@ -1,0 +1,47 @@
+
+mock_provider "test" {
+  override_resource {
+    target = test_resource.absent_one
+  }
+}
+
+override_resource {
+  target = test_resource.absent_two
+}
+
+override_resource {
+  target = module.setup.test_resource.absent_three
+}
+
+override_module {
+  target = module.absent_four
+}
+
+override_resource {
+  // This one only exists in the main configuration, but not the setup
+  // configuration. We shouldn't see a warning for this.
+  target = module.setup.test_resource.child_resource
+}
+
+override_resource {
+  // This is the reverse, only exists if you load the setup module directly.
+  // We shouldn't see a warning for this even though it's not in the main
+  // configuration.
+  target = test_resource.child_resource
+}
+
+run "setup" {
+  module {
+    source = "./setup"
+  }
+
+  override_resource {
+    target = test_resource.absent_five
+  }
+}
+
+run "test" {
+  override_resource {
+    target = module.setup.test_resource.absent_six
+  }
+}

--- a/internal/command/testdata/test/invalid-overrides/setup/main.tf
+++ b/internal/command/testdata/test/invalid-overrides/setup/main.tf
@@ -1,0 +1,2 @@
+
+resource "test_resource" "child_resource" {}

--- a/internal/command/validate.go
+++ b/internal/command/validate.go
@@ -108,6 +108,11 @@ func (c *ValidateCommand) validate(dir, testDir string, noTests bool) tfdiags.Di
 	// We'll also do a quick validation of the Terraform test files. These live
 	// outside the Terraform graph so we have to do this separately.
 	for _, file := range cfg.Module.Tests {
+
+		// The file validation only returns warnings so we'll just add them
+		// without checking anything about them.
+		diags = diags.Append(file.Validate(cfg))
+
 		for _, run := range file.Runs {
 
 			if run.Module != nil {
@@ -130,9 +135,12 @@ func (c *ValidateCommand) validate(dir, testDir string, noTests bool) tfdiags.Di
 					}
 
 				}
+
+				diags = diags.Append(run.Validate(run.ConfigUnderTest))
+			} else {
+				diags = diags.Append(run.Validate(cfg))
 			}
 
-			diags = diags.Append(run.Validate())
 		}
 	}
 

--- a/internal/command/validate_test.go
+++ b/internal/command/validate_test.go
@@ -368,8 +368,8 @@ Warning: Invalid override target
    4:     target = test_resource.absent_one
 
 The override target test_resource.absent_one does not exist within the
-configuration under test. This could indicate or a typo in the target address
-or an unnecessary override.
+configuration under test. This could indicate a typo in the target address or
+an unnecessary override.
 
 (and 5 more similar warnings elsewhere)
 Success! The configuration is valid, but there were some validation warnings

--- a/internal/configs/mock_provider.go
+++ b/internal/configs/mock_provider.go
@@ -32,7 +32,8 @@ func decodeMockProviderBlock(block *hcl.Block) (*Provider, hcl.Diagnostics) {
 		NameRange: block.LabelRanges[0],
 		DeclRange: block.DefRange,
 
-		Config: config,
+		// Mock providers shouldn't need any additional data.
+		Config: hcl.EmptyBody(),
 
 		// Mark this provider as being mocked.
 		Mock: true,
@@ -83,12 +84,23 @@ type MockResource struct {
 	DefaultsRange hcl.Range
 }
 
+type OverrideSource int
+
+const (
+	RunBlockOverrideSource OverrideSource = iota
+	TestFileOverrideSource
+	MockProviderOverrideSource
+)
+
 // Override targets a specific module, resource or data source with a set of
 // replacement values that should be used in place of whatever the underlying
 // provider would normally do.
 type Override struct {
 	Target *addrs.Target
 	Values cty.Value
+
+	// Source tells us where this Override was defined.
+	Source OverrideSource
 
 	Range       hcl.Range
 	TypeRange   hcl.Range
@@ -141,7 +153,7 @@ func decodeMockDataBody(body hcl.Body) (*MockData, hcl.Diagnostics) {
 				}
 			}
 		case "override_resource":
-			override, overrideDiags := decodeOverrideResourceBlock(block)
+			override, overrideDiags := decodeOverrideResourceBlock(block, MockProviderOverrideSource)
 			diags = append(diags, overrideDiags...)
 
 			if override != nil && override.Target != nil {
@@ -158,7 +170,7 @@ func decodeMockDataBody(body hcl.Body) (*MockData, hcl.Diagnostics) {
 				data.Overrides.Put(subject, override)
 			}
 		case "override_data":
-			override, overrideDiags := decodeOverrideDataBlock(block)
+			override, overrideDiags := decodeOverrideDataBlock(block, MockProviderOverrideSource)
 			diags = append(diags, overrideDiags...)
 
 			if override != nil && override.Target != nil {
@@ -213,8 +225,8 @@ func decodeMockResourceBlock(block *hcl.Block) (*MockResource, hcl.Diagnostics) 
 	return resource, diags
 }
 
-func decodeOverrideModuleBlock(block *hcl.Block) (*Override, hcl.Diagnostics) {
-	override, diags := decodeOverrideBlock(block, "outputs", "override_module")
+func decodeOverrideModuleBlock(block *hcl.Block, source OverrideSource) (*Override, hcl.Diagnostics) {
+	override, diags := decodeOverrideBlock(block, "outputs", "override_module", source)
 
 	if override.Target != nil {
 		switch override.Target.Subject.AddrType() {
@@ -234,8 +246,8 @@ func decodeOverrideModuleBlock(block *hcl.Block) (*Override, hcl.Diagnostics) {
 	return override, diags
 }
 
-func decodeOverrideResourceBlock(block *hcl.Block) (*Override, hcl.Diagnostics) {
-	override, diags := decodeOverrideBlock(block, "values", "override_resource")
+func decodeOverrideResourceBlock(block *hcl.Block, source OverrideSource) (*Override, hcl.Diagnostics) {
+	override, diags := decodeOverrideBlock(block, "values", "override_resource", source)
 
 	if override.Target != nil {
 		var mode addrs.ResourceMode
@@ -271,8 +283,8 @@ func decodeOverrideResourceBlock(block *hcl.Block) (*Override, hcl.Diagnostics) 
 	return override, diags
 }
 
-func decodeOverrideDataBlock(block *hcl.Block) (*Override, hcl.Diagnostics) {
-	override, diags := decodeOverrideBlock(block, "values", "override_data")
+func decodeOverrideDataBlock(block *hcl.Block, source OverrideSource) (*Override, hcl.Diagnostics) {
+	override, diags := decodeOverrideBlock(block, "values", "override_data", source)
 
 	if override.Target != nil {
 		var mode addrs.ResourceMode
@@ -308,7 +320,7 @@ func decodeOverrideDataBlock(block *hcl.Block) (*Override, hcl.Diagnostics) {
 	return override, diags
 }
 
-func decodeOverrideBlock(block *hcl.Block, attributeName string, blockName string) (*Override, hcl.Diagnostics) {
+func decodeOverrideBlock(block *hcl.Block, attributeName string, blockName string, source OverrideSource) (*Override, hcl.Diagnostics) {
 	var diags hcl.Diagnostics
 
 	content, contentDiags := block.Body.Content(&hcl.BodySchema{
@@ -320,6 +332,7 @@ func decodeOverrideBlock(block *hcl.Block, attributeName string, blockName strin
 	diags = append(diags, contentDiags...)
 
 	override := &Override{
+		Source:    source,
 		Range:     block.DefRange,
 		TypeRange: block.TypeRange,
 	}

--- a/internal/configs/mock_provider.go
+++ b/internal/configs/mock_provider.go
@@ -87,9 +87,11 @@ type MockResource struct {
 type OverrideSource int
 
 const (
-	RunBlockOverrideSource OverrideSource = iota
+	UnknownOverrideSource OverrideSource = iota
+	RunBlockOverrideSource
 	TestFileOverrideSource
 	MockProviderOverrideSource
+	MockDataFileOverrideSource
 )
 
 // Override targets a specific module, resource or data source with a set of

--- a/internal/configs/test_file.go
+++ b/internal/configs/test_file.go
@@ -165,7 +165,7 @@ func (file *TestFile) Validate(config *Config) tfdiags.Diagnostics {
 				diags = diags.Append(&hcl.Diagnostic{
 					Severity: hcl.DiagWarning,
 					Summary:  "Invalid override target",
-					Detail:   fmt.Sprintf("The override target %s does not exist within the configuration under test. This could indicate or a typo in the target address or an unnecessary override.", elem.Key),
+					Detail:   fmt.Sprintf("The override target %s does not exist within the configuration under test. This could indicate a typo in the target address or an unnecessary override.", elem.Key),
 					Subject:  elem.Value.TargetRange.Ptr(),
 				})
 			}
@@ -177,7 +177,7 @@ func (file *TestFile) Validate(config *Config) tfdiags.Diagnostics {
 			diags = diags.Append(&hcl.Diagnostic{
 				Severity: hcl.DiagWarning,
 				Summary:  "Invalid override target",
-				Detail:   fmt.Sprintf("The override target %s does not exist within the configuration under test. This could indicate or a typo in the target address or an unnecessary override.", elem.Key),
+				Detail:   fmt.Sprintf("The override target %s does not exist within the configuration under test. This could indicate a typo in the target address or an unnecessary override.", elem.Key),
 				Subject:  elem.Value.TargetRange.Ptr(),
 			})
 		}
@@ -244,7 +244,7 @@ func (run *TestRun) Validate(config *Config) tfdiags.Diagnostics {
 			diags = diags.Append(&hcl.Diagnostic{
 				Severity: hcl.DiagWarning,
 				Summary:  "Invalid override target",
-				Detail:   fmt.Sprintf("The override target %s does not exist within the configuration under test. This could indicate or a typo in the target address or an unnecessary override.", elem.Key),
+				Detail:   fmt.Sprintf("The override target %s does not exist within the configuration under test. This could indicate a typo in the target address or an unnecessary override.", elem.Key),
 				Subject:  elem.Value.TargetRange.Ptr(),
 			})
 		}

--- a/internal/configs/test_file_test.go
+++ b/internal/configs/test_file_test.go
@@ -65,7 +65,7 @@ func TestTestRun_Validate(t *testing.T) {
 				run.ExpectFailures = append(run.ExpectFailures, parseTraversal(t, addr))
 			}
 
-			diags := run.Validate()
+			diags := run.Validate(nil)
 
 			if len(diags) > 1 {
 				t.Fatalf("too many diags: %d", len(diags))


### PR DESCRIPTION
I think it would be a source of frustration to a user who thinks they have set up an override but have a small typo in their target address, or something similar. This PR adds an explicit warning to the validate command, and during tests, if we discover any targets that point to addresses that can never exist. We validate this outside the graph, so we don't consider instance expansion but just look at the raw config.

We plan on adding source files for terraform mocks soon. I've pre-emptively added a source attribute to the override structures so we can differentiate between override blocks defined inside an actual file (which means we can reasonably say a user meant to target a resource available to this testing file) vs override blocks in the soon to be implemented data files. Override blocks in the data files might target different configurations, so we won't be adding warnings for targets in data files.

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.7.0

