### PR TITLE
logging: Send captured panics to real stderr

### DIFF
--- a/internal/logging/panic.go
+++ b/internal/logging/panic.go
@@ -9,6 +9,7 @@ import (
 	"runtime/debug"
 	"strings"
 	"sync"
+	"syscall"
 
 	"github.com/hashicorp/go-hclog"
 )
@@ -50,12 +51,37 @@ func PanicHandler() {
 		return
 	}
 
-	fmt.Fprint(os.Stderr, panicOutput)
-	fmt.Fprint(os.Stderr, recovered, "\n")
-
-	// When called from a deferred function, debug.PrintStack will include the
-	// full stack from the point of the pending panic.
-	debug.PrintStack()
+	// We're aiming to behave as much as possible like the built-in panic
+	// handler aside from our few intentional exceptions.
+	//
+	// One detail is that we want the panic information to definitely go to the
+	// real stderr even if something else in our process has rudely reassigned
+	// [`os.Stderr`] to point to something else. Software that's designed to
+	// monitor the output of Go programs to detect and report panics expects
+	// the panic message to appear on the real process stderr.
+	//
+	// (At the time of writing, the go-plugin Serve function is an example
+	// of modifying the global os.Stderr, causing it to get routed over a
+	// plugin-specific stream rather than to the real process stderr. If
+	// we used os.Stderr here then panics under "terraform rpcapi" would
+	// end up in the wrong place.)
+	//
+	// The following mimics how the standard library (package os) constructs
+	// os.Stderr in the first place. Technically even this syscall.Stderr
+	// can be overridden rudely at runtime, but thankfully we've not yet
+	// encountered anything linked into Terraform that does _that_!
+	stderr := os.NewFile(uintptr(syscall.Stderr), "/dev/stderr")
+	if stderr == nil {
+		// os.NewFile has a few esoteric error cases where it'll return nil,
+		// in which case we'll just do our best with whatever happens to
+		// be in os.Stderr right now as a last resort.
+		stderr = os.Stderr
+	}
+	fmt.Fprint(stderr, panicOutput)
+	fmt.Fprint(stderr, recovered, "\n")
+	// The following mimics the implementation of debug.PrintStack, but
+	// without the hard-coded reference to os.Stderr.
+	stderr.Write(debug.Stack())
 
 	// An exit code of 11 keeps us out of the way of the detailed exitcodes
 	// from plan, and also happens to be the same code as SIGSEGV which is


### PR DESCRIPTION
Our goal with this panic-interception was to largely mimic how the Go runtime would normally report panics except for two intentional exceptions: an extra prompt explaining to the user that Terraform crashed, and exiting with status code 11 instead of 2.

Unfortunately we accidentally deviated in a different way: we're reporting to whatever `os.Stderr` happens to refer to, instead of to the real process stderr. It seems like that shouldn't really matter, but unfortunately go-plugin intentionally changes `os.Stderr` to refer to a totally separate stream that it manages, causing the captured panic messages from a `terraform rpcapi` process to be routed over a grpc-based channel to the plugin client, instead of into the real stderr pipe directly.

This deviation makes the panic messages not visible to usual strategies for trying to heuristically detect that a Go program has panicked. Without a special interception like Terraform is doing here, the Go runtime writes directly to the stderr file descriptor without going through the `os.Stderr` abstraction, and so to achieve consistent behavior we need to do a little hoop-jumping to approximate that result.

In particular, this makes the behavior now consistent with what happens when a provider plugin running as a child of Terraform Core panics -- since most provider plugins don't do a similar trick of intercepting unexpected panics -- and so a system which tries to sniff stderr for content that seems like a panic message will be able to handle both situations equally and avoid making a special case for Terraform Core/CLI's own panics.

---

We don't have any automated testing for the panic-handling behavior due to the complexity of testing something that rudely interrupts the Go runtime, so I manually tested this by introducing an intentional panic and verifying that it did indeed get written to the real stderr despite `os.Stderr` having been rudely reassigned.
