### PR TITLE
manual backport of remove repetitive words into v1.7

### DIFF
--- a/internal/backend/local/backend_plan_test.go
+++ b/internal/backend/local/backend_plan_test.go
@@ -634,7 +634,7 @@ func TestLocal_planDestroy_withDataSources(t *testing.T) {
 		t.Fatal("plan should not be empty")
 	}
 
-	// Data source should still exist in the the plan file
+	// Data source should still exist in the plan file
 	plan := testReadPlan(t, planPath)
 	if len(plan.Changes.Resources) != 2 {
 		t.Fatalf("Expected exactly 1 resource for destruction, %d given: %q",

--- a/internal/backend/remote-state/s3/backend_test.go
+++ b/internal/backend/remote-state/s3/backend_test.go
@@ -2626,7 +2626,7 @@ func TestAssumeRole_PrepareConfigValidation(t *testing.T) {
 // an s3 backend Block
 //
 // This serves as a smoke test for use of the terraform_remote_state
-// data source with the s3 backend, replicating the the process that
+// data source with the s3 backend, replicating the process that
 // data source uses. The returned value is ignored as the object is
 // large (representing the entire s3 backend schema) and the focus of
 // this test is early detection of coercion failures.

--- a/internal/checks/state.go
+++ b/internal/checks/state.go
@@ -12,7 +12,7 @@ import (
 	"github.com/hashicorp/terraform/internal/configs"
 )
 
-// State is a container for state tracking of all of the the checks declared in
+// State is a container for state tracking of all of the checks declared in
 // a particular Terraform configuration and their current statuses.
 //
 // A State object is mutable during plan and apply operations but should

--- a/internal/command/e2etest/automation_test.go
+++ b/internal/command/e2etest/automation_test.go
@@ -236,7 +236,7 @@ func TestPlanOnlyInAutomation(t *testing.T) {
 	}
 
 	// Because we're running with TF_IN_AUTOMATION set, we should not see
-	// any mention of the the "terraform apply" command in the output.
+	// any mention of the "terraform apply" command in the output.
 	if strings.Contains(stdout, "terraform apply") {
 		t.Errorf("unwanted mention of \"terraform apply\" in plan output\n%s", stdout)
 	}

--- a/internal/command/jsonplan/plan.go
+++ b/internal/command/jsonplan/plan.go
@@ -875,7 +875,7 @@ func UnmarshalActions(actions []string) plans.Action {
 // indexes.
 //
 // JavaScript (or similar dynamic language) consumers of these values can
-// iterate over the the steps starting from the root object to reach the
+// iterate over the steps starting from the root object to reach the
 // value that each path is describing.
 func encodePaths(pathSet cty.PathSet) (json.RawMessage, error) {
 	if pathSet.Empty() {

--- a/internal/command/meta_backend_migrate.go
+++ b/internal/command/meta_backend_migrate.go
@@ -708,7 +708,7 @@ func (m *Meta) backendMigrateState_S_TFC(opts *backendMigrateOpts, sourceWorkspa
 	// * Specifically for a migration from the "remote" backend using 'prefix', we will
 	//   instead 'migrate' the workspaces using a pattern based on the old prefix+name,
 	//   not allowing a user to accidentally input the wrong pattern to line up with
-	//   what the the remote backend was already using before (which presumably already
+	//   what the remote backend was already using before (which presumably already
 	//   meets the naming considerations for Terraform Cloud).
 	//   In other words, this is a fast-track migration path from the remote backend, retaining
 	//   how things already are in Terraform Cloud with no user intervention needed.

--- a/internal/getproviders/package_authentication.go
+++ b/internal/getproviders/package_authentication.go
@@ -531,7 +531,7 @@ func (s signatureAuthentication) findSigningKey() (*SigningKey, string, error) {
 
 		entity, err := s.checkDetachedSignature(keyring, bytes.NewReader(s.Document), bytes.NewReader(s.Signature), nil)
 
-		// If the signature issuer does not match the the key, keep trying the
+		// If the signature issuer does not match the key, keep trying the
 		// rest of the provided keys.
 		if err == openpgpErrors.ErrUnknownIssuer {
 			continue

--- a/internal/registry/test/mock_registry.go
+++ b/internal/registry/test/mock_registry.go
@@ -64,7 +64,7 @@ var (
 )
 
 // All the locationes from the mockRegistry start with a file:// scheme. If
-// the the location string here doesn't have a scheme, the mockRegistry will
+// the location string here doesn't have a scheme, the mockRegistry will
 // find the absolute path and return a complete URL.
 var testMods = map[string][]testMod{
 	"registry/foo/bar": {{

--- a/website/README.md
+++ b/website/README.md
@@ -23,7 +23,7 @@ If the validation fails, actionable error messages will be displayed to help you
 
 ## Modifying Sidebar Navigation
 
-You must update the the sidebar navigation when you add or delete documentation .mdx files. If you do not update the navigation, the website deploy preview fails.
+You must update the sidebar navigation when you add or delete documentation .mdx files. If you do not update the navigation, the website deploy preview fails.
 
 To update the sidebar navigation, you must edit the appropriate `nav-data.json` file. This repository contains the sidebar navigation files for the following documentation sets:
 


### PR DESCRIPTION
Manual backport of https://github.com/hashicorp/terraform/pull/34776 into v1.7 after failure of https://github.com/hashicorp/terraform/pull/34778.