### PR TITLE
refactor: Resolve struct literal uses unkeyed fields

### DIFF
--- a/internal/replacefile/replacefile_windows.go
+++ b/internal/replacefile/replacefile_windows.go
@@ -28,17 +28,17 @@ func AtomicRename(source, destination string) error {
 	// existing file.
 	srcPtr, err := syscall.UTF16PtrFromString(source)
 	if err != nil {
-		return &os.LinkError{"replace", source, destination, err}
+		return &os.LinkError{Op: "replace", Old: source, New: destination, Err: err}
 	}
 	destPtr, err := syscall.UTF16PtrFromString(destination)
 	if err != nil {
-		return &os.LinkError{"replace", source, destination, err}
+		return &os.LinkError{Op: "replace", Old: source, New: destination, Err: err}
 	}
 
 	flags := uint32(windows.MOVEFILE_REPLACE_EXISTING | windows.MOVEFILE_WRITE_THROUGH)
 	err = windows.MoveFileEx(srcPtr, destPtr, flags)
 	if err != nil {
-		return &os.LinkError{"replace", source, destination, err}
+		return &os.LinkError{Op: "replace", Old: source, New: destination, Err: err}
 	}
 	return nil
 }


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

Resolve struct literal uses unkeyed fields
<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Fixes #

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.5.x

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

### NEW FEATURES | UPGRADE NOTES | ENHANCEMENTS | BUG FIXES | EXPERIMENTS

<!--

Write a short description of the user-facing change. Examples:

- `terraform show -json`: Fixed crash with sensitive set values.
- When rendering a diff, Terraform now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 

-  
