### PR TITLE
stackeval: Unmark provider config for plugin RPC

### DIFF
--- a/internal/stacks/stackruntime/internal/stackeval/provider_config.go
+++ b/internal/stacks/stackruntime/internal/stackeval/provider_config.go
@@ -119,8 +119,11 @@ func (p *ProviderConfig) CheckProviderArgs(ctx context.Context) (cty.Value, tfdi
 			if moreDiags.HasErrors() {
 				return cty.UnknownVal(hcldec.ImpliedType(spec)), diags
 			}
+			// We unmark the config before making the RPC call, but will still
+			// return the original possibly-marked config if successful.
+			unmarkedConfigVal, _ := configVal.UnmarkDeep()
 			validateResp := client.ValidateProviderConfig(providers.ValidateProviderConfigRequest{
-				Config: configVal,
+				Config: unmarkedConfigVal,
 			})
 			diags = diags.Append(validateResp.Diagnostics)
 			if validateResp.Diagnostics.HasErrors() {

--- a/internal/stacks/stackruntime/internal/stackeval/provider_config_test.go
+++ b/internal/stacks/stackruntime/internal/stackeval/provider_config_test.go
@@ -1,0 +1,146 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package stackeval
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform/internal/addrs"
+	"github.com/hashicorp/terraform/internal/configs/configschema"
+	"github.com/hashicorp/terraform/internal/providers"
+	"github.com/hashicorp/terraform/internal/stacks/stackaddrs"
+	"github.com/hashicorp/terraform/internal/terraform"
+	"github.com/hashicorp/terraform/internal/tfdiags"
+	"github.com/zclconf/go-cty-debug/ctydebug"
+	"github.com/zclconf/go-cty/cty"
+)
+
+func TestProviderConfigCheckProviderArgs(t *testing.T) {
+	cfg := testStackConfig(t, "provider", "single_instance_configured")
+	providerTypeAddr := addrs.NewBuiltInProvider("foo")
+	newMockProvider := func(t *testing.T) (*terraform.MockProvider, providers.Factory) {
+		t.Helper()
+		mockProvider := &terraform.MockProvider{
+			GetProviderSchemaResponse: &providers.GetProviderSchemaResponse{
+				Provider: providers.Schema{
+					Block: &configschema.Block{
+						Attributes: map[string]*configschema.Attribute{
+							"test": {
+								Type:     cty.String,
+								Optional: true,
+							},
+						},
+					},
+				},
+			},
+			ValidateProviderConfigFn: func(vpcr providers.ValidateProviderConfigRequest) providers.ValidateProviderConfigResponse {
+				if vpcr.Config.ContainsMarked() {
+					panic("config has marks")
+				}
+				var diags tfdiags.Diagnostics
+				if vpcr.Config.Type().HasAttribute("test") {
+					if vpcr.Config.GetAttr("test").RawEquals(cty.StringVal("invalid")) {
+						diags = diags.Append(fmt.Errorf("invalid value checked by provider itself"))
+					}
+				}
+				return providers.ValidateProviderConfigResponse{
+					PreparedConfig: vpcr.Config,
+					Diagnostics:    diags,
+				}
+			},
+		}
+		providerFactory := providers.FactoryFixed(mockProvider)
+		return mockProvider, providerFactory
+	}
+	getProviderConfig := func(ctx context.Context, t *testing.T, main *Main) *ProviderConfig {
+		t.Helper()
+		mainStack := main.MainStack(ctx)
+		provider := mainStack.Provider(ctx, stackaddrs.ProviderConfig{
+			Provider: providerTypeAddr,
+			Name:     "bar",
+		})
+		if provider == nil {
+			t.Fatal("no provider.foo.bar is available")
+		}
+		return provider.Config(ctx)
+	}
+
+	subtestInPromisingTask(t, "valid", func(ctx context.Context, t *testing.T) {
+		mockProvider, providerFactory := newMockProvider(t)
+		main := testEvaluator(t, testEvaluatorOpts{
+			Config: cfg,
+			TestOnlyGlobals: map[string]cty.Value{
+				"provider_configuration": cty.StringVal("yep"),
+			},
+			ProviderFactories: ProviderFactories{
+				providerTypeAddr: providerFactory,
+			},
+		})
+		config := getProviderConfig(ctx, t, main)
+
+		want := cty.ObjectVal(map[string]cty.Value{
+			"test": cty.StringVal("yep"),
+		})
+		got, diags := config.CheckProviderArgs(ctx)
+		assertNoDiags(t, diags)
+
+		if diff := cmp.Diff(want, got, ctydebug.CmpOptions); diff != "" {
+			t.Errorf("wrong result\n%s", diff)
+		}
+
+		if !mockProvider.ValidateProviderConfigCalled {
+			t.Error("ValidateProviderConfig was not called; should've been")
+		} else {
+			got := mockProvider.ValidateProviderConfigRequest
+			want := providers.ValidateProviderConfigRequest{
+				Config: cty.ObjectVal(map[string]cty.Value{
+					"test": cty.StringVal("yep"),
+				}),
+			}
+			if diff := cmp.Diff(want, got, ctydebug.CmpOptions); diff != "" {
+				t.Errorf("wrong request\n%s", diff)
+			}
+		}
+	})
+	subtestInPromisingTask(t, "valid with marks", func(ctx context.Context, t *testing.T) {
+		mockProvider, providerFactory := newMockProvider(t)
+		main := testEvaluator(t, testEvaluatorOpts{
+			Config: cfg,
+			TestOnlyGlobals: map[string]cty.Value{
+				"provider_configuration": cty.StringVal("yep").Mark("nope"),
+			},
+			ProviderFactories: ProviderFactories{
+				providerTypeAddr: providerFactory,
+			},
+		})
+		config := getProviderConfig(ctx, t, main)
+
+		want := cty.ObjectVal(map[string]cty.Value{
+			"test": cty.StringVal("yep").Mark("nope"),
+		})
+		got, diags := config.CheckProviderArgs(ctx)
+		assertNoDiags(t, diags)
+
+		if diff := cmp.Diff(want, got, ctydebug.CmpOptions); diff != "" {
+			t.Errorf("wrong result\n%s", diff)
+		}
+
+		if !mockProvider.ValidateProviderConfigCalled {
+			t.Error("ValidateProviderConfig was not called; should've been")
+		} else {
+			got := mockProvider.ValidateProviderConfigRequest
+			want := providers.ValidateProviderConfigRequest{
+				Config: cty.ObjectVal(map[string]cty.Value{
+					"test": cty.StringVal("yep"),
+				}),
+			}
+			if diff := cmp.Diff(want, got, ctydebug.CmpOptions); diff != "" {
+				t.Errorf("wrong request\n%s", diff)
+			}
+		}
+	})
+}

--- a/internal/stacks/stackruntime/internal/stackeval/stack_config.go
+++ b/internal/stacks/stackruntime/internal/stackeval/stack_config.go
@@ -323,6 +323,13 @@ func (s *StackConfig) ResolveExpressionReference(ctx context.Context, ref stacka
 func (s *StackConfig) resolveExpressionReference(ctx context.Context, ref stackaddrs.Reference, repetition instances.RepetitionData, selfAddr stackaddrs.Referenceable) (Referenceable, tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
 
+	// "Test-only globals" is a special affordance we have only when running
+	// unit tests in this package. The function called in this branch will
+	// return an error itself if we're not running in a suitable test situation.
+	if addr, ok := ref.Target.(stackaddrs.TestOnlyGlobal); ok {
+		return s.main.resolveTestOnlyGlobalReference(ctx, addr, ref.SourceRange)
+	}
+
 	// TODO: Most of the below would benefit from "Did you mean..." suggestions
 	// when something is missing but there's a similarly-named object nearby.
 


### PR DESCRIPTION
When validating or applying a provider configuration, we must unmark the value before attempting to use plugin RPC, as we cannot serialize marks.

## Target Release

1.8.0
