### PR TITLE
namedvals: A new package for tracking the results of "named values"

### DIFF
--- a/internal/addrs/partial_expanded.go
+++ b/internal/addrs/partial_expanded.go
@@ -155,7 +155,7 @@ func (pem PartialExpandedModule) String() string {
 		buf.WriteString(pem.expandedPrefix.String())
 	}
 	for i, callName := range pem.unexpandedSuffix {
-		if i > 0 || len(pem.unexpandedSuffix) != 0 {
+		if i > 0 || len(pem.expandedPrefix) != 0 {
 			buf.WriteByte('.')
 		}
 		buf.WriteString("module.")

--- a/internal/namedvals/doc.go
+++ b/internal/namedvals/doc.go
@@ -1,0 +1,7 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+// Package namedvals has container types to help with modelling the gradual
+// evaluation of local values (input variable values, local values, output
+// values) during a graph walk.
+package namedvals

--- a/internal/namedvals/state.go
+++ b/internal/namedvals/state.go
@@ -1,0 +1,108 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package namedvals
+
+import (
+	"sync"
+
+	"github.com/zclconf/go-cty/cty"
+
+	"github.com/hashicorp/terraform/internal/addrs"
+)
+
+// State is the main type in this package, representing the current state of
+// evaluation that can be mutated as Terraform Core visits different graph
+// nodes and then queried to find values that were already resolved earlier
+// in the graph walk.
+//
+// Instances of this type are concurrency-safe so callers do not need to
+// implement their own locking when reading and writing from named value
+// state.
+type State struct {
+	mu sync.Mutex
+
+	variables inputVariableValues
+	locals    localValues
+	outputs   outputValues
+}
+
+func NewState() *State {
+	return &State{
+		variables: newValues[addrs.InputVariable, addrs.AbsInputVariableInstance](),
+		locals:    newValues[addrs.LocalValue, addrs.AbsLocalValue](),
+		outputs:   newValues[addrs.OutputValue, addrs.AbsOutputValue](),
+	}
+}
+
+func (s *State) SetInputVariableValue(addr addrs.AbsInputVariableInstance, val cty.Value) {
+	s.mu.Lock()
+	s.variables.SetExactResult(addr, val)
+	s.mu.Unlock()
+}
+
+func (s *State) GetInputVariableValue(addr addrs.AbsInputVariableInstance) cty.Value {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.variables.GetExactResult(addr)
+}
+
+func (s *State) SetInputVariablePlaceholder(addr addrs.InPartialExpandedModule[addrs.InputVariable], val cty.Value) {
+	s.mu.Lock()
+	s.variables.SetPlaceholderResult(addr, val)
+	s.mu.Unlock()
+}
+
+func (s *State) GetInputVariablePlaceholder(addr addrs.InPartialExpandedModule[addrs.InputVariable]) cty.Value {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.variables.GetPlaceholderResult(addr)
+}
+
+func (s *State) SetLocalValue(addr addrs.AbsLocalValue, val cty.Value) {
+	s.mu.Lock()
+	s.locals.SetExactResult(addr, val)
+	s.mu.Unlock()
+}
+
+func (s *State) GetLocalValue(addr addrs.AbsLocalValue) cty.Value {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.locals.GetExactResult(addr)
+}
+
+func (s *State) SetLocalValuePlaceholder(addr addrs.InPartialExpandedModule[addrs.LocalValue], val cty.Value) {
+	s.mu.Lock()
+	s.locals.SetPlaceholderResult(addr, val)
+	s.mu.Unlock()
+}
+
+func (s *State) GetLocalValuePlaceholder(addr addrs.InPartialExpandedModule[addrs.LocalValue]) cty.Value {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.locals.GetPlaceholderResult(addr)
+}
+
+func (s *State) SetOutputValue(addr addrs.AbsOutputValue, val cty.Value) {
+	s.mu.Lock()
+	s.outputs.SetExactResult(addr, val)
+	s.mu.Unlock()
+}
+
+func (s *State) GetOutputValue(addr addrs.AbsOutputValue) cty.Value {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.outputs.GetExactResult(addr)
+}
+
+func (s *State) SetOutputValuePlaceholder(addr addrs.InPartialExpandedModule[addrs.OutputValue], val cty.Value) {
+	s.mu.Lock()
+	s.outputs.SetPlaceholderResult(addr, val)
+	s.mu.Unlock()
+}
+
+func (s *State) GetOutputValuePlaceholder(addr addrs.InPartialExpandedModule[addrs.OutputValue]) cty.Value {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.outputs.GetPlaceholderResult(addr)
+}

--- a/internal/namedvals/state.go
+++ b/internal/namedvals/state.go
@@ -47,6 +47,12 @@ func (s *State) GetInputVariableValue(addr addrs.AbsInputVariableInstance) cty.V
 	return s.variables.GetExactResult(addr)
 }
 
+func (s *State) HasInputVariableValue(addr addrs.AbsInputVariableInstance) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.variables.HasExactResult(addr)
+}
+
 func (s *State) SetInputVariablePlaceholder(addr addrs.InPartialExpandedModule[addrs.InputVariable], val cty.Value) {
 	s.mu.Lock()
 	s.variables.SetPlaceholderResult(addr, val)
@@ -71,6 +77,12 @@ func (s *State) GetLocalValue(addr addrs.AbsLocalValue) cty.Value {
 	return s.locals.GetExactResult(addr)
 }
 
+func (s *State) HasLocalValue(addr addrs.AbsLocalValue) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.locals.HasExactResult(addr)
+}
+
 func (s *State) SetLocalValuePlaceholder(addr addrs.InPartialExpandedModule[addrs.LocalValue], val cty.Value) {
 	s.mu.Lock()
 	s.locals.SetPlaceholderResult(addr, val)
@@ -93,6 +105,12 @@ func (s *State) GetOutputValue(addr addrs.AbsOutputValue) cty.Value {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return s.outputs.GetExactResult(addr)
+}
+
+func (s *State) HasOutputValue(addr addrs.AbsOutputValue) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.outputs.HasExactResult(addr)
 }
 
 func (s *State) SetOutputValuePlaceholder(addr addrs.InPartialExpandedModule[addrs.OutputValue], val cty.Value) {

--- a/internal/namedvals/values.go
+++ b/internal/namedvals/values.go
@@ -1,0 +1,133 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package namedvals
+
+import (
+	"fmt"
+
+	"github.com/zclconf/go-cty/cty"
+
+	"github.com/hashicorp/terraform/internal/addrs"
+)
+
+// Values is a type we use internally to track values that were already
+// resolved.
+//
+// This container encapsulates the problem of dealing with placeholder values
+// in modules whose instance addresses are not yet fully known due to unknown
+// values in count or for_each. Callers can register values in module paths
+// of different levels of "known-ness" and then when queried the result will
+// be the value from the most specific registration seen so far.
+//
+// Values is not concurrency-safe, because we expect to use it only indirectly
+// through the public-facing [State] type and it should be the one to ensure
+// concurrency safety.
+type values[LocalType namedValueAddr, AbsType namedValueAddr] struct {
+	// exact are values for objects in fully-qualified module instances.
+	exact addrs.Map[AbsType, cty.Value]
+
+	// placeholder are placeholder values to use for objects under an
+	// unexpanded module prefix. These placeholders will contain known
+	// values only in positions that are guaranteed to have equal values
+	// across all module instances under a given prefix, thereby allowing
+	// similar placeholder evaluation for other objects downstream of
+	// the partially-evaluated ones.
+	//
+	// This one is more awkward because there can be conflicting placeholders
+	// for the same object at different levels of specificity, and so we'll
+	// need to scan over elements to find ones that match the most. To slightly
+	// optimize that we have the values bucketed by the static module address
+	// they belong to; maybe we'll optimize this more later if it seems like
+	// a bottleneck, but we're assuming a relatively small number of declared
+	// objects of each type in each module.
+	placeholder addrs.Map[addrs.Module, addrs.Map[addrs.InPartialExpandedModule[LocalType], cty.Value]]
+}
+
+type inputVariableValues = values[addrs.InputVariable, addrs.AbsInputVariableInstance]
+type localValues = values[addrs.LocalValue, addrs.AbsLocalValue]
+type outputValues = values[addrs.OutputValue, addrs.AbsOutputValue]
+
+// namedValueAddr describes the address behaviors we need for address types
+// we'll use with type [values] as defined above.
+type namedValueAddr interface {
+	addrs.UniqueKeyer
+	fmt.Stringer
+}
+
+func newValues[LocalType namedValueAddr, AbsType namedValueAddr]() values[LocalType, AbsType] {
+	return values[LocalType, AbsType]{
+		exact:       addrs.MakeMap[AbsType, cty.Value](),
+		placeholder: addrs.MakeMap[addrs.Module, addrs.Map[addrs.InPartialExpandedModule[LocalType], cty.Value]](),
+	}
+}
+
+func (v *values[LocalType, AbsType]) SetExactResult(addr AbsType, val cty.Value) {
+	if v.exact.Has(addr) {
+		// This is always a bug in the caller, because Terraform Core should
+		// use its graph to ensure that each value gets set exactly once and
+		// the values get registered in the correct order.
+		panic(fmt.Sprintf("value for %s was already set by an earlier caller", addr))
+	}
+	v.exact.Put(addr, val)
+}
+
+func (v *values[LocalType, AbsType]) GetExactResult(addr AbsType) cty.Value {
+	// TODO: Do we need to handle placeholder results in here too? Seems like
+	// callers should not end up holding AbsType addresses if they are dealing
+	// with unexpanded objects because they wouldn't have instance keys to
+	// fill in to the address, so assuming not for now.
+	if !v.exact.Has(addr) {
+		// This is always a bug in the caller, because Terraform Core should
+		// use its graph to ensure that each value gets set exactly once and
+		// the values get registered in the correct order.
+		panic(fmt.Sprintf("value for %s was requested before it was provided", addr))
+	}
+	return v.exact.Get(addr)
+}
+
+func (v *values[LocalType, AbsType]) SetPlaceholderResult(addr addrs.InPartialExpandedModule[LocalType], val cty.Value) {
+	modAddr := addr.Module.Module()
+	if !v.placeholder.Has(modAddr) {
+		v.placeholder.Put(modAddr, addrs.MakeMap[addrs.InPartialExpandedModule[LocalType], cty.Value]())
+	}
+	placeholders := v.placeholder.Get(modAddr)
+	if placeholders.Has(addr) {
+		// This is always a bug in the caller, because Terraform Core should
+		// use its graph to ensure that each value gets set exactly once and
+		// the values get registered in the correct order.
+		panic(fmt.Sprintf("placeholder value for %s was already set by an earlier caller", addr))
+	}
+	placeholders.Put(addr, val)
+}
+
+func (v *values[LocalType, AbsType]) GetPlaceholderResult(addr addrs.InPartialExpandedModule[LocalType]) cty.Value {
+	modAddr := addr.Module.Module()
+	if !v.placeholder.Has(modAddr) {
+		return cty.DynamicVal
+	}
+	placeholders := v.placeholder.Get(modAddr)
+
+	// We'll now search the placeholders for just the ones that match the
+	// given address, and take the one that has the longest known module prefix.
+	longestVal := cty.DynamicVal
+	longestLen := -1
+
+	for _, elem := range placeholders.Elems {
+		candidate := elem.Key
+		lenKnown := candidate.ModuleLevelsKnown()
+		if lenKnown < longestLen {
+			continue
+		}
+		if !addrs.Equivalent(candidate.Local, addr.Local) {
+			continue
+		}
+		if !candidate.Module.MatchesPartial(addr.Module) {
+			continue
+		}
+		longestVal = elem.Value
+		longestLen = lenKnown
+	}
+
+	return longestVal
+}

--- a/internal/namedvals/values.go
+++ b/internal/namedvals/values.go
@@ -72,6 +72,10 @@ func (v *values[LocalType, AbsType]) SetExactResult(addr AbsType, val cty.Value)
 	v.exact.Put(addr, val)
 }
 
+func (v *values[LocalType, AbsType]) HasExactResult(addr AbsType) bool {
+	return v.exact.Has(addr)
+}
+
 func (v *values[LocalType, AbsType]) GetExactResult(addr AbsType) cty.Value {
 	// TODO: Do we need to handle placeholder results in here too? Seems like
 	// callers should not end up holding AbsType addresses if they are dealing

--- a/internal/namedvals/values_test.go
+++ b/internal/namedvals/values_test.go
@@ -1,0 +1,91 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package namedvals
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/internal/addrs"
+	"github.com/zclconf/go-cty/cty"
+)
+
+func TestValues(t *testing.T) {
+	// The behavior of [values] is the same for all named value address types,
+	// and so we'll just use local values here as a placeholder and assume
+	// that input variables and output values would also work.
+
+	// The following addresses are taking some liberties with which combinations
+	// would actually be possible in practice with a real Terraform
+	// configuration -- unknowns and knowns cannot typically mix at the same
+	// known-expansion module prefix -- but the abstraction in this package
+	// doesn't aim to enforce those rules, and so we can expect it to be a
+	// little more flexible here than it really needs to be, as a way to
+	// reduce the amount of test setup we need.
+	childInst0 := addrs.ModuleInstance{{Name: "child", InstanceKey: addrs.IntKey(0)}}
+	childInst1 := addrs.ModuleInstance{{Name: "child", InstanceKey: addrs.IntKey(1)}}
+	childInst2 := addrs.ModuleInstance{{Name: "child", InstanceKey: addrs.IntKey(2)}}
+	childInstUnk := addrs.RootModuleInstance.UnexpandedChild(addrs.ModuleCall{Name: "child"})
+	grandchildInst0_0 := childInst0.Child("grandchild", addrs.IntKey(0))
+	grandchildInst1_unk := childInst1.UnexpandedChild(addrs.ModuleCall{Name: "grandchild"})
+	grandchildInst2_unk := childInst2.UnexpandedChild(addrs.ModuleCall{Name: "grandchild"})
+	grandchildInstUnk_unk := childInstUnk.Child(addrs.ModuleCall{Name: "grandchild"})
+
+	inRoot := addrs.LocalValue{Name: "in_root"}.Absolute(addrs.RootModuleInstance)
+	inChild0 := addrs.LocalValue{Name: "in_child"}.Absolute(childInst0)
+	inChildUnk := addrs.ObjectInPartialExpandedModule(childInstUnk, addrs.LocalValue{Name: "in_child"})
+	inGrandchild0_0 := addrs.LocalValue{Name: "in_grandchild"}.Absolute(grandchildInst0_0)
+	inGrandchild1_unk := addrs.ObjectInPartialExpandedModule(grandchildInst1_unk, addrs.LocalValue{Name: "in_grandchild"})
+	inGrandchild2_unk := addrs.ObjectInPartialExpandedModule(grandchildInst2_unk, addrs.LocalValue{Name: "in_grandchild"})
+	inGrandchildUnk_unk := addrs.ObjectInPartialExpandedModule(grandchildInstUnk_unk, addrs.LocalValue{Name: "in_grandchild"})
+
+	vals := newValues[addrs.LocalValue, addrs.AbsLocalValue]()
+	vals.SetExactResult(inRoot, cty.StringVal("in root"))
+	vals.SetExactResult(inChild0, cty.StringVal("in child 0"))
+	vals.SetExactResult(inGrandchild0_0, cty.StringVal("in grandchild 0, 0"))
+	vals.SetPlaceholderResult(inChildUnk, cty.StringVal("placeholder for all unknown instances of child"))
+	vals.SetPlaceholderResult(inGrandchild1_unk, cty.StringVal("placeholder for all unknown instances of child 1 grandchild"))
+	vals.SetPlaceholderResult(inGrandchildUnk_unk, cty.StringVal("placeholder for all unknown instances of child unknown grandchild"))
+
+	t.Run("exact values", func(t *testing.T) {
+		// Exact values require the given address to exactly match something
+		// that was registered.
+
+		if got, want := vals.GetExactResult(inRoot), cty.StringVal("in root"); !want.RawEquals(got) {
+			t.Errorf("wrong exact value for %s\ngot:  %#v\nwant: %#v", inRoot, got, want)
+		}
+		if got, want := vals.GetExactResult(inChild0), cty.StringVal("in child 0"); !want.RawEquals(got) {
+			t.Errorf("wrong exact value for %s\ngot:  %#v\nwant: %#v", inChild0, got, want)
+		}
+		if got, want := vals.GetExactResult(inGrandchild0_0), cty.StringVal("in grandchild 0, 0"); !want.RawEquals(got) {
+			t.Errorf("wrong exact value for %s\ngot:  %#v\nwant: %#v", inGrandchild0_0, got, want)
+		}
+	})
+	t.Run("placeholder values", func(t *testing.T) {
+		// Placeholder values are selected by longest-prefix pattern matching,
+		// and so we can ask both for specific prefixes we registered above
+		// and for more specific prefixes that we didn't register but yet
+		// still match a less-specific address.
+
+		if got, want := vals.GetPlaceholderResult(inChildUnk), cty.StringVal("placeholder for all unknown instances of child"); !want.RawEquals(got) {
+			// This one exactly matches one of the address patterns we registered.
+			t.Errorf("wrong exact value for %s\ngot:  %#v\nwant: %#v", inChildUnk, got, want)
+		}
+		if got, want := vals.GetPlaceholderResult(inGrandchild1_unk), cty.StringVal("placeholder for all unknown instances of child 1 grandchild"); !want.RawEquals(got) {
+			// This one exactly matches one of the address patterns we registered.
+			t.Errorf("wrong exact value for %s\ngot:  %#v\nwant: %#v", inGrandchild1_unk, got, want)
+		}
+		if got, want := vals.GetPlaceholderResult(inGrandchild2_unk), cty.StringVal("placeholder for all unknown instances of child unknown grandchild"); !want.RawEquals(got) {
+			// This one falls back to the placeholder for when the child
+			// instance key isn't known, because there isn't a more specific
+			// placeholder available.
+			t.Errorf("wrong exact value for %s\ngot:  %#v\nwant: %#v", inGrandchild2_unk, got, want)
+		}
+		if got, want := vals.GetPlaceholderResult(inGrandchildUnk_unk), cty.StringVal("placeholder for all unknown instances of child unknown grandchild"); !want.RawEquals(got) {
+			// This one falls back to the placeholder for when the child
+			// instance key isn't known, because we can't know which of
+			// the more specific placeholders to select.
+			t.Errorf("wrong exact value for %s\ngot:  %#v\nwant: %#v", inGrandchildUnk_unk, got, want)
+		}
+	})
+}


### PR DESCRIPTION
Currently we have a slightly different treatment for each of the different kinds of named values, which makes it hard to generalize the implementations of their very similar behaviors.

This package should over time take ownership of the problem of tracking all three kinds of named value during a graph walk, with the main modules runtime copying the relevant subset of values out into the plan and state data structures as needed, while letting `namedvals.State` be the authority on all of their values for evaluation purposes.

Nothing is using this yet, though. In future PRs I'm planning to carefully swap out our existing mechanisms for tracking these in the `terraform` package to use `namedvals.State` instead. That will initially use only the "exact" value tracking, because that's all the modules runtime knows how to deal with right now, but then afterwards we'll extend it to also register and make use of placeholders for partially-expanded prefixes as part of solving #30937.

(This also bundles in a small number of additions and fixes for `addrs.PartialExpandedModule` that I missed when I was preparing #34289, since this series of PRs is really just me cherry-picking and tidying some work I started earlier in the year.)