### PR TITLE
terraform test: rearrange the order of destroy operations

### DIFF
--- a/internal/backend/local/test.go
+++ b/internal/backend/local/test.go
@@ -860,8 +860,6 @@ func (runner *TestFileRunner) wait(ctx *terraform.Context, runningCtx context.Co
 }
 
 func (runner *TestFileRunner) cleanup(file *moduletest.File) {
-	var diags tfdiags.Diagnostics
-
 	log.Printf("[TRACE] TestStateManager: cleaning up state for %s", file.Name)
 
 	if runner.Suite.Cancelled {
@@ -870,47 +868,8 @@ func (runner *TestFileRunner) cleanup(file *moduletest.File) {
 		return
 	}
 
-	// First, we'll clean up the main state.
-	main := runner.RelevantStates[MainStateIdentifier]
-
-	updated := main.State
-	if main.Run == nil {
-		if !main.State.Empty() {
-			log.Printf("[ERROR] TestFileRunner: found inconsistent run block and state file in %s", file.Name)
-			diags = diags.Append(tfdiags.Sourceless(tfdiags.Error, "Inconsistent state", fmt.Sprintf("Found inconsistent state while cleaning up %s. This is a bug in Terraform - please report it", file.Name)))
-		}
-	} else {
-		reset, configDiags := configtest.TransformConfigForTest(runner.Suite.Config, main.Run, file, runner.globalVariables, runner.PriorStates, runner.Suite.configProviders[MainStateIdentifier])
-		diags = diags.Append(configDiags)
-
-		if !configDiags.HasErrors() {
-			var destroyDiags tfdiags.Diagnostics
-			updated, destroyDiags = runner.destroy(runner.Suite.Config, main.State, main.Run, file)
-			diags = diags.Append(destroyDiags)
-		}
-
-		reset()
-	}
-
-	if !updated.Empty() {
-		// Then we failed to adequately clean up the state, so mark success
-		// as false.
-		file.Status = moduletest.Error
-	}
-	runner.Suite.View.DestroySummary(diags, main.Run, file, updated)
-
-	if runner.Suite.Cancelled {
-		// In case things were cancelled during the last execution.
-		return
-	}
-
 	var states []*TestFileState
 	for key, state := range runner.RelevantStates {
-		if key == MainStateIdentifier {
-			// We processed the main state above.
-			continue
-		}
-
 		if state.Run == nil {
 			if state.State.Empty() {
 				// We can see a run block being empty when the state is empty if
@@ -955,13 +914,22 @@ func (runner *TestFileRunner) cleanup(file *moduletest.File) {
 
 		var diags tfdiags.Diagnostics
 
-		reset, configDiags := configtest.TransformConfigForTest(state.Run.Config.ConfigUnderTest, state.Run, file, runner.globalVariables, runner.PriorStates, runner.Suite.configProviders[state.Run.Config.Module.Source.String()])
+		config := runner.Suite.Config
+		key := MainStateIdentifier
+
+		if state.Run.Config.Module != nil {
+			// Then this state was produced by an alternate module.
+			config = state.Run.Config.ConfigUnderTest
+			key = state.Run.Config.Module.Source.String()
+		}
+
+		reset, configDiags := configtest.TransformConfigForTest(config, state.Run, file, runner.globalVariables, runner.PriorStates, runner.Suite.configProviders[key])
 		diags = diags.Append(configDiags)
 
 		updated := state.State
 		if !diags.HasErrors() {
 			var destroyDiags tfdiags.Diagnostics
-			updated, destroyDiags = runner.destroy(state.Run.Config.ConfigUnderTest, state.State, state.Run, file)
+			updated, destroyDiags = runner.destroy(config, state.State, state.Run, file)
 			diags = diags.Append(destroyDiags)
 		}
 

--- a/internal/command/test_test.go
+++ b/internal/command/test_test.go
@@ -197,6 +197,10 @@ func TestTest(t *testing.T) {
 			expected: "5 passed, 0 failed.",
 			code:     0,
 		},
+		"dangling_data_block": {
+			expected: "2 passed, 0 failed.",
+			code:     0,
+		},
 	}
 	for name, tc := range tcs {
 		t.Run(name, func(t *testing.T) {

--- a/internal/command/testdata/test/dangling_data_block/main.tf
+++ b/internal/command/testdata/test/dangling_data_block/main.tf
@@ -1,0 +1,11 @@
+variable "input" {
+  type = string
+}
+
+resource "test_resource" "resource" {
+  value = var.input
+}
+
+output "id" {
+  value = test_resource.resource.id
+}

--- a/internal/command/testdata/test/dangling_data_block/testing/verify/main.tf
+++ b/internal/command/testdata/test/dangling_data_block/testing/verify/main.tf
@@ -1,0 +1,11 @@
+variable "id" {
+  type = string
+}
+
+data "test_data_source" "resource" {
+  id = var.id
+}
+
+output "value" {
+  value = data.test_data_source.resource.value
+}

--- a/internal/command/testdata/test/dangling_data_block/tests/main.tftest.hcl
+++ b/internal/command/testdata/test/dangling_data_block/tests/main.tftest.hcl
@@ -1,0 +1,15 @@
+run "test" {
+  variables {
+    input = "Hello, world!"
+  }
+}
+
+run "verify" {
+  module {
+    source = "./testing/verify"
+  }
+
+  variables {
+    id = run.test.id
+  }
+}

--- a/website/docs/language/tests/index.mdx
+++ b/website/docs/language/tests/index.mdx
@@ -618,15 +618,11 @@ run "loader" {
 
 #### Modules Cleanup
 
-At the conclusion of a test file, Terraform attempts to destroy every resource it created during the execution of that test file. When Terraform loads alternate modules, the order in which Terraform destroys those objects in is important. For example, in the first [Modules](#modules) example, we could not destroy the resources created in the "setup" `run` block before the objects created in the "execute" `run` block, because the S3 bucket we created in the "setup" step can not be destroyed while it contains objects.
+At the conclusion of a test file, Terraform attempts to destroy every resource it created during the execution of that test file. When Terraform loads alternate modules, the order in which Terraform destroys those objects in is important. For example, in the first [Modules](#modules) example, Terraform could not destroy the resources created in the "setup" `run` block before the objects created in the "execute" `run` block, because the S3 bucket we created in the "setup" step can not be destroyed while it contains objects.
 
-Terraform destroys resources in the following order, and this order is _important_ because it affects the structure of your testing files:
+Terraform destroys resources in reverse `run` block order. In the most recent [example](#modules-state), there are three state files. One for the main state, one for the `./testing/loader` module, and one for the `./testing/setup` module. The `./testing/loader` state file would be destroyed first as it was referenced most recently by the last run block. The main state file would be destroyed second as it was referenced by the "update" `run` block. The `./testing/setup` state file would then be destroyed last.
 
-1. Resources in the main state file. Do not create resources in alternate modules that depend on resources from your main configuration.
-   - Data sources can refer to objects in your main configuration, because Terraform does not have to destroy data sources.
-2. Resources created by alternate modules in reverse `run` block order.
-
-From our [example](#modules-state), any resources created in the "verify" `run` block would be destroyed before resources created in the "setup" `run` block. Note, that in our example this doesn't particularly matter as our "verify" `run` block only loads a data source and creates no resources.
+Note, that the first two `run` blocks "setup" and "init", do nothing during the destroy operations as their state files are used by later run blocks and have already been destroyed.
 
 If you use a single setup module as an alternate module, and it executes first, or you use no alternate modules, then the order of destruction does not affect you. Anything more complex may require careful consideration to make sure the destruction of resources can complete automatically.
 


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

This is my second attempt at this, see #34285.

I think I overcomplicated this logic initially. Previously, we'd destroy the main state first, and then iterate through the remaining states from alternate modules in reverse order. We had documentation advising users not to create dependencies on the main state so this ordering should have been safe. I hadn't considered data sources requiring read operations during the pre-destroy refresh which leads to the referenced bug.

After this PR, we just destroy in reverse ordering with the documentation updated to simply say don't create references into later run blocks (eg. don't make a resource that depends on the creation of an earlier run block, and then reference the underlying module of that earlier run block later). I think this is actually acceptable given the way people are using the testing framework - it's much simpler this way and easier to explain. It also gives more control to the users - they can simply do a plan only run block against a module to tweak the destroy order.

A complicated extension to this would be to not only destroy during the destroy operation, but to essentially rollback states to previous run blocks until you find the first time they are created, at which point you could destroy them. I think this would be overkill for what we're trying to solve here but we could revisit that idea if this solution is inadequate.

I'm not sure if we can backport this change (given the change in the docs) but also this is quite advanced and I doubt many (if any) users will have created test configurations at the required complexity for this to be an issue yet. So maybe we could backport it? If not, we can fix this as part of the upcoming 1.7 release.

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Fixes #34280 

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.7.0 or 1.6.5 - I'm not sure.

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

### UPGRADE NOTES

<!--

Write a short description of the user-facing change. Examples:

- `terraform show -json`: Fixed crash with sensitive set values.
- When rendering a diff, Terraform now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 

-  `terraform test`: Simplify the ordering of destroy operations during test cleanup to simple reverse `run` block order.
