### PR TITLE
docs(tests): add some info about how the states are managed in memory

### DIFF
--- a/website/docs/language/tests/index.mdx
+++ b/website/docs/language/tests/index.mdx
@@ -574,7 +574,7 @@ run "verify" {
 
 ### Modules state
 
-While Terraform executes a `terraform test` command, Terraform maintains at least one, but possibly many, state files within memory for each test file.
+While Terraform executes a `terraform test` command, Terraform maintains at least one, but possibly many, state files within memory for each test file. As the state fil are stored in memory, for now, there is no way to store or expose any state created by a test file.
 
 There is always at least one state file that maintains the state of the main configuration under test. This state file is shared by all `run` blocks that do not have a `module` block specifying an alternate module to load.
 

--- a/website/docs/language/tests/index.mdx
+++ b/website/docs/language/tests/index.mdx
@@ -574,7 +574,7 @@ run "verify" {
 
 ### Modules state
 
-While Terraform executes a `terraform test` command, Terraform maintains at least one, but possibly many, state files within memory for each test file. As the state fil are stored in memory, for now, there is no way to store or expose any state created by a test file.
+While Terraform executes a `terraform test` command, Terraform maintains at least one, but possibly many, state files within memory for each test file. As the states files are stored in memory, for now, there is no way to store or expose any state created by a test file.
 
 There is always at least one state file that maintains the state of the main configuration under test. This state file is shared by all `run` blocks that do not have a `module` block specifying an alternate module to load.
 


### PR DESCRIPTION
# Context

<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

Adding information about the fact that the states created by the tests files are not accessible for the users. It gives more meaning to the "managed internally" that can be ambiguous.

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Fixes : https://github.com/hashicorp/terraform/issues/34668

Relates to : https://github.com/hashicorp/terraform/issues/33786

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

Next minor or patch release.

## Draft CHANGELOG entry

### ENHANCEMENTS

- docs(tests): add some info about how the states are managed in memory by the tests files