### PR TITLE
Handle marks a little more consistently

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -64,7 +64,7 @@ require (
 	github.com/xanzy/ssh-agent v0.3.3
 	github.com/xlab/treeprint v0.0.0-20161029104018-1d6e34225557
 	github.com/zclconf/go-cty v1.14.3
-	github.com/zclconf/go-cty-debug v0.0.0-20240209213017-b8d9e32151be
+	github.com/zclconf/go-cty-debug v0.0.0-20240417160409-8c45e122ae1a
 	github.com/zclconf/go-cty-yaml v1.0.3
 	go.opentelemetry.io/contrib/exporters/autoexport v0.45.0
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.46.0

--- a/go.sum
+++ b/go.sum
@@ -1040,8 +1040,8 @@ github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 github.com/zclconf/go-cty v1.14.3 h1:1JXy1XroaGrzZuG6X9dt7HL6s9AwbY+l4UNL8o5B6ho=
 github.com/zclconf/go-cty v1.14.3/go.mod h1:VvMs5i0vgZdhYawQNq5kePSpLAoz8u1xvZgrPIxfnZE=
-github.com/zclconf/go-cty-debug v0.0.0-20240209213017-b8d9e32151be h1:JoF5rruXECi+VEbdJ6xanklyLnz+TVCZ0FcmvSQq/Go=
-github.com/zclconf/go-cty-debug v0.0.0-20240209213017-b8d9e32151be/go.mod h1:CmBdvvj3nqzfzJ6nTCIwDTPZ56aVGvDrmztiO5g3qrM=
+github.com/zclconf/go-cty-debug v0.0.0-20240417160409-8c45e122ae1a h1:/o/Emn22dZIQ7AhyA0aLOKo528WG/WRAM5tqzIoQIOs=
+github.com/zclconf/go-cty-debug v0.0.0-20240417160409-8c45e122ae1a/go.mod h1:CmBdvvj3nqzfzJ6nTCIwDTPZ56aVGvDrmztiO5g3qrM=
 github.com/zclconf/go-cty-yaml v1.0.3 h1:og/eOQ7lvA/WWhHGFETVWNduJM7Rjsv2RRpx1sdFMLc=
 github.com/zclconf/go-cty-yaml v1.0.3/go.mod h1:9YLUH4g7lOhVWqUbctnVlZ5KLpg7JAprQNgxSZ1Gyxs=
 go.etcd.io/etcd/api/v3 v3.5.4/go.mod h1:5GB2vv4A4AOn3yk7MftYGHkUfGtDHnEraIjym4dYz5A=

--- a/internal/backend/remote-state/azure/go.sum
+++ b/internal/backend/remote-state/azure/go.sum
@@ -323,8 +323,8 @@ github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9de
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/zclconf/go-cty v1.14.3 h1:1JXy1XroaGrzZuG6X9dt7HL6s9AwbY+l4UNL8o5B6ho=
 github.com/zclconf/go-cty v1.14.3/go.mod h1:VvMs5i0vgZdhYawQNq5kePSpLAoz8u1xvZgrPIxfnZE=
-github.com/zclconf/go-cty-debug v0.0.0-20240209213017-b8d9e32151be h1:JoF5rruXECi+VEbdJ6xanklyLnz+TVCZ0FcmvSQq/Go=
-github.com/zclconf/go-cty-debug v0.0.0-20240209213017-b8d9e32151be/go.mod h1:CmBdvvj3nqzfzJ6nTCIwDTPZ56aVGvDrmztiO5g3qrM=
+github.com/zclconf/go-cty-debug v0.0.0-20240417160409-8c45e122ae1a h1:/o/Emn22dZIQ7AhyA0aLOKo528WG/WRAM5tqzIoQIOs=
+github.com/zclconf/go-cty-debug v0.0.0-20240417160409-8c45e122ae1a/go.mod h1:CmBdvvj3nqzfzJ6nTCIwDTPZ56aVGvDrmztiO5g3qrM=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=
 go.opencensus.io v0.22.2/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=

--- a/internal/backend/remote-state/consul/go.sum
+++ b/internal/backend/remote-state/consul/go.sum
@@ -323,8 +323,8 @@ github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9de
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/zclconf/go-cty v1.14.3 h1:1JXy1XroaGrzZuG6X9dt7HL6s9AwbY+l4UNL8o5B6ho=
 github.com/zclconf/go-cty v1.14.3/go.mod h1:VvMs5i0vgZdhYawQNq5kePSpLAoz8u1xvZgrPIxfnZE=
-github.com/zclconf/go-cty-debug v0.0.0-20240209213017-b8d9e32151be h1:JoF5rruXECi+VEbdJ6xanklyLnz+TVCZ0FcmvSQq/Go=
-github.com/zclconf/go-cty-debug v0.0.0-20240209213017-b8d9e32151be/go.mod h1:CmBdvvj3nqzfzJ6nTCIwDTPZ56aVGvDrmztiO5g3qrM=
+github.com/zclconf/go-cty-debug v0.0.0-20240417160409-8c45e122ae1a h1:/o/Emn22dZIQ7AhyA0aLOKo528WG/WRAM5tqzIoQIOs=
+github.com/zclconf/go-cty-debug v0.0.0-20240417160409-8c45e122ae1a/go.mod h1:CmBdvvj3nqzfzJ6nTCIwDTPZ56aVGvDrmztiO5g3qrM=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=
 go.opencensus.io v0.22.2/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=

--- a/internal/backend/remote-state/cos/go.sum
+++ b/internal/backend/remote-state/cos/go.sum
@@ -264,8 +264,8 @@ github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9de
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/zclconf/go-cty v1.14.3 h1:1JXy1XroaGrzZuG6X9dt7HL6s9AwbY+l4UNL8o5B6ho=
 github.com/zclconf/go-cty v1.14.3/go.mod h1:VvMs5i0vgZdhYawQNq5kePSpLAoz8u1xvZgrPIxfnZE=
-github.com/zclconf/go-cty-debug v0.0.0-20240209213017-b8d9e32151be h1:JoF5rruXECi+VEbdJ6xanklyLnz+TVCZ0FcmvSQq/Go=
-github.com/zclconf/go-cty-debug v0.0.0-20240209213017-b8d9e32151be/go.mod h1:CmBdvvj3nqzfzJ6nTCIwDTPZ56aVGvDrmztiO5g3qrM=
+github.com/zclconf/go-cty-debug v0.0.0-20240417160409-8c45e122ae1a h1:/o/Emn22dZIQ7AhyA0aLOKo528WG/WRAM5tqzIoQIOs=
+github.com/zclconf/go-cty-debug v0.0.0-20240417160409-8c45e122ae1a/go.mod h1:CmBdvvj3nqzfzJ6nTCIwDTPZ56aVGvDrmztiO5g3qrM=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=
 go.opencensus.io v0.22.2/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=

--- a/internal/backend/remote-state/gcs/go.sum
+++ b/internal/backend/remote-state/gcs/go.sum
@@ -267,8 +267,8 @@ github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9dec
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 github.com/zclconf/go-cty v1.14.3 h1:1JXy1XroaGrzZuG6X9dt7HL6s9AwbY+l4UNL8o5B6ho=
 github.com/zclconf/go-cty v1.14.3/go.mod h1:VvMs5i0vgZdhYawQNq5kePSpLAoz8u1xvZgrPIxfnZE=
-github.com/zclconf/go-cty-debug v0.0.0-20240209213017-b8d9e32151be h1:JoF5rruXECi+VEbdJ6xanklyLnz+TVCZ0FcmvSQq/Go=
-github.com/zclconf/go-cty-debug v0.0.0-20240209213017-b8d9e32151be/go.mod h1:CmBdvvj3nqzfzJ6nTCIwDTPZ56aVGvDrmztiO5g3qrM=
+github.com/zclconf/go-cty-debug v0.0.0-20240417160409-8c45e122ae1a h1:/o/Emn22dZIQ7AhyA0aLOKo528WG/WRAM5tqzIoQIOs=
+github.com/zclconf/go-cty-debug v0.0.0-20240417160409-8c45e122ae1a/go.mod h1:CmBdvvj3nqzfzJ6nTCIwDTPZ56aVGvDrmztiO5g3qrM=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=
 go.opencensus.io v0.22.2/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=

--- a/internal/backend/remote-state/kubernetes/go.sum
+++ b/internal/backend/remote-state/kubernetes/go.sum
@@ -325,8 +325,8 @@ github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9de
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/zclconf/go-cty v1.14.3 h1:1JXy1XroaGrzZuG6X9dt7HL6s9AwbY+l4UNL8o5B6ho=
 github.com/zclconf/go-cty v1.14.3/go.mod h1:VvMs5i0vgZdhYawQNq5kePSpLAoz8u1xvZgrPIxfnZE=
-github.com/zclconf/go-cty-debug v0.0.0-20240209213017-b8d9e32151be h1:JoF5rruXECi+VEbdJ6xanklyLnz+TVCZ0FcmvSQq/Go=
-github.com/zclconf/go-cty-debug v0.0.0-20240209213017-b8d9e32151be/go.mod h1:CmBdvvj3nqzfzJ6nTCIwDTPZ56aVGvDrmztiO5g3qrM=
+github.com/zclconf/go-cty-debug v0.0.0-20240417160409-8c45e122ae1a h1:/o/Emn22dZIQ7AhyA0aLOKo528WG/WRAM5tqzIoQIOs=
+github.com/zclconf/go-cty-debug v0.0.0-20240417160409-8c45e122ae1a/go.mod h1:CmBdvvj3nqzfzJ6nTCIwDTPZ56aVGvDrmztiO5g3qrM=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=
 go.opencensus.io v0.22.2/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=

--- a/internal/backend/remote-state/oss/go.sum
+++ b/internal/backend/remote-state/oss/go.sum
@@ -273,8 +273,8 @@ github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9de
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/zclconf/go-cty v1.14.3 h1:1JXy1XroaGrzZuG6X9dt7HL6s9AwbY+l4UNL8o5B6ho=
 github.com/zclconf/go-cty v1.14.3/go.mod h1:VvMs5i0vgZdhYawQNq5kePSpLAoz8u1xvZgrPIxfnZE=
-github.com/zclconf/go-cty-debug v0.0.0-20240209213017-b8d9e32151be h1:JoF5rruXECi+VEbdJ6xanklyLnz+TVCZ0FcmvSQq/Go=
-github.com/zclconf/go-cty-debug v0.0.0-20240209213017-b8d9e32151be/go.mod h1:CmBdvvj3nqzfzJ6nTCIwDTPZ56aVGvDrmztiO5g3qrM=
+github.com/zclconf/go-cty-debug v0.0.0-20240417160409-8c45e122ae1a h1:/o/Emn22dZIQ7AhyA0aLOKo528WG/WRAM5tqzIoQIOs=
+github.com/zclconf/go-cty-debug v0.0.0-20240417160409-8c45e122ae1a/go.mod h1:CmBdvvj3nqzfzJ6nTCIwDTPZ56aVGvDrmztiO5g3qrM=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=
 go.opencensus.io v0.22.2/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=

--- a/internal/backend/remote-state/pg/go.sum
+++ b/internal/backend/remote-state/pg/go.sum
@@ -244,8 +244,8 @@ github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9de
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/zclconf/go-cty v1.14.3 h1:1JXy1XroaGrzZuG6X9dt7HL6s9AwbY+l4UNL8o5B6ho=
 github.com/zclconf/go-cty v1.14.3/go.mod h1:VvMs5i0vgZdhYawQNq5kePSpLAoz8u1xvZgrPIxfnZE=
-github.com/zclconf/go-cty-debug v0.0.0-20240209213017-b8d9e32151be h1:JoF5rruXECi+VEbdJ6xanklyLnz+TVCZ0FcmvSQq/Go=
-github.com/zclconf/go-cty-debug v0.0.0-20240209213017-b8d9e32151be/go.mod h1:CmBdvvj3nqzfzJ6nTCIwDTPZ56aVGvDrmztiO5g3qrM=
+github.com/zclconf/go-cty-debug v0.0.0-20240417160409-8c45e122ae1a h1:/o/Emn22dZIQ7AhyA0aLOKo528WG/WRAM5tqzIoQIOs=
+github.com/zclconf/go-cty-debug v0.0.0-20240417160409-8c45e122ae1a/go.mod h1:CmBdvvj3nqzfzJ6nTCIwDTPZ56aVGvDrmztiO5g3qrM=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=
 go.opencensus.io v0.22.2/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=

--- a/internal/backend/remote-state/s3/go.sum
+++ b/internal/backend/remote-state/s3/go.sum
@@ -306,8 +306,8 @@ github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9de
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/zclconf/go-cty v1.14.3 h1:1JXy1XroaGrzZuG6X9dt7HL6s9AwbY+l4UNL8o5B6ho=
 github.com/zclconf/go-cty v1.14.3/go.mod h1:VvMs5i0vgZdhYawQNq5kePSpLAoz8u1xvZgrPIxfnZE=
-github.com/zclconf/go-cty-debug v0.0.0-20240209213017-b8d9e32151be h1:JoF5rruXECi+VEbdJ6xanklyLnz+TVCZ0FcmvSQq/Go=
-github.com/zclconf/go-cty-debug v0.0.0-20240209213017-b8d9e32151be/go.mod h1:CmBdvvj3nqzfzJ6nTCIwDTPZ56aVGvDrmztiO5g3qrM=
+github.com/zclconf/go-cty-debug v0.0.0-20240417160409-8c45e122ae1a h1:/o/Emn22dZIQ7AhyA0aLOKo528WG/WRAM5tqzIoQIOs=
+github.com/zclconf/go-cty-debug v0.0.0-20240417160409-8c45e122ae1a/go.mod h1:CmBdvvj3nqzfzJ6nTCIwDTPZ56aVGvDrmztiO5g3qrM=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=
 go.opencensus.io v0.22.2/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=

--- a/internal/command/jsonplan/plan.go
+++ b/internal/command/jsonplan/plan.go
@@ -18,6 +18,7 @@ import (
 	"github.com/hashicorp/terraform/internal/command/jsonconfig"
 	"github.com/hashicorp/terraform/internal/command/jsonstate"
 	"github.com/hashicorp/terraform/internal/configs"
+	"github.com/hashicorp/terraform/internal/lang/marks"
 	"github.com/hashicorp/terraform/internal/plans"
 	"github.com/hashicorp/terraform/internal/states"
 	"github.com/hashicorp/terraform/internal/states/statefile"
@@ -418,11 +419,9 @@ func MarshalResourceChanges(resources []*plans.ResourceInstanceChangeSrc, schema
 			if err != nil {
 				return nil, err
 			}
-			marks := rc.BeforeValMarks
-			if schema.ContainsSensitive() {
-				marks = append(marks, schema.ValueMarks(changeV.Before, nil)...)
-			}
-			bs := jsonstate.SensitiveAsBool(changeV.Before.MarkWithPaths(marks))
+			sensitivePaths := rc.BeforeSensitivePaths
+			sensitivePaths = append(sensitivePaths, schema.SensitivePaths(changeV.Before, nil)...)
+			bs := jsonstate.SensitiveAsBool(marks.MarkPaths(changeV.Before, marks.Sensitive, sensitivePaths))
 			beforeSensitive, err = ctyjson.Marshal(bs, bs.Type())
 			if err != nil {
 				return nil, err
@@ -447,11 +446,9 @@ func MarshalResourceChanges(resources []*plans.ResourceInstanceChangeSrc, schema
 				}
 				afterUnknown = unknownAsBool(changeV.After)
 			}
-			marks := rc.AfterValMarks
-			if schema.ContainsSensitive() {
-				marks = append(marks, schema.ValueMarks(changeV.After, nil)...)
-			}
-			as := jsonstate.SensitiveAsBool(changeV.After.MarkWithPaths(marks))
+			sensitivePaths := rc.AfterSensitivePaths
+			sensitivePaths = append(sensitivePaths, schema.SensitivePaths(changeV.After, nil)...)
+			as := jsonstate.SensitiveAsBool(marks.MarkPaths(changeV.After, marks.Sensitive, sensitivePaths))
 			afterSensitive, err = ctyjson.Marshal(as, as.Type())
 			if err != nil {
 				return nil, err

--- a/internal/configs/configschema/marks_test.go
+++ b/internal/configs/configschema/marks_test.go
@@ -176,8 +176,9 @@ func TestBlockValueMarks(t *testing.T) {
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			got := tc.given.MarkWithPaths(schema.ValueMarks(tc.given, nil))
-			if !got.RawEquals(tc.expect) {
+			sensitivePaths := schema.SensitivePaths(tc.given, nil)
+			got := marks.MarkPaths(tc.given, marks.Sensitive, sensitivePaths)
+			if !tc.expect.RawEquals(got) {
 				t.Fatalf("\nexpected: %#v\ngot:      %#v\n", tc.expect, got)
 			}
 		})

--- a/internal/lang/marks/paths.go
+++ b/internal/lang/marks/paths.go
@@ -36,3 +36,27 @@ func PathsWithMark(pvms []cty.PathValueMarks, wantMark any) (withWanted []cty.Pa
 
 	return withWanted, withOthers
 }
+
+// MarkPaths transforms the given value by marking each of the given paths
+// with the given mark value.
+func MarkPaths(val cty.Value, mark any, paths []cty.Path) cty.Value {
+	if len(paths) == 0 {
+		// No-allocations path for the common case where there are no marked paths at all.
+		return val
+	}
+
+	// For now we'll use cty's slightly lower-level function to achieve this
+	// result. This is a little inefficient due to an additional dynamic
+	// allocation for the intermediate data structure, so if that becomes
+	// a problem in practice then we may wish to write a more direct
+	// implementation here.
+	markses := make([]cty.PathValueMarks, len(paths))
+	marks := cty.NewValueMarks(mark)
+	for i, path := range paths {
+		markses[i] = cty.PathValueMarks{
+			Path:  path,
+			Marks: marks,
+		}
+	}
+	return val.MarkWithPaths(markses)
+}

--- a/internal/lang/marks/paths.go
+++ b/internal/lang/marks/paths.go
@@ -1,0 +1,38 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package marks
+
+import (
+	"github.com/zclconf/go-cty/cty"
+)
+
+// PathsWithMark produces a list of paths identified as having a specified
+// mark in a given set of [cty.PathValueMarks] that presumably resulted from
+// deeply-unmarking a [cty.Value].
+//
+// This is for situations where a subsystem needs to give special treatment
+// to one specific mark value, as opposed to just handling all marks
+// generically as cty operations would. The second return value is a
+// subset of the given [cty.PathValueMarks] values which contained marks
+// other than the one requested, so that a caller that can't preserve other
+// marks at all can more easily return an error explaining that.
+func PathsWithMark(pvms []cty.PathValueMarks, wantMark any) (withWanted []cty.Path, withOthers []cty.PathValueMarks) {
+	if len(pvms) == 0 {
+		// No-allocations path for the common case where there are no marks at all.
+		return nil, nil
+	}
+
+	for _, pvm := range pvms {
+		if _, ok := pvm.Marks[wantMark]; ok {
+			withWanted = append(withWanted, pvm.Path)
+		}
+		for mark := range pvm.Marks {
+			if mark != wantMark {
+				withOthers = append(withOthers, pvm)
+			}
+		}
+	}
+
+	return withWanted, withOthers
+}

--- a/internal/lang/marks/paths_test.go
+++ b/internal/lang/marks/paths_test.go
@@ -1,0 +1,58 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package marks
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/zclconf/go-cty-debug/ctydebug"
+	"github.com/zclconf/go-cty/cty"
+)
+
+func TestPathsWithMark(t *testing.T) {
+	input := []cty.PathValueMarks{
+		{
+			Path:  cty.GetAttrPath("sensitive"),
+			Marks: cty.NewValueMarks(Sensitive),
+		},
+		{
+			Path:  cty.GetAttrPath("other"),
+			Marks: cty.NewValueMarks("other"),
+		},
+		{
+			Path:  cty.GetAttrPath("both"),
+			Marks: cty.NewValueMarks(Sensitive, "other"),
+		},
+	}
+
+	gotPaths, gotOthers := PathsWithMark(input, Sensitive)
+	wantPaths := []cty.Path{
+		cty.GetAttrPath("sensitive"),
+		cty.GetAttrPath("both"),
+	}
+	wantOthers := []cty.PathValueMarks{
+		{
+			Path:  cty.GetAttrPath("other"),
+			Marks: cty.NewValueMarks("other"),
+		},
+		{
+			Path:  cty.GetAttrPath("both"),
+			Marks: cty.NewValueMarks(Sensitive, "other"),
+			// Note that this intentionally preserves the fact that the
+			// attribute was both sensitive _and_ had another mark, since
+			// that gives the caller the most possible information to
+			// potentially handle this combination in a special way in
+			// an error message, or whatever. It also conveniently avoids
+			// allocating a new mark set, which is nice.
+		},
+	}
+
+	if diff := cmp.Diff(wantPaths, gotPaths, ctydebug.CmpOptions); diff != "" {
+		t.Errorf("wrong matched paths\n%s", diff)
+	}
+	if diff := cmp.Diff(wantOthers, gotOthers, ctydebug.CmpOptions); diff != "" {
+		t.Errorf("wrong set of entries with other marks\n%s", diff)
+	}
+}

--- a/internal/legacy/go.sum
+++ b/internal/legacy/go.sum
@@ -233,8 +233,8 @@ github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9de
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/zclconf/go-cty v1.14.3 h1:1JXy1XroaGrzZuG6X9dt7HL6s9AwbY+l4UNL8o5B6ho=
 github.com/zclconf/go-cty v1.14.3/go.mod h1:VvMs5i0vgZdhYawQNq5kePSpLAoz8u1xvZgrPIxfnZE=
-github.com/zclconf/go-cty-debug v0.0.0-20240209213017-b8d9e32151be h1:JoF5rruXECi+VEbdJ6xanklyLnz+TVCZ0FcmvSQq/Go=
-github.com/zclconf/go-cty-debug v0.0.0-20240209213017-b8d9e32151be/go.mod h1:CmBdvvj3nqzfzJ6nTCIwDTPZ56aVGvDrmztiO5g3qrM=
+github.com/zclconf/go-cty-debug v0.0.0-20240417160409-8c45e122ae1a h1:/o/Emn22dZIQ7AhyA0aLOKo528WG/WRAM5tqzIoQIOs=
+github.com/zclconf/go-cty-debug v0.0.0-20240417160409-8c45e122ae1a/go.mod h1:CmBdvvj3nqzfzJ6nTCIwDTPZ56aVGvDrmztiO5g3qrM=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=
 go.opencensus.io v0.22.2/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=

--- a/internal/plans/changes.go
+++ b/internal/plans/changes.go
@@ -4,10 +4,14 @@
 package plans
 
 import (
+	"fmt"
+
 	"github.com/zclconf/go-cty/cty"
 
 	"github.com/hashicorp/terraform/internal/addrs"
+	"github.com/hashicorp/terraform/internal/lang/marks"
 	"github.com/hashicorp/terraform/internal/states"
+	"github.com/hashicorp/terraform/internal/tfdiags"
 )
 
 // Changes describes various actions that Terraform will attempt to take if
@@ -555,22 +559,34 @@ type Change struct {
 // to call the corresponding Encode method of that struct rather than working
 // directly with its embedded Change.
 func (c *Change) Encode(ty cty.Type) (*ChangeSrc, error) {
-	// Storing unmarked values so that we can encode unmarked values
-	// and save the PathValueMarks for re-marking the values later
-	var beforeVM, afterVM []cty.PathValueMarks
-	unmarkedBefore := c.Before
-	unmarkedAfter := c.After
-
-	if c.Before.ContainsMarked() {
-		unmarkedBefore, beforeVM = c.Before.UnmarkDeepWithPaths()
+	// We can't serialize value marks directly so we'll need to extract the
+	// sensitive marks and store them in a separate field.
+	//
+	// We don't accept any other marks here. The caller should have dealt
+	// with those somehow and replaced them with unmarked placeholders before
+	// writing the value into the state.
+	unmarkedBefore, marksesBefore := c.Before.UnmarkDeepWithPaths()
+	unmarkedAfter, marksesAfter := c.After.UnmarkDeepWithPaths()
+	sensitiveAttrsBefore, unsupportedMarksesBefore := marks.PathsWithMark(marksesBefore, marks.Sensitive)
+	sensitiveAttrsAfter, unsupportedMarksesAfter := marks.PathsWithMark(marksesAfter, marks.Sensitive)
+	if len(unsupportedMarksesBefore) != 0 {
+		return nil, fmt.Errorf(
+			"prior value %s: can't serialize value marked with %#v (this is a bug in Terraform)",
+			tfdiags.FormatCtyPath(unsupportedMarksesBefore[0].Path),
+			unsupportedMarksesBefore[0].Marks,
+		)
 	}
+	if len(unsupportedMarksesAfter) != 0 {
+		return nil, fmt.Errorf(
+			"new value %s: can't serialize value marked with %#v (this is a bug in Terraform)",
+			tfdiags.FormatCtyPath(unsupportedMarksesAfter[0].Path),
+			unsupportedMarksesAfter[0].Marks,
+		)
+	}
+
 	beforeDV, err := NewDynamicValue(unmarkedBefore, ty)
 	if err != nil {
 		return nil, err
-	}
-
-	if c.After.ContainsMarked() {
-		unmarkedAfter, afterVM = c.After.UnmarkDeepWithPaths()
 	}
 	afterDV, err := NewDynamicValue(unmarkedAfter, ty)
 	if err != nil {
@@ -583,12 +599,12 @@ func (c *Change) Encode(ty cty.Type) (*ChangeSrc, error) {
 	}
 
 	return &ChangeSrc{
-		Action:          c.Action,
-		Before:          beforeDV,
-		After:           afterDV,
-		BeforeValMarks:  beforeVM,
-		AfterValMarks:   afterVM,
-		Importing:       importing,
-		GeneratedConfig: c.GeneratedConfig,
+		Action:               c.Action,
+		Before:               beforeDV,
+		After:                afterDV,
+		BeforeSensitivePaths: sensitiveAttrsBefore,
+		AfterSensitivePaths:  sensitiveAttrsAfter,
+		Importing:            importing,
+		GeneratedConfig:      c.GeneratedConfig,
 	}, nil
 }

--- a/internal/plans/changes_test.go
+++ b/internal/plans/changes_test.go
@@ -133,8 +133,8 @@ func TestChangeEncodeSensitive(t *testing.T) {
 		cty.ObjectVal(map[string]cty.Value{
 			"ding": cty.StringVal("dong").Mark(marks.Sensitive),
 		}),
-		cty.StringVal("bleep").Mark("bloop"),
-		cty.ListVal([]cty.Value{cty.UnknownVal(cty.String).Mark("sup?")}),
+		cty.StringVal("bleep").Mark(marks.Sensitive),
+		cty.ListVal([]cty.Value{cty.UnknownVal(cty.String).Mark(marks.Sensitive)}),
 	}
 
 	for _, v := range testVals {

--- a/internal/plans/planfile/config_snapshot.go
+++ b/internal/plans/planfile/config_snapshot.go
@@ -7,7 +7,7 @@ import (
 	"archive/zip"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"path"
 	"sort"
 	"strings"
@@ -55,7 +55,7 @@ func readConfigSnapshot(z *zip.Reader) (*configload.Snapshot, error) {
 			if err != nil {
 				return nil, fmt.Errorf("failed to open module manifest: %s", r)
 			}
-			manifestSrc, err = ioutil.ReadAll(r)
+			manifestSrc, err = io.ReadAll(r)
 			if err != nil {
 				return nil, fmt.Errorf("failed to read module manifest: %s", r)
 			}
@@ -77,7 +77,7 @@ func readConfigSnapshot(z *zip.Reader) (*configload.Snapshot, error) {
 			if err != nil {
 				return nil, fmt.Errorf("failed to open snapshot of %s from module %q: %s", fileName, moduleKey, err)
 			}
-			fileSrc, err := ioutil.ReadAll(r)
+			fileSrc, err := io.ReadAll(r)
 			if err != nil {
 				return nil, fmt.Errorf("failed to read snapshot of %s from module %q: %s", fileName, moduleKey, err)
 			}

--- a/internal/plans/planfile/reader.go
+++ b/internal/plans/planfile/reader.go
@@ -7,7 +7,8 @@ import (
 	"archive/zip"
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
+	"os"
 
 	"github.com/hashicorp/terraform/internal/configs"
 	"github.com/hashicorp/terraform/internal/configs/configload"
@@ -59,7 +60,7 @@ func Open(filename string) (*Reader, error) {
 	if err != nil {
 		// To give a better error message, we'll sniff to see if this looks
 		// like our old plan format from versions prior to 0.12.
-		if b, sErr := ioutil.ReadFile(filename); sErr == nil {
+		if b, sErr := os.ReadFile(filename); sErr == nil {
 			if bytes.HasPrefix(b, []byte("tfplan")) {
 				return nil, errUnusable(fmt.Errorf("the given plan file was created by an earlier version of Terraform; plan files cannot be shared between different Terraform versions"))
 			}
@@ -236,7 +237,7 @@ func (r *Reader) ReadDependencyLocks() (*depsfile.Locks, tfdiags.Diagnostics) {
 				))
 				return nil, diags
 			}
-			src, err := ioutil.ReadAll(r)
+			src, err := io.ReadAll(r)
 			if err != nil {
 				diags = diags.Append(tfdiags.Sourceless(
 					tfdiags.Error,

--- a/internal/plans/planfile/tfplan.go
+++ b/internal/plans/planfile/tfplan.go
@@ -14,12 +14,10 @@ import (
 	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/checks"
 	"github.com/hashicorp/terraform/internal/lang/globalref"
-	"github.com/hashicorp/terraform/internal/lang/marks"
 	"github.com/hashicorp/terraform/internal/plans"
 	"github.com/hashicorp/terraform/internal/plans/planproto"
 	"github.com/hashicorp/terraform/internal/providers"
 	"github.com/hashicorp/terraform/internal/states"
-	"github.com/hashicorp/terraform/internal/tfdiags"
 	"github.com/hashicorp/terraform/version"
 )
 
@@ -416,20 +414,19 @@ func changeFromTfplan(rawChange *planproto.Change) (*plans.ChangeSrc, error) {
 	}
 	ret.GeneratedConfig = rawChange.GeneratedConfig
 
-	sensitive := cty.NewValueMarks(marks.Sensitive)
-	beforeValMarks, err := pathValueMarksFromTfplan(rawChange.BeforeSensitivePaths, sensitive)
+	beforeValSensitiveAttrs, err := pathsFromTfplan(rawChange.BeforeSensitivePaths)
 	if err != nil {
 		return nil, fmt.Errorf("failed to decode before sensitive paths: %s", err)
 	}
-	afterValMarks, err := pathValueMarksFromTfplan(rawChange.AfterSensitivePaths, sensitive)
+	afterValSensitiveAttrs, err := pathsFromTfplan(rawChange.AfterSensitivePaths)
 	if err != nil {
 		return nil, fmt.Errorf("failed to decode after sensitive paths: %s", err)
 	}
-	if len(beforeValMarks) > 0 {
-		ret.BeforeValMarks = beforeValMarks
+	if len(beforeValSensitiveAttrs) > 0 {
+		ret.BeforeSensitivePaths = beforeValSensitiveAttrs
 	}
-	if len(afterValMarks) > 0 {
-		ret.AfterValMarks = afterValMarks
+	if len(afterValSensitiveAttrs) > 0 {
+		ret.AfterSensitivePaths = afterValSensitiveAttrs
 	}
 
 	return ret, nil
@@ -788,11 +785,11 @@ func changeToTfplan(change *plans.ChangeSrc) (*planproto.Change, error) {
 	before := valueToTfplan(change.Before)
 	after := valueToTfplan(change.After)
 
-	beforeSensitivePaths, err := pathValueMarksToTfplan(change.BeforeValMarks)
+	beforeSensitivePaths, err := pathsToTfplan(change.BeforeSensitivePaths)
 	if err != nil {
 		return nil, err
 	}
-	afterSensitivePaths, err := pathValueMarksToTfplan(change.AfterValMarks)
+	afterSensitivePaths, err := pathsToTfplan(change.AfterSensitivePaths)
 	if err != nil {
 		return nil, err
 	}
@@ -842,33 +839,28 @@ func valueToTfplan(val plans.DynamicValue) *planproto.DynamicValue {
 	return planproto.NewPlanDynamicValue(val)
 }
 
-func pathValueMarksFromTfplan(paths []*planproto.Path, marks cty.ValueMarks) ([]cty.PathValueMarks, error) {
-	ret := make([]cty.PathValueMarks, 0, len(paths))
+func pathsFromTfplan(paths []*planproto.Path) ([]cty.Path, error) {
+	if len(paths) == 0 {
+		return nil, nil
+	}
+	ret := make([]cty.Path, 0, len(paths))
 	for _, p := range paths {
 		path, err := pathFromTfplan(p)
 		if err != nil {
 			return nil, err
 		}
-		ret = append(ret, cty.PathValueMarks{
-			Path:  path,
-			Marks: marks,
-		})
+		ret = append(ret, path)
 	}
 	return ret, nil
 }
 
-func pathValueMarksToTfplan(pvm []cty.PathValueMarks) ([]*planproto.Path, error) {
-	ret := make([]*planproto.Path, 0, len(pvm))
-	for _, p := range pvm {
-		for mark := range p.Marks {
-			if mark != marks.Sensitive {
-				return nil, fmt.Errorf("%s: cannot serialize values marked as %#v (this is a bug in Terraform)", tfdiags.FormatCtyPath(p.Path), mark)
-			}
-		}
-		if _, ok := p.Marks[marks.Sensitive]; !ok {
-			continue
-		}
-		path, err := pathToTfplan(p.Path)
+func pathsToTfplan(paths []cty.Path) ([]*planproto.Path, error) {
+	if len(paths) == 0 {
+		return nil, nil
+	}
+	ret := make([]*planproto.Path, 0, len(paths))
+	for _, p := range paths {
+		path, err := pathToTfplan(p)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/plans/planfile/tfplan.go
+++ b/internal/plans/planfile/tfplan.go
@@ -6,7 +6,6 @@ package planfile
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"time"
 
 	"github.com/zclconf/go-cty/cty"
@@ -39,7 +38,7 @@ const tfplanFilename = "tfplan"
 // a plan file, which is stored in a special file in the archive called
 // "tfplan".
 func readTfplan(r io.Reader) (*plans.Plan, error) {
-	src, err := ioutil.ReadAll(r)
+	src, err := io.ReadAll(r)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/stacks/stackplan/planned_change.go
+++ b/internal/stacks/stackplan/planned_change.go
@@ -340,8 +340,14 @@ func (pc *PlannedChangeResourceInstancePlanned) PlannedChangeProto() (*terraform
 
 						Actions: protoChangeTypes,
 						Values: &terraform1.DynamicValueChange{
-							Old: terraform1.NewDynamicValue(pc.ChangeSrc.Before, pc.ChangeSrc.BeforeValMarks),
-							New: terraform1.NewDynamicValue(pc.ChangeSrc.After, pc.ChangeSrc.AfterValMarks),
+							Old: terraform1.NewDynamicValue(
+								pc.ChangeSrc.Before,
+								pc.ChangeSrc.BeforeSensitivePaths,
+							),
+							New: terraform1.NewDynamicValue(
+								pc.ChangeSrc.After,
+								pc.ChangeSrc.AfterSensitivePaths,
+							),
 						},
 						ReplacePaths: replacePaths,
 						// TODO: Moved, Imported
@@ -380,8 +386,8 @@ type PlannedChangeOutputValue struct {
 	Addr   stackaddrs.OutputValue // Covers only root stack output values
 	Action plans.Action
 
-	OldValue, NewValue           plans.DynamicValue
-	OldValueMarks, NewValueMarks []cty.PathValueMarks
+	OldValue, NewValue                             plans.DynamicValue
+	OldValueSensitivePaths, NewValueSensitivePaths []cty.Path
 }
 
 var _ PlannedChange = (*PlannedChangeOutputValue)(nil)
@@ -405,8 +411,8 @@ func (pc *PlannedChangeOutputValue) PlannedChangeProto() (*terraform1.PlannedCha
 						Actions: protoChangeTypes,
 
 						Values: &terraform1.DynamicValueChange{
-							Old: terraform1.NewDynamicValue(pc.OldValue, pc.OldValueMarks),
-							New: terraform1.NewDynamicValue(pc.NewValue, pc.NewValueMarks),
+							Old: terraform1.NewDynamicValue(pc.OldValue, pc.OldValueSensitivePaths),
+							New: terraform1.NewDynamicValue(pc.NewValue, pc.NewValueSensitivePaths),
 						},
 					},
 				},

--- a/internal/stacks/stackruntime/apply_test.go
+++ b/internal/stacks/stackruntime/apply_test.go
@@ -317,11 +317,8 @@ func TestApplyWithSensitivePropagation(t *testing.T) {
 					"id":    "bb5cf32312ec",
 					"value": "secret",
 				}),
-				AttrSensitivePaths: []cty.PathValueMarks{
-					{
-						Path:  cty.GetAttrPath("value"),
-						Marks: cty.NewValueMarks(marks.Sensitive),
-					},
+				AttrSensitivePaths: []cty.Path{
+					cty.GetAttrPath("value"),
 				},
 				Status:       states.ObjectReady,
 				Dependencies: make([]addrs.ConfigResource, 0),

--- a/internal/stacks/stackruntime/plan_test.go
+++ b/internal/stacks/stackruntime/plan_test.go
@@ -650,11 +650,13 @@ func TestPlanSensitiveOutput(t *testing.T) {
 			TerraformVersion: version.SemVer,
 		},
 		&stackplan.PlannedChangeOutputValue{
-			Addr:          stackaddrs.OutputValue{Name: "result"},
-			Action:        plans.Create,
-			OldValue:      plans.DynamicValue{0xc0}, // MessagePack nil
-			NewValue:      mustPlanDynamicValue(cty.StringVal("secret")),
-			NewValueMarks: []cty.PathValueMarks{{Marks: cty.NewValueMarks(marks.Sensitive)}},
+			Addr:     stackaddrs.OutputValue{Name: "result"},
+			Action:   plans.Create,
+			OldValue: plans.DynamicValue{0xc0}, // MessagePack nil
+			NewValue: mustPlanDynamicValue(cty.StringVal("secret")),
+			NewValueSensitivePaths: []cty.Path{
+				nil, // the whole value is sensitive
+			},
 		},
 	}
 	sort.SliceStable(gotChanges, func(i, j int) bool {
@@ -701,11 +703,13 @@ func TestPlanSensitiveOutputNested(t *testing.T) {
 			TerraformVersion: version.SemVer,
 		},
 		&stackplan.PlannedChangeOutputValue{
-			Addr:          stackaddrs.OutputValue{Name: "result"},
-			Action:        plans.Create,
-			OldValue:      plans.DynamicValue{0xc0}, // MessagePack nil
-			NewValue:      mustPlanDynamicValue(cty.StringVal("secret")),
-			NewValueMarks: []cty.PathValueMarks{{Marks: cty.NewValueMarks(marks.Sensitive)}},
+			Addr:     stackaddrs.OutputValue{Name: "result"},
+			Action:   plans.Create,
+			OldValue: plans.DynamicValue{0xc0}, // MessagePack nil
+			NewValue: mustPlanDynamicValue(cty.StringVal("secret")),
+			NewValueSensitivePaths: []cty.Path{
+				nil, // the whole value is sensitive
+			},
 		},
 		&stackplan.PlannedChangeComponentInstance{
 			Addr: stackaddrs.Absolute(
@@ -795,11 +799,13 @@ func TestPlanSensitiveOutputAsInput(t *testing.T) {
 			TerraformVersion: version.SemVer,
 		},
 		&stackplan.PlannedChangeOutputValue{
-			Addr:          stackaddrs.OutputValue{Name: "result"},
-			Action:        plans.Create,
-			OldValue:      plans.DynamicValue{0xc0}, // MessagePack nil
-			NewValue:      mustPlanDynamicValue(cty.StringVal("SECRET")),
-			NewValueMarks: []cty.PathValueMarks{{Marks: cty.NewValueMarks(marks.Sensitive)}},
+			Addr:     stackaddrs.OutputValue{Name: "result"},
+			Action:   plans.Create,
+			OldValue: plans.DynamicValue{0xc0}, // MessagePack nil
+			NewValue: mustPlanDynamicValue(cty.StringVal("SECRET")),
+			NewValueSensitivePaths: []cty.Path{
+				nil, // the whole value is sensitive
+			},
 		},
 		&stackplan.PlannedChangeComponentInstance{
 			Addr: stackaddrs.Absolute(
@@ -1128,11 +1134,8 @@ func TestPlanWithSensitivePropagation(t *testing.T) {
 						"id":    cty.UnknownVal(cty.String),
 						"value": cty.StringVal("secret"),
 					}), stacks_testing_provider.TestingResourceSchema),
-					AfterValMarks: []cty.PathValueMarks{
-						{
-							Path:  cty.GetAttrPath("value"),
-							Marks: cty.NewValueMarks(marks.Sensitive),
-						},
+					AfterSensitivePaths: []cty.Path{
+						cty.GetAttrPath("value"),
 					},
 				},
 			},
@@ -1278,11 +1281,8 @@ func TestPlanWithSensitivePropagationNested(t *testing.T) {
 						"id":    cty.UnknownVal(cty.String),
 						"value": cty.StringVal("secret"),
 					}), stacks_testing_provider.TestingResourceSchema),
-					AfterValMarks: []cty.PathValueMarks{
-						{
-							Path:  cty.GetAttrPath("value"),
-							Marks: cty.NewValueMarks(marks.Sensitive),
-						},
+					AfterSensitivePaths: []cty.Path{
+						cty.GetAttrPath("value"),
 					},
 				},
 			},

--- a/internal/stacks/stackstate/applied_change_test.go
+++ b/internal/stacks/stackstate/applied_change_test.go
@@ -9,11 +9,6 @@ import (
 
 	"github.com/davecgh/go-spew/spew"
 	"github.com/google/go-cmp/cmp"
-	"github.com/hashicorp/terraform/internal/configs/configschema"
-	"github.com/hashicorp/terraform/internal/lang/marks"
-	"github.com/hashicorp/terraform/internal/plans/planproto"
-	"github.com/hashicorp/terraform/internal/stacks/tfstackdata1"
-	"github.com/hashicorp/terraform/internal/states"
 	"github.com/zclconf/go-cty/cty"
 	ctymsgpack "github.com/zclconf/go-cty/cty/msgpack"
 	"google.golang.org/protobuf/proto"
@@ -21,8 +16,12 @@ import (
 	"google.golang.org/protobuf/types/known/anypb"
 
 	"github.com/hashicorp/terraform/internal/addrs"
+	"github.com/hashicorp/terraform/internal/configs/configschema"
+	"github.com/hashicorp/terraform/internal/plans/planproto"
 	"github.com/hashicorp/terraform/internal/rpcapi/terraform1"
 	"github.com/hashicorp/terraform/internal/stacks/stackaddrs"
+	"github.com/hashicorp/terraform/internal/stacks/tfstackdata1"
+	"github.com/hashicorp/terraform/internal/states"
 )
 
 func TestAppliedChangeAsProto(t *testing.T) {
@@ -69,11 +68,8 @@ func TestAppliedChangeAsProto(t *testing.T) {
 				NewStateSrc: &states.ResourceInstanceObjectSrc{
 					Status:    states.ObjectReady,
 					AttrsJSON: []byte(`{"id":"bar","secret":"top"}`),
-					AttrSensitivePaths: []cty.PathValueMarks{
-						{
-							Path:  []cty.PathStep{cty.GetAttrStep{Name: "secret"}},
-							Marks: map[interface{}]struct{}{marks.Sensitive: {}},
-						},
+					AttrSensitivePaths: []cty.Path{
+						cty.GetAttrPath("secret"),
 					},
 				},
 			},

--- a/internal/stacks/stackstate/from_proto.go
+++ b/internal/stacks/stackstate/from_proto.go
@@ -13,7 +13,6 @@ import (
 	"google.golang.org/protobuf/types/known/anypb"
 
 	"github.com/hashicorp/terraform/internal/addrs"
-	"github.com/hashicorp/terraform/internal/lang/marks"
 	"github.com/hashicorp/terraform/internal/plans/planfile"
 	"github.com/hashicorp/terraform/internal/stacks/stackaddrs"
 	"github.com/hashicorp/terraform/internal/stacks/stackstate/statekeys"
@@ -232,17 +231,13 @@ func DecodeProtoResourceInstanceObject(protoObj *tfstackdata1.StateResourceInsta
 		return nil, fmt.Errorf("unsupported status %s", protoObj.Status.String())
 	}
 
-	paths := make([]cty.PathValueMarks, 0, len(protoObj.SensitivePaths))
-	marks := cty.NewValueMarks(marks.Sensitive)
+	paths := make([]cty.Path, 0, len(protoObj.SensitivePaths))
 	for _, p := range protoObj.SensitivePaths {
 		path, err := planfile.PathFromProto(p)
 		if err != nil {
 			return nil, err
 		}
-		paths = append(paths, cty.PathValueMarks{
-			Path:  path,
-			Marks: marks,
-		})
+		paths = append(paths, path)
 	}
 	objSrc.AttrSensitivePaths = paths
 

--- a/internal/states/instance_object_src.go
+++ b/internal/states/instance_object_src.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/configs/hcl2shim"
+	"github.com/hashicorp/terraform/internal/lang/marks"
 )
 
 // ResourceInstanceObjectSrc is a not-fully-decoded version of
@@ -54,7 +55,7 @@ type ResourceInstanceObjectSrc struct {
 
 	// AttrSensitivePaths is an array of paths to mark as sensitive coming out of
 	// state, or to save as sensitive paths when saving state
-	AttrSensitivePaths []cty.PathValueMarks
+	AttrSensitivePaths []cty.Path
 
 	// These fields all correspond to the fields of the same name on
 	// ResourceInstanceObject.
@@ -85,10 +86,7 @@ func (os *ResourceInstanceObjectSrc) Decode(ty cty.Type) (*ResourceInstanceObjec
 		}
 	} else {
 		val, err = ctyjson.Unmarshal(os.AttrsJSON, ty)
-		// Mark the value with paths if applicable
-		if os.AttrSensitivePaths != nil {
-			val = val.MarkWithPaths(os.AttrSensitivePaths)
-		}
+		val = marks.MarkPaths(val, marks.Sensitive, os.AttrSensitivePaths)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/states/instance_object_test.go
+++ b/internal/states/instance_object_test.go
@@ -84,3 +84,27 @@ func TestResourceInstanceObject_encode(t *testing.T) {
 		}
 	}
 }
+
+func TestResourceInstanceObject_encodeInvalidMarks(t *testing.T) {
+	value := cty.ObjectVal(map[string]cty.Value{
+		// State only supports a subset of marks that we know how to persist
+		// between plan/apply rounds. All values with other marks must be
+		// replaced with unmarked placeholders before attempting to store the
+		// value in the state.
+		"foo": cty.True.Mark("unsupported"),
+	})
+
+	obj := &ResourceInstanceObject{
+		Value:  value,
+		Status: ObjectReady,
+	}
+	_, err := obj.Encode(value.Type(), 0)
+	if err == nil {
+		t.Fatalf("unexpected success; want error")
+	}
+	got := err.Error()
+	want := `cannot serialize value marked as "unsupported" for inclusion in a state snapshot (this is a bug in Terraform)`
+	if got != want {
+		t.Errorf("wrong error\ngot:  %s\nwant: %s", got, want)
+	}
+}

--- a/internal/states/instance_object_test.go
+++ b/internal/states/instance_object_test.go
@@ -103,7 +103,7 @@ func TestResourceInstanceObject_encodeInvalidMarks(t *testing.T) {
 		t.Fatalf("unexpected success; want error")
 	}
 	got := err.Error()
-	want := `cannot serialize value marked as "unsupported" for inclusion in a state snapshot (this is a bug in Terraform)`
+	want := `.foo: cannot serialize value marked as cty.NewValueMarks("unsupported") for inclusion in a state snapshot (this is a bug in Terraform)`
 	if got != want {
 		t.Errorf("wrong error\ngot:  %s\nwant: %s", got, want)
 	}

--- a/internal/states/state_deepcopy.go
+++ b/internal/states/state_deepcopy.go
@@ -142,9 +142,9 @@ func (os *ResourceInstanceObjectSrc) DeepCopy() *ResourceInstanceObjectSrc {
 		copy(attrsJSON, os.AttrsJSON)
 	}
 
-	var attrPaths []cty.PathValueMarks
+	var attrPaths []cty.Path
 	if os.AttrSensitivePaths != nil {
-		attrPaths = make([]cty.PathValueMarks, len(os.AttrSensitivePaths))
+		attrPaths = make([]cty.Path, len(os.AttrSensitivePaths))
 		copy(attrPaths, os.AttrSensitivePaths)
 	}
 

--- a/internal/states/state_test.go
+++ b/internal/states/state_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/zclconf/go-cty/cty"
 
 	"github.com/hashicorp/terraform/internal/addrs"
-	"github.com/hashicorp/terraform/internal/lang/marks"
 )
 
 func TestState(t *testing.T) {
@@ -220,11 +219,8 @@ func TestStateDeepCopy(t *testing.T) {
 			SchemaVersion: 1,
 			AttrsJSON:     []byte(`{"woozles":"confuzles"}`),
 			// Sensitive path at "woozles"
-			AttrSensitivePaths: []cty.PathValueMarks{
-				{
-					Path:  cty.Path{cty.GetAttrStep{Name: "woozles"}},
-					Marks: cty.NewValueMarks(marks.Sensitive),
-				},
+			AttrSensitivePaths: []cty.Path{
+				cty.GetAttrPath("woozles"),
 			},
 			Private: []byte("private data"),
 			Dependencies: []addrs.ConfigResource{

--- a/internal/states/statefile/version4.go
+++ b/internal/states/statefile/version4.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/checks"
-	"github.com/hashicorp/terraform/internal/lang/marks"
 	"github.com/hashicorp/terraform/internal/states"
 	"github.com/hashicorp/terraform/internal/tfdiags"
 )
@@ -164,15 +163,7 @@ func prepareStateV4(sV4 *stateV4) (*File, tfdiags.Diagnostics) {
 				if pathsDiags.HasErrors() {
 					continue
 				}
-
-				var pvm []cty.PathValueMarks
-				for _, path := range paths {
-					pvm = append(pvm, cty.PathValueMarks{
-						Path:  path,
-						Marks: cty.NewValueMarks(marks.Sensitive),
-					})
-				}
-				obj.AttrSensitivePaths = pvm
+				obj.AttrSensitivePaths = paths
 			}
 
 			{
@@ -488,32 +479,8 @@ func appendInstanceObjectStateV4(rs *states.Resource, is *states.ResourceInstanc
 		}
 	}
 
-	// Extract paths from path value marks
-	var paths []cty.Path
-	for _, vm := range obj.AttrSensitivePaths {
-		// It's a bug for AttrSensitivePaths to contain anything other than
-		// sensitive marks, because we don't know how to serialize anything
-		// else here. (The main "states" package should've previously rejected
-		// such marks, so this is here just for robustness.)
-		for mark := range vm.Marks {
-			if mark != marks.Sensitive {
-				diags = diags.Append(tfdiags.Sourceless(
-					tfdiags.Error,
-					"Unserializable value mark",
-					fmt.Sprintf(
-						"An attribute of %s has unserializable value mark %#v. This is a bug in Terraform.",
-						rs.Addr.Instance(key), mark,
-					),
-				))
-			}
-		}
-		if _, ok := vm.Marks[marks.Sensitive]; ok {
-			paths = append(paths, vm.Path)
-		}
-	}
-
 	// Marshal paths to JSON
-	attributeSensitivePaths, pathsDiags := marshalPaths(paths)
+	attributeSensitivePaths, pathsDiags := marshalPaths(obj.AttrSensitivePaths)
 	diags = diags.Append(pathsDiags)
 
 	return append(isV4s, instanceObjectStateV4{
@@ -843,6 +810,9 @@ func unmarshalPaths(buf []byte) ([]cty.Path, tfdiags.Diagnostics) {
 		))
 	}
 
+	if len(jsonPaths) == 0 {
+		return nil, diags
+	}
 	paths := make([]cty.Path, 0, len(jsonPaths))
 
 unmarshalOuter:

--- a/internal/states/statefile/version4_test.go
+++ b/internal/states/statefile/version4_test.go
@@ -10,8 +10,6 @@ import (
 
 	"github.com/zclconf/go-cty/cty"
 
-	"github.com/hashicorp/terraform/internal/addrs"
-	"github.com/hashicorp/terraform/internal/states"
 	"github.com/hashicorp/terraform/internal/tfdiags"
 )
 
@@ -260,51 +258,5 @@ func TestVersion4_marshalPaths(t *testing.T) {
 				t.Fatalf("wrong JSON output\n got: %s\nwant: %s\n", got, want)
 			}
 		})
-	}
-}
-
-func TestVersion4_unsupportedMarksInResourceObject(t *testing.T) {
-	// This tests that we reject attempts to serialize unsupported kinds
-	// of value marks as part of the AttrSensitivePaths collection, which
-	// is supposed to be filtered by a caller to include only marks.Sensitive
-	// in particular.
-
-	_, diags := appendInstanceObjectStateV4(
-		&states.Resource{
-			Addr: addrs.AbsResource{
-				Resource: addrs.Resource{
-					Mode: addrs.ManagedResourceMode,
-					Type: "any_type",
-					Name: "any_name",
-				},
-			},
-			ProviderConfig: addrs.AbsProviderConfig{
-				Provider: addrs.NewBuiltInProvider("test"),
-			},
-		},
-		&states.ResourceInstance{},
-		addrs.NoKey,
-		&states.ResourceInstanceObjectSrc{
-			Status:    states.ObjectReady,
-			AttrsJSON: []byte(`{"foo":"bar"}`),
-			AttrSensitivePaths: []cty.PathValueMarks{
-				{
-					Marks: cty.ValueMarks{
-						"unsupported": struct{}{},
-					},
-					Path: cty.GetAttrPath("foo"),
-				},
-			},
-		},
-		addrs.NotDeposed,
-		nil,
-	)
-	if !diags.HasErrors() {
-		t.Fatalf("unexpected success; want error")
-	}
-	got := diags.Err().Error()
-	want := `Unserializable value mark: An attribute of any_type.any_name has unserializable value mark "unsupported". This is a bug in Terraform.`
-	if got != want {
-		t.Errorf("wrong error\ngot:  %s\nwant: %s", got, want)
 	}
 }

--- a/internal/terraform/context_plan2_test.go
+++ b/internal/terraform/context_plan2_test.go
@@ -201,11 +201,8 @@ data "test_data_source" "foo" {
 		&states.ResourceInstanceObjectSrc{
 			Status:    states.ObjectReady,
 			AttrsJSON: []byte(`{"id":"data_id", "foo":[{"bar":"baz"}]}`),
-			AttrSensitivePaths: []cty.PathValueMarks{
-				{
-					Path:  cty.GetAttrPath("foo"),
-					Marks: cty.NewValueMarks(marks.Sensitive),
-				},
+			AttrSensitivePaths: []cty.Path{
+				cty.GetAttrPath("foo"),
 			},
 		},
 		mustProviderConfig(`provider["registry.terraform.io/hashicorp/test"]`),
@@ -2706,11 +2703,8 @@ data "test_data_source" "foo" {
 		&states.ResourceInstanceObjectSrc{
 			Status:    states.ObjectReady,
 			AttrsJSON: []byte(`{"string":"data_id", "foo":[{"bar":"old"}]}`),
-			AttrSensitivePaths: []cty.PathValueMarks{
-				{
-					Path:  cty.GetAttrPath("foo"),
-					Marks: cty.NewValueMarks(marks.Sensitive),
-				},
+			AttrSensitivePaths: []cty.Path{
+				cty.GetAttrPath("foo"),
 			},
 		},
 		mustProviderConfig(`provider["registry.terraform.io/hashicorp/test"]`),
@@ -2720,11 +2714,8 @@ data "test_data_source" "foo" {
 		&states.ResourceInstanceObjectSrc{
 			Status:    states.ObjectReady,
 			AttrsJSON: []byte(`{"sensitive":"old"}`),
-			AttrSensitivePaths: []cty.PathValueMarks{
-				{
-					Path:  cty.GetAttrPath("sensitive"),
-					Marks: cty.NewValueMarks(marks.Sensitive),
-				},
+			AttrSensitivePaths: []cty.Path{
+				cty.GetAttrPath("sensitive"),
 			},
 		},
 		mustProviderConfig(`provider["registry.terraform.io/hashicorp/test"]`),
@@ -5403,11 +5394,8 @@ resource "test_resource" "a" {
 		&states.ResourceInstanceObjectSrc{
 			Status:    states.ObjectReady,
 			AttrsJSON: []byte(`{"value":"secret"}]}`),
-			AttrSensitivePaths: []cty.PathValueMarks{
-				{
-					Path:  cty.GetAttrPath("value"),
-					Marks: cty.NewValueMarks(marks.Sensitive),
-				},
+			AttrSensitivePaths: []cty.Path{
+				cty.GetAttrPath("value"),
 			},
 		},
 		mustProviderConfig(`provider["registry.terraform.io/hashicorp/test"]`),
@@ -5484,7 +5472,7 @@ resource "test_object" "obj" {
 	assertNoErrors(t, diags)
 
 	ch := plan.Changes.ResourceInstance(mustResourceInstanceAddr("test_object.obj"))
-	if len(ch.AfterValMarks) == 0 {
+	if len(ch.AfterSensitivePaths) == 0 {
 		t.Fatal("expected marked values in test_object.obj")
 	}
 
@@ -5540,9 +5528,11 @@ resource "test_object" "obj" {
 
 	state := states.BuildState(func(s *states.SyncState) {
 		s.SetResourceInstanceCurrent(mustResourceInstanceAddr("test_object.obj"), &states.ResourceInstanceObjectSrc{
-			AttrsJSON:          []byte(`{"id":"z","set_block":[{"foo":"bar"}]}`),
-			AttrSensitivePaths: []cty.PathValueMarks{{Path: cty.Path{cty.GetAttrStep{Name: "set_block"}}, Marks: cty.NewValueMarks(marks.Sensitive)}},
-			Status:             states.ObjectReady,
+			AttrsJSON: []byte(`{"id":"z","set_block":[{"foo":"bar"}]}`),
+			AttrSensitivePaths: []cty.Path{
+				cty.GetAttrPath("set_block"),
+			},
+			Status: states.ObjectReady,
 		}, mustProviderConfig(`provider["registry.terraform.io/hashicorp/test"]`))
 	})
 

--- a/internal/terraform/context_plan_test.go
+++ b/internal/terraform/context_plan_test.go
@@ -5605,19 +5605,16 @@ func TestContext2Plan_variableSensitivity(t *testing.T) {
 			checkVals(t, objectVal(t, schema, map[string]cty.Value{
 				"foo": cty.StringVal("foo").Mark(marks.Sensitive),
 			}), ric.After)
-			if len(res.ChangeSrc.BeforeValMarks) != 0 {
-				t.Errorf("unexpected BeforeValMarks: %#v", res.ChangeSrc.BeforeValMarks)
+			if len(res.ChangeSrc.BeforeSensitivePaths) != 0 {
+				t.Errorf("unexpected BeforeSensitivePaths: %#v", res.ChangeSrc.BeforeSensitivePaths)
 			}
-			if len(res.ChangeSrc.AfterValMarks) != 1 {
-				t.Errorf("unexpected AfterValMarks: %#v", res.ChangeSrc.AfterValMarks)
+			if len(res.ChangeSrc.AfterSensitivePaths) != 1 {
+				t.Errorf("unexpected AfterSensitivePaths: %#v", res.ChangeSrc.AfterSensitivePaths)
 				continue
 			}
-			pvm := res.ChangeSrc.AfterValMarks[0]
-			if got, want := pvm.Path, cty.GetAttrPath("foo"); !got.Equals(want) {
+			sensitivePath := res.ChangeSrc.AfterSensitivePaths[0]
+			if got, want := sensitivePath, cty.GetAttrPath("foo"); !got.Equals(want) {
 				t.Errorf("unexpected path for mark\n got: %#v\nwant: %#v", got, want)
-			}
-			if got, want := pvm.Marks, cty.NewValueMarks(marks.Sensitive); !got.Equal(want) {
-				t.Errorf("unexpected value for mark\n got: %#v\nwant: %#v", got, want)
 			}
 		default:
 			t.Fatal("unknown instance:", i)
@@ -5675,29 +5672,27 @@ func TestContext2Plan_variableSensitivityModule(t *testing.T) {
 				"foo":   cty.StringVal("foo").Mark(marks.Sensitive),
 				"value": cty.StringVal("boop").Mark(marks.Sensitive),
 			}), ric.After)
-			if len(res.ChangeSrc.BeforeValMarks) != 0 {
-				t.Errorf("unexpected BeforeValMarks: %#v", res.ChangeSrc.BeforeValMarks)
+			if len(res.ChangeSrc.BeforeSensitivePaths) != 0 {
+				t.Errorf("unexpected BeforeSensitivePaths: %#v", res.ChangeSrc.BeforeSensitivePaths)
 			}
-			if len(res.ChangeSrc.AfterValMarks) != 2 {
-				t.Errorf("expected AfterValMarks to contain two elements: %#v", res.ChangeSrc.AfterValMarks)
+			if len(res.ChangeSrc.AfterSensitivePaths) != 2 {
+				t.Errorf("expected AfterSensitivePaths to contain two elements: %#v", res.ChangeSrc.AfterSensitivePaths)
 				continue
 			}
 			// validate that the after marks have "foo" and "value"
-			contains := func(pvmSlice []cty.PathValueMarks, stepName string) bool {
-				for _, pvm := range pvmSlice {
-					if pvm.Path.Equals(cty.GetAttrPath(stepName)) {
-						if pvm.Marks.Equal(cty.NewValueMarks(marks.Sensitive)) {
-							return true
-						}
+			contains := func(paths []cty.Path, stepName string) bool {
+				for _, path := range paths {
+					if path.Equals(cty.GetAttrPath(stepName)) {
+						return true
 					}
 				}
 				return false
 			}
-			if !contains(res.ChangeSrc.AfterValMarks, "foo") {
-				t.Error("unexpected AfterValMarks to contain \"foo\" with sensitive mark")
+			if !contains(res.ChangeSrc.AfterSensitivePaths, "foo") {
+				t.Error("unexpected AfterSensitivePaths to contain \"foo\" with sensitive mark")
 			}
-			if !contains(res.ChangeSrc.AfterValMarks, "value") {
-				t.Error("unexpected AfterValMarks to contain \"value\" with sensitive mark")
+			if !contains(res.ChangeSrc.AfterSensitivePaths, "value") {
+				t.Error("unexpected AfterSensitivePaths to contain \"value\" with sensitive mark")
 			}
 		default:
 			t.Fatal("unknown instance:", i)
@@ -6902,9 +6897,9 @@ resource "test_resource" "foo" {
 			&states.ResourceInstanceObjectSrc{
 				Status:    states.ObjectReady,
 				AttrsJSON: []byte(`{"id":"foo", "value":"hello", "sensitive_value":"hello"}`),
-				AttrSensitivePaths: []cty.PathValueMarks{
-					{Path: cty.Path{cty.GetAttrStep{Name: "value"}}, Marks: cty.NewValueMarks(marks.Sensitive)},
-					{Path: cty.Path{cty.GetAttrStep{Name: "sensitive_value"}}, Marks: cty.NewValueMarks(marks.Sensitive)},
+				AttrSensitivePaths: []cty.Path{
+					cty.GetAttrPath("value"),
+					cty.GetAttrPath("sensitive_value"),
 				},
 			},
 			addrs.AbsProviderConfig{

--- a/internal/terraform/evaluate.go
+++ b/internal/terraform/evaluate.go
@@ -730,7 +730,10 @@ func (d *evaluationStateData) GetResource(addr addrs.Resource, rng tfdiags.Sourc
 
 			// Unlike decoding state, decoding a change does not automatically
 			// mark values.
-			instances[key] = val.MarkWithPaths(change.AfterValMarks)
+			// FIXME: Correct that inconsistency by moving this logic into
+			// the decoder function in the plans package, so that we can
+			// test that behavior being implemented in only one place.
+			instances[key] = marks.MarkPaths(val, marks.Sensitive, change.AfterSensitivePaths)
 			continue
 		}
 

--- a/internal/terraform/evaluate_test.go
+++ b/internal/terraform/evaluate_test.go
@@ -236,31 +236,13 @@ func TestEvaluatorGetResource(t *testing.T) {
 			&states.ResourceInstanceObjectSrc{
 				Status:    states.ObjectReady,
 				AttrsJSON: []byte(`{"id":"foo", "nesting_list": [{"sensitive_value":"abc"}], "nesting_map": {"foo":{"foo":"x"}}, "nesting_set": [{"baz":"abc"}], "nesting_single": {"boop":"abc"}, "nesting_nesting": {"nesting_list":[{"sensitive_value":"abc"}]}, "value":"hello"}`),
-				AttrSensitivePaths: []cty.PathValueMarks{
-					{
-						Path:  cty.GetAttrPath("nesting_list").IndexInt(0).GetAttr("sensitive_value"),
-						Marks: cty.NewValueMarks(marks.Sensitive),
-					},
-					{
-						Path:  cty.GetAttrPath("nesting_map").IndexString("foo").GetAttr("foo"),
-						Marks: cty.NewValueMarks(marks.Sensitive),
-					},
-					{
-						Path:  cty.GetAttrPath("nesting_nesting").GetAttr("nesting_list").IndexInt(0).GetAttr("sensitive_value"),
-						Marks: cty.NewValueMarks(marks.Sensitive),
-					},
-					{
-						Path:  cty.GetAttrPath("nesting_set"),
-						Marks: cty.NewValueMarks(marks.Sensitive),
-					},
-					{
-						Path:  cty.GetAttrPath("nesting_single").GetAttr("boop"),
-						Marks: cty.NewValueMarks(marks.Sensitive),
-					},
-					{
-						Path:  cty.GetAttrPath("value"),
-						Marks: cty.NewValueMarks(marks.Sensitive),
-					},
+				AttrSensitivePaths: []cty.Path{
+					cty.GetAttrPath("nesting_list").IndexInt(0).GetAttr("sensitive_value"),
+					cty.GetAttrPath("nesting_map").IndexString("foo").GetAttr("foo"),
+					cty.GetAttrPath("nesting_nesting").GetAttr("nesting_list").IndexInt(0).GetAttr("sensitive_value"),
+					cty.GetAttrPath("nesting_set"),
+					cty.GetAttrPath("nesting_single").GetAttr("boop"),
+					cty.GetAttrPath("value"),
 				},
 			},
 			addrs.AbsProviderConfig{

--- a/internal/terraform/node_resource_abstract_instance.go
+++ b/internal/terraform/node_resource_abstract_instance.go
@@ -17,6 +17,7 @@ import (
 	"github.com/hashicorp/terraform/internal/configs"
 	"github.com/hashicorp/terraform/internal/configs/configschema"
 	"github.com/hashicorp/terraform/internal/instances"
+	"github.com/hashicorp/terraform/internal/lang/marks"
 	"github.com/hashicorp/terraform/internal/moduletest/mocking"
 	"github.com/hashicorp/terraform/internal/plans"
 	"github.com/hashicorp/terraform/internal/plans/objchange"
@@ -634,9 +635,7 @@ func (n *NodeAbstractResourceInstance) refresh(ctx EvalContext, deposedKey state
 
 	// Unmarked before sending to provider
 	var priorMarks []cty.PathValueMarks
-	if priorVal.ContainsMarked() {
-		priorVal, priorMarks = priorVal.UnmarkDeepWithPaths()
-	}
+	priorVal, priorMarks = priorVal.UnmarkDeepWithPaths()
 
 	var resp providers.ReadResourceResponse
 	if n.override != nil {
@@ -739,8 +738,9 @@ func (n *NodeAbstractResourceInstance) refresh(ctx EvalContext, deposedKey state
 	// configuration, as well as any marks from the schema which were not in
 	// the prior state. New marks may appear when the prior state was from an
 	// import operation, or if the provider added new marks to the schema.
-	if marks := append(priorMarks, schema.ValueMarks(ret.Value, nil)...); len(marks) > 0 {
-		ret.Value = ret.Value.MarkWithPaths(marks)
+	ret.Value = ret.Value.MarkWithPaths(priorMarks)
+	if moreSensitivePaths := schema.SensitivePaths(ret.Value, nil); len(moreSensitivePaths) != 0 {
+		ret.Value = marks.MarkPaths(ret.Value, marks.Sensitive, moreSensitivePaths)
 	}
 
 	return ret, deferred, diags
@@ -1032,12 +1032,10 @@ func (n *NodeAbstractResourceInstance) plan(
 	// ignore changes have been processed. We add in the schema marks as well,
 	// to ensure that provider defined private attributes are marked correctly
 	// here.
-
-	unmarkedPaths = append(unmarkedPaths, schema.ValueMarks(plannedNewVal, nil)...)
 	unmarkedPlannedNewVal := plannedNewVal
-
-	if len(unmarkedPaths) > 0 {
-		plannedNewVal = plannedNewVal.MarkWithPaths(unmarkedPaths)
+	plannedNewVal = plannedNewVal.MarkWithPaths(unmarkedPaths)
+	if sensitivePaths := schema.SensitivePaths(plannedNewVal, nil); len(sensitivePaths) != 0 {
+		plannedNewVal = marks.MarkPaths(plannedNewVal, marks.Sensitive, sensitivePaths)
 	}
 
 	reqRep, reqRepDiags := getRequiredReplaces(priorVal, plannedNewVal, resp.RequiresReplace, n.ResolvedProvider.Provider, n.Addr)
@@ -1588,9 +1586,9 @@ func (n *NodeAbstractResourceInstance) readDataSource(ctx EvalContext, configVal
 			newVal = cty.UnknownAsNull(newVal)
 		}
 	}
-	pvm = append(pvm, schema.ValueMarks(newVal, nil)...)
-	if len(pvm) > 0 {
-		newVal = newVal.MarkWithPaths(pvm)
+	newVal = newVal.MarkWithPaths(pvm)
+	if sensitivePaths := schema.SensitivePaths(newVal, nil); len(sensitivePaths) != 0 {
+		newVal = marks.MarkPaths(newVal, marks.Sensitive, sensitivePaths)
 	}
 
 	diags = diags.Append(ctx.Hook(func(h Hook) (HookAction, error) {
@@ -1742,9 +1740,9 @@ func (n *NodeAbstractResourceInstance) planDataSource(ctx EvalContext, checkRule
 		// even though we are only returning the config value because we can't
 		// yet read the data source, we need to incorporate the schema marks so
 		// that downstream consumers can detect them when planning.
-		unmarkedPaths = append(unmarkedPaths, schema.ValueMarks(proposedNewVal, nil)...)
-		if len(unmarkedPaths) > 0 {
-			proposedNewVal = proposedNewVal.MarkWithPaths(unmarkedPaths)
+		proposedNewVal = proposedNewVal.MarkWithPaths(unmarkedPaths)
+		if sensitivePaths := schema.SensitivePaths(proposedNewVal, nil); len(sensitivePaths) != 0 {
+			proposedNewVal = marks.MarkPaths(proposedNewVal, marks.Sensitive, sensitivePaths)
 		}
 
 		// Apply detects that the data source will need to be read by the After
@@ -1814,10 +1812,9 @@ func (n *NodeAbstractResourceInstance) planDataSource(ctx EvalContext, checkRule
 			// not only do we want to ensure this synthetic value has the marks,
 			// but since this is the value being returned from the data source
 			// we need to ensure the schema marks are added as well.
-			unmarkedPaths = append(unmarkedPaths, schema.ValueMarks(newVal, nil)...)
-
-			if len(unmarkedPaths) > 0 {
-				newVal = newVal.MarkWithPaths(unmarkedPaths)
+			newVal = newVal.MarkWithPaths(unmarkedPaths)
+			if sensitivePaths := schema.SensitivePaths(newVal, nil); len(sensitivePaths) != 0 {
+				newVal = marks.MarkPaths(newVal, marks.Sensitive, sensitivePaths)
 			}
 
 			// We still want to report the check as failed even if we are still
@@ -2445,8 +2442,9 @@ func (n *NodeAbstractResourceInstance) apply(
 	// re-check the value against the schema, because nested computed values
 	// won't be included in afterPaths, which are only what was read from the
 	// After plan value.
-	if marks := append(afterPaths, schema.ValueMarks(newVal, nil)...); len(marks) > 0 {
-		newVal = newVal.MarkWithPaths(marks)
+	newVal = newVal.MarkWithPaths(afterPaths)
+	if sensitivePaths := schema.SensitivePaths(newVal, nil); len(sensitivePaths) != 0 {
+		newVal = marks.MarkPaths(newVal, marks.Sensitive, sensitivePaths)
 	}
 
 	if newVal == cty.NilVal {

--- a/internal/terraform/node_resource_plan_partialexp.go
+++ b/internal/terraform/node_resource_plan_partialexp.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/configs"
 	"github.com/hashicorp/terraform/internal/instances"
+	"github.com/hashicorp/terraform/internal/lang/marks"
 	"github.com/hashicorp/terraform/internal/plans"
 	"github.com/hashicorp/terraform/internal/plans/objchange"
 	"github.com/hashicorp/terraform/internal/providers"
@@ -291,9 +292,9 @@ func (n *nodePlannablePartialExpandedResource) managedResourceExecute(ctx EvalCo
 
 	// We need to combine the dynamic marks with the static marks implied by
 	// the provider's schema.
-	unmarkedPaths = append(unmarkedPaths, schema.ValueMarks(plannedNewVal, nil)...)
-	if len(unmarkedPaths) > 0 {
-		plannedNewVal = plannedNewVal.MarkWithPaths(unmarkedPaths)
+	plannedNewVal = plannedNewVal.MarkWithPaths(unmarkedPaths)
+	if sensitivePaths := schema.SensitivePaths(plannedNewVal, nil); len(sensitivePaths) != 0 {
+		plannedNewVal = marks.MarkPaths(plannedNewVal, marks.Sensitive, sensitivePaths)
 	}
 
 	change.After = plannedNewVal


### PR DESCRIPTION
In the very first implementation of "sensitive values" we were unfortunately not disciplined about separating the idea of "marked value" from the idea of "sensitive value" (where the latter is a subset of the former). The first implementation just assumed that any marking whatsoever meant "sensitive".

We later improved that by adding the marks package and the `marks.Sensitive` value to standardize on the representation of "sensitive value" as being a value marked with _that specific mark_.

However, we did not perform a thorough review of all of the mark-handling codepaths to make sure they all agreed on that definition. In particular, the state and plan models were both designed as if they supported arbitrary marks but then in practice marks other than `marks.Sensitive` would be handled in various inconsistent ways: dropped entirely, or interpreted as if marks.Sensitive, and possibly do so inconsistently when a value is used only in memory vs. round-tripped through a wire/file format.

The goal of this commit is to resolve those oddities so that there are now two possible situations:
 - **Fully-general mark handling:** some codepaths genuinely handle marks generically, by transporting them from input value to output value in a way consistent with how cty itself deals with marks. This is the ideal case because it means we can add new marks in future and assume these codepaths will handle them correctly without any further modifications.
 - **Sensitive-only mark preservation:** the codepaths that interact with our wire protocols and file formats typically have only specialized support for sensitive values in particular, and lack support for any other marks. Those codepaths are now subject to a new rule where they must return an error if asked to deal with any other mark, so that if we introduce new marks in future we'll be forced either to define how we'll avoid those markings reaching the file/wire formats or extend the file/wire formats to support the new marks.

Some new helper functions in `package marks` are intended to standardize how we deal with the "sensitive values only" situations, in the hope that this will make it easier to keep things consistent as the codebase evolves in future.

In practice the modules runtime only ever uses `marks.Sensitive` as a mark today, so all of these checks are effectively covering "should never happen" cases. The only other mark Terraform uses is an implementation detail of `terraform console` and does not interact with any of the codepaths that only support sensitive values in particular.

---

The motivation for doing this _now_ is that I'm starting some research/prototyping on a new feature whose most reasonable implementation is to add another mark, and the inconsistent handling of marks was a significant reason why the previous round of prototyping in this area was unsuccessful.

This particular new mark would _not_ need to be supported by our wire formats because its purpose is specifically to represent values that are forbidden from being persisted. That, then, is what motivated some of the comments in the code added by this PR which asserts that some caller ought to have already dealt with other marks: the only other candidate we have for a mark right now is one that would be handled entirely inside the modules runtime itself, and not exposed in the file formats at all.
