### PR TITLE
terraform test: no refresh on destroy

### DIFF
--- a/internal/backend/local/test.go
+++ b/internal/backend/local/test.go
@@ -603,8 +603,15 @@ func (runner *TestFileRunner) destroy(config *configs.Config, state *states.Stat
 	// we care about.
 	setVariables, _ := runner.FilterVariablesToConfig(config, variables)
 
+	// We may have data sources that depend on other run blocks which can error
+	// when read if the other run block was destroyed first. We also don't
+	// particularly care about the resources here, we just want them destroyed
+	// so reducing the potential for error in any way is a good thing.
+	skipRefresh := true
+
 	planOpts := &terraform.PlanOpts{
 		Mode:         plans.DestroyMode,
+		SkipRefresh:  skipRefresh,
 		SetVariables: setVariables,
 		Overrides:    mocking.PackageOverrides(run.Config, file.Config, config),
 	}

--- a/internal/command/test_test.go
+++ b/internal/command/test_test.go
@@ -197,6 +197,10 @@ func TestTest(t *testing.T) {
 			expected: "5 passed, 0 failed.",
 			code:     0,
 		},
+		"dangling_data": {
+			expected: "2 passed, 0 failed.",
+			code:     0,
+		},
 	}
 	for name, tc := range tcs {
 		t.Run(name, func(t *testing.T) {

--- a/internal/command/testdata/test/dangling_data/main.tf
+++ b/internal/command/testdata/test/dangling_data/main.tf
@@ -1,0 +1,12 @@
+
+variable "input" {
+  type = string
+}
+
+resource "test_resource" "resource" {
+  value = var.input
+}
+
+output "id" {
+  value = test_resource.resource.id
+}

--- a/internal/command/testdata/test/dangling_data/testing/main.tf
+++ b/internal/command/testdata/test/dangling_data/testing/main.tf
@@ -1,0 +1,12 @@
+
+variable "id" {
+  type = string
+}
+
+data "test_data_source" "resource" {
+  id = var.id
+}
+
+output "value" {
+  value = data.test_data_source.resource.value
+}

--- a/internal/command/testdata/test/dangling_data/tests/main.tftest.hcl
+++ b/internal/command/testdata/test/dangling_data/tests/main.tftest.hcl
@@ -1,0 +1,16 @@
+
+run "test" {
+  variables {
+    input = "Hello, world!"
+  }
+}
+
+run "verify" {
+  module {
+    source = "./testing"
+  }
+
+  variables {
+    id = run.test.id
+  }
+}


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

This PR updates the destroy operation during terraform test operations to skip the refresh step. This means that data sources of helper modules that rely on the main state will no longer fail to be read during the refresh step, resulting in a failed destroy operation and error messages.

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Fixes #34280 

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.6.5

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

### BUG FIXES

<!--

Write a short description of the user-facing change. Examples:

- `terraform show -json`: Fixed crash with sensitive set values.
- When rendering a diff, Terraform now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 

-  `terraform test`: Don't refresh state during destroy operations during the test command, this fixes a bug where destroy operations could fail because state they depend on had been previously destroyed.
