### PR TITLE
terraform test: Keep modules in state if they are required by the external references

### DIFF
--- a/internal/command/test_test.go
+++ b/internal/command/test_test.go
@@ -223,6 +223,10 @@ func TestTest_Runs(t *testing.T) {
 			expectedOut: "3 passed, 0 failed.",
 			code:        0,
 		},
+		"empty_module_with_output": {
+			expectedOut: "1 passed, 0 failed.",
+			code:        0,
+		},
 	}
 	for name, tc := range tcs {
 		t.Run(name, func(t *testing.T) {

--- a/internal/command/testdata/test/empty_module_with_output/empty/main.tf
+++ b/internal/command/testdata/test/empty_module_with_output/empty/main.tf
@@ -1,0 +1,3 @@
+output "value" {
+  value = "Hello, World!"
+}

--- a/internal/command/testdata/test/empty_module_with_output/main.tf
+++ b/internal/command/testdata/test/empty_module_with_output/main.tf
@@ -1,0 +1,3 @@
+module "empty" {
+  source = "./empty"
+}

--- a/internal/command/testdata/test/empty_module_with_output/main.tftest.hcl
+++ b/internal/command/testdata/test/empty_module_with_output/main.tftest.hcl
@@ -1,0 +1,6 @@
+run "empty" {
+  assert {
+    condition = module.empty.value == "Hello, World!"
+    error_message = "wrong output value"
+  }
+}

--- a/internal/terraform/graph_builder_apply.go
+++ b/internal/terraform/graph_builder_apply.go
@@ -202,7 +202,9 @@ func (b *ApplyGraphBuilder) Steps() []GraphTransformer {
 		&CloseProviderTransformer{},
 
 		// close the root module
-		&CloseRootModuleTransformer{},
+		&CloseRootModuleTransformer{
+			ExternalReferences: b.ExternalReferences,
+		},
 
 		// Perform the transitive reduction to make our graph a bit
 		// more understandable if possible (it usually is possible).

--- a/internal/terraform/graph_builder_plan.go
+++ b/internal/terraform/graph_builder_plan.go
@@ -256,7 +256,9 @@ func (b *PlanGraphBuilder) Steps() []GraphTransformer {
 		&CloseProviderTransformer{},
 
 		// Close the root module
-		&CloseRootModuleTransformer{},
+		&CloseRootModuleTransformer{
+			ExternalReferences: b.ExternalReferences,
+		},
 
 		// Perform the transitive reduction to make our graph a bit
 		// more understandable if possible (it usually is possible).

--- a/internal/terraform/node_module_expand.go
+++ b/internal/terraform/node_module_expand.go
@@ -148,6 +148,11 @@ func (n *nodeExpandModule) Execute(ctx EvalContext, op walkOperation) (diags tfd
 // do not have a lifecycle controlled by individual graph nodes.
 type nodeCloseModule struct {
 	Addr addrs.Module
+
+	// The ExternalReferences mean the closer can keep modules in state that
+	// have no resources if they contain outputs referenced externally. They are
+	// only included by the root closer.
+	ExternalReferences []*addrs.Reference
 }
 
 var (
@@ -217,7 +222,28 @@ func (n *nodeCloseModule) Execute(ctx EvalContext, op walkOperation) (diags tfdi
 
 			// empty child modules are always removed
 			if len(mod.Resources) == 0 && !mod.Addr.IsRoot() && !overridden {
-				delete(state.Modules, modKey)
+
+				if len(mod.Addr) > 1 {
+					// Then it's a deeply nested module that external callers
+					// shouldn't have access to anyway.
+					delete(state.Modules, modKey)
+				}
+
+				// Otherwise, it might be that we want to keep this module in
+				// state if it's being referenced by the testing framework.
+				externalOutput := false
+				for _, reference := range n.ExternalReferences {
+					if call, ok := reference.Subject.(addrs.ModuleCallInstanceOutput); ok {
+						if call.Call.Call.Name == mod.Addr[0].Name && call.Call.Key == mod.Addr[0].InstanceKey {
+							externalOutput = true
+							break
+						}
+					}
+				}
+
+				if !externalOutput {
+					delete(state.Modules, modKey)
+				}
 			}
 		}
 		return nil

--- a/internal/terraform/node_module_expand_test.go
+++ b/internal/terraform/node_module_expand_test.go
@@ -7,11 +7,12 @@ import (
 	"testing"
 
 	"github.com/hashicorp/hcl/v2/hcltest"
+	"github.com/zclconf/go-cty/cty"
+
 	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/configs"
 	"github.com/hashicorp/terraform/internal/instances"
 	"github.com/hashicorp/terraform/internal/states"
-	"github.com/zclconf/go-cty/cty"
 )
 
 func TestNodeExpandModuleExecute(t *testing.T) {
@@ -44,7 +45,7 @@ func TestNodeCloseModuleExecute(t *testing.T) {
 		ctx := &MockEvalContext{
 			StateState: state.SyncWrapper(),
 		}
-		node := nodeCloseModule{addrs.Module{"child"}}
+		node := nodeCloseModule{Addr: addrs.Module{"child"}}
 		diags := node.Execute(ctx, walkApply)
 		if diags.HasErrors() {
 			t.Fatalf("unexpected error: %s", diags.Err())
@@ -56,7 +57,7 @@ func TestNodeCloseModuleExecute(t *testing.T) {
 		}
 
 		// the root module should do all the module cleanup
-		node = nodeCloseModule{addrs.RootModule}
+		node = nodeCloseModule{Addr: addrs.RootModule}
 		diags = node.Execute(ctx, walkApply)
 		if diags.HasErrors() {
 			t.Fatalf("unexpected error: %s", diags.Err())
@@ -67,6 +68,80 @@ func TestNodeCloseModuleExecute(t *testing.T) {
 			t.Fatal("module.child was not removed from state")
 		}
 	})
+	t.Run("walkApplyWithOutputs", func(t *testing.T) {
+		state := states.NewState()
+		state.EnsureModule(addrs.RootModuleInstance.Child("child", addrs.NoKey))
+		state.EnsureModule(addrs.RootModuleInstance.Child("child", addrs.NoKey)).SetOutputValue("foo", cty.StringVal("bar"), false)
+		ctx := &MockEvalContext{
+			StateState: state.SyncWrapper(),
+		}
+		node := nodeCloseModule{Addr: addrs.Module{"child"}}
+		diags := node.Execute(ctx, walkApply)
+		if diags.HasErrors() {
+			t.Fatalf("unexpected error: %s", diags.Err())
+		}
+
+		// Since module.child has no resources, it should be removed even though
+		// it has outputs.
+		if _, ok := state.Modules["module.child"]; !ok {
+			t.Fatal("module.child should not be removed from state yet")
+		}
+
+		// the root module should do all the module cleanup
+		node = nodeCloseModule{Addr: addrs.RootModule}
+		diags = node.Execute(ctx, walkApply)
+		if diags.HasErrors() {
+			t.Fatalf("unexpected error: %s", diags.Err())
+		}
+
+		// Since module.child has no resources, it should be removed
+		if _, ok := state.Modules["module.child"]; ok {
+			t.Fatal("module.child was not removed from state")
+		}
+	})
+	t.Run("walkApplyWithReferencedOutputs", func(t *testing.T) {
+		state := states.NewState()
+		state.EnsureModule(addrs.RootModuleInstance.Child("child", addrs.NoKey))
+		state.EnsureModule(addrs.RootModuleInstance.Child("child", addrs.NoKey)).SetOutputValue("foo", cty.StringVal("bar"), false)
+		ctx := &MockEvalContext{
+			StateState: state.SyncWrapper(),
+		}
+		node := nodeCloseModule{Addr: addrs.Module{"child"}}
+		diags := node.Execute(ctx, walkApply)
+		if diags.HasErrors() {
+			t.Fatalf("unexpected error: %s", diags.Err())
+		}
+
+		// module.child should not be removed, since we have referenced it from
+		// the external references.
+		if _, ok := state.Modules["module.child"]; !ok {
+			t.Fatal("module.child should not be removed from state yet")
+		}
+
+		// the root module should do all the module cleanup
+		node = nodeCloseModule{Addr: addrs.RootModule, ExternalReferences: []*addrs.Reference{
+			{
+				Subject: addrs.ModuleCallInstanceOutput{
+					Call: addrs.ModuleCallInstance{
+						Call: addrs.ModuleCall{
+							Name: "child",
+						},
+						Key: addrs.NoKey,
+					},
+					Name: "foo",
+				},
+			},
+		}}
+		diags = node.Execute(ctx, walkApply)
+		if diags.HasErrors() {
+			t.Fatalf("unexpected error: %s", diags.Err())
+		}
+
+		// Since module.child has no resources, it should be removed
+		if _, ok := state.Modules["module.child"]; !ok {
+			t.Fatal("module.child should not have been removed from state at all")
+		}
+	})
 
 	// walkImport is a no-op
 	t.Run("walkImport", func(t *testing.T) {
@@ -75,7 +150,7 @@ func TestNodeCloseModuleExecute(t *testing.T) {
 		ctx := &MockEvalContext{
 			StateState: state.SyncWrapper(),
 		}
-		node := nodeCloseModule{addrs.Module{"child"}}
+		node := nodeCloseModule{Addr: addrs.Module{"child"}}
 
 		diags := node.Execute(ctx, walkImport)
 		if diags.HasErrors() {


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

This PR updates the v1.7 branch such that it won't remove "empty" modules from state if they have external references pointing to their outputs.

This does potentially increase the size of the state files, but currently it will only affect the `terraform test` framework as the external references are only set by the testing framework. This has been fixed "properly" in main, so it also means that slight hack implemented here will only be present in the v1.7 branch. Overall, I think that makes the approach here acceptable given the temporary nature of the fix. I had attempted to port over the real fix in #34477, but it was rightly pointed out that it's a bit overkill and potentially risky so close to an upcoming release. Hopefully, this is an acceptable middle ground.

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Fixes #34476 

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.7.0-rc2

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

### BUG FIXES

<!--

Write a short description of the user-facing change. Examples:

- `terraform show -json`: Fixed crash with sensitive set values.
- When rendering a diff, Terraform now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 

-  `terraform test`: Fix bug where outputs in "empty" modules were not available to the assertions from Terraform test files.
