### PR TITLE
terraform test: skip destroy step for empty run blocks

### DIFF
--- a/internal/backend/local/test.go
+++ b/internal/backend/local/test.go
@@ -870,19 +870,32 @@ func (runner *TestFileRunner) cleanup(file *moduletest.File) {
 
 	var states []*TestFileState
 	for key, state := range runner.RelevantStates {
-		if state.Run == nil {
-			if state.State.Empty() {
-				// We can see a run block being empty when the state is empty if
-				// a module was only used to execute plan commands. So this is
-				// okay, and means we have nothing to cleanup so we'll just
-				// skip it.
-				continue
+
+		empty := true
+		for _, module := range state.State.Modules {
+			for _, resource := range module.Resources {
+				if resource.Addr.Resource.Mode == addrs.ManagedResourceMode {
+					empty = false
+					break
+				}
 			}
+		}
+
+		if empty {
+			// The state can be empty for a run block that just executed a plan
+			// command, or a run block that only read data sources. We'll just
+			// skip empty run blocks.
+			continue
+		}
+
+		if state.Run == nil {
 			log.Printf("[ERROR] TestFileRunner: found inconsistent run block and state file in %s for module %s", file.Name, key)
 
-			// Otherwise something bad has happened, and we have no way to
-			// recover from it. This shouldn't happen in reality, but we'll
-			// print a diagnostic instead of panicking later.
+			// The state can have a nil run block if it only executed a plan
+			// command. In which case, we shouldn't have reached here as the
+			// state should also have been empty and this will have been skipped
+			// above. If we do reach here, then something has gone badly wrong
+			// and we can't really recover from it.
 
 			var diags tfdiags.Diagnostics
 			diags = diags.Append(tfdiags.Sourceless(tfdiags.Error, "Inconsistent state", fmt.Sprintf("Found inconsistent state while cleaning up %s. This is a bug in Terraform - please report it", file.Name)))

--- a/internal/command/test_test.go
+++ b/internal/command/test_test.go
@@ -202,6 +202,10 @@ func TestTest(t *testing.T) {
 			expectedOut: "2 passed, 0 failed.",
 			code:        0,
 		},
+		"skip_destroy_on_empty": {
+			expectedOut: "3 passed, 0 failed.",
+			code:        0,
+		},
 	}
 	for name, tc := range tcs {
 		t.Run(name, func(t *testing.T) {
@@ -252,15 +256,15 @@ func TestTest(t *testing.T) {
 			output := done(t)
 
 			if code != tc.code {
-				t.Errorf("expected status code %d but got %d", tc.code, code)
+				t.Errorf("expected status code %d but got %d:\n\n%s", tc.code, code, output.All())
 			}
 
 			if !strings.Contains(output.Stdout(), tc.expectedOut) {
-				t.Errorf("output didn't contain expected string:\n\n%s", output.Stdout())
+				t.Errorf("output didn't contain expected string:\n\n%s", output.All())
 			}
 
 			if !strings.Contains(output.Stderr(), tc.expectedErr) {
-				t.Errorf("error didn't contain expected string:\n\n%s", output.Stderr())
+				t.Errorf("error didn't contain expected string:\n\n%s", output.All())
 			}
 
 			if provider.ResourceCount() != tc.expectedResourceCount {

--- a/internal/command/testdata/test/skip_destroy_on_empty/main.tf
+++ b/internal/command/testdata/test/skip_destroy_on_empty/main.tf
@@ -1,0 +1,6 @@
+
+resource "test_resource" "resource" {}
+
+output "id" {
+  value = test_resource.resource.id
+}

--- a/internal/command/testdata/test/skip_destroy_on_empty/main.tftest.hcl
+++ b/internal/command/testdata/test/skip_destroy_on_empty/main.tftest.hcl
@@ -1,0 +1,14 @@
+
+run "test" {}
+
+run "verify" {
+  module {
+    source = "./verify"
+  }
+
+  variables {
+    id = run.test.id
+  }
+}
+
+run "test_two" {}

--- a/internal/command/testdata/test/skip_destroy_on_empty/verify/main.tf
+++ b/internal/command/testdata/test/skip_destroy_on_empty/verify/main.tf
@@ -1,0 +1,8 @@
+
+variable "id" {
+  type = string
+}
+
+data "test_data_source" "resource" {
+  id = var.id
+}


### PR DESCRIPTION
This PR updates the testing framework so that it won't attempt to destroy run blocks that only contain data sources. 

This doesn't really fix the underlying issue that was exposed by #34280 and then mostly fixed in #34293, but it does mean that users that are following our tutorials and docs will not encounter that particular issue. Also, we can backport this change in a way we couldn't with the actual fix. This should make users in the 1.6 series have a slightly better time when following our docs and tutorials.

# CHANGELOG

## BUG FIXES

- `terraform test`: Stop attempting to destroy run blocks that have no actual infrastructure to destroy. This fixes an issue where attempts to destroy "verification" run blocks that load only data sources would fail if the underlying infrastructure referenced by the run blocks had already been destroyed.