### PR TITLE
CODEOWNERS: Make it valid, and exclude go.sum updates

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -12,7 +12,7 @@
 /internal/backend/remote-state/azure             @hashicorp/terraform-azure
 #/internal/backend/remote-state/consul           Unmaintained
 #/internal/backend/remote-state/cos              @likexian
-/internal/backend/remote-state/gcs               @hashicorp/terraform-google @hashicorp/terraform-ecosystem-strategic
+/internal/backend/remote-state/gcs               @hashicorp/terraform-google
 /internal/backend/remote-state/http              @hashicorp/terraform-core
 #/internal/backend/remote-state/oss              @xiaozhu36
 #/internal/backend/remote-state/pg               @remilapeyre

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -17,7 +17,7 @@
 #/internal/backend/remote-state/oss              @xiaozhu36
 #/internal/backend/remote-state/pg               @remilapeyre
 /internal/backend/remote-state/s3                @hashicorp/terraform-aws
-/internal/backend/remote-state/kubernetes        @jrhouston @alexsomesan
+/internal/backend/remote-state/kubernetes        @hashicorp/tf-eco-hybrid-cloud
 
 # Provisioners
 builtin/provisioners/file               @hashicorp/terraform-core

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -12,7 +12,7 @@
 /internal/backend/remote-state/azure             @hashicorp/terraform-azure
 #/internal/backend/remote-state/consul           Unmaintained
 #/internal/backend/remote-state/cos              @likexian
-/internal/backend/remote-state/gcs               @hashicorp/terraform-google
+/internal/backend/remote-state/gcs               @hashicorp/tf-eco-hybrid-cloud
 /internal/backend/remote-state/http              @hashicorp/terraform-core
 #/internal/backend/remote-state/oss              @xiaozhu36
 #/internal/backend/remote-state/pg               @remilapeyre

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,26 +2,17 @@
 # More on CODEOWNERS files: https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners
 
 # Remote-state backend                  # Maintainer
-/internal/backend/remote-state/artifactory       Unmaintained
 /internal/backend/remote-state/azure             @hashicorp/terraform-azure
 /internal/backend/remote-state/consul            Unmaintained
 /internal/backend/remote-state/cos               @likexian
-/internal/backend/remote-state/etcdv2            Unmaintained
-/internal/backend/remote-state/etcdv3            Unmaintained
 /internal/backend/remote-state/gcs               @hashicorp/terraform-google @hashicorp/terraform-ecosystem-strategic
 /internal/backend/remote-state/http              @hashicorp/terraform-core
-/internal/backend/remote-state/manta             Unmaintained
 /internal/backend/remote-state/oss               @xiaozhu36
 /internal/backend/remote-state/pg                @remilapeyre
 /internal/backend/remote-state/s3                @hashicorp/terraform-aws
-/internal/backend/remote-state/swift             Unmaintained
 /internal/backend/remote-state/kubernetes        @jrhouston @alexsomesan
 
 # Provisioners
-builtin/provisioners/chef               Deprecated
 builtin/provisioners/file               @hashicorp/terraform-core
-builtin/provisioners/habitat            Deprecated
 builtin/provisioners/local-exec         @hashicorp/terraform-core
-builtin/provisioners/puppet             Deprecated
 builtin/provisioners/remote-exec        @hashicorp/terraform-core
-builtin/provisioners/salt-masterless    Deprecated

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,14 +1,21 @@
 # Each line is a file pattern followed by one or more owners.
 # More on CODEOWNERS files: https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners
 
+# Entries that are commented out have maintainers that are not in the
+# HashiCorp organization and so cannot be automatically added as reviewers.
+#
+# We retain those as documentation of who agreed to maintain, but they
+# cannot be used automatically by GitHub's pull request workflow and would
+# make GitHub consider this file invalid if not commented.
+
 # Remote-state backend                  # Maintainer
 /internal/backend/remote-state/azure             @hashicorp/terraform-azure
-/internal/backend/remote-state/consul            Unmaintained
-/internal/backend/remote-state/cos               @likexian
+#/internal/backend/remote-state/consul           Unmaintained
+#/internal/backend/remote-state/cos              @likexian
 /internal/backend/remote-state/gcs               @hashicorp/terraform-google @hashicorp/terraform-ecosystem-strategic
 /internal/backend/remote-state/http              @hashicorp/terraform-core
-/internal/backend/remote-state/oss               @xiaozhu36
-/internal/backend/remote-state/pg                @remilapeyre
+#/internal/backend/remote-state/oss              @xiaozhu36
+#/internal/backend/remote-state/pg               @remilapeyre
 /internal/backend/remote-state/s3                @hashicorp/terraform-aws
 /internal/backend/remote-state/kubernetes        @jrhouston @alexsomesan
 

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -23,3 +23,13 @@
 builtin/provisioners/file               @hashicorp/terraform-core
 builtin/provisioners/local-exec         @hashicorp/terraform-core
 builtin/provisioners/remote-exec        @hashicorp/terraform-core
+
+# go.sum files should never cause automatic review requests because they only
+# ever change in response to go.mod files (our PR checks would fail if not) and
+# if a specific module has _only_ a go.sum update without an associated go.mod
+# update then that represents that the update cannot affect the module, and
+# the Go toolchain just needed to download something new to prove that.
+#
+# (The last match in the file "wins", so this overrides any explicit owner
+# specified above when go.sum is the only file that changed.)
+*/go.sum   # no owner for these


### PR DESCRIPTION
We were using the CODEOWNERS file prior to GitHub having special support for it just as human documentation. GitHub has since claimed this file format as belonging to them, and declared our use of it invalid.

This PR therefore:
- Clears out some obsolete entries that refer to directories we already deleted long ago.
- Uses commented-out entries to retain the information that's useful to humans but not to GitHub, because some of our code owners are not HashiCorp employees and so cannot be requested as PR reviewers in this repository.
- Removes an obsolete HashiCorp team `hashicorp/terraform-ecosystem-strategic`, since ~it doesn't exist anymore and so cannot be requested as a reviewer.~

    On further investigation I see that it _does_ exist as a team but that the team doesn't have any access to this repository, and so _that's_ why it cannot be requested as a reviewer. I've seen some earlier discussion that we ended up with both of these because at the time the `terraform-google` team was defunct and unused, but that doesn't seem to be true any more because it has members and one of those members has been responding to review requests on behalf of that team in the last few days. I think the removal of this unusable team therefore still makes sense, even if the reason for doing so is now different.

After these updates, GitHub considers the file to be valid. We are therefore more likely to notice if we accidentally make it invalid again in the future.

---

I've also learned in my dependency-updating adventures in the last few weeks that the Go toolchain likes to update `go.sum` to record checksums for modules that were needed in the dependency resolution process but not actually included in the built program. When the _only_ update is to `go.sum`, that creates unnecessary notification noise for the relevant teams, since we've already proven that that the modules mentioned do not contribute to the manifest's own module at runtime.

To try to mitigate that, I've added a rule at the end that declares that `go.sum` files under any prefix have no maintainer, which (according to the CODEOWNERS format documentation) should supersede all of the other entries so that a reviewer will be auto-added only if there's at least one file _other than `go.sum`_ that was updated as part of a changeset. I've not actually confirmed that this particular detail works yet, but I have a few other dependency upgrade PRs on the way that will help me to test this, and if I find that it isn't working correctly then I'll iterate more in future PRs.
