### PR TITLE
test: allow using global variables in suite-level variable definitions

### DIFF
--- a/internal/backend/local/test.go
+++ b/internal/backend/local/test.go
@@ -1196,7 +1196,7 @@ func (runner *TestFileRunner) getVariablesFromConfiguration(knownVariables terra
 	for name, expr := range variableConfig {
 		relevanceDiags := validateRelevance(name, expr)
 		diags = diags.Append(relevanceDiags)
-		if relevanceDiags.HasWarnings() {
+		if len(relevanceDiags) > 0 {
 			continue
 		}
 

--- a/internal/backend/local/test.go
+++ b/internal/backend/local/test.go
@@ -1195,8 +1195,8 @@ func (runner *TestFileRunner) getVariablesFromConfiguration(knownVariables terra
 
 	for name, expr := range variableConfig {
 		relevanceDiags := validateRelevance(name, expr)
+		diags = diags.Append(relevanceDiags)
 		if relevanceDiags.HasWarnings() {
-			diags = diags.Append(relevanceDiags)
 			continue
 		}
 

--- a/internal/backend/local/test.go
+++ b/internal/backend/local/test.go
@@ -250,9 +250,9 @@ type TestFileRunner struct {
 	fileVariables terraform.InputValues
 	// fileVariableExpressions are the hcl expressions for the fileVariables
 	fileVariableExpressions map[string]hcl.Expression
-	// GlobalAndSuiteVariables is a combination of globalVariables and fileVariables
+	// globalAndFileVariables is a combination of globalVariables and fileVariables
 	// created for convenience
-	GlobalAndSuiteVariables terraform.InputValues
+	globalAndFileVariables terraform.InputValues
 }
 
 // TestFileState is a helper struct that just maps a run block to the state that
@@ -395,7 +395,7 @@ func (runner *TestFileRunner) run(run *moduletest.Run, file *moduletest.File, st
 	}
 	runner.gatherProviders(key, config)
 
-	resetConfig, configDiags := configtest.TransformConfigForTest(config, run, file, runner.GlobalAndSuiteVariables, runner.PriorOutputs, runner.Suite.configProviders[key])
+	resetConfig, configDiags := configtest.TransformConfigForTest(config, run, file, runner.globalAndFileVariables, runner.PriorOutputs, runner.Suite.configProviders[key])
 	defer resetConfig()
 
 	run.Diagnostics = run.Diagnostics.Append(configDiags)
@@ -960,7 +960,7 @@ func (runner *TestFileRunner) cleanup(file *moduletest.File) {
 			key = state.Run.Config.Module.Source.String()
 		}
 
-		reset, configDiags := configtest.TransformConfigForTest(config, state.Run, file, runner.GlobalAndSuiteVariables, runner.PriorOutputs, runner.Suite.configProviders[key])
+		reset, configDiags := configtest.TransformConfigForTest(config, state.Run, file, runner.globalAndFileVariables, runner.PriorOutputs, runner.Suite.configProviders[key])
 		diags = diags.Append(configDiags)
 
 		updated := state.State
@@ -1342,12 +1342,12 @@ func (runner *TestFileRunner) initVariables(file *moduletest.File) {
 
 	// Finally, we merge the global and file variables together to get all
 	// available variables outside the run specific ones
-	runner.GlobalAndSuiteVariables = make(terraform.InputValues)
+	runner.globalAndFileVariables = make(terraform.InputValues)
 	for name, value := range runner.globalVariables {
-		runner.GlobalAndSuiteVariables[name] = value
+		runner.globalAndFileVariables[name] = value
 	}
 	for name, value := range runner.fileVariables {
-		runner.GlobalAndSuiteVariables[name] = value
+		runner.globalAndFileVariables[name] = value
 	}
 }
 

--- a/internal/backend/local/test.go
+++ b/internal/backend/local/test.go
@@ -1024,7 +1024,7 @@ func (runner *TestFileRunner) GetVariables(config *configs.Config, run *modulete
 		return getVarsDiags
 	}
 
-	// Second, we'll check to see which variables the suites global variables
+	// Second, we'll check to see which variables the file variables
 	// themselves reference.
 	diags = diags.Append(getRelevantVariables(runner.fileVariableExpressions))
 

--- a/internal/command/testdata/test/global_var_ref_in_suite_var/main.tf
+++ b/internal/command/testdata/test/global_var_ref_in_suite_var/main.tf
@@ -1,0 +1,10 @@
+variable "input" {
+  default = null
+  type    = object({
+              organization_name = string
+            })
+}
+
+output "value" {
+  value = var.input
+}

--- a/internal/command/testdata/test/global_var_ref_in_suite_var/main.tf
+++ b/internal/command/testdata/test/global_var_ref_in_suite_var/main.tf
@@ -1,8 +1,8 @@
 variable "input" {
   default = null
-  type    = object({
-              organization_name = string
-            })
+  type = object({
+    organization_name = string
+  })
 }
 
 output "value" {

--- a/internal/command/testdata/test/global_var_ref_in_suite_var/run_block_output.tftest.hcl
+++ b/internal/command/testdata/test/global_var_ref_in_suite_var/run_block_output.tftest.hcl
@@ -1,7 +1,7 @@
 
 variables {
   input = {
-      organization_name = var.org_name
+    organization_name = var.org_name
   }
 }
 

--- a/internal/command/testdata/test/global_var_ref_in_suite_var/run_block_output.tftest.hcl
+++ b/internal/command/testdata/test/global_var_ref_in_suite_var/run_block_output.tftest.hcl
@@ -1,0 +1,13 @@
+
+variables {
+  input = {
+      organization_name = var.org_name
+  }
+}
+
+run "execute" {
+  assert {
+    condition     = output.value.organization_name == "my-org"
+    error_message = "bad output value"
+  }
+}

--- a/internal/command/testdata/test/global_var_ref_in_suite_var/terraform.tfvars
+++ b/internal/command/testdata/test/global_var_ref_in_suite_var/terraform.tfvars
@@ -1,0 +1,1 @@
+org_name = "my-org"

--- a/internal/moduletest/config/config.go
+++ b/internal/moduletest/config/config.go
@@ -10,10 +10,10 @@ import (
 	"github.com/zclconf/go-cty/cty"
 
 	"github.com/hashicorp/terraform/internal/addrs"
-	"github.com/hashicorp/terraform/internal/backend"
 	"github.com/hashicorp/terraform/internal/configs"
 	"github.com/hashicorp/terraform/internal/moduletest"
 	hcltest "github.com/hashicorp/terraform/internal/moduletest/hcl"
+	"github.com/hashicorp/terraform/internal/terraform"
 )
 
 // TransformConfigForTest transforms the provided configuration ready for the
@@ -27,7 +27,7 @@ import (
 // We also return a reset function that should be called to return the
 // configuration to it's original state before the next run block or test file
 // needs to use it.
-func TransformConfigForTest(config *configs.Config, run *moduletest.Run, file *moduletest.File, availableVariables map[string]backend.UnparsedVariableValue, availableRunOutputs map[addrs.Run]cty.Value, requiredProviders map[string]bool) (func(), hcl.Diagnostics) {
+func TransformConfigForTest(config *configs.Config, run *moduletest.Run, file *moduletest.File, availableVariables terraform.InputValues, availableRunOutputs map[addrs.Run]cty.Value, requiredProviders map[string]bool) (func(), hcl.Diagnostics) {
 	var diags hcl.Diagnostics
 
 	// Currently, we only need to override the provider settings.

--- a/internal/moduletest/config/config.go
+++ b/internal/moduletest/config/config.go
@@ -91,7 +91,6 @@ func TransformConfigForTest(config *configs.Config, run *moduletest.Run, file *m
 				Version:    testProvider.Version,
 				Config: &hcltest.ProviderConfig{
 					Original:            testProvider.Config,
-					ConfigVariables:     config.Module.Variables,
 					AvailableVariables:  availableVariables,
 					AvailableRunOutputs: availableRunOutputs,
 				},
@@ -119,7 +118,6 @@ func TransformConfigForTest(config *configs.Config, run *moduletest.Run, file *m
 				Version:    provider.Version,
 				Config: &hcltest.ProviderConfig{
 					Original:            provider.Config,
-					ConfigVariables:     config.Module.Variables,
 					AvailableVariables:  availableVariables,
 					AvailableRunOutputs: availableRunOutputs,
 				},

--- a/internal/moduletest/hcl/context.go
+++ b/internal/moduletest/hcl/context.go
@@ -132,7 +132,7 @@ func EvalContext(target EvalContextTarget, expressions []hcl.Expression, availab
 				if _, exists := availableVariables[addr.Name]; !exists {
 					// This variable reference doesn't exist.
 
-					detail := fmt.Sprintf("The input variable %q is not available to the current run block. You can only reference variables defined at the file or global levels when populating the variables block within a run block.", addr.Name)
+					detail := fmt.Sprintf("The input variable %q is not available to the current context. Within the variables block of a run block you can only reference variables defined at the file or global levels; within the variables block of a suite you can only reference variables defined at the global levels.", addr.Name)
 					if availableRunOutputs == nil {
 						detail = fmt.Sprintf("The input variable %q is not available to the current provider configuration. You can only reference variables defined at the file or global levels within provider configurations.", addr.Name)
 					}

--- a/internal/moduletest/hcl/provider.go
+++ b/internal/moduletest/hcl/provider.go
@@ -8,7 +8,6 @@ import (
 	"github.com/zclconf/go-cty/cty"
 
 	"github.com/hashicorp/terraform/internal/addrs"
-	"github.com/hashicorp/terraform/internal/configs"
 	"github.com/hashicorp/terraform/internal/lang"
 	"github.com/hashicorp/terraform/internal/terraform"
 )
@@ -26,7 +25,6 @@ var _ hcl.Body = (*ProviderConfig)(nil)
 type ProviderConfig struct {
 	Original hcl.Body
 
-	ConfigVariables     map[string]*configs.Variable
 	AvailableVariables  terraform.InputValues
 	AvailableRunOutputs map[addrs.Run]cty.Value
 }
@@ -52,7 +50,7 @@ func (p *ProviderConfig) PartialContent(schema *hcl.BodySchema) (*hcl.BodyConten
 		Attributes:       attrs,
 		Blocks:           p.transformBlocks(content.Blocks),
 		MissingItemRange: content.MissingItemRange,
-	}, &ProviderConfig{rest, p.ConfigVariables, p.AvailableVariables, p.AvailableRunOutputs}, diags
+	}, &ProviderConfig{rest, p.AvailableVariables, p.AvailableRunOutputs}, diags
 }
 
 func (p *ProviderConfig) JustAttributes() (hcl.Attributes, hcl.Diagnostics) {
@@ -127,7 +125,7 @@ func (p *ProviderConfig) transformBlocks(originals hcl.Blocks) hcl.Blocks {
 		blocks[name] = &hcl.Block{
 			Type:        block.Type,
 			Labels:      block.Labels,
-			Body:        &ProviderConfig{block.Body, p.ConfigVariables, p.AvailableVariables, p.AvailableRunOutputs},
+			Body:        &ProviderConfig{block.Body, p.AvailableVariables, p.AvailableRunOutputs},
 			DefRange:    block.DefRange,
 			TypeRange:   block.TypeRange,
 			LabelRanges: block.LabelRanges,

--- a/internal/moduletest/hcl/provider_test.go
+++ b/internal/moduletest/hcl/provider_test.go
@@ -183,10 +183,12 @@ func TestProviderConfig(t *testing.T) {
 					}
 					return variables
 				}(),
-				AvailableVariables: func() map[string]backend.UnparsedVariableValue {
-					variables := make(map[string]backend.UnparsedVariableValue)
+				AvailableVariables: func() terraform.InputValues {
+					variables := make(terraform.InputValues)
 					for name, value := range tc.variables {
-						variables[name] = &variable{value}
+						variables[name] = &terraform.InputValue{
+							Value: value,
+						}
 					}
 					return variables
 				}(),

--- a/internal/moduletest/hcl/provider_test.go
+++ b/internal/moduletest/hcl/provider_test.go
@@ -71,7 +71,7 @@ func TestProviderConfig(t *testing.T) {
 				"input": cty.StringVal("string"),
 			},
 			expectedErrors: []string{
-				"The input variable \"missing\" is not available to the current run block. You can only reference variables defined at the file or global levels when populating the variables block within a run block.",
+				"The input variable \"missing\" is not available to the current context. Within the variables block of a run block you can only reference variables defined at the file or global levels; within the variables block of a suite you can only reference variables defined at the global levels.",
 			},
 			validate: func(t *testing.T, content *hcl.BodyContent) {
 				if len(content.Attributes) > 0 {

--- a/internal/moduletest/hcl/provider_test.go
+++ b/internal/moduletest/hcl/provider_test.go
@@ -174,15 +174,6 @@ func TestProviderConfig(t *testing.T) {
 
 			config := ProviderConfig{
 				Original: file.Body,
-				ConfigVariables: func() map[string]*configs.Variable {
-					variables := make(map[string]*configs.Variable)
-					for variable := range tc.variables {
-						variables[variable] = &configs.Variable{
-							Name: variable,
-						}
-					}
-					return variables
-				}(),
 				AvailableVariables: func() terraform.InputValues {
 					variables := make(terraform.InputValues)
 					for name, value := range tc.variables {

--- a/internal/terraform/context_apply.go
+++ b/internal/terraform/context_apply.go
@@ -183,7 +183,7 @@ func (c *Context) ApplyAndEval(plan *plans.Plan, config *configs.Config, opts *A
 			"Applied changes may be incomplete",
 			`The plan was created with the -target option in effect, so some changes requested in the configuration may have been ignored and the output values may not be fully updated. Run the following command to verify that no other changes are pending:
     terraform plan
-	
+
 Note that the -target option is not suitable for routine use, and is provided only for exceptional situations such as recovering from errors or mistakes, or when Terraform specifically suggests to use it as part of an error message.`,
 		))
 	}

--- a/website/docs/language/tests/index.mdx
+++ b/website/docs/language/tests/index.mdx
@@ -174,7 +174,7 @@ For tests defined in a test directory, any variable values defined in automatic 
 
 ### Variable References
 
-Variables you define within `run` blocks can refer to outputs from modules executed in earlier `run` blocks and variables defined at higher precedence levels. Variables in the root `variables` block can only refer to global variables.
+Variables you define within `run` blocks can refer to outputs from modules executed in earlier `run` blocks and variables defined at higher precedence levels. Variables defined within the file level `variables` block can only refer to global variables.
 
 For example, the following code block shows how a variable can refer to higher precedence variables and previous run blocks:
 

--- a/website/docs/language/tests/index.mdx
+++ b/website/docs/language/tests/index.mdx
@@ -8,7 +8,7 @@ description: >-
 
 -> **Note:** This testing framework is available in Terraform v1.6.0 and later.
 
-Terraform tests let authors validate that module configuration updates do not introduce breaking changes. Tests run against test-specific, short-lived resources, preventing any risk to your existing infrastructure or state. 
+Terraform tests let authors validate that module configuration updates do not introduce breaking changes. Tests run against test-specific, short-lived resources, preventing any risk to your existing infrastructure or state.
 
 ## Integration or Unit testing
 
@@ -174,7 +174,7 @@ For tests defined in a test directory, any variable values defined in automatic 
 
 ### Variable References
 
-Variables you define within `run` blocks can refer to outputs from modules executed in earlier `run` blocks and variables defined at higher precedence levels.
+Variables you define within `run` blocks can refer to outputs from modules executed in earlier `run` blocks and variables defined at higher precedence levels. Variables in the root `variables` block can only refer to global variables.
 
 For example, the following code block shows how a variable can refer to higher precedence variables and previous run blocks:
 


### PR DESCRIPTION
This allows practitioners to define variables in `.tfvar` files, environment variables, CLI flags and use them in the definition of suit-level variables in the top-level variables block.
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Fixes #34534
Fixes #34538

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.8.x

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

### ENHANCEMENTS

<!--

Write a short description of the user-facing change. Examples:

- `terraform show -json`: Fixed crash with sensitive set values.
- When rendering a diff, Terraform now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 

-  test: allow using global variables in suite-level variable definitions
