### PR TITLE
plan rendering: fix truncation of very large numbers

### DIFF
--- a/internal/command/jsonformat/computed/renderers/primitive.go
+++ b/internal/command/jsonformat/computed/renderers/primitive.go
@@ -4,8 +4,8 @@
 package renderers
 
 import (
+	"encoding/json"
 	"fmt"
-	"math/big"
 	"strings"
 
 	"github.com/zclconf/go-cty/cty"
@@ -67,8 +67,8 @@ func renderPrimitiveValue(value interface{}, t cty.Type, opts computed.RenderHum
 		}
 		return "false"
 	case t == cty.Number:
-		bf := big.NewFloat(value.(float64))
-		return bf.Text('f', -1)
+		number := value.(json.Number)
+		return number.String()
 	default:
 		panic("unrecognized primitive type: " + t.FriendlyName())
 	}

--- a/internal/command/jsonformat/computed/renderers/renderer_test.go
+++ b/internal/command/jsonformat/computed/renderers/renderer_test.go
@@ -4,6 +4,7 @@
 package renderers
 
 import (
+	"encoding/json"
 	"strings"
 	"testing"
 
@@ -126,21 +127,21 @@ null -> jsonencode(
 		},
 		"primitive_create": {
 			diff: computed.Diff{
-				Renderer: Primitive(nil, 1.0, cty.Number),
+				Renderer: Primitive(nil, json.Number("1"), cty.Number),
 				Action:   plans.Create,
 			},
 			expected: "1",
 		},
 		"primitive_delete": {
 			diff: computed.Diff{
-				Renderer: Primitive(1.0, nil, cty.Number),
+				Renderer: Primitive(json.Number("1"), nil, cty.Number),
 				Action:   plans.Delete,
 			},
 			expected: "1 -> null",
 		},
 		"primitive_delete_override": {
 			diff: computed.Diff{
-				Renderer: Primitive(1.0, nil, cty.Number),
+				Renderer: Primitive(json.Number("1"), nil, cty.Number),
 				Action:   plans.Delete,
 			},
 			opts:     computed.RenderHumanOpts{OverrideNullSuffix: true},
@@ -148,35 +149,49 @@ null -> jsonencode(
 		},
 		"primitive_update_to_null": {
 			diff: computed.Diff{
-				Renderer: Primitive(1.0, nil, cty.Number),
+				Renderer: Primitive(json.Number("1"), nil, cty.Number),
 				Action:   plans.Update,
 			},
 			expected: "1 -> null",
 		},
 		"primitive_update_from_null": {
 			diff: computed.Diff{
-				Renderer: Primitive(nil, 1.0, cty.Number),
+				Renderer: Primitive(nil, json.Number("1"), cty.Number),
 				Action:   plans.Update,
 			},
 			expected: "null -> 1",
 		},
 		"primitive_update": {
 			diff: computed.Diff{
-				Renderer: Primitive(0.0, 1.0, cty.Number),
+				Renderer: Primitive(json.Number("0"), json.Number("1"), cty.Number),
 				Action:   plans.Update,
 			},
 			expected: "0 -> 1",
 		},
 		"primitive_update_long_float": {
 			diff: computed.Diff{
-				Renderer: Primitive(123456789.0, 987654321.0, cty.Number),
+				Renderer: Primitive(json.Number("123456789"), json.Number("987654321"), cty.Number),
 				Action:   plans.Update,
 			},
 			expected: "123456789 -> 987654321",
 		},
+		"primitive_update_long_float_with_decimals": {
+			diff: computed.Diff{
+				Renderer: Primitive(json.Number("1.23456789"), json.Number("9.87654321"), cty.Number),
+				Action:   plans.Update,
+			},
+			expected: "1.23456789 -> 9.87654321",
+		},
+		"primitive_create_very_long_float": {
+			diff: computed.Diff{
+				Renderer: Primitive(nil, json.Number("9223372036854773256"), cty.Number),
+				Action:   plans.Create,
+			},
+			expected: "9223372036854773256",
+		},
 		"primitive_update_replace": {
 			diff: computed.Diff{
-				Renderer: Primitive(0.0, 1.0, cty.Number),
+				Renderer: Primitive(json.Number("0"), json.Number("1"), cty.Number),
 				Action:   plans.Update,
 				Replace:  true,
 			},
@@ -375,7 +390,7 @@ jsonencode(
 		"sensitive_update": {
 			diff: computed.Diff{
 				Renderer: Sensitive(computed.Diff{
-					Renderer: Primitive(0.0, 1.0, cty.Number),
+					Renderer: Primitive(json.Number("0"), json.Number("1"), cty.Number),
 					Action:   plans.Update,
 				}, true, true),
 				Action: plans.Update,
@@ -385,7 +400,7 @@ jsonencode(
 		"sensitive_update_replace": {
 			diff: computed.Diff{
 				Renderer: Sensitive(computed.Diff{
-					Renderer: Primitive(0.0, 1.0, cty.Number),
+					Renderer: Primitive(json.Number("0"), json.Number("1"), cty.Number),
 					Action:   plans.Update,
 					Replace:  true,
 				}, true, true),
@@ -404,7 +419,7 @@ jsonencode(
 		"computed_update": {
 			diff: computed.Diff{
 				Renderer: Unknown(computed.Diff{
-					Renderer: Primitive(0.0, nil, cty.Number),
+					Renderer: Primitive(json.Number("0"), nil, cty.Number),
 					Action:   plans.Delete,
 				}),
 				Action: plans.Update,
@@ -422,7 +437,7 @@ jsonencode(
 		"computed_update_forces_replacement": {
 			diff: computed.Diff{
 				Renderer: Unknown(computed.Diff{
-					Renderer: Primitive(0.0, nil, cty.Number),
+					Renderer: Primitive(json.Number("0"), nil, cty.Number),
 					Action:   plans.Delete,
 				}),
 				Action:  plans.Update,
@@ -441,7 +456,7 @@ jsonencode(
 			diff: computed.Diff{
 				Renderer: Object(map[string]computed.Diff{
 					"attribute_one": {
-						Renderer: Primitive(nil, 0.0, cty.Number),
+						Renderer: Primitive(nil, json.Number("0"), cty.Number),
 						Action:   plans.Create,
 					},
 				}),
@@ -464,7 +479,7 @@ jsonencode(
 			diff: computed.Diff{
 				Renderer: Object(map[string]computed.Diff{
 					"attribute_one": {
-						Renderer: Primitive(0.0, nil, cty.Number),
+						Renderer: Primitive(json.Number("0"), nil, cty.Number),
 						Action:   plans.Delete,
 					},
 				}),
@@ -487,7 +502,7 @@ jsonencode(
 			diff: computed.Diff{
 				Renderer: NestedObject(map[string]computed.Diff{
 					"attribute_one": {
-						Renderer: Primitive(0.0, nil, cty.Number),
+						Renderer: Primitive(json.Number("0"), nil, cty.Number),
 						Action:   plans.Delete,
 					},
 				}),
@@ -503,7 +518,7 @@ jsonencode(
 			diff: computed.Diff{
 				Renderer: Object(map[string]computed.Diff{
 					"attribute_one": {
-						Renderer: Primitive(nil, 0.0, cty.Number),
+						Renderer: Primitive(nil, json.Number("0"), cty.Number),
 						Action:   plans.Create,
 					},
 				}),
@@ -519,7 +534,7 @@ jsonencode(
 			diff: computed.Diff{
 				Renderer: Object(map[string]computed.Diff{
 					"attribute_one": {
-						Renderer: Primitive(0.0, 1.0, cty.Number),
+						Renderer: Primitive(json.Number("0"), json.Number("1"), cty.Number),
 						Action:   plans.Update,
 					},
 				}),
@@ -535,7 +550,7 @@ jsonencode(
 			diff: computed.Diff{
 				Renderer: Object(map[string]computed.Diff{
 					"attribute_one": {
-						Renderer: Primitive(0.0, 1.0, cty.Number),
+						Renderer: Primitive(json.Number("0"), json.Number("1"), cty.Number),
 						Action:   plans.Update,
 					},
 				}),
@@ -552,7 +567,7 @@ jsonencode(
 			diff: computed.Diff{
 				Renderer: Object(map[string]computed.Diff{
 					"attribute_one": {
-						Renderer: Primitive(0.0, nil, cty.Number),
+						Renderer: Primitive(json.Number("0"), nil, cty.Number),
 						Action:   plans.Delete,
 					},
 				}),
@@ -568,15 +583,15 @@ jsonencode(
 			diff: computed.Diff{
 				Renderer: Object(map[string]computed.Diff{
 					"attribute_one": {
-						Renderer: Primitive(0.0, 1.0, cty.Number),
+						Renderer: Primitive(json.Number("0"), json.Number("1"), cty.Number),
 						Action:   plans.Update,
 					},
 					"attribute_two": {
-						Renderer: Primitive(0.0, 0.0, cty.Number),
+						Renderer: Primitive(json.Number("0"), json.Number("0"), cty.Number),
 						Action:   plans.NoOp,
 					},
 					"attribute_three": {
-						Renderer: Primitive(nil, 1.0, cty.Number),
+						Renderer: Primitive(nil, json.Number("1"), cty.Number),
 						Action:   plans.Create,
 					},
 				}),
@@ -595,7 +610,7 @@ jsonencode(
 				Renderer: Object(map[string]computed.Diff{
 					"attribute_one": {
 						Renderer: Sensitive(computed.Diff{
-							Renderer: Primitive(nil, 1.0, cty.Number),
+							Renderer: Primitive(nil, json.Number("1"), cty.Number),
 							Action:   plans.Create,
 						}, false, true),
 						Action: plans.Create,
@@ -614,7 +629,7 @@ jsonencode(
 				Renderer: Object(map[string]computed.Diff{
 					"attribute_one": {
 						Renderer: Sensitive(computed.Diff{
-							Renderer: Primitive(0.0, 1.0, cty.Number),
+							Renderer: Primitive(json.Number("0"), json.Number("1"), cty.Number),
 							Action:   plans.Update,
 						}, true, true),
 						Action: plans.Update,
@@ -633,7 +648,7 @@ jsonencode(
 				Renderer: Object(map[string]computed.Diff{
 					"attribute_one": {
 						Renderer: Sensitive(computed.Diff{
-							Renderer: Primitive(0.0, nil, cty.Number),
+							Renderer: Primitive(json.Number("0"), nil, cty.Number),
 							Action:   plans.Delete,
 						}, true, false),
 						Action: plans.Delete,
@@ -668,7 +683,7 @@ jsonencode(
 				Renderer: Object(map[string]computed.Diff{
 					"attribute_one": {
 						Renderer: Unknown(computed.Diff{
-							Renderer: Primitive(1.0, nil, cty.Number),
+							Renderer: Primitive(json.Number("1"), nil, cty.Number),
 							Action:   plans.Delete,
 						}),
 						Action: plans.Update,
@@ -686,15 +701,15 @@ jsonencode(
 			diff: computed.Diff{
 				Renderer: Object(map[string]computed.Diff{
 					"attribute_one": {
-						Renderer: Primitive(1.0, 2.0, cty.Number),
+						Renderer: Primitive(json.Number("1"), json.Number("2"), cty.Number),
 						Action:   plans.Update,
 					},
 					"attribute:two": {
-						Renderer: Primitive(2.0, 3.0, cty.Number),
+						Renderer: Primitive(json.Number("2"), json.Number("3"), cty.Number),
 						Action:   plans.Update,
 					},
 					"attribute_six": {
-						Renderer: Primitive(3.0, 4.0, cty.Number),
+						Renderer: Primitive(json.Number("3"), json.Number("4"), cty.Number),
 						Action:   plans.Update,
 					},
 				}),
@@ -850,7 +865,7 @@ jsonencode(
 				Renderer: Map(map[string]computed.Diff{
 					"element_one": {
 						Renderer: Sensitive(computed.Diff{
-							Renderer: Primitive(nil, 1.0, cty.Number),
+							Renderer: Primitive(nil, json.Number("1"), cty.Number),
 							Action:   plans.Create,
 						}, false, true),
 						Action: plans.Create,
@@ -869,7 +884,7 @@ jsonencode(
 				Renderer: Map(map[string]computed.Diff{
 					"element_one": {
 						Renderer: Sensitive(computed.Diff{
-							Renderer: Primitive(0.0, 1.0, cty.Number),
+							Renderer: Primitive(json.Number("0"), json.Number("1"), cty.Number),
 							Action:   plans.Update,
 						}, true, true),
 						Action: plans.Update,
@@ -888,7 +903,7 @@ jsonencode(
 				Renderer: Map(map[string]computed.Diff{
 					"element_one": {
 						Renderer: Sensitive(computed.Diff{
-							Renderer: Primitive(0.0, 0.0, cty.Number),
+							Renderer: Primitive(json.Number("0"), json.Number("0"), cty.Number),
 							Action:   plans.NoOp,
 						}, true, false),
 						Action: plans.Update,
@@ -909,7 +924,7 @@ jsonencode(
 				Renderer: Map(map[string]computed.Diff{
 					"element_one": {
 						Renderer: Sensitive(computed.Diff{
-							Renderer: Primitive(0.0, nil, cty.Number),
+							Renderer: Primitive(json.Number("0"), nil, cty.Number),
 							Action:   plans.Delete,
 						}, true, false),
 						Action: plans.Delete,
@@ -944,7 +959,7 @@ jsonencode(
 				Renderer: Map(map[string]computed.Diff{
 					"element_one": {
 						Renderer: Unknown(computed.Diff{
-							Renderer: Primitive(1.0, nil, cty.Number),
+							Renderer: Primitive(json.Number("1"), nil, cty.Number),
 							Action:   plans.Delete,
 						}),
 						Action: plans.Update,
@@ -962,15 +977,15 @@ jsonencode(
 			diff: computed.Diff{
 				Renderer: Map(map[string]computed.Diff{
 					"element_one": {
-						Renderer: Primitive(1.0, 2.0, cty.Number),
+						Renderer: Primitive(json.Number("1"), json.Number("2"), cty.Number),
 						Action:   plans.Update,
 					},
 					"element_two": {
-						Renderer: Primitive(1.0, 3.0, cty.Number),
+						Renderer: Primitive(json.Number("1"), json.Number("3"), cty.Number),
 						Action:   plans.Update,
 					},
 					"element_three": {
-						Renderer: Primitive(1.0, 4.0, cty.Number),
+						Renderer: Primitive(json.Number("1"), json.Number("4"), cty.Number),
 						Action:   plans.Update,
 					},
 				}),
@@ -988,15 +1003,15 @@ jsonencode(
 			diff: computed.Diff{
 				Renderer: NestedMap(map[string]computed.Diff{
 					"element_one": {
-						Renderer: Primitive(1.0, 2.0, cty.Number),
+						Renderer: Primitive(json.Number("1"), json.Number("2"), cty.Number),
 						Action:   plans.Update,
 					},
 					"element_two": {
-						Renderer: Primitive(1.0, 3.0, cty.Number),
+						Renderer: Primitive(json.Number("1"), json.Number("3"), cty.Number),
 						Action:   plans.Update,
 					},
 					"element_three": {
-						Renderer: Primitive(1.0, 4.0, cty.Number),
+						Renderer: Primitive(json.Number("1"), json.Number("4"), cty.Number),
 						Action:   plans.Update,
 					},
 				}),
@@ -1021,7 +1036,7 @@ jsonencode(
 			diff: computed.Diff{
 				Renderer: List([]computed.Diff{
 					{
-						Renderer: Primitive(nil, 1.0, cty.Number),
+						Renderer: Primitive(nil, json.Number("1"), cty.Number),
 						Action:   plans.Create,
 					},
 				}),
@@ -1044,7 +1059,7 @@ jsonencode(
 			diff: computed.Diff{
 				Renderer: List([]computed.Diff{
 					{
-						Renderer: Primitive(1.0, nil, cty.Number),
+						Renderer: Primitive(json.Number("1"), nil, cty.Number),
 						Action:   plans.Delete,
 					},
 				}),
@@ -1060,7 +1075,7 @@ jsonencode(
 			diff: computed.Diff{
 				Renderer: List([]computed.Diff{
 					{
-						Renderer: Primitive(nil, 1.0, cty.Number),
+						Renderer: Primitive(nil, json.Number("1"), cty.Number),
 						Action:   plans.Create,
 					},
 				}),
@@ -1076,7 +1091,7 @@ jsonencode(
 			diff: computed.Diff{
 				Renderer: List([]computed.Diff{
 					{
-						Renderer: Primitive(0.0, 1.0, cty.Number),
+						Renderer: Primitive(json.Number("0"), json.Number("1"), cty.Number),
 						Action:   plans.Update,
 					},
 				}),
@@ -1092,11 +1107,11 @@ jsonencode(
 			diff: computed.Diff{
 				Renderer: List([]computed.Diff{
 					{
-						Renderer: Primitive(0.0, nil, cty.Number),
+						Renderer: Primitive(json.Number("0"), nil, cty.Number),
 						Action:   plans.Delete,
 					},
 					{
-						Renderer: Primitive(nil, 1.0, cty.Number),
+						Renderer: Primitive(nil, json.Number("1"), cty.Number),
 						Action:   plans.Create,
 					},
 				}),
@@ -1113,7 +1128,7 @@ jsonencode(
 			diff: computed.Diff{
 				Renderer: List([]computed.Diff{
 					{
-						Renderer: Primitive(0.0, nil, cty.Number),
+						Renderer: Primitive(json.Number("0"), nil, cty.Number),
 						Action:   plans.Delete,
 					},
 				}),
@@ -1129,7 +1144,7 @@ jsonencode(
 			diff: computed.Diff{
 				Renderer: List([]computed.Diff{
 					{
-						Renderer: Primitive(0.0, 1.0, cty.Number),
+						Renderer: Primitive(json.Number("0"), json.Number("1"), cty.Number),
 						Action:   plans.Update,
 					},
 				}),
@@ -1146,23 +1161,23 @@ jsonencode(
 			diff: computed.Diff{
 				Renderer: NestedList([]computed.Diff{
 					{
-						Renderer: Primitive(0.0, 0.0, cty.Number),
+						Renderer: Primitive(json.Number("0"), json.Number("0"), cty.Number),
 						Action:   plans.NoOp,
 					},
 					{
-						Renderer: Primitive(1.0, 1.0, cty.Number),
+						Renderer: Primitive(json.Number("1"), json.Number("1"), cty.Number),
 						Action:   plans.NoOp,
 					},
 					{
-						Renderer: Primitive(2.0, 5.0, cty.Number),
+						Renderer: Primitive(json.Number("2"), json.Number("5"), cty.Number),
 						Action:   plans.Update,
 					},
 					{
-						Renderer: Primitive(3.0, 3.0, cty.Number),
+						Renderer: Primitive(json.Number("3"), json.Number("3"), cty.Number),
 						Action:   plans.NoOp,
 					},
 					{
-						Renderer: Primitive(4.0, 4.0, cty.Number),
+						Renderer: Primitive(json.Number("4"), json.Number("4"), cty.Number),
 						Action:   plans.NoOp,
 					},
 				}),
@@ -1179,23 +1194,23 @@ jsonencode(
 			diff: computed.Diff{
 				Renderer: List([]computed.Diff{
 					{
-						Renderer: Primitive(0.0, 0.0, cty.Number),
+						Renderer: Primitive(json.Number("0"), json.Number("0"), cty.Number),
 						Action:   plans.NoOp,
 					},
 					{
-						Renderer: Primitive(1.0, 1.0, cty.Number),
+						Renderer: Primitive(json.Number("1"), json.Number("1"), cty.Number),
 						Action:   plans.NoOp,
 					},
 					{
-						Renderer: Primitive(2.0, 5.0, cty.Number),
+						Renderer: Primitive(json.Number("2"), json.Number("5"), cty.Number),
 						Action:   plans.Update,
 					},
 					{
-						Renderer: Primitive(3.0, 3.0, cty.Number),
+						Renderer: Primitive(json.Number("3"), json.Number("3"), cty.Number),
 						Action:   plans.NoOp,
 					},
 					{
-						Renderer: Primitive(4.0, 4.0, cty.Number),
+						Renderer: Primitive(json.Number("4"), json.Number("4"), cty.Number),
 						Action:   plans.NoOp,
 					},
 				}),
@@ -1216,7 +1231,7 @@ jsonencode(
 				Renderer: List([]computed.Diff{
 					{
 						Renderer: Sensitive(computed.Diff{
-							Renderer: Primitive(nil, 1.0, cty.Number),
+							Renderer: Primitive(nil, json.Number("1"), cty.Number),
 							Action:   plans.Create,
 						}, false, true),
 						Action: plans.Create,
@@ -1235,7 +1250,7 @@ jsonencode(
 				Renderer: List([]computed.Diff{
 					{
 						Renderer: Sensitive(computed.Diff{
-							Renderer: Primitive(1.0, nil, cty.Number),
+							Renderer: Primitive(json.Number("1"), nil, cty.Number),
 							Action:   plans.Delete,
 						}, true, false),
 						Action: plans.Delete,
@@ -1254,7 +1269,7 @@ jsonencode(
 				Renderer: List([]computed.Diff{
 					{
 						Renderer: Sensitive(computed.Diff{
-							Renderer: Primitive(0.0, 1.0, cty.Number),
+							Renderer: Primitive(json.Number("0"), json.Number("1"), cty.Number),
 							Action:   plans.Update,
 						}, true, true),
 						Action: plans.Update,
@@ -1273,7 +1288,7 @@ jsonencode(
 				Renderer: List([]computed.Diff{
 					{
 						Renderer: Sensitive(computed.Diff{
-							Renderer: Primitive(1.0, 1.0, cty.Number),
+							Renderer: Primitive(json.Number("1"), json.Number("1"), cty.Number),
 							Action:   plans.NoOp,
 						}, false, true),
 						Action: plans.Update,
@@ -1310,7 +1325,7 @@ jsonencode(
 				Renderer: List([]computed.Diff{
 					{
 						Renderer: Unknown(computed.Diff{
-							Renderer: Primitive(0.0, nil, cty.Number),
+							Renderer: Primitive(json.Number("0"), nil, cty.Number),
 							Action:   plans.Delete,
 						}),
 						Action: plans.Update,
@@ -1335,7 +1350,7 @@ jsonencode(
 			diff: computed.Diff{
 				Renderer: Set([]computed.Diff{
 					{
-						Renderer: Primitive(nil, 1.0, cty.Number),
+						Renderer: Primitive(nil, json.Number("1"), cty.Number),
 						Action:   plans.Create,
 					},
 				}),
@@ -1358,7 +1373,7 @@ jsonencode(
 			diff: computed.Diff{
 				Renderer: Set([]computed.Diff{
 					{
-						Renderer: Primitive(1.0, nil, cty.Number),
+						Renderer: Primitive(json.Number("1"), nil, cty.Number),
 						Action:   plans.Delete,
 					},
 				}),
@@ -1374,7 +1389,7 @@ jsonencode(
 			diff: computed.Diff{
 				Renderer: Set([]computed.Diff{
 					{
-						Renderer: Primitive(nil, 1.0, cty.Number),
+						Renderer: Primitive(nil, json.Number("1"), cty.Number),
 						Action:   plans.Create,
 					},
 				}),
@@ -1390,7 +1405,7 @@ jsonencode(
 			diff: computed.Diff{
 				Renderer: Set([]computed.Diff{
 					{
-						Renderer: Primitive(0.0, 1.0, cty.Number),
+						Renderer: Primitive(json.Number("0"), json.Number("1"), cty.Number),
 						Action:   plans.Update,
 					},
 				}),
@@ -1406,11 +1421,11 @@ jsonencode(
 			diff: computed.Diff{
 				Renderer: Set([]computed.Diff{
 					{
-						Renderer: Primitive(0.0, nil, cty.Number),
+						Renderer: Primitive(json.Number("0"), nil, cty.Number),
 						Action:   plans.Delete,
 					},
 					{
-						Renderer: Primitive(nil, 1.0, cty.Number),
+						Renderer: Primitive(nil, json.Number("1"), cty.Number),
 						Action:   plans.Create,
 					},
 				}),
@@ -1427,7 +1442,7 @@ jsonencode(
 			diff: computed.Diff{
 				Renderer: Set([]computed.Diff{
 					{
-						Renderer: Primitive(0.0, nil, cty.Number),
+						Renderer: Primitive(json.Number("0"), nil, cty.Number),
 						Action:   plans.Delete,
 					},
 				}),
@@ -1443,7 +1458,7 @@ jsonencode(
 			diff: computed.Diff{
 				Renderer: Set([]computed.Diff{
 					{
-						Renderer: Primitive(0.0, 1.0, cty.Number),
+						Renderer: Primitive(json.Number("0"), json.Number("1"), cty.Number),
 						Action:   plans.Update,
 					},
 				}),
@@ -1462,7 +1477,7 @@ jsonencode(
 					{
 						Renderer: Object(map[string]computed.Diff{
 							"attribute_one": {
-								Renderer: Primitive(0.0, 1.0, cty.Number),
+								Renderer: Primitive(json.Number("0"), json.Number("1"), cty.Number),
 								Action:   plans.Update,
 							},
 						}),
@@ -1484,23 +1499,23 @@ jsonencode(
 			diff: computed.Diff{
 				Renderer: Set([]computed.Diff{
 					{
-						Renderer: Primitive(0.0, 0.0, cty.Number),
+						Renderer: Primitive(json.Number("0"), json.Number("0"), cty.Number),
 						Action:   plans.NoOp,
 					},
 					{
-						Renderer: Primitive(1.0, 1.0, cty.Number),
+						Renderer: Primitive(json.Number("1"), json.Number("1"), cty.Number),
 						Action:   plans.NoOp,
 					},
 					{
-						Renderer: Primitive(2.0, 5.0, cty.Number),
+						Renderer: Primitive(json.Number("2"), json.Number("5"), cty.Number),
 						Action:   plans.Update,
 					},
 					{
-						Renderer: Primitive(3.0, 3.0, cty.Number),
+						Renderer: Primitive(json.Number("3"), json.Number("3"), cty.Number),
 						Action:   plans.NoOp,
 					},
 					{
-						Renderer: Primitive(4.0, 4.0, cty.Number),
+						Renderer: Primitive(json.Number("4"), json.Number("4"), cty.Number),
 						Action:   plans.NoOp,
 					},
 				}),
@@ -1518,7 +1533,7 @@ jsonencode(
 				Renderer: Set([]computed.Diff{
 					{
 						Renderer: Sensitive(computed.Diff{
-							Renderer: Primitive(nil, 1.0, cty.Number),
+							Renderer: Primitive(nil, json.Number("1"), cty.Number),
 							Action:   plans.Create,
 						}, false, true),
 						Action: plans.Create,
@@ -1537,7 +1552,7 @@ jsonencode(
 				Renderer: Set([]computed.Diff{
 					{
 						Renderer: Sensitive(computed.Diff{
-							Renderer: Primitive(1.0, nil, cty.Number),
+							Renderer: Primitive(json.Number("1"), nil, cty.Number),
 							Action:   plans.Delete,
 						}, false, true),
 						Action: plans.Delete,
@@ -1556,7 +1571,7 @@ jsonencode(
 				Renderer: Set([]computed.Diff{
 					{
 						Renderer: Sensitive(computed.Diff{
-							Renderer: Primitive(0.0, 1.0, cty.Number),
+							Renderer: Primitive(json.Number("0"), json.Number("1"), cty.Number),
 							Action:   plans.Update,
 						}, true, true),
 						Action: plans.Update,
@@ -1575,7 +1590,7 @@ jsonencode(
 				Renderer: Set([]computed.Diff{
 					{
 						Renderer: Sensitive(computed.Diff{
-							Renderer: Primitive(1.0, 2.0, cty.Number),
+							Renderer: Primitive(json.Number("1"), json.Number("2"), cty.Number),
 							Action:   plans.Update,
 						}, false, true),
 						Action: plans.Update,
@@ -1612,7 +1627,7 @@ jsonencode(
 				Renderer: Set([]computed.Diff{
 					{
 						Renderer: Unknown(computed.Diff{
-							Renderer: Primitive(0.0, nil, cty.Number),
+							Renderer: Primitive(json.Number("0"), nil, cty.Number),
 							Action:   plans.Delete,
 						}),
 						Action: plans.Update,
@@ -1888,7 +1903,7 @@ jsonencode(
 								{
 									Renderer: Block(map[string]computed.Diff{
 										"number": {
-											Renderer: Primitive(1.0, 2.0, cty.Number),
+											Renderer: Primitive(json.Number("1"), json.Number("2"), cty.Number),
 											Action:   plans.Update,
 										},
 										"string": {
@@ -1901,7 +1916,7 @@ jsonencode(
 								{
 									Renderer: Block(map[string]computed.Diff{
 										"number": {
-											Renderer: Primitive(1.0, nil, cty.Number),
+											Renderer: Primitive(json.Number("1"), nil, cty.Number),
 											Action:   plans.Delete,
 										},
 										"string": {
@@ -1937,7 +1952,7 @@ jsonencode(
 								{
 									Renderer: Block(map[string]computed.Diff{
 										"number": {
-											Renderer: Primitive(1.0, 2.0, cty.Number),
+											Renderer: Primitive(json.Number("1"), json.Number("2"), cty.Number),
 											Action:   plans.Update,
 										},
 										"string": {
@@ -1950,7 +1965,7 @@ jsonencode(
 								{
 									Renderer: Block(map[string]computed.Diff{
 										"number": {
-											Renderer: Primitive(1.0, nil, cty.Number),
+											Renderer: Primitive(json.Number("1"), nil, cty.Number),
 											Action:   plans.Delete,
 										},
 										"string": {
@@ -1986,7 +2001,7 @@ jsonencode(
 								"key_one": {
 									Renderer: Block(map[string]computed.Diff{
 										"number": {
-											Renderer: Primitive(1.0, 2.0, cty.Number),
+											Renderer: Primitive(json.Number("1"), json.Number("2"), cty.Number),
 											Action:   plans.Update,
 										},
 										"string": {
@@ -1999,7 +2014,7 @@ jsonencode(
 								"key:two": {
 									Renderer: Block(map[string]computed.Diff{
 										"number": {
-											Renderer: Primitive(1.0, nil, cty.Number),
+											Renderer: Primitive(json.Number("1"), nil, cty.Number),
 											Action:   plans.Delete,
 										},
 										"string": {
@@ -2052,15 +2067,15 @@ jsonencode(
 			diff: computed.Diff{
 				Renderer: Block(map[string]computed.Diff{
 					"attribute_one": {
-						Renderer: Primitive(1.0, 2.0, cty.Number),
+						Renderer: Primitive(json.Number("1"), json.Number("2"), cty.Number),
 						Action:   plans.Update,
 					},
 					"attribute:two": {
-						Renderer: Primitive(2.0, 3.0, cty.Number),
+						Renderer: Primitive(json.Number("2"), json.Number("3"), cty.Number),
 						Action:   plans.Update,
 					},
 					"attribute_six": {
-						Renderer: Primitive(3.0, 4.0, cty.Number),
+						Renderer: Primitive(json.Number("3"), json.Number("4"), cty.Number),
 						Action:   plans.Update,
 					},
 				}, Blocks{
@@ -2150,11 +2165,11 @@ jsonencode(
 				Renderer: TypeChange(computed.Diff{
 					Renderer: Map(map[string]computed.Diff{
 						"element_one": {
-							Renderer: Primitive(0.0, nil, cty.Number),
+							Renderer: Primitive(json.Number("0"), nil, cty.Number),
 							Action:   plans.Delete,
 						},
 						"element_two": {
-							Renderer: Primitive(1.0, nil, cty.Number),
+							Renderer: Primitive(json.Number("1"), nil, cty.Number),
 							Action:   plans.Delete,
 						},
 					}),
@@ -2162,11 +2177,11 @@ jsonencode(
 				}, computed.Diff{
 					Renderer: List([]computed.Diff{
 						{
-							Renderer: Primitive(nil, 0.0, cty.Number),
+							Renderer: Primitive(nil, json.Number("0"), cty.Number),
 							Action:   plans.Create,
 						},
 						{
-							Renderer: Primitive(nil, 1.0, cty.Number),
+							Renderer: Primitive(nil, json.Number("1"), cty.Number),
 							Action:   plans.Create,
 						},
 					}),

--- a/internal/command/jsonformat/computed/renderers/string.go
+++ b/internal/command/jsonformat/computed/renderers/string.go
@@ -30,8 +30,12 @@ func evaluatePrimitiveString(value interface{}, opts computed.RenderHumanOpts) e
 	str := value.(string)
 
 	if strings.HasPrefix(str, "{") || strings.HasPrefix(str, "[") {
+
+		decoder := json.NewDecoder(strings.NewReader(str))
+		decoder.UseNumber()
+
 		var jv interface{}
-		if err := json.Unmarshal([]byte(str), &jv); err == nil {
+		if err := decoder.Decode(&jv); err == nil {
 			return evaluatedString{
 				String: str,
 				Json:   jv,

--- a/internal/command/jsonformat/differ/differ_test.go
+++ b/internal/command/jsonformat/differ/differ_test.go
@@ -1766,22 +1766,22 @@ func TestValue_PrimitiveAttributes(t *testing.T) {
 		"dynamic_type_change": {
 			input: structured.Change{
 				Before: "old",
-				After:  4.0,
+				After:  json.Number("4"),
 			},
 			attribute: cty.DynamicPseudoType,
 			validateDiff: renderers.ValidateTypeChange(
 				renderers.ValidatePrimitive("old", nil, plans.Delete, false),
-				renderers.ValidatePrimitive(nil, 4.0, plans.Create, false),
+				renderers.ValidatePrimitive(nil, json.Number("4"), plans.Create, false),
 				plans.Update, false),
 			validateSliceDiffs: []renderers.ValidateDiffFunction{
 				renderers.ValidateTypeChange(
 					renderers.ValidatePrimitive("old", nil, plans.Delete, false),
-					renderers.ValidatePrimitive(nil, 4.0, plans.Create, false),
+					renderers.ValidatePrimitive(nil, json.Number("4"), plans.Create, false),
 					plans.Update, false),
 			},
 			validateSetDiffs: []renderers.ValidateDiffFunction{
 				renderers.ValidatePrimitive("old", nil, plans.Delete, false),
-				renderers.ValidatePrimitive(nil, 4.0, plans.Create, false),
+				renderers.ValidatePrimitive(nil, json.Number("4"), plans.Create, false),
 			},
 		},
 	}
@@ -2194,12 +2194,12 @@ func TestValue_CollectionAttributes(t *testing.T) {
 			input: structured.Change{
 				Before: []interface{}{
 					"one",
-					2.0,
+					json.Number("2"),
 					"three",
 				},
 				After: []interface{}{
 					"one",
-					4.0,
+					json.Number("4"),
 					"three",
 				},
 			},
@@ -2208,7 +2208,7 @@ func TestValue_CollectionAttributes(t *testing.T) {
 			},
 			validateDiff: renderers.ValidateList([]renderers.ValidateDiffFunction{
 				renderers.ValidatePrimitive("one", "one", plans.NoOp, false),
-				renderers.ValidatePrimitive(2.0, 4.0, plans.Update, false),
+				renderers.ValidatePrimitive(json.Number("2"), json.Number("4"), plans.Update, false),
 				renderers.ValidatePrimitive("three", "three", plans.NoOp, false),
 			}, plans.Update, false),
 		},
@@ -2366,12 +2366,12 @@ func TestRelevantAttributes(t *testing.T) {
 			input: structured.Change{
 				Before: map[string]interface{}{
 					"list": []interface{}{
-						0, 1, 2, 3, 4,
+						json.Number("0"), json.Number("1"), json.Number("2"), json.Number("3"), json.Number("4"),
 					},
 				},
 				After: map[string]interface{}{
 					"list": []interface{}{
-						0, 5, 6, 7, 4,
+						json.Number("0"), json.Number("5"), json.Number("6"), json.Number("7"), json.Number("4"),
 					},
 				},
 				RelevantAttributes: &attribute_path.PathMatcher{
@@ -2402,11 +2402,11 @@ func TestRelevantAttributes(t *testing.T) {
 				// The list validator below just ignores our relevant
 				// attributes. This is deliberate.
 				"list": renderers.ValidateList([]renderers.ValidateDiffFunction{
-					renderers.ValidatePrimitive(0, 0, plans.NoOp, false),
-					renderers.ValidatePrimitive(1, 5, plans.Update, false),
-					renderers.ValidatePrimitive(2, 6, plans.Update, false),
-					renderers.ValidatePrimitive(3, 7, plans.Update, false),
-					renderers.ValidatePrimitive(4, 4, plans.NoOp, false),
+					renderers.ValidatePrimitive(json.Number("0"), json.Number("0"), plans.NoOp, false),
+					renderers.ValidatePrimitive(json.Number("1"), json.Number("5"), plans.Update, false),
+					renderers.ValidatePrimitive(json.Number("2"), json.Number("6"), plans.Update, false),
+					renderers.ValidatePrimitive(json.Number("3"), json.Number("7"), plans.Update, false),
+					renderers.ValidatePrimitive(json.Number("4"), json.Number("4"), plans.NoOp, false),
 				}, plans.Update, false),
 			}, nil, nil, nil, nil, plans.Update, false),
 		},
@@ -2463,12 +2463,12 @@ func TestRelevantAttributes(t *testing.T) {
 			input: structured.Change{
 				Before: map[string]interface{}{
 					"set": []interface{}{
-						0, 1, 2, 3, 4,
+						json.Number("0"), json.Number("1"), json.Number("2"), json.Number("3"), json.Number("4"),
 					},
 				},
 				After: map[string]interface{}{
 					"set": []interface{}{
-						0, 2, 4, 5, 6,
+						json.Number("0"), json.Number("2"), json.Number("4"), json.Number("5"), json.Number("6"),
 					},
 				},
 				RelevantAttributes: &attribute_path.PathMatcher{
@@ -2489,13 +2489,13 @@ func TestRelevantAttributes(t *testing.T) {
 			},
 			validate: renderers.ValidateBlock(map[string]renderers.ValidateDiffFunction{
 				"set": renderers.ValidateSet([]renderers.ValidateDiffFunction{
-					renderers.ValidatePrimitive(0, 0, plans.NoOp, false),
-					renderers.ValidatePrimitive(1, nil, plans.Delete, false),
-					renderers.ValidatePrimitive(2, 2, plans.NoOp, false),
-					renderers.ValidatePrimitive(3, nil, plans.Delete, false),
-					renderers.ValidatePrimitive(4, 4, plans.NoOp, false),
-					renderers.ValidatePrimitive(nil, 5, plans.Create, false),
-					renderers.ValidatePrimitive(nil, 6, plans.Create, false),
+					renderers.ValidatePrimitive(json.Number("0"), json.Number("0"), plans.NoOp, false),
+					renderers.ValidatePrimitive(json.Number("1"), nil, plans.Delete, false),
+					renderers.ValidatePrimitive(json.Number("2"), json.Number("2"), plans.NoOp, false),
+					renderers.ValidatePrimitive(json.Number("3"), nil, plans.Delete, false),
+					renderers.ValidatePrimitive(json.Number("4"), json.Number("4"), plans.NoOp, false),
+					renderers.ValidatePrimitive(nil, json.Number("5"), plans.Create, false),
+					renderers.ValidatePrimitive(nil, json.Number("6"), plans.Create, false),
 				}, plans.Update, false),
 			}, nil, nil, nil, nil, plans.Update, false),
 		},
@@ -2782,14 +2782,14 @@ func TestSpecificCases(t *testing.T) {
 				Before: map[string]interface{}{
 					"list": []interface{}{
 						map[string]interface{}{
-							"number": -1,
+							"number": json.Number("-1"),
 						},
 					},
 				},
 				After: map[string]interface{}{
 					"list": []interface{}{
 						map[string]interface{}{
-							"number": 2,
+							"number": json.Number("2"),
 						},
 					},
 				},
@@ -2820,7 +2820,7 @@ func TestSpecificCases(t *testing.T) {
 			validate: renderers.ValidateBlock(map[string]renderers.ValidateDiffFunction{
 				"list": renderers.ValidateList([]renderers.ValidateDiffFunction{
 					renderers.ValidateObject(map[string]renderers.ValidateDiffFunction{
-						"number": renderers.ValidatePrimitive(-1, 2, plans.Update, false),
+						"number": renderers.ValidatePrimitive(json.Number("-1"), json.Number("2"), plans.Update, false),
 					}, plans.Update, false),
 				}, plans.Update, false),
 			}, nil, nil, nil, nil, plans.Update, false),
@@ -2831,14 +2831,14 @@ func TestSpecificCases(t *testing.T) {
 				Before: map[string]interface{}{
 					"list": []interface{}{
 						map[string]interface{}{
-							"number": -1,
+							"number": json.Number("-1"),
 						},
 					},
 				},
 				After: map[string]interface{}{
 					"list": []interface{}{
 						map[string]interface{}{
-							"number": 2,
+							"number": json.Number("2"),
 						},
 					},
 				},
@@ -2869,7 +2869,7 @@ func TestSpecificCases(t *testing.T) {
 			validate: renderers.ValidateBlock(map[string]renderers.ValidateDiffFunction{
 				"list": renderers.ValidateList([]renderers.ValidateDiffFunction{
 					renderers.ValidateObject(map[string]renderers.ValidateDiffFunction{
-						"number": renderers.ValidatePrimitive(-1, 2, plans.Update, false),
+						"number": renderers.ValidatePrimitive(json.Number("-1"), json.Number("2"), plans.Update, false),
 					}, plans.Update, false),
 				}, plans.Update, false),
 			}, nil, nil, nil, nil, plans.Update, false),

--- a/internal/command/jsonformat/jsondiff/types.go
+++ b/internal/command/jsonformat/jsondiff/types.go
@@ -3,7 +3,10 @@
 
 package jsondiff
 
-import "fmt"
+import (
+	"encoding/json"
+	"fmt"
+)
 
 type Type string
 
@@ -16,11 +19,11 @@ const (
 	Null   Type = "null"
 )
 
-func GetType(json interface{}) Type {
-	switch json.(type) {
+func GetType(value interface{}) Type {
+	switch value.(type) {
 	case []interface{}:
 		return Array
-	case float64:
+	case json.Number:
 		return Number
 	case string:
 		return String
@@ -31,6 +34,6 @@ func GetType(json interface{}) Type {
 	case map[string]interface{}:
 		return Object
 	default:
-		panic(fmt.Sprintf("unrecognized json type %T", json))
+		panic(fmt.Sprintf("unrecognized json type %T", value))
 	}
 }

--- a/internal/command/jsonformat/structured/change.go
+++ b/internal/command/jsonformat/structured/change.go
@@ -4,6 +4,7 @@
 package structured
 
 import (
+	"bytes"
 	"encoding/json"
 	"reflect"
 
@@ -273,8 +274,11 @@ func unmarshalGeneric(raw json.RawMessage) interface{} {
 		return nil
 	}
 
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.UseNumber() // We support very big (> 2^64) numbers.
+
 	var out interface{}
-	if err := json.Unmarshal(raw, &out); err != nil {
+	if err := decoder.Decode(&out); err != nil {
 		panic("unrecognized json type: " + err.Error())
 	}
 	return out


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

When unmarshalling the JSON plan, the renderer now uses `json.Number` to represent numbers instead of `float64`.  This means that very large numbers (> 2^63) will no longer be truncated down to 2^63.

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Fixes #34686

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.7.4 or whatever the next 1.7 release is.

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

### BUG FIXES

<!--

Write a short description of the user-facing change. Examples:

- `terraform show -json`: Fixed crash with sensitive set values.
- When rendering a diff, Terraform now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 

-  plan renderer: Numbers larger than 2^63 will now be accurately rendered.
