### PR TITLE
internal/command/jsonprovider: Remove root jsonfunction object from function output

### DIFF
--- a/internal/command/jsonfunction/function.go
+++ b/internal/command/jsonfunction/function.go
@@ -16,6 +16,10 @@ import (
 // FormatVersion represents the version of the json format and will be
 // incremented for any change to this format that requires changes to a
 // consuming parser.
+//
+// Any changes to this version should also consider compatibility in the
+// jsonprovider package versioning as well, as that functionality is also
+// reliant on this package.
 const FormatVersion = "1.0"
 
 // functions is the top-level object returned when exporting function signatures
@@ -59,22 +63,18 @@ func newFunctions() *functions {
 	}
 }
 
-func MarshalProviderFunctions(f map[string]providers.FunctionDecl) ([]byte, error) {
-	if len(f) == 0 {
-		return nil, nil
+func MarshalProviderFunctions(f map[string]providers.FunctionDecl) map[string]*FunctionSignature {
+	if f == nil {
+		return nil
 	}
 
-	signatures := newFunctions()
+	result := make(map[string]*FunctionSignature, len(f))
 
 	for name, v := range f {
-		signatures.Signatures[name] = marshalProviderFunction(v)
+		result[name] = marshalProviderFunction(v)
 	}
 
-	ret, err := json.Marshal(signatures)
-	if err != nil {
-		return nil, fmt.Errorf("Failed to serialize provider functions: %w", err)
-	}
-	return ret, nil
+	return result
 }
 
 func Marshal(f map[string]function.Function) ([]byte, tfdiags.Diagnostics) {

--- a/internal/command/jsonprovider/provider.go
+++ b/internal/command/jsonprovider/provider.go
@@ -23,27 +23,10 @@ type Providers struct {
 }
 
 type Provider struct {
-	Provider          *Schema            `json:"provider,omitempty"`
-	ResourceSchemas   map[string]*Schema `json:"resource_schemas,omitempty"`
-	DataSourceSchemas map[string]*Schema `json:"data_source_schemas,omitempty"`
-
-	// Functions are serialized by the jsonfunction package
-	Functions               json.RawMessage `json:"functions,omitempty"`
-	providerSchemaFunctions map[string]providers.FunctionDecl
-}
-
-func (p Provider) MarshalJSON() ([]byte, error) {
-	type provider Provider
-
-	tmp := provider(p)
-
-	var err error
-	tmp.Functions, err = jsonfunction.MarshalProviderFunctions(p.providerSchemaFunctions)
-	if err != nil {
-		return nil, err
-	}
-
-	return json.Marshal(tmp)
+	Provider          *Schema                                    `json:"provider,omitempty"`
+	ResourceSchemas   map[string]*Schema                         `json:"resource_schemas,omitempty"`
+	DataSourceSchemas map[string]*Schema                         `json:"data_source_schemas,omitempty"`
+	Functions         map[string]*jsonfunction.FunctionSignature `json:"functions,omitempty"`
 }
 
 func newProviders() *Providers {
@@ -75,9 +58,9 @@ func Marshal(s *terraform.Schemas) ([]byte, error) {
 
 func marshalProvider(tps providers.ProviderSchema) *Provider {
 	return &Provider{
-		Provider:                marshalSchema(tps.Provider),
-		ResourceSchemas:         marshalSchemas(tps.ResourceTypes),
-		DataSourceSchemas:       marshalSchemas(tps.DataSources),
-		providerSchemaFunctions: tps.Functions,
+		Provider:          marshalSchema(tps.Provider),
+		ResourceSchemas:   marshalSchemas(tps.ResourceTypes),
+		DataSourceSchemas: marshalSchemas(tps.DataSources),
+		Functions:         jsonfunction.MarshalProviderFunctions(tps.Functions),
 	}
 }

--- a/website/docs/cli/commands/providers/schema.mdx
+++ b/website/docs/cli/commands/providers/schema.mdx
@@ -47,7 +47,7 @@ The JSON output format consists of the following objects and sub-objects:
 - [Providers Schema Representation](#providers-schema-representation) - the top-level object returned by `terraform providers schema -json`
 - [Schema Representation](#schema-representation) - a sub-object of providers, resources, and data sources that describes their schema, along with function signatures
 - [Block Representation](#block-representation) - a sub-object of schemas that describes attributes and nested blocks
-- [Function Signature Representation](#function-signature-representation) - a sub-object of functions that describes parameters, the return, and additional documentation
+- [Function Representation](#function-representation) - a sub-object of functions that describes parameters, the return, and additional documentation
 - [Parameter Representation](#parameter-representation) - a sub-object of function signatures that describes their type and additional documentation
 
 ## Providers Schema Representation
@@ -75,18 +75,9 @@ The JSON output format consists of the following objects and sub-objects:
         "example_datasource_name": <schema-representation>,
       },
 
-      // "functions" describes the provider functions
+      // "functions" map the provider function name to the function definition
       "functions": {
-        // "format_version" describes the format version for the function
-        // signatures.
-        "format_version": "1.0",
-
-        // "function_signatures" describes the signatures for all
-        // available functions.
-        "function_signatures": {
-          // keys in this map are the function names, such as "abs"
-          "example_function": <function-signature-representation>
-        }
+        "example_function": <function-representation>
       }
     },
     "example_provider_two": { … }
@@ -166,9 +157,9 @@ A block representation contains "attributes" and "block_types" (which represent 
 }
 ```
 
-## Function Signature Representation
+## Function Representation
 
-A function signature describes the definition of a function.
+A function representation describes the definition of a function.
 
 ```javascript
 {


### PR DESCRIPTION
Previously, the `providers schema -json` output would include the root object from `metadata functions -json`. This object had its own `format_version` property, which would be confusing with the root `format_version` property already present.

This change still uses the `jsonfunction` package for consistency between cty and provider function JSON handling, but removes that extra object, instead making `functions` directly a mapping of names to signatures/definitions. This also adds a code comment to hint maintainers that jsonprovider format versioning is tied to jsonfunction format versioning.

There are no compatibility concerns from this change as there have been no releases (even alphas) with the prior output.

Example output prior to change:

```jsonc
{
  "format_version": "1.0",
  "provider_schemas": {
    "registry.terraform.io/bflad/framework": {
      // ...
      "functions": {
        "format_version": "1.0",
        "function_signatures": {
          "example": {
            "description": "Echoes given argument as result",
            "summary": "Example function",
            "return_type": "string",
            "parameters": [
              {
                "name": "input",
                "description": "String to echo",
                "type": "string"
              }
            ]
          }
        }
      }
    }
  }
}
```

Example output after change:

```jsonc
{
  "format_version": "1.0",
  "provider_schemas": {
    "registry.terraform.io/bflad/framework": {
      // ...
      "functions": {
        "example": {
          "description": "Echoes given argument as result",
          "summary": "Example function",
          "return_type": "string",
          "parameters": [
            {
              "name": "input",
              "description": "String to echo",
              "type": "string"
            }
          ]
        }
      }
    }
  }
}
```

## Target Release

1.8.x

