### PR TITLE
stacks: validate providers based on types instead of local names

### DIFF
--- a/internal/stacks/stackruntime/internal/stackeval/component_config.go
+++ b/internal/stacks/stackruntime/internal/stackeval/component_config.go
@@ -22,6 +22,7 @@ import (
 	"github.com/hashicorp/terraform/internal/providers"
 	"github.com/hashicorp/terraform/internal/stacks/stackaddrs"
 	"github.com/hashicorp/terraform/internal/stacks/stackconfig"
+	"github.com/hashicorp/terraform/internal/stacks/stackconfig/stackconfigtypes"
 	"github.com/hashicorp/terraform/internal/stacks/stackplan"
 	"github.com/hashicorp/terraform/internal/terraform"
 	"github.com/hashicorp/terraform/internal/tfdiags"
@@ -244,13 +245,13 @@ func (c *ComponentConfig) CheckInputVariableValues(ctx context.Context, phase Ev
 // If any modules in the component's root module tree are invalid then this
 // result could under-promise or over-promise depending on the kind of
 // invalidity.
-func (c *ComponentConfig) RequiredProviderInstances(ctx context.Context) addrs.Set[addrs.RootProviderConfig] {
+func (c *ComponentConfig) RequiredProviderInstances(ctx context.Context) addrs.Map[addrs.RootProviderConfig, addrs.LocalProviderConfig] {
 	moduleTree := c.ModuleTree(ctx)
 	if moduleTree == nil || moduleTree.Root == nil {
 		// If we get here then we presumably failed to load the module, and
 		// so we'll just unwind quickly so a different return path can return
 		// the error diagnostics.
-		return nil
+		return addrs.MakeMap[addrs.RootProviderConfig, addrs.LocalProviderConfig]()
 	}
 	return moduleTree.Root.EffectiveRequiredProviderConfigs()
 }
@@ -262,11 +263,29 @@ func (c *ComponentConfig) CheckProviders(ctx context.Context, phase EvalPhase) (
 	declConfigs := c.Declaration(ctx).ProviderConfigs
 	neededProviders := c.RequiredProviderInstances(ctx)
 
+	// neededProviders are the providers that are required by the module tree itself.
+	// We need to make sure all the neededProviders are included in the `providers` argument of the declaration.
+	// Then we need to make sure all the providers in the `providers` argument exist.
+	// Then we need to make sure the types of the providers in the `providers` argument match the types of the neededProviders.
+
 	ret := addrs.MakeSet[addrs.RootProviderConfig]()
-	for _, inCalleeAddr := range neededProviders {
-		typeAddr := inCalleeAddr.Provider
-		localName, ok := stackConfig.ProviderLocalName(ctx, typeAddr)
-		if !ok {
+	for _, elem := range neededProviders.Elems {
+
+		// sourceAddr is the addrs.RootProviderConfig that should be used to
+		// set this provider in the component later.
+		sourceAddr := elem.Key
+
+		// componentAddr is the addrs.LocalProviderConfig that specifies the
+		// local name and (optional) alias of the provider in the component.
+		componentAddr := elem.Value
+
+		// typeAddr is the absolute address of the provider type itself.
+		typeAddr := sourceAddr.Provider
+
+		// This type should be in the stack's required_providers list.
+		if _, ok := stackConfig.ProviderLocalName(ctx, typeAddr); !ok {
+			// This means we haven't got this provider in the stacks
+			// required_provider list.
 			diags = diags.Append(&hcl.Diagnostic{
 				Severity: hcl.DiagError,
 				Summary:  "Component requires undeclared provider",
@@ -279,42 +298,69 @@ func (c *ComponentConfig) CheckProviders(ctx context.Context, phase EvalPhase) (
 			continue
 		}
 
-		localAddr := addrs.LocalProviderConfig{
-			LocalName: localName,
-			Alias:     inCalleeAddr.Alias,
-		}
-		if _, exists := declConfigs[localAddr]; !exists {
+		expr, exists := declConfigs[componentAddr]
+		if !exists {
+			// Then this provider isn't listed in the `providers` block of this
+			// component. Which is bad!
 			diags = diags.Append(&hcl.Diagnostic{
 				Severity: hcl.DiagError,
 				Summary:  "Missing required provider configuration",
 				Detail: fmt.Sprintf(
 					"The root module for %s requires a provider configuration named %q for provider %q, which is not assigned in the component's \"providers\" argument.",
-					c.Addr(), localAddr.StringCompact(), typeAddr.ForDisplay(),
+					c.Addr(), componentAddr.StringCompact(), typeAddr.ForDisplay(),
 				),
 				Subject: c.Declaration(ctx).DeclRange.ToHCL().Ptr(),
 			})
 			continue
 		}
 
-		// TODO: It's not currently possible to assign a provider configuration
-		//  with a different local name even if the types match. Find out if
-		//  this is deliberate. Note, the component_instance CheckProviders
-		//  function also enforces this.
-		//
-		// In theory you should be able to do this:
-		//   provider_one = provider.provider_two.default
-		//
-		// Assuming the underlying types of the providers are the same, even if
-		// the local names are not. This is not possible at the moment, the
-		// local names must match up.
-		//
-		// We'll have to partially parse the reference here to get the local
-		// configuration block (uninstanced), and then resolve the underlying
-		// type. And then make sure it matches the type of the provider we're
-		// assigning it to in the module. Also, we should fix the equivalent
-		// function in component_instance at the same time.
+		// At the validation stage, it's really likely the result here is
+		// unknown. But, we can still check the returned type to make sure it
+		// matches everything expected.
+		result, hclDiags := EvalExprAndEvalContext(ctx, expr, phase, c)
+		diags = diags.Append(hclDiags)
+		if hclDiags.HasErrors() {
+			continue
+		}
 
-		ret.Add(inCalleeAddr)
+		const errSummary = "Invalid provider configuration"
+		if actualTy := result.Value.Type(); stackconfigtypes.IsProviderConfigType(actualTy) {
+			// Then we at least got a provider reference of some kind.
+			actualTypeAddr := stackconfigtypes.ProviderForProviderConfigType(actualTy)
+			if actualTypeAddr != typeAddr {
+				// But, unfortunately, the underlying types of the providers
+				// do not match up.
+				diags = diags.Append(&hcl.Diagnostic{
+					Severity: hcl.DiagError,
+					Summary:  errSummary,
+					Detail: fmt.Sprintf(
+						"The provider configuration slot %s requires a configuration for provider %q, not for provider %q.",
+						componentAddr.StringCompact(), typeAddr, actualTypeAddr,
+					),
+					Subject: result.Expression.Range().Ptr(),
+				})
+				continue
+			}
+		} else {
+			// We got something that isn't a provider reference at all.
+			diags = diags.Append(&hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  errSummary,
+				Detail: fmt.Sprintf(
+					"The provider configuration slot %s requires a configuration for provider %q.",
+					componentAddr.StringCompact(), typeAddr,
+				),
+				Subject: result.Expression.Range().Ptr(),
+			})
+			continue
+		}
+
+		// If we made it here, the types all matched up so we've done everything
+		// we can. component_instance.go will do additional checks to make sure
+		// the result is known and not null when it comes time to actually
+		// check the plan.
+
+		ret.Add(sourceAddr)
 	}
 	return ret, diags
 }

--- a/internal/stacks/stackruntime/internal/stackeval/component_config.go
+++ b/internal/stacks/stackruntime/internal/stackeval/component_config.go
@@ -263,11 +263,6 @@ func (c *ComponentConfig) CheckProviders(ctx context.Context, phase EvalPhase) (
 	declConfigs := c.Declaration(ctx).ProviderConfigs
 	neededProviders := c.RequiredProviderInstances(ctx)
 
-	// neededProviders are the providers that are required by the module tree itself.
-	// We need to make sure all the neededProviders are included in the `providers` argument of the declaration.
-	// Then we need to make sure all the providers in the `providers` argument exist.
-	// Then we need to make sure the types of the providers in the `providers` argument match the types of the neededProviders.
-
 	ret := addrs.MakeSet[addrs.RootProviderConfig]()
 	for _, elem := range neededProviders.Elems {
 

--- a/internal/stacks/stackruntime/internal/stackeval/component_instance.go
+++ b/internal/stacks/stackruntime/internal/stackeval/component_instance.go
@@ -154,181 +154,237 @@ func (c *ComponentInstance) CheckProviders(ctx context.Context, phase EvalPhase)
 	var diags tfdiags.Diagnostics
 	ret := make(map[addrs.RootProviderConfig]stackaddrs.AbsProviderConfigInstance)
 
+	declConfigs := c.call.Declaration(ctx).ProviderConfigs
+	neededProviders := c.call.Config(ctx).RequiredProviderInstances(ctx)
+
+	for _, elem := range neededProviders.Elems {
+
+		// sourceAddr is the addrs.RootProviderConfig that should be used to
+		// set this provider in the component later.
+		sourceAddr := elem.Key
+
+		// componentAddr is the addrs.LocalProviderConfig that specifies the
+		// local name and (optional) alias of the provider in the component.
+		componentAddr := elem.Value
+
+		// We validated the config providers during the static analysis, so we
+		// know this expression exists and resolves to the correct type.
+		expr := declConfigs[componentAddr]
+
+		// We've now found the entry in declConfigs that should handle this
+		// provider so we'll remove it. This helps us later to find any unused
+		// entries that might be assignable to removed configurations.
+		delete(declConfigs, componentAddr)
+
+		inst, instDiags, ok := c.checkProvider(ctx, sourceAddr, componentAddr, expr, phase)
+		diags = diags.Append(instDiags)
+		if ok {
+			ret[sourceAddr] = inst
+		}
+	}
+
+	// Now, we've got types for all the providers that are required by the
+	// current configuration. We don't currently store enough information to
+	// be able to retrieve the original provider directly from the stack
+	// configuration. We only store the provider type and alias of the original
+	// provider within the state. Stacks can have multiple instances of the same
+	// provider type, local name, and alias. This means we need the user to
+	// still provide an entry for this provider in the declConfigs.
+	// TODO: There's another TODO in the state package that suggests we should
+	//   store the additional information we need. Once this is fixed we can
+	//   come and tidy this up as well.
+
 	stack := c.call.Stack(ctx)
 	stackConfig := stack.StackConfig(ctx)
-	declConfigs := c.call.Declaration(ctx).ProviderConfigs
+	moduleTree := c.call.Config(ctx).ModuleTree(ctx)
 
-	// We'll iterate over the set of providers actually required for this
-	// operation, and make sure they have been properly declared and are
-	// available.
-
-	// First, gather all the providers implied by the configuration.
-	configProviders := c.call.Config(ctx).RequiredProviderInstances(ctx)
-
-	// Second, we also need to add any providers that were required by the
-	// component's previous runs and have since been removed from the config.
 	previousProviders := c.main.PreviousProviderInstances(c.Addr(), phase)
+	for localProviderAddr, expr := range declConfigs {
+		provider := moduleTree.ProviderForConfigAddr(localProviderAddr)
 
-	neededProviders := configProviders.Union(previousProviders)
-	for _, inCalleeAddr := range neededProviders {
-
-		providerContextString := "requires"
-		if !configProviders.Has(inCalleeAddr) {
-			// This provider was required by the previous state but is no
-			// longer required by the configuration, so we'll add a bit of
-			// extra context to the diagnostic to help the user understand
-			// what's going on.
-			providerContextString = "has resources in state that require"
+		sourceAddr := addrs.RootProviderConfig{
+			Provider: provider,
+			Alias:    localProviderAddr.Alias,
 		}
 
-		// declConfigs is based on _local_ provider references so we'll
-		// need to translate based on the stack configuration's
-		// required_providers block.
-		typeAddr := inCalleeAddr.Provider
-		localName, ok := stackConfig.ProviderLocalName(ctx, typeAddr)
-		if !ok {
-			// We perform a similar check within component_config.go during
-			// the validation. At the validation stage we are only verifying the
-			// configuration, while this check is also checking the state. We
-			// can't check the state during validation, so we perform this check
-			// again. In reality, we will not even reach this if there are
-			// problems with the configuration as the validation will have
-			// failed before the plan/apply was even started.
+		if !previousProviders.Has(sourceAddr) {
+			// Then this entry in declConfigs is just referring to a provider
+			// that we don't need. This is okay, just redundant.
+			// TODO: We could raise a warning here?
+			continue
+		}
+
+		// We do have an entry for this provider so remove it from the list of
+		// previous providers. This helps us later to find any unused entries.
+		previousProviders.Remove(sourceAddr)
+
+		inst, instDiags, ok := c.checkProvider(ctx, sourceAddr, localProviderAddr, expr, phase)
+		diags = diags.Append(instDiags)
+		if ok {
+			ret[sourceAddr] = inst
+		}
+
+		if _, ok := stackConfig.ProviderLocalName(ctx, provider); !ok {
+			// Even though we have an entry for this provider in the declConfigs
+			// doesn't mean we have an entry for this in our required providers.
 			diags = diags.Append(&hcl.Diagnostic{
 				Severity: hcl.DiagError,
 				Summary:  "Component requires undeclared provider",
 				Detail: fmt.Sprintf(
-					"The root module for %s %s a configuration for provider %q, which isn't declared as a dependency of this stack configuration.\n\nDeclare this provider in the stack's required_providers block, and then assign a configuration for that provider in this component's \"providers\" argument.",
-					c.Addr(), providerContextString, typeAddr.ForDisplay(),
+					"The root module for %s has resources in state that require a configuration for provider %q, which isn't declared as a dependency of this stack configuration.\n\nDeclare this provider in the stack's required_providers block, and then assign a configuration for that provider in this component's \"providers\" argument.",
+					c.Addr(), provider.ForDisplay(),
 				),
 				Subject: c.call.Declaration(ctx).DeclRange.ToHCL().Ptr(),
 			})
 			continue
 		}
+	}
+
+	for _, previousProvider := range previousProviders {
+		if _, ok := ret[previousProvider]; ok {
+			// Then this provider is needed by the configuration anyway, so we
+			// don't need to raise an error about it being missed.
+			continue
+		}
+
+		// localAddr helps with the error message.
 		localAddr := addrs.LocalProviderConfig{
-			LocalName: localName,
-			Alias:     inCalleeAddr.Alias,
-		}
-		expr, ok := declConfigs[localAddr]
-		if !ok {
-			diags = diags.Append(&hcl.Diagnostic{
-				Severity: hcl.DiagError,
-				Summary:  "Missing required provider configuration",
-				Detail: fmt.Sprintf(
-					"The root module for %s %s a provider configuration named %q for provider %q, which is not assigned in the component's \"providers\" argument.",
-					c.Addr(), providerContextString, localAddr.StringCompact(), typeAddr.ForDisplay(),
-				),
-				Subject: c.call.Declaration(ctx).DeclRange.ToHCL().Ptr(),
-			})
-			continue
+			LocalName: moduleTree.Module.LocalNameForProvider(previousProvider.Provider),
+			Alias:     previousProvider.Alias,
 		}
 
-		// If we've got this far then expr is an expression that should
-		// evaluate to a special cty capsule type that acts as a reference
-		// to a provider configuration declared elsewhere in the tree
-		// of stack configurations.
-		result, hclDiags := EvalExprAndEvalContext(ctx, expr, phase, c)
-		diags = diags.Append(hclDiags)
-		if hclDiags.HasErrors() {
-			continue
-		}
-
-		const errSummary = "Invalid provider reference"
-		if actualTy := result.Value.Type(); stackconfigtypes.IsProviderConfigType(actualTy) {
-			actualTypeAddr := stackconfigtypes.ProviderForProviderConfigType(actualTy)
-			if actualTypeAddr != typeAddr {
-				diags = diags.Append(&hcl.Diagnostic{
-					Severity: hcl.DiagError,
-					Summary:  errSummary,
-					Detail: fmt.Sprintf(
-						"The provider configuration slot %s requires a configuration for provider %q, not for provider %q.",
-						localAddr.StringCompact(), typeAddr, actualTypeAddr,
-					),
-					Subject: result.Expression.Range().Ptr(),
-				})
-				continue
-			}
-		} else {
-			diags = diags.Append(&hcl.Diagnostic{
-				Severity: hcl.DiagError,
-				Summary:  errSummary,
-				Detail: fmt.Sprintf(
-					"The provider configuration slot %s requires a configuration for provider %q.",
-					localAddr.StringCompact(), typeAddr,
-				),
-				Subject: result.Expression.Range().Ptr(),
-			})
-		}
-		v := result.Value
-
-		// If the tests succeeded above then "v" should definitely
-		// be of the expected type, but might be unknown or null.
-		if v.IsNull() {
-			diags = diags.Append(&hcl.Diagnostic{
-				Severity: hcl.DiagError,
-				Summary:  errSummary,
-				Detail: fmt.Sprintf(
-					"The provider configuration slot %s is required, but this definition returned null.",
-					localAddr.StringCompact(),
-				),
-				Subject: result.Expression.Range().Ptr(),
-			})
-			continue
-		}
-		if !v.IsKnown() {
-			// TODO: Once we support deferred changes we should return
-			// something that lets the caller know the configuration is
-			// incomplete so it can defer planning the entire component.
-			diags = diags.Append(&hcl.Diagnostic{
-				Severity: hcl.DiagError,
-				Summary:  errSummary,
-				Detail: fmt.Sprintf(
-					"This expression depends on values that won't be known until the apply phase, so Terraform cannot determine which provider configuration to use while planning changes for %s.",
-					c.Addr().String(),
-				),
-				Subject: result.Expression.Range().Ptr(),
-			})
-			continue
-		}
-
-		// If it's of the correct type, known, and not null then we should
-		// be able to retrieve a specific provider instance address that
-		// this value refers to.
-		providerInstAddr := stackconfigtypes.ProviderInstanceForValue(v)
-		ret[inCalleeAddr] = providerInstAddr
-
-		// The reference must be to a provider instance that's actually
-		// configured.
-		providerInstStack := c.main.Stack(ctx, providerInstAddr.Stack, phase)
-		if providerInstStack != nil {
-			provider := providerInstStack.Provider(ctx, providerInstAddr.Item.ProviderConfig)
-			if provider != nil {
-				insts := provider.Instances(ctx, phase)
-				if insts == nil {
-					// If we get here then we don't yet know which instances
-					// this provider has, so we'll be optimistic that it'll
-					// show up in a later phase.
-					continue
-				}
-				if _, exists := insts[providerInstAddr.Item.Key]; exists {
-					continue
-				}
-			}
-		}
-		// If we fall here then something on the path to the provider instance
-		// doesn't exist, and so effectively the provider instance doesn't exist.
+		// If we get here, then we didn't find an entry for this provider in
+		// the declConfigs. This is an error because we need to have an entry
+		// for every provider that we have in the state.
 		diags = diags.Append(&hcl.Diagnostic{
 			Severity: hcl.DiagError,
-			Summary:  errSummary,
+			Summary:  "Missing required provider configuration",
 			Detail: fmt.Sprintf(
-				"Expression result refers to undefined provider instance %s.",
-				providerInstAddr,
+				"The root module for %s has resources in state that require a provider configuration named %q for provider %q, which is not assigned in the component's \"providers\" argument.",
+				c.Addr(), localAddr.StringCompact(), previousProvider.Provider.ForDisplay(),
 			),
-			Subject: result.Expression.Range().Ptr(),
+			Subject: c.call.Declaration(ctx).DeclRange.ToHCL().Ptr(),
 		})
 	}
 
 	return ret, diags
+}
+
+func (c *ComponentInstance) checkProvider(ctx context.Context, sourceAddr addrs.RootProviderConfig, componentAddr addrs.LocalProviderConfig, expr hcl.Expression, phase EvalPhase) (stackaddrs.AbsProviderConfigInstance, tfdiags.Diagnostics, bool) {
+	var diags tfdiags.Diagnostics
+	var ret stackaddrs.AbsProviderConfigInstance
+
+	result, hclDiags := EvalExprAndEvalContext(ctx, expr, phase, c)
+	diags = diags.Append(hclDiags)
+	if hclDiags.HasErrors() {
+		return ret, diags, false
+	}
+	v := result.Value
+
+	// The first set of checks can perform a redundant check in some cases. For
+	// providers required by the configuration the type validation should have
+	// been performed by the static analysis. However, we'll repeat the checks
+	// here to also catch the case where providers are required by the existing
+	// state but are not defined in the configuration. This isn't checked by
+	// the static analysis.
+	const errSummary = "Invalid provider configuration"
+	if actualTy := result.Value.Type(); stackconfigtypes.IsProviderConfigType(actualTy) {
+		// Then we at least got a provider reference of some kind.
+		actualTypeAddr := stackconfigtypes.ProviderForProviderConfigType(actualTy)
+		if actualTypeAddr != sourceAddr.Provider {
+			// But, unfortunately, the underlying types of the providers
+			// do not match up.
+			diags = diags.Append(&hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  errSummary,
+				Detail: fmt.Sprintf(
+					"The provider configuration slot %s requires a configuration for provider %q, not for provider %q.",
+					componentAddr.StringCompact(), sourceAddr.Provider, actualTypeAddr,
+				),
+				Subject: result.Expression.Range().Ptr(),
+			})
+			return ret, diags, false
+		}
+	} else {
+		// We got something that isn't a provider reference at all.
+		diags = diags.Append(&hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  errSummary,
+			Detail: fmt.Sprintf(
+				"The provider configuration slot %s requires a configuration for provider %q.",
+				componentAddr.StringCompact(), sourceAddr.Provider,
+			),
+			Subject: result.Expression.Range().Ptr(),
+		})
+		return ret, diags, false
+	}
+
+	// Now, we differ from the static analysis in that we should have
+	// returned a concrete value while we may have got unknown during the
+	// static analysis.
+	if v.IsNull() {
+		diags = diags.Append(&hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  errSummary,
+			Detail: fmt.Sprintf(
+				"The provider configuration slot %s is required, but this definition returned null.",
+				componentAddr.StringCompact(),
+			),
+			Subject: result.Expression.Range().Ptr(),
+		})
+		return ret, diags, false
+	}
+	if !v.IsKnown() {
+		// TODO: Once we support deferred changes we should return
+		// something that lets the caller know the configuration is
+		// incomplete so it can defer planning the entire component.
+		diags = diags.Append(&hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  errSummary,
+			Detail: fmt.Sprintf(
+				"This expression depends on values that won't be known until the apply phase, so Terraform cannot determine which provider configuration to use while planning changes for %s.",
+				c.Addr().String(),
+			),
+			Subject: result.Expression.Range().Ptr(),
+		})
+		return ret, diags, false
+	}
+
+	// If it's of the correct type, known, and not null then we should
+	// be able to retrieve a specific provider instance address that
+	// this value refers to.
+	ret = stackconfigtypes.ProviderInstanceForValue(v)
+
+	// The reference must be to a provider instance that's actually
+	// configured.
+	providerInstStack := c.main.Stack(ctx, ret.Stack, phase)
+	if providerInstStack != nil {
+		provider := providerInstStack.Provider(ctx, ret.Item.ProviderConfig)
+		if provider != nil {
+			insts := provider.Instances(ctx, phase)
+			if insts == nil {
+				// If we get here then we don't yet know which instances
+				// this provider has, so we'll be optimistic that it'll
+				// show up in a later phase.
+				return ret, diags, true
+			}
+			if _, exists := insts[ret.Item.Key]; exists {
+				return ret, diags, true
+			}
+		}
+	}
+	// If we fall here then something on the path to the provider instance
+	// doesn't exist, and so effectively the provider instance doesn't exist.
+	diags = diags.Append(&hcl.Diagnostic{
+		Severity: hcl.DiagError,
+		Summary:  errSummary,
+		Detail: fmt.Sprintf(
+			"Expression result refers to undefined provider instance %s.",
+			ret,
+		),
+		Subject: result.Expression.Range().Ptr(),
+	})
+	return ret, diags, true
 }
 
 func (c *ComponentInstance) neededProviderSchemas(ctx context.Context) (map[addrs.Provider]providers.ProviderSchema, tfdiags.Diagnostics) {

--- a/internal/stacks/stackruntime/plan_test.go
+++ b/internal/stacks/stackruntime/plan_test.go
@@ -64,7 +64,14 @@ func TestPlan_valid(t *testing.T) {
 			req := PlanRequest{
 				Config: cfg,
 				ProviderFactories: map[addrs.Provider]providers.Factory{
+					// We support both hashicorp/testing and
+					// terraform.io/builtin/testing as providers. This lets us
+					// test the provider aliasing feature. Both providers
+					// support the same set of resources and data sources.
 					addrs.NewDefaultProvider("testing"): func() (providers.Interface, error) {
+						return stacks_testing_provider.NewProvider(), nil
+					},
+					addrs.NewBuiltInProvider("testing"): func() (providers.Interface, error) {
 						return stacks_testing_provider.NewProvider(), nil
 					},
 				},
@@ -138,7 +145,14 @@ func TestPlan_invalid(t *testing.T) {
 			req := PlanRequest{
 				Config: cfg,
 				ProviderFactories: map[addrs.Provider]providers.Factory{
+					// We support both hashicorp/testing and
+					// terraform.io/builtin/testing as providers. This lets us
+					// test the provider aliasing feature. Both providers
+					// support the same set of resources and data sources.
 					addrs.NewDefaultProvider("testing"): func() (providers.Interface, error) {
+						return stacks_testing_provider.NewProvider(), nil
+					},
+					addrs.NewBuiltInProvider("testing"): func() (providers.Interface, error) {
 						return stacks_testing_provider.NewProvider(), nil
 					},
 				},

--- a/internal/stacks/stackruntime/testdata/mainbundle/test/with-single-input/valid/valid.tfstack.hcl
+++ b/internal/stacks/stackruntime/testdata/mainbundle/test/with-single-input/valid/valid.tfstack.hcl
@@ -1,8 +1,5 @@
 required_providers {
   testing = {
-    source  = "terraform.io/builtin/testing"
-  }
-  external = {
     source  = "hashicorp/testing"
     version = "0.1.0"
   }
@@ -18,7 +15,6 @@ component "self" {
   source = "../"
 
   providers = {
-    // Everything looks okay here, but the provider types are actually wrong.
     testing = provider.testing.default
   }
 

--- a/internal/terraform/providers.go
+++ b/internal/terraform/providers.go
@@ -31,7 +31,7 @@ func checkExternalProviders(rootCfg *configs.Config, got map[addrs.RootProviderC
 	for _, addr := range rootCfg.ProviderTypes() {
 		allowedProviders[addr] = struct{}{}
 	}
-	requiredConfigs := rootCfg.EffectiveRequiredProviderConfigs()
+	requiredConfigs := rootCfg.EffectiveRequiredProviderConfigs().Keys()
 
 	// Passed-in provider configurations can only be for providers that this
 	// configuration actually contains some use of.


### PR DESCRIPTION
Currently, stacks resolves provider types entirely by doing reverse look ups against the local name of the provider within the stack configuration. It then tries to resolve the provider map within components by looking up the provider entries by that local name. There is no guarantee that the local names between the component configs and the stack configs will match up.

This PR makes the `RequiredProviderInstances` lookup function also return the `LocalProviderConfig` address. This means we can look up the local name for the required provider in the stack configuration separately to resolving the local name within the component configuration.

We also expand the static analysis so that it checks the type of the returned references (to make sure they are referencing providers). The dynamic analysis now doesn't repeat the same set of checks as the static analysis, with the providers required by the state processed separately to the configuration providers.