### PR TITLE
Update the Terraform CLI output to show logical separation between OPA and Sentinel policy evaluations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ ENHANCEMENTS:
 * `terraform console`: Now has basic support for multi-line input in interactive mode. ([#34822](https://github.com/hashicorp/terraform/pull/34822))
 
     If an entered line contains opening paretheses/etc that are not closed, Terraform will await another line of input to complete the expression. This initial implementation is primarily intended to support pasting in multi-line expressions from elsewhere, rather than for manual multi-line editing, so the interactive editing support is currently limited.
+* `cli`: Updates the Terraform CLI output to show logical separation between OPA and Sentinel policy evaluations
 
 BUG FIXES:
 

--- a/internal/cloud/backend_taskStage_policyEvaluation.go
+++ b/internal/cloud/backend_taskStage_policyEvaluation.go
@@ -45,7 +45,7 @@ func newPolicyEvaluationSummarizer(b *Cloud, ts *tfe.TaskStage) taskStageSummari
 
 func (pes *policyEvaluationSummarizer) Summarize(context *IntegrationContext, output IntegrationOutputWriter, ts *tfe.TaskStage) (bool, *string, error) {
 	if pes.counter == 0 {
-		//output.Output("[bold]Policy Evaluations\n")
+		output.Output("[bold]Policy Evaluations\n")
 		pes.counter++
 	}
 
@@ -122,6 +122,7 @@ func (pes *policyEvaluationSummarizer) taskStageWithPolicyEvaluation(context *In
 			result = fmt.Sprintf("[red]%s", strings.ToUpper(string(tfe.PolicyEvaluationFailed)))
 		}
 
+		output.Output("")
 		output.Output(fmt.Sprintf("[bold]%s Policy Evaluation\n", kind))
 		output.Output(fmt.Sprintf("[bold]%c%c Overall Result: %s", Arrow, Arrow, result))
 

--- a/internal/cloud/backend_taskStage_policyEvaluation.go
+++ b/internal/cloud/backend_taskStage_policyEvaluation.go
@@ -45,7 +45,7 @@ func newPolicyEvaluationSummarizer(b *Cloud, ts *tfe.TaskStage) taskStageSummari
 
 func (pes *policyEvaluationSummarizer) Summarize(context *IntegrationContext, output IntegrationOutputWriter, ts *tfe.TaskStage) (bool, *string, error) {
 	if pes.counter == 0 {
-		output.Output("[bold]OPA Policy Evaluation\n")
+		//output.Output("[bold]Policy Evaluations\n")
 		pes.counter++
 	}
 
@@ -103,20 +103,26 @@ func summarizePolicyEvaluationResults(policyEvaluations []*tfe.PolicyEvaluation)
 }
 
 func (pes *policyEvaluationSummarizer) taskStageWithPolicyEvaluation(context *IntegrationContext, output IntegrationOutputWriter, policyEvaluation []*tfe.PolicyEvaluation) error {
-	var result, message string
+	var result, message, kind string
 	// Currently only one policy evaluation supported : OPA
 	for _, polEvaluation := range policyEvaluation {
+		if polEvaluation.PolicyKind == "opa" {
+			kind = "OPA"
+		} else {
+			kind = "Sentinel"
+		}
 		if polEvaluation.Status == tfe.PolicyEvaluationPassed {
-			message = "[dim] This result means that all OPA policies passed and the protected behavior is allowed"
+			message = fmt.Sprintf("[dim] This result means that all %s policies passed and the protected behavior is allowed", kind)
 			result = fmt.Sprintf("[green]%s", strings.ToUpper(string(tfe.PolicyEvaluationPassed)))
 			if polEvaluation.ResultCount.AdvisoryFailed > 0 {
 				result += " (with advisory)"
 			}
 		} else {
-			message = "[dim] This result means that one or more OPA policies failed. More than likely, this was due to the discovery of violations by the main rule and other sub rules"
+			message = fmt.Sprintf("[dim] This result means that one or more %s policies failed. More than likely, this was due to the discovery of violations by the main rule and other sub rules", kind)
 			result = fmt.Sprintf("[red]%s", strings.ToUpper(string(tfe.PolicyEvaluationFailed)))
 		}
 
+		output.Output(fmt.Sprintf("[bold]%s Policy Evaluation\n", kind))
 		output.Output(fmt.Sprintf("[bold]%c%c Overall Result: %s", Arrow, Arrow, result))
 
 		output.Output(message)

--- a/internal/cloud/backend_taskStage_policyEvaluation_test.go
+++ b/internal/cloud/backend_taskStage_policyEvaluation_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/go-tfe"
 )
 
-func TestCloud_runTaskStageWithPolicyEvaluation(t *testing.T) {
+func TestCloud_runTaskStageWithOPAPolicyEvaluation(t *testing.T) {
 	b, bCleanup := testBackendWithName(t)
 	defer bCleanup()
 
@@ -27,7 +27,7 @@ func TestCloud_runTaskStageWithPolicyEvaluation(t *testing.T) {
 			taskStage: func() *tfe.TaskStage {
 				ts := &tfe.TaskStage{}
 				ts.PolicyEvaluations = []*tfe.PolicyEvaluation{
-					{ID: "pol-pass", ResultCount: &tfe.PolicyResultCount{Passed: 1}, Status: "passed"},
+					{ID: "pol-pass", ResultCount: &tfe.PolicyResultCount{Passed: 1}, Status: "passed", PolicyKind: "opa"},
 				}
 				return ts
 			},
@@ -40,7 +40,7 @@ func TestCloud_runTaskStageWithPolicyEvaluation(t *testing.T) {
 			taskStage: func() *tfe.TaskStage {
 				ts := &tfe.TaskStage{}
 				ts.PolicyEvaluations = []*tfe.PolicyEvaluation{
-					{ID: "pol-fail", ResultCount: &tfe.PolicyResultCount{MandatoryFailed: 1}, Status: "failed"},
+					{ID: "pol-fail", ResultCount: &tfe.PolicyResultCount{MandatoryFailed: 1}, Status: "failed", PolicyKind: "opa"},
 				}
 				return ts
 			},
@@ -53,7 +53,7 @@ func TestCloud_runTaskStageWithPolicyEvaluation(t *testing.T) {
 			taskStage: func() *tfe.TaskStage {
 				ts := &tfe.TaskStage{}
 				ts.PolicyEvaluations = []*tfe.PolicyEvaluation{
-					{ID: "adv-fail", ResultCount: &tfe.PolicyResultCount{AdvisoryFailed: 1}, Status: "failed"},
+					{ID: "adv-fail", ResultCount: &tfe.PolicyResultCount{AdvisoryFailed: 1}, Status: "failed", PolicyKind: "opa"},
 				}
 				return ts
 			},
@@ -66,7 +66,96 @@ func TestCloud_runTaskStageWithPolicyEvaluation(t *testing.T) {
 			taskStage: func() *tfe.TaskStage {
 				ts := &tfe.TaskStage{}
 				ts.PolicyEvaluations = []*tfe.PolicyEvaluation{
-					{ID: "adv-fail", ResultCount: &tfe.PolicyResultCount{Errored: 1}, Status: "unreachable"},
+					{ID: "adv-fail", ResultCount: &tfe.PolicyResultCount{Errored: 1}, Status: "unreachable", PolicyKind: "opa"},
+				}
+				return ts
+			},
+			writer:          writer,
+			context:         integrationContext,
+			expectedOutputs: []string{"Skipping policy evaluation."},
+			isError:         false,
+		},
+	}
+
+	for _, c := range cases {
+		c.writer.output.Reset()
+		trs := policyEvaluationSummarizer{
+			cloud: b,
+		}
+		c.context.Poll(0, 0, func(i int) (bool, error) {
+			cont, _, _ := trs.Summarize(c.context, c.writer, c.taskStage())
+			if cont {
+				return true, nil
+			}
+
+			output := c.writer.output.String()
+			for _, expected := range c.expectedOutputs {
+				if !strings.Contains(output, expected) {
+					t.Fatalf("Expected output to contain '%s' but it was:\n\n%s", expected, output)
+				}
+			}
+			return false, nil
+		})
+	}
+}
+
+func TestCloud_runTaskStageWithSentinelPolicyEvaluation(t *testing.T) {
+	b, bCleanup := testBackendWithName(t)
+	defer bCleanup()
+
+	integrationContext, writer := newMockIntegrationContext(b, t)
+
+	cases := map[string]struct {
+		taskStage       func() *tfe.TaskStage
+		context         *IntegrationContext
+		writer          *testIntegrationOutput
+		expectedOutputs []string
+		isError         bool
+	}{
+		"all-succeeded": {
+			taskStage: func() *tfe.TaskStage {
+				ts := &tfe.TaskStage{}
+				ts.PolicyEvaluations = []*tfe.PolicyEvaluation{
+					{ID: "pol-pass", ResultCount: &tfe.PolicyResultCount{Passed: 1}, Status: "passed", PolicyKind: "sentinel"},
+				}
+				return ts
+			},
+			writer:          writer,
+			context:         integrationContext,
+			expectedOutputs: []string{"│ [bold]Sentinel Policy Evaluation\n\n│ [bold]→→ Overall Result: [green]PASSED\n│ [dim] This result means that all Sentinel policies passed and the protected behavior is allowed\n│ 1 policies evaluated\n\n│ → Policy set 1: [bold]policy-set-that-passes (1)\n│   ↳ Policy name: [bold]policy-pass\n│      | [green][bold]✓ Passed\n│      | [dim]This policy will pass\n"},
+			isError:         false,
+		},
+		"mandatory-failed": {
+			taskStage: func() *tfe.TaskStage {
+				ts := &tfe.TaskStage{}
+				ts.PolicyEvaluations = []*tfe.PolicyEvaluation{
+					{ID: "pol-fail", ResultCount: &tfe.PolicyResultCount{MandatoryFailed: 1}, Status: "failed", PolicyKind: "sentinel"},
+				}
+				return ts
+			},
+			writer:          writer,
+			context:         integrationContext,
+			expectedOutputs: []string{"│ [bold]→→ Overall Result: [red]FAILED\n│ [dim] This result means that one or more Sentinel policies failed. More than likely, this was due to the discovery of violations by the main rule and other sub rules\n│ 1 policies evaluated\n\n│ → Policy set 1: [bold]policy-set-that-fails (1)\n│   ↳ Policy name: [bold]policy-fail\n│      | [red][bold]× Failed\n│      | [dim]This policy will fail"},
+			isError:         true,
+		},
+		"advisory-failed": {
+			taskStage: func() *tfe.TaskStage {
+				ts := &tfe.TaskStage{}
+				ts.PolicyEvaluations = []*tfe.PolicyEvaluation{
+					{ID: "adv-fail", ResultCount: &tfe.PolicyResultCount{AdvisoryFailed: 1}, Status: "failed", PolicyKind: "sentinel"},
+				}
+				return ts
+			},
+			writer:          writer,
+			context:         integrationContext,
+			expectedOutputs: []string{"│ [bold]Sentinel Policy Evaluation\n\n│ [bold]→→ Overall Result: [red]FAILED\n│ [dim] This result means that one or more Sentinel policies failed. More than likely, this was due to the discovery of violations by the main rule and other sub rules\n│ 1 policies evaluated\n\n│ → Policy set 1: [bold]policy-set-that-fails (1)\n│   ↳ Policy name: [bold]policy-fail\n│      | [blue][bold]Ⓘ Advisory\n│      | [dim]This policy will fail"},
+			isError:         false,
+		},
+		"unreachable": {
+			taskStage: func() *tfe.TaskStage {
+				ts := &tfe.TaskStage{}
+				ts.PolicyEvaluations = []*tfe.PolicyEvaluation{
+					{ID: "adv-fail", ResultCount: &tfe.PolicyResultCount{Errored: 1}, Status: "unreachable", PolicyKind: "sentinel"},
 				}
 				return ts
 			},


### PR DESCRIPTION
This PR updates the Terraform CLI output to show logical separation between OPA and Sentinel policy evaluations

## Draft CHANGELOG entry

### ENHANCEMENTS 
- Updates the Terraform CLI output to show logical separation between OPA and Sentinel policy evaluations

## Testing
- Unit tests
- E2E tests (screenshots below)
<img width="1366" alt="Screenshot 2024-04-02 at 1 32 02 pm" src="https://github.com/hashicorp/terraform/assets/17270065/a66c29f3-e473-4750-8de3-dd359fe79ab0">

<img width="1159" alt="Screenshot 2024-04-02 at 1 32 14 pm" src="https://github.com/hashicorp/terraform/assets/17270065/533dc726-2bd4-4476-96e9-b0bd00beb0a4">
