### PR TITLE
terraform: Further generalization of the EvalContext scope handling

### DIFF
--- a/internal/terraform/context_eval.go
+++ b/internal/terraform/context_eval.go
@@ -116,6 +116,6 @@ func evalScopeFromGraphWalk(walker *ContextGraphWalker, moduleAddr addrs.ModuleI
 	// just to get hold of an EvalContext for it. ContextGraphWalker
 	// caches its contexts, so we should get hold of the context that was
 	// previously used for evaluation here, unless we skipped walking.
-	evalCtx := walker.EnterPath(moduleAddr)
+	evalCtx := walker.enterScope(evalContextModuleInstance{Addr: moduleAddr})
 	return evalCtx.EvaluationScope(nil, nil, EvalDataForNoInstanceKey)
 }

--- a/internal/terraform/eval_context.go
+++ b/internal/terraform/eval_context.go
@@ -190,11 +190,13 @@ type EvalContext interface {
 	// this execution.
 	Overrides() *mocking.Overrides
 
-	// WithPath returns a copy of the context with the internal path set to the
-	// path argument.
-	WithPath(path addrs.ModuleInstance) EvalContext
+	// withScope derives a new EvalContext that has all of the same global
+	// context, but a new evaluation scope.
+	withScope(scope evalContextScope) EvalContext
+}
 
-	// WithPartialExpandedPath returns a copy of the context with the internal
-	// path set to the path argument.
-	WithPartialExpandedPath(path addrs.PartialExpandedModule) EvalContext
+func evalContextForModuleInstance(baseCtx EvalContext, addr addrs.ModuleInstance) EvalContext {
+	return baseCtx.withScope(evalContextModuleInstance{
+		Addr: addr,
+	})
 }

--- a/internal/terraform/eval_context_builtin.go
+++ b/internal/terraform/eval_context_builtin.go
@@ -86,19 +86,9 @@ type BuiltinEvalContext struct {
 // BuiltinEvalContext implements EvalContext
 var _ EvalContext = (*BuiltinEvalContext)(nil)
 
-func (ctx *BuiltinEvalContext) WithPath(path addrs.ModuleInstance) EvalContext {
+func (ctx *BuiltinEvalContext) withScope(scope evalContextScope) EvalContext {
 	newCtx := *ctx
-	newCtx.scope = evalContextModuleInstance{
-		Addr: path,
-	}
-	return &newCtx
-}
-
-func (ctx *BuiltinEvalContext) WithPartialExpandedPath(path addrs.PartialExpandedModule) EvalContext {
-	newCtx := *ctx
-	newCtx.scope = evalContextPartialExpandedModule{
-		Addr: path,
-	}
+	newCtx.scope = scope
 	return &newCtx
 }
 

--- a/internal/terraform/eval_context_builtin_test.go
+++ b/internal/terraform/eval_context_builtin_test.go
@@ -20,12 +20,12 @@ func TestBuiltinEvalContextProviderInput(t *testing.T) {
 	cache := make(map[string]map[string]cty.Value)
 
 	ctx1 := testBuiltinEvalContext(t)
-	ctx1 = ctx1.WithPath(addrs.RootModuleInstance).(*BuiltinEvalContext)
+	ctx1 = ctx1.withScope(evalContextModuleInstance{Addr: addrs.RootModuleInstance}).(*BuiltinEvalContext)
 	ctx1.ProviderInputConfig = cache
 	ctx1.ProviderLock = &lock
 
 	ctx2 := testBuiltinEvalContext(t)
-	ctx2 = ctx2.WithPath(addrs.RootModuleInstance.Child("child", addrs.NoKey)).(*BuiltinEvalContext)
+	ctx2 = ctx2.withScope(evalContextModuleInstance{Addr: addrs.RootModuleInstance.Child("child", addrs.NoKey)}).(*BuiltinEvalContext)
 	ctx2.ProviderInputConfig = cache
 	ctx2.ProviderLock = &lock
 
@@ -61,7 +61,7 @@ func TestBuildingEvalContextInitProvider(t *testing.T) {
 	testP := &MockProvider{}
 
 	ctx := testBuiltinEvalContext(t)
-	ctx = ctx.WithPath(addrs.RootModuleInstance).(*BuiltinEvalContext)
+	ctx = ctx.withScope(evalContextModuleInstance{Addr: addrs.RootModuleInstance}).(*BuiltinEvalContext)
 	ctx.ProviderLock = &lock
 	ctx.ProviderCache = make(map[string]providers.Interface)
 	ctx.Plugins = newContextPlugins(map[addrs.Provider]providers.Factory{

--- a/internal/terraform/eval_context_mock.go
+++ b/internal/terraform/eval_context_mock.go
@@ -118,7 +118,7 @@ type MockEvalContext struct {
 	EvaluationScopeScope   *lang.Scope
 
 	PathCalled bool
-	PathPath   addrs.ModuleInstance
+	Scope      evalContextScope
 
 	LanguageExperimentsActive experiments.Set
 
@@ -326,23 +326,18 @@ func (c *MockEvalContext) EvaluationScope(self addrs.Referenceable, source addrs
 	return c.EvaluationScopeScope
 }
 
-func (c *MockEvalContext) WithPath(path addrs.ModuleInstance) EvalContext {
+func (c *MockEvalContext) withScope(scope evalContextScope) EvalContext {
 	newC := *c
-	newC.PathPath = path
+	newC.Scope = scope
 	return &newC
-}
-
-func (c *MockEvalContext) WithPartialExpandedPath(path addrs.PartialExpandedModule) EvalContext {
-	// This is not yet implemented as a mock, because we've not yet had any
-	// need for it. If we end up needing to test this behavior in isolation
-	// somewhere then we'll need to figure out how to fit it in here without
-	// upsetting too many existing tests that rely on the PathPath field.
-	panic("WithPartialExpandedPath not implemented for MockEvalContext")
 }
 
 func (c *MockEvalContext) Path() addrs.ModuleInstance {
 	c.PathCalled = true
-	return c.PathPath
+	// This intentionally panics if scope isn't a module instance; callers
+	// should use this only for an eval context that's working in a
+	// fully-expanded module instance.
+	return c.Scope.(evalContextModuleInstance).Addr
 }
 
 func (c *MockEvalContext) LanguageExperimentActive(experiment experiments.Experiment) bool {

--- a/internal/terraform/eval_import.go
+++ b/internal/terraform/eval_import.go
@@ -21,7 +21,7 @@ func evaluateImportIdExpression(expr hcl.Expression, ctx EvalContext, keyData in
 
 	// import blocks only exist in the root module, and must be evaluated in
 	// that context.
-	ctx = ctx.WithPath(addrs.RootModuleInstance)
+	ctx = evalContextForModuleInstance(ctx, addrs.RootModuleInstance)
 
 	if expr == nil {
 		return "", diags.Append(&hcl.Diagnostic{

--- a/internal/terraform/graph_interface_subgraph.go
+++ b/internal/terraform/graph_interface_subgraph.go
@@ -36,3 +36,17 @@ type GraphNodeModulePath interface {
 type GraphNodePartialExpandedModule interface {
 	Path() addrs.PartialExpandedModule
 }
+
+// graphNodeEvalContextScope is essentially a combination of
+// [GraphNodeModuleInstance] and [GraphNodePartialExpandedModule] for when
+// the decision between the two must be made dynamically.
+//
+// When a graph node implements this interface, the [EvalContext] passed
+// to its DynamicExpand and/or Execute method will be associated with whatever
+// scope is returned by method Path.
+type graphNodeEvalContextScope interface {
+	// Path must return a _non-nil_ evalContextScope value, which therefore
+	// describes either a fully-expanded module instance address or a
+	// partial-expanded module address.
+	Path() evalContextScope
+}

--- a/internal/terraform/graph_walk.go
+++ b/internal/terraform/graph_walk.go
@@ -4,7 +4,6 @@
 package terraform
 
 import (
-	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/tfdiags"
 )
 
@@ -12,10 +11,8 @@ import (
 // with Graph.Walk will invoke the given callbacks under certain events.
 type GraphWalker interface {
 	EvalContext() EvalContext
-	EnterPath(addrs.ModuleInstance) EvalContext
-	ExitPath(addrs.ModuleInstance)
-	EnterPartialExpandedPath(addrs.PartialExpandedModule) EvalContext
-	ExitPartialExpandedPath(addrs.PartialExpandedModule)
+	enterScope(evalContextScope) EvalContext
+	exitScope(evalContextScope)
 	Execute(EvalContext, GraphNodeExecutable) tfdiags.Diagnostics
 }
 
@@ -24,11 +21,7 @@ type GraphWalker interface {
 // implementing all the required functions.
 type NullGraphWalker struct{}
 
-func (NullGraphWalker) EvalContext() EvalContext                   { return new(MockEvalContext) }
-func (NullGraphWalker) EnterPath(addrs.ModuleInstance) EvalContext { return new(MockEvalContext) }
-func (NullGraphWalker) ExitPath(addrs.ModuleInstance)              {}
-func (NullGraphWalker) EnterPartialExpandedPath(addrs.PartialExpandedModule) EvalContext {
-	return new(MockEvalContext)
-}
-func (NullGraphWalker) ExitPartialExpandedPath(addrs.PartialExpandedModule)          {}
+func (NullGraphWalker) EvalContext() EvalContext                                     { return new(MockEvalContext) }
+func (NullGraphWalker) enterScope(evalContextScope) EvalContext                      { return new(MockEvalContext) }
+func (NullGraphWalker) exitScope(evalContextScope)                                   {}
 func (NullGraphWalker) Execute(EvalContext, GraphNodeExecutable) tfdiags.Diagnostics { return nil }

--- a/internal/terraform/node_resource_abstract_instance_test.go
+++ b/internal/terraform/node_resource_abstract_instance_test.go
@@ -145,7 +145,7 @@ func TestNodeAbstractResourceInstance_WriteResourceInstanceState(t *testing.T) {
 	state := states.NewState()
 	ctx := new(MockEvalContext)
 	ctx.StateState = state.SyncWrapper()
-	ctx.PathPath = addrs.RootModuleInstance
+	ctx.Scope = evalContextModuleInstance{Addr: addrs.RootModuleInstance}
 
 	mockProvider := mockProviderWithResourceTypeSchema("aws_instance", &configschema.Block{
 		Attributes: map[string]*configschema.Attribute{

--- a/internal/terraform/node_resource_abstract_test.go
+++ b/internal/terraform/node_resource_abstract_test.go
@@ -229,7 +229,7 @@ func TestNodeAbstractResource_ReadResourceInstanceState(t *testing.T) {
 		t.Run(k, func(t *testing.T) {
 			ctx := new(MockEvalContext)
 			ctx.StateState = test.State.SyncWrapper()
-			ctx.PathPath = addrs.RootModuleInstance
+			ctx.Scope = evalContextModuleInstance{Addr: addrs.RootModuleInstance}
 			ctx.ProviderSchemaSchema = mockProvider.GetProviderSchema()
 
 			ctx.ProviderProvider = providers.Interface(mockProvider)
@@ -294,7 +294,7 @@ func TestNodeAbstractResource_ReadResourceInstanceStateDeposed(t *testing.T) {
 		t.Run(k, func(t *testing.T) {
 			ctx := new(MockEvalContext)
 			ctx.StateState = test.State.SyncWrapper()
-			ctx.PathPath = addrs.RootModuleInstance
+			ctx.Scope = evalContextModuleInstance{Addr: addrs.RootModuleInstance}
 			ctx.ProviderSchemaSchema = mockProvider.GetProviderSchema()
 			ctx.ProviderProvider = providers.Interface(mockProvider)
 

--- a/internal/terraform/node_resource_apply.go
+++ b/internal/terraform/node_resource_apply.go
@@ -46,13 +46,13 @@ func (n *nodeExpandApplyableResource) Name() string {
 	return n.NodeAbstractResource.Name() + " (expand)"
 }
 
-func (n *nodeExpandApplyableResource) Execute(ctx EvalContext, op walkOperation) tfdiags.Diagnostics {
+func (n *nodeExpandApplyableResource) Execute(globalCtx EvalContext, op walkOperation) tfdiags.Diagnostics {
 	var diags tfdiags.Diagnostics
-	expander := ctx.InstanceExpander()
+	expander := globalCtx.InstanceExpander()
 	moduleInstances := expander.ExpandModule(n.Addr.Module)
 	for _, module := range moduleInstances {
-		ctx = ctx.WithPath(module)
-		diags = diags.Append(n.writeResourceState(ctx, n.Addr.Resource.Absolute(module)))
+		moduleCtx := evalContextForModuleInstance(globalCtx, module)
+		diags = diags.Append(n.writeResourceState(moduleCtx, n.Addr.Resource.Absolute(module)))
 	}
 
 	return diags

--- a/internal/terraform/node_resource_destroy_deposed_test.go
+++ b/internal/terraform/node_resource_destroy_deposed_test.go
@@ -153,7 +153,7 @@ func TestNodeDestroyDeposedResourceInstanceObject_WriteResourceInstanceState(t *
 	state := states.NewState()
 	ctx := new(MockEvalContext)
 	ctx.StateState = state.SyncWrapper()
-	ctx.PathPath = addrs.RootModuleInstance
+	ctx.Scope = evalContextModuleInstance{Addr: addrs.RootModuleInstance}
 	mockProvider := mockProviderWithResourceTypeSchema("aws_instance", &configschema.Block{
 		Attributes: map[string]*configschema.Attribute{
 			"id": {

--- a/internal/terraform/node_resource_plan.go
+++ b/internal/terraform/node_resource_plan.go
@@ -230,7 +230,7 @@ func (n *nodeExpandPlannableResource) expandResourceInstances(globalCtx EvalCont
 
 	// The rest of our work here needs to know which module instance it's
 	// working in, so that it can evaluate expressions in the appropriate scope.
-	moduleCtx := globalCtx.WithPath(resAddr.Module)
+	moduleCtx := evalContextForModuleInstance(globalCtx, resAddr.Module)
 
 	// writeResourceState is responsible for informing the expander of what
 	// repetition mode this resource has, which allows expander.ExpandResource
@@ -339,7 +339,7 @@ func (n nodeExpandPlannableResource) expandResourceImports(ctx EvalContext, addr
 
 	// Import blocks are only valid within the root module, and must be
 	// evaluated within that context
-	ctx = ctx.WithPath(addrs.RootModuleInstance)
+	ctx = evalContextForModuleInstance(ctx, addrs.RootModuleInstance)
 
 	for _, imp := range n.importTargets {
 		if imp.Config == nil {

--- a/internal/terraform/transform_import_state_test.go
+++ b/internal/terraform/transform_import_state_test.go
@@ -30,6 +30,7 @@ func TestGraphNodeImportStateExecute(t *testing.T) {
 	provider.ConfigureProvider(providers.ConfigureProviderRequest{})
 
 	ctx := &MockEvalContext{
+		Scope:            evalContextModuleInstance{Addr: addrs.RootModuleInstance},
 		StateState:       state.SyncWrapper(),
 		ProviderProvider: provider,
 	}


### PR DESCRIPTION
This is a continuation of some restructuring started in #34571.

In those earlier commits my goal was to minimize breaking changes to the `EvalContext` API to churn existing code as little as possible.

However, the way I achieved that was to handle fully-expanded modules and partial-expanded modules as two completely separate codepaths, which means that all other code must statically decide which of the two cases it's dealing with even though there's not really any reason the `EvalContext` implementation couldn't support that being decided dynamically.

For the "deferred actions" work, in a future commit we'll need to introduce a new graph node type representing partial-expanded resources which must decide dynamically whether it's in a fully-expanded module scope or a partial-expanded module scope, because the treatment is quite different for a fully-expanded module containing a resource with unknown expansion vs. a resource that's inside a module that hasn't been expanded itself.

This is therefore the logical conclusion of the previous work, making "eval context scope" the primary way that we talk about where an eval context is doing its work, with a helper function for the common case where that's a fully-expanded `ModuleInstance`.

In particular, this includes a third variation of the family of interfaces that have method `Path` indicating the scope that the node should be evaluated in. `graphNodeEvalContextScope.Path` may return any non-nil `evalContextScope` value chosen dynamically at runtime. The existing interfaces that statically return `addrs.ModuleInstance` and `addrs.PartialExpandedModule` respectively remain as statically-typed alternatives for the common case, since the need to decide dynamically is (for now) limited only to nodes representing `addrs.PartialExpandedResource` addresses.

This has unfortunately now churned a little more code than I originally wanted to, but the helper functions and the retaining of the statically-typed node-scope-discovery interfaces has kept it as small as possible.

(This also continues our effort to gradually make the implementation details of package terraform be unexported, at the expense of a little inconsistency in the short term where these new fields/types are mixed in with exported fields/types. Hopefully we'll continue on this quest over time and eventually reach things being consistently unexported.)

---

The first (and, for now, only) implementation of `graphNodeEvalContextScope` will follow in a future PR, adding a new graph node representing what the `addrs.PartialExpandedResource` address type represents: either an unknown resource instance address inside a known module instance address, _or_ an unknown resource instance address inside an unknown module instance address.

