### PR TITLE
if file provisioners source is null throw error instead of panic

### DIFF
--- a/internal/builtin/provisioners/file/resource_provisioner.go
+++ b/internal/builtin/provisioners/file/resource_provisioner.go
@@ -148,7 +148,7 @@ func getSrc(v cty.Value) (string, bool, error) {
 		return expansion, false, err
 
 	default:
-		panic("source and content cannot both be null")
+		return "", false, errors.New("source and content cannot both be null")
 	}
 }
 

--- a/internal/builtin/provisioners/file/resource_provisioner_test.go
+++ b/internal/builtin/provisioners/file/resource_provisioner_test.go
@@ -84,6 +84,21 @@ func TestResourceProvider_Validate_bad_no_source(t *testing.T) {
 	}
 }
 
+func TestResourceProvider_Validate_bad_null_source(t *testing.T) {
+	v := cty.ObjectVal(map[string]cty.Value{
+		"destination": cty.StringVal("/tmp/bar"),
+		"source":      cty.NullVal(cty.String),
+	})
+
+	resp := New().ValidateProvisionerConfig(provisioners.ValidateProvisionerConfigRequest{
+		Config: v,
+	})
+
+	if !resp.Diagnostics.HasErrors() {
+		t.Fatal("Should have errors")
+	}
+}
+
 func TestResourceProvider_Validate_bad_to_many_src(t *testing.T) {
 	v := cty.ObjectVal(map[string]cty.Value{
 		"source":      cty.StringVal("nope"),


### PR DESCRIPTION
Instead of a panic return an error


<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Fixes #34454

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.7.x

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

### BUG FIXES

<!--

Write a short description of the user-facing change. Examples:

- `terraform show -json`: Fixed crash with sensitive set values.
- When rendering a diff, Terraform now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 

- don't panic when file provisioner source is null 
