### PR TITLE
provider/terraform: Add description to `encode_tfvars`, `decode_tfvars`, and `encode_expr`

### DIFF
--- a/internal/builtin/providers/terraform/provider.go
+++ b/internal/builtin/providers/terraform/provider.go
@@ -31,6 +31,8 @@ func (p *Provider) GetProviderSchema() providers.GetProviderSchemaResponse {
 		},
 		Functions: map[string]providers.FunctionDecl{
 			"encode_tfvars": {
+				Summary:     "Produce a string representation of an object using the same syntax as for `.tfvars` files",
+				Description: "A rarely-needed function which takes an object value and produces a string containing a description of that object using the same syntax as Terraform CLI would expect in a `.tfvars`.",
 				Parameters: []providers.FunctionParam{
 					{
 						Name:               "value",
@@ -41,6 +43,8 @@ func (p *Provider) GetProviderSchema() providers.GetProviderSchemaResponse {
 				ReturnType: cty.String,
 			},
 			"decode_tfvars": {
+				Summary:     "Parse a string containing syntax like that used in a `.tfvars` file",
+				Description: "A rarely-needed function which takes a string containing the content of a `.tfvars` file and returns an object describing the raw variable values it defines.",
 				Parameters: []providers.FunctionParam{
 					{
 						Name: "src",
@@ -50,6 +54,8 @@ func (p *Provider) GetProviderSchema() providers.GetProviderSchemaResponse {
 				ReturnType: cty.DynamicPseudoType,
 			},
 			"encode_expr": {
+				Summary:     "Produce a string representation of an arbitrary value using Terraform expression syntax",
+				Description: "A rarely-needed function which takes any value and produces a string containing Terraform language expression syntax approximating that value.",
 				Parameters: []providers.FunctionParam{
 					{
 						Name:               "value",


### PR DESCRIPTION
This PR adds descriptions to the new functions of the built-in Terraform provider. Since these are part of the provider schema, they  can then be used by consumers of the schema, such as terraform-ls.

I copied the description from the markdown docs.

### terraform-ls UX before
<img width="955" alt="CleanShot 2024-03-27 at 10 34 57@2x" src="https://github.com/hashicorp/terraform/assets/45985/9aee5646-f944-449a-98e4-54fb77e70962">

### terraform-ls UX after
<img width="957" alt="CleanShot 2024-03-27 at 10 39 54@2x" src="https://github.com/hashicorp/terraform/assets/45985/2a6e3c28-a3e6-4589-ac79-21caa6647971">

## Target Release

1.8.x

Can this be backported to 1.8?

