### PR TITLE
terraform test: don't remove sensitive marks from inputs

### DIFF
--- a/internal/backend/local/test.go
+++ b/internal/backend/local/test.go
@@ -20,7 +20,6 @@ import (
 	"github.com/hashicorp/terraform/internal/command/views"
 	"github.com/hashicorp/terraform/internal/configs"
 	"github.com/hashicorp/terraform/internal/lang"
-	"github.com/hashicorp/terraform/internal/lang/marks"
 	"github.com/hashicorp/terraform/internal/logging"
 	"github.com/hashicorp/terraform/internal/moduletest"
 	configtest "github.com/hashicorp/terraform/internal/moduletest/config"
@@ -1239,34 +1238,11 @@ func (runner *TestFileRunner) FilterVariablesToModule(config *configs.Config, va
 	moduleVars = make(terraform.InputValues)
 	testOnlyVars = make(terraform.InputValues)
 	for name, value := range values {
-		variableConfig, exists := config.Module.Variables[name]
+		_, exists := config.Module.Variables[name]
 		if !exists {
 			// If it's not in the configuration then it's a test-only variable.
 			testOnlyVars[name] = value
 			continue
-		}
-
-		if marks.Has(value.Value, marks.Sensitive) {
-			unmarkedValue, _ := value.Value.Unmark()
-			if !variableConfig.Sensitive {
-				// Then we are passing a sensitive value into a non-sensitive
-				// variable. Let's add a warning and tell the user they should
-				// mark the config as sensitive as well. If the config variable
-				// is sensitive, then we don't need to worry.
-				diags = diags.Append(&hcl.Diagnostic{
-					Severity: hcl.DiagWarning,
-					Summary:  "Sensitive metadata on variable lost",
-					Detail:   fmt.Sprintf("The input variable is marked as sensitive, while the receiving configuration is not. The underlying sensitive information may be exposed when var.%s is referenced. Mark the variable block in the configuration as sensitive to resolve this warning.", variableConfig.Name),
-					Subject:  value.SourceRange.ToHCL().Ptr(),
-				})
-			}
-
-			// Set the unmarked value into the input value.
-			value = &terraform.InputValue{
-				Value:       unmarkedValue,
-				SourceType:  value.SourceType,
-				SourceRange: value.SourceRange,
-			}
 		}
 
 		moduleVars[name] = value

--- a/internal/command/test_test.go
+++ b/internal/command/test_test.go
@@ -1703,7 +1703,7 @@ func TestTest_SensitiveInputValues(t *testing.T) {
 		Meta: meta,
 	}
 
-	code := c.Run([]string{"-no-color"})
+	code := c.Run([]string{"-no-color", "-verbose"})
 	output := done(t)
 
 	if code != 0 {
@@ -1712,17 +1712,26 @@ func TestTest_SensitiveInputValues(t *testing.T) {
 
 	expected := `main.tftest.hcl... in progress
   run "setup"... pass
+
+
+
+Outputs:
+
+password = (sensitive value)
+
   run "test"... pass
 
-Warning: Sensitive metadata on variable lost
+# test_resource.resource:
+resource "test_resource" "resource" {
+    destroy_fail = false
+    id           = "9ddca5a9"
+    value        = (sensitive value)
+}
 
-  on main.tftest.hcl line 13, in run "test":
-  13:     password = run.setup.password
 
-The input variable is marked as sensitive, while the receiving configuration
-is not. The underlying sensitive information may be exposed when var.password
-is referenced. Mark the variable block in the configuration as sensitive to
-resolve this warning.
+Outputs:
+
+password = (sensitive value)
 
 main.tftest.hcl... tearing down
 main.tftest.hcl... pass

--- a/internal/command/testdata/test/sensitive_input_values/main.tf
+++ b/internal/command/testdata/test/sensitive_input_values/main.tf
@@ -2,6 +2,11 @@ variable "password" {
   type = string
 }
 
+resource "test_resource" "resource" {
+  id = "9ddca5a9"
+  value = var.password
+}
+
 output "password" {
   value = var.password
   sensitive = true


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

Previously, the Terraform plan functionality forbade input values with sensitive marks. The testing framework avoided this by removing the sensitive marks from inputs, and printing a warning if the input variable was not marked as sensitive. As of https://github.com/hashicorp/terraform/pull/34414 the terraform plan can now handle sensitive marks on input values. This means the testing framework no longer needs to remove sensitive marks, and warn users about the sensitive metadata being lost.

There's also a flyby refactoring of the tests in test_test.go to remove the init output from the expected/actual comparisons introduced as part of the recent `init` command refactoring. We don't care about validating the init output for theses tests.

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Fixes #35011

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.9.0

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

### ENHANCEMENTS

<!--

Write a short description of the user-facing change. Examples:

- `terraform show -json`: Fixed crash with sensitive set values.
- When rendering a diff, Terraform now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 

-  `terraform test`: The test framework can now maintain sensitive metadata between run blocks.
