### PR TITLE
refact: removed ambiguous reference from purpose of terraform state

### DIFF
--- a/website/docs/language/state/purpose.mdx
+++ b/website/docs/language/state/purpose.mdx
@@ -59,7 +59,7 @@ of dependencies within the state. Now Terraform can still determine the correct
 order for destruction from the state when you delete one or more items from
 the configuration.
 
-One way to avoid this would be for Terraform to know a required ordering
+Another way would be for Terraform to know a required ordering
 between resource types. For example, Terraform could know that servers must be
 deleted before the subnets they are a part of. The complexity for this approach
 quickly explodes, however: in addition to Terraform having to understand the

--- a/website/docs/language/state/purpose.mdx
+++ b/website/docs/language/state/purpose.mdx
@@ -59,7 +59,7 @@ of dependencies within the state. Now Terraform can still determine the correct
 order for destruction from the state when you delete one or more items from
 the configuration.
 
-Another way would be for Terraform to know a required ordering
+Terraform could take another approach to dependency order by using an underlying hierarchy of order
 between resource types. For example, Terraform could know that servers must be
 deleted before the subnets they are a part of. The complexity for this approach
 quickly explodes, however: in addition to Terraform having to understand the


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Fixes #34389

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.7.x

## Draft CHANGELOG entry

- Removed ambiguous reference from purpose of terraform state.

<!--

Choose a category, delete the others:

-->

<!--

### ENHANCEMENTS

Write a short description of the user-facing change. Examples:

- `terraform show -json`: Fixed crash with sensitive set values.
- When rendering a diff, Terraform now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.
-  Easier underderstanding
--> 


