### PR TITLE
stacks: apply sensitive marks to outputs from components

### DIFF
--- a/internal/collections/set.go
+++ b/internal/collections/set.go
@@ -16,24 +16,28 @@ type Set[T any] struct {
 	key     func(T) UniqueKey[T]
 }
 
-// NewMap constructs a new set whose element type knows how to calculate its own
+// NewSet constructs a new set whose element type knows how to calculate its own
 // unique keys, by implementing [UniqueKeyer] of itself.
-func NewSet[T UniqueKeyer[T]]() Set[T] {
-	return NewSetFunc(T.UniqueKey)
+func NewSet[T UniqueKeyer[T]](elems ...T) Set[T] {
+	return NewSetFunc(T.UniqueKey, elems...)
 }
 
-// NewSet constructs a new set with the given "key function".
+// NewSetFunc constructs a new set with the given "key function".
 //
 // A valid key function must produce only values of types that can be compared
 // for equality using the Go == operator, and must guarantee that each unique
 // value of T has a corresponding key that uniquely identifies it. The
 // implementer of the key function can decide what constitutes a
 // "unique value of T", based on the meaning of type T.
-func NewSetFunc[T any](keyFunc func(T) UniqueKey[T]) Set[T] {
-	return Set[T]{
+func NewSetFunc[T any](keyFunc func(T) UniqueKey[T], elems ...T) Set[T] {
+	set := Set[T]{
 		members: make(map[UniqueKey[T]]T),
 		key:     keyFunc,
 	}
+	for _, elem := range elems {
+		set.Add(elem)
+	}
+	return set
 }
 
 // NewSetCmp constructs a new set for any comparable type, using the built-in

--- a/internal/stacks/stackruntime/apply_test.go
+++ b/internal/stacks/stackruntime/apply_test.go
@@ -280,23 +280,6 @@ func TestApplyWithSensitivePropagation(t *testing.T) {
 		&stackstate.AppliedChangeComponentInstance{
 			ComponentAddr: stackaddrs.AbsComponent{
 				Item: stackaddrs.Component{
-					Name: "sensitive",
-				},
-			},
-			ComponentInstanceAddr: stackaddrs.AbsComponentInstance{
-				Item: stackaddrs.ComponentInstance{
-					Component: stackaddrs.Component{
-						Name: "sensitive",
-					},
-				},
-			},
-			OutputValues: map[addrs.OutputValue]cty.Value{
-				addrs.OutputValue{Name: "out"}: cty.StringVal("secret").Mark(marks.Sensitive),
-			},
-		},
-		&stackstate.AppliedChangeComponentInstance{
-			ComponentAddr: stackaddrs.AbsComponent{
-				Item: stackaddrs.Component{
 					Name: "self",
 				},
 			},
@@ -349,11 +332,27 @@ func TestApplyWithSensitivePropagation(t *testing.T) {
 			},
 			Schema: stacks_testing_provider.TestingResourceSchema,
 		},
+		&stackstate.AppliedChangeComponentInstance{
+			ComponentAddr: stackaddrs.AbsComponent{
+				Item: stackaddrs.Component{
+					Name: "sensitive",
+				},
+			},
+			ComponentInstanceAddr: stackaddrs.AbsComponentInstance{
+				Item: stackaddrs.ComponentInstance{
+					Component: stackaddrs.Component{
+						Name: "sensitive",
+					},
+				},
+			},
+			OutputValues: map[addrs.OutputValue]cty.Value{
+				addrs.OutputValue{Name: "out"}: cty.StringVal("secret").Mark(marks.Sensitive),
+			},
+		},
 	}
 
 	sort.SliceStable(applyChanges, func(i, j int) bool {
-		// An arbitrary sort just to make the result stable for comparison.
-		return fmt.Sprintf("%T", applyChanges[i]) < fmt.Sprintf("%T", applyChanges[j])
+		return appliedChangeSortKey(applyChanges[i]) < appliedChangeSortKey(applyChanges[j])
 	})
 
 	if diff := cmp.Diff(wantChanges, applyChanges, ctydebug.CmpOptions, cmpCollectionsSet); diff != "" {

--- a/internal/stacks/stackruntime/apply_test.go
+++ b/internal/stacks/stackruntime/apply_test.go
@@ -5,7 +5,6 @@ package stackruntime
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"path"
 	"sort"
@@ -19,9 +18,11 @@ import (
 
 	"github.com/hashicorp/terraform/internal/addrs"
 	terraformProvider "github.com/hashicorp/terraform/internal/builtin/providers/terraform"
+	"github.com/hashicorp/terraform/internal/lang/marks"
 	"github.com/hashicorp/terraform/internal/providers"
 	"github.com/hashicorp/terraform/internal/stacks/stackaddrs"
 	"github.com/hashicorp/terraform/internal/stacks/stackplan"
+	stacks_testing_provider "github.com/hashicorp/terraform/internal/stacks/stackruntime/testing"
 	"github.com/hashicorp/terraform/internal/stacks/stackstate"
 	"github.com/hashicorp/terraform/internal/states"
 	"github.com/hashicorp/terraform/internal/tfdiags"
@@ -29,23 +30,6 @@ import (
 
 func TestApplyWithRemovedResource(t *testing.T) {
 	fakePlanTimestamp, err := time.Parse(time.RFC3339, "1994-09-05T08:50:00Z")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	attrs := map[string]interface{}{
-		"id": "FE1D5830765C",
-		"input": map[string]interface{}{
-			"value": "hello",
-			"type":  "string",
-		},
-		"output": map[string]interface{}{
-			"value": nil,
-			"type":  "string",
-		},
-		"triggers_replace": nil,
-	}
-	attrsJSON, err := json.Marshal(attrs)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -95,8 +79,19 @@ func TestApplyWithRemovedResource(t *testing.T) {
 				}).
 				SetResourceInstanceObjectSrc(states.ResourceInstanceObjectSrc{
 					SchemaVersion: 0,
-					AttrsJSON:     attrsJSON,
-					Status:        states.ObjectReady,
+					AttrsJSON: mustMarshalJSONAttrs(map[string]interface{}{
+						"id": "FE1D5830765C",
+						"input": map[string]interface{}{
+							"value": "hello",
+							"type":  "string",
+						},
+						"output": map[string]interface{}{
+							"value": nil,
+							"type":  "string",
+						},
+						"triggers_replace": nil,
+					}),
+					Status: states.ObjectReady,
 				}).
 				SetProviderAddr(addrs.AbsProviderConfig{
 					Module:   addrs.RootModule,
@@ -142,7 +137,6 @@ func TestApplyWithRemovedResource(t *testing.T) {
 	diagsCh = make(chan tfdiags.Diagnostic)
 
 	applyResp := ApplyResponse{
-		Complete:       false,
 		AppliedChanges: applyChangesCh,
 		Diagnostics:    diagsCh,
 	}
@@ -151,10 +145,6 @@ func TestApplyWithRemovedResource(t *testing.T) {
 	applyChanges, applyDiags := collectApplyOutput(applyChangesCh, diagsCh)
 	if len(applyDiags) > 0 {
 		t.Fatalf("expected no diagnostics, got %s", applyDiags.ErrWithWarnings())
-	}
-
-	if len(applyChanges) != 2 {
-		t.Fatalf("expected 2 applied changes, got %d", len(applyChanges))
 	}
 
 	wantChanges := []stackstate.AppliedChange{
@@ -202,6 +192,162 @@ func TestApplyWithRemovedResource(t *testing.T) {
 					Hostname:  "terraform.io",
 				},
 			},
+		},
+	}
+
+	sort.SliceStable(applyChanges, func(i, j int) bool {
+		// An arbitrary sort just to make the result stable for comparison.
+		return fmt.Sprintf("%T", applyChanges[i]) < fmt.Sprintf("%T", applyChanges[j])
+	})
+
+	if diff := cmp.Diff(wantChanges, applyChanges, ctydebug.CmpOptions, cmpCollectionsSet); diff != "" {
+		t.Errorf("wrong changes\n%s", diff)
+	}
+}
+
+func TestApplyWithSensitivePropagation(t *testing.T) {
+	ctx := context.Background()
+	cfg := loadMainBundleConfigForTest(t, path.Join("with-single-input", "sensitive-input"))
+
+	fakePlanTimestamp, err := time.Parse(time.RFC3339, "1991-08-25T20:57:08Z")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	changesCh := make(chan stackplan.PlannedChange)
+	diagsCh := make(chan tfdiags.Diagnostic)
+	req := PlanRequest{
+		Config: cfg,
+		ProviderFactories: map[addrs.Provider]providers.Factory{
+			addrs.NewDefaultProvider("testing"): func() (providers.Interface, error) {
+				return stacks_testing_provider.NewProvider(), nil
+			},
+		},
+
+		ForcePlanTimestamp: &fakePlanTimestamp,
+
+		InputValues: map[stackaddrs.InputVariable]ExternalInputValue{
+			stackaddrs.InputVariable{Name: "id"}: {
+				Value: cty.StringVal("bb5cf32312ec"),
+			},
+		},
+	}
+	resp := PlanResponse{
+		PlannedChanges: changesCh,
+		Diagnostics:    diagsCh,
+	}
+
+	go Plan(ctx, &req, &resp)
+	planChanges, diags := collectPlanOutput(changesCh, diagsCh)
+	if len(diags) > 0 {
+		t.Fatalf("expected no diagnostics, got %s", diags.ErrWithWarnings())
+	}
+
+	var raw []*anypb.Any
+	for _, change := range planChanges {
+		proto, err := change.PlannedChangeProto()
+		if err != nil {
+			t.Fatal(err)
+		}
+		raw = append(raw, proto.Raw...)
+	}
+
+	applyReq := ApplyRequest{
+		Config:  cfg,
+		RawPlan: raw,
+		ProviderFactories: map[addrs.Provider]providers.Factory{
+			addrs.NewDefaultProvider("testing"): func() (providers.Interface, error) {
+				return stacks_testing_provider.NewProvider(), nil
+			},
+		},
+	}
+
+	applyChangesCh := make(chan stackstate.AppliedChange)
+	diagsCh = make(chan tfdiags.Diagnostic)
+
+	applyResp := ApplyResponse{
+		AppliedChanges: applyChangesCh,
+		Diagnostics:    diagsCh,
+	}
+
+	go Apply(ctx, &applyReq, &applyResp)
+	applyChanges, applyDiags := collectApplyOutput(applyChangesCh, diagsCh)
+	if len(applyDiags) > 0 {
+		t.Fatalf("expected no diagnostics, got %s", applyDiags.ErrWithWarnings())
+	}
+
+	wantChanges := []stackstate.AppliedChange{
+		&stackstate.AppliedChangeComponentInstance{
+			ComponentAddr: stackaddrs.AbsComponent{
+				Item: stackaddrs.Component{
+					Name: "sensitive",
+				},
+			},
+			ComponentInstanceAddr: stackaddrs.AbsComponentInstance{
+				Item: stackaddrs.ComponentInstance{
+					Component: stackaddrs.Component{
+						Name: "sensitive",
+					},
+				},
+			},
+			OutputValues: map[addrs.OutputValue]cty.Value{
+				addrs.OutputValue{Name: "out"}: cty.StringVal("secret").Mark(marks.Sensitive),
+			},
+		},
+		&stackstate.AppliedChangeComponentInstance{
+			ComponentAddr: stackaddrs.AbsComponent{
+				Item: stackaddrs.Component{
+					Name: "self",
+				},
+			},
+			ComponentInstanceAddr: stackaddrs.AbsComponentInstance{
+				Item: stackaddrs.ComponentInstance{
+					Component: stackaddrs.Component{
+						Name: "self",
+					},
+				},
+			},
+			OutputValues: make(map[addrs.OutputValue]cty.Value),
+		},
+		&stackstate.AppliedChangeResourceInstanceObject{
+			ResourceInstanceObjectAddr: stackaddrs.AbsResourceInstanceObject{
+				Component: stackaddrs.AbsComponentInstance{
+					Item: stackaddrs.ComponentInstance{
+						Component: stackaddrs.Component{
+							Name: "self",
+						},
+					},
+				},
+				Item: addrs.AbsResourceInstanceObject{
+					ResourceInstance: addrs.AbsResourceInstance{
+						Resource: addrs.ResourceInstance{
+							Resource: addrs.Resource{
+								Mode: addrs.ManagedResourceMode,
+								Type: "testing_resource",
+								Name: "data",
+							},
+						},
+					},
+				},
+			},
+			NewStateSrc: &states.ResourceInstanceObjectSrc{
+				AttrsJSON: mustMarshalJSONAttrs(map[string]interface{}{
+					"id":    "bb5cf32312ec",
+					"value": "secret",
+				}),
+				AttrSensitivePaths: []cty.PathValueMarks{
+					{
+						Path:  cty.GetAttrPath("value"),
+						Marks: cty.NewValueMarks(marks.Sensitive),
+					},
+				},
+				Status:       states.ObjectReady,
+				Dependencies: make([]addrs.ConfigResource, 0),
+			},
+			ProviderConfigAddr: addrs.AbsProviderConfig{
+				Provider: addrs.NewDefaultProvider("testing"),
+			},
+			Schema: stacks_testing_provider.TestingResourceSchema,
 		},
 	}
 

--- a/internal/stacks/stackruntime/helper_test.go
+++ b/internal/stacks/stackruntime/helper_test.go
@@ -4,15 +4,18 @@
 package stackruntime
 
 import (
+	"encoding/json"
 	"strings"
 	"testing"
 
 	"github.com/hashicorp/go-slug/sourceaddrs"
 	"github.com/hashicorp/go-slug/sourcebundle"
+	"github.com/zclconf/go-cty/cty"
+
+	"github.com/hashicorp/terraform/internal/configs/configschema"
 	"github.com/hashicorp/terraform/internal/plans"
 	"github.com/hashicorp/terraform/internal/stacks/stackconfig"
 	"github.com/hashicorp/terraform/internal/tfdiags"
-	"github.com/zclconf/go-cty/cty"
 )
 
 // This file has helper functions used by other tests. It doesn't contain any
@@ -117,4 +120,21 @@ func mustPlanDynamicValueDynamicType(v cty.Value) plans.DynamicValue {
 		panic(err)
 	}
 	return ret
+}
+
+func mustPlanDynamicValueSchema(v cty.Value, block *configschema.Block) plans.DynamicValue {
+	ty := block.ImpliedType()
+	ret, err := plans.NewDynamicValue(v, ty)
+	if err != nil {
+		panic(err)
+	}
+	return ret
+}
+
+func mustMarshalJSONAttrs(attrs map[string]interface{}) []byte {
+	jsonAttrs, err := json.Marshal(attrs)
+	if err != nil {
+		panic(err)
+	}
+	return jsonAttrs
 }

--- a/internal/stacks/stackruntime/internal/stackeval/component_instance.go
+++ b/internal/stacks/stackruntime/internal/stackeval/component_instance.go
@@ -991,6 +991,16 @@ func (c *ComponentInstance) ResultValue(ctx context.Context, phase EvalPhase) ct
 					attrs[name] = cty.DynamicVal
 					continue
 				}
+
+				if changeSrc.Sensitive {
+					// For our purposes here, a static sensitive flag on the
+					// output value is indistinguishable from the value having
+					// been dynamically marked as sensitive.
+					attrs[name] = change.After.Mark(marks.Sensitive)
+					continue
+				}
+
+				// Otherwise, just use the value as-is.
 				attrs[name] = change.After
 			}
 		} else {
@@ -1101,6 +1111,16 @@ func (c *ComponentInstance) ResultValue(ctx context.Context, phase EvalPhase) ct
 		attrs := make(map[string]cty.Value, len(outputVals))
 		for _, ov := range outputVals {
 			name := ov.Addr.OutputValue.Name
+
+			if ov.Sensitive {
+				// For our purposes here, a static sensitive flag on the
+				// output value is indistinguishable from the value having
+				// been dynamically marked as sensitive.
+				attrs[name] = ov.Value.Mark(marks.Sensitive)
+				continue
+			}
+
+			// Otherwise, just set the value as is.
 			attrs[name] = ov.Value
 		}
 		return cty.ObjectVal(attrs)

--- a/internal/stacks/stackruntime/plan_test.go
+++ b/internal/stacks/stackruntime/plan_test.go
@@ -771,22 +771,6 @@ func TestPlanWithSensitivePropagation(t *testing.T) {
 			Addr: stackaddrs.Absolute(
 				stackaddrs.RootStackInstance,
 				stackaddrs.ComponentInstance{
-					Component: stackaddrs.Component{Name: "sensitive"},
-				},
-			),
-			PlanApplyable:      true,
-			PlanComplete:       true,
-			Action:             plans.Create,
-			PlannedInputValues: make(map[string]plans.DynamicValue),
-			PlannedOutputValues: map[string]cty.Value{
-				"out": cty.StringVal("secret").Mark(marks.Sensitive),
-			},
-			PlanTimestamp: fakePlanTimestamp,
-		},
-		&stackplan.PlannedChangeComponentInstance{
-			Addr: stackaddrs.Absolute(
-				stackaddrs.RootStackInstance,
-				stackaddrs.ComponentInstance{
 					Component: stackaddrs.Component{Name: "self"},
 				},
 			),
@@ -813,9 +797,6 @@ func TestPlanWithSensitivePropagation(t *testing.T) {
 			},
 			PlannedOutputValues: make(map[string]cty.Value),
 			PlanTimestamp:       fakePlanTimestamp,
-		},
-		&stackplan.PlannedChangeHeader{
-			TerraformVersion: version.SemVer,
 		},
 		&stackplan.PlannedChangeResourceInstancePlanned{
 			ResourceInstanceObjectAddr: stackaddrs.AbsResourceInstanceObject{
@@ -869,6 +850,25 @@ func TestPlanWithSensitivePropagation(t *testing.T) {
 			},
 			Schema: stacks_testing_provider.TestingResourceSchema,
 		},
+		&stackplan.PlannedChangeComponentInstance{
+			Addr: stackaddrs.Absolute(
+				stackaddrs.RootStackInstance,
+				stackaddrs.ComponentInstance{
+					Component: stackaddrs.Component{Name: "sensitive"},
+				},
+			),
+			PlanApplyable:      true,
+			PlanComplete:       true,
+			Action:             plans.Create,
+			PlannedInputValues: make(map[string]plans.DynamicValue),
+			PlannedOutputValues: map[string]cty.Value{
+				"out": cty.StringVal("secret").Mark(marks.Sensitive),
+			},
+			PlanTimestamp: fakePlanTimestamp,
+		},
+		&stackplan.PlannedChangeHeader{
+			TerraformVersion: version.SemVer,
+		},
 		&stackplan.PlannedChangeRootInputValue{
 			Addr:  stackaddrs.InputVariable{Name: "id"},
 			Value: cty.NullVal(cty.String),
@@ -876,8 +876,7 @@ func TestPlanWithSensitivePropagation(t *testing.T) {
 	}
 
 	sort.SliceStable(gotChanges, func(i, j int) bool {
-		// An arbitrary sort just to make the result stable for comparison.
-		return fmt.Sprintf("%T", gotChanges[i]) < fmt.Sprintf("%T", gotChanges[j])
+		return plannedChangeSortKey(gotChanges[i]) < plannedChangeSortKey(gotChanges[j])
 	})
 
 	if diff := cmp.Diff(wantChanges, gotChanges, ctydebug.CmpOptions, cmpCollectionsSet); diff != "" {
@@ -924,22 +923,6 @@ func TestPlanWithSensitivePropagationNested(t *testing.T) {
 		},
 		&stackplan.PlannedChangeComponentInstance{
 			Addr: stackaddrs.Absolute(
-				stackaddrs.RootStackInstance.Child("sensitive", addrs.NoKey),
-				stackaddrs.ComponentInstance{
-					Component: stackaddrs.Component{Name: "self"},
-				},
-			),
-			Action:             plans.Create,
-			PlanApplyable:      true,
-			PlanComplete:       true,
-			PlannedInputValues: make(map[string]plans.DynamicValue),
-			PlannedOutputValues: map[string]cty.Value{
-				"out": cty.StringVal("secret").Mark(marks.Sensitive),
-			},
-			PlanTimestamp: fakePlanTimestamp,
-		},
-		&stackplan.PlannedChangeComponentInstance{
-			Addr: stackaddrs.Absolute(
 				stackaddrs.RootStackInstance,
 				stackaddrs.ComponentInstance{
 					Component: stackaddrs.Component{Name: "self"},
@@ -962,9 +945,6 @@ func TestPlanWithSensitivePropagationNested(t *testing.T) {
 			},
 			PlannedOutputValues: make(map[string]cty.Value),
 			PlanTimestamp:       fakePlanTimestamp,
-		},
-		&stackplan.PlannedChangeHeader{
-			TerraformVersion: version.SemVer,
 		},
 		&stackplan.PlannedChangeResourceInstancePlanned{
 			ResourceInstanceObjectAddr: stackaddrs.AbsResourceInstanceObject{
@@ -1018,6 +998,25 @@ func TestPlanWithSensitivePropagationNested(t *testing.T) {
 			},
 			Schema: stacks_testing_provider.TestingResourceSchema,
 		},
+		&stackplan.PlannedChangeHeader{
+			TerraformVersion: version.SemVer,
+		},
+		&stackplan.PlannedChangeComponentInstance{
+			Addr: stackaddrs.Absolute(
+				stackaddrs.RootStackInstance.Child("sensitive", addrs.NoKey),
+				stackaddrs.ComponentInstance{
+					Component: stackaddrs.Component{Name: "self"},
+				},
+			),
+			Action:             plans.Create,
+			PlanApplyable:      true,
+			PlanComplete:       true,
+			PlannedInputValues: make(map[string]plans.DynamicValue),
+			PlannedOutputValues: map[string]cty.Value{
+				"out": cty.StringVal("secret").Mark(marks.Sensitive),
+			},
+			PlanTimestamp: fakePlanTimestamp,
+		},
 		&stackplan.PlannedChangeRootInputValue{
 			Addr:  stackaddrs.InputVariable{Name: "id"},
 			Value: cty.NullVal(cty.String),
@@ -1025,8 +1024,7 @@ func TestPlanWithSensitivePropagationNested(t *testing.T) {
 	}
 
 	sort.SliceStable(gotChanges, func(i, j int) bool {
-		// An arbitrary sort just to make the result stable for comparison.
-		return fmt.Sprintf("%T", gotChanges[i]) < fmt.Sprintf("%T", gotChanges[j])
+		return plannedChangeSortKey(gotChanges[i]) < plannedChangeSortKey(gotChanges[j])
 	})
 
 	if diff := cmp.Diff(wantChanges, gotChanges, ctydebug.CmpOptions, cmpCollectionsSet); diff != "" {

--- a/internal/stacks/stackruntime/plan_test.go
+++ b/internal/stacks/stackruntime/plan_test.go
@@ -25,9 +25,10 @@ import (
 	"github.com/hashicorp/terraform/internal/lang/marks"
 	"github.com/hashicorp/terraform/internal/plans"
 	"github.com/hashicorp/terraform/internal/providers"
-	testing_provider "github.com/hashicorp/terraform/internal/providers/testing"
+	default_testing_provider "github.com/hashicorp/terraform/internal/providers/testing"
 	"github.com/hashicorp/terraform/internal/stacks/stackaddrs"
 	"github.com/hashicorp/terraform/internal/stacks/stackplan"
+	stacks_testing_provider "github.com/hashicorp/terraform/internal/stacks/stackruntime/testing"
 	"github.com/hashicorp/terraform/internal/stacks/stackstate"
 	"github.com/hashicorp/terraform/internal/states"
 	"github.com/hashicorp/terraform/internal/tfdiags"
@@ -565,7 +566,7 @@ func TestPlanWithProviderConfig(t *testing.T) {
 		changesCh := make(chan stackplan.PlannedChange, 8)
 		diagsCh := make(chan tfdiags.Diagnostic, 2)
 
-		provider := &testing_provider.MockProvider{
+		provider := &default_testing_provider.MockProvider{
 			GetProviderSchemaResponse:      providerSchema,
 			ValidateProviderConfigResponse: &providers.ValidateProviderConfigResponse{},
 			ConfigureProviderResponse:      &providers.ConfigureProviderResponse{},
@@ -616,6 +617,7 @@ func TestPlanWithProviderConfig(t *testing.T) {
 		}
 	})
 }
+
 func TestPlanWithRemovedResource(t *testing.T) {
 	fakePlanTimestamp, err := time.Parse(time.RFC3339, "1994-09-05T08:50:00Z")
 	if err != nil {
@@ -725,6 +727,310 @@ func TestPlanWithRemovedResource(t *testing.T) {
 				t.Fatalf("unexpected diagnostics: %s", diags.ErrWithWarnings().Error())
 			}
 		})
+	}
+}
+
+func TestPlanWithSensitivePropagation(t *testing.T) {
+	ctx := context.Background()
+	cfg := loadMainBundleConfigForTest(t, path.Join("with-single-input", "sensitive-input"))
+
+	fakePlanTimestamp, err := time.Parse(time.RFC3339, "1991-08-25T20:57:08Z")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	changesCh := make(chan stackplan.PlannedChange, 8)
+	diagsCh := make(chan tfdiags.Diagnostic, 2)
+	req := PlanRequest{
+		Config: cfg,
+		ProviderFactories: map[addrs.Provider]providers.Factory{
+			addrs.NewDefaultProvider("testing"): func() (providers.Interface, error) {
+				return stacks_testing_provider.NewProvider(), nil
+			},
+		},
+
+		ForcePlanTimestamp: &fakePlanTimestamp,
+	}
+	resp := PlanResponse{
+		PlannedChanges: changesCh,
+		Diagnostics:    diagsCh,
+	}
+
+	go Plan(ctx, &req, &resp)
+	gotChanges, diags := collectPlanOutput(changesCh, diagsCh)
+
+	if len(diags) != 0 {
+		t.Errorf("unexpected diagnostics\n%s", diags.ErrWithWarnings().Error())
+	}
+
+	wantChanges := []stackplan.PlannedChange{
+		&stackplan.PlannedChangeApplyable{
+			Applyable: true,
+		},
+		&stackplan.PlannedChangeComponentInstance{
+			Addr: stackaddrs.Absolute(
+				stackaddrs.RootStackInstance,
+				stackaddrs.ComponentInstance{
+					Component: stackaddrs.Component{Name: "sensitive"},
+				},
+			),
+			PlanApplyable:      true,
+			PlanComplete:       true,
+			Action:             plans.Create,
+			PlannedInputValues: make(map[string]plans.DynamicValue),
+			PlannedOutputValues: map[string]cty.Value{
+				"out": cty.StringVal("secret").Mark(marks.Sensitive),
+			},
+			PlanTimestamp: fakePlanTimestamp,
+		},
+		&stackplan.PlannedChangeComponentInstance{
+			Addr: stackaddrs.Absolute(
+				stackaddrs.RootStackInstance,
+				stackaddrs.ComponentInstance{
+					Component: stackaddrs.Component{Name: "self"},
+				},
+			),
+			PlanApplyable: true,
+			PlanComplete:  true,
+			Action:        plans.Create,
+			RequiredComponents: collections.NewSet[stackaddrs.AbsComponent](
+				stackaddrs.AbsComponent{
+					Stack: stackaddrs.RootStackInstance,
+					Item:  stackaddrs.Component{Name: "sensitive"},
+				},
+			),
+			PlannedInputValues: map[string]plans.DynamicValue{
+				"id":    mustPlanDynamicValueDynamicType(cty.NullVal(cty.String)),
+				"input": mustPlanDynamicValueDynamicType(cty.StringVal("secret")),
+			},
+			PlannedInputValueMarks: map[string][]cty.PathValueMarks{
+				"id": nil,
+				"input": {
+					{
+						Marks: cty.NewValueMarks(marks.Sensitive),
+					},
+				},
+			},
+			PlannedOutputValues: make(map[string]cty.Value),
+			PlanTimestamp:       fakePlanTimestamp,
+		},
+		&stackplan.PlannedChangeHeader{
+			TerraformVersion: version.SemVer,
+		},
+		&stackplan.PlannedChangeResourceInstancePlanned{
+			ResourceInstanceObjectAddr: stackaddrs.AbsResourceInstanceObject{
+				Component: stackaddrs.Absolute(
+					stackaddrs.RootStackInstance,
+					stackaddrs.ComponentInstance{
+						Component: stackaddrs.Component{Name: "self"},
+					},
+				),
+				Item: addrs.AbsResourceInstanceObject{
+					ResourceInstance: addrs.Resource{
+						Mode: addrs.ManagedResourceMode,
+						Type: "testing_resource",
+						Name: "data",
+					}.Instance(addrs.NoKey).Absolute(addrs.RootModuleInstance),
+				},
+			},
+			ProviderConfigAddr: addrs.AbsProviderConfig{
+				Module:   addrs.RootModule,
+				Provider: addrs.MustParseProviderSourceString("hashicorp/testing"),
+			},
+			ChangeSrc: &plans.ResourceInstanceChangeSrc{
+				Addr: addrs.Resource{
+					Mode: addrs.ManagedResourceMode,
+					Type: "testing_resource",
+					Name: "data",
+				}.Instance(addrs.NoKey).Absolute(addrs.RootModuleInstance),
+				PrevRunAddr: addrs.Resource{
+					Mode: addrs.ManagedResourceMode,
+					Type: "testing_resource",
+					Name: "data",
+				}.Instance(addrs.NoKey).Absolute(addrs.RootModuleInstance),
+				ProviderAddr: addrs.AbsProviderConfig{
+					Module:   addrs.RootModule,
+					Provider: addrs.NewDefaultProvider("testing"),
+				},
+				ChangeSrc: plans.ChangeSrc{
+					Action: plans.Create,
+					Before: mustPlanDynamicValue(cty.NullVal(cty.DynamicPseudoType)),
+					After: mustPlanDynamicValueSchema(cty.ObjectVal(map[string]cty.Value{
+						"id":    cty.UnknownVal(cty.String),
+						"value": cty.StringVal("secret"),
+					}), stacks_testing_provider.TestingResourceSchema),
+					AfterValMarks: []cty.PathValueMarks{
+						{
+							Path:  cty.GetAttrPath("value"),
+							Marks: cty.NewValueMarks(marks.Sensitive),
+						},
+					},
+				},
+			},
+			Schema: stacks_testing_provider.TestingResourceSchema,
+		},
+		&stackplan.PlannedChangeRootInputValue{
+			Addr:  stackaddrs.InputVariable{Name: "id"},
+			Value: cty.NullVal(cty.String),
+		},
+	}
+
+	sort.SliceStable(gotChanges, func(i, j int) bool {
+		// An arbitrary sort just to make the result stable for comparison.
+		return fmt.Sprintf("%T", gotChanges[i]) < fmt.Sprintf("%T", gotChanges[j])
+	})
+
+	if diff := cmp.Diff(wantChanges, gotChanges, ctydebug.CmpOptions, cmpCollectionsSet); diff != "" {
+		t.Errorf("wrong changes\n%s", diff)
+	}
+}
+
+func TestPlanWithSensitivePropagationNested(t *testing.T) {
+	ctx := context.Background()
+	cfg := loadMainBundleConfigForTest(t, path.Join("with-single-input", "sensitive-input-nested"))
+
+	fakePlanTimestamp, err := time.Parse(time.RFC3339, "1991-08-25T20:57:08Z")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	changesCh := make(chan stackplan.PlannedChange, 8)
+	diagsCh := make(chan tfdiags.Diagnostic, 2)
+	req := PlanRequest{
+		Config: cfg,
+		ProviderFactories: map[addrs.Provider]providers.Factory{
+			addrs.NewDefaultProvider("testing"): func() (providers.Interface, error) {
+				return stacks_testing_provider.NewProvider(), nil
+			},
+		},
+
+		ForcePlanTimestamp: &fakePlanTimestamp,
+	}
+	resp := PlanResponse{
+		PlannedChanges: changesCh,
+		Diagnostics:    diagsCh,
+	}
+
+	go Plan(ctx, &req, &resp)
+	gotChanges, diags := collectPlanOutput(changesCh, diagsCh)
+
+	if len(diags) != 0 {
+		t.Errorf("unexpected diagnostics\n%s", diags.ErrWithWarnings().Error())
+	}
+
+	wantChanges := []stackplan.PlannedChange{
+		&stackplan.PlannedChangeApplyable{
+			Applyable: true,
+		},
+		&stackplan.PlannedChangeComponentInstance{
+			Addr: stackaddrs.Absolute(
+				stackaddrs.RootStackInstance.Child("sensitive", addrs.NoKey),
+				stackaddrs.ComponentInstance{
+					Component: stackaddrs.Component{Name: "self"},
+				},
+			),
+			Action:             plans.Create,
+			PlanApplyable:      true,
+			PlanComplete:       true,
+			PlannedInputValues: make(map[string]plans.DynamicValue),
+			PlannedOutputValues: map[string]cty.Value{
+				"out": cty.StringVal("secret").Mark(marks.Sensitive),
+			},
+			PlanTimestamp: fakePlanTimestamp,
+		},
+		&stackplan.PlannedChangeComponentInstance{
+			Addr: stackaddrs.Absolute(
+				stackaddrs.RootStackInstance,
+				stackaddrs.ComponentInstance{
+					Component: stackaddrs.Component{Name: "self"},
+				},
+			),
+			Action:        plans.Create,
+			PlanApplyable: true,
+			PlanComplete:  true,
+			PlannedInputValues: map[string]plans.DynamicValue{
+				"id":    mustPlanDynamicValueDynamicType(cty.NullVal(cty.String)),
+				"input": mustPlanDynamicValueDynamicType(cty.StringVal("secret")),
+			},
+			PlannedInputValueMarks: map[string][]cty.PathValueMarks{
+				"id": nil,
+				"input": {
+					{
+						Marks: cty.NewValueMarks(marks.Sensitive),
+					},
+				},
+			},
+			PlannedOutputValues: make(map[string]cty.Value),
+			PlanTimestamp:       fakePlanTimestamp,
+		},
+		&stackplan.PlannedChangeHeader{
+			TerraformVersion: version.SemVer,
+		},
+		&stackplan.PlannedChangeResourceInstancePlanned{
+			ResourceInstanceObjectAddr: stackaddrs.AbsResourceInstanceObject{
+				Component: stackaddrs.Absolute(
+					stackaddrs.RootStackInstance,
+					stackaddrs.ComponentInstance{
+						Component: stackaddrs.Component{Name: "self"},
+					},
+				),
+				Item: addrs.AbsResourceInstanceObject{
+					ResourceInstance: addrs.Resource{
+						Mode: addrs.ManagedResourceMode,
+						Type: "testing_resource",
+						Name: "data",
+					}.Instance(addrs.NoKey).Absolute(addrs.RootModuleInstance),
+				},
+			},
+			ProviderConfigAddr: addrs.AbsProviderConfig{
+				Module:   addrs.RootModule,
+				Provider: addrs.MustParseProviderSourceString("hashicorp/testing"),
+			},
+			ChangeSrc: &plans.ResourceInstanceChangeSrc{
+				Addr: addrs.Resource{
+					Mode: addrs.ManagedResourceMode,
+					Type: "testing_resource",
+					Name: "data",
+				}.Instance(addrs.NoKey).Absolute(addrs.RootModuleInstance),
+				PrevRunAddr: addrs.Resource{
+					Mode: addrs.ManagedResourceMode,
+					Type: "testing_resource",
+					Name: "data",
+				}.Instance(addrs.NoKey).Absolute(addrs.RootModuleInstance),
+				ProviderAddr: addrs.AbsProviderConfig{
+					Module:   addrs.RootModule,
+					Provider: addrs.NewDefaultProvider("testing"),
+				},
+				ChangeSrc: plans.ChangeSrc{
+					Action: plans.Create,
+					Before: mustPlanDynamicValue(cty.NullVal(cty.DynamicPseudoType)),
+					After: mustPlanDynamicValueSchema(cty.ObjectVal(map[string]cty.Value{
+						"id":    cty.UnknownVal(cty.String),
+						"value": cty.StringVal("secret"),
+					}), stacks_testing_provider.TestingResourceSchema),
+					AfterValMarks: []cty.PathValueMarks{
+						{
+							Path:  cty.GetAttrPath("value"),
+							Marks: cty.NewValueMarks(marks.Sensitive),
+						},
+					},
+				},
+			},
+			Schema: stacks_testing_provider.TestingResourceSchema,
+		},
+		&stackplan.PlannedChangeRootInputValue{
+			Addr:  stackaddrs.InputVariable{Name: "id"},
+			Value: cty.NullVal(cty.String),
+		},
+	}
+
+	sort.SliceStable(gotChanges, func(i, j int) bool {
+		// An arbitrary sort just to make the result stable for comparison.
+		return fmt.Sprintf("%T", gotChanges[i]) < fmt.Sprintf("%T", gotChanges[j])
+	})
+
+	if diff := cmp.Diff(wantChanges, gotChanges, ctydebug.CmpOptions, cmpCollectionsSet); diff != "" {
+		t.Errorf("wrong changes\n%s", diff)
 	}
 }
 

--- a/internal/stacks/stackruntime/testdata/mainbundle/test/with-single-input/sensitive-input-nested/sensitive-input-nested.tfstack.hcl
+++ b/internal/stacks/stackruntime/testdata/mainbundle/test/with-single-input/sensitive-input-nested/sensitive-input-nested.tfstack.hcl
@@ -1,0 +1,30 @@
+required_providers {
+  testing = {
+    source  = "hashicorp/testing"
+    version = "0.1.0"
+  }
+}
+
+variable "id" {
+  type     = string
+  default  = null
+}
+
+provider "testing" "default" {}
+
+stack "sensitive" {
+  source = "../../sensitive-output"
+}
+
+component "self" {
+  source = "../"
+
+  providers = {
+    testing = provider.testing.default
+  }
+
+  inputs = {
+    id    = var.id
+    input = stack.sensitive.result
+  }
+}

--- a/internal/stacks/stackruntime/testdata/mainbundle/test/with-single-input/sensitive-input/sensitive-input.tfstack.hcl
+++ b/internal/stacks/stackruntime/testdata/mainbundle/test/with-single-input/sensitive-input/sensitive-input.tfstack.hcl
@@ -1,0 +1,30 @@
+required_providers {
+  testing = {
+    source  = "hashicorp/testing"
+    version = "0.1.0"
+  }
+}
+
+variable "id" {
+  type     = string
+  default  = null
+}
+
+provider "testing" "default" {}
+
+component "sensitive" {
+  source = "../../sensitive-output"
+}
+
+component "self" {
+  source = "../"
+
+  providers = {
+    testing = provider.testing.default
+  }
+
+  inputs = {
+    id    = var.id
+    input = component.sensitive.out
+  }
+}

--- a/internal/stacks/stackruntime/testdata/mainbundle/test/with-single-input/single-input.tf
+++ b/internal/stacks/stackruntime/testdata/mainbundle/test/with-single-input/single-input.tf
@@ -1,0 +1,23 @@
+terraform {
+  required_providers {
+    testing = {
+      source  = "hashicorp/testing"
+      version = "0.1.0"
+    }
+  }
+}
+
+variable "id" {
+  type     = string
+  default  = null
+  nullable = true # We'll generate an ID if none provided.
+}
+
+variable "input" {
+  type = string
+}
+
+resource "testing_resource" "data" {
+  id    = var.id
+  value = var.input
+}

--- a/internal/stacks/stackruntime/testing/provider.go
+++ b/internal/stacks/stackruntime/testing/provider.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
 package testing
 
 import (

--- a/internal/stacks/stackruntime/testing/provider.go
+++ b/internal/stacks/stackruntime/testing/provider.go
@@ -1,0 +1,143 @@
+package testing
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/zclconf/go-cty/cty"
+
+	"github.com/hashicorp/terraform/internal/configs/configschema"
+	"github.com/hashicorp/terraform/internal/providers"
+	testing_provider "github.com/hashicorp/terraform/internal/providers/testing"
+	"github.com/hashicorp/terraform/internal/tfdiags"
+)
+
+var (
+	TestingResourceSchema = &configschema.Block{
+		Attributes: map[string]*configschema.Attribute{
+			"id":    {Type: cty.String, Optional: true, Computed: true},
+			"value": {Type: cty.String, Optional: true},
+		},
+	}
+
+	TestingDataSourceSchema = &configschema.Block{
+		Attributes: map[string]*configschema.Attribute{
+			"id":    {Type: cty.String, Required: true},
+			"value": {Type: cty.String, Computed: true},
+		},
+	}
+)
+
+// MockProvider wraps the standard MockProvider with a simple in-memory
+// data store for resources and data sources.
+type MockProvider struct {
+	*testing_provider.MockProvider
+
+	ResourceStore *ResourceStore
+}
+
+// NewProvider returns a new MockProvider with an empty data store.
+func NewProvider() *MockProvider {
+	return NewProviderWithData(NewResourceStore())
+}
+
+// NewProviderWithData returns a new MockProvider with the given data store.
+func NewProviderWithData(store *ResourceStore) *MockProvider {
+	return &MockProvider{
+		MockProvider: &testing_provider.MockProvider{
+			GetProviderSchemaResponse: &providers.GetProviderSchemaResponse{
+				ResourceTypes: map[string]providers.Schema{
+					"testing_resource": {
+						Block: TestingResourceSchema,
+					},
+					"testing_data_source": {
+						Block: TestingDataSourceSchema,
+					},
+				},
+			},
+			PlanResourceChangeFn: func(request providers.PlanResourceChangeRequest) providers.PlanResourceChangeResponse {
+				if request.ProposedNewState.IsNull() {
+					// Deleting, so just return the proposed change.
+					return providers.PlanResourceChangeResponse{
+						PlannedState: request.ProposedNewState,
+					}
+				}
+
+				// We're creating or updating, so we need to return the new
+				// state with any computed values filled in.
+
+				value := request.ProposedNewState
+				if id := value.GetAttr("id"); id.IsNull() {
+					vals := value.AsValueMap()
+					vals["id"] = cty.UnknownVal(cty.String)
+					value = cty.ObjectVal(vals)
+				}
+
+				return providers.PlanResourceChangeResponse{
+					PlannedState: value,
+				}
+			},
+			ApplyResourceChangeFn: func(request providers.ApplyResourceChangeRequest) providers.ApplyResourceChangeResponse {
+				if request.PlannedState.IsNull() {
+					// Deleting, so just update the store and return.
+					store.Delete(request.PlannedState.GetAttr("id").AsString())
+					return providers.ApplyResourceChangeResponse{
+						NewState: request.PlannedState,
+					}
+				}
+
+				// Creating or updating, so update the store and return.
+
+				// First, populate the computed value if we have to.
+				value := request.PlannedState
+				if id := value.GetAttr("id"); !id.IsKnown() {
+					vals := value.AsValueMap()
+					vals["id"] = cty.StringVal(mustGenerateUUID())
+					value = cty.ObjectVal(vals)
+				}
+
+				// Finally, update the store and return.
+				store.Set(value.GetAttr("id").AsString(), value)
+				return providers.ApplyResourceChangeResponse{
+					NewState: value,
+				}
+			},
+			ReadResourceFn: func(request providers.ReadResourceRequest) providers.ReadResourceResponse {
+				var diags tfdiags.Diagnostics
+
+				id := request.PriorState.GetAttr("id").AsString()
+				value, exists := store.Get(id)
+				if !exists {
+					diags = diags.Append(tfdiags.Sourceless(tfdiags.Error, "not found", fmt.Sprintf("%q not found", id)))
+				}
+				return providers.ReadResourceResponse{
+					NewState:    value,
+					Diagnostics: diags,
+				}
+			},
+			ReadDataSourceFn: func(request providers.ReadDataSourceRequest) providers.ReadDataSourceResponse {
+				var diags tfdiags.Diagnostics
+
+				id := request.Config.GetAttr("id").AsString()
+				value, exists := store.Get(id)
+				if !exists {
+					diags = diags.Append(tfdiags.Sourceless(tfdiags.Error, "not found", fmt.Sprintf("%q not found", id)))
+				}
+				return providers.ReadDataSourceResponse{
+					State:       value,
+					Diagnostics: diags,
+				}
+			},
+		},
+		ResourceStore: store,
+	}
+}
+
+// mustGenerateUUID is a helper to generate a UUID and panic if it fails.
+func mustGenerateUUID() string {
+	val, err := uuid.GenerateUUID()
+	if err != nil {
+		panic(err)
+	}
+	return val
+}

--- a/internal/stacks/stackruntime/testing/store.go
+++ b/internal/stacks/stackruntime/testing/store.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
 package testing
 
 import (

--- a/internal/stacks/stackruntime/testing/store.go
+++ b/internal/stacks/stackruntime/testing/store.go
@@ -1,0 +1,75 @@
+package testing
+
+import (
+	"sync"
+
+	"github.com/zclconf/go-cty/cty"
+)
+
+// ResourceStore is a simple data store, that can let the mock provider defined
+// in this package store and return interesting values for resources and data
+// sources.
+type ResourceStore struct {
+	mutex sync.RWMutex
+
+	Resources map[string]cty.Value
+}
+
+func NewResourceStore() *ResourceStore {
+	return &ResourceStore{
+		Resources: map[string]cty.Value{},
+	}
+}
+
+func (rs *ResourceStore) Get(id string) (cty.Value, bool) {
+	rs.mutex.RLock()
+	defer rs.mutex.RUnlock()
+
+	value, exists := rs.Resources[id]
+	return value, exists
+}
+
+func (rs *ResourceStore) Set(id string, value cty.Value) {
+	rs.mutex.Lock()
+	defer rs.mutex.Unlock()
+
+	rs.Resources[id] = value
+}
+
+func (rs *ResourceStore) Delete(id string) {
+	rs.mutex.Lock()
+	defer rs.mutex.Unlock()
+
+	delete(rs.Resources, id)
+}
+
+// ResourceStoreBuilder is an implementation of the builder pattern for building
+// a ResourceStore with prepopulated values.
+type ResourceStoreBuilder struct {
+	store *ResourceStore
+}
+
+func NewResourceStoreBuilder() *ResourceStoreBuilder {
+	return &ResourceStoreBuilder{
+		store: NewResourceStore(),
+	}
+}
+
+func (b *ResourceStoreBuilder) AddResource(id string, value cty.Value) *ResourceStoreBuilder {
+	if b.store == nil {
+		panic("cannot add resources after calling Build()")
+	}
+
+	b.store.Set(id, value)
+	return b
+}
+
+func (b *ResourceStoreBuilder) Build() *ResourceStore {
+	if b.store == nil {
+		panic("cannot call Build() more than once")
+	}
+
+	store := b.store
+	b.store = nil
+	return store
+}


### PR DESCRIPTION
This PR fixes 2 bugs in stacks' processing of sensitive values from outputs.

During planning, the `sensitive` attribute on output configuration blocks is essentially ignored. The value must be marked as `sensitive` by another source (like, the `sensitive(...)` function) for the sensitivity to be applied within stacks references. This PR fixes this by explicitly checking the configuration of the output blocks for the sensitive attribute, and applying the relevant marks.

During apply, because of [this](https://github.com/hashicorp/terraform/blob/main/internal/terraform/node_output.go#L702) line, the output values themselves do not have sensitive marks applied to them from the state ever. So, the only way the sensitive marks would be applied would be if we were checking the config attributes which we weren't. This PR fixes this with the same approach, we now look at the configuration and apply the relevant marks when stacks is processing the outputs.