### PR TITLE
Add 'explicit configuration required' message when provider schema validation fails

### DIFF
--- a/internal/terraform/node_provider.go
+++ b/internal/terraform/node_provider.go
@@ -115,6 +115,16 @@ func (n *NodeApplyableProvider) ConfigureProvider(ctx EvalContext, provider prov
 	configVal, configBody, evalDiags := ctx.EvaluateBlock(configBody, configSchema, nil, EvalDataForNoInstanceKey)
 	diags = diags.Append(evalDiags)
 	if evalDiags.HasErrors() {
+		if config == nil {
+			// The error messages from the above evaluation will be confusing
+			// if there isn't an explicit "provider" block in the configuration.
+			// Add some detail to the error message in this case.
+			diags = diags.Append(tfdiags.Sourceless(
+				tfdiags.Error,
+				"Invalid provider configuration",
+				fmt.Sprintf(providerConfigErr, n.Addr.Provider),
+			))
+		}
 		return diags
 	}
 

--- a/internal/terraform/node_provider_test.go
+++ b/internal/terraform/node_provider_test.go
@@ -9,13 +9,14 @@ import (
 	"testing"
 
 	"github.com/hashicorp/hcl/v2"
+	"github.com/zclconf/go-cty/cty"
+
 	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/configs"
 	"github.com/hashicorp/terraform/internal/configs/configschema"
 	"github.com/hashicorp/terraform/internal/lang/marks"
 	"github.com/hashicorp/terraform/internal/providers"
 	"github.com/hashicorp/terraform/internal/tfdiags"
-	"github.com/zclconf/go-cty/cty"
 )
 
 func TestNodeApplyableProviderExecute(t *testing.T) {
@@ -349,6 +350,19 @@ func TestNodeApplyableProvider_ConfigProvider(t *testing.T) {
 		}
 		return
 	}
+
+	// requiredProvider matches provider, but its attributes are required
+	// explicitly. This means we can simulate an earlier failure in the
+	// config validation.
+	requiredProvider := mockProviderWithConfigSchema(&configschema.Block{
+		Attributes: map[string]*configschema.Attribute{
+			"region": {
+				Type:     cty.String,
+				Required: true,
+			},
+		},
+	})
+
 	ctx := &MockEvalContext{ProviderProvider: provider}
 	ctx.installSimpleEval()
 
@@ -406,6 +420,43 @@ func TestNodeApplyableProvider_ConfigProvider(t *testing.T) {
 			t.Fatal("missing expected error with invalid config")
 		}
 		if !strings.Contains(diags.Err().Error(), "value is not found") {
+			t.Errorf("wrong diagnostic: %s", diags.Err())
+		}
+	})
+
+	t.Run("missing schema-required config (no config at all)", func(t *testing.T) {
+		node := NodeApplyableProvider{
+			NodeAbstractProvider: &NodeAbstractProvider{
+				Addr: mustProviderConfig(`provider["registry.terraform.io/hashicorp/aws"]`),
+			},
+		}
+
+		diags := node.ConfigureProvider(ctx, requiredProvider, false)
+		if !diags.HasErrors() {
+			t.Fatal("missing expected error with nil config")
+		}
+		if !strings.Contains(diags.Err().Error(), "requires explicit configuration") {
+			t.Errorf("diagnostic is missing \"requires explicit configuration\" message: %s", diags.Err())
+		}
+	})
+
+	t.Run("missing schema-required config", func(t *testing.T) {
+		config := &configs.Provider{
+			Name:   "test",
+			Config: hcl.EmptyBody(),
+		}
+		node := NodeApplyableProvider{
+			NodeAbstractProvider: &NodeAbstractProvider{
+				Addr:   mustProviderConfig(`provider["registry.terraform.io/hashicorp/aws"]`),
+				Config: config,
+			},
+		}
+
+		diags := node.ConfigureProvider(ctx, requiredProvider, false)
+		if !diags.HasErrors() {
+			t.Fatal("missing expected error with invalid config")
+		}
+		if !strings.Contains(diags.Err().Error(), "The argument \"region\" is required, but was not set.") {
 			t.Errorf("wrong diagnostic: %s", diags.Err())
 		}
 	})


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

Currently, when the `ValidateProviderConfig` RPC fails as part of schema validation for a generated provider configuration block, we add an additional sourceless diagnostic that adds some context around the provider that failed saying the user should add an explicit configuration block.

We do not currently do this if the **schema** validation itself fails (such as missing a required attribute). This PR adds the same error message we generate for the failed provider validation call to the earlier schema validation. The logic is exactly the same: if a generated configuration block fails validation it means the user must write it themselves.

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Fixes #34594 
Fixes #28482 

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.7.2

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

### ENHANCEMENTS

<!--

Write a short description of the user-facing change. Examples:

- `terraform show -json`: Fixed crash with sensitive set values.
- When rendering a diff, Terraform now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 

-  Add additional diagnostics when a generated provider block that fails schema validation requires explicit configuration.
