### PR TITLE
plan renderer: ensure JSON strings are completely JSON

### DIFF
--- a/internal/command/jsonformat/computed/renderers/renderer_test.go
+++ b/internal/command/jsonformat/computed/renderers/renderer_test.go
@@ -111,6 +111,13 @@ null -> jsonencode(
     )
 `,
 		},
+		"primitive_create_fake_json": {
+			diff: computed.Diff{
+				Renderer: Primitive(nil, "[\"hello\"] and some more", cty.String),
+				Action:   plans.Create,
+			},
+			expected: `"[\"hello\"] and some more"`,
+		},
 		"primitive_create_null_string": {
 			diff: computed.Diff{
 				Renderer: Primitive(nil, nil, cty.String),

--- a/internal/command/jsonformat/computed/renderers/string.go
+++ b/internal/command/jsonformat/computed/renderers/string.go
@@ -4,11 +4,11 @@
 package renderers
 
 import (
-	"encoding/json"
 	"fmt"
 	"strings"
 
 	"github.com/hashicorp/terraform/internal/command/jsonformat/computed"
+	"github.com/hashicorp/terraform/internal/command/jsonformat/structured"
 )
 
 type evaluatedString struct {
@@ -30,12 +30,8 @@ func evaluatePrimitiveString(value interface{}, opts computed.RenderHumanOpts) e
 	str := value.(string)
 
 	if strings.HasPrefix(str, "{") || strings.HasPrefix(str, "[") {
-
-		decoder := json.NewDecoder(strings.NewReader(str))
-		decoder.UseNumber()
-
-		var jv interface{}
-		if err := decoder.Decode(&jv); err == nil {
+		jv, err := structured.ParseJson(strings.NewReader(str))
+		if err == nil {
 			return evaluatedString{
 				String: str,
 				Json:   jv,


### PR DESCRIPTION

*Don't merge (or at least backport) this until after the release of 1.8.0 has been completed this week.*

In https://github.com/hashicorp/terraform/pull/34702 we modified the JSON parsing of the plan renderer to support large (> 2^64) numbers. In doing so we changed the parsing to use the json.Decoder. The Decoder accepts partial JSON strings, so this means that a string that starts with a valid JSON object and then ends with a non-JSON piece of text is interpreted as valid JSON.

This PR updates the renderer so it checks the decoder has consumed the complete string before trusting that the returned object can be rendered as JSON. 

In Martin's comments, he details how the `ctyjson` package supports this and the large number parsing by default. Unfortunately, we can't use the `ctyjson` package here as the renderer doesn't handle `cty.Value` objects instead just relying on the raw JSON objects that are available from the `jsonplan` package.

Fixes #34954 

## Target Version

v1.8.1

## Proposed CHANGELOG

### BUG FIXES

- plan renderer: Correctly render strings that begin with JSON compatible text but don't end with it.