### PR TITLE
Complete implementation of targeting with deferred resources

### DIFF
--- a/internal/addrs/partial_expanded_test.go
+++ b/internal/addrs/partial_expanded_test.go
@@ -1,0 +1,112 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package addrs
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestPartialExpandedResourceIsTargetedBy(t *testing.T) {
+
+	tcs := []struct {
+		per    string
+		target string
+		want   bool
+	}{
+		{
+			"test.a",
+			"test.a",
+			true,
+		},
+		{
+			"test.a",
+			"test.a[0]",
+			true,
+		},
+		{
+			"test.a[\"*\"]",
+			"test.a",
+			true,
+		},
+		{
+			"test.a[\"*\"]",
+			"test.a[0]",
+			true,
+		},
+		{
+			"test.a[\"*\"]",
+			"test.a[\"key\"]",
+			true,
+		},
+		{
+			"module.mod.test.a",
+			"module.mod.test.a",
+			true,
+		},
+		{
+			"module.mod[1].test.a",
+			"module.mod[0].test.a",
+			false,
+		},
+		{
+			"module.mod.test.a[\"*\"]",
+			"module.mod.test.a",
+			true,
+		},
+		{
+			"module.mod.test.a[\"*\"]",
+			"module.mod.test.a[0]",
+			true,
+		},
+		{
+			"module.mod.test.a[\"*\"]",
+			"module.mod.test.a[\"key\"]",
+			true,
+		},
+		{
+			"module.mod.test.a[\"*\"]",
+			"module.mod[0].test.a",
+			false,
+		},
+		{
+			"module.mod[1].test.a[\"*\"]",
+			"module.mod[\"key\"].test.a[0]",
+			false,
+		},
+		{
+			"module.mod[\"*\"].test.a",
+			"module.mod.test.a",
+			true,
+		},
+		{
+			"module.mod[\"*\"].test.a",
+			"module.mod.test.a[0]",
+			true,
+		},
+		{
+			"module.mod[\"*\"].test.a",
+			"module.mod[0].test.a",
+			true,
+		},
+		{
+			"module.mod[\"*\"].test.a",
+			"module.mod[\"key\"].test.a",
+			true,
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(fmt.Sprintf("PartialResource(%q).IsTargetedBy(%q)", tc.per, tc.target), func(t *testing.T) {
+			per := mustParseAbsResourceInstanceStr(tc.per).PartialResource()
+			target := mustParseTarget(tc.target)
+
+			got := per.IsTargetedBy(target)
+			if got != tc.want {
+				t.Errorf("PartialResource(%q).IsTargetedBy(%q): got %v; want %v", tc.per, tc.target, got, tc.want)
+			}
+		})
+	}
+
+}

--- a/internal/terraform/context_apply.go
+++ b/internal/terraform/context_apply.go
@@ -277,6 +277,7 @@ func (c *Context) applyGraph(plan *plans.Plan, config *configs.Config, opts *App
 	graph, moreDiags := (&ApplyGraphBuilder{
 		Config:                  config,
 		Changes:                 plan.Changes,
+		DeferredChanges:         plan.DeferredResources,
 		State:                   plan.PriorState,
 		RootVariableValues:      variables,
 		ExternalProviderConfigs: externalProviderConfigs,

--- a/internal/terraform/graph_builder_apply.go
+++ b/internal/terraform/graph_builder_apply.go
@@ -27,6 +27,10 @@ type ApplyGraphBuilder struct {
 	// Changes describes the changes that we need apply.
 	Changes *plans.Changes
 
+	// DeferredChanges describes the changes that were deferred during the plan
+	// and should not be applied.
+	DeferredChanges []*plans.DeferredResourceInstanceChangeSrc
+
 	// State is the current state
 	State *states.State
 
@@ -133,6 +137,11 @@ func (b *ApplyGraphBuilder) Steps() []GraphTransformer {
 			State:    b.State,
 			Changes:  b.Changes,
 			Config:   b.Config,
+		},
+
+		// Creates nodes for all the deferred changes.
+		&DeferredTransformer{
+			DeferredChanges: b.DeferredChanges,
 		},
 
 		// Add nodes and edges for check block assertions. Check block data

--- a/internal/terraform/node_resource_apply.go
+++ b/internal/terraform/node_resource_apply.go
@@ -14,6 +14,8 @@ import (
 // NodeApplyableResource nodes into their respective modules.
 type nodeExpandApplyableResource struct {
 	*NodeAbstractResource
+
+	PartialExpansions []addrs.PartialExpandedResource
 }
 
 var (
@@ -47,10 +49,35 @@ func (n *nodeExpandApplyableResource) Name() string {
 }
 
 func (n *nodeExpandApplyableResource) Execute(globalCtx EvalContext, op walkOperation) tfdiags.Diagnostics {
+
+	// TODO: When validating support for modules (TF-13952), we should check
+	// here if the whole module is partially expanded and skip the .ExpandModule
+	// call below.
+	//
+	//  for _, per := range n.PartialExpansions {
+	//    if _, ok := per.PartialExpandedModule(); ok {
+	//      return nil // don't even try to expand the modules
+	//    }
+	//  }
+	//
+	//  The above checks if the module is partially expanded and if it is, it
+	//  skips the expansion of the module. This isn't implemented yet, because
+	//  partial module expansion is not implemented properly yet.
+
 	var diags tfdiags.Diagnostics
 	expander := globalCtx.InstanceExpander()
 	moduleInstances := expander.ExpandModule(n.Addr.Module)
+Insts:
 	for _, module := range moduleInstances {
+
+		// First check if this resource in this module instance in part of a
+		// partial expansion. If it is, we can't and don't need to expand it.
+		for _, per := range n.PartialExpansions {
+			if per.MatchesResource(n.Addr.Absolute(module)) {
+				continue Insts
+			}
+		}
+
 		moduleCtx := evalContextForModuleInstance(globalCtx, module)
 		diags = diags.Append(n.writeResourceState(moduleCtx, n.Addr.Resource.Absolute(module)))
 	}

--- a/internal/terraform/node_resource_apply_deferred.go
+++ b/internal/terraform/node_resource_apply_deferred.go
@@ -1,0 +1,26 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package terraform
+
+import "github.com/hashicorp/terraform/internal/addrs"
+
+// nodeApplyableDeferredInstance is a node that represents a deferred instance
+// in the apply graph. This node is targetable and helps maintain the correct
+// ordering of the apply graph.
+//
+// Note, that it does not implement Execute, as deferred instances are not
+// executed during the apply phase.
+type nodeApplyableDeferredInstance struct {
+	*NodeAbstractResourceInstance
+}
+
+// nodeApplyableDeferredPartialInstance is a node that represents a deferred
+// partial instance in the apply graph. This simply adds a method  to get the
+// partial address on top of the regular behaviour of
+// nodeApplyableDeferredInstance.
+type nodeApplyableDeferredPartialInstance struct {
+	*nodeApplyableDeferredInstance
+
+	PartialAddr addrs.PartialExpandedResource
+}

--- a/internal/terraform/node_resource_partial_plan.go
+++ b/internal/terraform/node_resource_partial_plan.go
@@ -44,12 +44,6 @@ func (n *nodeExpandPlannableResource) dynamicExpandPartial(ctx EvalContext, know
 		maybeOrphanResources = maybeOrphanResources.Union(maybeOrphans)
 	}
 
-	// TODO: What about targeting and force replacement for these resources?
-	//   For now, it actually kind of works out because we don't want to make
-	//   any changes for these and that's what happens. Later, when we start
-	//   tracking deferrals in the plan, we'll need to make sure that the
-	//   targeting is applied properly.
-
 	for _, moduleAddr := range partialModules {
 		resourceAddr := moduleAddr.Resource(n.Addr.Resource)
 		partialResources.Add(resourceAddr)

--- a/internal/terraform/transform_deferred.go
+++ b/internal/terraform/transform_deferred.go
@@ -1,0 +1,62 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package terraform
+
+import (
+	"github.com/hashicorp/terraform/internal/plans"
+	"github.com/hashicorp/terraform/internal/providers"
+)
+
+// DeferredTransformer is a GraphTransformer that adds graph nodes representing
+// each of the deferred changes to the graph.
+//
+// Deferred changes are not executed during the apply phase, but they are
+// tracked in the graph to ensure that the correct ordering is maintained and
+// the target flags are correctly applied.
+type DeferredTransformer struct {
+	DeferredChanges []*plans.DeferredResourceInstanceChangeSrc
+}
+
+func (t *DeferredTransformer) Transform(g *Graph) error {
+	if t.DeferredChanges == nil || len(t.DeferredChanges) == 0 {
+		return nil
+	}
+
+	for _, change := range t.DeferredChanges {
+		node := &nodeApplyableDeferredInstance{
+			NodeAbstractResourceInstance: NewNodeAbstractResourceInstance(change.ChangeSrc.Addr),
+		}
+
+		// Create a special node for partial instances, that handles the
+		// addresses a little differently.
+		if change.DeferredReason == providers.DeferredReasonInstanceCountUnknown {
+			per := change.ChangeSrc.Addr.PartialResource()
+
+			// This is a partial instance, so we need to create a partial node
+			// instead of a full instance node.
+			g.Add(&nodeApplyableDeferredPartialInstance{
+				nodeApplyableDeferredInstance: node,
+				PartialAddr:                   per,
+			})
+
+			// Now we want to find the expansion node that would be applied for
+			// this resource, and tell it that it is performing a partial
+			// expansion.
+			for _, v := range g.Vertices() {
+				if n, ok := v.(*nodeExpandApplyableResource); ok {
+					if per.ConfigResource().Equal(n.Addr) {
+						n.PartialExpansions = append(n.PartialExpansions, per)
+					}
+				}
+			}
+
+			continue
+		}
+
+		// Otherwise, just add the normal deferred instance node.
+		g.Add(node)
+	}
+
+	return nil
+}

--- a/internal/terraform/transform_targets.go
+++ b/internal/terraform/transform_targets.go
@@ -126,13 +126,30 @@ func (t *TargetsTransformer) selectTargetedNodes(g *Graph, addrs []addrs.Targeta
 func (t *TargetsTransformer) nodeIsTarget(v dag.Vertex, targets []addrs.Targetable) bool {
 	var vertexAddr addrs.Targetable
 	switch r := v.(type) {
+	case *nodeApplyableDeferredPartialInstance:
+
+		// Partial instances are not targeted directly, but they might be
+		// targeted after they have been expanded so we need to perform a custom
+		// check for them here.
+		//
+		// The other types of nodes can be targeted directly, and are handled
+		// together.
+
+		for _, targetAddr := range targets {
+			if r.PartialAddr.IsTargetedBy(targetAddr) {
+				return true
+			}
+		}
+		return false
+
 	case GraphNodeResourceInstance:
 		vertexAddr = r.ResourceInstanceAddr()
 	case GraphNodeConfigResource:
 		vertexAddr = r.ResourceAddr()
 
 	default:
-		// Only resource and resource instance nodes can be targeted.
+		// Only partial nodes and resource and resource instance nodes can be
+		// targeted.
 		return false
 	}
 


### PR DESCRIPTION
This PR completes the implementation of targeting deferred resources.

We've added a new type of node to the apply graph, which holds the deferred resources. The deferred resources do not implement an `Execute` function, so they make no changes to the state or the underlying cloud providers. They do implement the `GraphNodeReferencer` and `GraphNodeReferenceable` interfaces, that ensure the apply graph now contains a representation for deferred resources that allow the `TargetsTransformer` to correctly include any dependencies of deferred changes that have been targeted. We will also use these new deferred nodes in an upcoming PR for calculating the correct outputs.

In addition, the `DeferredTransformer` updates the node expanders to skip expansion for partial resources. This saves us having to reimplement the expansion logic, and doesn't matter anyway as the unexpanded resources are not executed. Also, there's a tweak to the targeting logic so that it can actually target the partially expanded resource addresses from the plan.