### PR TITLE
Fix nil pointer exception when planning stacks with undeclared variables

### DIFF
--- a/internal/stacks/stackruntime/internal/stackeval/stack.go
+++ b/internal/stacks/stackruntime/internal/stackeval/stack.go
@@ -420,6 +420,7 @@ func (s *Stack) resolveExpressionReference(ctx context.Context, ref stackaddrs.R
 				Detail:   fmt.Sprintf("There is no variable %q block declared in this stack.", addr.Name),
 				Subject:  ref.SourceRange.ToHCL().Ptr(),
 			})
+			return nil, diags
 		}
 		return ret, diags
 	case stackaddrs.Component:
@@ -431,6 +432,7 @@ func (s *Stack) resolveExpressionReference(ctx context.Context, ref stackaddrs.R
 				Detail:   fmt.Sprintf("There is no component %q block declared in this stack.", addr.Name),
 				Subject:  ref.SourceRange.ToHCL().Ptr(),
 			})
+			return nil, diags
 		}
 		return ret, diags
 	case stackaddrs.StackCall:
@@ -442,6 +444,7 @@ func (s *Stack) resolveExpressionReference(ctx context.Context, ref stackaddrs.R
 				Detail:   fmt.Sprintf("There is no stack %q block declared this stack.", addr.Name),
 				Subject:  ref.SourceRange.ToHCL().Ptr(),
 			})
+			return nil, diags
 		}
 		return ret, diags
 	case stackaddrs.ProviderConfigRef:
@@ -453,6 +456,7 @@ func (s *Stack) resolveExpressionReference(ctx context.Context, ref stackaddrs.R
 				Detail:   fmt.Sprintf("There is no provider %q %q block declared this stack.", addr.ProviderLocalName, addr.Name),
 				Subject:  ref.SourceRange.ToHCL().Ptr(),
 			})
+			return nil, diags
 		}
 		return ret, diags
 	case stackaddrs.ContextualRef:

--- a/internal/stacks/stackruntime/internal/stackeval/stack_config.go
+++ b/internal/stacks/stackruntime/internal/stackeval/stack_config.go
@@ -9,13 +9,14 @@ import (
 	"sync"
 
 	"github.com/hashicorp/hcl/v2"
+	"github.com/zclconf/go-cty/cty"
+
 	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/instances"
 	"github.com/hashicorp/terraform/internal/promising"
 	"github.com/hashicorp/terraform/internal/stacks/stackaddrs"
 	"github.com/hashicorp/terraform/internal/stacks/stackconfig"
 	"github.com/hashicorp/terraform/internal/tfdiags"
-	"github.com/zclconf/go-cty/cty"
 )
 
 // StackConfig represents a stack as represented in the configuration: either the
@@ -336,6 +337,7 @@ func (s *StackConfig) resolveExpressionReference(ctx context.Context, ref stacka
 				Detail:   fmt.Sprintf("There is no variable %q block declared in this stack.", addr.Name),
 				Subject:  ref.SourceRange.ToHCL().Ptr(),
 			})
+			return nil, diags
 		}
 		return ret, diags
 	case stackaddrs.Component:
@@ -347,6 +349,7 @@ func (s *StackConfig) resolveExpressionReference(ctx context.Context, ref stacka
 				Detail:   fmt.Sprintf("There is no component %q block declared in this stack.", addr.Name),
 				Subject:  ref.SourceRange.ToHCL().Ptr(),
 			})
+			return nil, diags
 		}
 		return ret, diags
 	case stackaddrs.StackCall:
@@ -358,6 +361,7 @@ func (s *StackConfig) resolveExpressionReference(ctx context.Context, ref stacka
 				Detail:   fmt.Sprintf("There is no stack %q block declared this stack.", addr.Name),
 				Subject:  ref.SourceRange.ToHCL().Ptr(),
 			})
+			return nil, diags
 		}
 		return ret, diags
 	default:

--- a/internal/stacks/stackruntime/plan_test.go
+++ b/internal/stacks/stackruntime/plan_test.go
@@ -11,6 +11,10 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/hcl/v2"
+	"github.com/zclconf/go-cty-debug/ctydebug"
+	"github.com/zclconf/go-cty/cty"
+
 	"github.com/hashicorp/terraform/internal/addrs"
 	terraformProvider "github.com/hashicorp/terraform/internal/builtin/providers/terraform"
 	"github.com/hashicorp/terraform/internal/collections"
@@ -23,9 +27,58 @@ import (
 	"github.com/hashicorp/terraform/internal/terraform"
 	"github.com/hashicorp/terraform/internal/tfdiags"
 	"github.com/hashicorp/terraform/version"
-	"github.com/zclconf/go-cty-debug/ctydebug"
-	"github.com/zclconf/go-cty/cty"
 )
+
+func TestPlanWithMissingInputVariable(t *testing.T) {
+	ctx := context.Background()
+	cfg := loadMainBundleConfigForTest(t, "plan-undeclared-variable-in-component")
+
+	fakePlanTimestamp, err := time.Parse(time.RFC3339, "1994-09-05T08:50:00Z")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	changesCh := make(chan stackplan.PlannedChange, 8)
+	diagsCh := make(chan tfdiags.Diagnostic, 2)
+	req := PlanRequest{
+		Config: cfg,
+		ProviderFactories: map[addrs.Provider]providers.Factory{
+			addrs.NewBuiltInProvider("terraform"): func() (providers.Interface, error) {
+				return terraformProvider.NewProvider(), nil
+			},
+		},
+
+		ForcePlanTimestamp: &fakePlanTimestamp,
+	}
+	resp := PlanResponse{
+		PlannedChanges: changesCh,
+		Diagnostics:    diagsCh,
+	}
+
+	go Plan(ctx, &req, &resp)
+	_, gotDiags := collectPlanOutput(changesCh, diagsCh)
+
+	// We'll normalize the diagnostics to be of consistent underlying type
+	// using ForRPC, so that we can easily diff them; we don't actually care
+	// about which underlying implementation is in use.
+	gotDiags = gotDiags.ForRPC()
+	var wantDiags tfdiags.Diagnostics
+	wantDiags = wantDiags.Append(&hcl.Diagnostic{
+		Severity: hcl.DiagError,
+		Summary:  "Reference to undeclared input variable",
+		Detail:   `There is no variable "input" block declared in this stack.`,
+		Subject: &hcl.Range{
+			Filename: mainBundleSourceAddrStr("plan-undeclared-variable-in-component/undeclared-variable.tfstack.hcl"),
+			Start:    hcl.Pos{Line: 17, Column: 13, Byte: 250},
+			End:      hcl.Pos{Line: 17, Column: 22, Byte: 259},
+		},
+	})
+	wantDiags = wantDiags.ForRPC()
+
+	if diff := cmp.Diff(wantDiags, gotDiags); diff != "" {
+		t.Errorf("wrong diagnostics\n%s", diff)
+	}
+}
 
 func TestPlanWithSingleResource(t *testing.T) {
 	ctx := context.Background()

--- a/internal/stacks/stackruntime/testdata/mainbundle/test/plan-undeclared-variable-in-component/undeclared-variable.tfstack.hcl
+++ b/internal/stacks/stackruntime/testdata/mainbundle/test/plan-undeclared-variable-in-component/undeclared-variable.tfstack.hcl
@@ -1,0 +1,19 @@
+required_providers {
+  terraform = {
+    source = "terraform.io/builtin/terraform"
+  }
+}
+
+provider "terraform" "default" {}
+
+component "self" {
+  source = "./"
+
+  providers = {
+    terraform = provider.terraform.default
+  }
+
+  inputs = {
+    input = var.input
+  }
+}

--- a/internal/stacks/stackruntime/testdata/mainbundle/test/plan-undeclared-variable-in-component/with-single-input.tf
+++ b/internal/stacks/stackruntime/testdata/mainbundle/test/plan-undeclared-variable-in-component/with-single-input.tf
@@ -1,0 +1,19 @@
+terraform {
+  required_providers {
+    terraform = {
+      source = "terraform.io/builtin/terraform"
+    }
+  }
+}
+
+variable "input" {
+  type = string
+}
+
+resource "terraform_data" "main" {
+  input = var.input
+}
+
+output "output" {
+  value = terraform_data.main.output
+}


### PR DESCRIPTION
This PR fixes a null pointer exception that originates here: https://github.com/hashicorp/terraform/blob/main/internal/stacks/stackruntime/internal/stackeval/expression_refs.go#L142

The lines in question are:

```go
target, _ := m.ResolveAbsExpressionReference(ctx, ref, phase)
if target == nil {
	continue
}
```

`target` is null, but makes it through the null check because of a quirk in the go type system. A golang value is made up of two elements, the type and the value. `nil` is a keyword that maps to `(type=nil,value=nil)`. In this case the logic in the modified function was essentially calling `Referenceable(nil)` (as it returns an `*InputValue` as a `Referenceable`). This means the value returned by that function was actually `(type=Referenceable,value=nil)` and not something equivalent to `nil`. And so, the nil check above was failing.

This PR makes the underlying function return the concrete `nil` value directly, instead of the implied cast up to `Referenceable` by calling `return ret, diags`. This fixes the underlying issue, and lets the plan return the expected diags that is has built anyway. There is a test that validates this.

## Alternatives

There are alternative ways to fix this. We could validate the missing diags directly instead of asserting over the `nil` status of the returned target:

```go
target, diags := m.ResolveAbsExpressionReference(ctx, ref, phase)
if diags.HasErrors() {
	continue
}
```

The above means we don't need to tweak the function that this PR changes. However, I've seen this pattern a lot in Terraform where we assert over null to check if something is valid so I think fixing at the source is a better idea since that is the expected functionality (as in a null check should work).

## Extensions

This should be caught by the validate functionality that is (or should be) called first. That way the plan would never even be called so it couldn't crash. This means there's missing validations. My understanding of the validate functionality is that it's missing lots of functionality, and I'm not sure whether the best way to handle this is to piecemeal adds bits of validate functionality as we find it (like now) or maybe we have a single project coming up later and I should make a note that this is missing. I can even add a test that is failing now, and mark it with a skip or TODO. I think this is something that @radditude could comment on. Fixing this null pointer is high priority, is implementing validations equally high priority or are there other tickets / features I could be fixing after fixing this specific issue.