### PR TITLE
cloudplugin: use terminal.Streams to write command output

### DIFF
--- a/internal/cloudplugin/cloudplugin1/grpc_client.go
+++ b/internal/cloudplugin/cloudplugin1/grpc_client.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/hashicorp/terraform/internal/cloudplugin"
 	"github.com/hashicorp/terraform/internal/cloudplugin/cloudproto1"
+	"github.com/hashicorp/terraform/internal/command/format"
 	"github.com/hashicorp/terraform/internal/terminal"
 )
 
@@ -48,7 +49,8 @@ func (c GRPCCloudClient) Execute(args []string) int {
 		}
 
 		if bytes := response.GetStdout(); len(bytes) > 0 {
-			written, err := c.streams.Print(string(bytes))
+			output := format.WordWrap(string(bytes), c.streams.Stdout.Columns())
+			written, err := c.streams.Print(output)
 			if err != nil {
 				log.Printf("[ERROR] Failed to write cloudplugin output to stdout: %s", err)
 				return 1
@@ -57,7 +59,8 @@ func (c GRPCCloudClient) Execute(args []string) int {
 				log.Printf("[ERROR] Wrote %d bytes to stdout but expected to write %d", written, len(bytes))
 			}
 		} else if bytes := response.GetStderr(); len(bytes) > 0 {
-			written, err := c.streams.Eprint(string(bytes))
+			output := format.WordWrap(string(bytes), c.streams.Stderr.Columns())
+			written, err := c.streams.Eprint(output)
 			if err != nil {
 				log.Printf("[ERROR] Failed to write cloudplugin output to stderr: %s", err)
 				return 1

--- a/internal/cloudplugin/cloudplugin1/grpc_plugin.go
+++ b/internal/cloudplugin/cloudplugin1/grpc_plugin.go
@@ -11,12 +11,15 @@ import (
 	"github.com/hashicorp/go-plugin"
 	"github.com/hashicorp/terraform/internal/cloudplugin"
 	"github.com/hashicorp/terraform/internal/cloudplugin/cloudproto1"
+	"github.com/hashicorp/terraform/internal/terminal"
 	"google.golang.org/grpc"
 )
 
 // GRPCCloudPlugin is the go-plugin implementation, but only the client
 // implementation exists in this package.
 type GRPCCloudPlugin struct {
+	Streams *terminal.Streams
+
 	plugin.GRPCPlugin
 	Impl cloudplugin.Cloud1
 }
@@ -44,5 +47,6 @@ func (p *GRPCCloudPlugin) GRPCClient(ctx context.Context, broker *plugin.GRPCBro
 	return &GRPCCloudClient{
 		client:  cloudproto1.NewCommandServiceClient(c),
 		context: ctx,
+		streams: p.Streams,
 	}, nil
 }

--- a/internal/cloudplugin/interface.go
+++ b/internal/cloudplugin/interface.go
@@ -3,10 +3,6 @@
 
 package cloudplugin
 
-import (
-	"io"
-)
-
 type Cloud1 interface {
-	Execute(args []string, stdout, stderr io.Writer) int
+	Execute(args []string) int
 }

--- a/internal/command/cloud.go
+++ b/internal/command/cloud.go
@@ -77,7 +77,9 @@ func (c *CloudCommand) realRun(args []string, stdout, stderr io.Writer) int {
 		Logger:           logging.NewCloudLogger(),
 		VersionedPlugins: map[int]plugin.PluginSet{
 			1: {
-				"cloud": &cloudplugin1.GRPCCloudPlugin{},
+				"cloud": &cloudplugin1.GRPCCloudPlugin{
+					Streams: c.Streams,
+				},
 			},
 		},
 	})
@@ -105,7 +107,7 @@ func (c *CloudCommand) realRun(args []string, stdout, stderr io.Writer) int {
 		c.Ui.Error("If more than one cloudplugin versions are available, they need to be added to the cloud command. This is a bug in Terraform.")
 		return ExitRPCError
 	}
-	return cloud1.Execute(args, stdout, stderr)
+	return cloud1.Execute(args)
 }
 
 // discover the TFC/E API service URL and version constraints.
@@ -242,7 +244,7 @@ func (c *CloudCommand) initPackagesCache() (string, error) {
 // Run runs the cloud command with the given arguments.
 func (c *CloudCommand) Run(args []string) int {
 	args = c.Meta.process(args)
-	return c.realRun(args, c.Meta.Streams.Stdout.File, c.Meta.Streams.Stderr.File)
+	return c.realRun(args, c.Streams.Stdout.File, c.Streams.Stderr.File)
 }
 
 // Help returns help text for the cloud command.

--- a/internal/command/cloud_test.go
+++ b/internal/command/cloud_test.go
@@ -22,6 +22,7 @@ import (
 	backendInit "github.com/hashicorp/terraform/internal/backend/init"
 	backendCloud "github.com/hashicorp/terraform/internal/cloud"
 	"github.com/hashicorp/terraform/internal/httpclient"
+	"github.com/hashicorp/terraform/internal/terminal"
 	"github.com/hashicorp/terraform/version"
 	"github.com/mitchellh/cli"
 )
@@ -114,7 +115,7 @@ func testDisco(s *httptest.Server) *disco.Disco {
 	return d
 }
 
-func TestCloud_withBackendConfig(t *testing.T) {
+func TestCloudCommand_withBackendConfig(t *testing.T) {
 	t.Skip("To be converted to an e2e test")
 
 	server := newCloudPluginManifestHTTPTestServer(t)
@@ -146,6 +147,8 @@ func TestCloud_withBackendConfig(t *testing.T) {
 		t.Fatalf("init failed\n%s", ui.ErrorWriter)
 	}
 
+	testStreams, done := terminal.StreamsForTesting(t)
+
 	// Run the cloud command
 	ui = cli.NewMockUi()
 	c := &CloudCommand{
@@ -153,6 +156,7 @@ func TestCloud_withBackendConfig(t *testing.T) {
 			Ui:               ui,
 			testingOverrides: metaOverridesForProvider(testProvider()),
 			Services:         disco,
+			Streams:          testStreams,
 			WorkingDir:       wd,
 		},
 	}
@@ -162,7 +166,7 @@ func TestCloud_withBackendConfig(t *testing.T) {
 		t.Fatalf("expected exit 0, got %d: \n%s", code, ui.ErrorWriter.String())
 	}
 
-	output := ui.OutputWriter.String()
+	output := done(t).Stdout()
 	expected := "Terraform Cloud Plugin v0.1.0\n\n"
 	if output != expected {
 		t.Fatalf("the output did not equal the expected string:\n%s", cmp.Diff(expected, output))
@@ -183,6 +187,8 @@ func TestCloud_withENVConfig(t *testing.T) {
 	os.Setenv("TF_CLOUD_HOSTNAME", serverURL.Host)
 	defer os.Unsetenv("TF_CLOUD_HOSTNAME")
 
+	testStreams, done := terminal.StreamsForTesting(t)
+
 	// Run the cloud command
 	ui := cli.NewMockUi()
 	c := &CloudCommand{
@@ -190,6 +196,7 @@ func TestCloud_withENVConfig(t *testing.T) {
 			Ui:               ui,
 			testingOverrides: metaOverridesForProvider(testProvider()),
 			Services:         disco,
+			Streams:          testStreams,
 			WorkingDir:       wd,
 		},
 	}
@@ -199,7 +206,7 @@ func TestCloud_withENVConfig(t *testing.T) {
 		t.Fatalf("expected exit 0, got %d: \n%s", code, ui.ErrorWriter.String())
 	}
 
-	output := ui.OutputWriter.String()
+	output := done(t).Stdout()
 	expected := "Terraform Cloud Plugin v0.1.0\n\n"
 	if output != expected {
 		t.Fatalf("the output did not equal the expected string:\n%s", cmp.Diff(expected, output))


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->
Use the command meta's `Streams` object to write output rather than pass stdout/stderr file descriptor between the command and the grpc client. This has two notable benefits:
- `terminal.Streams` is the desired interface commands should use to write output to stdout/error
- `terminal.Streams` readily provides terminal width information which allows the cloud command to word wrap output. We lose this information implicitly casting `c.Meta.Streams.Stdout.File` (and the stderr equivalent) to an `io.Writer`. 

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Fixes #

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.6.x

