### PR TITLE
testing framework: add support for functions in variables and providers

### DIFF
--- a/internal/command/test_test.go
+++ b/internal/command/test_test.go
@@ -189,6 +189,10 @@ func TestTest(t *testing.T) {
 			expected: "4 passed, 0 failed.",
 			code:     0,
 		},
+		"functions_available": {
+			expected: "1 passed, 0 failed.",
+			code:     0,
+		},
 	}
 	for name, tc := range tcs {
 		t.Run(name, func(t *testing.T) {

--- a/internal/command/testdata/test/functions_available/main.tf
+++ b/internal/command/testdata/test/functions_available/main.tf
@@ -1,0 +1,8 @@
+
+variable "input" {
+  type = string
+}
+
+resource "test_resource" "resource" {
+  value = var.input
+}

--- a/internal/command/testdata/test/functions_available/main.tftest.hcl
+++ b/internal/command/testdata/test/functions_available/main.tftest.hcl
@@ -1,0 +1,11 @@
+
+run "test" {
+  variables {
+    input = jsonencode({key:"value"})
+  }
+
+  assert {
+    condition = jsondecode(test_resource.resource.value).key == "value"
+    error_message = "wrong value"
+  }
+}

--- a/internal/lang/functions.go
+++ b/internal/lang/functions.go
@@ -27,136 +27,10 @@ var impureFunctions = []string{
 func (s *Scope) Functions() map[string]function.Function {
 	s.funcsLock.Lock()
 	if s.funcs == nil {
-		// Some of our functions are just directly the cty stdlib functions.
-		// Others are implemented in the subdirectory "funcs" here in this
-		// repository. New functions should generally start out their lives
-		// in the "funcs" directory and potentially graduate to cty stdlib
-		// later if the functionality seems to be something domain-agnostic
-		// that would be useful to all applications using cty functions.
+		s.funcs = baseFunctions(s.BaseDir)
 
-		s.funcs = map[string]function.Function{
-			"abs":              stdlib.AbsoluteFunc,
-			"abspath":          funcs.AbsPathFunc,
-			"alltrue":          funcs.AllTrueFunc,
-			"anytrue":          funcs.AnyTrueFunc,
-			"basename":         funcs.BasenameFunc,
-			"base64decode":     funcs.Base64DecodeFunc,
-			"base64encode":     funcs.Base64EncodeFunc,
-			"base64gzip":       funcs.Base64GzipFunc,
-			"base64sha256":     funcs.Base64Sha256Func,
-			"base64sha512":     funcs.Base64Sha512Func,
-			"bcrypt":           funcs.BcryptFunc,
-			"can":              tryfunc.CanFunc,
-			"ceil":             stdlib.CeilFunc,
-			"chomp":            stdlib.ChompFunc,
-			"cidrhost":         funcs.CidrHostFunc,
-			"cidrnetmask":      funcs.CidrNetmaskFunc,
-			"cidrsubnet":       funcs.CidrSubnetFunc,
-			"cidrsubnets":      funcs.CidrSubnetsFunc,
-			"coalesce":         funcs.CoalesceFunc,
-			"coalescelist":     stdlib.CoalesceListFunc,
-			"compact":          stdlib.CompactFunc,
-			"concat":           stdlib.ConcatFunc,
-			"contains":         stdlib.ContainsFunc,
-			"csvdecode":        stdlib.CSVDecodeFunc,
-			"dirname":          funcs.DirnameFunc,
-			"distinct":         stdlib.DistinctFunc,
-			"element":          stdlib.ElementFunc,
-			"endswith":         funcs.EndsWithFunc,
-			"chunklist":        stdlib.ChunklistFunc,
-			"file":             funcs.MakeFileFunc(s.BaseDir, false),
-			"fileexists":       funcs.MakeFileExistsFunc(s.BaseDir),
-			"fileset":          funcs.MakeFileSetFunc(s.BaseDir),
-			"filebase64":       funcs.MakeFileFunc(s.BaseDir, true),
-			"filebase64sha256": funcs.MakeFileBase64Sha256Func(s.BaseDir),
-			"filebase64sha512": funcs.MakeFileBase64Sha512Func(s.BaseDir),
-			"filemd5":          funcs.MakeFileMd5Func(s.BaseDir),
-			"filesha1":         funcs.MakeFileSha1Func(s.BaseDir),
-			"filesha256":       funcs.MakeFileSha256Func(s.BaseDir),
-			"filesha512":       funcs.MakeFileSha512Func(s.BaseDir),
-			"flatten":          stdlib.FlattenFunc,
-			"floor":            stdlib.FloorFunc,
-			"format":           stdlib.FormatFunc,
-			"formatdate":       stdlib.FormatDateFunc,
-			"formatlist":       stdlib.FormatListFunc,
-			"indent":           stdlib.IndentFunc,
-			"index":            funcs.IndexFunc, // stdlib.IndexFunc is not compatible
-			"join":             stdlib.JoinFunc,
-			"jsondecode":       stdlib.JSONDecodeFunc,
-			"jsonencode":       stdlib.JSONEncodeFunc,
-			"keys":             stdlib.KeysFunc,
-			"length":           funcs.LengthFunc,
-			"list":             funcs.ListFunc,
-			"log":              stdlib.LogFunc,
-			"lookup":           funcs.LookupFunc,
-			"lower":            stdlib.LowerFunc,
-			"map":              funcs.MapFunc,
-			"matchkeys":        funcs.MatchkeysFunc,
-			"max":              stdlib.MaxFunc,
-			"md5":              funcs.Md5Func,
-			"merge":            stdlib.MergeFunc,
-			"min":              stdlib.MinFunc,
-			"one":              funcs.OneFunc,
-			"parseint":         stdlib.ParseIntFunc,
-			"pathexpand":       funcs.PathExpandFunc,
-			"pow":              stdlib.PowFunc,
-			"range":            stdlib.RangeFunc,
-			"regex":            stdlib.RegexFunc,
-			"regexall":         stdlib.RegexAllFunc,
-			"replace":          funcs.ReplaceFunc,
-			"reverse":          stdlib.ReverseListFunc,
-			"rsadecrypt":       funcs.RsaDecryptFunc,
-			"sensitive":        funcs.SensitiveFunc,
-			"nonsensitive":     funcs.NonsensitiveFunc,
-			"setintersection":  stdlib.SetIntersectionFunc,
-			"setproduct":       stdlib.SetProductFunc,
-			"setsubtract":      stdlib.SetSubtractFunc,
-			"setunion":         stdlib.SetUnionFunc,
-			"sha1":             funcs.Sha1Func,
-			"sha256":           funcs.Sha256Func,
-			"sha512":           funcs.Sha512Func,
-			"signum":           stdlib.SignumFunc,
-			"slice":            stdlib.SliceFunc,
-			"sort":             stdlib.SortFunc,
-			"split":            stdlib.SplitFunc,
-			"startswith":       funcs.StartsWithFunc,
-			"strcontains":      funcs.StrContainsFunc,
-			"strrev":           stdlib.ReverseFunc,
-			"substr":           stdlib.SubstrFunc,
-			"sum":              funcs.SumFunc,
-			"textdecodebase64": funcs.TextDecodeBase64Func,
-			"textencodebase64": funcs.TextEncodeBase64Func,
-			"timestamp":        funcs.TimestampFunc,
-			"timeadd":          stdlib.TimeAddFunc,
-			"timecmp":          funcs.TimeCmpFunc,
-			"title":            stdlib.TitleFunc,
-			"tostring":         funcs.MakeToFunc(cty.String),
-			"tonumber":         funcs.MakeToFunc(cty.Number),
-			"tobool":           funcs.MakeToFunc(cty.Bool),
-			"toset":            funcs.MakeToFunc(cty.Set(cty.DynamicPseudoType)),
-			"tolist":           funcs.MakeToFunc(cty.List(cty.DynamicPseudoType)),
-			"tomap":            funcs.MakeToFunc(cty.Map(cty.DynamicPseudoType)),
-			"transpose":        funcs.TransposeFunc,
-			"trim":             stdlib.TrimFunc,
-			"trimprefix":       stdlib.TrimPrefixFunc,
-			"trimspace":        stdlib.TrimSpaceFunc,
-			"trimsuffix":       stdlib.TrimSuffixFunc,
-			"try":              tryfunc.TryFunc,
-			"upper":            stdlib.UpperFunc,
-			"urlencode":        funcs.URLEncodeFunc,
-			"uuid":             funcs.UUIDFunc,
-			"uuidv5":           funcs.UUIDV5Func,
-			"values":           stdlib.ValuesFunc,
-			"yamldecode":       ctyyaml.YAMLDecodeFunc,
-			"yamlencode":       ctyyaml.YAMLEncodeFunc,
-			"zipmap":           stdlib.ZipmapFunc,
-		}
-
-		s.funcs["templatefile"] = funcs.MakeTemplateFileFunc(s.BaseDir, func() map[string]function.Function {
-			// The templatefile function prevents recursive calls to itself
-			// by copying this map and overwriting the "templatefile" entry.
-			return s.funcs
-		})
+		// Then we add some functions that are only relevant when being accessed
+		// from inside a specific scope.
 
 		if s.ConsoleMode {
 			// The type function is only available in terraform console.
@@ -188,6 +62,161 @@ func (s *Scope) Functions() map[string]function.Function {
 	s.funcsLock.Unlock()
 
 	return s.funcs
+}
+
+// TestingFunctions returns the set of functions available to the testing
+// framework. Generally, the testing framework doesn't have access to a specific
+// state or plan when executing these functions so some of the functions
+// available normally are not available during tests.
+func TestingFunctions() map[string]function.Function {
+	// The baseDir is always the current directory during the tests.
+	fs := baseFunctions(".")
+
+	// Add a description to each function and parameter based on the
+	// contents of descriptionList.
+	// One must create a matching description entry whenever a new
+	// function is introduced.
+	for name, f := range fs {
+		fs[name] = funcs.WithDescription(name, f)
+	}
+
+	return fs
+}
+
+// baseFunctions loads the set of functions that are used in both the testing
+// framework and the main Terraform operations.
+func baseFunctions(baseDir string) map[string]function.Function {
+	// Some of our functions are just directly the cty stdlib functions.
+	// Others are implemented in the subdirectory "funcs" here in this
+	// repository. New functions should generally start out their lives
+	// in the "funcs" directory and potentially graduate to cty stdlib
+	// later if the functionality seems to be something domain-agnostic
+	// that would be useful to all applications using cty functions.
+	fs := map[string]function.Function{
+		"abs":              stdlib.AbsoluteFunc,
+		"abspath":          funcs.AbsPathFunc,
+		"alltrue":          funcs.AllTrueFunc,
+		"anytrue":          funcs.AnyTrueFunc,
+		"basename":         funcs.BasenameFunc,
+		"base64decode":     funcs.Base64DecodeFunc,
+		"base64encode":     funcs.Base64EncodeFunc,
+		"base64gzip":       funcs.Base64GzipFunc,
+		"base64sha256":     funcs.Base64Sha256Func,
+		"base64sha512":     funcs.Base64Sha512Func,
+		"bcrypt":           funcs.BcryptFunc,
+		"can":              tryfunc.CanFunc,
+		"ceil":             stdlib.CeilFunc,
+		"chomp":            stdlib.ChompFunc,
+		"cidrhost":         funcs.CidrHostFunc,
+		"cidrnetmask":      funcs.CidrNetmaskFunc,
+		"cidrsubnet":       funcs.CidrSubnetFunc,
+		"cidrsubnets":      funcs.CidrSubnetsFunc,
+		"coalesce":         funcs.CoalesceFunc,
+		"coalescelist":     stdlib.CoalesceListFunc,
+		"compact":          stdlib.CompactFunc,
+		"concat":           stdlib.ConcatFunc,
+		"contains":         stdlib.ContainsFunc,
+		"csvdecode":        stdlib.CSVDecodeFunc,
+		"dirname":          funcs.DirnameFunc,
+		"distinct":         stdlib.DistinctFunc,
+		"element":          stdlib.ElementFunc,
+		"endswith":         funcs.EndsWithFunc,
+		"chunklist":        stdlib.ChunklistFunc,
+		"file":             funcs.MakeFileFunc(baseDir, false),
+		"fileexists":       funcs.MakeFileExistsFunc(baseDir),
+		"fileset":          funcs.MakeFileSetFunc(baseDir),
+		"filebase64":       funcs.MakeFileFunc(baseDir, true),
+		"filebase64sha256": funcs.MakeFileBase64Sha256Func(baseDir),
+		"filebase64sha512": funcs.MakeFileBase64Sha512Func(baseDir),
+		"filemd5":          funcs.MakeFileMd5Func(baseDir),
+		"filesha1":         funcs.MakeFileSha1Func(baseDir),
+		"filesha256":       funcs.MakeFileSha256Func(baseDir),
+		"filesha512":       funcs.MakeFileSha512Func(baseDir),
+		"flatten":          stdlib.FlattenFunc,
+		"floor":            stdlib.FloorFunc,
+		"format":           stdlib.FormatFunc,
+		"formatdate":       stdlib.FormatDateFunc,
+		"formatlist":       stdlib.FormatListFunc,
+		"indent":           stdlib.IndentFunc,
+		"index":            funcs.IndexFunc, // stdlib.IndexFunc is not compatible
+		"join":             stdlib.JoinFunc,
+		"jsondecode":       stdlib.JSONDecodeFunc,
+		"jsonencode":       stdlib.JSONEncodeFunc,
+		"keys":             stdlib.KeysFunc,
+		"length":           funcs.LengthFunc,
+		"list":             funcs.ListFunc,
+		"log":              stdlib.LogFunc,
+		"lookup":           funcs.LookupFunc,
+		"lower":            stdlib.LowerFunc,
+		"map":              funcs.MapFunc,
+		"matchkeys":        funcs.MatchkeysFunc,
+		"max":              stdlib.MaxFunc,
+		"md5":              funcs.Md5Func,
+		"merge":            stdlib.MergeFunc,
+		"min":              stdlib.MinFunc,
+		"one":              funcs.OneFunc,
+		"parseint":         stdlib.ParseIntFunc,
+		"pathexpand":       funcs.PathExpandFunc,
+		"pow":              stdlib.PowFunc,
+		"range":            stdlib.RangeFunc,
+		"regex":            stdlib.RegexFunc,
+		"regexall":         stdlib.RegexAllFunc,
+		"replace":          funcs.ReplaceFunc,
+		"reverse":          stdlib.ReverseListFunc,
+		"rsadecrypt":       funcs.RsaDecryptFunc,
+		"sensitive":        funcs.SensitiveFunc,
+		"nonsensitive":     funcs.NonsensitiveFunc,
+		"setintersection":  stdlib.SetIntersectionFunc,
+		"setproduct":       stdlib.SetProductFunc,
+		"setsubtract":      stdlib.SetSubtractFunc,
+		"setunion":         stdlib.SetUnionFunc,
+		"sha1":             funcs.Sha1Func,
+		"sha256":           funcs.Sha256Func,
+		"sha512":           funcs.Sha512Func,
+		"signum":           stdlib.SignumFunc,
+		"slice":            stdlib.SliceFunc,
+		"sort":             stdlib.SortFunc,
+		"split":            stdlib.SplitFunc,
+		"startswith":       funcs.StartsWithFunc,
+		"strcontains":      funcs.StrContainsFunc,
+		"strrev":           stdlib.ReverseFunc,
+		"substr":           stdlib.SubstrFunc,
+		"sum":              funcs.SumFunc,
+		"textdecodebase64": funcs.TextDecodeBase64Func,
+		"textencodebase64": funcs.TextEncodeBase64Func,
+		"timestamp":        funcs.TimestampFunc,
+		"timeadd":          stdlib.TimeAddFunc,
+		"timecmp":          funcs.TimeCmpFunc,
+		"title":            stdlib.TitleFunc,
+		"tostring":         funcs.MakeToFunc(cty.String),
+		"tonumber":         funcs.MakeToFunc(cty.Number),
+		"tobool":           funcs.MakeToFunc(cty.Bool),
+		"toset":            funcs.MakeToFunc(cty.Set(cty.DynamicPseudoType)),
+		"tolist":           funcs.MakeToFunc(cty.List(cty.DynamicPseudoType)),
+		"tomap":            funcs.MakeToFunc(cty.Map(cty.DynamicPseudoType)),
+		"transpose":        funcs.TransposeFunc,
+		"trim":             stdlib.TrimFunc,
+		"trimprefix":       stdlib.TrimPrefixFunc,
+		"trimspace":        stdlib.TrimSpaceFunc,
+		"trimsuffix":       stdlib.TrimSuffixFunc,
+		"try":              tryfunc.TryFunc,
+		"upper":            stdlib.UpperFunc,
+		"urlencode":        funcs.URLEncodeFunc,
+		"uuid":             funcs.UUIDFunc,
+		"uuidv5":           funcs.UUIDV5Func,
+		"values":           stdlib.ValuesFunc,
+		"yamldecode":       ctyyaml.YAMLDecodeFunc,
+		"yamlencode":       ctyyaml.YAMLEncodeFunc,
+		"zipmap":           stdlib.ZipmapFunc,
+	}
+
+	fs["templatefile"] = funcs.MakeTemplateFileFunc(baseDir, func() map[string]function.Function {
+		// The templatefile function prevents recursive calls to itself
+		// by copying this map and overwriting the "templatefile" entry.
+		return fs
+	})
+
+	return fs
 }
 
 // experimentalFunction checks whether the given experiment is enabled for

--- a/internal/moduletest/hcl/context.go
+++ b/internal/moduletest/hcl/context.go
@@ -46,6 +46,11 @@ const (
 // expressions to be evaluated will pass evaluation. Anything present in the
 // expressions argument will be validated to make sure the only reference the
 // availableVariables and availableRunBlocks.
+//
+// We perform some pre-validation of the expected expressions that this context
+// will be used to evaluate. This is just so we can provide some better error
+// messages and diagnostics. The expressions argument could be empty without
+// affecting the returned context.
 func EvalContext(target EvalContextTarget, expressions []hcl.Expression, availableVariables map[string]cty.Value, availableRunBlocks map[string]*terraform.TestContext) (*hcl.EvalContext, tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
 
@@ -227,5 +232,6 @@ func EvalContext(target EvalContextTarget, expressions []hcl.Expression, availab
 			}
 			return variables
 		}(),
+		Functions: lang.TestingFunctions(),
 	}, diags
 }


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

This PR adds the base Terraform functions into the testing framework, so that users can access them when defining providers and variables within the testing framework.

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->


## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.7.0

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

### ENHANCEMENTS

<!--

Write a short description of the user-facing change. Examples:

- `terraform show -json`: Fixed crash with sensitive set values.
- When rendering a diff, Terraform now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 

-  `terraform test`: Terraform functions are now available within `variables` and `provider` blocks within test files.
