### PR TITLE
core: remove import,forget targets from PlanOpts

### DIFF
--- a/internal/terraform/context_apply2_test.go
+++ b/internal/terraform/context_apply2_test.go
@@ -2483,8 +2483,7 @@ removed {
 		},
 	})
 
-	planOpts := *DefaultPlanOpts
-	plan, diags := ctx.Plan(m, state, &planOpts)
+	plan, diags := ctx.Plan(m, state, DefaultPlanOpts)
 	if diags.HasErrors() {
 		t.Fatalf("diags: %s", diags.Err())
 	}
@@ -2530,8 +2529,7 @@ removed {
 		},
 	})
 
-	planOpts := *DefaultPlanOpts
-	plan, diags := ctx.Plan(m, state, &planOpts)
+	plan, diags := ctx.Plan(m, state, DefaultPlanOpts)
 	if diags.HasErrors() {
 		t.Fatalf("diags: %s", diags.Err())
 	}


### PR DESCRIPTION
`PlanOpts` should contain only static options which are known before planning. Previous to this commit, `ctx.plan` was modifying the `opts` object, which, since it is passed via pointer, could be shared by other `ctx.plan` calls happening concurrently, producing weird behaviour.

Such weird behaviour was only noticeable during tests, in which it is common to pass a pointer to `DefaultPlanOpts`. When one test that modified `opts.forgetResources` was run at the same time as another test, `DefaultPlanOpts.forgetResources` would be populated when it shouldn't be. The real Terraform binary does not do this and `ctx.plan` is only called once per run.

One fix for the race condition would be to have `ctx.plan` take a deep copy of the entire `PlanOpts` object which it can modify without touching the caller's object. Due to the multiple nested data structures in `PlanOpts` this would be a large amount of code, with a lot of `DeepCopy` methods it would be easy to miss when adding struct fields.

Instead we just remove `ImportTargets`, `forgetResources`, and `forgetModules` from `PlanOpts`, since they did not belong there in the first place. These slices must be populated dynamically during planning once the entire config tree is available and passed to the graph builder.