### PR TITLE
backend/s3: default `use_legacy_workflow` to false, deprecate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ UPGRADE NOTES:
     The type of graph that earlier versions of Terraform produced by default is still available with explicit use of the `-type=plan` option, producing an approximation of the real dependency graph Terraform Core would use to construct a plan.
 * `terraform test`: Simplify the ordering of destroy operations during test cleanup to simple reverse run block order. ([#34293](https://github.com/hashicorp/terraform/issues/34293))
 
+* backend/s3: The `use_legacy_workflow` argument now defaults to `false`. The backend will now search for credentials in the same order as the default provider chain in the AWS SDKs and AWS CLI. To revert to the legacy credential provider chain ordering, set this value to `true`. This argument, and the ability to use the legacy workflow, is deprecated. To encourage consistency with the AWS SDKs, this argument will be removed in a future minor version.
+
 NEW FEATURES:
 
 * `terraform test`: Providers, modules, resources, and data sources can now be mocked during executions of `terraform test`. The following new blocks have been introduced within `.tftest.hcl` files:

--- a/internal/backend/remote-state/s3/backend_complete_test.go
+++ b/internal/backend/remote-state/s3/backend_complete_test.go
@@ -206,8 +206,7 @@ aws_secret_access_key = ProfileSharedCredentialsSecretKey
 
 		"environment AWS_ACCESS_KEY_ID does not override config Profile": {
 			config: map[string]any{
-				"profile":             "SharedCredentialsProfile",
-				"use_legacy_workflow": false,
+				"profile": "SharedCredentialsProfile",
 			},
 			EnvironmentVariables: map[string]string{
 				"AWS_ACCESS_KEY_ID":     servicemocks.MockEnvAccessKey,
@@ -235,7 +234,8 @@ aws_secret_access_key = ProfileSharedCredentialsSecretKey
 
 		"environment AWS_ACCESS_KEY_ID overrides config Profile in legacy workflow": { // Legacy behavior
 			config: map[string]any{
-				"profile": "SharedCredentialsProfile",
+				"profile":             "SharedCredentialsProfile",
+				"use_legacy_workflow": true,
 			},
 			EnvironmentVariables: map[string]string{
 				"AWS_ACCESS_KEY_ID":     servicemocks.MockEnvAccessKey,
@@ -254,7 +254,11 @@ aws_secret_access_key = DefaultSharedCredentialsSecretKey
 aws_access_key_id = ProfileSharedCredentialsAccessKey
 aws_secret_access_key = ProfileSharedCredentialsSecretKey
 `,
-			ValidateDiags: ExpectNoDiags,
+			ValidateDiags: ExpectDiagMatching(
+				tfdiags.Warning,
+				equalsMatcher("Deprecated Parameter"),
+				ignoreMatcher{},
+			),
 		},
 
 		"environment AWS_ACCESS_KEY_ID": {

--- a/website/docs/language/settings/backends/s3.mdx
+++ b/website/docs/language/settings/backends/s3.mdx
@@ -197,7 +197,7 @@ The following configuration is optional:
 * `token` - (Optional) Multi-Factor Authentication (MFA) token. This can also be sourced from the `AWS_SESSION_TOKEN` environment variable.
 * `use_dualstack_endpoint` - (Optional) Force the backend to resolve endpoints with DualStack capability. Can also be set with the `AWS_USE_DUALSTACK_ENDPOINT` environment variable or in a shared config file (`use_dualstack_endpoint`).
 * `use_fips_endpoint` - (Optional) Force the backend to resolve endpoints with FIPS capability. Can also be set with the `AWS_USE_FIPS_ENDPOINT` environment variable or in a shared config file (`use_fips_endpoint`).
-* `use_legacy_workflow` - (Optional) Use the legacy authentication workflow, preferring environment variables over backend configuration. Defaults to `true`. This behavior does not align with the authentication flow of the AWS CLI or SDK's, and will be removed in the future.
+* `use_legacy_workflow` - (Optional, **Deprecated**) Use the legacy authentication workflow, preferring environment variables over backend configuration. Defaults to `false`. To encourage consistency with the default credential chain ordering of the AWS SDKs, this argument will be removed in a future minor version.
 
 #### Overriding AWS API endpoints
 

--- a/website/docs/language/upgrade-guides/index.mdx
+++ b/website/docs/language/upgrade-guides/index.mdx
@@ -136,54 +136,17 @@ The `run` block also applies or plans the main configuration by default, there i
 
 ## S3 Backend
 
-We updated the S3 backend in Terraform 1.6.0 so that it more closely matches the AWS provider configuration.
-As a result, the backend has new and deprecated fields.
-Refer to the [release notes](https://github.com/hashicorp/terraform/releases/tag/v1.6.0) for additional information. 
-
-The major deprecations are discussed here.
-Refer to the [S3 backend documentation](/terraform/language/settings/backends/s3) for information about all deprecations.
-
-We removed the configuration for assuming an IAM role from several top-level attributes and consolidated them into the `assume_role` attribute.
-
-The following example shows the configuration in Terraform 1.5.6 and older for assuming the IAM role `arn:aws:iam::123456789012:role/example` with a session name `example-session` and a session duration of 15 minutes:
+In Terraform 1.7.0 the S3 backend will begin phasing out the legacy credential chain evaluation order by defaulting `use_legacy_workflow` to `false` and deprecating the argument.
+This will bring the default behavior of the backend into alignment with the AWS SDKs and CLI.
+The legacy behavior can be preserved by setting this argument to `true`.
 
 ```hcl
 terraform {
   backend "s3" {
     # additional configuration omitted for brevity
-    role_arn                     = "arn:aws:iam::123456789012:role/example"
-    session_name                 = "example-session"
-    assume_role_duration_seconds = 900
+    use_legacy_workflow = true
   }
 }
 ```
 
-The configuration in Terraform 1.6.0 is:
-
-```hcl
-terraform {
-  backend "s3" {
-    # additional configuration omitted for brevity
-    assume_role = {
-      role_arn     = "arn:aws:iam::123456789012:role/example"
-      session_name = "example-session"
-      duration     = "15m"
-    }
-  }
-}
-```
-
-We removed the configuration for overriding AWS API endpoints from several top-level attributes and consolidated them into the `endpoints` attribute.
-The following endpoint attributes are now nested under the `endpoint` attribute:
-
-- `s3`
-- `dynamodb`
-- `iam`
-- `sts`
-
-The `endpoint` attribute replaces the following top-level attributes:
-
-- `endpoint` (for S3),
-- `dynamodb_endpoint`,
-- `iam_endpoint`
-- `sts_endpoint`
+In Terraform 1.8.0 this argument will be removed, and the S3 backend will always use the default AWS SDK for Go credential chain evaluation order.


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->
In Terraform 1.7 we'll begin phasing out the legacy credential chain evaluation order by defaulting `use_legacy_workflow` to `false` and deprecating the argument. This will bring the default behavior into alignment with the AWS SDKs and CLI. Practitioners can still preserve the legacy behavior by setting this argument to `true`. In Terraform 1.8 this argument will be removed, and the S3 backend will always use the default credential chain evaluation order from the AWS SDK for Go.

```console
% TF_ACC=1 go test -count=1 ./internal/backend/remote-state/s3/...
ok      github.com/hashicorp/terraform/internal/backend/remote-state/s3 140.736s
```

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Relates #30443

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.7.x

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

### UPGRADE NOTES 

<!--

Write a short description of the user-facing change. Examples:

- `terraform show -json`: Fixed crash with sensitive set values.
- When rendering a diff, Terraform now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 

* backend/s3: The `use_legacy_workflow` argument now defaults to `false`. The backend will now search for credentials in the same order as the default provider chain in the AWS SDKs and AWS CLI. To revert to the legacy credential provider chain ordering, set this value to `true`. This argument, and the ability to use the legacy workflow, is deprecated. To encourage consistency with the AWS SDKs, this argument will be removed in a future minor version.
