### PR TITLE
Remove three redundant error-related dependencies

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -73,7 +73,6 @@ require (
 	github.com/nishanths/exhaustive v0.7.11
 	github.com/packer-community/winrmcp v0.0.0-20180921211025-c76d91c1e7db
 	github.com/pkg/browser v0.0.0-20201207095918-0426ae3fba23
-	github.com/pkg/errors v0.9.1
 	github.com/posener/complete v1.2.3
 	github.com/spf13/afero v1.9.3
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.0.588
@@ -235,6 +234,7 @@ require (
 	github.com/nu7hatch/gouuid v0.0.0-20131221200532-179d4d0c4d8d // indirect
 	github.com/oklog/run v1.0.0 // indirect
 	github.com/oklog/ulid v1.3.1 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/rivo/uniseg v0.2.0 // indirect
 	github.com/samber/lo v1.37.0 // indirect
 	github.com/satori/go.uuid v1.2.0 // indirect

--- a/internal/backend/remote-state/azure/client.go
+++ b/internal/backend/remote-state/azure/client.go
@@ -7,15 +7,16 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
 	"net/http"
 
-	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/go-uuid"
+	"github.com/tombuildsstuff/giovanni/storage/2018-11-09/blob/blobs"
+
 	"github.com/hashicorp/terraform/internal/states/remote"
 	"github.com/hashicorp/terraform/internal/states/statemgr"
-	"github.com/tombuildsstuff/giovanni/storage/2018-11-09/blob/blobs"
 )
 
 const (
@@ -135,7 +136,7 @@ func (c *RemoteClient) Lock(info *statemgr.LockInfo) (string, error) {
 	getLockInfoErr := func(err error) error {
 		lockInfo, infoErr := c.getLockInfo()
 		if infoErr != nil {
-			err = multierror.Append(err, infoErr)
+			err = errors.Join(err, infoErr)
 		}
 
 		return &statemgr.LockError{

--- a/internal/backend/remote-state/consul/client.go
+++ b/internal/backend/remote-state/consul/client.go
@@ -17,7 +17,7 @@ import (
 	"time"
 
 	consulapi "github.com/hashicorp/consul/api"
-	multierror "github.com/hashicorp/go-multierror"
+
 	"github.com/hashicorp/terraform/internal/states/remote"
 	"github.com/hashicorp/terraform/internal/states/statemgr"
 )
@@ -236,7 +236,7 @@ func (c *RemoteClient) Put(data []byte) error {
 		if !ok {
 			var resultErr error
 			for _, respError := range resp.Errors {
-				resultErr = multierror.Append(resultErr, errors.New(respError.What))
+				resultErr = errors.Join(resultErr, errors.New(respError.What))
 			}
 			return fmt.Errorf("consul CAS failed with transaction errors: %w", resultErr)
 		}
@@ -450,7 +450,7 @@ func (c *RemoteClient) lock() (string, error) {
 	err = c.putLockInfo(c.info)
 	if err != nil {
 		if unlockErr := c.unlock(c.info.ID); unlockErr != nil {
-			err = multierror.Append(err, unlockErr)
+			err = errors.Join(err, unlockErr)
 		}
 
 		return "", err
@@ -602,11 +602,11 @@ func (c *RemoteClient) unlock(id string) error {
 	var errs error
 
 	if _, err := kv.Delete(c.lockPath()+lockInfoSuffix, nil); err != nil {
-		errs = multierror.Append(errs, err)
+		errs = errors.Join(errs, err)
 	}
 
 	if err := c.consulLock.Unlock(); err != nil {
-		errs = multierror.Append(errs, err)
+		errs = errors.Join(errs, err)
 	}
 
 	// the monitoring goroutine may be in a select on the lockCh, so we need to

--- a/internal/backend/remote-state/cos/client.go
+++ b/internal/backend/remote-state/cos/client.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"crypto/md5"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"log"
@@ -15,11 +16,11 @@ import (
 	"strings"
 	"time"
 
-	multierror "github.com/hashicorp/go-multierror"
-	"github.com/hashicorp/terraform/internal/states/remote"
-	"github.com/hashicorp/terraform/internal/states/statemgr"
 	tag "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tag/v20180813"
 	"github.com/tencentyun/cos-go-sdk-v5"
+
+	"github.com/hashicorp/terraform/internal/states/remote"
+	"github.com/hashicorp/terraform/internal/states/statemgr"
 )
 
 const (
@@ -144,7 +145,7 @@ func (c *remoteClient) lockError(err error) *statemgr.LockError {
 
 	info, infoErr := c.lockInfo()
 	if infoErr != nil {
-		lockErr.Err = multierror.Append(lockErr.Err, infoErr)
+		lockErr.Err = errors.Join(lockErr.Err, infoErr)
 	} else {
 		lockErr.Info = info
 	}

--- a/internal/backend/remote-state/gcs/client.go
+++ b/internal/backend/remote-state/gcs/client.go
@@ -5,15 +5,16 @@ package gcs
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"strconv"
 
 	"cloud.google.com/go/storage"
-	multierror "github.com/hashicorp/go-multierror"
+	"golang.org/x/net/context"
+
 	"github.com/hashicorp/terraform/internal/states/remote"
 	"github.com/hashicorp/terraform/internal/states/statemgr"
-	"golang.org/x/net/context"
 )
 
 // remoteClient is used by "state/remote".State to read and write
@@ -134,7 +135,7 @@ func (c *remoteClient) lockError(err error) *statemgr.LockError {
 
 	info, infoErr := c.lockInfo()
 	if infoErr != nil {
-		lockErr.Err = multierror.Append(lockErr.Err, infoErr)
+		lockErr.Err = errors.Join(lockErr.Err, infoErr)
 	} else {
 		lockErr.Info = info
 	}

--- a/internal/backend/remote-state/oss/client.go
+++ b/internal/backend/remote-state/oss/client.go
@@ -8,6 +8,7 @@ import (
 	"crypto/md5"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -15,9 +16,7 @@ import (
 
 	"github.com/aliyun/aliyun-oss-go-sdk/oss"
 	"github.com/aliyun/aliyun-tablestore-go-sdk/tablestore"
-	"github.com/hashicorp/go-multierror"
 	uuid "github.com/hashicorp/go-uuid"
-	"github.com/pkg/errors"
 
 	"github.com/hashicorp/terraform/internal/states/remote"
 	"github.com/hashicorp/terraform/internal/states/statemgr"
@@ -192,7 +191,7 @@ func (c *RemoteClient) Lock(info *statemgr.LockInfo) (string, error) {
 		err = fmt.Errorf("invoking PutRow got an error: %#v", err)
 		lockInfo, infoErr := c.getLockInfo()
 		if infoErr != nil {
-			err = multierror.Append(err, fmt.Errorf("\ngetting lock info got an error: %#v", infoErr))
+			err = errors.Join(err, fmt.Errorf("\ngetting lock info got an error: %#v", infoErr))
 		}
 		lockErr := &statemgr.LockError{
 			Err:  err,

--- a/internal/backend/remote-state/s3/client.go
+++ b/internal/backend/remote-state/s3/client.go
@@ -23,8 +23,8 @@ import (
 	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
 	baselogging "github.com/hashicorp/aws-sdk-go-base/v2/logging"
 	"github.com/hashicorp/go-hclog"
-	multierror "github.com/hashicorp/go-multierror"
 	uuid "github.com/hashicorp/go-uuid"
+
 	"github.com/hashicorp/terraform/internal/states/remote"
 	"github.com/hashicorp/terraform/internal/states/statemgr"
 )
@@ -312,7 +312,7 @@ func (c *RemoteClient) Lock(info *statemgr.LockInfo) (string, error) {
 	if err != nil {
 		lockInfo, infoErr := c.getLockInfo(ctx)
 		if infoErr != nil {
-			err = multierror.Append(err, infoErr)
+			err = errors.Join(err, infoErr)
 		}
 
 		lockErr := &statemgr.LockError{

--- a/internal/command/clistate/local_state.go
+++ b/internal/command/clistate/local_state.go
@@ -6,6 +6,7 @@ package clistate
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -14,7 +15,6 @@ import (
 	"sync"
 	"time"
 
-	multierror "github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform/internal/legacy/terraform"
 	"github.com/hashicorp/terraform/internal/states/statemgr"
 )
@@ -193,7 +193,7 @@ func (s *LocalState) Lock(info *statemgr.LockInfo) (string, error) {
 	if err := s.lock(); err != nil {
 		info, infoErr := s.lockInfo()
 		if infoErr != nil {
-			err = multierror.Append(err, infoErr)
+			err = errors.Join(err, infoErr)
 		}
 
 		lockErr := &statemgr.LockError{
@@ -220,7 +220,7 @@ func (s *LocalState) Unlock(id string) error {
 		idErr := fmt.Errorf("invalid lock id: %q. current id: %q", id, s.lockID)
 		info, err := s.lockInfo()
 		if err != nil {
-			idErr = multierror.Append(idErr, err)
+			idErr = errors.Join(idErr, err)
 		}
 
 		return &statemgr.LockError{

--- a/internal/configs/configschema/internal_validate.go
+++ b/internal/configs/configschema/internal_validate.go
@@ -4,12 +4,11 @@
 package configschema
 
 import (
+	"errors"
 	"fmt"
 	"regexp"
 
 	"github.com/zclconf/go-cty/cty"
-
-	multierror "github.com/hashicorp/go-multierror"
 )
 
 var validName = regexp.MustCompile(`^[a-z0-9_]+$`)
@@ -28,47 +27,47 @@ func (b *Block) InternalValidate() error {
 }
 
 func (b *Block) internalValidate(prefix string) error {
-	var multiErr *multierror.Error
+	var multiErr error
 
 	for name, attrS := range b.Attributes {
 		if attrS == nil {
-			multiErr = multierror.Append(multiErr, fmt.Errorf("%s%s: attribute schema is nil", prefix, name))
+			multiErr = errors.Join(multiErr, fmt.Errorf("%s%s: attribute schema is nil", prefix, name))
 			continue
 		}
-		multiErr = multierror.Append(multiErr, attrS.internalValidate(name, prefix))
+		multiErr = errors.Join(multiErr, attrS.internalValidate(name, prefix))
 	}
 
 	for name, blockS := range b.BlockTypes {
 		if blockS == nil {
-			multiErr = multierror.Append(multiErr, fmt.Errorf("%s%s: block schema is nil", prefix, name))
+			multiErr = errors.Join(multiErr, fmt.Errorf("%s%s: block schema is nil", prefix, name))
 			continue
 		}
 
 		if _, isAttr := b.Attributes[name]; isAttr {
-			multiErr = multierror.Append(multiErr, fmt.Errorf("%s%s: name defined as both attribute and child block type", prefix, name))
+			multiErr = errors.Join(multiErr, fmt.Errorf("%s%s: name defined as both attribute and child block type", prefix, name))
 		} else if !validName.MatchString(name) {
-			multiErr = multierror.Append(multiErr, fmt.Errorf("%s%s: name may contain only lowercase letters, digits and underscores", prefix, name))
+			multiErr = errors.Join(multiErr, fmt.Errorf("%s%s: name may contain only lowercase letters, digits and underscores", prefix, name))
 		}
 
 		if blockS.MinItems < 0 || blockS.MaxItems < 0 {
-			multiErr = multierror.Append(multiErr, fmt.Errorf("%s%s: MinItems and MaxItems must both be greater than zero", prefix, name))
+			multiErr = errors.Join(multiErr, fmt.Errorf("%s%s: MinItems and MaxItems must both be greater than zero", prefix, name))
 		}
 
 		switch blockS.Nesting {
 		case NestingSingle:
 			switch {
 			case blockS.MinItems != blockS.MaxItems:
-				multiErr = multierror.Append(multiErr, fmt.Errorf("%s%s: MinItems and MaxItems must match in NestingSingle mode", prefix, name))
+				multiErr = errors.Join(multiErr, fmt.Errorf("%s%s: MinItems and MaxItems must match in NestingSingle mode", prefix, name))
 			case blockS.MinItems < 0 || blockS.MinItems > 1:
-				multiErr = multierror.Append(multiErr, fmt.Errorf("%s%s: MinItems and MaxItems must be set to either 0 or 1 in NestingSingle mode", prefix, name))
+				multiErr = errors.Join(multiErr, fmt.Errorf("%s%s: MinItems and MaxItems must be set to either 0 or 1 in NestingSingle mode", prefix, name))
 			}
 		case NestingGroup:
 			if blockS.MinItems != 0 || blockS.MaxItems != 0 {
-				multiErr = multierror.Append(multiErr, fmt.Errorf("%s%s: MinItems and MaxItems cannot be used in NestingGroup mode", prefix, name))
+				multiErr = errors.Join(multiErr, fmt.Errorf("%s%s: MinItems and MaxItems cannot be used in NestingGroup mode", prefix, name))
 			}
 		case NestingList, NestingSet:
 			if blockS.MinItems > blockS.MaxItems && blockS.MaxItems != 0 {
-				multiErr = multierror.Append(multiErr, fmt.Errorf("%s%s: MinItems must be less than or equal to MaxItems in %s mode", prefix, name, blockS.Nesting))
+				multiErr = errors.Join(multiErr, fmt.Errorf("%s%s: MinItems must be less than or equal to MaxItems in %s mode", prefix, name, blockS.Nesting))
 			}
 			if blockS.Nesting == NestingSet {
 				ety := blockS.Block.ImpliedType()
@@ -76,22 +75,22 @@ func (b *Block) internalValidate(prefix string) error {
 					// This is not permitted because the HCL (cty) set implementation
 					// needs to know the exact type of set elements in order to
 					// properly hash them, and so can't support mixed types.
-					multiErr = multierror.Append(multiErr, fmt.Errorf("%s%s: NestingSet blocks may not contain attributes of cty.DynamicPseudoType", prefix, name))
+					multiErr = errors.Join(multiErr, fmt.Errorf("%s%s: NestingSet blocks may not contain attributes of cty.DynamicPseudoType", prefix, name))
 				}
 			}
 		case NestingMap:
 			if blockS.MinItems != 0 || blockS.MaxItems != 0 {
-				multiErr = multierror.Append(multiErr, fmt.Errorf("%s%s: MinItems and MaxItems must both be 0 in NestingMap mode", prefix, name))
+				multiErr = errors.Join(multiErr, fmt.Errorf("%s%s: MinItems and MaxItems must both be 0 in NestingMap mode", prefix, name))
 			}
 		default:
-			multiErr = multierror.Append(multiErr, fmt.Errorf("%s%s: invalid nesting mode %s", prefix, name, blockS.Nesting))
+			multiErr = errors.Join(multiErr, fmt.Errorf("%s%s: invalid nesting mode %s", prefix, name, blockS.Nesting))
 		}
 
 		subPrefix := prefix + name + "."
-		multiErr = multierror.Append(multiErr, blockS.Block.internalValidate(subPrefix))
+		multiErr = errors.Join(multiErr, blockS.Block.internalValidate(subPrefix))
 	}
 
-	return multiErr.ErrorOrNil()
+	return multiErr
 }
 
 // InternalValidate returns an error if the receiving attribute and its child
@@ -105,30 +104,30 @@ func (a *Attribute) InternalValidate(name string) error {
 }
 
 func (a *Attribute) internalValidate(name, prefix string) error {
-	var err *multierror.Error
+	var err error
 
 	/* FIXME: this validation breaks certain existing providers and cannot be enforced without coordination.
 	if !validName.MatchString(name) {
-		err = multierror.Append(err, fmt.Errorf("%s%s: name may contain only lowercase letters, digits and underscores", prefix, name))
+		err = errors.Join(err, fmt.Errorf("%s%s: name may contain only lowercase letters, digits and underscores", prefix, name))
 	}
 	*/
 	if !a.Optional && !a.Required && !a.Computed {
-		err = multierror.Append(err, fmt.Errorf("%s%s: must set Optional, Required or Computed", prefix, name))
+		err = errors.Join(err, fmt.Errorf("%s%s: must set Optional, Required or Computed", prefix, name))
 	}
 	if a.Optional && a.Required {
-		err = multierror.Append(err, fmt.Errorf("%s%s: cannot set both Optional and Required", prefix, name))
+		err = errors.Join(err, fmt.Errorf("%s%s: cannot set both Optional and Required", prefix, name))
 	}
 	if a.Computed && a.Required {
-		err = multierror.Append(err, fmt.Errorf("%s%s: cannot set both Computed and Required", prefix, name))
+		err = errors.Join(err, fmt.Errorf("%s%s: cannot set both Computed and Required", prefix, name))
 	}
 
 	if a.Type == cty.NilType && a.NestedType == nil {
-		err = multierror.Append(err, fmt.Errorf("%s%s: either Type or NestedType must be defined", prefix, name))
+		err = errors.Join(err, fmt.Errorf("%s%s: either Type or NestedType must be defined", prefix, name))
 	}
 
 	if a.Type != cty.NilType {
 		if a.NestedType != nil {
-			err = multierror.Append(fmt.Errorf("%s: Type and NestedType cannot both be set", name))
+			err = errors.Join(fmt.Errorf("%s: Type and NestedType cannot both be set", name))
 		}
 	}
 
@@ -143,20 +142,20 @@ func (a *Attribute) internalValidate(name, prefix string) error {
 					// This is not permitted because the HCL (cty) set implementation
 					// needs to know the exact type of set elements in order to
 					// properly hash them, and so can't support mixed types.
-					err = multierror.Append(err, fmt.Errorf("%s%s: NestingSet blocks may not contain attributes of cty.DynamicPseudoType", prefix, name))
+					err = errors.Join(err, fmt.Errorf("%s%s: NestingSet blocks may not contain attributes of cty.DynamicPseudoType", prefix, name))
 				}
 			}
 		default:
-			err = multierror.Append(err, fmt.Errorf("%s%s: invalid nesting mode %s", prefix, name, a.NestedType.Nesting))
+			err = errors.Join(err, fmt.Errorf("%s%s: invalid nesting mode %s", prefix, name, a.NestedType.Nesting))
 		}
 		for name, attrS := range a.NestedType.Attributes {
 			if attrS == nil {
-				err = multierror.Append(err, fmt.Errorf("%s%s: attribute schema is nil", prefix, name))
+				err = errors.Join(err, fmt.Errorf("%s%s: attribute schema is nil", prefix, name))
 				continue
 			}
-			err = multierror.Append(err, attrS.internalValidate(name, prefix))
+			err = errors.Join(err, attrS.internalValidate(name, prefix))
 		}
 	}
 
-	return err.ErrorOrNil()
+	return err
 }

--- a/internal/dag/dag.go
+++ b/internal/dag/dag.go
@@ -4,13 +4,12 @@
 package dag
 
 import (
+	"errors"
 	"fmt"
 	"sort"
 	"strings"
 
 	"github.com/hashicorp/terraform/internal/tfdiags"
-
-	"github.com/hashicorp/go-multierror"
 )
 
 // AcyclicGraph is a specialization of Graph that cannot have cycles.
@@ -131,7 +130,7 @@ func (g *AcyclicGraph) Validate() error {
 				cycleStr[j] = VertexName(vertex)
 			}
 
-			err = multierror.Append(err, fmt.Errorf(
+			err = errors.Join(err, fmt.Errorf(
 				"Cycle: %s", strings.Join(cycleStr, ", ")))
 		}
 	}
@@ -139,7 +138,7 @@ func (g *AcyclicGraph) Validate() error {
 	// Look for cycles to self
 	for _, e := range g.Edges() {
 		if e.Source() == e.Target() {
-			err = multierror.Append(err, fmt.Errorf(
+			err = errors.Join(err, fmt.Errorf(
 				"Self reference: %s", VertexName(e.Source())))
 		}
 	}

--- a/internal/states/statemgr/filesystem.go
+++ b/internal/states/statemgr/filesystem.go
@@ -6,6 +6,7 @@ package statemgr
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -14,8 +15,6 @@ import (
 	"path/filepath"
 	"sync"
 	"time"
-
-	multierror "github.com/hashicorp/go-multierror"
 
 	"github.com/hashicorp/terraform/internal/states"
 	"github.com/hashicorp/terraform/internal/states/statefile"
@@ -327,7 +326,7 @@ func (s *Filesystem) Lock(info *LockInfo) (string, error) {
 	if err := s.lock(); err != nil {
 		info, infoErr := s.lockInfo()
 		if infoErr != nil {
-			err = multierror.Append(err, infoErr)
+			err = errors.Join(err, infoErr)
 		}
 
 		lockErr := &LockError{
@@ -354,7 +353,7 @@ func (s *Filesystem) Unlock(id string) error {
 		idErr := fmt.Errorf("invalid lock id: %q. current id: %q", id, s.lockID)
 		info, err := s.lockInfo()
 		if err != nil {
-			idErr = multierror.Append(idErr, err)
+			idErr = errors.Join(idErr, err)
 		}
 
 		return &LockError{


### PR DESCRIPTION
In the early days the Go standard library lacked various useful helpers for wrapping and combining errors and so various parties, including HashiCorp itself, wrote separate libraries to fill those gaps.

However, recent improvements to the standard library have made those all redundant. There's now sufficient functionality in the standard library to support all of Terraform's error wrapping and combining needs.

This therefore removes all of the uses of the following three modules from our non-legacy packages:

- `github.com/pkg/errors`
- `github.com/hashicorp/go-multierror`
- `github.com/hashicorp/errwrap`

The latter two still have callers in the packages under our `legacy` directory, but we'll hopefully eventually take care of those with a combination of https://github.com/hashicorp/terraform/pull/34793 and https://github.com/hashicorp/terraform/pull/34772.

The first has no remaining callers in this repository, but unfortunately it's still used by the Consul SDK that we depend on for the `consul` remote state backend. Hopefully a future version of that will switch to using the standard library functions instead too, if that hasn't already happened.

This is motivated just by minimizing the number of external dependencies Terraform has. We prefer to use standard library functionality instead of third-party libraries whenever possible.

---

As a bonus, this also fills two prior gaps in the unit testing in `package tfdiags`.
