### PR TITLE
Add acceptance and internal tests for `gcs` backend, add some test helper functions

### DIFF
--- a/internal/backend/remote-state/gcs/backend_internal_test.go
+++ b/internal/backend/remote-state/gcs/backend_internal_test.go
@@ -12,7 +12,8 @@ import (
 )
 
 func TestBackendConfig_encryptionKey(t *testing.T) {
-	t.Parallel()
+	// Cannot use t.Parallel as t.SetEnv used
+
 	// TODO - add pre check that asserts ENVs for credentials are set when the test runs
 
 	// getWantValue is required because the key input is changed internally in the backend's code

--- a/internal/backend/remote-state/gcs/backend_internal_test.go
+++ b/internal/backend/remote-state/gcs/backend_internal_test.go
@@ -15,6 +15,9 @@ func TestBackendConfig_encryptionKey(t *testing.T) {
 	t.Parallel()
 	// TODO - add pre check that asserts ENVs for credentials are set when the test runs
 
+	// getWantValue is required because the key input is changed internally in the backend's code
+	// This function is a quick way to help us get a want value, but ideally in future the test and
+	// the code under test will use a reusable function to avoid logic duplication.
 	getWantValue := func(key string) []byte {
 		var want []byte
 		if key == "" {

--- a/internal/backend/remote-state/gcs/backend_internal_test.go
+++ b/internal/backend/remote-state/gcs/backend_internal_test.go
@@ -12,9 +12,8 @@ import (
 )
 
 func TestBackendConfig_encryptionKey(t *testing.T) {
+	preCheckEnvironmentVariables(t)
 	// Cannot use t.Parallel as t.SetEnv used
-
-	// TODO - add pre check that asserts ENVs for credentials are set when the test runs
 
 	// getWantValue is required because the key input is changed internally in the backend's code
 	// This function is a quick way to help us get a want value, but ideally in future the test and
@@ -104,8 +103,8 @@ func TestBackendConfig_encryptionKey(t *testing.T) {
 }
 
 func TestBackendConfig_kmsKey(t *testing.T) {
-	t.Parallel()
-	// TODO - add pre check that asserts ENVs for credentials are set when the test runs
+	preCheckEnvironmentVariables(t)
+	// Cannot use t.Parallel() due to t.Setenv
 
 	cases := map[string]struct {
 		config map[string]interface{}

--- a/internal/backend/remote-state/gcs/backend_internal_test.go
+++ b/internal/backend/remote-state/gcs/backend_internal_test.go
@@ -6,9 +6,11 @@ package gcs
 import (
 	"encoding/base64"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform/internal/backend"
+	"github.com/zclconf/go-cty/cty"
 )
 
 func TestBackendConfig_encryptionKey(t *testing.T) {
@@ -200,5 +202,55 @@ func TestStateFile(t *testing.T) {
 		if got := b.lockFile(c.name); got != c.wantLockFile {
 			t.Errorf("lockFile(%q) = %q, want %q", c.name, got, c.wantLockFile)
 		}
+	}
+}
+
+func TestBackendEncryptionKeyEmptyConflict(t *testing.T) {
+	// This test is for the edge case where encryption_key and
+	// kms_encryption_key are both set in the configuration but set to empty
+	// strings. The "SDK-like" helpers treat unset as empty string, so
+	// we need an extra rule to catch them both being set to empty string
+	// directly inside the configuration, and this test covers that
+	// special case.
+	//
+	// The following assumes that the validation check we're testing will, if
+	// failing, always block attempts to reach any real GCP services, and so
+	// this test should be fine to run without an acceptance testing opt-in.
+
+	// This test is for situations where these environment variables are not set.
+	t.Setenv("GOOGLE_ENCRYPTION_KEY", "")
+	t.Setenv("GOOGLE_KMS_ENCRYPTION_KEY", "")
+
+	backend := New()
+	schema := backend.ConfigSchema()
+	rawVal := cty.ObjectVal(map[string]cty.Value{
+		"bucket": cty.StringVal("fake-placeholder"),
+
+		// These are both empty strings but should still be considered as
+		// set when we enforce teh rule that they can't both be set at once.
+		"encryption_key":     cty.StringVal(""),
+		"kms_encryption_key": cty.StringVal(""),
+	})
+	// The following mimicks how the terraform_remote_state data source
+	// treats its "config" argument, which is a realistic situation where
+	// we take an arbitrary object and try to force it to conform to the
+	// backend's schema.
+	configVal, err := schema.CoerceValue(rawVal)
+	if err != nil {
+		t.Fatalf("unexpected coersion error: %s", err)
+	}
+	configVal, diags := backend.PrepareConfig(configVal)
+	if diags.HasErrors() {
+		t.Fatalf("unexpected PrepareConfig error: %s", diags.Err().Error())
+	}
+
+	configDiags := backend.Configure(configVal)
+	if !configDiags.HasErrors() {
+		t.Fatalf("unexpected success; want error")
+	}
+	gotErr := configDiags.Err().Error()
+	wantErr := `can't set both encryption_key and kms_encryption_key`
+	if !strings.Contains(gotErr, wantErr) {
+		t.Errorf("wrong error\ngot: %s\nwant substring: %s", gotErr, wantErr)
 	}
 }

--- a/internal/backend/remote-state/gcs/backend_internal_test.go
+++ b/internal/backend/remote-state/gcs/backend_internal_test.go
@@ -1,0 +1,201 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package gcs
+
+import (
+	"encoding/base64"
+	"reflect"
+	"testing"
+
+	"github.com/hashicorp/terraform/internal/backend"
+)
+
+func TestBackendConfig_encryptionKey(t *testing.T) {
+	t.Parallel()
+	// TODO - add pre check that asserts ENVs for credentials are set when the test runs
+
+	getWantValue := func(key string) []byte {
+		var want []byte
+		if key == "" {
+			want = nil
+		}
+		if key != "" {
+			var err error
+			want, err = base64.StdEncoding.DecodeString(key)
+			if err != nil {
+				t.Fatalf("error in test setup: %s", err.Error())
+			}
+		}
+		return want
+	}
+
+	cases := map[string]struct {
+		config map[string]interface{}
+		envs   map[string]string
+		want   []byte
+	}{
+		"unset in config and ENVs": {
+			config: map[string]interface{}{
+				"bucket": "foobar",
+			},
+			want: getWantValue(""),
+		},
+
+		"set in config only": {
+			config: map[string]interface{}{
+				"bucket":         "foobar",
+				"encryption_key": encryptionKey,
+			},
+			want: getWantValue(encryptionKey),
+		},
+
+		"set in config and GOOGLE_ENCRYPTION_KEY": {
+			config: map[string]interface{}{
+				"bucket":         "foobar",
+				"encryption_key": encryptionKey,
+			},
+			envs: map[string]string{
+				"GOOGLE_ENCRYPTION_KEY": encryptionKey2, // Different
+			},
+			want: getWantValue(encryptionKey),
+		},
+
+		"set in GOOGLE_ENCRYPTION_KEY only": {
+			config: map[string]interface{}{
+				"bucket": "foobar",
+			},
+			envs: map[string]string{
+				"GOOGLE_ENCRYPTION_KEY": encryptionKey2,
+			},
+			want: getWantValue(encryptionKey2),
+		},
+
+		"set in config as empty string and in GOOGLE_ENCRYPTION_KEY": {
+			config: map[string]interface{}{
+				"bucket":         "foobar",
+				"encryption_key": "",
+			},
+			envs: map[string]string{
+				"GOOGLE_ENCRYPTION_KEY": encryptionKey2,
+			},
+			want: getWantValue(encryptionKey2),
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			for k, v := range tc.envs {
+				t.Setenv(k, v)
+			}
+
+			b := backend.TestBackendConfig(t, New(), backend.TestWrapConfig(tc.config))
+			be := b.(*Backend)
+
+			if !reflect.DeepEqual(be.encryptionKey, tc.want) {
+				t.Fatalf("unexpected encryption_key value: wanted %v, got %v", tc.want, be.encryptionKey)
+			}
+		})
+	}
+}
+
+func TestBackendConfig_kmsKey(t *testing.T) {
+	t.Parallel()
+	// TODO - add pre check that asserts ENVs for credentials are set when the test runs
+
+	cases := map[string]struct {
+		config map[string]interface{}
+		envs   map[string]string
+		want   string
+	}{
+		"unset in config and ENVs": {
+			config: map[string]interface{}{
+				"bucket": "foobar",
+			},
+		},
+
+		"set in config only": {
+			config: map[string]interface{}{
+				"bucket":             "foobar",
+				"kms_encryption_key": "value from config",
+			},
+			want: "value from config",
+		},
+
+		"set in config and GOOGLE_KMS_ENCRYPTION_KEY": {
+			config: map[string]interface{}{
+				"bucket":             "foobar",
+				"kms_encryption_key": "value from config",
+			},
+			envs: map[string]string{
+				"GOOGLE_KMS_ENCRYPTION_KEY": "value from GOOGLE_KMS_ENCRYPTION_KEY",
+			},
+			want: "value from config",
+		},
+
+		"set in GOOGLE_KMS_ENCRYPTION_KEY only": {
+			config: map[string]interface{}{
+				"bucket": "foobar",
+			},
+			envs: map[string]string{
+				"GOOGLE_KMS_ENCRYPTION_KEY": "value from GOOGLE_KMS_ENCRYPTION_KEY",
+			},
+			want: "value from GOOGLE_KMS_ENCRYPTION_KEY",
+		},
+
+		"set in config as empty string and in GOOGLE_KMS_ENCRYPTION_KEY": {
+			config: map[string]interface{}{
+				"bucket":             "foobar",
+				"kms_encryption_key": "",
+			},
+			envs: map[string]string{
+				"GOOGLE_KMS_ENCRYPTION_KEY": "value from GOOGLE_KMS_ENCRYPTION_KEY",
+			},
+			want: "value from GOOGLE_KMS_ENCRYPTION_KEY",
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			for k, v := range tc.envs {
+				t.Setenv(k, v)
+			}
+
+			b := backend.TestBackendConfig(t, New(), backend.TestWrapConfig(tc.config))
+			be := b.(*Backend)
+
+			if be.kmsKeyName != tc.want {
+				t.Fatalf("unexpected kms_encryption_key value: wanted %v, got %v", tc.want, be.kmsKeyName)
+			}
+		})
+	}
+}
+
+func TestStateFile(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		prefix        string
+		name          string
+		wantStateFile string
+		wantLockFile  string
+	}{
+		{"state", "default", "state/default.tfstate", "state/default.tflock"},
+		{"state", "test", "state/test.tfstate", "state/test.tflock"},
+		{"state", "test", "state/test.tfstate", "state/test.tflock"},
+		{"state", "test", "state/test.tfstate", "state/test.tflock"},
+	}
+	for _, c := range cases {
+		b := &Backend{
+			prefix: c.prefix,
+		}
+
+		if got := b.stateFile(c.name); got != c.wantStateFile {
+			t.Errorf("stateFile(%q) = %q, want %q", c.name, got, c.wantStateFile)
+		}
+
+		if got := b.lockFile(c.name); got != c.wantLockFile {
+			t.Errorf("lockFile(%q) = %q, want %q", c.name, got, c.wantLockFile)
+		}
+	}
+}

--- a/internal/backend/remote-state/gcs/backend_internal_test.go
+++ b/internal/backend/remote-state/gcs/backend_internal_test.go
@@ -17,22 +17,20 @@ func TestBackendConfig_encryptionKey(t *testing.T) {
 	preCheckEnvironmentVariables(t)
 	// Cannot use t.Parallel as t.SetEnv used
 
-	// getWantValue is required because the key input is changed internally in the backend's code
-	// This function is a quick way to help us get a want value, but ideally in future the test and
-	// the code under test will use a reusable function to avoid logic duplication.
-	getWantValue := func(key string) []byte {
-		var want []byte
+	// This function is required because the key input is changed internally in the backend's code.
+	// This function is a quick way to help us get an expected value for tests, but ideally in future
+	// the test and the code under test will use a reusable function to avoid logic duplication.
+	expectedValue := func(key string) []byte {
 		if key == "" {
-			want = nil
+			return nil
 		}
 		if key != "" {
-			var err error
-			want, err = base64.StdEncoding.DecodeString(key)
+			v, err := base64.StdEncoding.DecodeString(key)
 			if err != nil {
 				t.Fatalf("error in test setup: %s", err.Error())
 			}
+			return v
 		}
-		return want
 	}
 
 	cases := map[string]struct {
@@ -44,7 +42,7 @@ func TestBackendConfig_encryptionKey(t *testing.T) {
 			config: map[string]interface{}{
 				"bucket": "foobar",
 			},
-			want: getWantValue(""),
+			want: expectedValue(""),
 		},
 
 		"set in config only": {
@@ -52,7 +50,7 @@ func TestBackendConfig_encryptionKey(t *testing.T) {
 				"bucket":         "foobar",
 				"encryption_key": encryptionKey,
 			},
-			want: getWantValue(encryptionKey),
+			want: expectedValue(encryptionKey),
 		},
 
 		"set in config and GOOGLE_ENCRYPTION_KEY": {
@@ -63,7 +61,7 @@ func TestBackendConfig_encryptionKey(t *testing.T) {
 			envs: map[string]string{
 				"GOOGLE_ENCRYPTION_KEY": encryptionKey2, // Different
 			},
-			want: getWantValue(encryptionKey),
+			want: expectedValue(encryptionKey),
 		},
 
 		"set in GOOGLE_ENCRYPTION_KEY only": {
@@ -73,7 +71,7 @@ func TestBackendConfig_encryptionKey(t *testing.T) {
 			envs: map[string]string{
 				"GOOGLE_ENCRYPTION_KEY": encryptionKey2,
 			},
-			want: getWantValue(encryptionKey2),
+			want: expectedValue(encryptionKey2),
 		},
 
 		"set in config as empty string and in GOOGLE_ENCRYPTION_KEY": {
@@ -84,7 +82,7 @@ func TestBackendConfig_encryptionKey(t *testing.T) {
 			envs: map[string]string{
 				"GOOGLE_ENCRYPTION_KEY": encryptionKey2,
 			},
-			want: getWantValue(encryptionKey2),
+			want: expectedValue(encryptionKey2),
 		},
 	}
 

--- a/internal/backend/remote-state/gcs/backend_internal_test.go
+++ b/internal/backend/remote-state/gcs/backend_internal_test.go
@@ -24,13 +24,12 @@ func TestBackendConfig_encryptionKey(t *testing.T) {
 		if key == "" {
 			return nil
 		}
-		if key != "" {
-			v, err := base64.StdEncoding.DecodeString(key)
-			if err != nil {
-				t.Fatalf("error in test setup: %s", err.Error())
-			}
-			return v
+
+		v, err := base64.StdEncoding.DecodeString(key)
+		if err != nil {
+			t.Fatalf("error in test setup: %s", err.Error())
 		}
+		return v
 	}
 
 	cases := map[string]struct {

--- a/internal/backend/remote-state/gcs/backend_test.go
+++ b/internal/backend/remote-state/gcs/backend_test.go
@@ -243,7 +243,10 @@ func TestAccRemoteClient(t *testing.T) {
 	t.Parallel()
 
 	bucket := bucketName(t)
-	be := setupBackend(t, bucket, noPrefix, noEncryptionKey, noKmsKeyName)
+	config := map[string]interface{}{
+		"bucket": bucket,
+	}
+	be := setupBackend(t, config)
 	defer teardownBackend(t, be, noPrefix)
 
 	ss, err := be.StateMgr(backend.DefaultStateName)
@@ -264,7 +267,11 @@ func TestAccRemoteClientWithEncryption(t *testing.T) {
 	t.Parallel()
 
 	bucket := bucketName(t)
-	be := setupBackend(t, bucket, noPrefix, encryptionKey, noKmsKeyName)
+	config := map[string]interface{}{
+		"bucket":         bucket,
+		"encryption_key": encryptionKey,
+	}
+	be := setupBackend(t, config)
 	defer teardownBackend(t, be, noPrefix)
 
 	ss, err := be.StateMgr(backend.DefaultStateName)
@@ -285,7 +292,10 @@ func TestAccRemoteLocks(t *testing.T) {
 	t.Parallel()
 
 	bucket := bucketName(t)
-	be := setupBackend(t, bucket, noPrefix, noEncryptionKey, noKmsKeyName)
+	config := map[string]interface{}{
+		"bucket": bucket,
+	}
+	be := setupBackend(t, config)
 	defer teardownBackend(t, be, noPrefix)
 
 	remoteClient := func() (remote.Client, error) {
@@ -320,10 +330,13 @@ func TestAccBackend(t *testing.T) {
 
 	bucket := bucketName(t)
 
-	be0 := setupBackend(t, bucket, noPrefix, noEncryptionKey, noKmsKeyName)
+	config := map[string]interface{}{
+		"bucket": bucket,
+	}
+	be0 := setupBackend(t, config)
 	defer teardownBackend(t, be0, noPrefix)
 
-	be1 := setupBackend(t, bucket, noPrefix, noEncryptionKey, noKmsKeyName)
+	be1 := setupBackend(t, config)
 
 	backend.TestBackendStates(t, be0)
 	backend.TestBackendStateLocks(t, be0, be1)
@@ -337,10 +350,16 @@ func TestAccBackendWithPrefix(t *testing.T) {
 	prefix := "test/prefix"
 	bucket := bucketName(t)
 
-	be0 := setupBackend(t, bucket, prefix, noEncryptionKey, noKmsKeyName)
+	config := map[string]interface{}{
+		"bucket":         bucket,
+		"prefix":         prefix,
+		"encryption_key": encryptionKey,
+	}
+	be0 := setupBackend(t, config)
 	defer teardownBackend(t, be0, prefix)
 
-	be1 := setupBackend(t, bucket, prefix+"/", noEncryptionKey, noKmsKeyName)
+	config["prefix"] = prefix + "/"
+	be1 := setupBackend(t, config)
 
 	backend.TestBackendStates(t, be0)
 	backend.TestBackendStateLocks(t, be0, be1)
@@ -352,10 +371,14 @@ func TestAccBackendWithCustomerSuppliedEncryption(t *testing.T) {
 
 	bucket := bucketName(t)
 
-	be0 := setupBackend(t, bucket, noPrefix, encryptionKey, noKmsKeyName)
+	config := map[string]interface{}{
+		"bucket":         bucket,
+		"encryption_key": encryptionKey,
+	}
+	be0 := setupBackend(t, config)
 	defer teardownBackend(t, be0, noPrefix)
 
-	be1 := setupBackend(t, bucket, noPrefix, encryptionKey, noKmsKeyName)
+	be1 := setupBackend(t, config)
 
 	backend.TestBackendStates(t, be0)
 	backend.TestBackendStateLocks(t, be0, be1)
@@ -378,10 +401,16 @@ func TestAccBackendWithCustomerManagedKMSEncryption(t *testing.T) {
 
 	kmsName := setupKmsKey(t, kmsDetails)
 
-	be0 := setupBackend(t, bucket, noPrefix, noEncryptionKey, kmsName)
+	config := map[string]interface{}{
+		"bucket":             bucket,
+		"prefix":             noPrefix,
+		"kms_encryption_key": kmsName,
+	}
+
+	be0 := setupBackend(t, config)
 	defer teardownBackend(t, be0, noPrefix)
 
-	be1 := setupBackend(t, bucket, noPrefix, noEncryptionKey, kmsName)
+	be1 := setupBackend(t, config)
 
 	backend.TestBackendStates(t, be0)
 	backend.TestBackendStateLocks(t, be0, be1)
@@ -438,7 +467,7 @@ func TestBackendEncryptionKeyEmptyConflict(t *testing.T) {
 }
 
 // setupBackend returns a new GCS backend.
-func setupBackend(t *testing.T, bucket, prefix, key, kmsName string) backend.Backend {
+func setupBackend(t *testing.T, config map[string]interface{}) backend.Backend {
 	t.Helper()
 	ctx := context.Background()
 
@@ -449,24 +478,11 @@ func setupBackend(t *testing.T, bucket, prefix, key, kmsName string) backend.Bac
 			"the TF_ACC and GOOGLE_PROJECT environment variables are set.")
 	}
 
-	config := map[string]interface{}{
-		"bucket": bucket,
-		"prefix": prefix,
-	}
-	// Only add encryption keys to config if non-zero value set
-	// If not set here, default values are supplied in `TestBackendConfig` by `PrepareConfig` function call
-	if len(key) > 0 {
-		config["encryption_key"] = key
-	}
-	if len(kmsName) > 0 {
-		config["kms_encryption_key"] = kmsName
-	}
-
 	b := backend.TestBackendConfig(t, New(), backend.TestWrapConfig(config))
 	be := b.(*Backend)
 
 	// create the bucket if it doesn't exist
-	bkt := be.storageClient.Bucket(bucket)
+	bkt := be.storageClient.Bucket(config["bucket"].(string))
 	_, err := bkt.Attrs(ctx)
 	if err != nil {
 		if err != storage.ErrBucketNotExist {

--- a/internal/backend/remote-state/gcs/backend_test.go
+++ b/internal/backend/remote-state/gcs/backend_test.go
@@ -46,7 +46,7 @@ var keyRingLocation = os.Getenv("GOOGLE_REGION")
 
 func preCheckTestAcc(t *testing.T) {
 	if v := os.Getenv("TF_ACC"); v == "" {
-		t.Fatalf("TF_ACC must be set to run acceptance tests, as they provision real resources")
+		t.Skip("TF_ACC must be set to run acceptance tests, as they provision real resources")
 	}
 }
 

--- a/internal/backend/remote-state/gcs/backend_test.go
+++ b/internal/backend/remote-state/gcs/backend_test.go
@@ -5,12 +5,10 @@ package gcs
 
 import (
 	"context"
-	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"log"
 	"os"
-	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -49,162 +47,6 @@ var keyRingLocation = os.Getenv("GOOGLE_REGION")
 func preCheckTestAcc(t *testing.T) {
 	if v := os.Getenv("TF_ACC"); v == "" {
 		t.Fatalf("TF_ACC must be set to run acceptance tests, as they provision real resources")
-	}
-}
-
-func TestBackendConfig_encryptionKey(t *testing.T) {
-
-	getWantValue := func(key string) []byte {
-		var want []byte
-		if key == "" {
-			want = nil
-		}
-		if key != "" {
-			var err error
-			want, err = base64.StdEncoding.DecodeString(key)
-			if err != nil {
-				t.Fatalf("error in test setup: %s", err.Error())
-			}
-		}
-		return want
-	}
-
-	cases := map[string]struct {
-		config map[string]interface{}
-		envs   map[string]string
-		want   []byte
-	}{
-		"unset in config and ENVs": {
-			config: map[string]interface{}{
-				"bucket": "foobar",
-			},
-			want: getWantValue(""),
-		},
-
-		"set in config only": {
-			config: map[string]interface{}{
-				"bucket":         "foobar",
-				"encryption_key": encryptionKey,
-			},
-			want: getWantValue(encryptionKey),
-		},
-
-		"set in config and GOOGLE_ENCRYPTION_KEY": {
-			config: map[string]interface{}{
-				"bucket":         "foobar",
-				"encryption_key": encryptionKey,
-			},
-			envs: map[string]string{
-				"GOOGLE_ENCRYPTION_KEY": encryptionKey2, // Different
-			},
-			want: getWantValue(encryptionKey),
-		},
-
-		"set in GOOGLE_ENCRYPTION_KEY only": {
-			config: map[string]interface{}{
-				"bucket": "foobar",
-			},
-			envs: map[string]string{
-				"GOOGLE_ENCRYPTION_KEY": encryptionKey2,
-			},
-			want: getWantValue(encryptionKey2),
-		},
-
-		"set in config as empty string and in GOOGLE_ENCRYPTION_KEY": {
-			config: map[string]interface{}{
-				"bucket":         "foobar",
-				"encryption_key": "",
-			},
-			envs: map[string]string{
-				"GOOGLE_ENCRYPTION_KEY": encryptionKey2,
-			},
-			want: getWantValue(encryptionKey2),
-		},
-	}
-
-	for name, tc := range cases {
-		t.Run(name, func(t *testing.T) {
-			for k, v := range tc.envs {
-				t.Setenv(k, v)
-			}
-
-			b := backend.TestBackendConfig(t, New(), backend.TestWrapConfig(tc.config))
-			be := b.(*Backend)
-
-			if !reflect.DeepEqual(be.encryptionKey, tc.want) {
-				t.Fatalf("unexpected encryption_key value: wanted %v, got %v", tc.want, be.encryptionKey)
-			}
-		})
-	}
-}
-
-func TestBackendConfig_kmsKey(t *testing.T) {
-
-	cases := map[string]struct {
-		config map[string]interface{}
-		envs   map[string]string
-		want   string
-	}{
-		"unset in config and ENVs": {
-			config: map[string]interface{}{
-				"bucket": "foobar",
-			},
-		},
-
-		"set in config only": {
-			config: map[string]interface{}{
-				"bucket":             "foobar",
-				"kms_encryption_key": "value from config",
-			},
-			want: "value from config",
-		},
-
-		"set in config and GOOGLE_KMS_ENCRYPTION_KEY": {
-			config: map[string]interface{}{
-				"bucket":             "foobar",
-				"kms_encryption_key": "value from config",
-			},
-			envs: map[string]string{
-				"GOOGLE_KMS_ENCRYPTION_KEY": "value from GOOGLE_KMS_ENCRYPTION_KEY",
-			},
-			want: "value from config",
-		},
-
-		"set in GOOGLE_KMS_ENCRYPTION_KEY only": {
-			config: map[string]interface{}{
-				"bucket": "foobar",
-			},
-			envs: map[string]string{
-				"GOOGLE_KMS_ENCRYPTION_KEY": "value from GOOGLE_KMS_ENCRYPTION_KEY",
-			},
-			want: "value from GOOGLE_KMS_ENCRYPTION_KEY",
-		},
-
-		"set in config as empty string and in GOOGLE_KMS_ENCRYPTION_KEY": {
-			config: map[string]interface{}{
-				"bucket":             "foobar",
-				"kms_encryption_key": "",
-			},
-			envs: map[string]string{
-				"GOOGLE_KMS_ENCRYPTION_KEY": "value from GOOGLE_KMS_ENCRYPTION_KEY",
-			},
-			want: "value from GOOGLE_KMS_ENCRYPTION_KEY",
-		},
-	}
-
-	for name, tc := range cases {
-		t.Run(name, func(t *testing.T) {
-			for k, v := range tc.envs {
-				t.Setenv(k, v)
-			}
-
-			b := backend.TestBackendConfig(t, New(), backend.TestWrapConfig(tc.config))
-			be := b.(*Backend)
-
-			if be.kmsKeyName != tc.want {
-				t.Fatalf("unexpected kms_encryption_key value: wanted %v, got %v", tc.want, be.kmsKeyName)
-			}
-		})
 	}
 }
 
@@ -275,35 +117,6 @@ func TestAccBackendConfig_credentials(t *testing.T) {
 		})
 	}
 
-}
-
-func TestStateFile(t *testing.T) {
-	t.Parallel()
-
-	cases := []struct {
-		prefix        string
-		name          string
-		wantStateFile string
-		wantLockFile  string
-	}{
-		{"state", "default", "state/default.tfstate", "state/default.tflock"},
-		{"state", "test", "state/test.tfstate", "state/test.tflock"},
-		{"state", "test", "state/test.tfstate", "state/test.tflock"},
-		{"state", "test", "state/test.tfstate", "state/test.tflock"},
-	}
-	for _, c := range cases {
-		b := &Backend{
-			prefix: c.prefix,
-		}
-
-		if got := b.stateFile(c.name); got != c.wantStateFile {
-			t.Errorf("stateFile(%q) = %q, want %q", c.name, got, c.wantStateFile)
-		}
-
-		if got := b.lockFile(c.name); got != c.wantLockFile {
-			t.Errorf("lockFile(%q) = %q, want %q", c.name, got, c.wantLockFile)
-		}
-	}
 }
 
 func TestAccRemoteClient(t *testing.T) {

--- a/internal/backend/remote-state/gcs/backend_test.go
+++ b/internal/backend/remote-state/gcs/backend_test.go
@@ -50,16 +50,40 @@ func preCheckTestAcc(t *testing.T) {
 	}
 }
 
+func preCheckEnvironmentVariables(t *testing.T) {
+
+	// TODO - implement a separate function specific to credentials which will iterate through a list of ENV names and return first value found.
+
+	credentials := []string{
+		"GOOGLE_BACKEND_CREDENTIALS",
+		"GOOGLE_CREDENTIALS",
+	}
+	credsFound := false
+	for _, name := range credentials {
+		v := os.Getenv(name)
+		if v != "" {
+			credsFound = true
+			break
+		}
+	}
+	if !credsFound {
+		// Skipping tests because hashicorp/terraform repo doesn't have credentials set up.
+		// In future we should enable tests to run automatically, and make this code fail when no creds are set.
+		t.Skip("credentials need to be provided via GOOGLE_BACKEND_CREDENTIALS or GOOGLE_CREDENTIALS environment variable but neither is set")
+	}
+}
+
 func TestAccBackendConfig_credentials(t *testing.T) {
-	preCheckTestAcc(t)
 	// Cannot use t.Parallel() due to t.Setenv
+	preCheckTestAcc(t)
+	preCheckEnvironmentVariables(t)
 
 	credentials := os.Getenv("GOOGLE_BACKEND_CREDENTIALS")
 	if credentials == "" {
 		credentials = os.Getenv("GOOGLE_CREDENTIALS")
 	}
 	if credentials == "" {
-		t.Fatalf("test requires credentials to be set as either GOOGLE_BACKEND_CREDENTIALS or GOOGLE_CREDENTIALS but neither is set")
+		t.Fatalf("unable to access credentials from the test environment")
 	}
 
 	t.Setenv("GOOGLE_BACKEND_CREDENTIALS", "") // unset value
@@ -120,8 +144,9 @@ func TestAccBackendConfig_credentials(t *testing.T) {
 }
 
 func TestAccRemoteClient(t *testing.T) {
-	preCheckTestAcc(t)
 	t.Parallel()
+	preCheckTestAcc(t)
+	preCheckEnvironmentVariables(t)
 
 	bucket := bucketName(t)
 	config := map[string]interface{}{
@@ -144,8 +169,9 @@ func TestAccRemoteClient(t *testing.T) {
 }
 
 func TestAccRemoteClientWithEncryption(t *testing.T) {
-	preCheckTestAcc(t)
 	t.Parallel()
+	preCheckTestAcc(t)
+	preCheckEnvironmentVariables(t)
 
 	bucket := bucketName(t)
 	config := map[string]interface{}{
@@ -169,8 +195,9 @@ func TestAccRemoteClientWithEncryption(t *testing.T) {
 }
 
 func TestAccRemoteLocks(t *testing.T) {
-	preCheckTestAcc(t)
 	t.Parallel()
+	preCheckTestAcc(t)
+	preCheckEnvironmentVariables(t)
 
 	bucket := bucketName(t)
 	config := map[string]interface{}{
@@ -206,8 +233,9 @@ func TestAccRemoteLocks(t *testing.T) {
 }
 
 func TestAccBackend(t *testing.T) {
-	preCheckTestAcc(t)
 	t.Parallel()
+	preCheckTestAcc(t)
+	preCheckEnvironmentVariables(t)
 
 	bucket := bucketName(t)
 
@@ -225,8 +253,9 @@ func TestAccBackend(t *testing.T) {
 }
 
 func TestAccBackendWithPrefix(t *testing.T) {
-	preCheckTestAcc(t)
 	t.Parallel()
+	preCheckTestAcc(t)
+	preCheckEnvironmentVariables(t)
 
 	prefix := "test/prefix"
 	bucket := bucketName(t)
@@ -247,8 +276,9 @@ func TestAccBackendWithPrefix(t *testing.T) {
 }
 
 func TestAccBackendWithCustomerSuppliedEncryption(t *testing.T) {
-	preCheckTestAcc(t)
 	t.Parallel()
+	preCheckTestAcc(t)
+	preCheckEnvironmentVariables(t)
 
 	bucket := bucketName(t)
 
@@ -266,8 +296,9 @@ func TestAccBackendWithCustomerSuppliedEncryption(t *testing.T) {
 }
 
 func TestAccBackendWithCustomerManagedKMSEncryption(t *testing.T) {
-	preCheckTestAcc(t)
 	t.Parallel()
+	preCheckTestAcc(t)
+	preCheckEnvironmentVariables(t)
 
 	projectID := os.Getenv("GOOGLE_PROJECT")
 	bucket := bucketName(t)

--- a/internal/backend/remote-state/gcs/backend_test.go
+++ b/internal/backend/remote-state/gcs/backend_test.go
@@ -43,6 +43,12 @@ const (
 
 var keyRingLocation = os.Getenv("GOOGLE_REGION")
 
+func preCheckTestAcc(t *testing.T) {
+	if v := os.Getenv("TF_ACC"); v == "" {
+		t.Fatalf("TF_ACC must be set to run acceptance tests, as they provision real resources")
+	}
+}
+
 func TestStateFile(t *testing.T) {
 	t.Parallel()
 
@@ -72,7 +78,8 @@ func TestStateFile(t *testing.T) {
 	}
 }
 
-func TestRemoteClient(t *testing.T) {
+func TestAccRemoteClient(t *testing.T) {
+	preCheckTestAcc(t)
 	t.Parallel()
 
 	bucket := bucketName(t)
@@ -91,7 +98,9 @@ func TestRemoteClient(t *testing.T) {
 
 	remote.TestClient(t, rs.Client)
 }
-func TestRemoteClientWithEncryption(t *testing.T) {
+
+func TestAccRemoteClientWithEncryption(t *testing.T) {
+	preCheckTestAcc(t)
 	t.Parallel()
 
 	bucket := bucketName(t)
@@ -111,7 +120,8 @@ func TestRemoteClientWithEncryption(t *testing.T) {
 	remote.TestClient(t, rs.Client)
 }
 
-func TestRemoteLocks(t *testing.T) {
+func TestAccRemoteLocks(t *testing.T) {
+	preCheckTestAcc(t)
 	t.Parallel()
 
 	bucket := bucketName(t)
@@ -144,7 +154,8 @@ func TestRemoteLocks(t *testing.T) {
 	remote.TestRemoteLocks(t, c0, c1)
 }
 
-func TestBackend(t *testing.T) {
+func TestAccBackend(t *testing.T) {
+	preCheckTestAcc(t)
 	t.Parallel()
 
 	bucket := bucketName(t)
@@ -159,7 +170,8 @@ func TestBackend(t *testing.T) {
 	backend.TestBackendStateForceUnlock(t, be0, be1)
 }
 
-func TestBackendWithPrefix(t *testing.T) {
+func TestAccBackendWithPrefix(t *testing.T) {
+	preCheckTestAcc(t)
 	t.Parallel()
 
 	prefix := "test/prefix"
@@ -173,7 +185,9 @@ func TestBackendWithPrefix(t *testing.T) {
 	backend.TestBackendStates(t, be0)
 	backend.TestBackendStateLocks(t, be0, be1)
 }
-func TestBackendWithCustomerSuppliedEncryption(t *testing.T) {
+
+func TestAccBackendWithCustomerSuppliedEncryption(t *testing.T) {
+	preCheckTestAcc(t)
 	t.Parallel()
 
 	bucket := bucketName(t)
@@ -187,7 +201,8 @@ func TestBackendWithCustomerSuppliedEncryption(t *testing.T) {
 	backend.TestBackendStateLocks(t, be0, be1)
 }
 
-func TestBackendWithCustomerManagedKMSEncryption(t *testing.T) {
+func TestAccBackendWithCustomerManagedKMSEncryption(t *testing.T) {
+	preCheckTestAcc(t)
 	t.Parallel()
 
 	projectID := os.Getenv("GOOGLE_PROJECT")

--- a/internal/backend/remote-state/gcs/backend_test.go
+++ b/internal/backend/remote-state/gcs/backend_test.go
@@ -111,18 +111,15 @@ func TestAccBackendConfig_credentials(t *testing.T) {
 				"GOOGLE_CREDENTIALS": credentials,
 			},
 		},
-		// Uncomment below for sanity checking
-		// Testing with TestBackendConfig currently doesn't let us assert for errors, so instead
-		// run the below and expect it to fail.
-		// "nonsense in config causes an error and GOOGLE_CREDENTIALS isn't used": {
-		// 	config: map[string]interface{}{
-		// 		"bucket":      "tf-test-testaccbackendconfig_credentials_3",
-		// 		"credentials": "foobar",
-		// 	},
-		// 	envs: map[string]string{
-		// 		"GOOGLE_CREDENTIALS": credentials,
-		// 	},
-		// },
+		"credentials in config that isn't an empty string takes precedence over credentials from the environment": {
+			config: map[string]interface{}{
+				"bucket":      "tf-test-testaccbackendconfig_credentials_3",
+				"credentials": credentials,
+			},
+			envs: map[string]string{
+				"GOOGLE_CREDENTIALS": "foobar", // Would cause an error if used
+			},
+		},
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {


### PR DESCRIPTION
Historically the `gcs` backend hasn't been touched much. In the past I've added a few features but largely left the existing codebase as it was previously. Recently the `gcs` backend was refactored in https://github.com/hashicorp/terraform/pull/34989 to avoid using the old SDK.

As part of reviewing that PR I started adding a few acceptance tests in this PR. **There's a lot more work to be done** but I want to avoid this PR getting too big.

This PR:
- Separates acceptance tests and 'internal' tests into separate _test.go files
- Implements some pre-check functions to test for TF_ACC being set and credentials being supplied by the test environment
    - When this info is missing the tests are skipped, to enable checks passing in this repo. This repo has no automated testing of the `gcs` backend set up (//TODO!)
- Adds internal tests that assert:
    - `TestBackendConfig_encryptionKey` - how the config and ENVs for customer-supplied encryption keys are used
    - `TestBackendConfig_kmsKey` - how the config and ENVs for customer-managed (KMS) encryption keys are used
- Adds acc tests the assert:
    - `TestAccBackendConfig_credentials` - empty strings in the backend config don't interrupt use of ENVs for creds.
    - Note: we cannot have tests where we assert a failure, [due to legacy reasons](https://github.com/hashicorp/terraform/blob/c77898c90d95cd1a44970af6af302024f73e56cb/internal/backend/testing.go#L47-L50).


## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.9.x

This PR is not user facing so there's no urgency for it to be in a release

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

### NEW FEATURES | UPGRADE NOTES | ENHANCEMENTS | BUG FIXES | EXPERIMENTS

<!--

Write a short description of the user-facing change. Examples:

- `terraform show -json`: Fixed crash with sensitive set values.
- When rendering a diff, Terraform now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 

-  
