### PR TITLE
stacks: Support sensitive component outputs

### DIFF
--- a/internal/plans/plan.go
+++ b/internal/plans/plan.go
@@ -42,6 +42,7 @@ type Plan struct {
 	UIMode Mode
 
 	VariableValues    map[string]DynamicValue
+	VariableMarks     map[string][]cty.PathValueMarks
 	Changes           *Changes
 	DriftedResources  []*ResourceInstanceChangeSrc
 	TargetAddrs       []addrs.Targetable

--- a/internal/stacks/stackruntime/helper_test.go
+++ b/internal/stacks/stackruntime/helper_test.go
@@ -110,3 +110,11 @@ func mustPlanDynamicValue(v cty.Value) plans.DynamicValue {
 	}
 	return ret
 }
+
+func mustPlanDynamicValueDynamicType(v cty.Value) plans.DynamicValue {
+	ret, err := plans.NewDynamicValue(v, cty.DynamicPseudoType)
+	if err != nil {
+		panic(err)
+	}
+	return ret
+}

--- a/internal/stacks/stackruntime/testdata/mainbundle/test/sensitive-output-as-input/sensitive-output-as-input.tf
+++ b/internal/stacks/stackruntime/testdata/mainbundle/test/sensitive-output-as-input/sensitive-output-as-input.tf
@@ -1,0 +1,8 @@
+variable "secret" {
+  type = string
+}
+
+output "result" {
+  value     = sensitive(upper(var.secret))
+  sensitive = true
+}

--- a/internal/stacks/stackruntime/testdata/mainbundle/test/sensitive-output-as-input/sensitive-output-as-input.tfstack.hcl
+++ b/internal/stacks/stackruntime/testdata/mainbundle/test/sensitive-output-as-input/sensitive-output-as-input.tfstack.hcl
@@ -1,0 +1,19 @@
+stack "sensitive" {
+  source = "../sensitive-output"
+
+  inputs = {
+  }
+}
+
+component "self" {
+  source = "./"
+
+  inputs = {
+    secret = stack.sensitive.result
+  }
+}
+
+output "result" {
+  type  = string
+  value = component.self.result
+}

--- a/internal/stacks/stackruntime/testdata/mainbundle/test/sensitive-output-nested/sensitive-output-nested.tfstack.hcl
+++ b/internal/stacks/stackruntime/testdata/mainbundle/test/sensitive-output-nested/sensitive-output-nested.tfstack.hcl
@@ -1,0 +1,11 @@
+stack "child" {
+  source = "../sensitive-output"
+
+  inputs = {
+  }
+}
+
+output "result" {
+  type  = string
+  value = stack.child.result
+}

--- a/internal/stacks/stackruntime/testdata/mainbundle/test/sensitive-output/sensitive-output.tf
+++ b/internal/stacks/stackruntime/testdata/mainbundle/test/sensitive-output/sensitive-output.tf
@@ -1,0 +1,4 @@
+output "out" {
+  value     = sensitive("secret")
+  sensitive = true
+}

--- a/internal/stacks/stackruntime/testdata/mainbundle/test/sensitive-output/sensitive-output.tfstack.hcl
+++ b/internal/stacks/stackruntime/testdata/mainbundle/test/sensitive-output/sensitive-output.tfstack.hcl
@@ -1,0 +1,10 @@
+component "self" {
+  source = "./"
+  inputs = {
+  }
+}
+
+output "result" {
+  type = string
+  value = component.self.out
+}

--- a/internal/terraform/context_apply.go
+++ b/internal/terraform/context_apply.go
@@ -202,6 +202,9 @@ func (c *Context) applyGraph(plan *plans.Plan, config *configs.Config, opts *App
 			))
 			continue
 		}
+		if pvm, ok := plan.VariableMarks[name]; ok {
+			val = val.MarkWithPaths(pvm)
+		}
 
 		variables[name] = &InputValue{
 			Value:      val,


### PR DESCRIPTION
This PR is in two parts: modifying the modules runtime to support marked input variable values, and updating the stacks runtime to use this new functionality.

The stacks runtime interacts directly with the modules runtime's planning operations, rather than through the usual CLI paths. As a result, root module input variable values can be marked as sensitive upon entry.

This PR adds support for such marked values to the modules runtime and the `plans.Plan` type. This is sufficient for stacks, which does not use the planfile serialization, but we may in future choose to serialize these decoded marks also.

Stack components can emit sensitive values as outputs, which can be consumed as inputs to other components. This PR also ensures that such values are correctly processed in order to pass their sensitivity to the modules runtime.

This PR originally targeted the unmerged `f-stacks-apply-ordering` as it depends on some of its behaviour. I've rebased it since review.

## Target Release

1.8.x