### PR TITLE
stackeval: Don't fail when data resource is removed

### DIFF
--- a/internal/stacks/stackplan/planned_change.go
+++ b/internal/stacks/stackplan/planned_change.go
@@ -274,6 +274,7 @@ func (pc *PlannedChangeResourceInstancePlanned) PlannedChangeProto() (*terraform
 			ComponentInstanceAddr: rioAddr.Component.String(),
 			ResourceInstanceAddr:  rioAddr.Item.ResourceInstance.String(),
 			DeposedKey:            rioAddr.Item.DeposedKey.String(),
+			ProviderConfigAddr:    pc.ProviderConfigAddr.String(),
 		}, proto.MarshalOptions{})
 		if err != nil {
 			return nil, err

--- a/internal/stacks/stackruntime/internal/stackeval/testdata/sourcebundle/planning/remove_data_resource/step1/remove-data-resource-step1.tf
+++ b/internal/stacks/stackruntime/internal/stackeval/testdata/sourcebundle/planning/remove_data_resource/step1/remove-data-resource-step1.tf
@@ -1,0 +1,11 @@
+
+terraform {
+  required_providers {
+    test = {
+        source = "terraform.io/builtin/test"
+    }
+  }
+}
+
+data "test" "test" {
+}

--- a/internal/stacks/stackruntime/internal/stackeval/testdata/sourcebundle/planning/remove_data_resource/step1/remove-data-resource-step1.tfstack.hcl
+++ b/internal/stacks/stackruntime/internal/stackeval/testdata/sourcebundle/planning/remove_data_resource/step1/remove-data-resource-step1.tfstack.hcl
@@ -1,0 +1,16 @@
+required_providers {
+  test = {
+    source = "terraform.io/builtin/test"
+  }
+}
+
+provider "test" "main" {
+}
+
+component "main" {
+  source = "./"
+
+  providers = {
+    test = provider.test.main
+  }
+}

--- a/internal/stacks/stackruntime/internal/stackeval/testdata/sourcebundle/planning/remove_data_resource/step2/remove-data-resource-step2.tf
+++ b/internal/stacks/stackruntime/internal/stackeval/testdata/sourcebundle/planning/remove_data_resource/step2/remove-data-resource-step2.tf
@@ -1,0 +1,10 @@
+
+terraform {
+  required_providers {
+    test = {
+        source = "terraform.io/builtin/test"
+    }
+  }
+}
+
+# data.test.test is now gone!

--- a/internal/stacks/stackruntime/internal/stackeval/testdata/sourcebundle/planning/remove_data_resource/step2/remove-data-resource-step2.tfstack.hcl
+++ b/internal/stacks/stackruntime/internal/stackeval/testdata/sourcebundle/planning/remove_data_resource/step2/remove-data-resource-step2.tfstack.hcl
@@ -1,0 +1,16 @@
+required_providers {
+  test = {
+    source = "terraform.io/builtin/test"
+  }
+}
+
+provider "test" "main" {
+}
+
+component "main" {
+  source = "./"
+
+  providers = {
+    test = provider.test.main
+  }
+}


### PR DESCRIPTION
Due to an oversight in our handling of resource instance objects that are neither in configuration nor plan -- which is true for data resources that have since been removed from the configuration -- we were generating plan change objects that were lacking a provider configuration address, which made them syntactically invalid and thus not reloadable using the raw plan parser.

This is a bit of a strange situation since we don't technically _need_ a provider configuration address for these; all we're going to do is just unceremoniously delete them from the state during apply anyway. However, we always have the provider configuration address available anyway, so adding this in here is overall simpler than changing the parser, the models it populates, and all of the downstream users of those models to treat this field as optional.

This commit is more test case than it is fix, since the fix was relatively straightforward once I had a test case to reproduce the problem it's fixing.

This fixes the non-public ticket `TF-13366`.