### PR TITLE
langrefs: Separate package for expression reference analysis

### DIFF
--- a/internal/command/jsonconfig/expression.go
+++ b/internal/command/jsonconfig/expression.go
@@ -15,8 +15,8 @@ import (
 
 	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/configs/configschema"
-	"github.com/hashicorp/terraform/internal/lang"
 	"github.com/hashicorp/terraform/internal/lang/blocktoattr"
+	"github.com/hashicorp/terraform/internal/lang/langrefs"
 )
 
 // expression represents any unparsed expression
@@ -48,7 +48,7 @@ func marshalExpression(ex hcl.Expression) expression {
 		ret.ConstantValue = valJSON
 	}
 
-	refs, _ := lang.ReferencesInExpr(addrs.ParseRef, ex)
+	refs, _ := langrefs.ReferencesInExpr(addrs.ParseRef, ex)
 	if len(refs) > 0 {
 		var varString []string
 		for _, ref := range refs {

--- a/internal/configs/checks.go
+++ b/internal/configs/checks.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 
 	"github.com/hashicorp/terraform/internal/addrs"
-	"github.com/hashicorp/terraform/internal/lang"
+	"github.com/hashicorp/terraform/internal/lang/langrefs"
 )
 
 // CheckRule represents a configuration-defined validation rule, precondition,
@@ -53,7 +53,7 @@ func (cr *CheckRule) validateSelfReferences(checkType string, addr addrs.Resourc
 		if expr == nil {
 			continue
 		}
-		refs, _ := lang.References(addrs.ParseRef, expr.Variables())
+		refs, _ := langrefs.References(addrs.ParseRef, expr.Variables())
 		for _, ref := range refs {
 			var refAddr addrs.Resource
 

--- a/internal/configs/resource.go
+++ b/internal/configs/resource.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 
 	"github.com/hashicorp/terraform/internal/addrs"
-	"github.com/hashicorp/terraform/internal/lang"
+	"github.com/hashicorp/terraform/internal/lang/langrefs"
 	"github.com/hashicorp/terraform/internal/tfdiags"
 )
 
@@ -558,7 +558,7 @@ func decodeReplaceTriggeredBy(expr hcl.Expression) ([]hcl.Expression, hcl.Diagno
 		// re-assign the value in case it was replaced by a json expression
 		exprs[i] = expr
 
-		refs, refDiags := lang.ReferencesInExpr(addrs.ParseRef, expr)
+		refs, refDiags := langrefs.ReferencesInExpr(addrs.ParseRef, expr)
 		for _, diag := range refDiags {
 			severity := hcl.DiagError
 			if diag.Severity() == tfdiags.Warning {

--- a/internal/lang/eval.go
+++ b/internal/lang/eval.go
@@ -19,6 +19,7 @@ import (
 	"github.com/hashicorp/terraform/internal/configs/configschema"
 	"github.com/hashicorp/terraform/internal/instances"
 	"github.com/hashicorp/terraform/internal/lang/blocktoattr"
+	"github.com/hashicorp/terraform/internal/lang/langrefs"
 	"github.com/hashicorp/terraform/internal/tfdiags"
 )
 
@@ -32,7 +33,7 @@ func (s *Scope) ExpandBlock(body hcl.Body, schema *configschema.Block) (hcl.Body
 	spec := schema.DecoderSpec()
 
 	traversals := dynblock.ExpandVariablesHCLDec(body, spec)
-	refs, diags := References(s.ParseRef, traversals)
+	refs, diags := langrefs.References(s.ParseRef, traversals)
 
 	ctx, ctxDiags := s.EvalContext(refs)
 	diags = diags.Append(ctxDiags)
@@ -53,7 +54,7 @@ func (s *Scope) ExpandBlock(body hcl.Body, schema *configschema.Block) (hcl.Body
 func (s *Scope) EvalBlock(body hcl.Body, schema *configschema.Block) (cty.Value, tfdiags.Diagnostics) {
 	spec := schema.DecoderSpec()
 
-	refs, diags := ReferencesInBlock(s.ParseRef, body, schema)
+	refs, diags := langrefs.ReferencesInBlock(s.ParseRef, body, schema)
 
 	ctx, ctxDiags := s.EvalContext(refs)
 	diags = diags.Append(ctxDiags)
@@ -100,7 +101,7 @@ func (s *Scope) EvalSelfBlock(body hcl.Body, self cty.Value, schema *configschem
 		})
 	}
 
-	refs, refDiags := References(s.ParseRef, hcldec.Variables(body, spec))
+	refs, refDiags := langrefs.References(s.ParseRef, hcldec.Variables(body, spec))
 	diags = diags.Append(refDiags)
 
 	terraformAttrs := map[string]cty.Value{}
@@ -165,7 +166,7 @@ func (s *Scope) EvalSelfBlock(body hcl.Body, self cty.Value, schema *configschem
 // If the returned diagnostics contains errors then the result may be
 // incomplete, but will always be of the requested type.
 func (s *Scope) EvalExpr(expr hcl.Expression, wantType cty.Type) (cty.Value, tfdiags.Diagnostics) {
-	refs, diags := ReferencesInExpr(s.ParseRef, expr)
+	refs, diags := langrefs.ReferencesInExpr(s.ParseRef, expr)
 
 	ctx, ctxDiags := s.EvalContext(refs)
 	diags = diags.Append(ctxDiags)

--- a/internal/lang/eval_test.go
+++ b/internal/lang/eval_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/configs/configschema"
 	"github.com/hashicorp/terraform/internal/instances"
+	"github.com/hashicorp/terraform/internal/lang/langrefs"
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
@@ -420,7 +421,7 @@ func TestScopeEvalContext(t *testing.T) {
 		},
 	}
 
-	exec := func(t *testing.T, parseRef ParseRef, test struct {
+	exec := func(t *testing.T, parseRef langrefs.ParseRef, test struct {
 		Expr        string
 		Want        map[string]cty.Value
 		TestingOnly bool
@@ -434,7 +435,7 @@ func TestScopeEvalContext(t *testing.T) {
 			return
 		}
 
-		refs, refsDiags := ReferencesInExpr(parseRef, expr)
+		refs, refsDiags := langrefs.ReferencesInExpr(parseRef, expr)
 		if refsDiags.HasErrors() {
 			t.Fatal(refsDiags.Err())
 		}

--- a/internal/lang/globalref/analyzer_meta_references.go
+++ b/internal/lang/globalref/analyzer_meta_references.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/configs/configschema"
-	"github.com/hashicorp/terraform/internal/lang"
+	"github.com/hashicorp/terraform/internal/lang/langrefs"
 )
 
 // MetaReferences inspects the configuration to find the references contained
@@ -118,7 +118,7 @@ func (a *Analyzer) metaReferencesInputVariable(calleeAddr addrs.ModuleInstance, 
 	if attr == nil {
 		return nil
 	}
-	refs, _ := lang.ReferencesInExpr(addrs.ParseRef, attr.Expr)
+	refs, _ := langrefs.ReferencesInExpr(addrs.ParseRef, attr.Expr)
 	return absoluteRefs(callerAddr, refs)
 }
 
@@ -138,7 +138,7 @@ func (a *Analyzer) metaReferencesOutputValue(callerAddr addrs.ModuleInstance, ad
 
 	// We don't check for errors here because we'll make a best effort to
 	// analyze whatever partial result HCL is able to extract.
-	refs, _ := lang.ReferencesInExpr(addrs.ParseRef, oc.Expr)
+	refs, _ := langrefs.ReferencesInExpr(addrs.ParseRef, oc.Expr)
 	return absoluteRefs(calleeAddr, refs)
 }
 
@@ -155,7 +155,7 @@ func (a *Analyzer) metaReferencesLocalValue(moduleAddr addrs.ModuleInstance, add
 
 	// We don't check for errors here because we'll make a best effort to
 	// analyze whatever partial result HCL is able to extract.
-	refs, _ := lang.ReferencesInExpr(addrs.ParseRef, local.Expr)
+	refs, _ := langrefs.ReferencesInExpr(addrs.ParseRef, local.Expr)
 	return absoluteRefs(moduleAddr, refs)
 }
 
@@ -389,12 +389,12 @@ Steps:
 
 	var refs []*addrs.Reference
 	for _, expr := range exprs {
-		moreRefs, _ := lang.ReferencesInExpr(addrs.ParseRef, expr)
+		moreRefs, _ := langrefs.ReferencesInExpr(addrs.ParseRef, expr)
 		refs = append(refs, moreRefs...)
 	}
 	if schema != nil {
 		for _, body := range bodies {
-			moreRefs, _ := lang.ReferencesInBlock(addrs.ParseRef, body, schema)
+			moreRefs, _ := langrefs.ReferencesInBlock(addrs.ParseRef, body, schema)
 			refs = append(refs, moreRefs...)
 		}
 	}

--- a/internal/lang/globalref/analyzer_meta_references_shortcuts.go
+++ b/internal/lang/globalref/analyzer_meta_references_shortcuts.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/terraform/internal/addrs"
-	"github.com/hashicorp/terraform/internal/lang"
+	"github.com/hashicorp/terraform/internal/lang/langrefs"
 )
 
 // ReferencesFromOutputValue returns all of the direct references from the
@@ -22,7 +22,7 @@ func (a *Analyzer) ReferencesFromOutputValue(addr addrs.AbsOutputValue) []Refere
 	if oc == nil {
 		return nil
 	}
-	refs, _ := lang.ReferencesInExpr(addrs.ParseRef, oc.Expr)
+	refs, _ := langrefs.ReferencesInExpr(addrs.ParseRef, oc.Expr)
 	return absoluteRefs(addr.Module, refs)
 }
 
@@ -38,11 +38,11 @@ func (a *Analyzer) ReferencesFromOutputValue(addr addrs.AbsOutputValue) []Refere
 // Analyzer.ReferencesFromResourceRepetition to get that same result directly.
 func (a *Analyzer) ReferencesFromResourceInstance(addr addrs.AbsResourceInstance) []Reference {
 	// Using MetaReferences for this is kinda overkill, since
-	// lang.ReferencesInBlock would be sufficient really, but
+	// langrefs.ReferencesInBlock would be sufficient really, but
 	// this ensures we keep consistent in how we build the
 	// resulting absolute references and otherwise aside from
 	// some extra overhead this call boils down to a call to
-	// lang.ReferencesInBlock anyway.
+	// langrefs.ReferencesInBlock anyway.
 	fakeRef := Reference{
 		ContainerAddr: addr.Module,
 		LocalRef: &addrs.Reference{
@@ -79,10 +79,10 @@ func (a *Analyzer) ReferencesFromResourceRepetition(addr addrs.AbsResource) []Re
 
 	switch {
 	case rc.ForEach != nil:
-		refs, _ := lang.ReferencesInExpr(addrs.ParseRef, rc.ForEach)
+		refs, _ := langrefs.ReferencesInExpr(addrs.ParseRef, rc.ForEach)
 		return absoluteRefs(addr.Module, refs)
 	case rc.Count != nil:
-		refs, _ := lang.ReferencesInExpr(addrs.ParseRef, rc.Count)
+		refs, _ := langrefs.ReferencesInExpr(addrs.ParseRef, rc.Count)
 		return absoluteRefs(addr.Module, refs)
 	default:
 		return nil

--- a/internal/lang/langrefs/references.go
+++ b/internal/lang/langrefs/references.go
@@ -1,7 +1,7 @@
 // Copyright (c) HashiCorp, Inc.
 // SPDX-License-Identifier: BUSL-1.1
 
-package lang
+package langrefs
 
 import (
 	"github.com/hashicorp/hcl/v2"
@@ -11,6 +11,10 @@ import (
 	"github.com/hashicorp/terraform/internal/lang/blocktoattr"
 	"github.com/hashicorp/terraform/internal/tfdiags"
 )
+
+// ParseRef describes the signature of a function that can attempt to raise
+// a raw HCL traversal into a reference.
+type ParseRef func(traversal hcl.Traversal) (*addrs.Reference, tfdiags.Diagnostics)
 
 // References finds all of the references in the given set of traversals,
 // returning diagnostics if any of the traversals cannot be interpreted as a

--- a/internal/lang/scope.go
+++ b/internal/lang/scope.go
@@ -7,15 +7,12 @@ import (
 	"sync"
 	"time"
 
-	"github.com/hashicorp/hcl/v2"
 	"github.com/zclconf/go-cty/cty/function"
 
 	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/experiments"
-	"github.com/hashicorp/terraform/internal/tfdiags"
+	"github.com/hashicorp/terraform/internal/lang/langrefs"
 )
-
-type ParseRef func(traversal hcl.Traversal) (*addrs.Reference, tfdiags.Diagnostics)
 
 // Scope is the main type in this package, allowing dynamic evaluation of
 // blocks and expressions based on some contextual information that informs
@@ -30,7 +27,7 @@ type Scope struct {
 	// while the main Terraform context scope can not. This means that this
 	// function for the testing scope will happily return outputs, while the
 	// main context scope would fail if a user attempts to reference an output.
-	ParseRef ParseRef
+	ParseRef langrefs.ParseRef
 
 	// SelfAddr is the address that the "self" object should be an alias of,
 	// or nil if the "self" object should not be available at all.

--- a/internal/legacy/go.mod
+++ b/internal/legacy/go.mod
@@ -26,12 +26,10 @@ require (
 	cloud.google.com/go/iam v1.1.1 // indirect
 	cloud.google.com/go/storage v1.30.1 // indirect
 	github.com/agext/levenshtein v1.2.3 // indirect
-	github.com/apparentlymart/go-cidr v1.1.0 // indirect
 	github.com/apparentlymart/go-textseg/v15 v15.0.0 // indirect
 	github.com/apparentlymart/go-versions v1.0.1 // indirect
 	github.com/aws/aws-sdk-go v1.44.122 // indirect
 	github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d // indirect
-	github.com/bmatcuk/doublestar v1.1.5 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/google/s2a-go v0.1.4 // indirect
@@ -53,7 +51,6 @@ require (
 	github.com/ulikunitz/xz v0.5.10 // indirect
 	github.com/vmihailenco/msgpack/v5 v5.3.5 // indirect
 	github.com/vmihailenco/tagparser/v2 v2.0.0 // indirect
-	github.com/zclconf/go-cty-yaml v1.0.3 // indirect
 	go.opencensus.io v0.24.0 // indirect
 	golang.org/x/crypto v0.19.0 // indirect
 	golang.org/x/mod v0.12.0 // indirect

--- a/internal/legacy/go.sum
+++ b/internal/legacy/go.sum
@@ -194,8 +194,6 @@ github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAE
 github.com/agext/levenshtein v1.2.3 h1:YB2fHEn0UJagG8T1rrWknE3ZQzWM06O8AMAatNn7lmo=
 github.com/agext/levenshtein v1.2.3/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
-github.com/apparentlymart/go-cidr v1.1.0 h1:2mAhrMoF+nhXqxTzSZMUzDHkLjmIHC+Zzn4tdgBZjnU=
-github.com/apparentlymart/go-cidr v1.1.0/go.mod h1:EBcsNrHc3zQeuaeCeCtQruQm+n9/YjEn/vI25Lg7Gwc=
 github.com/apparentlymart/go-dump v0.0.0-20180507223929-23540a00eaa3 h1:ZSTrOEhiM5J5RFxEaFvMZVEAM1KvT1YzbEOwB2EAGjA=
 github.com/apparentlymart/go-dump v0.0.0-20180507223929-23540a00eaa3/go.mod h1:oL81AME2rN47vu18xqj1S1jPIPuN7afo62yKTNn3XMM=
 github.com/apparentlymart/go-textseg/v15 v15.0.0 h1:uYvfpb3DyLSCGWnctWKGj857c6ew1u1fNQOlOtuGxQY=
@@ -206,8 +204,6 @@ github.com/aws/aws-sdk-go v1.44.122 h1:p6mw01WBaNpbdP2xrisz5tIkcNwzj/HysobNoaAHj
 github.com/aws/aws-sdk-go v1.44.122/go.mod h1:y4AeaBuwd2Lk+GepC1E9v0qOiTws0MIWAX4oIKwKHZo=
 github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d h1:xDfNPAt8lFiC1UJrqV3uuy861HCTo708pDMbjHHdCas=
 github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d/go.mod h1:6QX/PXZ00z/TKoufEY6K/a0k6AhaJrQKdFe6OfVXsa4=
-github.com/bmatcuk/doublestar v1.1.5 h1:2bNwBOmhyFEFcoB3tGvTD5xanq+4kyOZlB8wFYbMjkk=
-github.com/bmatcuk/doublestar v1.1.5/go.mod h1:wiQtGV+rzVYxB7WIlirSN++5HPtPlXEo9MEoZQC/PmE=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
@@ -460,8 +456,6 @@ github.com/zclconf/go-cty v1.14.3 h1:1JXy1XroaGrzZuG6X9dt7HL6s9AwbY+l4UNL8o5B6ho
 github.com/zclconf/go-cty v1.14.3/go.mod h1:VvMs5i0vgZdhYawQNq5kePSpLAoz8u1xvZgrPIxfnZE=
 github.com/zclconf/go-cty-debug v0.0.0-20240209213017-b8d9e32151be h1:JoF5rruXECi+VEbdJ6xanklyLnz+TVCZ0FcmvSQq/Go=
 github.com/zclconf/go-cty-debug v0.0.0-20240209213017-b8d9e32151be/go.mod h1:CmBdvvj3nqzfzJ6nTCIwDTPZ56aVGvDrmztiO5g3qrM=
-github.com/zclconf/go-cty-yaml v1.0.3 h1:og/eOQ7lvA/WWhHGFETVWNduJM7Rjsv2RRpx1sdFMLc=
-github.com/zclconf/go-cty-yaml v1.0.3/go.mod h1:9YLUH4g7lOhVWqUbctnVlZ5KLpg7JAprQNgxSZ1Gyxs=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=
 go.opencensus.io v0.22.2/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=
@@ -685,8 +679,6 @@ golang.org/x/sys v0.17.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/term v0.1.0/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
-golang.org/x/term v0.17.0 h1:mkTF7LCd6WGJNL3K1Ad7kwxNfYAW6a8a8QqtMblp/4U=
-golang.org/x/term v0.17.0/go.mod h1:lLRBjIVuehSbZlaOtGMbcMncT+aqLLLmKrsjNrUguwk=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/internal/moduletest/eval_context.go
+++ b/internal/moduletest/eval_context.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hashicorp/terraform/internal/configs"
 	"github.com/hashicorp/terraform/internal/didyoumean"
 	"github.com/hashicorp/terraform/internal/lang"
+	"github.com/hashicorp/terraform/internal/lang/langrefs"
 	"github.com/hashicorp/terraform/internal/terraform"
 	"github.com/hashicorp/terraform/internal/tfdiags"
 )
@@ -84,9 +85,9 @@ func (ec *EvalContext) Evaluate() (Status, cty.Value, tfdiags.Diagnostics) {
 	for i, rule := range run.Config.CheckRules {
 		var ruleDiags tfdiags.Diagnostics
 
-		refs, moreDiags := lang.ReferencesInExpr(addrs.ParseRefFromTestingScope, rule.Condition)
+		refs, moreDiags := langrefs.ReferencesInExpr(addrs.ParseRefFromTestingScope, rule.Condition)
 		ruleDiags = ruleDiags.Append(moreDiags)
-		moreRefs, moreDiags := lang.ReferencesInExpr(addrs.ParseRefFromTestingScope, rule.ErrorMessage)
+		moreRefs, moreDiags := langrefs.ReferencesInExpr(addrs.ParseRefFromTestingScope, rule.ErrorMessage)
 		ruleDiags = ruleDiags.Append(moreDiags)
 		refs = append(refs, moreRefs...)
 

--- a/internal/moduletest/hcl/context.go
+++ b/internal/moduletest/hcl/context.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/lang"
+	"github.com/hashicorp/terraform/internal/lang/langrefs"
 	"github.com/hashicorp/terraform/internal/tfdiags"
 )
 
@@ -57,7 +58,7 @@ func EvalContext(target EvalContextTarget, expressions []hcl.Expression, availab
 	}
 
 	for _, expression := range expressions {
-		refs, refDiags := lang.ReferencesInExpr(addrs.ParseRefFromTestingScope, expression)
+		refs, refDiags := langrefs.ReferencesInExpr(addrs.ParseRefFromTestingScope, expression)
 		diags = diags.Append(refDiags)
 
 		for _, ref := range refs {

--- a/internal/moduletest/hcl/provider.go
+++ b/internal/moduletest/hcl/provider.go
@@ -8,7 +8,7 @@ import (
 	"github.com/zclconf/go-cty/cty"
 
 	"github.com/hashicorp/terraform/internal/addrs"
-	"github.com/hashicorp/terraform/internal/lang"
+	"github.com/hashicorp/terraform/internal/lang/langrefs"
 	"github.com/hashicorp/terraform/internal/terraform"
 )
 
@@ -76,7 +76,7 @@ func (p *ProviderConfig) transformAttributes(originals hcl.Attributes) (hcl.Attr
 		// the references from this expression now and see if they reference any
 		// input variables. If we find an input variable, we'll copy it into
 		// our availableVariables local.
-		refs, _ := lang.ReferencesInExpr(addrs.ParseRefFromTestingScope, original.Expr)
+		refs, _ := langrefs.ReferencesInExpr(addrs.ParseRefFromTestingScope, original.Expr)
 		for _, ref := range refs {
 			if addr, ok := ref.Subject.(addrs.InputVariable); ok {
 				if _, exists := availableVariables[addr.Name]; exists {

--- a/internal/terraform/eval_conditions.go
+++ b/internal/terraform/eval_conditions.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hashicorp/terraform/internal/configs"
 	"github.com/hashicorp/terraform/internal/instances"
 	"github.com/hashicorp/terraform/internal/lang"
+	"github.com/hashicorp/terraform/internal/lang/langrefs"
 	"github.com/hashicorp/terraform/internal/tfdiags"
 )
 
@@ -71,9 +72,9 @@ type checkResult struct {
 func validateCheckRule(addr addrs.CheckRule, rule *configs.CheckRule, ctx EvalContext, keyData instances.RepetitionData) (string, *hcl.EvalContext, tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
 
-	refs, moreDiags := lang.ReferencesInExpr(addrs.ParseRef, rule.Condition)
+	refs, moreDiags := langrefs.ReferencesInExpr(addrs.ParseRef, rule.Condition)
 	diags = diags.Append(moreDiags)
-	moreRefs, moreDiags := lang.ReferencesInExpr(addrs.ParseRef, rule.ErrorMessage)
+	moreRefs, moreDiags := langrefs.ReferencesInExpr(addrs.ParseRef, rule.ErrorMessage)
 	diags = diags.Append(moreDiags)
 	refs = append(refs, moreRefs...)
 

--- a/internal/terraform/eval_for_each.go
+++ b/internal/terraform/eval_for_each.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/instances"
-	"github.com/hashicorp/terraform/internal/lang"
+	"github.com/hashicorp/terraform/internal/lang/langrefs"
 	"github.com/hashicorp/terraform/internal/lang/marks"
 	"github.com/hashicorp/terraform/internal/tfdiags"
 )
@@ -146,7 +146,7 @@ func (ev *forEachEvaluator) Value() (cty.Value, tfdiags.Diagnostics) {
 		return cty.NullVal(cty.Map(cty.DynamicPseudoType)), nil
 	}
 
-	refs, moreDiags := lang.ReferencesInExpr(addrs.ParseRef, ev.expr)
+	refs, moreDiags := langrefs.ReferencesInExpr(addrs.ParseRef, ev.expr)
 	diags = diags.Append(moreDiags)
 	scope := ev.ctx.EvaluationScope(nil, nil, EvalDataForNoInstanceKey)
 	if scope != nil {

--- a/internal/terraform/evaluate_valid_test.go
+++ b/internal/terraform/evaluate_valid_test.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/configs/configschema"
-	"github.com/hashicorp/terraform/internal/lang"
+	"github.com/hashicorp/terraform/internal/lang/langrefs"
 	"github.com/hashicorp/terraform/internal/providers"
 )
 
@@ -130,7 +130,7 @@ For example, to correlate with indices of a referring resource, use:
 				t.Fatal(hclDiags.Error())
 			}
 
-			refs, diags := lang.References(addrs.ParseRef, []hcl.Traversal{traversal})
+			refs, diags := langrefs.References(addrs.ParseRef, []hcl.Traversal{traversal})
 			if diags.HasErrors() {
 				t.Fatal(diags.Err())
 			}

--- a/internal/terraform/node_check.go
+++ b/internal/terraform/node_check.go
@@ -12,7 +12,7 @@ import (
 	"github.com/hashicorp/terraform/internal/checks"
 	"github.com/hashicorp/terraform/internal/configs"
 	"github.com/hashicorp/terraform/internal/dag"
-	"github.com/hashicorp/terraform/internal/lang"
+	"github.com/hashicorp/terraform/internal/lang/langrefs"
 	"github.com/hashicorp/terraform/internal/tfdiags"
 )
 
@@ -109,8 +109,8 @@ func (n *nodeExpandCheck) References() []*addrs.Reference {
 	for _, assert := range n.config.Asserts {
 		// Check blocks reference anything referenced by conditions or messages
 		// in their check rules.
-		condition, _ := lang.ReferencesInExpr(addrs.ParseRef, assert.Condition)
-		message, _ := lang.ReferencesInExpr(addrs.ParseRef, assert.ErrorMessage)
+		condition, _ := langrefs.ReferencesInExpr(addrs.ParseRef, assert.Condition)
+		message, _ := langrefs.ReferencesInExpr(addrs.ParseRef, assert.ErrorMessage)
 		refs = append(refs, condition...)
 		refs = append(refs, message...)
 	}

--- a/internal/terraform/node_local.go
+++ b/internal/terraform/node_local.go
@@ -13,7 +13,7 @@ import (
 	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/configs"
 	"github.com/hashicorp/terraform/internal/dag"
-	"github.com/hashicorp/terraform/internal/lang"
+	"github.com/hashicorp/terraform/internal/lang/langrefs"
 	"github.com/hashicorp/terraform/internal/tfdiags"
 )
 
@@ -62,7 +62,7 @@ func (n *nodeExpandLocal) ReferenceableAddrs() []addrs.Referenceable {
 
 // GraphNodeReferencer
 func (n *nodeExpandLocal) References() []*addrs.Reference {
-	refs, _ := lang.ReferencesInExpr(addrs.ParseRef, n.Config.Expr)
+	refs, _ := langrefs.ReferencesInExpr(addrs.ParseRef, n.Config.Expr)
 	return refs
 }
 
@@ -136,7 +136,7 @@ func (n *NodeLocal) ReferenceableAddrs() []addrs.Referenceable {
 
 // GraphNodeReferencer
 func (n *NodeLocal) References() []*addrs.Reference {
-	refs, _ := lang.ReferencesInExpr(addrs.ParseRef, n.Config.Expr)
+	refs, _ := langrefs.ReferencesInExpr(addrs.ParseRef, n.Config.Expr)
 	return refs
 }
 
@@ -220,7 +220,7 @@ func evaluateLocalValue(config *configs.Local, localAddr addrs.LocalValue, addrS
 
 	// We ignore diags here because any problems we might find will be found
 	// again in EvaluateExpr below.
-	refs, _ := lang.ReferencesInExpr(addrs.ParseRef, expr)
+	refs, _ := langrefs.ReferencesInExpr(addrs.ParseRef, expr)
 	for _, ref := range refs {
 		if ref.Subject == localAddr {
 			diags = diags.Append(&hcl.Diagnostic{

--- a/internal/terraform/node_module_expand.go
+++ b/internal/terraform/node_module_expand.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform/internal/configs"
 	"github.com/hashicorp/terraform/internal/dag"
 	"github.com/hashicorp/terraform/internal/experiments"
-	"github.com/hashicorp/terraform/internal/lang"
+	"github.com/hashicorp/terraform/internal/lang/langrefs"
 	"github.com/hashicorp/terraform/internal/tfdiags"
 )
 
@@ -65,11 +65,11 @@ func (n *nodeExpandModule) References() []*addrs.Reference {
 	// child module instances we might expand to during our evaluation.
 
 	if n.ModuleCall.Count != nil {
-		countRefs, _ := lang.ReferencesInExpr(addrs.ParseRef, n.ModuleCall.Count)
+		countRefs, _ := langrefs.ReferencesInExpr(addrs.ParseRef, n.ModuleCall.Count)
 		refs = append(refs, countRefs...)
 	}
 	if n.ModuleCall.ForEach != nil {
-		forEachRefs, _ := lang.ReferencesInExpr(addrs.ParseRef, n.ModuleCall.ForEach)
+		forEachRefs, _ := langrefs.ReferencesInExpr(addrs.ParseRef, n.ModuleCall.ForEach)
 		refs = append(refs, forEachRefs...)
 	}
 	return refs

--- a/internal/terraform/node_module_variable.go
+++ b/internal/terraform/node_module_variable.go
@@ -14,7 +14,7 @@ import (
 	"github.com/hashicorp/terraform/internal/configs"
 	"github.com/hashicorp/terraform/internal/dag"
 	"github.com/hashicorp/terraform/internal/instances"
-	"github.com/hashicorp/terraform/internal/lang"
+	"github.com/hashicorp/terraform/internal/lang/langrefs"
 	"github.com/hashicorp/terraform/internal/tfdiags"
 )
 
@@ -136,7 +136,7 @@ func (n *nodeExpandModuleVariable) References() []*addrs.Reference {
 	// where our associated variable was declared, which is correct because
 	// our value expression is assigned within a "module" block in the parent
 	// module.
-	refs, _ := lang.ReferencesInExpr(addrs.ParseRef, n.Expr)
+	refs, _ := langrefs.ReferencesInExpr(addrs.ParseRef, n.Expr)
 	return refs
 }
 

--- a/internal/terraform/node_output.go
+++ b/internal/terraform/node_output.go
@@ -13,7 +13,7 @@ import (
 	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/configs"
 	"github.com/hashicorp/terraform/internal/dag"
-	"github.com/hashicorp/terraform/internal/lang"
+	"github.com/hashicorp/terraform/internal/lang/langrefs"
 	"github.com/hashicorp/terraform/internal/lang/marks"
 	"github.com/hashicorp/terraform/internal/namedvals"
 	"github.com/hashicorp/terraform/internal/plans"
@@ -299,16 +299,16 @@ func (n *NodeApplyableOutput) ReferenceableAddrs() []addrs.Referenceable {
 func referencesForOutput(c *configs.Output) []*addrs.Reference {
 	var refs []*addrs.Reference
 
-	impRefs, _ := lang.ReferencesInExpr(addrs.ParseRef, c.Expr)
-	expRefs, _ := lang.References(addrs.ParseRef, c.DependsOn)
+	impRefs, _ := langrefs.ReferencesInExpr(addrs.ParseRef, c.Expr)
+	expRefs, _ := langrefs.References(addrs.ParseRef, c.DependsOn)
 
 	refs = append(refs, impRefs...)
 	refs = append(refs, expRefs...)
 
 	for _, check := range c.Preconditions {
-		condRefs, _ := lang.ReferencesInExpr(addrs.ParseRef, check.Condition)
+		condRefs, _ := langrefs.ReferencesInExpr(addrs.ParseRef, check.Condition)
 		refs = append(refs, condRefs...)
-		errRefs, _ := lang.ReferencesInExpr(addrs.ParseRef, check.ErrorMessage)
+		errRefs, _ := langrefs.ReferencesInExpr(addrs.ParseRef, check.ErrorMessage)
 		refs = append(refs, errRefs...)
 	}
 

--- a/internal/terraform/node_resource_abstract.go
+++ b/internal/terraform/node_resource_abstract.go
@@ -12,7 +12,7 @@ import (
 	"github.com/hashicorp/terraform/internal/configs/configschema"
 	"github.com/hashicorp/terraform/internal/dag"
 	"github.com/hashicorp/terraform/internal/experiments"
-	"github.com/hashicorp/terraform/internal/lang"
+	"github.com/hashicorp/terraform/internal/lang/langrefs"
 	"github.com/hashicorp/terraform/internal/states"
 	"github.com/hashicorp/terraform/internal/tfdiags"
 )
@@ -161,25 +161,25 @@ func (n *NodeAbstractResource) References() []*addrs.Reference {
 			log.Printf("[WARN] no schema is attached to %s, so config references cannot be detected", n.Name())
 		}
 
-		refs, _ := lang.ReferencesInExpr(addrs.ParseRef, c.Count)
+		refs, _ := langrefs.ReferencesInExpr(addrs.ParseRef, c.Count)
 		result = append(result, refs...)
-		refs, _ = lang.ReferencesInExpr(addrs.ParseRef, c.ForEach)
+		refs, _ = langrefs.ReferencesInExpr(addrs.ParseRef, c.ForEach)
 		result = append(result, refs...)
 
 		for _, expr := range c.TriggersReplacement {
-			refs, _ = lang.ReferencesInExpr(addrs.ParseRef, expr)
+			refs, _ = langrefs.ReferencesInExpr(addrs.ParseRef, expr)
 			result = append(result, refs...)
 		}
 
 		// ReferencesInBlock() requires a schema
 		if n.Schema != nil {
-			refs, _ = lang.ReferencesInBlock(addrs.ParseRef, c.Config, n.Schema)
+			refs, _ = langrefs.ReferencesInBlock(addrs.ParseRef, c.Config, n.Schema)
 			result = append(result, refs...)
 		}
 
 		if c.Managed != nil {
 			if c.Managed.Connection != nil {
-				refs, _ = lang.ReferencesInBlock(addrs.ParseRef, c.Managed.Connection.Config, connectionBlockSupersetSchema)
+				refs, _ = langrefs.ReferencesInBlock(addrs.ParseRef, c.Managed.Connection.Config, connectionBlockSupersetSchema)
 				result = append(result, refs...)
 			}
 
@@ -188,7 +188,7 @@ func (n *NodeAbstractResource) References() []*addrs.Reference {
 					continue
 				}
 				if p.Connection != nil {
-					refs, _ = lang.ReferencesInBlock(addrs.ParseRef, p.Connection.Config, connectionBlockSupersetSchema)
+					refs, _ = langrefs.ReferencesInBlock(addrs.ParseRef, p.Connection.Config, connectionBlockSupersetSchema)
 					result = append(result, refs...)
 				}
 
@@ -196,21 +196,21 @@ func (n *NodeAbstractResource) References() []*addrs.Reference {
 				if schema == nil {
 					log.Printf("[WARN] no schema for provisioner %q is attached to %s, so provisioner block references cannot be detected", p.Type, n.Name())
 				}
-				refs, _ = lang.ReferencesInBlock(addrs.ParseRef, p.Config, schema)
+				refs, _ = langrefs.ReferencesInBlock(addrs.ParseRef, p.Config, schema)
 				result = append(result, refs...)
 			}
 		}
 
 		for _, check := range c.Preconditions {
-			refs, _ := lang.ReferencesInExpr(addrs.ParseRef, check.Condition)
+			refs, _ := langrefs.ReferencesInExpr(addrs.ParseRef, check.Condition)
 			result = append(result, refs...)
-			refs, _ = lang.ReferencesInExpr(addrs.ParseRef, check.ErrorMessage)
+			refs, _ = langrefs.ReferencesInExpr(addrs.ParseRef, check.ErrorMessage)
 			result = append(result, refs...)
 		}
 		for _, check := range c.Postconditions {
-			refs, _ := lang.ReferencesInExpr(addrs.ParseRef, check.Condition)
+			refs, _ := langrefs.ReferencesInExpr(addrs.ParseRef, check.Condition)
 			result = append(result, refs...)
-			refs, _ = lang.ReferencesInExpr(addrs.ParseRef, check.ErrorMessage)
+			refs, _ = langrefs.ReferencesInExpr(addrs.ParseRef, check.ErrorMessage)
 			result = append(result, refs...)
 		}
 	}
@@ -226,9 +226,9 @@ func (n *NodeAbstractResource) ImportReferences() []*addrs.Reference {
 			continue
 		}
 
-		refs, _ := lang.ReferencesInExpr(addrs.ParseRef, importTarget.Config.ID)
+		refs, _ := langrefs.ReferencesInExpr(addrs.ParseRef, importTarget.Config.ID)
 		result = append(result, refs...)
-		refs, _ = lang.ReferencesInExpr(addrs.ParseRef, importTarget.Config.ForEach)
+		refs, _ = langrefs.ReferencesInExpr(addrs.ParseRef, importTarget.Config.ForEach)
 		result = append(result, refs...)
 	}
 	return result

--- a/internal/terraform/node_resource_validate.go
+++ b/internal/terraform/node_resource_validate.go
@@ -15,7 +15,7 @@ import (
 	"github.com/hashicorp/terraform/internal/configs/configschema"
 	"github.com/hashicorp/terraform/internal/didyoumean"
 	"github.com/hashicorp/terraform/internal/instances"
-	"github.com/hashicorp/terraform/internal/lang"
+	"github.com/hashicorp/terraform/internal/lang/langrefs"
 	"github.com/hashicorp/terraform/internal/providers"
 	"github.com/hashicorp/terraform/internal/provisioners"
 	"github.com/hashicorp/terraform/internal/tfdiags"
@@ -472,7 +472,7 @@ func (n *NodeValidatableResource) validateResource(ctx EvalContext) tfdiags.Diag
 func (n *NodeValidatableResource) evaluateExpr(ctx EvalContext, expr hcl.Expression, wantTy cty.Type, self addrs.Referenceable, keyData instances.RepetitionData) (cty.Value, tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
 
-	refs, refDiags := lang.ReferencesInExpr(addrs.ParseRef, expr)
+	refs, refDiags := langrefs.ReferencesInExpr(addrs.ParseRef, expr)
 	diags = diags.Append(refDiags)
 
 	scope := ctx.EvaluationScope(self, nil, keyData)

--- a/internal/terraform/transform_reference.go
+++ b/internal/terraform/transform_reference.go
@@ -13,7 +13,7 @@ import (
 	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/configs/configschema"
 	"github.com/hashicorp/terraform/internal/dag"
-	"github.com/hashicorp/terraform/internal/lang"
+	"github.com/hashicorp/terraform/internal/lang/langrefs"
 )
 
 // GraphNodeReferenceable must be implemented by any node that represents
@@ -571,6 +571,6 @@ func ReferencesFromConfig(body hcl.Body, schema *configschema.Block) []*addrs.Re
 	if body == nil {
 		return nil
 	}
-	refs, _ := lang.ReferencesInBlock(addrs.ParseRef, body, schema)
+	refs, _ := langrefs.ReferencesInBlock(addrs.ParseRef, body, schema)
 	return refs
 }

--- a/internal/terraform/validate_selfref.go
+++ b/internal/terraform/validate_selfref.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/configs/configschema"
-	"github.com/hashicorp/terraform/internal/lang"
+	"github.com/hashicorp/terraform/internal/lang/langrefs"
 	"github.com/hashicorp/terraform/internal/providers"
 	"github.com/hashicorp/terraform/internal/tfdiags"
 )
@@ -41,7 +41,7 @@ func validateSelfRef(addr addrs.Referenceable, config hcl.Body, providerSchema p
 		return diags
 	}
 
-	refs, _ := lang.ReferencesInBlock(addrs.ParseRef, config, schema)
+	refs, _ := langrefs.ReferencesInBlock(addrs.ParseRef, config, schema)
 	for _, ref := range refs {
 		for _, addrStr := range addrStrs {
 			if ref.Subject.String() == addrStr {


### PR DESCRIPTION
Finding references in an expression is a static analysis operation, but we previously had it grouped in with "package lang" that primarily deals with dynamic evaluation of expressions.

We need to do static analysis in far more locations than we do full expression evaluation, the static-analysis-only callers don't need anything else from package lang, and the reference-analysis functions are self-contained little wrappers around the address parsing logic in package addrs anyway.

Splitting these into a separate package therefore minimizes which packages depend indirectly on package lang, and thus which packages depend indirectly on the implementations of the built-in functions. Some of the built-in functions rely on dependencies we don't use anywhere else, so cutting these out shrinks how many packages indirectly depend on those external dependencies. In particular, they are no longer in the indirect import chain for the "legacy" module.

---

This is also a prerequisite for the remote state backends to stop depending indirectly on the built-in functions, but it isn't sufficient: we currently have all of the backend-related functionality together in one package, so the remote state backends all depend on the machinery for performing Terraform runs even though they never actually perform Terraform runs. It'll take a separate change to the organization of the main `backend` package to cut these out of the remote state backend dependency chain too, which I'll save for another time.
