### PR TITLE
Adds autocomplete flag options to plan and apply

### DIFF
--- a/internal/command/apply.go
+++ b/internal/command/apply.go
@@ -5,6 +5,7 @@ package command
 
 import (
 	"fmt"
+	"github.com/posener/complete"
 	"strings"
 
 	"github.com/hashicorp/terraform/internal/backend"
@@ -321,6 +322,26 @@ func (c *ApplyCommand) Synopsis() string {
 	}
 
 	return "Create or update infrastructure"
+}
+
+func (c *ApplyCommand) AutocompleteArgs() complete.Predictor {
+	return complete.PredictDirs("")
+}
+
+func (c *ApplyCommand) AutocompleteFlags() complete.Flags {
+	return complete.Flags{
+		"-auto-approve":     complete.PredictNothing,
+		"-backup":           complete.PredictNothing,
+		"-compact-warnings": complete.PredictNothing,
+		"-destroy":          complete.PredictNothing,
+		"-lock":             completePredictBoolean,
+		"-lock-timeout":     complete.PredictNothing,
+		"-input":            completePredictBoolean,
+		"-no-color":         complete.PredictNothing,
+		"-parallelism":      complete.PredictNothing,
+		"-state":            complete.PredictNothing,
+		"-state-out":        complete.PredictNothing,
+	}
 }
 
 func (c *ApplyCommand) helpApply() string {

--- a/internal/command/plan.go
+++ b/internal/command/plan.go
@@ -5,6 +5,7 @@ package command
 
 import (
 	"fmt"
+	"github.com/posener/complete"
 	"strings"
 
 	"github.com/hashicorp/terraform/internal/backend"
@@ -191,6 +192,32 @@ func (c *PlanCommand) GatherVariables(opReq *backend.Operation, args *arguments.
 	opReq.Variables, diags = c.collectVariableValues()
 
 	return diags
+}
+
+func (c *PlanCommand) AutocompleteArgs() complete.Predictor {
+	return complete.PredictDirs("")
+}
+
+func (c *PlanCommand) AutocompleteFlags() complete.Flags {
+	return complete.Flags{
+		"-destroy":             complete.PredictNothing,
+		"-refresh-only":        complete.PredictNothing,
+		"-refresh":             completePredictBoolean,
+		"-replace":             complete.PredictNothing,
+		"-target":              complete.PredictNothing,
+		"-var":                 complete.PredictNothing,
+		"-var-file":            complete.PredictNothing,
+		"-compact-warnings":    complete.PredictNothing,
+		"-detailed-exitcode":   complete.PredictNothing,
+		"-generate-config-out": complete.PredictNothing,
+		"-input":               completePredictBoolean,
+		"-lock":                completePredictBoolean,
+		"-lock-timeout":        complete.PredictNothing,
+		"-no-color":            complete.PredictNothing,
+		"-out":                 complete.PredictNothing,
+		"-parallelism":         complete.PredictNothing,
+		"-state":               complete.PredictNothing,
+	}
 }
 
 func (c *PlanCommand) Help() string {


### PR DESCRIPTION
Fixes - https://github.com/hashicorp/terraform/issues/34396

Terraform plan and apply is possibly the most popular commands. This PR adds auto-complete for flag options.
When user types `terraform apply` / `terraform plan` followed by `-` the auto-complete flag options are visible to him.

Auto complete flag options created in this PR is from help section of the command.

Fixes #

## Target Release

1.6.x

## Draft CHANGELOG entry

ENHANCEMENTS

```
asheshvidyut@asheshvidyut-H2GX766V9T ~/terraform (gh-issue-34396) » ./bin/terraform apply -                                                     130 ↵
-auto-approve      -compact-warnings  -input             -lock-timeout      -parallelism       -state-out
-backup            -destroy           -lock              -no-color          -state
```

```
asheshvidyut@asheshvidyut-H2GX766V9T ~/terraform (gh-issue-34396) » ./bin/terraform plan -                                                      130 ↵
-compact-warnings     -generate-config-out  -lock-timeout         -parallelism          -replace              -var
-destroy              -input                -no-color             -refresh              -state                -var-file
-detailed-exitcode    -lock                 -out                  -refresh-only         -target
```

