### PR TITLE
manual backport of docs update into v1.7

### DIFF
--- a/website/docs/language/modules/sources.mdx
+++ b/website/docs/language/modules/sources.mdx
@@ -262,8 +262,11 @@ to reduce the time taken to retrieve the remote repository.
 
 The `depth` URL argument corresponds to
 [the `--depth` argument to `git clone`](https://git-scm.com/docs/git-clone#Documentation/git-clone.txt---depthltdepthgt),
-telling Git to create a shallow clone with the history truncated to only
-the specified number of commits.
+instructs the Git to create a shallow clone with the history truncated to only
+the specified number of commits. For example, if you want to perform a shallow clone with only the last 3 commits
+of a repository, you would use the `--depth=3` parameter in the clone URL
+like git::https://example.com/vpc.git?depth=3&ref=v1.2.0. This would fetch only the most recent 3 commits along with
+the necessary data, making the clone faster and more efficient, especially for large repositories.
 
 However, because shallow clone requires different Git protocol behavior,
 setting the `depth` argument makes Terraform pass your [`ref` argument](#selecting-a-revision),

--- a/website/docs/language/modules/sources.mdx
+++ b/website/docs/language/modules/sources.mdx
@@ -263,10 +263,15 @@ to reduce the time taken to retrieve the remote repository.
 The `depth` URL argument corresponds to
 [the `--depth` argument to `git clone`](https://git-scm.com/docs/git-clone#Documentation/git-clone.txt---depthltdepthgt),
 instructs the Git to create a shallow clone with the history truncated to only
-the specified number of commits. For example, if you want to perform a shallow clone with only the last 3 commits
-of a repository, you would use the `--depth=3` parameter in the clone URL
-like git::https://example.com/vpc.git?depth=3&ref=v1.2.0. This would fetch only the most recent 3 commits along with
-the necessary data, making the clone faster and more efficient, especially for large repositories.
+the specified number of commits. 
+Because Terraform only uses the most recent selected commit to find the source
+code of your specified module, it is not typically useful to set `depth`
+to any value other than `1`.
+```hcl
+module "vpc" {
+  source = "git::https://example.com/vpc.git?depth=1&ref=v1.2.0"
+}
+```
 
 However, because shallow clone requires different Git protocol behavior,
 setting the `depth` argument makes Terraform pass your [`ref` argument](#selecting-a-revision),

--- a/website/docs/language/modules/sources.mdx
+++ b/website/docs/language/modules/sources.mdx
@@ -262,11 +262,9 @@ to reduce the time taken to retrieve the remote repository.
 
 The `depth` URL argument corresponds to
 [the `--depth` argument to `git clone`](https://git-scm.com/docs/git-clone#Documentation/git-clone.txt---depthltdepthgt),
-instructs the Git to create a shallow clone with the history truncated to only
-the specified number of commits. 
-Because Terraform only uses the most recent selected commit to find the source
-code of your specified module, it is not typically useful to set `depth`
-to any value other than `1`.
+which instructs Git to create a shallow clone that includes
+only the specified number of commits in the history. 
+Setting `depth` to `1` is suitable for most cases. This is because Terraform only uses the most recently selected commit to find the source.
 ```hcl
 module "vpc" {
   source = "git::https://example.com/vpc.git?depth=1&ref=v1.2.0"

--- a/website/docs/language/modules/sources.mdx
+++ b/website/docs/language/modules/sources.mdx
@@ -278,10 +278,6 @@ if any, to
 instead. That means it must specify a named branch or tag known to the remote
 repository, and that raw commit IDs are not acceptable.
 
-Because Terraform only uses the most recent selected commit to find the source
-code of your specified module, it is not typically useful to set `depth`
-to any value other than `1`.
-
 ### "scp-like" address syntax
 
 When using Git over SSH, we recommend using the `ssh://`-prefixed URL form


### PR DESCRIPTION
Manual backport of https://github.com/hashicorp/terraform/pull/34692 into v1.7 after failure of https://github.com/hashicorp/terraform/pull/34787.
Note that the final commit https://github.com/hashicorp/terraform/pull/34790/commits/8f6ddfa4cb32ac0be9aa11a61ad65136bc297074 replaces https://github.com/hashicorp/terraform/pull/34692/commits/b496edd1d30275d5016e63ac2c39b88a52cf0b00, which is a merge commit.