### PR TITLE
feat(import): adds parameter to ignore non-existing remote resource for import

### DIFF
--- a/internal/configs/import.go
+++ b/internal/configs/import.go
@@ -5,6 +5,7 @@ package configs
 
 import (
 	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/gohcl"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 	hcljson "github.com/hashicorp/hcl/v2/json"
 	"github.com/hashicorp/terraform/internal/addrs"
@@ -22,6 +23,8 @@ type Import struct {
 	ToResource addrs.ConfigResource
 
 	ForEach hcl.Expression
+
+	IgnoreNotExists bool
 
 	ProviderConfigRef *ProviderConfigRef
 	Provider          addrs.Provider
@@ -41,6 +44,12 @@ func decodeImportBlock(block *hcl.Block) (*Import, hcl.Diagnostics) {
 
 	if attr, exists := content.Attributes["id"]; exists {
 		imp.ID = attr.Expr
+	}
+
+	if attr, exists := content.Attributes["ignore_not_exists"]; exists {
+		valDiags := gohcl.DecodeExpression(attr.Expr, nil, &imp.IgnoreNotExists)
+		diags = append(diags, valDiags...)
+		imp.IgnoreNotExists = true
 	}
 
 	if attr, exists := content.Attributes["to"]; exists {
@@ -97,6 +106,9 @@ var importBlockSchema = &hcl.BodySchema{
 		},
 		{
 			Name: "for_each",
+		},
+		{
+			Name: "ignore_not_exists",
 		},
 		{
 			Name:     "id",

--- a/internal/terraform/node_resource_import.go
+++ b/internal/terraform/node_resource_import.go
@@ -230,7 +230,7 @@ func (n *graphNodeImportStateSub) Execute(ctx EvalContext, op walkOperation) (di
 		return diags
 	}
 
-	// Verify the existance of the imported resource
+	// Verify the existence of the imported resource
 	if state.Value.IsNull() {
 		var diags tfdiags.Diagnostics
 		diags = diags.Append(tfdiags.Sourceless(

--- a/internal/terraform/node_resource_plan_instance.go
+++ b/internal/terraform/node_resource_plan_instance.go
@@ -176,6 +176,16 @@ func (n *NodePlannableResourceInstance) managedResourceExecute(ctx EvalContext) 
 		}
 	}
 
+	if n.importTarget.Config != nil && n.importTarget.Config.IgnoreNotExists && diags.HasErrors() {
+		var filteredDiags tfdiags.Diagnostics
+		for _, diag := range diags {
+			if diag.Description().Summary != "Cannot import non-existent remote object" {
+				filteredDiags = append(filteredDiags, diag)
+			}
+		}
+		diags = filteredDiags
+	}
+
 	// We'll save a snapshot of what we just read from the state into the
 	// prevRunState before we do anything else, since this will capture the
 	// result of any schema upgrading that readResourceInstanceState just did,


### PR DESCRIPTION
The goal of these changes is to provide a way for a user to ignore the "Cannot import non-existent remote object" error. This relates to https://github.com/hashicorp/terraform/issues/33633

The change is to add a new parameter for the import block "ignore_not_exists" which when set to true will result in the "Cannot import non-existent remote object" error being filtered from the the diagnostics and thus allow for the plan to continue.

Fixes #33633 

## Target Release

1.8.x

## Draft CHANGELOG entry

### NEW FEATURES

-  Adds "ignore_not_exists" (boolean) parameter to the import block to ignore the "Cannot import non-existent remote object" error during import.
