### PR TITLE
docs: fix typo in spelling of 'Sentinel'

### DIFF
--- a/website/docs/language/style.mdx
+++ b/website/docs/language/style.mdx
@@ -672,7 +672,7 @@ Policies are rules that Terraform Cloud enforces on Terraform runs. You can use 
 
 We recommend that you store policies in a separate VCS repository from your Terraform code.
 
-For more information, refer to the [policy enforcement documentation](/terraform/cloud-docs/policy-enforcement), as well as the [enforce policy with Sential](/terraform/tutorials/policy) and [detect infrastructure drift and enforce OPA policies](/terraform/tutorials/cloud/drift-and-opa) tutorials.
+For more information, refer to the [policy enforcement documentation](/terraform/cloud-docs/policy-enforcement), as well as the [enforce policy with Sentinel](/terraform/tutorials/policy) and [detect infrastructure drift and enforce OPA policies](/terraform/tutorials/cloud/drift-and-opa) tutorials.
 
 ## Next steps
 


### PR DESCRIPTION
Correct spelling from 'Sential' to 'Sentinel'

