### PR TITLE
website: removed block docs

### DIFF
--- a/website/docs/cli/commands/state/rm.mdx
+++ b/website/docs/cli/commands/state/rm.mdx
@@ -18,6 +18,8 @@ to remove a binding to an existing remote object without first destroying it,
 which will effectively make Terraform "forget" the object while it continues
 to exist in the remote system.
 
+-> **Note:** Terraform v1.7.0 and later supports `removed` blocks. Unlike the `terraform state rm` command, you can use `removed` blocks to remove more than one resource at a time, and you can review removals as part of your normal plan and apply workflow. [Learn more about using `removed` blocks with resources](/terraform/language/resources/syntax#removing-resources) and [using `removed` blocks with modules](/terraform/language/modules/syntax#removing-modules).
+
 ## Usage
 
 Usage: `terraform state rm [options] ADDRESS...`

--- a/website/docs/language/modules/syntax.mdx
+++ b/website/docs/language/modules/syntax.mdx
@@ -193,3 +193,29 @@ The above selects a `resource "aws_instance" "example"` declared inside a
 Because replacing is a very disruptive action, Terraform only allows selecting
 individual resource instances. There is no syntax to force replacing _all_
 resource instances belonging to a particular module.
+
+## Removing Modules
+
+-> **Note:** The `removed` block is available in Terraform v1.7 and later. For earlier Terraform versions, you can use the [`terraform state rm` CLI command](/terraform/cli/commands/state/rm) as a separate step.
+
+To remove a module from Terraform, simply delete the module call from your Terraform configuration.
+
+By default, after you remove the `module` block, Terraform will plan to destroy any resources it is managing that were declared in that module. This is because when you remove the module call, that module's configuration is no longer included in your Terraform configuration.
+
+Sometimes you may wish to remove a module from your Terraform configuration without destroying the real infrastructure objects it manages. In this case, the resources will be removed from the [Terraform state](/terraform/language/state), but the real infrastructure objects will not be destroyed.
+
+To declare that a module was removed from Terraform configuration but that its managed objects should not be destroyed, remove the `module` block from your configuration and replace it with a `removed` block:
+
+```hcl
+removed {
+  from = module.example
+
+  lifecycle {
+    destroy = false
+  }
+}
+```
+
+The `from` argument is the address of the module you want to remove, without any instance keys (such as "module.example[1]").
+
+The `lifecycle` block is required. The `destroy` argument determines whether Terraform will attempt to destroy the objects managed by the module or not. A value of `false` means that Terraform will remove the resources from state without destroying them.

--- a/website/docs/language/resources/syntax.mdx
+++ b/website/docs/language/resources/syntax.mdx
@@ -111,6 +111,32 @@ any resource type to change the behavior of resources:
 - [`lifecycle`, for lifecycle customizations](/terraform/language/meta-arguments/lifecycle)
 - [`provisioner`, for taking extra actions after resource creation](/terraform/language/resources/provisioners/syntax)
 
+## Removing Resources
+
+-> **Note:** The `removed` block is available in Terraform v1.7 and later. For earlier Terraform versions, you can use the [`terraform state rm` CLI command](/terraform/cli/commands/state/rm) as a separate step.
+
+To remove a resource from Terraform, simply delete the `resource` block from your Terraform configuration.
+
+By default, after you remove the `resource` block, Terraform will plan to destroy any real infrastructure object managed by that resource.
+
+Sometimes you may wish to remove a resource from your Terraform configuration without destroying the real infrastructure object it manages. In this case, the resource will be removed from the [Terraform state](/terraform/language/state), but the real infrastructure object will not be destroyed.
+
+To declare that a resource was removed from Terraform configuration but that its managed object should not be destroyed, remove the `resource` block from your configuration and replace it with a `removed` block:
+
+```hcl
+removed {
+  from = aws_instance.example
+
+  lifecycle {
+    destroy = false
+  }
+}
+```
+
+The `from` argument is the address of the resource you want to remove, without any instance keys (such as "aws_instance.example[1]").
+
+The `lifecycle` block is required. The `destroy` argument determines whether Terraform will attempt to destroy the object managed by the resource or not. A value of `false` means that Terraform will remove the resource from state without destroying it.
+
 ## Custom Condition Checks
 
 You can use `precondition` and `postcondition` blocks to specify assumptions and guarantees about how the resource operates. The following example creates a precondition that checks whether the AMI is properly configured.


### PR DESCRIPTION
Config-driven remove via the `removed` block has two main applications: removing modules and removing resources. Add a section on the appropriate page for each.

Also link to the config-driven alternative on the `terraform state rm` page.

Questions:
1. Should I add something on the `removed` block to the [Language -> Modules -> Refactoring](https://developer.hashicorp.com/terraform/language/modules/develop/refactoring) page? Refactoring a module is one use case for the `removed` block, but not all use cases (in particular some future ones) can be considered refactoring. We've also used "refactoring" as synonymous with "using `moved` blocks" in some places, so this page would need some reorganisation.
2. Should there be a single page describing the syntax for the `removed` block somewhere? The IA of the docs is a little confusing to me, as some configuration constructs are given single-page manuals, while others appear only in how-to articles.