### PR TITLE
Fix crash when generating config for a resource with complex sensitive attributes

### DIFF
--- a/internal/genconfig/generate_config.go
+++ b/internal/genconfig/generate_config.go
@@ -38,7 +38,6 @@ func GenerateResourceContents(addr addrs.AbsResourceInstance,
 		buf.WriteString(fmt.Sprintf("provider = %s\n", pc.StringCompact()))
 	}
 
-	stateVal = omitUnknowns(stateVal)
 	if stateVal.RawEquals(cty.NilVal) {
 		diags = diags.Append(writeConfigAttributes(addr, &buf, schema.Attributes, 2))
 		diags = diags.Append(writeConfigBlocks(addr, &buf, schema.BlockTypes, 2))
@@ -151,11 +150,17 @@ func writeConfigAttributesFromExisting(addr addrs.AbsResourceInstance, buf *stri
 				val = attrS.EmptyValue()
 			}
 			if val.Type() == cty.String {
+				// Before we inspect the string, take off any marks.
+				unmarked, marks := val.Unmark()
+
 				// SHAMELESS HACK: If we have "" for an optional value, assume
 				// it is actually null, due to the legacy SDK.
-				if !val.IsNull() && attrS.Optional && len(val.AsString()) == 0 {
-					val = attrS.EmptyValue()
+				if !unmarked.IsNull() && attrS.Optional && len(unmarked.AsString()) == 0 {
+					unmarked = attrS.EmptyValue()
 				}
+
+				// Before we carry on, add the marks back.
+				val = unmarked.WithMarks(marks)
 			}
 			if attrS.Sensitive || val.IsMarked() {
 				buf.WriteString("null # sensitive")
@@ -566,60 +571,4 @@ func ctyCollectionValues(val cty.Value) []cty.Value {
 	}
 
 	return ret
-}
-
-// omitUnknowns recursively walks the src cty.Value and returns a new cty.Value,
-// omitting any unknowns.
-//
-// The result also normalizes some types: all sequence types are turned into
-// tuple types and all mapping types are converted to object types, since we
-// assume the result of this is just going to be serialized as JSON (and thus
-// lose those distinctions) anyway.
-func omitUnknowns(val cty.Value) cty.Value {
-	ty := val.Type()
-	switch {
-	case val.IsNull():
-		return val
-	case !val.IsKnown():
-		return cty.NilVal
-	case ty.IsPrimitiveType():
-		return val
-	case ty.IsListType() || ty.IsTupleType() || ty.IsSetType():
-		var vals []cty.Value
-		it := val.ElementIterator()
-		for it.Next() {
-			_, v := it.Element()
-			newVal := omitUnknowns(v)
-			if newVal != cty.NilVal {
-				vals = append(vals, newVal)
-			} else if newVal == cty.NilVal {
-				// element order is how we correlate unknownness, so we must
-				// replace unknowns with nulls
-				vals = append(vals, cty.NullVal(v.Type()))
-			}
-		}
-		// We use tuple types always here, because the work we did above
-		// may have caused the individual elements to have different types,
-		// and we're doing this work to produce JSON anyway and JSON marshalling
-		// represents all of these sequence types as an array.
-		return cty.TupleVal(vals)
-	case ty.IsMapType() || ty.IsObjectType():
-		vals := make(map[string]cty.Value)
-		it := val.ElementIterator()
-		for it.Next() {
-			k, v := it.Element()
-			newVal := omitUnknowns(v)
-			if newVal != cty.NilVal {
-				vals[k.AsString()] = newVal
-			}
-		}
-		// We use object types always here, because the work we did above
-		// may have caused the individual elements to have different types,
-		// and we're doing this work to produce JSON anyway and JSON marshalling
-		// represents both of these mapping types as an object.
-		return cty.ObjectVal(vals)
-	default:
-		// Should never happen, since the above should cover all types
-		panic(fmt.Sprintf("omitUnknowns cannot handle %#v", val))
-	}
 }

--- a/internal/genconfig/generate_config_test.go
+++ b/internal/genconfig/generate_config_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/configs/configschema"
+	"github.com/hashicorp/terraform/internal/lang/marks"
 )
 
 func TestConfigGeneration(t *testing.T) {
@@ -538,6 +539,67 @@ resource "tfcoremock_simple_resource" "empty" {
   value = "[\"Hello\", \"World\""
 }`,
 		},
+		// Just try all the simple values with sensitive marks.
+		"sensitive_values": {
+			schema: &configschema.Block{
+				Attributes: map[string]*configschema.Attribute{
+					"string":       sensitiveAttribute(cty.String),
+					"empty_string": sensitiveAttribute(cty.String),
+					"number":       sensitiveAttribute(cty.Number),
+					"bool":         sensitiveAttribute(cty.Bool),
+					"object": sensitiveAttribute(cty.Object(map[string]cty.Type{
+						"nested": cty.String,
+					})),
+					"list": sensitiveAttribute(cty.List(cty.String)),
+					"map":  sensitiveAttribute(cty.Map(cty.String)),
+					"set":  sensitiveAttribute(cty.Set(cty.String)),
+				},
+			},
+			addr: addrs.AbsResourceInstance{
+				Module: addrs.RootModuleInstance,
+				Resource: addrs.ResourceInstance{
+					Resource: addrs.Resource{
+						Mode: addrs.ManagedResourceMode,
+						Type: "tfcoremock_sensitive_values",
+						Name: "values",
+					},
+					Key: addrs.NoKey,
+				},
+			},
+			provider: addrs.LocalProviderConfig{
+				LocalName: "tfcoremock",
+			},
+			value: cty.ObjectVal(map[string]cty.Value{
+				// Values that are sensitive will now be marked as such
+				"string":       cty.StringVal("Hello, world!").Mark(marks.Sensitive),
+				"empty_string": cty.StringVal("").Mark(marks.Sensitive),
+				"number":       cty.NumberIntVal(42).Mark(marks.Sensitive),
+				"bool":         cty.True.Mark(marks.Sensitive),
+				"object": cty.ObjectVal(map[string]cty.Value{
+					"nested": cty.StringVal("Hello, solar system!"),
+				}).Mark(marks.Sensitive),
+				"list": cty.ListVal([]cty.Value{
+					cty.StringVal("Hello, world!"),
+				}).Mark(marks.Sensitive),
+				"map": cty.MapVal(map[string]cty.Value{
+					"key": cty.StringVal("Hello, world!"),
+				}).Mark(marks.Sensitive),
+				"set": cty.SetVal([]cty.Value{
+					cty.StringVal("Hello, world!"),
+				}).Mark(marks.Sensitive),
+			}),
+			expected: `
+resource "tfcoremock_sensitive_values" "values" {
+  bool         = null # sensitive
+  empty_string = null # sensitive
+  list         = null # sensitive
+  map          = null # sensitive
+  number       = null # sensitive
+  object       = null # sensitive
+  set          = null # sensitive
+  string       = null # sensitive
+}`,
+		},
 	}
 	for name, tc := range tcs {
 		t.Run(name, func(t *testing.T) {
@@ -556,5 +618,13 @@ resource "tfcoremock_simple_resource" "empty" {
 				t.Errorf("got:\n%s\nwant:\n%s\ndiff:\n%s", got, want, diff)
 			}
 		})
+	}
+}
+
+func sensitiveAttribute(t cty.Type) *configschema.Attribute {
+	return &configschema.Attribute{
+		Type:      t,
+		Optional:  true,
+		Sensitive: true,
 	}
 }


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

This PR fixes a crash that occurs when generating configuration for a resource with "complex" sensitive attributes. Complex in this case means a list, set, map or object. Basically anything not a primitive type.


This bug was exposed by an earlier fix in which we started properly marking sensitive attributes within the plan, instead of waiting for the plan renderer to handle these directly (#34567). Now that sensitive marks will appear on values returned by the provider the config generation logic crashes as it is not checking for sensitive marks in the correct places.

The linked stack trace indicates this is happening during the `omitUnknowns` function. The fix in this case is to simply remove that function. As of #34525, it is impossible for us to encounter unknowns at this point anyway so the validation is just needless extra work.

There is also a problem with the check for "empty strings as null strings" required due to the legacy SDK. We need to unmark the string value before reading it. We don't need to do anything except restore the marks after the value has been changed into a null.

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Fixes #34992 

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.8.1

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

### BUG FIXES

<!--

Write a short description of the user-facing change. Examples:

- `terraform show -json`: Fixed crash with sensitive set values.
- When rendering a diff, Terraform now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 

-  Fix crash when generating configuration for resources with complex sensitive attributes.
