### PR TITLE
go.mod: Eliminate github.com/apparentlymart/go-dump

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,6 @@ require (
 	github.com/aliyun/aliyun-oss-go-sdk v0.0.0-20190103054945-8205d1f41e70
 	github.com/aliyun/aliyun-tablestore-go-sdk v4.1.2+incompatible
 	github.com/apparentlymart/go-cidr v1.1.0
-	github.com/apparentlymart/go-dump v0.0.0-20190214190832-042adf3cf4a0
 	github.com/apparentlymart/go-shquot v0.0.1
 	github.com/apparentlymart/go-userdirs v0.0.0-20200915174352-b0c018a67c13
 	github.com/apparentlymart/go-versions v1.0.1

--- a/go.sum
+++ b/go.sum
@@ -279,8 +279,8 @@ github.com/antchfx/xpath v1.1.10/go.mod h1:Yee4kTMuNiPYJ7nSNorELQMr1J33uOpXDMByN
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/apparentlymart/go-cidr v1.1.0 h1:2mAhrMoF+nhXqxTzSZMUzDHkLjmIHC+Zzn4tdgBZjnU=
 github.com/apparentlymart/go-cidr v1.1.0/go.mod h1:EBcsNrHc3zQeuaeCeCtQruQm+n9/YjEn/vI25Lg7Gwc=
-github.com/apparentlymart/go-dump v0.0.0-20190214190832-042adf3cf4a0 h1:MzVXffFUye+ZcSR6opIgz9Co7WcDx6ZcY+RjfFHoA0I=
-github.com/apparentlymart/go-dump v0.0.0-20190214190832-042adf3cf4a0/go.mod h1:oL81AME2rN47vu18xqj1S1jPIPuN7afo62yKTNn3XMM=
+github.com/apparentlymart/go-dump v0.0.0-20180507223929-23540a00eaa3 h1:ZSTrOEhiM5J5RFxEaFvMZVEAM1KvT1YzbEOwB2EAGjA=
+github.com/apparentlymart/go-dump v0.0.0-20180507223929-23540a00eaa3/go.mod h1:oL81AME2rN47vu18xqj1S1jPIPuN7afo62yKTNn3XMM=
 github.com/apparentlymart/go-shquot v0.0.1 h1:MGV8lwxF4zw75lN7e0MGs7o6AFYn7L6AZaExUpLh0Mo=
 github.com/apparentlymart/go-shquot v0.0.1/go.mod h1:lw58XsE5IgUXZ9h0cxnypdx31p9mPFIVEQ9P3c7MlrU=
 github.com/apparentlymart/go-textseg/v15 v15.0.0 h1:uYvfpb3DyLSCGWnctWKGj857c6ew1u1fNQOlOtuGxQY=

--- a/internal/builtin/providers/terraform/data_source_state_test.go
+++ b/internal/builtin/providers/terraform/data_source_state_test.go
@@ -8,12 +8,14 @@ import (
 	"log"
 	"testing"
 
-	"github.com/apparentlymart/go-dump/dump"
+	"github.com/google/go-cmp/cmp"
+	"github.com/zclconf/go-cty-debug/ctydebug"
+	"github.com/zclconf/go-cty/cty"
+
 	"github.com/hashicorp/terraform/internal/backend"
 	"github.com/hashicorp/terraform/internal/configs/configschema"
 	"github.com/hashicorp/terraform/internal/states/statemgr"
 	"github.com/hashicorp/terraform/internal/tfdiags"
-	"github.com/zclconf/go-cty/cty"
 )
 
 func TestResource(t *testing.T) {
@@ -276,7 +278,13 @@ func TestState_basic(t *testing.T) {
 				"backend": cty.StringVal("local"),
 				"config":  cty.NullVal(cty.DynamicPseudoType),
 			}),
-			cty.NilVal,
+			cty.ObjectVal(map[string]cty.Value{
+				"backend":   cty.StringVal("local"),
+				"config":    cty.NullVal(cty.DynamicPseudoType),
+				"defaults":  cty.NullVal(cty.DynamicPseudoType),
+				"outputs":   cty.EmptyObjectVal,
+				"workspace": cty.NullVal(cty.String),
+			}),
 			true,
 		},
 	}
@@ -305,8 +313,8 @@ func TestState_basic(t *testing.T) {
 				t.Fatalf("unexpected errors: %s", diags.Err())
 			}
 
-			if test.Want != cty.NilVal && !test.Want.RawEquals(got) {
-				t.Errorf("wrong result\nconfig: %sgot:    %swant:   %s", dump.Value(config), dump.Value(got), dump.Value(test.Want))
+			if diff := cmp.Diff(test.Want, got, ctydebug.CmpOptions); diff != "" {
+				t.Errorf("wrong result\n%s", diff)
 			}
 		})
 	}

--- a/internal/configs/configschema/decoder_spec_test.go
+++ b/internal/configs/configschema/decoder_spec_test.go
@@ -7,13 +7,12 @@ import (
 	"sort"
 	"testing"
 
-	"github.com/apparentlymart/go-dump/dump"
 	"github.com/davecgh/go-spew/spew"
 	"github.com/google/go-cmp/cmp"
-
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hcldec"
 	"github.com/hashicorp/hcl/v2/hcltest"
+	"github.com/zclconf/go-cty-debug/ctydebug"
 	"github.com/zclconf/go-cty/cty"
 )
 
@@ -410,9 +409,9 @@ func TestBlockDecoderSpec(t *testing.T) {
 				}
 			}
 
-			if !got.RawEquals(test.Want) {
-				t.Logf("[INFO] implied schema is %s", spew.Sdump(hcldec.ImpliedSchema(spec)))
-				t.Errorf("wrong result\ngot:  %s\nwant: %s", dump.Value(got), dump.Value(test.Want))
+			if diff := cmp.Diff(test.Want, got, ctydebug.CmpOptions); diff != "" {
+				t.Logf("implied schema is %s", spew.Sdump(hcldec.ImpliedSchema(spec)))
+				t.Errorf("wrong result\n%s", diff)
 			}
 
 			// Double-check that we're producing consistent results for DecoderSpec
@@ -852,9 +851,9 @@ func TestAttributeDecoderSpec(t *testing.T) {
 				}
 			}
 
-			if !got.RawEquals(test.Want) {
-				t.Logf("[INFO] implied schema is %s", spew.Sdump(hcldec.ImpliedSchema(spec)))
-				t.Errorf("wrong result\ngot:  %s\nwant: %s", dump.Value(got), dump.Value(test.Want))
+			if diff := cmp.Diff(test.Want, got, ctydebug.CmpOptions); diff != "" {
+				t.Logf("implied schema is %s", spew.Sdump(hcldec.ImpliedSchema(spec)))
+				t.Errorf("wrong result\n%s", diff)
 			}
 		})
 	}

--- a/internal/configs/configschema/empty_value_test.go
+++ b/internal/configs/configschema/empty_value_test.go
@@ -7,8 +7,9 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/apparentlymart/go-dump/dump"
 	"github.com/davecgh/go-spew/spew"
+	"github.com/google/go-cmp/cmp"
+	"github.com/zclconf/go-cty-debug/ctydebug"
 	"github.com/zclconf/go-cty/cty"
 )
 
@@ -165,8 +166,8 @@ func TestBlockEmptyValue(t *testing.T) {
 	for _, test := range tests {
 		t.Run(fmt.Sprintf("%#v", test.Schema), func(t *testing.T) {
 			got := test.Schema.EmptyValue()
-			if !test.Want.RawEquals(got) {
-				t.Errorf("wrong result\nschema: %s\ngot: %s\nwant: %s", spew.Sdump(test.Schema), dump.Value(got), dump.Value(test.Want))
+			if diff := cmp.Diff(test.Want, got, ctydebug.CmpOptions); diff != "" {
+				t.Errorf("wrong result\nschema: %s\ndiff:\n%s", spew.Sdump(test.Schema), diff)
 			}
 		})
 	}
@@ -252,8 +253,8 @@ func TestAttributeEmptyValue(t *testing.T) {
 	for _, test := range tests {
 		t.Run(fmt.Sprintf("%#v", test.Schema), func(t *testing.T) {
 			got := test.Schema.EmptyValue()
-			if !test.Want.RawEquals(got) {
-				t.Errorf("wrong result\nschema: %s\ngot: %s\nwant: %s", spew.Sdump(test.Schema), dump.Value(got), dump.Value(test.Want))
+			if diff := cmp.Diff(test.Want, got, ctydebug.CmpOptions); diff != "" {
+				t.Errorf("wrong result\nschema: %s\ndiff:\n%s", spew.Sdump(test.Schema), diff)
 			}
 		})
 	}

--- a/internal/plans/objchange/compatible_test.go
+++ b/internal/plans/objchange/compatible_test.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/apparentlymart/go-dump/dump"
+	"github.com/zclconf/go-cty-debug/ctydebug"
 	"github.com/zclconf/go-cty/cty"
 
 	"github.com/hashicorp/terraform/internal/configs/configschema"
@@ -1422,7 +1422,7 @@ func TestAssertObjectCompatible(t *testing.T) {
 				wantErrs[msg] = struct{}{}
 			}
 
-			t.Logf("\nplanned: %sactual:  %s", dump.Value(test.Planned), dump.Value(test.Actual))
+			t.Logf("\nplanned: %sactual:  %s", ctydebug.ValueString(test.Planned), ctydebug.ValueString(test.Actual))
 			for msg := range wantErrs {
 				if _, ok := gotErrs[msg]; !ok {
 					t.Errorf("missing expected error: %s", msg)

--- a/internal/plans/objchange/normalize_obj_test.go
+++ b/internal/plans/objchange/normalize_obj_test.go
@@ -6,9 +6,11 @@ package objchange
 import (
 	"testing"
 
-	"github.com/apparentlymart/go-dump/dump"
-	"github.com/hashicorp/terraform/internal/configs/configschema"
+	"github.com/google/go-cmp/cmp"
+	"github.com/zclconf/go-cty-debug/ctydebug"
 	"github.com/zclconf/go-cty/cty"
+
+	"github.com/hashicorp/terraform/internal/configs/configschema"
 )
 
 func TestNormalizeObjectFromLegacySDK(t *testing.T) {
@@ -300,11 +302,8 @@ func TestNormalizeObjectFromLegacySDK(t *testing.T) {
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			got := NormalizeObjectFromLegacySDK(test.Input, test.Schema)
-			if !got.RawEquals(test.Want) {
-				t.Errorf(
-					"wrong result\ngot:  %s\nwant: %s",
-					dump.Value(got), dump.Value(test.Want),
-				)
+			if diff := cmp.Diff(test.Want, got, ctydebug.CmpOptions); diff != "" {
+				t.Errorf("wrong result\n%s", diff)
 			}
 		})
 	}

--- a/internal/plans/objchange/objchange_test.go
+++ b/internal/plans/objchange/objchange_test.go
@@ -6,7 +6,8 @@ package objchange
 import (
 	"testing"
 
-	"github.com/apparentlymart/go-dump/dump"
+	"github.com/google/go-cmp/cmp"
+	"github.com/zclconf/go-cty-debug/ctydebug"
 	"github.com/zclconf/go-cty/cty"
 
 	"github.com/hashicorp/terraform/internal/configs/configschema"
@@ -2733,8 +2734,8 @@ func TestProposedNew(t *testing.T) {
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			got := ProposedNew(test.Schema, test.Prior, test.Config)
-			if !got.RawEquals(test.Want) {
-				t.Errorf("wrong result\ngot:  %swant: %s", dump.Value(got), dump.Value(test.Want))
+			if diff := cmp.Diff(test.Want, got, ctydebug.CmpOptions); diff != "" {
+				t.Errorf("wrong result\n%s", diff)
 			}
 		})
 	}

--- a/internal/plans/objchange/plan_valid_test.go
+++ b/internal/plans/objchange/plan_valid_test.go
@@ -6,7 +6,7 @@ package objchange
 import (
 	"testing"
 
-	"github.com/apparentlymart/go-dump/dump"
+	"github.com/zclconf/go-cty-debug/ctydebug"
 	"github.com/zclconf/go-cty/cty"
 
 	"github.com/hashicorp/terraform/internal/configs/configschema"
@@ -1953,9 +1953,9 @@ func TestAssertPlanValid(t *testing.T) {
 
 			t.Logf(
 				"\nprior:  %sconfig:  %splanned: %s",
-				dump.Value(test.Prior),
-				dump.Value(test.Config),
-				dump.Value(test.Planned),
+				ctydebug.ValueString(test.Prior),
+				ctydebug.ValueString(test.Config),
+				ctydebug.ValueString(test.Planned),
 			)
 			for msg := range wantErrs {
 				if _, ok := gotErrs[msg]; !ok {


### PR DESCRIPTION
I originally wrote this library as a stopgap measure because davecgh/go-spew produced a hard-to-read representation of cty.Value due to exposing the raw internals, whereas my "go-dump" instead just pretty-prints whatever fmt.Sprintf("%#v", ...) would return for a given value.

However, in the meantime I wrote ctydebug as a more cty-specialized library for this purpose, and we switched to using go-cmp as our primary library for deep-comparing data structures, and so our few remaining uses of apparentlymart/go-dump were vestigial in tests that haven't been updated recently enough to have been updated to our new standards.

This commit therefore swaps out all use of that library with combinations of go-cmp and ctydebug, matching our current standards for how to do these sorts of things in tests. This removes our dependency on "go-dump" altogether.

At least one of our dependencies is still using go-dump as part of its own test suite, and so the Go toolchain still includes its declared version in our go.sum file. However, this library is no longer linked in to Terraform either in real builds or in test binaries, and so it gets dropped entirely from our go.mod file.
