### PR TITLE
Add functions definitions to the `providers schema -json` output

### DIFF
--- a/internal/command/jsonfunction/function.go
+++ b/internal/command/jsonfunction/function.go
@@ -30,6 +30,9 @@ type FunctionSignature struct {
 	// of the function
 	Description string `json:"description,omitempty"`
 
+	// Summary is the optional shortened description of the function
+	Summary string `json:"summary,omitempty"`
+
 	// ReturnTypes is the ctyjson representation of the function's
 	// return types based on supplying all parameters using
 	// dynamic types. Functions can have dynamic return types.
@@ -145,6 +148,7 @@ func marshalProviderFunction(f providers.FunctionDecl) *FunctionSignature {
 
 	return &FunctionSignature{
 		Description:       f.Description,
+		Summary:           f.Summary,
 		ReturnType:        f.ReturnType,
 		Parameters:        p,
 		VariadicParameter: vp,

--- a/internal/command/jsonfunction/function_test.go
+++ b/internal/command/jsonfunction/function_test.go
@@ -8,42 +8,52 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/zclconf/go-cty-debug/ctydebug"
+	"github.com/hashicorp/terraform/internal/providers"
 	"github.com/zclconf/go-cty/cty"
 	"github.com/zclconf/go-cty/cty/function"
 )
 
 func TestMarshal(t *testing.T) {
 	tests := []struct {
-		Name    string
-		Input   map[string]function.Function
-		Want    string
-		WantErr string
+		Name              string
+		Functions         map[string]function.Function
+		ProviderFunctions map[string]providers.FunctionDecl
+		Want              string
+		WantErr           string
 	}{
 		{
-			"minimal function",
-			map[string]function.Function{
+			Name: "minimal function",
+			Functions: map[string]function.Function{
 				"fun": function.New(&function.Spec{
 					Type: function.StaticReturnType(cty.Bool),
 				}),
 			},
-			`{"format_version":"1.0","function_signatures":{"fun":{"return_type":"bool"}}}`,
-			"",
+			ProviderFunctions: map[string]providers.FunctionDecl{
+				"fun": {
+					ReturnType: cty.Bool,
+				},
+			},
+			Want: `{"format_version":"1.0","function_signatures":{"fun":{"return_type":"bool"}}}`,
 		},
 		{
-			"function with description",
-			map[string]function.Function{
+			Name: "function with description",
+			Functions: map[string]function.Function{
 				"fun": function.New(&function.Spec{
 					Description: "`timestamp` returns a UTC timestamp string.",
 					Type:        function.StaticReturnType(cty.String),
 				}),
 			},
-			"{\"format_version\":\"1.0\",\"function_signatures\":{\"fun\":{\"description\":\"`timestamp` returns a UTC timestamp string.\",\"return_type\":\"string\"}}}",
-			"",
+			ProviderFunctions: map[string]providers.FunctionDecl{
+				"fun": {
+					Description: "`timestamp` returns a UTC timestamp string.",
+					ReturnType:  cty.String,
+				},
+			},
+			Want: "{\"format_version\":\"1.0\",\"function_signatures\":{\"fun\":{\"description\":\"`timestamp` returns a UTC timestamp string.\",\"return_type\":\"string\"}}}",
 		},
 		{
-			"function with parameters",
-			map[string]function.Function{
+			Name: "function with parameters",
+			Functions: map[string]function.Function{
 				"fun": function.New(&function.Spec{
 					Params: []function.Parameter{
 						{
@@ -60,12 +70,28 @@ func TestMarshal(t *testing.T) {
 					Type: function.StaticReturnType(cty.String),
 				}),
 			},
-			`{"format_version":"1.0","function_signatures":{"fun":{"return_type":"string","parameters":[{"name":"timestamp","description":"timestamp text","type":"string"},{"name":"duration","description":"duration text","type":"string"}]}}}`,
-			"",
+			ProviderFunctions: map[string]providers.FunctionDecl{
+				"fun": {
+					Parameters: []providers.FunctionParam{
+						{
+							Name:        "timestamp",
+							Description: "timestamp text",
+							Type:        cty.String,
+						},
+						{
+							Name:        "duration",
+							Description: "duration text",
+							Type:        cty.String,
+						},
+					},
+					ReturnType: cty.String,
+				},
+			},
+			Want: `{"format_version":"1.0","function_signatures":{"fun":{"return_type":"string","parameters":[{"name":"timestamp","description":"timestamp text","type":"string"},{"name":"duration","description":"duration text","type":"string"}]}}}`,
 		},
 		{
-			"function with variadic parameter",
-			map[string]function.Function{
+			Name: "function with variadic parameter",
+			Functions: map[string]function.Function{
 				"fun": function.New(&function.Spec{
 					VarParam: &function.Parameter{
 						Name:             "default",
@@ -79,12 +105,23 @@ func TestMarshal(t *testing.T) {
 					Type: function.StaticReturnType(cty.DynamicPseudoType),
 				}),
 			},
-			`{"format_version":"1.0","function_signatures":{"fun":{"return_type":"dynamic","variadic_parameter":{"name":"default","description":"default description","is_nullable":true,"type":"dynamic"}}}}`,
-			"",
+			ProviderFunctions: map[string]providers.FunctionDecl{
+				"fun": providers.FunctionDecl{
+					VariadicParameter: &providers.FunctionParam{
+						Name:               "default",
+						Description:        "default description",
+						Type:               cty.DynamicPseudoType,
+						AllowUnknownValues: true,
+						AllowNullValue:     true,
+					},
+					ReturnType: cty.DynamicPseudoType,
+				},
+			},
+			Want: `{"format_version":"1.0","function_signatures":{"fun":{"return_type":"dynamic","variadic_parameter":{"name":"default","description":"default description","is_nullable":true,"type":"dynamic"}}}}`,
 		},
 		{
-			"function with list types",
-			map[string]function.Function{
+			Name: "function with list types",
+			Functions: map[string]function.Function{
 				"fun": function.New(&function.Spec{
 					Params: []function.Parameter{
 						{
@@ -95,12 +132,22 @@ func TestMarshal(t *testing.T) {
 					Type: function.StaticReturnType(cty.List(cty.String)),
 				}),
 			},
-			`{"format_version":"1.0","function_signatures":{"fun":{"return_type":["list","string"],"parameters":[{"name":"list","type":["list","string"]}]}}}`,
-			"",
+			ProviderFunctions: map[string]providers.FunctionDecl{
+				"fun": {
+					Parameters: []providers.FunctionParam{
+						{
+							Name: "list",
+							Type: cty.List(cty.String),
+						},
+					},
+					ReturnType: cty.List(cty.String),
+				},
+			},
+			Want: `{"format_version":"1.0","function_signatures":{"fun":{"return_type":["list","string"],"parameters":[{"name":"list","type":["list","string"]}]}}}`,
 		},
 		{
-			"returns diagnostics on failure",
-			map[string]function.Function{
+			Name: "returns diagnostics on failure",
+			Functions: map[string]function.Function{
 				"fun": function.New(&function.Spec{
 					Params: []function.Parameter{},
 					Type: func(args []cty.Value) (ret cty.Type, err error) {
@@ -108,14 +155,13 @@ func TestMarshal(t *testing.T) {
 					},
 				}),
 			},
-			"",
-			"Failed to serialize function \"fun\": error",
+			WantErr: "Failed to serialize function \"fun\": error",
 		},
 	}
 
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("%d-%s", i, test.Name), func(t *testing.T) {
-			got, diags := Marshal(test.Input)
+			got, diags := Marshal(test.Functions)
 			if test.WantErr != "" {
 				if !diags.HasErrors() {
 					t.Fatal("expected error, got none")
@@ -128,7 +174,20 @@ func TestMarshal(t *testing.T) {
 					t.Fatal(diags)
 				}
 
-				if diff := cmp.Diff(test.Want, string(got), ctydebug.CmpOptions); diff != "" {
+				if diff := cmp.Diff(test.Want, string(got)); diff != "" {
+					t.Fatalf("mismatch of function signature: %s", diff)
+				}
+			}
+
+			if test.ProviderFunctions != nil {
+				got, err := MarshalProviderFunctions(test.ProviderFunctions)
+				if err != nil {
+					// these should never error
+					t.Fatal("MarshalProviderFunctions failed:", err)
+				}
+
+				// Provider functions should marshal identically to cty functions
+				if diff := cmp.Diff(test.Want, string(got)); diff != "" {
 					t.Fatalf("mismatch of function signature: %s", diff)
 				}
 			}

--- a/internal/command/jsonfunction/parameter.go
+++ b/internal/command/jsonfunction/parameter.go
@@ -4,6 +4,7 @@
 package jsonfunction
 
 import (
+	"github.com/hashicorp/terraform/internal/providers"
 	"github.com/zclconf/go-cty/cty"
 	"github.com/zclconf/go-cty/cty/function"
 )
@@ -41,6 +42,23 @@ func marshalParameters(parameters []function.Parameter) []*parameter {
 	ret := make([]*parameter, len(parameters))
 	for k, p := range parameters {
 		ret[k] = marshalParameter(&p)
+	}
+	return ret
+}
+
+func marshalProviderParameter(p providers.FunctionParam) *parameter {
+	return &parameter{
+		Name:        p.Name,
+		Description: p.Description,
+		IsNullable:  p.AllowNullValue,
+		Type:        p.Type,
+	}
+}
+
+func marshalProviderParameters(parameters []providers.FunctionParam) []*parameter {
+	ret := make([]*parameter, len(parameters))
+	for k, p := range parameters {
+		ret[k] = marshalProviderParameter(p)
 	}
 	return ret
 }

--- a/internal/command/jsonprovider/provider_test.go
+++ b/internal/command/jsonprovider/provider_test.go
@@ -9,11 +9,14 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/zclconf/go-cty/cty"
 
 	"github.com/hashicorp/terraform/internal/configs/configschema"
 	"github.com/hashicorp/terraform/internal/providers"
 )
+
+var cmpOpts = cmpopts.IgnoreUnexported(Provider{})
 
 func TestMarshalProvider(t *testing.T) {
 	tests := []struct {
@@ -151,8 +154,8 @@ func TestMarshalProvider(t *testing.T) {
 	for i, test := range tests {
 		t.Run(fmt.Sprint(i), func(t *testing.T) {
 			got := marshalProvider(test.Input)
-			if !cmp.Equal(got, test.Want) {
-				t.Fatalf("wrong result:\n %v\n", cmp.Diff(got, test.Want))
+			if !cmp.Equal(got, test.Want, cmpOpts) {
+				t.Fatalf("wrong result:\n %v\n", cmp.Diff(got, test.Want, cmpOpts))
 			}
 		})
 	}

--- a/internal/plugin/convert/functions.go
+++ b/internal/plugin/convert/functions.go
@@ -32,6 +32,7 @@ func FunctionDeclFromProto(protoFunc *tfplugin5.Function) (providers.FunctionDec
 
 	ret.Description = protoFunc.Description
 	ret.DescriptionKind = schemaStringKind(protoFunc.DescriptionKind)
+	ret.Summary = protoFunc.Summary
 
 	if err := json.Unmarshal(protoFunc.Return.Type, &ret.ReturnType); err != nil {
 		return ret, fmt.Errorf("invalid return type constraint: %s", err)

--- a/internal/plugin6/convert/functions.go
+++ b/internal/plugin6/convert/functions.go
@@ -32,6 +32,7 @@ func FunctionDeclFromProto(protoFunc *tfplugin6.Function) (providers.FunctionDec
 
 	ret.Description = protoFunc.Description
 	ret.DescriptionKind = schemaStringKind(protoFunc.DescriptionKind)
+	ret.Summary = protoFunc.Summary
 
 	if err := json.Unmarshal(protoFunc.Return.Type, &ret.ReturnType); err != nil {
 		return ret, fmt.Errorf("invalid return type constraint: %s", err)

--- a/internal/providers/functions.go
+++ b/internal/providers/functions.go
@@ -19,6 +19,7 @@ type FunctionDecl struct {
 
 	Description     string
 	DescriptionKind configschema.StringKind
+	Summary         string
 }
 
 type FunctionParam struct {


### PR DESCRIPTION
Add function definitions to the json schema CLI output.  While the protocol names may not exactly match the json keys, this matches the existing `metadata functions` output for easier integration with tooling already using that interface. We use the `jsonfunction` package from the `metadata` command to serialize the new provider functions, and ensure they stay synchronized. This makes the integration a little clumsy, and it may be a good idea to combine the cli json definitions into a single package, but the separate serialization works well enough for now.

An example of the `"functions"` portion of the schema would look like:

```
      "functions": {
        "format_version": "1.0",
        "function_signatures": {
          "noop": {
            "description": "noop takes any single argument and returns the same value",
            "return_type": "dynamic",
            "parameters": [
              {
                "name": "noop",
                "description": "any value",
                "is_nullable": true,
                "type": "dynamic"
              }
            ]
          }
        }
      }
    },
```

The provider functions are not being added to the `metadata functions` command. The function names in the configuration are dependent on the local provider name in the module, and therefor are context dependent. The `metadata` command is also not guaranteed to have an initialized working directory and providers may not be available at all.