### PR TITLE
Correct S3 backend DynamoDB permissions

### DIFF
--- a/website/docs/language/settings/backends/s3.mdx
+++ b/website/docs/language/settings/backends/s3.mdx
@@ -91,7 +91,6 @@ documentation about
 If you are using state locking, Terraform will need the following AWS IAM
 permissions on the DynamoDB table (`arn:aws:dynamodb:::table/mytable`):
 
-* `dynamodb:DescribeTable`
 * `dynamodb:GetItem`
 * `dynamodb:PutItem`
 * `dynamodb:DeleteItem`
@@ -105,7 +104,6 @@ This is seen in the following AWS IAM Statement:
     {
       "Effect": "Allow",
       "Action": [
-        "dynamodb:DescribeTable",
         "dynamodb:GetItem",
         "dynamodb:PutItem",
         "dynamodb:DeleteItem"


### PR DESCRIPTION
This reverts commit 0900b787f81f1ab60444677c5f700cff256bf0b9 as introduced in #31792.

This commit was made in error. The permissions were correct as they were.

`DescribeTable` is not called from any of the S3 backend code.

`init`, `plan`, and `workspace list` all work without the `DescribeTable` permission.