### PR TITLE
docs: update azurerm backend docs

### DIFF
--- a/website/docs/language/settings/backends/azurerm.mdx
+++ b/website/docs/language/settings/backends/azurerm.mdx
@@ -9,90 +9,90 @@ Stores the state as a Blob with the given Key within the Blob Container within [
 
 This backend supports state locking and consistency checking with Azure Blob Storage native capabilities.
 
-~> **Terraform 1.1 and 1.2 supported a feature-flag to allow enabling/disabling the use of Microsoft Graph (and MSAL) rather than Azure Active Directory Graph (and ADAL) - however this flag has since been removed in Terraform 1.3. Microsoft Graph (and MSAL) are now enabled by default and Azure Active Directory Graph (and ADAL) can no longer be used.
+~> Terraform 1.1 and 1.2 supported a feature-flag to allow enabling/disabling the use of Microsoft Graph (and MSAL) rather than Azure Active Directory Graph (and ADAL) - however this flag has since been removed in Terraform 1.3. Microsoft Graph (and MSAL) are now enabled by default and Azure Active Directory Graph (and ADAL) can no longer be used.
 
 ## Authentication
 
 The `azurerm` backend supports 3 methods of authenticating to the storage account:
 
 - **Access Key** (default)
-- **Entra ID**
+- **Azure Active Directory**
 - **SAS Token**
 
-The **Access Key** method can be used directly or in combination with an Entra ID principal (e.g. user, service principal or managed identity). By default when you use an Entra ID principal, it will use the Access Token of that principal to generate an Access Key for the storage account and use that Access Key to authenticate to the state file blob. To use an Access Key directly you must generate one for your state file blob and pass it to the backend config.
+The *Access Key* method can be used directly, by specifying the access key, or in combination with an Azure AD principal (e.g. user, service principal or managed identity). To use an Access Key directly you must generate one for your state file blob and specify it in the backend configuration. If neither an access key or client ID is specified, Terraform will attempt to use Azure CLI. In both cases where no access key is given, Terraform will attempt to retrieve the access key for the storage account, using the authenticated Azure AD principal.
 
-The **Entra ID** method can only be used in combination with an Entra ID principal. To use the Entra ID method you must set the `use_azuread_auth` variable to `true` in your backend configuration. This will cause the backend to use the Access Token of the Entra ID principal to authenticate to the state file blob.
+The *Azure Active Directory* method can only be used in combination with an Azure AD principal. To use the Azure Active Directory method you must set the `use_azuread_auth` variable to `true` in your backend configuration. This will cause the backend to use the Access Token of the Azure AD principal to authenticate to the state file blob, nstead of authenticating using a shared access key.
 
-The **SAS Token** method can only be used directly. You must generate a SAS Token for your state file blob and pass it to the backend config.
+The *SAS Token* method can only be used directly. You must generate a SAS Token for your state file blob and pass it to the backend config.
 
-The `azurerm` backend supports the following authentication methods to connect the storage account based on the variables that are set:
+The `azurerm` backend supports the following authentication scenarios to connect to the storage account, based on the configuration variables provided:
 
-| Entra ID Authentication Method | Storage Account Authentication Type | Authentication variable * | Entra ID variable |
+| Authentication Method | Storage Account Authentication Type | Minimum Required Configuration* |
 |-----|---|---|---|
-| Entra ID User Principal via Azure CLI | Access Key | N/A | N/A |
-| Entra ID User Principal via Azure CLI | Entra ID | N/A | `use_azuread_auth = true` |
-| Entra ID Service Principal or User Assigned Managed Identity via OIDC (Workload identity federation) | Access Key | `use_oidc = true` | N/A |
-| Entra ID Service Principal or User Assigned Managed Identity via OIDC (Workload identity federation) | Entra ID | `use_oidc = true` | `use_azuread_auth = true` |
-| Entra ID Managed Identity Principal | Access Key | `use_msi = true` | N/A |
-| Entra ID Managed Identity Principal | Entra ID | `use_msi = true` | `use_azuread_auth = true` |
-| Entra ID Service Principal via Client Secret | Access Key | `client_secret = <service principal secret>` | N/A |
-| Entra ID Service Principal via Client Secret | Entra ID | `client_secret = <service principal secret>` | `use_azuread_auth = true` |
-| Entra ID Service Principal via Client Certificate | Access Key | `client_certificate_path = <cert path>` | N/A |
-| Entra ID Service Principal via Client Certificate | Entra ID | `client_certificate_path = <cert path>` | `use_azuread_auth = true` |
-| Access Key direct | Access Key | `access_key = <access key>` | N/A |
-| SAS Key direct | SAS Token | `sas_token = <sas token>` | N/A |
+| User Principal via Azure CLI | Access Key | N/A |
+| User Principal via Azure CLI | Azure AD | `use_azuread_auth = true` |
+| Service Principal or User Assigned Managed Identity via OIDC (Workload identity federation) | Access Key | `use_oidc = true` |
+| Service Principal or User Assigned Managed Identity via OIDC (Workload identity federation) | Azure AD | `use_azuread_auth = true`, `use_oidc = true` |
+| Managed Identity Principal | Access Key | `use_msi = true` |
+| Managed Identity Principal | Azure AD | `use_azuread_auth = true`, `use_msi = true` |
+| Service Principal via Client Secret | Access Key | `client_secret = "..."` |
+| Service Principal via Client Secret | Azure AD | `use_azuread_auth = true`, `client_secret = "..."` |
+| Service Principal via Client Certificate | Access Key | `client_certificate_path = "..."` |
+| Service Principal via Client Certificate | Azure AD | `client_certificate_path = "...`, `use_azuread_auth = true` |
+| Access Key direct | Access Key | `access_key = "..."` |
+| SAS Token direct | SAS Token | `sas_token = "..."` |
 
--> * = We provide a single variable here, but there is usually more than one required for successful authentication. The variable we show is the one that triggers the backend to use that authentication type. You can see examples of each option below.
+-> * There are sometimes more options needed for successful authentication. The variable shown is the one that triggers the backend to use a given authentication scenario. You can see examples of each option below.
 
--> NOTE: In the table we show the variable passed as it would be hard coded. Variables can and should be passed via environment variables or partial config flags in the `init` command of the CLI.
+-> Sensitive values should not be hardcoded into your configuration, and should instead be specified using environment variables or partial configuration flags in the `init` command of Terraform CLI.
 
 ## Example Backend Configurations
 
-### Backend: Entra ID User via Azure CLI
+### Backend: Azure AD User via Azure CLI
 
 This method is not suitable for automation since it only supports a User Principal. To check which tenant and subscription you are pointed to, run `az account show`.
 
-Connect to Storage Account with Access Key (default):
+*Connect to Storage Account with Access Key*
 
 ```hcl
 terraform {
   backend "azurerm" {
-    resource_group_name  = "rg-tfstate-001"  # Can be passed via `-backend-config=`"resource_group_name=<resource group name>"` in the `init` command.
-    storage_account_name = "stotfstate001"  # Can be passed via `-backend-config=`"storage_account_name=<storage account name>"` in the `init` command.
-    container_name       = "prod"  # Can be passed via `-backend-config=`"container_name=<container name>"` in the `init` command.
-    key                  = "terraform.tfstate"  # Can be passed via `-backend-config=`"key=<blob key name>"` in the `init` command.
+    resource_group_name  = "StorageAccount-ResourceGroup"  # Can be passed via `-backend-config=`"resource_group_name=<resource group name>"` in the `init` command.
+    storage_account_name = "abcd1234"                      # Can be passed via `-backend-config=`"storage_account_name=<storage account name>"` in the `init` command.
+    container_name       = "tfstate"                       # Can be passed via `-backend-config=`"container_name=<container name>"` in the `init` command.
+    key                  = "prod.terraform.tfstate"        # Can be passed via `-backend-config=`"key=<blob key name>"` in the `init` command.
   }
 }
 ```
 
-Connect to Storage Account with Entra ID:
+*Connect to Storage Account with Azure Active Directory authentication*
 
 ```hcl
 terraform {
   backend "azurerm" {
-    resource_group_name  = "rg-tfstate-001"  # Can be passed via `-backend-config=`"resource_group_name=<resource group name>"` in the `init` command.
-    storage_account_name = "stotfstate001"  # Can be passed via `-backend-config=`"storage_account_name=<storage account name>"` in the `init` command.
-    container_name       = "prod"  # Can be passed via `-backend-config=`"container_name=<container name>"` in the `init` command.
-    key                  = "terraform.tfstate"  # Can be passed via `-backend-config=`"key=<blob key name>"` in the `init` command.
-    use_azuread_auth     = true  # Can also be set via `USE_AZURE_AD` environment variable.
+    resource_group_name  = "StorageAccount-ResourceGroup"  # Can be passed via `-backend-config=`"resource_group_name=<resource group name>"` in the `init` command.
+    storage_account_name = "abcd1234"                      # Can be passed via `-backend-config=`"storage_account_name=<storage account name>"` in the `init` command.
+    container_name       = "tfstate"                       # Can be passed via `-backend-config=`"container_name=<container name>"` in the `init` command.
+    key                  = "prod.terraform.tfstate"        # Can be passed via `-backend-config=`"key=<blob key name>"` in the `init` command.
+    use_azuread_auth     = true                            # Can also be set via `ARM_USE_AZUREAD` environment variable.
   }
 }
 ```
 
-### Backend: Entra ID Service Principal or User Assigned Managed Identity via OIDC (Workload identity federation)
+### Backend: Azure AD Service Principal or User Assigned Managed Identity via OIDC (Workload Identity Federation)
 
-You can use an App Registration (Service Principal) or a User Assigned Managed Identity to configure federated credentials. You must supply the client id of the principal.
+You can use an App Registration (Service Principal) or a User Assigned Managed Identity to configure federated credentials. You must supply the Client ID of the principal.
 
-Connect to Storage Account with Access Key (default):
+*Connect to Storage Account with Access Key*
 
 ```hcl
 terraform {
   backend "azurerm" {
-    resource_group_name  = "rg-tfstate-001"  # Can be passed via `-backend-config=`"resource_group_name=<resource group name>"` in the `init` command.
-    storage_account_name = "stotfstate001"  # Can be passed via `-backend-config=`"storage_account_name=<storage account name>"` in the `init` command.
-    container_name       = "prod"  # Can be passed via `-backend-config=`"container_name=<container name>"` in the `init` command.
-    key                  = "terraform.tfstate"  # Can be passed via `-backend-config=`"key=<blob key name>"` in the `init` command.
-    use_oidc              = true  # Can also be set via `USE_OIDC` environment variable.
+    resource_group_name  = "StorageAccount-ResourceGroup"          # Can be passed via `-backend-config=`"resource_group_name=<resource group name>"` in the `init` command.
+    storage_account_name = "abcd1234"                              # Can be passed via `-backend-config=`"storage_account_name=<storage account name>"` in the `init` command.
+    container_name       = "tfstate"                               # Can be passed via `-backend-config=`"container_name=<container name>"` in the `init` command.
+    key                  = "prod.terraform.tfstate"                # Can be passed via `-backend-config=`"key=<blob key name>"` in the `init` command.
+    use_oidc             = true                                    # Can also be set via `ARM_USE_OIDC` environment variable.
     client_id            = "00000000-0000-0000-0000-000000000000"  # Can also be set via `ARM_CLIENT_ID` environment variable.
     subscription_id      = "00000000-0000-0000-0000-000000000000"  # Can also be set via `ARM_SUBSCRIPTION_ID` environment variable.
     tenant_id            = "00000000-0000-0000-0000-000000000000"  # Can also be set via `ARM_TENANT_ID` environment variable.
@@ -100,74 +100,76 @@ terraform {
 }
 ```
 
-Connect to Storage Account with Entra ID:
+*Connect to Storage Account with Azure Active Directory authentication*
 
 ```hcl
 terraform {
   backend "azurerm" {
-    resource_group_name  = "rg-tfstate-001"  # Can be passed via `-backend-config=`"resource_group_name=<resource group name>"` in the `init` command.
-    storage_account_name = "stotfstate001"  # Can be passed via `-backend-config=`"storage_account_name=<storage account name>"` in the `init` command.
-    container_name       = "prod"  # Can be passed via `-backend-config=`"container_name=<container name>"` in the `init` command.
-    key                  = "terraform.tfstate"  # Can be passed via `-backend-config=`"key=<blob key name>"` in the `init` command.
-    use_oidc              = true  # Can also be set via `USE_OIDC` environment variable.
+    resource_group_name  = "StorageAccount-ResourceGroup"          # Can be passed via `-backend-config=`"resource_group_name=<resource group name>"` in the `init` command.
+    storage_account_name = "abcd1234"                              # Can be passed via `-backend-config=`"storage_account_name=<storage account name>"` in the `init` command.
+    container_name       = "tfstate"                               # Can be passed via `-backend-config=`"container_name=<container name>"` in the `init` command.
+    key                  = "prod.terraform.tfstate"                # Can be passed via `-backend-config=`"key=<blob key name>"` in the `init` command.
+    use_oidc             = true                                    # Can also be set via `ARM_USE_OIDC` environment variable.
     client_id            = "00000000-0000-0000-0000-000000000000"  # Can also be set via `ARM_CLIENT_ID` environment variable.
     subscription_id      = "00000000-0000-0000-0000-000000000000"  # Can also be set via `ARM_SUBSCRIPTION_ID` environment variable.
     tenant_id            = "00000000-0000-0000-0000-000000000000"  # Can also be set via `ARM_TENANT_ID` environment variable.
-    use_azuread_auth     = true  # Can also be set via `USE_AZURE_AD` environment variable.
+    use_azuread_auth     = true                                    # Can also be set via `ARM_USE_AZUREAD` environment variable.
   }
 }
 ```
 
-### Backend: Entra ID Managed Identity Principal
+### Backend: Azure AD Managed Identity Principal
 
-You can use a User Assigned Managed Identity as well as a System Assigned Managed Identity on your agent / runner compute. However the authentication does not support specifiying the Client ID of the User Assigned Managed Identity, so you can only supply one per compute instance.
+You can use a User Assigned Managed Identity as well as a System Assigned Managed Identity on your agent / runner compute environment. However the backend does not currently support specifying the Client ID of the User Assigned Managed Identity, so you can only supply one per compute instance.
 
-Connect to Storage Account with Access Key (default):
+*Connect to Storage Account with Access Key*
 
 ```hcl
 terraform {
   backend "azurerm" {
-    resource_group_name  = "rg-tfstate-001"  # Can be passed via `-backend-config=`"resource_group_name=<resource group name>"` in the `init` command.
-    storage_account_name = "stotfstate001"  # Can be passed via `-backend-config=`"storage_account_name=<storage account name>"` in the `init` command.
-    container_name       = "prod"  # Can be passed via `-backend-config=`"container_name=<container name>"` in the `init` command.
-    key                  = "terraform.tfstate"  # Can be passed via `-backend-config=`"key=<blob key name>"` in the `init` command.
-    use_msi              = true  # Can also be set via `USE_MSI` environment variable.
+    resource_group_name  = "StorageAccount-ResourceGroup"          # Can be passed via `-backend-config=`"resource_group_name=<resource group name>"` in the `init` command.
+    storage_account_name = "abcd1234"                              # Can be passed via `-backend-config=`"storage_account_name=<storage account name>"` in the `init` command.
+    container_name       = "tfstate"                               # Can be passed via `-backend-config=`"container_name=<container name>"` in the `init` command.
+    key                  = "prod.terraform.tfstate"                # Can be passed via `-backend-config=`"key=<blob key name>"` in the `init` command.
+    use_msi              = true                                    # Can also be set via `ARM_USE_MSI` environment variable.
+    client_id            = "00000000-0000-0000-0000-000000000000"  # Can also be set via `ARM_CLIENT_ID` environment variable.
     subscription_id      = "00000000-0000-0000-0000-000000000000"  # Can also be set via `ARM_SUBSCRIPTION_ID` environment variable.
     tenant_id            = "00000000-0000-0000-0000-000000000000"  # Can also be set via `ARM_TENANT_ID` environment variable.
   }
 }
 ```
 
-Connect to Storage Account with Entra ID:
+*Connect to Storage Account with Azure Active Directory authentication*
 
 ```hcl
 terraform {
   backend "azurerm" {
-    resource_group_name  = "rg-tfstate-001"  # Can be passed via `-backend-config=`"resource_group_name=<resource group name>"` in the `init` command.
-    storage_account_name = "stotfstate001"  # Can be passed via `-backend-config=`"storage_account_name=<storage account name>"` in the `init` command.
-    container_name       = "prod"  # Can be passed via `-backend-config=`"container_name=<container name>"` in the `init` command.
-    key                  = "terraform.tfstate"  # Can be passed via `-backend-config=`"key=<blob key name>"` in the `init` command.
-    use_msi              = true  # Can also be set via `USE_MSI` environment variable.
+    resource_group_name  = "StorageAccount-ResourceGroup"          # Can be passed via `-backend-config=`"resource_group_name=<resource group name>"` in the `init` command.
+    storage_account_name = "abcd1234"                              # Can be passed via `-backend-config=`"storage_account_name=<storage account name>"` in the `init` command.
+    container_name       = "tfstate"                               # Can be passed via `-backend-config=`"container_name=<container name>"` in the `init` command.
+    key                  = "prod.terraform.tfstate"                # Can be passed via `-backend-config=`"key=<blob key name>"` in the `init` command.
+    use_msi              = true                                    # Can also be set via `ARM_USE_MSI` environment variable.
+    client_id            = "00000000-0000-0000-0000-000000000000"  # Can also be set via `ARM_CLIENT_ID` environment variable.
     subscription_id      = "00000000-0000-0000-0000-000000000000"  # Can also be set via `ARM_SUBSCRIPTION_ID` environment variable.
     tenant_id            = "00000000-0000-0000-0000-000000000000"  # Can also be set via `ARM_TENANT_ID` environment variable.
-    use_azuread_auth     = true  # Can also be set via `USE_AZURE_AD` environment variable.
+    use_azuread_auth     = true                                    # Can also be set via `ARM_USE_AZUREAD` environment variable.
   }
 }
 ```
 
-### Backend: Entra ID Service Principal via Client Secret
+### Backend: Azure AD Service Principal via Client Secret
 
 ~> **Warning!**: This method requires you to manage and rotate a secret. Consider using OIDC as a more secure approach.
 
-Connect to Storage Account with Access Key (default):
+*Connect to Storage Account with Access Key*
 
 ```hcl
 terraform {
   backend "azurerm" {
-    resource_group_name  = "rg-tfstate-001"  # Can be passed via `-backend-config=`"resource_group_name=<resource group name>"` in the `init` command.
-    storage_account_name = "stotfstate001"  # Can be passed via `-backend-config=`"storage_account_name=<storage account name>"` in the `init` command.
-    container_name       = "prod"  # Can be passed via `-backend-config=`"container_name=<container name>"` in the `init` command.
-    key                  = "terraform.tfstate"  # Can be passed via `-backend-config=`"key=<blob key name>"` in the `init` command.
+    resource_group_name  = "StorageAccount-ResourceGroup"          # Can be passed via `-backend-config=`"resource_group_name=<resource group name>"` in the `init` command.
+    storage_account_name = "abcd1234"                              # Can be passed via `-backend-config=`"storage_account_name=<storage account name>"` in the `init` command.
+    container_name       = "tfstate"                               # Can be passed via `-backend-config=`"container_name=<container name>"` in the `init` command.
+    key                  = "prod.terraform.tfstate"                # Can be passed via `-backend-config=`"key=<blob key name>"` in the `init` command.
     client_id            = "00000000-0000-0000-0000-000000000000"  # Can also be set via `ARM_CLIENT_ID` environment variable.
     client_secret        = "************************************"  # Can also be set via `ARM_CLIENT_SECRET` environment variable.
     subscription_id      = "00000000-0000-0000-0000-000000000000"  # Can also be set via `ARM_SUBSCRIPTION_ID` environment variable.
@@ -176,39 +178,39 @@ terraform {
 }
 ```
 
-Connect to Storage Account with Entra ID:
+*Connect to Storage Account with Azure Active Directory authentication*
 
 ```hcl
 terraform {
   backend "azurerm" {
-    resource_group_name  = "rg-tfstate-001"  # Can be passed via `-backend-config=`"resource_group_name=<resource group name>"` in the `init` command.
-    storage_account_name = "stotfstate001"  # Can be passed via `-backend-config=`"storage_account_name=<storage account name>"` in the `init` command.
-    container_name       = "prod"  # Can be passed via `-backend-config=`"container_name=<container name>"` in the `init` command.
-    key                  = "terraform.tfstate"  # Can be passed via `-backend-config=`"key=<blob key name>"` in the `init` command.
+    resource_group_name  = "StorageAccount-ResourceGroup"          # Can be passed via `-backend-config=`"resource_group_name=<resource group name>"` in the `init` command.
+    storage_account_name = "abcd1234"                              # Can be passed via `-backend-config=`"storage_account_name=<storage account name>"` in the `init` command.
+    container_name       = "tfstate"                               # Can be passed via `-backend-config=`"container_name=<container name>"` in the `init` command.
+    key                  = "prod.terraform.tfstate"                # Can be passed via `-backend-config=`"key=<blob key name>"` in the `init` command.
     client_id            = "00000000-0000-0000-0000-000000000000"  # Can also be set via `ARM_CLIENT_ID` environment variable.
     client_secret        = "************************************"  # Can also be set via `ARM_CLIENT_SECRET` environment variable.
     subscription_id      = "00000000-0000-0000-0000-000000000000"  # Can also be set via `ARM_SUBSCRIPTION_ID` environment variable.
     tenant_id            = "00000000-0000-0000-0000-000000000000"  # Can also be set via `ARM_TENANT_ID` environment variable.
-    use_azuread_auth     = true  # Can also be set via `USE_AZURE_AD` environment variable.
+    use_azuread_auth     = true                                    # Can also be set via `ARM_USE_AZUREAD` environment variable.
   }
 }
 ```
 
-### Backend: Entra ID Service Principal via Client Certificate
+### Backend: Azure AD Service Principal via Client Certificate
 
 ~> **Warning!**: This method requires you to manage and rotate a secret. Consider using OIDC as a more secure approach.
 
-Connect to Storage Account with Access Key (default):
+*Connect to Storage Account with Access Key*
 
 ```hcl
 terraform {
   backend "azurerm" {
-    resource_group_name         = "rg-tfstate-001"  # Can be passed via `-backend-config=`"resource_group_name=<resource group name>"` in the `init` command.
-    storage_account_name        = "stotfstate001"  # Can be passed via `-backend-config=`"storage_account_name=<storage account name>"` in the `init` command.
-    container_name              = "prod"  # Can be passed via `-backend-config=`"container_name=<container name>"` in the `init` command.
-    key                         = "terraform.tfstate"  # Can be passed via `-backend-config=`"key=<blob key name>"` in the `init` command.
+    resource_group_name         = "StorageAccount-ResourceGroup"          # Can be passed via `-backend-config=`"resource_group_name=<resource group name>"` in the `init` command.
+    storage_account_name        = "abcd1234"                              # Can be passed via `-backend-config=`"storage_account_name=<storage account name>"` in the `init` command.
+    container_name              = "tfstate"                               # Can be passed via `-backend-config=`"container_name=<container name>"` in the `init` command.
+    key                         = "prod.terraform.tfstate"                # Can be passed via `-backend-config=`"key=<blob key name>"` in the `init` command.
     client_id                   = "00000000-0000-0000-0000-000000000000"  # Can also be set via `ARM_CLIENT_ID` environment variable.
-    client_certificate_path     = "./cert.pfx"  # Can also be set via `ARM_CLIENT_CERTIFICATE_PATH` environment variable.
+    client_certificate_path     = "/path/to/bundle.pfx"                   # Can also be set via `ARM_CLIENT_CERTIFICATE_PATH` environment variable.
     client_certificate_password = "************************************"  # Can also be set via `ARM_CLIENT_CERTIFICATE_PASSWORD` environment variable.
     subscription_id             = "00000000-0000-0000-0000-000000000000"  # Can also be set via `ARM_SUBSCRIPTION_ID` environment variable.
     tenant_id                   = "00000000-0000-0000-0000-000000000000"  # Can also be set via `ARM_TENANT_ID` environment variable.
@@ -216,21 +218,21 @@ terraform {
 }
 ```
 
-Connect to Storage Account with Entra ID:
+*Connect to Storage Account with Azure Active Directory authentication*
 
 ```hcl
 terraform {
   backend "azurerm" {
-    resource_group_name         = "rg-tfstate-001"  # Can be passed via `-backend-config=`"resource_group_name=<resource group name>"` in the `init` command.
-    storage_account_name        = "stotfstate001"  # Can be passed via `-backend-config=`"storage_account_name=<storage account name>"` in the `init` command.
-    container_name              = "prod"  # Can be passed via `-backend-config=`"container_name=<container name>"` in the `init` command.
-    key                         = "terraform.tfstate"  # Can be passed via `-backend-config=`"key=<blob key name>"` in the `init` command.
+    resource_group_name         = "StorageAccount-ResourceGroup"          # Can be passed via `-backend-config=`"resource_group_name=<resource group name>"` in the `init` command.
+    storage_account_name        = "abcd1234"                              # Can be passed via `-backend-config=`"storage_account_name=<storage account name>"` in the `init` command.
+    container_name              = "tfstate"                               # Can be passed via `-backend-config=`"container_name=<container name>"` in the `init` command.
+    key                         = "prod.terraform.tfstate"                # Can be passed via `-backend-config=`"key=<blob key name>"` in the `init` command.
     client_id                   = "00000000-0000-0000-0000-000000000000"  # Can also be set via `ARM_CLIENT_ID` environment variable.
-    client_certificate_path     = "./cert.pfx"  # Can also be set via `ARM_CLIENT_CERTIFICATE_PATH` environment variable.
+    client_certificate_path     = "/path/to/bundle.pfx"                   # Can also be set via `ARM_CLIENT_CERTIFICATE_PATH` environment variable.
     client_certificate_password = "************************************"  # Can also be set via `ARM_CLIENT_CERTIFICATE_PASSWORD` environment variable.
     subscription_id             = "00000000-0000-0000-0000-000000000000"  # Can also be set via `ARM_SUBSCRIPTION_ID` environment variable.
     tenant_id                   = "00000000-0000-0000-0000-000000000000"  # Can also be set via `ARM_TENANT_ID` environment variable.
-    use_azuread_auth            = true  # Can also be set via `USE_AZURE_AD` environment variable.
+    use_azuread_auth            = true                                    # Can also be set via `ARM_USE_AZUREAD` environment variable.
   }
 }
 ```
@@ -242,10 +244,10 @@ terraform {
 ```hcl
 terraform {
   backend "azurerm" {
-    resource_group_name  = "rg-tfstate-001"  # Can be passed via `-backend-config=`"resource_group_name=<resource group name>"` in the `init` command.
-    storage_account_name = "stotfstate001"  # Can be passed via `-backend-config=`"storage_account_name=<storage account name>"` in the `init` command.
-    container_name       = "prod"  # Can be passed via `-backend-config=`"container_name=<container name>"` in the `init` command.
-    key                  = "terraform.tfstate"  # Can be passed via `-backend-config=`"key=<blob key name>"` in the `init` command.
+    resource_group_name  = "StorageAccount-ResourceGroup"             # Can be passed via `-backend-config=`"resource_group_name=<resource group name>"` in the `init` command.
+    storage_account_name = "abcd1234"                                 # Can be passed via `-backend-config=`"storage_account_name=<storage account name>"` in the `init` command.
+    container_name       = "tfstate"                                  # Can be passed via `-backend-config=`"container_name=<container name>"` in the `init` command.
+    key                  = "prod.terraform.tfstate"                   # Can be passed via `-backend-config=`"key=<blob key name>"` in the `init` command.
     access_key           = "abcdefghijklmnopqrstuvwxyz0123456789..."  # Can also be set via `ARM_ACCESS_KEY` environment variable.
   }
 }
@@ -258,10 +260,10 @@ terraform {
 ```hcl
 terraform {
   backend "azurerm" {
-    resource_group_name  = "rg-tfstate-001"  # Can be passed via `-backend-config=`"resource_group_name=<resource group name>"` in the `init` command.
-    storage_account_name = "stotfstate001"  # Can be passed via `-backend-config=`"storage_account_name=<storage account name>"` in the `init` command.
-    container_name       = "prod"  # Can be passed via `-backend-config=`"container_name=<container name>"` in the `init` command.
-    key                  = "terraform.tfstate"  # Can be passed via `-backend-config=`"key=<blob key name>"` in the `init` command.
+    resource_group_name  = "StorageAccount-ResourceGroup"             # Can be passed via `-backend-config=`"resource_group_name=<resource group name>"` in the `init` command.
+    storage_account_name = "abcd1234"                                 # Can be passed via `-backend-config=`"storage_account_name=<storage account name>"` in the `init` command.
+    container_name       = "tfstate"                                  # Can be passed via `-backend-config=`"container_name=<container name>"` in the `init` command.
+    key                  = "prod.terraform.tfstate"                   # Can be passed via `-backend-config=`"key=<blob key name>"` in the `init` command.
     sas_token            = "abcdefghijklmnopqrstuvwxyz0123456789..."  # Can also be set via `ARM_SAS_TOKEN` environment variable.
   }
 }
@@ -269,54 +271,54 @@ terraform {
 
 ## Example Data Source Configurations
 
-### Data Source: Entra ID User Principal via Azure CLI
+### Data Source: Azure AD User Principal via Azure CLI
 
 This method is not suitable for automation since it only supports a User Principal. To check which tenant and subscription you are pointed to, run `az account show`.
 
-Connect to Storage Account with Access Key (default):
+*Connect to Storage Account with Access Key*
 
 ```hcl
 data "terraform_remote_state" "foo" {
   backend = "azurerm"
   config = {
-    resource_group_name  = "rg-tfstate-001"
-    storage_account_name = "stotfstate001"
-    container_name       = "prod"
-    key                  = "terraform.tfstate"
+    resource_group_name  = "StorageAccount-ResourceGroup"
+    storage_account_name = "terraform123abc"
+    container_name       = "tfstate"
+    key                  = "prod.terraform.tfstate"
   }
 }
 ```
 
-Connect to Storage Account with Entra ID:
+*Connect to Storage Account with Azure Active Directory authentication*
 
 ```hcl
 data "terraform_remote_state" "foo" {
   backend = "azurerm"
   config = {
-    resource_group_name  = "rg-tfstate-001"
-    storage_account_name = "stotfstate001"
-    container_name       = "prod"
-    key                  = "terraform.tfstate"
-    use_azuread_auth     = true  # Can also be set via `USE_AZURE_AD` environment variable.
+    resource_group_name  = "StorageAccount-ResourceGroup"
+    storage_account_name = "terraform123abc"
+    container_name       = "tfstate"
+    key                  = "prod.terraform.tfstate"
+    use_azuread_auth     = true                            # Can also be set via `ARM_USE_AZUREAD` environment variable.
   }
 }
 ```
 
-### Data Source: Entra ID Service Principal or User Assigned Managed Identity via OIDC (Workload identity federation)
+### Data Source: Azure AD Service Principal or User Assigned Managed Identity via OIDC (Workload Identity Federation)
 
-You can use an App Registration (Service Principal) or a User Assigned Managed Identity to configure federated credentials. You must supply the client id of the principal.
+You can use an App Registration (Service Principal) or a User Assigned Managed Identity to configure federated credentials. You must supply the Client ID of the principal.
 
-Connect to Storage Account with Access Key (default):
+*Connect to Storage Account with Access Key*
 
 ```hcl
 data "terraform_remote_state" "foo" {
   backend = "azurerm"
   config = {
-    resource_group_name  = "rg-tfstate-001"
-    storage_account_name = "stotfstate001"
-    container_name       = "prod"
-    key                  = "terraform.tfstate"
-    use_oidc             = true  # Can also be set via `USE_OIDC` environment variable.
+    resource_group_name  = "StorageAccount-ResourceGroup"
+    storage_account_name = "terraform123abc"
+    container_name       = "tfstate"
+    key                  = "prod.terraform.tfstate"
+    use_oidc             = true                                    # Can also be set via `ARM_USE_OIDC` environment variable.
     client_id            = "00000000-0000-0000-0000-000000000000"  # Can also be set via `ARM_CLIENT_ID` environment variable.
     subscription_id      = "00000000-0000-0000-0000-000000000000"  # Can also be set via `ARM_SUBSCRIPTION_ID` environment variable.
     tenant_id            = "00000000-0000-0000-0000-000000000000"  # Can also be set via `ARM_TENANT_ID` environment variable.
@@ -324,78 +326,78 @@ data "terraform_remote_state" "foo" {
 }
 ```
 
-Connect to Storage Account with Entra ID:
+*Connect to Storage Account with Azure Active Directory authentication*
 
 ```hcl
 data "terraform_remote_state" "foo" {
   backend = "azurerm"
   config = {
-    resource_group_name  = "rg-tfstate-001"
-    storage_account_name = "stotfstate001"
-    container_name       = "prod"
-    key                  = "terraform.tfstate"
-    use_oidc             = true  # Can also be set via `USE_OIDC` environment variable.
+    resource_group_name  = "StorageAccount-ResourceGroup"
+    storage_account_name = "terraform123abc"
+    container_name       = "tfstate"
+    key                  = "prod.terraform.tfstate"
+    use_oidc             = true                                    # Can also be set via `ARM_USE_OIDC` environment variable.
     client_id            = "00000000-0000-0000-0000-000000000000"  # Can also be set via `ARM_CLIENT_ID` environment variable.
     subscription_id      = "00000000-0000-0000-0000-000000000000"  # Can also be set via `ARM_SUBSCRIPTION_ID` environment variable.
     tenant_id            = "00000000-0000-0000-0000-000000000000"  # Can also be set via `ARM_TENANT_ID` environment variable.
-    use_azuread_auth     = true  # Can also be set via `USE_AZURE_AD` environment variable.
+    use_azuread_auth     = true                                    # Can also be set via `ARM_USE_AZUREAD` environment variable.
   }
 }
 ```
 
-### Data Source: Entra ID Managed Identity Principal
+### Data Source: Azure AD Managed Identity Principal
 
-You can use a User Assigned Managed Identity as well as a System Assigned Managed Identity on your agent / runner compute. However the authentication does not support specifiying the Client ID of the User Assigned Managed Identity, so you can only supply one per compute instance.
+You can use a User Assigned Managed Identity as well as a System Assigned Managed Identity on your agent / runner compute environment. However the backend does not currently support specifying the Client ID of the User Assigned Managed Identity, so you can only supply one per compute instance.
 
-Connect to Storage Account with Access Key (default):
+*Connect to Storage Account with Access Key*
 
 ```hcl
 data "terraform_remote_state" "foo" {
   backend = "azurerm"
   config = {
-    resource_group_name  = "rg-tfstate-001"
-    storage_account_name = "stotfstate001"
-    container_name       = "prod"
-    key                  = "terraform.tfstate"
-    use_msi              = true  # Can also be set via `USE_MSI` environment variable.
+    resource_group_name  = "StorageAccount-ResourceGroup"
+    storage_account_name = "terraform123abc"
+    container_name       = "tfstate"
+    key                  = "prod.terraform.tfstate"
+    use_msi              = true                                    # Can also be set via `ARM_USE_MSI` environment variable.
     subscription_id      = "00000000-0000-0000-0000-000000000000"  # Can also be set via `ARM_SUBSCRIPTION_ID` environment variable.
     tenant_id            = "00000000-0000-0000-0000-000000000000"  # Can also be set via `ARM_TENANT_ID` environment variable.
   }
 }
 ```
 
-Connect to Storage Account with Entra ID:
+*Connect to Storage Account with Azure Active Directory authentication*
 
 ```hcl
 data "terraform_remote_state" "foo" {
   backend = "azurerm"
   config = {
-    resource_group_name  = "rg-tfstate-001"
-    storage_account_name = "stotfstate001"
-    container_name       = "prod"
-    key                  = "terraform.tfstate"
-    use_msi              = true  # Can also be set via `USE_MSI` environment variable.
+    resource_group_name  = "StorageAccount-ResourceGroup"
+    storage_account_name = "terraform123abc"
+    container_name       = "tfstate"
+    key                  = "prod.terraform.tfstate"
+    use_msi              = true                                    # Can also be set via `ARM_USE_MSI` environment variable.
     subscription_id      = "00000000-0000-0000-0000-000000000000"  # Can also be set via `ARM_SUBSCRIPTION_ID` environment variable.
     tenant_id            = "00000000-0000-0000-0000-000000000000"  # Can also be set via `ARM_TENANT_ID` environment variable.
-    use_azuread_auth     = true  # Can also be set via `USE_AZURE_AD` environment variable.
+    use_azuread_auth     = true                                    # Can also be set via `ARM_USE_AZUREAD` environment variable.
   }
 }
 ```
 
-### Data Source: Entra ID Service Principal via Client Secret
+### Data Source: Azure AD Service Principal via Client Secret
 
 ~> **Warning!**: This method requires you to manage and rotate a secret. Consider using OIDC as a more secure approach.
 
-Connect to Storage Account with Access Key (default):
+*Connect to Storage Account with Access Key*
 
 ```hcl
 data "terraform_remote_state" "foo" {
   backend = "azurerm"
   config = {
-    resource_group_name  = "rg-tfstate-001"
-    storage_account_name = "stotfstate001"
-    container_name       = "prod"
-    key                  = "terraform.tfstate"
+    resource_group_name  = "StorageAccount-ResourceGroup"
+    storage_account_name = "terraform123abc"
+    container_name       = "tfstate"
+    key                  = "prod.terraform.tfstate"
     client_id            = "00000000-0000-0000-0000-000000000000"  # Can also be set via `ARM_CLIENT_ID` environment variable.
     client_secret        = "************************************"  # Can also be set via `ARM_CLIENT_SECRET` environment variable.
     subscription_id      = "00000000-0000-0000-0000-000000000000"  # Can also be set via `ARM_SUBSCRIPTION_ID` environment variable.
@@ -404,41 +406,41 @@ data "terraform_remote_state" "foo" {
 }
 ```
 
-Connect to Storage Account with Entra ID:
+*Connect to Storage Account with Azure Active Directory authentication*
 
 ```hcl
 data "terraform_remote_state" "foo" {
   backend = "azurerm"
   config = {
-    resource_group_name  = "rg-tfstate-001"
-    storage_account_name = "stotfstate001"
-    container_name       = "prod"
-    key                  = "terraform.tfstate"
+    resource_group_name  = "StorageAccount-ResourceGroup"
+    storage_account_name = "terraform123abc"
+    container_name       = "tfstate"
+    key                  = "prod.terraform.tfstate"
     client_id            = "00000000-0000-0000-0000-000000000000"  # Can also be set via `ARM_CLIENT_ID` environment variable.
     client_secret        = "************************************"  # Can also be set via `ARM_CLIENT_SECRET` environment variable.
     subscription_id      = "00000000-0000-0000-0000-000000000000"  # Can also be set via `ARM_SUBSCRIPTION_ID` environment variable.
     tenant_id            = "00000000-0000-0000-0000-000000000000"  # Can also be set via `ARM_TENANT_ID` environment variable.
-    use_azuread_auth     = true  # Can also be set via `USE_AZURE_AD` environment variable.
+    use_azuread_auth     = true                                    # Can also be set via `ARM_USE_AZUREAD` environment variable.
   }
 }
 ```
 
-### Data Source: Entra ID Service Principal via Client Certificate
+### Data Source: Azure AD Service Principal via Client Certificate
 
 ~> **Warning!**: This method requires you to manage and rotate a secret. Consider using OIDC as a more secure approach.
 
-Connect to Storage Account with Access Key (default):
+*Connect to Storage Account with Access Key*
 
 ```hcl
 data "terraform_remote_state" "foo" {
   backend = "azurerm"
   config = {
-    resource_group_name  = "rg-tfstate-001"
-    storage_account_name = "stotfstate001"
-    container_name       = "prod"
-    key                  = "terraform.tfstate"
+    resource_group_name         = "StorageAccount-ResourceGroup"
+    storage_account_name        = "terraform123abc"
+    container_name              = "tfstate"
+    key                         = "prod.terraform.tfstate"
     client_id                   = "00000000-0000-0000-0000-000000000000"  # Can also be set via `ARM_CLIENT_ID` environment variable.
-    client_certificate_path     = "./cert.pfx"  # Can also be set via `ARM_CLIENT_CERTIFICATE_PATH` environment variable.
+    client_certificate_path     = "/path/to/bundle.pfx"                   # Can also be set via `ARM_CLIENT_CERTIFICATE_PATH` environment variable.
     client_certificate_password = "************************************"  # Can also be set via `ARM_CLIENT_CERTIFICATE_PASSWORD` environment variable.
     subscription_id             = "00000000-0000-0000-0000-000000000000"  # Can also be set via `ARM_SUBSCRIPTION_ID` environment variable.
     tenant_id                   = "00000000-0000-0000-0000-000000000000"  # Can also be set via `ARM_TENANT_ID` environment variable.
@@ -446,22 +448,22 @@ data "terraform_remote_state" "foo" {
 }
 ```
 
-Connect to Storage Account with Entra ID:
+*Connect to Storage Account with Azure Active Directory authentication*
 
 ```hcl
 data "terraform_remote_state" "foo" {
   backend = "azurerm"
   config = {
-    resource_group_name  = "rg-tfstate-001"
-    storage_account_name = "stotfstate001"
-    container_name       = "prod"
-    key                  = "terraform.tfstate"
+    resource_group_name         = "StorageAccount-ResourceGroup"
+    storage_account_name        = "terraform123abc"
+    container_name              = "tfstate"
+    key                         = "prod.terraform.tfstate"
     client_id                   = "00000000-0000-0000-0000-000000000000"  # Can also be set via `ARM_CLIENT_ID` environment variable.
-    client_certificate_path     = "./cert.pfx"  # Can also be set via `ARM_CLIENT_CERTIFICATE_PATH` environment variable.
+    client_certificate_path     = "/path/to/bundle.pfx"                   # Can also be set via `ARM_CLIENT_CERTIFICATE_PATH` environment variable.
     client_certificate_password = "************************************"  # Can also be set via `ARM_CLIENT_CERTIFICATE_PASSWORD` environment variable.
     subscription_id             = "00000000-0000-0000-0000-000000000000"  # Can also be set via `ARM_SUBSCRIPTION_ID` environment variable.
     tenant_id                   = "00000000-0000-0000-0000-000000000000"  # Can also be set via `ARM_TENANT_ID` environment variable.
-    use_azuread_auth            = true  # Can also be set via `USE_AZURE_AD` environment variable.
+    use_azuread_auth            = true                                    # Can also be set via `ARM_USE_AZUREAD` environment variable.
   }
 }
 ```
@@ -474,10 +476,10 @@ data "terraform_remote_state" "foo" {
 data "terraform_remote_state" "foo" {
   backend = "azurerm"
   config = {
-    resource_group_name  = "rg-tfstate-001"
-    storage_account_name = "stotfstate001"
-    container_name       = "prod"
-    key                  = "terraform.tfstate"
+    resource_group_name  = "StorageAccount-ResourceGroup"
+    storage_account_name = "terraform123abc"
+    container_name       = "tfstate"
+    key                  = "prod.terraform.tfstate"
     access_key           = "abcdefghijklmnopqrstuvwxyz0123456789..."  # Can also be set via `ARM_ACCESS_KEY` environment variable.
   }
 }
@@ -491,10 +493,10 @@ data "terraform_remote_state" "foo" {
 data "terraform_remote_state" "foo" {
   backend = "azurerm"
   config = {
-    resource_group_name  = "rg-tfstate-001"
-    storage_account_name = "stotfstate001"
-    container_name       = "prod"
-    key                  = "terraform.tfstate"
+    resource_group_name  = "StorageAccount-ResourceGroup"
+    storage_account_name = "terraform123abc"
+    container_name       = "tfstate"
+    key                  = "prod.terraform.tfstate"
     sas_token            = "abcdefghijklmnopqrstuvwxyz0123456789..."  # Can also be set via `ARM_SAS_TOKEN` environment variable.
   }
 }
@@ -502,7 +504,7 @@ data "terraform_remote_state" "foo" {
 
 ## Configuration Variables
 
-!> ****Warning!**:**  We recommend using environment variables to supply credentials and other sensitive data. If you use `-backend-config` or hardcode these values directly in your configuration, Terraform will include these values in both the `.terraform` subdirectory and in plan files. Refer to [Credentials and Sensitive Data](/terraform/language/settings/backends/configuration#credentials-and-sensitive-data) for details.
+!> **Warning:**  We recommend using environment variables to supply credentials and other sensitive data. If you use `-backend-config` or hardcode these values directly in your configuration, Terraform will include these values in both the `.terraform` subdirectory and in plan files. Refer to [Credentials and Sensitive Data](/terraform/language/settings/backends/configuration#credentials-and-sensitive-data) for details.
 
 The following configuration options are supported:
 
@@ -538,7 +540,7 @@ When authenticating using a Managed Identity (MSI) - the following fields are al
 
 ***
 
-When authenticating using a Service Principal with OpenID Connect (OIDC / Workload identity federation)  - the following fields are also supported:
+When authenticating using a Service Principal with OpenID Connect (OIDC / Workload Identity Federation) - the following fields are also supported:
 
 * `oidc_request_url` - (Optional) The URL for the OIDC provider from which to request an ID token. This can also be sourced from the `ARM_OIDC_REQUEST_URL` or `ACTIONS_ID_TOKEN_REQUEST_URL` environment variables.
 
@@ -564,11 +566,11 @@ When authenticating using the Storage Account's Access Key - the following field
 
 ***
 
-When authenticating using Entra ID service principal, you have the option to use Entra ID authentication for the storage account (as opposed to Access Key or SAS Token) - the following fields are also supported:
+When authenticating using an Azure AD Service Principal, you have the option to use Azure Active Directory authentication for the storage account (rather than by an Access Key or SAS Token) - the following fields are also supported:
 
-* `use_azuread_auth` - (Optional) Should EntraID Authentication be used to access the Blob Storage Account. This can also be sourced from the `ARM_USE_AZUREAD` environment variable.
+* `use_azuread_auth` - (Optional) Whether Azure Active Directory Authentication should be used to access the Blob Storage Account. This can also be sourced from the `ARM_USE_AZUREAD` environment variable.
 
--> **Note:** When using Entra ID for Authentication to Storage you need to ensure the `Storage Blob Data Owner` or `Container Blob Data Owner` roles are assigned.
+-> **Note:** When using Azure Active Directory Authentication, you must ensure the `Storage Blob Data Owner` or `Container Blob Data Owner` roles are assigned to your Storage Account.
 
 ***
 

--- a/website/docs/language/settings/backends/azurerm.mdx
+++ b/website/docs/language/settings/backends/azurerm.mdx
@@ -253,7 +253,7 @@ terraform {
 
 ### Backend: SAS Token
 
-~> **Warning!**: This method requires you to manage and a rotate a secret. Consider using OIDC as a more secure approach.
+~> **Warning!**: This method requires you to manage and rotate a secret. Consider using OIDC as a more secure approach.
 
 ```hcl
 terraform {

--- a/website/docs/language/settings/backends/azurerm.mdx
+++ b/website/docs/language/settings/backends/azurerm.mdx
@@ -11,221 +11,462 @@ This backend supports state locking and consistency checking with Azure Blob Sto
 
 ~> **Terraform 1.1 and 1.2 supported a feature-flag to allow enabling/disabling the use of Microsoft Graph (and MSAL) rather than Azure Active Directory Graph (and ADAL) - however this flag has since been removed in Terraform 1.3. Microsoft Graph (and MSAL) are now enabled by default and Azure Active Directory Graph (and ADAL) can no longer be used.
 
-## Example Configuration
+## Authentication
 
-When authenticating using the Azure CLI or a Service Principal (either with a Client Certificate or a Client Secret):
+The `azurerm` backend supports 3 methods of authenticating to the storage account:
 
-```hcl
-terraform {
-  backend "azurerm" {
-    resource_group_name  = "StorageAccount-ResourceGroup"
-    storage_account_name = "abcd1234"
-    container_name       = "tfstate"
-    key                  = "prod.terraform.tfstate"
-  }
-}
-```
+- Access Key (default)
+- Entra ID
+- SAS Token
 
-***
+The Access Key method can be used directly or in combination with an Entra ID principal. By default when you use an Entra ID principal, it will use the Access Token of that principal to generate an Access Key for the storage account and use that Access Key to authenticate to the blob.
 
-When authenticating using Managed Service Identity (MSI):
+The Entra ID method can only be used in combination with an Entra ID principal.
 
-```hcl
-terraform {
-  backend "azurerm" {
-    resource_group_name  = "StorageAccount-ResourceGroup"
-    storage_account_name = "abcd1234"
-    container_name       = "tfstate"
-    key                  = "prod.terraform.tfstate"
-    use_msi              = true
-    subscription_id      = "00000000-0000-0000-0000-000000000000"
-    tenant_id            = "00000000-0000-0000-0000-000000000000"
-  }
-}
-```
+The SAS Token method can only be used directly.
 
-***
+The `azurerm` backend supports the following authentication methods to connect the storage account based on the variables that are set:
 
-When authenticating using OpenID Connect (OIDC):
+| Entra ID Authentication Method | Storage Account Authentication Type | Authentication variable * | Entra ID variable |
+| Entra ID User via Azure CLI | Access Key | N/A | N/A |
+| Entra ID User via Azure CLI | Entra ID | N/A | `use_azuread_auth = true` |
+| Entra ID Service Principal via OIDC (Workload identity federation) | Access Key | `use_oidc = true` | N/A |
+| Entra ID Service Principal via OIDC (Workload identity federation) | Entra ID | `use_oidc = true` | `use_azuread_auth = true` |
+| Entra ID Service Principal via Managed identity | Access Key | `use_msi = true` | N/A |
+| Entra ID Service Principal via Managed identity | Entra ID | `use_msi = true` | `use_azuread_auth = true` |
+| Entra ID Service Principal via Client Secret | Access Key | `client_secret = <service principal secret>` | N/A |
+| Entra ID Service Principal via Client Secret | Entra ID | `client_secret = <service principal secret>` | `use_azuread_auth = true` |
+| Entra ID Service Principal via Client Certificate | Access Key | `client_certificate_path = <cert path>` | N/A |
+| Entra ID Service Principal via Client Certificate | Entra ID | `client_certificate_path = <cert path>` | `use_azuread_auth = true` |
+| Access Key direct | Access Key | `access_key = <access key>` | N/A |
+| SAS Key direct | SAS Token | `sas_token = <sas token>` | N/A |
 
-```hcl
-terraform {
-  backend "azurerm" {
-    resource_group_name  = "StorageAccount-ResourceGroup"
-    storage_account_name = "abcd1234"
-    container_name       = "tfstate"
-    key                  = "prod.terraform.tfstate"
-    use_oidc             = true
-    subscription_id      = "00000000-0000-0000-0000-000000000000"
-    tenant_id            = "00000000-0000-0000-0000-000000000000"
-  }
-}
-```
+> * = We provide a single variable here, but there is usually more than one required for successful authentication. The variable we show is the one that triggers the backend to use that authentication type.
 
-***
+> NOTE: In the table we show the variable passed as it would be hard coded. Variables can and should be passed via environment variables or partial config flags in the `init` command of the CLI.
 
-When authenticating using Azure AD Authentication:
+## Example Configurations
+
+### Entra ID via Azure CLI
+
+Access Key (default):
 
 ```hcl
 terraform {
   backend "azurerm" {
-    storage_account_name = "abcd1234"
-    container_name       = "tfstate"
-    key                  = "prod.terraform.tfstate"
-    use_azuread_auth     = true
-    subscription_id      = "00000000-0000-0000-0000-000000000000"
-    tenant_id            = "00000000-0000-0000-0000-000000000000"
+    resource_group_name  = "StorageAccount-ResourceGroup"  # Can be passed via `-backend-config=`"resource_group_name=<resource group name>"` in the `init` command.
+    storage_account_name = "abcd1234"  # Can be passed via `-backend-config=`"storage_account_name=<storage account name>"` in the `init` command.
+    container_name       = "tfstate"  # Can be passed via `-backend-config=`"container_name=<container name>"` in the `init` command.
+    key                  = "prod.terraform.tfstate"  # Can be passed via `-backend-config=`"key=<blob key name>"` in the `init` command.
   }
 }
 ```
 
--> **Note:** When using AzureAD for Authentication to Storage you also need to ensure the `Storage Blob Data Owner` role is assigned.
-
-***
-
-When authenticating using the Access Key associated with the Storage Account:
+Entra ID:
 
 ```hcl
 terraform {
   backend "azurerm" {
-    storage_account_name = "abcd1234"
-    container_name       = "tfstate"
-    key                  = "prod.terraform.tfstate"
-
-    # rather than defining this inline, the Access Key can also be sourced
-    # from an Environment Variable - more information is available below.
-    access_key = "abcdefghijklmnopqrstuvwxyz0123456789..."
+    resource_group_name  = "StorageAccount-ResourceGroup"  # Can be passed via `-backend-config=`"resource_group_name=<resource group name>"` in the `init` command.
+    storage_account_name = "abcd1234"  # Can be passed via `-backend-config=`"storage_account_name=<storage account name>"` in the `init` command.
+    container_name       = "tfstate"  # Can be passed via `-backend-config=`"container_name=<container name>"` in the `init` command.
+    key                  = "prod.terraform.tfstate"  # Can be passed via `-backend-config=`"key=<blob key name>"` in the `init` command.
+    use_azuread_auth     = true  # Can also be set via `USE_AZURE_AD` environment variable.
   }
 }
 ```
 
-***
+### Entra ID via OIDC (Workload identity federation):
 
-When authenticating using a SAS Token associated with the Storage Account:
+Access Key (default):
 
 ```hcl
 terraform {
   backend "azurerm" {
-    storage_account_name = "abcd1234"
-    container_name       = "tfstate"
-    key                  = "prod.terraform.tfstate"
-
-    # rather than defining this inline, the SAS Token can also be sourced
-    # from an Environment Variable - more information is available below.
-    sas_token = "abcdefghijklmnopqrstuvwxyz0123456789..."
+    resource_group_name  = "StorageAccount-ResourceGroup"  # Can be passed via `-backend-config=`"resource_group_name=<resource group name>"` in the `init` command.
+    storage_account_name = "abcd1234"  # Can be passed via `-backend-config=`"storage_account_name=<storage account name>"` in the `init` command.
+    container_name       = "tfstate"  # Can be passed via `-backend-config=`"container_name=<container name>"` in the `init` command.
+    key                  = "prod.terraform.tfstate"  # Can be passed via `-backend-config=`"key=<blob key name>"` in the `init` command.
+    use_oidc              = true  # Can also be set via `USE_OIDC` environment variable.
+    client_id            = "00000000-0000-0000-0000-000000000000"  # Can also be set via `ARM_CLIENT_ID` environment variable.
+    subscription_id      = "00000000-0000-0000-0000-000000000000"  # Can also be set via `ARM_SUBSCRIPTION_ID` environment variable.
+    tenant_id            = "00000000-0000-0000-0000-000000000000"  # Can also be set via `ARM_TENANT_ID` environment variable.
   }
 }
 ```
 
--> **NOTE:** When using a Service Principal or an Access Key - we recommend using a [Partial Configuration](/terraform/language/settings/backends/configuration#partial-configuration) for the credentials.
+Entra ID:
+
+```hcl
+terraform {
+  backend "azurerm" {
+    resource_group_name  = "StorageAccount-ResourceGroup"  # Can be passed via `-backend-config=`"resource_group_name=<resource group name>"` in the `init` command.
+    storage_account_name = "abcd1234"  # Can be passed via `-backend-config=`"storage_account_name=<storage account name>"` in the `init` command.
+    container_name       = "tfstate"  # Can be passed via `-backend-config=`"container_name=<container name>"` in the `init` command.
+    key                  = "prod.terraform.tfstate"  # Can be passed via `-backend-config=`"key=<blob key name>"` in the `init` command.
+    use_oidc              = true  # Can also be set via `USE_OIDC` environment variable.
+    client_id            = "00000000-0000-0000-0000-000000000000"  # Can also be set via `ARM_CLIENT_ID` environment variable.
+    subscription_id      = "00000000-0000-0000-0000-000000000000"  # Can also be set via `ARM_SUBSCRIPTION_ID` environment variable.
+    tenant_id            = "00000000-0000-0000-0000-000000000000"  # Can also be set via `ARM_TENANT_ID` environment variable.
+    use_azuread_auth     = true  # Can also be set via `USE_AZURE_AD` environment variable.
+  }
+}
+```
+
+### Entra ID via Managed identity:
+
+Access Key (default):
+
+```hcl
+terraform {
+  backend "azurerm" {
+    resource_group_name  = "StorageAccount-ResourceGroup"  # Can be passed via `-backend-config=`"resource_group_name=<resource group name>"` in the `init` command.
+    storage_account_name = "abcd1234"  # Can be passed via `-backend-config=`"storage_account_name=<storage account name>"` in the `init` command.
+    container_name       = "tfstate"  # Can be passed via `-backend-config=`"container_name=<container name>"` in the `init` command.
+    key                  = "prod.terraform.tfstate"  # Can be passed via `-backend-config=`"key=<blob key name>"` in the `init` command.
+    use_msi              = true  # Can also be set via `USE_MSI` environment variable.
+    subscription_id      = "00000000-0000-0000-0000-000000000000"  # Can also be set via `ARM_SUBSCRIPTION_ID` environment variable.
+    tenant_id            = "00000000-0000-0000-0000-000000000000"  # Can also be set via `ARM_TENANT_ID` environment variable.
+  }
+}
+```
+
+Entra ID:
+
+```hcl
+terraform {
+  backend "azurerm" {
+    resource_group_name  = "StorageAccount-ResourceGroup"  # Can be passed via `-backend-config=`"resource_group_name=<resource group name>"` in the `init` command.
+    storage_account_name = "abcd1234"  # Can be passed via `-backend-config=`"storage_account_name=<storage account name>"` in the `init` command.
+    container_name       = "tfstate"  # Can be passed via `-backend-config=`"container_name=<container name>"` in the `init` command.
+    key                  = "prod.terraform.tfstate"  # Can be passed via `-backend-config=`"key=<blob key name>"` in the `init` command.
+    use_msi              = true  # Can also be set via `USE_MSI` environment variable.
+    subscription_id      = "00000000-0000-0000-0000-000000000000"  # Can also be set via `ARM_SUBSCRIPTION_ID` environment variable.
+    tenant_id            = "00000000-0000-0000-0000-000000000000"  # Can also be set via `ARM_TENANT_ID` environment variable.
+    use_azuread_auth     = true  # Can also be set via `USE_AZURE_AD` environment variable.
+  }
+}
+```
+
+### Entra ID via Client Secret:
+
+Access Key (default):
+
+```hcl
+terraform {
+  backend "azurerm" {
+    resource_group_name  = "StorageAccount-ResourceGroup"  # Can be passed via `-backend-config=`"resource_group_name=<resource group name>"` in the `init` command.
+    storage_account_name = "abcd1234"  # Can be passed via `-backend-config=`"storage_account_name=<storage account name>"` in the `init` command.
+    container_name       = "tfstate"  # Can be passed via `-backend-config=`"container_name=<container name>"` in the `init` command.
+    key                  = "prod.terraform.tfstate"  # Can be passed via `-backend-config=`"key=<blob key name>"` in the `init` command.
+    client_id            = "00000000-0000-0000-0000-000000000000"  # Can also be set via `ARM_CLIENT_ID` environment variable.
+    client_secret        = "************************************"  # Can also be set via `ARM_CLIENT_SECRET` environment variable.
+    subscription_id      = "00000000-0000-0000-0000-000000000000"  # Can also be set via `ARM_SUBSCRIPTION_ID` environment variable.
+    tenant_id            = "00000000-0000-0000-0000-000000000000"  # Can also be set via `ARM_TENANT_ID` environment variable.
+  }
+}
+```
+
+Entra ID:
+
+```hcl
+terraform {
+  backend "azurerm" {
+    resource_group_name  = "StorageAccount-ResourceGroup"  # Can be passed via `-backend-config=`"resource_group_name=<resource group name>"` in the `init` command.
+    storage_account_name = "abcd1234"  # Can be passed via `-backend-config=`"storage_account_name=<storage account name>"` in the `init` command.
+    container_name       = "tfstate"  # Can be passed via `-backend-config=`"container_name=<container name>"` in the `init` command.
+    key                  = "prod.terraform.tfstate"  # Can be passed via `-backend-config=`"key=<blob key name>"` in the `init` command.
+    client_id            = "00000000-0000-0000-0000-000000000000"  # Can also be set via `ARM_CLIENT_ID` environment variable.
+    client_secret        = "************************************"  # Can also be set via `ARM_CLIENT_SECRET` environment variable.
+    subscription_id      = "00000000-0000-0000-0000-000000000000"  # Can also be set via `ARM_SUBSCRIPTION_ID` environment variable.
+    tenant_id            = "00000000-0000-0000-0000-000000000000"  # Can also be set via `ARM_TENANT_ID` environment variable.
+    use_azuread_auth     = true  # Can also be set via `USE_AZURE_AD` environment variable.
+  }
+}
+```
+
+### Entra ID via Client Certificate:
+
+Access Key (default):
+
+```hcl
+terraform {
+  backend "azurerm" {
+    resource_group_name         = "StorageAccount-ResourceGroup"  # Can be passed via `-backend-config=`"resource_group_name=<resource group name>"` in the `init` command.
+    storage_account_name        = "abcd1234"  # Can be passed via `-backend-config=`"storage_account_name=<storage account name>"` in the `init` command.
+    container_name              = "tfstate"  # Can be passed via `-backend-config=`"container_name=<container name>"` in the `init` command.
+    key                         = "prod.terraform.tfstate"  # Can be passed via `-backend-config=`"key=<blob key name>"` in the `init` command.
+    client_id                   = "00000000-0000-0000-0000-000000000000"  # Can also be set via `ARM_CLIENT_ID` environment variable.
+    client_certificate_path     = "./cert.pfx"  # Can also be set via `ARM_CLIENT_CERTIFICATE_PATH` environment variable.
+    client_certificate_password = "************************************"  # Can also be set via `ARM_CLIENT_CERTIFICATE_PASSWORD` environment variable.
+    subscription_id             = "00000000-0000-0000-0000-000000000000"  # Can also be set via `ARM_SUBSCRIPTION_ID` environment variable.
+    tenant_id                   = "00000000-0000-0000-0000-000000000000"  # Can also be set via `ARM_TENANT_ID` environment variable.
+  }
+}
+```
+
+Entra ID:
+
+```hcl
+terraform {
+  backend "azurerm" {
+    resource_group_name         = "StorageAccount-ResourceGroup"  # Can be passed via `-backend-config=`"resource_group_name=<resource group name>"` in the `init` command.
+    storage_account_name        = "abcd1234"  # Can be passed via `-backend-config=`"storage_account_name=<storage account name>"` in the `init` command.
+    container_name              = "tfstate"  # Can be passed via `-backend-config=`"container_name=<container name>"` in the `init` command.
+    key                         = "prod.terraform.tfstate"  # Can be passed via `-backend-config=`"key=<blob key name>"` in the `init` command.
+    client_id                   = "00000000-0000-0000-0000-000000000000"  # Can also be set via `ARM_CLIENT_ID` environment variable.
+    client_certificate_path     = "./cert.pfx"  # Can also be set via `ARM_CLIENT_CERTIFICATE_PATH` environment variable.
+    client_certificate_password = "************************************"  # Can also be set via `ARM_CLIENT_CERTIFICATE_PASSWORD` environment variable.
+    subscription_id             = "00000000-0000-0000-0000-000000000000"  # Can also be set via `ARM_SUBSCRIPTION_ID` environment variable.
+    tenant_id                   = "00000000-0000-0000-0000-000000000000"  # Can also be set via `ARM_TENANT_ID` environment variable.
+    use_azuread_auth            = true  # Can also be set via `USE_AZURE_AD` environment variable.
+  }
+}
+```
+
+### Access Key direct
+
+```hcl
+terraform {
+  backend "azurerm" {
+    resource_group_name  = "StorageAccount-ResourceGroup"  # Can be passed via `-backend-config=`"resource_group_name=<resource group name>"` in the `init` command.
+    storage_account_name = "abcd1234"  # Can be passed via `-backend-config=`"storage_account_name=<storage account name>"` in the `init` command.
+    container_name       = "tfstate"  # Can be passed via `-backend-config=`"container_name=<container name>"` in the `init` command.
+    key                  = "prod.terraform.tfstate"  # Can be passed via `-backend-config=`"key=<blob key name>"` in the `init` command.
+    access_key           = "abcdefghijklmnopqrstuvwxyz0123456789..."  # Can also be set via `ARM_ACCESS_KEY` environment variable.
+  }
+}
+```
+
+### SAS Token
+
+```hcl
+terraform {
+  backend "azurerm" {
+    resource_group_name  = "StorageAccount-ResourceGroup"  # Can be passed via `-backend-config=`"resource_group_name=<resource group name>"` in the `init` command.
+    storage_account_name = "abcd1234"  # Can be passed via `-backend-config=`"storage_account_name=<storage account name>"` in the `init` command.
+    container_name       = "tfstate"  # Can be passed via `-backend-config=`"container_name=<container name>"` in the `init` command.
+    key                  = "prod.terraform.tfstate"  # Can be passed via `-backend-config=`"key=<blob key name>"` in the `init` command.
+    sas_token            = "abcdefghijklmnopqrstuvwxyz0123456789..."  # Can also be set via `ARM_SAS_TOKEN` environment variable.
+  }
+}
+```
 
 ## Data Source Configuration
 
-When authenticating using a Service Principal (either with a Client Certificate or a Client Secret):
+### Entra ID via Azure CLI
 
-```hcl
-data "terraform_remote_state" "foo" {
-  backend = "azurerm"
-  config = {
-    storage_account_name = "terraform123abc"
-    container_name       = "terraform-state"
-    key                  = "prod.terraform.tfstate"
-  }
-}
-```
-
-***
-
-When authenticating using Managed Service Identity (MSI):
+Access Key (default):
 
 ```hcl
 data "terraform_remote_state" "foo" {
   backend = "azurerm"
   config = {
     resource_group_name  = "StorageAccount-ResourceGroup"
-    storage_account_name = "terraform123abc"
-    container_name       = "terraform-state"
+    storage_account_name = "abcd1234"
+    container_name       = "tfstate"
     key                  = "prod.terraform.tfstate"
-    use_msi              = true
-    subscription_id      = "00000000-0000-0000-0000-000000000000"
-    tenant_id            = "00000000-0000-0000-0000-000000000000"
   }
 }
 ```
 
-***
-
-When authenticating using OpenID Connect (OIDC):
+Entra ID:
 
 ```hcl
 data "terraform_remote_state" "foo" {
   backend = "azurerm"
   config = {
     resource_group_name  = "StorageAccount-ResourceGroup"
-    storage_account_name = "terraform123abc"
-    container_name       = "terraform-state"
+    storage_account_name = "abcd1234"
+    container_name       = "tfstate"
     key                  = "prod.terraform.tfstate"
-    use_oidc             = true
-    subscription_id      = "00000000-0000-0000-0000-000000000000"
-    tenant_id            = "00000000-0000-0000-0000-000000000000"
+    use_azuread_auth     = true  # Can also be set via `USE_AZURE_AD` environment variable.
   }
 }
 ```
 
-***
+### Entra ID via OIDC (Workload identity federation):
 
-When authenticating using AzureAD Authentication:
+Access Key (default):
 
 ```hcl
 data "terraform_remote_state" "foo" {
   backend = "azurerm"
   config = {
-    storage_account_name = "terraform123abc"
-    container_name       = "terraform-state"
+    resource_group_name  = "StorageAccount-ResourceGroup"
+    storage_account_name = "abcd1234"
+    container_name       = "tfstate"
     key                  = "prod.terraform.tfstate"
-    use_azuread_auth     = true
-    subscription_id      = "00000000-0000-0000-0000-000000000000"
-    tenant_id            = "00000000-0000-0000-0000-000000000000"
+    use_oidc             = true  # Can also be set via `USE_OIDC` environment variable.
+    client_id            = "00000000-0000-0000-0000-000000000000"  # Can also be set via `ARM_CLIENT_ID` environment variable.
+    subscription_id      = "00000000-0000-0000-0000-000000000000"  # Can also be set via `ARM_SUBSCRIPTION_ID` environment variable.
+    tenant_id            = "00000000-0000-0000-0000-000000000000"  # Can also be set via `ARM_TENANT_ID` environment variable.
   }
 }
 ```
 
--> **Note:** When using AzureAD for Authentication to Storage you also need to ensure the `Storage Blob Data Owner` role is assigned.
-
-***
-
-When authenticating using the Access Key associated with the Storage Account:
+Entra ID:
 
 ```hcl
 data "terraform_remote_state" "foo" {
   backend = "azurerm"
   config = {
-    storage_account_name = "terraform123abc"
-    container_name       = "terraform-state"
+    resource_group_name  = "StorageAccount-ResourceGroup"
+    storage_account_name = "abcd1234"
+    container_name       = "tfstate"
     key                  = "prod.terraform.tfstate"
-
-    # rather than defining this inline, the Access Key can also be sourced
-    # from an Environment Variable - more information is available below.
-    access_key = "abcdefghijklmnopqrstuvwxyz0123456789..."
+    use_oidc             = true  # Can also be set via `USE_OIDC` environment variable.
+    client_id            = "00000000-0000-0000-0000-000000000000"  # Can also be set via `ARM_CLIENT_ID` environment variable.
+    subscription_id      = "00000000-0000-0000-0000-000000000000"  # Can also be set via `ARM_SUBSCRIPTION_ID` environment variable.
+    tenant_id            = "00000000-0000-0000-0000-000000000000"  # Can also be set via `ARM_TENANT_ID` environment variable.
+    use_azuread_auth     = true  # Can also be set via `USE_AZURE_AD` environment variable.
   }
 }
 ```
 
-***
+### Entra ID via Managed identity:
 
-When authenticating using a SAS Token associated with the Storage Account:
+Access Key (default):
 
 ```hcl
 data "terraform_remote_state" "foo" {
   backend = "azurerm"
   config = {
-    storage_account_name = "terraform123abc"
-    container_name       = "terraform-state"
+    resource_group_name  = "StorageAccount-ResourceGroup"
+    storage_account_name = "abcd1234"
+    container_name       = "tfstate"
     key                  = "prod.terraform.tfstate"
+    use_msi              = true  # Can also be set via `USE_MSI` environment variable.
+    subscription_id      = "00000000-0000-0000-0000-000000000000"  # Can also be set via `ARM_SUBSCRIPTION_ID` environment variable.
+    tenant_id            = "00000000-0000-0000-0000-000000000000"  # Can also be set via `ARM_TENANT_ID` environment variable.
+  }
+}
+```
 
-    # rather than defining this inline, the SAS Token can also be sourced
-    # from an Environment Variable - more information is available below.
-    sas_token = "abcdefghijklmnopqrstuvwxyz0123456789..."
+Entra ID:
+
+```hcl
+data "terraform_remote_state" "foo" {
+  backend = "azurerm"
+  config = {
+    resource_group_name  = "StorageAccount-ResourceGroup"
+    storage_account_name = "abcd1234"
+    container_name       = "tfstate"
+    key                  = "prod.terraform.tfstate"
+    use_msi              = true  # Can also be set via `USE_MSI` environment variable.
+    subscription_id      = "00000000-0000-0000-0000-000000000000"  # Can also be set via `ARM_SUBSCRIPTION_ID` environment variable.
+    tenant_id            = "00000000-0000-0000-0000-000000000000"  # Can also be set via `ARM_TENANT_ID` environment variable.
+    use_azuread_auth     = true  # Can also be set via `USE_AZURE_AD` environment variable.
+  }
+}
+```
+
+### Entra ID via Client Secret:
+
+Access Key (default):
+
+```hcl
+data "terraform_remote_state" "foo" {
+  backend = "azurerm"
+  config = {
+    resource_group_name  = "StorageAccount-ResourceGroup"
+    storage_account_name = "abcd1234"
+    container_name       = "tfstate"
+    key                  = "prod.terraform.tfstate"
+    client_id            = "00000000-0000-0000-0000-000000000000"  # Can also be set via `ARM_CLIENT_ID` environment variable.
+    client_secret        = "************************************"  # Can also be set via `ARM_CLIENT_SECRET` environment variable.
+    subscription_id      = "00000000-0000-0000-0000-000000000000"  # Can also be set via `ARM_SUBSCRIPTION_ID` environment variable.
+    tenant_id            = "00000000-0000-0000-0000-000000000000"  # Can also be set via `ARM_TENANT_ID` environment variable.
+  }
+}
+```
+
+Entra ID:
+
+```hcl
+data "terraform_remote_state" "foo" {
+  backend = "azurerm"
+  config = {
+    resource_group_name  = "StorageAccount-ResourceGroup"
+    storage_account_name = "abcd1234"
+    container_name       = "tfstate"
+    key                  = "prod.terraform.tfstate"
+    client_id            = "00000000-0000-0000-0000-000000000000"  # Can also be set via `ARM_CLIENT_ID` environment variable.
+    client_secret        = "************************************"  # Can also be set via `ARM_CLIENT_SECRET` environment variable.
+    subscription_id      = "00000000-0000-0000-0000-000000000000"  # Can also be set via `ARM_SUBSCRIPTION_ID` environment variable.
+    tenant_id            = "00000000-0000-0000-0000-000000000000"  # Can also be set via `ARM_TENANT_ID` environment variable.
+    use_azuread_auth     = true  # Can also be set via `USE_AZURE_AD` environment variable.
+  }
+}
+```
+
+### Entra ID via Client Certificate:
+
+Access Key (default):
+
+```hcl
+data "terraform_remote_state" "foo" {
+  backend = "azurerm"
+  config = {
+    resource_group_name  = "StorageAccount-ResourceGroup"
+    storage_account_name = "abcd1234"
+    container_name       = "tfstate"
+    key                  = "prod.terraform.tfstate"
+    client_id                   = "00000000-0000-0000-0000-000000000000"  # Can also be set via `ARM_CLIENT_ID` environment variable.
+    client_certificate_path     = "./cert.pfx"  # Can also be set via `ARM_CLIENT_CERTIFICATE_PATH` environment variable.
+    client_certificate_password = "************************************"  # Can also be set via `ARM_CLIENT_CERTIFICATE_PASSWORD` environment variable.
+    subscription_id             = "00000000-0000-0000-0000-000000000000"  # Can also be set via `ARM_SUBSCRIPTION_ID` environment variable.
+    tenant_id                   = "00000000-0000-0000-0000-000000000000"  # Can also be set via `ARM_TENANT_ID` environment variable.
+  }
+}
+```
+
+Entra ID:
+
+```hcl
+data "terraform_remote_state" "foo" {
+  backend = "azurerm"
+  config = {
+    resource_group_name  = "StorageAccount-ResourceGroup"
+    storage_account_name = "abcd1234"
+    container_name       = "tfstate"
+    key                  = "prod.terraform.tfstate"
+    client_id                   = "00000000-0000-0000-0000-000000000000"  # Can also be set via `ARM_CLIENT_ID` environment variable.
+    client_certificate_path     = "./cert.pfx"  # Can also be set via `ARM_CLIENT_CERTIFICATE_PATH` environment variable.
+    client_certificate_password = "************************************"  # Can also be set via `ARM_CLIENT_CERTIFICATE_PASSWORD` environment variable.
+    subscription_id             = "00000000-0000-0000-0000-000000000000"  # Can also be set via `ARM_SUBSCRIPTION_ID` environment variable.
+    tenant_id                   = "00000000-0000-0000-0000-000000000000"  # Can also be set via `ARM_TENANT_ID` environment variable.
+    use_azuread_auth            = true  # Can also be set via `USE_AZURE_AD` environment variable.
+  }
+}
+```
+
+### Access Key direct
+
+```hcl
+data "terraform_remote_state" "foo" {
+  backend = "azurerm"
+  config = {
+    resource_group_name  = "StorageAccount-ResourceGroup"
+    storage_account_name = "abcd1234"
+    container_name       = "tfstate"
+    key                  = "prod.terraform.tfstate"
+    access_key           = "abcdefghijklmnopqrstuvwxyz0123456789..."  # Can also be set via `ARM_ACCESS_KEY` environment variable.
+  }
+}
+```
+
+### SAS Token
+
+```hcl
+data "terraform_remote_state" "foo" {
+  backend = "azurerm"
+  config = {
+    resource_group_name  = "StorageAccount-ResourceGroup"
+    storage_account_name = "abcd1234"
+    container_name       = "tfstate"
+    key                  = "prod.terraform.tfstate"
+    sas_token            = "abcdefghijklmnopqrstuvwxyz0123456789..."  # Can also be set via `ARM_SAS_TOKEN` environment variable.
   }
 }
 ```
@@ -255,7 +496,7 @@ The following configuration options are supported:
 
 ***
 
-When authenticating using the Managed Service Identity (MSI) - the following fields are also supported:
+When authenticating using a Managed Identity (MSI) - the following fields are also supported:
 
 * `resource_group_name` - (Required) The Name of the Resource Group in which the Storage Account exists.
 
@@ -269,7 +510,7 @@ When authenticating using the Managed Service Identity (MSI) - the following fie
 
 ***
 
-When authenticating using a Service Principal with OpenID Connect (OIDC) - the following fields are also supported:
+When authenticating using a Service Principal with OpenID Connect (OIDC / Workload identity federation)  - the following fields are also supported:
 
 * `oidc_request_url` - (Optional) The URL for the OIDC provider from which to request an ID token. This can also be sourced from the `ARM_OIDC_REQUEST_URL` or `ACTIONS_ID_TOKEN_REQUEST_URL` environment variables.
 
@@ -295,11 +536,11 @@ When authenticating using the Storage Account's Access Key - the following field
 
 ***
 
-When authenticating using AzureAD Authentication - the following fields are also supported:
+When authenticating using Entra ID service principal, you have the option to use Entra ID authentication for the storage account (as opposed to Access Key or SAS Token) - the following fields are also supported:
 
-* `use_azuread_auth` - (Optional) Should AzureAD Authentication be used to access the Blob Storage Account. This can also be sourced from the `ARM_USE_AZUREAD` environment variable.
+* `use_azuread_auth` - (Optional) Should EntraID Authentication be used to access the Blob Storage Account. This can also be sourced from the `ARM_USE_AZUREAD` environment variable.
 
--> **Note:** When using AzureAD for Authentication to Storage you also need to ensure the `Storage Blob Data Owner` role is assigned.
+-> **Note:** When using Entra ID for Authentication to Storage you need to ensure the `Storage Blob Data Owner` or `Container Blob Data Owner` roles are assigned.
 
 ***
 

--- a/website/docs/language/settings/backends/azurerm.mdx
+++ b/website/docs/language/settings/backends/azurerm.mdx
@@ -50,6 +50,8 @@ The `azurerm` backend supports the following authentication methods to connect t
 
 ### Backend: Entra ID User via Azure CLI
 
+This method is not suitable for automation since it only supports a User Principal. To check which tenant and subscription you are pointed to, run `az account show`.
+
 Connect to Storage Account with Access Key (default):
 
 ```hcl
@@ -260,6 +262,8 @@ terraform {
 ## Example Data Source Configurations
 
 ### Data Source: Entra ID User Principal via Azure CLI
+
+This method is not suitable for automation since it only supports a User Principal. To check which tenant and subscription you are pointed to, run `az account show`.
 
 Connect to Storage Account with Access Key (default):
 

--- a/website/docs/language/settings/backends/azurerm.mdx
+++ b/website/docs/language/settings/backends/azurerm.mdx
@@ -11,19 +11,19 @@ This backend supports state locking and consistency checking with Azure Blob Sto
 
 ~> **Terraform 1.1 and 1.2 supported a feature-flag to allow enabling/disabling the use of Microsoft Graph (and MSAL) rather than Azure Active Directory Graph (and ADAL) - however this flag has since been removed in Terraform 1.3. Microsoft Graph (and MSAL) are now enabled by default and Azure Active Directory Graph (and ADAL) can no longer be used.
 
-## Authentication4
+## Authentication
 
 The `azurerm` backend supports 3 methods of authenticating to the storage account:
 
-- Access Key (default)
-- Entra ID
-- SAS Token
+- **Access Key** (default)
+- **Entra ID**
+- **SAS Token**
 
-The Access Key method can be used directly or in combination with an Entra ID principal. By default when you use an Entra ID principal, it will use the Access Token of that principal to generate an Access Key for the storage account and use that Access Key to authenticate to the blob.
+The **Access Key** method can be used directly or in combination with an Entra ID principal (e.g. user, service principal or managed identity). By default when you use an Entra ID principal, it will use the Access Token of that principal to generate an Access Key for the storage account and use that Access Key to authenticate to the state file blob. To use an Access Key directly you must generate one for you state file blob and pass it to the backend config.
 
-The Entra ID method can only be used in combination with an Entra ID principal.
+The **Entra ID** method can only be used in combination with an Entra ID principal. To use the Entra ID method you must set the `use_azuread_auth` variable to `true` in your backend configuration. This will cause the backend to use the Access Token of the Entra ID principal to authenticate to the state file blob.
 
-The SAS Token method can only be used directly.
+The **SAS Token** method can only be used directly. You must generate a SAS Token for your state file blob and pass it to the backend config.
 
 The `azurerm` backend supports the following authentication methods to connect the storage account based on the variables that are set:
 

--- a/website/docs/language/settings/backends/azurerm.mdx
+++ b/website/docs/language/settings/backends/azurerm.mdx
@@ -196,7 +196,7 @@ terraform {
 
 ### Backend: Entra ID Service Principal via Client Certificate
 
-~> **Warning!**: This method requires you to manage and a rotate a secret. Consider using OIDC as a more secure approach.
+~> **Warning!**: This method requires you to manage and rotate a secret. Consider using OIDC as a more secure approach.
 
 Connect to Storage Account with Access Key (default):
 

--- a/website/docs/language/settings/backends/azurerm.mdx
+++ b/website/docs/language/settings/backends/azurerm.mdx
@@ -157,7 +157,7 @@ terraform {
 
 ### Backend: Entra ID Service Principal via Client Secret
 
-~> WARNING: This method requires you to manage and a rotate a secret. Consider using OIDC as a more secure approach.
+~> **Warning!**: This method requires you to manage and a rotate a secret. Consider using OIDC as a more secure approach.
 
 Connect to Storage Account with Access Key (default):
 
@@ -196,7 +196,7 @@ terraform {
 
 ### Backend: Entra ID Service Principal via Client Certificate
 
-~> WARNING: This method requires you to manage and a rotate a secret. Consider using OIDC as a more secure approach.
+~> **Warning!**: This method requires you to manage and a rotate a secret. Consider using OIDC as a more secure approach.
 
 Connect to Storage Account with Access Key (default):
 
@@ -237,7 +237,7 @@ terraform {
 
 ### Backend: Access Key Direct
 
-~> WARNING: This method requires you to manage and a rotate a secret. Consider using OIDC as a more secure approach.
+~> **Warning!**: This method requires you to manage and a rotate a secret. Consider using OIDC as a more secure approach.
 
 ```hcl
 terraform {
@@ -253,7 +253,7 @@ terraform {
 
 ### Backend: SAS Token
 
-~> WARNING: This method requires you to manage and a rotate a secret. Consider using OIDC as a more secure approach.
+~> **Warning!**: This method requires you to manage and a rotate a secret. Consider using OIDC as a more secure approach.
 
 ```hcl
 terraform {
@@ -384,7 +384,7 @@ data "terraform_remote_state" "foo" {
 
 ### Data Source: Entra ID Service Principal via Client Secret
 
-~> WARNING: This method requires you to manage and a rotate a secret. Consider using OIDC as a more secure approach.
+~> **Warning!**: This method requires you to manage and a rotate a secret. Consider using OIDC as a more secure approach.
 
 Connect to Storage Account with Access Key (default):
 
@@ -425,7 +425,7 @@ data "terraform_remote_state" "foo" {
 
 ### Data Source: Entra ID Service Principal via Client Certificate
 
-~> WARNING: This method requires you to manage and a rotate a secret. Consider using OIDC as a more secure approach.
+~> **Warning!**: This method requires you to manage and a rotate a secret. Consider using OIDC as a more secure approach.
 
 Connect to Storage Account with Access Key (default):
 
@@ -468,7 +468,7 @@ data "terraform_remote_state" "foo" {
 
 ### Data Source: Access Key Direct
 
-~> WARNING: This method requires you to manage and a rotate a secret. Consider using OIDC as a more secure approach.
+~> **Warning!**: This method requires you to manage and a rotate a secret. Consider using OIDC as a more secure approach.
 
 ```hcl
 data "terraform_remote_state" "foo" {
@@ -485,7 +485,7 @@ data "terraform_remote_state" "foo" {
 
 ### Data Source: SAS Token
 
-~> WARNING: This method requires you to manage and a rotate a secret. Consider using OIDC as a more secure approach.
+~> **Warning!**: This method requires you to manage and a rotate a secret. Consider using OIDC as a more secure approach.
 
 ```hcl
 data "terraform_remote_state" "foo" {
@@ -502,7 +502,7 @@ data "terraform_remote_state" "foo" {
 
 ## Configuration Variables
 
-!> **Warning:**  We recommend using environment variables to supply credentials and other sensitive data. If you use `-backend-config` or hardcode these values directly in your configuration, Terraform will include these values in both the `.terraform` subdirectory and in plan files. Refer to [Credentials and Sensitive Data](/terraform/language/settings/backends/configuration#credentials-and-sensitive-data) for details.
+!> ****Warning!**:**  We recommend using environment variables to supply credentials and other sensitive data. If you use `-backend-config` or hardcode these values directly in your configuration, Terraform will include these values in both the `.terraform` subdirectory and in plan files. Refer to [Credentials and Sensitive Data](/terraform/language/settings/backends/configuration#credentials-and-sensitive-data) for details.
 
 The following configuration options are supported:
 

--- a/website/docs/language/settings/backends/azurerm.mdx
+++ b/website/docs/language/settings/backends/azurerm.mdx
@@ -384,7 +384,7 @@ data "terraform_remote_state" "foo" {
 
 ### Data Source: Entra ID Service Principal via Client Secret
 
-~> **Warning!**: This method requires you to manage and a rotate a secret. Consider using OIDC as a more secure approach.
+~> **Warning!**: This method requires you to manage and rotate a secret. Consider using OIDC as a more secure approach.
 
 Connect to Storage Account with Access Key (default):
 

--- a/website/docs/language/settings/backends/azurerm.mdx
+++ b/website/docs/language/settings/backends/azurerm.mdx
@@ -29,12 +29,12 @@ The `azurerm` backend supports the following authentication methods to connect t
 
 | Entra ID Authentication Method | Storage Account Authentication Type | Authentication variable * | Entra ID variable |
 |-----|---|---|---|
-| Entra ID User via Azure CLI | Access Key | N/A | N/A |
-| Entra ID User via Azure CLI | Entra ID | N/A | `use_azuread_auth = true` |
-| Entra ID Service Principal via OIDC (Workload identity federation) | Access Key | `use_oidc = true` | N/A |
-| Entra ID Service Principal via OIDC (Workload identity federation) | Entra ID | `use_oidc = true` | `use_azuread_auth = true` |
-| Entra ID Service Principal via Managed identity | Access Key | `use_msi = true` | N/A |
-| Entra ID Service Principal via Managed identity | Entra ID | `use_msi = true` | `use_azuread_auth = true` |
+| Entra ID User Principal via Azure CLI | Access Key | N/A | N/A |
+| Entra ID User Principal via Azure CLI | Entra ID | N/A | `use_azuread_auth = true` |
+| Entra ID Service Principal or User Assigned Managed Identity via OIDC (Workload identity federation) | Access Key | `use_oidc = true` | N/A |
+| Entra ID Service Principal or User Assigned Managed Identity via OIDC (Workload identity federation) | Entra ID | `use_oidc = true` | `use_azuread_auth = true` |
+| Entra ID Managed Identity Principal | Access Key | `use_msi = true` | N/A |
+| Entra ID Managed Identity Principal | Entra ID | `use_msi = true` | `use_azuread_auth = true` |
 | Entra ID Service Principal via Client Secret | Access Key | `client_secret = <service principal secret>` | N/A |
 | Entra ID Service Principal via Client Secret | Entra ID | `client_secret = <service principal secret>` | `use_azuread_auth = true` |
 | Entra ID Service Principal via Client Certificate | Access Key | `client_certificate_path = <cert path>` | N/A |
@@ -48,9 +48,9 @@ The `azurerm` backend supports the following authentication methods to connect t
 
 ## Example Backend Configurations
 
-### Backend Entra ID via Azure CLI
+### Backend: Entra ID User via Azure CLI
 
-Access Key (default):
+Connect to Storage Account with Access Key (default):
 
 ```hcl
 terraform {
@@ -63,7 +63,7 @@ terraform {
 }
 ```
 
-Entra ID:
+Connect to Storage Account with Entra ID:
 
 ```hcl
 terraform {
@@ -77,9 +77,11 @@ terraform {
 }
 ```
 
-### Backend Entra ID via OIDC (Workload identity federation)
+### Backend: Entra ID Service Principal or User Assigned Managed Identity via OIDC (Workload identity federation)
 
-Access Key (default):
+You can use an App Registration (Service Principal) or a User Assigned Managed Identity to configure federated credentials. You must supply the client id of the principal.
+
+Connect to Storage Account with Access Key (default):
 
 ```hcl
 terraform {
@@ -96,7 +98,7 @@ terraform {
 }
 ```
 
-Entra ID:
+Connect to Storage Account with Entra ID:
 
 ```hcl
 terraform {
@@ -114,9 +116,11 @@ terraform {
 }
 ```
 
-### Backend Entra ID via Managed identity
+### Backend: Entra ID Managed Identity Principal
 
-Access Key (default):
+You can use a User Assigned Managed Identity as well as a System Assigned Managed Identity on your agent / runner compute. However the authentication does not support specifiying the Client ID of the User Assigned Managed Identity, so you can only supply one per compute instance.
+
+Connect to Storage Account with Access Key (default):
 
 ```hcl
 terraform {
@@ -132,7 +136,7 @@ terraform {
 }
 ```
 
-Entra ID:
+Connect to Storage Account with Entra ID:
 
 ```hcl
 terraform {
@@ -149,9 +153,9 @@ terraform {
 }
 ```
 
-### Backend Entra ID via Client Secret
+### Backend: Entra ID Service Principal via Client Secret
 
-Access Key (default):
+Connect to Storage Account with Access Key (default):
 
 ```hcl
 terraform {
@@ -168,7 +172,7 @@ terraform {
 }
 ```
 
-Entra ID:
+Connect to Storage Account with Entra ID:
 
 ```hcl
 terraform {
@@ -186,9 +190,9 @@ terraform {
 }
 ```
 
-### Backend Entra ID via Client Certificate
+### Backend: Entra ID Service Principal via Client Certificate
 
-Access Key (default):
+Connect to Storage Account with Access Key (default):
 
 ```hcl
 terraform {
@@ -206,7 +210,7 @@ terraform {
 }
 ```
 
-Entra ID:
+Connect to Storage Account with Entra ID:
 
 ```hcl
 terraform {
@@ -225,7 +229,7 @@ terraform {
 }
 ```
 
-### Backend Access Key Direct
+### Backend: Access Key Direct
 
 ```hcl
 terraform {
@@ -239,7 +243,7 @@ terraform {
 }
 ```
 
-### Backend SAS Token
+### Backend: SAS Token
 
 ```hcl
 terraform {
@@ -255,9 +259,9 @@ terraform {
 
 ## Example Data Source Configurations
 
-### Data Source Entra ID via Azure CLI
+### Data Source: Entra ID User Principal via Azure CLI
 
-Access Key (default):
+Connect to Storage Account with Access Key (default):
 
 ```hcl
 data "terraform_remote_state" "foo" {
@@ -271,7 +275,7 @@ data "terraform_remote_state" "foo" {
 }
 ```
 
-Entra ID:
+Connect to Storage Account with Entra ID:
 
 ```hcl
 data "terraform_remote_state" "foo" {
@@ -286,9 +290,11 @@ data "terraform_remote_state" "foo" {
 }
 ```
 
-### Data Source Entra ID via OIDC (Workload identity federation)
+### Data Source: Entra ID Service Principal or User Assigned Managed Identity via OIDC (Workload identity federation)
 
-Access Key (default):
+You can use an App Registration (Service Principal) or a User Assigned Managed Identity to configure federated credentials. You must supply the client id of the principal.
+
+Connect to Storage Account with Access Key (default):
 
 ```hcl
 data "terraform_remote_state" "foo" {
@@ -306,7 +312,7 @@ data "terraform_remote_state" "foo" {
 }
 ```
 
-Entra ID:
+Connect to Storage Account with Entra ID:
 
 ```hcl
 data "terraform_remote_state" "foo" {
@@ -325,9 +331,11 @@ data "terraform_remote_state" "foo" {
 }
 ```
 
-### Data Source Entra ID via Managed identity
+### Data Source: Entra ID Managed Identity Principal
 
-Access Key (default):
+You can use a User Assigned Managed Identity as well as a System Assigned Managed Identity on your agent / runner compute. However the authentication does not support specifiying the Client ID of the User Assigned Managed Identity, so you can only supply one per compute instance.
+
+Connect to Storage Account with Access Key (default):
 
 ```hcl
 data "terraform_remote_state" "foo" {
@@ -344,7 +352,7 @@ data "terraform_remote_state" "foo" {
 }
 ```
 
-Entra ID:
+Connect to Storage Account with Entra ID:
 
 ```hcl
 data "terraform_remote_state" "foo" {
@@ -362,9 +370,9 @@ data "terraform_remote_state" "foo" {
 }
 ```
 
-### Data Source Entra ID via Client Secret
+### Data Source: Entra ID Service Principal via Client Secret
 
-Access Key (default):
+Connect to Storage Account with Access Key (default):
 
 ```hcl
 data "terraform_remote_state" "foo" {
@@ -382,7 +390,7 @@ data "terraform_remote_state" "foo" {
 }
 ```
 
-Entra ID:
+Connect to Storage Account with Entra ID:
 
 ```hcl
 data "terraform_remote_state" "foo" {
@@ -401,9 +409,9 @@ data "terraform_remote_state" "foo" {
 }
 ```
 
-### Data Source Entra ID via Client Certificate
+### Data Source: Entra ID Service Principal via Client Certificate
 
-Access Key (default):
+Connect to Storage Account with Access Key (default):
 
 ```hcl
 data "terraform_remote_state" "foo" {
@@ -422,7 +430,7 @@ data "terraform_remote_state" "foo" {
 }
 ```
 
-Entra ID:
+Connect to Storage Account with Entra ID:
 
 ```hcl
 data "terraform_remote_state" "foo" {
@@ -442,7 +450,7 @@ data "terraform_remote_state" "foo" {
 }
 ```
 
-### Data Source Access Key Direct
+### Data Source: Access Key Direct
 
 ```hcl
 data "terraform_remote_state" "foo" {
@@ -457,7 +465,7 @@ data "terraform_remote_state" "foo" {
 }
 ```
 
-### Data Source SAS Token
+### Data Source: SAS Token
 
 ```hcl
 data "terraform_remote_state" "foo" {

--- a/website/docs/language/settings/backends/azurerm.mdx
+++ b/website/docs/language/settings/backends/azurerm.mdx
@@ -157,7 +157,7 @@ terraform {
 
 ### Backend: Entra ID Service Principal via Client Secret
 
-~> **Warning!**: This method requires you to manage and a rotate a secret. Consider using OIDC as a more secure approach.
+~> **Warning!**: This method requires you to manage and rotate a secret. Consider using OIDC as a more secure approach.
 
 Connect to Storage Account with Access Key (default):
 

--- a/website/docs/language/settings/backends/azurerm.mdx
+++ b/website/docs/language/settings/backends/azurerm.mdx
@@ -237,7 +237,7 @@ terraform {
 
 ### Backend: Access Key Direct
 
-~> **Warning!**: This method requires you to manage and a rotate a secret. Consider using OIDC as a more secure approach.
+~> **Warning!**: This method requires you to manage and rotate a secret. Consider using OIDC as a more secure approach.
 
 ```hcl
 terraform {

--- a/website/docs/language/settings/backends/azurerm.mdx
+++ b/website/docs/language/settings/backends/azurerm.mdx
@@ -485,7 +485,7 @@ data "terraform_remote_state" "foo" {
 
 ### Data Source: SAS Token
 
-~> **Warning!**: This method requires you to manage and a rotate a secret. Consider using OIDC as a more secure approach.
+~> **Warning!**: This method requires you to manage and rotate a secret. Consider using OIDC as a more secure approach.
 
 ```hcl
 data "terraform_remote_state" "foo" {

--- a/website/docs/language/settings/backends/azurerm.mdx
+++ b/website/docs/language/settings/backends/azurerm.mdx
@@ -46,9 +46,9 @@ The `azurerm` backend supports the following authentication methods to connect t
 
 -> NOTE: In the table we show the variable passed as it would be hard coded. Variables can and should be passed via environment variables or partial config flags in the `init` command of the CLI.
 
-## Example Configurations
+## Example Backend Configurations
 
-### Entra ID via Azure CLI
+### Backend Entra ID via Azure CLI
 
 Access Key (default):
 
@@ -77,7 +77,7 @@ terraform {
 }
 ```
 
-### Entra ID via OIDC (Workload identity federation):
+### Backend Entra ID via OIDC (Workload identity federation)
 
 Access Key (default):
 
@@ -114,7 +114,7 @@ terraform {
 }
 ```
 
-### Entra ID via Managed identity:
+### Backend Entra ID via Managed identity
 
 Access Key (default):
 
@@ -149,7 +149,7 @@ terraform {
 }
 ```
 
-### Entra ID via Client Secret:
+### Backend Entra ID via Client Secret
 
 Access Key (default):
 
@@ -186,7 +186,7 @@ terraform {
 }
 ```
 
-### Entra ID via Client Certificate:
+### Backend Entra ID via Client Certificate
 
 Access Key (default):
 
@@ -225,7 +225,7 @@ terraform {
 }
 ```
 
-### Access Key direct
+### Backend Access Key Direct
 
 ```hcl
 terraform {
@@ -239,7 +239,7 @@ terraform {
 }
 ```
 
-### SAS Token
+### Backend SAS Token
 
 ```hcl
 terraform {
@@ -253,9 +253,9 @@ terraform {
 }
 ```
 
-## Data Source Configuration
+## Example Data Source Configurations
 
-### Entra ID via Azure CLI
+### Data Source Entra ID via Azure CLI
 
 Access Key (default):
 
@@ -286,7 +286,7 @@ data "terraform_remote_state" "foo" {
 }
 ```
 
-### Entra ID via OIDC (Workload identity federation):
+### Data Source Entra ID via OIDC (Workload identity federation)
 
 Access Key (default):
 
@@ -325,7 +325,7 @@ data "terraform_remote_state" "foo" {
 }
 ```
 
-### Entra ID via Managed identity:
+### Data Source Entra ID via Managed identity
 
 Access Key (default):
 
@@ -362,7 +362,7 @@ data "terraform_remote_state" "foo" {
 }
 ```
 
-### Entra ID via Client Secret:
+### Data Source Entra ID via Client Secret
 
 Access Key (default):
 
@@ -401,7 +401,7 @@ data "terraform_remote_state" "foo" {
 }
 ```
 
-### Entra ID via Client Certificate:
+### Data Source Entra ID via Client Certificate
 
 Access Key (default):
 
@@ -442,7 +442,7 @@ data "terraform_remote_state" "foo" {
 }
 ```
 
-### Access Key direct
+### Data Source Access Key Direct
 
 ```hcl
 data "terraform_remote_state" "foo" {
@@ -457,7 +457,7 @@ data "terraform_remote_state" "foo" {
 }
 ```
 
-### SAS Token
+### Data Source SAS Token
 
 ```hcl
 data "terraform_remote_state" "foo" {
@@ -475,7 +475,6 @@ data "terraform_remote_state" "foo" {
 ## Configuration Variables
 
 !> **Warning:**  We recommend using environment variables to supply credentials and other sensitive data. If you use `-backend-config` or hardcode these values directly in your configuration, Terraform will include these values in both the `.terraform` subdirectory and in plan files. Refer to [Credentials and Sensitive Data](/terraform/language/settings/backends/configuration#credentials-and-sensitive-data) for details.
-
 
 The following configuration options are supported:
 

--- a/website/docs/language/settings/backends/azurerm.mdx
+++ b/website/docs/language/settings/backends/azurerm.mdx
@@ -468,7 +468,7 @@ data "terraform_remote_state" "foo" {
 
 ### Data Source: Access Key Direct
 
-~> **Warning!**: This method requires you to manage and a rotate a secret. Consider using OIDC as a more secure approach.
+~> **Warning!**: This method requires you to manage and rotate a secret. Consider using OIDC as a more secure approach.
 
 ```hcl
 data "terraform_remote_state" "foo" {

--- a/website/docs/language/settings/backends/azurerm.mdx
+++ b/website/docs/language/settings/backends/azurerm.mdx
@@ -425,7 +425,7 @@ data "terraform_remote_state" "foo" {
 
 ### Data Source: Entra ID Service Principal via Client Certificate
 
-~> **Warning!**: This method requires you to manage and a rotate a secret. Consider using OIDC as a more secure approach.
+~> **Warning!**: This method requires you to manage and rotate a secret. Consider using OIDC as a more secure approach.
 
 Connect to Storage Account with Access Key (default):
 

--- a/website/docs/language/settings/backends/azurerm.mdx
+++ b/website/docs/language/settings/backends/azurerm.mdx
@@ -57,10 +57,10 @@ Connect to Storage Account with Access Key (default):
 ```hcl
 terraform {
   backend "azurerm" {
-    resource_group_name  = "StorageAccount-ResourceGroup"  # Can be passed via `-backend-config=`"resource_group_name=<resource group name>"` in the `init` command.
-    storage_account_name = "abcd1234"  # Can be passed via `-backend-config=`"storage_account_name=<storage account name>"` in the `init` command.
-    container_name       = "tfstate"  # Can be passed via `-backend-config=`"container_name=<container name>"` in the `init` command.
-    key                  = "prod.terraform.tfstate"  # Can be passed via `-backend-config=`"key=<blob key name>"` in the `init` command.
+    resource_group_name  = "rg-tfstate-001"  # Can be passed via `-backend-config=`"resource_group_name=<resource group name>"` in the `init` command.
+    storage_account_name = "stotfstate001"  # Can be passed via `-backend-config=`"storage_account_name=<storage account name>"` in the `init` command.
+    container_name       = "prod"  # Can be passed via `-backend-config=`"container_name=<container name>"` in the `init` command.
+    key                  = "terraform.tfstate"  # Can be passed via `-backend-config=`"key=<blob key name>"` in the `init` command.
   }
 }
 ```
@@ -70,10 +70,10 @@ Connect to Storage Account with Entra ID:
 ```hcl
 terraform {
   backend "azurerm" {
-    resource_group_name  = "StorageAccount-ResourceGroup"  # Can be passed via `-backend-config=`"resource_group_name=<resource group name>"` in the `init` command.
-    storage_account_name = "abcd1234"  # Can be passed via `-backend-config=`"storage_account_name=<storage account name>"` in the `init` command.
-    container_name       = "tfstate"  # Can be passed via `-backend-config=`"container_name=<container name>"` in the `init` command.
-    key                  = "prod.terraform.tfstate"  # Can be passed via `-backend-config=`"key=<blob key name>"` in the `init` command.
+    resource_group_name  = "rg-tfstate-001"  # Can be passed via `-backend-config=`"resource_group_name=<resource group name>"` in the `init` command.
+    storage_account_name = "stotfstate001"  # Can be passed via `-backend-config=`"storage_account_name=<storage account name>"` in the `init` command.
+    container_name       = "prod"  # Can be passed via `-backend-config=`"container_name=<container name>"` in the `init` command.
+    key                  = "terraform.tfstate"  # Can be passed via `-backend-config=`"key=<blob key name>"` in the `init` command.
     use_azuread_auth     = true  # Can also be set via `USE_AZURE_AD` environment variable.
   }
 }
@@ -88,10 +88,10 @@ Connect to Storage Account with Access Key (default):
 ```hcl
 terraform {
   backend "azurerm" {
-    resource_group_name  = "StorageAccount-ResourceGroup"  # Can be passed via `-backend-config=`"resource_group_name=<resource group name>"` in the `init` command.
-    storage_account_name = "abcd1234"  # Can be passed via `-backend-config=`"storage_account_name=<storage account name>"` in the `init` command.
-    container_name       = "tfstate"  # Can be passed via `-backend-config=`"container_name=<container name>"` in the `init` command.
-    key                  = "prod.terraform.tfstate"  # Can be passed via `-backend-config=`"key=<blob key name>"` in the `init` command.
+    resource_group_name  = "rg-tfstate-001"  # Can be passed via `-backend-config=`"resource_group_name=<resource group name>"` in the `init` command.
+    storage_account_name = "stotfstate001"  # Can be passed via `-backend-config=`"storage_account_name=<storage account name>"` in the `init` command.
+    container_name       = "prod"  # Can be passed via `-backend-config=`"container_name=<container name>"` in the `init` command.
+    key                  = "terraform.tfstate"  # Can be passed via `-backend-config=`"key=<blob key name>"` in the `init` command.
     use_oidc              = true  # Can also be set via `USE_OIDC` environment variable.
     client_id            = "00000000-0000-0000-0000-000000000000"  # Can also be set via `ARM_CLIENT_ID` environment variable.
     subscription_id      = "00000000-0000-0000-0000-000000000000"  # Can also be set via `ARM_SUBSCRIPTION_ID` environment variable.
@@ -105,10 +105,10 @@ Connect to Storage Account with Entra ID:
 ```hcl
 terraform {
   backend "azurerm" {
-    resource_group_name  = "StorageAccount-ResourceGroup"  # Can be passed via `-backend-config=`"resource_group_name=<resource group name>"` in the `init` command.
-    storage_account_name = "abcd1234"  # Can be passed via `-backend-config=`"storage_account_name=<storage account name>"` in the `init` command.
-    container_name       = "tfstate"  # Can be passed via `-backend-config=`"container_name=<container name>"` in the `init` command.
-    key                  = "prod.terraform.tfstate"  # Can be passed via `-backend-config=`"key=<blob key name>"` in the `init` command.
+    resource_group_name  = "rg-tfstate-001"  # Can be passed via `-backend-config=`"resource_group_name=<resource group name>"` in the `init` command.
+    storage_account_name = "stotfstate001"  # Can be passed via `-backend-config=`"storage_account_name=<storage account name>"` in the `init` command.
+    container_name       = "prod"  # Can be passed via `-backend-config=`"container_name=<container name>"` in the `init` command.
+    key                  = "terraform.tfstate"  # Can be passed via `-backend-config=`"key=<blob key name>"` in the `init` command.
     use_oidc              = true  # Can also be set via `USE_OIDC` environment variable.
     client_id            = "00000000-0000-0000-0000-000000000000"  # Can also be set via `ARM_CLIENT_ID` environment variable.
     subscription_id      = "00000000-0000-0000-0000-000000000000"  # Can also be set via `ARM_SUBSCRIPTION_ID` environment variable.
@@ -127,10 +127,10 @@ Connect to Storage Account with Access Key (default):
 ```hcl
 terraform {
   backend "azurerm" {
-    resource_group_name  = "StorageAccount-ResourceGroup"  # Can be passed via `-backend-config=`"resource_group_name=<resource group name>"` in the `init` command.
-    storage_account_name = "abcd1234"  # Can be passed via `-backend-config=`"storage_account_name=<storage account name>"` in the `init` command.
-    container_name       = "tfstate"  # Can be passed via `-backend-config=`"container_name=<container name>"` in the `init` command.
-    key                  = "prod.terraform.tfstate"  # Can be passed via `-backend-config=`"key=<blob key name>"` in the `init` command.
+    resource_group_name  = "rg-tfstate-001"  # Can be passed via `-backend-config=`"resource_group_name=<resource group name>"` in the `init` command.
+    storage_account_name = "stotfstate001"  # Can be passed via `-backend-config=`"storage_account_name=<storage account name>"` in the `init` command.
+    container_name       = "prod"  # Can be passed via `-backend-config=`"container_name=<container name>"` in the `init` command.
+    key                  = "terraform.tfstate"  # Can be passed via `-backend-config=`"key=<blob key name>"` in the `init` command.
     use_msi              = true  # Can also be set via `USE_MSI` environment variable.
     subscription_id      = "00000000-0000-0000-0000-000000000000"  # Can also be set via `ARM_SUBSCRIPTION_ID` environment variable.
     tenant_id            = "00000000-0000-0000-0000-000000000000"  # Can also be set via `ARM_TENANT_ID` environment variable.
@@ -143,10 +143,10 @@ Connect to Storage Account with Entra ID:
 ```hcl
 terraform {
   backend "azurerm" {
-    resource_group_name  = "StorageAccount-ResourceGroup"  # Can be passed via `-backend-config=`"resource_group_name=<resource group name>"` in the `init` command.
-    storage_account_name = "abcd1234"  # Can be passed via `-backend-config=`"storage_account_name=<storage account name>"` in the `init` command.
-    container_name       = "tfstate"  # Can be passed via `-backend-config=`"container_name=<container name>"` in the `init` command.
-    key                  = "prod.terraform.tfstate"  # Can be passed via `-backend-config=`"key=<blob key name>"` in the `init` command.
+    resource_group_name  = "rg-tfstate-001"  # Can be passed via `-backend-config=`"resource_group_name=<resource group name>"` in the `init` command.
+    storage_account_name = "stotfstate001"  # Can be passed via `-backend-config=`"storage_account_name=<storage account name>"` in the `init` command.
+    container_name       = "prod"  # Can be passed via `-backend-config=`"container_name=<container name>"` in the `init` command.
+    key                  = "terraform.tfstate"  # Can be passed via `-backend-config=`"key=<blob key name>"` in the `init` command.
     use_msi              = true  # Can also be set via `USE_MSI` environment variable.
     subscription_id      = "00000000-0000-0000-0000-000000000000"  # Can also be set via `ARM_SUBSCRIPTION_ID` environment variable.
     tenant_id            = "00000000-0000-0000-0000-000000000000"  # Can also be set via `ARM_TENANT_ID` environment variable.
@@ -164,10 +164,10 @@ Connect to Storage Account with Access Key (default):
 ```hcl
 terraform {
   backend "azurerm" {
-    resource_group_name  = "StorageAccount-ResourceGroup"  # Can be passed via `-backend-config=`"resource_group_name=<resource group name>"` in the `init` command.
-    storage_account_name = "abcd1234"  # Can be passed via `-backend-config=`"storage_account_name=<storage account name>"` in the `init` command.
-    container_name       = "tfstate"  # Can be passed via `-backend-config=`"container_name=<container name>"` in the `init` command.
-    key                  = "prod.terraform.tfstate"  # Can be passed via `-backend-config=`"key=<blob key name>"` in the `init` command.
+    resource_group_name  = "rg-tfstate-001"  # Can be passed via `-backend-config=`"resource_group_name=<resource group name>"` in the `init` command.
+    storage_account_name = "stotfstate001"  # Can be passed via `-backend-config=`"storage_account_name=<storage account name>"` in the `init` command.
+    container_name       = "prod"  # Can be passed via `-backend-config=`"container_name=<container name>"` in the `init` command.
+    key                  = "terraform.tfstate"  # Can be passed via `-backend-config=`"key=<blob key name>"` in the `init` command.
     client_id            = "00000000-0000-0000-0000-000000000000"  # Can also be set via `ARM_CLIENT_ID` environment variable.
     client_secret        = "************************************"  # Can also be set via `ARM_CLIENT_SECRET` environment variable.
     subscription_id      = "00000000-0000-0000-0000-000000000000"  # Can also be set via `ARM_SUBSCRIPTION_ID` environment variable.
@@ -181,10 +181,10 @@ Connect to Storage Account with Entra ID:
 ```hcl
 terraform {
   backend "azurerm" {
-    resource_group_name  = "StorageAccount-ResourceGroup"  # Can be passed via `-backend-config=`"resource_group_name=<resource group name>"` in the `init` command.
-    storage_account_name = "abcd1234"  # Can be passed via `-backend-config=`"storage_account_name=<storage account name>"` in the `init` command.
-    container_name       = "tfstate"  # Can be passed via `-backend-config=`"container_name=<container name>"` in the `init` command.
-    key                  = "prod.terraform.tfstate"  # Can be passed via `-backend-config=`"key=<blob key name>"` in the `init` command.
+    resource_group_name  = "rg-tfstate-001"  # Can be passed via `-backend-config=`"resource_group_name=<resource group name>"` in the `init` command.
+    storage_account_name = "stotfstate001"  # Can be passed via `-backend-config=`"storage_account_name=<storage account name>"` in the `init` command.
+    container_name       = "prod"  # Can be passed via `-backend-config=`"container_name=<container name>"` in the `init` command.
+    key                  = "terraform.tfstate"  # Can be passed via `-backend-config=`"key=<blob key name>"` in the `init` command.
     client_id            = "00000000-0000-0000-0000-000000000000"  # Can also be set via `ARM_CLIENT_ID` environment variable.
     client_secret        = "************************************"  # Can also be set via `ARM_CLIENT_SECRET` environment variable.
     subscription_id      = "00000000-0000-0000-0000-000000000000"  # Can also be set via `ARM_SUBSCRIPTION_ID` environment variable.
@@ -203,10 +203,10 @@ Connect to Storage Account with Access Key (default):
 ```hcl
 terraform {
   backend "azurerm" {
-    resource_group_name         = "StorageAccount-ResourceGroup"  # Can be passed via `-backend-config=`"resource_group_name=<resource group name>"` in the `init` command.
-    storage_account_name        = "abcd1234"  # Can be passed via `-backend-config=`"storage_account_name=<storage account name>"` in the `init` command.
-    container_name              = "tfstate"  # Can be passed via `-backend-config=`"container_name=<container name>"` in the `init` command.
-    key                         = "prod.terraform.tfstate"  # Can be passed via `-backend-config=`"key=<blob key name>"` in the `init` command.
+    resource_group_name         = "rg-tfstate-001"  # Can be passed via `-backend-config=`"resource_group_name=<resource group name>"` in the `init` command.
+    storage_account_name        = "stotfstate001"  # Can be passed via `-backend-config=`"storage_account_name=<storage account name>"` in the `init` command.
+    container_name              = "prod"  # Can be passed via `-backend-config=`"container_name=<container name>"` in the `init` command.
+    key                         = "terraform.tfstate"  # Can be passed via `-backend-config=`"key=<blob key name>"` in the `init` command.
     client_id                   = "00000000-0000-0000-0000-000000000000"  # Can also be set via `ARM_CLIENT_ID` environment variable.
     client_certificate_path     = "./cert.pfx"  # Can also be set via `ARM_CLIENT_CERTIFICATE_PATH` environment variable.
     client_certificate_password = "************************************"  # Can also be set via `ARM_CLIENT_CERTIFICATE_PASSWORD` environment variable.
@@ -221,10 +221,10 @@ Connect to Storage Account with Entra ID:
 ```hcl
 terraform {
   backend "azurerm" {
-    resource_group_name         = "StorageAccount-ResourceGroup"  # Can be passed via `-backend-config=`"resource_group_name=<resource group name>"` in the `init` command.
-    storage_account_name        = "abcd1234"  # Can be passed via `-backend-config=`"storage_account_name=<storage account name>"` in the `init` command.
-    container_name              = "tfstate"  # Can be passed via `-backend-config=`"container_name=<container name>"` in the `init` command.
-    key                         = "prod.terraform.tfstate"  # Can be passed via `-backend-config=`"key=<blob key name>"` in the `init` command.
+    resource_group_name         = "rg-tfstate-001"  # Can be passed via `-backend-config=`"resource_group_name=<resource group name>"` in the `init` command.
+    storage_account_name        = "stotfstate001"  # Can be passed via `-backend-config=`"storage_account_name=<storage account name>"` in the `init` command.
+    container_name              = "prod"  # Can be passed via `-backend-config=`"container_name=<container name>"` in the `init` command.
+    key                         = "terraform.tfstate"  # Can be passed via `-backend-config=`"key=<blob key name>"` in the `init` command.
     client_id                   = "00000000-0000-0000-0000-000000000000"  # Can also be set via `ARM_CLIENT_ID` environment variable.
     client_certificate_path     = "./cert.pfx"  # Can also be set via `ARM_CLIENT_CERTIFICATE_PATH` environment variable.
     client_certificate_password = "************************************"  # Can also be set via `ARM_CLIENT_CERTIFICATE_PASSWORD` environment variable.
@@ -242,10 +242,10 @@ terraform {
 ```hcl
 terraform {
   backend "azurerm" {
-    resource_group_name  = "StorageAccount-ResourceGroup"  # Can be passed via `-backend-config=`"resource_group_name=<resource group name>"` in the `init` command.
-    storage_account_name = "abcd1234"  # Can be passed via `-backend-config=`"storage_account_name=<storage account name>"` in the `init` command.
-    container_name       = "tfstate"  # Can be passed via `-backend-config=`"container_name=<container name>"` in the `init` command.
-    key                  = "prod.terraform.tfstate"  # Can be passed via `-backend-config=`"key=<blob key name>"` in the `init` command.
+    resource_group_name  = "rg-tfstate-001"  # Can be passed via `-backend-config=`"resource_group_name=<resource group name>"` in the `init` command.
+    storage_account_name = "stotfstate001"  # Can be passed via `-backend-config=`"storage_account_name=<storage account name>"` in the `init` command.
+    container_name       = "prod"  # Can be passed via `-backend-config=`"container_name=<container name>"` in the `init` command.
+    key                  = "terraform.tfstate"  # Can be passed via `-backend-config=`"key=<blob key name>"` in the `init` command.
     access_key           = "abcdefghijklmnopqrstuvwxyz0123456789..."  # Can also be set via `ARM_ACCESS_KEY` environment variable.
   }
 }
@@ -258,10 +258,10 @@ terraform {
 ```hcl
 terraform {
   backend "azurerm" {
-    resource_group_name  = "StorageAccount-ResourceGroup"  # Can be passed via `-backend-config=`"resource_group_name=<resource group name>"` in the `init` command.
-    storage_account_name = "abcd1234"  # Can be passed via `-backend-config=`"storage_account_name=<storage account name>"` in the `init` command.
-    container_name       = "tfstate"  # Can be passed via `-backend-config=`"container_name=<container name>"` in the `init` command.
-    key                  = "prod.terraform.tfstate"  # Can be passed via `-backend-config=`"key=<blob key name>"` in the `init` command.
+    resource_group_name  = "rg-tfstate-001"  # Can be passed via `-backend-config=`"resource_group_name=<resource group name>"` in the `init` command.
+    storage_account_name = "stotfstate001"  # Can be passed via `-backend-config=`"storage_account_name=<storage account name>"` in the `init` command.
+    container_name       = "prod"  # Can be passed via `-backend-config=`"container_name=<container name>"` in the `init` command.
+    key                  = "terraform.tfstate"  # Can be passed via `-backend-config=`"key=<blob key name>"` in the `init` command.
     sas_token            = "abcdefghijklmnopqrstuvwxyz0123456789..."  # Can also be set via `ARM_SAS_TOKEN` environment variable.
   }
 }
@@ -279,10 +279,10 @@ Connect to Storage Account with Access Key (default):
 data "terraform_remote_state" "foo" {
   backend = "azurerm"
   config = {
-    resource_group_name  = "StorageAccount-ResourceGroup"
-    storage_account_name = "abcd1234"
-    container_name       = "tfstate"
-    key                  = "prod.terraform.tfstate"
+    resource_group_name  = "rg-tfstate-001"
+    storage_account_name = "stotfstate001"
+    container_name       = "prod"
+    key                  = "terraform.tfstate"
   }
 }
 ```
@@ -293,10 +293,10 @@ Connect to Storage Account with Entra ID:
 data "terraform_remote_state" "foo" {
   backend = "azurerm"
   config = {
-    resource_group_name  = "StorageAccount-ResourceGroup"
-    storage_account_name = "abcd1234"
-    container_name       = "tfstate"
-    key                  = "prod.terraform.tfstate"
+    resource_group_name  = "rg-tfstate-001"
+    storage_account_name = "stotfstate001"
+    container_name       = "prod"
+    key                  = "terraform.tfstate"
     use_azuread_auth     = true  # Can also be set via `USE_AZURE_AD` environment variable.
   }
 }
@@ -312,10 +312,10 @@ Connect to Storage Account with Access Key (default):
 data "terraform_remote_state" "foo" {
   backend = "azurerm"
   config = {
-    resource_group_name  = "StorageAccount-ResourceGroup"
-    storage_account_name = "abcd1234"
-    container_name       = "tfstate"
-    key                  = "prod.terraform.tfstate"
+    resource_group_name  = "rg-tfstate-001"
+    storage_account_name = "stotfstate001"
+    container_name       = "prod"
+    key                  = "terraform.tfstate"
     use_oidc             = true  # Can also be set via `USE_OIDC` environment variable.
     client_id            = "00000000-0000-0000-0000-000000000000"  # Can also be set via `ARM_CLIENT_ID` environment variable.
     subscription_id      = "00000000-0000-0000-0000-000000000000"  # Can also be set via `ARM_SUBSCRIPTION_ID` environment variable.
@@ -330,10 +330,10 @@ Connect to Storage Account with Entra ID:
 data "terraform_remote_state" "foo" {
   backend = "azurerm"
   config = {
-    resource_group_name  = "StorageAccount-ResourceGroup"
-    storage_account_name = "abcd1234"
-    container_name       = "tfstate"
-    key                  = "prod.terraform.tfstate"
+    resource_group_name  = "rg-tfstate-001"
+    storage_account_name = "stotfstate001"
+    container_name       = "prod"
+    key                  = "terraform.tfstate"
     use_oidc             = true  # Can also be set via `USE_OIDC` environment variable.
     client_id            = "00000000-0000-0000-0000-000000000000"  # Can also be set via `ARM_CLIENT_ID` environment variable.
     subscription_id      = "00000000-0000-0000-0000-000000000000"  # Can also be set via `ARM_SUBSCRIPTION_ID` environment variable.
@@ -353,10 +353,10 @@ Connect to Storage Account with Access Key (default):
 data "terraform_remote_state" "foo" {
   backend = "azurerm"
   config = {
-    resource_group_name  = "StorageAccount-ResourceGroup"
-    storage_account_name = "abcd1234"
-    container_name       = "tfstate"
-    key                  = "prod.terraform.tfstate"
+    resource_group_name  = "rg-tfstate-001"
+    storage_account_name = "stotfstate001"
+    container_name       = "prod"
+    key                  = "terraform.tfstate"
     use_msi              = true  # Can also be set via `USE_MSI` environment variable.
     subscription_id      = "00000000-0000-0000-0000-000000000000"  # Can also be set via `ARM_SUBSCRIPTION_ID` environment variable.
     tenant_id            = "00000000-0000-0000-0000-000000000000"  # Can also be set via `ARM_TENANT_ID` environment variable.
@@ -370,10 +370,10 @@ Connect to Storage Account with Entra ID:
 data "terraform_remote_state" "foo" {
   backend = "azurerm"
   config = {
-    resource_group_name  = "StorageAccount-ResourceGroup"
-    storage_account_name = "abcd1234"
-    container_name       = "tfstate"
-    key                  = "prod.terraform.tfstate"
+    resource_group_name  = "rg-tfstate-001"
+    storage_account_name = "stotfstate001"
+    container_name       = "prod"
+    key                  = "terraform.tfstate"
     use_msi              = true  # Can also be set via `USE_MSI` environment variable.
     subscription_id      = "00000000-0000-0000-0000-000000000000"  # Can also be set via `ARM_SUBSCRIPTION_ID` environment variable.
     tenant_id            = "00000000-0000-0000-0000-000000000000"  # Can also be set via `ARM_TENANT_ID` environment variable.
@@ -392,10 +392,10 @@ Connect to Storage Account with Access Key (default):
 data "terraform_remote_state" "foo" {
   backend = "azurerm"
   config = {
-    resource_group_name  = "StorageAccount-ResourceGroup"
-    storage_account_name = "abcd1234"
-    container_name       = "tfstate"
-    key                  = "prod.terraform.tfstate"
+    resource_group_name  = "rg-tfstate-001"
+    storage_account_name = "stotfstate001"
+    container_name       = "prod"
+    key                  = "terraform.tfstate"
     client_id            = "00000000-0000-0000-0000-000000000000"  # Can also be set via `ARM_CLIENT_ID` environment variable.
     client_secret        = "************************************"  # Can also be set via `ARM_CLIENT_SECRET` environment variable.
     subscription_id      = "00000000-0000-0000-0000-000000000000"  # Can also be set via `ARM_SUBSCRIPTION_ID` environment variable.
@@ -410,10 +410,10 @@ Connect to Storage Account with Entra ID:
 data "terraform_remote_state" "foo" {
   backend = "azurerm"
   config = {
-    resource_group_name  = "StorageAccount-ResourceGroup"
-    storage_account_name = "abcd1234"
-    container_name       = "tfstate"
-    key                  = "prod.terraform.tfstate"
+    resource_group_name  = "rg-tfstate-001"
+    storage_account_name = "stotfstate001"
+    container_name       = "prod"
+    key                  = "terraform.tfstate"
     client_id            = "00000000-0000-0000-0000-000000000000"  # Can also be set via `ARM_CLIENT_ID` environment variable.
     client_secret        = "************************************"  # Can also be set via `ARM_CLIENT_SECRET` environment variable.
     subscription_id      = "00000000-0000-0000-0000-000000000000"  # Can also be set via `ARM_SUBSCRIPTION_ID` environment variable.
@@ -433,10 +433,10 @@ Connect to Storage Account with Access Key (default):
 data "terraform_remote_state" "foo" {
   backend = "azurerm"
   config = {
-    resource_group_name  = "StorageAccount-ResourceGroup"
-    storage_account_name = "abcd1234"
-    container_name       = "tfstate"
-    key                  = "prod.terraform.tfstate"
+    resource_group_name  = "rg-tfstate-001"
+    storage_account_name = "stotfstate001"
+    container_name       = "prod"
+    key                  = "terraform.tfstate"
     client_id                   = "00000000-0000-0000-0000-000000000000"  # Can also be set via `ARM_CLIENT_ID` environment variable.
     client_certificate_path     = "./cert.pfx"  # Can also be set via `ARM_CLIENT_CERTIFICATE_PATH` environment variable.
     client_certificate_password = "************************************"  # Can also be set via `ARM_CLIENT_CERTIFICATE_PASSWORD` environment variable.
@@ -452,10 +452,10 @@ Connect to Storage Account with Entra ID:
 data "terraform_remote_state" "foo" {
   backend = "azurerm"
   config = {
-    resource_group_name  = "StorageAccount-ResourceGroup"
-    storage_account_name = "abcd1234"
-    container_name       = "tfstate"
-    key                  = "prod.terraform.tfstate"
+    resource_group_name  = "rg-tfstate-001"
+    storage_account_name = "stotfstate001"
+    container_name       = "prod"
+    key                  = "terraform.tfstate"
     client_id                   = "00000000-0000-0000-0000-000000000000"  # Can also be set via `ARM_CLIENT_ID` environment variable.
     client_certificate_path     = "./cert.pfx"  # Can also be set via `ARM_CLIENT_CERTIFICATE_PATH` environment variable.
     client_certificate_password = "************************************"  # Can also be set via `ARM_CLIENT_CERTIFICATE_PASSWORD` environment variable.
@@ -474,10 +474,10 @@ data "terraform_remote_state" "foo" {
 data "terraform_remote_state" "foo" {
   backend = "azurerm"
   config = {
-    resource_group_name  = "StorageAccount-ResourceGroup"
-    storage_account_name = "abcd1234"
-    container_name       = "tfstate"
-    key                  = "prod.terraform.tfstate"
+    resource_group_name  = "rg-tfstate-001"
+    storage_account_name = "stotfstate001"
+    container_name       = "prod"
+    key                  = "terraform.tfstate"
     access_key           = "abcdefghijklmnopqrstuvwxyz0123456789..."  # Can also be set via `ARM_ACCESS_KEY` environment variable.
   }
 }
@@ -491,10 +491,10 @@ data "terraform_remote_state" "foo" {
 data "terraform_remote_state" "foo" {
   backend = "azurerm"
   config = {
-    resource_group_name  = "StorageAccount-ResourceGroup"
-    storage_account_name = "abcd1234"
-    container_name       = "tfstate"
-    key                  = "prod.terraform.tfstate"
+    resource_group_name  = "rg-tfstate-001"
+    storage_account_name = "stotfstate001"
+    container_name       = "prod"
+    key                  = "terraform.tfstate"
     sas_token            = "abcdefghijklmnopqrstuvwxyz0123456789..."  # Can also be set via `ARM_SAS_TOKEN` environment variable.
   }
 }

--- a/website/docs/language/settings/backends/azurerm.mdx
+++ b/website/docs/language/settings/backends/azurerm.mdx
@@ -19,7 +19,7 @@ The `azurerm` backend supports 3 methods of authenticating to the storage accoun
 - **Entra ID**
 - **SAS Token**
 
-The **Access Key** method can be used directly or in combination with an Entra ID principal (e.g. user, service principal or managed identity). By default when you use an Entra ID principal, it will use the Access Token of that principal to generate an Access Key for the storage account and use that Access Key to authenticate to the state file blob. To use an Access Key directly you must generate one for you state file blob and pass it to the backend config.
+The **Access Key** method can be used directly or in combination with an Entra ID principal (e.g. user, service principal or managed identity). By default when you use an Entra ID principal, it will use the Access Token of that principal to generate an Access Key for the storage account and use that Access Key to authenticate to the state file blob. To use an Access Key directly you must generate one for your state file blob and pass it to the backend config.
 
 The **Entra ID** method can only be used in combination with an Entra ID principal. To use the Entra ID method you must set the `use_azuread_auth` variable to `true` in your backend configuration. This will cause the backend to use the Access Token of the Entra ID principal to authenticate to the state file blob.
 

--- a/website/docs/language/settings/backends/azurerm.mdx
+++ b/website/docs/language/settings/backends/azurerm.mdx
@@ -41,9 +41,9 @@ The `azurerm` backend supports the following authentication methods to connect t
 | Access Key direct | Access Key | `access_key = <access key>` | N/A |
 | SAS Key direct | SAS Token | `sas_token = <sas token>` | N/A |
 
-> * = We provide a single variable here, but there is usually more than one required for successful authentication. The variable we show is the one that triggers the backend to use that authentication type.
+-> * = We provide a single variable here, but there is usually more than one required for successful authentication. The variable we show is the one that triggers the backend to use that authentication type. You can see examples of each option below.
 
-> NOTE: In the table we show the variable passed as it would be hard coded. Variables can and should be passed via environment variables or partial config flags in the `init` command of the CLI.
+-> NOTE: In the table we show the variable passed as it would be hard coded. Variables can and should be passed via environment variables or partial config flags in the `init` command of the CLI.
 
 ## Example Configurations
 

--- a/website/docs/language/settings/backends/azurerm.mdx
+++ b/website/docs/language/settings/backends/azurerm.mdx
@@ -11,7 +11,7 @@ This backend supports state locking and consistency checking with Azure Blob Sto
 
 ~> **Terraform 1.1 and 1.2 supported a feature-flag to allow enabling/disabling the use of Microsoft Graph (and MSAL) rather than Azure Active Directory Graph (and ADAL) - however this flag has since been removed in Terraform 1.3. Microsoft Graph (and MSAL) are now enabled by default and Azure Active Directory Graph (and ADAL) can no longer be used.
 
-## Authentication
+## Authentication4
 
 The `azurerm` backend supports 3 methods of authenticating to the storage account:
 
@@ -28,6 +28,7 @@ The SAS Token method can only be used directly.
 The `azurerm` backend supports the following authentication methods to connect the storage account based on the variables that are set:
 
 | Entra ID Authentication Method | Storage Account Authentication Type | Authentication variable * | Entra ID variable |
+|-----|---|---|---|
 | Entra ID User via Azure CLI | Access Key | N/A | N/A |
 | Entra ID User via Azure CLI | Entra ID | N/A | `use_azuread_auth = true` |
 | Entra ID Service Principal via OIDC (Workload identity federation) | Access Key | `use_oidc = true` | N/A |

--- a/website/docs/language/settings/backends/azurerm.mdx
+++ b/website/docs/language/settings/backends/azurerm.mdx
@@ -157,6 +157,8 @@ terraform {
 
 ### Backend: Entra ID Service Principal via Client Secret
 
+~> WARNING: This method requires you to manage and a rotate a secret. Consider using OIDC as a more secure approach.
+
 Connect to Storage Account with Access Key (default):
 
 ```hcl
@@ -193,6 +195,8 @@ terraform {
 ```
 
 ### Backend: Entra ID Service Principal via Client Certificate
+
+~> WARNING: This method requires you to manage and a rotate a secret. Consider using OIDC as a more secure approach.
 
 Connect to Storage Account with Access Key (default):
 
@@ -233,6 +237,8 @@ terraform {
 
 ### Backend: Access Key Direct
 
+~> WARNING: This method requires you to manage and a rotate a secret. Consider using OIDC as a more secure approach.
+
 ```hcl
 terraform {
   backend "azurerm" {
@@ -246,6 +252,8 @@ terraform {
 ```
 
 ### Backend: SAS Token
+
+~> WARNING: This method requires you to manage and a rotate a secret. Consider using OIDC as a more secure approach.
 
 ```hcl
 terraform {
@@ -376,6 +384,8 @@ data "terraform_remote_state" "foo" {
 
 ### Data Source: Entra ID Service Principal via Client Secret
 
+~> WARNING: This method requires you to manage and a rotate a secret. Consider using OIDC as a more secure approach.
+
 Connect to Storage Account with Access Key (default):
 
 ```hcl
@@ -414,6 +424,8 @@ data "terraform_remote_state" "foo" {
 ```
 
 ### Data Source: Entra ID Service Principal via Client Certificate
+
+~> WARNING: This method requires you to manage and a rotate a secret. Consider using OIDC as a more secure approach.
 
 Connect to Storage Account with Access Key (default):
 
@@ -456,6 +468,8 @@ data "terraform_remote_state" "foo" {
 
 ### Data Source: Access Key Direct
 
+~> WARNING: This method requires you to manage and a rotate a secret. Consider using OIDC as a more secure approach.
+
 ```hcl
 data "terraform_remote_state" "foo" {
   backend = "azurerm"
@@ -470,6 +484,8 @@ data "terraform_remote_state" "foo" {
 ```
 
 ### Data Source: SAS Token
+
+~> WARNING: This method requires you to manage and a rotate a secret. Consider using OIDC as a more secure approach.
 
 ```hcl
 data "terraform_remote_state" "foo" {


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->
This PR refactors the documentation for the `azurerm` backend to provide clarity for users on the various authentication options. The existing documentation was missing clarity on the Access Key vs Entra ID option to access the storage account. This change is designed to provide that clarity and make it clear that the `use_azuread_auth` variable is not mutually exclusive with the other authentication options, it is additive.
<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Fixes N/A

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.7.1

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

### NEW FEATURES | UPGRADE NOTES | ENHANCEMENTS | BUG FIXES | EXPERIMENTS

<!--

Write a short description of the user-facing change. Examples:

- `terraform show -json`: Fixed crash with sensitive set values.
- When rendering a diff, Terraform now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 

-  
