### PR TITLE
jsonformat: render forget-only attr changes as no-op

### DIFF
--- a/internal/command/jsonformat/plan_test.go
+++ b/internal/command/jsonformat/plan_test.go
@@ -572,19 +572,22 @@ func TestResourceChange_primitiveTypes(t *testing.T) {
 			Action: plans.Forget,
 			Mode:   addrs.ManagedResourceMode,
 			Before: cty.ObjectVal(map[string]cty.Value{
-				"id": cty.StringVal("i-02ae66f368e8518a9"),
+				"id":  cty.StringVal("i-02ae66f368e8518a9"),
+				"ami": cty.StringVal("ami-123"),
 			}),
 			After: cty.NullVal(cty.EmptyObject),
 			Schema: &configschema.Block{
 				Attributes: map[string]*configschema.Attribute{
-					"id": {Type: cty.String, Computed: true},
+					"id":  {Type: cty.String, Computed: true},
+					"ami": {Type: cty.String, Optional: true},
 				},
 			},
 			RequiredReplace: cty.NewPathSet(),
 			ExpectedOutput: ` # test_instance.example will no longer be managed by Terraform, but will not be destroyed
  # (destroy = false is set in the configuration)
  . resource "test_instance" "example" {
-      - id = "i-02ae66f368e8518a9" -> null
+        id  = "i-02ae66f368e8518a9"
+        # (1 unchanged attribute hidden)
     }`,
 		},
 		"forget (deposed)": {
@@ -605,7 +608,7 @@ func TestResourceChange_primitiveTypes(t *testing.T) {
  # (left over from a partially-failed replacement of this instance)
  # (destroy = false is set in the configuration)
  . resource "test_instance" "example" {
-      - id = "i-02ae66f368e8518a9" -> null
+        id = "i-02ae66f368e8518a9"
     }`,
 		},
 		"create-then-forget": {

--- a/internal/command/jsonplan/plan.go
+++ b/internal/command/jsonplan/plan.go
@@ -87,21 +87,23 @@ type Change struct {
 	//    ["create"]
 	//    ["read"]
 	//    ["update"]
-	//    ["delete", "create"]
-	//    ["create", "delete"]
+	//    ["delete", "create"] (replace)
+	//    ["create", "delete"] (replace)
 	//    ["delete"]
 	//    ["forget"]
-	// The two "replace" actions are represented in this way to allow callers to
-	// e.g. just scan the list for "delete" to recognize all three situations
-	// where the object will be deleted, allowing for any new deletion
-	// combinations that might be added in future.
+	//    ["create", "forget"] (replace)
+	// The three "replace" actions are represented in this way to allow callers
+	// to, e.g., just scan the list for "delete" to recognize all three
+	// situations where the object will be deleted, allowing for any new
+	// deletion combinations that might be added in future.
 	Actions []string `json:"actions,omitempty"`
 
 	// Before and After are representations of the object value both before and
-	// after the action. For ["create"] and ["delete"] actions, either "before"
-	// or "after" is unset (respectively). For ["no-op"], the before and after
-	// values are identical. The "after" value will be incomplete if there are
-	// values within it that won't be known until after apply.
+	// after the action. For ["create"] and ["delete"]/["forget"] actions,
+	// either "before" or "after" is unset (respectively). For ["no-op"], the
+	// before and after values are identical. The "after" value will be
+	// incomplete if there are values within it that won't be known until after
+	// apply.
 	Before json.RawMessage `json:"before,omitempty"`
 	After  json.RawMessage `json:"after,omitempty"`
 


### PR DESCRIPTION
Previous to this change, forget-only actions (i.e. "forget", not "create then forget") would be rendered using the forget action symbol for the top-level resource, and the delete action symbol for each resource attribute, with a new value of "null". For example:

```
Terraform will perform the following actions:

 # aws_ecr_repository.this will no longer be managed by Terraform, but will not be destroyed
 # (destroy = false is set in the configuration)
 . resource "aws_ecr_repository" "this" {
      - arn                  = "arn:aws:ecr:us-east-1:634211456147:repository/delete-test" -> null
      - id                   = "delete-test" -> null
      - image_tag_mutability = "MUTABLE" -> null
      - name                 = "delete-test" -> null
      - registry_id          = "634211456147" -> null
      - repository_url       = "634211456147.dkr.ecr.us-east-1.amazonaws.com/delete-test" -> null
      - tags                 = {} -> null
      - tags_all             = {} -> null

      - encryption_configuration {
          - encryption_type = "AES256" -> null
        }

      - image_scanning_configuration {
          - scan_on_push = true -> null
        }
    }

```


This attribute rendering is identical to that for resource deletion, which might suggest to some users that Terraform plans to delete the resource, not just remove it from state.


This commit tweaks the renderer so forget-only changes render as no-ops but with the forget action symbol and resource change comment, e.g.:

```
Terraform will perform the following actions:

 # aws_ecr_repository.this will no longer be managed by Terraform, but will not be destroyed
 # (destroy = false is set in the configuration)
 . resource "aws_ecr_repository" "this" {
       id                   = "delete-test"
       # (9 unchanged attributes hidden)
    }
```

Thanks to @benjamin-lykins for the example.