### PR TITLE
stacks: actions for a no-op change are a concrete list

### DIFF
--- a/internal/rpcapi/terraform1/conversion.go
+++ b/internal/rpcapi/terraform1/conversion.go
@@ -7,10 +7,11 @@ import (
 	"fmt"
 	"math/big"
 
+	"github.com/zclconf/go-cty/cty"
+
 	"github.com/hashicorp/terraform/internal/lang/marks"
 	"github.com/hashicorp/terraform/internal/plans"
 	"github.com/hashicorp/terraform/internal/stacks/stackaddrs"
-	"github.com/zclconf/go-cty/cty"
 )
 
 // This file contains some hand-written type conversion helpers to complement
@@ -21,7 +22,7 @@ import (
 func ChangeTypesForPlanAction(action plans.Action) ([]ChangeType, error) {
 	switch action {
 	case plans.NoOp:
-		return nil, nil
+		return []ChangeType{ChangeType_NOOP}, nil
 	case plans.Create:
 		return []ChangeType{ChangeType_CREATE}, nil
 	case plans.Read:

--- a/internal/stacks/stackplan/planned_change_test.go
+++ b/internal/stacks/stackplan/planned_change_test.go
@@ -146,6 +146,7 @@ func TestPlannedChangeAsProto(t *testing.T) {
 					{
 						Description: &terraform1.PlannedChange_ChangeDescription_ComponentInstancePlanned{
 							ComponentInstancePlanned: &terraform1.PlannedChange_ComponentInstance{
+								Actions: []terraform1.ChangeType{terraform1.ChangeType_NOOP},
 								Addr: &terraform1.ComponentInstanceInStackAddr{
 									ComponentAddr:         "component.foo",
 									ComponentInstanceAddr: `component.foo["bar"]`,


### PR DESCRIPTION
This PR updates the stacks RPC API logic to specify the actions for a no-op change as a single item list with the no-op action. Given we include the `ChangeType_NOOP` enum value it feels like we should use it.

Meta-note: I had assumed this was going to be a bug but it looks very deliberate. I think the nil list is a change from how this works anywhere else in the Terraform ecosystem? The TFC agents and the UI are assuming no-op changes are formatted in this way, so we could go and change things at that point to interpret things in this way.