### PR TITLE
core: Plumbing for graph nodes that belong to partially-expanded module prefixes

### DIFF
--- a/internal/terraform/eval_context.go
+++ b/internal/terraform/eval_context.go
@@ -193,4 +193,8 @@ type EvalContext interface {
 	// WithPath returns a copy of the context with the internal path set to the
 	// path argument.
 	WithPath(path addrs.ModuleInstance) EvalContext
+
+	// WithPartialExpandedPath returns a copy of the context with the internal
+	// path set to the path argument.
+	WithPartialExpandedPath(path addrs.PartialExpandedModule) EvalContext
 }

--- a/internal/terraform/eval_context_mock.go
+++ b/internal/terraform/eval_context_mock.go
@@ -332,6 +332,14 @@ func (c *MockEvalContext) WithPath(path addrs.ModuleInstance) EvalContext {
 	return &newC
 }
 
+func (c *MockEvalContext) WithPartialExpandedPath(path addrs.PartialExpandedModule) EvalContext {
+	// This is not yet implemented as a mock, because we've not yet had any
+	// need for it. If we end up needing to test this behavior in isolation
+	// somewhere then we'll need to figure out how to fit it in here without
+	// upsetting too many existing tests that rely on the PathPath field.
+	panic("WithPartialExpandedPath not implemented for MockEvalContext")
+}
+
 func (c *MockEvalContext) Path() addrs.ModuleInstance {
 	c.PathCalled = true
 	return c.PathPath

--- a/internal/terraform/eval_context_scope.go
+++ b/internal/terraform/eval_context_scope.go
@@ -1,0 +1,61 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package terraform
+
+import (
+	"github.com/hashicorp/terraform/internal/addrs"
+)
+
+// evalContextScope represents the scope that an [EvalContext] (or rather,
+// an [EvalContextBuiltin] is associated with.
+//
+// This is a closed interface representing a sum type, with three possible
+// variants:
+//
+//   - a nil value of this type represents a "global" evaluation context used
+//     for graph nodes that aren't considered to belong to any specific module
+//     instance. Some [EvalContext] methods are not appropriate for such a
+//     context, and so will panic on a global evaluation context.
+//   - [evalContextModuleInstance] is for an evaluation context used for
+//     graph nodes that implement [GraphNodeModuleInstance], meaning that
+//     they belong to a fully-expanded single module instance.
+//   - [evalContextPartialExpandedModule] is for an evaluation context used for
+//     graph nodes that implement [GraphNodeUnexpandedModule], meaning that
+//     they belong to an unbounded set of possible module instances sharing
+//     a common known prefix, in situations where a module call has an unknown
+//     value for its count or for_each argument.
+type evalContextScope interface {
+	// evalContextScopeModule returns the static module address of whatever
+	// fully- or partially-expanded module instance address this scope is
+	// associated with.
+	//
+	// A "global" evaluation context is a nil [evalContextScope], and so
+	// this method will panic for that scope.
+	evalContextScopeModule() addrs.Module
+}
+
+// evalContextGlobal is the nil [evalContextScope] used to represent an
+// [EvalContext] that isn't associated with any module at all.
+var evalContextGlobal evalContextScope
+
+// evalContextModuleInstance is an [evalContextScope] associated with a
+// fully-expanded single module instance.
+type evalContextModuleInstance struct {
+	Addr addrs.ModuleInstance
+}
+
+func (s evalContextModuleInstance) evalContextScopeModule() addrs.Module {
+	return s.Addr.Module()
+}
+
+// evalContextPartialExpandedModule is an [evalContextScope] associated with
+// an unbounded set of possible module instances that share a common known
+// address prefix.
+type evalContextPartialExpandedModule struct {
+	Addr addrs.PartialExpandedModule
+}
+
+func (s evalContextPartialExpandedModule) evalContextScopeModule() addrs.Module {
+	return s.Addr.Module()
+}

--- a/internal/terraform/evaluate.go
+++ b/internal/terraform/evaluate.go
@@ -146,6 +146,13 @@ var EvalDataForNoInstanceKey = InstanceKeyEvalData{}
 // evaluationStateData must implement lang.Data
 var _ lang.Data = (*evaluationStateData)(nil)
 
+// StaticValidateReferences calls [Evaluator.StaticValidateReferences] on
+// the evaluator embedded in this data object, using this data object's
+// static module path.
+func (d *evaluationStateData) StaticValidateReferences(refs []*addrs.Reference, self addrs.Referenceable, source addrs.Referenceable) tfdiags.Diagnostics {
+	return d.Evaluator.StaticValidateReferences(refs, d.ModulePath.Module(), self, source)
+}
+
 func (d *evaluationStateData) GetCountAttr(addr addrs.CountAttr, rng tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
 	switch addr.Name {

--- a/internal/terraform/evaluate_placeholder.go
+++ b/internal/terraform/evaluate_placeholder.go
@@ -1,0 +1,275 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package terraform
+
+import (
+	"fmt"
+
+	"github.com/zclconf/go-cty/cty"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/terraform/internal/addrs"
+	"github.com/hashicorp/terraform/internal/lang"
+	"github.com/hashicorp/terraform/internal/tfdiags"
+)
+
+// evaluationPlaceholderData is an implementation of lang.Data that deals
+// with resolving references inside module prefixes whose full expansion
+// isn't known yet, and thus returns placeholder values that represent
+// only what we know to be true for all possible final module instances
+// that could exist for the prefix.
+type evaluationPlaceholderData struct {
+	Evaluator *Evaluator
+
+	// ModulePath is the partially-expanded path through the dynamic module
+	// tree to a set of possible module instances that share a common known
+	// prefix.
+	ModulePath addrs.PartialExpandedModule
+
+	// CountAvailable is true if this data object is representing an evaluation
+	// scope where the "count" symbol would be available.
+	CountAvailable bool
+
+	// EachAvailable is true if this data object is representing an evaluation
+	// scope where the "each" symbol would be available.
+	EachAvailable bool
+
+	// Operation records the type of walk the evaluationStateData is being used
+	// for.
+	Operation walkOperation
+}
+
+// TODO: Historically we were inconsistent about whether static validation
+// logic is implemented in Evaluator.StaticValidateReference or inline in
+// methods of evaluationStateData, because the dedicated static validator
+// came later.
+//
+// Some validation rules (and their associated error messages) have therefore
+// ended up being duplicated between evaluationPlaceholderData and
+// evaluationStateData. We've accepted that for now to avoid creating a bunch
+// of churn in pre-existing code while adding support for partial expansion
+// placeholders, but one day it would be nice to refactor this a little so
+// that the division between these three units is a little clearer and so
+// that all of the error checks are implemented in only one place each.
+
+var _ lang.Data = (*evaluationPlaceholderData)(nil)
+
+// GetCheckBlock implements lang.Data.
+func (d *evaluationPlaceholderData) GetCheckBlock(addr addrs.Check, rng tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics) {
+	// check blocks don't produce any useful data and can only be referred
+	// to within an expect_failures attribute in the test language.
+	var diags tfdiags.Diagnostics
+	diags = diags.Append(&hcl.Diagnostic{
+		Severity: hcl.DiagError,
+		Summary:  "Reference to \"check\" in invalid context",
+		Detail:   "The \"check\" object can only be used from an \"expect_failures\" attribute within a Terraform testing \"run\" block.",
+		Subject:  rng.ToHCL().Ptr(),
+	})
+	return cty.NilVal, diags
+
+}
+
+// GetCountAttr implements lang.Data.
+func (d *evaluationPlaceholderData) GetCountAttr(addr addrs.CountAttr, rng tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics) {
+	var diags tfdiags.Diagnostics
+	switch addr.Name {
+
+	case "index":
+		if !d.CountAvailable {
+			diags = diags.Append(&hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  `Reference to "count" in non-counted context`,
+				Detail:   `The "count" object can only be used in "module", "resource", and "data" blocks, and only when the "count" argument is set.`,
+				Subject:  rng.ToHCL().Ptr(),
+			})
+		}
+		// When we're under a partially-expanded prefix, the leaf instance
+		// keys are never known because otherwise we'd be under a fully-known
+		// prefix by definition. We do know it's always >= 0 and not null,
+		// though.
+		return cty.UnknownVal(cty.Number).Refine().
+			NumberRangeLowerBound(cty.Zero, true).
+			NotNull().
+			NewValue(), diags
+
+	default:
+		diags = diags.Append(&hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  `Invalid "count" attribute`,
+			Detail:   fmt.Sprintf(`The "count" object does not have an attribute named %q. The only supported attribute is count.index, which is the index of each instance of a resource block that has the "count" argument set.`, addr.Name),
+			Subject:  rng.ToHCL().Ptr(),
+		})
+		return cty.DynamicVal, diags
+	}
+}
+
+// GetForEachAttr implements lang.Data.
+func (d *evaluationPlaceholderData) GetForEachAttr(addr addrs.ForEachAttr, rng tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics) {
+	var diags tfdiags.Diagnostics
+
+	// When we're under a partially-expanded prefix, the leaf instance
+	// keys are never known because otherwise we'd be under a fully-known
+	// prefix by definition. Therefore all return paths here produce unknown
+	// values.
+
+	if !d.EachAvailable {
+		diags = diags.Append(&hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  `Reference to "each" in context without for_each`,
+			Detail:   `The "each" object can be used only in "module" or "resource" blocks, and only when the "for_each" argument is set.`,
+			Subject:  rng.ToHCL().Ptr(),
+		})
+		return cty.UnknownVal(cty.DynamicPseudoType), diags
+	}
+
+	switch addr.Name {
+
+	case "key":
+		// each.key is always a string and is never null
+		return cty.UnknownVal(cty.String).RefineNotNull(), diags
+	case "value":
+		return cty.DynamicVal, diags
+	default:
+		diags = diags.Append(&hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  `Invalid "each" attribute`,
+			Detail:   fmt.Sprintf(`The "each" object does not have an attribute named %q. The supported attributes are each.key and each.value, the current key and value pair of the "for_each" attribute set.`, addr.Name),
+			Subject:  rng.ToHCL().Ptr(),
+		})
+		return cty.DynamicVal, diags
+	}
+}
+
+// GetInputVariable implements lang.Data.
+func (d *evaluationPlaceholderData) GetInputVariable(addr addrs.InputVariable, rng tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics) {
+	namedVals := d.Evaluator.NamedValues
+	absAddr := addrs.ObjectInPartialExpandedModule(d.ModulePath, addr)
+	return namedVals.GetInputVariablePlaceholder(absAddr), nil
+}
+
+// GetLocalValue implements lang.Data.
+func (d *evaluationPlaceholderData) GetLocalValue(addr addrs.LocalValue, rng tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics) {
+	namedVals := d.Evaluator.NamedValues
+	absAddr := addrs.ObjectInPartialExpandedModule(d.ModulePath, addr)
+	return namedVals.GetLocalValuePlaceholder(absAddr), nil
+}
+
+// GetModule implements lang.Data.
+func (d *evaluationPlaceholderData) GetModule(addr addrs.ModuleCall, rng tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics) {
+	// We'll reuse the evaluator's "static evaluate" logic to check that the
+	// module call being referred to is even declared in the configuration,
+	// since it returns a good-quality error message for that case that
+	// we don't want to have to duplicate here.
+	diags := d.Evaluator.StaticValidateReference(&addrs.Reference{
+		Subject:     addr,
+		SourceRange: rng,
+	}, d.ModulePath.Module(), nil, nil)
+	if diags.HasErrors() {
+		return cty.DynamicVal, diags
+	}
+
+	callerCfg := d.Evaluator.Config.Descendent(d.ModulePath.Module())
+	if callerCfg == nil {
+		// Strange! The above StaticValidateReference should've failed if
+		// the module we're in isn't even declared. But we'll just tolerate
+		// it and return a very general placeholder.
+		return cty.DynamicVal, diags
+	}
+	callCfg := callerCfg.Module.ModuleCalls[addr.Name]
+	if callCfg == nil {
+		// Again strange, for the same reason as just above.
+		return cty.DynamicVal, diags
+	}
+
+	// Any module call under an unexpanded prefix has an unknown set of instance
+	// keys itself by definition, unless that call isn't using count or for_each
+	// at all and thus we know it has exactly one "no-key" instance.
+	//
+	// If we don't know the instance keys then we cannot predict anything about
+	// the result, because module calls with repetition appear as either
+	// object or tuple types and we cannot predict those types here.
+	if callCfg.Count != nil || callCfg.ForEach != nil {
+		return cty.DynamicVal, diags
+	}
+
+	// If we get down here then we know we have a single-instance module, and
+	// so we can return a more specific placeholder object that has all of
+	// the child module's declared output values represented, which could
+	// then potentially allow detecting a downstream error referring to
+	// an output value that doesn't actually exist.
+	calledCfg := d.Evaluator.Config.Descendent(d.ModulePath.Module().Child(addr.Name))
+	if calledCfg == nil {
+		// This suggests that the config wasn't constructed correctly, since
+		// there should always be a child config node for any module call,
+		// but that's a "package configs" problem and so we'll just tolerate
+		// it here for robustness.
+		return cty.DynamicVal, diags
+	}
+
+	attrs := make(map[string]cty.Value, len(calledCfg.Module.Outputs))
+	for name := range calledCfg.Module.Outputs {
+		// Module output values are dynamically-typed, so we cannot
+		// predict anything about their results until finalized.
+		attrs[name] = cty.DynamicVal
+	}
+	return cty.ObjectVal(attrs), diags
+}
+
+// GetOutput implements lang.Data.
+func (d *evaluationPlaceholderData) GetOutput(addr addrs.OutputValue, rng tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics) {
+	namedVals := d.Evaluator.NamedValues
+	absAddr := addrs.ObjectInPartialExpandedModule(d.ModulePath, addr)
+	return namedVals.GetOutputValuePlaceholder(absAddr), nil
+
+}
+
+// GetPathAttr implements lang.Data.
+func (d *evaluationPlaceholderData) GetPathAttr(addrs.PathAttr, tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics) {
+	// TODO: It would be helpful to perform the same logic here as we do
+	// in the full-evaluation case, since the paths we'd return here cannot
+	// vary based on dynamic data, but we'll need to factor out the logic
+	// into a common location we can call from both places first. For now,
+	// we'll just leave these all as unknown value placeholders.
+	//
+	// What we _do_ know is that all valid attributes of "path" are strings
+	// that are definitely not null, so we can at least catch situations
+	// where someone tries to use them in a place where a string is
+	// unacceptable.
+	return cty.UnknownVal(cty.String).RefineNotNull(), nil
+}
+
+// GetResource implements lang.Data.
+func (d *evaluationPlaceholderData) GetResource(addrs.Resource, tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics) {
+	// TODO: Once we've implemented the evaluation of placeholders for
+	// deferred resources during the graph walk, we should return such
+	// placeholders here where possible.
+	//
+	// However, for resources that use count or for_each we'd not be able
+	// to predict anything more than cty.DynamicVal here anyway, since
+	// we don't know the instance keys, and so that improvement would only
+	// really help references to single-instance resources.
+	return cty.DynamicVal, nil
+}
+
+// GetRunBlock implements lang.Data.
+func (d *evaluationPlaceholderData) GetRunBlock(addrs.Run, tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics) {
+	// We should not get here because any scope that has an [evaluationPlaceholderData]
+	// as its Data should have a reference parser that doesn't accept addrs.Run
+	// addresses.
+	panic("GetRunBlock called on non-test evaluation dataset")
+}
+
+// GetTerraformAttr implements lang.Data.
+func (d *evaluationPlaceholderData) GetTerraformAttr(addrs.TerraformAttr, tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics) {
+	// TODO: It would be helpful to perform the same validation checks that
+	// occur in evaluationStateData.GetTerraformAttr, so authors can catch
+	// invalid usage of the "terraform" object even when under an unexpanded
+	// module prefix.
+	return cty.DynamicVal, nil
+}
+
+// StaticValidateReferences implements lang.Data.
+func (d *evaluationPlaceholderData) StaticValidateReferences(refs []*addrs.Reference, self addrs.Referenceable, source addrs.Referenceable) tfdiags.Diagnostics {
+	return d.Evaluator.StaticValidateReferences(refs, d.ModulePath.Module(), self, source)
+}

--- a/internal/terraform/evaluate_valid.go
+++ b/internal/terraform/evaluate_valid.go
@@ -31,24 +31,27 @@ import (
 //
 // The result may include warning diagnostics if, for example, deprecated
 // features are referenced.
-func (d *evaluationStateData) StaticValidateReferences(refs []*addrs.Reference, self addrs.Referenceable, source addrs.Referenceable) tfdiags.Diagnostics {
+func (e *Evaluator) StaticValidateReferences(refs []*addrs.Reference, modAddr addrs.Module, self addrs.Referenceable, source addrs.Referenceable) tfdiags.Diagnostics {
 	var diags tfdiags.Diagnostics
 	for _, ref := range refs {
-		moreDiags := d.staticValidateReference(ref, self, source)
+		moreDiags := e.StaticValidateReference(ref, modAddr, self, source)
 		diags = diags.Append(moreDiags)
 	}
 	return diags
 }
 
-func (d *evaluationStateData) staticValidateReference(ref *addrs.Reference, self addrs.Referenceable, source addrs.Referenceable) tfdiags.Diagnostics {
-	modCfg := d.Evaluator.Config.DescendentForInstance(d.ModulePath)
+func (e *Evaluator) StaticValidateReference(ref *addrs.Reference, modAddr addrs.Module, self addrs.Referenceable, source addrs.Referenceable) tfdiags.Diagnostics {
+	modCfg := e.Config.Descendent(modAddr)
 	if modCfg == nil {
 		// This is a bug in the caller rather than a problem with the
 		// reference, but rather than crashing out here in an unhelpful way
 		// we'll just ignore it and trust a different layer to catch it.
 		return nil
 	}
+	return e.staticValidateReference(ref, modCfg, self, source)
+}
 
+func (e *Evaluator) staticValidateReference(ref *addrs.Reference, modCfg *configs.Config, self addrs.Referenceable, source addrs.Referenceable) tfdiags.Diagnostics {
 	if ref.Subject == addrs.Self {
 		// The "self" address is a special alias for the address given as
 		// our self parameter here, if present.
@@ -80,20 +83,20 @@ func (d *evaluationStateData) staticValidateReference(ref *addrs.Reference, self
 	// staticValidateMultiResourceReference respectively.
 	case addrs.Resource:
 		var diags tfdiags.Diagnostics
-		diags = diags.Append(d.staticValidateSingleResourceReference(modCfg, addr, ref.Remaining, ref.SourceRange))
-		diags = diags.Append(d.staticValidateResourceReference(modCfg, addr, source, ref.Remaining, ref.SourceRange))
+		diags = diags.Append(staticValidateSingleResourceReference(modCfg, addr, ref.Remaining, ref.SourceRange))
+		diags = diags.Append(staticValidateResourceReference(modCfg, addr, source, e.Plugins, ref.Remaining, ref.SourceRange))
 		return diags
 	case addrs.ResourceInstance:
 		var diags tfdiags.Diagnostics
-		diags = diags.Append(d.staticValidateMultiResourceReference(modCfg, addr, ref.Remaining, ref.SourceRange))
-		diags = diags.Append(d.staticValidateResourceReference(modCfg, addr.ContainingResource(), source, ref.Remaining, ref.SourceRange))
+		diags = diags.Append(staticValidateMultiResourceReference(modCfg, addr, ref.Remaining, ref.SourceRange))
+		diags = diags.Append(staticValidateResourceReference(modCfg, addr.ContainingResource(), source, e.Plugins, ref.Remaining, ref.SourceRange))
 		return diags
 
 	// We also handle all module call references the same way, disregarding index.
 	case addrs.ModuleCall:
-		return d.staticValidateModuleCallReference(modCfg, addr, ref.Remaining, ref.SourceRange)
+		return staticValidateModuleCallReference(modCfg, addr, ref.Remaining, ref.SourceRange)
 	case addrs.ModuleCallInstance:
-		return d.staticValidateModuleCallReference(modCfg, addr.Call, ref.Remaining, ref.SourceRange)
+		return staticValidateModuleCallReference(modCfg, addr.Call, ref.Remaining, ref.SourceRange)
 	case addrs.ModuleCallInstanceOutput:
 		// This one is a funny one because we will take the output name referenced
 		// and use it to fake up a "remaining" that would make sense for the
@@ -109,7 +112,7 @@ func (d *evaluationStateData) staticValidateReference(ref *addrs.Reference, self
 			// but is close enough for our purposes.
 			SrcRange: ref.SourceRange.ToHCL(),
 		}
-		return d.staticValidateModuleCallReference(modCfg, addr.Call.Call, remain, ref.SourceRange)
+		return staticValidateModuleCallReference(modCfg, addr.Call.Call, remain, ref.SourceRange)
 
 	default:
 		// Anything else we'll just permit through without any static validation
@@ -118,7 +121,7 @@ func (d *evaluationStateData) staticValidateReference(ref *addrs.Reference, self
 	}
 }
 
-func (d *evaluationStateData) staticValidateSingleResourceReference(modCfg *configs.Config, addr addrs.Resource, remain hcl.Traversal, rng tfdiags.SourceRange) tfdiags.Diagnostics {
+func staticValidateSingleResourceReference(modCfg *configs.Config, addr addrs.Resource, remain hcl.Traversal, rng tfdiags.SourceRange) tfdiags.Diagnostics {
 	// If we have at least one step in "remain" and this resource has
 	// "count" set then we know for sure this in invalid because we have
 	// something like:
@@ -163,7 +166,7 @@ func (d *evaluationStateData) staticValidateSingleResourceReference(modCfg *conf
 	return diags
 }
 
-func (d *evaluationStateData) staticValidateMultiResourceReference(modCfg *configs.Config, addr addrs.ResourceInstance, remain hcl.Traversal, rng tfdiags.SourceRange) tfdiags.Diagnostics {
+func staticValidateMultiResourceReference(modCfg *configs.Config, addr addrs.ResourceInstance, remain hcl.Traversal, rng tfdiags.SourceRange) tfdiags.Diagnostics {
 	var diags tfdiags.Diagnostics
 
 	cfg := modCfg.Module.ResourceByAddr(addr.ContainingResource())
@@ -175,7 +178,7 @@ func (d *evaluationStateData) staticValidateMultiResourceReference(modCfg *confi
 
 	if addr.Key == addrs.NoKey {
 		// This is a different path into staticValidateSingleResourceReference
-		return d.staticValidateSingleResourceReference(modCfg, addr.ContainingResource(), remain, rng)
+		return staticValidateSingleResourceReference(modCfg, addr.ContainingResource(), remain, rng)
 	} else {
 		if cfg.Count == nil && cfg.ForEach == nil {
 			diags = diags.Append(&hcl.Diagnostic{
@@ -190,7 +193,7 @@ func (d *evaluationStateData) staticValidateMultiResourceReference(modCfg *confi
 	return diags
 }
 
-func (d *evaluationStateData) staticValidateResourceReference(modCfg *configs.Config, addr addrs.Resource, source addrs.Referenceable, remain hcl.Traversal, rng tfdiags.SourceRange) tfdiags.Diagnostics {
+func staticValidateResourceReference(modCfg *configs.Config, addr addrs.Resource, source addrs.Referenceable, plugins *contextPlugins, remain hcl.Traversal, rng tfdiags.SourceRange) tfdiags.Diagnostics {
 	var diags tfdiags.Diagnostics
 
 	var modeAdjective string
@@ -236,7 +239,7 @@ func (d *evaluationStateData) staticValidateResourceReference(modCfg *configs.Co
 	}
 
 	providerFqn := modCfg.Module.ProviderForLocalConfig(cfg.ProviderConfigAddr())
-	schema, _, err := d.Evaluator.Plugins.ResourceTypeSchema(providerFqn, addr.Mode, addr.Type)
+	schema, _, err := plugins.ResourceTypeSchema(providerFqn, addr.Mode, addr.Type)
 	if err != nil {
 		// Prior validation should've taken care of a schema lookup error,
 		// so we should never get here but we'll handle it here anyway for
@@ -286,7 +289,7 @@ func (d *evaluationStateData) staticValidateResourceReference(modCfg *configs.Co
 	return diags
 }
 
-func (d *evaluationStateData) staticValidateModuleCallReference(modCfg *configs.Config, addr addrs.ModuleCall, remain hcl.Traversal, rng tfdiags.SourceRange) tfdiags.Diagnostics {
+func staticValidateModuleCallReference(modCfg *configs.Config, addr addrs.ModuleCall, remain hcl.Traversal, rng tfdiags.SourceRange) tfdiags.Diagnostics {
 	var diags tfdiags.Diagnostics
 
 	// For now, our focus here is just in testing that the referenced module

--- a/internal/terraform/evaluate_valid_test.go
+++ b/internal/terraform/evaluate_valid_test.go
@@ -135,11 +135,7 @@ For example, to correlate with indices of a referring resource, use:
 				t.Fatal(diags.Err())
 			}
 
-			data := &evaluationStateData{
-				Evaluator: evaluator,
-			}
-
-			diags = data.StaticValidateReferences(refs, nil, test.Src)
+			diags = evaluator.StaticValidateReferences(refs, addrs.RootModule, nil, test.Src)
 			if diags.HasErrors() {
 				if test.WantErr == "" {
 					t.Fatalf("Unexpected diagnostics: %s", diags.Err())

--- a/internal/terraform/graph_interface_subgraph.go
+++ b/internal/terraform/graph_interface_subgraph.go
@@ -18,3 +18,21 @@ type GraphNodeModuleInstance interface {
 type GraphNodeModulePath interface {
 	ModulePath() addrs.Module
 }
+
+// GraphNodePartialExpandedModule says that a node represents an unbounded
+// set of objects within an unbounded set of module instances that happen
+// to share a known address prefix.
+//
+// Nodes of this type typically produce placeholder data to support partial
+// evaluation despite the full analysis of a module being deferred to a future
+// plan when more information will be available. They might also perform
+// checks and raise errors when something can be proven to be definitely
+// invalid regardless of what the final set of module instances turns out to
+// be.
+//
+// Node types implementing this interface cannot also implement
+// [GraphNodeModuleInstance], because it is not possible to evaluate a
+// node in two different contexts at once.
+type GraphNodePartialExpandedModule interface {
+	Path() addrs.PartialExpandedModule
+}

--- a/internal/terraform/graph_walk.go
+++ b/internal/terraform/graph_walk.go
@@ -14,6 +14,8 @@ type GraphWalker interface {
 	EvalContext() EvalContext
 	EnterPath(addrs.ModuleInstance) EvalContext
 	ExitPath(addrs.ModuleInstance)
+	EnterPartialExpandedPath(addrs.PartialExpandedModule) EvalContext
+	ExitPartialExpandedPath(addrs.PartialExpandedModule)
 	Execute(EvalContext, GraphNodeExecutable) tfdiags.Diagnostics
 }
 
@@ -22,7 +24,11 @@ type GraphWalker interface {
 // implementing all the required functions.
 type NullGraphWalker struct{}
 
-func (NullGraphWalker) EvalContext() EvalContext                                     { return new(MockEvalContext) }
-func (NullGraphWalker) EnterPath(addrs.ModuleInstance) EvalContext                   { return new(MockEvalContext) }
-func (NullGraphWalker) ExitPath(addrs.ModuleInstance)                                {}
+func (NullGraphWalker) EvalContext() EvalContext                   { return new(MockEvalContext) }
+func (NullGraphWalker) EnterPath(addrs.ModuleInstance) EvalContext { return new(MockEvalContext) }
+func (NullGraphWalker) ExitPath(addrs.ModuleInstance)              {}
+func (NullGraphWalker) EnterPartialExpandedPath(addrs.PartialExpandedModule) EvalContext {
+	return new(MockEvalContext)
+}
+func (NullGraphWalker) ExitPartialExpandedPath(addrs.PartialExpandedModule)          {}
 func (NullGraphWalker) Execute(EvalContext, GraphNodeExecutable) tfdiags.Diagnostics { return nil }

--- a/internal/terraform/graph_walk_context.go
+++ b/internal/terraform/graph_walk_context.go
@@ -63,6 +63,8 @@ type ContextGraphWalker struct {
 	provisionerLock     sync.Mutex
 }
 
+var _ GraphWalker = (*ContextGraphWalker)(nil)
+
 func (w *ContextGraphWalker) EnterPath(path addrs.ModuleInstance) EvalContext {
 	w.contextLock.Lock()
 	defer w.contextLock.Unlock()
@@ -74,6 +76,21 @@ func (w *ContextGraphWalker) EnterPath(path addrs.ModuleInstance) EvalContext {
 	}
 
 	ctx := w.EvalContext().WithPath(path)
+	w.contexts[key] = ctx.(*BuiltinEvalContext)
+	return ctx
+}
+
+func (w *ContextGraphWalker) EnterPartialExpandedPath(path addrs.PartialExpandedModule) EvalContext {
+	w.contextLock.Lock()
+	defer w.contextLock.Unlock()
+
+	// If we already have a context for this path cached, use that
+	key := path.String()
+	if ctx, ok := w.contexts[key]; ok {
+		return ctx
+	}
+
+	ctx := w.EvalContext().WithPartialExpandedPath(path)
 	w.contexts[key] = ctx.(*BuiltinEvalContext)
 	return ctx
 }

--- a/internal/terraform/node_local.go
+++ b/internal/terraform/node_local.go
@@ -201,4 +201,8 @@ type nodeLocalInPartialModule struct {
 	Config *configs.Local
 }
 
+func (n *nodeLocalInPartialModule) Path() addrs.PartialExpandedModule {
+	return n.Addr.Module
+}
+
 // TODO: Implement nodeLocalUnexpandedPlaceholder.Execute

--- a/internal/terraform/node_module_variable.go
+++ b/internal/terraform/node_module_variable.go
@@ -323,4 +323,8 @@ type nodeModuleVariableInPartialModule struct {
 	DestroyApply bool
 }
 
+func (n *nodeModuleVariableInPartialModule) Path() addrs.PartialExpandedModule {
+	return n.Addr.Module
+}
+
 // TODO: Implement nodeModuleVariableInPartialModule.Execute

--- a/internal/terraform/node_output.go
+++ b/internal/terraform/node_output.go
@@ -464,6 +464,10 @@ type nodeOutputInPartialModule struct {
 	RefreshOnly bool
 }
 
+func (n *nodeOutputInPartialModule) Path() addrs.PartialExpandedModule {
+	return n.Addr.Module
+}
+
 // TODO: Implement nodeOutputInPartialModule.Execute
 
 // NodeDestroyableOutput represents an output that is "destroyable":


### PR DESCRIPTION
This is a further iteration towards #30937, and follows on from yesterday's #34561.

This particular PR deals with plumbing in the evaluation nuts-and-bolts for graph nodes that are representing unbounded sets of as-yet-unknown instances of objects that are declared beneath a module call that has an insufficiently-known `count` or `for_each` argument.

This has a few different parts:
- A new implementation of `lang.Data` that's designed to return placeholder values that should represent what all instances of a given object have in common, while using unknown values for the parts where they differ.

    In this initial round it's quite meagre and returns `cty.DynamicVal` in some situations where it could technically be more precise than that, but we can improve the precision later to give earlier feedback about problems that would definitely cause a failure on a subsequent plan.
- `EvalContext` (or rather the concrete `EvalContextBuiltin` implementation of it) now has a third mode for evaluating in a partially-unknown module prefix, in addition to its existing modes for not being in a module at all or being in a fully-expanded module instance.

    I modeled this new tristate situation by replacing the previous `PathValue` and `pathSet` fields with a single field `scope` of an interface type, where that interface type is acting as a closed sum type covering the three different variants. The small amount of logic in `EvalContextBuiltin` that varies based on the module path then uses type assertions and type switches to distinguish between the three cases.
- The "context graph walker" now knows of a new extension interface for graph nodes which announces that a node belongs to a partial-expanded module prefix. For graph nodes that implement that interface, their `Execute` and `EvalContext` methods get an `EvalContext` in the partially-unknown module prefix mode.

    I intentionally chose the same method name for the new interface as for the existing interface used for `ModuleInstance` affinity, but with a different signature, to statically represent that these two interfaces are mutually-exclusive: a graph node cannot be evaluated in two different contexts at once.

For good measure I also retrofitted the three stubby node types added previously to represent partial-expanded named values with implementations of the new interface, so once they have `Execute` implemented they'll get a suitably-configured `EvalContext`. However, the actual `Execute` implementations are not included here, and will follow in future commits.

Reviewers might prefer to take this on a commit-by-commit basis; the series of commits follows roughly the sequence of changes I described above.

Therefore this PR is just another nothingburger as far as functionality is concerned -- no externally-visible behavior should be any different than it was before -- but this is an internal milestone where we now have all of the shared plumbing implemented, so future PRs can implement the language-feature-specific evaluation logic in terms of this. Again, there are no new integration tests here because there isn't yet any real new behavior to test, but those too will follow along with the language-feature-specific implementations in later PRs.


