### PR TITLE
`Block.Filter` can panic with a nested object which has no attributes

### DIFF
--- a/internal/configs/configschema/filter.go
+++ b/internal/configs/configschema/filter.go
@@ -50,10 +50,9 @@ func (b *Block) Filter(filterAttribute FilterT[*Attribute], filterBlock FilterT[
 	for name, attrS := range b.Attributes {
 		if filterAttribute == nil || !filterAttribute(name, attrS) {
 			ret.Attributes[name] = attrS
-		}
-
-		if attrS.NestedType != nil {
-			ret.Attributes[name].NestedType = filterNestedType(attrS.NestedType, filterAttribute)
+			if attrS.NestedType != nil {
+				ret.Attributes[name].NestedType = filterNestedType(attrS.NestedType, filterAttribute)
+			}
 		}
 	}
 

--- a/internal/configs/configschema/filter_test.go
+++ b/internal/configs/configschema/filter_test.go
@@ -175,6 +175,12 @@ func TestFilter(t *testing.T) {
 							Nesting: NestingList,
 						},
 					},
+					"missing_attributes": {
+						NestedType: &Object{
+							Nesting: NestingList,
+						},
+						Computed: true,
+					},
 				},
 
 				BlockTypes: map[string]*NestedBlock{


### PR DESCRIPTION
Make sure that we only dereference an attribute if it was set in the filter. While not extremely useful, a provider could technically have a nested object with no attributes.

Fixes #34463

