### PR TITLE
try to render some changes between `""` and `null`

### DIFF
--- a/internal/command/jsonformat/differ/attribute.go
+++ b/internal/command/jsonformat/differ/attribute.go
@@ -44,6 +44,18 @@ func computeDiffForNestedAttribute(change structured.Change, nested *jsonprovide
 }
 
 func ComputeDiffForType(change structured.Change, ctype cty.Type) computed.Diff {
+	if !change.NonLegacySchema {
+		// Empty strings in blocks should be considered null, because the legacy
+		// SDK can't always differentiate between null and empty strings and may
+		// return either.
+		if before, ok := change.Before.(string); ok && len(before) == 0 {
+			change.Before = nil
+		}
+		if after, ok := change.After.(string); ok && len(after) == 0 {
+			change.After = nil
+		}
+	}
+
 	if sensitive, ok := checkForSensitiveType(change, ctype); ok {
 		return sensitive
 	}

--- a/internal/command/jsonformat/structured/change.go
+++ b/internal/command/jsonformat/structured/change.go
@@ -90,6 +90,14 @@ type Change struct {
 	// that we should display. Any element/attribute not matched by this Matcher
 	// should be skipped.
 	RelevantAttributes attribute_path.Matcher
+
+	// NonLegacySchema must only be used when rendering the change to the CLI,
+	// and is otherwise ignored. This flag is set when we can be sure that the
+	// change originated from a resource which is not using the legacy SDK, so
+	// we don't need to hide changes between empty and null strings.
+	// NonLegacySchema is only switched to true by the renderer, because that is
+	// where we have most of the schema information to detect the condition.
+	NonLegacySchema bool
 }
 
 // FromJsonChange unmarshals the raw []byte values in the jsonplan.Change

--- a/internal/command/jsonformat/structured/map.go
+++ b/internal/command/jsonformat/structured/map.go
@@ -33,6 +33,10 @@ type ChangeMap struct {
 
 	// RelevantAttributes matches the same attributes in Change exactly.
 	RelevantAttributes attribute_path.Matcher
+
+	// this reflects the parent NonLegacyValue, so that any behavior is
+	// automatically inherited into child changes.
+	nonLegacySchema bool
 }
 
 // AsMap converts the Change into an object or map representation by converting
@@ -47,6 +51,7 @@ func (change Change) AsMap() ChangeMap {
 		AfterSensitive:     genericToMap(change.AfterSensitive),
 		ReplacePaths:       change.ReplacePaths,
 		RelevantAttributes: change.RelevantAttributes,
+		nonLegacySchema:    change.NonLegacySchema,
 	}
 }
 
@@ -69,6 +74,7 @@ func (m ChangeMap) GetChild(key string) Change {
 		AfterSensitive:     afterSensitive,
 		ReplacePaths:       m.ReplacePaths.GetChildWithKey(key),
 		RelevantAttributes: m.RelevantAttributes.GetChildWithKey(key),
+		NonLegacySchema:    m.nonLegacySchema,
 	}
 }
 


### PR DESCRIPTION
Changes between empty strings and `null` were hidden in the CLI output, because the SDK could not reliably detect the difference and may return either value depending on the situation.

This legacy behavior can be confusing for authors of new providers which can correctly handle `null`, and it would be preferable to be able to render those changes in the CLI.

While we don't have enough information to detect when the legacy behavior is required, we can detect a number of cases where it's certain that we are not dealing with a legacy schema and should output the full diff:

 - Anything with nested structural attributes
 - Blocks of type NestingMap and NestingGroup
 - Dynamic types

While this cannot solve all issues when the resource only uses primitive types, like with `random_password` in #31887, it would for example solve the `terraform_data` example because of it's use of `DynamicPseudoType`.