### PR TITLE
docs: Fix upgrading version in docs Navbar

### DIFF
--- a/website/data/language-nav-data.json
+++ b/website/data/language-nav-data.json
@@ -1066,7 +1066,7 @@
     ]
   },
   {
-    "title": "Upgrading to Terraform v1.6",
+    "title": "Upgrading to Terraform v1.7",
     "path": "upgrade-guides"
   },
   {


### PR DESCRIPTION
[Someone on slack pointed out](https://hashicorp.slack.com/archives/CFCJ63SRL/p1705773259517479) we forgot to update the navbar to match upgrading to TF 1.7 (no longer 1.6)