### PR TITLE
deferred actions: include deferred resources within JSON plan output

### DIFF
--- a/internal/command/jsonplan/resource.go
+++ b/internal/command/jsonplan/resource.go
@@ -93,3 +93,13 @@ type ResourceChange struct {
 	// and treat them as an unspecified reason.
 	ActionReason string `json:"action_reason,omitempty"`
 }
+
+// DeferredResourceChange is a description of a resource change that has been
+// deferred for some reason.
+type DeferredResourceChange struct {
+	// Reason is the reason why this resource change was deferred.
+	Reason string `json:"reason"`
+
+	// Change contains any information we have about the deferred change.
+	ResourceChange ResourceChange `json:"resource_change"`
+}


### PR DESCRIPTION
This PR adds support for rendering the deferred actions within the JSON plan output produced by `terraform show -json <planfile>`.

This is needed for providers to test their implementation of the deferred actions within the plugin protocol.