### PR TITLE
terraform test: add support for importing overridden resources

### DIFF
--- a/internal/moduletest/mocking/fill.go
+++ b/internal/moduletest/mocking/fill.go
@@ -1,0 +1,229 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package mocking
+
+import (
+	"fmt"
+
+	"github.com/zclconf/go-cty/cty"
+	"github.com/zclconf/go-cty/cty/convert"
+
+	"github.com/hashicorp/terraform/internal/configs/configschema"
+)
+
+// FillAttribute makes the input value match the specified attribute by adding
+// attributes and/or performing conversions to make the input value correct.
+//
+// It is similar to FillType, except it accepts attributes instead of types.
+func FillAttribute(in cty.Value, attribute *configschema.Attribute) (cty.Value, error) {
+	return fillAttribute(in, attribute, cty.Path{})
+}
+
+func fillAttribute(in cty.Value, attribute *configschema.Attribute, path cty.Path) (cty.Value, error) {
+	if attribute.NestedType != nil {
+
+		// Then the in value must be an object.
+		if !in.Type().IsObjectType() {
+			return cty.NilVal, path.NewErrorf("incompatible types; expected object type, found %s", in.Type().FriendlyName())
+		}
+
+		switch attribute.NestedType.Nesting {
+		case configschema.NestingSingle, configschema.NestingGroup:
+			children := make(map[string]cty.Value)
+			for name, attribute := range attribute.NestedType.Attributes {
+				if in.Type().HasAttribute(name) {
+					child, err := fillAttribute(in.GetAttr(name), attribute, path.GetAttr(name))
+					if err != nil {
+						return cty.NilVal, err
+					}
+					children[name] = child
+					continue
+				}
+
+				children[name] = GenerateValueForAttribute(attribute)
+			}
+			if len(children) == 0 {
+				return cty.EmptyObjectVal, nil
+			}
+			return cty.ObjectVal(children), nil
+		case configschema.NestingSet:
+			return cty.SetValEmpty(attribute.ImpliedType().ElementType()), nil
+		case configschema.NestingList:
+			return cty.ListValEmpty(attribute.ImpliedType().ElementType()), nil
+		case configschema.NestingMap:
+			return cty.MapValEmpty(attribute.ImpliedType().ElementType()), nil
+		default:
+			panic(fmt.Errorf("unknown nesting mode: %d", attribute.NestedType.Nesting))
+		}
+	}
+
+	return FillType(in, attribute.Type)
+}
+
+// FillType makes the input value match the target type by adding attributes
+// directly to it or to any nested objects. Essentially, this is a "safe"
+// conversion between two objects.
+//
+// This function can error if one of the embedded types within value doesn't
+// match the type expected by target.
+//
+// If the supplied value isn't an object (or a map that can be treated as an
+// object) then a normal conversion is attempted from value into target.
+//
+// Superfluous attributes within the supplied value (ie. attributes not
+// mentioned by the target type) are dropped without error.
+func FillType(in cty.Value, target cty.Type) (cty.Value, error) {
+	return fillType(in, target, cty.Path{})
+}
+
+func fillType(in cty.Value, target cty.Type, path cty.Path) (cty.Value, error) {
+	// If we're targeting an object directly, and we have an object then we just
+	// need
+	if in.Type().IsObjectType() && target.IsObjectType() {
+		attributes := make(map[string]cty.Value)
+		for name, attributeType := range target.AttributeTypes() {
+			if in.Type().HasAttribute(name) {
+				child, err := fillType(in.GetAttr(name), attributeType, path.IndexString(name))
+				if err != nil {
+					return cty.NilVal, err
+				}
+				attributes[name] = child
+				continue
+			}
+
+			attributes[name] = GenerateValueForType(attributeType)
+		}
+		if len(attributes) == 0 {
+			return cty.EmptyObjectVal, nil
+		}
+		return cty.ObjectVal(attributes), nil
+	}
+
+	if in.Type().IsMapType() && target.IsObjectType() {
+		attributes := make(map[string]cty.Value)
+		for name, attributeType := range target.AttributeTypes() {
+			index := cty.StringVal(name)
+			if in.HasIndex(index).True() {
+				child, err := fillType(in.Index(index), attributeType, path.Index(index))
+				if err != nil {
+					return cty.NilVal, err
+				}
+				attributes[name] = child
+				continue
+			}
+
+			attributes[name] = GenerateValueForType(attributeType)
+		}
+		if len(attributes) == 0 {
+			return cty.EmptyObjectVal, nil
+		}
+		return cty.ObjectVal(attributes), nil
+	}
+
+	if target.IsObjectType() {
+		// If the target is an object type, and the input wasn't an object or
+		// a map, then we have incompatible types.
+		return cty.NilVal, path.NewErrorf("incompatible types; expected %s, found %s", target.FriendlyName(), in.Type().FriendlyName())
+	}
+
+	if target.IsCollectionType() && target.ElementType().IsObjectType() {
+		switch {
+		case target.IsListType():
+			var values []cty.Value
+			switch {
+			case in.Type().IsSetType(), in.Type().IsListType(), in.Type().IsTupleType():
+				for iterator := in.ElementIterator(); iterator.Next(); {
+					index, value := iterator.Element()
+					child, err := fillType(value, target.ElementType(), path.Index(index))
+					if err != nil {
+						return cty.NilVal, err
+					}
+					values = append(values, child)
+				}
+			default:
+				return cty.NilVal, path.NewErrorf("incompatible types; expected %s, found %s", target.FriendlyName(), in.Type().FriendlyName())
+			}
+			if len(values) == 0 {
+				return cty.ListValEmpty(target.ElementType()), nil
+			}
+			return cty.ListVal(values), nil
+		case target.IsSetType():
+			var values []cty.Value
+			switch {
+			case in.Type().IsSetType(), in.Type().IsListType(), in.Type().IsTupleType():
+				for iterator := in.ElementIterator(); iterator.Next(); {
+					index, value := iterator.Element()
+					child, err := fillType(value, target.ElementType(), path.Index(index))
+					if err != nil {
+						return cty.NilVal, err
+					}
+					values = append(values, child)
+				}
+			default:
+				return cty.NilVal, path.NewErrorf("incompatible types; expected %s, found %s", target.FriendlyName(), in.Type().FriendlyName())
+			}
+			if len(values) == 0 {
+				return cty.SetValEmpty(target.ElementType()), nil
+			}
+			return cty.SetVal(values), nil
+		case target.IsMapType():
+			values := make(map[string]cty.Value)
+			switch {
+			case in.Type().IsMapType():
+				for name, value := range in.AsValueMap() {
+					child, err := fillType(value, target.ElementType(), path.IndexString(name))
+					if err != nil {
+						return cty.NilVal, err
+					}
+					values[name] = child
+				}
+			case in.Type().IsObjectType():
+				for name := range in.Type().AttributeTypes() {
+					value := in.GetAttr(name)
+					child, err := fillType(value, target.ElementType(), path.IndexString(name))
+					if err != nil {
+						return cty.NilVal, err
+					}
+					values[name] = child
+				}
+			default:
+				return cty.NilVal, path.NewErrorf("incompatible types; expected %s, found %s", target.FriendlyName(), in.Type().FriendlyName())
+			}
+			if len(values) == 0 {
+				return cty.MapValEmpty(target.ElementType()), nil
+			}
+			return cty.MapVal(values), nil
+		default:
+			panic(fmt.Errorf("unrecognized collection type: %s", target.FriendlyName()))
+		}
+	}
+
+	if target.IsTupleType() && in.Type().IsTupleType() {
+		if target.Length() != in.Type().Length() {
+			return cty.NilVal, path.NewErrorf("incompatible types; expected %s with length %d, found %s with length %d", target.FriendlyName(), target.Length(), in.Type().FriendlyName(), in.Type().Length())
+		}
+
+		var values []cty.Value
+		for ix, value := range in.AsValueSlice() {
+			child, err := fillType(value, target.TupleElementType(ix), path.IndexInt(ix))
+			if err != nil {
+				return cty.NilVal, err
+			}
+			values = append(values, child)
+		}
+		if len(values) == 0 {
+			return cty.EmptyTupleVal, nil
+		}
+		return cty.TupleVal(values), nil
+	}
+
+	// Otherwise, we don't have any nested object types we need to fill and this
+	// isn't an actual object either. So we can just do a simple conversion into
+	// the target type.
+	value, err := convert.Convert(in, target)
+	if err != nil {
+		return value, path.NewError(err)
+	}
+	return value, nil
+}

--- a/internal/moduletest/mocking/fill_test.go
+++ b/internal/moduletest/mocking/fill_test.go
@@ -1,0 +1,262 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package mocking
+
+import (
+	"math/rand"
+	"testing"
+
+	"github.com/zclconf/go-cty/cty"
+)
+
+func TestFillType(t *testing.T) {
+	tcs := map[string]struct {
+		in  cty.Value
+		out cty.Value
+	}{
+		"object_to_object": {
+			in: cty.ObjectVal(map[string]cty.Value{
+				"id": cty.StringVal("hello"),
+			}),
+			out: cty.ObjectVal(map[string]cty.Value{
+				"id":    cty.StringVal("hello"),
+				"value": cty.StringVal("ssnk9qhr"),
+			}),
+		},
+		"map_to_object": {
+			in: cty.MapVal(map[string]cty.Value{
+				"id": cty.StringVal("hello"),
+			}),
+			out: cty.ObjectVal(map[string]cty.Value{
+				"id":    cty.StringVal("hello"),
+				"value": cty.StringVal("ssnk9qhr"),
+			}),
+		},
+		"list_to_list": {
+			in: cty.ListVal([]cty.Value{
+				cty.ObjectVal(map[string]cty.Value{}),
+				cty.ObjectVal(map[string]cty.Value{}),
+			}),
+			out: cty.ListVal([]cty.Value{
+				cty.ObjectVal(map[string]cty.Value{
+					"id": cty.StringVal("ssnk9qhr"),
+				}),
+				cty.ObjectVal(map[string]cty.Value{
+					"id": cty.StringVal("amyllmyg"),
+				}),
+			}),
+		},
+		"tuple_to_list": {
+			in: cty.TupleVal([]cty.Value{
+				cty.ObjectVal(map[string]cty.Value{}),
+				cty.ObjectVal(map[string]cty.Value{}),
+			}),
+			out: cty.ListVal([]cty.Value{
+				cty.ObjectVal(map[string]cty.Value{
+					"id": cty.StringVal("ssnk9qhr"),
+				}),
+				cty.ObjectVal(map[string]cty.Value{
+					"id": cty.StringVal("amyllmyg"),
+				}),
+			}),
+		},
+		"set_to_list": {
+			in: cty.SetVal([]cty.Value{
+				cty.ObjectVal(map[string]cty.Value{
+					"value": cty.StringVal("ssnk9qhr"),
+				}),
+				cty.ObjectVal(map[string]cty.Value{
+					"value": cty.StringVal("amyllmyg"),
+				}),
+			}),
+			out: cty.ListVal([]cty.Value{
+				cty.ObjectVal(map[string]cty.Value{
+					"id":    cty.StringVal("ssnk9qhr"),
+					"value": cty.StringVal("amyllmyg"),
+				}),
+				cty.ObjectVal(map[string]cty.Value{
+					"id":    cty.StringVal("amyllmyg"),
+					"value": cty.StringVal("ssnk9qhr"),
+				}),
+			}),
+		},
+		"list_to_set": {
+			in: cty.ListVal([]cty.Value{
+				cty.ObjectVal(map[string]cty.Value{}),
+				cty.ObjectVal(map[string]cty.Value{}),
+			}),
+			out: cty.SetVal([]cty.Value{
+				cty.ObjectVal(map[string]cty.Value{
+					"id": cty.StringVal("ssnk9qhr"),
+				}),
+				cty.ObjectVal(map[string]cty.Value{
+					"id": cty.StringVal("amyllmyg"),
+				}),
+			}),
+		},
+		"tuple_to_set": {
+			in: cty.TupleVal([]cty.Value{
+				cty.ObjectVal(map[string]cty.Value{}),
+				cty.ObjectVal(map[string]cty.Value{}),
+			}),
+			out: cty.SetVal([]cty.Value{
+				cty.ObjectVal(map[string]cty.Value{
+					"id": cty.StringVal("ssnk9qhr"),
+				}),
+				cty.ObjectVal(map[string]cty.Value{
+					"id": cty.StringVal("amyllmyg"),
+				}),
+			}),
+		},
+		"set_to_set": {
+			in: cty.SetVal([]cty.Value{
+				cty.ObjectVal(map[string]cty.Value{
+					"value": cty.StringVal("ssnk9qhr"),
+				}),
+				cty.ObjectVal(map[string]cty.Value{
+					"value": cty.StringVal("amyllmyg"),
+				}),
+			}),
+			out: cty.SetVal([]cty.Value{
+				cty.ObjectVal(map[string]cty.Value{
+					"id":    cty.StringVal("ssnk9qhr"),
+					"value": cty.StringVal("amyllmyg"),
+				}),
+				cty.ObjectVal(map[string]cty.Value{
+					"id":    cty.StringVal("amyllmyg"),
+					"value": cty.StringVal("ssnk9qhr"),
+				}),
+			}),
+		},
+		"tuple_to_tuple": {
+			in: cty.TupleVal([]cty.Value{
+				cty.ObjectVal(map[string]cty.Value{}),
+				cty.ObjectVal(map[string]cty.Value{}),
+			}),
+			out: cty.TupleVal([]cty.Value{
+				cty.ObjectVal(map[string]cty.Value{
+					"id": cty.StringVal("ssnk9qhr"),
+				}),
+				cty.ObjectVal(map[string]cty.Value{
+					"id": cty.StringVal("amyllmyg"),
+				}),
+			}),
+		},
+		"map_to_map": {
+			in: cty.MapVal(map[string]cty.Value{
+				"one": cty.ObjectVal(map[string]cty.Value{}),
+				"two": cty.ObjectVal(map[string]cty.Value{}),
+			}),
+			out: cty.MapVal(map[string]cty.Value{
+				"one": cty.ObjectVal(map[string]cty.Value{
+					"id": cty.StringVal("ssnk9qhr"),
+				}),
+				"two": cty.ObjectVal(map[string]cty.Value{
+					"id": cty.StringVal("amyllmyg"),
+				}),
+			}),
+		},
+		"object_to_map": {
+			in: cty.ObjectVal(map[string]cty.Value{
+				"one": cty.ObjectVal(map[string]cty.Value{}),
+				"two": cty.ObjectVal(map[string]cty.Value{}),
+			}),
+			out: cty.MapVal(map[string]cty.Value{
+				"one": cty.ObjectVal(map[string]cty.Value{
+					"id": cty.StringVal("ssnk9qhr"),
+				}),
+				"two": cty.ObjectVal(map[string]cty.Value{
+					"id": cty.StringVal("amyllmyg"),
+				}),
+			}),
+		},
+		"additional_attributes": {
+			in: cty.ObjectVal(map[string]cty.Value{
+				"one": cty.StringVal("hello"),
+				"two": cty.StringVal("world"),
+			}),
+			out: cty.ObjectVal(map[string]cty.Value{
+				"one":   cty.StringVal("hello"),
+				"three": cty.StringVal("ssnk9qhr"),
+			}),
+		},
+		// This is just a sort of safety check to validate it falls through to
+		// normal conversions for everything we don't handle.
+		"normal_conversion": {
+			in: cty.MapVal(map[string]cty.Value{
+				"key_one": cty.StringVal("value_one"),
+				"key_two": cty.StringVal("value_two"),
+			}),
+			out: cty.ObjectVal(map[string]cty.Value{
+				"key_one": cty.StringVal("value_one"),
+				"key_two": cty.StringVal("value_two"),
+			}),
+		},
+	}
+
+	for name, tc := range tcs {
+		t.Run(name, func(t *testing.T) {
+
+			// Let's have predictable test outcomes.
+			testRand = rand.New(rand.NewSource(0))
+			defer func() {
+				testRand = nil
+			}()
+
+			actual, err := FillType(tc.in, tc.out.Type())
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			expected := tc.out
+			if !expected.RawEquals(actual) {
+				t.Errorf("expected:%s\nactual:   %s", expected.GoString(), actual.GoString())
+			}
+		})
+	}
+}
+
+func TestFillType_Errors(t *testing.T) {
+
+	tcs := map[string]struct {
+		in     cty.Value
+		target cty.Type
+		err    string
+	}{
+		"error_diff_tuple_types": {
+			in: cty.TupleVal([]cty.Value{
+				cty.ObjectVal(map[string]cty.Value{}),
+				cty.StringVal("not an object"),
+			}),
+			target: cty.List(cty.EmptyObject),
+			err:    "incompatible types; expected object, found string",
+		},
+		"error_diff_object_types": {
+			in: cty.ObjectVal(map[string]cty.Value{
+				"object": cty.ObjectVal(map[string]cty.Value{}),
+				"string": cty.StringVal("not an object"),
+			}),
+			target: cty.Map(cty.EmptyObject),
+			err:    "incompatible types; expected object, found string",
+		},
+	}
+
+	for name, tc := range tcs {
+		t.Run(name, func(t *testing.T) {
+			actual, err := FillType(tc.in, tc.target)
+			if err == nil {
+				t.Fatal("should have errored")
+			}
+
+			if out := err.Error(); out != tc.err {
+				t.Errorf("\nexpected: %s\nactual:   %s", tc.err, out)
+			}
+
+			if actual != cty.NilVal {
+				t.Fatal("should have errored")
+			}
+		})
+	}
+
+}

--- a/internal/moduletest/mocking/generate.go
+++ b/internal/moduletest/mocking/generate.go
@@ -1,0 +1,98 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package mocking
+
+import (
+	"fmt"
+	"math/rand"
+
+	"github.com/zclconf/go-cty/cty"
+
+	"github.com/hashicorp/terraform/internal/configs/configschema"
+)
+
+var (
+	// testRand and chars are used to generate random strings for the computed
+	// values.
+	//
+	// If testRand is null, then the global random is used. This allows us to
+	// seed tests for repeatable results.
+	testRand *rand.Rand
+	chars    = []rune("abcdefghijklmnopqrstuvwxyz0123456789")
+)
+
+// GenerateValueForAttribute accepts a configschema.Attribute and returns a
+// valid value for that attribute.
+func GenerateValueForAttribute(attribute *configschema.Attribute) cty.Value {
+	if attribute.NestedType != nil {
+		switch attribute.NestedType.Nesting {
+		case configschema.NestingSingle, configschema.NestingGroup:
+			children := make(map[string]cty.Value)
+			for name, attribute := range attribute.NestedType.Attributes {
+				children[name] = GenerateValueForAttribute(attribute)
+			}
+			if len(children) == 0 {
+				return cty.EmptyObjectVal
+			}
+			return cty.ObjectVal(children)
+		case configschema.NestingSet:
+			return cty.SetValEmpty(attribute.ImpliedType().ElementType())
+		case configschema.NestingList:
+			return cty.ListValEmpty(attribute.ImpliedType().ElementType())
+		case configschema.NestingMap:
+			return cty.MapValEmpty(attribute.ImpliedType().ElementType())
+		default:
+			panic(fmt.Errorf("unknown nesting mode: %d", attribute.NestedType.Nesting))
+		}
+	}
+
+	return GenerateValueForType(attribute.Type)
+}
+
+// GenerateValueForType accepts a cty.Type and returns a valid value for that
+// type.
+func GenerateValueForType(target cty.Type) cty.Value {
+	switch {
+	case target.IsPrimitiveType():
+		switch target {
+		case cty.String:
+			return cty.StringVal(str(8))
+		case cty.Number:
+			return cty.Zero
+		case cty.Bool:
+			return cty.False
+		default:
+			panic(fmt.Errorf("unknown primitive type: %s", target.FriendlyName()))
+		}
+	case target.IsListType():
+		return cty.ListValEmpty(target.ElementType())
+	case target.IsSetType():
+		return cty.SetValEmpty(target.ElementType())
+	case target.IsMapType():
+		return cty.MapValEmpty(target.ElementType())
+	case target.IsObjectType():
+		children := make(map[string]cty.Value)
+		for name, attribute := range target.AttributeTypes() {
+			children[name] = GenerateValueForType(attribute)
+		}
+		if len(children) == 0 {
+			return cty.EmptyObjectVal
+		}
+		return cty.ObjectVal(children)
+	default:
+		panic(fmt.Errorf("unknown complex type: %s", target.FriendlyName()))
+	}
+}
+
+func str(n int) string {
+	b := make([]rune, n)
+	for i := range b {
+		if testRand != nil {
+			b[i] = chars[testRand.Intn(len(chars))]
+		} else {
+			b[i] = chars[rand.Intn(len(chars))]
+		}
+	}
+	return string(b)
+}

--- a/internal/moduletest/mocking/values_test.go
+++ b/internal/moduletest/mocking/values_test.go
@@ -413,6 +413,62 @@ func TestComputedValuesForDataSource(t *testing.T) {
 				}),
 			}),
 		},
+		"nested_single_attribute_generated": {
+			target: cty.ObjectVal(map[string]cty.Value{
+				"nested": cty.NullVal(cty.Object(map[string]cty.Type{
+					"id":    cty.String,
+					"value": cty.String,
+				})),
+			}),
+			with: cty.NilVal,
+			schema: &configschema.Block{
+				Attributes: map[string]*configschema.Attribute{
+					"nested": {
+						NestedType: &configschema.Object{
+							Attributes: computedAttributes,
+							Nesting:    configschema.NestingSingle,
+						},
+						Computed: true,
+					},
+				},
+			},
+			expected: cty.ObjectVal(map[string]cty.Value{
+				"nested": cty.ObjectVal(map[string]cty.Value{
+					"id":    cty.StringVal("ssnk9qhr"),
+					"value": cty.StringVal("amyllmyg"),
+				}),
+			}),
+		},
+		"nested_single_attribute_computed": {
+			target: cty.ObjectVal(map[string]cty.Value{
+				"nested": cty.NullVal(cty.Object(map[string]cty.Type{
+					"id":    cty.String,
+					"value": cty.String,
+				})),
+			}),
+			with: cty.ObjectVal(map[string]cty.Value{
+				"nested": cty.ObjectVal(map[string]cty.Value{
+					"id": cty.StringVal("hello"),
+				}),
+			}),
+			schema: &configschema.Block{
+				Attributes: map[string]*configschema.Attribute{
+					"nested": {
+						NestedType: &configschema.Object{
+							Attributes: computedAttributes,
+							Nesting:    configschema.NestingSingle,
+						},
+						Computed: true,
+					},
+				},
+			},
+			expected: cty.ObjectVal(map[string]cty.Value{
+				"nested": cty.ObjectVal(map[string]cty.Value{
+					"id":    cty.StringVal("hello"),
+					"value": cty.StringVal("ssnk9qhr"),
+				}),
+			}),
+		},
 		"nested_list_attribute": {
 			target: cty.ObjectVal(map[string]cty.Value{
 				"nested": cty.ListVal([]cty.Value{
@@ -452,6 +508,62 @@ func TestComputedValuesForDataSource(t *testing.T) {
 						"value": cty.StringVal("two"),
 					}),
 				}),
+			}),
+		},
+		"nested_list_attribute_generated": {
+			target: cty.ObjectVal(map[string]cty.Value{
+				"nested": cty.NullVal(cty.List(cty.Object(map[string]cty.Type{
+					"id":    cty.String,
+					"value": cty.String,
+				}))),
+			}),
+			with: cty.NilVal,
+			schema: &configschema.Block{
+				Attributes: map[string]*configschema.Attribute{
+					"nested": {
+						NestedType: &configschema.Object{
+							Attributes: computedAttributes,
+							Nesting:    configschema.NestingList,
+						},
+						Computed: true,
+					},
+				},
+			},
+			expected: cty.ObjectVal(map[string]cty.Value{
+				"nested": cty.ListValEmpty(cty.Object(map[string]cty.Type{
+					"id":    cty.String,
+					"value": cty.String,
+				})),
+			}),
+		},
+		"nested_list_attribute_computed": {
+			target: cty.ObjectVal(map[string]cty.Value{
+				"nested": cty.NullVal(cty.List(cty.Object(map[string]cty.Type{
+					"id":    cty.String,
+					"value": cty.String,
+				}))),
+			}),
+			with: cty.ObjectVal(map[string]cty.Value{
+				"nested": cty.ObjectVal(map[string]cty.Value{
+					"id": cty.StringVal("myvalue"),
+				}),
+			}),
+			schema: &configschema.Block{
+				Attributes: map[string]*configschema.Attribute{
+					"nested": {
+						NestedType: &configschema.Object{
+							Attributes: computedAttributes,
+							Nesting:    configschema.NestingList,
+						},
+						Computed: true,
+					},
+				},
+			},
+			expected: cty.ObjectVal(map[string]cty.Value{
+				"nested": cty.ListValEmpty(cty.Object(map[string]cty.Type{
+					"id":    cty.String,
+					"value": cty.String,
+				})),
 			}),
 		},
 		"nested_set_attribute": {
@@ -495,6 +607,62 @@ func TestComputedValuesForDataSource(t *testing.T) {
 				}),
 			}),
 		},
+		"nested_set_attribute_generated": {
+			target: cty.ObjectVal(map[string]cty.Value{
+				"nested": cty.NullVal(cty.Set(cty.Object(map[string]cty.Type{
+					"id":    cty.String,
+					"value": cty.String,
+				}))),
+			}),
+			with: cty.NilVal,
+			schema: &configschema.Block{
+				Attributes: map[string]*configschema.Attribute{
+					"nested": {
+						NestedType: &configschema.Object{
+							Attributes: computedAttributes,
+							Nesting:    configschema.NestingSet,
+						},
+						Computed: true,
+					},
+				},
+			},
+			expected: cty.ObjectVal(map[string]cty.Value{
+				"nested": cty.SetValEmpty(cty.Object(map[string]cty.Type{
+					"id":    cty.String,
+					"value": cty.String,
+				})),
+			}),
+		},
+		"nested_set_attribute_computed": {
+			target: cty.ObjectVal(map[string]cty.Value{
+				"nested": cty.NullVal(cty.Set(cty.Object(map[string]cty.Type{
+					"id":    cty.String,
+					"value": cty.String,
+				}))),
+			}),
+			with: cty.ObjectVal(map[string]cty.Value{
+				"nested": cty.ObjectVal(map[string]cty.Value{
+					"id": cty.StringVal("myvalue"),
+				}),
+			}),
+			schema: &configschema.Block{
+				Attributes: map[string]*configschema.Attribute{
+					"nested": {
+						NestedType: &configschema.Object{
+							Attributes: computedAttributes,
+							Nesting:    configschema.NestingSet,
+						},
+						Computed: true,
+					},
+				},
+			},
+			expected: cty.ObjectVal(map[string]cty.Value{
+				"nested": cty.SetValEmpty(cty.Object(map[string]cty.Type{
+					"id":    cty.String,
+					"value": cty.String,
+				})),
+			}),
+		},
 		"nested_map_attribute": {
 			target: cty.ObjectVal(map[string]cty.Value{
 				"nested": cty.MapVal(map[string]cty.Value{
@@ -534,6 +702,62 @@ func TestComputedValuesForDataSource(t *testing.T) {
 						"value": cty.StringVal("two"),
 					}),
 				}),
+			}),
+		},
+		"nested_map_attribute_generated": {
+			target: cty.ObjectVal(map[string]cty.Value{
+				"nested": cty.NullVal(cty.Map(cty.Object(map[string]cty.Type{
+					"id":    cty.String,
+					"value": cty.String,
+				}))),
+			}),
+			with: cty.NilVal,
+			schema: &configschema.Block{
+				Attributes: map[string]*configschema.Attribute{
+					"nested": {
+						NestedType: &configschema.Object{
+							Attributes: computedAttributes,
+							Nesting:    configschema.NestingMap,
+						},
+						Computed: true,
+					},
+				},
+			},
+			expected: cty.ObjectVal(map[string]cty.Value{
+				"nested": cty.MapValEmpty(cty.Object(map[string]cty.Type{
+					"id":    cty.String,
+					"value": cty.String,
+				})),
+			}),
+		},
+		"nested_map_attribute_computed": {
+			target: cty.ObjectVal(map[string]cty.Value{
+				"nested": cty.NullVal(cty.Map(cty.Object(map[string]cty.Type{
+					"id":    cty.String,
+					"value": cty.String,
+				}))),
+			}),
+			with: cty.ObjectVal(map[string]cty.Value{
+				"nested": cty.ObjectVal(map[string]cty.Value{
+					"id": cty.StringVal("myvalue"),
+				}),
+			}),
+			schema: &configschema.Block{
+				Attributes: map[string]*configschema.Attribute{
+					"nested": {
+						NestedType: &configschema.Object{
+							Attributes: computedAttributes,
+							Nesting:    configschema.NestingMap,
+						},
+						Computed: true,
+					},
+				},
+			},
+			expected: cty.ObjectVal(map[string]cty.Value{
+				"nested": cty.MapValEmpty(cty.Object(map[string]cty.Type{
+					"id":    cty.String,
+					"value": cty.String,
+				})),
 			}),
 		},
 		"invalid_replacement_path": {
@@ -585,7 +809,7 @@ func TestComputedValuesForDataSource(t *testing.T) {
 				}),
 			}),
 			expectedFailures: []string{
-				"Terraform expected an object type at nested_object within the replacement value defined at :0,0-0, but found string.",
+				"Terraform expected an object type for attribute \"nested_object\" defined within the mocked data at :0,0-0, but found string.",
 			},
 		},
 		"invalid_replacement_path_nested_block": {
@@ -622,7 +846,7 @@ func TestComputedValuesForDataSource(t *testing.T) {
 				}),
 			}),
 			expectedFailures: []string{
-				"Terraform expected an object type at nested_object within the replacement value defined at :0,0-0, but found string.",
+				"Terraform expected an object type for attribute \"nested_object\" defined within the mocked data at :0,0-0, but found string.",
 			},
 		},
 		"invalid_replacement_type": {
@@ -639,7 +863,7 @@ func TestComputedValuesForDataSource(t *testing.T) {
 				"value": cty.StringVal("Hello, world!"),
 			}),
 			expectedFailures: []string{
-				"Terraform could not replace the target type string with the replacement value defined at id within :0,0-0: string required.",
+				"Terraform could not compute a value for the target type string with the mocked data defined at :0,0-0 with the attribute \"id\": string required.",
 			},
 		},
 		"invalid_replacement_type_nested": {
@@ -675,7 +899,7 @@ func TestComputedValuesForDataSource(t *testing.T) {
 				}),
 			}),
 			expectedFailures: []string{
-				"Terraform could not replace the target type string with the replacement value defined at nested.id within :0,0-0: string required.",
+				"Terraform could not compute a value for the target type string with the mocked data defined at :0,0-0 with the attribute \"nested.id\": string required.",
 			},
 		},
 		"invalid_replacement_type_nested_block": {
@@ -709,7 +933,7 @@ func TestComputedValuesForDataSource(t *testing.T) {
 				}),
 			}),
 			expectedFailures: []string{
-				"Terraform could not replace the target type string with the replacement value defined at block.id within :0,0-0: string required.",
+				"Terraform could not compute a value for the target type string with the mocked data defined at :0,0-0 with the attribute \"block.id\": string required.",
 			},
 		},
 	}
@@ -723,7 +947,7 @@ func TestComputedValuesForDataSource(t *testing.T) {
 				testRand = nil
 			}()
 
-			actual, diags := ComputedValuesForDataSource(tc.target, ReplacementValue{
+			actual, diags := ComputedValuesForDataSource(tc.target, MockedData{
 				Value: tc.with,
 			}, tc.schema)
 

--- a/internal/terraform/node_resource_abstract_instance.go
+++ b/internal/terraform/node_resource_abstract_instance.go
@@ -1513,7 +1513,7 @@ func (n *NodeAbstractResourceInstance) readDataSource(ctx EvalContext, configVal
 
 	var resp providers.ReadDataSourceResponse
 	if n.override != nil {
-		override, overrideDiags := mocking.ComputedValuesForDataSource(configVal, mocking.ReplacementValue{
+		override, overrideDiags := mocking.ComputedValuesForDataSource(configVal, mocking.MockedData{
 			Value: n.override.Values,
 			Range: n.override.ValuesRange,
 		}, schema)
@@ -2375,7 +2375,7 @@ func (n *NodeAbstractResourceInstance) apply(
 		// values the first time the object is created. Otherwise, we're happy
 		// to just apply whatever the user asked for.
 		if change.Action == plans.Create {
-			override, overrideDiags := mocking.ApplyComputedValuesForResource(unmarkedAfter, mocking.ReplacementValue{
+			override, overrideDiags := mocking.ApplyComputedValuesForResource(unmarkedAfter, mocking.MockedData{
 				Value: n.override.Values,
 				Range: n.override.ValuesRange,
 			}, schema)


### PR DESCRIPTION
This PR adds support for importing overridden resources during `terraform test` execution.

We parse the config early when importing into an overridden resource, and use the config to generate a complete value in the same we would if we were creating the resource from scratch. Then we pass that imported resource forward as normal.

The main use case for this is to allow users to test configs like those described in #34150.

In addition, this PR tweaks the behaviour of the mocking framework when generating mock data so that it more uniformly behaves as expected. Previously, it wasn't always following the guidelines around repeated blocks and nested attributes. The introduction of the `Fill` functions that behave in the same way as the `Generate` functions helps to address this, and makes sure the two paths (either generating data from nothing, or fixing up mocked data from the user) both apply the same uniform set of rules.

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.7.0


