### PR TITLE
release: use new syntax for promotion hooks

### DIFF
--- a/.release/ci.hcl
+++ b/.release/ci.hcl
@@ -108,17 +108,12 @@ event "promote-production" {
     workflow = "promote-production"
   }
 
-  notification {
-    on = "always"
-  }
-}
-
-event "crt-hook-tfc-upload" {
-  depends = ["promote-production"]
-  action "crt-hook-tfc-upload" {
-    organization = "hashicorp"
-    repository = "terraform-releases"
-    workflow = "crt-hook-tfc-upload"
+  promotion-events  {
+    post-promotion {
+      organization = "hashicorp"
+      repository = "terraform-releases"
+      workflow = "crt-hook-tfc-upload"
+    }
   }
 
   notification {


### PR DESCRIPTION
Update our TFC update hook to use the new, more generic `promotion-events` syntax.

## Target Release

1.8.x
