### PR TITLE
enable use of provider functions in the Terraform language

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -52,7 +52,7 @@ require (
 	github.com/hashicorp/go-uuid v1.0.3
 	github.com/hashicorp/go-version v1.6.0
 	github.com/hashicorp/hcl v1.0.0
-	github.com/hashicorp/hcl/v2 v2.19.1
+	github.com/hashicorp/hcl/v2 v2.19.2-0.20231109190535-c964a71ca320
 	github.com/hashicorp/jsonapi v1.2.0
 	github.com/hashicorp/terraform-registry-address v0.2.0
 	github.com/hashicorp/terraform-svchost v0.1.1

--- a/go.sum
+++ b/go.sum
@@ -706,8 +706,8 @@ github.com/hashicorp/golang-lru v0.5.1 h1:0hERBMJE1eitiLkihrMvRVBYAkpHzc/J3QdDN+
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
-github.com/hashicorp/hcl/v2 v2.19.1 h1://i05Jqznmb2EXqa39Nsvyan2o5XyMowW5fnCKW5RPI=
-github.com/hashicorp/hcl/v2 v2.19.1/go.mod h1:ThLC89FV4p9MPW804KVbe/cEXoQ8NZEh+JtMeeGErHE=
+github.com/hashicorp/hcl/v2 v2.19.2-0.20231109190535-c964a71ca320 h1:XCxc/uVhiBd2uKHRCiOItsuH8RbpwvPC5Pi+LAzZDn8=
+github.com/hashicorp/hcl/v2 v2.19.2-0.20231109190535-c964a71ca320/go.mod h1:ThLC89FV4p9MPW804KVbe/cEXoQ8NZEh+JtMeeGErHE=
 github.com/hashicorp/jsonapi v1.2.0 h1:ezDCzOFsKTL+KxVQuA1rNxkIGTvZph1rNu8kT5A8trI=
 github.com/hashicorp/jsonapi v1.2.0/go.mod h1:Yog5+CPEM3c99L1CL2CFCYoSzgWm5vTU58idbRUaLik=
 github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO+LraFDTW64=

--- a/internal/command/jsonfunction/function.go
+++ b/internal/command/jsonfunction/function.go
@@ -55,9 +55,9 @@ func Marshal(f map[string]function.Function) ([]byte, tfdiags.Diagnostics) {
 	signatures := newFunctions()
 
 	for name, v := range f {
-		if name == "can" {
+		if name == "can" || name == "core::can" {
 			signatures.Signatures[name] = marshalCan(v)
-		} else if name == "try" {
+		} else if name == "try" || name == "core::try" {
 			signatures.Signatures[name] = marshalTry(v)
 		} else {
 			signature, err := marshalFunction(v)

--- a/internal/command/metadata_functions.go
+++ b/internal/command/metadata_functions.go
@@ -12,7 +12,7 @@ import (
 )
 
 var (
-	ignoredFunctions = []string{"map", "list"}
+	ignoredFunctions = []string{"map", "list", "core::map", "core::list"}
 )
 
 // MetadataFunctionsCommand is a Command implementation that prints out information

--- a/internal/lang/funcs/descriptions.go
+++ b/internal/lang/funcs/descriptions.go
@@ -3,7 +3,9 @@
 
 package funcs
 
-import "github.com/zclconf/go-cty/cty/function"
+import (
+	"github.com/zclconf/go-cty/cty/function"
+)
 
 type descriptionEntry struct {
 	// Description is a description for the function.

--- a/internal/lang/funcs/filesystem.go
+++ b/internal/lang/funcs/filesystem.go
@@ -135,7 +135,7 @@ func MakeTemplateFileFunc(baseDir string, funcsCb func() map[string]function.Fun
 		givenFuncs := funcsCb() // this callback indirection is to avoid chicken/egg problems
 		funcs := make(map[string]function.Function, len(givenFuncs))
 		for name, fn := range givenFuncs {
-			if name == "templatefile" {
+			if name == "templatefile" || name == "core::templatefile" {
 				// We stub this one out to prevent recursive calls.
 				funcs[name] = function.New(&function.Spec{
 					Params: params,

--- a/internal/lang/funcs/filesystem_test.go
+++ b/internal/lang/funcs/filesystem_test.go
@@ -152,6 +152,12 @@ func TestTemplateFile(t *testing.T) {
 			`testdata/recursive.tmpl:1,3-16: Error in function call; Call to function "templatefile" failed: cannot recursively call templatefile from inside templatefile call.`,
 		},
 		{
+			cty.StringVal("testdata/recursive_namespaced.tmpl"),
+			cty.MapValEmpty(cty.String),
+			cty.NilVal,
+			`testdata/recursive_namespaced.tmpl:1,3-22: Error in function call; Call to function "core::templatefile" failed: cannot recursively call templatefile from inside templatefile call.`,
+		},
+		{
 			cty.StringVal("testdata/list.tmpl"),
 			cty.ObjectVal(map[string]cty.Value{
 				"list": cty.ListVal([]cty.Value{
@@ -183,8 +189,10 @@ func TestTemplateFile(t *testing.T) {
 
 	templateFileFn := MakeTemplateFileFunc(".", func() map[string]function.Function {
 		return map[string]function.Function{
-			"join":         stdlib.JoinFunc,
-			"templatefile": MakeFileFunc(".", false), // just a placeholder, since templatefile itself overrides this
+			"join":               stdlib.JoinFunc,
+			"core::join":         stdlib.JoinFunc,
+			"templatefile":       MakeFileFunc(".", false), // just a placeholder, since templatefile itself overrides this
+			"core::templatefile": MakeFileFunc(".", false), // just a placeholder, since templatefile itself overrides this
 		}
 	})
 

--- a/internal/lang/funcs/testdata/recursive_namespaced.tmpl
+++ b/internal/lang/funcs/testdata/recursive_namespaced.tmpl
@@ -1,0 +1,1 @@
+${core::templatefile("recursive_namespaced.tmpl", {})}

--- a/internal/lang/functions.go
+++ b/internal/lang/functions.go
@@ -178,7 +178,8 @@ func (s *Scope) Functions() map[string]function.Function {
 		// namespaces that can serve as external extension points.
 		s.funcs = make(map[string]function.Function, len(coreFuncs)*2)
 		for name, fn := range coreFuncs {
-			s.funcs[name] = funcs.WithDescription(name, fn)
+			fn = funcs.WithDescription(name, fn)
+			s.funcs[name] = fn
 			s.funcs["core::"+name] = fn
 		}
 

--- a/internal/lang/functions.go
+++ b/internal/lang/functions.go
@@ -29,34 +29,157 @@ func (s *Scope) Functions() map[string]function.Function {
 	if s.funcs == nil {
 		s.funcs = baseFunctions(s.BaseDir)
 
-		// Then we add some functions that are only relevant when being accessed
-		// from inside a specific scope.
+		coreFuncs := map[string]function.Function{
+			"abs":              stdlib.AbsoluteFunc,
+			"abspath":          funcs.AbsPathFunc,
+			"alltrue":          funcs.AllTrueFunc,
+			"anytrue":          funcs.AnyTrueFunc,
+			"basename":         funcs.BasenameFunc,
+			"base64decode":     funcs.Base64DecodeFunc,
+			"base64encode":     funcs.Base64EncodeFunc,
+			"base64gzip":       funcs.Base64GzipFunc,
+			"base64sha256":     funcs.Base64Sha256Func,
+			"base64sha512":     funcs.Base64Sha512Func,
+			"bcrypt":           funcs.BcryptFunc,
+			"can":              tryfunc.CanFunc,
+			"ceil":             stdlib.CeilFunc,
+			"chomp":            stdlib.ChompFunc,
+			"cidrhost":         funcs.CidrHostFunc,
+			"cidrnetmask":      funcs.CidrNetmaskFunc,
+			"cidrsubnet":       funcs.CidrSubnetFunc,
+			"cidrsubnets":      funcs.CidrSubnetsFunc,
+			"coalesce":         funcs.CoalesceFunc,
+			"coalescelist":     stdlib.CoalesceListFunc,
+			"compact":          stdlib.CompactFunc,
+			"concat":           stdlib.ConcatFunc,
+			"contains":         stdlib.ContainsFunc,
+			"csvdecode":        stdlib.CSVDecodeFunc,
+			"dirname":          funcs.DirnameFunc,
+			"distinct":         stdlib.DistinctFunc,
+			"element":          stdlib.ElementFunc,
+			"endswith":         funcs.EndsWithFunc,
+			"chunklist":        stdlib.ChunklistFunc,
+			"file":             funcs.MakeFileFunc(s.BaseDir, false),
+			"fileexists":       funcs.MakeFileExistsFunc(s.BaseDir),
+			"fileset":          funcs.MakeFileSetFunc(s.BaseDir),
+			"filebase64":       funcs.MakeFileFunc(s.BaseDir, true),
+			"filebase64sha256": funcs.MakeFileBase64Sha256Func(s.BaseDir),
+			"filebase64sha512": funcs.MakeFileBase64Sha512Func(s.BaseDir),
+			"filemd5":          funcs.MakeFileMd5Func(s.BaseDir),
+			"filesha1":         funcs.MakeFileSha1Func(s.BaseDir),
+			"filesha256":       funcs.MakeFileSha256Func(s.BaseDir),
+			"filesha512":       funcs.MakeFileSha512Func(s.BaseDir),
+			"flatten":          stdlib.FlattenFunc,
+			"floor":            stdlib.FloorFunc,
+			"format":           stdlib.FormatFunc,
+			"formatdate":       stdlib.FormatDateFunc,
+			"formatlist":       stdlib.FormatListFunc,
+			"indent":           stdlib.IndentFunc,
+			"index":            funcs.IndexFunc, // stdlib.IndexFunc is not compatible
+			"join":             stdlib.JoinFunc,
+			"jsondecode":       stdlib.JSONDecodeFunc,
+			"jsonencode":       stdlib.JSONEncodeFunc,
+			"keys":             stdlib.KeysFunc,
+			"length":           funcs.LengthFunc,
+			"list":             funcs.ListFunc,
+			"log":              stdlib.LogFunc,
+			"lookup":           funcs.LookupFunc,
+			"lower":            stdlib.LowerFunc,
+			"map":              funcs.MapFunc,
+			"matchkeys":        funcs.MatchkeysFunc,
+			"max":              stdlib.MaxFunc,
+			"md5":              funcs.Md5Func,
+			"merge":            stdlib.MergeFunc,
+			"min":              stdlib.MinFunc,
+			"one":              funcs.OneFunc,
+			"parseint":         stdlib.ParseIntFunc,
+			"pathexpand":       funcs.PathExpandFunc,
+			"pow":              stdlib.PowFunc,
+			"range":            stdlib.RangeFunc,
+			"regex":            stdlib.RegexFunc,
+			"regexall":         stdlib.RegexAllFunc,
+			"replace":          funcs.ReplaceFunc,
+			"reverse":          stdlib.ReverseListFunc,
+			"rsadecrypt":       funcs.RsaDecryptFunc,
+			"sensitive":        funcs.SensitiveFunc,
+			"nonsensitive":     funcs.NonsensitiveFunc,
+			"setintersection":  stdlib.SetIntersectionFunc,
+			"setproduct":       stdlib.SetProductFunc,
+			"setsubtract":      stdlib.SetSubtractFunc,
+			"setunion":         stdlib.SetUnionFunc,
+			"sha1":             funcs.Sha1Func,
+			"sha256":           funcs.Sha256Func,
+			"sha512":           funcs.Sha512Func,
+			"signum":           stdlib.SignumFunc,
+			"slice":            stdlib.SliceFunc,
+			"sort":             stdlib.SortFunc,
+			"split":            stdlib.SplitFunc,
+			"startswith":       funcs.StartsWithFunc,
+			"strcontains":      funcs.StrContainsFunc,
+			"strrev":           stdlib.ReverseFunc,
+			"substr":           stdlib.SubstrFunc,
+			"sum":              funcs.SumFunc,
+			"textdecodebase64": funcs.TextDecodeBase64Func,
+			"textencodebase64": funcs.TextEncodeBase64Func,
+			"timestamp":        funcs.TimestampFunc,
+			"timeadd":          stdlib.TimeAddFunc,
+			"timecmp":          funcs.TimeCmpFunc,
+			"title":            stdlib.TitleFunc,
+			"tostring":         funcs.MakeToFunc(cty.String),
+			"tonumber":         funcs.MakeToFunc(cty.Number),
+			"tobool":           funcs.MakeToFunc(cty.Bool),
+			"toset":            funcs.MakeToFunc(cty.Set(cty.DynamicPseudoType)),
+			"tolist":           funcs.MakeToFunc(cty.List(cty.DynamicPseudoType)),
+			"tomap":            funcs.MakeToFunc(cty.Map(cty.DynamicPseudoType)),
+			"transpose":        funcs.TransposeFunc,
+			"trim":             stdlib.TrimFunc,
+			"trimprefix":       stdlib.TrimPrefixFunc,
+			"trimspace":        stdlib.TrimSpaceFunc,
+			"trimsuffix":       stdlib.TrimSuffixFunc,
+			"try":              tryfunc.TryFunc,
+			"upper":            stdlib.UpperFunc,
+			"urlencode":        funcs.URLEncodeFunc,
+			"uuid":             funcs.UUIDFunc,
+			"uuidv5":           funcs.UUIDV5Func,
+			"values":           stdlib.ValuesFunc,
+			"yamldecode":       ctyyaml.YAMLDecodeFunc,
+			"yamlencode":       ctyyaml.YAMLEncodeFunc,
+			"zipmap":           stdlib.ZipmapFunc,
+		}
+
+		coreFuncs["templatefile"] = funcs.MakeTemplateFileFunc(s.BaseDir, func() map[string]function.Function {
+			// The templatefile function prevents recursive calls to itself
+			// by copying this map and overwriting the "templatefile" and
+			// "core:templatefile" entries.
+			return s.funcs
+		})
 
 		if s.ConsoleMode {
 			// The type function is only available in terraform console.
-			s.funcs["type"] = funcs.TypeFunc
+			coreFuncs["type"] = funcs.TypeFunc
 		}
 
 		if !s.ConsoleMode {
 			// The plantimestamp function doesn't make sense in the terraform
 			// console.
-			s.funcs["plantimestamp"] = funcs.MakeStaticTimestampFunc(s.PlanTimestamp)
+			coreFuncs["plantimestamp"] = funcs.MakeStaticTimestampFunc(s.PlanTimestamp)
 		}
 
 		if s.PureOnly {
 			// Force our few impure functions to return unknown so that we
 			// can defer evaluating them until a later pass.
 			for _, name := range impureFunctions {
-				s.funcs[name] = function.Unpredictable(s.funcs[name])
+				coreFuncs[name] = function.Unpredictable(coreFuncs[name])
 			}
 		}
 
-		// Add a description to each function and parameter based on the
-		// contents of descriptionList.
-		// One must create a matching description entry whenever a new
-		// function is introduced.
-		for name, f := range s.funcs {
-			s.funcs[name] = funcs.WithDescription(name, f)
+		// All of the built-in functions are also available under the "core::"
+		// namespace, to distinguish from the "provider::" and "module::"
+		// namespaces that can serve as external extension points.
+		s.funcs = make(map[string]function.Function, len(coreFuncs)*2)
+		for name, fn := range coreFuncs {
+			s.funcs[name] = funcs.WithDescription(name, fn)
+			s.funcs["core::"+name] = fn
 		}
 	}
 	s.funcsLock.Unlock()

--- a/internal/lang/functions_descriptions_test.go
+++ b/internal/lang/functions_descriptions_test.go
@@ -5,28 +5,14 @@ package lang
 
 import (
 	"testing"
-
-	"github.com/hashicorp/terraform/internal/lang/funcs"
 )
 
 func TestFunctionDescriptions(t *testing.T) {
 	scope := &Scope{
 		ConsoleMode: true,
 	}
-	// This will implicitly test the parameter description count since
-	// WithNewDescriptions will panic if the number doesn't match.
-	allFunctions := scope.Functions()
-
-	// plantimestamp isn't available with ConsoleMode: true
-	expectedFunctionCount := len(funcs.DescriptionList) - 1
-
-	if len(allFunctions) != expectedFunctionCount {
-		t.Errorf("DescriptionList length expected: %d, got %d", len(allFunctions), expectedFunctionCount)
-	}
-
-	for name := range allFunctions {
-		_, ok := funcs.DescriptionList[name]
-		if !ok {
+	for name, fn := range scope.Functions() {
+		if fn.Description() == "" {
 			t.Errorf("missing DescriptionList entry for function %q", name)
 		}
 	}

--- a/internal/lang/functions_test.go
+++ b/internal/lang/functions_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -960,6 +961,10 @@ func TestFunctions(t *testing.T) {
 				`templatefile("hello.tmpl", {name = "Jodie"})`,
 				cty.StringVal("Hello, Jodie!"),
 			},
+			{
+				`core::templatefile("hello.tmpl", {name = "Namespaced Jodie"})`,
+				cty.StringVal("Hello, Namespaced Jodie!"),
+			},
 		},
 
 		"timeadd": {
@@ -1100,6 +1105,10 @@ func TestFunctions(t *testing.T) {
 				`upper("hello")`,
 				cty.StringVal("HELLO"),
 			},
+			{
+				`core::upper("hello")`,
+				cty.StringVal("HELLO"),
+			},
 		},
 
 		"urlencode": {
@@ -1207,6 +1216,11 @@ func TestFunctions(t *testing.T) {
 			delete(allFunctions, impureFunc)
 		}
 		for f := range scope.Functions() {
+			if strings.Contains(f, "::") {
+				// Only non-namespaced functions are absolutely required to
+				// have at least one test. (Others _may_ have tests.)
+				continue
+			}
 			if _, ok := tests[f]; !ok {
 				t.Errorf("Missing test for function %s\n", f)
 			}

--- a/internal/lang/scope.go
+++ b/internal/lang/scope.go
@@ -54,6 +54,14 @@ type Scope struct {
 	// then differ during apply.
 	PureOnly bool
 
+	// ExternalFuncs specifies optional additional functions contributed by
+	// components outside of Terraform Core.
+	//
+	// Do not modify anything this field refers to after constructing a
+	// Scope value; Scope methods may derive and cache other data from
+	// this data structure and will assume this entire structure is immutable.
+	ExternalFuncs ExternalFuncs
+
 	funcs     map[string]function.Function
 	funcsLock sync.Mutex
 

--- a/internal/provider-simple-v6/provider.go
+++ b/internal/provider-simple-v6/provider.go
@@ -47,7 +47,25 @@ func Provider() providers.Interface {
 				"simple_resource": simpleResource,
 			},
 			ServerCapabilities: providers.ServerCapabilities{
-				PlanDestroy: true,
+				PlanDestroy:               true,
+				GetProviderSchemaOptional: true,
+			},
+			Functions: map[string]providers.FunctionDecl{
+				"noop": providers.FunctionDecl{
+					Parameters: []providers.FunctionParam{
+						{
+							Name:               "noop",
+							Type:               cty.DynamicPseudoType,
+							AllowNullValue:     true,
+							AllowUnknownValues: true,
+							Description:        "any value",
+							DescriptionKind:    configschema.StringPlain,
+						},
+					},
+					ReturnType:      cty.DynamicPseudoType,
+					Description:     "noop takes any single argument and returns the same value",
+					DescriptionKind: configschema.StringPlain,
+				},
 			},
 		},
 	}
@@ -146,9 +164,13 @@ func (s simple) ReadDataSource(req providers.ReadDataSourceRequest) (resp provid
 }
 
 func (s simple) CallFunction(req providers.CallFunctionRequest) (resp providers.CallFunctionResponse) {
-	// Our schema doesn't include any functions, so it should be impossible
-	// to get in here.
-	panic("CallFunction on provider that didn't declare any functions")
+	if req.FunctionName != "noop" {
+		resp.Diagnostics = resp.Diagnostics.Append(fmt.Errorf("CallFunction for undefined function %q", req.FunctionName))
+		return resp
+	}
+
+	resp.Result = req.Arguments[0]
+	return resp
 }
 
 func (s simple) Close() error {

--- a/internal/terraform/context_functions_test.go
+++ b/internal/terraform/context_functions_test.go
@@ -1,0 +1,79 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package terraform
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/hashicorp/terraform/internal/addrs"
+	"github.com/hashicorp/terraform/internal/plans"
+	"github.com/hashicorp/terraform/internal/providers"
+	"github.com/hashicorp/terraform/internal/states"
+	"github.com/zclconf/go-cty/cty"
+)
+
+func TestContext2Plan_providerFunctionBasic(t *testing.T) {
+	m := testModuleInline(t, map[string]string{
+		"main.tf": `
+terraform {
+  required_providers {
+    test = {
+      source = "registry.terraform.io/hashicorp/test"
+	}
+  }
+}
+
+locals {
+  input = {
+    key = "value"
+  }
+
+  expected = {
+    key = "value"
+  }
+}
+
+output "noop_equals" {
+  // The false branch will fail to evaluate entirely if our condition doesn't
+  // hold true. This is not a normal way to check a condition, but it's been
+  // seen in the wild, so adding it here for variety.
+  value = provider::test::noop(local.input) == local.expected ? "ok" : {}["fail"]
+}
+`,
+	})
+
+	p := new(MockProvider)
+	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
+		Functions: map[string]providers.FunctionDecl{
+			"noop": providers.FunctionDecl{
+				Parameters: []providers.FunctionParam{
+					{
+						Name: "any",
+						Type: cty.DynamicPseudoType,
+					},
+				},
+				ReturnType: cty.DynamicPseudoType,
+			},
+		},
+	}
+	p.CallFunctionFn = func(req providers.CallFunctionRequest) (resp providers.CallFunctionResponse) {
+		resp.Result = req.Arguments[0]
+		return resp
+	}
+
+	ctx := testContext2(t, &ContextOpts{
+		Providers: map[addrs.Provider]providers.Factory{
+			addrs.NewDefaultProvider("test"): testProviderFuncFixed(p),
+		},
+	})
+
+	plan, diags := ctx.Plan(m, states.NewState(), SimplePlanOpts(plans.NormalMode, testInputValuesUnset(m.Module.Variables)))
+	assertNoErrors(t, diags)
+
+	// there is exactly one output, which is a dynamically typed string
+	if !bytes.Equal([]byte("\x92\xc4\b\"string\"\xa2ok"), plan.Changes.Outputs[0].After) {
+		t.Fatalf("got output dynamic value of %q", plan.Changes.Outputs[0].After)
+	}
+}

--- a/internal/terraform/eval_context.go
+++ b/internal/terraform/eval_context.go
@@ -94,8 +94,8 @@ type EvalContext interface {
 	// InitProvisioner.
 	ProvisionerSchema(string) (*configschema.Block, error)
 
-	// CloseProvisioner closes all provisioner plugins.
-	CloseProvisioners() error
+	// ClosePlugins closes all cached provisioner and provider plugins.
+	ClosePlugins() error
 
 	// EvaluateBlock takes the given raw configuration block and associated
 	// schema and evaluates it to produce a value of an object type that

--- a/internal/terraform/eval_context_builtin.go
+++ b/internal/terraform/eval_context_builtin.go
@@ -443,7 +443,7 @@ func (ctx *BuiltinEvalContext) EvaluationScope(self addrs.Referenceable, source 
 		InstanceKeyData: keyData,
 		Operation:       ctx.Evaluator.Operation,
 	}
-	scope := ctx.Evaluator.Scope(data, self, source, lang.ExternalFuncs{})
+	scope := ctx.Evaluator.Scope(data, self, source, ctx.evaluationExternalFunctions())
 
 	// ctx.PathValue is the path of the module that contains whatever
 	// expression the caller will be trying to evaluate, so this will

--- a/internal/terraform/eval_context_builtin.go
+++ b/internal/terraform/eval_context_builtin.go
@@ -430,7 +430,7 @@ func (ctx *BuiltinEvalContext) EvaluationScope(self addrs.Referenceable, source 
 		InstanceKeyData: keyData,
 		Operation:       ctx.Evaluator.Operation,
 	}
-	scope := ctx.Evaluator.Scope(data, self, source)
+	scope := ctx.Evaluator.Scope(data, self, source, lang.ExternalFuncs{})
 
 	// ctx.PathValue is the path of the module that contains whatever
 	// expression the caller will be trying to evaluate, so this will

--- a/internal/terraform/eval_context_builtin.go
+++ b/internal/terraform/eval_context_builtin.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/zclconf/go-cty/cty"
+	"github.com/zclconf/go-cty/cty/function"
 
 	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/checks"
@@ -67,6 +68,7 @@ type BuiltinEvalContext struct {
 	Hooks                 []Hook
 	InputValue            UIInput
 	ProviderCache         map[string]providers.Interface
+	ProviderFuncCache     map[string]providers.Interface
 	ProviderInputConfig   map[string]map[string]cty.Value
 	ProviderLock          *sync.Mutex
 	ProvisionerCache      map[string]provisioners.Interface
@@ -276,7 +278,7 @@ func (ctx *BuiltinEvalContext) ProvisionerSchema(n string) (*configschema.Block,
 	return ctx.Plugins.ProvisionerSchema(n)
 }
 
-func (ctx *BuiltinEvalContext) CloseProvisioners() error {
+func (ctx *BuiltinEvalContext) ClosePlugins() error {
 	var diags tfdiags.Diagnostics
 	ctx.ProvisionerLock.Lock()
 	defer ctx.ProvisionerLock.Unlock()
@@ -286,6 +288,17 @@ func (ctx *BuiltinEvalContext) CloseProvisioners() error {
 		if err != nil {
 			diags = diags.Append(fmt.Errorf("provisioner.Close %s: %s", name, err))
 		}
+		delete(ctx.ProvisionerCache, name)
+	}
+
+	ctx.ProviderLock.Lock()
+	defer ctx.ProviderLock.Unlock()
+	for name, prov := range ctx.ProviderFuncCache {
+		err := prov.Close()
+		if err != nil {
+			diags = diags.Append(fmt.Errorf("provider.Close %s: %s", name, err))
+		}
+		delete(ctx.ProviderFuncCache, name)
 	}
 
 	return diags.Err()
@@ -443,6 +456,75 @@ func (ctx *BuiltinEvalContext) EvaluationScope(self addrs.Referenceable, source 
 		scope.SetActiveExperiments(mc.Module.ActiveExperiments)
 	}
 	return scope
+}
+
+// evaluationExternalFunctions is a helper for method EvaluationScope which
+// determines the set of external functions that should be available for
+// evaluation in this EvalContext, based on declarations in the configuration.
+func (ctx *BuiltinEvalContext) evaluationExternalFunctions() lang.ExternalFuncs {
+	// The set of functions in scope includes the functions contributed by
+	// every provider that the current module has as a requirement.
+	//
+	// We expose them under the local name for each provider that was selected
+	// by the module author.
+	ret := lang.ExternalFuncs{}
+
+	cfg := ctx.Evaluator.Config.DescendentForInstance(ctx.Path())
+	if cfg == nil {
+		// It's weird to not have a configuration by this point, but we'll
+		// tolerate it for robustness and just return no functions at all.
+		return ret
+	}
+	if cfg.Module.ProviderRequirements == nil {
+		// A module with no provider requirements can't have any
+		// provider-contributed functions.
+		return ret
+	}
+
+	reqs := cfg.Module.ProviderRequirements.RequiredProviders
+	ret.Provider = make(map[string]map[string]function.Function, len(reqs))
+	for localName, req := range reqs {
+		providerAddr := req.Type
+		funcDecls, err := ctx.Plugins.ProviderFunctionDecls(providerAddr)
+		if err != nil {
+			// If a particular provider can't return schema then we'll catch
+			// it in plenty other places where it's more reasonable for us
+			// to return an error, so here we'll just treat it as having
+			// no functions.
+			log.Printf("[WARN] Error loading schema for %s to determine its functions: %s", providerAddr, err)
+			continue
+		}
+
+		ret.Provider[localName] = make(map[string]function.Function, len(funcDecls))
+		funcs := ret.Provider[localName]
+		for name, decl := range funcDecls {
+			funcs[name] = decl.BuildFunction(name, func() (providers.Interface, error) {
+				return ctx.functionProvider(providerAddr)
+			})
+		}
+	}
+
+	return ret
+}
+
+// functionProvider fetches a running provider instance for evaluating
+// functions from the cache, or starts a new instance and adds it to the cache.
+func (ctx *BuiltinEvalContext) functionProvider(addr addrs.Provider) (providers.Interface, error) {
+	ctx.ProviderLock.Lock()
+	defer ctx.ProviderLock.Unlock()
+
+	p, ok := ctx.ProviderFuncCache[addr.String()]
+	if ok {
+		return p, nil
+	}
+
+	log.Printf("[TRACE] starting function provider instance for %s", addr)
+	p, err := ctx.Plugins.NewProviderInstance(addr)
+	if err == nil {
+		ctx.ProviderFuncCache[addr.String()] = p
+	}
+
+	return p, err
 }
 
 func (ctx *BuiltinEvalContext) Path() addrs.ModuleInstance {

--- a/internal/terraform/eval_context_mock.go
+++ b/internal/terraform/eval_context_mock.go
@@ -82,7 +82,7 @@ type MockEvalContext struct {
 	ProvisionerSchemaSchema *configschema.Block
 	ProvisionerSchemaError  error
 
-	CloseProvisionersCalled bool
+	ClosePluginsCalled bool
 
 	EvaluateBlockCalled     bool
 	EvaluateBlockBody       hcl.Body
@@ -231,8 +231,8 @@ func (c *MockEvalContext) ProvisionerSchema(n string) (*configschema.Block, erro
 	return c.ProvisionerSchemaSchema, c.ProvisionerSchemaError
 }
 
-func (c *MockEvalContext) CloseProvisioners() error {
-	c.CloseProvisionersCalled = true
+func (c *MockEvalContext) ClosePlugins() error {
+	c.ClosePluginsCalled = true
 	return nil
 }
 

--- a/internal/terraform/evaluate.go
+++ b/internal/terraform/evaluate.go
@@ -68,7 +68,7 @@ type Evaluator struct {
 // If the "self" argument is nil then the "self" object is not available
 // in evaluated expressions. Otherwise, it behaves as an alias for the given
 // address.
-func (e *Evaluator) Scope(data lang.Data, self addrs.Referenceable, source addrs.Referenceable) *lang.Scope {
+func (e *Evaluator) Scope(data lang.Data, self addrs.Referenceable, source addrs.Referenceable, extFuncs lang.ExternalFuncs) *lang.Scope {
 	return &lang.Scope{
 		Data:          data,
 		ParseRef:      addrs.ParseRef,
@@ -77,6 +77,7 @@ func (e *Evaluator) Scope(data lang.Data, self addrs.Referenceable, source addrs
 		PureOnly:      e.Operation != walkApply && e.Operation != walkDestroy && e.Operation != walkEval,
 		BaseDir:       ".", // Always current working directory for now.
 		PlanTimestamp: e.PlanTimestamp,
+		ExternalFuncs: extFuncs,
 	}
 }
 

--- a/internal/terraform/evaluate_test.go
+++ b/internal/terraform/evaluate_test.go
@@ -4,7 +4,6 @@
 package terraform
 
 import (
-	"sync"
 	"testing"
 
 	"github.com/davecgh/go-spew/spew"
@@ -15,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform/internal/configs/configschema"
 	"github.com/hashicorp/terraform/internal/lang"
 	"github.com/hashicorp/terraform/internal/lang/marks"
+	"github.com/hashicorp/terraform/internal/namedvals"
 	"github.com/hashicorp/terraform/internal/plans"
 	"github.com/hashicorp/terraform/internal/providers"
 	"github.com/hashicorp/terraform/internal/states"
@@ -26,6 +26,7 @@ func TestEvaluatorGetTerraformAttr(t *testing.T) {
 		Meta: &ContextMeta{
 			Env: "foo",
 		},
+		NamedValues: namedvals.NewState(),
 	}
 	data := &evaluationStateData{
 		Evaluator: evaluator,
@@ -56,6 +57,7 @@ func TestEvaluatorGetPathAttr(t *testing.T) {
 				SourceDir: "bar/baz",
 			},
 		},
+		NamedValues: namedvals.NewState(),
 	}
 	data := &evaluationStateData{
 		Evaluator: evaluator,
@@ -156,6 +158,14 @@ func TestEvaluatorGetOutputValue(t *testing.T) {
 // This particularly tests that a sensitive attribute in config
 // results in a value that has a "sensitive" cty Mark
 func TestEvaluatorGetInputVariable(t *testing.T) {
+	namedValues := namedvals.NewState()
+	namedValues.SetInputVariableValue(
+		addrs.RootModuleInstance.InputVariable("some_var"), cty.StringVal("bar"),
+	)
+	namedValues.SetInputVariableValue(
+		addrs.RootModuleInstance.InputVariable("some_other_var"), cty.StringVal("boop").Mark(marks.Sensitive),
+	)
+
 	evaluator := &Evaluator{
 		Meta: &ContextMeta{
 			Env: "foo",
@@ -181,13 +191,7 @@ func TestEvaluatorGetInputVariable(t *testing.T) {
 				},
 			},
 		},
-		VariableValues: map[string]map[string]cty.Value{
-			"": {
-				"some_var":       cty.StringVal("bar"),
-				"some_other_var": cty.StringVal("boop").Mark(marks.Sensitive),
-			},
-		},
-		VariableValuesLock: &sync.Mutex{},
+		NamedValues: namedValues,
 	}
 
 	data := &evaluationStateData{
@@ -265,7 +269,8 @@ func TestEvaluatorGetResource(t *testing.T) {
 				},
 			},
 		},
-		State: stateSync,
+		State:       stateSync,
+		NamedValues: namedvals.NewState(),
 		Plugins: schemaOnlyProvidersForTesting(map[addrs.Provider]providers.ProviderSchema{
 			addrs.NewDefaultProvider("test"): {
 				ResourceTypes: map[string]providers.Schema{
@@ -502,8 +507,9 @@ func TestEvaluatorGetResource_changes(t *testing.T) {
 				},
 			},
 		},
-		State:   stateSync,
-		Plugins: schemaOnlyProvidersForTesting(schemas.Providers),
+		State:       stateSync,
+		NamedValues: namedvals.NewState(),
+		Plugins:     schemaOnlyProvidersForTesting(schemas.Providers),
 	}
 
 	data := &evaluationStateData{
@@ -541,6 +547,10 @@ func TestEvaluatorGetModule(t *testing.T) {
 		)
 	}).SyncWrapper()
 	evaluator := evaluatorForModule(stateSync, plans.NewChanges().SyncWrapper())
+	evaluator.NamedValues.SetOutputValue(
+		addrs.OutputValue{Name: "out"}.Absolute(addrs.ModuleInstance{addrs.ModuleInstanceStep{Name: "mod"}}),
+		cty.StringVal("bar").Mark(marks.Sensitive),
+	)
 	data := &evaluationStateData{
 		Evaluator: evaluator,
 	}
@@ -554,7 +564,7 @@ func TestEvaluatorGetModule(t *testing.T) {
 		t.Errorf("unexpected diagnostics %s", spew.Sdump(diags))
 	}
 	if !got.RawEquals(want) {
-		t.Errorf("wrong result %#v; want %#v", got, want)
+		t.Errorf("wrong result\ngot:  %#v\nwant: %#v", got, want)
 	}
 
 	// Changes should override the state value
@@ -631,99 +641,8 @@ func evaluatorForModule(stateSync *states.SyncState, changesSync *plans.ChangesS
 				},
 			},
 		},
-		State:   stateSync,
-		Changes: changesSync,
-	}
-}
-
-func TestGetRunBlocks(t *testing.T) {
-	evaluator := &Evaluator{
-		AlternateStates: map[string]*evaluationStateData{
-			"zero": {
-				Evaluator: &Evaluator{
-					State: states.BuildState(func(state *states.SyncState) {
-						state.SetOutputValue(addrs.AbsOutputValue{
-							Module: addrs.RootModuleInstance,
-							OutputValue: addrs.OutputValue{
-								Name: "value",
-							},
-						}, cty.StringVal("Hello, world!"), false)
-					}).SyncWrapper(),
-					Config: &configs.Config{
-						Module: &configs.Module{
-							Outputs: map[string]*configs.Output{
-								"value": {
-									Name: "value",
-								},
-							},
-						},
-					},
-				},
-			},
-			"one": {
-				Evaluator: &Evaluator{
-					State: states.BuildState(func(state *states.SyncState) {
-						state.SetOutputValue(addrs.AbsOutputValue{
-							Module: addrs.RootModuleInstance,
-							OutputValue: addrs.OutputValue{
-								Name: "value",
-							},
-						}, cty.StringVal("Hello, universe!"), false)
-					}).SyncWrapper(),
-					Config: &configs.Config{
-						Module: &configs.Module{
-							Outputs: map[string]*configs.Output{
-								"value": {
-									Name: "value",
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-	}
-
-	data := &evaluationStateData{
-		Evaluator:       evaluator,
-		ModulePath:      nil,
-		InstanceKeyData: EvalDataForNoInstanceKey,
-	}
-
-	scope := evaluator.Scope(data, nil, nil, lang.ExternalFuncs{})
-	got, diags := scope.Data.GetRunBlock(addrs.Run{Name: "zero"}, tfdiags.SourceRange{})
-	want := cty.ObjectVal(map[string]cty.Value{
-		"value": cty.StringVal("Hello, world!"),
-	})
-
-	if diags.HasErrors() {
-		t.Fatalf("unexpected diagnostics: %s", diags.Err())
-	}
-
-	if !got.RawEquals(want) {
-		t.Errorf("\ngot: %#v\nwant: %#v", got, want)
-	}
-
-	got, diags = scope.Data.GetRunBlock(addrs.Run{Name: "one"}, tfdiags.SourceRange{})
-	want = cty.ObjectVal(map[string]cty.Value{
-		"value": cty.StringVal("Hello, universe!"),
-	})
-
-	if diags.HasErrors() {
-		t.Fatalf("unexpected diagnostics: %s", diags.Err())
-	}
-
-	if !got.RawEquals(want) {
-		t.Errorf("\ngot: %#v\nwant: %#v", got, want)
-	}
-
-	_, diags = scope.Data.GetRunBlock(addrs.Run{Name: "two"}, tfdiags.SourceRange{})
-
-	if !diags.HasErrors() {
-		t.Fatalf("expected some diags but got none")
-	}
-
-	if diags[0].Description().Summary != "Reference to unavailable run block" {
-		t.Errorf("retrieved unexpected diagnostic: %s", diags[0].Description().Summary)
+		State:       stateSync,
+		Changes:     changesSync,
+		NamedValues: namedvals.NewState(),
 	}
 }

--- a/internal/terraform/graph_walk_context.go
+++ b/internal/terraform/graph_walk_context.go
@@ -54,6 +54,7 @@ type ContextGraphWalker struct {
 	contexts           map[string]*BuiltinEvalContext
 	contextLock        sync.Mutex
 	providerCache      map[string]providers.Interface
+	providerFuncCache  map[string]providers.Interface
 	providerSchemas    map[string]providers.ProviderSchema
 	providerLock       sync.Mutex
 	provisionerCache   map[string]provisioners.Interface
@@ -102,6 +103,7 @@ func (w *ContextGraphWalker) EvalContext() EvalContext {
 		ExternalProviderConfigs: w.ExternalProviderConfigs,
 		MoveResultsValue:        w.MoveResults,
 		ProviderCache:           w.providerCache,
+		ProviderFuncCache:       w.providerFuncCache,
 		ProviderInputConfig:     w.Context.providerInputConfig,
 		ProviderLock:            &w.providerLock,
 		ProvisionerCache:        w.provisionerCache,
@@ -122,6 +124,7 @@ func (w *ContextGraphWalker) EvalContext() EvalContext {
 func (w *ContextGraphWalker) init() {
 	w.contexts = make(map[string]*BuiltinEvalContext)
 	w.providerCache = make(map[string]providers.Interface)
+	w.providerFuncCache = make(map[string]providers.Interface)
 	w.providerSchemas = make(map[string]providers.ProviderSchema)
 	w.provisionerCache = make(map[string]provisioners.Interface)
 	w.provisionerSchemas = make(map[string]*configschema.Block)

--- a/internal/terraform/node_module_expand.go
+++ b/internal/terraform/node_module_expand.go
@@ -184,8 +184,8 @@ func (n *nodeCloseModule) Execute(ctx EvalContext, op walkOperation) (diags tfdi
 	}
 
 	// If this is the root module, we are cleaning up the walk, so close
-	// any running provisioners
-	diags = diags.Append(ctx.CloseProvisioners())
+	// any running plugins
+	diags = diags.Append(ctx.ClosePlugins())
 
 	switch op {
 	case walkApply, walkDestroy:

--- a/internal/terraform/provider_mock.go
+++ b/internal/terraform/provider_mock.go
@@ -529,7 +529,7 @@ func (p *MockProvider) CallFunction(r providers.CallFunctionRequest) providers.C
 	p.CallFunctionCalled = true
 	p.CallFunctionRequest = r
 
-	if p.ReadDataSourceFn != nil {
+	if p.CallFunctionFn != nil {
 		return p.CallFunctionFn(r)
 	}
 


### PR DESCRIPTION
Enable the use of provider-defined functions within the `provider::` scope.

Providers can now implement functions which can be used from within the Terraform configuration language. The schema for each function is defined via the provider schema, using a layout similar to that of `cty` function definitions already in use internally. All provider functions found via their schemas are added to the `provider::` namespace, using the provider's local name as defined in the module's `required_providers`. This means that a `noop` function declared by the `aws` provider would be access as `provider::aws::noop()`. The use of the `::` delimiter as a function scoping mechanism was already added to the updated `hcl` package.

While providers must be trusted to ensure their functions only operate "offline", Terraform helps enforce this by only calling provider functions on an un-configured provider instance. This special provider instance will be started on demand, and cached for the remainder of the evaluation run. Having a separate provider is also required because normal resource providers have a lifecycle tied to their respective provider graph node, however function evaluation can happen from any node in the configuration so a separate instance must be waiting for any possible calls.

One important validation is not yet implemented, which is checking the purity of the function implementations. Checking for side effects of course is not possible, so again we must trust the providers implementations, but we do intend to validate the result values for consistency. 