### PR TITLE
Update machine-readable-ui.mdx - missing "action" value "import"

### DIFF
--- a/website/docs/internals/machine-readable-ui.mdx
+++ b/website/docs/internals/machine-readable-ui.mdx
@@ -146,7 +146,7 @@ At the end of a plan or before an apply, Terraform will emit a `planned_change` 
 
 - `resource`: object describing the address of the resource to be changed; see [resource object](#resource-object) below for details
 - `previous_resource`: object describing the previous address of the resource, if this change includes a configuration-driven move
-- `action`: the action planned to be taken for the resource. Values: `noop`, `create`, `read`, `update`, `replace`, `delete`, `move`.
+- `action`: the action planned to be taken for the resource. Values: `noop`, `create`, `read`, `update`, `replace`, `delete`, `move`, `import`.
 - `reason`: an optional reason for the change, only used when the action is `replace` or `delete`. Values:
   - `tainted`: resource was marked as tainted
   - `requested`: user requested that the resource be replaced, for example via the `-replace` plan flag


### PR DESCRIPTION
Added "import" under values of "action" for "planned_change". This is my first PR, let me know if I missed anything!

There are other lists of actions under in the same page; I _assume_ that they need to be updated too, but I'm not familiar enough with them.

<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Fixes #

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.5.x

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

### UPGRADE NOTES

<!--

Write a short description of the user-facing change. Examples:

- `terraform show -json`: Fixed crash with sensitive set values.
- When rendering a diff, Terraform now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 

- Adds missing possible values of `action` for the documentation of the machine readable UI.
