### PR TITLE
Cloudplugin: Pass configuration via gRPC metadata

### DIFF
--- a/internal/cloud/backend_apply.go
+++ b/internal/cloud/backend_apply.go
@@ -114,7 +114,7 @@ func (b *Cloud) opApply(stopCtx, cancelCtx context.Context, op *backend.Operatio
 		}
 
 		if !r.Actions.IsConfirmable {
-			url := runURL(b.Hostname, b.organization, op.Workspace, r.ID)
+			url := runURL(b.Hostname, b.Organization, op.Workspace, r.ID)
 			return r, unusableSavedPlanError(r.Status, url)
 		}
 
@@ -122,7 +122,7 @@ func (b *Cloud) opApply(stopCtx, cancelCtx context.Context, op *backend.Operatio
 		if b.CLI != nil {
 			b.CLI.Output(b.Colorize().Color(strings.TrimSpace(applySavedHeader) + "\n"))
 			b.CLI.Output(b.Colorize().Color(strings.TrimSpace(fmt.Sprintf(
-				runHeader, b.Hostname, b.organization, r.Workspace.Name, r.ID)) + "\n"))
+				runHeader, b.Hostname, b.Organization, r.Workspace.Name, r.ID)) + "\n"))
 		}
 	} else {
 		log.Printf("[TRACE] Running new cloud plan for apply")

--- a/internal/cloud/backend_apply_test.go
+++ b/internal/cloud/backend_apply_test.go
@@ -303,7 +303,7 @@ func TestCloud_applyWithoutPermissions(t *testing.T) {
 	// Create a named workspace without permissions.
 	w, err := b.client.Workspaces.Create(
 		context.Background(),
-		b.organization,
+		b.Organization,
 		tfe.WorkspaceCreateOptions{
 			Name: tfe.String("prod"),
 		},
@@ -343,7 +343,7 @@ func TestCloud_applyWithVCS(t *testing.T) {
 	// Create a named workspace with a VCS.
 	_, err := b.client.Workspaces.Create(
 		context.Background(),
-		b.organization,
+		b.Organization,
 		tfe.WorkspaceCreateOptions{
 			Name:    tfe.String("prod"),
 			VCSRepo: &tfe.VCSRepoOptions{},
@@ -455,7 +455,7 @@ func TestCloud_applyWithCloudPlan(t *testing.T) {
 	mockSROWorkspace(t, b, op.Workspace)
 
 	// Perform the plan before trying to apply it
-	ws, err := b.client.Workspaces.Read(context.Background(), b.organization, b.WorkspaceMapping.Name)
+	ws, err := b.client.Workspaces.Read(context.Background(), b.Organization, b.WorkspaceMapping.Name)
 	if err != nil {
 		t.Fatalf("Couldn't read workspace: %s", err)
 	}
@@ -877,7 +877,7 @@ func TestCloud_applyApprovedExternally(t *testing.T) {
 
 	wl, err := b.client.Workspaces.List(
 		ctx,
-		b.organization,
+		b.Organization,
 		nil,
 	)
 	if err != nil {
@@ -951,7 +951,7 @@ func TestCloud_applyDiscardedExternally(t *testing.T) {
 
 	wl, err := b.client.Workspaces.List(
 		ctx,
-		b.organization,
+		b.Organization,
 		nil,
 	)
 	if err != nil {
@@ -1012,7 +1012,7 @@ func TestCloud_applyWithAutoApprove(t *testing.T) {
 	// Create a named workspace that auto applies.
 	_, err := b.client.Workspaces.Create(
 		context.Background(),
-		b.organization,
+		b.Organization,
 		tfe.WorkspaceCreateOptions{
 			Name: tfe.String("prod"),
 		},
@@ -1128,7 +1128,7 @@ func TestCloud_applyWorkspaceWithoutOperations(t *testing.T) {
 	// Create a named workspace that doesn't allow operations.
 	_, err := b.client.Workspaces.Create(
 		ctx,
-		b.organization,
+		b.Organization,
 		tfe.WorkspaceCreateOptions{
 			Name: tfe.String("no-operations"),
 		},
@@ -1189,7 +1189,7 @@ func TestCloud_applyLockTimeout(t *testing.T) {
 	ctx := context.Background()
 
 	// Retrieve the workspace used to run this operation in.
-	w, err := b.client.Workspaces.Read(ctx, b.organization, b.WorkspaceMapping.Name)
+	w, err := b.client.Workspaces.Read(ctx, b.Organization, b.WorkspaceMapping.Name)
 	if err != nil {
 		t.Fatalf("error retrieving workspace: %v", err)
 	}
@@ -1679,7 +1679,7 @@ func TestCloud_applyPolicySoftFailAutoApprove(t *testing.T) {
 	// Create a named workspace that auto applies.
 	_, err := b.client.Workspaces.Create(
 		context.Background(),
-		b.organization,
+		b.Organization,
 		tfe.WorkspaceCreateOptions{
 			Name: tfe.String("prod"),
 		},
@@ -1870,7 +1870,7 @@ func TestCloud_applyVersionCheck(t *testing.T) {
 			// remote workspace
 			_, err := b.client.Workspaces.Update(
 				ctx,
-				b.organization,
+				b.Organization,
 				b.WorkspaceMapping.Name,
 				tfe.WorkspaceUpdateOptions{
 					ExecutionMode:    tfe.String(tc.executionMode),

--- a/internal/cloud/backend_common.go
+++ b/internal/cloud/backend_common.go
@@ -90,7 +90,7 @@ func (b *Cloud) waitForRun(stopCtx, cancelCtx context.Context, op *backend.Opera
 			}
 
 			// Retrieve the workspace used to run this operation in.
-			w, err = b.client.Workspaces.Read(stopCtx, b.organization, w.Name)
+			w, err = b.client.Workspaces.Read(stopCtx, b.Organization, w.Name)
 			if err != nil {
 				return nil, generalError("Failed to retrieve workspace", err)
 			}
@@ -170,7 +170,7 @@ func (b *Cloud) waitForRun(stopCtx, cancelCtx context.Context, op *backend.Opera
 			options := tfe.ReadRunQueueOptions{}
 		search:
 			for {
-				rq, err := b.client.Organizations.ReadRunQueue(stopCtx, b.organization, options)
+				rq, err := b.client.Organizations.ReadRunQueue(stopCtx, b.Organization, options)
 				if err != nil {
 					return r, generalError("Failed to retrieve queue", err)
 				}
@@ -193,7 +193,7 @@ func (b *Cloud) waitForRun(stopCtx, cancelCtx context.Context, op *backend.Opera
 			}
 
 			if position > 0 {
-				c, err := b.client.Organizations.ReadCapacity(stopCtx, b.organization)
+				c, err := b.client.Organizations.ReadCapacity(stopCtx, b.Organization)
 				if err != nil {
 					return r, generalError("Failed to retrieve capacity", err)
 				}
@@ -391,7 +391,7 @@ func (b *Cloud) checkPolicy(stopCtx, cancelCtx context.Context, op *backend.Oper
 		case tfe.PolicyHardFailed:
 			return fmt.Errorf(msgPrefix + " hard failed.")
 		case tfe.PolicySoftFailed:
-			runUrl := fmt.Sprintf(runHeader, b.Hostname, b.organization, op.Workspace, r.ID)
+			runUrl := fmt.Sprintf(runHeader, b.Hostname, b.Organization, op.Workspace, r.ID)
 
 			if op.Type == backend.OperationTypePlan || op.UIOut == nil || op.UIIn == nil ||
 				!pc.Actions.IsOverridable || !pc.Permissions.CanOverride {

--- a/internal/cloud/backend_context.go
+++ b/internal/cloud/backend_context.go
@@ -100,16 +100,16 @@ func (b *Cloud) LocalRun(op *backend.Operation) (*backend.LocalRun, statemgr.Ful
 			diags = diags.Append(fmt.Errorf("error finding remote workspace: %w", err))
 			return nil, nil, diags
 		}
-		w, err := b.fetchWorkspace(context.Background(), b.organization, op.Workspace)
+		w, err := b.fetchWorkspace(context.Background(), b.Organization, op.Workspace)
 		if err != nil {
 			diags = diags.Append(fmt.Errorf("error loading workspace: %w", err))
 			return nil, nil, diags
 		}
 
 		if isLocalExecutionMode(w.ExecutionMode) {
-			log.Printf("[TRACE] skipping retrieving variables from workspace %s/%s (%s), workspace is in Local Execution mode", remoteWorkspaceName, b.organization, remoteWorkspaceID)
+			log.Printf("[TRACE] skipping retrieving variables from workspace %s/%s (%s), workspace is in Local Execution mode", remoteWorkspaceName, b.Organization, remoteWorkspaceID)
 		} else {
-			log.Printf("[TRACE] cloud: retrieving variables from workspace %s/%s (%s)", remoteWorkspaceName, b.organization, remoteWorkspaceID)
+			log.Printf("[TRACE] cloud: retrieving variables from workspace %s/%s (%s)", remoteWorkspaceName, b.Organization, remoteWorkspaceID)
 			tfeVariables, err := b.client.Variables.List(context.Background(), remoteWorkspaceID, nil)
 			if err != nil && err != tfe.ErrResourceNotFound {
 				diags = diags.Append(fmt.Errorf("error loading variables: %w", err))
@@ -165,8 +165,8 @@ func (b *Cloud) getRemoteWorkspaceName(localWorkspaceName string) string {
 func (b *Cloud) getRemoteWorkspace(ctx context.Context, localWorkspaceName string) (*tfe.Workspace, error) {
 	remoteWorkspaceName := b.getRemoteWorkspaceName(localWorkspaceName)
 
-	log.Printf("[TRACE] cloud: looking up workspace for %s/%s", b.organization, remoteWorkspaceName)
-	remoteWorkspace, err := b.client.Workspaces.Read(ctx, b.organization, remoteWorkspaceName)
+	log.Printf("[TRACE] cloud: looking up workspace for %s/%s", b.Organization, remoteWorkspaceName)
+	remoteWorkspace, err := b.client.Workspaces.Read(ctx, b.Organization, remoteWorkspaceName)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/cloud/backend_plan.go
+++ b/internal/cloud/backend_plan.go
@@ -333,7 +333,7 @@ in order to capture the filesystem context the remote workspace expects:
 
 	if b.CLI != nil {
 		b.CLI.Output(b.Colorize().Color(strings.TrimSpace(fmt.Sprintf(
-			runHeader, b.Hostname, b.organization, op.Workspace, r.ID)) + "\n"))
+			runHeader, b.Hostname, b.Organization, op.Workspace, r.ID)) + "\n"))
 	}
 
 	// Render any warnings that were raised during run creation
@@ -521,7 +521,7 @@ func (b *Cloud) renderPlanLogs(ctx context.Context, op *backend.Operation, run *
 		return err
 	}
 	if renderSRO || shouldGenerateConfig {
-		jsonBytes, err := readRedactedPlan(ctx, b.client.BaseURL(), b.token, run.Plan.ID)
+		jsonBytes, err := readRedactedPlan(ctx, b.client.BaseURL(), b.Token, run.Plan.ID)
 		if err != nil {
 			return generalError("Failed to read JSON plan", err)
 		}

--- a/internal/cloud/backend_plan_test.go
+++ b/internal/cloud/backend_plan_test.go
@@ -269,7 +269,7 @@ func TestCloud_planWithoutPermissions(t *testing.T) {
 	// Create a named workspace without permissions.
 	w, err := b.client.Workspaces.Create(
 		context.Background(),
-		b.organization,
+		b.Organization,
 		tfe.WorkspaceCreateOptions{
 			Name: tfe.String("prod"),
 		},
@@ -429,7 +429,7 @@ func TestCloud_planWithPathAndVCS(t *testing.T) {
 	// Create a named workspace with a VCS.
 	_, err := b.client.Workspaces.Create(
 		context.Background(),
-		b.organization,
+		b.Organization,
 		tfe.WorkspaceCreateOptions{
 			Name:    tfe.String("prod-vcs"),
 			VCSRepo: &tfe.VCSRepoOptions{},
@@ -827,7 +827,7 @@ func TestCloud_planWorkspaceWithoutOperations(t *testing.T) {
 	// Create a named workspace that doesn't allow operations.
 	_, err := b.client.Workspaces.Create(
 		ctx,
-		b.organization,
+		b.Organization,
 		tfe.WorkspaceCreateOptions{
 			Name: tfe.String("no-operations"),
 		},
@@ -875,7 +875,7 @@ func TestCloud_planLockTimeout(t *testing.T) {
 	ctx := context.Background()
 
 	// Retrieve the workspace used to run this operation in.
-	w, err := b.client.Workspaces.Read(ctx, b.organization, b.WorkspaceMapping.Name)
+	w, err := b.client.Workspaces.Read(ctx, b.Organization, b.WorkspaceMapping.Name)
 	if err != nil {
 		t.Fatalf("error retrieving workspace: %v", err)
 	}
@@ -998,7 +998,7 @@ func TestCloud_planWithWorkingDirectory(t *testing.T) {
 	}
 
 	// Configure the workspace to use a custom working directory.
-	_, err := b.client.Workspaces.Update(context.Background(), b.organization, b.WorkspaceMapping.Name, options)
+	_, err := b.client.Workspaces.Update(context.Background(), b.Organization, b.WorkspaceMapping.Name, options)
 	if err != nil {
 		t.Fatalf("error configuring working directory: %v", err)
 	}
@@ -1043,7 +1043,7 @@ func TestCloud_planWithWorkingDirectoryFromCurrentPath(t *testing.T) {
 	}
 
 	// Configure the workspace to use a custom working directory.
-	_, err := b.client.Workspaces.Update(context.Background(), b.organization, b.WorkspaceMapping.Name, options)
+	_, err := b.client.Workspaces.Update(context.Background(), b.Organization, b.WorkspaceMapping.Name, options)
 	if err != nil {
 		t.Fatalf("error configuring working directory: %v", err)
 	}

--- a/internal/cloud/backend_show.go
+++ b/internal/cloud/backend_show.go
@@ -61,7 +61,7 @@ func (b *Cloud) ShowPlanForRun(ctx context.Context, runID, runHostname string, r
 
 	// Fetch the json plan!
 	if redacted {
-		jsonBytes, err = readRedactedPlan(ctx, b.client.BaseURL(), b.token, r.Plan.ID)
+		jsonBytes, err = readRedactedPlan(ctx, b.client.BaseURL(), b.Token, r.Plan.ID)
 	} else {
 		jsonBytes, err = b.client.Plans.ReadJSONOutput(ctx, r.Plan.ID)
 	}
@@ -76,7 +76,7 @@ func (b *Cloud) ShowPlanForRun(ctx context.Context, runID, runHostname string, r
 	}
 
 	// Format a run header and footer
-	header := strings.TrimSpace(fmt.Sprintf(runHeader, b.Hostname, b.organization, r.Workspace.Name, r.ID))
+	header := strings.TrimSpace(fmt.Sprintf(runHeader, b.Hostname, b.Organization, r.Workspace.Name, r.ID))
 	footer := strings.TrimSpace(statusFooter(r.Status, r.Actions.IsConfirmable, r.Workspace.Locked))
 
 	out := &cloudplan.RemotePlanJSON{

--- a/internal/cloud/backend_taskStage_taskResults_test.go
+++ b/internal/cloud/backend_taskStage_taskResults_test.go
@@ -39,7 +39,7 @@ func newMockIntegrationContext(b *Cloud, t *testing.T) (*IntegrationContext, *te
 	ctx := context.Background()
 
 	// Retrieve the workspace used to run this operation in.
-	w, err := b.client.Workspaces.Read(ctx, b.organization, b.WorkspaceMapping.Name)
+	w, err := b.client.Workspaces.Read(ctx, b.Organization, b.WorkspaceMapping.Name)
 	if err != nil {
 		t.Fatalf("error retrieving workspace: %v", err)
 	}

--- a/internal/cloud/backend_taskStages.go
+++ b/internal/cloud/backend_taskStages.go
@@ -174,7 +174,7 @@ func (b *Cloud) processStageOverrides(context *IntegrationContext, output Integr
 		Query:       "\nDo you want to override the failed policy check?",
 		Description: "Only 'override' will be accepted to override.",
 	}
-	runUrl := fmt.Sprintf(taskStageHeader, b.Hostname, b.organization, context.Op.Workspace, context.Run.ID)
+	runUrl := fmt.Sprintf(taskStageHeader, b.Hostname, b.Organization, context.Op.Workspace, context.Run.ID)
 	err := b.confirm(context.StopContext, context.Op, opts, context.Run, "override")
 	if err != nil && err != errRunOverridden {
 		return false, fmt.Errorf(

--- a/internal/cloud/backend_test.go
+++ b/internal/cloud/backend_test.go
@@ -434,8 +434,8 @@ func TestCloud_configWithEnvVars(t *testing.T) {
 				t.Fatalf("%s: unexpected configure result: %v", name, diags.Err())
 			}
 
-			if tc.expectedOrganization != "" && tc.expectedOrganization != b.organization {
-				t.Fatalf("%s: organization not valid: %s, expected: %s", name, b.organization, tc.expectedOrganization)
+			if tc.expectedOrganization != "" && tc.expectedOrganization != b.Organization {
+				t.Fatalf("%s: organization not valid: %s, expected: %s", name, b.Organization, tc.expectedOrganization)
 			}
 
 			if tc.expectedHostname != "" && tc.expectedHostname != b.Hostname {
@@ -675,9 +675,9 @@ func TestCloud_setUnavailableTerraformVersion(t *testing.T) {
 	// happens when a workspace gets created. This is why we can't use "name" in
 	// the backend config above, btw: if you do, testBackend() creates the default
 	// workspace before we get a chance to do anything.
-	_, err := b.client.Workspaces.Read(context.Background(), b.organization, workspaceName)
+	_, err := b.client.Workspaces.Read(context.Background(), b.Organization, workspaceName)
 	if err != tfe.ErrResourceNotFound {
-		t.Fatalf("the workspace we were about to try and create (%s/%s) already exists in the mocks somehow, so this test isn't trustworthy anymore", b.organization, workspaceName)
+		t.Fatalf("the workspace we were about to try and create (%s/%s) already exists in the mocks somehow, so this test isn't trustworthy anymore", b.Organization, workspaceName)
 	}
 
 	_, err = b.StateMgr(workspaceName)
@@ -685,7 +685,7 @@ func TestCloud_setUnavailableTerraformVersion(t *testing.T) {
 		t.Fatalf("expected no error from StateMgr, despite not being able to set remote Terraform version: %#v", err)
 	}
 	// Make sure the workspace was created:
-	workspace, err := b.client.Workspaces.Read(context.Background(), b.organization, workspaceName)
+	workspace, err := b.client.Workspaces.Read(context.Background(), b.Organization, workspaceName)
 	if err != nil {
 		t.Fatalf("b.StateMgr() didn't actually create the desired workspace")
 	}
@@ -1125,7 +1125,7 @@ func TestCloud_StateMgr_versionCheck(t *testing.T) {
 	// Terraform version
 	if _, err := b.client.Workspaces.Update(
 		context.Background(),
-		b.organization,
+		b.Organization,
 		b.WorkspaceMapping.Name,
 		tfe.WorkspaceUpdateOptions{
 			TerraformVersion: tfe.String(v0140.String()),
@@ -1142,7 +1142,7 @@ func TestCloud_StateMgr_versionCheck(t *testing.T) {
 	// Now change the remote workspace to a different Terraform version
 	if _, err := b.client.Workspaces.Update(
 		context.Background(),
-		b.organization,
+		b.Organization,
 		b.WorkspaceMapping.Name,
 		tfe.WorkspaceUpdateOptions{
 			TerraformVersion: tfe.String(v0135.String()),
@@ -1182,7 +1182,7 @@ func TestCloud_StateMgr_versionCheckLatest(t *testing.T) {
 	// Update the remote workspace to the pseudo-version "latest"
 	if _, err := b.client.Workspaces.Update(
 		context.Background(),
-		b.organization,
+		b.Organization,
 		b.WorkspaceMapping.Name,
 		tfe.WorkspaceUpdateOptions{
 			TerraformVersion: tfe.String("latest"),
@@ -1251,7 +1251,7 @@ func TestCloud_VerifyWorkspaceTerraformVersion(t *testing.T) {
 			// specified remote version
 			if _, err := b.client.Workspaces.Update(
 				context.Background(),
-				b.organization,
+				b.Organization,
 				b.WorkspaceMapping.Name,
 				tfe.WorkspaceUpdateOptions{
 					ExecutionMode:    &tc.executionMode,
@@ -1302,7 +1302,7 @@ func TestCloud_VerifyWorkspaceTerraformVersion_workspaceErrors(t *testing.T) {
 	// Update the mock remote workspace Terraform version to an invalid version
 	if _, err := b.client.Workspaces.Update(
 		context.Background(),
-		b.organization,
+		b.Organization,
 		b.WorkspaceMapping.Name,
 		tfe.WorkspaceUpdateOptions{
 			TerraformVersion: tfe.String("1.0.cheetarah"),
@@ -1350,7 +1350,7 @@ func TestCloud_VerifyWorkspaceTerraformVersion_ignoreFlagSet(t *testing.T) {
 	// specified remote version
 	if _, err := b.client.Workspaces.Update(
 		context.Background(),
-		b.organization,
+		b.Organization,
 		b.WorkspaceMapping.Name,
 		tfe.WorkspaceUpdateOptions{
 			TerraformVersion: tfe.String(remote.String()),
@@ -1402,7 +1402,7 @@ func TestCloudBackend_DeleteWorkspace_SafeAndForce(t *testing.T) {
 	}
 
 	c := context.Background()
-	safeDeleteWorkspace, err := b.client.Workspaces.Read(c, b.organization, safeDeleteWorkspaceName)
+	safeDeleteWorkspace, err := b.client.Workspaces.Read(c, b.Organization, safeDeleteWorkspaceName)
 	if err != nil {
 		t.Fatalf("error fetching workspace: %v", err)
 	}
@@ -1428,7 +1428,7 @@ func TestCloudBackend_DeleteWorkspace_SafeAndForce(t *testing.T) {
 	}
 
 	// lock a workspace and then confirm that force deleting it works
-	forceDeleteWorkspace, err := b.client.Workspaces.Read(c, b.organization, forceDeleteWorkspaceName)
+	forceDeleteWorkspace, err := b.client.Workspaces.Read(c, b.Organization, forceDeleteWorkspaceName)
 	if err != nil {
 		t.Fatalf("error fetching workspace: %v", err)
 	}

--- a/internal/cloud/state_test.go
+++ b/internal/cloud/state_test.go
@@ -38,7 +38,7 @@ func TestState_GetRootOutputValues(t *testing.T) {
 	b, bCleanup := testBackendWithOutputs(t)
 	defer bCleanup()
 
-	state := &State{tfeClient: b.client, organization: b.organization, workspace: &tfe.Workspace{
+	state := &State{tfeClient: b.client, organization: b.Organization, workspace: &tfe.Workspace{
 		ID: "ws-abcd",
 	}}
 	outputs, err := state.GetRootOutputValues()

--- a/internal/cloud/testing.go
+++ b/internal/cloud/testing.go
@@ -283,7 +283,7 @@ func testBackend(t *testing.T, obj cty.Value, handlers map[string]func(http.Resp
 
 	// Create the organization.
 	_, err = b.client.Organizations.Create(ctx, tfe.OrganizationCreateOptions{
-		Name: tfe.String(b.organization),
+		Name: tfe.String(b.Organization),
 	})
 	if err != nil {
 		t.Fatalf("error: %v", err)
@@ -291,7 +291,7 @@ func testBackend(t *testing.T, obj cty.Value, handlers map[string]func(http.Resp
 
 	// Create the default workspace if required.
 	if b.WorkspaceMapping.Name != "" {
-		_, err = b.client.Workspaces.Create(ctx, b.organization, tfe.WorkspaceCreateOptions{
+		_, err = b.client.Workspaces.Create(ctx, b.Organization, tfe.WorkspaceCreateOptions{
 			Name: tfe.String(b.WorkspaceMapping.Name),
 		})
 		if err != nil {

--- a/internal/command/cloud.go
+++ b/internal/command/cloud.go
@@ -87,7 +87,9 @@ func (c *CloudCommand) realRun(args []string, stdout, stderr io.Writer) int {
 		Logger:           logging.NewCloudLogger(),
 		VersionedPlugins: map[int]plugin.PluginSet{
 			1: {
-				"cloud": &cloudplugin1.GRPCCloudPlugin{},
+				"cloud": &cloudplugin1.GRPCCloudPlugin{
+					Metadata: c.pluginConfig.ToMetadata(),
+				},
 			},
 		},
 	})

--- a/internal/command/cloud.go
+++ b/internal/command/cloud.go
@@ -205,7 +205,7 @@ func (c *CloudCommand) initPlugin() tfdiags.Diagnostics {
 	defer done()
 
 	// Discover service URLs, and build out the plugin config
-	diags.Append(c.discoverAndConfigure())
+	diags = diags.Append(c.discoverAndConfigure())
 	if diags.HasErrors() {
 		return diags
 	}

--- a/internal/command/cloud.go
+++ b/internal/command/cloud.go
@@ -282,23 +282,25 @@ func (c *CloudCommand) Synopsis() string {
 	return "Manage Terraform Cloud settings and metadata"
 }
 
-// Everything the cloud plugin needs to know to configure a client and talk to TFC.
+// CloudPluginConfig is everything the cloud plugin needs to know to configure a
+// client and talk to TFC.
 type CloudPluginConfig struct {
 	// Maybe someday we can use struct tags to automate grabbing these out of
 	// the metadata headers! And verify client-side that we're sending the right
 	// stuff, instead of having it all be a stringly-typed mystery ball! I want
 	// to believe in that distant shining day! 🌻 Meantime, these struct tags
 	// serve purely as docs.
-	Address          string `md:"tfc-address"`
-	BasePath         string `md:"tfc-base-path"`
-	DisplayHostname  string `md:"tfc-display-hostname"`
-	Token            string `md:"tfc-token"`
-	Organization     string `md:"tfc-organization"`
+	Address         string `md:"tfc-address"`
+	BasePath        string `md:"tfc-base-path"`
+	DisplayHostname string `md:"tfc-display-hostname"`
+	Token           string `md:"tfc-token"`
+	Organization    string `md:"tfc-organization"`
+	// The actual selected workspace
 	CurrentWorkspace string `md:"tfc-current-workspace"`
 
-	// The classic "WorkspaceMapping" attributes. I think 90% of the time we
-	// actually won't care about these, and just want the current workspace
-	// instead.
+	// The raw "WorkspaceMapping" attributes, which determine the workspaces
+	// that could be selected. Generally you want CurrentWorkspace instead, but
+	// these can potentially be useful for niche use cases.
 	WorkspaceName      string   `md:"tfc-workspace-name"`
 	WorkspaceTags      []string `md:"tfc-workspace-tags"`
 	DefaultProjectName string   `md:"tfc-default-project-name"`


### PR DESCRIPTION
- The cloud plugin wants a go-tfe client to get stuff from TFC.
- Terraform knows how to find all the info you need in order to configure a
go-tfe client, but it's sometimes scattered across configs and env vars and
credentials helpers, and trying to re-implement the resolution logic identically
in another codebase would be error-prone.
- Therefore, it'd be best if Terraform did that resolution and just passed the
plugin all the config info it needs.

There are two options for that handoff:

1. Adding it as an additional argument to the primary Execute RPC interface.
2. Passing it as gRPC metadata, which is a pile of arbitrary key => list-of-strings
   pairs transmitted via HTTP/2 headers.

The crux of the decision here is whether a proliferation of plugin protocol
versions whenever we need to add more config data is better or worse than a
fuzzy and typeless key/value bag.

This PR is an implementation of option 2, for discussion and evaluation. (And
after all, this is considered an experimental feature anyway.) It assembles the
necessary information, translates it to the required metadata format, and
attaches it to the request at the proper moment to get everything over to the
plugin.

To support this, this PR also increases the public surface area of the Cloud backend slightly — making the Organization and Token fields public, and adding a public cache of the service discovery request it made to the TFC server during `Configure()`. This seemed more parsimonious than re-implementing a bunch of logic in the cloud command (which already needed to construct and configure the backend anyway in order to get the TFC hostname out of the config).

## Target Release

1.7.x

## Draft CHANGELOG entry

n/a (it's an unreleased experimental feature) 