### PR TITLE
website: ensure `for_each` examples take maps

### DIFF
--- a/website/docs/cli/state/resource-addressing.mdx
+++ b/website/docs/cli/state/resource-addressing.mdx
@@ -118,12 +118,12 @@ Given a Terraform config that includes:
 ```hcl
 resource "aws_instance" "web" {
   # ...
-  for_each = {
+  for_each = tomap({
     "terraform": "value1",
     "resource":  "value2",
     "indexing":  "value3",
     "example":   "value4",
-  }
+  })
 }
 ```
 

--- a/website/docs/language/functions/csvdecode.mdx
+++ b/website/docs/language/functions/csvdecode.mdx
@@ -63,7 +63,7 @@ locals {
 }
 
 resource "aws_instance" "example" {
-  for_each = { for inst in local.instances : inst.local_id => inst }
+  for_each = tomap({ for inst in local.instances : inst.local_id => inst })
 
   instance_type = each.value.instance_type
   ami           = each.value.ami

--- a/website/docs/language/functions/flatten.mdx
+++ b/website/docs/language/functions/flatten.mdx
@@ -118,9 +118,9 @@ resource "aws_subnet" "example" {
   # local.network_subnets is a list, so we must now project it into a map
   # where each key is unique. We'll combine the network and subnet keys to
   # produce a single unique key per instance.
-  for_each = {
+  for_each = tomap({
     for subnet in local.network_subnets : "${subnet.network_key}.${subnet.subnet_key}" => subnet
-  }
+  })
 
   vpc_id            = each.value.network_id
   availability_zone = each.value.subnet_key

--- a/website/docs/language/functions/setproduct.mdx
+++ b/website/docs/language/functions/setproduct.mdx
@@ -190,9 +190,9 @@ resource "aws_subnet" "example" {
   # local.network_subnets is a list, so project it into a map
   # where each key is unique. Combine the network and subnet keys to
   # produce a single unique key per instance.
-  for_each = {
+  for_each = tomap({
     for subnet in local.network_subnets : "${subnet.network_key}.${subnet.subnet_key}" => subnet
-  }
+  })
 
   vpc_id            = each.value.network_id
   availability_zone = each.value.subnet_key

--- a/website/docs/language/meta-arguments/for_each.mdx
+++ b/website/docs/language/meta-arguments/for_each.mdx
@@ -42,10 +42,10 @@ Map:
 
 ```hcl
 resource "azurerm_resource_group" "rg" {
-  for_each = {
-    a_group = "eastus"
+  for_each = tomap({
+    a_group       = "eastus"
     another_group = "westus2"
-  }
+  })
   name     = each.key
   location = each.value
 }
@@ -55,7 +55,7 @@ Set of strings:
 
 ```hcl
 resource "aws_iam_user" "the-accounts" {
-  for_each = toset( ["Todd", "James", "Alice", "Dottie"] )
+  for_each = toset(["Todd", "James", "Alice", "Dottie"])
   name     = each.key
 }
 ```


### PR DESCRIPTION
While objects in `for_each` do not strictly yield _invalid_ configuration, we explicitly document that `for_each` expects maps or sets.

In most places I am proposing to fix, the wording near those snippets even explicitly mentions _map_ while providing a snippet which has (although implied) _object_.

I think this contributes to confusion of users about types.