### PR TITLE
terraform test: Fix crash when file level variables reference variables.

### DIFF
--- a/internal/backend/local/backend_local.go
+++ b/internal/backend/local/backend_local.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hashicorp/terraform/internal/backend"
 	"github.com/hashicorp/terraform/internal/configs"
 	"github.com/hashicorp/terraform/internal/configs/configload"
+	"github.com/hashicorp/terraform/internal/lang"
 	"github.com/hashicorp/terraform/internal/plans/planfile"
 	"github.com/hashicorp/terraform/internal/states/statemgr"
 	"github.com/hashicorp/terraform/internal/terraform"
@@ -516,7 +517,9 @@ var _ backend.UnparsedVariableValue = unparsedTestVariableValue{}
 func (v unparsedTestVariableValue) ParseVariableValue(mode configs.VariableParsingMode) (*terraform.InputValue, tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
 
-	value, valueDiags := v.Expr.Value(nil)
+	value, valueDiags := v.Expr.Value(&hcl.EvalContext{
+		Functions: lang.TestingFunctions(),
+	})
 	diags = diags.Append(valueDiags)
 	if valueDiags.HasErrors() {
 		return nil, diags

--- a/internal/command/test_test.go
+++ b/internal/command/test_test.go
@@ -208,7 +208,7 @@ func TestTest_Runs(t *testing.T) {
 			code:        0,
 		},
 		"functions_available": {
-			expectedOut: "1 passed, 0 failed.",
+			expectedOut: "2 passed, 0 failed.",
 			code:        0,
 		},
 		"mocking": {

--- a/internal/command/test_test.go
+++ b/internal/command/test_test.go
@@ -227,6 +227,11 @@ func TestTest_Runs(t *testing.T) {
 			expectedOut: "1 passed, 0 failed.",
 			code:        0,
 		},
+		"global_var_refs": {
+			expectedOut: "2 failed, 1 skipped.",
+			expectedErr: "Variables may not be used here.",
+			code:        1,
+		},
 	}
 	for name, tc := range tcs {
 		t.Run(name, func(t *testing.T) {
@@ -281,7 +286,7 @@ func TestTest_Runs(t *testing.T) {
 			}
 
 			if !strings.Contains(output.Stdout(), tc.expectedOut) {
-				t.Errorf("output didn't contain expected string:\n\n%s", output.All())
+				t.Errorf("output didn't contain expected string:\n\n%s", output.Stdout())
 			}
 
 			if !strings.Contains(output.Stderr(), tc.expectedErr) {

--- a/internal/command/testdata/test/functions_available/alternate.tftest.hcl
+++ b/internal/command/testdata/test/functions_available/alternate.tftest.hcl
@@ -1,0 +1,10 @@
+variables {
+  input = jsonencode({key:"value"})
+}
+
+run "test" {
+  assert {
+    condition = jsondecode(test_resource.resource.value).key == "value"
+    error_message = "wrong value"
+  }
+}

--- a/internal/command/testdata/test/global_var_refs/environment_variable.tftest.hcl
+++ b/internal/command/testdata/test/global_var_refs/environment_variable.tftest.hcl
@@ -1,0 +1,6 @@
+
+variables {
+  input = var.env_var_input
+}
+
+run "execute" {}

--- a/internal/command/testdata/test/global_var_refs/main.tf
+++ b/internal/command/testdata/test/global_var_refs/main.tf
@@ -1,0 +1,7 @@
+variable "input" {
+  type = string
+}
+
+output "value" {
+  value = var.input
+}

--- a/internal/command/testdata/test/global_var_refs/run_block_output.tftest.hcl
+++ b/internal/command/testdata/test/global_var_refs/run_block_output.tftest.hcl
@@ -1,0 +1,17 @@
+
+variables {
+  input = var.setup.value
+}
+
+run "setup" {
+  variables {
+    input = "hello"
+  }
+}
+
+run "execute" {
+  assert {
+    condition     = output.value == "hello"
+    error_message = "bad output value"
+  }
+}


### PR DESCRIPTION

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Fixes #34529 

This PR also allows users to reference functions at test-file level global variables, which is something we published within the CHANGELOG for v1.7.

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.7.1

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

### BUG FIXES 

<!--

Write a short description of the user-facing change. Examples:

- `terraform show -json`: Fixed crash with sensitive set values.
- When rendering a diff, Terraform now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 

-  `terraform test: Fix crash when referencing variables within the file level `variables` block.
