### PR TITLE
terraform test: Another round of the JUnit XML output experiment

### DIFF
--- a/internal/backend/local/test.go
+++ b/internal/backend/local/test.go
@@ -349,7 +349,9 @@ func (runner *TestFileRunner) Test(file *moduletest.File) {
 			}
 		}
 
+		startTime := time.Now()
 		state, updatedState := runner.run(run, file, runner.RelevantStates[key].State, config)
+		runDuration := time.Since(startTime)
 		if updatedState {
 			// Only update the most recent run and state if the state was
 			// actually updated by this change. We want to use the run that
@@ -359,6 +361,11 @@ func (runner *TestFileRunner) Test(file *moduletest.File) {
 			runner.RelevantStates[key].Run = run
 		}
 
+		// If we got far enough to actually execute the run then we'll give
+		// the view some additional metadata about the execution.
+		run.ExecutionMeta = &moduletest.RunExecutionMeta{
+			Duration: runDuration,
+		}
 		runner.Suite.View.Run(run, file, moduletest.Complete, 0)
 		file.Status = file.Status.Merge(run.Status)
 	}

--- a/internal/command/views/test.go
+++ b/internal/command/views/test.go
@@ -886,6 +886,19 @@ func junitXMLTestReport(suite *moduletest.Suite) ([]byte, error) {
 				Failure   *WithMessage `xml:"failure,omitempty"`
 				Error     *WithMessage `xml:"error,omitempty"`
 				Stderr    *WithMessage `xml:"system-err,omitempty"`
+
+				// RunTime is the time spent executing the run associated
+				// with this test case, in seconds with the fractional component
+				// representing partial seconds.
+				//
+				// We assume here that it's not practically possible for an
+				// execution to take literally zero fractional seconds at
+				// the accuracy we're using here (nanoseconds converted into
+				// floating point seconds) and so use zero to represent
+				// "not known", and thus omit that case. (In practice many
+				// JUnit XML consumers treat the absense of this attribute
+				// as zero anyway.)
+				RunTime float64 `xml:"time,attr,omitempty"`
 			}
 
 			testCase := TestCase{
@@ -897,6 +910,9 @@ func junitXMLTestReport(suite *moduletest.Suite) ([]byte, error) {
 				// some consumers of JUnit XML that were designed for
 				// Java-shaped languages.
 				Classname: file.Name,
+			}
+			if execMeta := run.ExecutionMeta; execMeta != nil {
+				testCase.RunTime = execMeta.Duration.Seconds()
 			}
 			switch run.Status {
 			case moduletest.Skip:

--- a/internal/command/views/test.go
+++ b/internal/command/views/test.go
@@ -880,15 +880,23 @@ func junitXMLTestReport(suite *moduletest.Suite) ([]byte, error) {
 				Body    string `xml:",cdata"`
 			}
 			type TestCase struct {
-				Name    string       `xml:"name,attr"`
-				Skipped *WithMessage `xml:"skipped,omitempty"`
-				Failure *WithMessage `xml:"failure,omitempty"`
-				Error   *WithMessage `xml:"error,omitempty"`
-				Stderr  *WithMessage `xml:"system-err,omitempty"`
+				Name      string       `xml:"name,attr"`
+				Classname string       `xml:"classname,attr"`
+				Skipped   *WithMessage `xml:"skipped,omitempty"`
+				Failure   *WithMessage `xml:"failure,omitempty"`
+				Error     *WithMessage `xml:"error,omitempty"`
+				Stderr    *WithMessage `xml:"system-err,omitempty"`
 			}
 
 			testCase := TestCase{
 				Name: run.Name,
+
+				// We treat the test scenario filename as the "class name",
+				// implying that the run name is the "method name", just
+				// because that seems to inspire more useful rendering in
+				// some consumers of JUnit XML that were designed for
+				// Java-shaped languages.
+				Classname: file.Name,
 			}
 			switch run.Status {
 			case moduletest.Skip:

--- a/internal/moduletest/run.go
+++ b/internal/moduletest/run.go
@@ -5,6 +5,7 @@ package moduletest
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/hashicorp/hcl/v2"
 
@@ -27,6 +28,22 @@ type Run struct {
 	Status Status
 
 	Diagnostics tfdiags.Diagnostics
+
+	// ExecutionMeta captures metadata about how the test run was executed.
+	//
+	// This field is not always populated. A run that has never been executed
+	// will definitely have a nil value for this field. A run that was
+	// executed may or may not populate this field, depending on exactly what
+	// happened during the run execution. Callers accessing this field MUST
+	// check for nil and handle that case in some reasonable way.
+	//
+	// Executing the same run multiple times may or may not update this field
+	// on each execution.
+	ExecutionMeta *RunExecutionMeta
+}
+
+type RunExecutionMeta struct {
+	Duration time.Duration
 }
 
 // Verbose is a utility struct that holds all the information required for a run


### PR DESCRIPTION
In https://github.com/hashicorp/terraform/pull/34291 we introduced an experimental option for `terraform test` to produce JUnit XML output, in the hope of collecting feedback to eventually resolve https://github.com/hashicorp/terraform/issues/34264.

The first round of experiment yielded some good information about how different JUnit XML-consuming software expects the data to be structured. As expected, because this format was designed for Java there are various different ways to map non-object-oriented language concepts onto it, and thus we didn't quite nail it on the first round.

This second round makes two changes in response to the feedback:
- The test scenario filename also gets populated into the `classname` attribute of each test case, in addition to its previous placement as the name of a test suite, because some consuming software seems to ignore test suites entirely and uses the test runs exclusively.

    Although the name "classname" suggests a Java class, in practice this seems to have been interpreted as something more general like "test group name", and so now the `classname` and `name` fields together uniquely identify a test run, and software can use the `classname` to group the test runs by which scenario file they were defined in.
- We now set the `time` attribute for each run to the duration of the run execution in fractional seconds. It appears that in most software this field is effectively required, in that its absence is treated as `time="0"` rather than as "time unspecified".

    This meant extending the test runner to actually measure the time and record it as a new field in the internal run model, which the JUnit XML renderer then reacts to. Since this remains just experimental I only did that for the local test runner. If this experiment is successful then we'll need to figure out how to plumb all this through the Terraform Cloud remote test execution environment too, but the focus for now is only on learning what JUnit XML structure makes sense, so we'll keep the experiment limited to local execution to allow iterating more quickly.

This PR does _not_ address the third main piece of feedback about including the specific test failure messages in the failure message instead of just a fixed placeholder message. That would require some more invasive changes to how the test runner recognizes and reports test failures as opposed to execution errors. However, it's already clear where in the JUnit XML structure that information would go, and so I think we can safely assume that we'll be able to do that at some later point without changing any other details of the output.

The option still remains experimental, so my intention for merging it would be to ask those who gave feedback the first time to try again once we have an alpha release containing this update. If that feedback suggests that we're on the right track, then we can start discussion about when and how to implement this "for real", with a more maintainable implementation approach and with the requisite support from Terraform Cloud's remote test execution environment.
