### PR TITLE
Fix leakage of sensitive variables on HCL syntax error in variable declaration

### DIFF
--- a/internal/command/apply_test.go
+++ b/internal/command/apply_test.go
@@ -695,6 +695,49 @@ func TestApply_plan(t *testing.T) {
 	}
 }
 
+// Test that sensitive variables are redacted in diagnostic output.
+func TestApply_varsSensitive(t *testing.T) {
+	// Create a temporary working directory that is empty
+	td := t.TempDir()
+	testCopyDir(t, testFixturePath("apply-sensitive"), td)
+	defer testChdir(t, td)()
+
+	p := planVarsFixtureProvider()
+	view, done := testView(t)
+	c := &ApplyCommand{
+		Meta: Meta{
+			testingOverrides: metaOverridesForProvider(p),
+			View:             view,
+		},
+	}
+
+	args := []string{
+		"-var-file", "sensitiveVar.tfvars",
+	}
+	code := c.Run(args)
+	output := done(t)
+
+	if code != 1 {
+		t.Errorf("expected status code 1 but got %d", code)
+	}
+
+	expected := `[31m╷[0m[0m
+[31m│[0m [0m[1m[31mError: [0m[0m[1mMissing key/value separator[0m
+[31m│[0m [0m
+[31m│[0m [0m[0m  on sensitiveVar.tfvars line 3:
+[31m│[0m [0m   (SENSITIVE)
+[31m│[0m [0m
+[31m│[0m [0mExpected an equals sign ("=") to mark the beginning of the attribute value.
+[31m╵[0m[0m
+`
+
+	actual := output.All()
+
+	if diff := cmp.Diff(actual, expected); len(diff) > 0 {
+		t.Errorf("output didn't match expected:\nexpected:\n%s\nactual:\n%s\ndiff:\n%s", expected, actual, diff)
+	}
+}
+
 func TestApply_plan_backup(t *testing.T) {
 	statePath := testTempFile(t)
 	backupPath := testTempFile(t)

--- a/internal/command/apply_test.go
+++ b/internal/command/apply_test.go
@@ -725,7 +725,7 @@ func TestApply_varsSensitive(t *testing.T) {
 [31m│[0m [0m[1m[31mError: [0m[0m[1mMissing key/value separator[0m
 [31m│[0m [0m
 [31m│[0m [0m[0m  on sensitiveVar.tfvars line 3:
-[31m│[0m [0m   (SENSITIVE)
+[31m│[0m [0m   1: (SENSITIVE)[4m[0m[0m
 [31m│[0m [0m
 [31m│[0m [0mExpected an equals sign ("=") to mark the beginning of the attribute value.
 [31m╵[0m[0m

--- a/internal/command/meta_vars.go
+++ b/internal/command/meta_vars.go
@@ -273,7 +273,7 @@ func (m *Meta) addVarsFromFile(filename string, sourceType terraform.ValueSource
 								"file":      attr.NameRange.Filename,
 								"sensitive": fmt.Sprintf("%t", sens.True()),
 							}
-							// TODO: Break loop here? Ensure non-sensitive labeled false
+							// TODO: Break loop here?
 						}
 					}
 				}

--- a/internal/command/plan_test.go
+++ b/internal/command/plan_test.go
@@ -764,7 +764,7 @@ func TestPlan_varsSensitive(t *testing.T) {
 [31m│[0m [0m[1m[31mError: [0m[0m[1mMissing key/value separator[0m
 [31m│[0m [0m
 [31m│[0m [0m[0m  on sensitiveVar.tfvars line 3:
-[31m│[0m [0m   (SENSITIVE)
+[31m│[0m [0m   1: (SENSITIVE)[4m[0m[0m
 [31m│[0m [0m
 [31m│[0m [0mExpected an equals sign ("=") to mark the beginning of the attribute value.
 [31m╵[0m[0m

--- a/internal/command/testdata/apply-sensitive/main.tf
+++ b/internal/command/testdata/apply-sensitive/main.tf
@@ -1,0 +1,4 @@
+variable secretConfig {
+  type = map(any)
+  sensitive = true
+}

--- a/internal/command/testdata/apply-sensitive/sensitiveVar.tfvars
+++ b/internal/command/testdata/apply-sensitive/sensitiveVar.tfvars
@@ -1,0 +1,3 @@
+secretConfig = { "something" = "extremely confidential",
+		"key" = "val",
+		"oops" }

--- a/internal/command/testdata/plan-sensitive/main.tf
+++ b/internal/command/testdata/plan-sensitive/main.tf
@@ -1,0 +1,4 @@
+variable secretConfig {
+  type = map(any)
+  sensitive = true
+}

--- a/internal/command/testdata/plan-sensitive/sensitiveVar.tfvars
+++ b/internal/command/testdata/plan-sensitive/sensitiveVar.tfvars
@@ -1,0 +1,3 @@
+secretConfig = { "something" = "extremely confidential",
+		"key" = "val",
+		"oops" }

--- a/internal/command/views/json/diagnostic.go
+++ b/internal/command/views/json/diagnostic.go
@@ -236,7 +236,13 @@ func NewDiagnostic(diag tfdiags.Diagnostic, sources map[string][]byte) *Diagnost
 					code.WriteRune('\n')
 				}
 			}
+
 			codeStr := strings.TrimSuffix(code.String(), "\n")
+			// FIXME: Add error handing in case map conversion fails, or key doesn't exist.
+			info := diag.ExtraInfo().(map[string]string)
+			if info["sensitive"] == "true" {
+				codeStr = "(SENSITIVE)"
+			}
 			diagnostic.Snippet.Code = codeStr
 
 			// Calculate the start and end byte of the highlight range relative

--- a/internal/command/views/json/diagnostic.go
+++ b/internal/command/views/json/diagnostic.go
@@ -239,8 +239,7 @@ func NewDiagnostic(diag tfdiags.Diagnostic, sources map[string][]byte) *Diagnost
 
 			codeStr := strings.TrimSuffix(code.String(), "\n")
 			// FIXME: Add error handing in case map conversion fails, or key doesn't exist.
-			info := diag.ExtraInfo().(map[string]string)
-			if info["sensitive"] == "true" {
+			if info, ok := diag.ExtraInfo().(map[string]string); ok && info["sensitive"] == "true" {
 				codeStr = "(SENSITIVE)"
 			}
 			diagnostic.Snippet.Code = codeStr

--- a/internal/command/views/json/diagnostic.go
+++ b/internal/command/views/json/diagnostic.go
@@ -239,6 +239,7 @@ func NewDiagnostic(diag tfdiags.Diagnostic, sources map[string][]byte) *Diagnost
 
 			codeStr := strings.TrimSuffix(code.String(), "\n")
 			// FIXME: Add error handing in case map conversion fails, or key doesn't exist.
+			// FIXME: Currently map conversion error falls through to regular error printing
 			if info, ok := diag.ExtraInfo().(map[string]string); ok && info["sensitive"] == "true" {
 				codeStr = "(SENSITIVE)"
 			}


### PR DESCRIPTION
# Issue

If a .tfvar file contains a syntax error the details are printed regardless of potential sensitivity label.
This occurs when running terraform apply and/or plan.

# Solution

Parse the loaded .tf files, for each variable look up the sensitivity label and create a variable-sensitivity map.
The diagnostics for the error caused by erronous syntax contains a context telling us which part of the .tfvar file the error belongs to, use this context to map the error to the appropriate variable.
Use the variable name to check sensitivity status from the map we built, and add sensitivity info to the diags ExtraInfo property.

In the diagnostics section, before printing, check the ExtraInfo section for a sensitivity label, if present, redact the sensitive information.

## Before

```bash
$ ./terraform plan
╷
│ Error: Missing key/value separator
│
│   on terraform.tfvars line 3:
│    1: secretConfig = { "something" = "extremely confidential",
│    2:                 "key" = "val",
│    3:                 "oops" }
│
│ Expected an equals sign ("=") to mark the beginning of the attribute value.
╵
```

## After

```bash
$ ./terraformPatched plan
╷
│ Error: Missing key/value separator
│
│   on terraform.tfvars line 3:
│    1: (SENSITIVE)
│
│ Expected an equals sign ("=") to mark the beginning of the attribute value.
╵
```

Fixes #31946 


### BUG FIXES

- `terraform plan`: Fixed leakage of sensitive values caused by HCL syntax error in .tfvar file.
- `terraform plan`: Fixed leakage of sensitive values caused by HCL syntax error in .tfvar file.
