### PR TITLE
In import-generated code represent JSON values in HCL instead of as strings

### DIFF
--- a/internal/genconfig/generate_config_test.go
+++ b/internal/genconfig/generate_config_test.go
@@ -423,6 +423,121 @@ resource "tfcoremock_simple_resource" "empty" {
   single = null
 }`,
 		},
+		"simple_resource_with_stringified_json_object": {
+			schema: &configschema.Block{
+				// BlockTypes: map[string]*configschema.NestedBlock{},
+				Attributes: map[string]*configschema.Attribute{
+					"id": {
+						Type:     cty.String,
+						Computed: true,
+					},
+					"value": {
+						Type:     cty.String,
+						Optional: true,
+					},
+				},
+			},
+			addr: addrs.AbsResourceInstance{
+				Module: nil,
+				Resource: addrs.ResourceInstance{
+					Resource: addrs.Resource{
+						Mode: addrs.ManagedResourceMode,
+						Type: "tfcoremock_simple_resource",
+						Name: "empty",
+					},
+					Key: nil,
+				},
+			},
+			provider: addrs.LocalProviderConfig{
+				LocalName: "tfcoremock",
+			},
+			value: cty.ObjectVal(map[string]cty.Value{
+				"id":    cty.StringVal("D2320658"),
+				"value": cty.StringVal(`{ "0Hello": "World", "And": ["Solar", "System"], "ready": true }`),
+			}),
+			expected: `
+resource "tfcoremock_simple_resource" "empty" {
+  value = jsonencode({
+    "0Hello" = "World"
+    And      = ["Solar", "System"]
+    ready    = true
+  })
+}`,
+		},
+		"simple_resource_with_stringified_json_array": {
+			schema: &configschema.Block{
+				// BlockTypes: map[string]*configschema.NestedBlock{},
+				Attributes: map[string]*configschema.Attribute{
+					"id": {
+						Type:     cty.String,
+						Computed: true,
+					},
+					"value": {
+						Type:     cty.String,
+						Optional: true,
+					},
+				},
+			},
+			addr: addrs.AbsResourceInstance{
+				Module: nil,
+				Resource: addrs.ResourceInstance{
+					Resource: addrs.Resource{
+						Mode: addrs.ManagedResourceMode,
+						Type: "tfcoremock_simple_resource",
+						Name: "empty",
+					},
+					Key: nil,
+				},
+			},
+			provider: addrs.LocalProviderConfig{
+				LocalName: "tfcoremock",
+			},
+			value: cty.ObjectVal(map[string]cty.Value{
+				"id":    cty.StringVal("D2320658"),
+				"value": cty.StringVal(`["Hello", "World"]`),
+			}),
+			expected: `
+resource "tfcoremock_simple_resource" "empty" {
+  value = jsonencode(["Hello", "World"])
+}`,
+		},
+		"simple_resource_with_malformed_json": {
+			schema: &configschema.Block{
+				// BlockTypes: map[string]*configschema.NestedBlock{},
+				Attributes: map[string]*configschema.Attribute{
+					"id": {
+						Type:     cty.String,
+						Computed: true,
+					},
+					"value": {
+						Type:     cty.String,
+						Optional: true,
+					},
+				},
+			},
+			addr: addrs.AbsResourceInstance{
+				Module: nil,
+				Resource: addrs.ResourceInstance{
+					Resource: addrs.Resource{
+						Mode: addrs.ManagedResourceMode,
+						Type: "tfcoremock_simple_resource",
+						Name: "empty",
+					},
+					Key: nil,
+				},
+			},
+			provider: addrs.LocalProviderConfig{
+				LocalName: "tfcoremock",
+			},
+			value: cty.ObjectVal(map[string]cty.Value{
+				"id":    cty.StringVal("D2320658"),
+				"value": cty.StringVal(`["Hello", "World"`),
+			}),
+			expected: `
+resource "tfcoremock_simple_resource" "empty" {
+  value = "[\"Hello\", \"World\""
+}`,
+		},
 	}
 	for name, tc := range tcs {
 		t.Run(name, func(t *testing.T) {


### PR DESCRIPTION
This makes the value easier to read and is mostly an aesthetic change.


<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Fixes #34444

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.8.x

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

### ENHANCEMENTS

<!--

Write a short description of the user-facing change. Examples:

- `terraform show -json`: Fixed crash with sensitive set values.
- When rendering a diff, Terraform now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 

-  In import-generated code represent JSON values in HCL instead of as strings
