### PR TITLE
Better diagnostics for unknown provider functions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -52,7 +52,7 @@ require (
 	github.com/hashicorp/go-uuid v1.0.3
 	github.com/hashicorp/go-version v1.6.0
 	github.com/hashicorp/hcl v1.0.0
-	github.com/hashicorp/hcl/v2 v2.19.2-0.20231109190535-c964a71ca320
+	github.com/hashicorp/hcl/v2 v2.19.2-0.20240214205714-fe0951f68911
 	github.com/hashicorp/jsonapi v1.2.0
 	github.com/hashicorp/terraform-registry-address v0.2.0
 	github.com/hashicorp/terraform-svchost v0.1.1

--- a/go.sum
+++ b/go.sum
@@ -705,8 +705,8 @@ github.com/hashicorp/golang-lru v0.5.1 h1:0hERBMJE1eitiLkihrMvRVBYAkpHzc/J3QdDN+
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
-github.com/hashicorp/hcl/v2 v2.19.2-0.20231109190535-c964a71ca320 h1:XCxc/uVhiBd2uKHRCiOItsuH8RbpwvPC5Pi+LAzZDn8=
-github.com/hashicorp/hcl/v2 v2.19.2-0.20231109190535-c964a71ca320/go.mod h1:ThLC89FV4p9MPW804KVbe/cEXoQ8NZEh+JtMeeGErHE=
+github.com/hashicorp/hcl/v2 v2.19.2-0.20240214205714-fe0951f68911 h1:LWT9UW4fPejxnFSCMcyreTizpA9DmxwFeryEoXkgNK0=
+github.com/hashicorp/hcl/v2 v2.19.2-0.20240214205714-fe0951f68911/go.mod h1:ThLC89FV4p9MPW804KVbe/cEXoQ8NZEh+JtMeeGErHE=
 github.com/hashicorp/jsonapi v1.2.0 h1:ezDCzOFsKTL+KxVQuA1rNxkIGTvZph1rNu8kT5A8trI=
 github.com/hashicorp/jsonapi v1.2.0/go.mod h1:Yog5+CPEM3c99L1CL2CFCYoSzgWm5vTU58idbRUaLik=
 github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO+LraFDTW64=

--- a/internal/lang/eval.go
+++ b/internal/lang/eval.go
@@ -571,7 +571,7 @@ func checkForUnknownFunctionDiags(diags hcl.Diagnostics) hcl.Diagnostics {
 
 		// no other functions exist for this provider, so hint that the user may
 		// need to include it in the configuration.
-		d.Detail = fmt.Sprintf(`There is no function named "%s%s". The provider %q may need to be added to the required_providers block within the module configuration.`, namespace, name, namespaceParts[1])
+		d.Detail = fmt.Sprintf(`There is no function named "%s%s". Ensure that provider name %q is declared in this module's required_providers block, and that this provider offers a function named %q.`, namespace, name, namespaceParts[1], name)
 	}
 
 	return diags

--- a/internal/lang/eval.go
+++ b/internal/lang/eval.go
@@ -5,10 +5,13 @@ package lang
 
 import (
 	"fmt"
+	"log"
+	"strings"
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/ext/dynblock"
 	"github.com/hashicorp/hcl/v2/hcldec"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/zclconf/go-cty/cty"
 	"github.com/zclconf/go-cty/cty/convert"
 
@@ -69,7 +72,7 @@ func (s *Scope) EvalBlock(body hcl.Body, schema *configschema.Block) (cty.Value,
 	body = blocktoattr.FixUpBlockAttrs(body, schema)
 
 	val, evalDiags := hcldec.Decode(body, spec, ctx)
-	diags = diags.Append(evalDiags)
+	diags = diags.Append(checkForUnknownFunctionDiags(evalDiags))
 
 	return val, diags
 }
@@ -147,7 +150,7 @@ func (s *Scope) EvalSelfBlock(body hcl.Body, self cty.Value, schema *configschem
 	}
 
 	val, decDiags := hcldec.Decode(body, schema.DecoderSpec(), ctx)
-	diags = diags.Append(decDiags)
+	diags = diags.Append(checkForUnknownFunctionDiags(decDiags))
 	return val, diags
 }
 
@@ -173,7 +176,7 @@ func (s *Scope) EvalExpr(expr hcl.Expression, wantType cty.Type) (cty.Value, tfd
 	}
 
 	val, evalDiags := expr.Value(ctx)
-	diags = diags.Append(evalDiags)
+	diags = diags.Append(checkForUnknownFunctionDiags(evalDiags))
 
 	if wantType != cty.DynamicPseudoType {
 		var convErr error
@@ -488,4 +491,88 @@ func normalizeRefValue(val cty.Value, diags tfdiags.Diagnostics) (cty.Value, tfd
 		return cty.UnknownVal(val.Type()), diags
 	}
 	return val, diags
+}
+
+// checkForUnknownFunctionDiags inspects the diagnostics for errors from unknown
+// function calls, and tailors the messages to better suit Terraform. We now
+// have multiple namespaces where functions may be declared, and it's up to the
+// user to have properly configured the module to populate the provider
+// namespace. The generic unknown function diagnostic from hcl does not direct
+// the user on how to remedy the situation in Terraform, and we can give more
+// useful information in a few Terraform specific cases here.
+func checkForUnknownFunctionDiags(diags hcl.Diagnostics) hcl.Diagnostics {
+	for _, d := range diags {
+		extra, ok := hcl.DiagnosticExtra[hclsyntax.FunctionCallUnknownDiagExtra](d)
+		if !ok {
+			continue
+		}
+		name := extra.CalledFunctionName()
+		namespace := extra.CalledFunctionNamespace()
+		namespaceParts := strings.Split(namespace, "::")
+		if len(namespaceParts) < 2 {
+			// no namespace (namespace includes ::, so will have at least 2
+			// parts), but check if there is a matching name in a provider
+			// namspace.
+			if d.EvalContext == nil {
+				continue
+			}
+
+			for funcName := range d.EvalContext.Functions {
+				if strings.HasSuffix(funcName, "::"+name) {
+					d.Detail = fmt.Sprintf("%s Did you mean %q?", d.Detail, funcName)
+					break
+				}
+			}
+			continue
+		}
+
+		// the diagnostic isn't really shared with anything, and copying would
+		// still retain the internal pointers, so we're going to modify the
+		// diagnostic in-place if we want to change the output. Log the original
+		// diagnostic for debugging purposes in case we overwrite something
+		// potentially useful in the future from hcl.
+		log.Printf("[ERROR] UnknownFunctionCall: %s", d.Error())
+		d.Summary = "Unknown provider function"
+
+		if namespaceParts[0] != "provider" {
+			// help if the user is skipping the provider:: prefix before the
+			// provider name.
+			d.Detail = fmt.Sprintf(`The function namespace %q is not valid. Provider function calls must use the "provider::" namespace prefix.`, namespaceParts[0])
+			continue
+		}
+
+		if namespaceParts[1] == "" {
+			// missing provider name entirely
+			d.Detail = `The function call must include the provider name after the "provider::" prefix.`
+			continue
+		}
+
+		if d.EvalContext == nil {
+			// There's no eval context for some reason, so we can't inspect the
+			// available functions.
+			d.Detail = fmt.Sprintf(`There is no function named "%s%s".`, namespace, name)
+			continue
+		}
+
+		otherProviderFuncs := false
+		for funcName := range d.EvalContext.Functions {
+			// there are other functions in this provider namespace, so it must
+			// have been included in the configuration, and we can be clear that
+			// this a function which the provider does not support.
+			if strings.HasPrefix(funcName, namespace) {
+				otherProviderFuncs = true
+				break
+			}
+		}
+		if otherProviderFuncs {
+			d.Detail = fmt.Sprintf("The function %q is not available from the provider %q.", name, namespaceParts[1])
+			continue
+		}
+
+		// no other functions exist for this provider, so hint that the user may
+		// need to include it in the configuration.
+		d.Detail = fmt.Sprintf(`There is no function named "%s%s". The provider %q may need to be added to the required_providers block within the module configuration.`, namespace, name, namespaceParts[1])
+	}
+
+	return diags
 }

--- a/internal/terraform/context_functions_test.go
+++ b/internal/terraform/context_functions_test.go
@@ -256,7 +256,7 @@ func TestContext2Validate_providerFunctionDiagnostics(t *testing.T) {
 			output "first" {
 				value = provider::test::echo("input")
 			}`}),
-			`The provider "test" may need to be added to the required_providers block within the module configuration.`,
+			`Ensure that provider name "test" is declared in this module's required_providers block, and that this provider offers a function named "echo"`,
 		},
 		{
 			"invalid namespace",

--- a/internal/terraform/context_validate_test.go
+++ b/internal/terraform/context_validate_test.go
@@ -2631,7 +2631,7 @@ output "result" {
 		if !diags.HasErrors() {
 			t.Fatal("unexpected success")
 		}
-		if got, want := diags.Err().Error(), "Call to unknown function: There is no function named \"cout_e\" in namespace provider::test::."; !strings.Contains(got, want) {
+		if got, want := diags.Err().Error(), `Unknown provider function: The function "cout_e" is not available from the provider "test"`; !strings.Contains(got, want) {
 			t.Errorf("wrong error message\nwant substring: %s\ngot: %s", want, got)
 		}
 
@@ -2666,7 +2666,7 @@ output "result" {
 		if !diags.HasErrors() {
 			t.Fatal("unexpected success")
 		}
-		if got, want := diags.Err().Error(), "Call to unknown function: There are no functions in namespace \"provider::toast::\"."; !strings.Contains(got, want) {
+		if got, want := diags.Err().Error(), `Unknown provider function: There is no function named "provider::toast::count_e`; !strings.Contains(got, want) {
 			t.Errorf("wrong error message\nwant substring: %s\ngot: %s", want, got)
 		}
 	})
@@ -2870,7 +2870,7 @@ output "result" {
 		}
 		// Module author must declare a provider requirement in order to
 		// import a provider's functions.
-		if got, want := diags.Err().Error(), "Call to unknown function: There are no functions in namespace \"provider::test::\"."; !strings.Contains(got, want) {
+		if got, want := diags.Err().Error(), `Unknown provider function: There is no function named "provider::test::count_e"`; !strings.Contains(got, want) {
 			t.Errorf("wrong error message\nwant substring: %s\ngot: %s", want, got)
 		}
 	})


### PR DESCRIPTION
The context of how to use provider functions is very specific to Terraform, and the generic diagnostics from HCL are very helpful to a user who is unfamiliar with how the functions are handled internally. This is more important here, because there are new concepts for even experienced users, and many are likely to encounter these errors when trying the new feature. 

For example, if a user forgot to add the provider to the module `required_providers`, HCL can only see that there is no function by the name and returns something like `There are no functions in namespace "provider::test::"`. Now we can make use of a new `FunctionCallUnknownDiagExtra` sentinel error type from HCL to detect any unknown function call, and replace the diagnostic messages with ones more suitable for Terraform.

This can detect 5 specific cases to help users with incorrect function calls in the code:

- calling a provider function without the `provider::providername::` namespace can offer the complete name as a suggestion:
```
│ There is no function named "noop". Did you mean "provider::example::noop"?
```

- leaving out the `provider::` portion of the namespace
```
│ The function namespace "example" is not valid. Provider function calls must use the "provider::"
│ namespace prefix.
```

- missing the provider name in the function, `provider::func()`
```
│ The function call must include the provider name after the "provider::" prefix.
```

- a correctly configured provider, but calling a function it does not support
``` 
│ The function "oops" is not available from the provider "example".
```

- and finally, what will probably be the most common, and hence the most important one
```
│ There is no function named "provider::example::func". Ensure that provider name "example" is
│ declared in this module's required_providers block, and that this provider offers a function
│ named "func".
```