### PR TITLE
docs: fix typo in spelling of 'flag'

### DIFF
--- a/website/docs/language/style.mdx
+++ b/website/docs/language/style.mdx
@@ -432,7 +432,7 @@ Do not commit:
 - Your `terraform.tfstate` state file, including `terraform.tfstate.*` backup state files.
 - Your `.terraform.tfstate.lock.info` file. Terraform creates and deletes this file automatically when you run a `terraform apply` command and contains info about your [state lock](/terraform/language/state/locking)
 - Your `.terraform` directory, where Terraform downloads providers and child modules. 
-[Saved plan files](/terraform/cli/commands/plan#out-filename) that you create when you include the `-out` flat when you run `terraform plan`.
+[Saved plan files](/terraform/cli/commands/plan#out-filename) that you create when you include the `-out` flag when you run `terraform plan`.
 - Any `.tfvars` files that contain sensitive information.
 
 Always commit:


### PR DESCRIPTION
Change spelling from 'flat' to 'flag' to fix typo

<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Fixes: Typo in docs



<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->



<!--

Choose a category, delete the others:

-->



<!--

Write a short description of the user-facing change. Examples:

- `terraform show -json`: Fixed crash with sensitive set values.
- When rendering a diff, Terraform now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 


