### PR TITLE
terraform test: move override evaluation into expander

### DIFF
--- a/internal/command/validate_test.go
+++ b/internal/command/validate_test.go
@@ -342,9 +342,15 @@ func TestValidateWithInvalidOverrides(t *testing.T) {
 		Meta: meta,
 	}
 
+	output := done(t)
 	if code := init.Run(nil); code != 0 {
-		t.Fatalf("expected status code 0 but got %d: %s", code, ui.ErrorWriter)
+		t.Fatalf("expected status code 0 but got %d: %s", code, output.All())
 	}
+
+	// reset streams for next command
+	streams, done = terminal.StreamsForTesting(t)
+	meta.View = views.NewView(streams)
+	meta.Streams = streams
 
 	c := &ValidateCommand{
 		Meta: meta,
@@ -354,50 +360,14 @@ func TestValidateWithInvalidOverrides(t *testing.T) {
 	args = append(args, "-no-color")
 
 	code := c.Run(args)
-	output := done(t)
+	output = done(t)
 
 	if code != 0 {
 		t.Errorf("Should have passed: %d\n\n%s", code, output.Stderr())
 	}
 
 	actual := output.All()
-	expected := `Initializing the backend...
-Initializing modules...
-- setup in setup
-- test.main.setup in setup
-Initializing provider plugins...
-- Finding latest version of hashicorp/test...
-- Installing hashicorp/test v1.0.0...
-- Installed hashicorp/test v1.0.0 (verified checksum)
-Terraform has created a lock file .terraform.lock.hcl to record the provider
-selections it made above. Include this file in your version control repository
-so that Terraform can guarantee to make the same selections by default when
-you run "terraform init" in the future.
-
-
-Warning: Incomplete lock file information for providers
-
-Due to your customized provider installation methods, Terraform was forced to
-calculate lock file checksums locally for the following providers:
-  - hashicorp/test
-
-The current .terraform.lock.hcl file only includes checksums for linux_amd64,
-so Terraform running on another platform will fail to install these
-providers.
-
-To calculate additional checksums for another platform, run:
-  terraform providers lock -platform=linux_amd64
-(where linux_amd64 is the platform to generate)
-Terraform has been successfully initialized!
-
-You may now begin working with Terraform. Try running "terraform plan" to see
-any changes that are required for your infrastructure. All Terraform commands
-should now work.
-
-If you ever set or change modules or backend configuration for Terraform,
-rerun this command to reinitialize your working directory. If you forget, other
-commands will detect it and remind you to do so if necessary.
-
+	expected := `
 Warning: Invalid override target
 
   on main.tftest.hcl line 4, in mock_provider "test":

--- a/internal/instances/expander.go
+++ b/internal/instances/expander.go
@@ -9,6 +9,8 @@ import (
 	"sync"
 
 	"github.com/hashicorp/terraform/internal/addrs"
+	"github.com/hashicorp/terraform/internal/moduletest/mocking"
+
 	"github.com/zclconf/go-cty/cty"
 )
 
@@ -44,9 +46,9 @@ type Expander struct {
 }
 
 // NewExpander initializes and returns a new Expander, empty and ready to use.
-func NewExpander() *Expander {
+func NewExpander(overrides *mocking.Overrides) *Expander {
 	return &Expander{
-		exps: newExpanderModule(),
+		exps: newExpanderModule(overrides),
 	}
 }
 
@@ -131,8 +133,10 @@ func (e *Expander) SetResourceForEachUnknown(moduleAddr addrs.ModuleInstance, re
 // All of the modules on the path to the identified module must already have
 // had their expansion registered using one of the SetModule* methods before
 // calling, or this method will panic.
-func (e *Expander) ExpandModule(addr addrs.Module) []addrs.ModuleInstance {
-	return e.expandModule(addr, false)
+//
+// Any overridden modules will not be included in the result here.
+func (e *Expander) ExpandModule(addr addrs.Module, includeDirectOverrides bool) []addrs.ModuleInstance {
+	return e.expandModule(addr, false, includeDirectOverrides)
 }
 
 // ExpandAbsModuleCall is similar to [Expander.ExpandModule] except that it
@@ -180,7 +184,7 @@ func (e *Expander) ExpandAbsModuleCall(addr addrs.AbsModuleCall) (keyType addrs.
 // expandModule allows skipping unexpanded module addresses by setting skipUnregistered to true.
 // This is used by instances.Set, which is only concerned with the expanded
 // instances, and should not panic when looking up unknown addresses.
-func (e *Expander) expandModule(addr addrs.Module, skipUnregistered bool) []addrs.ModuleInstance {
+func (e *Expander) expandModule(addr addrs.Module, skipUnregistered, includeDirectOverrides bool) []addrs.ModuleInstance {
 	if len(addr) == 0 {
 		// Root module is always a singleton.
 		return singletonRootModule
@@ -195,7 +199,7 @@ func (e *Expander) expandModule(addr addrs.Module, skipUnregistered bool) []addr
 	// (moduleInstances does plenty of allocations itself, so the benefit of
 	// pre-allocating this is marginal but it's not hard to do.)
 	parentAddr := make(addrs.ModuleInstance, 0, 4)
-	ret := e.exps.moduleInstances(addr, parentAddr, skipUnregistered)
+	ret := e.exps.moduleInstances(addr, parentAddr, skipUnregistered, includeDirectOverrides)
 	sort.SliceStable(ret, func(i, j int) bool {
 		return ret[i].Less(ret[j])
 	})
@@ -215,7 +219,7 @@ func (e *Expander) expandModule(addr addrs.Module, skipUnregistered bool) []addr
 // considered as the union of all of those sets but we return it as a set of
 // sets because the inner sets are of infinite size while the outer set is
 // finite.
-func (e *Expander) UnknownModuleInstances(addr addrs.Module) addrs.Set[addrs.PartialExpandedModule] {
+func (e *Expander) UnknownModuleInstances(addr addrs.Module, includeDirectOverrides bool) addrs.Set[addrs.PartialExpandedModule] {
 	if len(addr) == 0 {
 		// The root module is always "expanded" because it's always a singleton,
 		// so we have nothing to return in that case.
@@ -227,7 +231,7 @@ func (e *Expander) UnknownModuleInstances(addr addrs.Module) addrs.Set[addrs.Par
 
 	ret := addrs.MakeSet[addrs.PartialExpandedModule]()
 	parentAddr := make(addrs.ModuleInstance, 0, 4)
-	e.exps.partialExpandedModuleInstances(addr, parentAddr, ret)
+	e.exps.partialExpandedModuleInstances(addr, parentAddr, includeDirectOverrides, ret)
 	return ret
 }
 
@@ -494,7 +498,7 @@ func (e *Expander) setModuleExpansion(parentAddr addrs.ModuleInstance, callAddr 
 		_, knownKeys, _ := exp.instanceKeys()
 		for _, key := range knownKeys {
 			step := addrs.ModuleInstanceStep{Name: callAddr.Name, InstanceKey: key}
-			mod.childInstances[step] = newExpanderModule()
+			mod.childInstances[step] = newExpanderModule(e.exps.overrides)
 		}
 	}
 	mod.moduleCalls[callAddr] = exp
@@ -550,13 +554,19 @@ type expanderModule struct {
 	moduleCalls    map[addrs.ModuleCall]expansion
 	resources      map[addrs.Resource]expansion
 	childInstances map[addrs.ModuleInstanceStep]*expanderModule
+
+	// overrides ensures that any overriden modules instances will not be
+	// returned as options for expansion. A nil overrides indicates there are
+	// no overrides and we're not operating within the testing framework.
+	overrides *mocking.Overrides
 }
 
-func newExpanderModule() *expanderModule {
+func newExpanderModule(overrides *mocking.Overrides) *expanderModule {
 	return &expanderModule{
 		moduleCalls:    make(map[addrs.ModuleCall]expansion),
 		resources:      make(map[addrs.Resource]expansion),
 		childInstances: make(map[addrs.ModuleInstanceStep]*expanderModule),
+		overrides:      overrides,
 	}
 }
 
@@ -566,8 +576,16 @@ var singletonRootModule = []addrs.ModuleInstance{addrs.RootModuleInstance}
 // expansions have been done, set skipUnregistered to true which allows addrs
 // which may not have been seen to return with no instances rather than
 // panicking.
-func (m *expanderModule) moduleInstances(addr addrs.Module, parentAddr addrs.ModuleInstance, skipUnregistered bool) []addrs.ModuleInstance {
+func (m *expanderModule) moduleInstances(addr addrs.Module, parentAddr addrs.ModuleInstance, skipUnregistered, includeDirectOverrides bool) []addrs.ModuleInstance {
 	callName := addr[0]
+
+	// If the parent module is overridden then this module should not be
+	// expanded. Note, we don't check includeDirectOverrides because if the
+	// parent module is overridden then this module isn't "directly" overridden.
+	if _, overridden := m.overrides.GetModuleOverride(parentAddr); overridden {
+		return nil
+	}
+
 	exp, ok := m.moduleCalls[addrs.ModuleCall{Name: callName}]
 	if !ok {
 		if skipUnregistered {
@@ -593,8 +611,14 @@ func (m *expanderModule) moduleInstances(addr addrs.Module, parentAddr addrs.Mod
 				continue
 			}
 			instAddr := append(parentAddr, step)
-			ret = append(ret, inst.moduleInstances(addr[1:], instAddr, skipUnregistered)...)
+			ret = append(ret, inst.moduleInstances(addr[1:], instAddr, skipUnregistered, includeDirectOverrides)...)
 		}
+		return ret
+	}
+
+	if _, overridden := m.overrides.GetModuleOverride(parentAddr.Child(callName, addrs.NoKey)); !includeDirectOverrides && overridden {
+		// Then all the potential instances of this module have been
+		// overridden so we don't want to do any expansion for them.
 		return ret
 	}
 
@@ -602,6 +626,11 @@ func (m *expanderModule) moduleInstances(addr addrs.Module, parentAddr addrs.Mod
 	// a sequence of addresses under this prefix.
 	_, knownKeys, _ := exp.instanceKeys()
 	for _, k := range knownKeys {
+		if _, overridden := m.overrides.GetModuleOverride(parentAddr.Child(callName, k)); !includeDirectOverrides && overridden {
+			// This specific instance is overridden, so we won't return it.
+			continue
+		}
+
 		// We're reusing the buffer under parentAddr as we recurse through
 		// the structure, so we need to copy it here to produce a final
 		// immutable slice to return.
@@ -613,8 +642,16 @@ func (m *expanderModule) moduleInstances(addr addrs.Module, parentAddr addrs.Mod
 	return ret
 }
 
-func (m *expanderModule) partialExpandedModuleInstances(addr addrs.Module, parentAddr addrs.ModuleInstance, into addrs.Set[addrs.PartialExpandedModule]) {
+func (m *expanderModule) partialExpandedModuleInstances(addr addrs.Module, parentAddr addrs.ModuleInstance, includeDirectOverrides bool, into addrs.Set[addrs.PartialExpandedModule]) {
 	callName := addr[0]
+
+	// If the parent module is overridden then this module should not be
+	// expanded. Note, we don't check includeDirectOverrides because if the
+	// parent module is overridden then this module isn't "directly" overridden.
+	if _, overridden := m.overrides.GetModuleOverride(parentAddr); overridden {
+		return
+	}
+
 	exp, ok := m.moduleCalls[addrs.ModuleCall{Name: callName}]
 	if !ok {
 		// This is a bug in the caller, because it should always register
@@ -623,6 +660,12 @@ func (m *expanderModule) partialExpandedModuleInstances(addr addrs.Module, paren
 		panic(fmt.Sprintf("no expansion has been registered for %s", parentAddr.Child(callName, addrs.NoKey)))
 	}
 	if expansionIsDeferred(exp) {
+		if _, overridden := m.overrides.GetModuleOverride(parentAddr.Child(callName, addrs.NoKey)); !includeDirectOverrides && overridden {
+			// Then all the potential instances of this module have been
+			// overridden so we don't want to do any expansion for them.
+			return
+		}
+
 		// We've found a deferred expansion, so we're done searching this
 		// subtree and can just treat the whole of "addr" as unexpanded
 		// calls.
@@ -642,7 +685,7 @@ func (m *expanderModule) partialExpandedModuleInstances(addr addrs.Module, paren
 				continue
 			}
 			instAddr := append(parentAddr, step)
-			inst.partialExpandedModuleInstances(addr[1:], instAddr, into)
+			inst.partialExpandedModuleInstances(addr[1:], instAddr, includeDirectOverrides, into)
 		}
 	}
 }

--- a/internal/instances/expander_test.go
+++ b/internal/instances/expander_test.go
@@ -9,10 +9,157 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/zclconf/go-cty-debug/ctydebug"
 	"github.com/zclconf/go-cty/cty"
 
 	"github.com/hashicorp/terraform/internal/addrs"
+	"github.com/hashicorp/terraform/internal/configs"
+	"github.com/hashicorp/terraform/internal/moduletest/mocking"
 )
+
+func TestExpanderWithOverrides(t *testing.T) {
+
+	mustModuleInstance := func(t *testing.T, s string) addrs.ModuleInstance {
+		if len(s) == 0 {
+			return addrs.RootModuleInstance
+		}
+
+		addr, diags := addrs.ParseModuleInstanceStr(s)
+		if diags.HasErrors() {
+			t.Fatalf("unexpected error: %s", diags.Err())
+		}
+		return addr
+	}
+
+	tcs := map[string]struct {
+		// Hook to install chosen overrides.
+		overrides mocking.InitLocalOverrides
+
+		// Hook to initialise the expander with the desired state.
+		expander func(*Expander)
+
+		// The target module instance to inspect.
+		target string
+
+		// Set to true to include overrides in the result.
+		includeOverrides bool
+
+		// The expected result.
+		wantModules []addrs.ModuleInstance
+
+		// The expected result for partial modules.
+		wantPartials map[string]bool
+	}{
+		"root module": {
+			wantModules:  singletonRootModule,
+			wantPartials: make(map[string]bool),
+		},
+		"instanced child module not overridden": {
+			expander: func(expander *Expander) {
+				expander.SetModuleCount(addrs.RootModuleInstance, addrs.ModuleCall{Name: "double"}, 2)
+			},
+			target: "module.double",
+			wantModules: []addrs.ModuleInstance{
+				mustModuleInstance(t, "module.double[0]"),
+				mustModuleInstance(t, "module.double[1]"),
+			},
+			wantPartials: make(map[string]bool),
+		},
+		"instanced child module single instance overridden": {
+			overrides: func(overrides addrs.Map[addrs.Targetable, *configs.Override]) {
+				overrides.Put(mustModuleInstance(t, "module.double[0]"), &configs.Override{})
+			},
+			expander: func(expander *Expander) {
+				expander.SetModuleCount(addrs.RootModuleInstance, addrs.ModuleCall{Name: "double"}, 2)
+			},
+			target: "module.double",
+			wantModules: []addrs.ModuleInstance{
+				mustModuleInstance(t, "module.double[1]"),
+			},
+			wantPartials: make(map[string]bool),
+		},
+		"instanced child module single instance overridden includes overrides": {
+			overrides: func(overrides addrs.Map[addrs.Targetable, *configs.Override]) {
+				overrides.Put(mustModuleInstance(t, "module.double[0]"), &configs.Override{})
+			},
+			expander: func(expander *Expander) {
+				expander.SetModuleCount(addrs.RootModuleInstance, addrs.ModuleCall{Name: "double"}, 2)
+			},
+			target:           "module.double",
+			includeOverrides: true,
+			wantModules: []addrs.ModuleInstance{
+				mustModuleInstance(t, "module.double[0]"),
+				mustModuleInstance(t, "module.double[1]"),
+			},
+			wantPartials: make(map[string]bool),
+		},
+		"deeply nested child module with parent overridden": {
+			overrides: func(overrides addrs.Map[addrs.Targetable, *configs.Override]) {
+				overrides.Put(mustModuleInstance(t, "module.double[0]"), &configs.Override{})
+			},
+			expander: func(expander *Expander) {
+				expander.SetModuleCount(addrs.RootModuleInstance, addrs.ModuleCall{Name: "double"}, 2)
+				expander.SetModuleSingle(mustModuleInstance(t, "module.double[1]"), addrs.ModuleCall{Name: "single"})
+			},
+			target:       "module.double.module.single",
+			wantModules:  []addrs.ModuleInstance{mustModuleInstance(t, "module.double[1].module.single")},
+			wantPartials: make(map[string]bool),
+		},
+		"unknown child module overridden by instanced module": {
+			overrides: func(overrides addrs.Map[addrs.Targetable, *configs.Override]) {
+				overrides.Put(mustModuleInstance(t, "module.unknown[0]"), &configs.Override{})
+			},
+			expander: func(expander *Expander) {
+				expander.SetModuleCountUnknown(addrs.RootModuleInstance, addrs.ModuleCall{Name: "unknown"})
+			},
+			target: "module.unknown",
+			wantPartials: map[string]bool{
+				"module.unknown[*]": true,
+			},
+		},
+		"unknown child module overridden by instanced module includes overrides": {
+			overrides: func(overrides addrs.Map[addrs.Targetable, *configs.Override]) {
+				overrides.Put(mustModuleInstance(t, "module.unknown"), &configs.Override{})
+			},
+			expander: func(expander *Expander) {
+				expander.SetModuleCountUnknown(addrs.RootModuleInstance, addrs.ModuleCall{Name: "unknown"})
+			},
+			target:       "module.unknown",
+			wantPartials: make(map[string]bool), // This time it's empty, as we overrode all instances.
+		},
+	}
+
+	for name, tc := range tcs {
+		t.Run(name, func(t *testing.T) {
+			overrides := mocking.OverridesForTesting(nil, tc.overrides)
+
+			expander := NewExpander(overrides)
+			if tc.expander != nil {
+				tc.expander(expander)
+			}
+
+			target := mustModuleInstance(t, tc.target).Module()
+
+			gotModules := expander.ExpandModule(target, tc.includeOverrides)
+			gotPartials := expander.UnknownModuleInstances(target, tc.includeOverrides)
+
+			if diff := cmp.Diff(tc.wantModules, gotModules); len(diff) > 0 {
+				t.Errorf("wrong result\n%s", diff)
+			}
+
+			// Convert the gotPartials into strings to make cmp.Diff work.
+			gotPartialsStr := make(map[string]bool, len(gotPartials))
+			for _, partial := range gotPartials {
+				gotPartialsStr[partial.String()] = true
+			}
+
+			if diff := cmp.Diff(tc.wantPartials, gotPartialsStr, ctydebug.CmpOptions); len(diff) > 0 {
+				t.Errorf("wrong result\n%s", diff)
+			}
+		})
+	}
+
+}
 
 func TestExpander(t *testing.T) {
 	// Some module and resource addresses and values we'll use repeatedly below.
@@ -70,7 +217,7 @@ func TestExpander(t *testing.T) {
 	//     - resource test.single with no count or for_each
 	//     - resource test.count2 with count = 2
 
-	ex := NewExpander()
+	ex := NewExpander(nil)
 
 	// We don't register the root module, because it's always implied to exist.
 	//
@@ -126,7 +273,7 @@ func TestExpander(t *testing.T) {
 	t.Run("root module", func(t *testing.T) {
 		// Requesting expansion of the root module doesn't really mean anything
 		// since it's always a singleton, but for consistency it should work.
-		got := ex.ExpandModule(addrs.RootModule)
+		got := ex.ExpandModule(addrs.RootModule, false)
 		want := []addrs.ModuleInstance{addrs.RootModuleInstance}
 		if diff := cmp.Diff(want, got); diff != "" {
 			t.Errorf("wrong result\n%s", diff)
@@ -181,7 +328,7 @@ func TestExpander(t *testing.T) {
 		}
 	})
 	t.Run("module single", func(t *testing.T) {
-		got := ex.ExpandModule(addrs.RootModule.Child("single"))
+		got := ex.ExpandModule(addrs.RootModule.Child("single"), false)
 		want := []addrs.ModuleInstance{
 			mustModuleInstanceAddr(`module.single`),
 		}
@@ -248,7 +395,7 @@ func TestExpander(t *testing.T) {
 		}
 	})
 	t.Run("module count2", func(t *testing.T) {
-		got := ex.ExpandModule(mustModuleAddr(`count2`))
+		got := ex.ExpandModule(mustModuleAddr(`count2`), false)
 		want := []addrs.ModuleInstance{
 			mustModuleInstanceAddr(`module.count2[0]`),
 			mustModuleInstanceAddr(`module.count2[1]`),
@@ -286,7 +433,7 @@ func TestExpander(t *testing.T) {
 		}
 	})
 	t.Run("module count2 module count2", func(t *testing.T) {
-		got := ex.ExpandModule(mustModuleAddr(`count2.count2`))
+		got := ex.ExpandModule(mustModuleAddr(`count2.count2`), false)
 		want := []addrs.ModuleInstance{
 			mustModuleInstanceAddr(`module.count2[0].module.count2[0]`),
 			mustModuleInstanceAddr(`module.count2[0].module.count2[1]`),
@@ -377,7 +524,7 @@ func TestExpander(t *testing.T) {
 		}
 	})
 	t.Run("module count0", func(t *testing.T) {
-		got := ex.ExpandModule(mustModuleAddr(`count0`))
+		got := ex.ExpandModule(mustModuleAddr(`count0`), false)
 		want := []addrs.ModuleInstance(nil)
 		if diff := cmp.Diff(want, got); diff != "" {
 			t.Errorf("wrong result\n%s", diff)
@@ -397,7 +544,7 @@ func TestExpander(t *testing.T) {
 		}
 	})
 	t.Run("module for_each", func(t *testing.T) {
-		got := ex.ExpandModule(mustModuleAddr(`for_each`))
+		got := ex.ExpandModule(mustModuleAddr(`for_each`), false)
 		want := []addrs.ModuleInstance{
 			mustModuleInstanceAddr(`module.for_each["a"]`),
 			mustModuleInstanceAddr(`module.for_each["b"]`),
@@ -524,7 +671,7 @@ func TestExpanderWithUnknowns(t *testing.T) {
 			Type: "test",
 			Name: "foo",
 		}
-		ex := NewExpander()
+		ex := NewExpander(nil)
 		ex.SetResourceForEachUnknown(addrs.RootModuleInstance, resourceAddr)
 
 		got := ex.ExpandModuleResource(addrs.RootModule, resourceAddr)
@@ -538,7 +685,7 @@ func TestExpanderWithUnknowns(t *testing.T) {
 			Type: "test",
 			Name: "foo",
 		}
-		ex := NewExpander()
+		ex := NewExpander(nil)
 		ex.SetResourceCountUnknown(addrs.RootModuleInstance, resourceAddr)
 
 		got := ex.ExpandModuleResource(addrs.RootModule, resourceAddr)
@@ -548,15 +695,15 @@ func TestExpanderWithUnknowns(t *testing.T) {
 	})
 	t.Run("module with unknown for_each", func(t *testing.T) {
 		moduleCallAddr := addrs.ModuleCall{Name: "foo"}
-		ex := NewExpander()
+		ex := NewExpander(nil)
 		ex.SetModuleForEachUnknown(addrs.RootModuleInstance, moduleCallAddr)
 
-		got := ex.ExpandModule(addrs.Module{moduleCallAddr.Name})
+		got := ex.ExpandModule(addrs.Module{moduleCallAddr.Name}, false)
 		if len(got) != 0 {
 			t.Errorf("unexpected known addresses: %#v", got)
 		}
 
-		gotUnknown := ex.UnknownModuleInstances(addrs.Module{moduleCallAddr.Name})
+		gotUnknown := ex.UnknownModuleInstances(addrs.Module{moduleCallAddr.Name}, false)
 		if len(gotUnknown) != 1 {
 			t.Errorf("unexpected unknown addresses: %#v", gotUnknown)
 		}
@@ -567,15 +714,15 @@ func TestExpanderWithUnknowns(t *testing.T) {
 	})
 	t.Run("module with unknown count", func(t *testing.T) {
 		moduleCallAddr := addrs.ModuleCall{Name: "foo"}
-		ex := NewExpander()
+		ex := NewExpander(nil)
 		ex.SetModuleCountUnknown(addrs.RootModuleInstance, moduleCallAddr)
 
-		gotKnown := ex.ExpandModule(addrs.Module{moduleCallAddr.Name})
+		gotKnown := ex.ExpandModule(addrs.Module{moduleCallAddr.Name}, false)
 		if len(gotKnown) != 0 {
 			t.Errorf("unexpected known addresses: %#v", gotKnown)
 		}
 
-		gotUnknown := ex.UnknownModuleInstances(addrs.Module{moduleCallAddr.Name})
+		gotUnknown := ex.UnknownModuleInstances(addrs.Module{moduleCallAddr.Name}, false)
 		if len(gotUnknown) != 1 {
 			t.Errorf("unexpected unknown addresses: %#v", gotUnknown)
 		}
@@ -592,7 +739,7 @@ func TestExpanderWithUnknowns(t *testing.T) {
 		module1Inst0 := addrs.RootModuleInstance.Child("foo", addrs.IntKey(0))
 		module1Inst1 := addrs.RootModuleInstance.Child("foo", addrs.IntKey(1))
 		module1Inst2 := addrs.RootModuleInstance.Child("foo", addrs.IntKey(2))
-		ex := NewExpander()
+		ex := NewExpander(nil)
 		ex.SetModuleCount(addrs.RootModuleInstance, moduleCallAddr1, 3)
 		ex.SetModuleCountUnknown(module1Inst0, moduleCallAddr2)
 		ex.SetModuleCount(module1Inst1, moduleCallAddr2, 1)
@@ -623,7 +770,7 @@ func TestExpanderWithUnknowns(t *testing.T) {
 			t.Fatalf("instances of %s are known; should be unknown", module2Call.String())
 		}
 
-		gotKnown := ex.ExpandModule(module2)
+		gotKnown := ex.ExpandModule(module2, false)
 		wantKnown := []addrs.ModuleInstance{
 			module1Inst1.Child("bar", addrs.IntKey(0)),
 		}
@@ -631,7 +778,7 @@ func TestExpanderWithUnknowns(t *testing.T) {
 			t.Errorf("unexpected known addresses\n%s", diff)
 		}
 
-		gotUnknown := ex.UnknownModuleInstances(module2)
+		gotUnknown := ex.UnknownModuleInstances(module2, false)
 		if len(gotUnknown) != 2 {
 			t.Errorf("unexpected unknown addresses: %#v", gotUnknown)
 		}

--- a/internal/instances/set.go
+++ b/internal/instances/set.go
@@ -49,6 +49,6 @@ func (s Set) HasResource(want addrs.AbsResource) bool {
 // If there are multiple module calls in the path that have repetition enabled
 // then the result is the full expansion of all combinations of all of their
 // declared instance keys.
-func (s Set) InstancesForModule(modAddr addrs.Module) []addrs.ModuleInstance {
-	return s.exp.expandModule(modAddr, true)
+func (s Set) InstancesForModule(modAddr addrs.Module, includeDirectOverrides bool) []addrs.ModuleInstance {
+	return s.exp.expandModule(modAddr, true, includeDirectOverrides)
 }

--- a/internal/instances/set_test.go
+++ b/internal/instances/set_test.go
@@ -6,12 +6,13 @@ package instances
 import (
 	"testing"
 
-	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/zclconf/go-cty/cty"
+
+	"github.com/hashicorp/terraform/internal/addrs"
 )
 
 func TestSet(t *testing.T) {
-	exp := NewExpander()
+	exp := NewExpander(nil)
 
 	// The following constructs the following imaginary module/resource tree:
 	// - root module
@@ -208,7 +209,7 @@ func TestSet(t *testing.T) {
 	}
 
 	// ensure we can lookup non-existent addrs in a set without panic
-	if set.InstancesForModule(addrs.RootModule.Child("missing")) != nil {
+	if set.InstancesForModule(addrs.RootModule.Child("missing"), false) != nil {
 		t.Error("unexpected instances from missing module")
 	}
 }

--- a/internal/moduletest/mocking/overrides.go
+++ b/internal/moduletest/mocking/overrides.go
@@ -79,6 +79,12 @@ func PackageOverrides(run *configs.TestRun, file *configs.TestFile, config *conf
 // cannot target modules directly. Therefore, we only need to check the local
 // overrides within this function.
 func (overrides *Overrides) IsOverridden(module addrs.ModuleInstance) bool {
+	if module.Equal(addrs.RootModuleInstance) {
+		// The root module is never overridden, so let's just short circuit
+		// this.
+		return false
+	}
+
 	if overrides.localOverrides.Has(module) {
 		// Short circuit things, if we have an exact match just return now.
 		return true
@@ -96,52 +102,36 @@ func (overrides *Overrides) IsOverridden(module addrs.ModuleInstance) bool {
 	return false
 }
 
-// IsDeeplyOverridden returns true if an ancestor of this module is overridden
-// but not if the module is overridden directly.
+// GetResourceOverride checks the overrides for the given resource instance.
+// This function automatically checks if the containing resource has been
+// overridden if the instance is instanced.
 //
-// This function doesn't consider an instanced module to be deeply overridden
-// by the uninstanced reference to the same module. So,
-// IsDeeplyOverridden("mod.child[0]") would return false if "mod.child" has been
-// overridden.
+// Users can mark a resource instance as overridden by overriding the instance
+// directly (eg. resource.foo[0]) or by overriding the containing resource
+// (eg. resource.foo).
 //
-// For this function, we know that overrides defined within mock providers
-// cannot target modules directly. Therefore, we only need to check the local
-// overrides within this function.
-func (overrides *Overrides) IsDeeplyOverridden(module addrs.ModuleInstance) bool {
-	for _, elem := range overrides.localOverrides.Elems {
-		target := elem.Key
-
-		if target.TargetContains(module) {
-			// So we do think it contains it, but it could be matching here
-			// because of equality or because we have an instanced module.
-			if instance, ok := target.(addrs.ModuleInstance); ok {
-				if instance.Equal(module) {
-					// Then we're exactly equal, so not deeply nested.
-					continue
-				}
-
-				if instance.Module().Equal(module.Module()) {
-					// Then we're an instanced version of they other one, so
-					// also not deeply nested by our definition of deeply.
-					continue
-				}
-
-			}
-
-			// Otherwise, it's deeply nested.
-			return true
-		}
+// If the resource is being supplied by a mock provider, then we need to check
+// the overrides for that provider as well, as such the provider config is
+// required so we know which mock provider to check.
+func (overrides *Overrides) GetResourceOverride(inst addrs.AbsResourceInstance, provider addrs.AbsProviderConfig) (*configs.Override, bool) {
+	if overrides.Empty() {
+		// Short circuit any lookups if we have no overrides.
+		return nil, false
 	}
-	return false
+
+	// First check this specific resource.
+	if override, ok := overrides.getResourceOverride(inst, provider); ok {
+		return override, true
+	}
+
+	// Otherwise check the containing resource in case the user has set for all
+	// the instances of a resource to be overridden.
+	return overrides.getResourceOverride(inst.ContainingResource(), provider)
 }
 
-// GetOverrideInclProviders retrieves the override for target if it exists.
-//
-// This function also checks the provider specific overrides using the provider
-// argument.
-func (overrides *Overrides) GetOverrideInclProviders(target addrs.Targetable, provider addrs.AbsProviderConfig) (*configs.Override, bool) {
+func (overrides *Overrides) getResourceOverride(target addrs.Targetable, provider addrs.AbsProviderConfig) (*configs.Override, bool) {
 	// If we have a local override, then apply that first.
-	if override, ok := overrides.GetOverride(target); ok {
+	if override, ok := overrides.localOverrides.GetOk(target); ok {
 		return override, true
 	}
 
@@ -157,10 +147,43 @@ func (overrides *Overrides) GetOverrideInclProviders(target addrs.Targetable, pr
 	return nil, false
 }
 
-// GetOverride retrieves the override for target from the local overrides if
-// it exists.
-func (overrides *Overrides) GetOverride(target addrs.Targetable) (*configs.Override, bool) {
-	return overrides.localOverrides.GetOk(target)
+// GetModuleOverride checks the overrides for the given module instance. This
+// function automatically checks if the containing module has been overridden
+// if the instance is instanced.
+//
+// Users can mark a module instance as overridden by overriding the instance
+// directly (eg. module.foo[0]) or by overriding the containing module
+// (eg. module.foo).
+//
+// Modules cannot be overridden by mock providers directly, so we don't need
+// to know anything about providers for this function (in contrast to
+// GetResourceOverride).
+func (overrides *Overrides) GetModuleOverride(inst addrs.ModuleInstance) (*configs.Override, bool) {
+	if len(inst) == 0 || overrides.Empty() {
+		// The root module is never overridden, so let's just short circuit
+		// this.
+		return nil, false
+	}
+
+	// Otherwise check if this specific instance has been overridden.
+	if override, ok := overrides.localOverrides.GetOk(inst); ok {
+		// It has, so just return that.
+		return override, true
+	}
+
+	// If this is an instanced address (eg. module.foo[0]), then we need to
+	// check if the containing module has been overridden as we let users
+	// override all instances of a module by overriding the containing module
+	// (eg. module.foo).
+
+	// Check if the last step is actually instanced, so we don't do extra work
+	// needlessly.
+	if inst[len(inst)-1].InstanceKey == addrs.NoKey {
+		// Then we already checked the instance itself and it wasn't overridden.
+		return nil, false
+	}
+
+	return overrides.localOverrides.GetOk(inst.ContainingModule())
 }
 
 // ProviderMatch returns true if we have overrides for the given provider.

--- a/internal/moduletest/mocking/overrides.go
+++ b/internal/moduletest/mocking/overrides.go
@@ -103,12 +103,10 @@ func (overrides *Overrides) IsOverridden(module addrs.ModuleInstance) bool {
 }
 
 // GetResourceOverride checks the overrides for the given resource instance.
-// This function automatically checks if the containing resource has been
-// overridden if the instance is instanced.
-//
-// Users can mark a resource instance as overridden by overriding the instance
-// directly (eg. resource.foo[0]) or by overriding the containing resource
-// (eg. resource.foo).
+// If the provided address is instanced, then we will check the containing
+// resource as well. This is because users can mark a resource instance as
+// overridden by overriding the instance directly (eg. resource.foo[0]) or by
+// overriding the containing resource (eg. resource.foo).
 //
 // If the resource is being supplied by a mock provider, then we need to check
 // the overrides for that provider as well, as such the provider config is

--- a/internal/moduletest/mocking/overrides_test.go
+++ b/internal/moduletest/mocking/overrides_test.go
@@ -86,9 +86,17 @@ func TestPackageOverrides(t *testing.T) {
 	overrides := PackageOverrides(run, file, config)
 
 	// We now expect that the run and file overrides took precedence.
-	first, pOk := overrides.GetOverride(primary)
-	second, sOk := overrides.GetOverride(secondary)
-	third, tOk := overrides.GetOverrideInclProviders(tertiary, addrs.AbsProviderConfig{
+	first, pOk := overrides.GetResourceOverride(primary, addrs.AbsProviderConfig{
+		Provider: addrs.Provider{
+			Type: "mock",
+		},
+	})
+	second, sOk := overrides.GetResourceOverride(secondary, addrs.AbsProviderConfig{
+		Provider: addrs.Provider{
+			Type: "mock",
+		},
+	})
+	third, tOk := overrides.GetResourceOverride(tertiary, addrs.AbsProviderConfig{
 		Provider: addrs.Provider{
 			Type: "mock",
 		},

--- a/internal/refactoring/move_validate.go
+++ b/internal/refactoring/move_validate.go
@@ -56,7 +56,7 @@ func ValidateMoves(stmts []MoveStatement, rootCfg *configs.Config, declaredInsts
 		// both stmt.From and stmt.To always belong to the same statement.
 		fromMod, _ := stmt.From.ModuleCallTraversals()
 
-		for _, fromModInst := range declaredInsts.InstancesForModule(fromMod) {
+		for _, fromModInst := range declaredInsts.InstancesForModule(fromMod, false) {
 			absFrom := stmt.From.InModuleInstance(fromModInst)
 
 			absTo := stmt.To.InModuleInstance(fromModInst)

--- a/internal/refactoring/move_validate_test.go
+++ b/internal/refactoring/move_validate_test.go
@@ -536,7 +536,7 @@ func loadRefactoringFixture(t *testing.T, dir string) (*configs.Config, instance
 		t.Fatalf("failed to load root module: %s", diags.Error())
 	}
 
-	expander := instances.NewExpander()
+	expander := instances.NewExpander(nil)
 	staticPopulateExpanderModule(t, rootCfg, addrs.RootModuleInstance, expander)
 	return rootCfg, expander.AllInstances()
 }
@@ -597,7 +597,7 @@ func staticPopulateExpanderModule(t *testing.T, rootCfg *configs.Config, moduleA
 
 		// We need to recursively analyze the child modules too.
 		calledMod := modCfg.Path.Child(call.Name)
-		for _, inst := range expander.ExpandModule(calledMod) {
+		for _, inst := range expander.ExpandModule(calledMod, false) {
 			staticPopulateExpanderModule(t, rootCfg, inst, expander)
 		}
 	}

--- a/internal/terraform/context_apply.go
+++ b/internal/terraform/context_apply.go
@@ -286,6 +286,7 @@ func (c *Context) applyGraph(plan *plans.Plan, config *configs.Config, opts *App
 		ForceReplace:            plan.ForceReplaceAddrs,
 		Operation:               operation,
 		ExternalReferences:      plan.ExternalReferences,
+		Overrides:               plan.Overrides,
 	}).Build(addrs.RootModuleInstance)
 	diags = diags.Append(moreDiags)
 	if moreDiags.HasErrors() {

--- a/internal/terraform/context_plan.go
+++ b/internal/terraform/context_plan.go
@@ -865,6 +865,7 @@ func (c *Context) planGraph(config *configs.Config, prevRunState *states.State, 
 			preDestroyRefresh:       opts.PreDestroyRefresh,
 			Operation:               walkPlan,
 			ExternalReferences:      opts.ExternalReferences,
+			Overrides:               opts.Overrides,
 			ImportTargets:           c.findImportTargets(config),
 			forgetResources:         forgetResources,
 			forgetModules:           forgetModules,
@@ -883,6 +884,7 @@ func (c *Context) planGraph(config *configs.Config, prevRunState *states.State, 
 			skipPlanChanges:         true, // this activates "refresh only" mode.
 			Operation:               walkPlan,
 			ExternalReferences:      opts.ExternalReferences,
+			Overrides:               opts.Overrides,
 		}).Build(addrs.RootModuleInstance)
 		return graph, walkPlan, diags
 	case plans.DestroyMode:
@@ -895,6 +897,7 @@ func (c *Context) planGraph(config *configs.Config, prevRunState *states.State, 
 			Targets:                 opts.Targets,
 			skipRefresh:             opts.SkipRefresh,
 			Operation:               walkPlanDestroy,
+			Overrides:               opts.Overrides,
 		}).Build(addrs.RootModuleInstance)
 		return graph, walkPlanDestroy, diags
 	default:

--- a/internal/terraform/context_walk.go
+++ b/internal/terraform/context_walk.go
@@ -187,7 +187,7 @@ func (c *Context) graphWalker(graph *Graph, operation walkOperation, opts *graph
 		NamedValues:             namedvals.NewState(),
 		Deferrals:               deferred,
 		Checks:                  checkState,
-		InstanceExpander:        instances.NewExpander(),
+		InstanceExpander:        instances.NewExpander(opts.Overrides),
 		ExternalProviderConfigs: opts.ExternalProviderConfigs,
 		MoveResults:             opts.MoveResults,
 		Operation:               operation,

--- a/internal/terraform/evaluate_test.go
+++ b/internal/terraform/evaluate_test.go
@@ -599,7 +599,7 @@ func evaluatorForModule(stateSync *states.SyncState, changesSync *plans.ChangesS
 		},
 		State:       stateSync,
 		Changes:     changesSync,
-		Instances:   instances.NewExpander(),
+		Instances:   instances.NewExpander(nil),
 		NamedValues: namedvals.NewState(),
 	}
 }

--- a/internal/terraform/graph_builder_apply.go
+++ b/internal/terraform/graph_builder_apply.go
@@ -7,6 +7,7 @@ import (
 	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/configs"
 	"github.com/hashicorp/terraform/internal/dag"
+	"github.com/hashicorp/terraform/internal/moduletest/mocking"
 	"github.com/hashicorp/terraform/internal/plans"
 	"github.com/hashicorp/terraform/internal/providers"
 	"github.com/hashicorp/terraform/internal/states"
@@ -68,6 +69,10 @@ type ApplyGraphBuilder struct {
 	// nodes that should not be pruned even if they are not referenced within
 	// the actual graph.
 	ExternalReferences []*addrs.Reference
+
+	// Overrides provides the set of overrides supplied by the testing
+	// framework.
+	Overrides *mocking.Overrides
 }
 
 // See GraphBuilder
@@ -127,6 +132,7 @@ func (b *ApplyGraphBuilder) Steps() []GraphTransformer {
 		&OutputTransformer{
 			Config:     b.Config,
 			Destroying: b.Operation == walkDestroy,
+			Overrides:  b.Overrides,
 		},
 
 		// Creates all the resource instances represented in the diff, along

--- a/internal/terraform/graph_builder_plan.go
+++ b/internal/terraform/graph_builder_plan.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/configs"
 	"github.com/hashicorp/terraform/internal/dag"
+	"github.com/hashicorp/terraform/internal/moduletest/mocking"
 	"github.com/hashicorp/terraform/internal/providers"
 	"github.com/hashicorp/terraform/internal/states"
 	"github.com/hashicorp/terraform/internal/tfdiags"
@@ -84,6 +85,10 @@ type PlanGraphBuilder struct {
 	// nodes that should not be pruned even if they are not referenced within
 	// the actual graph.
 	ExternalReferences []*addrs.Reference
+
+	// Overrides provides the set of overrides supplied by the testing
+	// framework.
+	Overrides *mocking.Overrides
 
 	// ImportTargets are the list of resources to import.
 	ImportTargets []*ImportTarget
@@ -162,6 +167,7 @@ func (b *PlanGraphBuilder) Steps() []GraphTransformer {
 			Config:      b.Config,
 			RefreshOnly: b.skipPlanChanges || b.preDestroyRefresh,
 			Destroying:  b.Operation == walkPlanDestroy,
+			Overrides:   b.Overrides,
 
 			// NOTE: We currently treat anything built with the plan graph
 			// builder as "planning" for our purposes here, because we share

--- a/internal/terraform/instance_expanders.go
+++ b/internal/terraform/instance_expanders.go
@@ -31,16 +31,11 @@ type graphNodeExpandsInstances interface {
 // partially-expanded prefixes conceptually represent an infinite set of
 // possible module instance addresses and therefore need quite different
 // treatment than a single concrete module instance address.
-func forEachModuleInstance(
-	insts *instances.Expander,
-	modAddr addrs.Module,
-	knownCb func(addrs.ModuleInstance),
-	unknownCb func(addrs.PartialExpandedModule),
-) {
-	for _, instAddr := range insts.ExpandModule(modAddr) {
+func forEachModuleInstance(insts *instances.Expander, modAddr addrs.Module, includeOverrides bool, knownCb func(addrs.ModuleInstance), unknownCb func(addrs.PartialExpandedModule)) {
+	for _, instAddr := range insts.ExpandModule(modAddr, includeOverrides) {
 		knownCb(instAddr)
 	}
-	for _, instsAddr := range insts.UnknownModuleInstances(modAddr) {
+	for _, instsAddr := range insts.UnknownModuleInstances(modAddr, includeOverrides) {
 		unknownCb(instsAddr)
 	}
 }

--- a/internal/terraform/node_local.go
+++ b/internal/terraform/node_local.go
@@ -69,25 +69,21 @@ func (n *nodeExpandLocal) References() []*addrs.Reference {
 func (n *nodeExpandLocal) DynamicExpand(ctx EvalContext) (*Graph, tfdiags.Diagnostics) {
 	var g Graph
 	expander := ctx.InstanceExpander()
-	forEachModuleInstance(
-		expander, n.Module,
-		func(module addrs.ModuleInstance) {
-			o := &NodeLocal{
-				Addr:   n.Addr.Absolute(module),
-				Config: n.Config,
-			}
-			log.Printf("[TRACE] Expanding local: adding %s as %T", o.Addr.String(), o)
-			g.Add(o)
-		},
-		func(pem addrs.PartialExpandedModule) {
-			o := &nodeLocalInPartialModule{
-				Addr:   addrs.ObjectInPartialExpandedModule(pem, n.Addr),
-				Config: n.Config,
-			}
-			log.Printf("[TRACE] Expanding local: adding placeholder for all %s as %T", o.Addr.String(), o)
-			g.Add(o)
-		},
-	)
+	forEachModuleInstance(expander, n.Module, false, func(module addrs.ModuleInstance) {
+		o := &NodeLocal{
+			Addr:   n.Addr.Absolute(module),
+			Config: n.Config,
+		}
+		log.Printf("[TRACE] Expanding local: adding %s as %T", o.Addr.String(), o)
+		g.Add(o)
+	}, func(pem addrs.PartialExpandedModule) {
+		o := &nodeLocalInPartialModule{
+			Addr:   addrs.ObjectInPartialExpandedModule(pem, n.Addr),
+			Config: n.Config,
+		}
+		log.Printf("[TRACE] Expanding local: adding placeholder for all %s as %T", o.Addr.String(), o)
+		g.Add(o)
+	})
 	addRootNodeToGraph(&g)
 	return &g, nil
 }

--- a/internal/terraform/node_module_expand.go
+++ b/internal/terraform/node_module_expand.go
@@ -125,7 +125,7 @@ func (n *nodeExpandModule) Execute(globalCtx EvalContext, op walkOperation) (dia
 	// nodeExpandModule itself does not have visibility into how its ancestors
 	// were expanded, so we use the expander here to provide all possible paths
 	// to our module, and register module instances with each of them.
-	for _, module := range expander.ExpandModule(n.Addr.Parent()) {
+	for _, module := range expander.ExpandModule(n.Addr.Parent(), false) {
 		moduleCtx := evalContextForModuleInstance(globalCtx, module)
 
 		switch {
@@ -233,12 +233,7 @@ func (n *nodeCloseModule) Execute(ctx EvalContext, op walkOperation) (diags tfdi
 			// module creating resources but we still care about the outputs.
 			overridden := false
 			if overrides := ctx.Overrides(); !overrides.Empty() {
-				_, overridden = overrides.GetOverride(mod.Addr)
-
-				if !overridden && len(mod.Addr) > 0 && mod.Addr[len(mod.Addr)-1].InstanceKey != addrs.NoKey {
-					// Could be all module instances are overridden.
-					_, overridden = overrides.GetOverride(mod.Addr.ContainingModule())
-				}
+				_, overridden = overrides.GetModuleOverride(mod.Addr)
 			}
 
 			// empty child modules are always removed
@@ -270,7 +265,7 @@ func (n *nodeValidateModule) Execute(globalCtx EvalContext, op walkOperation) (d
 	// create a proper context within which to evaluate. All parent modules
 	// will be a single instance, but still get our address in the expected
 	// manner anyway to ensure they've been registered correctly.
-	for _, module := range expander.ExpandModule(n.Addr.Parent()) {
+	for _, module := range expander.ExpandModule(n.Addr.Parent(), false) {
 		moduleCtx := evalContextForModuleInstance(globalCtx, module)
 
 		// Validate our for_each and count expressions at a basic level

--- a/internal/terraform/node_module_expand_test.go
+++ b/internal/terraform/node_module_expand_test.go
@@ -7,16 +7,17 @@ import (
 	"testing"
 
 	"github.com/hashicorp/hcl/v2/hcltest"
+	"github.com/zclconf/go-cty/cty"
+
 	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/configs"
 	"github.com/hashicorp/terraform/internal/instances"
 	"github.com/hashicorp/terraform/internal/states"
-	"github.com/zclconf/go-cty/cty"
 )
 
 func TestNodeExpandModuleExecute(t *testing.T) {
 	ctx := &MockEvalContext{
-		InstanceExpanderExpander: instances.NewExpander(),
+		InstanceExpanderExpander: instances.NewExpander(nil),
 	}
 	ctx.installSimpleEval()
 
@@ -90,7 +91,7 @@ func TestNodeCloseModuleExecute(t *testing.T) {
 func TestNodeValidateModuleExecute(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		ctx := &MockEvalContext{
-			InstanceExpanderExpander: instances.NewExpander(),
+			InstanceExpanderExpander: instances.NewExpander(nil),
 		}
 		ctx.installSimpleEval()
 		node := nodeValidateModule{
@@ -110,7 +111,7 @@ func TestNodeValidateModuleExecute(t *testing.T) {
 
 	t.Run("invalid count", func(t *testing.T) {
 		ctx := &MockEvalContext{
-			InstanceExpanderExpander: instances.NewExpander(),
+			InstanceExpanderExpander: instances.NewExpander(nil),
 		}
 		ctx.installSimpleEval()
 		node := nodeValidateModule{

--- a/internal/terraform/node_module_variable.go
+++ b/internal/terraform/node_module_variable.go
@@ -65,35 +65,31 @@ func (n *nodeExpandModuleVariable) DynamicExpand(ctx EvalContext) (*Graph, tfdia
 	}
 
 	expander := ctx.InstanceExpander()
-	forEachModuleInstance(
-		expander, n.Module,
-		func(module addrs.ModuleInstance) {
-			addr := n.Addr.Absolute(module)
-			if checkableAddrs != nil {
-				checkableAddrs.Add(addr)
-			}
+	forEachModuleInstance(expander, n.Module, false, func(module addrs.ModuleInstance) {
+		addr := n.Addr.Absolute(module)
+		if checkableAddrs != nil {
+			checkableAddrs.Add(addr)
+		}
 
-			o := &nodeModuleVariable{
-				Addr:           addr,
-				Config:         n.Config,
-				Expr:           n.Expr,
-				ModuleInstance: module,
-				DestroyApply:   n.DestroyApply,
-			}
-			g.Add(o)
-		},
-		func(pem addrs.PartialExpandedModule) {
-			addr := addrs.ObjectInPartialExpandedModule(pem, n.Addr)
-			o := &nodeModuleVariableInPartialModule{
-				Addr:           addr,
-				Config:         n.Config,
-				Expr:           n.Expr,
-				ModuleInstance: pem,
-				DestroyApply:   n.DestroyApply,
-			}
-			g.Add(o)
-		},
-	)
+		o := &nodeModuleVariable{
+			Addr:           addr,
+			Config:         n.Config,
+			Expr:           n.Expr,
+			ModuleInstance: module,
+			DestroyApply:   n.DestroyApply,
+		}
+		g.Add(o)
+	}, func(pem addrs.PartialExpandedModule) {
+		addr := addrs.ObjectInPartialExpandedModule(pem, n.Addr)
+		o := &nodeModuleVariableInPartialModule{
+			Addr:           addr,
+			Config:         n.Config,
+			Expr:           n.Expr,
+			ModuleInstance: pem,
+			DestroyApply:   n.DestroyApply,
+		}
+		g.Add(o)
+	})
 	addRootNodeToGraph(&g)
 
 	if checkableAddrs != nil {

--- a/internal/terraform/node_resource_apply.go
+++ b/internal/terraform/node_resource_apply.go
@@ -66,7 +66,7 @@ func (n *nodeExpandApplyableResource) Execute(globalCtx EvalContext, op walkOper
 
 	var diags tfdiags.Diagnostics
 	expander := globalCtx.InstanceExpander()
-	moduleInstances := expander.ExpandModule(n.Addr.Module)
+	moduleInstances := expander.ExpandModule(n.Addr.Module, false)
 Insts:
 	for _, module := range moduleInstances {
 

--- a/internal/terraform/node_resource_apply_test.go
+++ b/internal/terraform/node_resource_apply_test.go
@@ -17,7 +17,7 @@ func TestNodeExpandApplyableResourceExecute(t *testing.T) {
 	t.Run("no config", func(t *testing.T) {
 		ctx := &MockEvalContext{
 			StateState:               state.SyncWrapper(),
-			InstanceExpanderExpander: instances.NewExpander(),
+			InstanceExpanderExpander: instances.NewExpander(nil),
 		}
 
 		node := &nodeExpandApplyableResource{
@@ -40,7 +40,7 @@ func TestNodeExpandApplyableResourceExecute(t *testing.T) {
 	t.Run("simple", func(t *testing.T) {
 		ctx := &MockEvalContext{
 			StateState:               state.SyncWrapper(),
-			InstanceExpanderExpander: instances.NewExpander(),
+			InstanceExpanderExpander: instances.NewExpander(nil),
 		}
 
 		node := &nodeExpandApplyableResource{

--- a/internal/terraform/node_resource_plan.go
+++ b/internal/terraform/node_resource_plan.go
@@ -98,7 +98,7 @@ func (n *nodeExpandPlannableResource) ModifyCreateBeforeDestroy(v bool) error {
 func (n *nodeExpandPlannableResource) DynamicExpand(ctx EvalContext) (*Graph, tfdiags.Diagnostics) {
 	// Expand the current module.
 	expander := ctx.InstanceExpander()
-	moduleInstances := expander.ExpandModule(n.Addr.Module)
+	moduleInstances := expander.ExpandModule(n.Addr.Module, false)
 
 	// Expand the imports for this resource.
 	// TODO: Add support for unknown instances in import blocks.
@@ -113,7 +113,7 @@ func (n *nodeExpandPlannableResource) DynamicExpand(ctx EvalContext) (*Graph, tf
 	// duplicating some of the logic for behavior this method would normally
 	// handle.
 	if ctx.Deferrals().DeferralAllowed() {
-		pem := expander.UnknownModuleInstances(n.Addr.Module)
+		pem := expander.UnknownModuleInstances(n.Addr.Module, false)
 		g, expandDiags := n.dynamicExpandPartial(ctx, moduleInstances, pem, imports)
 		diags = diags.Append(expandDiags)
 		return g, diags

--- a/internal/terraform/node_resource_plan_orphan.go
+++ b/internal/terraform/node_resource_plan_orphan.go
@@ -301,7 +301,7 @@ func (n *NodePlannableResourceInstanceOrphan) deleteActionReason(ctx EvalContext
 		// First we'll check whether our containing module instance still
 		// exists, so we can talk about that differently in the reason.
 		declared := false
-		for _, inst := range expander.ExpandModule(n.Addr.Module.Module()) {
+		for _, inst := range expander.ExpandModule(n.Addr.Module.Module(), false) {
 			if n.Addr.Module.Equal(inst) {
 				declared = true
 				break

--- a/internal/terraform/node_resource_plan_orphan_test.go
+++ b/internal/terraform/node_resource_plan_orphan_test.go
@@ -6,12 +6,13 @@ package terraform
 import (
 	"testing"
 
+	"github.com/zclconf/go-cty/cty"
+
 	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/instances"
 	"github.com/hashicorp/terraform/internal/plans"
 	"github.com/hashicorp/terraform/internal/providers"
 	"github.com/hashicorp/terraform/internal/states"
-	"github.com/zclconf/go-cty/cty"
 )
 
 func TestNodeResourcePlanOrphanExecute(t *testing.T) {
@@ -40,7 +41,7 @@ func TestNodeResourcePlanOrphanExecute(t *testing.T) {
 		StateState:               state.SyncWrapper(),
 		RefreshStateState:        state.DeepCopy().SyncWrapper(),
 		PrevRunStateState:        state.DeepCopy().SyncWrapper(),
-		InstanceExpanderExpander: instances.NewExpander(),
+		InstanceExpanderExpander: instances.NewExpander(nil),
 		ProviderProvider:         p,
 		ProviderSchemaSchema: providers.ProviderSchema{
 			ResourceTypes: map[string]providers.Schema{
@@ -106,7 +107,7 @@ func TestNodeResourcePlanOrphanExecute_alreadyDeleted(t *testing.T) {
 		StateState:               state.SyncWrapper(),
 		RefreshStateState:        refreshState.SyncWrapper(),
 		PrevRunStateState:        prevRunState.SyncWrapper(),
-		InstanceExpanderExpander: instances.NewExpander(),
+		InstanceExpanderExpander: instances.NewExpander(nil),
 		ProviderProvider:         p,
 		ProviderSchemaSchema: providers.ProviderSchema{
 			ResourceTypes: map[string]providers.Schema{
@@ -188,7 +189,7 @@ func TestNodeResourcePlanOrphanExecute_deposed(t *testing.T) {
 		StateState:               state.SyncWrapper(),
 		RefreshStateState:        refreshState.SyncWrapper(),
 		PrevRunStateState:        prevRunState.SyncWrapper(),
-		InstanceExpanderExpander: instances.NewExpander(),
+		InstanceExpanderExpander: instances.NewExpander(nil),
 		ProviderProvider:         p,
 		ProviderSchemaSchema: providers.ProviderSchema{
 			ResourceTypes: map[string]providers.Schema{

--- a/internal/terraform/node_variable_validation.go
+++ b/internal/terraform/node_variable_validation.go
@@ -111,7 +111,7 @@ func (n *nodeVariableValidation) Execute(globalCtx EvalContext, op walkOperation
 	// the variable across expanded modules, because each one could potentially
 	// have a different value assigned to it and other different data in scope.
 	expander := globalCtx.InstanceExpander()
-	for _, modInst := range expander.ExpandModule(n.configAddr.Module) {
+	for _, modInst := range expander.ExpandModule(n.configAddr.Module, false) {
 		addr := n.configAddr.Variable.Absolute(modInst)
 		moduleCtx := globalCtx.withScope(evalContextModuleInstance{Addr: addr.Module})
 		if n.allowGeneralReferences {

--- a/internal/terraform/transform_output.go
+++ b/internal/terraform/transform_output.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/configs"
+	"github.com/hashicorp/terraform/internal/moduletest/mocking"
 )
 
 // OutputTransformer is a GraphTransformer that adds all the outputs
@@ -30,6 +31,10 @@ type OutputTransformer struct {
 	// If this is a planned destroy, root outputs are still in the configuration
 	// so we need to record that we wish to remove them.
 	Destroying bool
+
+	// Overrides supplies the values for any output variables that should be
+	// overridden by the testing framework.
+	Overrides *mocking.Overrides
 }
 
 func (t *OutputTransformer) Transform(g *Graph) error {
@@ -61,6 +66,7 @@ func (t *OutputTransformer) transform(g *Graph, c *configs.Config) error {
 			Destroying:  t.Destroying,
 			RefreshOnly: t.RefreshOnly,
 			Planning:    t.Planning,
+			Overrides:   t.Overrides,
 		}
 
 		log.Printf("[TRACE] OutputTransformer: adding %s as %T", o.Name, node)


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

This PR makes use of the new expander logic to handle the terraform test module overrides directly where the modules are expanded instead of later within the group as it was doing previously.

Previously, we just generally let the graph expansion happen and then looked for nodes within overridden modules as the graph executed. We'd then skip nodes within overridden modules to ensure they didn't execute, and then sideload values into the output nodes of the overridden modules.

This was actually broken for the expand nodes, as they aren't keyed by a module instance address which means it is impossible for us to tell during graph execution that they should be skipped. This meant that the expansion was still attempted for anything within an overridden module. If that expansion then required a value from something else in the module such as a local variable, the expansion failed with a crash. This is because the local variable execution was skipped (as it was in an overridden module), while the expansion was still attempted by the expansion nodes are not keyed by module instances.

Now, we pass the override information into the expander. When it is asked for module instances, it excludes instances that have been overridden. This means that concrete execute nodes for overridden modules are not even created as a result of that expansion essentially not even existing.

For output nodes, we actually do include the overridden module instances and we implement the logic for checking if the module instance has been overridden directly within the output node. This means the output nodes can load the values from the override, instead of attempting to look at any references which would then fail since the other nodes in the module were not executed.

The change count here is smaller than it looks. I changed some wide-ranging function arguments, which has led to a lot of diffs that simply set `false` or `nil` for the `includeOverrides` and `overrides` arguments within the expander and the "get module instances" functions.

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Fixes #35019 

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.8.2

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

### NEW FEATURES | UPGRADE NOTES | ENHANCEMENTS | BUG FIXES | EXPERIMENTS

<!--

Write a short description of the user-facing change. Examples:

- `terraform show -json`: Fixed crash with sensitive set values.
- When rendering a diff, Terraform now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 

-  `terraform test`: Prevent crash when referencing local variables within overridden modules.
