### PR TITLE
gitignore: Add `go.work{.sum}`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,8 @@ website/node_modules
 *.test
 *.iml
 
+go.work*
+
 /terraform
 
 website/vendor


### PR DESCRIPTION
The workspace files (`go.work` + `go.work.sum`) can be used when working on upstream dependencies (such as `hashicorp/hcl` in our case) and enable testing downstream here without having to touch `go.mod` or `go.sum`, i.e. delay the need to bump dependencies until the point of a PR.

Example of such a file:

```go
go 1.21.5

use .

replace (
 	github.com/hashicorp/hcl/v2 => ../hcl
)
```

Relevant docs for multi-module workspaces which enable the above: https://go.dev/doc/tutorial/workspaces

The (relative) paths included in those files are typically machine specific and so unlikely to work on other systems.