### PR TITLE
stacks: expand reference scope of static validations

### DIFF
--- a/internal/stacks/stackruntime/internal/stackeval/stack_call_config.go
+++ b/internal/stacks/stackruntime/internal/stackeval/stack_call_config.go
@@ -8,14 +8,15 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/hcl/v2"
+	"github.com/zclconf/go-cty/cty"
+	"github.com/zclconf/go-cty/cty/convert"
+
 	"github.com/hashicorp/terraform/internal/instances"
 	"github.com/hashicorp/terraform/internal/promising"
 	"github.com/hashicorp/terraform/internal/stacks/stackaddrs"
 	"github.com/hashicorp/terraform/internal/stacks/stackconfig"
 	"github.com/hashicorp/terraform/internal/stacks/stackplan"
 	"github.com/hashicorp/terraform/internal/tfdiags"
-	"github.com/zclconf/go-cty/cty"
-	"github.com/zclconf/go-cty/cty/convert"
 )
 
 // StackCallConfig represents a "stack" block in a stack configuration,
@@ -320,9 +321,22 @@ func (s *StackCallConfig) ResolveExpressionReference(ctx context.Context, ref st
 		repetition.EachKey = cty.UnknownVal(cty.String).RefineNotNull()
 		repetition.EachValue = cty.DynamicVal
 	}
-	return s.main.
+	ret, diags := s.main.
 		mustStackConfig(ctx, s.Addr().Stack).
-		resolveExpressionReference(ctx, ref, instances.RepetitionData{}, nil)
+		resolveExpressionReference(ctx, ref, nil, repetition)
+
+	if _, ok := ret.(*ProviderConfig); ok {
+		// We can't reference other providers from anywhere inside an embedded
+		// stack call - they should define their own providers.
+		diags = diags.Append(&hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  "Invalid reference",
+			Detail:   fmt.Sprintf("The object %s is not in scope at this location.", ref.Target.String()),
+			Subject:  ref.SourceRange.ToHCL().Ptr(),
+		})
+	}
+
+	return ret, diags
 }
 
 func (s *StackCallConfig) checkValid(ctx context.Context, phase EvalPhase) tfdiags.Diagnostics {


### PR DESCRIPTION
This PR extends the scope of the static evaluations so that we can follow references to providers, foreach, count, and self during static walks of a Stacks configuration.

We add the relevant references to `stack_config.go`, update `component_config.go` so it implements `ExpressionScope`, update the remaining static nodes so they handle the returned references properly.

This will be used to validate input variables and providers statically in later PRs. There's no behaviour changes here, as nothing uses the new behaviour yet.