### PR TITLE
Include provider functions in scope used to evaluate test assertions

### DIFF
--- a/internal/command/test_test.go
+++ b/internal/command/test_test.go
@@ -212,6 +212,10 @@ func TestTest_Runs(t *testing.T) {
 			expectedOut: "2 passed, 0 failed.",
 			code:        0,
 		},
+		"provider-functions-available": {
+			expectedOut: "1 passed, 0 failed.",
+			code:        0,
+		},
 		"mocking": {
 			expectedOut: "6 passed, 0 failed.",
 			code:        0,

--- a/internal/command/testdata/test/provider-functions-available/main.tf
+++ b/internal/command/testdata/test/provider-functions-available/main.tf
@@ -1,0 +1,12 @@
+terraform {
+  required_providers {
+    test = {
+      source = "test"
+    }
+  }
+}
+
+
+output "value" {
+  value = provider::test::is_true(true)
+}

--- a/internal/command/testdata/test/provider-functions-available/main.tftest.hcl
+++ b/internal/command/testdata/test/provider-functions-available/main.tftest.hcl
@@ -1,0 +1,7 @@
+
+run "test" {
+  assert {
+    condition = provider::test::is_true(output.value)
+    error_message = "bad response"
+  }
+}

--- a/internal/command/testing/test_provider.go
+++ b/internal/command/testing/test_provider.go
@@ -63,6 +63,19 @@ var (
 				},
 			},
 		},
+		Functions: map[string]providers.FunctionDecl{
+			"is_true": {
+				Parameters: []providers.FunctionParam{
+					{
+						Name:               "input",
+						Type:               cty.Bool,
+						AllowNullValue:     false,
+						AllowUnknownValues: false,
+					},
+				},
+				ReturnType: cty.Bool,
+			},
+		},
 	}
 )
 
@@ -96,6 +109,7 @@ func NewProvider(store *ResourceStore) *TestProvider {
 	provider.Provider.ApplyResourceChangeFn = provider.ApplyResourceChange
 	provider.Provider.ReadResourceFn = provider.ReadResource
 	provider.Provider.ReadDataSourceFn = provider.ReadDataSource
+	provider.Provider.CallFunctionFn = provider.CallFunction
 
 	return provider
 }
@@ -310,6 +324,19 @@ func (provider *TestProvider) ReadDataSource(request providers.ReadDataSourceReq
 	return providers.ReadDataSourceResponse{
 		State:       resource,
 		Diagnostics: diags,
+	}
+}
+
+func (provider *TestProvider) CallFunction(request providers.CallFunctionRequest) providers.CallFunctionResponse {
+	switch request.FunctionName {
+	case "is_true":
+		return providers.CallFunctionResponse{
+			Result: request.Arguments[0],
+		}
+	default:
+		return providers.CallFunctionResponse{
+			Err: fmt.Errorf("unknown function %q", request.FunctionName),
+		}
 	}
 }
 

--- a/internal/moduletest/eval_context.go
+++ b/internal/moduletest/eval_context.go
@@ -58,6 +58,7 @@ func NewEvalContext(run *Run, module *configs.Module, resultScope *lang.Scope, e
 		BaseDir:       resultScope.BaseDir,
 		PureOnly:      resultScope.PureOnly,
 		PlanTimestamp: resultScope.PlanTimestamp,
+		ExternalFuncs: resultScope.ExternalFuncs,
 	}
 	return &EvalContext{
 		run:       run,


### PR DESCRIPTION
This PR adds support for using provider functions within the `assert` blocks for `terraform test`. I think we can still add this to the upcoming v1.8 release as we're still in the beta period, and this is such a simple fix with a lot of value.

We don't currently support referencing provider functions from the `variables` blocks within test files or run blocks, even with this change. Terraform test doesn't have access to the scope used by Terraform Core at that point in evaluation. We could add this in future, but we'd need to start the providers outside the Terraform Core context for this, gather the provider functions, etc. Which is a bit of a bigger piece of work than this change. 

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.8.0 (or next beta / RC)

## Draft CHANGELOG entry

N/A, we already have the changelog entry for provider functions in general.