### PR TITLE
apply schema marks to returned instance values

### DIFF
--- a/internal/command/testdata/show-json-sensitive/output.json
+++ b/internal/command/testdata/show-json-sensitive/output.json
@@ -28,7 +28,8 @@
                         "password": "secret"
                     },
                     "sensitive_values": {
-                        "ami": true
+                        "ami": true,
+                        "password": true
                     }
                 },
                 {
@@ -44,7 +45,8 @@
                         "password": "secret"
                     },
                     "sensitive_values": {
-                        "ami": true
+                        "ami": true,
+                        "password": true
                     }
                 },
                 {
@@ -60,7 +62,8 @@
                         "password": "secret"
                     },
                     "sensitive_values": {
-                        "ami": true
+                        "ami": true,
+                        "password": true
                     }
                 }
             ]

--- a/internal/command/testdata/show-json/conditions/for-refresh.tfstate
+++ b/internal/command/testdata/show-json/conditions/for-refresh.tfstate
@@ -1,39 +1,55 @@
 {
-    "version": 4,
-    "terraform_version": "1.2.0-dev",
-    "serial": 1,
-    "lineage": "no",
-    "outputs": {},
-    "resources": [
+  "version": 4,
+  "terraform_version": "1.2.0-dev",
+  "serial": 1,
+  "lineage": "no",
+  "outputs": {},
+  "resources": [
+    {
+      "mode": "managed",
+      "type": "test_instance",
+      "name": "foo",
+      "provider": "provider[\"registry.terraform.io/hashicorp/test\"]",
+      "instances": [
         {
-            "mode": "managed",
-            "type": "test_instance",
-            "name": "foo",
-            "provider": "provider[\"registry.terraform.io/hashicorp/test\"]",
-            "instances": [
-                {
-                    "schema_version": 0,
-                    "attributes": {
-                        "ami": "ami-test",
-                        "id": "placeholder"
-                    }
-                }
+          "schema_version": 0,
+          "attributes": {
+            "ami": "ami-test",
+            "id": "placeholder"
+          },
+          "sensitive_attributes": [
+            [
+              {
+                "type": "get_attr",
+                "value": "password"
+              }
             ]
-        },
-        {
-            "mode": "managed",
-            "type": "test_instance",
-            "name": "bar",
-            "provider": "provider[\"registry.terraform.io/hashicorp/test\"]",
-            "instances": [
-                {
-                    "schema_version": 0,
-                    "attributes": {
-                        "ami": "ami-test",
-                        "id": "placeheld"
-                    }
-                }
-            ]
+          ]
         }
-    ]
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "test_instance",
+      "name": "bar",
+      "provider": "provider[\"registry.terraform.io/hashicorp/test\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "ami": "ami-test",
+            "id": "placeheld"
+          },
+          "sensitive_attributes": [
+            [
+              {
+                "type": "get_attr",
+                "value": "password"
+              }
+            ]
+          ]
+        }
+      ]
+    }
+  ]
 }

--- a/internal/command/testdata/show-json/conditions/output-refresh-only.json
+++ b/internal/command/testdata/show-json/conditions/output-refresh-only.json
@@ -1,6 +1,6 @@
 {
-  "format_version": "1.1",
-  "terraform_version": "1.2.0-dev",
+  "format_version": "1.2",
+  "terraform_version": "1.8.0-dev",
   "variables": {
     "ami": {
       "value": "bad-ami"
@@ -33,13 +33,13 @@
   },
   "prior_state": {
     "format_version": "1.0",
-    "terraform_version": "1.1.0",
+    "terraform_version": "1.8.0",
     "values": {
       "outputs": {
         "foo_id": {
           "sensitive": false,
-          "type": "string",
-          "value": "placeholder"
+          "value": "placeholder",
+          "type": "string"
         }
       },
       "root_module": {
@@ -146,26 +146,70 @@
       ]
     }
   ],
-  "condition_results": [
+  "checks": [
     {
-      "address": "output.foo_id",
-      "condition_type": "OutputPrecondition",
-      "result": true,
-      "unknown": false
+      "address": {
+        "kind": "output_value",
+        "name": "foo_id",
+        "to_display": "output.foo_id"
+      },
+      "status": "pass",
+      "instances": [
+        {
+          "address": {
+            "to_display": "output.foo_id"
+          },
+          "status": "pass"
+        }
+      ]
     },
     {
-      "address": "test_instance.bar",
-      "condition_type": "ResourcePostcondition",
-      "result": false,
-      "unknown": false,
-      "error_message": "Resource ID is unacceptably short (9 characters)."
+      "address": {
+        "kind": "resource",
+        "mode": "managed",
+        "name": "bar",
+        "to_display": "test_instance.bar",
+        "type": "test_instance"
+      },
+      "status": "fail",
+      "instances": [
+        {
+          "address": {
+            "to_display": "test_instance.bar"
+          },
+          "status": "fail",
+          "problems": [
+            {
+              "message": "Resource ID is unacceptably short (9 characters)."
+            }
+          ]
+        }
+      ]
     },
     {
-      "address": "test_instance.foo",
-      "condition_type": "ResourcePrecondition",
-      "result": false,
-      "unknown": false,
-      "error_message": "Invalid AMI ID: must start with \"ami-\"."
+      "address": {
+        "kind": "resource",
+        "mode": "managed",
+        "name": "foo",
+        "to_display": "test_instance.foo",
+        "type": "test_instance"
+      },
+      "status": "fail",
+      "instances": [
+        {
+          "address": {
+            "to_display": "test_instance.foo"
+          },
+          "status": "fail",
+          "problems": [
+            {
+              "message": "Invalid AMI ID: must start with \"ami-\"."
+            }
+          ]
+        }
+      ]
     }
-  ]
+  ],
+  "timestamp": "2024-01-24T18:33:05Z",
+  "errored": false
 }

--- a/internal/terraform/context_plan2_test.go
+++ b/internal/terraform/context_plan2_test.go
@@ -2932,7 +2932,8 @@ output "output" {
 		}
 
 		if res.Addr.Resource.Resource.Mode == addrs.DataResourceMode && res.Action != plans.NoOp {
-			t.Errorf("unexpected %s plan for %s", res.Action, res.Addr)
+			fmt.Println(res.Addr, res.ActionReason)
+			t.Errorf("unexpected %s/%s plan for %s", res.Action, res.ActionReason, res.Addr)
 		}
 	}
 }

--- a/internal/terraform/context_plan2_test.go
+++ b/internal/terraform/context_plan2_test.go
@@ -2932,7 +2932,6 @@ output "output" {
 		}
 
 		if res.Addr.Resource.Resource.Mode == addrs.DataResourceMode && res.Action != plans.NoOp {
-			fmt.Println(res.Addr, res.ActionReason)
 			t.Errorf("unexpected %s/%s plan for %s", res.Action, res.ActionReason, res.Addr)
 		}
 	}

--- a/internal/terraform/evaluate.go
+++ b/internal/terraform/evaluate.go
@@ -744,13 +744,9 @@ func (d *evaluationStateData) GetResource(addr addrs.Resource, rng tfdiags.Sourc
 				continue
 			}
 
-			// If our provider schema contains sensitive values, mark those as sensitive
-			afterMarks := change.AfterValMarks
-			if schema.ContainsSensitive() {
-				afterMarks = append(afterMarks, schema.ValueMarks(val, nil)...)
-			}
-
-			instances[key] = val.MarkWithPaths(afterMarks)
+			// Unlike decoding state, decoding a change does not automatically
+			// mark values.
+			instances[key] = val.MarkWithPaths(change.AfterValMarks)
 			continue
 		}
 
@@ -769,16 +765,6 @@ func (d *evaluationStateData) GetResource(addr addrs.Resource, rng tfdiags.Sourc
 
 		val := ios.Value
 
-		// If our schema contains sensitive values, mark those as sensitive.
-		// Since decoding the instance object can also apply sensitivity marks,
-		// we must remove and combine those before remarking to avoid a double-
-		// mark error.
-		if schema.ContainsSensitive() {
-			var marks []cty.PathValueMarks
-			val, marks = val.UnmarkDeepWithPaths()
-			marks = append(marks, schema.ValueMarks(val, nil)...)
-			val = val.MarkWithPaths(marks)
-		}
 		instances[key] = val
 	}
 

--- a/internal/terraform/marks.go
+++ b/internal/terraform/marks.go
@@ -56,3 +56,26 @@ func marksEqual(a, b []cty.PathValueMarks) bool {
 
 	return true
 }
+
+// Remove duplicate PathValueMarks from the slice.
+// When adding marks from a resource schema to a value, most of the time there
+// will be duplicates from a prior value already in the list of marks. While
+// MarkwithPaths will accept duplicates, we need to be able to easily compare
+// the PathValueMarks within this package too.
+func dedupePathValueMarks(m []cty.PathValueMarks) []cty.PathValueMarks {
+	var res []cty.PathValueMarks
+	// we'll use a GoString format key to differentiate PathValueMarks, since
+	// the Path portion is not automagically comparable.
+	seen := make(map[string]bool)
+
+	for _, pvm := range m {
+		key := fmt.Sprintf("%#v", pvm)
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = true
+		res = append(res, pvm)
+	}
+
+	return res
+}

--- a/internal/terraform/node_resource_abstract_instance.go
+++ b/internal/terraform/node_resource_abstract_instance.go
@@ -997,12 +997,11 @@ func (n *NodeAbstractResourceInstance) plan(
 		}
 	}
 
-	// Add the marks back to the planned new value -- this must happen after ignore changes
-	// have been processed. We add in the schema marks as well, so ensure that
-	// provider defined private attributes are marked correctly here.
+	// Add the marks back to the planned new value -- this must happen after
+	// ignore changes have been processed. We add in the schema marks as well,
+	// to ensure that provider defined private attributes are marked correctly
+	// here.
 	unmarkedPlannedNewVal := plannedNewVal
-	// Add schema path marks to unmarkedPaths, so that any difference in
-	// sensitive attributes from the provider are marked correctly too.
 	unmarkedPaths = dedupePathValueMarks(append(unmarkedPaths, schema.ValueMarks(plannedNewVal, nil)...))
 
 	if len(unmarkedPaths) > 0 {


### PR DESCRIPTION
The original sensitivity handling implementation applied the marks from a resource schema only when decoding values for evaluation. This appeared to work in most cases, since the resource value could only be used elsewhere in the configuration by references that would be returned from the evaluator. However, this approach left holes in the handling of the instance values where some marks may have been inserted from its own references to sensitive value, but the instance's own sensitive attributes were left unmarked. This was most noticeable in the state storage, where only sensitive references were listed in `sensitive_attributes`, leaving the actual sensitive attributes unmarked.

The same problems would arise in the plan artifacts too, with the change `After` values missing attributes that should be sensitive, and the correction to those sensitive attributes depending on being decoded again during evaluation. This would appear to users as unexpected updates in a plan with no changes, usually when the provider added a sensitive attribute, or the instance was recently imported.

Rather than depending on a value to be round-tripped through an encoding/decoding cycle via evaluation in order to be correctly marked, we need to apply the schema marks to all new values returned by a provider. This is added to the `ReadResource`, and `PlanResourceChange` paths to ensure values are consistently marked. We can then remove the re-insertion of the schema marks from the evaluator, because the value it sees should be correctly marked in all cases.

Notably we don't need to do this for `Import`, because that value is never stored or referenced, -- an `ImportResource` call always consists of a followup `ReadResource` call, and there is no need to strip and re-apply the same marks. We also don't need to separately apply the schema marks after `ApplyResourceChange`, because they are the same marks we already stored in the plan `After` value (which should always be correct now that we insert them after `PlanResourceChange`).

Finally, even though we rely on the stored state to be correctly marked, this should not affect normal usage when the user has a state missing the `sensitive_attributes`, because the plan will compare the newly refreshed state with the new planned state, which will both be correctly marked. There will however be an empty update to resources when using `-refresh=false` or `-refresh-only` which should be called out in the upgrade notes. If that is deemed too intrusive, we could insert an extra addition of marks to state decoding, but I opted not to yet as that is apt to hide any other mis-handling of marks.

There were a number of tests written to match the inconsistent marks handling which needed to be updated, but that provided some good locations to double check the new behavior using those same tests.

Fixes: #34144
Fixes: #34323