### PR TITLE
terraform graph: By default, produce a compact graph with only resources in it

### DIFF
--- a/internal/addrs/graph.go
+++ b/internal/addrs/graph.go
@@ -1,0 +1,224 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package addrs
+
+import (
+	"bytes"
+	"fmt"
+	"sort"
+
+	"github.com/hashicorp/terraform/internal/dag"
+)
+
+// DirectedGraph represents a directed graph whose nodes are addresses of
+// type T.
+//
+// This graph type supports directed edges between pairs of addresses, and
+// because Terraform most commonly uses graphs to represent dependency
+// relationships it uses "dependency" and "dependent" as the names of the
+// endpoints of an edge, even though technically this data structure could
+// be used to represent other kinds of directed relationships if needed.
+// When used as an operation dependency graph, the "dependency" must be visited
+// before the "dependent".
+//
+// This data structure is not concurrency-safe for writes and so callers must
+// supply suitable synchronization primitives if modifying a graph concurrently
+// with readers or other writers. Concurrent reads of an already-constructed
+// graph are safe.
+type DirectedGraph[T UniqueKeyer] struct {
+	// Our dag.AcyclicGraph implementation is a little quirky but also
+	// well-tested and stable, so we'll use that for the underlying
+	// graph operations and just wrap a slightly nicer address-oriented
+	// API around it.
+	// Reusing this does mean that some of our operations end up allocating
+	// more than they would need to otherwise, so perhaps we'll revisit this
+	// in future if it seems to be causing performance problems.
+	g *dag.AcyclicGraph
+
+	// dag.AcyclicGraph can only support node types that are either
+	// comparable using == or that implement a special "hashable"
+	// interface, so we'll use our UniqueKeyer technique to produce
+	// suitable node values but we need a sidecar structure to remember
+	// which real address value belongs to each node value.
+	nodes map[UniqueKey]T
+}
+
+func NewDirectedGraph[T UniqueKeyer]() DirectedGraph[T] {
+	return DirectedGraph[T]{
+		g:     &dag.AcyclicGraph{},
+		nodes: map[UniqueKey]T{},
+	}
+}
+
+func (g DirectedGraph[T]) Add(addr T) {
+	k := addr.UniqueKey()
+	g.nodes[k] = addr
+	g.g.Add(k)
+}
+
+func (g DirectedGraph[T]) Has(addr T) bool {
+	k := addr.UniqueKey()
+	_, ok := g.nodes[k]
+	return ok
+}
+
+func (g DirectedGraph[T]) Remove(addr T) {
+	k := addr.UniqueKey()
+	g.g.Remove(k)
+	delete(g.nodes, k)
+}
+
+func (g DirectedGraph[T]) AllNodes() Set[T] {
+	ret := make(Set[T], len(g.nodes))
+	for _, addr := range g.nodes {
+		ret.Add(addr)
+	}
+	return ret
+}
+
+// AddDependency records that the first address depends on the second.
+//
+// If either address is not already in the graph then it will be implicitly
+// added as part of this operation.
+func (g DirectedGraph[T]) AddDependency(dependent, dependency T) {
+	g.Add(dependent)
+	g.Add(dependency)
+	g.g.Connect(dag.BasicEdge(dependent.UniqueKey(), dependency.UniqueKey()))
+}
+
+// DirectDependenciesOf returns only the direct dependencies of the given
+// dependent address.
+func (g DirectedGraph[T]) DirectDependenciesOf(addr T) Set[T] {
+	k := addr.UniqueKey()
+	ret := MakeSet[T]()
+	raw := g.g.DownEdges(k)
+	for otherKI := range raw {
+		ret.Add(g.nodes[otherKI.(UniqueKey)])
+	}
+	return ret
+}
+
+// TransitiveDependenciesOf returns both direct and indirect dependencies of the
+// given dependent address.
+//
+// This operation is valid only for an acyclic graph, and will panic if
+// the graph contains cycles.
+func (g DirectedGraph[T]) TransitiveDependenciesOf(addr T) Set[T] {
+	k := addr.UniqueKey()
+	ret := MakeSet[T]()
+	raw, err := g.g.Ancestors(k)
+	if err != nil {
+		// It should be impossible for "Ancestors" to fail
+		panic(err)
+	}
+	for otherKI := range raw {
+		ret.Add(g.nodes[otherKI.(UniqueKey)])
+	}
+	return ret
+}
+
+// DirectDependentsOf returns only the direct dependents of the given
+// dependency address.
+func (g DirectedGraph[T]) DirectDependentsOf(addr T) Set[T] {
+	k := addr.UniqueKey()
+	ret := MakeSet[T]()
+	raw := g.g.UpEdges(k)
+	for otherKI := range raw {
+		ret.Add(g.nodes[otherKI.(UniqueKey)])
+	}
+	return ret
+}
+
+// TransitiveDependentsOf returns both direct and indirect dependents of the
+// given dependency address.
+//
+// This operation is valid only for an acyclic graph, and will panic if
+// the graph contains cycles.
+func (g DirectedGraph[T]) TransitiveDependentsOf(addr T) Set[T] {
+	k := addr.UniqueKey()
+	ret := MakeSet[T]()
+	raw, err := g.g.Descendents(k)
+	if err != nil {
+		// It should be impossible for "Descendents" to fail
+		panic(err)
+	}
+	for otherKI := range raw {
+		ret.Add(g.nodes[otherKI.(UniqueKey)])
+	}
+	return ret
+}
+
+// TopologicalOrder returns one possible topological sort of the addresses
+// in the graph.
+//
+// There are often multiple possible sort orders that preserve the required
+// dependency ordering. The exact order returned by this function is undefined
+// and may vary between calls against the same graph.
+func (g DirectedGraph[T]) TopologicalOrder() []T {
+	raw := g.g.TopologicalOrder()
+	if len(raw) == 0 {
+		return nil
+	}
+	ret := make([]T, len(raw))
+	for i, k := range raw {
+		ret[i] = g.nodes[k.(UniqueKey)]
+	}
+	return ret
+}
+
+// StringForComparison outputs a string representing the topology of the
+// graph in a form intended for convenient equality testing by string comparison.
+//
+// For best results all possible dynamic types of T should implement
+// fmt.Stringer.
+func (g DirectedGraph[T]) StringForComparison() string {
+	var buf bytes.Buffer
+
+	stringRepr := func(v any) string {
+		switch v := v.(type) {
+		case fmt.Stringer:
+			return v.String()
+		default:
+			return fmt.Sprintf("%#v", v)
+		}
+	}
+
+	// We want the addresses in a consistent order but it doesn't really
+	// matter what that order is, so we'll just do it lexically by each
+	// type's standard string representation.
+	nodeKeys := make([]UniqueKey, 0, len(g.nodes))
+	for k := range g.nodes {
+		nodeKeys = append(nodeKeys, k)
+	}
+	sort.Slice(nodeKeys, func(i, j int) bool {
+		iStr := stringRepr(g.nodes[nodeKeys[i]])
+		jStr := stringRepr(g.nodes[nodeKeys[j]])
+		return iStr < jStr
+	})
+
+	for _, k := range nodeKeys {
+		addr := g.nodes[k]
+		fmt.Fprintf(&buf, "%s\n", stringRepr(addr))
+
+		deps := g.DirectDependenciesOf(addr)
+		if len(deps) == 0 {
+			continue
+		}
+
+		depKeys := make([]UniqueKey, 0, len(deps))
+		for k := range deps {
+			depKeys = append(depKeys, k)
+		}
+		sort.Slice(depKeys, func(i, j int) bool {
+			iStr := stringRepr(g.nodes[depKeys[i]])
+			jStr := stringRepr(g.nodes[depKeys[j]])
+			return iStr < jStr
+		})
+		for _, k := range depKeys {
+			fmt.Fprintf(&buf, "  %s\n", stringRepr(g.nodes[k]))
+		}
+	}
+
+	return buf.String()
+}

--- a/internal/addrs/graph_test.go
+++ b/internal/addrs/graph_test.go
@@ -1,0 +1,158 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package addrs
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestGraph(t *testing.T) {
+	a := LocalValue{Name: "a"}
+	b := LocalValue{Name: "b"}
+	c := LocalValue{Name: "c"}
+	d := LocalValue{Name: "d"}
+
+	g := NewDirectedGraph[LocalValue]()
+
+	g.AddDependency(d, c)
+	g.AddDependency(d, b)
+	g.AddDependency(c, b)
+	g.AddDependency(b, a)
+
+	t.Run("StringForComparison", func(t *testing.T) {
+		gotStr := strings.TrimSpace(g.StringForComparison())
+		wantStr := strings.TrimSpace(`
+local.a
+local.b
+  local.a
+local.c
+  local.b
+local.d
+  local.b
+  local.c
+`)
+		if gotStr != wantStr {
+			t.Errorf("wrong string representation\ngot:\n%s\n\nwant:\n%s", gotStr, wantStr)
+		}
+	})
+
+	t.Run("direct dependencies of a", func(t *testing.T) {
+		deps := g.DirectDependenciesOf(a)
+		if got, want := len(deps), 0; got != want {
+			t.Errorf("a has %d dependencies, but should have %d", got, want)
+		}
+	})
+	t.Run("direct dependencies of b", func(t *testing.T) {
+		deps := g.DirectDependenciesOf(b)
+		if got, want := len(deps), 1; got != want {
+			t.Errorf("b has %d dependencies, but should have %d", got, want)
+		}
+		if !deps.Has(a) {
+			t.Errorf("b does not depend on a, but should")
+		}
+	})
+	t.Run("direct dependencies of d", func(t *testing.T) {
+		deps := g.DirectDependenciesOf(d)
+		if got, want := len(deps), 2; got != want {
+			t.Errorf("d has %d dependencies, but should have %d", got, want)
+		}
+		if !deps.Has(b) {
+			t.Errorf("d does not depend on b, but should")
+		}
+		if !deps.Has(c) {
+			t.Errorf("d does not depend on c, but should")
+		}
+	})
+	t.Run("direct dependents of a", func(t *testing.T) {
+		depnts := g.DirectDependentsOf(a)
+		if got, want := len(depnts), 1; got != want {
+			t.Errorf("a has %d dependents, but should have %d", got, want)
+		}
+		if !depnts.Has(b) {
+			t.Errorf("b does not depend on a, but should")
+		}
+	})
+	t.Run("direct dependents of b", func(t *testing.T) {
+		depnts := g.DirectDependentsOf(b)
+		if got, want := len(depnts), 2; got != want {
+			t.Errorf("b has %d dependents, but should have %d", got, want)
+		}
+		if !depnts.Has(c) {
+			t.Errorf("c does not depend on b, but should")
+		}
+		if !depnts.Has(d) {
+			t.Errorf("d does not depend on b, but should")
+		}
+	})
+	t.Run("direct dependents of d", func(t *testing.T) {
+		depnts := g.DirectDependentsOf(d)
+		if got, want := len(depnts), 0; got != want {
+			t.Errorf("d has %d dependents, but should have %d", got, want)
+		}
+	})
+	t.Run("transitive dependencies of a", func(t *testing.T) {
+		deps := g.TransitiveDependenciesOf(a)
+		if got, want := len(deps), 0; got != want {
+			t.Errorf("a has %d transitive dependencies, but should have %d", got, want)
+		}
+	})
+	t.Run("transitive dependencies of b", func(t *testing.T) {
+		deps := g.TransitiveDependenciesOf(b)
+		if got, want := len(deps), 1; got != want {
+			t.Errorf("b has %d transitive dependencies, but should have %d", got, want)
+		}
+		if !deps.Has(a) {
+			t.Errorf("b does not depend on a, but should")
+		}
+	})
+	t.Run("transitive dependencies of d", func(t *testing.T) {
+		deps := g.TransitiveDependenciesOf(d)
+		if got, want := len(deps), 3; got != want {
+			t.Errorf("d has %d transitive dependencies, but should have %d", got, want)
+		}
+		if !deps.Has(a) {
+			t.Errorf("d does not depend on a, but should")
+		}
+		if !deps.Has(b) {
+			t.Errorf("d does not depend on b, but should")
+		}
+		if !deps.Has(c) {
+			t.Errorf("d does not depend on c, but should")
+		}
+	})
+	t.Run("transitive dependents of a", func(t *testing.T) {
+		depnts := g.TransitiveDependentsOf(a)
+		if got, want := len(depnts), 3; got != want {
+			t.Errorf("a has %d transitive dependents, but should have %d", got, want)
+		}
+		if !depnts.Has(b) {
+			t.Errorf("b does not depend on a, but should")
+		}
+		if !depnts.Has(c) {
+			t.Errorf("c does not depend on a, but should")
+		}
+		if !depnts.Has(d) {
+			t.Errorf("d does not depend on a, but should")
+		}
+	})
+	t.Run("transitive dependents of b", func(t *testing.T) {
+		depnts := g.TransitiveDependentsOf(b)
+		if got, want := len(depnts), 2; got != want {
+			t.Errorf("b has %d transitive dependents, but should have %d", got, want)
+		}
+		if !depnts.Has(c) {
+			t.Errorf("c does not depend on b, but should")
+		}
+		if !depnts.Has(d) {
+			t.Errorf("d does not depend on b, but should")
+		}
+	})
+	t.Run("transitive dependents of d", func(t *testing.T) {
+		depnts := g.TransitiveDependentsOf(d)
+		if got, want := len(depnts), 0; got != want {
+			t.Errorf("d has %d transitive dependents, but should have %d", got, want)
+		}
+	})
+}

--- a/internal/command/graph.go
+++ b/internal/command/graph.go
@@ -5,8 +5,10 @@ package command
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 
+	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/backend"
 	"github.com/hashicorp/terraform/internal/command/arguments"
 	"github.com/hashicorp/terraform/internal/dag"
@@ -115,11 +117,23 @@ func (c *GraphCommand) Run(args []string) int {
 	}
 
 	if graphTypeStr == "" {
-		switch {
-		case lr.Plan != nil:
+		if planFile == nil {
+			// Simple resource dependency mode:
+			// This is based on the plan graph but we then further reduce it down
+			// to just resource dependency relationships, assuming that in most
+			// cases the most important thing is what order we'll visit the
+			// resources in.
+			fullG, graphDiags := lr.Core.PlanGraphForUI(lr.Config, lr.InputState, plans.NormalMode)
+			diags = diags.Append(graphDiags)
+			if graphDiags.HasErrors() {
+				c.showDiagnostics(diags)
+				return 1
+			}
+
+			g := fullG.ResourceGraph()
+			return c.resourceOnlyGraph(g)
+		} else {
 			graphTypeStr = "apply"
-		default:
-			graphTypeStr = "plan"
 		}
 	}
 
@@ -189,8 +203,100 @@ func (c *GraphCommand) Run(args []string) int {
 		return 1
 	}
 
-	c.Ui.Output(graphStr)
+	_, err = c.Streams.Stdout.File.WriteString(graphStr)
+	if err != nil {
+		c.Ui.Error(fmt.Sprintf("Failed to write graph to stdout: %s", err))
+		return 1
+	}
 
+	return 0
+}
+
+func (c *GraphCommand) resourceOnlyGraph(graph addrs.DirectedGraph[addrs.ConfigResource]) int {
+	out := c.Streams.Stdout.File
+	fmt.Fprintln(out, "digraph G {")
+	// Horizontal presentation is easier to read because our nodes tend
+	// to be much wider than they are tall. The leftmost nodes in the output
+	// are those Terraform would visit first.
+	fmt.Fprintln(out, "  rankdir = \"RL\";")
+	fmt.Fprintln(out, "  node [shape = rect, fontname = \"sans-serif\"];")
+
+	// To help relate the output back to the configuration it came from,
+	// and to make the individual node labels more reasonably sized when
+	// deeply nested inside modules, we'll cluster the nodes together by
+	// the module they belong to and then show only the local resource
+	// address in the individual nodes. We'll accomplish that by sorting
+	// the nodes first by module, so we can then notice the transitions.
+	allAddrs := graph.AllNodes()
+	if len(allAddrs) == 0 {
+		fmt.Fprintln(out, "  /* This configuration does not contain any resources.         */")
+		fmt.Fprintln(out, "  /* For a more detailed graph, try: terraform graph -type=plan */")
+	}
+	addrsOrder := make([]addrs.ConfigResource, 0, len(allAddrs))
+	for _, addr := range allAddrs {
+		addrsOrder = append(addrsOrder, addr)
+	}
+	sort.Slice(addrsOrder, func(i, j int) bool {
+		iAddr, jAddr := addrsOrder[i], addrsOrder[j]
+		iModStr, jModStr := iAddr.Module.String(), jAddr.Module.String()
+		switch {
+		case iModStr != jModStr:
+			return iModStr < jModStr
+		default:
+			iRes, jRes := iAddr.Resource, jAddr.Resource
+			switch {
+			case iRes.Mode != jRes.Mode:
+				return iRes.Mode == addrs.DataResourceMode
+			case iRes.Type != jRes.Type:
+				return iRes.Type < jRes.Type
+			default:
+				return iRes.Name < jRes.Name
+			}
+		}
+	})
+
+	currentMod := addrs.RootModule
+	for _, addr := range addrsOrder {
+		if !addr.Module.Equal(currentMod) {
+			// We need a new subgraph, then.
+			// Experimentally it seems like nested clusters tend to make it
+			// hard for dot to converge on a good layout, so we'll stick with
+			// just one level of clusters for now but could revise later based
+			// on feedback.
+			if !currentMod.IsRoot() {
+				fmt.Fprintln(out, "  }")
+			}
+			currentMod = addr.Module
+			fmt.Fprintf(out, "  subgraph \"cluster_%s\" {\n", currentMod.String())
+			fmt.Fprintf(out, "    label = %q\n", currentMod.String())
+			fmt.Fprintf(out, "    fontname = %q\n", "sans-serif")
+		}
+		if currentMod.IsRoot() {
+			fmt.Fprintf(out, "  %q [label=%q];\n", addr.String(), addr.Resource.String())
+		} else {
+			fmt.Fprintf(out, "    %q [label=%q];\n", addr.String(), addr.Resource.String())
+		}
+	}
+	if !currentMod.IsRoot() {
+		fmt.Fprintln(out, "  }")
+	}
+
+	// Now we'll emit all of the edges.
+	// We use addrsOrder for both levels to ensure a consistent ordering between
+	// runs without further sorting, which means we visit more nodes than we
+	// really need to but this output format is only really useful for relatively
+	// small graphs anyway, so this should be fine.
+	for _, sourceAddr := range addrsOrder {
+		deps := graph.DirectDependenciesOf(sourceAddr)
+		for _, targetAddr := range addrsOrder {
+			if !deps.Has(targetAddr) {
+				continue
+			}
+			fmt.Fprintf(out, "  %q -> %q;\n", sourceAddr.String(), targetAddr.String())
+		}
+	}
+
+	fmt.Fprintln(out, "}")
 	return 0
 }
 
@@ -201,6 +307,12 @@ Usage: terraform [global options] graph [options]
   Produces a representation of the dependency graph between different
   objects in the current configuration and state.
 
+  By default the graph shows a summary only of the relationships between
+  resources in the configuration, since those are the main objects that
+  have side-effects whose ordering is significant. You can generate more
+  detailed graphs reflecting Terraform's actual evaluation strategy
+  by specifying the -type=TYPE option to select an operation type.
+
   The graph is presented in the DOT language. The typical program that can
   read this format is GraphViz, but many web services are also available
   to read this format.
@@ -208,17 +320,22 @@ Usage: terraform [global options] graph [options]
 Options:
 
   -plan=tfplan     Render graph using the specified plan file instead of the
-                   configuration in the current directory.
+                   configuration in the current directory. Implies -type=apply.
 
   -draw-cycles     Highlight any cycles in the graph with colored edges.
-                   This helps when diagnosing cycle errors.
+                   This helps when diagnosing cycle errors. This option is
+                   supported only when illustrating a real evaluation graph,
+                   selected using the -type=TYPE option.
 
-  -type=plan       Type of graph to output. Can be: plan, plan-refresh-only,
-                   plan-destroy, or apply. By default Terraform chooses
-				   "plan", or "apply" if you also set the -plan=... option.
+  -type=TYPE       Type of operation graph to output. Can be: plan,
+                   plan-refresh-only, plan-destroy, or apply. By default
+                   Terraform just summarizes the relationships between the
+                   resources in your configuration, without any particular
+                   operation in mind. Full operation graphs are more detailed
+                   but therefore often harder to read.
 
   -module-depth=n  (deprecated) In prior versions of Terraform, specified the
-				   depth of modules to show in the output.
+                   depth of modules to show in the output.
 `
 	return strings.TrimSpace(helpText)
 }

--- a/internal/command/graph_test.go
+++ b/internal/command/graph_test.go
@@ -4,39 +4,49 @@
 package command
 
 import (
+	"context"
 	"os"
 	"strings"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/mitchellh/cli"
 	"github.com/zclconf/go-cty/cty"
 
 	"github.com/hashicorp/terraform/internal/addrs"
+	"github.com/hashicorp/terraform/internal/configs/configload"
+	"github.com/hashicorp/terraform/internal/configs/configschema"
+	"github.com/hashicorp/terraform/internal/initwd"
 	"github.com/hashicorp/terraform/internal/plans"
+	"github.com/hashicorp/terraform/internal/providers"
+	"github.com/hashicorp/terraform/internal/registry"
 	"github.com/hashicorp/terraform/internal/states"
+	"github.com/hashicorp/terraform/internal/terminal"
 )
 
-func TestGraph(t *testing.T) {
+func TestGraph_planPhase(t *testing.T) {
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("graph"), td)
 	defer testChdir(t, td)()
 
 	ui := new(cli.MockUi)
+	streams, closeStreams := terminal.StreamsForTesting(t)
 	c := &GraphCommand{
 		Meta: Meta{
 			testingOverrides: metaOverridesForProvider(applyFixtureProvider()),
 			Ui:               ui,
+			Streams:          streams,
 		},
 	}
 
-	args := []string{}
+	args := []string{"-type=plan"}
 	if code := c.Run(args); code != 0 {
 		t.Fatalf("bad: \n%s", ui.ErrorWriter.String())
 	}
 
-	output := ui.OutputWriter.String()
-	if !strings.Contains(output, `provider[\"registry.terraform.io/hashicorp/test\"]`) {
-		t.Fatalf("doesn't look like digraph: %s", output)
+	output := closeStreams(t)
+	if !strings.Contains(output.Stdout(), `provider[\"registry.terraform.io/hashicorp/test\"]`) {
+		t.Fatalf("doesn't look like digraph:\n%s\n\nstderr:\n%s", output.Stdout(), output.Stderr())
 	}
 }
 
@@ -58,40 +68,19 @@ func TestGraph_multipleArgs(t *testing.T) {
 	}
 }
 
-func TestGraph_noArgs(t *testing.T) {
-	td := t.TempDir()
-	testCopyDir(t, testFixturePath("graph"), td)
-	defer testChdir(t, td)()
-
-	ui := new(cli.MockUi)
-	c := &GraphCommand{
-		Meta: Meta{
-			testingOverrides: metaOverridesForProvider(applyFixtureProvider()),
-			Ui:               ui,
-		},
-	}
-
-	args := []string{}
-	if code := c.Run(args); code != 0 {
-		t.Fatalf("bad: \n%s", ui.ErrorWriter.String())
-	}
-
-	output := ui.OutputWriter.String()
-	if !strings.Contains(output, `provider[\"registry.terraform.io/hashicorp/test\"]`) {
-		t.Fatalf("doesn't look like digraph: %s", output)
-	}
-}
-
 func TestGraph_noConfig(t *testing.T) {
 	td := t.TempDir()
 	os.MkdirAll(td, 0755)
 	defer testChdir(t, td)()
 
-	ui := new(cli.MockUi)
+	streams, closeStreams := terminal.StreamsForTesting(t)
+	defer closeStreams(t)
+	ui := cli.NewMockUi()
 	c := &GraphCommand{
 		Meta: Meta{
 			testingOverrides: metaOverridesForProvider(applyFixtureProvider()),
 			Ui:               ui,
+			Streams:          streams,
 		},
 	}
 
@@ -103,7 +92,88 @@ func TestGraph_noConfig(t *testing.T) {
 	}
 }
 
-func TestGraph_plan(t *testing.T) {
+func TestGraph_resourcesOnly(t *testing.T) {
+	wd := tempWorkingDirFixture(t, "graph-interesting")
+	defer testChdir(t, wd.RootModuleDir())()
+
+	// The graph-interesting fixture has a child module, so we'll need to
+	// run the module installer just to get the working directory set up
+	// properly, as if the user has run "terraform init". This is really
+	// just building the working directory's index of module directories.
+	loader, cleanupLoader := configload.NewLoaderForTests(t)
+	t.Cleanup(cleanupLoader)
+	err := os.MkdirAll(".terraform/modules", 0700)
+	if err != nil {
+		t.Fatal(err)
+	}
+	inst := initwd.NewModuleInstaller(".terraform/modules", loader, registry.NewClient(nil, nil))
+	_, instDiags := inst.InstallModules(context.Background(), ".", "tests", true, false, initwd.ModuleInstallHooksImpl{})
+	if instDiags.HasErrors() {
+		t.Fatal(instDiags.Err())
+	}
+
+	p := testProvider()
+	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
+		ResourceTypes: map[string]providers.Schema{
+			"foo": {
+				Block: &configschema.Block{
+					Attributes: map[string]*configschema.Attribute{
+						"arg": {
+							Type:     cty.String,
+							Optional: true,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	ui := cli.NewMockUi()
+	streams, closeStreams := terminal.StreamsForTesting(t)
+	c := &GraphCommand{
+		Meta: Meta{
+			testingOverrides: &testingOverrides{
+				Providers: map[addrs.Provider]providers.Factory{
+					addrs.NewDefaultProvider("foo"): providers.FactoryFixed(p),
+				},
+			},
+			Ui:      ui,
+			Streams: streams,
+		},
+	}
+
+	// A "resources only" graph is the default behavior, with no extra arguments.
+	args := []string{}
+	if code := c.Run(args); code != 0 {
+		output := closeStreams(t)
+		t.Fatalf("unexpected error: \n%s", output.Stderr())
+	}
+
+	output := closeStreams(t)
+	gotGraph := strings.TrimSpace(output.Stdout())
+	wantGraph := strings.TrimSpace(`
+digraph G {
+  rankdir = "RL";
+  node [shape = rect, fontname = "sans-serif"];
+  "foo.bar" [label="foo.bar"];
+  "foo.baz" [label="foo.baz"];
+  "foo.boop" [label="foo.boop"];
+  subgraph "cluster_module.child" {
+    label = "module.child"
+    fontname = "sans-serif"
+    "module.child.foo.bleep" [label="foo.bleep"];
+  }
+  "foo.baz" -> "foo.bar";
+  "foo.boop" -> "module.child.foo.bleep";
+  "module.child.foo.bleep" -> "foo.bar";
+}
+`)
+	if diff := cmp.Diff(wantGraph, gotGraph); diff != "" {
+		t.Fatalf("wrong result\n%s", diff)
+	}
+}
+
+func TestGraph_applyPhaseSavedPlan(t *testing.T) {
 	testCwd(t)
 
 	plan := &plans.Plan{
@@ -140,11 +210,13 @@ func TestGraph_plan(t *testing.T) {
 
 	planPath := testPlanFile(t, configSnap, states.NewState(), plan)
 
-	ui := new(cli.MockUi)
+	streams, closeStreams := terminal.StreamsForTesting(t)
+	ui := cli.NewMockUi()
 	c := &GraphCommand{
 		Meta: Meta{
 			testingOverrides: metaOverridesForProvider(applyFixtureProvider()),
 			Ui:               ui,
+			Streams:          streams,
 		},
 	}
 
@@ -155,8 +227,8 @@ func TestGraph_plan(t *testing.T) {
 		t.Fatalf("bad: \n%s", ui.ErrorWriter.String())
 	}
 
-	output := ui.OutputWriter.String()
-	if !strings.Contains(output, `provider[\"registry.terraform.io/hashicorp/test\"]`) {
-		t.Fatalf("doesn't look like digraph: %s", output)
+	output := closeStreams(t)
+	if !strings.Contains(output.Stdout(), `provider[\"registry.terraform.io/hashicorp/test\"]`) {
+		t.Fatalf("doesn't look like digraph:\n%s\n\nstderr:\n%s", output.Stdout(), output.Stderr())
 	}
 }

--- a/internal/command/testdata/graph-interesting/child/graph-interesting-child.tf
+++ b/internal/command/testdata/graph-interesting/child/graph-interesting-child.tf
@@ -1,0 +1,12 @@
+
+variable "in" {
+  type = string
+}
+
+resource "foo" "bleep" {
+  arg = var.in
+}
+
+output "out" {
+  value = foo.bleep.arg
+}

--- a/internal/command/testdata/graph-interesting/graph-interesting.tf
+++ b/internal/command/testdata/graph-interesting/graph-interesting.tf
@@ -1,0 +1,20 @@
+resource "foo" "bar" {
+}
+
+locals {
+  foo_bar_baz = foo.bar.baz
+}
+
+resource "foo" "baz" {
+  arg = local.foo_bar_baz
+}
+
+module "child" {
+  source = "./child"
+
+  in = local.foo_bar_baz
+}
+
+resource "foo" "boop" {
+  arg = module.child.out
+}

--- a/website/docs/cli/commands/graph.mdx
+++ b/website/docs/cli/commands/graph.mdx
@@ -7,50 +7,50 @@ description: >-
 
 # Command: graph
 
-The `terraform graph` command is used to generate a visual
-representation of either a configuration or execution plan.
-The output is in the DOT format, which can be used by
-[GraphViz](http://www.graphviz.org) to generate charts.
+The `terraform graph` command produces descriptions of the relationships
+between objects in a Terraform configuration, using
+[the DOT language](https://en.wikipedia.org/wiki/DOT_(graph_description_language)).
 
 ## Usage
 
 Usage: `terraform graph [options]`
 
-Outputs the visual execution graph of Terraform resources according to
-either the current configuration or an execution plan.
+By default the result is a simplified graph which describes only the dependency
+ordering of the resources (`resource` and `data` blocks) in the configuration.
 
-The graph is outputted in DOT format. The typical program that can
-read this format is GraphViz, but many web services are also available
-to read this format.
-
-The `-type` flag can be used to control the type of graph shown. Terraform
-creates different graphs for different operations. See the options below
-for the list of types supported. The default type is "plan" if a
-configuration is given, and "apply" if a plan file is passed as an
-argument.
+The `-type=...` option optionally selects from a number of other graph types
+which have more detail, at the expense of also exposing some of the
+implementation details of the Terraform language runtime.
 
 Options:
 
-* `-plan=tfplan`    - Render graph using the specified plan file instead of the
-  configuration in the current directory.
+* `-plan=tfplan` - Produce a graph for applying the given plan. Implies `-type=apply`.
 
-* `-draw-cycles`    - Highlight any cycles in the graph with colored edges.
-  This helps when diagnosing cycle errors.
+* `-draw-cycles` - Highlight any cycles in the graph with colored edges.
+  This helps when diagnosing cycle errors. This option is supported only when
+  selecting one of the real graph operaton types using the `-type=...`
+  option.
 
-* `-type=plan`      - Type of graph to output. Can be: `plan`, `plan-refresh-only`, `plan-destroy`, or `apply`.
-
-* `-module-depth=n` - (deprecated) In prior versions of Terraform, specified the
-  depth of modules to show in the output.
+* `-type=...` - Selects a specific operation type to show the graph of, instead
+  of the default resources-only simplified graph.
+  Can be: `plan`, `plan-refresh-only`, `plan-destroy`, or `apply`.
 
 ## Generating Images
 
-The output of `terraform graph` is in the DOT format, which can
-easily be converted to an image by making use of `dot` provided
-by GraphViz:
+The graph output uses
+[the DOT language](https://en.wikipedia.org/wiki/DOT_(graph_description_language)),
+which is a machine-readable graph description language which originated in
+[Graphviz](https://graphviz.org/). You can use the Graphviz `dot` command
+to present the resulting graph description as an image. There are also various
+third-party online graph rendering services which accept this format.
+
+If you have the Graphviz `dot` command already installed, you can render
+a PNG image by piping into that command:
 
 ```shellsession
-$ terraform graph | dot -Tsvg > graph.svg
+$ terraform graph -type=plan | dot -Tpng >graph.png
 ```
 
-Here is an example graph output:
-![Graph Example](/img/docs/graph-example.png)
+The following is an example result:
+
+![A visualization of the plan graph of a hypothetical Terraform configuration, produced by dot](/img/docs/graph-example.png)


### PR DESCRIPTION
This fixes #14511.

I actually wrote the first two commits here as part of a new round of work on #30937, but after implementing `Graph.ResourceGraph` I remembered that a graph just of the relationships between resources -- without all of the other intermediaries -- was the main idea I heard about when researching #14511 many years ago.

Given that the `terraform graph` command is an ancillary debugging/learning tool rather than part of the main Terraform workflow, I find it pretty unlikely that we'd prioritize any work directly on it in the near future, but since my work here already got most of the way there I figured I might as well make a small effort to close that old issue at the same time, while I'm working in this area anyway.

The effect of this PR, then, is to change the default behavior of `terraform graph` to produce a reduced graph that includes only the resources (both `resource` and `data`) described in the configuration, grouped by which module they belong to. Any intermediate nodes such as input variables and output values are not directly included, but indirect dependencies through them are preserved and shown as if they were direct dependencies between resources.

The idea of prioritizing resources here is to roughly align with how we prioritize information in other parts of the CLI, such as in `terraform plan` and `terraform show` which both spend most of their output showing data about resources and de-emphasize (or ignore entirely) most other kinds of objects in Terraform.

This also incorporates another very old `terraform graph` improvement idea, which is to arrange the graph in reverse order of the dependency arrows so that a sighted viewer can read the image from left to right to see approximately what order the operations might happen in, with the first operations on the far left and the last operations on the far right. This aligns with the left-to-right reading order of most languages using the latin alphabet, which is the alphabet Terraform uses for its own identifiers/etc. Anyone who would prefer to have it oriented the other way (with the first operations on the far right) can change the `rankdir` argument to be `"LR"` instead after they've generated a graph.

This will change behavior for anyone who is routinely running `terraform graph` with no other options. That command was intentionally excluded from the Terraform v1.x compatibility promises in anticipation of making changes like this one, and the old default behavior is still available here as `terraform graph -type=plan`. If we move forward with this, I'll add an upgrade note to the changelog describing how to obtain the previous default behavior.

---

While in the area anyway I also did a small amount of modernization of the `terraform graph` command and its tests, now using the "streams" abstraction to write to stdout instead of using the legacy "Ui" object.

---

I mentioned above that the first two commits here are really for #30937. The connection there is that resources are the main object type that performs actions that can potentially need to be deferred due to unknown values, and so having a summarized graph with _just_ the relationships between resources makes it more efficient to ask the question "does this resource depend on any other resources that have already been deferred?". But more on that will follow in later PRs, once I've made more progress on the details there.

Because this was a "while I was in the area" sort of thing, I don't expect to have time to respond to non-trivial feedback, but of course if anyone has any big concerns about this then we can always put it back on the shelf and try again another time!
