### PR TITLE
A "unknown_instances" language experiment, allowing unknown values in count and for_each

### DIFF
--- a/internal/experiments/experiment.go
+++ b/internal/experiments/experiment.go
@@ -21,11 +21,13 @@ const (
 	SuppressProviderSensitiveAttrs = Experiment("provider_sensitive_attrs")
 	ConfigDrivenMove               = Experiment("config_driven_move")
 	PreconditionsPostconditions    = Experiment("preconditions_postconditions")
+	UnknownInstances               = Experiment("unknown_instances")
 )
 
 func init() {
 	// Each experiment constant defined above must be registered here as either
 	// a current or a concluded experiment.
+	registerCurrentExperiment(UnknownInstances)
 	registerConcludedExperiment(VariableValidation, "Custom variable validation can now be used by default, without enabling an experiment.")
 	registerConcludedExperiment(SuppressProviderSensitiveAttrs, "Provider-defined sensitive attributes are now redacted by default, without enabling an experiment.")
 	registerConcludedExperiment(ConfigDrivenMove, "Declarations of moved resource instances using \"moved\" blocks can now be used by default, without enabling an experiment.")

--- a/internal/terraform/eval_context.go
+++ b/internal/terraform/eval_context.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform/internal/checks"
 	"github.com/hashicorp/terraform/internal/configs"
 	"github.com/hashicorp/terraform/internal/configs/configschema"
+	"github.com/hashicorp/terraform/internal/experiments"
 	"github.com/hashicorp/terraform/internal/instances"
 	"github.com/hashicorp/terraform/internal/lang"
 	"github.com/hashicorp/terraform/internal/moduletest/mocking"
@@ -133,6 +134,11 @@ type EvalContext interface {
 	// EvaluationScope returns a scope that can be used to evaluate reference
 	// addresses in this context.
 	EvaluationScope(self addrs.Referenceable, source addrs.Referenceable, keyData InstanceKeyEvalData) *lang.Scope
+
+	// LanguageExperimentActive returns true if the given experiment is
+	// active in the module associated with this EvalContext, or false
+	// otherwise.
+	LanguageExperimentActive(experiment experiments.Experiment) bool
 
 	// NamedValues returns the object that tracks the gradual evaluation of
 	// all input variables, local values, and output values during a graph

--- a/internal/terraform/eval_context_mock.go
+++ b/internal/terraform/eval_context_mock.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform/internal/checks"
 	"github.com/hashicorp/terraform/internal/configs"
 	"github.com/hashicorp/terraform/internal/configs/configschema"
+	"github.com/hashicorp/terraform/internal/experiments"
 	"github.com/hashicorp/terraform/internal/instances"
 	"github.com/hashicorp/terraform/internal/lang"
 	"github.com/hashicorp/terraform/internal/moduletest/mocking"
@@ -118,6 +119,8 @@ type MockEvalContext struct {
 
 	PathCalled bool
 	PathPath   addrs.ModuleInstance
+
+	LanguageExperimentsActive experiments.Set
 
 	NamedValuesCalled bool
 	NamedValuesState  *namedvals.State
@@ -332,6 +335,15 @@ func (c *MockEvalContext) WithPath(path addrs.ModuleInstance) EvalContext {
 func (c *MockEvalContext) Path() addrs.ModuleInstance {
 	c.PathCalled = true
 	return c.PathPath
+}
+
+func (c *MockEvalContext) LanguageExperimentActive(experiment experiments.Experiment) bool {
+	// This particular function uses a live data structure so that tests can
+	// exercise different experiments being enabled; there is little reason
+	// to directly test whether this function was called since we use this
+	// function only temporarily while an experiment is active, and then
+	// remove the calls once the experiment is concluded.
+	return c.LanguageExperimentsActive.Has(experiment)
 }
 
 func (c *MockEvalContext) NamedValues() *namedvals.State {

--- a/internal/terraform/eval_count.go
+++ b/internal/terraform/eval_count.go
@@ -6,10 +6,11 @@ package terraform
 import (
 	"fmt"
 
-	"github.com/hashicorp/hcl/v2"
-	"github.com/hashicorp/terraform/internal/tfdiags"
 	"github.com/zclconf/go-cty/cty"
 	"github.com/zclconf/go-cty/cty/gocty"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/terraform/internal/tfdiags"
 )
 
 // evaluateCountExpression is our standard mechanism for interpreting an
@@ -20,9 +21,15 @@ import (
 // evaluateCountExpression differs from evaluateCountExpressionValue by
 // returning an error if the count value is not known, and converting the
 // cty.Value to an integer.
-func evaluateCountExpression(expr hcl.Expression, ctx EvalContext) (int, tfdiags.Diagnostics) {
+//
+// If allowUnknown is false then this function will return error diagnostics
+// whenever the expression returns an unknown value. Setting allowUnknown to
+// true instead permits unknown values, indicating them by returning the
+// placeholder value -1. Callers can assume that a return value of -1 without
+// any error diagnostics represents a valid unknown value.
+func evaluateCountExpression(expr hcl.Expression, ctx EvalContext, allowUnknown bool) (int, tfdiags.Diagnostics) {
 	countVal, diags := evaluateCountExpressionValue(expr, ctx)
-	if !countVal.IsKnown() {
+	if !allowUnknown && !countVal.IsKnown() {
 		// Currently this is a rather bad outcome from a UX standpoint, since we have
 		// no real mechanism to deal with this situation and all we can do is produce
 		// an error message.

--- a/internal/terraform/eval_count_test.go
+++ b/internal/terraform/eval_count_test.go
@@ -32,7 +32,7 @@ func TestEvaluateCountExpression(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			ctx := &MockEvalContext{}
 			ctx.installSimpleEval()
-			countVal, diags := evaluateCountExpression(test.Expr, ctx)
+			countVal, diags := evaluateCountExpression(test.Expr, ctx, false)
 
 			if len(diags) != 0 {
 				t.Errorf("unexpected diagnostics %s", spew.Sdump(diags))
@@ -42,6 +42,40 @@ func TestEvaluateCountExpression(t *testing.T) {
 				t.Errorf(
 					"wrong map value\ngot:  %swant: %s",
 					spew.Sdump(countVal), spew.Sdump(test.Count),
+				)
+			}
+		})
+	}
+}
+
+func TestEvaluateCountExpression_allowUnknown(t *testing.T) {
+	tests := map[string]struct {
+		Expr  hcl.Expression
+		Count int
+	}{
+		"unknown number": {
+			hcltest.MockExprLiteral(cty.UnknownVal(cty.Number)),
+			-1,
+		},
+		"dynamicval": {
+			hcltest.MockExprLiteral(cty.DynamicVal),
+			-1,
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			ctx := &MockEvalContext{}
+			ctx.installSimpleEval()
+			countVal, diags := evaluateCountExpression(test.Expr, ctx, true)
+
+			if len(diags) != 0 {
+				t.Errorf("unexpected diagnostics %s", spew.Sdump(diags))
+			}
+
+			if !reflect.DeepEqual(countVal, test.Count) {
+				t.Errorf(
+					"wrong result\ngot:  %#v\nwant: %#v",
+					countVal, test.Count,
 				)
 			}
 		})

--- a/internal/terraform/eval_for_each.go
+++ b/internal/terraform/eval_for_each.go
@@ -19,20 +19,21 @@ import (
 // evaluateForEachExpression differs from evaluateForEachExpressionValue by
 // returning an error if the count value is not known, and converting the
 // cty.Value to a map[string]cty.Value for compatibility with other calls.
-func evaluateForEachExpression(expr hcl.Expression, ctx EvalContext) (forEach map[string]cty.Value, diags tfdiags.Diagnostics) {
-	return newForEachEvaluator(expr, ctx).ResourceValue()
+func evaluateForEachExpression(expr hcl.Expression, ctx EvalContext, allowUnknown bool) (forEach map[string]cty.Value, known bool, diags tfdiags.Diagnostics) {
+	return newForEachEvaluator(expr, ctx, allowUnknown).ResourceValue()
 }
 
 // forEachEvaluator is the standard mechanism for interpreting an expression
 // given for a "for_each" argument on a resource, module, or import.
-func newForEachEvaluator(expr hcl.Expression, ctx EvalContext) *forEachEvaluator {
+func newForEachEvaluator(expr hcl.Expression, ctx EvalContext, allowUnknown bool) *forEachEvaluator {
 	if ctx == nil {
 		panic("nil EvalContext")
 	}
 
 	return &forEachEvaluator{
-		ctx:  ctx,
-		expr: expr,
+		ctx:          ctx,
+		expr:         expr,
+		allowUnknown: allowUnknown,
 	}
 }
 
@@ -48,44 +49,54 @@ type forEachEvaluator struct {
 	ctx  EvalContext
 	expr hcl.Expression
 
+	// TEMP: If allowUnknown is set then we skip the usual restriction that
+	// unknown values are not allowed in for_each. A caller that sets this
+	// must therefore be ready to deal with the result being unknown.
+	// This will eventually become the default behavior, once we've updated
+	// the rest of this package to handle that situation in a reasonable way.
+	allowUnknown bool
+
 	// internal
 	hclCtx *hcl.EvalContext
 }
 
 // ResourceForEachValue returns a known for_each map[string]cty.Value
 // appropriate for use within resource expansion.
-func (ev *forEachEvaluator) ResourceValue() (map[string]cty.Value, tfdiags.Diagnostics) {
+func (ev *forEachEvaluator) ResourceValue() (map[string]cty.Value, bool, tfdiags.Diagnostics) {
 	res := map[string]cty.Value{}
 
 	// no expression always results in an empty map
 	if ev.expr == nil {
-		return res, nil
+		return res, true, nil
 	}
 
 	forEachVal, diags := ev.Value()
 	if diags.HasErrors() {
-		return res, diags
+		return res, false, diags
 	}
 
 	// ensure our value is known for use in resource expansion
-	diags = diags.Append(ev.ensureKnownForResource(forEachVal))
-	if diags.HasErrors() {
-		return res, diags
+	unknownDiags := ev.ensureKnownForResource(forEachVal)
+	if unknownDiags.HasErrors() {
+		if !ev.allowUnknown {
+			diags = diags.Append(unknownDiags)
+		}
+		return res, false, diags
 	}
 
 	// validate the for_each value for use in resource expansion
 	diags = diags.Append(ev.validateResource(forEachVal))
 	if diags.HasErrors() {
-		return res, diags
+		return res, false, diags
 	}
 
 	if forEachVal.IsNull() || !forEachVal.IsKnown() || markSafeLengthInt(forEachVal) == 0 {
 		// we check length, because an empty set returns a nil map which will panic below
-		return res, diags
+		return res, true, diags
 	}
 
 	res = forEachVal.AsValueMap()
-	return res, diags
+	return res, true, diags
 }
 
 // ImportValue returns the for_each map for use within an import block,

--- a/internal/terraform/eval_for_each_test.go
+++ b/internal/terraform/eval_for_each_test.go
@@ -72,7 +72,7 @@ func TestEvaluateForEachExpression_valid(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			ctx := &MockEvalContext{}
 			ctx.installSimpleEval()
-			forEachMap, diags := evaluateForEachExpression(test.Expr, ctx)
+			forEachMap, _, diags := evaluateForEachExpression(test.Expr, ctx, false)
 
 			if len(diags) != 0 {
 				t.Errorf("unexpected diagnostics %s", spew.Sdump(diags))
@@ -176,7 +176,7 @@ func TestEvaluateForEachExpression_errors(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			ctx := &MockEvalContext{}
 			ctx.installSimpleEval()
-			_, diags := evaluateForEachExpression(test.Expr, ctx)
+			_, _, diags := evaluateForEachExpression(test.Expr, ctx, false)
 
 			if len(diags) != 1 {
 				t.Fatalf("got %d diagnostics; want 1", len(diags))
@@ -211,6 +211,41 @@ func TestEvaluateForEachExpression_errors(t *testing.T) {
 	}
 }
 
+func TestEvaluateForEachExpression_allowUnknown(t *testing.T) {
+	tests := map[string]struct {
+		Expr hcl.Expression
+	}{
+		"unknown string set": {
+			hcltest.MockExprLiteral(cty.UnknownVal(cty.Set(cty.String))),
+		},
+		"unknown map": {
+			hcltest.MockExprLiteral(cty.UnknownVal(cty.Map(cty.Bool))),
+		},
+		"set containing unknown value": {
+			hcltest.MockExprLiteral(cty.SetVal([]cty.Value{cty.UnknownVal(cty.String)})),
+		},
+		"set containing dynamic unknown value": {
+			hcltest.MockExprLiteral(cty.SetVal([]cty.Value{cty.UnknownVal(cty.DynamicPseudoType)})),
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			ctx := &MockEvalContext{}
+			ctx.installSimpleEval()
+			_, known, diags := evaluateForEachExpression(test.Expr, ctx, true)
+
+			// With allowUnknown set, all of these expressions should be treated
+			// as valid for_each values.
+			assertNoDiagnostics(t, diags)
+
+			if known {
+				t.Errorf("result is known; want unknown")
+			}
+		})
+	}
+}
+
 func TestEvaluateForEachExpressionKnown(t *testing.T) {
 	tests := map[string]hcl.Expression{
 		"unknown string set": hcltest.MockExprLiteral(cty.UnknownVal(cty.Set(cty.String))),
@@ -221,7 +256,7 @@ func TestEvaluateForEachExpressionKnown(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			ctx := &MockEvalContext{}
 			ctx.installSimpleEval()
-			diags := newForEachEvaluator(expr, ctx).ValidateResourceValue()
+			diags := newForEachEvaluator(expr, ctx, false).ValidateResourceValue()
 
 			if len(diags) != 0 {
 				t.Errorf("unexpected diagnostics %s", spew.Sdump(diags))

--- a/internal/terraform/instance_expanders.go
+++ b/internal/terraform/instance_expanders.go
@@ -3,8 +3,44 @@
 
 package terraform
 
+import (
+	"github.com/hashicorp/terraform/internal/addrs"
+	"github.com/hashicorp/terraform/internal/instances"
+)
+
 // graphNodeExpandsInstances is implemented by nodes that causes instances to
 // be registered in the instances.Expander.
 type graphNodeExpandsInstances interface {
 	expandsInstances()
+}
+
+// forEachModuleInstance is a helper to deal with the common need of doing
+// some action for every dynamic module instance associated with a static
+// module path.
+//
+// Many of our plan graph nodes represent configuration constructs that need
+// to produce a dynamic subgraph based on the expansion of whatever module
+// they are declared inside, and this helper deals with enumerating those
+// dynamic addresses so that callers can just focus on building a graph node
+// for each one and registering it in the subgraph.
+//
+// Both of the two callbacks will be called for each instance or set of
+// unknown instances. knownCb receives fully-known instance addresses,
+// while unknownCb receives partially-expanded addresses. Callers typically
+// create a different graph node type in each callback, because
+// partially-expanded prefixes conceptually represent an infinite set of
+// possible module instance addresses and therefore need quite different
+// treatment than a single concrete module instance address.
+func forEachModuleInstance(
+	insts *instances.Expander,
+	modAddr addrs.Module,
+	knownCb func(addrs.ModuleInstance),
+	unknownCb func(addrs.PartialExpandedModule),
+) {
+	for _, instAddr := range insts.ExpandModule(modAddr) {
+		knownCb(instAddr)
+	}
+	for _, instsAddr := range insts.UnknownModuleInstances(modAddr) {
+		unknownCb(instsAddr)
+	}
 }

--- a/internal/terraform/node_module_expand.go
+++ b/internal/terraform/node_module_expand.go
@@ -113,7 +113,7 @@ func (n *nodeExpandModule) Execute(ctx EvalContext, op walkOperation) (diags tfd
 		ctx = ctx.WithPath(module)
 		switch {
 		case n.ModuleCall.Count != nil:
-			count, ctDiags := evaluateCountExpression(n.ModuleCall.Count, ctx)
+			count, ctDiags := evaluateCountExpression(n.ModuleCall.Count, ctx, false)
 			diags = diags.Append(ctDiags)
 			if diags.HasErrors() {
 				return diags
@@ -121,7 +121,7 @@ func (n *nodeExpandModule) Execute(ctx EvalContext, op walkOperation) (diags tfd
 			expander.SetModuleCount(module, call, count)
 
 		case n.ModuleCall.ForEach != nil:
-			forEach, feDiags := evaluateForEachExpression(n.ModuleCall.ForEach, ctx)
+			forEach, _, feDiags := evaluateForEachExpression(n.ModuleCall.ForEach, ctx, false)
 			diags = diags.Append(feDiags)
 			if diags.HasErrors() {
 				return diags
@@ -256,7 +256,7 @@ func (n *nodeValidateModule) Execute(ctx EvalContext, op walkOperation) (diags t
 			diags = diags.Append(countDiags)
 
 		case n.ModuleCall.ForEach != nil:
-			forEachDiags := newForEachEvaluator(n.ModuleCall.ForEach, ctx).ValidateResourceValue()
+			forEachDiags := newForEachEvaluator(n.ModuleCall.ForEach, ctx, false).ValidateResourceValue()
 			diags = diags.Append(forEachDiags)
 		}
 

--- a/internal/terraform/node_resource_abstract.go
+++ b/internal/terraform/node_resource_abstract.go
@@ -404,7 +404,7 @@ func (n *NodeAbstractResource) writeResourceState(ctx EvalContext, addr addrs.Ab
 
 	switch {
 	case n.Config != nil && n.Config.Count != nil:
-		count, countDiags := evaluateCountExpression(n.Config.Count, ctx)
+		count, countDiags := evaluateCountExpression(n.Config.Count, ctx, false)
 		diags = diags.Append(countDiags)
 		if countDiags.HasErrors() {
 			return diags
@@ -414,7 +414,7 @@ func (n *NodeAbstractResource) writeResourceState(ctx EvalContext, addr addrs.Ab
 		expander.SetResourceCount(addr.Module, n.Addr.Resource, count)
 
 	case n.Config != nil && n.Config.ForEach != nil:
-		forEach, forEachDiags := evaluateForEachExpression(n.Config.ForEach, ctx)
+		forEach, _, forEachDiags := evaluateForEachExpression(n.Config.ForEach, ctx, false)
 		diags = diags.Append(forEachDiags)
 		if forEachDiags.HasErrors() {
 			return diags

--- a/internal/terraform/node_resource_abstract_instance.go
+++ b/internal/terraform/node_resource_abstract_instance.go
@@ -772,7 +772,7 @@ func (n *NodeAbstractResourceInstance) plan(
 	}
 
 	// Evaluate the configuration
-	forEach, _ := evaluateForEachExpression(n.Config.ForEach, ctx)
+	forEach, _, _ := evaluateForEachExpression(n.Config.ForEach, ctx, false)
 
 	keyData = EvalDataForInstanceKey(n.ResourceInstanceAddr().Resource.Key, forEach)
 
@@ -1700,7 +1700,7 @@ func (n *NodeAbstractResourceInstance) planDataSource(ctx EvalContext, checkRule
 	objTy := schema.ImpliedType()
 	priorVal := cty.NullVal(objTy)
 
-	forEach, _ := evaluateForEachExpression(config.ForEach, ctx)
+	forEach, _, _ := evaluateForEachExpression(config.ForEach, ctx, false)
 	keyData = EvalDataForInstanceKey(n.ResourceInstanceAddr().Resource.Key, forEach)
 
 	checkDiags := evalCheckRules(
@@ -1980,7 +1980,7 @@ func (n *NodeAbstractResourceInstance) applyDataSource(ctx EvalContext, planned 
 		return nil, keyData, diags
 	}
 
-	forEach, _ := evaluateForEachExpression(config.ForEach, ctx)
+	forEach, _, _ := evaluateForEachExpression(config.ForEach, ctx, false)
 	keyData = EvalDataForInstanceKey(n.Addr.Resource.Key, forEach)
 
 	checkDiags := evalCheckRules(
@@ -2284,7 +2284,7 @@ func (n *NodeAbstractResourceInstance) applyProvisioners(ctx EvalContext, state 
 func (n *NodeAbstractResourceInstance) evalProvisionerConfig(ctx EvalContext, body hcl.Body, self cty.Value, schema *configschema.Block) (cty.Value, tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
 
-	forEach, forEachDiags := evaluateForEachExpression(n.Config.ForEach, ctx)
+	forEach, _, forEachDiags := evaluateForEachExpression(n.Config.ForEach, ctx, false)
 	diags = diags.Append(forEachDiags)
 
 	keyData := EvalDataForInstanceKey(n.ResourceInstanceAddr().Resource.Key, forEach)

--- a/internal/terraform/node_resource_plan.go
+++ b/internal/terraform/node_resource_plan.go
@@ -218,7 +218,7 @@ func (n *nodeExpandPlannableResource) validateExpandedImportTargets() tfdiags.Di
 //
 // It has several side-effects:
 //   - Adds a node to Graph g for each leaf resource instance it discovers, whether present or orphaned.
-//   - Registers the expansion of the resource in the "expander" object embedded inside EvalContext ctx.
+//   - Registers the expansion of the resource in the "expander" object embedded inside EvalContext globalCtx.
 //   - Adds each present (non-orphaned) resource instance address to checkableAddrs (guaranteed to always be addrs.AbsResourceInstance, despite being declared as addrs.Checkable).
 //
 // After calling this for each of the module instances the resource appears

--- a/internal/terraform/node_resource_plan.go
+++ b/internal/terraform/node_resource_plan.go
@@ -378,7 +378,7 @@ func (n nodeExpandPlannableResource) expandResourceImports(ctx EvalContext, addr
 			continue
 		}
 
-		forEachData, forEachDiags := newForEachEvaluator(imp.Config.ForEach, ctx).ImportValues()
+		forEachData, forEachDiags := newForEachEvaluator(imp.Config.ForEach, ctx, false).ImportValues()
 		diags = diags.Append(forEachDiags)
 		if forEachDiags.HasErrors() {
 			return imports, diags

--- a/internal/terraform/node_resource_plan_instance.go
+++ b/internal/terraform/node_resource_plan_instance.go
@@ -355,7 +355,7 @@ func (n *NodePlannableResourceInstance) managedResourceExecute(ctx EvalContext) 
 		// values, which could result in a post-condition check relying on that
 		// value being inaccurate. Unless we decide to store the value of the
 		// for-each expression in state, this is unavoidable.
-		forEach, _ := evaluateForEachExpression(n.Config.ForEach, ctx)
+		forEach, _, _ := evaluateForEachExpression(n.Config.ForEach, ctx, false)
 		repeatData := EvalDataForInstanceKey(n.ResourceInstanceAddr().Resource.Key, forEach)
 
 		checkDiags := evalCheckRules(
@@ -463,7 +463,7 @@ func (n *NodePlannableResourceInstance) importState(ctx EvalContext, addr addrs.
 			return nil, diags
 		}
 
-		forEach, _ := evaluateForEachExpression(n.Config.ForEach, ctx)
+		forEach, _, _ := evaluateForEachExpression(n.Config.ForEach, ctx, false)
 		keyData := EvalDataForInstanceKey(n.ResourceInstanceAddr().Resource.Key, forEach)
 		configVal, _, configDiags := ctx.EvaluateBlock(n.Config.Config, schema, nil, keyData)
 		if configDiags.HasErrors() {

--- a/internal/terraform/node_resource_validate.go
+++ b/internal/terraform/node_resource_validate.go
@@ -306,7 +306,7 @@ func (n *NodeValidatableResource) validateResource(ctx EvalContext) tfdiags.Diag
 		}
 
 		// Evaluate the for_each expression here so we can expose the diagnostics
-		forEachDiags := newForEachEvaluator(n.Config.ForEach, ctx).ValidateResourceValue()
+		forEachDiags := newForEachEvaluator(n.Config.ForEach, ctx, false).ValidateResourceValue()
 		diags = diags.Append(forEachDiags)
 	}
 


### PR DESCRIPTION
This set of changes aims to finally expose some of the previously-unreachable codepaths dealing with modules or resources that have unknown values as their `count` or `for_each`.

The work here is _far_ from done, but I've reached the point where I can no longer continue just adding dead code that isn't actually exercisable, and so this PR introduces a new language experiment named `unknown_instances` which, if enabled, will cause the expansion logic to tolerate unknown values in the relevant arguments and register the unknown-ness with the instance expander.

As usual with experiments, this is available only in dev and alpha builds. Even in alpha builds, it's enabled only when explicitly enabled for the modules that would rely on it. If the next minor release comes before the remaining work is completed, then this unfinished stuff will not actually be reachable in beta, RC, or final releases in that new series.

For now, turning this on just gives you a way to break yourself, because the rest of the modules runtime is not yet equipped to deal with this situation. I will continue to wire this in to the rest of the runtime over subsequent PRs, so that this experiment will eventually be guarding a working feature rather than a broken one.

Concretely, using this experiment to provide an unknown `for_each` or `count` as of this PR will:
- Cause some no-op graph nodes to get added to the dynamic subgraphs of the nodes representing input variables, output values, and local values.

    These nodes don't yet implement `Execute`, so they won't do anything at all when visited. They're included here just to illustrate how the instance expander API models unknown expansion and how our `DynamicExpand` functions will make use of that API.
- Make any resource that has unknown expansion (either directly or via a containing module) be essentially ignored during graph walk, because the resource `DynamicExpand` doesn't yet know it should go looking for unexpanded instance sets and so will not add graph nodes for them at all.

    (The final approach for this will have a similar shape to the handling of unexpanded named values in this PR, but with some extra complexity to make sure that any objects already known in the state will get refreshed even though their planning will eventually get deferred.)
- Due to the above, also cause some expression evaluation to produce strange results, because the expression-reference evaluation logic largely has no awareness yet of how to decide placeholder values for objects whose evaluation was deferred.

This is yet another incremental step toward resolving #30937, but there are many steps remaining after this one. Since this is just an intermediate step and not a useful final state, there aren't any new integration tests here just yet. I'll add those in later PRs once there's actually some working behavior to test.

I suggest reviewing this on a commit-by-commit basis, because there's some distracting noise in the diff from updating some callers and I expect it'll be easier to understand what that's all about when viewing just the commit that introduced it.
