### PR TITLE
mocking overrides: default to concrete empty object when values are missing

### DIFF
--- a/internal/command/test_test.go
+++ b/internal/command/test_test.go
@@ -29,6 +29,7 @@ func TestTest_Runs(t *testing.T) {
 		expectedErr           string
 		expectedResourceCount int
 		code                  int
+		initCode              int
 		skip                  bool
 	}{
 		"simple_pass": {
@@ -212,8 +213,12 @@ func TestTest_Runs(t *testing.T) {
 			code:        0,
 		},
 		"mocking": {
-			expectedOut: "5 passed, 0 failed.",
+			expectedOut: "6 passed, 0 failed.",
 			code:        0,
+		},
+		"mocking-invalid": {
+			expectedErr: "Invalid outputs attribute",
+			initCode:    1,
 		},
 		"dangling_data_block": {
 			expectedOut: "2 passed, 0 failed.",
@@ -270,8 +275,30 @@ func TestTest_Runs(t *testing.T) {
 				Meta: meta,
 			}
 
-			if code := init.Run(nil); code != 0 {
-				t.Fatalf("expected status code 0 but got %d: %s", code, ui.ErrorWriter)
+			if code := init.Run(nil); code != tc.initCode {
+				t.Fatalf("expected status code %d but got %d: %s", tc.initCode, code, ui.ErrorWriter)
+			}
+
+			if tc.initCode > 0 {
+				// Then we don't expect the init step to succeed. So we'll check
+				// the init output for our expected error messages and outputs.
+
+				stdout, stderr := ui.ErrorWriter.String(), ui.ErrorWriter.String()
+
+				if !strings.Contains(stdout, tc.expectedOut) {
+					t.Errorf("output didn't contain expected string:\n\n%s", stdout)
+				}
+
+				if !strings.Contains(stderr, tc.expectedErr) {
+					t.Errorf("error didn't contain expected string:\n\n%s", stderr)
+				} else if tc.expectedErr == "" && stderr != "" {
+					t.Errorf("unexpected stderr output\n%s", stderr)
+				}
+
+				// If `terraform init` failed, then we don't expect that
+				// `terraform test` will have run at all, so we can just return
+				// here.
+				return
 			}
 
 			c := &TestCommand{

--- a/internal/command/testdata/test/mocking-invalid/child/main.tf
+++ b/internal/command/testdata/test/mocking-invalid/child/main.tf
@@ -1,0 +1,30 @@
+terraform {
+  required_providers {
+    test = {
+      source = "hashicorp/test"
+      configuration_aliases = [test.primary, test.secondary]
+    }
+  }
+}
+
+variable "instances" {
+  type = number
+}
+
+resource "test_resource" "primary" {
+  provider = test.primary
+  count = var.instances
+}
+
+resource "test_resource" "secondary" {
+  provider = test.secondary
+  count = var.instances
+}
+
+output "primary" {
+  value = test_resource.primary
+}
+
+output "secondary" {
+  value = test_resource.secondary
+}

--- a/internal/command/testdata/test/mocking-invalid/main.tf
+++ b/internal/command/testdata/test/mocking-invalid/main.tf
@@ -1,0 +1,46 @@
+terraform {
+  required_providers {
+    test = {
+      source = "hashicorp/test"
+    }
+  }
+}
+
+provider "test" {
+  alias = "primary"
+}
+
+provider "test" {
+  alias = "secondary"
+}
+
+variable "instances" {
+  type = number
+}
+
+variable "child_instances" {
+  type = number
+}
+
+resource "test_resource" "primary" {
+  provider = test.primary
+  count = var.instances
+}
+
+resource "test_resource" "secondary" {
+  provider = test.secondary
+  count = var.instances
+}
+
+module "child" {
+  count = var.instances
+
+  source = "./child"
+
+  providers = {
+    test.primary = test.primary
+    test.secondary = test.secondary
+  }
+
+  instances = var.child_instances
+}

--- a/internal/command/testdata/test/mocking-invalid/tests/module_mocked_invalid_type.tftest.hcl
+++ b/internal/command/testdata/test/mocking-invalid/tests/module_mocked_invalid_type.tftest.hcl
@@ -1,0 +1,13 @@
+override_module {
+  target  = module.child[1]
+  outputs = "should be an object"
+}
+
+variables {
+  instances = 3
+  child_instances = 1
+}
+
+run "test" {
+  # We won't even execute this, as the configuration isn't valid.
+}

--- a/internal/command/testdata/test/mocking/tests/module_empty_outputs.tftest.hcl
+++ b/internal/command/testdata/test/mocking/tests/module_empty_outputs.tftest.hcl
@@ -1,0 +1,12 @@
+override_module {
+  target = module.child[1]
+}
+
+variables {
+  instances = 3
+  child_instances = 1
+}
+
+run "test" {
+  # Just want to make sure things don't crash with missing `outputs` attribute.
+}

--- a/internal/terraform/graph.go
+++ b/internal/terraform/graph.go
@@ -196,7 +196,13 @@ func (g *Graph) checkAndApplyOverrides(overrides *mocking.Overrides, target dag.
 
 		setOverride := func(values cty.Value) {
 			key := v.Addr.OutputValue.Name
-			if values.Type().HasAttribute(key) {
+
+			// The values.Type() should be an object type, but it might have
+			// been set to nil by a test or something. We can handle it in the
+			// same way as the attribute just not being specified. It's
+			// functionally the same for us and not something we need to raise
+			// alarms about.
+			if values.Type().IsObjectType() && values.Type().HasAttribute(key) {
 				v.override = values.GetAttr(key)
 			} else {
 				// If we don't have a value provided for an output, then we'll


### PR DESCRIPTION

<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

When the `values` or `outputs` attribute was missing from the `override_*` blocks in the new mocking framework, we were setting the value to be `cty.NilVal`. This was then causing a crash later in the processing when Terraform was assuming the values in these attributes was an object.

From the perspective of the mocking framework a nil or empty value is the same, in both cases it should just generate the values required. This PR updates the config parsing so that it just sets the value to be an object always using `cty.EmptyObjectValue` if the attribute isn't specified. It also updates the Terraform graph where this is read so that it can safely handle a `cty.NilVal` anyway.

We also add in a quick bit of validation, that makes sure the config specifies the attributes as an object, if it is specified.

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Fixes #34562 

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.7.1

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

### BUG FIXES

<!--

Write a short description of the user-facing change. Examples:

- `terraform show -json`: Fixed crash with sensitive set values.
- When rendering a diff, Terraform now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 

-  `terraform test`: Fix crash when `override_module` block was missing the `outputs` attribute.
