### PR TITLE
terraform test: Fix invalid XML processing instruction in experimental JUnit XML output

### DIFF
--- a/internal/command/views/test.go
+++ b/internal/command/views/test.go
@@ -828,7 +828,7 @@ func junitXMLTestReport(suite *moduletest.Suite) ([]byte, error) {
 	enc := xml.NewEncoder(&buf)
 	enc.EncodeToken(xml.ProcInst{
 		Target: "xml",
-		Inst:   []byte(`version="1.0" encoding="UTF-8`),
+		Inst:   []byte(`version="1.0" encoding="UTF-8"`),
 	})
 	enc.Indent("", "  ")
 


### PR DESCRIPTION
Annoyingly, I seem to have flubbed this slightly while I was adapting to use `enc.EncodeToken` instead of (as originally written) just writing the literal processing instruction bytes onto the front of the buffer directly. :confounded: 

This made the output invalid and therefore unreadable for any XML processor that interprets the special `xml` processing instruction. It'll now be valid again.

This JUnit XML output is currently behind an experiment guard and so only available in alpha releases. Merging this will not have any impact on on-alpha release behavior.
