### PR TITLE
provider/terraform: Use new convention for function names

### DIFF
--- a/internal/builtin/providers/terraform/functions.go
+++ b/internal/builtin/providers/terraform/functions.go
@@ -16,12 +16,12 @@ import (
 )
 
 var functions = map[string]func([]cty.Value) (cty.Value, error){
-	"tfvarsencode": tfvarsencodeFunc,
-	"tfvarsdecode": tfvarsdecodeFunc,
-	"exprencode":   exprencodeFunc,
+	"encode_tfvars": encodeTfvarsFunc,
+	"decode_tfvars": decodeTfvarsFunc,
+	"encode_expr":   encodeExprFunc,
 }
 
-func tfvarsencodeFunc(args []cty.Value) (cty.Value, error) {
+func encodeTfvarsFunc(args []cty.Value) (cty.Value, error) {
 	// These error checks should not be hit in practice because the language
 	// runtime should check them before calling, so this is just for robustness
 	// and completeness.
@@ -82,7 +82,7 @@ func tfvarsencodeFunc(args []cty.Value) (cty.Value, error) {
 	return cty.StringVal(string(result)), nil
 }
 
-func tfvarsdecodeFunc(args []cty.Value) (cty.Value, error) {
+func decodeTfvarsFunc(args []cty.Value) (cty.Value, error) {
 	// These error checks should not be hit in practice because the language
 	// runtime should check them before calling, so this is just for robustness
 	// and completeness.
@@ -116,7 +116,7 @@ func tfvarsdecodeFunc(args []cty.Value) (cty.Value, error) {
 	// stuff HCL diagnostics into plain string error messages. This produces
 	// a non-ideal result but is still better than hiding the HCL-provided
 	// diagnosis altogether.
-	f, hclDiags := hclsyntax.ParseConfig(src, "<tfvarsdecode argument>", hcl.InitialPos)
+	f, hclDiags := hclsyntax.ParseConfig(src, "<decode_tfvars argument>", hcl.InitialPos)
 	if hclDiags.HasErrors() {
 		return cty.NilVal, fmt.Errorf("invalid tfvars syntax: %s", hclDiags.Error())
 	}
@@ -139,7 +139,7 @@ func tfvarsdecodeFunc(args []cty.Value) (cty.Value, error) {
 	return cty.ObjectVal(retAttrs), nil
 }
 
-func exprencodeFunc(args []cty.Value) (cty.Value, error) {
+func encodeExprFunc(args []cty.Value) (cty.Value, error) {
 	// These error checks should not be hit in practice because the language
 	// runtime should check them before calling, so this is just for robustness
 	// and completeness.

--- a/internal/builtin/providers/terraform/functions_test.go
+++ b/internal/builtin/providers/terraform/functions_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestTfvarsencode(t *testing.T) {
-	tableTestFunction(t, "tfvarsencode", []functionTest{
+	tableTestFunction(t, "encode_tfvars", []functionTest{
 		{
 			Input: cty.ObjectVal(map[string]cty.Value{
 				"string": cty.StringVal("hello"),
@@ -126,7 +126,7 @@ two   = 2
 }
 
 func TestTfvarsdecode(t *testing.T) {
-	tableTestFunction(t, "tfvarsdecode", []functionTest{
+	tableTestFunction(t, "decode_tfvars", []functionTest{
 		{
 			Input: cty.StringVal(`string = "hello"
 number = 2`),
@@ -152,25 +152,25 @@ number = 2`),
 			// This is actually not a very good diagnosis for this error,
 			// since we're expecting HCL arguments rather than HCL blocks,
 			// but that's something we'd need to address in HCL.
-			WantErr: `invalid tfvars syntax: <tfvarsdecode argument>:1,17-17: Invalid block definition; Either a quoted string block label or an opening brace ("{") is expected here.`,
+			WantErr: `invalid tfvars syntax: <decode_tfvars argument>:1,17-17: Invalid block definition; Either a quoted string block label or an opening brace ("{") is expected here.`,
 		},
 		{
 			Input:   cty.StringVal(`foo = not valid syntax`),
-			WantErr: `invalid tfvars syntax: <tfvarsdecode argument>:1,11-16: Missing newline after argument; An argument definition must end with a newline.`,
+			WantErr: `invalid tfvars syntax: <decode_tfvars argument>:1,11-16: Missing newline after argument; An argument definition must end with a newline.`,
 		},
 		{
 			Input:   cty.StringVal(`foo = var.whatever`),
-			WantErr: `invalid expression for variable "foo": <tfvarsdecode argument>:1,7-10: Variables not allowed; Variables may not be used here.`,
+			WantErr: `invalid expression for variable "foo": <decode_tfvars argument>:1,7-10: Variables not allowed; Variables may not be used here.`,
 		},
 		{
 			Input:   cty.StringVal(`foo = whatever()`),
-			WantErr: `invalid expression for variable "foo": <tfvarsdecode argument>:1,7-17: Function calls not allowed; Functions may not be called here.`,
+			WantErr: `invalid expression for variable "foo": <decode_tfvars argument>:1,7-17: Function calls not allowed; Functions may not be called here.`,
 		},
 	})
 }
 
 func TestExprencode(t *testing.T) {
-	tableTestFunction(t, "exprencode", []functionTest{
+	tableTestFunction(t, "encode_expr", []functionTest{
 		{
 			Input: cty.StringVal("hello"),
 			Want:  cty.StringVal(`"hello"`),

--- a/internal/builtin/providers/terraform/provider.go
+++ b/internal/builtin/providers/terraform/provider.go
@@ -30,7 +30,7 @@ func (p *Provider) GetProviderSchema() providers.GetProviderSchemaResponse {
 			"terraform_data": dataStoreResourceSchema(),
 		},
 		Functions: map[string]providers.FunctionDecl{
-			"tfvarsencode": {
+			"encode_tfvars": {
 				Parameters: []providers.FunctionParam{
 					{
 						Name:               "value",
@@ -40,7 +40,7 @@ func (p *Provider) GetProviderSchema() providers.GetProviderSchemaResponse {
 				},
 				ReturnType: cty.String,
 			},
-			"tfvarsdecode": {
+			"decode_tfvars": {
 				Parameters: []providers.FunctionParam{
 					{
 						Name: "src",
@@ -49,7 +49,7 @@ func (p *Provider) GetProviderSchema() providers.GetProviderSchemaResponse {
 				},
 				ReturnType: cty.DynamicPseudoType,
 			},
-			"exprencode": {
+			"encode_expr": {
 				Parameters: []providers.FunctionParam{
 					{
 						Name:               "value",

--- a/internal/command/e2etest/testdata/terraform-provider-funcs/terraform-provider-funcs.tf
+++ b/internal/command/e2etest/testdata/terraform-provider-funcs/terraform-provider-funcs.tf
@@ -14,7 +14,7 @@ terraform {
 }
 
 output "tfvarsencode" {
-  value = provider::terraform::tfvarsencode({
+  value = provider::terraform::encode_tfvars({
     a = "👋"
     b = "🐝"
     c = "👓"
@@ -22,7 +22,7 @@ output "tfvarsencode" {
 }
 
 output "tfvarsdecode" {
-  value = provider::terraform::tfvarsdecode(
+  value = provider::terraform::decode_tfvars(
     <<-EOT
       boop = "👃"
       baaa = "🐑"
@@ -31,5 +31,5 @@ output "tfvarsdecode" {
 }
 
 output "exprencode" {
-  value = provider::terraform::exprencode([1, 2, 3])
+  value = provider::terraform::encode_expr([1, 2, 3])
 }

--- a/website/data/language-nav-data.json
+++ b/website/data/language-nav-data.json
@@ -733,9 +733,9 @@
       {
         "title": "Terraform-specific Functions",
         "routes": [
-          { "title": "<code>provider::terraform::tfvarsencode</code>", "href": "/language/functions/terraform-tfvarsencode" },
-          { "title": "<code>provider::terraform::tfvarsdecode</code>", "href": "/language/functions/terraform-tfvarsdecode" },
-          { "title": "<code>provider::terraform::exprencode</code>", "href": "/language/functions/terraform-exprencode" }
+          { "title": "<code>provider::terraform::encode_tfvars</code>", "href": "/language/functions/terraform-encode_tfvars" },
+          { "title": "<code>provider::terraform::decode_tfvars</code>", "href": "/language/functions/terraform-decode_tfvars" },
+          { "title": "<code>provider::terraform::encode_expr</code>", "href": "/language/functions/terraform-encode_expr" }
         ]
       },
       { "title": "abs", "path": "functions/abs", "hidden": true },
@@ -886,9 +886,9 @@
         "path": "functions/templatefile",
         "hidden": true
       },
-      { "title": "terraform-tfvarsencode", "path": "functions/terraform-tfvarsencode", "hidden": true },
-      { "title": "terraform-tfvarsdecode", "path": "functions/terraform-tfvarsdecode", "hidden": true },
-      { "title": "terraform-exprencode", "path": "functions/terraform-exprencode", "hidden": true },
+      { "title": "terraform-encode_tfvars", "path": "functions/terraform-encode_tfvars", "hidden": true },
+      { "title": "terraform-decode_tfvars", "path": "functions/terraform-decode_tfvars", "hidden": true },
+      { "title": "terraform-encode_expr", "path": "functions/terraform-encode_expr", "hidden": true },
       {
         "title": "textdecodebase64",
         "path": "functions/textdecodebase64",

--- a/website/docs/language/functions/terraform-decode_tfvars.mdx
+++ b/website/docs/language/functions/terraform-decode_tfvars.mdx
@@ -1,15 +1,15 @@
 ---
-page_title: provider::terraform::tfvarsdecode - Functions - Configuration Language
+page_title: provider::terraform::decode_tfvars - Functions - Configuration Language
 description: >-
-  The tfvarsencode function parses a string containing syntax like that used
+  The decode_tfvars function parses a string containing syntax like that used
   in a ".tfvars" file.
 ---
 
-# `provider::terraform::tfvarsdecode` Function
+# `provider::terraform::decode_tfvars` Function
 
 -> **Note:** This function is supported only in Terraform v1.8 and later.
 
-`provider::terraform::tfvarsdecode` is a rarely-needed function which takes
+`provider::terraform::decode_tfvars` is a rarely-needed function which takes
 a string containing the content of a
 [`.tfvars` file](/terraform/language/values/variables#variable-definitions-tfvars-files)
 and returns an object describing the raw variable values it defines.
@@ -30,7 +30,7 @@ terraform {
 Elsewhere in your module you can then call this function:
 
 ```hcl
-provider::terraform::tfvarsdecode(
+provider::terraform::decode_tfvars(
   <<EOT
     example = "Hello!"
   EOT
@@ -65,6 +65,6 @@ to represent list, set, or map values directly in the `.tfvars` format.
 
 ## Related Functions
 
-* [`tfvarsencode`](/terraform/language/functions/terraform-tfvarsencode)
+* [`encode_tfvars`](/terraform/language/functions/terraform-encode_tfvars)
   performs the opposite operation: producing `.tfvars` content from an
   object value.

--- a/website/docs/language/functions/terraform-encode_expr.mdx
+++ b/website/docs/language/functions/terraform-encode_expr.mdx
@@ -1,15 +1,15 @@
 ---
-page_title: provider::terraform::exprencode - Functions - Configuration Language
+page_title: provider::terraform::encode_expr - Functions - Configuration Language
 description: >-
-  The exprencode function produces a string representation of an arbitrary value
+  The encode_expr function produces a string representation of an arbitrary value
   using Terraform expression syntax.
 ---
 
-# `provider::terraform::exprencode` Function
+# `provider::terraform::encode_expr` Function
 
 -> **Note:** This function is supported only in Terraform v1.8 and later.
 
-`provider::terraform::exprencode` is a rarely-needed function which takes
+`provider::terraform::encode_expr` is a rarely-needed function which takes
 any value and produces a string containing Terraform language expression syntax
 approximating that value.
 
@@ -49,7 +49,7 @@ resource "tfe_variable" "test" {
   workspace_id = tfe_workspace.example.id
 
   key   = each.key
-  value = provider::terraform::exprencode(each.value)
+  value = provider::terraform::encode_expr(each.value)
   hcl   = true
 }
 ```
@@ -67,6 +67,6 @@ when upgrading Terraform in future.
 
 ## Related Functions
 
-* [`tfvarsencode`](/terraform/language/functions/terraform-tfvarsencode)
+* [`encode_tfvars`](/terraform/language/functions/terraform-encode_tfvars)
   produces expression strings for many different values at once, in `.tfvars`
   syntax.

--- a/website/docs/language/functions/terraform-encode_tfvars.mdx
+++ b/website/docs/language/functions/terraform-encode_tfvars.mdx
@@ -1,15 +1,15 @@
 ---
-page_title: provider::terraform::tfvarsencode - Functions - Configuration Language
+page_title: provider::terraform::encode_tfvars - Functions - Configuration Language
 description: >-
-  The tfvarsencode function produces a string representation of an object
+  The encode_tfvars function produces a string representation of an object
   using the same syntax as for ".tfvars" files used in Terraform CLI.
 ---
 
-# `provider::terraform::tfvarsencode` Function
+# `provider::terraform::encode_tfvars` Function
 
 -> **Note:** This function is supported only in Terraform v1.8 and later.
 
-`provider::terraform::tfvarsencode` is a rarely-needed function which takes
+`provider::terraform::encode_tfvars` is a rarely-needed function which takes
 an object value and produces a string containing a description of that object
 using the same syntax as Terraform CLI would expect in a
 [`.tfvars` file](/terraform/language/values/variables#variable-definitions-tfvars-files).
@@ -35,7 +35,7 @@ terraform {
 Elsewhere in your module you can then call this function:
 
 ```hcl
-provider::terraform::tfvarsencode({
+provider::terraform::encode_tfvars({
   example = "Hello!"
 })
 ```
@@ -64,9 +64,9 @@ when upgrading Terraform in future.
 
 ## Related Functions
 
-* [`tfvarsdecode`](/terraform/language/functions/terraform-tfvarsdecode)
+* [`decode_tfvars`](/terraform/language/functions/terraform-decode_tfvars)
   performs the opposite operation: parsing `.tfvars` content to obtain
   the variable values declared inside.
-* [`exprencode`](/terraform/language/functions/terraform-exprdecode)
+* [`encode_expr`](/terraform/language/functions/terraform-encode_expr)
   encodes a single value as a plain expression, without the `.tfvars`
   container around it.


### PR DESCRIPTION
When we added these functions we hadn't yet settled on a single convention for how provider-contributed functions ought to be named, and so these followed the convention previously used for Terraform's own built-in functions.

We've now decided to use the new provider namespace as an opportunity to partially fix the historical design error of naming functions as all lowercase without any separation between words. [The documented convention for providers is underscore-separated words](https://developer.hashicorp.com/terraform/plugin/best-practices/naming#function-names). This makes the provider functions inconsistent with the built-in functions, but should at least hopefully encourage the provider functions to be consistent with one another, so that the rule for which to use is relatively easy to remember.

This also switches the word order because the provider functions convention prefers the verb to come first: `encode_tfvars` instead of `tfvarsencode`, similar to the documentation's example `parse_rfc3339` instead of `rfc3339parse`.

---

I've requested v1.8 backport because we want to correct this inconsistency before the v1.8 release so that the old spellings won't become subject to the Terraform v1.x Compatibility Promises.
