### PR TITLE
website docs: fix "Block Representation" for `provider schema -json`

### DIFF
--- a/website/docs/cli/commands/providers/schema.mdx
+++ b/website/docs/cli/commands/providers/schema.mdx
@@ -144,16 +144,17 @@ A block representation contains "attributes" and "block_types" (which represent 
       // 	list
       // 	set
       // 	map
-    "nesting_mode": "list",
-    "block": <block-representation>,
+      "nesting_mode": "list",
+      "block": <block-representation>,
 
-    // "min_items" and "max_items" set lower and upper
-    // limits on the number of child blocks allowed for
-    // the list and set modes. These are
-    // omitted for other modes.
-    "min_items": 1,
-    "max_items": 3
-  }
+      // "min_items" and "max_items" set lower and upper
+      // limits on the number of child blocks allowed for
+      // the list and set modes. These are
+      // omitted for other modes.
+      "min_items": 1,
+      "max_items": 3
+    },
+  },
 }
 ```
 

--- a/website/docs/cli/commands/providers/schema.mdx
+++ b/website/docs/cli/commands/providers/schema.mdx
@@ -153,8 +153,8 @@ A block representation contains "attributes" and "block_types" (which represent 
       // omitted for other modes.
       "min_items": 1,
       "max_items": 3
-    },
-  },
+    }
+  }
 }
 ```
 


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->
The ["Block Representation" in `terraform providers schema -json` documentation](https://developer.hashicorp.com/terraform/cli/commands/providers/schema#block-representation) seems to have wrong indentation and matching curly braces in the `"block types"` object.

