### PR TITLE
Correct EC2 instance encryption condition example in custom-conditions.mdx

### DIFF
--- a/website/docs/language/expressions/custom-conditions.mdx
+++ b/website/docs/language/expressions/custom-conditions.mdx
@@ -121,7 +121,7 @@ The following example shows use cases for preconditions and postconditions. The 
 
 - **The EC2 instance must be allocated a public DNS hostname.** In Amazon Web Services, EC2 instances are assigned public DNS hostnames only if they belong to a virtual network configured in a certain way. The postcondition would detect if the selected virtual network is not configured correctly, prompting the user to debug the network settings.
 
-- **The EC2 instance will have an encrypted root volume.** The precondition ensures that the root volume is encrypted, even though the software running in this EC2 instance would probably still operate as expected on an unencrypted volume. This lets Terraform produce an error immediately, before any other components rely on the new EC2 instance.
+- **The EC2 instance will have an encrypted root volume.** The postcondition ensures that the root volume is encrypted, even though the software running in this EC2 instance would probably still operate as expected on an unencrypted volume. This lets Terraform produce an error immediately, before any other components rely on the new EC2 instance.
 
 ```hcl
 


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

# Description

This is a simple correction in the Expressions docs related to the custom condition examples. The EC2 instance encryption example mentions "precondition" when the example uses a `postcondition`.

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

<!-- Fixes # -->


<!--
## Target Release


In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

1.5.x
-->



## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

### DOC FIX

<!--

Write a short description of the user-facing change. Examples:

- `terraform show -json`: Fixed crash with sensitive set values.
- When rendering a diff, Terraform now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 

-  Fixed explanation for EC2 instance encryption example in custom condition expression docs
