### PR TITLE
Basic support for provisioners in "removed" blocks

### DIFF
--- a/internal/configs/experiments.go
+++ b/internal/configs/experiments.go
@@ -235,5 +235,18 @@ func checkModuleExperiments(m *Module) hcl.Diagnostics {
 		}
 	*/
 
+	if !m.ActiveExperiments.Has(experiments.RemovedProvisioners) {
+		for _, c := range m.Removed {
+			if c.Managed != nil && (c.Managed.Connection != nil || len(c.Managed.Provisioners) > 0) {
+				diags = append(diags, &hcl.Diagnostic{
+					Severity: hcl.DiagError,
+					Summary:  "Provisioners for removed resources are experimental",
+					Detail:   "This feature is currently an opt-in experiment, subject to change in future releases based on feedback.\n\nActivate the feature for this module by adding removed_provisioners to the list of active experiments.",
+					Subject:  c.DeclRange.Ptr(),
+				})
+			}
+		}
+	}
+
 	return diags
 }

--- a/internal/configs/removed.go
+++ b/internal/configs/removed.go
@@ -4,6 +4,8 @@
 package configs
 
 import (
+	"fmt"
+
 	"github.com/hashicorp/terraform/internal/addrs"
 
 	"github.com/hashicorp/hcl/v2"
@@ -19,6 +21,12 @@ type Removed struct {
 	// from state. Defaults to true.
 	Destroy bool
 
+	// Managed captures a number of metadata fields that are applicable only
+	// for managed resources, and not for other resource modes.
+	//
+	// "removed" blocks support only a subset of the fields in [ManagedResource].
+	Managed *ManagedResource
+
 	DeclRange hcl.Range
 }
 
@@ -31,6 +39,8 @@ func decodeRemovedBlock(block *hcl.Block) (*Removed, hcl.Diagnostics) {
 	content, moreDiags := block.Body.Content(removedBlockSchema)
 	diags = append(diags, moreDiags...)
 
+	var targetKind addrs.RemoveTargetKind
+	var resourceMode addrs.ResourceMode // only valid if targetKind is addrs.RemoveTargetResource
 	if attr, exists := content.Attributes["from"]; exists {
 		from, traversalDiags := hcl.AbsTraversalForExpr(attr.Expr)
 		diags = append(diags, traversalDiags...)
@@ -38,11 +48,21 @@ func decodeRemovedBlock(block *hcl.Block) (*Removed, hcl.Diagnostics) {
 			from, fromDiags := addrs.ParseRemoveTarget(from)
 			diags = append(diags, fromDiags.ToHCL()...)
 			removed.From = from
+			if removed.From != nil {
+				targetKind = removed.From.ObjectKind()
+				if targetKind == addrs.RemoveTargetResource {
+					resourceMode = removed.From.RelSubject.(addrs.ConfigResource).Resource.Mode
+				}
+			}
 		}
 	}
 
 	removed.Destroy = true
+	if resourceMode == addrs.ManagedResourceMode {
+		removed.Managed = &ManagedResource{}
+	}
 
+	var seenConnection *hcl.Block
 	for _, block := range content.Blocks {
 		switch block.Type {
 		case "lifecycle":
@@ -52,6 +72,61 @@ func decodeRemovedBlock(block *hcl.Block) (*Removed, hcl.Diagnostics) {
 			if attr, exists := lcContent.Attributes["destroy"]; exists {
 				valDiags := gohcl.DecodeExpression(attr.Expr, nil, &removed.Destroy)
 				diags = append(diags, valDiags...)
+			}
+
+		case "connection":
+			if removed.Managed == nil {
+				// target is not a managed resource, then
+				diags = append(diags, &hcl.Diagnostic{
+					Severity: hcl.DiagError,
+					Summary:  "Invalid connection block",
+					Detail:   "Provisioner connection configuration is valid only when a removed block targets a managed resource.",
+					Subject:  &block.DefRange,
+				})
+				continue
+			}
+
+			if seenConnection != nil {
+				diags = append(diags, &hcl.Diagnostic{
+					Severity: hcl.DiagError,
+					Summary:  "Duplicate connection block",
+					Detail:   fmt.Sprintf("This \"removed\" block already has a connection block at %s.", seenConnection.DefRange),
+					Subject:  &block.DefRange,
+				})
+				continue
+			}
+			seenConnection = block
+
+			removed.Managed.Connection = &Connection{
+				Config:    block.Body,
+				DeclRange: block.DefRange,
+			}
+
+		case "provisioner":
+			if removed.Managed == nil {
+				// target is not a managed resource, then
+				diags = append(diags, &hcl.Diagnostic{
+					Severity: hcl.DiagError,
+					Summary:  "Invalid provisioner block",
+					Detail:   "Provisioners are valid only when a removed block targets a managed resource.",
+					Subject:  &block.DefRange,
+				})
+				continue
+			}
+
+			pv, pvDiags := decodeProvisionerBlock(block)
+			diags = append(diags, pvDiags...)
+			if pv != nil {
+				removed.Managed.Provisioners = append(removed.Managed.Provisioners, pv)
+
+				if pv.When != ProvisionerWhenDestroy {
+					diags = append(diags, &hcl.Diagnostic{
+						Severity: hcl.DiagError,
+						Summary:  "Invalid provisioner block",
+						Detail:   "Only destroy-time provisioners are valid in \"removed\" blocks. To declare a destroy-time provisioner, use:\n    when = destroy",
+						Subject:  &block.DefRange,
+					})
+				}
 			}
 		}
 	}
@@ -67,9 +142,9 @@ var removedBlockSchema = &hcl.BodySchema{
 		},
 	},
 	Blocks: []hcl.BlockHeaderSchema{
-		{
-			Type: "lifecycle",
-		},
+		{Type: "lifecycle"},
+		{Type: "connection"},
+		{Type: "provisioner", LabelNames: []string{"type"}},
 	},
 }
 

--- a/internal/experiments/experiment.go
+++ b/internal/experiments/experiment.go
@@ -16,6 +16,7 @@ type Experiment string
 // Each experiment is represented by a string that must be a valid HCL
 // identifier so that it can be specified in configuration.
 const (
+	RemovedProvisioners            = Experiment("removed_provisioners")
 	VariableValidation             = Experiment("variable_validation")
 	ModuleVariableOptionalAttrs    = Experiment("module_variable_optional_attrs")
 	SuppressProviderSensitiveAttrs = Experiment("provider_sensitive_attrs")
@@ -27,6 +28,7 @@ const (
 func init() {
 	// Each experiment constant defined above must be registered here as either
 	// a current or a concluded experiment.
+	registerCurrentExperiment(RemovedProvisioners)
 	registerCurrentExperiment(UnknownInstances)
 	registerConcludedExperiment(VariableValidation, "Custom variable validation can now be used by default, without enabling an experiment.")
 	registerConcludedExperiment(SuppressProviderSensitiveAttrs, "Provider-defined sensitive attributes are now redacted by default, without enabling an experiment.")

--- a/internal/terraform/node_resource_abstract.go
+++ b/internal/terraform/node_resource_abstract.go
@@ -56,7 +56,11 @@ type NodeAbstractResource struct {
 
 	Schema        *configschema.Block // Schema for processing the configuration body
 	SchemaVersion uint64              // Schema version of "Schema", as decided by the provider
-	Config        *configs.Resource   // Config is the resource in the config
+
+	// Config and RemovedConfig are mutally-exclusive, because a
+	// resource can't be both declared and removed at the same time.
+	Config        *configs.Resource // Config is the resource in the config, if any
+	RemovedConfig *configs.Removed  // RemovedConfig is the "removed" block for this resource, if any
 
 	// ProviderMetas is the provider_meta configs for the module this resource belongs to
 	ProviderMetas map[addrs.Provider]*configs.ProviderMeta
@@ -367,8 +371,9 @@ func (n *NodeAbstractResource) AttachDataResourceDependsOn(deps []addrs.ConfigRe
 }
 
 // GraphNodeAttachResourceConfig
-func (n *NodeAbstractResource) AttachResourceConfig(c *configs.Resource) {
+func (n *NodeAbstractResource) AttachResourceConfig(c *configs.Resource, rc *configs.Removed) {
 	n.Config = c
+	n.RemovedConfig = rc
 }
 
 // GraphNodeAttachResourceSchema impl

--- a/internal/terraform/node_resource_abstract_instance.go
+++ b/internal/terraform/node_resource_abstract_instance.go
@@ -2090,7 +2090,15 @@ func (n *NodeAbstractResourceInstance) evalApplyProvisioners(ctx EvalContext, st
 		return nil
 	}
 
-	provs := filterProvisioners(n.Config, when)
+	var allProvs []*configs.Provisioner
+	switch {
+	case n.Config != nil && n.Config.Managed != nil:
+		allProvs = n.Config.Managed.Provisioners
+	case n.RemovedConfig != nil && n.RemovedConfig.Managed != nil:
+		allProvs = n.RemovedConfig.Managed.Provisioners
+	}
+
+	provs := filterProvisioners(allProvs, when)
 	if len(provs) == 0 {
 		// We have no provisioners, so don't do anything
 		return nil
@@ -2120,18 +2128,13 @@ func (n *NodeAbstractResourceInstance) evalApplyProvisioners(ctx EvalContext, st
 
 // filterProvisioners filters the provisioners on the resource to only
 // the provisioners specified by the "when" option.
-func filterProvisioners(config *configs.Resource, when configs.ProvisionerWhen) []*configs.Provisioner {
-	// Fast path the zero case
-	if config == nil || config.Managed == nil {
+func filterProvisioners(configured []*configs.Provisioner, when configs.ProvisionerWhen) []*configs.Provisioner {
+	if len(configured) == 0 {
 		return nil
 	}
 
-	if len(config.Managed.Provisioners) == 0 {
-		return nil
-	}
-
-	result := make([]*configs.Provisioner, 0, len(config.Managed.Provisioners))
-	for _, p := range config.Managed.Provisioners {
+	result := make([]*configs.Provisioner, 0, len(configured))
+	for _, p := range configured {
 		if p.When == when {
 			result = append(result, p)
 		}
@@ -2160,8 +2163,11 @@ func (n *NodeAbstractResourceInstance) applyProvisioners(ctx EvalContext, state 
 	// then it'll serve as a base connection configuration for all of the
 	// provisioners.
 	var baseConn hcl.Body
-	if n.Config.Managed != nil && n.Config.Managed.Connection != nil {
+	switch {
+	case n.Config != nil && n.Config.Managed != nil && n.Config.Managed.Connection != nil:
 		baseConn = n.Config.Managed.Connection.Config
+	case n.RemovedConfig != nil && n.RemovedConfig.Managed != nil && n.RemovedConfig.Managed.Connection != nil:
+		baseConn = n.RemovedConfig.Managed.Connection.Config
 	}
 
 	for _, prov := range provs {

--- a/internal/terraform/testdata/apply-provisioner-destroy-removed/main.tf
+++ b/internal/terraform/testdata/apply-provisioner-destroy-removed/main.tf
@@ -1,0 +1,13 @@
+terraform {
+  # provisioners in removed blocks are currently only experimental
+  experiments = [removed_provisioners]
+}
+
+removed {
+  from = aws_instance.foo
+
+  provisioner "shell" {
+    when     = "destroy"
+    command  = "destroy ${each.key} ${self.foo}"
+  }
+}


### PR DESCRIPTION
During the apply phase, we'll check if there are provisioners either in the matching `resource` block or the matching `removed` block -- whichever of the two is present -- and execute the destroy-time subset of them either way.

This also establishes a standard way to attach a `removed` block to a `NodeResourceAbstract` when one is defined, which is likely to be useful for supporting other resource-related meta arguments in `removed` blocks in future.

```hcl
removed {
  from = aws_instance.example

  provisioner "local-exec" {
    # All provisioners must have when = destroy in this context,
    # because "removed" resources can only be destroyed.
    when = destroy

    # ...
  }
}
```

This code is currently accessible only to modules that opt in to the `removed_provisioners` language experiment, and therefore only available in alpha releases.

---

One known limitation and design question from this initial implementation is:

How should `each.key`, `each.value`, and `count.index` behave when used as part of a `provisioner` configuration in a `removed` block?

This is a tricky question because whereas a `resource` block allows us to determine from the configuration whether we're using `count`, `for_each`, or neither -- and treat invalid references as an error -- `removed` blocks must accept whatever happens to be in the state and so in unusual cases there might even be a mixture of numeric instance keys and string instance keys for the same resource, making it impossible to write a provisioner configuration that would work with both.

---

Other notes/questions for future work:

- Should it be invalid to combine a destroy-time provisioner with `destroy = false`? Or should that instead mean "run the provisioner just before forgetting the object"?
- Can we and should we provide a new command like `terraform rm aws_instance.example` that would automatically replace the `resource "aws_instance" "example"` block with a matching `removed` block, and copy over its destroy-time provisioners, to avoid the need to migrate them over manually?

---

This is motivated by https://github.com/hashicorp/terraform/issues/34711 and _part_ of https://github.com/hashicorp/terraform/issues/13549 .
