### PR TITLE
backends: Start to wean off of legacy helper/schema

### DIFF
--- a/internal/backend/backendbase/base.go
+++ b/internal/backend/backendbase/base.go
@@ -1,0 +1,93 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package backendbase
+
+import (
+	"fmt"
+
+	"github.com/zclconf/go-cty/cty"
+
+	"github.com/hashicorp/terraform/internal/configs/configschema"
+	"github.com/hashicorp/terraform/internal/tfdiags"
+)
+
+// Base is a partial implementation of [backend.Backend] that can be embedded
+// into another implementer to handle most of the configuration schema
+// wrangling.
+//
+// Specifically it implements the ConfigSchema and PrepareConfig methods.
+// Implementers embedding this base type must still implement all of the other
+// Backend methods.
+type Base struct {
+	// Schema is the schema for the backend configuration.
+	//
+	// This shares the same configuration schema model as used in provider
+	// schemas for resource types, etc, but only a subset of the model is
+	// actually meaningful for backends. In particular, it doesn't make sense
+	// to define "computed" attributes because objects conforming to the
+	// schema are only use for input based on the configuration, and can't
+	// export any data for use elsewhere in the configuration.
+	Schema *configschema.Block
+}
+
+// ConfigSchema returns the configuration schema for the backend.
+func (b Base) ConfigSchema() *configschema.Block {
+	return b.Schema
+}
+
+// PrepareConfig coerces the given value to the backend's schema if possible,
+// and emits deprecation warnings if any deprecated arguments have values
+// assigned to them.
+func (b Base) PrepareConfig(configVal cty.Value) (cty.Value, tfdiags.Diagnostics) {
+	var diags tfdiags.Diagnostics
+
+	schema := b.Schema
+
+	v, err := schema.CoerceValue(configVal)
+	if err != nil {
+		var path cty.Path
+		if err, ok := err.(cty.PathError); ok {
+			path = err.Path
+		}
+		diags = diags.Append(tfdiags.AttributeValue(
+			tfdiags.Error,
+			"Invalid backend configuration",
+			fmt.Sprintf("The backend configuration is incorrect: %s.", tfdiags.FormatError(err)),
+			path,
+		))
+		return cty.DynamicVal, diags
+	}
+
+	cty.Walk(v, func(path cty.Path, v cty.Value) (bool, error) {
+		if v.IsNull() {
+			// Null values for deprecated arguments do not generate deprecation
+			// warnings, because that represents the argument not being set.
+			return false, nil
+		}
+
+		// If this path refers to a schema attribute then it might be
+		// deprecated, in which case we need to return a warning.
+		attr := schema.AttributeByPath(path)
+		if attr == nil {
+			return true, nil
+		}
+		if attr.Deprecated {
+			// The configschema model only has a boolean flag for whether the
+			// argument is deprecated or not, so this warning message is
+			// generic. Backends that want to return a custom message should
+			// leave this flag unset and instead implement a check inside
+			// their Configure method that returns a warning diagnostic.
+			diags = diags.Append(tfdiags.AttributeValue(
+				tfdiags.Warning,
+				"Deprecated provider argument",
+				fmt.Sprintf("The argument %s is deprecated. Refer to the backend documentation for more information.", tfdiags.FormatCtyPath(path)),
+				path,
+			))
+		}
+
+		return false, nil
+	})
+
+	return v, diags
+}

--- a/internal/backend/backendbase/base_test.go
+++ b/internal/backend/backendbase/base_test.go
@@ -1,0 +1,216 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package backendbase
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hcltest"
+	"github.com/zclconf/go-cty-debug/ctydebug"
+	"github.com/zclconf/go-cty/cty"
+
+	"github.com/hashicorp/terraform/internal/configs/configschema"
+	"github.com/hashicorp/terraform/internal/tfdiags"
+)
+
+func TestBase_coerceError(t *testing.T) {
+	// This tests that we return errors if type coersion fails.
+	// This doesn't thoroughly test all cases because we're just delegating
+	// to the configschema package's coersion function, which is already
+	// tested in its own package.
+
+	b := Base{
+		Schema: &configschema.Block{
+			Attributes: map[string]*configschema.Attribute{
+				"foo": {
+					Type:     cty.String,
+					Optional: true,
+				},
+			},
+		},
+	}
+	// This is a fake body just to give us something to correlate the
+	// diagnostic attribute paths against so we can test that the
+	// errors are properly annotated. In the real implementation
+	// the command package logic would evaluate the diagnostics against
+	// the real HCL body written by the end-user.
+	//
+	// Because we're using MockExprLiteral for the expressions here,
+	// the source range for each expression is just the fake filename
+	// "MockExprLiteral". If the PrepareConfig function fails to properly
+	// annotate its diagnostics then the source range won't be populated
+	// at all.
+	body := hcltest.MockBody(&hcl.BodyContent{
+		Attributes: hcl.Attributes{
+			"foo": {
+				Expr: hcltest.MockExprLiteral(cty.StringVal("")),
+			},
+		},
+	})
+
+	t.Run("error", func(t *testing.T) {
+		_, diags := b.PrepareConfig(cty.ObjectVal(map[string]cty.Value{
+			// This is incorrect because the schema wants a string
+			"foo": cty.MapValEmpty(cty.String),
+		}))
+		// We'll use the "RPC" representation of the diagnostics just because
+		// it's convenient for comparing without any unusual cmp options.
+		gotDiags := diags.InConfigBody(body, "").ForRPC()
+		var wantDiags tfdiags.Diagnostics
+		wantDiags = wantDiags.Append(&hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  "Invalid backend configuration",
+			Detail:   "The backend configuration is incorrect: .foo: string required.",
+			Subject:  &hcl.Range{Filename: "MockExprLiteral"},
+		})
+		wantDiags = wantDiags.ForRPC()
+		if diff := cmp.Diff(wantDiags, gotDiags); diff != "" {
+			t.Errorf("wrong diagnostics\n%s", diff)
+		}
+	})
+}
+
+func TestBase_deprecatedArg(t *testing.T) {
+	b := Base{
+		Schema: &configschema.Block{
+			Attributes: map[string]*configschema.Attribute{
+				"not_deprecated": {
+					Type:     cty.String,
+					Optional: true,
+				},
+				"deprecated": {
+					Type:       cty.String,
+					Optional:   true,
+					Deprecated: true,
+				},
+			},
+			BlockTypes: map[string]*configschema.NestedBlock{
+				"nested": {
+					Nesting: configschema.NestingList,
+					Block: configschema.Block{
+						Attributes: map[string]*configschema.Attribute{
+							"deprecated": {
+								Type:       cty.String,
+								Optional:   true,
+								Deprecated: true,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	// This is a fake body just to give us something to correlate the
+	// diagnostic attribute paths against so we can test that the
+	// warnings are properly annotated. In the real implementation
+	// the command package logic would evaluate the diagnostics against
+	// the real HCL body written by the end-user.
+	//
+	// Because we're using MockExprLiteral for the expressions here,
+	// the source range for each expression is just the fake filename
+	// "MockExprLiteral". If the PrepareConfig function fails to properly
+	// annotate its diagnostics then the source range won't be populated
+	// at all.
+	body := hcltest.MockBody(&hcl.BodyContent{
+		Attributes: hcl.Attributes{
+			"deprecated": {
+				Expr: hcltest.MockExprLiteral(cty.StringVal("")),
+			},
+		},
+		Blocks: hcl.Blocks{
+			{
+				Type: "nested",
+				Body: hcltest.MockBody(&hcl.BodyContent{
+					Attributes: hcl.Attributes{
+						"deprecated": {
+							Expr: hcltest.MockExprLiteral(cty.StringVal("")),
+						},
+					},
+				}),
+			},
+			{
+				Type: "nested",
+				Body: hcltest.MockBody(&hcl.BodyContent{
+					Attributes: hcl.Attributes{
+						"deprecated": {
+							Expr: hcltest.MockExprLiteral(cty.StringVal("")),
+						},
+					},
+				}),
+			},
+		},
+	})
+
+	t.Run("nothing deprecated", func(t *testing.T) {
+		got, diags := b.PrepareConfig(cty.ObjectVal(map[string]cty.Value{
+			"not_deprecated": cty.StringVal("hello"),
+		}))
+		if len(diags) != 0 {
+			t.Errorf("unexpected diagnostics: %s", diags.ErrWithWarnings().Error())
+		}
+		want := cty.ObjectVal(map[string]cty.Value{
+			"deprecated":     cty.NullVal(cty.String),
+			"not_deprecated": cty.StringVal("hello"),
+			"nested": cty.ListValEmpty(cty.Object(map[string]cty.Type{
+				"deprecated": cty.String,
+			})),
+		})
+		if diff := cmp.Diff(want, got, ctydebug.CmpOptions); diff != "" {
+			t.Errorf("wrong result\n%s", diff)
+		}
+	})
+	t.Run("toplevel deprecated", func(t *testing.T) {
+		_, diags := b.PrepareConfig(cty.ObjectVal(map[string]cty.Value{
+			"deprecated": cty.StringVal("hello"),
+		}))
+		// We'll use the "RPC" representation of the diagnostics just because
+		// it's convenient for comparing without any unusual cmp options.
+		gotDiags := diags.InConfigBody(body, "").ForRPC()
+		var wantDiags tfdiags.Diagnostics
+		wantDiags = wantDiags.Append(&hcl.Diagnostic{
+			Severity: hcl.DiagWarning,
+			Summary:  "Deprecated provider argument",
+			Detail:   "The argument .deprecated is deprecated. Refer to the backend documentation for more information.",
+			Subject:  &hcl.Range{Filename: "MockExprLiteral"},
+		})
+		wantDiags = wantDiags.ForRPC()
+		if diff := cmp.Diff(wantDiags, gotDiags); diff != "" {
+			t.Errorf("wrong diagnostics\n%s", diff)
+		}
+	})
+	t.Run("nested deprecated", func(t *testing.T) {
+		_, diags := b.PrepareConfig(cty.ObjectVal(map[string]cty.Value{
+			"nested": cty.TupleVal([]cty.Value{
+				cty.ObjectVal(map[string]cty.Value{
+					"deprecated": cty.StringVal("hello"),
+				}),
+				cty.ObjectVal(map[string]cty.Value{
+					"deprecated": cty.StringVal("hello"),
+				}),
+			}),
+		}))
+		// We'll use the "RPC" representation of the diagnostics just because
+		// it's convenient for comparing without any unusual cmp options.
+		gotDiags := diags.InConfigBody(body, "").ForRPC()
+		var wantDiags tfdiags.Diagnostics
+		wantDiags = wantDiags.Append(&hcl.Diagnostic{
+			Severity: hcl.DiagWarning,
+			Summary:  "Deprecated provider argument",
+			Detail:   "The argument .nested[0].deprecated is deprecated. Refer to the backend documentation for more information.",
+			Subject:  &hcl.Range{Filename: "MockExprLiteral"},
+		})
+		wantDiags = wantDiags.Append(&hcl.Diagnostic{
+			Severity: hcl.DiagWarning,
+			Summary:  "Deprecated provider argument",
+			Detail:   "The argument .nested[1].deprecated is deprecated. Refer to the backend documentation for more information.",
+			Subject:  &hcl.Range{Filename: "MockExprLiteral"},
+		})
+		wantDiags = wantDiags.ForRPC()
+		if diff := cmp.Diff(wantDiags, gotDiags); diff != "" {
+			t.Errorf("wrong diagnostics\n%s", diff)
+		}
+	})
+}

--- a/internal/backend/backendbase/doc.go
+++ b/internal/backend/backendbase/doc.go
@@ -1,0 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+// Package backendbase contains helpers for implementing the parts of remote
+// state backends that tend to be treated similarly across all implementations.
+package backendbase

--- a/internal/backend/backendbase/helper.go
+++ b/internal/backend/backendbase/helper.go
@@ -5,6 +5,7 @@ package backendbase
 
 import (
 	"fmt"
+	"math/big"
 	"os"
 
 	"github.com/hashicorp/terraform/internal/tfdiags"
@@ -91,6 +92,23 @@ func GetAttrEnvDefaultFallback(v cty.Value, attrName string, defEnv string, fall
 		return fallback
 	}
 	return ret
+}
+
+// IntValue converts a cty value of type cty.Number into a Go int64, or returns
+// an error if that's not possible.
+func IntValue(v cty.Value) (int64, error) {
+	if v.Type() != cty.Number {
+		return 0, fmt.Errorf("a number is required")
+	}
+	if v.IsNull() {
+		return 0, fmt.Errorf("must not be null")
+	}
+	bf := v.AsBigFloat()
+	ret, acc := bf.Int64()
+	if acc != big.Exact {
+		return 0, fmt.Errorf("must not be a whole number")
+	}
+	return ret, nil
 }
 
 // ErrorAsDiagnostics wraps a non-nil error as a tfdiags.Diagnostics.

--- a/internal/backend/backendbase/helper.go
+++ b/internal/backend/backendbase/helper.go
@@ -1,0 +1,94 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package backendbase
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/hashicorp/terraform/internal/tfdiags"
+	"github.com/zclconf/go-cty/cty"
+)
+
+// GetPathDefault traverses the steps of the given path through the given
+// value, and then returns either that value or the value given in def,
+// if the found value was null.
+//
+// This function expects the given path to be valid for the given value, and
+// will panic if not. This should be used only for values that have already
+// been coerced into a known-good data type, which is typically achieved by
+// passing the value that was returned by [Base.PrepareConfig], which is also
+// the value passed to [Backend.Configure].
+func GetPathDefault(v cty.Value, path cty.Path, def cty.Value) cty.Value {
+	v, err := path.Apply(v)
+	if err != nil {
+		panic(fmt.Sprintf("invalid path: %s", tfdiags.FormatError(err)))
+	}
+	if v.IsNull() {
+		return def
+	}
+	return v
+}
+
+// GetAttrDefault is like [GetPathDefault] but more convenient for the common
+// case of looking up a single top-level attribute.
+func GetAttrDefault(v cty.Value, attrName string, def cty.Value) cty.Value {
+	return GetPathDefault(v, cty.GetAttrPath(attrName), def)
+}
+
+// GetPathEnvDefault is like [GetPathDefault] except that the default value
+// is taken from an environment variable of the name given in defEnv, returned
+// as a string value.
+//
+// If that environment variable is unset or has an empty-string value then
+// the result is null, as a convenience to callers so that they don't need to
+// handle both null-ness and empty-string-ness as variants of "unset".
+//
+// This function panics in the same situations as [GetPathDefault].
+func GetPathEnvDefault(v cty.Value, path cty.Path, defEnv string) cty.Value {
+	v, err := path.Apply(v)
+	if err != nil {
+		panic(fmt.Sprintf("invalid path: %s", tfdiags.FormatError(err)))
+	}
+	if v.IsNull() {
+		if defStr := os.Getenv(defEnv); defStr != "" {
+			return cty.StringVal(defStr)
+		}
+	}
+	return v
+}
+
+// GetAttrEnvDefault is like [GetPathEnvDefault] but more convenient for the
+// common case of looking up a single top-level attribute.
+func GetAttrEnvDefault(v cty.Value, attrName string, defEnv string) cty.Value {
+	return GetPathEnvDefault(v, cty.GetAttrPath(attrName), defEnv)
+}
+
+// GetPathEnvDefaultFallback is like [GetPathEnvDefault] except that if
+// neither the attribute nor the environment variable are set then instead
+// of returning null it will return the given fallback value.
+//
+// Unless the fallback value is null itself, this function guarantees to never
+// return null.
+func GetPathEnvDefaultFallback(v cty.Value, path cty.Path, defEnv string, fallback cty.Value) cty.Value {
+	ret := GetPathEnvDefault(v, path, defEnv)
+	if ret.IsNull() {
+		return fallback
+	}
+	return ret
+}
+
+// GetAttrEnvDefaultFallback is like [GetPathEnvDefault] except that if
+// neither the attribute nor the environment variable are set then instead
+// of returning null it will return the given fallback value.
+//
+// Unless the fallback value is null itself, this function guarantees to never
+// return null.
+func GetAttrEnvDefaultFallback(v cty.Value, attrName string, defEnv string, fallback cty.Value) cty.Value {
+	ret := GetAttrEnvDefault(v, attrName, defEnv)
+	if ret.IsNull() {
+		return fallback
+	}
+	return ret
+}

--- a/internal/backend/backendbase/helper.go
+++ b/internal/backend/backendbase/helper.go
@@ -92,3 +92,28 @@ func GetAttrEnvDefaultFallback(v cty.Value, attrName string, defEnv string, fall
 	}
 	return ret
 }
+
+// ErrorAsDiagnostics wraps a non-nil error as a tfdiags.Diagnostics.
+//
+// Panics if the given error is nil, since the caller should only be using
+// this if they've encountered a non-nil error.
+//
+// This is here just as a temporary measure to preserve the old treatment of
+// errors returned from legacy helper/schema-based backend implementations,
+// so that we can minimize the churn caused in the first iteration of adopting
+// backendbase.
+//
+// In the long run backends should produce higher-quality diagnostics directly
+// themselves, but we wanted to first complete the deprecation of the
+// legacy/helper/schema package with only mechanical code updates and then
+// save diagnostic quality improvements for a later time.
+func ErrorAsDiagnostics(err error) tfdiags.Diagnostics {
+	if err == nil {
+		panic("ErrorAsDiagnostics with nil error")
+	}
+	var diags tfdiags.Diagnostics
+	// This produces a very low-quality diagnostic message, but it matches
+	// how legacy helper/schema dealt with the same situation.
+	diags = diags.Append(err)
+	return diags
+}

--- a/internal/backend/backendbase/helper_test.go
+++ b/internal/backend/backendbase/helper_test.go
@@ -1,0 +1,183 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package backendbase
+
+import (
+	"testing"
+
+	"github.com/zclconf/go-cty/cty"
+)
+
+func TestGetPathDefault(t *testing.T) {
+	tests := map[string]struct {
+		Value   cty.Value
+		Path    cty.Path
+		Default cty.Value
+		Want    cty.Value
+	}{
+		// The test cases here don't aim to exhaustively test all possible
+		// cty.Path values, because we're just delegating to cty.Path.Apply
+		// and that's already tested upstream.
+
+		"attribute is set": {
+			cty.ObjectVal(map[string]cty.Value{
+				"a": cty.StringVal("a value"),
+			}),
+			cty.GetAttrPath("a"),
+			cty.StringVal("default"),
+			cty.StringVal("a value"),
+		},
+		"attribute is not set": {
+			cty.ObjectVal(map[string]cty.Value{
+				"a": cty.NullVal(cty.String),
+			}),
+			cty.GetAttrPath("a"),
+			cty.StringVal("default"),
+			cty.StringVal("default"),
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := GetPathDefault(test.Value, test.Path, test.Default)
+			if !test.Want.RawEquals(got) {
+				t.Errorf(
+					"wrong result\nvalue:   %#v\npath:    %#v\ndefault: %#v\n\ngot:  %#v\nwant: %#v",
+					test.Value,
+					test.Path,
+					test.Default,
+					got,
+					test.Want,
+				)
+			}
+		})
+	}
+}
+
+func TestGetAttrDefault(t *testing.T) {
+	tests := map[string]struct {
+		Value   cty.Value
+		Attr    string
+		Default cty.Value
+		Want    cty.Value
+	}{
+		"attribute is set": {
+			cty.ObjectVal(map[string]cty.Value{
+				"a": cty.StringVal("a value"),
+			}),
+			"a",
+			cty.StringVal("default"),
+			cty.StringVal("a value"),
+		},
+		"attribute is not set": {
+			cty.ObjectVal(map[string]cty.Value{
+				"a": cty.NullVal(cty.String),
+			}),
+			"a",
+			cty.StringVal("default"),
+			cty.StringVal("default"),
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := GetAttrDefault(test.Value, test.Attr, test.Default)
+			if !test.Want.RawEquals(got) {
+				t.Errorf(
+					"wrong result\nvalue:   %#v\nattr:    %#v\ndefault: %#v\n\ngot:  %#v\nwant: %#v",
+					test.Value,
+					test.Attr,
+					test.Default,
+					got,
+					test.Want,
+				)
+			}
+		})
+	}
+}
+
+func TestGetPathEnvDefault(t *testing.T) {
+	// This one is actually testing both GetPathEnvDefault and GetAttrEnvDefault
+	// together, since they are both really just the same functionality exposed
+	// in two different ways.
+
+	t.Setenv("DEFAULT_VALUE_SET", "default")
+	t.Setenv("DEFAULT_VALUE_EMPTY", "")
+
+	tests := map[string]struct {
+		Value  cty.Value
+		Attr   string
+		EnvVar string
+		Want   cty.Value
+	}{
+		// The test cases here don't aim to exhaustively test all possible
+		// cty.Path values, because we're just delegating to cty.Path.Apply
+		// and that's already tested upstream.
+
+		"attribute is set": {
+			cty.ObjectVal(map[string]cty.Value{
+				"a": cty.StringVal("a value"),
+			}),
+			"a",
+			"DEFAULT_VALUE_SET",
+			cty.StringVal("a value"),
+		},
+		"attribute is not set, but environment is": {
+			cty.ObjectVal(map[string]cty.Value{
+				"a": cty.NullVal(cty.String),
+			}),
+			"a",
+			"DEFAULT_VALUE_SET",
+			cty.StringVal("default"),
+		},
+		"neither attribute or environment are set": {
+			cty.ObjectVal(map[string]cty.Value{
+				"a": cty.NullVal(cty.String),
+			}),
+			"a",
+			"DEFAULT_VALUE_UNSET",
+			cty.NullVal(cty.String),
+		},
+		"attribute is not set, and environment variable is empty": {
+			cty.ObjectVal(map[string]cty.Value{
+				"a": cty.NullVal(cty.String),
+			}),
+			"a",
+			"DEFAULT_VALUE_EMPTY",
+			cty.NullVal(cty.String),
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Run("by attr", func(t *testing.T) {
+				got := GetAttrEnvDefault(test.Value, test.Attr, test.EnvVar)
+				if !test.Want.RawEquals(got) {
+					t.Errorf(
+						"wrong result\nvalue:    %#v\nattr:     %#v\nvariable: %#v\n\ngot:  %#v\nwant: %#v",
+						test.Value,
+						test.Attr,
+						test.EnvVar,
+						got,
+						test.Want,
+					)
+				}
+			})
+			t.Run("by path", func(t *testing.T) {
+				path := cty.GetAttrPath(test.Attr)
+				got := GetPathEnvDefault(test.Value, path, test.EnvVar)
+				if !test.Want.RawEquals(got) {
+					t.Errorf(
+						"wrong result\nvalue:    %#v\npath:     %#v\nvariable: %#v\n\ngot:  %#v\nwant: %#v",
+						test.Value,
+						path,
+						test.EnvVar,
+						got,
+						test.Want,
+					)
+				}
+			})
+		})
+	}
+}

--- a/internal/backend/backendbase/sdklike.go
+++ b/internal/backend/backendbase/sdklike.go
@@ -1,0 +1,158 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package backendbase
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/zclconf/go-cty/cty"
+	"github.com/zclconf/go-cty/cty/convert"
+)
+
+// SDKLikeData offers an approximation of the legack SDK "ResourceData" API
+// as a stopgap measure to help migrate all of the remote state backend
+// implementations away from the legacy SDK.
+//
+// It's designed to wrap an object returned by [Base.PrepareConfig] which
+// should therefore already have a fixed, known data type. Therefore the
+// methods assume that the caller already knows what type each attribute
+// should have and will panic if a caller asks for an incompatible type.
+type SDKLikeData struct {
+	v cty.Value
+}
+
+func NewSDKLikeData(v cty.Value) SDKLikeData {
+	return SDKLikeData{v}
+}
+
+// String extracts a string attribute from a configuration object
+// in a similar way to how the legacy SDK would interpret an attribute
+// of type schema.TypeString, or panics if the wrapped object isn't of a
+// suitable type.
+func (d SDKLikeData) String(attrPath string) string {
+	v := d.GetAttr(attrPath, cty.String)
+	if v.IsNull() {
+		return ""
+	}
+	return v.AsString()
+}
+
+// Int extracts a string attribute from a configuration object
+// in a similar way to how the legacy SDK would interpret an attribute
+// of type schema.TypeInt, or panics if the wrapped object isn't of a
+// suitable type.
+//
+// Since the Terraform language does not have an integers-only type, this
+// can fail dynamically (returning an error) if the given value has a
+// fractional component.
+func (d SDKLikeData) Int64(attrPath string) (int64, error) {
+	// Legacy SDK used strconv.ParseInt to interpret values, so we'll
+	// follow its lead here for maximal compatibility.
+	v := d.GetAttr(attrPath, cty.String)
+	if v.IsNull() {
+		return 0, nil
+	}
+	return strconv.ParseInt(v.AsString(), 0, 0)
+}
+
+// Bool extracts a string attribute from a configuration object
+// in a similar way to how the legacy SDK would interpret an attribute
+// of type schema.TypeBool, or panics if the wrapped object isn't of a
+// suitable type.
+func (d SDKLikeData) Bool(attrPath string) bool {
+	// Legacy SDK used strconv.ParseBool to interpret values, but it
+	// did so only after the configuration was interpreted by HCL and
+	// thus HCL's more constrained definition of bool still "won",
+	// and we follow that tradition here.
+	v := d.GetAttr(attrPath, cty.Bool)
+	if v.IsNull() {
+		return false
+	}
+	return v.True()
+}
+
+// GetAttr is just a thin wrapper around [cty.Path.Apply] that accepts
+// a legacy-SDK-like dot-separated string as attribute path, instead of
+// a [cty.Path] directly.
+//
+// It uses [SDKLikePath] to interpret the given path, and so the limitations
+// of that function apply equally to this function.
+//
+// This function will panic if asked to extract a path that isn't compatible
+// with the object type of the enclosed value.
+func (d SDKLikeData) GetAttr(attrPath string, wantType cty.Type) cty.Value {
+	path := SDKLikePath(attrPath)
+	v, err := path.Apply(d.v)
+	if err != nil {
+		panic("invalid attribute path: " + err.Error())
+	}
+	v, err = convert.Convert(v, wantType)
+	if err != nil {
+		panic("incorrect attribute type: " + err.Error())
+	}
+	return v
+}
+
+// SDKLikePath interprets a subset of the legacy SDK attribute path syntax --
+// identifiers separated by dots -- into a cty.Path.
+//
+// This is designed only for migrating historical remote system backends that
+// were originally written using the SDK, and so it's limited only to the
+// simple cases they use. It's not suitable for the more complex legacy SDK
+// uses made by Terraform providers.
+func SDKLikePath(rawPath string) cty.Path {
+	var ret cty.Path
+	remain := rawPath
+	for {
+		dot := strings.IndexByte(remain, '.')
+		last := false
+		if dot == -1 {
+			dot = len(remain)
+			last = true
+		}
+
+		attrName := remain[:dot]
+		ret = append(ret, cty.GetAttrStep{Name: attrName})
+		if last {
+			return ret
+		}
+		remain = remain[dot+1:]
+	}
+}
+
+// SDKLikeEnvDefault emulates an SDK-style "EnvDefaultFunc" by taking the
+// result of [SDKLikeData.String] and a series of environment variable names.
+//
+// If the given string is already non-empty then it just returns it directly.
+// Otherwise it returns the value of the first environment variable that has
+// a non-empty value. If everything turns out empty, the result is an empty
+// string.
+func SDKLikeEnvDefault(v string, envNames ...string) string {
+	if v == "" {
+		for _, envName := range envNames {
+			v = os.Getenv(envName)
+			if v != "" {
+				return v
+			}
+		}
+	}
+	return v
+}
+
+// SDKLikeRequiredWithEnvDefault is a convenience wrapper around
+// [SDKLikeEnvDefault] which returns an error if the result is still the
+// empty string even after trying all of the fallback environment variables.
+//
+// This wrapper requires an additional argument specifying the attribute name
+// just because that becomes part of the returned error message.
+func SDKLikeRequiredWithEnvDefault(attrPath string, v string, envNames ...string) (string, error) {
+	ret := SDKLikeEnvDefault(v, envNames...)
+	if ret == "" {
+		return "", fmt.Errorf("attribute %q is required", attrPath)
+	}
+	return ret, nil
+}

--- a/internal/backend/backendbase/sdklike_test.go
+++ b/internal/backend/backendbase/sdklike_test.go
@@ -1,0 +1,204 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package backendbase
+
+import (
+	"testing"
+
+	"github.com/zclconf/go-cty/cty"
+)
+
+func TestSDKLikePath(t *testing.T) {
+	tests := []struct {
+		Input string
+		Want  cty.Path
+	}{
+		{
+			"foo",
+			cty.GetAttrPath("foo"),
+		},
+		{
+			"foo.bar",
+			cty.GetAttrPath("foo").GetAttr("bar"),
+		},
+		{
+			"foo.bar.baz",
+			cty.GetAttrPath("foo").GetAttr("bar").GetAttr("baz"),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.Input, func(t *testing.T) {
+			got := SDKLikePath(test.Input)
+			if !test.Want.Equals(got) {
+				t.Errorf("wrong result\ngot:  %#v\nwant: %#v", got, test.Want)
+			}
+		})
+	}
+}
+
+func TestSDKLikeEnvDefault(t *testing.T) {
+	t.Setenv("FALLBACK_A", "fallback a")
+	t.Setenv("FALLBACK_B", "fallback b")
+	t.Setenv("FALLBACK_UNSET", "")
+	t.Setenv("FALLBACK_UNSET_1", "")
+	t.Setenv("FALLBACK_UNSET_2", "")
+
+	tests := map[string]struct {
+		Value    string
+		EnvNames []string
+		Want     string
+	}{
+		"value is set": {
+			"hello",
+			[]string{"FALLBACK_A", "FALLBACK_B"},
+			"hello",
+		},
+		"value is not set, but both fallbacks are": {
+			"",
+			[]string{"FALLBACK_A", "FALLBACK_B"},
+			"fallback a",
+		},
+		"value is not set, and first callback isn't set": {
+			"",
+			[]string{"FALLBACK_UNSET", "FALLBACK_B"},
+			"fallback b",
+		},
+		"value is not set, and second callback isn't set": {
+			"",
+			[]string{"FALLBACK_A", "FALLBACK_UNSET"},
+			"fallback a",
+		},
+		"nothing is set": {
+			"",
+			[]string{"FALLBACK_UNSET_1", "FALLBACK_UNSET_2"},
+			"",
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := SDKLikeEnvDefault(test.Value, test.EnvNames...)
+			if got != test.Want {
+				t.Errorf("wrong result\nvalue: %s\nenvs:  %s\n\ngot:  %s\nwant: %s", test.Value, test.EnvNames, got, test.Want)
+			}
+		})
+	}
+}
+
+func TestSDKLikeRequiredWithEnvDefault(t *testing.T) {
+	// This intentionally doesn't duplicate all of the test cases from
+	// TestSDKLikeEnvDefault, since SDKLikeRequiredWithEnvDefault is
+	// just a thin wrapper which adds an error check.
+
+	t.Setenv("FALLBACK_UNSET", "")
+	_, err := SDKLikeRequiredWithEnvDefault("attr_name", "", "FALLBACK_UNSET")
+	if err == nil {
+		t.Fatalf("unexpected success; want error")
+	}
+	if got, want := err.Error(), `attribute "attr_name" is required`; got != want {
+		t.Errorf("wrong error\ngot:  %s\nwant: %s", got, want)
+	}
+}
+
+func TestSDKLikeData(t *testing.T) {
+	d := NewSDKLikeData(cty.ObjectVal(map[string]cty.Value{
+		"string": cty.StringVal("hello"),
+		"int":    cty.NumberIntVal(5),
+		"float":  cty.NumberFloatVal(0.5),
+		"bool":   cty.True,
+
+		"null_string": cty.NullVal(cty.String),
+		"null_number": cty.NullVal(cty.Number),
+		"null_bool":   cty.NullVal(cty.Bool),
+	}))
+
+	t.Run("string", func(t *testing.T) {
+		got := d.String("string")
+		want := "hello"
+		if got != want {
+			t.Errorf("wrong result\ngot:  %#v\nwant: %#v", got, want)
+		}
+	})
+	t.Run("null string", func(t *testing.T) {
+		got := d.String("null_string")
+		want := ""
+		if got != want {
+			t.Errorf("wrong result\ngot:  %#v\nwant: %#v", got, want)
+		}
+	})
+	t.Run("int as string", func(t *testing.T) {
+		// This is allowed as a convenience for backends that want to
+		// allow environment-based default values for integer values,
+		// since environment variables are always strings and so they'd
+		// need to do their own parsing afterwards anyway.
+		got := d.String("int")
+		want := "5"
+		if got != want {
+			t.Errorf("wrong result\ngot:  %#v\nwant: %#v", got, want)
+		}
+	})
+	t.Run("bool as string", func(t *testing.T) {
+		// This is allowed as a convenience for backends that want to
+		// allow environment-based default values for bool values,
+		// since environment variables are always strings and so they'd
+		// need to do their own parsing afterwards anyway.
+		got := d.String("bool")
+		want := "true"
+		if got != want {
+			t.Errorf("wrong result\ngot:  %#v\nwant: %#v", got, want)
+		}
+	})
+
+	t.Run("int", func(t *testing.T) {
+		got, err := d.Int64("int")
+		want := int64(5)
+		if err != nil {
+			t.Fatalf("unexpected error: %s", err)
+		}
+		if got != want {
+			t.Errorf("wrong result\ngot:  %#v\nwant: %#v", got, want)
+		}
+	})
+	t.Run("int with fractional part", func(t *testing.T) {
+		got, err := d.Int64("float")
+		if err == nil {
+			t.Fatalf("unexpected success; want error\ngot: %#v", got)
+		}
+		// Legacy SDK exposed the strconv.ParseInt implementation detail in
+		// its error message, and so for now we do the same. Maybe we'll
+		// improve this later, but it would probably be better to wean
+		// the backends off using the "SDKLike" helper altogether instead.
+		if got, want := err.Error(), `strconv.ParseInt: parsing "0.5": invalid syntax`; got != want {
+			t.Errorf("wrong error\ngot:  %s\nwant: %s", got, want)
+		}
+	})
+	t.Run("null number as int", func(t *testing.T) {
+		got, err := d.Int64("null_number")
+		want := int64(0)
+		if err != nil {
+			t.Fatalf("unexpected error: %s", err)
+		}
+		if got != want {
+			t.Errorf("wrong result\ngot:  %#v\nwant: %#v", got, want)
+		}
+	})
+
+	t.Run("bool", func(t *testing.T) {
+		got := d.Bool("bool")
+		want := true
+		if got != want {
+			t.Errorf("wrong result\ngot:  %#v\nwant: %#v", got, want)
+		}
+	})
+	t.Run("null bool", func(t *testing.T) {
+		// Assuming false for a null is quite questionable, but it's what
+		// the legacy SDK did and so we'll follow its lead.
+		got := d.Bool("null_bool")
+		want := false
+		if got != want {
+			t.Errorf("wrong result\ngot:  %#v\nwant: %#v", got, want)
+		}
+	})
+}

--- a/internal/backend/remote-state/consul/backend.go
+++ b/internal/backend/remote-state/consul/backend.go
@@ -4,120 +4,104 @@
 package consul
 
 import (
-	"context"
 	"net"
 	"strings"
 	"time"
 
 	consulapi "github.com/hashicorp/consul/api"
+	"github.com/zclconf/go-cty/cty"
+
 	"github.com/hashicorp/terraform/internal/backend"
-	"github.com/hashicorp/terraform/internal/legacy/helper/schema"
+	"github.com/hashicorp/terraform/internal/backend/backendbase"
+	"github.com/hashicorp/terraform/internal/configs/configschema"
+	"github.com/hashicorp/terraform/internal/tfdiags"
 )
 
 // New creates a new backend for Consul remote state.
 func New() backend.Backend {
-	s := &schema.Backend{
-		Schema: map[string]*schema.Schema{
-			"path": &schema.Schema{
-				Type:        schema.TypeString,
-				Required:    true,
-				Description: "Path to store state in Consul",
-			},
-
-			"access_token": &schema.Schema{
-				Type:        schema.TypeString,
-				Optional:    true,
-				Description: "Access token for a Consul ACL",
-				Default:     "", // To prevent input
-			},
-
-			"address": &schema.Schema{
-				Type:        schema.TypeString,
-				Optional:    true,
-				Description: "Address to the Consul Cluster",
-				Default:     "", // To prevent input
-			},
-
-			"scheme": &schema.Schema{
-				Type:        schema.TypeString,
-				Optional:    true,
-				Description: "Scheme to communicate to Consul with",
-				Default:     "", // To prevent input
-			},
-
-			"datacenter": &schema.Schema{
-				Type:        schema.TypeString,
-				Optional:    true,
-				Description: "Datacenter to communicate with",
-				Default:     "", // To prevent input
-			},
-
-			"http_auth": &schema.Schema{
-				Type:        schema.TypeString,
-				Optional:    true,
-				Description: "HTTP Auth in the format of 'username:password'",
-				Default:     "", // To prevent input
-			},
-
-			"gzip": &schema.Schema{
-				Type:        schema.TypeBool,
-				Optional:    true,
-				Description: "Compress the state data using gzip",
-				Default:     false,
-			},
-
-			"lock": &schema.Schema{
-				Type:        schema.TypeBool,
-				Optional:    true,
-				Description: "Lock state access",
-				Default:     true,
-			},
-
-			"ca_file": &schema.Schema{
-				Type:        schema.TypeString,
-				Optional:    true,
-				Description: "A path to a PEM-encoded certificate authority used to verify the remote agent's certificate.",
-				DefaultFunc: schema.EnvDefaultFunc("CONSUL_CACERT", ""),
-			},
-
-			"cert_file": &schema.Schema{
-				Type:        schema.TypeString,
-				Optional:    true,
-				Description: "A path to a PEM-encoded certificate provided to the remote agent; requires use of key_file.",
-				DefaultFunc: schema.EnvDefaultFunc("CONSUL_CLIENT_CERT", ""),
-			},
-
-			"key_file": &schema.Schema{
-				Type:        schema.TypeString,
-				Optional:    true,
-				Description: "A path to a PEM-encoded private key, required if cert_file is specified.",
-				DefaultFunc: schema.EnvDefaultFunc("CONSUL_CLIENT_KEY", ""),
+	return &Backend{
+		Base: backendbase.Base{
+			Schema: &configschema.Block{
+				Attributes: map[string]*configschema.Attribute{
+					"path": {
+						Type:        cty.String,
+						Required:    true,
+						Description: "Path to store state in Consul",
+					},
+					"access_token": {
+						Type:        cty.String,
+						Optional:    true,
+						Description: "Access token for a Consul ACL",
+					},
+					"address": {
+						Type:        cty.String,
+						Optional:    true,
+						Description: "Address to the Consul Cluster",
+					},
+					"scheme": {
+						Type:        cty.String,
+						Optional:    true,
+						Description: "Scheme to communicate to Consul with",
+					},
+					"datacenter": {
+						Type:        cty.String,
+						Optional:    true,
+						Description: "Datacenter to communicate with",
+					},
+					"http_auth": {
+						Type:        cty.String,
+						Optional:    true,
+						Description: "HTTP Auth in the format of 'username:password'",
+					},
+					"gzip": {
+						Type:        cty.Bool,
+						Optional:    true,
+						Description: "Compress the state data using gzip",
+					},
+					"lock": {
+						Type:        cty.Bool,
+						Optional:    true,
+						Description: "Lock state access",
+					},
+					"ca_file": {
+						Type:        cty.String,
+						Optional:    true,
+						Description: "A path to a PEM-encoded certificate authority used to verify the remote agent's certificate",
+					},
+					"cert_file": {
+						Type:        cty.String,
+						Optional:    true,
+						Description: "A path to a PEM-encoded certificate provided to the remote agent; requires use of key_file",
+					},
+					"key_file": {
+						Type:        cty.String,
+						Optional:    true,
+						Description: "A path to a PEM-encoded private key, required if cert_file is specified",
+					},
+				},
 			},
 		},
 	}
-
-	result := &Backend{Backend: s}
-	result.Backend.ConfigureFunc = result.configure
-	return result
 }
 
 type Backend struct {
-	*schema.Backend
+	backendbase.Base
 
 	// The fields below are set from configure
-	client     *consulapi.Client
-	configData *schema.ResourceData
-	lock       bool
+	client *consulapi.Client
+	path   string
+	gzip   bool
+	lock   bool
 }
 
-func (b *Backend) configure(ctx context.Context) error {
-	// Grab the resource data
-	b.configData = schema.FromContextBackendConfig(ctx)
-
-	// Store the lock information
-	b.lock = b.configData.Get("lock").(bool)
-
-	data := b.configData
+func (b *Backend) Configure(configVal cty.Value) tfdiags.Diagnostics {
+	b.path = configVal.GetAttr("path").AsString()
+	b.gzip = backendbase.MustBoolValue(
+		backendbase.GetAttrDefault(configVal, "gzip", cty.False),
+	)
+	b.lock = backendbase.MustBoolValue(
+		backendbase.GetAttrDefault(configVal, "lock", cty.True),
+	)
 
 	// Configure the client
 	config := consulapi.DefaultConfig()
@@ -125,31 +109,32 @@ func (b *Backend) configure(ctx context.Context) error {
 	// replace the default Transport Dialer to reduce the KeepAlive
 	config.Transport.DialContext = dialContext
 
-	if v, ok := data.GetOk("access_token"); ok && v.(string) != "" {
-		config.Token = v.(string)
+	empty := cty.StringVal("")
+	if v := backendbase.GetAttrDefault(configVal, "access_token", empty); v != empty {
+		config.Token = v.AsString()
 	}
-	if v, ok := data.GetOk("address"); ok && v.(string) != "" {
-		config.Address = v.(string)
+	if v := backendbase.GetAttrDefault(configVal, "address", empty); v != empty {
+		config.Address = v.AsString()
 	}
-	if v, ok := data.GetOk("scheme"); ok && v.(string) != "" {
-		config.Scheme = v.(string)
+	if v := backendbase.GetAttrDefault(configVal, "scheme", empty); v != empty {
+		config.Scheme = v.AsString()
 	}
-	if v, ok := data.GetOk("datacenter"); ok && v.(string) != "" {
-		config.Datacenter = v.(string)
-	}
-
-	if v, ok := data.GetOk("ca_file"); ok && v.(string) != "" {
-		config.TLSConfig.CAFile = v.(string)
-	}
-	if v, ok := data.GetOk("cert_file"); ok && v.(string) != "" {
-		config.TLSConfig.CertFile = v.(string)
-	}
-	if v, ok := data.GetOk("key_file"); ok && v.(string) != "" {
-		config.TLSConfig.KeyFile = v.(string)
+	if v := backendbase.GetAttrDefault(configVal, "datacenter", empty); v != empty {
+		config.Datacenter = v.AsString()
 	}
 
-	if v, ok := data.GetOk("http_auth"); ok && v.(string) != "" {
-		auth := v.(string)
+	if v := backendbase.GetAttrEnvDefaultFallback(configVal, "ca_file", "CONSUL_CACERT", empty); v != empty {
+		config.TLSConfig.CAFile = v.AsString()
+	}
+	if v := backendbase.GetAttrEnvDefaultFallback(configVal, "cert_file", "CONSUL_CLIENT_CERT", empty); v != empty {
+		config.TLSConfig.CertFile = v.AsString()
+	}
+	if v := backendbase.GetAttrEnvDefaultFallback(configVal, "key_file", "CONSUL_CLIENT_KEY", empty); v != empty {
+		config.TLSConfig.KeyFile = v.AsString()
+	}
+
+	if v := backendbase.GetAttrDefault(configVal, "http_auth", empty); v != empty {
+		auth := v.AsString()
 
 		var username, password string
 		if strings.Contains(auth, ":") {
@@ -168,7 +153,7 @@ func (b *Backend) configure(ctx context.Context) error {
 
 	client, err := consulapi.NewClient(config)
 	if err != nil {
-		return err
+		return backendbase.ErrorAsDiagnostics(err)
 	}
 
 	b.client = client

--- a/internal/backend/remote-state/consul/backend_state.go
+++ b/internal/backend/remote-state/consul/backend_state.go
@@ -19,7 +19,7 @@ const (
 
 func (b *Backend) Workspaces() ([]string, error) {
 	// List our raw path
-	prefix := b.configData.Get("path").(string) + keyEnvPrefix
+	prefix := b.path + keyEnvPrefix
 	keys, _, err := b.client.KV().Keys(prefix, "/", nil)
 	if err != nil {
 		return nil, err
@@ -58,7 +58,7 @@ func (b *Backend) DeleteWorkspace(name string, _ bool) error {
 	}
 
 	// Determine the path of the data
-	path := b.path(name)
+	path := b.statePath(name)
 
 	// Delete it. We just delete it without any locking since
 	// the DeleteState API is documented as such.
@@ -68,10 +68,10 @@ func (b *Backend) DeleteWorkspace(name string, _ bool) error {
 
 func (b *Backend) StateMgr(name string) (statemgr.Full, error) {
 	// Determine the path of the data
-	path := b.path(name)
+	path := b.statePath(name)
 
 	// Determine whether to gzip or not
-	gzip := b.configData.Get("gzip").(bool)
+	gzip := b.gzip
 
 	// Build the state client
 	var stateMgr = &remote.State{
@@ -137,8 +137,8 @@ func (b *Backend) StateMgr(name string) (statemgr.Full, error) {
 	return stateMgr, nil
 }
 
-func (b *Backend) path(name string) string {
-	path := b.configData.Get("path").(string)
+func (b *Backend) statePath(name string) string {
+	path := b.path
 	if name != backend.DefaultStateName {
 		path += fmt.Sprintf("%s%s", keyEnvPrefix, name)
 	}

--- a/internal/backend/remote-state/http/backend.go
+++ b/internal/backend/remote-state/http/backend.go
@@ -4,7 +4,6 @@
 package http
 
 import (
-	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"errors"
@@ -15,128 +14,261 @@ import (
 	"time"
 
 	"github.com/hashicorp/go-retryablehttp"
+	"github.com/zclconf/go-cty/cty"
 
 	"github.com/hashicorp/terraform/internal/backend"
-	"github.com/hashicorp/terraform/internal/legacy/helper/schema"
+	"github.com/hashicorp/terraform/internal/backend/backendbase"
+	"github.com/hashicorp/terraform/internal/configs/configschema"
 	"github.com/hashicorp/terraform/internal/logging"
 	"github.com/hashicorp/terraform/internal/states/remote"
 	"github.com/hashicorp/terraform/internal/states/statemgr"
+	"github.com/hashicorp/terraform/internal/tfdiags"
 )
 
 func New() backend.Backend {
-	s := &schema.Backend{
-		Schema: map[string]*schema.Schema{
-			"address": &schema.Schema{
-				Type:        schema.TypeString,
-				Required:    true,
-				DefaultFunc: schema.EnvDefaultFunc("TF_HTTP_ADDRESS", nil),
-				Description: "The address of the REST endpoint",
-			},
-			"update_method": &schema.Schema{
-				Type:        schema.TypeString,
-				Optional:    true,
-				DefaultFunc: schema.EnvDefaultFunc("TF_HTTP_UPDATE_METHOD", "POST"),
-				Description: "HTTP method to use when updating state",
-			},
-			"lock_address": &schema.Schema{
-				Type:        schema.TypeString,
-				Optional:    true,
-				DefaultFunc: schema.EnvDefaultFunc("TF_HTTP_LOCK_ADDRESS", nil),
-				Description: "The address of the lock REST endpoint",
-			},
-			"unlock_address": &schema.Schema{
-				Type:        schema.TypeString,
-				Optional:    true,
-				DefaultFunc: schema.EnvDefaultFunc("TF_HTTP_UNLOCK_ADDRESS", nil),
-				Description: "The address of the unlock REST endpoint",
-			},
-			"lock_method": &schema.Schema{
-				Type:        schema.TypeString,
-				Optional:    true,
-				DefaultFunc: schema.EnvDefaultFunc("TF_HTTP_LOCK_METHOD", "LOCK"),
-				Description: "The HTTP method to use when locking",
-			},
-			"unlock_method": &schema.Schema{
-				Type:        schema.TypeString,
-				Optional:    true,
-				DefaultFunc: schema.EnvDefaultFunc("TF_HTTP_UNLOCK_METHOD", "UNLOCK"),
-				Description: "The HTTP method to use when unlocking",
-			},
-			"username": &schema.Schema{
-				Type:        schema.TypeString,
-				Optional:    true,
-				DefaultFunc: schema.EnvDefaultFunc("TF_HTTP_USERNAME", nil),
-				Description: "The username for HTTP basic authentication",
-			},
-			"password": &schema.Schema{
-				Type:        schema.TypeString,
-				Optional:    true,
-				DefaultFunc: schema.EnvDefaultFunc("TF_HTTP_PASSWORD", nil),
-				Description: "The password for HTTP basic authentication",
-			},
-			"skip_cert_verification": &schema.Schema{
-				Type:        schema.TypeBool,
-				Optional:    true,
-				Default:     false,
-				Description: "Whether to skip TLS verification.",
-			},
-			"retry_max": &schema.Schema{
-				Type:        schema.TypeInt,
-				Optional:    true,
-				DefaultFunc: schema.EnvDefaultFunc("TF_HTTP_RETRY_MAX", 2),
-				Description: "The number of HTTP request retries.",
-			},
-			"retry_wait_min": &schema.Schema{
-				Type:        schema.TypeInt,
-				Optional:    true,
-				DefaultFunc: schema.EnvDefaultFunc("TF_HTTP_RETRY_WAIT_MIN", 1),
-				Description: "The minimum time in seconds to wait between HTTP request attempts.",
-			},
-			"retry_wait_max": &schema.Schema{
-				Type:        schema.TypeInt,
-				Optional:    true,
-				DefaultFunc: schema.EnvDefaultFunc("TF_HTTP_RETRY_WAIT_MAX", 30),
-				Description: "The maximum time in seconds to wait between HTTP request attempts.",
-			},
-			"client_ca_certificate_pem": &schema.Schema{
-				Type:        schema.TypeString,
-				Optional:    true,
-				DefaultFunc: schema.EnvDefaultFunc("TF_HTTP_CLIENT_CA_CERTIFICATE_PEM", ""),
-				Description: "A PEM-encoded CA certificate chain used by the client to verify server certificates during TLS authentication.",
-			},
-			"client_certificate_pem": &schema.Schema{
-				Type:        schema.TypeString,
-				Optional:    true,
-				DefaultFunc: schema.EnvDefaultFunc("TF_HTTP_CLIENT_CERTIFICATE_PEM", ""),
-				Description: "A PEM-encoded certificate used by the server to verify the client during mutual TLS (mTLS) authentication.",
-			},
-			"client_private_key_pem": &schema.Schema{
-				Type:        schema.TypeString,
-				Optional:    true,
-				DefaultFunc: schema.EnvDefaultFunc("TF_HTTP_CLIENT_PRIVATE_KEY_PEM", ""),
-				Description: "A PEM-encoded private key, required if client_certificate_pem is specified.",
+	return &Backend{
+		Base: backendbase.Base{
+			Schema: &configschema.Block{
+				Attributes: map[string]*configschema.Attribute{
+					"address": {
+						Type:        cty.String,
+						Optional:    true, // Must be set but can be set using the TF_HTTP_ADDRESS environment variable
+						Description: "The address of the REST endpoint",
+					},
+					"update_method": {
+						Type:        cty.String,
+						Optional:    true,
+						Description: "HTTP method to use when updating state",
+					},
+					"lock_address": {
+						Type:        cty.String,
+						Optional:    true,
+						Description: "The address of the lock REST endpoint",
+					},
+					"unlock_address": {
+						Type:        cty.String,
+						Optional:    true,
+						Description: "The address of the unlock REST endpoint",
+					},
+					"lock_method": {
+						Type:        cty.String,
+						Optional:    true,
+						Description: "The HTTP method to use when locking",
+					},
+					"unlock_method": {
+						Type:        cty.String,
+						Optional:    true,
+						Description: "The HTTP method to use when unlocking",
+					},
+					"username": {
+						Type:        cty.String,
+						Optional:    true,
+						Description: "The username for HTTP basic authentication",
+					},
+					"password": {
+						Type:        cty.String,
+						Optional:    true,
+						Description: "The password for HTTP basic authentication",
+					},
+					"skip_cert_verification": {
+						Type:        cty.Bool,
+						Optional:    true,
+						Description: "Whether to skip TLS verification",
+					},
+					"retry_max": {
+						Type:        cty.Number,
+						Optional:    true,
+						Description: "The number of HTTP request retries",
+					},
+					"retry_wait_min": {
+						Type:        cty.Number,
+						Optional:    true,
+						Description: "The minimum time in seconds to wait between HTTP request attempts",
+					},
+					"retry_wait_max": {
+						Type:        cty.Number,
+						Optional:    true,
+						Description: "The maximum time in seconds to wait between HTTP request attempts",
+					},
+					"client_ca_certificate_pem": {
+						Type:        cty.String,
+						Optional:    true,
+						Description: "A PEM-encoded CA certificate chain used by the client to verify server certificates during TLS authentication",
+					},
+					"client_certificate_pem": {
+						Type:        cty.String,
+						Optional:    true,
+						Description: "A PEM-encoded certificate used by the server to verify the client during mutual TLS (mTLS) authentication",
+					},
+					"client_private_key_pem": {
+						Type:        cty.String,
+						Optional:    true,
+						Description: "A PEM-encoded private key, required if client_certificate_pem is specified",
+					},
+				},
 			},
 		},
 	}
-
-	b := &Backend{Backend: s}
-	b.Backend.ConfigureFunc = b.configure
-	return b
 }
 
 type Backend struct {
-	*schema.Backend
+	backendbase.Base
 
 	client *httpClient
 }
 
+func (b *Backend) Configure(configVal cty.Value) tfdiags.Diagnostics {
+	address := backendbase.GetAttrEnvDefaultFallback(
+		configVal, "address",
+		"TF_HTTP_ADDRESS", cty.StringVal(""),
+	).AsString()
+	if address == "" {
+		return backendbase.ErrorAsDiagnostics(
+			fmt.Errorf("address argument is required"),
+		)
+	}
+	updateURL, err := url.Parse(address)
+	if err != nil {
+		return backendbase.ErrorAsDiagnostics(
+			fmt.Errorf("failed to parse address URL: %s", err),
+		)
+	}
+	if updateURL.Scheme != "http" && updateURL.Scheme != "https" {
+		return backendbase.ErrorAsDiagnostics(
+			fmt.Errorf("address must be HTTP or HTTPS"),
+		)
+	}
+
+	updateMethod := backendbase.GetAttrEnvDefaultFallback(
+		configVal, "update_method",
+		"TF_HTTP_UPDATE_METHOD", cty.StringVal("POST"),
+	).AsString()
+
+	var lockURL *url.URL
+	if v := backendbase.GetAttrEnvDefault(configVal, "lock_address", "TF_HTTP_LOCK_ADDRESS"); !v.IsNull() {
+		var err error
+		lockURL, err = url.Parse(v.AsString())
+		if err != nil {
+			return backendbase.ErrorAsDiagnostics(
+				fmt.Errorf("failed to parse lock_address URL: %s", err),
+			)
+		}
+		if lockURL.Scheme != "http" && lockURL.Scheme != "https" {
+			return backendbase.ErrorAsDiagnostics(
+				fmt.Errorf("lock_address must be HTTP or HTTPS"),
+			)
+		}
+	}
+	lockMethod := backendbase.GetAttrEnvDefaultFallback(
+		configVal, "lock_method",
+		"TF_HTTP_LOCK_METHOD", cty.StringVal("LOCK"),
+	).AsString()
+
+	var unlockURL *url.URL
+	if v := backendbase.GetAttrEnvDefault(configVal, "unlock_address", "TF_HTTP_UNLOCK_ADDRESS"); !v.IsNull() {
+		var err error
+		unlockURL, err = url.Parse(v.AsString())
+		if err != nil {
+			return backendbase.ErrorAsDiagnostics(
+				fmt.Errorf("failed to parse unlock_address URL: %s", err),
+			)
+		}
+		if unlockURL.Scheme != "http" && unlockURL.Scheme != "https" {
+			return backendbase.ErrorAsDiagnostics(
+				fmt.Errorf("unlock_address must be HTTP or HTTPS"),
+			)
+		}
+	}
+	unlockMethod := backendbase.GetAttrEnvDefaultFallback(
+		configVal, "unlock_method",
+		"TF_HTTP_UNLOCK_METHOD", cty.StringVal("UNLOCK"),
+	).AsString()
+
+	retryMax, err := backendbase.IntValue(
+		backendbase.GetAttrEnvDefaultFallback(
+			configVal, "retry_max",
+			"TF_HTTP_RETRY_MAX", cty.NumberIntVal(2),
+		),
+	)
+	if err != nil {
+		return backendbase.ErrorAsDiagnostics(
+			fmt.Errorf("invalid retry_max: %s", err),
+		)
+	}
+	retryWaitMin, err := backendbase.IntValue(
+		backendbase.GetAttrEnvDefaultFallback(
+			configVal, "retry_wait_min",
+			"TF_HTTP_RETRY_WAIT_MIN", cty.NumberIntVal(1),
+		),
+	)
+	if err != nil {
+		return backendbase.ErrorAsDiagnostics(
+			fmt.Errorf("invalid retry_wait_min: %s", err),
+		)
+	}
+	retryWaitMax, err := backendbase.IntValue(
+		backendbase.GetAttrEnvDefaultFallback(
+			configVal, "retry_wait_max",
+			"TF_HTTP_RETRY_WAIT_MAX", cty.NumberIntVal(30),
+		),
+	)
+	if err != nil {
+		return backendbase.ErrorAsDiagnostics(
+			fmt.Errorf("invalid retry_wait_max: %s", err),
+		)
+	}
+
+	rClient := retryablehttp.NewClient()
+	rClient.RetryMax = int(retryMax)
+	rClient.RetryWaitMin = time.Duration(retryWaitMin) * time.Second
+	rClient.RetryWaitMax = time.Duration(retryWaitMax) * time.Second
+	rClient.Logger = log.New(logging.LogOutput(), "", log.Flags())
+	if err = b.configureTLS(rClient, configVal); err != nil {
+		return backendbase.ErrorAsDiagnostics(err)
+	}
+
+	b.client = &httpClient{
+		URL:          updateURL,
+		UpdateMethod: updateMethod,
+
+		LockURL:      lockURL,
+		LockMethod:   lockMethod,
+		UnlockURL:    unlockURL,
+		UnlockMethod: unlockMethod,
+
+		Username: backendbase.GetAttrEnvDefaultFallback(
+			configVal, "username",
+			"TF_HTTP_USERNAME", cty.StringVal(""),
+		).AsString(),
+		Password: backendbase.GetAttrEnvDefaultFallback(
+			configVal, "password",
+			"TF_HTTP_PASSWORD", cty.StringVal(""),
+		).AsString(),
+
+		// accessible only for testing use
+		Client: rClient,
+	}
+	return nil
+}
+
 // configureTLS configures TLS when needed; if there are no conditions requiring TLS, no change is made.
-func (b *Backend) configureTLS(client *retryablehttp.Client, data *schema.ResourceData) error {
+func (b *Backend) configureTLS(client *retryablehttp.Client, configVal cty.Value) error {
 	// If there are no conditions needing to configure TLS, leave the client untouched
-	skipCertVerification := data.Get("skip_cert_verification").(bool)
-	clientCACertificatePem := data.Get("client_ca_certificate_pem").(string)
-	clientCertificatePem := data.Get("client_certificate_pem").(string)
-	clientPrivateKeyPem := data.Get("client_private_key_pem").(string)
+	skipCertVerification := backendbase.MustBoolValue(
+		backendbase.GetAttrDefault(configVal, "skip_cert_verification", cty.False),
+	)
+	clientCACertificatePem := backendbase.GetAttrEnvDefaultFallback(
+		configVal, "client_ca_certificate_pem",
+		"TF_HTTP_CLIENT_CA_CERTIFICATE_PEM", cty.StringVal(""),
+	).AsString()
+	clientCertificatePem := backendbase.GetAttrEnvDefaultFallback(
+		configVal, "client_certificate_pem",
+		"TF_HTTP_CLIENT_CERTIFICATE_PEM", cty.StringVal(""),
+	).AsString()
+	clientPrivateKeyPem := backendbase.GetAttrEnvDefaultFallback(
+		configVal, "client_private_key_pem",
+		"TF_HTTP_CLIENT_PRIVATE_KEY_PEM", cty.StringVal(""),
+	).AsString()
 	if !skipCertVerification && clientCACertificatePem == "" && clientCertificatePem == "" && clientPrivateKeyPem == "" {
 		return nil
 	}
@@ -171,75 +303,6 @@ func (b *Backend) configureTLS(client *retryablehttp.Client, data *schema.Resour
 		tlsConfig.Certificates = []tls.Certificate{certificate}
 	}
 
-	return nil
-}
-
-func (b *Backend) configure(ctx context.Context) error {
-	data := schema.FromContextBackendConfig(ctx)
-
-	address := data.Get("address").(string)
-	updateURL, err := url.Parse(address)
-	if err != nil {
-		return fmt.Errorf("failed to parse address URL: %s", err)
-	}
-	if updateURL.Scheme != "http" && updateURL.Scheme != "https" {
-		return fmt.Errorf("address must be HTTP or HTTPS")
-	}
-
-	updateMethod := data.Get("update_method").(string)
-
-	var lockURL *url.URL
-	if v, ok := data.GetOk("lock_address"); ok && v.(string) != "" {
-		var err error
-		lockURL, err = url.Parse(v.(string))
-		if err != nil {
-			return fmt.Errorf("failed to parse lockAddress URL: %s", err)
-		}
-		if lockURL.Scheme != "http" && lockURL.Scheme != "https" {
-			return fmt.Errorf("lockAddress must be HTTP or HTTPS")
-		}
-	}
-
-	lockMethod := data.Get("lock_method").(string)
-
-	var unlockURL *url.URL
-	if v, ok := data.GetOk("unlock_address"); ok && v.(string) != "" {
-		var err error
-		unlockURL, err = url.Parse(v.(string))
-		if err != nil {
-			return fmt.Errorf("failed to parse unlockAddress URL: %s", err)
-		}
-		if unlockURL.Scheme != "http" && unlockURL.Scheme != "https" {
-			return fmt.Errorf("unlockAddress must be HTTP or HTTPS")
-		}
-	}
-
-	unlockMethod := data.Get("unlock_method").(string)
-
-	rClient := retryablehttp.NewClient()
-	rClient.RetryMax = data.Get("retry_max").(int)
-	rClient.RetryWaitMin = time.Duration(data.Get("retry_wait_min").(int)) * time.Second
-	rClient.RetryWaitMax = time.Duration(data.Get("retry_wait_max").(int)) * time.Second
-	rClient.Logger = log.New(logging.LogOutput(), "", log.Flags())
-	if err = b.configureTLS(rClient, data); err != nil {
-		return err
-	}
-
-	b.client = &httpClient{
-		URL:          updateURL,
-		UpdateMethod: updateMethod,
-
-		LockURL:      lockURL,
-		LockMethod:   lockMethod,
-		UnlockURL:    unlockURL,
-		UnlockMethod: unlockMethod,
-
-		Username: data.Get("username").(string),
-		Password: data.Get("password").(string),
-
-		// accessible only for testing use
-		Client: rClient,
-	}
 	return nil
 }
 


### PR DESCRIPTION
This PR has a subset of the commits from https://github.com/hashicorp/terraform/pull/34772 .

Rather than letting perfect be the enemy of the good, I've pulled in here the subset of the commits from that PR whose behavior I was able to test without access to credentials for remote cloud services. My hope is that by landing this subset now we can make a little progress and also avoid this shared helper code from rotting in a PR before we get a chance to update the other backends to use it.

This includes removing `helper/schema` usage from the following backends, since these ones were all testable locally on my computer:
- `inmem` (used only in tests)
- `http`
- `consul`

I expect that we'll want to take the individual backend updates one by one in separate PRs since they will each require at least testing and review by the separate teams that own those backends. This PR includes all of the shared code my backend-specific work depended on so that we can then approach the backend migrations in whatever order is most convenient.

However, that does mean that a lot of the code in `backendbase` is dead code for now, since this PR only includes the simpler backends that didn't need quite so much helper code. I'd like to include it anyway just because otherwise it'll force us to carefully sequence the addition of this code along with the individual backend updates that need it.
