### PR TITLE
Add and use a source bundle aware configuration parser for stacks

### DIFF
--- a/internal/configs/parser_config.go
+++ b/internal/configs/parser_config.go
@@ -70,6 +70,10 @@ func (p *Parser) loadConfigFile(path string, override bool) (*File, hcl.Diagnost
 		return nil, diags
 	}
 
+	return parseConfigFile(body, diags, override, p.allowExperiments)
+}
+
+func parseConfigFile(body hcl.Body, diags hcl.Diagnostics, override, allowExperiments bool) (*File, hcl.Diagnostics) {
 	file := &File{}
 
 	var reqDiags hcl.Diagnostics
@@ -79,7 +83,7 @@ func (p *Parser) loadConfigFile(path string, override bool) (*File, hcl.Diagnost
 	// We'll load the experiments first because other decoding logic in the
 	// loop below might depend on these experiments.
 	var expDiags hcl.Diagnostics
-	file.ActiveExperiments, expDiags = sniffActiveExperiments(body, p.allowExperiments)
+	file.ActiveExperiments, expDiags = sniffActiveExperiments(body, allowExperiments)
 	diags = append(diags, expDiags...)
 
 	content, contentDiags := body.Content(configFileSchema)

--- a/internal/configs/source_bundle_parser.go
+++ b/internal/configs/source_bundle_parser.go
@@ -1,0 +1,223 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package configs
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/hashicorp/go-slug/sourceaddrs"
+	"github.com/hashicorp/go-slug/sourcebundle"
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclparse"
+)
+
+// SourceBundleParser is the main interface to read configuration files and
+// other related files from a source bundle. This is a subset of the
+// functionality implemented by [Parser], specifically ignoring tftest files,
+// which are not relevant for now.
+type SourceBundleParser struct {
+	sources *sourcebundle.Bundle
+	p       *hclparse.Parser
+
+	// allowExperiments controls whether we will allow modules to opt in to
+	// experimental language features. In main code this will be set only
+	// for alpha releases and some development builds. Test code must decide
+	// for itself whether to enable it so that tests can cover both the
+	// allowed and not-allowed situations.
+	allowExperiments bool
+}
+
+// NewSourceBundleParser creates a new [SourceBundleParser] for the given
+// source bundle.
+func NewSourceBundleParser(sources *sourcebundle.Bundle) *SourceBundleParser {
+	return &SourceBundleParser{
+		sources: sources,
+		p:       hclparse.NewParser(),
+	}
+}
+
+// LoadConfigDir is the primary public entry point for [SourceBundleParser],
+// and is similar to [Parser.LoadConfigDir]. It reads the .tf and .tf.json
+// files at the given source address as config files, and combines these into a
+// single [Module].
+func (p *SourceBundleParser) LoadConfigDir(source sourceaddrs.FinalSource) (*Module, hcl.Diagnostics) {
+	primarySources, overrideSources, diags := p.dirSources(source)
+	if diags.HasErrors() {
+		return nil, diags
+	}
+
+	primary, fDiags := p.loadSources(primarySources, false)
+	diags = append(diags, fDiags...)
+	override, fDiags := p.loadSources(overrideSources, true)
+	diags = append(diags, fDiags...)
+
+	mod, modDiags := NewModule(primary, override)
+	diags = append(diags, modDiags...)
+
+	mod.SourceDir = source.String()
+
+	return mod, diags
+}
+
+// IsConfigDir is used to detect directories which have no config files, so
+// that we can return useful early diagnostics when a given root module source
+// address points at a directory which is not Terraform module.
+func (p *SourceBundleParser) IsConfigDir(source sourceaddrs.FinalSource) bool {
+	primaryPaths, overridePaths, _ := p.dirSources(source)
+	return (len(primaryPaths) + len(overridePaths)) > 0
+}
+
+func (p *SourceBundleParser) dirSources(source sourceaddrs.FinalSource) (primary, override []sourceaddrs.FinalSource, diags hcl.Diagnostics) {
+	localDir, err := p.sources.LocalPathForSource(source)
+	if err != nil {
+		diags = diags.Append(&hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  "Cannot find configuration source code",
+			Detail:   fmt.Sprintf("Failed to load %s from the pre-installed source packages: %s.", source, err),
+		})
+		return
+	}
+
+	allEntries, err := os.ReadDir(localDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			diags = diags.Append(&hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  "Missing Terraform configuration",
+				Detail:   fmt.Sprintf("There is no Terraform configuration directory at %s.", source),
+			})
+		} else {
+			diags = diags.Append(&hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  "Cannot read Terraform configuration",
+				// In this case the error message from the Go standard library
+				// is likely to disclose the real local directory name
+				// from the source bundle, but that's okay because it may
+				// sometimes help with debugging.
+				Detail: fmt.Sprintf("Error while reading the cached snapshot of %s: %s.", source, err),
+			})
+		}
+		return
+	}
+
+	for _, entry := range allEntries {
+		if entry.IsDir() {
+			continue
+		}
+
+		name := entry.Name()
+		ext := fileExt(name)
+		if ext == "" || IsIgnoredFile(name) {
+			continue
+		}
+
+		if ext == ".tftest.hcl" || ext == ".tftest.json" {
+			continue
+		}
+
+		baseName := name[:len(name)-len(ext)] // strip extension
+		isOverride := baseName == "override" || strings.HasSuffix(baseName, "_override")
+
+		asLocalSourcePath := "./" + filepath.Base(name)
+		relSource, err := sourceaddrs.ParseLocalSource(asLocalSourcePath)
+		if err != nil {
+			// If we get here then it's a bug in how we constructed the
+			// path above, not invalid user input.
+			panic(fmt.Sprintf("constructed invalid relative source path: %s", err))
+		}
+		fileSourceAddr, err := sourceaddrs.ResolveRelativeFinalSource(source, relSource)
+		if err != nil {
+			// If we get here then it's a bug in how we constructed the
+			// path above, not invalid user input.
+			panic(fmt.Sprintf("constructed invalid relative source path: %s", err))
+		}
+
+		if isOverride {
+			override = append(override, fileSourceAddr)
+		} else {
+			primary = append(primary, fileSourceAddr)
+		}
+	}
+
+	return
+}
+
+func (p *SourceBundleParser) loadSources(sources []sourceaddrs.FinalSource, override bool) ([]*File, hcl.Diagnostics) {
+	var files []*File
+	var diags hcl.Diagnostics
+
+	for _, path := range sources {
+		f, fDiags := p.loadConfigFile(path, override)
+		diags = append(diags, fDiags...)
+		if f != nil {
+			files = append(files, f)
+		}
+	}
+
+	return files, diags
+}
+
+func (p *SourceBundleParser) loadConfigFile(source sourceaddrs.FinalSource, override bool) (*File, hcl.Diagnostics) {
+	var diags hcl.Diagnostics
+	path, err := p.sources.LocalPathForSource(source)
+	if err != nil {
+		diags = diags.Append(&hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  "Cannot find configuration source code",
+			Detail:   fmt.Sprintf("Failed to load %s from the pre-installed source packages: %s.", source, err),
+		})
+		return nil, diags
+	}
+
+	src, err := os.ReadFile(path)
+	if err != nil {
+		return nil, hcl.Diagnostics{
+			{
+				Severity: hcl.DiagError,
+				Summary:  "Failed to read file",
+				Detail:   fmt.Sprintf("The file %q could not be read.", path),
+			},
+		}
+	}
+
+	// NOTE: this synthetic filename is intentionally a string rendering of the
+	// file's source address, which in many cases is _not_ a path name. We use
+	// the full source address in order to allow later consumers of diagnostics
+	// to look up the configuration file from the source bundle. We use this in
+	// the filename field of the diagnostic source to achieve this.
+	syntheticFilename := source.String()
+
+	var file *hcl.File
+	var fdiags hcl.Diagnostics
+	switch {
+	case strings.HasSuffix(path, ".json"):
+		file, fdiags = p.p.ParseJSON(src, syntheticFilename)
+	default:
+		file, fdiags = p.p.ParseHCL(src, syntheticFilename)
+	}
+	diags = append(diags, fdiags...)
+
+	body := hcl.EmptyBody()
+	if file != nil && file.Body != nil {
+		body = file.Body
+	}
+
+	return parseConfigFile(body, diags, override, p.allowExperiments)
+}
+
+// AllowLanguageExperiments specifies whether subsequent LoadConfigFile (and
+// similar) calls will allow opting in to experimental language features.
+//
+// If this method is never called for a particular parser, the default behavior
+// is to disallow language experiments.
+//
+// Main code should set this only for alpha or development builds. Test code
+// is responsible for deciding for itself whether and how to call this
+// method.
+func (p *SourceBundleParser) AllowLanguageExperiments(allowed bool) {
+	p.allowExperiments = allowed
+}

--- a/internal/stacks/stackruntime/helper_test.go
+++ b/internal/stacks/stackruntime/helper_test.go
@@ -55,12 +55,6 @@ func mainBundleSourceAddrStr(dirName string) string {
 	return "git::https://example.com/test.git//" + dirName
 }
 
-func mainBundleLocalAddrStr(dirName string) string {
-	// For now, the internal Terraform graph doesn't know about source bundles
-	// so diagnostics returned from there use the relative path.
-	return "testdata/mainbundle/test/" + dirName
-}
-
 // loadMainBundleConfigForTest is a convenience wrapper around
 // loadConfigForTest that knows the location and package address of our
 // "main" source bundle, in ./testdata/mainbundle, so that we can use that

--- a/internal/stacks/stackruntime/internal/stackeval/testdata/sourcebundle/invalid/invalid.tf
+++ b/internal/stacks/stackruntime/internal/stackeval/testdata/sourcebundle/invalid/invalid.tf
@@ -1,0 +1,3 @@
+invalid "top_level" "block" {
+  not_valid = true
+}

--- a/internal/stacks/stackruntime/internal/stackeval/testdata/sourcebundle/invalid_child/.terraform/modules/modules.json
+++ b/internal/stacks/stackruntime/internal/stackeval/testdata/sourcebundle/invalid_child/.terraform/modules/modules.json
@@ -1,0 +1,1 @@
+{"Modules":[{"Key":"","Source":"","Dir":"."},{"Key":"child","Source":"./child","Dir":"child"}]}

--- a/internal/stacks/stackruntime/internal/stackeval/testdata/sourcebundle/invalid_child/child/invalid_child.tf
+++ b/internal/stacks/stackruntime/internal/stackeval/testdata/sourcebundle/invalid_child/child/invalid_child.tf
@@ -1,0 +1,3 @@
+invalid "top_level" "block" {
+  not_valid = true
+}

--- a/internal/stacks/stackruntime/internal/stackeval/testdata/sourcebundle/invalid_child/invalid.tf
+++ b/internal/stacks/stackruntime/internal/stackeval/testdata/sourcebundle/invalid_child/invalid.tf
@@ -1,0 +1,3 @@
+module "child" {
+  source = "./child"
+}

--- a/internal/stacks/stackruntime/internal/stackeval/testdata/sourcebundle/invalid_grandchildren/first/child/invalid_child.tf
+++ b/internal/stacks/stackruntime/internal/stackeval/testdata/sourcebundle/invalid_grandchildren/first/child/invalid_child.tf
@@ -1,0 +1,3 @@
+invalid "top_level" "block" {
+  not_valid = true
+}

--- a/internal/stacks/stackruntime/internal/stackeval/testdata/sourcebundle/invalid_grandchildren/first/first.tf
+++ b/internal/stacks/stackruntime/internal/stackeval/testdata/sourcebundle/invalid_grandchildren/first/first.tf
@@ -1,0 +1,3 @@
+module "child" {
+  source = "./child"
+}

--- a/internal/stacks/stackruntime/internal/stackeval/testdata/sourcebundle/invalid_grandchildren/root.tf
+++ b/internal/stacks/stackruntime/internal/stackeval/testdata/sourcebundle/invalid_grandchildren/root.tf
@@ -1,0 +1,7 @@
+module "first" {
+  source = "./first"
+}
+
+module "second" {
+  source = "./second"
+}

--- a/internal/stacks/stackruntime/internal/stackeval/testdata/sourcebundle/invalid_grandchildren/second/child/invalid_child.tf
+++ b/internal/stacks/stackruntime/internal/stackeval/testdata/sourcebundle/invalid_grandchildren/second/child/invalid_child.tf
@@ -1,0 +1,3 @@
+invalid "top_level" "block" {
+  not_valid = true
+}

--- a/internal/stacks/stackruntime/internal/stackeval/testdata/sourcebundle/invalid_grandchildren/second/second.tf
+++ b/internal/stacks/stackruntime/internal/stackeval/testdata/sourcebundle/invalid_grandchildren/second/second.tf
@@ -1,0 +1,3 @@
+module "child" {
+  source = "./child"
+}

--- a/internal/stacks/stackruntime/internal/stackeval/testdata/sourcebundle/terraform-sources.json
+++ b/internal/stacks/stackruntime/internal/stackeval/testdata/sourcebundle/terraform-sources.json
@@ -1,37 +1,45 @@
 {
-    "terraform_source_bundle": 1,
-    "packages": [
-      {
-        "source": "https://testing.invalid/input_variable.tar.gz",
-        "local": "input_variable"
-      },
-      {
-        "source": "https://testing.invalid/output_value.tar.gz",
-        "local": "output_value"
-      },
-      {
-        "source": "https://testing.invalid/stack_call.tar.gz",
-        "local": "stack_call"
-      },
-      {
-        "source": "https://testing.invalid/component.tar.gz",
-        "local": "component"
-      },
-      {
-        "source": "https://testing.invalid/provider.tar.gz",
-        "local": "provider"
-      },
-      {
-        "source": "https://testing.invalid/planning.tar.gz",
-        "local": "planning"
-      },
-      {
-        "source": "https://testing.invalid/applying.tar.gz",
-        "local": "applying"
-      },
-      {
-        "source": "https://testing.invalid/validating.tar.gz",
-        "local": "validating"
-      }
-    ]
-  }
+  "terraform_source_bundle": 1,
+  "packages": [
+    {
+      "source": "https://testing.invalid/input_variable.tar.gz",
+      "local": "input_variable"
+    },
+    {
+      "source": "https://testing.invalid/output_value.tar.gz",
+      "local": "output_value"
+    },
+    {
+      "source": "https://testing.invalid/stack_call.tar.gz",
+      "local": "stack_call"
+    },
+    {
+      "source": "https://testing.invalid/component.tar.gz",
+      "local": "component"
+    },
+    {
+      "source": "https://testing.invalid/provider.tar.gz",
+      "local": "provider"
+    },
+    {
+      "source": "https://testing.invalid/planning.tar.gz",
+      "local": "planning"
+    },
+    {
+      "source": "https://testing.invalid/applying.tar.gz",
+      "local": "applying"
+    },
+    {
+      "source": "https://testing.invalid/validating.tar.gz",
+      "local": "validating"
+    },
+    {
+      "source": "https://testing.invalid/invalid.tar.gz",
+      "local": "invalid"
+    },
+    {
+      "source": "https://testing.invalid/invalid_child.tar.gz",
+      "local": "invalid_child"
+    }
+  ]
+}

--- a/internal/stacks/stackruntime/internal/stackeval/testdata/sourcebundle/terraform-sources.json
+++ b/internal/stacks/stackruntime/internal/stackeval/testdata/sourcebundle/terraform-sources.json
@@ -40,6 +40,10 @@
     {
       "source": "https://testing.invalid/invalid_child.tar.gz",
       "local": "invalid_child"
+    },
+    {
+      "source": "https://testing.invalid/invalid_grandchildren.tar.gz",
+      "local": "invalid_grandchildren"
     }
   ]
 }

--- a/internal/stacks/stackruntime/internal/stackeval/testdata/sourcebundle/validating/nested_module_diagnostics/invalid/invalid.tf
+++ b/internal/stacks/stackruntime/internal/stackeval/testdata/sourcebundle/validating/nested_module_diagnostics/invalid/invalid.tf
@@ -1,0 +1,3 @@
+invalid "top_level" "block" {
+  not_valid = true
+}

--- a/internal/stacks/stackruntime/internal/stackeval/testdata/sourcebundle/validating/nested_module_diagnostics/invalid_child/.terraform/modules/modules.json
+++ b/internal/stacks/stackruntime/internal/stackeval/testdata/sourcebundle/validating/nested_module_diagnostics/invalid_child/.terraform/modules/modules.json
@@ -1,0 +1,1 @@
+{"Modules":[{"Key":"","Source":"","Dir":"."},{"Key":"child","Source":"./child","Dir":"child"}]}

--- a/internal/stacks/stackruntime/internal/stackeval/testdata/sourcebundle/validating/nested_module_diagnostics/invalid_child/child/invalid_child.tf
+++ b/internal/stacks/stackruntime/internal/stackeval/testdata/sourcebundle/validating/nested_module_diagnostics/invalid_child/child/invalid_child.tf
@@ -1,0 +1,3 @@
+invalid "top_level" "block" {
+  not_valid = true
+}

--- a/internal/stacks/stackruntime/internal/stackeval/testdata/sourcebundle/validating/nested_module_diagnostics/invalid_child/invalid.tf
+++ b/internal/stacks/stackruntime/internal/stackeval/testdata/sourcebundle/validating/nested_module_diagnostics/invalid_child/invalid.tf
@@ -1,0 +1,3 @@
+module "child" {
+  source = "./child"
+}

--- a/internal/stacks/stackruntime/internal/stackeval/testdata/sourcebundle/validating/nested_module_diagnostics/invalid_nested_remote/invalid_nested_remote.tf
+++ b/internal/stacks/stackruntime/internal/stackeval/testdata/sourcebundle/validating/nested_module_diagnostics/invalid_nested_remote/invalid_nested_remote.tf
@@ -1,0 +1,3 @@
+module "invalid_grandchild" {
+  source =  "https://testing.invalid/invalid_child.tar.gz"
+}

--- a/internal/stacks/stackruntime/internal/stackeval/testdata/sourcebundle/validating/nested_module_diagnostics/nested_module_diagnostics.tfstack.hcl
+++ b/internal/stacks/stackruntime/internal/stackeval/testdata/sourcebundle/validating/nested_module_diagnostics/nested_module_diagnostics.tfstack.hcl
@@ -24,3 +24,9 @@ component "remote_invalid" {
 component "remote_invalid_child" {
   source = "https://testing.invalid/invalid_child.tar.gz"
 }
+
+// This remote source component has two invalid grandchildren which are both
+// in-repo modules and share the same relative source
+component "remote_invalid_grandchildren" {
+  source = "https://testing.invalid/invalid_grandchildren.tar.gz"
+}

--- a/internal/stacks/stackruntime/internal/stackeval/testdata/sourcebundle/validating/nested_module_diagnostics/nested_module_diagnostics.tfstack.hcl
+++ b/internal/stacks/stackruntime/internal/stackeval/testdata/sourcebundle/validating/nested_module_diagnostics/nested_module_diagnostics.tfstack.hcl
@@ -1,0 +1,26 @@
+// This in-repo component has an invalid root module
+component "in_repo_invalid" {
+  source = "./invalid"
+}
+
+// This in-repo component has a valid root module and an invalid child in-repo
+// module
+component "in_repo_invalid_child" {
+  source = "./invalid_child"
+}
+
+// This in-repo component has a remote source child module with a valid root
+// module and an invalid child in-repo module
+component "in_repo_invalid_nested_remote" {
+  source = "./invalid_nested_remote"
+}
+
+// This remote source component has an invalid root module
+component "remote_invalid" {
+  source = "https://testing.invalid/invalid.tar.gz"
+}
+
+// This remote source component has an invalid child in-repo module
+component "remote_invalid_child" {
+  source = "https://testing.invalid/invalid_child.tar.gz"
+}

--- a/internal/stacks/stackruntime/internal/stackeval/validating_test.go
+++ b/internal/stacks/stackruntime/internal/stackeval/validating_test.go
@@ -109,57 +109,29 @@ func TestValidate_nestedModuleDiagnostics(t *testing.T) {
 		gotDiags := diags.ForRPC()
 
 		var wantDiags tfdiags.Diagnostics
-		// This configuration has the same errors repeated multiple times, varying only on filename (source address).
-		wantDiags = wantDiags.Append(&hcl.Diagnostic{
-			Severity: hcl.DiagError,
-			Summary:  "Unsupported block type",
-			Detail:   `Blocks of type "invalid" are not expected here.`,
-			Subject: &hcl.Range{
-				Filename: "https://testing.invalid/invalid.tar.gz//invalid.tf",
-				Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
-				End:      hcl.Pos{Line: 1, Column: 8, Byte: 7},
-			},
-		})
-		wantDiags = wantDiags.Append(&hcl.Diagnostic{
-			Severity: hcl.DiagError,
-			Summary:  "Unsupported block type",
-			Detail:   `Blocks of type "invalid" are not expected here.`,
-			Subject: &hcl.Range{
-				Filename: "https://testing.invalid/invalid_child.tar.gz//child/invalid_child.tf",
-				Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
-				End:      hcl.Pos{Line: 1, Column: 8, Byte: 7},
-			},
-		})
-		wantDiags = wantDiags.Append(&hcl.Diagnostic{
-			Severity: hcl.DiagError,
-			Summary:  "Unsupported block type",
-			Detail:   `Blocks of type "invalid" are not expected here.`,
-			Subject: &hcl.Range{
-				Filename: "https://testing.invalid/invalid_child.tar.gz//child/invalid_child.tf",
-				Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
-				End:      hcl.Pos{Line: 1, Column: 8, Byte: 7},
-			},
-		})
-		wantDiags = wantDiags.Append(&hcl.Diagnostic{
-			Severity: hcl.DiagError,
-			Summary:  "Unsupported block type",
-			Detail:   `Blocks of type "invalid" are not expected here.`,
-			Subject: &hcl.Range{
-				Filename: "https://testing.invalid/validating.tar.gz//nested_module_diagnostics/invalid/invalid.tf",
-				Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
-				End:      hcl.Pos{Line: 1, Column: 8, Byte: 7},
-			},
-		})
-		wantDiags = wantDiags.Append(&hcl.Diagnostic{
-			Severity: hcl.DiagError,
-			Summary:  "Unsupported block type",
-			Detail:   `Blocks of type "invalid" are not expected here.`,
-			Subject: &hcl.Range{
-				Filename: "https://testing.invalid/validating.tar.gz//nested_module_diagnostics/invalid_child/child/invalid_child.tf",
-				Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
-				End:      hcl.Pos{Line: 1, Column: 8, Byte: 7},
-			},
-		})
+		// This configuration has the same errors repeated multiple times,
+		// varying only on filename (source address).
+		filenames := []string{
+			"https://testing.invalid/invalid.tar.gz//invalid.tf",
+			"https://testing.invalid/invalid_child.tar.gz//child/invalid_child.tf",
+			"https://testing.invalid/invalid_child.tar.gz//child/invalid_child.tf",
+			"https://testing.invalid/invalid_grandchildren.tar.gz//first/child/invalid_child.tf",
+			"https://testing.invalid/invalid_grandchildren.tar.gz//second/child/invalid_child.tf",
+			"https://testing.invalid/validating.tar.gz//nested_module_diagnostics/invalid/invalid.tf",
+			"https://testing.invalid/validating.tar.gz//nested_module_diagnostics/invalid_child/child/invalid_child.tf",
+		}
+		for _, filename := range filenames {
+			wantDiags = wantDiags.Append(&hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  "Unsupported block type",
+				Detail:   `Blocks of type "invalid" are not expected here.`,
+				Subject: &hcl.Range{
+					Filename: filename,
+					Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+					End:      hcl.Pos{Line: 1, Column: 8, Byte: 7},
+				},
+			})
+		}
 		wantDiags = wantDiags.ForRPC()
 
 		if diff := cmp.Diff(wantDiags, gotDiags); diff != "" {

--- a/internal/stacks/stackruntime/internal/stackeval/validating_test.go
+++ b/internal/stacks/stackruntime/internal/stackeval/validating_test.go
@@ -52,16 +52,6 @@ func TestValidate_modulesWithProviderConfigs(t *testing.T) {
 		gotDiags := diags.ForRPC()
 
 		var wantDiags tfdiags.Diagnostics
-		// TEMP: Because we're currently essentially just tricking the module
-		// loader into reading from a source bundle without actually knowing
-		// that's what its doing, these diagnostics show local filesystem
-		// paths instead of source addresses. Once we fix that in future,
-		// the following wanted diagnostics should switch to refer to
-		// source addresses starting with:
-		//   https://testing.invalid/validating.tar.gz//modules_with_provider_configs/
-		// ...which is the fake source address form used by the testStackConfig
-		// helper we used above.
-
 		// Configurations in the root module get a different detail message
 		// than those in descendent modules, because for descendents we don't
 		// assume that the author is empowered to make the module
@@ -73,7 +63,7 @@ func TestValidate_modulesWithProviderConfigs(t *testing.T) {
 			Summary:  "Inline provider configuration not allowed",
 			Detail:   `A module used as a stack component must have all of its provider configurations passed from the stack configuration, using the "providers" argument within the component configuration block.`,
 			Subject: &hcl.Range{
-				Filename: "testdata/sourcebundle/validating/modules_with_provider_configs/module-a/modules-with-provider-configs-a.tf",
+				Filename: "https://testing.invalid/validating.tar.gz//modules_with_provider_configs/module-a/modules-with-provider-configs-a.tf",
 				Start:    hcl.Pos{Line: 9, Column: 1, Byte: 104},
 				End:      hcl.Pos{Line: 9, Column: 16, Byte: 119},
 			},
@@ -83,7 +73,7 @@ func TestValidate_modulesWithProviderConfigs(t *testing.T) {
 			Summary:  "Inline provider configuration not allowed",
 			Detail:   "This module is not compatible with Terraform Stacks, because it declares an inline provider configuration.\n\nTo be used with stacks, this module must instead accept provider configurations from its caller.",
 			Subject: &hcl.Range{
-				Filename: "testdata/sourcebundle/validating/modules_with_provider_configs/module-b/modules-with-provider-configs-b.tf",
+				Filename: "https://testing.invalid/validating.tar.gz//modules_with_provider_configs/module-b/modules-with-provider-configs-b.tf",
 				Start:    hcl.Pos{Line: 9, Column: 1, Byte: 104},
 				End:      hcl.Pos{Line: 9, Column: 16, Byte: 119},
 			},

--- a/internal/stacks/stackruntime/validate_test.go
+++ b/internal/stacks/stackruntime/validate_test.go
@@ -92,7 +92,7 @@ func TestValidate_invalid(t *testing.T) {
 					Summary:  "Unsupported argument",
 					Detail:   "An argument named \"invalid\" is not expected here.",
 					Subject: &hcl.Range{
-						Filename: mainBundleLocalAddrStr("invalid-configuration/invalid-configuration.tf"),
+						Filename: mainBundleSourceAddrStr("invalid-configuration/invalid-configuration.tf"),
 						Start:    hcl.Pos{Line: 11, Column: 3, Byte: 163},
 						End:      hcl.Pos{Line: 11, Column: 10, Byte: 170},
 					},


### PR DESCRIPTION
Stacks uses go-slug's source bundles in order to compile a full configuration. Until now, we've been loading Terraform modules within these source bundles with the standard configuration parser, which worked as a stop-gap.

However, configuration diagnostics were reported with module-relative paths as the source filename, which made it tricky to correctly load the configuration file in order to later display a snippet of related code. This PR replaces these paths with source addresses, allowing consumers of diagnostics to query the source bundle to reliably find the target file.

This change will require an update in the diagnostic handling code for consumers of stack diagnostics, which will come in separate PRs.

## Target Release

1.8.0