### PR TITLE
import: don't panic if expanded import returns no instances with config generation

### DIFF
--- a/internal/terraform/eval_for_each.go
+++ b/internal/terraform/eval_for_each.go
@@ -23,7 +23,7 @@ func evaluateForEachExpression(expr hcl.Expression, ctx EvalContext) (forEach ma
 	return newForEachEvaluator(expr, ctx).ResourceValue()
 }
 
-// rorEachEvaluator is the standard mechanism for interpreting an expression
+// forEachEvaluator is the standard mechanism for interpreting an expression
 // given for a "for_each" argument on a resource, module, or import.
 func newForEachEvaluator(expr hcl.Expression, ctx EvalContext) *forEachEvaluator {
 	if ctx == nil {

--- a/internal/terraform/node_resource_plan.go
+++ b/internal/terraform/node_resource_plan.go
@@ -423,6 +423,15 @@ func (n *nodeExpandPlannableResource) resourceInstanceSubgraph(ctx EvalContext, 
 	imports, importDiags := n.expandResourceImports(ctx, addr, instanceAddrs)
 	diags = diags.Append(importDiags)
 
+	if n.Config == nil && n.generateConfigPath != "" && imports.Len() == 0 {
+		// We're generating configuration, but there's nothing to import, which
+		// means the import block must have expanded to zero instances.
+		// the instance expander will always return a single instance because
+		// we have assumed there will eventually be a configuration for this
+		// resource, so return here before we add that to the graph.
+		return &Graph{}, diags
+	}
+
 	// Our graph transformers require access to the full state, so we'll
 	// temporarily lock it while we work on this.
 	state := ctx.State().Lock()


### PR DESCRIPTION
The expansion process has to assume that there will eventually be a configuration for instances to allow for config generation, but if the import block expands to no instances, we don't want to add that instance node to the graph with no import or configuration data.