### PR TITLE
stackstate: sensitive values are preserved when deserializing stack state

### DIFF
--- a/internal/plans/planfile/tfplan.go
+++ b/internal/plans/planfile/tfplan.go
@@ -906,6 +906,18 @@ func pathValueMarksToTfplan(pvm []cty.PathValueMarks) ([]*planproto.Path, error)
 	return ret, nil
 }
 
+// PathFromProto decodes a path to a nested attribute into a cty.Path for
+// use in tracking marked values.
+//
+// This is used by the stackstate package, which uses planproto.Path messages
+// while using a different overall container.
+func PathFromProto(path *planproto.Path) (cty.Path, error) {
+	if path == nil {
+		return nil, nil
+	}
+	return pathFromTfplan(path)
+}
+
 func pathFromTfplan(path *planproto.Path) (cty.Path, error) {
 	ret := make([]cty.PathStep, 0, len(path.Steps))
 	for _, step := range path.Steps {


### PR DESCRIPTION
Currently, sensitive values cause a permadiff because they aren't being round-tripped through state correctly - they lose their sensitivity each time they're read from state, and then Terraform plans a change to mark them as sensitive again. This change preserves sensitive marks when deserializing stack state.

I tried to write a test for this and wasn't very successful due to the fact that we don't have much integration-y testing for stacks just yet. I'd be very open to other ideas on how/where to test this change, though!

