### PR TITLE
Interpolate environment variables when configuring dev_overrides

### DIFF
--- a/internal/command/cliconfig/provider_installation.go
+++ b/internal/command/cliconfig/provider_installation.go
@@ -5,6 +5,7 @@ package cliconfig
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 
 	"github.com/hashicorp/hcl"
@@ -253,7 +254,8 @@ func decodeProviderInstallationFromConfig(hclFile *hclast.File) ([]*ProviderInst
 						))
 						continue
 					}
-					dirPath := filepath.Clean(rawPath)
+					interpolatedPath := os.ExpandEnv(rawPath)
+					dirPath := filepath.Clean(interpolatedPath)
 					devOverrides[addr] = getproviders.PackageLocalDir(dirPath)
 				}
 

--- a/internal/command/cliconfig/provider_installation.go
+++ b/internal/command/cliconfig/provider_installation.go
@@ -254,15 +254,19 @@ func decodeProviderInstallationFromConfig(hclFile *hclast.File) ([]*ProviderInst
 						))
 						continue
 					}
+					unsetEnvVars := make(map[string]bool)
 					interpolatedPath := os.Expand(rawPath, func(envVarName string) string {
 						if value, ok := os.LookupEnv(envVarName); ok {
 							return value
 						} else {
-							diags = diags.Append(tfdiags.Sourceless(
-								tfdiags.Error,
-								"Interpolated environment variable not set",
-								fmt.Sprintf("The environment variable %s is not set or empty and can result in undesired behavior", envVarName),
-							))
+							if _, reported := unsetEnvVars[envVarName]; !reported {
+								diags = diags.Append(tfdiags.Sourceless(
+									tfdiags.Error,
+									"Interpolated environment variable not set",
+									fmt.Sprintf("The environment variable %s is not set or empty and can result in undesired behavior", envVarName),
+								))
+								unsetEnvVars[envVarName] = true
+							}
 							return ""
 						}
 					})


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

This pull request adds environment variable interpolation to the `dev_overrides` configuration block, specifically for the local filesystem path being mapped to the provider source address.

## Example
Before the proposed change:
```hcl
provider_installation {
  dev_overrides {
    "craigsloggett/github" = "/Users/craig.sloggett/.cache/go/bin"
  }

  direct {}
}
```
After the proposed change:
```hcl
provider_installation {
  dev_overrides {
    "craigsloggett/github" = "${GOPATH}/bin"
  }

  direct {}
}
```

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Fixes #28602

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.8.x

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

### ENHANCEMENTS

<!--

Write a short description of the user-facing change. Examples:

- `terraform show -json`: Fixed crash with sensitive set values.
- When rendering a diff, Terraform now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 

-  Maintaining a `terraform.rc` file that's portable across systems, platforms, or users.
