### PR TITLE
Document negative host numbers for `cidrhost()` function

### DIFF
--- a/website/docs/language/functions/cidrhost.mdx
+++ b/website/docs/language/functions/cidrhost.mdx
@@ -19,7 +19,11 @@ cidrhost(prefix, hostnum)
 
 `hostnum` is a whole number that can be represented as a binary integer with
 no more than the number of digits remaining in the address after the given
-prefix. For more details on how this function interprets CIDR prefixes and
+prefix. If `hostnum` is negative, the count starts from the end of the range.
+For example, `cidrhost("10.0.0.0/8", 2)` returns `10.0.0.2` and
+`cidrhost("10.0.0.0/8", -2)` returns `10.255.255.254`.
+
+For more details on how this function interprets CIDR prefixes and
 populates host numbers, see the worked example for
 [`cidrsubnet`](/terraform/language/functions/cidrsubnet).
 


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->
This feature was introduced (and documented) in https://github.com/hashicorp/terraform/pull/13765, but it seems that its documentation was not carried over when the docs were reorganized.
<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.6.x

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

### BUG FIXES

<!--

Write a short description of the user-facing change. Examples:

- `terraform show -json`: Fixed crash with sensitive set values.
- When rendering a diff, Terraform now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 

- Document negative host numbers for `cidrhost()` function
