### PR TITLE
Update custom conditions doc: root_block_device requires an index

### DIFF
--- a/website/docs/language/expressions/custom-conditions.mdx
+++ b/website/docs/language/expressions/custom-conditions.mdx
@@ -163,7 +163,7 @@ data "aws_ebs_volume" "example" {
 
   filter {
     name = "volume-id"
-    values = [aws_instance.example.root_block_device.volume_id]
+    values = [aws_instance.example.root_block_device[0].volume_id]
   }
 
   # Whenever a data resource is verifying the result of a managed resource


### PR DESCRIPTION
It was pointed out that the example in the Custom Conditions docs that shows how to use a data source to validate conditions on resources, `root_block_device` is exposed as a list containing an object, so you must include an index when referencing it.

Running the example as-is fails validation with the below error:

```
│ Error: Invalid operation
│
│   on main.tf line 35, in data "aws_ebs_volume" "example":
│   35:     values = [aws_instance.example.root_block_device.volume_id]
│
│ Block type "root_block_device" is represented by a list of objects, so it must be indexed using a numeric key, like
│ .root_block_device[0].
```