### PR TITLE
terraform: BuiltinEvalContext function eval in partial-expanded module

### DIFF
--- a/internal/terraform/eval_context_builtin.go
+++ b/internal/terraform/eval_context_builtin.go
@@ -485,7 +485,7 @@ func (ctx *BuiltinEvalContext) evaluationExternalFunctions() lang.ExternalFuncs 
 	// by the module author.
 	ret := lang.ExternalFuncs{}
 
-	cfg := ctx.Evaluator.Config.DescendentForInstance(ctx.Path())
+	cfg := ctx.Evaluator.Config.Descendent(ctx.scope.evalContextScopeModule())
 	if cfg == nil {
 		// It's weird to not have a configuration by this point, but we'll
 		// tolerate it for robustness and just return no functions at all.


### PR DESCRIPTION
https://github.com/hashicorp/terraform/pull/34571 and https://github.com/hashicorp/terraform/pull/34614 previously changed the `EvalContext` interface to support evaluation in both fully-expanded and partial-expanded modules, but the provider-contributed functions feature landed semi-concurrently with it and so inadvertently introduced a codepath that only worked in the fully-expanded case.

This will now handle both situations, since all we really need is the `addrs.Module`, which we can obtain in both modes.
