### PR TITLE
terraform apply: restore marks after unknown validation

### DIFF
--- a/internal/terraform/node_resource_abstract_instance.go
+++ b/internal/terraform/node_resource_abstract_instance.go
@@ -2438,15 +2438,6 @@ func (n *NodeAbstractResourceInstance) apply(
 	// incomplete.
 	newVal := resp.NewState
 
-	// If we have paths to mark, mark those on this new value we need to
-	// re-check the value against the schema, because nested computed values
-	// won't be included in afterPaths, which are only what was read from the
-	// After plan value.
-	newVal = newVal.MarkWithPaths(afterPaths)
-	if sensitivePaths := schema.SensitivePaths(newVal, nil); len(sensitivePaths) != 0 {
-		newVal = marks.MarkPaths(newVal, marks.Sensitive, sensitivePaths)
-	}
-
 	if newVal == cty.NilVal {
 		// Providers are supposed to return a partial new value even when errors
 		// occur, but sometimes they don't and so in that case we'll patch that up
@@ -2530,6 +2521,15 @@ func (n *NodeAbstractResourceInstance) apply(
 		// bug, we accept this because storing a result here is always a
 		// best-effort sort of thing.
 		newVal = cty.UnknownAsNull(newVal)
+	}
+
+	// If we have paths to mark, mark those on this new value we need to
+	// re-check the value against the schema, because nested computed values
+	// won't be included in afterPaths, which are only what was read from the
+	// After plan value.
+	newVal = newVal.MarkWithPaths(afterPaths)
+	if sensitivePaths := schema.SensitivePaths(newVal, nil); len(sensitivePaths) != 0 {
+		newVal = marks.MarkPaths(newVal, marks.Sensitive, sensitivePaths)
 	}
 
 	if change.Action != plans.Delete && !diags.HasErrors() {


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

This PR updates the order of validations that happen after an `ApplyResourceChange` operation. Previously, we restored the sensitive marks on the new value before validating that is was wholly known. If the value was not wholly known, then a panic might occur during the `UnknownAsNull` fix up call that ensures there are no unknown values present. 

Now, we restore the sensitive marks only after this validation has been completed. This ensures there are no sensitive marks during the `UnknownAsNull` function call.

This change should be safe as only validations occur between the old point and new point of mark reapplication. The attributes within the value are not exposed by these validations.

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Fixes #35039 

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.8.2

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

### ENHANCEMENTS

<!--

Write a short description of the user-facing change. Examples:

- `terraform show -json`: Fixed crash with sensitive set values.
- When rendering a diff, Terraform now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 

-  `terraform apply`: Prevent panic when a provider erroneously provides 
