### PR TITLE
refactor: removed min function and adopted go standard min

### DIFF
--- a/internal/dag/tarjan.go
+++ b/internal/dag/tarjan.go
@@ -58,13 +58,6 @@ func stronglyConnected(acct *sccAcct, g *Graph, v Vertex) int {
 	return minIdx
 }
 
-func min(a, b int) int {
-	if a <= b {
-		return a
-	}
-	return b
-}
-
 // sccAcct is used ot pass around accounting information for
 // the StronglyConnectedComponents algorithm
 type sccAcct struct {


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Min built-in functions have been added since go1.21, so unnecessary parts have been removed.

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.8.x

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

### ENHANCEMENTS 
removed min function and adopted go standard min
<!--

Write a short description of the user-facing change. Examples:

- `terraform show -json`: Fixed crash with sensitive set values.
- When rendering a diff, Terraform now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 

-  
