### PR TITLE
stackruntime: Apply defaults to root variables

### DIFF
--- a/internal/stacks/stackruntime/internal/stackeval/input_variable.go
+++ b/internal/stacks/stackruntime/internal/stackeval/input_variable.go
@@ -109,8 +109,34 @@ func (v *InputVariable) CheckValue(ctx context.Context, phase EvalPhase) (cty.Va
 
 			switch {
 			case v.Addr().Stack.IsRoot():
-				extVal := v.main.RootVariableValue(ctx, v.Addr().Item, phase)
 				wantTy := v.Declaration(ctx).Type.Constraint
+
+				extVal := v.main.RootVariableValue(ctx, v.Addr().Item, phase)
+
+				// If the calling context does not define a value for this
+				// variable, we need to fall back to the default.
+				if extVal.Value == cty.NilVal {
+					cfg := v.Config(ctx)
+
+					// A separate code path will validate the default value, so
+					// we don't need to do that here.
+					defVal := cfg.DefaultValue(ctx)
+					if defVal == cty.NilVal {
+						diags = diags.Append(&hcl.Diagnostic{
+							Severity: hcl.DiagError,
+							Summary:  "No value for required variable",
+							Detail:   fmt.Sprintf("The root input variable %q is not set, and has no default value.", v.Addr()),
+							Subject:  cfg.config.DeclRange.ToHCL().Ptr(),
+						})
+						return cty.UnknownVal(wantTy), diags
+					}
+
+					extVal = ExternalInputValue{
+						Value:    defVal,
+						DefRange: cfg.Declaration().DeclRange,
+					}
+				}
+
 				val, err := convert.Convert(extVal.Value, wantTy)
 				const errSummary = "Invalid value for root input variable"
 				if err != nil {

--- a/internal/stacks/stackruntime/internal/stackeval/input_variable.go
+++ b/internal/stacks/stackruntime/internal/stackeval/input_variable.go
@@ -113,9 +113,10 @@ func (v *InputVariable) CheckValue(ctx context.Context, phase EvalPhase) (cty.Va
 
 				extVal := v.main.RootVariableValue(ctx, v.Addr().Item, phase)
 
-				// If the calling context does not define a value for this
-				// variable, we need to fall back to the default.
-				if extVal.Value == cty.NilVal {
+				// We treat a null value as equivalent to an unspecified value,
+				// and replace it with the variable's default value. This is
+				// consistent with how embedded stacks handle defaults.
+				if extVal.Value.IsNull() {
 					cfg := v.Config(ctx)
 
 					// A separate code path will validate the default value, so

--- a/internal/stacks/stackruntime/internal/stackeval/main.go
+++ b/internal/stacks/stackruntime/internal/stackeval/main.go
@@ -455,11 +455,11 @@ func (m *Main) RootVariableValue(ctx context.Context, addr stackaddrs.InputVaria
 		ret, ok := m.planning.opts.InputVariableValues[addr]
 		if !ok {
 			// If no value is specified for the given input variable, we return
-			// a nil placeholder. Nil can never be specified, so the caller can
-			// determine that the variable's default value should be used (if
-			// present) or an error raised (if not).
+			// a null value. Callers should treat a null value as equivalent to
+			// an unspecified one, applying default (if present) or raising an
+			// error (if not).
 			return ExternalInputValue{
-				Value: cty.NilVal,
+				Value: cty.NullVal(cty.DynamicPseudoType),
 			}
 		}
 		return ret

--- a/internal/stacks/stackruntime/internal/stackeval/main.go
+++ b/internal/stacks/stackruntime/internal/stackeval/main.go
@@ -442,6 +442,10 @@ func (m *Main) PreviousProviderInstances(addr stackaddrs.AbsComponentInstance, p
 	}
 }
 
+// RootVariableValue returns the original root variable value specified by the
+// caller, if any. The caller of this function is responsible for replacing
+// missing values with defaults, and performing type conversion and and
+// validation.
 func (m *Main) RootVariableValue(ctx context.Context, addr stackaddrs.InputVariable, phase EvalPhase) ExternalInputValue {
 	switch phase {
 	case PlanPhase:
@@ -450,8 +454,12 @@ func (m *Main) RootVariableValue(ctx context.Context, addr stackaddrs.InputVaria
 		}
 		ret, ok := m.planning.opts.InputVariableValues[addr]
 		if !ok {
+			// If no value is specified for the given input variable, we return
+			// a nil placeholder. Nil can never be specified, so the caller can
+			// determine that the variable's default value should be used (if
+			// present) or an error raised (if not).
 			return ExternalInputValue{
-				Value: cty.NullVal(cty.DynamicPseudoType),
+				Value: cty.NilVal,
 			}
 		}
 		return ret

--- a/internal/stacks/stackruntime/testdata/mainbundle/test/plan-no-value-for-required-variable/unset-variable.tfstack.hcl
+++ b/internal/stacks/stackruntime/testdata/mainbundle/test/plan-no-value-for-required-variable/unset-variable.tfstack.hcl
@@ -1,0 +1,3 @@
+variable "beep" {
+  type = string
+}

--- a/internal/stacks/stackruntime/testdata/mainbundle/test/plan-variable-defaults/child/child.tfstack.hcl
+++ b/internal/stacks/stackruntime/testdata/mainbundle/test/plan-variable-defaults/child/child.tfstack.hcl
@@ -1,0 +1,9 @@
+variable "boop" {
+  type    = string
+  default = "BOOP"
+}
+
+output "result" {
+  type  = string
+  value = var.boop
+}

--- a/internal/stacks/stackruntime/testdata/mainbundle/test/plan-variable-defaults/deployments.tfdeploy.hcl
+++ b/internal/stacks/stackruntime/testdata/mainbundle/test/plan-variable-defaults/deployments.tfdeploy.hcl
@@ -1,0 +1,3 @@
+deployment "main" {
+  inputs = {}
+}

--- a/internal/stacks/stackruntime/testdata/mainbundle/test/plan-variable-defaults/plan-variable-default.tfstack.hcl
+++ b/internal/stacks/stackruntime/testdata/mainbundle/test/plan-variable-defaults/plan-variable-default.tfstack.hcl
@@ -1,0 +1,31 @@
+variable "beep" {
+  type    = string
+  default = "BEEP"
+}
+
+output "beep" {
+  type  = string
+  value = var.beep
+}
+
+stack "specified" {
+  source = "./child"
+  inputs = {
+    boop = var.beep
+  }
+}
+
+stack "defaulted" {
+  source = "./child"
+  inputs = {}
+}
+
+output "specified" {
+  type = string
+  value = stack.specified.result
+}
+
+output "defaulted" {
+  type = string
+  value = stack.defaulted.result
+}

--- a/internal/stacks/stackruntime/validate_test.go
+++ b/internal/stacks/stackruntime/validate_test.go
@@ -38,6 +38,7 @@ var (
 	// validConfigurations are shared between the validate and plan tests.
 	validConfigurations = map[string]validateTestInput{
 		"empty":                            {},
+		"plan-variable-defaults":           {},
 		"variable-output-roundtrip":        {},
 		"variable-output-roundtrip-nested": {},
 		filepath.Join("with-single-input", "input-from-component"): {},

--- a/internal/stacks/stackruntime/validate_test.go
+++ b/internal/stacks/stackruntime/validate_test.go
@@ -50,8 +50,16 @@ var (
 				}),
 			},
 		},
-		filepath.Join("with-single-input", "provider-name-clash"): {},
-		filepath.Join("with-single-input", "valid"):               {},
+		filepath.Join("with-single-input", "provider-name-clash"): {
+			planInputVars: map[string]cty.Value{
+				"input": cty.StringVal("input"),
+			},
+		},
+		filepath.Join("with-single-input", "valid"): {
+			planInputVars: map[string]cty.Value{
+				"input": cty.StringVal("input"),
+			},
+		},
 	}
 
 	// invalidConfigurations are shared between the validate and plan tests.


### PR DESCRIPTION
When evaluating a stack's root input variables, supplied by the caller, we must apply any default values specified in the variable configuration for variables with no specified value. This commit adds this default fallback case, using NilVal as a marker indicating the lack of a specified value.

If no default value exists for a variable, it is therefore required to be supplied by the caller. This commit also reports a diagnostic error in this case.

## Target Release

1.8.x
