### PR TITLE
docs: Update 'Sensitive Data in State' page to describe encryption features of gcs backend

### DIFF
--- a/website/docs/language/state/sensitive-data.mdx
+++ b/website/docs/language/state/sensitive-data.mdx
@@ -35,6 +35,6 @@ For example:
 - The S3 backend supports encryption at rest when the `encrypt` option is
   enabled. IAM policies and logging can be used to identify any invalid access.
   Requests for the state go over a TLS connection.
-- The GCS (Google Cloud Storage) backend supports:
+- The GCS (Google Cloud Storage) backend supports using [customer-supplied](/terraform/language/settings/backends/gcs#customer-supplied-encryption-keys) or [customer-managed (Cloud KMS)](/terraform/language/settings/backends/gcs#customer-managed-encryption-keys-cloud-kms) encryption keys.
     - [Using customer-supplied encryption keys](https://developer.hashicorp.com/terraform/language/settings/backends/gcs#customer-supplied-encryption-keys).
     - [Using customer-managed encryption keys (Cloud KMS)](https://developer.hashicorp.com/terraform/language/settings/backends/gcs#customer-managed-encryption-keys-cloud-kms).

--- a/website/docs/language/state/sensitive-data.mdx
+++ b/website/docs/language/state/sensitive-data.mdx
@@ -36,5 +36,3 @@ For example:
   enabled. IAM policies and logging can be used to identify any invalid access.
   Requests for the state go over a TLS connection.
 - The GCS (Google Cloud Storage) backend supports using [customer-supplied](/terraform/language/settings/backends/gcs#customer-supplied-encryption-keys) or [customer-managed (Cloud KMS)](/terraform/language/settings/backends/gcs#customer-managed-encryption-keys-cloud-kms) encryption keys.
-    - [Using customer-supplied encryption keys](https://developer.hashicorp.com/terraform/language/settings/backends/gcs#customer-supplied-encryption-keys).
-    - [Using customer-managed encryption keys (Cloud KMS)](https://developer.hashicorp.com/terraform/language/settings/backends/gcs#customer-managed-encryption-keys-cloud-kms).

--- a/website/docs/language/state/sensitive-data.mdx
+++ b/website/docs/language/state/sensitive-data.mdx
@@ -35,3 +35,6 @@ For example:
 - The S3 backend supports encryption at rest when the `encrypt` option is
   enabled. IAM policies and logging can be used to identify any invalid access.
   Requests for the state go over a TLS connection.
+- The GCS (Google Cloud Storage) backend supports:
+    - [Using customer-supplied encryption keys](https://developer.hashicorp.com/terraform/language/settings/backends/gcs#customer-supplied-encryption-keys).
+    - [Using customer-managed encryption keys (Cloud KMS)](https://developer.hashicorp.com/terraform/language/settings/backends/gcs#customer-managed-encryption-keys-cloud-kms).


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Updates this page (https://developer.hashicorp.com/terraform/language/state/sensitive-data) of the documentation to reflect gcs backend features added in the past. See: https://developer.hashicorp.com/terraform/language/settings/backends/gcs

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.8.1

Do docs changes need a release target? 


## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

### NEW FEATURES | UPGRADE NOTES | ENHANCEMENTS | BUG FIXES | EXPERIMENTS

<!--

Write a short description of the user-facing change. Examples:

- `terraform show -json`: Fixed crash with sensitive set values.
- When rendering a diff, Terraform now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 

-  
