### PR TITLE
terraform test: implement the source attribute for mock providers

### DIFF
--- a/internal/configs/config_build_test.go
+++ b/internal/configs/config_build_test.go
@@ -40,8 +40,11 @@ func TestBuildConfig(t *testing.T) {
 			version, _ := version.NewVersion(fmt.Sprintf("1.0.%d", versionI))
 			versionI++
 			return mod, version, diags
-		},
-	))
+		}),
+		MockDataLoaderFunc(func(provider *Provider) (*MockData, hcl.Diagnostics) {
+			return nil, nil
+		}),
+	)
 	assertNoDiagnostics(t, diags)
 	if cfg == nil {
 		t.Fatal("got nil config; want non-nil")
@@ -96,8 +99,11 @@ func TestBuildConfigDiags(t *testing.T) {
 			version, _ := version.NewVersion(fmt.Sprintf("1.0.%d", versionI))
 			versionI++
 			return mod, version, diags
-		},
-	))
+		}),
+		MockDataLoaderFunc(func(provider *Provider) (*MockData, hcl.Diagnostics) {
+			return nil, nil
+		}),
+	)
 
 	wantDiag := `testdata/nested-errors/child_c/child_c.tf:5,1-8: ` +
 		`Unsupported block type; Blocks of type "invalid" are not expected here.`
@@ -139,8 +145,11 @@ func TestBuildConfigChildModuleBackend(t *testing.T) {
 			mod, diags := parser.LoadConfigDir(sourcePath)
 			version, _ := version.NewVersion("1.0.0")
 			return mod, version, diags
-		},
-	))
+		}),
+		MockDataLoaderFunc(func(provider *Provider) (*MockData, hcl.Diagnostics) {
+			return nil, nil
+		}),
+	)
 
 	assertDiagnosticSummary(t, diags, "Backend configuration ignored")
 
@@ -214,8 +223,11 @@ func TestBuildConfigInvalidModules(t *testing.T) {
 					mod, diags := parser.LoadConfigDir(sourcePath)
 					version, _ := version.NewVersion("1.0.0")
 					return mod, version, diags
-				},
-			))
+				}),
+				MockDataLoaderFunc(func(provider *Provider) (*MockData, hcl.Diagnostics) {
+					return nil, nil
+				}),
+			)
 
 			// we can make this less repetitive later if we want
 			for _, msg := range expectedErrs {
@@ -310,8 +322,11 @@ func TestBuildConfig_WithNestedTestModules(t *testing.T) {
 			mod, diags := parser.LoadConfigDir(sourcePath)
 			version, _ := version.NewVersion("1.0.0")
 			return mod, version, diags
-		},
-	))
+		}),
+		MockDataLoaderFunc(func(provider *Provider) (*MockData, hcl.Diagnostics) {
+			return nil, nil
+		}),
+	)
 	assertNoDiagnostics(t, diags)
 	if cfg == nil {
 		t.Fatal("got nil config; want non-nil")
@@ -383,8 +398,11 @@ func TestBuildConfig_WithTestModule(t *testing.T) {
 			mod, diags := parser.LoadConfigDir(sourcePath)
 			version, _ := version.NewVersion("1.0.0")
 			return mod, version, diags
-		},
-	))
+		}),
+		MockDataLoaderFunc(func(provider *Provider) (*MockData, hcl.Diagnostics) {
+			return nil, nil
+		}),
+	)
 	assertNoDiagnostics(t, diags)
 	if cfg == nil {
 		t.Fatal("got nil config; want non-nil")

--- a/internal/configs/configload/loader_load.go
+++ b/internal/configs/configload/loader_load.go
@@ -43,10 +43,22 @@ func (l *Loader) loadConfig(rootMod *configs.Module, diags hcl.Diagnostics) (*co
 		return cfg, diags
 	}
 
-	cfg, cDiags := configs.BuildConfig(rootMod, configs.ModuleWalkerFunc(l.moduleWalkerLoad))
+	cfg, cDiags := configs.BuildConfig(rootMod, configs.ModuleWalkerFunc(l.moduleWalkerLoad), configs.MockDataLoaderFunc(l.LoadExternalMockData))
 	diags = append(diags, cDiags...)
 
 	return cfg, diags
+}
+
+// LoadExternalMockData reads the external mock data files for the given
+// provider, if they are present.
+func (l *Loader) LoadExternalMockData(provider *configs.Provider) (*configs.MockData, hcl.Diagnostics) {
+	if len(provider.MockDataExternalSource) == 0 {
+		// We have no external mock data, so don't do anything.
+		return nil, nil
+	}
+
+	// Otherwise, just hand this off to the parser to handle.
+	return l.parser.LoadMockDataDir(provider.MockDataExternalSource, provider.DeclRange)
 }
 
 // moduleWalkerLoad is a configs.ModuleWalkerFunc for loading modules that

--- a/internal/configs/configload/loader_snapshot.go
+++ b/internal/configs/configload/loader_snapshot.go
@@ -13,9 +13,10 @@ import (
 
 	version "github.com/hashicorp/go-version"
 	"github.com/hashicorp/hcl/v2"
+	"github.com/spf13/afero"
+
 	"github.com/hashicorp/terraform/internal/configs"
 	"github.com/hashicorp/terraform/internal/modsdir"
-	"github.com/spf13/afero"
 )
 
 // LoadConfigWithSnapshot is a variant of LoadConfig that also simultaneously
@@ -31,7 +32,7 @@ func (l *Loader) LoadConfigWithSnapshot(rootDir string) (*configs.Config, *Snaps
 		Modules: map[string]*SnapshotModule{},
 	}
 	walker := l.makeModuleWalkerSnapshot(snap)
-	cfg, cDiags := configs.BuildConfig(rootMod, walker)
+	cfg, cDiags := configs.BuildConfig(rootMod, walker, configs.MockDataLoaderFunc(l.LoadExternalMockData))
 	diags = append(diags, cDiags...)
 
 	addDiags := l.addModuleToSnapshot(snap, "", rootDir, "", nil)

--- a/internal/configs/mock_provider.go
+++ b/internal/configs/mock_provider.go
@@ -103,7 +103,7 @@ func (data *MockData) Merge(other *MockData, skipCollisions bool) (diags hcl.Dia
 	for name, datasource := range other.MockDataSources {
 		current, exists := data.MockDataSources[name]
 		if !exists {
-			data.MockResources[name] = datasource
+			data.MockDataSources[name] = datasource
 			continue
 		}
 

--- a/internal/configs/mock_provider_test.go
+++ b/internal/configs/mock_provider_test.go
@@ -1,0 +1,585 @@
+package configs
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/zclconf/go-cty/cty"
+
+	"github.com/hashicorp/terraform/internal/addrs"
+)
+
+func TestMockData_Merge(t *testing.T) {
+
+	tcs := map[string]struct {
+		current *MockData
+		target  *MockData
+		result  *MockData
+	}{
+		"empty_target": {
+			current: &MockData{
+				MockResources: map[string]*MockResource{
+					"test_resource": {
+						Mode:     addrs.ManagedResourceMode,
+						Type:     "test_resource",
+						Defaults: cty.StringVal("current"),
+					},
+				},
+				MockDataSources: map[string]*MockResource{
+					"test_data_source": {
+						Mode:     addrs.ManagedResourceMode,
+						Type:     "test_data_source",
+						Defaults: cty.StringVal("current"),
+					},
+				},
+				Overrides: addrs.MakeMap[addrs.Targetable, *Override](
+					makeOverride(t, "test_resource.my_resource", cty.StringVal("current")),
+				),
+			},
+			target: &MockData{
+				MockResources:   map[string]*MockResource{},
+				MockDataSources: map[string]*MockResource{},
+				Overrides:       addrs.MakeMap[addrs.Targetable, *Override](),
+			},
+			result: &MockData{
+				MockResources: map[string]*MockResource{
+					"test_resource": {
+						Mode:     addrs.ManagedResourceMode,
+						Type:     "test_resource",
+						Defaults: cty.StringVal("current"),
+					},
+				},
+				MockDataSources: map[string]*MockResource{
+					"test_data_source": {
+						Mode:     addrs.ManagedResourceMode,
+						Type:     "test_data_source",
+						Defaults: cty.StringVal("current"),
+					},
+				},
+				Overrides: addrs.MakeMap[addrs.Targetable, *Override](
+					makeOverride(t, "test_resource.my_resource", cty.StringVal("current")),
+				),
+			},
+		},
+		"nil_target": {
+			current: &MockData{
+				MockResources: map[string]*MockResource{
+					"test_resource": {
+						Mode:     addrs.ManagedResourceMode,
+						Type:     "test_resource",
+						Defaults: cty.StringVal("current"),
+					},
+				},
+				MockDataSources: map[string]*MockResource{
+					"test_data_source": {
+						Mode:     addrs.ManagedResourceMode,
+						Type:     "test_data_source",
+						Defaults: cty.StringVal("current"),
+					},
+				},
+				Overrides: addrs.MakeMap[addrs.Targetable, *Override](
+					makeOverride(t, "test_resource.my_resource", cty.StringVal("current")),
+				),
+			},
+			target: nil,
+			result: &MockData{
+				MockResources: map[string]*MockResource{
+					"test_resource": {
+						Mode:     addrs.ManagedResourceMode,
+						Type:     "test_resource",
+						Defaults: cty.StringVal("current"),
+					},
+				},
+				MockDataSources: map[string]*MockResource{
+					"test_data_source": {
+						Mode:     addrs.ManagedResourceMode,
+						Type:     "test_data_source",
+						Defaults: cty.StringVal("current"),
+					},
+				},
+				Overrides: addrs.MakeMap[addrs.Targetable, *Override](
+					makeOverride(t, "test_resource.my_resource", cty.StringVal("current")),
+				),
+			},
+		},
+		"all_collisions": {
+			current: &MockData{
+				MockResources: map[string]*MockResource{
+					"test_resource": {
+						Mode:     addrs.ManagedResourceMode,
+						Type:     "test_resource",
+						Defaults: cty.StringVal("current"),
+					},
+				},
+				MockDataSources: map[string]*MockResource{
+					"test_data_source": {
+						Mode:     addrs.ManagedResourceMode,
+						Type:     "test_data_source",
+						Defaults: cty.StringVal("current"),
+					},
+				},
+				Overrides: addrs.MakeMap[addrs.Targetable, *Override](
+					makeOverride(t, "test_resource.my_resource", cty.StringVal("current")),
+				),
+			},
+			target: &MockData{
+				MockResources: map[string]*MockResource{
+					"test_resource": {
+						Mode:     addrs.ManagedResourceMode,
+						Type:     "test_resource",
+						Defaults: cty.StringVal("target"),
+					},
+				},
+				MockDataSources: map[string]*MockResource{
+					"test_data_source": {
+						Mode:     addrs.ManagedResourceMode,
+						Type:     "test_data_source",
+						Defaults: cty.StringVal("target"),
+					},
+				},
+				Overrides: addrs.MakeMap[addrs.Targetable, *Override](
+					makeOverride(t, "test_resource.my_resource", cty.StringVal("target")),
+				),
+			},
+			result: &MockData{
+				MockResources: map[string]*MockResource{
+					"test_resource": {
+						Mode:     addrs.ManagedResourceMode,
+						Type:     "test_resource",
+						Defaults: cty.StringVal("current"),
+					},
+				},
+				MockDataSources: map[string]*MockResource{
+					"test_data_source": {
+						Mode:     addrs.ManagedResourceMode,
+						Type:     "test_data_source",
+						Defaults: cty.StringVal("current"),
+					},
+				},
+				Overrides: addrs.MakeMap[addrs.Targetable, *Override](
+					makeOverride(t, "test_resource.my_resource", cty.StringVal("current")),
+				),
+			},
+		},
+		"no_collisions": {
+			current: &MockData{
+				MockResources: map[string]*MockResource{
+					"test_resource": {
+						Mode:     addrs.ManagedResourceMode,
+						Type:     "test_resource",
+						Defaults: cty.StringVal("current"),
+					},
+				},
+				MockDataSources: map[string]*MockResource{
+					"test_data_source": {
+						Mode:     addrs.ManagedResourceMode,
+						Type:     "test_data_source",
+						Defaults: cty.StringVal("current"),
+					},
+				},
+				Overrides: addrs.MakeMap[addrs.Targetable, *Override](
+					makeOverride(t, "test_resource.my_resource", cty.StringVal("current")),
+				),
+			},
+			target: &MockData{
+				MockResources: map[string]*MockResource{
+					"test_resource_two": {
+						Mode:     addrs.ManagedResourceMode,
+						Type:     "test_resource_two",
+						Defaults: cty.StringVal("target"),
+					},
+				},
+				MockDataSources: map[string]*MockResource{
+					"test_data_source_two": {
+						Mode:     addrs.ManagedResourceMode,
+						Type:     "test_data_source_two",
+						Defaults: cty.StringVal("target"),
+					},
+				},
+				Overrides: addrs.MakeMap[addrs.Targetable, *Override](
+					makeOverride(t, "test_resource.my_other_resource", cty.StringVal("target")),
+				),
+			},
+			result: &MockData{
+				MockResources: map[string]*MockResource{
+					"test_resource": {
+						Mode:     addrs.ManagedResourceMode,
+						Type:     "test_resource",
+						Defaults: cty.StringVal("current"),
+					},
+					"test_resource_two": {
+						Mode:     addrs.ManagedResourceMode,
+						Type:     "test_resource_two",
+						Defaults: cty.StringVal("target"),
+					},
+				},
+				MockDataSources: map[string]*MockResource{
+					"test_data_source": {
+						Mode:     addrs.ManagedResourceMode,
+						Type:     "test_data_source",
+						Defaults: cty.StringVal("current"),
+					},
+					"test_data_source_two": {
+						Mode:     addrs.ManagedResourceMode,
+						Type:     "test_data_source_two",
+						Defaults: cty.StringVal("target"),
+					},
+				},
+				Overrides: addrs.MakeMap[addrs.Targetable, *Override](
+					makeOverride(t, "test_resource.my_resource", cty.StringVal("current")),
+					makeOverride(t, "test_resource.my_other_resource", cty.StringVal("target")),
+				),
+			},
+		},
+	}
+
+	for name, tc := range tcs {
+		t.Run(name, func(t *testing.T) {
+			diags := tc.current.Merge(tc.target, true)
+			validateMockData(t, tc.current, tc.result)
+
+			var details []string
+			for _, diag := range diags {
+				details = append(details, diag.Detail)
+			}
+			if len(details) > 0 {
+				t.Errorf("expected no diags but found [%s]", strings.Join(details, ", "))
+			}
+
+		})
+	}
+}
+
+func TestMockData_MergeWithCollisions(t *testing.T) {
+
+	tcs := map[string]struct {
+		current *MockData
+		target  *MockData
+		result  *MockData
+		diags   []string
+	}{
+		"empty_target": {
+			current: &MockData{
+				MockResources: map[string]*MockResource{
+					"test_resource": {
+						Mode:     addrs.ManagedResourceMode,
+						Type:     "test_resource",
+						Defaults: cty.StringVal("current"),
+					},
+				},
+				MockDataSources: map[string]*MockResource{
+					"test_data_source": {
+						Mode:     addrs.ManagedResourceMode,
+						Type:     "test_data_source",
+						Defaults: cty.StringVal("current"),
+					},
+				},
+				Overrides: addrs.MakeMap[addrs.Targetable, *Override](
+					makeOverride(t, "test_resource.my_resource", cty.StringVal("current")),
+				),
+			},
+			target: &MockData{
+				MockResources:   map[string]*MockResource{},
+				MockDataSources: map[string]*MockResource{},
+				Overrides:       addrs.MakeMap[addrs.Targetable, *Override](),
+			},
+			result: &MockData{
+				MockResources: map[string]*MockResource{
+					"test_resource": {
+						Mode:     addrs.ManagedResourceMode,
+						Type:     "test_resource",
+						Defaults: cty.StringVal("current"),
+					},
+				},
+				MockDataSources: map[string]*MockResource{
+					"test_data_source": {
+						Mode:     addrs.ManagedResourceMode,
+						Type:     "test_data_source",
+						Defaults: cty.StringVal("current"),
+					},
+				},
+				Overrides: addrs.MakeMap[addrs.Targetable, *Override](
+					makeOverride(t, "test_resource.my_resource", cty.StringVal("current")),
+				),
+			},
+		},
+		"nil_target": {
+			current: &MockData{
+				MockResources: map[string]*MockResource{
+					"test_resource": {
+						Mode:     addrs.ManagedResourceMode,
+						Type:     "test_resource",
+						Defaults: cty.StringVal("current"),
+					},
+				},
+				MockDataSources: map[string]*MockResource{
+					"test_data_source": {
+						Mode:     addrs.ManagedResourceMode,
+						Type:     "test_data_source",
+						Defaults: cty.StringVal("current"),
+					},
+				},
+				Overrides: addrs.MakeMap[addrs.Targetable, *Override](
+					makeOverride(t, "test_resource.my_resource", cty.StringVal("current")),
+				),
+			},
+			target: nil,
+			result: &MockData{
+				MockResources: map[string]*MockResource{
+					"test_resource": {
+						Mode:     addrs.ManagedResourceMode,
+						Type:     "test_resource",
+						Defaults: cty.StringVal("current"),
+					},
+				},
+				MockDataSources: map[string]*MockResource{
+					"test_data_source": {
+						Mode:     addrs.ManagedResourceMode,
+						Type:     "test_data_source",
+						Defaults: cty.StringVal("current"),
+					},
+				},
+				Overrides: addrs.MakeMap[addrs.Targetable, *Override](
+					makeOverride(t, "test_resource.my_resource", cty.StringVal("current")),
+				),
+			},
+		},
+		"all_collisions": {
+			current: &MockData{
+				MockResources: map[string]*MockResource{
+					"test_resource": {
+						Mode:     addrs.ManagedResourceMode,
+						Type:     "test_resource",
+						Defaults: cty.StringVal("current"),
+					},
+				},
+				MockDataSources: map[string]*MockResource{
+					"test_data_source": {
+						Mode:     addrs.ManagedResourceMode,
+						Type:     "test_data_source",
+						Defaults: cty.StringVal("current"),
+					},
+				},
+				Overrides: addrs.MakeMap[addrs.Targetable, *Override](
+					makeOverride(t, "test_resource.my_resource", cty.StringVal("current")),
+				),
+			},
+			target: &MockData{
+				MockResources: map[string]*MockResource{
+					"test_resource": {
+						Mode:     addrs.ManagedResourceMode,
+						Type:     "test_resource",
+						Defaults: cty.StringVal("target"),
+					},
+				},
+				MockDataSources: map[string]*MockResource{
+					"test_data_source": {
+						Mode:     addrs.ManagedResourceMode,
+						Type:     "test_data_source",
+						Defaults: cty.StringVal("target"),
+					},
+				},
+				Overrides: addrs.MakeMap[addrs.Targetable, *Override](
+					makeOverride(t, "test_resource.my_resource", cty.StringVal("target")),
+				),
+			},
+			result: &MockData{
+				MockResources: map[string]*MockResource{
+					"test_resource": {
+						Mode:     addrs.ManagedResourceMode,
+						Type:     "test_resource",
+						Defaults: cty.StringVal("current"),
+					},
+				},
+				MockDataSources: map[string]*MockResource{
+					"test_data_source": {
+						Mode:     addrs.ManagedResourceMode,
+						Type:     "test_data_source",
+						Defaults: cty.StringVal("current"),
+					},
+				},
+				Overrides: addrs.MakeMap[addrs.Targetable, *Override](
+					makeOverride(t, "test_resource.my_resource", cty.StringVal("current")),
+				),
+			},
+			diags: []string{
+				"A mock_resource \"test_resource\" block already exists at :0,0-0.",
+				"A mock_data \"test_data_source\" block already exists at :0,0-0.",
+				"An override block for test_resource.my_resource already exists at :0,0-0.",
+			},
+		},
+		"no_collisions": {
+			current: &MockData{
+				MockResources: map[string]*MockResource{
+					"test_resource": {
+						Mode:     addrs.ManagedResourceMode,
+						Type:     "test_resource",
+						Defaults: cty.StringVal("current"),
+					},
+				},
+				MockDataSources: map[string]*MockResource{
+					"test_data_source": {
+						Mode:     addrs.ManagedResourceMode,
+						Type:     "test_data_source",
+						Defaults: cty.StringVal("current"),
+					},
+				},
+				Overrides: addrs.MakeMap[addrs.Targetable, *Override](
+					makeOverride(t, "test_resource.my_resource", cty.StringVal("current")),
+				),
+			},
+			target: &MockData{
+				MockResources: map[string]*MockResource{
+					"test_resource_two": {
+						Mode:     addrs.ManagedResourceMode,
+						Type:     "test_resource_two",
+						Defaults: cty.StringVal("target"),
+					},
+				},
+				MockDataSources: map[string]*MockResource{
+					"test_data_source_two": {
+						Mode:     addrs.ManagedResourceMode,
+						Type:     "test_data_source_two",
+						Defaults: cty.StringVal("target"),
+					},
+				},
+				Overrides: addrs.MakeMap[addrs.Targetable, *Override](
+					makeOverride(t, "test_resource.my_other_resource", cty.StringVal("target")),
+				),
+			},
+			result: &MockData{
+				MockResources: map[string]*MockResource{
+					"test_resource": {
+						Mode:     addrs.ManagedResourceMode,
+						Type:     "test_resource",
+						Defaults: cty.StringVal("current"),
+					},
+					"test_resource_two": {
+						Mode:     addrs.ManagedResourceMode,
+						Type:     "test_resource_two",
+						Defaults: cty.StringVal("target"),
+					},
+				},
+				MockDataSources: map[string]*MockResource{
+					"test_data_source": {
+						Mode:     addrs.ManagedResourceMode,
+						Type:     "test_data_source",
+						Defaults: cty.StringVal("current"),
+					},
+					"test_data_source_two": {
+						Mode:     addrs.ManagedResourceMode,
+						Type:     "test_data_source_two",
+						Defaults: cty.StringVal("target"),
+					},
+				},
+				Overrides: addrs.MakeMap[addrs.Targetable, *Override](
+					makeOverride(t, "test_resource.my_resource", cty.StringVal("current")),
+					makeOverride(t, "test_resource.my_other_resource", cty.StringVal("target")),
+				),
+			},
+		},
+	}
+
+	for name, tc := range tcs {
+		t.Run(name, func(t *testing.T) {
+			diags := tc.current.Merge(tc.target, false)
+			validateMockData(t, tc.current, tc.result)
+
+			var details []string
+			for _, diag := range diags {
+				details = append(details, diag.Detail)
+			}
+			if diff := cmp.Diff(tc.diags, details); len(diff) > 0 {
+				t.Error(diff)
+			}
+
+		})
+	}
+}
+
+func validateMockData(t *testing.T, actual, expected *MockData) {
+
+	// Validate mock resources.
+
+	for key, actual := range actual.MockResources {
+		expected, exists := expected.MockResources[key]
+		if !exists {
+			t.Errorf("actual mock resources contained %s but expected mock resources did not", key)
+			continue
+		}
+
+		validateValues(t, key, actual.Defaults, expected.Defaults)
+	}
+
+	for key := range expected.MockResources {
+		_, exists := actual.MockResources[key]
+		if !exists {
+			t.Errorf("expected mock resources contained %s but actual mock resources did not", key)
+		}
+	}
+
+	// Validate mock data sources.
+
+	for key, actual := range actual.MockDataSources {
+		expected, exists := expected.MockDataSources[key]
+		if !exists {
+			t.Errorf("actual mock data sources contained %s but expected mock data sources did not", key)
+			continue
+		}
+
+		validateValues(t, key, actual.Defaults, expected.Defaults)
+	}
+
+	for key := range expected.MockDataSources {
+		_, exists := actual.MockDataSources[key]
+		if !exists {
+			t.Errorf("expected mock data sources contained %s but actual mock data sources did not", key)
+		}
+	}
+
+	// Validate the overrides.
+
+	for _, elem := range actual.Overrides.Elems {
+		key, actual := elem.Key, elem.Value
+
+		expected, exists := expected.Overrides.GetOk(key)
+		if !exists {
+			t.Errorf("actual overrides contained %s but expected overrides did not", key)
+			continue
+		}
+
+		validateValues(t, key.String(), actual.Values, expected.Values)
+	}
+
+	for _, elem := range expected.Overrides.Elems {
+		key := elem.Key
+
+		if actual.Overrides.Has(key) {
+			continue
+		}
+
+		t.Errorf("expected overrides contained %s but actual overrides did not", key)
+	}
+}
+
+func validateValues(t *testing.T, key string, actual, expected cty.Value) {
+	if !actual.RawEquals(expected) {
+		t.Errorf("for %s\n\tactual: %s\n\texpected: %s", key, actual, expected)
+	}
+}
+
+func makeOverride(t *testing.T, target string, values cty.Value) addrs.MapElem[addrs.Targetable, *Override] {
+	addr, diags := addrs.ParseTargetStr(target)
+	if diags.HasErrors() {
+		t.Fatalf("failed to parse target: %s", diags)
+	}
+
+	return addrs.MapElem[addrs.Targetable, *Override]{
+		Key: addr.Subject,
+		Value: &Override{
+			Target: addr,
+			Values: values,
+		},
+	}
+}

--- a/internal/configs/parser_config.go
+++ b/internal/configs/parser_config.go
@@ -48,6 +48,22 @@ func (p *Parser) LoadTestFile(path string) (*TestFile, hcl.Diagnostics) {
 	return test, diags
 }
 
+// LoadMockDataFile reads the file at the given path and parses it as a
+// Terraform mock data file.
+//
+// It references the same LoadHCLFile as LoadConfigFile, so inherits the same
+// syntax selection behaviours.
+func (p *Parser) LoadMockDataFile(path string) (*MockData, hcl.Diagnostics) {
+	body, diags := p.LoadHCLFile(path)
+	if body == nil {
+		return nil, diags
+	}
+
+	data, dataDiags := decodeMockDataBody(body)
+	diags = append(diags, dataDiags...)
+	return data, diags
+}
+
 func (p *Parser) loadConfigFile(path string, override bool) (*File, hcl.Diagnostics) {
 	body, diags := p.LoadHCLFile(path)
 	if body == nil {

--- a/internal/configs/parser_config_dir.go
+++ b/internal/configs/parser_config_dir.go
@@ -119,7 +119,7 @@ func (p *Parser) LoadMockDataDir(dir string, source hcl.Range) (*MockData, hcl.D
 			diags = append(diags, data.Merge(current, false)...)
 			continue
 		}
-		current = data
+		data = current
 	}
 	return data, diags
 }

--- a/internal/configs/parser_test.go
+++ b/internal/configs/parser_test.go
@@ -48,7 +48,7 @@ func testModuleConfigFromFile(filename string) (*Config, hcl.Diagnostics) {
 	f, diags := parser.LoadConfigFile(filename)
 	mod, modDiags := NewModule([]*File{f}, nil)
 	diags = append(diags, modDiags...)
-	cfg, moreDiags := BuildConfig(mod, nil)
+	cfg, moreDiags := BuildConfig(mod, nil, nil)
 	return cfg, append(diags, moreDiags...)
 }
 
@@ -64,7 +64,7 @@ func testModuleFromDir(path string) (*Module, hcl.Diagnostics) {
 func testModuleConfigFromDir(path string) (*Config, hcl.Diagnostics) {
 	parser := NewParser(nil)
 	mod, diags := parser.LoadConfigDir(path)
-	cfg, moreDiags := BuildConfig(mod, nil)
+	cfg, moreDiags := BuildConfig(mod, nil, nil)
 	return cfg, append(diags, moreDiags...)
 }
 
@@ -125,8 +125,11 @@ func buildNestedModuleConfig(mod *Module, path string, parser *Parser) (*Config,
 			version, _ := version.NewVersion(fmt.Sprintf("1.0.%d", versionI))
 			versionI++
 			return mod, version, diags
-		},
-	))
+		}),
+		MockDataLoaderFunc(func(provider *Provider) (*MockData, hcl.Diagnostics) {
+			return nil, nil
+		}),
+	)
 }
 
 func assertNoDiagnostics(t *testing.T, diags hcl.Diagnostics) bool {

--- a/internal/configs/provider.go
+++ b/internal/configs/provider.go
@@ -41,6 +41,11 @@ type Provider struct {
 	// provider.
 	Mock     bool
 	MockData *MockData
+
+	// MockDataExternalSource is a file path pointing to the external data
+	// file for a mock provider. An empty string indicates all data should be
+	// loaded inline.
+	MockDataExternalSource string
 }
 
 func decodeProviderBlock(block *hcl.Block) (*Provider, hcl.Diagnostics) {

--- a/internal/configs/testdata/valid-modules/with-mock-sources-inline/main.tf
+++ b/internal/configs/testdata/valid-modules/with-mock-sources-inline/main.tf
@@ -1,0 +1,2 @@
+
+resource "aws_s3_bucket" "my_bucket" {}

--- a/internal/configs/testdata/valid-modules/with-mock-sources-inline/main.tftest.hcl
+++ b/internal/configs/testdata/valid-modules/with-mock-sources-inline/main.tftest.hcl
@@ -1,0 +1,12 @@
+
+mock_provider "aws" {
+  source = "./testing/aws"
+
+  mock_resource "aws_s3_bucket" {
+    defaults = {
+      arn = "aws:s3:::bucket"
+    }
+  }
+}
+
+run "test" {}

--- a/internal/configs/testdata/valid-modules/with-mock-sources-inline/testing/aws/.ignored.tfmock.hcl
+++ b/internal/configs/testdata/valid-modules/with-mock-sources-inline/testing/aws/.ignored.tfmock.hcl
@@ -1,0 +1,9 @@
+# If read, this file should cause issues. But, it should be ignored.
+
+mock_resource "aws_s3_bucket" {}
+
+mock_data "aws_s3_bucket" {}
+
+override_resource {
+  target = aws_s3_bucket.my_bucket
+}

--- a/internal/configs/testdata/valid-modules/with-mock-sources-inline/testing/aws/data.tfmock.hcl
+++ b/internal/configs/testdata/valid-modules/with-mock-sources-inline/testing/aws/data.tfmock.hcl
@@ -1,0 +1,1 @@
+mock_data "aws_s3_bucket" {}

--- a/internal/configs/testdata/valid-modules/with-mock-sources-inline/testing/aws/resource.tfmock.hcl
+++ b/internal/configs/testdata/valid-modules/with-mock-sources-inline/testing/aws/resource.tfmock.hcl
@@ -1,0 +1,5 @@
+mock_resource "aws_s3_bucket" {}
+
+override_resource {
+  target = aws_s3_bucket.my_bucket
+}

--- a/internal/configs/testdata/valid-modules/with-mock-sources/main.tf
+++ b/internal/configs/testdata/valid-modules/with-mock-sources/main.tf
@@ -1,0 +1,2 @@
+
+resource "aws_s3_bucket" "my_bucket" {}

--- a/internal/configs/testdata/valid-modules/with-mock-sources/main.tftest.hcl
+++ b/internal/configs/testdata/valid-modules/with-mock-sources/main.tftest.hcl
@@ -1,0 +1,6 @@
+
+mock_provider "aws" {
+  source = "./testing/aws"
+}
+
+run "test" {}

--- a/internal/configs/testdata/valid-modules/with-mock-sources/testing/aws/.ignored.tfmock.hcl
+++ b/internal/configs/testdata/valid-modules/with-mock-sources/testing/aws/.ignored.tfmock.hcl
@@ -1,0 +1,9 @@
+# If read, this file should cause issues. But, it should be ignored.
+
+mock_resource "aws_s3_bucket" {}
+
+mock_data "aws_s3_bucket" {}
+
+override_resource {
+  target = aws_s3_bucket.my_bucket
+}

--- a/internal/configs/testdata/valid-modules/with-mock-sources/testing/aws/data.tfmock.hcl
+++ b/internal/configs/testdata/valid-modules/with-mock-sources/testing/aws/data.tfmock.hcl
@@ -1,0 +1,1 @@
+mock_data "aws_s3_bucket" {}

--- a/internal/configs/testdata/valid-modules/with-mock-sources/testing/aws/resource.tfmock.hcl
+++ b/internal/configs/testdata/valid-modules/with-mock-sources/testing/aws/resource.tfmock.hcl
@@ -1,0 +1,5 @@
+mock_resource "aws_s3_bucket" {}
+
+override_resource {
+  target = aws_s3_bucket.my_bucket
+}

--- a/internal/initwd/module_install.go
+++ b/internal/initwd/module_install.go
@@ -17,6 +17,7 @@ import (
 	version "github.com/hashicorp/go-version"
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
+
 	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/configs"
 	"github.com/hashicorp/terraform/internal/configs/configload"
@@ -310,7 +311,7 @@ func (i *ModuleInstaller) installDescendentModules(rootMod *configs.Module, mani
 		})
 	}
 
-	cfg, cDiags := configs.BuildConfig(rootMod, walker)
+	cfg, cDiags := configs.BuildConfig(rootMod, walker, configs.MockDataLoaderFunc(i.loader.LoadExternalMockData))
 	diags = diags.Append(cDiags)
 	if installErrsOnly {
 		// We can't continue if there was an error during installation, but


### PR DESCRIPTION
This PR implements the `source` attribute in `mock_provider` blocks.

This will allow users to share implementation of mocks between different test files. We load the data sources during the `BuildConfig` function, which is the same time we load the modules. This should make a future extension in which mock data sources could be loaded from an external source (like the registry or a repository) easier.

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.7.0
