### PR TITLE
compare individual elements if list is same length and not reordered

### DIFF
--- a/internal/command/jsonformat/collections/slice.go
+++ b/internal/command/jsonformat/collections/slice.go
@@ -83,7 +83,7 @@ func ProcessSlice[Input any](before, after []Input, process ProcessIndices, isOb
 	}
 }
 
-// Returns if every item of before can be found in after
+// isReorder returns true if every item of before can be found in after
 func isReorder[Input any](before, after []Input) bool {
 	// To be a reorder the length needs to be the same
 	if len(before) != len(after) {

--- a/internal/command/jsonformat/collections/slice.go
+++ b/internal/command/jsonformat/collections/slice.go
@@ -35,6 +35,16 @@ func TransformSlice[Input any](before, after []Input, process TransformIndices, 
 }
 
 func ProcessSlice[Input any](before, after []Input, process ProcessIndices, isObjType IsObjType[Input]) {
+	// If before and after are the same length we want to compare elements
+	// on an individual basis
+
+	if len(before) == len(after) {
+		for ix := range before {
+			process(ix, ix)
+		}
+		return
+	}
+
 	lcs := objchange.LongestCommonSubsequence(before, after, func(before, after Input) bool {
 		return reflect.DeepEqual(before, after)
 	})

--- a/internal/command/jsonformat/collections/slice.go
+++ b/internal/command/jsonformat/collections/slice.go
@@ -38,7 +38,7 @@ func ProcessSlice[Input any](before, after []Input, process ProcessIndices, isOb
 	// If before and after are the same length we want to compare elements
 	// on an individual basis
 
-	if len(before) == len(after) {
+	if len(before) == len(after) && !isReorder(before, after) {
 		for ix := range before {
 			process(ix, ix)
 		}
@@ -82,4 +82,28 @@ func ProcessSlice[Input any](before, after []Input, process ProcessIndices, isOb
 			lcsIx++
 		}
 	}
+}
+
+// Returns if every item of before can be found in after
+func isReorder[Input any](before, after []Input) bool {
+	// To be a reorder the length needs to be the same
+	if len(before) != len(after) {
+		return false
+	}
+
+	for _, b := range before {
+		hasMatch := false
+		for _, a := range after {
+			if reflect.DeepEqual(b, a) {
+				// Match found, no need to search anymore
+				hasMatch = true
+				break
+			}
+		}
+		if !hasMatch {
+			return false
+		}
+	}
+
+	return true
 }

--- a/internal/command/jsonformat/collections/slice.go
+++ b/internal/command/jsonformat/collections/slice.go
@@ -35,9 +35,8 @@ func TransformSlice[Input any](before, after []Input, process TransformIndices, 
 }
 
 func ProcessSlice[Input any](before, after []Input, process ProcessIndices, isObjType IsObjType[Input]) {
-	// If before and after are the same length we want to compare elements
-	// on an individual basis
-
+	// If before and after are the same length and is not a reordering
+	// we want to compare elements on an individual basis
 	if len(before) == len(after) && !isReorder(before, after) {
 		for ix := range before {
 			process(ix, ix)

--- a/internal/command/jsonformat/computed/renderers/primitive.go
+++ b/internal/command/jsonformat/computed/renderers/primitive.go
@@ -167,6 +167,12 @@ func (renderer primitiveRenderer) renderStringDiff(diff computed.Diff, indent in
 				return
 			}
 
+			if beforeLines[beforeIx] != afterLines[afterIx] {
+				lines = append(lines, fmt.Sprintf("%s%s%s", formatIndent(indent+1), writeDiffActionSymbol(plans.Delete, opts), beforeLines[beforeIx]))
+				lines = append(lines, fmt.Sprintf("%s%s%s", formatIndent(indent+1), writeDiffActionSymbol(plans.Create, opts), afterLines[afterIx]))
+				return
+			}
+
 			lines = append(lines, fmt.Sprintf("%s%s%s", formatIndent(indent+1), writeDiffActionSymbol(plans.NoOp, opts), beforeLines[beforeIx]))
 		}
 		isObjType := func(_ string) bool {

--- a/internal/command/jsonformat/differ/differ_test.go
+++ b/internal/command/jsonformat/differ/differ_test.go
@@ -1428,10 +1428,8 @@ func TestValue_Outputs(t *testing.T) {
 				},
 			},
 			validateDiff: renderers.ValidateList([]renderers.ValidateDiffFunction{
-				renderers.ValidatePrimitive("old_one", nil, plans.Delete, false),
-				renderers.ValidatePrimitive("old_two", nil, plans.Delete, false),
-				renderers.ValidatePrimitive(nil, "new_one", plans.Create, false),
-				renderers.ValidatePrimitive(nil, "new_two", plans.Create, false),
+				renderers.ValidatePrimitive("old_one", "new_one", plans.Update, false),
+				renderers.ValidatePrimitive("old_two", "new_two", plans.Update, false),
 			}, plans.Update, false),
 		},
 		"primitive_delete": {
@@ -1599,6 +1597,7 @@ func TestValue_PrimitiveAttributes(t *testing.T) {
 		attribute          cty.Type
 		validateDiff       renderers.ValidateDiffFunction
 		validateSliceDiffs []renderers.ValidateDiffFunction // Lists are special in some cases.
+		validateSetDiffs   []renderers.ValidateDiffFunction // Sets are special in some cases.
 	}{
 		"primitive_create": {
 			input: structured.Change{
@@ -1622,6 +1621,9 @@ func TestValue_PrimitiveAttributes(t *testing.T) {
 			attribute:    cty.String,
 			validateDiff: renderers.ValidatePrimitive("old", "new", plans.Update, false),
 			validateSliceDiffs: []renderers.ValidateDiffFunction{
+				renderers.ValidatePrimitive("old", "new", plans.Update, false),
+			},
+			validateSetDiffs: []renderers.ValidateDiffFunction{
 				renderers.ValidatePrimitive("old", nil, plans.Delete, false),
 				renderers.ValidatePrimitive(nil, "new", plans.Create, false),
 			},
@@ -1635,6 +1637,9 @@ func TestValue_PrimitiveAttributes(t *testing.T) {
 			attribute:    cty.String,
 			validateDiff: renderers.ValidatePrimitive("old", nil, plans.Update, false),
 			validateSliceDiffs: []renderers.ValidateDiffFunction{
+				renderers.ValidatePrimitive("old", nil, plans.Update, false),
+			},
+			validateSetDiffs: []renderers.ValidateDiffFunction{
 				renderers.ValidatePrimitive("old", nil, plans.Delete, false),
 				renderers.ValidatePrimitive(nil, nil, plans.Create, false),
 			},
@@ -1648,6 +1653,9 @@ func TestValue_PrimitiveAttributes(t *testing.T) {
 			attribute:    cty.String,
 			validateDiff: renderers.ValidatePrimitive(nil, "new", plans.Update, false),
 			validateSliceDiffs: []renderers.ValidateDiffFunction{
+				renderers.ValidatePrimitive(nil, "new", plans.Update, false),
+			},
+			validateSetDiffs: []renderers.ValidateDiffFunction{
 				renderers.ValidatePrimitive(nil, nil, plans.Delete, false),
 				renderers.ValidatePrimitive(nil, "new", plans.Create, false),
 			},
@@ -1680,6 +1688,9 @@ func TestValue_PrimitiveAttributes(t *testing.T) {
 			attribute:    cty.String,
 			validateDiff: renderers.ValidateSensitive(renderers.ValidatePrimitive("old", "new", plans.Update, false), true, true, plans.Update, false),
 			validateSliceDiffs: []renderers.ValidateDiffFunction{
+				renderers.ValidateSensitive(renderers.ValidatePrimitive("old", "new", plans.Update, false), true, true, plans.Update, false),
+			},
+			validateSetDiffs: []renderers.ValidateDiffFunction{
 				renderers.ValidateSensitive(renderers.ValidatePrimitive("old", nil, plans.Delete, false), true, false, plans.Delete, false),
 				renderers.ValidateSensitive(renderers.ValidatePrimitive(nil, "new", plans.Create, false), false, true, plans.Create, false),
 			},
@@ -1702,6 +1713,9 @@ func TestValue_PrimitiveAttributes(t *testing.T) {
 			attribute:    cty.String,
 			validateDiff: renderers.ValidateUnknown(renderers.ValidatePrimitive("old", nil, plans.Delete, false), plans.Update, false),
 			validateSliceDiffs: []renderers.ValidateDiffFunction{
+				renderers.ValidateUnknown(renderers.ValidatePrimitive("old", nil, plans.Delete, false), plans.Update, false),
+			},
+			validateSetDiffs: []renderers.ValidateDiffFunction{
 				renderers.ValidatePrimitive("old", nil, plans.Delete, false),
 				renderers.ValidateUnknown(nil, plans.Create, false),
 			},
@@ -1719,6 +1733,9 @@ func TestValue_PrimitiveAttributes(t *testing.T) {
 			attribute:    cty.String,
 			validateDiff: renderers.ValidatePrimitive("old", "new", plans.Update, true),
 			validateSliceDiffs: []renderers.ValidateDiffFunction{
+				renderers.ValidatePrimitive("old", "new", plans.Update, true),
+			},
+			validateSetDiffs: []renderers.ValidateDiffFunction{
 				renderers.ValidatePrimitive("old", nil, plans.Delete, true),
 				renderers.ValidatePrimitive(nil, "new", plans.Create, true),
 			},
@@ -1739,6 +1756,9 @@ func TestValue_PrimitiveAttributes(t *testing.T) {
 			attribute:    cty.DynamicPseudoType,
 			validateDiff: renderers.ValidatePrimitive("old", "new", plans.Update, false),
 			validateSliceDiffs: []renderers.ValidateDiffFunction{
+				renderers.ValidatePrimitive("old", "new", plans.Update, false),
+			},
+			validateSetDiffs: []renderers.ValidateDiffFunction{
 				renderers.ValidatePrimitive("old", nil, plans.Delete, false),
 				renderers.ValidatePrimitive(nil, "new", plans.Create, false),
 			},
@@ -1754,6 +1774,12 @@ func TestValue_PrimitiveAttributes(t *testing.T) {
 				renderers.ValidatePrimitive(nil, 4.0, plans.Create, false),
 				plans.Update, false),
 			validateSliceDiffs: []renderers.ValidateDiffFunction{
+				renderers.ValidateTypeChange(
+					renderers.ValidatePrimitive("old", nil, plans.Delete, false),
+					renderers.ValidatePrimitive(nil, 4.0, plans.Create, false),
+					plans.Update, false),
+			},
+			validateSetDiffs: []renderers.ValidateDiffFunction{
 				renderers.ValidatePrimitive("old", nil, plans.Delete, false),
 				renderers.ValidatePrimitive(nil, 4.0, plans.Create, false),
 			},
@@ -1819,7 +1845,7 @@ func TestValue_PrimitiveAttributes(t *testing.T) {
 				}
 
 				if tc.validateSliceDiffs != nil {
-					validate := renderers.ValidateSet(tc.validateSliceDiffs, defaultCollectionsAction, false)
+					validate := renderers.ValidateSet(tc.validateSetDiffs, defaultCollectionsAction, false)
 					validate(t, ComputeDiffForAttribute(input, attribute))
 					return
 				}
@@ -2377,12 +2403,9 @@ func TestRelevantAttributes(t *testing.T) {
 				// attributes. This is deliberate.
 				"list": renderers.ValidateList([]renderers.ValidateDiffFunction{
 					renderers.ValidatePrimitive(0, 0, plans.NoOp, false),
-					renderers.ValidatePrimitive(1, nil, plans.Delete, false),
-					renderers.ValidatePrimitive(2, nil, plans.Delete, false),
-					renderers.ValidatePrimitive(3, nil, plans.Delete, false),
-					renderers.ValidatePrimitive(nil, 5, plans.Create, false),
-					renderers.ValidatePrimitive(nil, 6, plans.Create, false),
-					renderers.ValidatePrimitive(nil, 7, plans.Create, false),
+					renderers.ValidatePrimitive(1, 5, plans.Update, false),
+					renderers.ValidatePrimitive(2, 6, plans.Update, false),
+					renderers.ValidatePrimitive(3, 7, plans.Update, false),
 					renderers.ValidatePrimitive(4, 4, plans.NoOp, false),
 				}, plans.Update, false),
 			}, nil, nil, nil, nil, plans.Update, false),

--- a/internal/command/jsonformat/plan_test.go
+++ b/internal/command/jsonformat/plan_test.go
@@ -2125,8 +2125,7 @@ func TestResourceChange_primitiveList(t *testing.T) {
       ~ id         = "i-02ae66f368e8518a9" -> (known after apply)
       ~ list_field = [
             "aaaa",
-          - "bbbb",
-          + (known after apply),
+          ~ "bbbb" -> (known after apply),
             "cccc",
         ]
         # (1 unchanged attribute hidden)
@@ -6213,8 +6212,9 @@ func TestResourceChange_sensitiveVariable(t *testing.T) {
       ~ list_field  = [
             # (1 unchanged element hidden)
             "friends",
-          - (sensitive value),
-          + ".",
+          # Warning: this attribute value will no longer be marked as sensitive
+          # after applying this change.
+          ~ (sensitive value),
         ]
       ~ map_key     = {
           # Warning: this attribute value will no longer be marked as sensitive
@@ -6332,8 +6332,9 @@ func TestResourceChange_sensitiveVariable(t *testing.T) {
   ~ resource "test_instance" "example" {
         id         = "i-02ae66f368e8518a9"
       ~ list_field = [
-          - "hello",
-          + (sensitive value),
+          # Warning: this attribute value will be marked as sensitive and will not
+          # display in UI output after applying this change.
+          ~ (sensitive value),
             "friends",
         ]
       ~ map_key    = {
@@ -6468,8 +6469,7 @@ func TestResourceChange_sensitiveVariable(t *testing.T) {
       ~ ami        = (sensitive value)
         id         = "i-02ae66f368e8518a9"
       ~ list_field = [
-          - (sensitive value),
-          + (sensitive value),
+          ~ (sensitive value),
             "friends",
         ]
       ~ map_key    = {


### PR DESCRIPTION
### Before
<img width="678" alt="after" src="https://github.com/hashicorp/terraform/assets/1337046/dc44a707-42c0-4eb5-ab0f-82e4d3d58860">

### After

<img width="674" alt="before" src="https://github.com/hashicorp/terraform/assets/1337046/33b5ee17-b662-4697-9804-721b4e021956">





<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Fixes #33779

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.8.x

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

### ENHANCEMENTS

<!--

Write a short description of the user-facing change. Examples:

- `terraform show -json`: Fixed crash with sensitive set values.
- When rendering a diff, Terraform now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 

-  Improve plan UI for lists to display item-level diffs on lists with unchanged length
