### PR TITLE
stacks: on module load convert relative paths to absolute

### DIFF
--- a/internal/stacks/stackruntime/internal/stackeval/testdata/sourcebundle/validating/modules_with_provider_configs/module-a/modules-with-provider-configs-a.tf
+++ b/internal/stacks/stackruntime/internal/stackeval/testdata/sourcebundle/validating/modules_with_provider_configs/module-a/modules-with-provider-configs-a.tf
@@ -11,10 +11,5 @@ provider "test" {
 }
 
 module "b" {
-  # FIXME: The following is an absolute remote address only because at the
-  # time of writing this test the stacks runtime's module loader can't deal
-  # with relative paths in this location.
-  source = "https://testing.invalid/validating.tar.gz//modules_with_provider_configs/module-b"
-  # Once that's been fixed, this should instead be:
-  # source = "../module-b"
+  source = "../module-b"
 }


### PR DESCRIPTION
Should fix https://hashicorp.atlassian.net/browse/TF-11905. I note that Martin mentioned a better fix would be to implement config and module loading from a source bundle properly but that's a lot of work. I think this should work in the mean time until we can revisit a proper refactor.

I think this fix should work since the parent module was definitely successfully loaded, so the cached source directory of the parent should be valid from the current working directory, and therefore any relative sources from the parent should be able to be joined with the parents directory. The source bundle implementation either returns absolute paths pointing to external dependencies or paths relative to the parent. I think we do have all the information we need to correctly deduce the target path of any local dependencies.