### PR TITLE
load provider schemas early during validation

### DIFF
--- a/internal/terraform/context_validate.go
+++ b/internal/terraform/context_validate.go
@@ -67,6 +67,15 @@ func (c *Context) Validate(config *configs.Config, opts *ValidateOpts) tfdiags.D
 		return diags
 	}
 
+	// There are some validation checks that happen when loading the provider
+	// schemas, and we can catch them early to ensure we are in a position to
+	// handle any errors.
+	_, moreDiags = c.Schemas(config, nil)
+	diags = diags.Append(moreDiags)
+	if moreDiags.HasErrors() {
+		return diags
+	}
+
 	log.Printf("[DEBUG] Building and walking validate graph")
 
 	// Validate is to check if the given module is valid regardless of


### PR DESCRIPTION
Schema errors are normally handled when the schema is retrieved at the point it's used. This however fails for functions, which are loaded in a context that cannot easily handle errors. Most code paths will end up loading schemas before calling a function, but in the case that a provider is used for one of its functions without any resources, the validate walk could end up skipping the error checks.

Force the loading of provider schemas as early as possible during validation, to ensure we can handle any diagnostics we receive. This won't add any extra overhead to `validate` which aims to be as efficient as possible, since we're caching the schemas for all future calls during the operation.

Fixes #34777