### PR TITLE
fix panic when import id is empty string

### DIFF
--- a/internal/terraform/context_plan_import_test.go
+++ b/internal/terraform/context_plan_import_test.go
@@ -598,6 +598,30 @@ func TestContext2Plan_importIdInvalidNull(t *testing.T) {
 	}
 }
 
+func TestContext2Plan_importIdInvalidEmptyString(t *testing.T) {
+	p := testProvider("test")
+	m := testModule(t, "import-id-invalid-null")
+	ctx := testContext2(t, &ContextOpts{
+		Providers: map[addrs.Provider]providers.Factory{
+			addrs.NewDefaultProvider("test"): testProviderFuncFixed(p),
+		},
+	})
+
+	_, diags := ctx.Plan(m, states.NewState(), &PlanOpts{
+		SetVariables: InputValues{
+			"the_id": &InputValue{
+				Value: cty.StringVal(""),
+			},
+		},
+	})
+	if !diags.HasErrors() {
+		t.Fatal("succeeded; want errors")
+	}
+	if got, want := diags.Err().Error(), "The import ID value evaluates to an empty string, please provide a non-empty value."; !strings.Contains(got, want) {
+		t.Fatalf("wrong error:\ngot:  %s\nwant: message containing %q", got, want)
+	}
+}
+
 func TestContext2Plan_importIdInvalidUnknown(t *testing.T) {
 	p := testProvider("test")
 	m := testModule(t, "import-id-invalid-unknown")

--- a/internal/terraform/eval_import.go
+++ b/internal/terraform/eval_import.go
@@ -72,6 +72,15 @@ func evaluateImportIdExpression(expr hcl.Expression, ctx EvalContext, keyData in
 		})
 	}
 
+	if importId == "" {
+		return "", diags.Append(&hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  "Invalid import id argument",
+			Detail:   "The import ID value evaluates to an empty string, please provide a non-empty value.",
+			Subject:  expr.Range().Ptr(),
+		})
+	}
+
 	return importId, diags
 }
 


### PR DESCRIPTION
 We can only detect this during evaluation since the import id is an hcl expression


<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Fixes #33505

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.7.x

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

### BUG FIXES


<!--

Write a short description of the user-facing change. Examples:

- `terraform show -json`: Fixed crash with sensitive set values.
- When rendering a diff, Terraform now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 

- throw helpful error message if import block is configured with id ""  
