### PR TITLE
Added a User-Agent header for remote-state http backend client

### DIFF
--- a/internal/backend/remote-state/http/client.go
+++ b/internal/backend/remote-state/http/client.go
@@ -60,6 +60,7 @@ func (c *httpClient) httpRequest(method string, url *url.URL, data *[]byte, what
 	// Work with data/body
 	if data != nil {
 		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("User-Agent", "Terraform-http-client/1.1")
 		req.ContentLength = int64(len(*data))
 
 		// Generate the MD5


### PR DESCRIPTION
Added a User-Agent header for the http client to determine which client call to the http backend for change state.

Sometimes need to be able to send specially formatted state in different ways (for example, hiding sensitive data that will be shown in Swagger output but not hidden for terraform cli). In this case, would like to be able to identify which client sends the request for change state.

## Target Release

1.8.x

## Draft CHANGELOG entry

### ENHANCEMENTS

- When calling http-backend from terraform,  "User-Agent" header does not change, which does not allow correctly identifying the type of connecting client. Changed "User-Agent" header from "Go-http-client/1.1" to "Terraform-http-client/1.1"