### PR TITLE
stacks: check providers blocks in components during validatation

### DIFF
--- a/internal/stacks/stackruntime/testdata/mainbundle/test/with-single-input/invalid-provider/invalid-provider.tfstack.hcl
+++ b/internal/stacks/stackruntime/testdata/mainbundle/test/with-single-input/invalid-provider/invalid-provider.tfstack.hcl
@@ -1,0 +1,26 @@
+required_providers {
+  testing = {
+    // The source is wrong, so validate should complain.
+    source  = "hashicorp/wrong"
+    version = "0.1.0"
+  }
+}
+
+provider "testing" "default" {}
+
+variable "input" {
+  type = string
+}
+
+component "self" {
+  source = "../"
+
+  providers = {
+    // Everything looks okay here, but the provider types are actually wrong.
+    testing = provider.testing.default
+  }
+
+  inputs = {
+    input = var.input
+  }
+}

--- a/internal/stacks/stackruntime/testdata/mainbundle/test/with-single-input/missing-provider/missing-provider.tfstack.hcl
+++ b/internal/stacks/stackruntime/testdata/mainbundle/test/with-single-input/missing-provider/missing-provider.tfstack.hcl
@@ -1,0 +1,23 @@
+required_providers {
+  testing = {
+    source  = "hashicorp/testing"
+    version = "0.1.0"
+  }
+}
+
+provider "testing" "default" {}
+
+variable "input" {
+  type = string
+}
+
+component "self" {
+  source = "../"
+
+  # We do actually require a provider here, Validate() should warn us.
+  providers = {}
+
+  inputs = {
+    input = var.input
+  }
+}

--- a/internal/stacks/stackruntime/testdata/mainbundle/test/with-single-input/provider-name-clash/provider-name-clash.tfstack.hcl
+++ b/internal/stacks/stackruntime/testdata/mainbundle/test/with-single-input/provider-name-clash/provider-name-clash.tfstack.hcl
@@ -1,0 +1,26 @@
+required_providers {
+  other = {
+    source  = "hashicorp/testing"
+    version = "0.1.0"
+  }
+}
+
+provider "other" "default" {}
+
+variable "input" {
+  type = string
+}
+
+component "self" {
+  source = "../"
+
+  providers = {
+    // Even though the names are wrong, the underlying types are the same
+    // so this should be okay.
+    testing = provider.other.default
+  }
+
+  inputs = {
+    input = var.input
+  }
+}

--- a/internal/stacks/stackruntime/testdata/mainbundle/test/with-single-input/undeclared-provider/undeclared-provider.tfstack.hcl
+++ b/internal/stacks/stackruntime/testdata/mainbundle/test/with-single-input/undeclared-provider/undeclared-provider.tfstack.hcl
@@ -1,0 +1,16 @@
+variable "input" {
+  type = string
+}
+
+component "self" {
+  source = "../"
+
+  providers = {
+    # We haven't provided a definition for this anywhere.
+    testing = provider.testing.default
+  }
+
+  inputs = {
+    input = var.input
+  }
+}


### PR DESCRIPTION
This PR explicitly checks the diagnostics produced by the `CheckProvider` function added in the last PR (#34705) as part of the stacks validate functionality. This means we get error messages if there are missing or undeclared providers in the `providers` block for components.

I've also added two additional test cases that are currently skipped during tests that describe assigning providers with the same underlying types but different local names (or the reverse in the error case). This isn't currently support but probably should be. I've expanded a TODO calling this out. I'll revisit this in a future PR.