### PR TITLE
Change workspace list indicator from asterisk to greater-than symbol

### DIFF
--- a/internal/command/workspace_command_test.go
+++ b/internal/command/workspace_command_test.go
@@ -104,7 +104,7 @@ func TestWorkspace_createAndList(t *testing.T) {
 	}
 
 	actual := strings.TrimSpace(ui.OutputWriter.String())
-	expected := "default\n  test_a\n  test_b\n* test_c"
+	expected := "default\n  test_a\n  test_b\n> test_c"
 
 	if actual != expected {
 		t.Fatalf("\nexpected: %q\nactual:  %q", expected, actual)
@@ -211,7 +211,7 @@ func TestWorkspace_createInvalid(t *testing.T) {
 	}
 
 	actual := strings.TrimSpace(ui.OutputWriter.String())
-	expected := "* default"
+	expected := "> default"
 
 	if actual != expected {
 		t.Fatalf("\nexpected: %q\nactual:  %q", expected, actual)

--- a/internal/command/workspace_list.go
+++ b/internal/command/workspace_list.go
@@ -68,7 +68,7 @@ func (c *WorkspaceListCommand) Run(args []string) int {
 	var out bytes.Buffer
 	for _, s := range states {
 		if s == env {
-			out.WriteString("* ")
+			out.WriteString("> ")
 		} else {
 			out.WriteString("  ")
 		}


### PR DESCRIPTION
### ENHANCEMENTS

This PR proposition updates the visual indicator for the current workspace in the workspace list command output. 

The asterisk (*) has been replaced with a greater-than symbol (>) to denote the active workspace and prevent unwanted behavior from wildcard symbol. 

This change is reflected in both the workspace command tests and the workspace list command implementation.

### Current

When you call `workspace list` argument, you have an output with your current workspace selected with `*` symbol like this : 
```shell
$ terraform workspace list
  * default
 ```

If you want to iterate over the output you will have an issue because of the wildcard.
```shell
$ for i in $(terraform workspace list) ; do echo -ne "$i" ; done
default main.tf api.tf modules README.md terraform.tfvars.example test.tfvars variables.tf default test
```

We can see here that during the iteration, the for made a `echo *` because of the wildcard and print the files in the current directory.

### Bypassing

To make it work, we have to add a sed command to remove the character.
```shell
for i in $(terraform workspace list | sed 's/*//g'); do echo "$i"; done
default
```

### Proposition

Replace `*` by `>` (or whatever character that is not a wildcard) so we can simply do :
```shell
for i in $(terraform workspace list) ; do echo -ne "$i" ; done
>
default
```
Now even if `>` char is present, we do not have unwanted behavior with wildcard substitution when piping.

That would be much more easier for shell programming (for eg) to parse output without bad surprise.