### PR TITLE
support force-unlock for remote http backends. Fixes #28421

### DIFF
--- a/internal/backend/remote-state/http/client.go
+++ b/internal/backend/remote-state/http/client.go
@@ -126,11 +126,20 @@ func (c *httpClient) Lock(info *statemgr.LockInfo) (string, error) {
 }
 
 func (c *httpClient) Unlock(id string) error {
+	var info statemgr.LockInfo
+
 	if c.UnlockURL == nil {
 		return nil
 	}
 
-	resp, err := c.httpRequest(c.UnlockMethod, c.UnlockURL, &c.jsonLockInfo, "unlock")
+	if err := json.Unmarshal(c.jsonLockInfo, &info); err != nil {
+		return err
+	}
+
+	info.ID = id
+	jsonLockInfo := info.Marshal()
+
+	resp, err := c.httpRequest(c.UnlockMethod, c.UnlockURL, &jsonLockInfo, "unlock")
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Credit: https://github.com/hashicorp/terraform/pull/28807

The issue #28421 is still present, previous PR was valid, `cloud` stanza mentioned [here](https://github.com/hashicorp/terraform/pull/28807#issuecomment-1490487650) has nothing to do with it.