### PR TITLE
Backport of Validate self-references within resource count and foreach arguments

### DIFF
--- a/internal/terraform/node_resource_plan.go
+++ b/internal/terraform/node_resource_plan.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/hashicorp/hcl/v2"
+
 	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/dag"
 	"github.com/hashicorp/terraform/internal/states"
@@ -104,6 +105,18 @@ func (n *nodeExpandPlannableResource) ModifyCreateBeforeDestroy(v bool) error {
 
 func (n *nodeExpandPlannableResource) DynamicExpand(ctx EvalContext) (*Graph, tfdiags.Diagnostics) {
 	var g Graph
+
+	// First, make sure the count and the foreach don't refer to the same
+	// resource. The config maybe nil if we are generating configuration, or
+	// deleting a resource.
+	if n.Config != nil {
+		var diags tfdiags.Diagnostics
+		diags = diags.Append(validateSelfRefInExpr(n.Addr.Resource, n.Config.Count))
+		diags = diags.Append(validateSelfRefInExpr(n.Addr.Resource, n.Config.ForEach))
+		if diags.HasErrors() {
+			return nil, diags
+		}
+	}
 
 	expander := ctx.InstanceExpander()
 	moduleInstances := expander.ExpandModule(n.Addr.Module)

--- a/internal/terraform/validate_selfref.go
+++ b/internal/terraform/validate_selfref.go
@@ -58,6 +58,37 @@ func validateSelfRef(addr addrs.Referenceable, config hcl.Body, providerSchema p
 	return diags
 }
 
+// validateSelfRefInExpr checks to ensure that a specific expression does not
+// reference the same block that it is contained within.
+func validateSelfRefInExpr(addr addrs.Referenceable, expr hcl.Expression) tfdiags.Diagnostics {
+	var diags tfdiags.Diagnostics
+
+	addrStrs := make([]string, 0, 1)
+	addrStrs = append(addrStrs, addr.String())
+	switch tAddr := addr.(type) {
+	case addrs.ResourceInstance:
+		// A resource instance may not refer to its containing resource either.
+		addrStrs = append(addrStrs, tAddr.ContainingResource().String())
+	}
+
+	refs, _ := lang.ReferencesInExpr(addrs.ParseRef, expr)
+	for _, ref := range refs {
+
+		for _, addrStr := range addrStrs {
+			if ref.Subject.String() == addrStr {
+				diags = diags.Append(&hcl.Diagnostic{
+					Severity: hcl.DiagError,
+					Summary:  "Self-referential block",
+					Detail:   fmt.Sprintf("Configuration for %s may not refer to itself.", addrStr),
+					Subject:  ref.SourceRange.ToHCL().Ptr(),
+				})
+			}
+		}
+	}
+
+	return diags
+}
+
 // Legacy provisioner configurations may refer to single instances using the
 // resource address. We need to filter these out from the reported references
 // to prevent cycles.

--- a/internal/terraform/validate_selfref_test.go
+++ b/internal/terraform/validate_selfref_test.go
@@ -12,8 +12,9 @@ import (
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hcltest"
-	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/zclconf/go-cty/cty"
+
+	"github.com/hashicorp/terraform/internal/addrs"
 )
 
 func TestValidateSelfRef(t *testing.T) {
@@ -98,7 +99,20 @@ func TestValidateSelfRef(t *testing.T) {
 				},
 			}
 
+			// First test the expression within the context of the configuration
+			// body.
 			diags := validateSelfRef(test.Addr, body, ps)
+			if diags.HasErrors() != test.Err {
+				if test.Err {
+					t.Errorf("unexpected success; want error")
+				} else {
+					t.Errorf("unexpected error\n\n%s", diags.Err())
+				}
+			}
+
+			// We can use the same expressions to test the expression
+			// validation.
+			diags = validateSelfRefInExpr(test.Addr, test.Expr)
 			if diags.HasErrors() != test.Err {
 				if test.Err {
 					t.Errorf("unexpected success; want error")


### PR DESCRIPTION
Manual backport of #35047. Replaces failed automatic backport in #35053.

Relates to #35038 