### PR TITLE
stackruntime: Pass ExperimentsAllowed into stackeval for apply

### DIFF
--- a/internal/stacks/stackruntime/apply.go
+++ b/internal/stacks/stackruntime/apply.go
@@ -59,7 +59,8 @@ func Apply(ctx context.Context, req *ApplyRequest, resp *ApplyResponse) {
 		req.Config,
 		req.RawPlan,
 		stackeval.ApplyOpts{
-			ProviderFactories: req.ProviderFactories,
+			ProviderFactories:  req.ProviderFactories,
+			ExperimentsAllowed: req.ExperimentsAllowed,
 		},
 		outp,
 	)


### PR DESCRIPTION
This was originally part of 7dad938fdb6bfeaf7cc082ce50bcf99f7889a2a9 but unfortunately seems to have got lost during some rebasing, or some other similar sort of annoying reason.

This now allows the "experiments allowed" flag to propagate into the stackeval package when we're running the apply phase, for consistency with all of the other phases. Without this, it's possible to plan a configuration that's participating in experiments, but then it fails in a strange way during the apply step due to Terraform suddenly thinking it's a stable release where experiments are disabled.

---

Unfortunately experimental features remain a bit of a testing hazard because we test them by enabling the "experiments are allowed" flag inline in the test, close to the code being tested, but in a real build it's `package main` that's ultimately making the decision and only our e2etests actually exercise _that_ codepath, and the e2etests cannot actually exercise experiments in practice because that would break the build for non-alpha releases where the experiments are always disabled.

I guess we'd need to teach the e2etest harness _itself_ to disable certain tests when it's working with  a non-alpha build, but it's not clear whether we can justify the opportunity cost of implementing e2etests just to verify that experiments are working (which we'd then presumably need to delete once the feature is no longer experimental).

I've not attempted to improve that situation here, but am just acknowledging it as a big part of why I wasn't able to detect my mistake until we'd already cut a release with it. :confounded: 

