### PR TITLE
Modify provider dev override warning to include a remote backend specific line

### DIFF
--- a/internal/command/apply.go
+++ b/internal/command/apply.go
@@ -260,8 +260,12 @@ func (c *ApplyCommand) OperationRequest(
 	// Applying changes with dev overrides in effect could make it impossible
 	// to switch back to a release version if the schema isn't compatible,
 	// so we'll warn about it.
-	_, isRemoteBackend := be.(BackendWithRemoteTerraformVersion)
-	diags = diags.Append(c.providerDevOverrideRuntimeWarnings(isRemoteBackend))
+	b, isRemoteBackend := be.(BackendWithRemoteTerraformVersion)
+	if isRemoteBackend && !b.IsLocalOperations() {
+		diags = diags.Append(c.providerDevOverrideRuntimeWarningsRemoteExecution())
+	} else {
+		diags = diags.Append(c.providerDevOverrideRuntimeWarnings())
+	}
 
 	// Build the operation
 	opReq := c.Operation(be, viewType)

--- a/internal/command/apply.go
+++ b/internal/command/apply.go
@@ -260,7 +260,8 @@ func (c *ApplyCommand) OperationRequest(
 	// Applying changes with dev overrides in effect could make it impossible
 	// to switch back to a release version if the schema isn't compatible,
 	// so we'll warn about it.
-	diags = diags.Append(c.providerDevOverrideRuntimeWarnings())
+	_, isRemoteBackend := be.(BackendWithRemoteTerraformVersion)
+	diags = diags.Append(c.providerDevOverrideRuntimeWarnings(isRemoteBackend))
 
 	// Build the operation
 	opReq := c.Operation(be, viewType)

--- a/internal/command/meta_providers.go
+++ b/internal/command/meta_providers.go
@@ -198,7 +198,7 @@ func (m *Meta) providerDevOverrideInitWarnings() tfdiags.Diagnostics {
 //
 // See providerDevOverrideInitWarnings for warnings specific to the init
 // command.
-func (m *Meta) providerDevOverrideRuntimeWarnings(backendIsRemote bool) tfdiags.Diagnostics {
+func (m *Meta) providerDevOverrideRuntimeWarnings() tfdiags.Diagnostics {
 	if len(m.ProviderDevOverrides) == 0 {
 		return nil
 	}
@@ -208,9 +208,35 @@ func (m *Meta) providerDevOverrideRuntimeWarnings(backendIsRemote bool) tfdiags.
 		detailMsg.WriteString(fmt.Sprintf(" - %s in %s\n", addr.ForDisplay(), path))
 	}
 	detailMsg.WriteString("\nThe behavior may therefore not match any released version of the provider and applying changes may cause the state to become incompatible with published releases.")
-	if backendIsRemote {
-		detailMsg.WriteString("\n\nNote that provider development overrides have only been configured locally and the remote operation won't be affected by them")
+	return tfdiags.Diagnostics{
+		tfdiags.Sourceless(
+			tfdiags.Warning,
+			"Provider development overrides are in effect",
+			detailMsg.String(),
+		),
 	}
+}
+
+// providerDevOverrideRuntimeWarningsRemoteExecution returns a diagnostics that contains at
+// least one warning if and only if there is at least one provider development
+// override in effect. If not, the result is always empty. The result never
+// contains error diagnostics.
+//
+// Certain commands when executing remotely can use this to include a warning that any provider overrides
+// are only locally configured, meaning the remote operation won't be affected by them.
+//
+// See providerDevOverrideRuntimeWarnings for runtime warnings specific to local execution
+func (m *Meta) providerDevOverrideRuntimeWarningsRemoteExecution() tfdiags.Diagnostics {
+	if len(m.ProviderDevOverrides) == 0 {
+		return nil
+	}
+	var detailMsg strings.Builder
+	detailMsg.WriteString("The following provider development overrides are set in the CLI configuration:\n")
+	for addr, path := range m.ProviderDevOverrides {
+		detailMsg.WriteString(fmt.Sprintf(" - %s in %s\n", addr.ForDisplay(), path))
+	}
+	detailMsg.WriteString("\n\nProvider development overrides are only configured locally and the remote operation won't be affected by them")
+
 	return tfdiags.Diagnostics{
 		tfdiags.Sourceless(
 			tfdiags.Warning,

--- a/internal/command/meta_providers.go
+++ b/internal/command/meta_providers.go
@@ -198,7 +198,7 @@ func (m *Meta) providerDevOverrideInitWarnings() tfdiags.Diagnostics {
 //
 // See providerDevOverrideInitWarnings for warnings specific to the init
 // command.
-func (m *Meta) providerDevOverrideRuntimeWarnings() tfdiags.Diagnostics {
+func (m *Meta) providerDevOverrideRuntimeWarnings(backendIsRemote bool) tfdiags.Diagnostics {
 	if len(m.ProviderDevOverrides) == 0 {
 		return nil
 	}
@@ -208,6 +208,9 @@ func (m *Meta) providerDevOverrideRuntimeWarnings() tfdiags.Diagnostics {
 		detailMsg.WriteString(fmt.Sprintf(" - %s in %s\n", addr.ForDisplay(), path))
 	}
 	detailMsg.WriteString("\nThe behavior may therefore not match any released version of the provider and applying changes may cause the state to become incompatible with published releases.")
+	if backendIsRemote {
+		detailMsg.WriteString("\n\nNote that provider development overrides have only been configured locally and the remote operation won't be affected by them")
+	}
 	return tfdiags.Diagnostics{
 		tfdiags.Sourceless(
 			tfdiags.Warning,

--- a/internal/command/meta_providers.go
+++ b/internal/command/meta_providers.go
@@ -235,7 +235,7 @@ func (m *Meta) providerDevOverrideRuntimeWarningsRemoteExecution() tfdiags.Diagn
 	for addr, path := range m.ProviderDevOverrides {
 		detailMsg.WriteString(fmt.Sprintf(" - %s in %s\n", addr.ForDisplay(), path))
 	}
-	detailMsg.WriteString("\n\nProvider development overrides are only configured locally and the remote operation won't be affected by them")
+	detailMsg.WriteString("\nProvider development overrides are only configured locally and the remote operation won't be affected by them")
 
 	return tfdiags.Diagnostics{
 		tfdiags.Sourceless(

--- a/internal/command/plan.go
+++ b/internal/command/plan.go
@@ -66,8 +66,12 @@ func (c *PlanCommand) Run(rawArgs []string) int {
 
 	// Prepare the backend with the backend-specific arguments
 	be, beDiags := c.PrepareBackend(args.State, args.ViewType)
-	_, isRemoteBackend := be.(BackendWithRemoteTerraformVersion)
-	diags = diags.Append(c.providerDevOverrideRuntimeWarnings(isRemoteBackend))
+	b, isRemoteBackend := be.(BackendWithRemoteTerraformVersion)
+	if isRemoteBackend && !b.IsLocalOperations() {
+		diags = diags.Append(c.providerDevOverrideRuntimeWarningsRemoteExecution())
+	} else {
+		diags = diags.Append(c.providerDevOverrideRuntimeWarnings())
+	}
 	diags = diags.Append(beDiags)
 	if diags.HasErrors() {
 		view.Diagnostics(diags)

--- a/internal/command/plan.go
+++ b/internal/command/plan.go
@@ -64,10 +64,10 @@ func (c *PlanCommand) Run(rawArgs []string) int {
 	// object state for now.
 	c.Meta.parallelism = args.Operation.Parallelism
 
-	diags = diags.Append(c.providerDevOverrideRuntimeWarnings())
-
 	// Prepare the backend with the backend-specific arguments
 	be, beDiags := c.PrepareBackend(args.State, args.ViewType)
+	_, isRemoteBackend := be.(BackendWithRemoteTerraformVersion)
+	diags = diags.Append(c.providerDevOverrideRuntimeWarnings(isRemoteBackend))
 	diags = diags.Append(beDiags)
 	if diags.HasErrors() {
 		view.Diagnostics(diags)

--- a/internal/command/validate.go
+++ b/internal/command/validate.go
@@ -61,7 +61,7 @@ func (c *ValidateCommand) Run(rawArgs []string) int {
 	// not be valid for a stable release, so we'll warn about that in case
 	// the user is trying to use "terraform validate" as a sort of pre-flight
 	// check before submitting a change.
-	diags = diags.Append(c.providerDevOverrideRuntimeWarnings())
+	diags = diags.Append(c.providerDevOverrideRuntimeWarnings(false))
 
 	return view.Results(diags)
 }

--- a/internal/command/validate.go
+++ b/internal/command/validate.go
@@ -61,7 +61,7 @@ func (c *ValidateCommand) Run(rawArgs []string) int {
 	// not be valid for a stable release, so we'll warn about that in case
 	// the user is trying to use "terraform validate" as a sort of pre-flight
 	// check before submitting a change.
-	diags = diags.Append(c.providerDevOverrideRuntimeWarnings(false))
+	diags = diags.Append(c.providerDevOverrideRuntimeWarnings())
 
 	return view.Results(diags)
 }


### PR DESCRIPTION
[JIRA Ticket](https://hashicorp.atlassian.net/browse/TF-3325)

Adds a remote specific line to the warning associated with plan and apply operations using provider overrides in the CLI config when a remote backend is being used. 

#### WITH a Remote Backend
![Screenshot 2024-03-04 at 10 46 34 AM](https://github.com/hashicorp/terraform/assets/72527044/a01f378e-d43f-4dff-9e0c-5ec0657885d3)


#### WITHOUT a Remote Backend

also how it was previously in either case
![Screenshot 2024-02-28 at 5 44 30 PM](https://github.com/hashicorp/terraform/assets/72527044/9e703df6-7f00-4f5e-a28e-9eb8f78161fc)


###  ENHANCEMENTS

<!--

Write a short description of the user-facing change. Examples:

- `terraform show -json`: Fixed crash with sensitive set values.
- When rendering a diff, Terraform now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 

-  Modified provider developer override warning to include remote specific warning when a remote backend is being used
