### PR TITLE
terraform test: run block names should be valid HCL identifiers

### DIFF
--- a/internal/configs/test_file.go
+++ b/internal/configs/test_file.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/gohcl"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
 
 	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/getmodules"
@@ -437,6 +438,16 @@ func decodeTestRunBlock(block *hcl.Block) (*TestRun, hcl.Diagnostics) {
 		NameDeclRange: block.LabelRanges[0],
 		DeclRange:     block.DefRange,
 	}
+
+	if !hclsyntax.ValidIdentifier(r.Name) {
+		diags = append(diags, &hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  "Invalid run block name",
+			Detail:   badIdentifierDetail,
+			Subject:  r.NameDeclRange.Ptr(),
+		})
+	}
+
 	for _, block := range content.Blocks {
 		switch block.Type {
 		case "assert":

--- a/internal/configs/testdata/config-diagnostics/tests-provider-mismatch/main.tftest.hcl
+++ b/internal/configs/testdata/config-diagnostics/tests-provider-mismatch/main.tftest.hcl
@@ -11,7 +11,7 @@ provider "bar" {
 
 run "default_should_be_fine" {}
 
-run "bit_complicated_still_okay "{
+run "bit_complicated_still_okay" {
 
   providers = {
     foo = foo

--- a/internal/configs/testdata/invalid-modules/tests-invalid-run-blocks/main.tf
+++ b/internal/configs/testdata/invalid-modules/tests-invalid-run-blocks/main.tf
@@ -1,0 +1,8 @@
+
+resource "aws_instance" "web" {
+  ami = "ami-1234"
+  security_groups = [
+    "foo",
+    "bar",
+  ]
+}

--- a/internal/configs/testdata/invalid-modules/tests-invalid-run-blocks/main.tftest.hcl
+++ b/internal/configs/testdata/invalid-modules/tests-invalid-run-blocks/main.tftest.hcl
@@ -1,0 +1,2 @@
+
+run "contains spaces" {}


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

Validate that run block names are valid HCL identifiers when they are parsed instead of failing with obscure error messages later.

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Fixes #34372 

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.7.0

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

### BUG FIXES

<!--

Write a short description of the user-facing change. Examples:

- `terraform show -json`: Fixed crash with sensitive set values.
- When rendering a diff, Terraform now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 

-  `terraform test`: Improve error message for invalid run block names.
