### PR TITLE
terraform test: remove planned state from plan

### DIFF
--- a/internal/backend/local/test.go
+++ b/internal/backend/local/test.go
@@ -456,7 +456,7 @@ func (runner *TestFileRunner) run(run *moduletest.Run, file *moduletest.File, st
 		defer resetVariables()
 
 		if runner.Suite.Verbose {
-			schemas, diags := tfCtx.Schemas(config, plan.PlannedState)
+			schemas, diags := tfCtx.Schemas(config, plan.PriorState)
 
 			// If we're going to fail to render the plan, let's not fail the overall
 			// test. It can still have succeeded. So we'll add the diagnostics, but
@@ -470,7 +470,7 @@ func (runner *TestFileRunner) run(run *moduletest.Run, file *moduletest.File, st
 			} else {
 				run.Verbose = &moduletest.Verbose{
 					Plan:         plan,
-					State:        plan.PlannedState,
+					State:        nil, // We don't have a state to show in plan mode.
 					Config:       config,
 					Providers:    schemas.Providers,
 					Provisioners: schemas.Provisioners,
@@ -544,7 +544,7 @@ func (runner *TestFileRunner) run(run *moduletest.Run, file *moduletest.File, st
 	}
 
 	if runner.Suite.Verbose {
-		schemas, diags := tfCtx.Schemas(config, plan.PlannedState)
+		schemas, diags := tfCtx.Schemas(config, updated)
 
 		// If we're going to fail to render the plan, let's not fail the overall
 		// test. It can still have succeeded. So we'll add the diagnostics, but
@@ -557,7 +557,7 @@ func (runner *TestFileRunner) run(run *moduletest.Run, file *moduletest.File, st
 				fmt.Sprintf("Terraform failed to print the verbose output for %s, other diagnostics will contain more details as to why.", filepath.Join(file.Name, run.Name))))
 		} else {
 			run.Verbose = &moduletest.Verbose{
-				Plan:         plan,
+				Plan:         nil, // We don't have a plan to show in apply mode.
 				State:        updated,
 				Config:       config,
 				Providers:    schemas.Providers,

--- a/internal/plans/plan.go
+++ b/internal/plans/plan.go
@@ -118,14 +118,8 @@ type Plan struct {
 	PrevRunState *states.State
 	PriorState   *states.State
 
-	// PlannedState is the temporary planned state that was created during the
-	// graph walk that generated this plan.
-	//
-	// This is required by the testing framework when evaluating run blocks
-	// executing in plan mode. The graph updates the state with certain values
-	// that are difficult to retrieve later, such as local values that reference
-	// updated resources. It is easier to build the testing scope with access
-	// to same temporary state the plan used/built.
+	// ExternalReferences are references that are being made to resources within
+	// the plan from external sources.
 	//
 	// This is never recorded outside of Terraform. It is not written into the
 	// binary plan file, and it is not written into the JSON structured outputs.
@@ -133,19 +127,13 @@ type Plan struct {
 	// memory as it executes, so there is no need to add any kind of
 	// serialization for this field. This does mean that you shouldn't rely on
 	// this field existing unless you have just generated the plan.
-	PlannedState *states.State
-
-	// ExternalReferences are references that are being made to resources within
-	// the plan from external sources. As with PlannedState this is used by the
-	// terraform testing framework, and so isn't written into any external
-	// representation of the plan.
 	ExternalReferences []*addrs.Reference
 
 	// Overrides contains the set of overrides that were applied while making
 	// this plan. We need to provide the same set of overrides when applying
-	// the plan so we preserve them here. As with PlannedState and
-	// ExternalReferences, this is only used by the testing framework and so
-	// isn't written into any external representation of the plan.
+	// the plan so we preserve them here. As with  ExternalReferences, this is
+	// only used by the testing framework and so isn't written into any external
+	// representation of the plan.
 	Overrides *mocking.Overrides
 
 	// Timestamp is the record of truth for when the plan happened.

--- a/internal/terraform/context_eval_test.go
+++ b/internal/terraform/context_eval_test.go
@@ -195,13 +195,6 @@ func TestContextPlanAndEval(t *testing.T) {
 	} else {
 		t.Fatalf("plan has no Changes")
 	}
-	if plan.PlannedState != nil {
-		if rs := plan.PlannedState.ResourceInstance(riAddr); rs == nil {
-			t.Errorf("planned satte does not include test_thing.a")
-		}
-	} else {
-		t.Fatalf("plan has no PlannedState")
-	}
 	if plan.PriorState == nil {
 		t.Fatalf("plan has no PriorState")
 	}
@@ -296,13 +289,6 @@ func TestContextApplyAndEval(t *testing.T) {
 		}
 	} else {
 		t.Fatalf("plan has no Changes")
-	}
-	if plan.PlannedState != nil {
-		if rs := plan.PlannedState.ResourceInstance(riAddr); rs == nil {
-			t.Errorf("planned satte does not include test_thing.a")
-		}
-	} else {
-		t.Fatalf("plan has no PlannedState")
 	}
 	if plan.PriorState == nil {
 		t.Fatalf("plan has no PriorState")

--- a/internal/terraform/context_plan.go
+++ b/internal/terraform/context_plan.go
@@ -759,7 +759,6 @@ func (c *Context) planWalk(config *configs.Config, prevRunState *states.State, o
 		DeferredResources:       deferredResources,
 		PrevRunState:            prevRunState,
 		PriorState:              priorState,
-		PlannedState:            walker.State.Close(),
 		ExternalReferences:      opts.ExternalReferences,
 		Overrides:               opts.Overrides,
 		Checks:                  states.NewCheckResults(walker.Checks),


### PR DESCRIPTION
This is an internal refactoring of the `PlannedState` field within the Terraform internal plan struct. This was added in the past to help the testing framework perform validations after a plan operation. As of https://github.com/hashicorp/terraform/commit/0f845adfdb0563c3e1cf0342402260f8ce36af5d this is no longer required. The `PlannedState` was only being referenced either in places it wasn't needed, or just within test files. There's no behaviour change here, just removing the no-longer used field to ensure it doesn't cause confusion elsewhere or become a dependency by accident that we'd have to maintain long term.