### PR TITLE
Add error diagnostics when receiving an unknown value from `ReadResource` or `UpgradeResourceState`

### DIFF
--- a/internal/refactoring/cross_provider_move.go
+++ b/internal/refactoring/cross_provider_move.go
@@ -161,6 +161,15 @@ func (move *crossTypeMove) applyCrossTypeMove(stmt *MoveStatement, source, targe
 		})
 		return diags
 	}
+	if !resp.TargetState.IsWhollyKnown() {
+		diags = diags.Append(&hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  "Provider returned invalid value",
+			Detail: fmt.Sprintf("The provider %s returned an invalid value during an across type move operation: The returned state contains unknown values. This is a bug in the relevant provider; Please report it.",
+				move.targetProviderAddr),
+			Subject: stmt.DeclRange.ToHCL().Ptr(),
+		})
+	}
 
 	// Finally, we can update the source value with the new value.
 

--- a/internal/terraform/context_plan2_test.go
+++ b/internal/terraform/context_plan2_test.go
@@ -5264,7 +5264,6 @@ resource "test_resource" "a" {
 	for _, res := range plan.Changes.Resources {
 		switch res.Addr.String() {
 		case "test_resource.a":
-			spew.Dump(res)
 			if res.Action != plans.NoOp {
 				t.Errorf("unexpected %s change for %s", res.Action, res.Addr)
 			}

--- a/internal/terraform/node_resource_abstract_instance.go
+++ b/internal/terraform/node_resource_abstract_instance.go
@@ -656,13 +656,24 @@ func (n *NodeAbstractResourceInstance) refresh(ctx EvalContext, deposedKey state
 		panic("new state is cty.NilVal")
 	}
 
+	if !resp.NewState.IsWhollyKnown() {
+		diags = diags.Append(tfdiags.Sourceless(
+			tfdiags.Error,
+			"Provider produced invalid object",
+			fmt.Sprintf(
+				"Provider %q planned an invalid value for %s during refresh: %s.\n\nThis is a bug in the provider, which should be reported in the provider's own issue tracker.",
+				n.ResolvedProvider.Provider, absAddr, "The returned state contains unknown values",
+			),
+		))
+	}
+
 	for _, err := range resp.NewState.Type().TestConformance(schema.ImpliedType()) {
 		diags = diags.Append(tfdiags.Sourceless(
 			tfdiags.Error,
 			"Provider produced invalid object",
 			fmt.Sprintf(
 				"Provider %q planned an invalid value for %s during refresh: %s.\n\nThis is a bug in the provider, which should be reported in the provider's own issue tracker.",
-				n.ResolvedProvider.Provider.String(), absAddr, tfdiags.FormatError(err),
+				n.ResolvedProvider.Provider, absAddr, tfdiags.FormatError(err),
 			),
 		))
 	}

--- a/internal/terraform/upgrade_resource_state.go
+++ b/internal/terraform/upgrade_resource_state.go
@@ -96,6 +96,14 @@ func upgradeResourceState(addr addrs.AbsResourceInstance, provider providers.Int
 		return nil, diags
 	}
 
+	if !resp.UpgradedState.IsWhollyKnown() {
+		diags = diags.Append(tfdiags.Sourceless(
+			tfdiags.Error,
+			"Invalid resource state upgrade",
+			fmt.Sprintf("The %s provider upgraded the state for %s from a previous version, but produced an invalid result: The returned state contains unknown values.", providerType, addr),
+		))
+	}
+
 	// After upgrading, the new value must conform to the current schema. When
 	// going over RPC this is actually already ensured by the
 	// marshaling/unmarshaling of the new value, but we'll check it here


### PR DESCRIPTION
Add error diagnostics to catch when we find an unknown value from `ReadResource` or `UpgradeResourceState`. An unknown value is not valid in either of these cases, but the current error is not helpful and only returns a generic error about failed state serialization.

Fixes #34502
Fixes #34503