### PR TITLE
lang: error when sensitive value used in dynamic for_each

### DIFF
--- a/internal/lang/diagnostics.go
+++ b/internal/lang/diagnostics.go
@@ -1,0 +1,28 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package lang
+
+import (
+	"github.com/hashicorp/terraform/internal/tfdiags"
+)
+
+// This file contains some package-local helpers for working with diagnostics.
+// For the main diagnostics API, see the separate "tfdiags" package.
+
+// diagnosticCausedBySensitive is an implementation of
+// tfdiags.DiagnosticExtraBecauseSensitive which we can use in the "Extra" field
+// of a diagnostic to indicate that the problem was caused by sensitive values
+// being involved in an expression evaluation.
+//
+// When using this, set the Extra to diagnosticCausedBySensitive(true) and also
+// populate the EvalContext and Expression fields of the diagnostic so that
+// the diagnostic renderer can use all of that information together to assist
+// the user in understanding what was sensitive.
+type diagnosticCausedBySensitive bool
+
+var _ tfdiags.DiagnosticExtraBecauseSensitive = diagnosticCausedBySensitive(true)
+
+func (e diagnosticCausedBySensitive) DiagnosticCausedBySensitive() bool {
+	return bool(e)
+}

--- a/internal/lang/eval.go
+++ b/internal/lang/eval.go
@@ -19,6 +19,7 @@ import (
 	"github.com/hashicorp/terraform/internal/configs/configschema"
 	"github.com/hashicorp/terraform/internal/instances"
 	"github.com/hashicorp/terraform/internal/lang/blocktoattr"
+	"github.com/hashicorp/terraform/internal/lang/marks"
 	"github.com/hashicorp/terraform/internal/tfdiags"
 )
 
@@ -37,7 +38,28 @@ func (s *Scope) ExpandBlock(body hcl.Body, schema *configschema.Block) (hcl.Body
 	ctx, ctxDiags := s.EvalContext(refs)
 	diags = diags.Append(ctxDiags)
 
-	return dynblock.Expand(body, ctx), diags
+	return dynblock.Expand(body, ctx, dynblock.OptCheckForEach(checkForEachSensitive)), diags
+}
+
+// checkForEachSensitive checks if the given value contains a sensitive value
+// and, if so, returns an error explaining why the value cannot be used in the
+// given for_each expression.
+//
+// This function is intended to be passed to dynblock.OptCheckForEach.
+func checkForEachSensitive(val cty.Value, expr hcl.Expression, ec *hcl.EvalContext) (hDiags hcl.Diagnostics) {
+	if marks.Contains(val, marks.Sensitive) {
+		hDiags = hcl.Diagnostics{
+			&hcl.Diagnostic{
+				Severity:    hcl.DiagError,
+				Summary:     "Invalid for_each argument",
+				Detail:      "Sensitive values, or values derived from sensitive values, cannot be used as for_each arguments. If used, the sensitive value could be exposed as a resource instance key.",
+				Expression:  expr,
+				EvalContext: ec,
+				Subject:     expr.Range().Ptr(),
+			},
+		}
+	}
+	return hDiags
 }
 
 // EvalBlock evaluates the given body using the given block schema and returns


### PR DESCRIPTION
When expanding a dynamic block with a for_each expression, the for_each value is not permitted to contain sensitive values. Prior to this change, the error returned to the user did not mention the sensitivity of the value, instead saying only that the collection was not iterable.

Using new functionality introduced in hcl/dynblock, we can now check whether the for_each value is sensitive and return a more helpful error.

This addresses https://github.com/hashicorp/terraform/issues/29744.