### PR TITLE
stacks: Return a better error if a component module tries to use an inline provider

### DIFF
--- a/internal/stacks/stackruntime/internal/stackeval/component_config.go
+++ b/internal/stacks/stackruntime/internal/stackeval/component_config.go
@@ -20,6 +20,7 @@ import (
 	"github.com/hashicorp/terraform/internal/promising"
 	"github.com/hashicorp/terraform/internal/stacks/stackaddrs"
 	"github.com/hashicorp/terraform/internal/stacks/stackconfig"
+	"github.com/hashicorp/terraform/internal/stacks/stackplan"
 	"github.com/hashicorp/terraform/internal/tfdiags"
 	"github.com/spf13/afero"
 	"github.com/zclconf/go-cty/cty"
@@ -228,14 +229,23 @@ func (c *ComponentConfig) ExprReferenceValue(ctx context.Context, phase EvalPhas
 	return cty.DynamicVal
 }
 
-// Validate implements Validatable.
-func (c *ComponentConfig) Validate(ctx context.Context) tfdiags.Diagnostics {
+func (c *ComponentConfig) checkValid(ctx context.Context, phase EvalPhase) tfdiags.Diagnostics {
 	var diags tfdiags.Diagnostics
 
 	_, moreDiags := c.CheckModuleTree(ctx)
 	diags = diags.Append(moreDiags)
 
 	return diags
+}
+
+// Validate implements Validatable.
+func (c *ComponentConfig) Validate(ctx context.Context) tfdiags.Diagnostics {
+	return c.checkValid(ctx, ValidatePhase)
+}
+
+// PlanChanges implements Plannable.
+func (c *ComponentConfig) PlanChanges(ctx context.Context) ([]stackplan.PlannedChange, tfdiags.Diagnostics) {
+	return nil, c.checkValid(ctx, PlanPhase)
 }
 
 func (c *ComponentConfig) tracingName() string {

--- a/internal/stacks/stackruntime/internal/stackeval/stack_config.go
+++ b/internal/stacks/stackruntime/internal/stackeval/stack_config.go
@@ -303,7 +303,7 @@ func (s *StackConfig) Components(ctx context.Context) map[stackaddrs.Component]*
 		return nil
 	}
 	ret := make(map[stackaddrs.Component]*ComponentConfig, len(s.config.Stack.Components))
-	for name := range s.config.Stack.InputVariables {
+	for name := range s.config.Stack.Components {
 		addr := stackaddrs.Component{Name: name}
 		ret[addr] = s.Component(ctx, addr)
 	}

--- a/internal/stacks/stackruntime/internal/stackeval/testdata/sourcebundle/terraform-sources.json
+++ b/internal/stacks/stackruntime/internal/stackeval/testdata/sourcebundle/terraform-sources.json
@@ -24,6 +24,10 @@
       {
         "source": "https://testing.invalid/planning.tar.gz",
         "local": "planning"
+      },
+      {
+        "source": "https://testing.invalid/validating.tar.gz",
+        "local": "validating"
       }
     ]
   }

--- a/internal/stacks/stackruntime/internal/stackeval/testdata/sourcebundle/validating/modules_with_provider_configs/module-a/modules-with-provider-configs-a.tf
+++ b/internal/stacks/stackruntime/internal/stackeval/testdata/sourcebundle/validating/modules_with_provider_configs/module-a/modules-with-provider-configs-a.tf
@@ -1,0 +1,20 @@
+terraform {
+  required_providers {
+    test = {
+      source = "terraform.io/builtin/test"
+    }
+  }
+}
+
+provider "test" {
+  arg = "foo"
+}
+
+module "b" {
+  # FIXME: The following is an absolute remote address only because at the
+  # time of writing this test the stacks runtime's module loader can't deal
+  # with relative paths in this location.
+  source = "https://testing.invalid/validating.tar.gz//modules_with_provider_configs/module-b"
+  # Once that's been fixed, this should instead be:
+  # source = "../module-b"
+}

--- a/internal/stacks/stackruntime/internal/stackeval/testdata/sourcebundle/validating/modules_with_provider_configs/module-b/modules-with-provider-configs-b.tf
+++ b/internal/stacks/stackruntime/internal/stackeval/testdata/sourcebundle/validating/modules_with_provider_configs/module-b/modules-with-provider-configs-b.tf
@@ -1,0 +1,11 @@
+terraform {
+  required_providers {
+    test = {
+      source = "terraform.io/builtin/test"
+    }
+  }
+}
+
+provider "test" {
+  arg = "foo"
+}

--- a/internal/stacks/stackruntime/internal/stackeval/testdata/sourcebundle/validating/modules_with_provider_configs/modules-with-provider-configs.tfstack.hcl
+++ b/internal/stacks/stackruntime/internal/stackeval/testdata/sourcebundle/validating/modules_with_provider_configs/modules-with-provider-configs.tfstack.hcl
@@ -1,0 +1,3 @@
+component "a" {
+  source = "./module-a"
+}

--- a/internal/stacks/stackruntime/internal/stackeval/validating_test.go
+++ b/internal/stacks/stackruntime/internal/stackeval/validating_test.go
@@ -1,0 +1,86 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package stackeval
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/hcl/v2"
+
+	"github.com/hashicorp/terraform/internal/tfdiags"
+)
+
+func TestValidate_modulesWithProviderConfigs(t *testing.T) {
+	// This test checks that we're correctly prohibiting inline provider
+	// configurations in Terraform modules used as stack components, which
+	// is forbidden because the stacks language is responsible for provider
+	// configurations.
+	//
+	// The underlying modules runtime isn't configured with any ability to
+	// instantiate provider plugins itself, so failing to prohibit this
+	// at the stacks language layer would just cause a lower-quality and
+	// more confusing error message to be emited by the modules runtime.
+
+	cfg := testStackConfig(t, "validating", "modules_with_provider_configs")
+	main := NewForValidating(cfg, ValidateOpts{})
+
+	inPromisingTask(t, func(ctx context.Context, t *testing.T) {
+		diags := main.ValidateAll(ctx)
+		if !diags.HasErrors() {
+			t.Fatalf("succeeded; want errors")
+		}
+		diags.Sort()
+
+		// We'll use the ForRPC method just as a convenient way to discard
+		// the specific diagnostic object types, so that we can compare
+		// the objects without worrying about exactly which diagnostic
+		// implementation each is using.
+		gotDiags := diags.ForRPC()
+
+		var wantDiags tfdiags.Diagnostics
+		// TEMP: Because we're currently essentially just tricking the module
+		// loader into reading from a source bundle without actually knowing
+		// that's what its doing, these diagnostics show local filesystem
+		// paths instead of source addresses. Once we fix that in future,
+		// the following wanted diagnostics should switch to refer to
+		// source addresses starting with:
+		//   https://testing.invalid/validating.tar.gz//modules_with_provider_configs/
+		// ...which is the fake source address form used by the testStackConfig
+		// helper we used above.
+
+		// Configurations in the root module get a different detail message
+		// than those in descendent modules, because for descendents we don't
+		// assume that the author is empowered to make the module
+		// stacks-compatible, while for the root it's more likely to be
+		// directly intended for stacks use, at least for now while things are
+		// relatively early. (We could revisit this tradeoff later.)
+		wantDiags = wantDiags.Append(&hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  "Inline provider configuration not allowed",
+			Detail:   `A module used as a stack component must have all of its provider configurations passed from the stack configuration, using the "providers" argument within the component configuration block.`,
+			Subject: &hcl.Range{
+				Filename: "testdata/sourcebundle/validating/modules_with_provider_configs/module-a/modules-with-provider-configs-a.tf",
+				Start:    hcl.Pos{Line: 9, Column: 1, Byte: 104},
+				End:      hcl.Pos{Line: 9, Column: 16, Byte: 119},
+			},
+		})
+		wantDiags = wantDiags.Append(&hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  "Inline provider configuration not allowed",
+			Detail:   "This module is not compatible with Terraform Stacks, because it declares an inline provider configuration.\n\nTo be used with stacks, this module must instead accept provider configurations from its caller.",
+			Subject: &hcl.Range{
+				Filename: "testdata/sourcebundle/validating/modules_with_provider_configs/module-b/modules-with-provider-configs-b.tf",
+				Start:    hcl.Pos{Line: 9, Column: 1, Byte: 104},
+				End:      hcl.Pos{Line: 9, Column: 16, Byte: 119},
+			},
+		})
+		wantDiags = wantDiags.ForRPC()
+
+		if diff := cmp.Diff(wantDiags, gotDiags); diff != "" {
+			t.Errorf("wrong diagnostics\n%s", diff)
+		}
+	})
+}

--- a/internal/stacks/stackruntime/internal/stackeval/walk_static.go
+++ b/internal/stacks/stackruntime/internal/stackeval/walk_static.go
@@ -53,6 +53,10 @@ func walkStaticObjectsInStackConfig[Output any](
 
 	// TODO: All of the other static object types
 
+	for _, obj := range stackConfig.Components(ctx) {
+		visit(ctx, walk, obj)
+	}
+
 	for _, obj := range stackConfig.StackCalls(ctx) {
 		visit(ctx, walk, obj)
 	}


### PR DESCRIPTION
When running in Stacks, it's the stack configuration that's responsible for configuring providers, and so the modules used to implement components should be written to expect provider configurations passed in from their caller.

Previously we didn't have any special checks for this and so it would fail with a useless error message saying that the relevant provider isn't available. (It's correct to say that it isn't available _in the modules runtime_, but the error message doesn't include that context, and we don't want to be discussing implementation details like "the modules runtime" in our error messages anyway.)

This introduces some more specialized error messages for that situation. I expect we'll revisit this and tweak these error messages over time based on feedback, but the main goal here is to just return _something_ that explicitly says that inline provider configurations are not allowed, to avoid that inevitably becoming a FAQ once more folks start trying this with their existing modules.

Implementing this involved plugging a gap in the static-walk implementation, and fixing a bug in how a stack configuration object determines which static component blocks are declared inside it. The final commit in this series is the one that actually does what I described above.
