### PR TITLE
Manual backport of core: Use the new namedvals.State API to track input variables, local values, and output values

### DIFF
--- a/internal/backend/remote/backend_state.go
+++ b/internal/backend/remote/backend_state.go
@@ -98,7 +98,7 @@ func (r *remoteClient) Put(state []byte) error {
 		return fmt.Errorf("error reading state: %s", err)
 	}
 
-	ov, err := jsonstate.MarshalOutputs(stateFile.State.RootModule().OutputValues)
+	ov, err := jsonstate.MarshalOutputs(stateFile.State.RootOutputValues)
 	if err != nil {
 		return fmt.Errorf("error reading output values: %s", err)
 	}

--- a/internal/builtin/providers/terraform/data_source_state.go
+++ b/internal/builtin/providers/terraform/data_source_state.go
@@ -169,11 +169,8 @@ func dataSourceRemoteStateRead(d cty.Value) (cty.Value, tfdiags.Diagnostics) {
 		newState["outputs"] = cty.EmptyObjectVal
 		return cty.ObjectVal(newState), diags
 	}
-	mod := remoteState.RootModule()
-	if mod != nil { // should always have a root module in any valid state
-		for k, os := range mod.OutputValues {
-			outputs[k] = os.Value
-		}
+	for k, os := range remoteState.RootOutputValues {
+		outputs[k] = os.Value
 	}
 
 	newState["outputs"] = cty.ObjectVal(outputs)

--- a/internal/cloud/state.go
+++ b/internal/cloud/state.go
@@ -220,7 +220,7 @@ func (s *State) PersistState(schemas *terraform.Schemas) error {
 		return fmt.Errorf("failed to read state: %w", err)
 	}
 
-	ov, err := jsonstate.MarshalOutputs(stateFile.State.RootModule().OutputValues)
+	ov, err := jsonstate.MarshalOutputs(stateFile.State.RootOutputValues)
 	if err != nil {
 		return fmt.Errorf("failed to translate outputs: %w", err)
 	}
@@ -547,7 +547,7 @@ func (s *State) GetRootOutputValues() (map[string]*states.OutputValue, error) {
 				return nil, ErrStateVersionUnauthorizedUpgradeState
 			}
 
-			return state.RootModule().OutputValues, nil
+			return state.RootOutputValues, nil
 		}
 
 		if output.Sensitive {

--- a/internal/command/apply.go
+++ b/internal/command/apply.go
@@ -137,7 +137,7 @@ func (c *ApplyCommand) Run(rawArgs []string) int {
 	if rb, isRemoteBackend := be.(BackendWithRemoteTerraformVersion); !isRemoteBackend || rb.IsLocalOperations() {
 		view.ResourceCount(args.State.StateOutPath)
 		if !c.Destroy && op.State != nil {
-			view.Outputs(op.State.RootModule().OutputValues)
+			view.Outputs(op.State.RootOutputValues)
 		}
 	}
 

--- a/internal/command/command_test.go
+++ b/internal/command/command_test.go
@@ -355,7 +355,10 @@ func testStateMgrCurrentLineage(mgr statemgr.Persistent) string {
 //	// (do stuff to the state)
 //	assertStateHasMarker(state, mark)
 func markStateForMatching(state *states.State, mark string) string {
-	state.RootModule().SetOutputValue("testing_mark", cty.StringVal(mark), false)
+	state.SetOutputValue(
+		addrs.OutputValue{Name: "testing_mark"}.Absolute(addrs.RootModuleInstance),
+		cty.StringVal(mark), false,
+	)
 	return mark
 }
 
@@ -363,7 +366,7 @@ func markStateForMatching(state *states.State, mark string) string {
 // mark string previously added to the given state. If no such mark is present,
 // the result is an empty string.
 func getStateMatchingMarker(state *states.State) string {
-	os := state.RootModule().OutputValues["testing_mark"]
+	os := state.RootOutputValues["testing_mark"]
 	if os == nil {
 		return ""
 	}

--- a/internal/command/e2etest/primary_test.go
+++ b/internal/command/e2etest/primary_test.go
@@ -204,13 +204,13 @@ func TestPrimaryChdirOption(t *testing.T) {
 		t.Fatalf("failed to read state file: %s", err)
 	}
 
-	gotOutput := state.RootModule().OutputValues["cwd"]
+	gotOutput := state.RootOutputValues["cwd"]
 	wantOutputValue := cty.StringVal(filepath.ToSlash(tf.Path())) // path.cwd returns the original path, because path.root is how we get the overridden path
 	if gotOutput == nil || !wantOutputValue.RawEquals(gotOutput.Value) {
 		t.Errorf("incorrect value for cwd output\ngot: %#v\nwant Value: %#v", gotOutput, wantOutputValue)
 	}
 
-	gotOutput = state.RootModule().OutputValues["root"]
+	gotOutput = state.RootOutputValues["root"]
 	wantOutputValue = cty.StringVal(filepath.ToSlash(tf.Path("subdir"))) // path.root is a relative path, but the text fixture uses abspath on it.
 	if gotOutput == nil || !wantOutputValue.RawEquals(gotOutput.Value) {
 		t.Errorf("incorrect value for root output\ngot: %#v\nwant Value: %#v", gotOutput, wantOutputValue)

--- a/internal/command/e2etest/terraform_test.go
+++ b/internal/command/e2etest/terraform_test.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/e2e"
 )
 
@@ -46,7 +45,7 @@ func TestTerraformProviderData(t *testing.T) {
 	}
 
 	// we'll check the final output to validate the resources
-	d := state.Module(addrs.RootModuleInstance).OutputValues["d"].Value
+	d := state.RootOutputValues["d"].Value
 	input := d.GetAttr("input")
 	output := d.GetAttr("output")
 	if input.IsNull() {

--- a/internal/command/jsonformat/state_test.go
+++ b/internal/command/jsonformat/state_test.go
@@ -32,32 +32,32 @@ func TestState(t *testing.T) {
 		Schemas *terraform.Schemas
 		Want    string
 	}{
-		{
+		0: {
 			State:   &states.State{},
 			Schemas: &terraform.Schemas{},
 			Want:    "The state file is empty. No resources are represented.\n",
 		},
-		{
+		1: {
 			State:   basicState(t),
 			Schemas: testSchemas(),
 			Want:    basicStateOutput,
 		},
-		{
+		2: {
 			State:   nestedState(t),
 			Schemas: testSchemas(),
 			Want:    nestedStateOutput,
 		},
-		{
+		3: {
 			State:   deposedState(t),
 			Schemas: testSchemas(),
 			Want:    deposedNestedStateOutput,
 		},
-		{
+		4: {
 			State:   onlyDeposedState(t),
 			Schemas: testSchemas(),
 			Want:    onlyDeposedOutput,
 		},
-		{
+		5: {
 			State:   stateWithMoreOutputs(t),
 			Schemas: testSchemas(),
 			Want:    stateWithMoreOutputsOutput,
@@ -253,7 +253,10 @@ func basicState(t *testing.T) *states.State {
 	}
 
 	rootModule.SetLocalValue("foo", cty.StringVal("foo value"))
-	rootModule.SetOutputValue("bar", cty.StringVal("bar value"), false)
+	state.SetOutputValue(
+		addrs.OutputValue{Name: "bar"}.Absolute(addrs.RootModuleInstance),
+		cty.StringVal("bar value"), false,
+	)
 	rootModule.SetResourceInstanceCurrent(
 		addrs.Resource{
 			Mode: addrs.ManagedResourceMode,
@@ -297,14 +300,30 @@ func stateWithMoreOutputs(t *testing.T) *states.State {
 		t.Errorf("root module is nil; want valid object")
 	}
 
-	rootModule.SetOutputValue("string_var", cty.StringVal("string value"), false)
-	rootModule.SetOutputValue("int_var", cty.NumberIntVal(42), false)
-	rootModule.SetOutputValue("bool_var", cty.BoolVal(true), false)
-	rootModule.SetOutputValue("sensitive_var", cty.StringVal("secret!!!"), true)
-	rootModule.SetOutputValue("map_var", cty.MapVal(map[string]cty.Value{
-		"first":  cty.StringVal("foo"),
-		"second": cty.StringVal("bar"),
-	}), false)
+	state.SetOutputValue(
+		addrs.OutputValue{Name: "string_var"}.Absolute(addrs.RootModuleInstance),
+		cty.StringVal("string value"), false,
+	)
+	state.SetOutputValue(
+		addrs.OutputValue{Name: "int_var"}.Absolute(addrs.RootModuleInstance),
+		cty.NumberIntVal(42), false,
+	)
+	state.SetOutputValue(
+		addrs.OutputValue{Name: "bool_var"}.Absolute(addrs.RootModuleInstance),
+		cty.True, false,
+	)
+	state.SetOutputValue(
+		addrs.OutputValue{Name: "sensitive_var"}.Absolute(addrs.RootModuleInstance),
+		cty.StringVal("secret!!!"), true,
+	)
+	state.SetOutputValue(
+		addrs.OutputValue{Name: "map_var"}.Absolute(addrs.RootModuleInstance),
+		cty.MapVal(map[string]cty.Value{
+			"first":  cty.StringVal("foo"),
+			"second": cty.StringVal("bar"),
+		}),
+		false,
+	)
 
 	rootModule.SetResourceInstanceCurrent(
 		addrs.Resource{

--- a/internal/command/jsonformat/state_test.go
+++ b/internal/command/jsonformat/state_test.go
@@ -252,7 +252,6 @@ func basicState(t *testing.T) *states.State {
 		t.Errorf("root module is nil; want valid object")
 	}
 
-	rootModule.SetLocalValue("foo", cty.StringVal("foo value"))
 	state.SetOutputValue(
 		addrs.OutputValue{Name: "bar"}.Absolute(addrs.RootModuleInstance),
 		cty.StringVal("bar value"), false,

--- a/internal/command/jsonstate/state.go
+++ b/internal/command/jsonstate/state.go
@@ -149,7 +149,7 @@ func MarshalForRenderer(sf *statefile.File, schemas *terraform.Schemas) (Module,
 		return Module{}, nil, nil
 	}
 
-	outputs, err := MarshalOutputs(sf.State.RootModule().OutputValues)
+	outputs, err := MarshalOutputs(sf.State.RootOutputValues)
 	if err != nil {
 		return Module{}, nil, err
 	}
@@ -193,7 +193,7 @@ func (jsonstate *state) marshalStateValues(s *states.State, schemas *terraform.S
 	var err error
 
 	// only marshal the root module outputs
-	sv.Outputs, err = MarshalOutputs(s.RootModule().OutputValues)
+	sv.Outputs, err = MarshalOutputs(s.RootOutputValues)
 	if err != nil {
 		return err
 	}

--- a/internal/command/meta_backend_test.go
+++ b/internal/command/meta_backend_test.go
@@ -136,7 +136,10 @@ func TestMetaBackend_emptyWithDefaultState(t *testing.T) {
 
 	// Write some state
 	next := testState()
-	next.RootModule().SetOutputValue("foo", cty.StringVal("bar"), false)
+	next.SetOutputValue(
+		addrs.OutputValue{Name: "foo"}.Absolute(addrs.RootModuleInstance),
+		cty.StringVal("bar"), false,
+	)
 	s.WriteState(next)
 	if err := s.PersistState(nil); err != nil {
 		t.Fatalf("unexpected error: %s", err)
@@ -1862,7 +1865,10 @@ func TestMetaBackend_localDoesNotDeleteLocal(t *testing.T) {
 
 	// // create our local state
 	orig := states.NewState()
-	orig.Module(addrs.RootModuleInstance).SetOutputValue("foo", cty.StringVal("bar"), false)
+	orig.SetOutputValue(
+		addrs.OutputValue{Name: "foo"}.Absolute(addrs.RootModuleInstance),
+		cty.StringVal("bar"), false,
+	)
 	testStateFileDefault(t, orig)
 
 	m := testMetaBackend(t, nil)

--- a/internal/command/refresh.go
+++ b/internal/command/refresh.go
@@ -104,7 +104,7 @@ func (c *RefreshCommand) Run(rawArgs []string) int {
 	}
 
 	if op.State != nil {
-		view.Outputs(op.State.RootModule().OutputValues)
+		view.Outputs(op.State.RootOutputValues)
 	}
 
 	return op.Result.ExitStatus()

--- a/internal/command/show_test.go
+++ b/internal/command/show_test.go
@@ -494,12 +494,15 @@ func TestShow_plan_json(t *testing.T) {
 
 func TestShow_state(t *testing.T) {
 	originalState := testState()
-	root := originalState.RootModule()
-	root.SetOutputValue("test", cty.ObjectVal(map[string]cty.Value{
-		"attr": cty.NullVal(cty.DynamicPseudoType),
-		"null": cty.NullVal(cty.String),
-		"list": cty.ListVal([]cty.Value{cty.NullVal(cty.Number)}),
-	}), false)
+	originalState.SetOutputValue(
+		addrs.OutputValue{Name: "test"}.Absolute(addrs.RootModuleInstance),
+		cty.ObjectVal(map[string]cty.Value{
+			"attr": cty.NullVal(cty.DynamicPseudoType),
+			"null": cty.NullVal(cty.String),
+			"list": cty.ListVal([]cty.Value{cty.NullVal(cty.Number)}),
+		}),
+		false,
+	)
 
 	statePath := testStateFile(t, originalState)
 	defer os.RemoveAll(filepath.Dir(statePath))

--- a/internal/namedvals/values.go
+++ b/internal/namedvals/values.go
@@ -90,6 +90,10 @@ func (v *values[LocalType, AbsType]) GetExactResult(addr AbsType) cty.Value {
 	return v.exact.Get(addr)
 }
 
+func (v *values[LocalType, AbsType]) GetExactResults() addrs.Map[AbsType, cty.Value] {
+	return v.exact
+}
+
 func (v *values[LocalType, AbsType]) SetPlaceholderResult(addr addrs.InPartialExpandedModule[LocalType], val cty.Value) {
 	modAddr := addr.Module.Module()
 	if !v.placeholder.Has(modAddr) {

--- a/internal/stacks/stackruntime/internal/stackeval/component_instance.go
+++ b/internal/stacks/stackruntime/internal/stackeval/component_instance.go
@@ -908,7 +908,7 @@ func (c *ComponentInstance) ResultValue(ctx context.Context, phase EvalPhase) ct
 
 		// For apply and inspect phases we use the root module output values
 		// from the state to construct our value.
-		outputVals := state.RootModule().OutputValues
+		outputVals := state.RootOutputValues
 		attrs := make(map[string]cty.Value, len(outputVals))
 		for _, ov := range outputVals {
 			name := ov.Addr.OutputValue.Name

--- a/internal/states/module.go
+++ b/internal/states/module.go
@@ -5,7 +5,6 @@ package states
 
 import (
 	"github.com/hashicorp/terraform/internal/addrs"
-	"github.com/zclconf/go-cty/cty"
 )
 
 // Module is a container for the states of objects within a particular module.
@@ -15,18 +14,13 @@ type Module struct {
 	// Resources contains the state for each resource. The keys in this map are
 	// an implementation detail and must not be used by outside callers.
 	Resources map[string]*Resource
-
-	// LocalValues contains the value for each named output value. The keys
-	// in this map are local value names.
-	LocalValues map[string]cty.Value
 }
 
 // NewModule constructs an empty module state for the given module address.
 func NewModule(addr addrs.ModuleInstance) *Module {
 	return &Module{
-		Addr:        addr,
-		Resources:   map[string]*Resource{},
-		LocalValues: map[string]cty.Value{},
+		Addr:      addr,
+		Resources: map[string]*Resource{},
 	}
 }
 
@@ -245,19 +239,6 @@ func (ms *Module) maybeRestoreResourceInstanceDeposed(addr addrs.ResourceInstanc
 	is.Current = is.Deposed[key]
 	delete(is.Deposed, key)
 	return true
-}
-
-// SetLocalValue writes a local value into the state, overwriting any
-// existing value of the same name.
-func (ms *Module) SetLocalValue(name string, value cty.Value) {
-	ms.LocalValues[name] = value
-}
-
-// RemoveLocalValue removes the local value of the given name from the state,
-// if it exists. This method is a no-op if there is no value of the given
-// name.
-func (ms *Module) RemoveLocalValue(name string) {
-	delete(ms.LocalValues, name)
 }
 
 // PruneResourceHusks is a specialized method that will remove any Resource

--- a/internal/states/remote/state.go
+++ b/internal/states/remote/state.go
@@ -70,7 +70,7 @@ func (s *State) GetRootOutputValues() (map[string]*states.OutputValue, error) {
 		state = states.NewState()
 	}
 
-	return state.RootModule().OutputValues, nil
+	return state.RootOutputValues, nil
 }
 
 // StateForMigration is part of our implementation of statemgr.Migrator.

--- a/internal/states/remote/state_test.go
+++ b/internal/states/remote/state_test.go
@@ -233,7 +233,10 @@ func TestStatePersist(t *testing.T) {
 			name: "add output to state",
 			mutationFunc: func(mgr *State) (*states.State, func()) {
 				s := mgr.State()
-				s.RootModule().SetOutputValue("foo", cty.StringVal("bar"), false)
+				s.SetOutputValue(
+					addrs.OutputValue{Name: "foo"}.Absolute(addrs.RootModuleInstance),
+					cty.StringVal("bar"), false,
+				)
 				return s, func() {}
 			},
 			expectedRequests: []mockClientRequest{
@@ -261,7 +264,10 @@ func TestStatePersist(t *testing.T) {
 			name: "mutate state bar -> baz",
 			mutationFunc: func(mgr *State) (*states.State, func()) {
 				s := mgr.State()
-				s.RootModule().SetOutputValue("foo", cty.StringVal("baz"), false)
+				s.SetOutputValue(
+					addrs.OutputValue{Name: "foo"}.Absolute(addrs.RootModuleInstance),
+					cty.StringVal("baz"), false,
+				)
 				return s, func() {}
 			},
 			expectedRequests: []mockClientRequest{

--- a/internal/states/state.go
+++ b/internal/states/state.go
@@ -7,10 +7,9 @@ import (
 	"fmt"
 	"sort"
 
-	"github.com/zclconf/go-cty/cty"
-
 	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/getproviders"
+	"github.com/zclconf/go-cty/cty"
 )
 
 // State is the top-level type of a Terraform state.
@@ -321,16 +320,6 @@ func (s *State) RemoveOutputValue(addr addrs.AbsOutputValue) {
 		return
 	}
 	delete(s.RootOutputValues, addr.OutputValue.Name)
-}
-
-// LocalValue returns the value of the named local value with the given address,
-// or cty.NilVal if no such value is tracked in the state.
-func (s *State) LocalValue(addr addrs.AbsLocalValue) cty.Value {
-	ms := s.Module(addr.Module)
-	if ms == nil {
-		return cty.NilVal
-	}
-	return ms.LocalValues[addr.LocalValue.Name]
 }
 
 // ProviderAddrs returns a list of all of the provider configuration addresses

--- a/internal/states/state_deepcopy.go
+++ b/internal/states/state_deepcopy.go
@@ -59,16 +59,10 @@ func (ms *Module) DeepCopy() *Module {
 	for k, r := range ms.Resources {
 		resources[k] = r.DeepCopy()
 	}
-	localValues := make(map[string]cty.Value, len(ms.LocalValues))
-	for k, v := range ms.LocalValues {
-		// cty.Value is immutable, so we don't need to copy these.
-		localValues[k] = v
-	}
 
 	return &Module{
-		Addr:        ms.Addr, // technically mutable, but immutable by convention
-		Resources:   resources,
-		LocalValues: localValues,
+		Addr:      ms.Addr, // technically mutable, but immutable by convention
+		Resources: resources,
 	}
 }
 

--- a/internal/states/state_deepcopy.go
+++ b/internal/states/state_deepcopy.go
@@ -31,9 +31,14 @@ func (s *State) DeepCopy() *State {
 	for k, m := range s.Modules {
 		modules[k] = m.DeepCopy()
 	}
+	outputValues := make(map[string]*OutputValue, len(s.RootOutputValues))
+	for k, v := range s.RootOutputValues {
+		outputValues[k] = v.DeepCopy()
+	}
 	return &State{
-		Modules:      modules,
-		CheckResults: s.CheckResults.DeepCopy(),
+		Modules:          modules,
+		RootOutputValues: outputValues,
+		CheckResults:     s.CheckResults.DeepCopy(),
 	}
 }
 
@@ -54,10 +59,6 @@ func (ms *Module) DeepCopy() *Module {
 	for k, r := range ms.Resources {
 		resources[k] = r.DeepCopy()
 	}
-	outputValues := make(map[string]*OutputValue, len(ms.OutputValues))
-	for k, v := range ms.OutputValues {
-		outputValues[k] = v.DeepCopy()
-	}
 	localValues := make(map[string]cty.Value, len(ms.LocalValues))
 	for k, v := range ms.LocalValues {
 		// cty.Value is immutable, so we don't need to copy these.
@@ -65,10 +66,9 @@ func (ms *Module) DeepCopy() *Module {
 	}
 
 	return &Module{
-		Addr:         ms.Addr, // technically mutable, but immutable by convention
-		Resources:    resources,
-		OutputValues: outputValues,
-		LocalValues:  localValues,
+		Addr:        ms.Addr, // technically mutable, but immutable by convention
+		Resources:   resources,
+		LocalValues: localValues,
 	}
 }
 

--- a/internal/states/state_test.go
+++ b/internal/states/state_test.go
@@ -28,7 +28,6 @@ func TestState(t *testing.T) {
 		t.Errorf("root module is nil; want valid object")
 	}
 
-	rootModule.SetLocalValue("foo", cty.StringVal("foo value"))
 	state.SetOutputValue(
 		addrs.OutputValue{Name: "bar"}.Absolute(addrs.RootModuleInstance),
 		cty.StringVal("bar value"), false,
@@ -91,9 +90,6 @@ func TestState(t *testing.T) {
 		Modules: map[string]*Module{
 			"": {
 				Addr: addrs.RootModuleInstance,
-				LocalValues: map[string]cty.Value{
-					"foo": cty.StringVal("foo value"),
-				},
 				Resources: map[string]*Resource{
 					"test_thing.baz": {
 						Addr: addrs.Resource{
@@ -120,19 +116,16 @@ func TestState(t *testing.T) {
 				},
 			},
 			"module.child": {
-				Addr:        addrs.RootModuleInstance.Child("child", addrs.NoKey),
-				LocalValues: map[string]cty.Value{},
-				Resources:   map[string]*Resource{},
+				Addr:      addrs.RootModuleInstance.Child("child", addrs.NoKey),
+				Resources: map[string]*Resource{},
 			},
 			`module.multi["a"]`: {
-				Addr:        addrs.RootModuleInstance.Child("multi", addrs.StringKey("a")),
-				LocalValues: map[string]cty.Value{},
-				Resources:   map[string]*Resource{},
+				Addr:      addrs.RootModuleInstance.Child("multi", addrs.StringKey("a")),
+				Resources: map[string]*Resource{},
 			},
 			`module.multi["b"]`: {
-				Addr:        addrs.RootModuleInstance.Child("multi", addrs.StringKey("b")),
-				LocalValues: map[string]cty.Value{},
-				Resources:   map[string]*Resource{},
+				Addr:      addrs.RootModuleInstance.Child("multi", addrs.StringKey("b")),
+				Resources: map[string]*Resource{},
 			},
 		},
 	}
@@ -189,7 +182,6 @@ func TestStateDeepCopy(t *testing.T) {
 		t.Fatalf("root module is nil; want valid object")
 	}
 
-	rootModule.SetLocalValue("foo", cty.StringVal("foo value"))
 	state.SetOutputValue(
 		addrs.OutputValue{Name: "bar"}.Absolute(rootModule.Addr),
 		cty.StringVal("bar value"), false,

--- a/internal/states/statefile/version4.go
+++ b/internal/states/statefile/version4.go
@@ -260,7 +260,6 @@ func prepareStateV4(sV4 *stateV4) (*File, tfdiags.Diagnostics) {
 	// need to reload them now. (For descendent modules we just re-calculate
 	// them based on the latest configuration on each run.)
 	{
-		rootModule := state.RootModule()
 		for name, fos := range sV4.RootOutputs {
 			os := &states.OutputValue{
 				Addr: addrs.AbsOutputValue{
@@ -292,7 +291,7 @@ func prepareStateV4(sV4 *stateV4) (*File, tfdiags.Diagnostics) {
 			}
 
 			os.Value = val
-			rootModule.OutputValues[name] = os
+			state.RootOutputValues[name] = os
 		}
 	}
 
@@ -338,7 +337,7 @@ func writeStateV4(file *File, w io.Writer) tfdiags.Diagnostics {
 		Resources:        []resourceStateV4{},
 	}
 
-	for name, os := range file.State.RootModule().OutputValues {
+	for name, os := range file.State.RootOutputValues {
 		src, err := ctyjson.Marshal(os.Value, os.Value.Type())
 		if err != nil {
 			diags = diags.Append(tfdiags.Sourceless(

--- a/internal/states/statemgr/filesystem.go
+++ b/internal/states/statemgr/filesystem.go
@@ -248,7 +248,7 @@ func (s *Filesystem) GetRootOutputValues() (map[string]*states.OutputValue, erro
 		state = states.NewState()
 	}
 
-	return state.RootModule().OutputValues, nil
+	return state.RootOutputValues, nil
 }
 
 func (s *Filesystem) refreshState() error {

--- a/internal/states/statemgr/statemgr_fake.go
+++ b/internal/states/statemgr/statemgr_fake.go
@@ -70,7 +70,7 @@ func (m *fakeFull) PersistState(schemas *terraform.Schemas) error {
 }
 
 func (m *fakeFull) GetRootOutputValues() (map[string]*states.OutputValue, error) {
-	return m.State().RootModule().OutputValues, nil
+	return m.State().RootOutputValues, nil
 }
 
 func (m *fakeFull) Lock(info *LockInfo) (string, error) {

--- a/internal/states/statemgr/testing.go
+++ b/internal/states/statemgr/testing.go
@@ -48,7 +48,10 @@ func TestFull(t *testing.T, s Full) {
 	current := s.State()
 
 	// Write a new state and verify that we have it
-	current.RootModule().SetOutputValue("bar", cty.StringVal("baz"), false)
+	current.SetOutputValue(
+		addrs.OutputValue{Name: "bar"}.Absolute(addrs.RootModuleInstance),
+		cty.StringVal("baz"), false,
+	)
 
 	if err := s.WriteState(current); err != nil {
 		t.Fatalf("err: %s", err)
@@ -101,9 +104,11 @@ func TestFull(t *testing.T, s Full) {
 
 	// Change the serial
 	current = current.DeepCopy()
-	current.EnsureModule(addrs.RootModuleInstance).SetOutputValue(
-		"serialCheck", cty.StringVal("true"), false,
+	current.SetOutputValue(
+		addrs.OutputValue{Name: "serialCheck"}.Absolute(addrs.RootModuleInstance),
+		cty.StringVal("true"), false,
 	)
+
 	if err := s.WriteState(current); err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -159,8 +164,14 @@ func TestFullInitialState() *states.State {
 	}
 	childMod.SetResourceProvider(rAddr, providerAddr)
 
-	state.RootModule().SetOutputValue("sensitive_output", cty.StringVal("it's a secret"), true)
-	state.RootModule().SetOutputValue("nonsensitive_output", cty.StringVal("hello, world!"), false)
+	state.SetOutputValue(
+		addrs.OutputValue{Name: "sensitive_output"}.Absolute(addrs.RootModuleInstance),
+		cty.StringVal("it's a secret"), true,
+	)
+	state.SetOutputValue(
+		addrs.OutputValue{Name: "nonsensitive_output"}.Absolute(addrs.RootModuleInstance),
+		cty.StringVal("hello, world!"), false,
+	)
 
 	return state
 }

--- a/internal/states/sync.go
+++ b/internal/states/sync.go
@@ -103,44 +103,6 @@ func (s *SyncState) RemoveOutputValue(addr addrs.AbsOutputValue) {
 	s.state.RemoveOutputValue(addr)
 }
 
-// LocalValue returns the current value associated with the given local value
-// address.
-func (s *SyncState) LocalValue(addr addrs.AbsLocalValue) cty.Value {
-	s.lock.RLock()
-	// cty.Value is immutable, so we don't need any extra copying here.
-	ret := s.state.LocalValue(addr)
-	s.lock.RUnlock()
-	return ret
-}
-
-// SetLocalValue writes a given output value into the state, overwriting
-// any existing value of the same name.
-//
-// If the module containing the local value is not yet tracked in state then it
-// will be added as a side-effect.
-func (s *SyncState) SetLocalValue(addr addrs.AbsLocalValue, value cty.Value) {
-	defer s.beginWrite()()
-
-	ms := s.state.EnsureModule(addr.Module)
-	ms.SetLocalValue(addr.LocalValue.Name, value)
-}
-
-// RemoveLocalValue removes the stored value for the local value with the
-// given address.
-//
-// If this results in its containing module being empty, the module will be
-// pruned from the state as a side-effect.
-func (s *SyncState) RemoveLocalValue(addr addrs.AbsLocalValue) {
-	defer s.beginWrite()()
-
-	ms := s.state.Module(addr.Module)
-	if ms == nil {
-		return
-	}
-	ms.RemoveLocalValue(addr.LocalValue.Name)
-	s.maybePruneModule(addr.Module)
-}
-
 // Resource returns a snapshot of the state of the resource with the given
 // address, or nil if no such resource is tracked.
 //

--- a/internal/states/sync.go
+++ b/internal/states/sync.go
@@ -53,18 +53,6 @@ func (s *SyncState) Module(addr addrs.ModuleInstance) *Module {
 	return ret
 }
 
-// ModuleOutputs returns the set of OutputValues that matches the given path.
-func (s *SyncState) ModuleOutputs(parentAddr addrs.ModuleInstance, module addrs.ModuleCall) []*OutputValue {
-	s.lock.RLock()
-	defer s.lock.RUnlock()
-	var os []*OutputValue
-
-	for _, o := range s.state.ModuleOutputs(parentAddr, module) {
-		os = append(os, o.DeepCopy())
-	}
-	return os
-}
-
 // RemoveModule removes the entire state for the given module, taking with
 // it any resources associated with the module. This should generally be
 // called only for modules whose resources have all been destroyed, but
@@ -90,29 +78,29 @@ func (s *SyncState) OutputValue(addr addrs.AbsOutputValue) *OutputValue {
 // SetOutputValue writes a given output value into the state, overwriting
 // any existing value of the same name.
 //
-// If the module containing the output is not yet tracked in state then it
-// be added as a side-effect.
+// The state only tracks output values for the root module, so attempts to
+// write output values for any other module will be silently ignored.
 func (s *SyncState) SetOutputValue(addr addrs.AbsOutputValue, value cty.Value, sensitive bool) {
-	defer s.beginWrite()()
+	if !addr.Module.IsRoot() {
+		return
+	}
 
-	ms := s.state.EnsureModule(addr.Module)
-	ms.SetOutputValue(addr.OutputValue.Name, value, sensitive)
+	defer s.beginWrite()()
+	s.state.SetOutputValue(addr, value, sensitive)
 }
 
 // RemoveOutputValue removes the stored value for the output value with the
 // given address.
 //
-// If this results in its containing module being empty, the module will be
-// pruned from the state as a side-effect.
+// The state only tracks output values for the root module, so attempts to
+// remove output values for any other module will be silently ignored.
 func (s *SyncState) RemoveOutputValue(addr addrs.AbsOutputValue) {
-	defer s.beginWrite()()
-
-	ms := s.state.Module(addr.Module)
-	if ms == nil {
+	if !addr.Module.IsRoot() {
 		return
 	}
-	ms.RemoveOutputValue(addr.OutputValue.Name)
-	s.maybePruneModule(addr.Module)
+
+	defer s.beginWrite()()
+	s.state.RemoveOutputValue(addr)
 }
 
 // LocalValue returns the current value associated with the given local value

--- a/internal/terraform/context_apply2_test.go
+++ b/internal/terraform/context_apply2_test.go
@@ -621,7 +621,7 @@ func TestContext2Apply_nullableVariables(t *testing.T) {
 		t.Fatalf("apply: %s", diags.Err())
 	}
 
-	outputs := state.Module(addrs.RootModuleInstance).OutputValues
+	outputs := state.RootOutputValues
 	// we check for null outputs be seeing that they don't exists
 	if _, ok := outputs["nullable_null_default"]; ok {
 		t.Error("nullable_null_default: expected no output value")
@@ -1686,7 +1686,10 @@ output "from_resource" {
 		},
 		mustProviderConfig(`provider["registry.terraform.io/hashicorp/test"]`),
 	)
-	mod.SetOutputValue("from_resource", cty.StringVal("wrong val"), false)
+	state.SetOutputValue(
+		addrs.OutputValue{Name: "from_resource"}.Absolute(addrs.RootModuleInstance),
+		cty.StringVal("wrong val"), false,
+	)
 
 	ctx := testContext2(t, &ContextOpts{
 		Providers: map[addrs.Provider]providers.Factory{

--- a/internal/terraform/context_apply_test.go
+++ b/internal/terraform/context_apply_test.go
@@ -717,10 +717,7 @@ module.test:
   null_resource.noop:
     ID = foo
     provider = provider["registry.terraform.io/hashicorp/null"]
-
-  Outputs:
-
-  amis_out = {eu-west-1:ami-789012 eu-west-2:ami-989484 us-west-1:ami-123456 us-west-2:ami-456789 }`)
+`)
 	if actual != expected {
 		t.Fatalf("expected: \n%s\n\ngot: \n%s\n", expected, actual)
 	}
@@ -3296,10 +3293,6 @@ module.A:
     provider = provider["registry.terraform.io/hashicorp/aws"]
     foo = bar
     type = aws_instance
-
-  Outputs:
-
-  value = foo
 module.B:
   aws_instance.bar:
     ID = foo
@@ -3605,7 +3598,7 @@ func TestContext2Apply_multiVar(t *testing.T) {
 		t.Fatalf("diags: %s", diags.Err())
 	}
 
-	actual := state.RootModule().OutputValues["output"]
+	actual := state.RootOutputValues["output"]
 	expected := cty.StringVal("bar0,bar1,bar2")
 	if actual == nil || actual.Value != expected {
 		t.Fatalf("wrong value\ngot:  %#v\nwant: %#v", actual.Value, expected)
@@ -3639,7 +3632,7 @@ func TestContext2Apply_multiVar(t *testing.T) {
 
 		t.Logf("End state: %s", state.String())
 
-		actual := state.RootModule().OutputValues["output"]
+		actual := state.RootOutputValues["output"]
 		if actual == nil {
 			t.Fatal("missing output")
 		}
@@ -3846,7 +3839,7 @@ func TestContext2Apply_multiVarComprehensive(t *testing.T) {
 			},
 		}
 		got := map[string]interface{}{}
-		for k, s := range state.RootModule().OutputValues {
+		for k, s := range state.RootOutputValues {
 			got[k] = hcl2shim.ConfigValueFromHCL2(s.Value)
 		}
 		if !reflect.DeepEqual(got, want) {
@@ -3882,7 +3875,7 @@ func TestContext2Apply_multiVarOrder(t *testing.T) {
 
 	t.Logf("State: %s", state.String())
 
-	actual := state.RootModule().OutputValues["should-be-11"]
+	actual := state.RootOutputValues["should-be-11"]
 	expected := cty.StringVal("index-11")
 	if actual == nil || actual.Value != expected {
 		t.Fatalf("wrong value\ngot:  %#v\nwant: %#v", actual.Value, expected)
@@ -3913,7 +3906,7 @@ func TestContext2Apply_multiVarOrderInterp(t *testing.T) {
 
 	t.Logf("State: %s", state.String())
 
-	actual := state.RootModule().OutputValues["should-be-11"]
+	actual := state.RootOutputValues["should-be-11"]
 	expected := cty.StringVal("baz-index-11")
 	if actual == nil || actual.Value != expected {
 		t.Fatalf("wrong value\ngot:  %#v\nwant: %#v", actual.Value, expected)
@@ -4070,9 +4063,14 @@ func TestContext2Apply_outputOrphan(t *testing.T) {
 	p.PlanResourceChangeFn = testDiffFn
 
 	state := states.NewState()
-	root := state.EnsureModule(addrs.RootModuleInstance)
-	root.SetOutputValue("foo", cty.StringVal("bar"), false)
-	root.SetOutputValue("bar", cty.StringVal("baz"), false)
+	state.SetOutputValue(
+		addrs.OutputValue{Name: "foo"}.Absolute(addrs.RootModuleInstance),
+		cty.StringVal("bar"), false,
+	)
+	state.SetOutputValue(
+		addrs.OutputValue{Name: "bar"}.Absolute(addrs.RootModuleInstance),
+		cty.StringVal("baz"), false,
+	)
 
 	ctx := testContext2(t, &ContextOpts{
 		Providers: map[addrs.Provider]providers.Factory{
@@ -7158,7 +7156,10 @@ func TestContext2Apply_targetedDestroy(t *testing.T) {
 		},
 		mustProviderConfig(`provider["registry.terraform.io/hashicorp/aws"]`),
 	)
-	root.SetOutputValue("out", cty.StringVal("bar"), false)
+	state.SetOutputValue(
+		addrs.OutputValue{Name: "out"}.Absolute(addrs.RootModuleInstance),
+		cty.StringVal("bar"), false,
+	)
 
 	child := state.EnsureModule(addrs.RootModuleInstance.Child("child", addrs.NoKey))
 	child.SetResourceInstanceCurrent(
@@ -7217,8 +7218,8 @@ func TestContext2Apply_targetedDestroy(t *testing.T) {
 	// TODO: Future refactoring may enable us to remove the output from state in
 	// this case, and that would be Just Fine - this test can be modified to
 	// expect 0 outputs.
-	if len(mod.OutputValues) != 1 {
-		t.Fatalf("expected 1 outputs, got: %#v", mod.OutputValues)
+	if len(state.RootOutputValues) != 1 {
+		t.Fatalf("expected 1 outputs, got: %#v", state.RootOutputValues)
 	}
 
 	// the module instance should remain
@@ -7521,6 +7522,7 @@ func TestContext2Apply_targetedModuleDep(t *testing.T) {
 		t.Fatalf("diags: %s", diags.Err())
 	}
 
+	// The output from module.child is copied into aws_instance.foo.foo
 	checkStateString(t, state, `
 aws_instance.foo:
   ID = foo
@@ -7536,11 +7538,7 @@ module.child:
     ID = foo
     provider = provider["registry.terraform.io/hashicorp/aws"]
     type = aws_instance
-
-  Outputs:
-
-  output = foo
-	`)
+`)
 }
 
 // GH-10911 untargeted outputs should not be in the graph, and therefore
@@ -7588,10 +7586,6 @@ module.child2:
     ID = foo
     provider = provider["registry.terraform.io/hashicorp/aws"]
     type = aws_instance
-
-  Outputs:
-
-  instance_id = foo
 `)
 }
 
@@ -8667,7 +8661,7 @@ func TestContext2Apply_terraformWorkspace(t *testing.T) {
 		t.Fatalf("diags: %s", diags.Err())
 	}
 
-	actual := state.RootModule().OutputValues["output"]
+	actual := state.RootOutputValues["output"]
 	expected := cty.StringVal("foo")
 	if actual == nil || actual.Value != expected {
 		t.Fatalf("wrong value\ngot:  %#v\nwant: %#v", actual.Value, expected)
@@ -8786,7 +8780,10 @@ func TestContext2Apply_destroyWithLocals(t *testing.T) {
 		},
 		mustProviderConfig(`provider["registry.terraform.io/hashicorp/aws"]`),
 	)
-	root.SetOutputValue("name", cty.StringVal("test-bar"), false)
+	state.SetOutputValue(
+		addrs.OutputValue{Name: "name"}.Absolute(addrs.RootModuleInstance),
+		cty.StringVal("test-bar"), false,
+	)
 
 	ctx := testContext2(t, &ContextOpts{
 		Providers: map[addrs.Provider]providers.Factory{
@@ -9094,7 +9091,10 @@ func TestContext2Apply_plannedDestroyInterpolatedCount(t *testing.T) {
 		},
 		mustProviderConfig(`provider["registry.terraform.io/hashicorp/aws"]`),
 	)
-	root.SetOutputValue("out", cty.ListVal([]cty.Value{cty.StringVal("foo"), cty.StringVal("foo")}), false)
+	state.SetOutputValue(
+		addrs.OutputValue{Name: "out"}.Absolute(addrs.RootModuleInstance),
+		cty.ListVal([]cty.Value{cty.StringVal("foo"), cty.StringVal("foo")}), false,
+	)
 
 	ctx := testContext2(t, &ContextOpts{
 		Providers: providers,
@@ -10833,6 +10833,14 @@ module "mod2" {
   source = "./mod"
   in = module.mod1["a"].out
 }
+
+output "mod1" {
+  value = module.mod1
+}
+
+output "mod2" {
+  value = module.mod2
+}
 `,
 		"mod/main.tf": `
 resource "aws_instance" "foo" {
@@ -10870,16 +10878,17 @@ output "out" {
 	}
 
 	expected := `<no state>
+Outputs:
+
+mod1 = {a:map[out:foo] }
+mod2 = {out:foo }
+
 module.mod1["a"]:
   aws_instance.foo:
     ID = foo
     provider = provider["registry.terraform.io/hashicorp/aws"]
     foo = default
     type = aws_instance
-
-  Outputs:
-
-  out = foo
 module.mod2:
   aws_instance.foo:
     ID = foo
@@ -11317,7 +11326,7 @@ locals {
 	}
 
 	// check the output, as those can't cause an error planning the value
-	out := state.RootModule().OutputValues["out"].Value.AsString()
+	out := state.RootOutputValues["out"].Value.AsString()
 	if out != "a0" {
 		t.Fatalf(`expected output "a0", got: %q`, out)
 	}
@@ -11372,7 +11381,7 @@ locals {
 	}
 
 	// check the output, as those can't cause an error planning the value
-	out = state.RootModule().OutputValues["out"].Value.AsString()
+	out = state.RootOutputValues["out"].Value.AsString()
 	if out != "" {
 		t.Fatalf(`expected output "", got: %q`, out)
 	}
@@ -12212,7 +12221,7 @@ output "out" {
 		t.Fatal(diags.ErrWithWarnings())
 	}
 
-	got := state.RootModule().OutputValues["out"].Value
+	got := state.RootOutputValues["out"].Value
 	want := cty.ObjectVal(map[string]cty.Value{
 		"required": cty.StringVal("boop"),
 
@@ -12271,7 +12280,7 @@ output "out" {
 		t.Fatal(diags.ErrWithWarnings())
 	}
 
-	got := state.RootModule().OutputValues["out"].Value
+	got := state.RootOutputValues["out"].Value
 	want := cty.ObjectVal(map[string]cty.Value{
 		"required": cty.StringVal("boop"),
 
@@ -12321,7 +12330,7 @@ output "out" {
 		t.Fatal(diags.ErrWithWarnings())
 	}
 
-	got := state.RootModule().OutputValues["out"].Value
+	got := state.RootOutputValues["out"].Value
 	// The null default value should be bound, after type converting to the
 	// full object type
 	want := cty.TupleVal([]cty.Value{cty.NullVal(cty.Object(map[string]cty.Type{
@@ -12384,7 +12393,7 @@ output "out" {
 		t.Fatal(diags.ErrWithWarnings())
 	}
 
-	got := state.RootModule().OutputValues["out"].Value
+	got := state.RootOutputValues["out"].Value
 	want := cty.ListVal([]cty.Value{
 		cty.ObjectVal(map[string]cty.Value{
 			"a": cty.SetVal([]cty.Value{cty.StringVal("foo")}),

--- a/internal/terraform/context_plan_test.go
+++ b/internal/terraform/context_plan_test.go
@@ -6914,8 +6914,10 @@ output "planned" {
 
 	ctx := testContext2(t, &ContextOpts{})
 	state := states.BuildState(func(s *states.SyncState) {
-		r := s.Module(addrs.RootModuleInstance)
-		r.SetOutputValue("planned", cty.NullVal(cty.DynamicPseudoType), false)
+		s.SetOutputValue(
+			addrs.OutputValue{Name: "planned"}.Absolute(addrs.RootModuleInstance),
+			cty.NullVal(cty.DynamicPseudoType), false,
+		)
 	})
 	plan, diags := ctx.Plan(m, state, DefaultPlanOpts)
 	if diags.HasErrors() {

--- a/internal/terraform/context_refresh_test.go
+++ b/internal/terraform/context_refresh_test.go
@@ -721,7 +721,10 @@ func TestContext2Refresh_output(t *testing.T) {
 	state := states.NewState()
 	root := state.EnsureModule(addrs.RootModuleInstance)
 	testSetResourceInstanceCurrent(root, "aws_instance.web", `{"id":"foo","foo":"bar"}`, `provider["registry.terraform.io/hashicorp/aws"]`)
-	root.SetOutputValue("foo", cty.StringVal("foo"), false)
+	state.SetOutputValue(
+		addrs.OutputValue{Name: "foo"}.Absolute(addrs.RootModuleInstance),
+		cty.StringVal("foo"), false,
+	)
 
 	ctx := testContext2(t, &ContextOpts{
 		Providers: map[addrs.Provider]providers.Factory{

--- a/internal/terraform/context_walk.go
+++ b/internal/terraform/context_walk.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform/internal/configs"
 	"github.com/hashicorp/terraform/internal/instances"
 	"github.com/hashicorp/terraform/internal/moduletest/mocking"
+	"github.com/hashicorp/terraform/internal/namedvals"
 	"github.com/hashicorp/terraform/internal/plans"
 	"github.com/hashicorp/terraform/internal/providers"
 	"github.com/hashicorp/terraform/internal/refactoring"
@@ -163,6 +164,7 @@ func (c *Context) graphWalker(operation walkOperation, opts *graphWalkOpts) *Con
 		Overrides:               opts.Overrides,
 		PrevRunState:            prevRunState,
 		Changes:                 changes.SyncWrapper(),
+		NamedValues:             namedvals.NewState(),
 		Checks:                  checkState,
 		InstanceExpander:        instances.NewExpander(),
 		ExternalProviderConfigs: opts.ExternalProviderConfigs,

--- a/internal/terraform/eval_context.go
+++ b/internal/terraform/eval_context.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform/internal/instances"
 	"github.com/hashicorp/terraform/internal/lang"
 	"github.com/hashicorp/terraform/internal/moduletest/mocking"
+	"github.com/hashicorp/terraform/internal/namedvals"
 	"github.com/hashicorp/terraform/internal/plans"
 	"github.com/hashicorp/terraform/internal/providers"
 	"github.com/hashicorp/terraform/internal/provisioners"
@@ -133,35 +134,10 @@ type EvalContext interface {
 	// addresses in this context.
 	EvaluationScope(self addrs.Referenceable, source addrs.Referenceable, keyData InstanceKeyEvalData) *lang.Scope
 
-	// SetRootModuleArgument defines the value for one variable of the root
-	// module. The caller must ensure that given value is a suitable
-	// "final value" for the variable, which means that it's already converted
-	// and validated to match any configured constraints and validation rules.
-	//
-	// Calling this function multiple times with the same variable address
-	// will silently overwrite the value provided by a previous call.
-	SetRootModuleArgument(addrs.InputVariable, cty.Value)
-
-	// SetModuleCallArgument defines the value for one input variable of a
-	// particular child module call. The caller must ensure that the given
-	// value is a suitable "final value" for the variable, which means that
-	// it's already converted and validated to match any configured
-	// constraints and validation rules.
-	//
-	// Calling this function multiple times with the same variable address
-	// will silently overwrite the value provided by a previous call.
-	SetModuleCallArgument(addrs.ModuleCallInstance, addrs.InputVariable, cty.Value)
-
-	// GetVariableValue returns the value provided for the input variable with
-	// the given address, or cty.DynamicVal if the variable hasn't been assigned
-	// a value yet.
-	//
-	// Most callers should deal with variable values only indirectly via
-	// EvaluationScope and the other expression evaluation functions, but
-	// this is provided because variables tend to be evaluated outside of
-	// the context of the module they belong to and so we sometimes need to
-	// override the normal expression evaluation behavior.
-	GetVariableValue(addr addrs.AbsInputVariableInstance) cty.Value
+	// NamedValues returns the object that tracks the gradual evaluation of
+	// all input variables, local values, and output values during a graph
+	// walk.
+	NamedValues() *namedvals.State
 
 	// Changes returns the writer object that can be used to write new proposed
 	// changes into the global changes set.

--- a/internal/terraform/eval_context_builtin.go
+++ b/internal/terraform/eval_context_builtin.go
@@ -49,9 +49,9 @@ type BuiltinEvalContext struct {
 	// eval context.
 	Evaluator *Evaluator
 
-	// NamedValues is where we keep the values of already-evaluated input
+	// NamedValuesValue is where we keep the values of already-evaluated input
 	// variables, local values, and output values.
-	NamedValues *namedvals.State
+	NamedValuesValue *namedvals.State
 
 	// Plugins is a library of plugin components (providers and provisioners)
 	// available for use during a graph walk.
@@ -452,25 +452,8 @@ func (ctx *BuiltinEvalContext) Path() addrs.ModuleInstance {
 	return ctx.PathValue
 }
 
-func (ctx *BuiltinEvalContext) SetRootModuleArgument(addr addrs.InputVariable, v cty.Value) {
-	log.Printf("[TRACE] BuiltinEvalContext: Storing final value for variable %s", addr.Absolute(addrs.RootModuleInstance))
-
-	absAddr := addrs.RootModuleInstance.InputVariable(addr.Name)
-	ctx.NamedValues.SetInputVariableValue(absAddr, v)
-}
-
-func (ctx *BuiltinEvalContext) SetModuleCallArgument(callAddr addrs.ModuleCallInstance, varAddr addrs.InputVariable, v cty.Value) {
-	if !ctx.pathSet {
-		panic("context path not set")
-	}
-
-	childPath := callAddr.ModuleInstance(ctx.PathValue)
-	log.Printf("[TRACE] BuiltinEvalContext: Storing final value for variable %s", varAddr.Absolute(childPath))
-	ctx.NamedValues.SetInputVariableValue(childPath.InputVariable(varAddr.Name), v)
-}
-
-func (ctx *BuiltinEvalContext) GetVariableValue(addr addrs.AbsInputVariableInstance) cty.Value {
-	return ctx.NamedValues.GetInputVariableValue(addr)
+func (ctx *BuiltinEvalContext) NamedValues() *namedvals.State {
+	return ctx.NamedValuesValue
 }
 
 func (ctx *BuiltinEvalContext) Changes() *plans.ChangesSync {

--- a/internal/terraform/eval_context_mock.go
+++ b/internal/terraform/eval_context_mock.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hashicorp/terraform/internal/instances"
 	"github.com/hashicorp/terraform/internal/lang"
 	"github.com/hashicorp/terraform/internal/moduletest/mocking"
+	"github.com/hashicorp/terraform/internal/namedvals"
 	"github.com/hashicorp/terraform/internal/plans"
 	"github.com/hashicorp/terraform/internal/providers"
 	"github.com/hashicorp/terraform/internal/provisioners"
@@ -118,21 +119,8 @@ type MockEvalContext struct {
 	PathCalled bool
 	PathPath   addrs.ModuleInstance
 
-	SetRootModuleArgumentCalled bool
-	SetRootModuleArgumentAddr   addrs.InputVariable
-	SetRootModuleArgumentValue  cty.Value
-	SetRootModuleArgumentFunc   func(addr addrs.InputVariable, v cty.Value)
-
-	SetModuleCallArgumentCalled     bool
-	SetModuleCallArgumentModuleCall addrs.ModuleCallInstance
-	SetModuleCallArgumentVariable   addrs.InputVariable
-	SetModuleCallArgumentValue      cty.Value
-	SetModuleCallArgumentFunc       func(callAddr addrs.ModuleCallInstance, varAddr addrs.InputVariable, v cty.Value)
-
-	GetVariableValueCalled bool
-	GetVariableValueAddr   addrs.AbsInputVariableInstance
-	GetVariableValueValue  cty.Value
-	GetVariableValueFunc   func(addr addrs.AbsInputVariableInstance) cty.Value // supersedes GetVariableValueValue
+	NamedValuesCalled bool
+	NamedValuesState  *namedvals.State
 
 	ChangesCalled  bool
 	ChangesChanges *plans.ChangesSync
@@ -346,32 +334,9 @@ func (c *MockEvalContext) Path() addrs.ModuleInstance {
 	return c.PathPath
 }
 
-func (c *MockEvalContext) SetRootModuleArgument(addr addrs.InputVariable, v cty.Value) {
-	c.SetRootModuleArgumentCalled = true
-	c.SetRootModuleArgumentAddr = addr
-	c.SetRootModuleArgumentValue = v
-	if c.SetRootModuleArgumentFunc != nil {
-		c.SetRootModuleArgumentFunc(addr, v)
-	}
-}
-
-func (c *MockEvalContext) SetModuleCallArgument(callAddr addrs.ModuleCallInstance, varAddr addrs.InputVariable, v cty.Value) {
-	c.SetModuleCallArgumentCalled = true
-	c.SetModuleCallArgumentModuleCall = callAddr
-	c.SetModuleCallArgumentVariable = varAddr
-	c.SetModuleCallArgumentValue = v
-	if c.SetModuleCallArgumentFunc != nil {
-		c.SetModuleCallArgumentFunc(callAddr, varAddr, v)
-	}
-}
-
-func (c *MockEvalContext) GetVariableValue(addr addrs.AbsInputVariableInstance) cty.Value {
-	c.GetVariableValueCalled = true
-	c.GetVariableValueAddr = addr
-	if c.GetVariableValueFunc != nil {
-		return c.GetVariableValueFunc(addr)
-	}
-	return c.GetVariableValueValue
+func (c *MockEvalContext) NamedValues() *namedvals.State {
+	c.NamedValuesCalled = true
+	return c.NamedValuesState
 }
 
 func (c *MockEvalContext) Changes() *plans.ChangesSync {

--- a/internal/terraform/eval_variable.go
+++ b/internal/terraform/eval_variable.go
@@ -223,7 +223,7 @@ func evalVariableValidations(addr addrs.AbsInputVariableInstance, config *config
 	// bypass our usual evaluation machinery here and just produce a minimal
 	// evaluation context containing just the required value, and thus avoid
 	// the problem that ctx's evaluation functions refer to the wrong module.
-	val := ctx.GetVariableValue(addr)
+	val := ctx.NamedValues().GetInputVariableValue(addr)
 	if val == cty.NilVal {
 		diags = diags.Append(&hcl.Diagnostic{
 			Severity: hcl.DiagError,

--- a/internal/terraform/eval_variable_test.go
+++ b/internal/terraform/eval_variable_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/terraform/internal/checks"
 	"github.com/hashicorp/terraform/internal/lang"
 	"github.com/hashicorp/terraform/internal/lang/marks"
+	"github.com/hashicorp/terraform/internal/namedvals"
 	"github.com/hashicorp/terraform/internal/tfdiags"
 )
 
@@ -1173,12 +1174,8 @@ func TestEvalVariableValidations_jsonErrorMessageEdgeCase(t *testing.T) {
 			// We need a minimal scope to allow basic functions to be passed to
 			// the HCL scope
 			ctx.EvaluationScopeScope = &lang.Scope{}
-			ctx.GetVariableValueFunc = func(addr addrs.AbsInputVariableInstance) cty.Value {
-				if got, want := addr.String(), varAddr.String(); got != want {
-					t.Errorf("incorrect argument to GetVariableValue: got %s, want %s", got, want)
-				}
-				return test.given
-			}
+			ctx.NamedValuesState = namedvals.NewState()
+			ctx.NamedValuesState.SetInputVariableValue(varAddr, test.given)
 			ctx.ChecksState = checks.NewState(cfg)
 			ctx.ChecksState.ReportCheckableObjects(varAddr.ConfigCheckable(), addrs.MakeSet[addrs.Checkable](varAddr))
 
@@ -1326,15 +1323,11 @@ variable "bar" {
 			// We need a minimal scope to allow basic functions to be passed to
 			// the HCL scope
 			ctx.EvaluationScopeScope = &lang.Scope{}
-			ctx.GetVariableValueFunc = func(addr addrs.AbsInputVariableInstance) cty.Value {
-				if got, want := addr.String(), varAddr.String(); got != want {
-					t.Errorf("incorrect argument to GetVariableValue: got %s, want %s", got, want)
-				}
-				if varCfg.Sensitive {
-					return test.given.Mark(marks.Sensitive)
-				} else {
-					return test.given
-				}
+			ctx.NamedValuesState = namedvals.NewState()
+			if varCfg.Sensitive {
+				ctx.NamedValuesState.SetInputVariableValue(varAddr, test.given.Mark(marks.Sensitive))
+			} else {
+				ctx.NamedValuesState.SetInputVariableValue(varAddr, test.given)
 			}
 			ctx.ChecksState = checks.NewState(cfg)
 			ctx.ChecksState.ReportCheckableObjects(varAddr.ConfigCheckable(), addrs.MakeSet[addrs.Checkable](varAddr))

--- a/internal/terraform/evaluate.go
+++ b/internal/terraform/evaluate.go
@@ -303,12 +303,7 @@ func (d *evaluationStateData) GetLocalValue(addr addrs.LocalValue, rng tfdiags.S
 		return cty.DynamicVal, diags
 	}
 
-	val := d.Evaluator.State.LocalValue(addr.Absolute(d.ModulePath))
-	if val == cty.NilVal {
-		// Not evaluated yet?
-		val = cty.DynamicVal
-	}
-
+	val := d.Evaluator.NamedValues.GetLocalValue(addr.Absolute(d.ModulePath))
 	return val, diags
 }
 

--- a/internal/terraform/evaluate.go
+++ b/internal/terraform/evaluate.go
@@ -346,20 +346,18 @@ func (d *evaluationStateData) GetModule(addr addrs.ModuleCall, rng tfdiags.Sourc
 	// We know the instance path up to this point, and the child module name,
 	// so we only need to store these by instance key.
 	stateMap := map[addrs.InstanceKey]map[string]cty.Value{}
-	for _, output := range d.Evaluator.State.ModuleOutputs(d.ModulePath, addr) {
-		val := output.Value
-		if output.Sensitive {
-			val = val.Mark(marks.Sensitive)
-		}
+	for _, elem := range d.Evaluator.NamedValues.GetOutputValuesForModuleCall(d.ModulePath, addr).Elems {
+		outputAddr := elem.Key
+		val := elem.Value
 
-		_, callInstance := output.Addr.Module.CallInstance()
+		_, callInstance := outputAddr.Module.CallInstance()
 		instance, ok := stateMap[callInstance.Key]
 		if !ok {
 			instance = map[string]cty.Value{}
 			stateMap[callInstance.Key] = instance
 		}
 
-		instance[output.Addr.OutputValue.Name] = val
+		instance[outputAddr.OutputValue.Name] = val
 	}
 
 	// Get all changes that reside for this module call within our path.

--- a/internal/terraform/evaluate.go
+++ b/internal/terraform/evaluate.go
@@ -8,7 +8,6 @@ import (
 	"log"
 	"os"
 	"path/filepath"
-	"sync"
 	"time"
 
 	"github.com/hashicorp/hcl/v2"
@@ -21,6 +20,7 @@ import (
 	"github.com/hashicorp/terraform/internal/instances"
 	"github.com/hashicorp/terraform/internal/lang"
 	"github.com/hashicorp/terraform/internal/lang/marks"
+	"github.com/hashicorp/terraform/internal/namedvals"
 	"github.com/hashicorp/terraform/internal/plans"
 	"github.com/hashicorp/terraform/internal/states"
 	"github.com/hashicorp/terraform/internal/tfdiags"
@@ -39,15 +39,9 @@ type Evaluator struct {
 	// Config is the root node in the configuration tree.
 	Config *configs.Config
 
-	// VariableValues is a map from variable names to their associated values,
-	// within the module indicated by ModulePath. VariableValues is modified
-	// concurrently, and so it must be accessed only while holding
-	// VariableValuesLock.
-	//
-	// The first map level is string representations of addr.ModuleInstance
-	// values, while the second level is variable names.
-	VariableValues     map[string]map[string]cty.Value
-	VariableValuesLock *sync.Mutex
+	// NamedValues is where we keep the values of already-evaluated input
+	// variables, local values, and output values.
+	NamedValues *namedvals.State
 
 	// Plugins is the library of available plugin components (providers and
 	// provisioners) that we have available to help us evaluate expressions
@@ -245,8 +239,6 @@ func (d *evaluationStateData) GetInputVariable(addr addrs.InputVariable, rng tfd
 		})
 		return cty.DynamicVal, diags
 	}
-	d.Evaluator.VariableValuesLock.Lock()
-	defer d.Evaluator.VariableValuesLock.Unlock()
 
 	// During the validate walk, input variables are always unknown so
 	// that we are validating the configuration for all possible input values
@@ -269,36 +261,7 @@ func (d *evaluationStateData) GetInputVariable(addr addrs.InputVariable, rng tfd
 		return cty.UnknownVal(config.Type), diags
 	}
 
-	moduleAddrStr := d.ModulePath.String()
-	vals := d.Evaluator.VariableValues[moduleAddrStr]
-	if vals == nil {
-		return cty.UnknownVal(config.Type), diags
-	}
-
-	// d.Evaluator.VariableValues should always contain valid "final values"
-	// for variables, which is to say that they have already had type
-	// conversions, validations, and default value handling applied to them.
-	// Those are the responsibility of the graph notes representing the
-	// variable declarations. Therefore here we just trust that we already
-	// have a correct value.
-
-	val, isSet := vals[addr.Name]
-	if !isSet {
-		// We should not be able to get here without having a valid value
-		// for every variable, so this always indicates a bug in either
-		// the graph builder (not including all the needed nodes) or in
-		// the graph nodes representing variables.
-		diags = diags.Append(&hcl.Diagnostic{
-			Severity: hcl.DiagError,
-			Summary:  `Reference to unresolved input variable`,
-			Detail: fmt.Sprintf(
-				`The final value for %s is missing in Terraform's evaluation context. This is a bug in Terraform; please report it!`,
-				addr.Absolute(d.ModulePath),
-			),
-			Subject: rng.ToHCL().Ptr(),
-		})
-		val = cty.UnknownVal(config.Type)
-	}
+	val := d.Evaluator.NamedValues.GetInputVariableValue(d.ModulePath.InputVariable(addr.Name))
 
 	// Mark if sensitive
 	if config.Sensitive {

--- a/internal/terraform/evaluate_test.go
+++ b/internal/terraform/evaluate_test.go
@@ -4,7 +4,6 @@
 package terraform
 
 import (
-	"sync"
 	"testing"
 
 	"github.com/davecgh/go-spew/spew"
@@ -14,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform/internal/configs"
 	"github.com/hashicorp/terraform/internal/configs/configschema"
 	"github.com/hashicorp/terraform/internal/lang/marks"
+	"github.com/hashicorp/terraform/internal/namedvals"
 	"github.com/hashicorp/terraform/internal/plans"
 	"github.com/hashicorp/terraform/internal/providers"
 	"github.com/hashicorp/terraform/internal/states"
@@ -155,6 +155,14 @@ func TestEvaluatorGetOutputValue(t *testing.T) {
 // This particularly tests that a sensitive attribute in config
 // results in a value that has a "sensitive" cty Mark
 func TestEvaluatorGetInputVariable(t *testing.T) {
+	namedValues := namedvals.NewState()
+	namedValues.SetInputVariableValue(
+		addrs.RootModuleInstance.InputVariable("some_var"), cty.StringVal("bar"),
+	)
+	namedValues.SetInputVariableValue(
+		addrs.RootModuleInstance.InputVariable("some_other_var"), cty.StringVal("boop").Mark(marks.Sensitive),
+	)
+
 	evaluator := &Evaluator{
 		Meta: &ContextMeta{
 			Env: "foo",
@@ -180,13 +188,7 @@ func TestEvaluatorGetInputVariable(t *testing.T) {
 				},
 			},
 		},
-		VariableValues: map[string]map[string]cty.Value{
-			"": {
-				"some_var":       cty.StringVal("bar"),
-				"some_other_var": cty.StringVal("boop").Mark(marks.Sensitive),
-			},
-		},
-		VariableValuesLock: &sync.Mutex{},
+		NamedValues: namedValues,
 	}
 
 	data := &evaluationStateData{

--- a/internal/terraform/graph_walk_context.go
+++ b/internal/terraform/graph_walk_context.go
@@ -108,7 +108,7 @@ func (w *ContextGraphWalker) EvalContext() EvalContext {
 		ProvisionerLock:         &w.provisionerLock,
 		ChangesValue:            w.Changes,
 		ChecksValue:             w.Checks,
-		NamedValues:             w.NamedValues,
+		NamedValuesValue:        w.NamedValues,
 		StateValue:              w.State,
 		RefreshStateValue:       w.RefreshState,
 		PrevRunStateValue:       w.PrevRunState,

--- a/internal/terraform/graph_walk_context.go
+++ b/internal/terraform/graph_walk_context.go
@@ -8,14 +8,13 @@ import (
 	"sync"
 	"time"
 
-	"github.com/zclconf/go-cty/cty"
-
 	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/checks"
 	"github.com/hashicorp/terraform/internal/configs"
 	"github.com/hashicorp/terraform/internal/configs/configschema"
 	"github.com/hashicorp/terraform/internal/instances"
 	"github.com/hashicorp/terraform/internal/moduletest/mocking"
+	"github.com/hashicorp/terraform/internal/namedvals"
 	"github.com/hashicorp/terraform/internal/plans"
 	"github.com/hashicorp/terraform/internal/providers"
 	"github.com/hashicorp/terraform/internal/provisioners"
@@ -36,12 +35,12 @@ type ContextGraphWalker struct {
 	PrevRunState            *states.SyncState   // Used for safe concurrent access to state
 	Changes                 *plans.ChangesSync  // Used for safe concurrent writes to changes
 	Checks                  *checks.State       // Used for safe concurrent writes of checkable objects and their check results
+	NamedValues             *namedvals.State    // Tracks evaluation of input variables, local values, and output values
 	InstanceExpander        *instances.Expander // Tracks our gradual expansion of module and resource instances
 	Imports                 []configs.Import
 	MoveResults             refactoring.MoveResults // Read-only record of earlier processing of move statements
 	Operation               walkOperation
 	StopContext             context.Context
-	RootVariableValues      InputValues
 	ExternalProviderConfigs map[addrs.RootProviderConfig]providers.Interface
 	Config                  *configs.Config
 	PlanTimestamp           time.Time
@@ -54,8 +53,6 @@ type ContextGraphWalker struct {
 	once               sync.Once
 	contexts           map[string]*BuiltinEvalContext
 	contextLock        sync.Mutex
-	variableValues     map[string]map[string]cty.Value
-	variableValuesLock sync.Mutex
 	providerCache      map[string]providers.Interface
 	providerSchemas    map[string]providers.ProviderSchema
 	providerLock       sync.Mutex
@@ -86,15 +83,14 @@ func (w *ContextGraphWalker) EvalContext() EvalContext {
 	// so that we can safely run multiple evaluations at once across
 	// different modules.
 	evaluator := &Evaluator{
-		Meta:               w.Context.meta,
-		Config:             w.Config,
-		Operation:          w.Operation,
-		State:              w.State,
-		Changes:            w.Changes,
-		Plugins:            w.Context.plugins,
-		VariableValues:     w.variableValues,
-		VariableValuesLock: &w.variableValuesLock,
-		PlanTimestamp:      w.PlanTimestamp,
+		Meta:          w.Context.meta,
+		Config:        w.Config,
+		Operation:     w.Operation,
+		State:         w.State,
+		Changes:       w.Changes,
+		Plugins:       w.Context.plugins,
+		NamedValues:   w.NamedValues,
+		PlanTimestamp: w.PlanTimestamp,
 	}
 
 	ctx := &BuiltinEvalContext{
@@ -112,12 +108,11 @@ func (w *ContextGraphWalker) EvalContext() EvalContext {
 		ProvisionerLock:         &w.provisionerLock,
 		ChangesValue:            w.Changes,
 		ChecksValue:             w.Checks,
+		NamedValues:             w.NamedValues,
 		StateValue:              w.State,
 		RefreshStateValue:       w.RefreshState,
 		PrevRunStateValue:       w.PrevRunState,
 		Evaluator:               evaluator,
-		VariableValues:          w.variableValues,
-		VariableValuesLock:      &w.variableValuesLock,
 		OverrideValues:          w.Overrides,
 	}
 
@@ -130,14 +125,6 @@ func (w *ContextGraphWalker) init() {
 	w.providerSchemas = make(map[string]providers.ProviderSchema)
 	w.provisionerCache = make(map[string]provisioners.Interface)
 	w.provisionerSchemas = make(map[string]*configschema.Block)
-	w.variableValues = make(map[string]map[string]cty.Value)
-
-	// Populate root module variable values. Other modules will be populated
-	// during the graph walk.
-	w.variableValues[""] = make(map[string]cty.Value)
-	for k, iv := range w.RootVariableValues {
-		w.variableValues[""][k] = iv.Value
-	}
 }
 
 func (w *ContextGraphWalker) Execute(ctx EvalContext, n GraphNodeExecutable) tfdiags.Diagnostics {

--- a/internal/terraform/node_external_reference.go
+++ b/internal/terraform/node_external_reference.go
@@ -3,7 +3,13 @@
 
 package terraform
 
-import "github.com/hashicorp/terraform/internal/addrs"
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/hashicorp/terraform/internal/addrs"
+)
 
 // nodeExternalReference allows external callers (such as the testing framework)
 // to provide the list of references they are making into the graph. This
@@ -31,4 +37,14 @@ func (n *nodeExternalReference) ModulePath() addrs.Module {
 // GraphNodeReferencer
 func (n *nodeExternalReference) References() []*addrs.Reference {
 	return n.ExternalReferences
+}
+
+// Name implements dag.NamedVertex
+func (n *nodeExternalReference) Name() string {
+	names := make([]string, len(n.ExternalReferences))
+	for i, ref := range n.ExternalReferences {
+		names[i] = ref.DisplayString()
+	}
+	sort.Strings(names)
+	return fmt.Sprintf("<external ref to %s>", strings.Join(names, ", "))
 }

--- a/internal/terraform/node_local.go
+++ b/internal/terraform/node_local.go
@@ -161,13 +161,7 @@ func (n *NodeLocal) Execute(ctx EvalContext, op walkOperation) (diags tfdiags.Di
 		return diags
 	}
 
-	state := ctx.State()
-	if state == nil {
-		diags = diags.Append(fmt.Errorf("cannot write local value to nil state"))
-		return diags
-	}
-
-	state.SetLocalValue(addr.Absolute(ctx.Path()), val)
+	ctx.NamedValues().SetLocalValue(addr.Absolute(ctx.Path()), val)
 
 	return diags
 }

--- a/internal/terraform/node_module_variable.go
+++ b/internal/terraform/node_module_variable.go
@@ -201,8 +201,7 @@ func (n *nodeModuleVariable) Execute(ctx EvalContext, op walkOperation) (diags t
 
 	// Set values for arguments of a child module call, for later retrieval
 	// during expression evaluation.
-	_, call := n.Addr.Module.CallInstance()
-	ctx.SetModuleCallArgument(call, n.Addr.Variable, val)
+	ctx.NamedValues().SetInputVariableValue(n.Addr, val)
 
 	// Skip evalVariableValidations during destroy operations. We still want
 	// to evaluate the variable in case it is used to initialise providers

--- a/internal/terraform/node_output.go
+++ b/internal/terraform/node_output.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/terraform/internal/dag"
 	"github.com/hashicorp/terraform/internal/lang"
 	"github.com/hashicorp/terraform/internal/lang/marks"
+	"github.com/hashicorp/terraform/internal/namedvals"
 	"github.com/hashicorp/terraform/internal/plans"
 	"github.com/hashicorp/terraform/internal/states"
 	"github.com/hashicorp/terraform/internal/tfdiags"
@@ -390,7 +391,7 @@ If you do intend to export this data, annotate the output value as sensitive by 
 			// if we're continuing, make sure the output is included, and
 			// marked as unknown. If the evaluator was able to find a type
 			// for the value in spite of the error then we'll use it.
-			n.setValue(state, changes, cty.UnknownVal(val.Type()))
+			n.setValue(ctx.NamedValues(), state, changes, cty.UnknownVal(val.Type()))
 
 			// Keep existing warnings, while converting errors to warnings.
 			// This is not meant to be the normal path, so there no need to
@@ -410,13 +411,13 @@ If you do intend to export this data, annotate the output value as sensitive by 
 		}
 		return diags
 	}
-	n.setValue(state, changes, val)
+	n.setValue(ctx.NamedValues(), state, changes, val)
 
 	// If we were able to evaluate a new value, we can update that in the
 	// refreshed state as well.
 	if state = ctx.RefreshState(); state != nil && val.IsWhollyKnown() {
 		// we only need to update the state, do not pass in the changes again
-		n.setValue(state, nil, val)
+		n.setValue(nil, state, nil, val)
 	}
 
 	return diags
@@ -472,15 +473,18 @@ func (n *NodeDestroyableOutput) Execute(ctx EvalContext, op walkOperation) tfdia
 	before := cty.NullVal(cty.DynamicPseudoType)
 	mod := state.Module(n.Addr.Module)
 	if n.Addr.Module.IsRoot() && mod != nil {
-		if o, ok := mod.OutputValues[n.Addr.OutputValue.Name]; ok {
+		s := state.Lock()
+		rootOutputs := s.RootOutputValues
+		if o, ok := rootOutputs[n.Addr.OutputValue.Name]; ok {
 			sensitiveBefore = o.Sensitive
 			before = o.Value
 		} else {
 			// If the output was not in state, a delete change would
 			// be meaningless, so exit early.
+			state.Unlock()
 			return nil
-
 		}
+		state.Unlock()
 	}
 
 	changes := ctx.Changes()
@@ -521,7 +525,7 @@ func (n *NodeDestroyableOutput) DotNode(name string, opts *dag.DotOpts) *dag.Dot
 	}
 }
 
-func (n *NodeApplyableOutput) setValue(state *states.SyncState, changes *plans.ChangesSync, val cty.Value) {
+func (n *NodeApplyableOutput) setValue(namedVals *namedvals.State, state *states.SyncState, changes *plans.ChangesSync, val cty.Value) {
 	if changes != nil && n.Planning {
 		// if this is a root module, try to get a before value from the state for
 		// the diff
@@ -533,7 +537,9 @@ func (n *NodeApplyableOutput) setValue(state *states.SyncState, changes *plans.C
 
 		mod := state.Module(n.Addr.Module)
 		if n.Addr.Module.IsRoot() && mod != nil {
-			for name, o := range mod.OutputValues {
+			s := state.Lock()
+			rootOutputs := s.RootOutputValues
+			for name, o := range rootOutputs {
 				if name == n.Addr.OutputValue.Name {
 					before = o.Value
 					sensitiveBefore = o.Sensitive
@@ -541,6 +547,7 @@ func (n *NodeApplyableOutput) setValue(state *states.SyncState, changes *plans.C
 					break
 				}
 			}
+			state.Unlock()
 		}
 
 		// We will not show the value if either the before or after are marked
@@ -606,8 +613,17 @@ func (n *NodeApplyableOutput) setValue(state *states.SyncState, changes *plans.C
 		return
 	}
 
-	log.Printf("[TRACE] setValue: Saving value for %s in state", n.Addr)
+	// caller leaves namedVals nil if they've already called this function
+	// with a different state, since we only have one namedVals regardless
+	// of how many states are involved in an operation.
+	if namedVals != nil {
+		namedVals.SetOutputValue(n.Addr, val)
+	}
 
+	// The state itself doesn't represent unknown values, so we null them
+	// out here and then we'll save the real unknown value in the planned
+	// changeset, if we have one on this graph walk.
+	log.Printf("[TRACE] setValue: Saving value for %s in state", n.Addr)
 	// non-root outputs need to keep sensitive marks for evaluation, but are
 	// not serialized.
 	if n.Addr.Module.IsRoot() {

--- a/internal/terraform/node_output_test.go
+++ b/internal/terraform/node_output_test.go
@@ -153,7 +153,10 @@ func TestNodeDestroyableOutputExecute(t *testing.T) {
 	outputAddr := addrs.OutputValue{Name: "foo"}.Absolute(addrs.RootModuleInstance)
 
 	state := states.NewState()
-	state.Module(addrs.RootModuleInstance).SetOutputValue("foo", cty.StringVal("bar"), false)
+	state.SetOutputValue(
+		addrs.OutputValue{Name: "foo"}.Absolute(addrs.RootModuleInstance),
+		cty.StringVal("bar"), false,
+	)
 	state.OutputValue(outputAddr)
 
 	ctx := &MockEvalContext{

--- a/internal/terraform/node_root_variable.go
+++ b/internal/terraform/node_root_variable.go
@@ -111,7 +111,7 @@ func (n *NodeRootVariable) Execute(ctx EvalContext, op walkOperation) tfdiags.Di
 		return diags
 	}
 
-	ctx.SetRootModuleArgument(addr.Variable, finalVal)
+	ctx.NamedValues().SetInputVariableValue(addr, finalVal)
 
 	if !n.DestroyApply {
 		diags = diags.Append(evalVariableValidations(

--- a/internal/terraform/node_root_variable_test.go
+++ b/internal/terraform/node_root_variable_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform/internal/checks"
 	"github.com/hashicorp/terraform/internal/configs"
 	"github.com/hashicorp/terraform/internal/lang"
+	"github.com/hashicorp/terraform/internal/namedvals"
 )
 
 func TestNodeRootVariableExecute(t *testing.T) {
@@ -33,18 +34,18 @@ func TestNodeRootVariableExecute(t *testing.T) {
 			},
 		}
 
+		ctx.NamedValuesState = namedvals.NewState()
+
 		diags := n.Execute(ctx, walkApply)
 		if diags.HasErrors() {
 			t.Fatalf("unexpected error: %s", diags.Err())
 		}
 
-		if !ctx.SetRootModuleArgumentCalled {
-			t.Fatalf("ctx.SetRootModuleArgument wasn't called")
+		absAddr := addrs.RootModuleInstance.InputVariable(n.Addr.Name)
+		if !ctx.NamedValues().HasInputVariableValue(absAddr) {
+			t.Fatalf("no result was registered")
 		}
-		if got, want := ctx.SetRootModuleArgumentAddr.String(), "var.foo"; got != want {
-			t.Errorf("wrong address for ctx.SetRootModuleArgument\ngot:  %s\nwant: %s", got, want)
-		}
-		if got, want := ctx.SetRootModuleArgumentValue, cty.StringVal("true"); !want.RawEquals(got) {
+		if got, want := ctx.NamedValues().GetInputVariableValue(absAddr), cty.StringVal("true"); !want.RawEquals(got) {
 			// NOTE: The given value was cty.Bool but the type constraint was
 			// cty.String, so it was NodeRootVariable's responsibility to convert
 			// as part of preparing the "final value".
@@ -54,29 +55,12 @@ func TestNodeRootVariableExecute(t *testing.T) {
 	t.Run("validation", func(t *testing.T) {
 		ctx := new(MockEvalContext)
 
+		ctx.NamedValuesState = namedvals.NewState()
+
 		// The variable validation function gets called with Terraform's
 		// built-in functions available, so we need a minimal scope just for
 		// it to get the functions from.
 		ctx.EvaluationScopeScope = &lang.Scope{}
-
-		// We need to reimplement a _little_ bit of EvalContextBuiltin logic
-		// here to get a similar effect with EvalContextMock just to get the
-		// value to flow through here in a realistic way that'll make this test
-		// useful.
-		var finalVal cty.Value
-		ctx.SetRootModuleArgumentFunc = func(addr addrs.InputVariable, v cty.Value) {
-			if addr.Name == "foo" {
-				t.Logf("set %s to %#v", addr.String(), v)
-				finalVal = v
-			}
-		}
-		ctx.GetVariableValueFunc = func(addr addrs.AbsInputVariableInstance) cty.Value {
-			if addr.String() != "var.foo" {
-				return cty.NilVal
-			}
-			t.Logf("reading final val for %s (%#v)", addr.String(), finalVal)
-			return finalVal
-		}
 
 		n := &NodeRootVariable{
 			Addr: addrs.InputVariable{Name: "foo"},
@@ -132,13 +116,11 @@ func TestNodeRootVariableExecute(t *testing.T) {
 			t.Fatalf("unexpected error: %s", diags.Err())
 		}
 
-		if !ctx.SetRootModuleArgumentCalled {
-			t.Fatalf("ctx.SetRootModuleArgument wasn't called")
+		absAddr := addrs.RootModuleInstance.InputVariable(n.Addr.Name)
+		if !ctx.NamedValues().HasInputVariableValue(absAddr) {
+			t.Fatalf("no result value for input variable")
 		}
-		if got, want := ctx.SetRootModuleArgumentAddr.String(), "var.foo"; got != want {
-			t.Errorf("wrong address for ctx.SetRootModuleArgument\ngot:  %s\nwant: %s", got, want)
-		}
-		if got, want := ctx.SetRootModuleArgumentValue, cty.NumberIntVal(5); !want.RawEquals(got) {
+		if got, want := ctx.NamedValues().GetInputVariableValue(absAddr), cty.NumberIntVal(5); !want.RawEquals(got) {
 			// NOTE: The given value was cty.Bool but the type constraint was
 			// cty.String, so it was NodeRootVariable's responsibility to convert
 			// as part of preparing the "final value".

--- a/internal/terraform/update_state_hook_test.go
+++ b/internal/terraform/update_state_hook_test.go
@@ -17,7 +17,10 @@ func TestUpdateStateHook(t *testing.T) {
 	mockHook := new(MockHook)
 
 	state := states.NewState()
-	state.Module(addrs.RootModuleInstance).SetLocalValue("foo", cty.StringVal("hello"))
+	state.SetOutputValue(
+		addrs.OutputValue{Name: "foo"}.Absolute(addrs.RootModuleInstance),
+		cty.StringVal("hello"), false,
+	)
 
 	ctx := new(MockEvalContext)
 	ctx.HookHook = mockHook
@@ -30,7 +33,7 @@ func TestUpdateStateHook(t *testing.T) {
 	if !mockHook.PostStateUpdateCalled {
 		t.Fatal("should call PostStateUpdate")
 	}
-	if mockHook.PostStateUpdateState.LocalValue(addrs.LocalValue{Name: "foo"}.Absolute(addrs.RootModuleInstance)) != cty.StringVal("hello") {
+	if mockHook.PostStateUpdateState.RootOutputValues["foo"].Value != cty.StringVal("hello") {
 		t.Fatalf("wrong state passed to hook: %s", spew.Sdump(mockHook.PostStateUpdateState))
 	}
 }


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

Manual backport of #34343 into `v1.7` branch. The pre-requisites for the original PR are already in the `v1.7` branch as they were merged before the `v1.7` branch was created, which makes this a safe and easy backport operation.

This PR had the side effect of fixing the linked issue which means the issue is already fixed in `main`. Rather than trying to hack a quick fix into the `v1.7` branch directly (making future changes and backports potentially harder), I thought it was easiest just to capture this follow up PR as well.

I will do another PR that adds a specific test for the issue into main to make sure the fix is captured, which I will backport separately after this backport has been merged.

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Fixes #34476 

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.7.0

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

### BUG FIXES

<!--

Write a short description of the user-facing change. Examples:

- `terraform show -json`: Fixed crash with sensitive set values.
- When rendering a diff, Terraform now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 

-  `terraform test`: Fix bug where outputs in "empty" modules were not available to the assertions from Terraform test files.
