### PR TITLE
improve provider lock speed by using cache

### DIFF
--- a/internal/command/providers_lock.go
+++ b/internal/command/providers_lock.go
@@ -415,7 +415,7 @@ Options:
 
   -enable-plugin-cache   Enable the usage of the globally configured plugin cache.
                          This will speed up the locking process, but the providers
-                         wont be loaded from am authoritative source.
+                         wont be loaded from an authoritative source.
 `
 }
 

--- a/internal/command/providers_lock.go
+++ b/internal/command/providers_lock.go
@@ -249,7 +249,7 @@ func (c *ProvidersLockCommand) Run(args []string) int {
 		dir := providercache.NewDirWithPlatform(tempDir, platform)
 		installer := providercache.NewInstaller(dir, source)
 
-		// Use global plugin cache for extra speed if this architecture matches the systems (and therefore the caches) one
+		// Use global plugin cache for extra speed if present and flag is set
 		globalCacheDir := c.providerGlobalCacheDir()
 		if *pluginCache && globalCacheDir != nil {
 			installer.SetGlobalCacheDir(globalCacheDir.WithPlatform(platform))

--- a/internal/command/providers_lock.go
+++ b/internal/command/providers_lock.go
@@ -249,8 +249,8 @@ func (c *ProvidersLockCommand) Run(args []string) int {
 
 		// Use global plugin cache for extra speed if this architecture matches the systems (and therefore the caches) one
 		globalCacheDir := c.providerGlobalCacheDir()
-		if globalCacheDir != nil && platform == getproviders.CurrentPlatform {
-			installer.SetGlobalCacheDir(globalCacheDir)
+		if globalCacheDir != nil {
+			installer.SetGlobalCacheDir(globalCacheDir.WithPlatform(platform))
 			installer.SetGlobalCacheDirMayBreakDependencyLockFile(c.PluginCacheMayBreakDependencyLockFile)
 		}
 

--- a/internal/command/providers_lock.go
+++ b/internal/command/providers_lock.go
@@ -43,9 +43,11 @@ func (c *ProvidersLockCommand) Run(args []string) int {
 	var optPlatforms FlagStringSlice
 	var fsMirrorDir string
 	var netMirrorURL string
+
 	cmdFlags.Var(&optPlatforms, "platform", "target platform")
 	cmdFlags.StringVar(&fsMirrorDir, "fs-mirror", "", "filesystem mirror directory")
 	cmdFlags.StringVar(&netMirrorURL, "net-mirror", "", "network mirror base URL")
+	pluginCache := cmdFlags.Bool("enable-plugin-cache", false, "")
 	cmdFlags.Usage = func() { c.Ui.Error(c.Help()) }
 	if err := cmdFlags.Parse(args); err != nil {
 		c.Ui.Error(fmt.Sprintf("Error parsing command-line flags: %s\n", err.Error()))
@@ -249,7 +251,7 @@ func (c *ProvidersLockCommand) Run(args []string) int {
 
 		// Use global plugin cache for extra speed if this architecture matches the systems (and therefore the caches) one
 		globalCacheDir := c.providerGlobalCacheDir()
-		if globalCacheDir != nil {
+		if *pluginCache && globalCacheDir != nil {
 			installer.SetGlobalCacheDir(globalCacheDir.WithPlatform(platform))
 			installer.SetGlobalCacheDirMayBreakDependencyLockFile(c.PluginCacheMayBreakDependencyLockFile)
 		}
@@ -378,38 +380,42 @@ Usage: terraform [global options] providers lock [options] [providers...]
 
 Options:
 
-  -fs-mirror=dir     Consult the given filesystem mirror directory instead
-                     of the origin registry for each of the given providers.
+  -fs-mirror=dir         Consult the given filesystem mirror directory instead
+                         of the origin registry for each of the given providers.
 
-                     This would be necessary to generate lock file entries for
-                     a provider that is available only via a mirror, and not
-                     published in an upstream registry. In this case, the set
-                     of valid checksums will be limited only to what Terraform
-                     can learn from the data in the mirror directory.
+                         This would be necessary to generate lock file entries for
+                         a provider that is available only via a mirror, and not
+                         published in an upstream registry. In this case, the set
+                         of valid checksums will be limited only to what Terraform
+                         can learn from the data in the mirror directory.
 
-  -net-mirror=url    Consult the given network mirror (given as a base URL)
-                     instead of the origin registry for each of the given
-                     providers.
+  -net-mirror=url        Consult the given network mirror (given as a base URL)
+                         instead of the origin registry for each of the given
+                         providers.
 
-                     This would be necessary to generate lock file entries for
-                     a provider that is available only via a mirror, and not
-                     published in an upstream registry. In this case, the set
-                     of valid checksums will be limited only to what Terraform
-                     can learn from the data in the mirror indices.
+                         This would be necessary to generate lock file entries for
+                         a provider that is available only via a mirror, and not
+                         published in an upstream registry. In this case, the set
+                         of valid checksums will be limited only to what Terraform
+                         can learn from the data in the mirror indices.
 
-  -platform=os_arch  Choose a target platform to request package checksums
-                     for.
+  -platform=os_arch      Choose a target platform to request package checksums
+                         for.
 
-                     By default Terraform will request package checksums
-                     suitable only for the platform where you run this
-                     command. Use this option multiple times to include
-                     checksums for multiple target systems.
+                         By default Terraform will request package checksums
+                         suitable only for the platform where you run this
+                         command. Use this option multiple times to include
+                         checksums for multiple target systems.
 
-                     Target names consist of an operating system and a CPU
-                     architecture. For example, "linux_amd64" selects the
-                     Linux operating system running on an AMD64 or x86_64
-                     CPU. Each provider is available only for a limited
-                     set of target platforms.
+                         Target names consist of an operating system and a CPU
+                         architecture. For example, "linux_amd64" selects the
+                         Linux operating system running on an AMD64 or x86_64
+                         CPU. Each provider is available only for a limited
+                         set of target platforms.
+
+  -enable-plugin-cache   Enable the usage of the globally configured plugin cache.
+                         This will speed up the locking process, but the providers
+                         wont be loaded from am authoritative source.
 `
 }
 

--- a/internal/command/providers_lock.go
+++ b/internal/command/providers_lock.go
@@ -245,7 +245,6 @@ func (c *ProvidersLockCommand) Run(args []string) int {
 		}
 		ctx := evts.OnContext(ctx)
 
-		// We can not use c.providerGlobalCacheDir() as we install the provider into a temp dir
 		dir := providercache.NewDirWithPlatform(tempDir, platform)
 		installer := providercache.NewInstaller(dir, source)
 

--- a/internal/providercache/dir.go
+++ b/internal/providercache/dir.go
@@ -75,6 +75,12 @@ func (d *Dir) BasePath() string {
 	return filepath.Clean(d.baseDir)
 }
 
+// WithPlatform creates a new dir with the provided platform based
+// on this dir
+func (d *Dir) WithPlatform(platform getproviders.Platform) *Dir {
+	return NewDirWithPlatform(d.baseDir, platform)
+}
+
 // AllAvailablePackages returns a description of all of the packages already
 // present in the directory. The cache entries are grouped by the provider
 // they relate to and then sorted by version precedence, with highest


### PR DESCRIPTION
This is only possible for the architecture of the system since the cache is only for one architecture.

<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Fixes #33837


## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.8.x

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

### ENHANCEMENTS

<!--

Write a short description of the user-facing change. Examples:

- `terraform show -json`: Fixed crash with sensitive set values.
- When rendering a diff, Terraform now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 

-  improve provider lock speed by using cache
