### PR TITLE
ensure unmanaged plugins have an address

### DIFF
--- a/internal/command/meta_providers.go
+++ b/internal/command/meta_providers.go
@@ -378,20 +378,26 @@ func providerFactory(meta *providercache.CachedProvider) providers.Factory {
 
 		// store the client so that the plugin can kill the child process
 		protoVer := client.NegotiatedVersion()
-		switch protoVer {
-		case 5:
-			p := raw.(*tfplugin.GRPCProvider)
-			p.PluginClient = client
-			p.Addr = meta.Provider
-			return p, nil
-		case 6:
-			p := raw.(*tfplugin6.GRPCProvider)
-			p.PluginClient = client
-			p.Addr = meta.Provider
-			return p, nil
-		default:
-			panic("unsupported protocol version")
-		}
+		return finalizeFactoryPlugin(raw, protoVer, meta.Provider, client), nil
+	}
+}
+
+// finalizeFactoryPlugin completes the setup of a plugin dispensed by the rpc
+// client to be returned by the plugin factory.
+func finalizeFactoryPlugin(rawPlugin any, protoVersion int, addr addrs.Provider, client *plugin.Client) providers.Interface {
+	switch protoVersion {
+	case 5:
+		p := rawPlugin.(*tfplugin.GRPCProvider)
+		p.PluginClient = client
+		p.Addr = addr
+		return p
+	case 6:
+		p := rawPlugin.(*tfplugin6.GRPCProvider)
+		p.PluginClient = client
+		p.Addr = addr
+		return p
+	default:
+		panic("unsupported protocol version")
 	}
 }
 
@@ -460,13 +466,9 @@ func unmanagedProviderFactory(provider addrs.Provider, reattach *plugin.Reattach
 			// go-plugin), so client.NegotiatedVersion() always returns 0. We
 			// assume that an unmanaged provider reporting protocol version 0 is
 			// actually using proto v5 for backwards compatibility.
-			p := raw.(*tfplugin.GRPCProvider)
-			p.PluginClient = client
-			return p, nil
+			return finalizeFactoryPlugin(raw, 5, provider, client), nil
 		case 6:
-			p := raw.(*tfplugin6.GRPCProvider)
-			p.PluginClient = client
-			return p, nil
+			return finalizeFactoryPlugin(raw, 6, provider, client), nil
 		default:
 			return nil, fmt.Errorf("unsupported protocol version %d", protoVer)
 		}


### PR DESCRIPTION
Unmanaged plugins use a slightly different factory function which was missed when adding the address to the plugin struct. This made little difference in most cases, but now with the new global schema cache it would prevent the plugin's schema from being cached due to lack of a key. The end result was acceptance tests for very large providers would take considerably longer due to the overhead of repeatedly generating the schema.

There is no good way to check the internals of an unmanaged provider in a unit test, but this PR puts the setup functionality in a single helper function so that unmanaged providers use the same setup codepath as the standard set of plugins.