### PR TITLE
chore(GitHub Actions): fix inputs of Lock Threads, and bump version

### DIFF
--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -8,16 +8,16 @@ jobs:
   lock:
     runs-on: ubuntu-latest
     steps:
-      - uses: dessant/lock-threads@be8aa5be94131386884a6da4189effda9b14aa21 # v4.0.1
+      - uses: dessant/lock-threads@1bf7ec25051fe7c00bdd17e6a7cf3d7bfb7dc771 # v5.0.1
         with:
           github-token: ${{ github.token }}
-          issue-lock-comment: >
+          issue-comment: >
             I'm going to lock this issue because it has been closed for _30 days_ ⏳. This helps our maintainers find and focus on the active issues.
 
             If you have found a problem that seems similar to this, please open a new issue and complete the issue template so we can capture all the details necessary to investigate further.
-          issue-lock-inactive-days: '30'
-          pr-lock-comment: >
+          issue-inactive-days: '30'
+          pr-comment: >
             I'm going to lock this pull request because it has been closed for _30 days_ ⏳. This helps our maintainers find and focus on the active contributions.
 
             If you have found a problem that seems related to this change, please open a new issue and complete the issue template so we can capture all the details necessary to investigate further.
-          pr-lock-inactive-days: '30'
+          pr-inactive-days: '30'


### PR DESCRIPTION
This is my first contribution to Terraform, so if I'm doing something wrong, please let me know.

# Why
- It seems like that `Lock Threads` is not working properly on GitHub Actions because of mismatch of inputs. (https://github.com/hashicorp/terraform/actions/runs/7095197463)
- Actually for example, [this PR closed over 30 days ago](https://github.com/hashicorp/terraform/issues/33919) is not locked. 
- According to their [CHANGELOG](https://github.com/dessant/lock-threads/blob/1bf7ec25051fe7c00bdd17e6a7cf3d7bfb7dc771/CHANGELOG.md?plain=1#L65-L74), some inputs are changed after `v3.0.0`.

# What
- I changed some inputs following the [CHANGELOG](https://github.com/dessant/lock-threads/blob/1bf7ec25051fe7c00bdd17e6a7cf3d7bfb7dc771/CHANGELOG.md?plain=1#L65-L74).
- Bump to latest version.