### PR TITLE
Fix: resource instance addresses displayed in escaped quotes in import error message when resource configuration isn't present.

### DIFF
--- a/internal/command/import.go
+++ b/internal/command/import.go
@@ -343,7 +343,7 @@ func (c *ImportCommand) Synopsis() string {
 const importCommandInvalidAddressReference = `For information on valid syntax, see:
 https://www.terraform.io/docs/cli/state/resource-addressing.html`
 
-const importCommandMissingResourceFmt = `[reset][bold][red]Error:[reset][bold] resource address %q does not exist in the configuration.[reset]
+const importCommandMissingResourceFmt = `[reset][bold][red]Error:[reset][bold] resource address "%s" does not exist in the configuration.[reset]
 
 Before importing this resource, please create its configuration in %s. For example:
 


### PR DESCRIPTION
Closes #34497  

As @apparentlymart outlined in #34124:
> Resource instance addresses should not be presented in quotes, because they aren't written in quotes in the configuration and because (as shown here) they sometimes contain quotes themselves, making the result misleading for someone who isn't familiar with Terraform's internals

This pull request addresses the formatting issue causing the quotes to be escaped.

Before:
```
$ ~/go/bin/terraform import 'google_service_account.bqowner["bqowner"]' "projects/1238328119/serviceAccounts/foobar123"                                             (base) 
Error: resource address "google_service_account.bqowner[\"bqowner\"]" does not exist in the configuration.

Before importing this resource, please create its configuration in the root module. For example:

resource "google_service_account" "bqowner" {
  # (resource arguments)
}
```

After fixing the formatting:
```
$ ~/go/bin/terraform import 'google_service_account.bqowner["bqowner"]' "projects/1238328119/serviceAccounts/foobar123"                                             (base) 
Error: resource address "google_service_account.bqowner["bqowner"]" does not exist in the configuration.

Before importing this resource, please create its configuration in the root module. For example:

resource "google_service_account" "bqowner" {
  # (resource arguments)
}
```