### PR TITLE
stacks: validate the types of input variables during validation

### DIFF
--- a/internal/stacks/stackruntime/internal/stackeval/stack.go
+++ b/internal/stacks/stackruntime/internal/stackeval/stack.go
@@ -169,7 +169,7 @@ func (s *Stack) StackConfig(ctx context.Context) *StackConfig {
 func (s *Stack) ConfigDeclarations(ctx context.Context) *stackconfig.Declarations {
 	// The declarations really belong to the static StackConfig, since
 	// all instances of a particular stack configuration share the same
-	// source code.
+	// source code.ResolveExpressionReference
 	return s.StackConfig(ctx).ConfigDeclarations(ctx)
 }
 
@@ -410,6 +410,13 @@ func (s *Stack) resolveExpressionReference(ctx context.Context, ref stackaddrs.R
 	// TODO: Most of the below would benefit from "Did you mean..." suggestions
 	// when something is missing but there's a similarly-named object nearby.
 
+	// See also a very similar function in stack_config.go. Both are returning
+	// similar referenceable objects but the context is different. For example,
+	// in this function we return an instanced Component, while in the other
+	// function we return a static ComponentConfig.
+	//
+	// Some of the returned types are the same across both functions, but most
+	// are different in terms of static vs dynamic types.
 	switch addr := ref.Target.(type) {
 	case stackaddrs.InputVariable:
 		ret := s.InputVariable(ctx, addr)

--- a/internal/stacks/stackruntime/testdata/mainbundle/test/with-single-input/input-from-component-list/input-from-component-list.tfstack.hcl
+++ b/internal/stacks/stackruntime/testdata/mainbundle/test/with-single-input/input-from-component-list/input-from-component-list.tfstack.hcl
@@ -1,0 +1,36 @@
+required_providers {
+  testing = {
+    source  = "hashicorp/testing"
+    version = "0.1.0"
+  }
+}
+
+variable "components" {
+  type = set(string)
+}
+
+provider "testing" "default" {}
+
+component "output" {
+  source = "../../with-single-output"
+
+  providers = {
+    testing = provider.testing.default
+  }
+
+  for_each = var.components
+}
+
+component "self" {
+  source = "../"
+
+  providers = {
+    testing = provider.testing.default
+  }
+
+  inputs = {
+    input = component.output[each.value].id
+  }
+
+  for_each = var.components
+}

--- a/internal/stacks/stackruntime/testdata/mainbundle/test/with-single-input/input-from-component/input-from-component.tfstack.hcl
+++ b/internal/stacks/stackruntime/testdata/mainbundle/test/with-single-input/input-from-component/input-from-component.tfstack.hcl
@@ -1,0 +1,28 @@
+required_providers {
+  testing = {
+    source  = "hashicorp/testing"
+    version = "0.1.0"
+  }
+}
+
+provider "testing" "default" {}
+
+component "output" {
+  source = "../../with-single-output"
+
+  providers = {
+    testing = provider.testing.default
+  }
+}
+
+component "self" {
+  source = "../"
+
+  providers = {
+    testing = provider.testing.default
+  }
+
+  inputs = {
+    input = component.output.id
+  }
+}

--- a/internal/stacks/stackruntime/testdata/mainbundle/test/with-single-input/input-from-missing-component/input-from-missing-component.tfstack.hcl
+++ b/internal/stacks/stackruntime/testdata/mainbundle/test/with-single-input/input-from-missing-component/input-from-missing-component.tfstack.hcl
@@ -1,0 +1,21 @@
+required_providers {
+  testing = {
+    source  = "hashicorp/testing"
+    version = "0.1.0"
+  }
+}
+
+provider "testing" "default" {}
+
+component "self" {
+  source = "../"
+
+  providers = {
+    testing = provider.testing.default
+  }
+
+  inputs = {
+    // This component doesn't exist. We should see an error.
+    input = component.output.id
+  }
+}

--- a/internal/stacks/stackruntime/testdata/mainbundle/test/with-single-input/input-from-provider/input-from-provider.tfstack.hcl
+++ b/internal/stacks/stackruntime/testdata/mainbundle/test/with-single-input/input-from-provider/input-from-provider.tfstack.hcl
@@ -1,0 +1,21 @@
+required_providers {
+  testing = {
+    source  = "hashicorp/testing"
+    version = "0.1.0"
+  }
+}
+
+provider "testing" "default" {}
+
+component "self" {
+  source = "../"
+
+  providers = {
+    testing = provider.testing.default
+  }
+
+  inputs = {
+    # Shouldn't be able to reference providers from here.
+    input = provider.testing.default
+  }
+}

--- a/internal/stacks/stackruntime/testdata/mainbundle/test/with-single-input/missing-variable/missing-variable.tfstack.hcl
+++ b/internal/stacks/stackruntime/testdata/mainbundle/test/with-single-input/missing-variable/missing-variable.tfstack.hcl
@@ -1,0 +1,23 @@
+required_providers {
+  testing = {
+    source  = "hashicorp/testing"
+    version = "0.1.0"
+  }
+}
+
+provider "testing" "default" {}
+
+variable "input" {
+  type = string
+}
+
+component "self" {
+  source = "../"
+
+  providers = {
+    testing = provider.testing.default
+  }
+
+  # We do have a required variable, so this should complain.
+  inputs = {}
+}

--- a/internal/stacks/stackruntime/testdata/mainbundle/test/with-single-input/undeclared-variable/undeclared-variable.tfstack.hcl
+++ b/internal/stacks/stackruntime/testdata/mainbundle/test/with-single-input/undeclared-variable/undeclared-variable.tfstack.hcl
@@ -1,0 +1,21 @@
+required_providers {
+  testing = {
+    source  = "hashicorp/testing"
+    version = "0.1.0"
+  }
+}
+
+provider "testing" "default" {}
+
+component "self" {
+  source = "../"
+
+  providers = {
+    testing = provider.testing.default
+  }
+
+  inputs = {
+    # var.input is not defined
+    input = var.input
+  }
+}

--- a/internal/stacks/stackruntime/testdata/mainbundle/test/with-single-output/single-output.tf
+++ b/internal/stacks/stackruntime/testdata/mainbundle/test/with-single-output/single-output.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_providers {
+    testing = {
+      source  = "hashicorp/testing"
+      version = "0.1.0"
+    }
+  }
+}
+
+resource "testing_resource" "data" {}
+
+output "id" {
+  value = testing_resource.data.id
+}


### PR DESCRIPTION
This PR adds variable validation into the static walk of the Stacks configuration. This means that missing variables, or badly typed variables, will be picked up by the Validate RPC command.

I've made the `ComponentConfig` an `ExpressionScope` so we can evaluate the input variable expressions, we don't use the returned value anywhere we just care about the diagnostics. The `ComponentConfig` and `ComponentInstance` now share the implementation for `CheckInputVariableValues`, so this has been extracted into a common location.