### PR TITLE
terraform: Stabilize the variable_validation_crossref experiment

### DIFF
--- a/internal/configs/experiments.go
+++ b/internal/configs/experiments.go
@@ -208,19 +208,5 @@ func checkModuleExperiments(m *Module) hcl.Diagnostics {
 		}
 	*/
 
-	if !m.ActiveExperiments.Has(experiments.VariableValidationCrossRef) {
-		// Without this experiment, validation rules are subject to the old
-		// rule that they can only refer to the variable whose value they
-		// are checking. This experiment removes that constraint, and makes
-		// the modules runtime responsible for validating and evaluating
-		// the conditions and error messages, just as we'd do for any other
-		// dynamic expression.
-		for varName, vc := range m.Variables {
-			for _, vv := range vc.Validations {
-				diags = append(diags, checkVariableValidationBlock(varName, vv)...)
-			}
-		}
-	}
-
 	return diags
 }

--- a/internal/configs/testdata/valid-files/variable-validation-condition-crossref.tf
+++ b/internal/configs/testdata/valid-files/variable-validation-condition-crossref.tf
@@ -5,7 +5,7 @@ locals {
 
 variable "validation" {
   validation {
-    condition     = local.foo == var.validation # ERROR: Invalid reference in variable validation
+    condition     = local.foo == var.validation
     error_message = "Must be five."
   }
 }
@@ -13,6 +13,6 @@ variable "validation" {
 variable "validation_error_expression" {
   validation {
     condition     = var.validation_error_expression != 1
-    error_message = "Cannot equal ${local.foo}." # ERROR: Invalid reference in variable validation
+    error_message = "Cannot equal ${local.foo}."
   }
 }

--- a/internal/experiments/experiment.go
+++ b/internal/experiments/experiment.go
@@ -31,7 +31,7 @@ func init() {
 	// a current or a concluded experiment.
 	registerConcludedExperiment(UnknownInstances, "Unknown instances are being rolled into a larger feature for deferring unready resources and modules.")
 	registerConcludedExperiment(VariableValidation, "Custom variable validation can now be used by default, without enabling an experiment.")
-	registerCurrentExperiment(VariableValidationCrossRef)
+	registerConcludedExperiment(VariableValidationCrossRef, "Input variable validation rules may now refer to other objects in the same module without enabling any experiment.")
 	registerConcludedExperiment(SuppressProviderSensitiveAttrs, "Provider-defined sensitive attributes are now redacted by default, without enabling an experiment.")
 	registerCurrentExperiment(TemplateStringFunc)
 	registerConcludedExperiment(ConfigDrivenMove, "Declarations of moved resource instances using \"moved\" blocks can now be used by default, without enabling an experiment.")

--- a/internal/terraform/context_plan_test.go
+++ b/internal/terraform/context_plan_test.go
@@ -6921,8 +6921,6 @@ resource "test_resource" "foo" {
 }
 
 func TestContext2Plan_variableCustomValidationsSimple(t *testing.T) {
-	// This test is dealing with validation rules that refer to other objects
-	// in the same module.
 	m := testModuleInline(t, map[string]string{
 		"main.tf": `
 			variable "a" {
@@ -6978,11 +6976,6 @@ func TestContext2Plan_variableCustomValidationsCrossRef(t *testing.T) {
 	// in the same module.
 	m := testModuleInline(t, map[string]string{
 		"main.tf": `
-			# Validation cross-references are currently experimental
-			terraform {
-				experiments = [variable_validation_crossref]
-			}
-
 			variable "a" {
 				type = string
 			}

--- a/internal/terraform/eval_variable_test.go
+++ b/internal/terraform/eval_variable_test.go
@@ -1173,7 +1173,13 @@ func TestEvalVariableValidations_jsonErrorMessageEdgeCase(t *testing.T) {
 
 			// We need a minimal scope to allow basic functions to be passed to
 			// the HCL scope
-			ctx.EvaluationScopeScope = &lang.Scope{}
+			ctx.EvaluationScopeScope = &lang.Scope{
+				Data: &fakeEvaluationData{
+					inputVariables: map[addrs.InputVariable]cty.Value{
+						varAddr.Variable: test.given,
+					},
+				},
+			}
 			ctx.NamedValuesState = namedvals.NewState()
 			ctx.NamedValuesState.SetInputVariableValue(varAddr, test.given)
 			ctx.ChecksState = checks.NewState(cfg)
@@ -1322,13 +1328,19 @@ variable "bar" {
 
 			// We need a minimal scope to allow basic functions to be passed to
 			// the HCL scope
-			ctx.EvaluationScopeScope = &lang.Scope{}
-			ctx.NamedValuesState = namedvals.NewState()
+			varVal := test.given
 			if varCfg.Sensitive {
-				ctx.NamedValuesState.SetInputVariableValue(varAddr, test.given.Mark(marks.Sensitive))
-			} else {
-				ctx.NamedValuesState.SetInputVariableValue(varAddr, test.given)
+				varVal = varVal.Mark(marks.Sensitive)
 			}
+			ctx.EvaluationScopeScope = &lang.Scope{
+				Data: &fakeEvaluationData{
+					inputVariables: map[addrs.InputVariable]cty.Value{
+						varAddr.Variable: varVal,
+					},
+				},
+			}
+			ctx.NamedValuesState = namedvals.NewState()
+			ctx.NamedValuesState.SetInputVariableValue(varAddr, varVal)
 			ctx.ChecksState = checks.NewState(cfg)
 			ctx.ChecksState.ReportCheckableObjects(varAddr.ConfigCheckable(), addrs.MakeSet[addrs.Checkable](varAddr))
 

--- a/internal/terraform/evaluate_test.go
+++ b/internal/terraform/evaluate_test.go
@@ -4,6 +4,7 @@
 package terraform
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/davecgh/go-spew/spew"
@@ -616,4 +617,103 @@ func evaluatorForModule(stateSync *states.SyncState, changesSync *plans.ChangesS
 		Instances:   instances.NewExpander(nil),
 		NamedValues: namedvals.NewState(),
 	}
+}
+
+// fakeEvaluationData is an implementation of [lang.Data] that answers most
+// questions just by returning data directly from the maps stored inside it.
+type fakeEvaluationData struct {
+	checkBlocks    map[addrs.Check]cty.Value
+	countAttrs     map[addrs.CountAttr]cty.Value
+	forEachAttrs   map[addrs.ForEachAttr]cty.Value
+	inputVariables map[addrs.InputVariable]cty.Value
+	localValues    map[addrs.LocalValue]cty.Value
+	modules        map[addrs.ModuleCall]cty.Value
+	outputValues   map[addrs.OutputValue]cty.Value
+	pathAttrs      map[addrs.PathAttr]cty.Value
+	resources      map[addrs.Resource]cty.Value
+	runBlocks      map[addrs.Run]cty.Value
+	terraformAttrs map[addrs.TerraformAttr]cty.Value
+
+	// staticValidateRefs optionally implements [lang.Data.StaticValidateReferences],
+	// but can be left as nil to just skip static validation altogether.
+	staticValidateRefs func(refs []*addrs.Reference, self addrs.Referenceable, source addrs.Referenceable) tfdiags.Diagnostics
+}
+
+var _ lang.Data = (*fakeEvaluationData)(nil)
+
+func fakeEvaluationDataLookup[Addr interface {
+	comparable
+	addrs.Referenceable
+}](addr Addr, _ tfdiags.SourceRange, table map[Addr]cty.Value) (cty.Value, tfdiags.Diagnostics) {
+	ret, ok := table[addr]
+	if !ok {
+		var diags tfdiags.Diagnostics
+		diags = diags.Append(fmt.Errorf("fakeEvaluationData does not know about %s", addr))
+		return cty.DynamicVal, diags
+	}
+	return ret, nil
+}
+
+// GetCheckBlock implements lang.Data.
+func (d *fakeEvaluationData) GetCheckBlock(addr addrs.Check, rng tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics) {
+	return fakeEvaluationDataLookup(addr, rng, d.checkBlocks)
+}
+
+// GetCountAttr implements lang.Data.
+func (d *fakeEvaluationData) GetCountAttr(addr addrs.CountAttr, rng tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics) {
+	return fakeEvaluationDataLookup(addr, rng, d.countAttrs)
+}
+
+// GetForEachAttr implements lang.Data.
+func (d *fakeEvaluationData) GetForEachAttr(addr addrs.ForEachAttr, rng tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics) {
+	return fakeEvaluationDataLookup(addr, rng, d.forEachAttrs)
+}
+
+// GetInputVariable implements lang.Data.
+func (d *fakeEvaluationData) GetInputVariable(addr addrs.InputVariable, rng tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics) {
+	return fakeEvaluationDataLookup(addr, rng, d.inputVariables)
+}
+
+// GetLocalValue implements lang.Data.
+func (d *fakeEvaluationData) GetLocalValue(addr addrs.LocalValue, rng tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics) {
+	return fakeEvaluationDataLookup(addr, rng, d.localValues)
+}
+
+// GetModule implements lang.Data.
+func (d *fakeEvaluationData) GetModule(addr addrs.ModuleCall, rng tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics) {
+	return fakeEvaluationDataLookup(addr, rng, d.modules)
+}
+
+// GetOutput implements lang.Data.
+func (d *fakeEvaluationData) GetOutput(addr addrs.OutputValue, rng tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics) {
+	return fakeEvaluationDataLookup(addr, rng, d.outputValues)
+}
+
+// GetPathAttr implements lang.Data.
+func (d *fakeEvaluationData) GetPathAttr(addr addrs.PathAttr, rng tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics) {
+	return fakeEvaluationDataLookup(addr, rng, d.pathAttrs)
+}
+
+// GetResource implements lang.Data.
+func (d *fakeEvaluationData) GetResource(addr addrs.Resource, rng tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics) {
+	return fakeEvaluationDataLookup(addr, rng, d.resources)
+}
+
+// GetRunBlock implements lang.Data.
+func (d *fakeEvaluationData) GetRunBlock(addr addrs.Run, rng tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics) {
+	return fakeEvaluationDataLookup(addr, rng, d.runBlocks)
+}
+
+// GetTerraformAttr implements lang.Data.
+func (d *fakeEvaluationData) GetTerraformAttr(addr addrs.TerraformAttr, rng tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics) {
+	return fakeEvaluationDataLookup(addr, rng, d.terraformAttrs)
+}
+
+// StaticValidateReferences implements lang.Data.
+func (d *fakeEvaluationData) StaticValidateReferences(refs []*addrs.Reference, self addrs.Referenceable, source addrs.Referenceable) tfdiags.Diagnostics {
+	if d.staticValidateRefs == nil {
+		// By default we just skip static validation
+		return nil
+	}
+	return d.staticValidateRefs(refs, self, source)
 }

--- a/internal/terraform/graph_builder_apply.go
+++ b/internal/terraform/graph_builder_apply.go
@@ -125,9 +125,7 @@ func (b *ApplyGraphBuilder) Steps() []GraphTransformer {
 			Config:       b.Config,
 			DestroyApply: b.Operation == walkDestroy,
 		},
-		&variableValidationTransformer{
-			config: b.Config,
-		},
+		&variableValidationTransformer{},
 		&LocalTransformer{Config: b.Config},
 		&OutputTransformer{
 			Config:     b.Config,

--- a/internal/terraform/graph_builder_eval.go
+++ b/internal/terraform/graph_builder_eval.go
@@ -76,9 +76,7 @@ func (b *EvalGraphBuilder) Steps() []GraphTransformer {
 		// Add dynamic values
 		&RootVariableTransformer{Config: b.Config, RawValues: b.RootVariableValues, Planning: true},
 		&ModuleVariableTransformer{Config: b.Config, Planning: true},
-		&variableValidationTransformer{
-			config: b.Config,
-		},
+		&variableValidationTransformer{},
 		&LocalTransformer{Config: b.Config},
 		&OutputTransformer{
 			Config:   b.Config,

--- a/internal/terraform/graph_builder_plan.go
+++ b/internal/terraform/graph_builder_plan.go
@@ -159,9 +159,7 @@ func (b *PlanGraphBuilder) Steps() []GraphTransformer {
 			Planning:     true,
 			DestroyApply: false, // always false for planning
 		},
-		&variableValidationTransformer{
-			config: b.Config,
-		},
+		&variableValidationTransformer{},
 		&LocalTransformer{Config: b.Config},
 		&OutputTransformer{
 			Config:      b.Config,

--- a/website/docs/language/expressions/custom-conditions.mdx
+++ b/website/docs/language/expressions/custom-conditions.mdx
@@ -29,9 +29,9 @@ For more information on when to use certain custom conditions, see [Choosing Bet
 
 ## Input Variable Validation
 
--> **Note:** Input variable validation is available in Terraform v0.13.0 and later.
+-> **Note:** Input variable validation is available in Terraform v0.13.0 and later. Before Terraform v1.9.0, validation rules can refer only to the variable being validated, and not to any other variables.
 
-Add one or more `validation` blocks within the `variable` block to specify custom conditions. Each validation requires a [`condition` argument](#condition-expressions), an expression that must use the value of the variable to return `true` if the value is valid, or `false` if it is invalid. The expression can refer only to the containing variable and must not produce errors.
+Add one or more `validation` blocks within the `variable` block to specify custom conditions. Each validation requires a [`condition` argument](#condition-expressions), an expression that must use the value of the variable to return `true` if the value is valid, or `false` if it is invalid. The expression must not cause errors directly itself.
 
 If the condition evaluates to `false`, Terraform produces an [error message](#error-messages) that includes the result of the `error_message` expression. If you declare multiple validations, Terraform returns error messages for all failed conditions.
 


### PR DESCRIPTION
In https://github.com/hashicorp/terraform/pull/34947 we introduced a language experiment that would permit variable validation rules to refer to other objects declared in the same module as the variable.

Now that experiment is concluded and its behavior is available for all modules.

This closes https://github.com/hashicorp/terraform/issues/25609.

---

This final version deviates slightly from the experiment: we learned from the experimental implementation that we accidentally made the `terraform validate` command able to validate constant-valued input variables in child modules
despite the usual rule that input variables are unknown during validation, because the previous compromise bypassed the main expression evaluator and built its own evaluation context directly.

Even though that behavior was not intended, it's a useful behavior that is protected by our compatibility promises and so this commit includes a slightly hacky emulation of that behavior, in `eval_variable.go`, that fetches the variable value in the same way the old implementation would have and then modifies the HCL evaluation context to include that value, while preserving anything else that our standard evaluation context builder put in there.

That narrowly preserves the old behavior for expressions that compare the variable value directly to a constant, while treating all other references (which were previously totally invalid) in the standard way. This quirk was already covered by the existing test `TestContext2Validate_variableCustomValidationsFail`, which fails if the special workaround is removed.