### PR TITLE
[TF-11813] do not colorize runHeader when returned as err

### DIFF
--- a/internal/backend/remote/backend_plan.go
+++ b/internal/backend/remote/backend_plan.go
@@ -443,8 +443,13 @@ Preparing the remote plan...
 `
 
 const runHeader = `
-[reset][yellow]To view this run in a browser, visit:
-https://%s/app/%s/%s/runs/%s[reset]
+[reset][yellow]To view this run in a browser, visit:[reset]
+[reset][yellow]https://%s/app/%s/%s/runs/%s[reset]
+`
+
+const runHeaderErr = `
+To view this run in a browser, visit:
+https://%s/app/%s/%s/runs/%s
 `
 
 // The newline in this error is to make it look good in the CLI!

--- a/internal/cloud/backend_common.go
+++ b/internal/cloud/backend_common.go
@@ -391,16 +391,16 @@ func (b *Cloud) checkPolicy(stopCtx, cancelCtx context.Context, op *backend.Oper
 		case tfe.PolicyHardFailed:
 			return fmt.Errorf(msgPrefix + " hard failed.")
 		case tfe.PolicySoftFailed:
-			runUrl := fmt.Sprintf(runHeader, b.Hostname, b.Organization, op.Workspace, r.ID)
+			runURL := fmt.Sprintf(runHeaderErr, b.Hostname, b.Organization, op.Workspace, r.ID)
 
 			if op.Type == backend.OperationTypePlan || op.UIOut == nil || op.UIIn == nil ||
 				!pc.Actions.IsOverridable || !pc.Permissions.CanOverride {
-				return fmt.Errorf(msgPrefix + " soft failed.\n" + runUrl)
+				return fmt.Errorf(msgPrefix + " soft failed.\n" + runURL)
 			}
 
 			if op.AutoApprove {
 				if _, err = b.client.PolicyChecks.Override(stopCtx, pc.ID); err != nil {
-					return generalError(fmt.Sprintf("Failed to override policy check.\n%s", runUrl), err)
+					return generalError(fmt.Sprintf("Failed to override policy check.\n%s", runURL), err)
 				}
 			} else if !b.input {
 				return errPolicyOverrideNeedsUIConfirmation
@@ -413,16 +413,17 @@ func (b *Cloud) checkPolicy(stopCtx, cancelCtx context.Context, op *backend.Oper
 				err = b.confirm(stopCtx, op, opts, r, "override")
 				if err != nil && err != errRunOverridden {
 					return fmt.Errorf(
-						fmt.Sprintf("Failed to override: %s\n%s\n", err.Error(), runUrl),
+						fmt.Sprintf("Failed to override: %s\n%s\n", err.Error(), runURL),
 					)
 				}
 
 				if err != errRunOverridden {
 					if _, err = b.client.PolicyChecks.Override(stopCtx, pc.ID); err != nil {
-						return generalError(fmt.Sprintf("Failed to override policy check.\n%s", runUrl), err)
+						return generalError(fmt.Sprintf("Failed to override policy check.\n%s", runURL), err)
 					}
 				} else {
-					b.CLI.Output(fmt.Sprintf("The run needs to be manually overridden or discarded.\n%s\n", runUrl))
+					runURL := fmt.Sprintf(runHeader, b.Hostname, b.Organization, op.Workspace, r.ID)
+					b.CLI.Output(fmt.Sprintf("The run needs to be manually overridden or discarded.\n%s\n", runURL))
 				}
 			}
 

--- a/internal/cloud/backend_plan.go
+++ b/internal/cloud/backend_plan.go
@@ -638,8 +638,13 @@ Preparing the remote plan...
 `
 
 const runHeader = `
-[reset][yellow]To view this run in a browser, visit:
-https://%s/app/%s/%s/runs/%s[reset]
+[reset][yellow]To view this run in a browser, visit:[reset]
+[reset][yellow]https://%s/app/%s/%s/runs/%s[reset]
+`
+
+const runHeaderErr = `
+To view this run in the browser, visit:
+https://%s/app/%s/%s/runs/%s
 `
 
 // The newline in this error is to make it look good in the CLI!

--- a/internal/cloud/backend_taskStages.go
+++ b/internal/cloud/backend_taskStages.go
@@ -174,22 +174,22 @@ func (b *Cloud) processStageOverrides(context *IntegrationContext, output Integr
 		Query:       "\nDo you want to override the failed policy check?",
 		Description: "Only 'override' will be accepted to override.",
 	}
-	runUrl := fmt.Sprintf(taskStageHeader, b.Hostname, b.Organization, context.Op.Workspace, context.Run.ID)
+	runURL := fmt.Sprintf(taskStageHeader, b.Hostname, b.Organization, context.Op.Workspace, context.Run.ID)
 	err := b.confirm(context.StopContext, context.Op, opts, context.Run, "override")
 	if err != nil && err != errRunOverridden {
 		return false, fmt.Errorf(
-			fmt.Sprintf("Failed to override: %s\n%s\n", err.Error(), runUrl),
+			fmt.Sprintf("Failed to override: %s\n%s\n", err.Error(), runURL),
 		)
 	}
 
 	if err != errRunOverridden {
 		if _, err = b.client.TaskStages.Override(context.StopContext, taskStageID, tfe.TaskStageOverrideOptions{}); err != nil {
-			return false, generalError(fmt.Sprintf("Failed to override policy check.\n%s", runUrl), err)
+			return false, generalError(fmt.Sprintf("Failed to override policy check.\n%s", runURL), err)
 		} else {
 			return true, nil
 		}
 	} else {
-		output.Output(fmt.Sprintf("The run needs to be manually overridden or discarded.\n%s\n", runUrl))
+		output.Output(fmt.Sprintf("The run needs to be manually overridden or discarded.\n%s\n", runURL))
 	}
 	return false, nil
 }


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Fixes #

We should not call colorize on strings that are returned as error messages. 

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.5.x

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

### NEW FEATURES | UPGRADE NOTES | ENHANCEMENTS | BUG FIXES | EXPERIMENTS

<!--

Write a short description of the user-facing change. Examples:

- `terraform show -json`: Fixed crash with sensitive set values.
- When rendering a diff, Terraform now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 
- Fix terminal error by removing colorized text

#### Before
<img width="689" alt="Screenshot 2024-01-16 at 3 17 57 PM" src="https://github.com/hashicorp/terraform/assets/29918071/81549924-43a3-4e1b-b0b0-38e01b4810ef">

