### PR TITLE
Respect the dependency relationships between components when applying

### DIFF
--- a/internal/stacks/stackruntime/internal/stackeval/applying_test.go
+++ b/internal/stacks/stackruntime/internal/stackeval/applying_test.go
@@ -1,0 +1,330 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package stackeval
+
+import (
+	"context"
+	"log"
+	"slices"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/davecgh/go-spew/spew"
+	"github.com/golang/protobuf/proto"
+	"github.com/google/go-cmp/cmp"
+	"github.com/zclconf/go-cty/cty"
+	"google.golang.org/protobuf/types/known/anypb"
+
+	"github.com/hashicorp/terraform/internal/addrs"
+	"github.com/hashicorp/terraform/internal/collections"
+	"github.com/hashicorp/terraform/internal/configs/configschema"
+	"github.com/hashicorp/terraform/internal/plans"
+	"github.com/hashicorp/terraform/internal/promising"
+	"github.com/hashicorp/terraform/internal/providers"
+	"github.com/hashicorp/terraform/internal/stacks/stackaddrs"
+	"github.com/hashicorp/terraform/internal/stacks/stackstate"
+	"github.com/hashicorp/terraform/internal/terraform"
+)
+
+func TestApply_componentOrdering(t *testing.T) {
+	// This verifies that component instances have their plans applied in a
+	// suitable order during the apply phase, both for normal plans and for
+	// destroy plans.
+	//
+	// This test also creates a plan using the normal planning logic, so
+	// it partially acts as an integration test for planning and applying
+	// with component inter-dependencies (since the plan phase is the one
+	// responsible for actually calculating the dependencies.)
+	//
+	// Since this is testing some concurrent code, the test might produce
+	// false-positives if things just happen to occur in the right order
+	// despite the sequencing code being incorrect. Consider running this
+	// test under the Go data race detector to find memory-safety-related
+	// problems, but also keep in mind that not all sequencing problems are
+	// caused by data races.
+	//
+	// If this test seems to be flaking and the race detector doesn't dig up
+	// any clues, you might consider the following:
+	//  - Is the code in function ApplyPlan waiting for all of the prerequisites
+	//    captured in the plan? Is it honoring the reversed order expected
+	//    for destroy plans?
+	//  - Is the ChangeExec function, and its subsequent execution, correctly
+	//    scheduling all of the apply tasks that were registered?
+	//
+	// If other tests in this package (or that call into this package) are
+	// also consistently failing, it'd likely be more productive to debug and
+	// fix those first, which might then give a clue as to what's making this
+	// test misbehave.
+
+	cfg := testStackConfig(t, "applying", "component_dependencies")
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	testProviderAddr := addrs.NewBuiltInProvider("test")
+	testProviderSchema := providers.GetProviderSchemaResponse{
+		ResourceTypes: map[string]providers.Schema{
+			"test_report": {
+				Block: &configschema.Block{
+					Attributes: map[string]*configschema.Attribute{
+						"marker": {
+							Type:     cty.String,
+							Required: true,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	cmpAAddr := stackaddrs.AbsComponent{
+		Stack: stackaddrs.RootStackInstance,
+		Item: stackaddrs.Component{
+			Name: "a",
+		},
+	}
+	cmpBAddr := stackaddrs.AbsComponent{
+		Stack: stackaddrs.RootStackInstance,
+		Item: stackaddrs.Component{
+			Name: "b",
+		},
+	}
+	cmpBInst1Addr := stackaddrs.AbsComponentInstance{
+		Stack: cmpBAddr.Stack,
+		Item: stackaddrs.ComponentInstance{
+			Component: cmpBAddr.Item,
+			Key:       addrs.StringKey("i"),
+		},
+	}
+	cmpCAddr := stackaddrs.AbsComponent{
+		Stack: stackaddrs.RootStackInstance,
+		Item: stackaddrs.Component{
+			Name: "c",
+		},
+	}
+	cmpCInstAddr := stackaddrs.AbsComponentInstance{
+		Stack: cmpCAddr.Stack,
+		Item: stackaddrs.ComponentInstance{
+			Component: cmpCAddr.Item,
+			Key:       addrs.NoKey,
+		},
+	}
+
+	// First we need to create a plan for this configuration, which will
+	// include the calculated component dependencies.
+	t.Log("initial plan")
+	planOutput, err := promising.MainTask(ctx, func(ctx context.Context) (*planOutputTester, error) {
+		main := NewForPlanning(cfg, stackstate.NewState(), PlanOpts{
+			PlanningMode: plans.NormalMode,
+			ProviderFactories: ProviderFactories{
+				testProviderAddr: func() (providers.Interface, error) {
+					return &terraform.MockProvider{
+						GetProviderSchemaResponse: &testProviderSchema,
+						PlanResourceChangeFn: func(prcr providers.PlanResourceChangeRequest) providers.PlanResourceChangeResponse {
+							return providers.PlanResourceChangeResponse{
+								PlannedState: prcr.ProposedNewState,
+							}
+						},
+					}, nil
+				},
+			},
+		})
+
+		outp, outpTester := testPlanOutput(t)
+		main.PlanAll(ctx, outp)
+
+		return outpTester, nil
+	})
+	if err != nil {
+		t.Fatalf("planning failed: %s", err)
+	}
+
+	rawPlan := planOutput.RawChanges(t)
+	plan, diags := planOutput.Close(t)
+	assertNoDiagnostics(t, diags)
+
+	// Before we proceed further we'll check that the plan contains the
+	// expected dependency relationships, because missing dependency edges
+	// will make the following tests invalid, and testing this is not
+	// subject to concurrency-related false-positives.
+	//
+	// This is not comprehensive, because the dependency calculation logic
+	// should already be tested more completely elsewhere. If this part fails
+	// then hopefully at least one of the planning-specific tests is also
+	// failing, and will give some more clues as to what's gone wrong here.
+	if !plan.Applyable {
+		m := proto.TextMarshaler{
+			Compact:   false,
+			ExpandAny: true,
+		}
+		for _, raw := range rawPlan {
+			t.Log(m.Text(raw))
+		}
+		t.Fatalf("plan is not applyable")
+	}
+	{
+		cmpPlan := plan.Components.Get(cmpCInstAddr)
+		gotDeps := cmpPlan.Dependencies
+		wantDeps := collections.NewSet[stackaddrs.AbsComponent]()
+		wantDeps.Add(cmpBAddr)
+		if diff := cmp.Diff(wantDeps, gotDeps, collections.CmpOptions); diff != "" {
+			t.Fatalf("wrong dependencies for component.c\n%s", diff)
+		}
+	}
+	{
+		cmpPlan := plan.Components.Get(cmpBInst1Addr)
+		gotDeps := cmpPlan.Dependencies
+		wantDeps := collections.NewSet[stackaddrs.AbsComponent]()
+		wantDeps.Add(cmpAAddr)
+		if diff := cmp.Diff(wantDeps, gotDeps, collections.CmpOptions); diff != "" {
+			t.Fatalf("wrong dependencies for component.b[\"i\"]\n%s", diff)
+		}
+	}
+
+	type applyResultData struct {
+		NewRawState    map[string]*anypb.Any
+		VisitedMarkers []string
+	}
+
+	// Now we're finally ready for the first apply, during which we expect
+	// the component ordering decided during the plan phase to be respected.
+	t.Log("initial apply")
+	applyResult, err := promising.MainTask(ctx, func(ctx context.Context) (applyResultData, error) {
+		var visitedMarkers []string
+		var visitedMarkersMu sync.Mutex
+
+		outp, outpTester := testApplyOutput(t, nil)
+
+		main, err := ApplyPlan(ctx, cfg, rawPlan, ApplyOpts{
+			ProviderFactories: ProviderFactories{
+				testProviderAddr: func() (providers.Interface, error) {
+					return &terraform.MockProvider{
+						GetProviderSchemaResponse: &testProviderSchema,
+						ApplyResourceChangeFn: func(arcr providers.ApplyResourceChangeRequest) providers.ApplyResourceChangeResponse {
+							markerStr := arcr.PlannedState.GetAttr("marker").AsString()
+							log.Printf("[TRACE] TestApply_componentOrdering: visiting %q", markerStr)
+							visitedMarkersMu.Lock()
+							visitedMarkers = append(visitedMarkers, markerStr)
+							visitedMarkersMu.Unlock()
+
+							return providers.ApplyResourceChangeResponse{
+								NewState: arcr.PlannedState,
+							}
+						},
+					}, nil
+				},
+			},
+		}, outp)
+		if main != nil {
+			defer main.DoCleanup(ctx)
+		}
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		assertNoDiagnostics(t, outpTester.Diags())
+
+		return applyResultData{
+			NewRawState:    outpTester.RawUpdatedState(t),
+			VisitedMarkers: visitedMarkers,
+		}, nil
+	})
+
+	{
+		if len(applyResult.VisitedMarkers) != 5 {
+			t.Fatalf("apply didn't visit all of the resources\n%s", spew.Sdump(applyResult.VisitedMarkers))
+		}
+		assertSliceElementsInRelativeOrder(
+			t, applyResult.VisitedMarkers,
+			"a", "b.i",
+		)
+		assertSliceElementsInRelativeOrder(
+			t, applyResult.VisitedMarkers,
+			"a", "b.ii",
+		)
+		assertSliceElementsInRelativeOrder(
+			t, applyResult.VisitedMarkers,
+			"a", "b.iii",
+		)
+		assertSliceElementsInRelativeOrder(
+			t, applyResult.VisitedMarkers,
+			"b.i", "c",
+		)
+		assertSliceElementsInRelativeOrder(
+			t, applyResult.VisitedMarkers,
+			"b.ii", "c",
+		)
+		assertSliceElementsInRelativeOrder(
+			t, applyResult.VisitedMarkers,
+			"b.iii", "c",
+		)
+	}
+
+	// If the initial plan and apply was successful and made its changes in
+	// the correct order, then we'll also test creating and applying a
+	// destroy-mode plan.
+	// FIXME: We can't actually do this yet, because we don't have the logic
+	// in place for handling component results correctly when destroying.
+	// We'll complete this in a future commit.
+	/*
+		t.Log("destroy plan")
+		planOutput, err = promising.MainTask(ctx, func(ctx context.Context) (*planOutputTester, error) {
+			main := NewForPlanning(cfg, stackstate.NewState(), PlanOpts{
+				PlanningMode: plans.DestroyMode,
+				ProviderFactories: ProviderFactories{
+					testProviderAddr: func() (providers.Interface, error) {
+						return &terraform.MockProvider{
+							GetProviderSchemaResponse: &testProviderSchema,
+							PlanResourceChangeFn: func(prcr providers.PlanResourceChangeRequest) providers.PlanResourceChangeResponse {
+								return providers.PlanResourceChangeResponse{
+									PlannedState: prcr.ProposedNewState,
+								}
+							},
+						}, nil
+					},
+				},
+			})
+
+			outp, outpTester := testPlanOutput(t)
+			main.PlanAll(ctx, outp)
+
+			return outpTester, nil
+		})
+		if err != nil {
+			t.Fatalf("planning failed: %s", err)
+		}
+
+		rawPlan = planOutput.RawChanges(t)
+		plan, diags = planOutput.Close(t)
+		assertNoDiagnostics(t, diags)
+		if !plan.Applyable {
+			m := proto.TextMarshaler{
+				Compact:   false,
+				ExpandAny: true,
+			}
+			for _, raw := range rawPlan {
+				t.Log(m.Text(raw))
+			}
+			t.Fatalf("plan is not applyable")
+		}
+	*/
+}
+
+func sliceElementsInRelativeOrder[S ~[]E, E comparable](s S, v1, v2 E) bool {
+	idx1 := slices.Index(s, v1)
+	idx2 := slices.Index(s, v2)
+	if idx1 < 0 || idx2 < 0 {
+		// both values must actually be present for this test to be meaningful
+		return false
+	}
+	return idx1 < idx2
+}
+
+func assertSliceElementsInRelativeOrder[S ~[]E, E comparable](t *testing.T, s S, v1, v2 E) {
+	t.Helper()
+
+	if !sliceElementsInRelativeOrder(s, v1, v2) {
+		t.Fatalf("incorrect element order\ngot: %s\nwant: %#v before %#v", strings.TrimSpace(spew.Sdump(s)), v1, v2)
+	}
+}

--- a/internal/stacks/stackruntime/internal/stackeval/component_instance_results.go
+++ b/internal/stacks/stackruntime/internal/stackeval/component_instance_results.go
@@ -23,6 +23,15 @@ type ComponentInstanceApplyResult struct {
 	// during plan, even though no external actions were taken during the
 	// apply phase.
 	AffectedResourceInstanceObjects addrs.Set[addrs.AbsResourceInstanceObject]
+
+	// Complete is set to true if the apply ran to completion successfully
+	// such that it should be safe to try to apply other component instances
+	// that are awaiting the completion of this one.
+	//
+	// If set to false, some changes may have been made but there may be
+	// some changes still pending and so other waiting component instances
+	// should not try to apply themselves at all.
+	Complete bool
 }
 
 // resourceInstanceObjectsAffectedByPlan finds an exhaustive set of addresses

--- a/internal/stacks/stackruntime/internal/stackeval/main.go
+++ b/internal/stacks/stackruntime/internal/stackeval/main.go
@@ -18,6 +18,7 @@ import (
 	"github.com/hashicorp/terraform/internal/promising"
 	"github.com/hashicorp/terraform/internal/stacks/stackaddrs"
 	"github.com/hashicorp/terraform/internal/stacks/stackconfig"
+	"github.com/hashicorp/terraform/internal/stacks/stackplan"
 	"github.com/hashicorp/terraform/internal/stacks/stackstate"
 	"github.com/hashicorp/terraform/internal/tfdiags"
 )
@@ -90,6 +91,7 @@ type mainPlanning struct {
 
 type mainApplying struct {
 	opts          ApplyOpts
+	plan          *stackplan.Plan
 	rootInputVals map[stackaddrs.InputVariable]cty.Value
 	results       *ChangeExecResults
 }
@@ -127,11 +129,12 @@ func NewForPlanning(config *stackconfig.Config, prevState *stackstate.State, opt
 	}
 }
 
-func NewForApplying(config *stackconfig.Config, rootInputs map[stackaddrs.InputVariable]cty.Value, execResults *ChangeExecResults, opts ApplyOpts) *Main {
+func NewForApplying(config *stackconfig.Config, rootInputs map[stackaddrs.InputVariable]cty.Value, plan *stackplan.Plan, execResults *ChangeExecResults, opts ApplyOpts) *Main {
 	return &Main{
 		config: config,
 		applying: &mainApplying{
 			opts:          opts,
+			plan:          plan,
 			rootInputVals: rootInputs,
 			results:       execResults,
 		},
@@ -216,6 +219,15 @@ func (m *Main) ApplyChangeResults() *ChangeExecResults {
 		panic("stacks language runtime is instantiated for applying but somehow has no change results")
 	}
 	return m.applying.results
+}
+
+// PlanBeingApplied returns the plan that's currently being applied, or panics
+// if called not during an apply phase.
+func (m *Main) PlanBeingApplied() *stackplan.Plan {
+	if !m.Applying() {
+		panic("stacks language runtime is not instantiated for applying")
+	}
+	return m.applying.plan
 }
 
 // InspectingState returns the state snapshot that was provided when

--- a/internal/stacks/stackruntime/internal/stackeval/main_apply.go
+++ b/internal/stacks/stackruntime/internal/stackeval/main_apply.go
@@ -198,7 +198,7 @@ func ApplyPlan(ctx context.Context, config *stackconfig.Config, rawPlan []*anypb
 			}
 		})
 
-		main := NewForApplying(config, plan.RootInputValues, results, opts)
+		main := NewForApplying(config, plan.RootInputValues, plan, results, opts)
 		begin(ctx, main) // the change tasks registered above become runnable
 
 		// With the planned changes now in progress, we'll visit everything and

--- a/internal/stacks/stackruntime/internal/stackeval/main_apply.go
+++ b/internal/stacks/stackruntime/internal/stackeval/main_apply.go
@@ -6,16 +6,23 @@ package stackeval
 import (
 	"context"
 	"fmt"
+	"log"
 	"sync/atomic"
 
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
+	"google.golang.org/protobuf/types/known/anypb"
+
 	"github.com/hashicorp/terraform/internal/collections"
+	"github.com/hashicorp/terraform/internal/plans"
 	"github.com/hashicorp/terraform/internal/promising"
+	"github.com/hashicorp/terraform/internal/stacks/stackaddrs"
 	"github.com/hashicorp/terraform/internal/stacks/stackconfig"
 	"github.com/hashicorp/terraform/internal/stacks/stackplan"
 	"github.com/hashicorp/terraform/internal/stacks/stackstate"
 	"github.com/hashicorp/terraform/internal/stacks/stackstate/statekeys"
 	"github.com/hashicorp/terraform/internal/tfdiags"
-	"google.golang.org/protobuf/types/known/anypb"
 )
 
 // ApplyPlan internally instantiates a [Main] configured to apply the given
@@ -71,6 +78,7 @@ func ApplyPlan(ctx context.Context, config *stackconfig.Config, rawPlan []*anypb
 	// with discarding the previous run state data that's no longer needed.
 	emitStateKeyDiscardEvents(ctx, discardRawKeys, discardDescKeys, outp)
 
+	log.Printf("[TRACE] stackeval.ApplyPlan starting")
 	withDiags, err := promising.MainTask(ctx, func(ctx context.Context) (withDiagnostics[*Main], error) {
 		// We'll register all of the changes we intend to make up front, so we
 		// can error rather than deadlock if something goes wrong and causes
@@ -79,11 +87,16 @@ func ApplyPlan(ctx context.Context, config *stackconfig.Config, rawPlan []*anypb
 			for _, elem := range plan.Components.Elems() {
 				addr := elem.K
 				componentInstPlan := elem.V
+				action := componentInstPlan.PlannedAction
+				dependencyAddrs := componentInstPlan.Dependencies
+				dependentAddrs := componentInstPlan.Dependents
+
 				reg.RegisterComponentInstanceChange(
 					ctx, addr,
 					func(ctx context.Context, main *Main) (*ComponentInstanceApplyResult, tfdiags.Diagnostics) {
 						ctx, span := tracer.Start(ctx, addr.String()+" apply")
 						defer span.End()
+						log.Printf("[TRACE] stackeval: %s preparing to apply", addr)
 
 						stack := main.Stack(ctx, addr.Stack, ApplyPhase)
 						component := stack.Component(ctx, addr.Item.Component)
@@ -100,6 +113,8 @@ func ApplyPlan(ctx context.Context, config *stackconfig.Config, rawPlan []*anypb
 							// returning a placeholder value and expect the cause
 							// to be reported by some object when we do the apply
 							// checking walk below.
+							log.Printf("[ERROR] stackeval: %s has planned changes, but does not seem to be declared", addr)
+							span.SetStatus(codes.Error, "missing component instance declaration")
 							return nil, nil
 						}
 
@@ -117,10 +132,67 @@ func ApplyPlan(ctx context.Context, config *stackconfig.Config, rawPlan []*anypb
 								"Inconsistent component instance plan",
 								fmt.Sprintf("The plan for %s is inconsistent with its prior state: %s.", addr, err),
 							))
+							log.Printf("[ERROR] stackeval: %s has a plan inconsistent with its prior state: %s", addr, err)
+							span.SetStatus(codes.Error, "plan is inconsistent with prior state")
 							return nil, diags
 						}
 
-						return inst.ApplyModuleTreePlan(ctx, modulesRuntimePlan)
+						var waitForComponents collections.Set[stackaddrs.AbsComponent]
+						if action == plans.Delete {
+							// If the effect of this apply will be to destroy this
+							// component instance then we need to wait for all
+							// of our dependents to be destroyed first, because
+							// we're required to outlive them.
+							//
+							// (We can assume that all of the dependents are
+							// also performing destroy plans, because we'd have
+							// rejected the configuration as invalid if a
+							// downstream component were referring to a
+							// component that's been removed from the config.)
+							waitForComponents = dependentAddrs
+						} else {
+							// For all other actions, we must wait for our
+							// dependencies to finish applying their changes.
+							waitForComponents = dependencyAddrs
+						}
+						if depCount := waitForComponents.Len(); depCount != 0 {
+							log.Printf("[TRACE] stackeval: %s waiting for its predecessors (%d) to complete", addr, depCount)
+						}
+						for _, waitComponentAddr := range waitForComponents.Elems() {
+							if stack := main.Stack(ctx, waitComponentAddr.Stack, ApplyPhase); stack != nil {
+								if component := stack.Component(ctx, waitComponentAddr.Item); component != nil {
+									span.AddEvent("awaiting predecessor", trace.WithAttributes(
+										attribute.String("component_addr", waitComponentAddr.String()),
+									))
+									success := component.ApplySuccessful(ctx)
+									if !success {
+										// If anything we're waiting on does not succeed then we can't proceed without
+										// violating the dependency invariants.
+										log.Printf("[TRACE] stackeval: %s cannot start because %s changes did not apply completely", addr, waitComponentAddr)
+										span.AddEvent("predecessor is incomplete", trace.WithAttributes(
+											attribute.String("component_addr", waitComponentAddr.String()),
+										))
+										span.SetStatus(codes.Error, "predecessors did not completely apply")
+
+										// We'll return a stub result that reports that nothing was changed, since
+										// we're not going to run our apply phase at all.
+										return inst.PlaceholderApplyResultForSkippedApply(ctx, modulesRuntimePlan), nil
+										// Since we're not calling inst.ApplyModuleTreePlan at all in this
+										// codepath, the stacks runtime will not emit any progress events for
+										// this component instance or any of the objects inside it.
+									}
+								}
+							}
+						}
+						log.Printf("[TRACE] stackeval: %s now applying", addr)
+
+						ret, diags := inst.ApplyModuleTreePlan(ctx, modulesRuntimePlan)
+						if !ret.Complete {
+							span.SetStatus(codes.Error, "apply did not complete successfully")
+						} else {
+							span.SetStatus(codes.Ok, "apply complete")
+						}
+						return ret, diags
 					},
 				)
 			}
@@ -195,6 +267,7 @@ func ApplyPlan(ctx context.Context, config *stackconfig.Config, rawPlan []*anypb
 	if len(diags) > 0 {
 		outp.AnnounceDiagnostics(ctx, diags)
 	}
+	log.Printf("[TRACE] stackeval.ApplyPlan complete")
 
 	return main, nil
 }

--- a/internal/stacks/stackruntime/internal/stackeval/testdata/sourcebundle/applying/component_dependencies/applying_component_dependencies.tf
+++ b/internal/stacks/stackruntime/internal/stackeval/testdata/sourcebundle/applying/component_dependencies/applying_component_dependencies.tf
@@ -1,0 +1,24 @@
+terraform {
+  required_providers {
+    test = {
+      source = "terraform.io/builtin/test"
+    }
+  }
+}
+
+variable "marker" {
+  type = string
+}
+
+variable "deps" {
+  type    = set(string)
+  default = []
+}
+
+resource "test_report" "main" {
+  marker = var.marker
+}
+
+output "marker" {
+  value = var.marker
+}

--- a/internal/stacks/stackruntime/internal/stackeval/testdata/sourcebundle/applying/component_dependencies/applying_component_dependencies.tfstack.hcl
+++ b/internal/stacks/stackruntime/internal/stackeval/testdata/sourcebundle/applying/component_dependencies/applying_component_dependencies.tfstack.hcl
@@ -1,0 +1,44 @@
+required_providers {
+  test = {
+    source = "terraform.io/builtin/test"
+  }
+}
+
+provider "test" "main" {
+}
+
+component "a" {
+  source = "./"
+
+  inputs = {
+    marker = "a"
+  }
+  providers = {
+    test = provider.test.main
+  }
+}
+
+component "b" {
+  source   = "./"
+  for_each = toset(["i", "ii", "iii"])
+
+  inputs = {
+    marker = "b.${each.key}"
+    deps   = [component.a.marker]
+  }
+  providers = {
+    test = provider.test.main
+  }
+}
+
+component "c" {
+  source = "./"
+
+  inputs = {
+    marker = "c"
+    deps   = [ for b in component.b : b.marker ]
+  }
+  providers = {
+    test = provider.test.main
+  }
+}

--- a/internal/stacks/stackruntime/internal/stackeval/testdata/sourcebundle/terraform-sources.json
+++ b/internal/stacks/stackruntime/internal/stackeval/testdata/sourcebundle/terraform-sources.json
@@ -26,6 +26,10 @@
         "local": "planning"
       },
       {
+        "source": "https://testing.invalid/applying.tar.gz",
+        "local": "applying"
+      },
+      {
         "source": "https://testing.invalid/validating.tar.gz",
         "local": "validating"
       }

--- a/internal/stacks/stackruntime/internal/stackeval/testing_test.go
+++ b/internal/stacks/stackruntime/internal/stackeval/testing_test.go
@@ -242,7 +242,11 @@ func (aot *applyOutputTester) RawUpdatedState(t *testing.T) map[string]*anypb.An
 			t.Fatalf("failed to encode %T: %s", change, err)
 		}
 		for _, protoRaw := range protoChange.Raw {
-			msgs[protoRaw.Key] = protoRaw.Value
+			if protoRaw.Value != nil {
+				msgs[protoRaw.Key] = protoRaw.Value
+			} else {
+				delete(msgs, protoRaw.Key)
+			}
 		}
 	}
 

--- a/internal/stacks/stackruntime/internal/stackeval/testing_test.go
+++ b/internal/stacks/stackruntime/internal/stackeval/testing_test.go
@@ -12,15 +12,17 @@ import (
 
 	"github.com/hashicorp/go-slug/sourceaddrs"
 	"github.com/hashicorp/go-slug/sourcebundle"
+	"github.com/zclconf/go-cty/cty"
+	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/types/known/anypb"
+
+	_ "github.com/hashicorp/terraform/internal/logging"
 	"github.com/hashicorp/terraform/internal/promising"
 	"github.com/hashicorp/terraform/internal/stacks/stackaddrs"
 	"github.com/hashicorp/terraform/internal/stacks/stackconfig"
 	"github.com/hashicorp/terraform/internal/stacks/stackplan"
 	"github.com/hashicorp/terraform/internal/stacks/stackstate"
 	"github.com/hashicorp/terraform/internal/tfdiags"
-	"github.com/zclconf/go-cty/cty"
-	"google.golang.org/protobuf/reflect/protoreflect"
-	"google.golang.org/protobuf/types/known/anypb"
 )
 
 // This file contains some general test utilities that many of our other
@@ -110,6 +112,61 @@ type planOutputTester struct {
 	mu      sync.Mutex
 }
 
+// PlannedChanges returns the planned changes that have been accumulated in the
+// receiver.
+//
+// It isn't safe to access the returned slice concurrently with a planning
+// operation. Use this method only once the plan operation is complete and
+// thus the changes are finalized.
+func (pot *planOutputTester) PlannedChanges() []stackplan.PlannedChange {
+	return pot.planned
+}
+
+// RawChanges returns the protobuf representation changes that have been
+// accumulated in the receiver.
+//
+// It isn't safe to call this method concurrently with a planning
+// operation. Use this method only once the plan operation is complete and
+// thus the raw changes are finalized.
+func (pot *planOutputTester) RawChanges(t *testing.T) []*anypb.Any {
+	t.Helper()
+
+	var msgs []*anypb.Any
+	for _, change := range pot.planned {
+		protoChange, err := change.PlannedChangeProto()
+		if err != nil {
+			t.Fatalf("failed to encode %T: %s", change, err)
+		}
+		msgs = append(msgs, protoChange.Raw...)
+	}
+
+	// Normally it's the stackeval caller (in stackruntime) that marks a
+	// plan as "applyable", but since we're calling into the stackeval functions
+	// directly here we'll need to add that extra item ourselves.
+	if !pot.diags.HasErrors() {
+		change := stackplan.PlannedChangeApplyable{
+			Applyable: true,
+		}
+		protoChange, err := change.PlannedChangeProto()
+		if err != nil {
+			t.Fatalf("failed to encode %T: %s", change, err)
+		}
+		msgs = append(msgs, protoChange.Raw...)
+	}
+
+	return msgs
+}
+
+// Diags returns the diagnostics that have been accumulated in the
+// receiver.
+//
+// It isn't safe to access the returned slice concurrently with a planning
+// operation. Use this method only once the plan operation is complete and
+// thus the diagnostics are finalized.
+func (pot *planOutputTester) Diags() tfdiags.Diagnostics {
+	return pot.diags
+}
+
 func (pot *planOutputTester) Close(t *testing.T) (*stackplan.Plan, tfdiags.Diagnostics) {
 	t.Helper()
 
@@ -123,19 +180,103 @@ func (pot *planOutputTester) Close(t *testing.T) (*stackplan.Plan, tfdiags.Diagn
 	// and deserialize logic to approximate the effect of this plan having been
 	// saved and then reloaded during a subsequent apply phase, since
 	// the reloaded plan is a more convenient artifact to inspect in tests.
-	var msgs []*anypb.Any
-	for _, change := range pot.planned {
-		protoChange, err := change.PlannedChangeProto()
-		if err != nil {
-			t.Fatalf("failed to encode %T: %s", change, err)
-		}
-		msgs = append(msgs, protoChange.Raw...)
-	}
+	msgs := pot.RawChanges(t)
 	plan, err := stackplan.LoadFromProto(msgs)
 	if err != nil {
 		t.Fatalf("failed to reload saved plan: %s", err)
 	}
 	return plan, pot.diags
+}
+
+func testApplyOutput(t *testing.T, priorStateRaw map[string]*anypb.Any) (ApplyOutput, *applyOutputTester) {
+	t.Helper()
+	tester := &applyOutputTester{}
+	outp := ApplyOutput{
+		AnnounceAppliedChange: func(ctx context.Context, ac stackstate.AppliedChange) {
+			tester.mu.Lock()
+			tester.applied = append(tester.applied, ac)
+			tester.mu.Unlock()
+		},
+		AnnounceDiagnostics: func(ctx context.Context, d tfdiags.Diagnostics) {
+			tester.mu.Lock()
+			tester.diags = tester.diags.Append(d)
+			tester.mu.Unlock()
+		},
+	}
+	return outp, tester
+}
+
+type applyOutputTester struct {
+	prior   map[string]*anypb.Any
+	applied []stackstate.AppliedChange
+	diags   tfdiags.Diagnostics
+	mu      sync.Mutex
+}
+
+// AppliedChanges returns the applied change objects that have been accumulated
+// in the receiver.
+//
+// It isn't safe to access the returned slice concurrently with an apply
+// operation. Use this method only once the apply operation is complete and
+// thus the changes are finalized.
+func (aot *applyOutputTester) AppliedChanges() []stackstate.AppliedChange {
+	return aot.applied
+}
+
+// RawUpdatedState returns the protobuf representation of the state with the
+// accumulated changes merged into it.
+//
+// It isn't safe to call this method concurrently with an apply
+// operation. Use this method only once the apply operation is complete and
+// thus the changes are finalized.
+func (aot *applyOutputTester) RawUpdatedState(t *testing.T) map[string]*anypb.Any {
+	t.Helper()
+
+	msgs := make(map[string]*anypb.Any)
+	for k, v := range aot.prior {
+		msgs[k] = v
+	}
+	for _, change := range aot.applied {
+		protoChange, err := change.AppliedChangeProto()
+		if err != nil {
+			t.Fatalf("failed to encode %T: %s", change, err)
+		}
+		for _, protoRaw := range protoChange.Raw {
+			msgs[protoRaw.Key] = protoRaw.Value
+		}
+	}
+
+	return msgs
+}
+
+// Diags returns the diagnostics that have been accumulated in the
+// receiver.
+//
+// It isn't safe to access the returned slice concurrently with an apply
+// operation. Use this method only once the apply operation is complete and
+// thus the diagnostics are finalized.
+func (aot *applyOutputTester) Diags() tfdiags.Diagnostics {
+	return aot.diags
+}
+
+func (aot *applyOutputTester) Close(t *testing.T) (*stackstate.State, tfdiags.Diagnostics) {
+	t.Helper()
+
+	// Caller shouldn't close concurrently with other work anyway, but we'll
+	// include this just to help make things behave more consistently even when
+	// the caller is buggy.
+	aot.mu.Lock()
+	defer aot.mu.Unlock()
+
+	// We'll now round-trip all of the applied changes through the serialize
+	// and deserialize logic to approximate the effect of this having having been
+	// saved and then reloaded during a subsequent planning phase.
+	msgs := aot.RawUpdatedState(t)
+	state, err := stackstate.LoadFromProto(msgs)
+	if err != nil {
+		t.Fatalf("failed to reload saved state: %s", err)
+	}
+	return state, aot.diags
 }
 
 func testFormatDiagnostics(t *testing.T, diags tfdiags.Diagnostics) string {


### PR DESCRIPTION
This builds on https://github.com/hashicorp/terraform/pull/34483 to actually make use of the computed dependency relationships during the apply phase.

When a component's plan is in normal or refresh-only mode, that component waits until its dependencies have completed applying.

For a destroy-mode plan the opposite is true, with the component waiting until its _dependents_ have finished applying. That therefore ensures that dependencies outlive their dependents as expected. Although there's no single place in the code that enforces this, it's not possible in practice for an upstream component to have a destroy-mode plan while a downstream has a non-destroy plan, because that would imply that the downstream still exists in the configuration but refers to something that's been removed, which would fail static validation and thus prevent the overall stack plan from being created altogether.

Some other supporting improvements to the test helpers came along the way here, and so it may help to review this on a commit-by-commit basis to see it grow over multiple steps.
