### PR TITLE
stacks: adding deferred action to datasource reads

### DIFF
--- a/internal/plugin/grpc_provider.go
+++ b/internal/plugin/grpc_provider.go
@@ -721,6 +721,7 @@ func (p *GRPCProvider) ReadDataSource(r providers.ReadDataSourceRequest) (resp p
 		Config: &proto.DynamicValue{
 			Msgpack: config,
 		},
+		DeferralAllowed: r.DeferralAllowed,
 	}
 
 	if metaSchema.Block != nil {
@@ -745,6 +746,7 @@ func (p *GRPCProvider) ReadDataSource(r providers.ReadDataSourceRequest) (resp p
 		return resp
 	}
 	resp.State = state
+	resp.Deferred = convert.ProtoToDeferred(protoResp.Deferred)
 
 	return resp
 }

--- a/internal/plugin6/grpc_provider.go
+++ b/internal/plugin6/grpc_provider.go
@@ -710,6 +710,7 @@ func (p *GRPCProvider) ReadDataSource(r providers.ReadDataSourceRequest) (resp p
 		Config: &proto6.DynamicValue{
 			Msgpack: config,
 		},
+		DeferralAllowed: r.DeferralAllowed,
 	}
 
 	if metaSchema.Block != nil {
@@ -734,6 +735,7 @@ func (p *GRPCProvider) ReadDataSource(r providers.ReadDataSourceRequest) (resp p
 		return resp
 	}
 	resp.State = state
+	resp.Deferred = convert.ProtoToDeferred(protoResp.Deferred)
 
 	return resp
 }

--- a/internal/providers/provider.go
+++ b/internal/providers/provider.go
@@ -508,6 +508,10 @@ type ReadDataSourceRequest struct {
 	// each provider, and it should not be used without coordination with
 	// HashiCorp. It is considered experimental and subject to change.
 	ProviderMeta cty.Value
+
+	// DeferralAllowed signals that the provider is allowed to defer the
+	// changes. If set the caller needs to handle the deferred response.
+	DeferralAllowed bool
 }
 
 type ReadDataSourceResponse struct {
@@ -516,6 +520,10 @@ type ReadDataSourceResponse struct {
 
 	// Diagnostics contains any warnings or errors from the method call.
 	Diagnostics tfdiags.Diagnostics
+
+	// Deferred if present signals that the provider was not able to fully
+	// complete this operation and a susequent run is required.
+	Deferred *Deferred
 }
 
 type CallFunctionRequest struct {

--- a/internal/terraform/context_apply_deferred_test.go
+++ b/internal/terraform/context_apply_deferred_test.go
@@ -1604,17 +1604,25 @@ output "b" {
 		},
 		stages: []deferredActionsTestStage{
 			{
-				inputs:      map[string]cty.Value{},
-				wantPlanned: map[string]cty.Value{},
+				inputs: map[string]cty.Value{},
+				wantPlanned: map[string]cty.Value{
+					// test.b is deffered but still in the plan. This is a bug
+					// that will be fixed when resource update is fixed.
+					"<unknown>": cty.ObjectVal(map[string]cty.Value{
+						"name":           cty.UnknownVal(cty.String),
+						"output":         cty.UnknownVal(cty.String),
+						"upstream_names": cty.NullVal(cty.Set(cty.String)),
+					}),
+				},
 				wantActions: map[string]plans.Action{},
 				wantApplied: map[string]cty.Value{
 					// The all resources will be deferred, so shouldn't
 					// have any action at this stage.
 				},
 				wantOutputs: map[string]cty.Value{
-					"a": cty.ObjectVal(map[string]cty.Value{
-						"name": cty.StringVal("deferred_read"),
-					}),
+					"a": cty.NullVal(cty.Object(map[string]cty.Type{
+						"name": cty.String,
+					})),
 					"b": cty.NullVal(cty.DynamicPseudoType),
 				},
 				wantDeferred: map[string]providers.DeferredReason{

--- a/internal/terraform/context_apply_deferred_test.go
+++ b/internal/terraform/context_apply_deferred_test.go
@@ -1625,8 +1625,9 @@ output "b" {
 					"b": cty.NullVal(cty.DynamicPseudoType),
 				},
 				wantDeferred: map[string]providers.DeferredReason{
-					"data.test.a": providers.DeferredReasonProviderConfigUnknown,
-					"test.b":      providers.DeferredReasonDeferredPrereq,
+					// data.test.a is not part of the plan so we can only
+					// observe the indirect consequence on the resource.
+					"test.b": providers.DeferredReasonDeferredPrereq,
 				},
 				complete: false,
 			},

--- a/internal/terraform/context_apply_deferred_test.go
+++ b/internal/terraform/context_apply_deferred_test.go
@@ -1604,15 +1604,8 @@ output "b" {
 		},
 		stages: []deferredActionsTestStage{
 			{
-				inputs: map[string]cty.Value{},
-				wantPlanned: map[string]cty.Value{
-					"deferred_read": cty.ObjectVal(map[string]cty.Value{
-						"name":           cty.StringVal("deferred_read"),
-						"upstream_names": cty.NullVal(cty.Set(cty.String)),
-						"output":         cty.UnknownVal(cty.String),
-					}),
-				},
-
+				inputs:      map[string]cty.Value{},
+				wantPlanned: map[string]cty.Value{},
 				wantActions: map[string]plans.Action{},
 				wantApplied: map[string]cty.Value{
 					// The all resources will be deferred, so shouldn't

--- a/internal/terraform/context_apply_deferred_test.go
+++ b/internal/terraform/context_apply_deferred_test.go
@@ -1606,8 +1606,8 @@ output "b" {
 			{
 				inputs: map[string]cty.Value{},
 				wantPlanned: map[string]cty.Value{
-					// test.b is deffered but still in the plan. This is a bug
-					// that will be fixed when resource update is fixed.
+					// test.b is deferred but still being planned. It being listed
+					// here does not mean it's in the plan.
 					"<unknown>": cty.ObjectVal(map[string]cty.Value{
 						"name":           cty.UnknownVal(cty.String),
 						"output":         cty.UnknownVal(cty.String),

--- a/internal/terraform/context_apply_deferred_test.go
+++ b/internal/terraform/context_apply_deferred_test.go
@@ -933,7 +933,7 @@ resource "test" "c" {
 	targetResourceThatDependsOnDeferredResourceTest = deferredActionsTest{
 		configs: map[string]string{
 			"main.tf": `
-variable "resource_count" {	
+variable "resource_count" {
 	type = number
 }
 
@@ -1581,11 +1581,61 @@ output "a" {
 			},
 		},
 	}
+
+	readDataSourceTest = deferredActionsTest{
+		configs: map[string]string{
+			"main.tf": `
+data "test" "a" {
+	name       = "deferred_read"
+}
+
+resource "test" "b" {
+	name = data.test.a.name
+}
+
+output "a" {
+	value = data.test.a
+}
+
+output "b" {
+	value = test.b
+}
+		`,
+		},
+		stages: []deferredActionsTestStage{
+			{
+				inputs: map[string]cty.Value{},
+				wantPlanned: map[string]cty.Value{
+					"deferred_read": cty.ObjectVal(map[string]cty.Value{
+						"name":           cty.StringVal("deferred_read"),
+						"upstream_names": cty.NullVal(cty.Set(cty.String)),
+						"output":         cty.UnknownVal(cty.String),
+					}),
+				},
+
+				wantActions: map[string]plans.Action{},
+				wantApplied: map[string]cty.Value{
+					// The all resources will be deferred, so shouldn't
+					// have any action at this stage.
+				},
+				wantOutputs: map[string]cty.Value{
+					"a": cty.ObjectVal(map[string]cty.Value{
+						"name": cty.StringVal("deferred_read"),
+					}),
+					"b": cty.NullVal(cty.DynamicPseudoType),
+				},
+				wantDeferred: map[string]providers.DeferredReason{
+					"data.test.a": providers.DeferredReasonProviderConfigUnknown,
+					"test.b":      providers.DeferredReasonDeferredPrereq,
+				},
+				complete: false,
+			},
+		},
+	}
 )
 
 func TestContextApply_deferredActions(t *testing.T) {
 	tests := map[string]deferredActionsTest{
-
 		"resource_for_each":                                 resourceForEachTest,
 		"resource_in_module_for_each":                       resourceInModuleForEachTest,
 		"resource_count":                                    resourceCountTest,
@@ -1599,6 +1649,7 @@ func TestContextApply_deferredActions(t *testing.T) {
 		"custom_conditions":                                 customConditionsTest,
 		"custom_conditions_with_orphans":                    customConditionsWithOrphansTest,
 		"resource_read":                                     resourceReadTest,
+		"data_read":                                         readDataSourceTest,
 	}
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
@@ -1784,6 +1835,18 @@ func (provider *deferredActionsProvider) Provider() providers.Interface {
 					},
 				},
 			},
+			DataSources: map[string]providers.Schema{
+				"test": {
+					Block: &configschema.Block{
+						Attributes: map[string]*configschema.Attribute{
+							"name": {
+								Type:     cty.String,
+								Required: true,
+							},
+						},
+					},
+				},
+			},
 		},
 		ReadResourceFn: func(req providers.ReadResourceRequest) providers.ReadResourceResponse {
 			if key := req.PriorState.GetAttr("name"); key.IsKnown() && key.AsString() == "deferred_read" {
@@ -1797,6 +1860,19 @@ func (provider *deferredActionsProvider) Provider() providers.Interface {
 
 			return providers.ReadResourceResponse{
 				NewState: req.PriorState,
+			}
+		},
+		ReadDataSourceFn: func(req providers.ReadDataSourceRequest) providers.ReadDataSourceResponse {
+			if key := req.Config.GetAttr("name"); key.IsKnown() && key.AsString() == "deferred_read" {
+				return providers.ReadDataSourceResponse{
+					State: req.Config,
+					Deferred: &providers.Deferred{
+						Reason: providers.DeferredReasonProviderConfigUnknown,
+					},
+				}
+			}
+			return providers.ReadDataSourceResponse{
+				State: req.Config,
 			}
 		},
 		PlanResourceChangeFn: func(req providers.PlanResourceChangeRequest) providers.PlanResourceChangeResponse {

--- a/internal/terraform/node_resource_abstract_instance.go
+++ b/internal/terraform/node_resource_abstract_instance.go
@@ -1926,7 +1926,7 @@ func (n *NodeAbstractResourceInstance) planDataSource(ctx EvalContext, checkRule
 	}
 
 	diags = diags.Append(readDiags)
-	if !diags.HasErrors() {
+	if !diags.HasErrors() && readDeferred == nil {
 		// Finally, let's make our new state.
 		plannedNewState = &states.ResourceInstanceObject{
 			Value:  newVal,

--- a/internal/terraform/node_resource_abstract_instance.go
+++ b/internal/terraform/node_resource_abstract_instance.go
@@ -1601,15 +1601,7 @@ func (n *NodeAbstractResourceInstance) readDataSource(ctx EvalContext, configVal
 		})
 
 		if resp.Deferred != nil {
-			deffered := ctx.Deferrals()
-			deffered.ReportResourceInstanceDeferred(n.Addr, resp.Deferred.Reason, &plans.ResourceInstanceChange{
-				Addr: n.Addr,
-				Change: plans.Change{
-					Action: plans.Read,
-					Before: cty.DynamicVal,
-					After:  resp.State,
-				},
-			})
+			ctx.Deferrals().ReportDataSourceInstanceDeferred(n.Addr)
 		}
 	}
 	diags = diags.Append(resp.Diagnostics.InConfigBody(config.Config, n.Addr.String()))


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->
Co-authored-by: Mark DeCrane <mark.decrane@hashicorp.com>

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.8.x

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

### NEW FEATURES

<!--

Write a short description of the user-facing change. Examples:

- `terraform show -json`: Fixed crash with sensitive set values.
- When rendering a diff, Terraform now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 

-  stacks: adding deferred action to datasource reads
