### PR TITLE
Update docs to clarify cross-type moves

### DIFF
--- a/website/docs/language/modules/develop/refactoring.mdx
+++ b/website/docs/language/modules/develop/refactoring.mdx
@@ -103,14 +103,13 @@ so Terraform recognizes the move for all instances of the resource. That is,
 it covers both `aws_instance.a[0]` and `aws_instance.a[1]` without the need
 to identify each one separately.
 
-Each resource type has a separate schema and so objects of different types
-are not typically compatible. However, some providers support changing the
-resource type of an object in a way that is compatible with the `moved` block.
-Therefore, you can always use the `moved` block to change the name of a resource
-but only sometimes to change the resource type. The documentation of each
-provider will detail which resources support across-type moves, if any. You
-_cannot_ use `moved` to change to a different resource type or to change a
-managed resource (a `resource` block) into a data resource (a `data` block).
+Each resource type has a separate schema so objects of different types
+are not typically compatible. You can always use the `moved` block to change 
+the name of a resource, but some providers also let you change an object from
+one resource type to another. Refer to the provider documentation for details
+on which resources can move between types. You _cannot_ use the `moved` 
+block to change a managed resource (a `resource` block) into a data 
+resource (a `data` block).
 
 ## Enabling `count` or `for_each` For a Resource
 

--- a/website/docs/language/modules/develop/refactoring.mdx
+++ b/website/docs/language/modules/develop/refactoring.mdx
@@ -104,10 +104,13 @@ it covers both `aws_instance.a[0]` and `aws_instance.a[1]` without the need
 to identify each one separately.
 
 Each resource type has a separate schema and so objects of different types
-are not compatible. Therefore, although you can use `moved` to change the name
-of a resource, you _cannot_ use `moved` to change to a different resource type
-or to change a managed resource (a `resource` block) into a data resource
-(a `data` block).
+are not typically compatible. However, some providers support changing the
+resource type of an object in a way that is compatible with the `moved` block.
+Therefore, you can always use the `moved` block to change the name of a resource
+but only sometimes to change the resource type. The documentation of each
+provider will detail which resources support across-type moves, if any. You
+_cannot_ use `moved` to change to a different resource type or to change a
+managed resource (a `resource` block) into a data resource (a `data` block).
 
 ## Enabling `count` or `for_each` For a Resource
 


### PR DESCRIPTION
I'm not updating the docs for `terraform state mv` as that command does not support cross-type moves. Only the `moved` blocks do.

The providers declare which cross-type moves are available to them, so we can only say here that "some" resources support this, and ask the readers to look at the provider docs for clarification on "some".