### PR TITLE
Insert schema marks to instance refresh state when import

### DIFF
--- a/internal/terraform/node_resource_plan_instance.go
+++ b/internal/terraform/node_resource_plan_instance.go
@@ -611,6 +611,17 @@ func (n *NodePlannableResourceInstance) importState(ctx EvalContext, addr addrs.
 		return instanceRefreshState, diags
 	}
 
+	// insert marks from schema
+	if n.Config != nil {
+		valueWithSchemaMarks, _, configDiags := ctx.EvaluateBlock(n.Config.Config, n.Schema, nil, EvalDataForNoInstanceKey)
+		diags = diags.Append(configDiags)
+		if configDiags.HasErrors() {
+			return instanceRefreshState, diags
+		}
+		_, pvm := valueWithSchemaMarks.UnmarkDeepWithPaths()
+		instanceRefreshState.Value = instanceRefreshState.Value.MarkWithPaths(pvm)
+	}
+
 	// If we're importing and generating config, generate it now.
 	if len(n.generateConfigPath) > 0 {
 		if n.Config != nil {


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

For resource import scenario, the instance refresh state should contains all the schema marks to avoid a update action caused by  difference marks between planned value and refresh state(for example: write or delete sensitive paths is an update action).

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Fixes #33597
