### PR TITLE
Add docs for automatic var files in test directories

### DIFF
--- a/internal/command/meta_vars.go
+++ b/internal/command/meta_vars.go
@@ -63,6 +63,22 @@ func (m *Meta) collectVariableValuesForTests(testsFilePath string) (map[string]b
 		diags = diags.Append(moreDiags)
 	}
 
+	// Also, load any variables from the *.auto.tfvars files.
+	if infos, err := os.ReadDir(testsFilePath); err == nil {
+		for _, info := range infos {
+			if info.IsDir() {
+				continue
+			}
+
+			if !isAutoVarFile(info.Name()) {
+				continue
+			}
+
+			moreDiags := m.addVarsFromFile(filepath.Join(testsFilePath, info.Name()), terraform.ValueFromAutoFile, ret)
+			diags = diags.Append(moreDiags)
+		}
+	}
+
 	// Also, no need to additionally process variables from command line,
 	// as this is also done via collectVariableValues
 

--- a/internal/command/test_test.go
+++ b/internal/command/test_test.go
@@ -201,6 +201,12 @@ func TestTest_Runs(t *testing.T) {
 			expectedOut: "2 passed, 0 failed.",
 			code:        0,
 		},
+		"auto_tfvars_in_test_dir": {
+			override:    "tfvars_in_test_dir",
+			args:        []string{"-test-directory=alternate"},
+			expectedOut: "2 passed, 0 failed.",
+			code:        0,
+		},
 		"functions_available": {
 			expectedOut: "1 passed, 0 failed.",
 			code:        0,

--- a/internal/command/testdata/test/tfvars_in_test_dir/alternate/main.tftest.hcl
+++ b/internal/command/testdata/test/tfvars_in_test_dir/alternate/main.tftest.hcl
@@ -1,0 +1,13 @@
+run "primary" {
+  assert {
+    condition     = var.foo == var.test_foo
+    error_message = "Expected: ${var.test_foo}, Actual: ${var.foo}"
+  }
+}
+
+run "secondary" {
+    assert {
+      condition     = var.fooJSON == var.test_foo_json
+      error_message = "Expected: ${var.test_foo_json}, Actual: ${var.fooJSON}"
+    }
+}

--- a/internal/command/testdata/test/tfvars_in_test_dir/alternate/vars.auto.tfvars
+++ b/internal/command/testdata/test/tfvars_in_test_dir/alternate/vars.auto.tfvars
@@ -1,0 +1,3 @@
+foo = "foo_tfvars_value"
+test_foo = "foo_tfvars_value"
+test_foo_json = "foo_json_tfvars_value"

--- a/internal/command/testdata/test/tfvars_in_test_dir/alternate/vars.auto.tfvars.json
+++ b/internal/command/testdata/test/tfvars_in_test_dir/alternate/vars.auto.tfvars.json
@@ -1,0 +1,3 @@
+{
+    "fooJSON": "foo_json_tfvars_value"
+}

--- a/website/docs/language/tests/index.mdx
+++ b/website/docs/language/tests/index.mdx
@@ -158,11 +158,17 @@ In addition to specifying variable values via test files, the Terraform `test` c
 
 You can specify values for variables across all tests with the [Command Line](/terraform/language/values/variables#variables-on-the-command-line) and with [Variable Definition Files](/terraform/language/values/variables#variable-definitions-tfvars-files).
 
+As with the main configuration direction, Terraform will automatically load any variables defined in the automatic variable files within a test directory. The automatic variable files are `terraform.tfvars`, `terraform.tfvars.json`, and any files that end with `.auto.tfvars` or `.auto.tfvars.json`.
+
+-> **Note:** Variable values loaded from the automatic variable files within a test directory will only apply to tests also defined within the same test directory. Variables defined in all other ways will apply to all tests in a given test run.
+
 This is particularly useful for using sensitive variables values and for configuring providers. Otherwise, testing files could directly expose those sensitive values.
 
 ### Variable definition precedence
 
 [Variable Definition Precedence](/terraform/language/values/variables#variable-definition-precedence) remains the same within tests, except for variable values that test files provide. The variables defined in test files take the highest precedence, overriding environment variables, variables files, or command-line input.
+
+For tests defined in a test directory, any variable values defined in automatic variable files from the test directory will override values defined in automatic variable files from the main configuration directory.
 
 ### Variable References
 


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

Update the testing docs to reflect the new functionality added in https://github.com/hashicorp/terraform/pull/34341. Now, automatic variable files defined within specific test directories will load and apply their contents to tests also defined in the same test directory.

This PR also contains a quick fix for a small piece of missing functionality that was forgotten in the previous PR.

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->


## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.7.0

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

N/A - we already have a CHANGELOG entry from https://github.com/hashicorp/terraform/pull/34341.
