### PR TITLE
stacks: add deferrals to PlanResourceChange 

### DIFF
--- a/internal/plugin/grpc_provider.go
+++ b/internal/plugin/grpc_provider.go
@@ -483,6 +483,7 @@ func (p *GRPCProvider) PlanResourceChange(r providers.PlanResourceChangeRequest)
 		Config:           &proto.DynamicValue{Msgpack: configMP},
 		ProposedNewState: &proto.DynamicValue{Msgpack: propMP},
 		PriorPrivate:     r.PriorPrivate,
+		DeferralAllowed:  r.DeferralAllowed,
 	}
 
 	if metaSchema.Block != nil {
@@ -520,6 +521,8 @@ func (p *GRPCProvider) PlanResourceChange(r providers.PlanResourceChangeRequest)
 	resp.PlannedPrivate = protoResp.PlannedPrivate
 
 	resp.LegacyTypeSystem = protoResp.LegacyTypeSystem
+
+	resp.Deferred = convert.ProtoToDeferred(protoResp.Deferred)
 
 	return resp
 }

--- a/internal/plugin6/grpc_provider.go
+++ b/internal/plugin6/grpc_provider.go
@@ -472,6 +472,7 @@ func (p *GRPCProvider) PlanResourceChange(r providers.PlanResourceChangeRequest)
 		Config:           &proto6.DynamicValue{Msgpack: configMP},
 		ProposedNewState: &proto6.DynamicValue{Msgpack: propMP},
 		PriorPrivate:     r.PriorPrivate,
+		DeferralAllowed:  r.DeferralAllowed,
 	}
 
 	if metaSchema.Block != nil {
@@ -509,6 +510,8 @@ func (p *GRPCProvider) PlanResourceChange(r providers.PlanResourceChangeRequest)
 	resp.PlannedPrivate = protoResp.PlannedPrivate
 
 	resp.LegacyTypeSystem = protoResp.LegacyTypeSystem
+
+	resp.Deferred = convert.ProtoToDeferred(protoResp.Deferred)
 
 	return resp
 }

--- a/internal/providers/provider.go
+++ b/internal/providers/provider.go
@@ -324,6 +324,10 @@ type PlanResourceChangeRequest struct {
 	// each provider, and it should not be used without coordination with
 	// HashiCorp. It is considered experimental and subject to change.
 	ProviderMeta cty.Value
+
+	// DeferralAllowed signals that the provider is allowed to defer the
+	// changes. If set the caller needs to handle the deferred response.
+	DeferralAllowed bool
 }
 
 type PlanResourceChangeResponse struct {
@@ -349,6 +353,10 @@ type PlanResourceChangeResponse struct {
 	// otherwise fail due to this imprecise mapping. No other provider or SDK
 	// implementation is permitted to set this.
 	LegacyTypeSystem bool
+
+	// Deferred if present signals that the provider was not able to fully
+	// complete this operation and a susequent run is required.
+	Deferred *Deferred
 }
 
 type ApplyResourceChangeRequest struct {

--- a/internal/terraform/context_apply_deferred_test.go
+++ b/internal/terraform/context_apply_deferred_test.go
@@ -1831,7 +1831,7 @@ output "a" {
 					"deferred_resource_change": cty.ObjectVal(map[string]cty.Value{
 						"name":           cty.StringVal("deferred_resource_change"),
 						"upstream_names": cty.NullVal(cty.Set(cty.String)),
-						"output":         cty.StringVal("mark_for_replacement"),
+						"output":         cty.UnknownVal(cty.String),
 					}),
 				},
 
@@ -1904,7 +1904,7 @@ output "a" {
 					"deferred_resource_change": cty.ObjectVal(map[string]cty.Value{
 						"name":           cty.StringVal("deferred_resource_change"),
 						"upstream_names": cty.NullVal(cty.Set(cty.String)),
-						"output":         cty.StringVal("computed_output"),
+						"output":         cty.UnknownVal(cty.String),
 					}),
 				},
 

--- a/internal/terraform/context_apply_deferred_test.go
+++ b/internal/terraform/context_apply_deferred_test.go
@@ -2003,6 +2003,8 @@ output "a" {
 				},
 				inputs: map[string]cty.Value{},
 				wantPlanned: map[string]cty.Value{
+					// This is here because of the additional full plan run if
+					// the previous state is not empty (and refresh is not skipped).
 					"deferred_resource_change": cty.ObjectVal(map[string]cty.Value{
 						"name":           cty.StringVal("deferred_resource_change"),
 						"upstream_names": cty.NullVal(cty.Set(cty.String)),

--- a/internal/terraform/context_apply_deferred_test.go
+++ b/internal/terraform/context_apply_deferred_test.go
@@ -46,7 +46,7 @@ type deferredActionsTestStage struct {
 	wantPlanned map[string]cty.Value
 
 	// The values we want to be deferred within each cycle.
-	wantDeferred map[string]providers.DeferredReason
+	wantDeferred map[string]ExpectedDeferred
 
 	// The expected actions from the plan step.
 	wantActions map[string]plans.Action
@@ -70,6 +70,11 @@ type deferredActionsTestStage struct {
 	// buildOpts is an optional field, that lets the test specify additional
 	// options to be used when building the plan.
 	buildOpts func(opts *PlanOpts)
+}
+
+type ExpectedDeferred struct {
+	Reason providers.DeferredReason
+	Action plans.Action
 }
 
 var (
@@ -152,9 +157,9 @@ output "c" {
 					// The other resources will be deferred, so shouldn't
 					// have any action at this stage.
 				},
-				wantDeferred: map[string]providers.DeferredReason{
-					"test.b[\"*\"]": providers.DeferredReasonInstanceCountUnknown,
-					"test.c":        providers.DeferredReasonDeferredPrereq,
+				wantDeferred: map[string]ExpectedDeferred{
+					"test.b[\"*\"]": {Reason: providers.DeferredReasonInstanceCountUnknown, Action: plans.Create},
+					"test.c":        {Reason: providers.DeferredReasonDeferredPrereq, Action: plans.Create},
 				},
 				wantApplied: map[string]cty.Value{
 					"a": cty.ObjectVal(map[string]cty.Value{
@@ -260,7 +265,7 @@ output "c" {
 					`test.b["2"]`: plans.Create,
 					`test.c`:      plans.Create,
 				},
-				wantDeferred: make(map[string]providers.DeferredReason),
+				wantDeferred: make(map[string]ExpectedDeferred),
 				wantApplied: map[string]cty.Value{
 					// Since test.a is no-op, it isn't visited during apply. The
 					// other instances should all be applied, though.
@@ -369,7 +374,7 @@ output "c" {
 					`test.b["2"]`: plans.NoOp,
 					`test.c`:      plans.NoOp,
 				},
-				wantDeferred: make(map[string]providers.DeferredReason),
+				wantDeferred: make(map[string]ExpectedDeferred),
 				complete:     true,
 				// We won't execute an apply step in this stage, because the
 				// plan should be empty.
@@ -433,9 +438,9 @@ resource "test" "c" {
 				wantActions: map[string]plans.Action{
 					"test.a": plans.Create,
 				},
-				wantDeferred: map[string]providers.DeferredReason{
-					"test.b[\"*\"]": providers.DeferredReasonInstanceCountUnknown,
-					"test.c":        providers.DeferredReasonDeferredPrereq,
+				wantDeferred: map[string]ExpectedDeferred{
+					"test.b[\"*\"]": {Reason: providers.DeferredReasonInstanceCountUnknown, Action: plans.Create},
+					"test.c":        {Reason: providers.DeferredReasonDeferredPrereq, Action: plans.Create},
 				},
 				wantApplied: map[string]cty.Value{
 					"a": cty.ObjectVal(map[string]cty.Value{
@@ -489,7 +494,7 @@ resource "test" "c" {
 					`test.b[1]`: plans.Create,
 					`test.c`:    plans.Create,
 				},
-				wantDeferred: map[string]providers.DeferredReason{},
+				wantDeferred: map[string]ExpectedDeferred{},
 				complete:     true,
 				// Don't run an apply for this cycle.
 			},
@@ -550,9 +555,9 @@ output "names" {
 					}),
 				},
 				wantActions: map[string]plans.Action{},
-				wantDeferred: map[string]providers.DeferredReason{
-					"module.mod.test.names[\"*\"]": providers.DeferredReasonInstanceCountUnknown,
-					"test.a":                       providers.DeferredReasonDeferredPrereq,
+				wantDeferred: map[string]ExpectedDeferred{
+					"module.mod.test.names[\"*\"]": {Reason: providers.DeferredReasonInstanceCountUnknown, Action: plans.Create},
+					"test.a":                       {Reason: providers.DeferredReasonDeferredPrereq, Action: plans.Create},
 				},
 				wantApplied: make(map[string]cty.Value),
 				wantOutputs: make(map[string]cty.Value),
@@ -586,7 +591,7 @@ output "names" {
 					"module.mod.test.names[\"2\"]": plans.Create,
 					"test.a":                       plans.Create,
 				},
-				wantDeferred: map[string]providers.DeferredReason{},
+				wantDeferred: map[string]ExpectedDeferred{},
 				complete:     true,
 			},
 		},
@@ -692,8 +697,8 @@ resource "test" "c" {
 					"test.a": plans.CreateThenDelete,
 					"test.b": plans.DeleteThenCreate,
 				},
-				wantDeferred: map[string]providers.DeferredReason{
-					"test.c[\"*\"]": providers.DeferredReasonInstanceCountUnknown,
+				wantDeferred: map[string]ExpectedDeferred{
+					"test.c[\"*\"]": {Reason: providers.DeferredReasonInstanceCountUnknown, Action: plans.Create},
 				},
 			},
 		},
@@ -751,7 +756,7 @@ removed {
 					"test.a[0]": plans.Forget,
 					"test.a[1]": plans.Forget,
 				},
-				wantDeferred:  map[string]providers.DeferredReason{},
+				wantDeferred:  map[string]ExpectedDeferred{},
 				allowWarnings: true,
 				complete:      true,
 			},
@@ -791,8 +796,8 @@ import {
 					}),
 				},
 				wantActions: make(map[string]plans.Action),
-				wantDeferred: map[string]providers.DeferredReason{
-					"test.a[\"*\"]": providers.DeferredReasonInstanceCountUnknown,
+				wantDeferred: map[string]ExpectedDeferred{
+					"test.a[\"*\"]": {Reason: providers.DeferredReasonInstanceCountUnknown, Action: plans.Create},
 				},
 				wantApplied: make(map[string]cty.Value),
 				wantOutputs: make(map[string]cty.Value),
@@ -811,7 +816,7 @@ import {
 				wantActions: map[string]plans.Action{
 					"test.a[0]": plans.NoOp, // noop not create because of the import.
 				},
-				wantDeferred: map[string]providers.DeferredReason{},
+				wantDeferred: map[string]ExpectedDeferred{},
 				complete:     true,
 			},
 		},
@@ -867,8 +872,8 @@ resource "test" "c" {
 				wantActions: map[string]plans.Action{
 					"test.b": plans.Create,
 				},
-				wantDeferred: map[string]providers.DeferredReason{
-					"test.a[\"*\"]": providers.DeferredReasonInstanceCountUnknown,
+				wantDeferred: map[string]ExpectedDeferred{
+					"test.a[\"*\"]": {Reason: providers.DeferredReasonInstanceCountUnknown, Action: plans.Create},
 				},
 				allowWarnings: true,
 			},
@@ -900,8 +905,8 @@ resource "test" "c" {
 				wantActions: map[string]plans.Action{
 					"test.b": plans.Create,
 				},
-				wantDeferred: map[string]providers.DeferredReason{
-					"test.a[\"*\"]": providers.DeferredReasonInstanceCountUnknown,
+				wantDeferred: map[string]ExpectedDeferred{
+					"test.a[\"*\"]": {Reason: providers.DeferredReasonInstanceCountUnknown, Action: plans.Create},
 				},
 				allowWarnings: true,
 			},
@@ -1271,8 +1276,8 @@ resource "test" "c" {
 					"test.b": plans.DeleteThenCreate,
 					"test.c": plans.NoOp,
 				},
-				wantDeferred: map[string]providers.DeferredReason{
-					"test.a[\"*\"]": providers.DeferredReasonInstanceCountUnknown,
+				wantDeferred: map[string]ExpectedDeferred{
+					"test.a[\"*\"]": {Reason: providers.DeferredReasonInstanceCountUnknown, Action: plans.Create},
 				},
 			},
 		},
@@ -1332,8 +1337,8 @@ resource "test" "b" {
 				wantActions: map[string]plans.Action{
 					"test.b": plans.Create,
 				},
-				wantDeferred: map[string]providers.DeferredReason{
-					"test.a[\"*\"]": providers.DeferredReasonInstanceCountUnknown,
+				wantDeferred: map[string]ExpectedDeferred{
+					"test.a[\"*\"]": {Reason: providers.DeferredReasonInstanceCountUnknown, Action: plans.Create},
 				},
 				wantApplied: map[string]cty.Value{
 					"b": cty.ObjectVal(map[string]cty.Value{
@@ -1364,7 +1369,7 @@ resource "test" "b" {
 					"test.a[0]": plans.Create,
 					"test.b":    plans.NoOp,
 				},
-				wantDeferred: map[string]providers.DeferredReason{},
+				wantDeferred: map[string]ExpectedDeferred{},
 				complete:     true,
 			},
 		},
@@ -1456,8 +1461,8 @@ resource "test" "c" {
 				wantActions: map[string]plans.Action{
 					"test.b": plans.Create,
 				},
-				wantDeferred: map[string]providers.DeferredReason{
-					"test.c[\"*\"]": providers.DeferredReasonInstanceCountUnknown,
+				wantDeferred: map[string]ExpectedDeferred{
+					"test.c[\"*\"]": {Reason: providers.DeferredReasonInstanceCountUnknown, Action: plans.Create},
 				},
 				wantApplied: map[string]cty.Value{
 					"b": cty.ObjectVal(map[string]cty.Value{
@@ -1489,7 +1494,7 @@ resource "test" "c" {
 					"test.c[1]": plans.Delete,
 					"test.b":    plans.NoOp,
 				},
-				wantDeferred: map[string]providers.DeferredReason{},
+				wantDeferred: map[string]ExpectedDeferred{},
 				complete:     true,
 			},
 		},
@@ -1544,8 +1549,8 @@ output "a" {
 						"upstream_names": cty.NullVal(cty.Set(cty.String)),
 					}),
 				},
-				wantDeferred: map[string]providers.DeferredReason{
-					"test.a": providers.DeferredReasonProviderConfigUnknown,
+				wantDeferred: map[string]ExpectedDeferred{
+					"test.a": {Reason: providers.DeferredReasonProviderConfigUnknown, Action: plans.Read},
 				},
 				complete: false,
 			},
@@ -1574,8 +1579,8 @@ output "a" {
 						"output":         cty.NullVal(cty.String),
 					}),
 				},
-				wantDeferred: map[string]providers.DeferredReason{
-					"test.a": providers.DeferredReasonProviderConfigUnknown,
+				wantDeferred: map[string]ExpectedDeferred{
+					"test.a": {Reason: providers.DeferredReasonProviderConfigUnknown, Action: plans.Read},
 				},
 				complete: false,
 			},
@@ -1731,12 +1736,12 @@ func TestContextApply_deferredActions(t *testing.T) {
 						t.Errorf("wrong actions in plan\n%s", diff)
 					}
 
-					gotDeferred := make(map[string]providers.DeferredReason)
+					gotDeferred := make(map[string]ExpectedDeferred)
 					for _, dc := range plan.DeferredResources {
-						gotDeferred[dc.ChangeSrc.Addr.String()] = dc.DeferredReason
+						gotDeferred[dc.ChangeSrc.Addr.String()] = ExpectedDeferred{Reason: dc.DeferredReason, Action: dc.ChangeSrc.Action}
 					}
 					if diff := cmp.Diff(stage.wantDeferred, gotDeferred); diff != "" {
-						t.Errorf("wrong deferred reasons in plan\n%s", diff)
+						t.Errorf("wrong deferred reasons or actions in plan\n%s", diff)
 					}
 
 					if stage.wantApplied == nil {

--- a/internal/terraform/context_apply_deferred_test.go
+++ b/internal/terraform/context_apply_deferred_test.go
@@ -2328,16 +2328,10 @@ func (provider *deferredActionsProvider) Provider() providers.Interface {
 			}
 		},
 		ApplyResourceChangeFn: func(req providers.ApplyResourceChangeRequest) providers.ApplyResourceChangeResponse {
-			var key string
-			if v := req.Config.GetAttr("name"); v.IsKnown() {
-				key = req.Config.GetAttr("name").AsString()
-			} else {
-				key = "<unknown>"
-			}
-
+			key := req.Config.GetAttr("name").AsString()
 			newState := req.PlannedState
 
-			if req.PlannedState.IsKnown() && !req.PlannedState.IsNull() && !newState.GetAttr("output").IsKnown() {
+			if !newState.GetAttr("output").IsKnown() {
 				newStateValues := req.PlannedState.AsValueMap()
 				newStateValues["output"] = cty.StringVal(key)
 				newState = cty.ObjectVal(newStateValues)

--- a/internal/terraform/node_resource_abstract_instance.go
+++ b/internal/terraform/node_resource_abstract_instance.go
@@ -454,13 +454,9 @@ func (n *NodeAbstractResourceInstance) planDestroy(ctx EvalContext, currentState
 			return plan, deferred, diags
 		}
 
-		if resp.Deferred != nil {
-			return plan, deferred, diags
-		}
-
 		// Check that the provider returned a null value here, since that is the
 		// only valid value for a destroy plan.
-		if !resp.PlannedState.IsNull() {
+		if !resp.PlannedState.IsNull() && deferred == nil {
 			diags = diags.Append(tfdiags.Sourceless(
 				tfdiags.Error,
 				"Provider produced invalid plan",
@@ -956,7 +952,7 @@ func (n *NodeAbstractResourceInstance) plan(
 			Change: plans.Change{
 				Action: action,
 				Before: priorVal,
-				After:  origConfigVal,
+				After:  unmarkedConfigVal,
 			},
 		})
 		return nil, nil, keyData, diags

--- a/internal/terraform/node_resource_abstract_instance.go
+++ b/internal/terraform/node_resource_abstract_instance.go
@@ -955,8 +955,8 @@ func (n *NodeAbstractResourceInstance) plan(
 			Addr: n.Addr,
 			Change: plans.Change{
 				Action: action,
-				Before: unmarkedPriorVal,
-				After:  unmarkedConfigVal,
+				Before: priorVal,
+				After:  origConfigVal,
 			},
 		})
 		return nil, nil, keyData, diags

--- a/internal/terraform/node_resource_abstract_instance.go
+++ b/internal/terraform/node_resource_abstract_instance.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/hashicorp/hcl/v2"
+	tfaddr "github.com/hashicorp/terraform-registry-address"
 	"github.com/zclconf/go-cty/cty"
 
 	"github.com/hashicorp/terraform/internal/addrs"
@@ -1023,64 +1024,10 @@ func (n *NodeAbstractResourceInstance) plan(
 		plannedNewVal = plannedNewVal.MarkWithPaths(unmarkedPaths)
 	}
 
-	// The provider produces a list of paths to attributes whose changes mean
-	// that we must replace rather than update an existing remote object.
-	// However, we only need to do that if the identified attributes _have_
-	// actually changed -- particularly after we may have undone some of the
-	// changes in processIgnoreChanges -- so now we'll filter that list to
-	// include only where changes are detected.
-	reqRep := cty.NewPathSet()
-	if len(resp.RequiresReplace) > 0 {
-		for _, path := range resp.RequiresReplace {
-			if priorVal.IsNull() {
-				// If prior is null then we don't expect any RequiresReplace at all,
-				// because this is a Create action.
-				continue
-			}
-
-			priorChangedVal, priorPathDiags := hcl.ApplyPath(unmarkedPriorVal, path, nil)
-			plannedChangedVal, plannedPathDiags := hcl.ApplyPath(plannedNewVal, path, nil)
-			if plannedPathDiags.HasErrors() && priorPathDiags.HasErrors() {
-				// This means the path was invalid in both the prior and new
-				// values, which is an error with the provider itself.
-				diags = diags.Append(tfdiags.Sourceless(
-					tfdiags.Error,
-					"Provider produced invalid plan",
-					fmt.Sprintf(
-						"Provider %q has indicated \"requires replacement\" on %s for a non-existent attribute path %#v.\n\nThis is a bug in the provider, which should be reported in the provider's own issue tracker.",
-						n.ResolvedProvider.Provider, n.Addr, path,
-					),
-				))
-				continue
-			}
-
-			// Make sure we have valid Values for both values.
-			// Note: if the opposing value was of the type
-			// cty.DynamicPseudoType, the type assigned here may not exactly
-			// match the schema. This is fine here, since we're only going to
-			// check for equality, but if the NullVal is to be used, we need to
-			// check the schema for th true type.
-			switch {
-			case priorChangedVal == cty.NilVal && plannedChangedVal == cty.NilVal:
-				// this should never happen without ApplyPath errors above
-				panic("requires replace path returned 2 nil values")
-			case priorChangedVal == cty.NilVal:
-				priorChangedVal = cty.NullVal(plannedChangedVal.Type())
-			case plannedChangedVal == cty.NilVal:
-				plannedChangedVal = cty.NullVal(priorChangedVal.Type())
-			}
-
-			// Unmark for this value for the equality test. If only sensitivity has changed,
-			// this does not require an Update or Replace
-			unmarkedPlannedChangedVal, _ := plannedChangedVal.UnmarkDeep()
-			eqV := unmarkedPlannedChangedVal.Equals(priorChangedVal)
-			if !eqV.IsKnown() || eqV.False() {
-				reqRep.Add(path)
-			}
-		}
-		if diags.HasErrors() {
-			return nil, nil, keyData, diags
-		}
+	reqRep, reqRepDiags := getRequiredReplaces(priorVal, plannedNewVal, resp.RequiresReplace, n.ResolvedProvider.Provider, n.Addr)
+	diags = diags.Append(reqRepDiags)
+	if diags.HasErrors() {
+		return nil, nil, keyData, diags
 	}
 
 	action, actionReason := getAction(n.Addr, priorVal, plannedNewVal, createBeforeDestroy, forceReplace, reqRep)
@@ -2740,4 +2687,74 @@ func getAction(addr addrs.AbsResourceInstance, priorVal, plannedNewVal cty.Value
 	}
 
 	return
+}
+
+// getRequiredReplaces returns a list of paths to attributes whose changes mean
+// that we must replace rather than update an existing remote object.
+//
+// The provider produces a list of paths to attributes whose changes mean
+// that we must replace rather than update an existing remote object.
+// However, we only need to do that if the identified attributes _have_
+// actually changed -- particularly after we may have undone some of the
+// changes in processIgnoreChanges -- so now we'll filter that list to
+// include only where changes are detected.
+func getRequiredReplaces(priorVal, plannedNewVal cty.Value, requiredReplaces []cty.Path, providerAddr tfaddr.Provider, addr addrs.AbsResourceInstance) (cty.PathSet, tfdiags.Diagnostics) {
+	var diags tfdiags.Diagnostics
+	unmarkedPriorVal, _ := priorVal.UnmarkDeepWithPaths()
+
+	reqRep := cty.NewPathSet()
+	if len(requiredReplaces) > 0 {
+		for _, path := range requiredReplaces {
+			if priorVal.IsNull() {
+				// If prior is null then we don't expect any RequiresReplace at all,
+				// because this is a Create action.
+				continue
+			}
+
+			priorChangedVal, priorPathDiags := hcl.ApplyPath(unmarkedPriorVal, path, nil)
+			plannedChangedVal, plannedPathDiags := hcl.ApplyPath(plannedNewVal, path, nil)
+			if plannedPathDiags.HasErrors() && priorPathDiags.HasErrors() {
+				// This means the path was invalid in both the prior and new
+				// values, which is an error with the provider itself.
+				diags = diags.Append(tfdiags.Sourceless(
+					tfdiags.Error,
+					"Provider produced invalid plan",
+					fmt.Sprintf(
+						"Provider %q has indicated \"requires replacement\" on %s for a non-existent attribute path %#v.\n\nThis is a bug in the provider, which should be reported in the provider's own issue tracker.",
+						providerAddr, addr, path,
+					),
+				))
+				continue
+			}
+
+			// Make sure we have valid Values for both values.
+			// Note: if the opposing value was of the type
+			// cty.DynamicPseudoType, the type assigned here may not exactly
+			// match the schema. This is fine here, since we're only going to
+			// check for equality, but if the NullVal is to be used, we need to
+			// check the schema for th true type.
+			switch {
+			case priorChangedVal == cty.NilVal && plannedChangedVal == cty.NilVal:
+				// this should never happen without ApplyPath errors above
+				panic("requires replace path returned 2 nil values")
+			case priorChangedVal == cty.NilVal:
+				priorChangedVal = cty.NullVal(plannedChangedVal.Type())
+			case plannedChangedVal == cty.NilVal:
+				plannedChangedVal = cty.NullVal(priorChangedVal.Type())
+			}
+
+			// Unmark for this value for the equality test. If only sensitivity has changed,
+			// this does not require an Update or Replace
+			unmarkedPlannedChangedVal, _ := plannedChangedVal.UnmarkDeep()
+			eqV := unmarkedPlannedChangedVal.Equals(priorChangedVal)
+			if !eqV.IsKnown() || eqV.False() {
+				reqRep.Add(path)
+			}
+		}
+		if diags.HasErrors() {
+			return reqRep, diags
+		}
+	}
+
+	return reqRep, diags
 }

--- a/internal/terraform/node_resource_destroy_deposed.go
+++ b/internal/terraform/node_resource_destroy_deposed.go
@@ -174,11 +174,8 @@ func (n *NodePlanDeposedResourceInstanceObject) Execute(ctx EvalContext, op walk
 		}
 		if deferred != nil {
 			ctx.Deferrals().ReportResourceInstanceDeferred(n.Addr, deferred.Reason, &plans.ResourceInstanceChange{
-				Addr: n.Addr,
-				Change: plans.Change{
-					Action: plans.Delete,
-					Before: state.Value,
-				},
+				Addr:   n.Addr,
+				Change: change.Change,
 			})
 			return diags
 		}
@@ -295,11 +292,8 @@ func (n *NodeDestroyDeposedResourceInstanceObject) Execute(ctx EvalContext, op w
 
 	if deferred != nil {
 		ctx.Deferrals().ReportResourceInstanceDeferred(n.Addr, deferred.Reason, &plans.ResourceInstanceChange{
-			Addr: n.Addr,
-			Change: plans.Change{
-				Action: plans.Delete,
-				Before: state.Value,
-			},
+			Addr:   n.Addr,
+			Change: change.Change,
 		})
 		return diags
 	}

--- a/internal/terraform/node_resource_plan_destroy.go
+++ b/internal/terraform/node_resource_plan_destroy.go
@@ -98,11 +98,8 @@ func (n *NodePlanDestroyableResourceInstance) managedResourceExecute(ctx EvalCon
 
 	if deferred != nil {
 		ctx.Deferrals().ReportResourceInstanceDeferred(n.Addr, deferred.Reason, &plans.ResourceInstanceChange{
-			Addr: n.Addr,
-			Change: plans.Change{
-				Action: plans.Delete,
-				Before: state.Value,
-			},
+			Addr:   n.Addr,
+			Change: change.Change,
 		})
 		return diags
 	}

--- a/internal/terraform/node_resource_plan_orphan.go
+++ b/internal/terraform/node_resource_plan_orphan.go
@@ -181,7 +181,10 @@ func (n *NodePlannableResourceInstanceOrphan) managedResourceExecute(ctx EvalCon
 	// We might be able to offer an approximate reason for why we are
 	// planning to delete this object. (This is best-effort; we might
 	// sometimes not have a reason.)
-	change.ActionReason = n.deleteActionReason(ctx)
+	// The change can be nil in case of deferred destroys.
+	if change != nil {
+		change.ActionReason = n.deleteActionReason(ctx)
+	}
 
 	// We intentionally write the change before the subsequent checks, because
 	// all of the checks below this point are for problems caused by the

--- a/internal/terraform/node_resource_plan_orphan.go
+++ b/internal/terraform/node_resource_plan_orphan.go
@@ -175,11 +175,8 @@ func (n *NodePlannableResourceInstanceOrphan) managedResourceExecute(ctx EvalCon
 
 		if deferred != nil {
 			ctx.Deferrals().ReportResourceInstanceDeferred(n.Addr, deferred.Reason, &plans.ResourceInstanceChange{
-				Addr: n.Addr,
-				Change: plans.Change{
-					Action: plans.Delete,
-					Before: oldState.Value,
-				},
+				Addr:   n.Addr,
+				Change: change.Change,
 			})
 			return diags
 		}


### PR DESCRIPTION
I would recommend reviewing this on a commit-by-commit basis since I included a refactoring.
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Co-authored-by: Mutahhir Hayat <mutahhir.hayat@hashicorp.com>

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.8.x

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

### NEW FEATURES

<!--

Write a short description of the user-facing change. Examples:

- `terraform show -json`: Fixed crash with sensitive set values.
- When rendering a diff, Terraform now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 

-  stacks: add deferrals to PlanResourceChange
