### PR TITLE
Add clarification around data sources in alternate testing modules

### DIFF
--- a/website/docs/language/tests/index.mdx
+++ b/website/docs/language/tests/index.mdx
@@ -530,6 +530,10 @@ run "verify" {
 }
 ```
 
+-> **Note**: The `loader` module only uses data sources for resources created by the `setup` module, and does not load data sources based on the main configuration.
+
+The state for the main configuration is destroyed first when Terraform performs the cleanup operations after the test has completed. Any data sources in alternate modules based on the main configuration will likely error during the cleanup operation as they will attempt to be refreshed, and will return unavailable or not found errors as the underlying infrastructure has already been destroyed.
+
 ### Modules state
 
 While Terraform executes a `terraform test` command, Terraform maintains at least one, but possibly many, state files within memory for each test file.


### PR DESCRIPTION
This PR updates the documentation to reflect the discovered bug in https://github.com/hashicorp/terraform/issues/34280.

I'm adding a clarification just for 1.6 (we fixed the underlying problem in 1.7 and onwards), that data sources in alternate modules should not depend on the main configuration.