### PR TITLE
Filter built-in functions with namespace in metadata command

### DIFF
--- a/internal/command/metadata_functions.go
+++ b/internal/command/metadata_functions.go
@@ -5,6 +5,7 @@ package command
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/hashicorp/terraform/internal/command/jsonfunction"
 	"github.com/hashicorp/terraform/internal/lang"
@@ -55,6 +56,14 @@ func (c *MetadataFunctionsCommand) Run(args []string) int {
 		if isIgnoredFunction(k) {
 			continue
 		}
+
+		// To remove duplication, we ignore the namespaced core functions.
+		// When consumers ingest the JSON output, they can choose to namespace
+		// the functions as they see fit, similar to the provider-defined functions.
+		if strings.HasPrefix(k, "core::") {
+			continue
+		}
+
 		filteredFuncs[k] = v
 	}
 


### PR DESCRIPTION
This PR removes all `core::` prefixed functions from the `metadata functions -json` output, reducing the number of functions from 232 to 116.

I think this is more in line with the output of the provider schema JSON, which also doesn't include the prefix. With this change, consumers can choose how they want to advertise the function signatures. Without prefix, with prefix, or even both.

## Target Release

1.8.x

Can this be backported to 1.8.0?