### PR TITLE
workflows/checks: Run tests for all modules in this repository

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -60,7 +60,10 @@ jobs:
 
       - name: "Unit tests"
         run: |
-          go test ./...
+          # We run tests for all packages from all modules in this repository.
+          for dir in $(go list -m -f '{{.Dir}}' github.com/hashicorp/terraform/...); do
+              (cd $dir && go test "./...")
+          done
 
   race-tests:
     name: "Race Tests"


### PR DESCRIPTION
A few of the packages in this repository are separated into their own Go modules to reflect boundaries of code ownership and/or boundaries with significantly different external Go module dependencies.

However, that means that the `./...` pattern in a Go command run at the root doesn't include those packages. The tests in the remote backends are mostly disabled in our unit test context because they require credentials for external network services, but nonetheless it's still useful to visit them and check if their packages can even compile.

Therefore we'll now visit each of the modules and run tests for all packages in each one. This restores the coverage we had before the module split, with the only slight difference being that the remote backend tests now run only after all of the main Terraform tests, rather than being interleaved with Terraform's own packages as before. Since we're only visiting them to see if they compile anyway, this doesn't seem like a big deal.
