### PR TITLE
terraform test: connect mock behaviour to test framework

### DIFF
--- a/internal/backend/local/test.go
+++ b/internal/backend/local/test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/hashicorp/terraform/internal/moduletest"
 	configtest "github.com/hashicorp/terraform/internal/moduletest/config"
 	hcltest "github.com/hashicorp/terraform/internal/moduletest/hcl"
+	"github.com/hashicorp/terraform/internal/moduletest/mocking"
 	"github.com/hashicorp/terraform/internal/plans"
 	"github.com/hashicorp/terraform/internal/states"
 	"github.com/hashicorp/terraform/internal/terraform"
@@ -601,6 +602,7 @@ func (runner *TestFileRunner) destroy(config *configs.Config, state *states.Stat
 	planOpts := &terraform.PlanOpts{
 		Mode:         plans.DestroyMode,
 		SetVariables: setVariables,
+		Overrides:    mocking.PackageOverrides(run.Config, file.Config, config),
 	}
 
 	tfCtx, ctxDiags := terraform.NewContext(runner.Suite.Opts)
@@ -671,6 +673,7 @@ func (runner *TestFileRunner) plan(config *configs.Config, state *states.State, 
 		SkipRefresh:        !run.Config.Options.Refresh,
 		SetVariables:       variables,
 		ExternalReferences: references,
+		Overrides:          mocking.PackageOverrides(run.Config, file.Config, config),
 	}
 
 	tfCtx, ctxDiags := terraform.NewContext(runner.Suite.Opts)

--- a/internal/command/test_test.go
+++ b/internal/command/test_test.go
@@ -189,6 +189,10 @@ func TestTest(t *testing.T) {
 			expected: "4 passed, 0 failed.",
 			code:     0,
 		},
+		"mocking": {
+			expected: "5 passed, 0 failed.",
+			code:     0,
+		},
 	}
 	for name, tc := range tcs {
 		t.Run(name, func(t *testing.T) {

--- a/internal/command/testdata/test/mocking/child/main.tf
+++ b/internal/command/testdata/test/mocking/child/main.tf
@@ -1,0 +1,30 @@
+terraform {
+  required_providers {
+    test = {
+      source = "hashicorp/test"
+      configuration_aliases = [test.primary, test.secondary]
+    }
+  }
+}
+
+variable "instances" {
+  type = number
+}
+
+resource "test_resource" "primary" {
+  provider = test.primary
+  count = var.instances
+}
+
+resource "test_resource" "secondary" {
+  provider = test.secondary
+  count = var.instances
+}
+
+output "primary" {
+  value = test_resource.primary
+}
+
+output "secondary" {
+  value = test_resource.secondary
+}

--- a/internal/command/testdata/test/mocking/main.tf
+++ b/internal/command/testdata/test/mocking/main.tf
@@ -1,0 +1,46 @@
+terraform {
+  required_providers {
+    test = {
+      source = "hashicorp/test"
+    }
+  }
+}
+
+provider "test" {
+  alias = "primary"
+}
+
+provider "test" {
+  alias = "secondary"
+}
+
+variable "instances" {
+  type = number
+}
+
+variable "child_instances" {
+  type = number
+}
+
+resource "test_resource" "primary" {
+  provider = test.primary
+  count = var.instances
+}
+
+resource "test_resource" "secondary" {
+  provider = test.secondary
+  count = var.instances
+}
+
+module "child" {
+  count = var.instances
+
+  source = "./child"
+
+  providers = {
+    test.primary = test.primary
+    test.secondary = test.secondary
+  }
+
+  instances = var.child_instances
+}

--- a/internal/command/testdata/test/mocking/tests/module_mocked.tftest.hcl
+++ b/internal/command/testdata/test/mocking/tests/module_mocked.tftest.hcl
@@ -1,0 +1,44 @@
+override_module {
+  target = module.child[1]
+  outputs = {
+    primary = [
+      {
+        id = "bbbb"
+      }
+    ]
+    secondary = [
+      {
+        id = "cccc"
+      }
+    ]
+  }
+}
+
+variables {
+  instances = 3
+  child_instances = 1
+}
+
+run "test" {
+
+  assert {
+    condition = module.child[0].primary[0].id != "bbbb"
+    error_message = "wrongly applied mocks"
+  }
+
+  assert {
+    condition = module.child[1].primary[0].id == "bbbb"
+    error_message = "did not apply mocks"
+  }
+
+  assert {
+    condition = module.child[1].secondary[0].id == "cccc"
+    error_message = "did not apply mocks"
+  }
+
+  assert {
+    condition = module.child[2].secondary[0].id != "cccc"
+    error_message = "wrongly applied mocks"
+  }
+
+}

--- a/internal/command/testdata/test/mocking/tests/module_mocked_overridden.tftest.hcl
+++ b/internal/command/testdata/test/mocking/tests/module_mocked_overridden.tftest.hcl
@@ -1,0 +1,70 @@
+override_module {
+  target = module.child
+  outputs = {
+    primary = [
+      {
+        id = "bbbb"
+      }
+    ]
+    secondary = [
+      {
+        id = "cccc"
+      }
+    ]
+  }
+}
+
+variables {
+  instances = 3
+  child_instances = 1
+}
+
+run "test" {
+
+  override_module {
+    target = module.child[1]
+    outputs = {
+      primary = [
+        {
+          id = "aaaa"
+        }
+      ]
+      secondary = [
+        {
+          id = "dddd"
+        }
+      ]
+    }
+  }
+
+  assert {
+    condition = module.child[0].primary[0].id == "bbbb"
+    error_message = "wrongly applied mocks"
+  }
+
+  assert {
+    condition = module.child[0].secondary[0].id == "cccc"
+    error_message = "did not apply mocks"
+  }
+
+  assert {
+    condition = module.child[2].primary[0].id == "bbbb"
+    error_message = "wrongly applied mocks"
+  }
+
+  assert {
+    condition = module.child[2].secondary[0].id == "cccc"
+    error_message = "did not apply mocks"
+  }
+
+  assert {
+    condition = module.child[1].primary[0].id == "aaaa"
+    error_message = "did not apply mocks"
+  }
+
+  assert {
+    condition = module.child[1].secondary[0].id == "dddd"
+    error_message = "did not apply mocks"
+  }
+
+}

--- a/internal/command/testdata/test/mocking/tests/no_mocks.tftest.hcl
+++ b/internal/command/testdata/test/mocking/tests/no_mocks.tftest.hcl
@@ -1,0 +1,7 @@
+
+variables {
+  instances = 1
+  child_instances = 0
+}
+
+run "test" {}

--- a/internal/command/testdata/test/mocking/tests/primary_mocked.tftest.hcl
+++ b/internal/command/testdata/test/mocking/tests/primary_mocked.tftest.hcl
@@ -1,0 +1,39 @@
+mock_provider "test" {
+  alias = "primary"
+
+  mock_resource "test_resource" {
+    defaults = {
+      id = "aaaa"
+    }
+  }
+}
+
+variables {
+  instances = 1
+  child_instances = 1
+}
+
+
+run "test" {
+
+  assert {
+    condition = test_resource.primary[0].id == "aaaa"
+    error_message = "did not apply mocks"
+  }
+
+  assert {
+    condition = module.child[0].primary[0].id == "aaaa"
+    error_message = "did not apply mocks"
+  }
+
+  assert {
+    condition = test_resource.secondary[0].id != "aaaa"
+    error_message = "wrongly applied mocks"
+  }
+
+  assert {
+    condition = module.child[0].secondary[0].id != "aaaa"
+    error_message = "wrongly applied mocks"
+  }
+
+}

--- a/internal/command/testdata/test/mocking/tests/primary_mocked_overridden.tftest.hcl
+++ b/internal/command/testdata/test/mocking/tests/primary_mocked_overridden.tftest.hcl
@@ -1,0 +1,52 @@
+mock_provider "test" {
+  alias = "primary"
+
+  mock_resource "test_resource" {
+    defaults = {
+      id = "aaaa"
+    }
+  }
+
+  override_resource {
+    target = test_resource.primary
+    values = {
+      id = "bbbb"
+    }
+  }
+}
+
+variables {
+  instances = 3
+  child_instances = 1
+}
+
+run "test" {
+
+  override_resource {
+    target = test_resource.primary[1]
+    values = {
+      id = "cccc"
+    }
+  }
+
+  assert {
+    condition = test_resource.primary[0].id == "bbbb"
+    error_message = "did not apply mocks"
+  }
+
+  assert {
+    condition = test_resource.primary[1].id == "cccc"
+    error_message = "did not apply mocks"
+  }
+
+  assert {
+    condition = test_resource.primary[2].id == "bbbb"
+    error_message = "did not apply mocks"
+  }
+
+  assert {
+    condition = module.child[0].primary[0].id == "aaaa"
+    error_message = "did not apply mocks"
+  }
+
+}

--- a/internal/configs/mock_provider.go
+++ b/internal/configs/mock_provider.go
@@ -32,7 +32,9 @@ func decodeMockProviderBlock(block *hcl.Block) (*Provider, hcl.Diagnostics) {
 		NameRange: block.LabelRanges[0],
 		DeclRange: block.DefRange,
 
-		Config: config,
+		// For mock providers we don't support any internal configuration, so
+		// we always just pass in an empty body.
+		Config: hcl.EmptyBody(),
 
 		// Mark this provider as being mocked.
 		Mock: true,

--- a/internal/moduletest/config/config.go
+++ b/internal/moduletest/config/config.go
@@ -67,9 +67,7 @@ func TransformConfigForTest(config *configs.Config, run *moduletest.Run, file *m
 	if len(run.Config.Providers) > 0 {
 		// Then we'll only copy over and overwrite the specific providers asked
 		// for by this run block.
-
 		for _, ref := range run.Config.Providers {
-
 			testProvider, ok := file.Config.Providers[ref.InParent.String()]
 			if !ok {
 				// Then this reference was invalid as we didn't have the
@@ -96,9 +94,10 @@ func TransformConfigForTest(config *configs.Config, run *moduletest.Run, file *m
 					AvailableVariables: availableVariables,
 					AvailableRunBlocks: availableRunBlocks,
 				},
+				Mock:      testProvider.Mock,
+				MockData:  testProvider.MockData,
 				DeclRange: testProvider.DeclRange,
 			}
-
 		}
 	} else {
 		// Otherwise, let's copy over and overwrite all providers specified by
@@ -123,6 +122,8 @@ func TransformConfigForTest(config *configs.Config, run *moduletest.Run, file *m
 					AvailableVariables: availableVariables,
 					AvailableRunBlocks: availableRunBlocks,
 				},
+				Mock:      provider.Mock,
+				MockData:  provider.MockData,
 				DeclRange: provider.DeclRange,
 			}
 		}


### PR DESCRIPTION
Pass the overrides and mock providers from the test files into the Terraform graph during the `terraform test` command.

There's two bugs fixed as well that were exposed by the new integration tests added into the `command` package:
- Stopped removing overridden modules from the returned state as they never contain resources and data sources so would normally be removed.
- Updated the mock provider to clarify which functions it passes through to the underlying provider and which it doesn't. Fixed the `UpgradeResourceState` call which shouldn't be called without configuring the underlying provider first which we don't do for mocked providers.

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.7.0

