### PR TITLE
Eliminate all non-legacy uses of the "legacy/terraform" package

### DIFF
--- a/internal/cloud/migration.go
+++ b/internal/cloud/migration.go
@@ -4,8 +4,8 @@
 package cloud
 
 import (
+	"github.com/hashicorp/terraform/internal/command/workdir"
 	"github.com/hashicorp/terraform/internal/configs"
-	legacy "github.com/hashicorp/terraform/internal/legacy/terraform"
 )
 
 // Most of the logic for migrating into and out of "cloud mode" actually lives
@@ -48,7 +48,7 @@ const (
 // the way we currently model working directory settings and config, so its
 // signature probably won't survive any non-trivial refactoring of how
 // the CLI layer thinks about backends/state storage.
-func DetectConfigChangeType(wdState *legacy.BackendState, config *configs.Backend, haveLocalStates bool) ConfigChangeMode {
+func DetectConfigChangeType(wdState *workdir.BackendState, config *configs.Backend, haveLocalStates bool) ConfigChangeMode {
 	// Although externally the cloud integration isn't really a "backend",
 	// internally we treat it a bit like one just to preserve all of our
 	// existing interfaces that assume backends. "cloud" is the placeholder

--- a/internal/cloud/migration_test.go
+++ b/internal/cloud/migration_test.go
@@ -6,8 +6,8 @@ package cloud
 import (
 	"testing"
 
+	"github.com/hashicorp/terraform/internal/command/workdir"
 	"github.com/hashicorp/terraform/internal/configs"
-	legacy "github.com/hashicorp/terraform/internal/legacy/terraform"
 )
 
 func TestDetectConfigChangeType(t *testing.T) {
@@ -101,10 +101,10 @@ func TestDetectConfigChangeType(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			var state *legacy.BackendState
+			var state *workdir.BackendState
 			var config *configs.Backend
 			if test.stateType != "" {
-				state = &legacy.BackendState{
+				state = &workdir.BackendState{
 					Type: test.stateType,
 					// everything else is irrelevant for our purposes here
 				}

--- a/internal/command/meta.go
+++ b/internal/command/meta.go
@@ -33,7 +33,6 @@ import (
 	"github.com/hashicorp/terraform/internal/configs"
 	"github.com/hashicorp/terraform/internal/configs/configload"
 	"github.com/hashicorp/terraform/internal/getproviders"
-	legacy "github.com/hashicorp/terraform/internal/legacy/terraform"
 	"github.com/hashicorp/terraform/internal/providers"
 	"github.com/hashicorp/terraform/internal/provisioners"
 	"github.com/hashicorp/terraform/internal/states"
@@ -201,7 +200,7 @@ type Meta struct {
 	configLoader *configload.Loader
 
 	// backendState is the currently active backend state
-	backendState *legacy.BackendState
+	backendState *workdir.BackendState
 
 	// Variables for the context (private)
 	variableArgs rawFlags

--- a/internal/command/unlock_test.go
+++ b/internal/command/unlock_test.go
@@ -8,9 +8,9 @@ import (
 	"testing"
 
 	"github.com/hashicorp/cli"
-	"github.com/hashicorp/terraform/internal/backend/remote-state/inmem"
 
-	legacy "github.com/hashicorp/terraform/internal/legacy/terraform"
+	"github.com/hashicorp/terraform/internal/backend/remote-state/inmem"
+	"github.com/hashicorp/terraform/internal/command/workdir"
 )
 
 // Since we can't unlock a local state file, just test that calling unlock
@@ -23,12 +23,12 @@ func TestUnlock(t *testing.T) {
 	// Write the legacy state
 	statePath := DefaultStateFilename
 	{
-		f, err := os.Create(statePath)
+		emptyStateFile := workdir.NewBackendStateFile()
+		emptyStateFileRaw, err := workdir.EncodeBackendStateFile(emptyStateFile)
 		if err != nil {
-			t.Fatalf("err: %s", err)
+			t.Fatal(err)
 		}
-		err = legacy.WriteState(legacy.NewState(), f)
-		f.Close()
+		err = os.WriteFile(statePath, emptyStateFileRaw, os.ModePerm)
 		if err != nil {
 			t.Fatalf("err: %s", err)
 		}

--- a/internal/command/workdir/backend_state.go
+++ b/internal/command/workdir/backend_state.go
@@ -1,0 +1,212 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package workdir
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/zclconf/go-cty/cty"
+	ctyjson "github.com/zclconf/go-cty/cty/json"
+
+	"github.com/hashicorp/terraform/internal/configs/configschema"
+	"github.com/hashicorp/terraform/internal/plans"
+	"github.com/hashicorp/terraform/version"
+)
+
+// BackendStateFile describes the overall structure of the file format used
+// to track a working directory's active backend.
+//
+// The main interesting part of this is the [BackendStateFile.Backend] field,
+// but [BackendStateFile.Version] is also important to make sure that the
+// current Terraform CLI version will be able to understand the file.
+type BackendStateFile struct {
+	// Don't access this directly. It's here only for use during serialization
+	// and deserialization of backend state file contents.
+	Version int `json:"version"`
+
+	// TFVersion is the version of Terraform that wrote this state. This is
+	// really just for debugging purposes; we don't currently vary behavior
+	// based on this field.
+	TFVersion string `json:"terraform_version,omitempty"`
+
+	// Backend tracks the configuration for the backend in use with
+	// this state. This is used to track any changes in the backend
+	// configuration.
+	Backend *BackendState `json:"backend,omitempty"`
+
+	// This is here just so we can sniff for the unlikely-but-possible
+	// situation that someone is trying to use modern Terraform with a
+	// directory that was most recently used with Terraform v0.8, before
+	// there was any concept of backends. Don't access this field.
+	Remote *struct{} `json:"remote,omitempty"`
+}
+
+// NewBackendStateFile returns a new [BackendStateFile] object that initially
+// has no backend configured.
+//
+// Callers should then mutate [BackendStateFile.Backend] in the result to
+// specify the explicit backend in use, if any.
+func NewBackendStateFile() *BackendStateFile {
+	return &BackendStateFile{
+		// NOTE: We don't populate Version or TFVersion here because we
+		// always clobber those when encoding a state file in
+		// [EncodeBackendStateFile].
+	}
+}
+
+// ParseBackendStateFile tries to decode the given byte slice as the backend
+// state file format.
+//
+// Returns an error if the content is not valid syntax, or if the file is
+// of an unsupported format version.
+//
+// This does not immediately decode the embedded backend config, and so
+// it's possible that a subsequent call to [BackendState.Config] will
+// return further errors even if this call succeeds.
+func ParseBackendStateFile(src []byte) (*BackendStateFile, error) {
+	// To avoid any weird collisions with as-yet-unknown future versions of
+	// the format, we'll do a first pass of decoding just the "version"
+	// property, and then decode the rest only if we find the version number
+	// that we're expecting.
+	type VersionSniff struct {
+		Version   int    `json:"version"`
+		TFVersion string `json:"terraform_version,omitempty"`
+	}
+	var versionSniff VersionSniff
+	err := json.Unmarshal(src, &versionSniff)
+	if err != nil {
+		return nil, fmt.Errorf("invalid syntax: %w", err)
+	}
+	if versionSniff.Version == 0 {
+		// This could either mean that it's explicitly "version": 0 or that
+		// the version property is missing. We'll assume the latter here
+		// because state snapshot version 0 was an encoding/gob binary format
+		// rather than a JSON format and so it would be very weird for
+		// that to show up in a JSON file.
+		return nil, fmt.Errorf("invalid syntax: no format version number")
+	}
+	if versionSniff.Version != 3 {
+		return nil, fmt.Errorf("unsupported backend state version %d; you may need to use Terraform CLI v%s to work in this directory", versionSniff.Version, versionSniff.TFVersion)
+	}
+
+	// If we get here then we can be sure that this file at least _thinks_
+	// it's format version 3.
+	var stateFile BackendStateFile
+	err = json.Unmarshal(src, &stateFile)
+	if err != nil {
+		return nil, fmt.Errorf("invalid syntax: %w", err)
+	}
+	if stateFile.Backend == nil && stateFile.Remote != nil {
+		// It's very unlikely to get here, but one way it could happen is
+		// if this working directory was most recently used with Terraform v0.8
+		// or earlier, which didn't yet include the concept of backends.
+		// This error message assumes that's the case.
+		return nil, fmt.Errorf("this working directory uses legacy remote state and so must first be upgraded using Terraform v0.9")
+	}
+
+	return &stateFile, nil
+}
+
+func EncodeBackendStateFile(f *BackendStateFile) ([]byte, error) {
+	f.Version = 3 // we only support version 3
+	f.TFVersion = version.SemVer.String()
+	return json.MarshalIndent(f, "", "  ")
+}
+
+func (f *BackendStateFile) DeepCopy() *BackendStateFile {
+	if f == nil {
+		return nil
+	}
+	ret := &BackendStateFile{
+		Version:   f.Version,
+		TFVersion: f.TFVersion,
+		Backend:   f.Backend.DeepCopy(),
+	}
+	if f.Remote != nil {
+		// This shouldn't ever be present in an object held by a caller since
+		// we'd return an error about it during load, but we'll set it anyway
+		// just to minimize surprise.
+		ret.Remote = &struct{}{}
+	}
+	return ret
+}
+
+// BackendState describes the physical storage format for the backend state
+// in a working directory, and provides the lowest-level API for decoding it.
+type BackendState struct {
+	Type      string          `json:"type"`   // Backend type
+	ConfigRaw json.RawMessage `json:"config"` // Backend raw config
+	Hash      uint64          `json:"hash"`   // Hash of portion of configuration from config files
+}
+
+// Empty returns true if there is no active backend.
+//
+// In practice this typically means that the working directory is using the
+// implied local backend, but that decision is made by the caller.
+func (s *BackendState) Empty() bool {
+	return s == nil || s.Type == ""
+}
+
+// Config decodes the type-specific configuration object using the provided
+// schema and returns the result as a cty.Value.
+//
+// An error is returned if the stored configuration does not conform to the
+// given schema, or is otherwise invalid.
+func (s *BackendState) Config(schema *configschema.Block) (cty.Value, error) {
+	ty := schema.ImpliedType()
+	if s == nil {
+		return cty.NullVal(ty), nil
+	}
+	return ctyjson.Unmarshal(s.ConfigRaw, ty)
+}
+
+// SetConfig replaces (in-place) the type-specific configuration object using
+// the provided value and associated schema.
+//
+// An error is returned if the given value does not conform to the implied
+// type of the schema.
+func (s *BackendState) SetConfig(val cty.Value, schema *configschema.Block) error {
+	ty := schema.ImpliedType()
+	buf, err := ctyjson.Marshal(val, ty)
+	if err != nil {
+		return err
+	}
+	s.ConfigRaw = buf
+	return nil
+}
+
+// ForPlan produces an alternative representation of the reciever that is
+// suitable for storing in a plan. The current workspace must additionally
+// be provided, to be stored alongside the backend configuration.
+//
+// The backend configuration schema is required in order to properly
+// encode the backend-specific configuration settings.
+func (s *BackendState) ForPlan(schema *configschema.Block, workspaceName string) (*plans.Backend, error) {
+	if s == nil {
+		return nil, nil
+	}
+
+	configVal, err := s.Config(schema)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode backend config: %w", err)
+	}
+	return plans.NewBackend(s.Type, configVal, schema, workspaceName)
+}
+
+func (s *BackendState) DeepCopy() *BackendState {
+	if s == nil {
+		return nil
+	}
+	ret := &BackendState{
+		Type: s.Type,
+		Hash: s.Hash,
+	}
+
+	if s.ConfigRaw != nil {
+		ret.ConfigRaw = make([]byte, len(s.ConfigRaw))
+		copy(ret.ConfigRaw, s.ConfigRaw)
+	}
+	return ret
+}

--- a/internal/command/workdir/backend_state_test.go
+++ b/internal/command/workdir/backend_state_test.go
@@ -1,0 +1,143 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package workdir
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/zclconf/go-cty-debug/ctydebug"
+	"github.com/zclconf/go-cty/cty"
+
+	"github.com/hashicorp/terraform/internal/configs/configschema"
+)
+
+func TestParseBackendStateFile(t *testing.T) {
+	tests := map[string]struct {
+		Input   string
+		Want    *BackendStateFile
+		WantErr string
+	}{
+		"empty": {
+			Input:   ``,
+			WantErr: `invalid syntax: unexpected end of JSON input`,
+		},
+		"empty but valid JSON syntax": {
+			Input:   `{}`,
+			WantErr: `invalid syntax: no format version number`,
+		},
+		"older version": {
+			Input: `{
+				"version": 2,
+				"terraform_version": "0.3.0"
+			}`,
+			WantErr: `unsupported backend state version 2; you may need to use Terraform CLI v0.3.0 to work in this directory`,
+		},
+		"newer version": {
+			Input: `{
+				"version": 4,
+				"terraform_version": "54.23.9"
+			}`,
+			WantErr: `unsupported backend state version 4; you may need to use Terraform CLI v54.23.9 to work in this directory`,
+		},
+		"legacy remote state is active": {
+			Input: `{
+				"version": 3,
+				"terraform_version": "0.8.0",
+				"remote": {
+					"anything": "goes"
+				}
+			}`,
+			WantErr: `this working directory uses legacy remote state and so must first be upgraded using Terraform v0.9`,
+		},
+		"active backend": {
+			Input: `{
+				"version": 3,
+				"terraform_version": "0.8.0",
+				"backend": {
+					"type": "treasure_chest_buried_on_a_remote_island",
+					"config": {}
+				}
+			}`,
+			Want: &BackendStateFile{
+				Version:   3,
+				TFVersion: "0.8.0",
+				Backend: &BackendState{
+					Type:      "treasure_chest_buried_on_a_remote_island",
+					ConfigRaw: json.RawMessage("{}"),
+				},
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			got, err := ParseBackendStateFile([]byte(test.Input))
+
+			if test.WantErr != "" {
+				if err == nil {
+					t.Fatalf("unexpected success\nwant error: %s", test.WantErr)
+				}
+				if got, want := err.Error(), test.WantErr; got != want {
+					t.Errorf("wrong error\ngot:  %s\nwant: %s", got, want)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+			if diff := cmp.Diff(test.Want, got); diff != "" {
+				t.Errorf("wrong result\n%s", diff)
+			}
+		})
+	}
+}
+
+func ParseBackendStateConfig(t *testing.T) {
+	// This test only really covers the happy path because Config/SetConfig is
+	// largely just a thin wrapper around configschema's "ImpliedType" and
+	// cty's json unmarshal/marshal and both of those are well-tested elsewhere.
+
+	s := &BackendState{
+		Type: "whatever",
+		ConfigRaw: []byte(`{
+			"foo": "bar"
+		}`),
+	}
+
+	schema := &configschema.Block{
+		Attributes: map[string]*configschema.Attribute{
+			"foo": {
+				Type:     cty.String,
+				Optional: true,
+			},
+		},
+	}
+	got, err := s.Config(schema)
+	want := cty.ObjectVal(map[string]cty.Value{
+		"foo": cty.StringVal("bar"),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if diff := cmp.Diff(want, got, ctydebug.CmpOptions); diff != "" {
+		t.Errorf("wrong result\n%s", diff)
+	}
+
+	err = s.SetConfig(cty.ObjectVal(map[string]cty.Value{
+		"foo": cty.StringVal("baz"),
+	}), schema)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	gotRaw := s.ConfigRaw
+	wantRaw := []byte(`{"foo":"baz"}`)
+	if !bytes.Equal(wantRaw, gotRaw) {
+		t.Errorf("wrong raw config after encode\ngot:  %s\nwant: %s", gotRaw, wantRaw)
+	}
+}

--- a/internal/command/workspace_command_test.go
+++ b/internal/command/workspace_command_test.go
@@ -11,14 +11,14 @@ import (
 	"testing"
 
 	"github.com/hashicorp/cli"
+
 	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/backend"
 	"github.com/hashicorp/terraform/internal/backend/local"
 	"github.com/hashicorp/terraform/internal/backend/remote-state/inmem"
 	"github.com/hashicorp/terraform/internal/states"
+	"github.com/hashicorp/terraform/internal/states/statefile"
 	"github.com/hashicorp/terraform/internal/states/statemgr"
-
-	legacy "github.com/hashicorp/terraform/internal/legacy/terraform"
 )
 
 func TestWorkspace_createAndChange(t *testing.T) {
@@ -384,20 +384,30 @@ func TestWorkspace_deleteWithState(t *testing.T) {
 	}
 
 	// create a non-empty state
-	originalState := &legacy.State{
-		Modules: []*legacy.ModuleState{
-			{
-				Path: []string{"root"},
-				Resources: map[string]*legacy.ResourceState{
-					"test_instance.foo": {
+	originalState := states.BuildState(func(ss *states.SyncState) {
+		ss.SetResourceInstanceCurrent(
+			addrs.AbsResourceInstance{
+				Resource: addrs.ResourceInstance{
+					Resource: addrs.Resource{
+						Mode: addrs.ManagedResourceMode,
 						Type: "test_instance",
-						Primary: &legacy.InstanceState{
-							ID: "bar",
-						},
+						Name: "foo",
 					},
 				},
 			},
-		},
+			&states.ResourceInstanceObjectSrc{
+				AttrsJSON: []byte("{}"),
+				Status:    states.ObjectReady,
+			},
+			addrs.AbsProviderConfig{
+				Provider: addrs.NewBuiltInProvider("test"),
+			},
+		)
+	})
+	originalStateFile := &statefile.File{
+		Serial:  1,
+		Lineage: "whatever",
+		State:   originalState,
 	}
 
 	f, err := os.Create(filepath.Join(local.DefaultWorkspaceDir, "test", "terraform.tfstate"))
@@ -405,7 +415,7 @@ func TestWorkspace_deleteWithState(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer f.Close()
-	if err := legacy.WriteState(originalState, f); err != nil {
+	if err := statefile.Write(originalStateFile, f); err != nil {
 		t.Fatal(err)
 	}
 


### PR DESCRIPTION
As a leftover of the Terraform v0.12 work back in 2019, we continued using a snapshot of the Terraform v0.11 version of `package terraform` for two main purposes:

1. To support the nearby snapshot of the legacy Terraform SDK that most of the remote state backends use.
2. To use a tiny subset of the state snapshot loading and saving code and models to represent Terraform CLI's "backend state" format, which tracks the active backend configuration for each working directory.

This PR eliminates the second case. Most of the changes here are in migrating the tiny sliver of legacy `package terraform` functionality that was related to Terraform CLI backend state into `command/workdir`, which is the package we use to deal with working-directory-related concerns.

Ideally we'd access the backend state through methods of the `workdir.Dir` type, but that's too disruptive a refactor to combine into this and so that'll need to wait for another day; for now we'll keep the existing callers doing their access through our `clistate` package that is itself a forked snapshot of what `statemgr.Filesystem` used to be in Terraform v0.11.

It's also amusing to note that only one of the callers was actually using the `BackendState.SetConfig` method to update the backend-specific configuration data, with everyone else just doing their own JSON encoding and constructing the object manually. I've not attempted to fix that here, because this diff is already big enough.

---

The second commit is not actually related to backend state but instead fixes up one leftover test that was still using the legacy state format to create a real state snapshot file. It should instead be using the modern state snapshot API, and that small fix removes the last remaining dependency on `legacy/terraform` so I included it here for completeness.

---

The only remaining uses of `legacy/terraform` after this come from `legacy/helper/schema`. That one's gonna be harder to clean up, but I've made a start on it in #34772. If that gets finished then we'll be able to delete the whole `legacy` directory tree (It'll be harder to deal with that because we'll need to coordinate with all of the different provider development teams who maintain those backends since the Terraform Core team doesn't have the needed credentials to test all of them, so I split this part off as something we can deal with just internally.)

