### PR TITLE
Fix race conditions in mock provider and mock tfc client

### DIFF
--- a/internal/cloud/tfe_client_mock.go
+++ b/internal/cloud/tfe_client_mock.go
@@ -1753,6 +1753,9 @@ func (m *MockTestRuns) Logs(ctx context.Context, moduleID tfe.RegistryModuleID, 
 	}
 
 	done := func() (bool, error) {
+		m.Lock()
+		defer m.Unlock()
+
 		tr, exists := m.TestRuns[testRunID]
 		if !exists {
 			return false, tfe.ErrResourceNotFound
@@ -1804,6 +1807,9 @@ func (m *MockTestRuns) Logs(ctx context.Context, moduleID tfe.RegistryModuleID, 
 }
 
 func (m *MockTestRuns) Cancel(ctx context.Context, moduleID tfe.RegistryModuleID, testRunID string) error {
+	m.Lock()
+	defer m.Unlock()
+
 	tr, exists := m.TestRuns[testRunID]
 	if !exists {
 		return tfe.ErrResourceNotFound

--- a/internal/terraform/provider_mock.go
+++ b/internal/terraform/provider_mock.go
@@ -395,15 +395,15 @@ func (p *MockProvider) PlanResourceChange(r providers.PlanResourceChangeRequest)
 
 func (p *MockProvider) ApplyResourceChange(r providers.ApplyResourceChangeRequest) (resp providers.ApplyResourceChangeResponse) {
 	p.Lock()
+	defer p.Unlock()
+
 	p.ApplyResourceChangeCalled = true
 	p.ApplyResourceChangeRequest = r
 
 	if !p.ConfigureProviderCalled {
-		p.Unlock()
 		resp.Diagnostics = resp.Diagnostics.Append(fmt.Errorf("Configure not called before ApplyResourceChange %q", r.TypeName))
 		return resp
 	}
-	p.Unlock()
 
 	if p.ApplyResourceChangeFn != nil {
 		return p.ApplyResourceChangeFn(r)


### PR DESCRIPTION
This PR fixes some race conditions within our testing TFC client and testing provider. See here for an example failure: https://github.com/hashicorp/terraform/actions/runs/6961590415/job/18943516900

I ran this with `go test -race ./...`and everything passed with no deadlocks so seems safe.

