### PR TITLE
stacks: handle deferred actions in refresh

### DIFF
--- a/internal/plans/deferring.go
+++ b/internal/plans/deferring.go
@@ -3,41 +3,16 @@
 
 package plans
 
-import "github.com/zclconf/go-cty/cty"
-
-type DeferredReason string
-
-const (
-	// DeferredReasonInvalid is used when the reason for deferring is
-	// unknown or irrelevant.
-	DeferredReasonInvalid DeferredReason = "invalid"
-
-	// DeferredReasonInstanceCountUnknown is used when the reason for deferring
-	// is that the count or for_each meta-attribute was unknown.
-	DeferredReasonInstanceCountUnknown DeferredReason = "instance_count_unknown"
-
-	// DeferredReasonResourceConfigUnknown is used when the reason for deferring
-	// is that the resource configuration was unknown.
-	DeferredReasonResourceConfigUnknown DeferredReason = "resource_config_unknown"
-
-	// DeferredReasonProviderConfigUnknown is used when the reason for deferring
-	// is that the provider configuration was unknown.
-	DeferredReasonProviderConfigUnknown DeferredReason = "provider_config_unknown"
-
-	// DeferredReasonAbsentPrereq is used when the reason for deferring is that
-	// a required prerequisite resource was absent.
-	DeferredReasonAbsentPrereq DeferredReason = "absent_prereq"
-
-	// DeferredReasonDeferredPrereq is used when the reason for deferring is
-	// that a required prerequisite resource was itself deferred.
-	DeferredReasonDeferredPrereq DeferredReason = "deferred_prereq"
+import (
+	"github.com/hashicorp/terraform/internal/providers"
+	"github.com/zclconf/go-cty/cty"
 )
 
 // DeferredResourceInstanceChangeSrc tracks information about a resource that
 // has been deferred for some reason.
 type DeferredResourceInstanceChangeSrc struct {
 	// DeferredReason is the reason why this resource instance was deferred.
-	DeferredReason DeferredReason
+	DeferredReason providers.DeferredReason
 
 	// ChangeSrc contains any information we have about the deferred change.
 	// This could be incomplete so must be parsed with care.
@@ -60,7 +35,7 @@ func (rcs *DeferredResourceInstanceChangeSrc) Decode(ty cty.Type) (*DeferredReso
 // has been deferred for some reason.
 type DeferredResourceInstanceChange struct {
 	// DeferredReason is the reason why this resource instance was deferred.
-	DeferredReason DeferredReason
+	DeferredReason providers.DeferredReason
 
 	// Change contains any information we have about the deferred change. This
 	// could be incomplete so must be parsed with care.

--- a/internal/plans/deferring/deferred.go
+++ b/internal/plans/deferring/deferred.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/plans"
+	"github.com/hashicorp/terraform/internal/providers"
 )
 
 // Deferred keeps track of deferrals that have already happened, to help
@@ -313,7 +314,7 @@ func (d *Deferred) ReportResourceExpansionDeferred(addr addrs.PartialExpandedRes
 		panic(fmt.Sprintf("duplicate deferral report for %s", addr))
 	}
 	configMap.Put(addr, &plans.DeferredResourceInstanceChange{
-		DeferredReason: plans.DeferredReasonInstanceCountUnknown,
+		DeferredReason: providers.DeferredReasonInstanceCountUnknown,
 		Change:         change,
 	})
 }
@@ -348,7 +349,7 @@ func (d *Deferred) ReportDataSourceExpansionDeferred(addr addrs.PartialExpandedR
 // ReportResourceInstanceDeferred records that a fully-expanded resource
 // instance has had its planned action deferred to a future round for a reason
 // other than its address being only partially-decided.
-func (d *Deferred) ReportResourceInstanceDeferred(addr addrs.AbsResourceInstance, reason plans.DeferredReason, change *plans.ResourceInstanceChange) {
+func (d *Deferred) ReportResourceInstanceDeferred(addr addrs.AbsResourceInstance, reason providers.DeferredReason, change *plans.ResourceInstanceChange) {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 

--- a/internal/plans/deferring/deferred_test.go
+++ b/internal/plans/deferring/deferred_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/plans"
+	"github.com/hashicorp/terraform/internal/providers"
 )
 
 func TestDeferred_externalDependency(t *testing.T) {
@@ -90,7 +91,7 @@ func TestDeferred_absResourceInstanceDeferred(t *testing.T) {
 	})
 
 	// Instance A has its Create action deferred for some reason.
-	deferred.ReportResourceInstanceDeferred(instAAddr, plans.DeferredReasonResourceConfigUnknown, &plans.ResourceInstanceChange{
+	deferred.ReportResourceInstanceDeferred(instAAddr, providers.DeferredReasonResourceConfigUnknown, &plans.ResourceInstanceChange{
 		Addr: instAAddr,
 		Change: plans.Change{
 			Action: plans.Create,

--- a/internal/plans/planfile/tfplan.go
+++ b/internal/plans/planfile/tfplan.go
@@ -464,20 +464,20 @@ func deferredChangeFromTfplan(dc *planproto.DeferredResourceInstanceChange) (*pl
 	}, nil
 }
 
-func deferredReasonFromProto(reason planproto.DeferredReason) (plans.DeferredReason, error) {
+func deferredReasonFromProto(reason planproto.DeferredReason) (providers.DeferredReason, error) {
 	switch reason {
 	case planproto.DeferredReason_INSTANCE_COUNT_UNKNOWN:
-		return plans.DeferredReasonInstanceCountUnknown, nil
+		return providers.DeferredReasonInstanceCountUnknown, nil
 	case planproto.DeferredReason_RESOURCE_CONFIG_UNKNOWN:
-		return plans.DeferredReasonResourceConfigUnknown, nil
+		return providers.DeferredReasonResourceConfigUnknown, nil
 	case planproto.DeferredReason_PROVIDER_CONFIG_UNKNOWN:
-		return plans.DeferredReasonProviderConfigUnknown, nil
+		return providers.DeferredReasonProviderConfigUnknown, nil
 	case planproto.DeferredReason_ABSENT_PREREQ:
-		return plans.DeferredReasonAbsentPrereq, nil
+		return providers.DeferredReasonAbsentPrereq, nil
 	case planproto.DeferredReason_DEFERRED_PREREQ:
-		return plans.DeferredReasonDeferredPrereq, nil
+		return providers.DeferredReasonDeferredPrereq, nil
 	default:
-		return plans.DeferredReasonInvalid, fmt.Errorf("invalid deferred reason %s", reason)
+		return providers.DeferredReasonInvalid, fmt.Errorf("invalid deferred reason %s", reason)
 	}
 }
 
@@ -931,17 +931,17 @@ func deferredChangeToTfplan(dc *plans.DeferredResourceInstanceChangeSrc) (*planp
 	}, nil
 }
 
-func deferredReasonToProto(reason plans.DeferredReason) (planproto.DeferredReason, error) {
+func deferredReasonToProto(reason providers.DeferredReason) (planproto.DeferredReason, error) {
 	switch reason {
-	case plans.DeferredReasonInstanceCountUnknown:
+	case providers.DeferredReasonInstanceCountUnknown:
 		return planproto.DeferredReason_INSTANCE_COUNT_UNKNOWN, nil
-	case plans.DeferredReasonResourceConfigUnknown:
+	case providers.DeferredReasonResourceConfigUnknown:
 		return planproto.DeferredReason_RESOURCE_CONFIG_UNKNOWN, nil
-	case plans.DeferredReasonProviderConfigUnknown:
+	case providers.DeferredReasonProviderConfigUnknown:
 		return planproto.DeferredReason_PROVIDER_CONFIG_UNKNOWN, nil
-	case plans.DeferredReasonAbsentPrereq:
+	case providers.DeferredReasonAbsentPrereq:
 		return planproto.DeferredReason_ABSENT_PREREQ, nil
-	case plans.DeferredReasonDeferredPrereq:
+	case providers.DeferredReasonDeferredPrereq:
 		return planproto.DeferredReason_DEFERRED_PREREQ, nil
 	default:
 		return planproto.DeferredReason_INVALID, fmt.Errorf("invalid deferred reason %s", reason)

--- a/internal/plans/planfile/tfplan_test.go
+++ b/internal/plans/planfile/tfplan_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/terraform/internal/lang/globalref"
 	"github.com/hashicorp/terraform/internal/lang/marks"
 	"github.com/hashicorp/terraform/internal/plans"
+	"github.com/hashicorp/terraform/internal/providers"
 	"github.com/hashicorp/terraform/internal/states"
 )
 
@@ -195,7 +196,7 @@ func TestTFPlanRoundTrip(t *testing.T) {
 		},
 		DeferredResources: []*plans.DeferredResourceInstanceChangeSrc{
 			{
-				DeferredReason: plans.DeferredReasonInstanceCountUnknown,
+				DeferredReason: providers.DeferredReasonInstanceCountUnknown,
 				ChangeSrc: &plans.ResourceInstanceChangeSrc{
 					Addr: addrs.Resource{
 						Mode: addrs.ManagedResourceMode,

--- a/internal/plugin/convert/deferred.go
+++ b/internal/plugin/convert/deferred.go
@@ -1,0 +1,34 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package convert
+
+import (
+	"github.com/hashicorp/terraform/internal/providers"
+	proto "github.com/hashicorp/terraform/internal/tfplugin5"
+)
+
+// ProtoToDeferred translates a proto.Deferred to a providers.Deferred.
+func ProtoToDeferred(d *proto.Deferred) *providers.Deferred {
+	if d == nil {
+		return nil
+	}
+
+	var reason providers.DeferredReason
+	switch d.Reason {
+	case proto.Deferred_UNKNOWN:
+		reason = providers.DeferredReasonInvalid
+	case proto.Deferred_RESOURCE_CONFIG_UNKNOWN:
+		reason = providers.DeferredReasonResourceConfigUnknown
+	case proto.Deferred_PROVIDER_CONFIG_UNKNOWN:
+		reason = providers.DeferredReasonProviderConfigUnknown
+	case proto.Deferred_ABSENT_PREREQ:
+		reason = providers.DeferredReasonAbsentPrereq
+	default:
+		reason = providers.DeferredReasonInvalid
+	}
+
+	return &providers.Deferred{
+		Reason: reason,
+	}
+}

--- a/internal/plugin/convert/deferred_test.go
+++ b/internal/plugin/convert/deferred_test.go
@@ -42,7 +42,7 @@ func TestProtoDeferred(t *testing.T) {
 
 			deferred := ProtoToDeferred(d)
 			if deferred.Reason != tc.expected {
-				t.Fatalf("expected %d, got %d", tc.expected, deferred.Reason)
+				t.Fatalf("expected %q, got %q", tc.expected, deferred.Reason)
 			}
 		})
 	}

--- a/internal/plugin/convert/deferred_test.go
+++ b/internal/plugin/convert/deferred_test.go
@@ -1,0 +1,56 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package convert
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/internal/providers"
+	proto "github.com/hashicorp/terraform/internal/tfplugin5"
+)
+
+func TestProtoDeferred(t *testing.T) {
+	testCases := []struct {
+		reason   proto.Deferred_Reason
+		expected providers.DeferredReason
+	}{
+		{
+			reason:   proto.Deferred_UNKNOWN,
+			expected: providers.DeferredReasonInvalid,
+		},
+		{
+			reason:   proto.Deferred_RESOURCE_CONFIG_UNKNOWN,
+			expected: providers.DeferredReasonResourceConfigUnknown,
+		},
+		{
+			reason:   proto.Deferred_PROVIDER_CONFIG_UNKNOWN,
+			expected: providers.DeferredReasonProviderConfigUnknown,
+		},
+		{
+			reason:   proto.Deferred_ABSENT_PREREQ,
+			expected: providers.DeferredReasonAbsentPrereq,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(fmt.Sprintf("deferred reason %q", tc.reason.String()), func(t *testing.T) {
+			d := &proto.Deferred{
+				Reason: tc.reason,
+			}
+
+			deferred := ProtoToDeferred(d)
+			if deferred.Reason != tc.expected {
+				t.Fatalf("expected %d, got %d", tc.expected, deferred.Reason)
+			}
+		})
+	}
+}
+
+func TestProtoDeferred_Nil(t *testing.T) {
+	deferred := ProtoToDeferred(nil)
+	if deferred != nil {
+		t.Fatalf("expected nil, got %v", deferred)
+	}
+}

--- a/internal/plugin/grpc_provider.go
+++ b/internal/plugin/grpc_provider.go
@@ -399,9 +399,10 @@ func (p *GRPCProvider) ReadResource(r providers.ReadResourceRequest) (resp provi
 	}
 
 	protoReq := &proto.ReadResource_Request{
-		TypeName:     r.TypeName,
-		CurrentState: &proto.DynamicValue{Msgpack: mp},
-		Private:      r.Private,
+		TypeName:        r.TypeName,
+		CurrentState:    &proto.DynamicValue{Msgpack: mp},
+		Private:         r.Private,
+		DeferralAllowed: r.DeferralAllowed,
 	}
 
 	if metaSchema.Block != nil {
@@ -418,6 +419,7 @@ func (p *GRPCProvider) ReadResource(r providers.ReadResourceRequest) (resp provi
 		resp.Diagnostics = resp.Diagnostics.Append(grpcErr(err))
 		return resp
 	}
+	resp.Deferred = convert.ProtoToDeferred(protoResp.Deferred)
 	resp.Diagnostics = resp.Diagnostics.Append(convert.ProtoToDiagnostics(protoResp.Diagnostics))
 
 	state, err := decodeDynamicValue(protoResp.NewState, resSchema.Block.ImpliedType())

--- a/internal/plugin6/convert/deferred.go
+++ b/internal/plugin6/convert/deferred.go
@@ -1,0 +1,34 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package convert
+
+import (
+	"github.com/hashicorp/terraform/internal/providers"
+	proto "github.com/hashicorp/terraform/internal/tfplugin6"
+)
+
+// ProtoToDeferred translates a proto.Deferred to a providers.Deferred.
+func ProtoToDeferred(d *proto.Deferred) *providers.Deferred {
+	if d == nil {
+		return nil
+	}
+
+	var reason providers.DeferredReason
+	switch d.Reason {
+	case proto.Deferred_UNKNOWN:
+		reason = providers.DeferredReasonInvalid
+	case proto.Deferred_RESOURCE_CONFIG_UNKNOWN:
+		reason = providers.DeferredReasonResourceConfigUnknown
+	case proto.Deferred_PROVIDER_CONFIG_UNKNOWN:
+		reason = providers.DeferredReasonProviderConfigUnknown
+	case proto.Deferred_ABSENT_PREREQ:
+		reason = providers.DeferredReasonAbsentPrereq
+	default:
+		reason = providers.DeferredReasonInvalid
+	}
+
+	return &providers.Deferred{
+		Reason: reason,
+	}
+}

--- a/internal/plugin6/convert/deferred_test.go
+++ b/internal/plugin6/convert/deferred_test.go
@@ -42,7 +42,7 @@ func TestProtoDeferred(t *testing.T) {
 
 			deferred := ProtoToDeferred(d)
 			if deferred.Reason != providers.DeferredReason(tc.expected) {
-				t.Fatalf("expected %d, got %d", tc.expected, deferred.Reason)
+				t.Fatalf("expected %q, got %q", tc.expected, deferred.Reason)
 			}
 		})
 	}

--- a/internal/plugin6/convert/deferred_test.go
+++ b/internal/plugin6/convert/deferred_test.go
@@ -1,0 +1,56 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package convert
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/internal/providers"
+	proto "github.com/hashicorp/terraform/internal/tfplugin6"
+)
+
+func TestProtoDeferred(t *testing.T) {
+	testCases := []struct {
+		reason   proto.Deferred_Reason
+		expected providers.DeferredReason
+	}{
+		{
+			reason:   proto.Deferred_UNKNOWN,
+			expected: providers.DeferredReasonInvalid,
+		},
+		{
+			reason:   proto.Deferred_RESOURCE_CONFIG_UNKNOWN,
+			expected: providers.DeferredReasonResourceConfigUnknown,
+		},
+		{
+			reason:   proto.Deferred_PROVIDER_CONFIG_UNKNOWN,
+			expected: providers.DeferredReasonProviderConfigUnknown,
+		},
+		{
+			reason:   proto.Deferred_ABSENT_PREREQ,
+			expected: providers.DeferredReasonAbsentPrereq,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(fmt.Sprintf("deferred reason %q", tc.reason.String()), func(t *testing.T) {
+			d := &proto.Deferred{
+				Reason: tc.reason,
+			}
+
+			deferred := ProtoToDeferred(d)
+			if deferred.Reason != providers.DeferredReason(tc.expected) {
+				t.Fatalf("expected %d, got %d", tc.expected, deferred.Reason)
+			}
+		})
+	}
+}
+
+func TestProtoDeferred_Nil(t *testing.T) {
+	deferred := ProtoToDeferred(nil)
+	if deferred != nil {
+		t.Fatalf("expected nil, got %v", deferred)
+	}
+}

--- a/internal/plugin6/grpc_provider.go
+++ b/internal/plugin6/grpc_provider.go
@@ -388,9 +388,10 @@ func (p *GRPCProvider) ReadResource(r providers.ReadResourceRequest) (resp provi
 	}
 
 	protoReq := &proto6.ReadResource_Request{
-		TypeName:     r.TypeName,
-		CurrentState: &proto6.DynamicValue{Msgpack: mp},
-		Private:      r.Private,
+		TypeName:        r.TypeName,
+		CurrentState:    &proto6.DynamicValue{Msgpack: mp},
+		Private:         r.Private,
+		DeferralAllowed: r.DeferralAllowed,
 	}
 
 	if metaSchema.Block != nil {
@@ -416,6 +417,7 @@ func (p *GRPCProvider) ReadResource(r providers.ReadResourceRequest) (resp provi
 	}
 	resp.NewState = state
 	resp.Private = protoResp.Private
+	resp.Deferred = convert.ProtoToDeferred(protoResp.Deferred)
 
 	return resp
 }

--- a/internal/plugin6/grpc_provider_test.go
+++ b/internal/plugin6/grpc_provider_test.go
@@ -374,6 +374,41 @@ func TestGRPCProvider_ReadResource(t *testing.T) {
 	}
 }
 
+func TestGRPCProvider_ReadResource_deferred(t *testing.T) {
+	client := mockProviderClient(t)
+	p := &GRPCProvider{
+		client: client,
+	}
+
+	client.EXPECT().ReadResource(
+		gomock.Any(),
+		gomock.Any(),
+	).Return(&proto.ReadResource_Response{
+		NewState: &proto.DynamicValue{
+			Msgpack: []byte("\x81\xa4attr\xa3bar"),
+		},
+		Deferred: &proto.Deferred{
+			Reason: proto.Deferred_ABSENT_PREREQ,
+		},
+	}, nil)
+
+	resp := p.ReadResource(providers.ReadResourceRequest{
+		TypeName: "resource",
+		PriorState: cty.ObjectVal(map[string]cty.Value{
+			"attr": cty.StringVal("foo"),
+		}),
+	})
+
+	checkDiags(t, resp.Diagnostics)
+
+	expectedDeferred := &providers.Deferred{
+		Reason: providers.DeferredReasonAbsentPrereq,
+	}
+	if !cmp.Equal(expectedDeferred, resp.Deferred, typeComparer, valueComparer, equateEmpty) {
+		t.Fatal(cmp.Diff(expectedDeferred, resp.Deferred, typeComparer, valueComparer, equateEmpty))
+	}
+}
+
 func TestGRPCProvider_ReadResourceJSON(t *testing.T) {
 	client := mockProviderClient(t)
 	p := &GRPCProvider{

--- a/internal/terraform/context_apply_deferred_test.go
+++ b/internal/terraform/context_apply_deferred_test.go
@@ -1351,6 +1351,7 @@ output "a" {
 		}),
 		stages: []deferredActionsTestStage{
 			{
+
 				buildOpts: func(opts *PlanOpts) {
 					opts.Mode = plans.RefreshOnlyMode
 				},
@@ -1481,9 +1482,6 @@ func TestContextApply_deferredActions(t *testing.T) {
 					}
 
 					plan, diags := ctx.Plan(cfg, state, opts)
-					if plan.Complete != stage.complete {
-						t.Errorf("wrong completion status in plan: got %v, want %v", plan.Complete, stage.complete)
-					}
 
 					// We expect the correct planned changes and no diagnostics.
 					if stage.allowWarnings {
@@ -1491,6 +1489,11 @@ func TestContextApply_deferredActions(t *testing.T) {
 					} else {
 						assertNoDiagnostics(t, diags)
 					}
+
+					if plan.Complete != stage.complete {
+						t.Errorf("wrong completion status in plan: got %v, want %v", plan.Complete, stage.complete)
+					}
+
 					provider.plannedChanges.Test(t, stage.wantPlanned)
 
 					// We expect the correct actions.

--- a/internal/terraform/context_apply_deferred_test.go
+++ b/internal/terraform/context_apply_deferred_test.go
@@ -1351,7 +1351,6 @@ output "a" {
 		}),
 		stages: []deferredActionsTestStage{
 			{
-
 				buildOpts: func(opts *PlanOpts) {
 					opts.Mode = plans.RefreshOnlyMode
 				},
@@ -1613,9 +1612,7 @@ func (provider *deferredActionsProvider) Provider() providers.Interface {
 			},
 		},
 		ReadResourceFn: func(req providers.ReadResourceRequest) providers.ReadResourceResponse {
-			fmt.Println("ReadResourceFn called")
 			if key := req.PriorState.GetAttr("name"); key.IsKnown() && key.AsString() == "deferred_read" {
-				fmt.Println("Deferring read")
 				return providers.ReadResourceResponse{
 					NewState: req.PriorState,
 					Deferred: &providers.Deferred{

--- a/internal/terraform/context_apply_deferred_test.go
+++ b/internal/terraform/context_apply_deferred_test.go
@@ -46,7 +46,7 @@ type deferredActionsTestStage struct {
 	wantPlanned map[string]cty.Value
 
 	// The values we want to be deferred within each cycle.
-	wantDeferred map[string]plans.DeferredReason
+	wantDeferred map[string]providers.DeferredReason
 
 	// The expected actions from the plan step.
 	wantActions map[string]plans.Action
@@ -152,9 +152,9 @@ output "c" {
 					// The other resources will be deferred, so shouldn't
 					// have any action at this stage.
 				},
-				wantDeferred: map[string]plans.DeferredReason{
-					"test.b[\"*\"]": plans.DeferredReasonInstanceCountUnknown,
-					"test.c":        plans.DeferredReasonDeferredPrereq,
+				wantDeferred: map[string]providers.DeferredReason{
+					"test.b[\"*\"]": providers.DeferredReasonInstanceCountUnknown,
+					"test.c":        providers.DeferredReasonDeferredPrereq,
 				},
 				wantApplied: map[string]cty.Value{
 					"a": cty.ObjectVal(map[string]cty.Value{
@@ -260,7 +260,7 @@ output "c" {
 					`test.b["2"]`: plans.Create,
 					`test.c`:      plans.Create,
 				},
-				wantDeferred: make(map[string]plans.DeferredReason),
+				wantDeferred: make(map[string]providers.DeferredReason),
 				wantApplied: map[string]cty.Value{
 					// Since test.a is no-op, it isn't visited during apply. The
 					// other instances should all be applied, though.
@@ -369,7 +369,7 @@ output "c" {
 					`test.b["2"]`: plans.NoOp,
 					`test.c`:      plans.NoOp,
 				},
-				wantDeferred: make(map[string]plans.DeferredReason),
+				wantDeferred: make(map[string]providers.DeferredReason),
 				complete:     true,
 				// We won't execute an apply step in this stage, because the
 				// plan should be empty.
@@ -1413,7 +1413,7 @@ func TestContextApply_deferredActions(t *testing.T) {
 						t.Errorf("wrong actions in plan\n%s", diff)
 					}
 
-					gotDeferred := make(map[string]plans.DeferredReason)
+					gotDeferred := make(map[string]providers.DeferredReason)
 					for _, dc := range plan.DeferredResources {
 						gotDeferred[dc.ChangeSrc.Addr.String()] = dc.DeferredReason
 					}

--- a/internal/terraform/context_apply_deferred_test.go
+++ b/internal/terraform/context_apply_deferred_test.go
@@ -433,9 +433,9 @@ resource "test" "c" {
 				wantActions: map[string]plans.Action{
 					"test.a": plans.Create,
 				},
-				wantDeferred: map[string]plans.DeferredReason{
-					"test.b[\"*\"]": plans.DeferredReasonInstanceCountUnknown,
-					"test.c":        plans.DeferredReasonDeferredPrereq,
+				wantDeferred: map[string]providers.DeferredReason{
+					"test.b[\"*\"]": providers.DeferredReasonInstanceCountUnknown,
+					"test.c":        providers.DeferredReasonDeferredPrereq,
 				},
 				wantApplied: map[string]cty.Value{
 					"a": cty.ObjectVal(map[string]cty.Value{
@@ -489,7 +489,7 @@ resource "test" "c" {
 					`test.b[1]`: plans.Create,
 					`test.c`:    plans.Create,
 				},
-				wantDeferred: map[string]plans.DeferredReason{},
+				wantDeferred: map[string]providers.DeferredReason{},
 				complete:     true,
 				// Don't run an apply for this cycle.
 			},
@@ -550,9 +550,9 @@ output "names" {
 					}),
 				},
 				wantActions: map[string]plans.Action{},
-				wantDeferred: map[string]plans.DeferredReason{
-					"module.mod.test.names[\"*\"]": plans.DeferredReasonInstanceCountUnknown,
-					"test.a":                       plans.DeferredReasonDeferredPrereq,
+				wantDeferred: map[string]providers.DeferredReason{
+					"module.mod.test.names[\"*\"]": providers.DeferredReasonInstanceCountUnknown,
+					"test.a":                       providers.DeferredReasonDeferredPrereq,
 				},
 				wantApplied: make(map[string]cty.Value),
 				wantOutputs: make(map[string]cty.Value),
@@ -586,7 +586,7 @@ output "names" {
 					"module.mod.test.names[\"2\"]": plans.Create,
 					"test.a":                       plans.Create,
 				},
-				wantDeferred: map[string]plans.DeferredReason{},
+				wantDeferred: map[string]providers.DeferredReason{},
 				complete:     true,
 			},
 		},
@@ -617,7 +617,7 @@ variable "resource_count" {
 # these, but nothing in the actual plan.
 resource "test" "c" {
 	count = var.resource_count
-	name = "c:${count.index}"	
+	name = "c:${count.index}"
 
 	lifecycle {
 		create_before_destroy = true
@@ -692,8 +692,8 @@ resource "test" "c" {
 					"test.a": plans.CreateThenDelete,
 					"test.b": plans.DeleteThenCreate,
 				},
-				wantDeferred: map[string]plans.DeferredReason{
-					"test.c[\"*\"]": plans.DeferredReasonInstanceCountUnknown,
+				wantDeferred: map[string]providers.DeferredReason{
+					"test.c[\"*\"]": providers.DeferredReasonInstanceCountUnknown,
 				},
 			},
 		},
@@ -751,7 +751,7 @@ removed {
 					"test.a[0]": plans.Forget,
 					"test.a[1]": plans.Forget,
 				},
-				wantDeferred:  map[string]plans.DeferredReason{},
+				wantDeferred:  map[string]providers.DeferredReason{},
 				allowWarnings: true,
 				complete:      true,
 			},
@@ -791,8 +791,8 @@ import {
 					}),
 				},
 				wantActions: make(map[string]plans.Action),
-				wantDeferred: map[string]plans.DeferredReason{
-					"test.a[\"*\"]": plans.DeferredReasonInstanceCountUnknown,
+				wantDeferred: map[string]providers.DeferredReason{
+					"test.a[\"*\"]": providers.DeferredReasonInstanceCountUnknown,
 				},
 				wantApplied: make(map[string]cty.Value),
 				wantOutputs: make(map[string]cty.Value),
@@ -811,7 +811,7 @@ import {
 				wantActions: map[string]plans.Action{
 					"test.a[0]": plans.NoOp, // noop not create because of the import.
 				},
-				wantDeferred: map[string]plans.DeferredReason{},
+				wantDeferred: map[string]providers.DeferredReason{},
 				complete:     true,
 			},
 		},
@@ -864,8 +864,8 @@ resource "test" "c" {
 				wantActions: map[string]plans.Action{
 					"test.b": plans.Create,
 				},
-				wantDeferred: map[string]plans.DeferredReason{
-					"test.a[\"*\"]": plans.DeferredReasonInstanceCountUnknown,
+				wantDeferred: map[string]providers.DeferredReason{
+					"test.a[\"*\"]": providers.DeferredReasonInstanceCountUnknown,
 				},
 				allowWarnings: true,
 			},
@@ -894,8 +894,8 @@ resource "test" "c" {
 				wantActions: map[string]plans.Action{
 					"test.b": plans.Create,
 				},
-				wantDeferred: map[string]plans.DeferredReason{
-					"test.a[\"*\"]": plans.DeferredReasonInstanceCountUnknown,
+				wantDeferred: map[string]providers.DeferredReason{
+					"test.a[\"*\"]": providers.DeferredReasonInstanceCountUnknown,
 				},
 				allowWarnings: true,
 			},
@@ -1098,8 +1098,8 @@ resource "test" "c" {
 					"test.b": plans.DeleteThenCreate,
 					"test.c": plans.NoOp,
 				},
-				wantDeferred: map[string]plans.DeferredReason{
-					"test.a[\"*\"]": plans.DeferredReasonInstanceCountUnknown,
+				wantDeferred: map[string]providers.DeferredReason{
+					"test.a[\"*\"]": providers.DeferredReasonInstanceCountUnknown,
 				},
 			},
 		},
@@ -1159,8 +1159,8 @@ resource "test" "b" {
 				wantActions: map[string]plans.Action{
 					"test.b": plans.Create,
 				},
-				wantDeferred: map[string]plans.DeferredReason{
-					"test.a[\"*\"]": plans.DeferredReasonInstanceCountUnknown,
+				wantDeferred: map[string]providers.DeferredReason{
+					"test.a[\"*\"]": providers.DeferredReasonInstanceCountUnknown,
 				},
 				wantApplied: map[string]cty.Value{
 					"b": cty.ObjectVal(map[string]cty.Value{
@@ -1191,7 +1191,7 @@ resource "test" "b" {
 					"test.a[0]": plans.Create,
 					"test.b":    plans.NoOp,
 				},
-				wantDeferred: map[string]plans.DeferredReason{},
+				wantDeferred: map[string]providers.DeferredReason{},
 				complete:     true,
 			},
 		},
@@ -1283,8 +1283,8 @@ resource "test" "c" {
 				wantActions: map[string]plans.Action{
 					"test.b": plans.Create,
 				},
-				wantDeferred: map[string]plans.DeferredReason{
-					"test.c[\"*\"]": plans.DeferredReasonInstanceCountUnknown,
+				wantDeferred: map[string]providers.DeferredReason{
+					"test.c[\"*\"]": providers.DeferredReasonInstanceCountUnknown,
 				},
 				wantApplied: map[string]cty.Value{
 					"b": cty.ObjectVal(map[string]cty.Value{
@@ -1316,8 +1316,95 @@ resource "test" "c" {
 					"test.c[1]": plans.Delete,
 					"test.b":    plans.NoOp,
 				},
-				wantDeferred: map[string]plans.DeferredReason{},
+				wantDeferred: map[string]providers.DeferredReason{},
 				complete:     true,
+			},
+		},
+	}
+
+	// resourceReadTest is a test that covers the behavior of reading resources
+	// in a refresh when the refresh is responding with a deferral.
+	resourceReadTest = deferredActionsTest{
+		configs: map[string]string{
+			"main.tf": `
+resource "test" "a" {
+	name = "a"
+}
+output "a" {
+	value = test.a
+}
+		`,
+		},
+		state: states.BuildState(func(state *states.SyncState) {
+			state.SetResourceInstanceCurrent(
+				mustResourceInstanceAddr("test.a"),
+				&states.ResourceInstanceObjectSrc{
+					Status: states.ObjectReady,
+					AttrsJSON: mustParseJson(map[string]interface{}{
+						"name": "deferred_read", // this signals the mock provider to defer the read
+					}),
+				},
+				addrs.AbsProviderConfig{
+					Provider: addrs.NewDefaultProvider("test"),
+					Module:   addrs.RootModule,
+				})
+		}),
+		stages: []deferredActionsTestStage{
+			{
+				buildOpts: func(opts *PlanOpts) {
+					opts.Mode = plans.RefreshOnlyMode
+				},
+				inputs:      map[string]cty.Value{},
+				wantPlanned: map[string]cty.Value{
+					// The all resources will be deferred, so shouldn't
+					// have any action at this stage.
+				},
+
+				wantActions: map[string]plans.Action{},
+				wantApplied: map[string]cty.Value{
+					// The all resources will be deferred, so shouldn't
+					// have any action at this stage.
+				},
+				wantOutputs: map[string]cty.Value{
+					"a": cty.ObjectVal(map[string]cty.Value{
+						"name":           cty.StringVal("a"),
+						"upstream_names": cty.NullVal(cty.Set(cty.String)),
+					}),
+				},
+				wantDeferred: map[string]providers.DeferredReason{
+					"test.a": providers.DeferredReasonProviderConfigUnknown,
+				},
+				complete: false,
+			},
+
+			{
+				inputs: map[string]cty.Value{},
+				wantPlanned: map[string]cty.Value{
+					// The read is deferred but the plan is not so we can still
+					// plan the resource.
+					"a": cty.ObjectVal(map[string]cty.Value{
+						"name":           cty.StringVal("a"),
+						"upstream_names": cty.NullVal(cty.Set(cty.String)),
+						"output":         cty.UnknownVal(cty.String),
+					}),
+				},
+
+				wantActions: map[string]plans.Action{},
+				wantApplied: map[string]cty.Value{
+					// The all resources will be deferred, so shouldn't
+					// have any action at this stage.
+				},
+				wantOutputs: map[string]cty.Value{
+					"a": cty.ObjectVal(map[string]cty.Value{
+						"name":           cty.StringVal("deferred_read"),
+						"upstream_names": cty.NullVal(cty.Set(cty.String)),
+						"output":         cty.NullVal(cty.String),
+					}),
+				},
+				wantDeferred: map[string]providers.DeferredReason{
+					"test.a": providers.DeferredReasonProviderConfigUnknown,
+				},
+				complete: false,
 			},
 		},
 	}
@@ -1325,6 +1412,7 @@ resource "test" "c" {
 
 func TestContextApply_deferredActions(t *testing.T) {
 	tests := map[string]deferredActionsTest{
+
 		"resource_for_each":                              resourceForEachTest,
 		"resource_in_module_for_each":                    resourceInModuleForEachTest,
 		"resource_count":                                 resourceCountTest,
@@ -1336,6 +1424,7 @@ func TestContextApply_deferredActions(t *testing.T) {
 		"replace_deferred_resource":                      replaceDeferredResourceTest,
 		"custom_conditions":                              customConditionsTest,
 		"custom_conditions_with_orphans":                 customConditionsWithOrphansTest,
+		"resource_read":                                  resourceReadTest,
 	}
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
@@ -1422,6 +1511,11 @@ func TestContextApply_deferredActions(t *testing.T) {
 					}
 
 					if stage.wantApplied == nil {
+						// Don't execute the apply stage if wantApplied is nil.
+						return
+					}
+
+					if opts.Mode == plans.RefreshOnlyMode {
 						// Don't execute the apply stage if wantApplied is nil.
 						return
 					}
@@ -1514,6 +1608,22 @@ func (provider *deferredActionsProvider) Provider() providers.Interface {
 					},
 				},
 			},
+		},
+		ReadResourceFn: func(req providers.ReadResourceRequest) providers.ReadResourceResponse {
+			fmt.Println("ReadResourceFn called")
+			if key := req.PriorState.GetAttr("name"); key.IsKnown() && key.AsString() == "deferred_read" {
+				fmt.Println("Deferring read")
+				return providers.ReadResourceResponse{
+					NewState: req.PriorState,
+					Deferred: &providers.Deferred{
+						Reason: providers.DeferredReasonProviderConfigUnknown,
+					},
+				}
+			}
+
+			return providers.ReadResourceResponse{
+				NewState: req.PriorState,
+			}
 		},
 		PlanResourceChangeFn: func(req providers.PlanResourceChangeRequest) providers.PlanResourceChangeResponse {
 			if req.ProposedNewState.IsNull() {

--- a/internal/terraform/node_resource_abstract_instance_test.go
+++ b/internal/terraform/node_resource_abstract_instance_test.go
@@ -232,7 +232,7 @@ func TestNodeAbstractResourceInstance_refresh_with_deferred_read(t *testing.T) {
 	resourceGraph := addrs.NewDirectedGraph[addrs.ConfigResource]()
 	evalCtx.DeferralsState = deferring.NewDeferred(resourceGraph, true)
 
-	rio, diags := node.refresh(evalCtx, states.NotDeposed, obj)
+	rio, deferred, diags := node.refresh(evalCtx, states.NotDeposed, obj)
 	if diags.HasErrors() {
 		t.Fatal(diags.Err())
 	}
@@ -242,11 +242,11 @@ func TestNodeAbstractResourceInstance_refresh_with_deferred_read(t *testing.T) {
 		t.Fatalf("value was known: %v", value)
 	}
 
-	if !evalCtx.DeferralsCalled {
-		t.Fatalf("expected deferral to be called")
+	if deferred == nil {
+		t.Fatalf("expected deferral to be present")
 	}
 
-	if !evalCtx.DeferralsState.HaveAnyDeferrals() {
-		t.Fatalf("expected deferral to be present")
+	if deferred.Reason != providers.DeferredReasonAbsentPrereq {
+		t.Fatalf("expected deferral to be AbsentPrereq, got %s", deferred.Reason)
 	}
 }

--- a/internal/terraform/node_resource_abstract_instance_test.go
+++ b/internal/terraform/node_resource_abstract_instance_test.go
@@ -10,6 +10,8 @@ import (
 	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/configs"
 	"github.com/hashicorp/terraform/internal/configs/configschema"
+	"github.com/hashicorp/terraform/internal/plans/deferring"
+	"github.com/hashicorp/terraform/internal/providers"
 	"github.com/hashicorp/terraform/internal/states"
 	"github.com/zclconf/go-cty/cty"
 )
@@ -183,4 +185,68 @@ aws_instance.foo:
   ID = i-abc123
   provider = provider["registry.terraform.io/hashicorp/aws"]
 	`)
+}
+
+func TestNodeAbstractResourceInstance_refresh_with_deferred_read(t *testing.T) {
+	state := states.NewState()
+	evalCtx := &MockEvalContext{}
+	evalCtx.StateState = state.SyncWrapper()
+	evalCtx.Scope = evalContextModuleInstance{Addr: addrs.RootModuleInstance}
+
+	mockProvider := mockProviderWithResourceTypeSchema("aws_instance", &configschema.Block{
+		Attributes: map[string]*configschema.Attribute{
+			"id": {
+				Type:     cty.String,
+				Optional: true,
+			},
+		},
+	})
+	mockProvider.ConfigureProviderCalled = true
+
+	mockProvider.ReadResourceFn = func(providers.ReadResourceRequest) providers.ReadResourceResponse {
+		return providers.ReadResourceResponse{
+			NewState: cty.ObjectVal(map[string]cty.Value{
+				"id": cty.UnknownVal(cty.String),
+			}),
+			Deferred: &providers.Deferred{
+				Reason: providers.DeferredReasonAbsentPrereq,
+			},
+		}
+	}
+
+	obj := &states.ResourceInstanceObject{
+		Value: cty.ObjectVal(map[string]cty.Value{
+			"id": cty.StringVal("i-abc123"),
+		}),
+		Status: states.ObjectReady,
+	}
+
+	node := &NodeAbstractResourceInstance{
+		Addr: mustResourceInstanceAddr("aws_instance.foo"),
+		NodeAbstractResource: NodeAbstractResource{
+			ResolvedProvider: mustProviderConfig(`provider["registry.terraform.io/hashicorp/aws"]`),
+		},
+	}
+	evalCtx.ProviderProvider = mockProvider
+	evalCtx.ProviderSchemaSchema = mockProvider.GetProviderSchema()
+	resourceGraph := addrs.NewDirectedGraph[addrs.ConfigResource]()
+	evalCtx.DeferralsState = deferring.NewDeferred(resourceGraph, true)
+
+	rio, diags := node.refresh(evalCtx, states.NotDeposed, obj)
+	if diags.HasErrors() {
+		t.Fatal(diags.Err())
+	}
+
+	value := rio.Value
+	if value.IsWhollyKnown() {
+		t.Fatalf("value was known: %v", value)
+	}
+
+	if !evalCtx.DeferralsCalled {
+		t.Fatalf("expected deferral to be called")
+	}
+
+	if !evalCtx.DeferralsState.HaveAnyDeferrals() {
+		t.Fatalf("expected deferral to be present")
+	}
 }

--- a/internal/terraform/node_resource_import.go
+++ b/internal/terraform/node_resource_import.go
@@ -8,6 +8,7 @@ import (
 	"log"
 
 	"github.com/hashicorp/terraform/internal/addrs"
+	"github.com/hashicorp/terraform/internal/plans"
 	"github.com/hashicorp/terraform/internal/providers"
 	"github.com/hashicorp/terraform/internal/states"
 	"github.com/hashicorp/terraform/internal/tfdiags"
@@ -228,29 +229,40 @@ func (n *graphNodeImportStateSub) Execute(ctx EvalContext, op walkOperation) (di
 			ResolvedProvider: n.ResolvedProvider,
 		},
 	}
-	state, refreshDiags := riNode.refresh(ctx, states.NotDeposed, state)
+	state, deferred, refreshDiags := riNode.refresh(ctx, states.NotDeposed, state)
 	diags = diags.Append(refreshDiags)
 	if diags.HasErrors() {
 		return diags
 	}
 
-	// Verify the existance of the imported resource
-	if state.Value.IsNull() {
-		var diags tfdiags.Diagnostics
-		diags = diags.Append(tfdiags.Sourceless(
-			tfdiags.Error,
-			"Cannot import non-existent remote object",
-			fmt.Sprintf(
-				"While attempting to import an existing object to %q, "+
-					"the provider detected that no object exists with the given id. "+
-					"Only pre-existing objects can be imported; check that the id "+
-					"is correct and that it is associated with the provider's "+
-					"configured region or endpoint, or use \"terraform apply\" to "+
-					"create a new remote object for this resource.",
-				n.TargetAddr,
-			),
-		))
-		return diags
+	// If the refresh is deferred we will need to do another cycle to import the resource
+	if deferred != nil {
+		ctx.Deferrals().ReportResourceInstanceDeferred(n.TargetAddr, deferred.Reason, &plans.ResourceInstanceChange{
+			Addr: n.TargetAddr,
+			Change: plans.Change{
+				Action: plans.Read,
+				After:  state.Value,
+			},
+		})
+	} else {
+		// Verify the existance of the imported resource
+		if state.Value.IsNull() {
+			var diags tfdiags.Diagnostics
+			diags = diags.Append(tfdiags.Sourceless(
+				tfdiags.Error,
+				"Cannot import non-existent remote object",
+				fmt.Sprintf(
+					"While attempting to import an existing object to %q, "+
+						"the provider detected that no object exists with the given id. "+
+						"Only pre-existing objects can be imported; check that the id "+
+						"is correct and that it is associated with the provider's "+
+						"configured region or endpoint, or use \"terraform apply\" to "+
+						"create a new remote object for this resource.",
+					n.TargetAddr,
+				),
+			))
+			return diags
+		}
 	}
 
 	diags = diags.Append(riNode.writeResourceInstanceState(ctx, state, workingState))

--- a/internal/terraform/node_resource_plan_instance.go
+++ b/internal/terraform/node_resource_plan_instance.go
@@ -205,13 +205,24 @@ func (n *NodePlannableResourceInstance) managedResourceExecute(ctx EvalContext) 
 	// Refresh, maybe
 	// The import process handles its own refresh
 	if !n.skipRefresh && !importing {
-		s, refreshDiags := n.refresh(ctx, states.NotDeposed, instanceRefreshState)
+		s, deferred, refreshDiags := n.refresh(ctx, states.NotDeposed, instanceRefreshState)
 		diags = diags.Append(refreshDiags)
 		if diags.HasErrors() {
 			return diags
 		}
 
-		instanceRefreshState = s
+		if deferred == nil {
+			instanceRefreshState = s
+		} else {
+			ctx.Deferrals().ReportResourceInstanceDeferred(n.Addr, deferred.Reason, &plans.ResourceInstanceChange{
+				Addr: n.Addr,
+				Change: plans.Change{
+					Action: plans.Read,
+					Before: s.Value,
+					After:  cty.DynamicVal,
+				},
+			})
+		}
 
 		if instanceRefreshState != nil {
 			// When refreshing we start by merging the stored dependencies and
@@ -586,10 +597,20 @@ func (n *NodePlannableResourceInstance) importState(ctx EvalContext, addr addrs.
 		},
 		override: n.override,
 	}
-	instanceRefreshState, refreshDiags := riNode.refresh(ctx, states.NotDeposed, importedState)
+	instanceRefreshState, deferred, refreshDiags := riNode.refresh(ctx, states.NotDeposed, importedState)
 	diags = diags.Append(refreshDiags)
 	if diags.HasErrors() {
 		return instanceRefreshState, diags
+	}
+
+	if deferred != nil {
+		ctx.Deferrals().ReportResourceInstanceDeferred(n.Addr, deferred.Reason, &plans.ResourceInstanceChange{
+			Addr: n.Addr,
+			Change: plans.Change{
+				Action: plans.Read,
+				After:  instanceRefreshState.Value,
+			},
+		})
 	}
 
 	// verify the existence of the imported resource

--- a/internal/terraform/node_resource_plan_instance.go
+++ b/internal/terraform/node_resource_plan_instance.go
@@ -359,7 +359,7 @@ func (n *NodePlannableResourceInstance) managedResourceExecute(ctx EvalContext) 
 			// In this case, the expression evaluator should use the placeholder
 			// value registered here as the value of this resource instance,
 			// instead of using the plan.
-			deferrals.ReportResourceInstanceDeferred(n.Addr, plans.DeferredReasonDeferredPrereq, change)
+			deferrals.ReportResourceInstanceDeferred(n.Addr, providers.DeferredReasonDeferredPrereq, change)
 		}
 	} else {
 		// In refresh-only mode we need to evaluate the for-each expression in

--- a/internal/terraform/node_resource_plan_orphan.go
+++ b/internal/terraform/node_resource_plan_orphan.go
@@ -116,7 +116,7 @@ func (n *NodePlannableResourceInstanceOrphan) managedResourceExecute(ctx EvalCon
 		// plan before apply, and may not handle a missing resource during
 		// Delete correctly.  If this is a simple refresh, Terraform is
 		// expected to remove the missing resource from the state entirely
-		refreshedState, refreshDiags := n.refresh(ctx, states.NotDeposed, oldState)
+		refreshedState, deferred, refreshDiags := n.refresh(ctx, states.NotDeposed, oldState)
 		diags = diags.Append(refreshDiags)
 		if diags.HasErrors() {
 			return diags
@@ -129,7 +129,18 @@ func (n *NodePlannableResourceInstanceOrphan) managedResourceExecute(ctx EvalCon
 
 		// If we refreshed then our subsequent planning should be in terms of
 		// the new object, not the original object.
-		oldState = refreshedState
+		if deferred == nil {
+			oldState = refreshedState
+		} else {
+			ctx.Deferrals().ReportResourceInstanceDeferred(n.Addr, deferred.Reason, &plans.ResourceInstanceChange{
+				Addr: n.Addr,
+				Change: plans.Change{
+					Action: plans.Read,
+					Before: oldState.Value,
+					After:  refreshedState.Value,
+				},
+			})
+		}
 	}
 
 	// If we're skipping planning, all we need to do is write the state. If the


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Co-authored-by: Matej Risek <matej.risek@hashicorp.com>
## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.8.x

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

### NEW FEATURES

<!--

Write a short description of the user-facing change. Examples:

- `terraform show -json`: Fixed crash with sensitive set values.
- When rendering a diff, Terraform now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 

-  stacks: handle deferred actions in refresh
