### PR TITLE
website: restore link to machine readable ui doc

### DIFF
--- a/website/data/internals-nav-data.json
+++ b/website/data/internals-nav-data.json
@@ -50,8 +50,7 @@
   },
   {
     "title": "Machine Readable UI",
-    "path": "machine-readable-ui",
-    "hidden": true
+    "path": "machine-readable-ui"
   },
   {
     "title": "Archiving",


### PR DESCRIPTION
The Terraform Internals page (https://developer.hashicorp.com/terraform/internals) sidebar is missing a link to the Machine Readable UI docs page.

The initial migration of the docs nav files (https://github.com/hashicorp/terraform/pull/30237) lists the page as hidden. I'm not sure why, as the page is still in use and should be discoverable.