### PR TITLE
build: Run checks on all pushed branches

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -19,9 +19,7 @@ on:
   pull_request:
   push:
     branches:
-      - main
-      - 'v[0-9]+.[0-9]+'
-      - checks-workflow-dev/*
+      - '*'
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+*'
 


### PR DESCRIPTION
It is helpful to see the result of the checks workflow prior to opening a PR, to avoid wasting time fixing unexpectedly failing checks while the PR is open and awaiting review. This commit configures GitHub Actions to run checks on all pushed branches.

See https://github.com/hashicorp/terraform/commit/5b615882e228e0654aa0b2067205bb1a84452bc2 for the previous commit introducing the push filtering behaviour.