### PR TITLE
terraform console: Option to evaluate in a planned state

### DIFF
--- a/internal/command/console.go
+++ b/internal/command/console.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/backend"
 	"github.com/hashicorp/terraform/internal/command/arguments"
+	"github.com/hashicorp/terraform/internal/lang"
 	"github.com/hashicorp/terraform/internal/repl"
 	"github.com/hashicorp/terraform/internal/terraform"
 	"github.com/hashicorp/terraform/internal/tfdiags"
@@ -27,8 +28,10 @@ type ConsoleCommand struct {
 
 func (c *ConsoleCommand) Run(args []string) int {
 	args = c.Meta.process(args)
+	var evalFromPlan bool
 	cmdFlags := c.Meta.extendedFlagSet("console")
 	cmdFlags.StringVar(&c.Meta.statePath, "state", DefaultStateFilename, "path")
+	cmdFlags.BoolVar(&evalFromPlan, "plan", false, "evaluate from plan")
 	cmdFlags.Usage = func() { c.Ui.Error(c.Help()) }
 	if err := cmdFlags.Parse(args); err != nil {
 		c.Ui.Error(fmt.Sprintf("Error parsing command line flags: %s\n", err.Error()))
@@ -121,19 +124,27 @@ func (c *ConsoleCommand) Run(args []string) int {
 		ErrorWriter: os.Stderr,
 	}
 
-	evalOpts := &terraform.EvalOpts{}
-	if lr.PlanOpts != nil {
-		// the LocalRun type is built primarily to support the main operations,
-		// so the variable values end up in the "PlanOpts" even though we're
-		// not actually making a plan.
-		evalOpts.SetVariables = lr.PlanOpts.SetVariables
-	}
+	var scope *lang.Scope
+	if evalFromPlan {
+		var planDiags tfdiags.Diagnostics
+		_, scope, planDiags = lr.Core.PlanAndEval(lr.Config, lr.InputState, lr.PlanOpts)
+		diags = diags.Append(planDiags)
+	} else {
+		evalOpts := &terraform.EvalOpts{}
+		if lr.PlanOpts != nil {
+			// the LocalRun type is built primarily to support the main operations,
+			// so the variable values end up in the "PlanOpts" even though we're
+			// not actually making a plan.
+			evalOpts.SetVariables = lr.PlanOpts.SetVariables
+		}
 
-	// Before we can evaluate expressions, we must compute and populate any
-	// derived values (input variables, local values, output values)
-	// that are not stored in the persistent state.
-	scope, scopeDiags := lr.Core.Eval(lr.Config, lr.InputState, addrs.RootModuleInstance, evalOpts)
-	diags = diags.Append(scopeDiags)
+		// Before we can evaluate expressions, we must compute and populate any
+		// derived values (input variables, local values, output values)
+		// that are not stored in the persistent state.
+		var scopeDiags tfdiags.Diagnostics
+		scope, scopeDiags = lr.Core.Eval(lr.Config, lr.InputState, addrs.RootModuleInstance, evalOpts)
+		diags = diags.Append(scopeDiags)
+	}
 	if scope == nil {
 		// scope is nil if there are errors so bad that we can't even build a scope.
 		// Otherwise, we'll try to eval anyway.
@@ -144,14 +155,21 @@ func (c *ConsoleCommand) Run(args []string) int {
 	// set the ConsoleMode to true so any available console-only functions included.
 	scope.ConsoleMode = true
 
-	if diags.HasErrors() {
-		diags = diags.Append(tfdiags.SimpleWarning("Due to the problems above, some expressions may produce unexpected results."))
-	}
-
 	// Before we become interactive we'll show any diagnostics we encountered
 	// during initialization, and then afterwards the driver will manage any
 	// further diagnostics itself.
+	if diags.HasErrors() {
+		// showDiagnostics is designed to always render warnings first, but
+		// for this command we have one special warning that should always
+		// appear after everything else, to increase the chances that the
+		// user will notice it before they become confused by an incomplete
+		// expression result.
+		c.showDiagnostics(diags)
+		diags = nil
+		diags = diags.Append(tfdiags.SimpleWarning("Due to the problems above, some expressions may produce unexpected results."))
+	}
 	c.showDiagnostics(diags)
+	diags = nil
 
 	// IO Loop
 	session := &repl.Session{
@@ -208,6 +226,12 @@ Options:
 
   -state=path       Legacy option for the local backend only. See the local
                     backend's documentation for more information.
+
+  -plan             Create a new plan (as if running "terraform plan") and
+                    then evaluate expressions against its planned state,
+                    instead of evaluating against the current state.
+                    You can use this to inspect the effects of configuration
+                    changes that haven't been applied yet.
 
   -var 'foo=bar'    Set a variable in the Terraform configuration. This
                     flag can be set multiple times.

--- a/website/docs/cli/commands/console.mdx
+++ b/website/docs/cli/commands/console.mdx
@@ -52,6 +52,31 @@ If [remote state](/terraform/language/state/remote) is used by the current backe
 Terraform will read the state for the current workspace from the backend
 before evaluating any expressions.
 
+## Evaluation against a Plan
+
+By default, `terraform console` evaluates expressions against the current
+Terraform state, and so the results are typically very limited for resource
+instances that haven't yet been created by applying a plan.
+
+You can use the `-plan` option to instead generate an execution plan first,
+as if running `terraform plan`, and then evaluate against the _planned_ state
+to describe the values Terraform expects will be correct after the plan is
+applied. This typically causes a longer delay before the console prompt
+appears, but in return there will be a more complete set of values available in
+the expression scope.
+
+For well-behaved configurations the planning phase should not make any
+modifications to real remote objects, but it _is_ possible to write a
+configuration that can take significant actions while planning. For example, a
+configuration which uses the `hashicorp/external` provider's
+[`external` data source](https://registry.terraform.io/providers/hashicorp/external/latest/docs/data-sources/external)
+is likely to run the configured external command during the plan phase, which
+means it would be run by `terraform console -plan` too.
+
+We don't recommend that you write configurations that make changes during the
+plan phase. If you do write such a configuration despite that recommendation,
+take care when using the console in plan mode against that configuration.
+
 ## Examples
 
 The `terraform console` command will read the Terraform configuration in the


### PR DESCRIPTION
Previously `terraform console` always evaluated in a kinda strange context where resource instance data comes from the prior state, but other derived of values end up being calculated dynamically based on the current configuration, which is okay for simple cases but can be confusing if the configuration has changed significantly since the most recent apply, or if there haven't yet been any applied changes.

Now we'll allow an optional new mode where Terraform runs the normal plan phase (as if running `terraform plan`) and then uses the resulting _planned state_ as the basis for evaluation, allowing evaluation against a partial approximation of what the world ought to look like if these changes were applied, without having to actually apply them first.

As with the previous use of the eval walk, it's possible that an erroneous situation will still produce a partial evaluation scope, and so the console still allows evaluation against that scope but with a caveat that it might produce unexpected results. In practice this can be useful for debugging situations like when unknown values block planning of an object, to allow inspection of the values that are contributing to that blocked planning operation even though the plan is not yet complete.

---

Working on #34338 yesterday, and realizing that the test language has requirements that are a mix of some requirements from the stacks language and some requirements from `terraform console`, made me recall an old idea of allowing `terraform console` to run in the context of a generated plan as a way to have more information available in scope, and as an additional option for debugging situations where unknown values are ending up in unfortunate places.

Since that PR already did most of the work to make this possible, this PR is a little extra value-add from #34338 to fill a little gap we've been hoping to fill for a long while now.

Here's an (admittedly rather contrived) example of using `terraform console -plan` in a configuration which cannot fully complete planning due to an unknown value in an inconvenient location:

```shellsession
$ terraform console -plan
╷
│ Error: Invalid count argument
│ 
│   on deferred-changes-module-exp.tf line 6, in module "child":
│    6:   count  = length(null_resource.a.id)
│ 
│ The "count" value depends on resource attributes that cannot be determined
│ until apply, so Terraform cannot predict how many instances will be created.
│ To work around this, use the -target argument to first apply only the
│ resources that the count depends on.
╵

╷
│ Warning: Due to the problems above, some expressions may produce unexpected results.
╵

> null_resource.a
{
  "id" = (known after apply)
  "triggers" = tomap(null) /* of string */
}
>  
```

Although hopefully soon we'll finish working on #30937 and thus the question of where an unknown value originated will become less significant, I think it's still pretty helpful to be able to peek into the details of what values contributed to a plan, such as with the situations I was aiming to improve on in #34312: why is my postcondition failing? why is the provider proposing to replace this object?
