### PR TITLE
terraform test: prevent crash when mocking dynamic types

### DIFF
--- a/internal/moduletest/mocking/generate.go
+++ b/internal/moduletest/mocking/generate.go
@@ -101,6 +101,12 @@ func GenerateValueForType(target cty.Type) cty.Value {
 			children[attribute] = GenerateValueForType(target.AttributeType(attribute))
 		}
 		return cty.ObjectVal(children)
+	case target == cty.DynamicPseudoType:
+		// For dynamic types, we cannot generate a value that is guaranteed to
+		// be valid. Instead, we return a null value. This means users will get
+		// an error saying that the value is null, but it's better than an error
+		// saying that the type is wrong which will be confusing.
+		return cty.NullVal(cty.DynamicPseudoType)
 	default:
 		panic(fmt.Errorf("unknown complex type: %s", target.FriendlyName()))
 	}

--- a/internal/moduletest/mocking/values_test.go
+++ b/internal/moduletest/mocking/values_test.go
@@ -936,6 +936,42 @@ func TestComputedValuesForDataSource(t *testing.T) {
 				"Terraform could not compute a value for the target type string with the mocked data defined at :0,0-0 with the attribute \"block.id\": string required.",
 			},
 		},
+		"dynamic_attribute_unset": {
+			target: cty.ObjectVal(map[string]cty.Value{
+				"dynamic_attribute": cty.NullVal(cty.DynamicPseudoType),
+			}),
+			with: cty.EmptyObjectVal,
+			schema: &configschema.Block{
+				Attributes: map[string]*configschema.Attribute{
+					"dynamic_attribute": {
+						Type:     cty.DynamicPseudoType,
+						Computed: true,
+					},
+				},
+			},
+			expected: cty.ObjectVal(map[string]cty.Value{
+				"dynamic_attribute": cty.NullVal(cty.DynamicPseudoType),
+			}),
+		},
+		"dynamic_attribute_set": {
+			target: cty.ObjectVal(map[string]cty.Value{
+				"dynamic_attribute": cty.NullVal(cty.DynamicPseudoType),
+			}),
+			with: cty.ObjectVal(map[string]cty.Value{
+				"dynamic_attribute": cty.StringVal("Hello, world!"),
+			}),
+			schema: &configschema.Block{
+				Attributes: map[string]*configschema.Attribute{
+					"dynamic_attribute": {
+						Type:     cty.DynamicPseudoType,
+						Computed: true,
+					},
+				},
+			},
+			expected: cty.ObjectVal(map[string]cty.Value{
+				"dynamic_attribute": cty.StringVal("Hello, world!"),
+			}),
+		},
 	}
 
 	for name, tc := range tcs {


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

Some data sources actually specify dynamic types as computed attributes, such as `tfe_outputs`. This PR adds support for dynamic attributes to the mock value generation. For a dynamic type, mock providers will now return a null value. This is different from the other types, which return usable concrete values. But, we cannot do this for dynamic types as we don't know which value to return. And an error saying the types are mismatched is more confusing than error saying the value is null.

An alternative here would be to try and add diagnostics telling the user they must provide concrete values for dynamic types, but this goes against the philosophy of the mocking framework which is to let users only worry about the data they actually need instead of expecting them to try and build a complete value for every data type in their configuration.

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Fixes #34601 

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.7.3

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

### BUG FIXES

<!--

Write a short description of the user-facing change. Examples:

- `terraform show -json`: Fixed crash with sensitive set values.
- When rendering a diff, Terraform now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 

-  `terraform test`: Fix crash when a dynamic-typed attribute does not have a value set for a mocked provider.
