### PR TITLE
ci: Add test for license headers

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -64,6 +64,17 @@ jobs:
         run: |
           go test ./...
 
+  copywrite-tests:
+    name: "License Header Checks"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+      - name: Install copywrite
+        uses: hashicorp/setup-copywrite@v1.1.2
+      - name: Validate Header Compliance
+        run: copywrite headers --plan
+
   race-tests:
     name: "Race Tests"
     runs-on: ubuntu-latest

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -64,17 +64,6 @@ jobs:
         run: |
           go test ./...
 
-  copywrite-tests:
-    name: "License Header Checks"
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Repo
-        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
-      - name: Install copywrite
-        uses: hashicorp/setup-copywrite@v1.1.2
-      - name: Validate Header Compliance
-        run: copywrite headers --plan
-
   race-tests:
     name: "Race Tests"
     runs-on: ubuntu-latest
@@ -193,7 +182,7 @@ jobs:
 
       - name: "Code consistency checks"
         run: |
-          make fmtcheck importscheck generate staticcheck exhaustive protobuf
+          make fmtcheck importscheck copyright generate staticcheck exhaustive protobuf
           if [[ -n "$(git status --porcelain)" ]]; then
             echo >&2 "ERROR: Generated files are inconsistent. Run 'make generate' and 'make protobuf' locally and then commit the updated files."
             git >&2 status --porcelain

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,9 @@ exhaustive:
 	"$(CURDIR)/scripts/exhaustive.sh"
 
 copyright:
+	"$(CURDIR)/scripts/copyright.sh" --plan
+
+copyrightfix:
 	"$(CURDIR)/scripts/copyright.sh"
 
 # Run this if working on the website locally to run in watch mode.

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,9 @@ staticcheck:
 exhaustive:
 	"$(CURDIR)/scripts/exhaustive.sh"
 
+copyright:
+	"$(CURDIR)/scripts/copyright.sh"
+
 # Run this if working on the website locally to run in watch mode.
 website:
 	$(MAKE) -C website website

--- a/copyright_headers.go
+++ b/copyright_headers.go
@@ -1,6 +1,0 @@
-// Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: BUSL-1.1
-
-package main
-
-//go:generate go run github.com/hashicorp/copywrite headers

--- a/docs/plugin-protocol/copyright_headers.go
+++ b/docs/plugin-protocol/copyright_headers.go
@@ -1,6 +1,0 @@
-// Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-1.1
-
-package plugin_protocol
-
-//go:generate go run github.com/hashicorp/copywrite headers

--- a/internal/tfplugin5/copyright_headers.go
+++ b/internal/tfplugin5/copyright_headers.go
@@ -1,6 +1,0 @@
-// Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-1.1
-
-package tfplugin5
-
-//go:generate go run github.com/hashicorp/copywrite headers

--- a/internal/tfplugin6/copyright_headers.go
+++ b/internal/tfplugin6/copyright_headers.go
@@ -1,6 +1,0 @@
-// Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-1.1
-
-package tfplugin6
-
-//go:generate go run github.com/hashicorp/copywrite headers

--- a/scripts/copyright.sh
+++ b/scripts/copyright.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
+# This script checks that all files have the appropriate copyright headers,
+# according to their nearest .copywrite.hcl config file. The copyright tool
+# does not natively support repos with multiple licenses, so we have to
+# script this ourselves.
+
+set -euo pipefail
+
+# Find all directories containing a .copywrite.hcl config file
+directories=$(find . -type f -name '.copywrite.hcl' -execdir pwd \;)
+
+for dir in $directories; do
+    cd $dir && go run github.com/hashicorp/copywrite headers --plan
+done

--- a/scripts/copyright.sh
+++ b/scripts/copyright.sh
@@ -11,7 +11,8 @@ set -euo pipefail
 
 # Find all directories containing a .copywrite.hcl config file
 directories=$(find . -type f -name '.copywrite.hcl' -execdir pwd \;)
+args=${1:-}
 
 for dir in $directories; do
-    cd $dir && go run github.com/hashicorp/copywrite headers --plan
+    cd $dir && pwd && go run github.com/hashicorp/copywrite headers $args
 done


### PR DESCRIPTION
This is a follow-up to https://github.com/hashicorp/terraform/pull/34617

In other words the aim here is to ensure we do not forget to add copyright/license headers for any future incoming code.

Here is a test run to verify this actually works: https://github.com/hashicorp/terraform/actions/runs/7799797486/job/21271331690?pr=34624#step:4:21

![Screenshot 2024-02-06 at 12 40 21](https://github.com/hashicorp/terraform/assets/287584/b7337616-de76-4518-a6e2-a6fdff46bd9f)

## Target Release

1.8.x
