### PR TITLE
removed: child modules should be removed if they are within a removed module

### DIFF
--- a/internal/terraform/node_resource_destroy_deposed.go
+++ b/internal/terraform/node_resource_destroy_deposed.go
@@ -144,7 +144,7 @@ func (n *NodePlanDeposedResourceInstanceObject) Execute(ctx EvalContext, op walk
 			}
 		}
 		for _, fm := range n.forgetModules {
-			if fm.Equal(n.Addr.Module.Module()) {
+			if fm.TargetContains(n.Addr) {
 				forget = true
 			}
 		}

--- a/internal/terraform/node_resource_plan_orphan.go
+++ b/internal/terraform/node_resource_plan_orphan.go
@@ -147,7 +147,7 @@ func (n *NodePlannableResourceInstanceOrphan) managedResourceExecute(ctx EvalCon
 		}
 	}
 	for _, fm := range n.forgetModules {
-		if fm.Equal(n.Addr.Module.Module()) {
+		if fm.TargetContains(n.Addr) {
 			forget = true
 		}
 	}


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

Previously, we were checking if a resources module matched a removed module exactly when deciding whether it should be deleted or forgotten. This meant deeply nested resources were being destroyed even though a parent module was marked as removed.

After this PR we use `TargetContains` function instead of an equality check, so that deeply nested resources will respect the removed status of parent modules.

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Fixes #34475

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.7.0-rc2

## Draft CHANGELOG entry

N/A - covered by the removed block entry more generally.
