### PR TITLE
stacks: fix flaky `stackruntime` tests

### DIFF
--- a/internal/stacks/stackruntime/apply_test.go
+++ b/internal/stacks/stackruntime/apply_test.go
@@ -5,7 +5,6 @@ package stackruntime
 
 import (
 	"context"
-	"fmt"
 	"path"
 	"sort"
 	"testing"
@@ -196,8 +195,7 @@ func TestApplyWithRemovedResource(t *testing.T) {
 	}
 
 	sort.SliceStable(applyChanges, func(i, j int) bool {
-		// An arbitrary sort just to make the result stable for comparison.
-		return fmt.Sprintf("%T", applyChanges[i]) < fmt.Sprintf("%T", applyChanges[j])
+		return appliedChangeSortKey(applyChanges[i]) < appliedChangeSortKey(applyChanges[j])
 	})
 
 	if diff := cmp.Diff(wantChanges, applyChanges, ctydebug.CmpOptions, cmpCollectionsSet); diff != "" {


### PR DESCRIPTION
This PR updates all the `stackruntime` tests to use the consistent sorting I introduced for some of my tests earlier.

Previously, we were sorting the test outputs based on the `%T` representation of their type. If we had two events of the same type this meant the results weren't deterministic. I introduced the `appliedChangeSortKey` and `plannedChangeSortKey` functions in an earlier PR. These sort of the unique addresses of each event type, and so are truly deterministic.

Here's an example of a flake, fixed with a retry: 

- https://github.com/hashicorp/terraform/actions/runs/7974971451/attempts/1 
- https://github.com/hashicorp/terraform/actions/runs/7974971451/attempts/2

I didn't think any of the other tests were producing two changes of the same type so I didn't update them previously. Now, I just blanket replaced everything.