### PR TITLE
Disallow saved cloud plans in VCS workspaces

### DIFF
--- a/internal/cloud/backend_plan.go
+++ b/internal/cloud/backend_plan.go
@@ -48,6 +48,16 @@ func (b *Cloud) opPlan(stopCtx, cancelCtx context.Context, op *backend.Operation
 		return nil, diags.Err()
 	}
 
+	if w.VCSRepo != nil && op.PlanOutPath != "" {
+		diags = diags.Append(tfdiags.Sourceless(
+			tfdiags.Error,
+			"Saved plans not allowed for workspaces with a VCS connection",
+			"A workspace that is connected to a VCS requires the VCS-driven workflow "+
+				"to ensure that the VCS remains the single source of truth.",
+		))
+		return nil, diags.Err()
+	}
+
 	if b.ContextOpts != nil && b.ContextOpts.Parallelism != defaultParallelism {
 		diags = diags.Append(tfdiags.Sourceless(
 			tfdiags.Error,


### PR DESCRIPTION
By convention, Terraform Cloud workspaces connected to a VCS repo should should only apply configs that come from the designated branch, to ensure that version control remains the source of truth for that infrastructure.

The cloud version of `terraform apply` already includes a guardrail for that, but we forgot to include an equivalent one for `terraform plan` when performing saved plans (which can be applied later, unlike a purely speculative plan).

We suspect that TFC actually needs some additional formal access controls around assigning configuration versions to workspaces, as everyone tends to be surprised to learn that the API doesn't actually prevent this. But in the meantime, what's good for the goose (apply command) is good for the gander (plan command), so I'm copying over the check to voluntarily enforce the VCS workflow for plans that can be applied.

## Target Release

1.6.x -- This behavior surprised folks, so it seems worthy of a backport.

## Draft CHANGELOG entry

### BUG FIXES

-  `terraform plan -out`: prevent running saved cloud plans in VCS-connected workspaces, since applying configurations from the command line in these workspaces is almost never desirable.
