### PR TITLE
backend/s3: Ignore default workspace prefix errors

### DIFF
--- a/internal/backend/remote-state/s3/backend.go
+++ b/internal/backend/remote-state/s3/backend.go
@@ -942,7 +942,7 @@ func (b *Backend) Configure(obj cty.Value) tfdiags.Diagnostics {
 	)
 
 	b.acl = stringAttr(obj, "acl")
-	b.workspaceKeyPrefix = stringAttrDefault(obj, "workspace_key_prefix", "env:")
+	b.workspaceKeyPrefix = stringAttrDefault(obj, "workspace_key_prefix", defaultWorkspaceKeyPrefix)
 	b.serverSideEncryption = boolAttr(obj, "encrypt")
 	b.kmsKeyID = stringAttr(obj, "kms_key_id")
 	b.ddbTable = stringAttr(obj, "dynamodb_table")

--- a/internal/backend/remote-state/s3/backend_state.go
+++ b/internal/backend/remote-state/s3/backend_state.go
@@ -22,6 +22,12 @@ import (
 	"github.com/hashicorp/terraform/internal/states/statemgr"
 )
 
+const (
+	// defaultWorkspaceKeyPrefix is the default prefix for workspace storage.
+	// The colon is used to reduce the chance of name conflicts with existing objects.
+	defaultWorkspaceKeyPrefix = "env:"
+)
+
 func (b *Backend) Workspaces() ([]string, error) {
 	const maxKeys = 1000
 

--- a/website/docs/language/settings/backends/s3.mdx
+++ b/website/docs/language/settings/backends/s3.mdx
@@ -310,7 +310,7 @@ terraform {
 The following configuration is required:
 
 * `bucket` - (Required) Name of the S3 Bucket.
-* `key` - (Required) Path to the state file inside the S3 Bucket. When using a non-default [workspace](/terraform/language/state/workspaces), the state path will be `/workspace_key_prefix/workspace_name/key` (see also the `workspace_key_prefix` configuration).
+* `key` - (Required) Path to the state file inside the S3 Bucket. When using a non-default [workspace](/terraform/language/state/workspaces), the state path will be `<workspace_key_prefix>/<workspace_name>/<key>` (see also the `workspace_key_prefix` configuration).
 
 The following configuration is optional:
 

--- a/website/docs/language/settings/backends/s3.mdx
+++ b/website/docs/language/settings/backends/s3.mdx
@@ -44,13 +44,13 @@ Using the example above, the state for the workspace `development` would be stor
 
 ### S3 Bucket Permissions
 
-Terraform will need the following AWS IAM permissions on
-the target backend bucket:
+When not using [workspaces](/terraform/language/state/workspaces)(or when only using the `default` workspace), Terraform will need the following AWS IAM permissions on the target backend bucket:
 
-* `s3:ListBucket` on `arn:aws:s3:::mybucket`
+* `s3:ListBucket` on `arn:aws:s3:::mybucket`. At a minimum, this must be able to list the path where the state is stored.
 * `s3:GetObject` on `arn:aws:s3:::mybucket/path/to/my/key`
 * `s3:PutObject` on `arn:aws:s3:::mybucket/path/to/my/key`
-* `s3:DeleteObject` on `arn:aws:s3:::mybucket/path/to/my/key`
+
+Note: `s3:DeleteObject` is not needed, as Terraform will not delete the state storage.
 
 This is seen in the following AWS IAM Statement:
 
@@ -65,12 +65,19 @@ This is seen in the following AWS IAM Statement:
     },
     {
       "Effect": "Allow",
-      "Action": ["s3:GetObject", "s3:PutObject", "s3:DeleteObject"],
+      "Action": ["s3:GetObject", "s3:PutObject"],
       "Resource": "arn:aws:s3:::mybucket/path/to/my/key"
     }
   ]
 }
 ```
+
+When using [workspaces](/terraform/language/state/workspaces), Terraform will also need permissions to create, list, read, update, and delete the workspace state storage:
+
+* `s3:ListBucket` on `arn:aws:s3:::mybucket`. At a minumum, this must be able to list the path where the `default` workspace is stored as well as the other workspaces.
+* `s3:GetObject` on `arn:aws:s3:::mybucket/path/to/my/key` and `arn:aws:s3:::mybucket/<workspace_key_prefix>/*/path/to/my/key`
+* `s3:PutObject` on `arn:aws:s3:::mybucket/path/to/my/key` and `arn:aws:s3:::mybucket/<workspace_key_prefix>/*/path/to/my/key`
+* `s3:DeleteObject` on `arn:aws:s3:::mybucket/<workspace_key_prefix>/*/path/to/my/key`
 
 -> **Note:** AWS can control access to S3 buckets with either IAM policies
 attached to users/groups/roles (like the example above) or resource policies
@@ -546,7 +553,12 @@ to only a single state object within an S3 bucket is shown below:
     {
       "Effect": "Allow",
       "Action": "s3:ListBucket",
-      "Resource": "arn:aws:s3:::myorg-terraform-states"
+      "Resource": "arn:aws:s3:::myorg-terraform-states",
+      "Condition": {
+				"StringEquals": {
+					"s3:prefix": "myapp/production/tfstate"
+				}
+			}
     },
     {
       "Effect": "Allow",

--- a/website/docs/language/settings/backends/s3.mdx
+++ b/website/docs/language/settings/backends/s3.mdx
@@ -555,10 +555,10 @@ to only a single state object within an S3 bucket is shown below:
       "Action": "s3:ListBucket",
       "Resource": "arn:aws:s3:::myorg-terraform-states",
       "Condition": {
-				"StringEquals": {
-					"s3:prefix": "myapp/production/tfstate"
-				}
-			}
+        "StringEquals": {
+          "s3:prefix": "myapp/production/tfstate"
+        }
+      }
     },
     {
       "Effect": "Allow",

--- a/website/docs/language/settings/backends/s3.mdx
+++ b/website/docs/language/settings/backends/s3.mdx
@@ -5,12 +5,10 @@ description: Terraform can store state remotely in S3 and lock that state with D
 
 # S3
 
-Stores the state as a given key in a given bucket on
-[Amazon S3](https://aws.amazon.com/s3/).
-This backend also supports state locking and consistency checking via
-[Dynamo DB](https://aws.amazon.com/dynamodb/), which can be enabled by setting
-the `dynamodb_table` field to an existing DynamoDB table name.
-A single DynamoDB table can be used to lock multiple remote state files. Terraform generates key names that include the values of the `bucket` and `key` variables.
+Stores the state as a given key in a given bucket on [Amazon S3](https://aws.amazon.com/s3/).
+This backend also supports state locking and consistency checking via [Dynamo DB](https://aws.amazon.com/dynamodb/), which can be enabled by setting the `dynamodb_table` field to an existing DynamoDB table name.
+A single DynamoDB table can be used to lock multiple remote state files.
+Terraform generates key names that include the values of the `bucket` and `key` variables.
 
 ~> **Warning!** It is highly recommended that you enable
 [Bucket Versioning](https://docs.aws.amazon.com/AmazonS3/latest/userguide/manage-versioning-examples.html)
@@ -28,11 +26,9 @@ terraform {
 }
 ```
 
-This assumes we have a bucket created called `mybucket`. The
-Terraform state is written to the key `path/to/my/key`.
+This assumes we have a bucket created called `mybucket`. The Terraform state is written to the key `path/to/my/key`.
 
-Note that for the access credentials we recommend using a
-[partial configuration](/terraform/language/settings/backends/configuration#partial-configuration).
+Note that for the access credentials we recommend using a [partial configuration](/terraform/language/settings/backends/configuration#partial-configuration).
 
 ### S3 Bucket Permissions
 

--- a/website/docs/language/settings/backends/s3.mdx
+++ b/website/docs/language/settings/backends/s3.mdx
@@ -30,6 +30,18 @@ This assumes we have a bucket created called `mybucket`. The Terraform state is 
 
 Note that for the access credentials we recommend using a [partial configuration](/terraform/language/settings/backends/configuration#partial-configuration).
 
+## State Storage
+
+The S3 backend stores state data in an S3 object at the path set by the `key` parameter in the S3 bucket indicated by the `bucket` parameter.
+Using the example shown above, the state would be stored at the path `path/to/my/key` in the bucket `mybucket`.
+
+When using [workspaces](/terraform/language/state/workspaces), the state for the `default` workspace is stored at the location described above.
+Other workspaces are stored using the path `<workspace_key_prefix>/<workspace_name>/<key>`.
+The default workspace key prefix is `env:` and it can be configured using the parameter `workspace_key_prefix`.
+Using the example above, the state for the workspace `development` would be stored at the path `env:/development/path/to/my/key`.
+
+## Permissions Required
+
 ### S3 Bucket Permissions
 
 Terraform will need the following AWS IAM permissions on


### PR DESCRIPTION
In versions prior to v1.6, the S3 backend ignored all errors other than `NoSuchBucket` when listing workspaces. This allowed cases where the user did not have access to the default workspace prefix `env:` to succeed.

In order to preserve this behaviour, now ignore `AccessDenied` errors when the user does not have access to the default workspace prefix. If `workspace_key_prefix` is specified, `AccessDenied` errors will cause a failure.

Updates documentation to list permissions needed when using workspaces.

Fixes #34223

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.7.0

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

### BUG FIXES

<!--

Write a short description of the user-facing change. Examples:

- `terraform show -json`: Fixed crash with sensitive set values.
- When rendering a diff, Terraform now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 

-  backend/s3: No longer returns error when IAM user or role does not have access to the default workspace prefix `env:`
