### PR TITLE
standardize panic output

### DIFF
--- a/internal/logging/panic.go
+++ b/internal/logging/panic.go
@@ -78,7 +78,7 @@ func PanicHandler() {
 		stderr = os.Stderr
 	}
 	fmt.Fprint(stderr, panicOutput)
-	fmt.Fprint(stderr, recovered, "\n")
+	fmt.Fprint(stderr, "panic: ", recovered, "\n")
 	// The following mimics the implementation of debug.PrintStack, but
 	// without the hard-coded reference to os.Stderr.
 	stderr.Write(debug.Stack())


### PR DESCRIPTION
Programs that monitor Terraform's output to report panics often make the reasonable assumption that the string "panic:" is always included and is therefore safe to monitor for. Our custom handling that outputs the `!! TERRAFORM CRASH !!` banner unfortunately breaks these assumptions at the moment.

Instead of asking consumers to add their own handling to deal with this problem, let's add that greppable string to our custom panic output.

## Target Release

1.8.x
