### PR TITLE
Limiting lock behavior to issues and PRs; ignoring discussions.

### DIFF
--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -10,6 +10,7 @@ jobs:
     steps:
       - uses: dessant/lock-threads@1bf7ec25051fe7c00bdd17e6a7cf3d7bfb7dc771 # v5.0.1
         with:
+          process-only: 'issues, prs'
           github-token: ${{ github.token }}
           issue-comment: >
             I'm going to lock this issue because it has been closed for _30 days_ ⏳. This helps our maintainers find and focus on the active issues.


### PR DESCRIPTION
Currently, discussions are not a feature we use on GitHub. However, we did not want to enable an automated behavior that would be difficult and confusing to track down for a future enabler of GitHub Discussions.

