### PR TITLE
terraform test: use platform independent path functions

### DIFF
--- a/internal/backend/local/test.go
+++ b/internal/backend/local/test.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"path"
+	"path/filepath"
 	"sort"
 	"time"
 
@@ -444,7 +444,7 @@ func (runner *TestFileRunner) run(run *moduletest.Run, file *moduletest.File, st
 				diags = diags.Append(tfdiags.Sourceless(
 					tfdiags.Warning,
 					"Failed to print verbose output",
-					fmt.Sprintf("Terraform failed to print the verbose output for %s, other diagnostics will contain more details as to why.", path.Join(file.Name, run.Name))))
+					fmt.Sprintf("Terraform failed to print the verbose output for %s, other diagnostics will contain more details as to why.", filepath.Join(file.Name, run.Name))))
 			} else {
 				run.Verbose = &moduletest.Verbose{
 					Plan:         plan,
@@ -532,7 +532,7 @@ func (runner *TestFileRunner) run(run *moduletest.Run, file *moduletest.File, st
 			diags = diags.Append(tfdiags.Sourceless(
 				tfdiags.Warning,
 				"Failed to print verbose output",
-				fmt.Sprintf("Terraform failed to print the verbose output for %s, other diagnostics will contain more details as to why.", path.Join(file.Name, run.Name))))
+				fmt.Sprintf("Terraform failed to print the verbose output for %s, other diagnostics will contain more details as to why.", filepath.Join(file.Name, run.Name))))
 		} else {
 			run.Verbose = &moduletest.Verbose{
 				Plan:         plan,
@@ -1252,7 +1252,7 @@ func (runner *TestFileRunner) initVariables(file *moduletest.File) {
 	for name, value := range runner.Suite.GlobalVariables {
 		runner.globalVariables[name] = value
 	}
-	if path.Dir(file.Name) == runner.Suite.TestingDirectory {
+	if filepath.Dir(file.Name) == runner.Suite.TestingDirectory {
 		// If the file is in the testing directory, then also include any
 		// variables that are defined within the default variable file also in
 		// the test directory.


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

This PR updates the testing framework to use the platform independent `filepath` package instead of the linux-only `path` package. This fixes loading and processing variable values loaded from automated variable files in the testing directory.

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Fixes #34664

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.7.x

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

### BUG FIXES

<!--

Write a short description of the user-facing change. Examples:

- `terraform show -json`: Fixed crash with sensitive set values.
- When rendering a diff, Terraform now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 

-  `terraform test`: Fix automatic loading of variable files within the test directory on `windows` platforms.
