### PR TITLE
stackruntime: Support referencing Local Values within the `tfstacks.hcl` language

### DIFF
--- a/internal/stacks/stackruntime/internal/stackeval/local_value.go
+++ b/internal/stacks/stackruntime/internal/stackeval/local_value.go
@@ -1,0 +1,144 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package stackeval
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/zclconf/go-cty/cty"
+	"github.com/zclconf/go-cty/cty/convert"
+
+	"github.com/hashicorp/terraform/internal/collections"
+	"github.com/hashicorp/terraform/internal/promising"
+	"github.com/hashicorp/terraform/internal/stacks/stackaddrs"
+	"github.com/hashicorp/terraform/internal/stacks/stackconfig"
+	"github.com/hashicorp/terraform/internal/stacks/stackplan"
+	"github.com/hashicorp/terraform/internal/stacks/stackstate"
+	"github.com/hashicorp/terraform/internal/tfdiags"
+)
+
+// LocalValue represents an input variable belonging to a [Stack].
+type LocalValue struct {
+	addr stackaddrs.AbsLocalValue
+
+	main *Main
+
+	value perEvalPhase[promising.Once[withDiagnostics[cty.Value]]]
+}
+
+var _ Referenceable = (*LocalValue)(nil)
+var _ Plannable = (*LocalValue)(nil)
+
+func newLocalValue(main *Main, addr stackaddrs.AbsLocalValue) *LocalValue {
+	return &LocalValue{
+		addr: addr,
+		main: main,
+	}
+}
+
+func (v *LocalValue) Addr() stackaddrs.AbsLocalValue {
+	return v.addr
+}
+
+func (v *LocalValue) Config(ctx context.Context) *LocalValueConfig {
+	configAddr := stackaddrs.ConfigForAbs(v.Addr())
+	stackCfg := v.main.StackConfig(ctx, configAddr.Stack)
+	return stackCfg.LocalValue(ctx, configAddr.Item)
+}
+
+func (v *LocalValue) Declaration(ctx context.Context) *stackconfig.LocalValue {
+	return v.Config(ctx).Declaration()
+}
+
+func (v *LocalValue) Stack(ctx context.Context, phase EvalPhase) *Stack {
+	return v.main.Stack(ctx, v.Addr().Stack, phase)
+}
+
+func (v *LocalValue) Value(ctx context.Context, phase EvalPhase) cty.Value {
+	val, _ := v.CheckValue(ctx, phase)
+	return val
+}
+
+// ExprReferenceValue implements Referenceable.
+func (v *LocalValue) ExprReferenceValue(ctx context.Context, phase EvalPhase) cty.Value {
+	return v.Value(ctx, phase)
+}
+
+func (v *LocalValue) checkValid(ctx context.Context, phase EvalPhase) tfdiags.Diagnostics {
+	var diags tfdiags.Diagnostics
+
+	_, moreDiags := v.CheckValue(ctx, phase)
+	diags = diags.Append(moreDiags)
+
+	return diags
+}
+
+func (v *LocalValue) CheckValue(ctx context.Context, phase EvalPhase) (cty.Value, tfdiags.Diagnostics) {
+	return withCtyDynamicValPlaceholder(doOnceWithDiags(
+		ctx, v.value.For(phase), v.main,
+		func(ctx context.Context) (cty.Value, tfdiags.Diagnostics) {
+			var diags tfdiags.Diagnostics
+
+			decl := v.Declaration(ctx)
+			stack := v.Stack(ctx, phase)
+
+			if stack == nil {
+				// TODO(mutahhir): Needs review by someone who knows the codebase better.
+				// In OutputValue, this is returning an unknown value with type, but
+				// locals don't have a type, so Dynamic makes some sense here, but
+				// I don't know how it would affect other things
+				return cty.DynamicVal, diags
+			}
+
+			result, moreDiags := EvalExprAndEvalContext(ctx, decl.Value, phase, stack)
+			diags = diags.Append(moreDiags)
+			if moreDiags.HasErrors() {
+				return cty.DynamicVal, diags
+			}
+
+			var err error
+			result.Value, err = convert.Convert(result.Value, cty.DynamicPseudoType)
+
+			if err != nil {
+				diags = diags.Append(result.Diagnostic(
+					tfdiags.Error,
+					"Invalid local value",
+					fmt.Sprintf("Unsuitable value for local %q: %s.", v.Addr().Item.Name, tfdiags.FormatError(err)),
+				))
+				return cty.DynamicVal, diags
+			}
+
+			return result.Value, diags
+		},
+	))
+}
+
+// PlanChanges implements Plannable as a plan-time validation of the variable's
+// declaration and of the caller's definition of the variable.
+func (v *LocalValue) PlanChanges(ctx context.Context) ([]stackplan.PlannedChange, tfdiags.Diagnostics) {
+	return nil, v.checkValid(ctx, PlanPhase)
+}
+
+// References implements Referrer
+func (v *LocalValue) References(ctx context.Context) []stackaddrs.AbsReference {
+	cfg := v.Declaration(ctx)
+	var ret []stackaddrs.Reference
+	ret = append(ret, ReferencesInExpr(ctx, cfg.Value)...)
+	return makeReferencesAbsolute(ret, v.Addr().Stack)
+}
+
+// RequiredComponents implements Applyable
+func (v *LocalValue) RequiredComponents(ctx context.Context) collections.Set[stackaddrs.AbsComponent] {
+	return v.main.requiredComponentsForReferrer(ctx, v, PlanPhase)
+}
+
+// CheckApply implements Applyable.
+func (v *LocalValue) CheckApply(ctx context.Context) ([]stackstate.AppliedChange, tfdiags.Diagnostics) {
+	return nil, v.checkValid(ctx, ApplyPhase)
+}
+
+func (v *LocalValue) tracingName() string {
+	return v.Addr().String()
+}

--- a/internal/stacks/stackruntime/internal/stackeval/local_value.go
+++ b/internal/stacks/stackruntime/internal/stackeval/local_value.go
@@ -19,7 +19,7 @@ import (
 	"github.com/hashicorp/terraform/internal/tfdiags"
 )
 
-// LocalValue represents an input variable belonging to a [Stack].
+// LocalValue represents a local value defined within a [Stack].
 type LocalValue struct {
 	addr stackaddrs.AbsLocalValue
 
@@ -85,10 +85,6 @@ func (v *LocalValue) CheckValue(ctx context.Context, phase EvalPhase) (cty.Value
 			stack := v.Stack(ctx, phase)
 
 			if stack == nil {
-				// TODO(mutahhir): Needs review by someone who knows the codebase better.
-				// In OutputValue, this is returning an unknown value with type, but
-				// locals don't have a type, so Dynamic makes some sense here, but
-				// I don't know how it would affect other things
 				return cty.DynamicVal, diags
 			}
 
@@ -115,8 +111,7 @@ func (v *LocalValue) CheckValue(ctx context.Context, phase EvalPhase) (cty.Value
 	))
 }
 
-// PlanChanges implements Plannable as a plan-time validation of the variable's
-// declaration and of the caller's definition of the variable.
+// PlanChanges implements Plannable as a plan-time validation of the local value
 func (v *LocalValue) PlanChanges(ctx context.Context) ([]stackplan.PlannedChange, tfdiags.Diagnostics) {
 	return nil, v.checkValid(ctx, PlanPhase)
 }

--- a/internal/stacks/stackruntime/internal/stackeval/local_value.go
+++ b/internal/stacks/stackruntime/internal/stackeval/local_value.go
@@ -5,10 +5,8 @@ package stackeval
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/zclconf/go-cty/cty"
-	"github.com/zclconf/go-cty/cty/convert"
 
 	"github.com/hashicorp/terraform/internal/collections"
 	"github.com/hashicorp/terraform/internal/promising"
@@ -91,18 +89,6 @@ func (v *LocalValue) CheckValue(ctx context.Context, phase EvalPhase) (cty.Value
 			result, moreDiags := EvalExprAndEvalContext(ctx, decl.Value, phase, stack)
 			diags = diags.Append(moreDiags)
 			if moreDiags.HasErrors() {
-				return cty.DynamicVal, diags
-			}
-
-			var err error
-			result.Value, err = convert.Convert(result.Value, cty.DynamicPseudoType)
-
-			if err != nil {
-				diags = diags.Append(result.Diagnostic(
-					tfdiags.Error,
-					"Invalid local value",
-					fmt.Sprintf("Unsuitable value for local %q: %s.", v.Addr().Item.Name, tfdiags.FormatError(err)),
-				))
 				return cty.DynamicVal, diags
 			}
 

--- a/internal/stacks/stackruntime/internal/stackeval/local_value_config.go
+++ b/internal/stacks/stackruntime/internal/stackeval/local_value_config.go
@@ -1,0 +1,117 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package stackeval
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform/internal/promising"
+	"github.com/hashicorp/terraform/internal/stacks/stackaddrs"
+	"github.com/hashicorp/terraform/internal/stacks/stackconfig"
+	"github.com/hashicorp/terraform/internal/stacks/stackplan"
+	"github.com/hashicorp/terraform/internal/tfdiags"
+	"github.com/zclconf/go-cty/cty"
+)
+
+// LocalValueConfig represents a "variable" block in a stack configuration.
+type LocalValueConfig struct {
+	addr   stackaddrs.ConfigLocalValue
+	config *stackconfig.LocalValue
+
+	main *Main
+
+	validatedValue perEvalPhase[promising.Once[withDiagnostics[cty.Value]]]
+}
+
+var (
+	_ Validatable          = (*LocalValueConfig)(nil)
+	_ Referenceable        = (*LocalValueConfig)(nil)
+	_ namedPromiseReporter = (*LocalValueConfig)(nil)
+)
+
+func newLocalValueConfig(main *Main, addr stackaddrs.ConfigLocalValue, config *stackconfig.LocalValue) *LocalValueConfig {
+	if config == nil {
+		panic("newLocalValueConfig with nil configuration")
+	}
+	return &LocalValueConfig{
+		addr:   addr,
+		config: config,
+		main:   main,
+	}
+}
+
+func (v *LocalValueConfig) Addr() stackaddrs.ConfigLocalValue {
+	return v.addr
+}
+
+func (v *LocalValueConfig) tracingName() string {
+	return v.Addr().String()
+}
+
+func (v *LocalValueConfig) Declaration() *stackconfig.LocalValue {
+	return v.config
+}
+
+// StackConfig returns the stack configuration that this input variable belongs
+// to.
+func (v *LocalValueConfig) StackConfig(ctx context.Context) *StackConfig {
+	return v.main.mustStackConfig(ctx, v.Addr().Stack)
+}
+
+// ExprReferenceValue implements Referenceable
+func (v *LocalValueConfig) ExprReferenceValue(ctx context.Context, phase EvalPhase) cty.Value {
+	return cty.StringVal("parent")
+}
+
+// ValidateValue validates that the value expression is evaluatable and that
+// its result can convert to the declared type constraint, returning the
+// resulting value.
+//
+// If the returned diagnostics has errors then the returned value might be
+// just an approximation of the result, such as an unknown value with the
+// declared type constraint.
+func (v *LocalValueConfig) ValidateValue(ctx context.Context, phase EvalPhase) (cty.Value, tfdiags.Diagnostics) {
+	return withCtyDynamicValPlaceholder(doOnceWithDiags(
+		ctx, v.validatedValue.For(phase), v.main,
+		v.validateValueInner,
+	))
+}
+
+// validateValueInner is the real implementation of ValidateValue, which runs
+// in the background only once per instance of [OutputValueConfig] and then
+// provides the result for all ValidateValue callers simultaneously.
+func (lv *LocalValueConfig) validateValueInner(ctx context.Context) (cty.Value, tfdiags.Diagnostics) {
+	var diags tfdiags.Diagnostics
+
+	result, moreDiags := EvalExprAndEvalContext(ctx, lv.config.Value, ValidatePhase, lv.StackConfig(ctx))
+	v := result.Value
+	diags = diags.Append(moreDiags)
+	if moreDiags.HasErrors() {
+		v = cty.UnknownVal(cty.DynamicPseudoType)
+	}
+
+	return v, diags
+}
+
+func (v *LocalValueConfig) checkValid(ctx context.Context, phase EvalPhase) tfdiags.Diagnostics {
+	var diags tfdiags.Diagnostics
+	_, moreDiags := v.ValidateValue(ctx, phase)
+	diags = diags.Append(moreDiags)
+	return diags
+}
+
+// Validate implements Validatable
+func (v *LocalValueConfig) Validate(ctx context.Context) tfdiags.Diagnostics {
+	return v.checkValid(ctx, ValidatePhase)
+}
+
+// PlanChanges implements Plannable.
+func (v *LocalValueConfig) PlanChanges(ctx context.Context) ([]stackplan.PlannedChange, tfdiags.Diagnostics) {
+	return nil, v.checkValid(ctx, PlanPhase)
+}
+
+// reportNamedPromises implements namedPromiseReporter.
+func (s *LocalValueConfig) reportNamedPromises(cb func(id promising.PromiseID, name string)) {
+	// Nothing to report yet
+}

--- a/internal/stacks/stackruntime/internal/stackeval/local_value_config.go
+++ b/internal/stacks/stackruntime/internal/stackeval/local_value_config.go
@@ -61,7 +61,9 @@ func (v *LocalValueConfig) StackConfig(ctx context.Context) *StackConfig {
 
 // ExprReferenceValue implements Referenceable
 func (v *LocalValueConfig) ExprReferenceValue(ctx context.Context, phase EvalPhase) cty.Value {
-	return cty.DynamicVal
+	out, _ := v.ValidateValue(ctx, phase)
+
+	return out
 }
 
 // ValidateValue validates that the value expression is evaluatable and that

--- a/internal/stacks/stackruntime/internal/stackeval/local_value_config.go
+++ b/internal/stacks/stackruntime/internal/stackeval/local_value_config.go
@@ -14,7 +14,7 @@ import (
 	"github.com/zclconf/go-cty/cty"
 )
 
-// LocalValueConfig represents a "variable" block in a stack configuration.
+// LocalValueConfig represents a "locals" block in a stack configuration.
 type LocalValueConfig struct {
 	addr   stackaddrs.ConfigLocalValue
 	config *stackconfig.LocalValue
@@ -61,7 +61,7 @@ func (v *LocalValueConfig) StackConfig(ctx context.Context) *StackConfig {
 
 // ExprReferenceValue implements Referenceable
 func (v *LocalValueConfig) ExprReferenceValue(ctx context.Context, phase EvalPhase) cty.Value {
-	return cty.StringVal("parent")
+	return cty.DynamicVal
 }
 
 // ValidateValue validates that the value expression is evaluatable and that

--- a/internal/stacks/stackruntime/internal/stackeval/local_value_test.go
+++ b/internal/stacks/stackruntime/internal/stackeval/local_value_test.go
@@ -5,14 +5,10 @@ package stackeval
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
-	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/promising"
-	"github.com/hashicorp/terraform/internal/providers"
 	"github.com/hashicorp/terraform/internal/stacks/stackaddrs"
-	stacks_testing_provider "github.com/hashicorp/terraform/internal/stacks/stackruntime/testing"
 	"github.com/zclconf/go-cty/cty"
 )
 
@@ -83,56 +79,4 @@ func TestLocalValueValue(t *testing.T) {
 			})
 		})
 	}
-}
-
-func TestLocalValueWithProvider(t *testing.T) {
-	ctx := context.Background()
-	cfg := testStackConfig(t, "local_value", "custom_provider")
-
-	tests := map[string]struct {
-		LocalName string
-		WantVal   cty.Value
-	}{
-		"name": {
-			LocalName: "name",
-			WantVal:   cty.StringVal("jackson"),
-		},
-	}
-
-	for name, test := range tests {
-		t.Run(name, func(t *testing.T) {
-			main := testEvaluator(t, testEvaluatorOpts{
-				Config: cfg,
-				ProviderFactories: map[addrs.Provider]providers.Factory{
-					addrs.NewDefaultProvider("test"): func() (providers.Interface, error) {
-						return stacks_testing_provider.NewProvider(), nil
-					},
-				},
-			})
-
-			promising.MainTask(ctx, func(ctx context.Context) (struct{}, error) {
-				promising.MainTask(ctx, func(ctx context.Context) (struct{}, error) {
-					mainStack := main.MainStack(ctx)
-					rootVal := mainStack.LocalValue(ctx, stackaddrs.LocalValue{Name: test.LocalName})
-					rootOutput := mainStack.OutputValues(ctx)[stackaddrs.OutputValue{Name: "name"}]
-					got, diags := rootVal.CheckValue(ctx, PlanPhase)
-
-					if diags.HasErrors() {
-						t.Errorf("unexpected errors\n%s", diags.Err().Error())
-					}
-
-					outs, diags := rootOutput.CheckResultValue(ctx, InspectPhase)
-					fmt.Printf("output: %#v\n", outs)
-
-					if got.Equals(test.WantVal).False() {
-						t.Errorf("got %s, want %s", got, test.WantVal)
-					}
-
-					return struct{}{}, nil
-				})
-				return struct{}{}, nil
-			})
-		})
-	}
-
 }

--- a/internal/stacks/stackruntime/internal/stackeval/local_value_test.go
+++ b/internal/stacks/stackruntime/internal/stackeval/local_value_test.go
@@ -24,10 +24,36 @@ func TestLocalValueValue(t *testing.T) {
 			LocalName: "name",
 			WantVal:   cty.StringVal("jackson"),
 		},
-		// "childName": {
-		// 	LocalName: "childName",
-		// 	WantVal:   cty.StringVal("foo"),
-		// },
+		"childName": {
+			LocalName: "childName",
+			WantVal:   cty.StringVal("outputted-child of jackson"),
+		},
+		"functional": {
+			LocalName: "functional",
+			WantVal:   cty.StringVal("Hello, Ander!"),
+		},
+		"mappy": {
+			LocalName: "mappy",
+			WantVal: cty.ObjectVal(map[string]cty.Value{
+				"name": cty.StringVal("jackson"),
+				"age":  cty.NumberIntVal(30),
+			}),
+		},
+		"listy": {
+			LocalName: "listy",
+			WantVal: cty.TupleVal([]cty.Value{
+				cty.StringVal("jackson"),
+				cty.NumberIntVal(30),
+			}),
+		},
+		"booleany": {
+			LocalName: "booleany",
+			WantVal:   cty.BoolVal(true),
+		},
+		"conditiony": {
+			LocalName: "conditiony",
+			WantVal:   cty.StringVal("true"),
+		},
 	}
 
 	for name, test := range tests {
@@ -45,7 +71,7 @@ func TestLocalValueValue(t *testing.T) {
 					t.Errorf("unexpected errors\n%s", diags.Err().Error())
 				}
 
-				if got != test.WantVal {
+				if got.Equals(test.WantVal).False() {
 					t.Errorf("got %s, want %s", got, test.WantVal)
 				}
 

--- a/internal/stacks/stackruntime/internal/stackeval/local_value_test.go
+++ b/internal/stacks/stackruntime/internal/stackeval/local_value_test.go
@@ -1,0 +1,77 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package stackeval
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform/internal/promising"
+	"github.com/hashicorp/terraform/internal/stacks/stackaddrs"
+	"github.com/zclconf/go-cty/cty"
+)
+
+func TestLocalValueValue(t *testing.T) {
+	ctx := context.Background()
+	cfg := testStackConfig(t, "local_value", "basics")
+
+	tests := map[string]struct {
+		LocalName string
+		WantVal   cty.Value
+	}{
+		"name": {
+			LocalName: "name",
+			WantVal:   cty.StringVal("jackson"),
+		},
+		// "childName": {
+		// 	LocalName: "childName",
+		// 	WantVal:   cty.StringVal("foo"),
+		// },
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			main := testEvaluator(t, testEvaluatorOpts{
+				Config: cfg,
+			})
+
+			promising.MainTask(ctx, func(ctx context.Context) (struct{}, error) {
+				mainStack := main.MainStack(ctx)
+				rootVal := mainStack.LocalValue(ctx, stackaddrs.LocalValue{Name: test.LocalName})
+				got, diags := rootVal.CheckValue(ctx, InspectPhase)
+
+				if diags.HasErrors() {
+					t.Errorf("unexpected errors\n%s", diags.Err().Error())
+				}
+
+				if got != test.WantVal {
+					t.Errorf("got %s, want %s", got, test.WantVal)
+				}
+
+				return struct{}{}, nil
+			})
+		})
+	}
+
+	// main := testEvaluator(t, testEvaluatorOpts{
+	// 	Config: cfg,
+	// })
+	//
+	// promising.MainTask(ctx, func(ctx context.Context) (struct{}, error) {
+	// 	mainStack := main.MainStack(ctx)
+	// 	rootVal := mainStack.LocalValue(ctx, stackaddrs.LocalValue{Name: "name"})
+	// 	got, diags := rootVal.CheckValue(ctx, InspectPhase)
+	//
+	// 	if diags.HasErrors() {
+	// 		t.Errorf("unexpected errors\n%s", diags.Err().Error())
+	// 	}
+	//
+	// 	want := cty.StringVal("parent")
+	// 	if got != want {
+	// 		t.Errorf("got %s, want %s", got, want)
+	// 	}
+	//
+	// 	return struct{}{}, nil
+	// })
+}

--- a/internal/stacks/stackruntime/internal/stackeval/local_value_test.go
+++ b/internal/stacks/stackruntime/internal/stackeval/local_value_test.go
@@ -5,10 +5,14 @@ package stackeval
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
+	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/promising"
+	"github.com/hashicorp/terraform/internal/providers"
 	"github.com/hashicorp/terraform/internal/stacks/stackaddrs"
+	stacks_testing_provider "github.com/hashicorp/terraform/internal/stacks/stackruntime/testing"
 	"github.com/zclconf/go-cty/cty"
 )
 
@@ -79,25 +83,56 @@ func TestLocalValueValue(t *testing.T) {
 			})
 		})
 	}
+}
 
-	// main := testEvaluator(t, testEvaluatorOpts{
-	// 	Config: cfg,
-	// })
-	//
-	// promising.MainTask(ctx, func(ctx context.Context) (struct{}, error) {
-	// 	mainStack := main.MainStack(ctx)
-	// 	rootVal := mainStack.LocalValue(ctx, stackaddrs.LocalValue{Name: "name"})
-	// 	got, diags := rootVal.CheckValue(ctx, InspectPhase)
-	//
-	// 	if diags.HasErrors() {
-	// 		t.Errorf("unexpected errors\n%s", diags.Err().Error())
-	// 	}
-	//
-	// 	want := cty.StringVal("parent")
-	// 	if got != want {
-	// 		t.Errorf("got %s, want %s", got, want)
-	// 	}
-	//
-	// 	return struct{}{}, nil
-	// })
+func TestLocalValueWithProvider(t *testing.T) {
+	ctx := context.Background()
+	cfg := testStackConfig(t, "local_value", "custom_provider")
+
+	tests := map[string]struct {
+		LocalName string
+		WantVal   cty.Value
+	}{
+		"name": {
+			LocalName: "name",
+			WantVal:   cty.StringVal("jackson"),
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			main := testEvaluator(t, testEvaluatorOpts{
+				Config: cfg,
+				ProviderFactories: map[addrs.Provider]providers.Factory{
+					addrs.NewDefaultProvider("test"): func() (providers.Interface, error) {
+						return stacks_testing_provider.NewProvider(), nil
+					},
+				},
+			})
+
+			promising.MainTask(ctx, func(ctx context.Context) (struct{}, error) {
+				promising.MainTask(ctx, func(ctx context.Context) (struct{}, error) {
+					mainStack := main.MainStack(ctx)
+					rootVal := mainStack.LocalValue(ctx, stackaddrs.LocalValue{Name: test.LocalName})
+					rootOutput := mainStack.OutputValues(ctx)[stackaddrs.OutputValue{Name: "name"}]
+					got, diags := rootVal.CheckValue(ctx, PlanPhase)
+
+					if diags.HasErrors() {
+						t.Errorf("unexpected errors\n%s", diags.Err().Error())
+					}
+
+					outs, diags := rootOutput.CheckResultValue(ctx, InspectPhase)
+					fmt.Printf("output: %#v\n", outs)
+
+					if got.Equals(test.WantVal).False() {
+						t.Errorf("got %s, want %s", got, test.WantVal)
+					}
+
+					return struct{}{}, nil
+				})
+				return struct{}{}, nil
+			})
+		})
+	}
+
 }

--- a/internal/stacks/stackruntime/internal/stackeval/planning_test.go
+++ b/internal/stacks/stackruntime/internal/stackeval/planning_test.go
@@ -1019,7 +1019,6 @@ func TestPlanning_LocalsDataSource(t *testing.T) {
 					if cmp.Diff(mapOutput, expectedMap, ctydebug.CmpOptions) != "" {
 						t.Fatalf("map output is wrong, expected \n%+v,\ngot\n%+v", expectedMap, mapOutput)
 					}
-
 				}
 			default:
 				break

--- a/internal/stacks/stackruntime/internal/stackeval/planning_test.go
+++ b/internal/stacks/stackruntime/internal/stackeval/planning_test.go
@@ -945,8 +945,5 @@ func TestPlanning_Locals(t *testing.T) {
 		if diags.HasErrors() {
 			t.Fatalf("errors encountered\n%s", spew.Sdump(diags.ForRPC()))
 		}
-
-		fmt.Printf("plan: %v\n", plan)
-
 	})
 }

--- a/internal/stacks/stackruntime/internal/stackeval/planning_test.go
+++ b/internal/stacks/stackruntime/internal/stackeval/planning_test.go
@@ -941,7 +941,7 @@ func TestPlanning_Locals(t *testing.T) {
 	})
 
 	inPromisingTask(t, func(ctx context.Context, t *testing.T) {
-		plan, diags := testPlan(t, main)
+		_, diags := testPlan(t, main)
 		if diags.HasErrors() {
 			t.Fatalf("errors encountered\n%s", spew.Sdump(diags.ForRPC()))
 		}

--- a/internal/stacks/stackruntime/internal/stackeval/planning_test.go
+++ b/internal/stacks/stackruntime/internal/stackeval/planning_test.go
@@ -970,6 +970,10 @@ func TestPlanning_LocalsDataSource(t *testing.T) {
 		return rawPlan, nil
 	})
 
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	_, err = promising.MainTask(ctx, func(ctx context.Context) (*stackstate.State, error) {
 		outp, outpTest := testApplyOutput(t, nil)
 		_, err := ApplyPlan(ctx, cfg, rawPlan, ApplyOpts{
@@ -1032,5 +1036,4 @@ func TestPlanning_LocalsDataSource(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-
 }

--- a/internal/stacks/stackruntime/internal/stackeval/planning_test.go
+++ b/internal/stacks/stackruntime/internal/stackeval/planning_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/davecgh/go-spew/spew"
 	"github.com/google/go-cmp/cmp"
+	"github.com/zclconf/go-cty-debug/ctydebug"
 	"github.com/zclconf/go-cty/cty"
 	"google.golang.org/protobuf/reflect/protoreflect"
 	"google.golang.org/protobuf/types/known/anypb"
@@ -24,6 +25,7 @@ import (
 	providerTesting "github.com/hashicorp/terraform/internal/providers/testing"
 	"github.com/hashicorp/terraform/internal/stacks/stackaddrs"
 	"github.com/hashicorp/terraform/internal/stacks/stackplan"
+	stacks_testing_provider "github.com/hashicorp/terraform/internal/stacks/stackruntime/testing"
 	"github.com/hashicorp/terraform/internal/stacks/stackstate"
 	"github.com/hashicorp/terraform/internal/stacks/stackstate/statekeys"
 	"github.com/hashicorp/terraform/internal/stacks/tfstackdata1"
@@ -924,17 +926,6 @@ func TestPlanning_NoWorkspaceNameRef(t *testing.T) {
 }
 
 func TestPlanning_Locals(t *testing.T) {
-	// This test verifies that a reference to terraform.workspace is treated
-	// as invalid for modules used in a stacks context, because there's
-	// no comparable single string to use in stacks context and we expect
-	// modules used in stack components to vary declarations based only
-	// on their input variables.
-	//
-	// (If something needs to vary between stack deployments then that's
-	// a good candidate for an input variable on the root stack configuration,
-	// set differently for each deployment, and then passed in to the
-	// components that need it.)
-
 	cfg := testStackConfig(t, "local_value", "basics")
 	main := NewForPlanning(cfg, stackstate.NewState(), PlanOpts{
 		PlanningMode: plans.NormalMode,
@@ -946,4 +937,101 @@ func TestPlanning_Locals(t *testing.T) {
 			t.Fatalf("errors encountered\n%s", spew.Sdump(diags.ForRPC()))
 		}
 	})
+}
+
+func TestPlanning_LocalsDataSource(t *testing.T) {
+	ctx := context.Background()
+	cfg := testStackConfig(t, "local_value", "custom_provider")
+	providerFactories := map[addrs.Provider]providers.Factory{
+		addrs.NewDefaultProvider("testing"): func() (providers.Interface, error) {
+			provider := stacks_testing_provider.NewProvider()
+			return provider, nil
+		},
+	}
+
+	main := NewForPlanning(cfg, stackstate.NewState(), PlanOpts{
+		PlanningMode:      plans.NormalMode,
+		ProviderFactories: providerFactories,
+	})
+
+	comp2Addr := stackaddrs.AbsComponentInstance{
+		Stack: stackaddrs.RootStackInstance,
+		Item: stackaddrs.ComponentInstance{
+			Component: stackaddrs.Component{Name: "child2"},
+		},
+	}
+
+	rawPlan, err := promising.MainTask(ctx, func(ctx context.Context) ([]*anypb.Any, error) {
+		outp, outpTest := testPlanOutput(t)
+		main.PlanAll(ctx, outp)
+		rawPlan := outpTest.RawChanges(t)
+		_, diags := outpTest.Close(t)
+		assertNoDiagnostics(t, diags)
+		return rawPlan, nil
+	})
+
+	_, err = promising.MainTask(ctx, func(ctx context.Context) (*stackstate.State, error) {
+		outp, outpTest := testApplyOutput(t, nil)
+		_, err := ApplyPlan(ctx, cfg, rawPlan, ApplyOpts{
+			ProviderFactories: providerFactories,
+		}, outp)
+		if err != nil {
+			t.Fatal(err)
+		}
+		state, diags := outpTest.Close(t)
+		applies := outpTest.AppliedChanges()
+		for _, apply := range applies {
+			switch v := apply.(type) {
+			case *stackstate.AppliedChangeComponentInstance:
+				if v.ComponentAddr.Item.Name == comp2Addr.Item.Component.Name {
+					stringKey := addrs.OutputValue{
+						Name: "bar",
+					}
+					listKey := addrs.OutputValue{
+						Name: "list",
+					}
+					mapKey := addrs.OutputValue{
+						Name: "map",
+					}
+
+					stringOutput := v.OutputValues[stringKey]
+					listOutput := v.OutputValues[listKey].AsValueSlice()
+					mapOutput := v.OutputValues[mapKey].AsValueMap()
+
+					expectedString := cty.StringVal("through-local-aloha-foo-foo")
+					expectedList := []cty.Value{
+						cty.StringVal("through-local-aloha-foo"),
+						cty.StringVal("foo")}
+
+					expectedMap := map[string]cty.Value{
+						"key":   cty.StringVal("through-local-aloha-foo"),
+						"value": cty.StringVal("foo"),
+					}
+
+					if cmp.Diff(stringOutput, expectedString, ctydebug.CmpOptions) != "" {
+						t.Fatalf("string output is wrong, expected %q", expectedString.AsString())
+					}
+
+					if cmp.Diff(listOutput, expectedList, ctydebug.CmpOptions) != "" {
+						t.Fatalf("list output is wrong, expected \n%+v,\ngot\n%+v", expectedList, listOutput)
+					}
+
+					if cmp.Diff(mapOutput, expectedMap, ctydebug.CmpOptions) != "" {
+						t.Fatalf("map output is wrong, expected \n%+v,\ngot\n%+v", expectedMap, mapOutput)
+					}
+
+				}
+			default:
+				break
+			}
+		}
+		assertNoDiagnostics(t, diags)
+
+		return state, nil
+	})
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
 }

--- a/internal/stacks/stackruntime/internal/stackeval/stack.go
+++ b/internal/stacks/stackruntime/internal/stackeval/stack.go
@@ -42,13 +42,16 @@ type Stack struct {
 	// use ChildStackChecked if you need to be sure it's actually configured.
 	childStacks    map[stackaddrs.StackInstanceStep]*Stack
 	inputVariables map[stackaddrs.InputVariable]*InputVariable
+	localValues    map[stackaddrs.LocalValue]*LocalValue
 	stackCalls     map[stackaddrs.StackCall]*StackCall
 	outputValues   map[stackaddrs.OutputValue]*OutputValue
 	components     map[stackaddrs.Component]*Component
 }
 
-var _ ExpressionScope = (*Stack)(nil)
-var _ Plannable = (*Stack)(nil)
+var (
+	_ ExpressionScope = (*Stack)(nil)
+	_ Plannable       = (*Stack)(nil)
+)
 
 func newStack(main *Main, addr stackaddrs.StackInstance) *Stack {
 	return &Stack{
@@ -201,6 +204,36 @@ func (s *Stack) InputVariables(ctx context.Context) map[stackaddrs.InputVariable
 
 func (s *Stack) InputVariable(ctx context.Context, addr stackaddrs.InputVariable) *InputVariable {
 	return s.InputVariables(ctx)[addr]
+}
+
+// LocalValues returns a map of all of the input variables declared within
+// this stack's configuration.
+func (s *Stack) LocalValues(ctx context.Context) map[stackaddrs.LocalValue]*LocalValue {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	// We intentionally save a non-nil map below even if it's empty so that
+	// we can unambiguously recognize whether we've loaded this or not.
+	if s.localValues != nil {
+		return s.localValues
+	}
+
+	decls := s.ConfigDeclarations(ctx)
+	ret := make(map[stackaddrs.LocalValue]*LocalValue, len(decls.LocalValues))
+	for _, c := range decls.LocalValues {
+		absAddr := stackaddrs.AbsLocalValue{
+			Stack: s.Addr(),
+			Item:  stackaddrs.LocalValue{Name: c.Name},
+		}
+		ret[absAddr.Item] = newLocalValue(s.main, absAddr)
+	}
+	s.localValues = ret
+	return ret
+}
+
+// LocalValue returns the [LocalValue] specified by address
+func (s *Stack) LocalValue(ctx context.Context, addr stackaddrs.LocalValue) *LocalValue {
+	return s.LocalValues(ctx)[addr]
 }
 
 // InputsType returns an object type that the object representing the caller's
@@ -398,7 +431,12 @@ func (s *Stack) ResolveExpressionReference(ctx context.Context, ref stackaddrs.R
 // used for this stack's scope and all of the nested scopes of declarations
 // in the same stack, since they tend to differ only in what "self" means
 // and what each.key, each.value, or count.index are set to (if anything).
-func (s *Stack) resolveExpressionReference(ctx context.Context, ref stackaddrs.Reference, selfAddr stackaddrs.Referenceable, repetition instances.RepetitionData) (Referenceable, tfdiags.Diagnostics) {
+func (s *Stack) resolveExpressionReference(
+	ctx context.Context,
+	ref stackaddrs.Reference,
+	selfAddr stackaddrs.Referenceable,
+	repetition instances.RepetitionData,
+) (Referenceable, tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
 
 	// "Test-only globals" is a special affordance we have only when running
@@ -426,6 +464,18 @@ func (s *Stack) resolveExpressionReference(ctx context.Context, ref stackaddrs.R
 				Severity: hcl.DiagError,
 				Summary:  "Reference to undeclared input variable",
 				Detail:   fmt.Sprintf("There is no variable %q block declared in this stack.", addr.Name),
+				Subject:  ref.SourceRange.ToHCL().Ptr(),
+			})
+			return nil, diags
+		}
+		return ret, diags
+	case stackaddrs.LocalValue:
+		ret := s.LocalValue(ctx, addr)
+		if ret == nil {
+			diags = diags.Append(&hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  "Reference to undeclared local value",
+				Detail:   fmt.Sprintf("There is no local %q declared in this stack.", addr.Name),
 				Subject:  ref.SourceRange.ToHCL().Ptr(),
 			})
 			return nil, diags

--- a/internal/stacks/stackruntime/internal/stackeval/testdata/sourcebundle/local_value/basics/child/local-value-basics-child.tfstack.hcl
+++ b/internal/stacks/stackruntime/internal/stackeval/testdata/sourcebundle/local_value/basics/child/local-value-basics-child.tfstack.hcl
@@ -1,0 +1,9 @@
+
+variable "name" {
+  type = string
+}
+
+output "outputted_name" {
+  type = string
+  value = "outputted-${var.name}"
+}

--- a/internal/stacks/stackruntime/internal/stackeval/testdata/sourcebundle/local_value/basics/local-value-basics.tfstack.hcl
+++ b/internal/stacks/stackruntime/internal/stackeval/testdata/sourcebundle/local_value/basics/local-value-basics.tfstack.hcl
@@ -2,6 +2,15 @@
 locals {
   name = "jackson"
   childName = stack.child.outputted_name
+  functional = format("Hello, %s!", "Ander")
+  mappy = {
+    name = "jackson",
+    age = 30
+  }
+
+  listy = ["jackson", 30]
+  booleany = true
+  conditiony = local.booleany == true ? "true" : "false"
 }
 
 stack "child" {

--- a/internal/stacks/stackruntime/internal/stackeval/testdata/sourcebundle/local_value/basics/local-value-basics.tfstack.hcl
+++ b/internal/stacks/stackruntime/internal/stackeval/testdata/sourcebundle/local_value/basics/local-value-basics.tfstack.hcl
@@ -1,0 +1,13 @@
+
+locals {
+  name = "jackson"
+  childName = stack.child.outputted_name
+}
+
+stack "child" {
+  source = "./child"
+
+  inputs = {
+    name = "child of ${local.name}"
+  }
+}

--- a/internal/stacks/stackruntime/internal/stackeval/testdata/sourcebundle/local_value/custom_provider/child/child.tf
+++ b/internal/stacks/stackruntime/internal/stackeval/testdata/sourcebundle/local_value/custom_provider/child/child.tf
@@ -1,0 +1,39 @@
+terraform {
+required_providers {
+    testing = {
+      source = "hashicorp/testing"
+    }
+  }
+}
+
+variable "name" {
+  type = string
+}
+variable "list" {
+  type = list(string)
+}
+variable "map" {
+  type = map(string)
+}
+
+resource "testing_resource" "resource" {
+  id = "foo"
+  value = "foo"
+}
+
+data "testing_data_source" "data_source" {
+  id = "foo"
+  depends_on = [testing_resource.resource]
+}
+
+output "bar" {
+  value = "${var.name}-${data.testing_data_source.data_source.value}"
+}
+
+output "list" {
+  value = concat(var.list, ["${data.testing_data_source.data_source.value}"])
+}
+
+output "map" {
+  value = merge(var.map, { "value" = data.testing_data_source.data_source.value })
+}

--- a/internal/stacks/stackruntime/internal/stackeval/testdata/sourcebundle/local_value/custom_provider/custom-provider-local.tfstack.hcl
+++ b/internal/stacks/stackruntime/internal/stackeval/testdata/sourcebundle/local_value/custom_provider/custom-provider-local.tfstack.hcl
@@ -1,0 +1,46 @@
+required_providers {
+  testing = {
+    source = "hashicorp/testing"
+    version = "0.0.1"
+ }
+}
+
+locals {
+  stringName = "through-local-${component.child.bar}"
+  listName = ["through-local-${component.child.bar}"]
+  mapName = {
+    key = "through-local-${component.child.bar}"
+  }
+}
+
+provider "testing" "this" {}
+
+component "child" {
+  source = "./child"
+
+  inputs = {
+    name = "aloha"
+    list = ["aloha"]
+    map = {
+      key = "aloha"
+    }
+  }
+
+  providers = {
+    testing = provider.testing.this
+  }
+}
+
+component "child2" {
+  source = "./child"
+
+  inputs = {
+    name = local.stringName
+    list = local.listName
+    map = local.mapName
+  }
+
+  providers = {
+    testing = provider.testing.this
+  }
+}

--- a/internal/stacks/stackruntime/internal/stackeval/testdata/sourcebundle/terraform-sources.json
+++ b/internal/stacks/stackruntime/internal/stackeval/testdata/sourcebundle/terraform-sources.json
@@ -6,6 +6,10 @@
       "local": "input_variable"
     },
     {
+      "source": "https://testing.invalid/local_value.tar.gz",
+      "local": "local_value"
+    },
+    {
       "source": "https://testing.invalid/output_value.tar.gz",
       "local": "output_value"
     },

--- a/internal/stacks/stackruntime/internal/stackeval/walk_static.go
+++ b/internal/stacks/stackruntime/internal/stackeval/walk_static.go
@@ -52,6 +52,9 @@ func walkStaticObjectsInStackConfig[Output any](
 	}
 
 	// TODO: All of the other static object types
+	for _, obj := range stackConfig.LocalValues(ctx) {
+		visit(ctx, walk, obj)
+	}
 
 	for _, obj := range stackConfig.Providers(ctx) {
 		visit(ctx, walk, obj)


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Local Values are made available in the .tfstack.hcl language. The existing codebase already had support for local values, it was incomplete was missing the machinery required to reference local values within the `tfstacks.hcl` files. 


## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.8.x