### PR TITLE
Fix panics due to missing graph edges on empty modules or invalid refs

### DIFF
--- a/internal/terraform/context_apply2_test.go
+++ b/internal/terraform/context_apply2_test.go
@@ -2893,3 +2893,35 @@ resource "test_object" "a" {
 		t.Errorf("Unexpected %s change for %s", c.Action, c.Addr)
 	}
 }
+
+// This test explicitly reproduces the issue described in #34976.
+func TestContext2Apply_34976(t *testing.T) {
+	m := testModuleInline(t, map[string]string{
+		"main.tf": `
+module "a" {
+  source = "./mod"
+  count = 1
+}
+
+resource "test_object" "obj" {
+  test_number = length(module.a)
+}
+`,
+		"mod/main.tf": ``, // just an empty module
+	})
+
+	p := simpleMockProvider()
+
+	ctx := testContext2(t, &ContextOpts{
+		Providers: map[addrs.Provider]providers.Factory{
+			addrs.NewDefaultProvider("test"): testProviderFuncFixed(p),
+		},
+	})
+
+	plan, diags := ctx.Plan(m, states.NewState(), SimplePlanOpts(plans.NormalMode, testInputValuesUnset(m.Module.Variables)))
+	assertNoErrors(t, diags)
+
+	// Just don't crash.
+	_, diags = ctx.Apply(plan, m, nil)
+	assertNoErrors(t, diags)
+}

--- a/internal/terraform/node_module_expand.go
+++ b/internal/terraform/node_module_expand.go
@@ -26,6 +26,7 @@ type nodeExpandModule struct {
 
 var (
 	_ GraphNodeExecutable       = (*nodeExpandModule)(nil)
+	_ GraphNodeReferenceable    = (*nodeExpandModule)(nil)
 	_ GraphNodeReferencer       = (*nodeExpandModule)(nil)
 	_ GraphNodeReferenceOutside = (*nodeExpandModule)(nil)
 	_ graphNodeExpandsInstances = (*nodeExpandModule)(nil)
@@ -74,6 +75,14 @@ func (n *nodeExpandModule) References() []*addrs.Reference {
 	return refs
 }
 
+func (n *nodeExpandModule) ReferenceableAddrs() []addrs.Referenceable {
+	// Anything referencing this module must do so after the ExpandModule call
+	// has been made to the expander, so we return the module call address as
+	// the only referenceable address.
+	_, call := n.Addr.Call()
+	return []addrs.Referenceable{call}
+}
+
 func (n *nodeExpandModule) DependsOn() []*addrs.Reference {
 	if n.ModuleCall == nil {
 		return nil
@@ -98,7 +107,7 @@ func (n *nodeExpandModule) DependsOn() []*addrs.Reference {
 
 // GraphNodeReferenceOutside
 func (n *nodeExpandModule) ReferenceOutside() (selfPath, referencePath addrs.Module) {
-	return n.Addr, n.Addr.Parent()
+	return n.Addr.Parent(), n.Addr.Parent()
 }
 
 // GraphNodeExecutable

--- a/internal/terraform/transform_reference.go
+++ b/internal/terraform/transform_reference.go
@@ -522,21 +522,50 @@ func (m ReferenceMap) referenceMapKey(path addrs.Module, addr addrs.Referenceabl
 		// might be in a resource-oriented graph rather than an
 		// instance-oriented graph, and so we'll see if we have the
 		// resource itself instead.
-		switch ri := addr.(type) {
-		case addrs.ResourceInstance:
-			addr = ri.ContainingResource()
-		case addrs.ResourceInstancePhase:
-			addr = ri.ContainingResource()
-		case addrs.ModuleCallInstanceOutput:
-			addr = ri.ModuleCallOutput()
-		case addrs.ModuleCallInstance:
-			addr = ri.Call
-		default:
-			return key
+
+		if ri, ok := addr.(addrs.ResourceInstance); ok {
+			return m.mapKey(path, ri.ContainingResource())
 		}
-		// if we matched any of the resource node types above, generate a new
-		// key
-		key = m.mapKey(path, addr)
+
+		if rip, ok := addr.(addrs.ResourceInstancePhase); ok {
+			return m.mapKey(path, rip.ContainingResource())
+		}
+
+		if mcio, ok := addr.(addrs.ModuleCallInstanceOutput); ok {
+
+			// A module call instance output is a reference to an output of a
+			// specific module call. If we can't find that, we'll look first
+			// for the general non-instanced output.
+
+			key = m.mapKey(path, mcio.ModuleCallOutput())
+			if _, exists := m[key]; exists {
+				// We found it, so we can just use that.
+				return key
+			}
+
+			// Otherwise we'll look just for the instanced module call itself.
+
+			key = m.mapKey(path, mcio.Call)
+			if _, exists := m[key]; exists {
+				// We found it, so we can just use that.
+				return key
+			}
+
+			// If we still can't find it, then we'll look for the non-instanced
+			// module call. This is the same as we'd do if the original call had
+			// just been for a ModuleCallInstance, so we'll let that fall
+			// through.
+
+			addr = mcio.Call
+
+		}
+
+		if mci, ok := addr.(addrs.ModuleCallInstance); ok {
+			return m.mapKey(path, mci.Call)
+		}
+
+		// If nothing matched, then we'll just return the original key
+		// unchanged.
 	}
 	return key
 }


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

This PR fixes two crashes within Terraform v1.8.0. In both cases a module expansion was being missed, and then crashing when something tried to reference the missed module.

The first occurs when referencing an output that doesn't exist within the `try()` function. In this case the executing node was not getting connected to the module expansion node because the output node to connect doesn't exist. Now, the `transform_reference` transformer will unfold module call output references into simple module call references if the target node for a module call output does not exist.

The second occurs when referencing a module block directly (ie. not a module output), on a module that has no changes during the apply. The module expansion node was being removed as it had no direct references (as no changes from within the module). Now, the module expansion node implements the referenceable interface, and we'll connect nodes that reference the module directly both to the expansion node and the closer node. This will ensure the expansion of a module happens before anything that references it is processed.

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Fixes #34976 

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.8.1

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

### BUG FIXES

<!--

Write a short description of the user-facing change. Examples:

- `terraform show -json`: Fixed crash with sensitive set values.
- When rendering a diff, Terraform now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 

- Fix crash in `terraform plan` when referencing a module output that does not exist within the `try(...)` function.
- Fix crash in `terraform apply` when referencing a module with no planned changes.
