### PR TITLE
Backport of terraform test: move override evaluation into expander

### DIFF
--- a/internal/command/validate_test.go
+++ b/internal/command/validate_test.go
@@ -342,9 +342,15 @@ func TestValidateWithInvalidOverrides(t *testing.T) {
 		Meta: meta,
 	}
 
+	output := done(t)
 	if code := init.Run(nil); code != 0 {
-		t.Fatalf("expected status code 0 but got %d: %s", code, ui.ErrorWriter)
+		t.Fatalf("expected status code 0 but got %d: %s", code, output.All())
 	}
+
+	// reset streams for next command
+	streams, done = terminal.StreamsForTesting(t)
+	meta.View = views.NewView(streams)
+	meta.Streams = streams
 
 	c := &ValidateCommand{
 		Meta: meta,
@@ -354,7 +360,7 @@ func TestValidateWithInvalidOverrides(t *testing.T) {
 	args = append(args, "-no-color")
 
 	code := c.Run(args)
-	output := done(t)
+	output = done(t)
 
 	if code != 0 {
 		t.Errorf("Should have passed: %d\n\n%s", code, output.Stderr())

--- a/internal/instances/expander.go
+++ b/internal/instances/expander.go
@@ -9,6 +9,8 @@ import (
 	"sync"
 
 	"github.com/hashicorp/terraform/internal/addrs"
+	"github.com/hashicorp/terraform/internal/moduletest/mocking"
+
 	"github.com/zclconf/go-cty/cty"
 )
 
@@ -44,9 +46,9 @@ type Expander struct {
 }
 
 // NewExpander initializes and returns a new Expander, empty and ready to use.
-func NewExpander() *Expander {
+func NewExpander(overrides *mocking.Overrides) *Expander {
 	return &Expander{
-		exps: newExpanderModule(),
+		exps: newExpanderModule(overrides),
 	}
 }
 
@@ -131,8 +133,10 @@ func (e *Expander) SetResourceForEachUnknown(moduleAddr addrs.ModuleInstance, re
 // All of the modules on the path to the identified module must already have
 // had their expansion registered using one of the SetModule* methods before
 // calling, or this method will panic.
-func (e *Expander) ExpandModule(addr addrs.Module) []addrs.ModuleInstance {
-	return e.expandModule(addr, false)
+//
+// Any overridden modules will not be included in the result here.
+func (e *Expander) ExpandModule(addr addrs.Module, includeDirectOverrides bool) []addrs.ModuleInstance {
+	return e.expandModule(addr, false, includeDirectOverrides)
 }
 
 // ExpandAbsModuleCall is similar to [Expander.ExpandModule] except that it
@@ -180,7 +184,7 @@ func (e *Expander) ExpandAbsModuleCall(addr addrs.AbsModuleCall) (keyType addrs.
 // expandModule allows skipping unexpanded module addresses by setting skipUnregistered to true.
 // This is used by instances.Set, which is only concerned with the expanded
 // instances, and should not panic when looking up unknown addresses.
-func (e *Expander) expandModule(addr addrs.Module, skipUnregistered bool) []addrs.ModuleInstance {
+func (e *Expander) expandModule(addr addrs.Module, skipUnregistered, includeDirectOverrides bool) []addrs.ModuleInstance {
 	if len(addr) == 0 {
 		// Root module is always a singleton.
 		return singletonRootModule
@@ -195,7 +199,7 @@ func (e *Expander) expandModule(addr addrs.Module, skipUnregistered bool) []addr
 	// (moduleInstances does plenty of allocations itself, so the benefit of
 	// pre-allocating this is marginal but it's not hard to do.)
 	parentAddr := make(addrs.ModuleInstance, 0, 4)
-	ret := e.exps.moduleInstances(addr, parentAddr, skipUnregistered)
+	ret := e.exps.moduleInstances(addr, parentAddr, skipUnregistered, includeDirectOverrides)
 	sort.SliceStable(ret, func(i, j int) bool {
 		return ret[i].Less(ret[j])
 	})
@@ -215,7 +219,7 @@ func (e *Expander) expandModule(addr addrs.Module, skipUnregistered bool) []addr
 // considered as the union of all of those sets but we return it as a set of
 // sets because the inner sets are of infinite size while the outer set is
 // finite.
-func (e *Expander) UnknownModuleInstances(addr addrs.Module) addrs.Set[addrs.PartialExpandedModule] {
+func (e *Expander) UnknownModuleInstances(addr addrs.Module, includeDirectOverrides bool) addrs.Set[addrs.PartialExpandedModule] {
 	if len(addr) == 0 {
 		// The root module is always "expanded" because it's always a singleton,
 		// so we have nothing to return in that case.
@@ -227,7 +231,7 @@ func (e *Expander) UnknownModuleInstances(addr addrs.Module) addrs.Set[addrs.Par
 
 	ret := addrs.MakeSet[addrs.PartialExpandedModule]()
 	parentAddr := make(addrs.ModuleInstance, 0, 4)
-	e.exps.partialExpandedModuleInstances(addr, parentAddr, ret)
+	e.exps.partialExpandedModuleInstances(addr, parentAddr, includeDirectOverrides, ret)
 	return ret
 }
 
@@ -494,7 +498,7 @@ func (e *Expander) setModuleExpansion(parentAddr addrs.ModuleInstance, callAddr 
 		_, knownKeys, _ := exp.instanceKeys()
 		for _, key := range knownKeys {
 			step := addrs.ModuleInstanceStep{Name: callAddr.Name, InstanceKey: key}
-			mod.childInstances[step] = newExpanderModule()
+			mod.childInstances[step] = newExpanderModule(e.exps.overrides)
 		}
 	}
 	mod.moduleCalls[callAddr] = exp
@@ -550,13 +554,19 @@ type expanderModule struct {
 	moduleCalls    map[addrs.ModuleCall]expansion
 	resources      map[addrs.Resource]expansion
 	childInstances map[addrs.ModuleInstanceStep]*expanderModule
+
+	// overrides ensures that any overriden modules instances will not be
+	// returned as options for expansion. A nil overrides indicates there are
+	// no overrides and we're not operating within the testing framework.
+	overrides *mocking.Overrides
 }
 
-func newExpanderModule() *expanderModule {
+func newExpanderModule(overrides *mocking.Overrides) *expanderModule {
 	return &expanderModule{
 		moduleCalls:    make(map[addrs.ModuleCall]expansion),
 		resources:      make(map[addrs.Resource]expansion),
 		childInstances: make(map[addrs.ModuleInstanceStep]*expanderModule),
+		overrides:      overrides,
 	}
 }
 
@@ -566,8 +576,16 @@ var singletonRootModule = []addrs.ModuleInstance{addrs.RootModuleInstance}
 // expansions have been done, set skipUnregistered to true which allows addrs
 // which may not have been seen to return with no instances rather than
 // panicking.
-func (m *expanderModule) moduleInstances(addr addrs.Module, parentAddr addrs.ModuleInstance, skipUnregistered bool) []addrs.ModuleInstance {
+func (m *expanderModule) moduleInstances(addr addrs.Module, parentAddr addrs.ModuleInstance, skipUnregistered, includeDirectOverrides bool) []addrs.ModuleInstance {
 	callName := addr[0]
+
+	// If the parent module is overridden then this module should not be
+	// expanded. Note, we don't check includeDirectOverrides because if the
+	// parent module is overridden then this module isn't "directly" overridden.
+	if _, overridden := m.overrides.GetModuleOverride(parentAddr); overridden {
+		return nil
+	}
+
 	exp, ok := m.moduleCalls[addrs.ModuleCall{Name: callName}]
 	if !ok {
 		if skipUnregistered {
@@ -593,8 +611,14 @@ func (m *expanderModule) moduleInstances(addr addrs.Module, parentAddr addrs.Mod
 				continue
 			}
 			instAddr := append(parentAddr, step)
-			ret = append(ret, inst.moduleInstances(addr[1:], instAddr, skipUnregistered)...)
+			ret = append(ret, inst.moduleInstances(addr[1:], instAddr, skipUnregistered, includeDirectOverrides)...)
 		}
+		return ret
+	}
+
+	if _, overridden := m.overrides.GetModuleOverride(parentAddr.Child(callName, addrs.NoKey)); !includeDirectOverrides && overridden {
+		// Then all the potential instances of this module have been
+		// overridden so we don't want to do any expansion for them.
 		return ret
 	}
 
@@ -602,6 +626,11 @@ func (m *expanderModule) moduleInstances(addr addrs.Module, parentAddr addrs.Mod
 	// a sequence of addresses under this prefix.
 	_, knownKeys, _ := exp.instanceKeys()
 	for _, k := range knownKeys {
+		if _, overridden := m.overrides.GetModuleOverride(parentAddr.Child(callName, k)); !includeDirectOverrides && overridden {
+			// This specific instance is overridden, so we won't return it.
+			continue
+		}
+
 		// We're reusing the buffer under parentAddr as we recurse through
 		// the structure, so we need to copy it here to produce a final
 		// immutable slice to return.
@@ -613,8 +642,16 @@ func (m *expanderModule) moduleInstances(addr addrs.Module, parentAddr addrs.Mod
 	return ret
 }
 
-func (m *expanderModule) partialExpandedModuleInstances(addr addrs.Module, parentAddr addrs.ModuleInstance, into addrs.Set[addrs.PartialExpandedModule]) {
+func (m *expanderModule) partialExpandedModuleInstances(addr addrs.Module, parentAddr addrs.ModuleInstance, includeDirectOverrides bool, into addrs.Set[addrs.PartialExpandedModule]) {
 	callName := addr[0]
+
+	// If the parent module is overridden then this module should not be
+	// expanded. Note, we don't check includeDirectOverrides because if the
+	// parent module is overridden then this module isn't "directly" overridden.
+	if _, overridden := m.overrides.GetModuleOverride(parentAddr); overridden {
+		return
+	}
+
 	exp, ok := m.moduleCalls[addrs.ModuleCall{Name: callName}]
 	if !ok {
 		// This is a bug in the caller, because it should always register
@@ -623,6 +660,12 @@ func (m *expanderModule) partialExpandedModuleInstances(addr addrs.Module, paren
 		panic(fmt.Sprintf("no expansion has been registered for %s", parentAddr.Child(callName, addrs.NoKey)))
 	}
 	if expansionIsDeferred(exp) {
+		if _, overridden := m.overrides.GetModuleOverride(parentAddr.Child(callName, addrs.NoKey)); !includeDirectOverrides && overridden {
+			// Then all the potential instances of this module have been
+			// overridden so we don't want to do any expansion for them.
+			return
+		}
+
 		// We've found a deferred expansion, so we're done searching this
 		// subtree and can just treat the whole of "addr" as unexpanded
 		// calls.
@@ -642,7 +685,7 @@ func (m *expanderModule) partialExpandedModuleInstances(addr addrs.Module, paren
 				continue
 			}
 			instAddr := append(parentAddr, step)
-			inst.partialExpandedModuleInstances(addr[1:], instAddr, into)
+			inst.partialExpandedModuleInstances(addr[1:], instAddr, includeDirectOverrides, into)
 		}
 	}
 }

--- a/internal/instances/expander.go
+++ b/internal/instances/expander.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 
 	"github.com/hashicorp/terraform/internal/addrs"
+	"github.com/hashicorp/terraform/internal/lang"
 	"github.com/hashicorp/terraform/internal/moduletest/mocking"
 
 	"github.com/zclconf/go-cty/cty"
@@ -351,10 +352,10 @@ func (e *Expander) UnknownResourceInstances(resourceAddr addrs.ConfigResource) a
 // GetModuleInstanceRepetitionData returns an object describing the values
 // that should be available for each.key, each.value, and count.index within
 // the call block for the given module instance.
-func (e *Expander) GetModuleInstanceRepetitionData(addr addrs.ModuleInstance) RepetitionData {
+func (e *Expander) GetModuleInstanceRepetitionData(addr addrs.ModuleInstance) lang.RepetitionData {
 	if len(addr) == 0 {
 		// The root module is always a singleton, so it has no repetition data.
-		return RepetitionData{}
+		return lang.RepetitionData{}
 	}
 
 	e.mu.RLock()
@@ -364,7 +365,7 @@ func (e *Expander) GetModuleInstanceRepetitionData(addr addrs.ModuleInstance) Re
 	if !known {
 		// If we're nested inside something unexpanded then we don't even
 		// know what type of expansion we're doing.
-		return TotallyUnknownRepetitionData
+		return lang.TotallyUnknownRepetitionData
 	}
 	lastStep := addr[len(addr)-1]
 	exp, ok := parentMod.moduleCalls[addrs.ModuleCall{Name: lastStep.Name}]
@@ -405,7 +406,7 @@ func (e *Expander) GetModuleCallInstanceKeys(addr addrs.AbsModuleCall) (keyType 
 // GetResourceInstanceRepetitionData returns an object describing the values
 // that should be available for each.key, each.value, and count.index within
 // the definition block for the given resource instance.
-func (e *Expander) GetResourceInstanceRepetitionData(addr addrs.AbsResourceInstance) RepetitionData {
+func (e *Expander) GetResourceInstanceRepetitionData(addr addrs.AbsResourceInstance) lang.RepetitionData {
 	e.mu.RLock()
 	defer e.mu.RUnlock()
 
@@ -413,7 +414,7 @@ func (e *Expander) GetResourceInstanceRepetitionData(addr addrs.AbsResourceInsta
 	if !known {
 		// If we're nested inside something unexpanded then we don't even
 		// know what type of expansion we're doing.
-		return TotallyUnknownRepetitionData
+		return lang.TotallyUnknownRepetitionData
 	}
 	exp, ok := parentMod.resources[addr.Resource.Resource]
 	if !ok {

--- a/internal/instances/expander_test.go
+++ b/internal/instances/expander_test.go
@@ -9,10 +9,157 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/zclconf/go-cty-debug/ctydebug"
 	"github.com/zclconf/go-cty/cty"
 
 	"github.com/hashicorp/terraform/internal/addrs"
+	"github.com/hashicorp/terraform/internal/configs"
+	"github.com/hashicorp/terraform/internal/moduletest/mocking"
 )
+
+func TestExpanderWithOverrides(t *testing.T) {
+
+	mustModuleInstance := func(t *testing.T, s string) addrs.ModuleInstance {
+		if len(s) == 0 {
+			return addrs.RootModuleInstance
+		}
+
+		addr, diags := addrs.ParseModuleInstanceStr(s)
+		if diags.HasErrors() {
+			t.Fatalf("unexpected error: %s", diags.Err())
+		}
+		return addr
+	}
+
+	tcs := map[string]struct {
+		// Hook to install chosen overrides.
+		overrides mocking.InitLocalOverrides
+
+		// Hook to initialise the expander with the desired state.
+		expander func(*Expander)
+
+		// The target module instance to inspect.
+		target string
+
+		// Set to true to include overrides in the result.
+		includeOverrides bool
+
+		// The expected result.
+		wantModules []addrs.ModuleInstance
+
+		// The expected result for partial modules.
+		wantPartials map[string]bool
+	}{
+		"root module": {
+			wantModules:  singletonRootModule,
+			wantPartials: make(map[string]bool),
+		},
+		"instanced child module not overridden": {
+			expander: func(expander *Expander) {
+				expander.SetModuleCount(addrs.RootModuleInstance, addrs.ModuleCall{Name: "double"}, 2)
+			},
+			target: "module.double",
+			wantModules: []addrs.ModuleInstance{
+				mustModuleInstance(t, "module.double[0]"),
+				mustModuleInstance(t, "module.double[1]"),
+			},
+			wantPartials: make(map[string]bool),
+		},
+		"instanced child module single instance overridden": {
+			overrides: func(overrides addrs.Map[addrs.Targetable, *configs.Override]) {
+				overrides.Put(mustModuleInstance(t, "module.double[0]"), &configs.Override{})
+			},
+			expander: func(expander *Expander) {
+				expander.SetModuleCount(addrs.RootModuleInstance, addrs.ModuleCall{Name: "double"}, 2)
+			},
+			target: "module.double",
+			wantModules: []addrs.ModuleInstance{
+				mustModuleInstance(t, "module.double[1]"),
+			},
+			wantPartials: make(map[string]bool),
+		},
+		"instanced child module single instance overridden includes overrides": {
+			overrides: func(overrides addrs.Map[addrs.Targetable, *configs.Override]) {
+				overrides.Put(mustModuleInstance(t, "module.double[0]"), &configs.Override{})
+			},
+			expander: func(expander *Expander) {
+				expander.SetModuleCount(addrs.RootModuleInstance, addrs.ModuleCall{Name: "double"}, 2)
+			},
+			target:           "module.double",
+			includeOverrides: true,
+			wantModules: []addrs.ModuleInstance{
+				mustModuleInstance(t, "module.double[0]"),
+				mustModuleInstance(t, "module.double[1]"),
+			},
+			wantPartials: make(map[string]bool),
+		},
+		"deeply nested child module with parent overridden": {
+			overrides: func(overrides addrs.Map[addrs.Targetable, *configs.Override]) {
+				overrides.Put(mustModuleInstance(t, "module.double[0]"), &configs.Override{})
+			},
+			expander: func(expander *Expander) {
+				expander.SetModuleCount(addrs.RootModuleInstance, addrs.ModuleCall{Name: "double"}, 2)
+				expander.SetModuleSingle(mustModuleInstance(t, "module.double[1]"), addrs.ModuleCall{Name: "single"})
+			},
+			target:       "module.double.module.single",
+			wantModules:  []addrs.ModuleInstance{mustModuleInstance(t, "module.double[1].module.single")},
+			wantPartials: make(map[string]bool),
+		},
+		"unknown child module overridden by instanced module": {
+			overrides: func(overrides addrs.Map[addrs.Targetable, *configs.Override]) {
+				overrides.Put(mustModuleInstance(t, "module.unknown[0]"), &configs.Override{})
+			},
+			expander: func(expander *Expander) {
+				expander.SetModuleCountUnknown(addrs.RootModuleInstance, addrs.ModuleCall{Name: "unknown"})
+			},
+			target: "module.unknown",
+			wantPartials: map[string]bool{
+				"module.unknown[*]": true,
+			},
+		},
+		"unknown child module overridden by instanced module includes overrides": {
+			overrides: func(overrides addrs.Map[addrs.Targetable, *configs.Override]) {
+				overrides.Put(mustModuleInstance(t, "module.unknown"), &configs.Override{})
+			},
+			expander: func(expander *Expander) {
+				expander.SetModuleCountUnknown(addrs.RootModuleInstance, addrs.ModuleCall{Name: "unknown"})
+			},
+			target:       "module.unknown",
+			wantPartials: make(map[string]bool), // This time it's empty, as we overrode all instances.
+		},
+	}
+
+	for name, tc := range tcs {
+		t.Run(name, func(t *testing.T) {
+			overrides := mocking.OverridesForTesting(nil, tc.overrides)
+
+			expander := NewExpander(overrides)
+			if tc.expander != nil {
+				tc.expander(expander)
+			}
+
+			target := mustModuleInstance(t, tc.target).Module()
+
+			gotModules := expander.ExpandModule(target, tc.includeOverrides)
+			gotPartials := expander.UnknownModuleInstances(target, tc.includeOverrides)
+
+			if diff := cmp.Diff(tc.wantModules, gotModules); len(diff) > 0 {
+				t.Errorf("wrong result\n%s", diff)
+			}
+
+			// Convert the gotPartials into strings to make cmp.Diff work.
+			gotPartialsStr := make(map[string]bool, len(gotPartials))
+			for _, partial := range gotPartials {
+				gotPartialsStr[partial.String()] = true
+			}
+
+			if diff := cmp.Diff(tc.wantPartials, gotPartialsStr, ctydebug.CmpOptions); len(diff) > 0 {
+				t.Errorf("wrong result\n%s", diff)
+			}
+		})
+	}
+
+}
 
 func TestExpander(t *testing.T) {
 	// Some module and resource addresses and values we'll use repeatedly below.
@@ -70,7 +217,7 @@ func TestExpander(t *testing.T) {
 	//     - resource test.single with no count or for_each
 	//     - resource test.count2 with count = 2
 
-	ex := NewExpander()
+	ex := NewExpander(nil)
 
 	// We don't register the root module, because it's always implied to exist.
 	//
@@ -126,7 +273,7 @@ func TestExpander(t *testing.T) {
 	t.Run("root module", func(t *testing.T) {
 		// Requesting expansion of the root module doesn't really mean anything
 		// since it's always a singleton, but for consistency it should work.
-		got := ex.ExpandModule(addrs.RootModule)
+		got := ex.ExpandModule(addrs.RootModule, false)
 		want := []addrs.ModuleInstance{addrs.RootModuleInstance}
 		if diff := cmp.Diff(want, got); diff != "" {
 			t.Errorf("wrong result\n%s", diff)
@@ -181,7 +328,7 @@ func TestExpander(t *testing.T) {
 		}
 	})
 	t.Run("module single", func(t *testing.T) {
-		got := ex.ExpandModule(addrs.RootModule.Child("single"))
+		got := ex.ExpandModule(addrs.RootModule.Child("single"), false)
 		want := []addrs.ModuleInstance{
 			mustModuleInstanceAddr(`module.single`),
 		}
@@ -248,7 +395,7 @@ func TestExpander(t *testing.T) {
 		}
 	})
 	t.Run("module count2", func(t *testing.T) {
-		got := ex.ExpandModule(mustModuleAddr(`count2`))
+		got := ex.ExpandModule(mustModuleAddr(`count2`), false)
 		want := []addrs.ModuleInstance{
 			mustModuleInstanceAddr(`module.count2[0]`),
 			mustModuleInstanceAddr(`module.count2[1]`),
@@ -286,7 +433,7 @@ func TestExpander(t *testing.T) {
 		}
 	})
 	t.Run("module count2 module count2", func(t *testing.T) {
-		got := ex.ExpandModule(mustModuleAddr(`count2.count2`))
+		got := ex.ExpandModule(mustModuleAddr(`count2.count2`), false)
 		want := []addrs.ModuleInstance{
 			mustModuleInstanceAddr(`module.count2[0].module.count2[0]`),
 			mustModuleInstanceAddr(`module.count2[0].module.count2[1]`),
@@ -377,7 +524,7 @@ func TestExpander(t *testing.T) {
 		}
 	})
 	t.Run("module count0", func(t *testing.T) {
-		got := ex.ExpandModule(mustModuleAddr(`count0`))
+		got := ex.ExpandModule(mustModuleAddr(`count0`), false)
 		want := []addrs.ModuleInstance(nil)
 		if diff := cmp.Diff(want, got); diff != "" {
 			t.Errorf("wrong result\n%s", diff)
@@ -397,7 +544,7 @@ func TestExpander(t *testing.T) {
 		}
 	})
 	t.Run("module for_each", func(t *testing.T) {
-		got := ex.ExpandModule(mustModuleAddr(`for_each`))
+		got := ex.ExpandModule(mustModuleAddr(`for_each`), false)
 		want := []addrs.ModuleInstance{
 			mustModuleInstanceAddr(`module.for_each["a"]`),
 			mustModuleInstanceAddr(`module.for_each["b"]`),
@@ -524,7 +671,7 @@ func TestExpanderWithUnknowns(t *testing.T) {
 			Type: "test",
 			Name: "foo",
 		}
-		ex := NewExpander()
+		ex := NewExpander(nil)
 		ex.SetResourceForEachUnknown(addrs.RootModuleInstance, resourceAddr)
 
 		got := ex.ExpandModuleResource(addrs.RootModule, resourceAddr)
@@ -538,7 +685,7 @@ func TestExpanderWithUnknowns(t *testing.T) {
 			Type: "test",
 			Name: "foo",
 		}
-		ex := NewExpander()
+		ex := NewExpander(nil)
 		ex.SetResourceCountUnknown(addrs.RootModuleInstance, resourceAddr)
 
 		got := ex.ExpandModuleResource(addrs.RootModule, resourceAddr)
@@ -548,15 +695,15 @@ func TestExpanderWithUnknowns(t *testing.T) {
 	})
 	t.Run("module with unknown for_each", func(t *testing.T) {
 		moduleCallAddr := addrs.ModuleCall{Name: "foo"}
-		ex := NewExpander()
+		ex := NewExpander(nil)
 		ex.SetModuleForEachUnknown(addrs.RootModuleInstance, moduleCallAddr)
 
-		got := ex.ExpandModule(addrs.Module{moduleCallAddr.Name})
+		got := ex.ExpandModule(addrs.Module{moduleCallAddr.Name}, false)
 		if len(got) != 0 {
 			t.Errorf("unexpected known addresses: %#v", got)
 		}
 
-		gotUnknown := ex.UnknownModuleInstances(addrs.Module{moduleCallAddr.Name})
+		gotUnknown := ex.UnknownModuleInstances(addrs.Module{moduleCallAddr.Name}, false)
 		if len(gotUnknown) != 1 {
 			t.Errorf("unexpected unknown addresses: %#v", gotUnknown)
 		}
@@ -567,15 +714,15 @@ func TestExpanderWithUnknowns(t *testing.T) {
 	})
 	t.Run("module with unknown count", func(t *testing.T) {
 		moduleCallAddr := addrs.ModuleCall{Name: "foo"}
-		ex := NewExpander()
+		ex := NewExpander(nil)
 		ex.SetModuleCountUnknown(addrs.RootModuleInstance, moduleCallAddr)
 
-		gotKnown := ex.ExpandModule(addrs.Module{moduleCallAddr.Name})
+		gotKnown := ex.ExpandModule(addrs.Module{moduleCallAddr.Name}, false)
 		if len(gotKnown) != 0 {
 			t.Errorf("unexpected known addresses: %#v", gotKnown)
 		}
 
-		gotUnknown := ex.UnknownModuleInstances(addrs.Module{moduleCallAddr.Name})
+		gotUnknown := ex.UnknownModuleInstances(addrs.Module{moduleCallAddr.Name}, false)
 		if len(gotUnknown) != 1 {
 			t.Errorf("unexpected unknown addresses: %#v", gotUnknown)
 		}
@@ -592,7 +739,7 @@ func TestExpanderWithUnknowns(t *testing.T) {
 		module1Inst0 := addrs.RootModuleInstance.Child("foo", addrs.IntKey(0))
 		module1Inst1 := addrs.RootModuleInstance.Child("foo", addrs.IntKey(1))
 		module1Inst2 := addrs.RootModuleInstance.Child("foo", addrs.IntKey(2))
-		ex := NewExpander()
+		ex := NewExpander(nil)
 		ex.SetModuleCount(addrs.RootModuleInstance, moduleCallAddr1, 3)
 		ex.SetModuleCountUnknown(module1Inst0, moduleCallAddr2)
 		ex.SetModuleCount(module1Inst1, moduleCallAddr2, 1)
@@ -623,7 +770,7 @@ func TestExpanderWithUnknowns(t *testing.T) {
 			t.Fatalf("instances of %s are known; should be unknown", module2Call.String())
 		}
 
-		gotKnown := ex.ExpandModule(module2)
+		gotKnown := ex.ExpandModule(module2, false)
 		wantKnown := []addrs.ModuleInstance{
 			module1Inst1.Child("bar", addrs.IntKey(0)),
 		}
@@ -631,7 +778,7 @@ func TestExpanderWithUnknowns(t *testing.T) {
 			t.Errorf("unexpected known addresses\n%s", diff)
 		}
 
-		gotUnknown := ex.UnknownModuleInstances(module2)
+		gotUnknown := ex.UnknownModuleInstances(module2, false)
 		if len(gotUnknown) != 2 {
 			t.Errorf("unexpected unknown addresses: %#v", gotUnknown)
 		}

--- a/internal/instances/expander_test.go
+++ b/internal/instances/expander_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/configs"
+	"github.com/hashicorp/terraform/internal/lang"
 	"github.com/hashicorp/terraform/internal/moduletest/mocking"
 )
 
@@ -598,7 +599,7 @@ func TestExpander(t *testing.T) {
 		got := ex.GetModuleInstanceRepetitionData(
 			mustModuleInstanceAddr(`module.for_each["b"]`),
 		)
-		want := RepetitionData{
+		want := lang.RepetitionData{
 			EachKey:   cty.StringVal("b"),
 			EachValue: cty.NumberIntVal(2),
 		}
@@ -610,7 +611,7 @@ func TestExpander(t *testing.T) {
 		got := ex.GetModuleInstanceRepetitionData(
 			mustModuleInstanceAddr(`module.count2[0].module.count2[1]`),
 		)
-		want := RepetitionData{
+		want := lang.RepetitionData{
 			CountIndex: cty.NumberIntVal(1),
 		}
 		if diff := cmp.Diff(want, got, cmp.Comparer(valueEquals)); diff != "" {
@@ -621,7 +622,7 @@ func TestExpander(t *testing.T) {
 		got := ex.GetModuleInstanceRepetitionData(
 			mustModuleInstanceAddr(`module.for_each["a"]`),
 		)
-		want := RepetitionData{
+		want := lang.RepetitionData{
 			EachKey:   cty.StringVal("a"),
 			EachValue: cty.NumberIntVal(1),
 		}
@@ -634,7 +635,7 @@ func TestExpander(t *testing.T) {
 		got := ex.GetResourceInstanceRepetitionData(
 			mustAbsResourceInstanceAddr(`test.for_each["a"]`),
 		)
-		want := RepetitionData{
+		want := lang.RepetitionData{
 			EachKey:   cty.StringVal("a"),
 			EachValue: cty.NumberIntVal(1),
 		}
@@ -646,7 +647,7 @@ func TestExpander(t *testing.T) {
 		got := ex.GetResourceInstanceRepetitionData(
 			mustAbsResourceInstanceAddr(`module.for_each["a"].test.single`),
 		)
-		want := RepetitionData{}
+		want := lang.RepetitionData{}
 		if diff := cmp.Diff(want, got, cmp.Comparer(valueEquals)); diff != "" {
 			t.Errorf("wrong result\n%s", diff)
 		}
@@ -655,7 +656,7 @@ func TestExpander(t *testing.T) {
 		got := ex.GetResourceInstanceRepetitionData(
 			mustAbsResourceInstanceAddr(`module.for_each["a"].test.count2[1]`),
 		)
-		want := RepetitionData{
+		want := lang.RepetitionData{
 			CountIndex: cty.NumberIntVal(1),
 		}
 		if diff := cmp.Diff(want, got, cmp.Comparer(valueEquals)); diff != "" {

--- a/internal/instances/expansion_mode.go
+++ b/internal/instances/expansion_mode.go
@@ -10,6 +10,7 @@ import (
 	"github.com/zclconf/go-cty/cty"
 
 	"github.com/hashicorp/terraform/internal/addrs"
+	"github.com/hashicorp/terraform/internal/lang"
 )
 
 // expansion is an internal interface used to represent the different
@@ -29,7 +30,7 @@ type expansion interface {
 	// if we don't even have enough information to predict what type of
 	// keys we will be using for this object.
 	instanceKeys() (keyType addrs.InstanceKeyType, keys []addrs.InstanceKey, keysUnknown bool)
-	repetitionData(addrs.InstanceKey) RepetitionData
+	repetitionData(addrs.InstanceKey) lang.RepetitionData
 }
 
 // expansionSingle is the expansion corresponding to no repetition arguments
@@ -45,11 +46,11 @@ func (e expansionSingle) instanceKeys() (addrs.InstanceKeyType, []addrs.Instance
 	return addrs.NoKeyType, singleKeys, false
 }
 
-func (e expansionSingle) repetitionData(key addrs.InstanceKey) RepetitionData {
+func (e expansionSingle) repetitionData(key addrs.InstanceKey) lang.RepetitionData {
 	if key != addrs.NoKey {
 		panic("cannot use instance key with non-repeating object")
 	}
-	return RepetitionData{}
+	return lang.RepetitionData{}
 }
 
 // expansionCount is the expansion corresponding to the "count" argument.
@@ -63,12 +64,12 @@ func (e expansionCount) instanceKeys() (addrs.InstanceKeyType, []addrs.InstanceK
 	return addrs.IntKeyType, ret, false
 }
 
-func (e expansionCount) repetitionData(key addrs.InstanceKey) RepetitionData {
+func (e expansionCount) repetitionData(key addrs.InstanceKey) lang.RepetitionData {
 	i := int(key.(addrs.IntKey))
 	if i < 0 || i >= int(e) {
 		panic(fmt.Sprintf("instance key %d out of range for count %d", i, e))
 	}
-	return RepetitionData{
+	return lang.RepetitionData{
 		CountIndex: cty.NumberIntVal(int64(i)),
 	}
 }
@@ -87,13 +88,13 @@ func (e expansionForEach) instanceKeys() (addrs.InstanceKeyType, []addrs.Instanc
 	return addrs.StringKeyType, ret, false
 }
 
-func (e expansionForEach) repetitionData(key addrs.InstanceKey) RepetitionData {
+func (e expansionForEach) repetitionData(key addrs.InstanceKey) lang.RepetitionData {
 	k := string(key.(addrs.StringKey))
 	v, ok := e[k]
 	if !ok {
 		panic(fmt.Sprintf("instance key %q does not match any instance", k))
 	}
-	return RepetitionData{
+	return lang.RepetitionData{
 		EachKey:   cty.StringVal(k),
 		EachValue: v,
 	}
@@ -114,7 +115,7 @@ func (e expansionDeferred) instanceKeys() (addrs.InstanceKeyType, []addrs.Instan
 	return addrs.InstanceKeyType(e), nil, true
 }
 
-func (e expansionDeferred) repetitionData(key addrs.InstanceKey) RepetitionData {
+func (e expansionDeferred) repetitionData(key addrs.InstanceKey) lang.RepetitionData {
 	panic("no known instances for object with deferred expansion")
 }
 

--- a/internal/instances/set.go
+++ b/internal/instances/set.go
@@ -49,6 +49,6 @@ func (s Set) HasResource(want addrs.AbsResource) bool {
 // If there are multiple module calls in the path that have repetition enabled
 // then the result is the full expansion of all combinations of all of their
 // declared instance keys.
-func (s Set) InstancesForModule(modAddr addrs.Module) []addrs.ModuleInstance {
-	return s.exp.expandModule(modAddr, true)
+func (s Set) InstancesForModule(modAddr addrs.Module, includeDirectOverrides bool) []addrs.ModuleInstance {
+	return s.exp.expandModule(modAddr, true, includeDirectOverrides)
 }

--- a/internal/instances/set_test.go
+++ b/internal/instances/set_test.go
@@ -6,12 +6,13 @@ package instances
 import (
 	"testing"
 
-	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/zclconf/go-cty/cty"
+
+	"github.com/hashicorp/terraform/internal/addrs"
 )
 
 func TestSet(t *testing.T) {
-	exp := NewExpander()
+	exp := NewExpander(nil)
 
 	// The following constructs the following imaginary module/resource tree:
 	// - root module
@@ -208,7 +209,7 @@ func TestSet(t *testing.T) {
 	}
 
 	// ensure we can lookup non-existent addrs in a set without panic
-	if set.InstancesForModule(addrs.RootModule.Child("missing")) != nil {
+	if set.InstancesForModule(addrs.RootModule.Child("missing"), false) != nil {
 		t.Error("unexpected instances from missing module")
 	}
 }

--- a/internal/lang/eval.go
+++ b/internal/lang/eval.go
@@ -17,7 +17,6 @@ import (
 
 	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/configs/configschema"
-	"github.com/hashicorp/terraform/internal/instances"
 	"github.com/hashicorp/terraform/internal/lang/blocktoattr"
 	"github.com/hashicorp/terraform/internal/tfdiags"
 )
@@ -81,7 +80,7 @@ func (s *Scope) EvalBlock(body hcl.Body, schema *configschema.Block) (cty.Value,
 // object and instance key data. References to the object must use self, and the
 // key data will only contain count.index or each.key. The static values for
 // terraform and path will also be available in this context.
-func (s *Scope) EvalSelfBlock(body hcl.Body, self cty.Value, schema *configschema.Block, keyData instances.RepetitionData) (cty.Value, tfdiags.Diagnostics) {
+func (s *Scope) EvalSelfBlock(body hcl.Body, self cty.Value, schema *configschema.Block, keyData RepetitionData) (cty.Value, tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
 
 	spec := schema.DecoderSpec()

--- a/internal/lang/eval_test.go
+++ b/internal/lang/eval_test.go
@@ -9,12 +9,11 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/hashicorp/terraform/internal/addrs"
-	"github.com/hashicorp/terraform/internal/configs/configschema"
-	"github.com/hashicorp/terraform/internal/instances"
-
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
+
+	"github.com/hashicorp/terraform/internal/addrs"
+	"github.com/hashicorp/terraform/internal/configs/configschema"
 
 	"github.com/zclconf/go-cty/cty"
 	ctyjson "github.com/zclconf/go-cty/cty/json"
@@ -828,7 +827,7 @@ func TestScopeEvalSelfBlock(t *testing.T) {
 	tests := []struct {
 		Config  string
 		Self    cty.Value
-		KeyData instances.RepetitionData
+		KeyData RepetitionData
 		Want    map[string]cty.Value
 	}{
 		{
@@ -836,7 +835,7 @@ func TestScopeEvalSelfBlock(t *testing.T) {
 			Self: cty.ObjectVal(map[string]cty.Value{
 				"foo": cty.StringVal("bar"),
 			}),
-			KeyData: instances.RepetitionData{
+			KeyData: RepetitionData{
 				CountIndex: cty.NumberIntVal(0),
 			},
 			Want: map[string]cty.Value{
@@ -846,7 +845,7 @@ func TestScopeEvalSelfBlock(t *testing.T) {
 		},
 		{
 			Config: `num = count.index`,
-			KeyData: instances.RepetitionData{
+			KeyData: RepetitionData{
 				CountIndex: cty.NumberIntVal(0),
 			},
 			Want: map[string]cty.Value{
@@ -856,7 +855,7 @@ func TestScopeEvalSelfBlock(t *testing.T) {
 		},
 		{
 			Config: `attr = each.key`,
-			KeyData: instances.RepetitionData{
+			KeyData: RepetitionData{
 				EachKey: cty.StringVal("a"),
 			},
 			Want: map[string]cty.Value{

--- a/internal/lang/instance_key_data.go
+++ b/internal/lang/instance_key_data.go
@@ -1,7 +1,7 @@
 // Copyright (c) HashiCorp, Inc.
 // SPDX-License-Identifier: BUSL-1.1
 
-package instances
+package lang
 
 import (
 	"github.com/zclconf/go-cty/cty"

--- a/internal/moduletest/mocking/overrides.go
+++ b/internal/moduletest/mocking/overrides.go
@@ -79,6 +79,12 @@ func PackageOverrides(run *configs.TestRun, file *configs.TestFile, config *conf
 // cannot target modules directly. Therefore, we only need to check the local
 // overrides within this function.
 func (overrides *Overrides) IsOverridden(module addrs.ModuleInstance) bool {
+	if module.Equal(addrs.RootModuleInstance) {
+		// The root module is never overridden, so let's just short circuit
+		// this.
+		return false
+	}
+
 	if overrides.localOverrides.Has(module) {
 		// Short circuit things, if we have an exact match just return now.
 		return true
@@ -96,52 +102,36 @@ func (overrides *Overrides) IsOverridden(module addrs.ModuleInstance) bool {
 	return false
 }
 
-// IsDeeplyOverridden returns true if an ancestor of this module is overridden
-// but not if the module is overridden directly.
+// GetResourceOverride checks the overrides for the given resource instance.
+// This function automatically checks if the containing resource has been
+// overridden if the instance is instanced.
 //
-// This function doesn't consider an instanced module to be deeply overridden
-// by the uninstanced reference to the same module. So,
-// IsDeeplyOverridden("mod.child[0]") would return false if "mod.child" has been
-// overridden.
+// Users can mark a resource instance as overridden by overriding the instance
+// directly (eg. resource.foo[0]) or by overriding the containing resource
+// (eg. resource.foo).
 //
-// For this function, we know that overrides defined within mock providers
-// cannot target modules directly. Therefore, we only need to check the local
-// overrides within this function.
-func (overrides *Overrides) IsDeeplyOverridden(module addrs.ModuleInstance) bool {
-	for _, elem := range overrides.localOverrides.Elems {
-		target := elem.Key
-
-		if target.TargetContains(module) {
-			// So we do think it contains it, but it could be matching here
-			// because of equality or because we have an instanced module.
-			if instance, ok := target.(addrs.ModuleInstance); ok {
-				if instance.Equal(module) {
-					// Then we're exactly equal, so not deeply nested.
-					continue
-				}
-
-				if instance.Module().Equal(module.Module()) {
-					// Then we're an instanced version of they other one, so
-					// also not deeply nested by our definition of deeply.
-					continue
-				}
-
-			}
-
-			// Otherwise, it's deeply nested.
-			return true
-		}
+// If the resource is being supplied by a mock provider, then we need to check
+// the overrides for that provider as well, as such the provider config is
+// required so we know which mock provider to check.
+func (overrides *Overrides) GetResourceOverride(inst addrs.AbsResourceInstance, provider addrs.AbsProviderConfig) (*configs.Override, bool) {
+	if overrides.Empty() {
+		// Short circuit any lookups if we have no overrides.
+		return nil, false
 	}
-	return false
+
+	// First check this specific resource.
+	if override, ok := overrides.getResourceOverride(inst, provider); ok {
+		return override, true
+	}
+
+	// Otherwise check the containing resource in case the user has set for all
+	// the instances of a resource to be overridden.
+	return overrides.getResourceOverride(inst.ContainingResource(), provider)
 }
 
-// GetOverrideInclProviders retrieves the override for target if it exists.
-//
-// This function also checks the provider specific overrides using the provider
-// argument.
-func (overrides *Overrides) GetOverrideInclProviders(target addrs.Targetable, provider addrs.AbsProviderConfig) (*configs.Override, bool) {
+func (overrides *Overrides) getResourceOverride(target addrs.Targetable, provider addrs.AbsProviderConfig) (*configs.Override, bool) {
 	// If we have a local override, then apply that first.
-	if override, ok := overrides.GetOverride(target); ok {
+	if override, ok := overrides.localOverrides.GetOk(target); ok {
 		return override, true
 	}
 
@@ -157,10 +147,43 @@ func (overrides *Overrides) GetOverrideInclProviders(target addrs.Targetable, pr
 	return nil, false
 }
 
-// GetOverride retrieves the override for target from the local overrides if
-// it exists.
-func (overrides *Overrides) GetOverride(target addrs.Targetable) (*configs.Override, bool) {
-	return overrides.localOverrides.GetOk(target)
+// GetModuleOverride checks the overrides for the given module instance. This
+// function automatically checks if the containing module has been overridden
+// if the instance is instanced.
+//
+// Users can mark a module instance as overridden by overriding the instance
+// directly (eg. module.foo[0]) or by overriding the containing module
+// (eg. module.foo).
+//
+// Modules cannot be overridden by mock providers directly, so we don't need
+// to know anything about providers for this function (in contrast to
+// GetResourceOverride).
+func (overrides *Overrides) GetModuleOverride(inst addrs.ModuleInstance) (*configs.Override, bool) {
+	if len(inst) == 0 || overrides.Empty() {
+		// The root module is never overridden, so let's just short circuit
+		// this.
+		return nil, false
+	}
+
+	// Otherwise check if this specific instance has been overridden.
+	if override, ok := overrides.localOverrides.GetOk(inst); ok {
+		// It has, so just return that.
+		return override, true
+	}
+
+	// If this is an instanced address (eg. module.foo[0]), then we need to
+	// check if the containing module has been overridden as we let users
+	// override all instances of a module by overriding the containing module
+	// (eg. module.foo).
+
+	// Check if the last step is actually instanced, so we don't do extra work
+	// needlessly.
+	if inst[len(inst)-1].InstanceKey == addrs.NoKey {
+		// Then we already checked the instance itself and it wasn't overridden.
+		return nil, false
+	}
+
+	return overrides.localOverrides.GetOk(inst.ContainingModule())
 }
 
 // ProviderMatch returns true if we have overrides for the given provider.

--- a/internal/moduletest/mocking/overrides.go
+++ b/internal/moduletest/mocking/overrides.go
@@ -103,12 +103,10 @@ func (overrides *Overrides) IsOverridden(module addrs.ModuleInstance) bool {
 }
 
 // GetResourceOverride checks the overrides for the given resource instance.
-// This function automatically checks if the containing resource has been
-// overridden if the instance is instanced.
-//
-// Users can mark a resource instance as overridden by overriding the instance
-// directly (eg. resource.foo[0]) or by overriding the containing resource
-// (eg. resource.foo).
+// If the provided address is instanced, then we will check the containing
+// resource as well. This is because users can mark a resource instance as
+// overridden by overriding the instance directly (eg. resource.foo[0]) or by
+// overriding the containing resource (eg. resource.foo).
 //
 // If the resource is being supplied by a mock provider, then we need to check
 // the overrides for that provider as well, as such the provider config is

--- a/internal/moduletest/mocking/overrides_test.go
+++ b/internal/moduletest/mocking/overrides_test.go
@@ -86,9 +86,17 @@ func TestPackageOverrides(t *testing.T) {
 	overrides := PackageOverrides(run, file, config)
 
 	// We now expect that the run and file overrides took precedence.
-	first, pOk := overrides.GetOverride(primary)
-	second, sOk := overrides.GetOverride(secondary)
-	third, tOk := overrides.GetOverrideInclProviders(tertiary, addrs.AbsProviderConfig{
+	first, pOk := overrides.GetResourceOverride(primary, addrs.AbsProviderConfig{
+		Provider: addrs.Provider{
+			Type: "mock",
+		},
+	})
+	second, sOk := overrides.GetResourceOverride(secondary, addrs.AbsProviderConfig{
+		Provider: addrs.Provider{
+			Type: "mock",
+		},
+	})
+	third, tOk := overrides.GetResourceOverride(tertiary, addrs.AbsProviderConfig{
 		Provider: addrs.Provider{
 			Type: "mock",
 		},

--- a/internal/refactoring/move_validate.go
+++ b/internal/refactoring/move_validate.go
@@ -56,7 +56,7 @@ func ValidateMoves(stmts []MoveStatement, rootCfg *configs.Config, declaredInsts
 		// both stmt.From and stmt.To always belong to the same statement.
 		fromMod, _ := stmt.From.ModuleCallTraversals()
 
-		for _, fromModInst := range declaredInsts.InstancesForModule(fromMod) {
+		for _, fromModInst := range declaredInsts.InstancesForModule(fromMod, false) {
 			absFrom := stmt.From.InModuleInstance(fromModInst)
 
 			absTo := stmt.To.InModuleInstance(fromModInst)

--- a/internal/refactoring/move_validate_test.go
+++ b/internal/refactoring/move_validate_test.go
@@ -536,7 +536,7 @@ func loadRefactoringFixture(t *testing.T, dir string) (*configs.Config, instance
 		t.Fatalf("failed to load root module: %s", diags.Error())
 	}
 
-	expander := instances.NewExpander()
+	expander := instances.NewExpander(nil)
 	staticPopulateExpanderModule(t, rootCfg, addrs.RootModuleInstance, expander)
 	return rootCfg, expander.AllInstances()
 }
@@ -597,7 +597,7 @@ func staticPopulateExpanderModule(t *testing.T, rootCfg *configs.Config, moduleA
 
 		// We need to recursively analyze the child modules too.
 		calledMod := modCfg.Path.Child(call.Name)
-		for _, inst := range expander.ExpandModule(calledMod) {
+		for _, inst := range expander.ExpandModule(calledMod, false) {
 			staticPopulateExpanderModule(t, rootCfg, inst, expander)
 		}
 	}

--- a/internal/stacks/stackruntime/internal/stackeval/component.go
+++ b/internal/stacks/stackruntime/internal/stackeval/component.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/collections"
-	"github.com/hashicorp/terraform/internal/instances"
+	"github.com/hashicorp/terraform/internal/lang"
 	"github.com/hashicorp/terraform/internal/promising"
 	"github.com/hashicorp/terraform/internal/stacks/stackaddrs"
 	"github.com/hashicorp/terraform/internal/stacks/stackconfig"
@@ -172,7 +172,7 @@ func (c *Component) CheckInstances(ctx context.Context, phase EvalPhase) (map[ad
 			var diags tfdiags.Diagnostics
 			forEachVal := c.ForEachValue(ctx, phase)
 
-			ret := instancesMap(forEachVal, func(ik addrs.InstanceKey, rd instances.RepetitionData) *ComponentInstance {
+			ret := instancesMap(forEachVal, func(ik addrs.InstanceKey, rd lang.RepetitionData) *ComponentInstance {
 				return newComponentInstance(c, ik, rd)
 			})
 

--- a/internal/stacks/stackruntime/internal/stackeval/component_config.go
+++ b/internal/stacks/stackruntime/internal/stackeval/component_config.go
@@ -17,7 +17,7 @@ import (
 
 	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/configs"
-	"github.com/hashicorp/terraform/internal/instances"
+	"github.com/hashicorp/terraform/internal/lang"
 	"github.com/hashicorp/terraform/internal/promising"
 	"github.com/hashicorp/terraform/internal/providers"
 	"github.com/hashicorp/terraform/internal/stacks/stackaddrs"
@@ -423,7 +423,7 @@ func (c *ComponentConfig) ExprReferenceValue(ctx context.Context, phase EvalPhas
 }
 
 func (c *ComponentConfig) ResolveExpressionReference(ctx context.Context, ref stackaddrs.Reference) (Referenceable, tfdiags.Diagnostics) {
-	repetition := instances.RepetitionData{}
+	repetition := lang.RepetitionData{}
 	if c.Declaration(ctx).ForEach != nil {
 		// For validation, we'll return unknown for the instance data.
 		repetition.EachKey = cty.UnknownVal(cty.String).RefineNotNull()

--- a/internal/stacks/stackruntime/internal/stackeval/component_instance.go
+++ b/internal/stacks/stackruntime/internal/stackeval/component_instance.go
@@ -13,7 +13,7 @@ import (
 	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/collections"
 	"github.com/hashicorp/terraform/internal/configs/configschema"
-	"github.com/hashicorp/terraform/internal/instances"
+	"github.com/hashicorp/terraform/internal/lang"
 	"github.com/hashicorp/terraform/internal/lang/marks"
 	"github.com/hashicorp/terraform/internal/plans"
 	"github.com/hashicorp/terraform/internal/promising"
@@ -34,7 +34,7 @@ type ComponentInstance struct {
 
 	main *Main
 
-	repetition instances.RepetitionData
+	repetition lang.RepetitionData
 
 	moduleTreePlan promising.Once[withDiagnostics[*plans.Plan]]
 }
@@ -42,7 +42,7 @@ type ComponentInstance struct {
 var _ Plannable = (*ComponentInstance)(nil)
 var _ ExpressionScope = (*ComponentInstance)(nil)
 
-func newComponentInstance(call *Component, key addrs.InstanceKey, repetition instances.RepetitionData) *ComponentInstance {
+func newComponentInstance(call *Component, key addrs.InstanceKey, repetition lang.RepetitionData) *ComponentInstance {
 	return &ComponentInstance{
 		call:       call,
 		key:        key,
@@ -63,7 +63,7 @@ func (c *ComponentInstance) Addr() stackaddrs.AbsComponentInstance {
 	}
 }
 
-func (c *ComponentInstance) RepetitionData() instances.RepetitionData {
+func (c *ComponentInstance) RepetitionData() lang.RepetitionData {
 	return c.repetition
 }
 

--- a/internal/stacks/stackruntime/internal/stackeval/component_test.go
+++ b/internal/stacks/stackruntime/internal/stackeval/component_test.go
@@ -10,12 +10,13 @@ import (
 
 	"github.com/davecgh/go-spew/spew"
 	"github.com/google/go-cmp/cmp"
-	"github.com/hashicorp/terraform/internal/addrs"
-	"github.com/hashicorp/terraform/internal/instances"
-	"github.com/hashicorp/terraform/internal/stacks/stackaddrs"
-	"github.com/hashicorp/terraform/internal/tfdiags"
 	"github.com/zclconf/go-cty-debug/ctydebug"
 	"github.com/zclconf/go-cty/cty"
+
+	"github.com/hashicorp/terraform/internal/addrs"
+	"github.com/hashicorp/terraform/internal/lang"
+	"github.com/hashicorp/terraform/internal/stacks/stackaddrs"
+	"github.com/hashicorp/terraform/internal/tfdiags"
 )
 
 // TestComponentInstances is a test of the [Component.CheckInstances] function.
@@ -58,7 +59,7 @@ func TestComponentCheckInstances(t *testing.T) {
 		if !ok {
 			t.Fatalf("missing expected addrs.NoKey instance\n%s", spew.Sdump(insts))
 		}
-		if diff := cmp.Diff(instances.RepetitionData{}, inst.RepetitionData(), ctydebug.CmpOptions); diff != "" {
+		if diff := cmp.Diff(lang.RepetitionData{}, inst.RepetitionData(), ctydebug.CmpOptions); diff != "" {
 			t.Errorf("wrong repetition data\n%s", diff)
 		}
 	})
@@ -126,7 +127,7 @@ func TestComponentCheckInstances(t *testing.T) {
 				if !ok {
 					t.Fatalf("missing expected addrs.StringKey(\"a\") instance\n%s", spew.Sdump(insts))
 				}
-				wantRepData := instances.RepetitionData{
+				wantRepData := lang.RepetitionData{
 					EachKey: cty.StringVal("a"),
 					EachValue: cty.ObjectVal(map[string]cty.Value{
 						"test_string": cty.StringVal("in a"),
@@ -141,7 +142,7 @@ func TestComponentCheckInstances(t *testing.T) {
 				if !ok {
 					t.Fatalf("missing expected addrs.StringKey(\"b\") instance\n%s", spew.Sdump(insts))
 				}
-				wantRepData := instances.RepetitionData{
+				wantRepData := lang.RepetitionData{
 					EachKey: cty.StringVal("b"),
 					EachValue: cty.ObjectVal(map[string]cty.Value{
 						"test_string": cty.StringVal("in b"),

--- a/internal/stacks/stackruntime/internal/stackeval/for_each_test.go
+++ b/internal/stacks/stackruntime/internal/stackeval/for_each_test.go
@@ -12,12 +12,13 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hcltest"
-	"github.com/hashicorp/terraform/internal/addrs"
-	"github.com/hashicorp/terraform/internal/instances"
-	"github.com/hashicorp/terraform/internal/lang/marks"
-	"github.com/hashicorp/terraform/internal/tfdiags"
 	"github.com/zclconf/go-cty-debug/ctydebug"
 	"github.com/zclconf/go-cty/cty"
+
+	"github.com/hashicorp/terraform/internal/addrs"
+	"github.com/hashicorp/terraform/internal/lang"
+	"github.com/hashicorp/terraform/internal/lang/marks"
+	"github.com/hashicorp/terraform/internal/tfdiags"
 )
 
 func TestEvaluateForEachExpr(t *testing.T) {
@@ -180,9 +181,9 @@ func TestEvaluateForEachExpr(t *testing.T) {
 func TestInstancesMap(t *testing.T) {
 	type InstanceObj struct {
 		Key addrs.InstanceKey
-		Rep instances.RepetitionData
+		Rep lang.RepetitionData
 	}
-	makeObj := func(k addrs.InstanceKey, r instances.RepetitionData) InstanceObj {
+	makeObj := func(k addrs.InstanceKey, r lang.RepetitionData) InstanceObj {
 		return InstanceObj{
 			Key: k,
 			Rep: r,
@@ -203,7 +204,7 @@ func TestInstancesMap(t *testing.T) {
 			map[addrs.InstanceKey]InstanceObj{
 				addrs.NoKey: {
 					Key: addrs.NoKey,
-					Rep: instances.RepetitionData{
+					Rep: lang.RepetitionData{
 						// No data available for the non-repeating case
 					},
 				},
@@ -259,14 +260,14 @@ func TestInstancesMap(t *testing.T) {
 			map[addrs.InstanceKey]InstanceObj{
 				addrs.StringKey("a"): {
 					Key: addrs.StringKey("a"),
-					Rep: instances.RepetitionData{
+					Rep: lang.RepetitionData{
 						EachKey:   cty.StringVal("a"),
 						EachValue: cty.StringVal("beep"),
 					},
 				},
 				addrs.StringKey("b"): {
 					Key: addrs.StringKey("b"),
-					Rep: instances.RepetitionData{
+					Rep: lang.RepetitionData{
 						EachKey:   cty.StringVal("b"),
 						EachValue: cty.StringVal("boop"),
 					},
@@ -281,14 +282,14 @@ func TestInstancesMap(t *testing.T) {
 			map[addrs.InstanceKey]InstanceObj{
 				addrs.StringKey("a"): {
 					Key: addrs.StringKey("a"),
-					Rep: instances.RepetitionData{
+					Rep: lang.RepetitionData{
 						EachKey:   cty.StringVal("a"),
 						EachValue: cty.StringVal("beep"),
 					},
 				},
 				addrs.StringKey("b"): {
 					Key: addrs.StringKey("b"),
-					Rep: instances.RepetitionData{
+					Rep: lang.RepetitionData{
 						EachKey:   cty.StringVal("b"),
 						EachValue: cty.StringVal("boop"),
 					},
@@ -303,14 +304,14 @@ func TestInstancesMap(t *testing.T) {
 			map[addrs.InstanceKey]InstanceObj{
 				addrs.StringKey("beep"): {
 					Key: addrs.StringKey("beep"),
-					Rep: instances.RepetitionData{
+					Rep: lang.RepetitionData{
 						EachKey:   cty.StringVal("beep"),
 						EachValue: cty.StringVal("beep"),
 					},
 				},
 				addrs.StringKey("boop"): {
 					Key: addrs.StringKey("boop"),
-					Rep: instances.RepetitionData{
+					Rep: lang.RepetitionData{
 						EachKey:   cty.StringVal("boop"),
 						EachValue: cty.StringVal("boop"),
 					},

--- a/internal/stacks/stackruntime/internal/stackeval/main.go
+++ b/internal/stacks/stackruntime/internal/stackeval/main.go
@@ -16,7 +16,7 @@ import (
 	"github.com/hashicorp/terraform/internal/addrs"
 	fileProvisioner "github.com/hashicorp/terraform/internal/builtin/provisioners/file"
 	remoteExecProvisioner "github.com/hashicorp/terraform/internal/builtin/provisioners/remote-exec"
-	"github.com/hashicorp/terraform/internal/instances"
+	"github.com/hashicorp/terraform/internal/lang"
 	"github.com/hashicorp/terraform/internal/promising"
 	"github.com/hashicorp/terraform/internal/provisioners"
 	"github.com/hashicorp/terraform/internal/stacks/stackaddrs"
@@ -413,7 +413,7 @@ func (m *Main) ProviderInstance(ctx context.Context, addr stackaddrs.AbsProvider
 		// so we must optimistically return an instance referring to the
 		// given address which will then presumably yield unknown values
 		// of some kind when used.
-		return newProviderInstance(provider, addr.Item.Key, instances.RepetitionData{
+		return newProviderInstance(provider, addr.Item.Key, lang.RepetitionData{
 			EachKey:   cty.UnknownVal(cty.String),
 			EachValue: cty.DynamicVal,
 		})

--- a/internal/stacks/stackruntime/internal/stackeval/provider.go
+++ b/internal/stacks/stackruntime/internal/stackeval/provider.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/collections"
-	"github.com/hashicorp/terraform/internal/instances"
+	"github.com/hashicorp/terraform/internal/lang"
 	"github.com/hashicorp/terraform/internal/promising"
 	"github.com/hashicorp/terraform/internal/stacks/stackaddrs"
 	"github.com/hashicorp/terraform/internal/stacks/stackconfig"
@@ -179,7 +179,7 @@ func (p *Provider) CheckInstances(ctx context.Context, phase EvalPhase) (map[add
 		func(ctx context.Context) (map[addrs.InstanceKey]*ProviderInstance, tfdiags.Diagnostics) {
 			var diags tfdiags.Diagnostics
 			forEachVal := p.ForEachValue(ctx, phase)
-			return instancesMap(forEachVal, func(ik addrs.InstanceKey, rd instances.RepetitionData) *ProviderInstance {
+			return instancesMap(forEachVal, func(ik addrs.InstanceKey, rd lang.RepetitionData) *ProviderInstance {
 				return newProviderInstance(p, ik, rd)
 			}), diags
 		},

--- a/internal/stacks/stackruntime/internal/stackeval/provider_config.go
+++ b/internal/stacks/stackruntime/internal/stackeval/provider_config.go
@@ -13,7 +13,7 @@ import (
 	"github.com/zclconf/go-cty/cty"
 
 	"github.com/hashicorp/terraform/internal/addrs"
-	"github.com/hashicorp/terraform/internal/instances"
+	"github.com/hashicorp/terraform/internal/lang"
 	"github.com/hashicorp/terraform/internal/promising"
 	"github.com/hashicorp/terraform/internal/providers"
 	"github.com/hashicorp/terraform/internal/stacks/stackaddrs"
@@ -149,7 +149,7 @@ func (p *ProviderConfig) CheckProviderArgs(ctx context.Context, phase EvalPhase)
 // of validating the static provider configuration before it has been expanded
 // into multiple instances.
 func (p *ProviderConfig) ResolveExpressionReference(ctx context.Context, ref stackaddrs.Reference) (Referenceable, tfdiags.Diagnostics) {
-	repetition := instances.RepetitionData{}
+	repetition := lang.RepetitionData{}
 	if p.Declaration(ctx).ForEach != nil {
 		// We're producing an approximation across all eventual instances
 		// of this call, so we'll set each.key and each.value to unknown

--- a/internal/stacks/stackruntime/internal/stackeval/provider_instance.go
+++ b/internal/stacks/stackruntime/internal/stackeval/provider_instance.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/collections"
-	"github.com/hashicorp/terraform/internal/instances"
+	"github.com/hashicorp/terraform/internal/lang"
 	"github.com/hashicorp/terraform/internal/promising"
 	"github.com/hashicorp/terraform/internal/providers"
 	"github.com/hashicorp/terraform/internal/stacks/stackaddrs"
@@ -32,7 +32,7 @@ import (
 type ProviderInstance struct {
 	provider   *Provider
 	key        addrs.InstanceKey
-	repetition instances.RepetitionData
+	repetition lang.RepetitionData
 
 	main *Main
 
@@ -40,7 +40,7 @@ type ProviderInstance struct {
 	client       perEvalPhase[promising.Once[withDiagnostics[providers.Interface]]]
 }
 
-func newProviderInstance(provider *Provider, key addrs.InstanceKey, repetition instances.RepetitionData) *ProviderInstance {
+func newProviderInstance(provider *Provider, key addrs.InstanceKey, repetition lang.RepetitionData) *ProviderInstance {
 	return &ProviderInstance{
 		provider:   provider,
 		key:        key,
@@ -60,7 +60,7 @@ func (p *ProviderInstance) Addr() stackaddrs.AbsProviderConfigInstance {
 	}
 }
 
-func (p *ProviderInstance) RepetitionData() instances.RepetitionData {
+func (p *ProviderInstance) RepetitionData() lang.RepetitionData {
 	return p.repetition
 }
 

--- a/internal/stacks/stackruntime/internal/stackeval/provider_test.go
+++ b/internal/stacks/stackruntime/internal/stackeval/provider_test.go
@@ -10,13 +10,14 @@ import (
 
 	"github.com/davecgh/go-spew/spew"
 	"github.com/google/go-cmp/cmp"
+	"github.com/zclconf/go-cty-debug/ctydebug"
+	"github.com/zclconf/go-cty/cty"
+
 	"github.com/hashicorp/terraform/internal/addrs"
-	"github.com/hashicorp/terraform/internal/instances"
+	"github.com/hashicorp/terraform/internal/lang"
 	"github.com/hashicorp/terraform/internal/stacks/stackaddrs"
 	"github.com/hashicorp/terraform/internal/stacks/stackconfig/stackconfigtypes"
 	"github.com/hashicorp/terraform/internal/tfdiags"
-	"github.com/zclconf/go-cty-debug/ctydebug"
-	"github.com/zclconf/go-cty/cty"
 )
 
 func TestProviderCheckInstances(t *testing.T) {
@@ -55,7 +56,7 @@ func TestProviderCheckInstances(t *testing.T) {
 		if !ok {
 			t.Fatalf("missing expected addrs.NoKey instance\n%s", spew.Sdump(insts))
 		}
-		if diff := cmp.Diff(instances.RepetitionData{}, inst.RepetitionData(), ctydebug.CmpOptions); diff != "" {
+		if diff := cmp.Diff(lang.RepetitionData{}, inst.RepetitionData(), ctydebug.CmpOptions); diff != "" {
 			t.Errorf("wrong repetition data\n%s", diff)
 		}
 	})
@@ -119,7 +120,7 @@ func TestProviderCheckInstances(t *testing.T) {
 				if !ok {
 					t.Fatalf("missing expected addrs.StringKey(\"a\") instance\n%s", spew.Sdump(insts))
 				}
-				wantRepData := instances.RepetitionData{
+				wantRepData := lang.RepetitionData{
 					EachKey:   cty.StringVal("a"),
 					EachValue: cty.StringVal("in a"),
 				}
@@ -132,7 +133,7 @@ func TestProviderCheckInstances(t *testing.T) {
 				if !ok {
 					t.Fatalf("missing expected addrs.StringKey(\"b\") instance\n%s", spew.Sdump(insts))
 				}
-				wantRepData := instances.RepetitionData{
+				wantRepData := lang.RepetitionData{
 					EachKey:   cty.StringVal("b"),
 					EachValue: cty.StringVal("in b"),
 				}

--- a/internal/stacks/stackruntime/internal/stackeval/stack.go
+++ b/internal/stacks/stackruntime/internal/stackeval/stack.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/collections"
-	"github.com/hashicorp/terraform/internal/instances"
+	"github.com/hashicorp/terraform/internal/lang"
 	"github.com/hashicorp/terraform/internal/plans"
 	"github.com/hashicorp/terraform/internal/stacks/stackaddrs"
 	"github.com/hashicorp/terraform/internal/stacks/stackconfig"
@@ -390,14 +390,14 @@ func (s *Stack) ResultValue(ctx context.Context, phase EvalPhase) cty.Value {
 // global scope for evaluation within an already-instanciated stack during the
 // plan and apply phases.
 func (s *Stack) ResolveExpressionReference(ctx context.Context, ref stackaddrs.Reference) (Referenceable, tfdiags.Diagnostics) {
-	return s.resolveExpressionReference(ctx, ref, nil, instances.RepetitionData{})
+	return s.resolveExpressionReference(ctx, ref, nil, lang.RepetitionData{})
 }
 
 // resolveExpressionReference is a shared implementation of [ExpressionScope]
 // used for this stack's scope and all of the nested scopes of declarations
 // in the same stack, since they tend to differ only in what "self" means
 // and what each.key, each.value, or count.index are set to (if anything).
-func (s *Stack) resolveExpressionReference(ctx context.Context, ref stackaddrs.Reference, selfAddr stackaddrs.Referenceable, repetition instances.RepetitionData) (Referenceable, tfdiags.Diagnostics) {
+func (s *Stack) resolveExpressionReference(ctx context.Context, ref stackaddrs.Reference, selfAddr stackaddrs.Referenceable, repetition lang.RepetitionData) (Referenceable, tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
 
 	// "Test-only globals" is a special affordance we have only when running

--- a/internal/stacks/stackruntime/internal/stackeval/stack_call.go
+++ b/internal/stacks/stackruntime/internal/stackeval/stack_call.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/collections"
-	"github.com/hashicorp/terraform/internal/instances"
+	"github.com/hashicorp/terraform/internal/lang"
 	"github.com/hashicorp/terraform/internal/promising"
 	"github.com/hashicorp/terraform/internal/stacks/stackaddrs"
 	"github.com/hashicorp/terraform/internal/stacks/stackconfig"
@@ -165,7 +165,7 @@ func (c *StackCall) CheckInstances(ctx context.Context, phase EvalPhase) (map[ad
 			var diags tfdiags.Diagnostics
 			forEachVal := c.ForEachValue(ctx, phase)
 
-			return instancesMap(forEachVal, func(ik addrs.InstanceKey, rd instances.RepetitionData) *StackCallInstance {
+			return instancesMap(forEachVal, func(ik addrs.InstanceKey, rd lang.RepetitionData) *StackCallInstance {
 				return newStackCallInstance(c, ik, rd)
 			}), diags
 		},

--- a/internal/stacks/stackruntime/internal/stackeval/stack_call_config.go
+++ b/internal/stacks/stackruntime/internal/stackeval/stack_call_config.go
@@ -11,7 +11,7 @@ import (
 	"github.com/zclconf/go-cty/cty"
 	"github.com/zclconf/go-cty/cty/convert"
 
-	"github.com/hashicorp/terraform/internal/instances"
+	"github.com/hashicorp/terraform/internal/lang"
 	"github.com/hashicorp/terraform/internal/promising"
 	"github.com/hashicorp/terraform/internal/stacks/stackaddrs"
 	"github.com/hashicorp/terraform/internal/stacks/stackconfig"
@@ -313,7 +313,7 @@ func (s *StackCallConfig) ValidateResultValue(ctx context.Context, phase EvalPha
 // instance of a stack call. This is not the right scope to use during the
 // plan and apply phases.
 func (s *StackCallConfig) ResolveExpressionReference(ctx context.Context, ref stackaddrs.Reference) (Referenceable, tfdiags.Diagnostics) {
-	repetition := instances.RepetitionData{}
+	repetition := lang.RepetitionData{}
 	if s.config.ForEach != nil {
 		// We're producing an approximation across all eventual instances
 		// of this call, so we'll set each.key and each.value to unknown

--- a/internal/stacks/stackruntime/internal/stackeval/stack_call_instance.go
+++ b/internal/stacks/stackruntime/internal/stackeval/stack_call_instance.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/collections"
-	"github.com/hashicorp/terraform/internal/instances"
+	"github.com/hashicorp/terraform/internal/lang"
 	"github.com/hashicorp/terraform/internal/stacks/stackaddrs"
 	"github.com/hashicorp/terraform/internal/stacks/stackplan"
 	"github.com/hashicorp/terraform/internal/stacks/stackstate"
@@ -33,13 +33,13 @@ type StackCallInstance struct {
 
 	main *Main
 
-	repetition instances.RepetitionData
+	repetition lang.RepetitionData
 }
 
 var _ ExpressionScope = (*StackCallInstance)(nil)
 var _ Plannable = (*StackCallInstance)(nil)
 
-func newStackCallInstance(call *StackCall, key addrs.InstanceKey, repetition instances.RepetitionData) *StackCallInstance {
+func newStackCallInstance(call *StackCall, key addrs.InstanceKey, repetition lang.RepetitionData) *StackCallInstance {
 	return &StackCallInstance{
 		call:       call,
 		key:        key,
@@ -48,7 +48,7 @@ func newStackCallInstance(call *StackCall, key addrs.InstanceKey, repetition ins
 	}
 }
 
-func (c *StackCallInstance) RepetitionData() instances.RepetitionData {
+func (c *StackCallInstance) RepetitionData() lang.RepetitionData {
 	return c.repetition
 }
 

--- a/internal/stacks/stackruntime/internal/stackeval/stack_call_test.go
+++ b/internal/stacks/stackruntime/internal/stackeval/stack_call_test.go
@@ -10,12 +10,13 @@ import (
 
 	"github.com/davecgh/go-spew/spew"
 	"github.com/google/go-cmp/cmp"
-	"github.com/hashicorp/terraform/internal/addrs"
-	"github.com/hashicorp/terraform/internal/instances"
-	"github.com/hashicorp/terraform/internal/stacks/stackaddrs"
-	"github.com/hashicorp/terraform/internal/tfdiags"
 	"github.com/zclconf/go-cty-debug/ctydebug"
 	"github.com/zclconf/go-cty/cty"
+
+	"github.com/hashicorp/terraform/internal/addrs"
+	"github.com/hashicorp/terraform/internal/lang"
+	"github.com/hashicorp/terraform/internal/stacks/stackaddrs"
+	"github.com/hashicorp/terraform/internal/tfdiags"
 )
 
 func TestStackCallCheckInstances(t *testing.T) {
@@ -53,7 +54,7 @@ func TestStackCallCheckInstances(t *testing.T) {
 		if !ok {
 			t.Fatalf("missing expected addrs.NoKey instance\n%s", spew.Sdump(insts))
 		}
-		if diff := cmp.Diff(instances.RepetitionData{}, inst.RepetitionData(), ctydebug.CmpOptions); diff != "" {
+		if diff := cmp.Diff(lang.RepetitionData{}, inst.RepetitionData(), ctydebug.CmpOptions); diff != "" {
 			t.Errorf("wrong repetition data\n%s", diff)
 		}
 	})
@@ -121,7 +122,7 @@ func TestStackCallCheckInstances(t *testing.T) {
 				if !ok {
 					t.Fatalf("missing expected addrs.StringKey(\"a\") instance\n%s", spew.Sdump(insts))
 				}
-				wantRepData := instances.RepetitionData{
+				wantRepData := lang.RepetitionData{
 					EachKey: cty.StringVal("a"),
 					EachValue: cty.ObjectVal(map[string]cty.Value{
 						"test_string": cty.StringVal("in a"),
@@ -136,7 +137,7 @@ func TestStackCallCheckInstances(t *testing.T) {
 				if !ok {
 					t.Fatalf("missing expected addrs.StringKey(\"b\") instance\n%s", spew.Sdump(insts))
 				}
-				wantRepData := instances.RepetitionData{
+				wantRepData := lang.RepetitionData{
 					EachKey: cty.StringVal("b"),
 					EachValue: cty.ObjectVal(map[string]cty.Value{
 						"test_string": cty.StringVal("in b"),

--- a/internal/stacks/stackruntime/internal/stackeval/stack_config.go
+++ b/internal/stacks/stackruntime/internal/stackeval/stack_config.go
@@ -12,7 +12,7 @@ import (
 	"github.com/zclconf/go-cty/cty"
 
 	"github.com/hashicorp/terraform/internal/addrs"
-	"github.com/hashicorp/terraform/internal/instances"
+	"github.com/hashicorp/terraform/internal/lang"
 	"github.com/hashicorp/terraform/internal/promising"
 	"github.com/hashicorp/terraform/internal/stacks/stackaddrs"
 	"github.com/hashicorp/terraform/internal/stacks/stackconfig"
@@ -378,13 +378,13 @@ func (s *StackConfig) Components(ctx context.Context) map[stackaddrs.Component]*
 // global scope for evaluation within an unexpanded stack during the validate
 // phase.
 func (s *StackConfig) ResolveExpressionReference(ctx context.Context, ref stackaddrs.Reference) (Referenceable, tfdiags.Diagnostics) {
-	return s.resolveExpressionReference(ctx, ref, nil, instances.RepetitionData{})
+	return s.resolveExpressionReference(ctx, ref, nil, lang.RepetitionData{})
 }
 
 // resolveExpressionReference is the shared implementation of various
 // validation-time ResolveExpressionReference methods, factoring out all
 // of the common parts into one place.
-func (s *StackConfig) resolveExpressionReference(ctx context.Context, ref stackaddrs.Reference, selfAddr stackaddrs.Referenceable, repetition instances.RepetitionData) (Referenceable, tfdiags.Diagnostics) {
+func (s *StackConfig) resolveExpressionReference(ctx context.Context, ref stackaddrs.Reference, selfAddr stackaddrs.Referenceable, repetition lang.RepetitionData) (Referenceable, tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
 
 	// "Test-only globals" is a special affordance we have only when running

--- a/internal/terraform/context_apply.go
+++ b/internal/terraform/context_apply.go
@@ -285,6 +285,7 @@ func (c *Context) applyGraph(plan *plans.Plan, config *configs.Config, opts *App
 		ForceReplace:            plan.ForceReplaceAddrs,
 		Operation:               operation,
 		ExternalReferences:      plan.ExternalReferences,
+		Overrides:               plan.Overrides,
 	}).Build(addrs.RootModuleInstance)
 	diags = diags.Append(moreDiags)
 	if moreDiags.HasErrors() {

--- a/internal/terraform/context_plan.go
+++ b/internal/terraform/context_plan.go
@@ -819,6 +819,7 @@ func (c *Context) planGraph(config *configs.Config, prevRunState *states.State, 
 			preDestroyRefresh:       opts.PreDestroyRefresh,
 			Operation:               walkPlan,
 			ExternalReferences:      opts.ExternalReferences,
+			Overrides:               opts.Overrides,
 			ImportTargets:           c.findImportTargets(config),
 			forgetResources:         forgetResources,
 			forgetModules:           forgetModules,
@@ -837,6 +838,7 @@ func (c *Context) planGraph(config *configs.Config, prevRunState *states.State, 
 			skipPlanChanges:         true, // this activates "refresh only" mode.
 			Operation:               walkPlan,
 			ExternalReferences:      opts.ExternalReferences,
+			Overrides:               opts.Overrides,
 		}).Build(addrs.RootModuleInstance)
 		return graph, walkPlan, diags
 	case plans.DestroyMode:
@@ -849,6 +851,7 @@ func (c *Context) planGraph(config *configs.Config, prevRunState *states.State, 
 			Targets:                 opts.Targets,
 			skipRefresh:             opts.SkipRefresh,
 			Operation:               walkPlanDestroy,
+			Overrides:               opts.Overrides,
 		}).Build(addrs.RootModuleInstance)
 		return graph, walkPlanDestroy, diags
 	default:

--- a/internal/terraform/context_walk.go
+++ b/internal/terraform/context_walk.go
@@ -184,7 +184,7 @@ func (c *Context) graphWalker(graph *Graph, operation walkOperation, opts *graph
 		NamedValues:             namedvals.NewState(),
 		Deferrals:               deferred,
 		Checks:                  checkState,
-		InstanceExpander:        instances.NewExpander(),
+		InstanceExpander:        instances.NewExpander(opts.Overrides),
 		ExternalProviderConfigs: opts.ExternalProviderConfigs,
 		MoveResults:             opts.MoveResults,
 		Operation:               operation,

--- a/internal/terraform/eval_conditions.go
+++ b/internal/terraform/eval_conditions.go
@@ -14,7 +14,6 @@ import (
 	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/checks"
 	"github.com/hashicorp/terraform/internal/configs"
-	"github.com/hashicorp/terraform/internal/instances"
 	"github.com/hashicorp/terraform/internal/lang"
 	"github.com/hashicorp/terraform/internal/tfdiags"
 )
@@ -28,7 +27,7 @@ import (
 //
 // If any of the rules do not pass, the returned diagnostics will contain
 // errors. Otherwise, it will either be empty or contain only warnings.
-func evalCheckRules(typ addrs.CheckRuleType, rules []*configs.CheckRule, ctx EvalContext, self addrs.Checkable, keyData instances.RepetitionData, diagSeverity tfdiags.Severity) tfdiags.Diagnostics {
+func evalCheckRules(typ addrs.CheckRuleType, rules []*configs.CheckRule, ctx EvalContext, self addrs.Checkable, keyData lang.RepetitionData, diagSeverity tfdiags.Severity) tfdiags.Diagnostics {
 	var diags tfdiags.Diagnostics
 
 	checkState := ctx.Checks()
@@ -68,7 +67,7 @@ type checkResult struct {
 	FailureMessage string
 }
 
-func validateCheckRule(addr addrs.CheckRule, rule *configs.CheckRule, ctx EvalContext, keyData instances.RepetitionData) (string, *hcl.EvalContext, tfdiags.Diagnostics) {
+func validateCheckRule(addr addrs.CheckRule, rule *configs.CheckRule, ctx EvalContext, keyData lang.RepetitionData) (string, *hcl.EvalContext, tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
 
 	refs, moreDiags := lang.ReferencesInExpr(addrs.ParseRef, rule.Condition)
@@ -108,7 +107,7 @@ func validateCheckRule(addr addrs.CheckRule, rule *configs.CheckRule, ctx EvalCo
 	return errorMessage, hclCtx, diags
 }
 
-func evalCheckRule(addr addrs.CheckRule, rule *configs.CheckRule, ctx EvalContext, keyData instances.RepetitionData, severity hcl.DiagnosticSeverity) (checkResult, tfdiags.Diagnostics) {
+func evalCheckRule(addr addrs.CheckRule, rule *configs.CheckRule, ctx EvalContext, keyData lang.RepetitionData, severity hcl.DiagnosticSeverity) (checkResult, tfdiags.Diagnostics) {
 	// NOTE: Intentionally not passing the caller's selected severity in here,
 	// because this reports errors in the configuration itself, not the failure
 	// of an otherwise-valid condition.

--- a/internal/terraform/eval_context.go
+++ b/internal/terraform/eval_context.go
@@ -130,7 +130,7 @@ type EvalContext interface {
 	// EvaluateReplaceTriggeredBy takes the raw reference expression from the
 	// config, and returns the evaluated *addrs.Reference along with a boolean
 	// indicating if that reference forces replacement.
-	EvaluateReplaceTriggeredBy(expr hcl.Expression, repData instances.RepetitionData) (*addrs.Reference, bool, tfdiags.Diagnostics)
+	EvaluateReplaceTriggeredBy(expr hcl.Expression, repData lang.RepetitionData) (*addrs.Reference, bool, tfdiags.Diagnostics)
 
 	// EvaluationScope returns a scope that can be used to evaluate reference
 	// addresses in this context.

--- a/internal/terraform/eval_context_builtin.go
+++ b/internal/terraform/eval_context_builtin.go
@@ -322,7 +322,7 @@ func (ctx *BuiltinEvalContext) EvaluateExpr(expr hcl.Expression, wantType cty.Ty
 	return scope.EvalExpr(expr, wantType)
 }
 
-func (ctx *BuiltinEvalContext) EvaluateReplaceTriggeredBy(expr hcl.Expression, repData instances.RepetitionData) (*addrs.Reference, bool, tfdiags.Diagnostics) {
+func (ctx *BuiltinEvalContext) EvaluateReplaceTriggeredBy(expr hcl.Expression, repData lang.RepetitionData) (*addrs.Reference, bool, tfdiags.Diagnostics) {
 
 	// get the reference to lookup changes in the plan
 	ref, diags := evalReplaceTriggeredByExpr(expr, repData)

--- a/internal/terraform/eval_context_mock.go
+++ b/internal/terraform/eval_context_mock.go
@@ -266,7 +266,7 @@ func (c *MockEvalContext) EvaluateExpr(expr hcl.Expression, wantType cty.Type, s
 	return c.EvaluateExprResult, c.EvaluateExprDiags
 }
 
-func (c *MockEvalContext) EvaluateReplaceTriggeredBy(hcl.Expression, instances.RepetitionData) (*addrs.Reference, bool, tfdiags.Diagnostics) {
+func (c *MockEvalContext) EvaluateReplaceTriggeredBy(hcl.Expression, lang.RepetitionData) (*addrs.Reference, bool, tfdiags.Diagnostics) {
 	return nil, false, nil
 }
 

--- a/internal/terraform/eval_for_each.go
+++ b/internal/terraform/eval_for_each.go
@@ -10,7 +10,6 @@ import (
 	"github.com/zclconf/go-cty/cty"
 
 	"github.com/hashicorp/terraform/internal/addrs"
-	"github.com/hashicorp/terraform/internal/instances"
 	"github.com/hashicorp/terraform/internal/lang"
 	"github.com/hashicorp/terraform/internal/lang/marks"
 	"github.com/hashicorp/terraform/internal/tfdiags"
@@ -101,8 +100,8 @@ func (ev *forEachEvaluator) ResourceValue() (map[string]cty.Value, bool, tfdiags
 
 // ImportValue returns the for_each map for use within an import block,
 // enumerated as individual instances.RepetitionData values.
-func (ev *forEachEvaluator) ImportValues() ([]instances.RepetitionData, tfdiags.Diagnostics) {
-	var res []instances.RepetitionData
+func (ev *forEachEvaluator) ImportValues() ([]lang.RepetitionData, tfdiags.Diagnostics) {
+	var res []lang.RepetitionData
 	if ev.expr == nil {
 		return res, nil
 	}
@@ -127,7 +126,7 @@ func (ev *forEachEvaluator) ImportValues() ([]instances.RepetitionData, tfdiags.
 	it := val.ElementIterator()
 	for it.Next() {
 		k, v := it.Element()
-		res = append(res, instances.RepetitionData{
+		res = append(res, lang.RepetitionData{
 			EachKey:   k,
 			EachValue: v.WithMarks(marks),
 		})

--- a/internal/terraform/eval_import.go
+++ b/internal/terraform/eval_import.go
@@ -8,15 +8,16 @@ import (
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
-	"github.com/hashicorp/terraform/internal/addrs"
-	"github.com/hashicorp/terraform/internal/instances"
-	"github.com/hashicorp/terraform/internal/lang/marks"
-	"github.com/hashicorp/terraform/internal/tfdiags"
 	"github.com/zclconf/go-cty/cty"
 	"github.com/zclconf/go-cty/cty/gocty"
+
+	"github.com/hashicorp/terraform/internal/addrs"
+	"github.com/hashicorp/terraform/internal/lang"
+	"github.com/hashicorp/terraform/internal/lang/marks"
+	"github.com/hashicorp/terraform/internal/tfdiags"
 )
 
-func evaluateImportIdExpression(expr hcl.Expression, ctx EvalContext, keyData instances.RepetitionData) (string, tfdiags.Diagnostics) {
+func evaluateImportIdExpression(expr hcl.Expression, ctx EvalContext, keyData lang.RepetitionData) (string, tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
 
 	// import blocks only exist in the root module, and must be evaluated in
@@ -84,7 +85,7 @@ func evaluateImportIdExpression(expr hcl.Expression, ctx EvalContext, keyData in
 	return importId, diags
 }
 
-func evalImportToExpression(expr hcl.Expression, keyData instances.RepetitionData) (addrs.AbsResourceInstance, tfdiags.Diagnostics) {
+func evalImportToExpression(expr hcl.Expression, keyData lang.RepetitionData) (addrs.AbsResourceInstance, tfdiags.Diagnostics) {
 	var res addrs.AbsResourceInstance
 	var diags tfdiags.Diagnostics
 
@@ -120,7 +121,7 @@ func evalImportToExpression(expr hcl.Expression, keyData instances.RepetitionDat
 // in replace_triggered_by, and converts it to a static traversal. The
 // RepetitionData contains the data necessary to evaluate the only allowed
 // variables in the expression, count.index and each.key.
-func importToExprToTraversal(expr hcl.Expression, keyData instances.RepetitionData) (hcl.Traversal, tfdiags.Diagnostics) {
+func importToExprToTraversal(expr hcl.Expression, keyData lang.RepetitionData) (hcl.Traversal, tfdiags.Diagnostics) {
 	var trav hcl.Traversal
 	var diags tfdiags.Diagnostics
 
@@ -165,7 +166,7 @@ func importToExprToTraversal(expr hcl.Expression, keyData instances.RepetitionDa
 
 // parseImportToKeyExpression takes an hcl.Expression and parses it as an index key, while
 // evaluating any references to count.index or each.key.
-func parseImportToKeyExpression(expr hcl.Expression, keyData instances.RepetitionData) (hcl.TraverseIndex, hcl.Diagnostics) {
+func parseImportToKeyExpression(expr hcl.Expression, keyData lang.RepetitionData) (hcl.TraverseIndex, hcl.Diagnostics) {
 	idx := hcl.TraverseIndex{
 		SrcRange: expr.Range(),
 	}

--- a/internal/terraform/evaluate.go
+++ b/internal/terraform/evaluate.go
@@ -118,7 +118,7 @@ type evaluationStateData struct {
 
 // InstanceKeyEvalData is the old name for instances.RepetitionData, aliased
 // here for compatibility. In new code, use instances.RepetitionData instead.
-type InstanceKeyEvalData = instances.RepetitionData
+type InstanceKeyEvalData = lang.RepetitionData
 
 // EvalDataForInstanceKey constructs a suitable InstanceKeyEvalData for
 // evaluating in a context that has the given instance key.

--- a/internal/terraform/evaluate_test.go
+++ b/internal/terraform/evaluate_test.go
@@ -617,7 +617,7 @@ func evaluatorForModule(stateSync *states.SyncState, changesSync *plans.ChangesS
 		},
 		State:       stateSync,
 		Changes:     changesSync,
-		Instances:   instances.NewExpander(),
+		Instances:   instances.NewExpander(nil),
 		NamedValues: namedvals.NewState(),
 	}
 }

--- a/internal/terraform/evaluate_triggers.go
+++ b/internal/terraform/evaluate_triggers.go
@@ -8,13 +8,14 @@ import (
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
-	"github.com/hashicorp/terraform/internal/addrs"
-	"github.com/hashicorp/terraform/internal/instances"
-	"github.com/hashicorp/terraform/internal/tfdiags"
 	"github.com/zclconf/go-cty/cty"
+
+	"github.com/hashicorp/terraform/internal/addrs"
+	"github.com/hashicorp/terraform/internal/lang"
+	"github.com/hashicorp/terraform/internal/tfdiags"
 )
 
-func evalReplaceTriggeredByExpr(expr hcl.Expression, keyData instances.RepetitionData) (*addrs.Reference, tfdiags.Diagnostics) {
+func evalReplaceTriggeredByExpr(expr hcl.Expression, keyData lang.RepetitionData) (*addrs.Reference, tfdiags.Diagnostics) {
 	var ref *addrs.Reference
 	var diags tfdiags.Diagnostics
 
@@ -34,7 +35,7 @@ func evalReplaceTriggeredByExpr(expr hcl.Expression, keyData instances.Repetitio
 // in replace_triggered_by, and converts it to a static traversal. The
 // RepetitionData contains the data necessary to evaluate the only allowed
 // variables in the expression, count.index and each.key.
-func triggersExprToTraversal(expr hcl.Expression, keyData instances.RepetitionData) (hcl.Traversal, tfdiags.Diagnostics) {
+func triggersExprToTraversal(expr hcl.Expression, keyData lang.RepetitionData) (hcl.Traversal, tfdiags.Diagnostics) {
 	var trav hcl.Traversal
 	var diags tfdiags.Diagnostics
 
@@ -82,7 +83,7 @@ func triggersExprToTraversal(expr hcl.Expression, keyData instances.RepetitionDa
 
 // parseReplaceTriggeredByKeyExpr takes an hcl.Expression and parses it as an index key, while
 // evaluating any references to count.index or each.key.
-func parseReplaceTriggeredByKeyExpr(expr hcl.Expression, keyData instances.RepetitionData) (hcl.TraverseIndex, hcl.Diagnostics) {
+func parseReplaceTriggeredByKeyExpr(expr hcl.Expression, keyData lang.RepetitionData) (hcl.TraverseIndex, hcl.Diagnostics) {
 	idx := hcl.TraverseIndex{
 		SrcRange: expr.Range(),
 	}

--- a/internal/terraform/evaluate_triggers_test.go
+++ b/internal/terraform/evaluate_triggers_test.go
@@ -8,8 +8,10 @@ import (
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
+
 	"github.com/hashicorp/terraform/internal/addrs"
-	"github.com/hashicorp/terraform/internal/instances"
+	"github.com/hashicorp/terraform/internal/lang"
+
 	"github.com/zclconf/go-cty/cty"
 )
 
@@ -23,7 +25,7 @@ func TestEvalReplaceTriggeredBy(t *testing.T) {
 		// If the expression contains count or each, then we need to add
 		// repetition data, and the static string to parse into the desired
 		// *addrs.Reference
-		repData   instances.RepetitionData
+		repData   lang.RepetitionData
 		reference string
 	}{
 		"single resource": {
@@ -40,21 +42,21 @@ func TestEvalReplaceTriggeredBy(t *testing.T) {
 
 		"resource instance count": {
 			expr: "test_resource.a[count.index]",
-			repData: instances.RepetitionData{
+			repData: lang.RepetitionData{
 				CountIndex: cty.NumberIntVal(0),
 			},
 			reference: "test_resource.a[0]",
 		},
 		"resource instance for_each": {
 			expr: "test_resource.a[each.key].attr",
-			repData: instances.RepetitionData{
+			repData: lang.RepetitionData{
 				EachKey: cty.StringVal("k"),
 			},
 			reference: `test_resource.a["k"].attr`,
 		},
 		"resource instance for_each map attr": {
 			expr: "test_resource.a[each.key].attr[each.key]",
-			repData: instances.RepetitionData{
+			repData: lang.RepetitionData{
 				EachKey: cty.StringVal("k"),
 			},
 			reference: `test_resource.a["k"].attr["k"]`,

--- a/internal/terraform/graph_builder_apply.go
+++ b/internal/terraform/graph_builder_apply.go
@@ -7,6 +7,7 @@ import (
 	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/configs"
 	"github.com/hashicorp/terraform/internal/dag"
+	"github.com/hashicorp/terraform/internal/moduletest/mocking"
 	"github.com/hashicorp/terraform/internal/plans"
 	"github.com/hashicorp/terraform/internal/providers"
 	"github.com/hashicorp/terraform/internal/states"
@@ -64,6 +65,10 @@ type ApplyGraphBuilder struct {
 	// nodes that should not be pruned even if they are not referenced within
 	// the actual graph.
 	ExternalReferences []*addrs.Reference
+
+	// Overrides provides the set of overrides supplied by the testing
+	// framework.
+	Overrides *mocking.Overrides
 }
 
 // See GraphBuilder
@@ -120,6 +125,7 @@ func (b *ApplyGraphBuilder) Steps() []GraphTransformer {
 		&OutputTransformer{
 			Config:     b.Config,
 			Destroying: b.Operation == walkDestroy,
+			Overrides:  b.Overrides,
 		},
 
 		// Creates all the resource instances represented in the diff, along

--- a/internal/terraform/graph_builder_plan.go
+++ b/internal/terraform/graph_builder_plan.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/configs"
 	"github.com/hashicorp/terraform/internal/dag"
+	"github.com/hashicorp/terraform/internal/moduletest/mocking"
 	"github.com/hashicorp/terraform/internal/providers"
 	"github.com/hashicorp/terraform/internal/states"
 	"github.com/hashicorp/terraform/internal/tfdiags"
@@ -85,6 +86,10 @@ type PlanGraphBuilder struct {
 	// the actual graph.
 	ExternalReferences []*addrs.Reference
 
+	// Overrides provides the set of overrides supplied by the testing
+	// framework.
+	Overrides *mocking.Overrides
+
 	// ImportTargets are the list of resources to import.
 	ImportTargets []*ImportTarget
 
@@ -159,6 +164,7 @@ func (b *PlanGraphBuilder) Steps() []GraphTransformer {
 			Config:      b.Config,
 			RefreshOnly: b.skipPlanChanges || b.preDestroyRefresh,
 			Destroying:  b.Operation == walkPlanDestroy,
+			Overrides:   b.Overrides,
 
 			// NOTE: We currently treat anything built with the plan graph
 			// builder as "planning" for our purposes here, because we share

--- a/internal/terraform/instance_expanders.go
+++ b/internal/terraform/instance_expanders.go
@@ -31,16 +31,11 @@ type graphNodeExpandsInstances interface {
 // partially-expanded prefixes conceptually represent an infinite set of
 // possible module instance addresses and therefore need quite different
 // treatment than a single concrete module instance address.
-func forEachModuleInstance(
-	insts *instances.Expander,
-	modAddr addrs.Module,
-	knownCb func(addrs.ModuleInstance),
-	unknownCb func(addrs.PartialExpandedModule),
-) {
-	for _, instAddr := range insts.ExpandModule(modAddr) {
+func forEachModuleInstance(insts *instances.Expander, modAddr addrs.Module, includeOverrides bool, knownCb func(addrs.ModuleInstance), unknownCb func(addrs.PartialExpandedModule)) {
+	for _, instAddr := range insts.ExpandModule(modAddr, includeOverrides) {
 		knownCb(instAddr)
 	}
-	for _, instsAddr := range insts.UnknownModuleInstances(modAddr) {
+	for _, instsAddr := range insts.UnknownModuleInstances(modAddr, includeOverrides) {
 		unknownCb(instsAddr)
 	}
 }

--- a/internal/terraform/node_local.go
+++ b/internal/terraform/node_local.go
@@ -69,25 +69,21 @@ func (n *nodeExpandLocal) References() []*addrs.Reference {
 func (n *nodeExpandLocal) DynamicExpand(ctx EvalContext) (*Graph, tfdiags.Diagnostics) {
 	var g Graph
 	expander := ctx.InstanceExpander()
-	forEachModuleInstance(
-		expander, n.Module,
-		func(module addrs.ModuleInstance) {
-			o := &NodeLocal{
-				Addr:   n.Addr.Absolute(module),
-				Config: n.Config,
-			}
-			log.Printf("[TRACE] Expanding local: adding %s as %T", o.Addr.String(), o)
-			g.Add(o)
-		},
-		func(pem addrs.PartialExpandedModule) {
-			o := &nodeLocalInPartialModule{
-				Addr:   addrs.ObjectInPartialExpandedModule(pem, n.Addr),
-				Config: n.Config,
-			}
-			log.Printf("[TRACE] Expanding local: adding placeholder for all %s as %T", o.Addr.String(), o)
-			g.Add(o)
-		},
-	)
+	forEachModuleInstance(expander, n.Module, false, func(module addrs.ModuleInstance) {
+		o := &NodeLocal{
+			Addr:   n.Addr.Absolute(module),
+			Config: n.Config,
+		}
+		log.Printf("[TRACE] Expanding local: adding %s as %T", o.Addr.String(), o)
+		g.Add(o)
+	}, func(pem addrs.PartialExpandedModule) {
+		o := &nodeLocalInPartialModule{
+			Addr:   addrs.ObjectInPartialExpandedModule(pem, n.Addr),
+			Config: n.Config,
+		}
+		log.Printf("[TRACE] Expanding local: adding placeholder for all %s as %T", o.Addr.String(), o)
+		g.Add(o)
+	})
 	addRootNodeToGraph(&g)
 	return &g, nil
 }

--- a/internal/terraform/node_module_expand_test.go
+++ b/internal/terraform/node_module_expand_test.go
@@ -7,16 +7,17 @@ import (
 	"testing"
 
 	"github.com/hashicorp/hcl/v2/hcltest"
+	"github.com/zclconf/go-cty/cty"
+
 	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/configs"
 	"github.com/hashicorp/terraform/internal/instances"
 	"github.com/hashicorp/terraform/internal/states"
-	"github.com/zclconf/go-cty/cty"
 )
 
 func TestNodeExpandModuleExecute(t *testing.T) {
 	ctx := &MockEvalContext{
-		InstanceExpanderExpander: instances.NewExpander(),
+		InstanceExpanderExpander: instances.NewExpander(nil),
 	}
 	ctx.installSimpleEval()
 
@@ -90,7 +91,7 @@ func TestNodeCloseModuleExecute(t *testing.T) {
 func TestNodeValidateModuleExecute(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		ctx := &MockEvalContext{
-			InstanceExpanderExpander: instances.NewExpander(),
+			InstanceExpanderExpander: instances.NewExpander(nil),
 		}
 		ctx.installSimpleEval()
 		node := nodeValidateModule{
@@ -110,7 +111,7 @@ func TestNodeValidateModuleExecute(t *testing.T) {
 
 	t.Run("invalid count", func(t *testing.T) {
 		ctx := &MockEvalContext{
-			InstanceExpanderExpander: instances.NewExpander(),
+			InstanceExpanderExpander: instances.NewExpander(nil),
 		}
 		ctx.installSimpleEval()
 		node := nodeValidateModule{

--- a/internal/terraform/node_module_variable.go
+++ b/internal/terraform/node_module_variable.go
@@ -65,35 +65,31 @@ func (n *nodeExpandModuleVariable) DynamicExpand(ctx EvalContext) (*Graph, tfdia
 	}
 
 	expander := ctx.InstanceExpander()
-	forEachModuleInstance(
-		expander, n.Module,
-		func(module addrs.ModuleInstance) {
-			addr := n.Addr.Absolute(module)
-			if checkableAddrs != nil {
-				checkableAddrs.Add(addr)
-			}
+	forEachModuleInstance(expander, n.Module, false, func(module addrs.ModuleInstance) {
+		addr := n.Addr.Absolute(module)
+		if checkableAddrs != nil {
+			checkableAddrs.Add(addr)
+		}
 
-			o := &nodeModuleVariable{
-				Addr:           addr,
-				Config:         n.Config,
-				Expr:           n.Expr,
-				ModuleInstance: module,
-				DestroyApply:   n.DestroyApply,
-			}
-			g.Add(o)
-		},
-		func(pem addrs.PartialExpandedModule) {
-			addr := addrs.ObjectInPartialExpandedModule(pem, n.Addr)
-			o := &nodeModuleVariableInPartialModule{
-				Addr:           addr,
-				Config:         n.Config,
-				Expr:           n.Expr,
-				ModuleInstance: pem,
-				DestroyApply:   n.DestroyApply,
-			}
-			g.Add(o)
-		},
-	)
+		o := &nodeModuleVariable{
+			Addr:           addr,
+			Config:         n.Config,
+			Expr:           n.Expr,
+			ModuleInstance: module,
+			DestroyApply:   n.DestroyApply,
+		}
+		g.Add(o)
+	}, func(pem addrs.PartialExpandedModule) {
+		addr := addrs.ObjectInPartialExpandedModule(pem, n.Addr)
+		o := &nodeModuleVariableInPartialModule{
+			Addr:           addr,
+			Config:         n.Config,
+			Expr:           n.Expr,
+			ModuleInstance: pem,
+			DestroyApply:   n.DestroyApply,
+		}
+		g.Add(o)
+	})
 	addRootNodeToGraph(&g)
 
 	if checkableAddrs != nil {

--- a/internal/terraform/node_module_variable.go
+++ b/internal/terraform/node_module_variable.go
@@ -13,7 +13,6 @@ import (
 	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/configs"
 	"github.com/hashicorp/terraform/internal/dag"
-	"github.com/hashicorp/terraform/internal/instances"
 	"github.com/hashicorp/terraform/internal/lang"
 	"github.com/hashicorp/terraform/internal/tfdiags"
 )
@@ -250,7 +249,7 @@ func (n *nodeModuleVariable) evalModuleVariable(ctx EvalContext, validateOnly bo
 	var givenVal cty.Value
 	var errSourceRange tfdiags.SourceRange
 	if expr := n.Expr; expr != nil {
-		var moduleInstanceRepetitionData instances.RepetitionData
+		var moduleInstanceRepetitionData lang.RepetitionData
 
 		switch {
 		case validateOnly:
@@ -259,7 +258,7 @@ func (n *nodeModuleVariable) evalModuleVariable(ctx EvalContext, validateOnly bo
 			// TODO: Ideally we should vary the placeholder we use here based
 			// on how the module call repetition was configured, but we don't
 			// have enough information here to decide that.
-			moduleInstanceRepetitionData = instances.TotallyUnknownRepetitionData
+			moduleInstanceRepetitionData = lang.TotallyUnknownRepetitionData
 
 		default:
 			// Get the repetition data for this module instance,
@@ -337,7 +336,7 @@ func (n *nodeModuleVariableInPartialModule) Execute(ctx EvalContext, op walkOper
 	// TODO: Ideally we should vary the placeholder we use here based
 	// on how the module call repetition was configured, but we don't
 	// have enough information here to decide that.
-	moduleInstanceRepetitionData := instances.TotallyUnknownRepetitionData
+	moduleInstanceRepetitionData := lang.TotallyUnknownRepetitionData
 
 	// NOTE WELL: Input variables are a little strange in that they announce
 	// themselves as belonging to the caller of the module they are declared

--- a/internal/terraform/node_output.go
+++ b/internal/terraform/node_output.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/terraform/internal/dag"
 	"github.com/hashicorp/terraform/internal/lang"
 	"github.com/hashicorp/terraform/internal/lang/marks"
+	"github.com/hashicorp/terraform/internal/moduletest/mocking"
 	"github.com/hashicorp/terraform/internal/namedvals"
 	"github.com/hashicorp/terraform/internal/plans"
 	"github.com/hashicorp/terraform/internal/states"
@@ -37,6 +38,11 @@ type nodeExpandOutput struct {
 	// we need to take between plan and apply. See method DynamicExpand for
 	// details.
 	Planning bool
+
+	// Overrides is the set of overrides applied by the testing framework. We
+	// may need to override the value for this output and if we do the value
+	// comes from here.
+	Overrides *mocking.Overrides
 }
 
 var (
@@ -80,7 +86,7 @@ func (n *nodeExpandOutput) DynamicExpand(ctx EvalContext) (*Graph, tfdiags.Diagn
 
 	var g Graph
 	forEachModuleInstance(
-		expander, n.Module,
+		expander, n.Module, true,
 		func(module addrs.ModuleInstance) {
 			absAddr := n.Addr.Absolute(module)
 			if checkableAddrs != nil {
@@ -119,6 +125,7 @@ func (n *nodeExpandOutput) DynamicExpand(ctx EvalContext) (*Graph, tfdiags.Diagn
 					RefreshOnly:  n.RefreshOnly,
 					DestroyApply: n.Destroying,
 					Planning:     n.Planning,
+					Override:     n.getOverrideValue(absAddr.Module),
 				}
 			}
 
@@ -206,6 +213,41 @@ func (n *nodeExpandOutput) References() []*addrs.Reference {
 	return referencesForOutput(n.Config)
 }
 
+func (n *nodeExpandOutput) getOverrideValue(inst addrs.ModuleInstance) cty.Value {
+	// First check if we have any overrides at all, this is a shorthand for
+	// "are we running terraform test".
+	if n.Overrides.Empty() {
+		// cty.NilVal means no override
+		return cty.NilVal
+	}
+
+	// We have overrides, let's see if we have one for this module instance.
+	if override, ok := n.Overrides.GetModuleOverride(inst); ok {
+
+		output := n.Addr.Name
+		values := override.Values
+
+		// The values.Type() should be an object type, but it might have
+		// been set to nil by a test or something. We can handle it in the
+		// same way as the attribute just not being specified. It's
+		// functionally the same for us and not something we need to raise
+		// alarms about.
+		if values.Type().IsObjectType() && values.Type().HasAttribute(output) {
+			return values.GetAttr(output)
+		}
+
+		// If we don't have a value provided for an output, then we'll
+		// just set it to be null.
+		//
+		// TODO(liamcervante): Can we generate a value here? Probably
+		//   not as we don't know the type.
+		return cty.NullVal(cty.DynamicPseudoType)
+	}
+
+	// cty.NilVal indicates no override.
+	return cty.NilVal
+}
+
 // NodeApplyableOutput represents an output that is "applyable":
 // it is ready to be applied.
 type NodeApplyableOutput struct {
@@ -224,8 +266,9 @@ type NodeApplyableOutput struct {
 
 	Planning bool
 
-	// override is set by the graph itself, just before this node executes.
-	override cty.Value
+	// Override provides the value to use for this output, if any. This can be
+	// set by testing framework when a module is overridden.
+	Override cty.Value
 }
 
 var (
@@ -345,7 +388,7 @@ func (n *NodeApplyableOutput) Execute(ctx EvalContext, op walkOperation) (diags 
 	// be valid, or may not have been registered at all.
 	// We also don't evaluate checks for overridden outputs. This is because
 	// any references within the checks will likely not have been created.
-	if !n.DestroyApply && n.override == cty.NilVal {
+	if !n.DestroyApply && n.Override == cty.NilVal {
 		checkRuleSeverity := tfdiags.Error
 		if n.RefreshOnly {
 			checkRuleSeverity = tfdiags.Warning
@@ -368,7 +411,7 @@ func (n *NodeApplyableOutput) Execute(ctx EvalContext, op walkOperation) (diags 
 
 		// First, we check if we have an overridden value. If we do, then we
 		// use that and we don't try and evaluate the underlying expression.
-		val = n.override
+		val = n.Override
 		if val == cty.NilVal {
 			// This has to run before we have a state lock, since evaluation also
 			// reads the state

--- a/internal/terraform/node_resource_abstract_instance.go
+++ b/internal/terraform/node_resource_abstract_instance.go
@@ -15,7 +15,7 @@ import (
 	"github.com/hashicorp/terraform/internal/checks"
 	"github.com/hashicorp/terraform/internal/configs"
 	"github.com/hashicorp/terraform/internal/configs/configschema"
-	"github.com/hashicorp/terraform/internal/instances"
+	"github.com/hashicorp/terraform/internal/lang"
 	"github.com/hashicorp/terraform/internal/moduletest/mocking"
 	"github.com/hashicorp/terraform/internal/plans"
 	"github.com/hashicorp/terraform/internal/plans/objchange"
@@ -739,9 +739,9 @@ func (n *NodeAbstractResourceInstance) plan(
 	currentState *states.ResourceInstanceObject,
 	createBeforeDestroy bool,
 	forceReplace []addrs.AbsResourceInstance,
-) (*plans.ResourceInstanceChange, *states.ResourceInstanceObject, instances.RepetitionData, tfdiags.Diagnostics) {
+) (*plans.ResourceInstanceChange, *states.ResourceInstanceObject, lang.RepetitionData, tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
-	var keyData instances.RepetitionData
+	var keyData lang.RepetitionData
 
 	resource := n.Addr.Resource.Resource
 	provider, providerSchema, err := getProvider(ctx, n.ResolvedProvider)
@@ -1694,9 +1694,9 @@ func (n *NodeAbstractResourceInstance) providerMetas(ctx EvalContext) (cty.Value
 // value, but it still matches the previous state, then we can record a NoNop
 // change. If the states don't match then we record a Read change so that the
 // new value is applied to the state.
-func (n *NodeAbstractResourceInstance) planDataSource(ctx EvalContext, checkRuleSeverity tfdiags.Severity, skipPlanChanges bool) (*plans.ResourceInstanceChange, *states.ResourceInstanceObject, instances.RepetitionData, tfdiags.Diagnostics) {
+func (n *NodeAbstractResourceInstance) planDataSource(ctx EvalContext, checkRuleSeverity tfdiags.Severity, skipPlanChanges bool) (*plans.ResourceInstanceChange, *states.ResourceInstanceObject, lang.RepetitionData, tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
-	var keyData instances.RepetitionData
+	var keyData lang.RepetitionData
 	var configVal cty.Value
 
 	_, providerSchema, err := getProvider(ctx, n.ResolvedProvider)
@@ -1984,9 +1984,9 @@ func (n *NodeAbstractResourceInstance) dependenciesHavePendingChanges(ctx EvalCo
 
 // apply deals with the main part of the data resource lifecycle: either
 // actually reading from the data source or generating a plan to do so.
-func (n *NodeAbstractResourceInstance) applyDataSource(ctx EvalContext, planned *plans.ResourceInstanceChange) (*states.ResourceInstanceObject, instances.RepetitionData, tfdiags.Diagnostics) {
+func (n *NodeAbstractResourceInstance) applyDataSource(ctx EvalContext, planned *plans.ResourceInstanceChange) (*states.ResourceInstanceObject, lang.RepetitionData, tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
-	var keyData instances.RepetitionData
+	var keyData lang.RepetitionData
 
 	_, providerSchema, err := getProvider(ctx, n.ResolvedProvider)
 	if err != nil {
@@ -2350,7 +2350,7 @@ func (n *NodeAbstractResourceInstance) apply(
 	state *states.ResourceInstanceObject,
 	change *plans.ResourceInstanceChange,
 	applyConfig *configs.Resource,
-	keyData instances.RepetitionData,
+	keyData lang.RepetitionData,
 	createBeforeDestroy bool) (*states.ResourceInstanceObject, tfdiags.Diagnostics) {
 
 	var diags tfdiags.Diagnostics

--- a/internal/terraform/node_resource_apply.go
+++ b/internal/terraform/node_resource_apply.go
@@ -49,7 +49,7 @@ func (n *nodeExpandApplyableResource) Name() string {
 func (n *nodeExpandApplyableResource) Execute(globalCtx EvalContext, op walkOperation) tfdiags.Diagnostics {
 	var diags tfdiags.Diagnostics
 	expander := globalCtx.InstanceExpander()
-	moduleInstances := expander.ExpandModule(n.Addr.Module)
+	moduleInstances := expander.ExpandModule(n.Addr.Module, false)
 	for _, module := range moduleInstances {
 		moduleCtx := evalContextForModuleInstance(globalCtx, module)
 		diags = diags.Append(n.writeResourceState(moduleCtx, n.Addr.Resource.Absolute(module)))

--- a/internal/terraform/node_resource_apply_instance.go
+++ b/internal/terraform/node_resource_apply_instance.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/configs"
-	"github.com/hashicorp/terraform/internal/instances"
+	"github.com/hashicorp/terraform/internal/lang"
 	"github.com/hashicorp/terraform/internal/plans"
 	"github.com/hashicorp/terraform/internal/plans/objchange"
 	"github.com/hashicorp/terraform/internal/providers"
@@ -384,7 +384,7 @@ func (n *NodeApplyableResourceInstance) managedResourceExecute(ctx EvalContext) 
 	return diags.Append(n.managedResourcePostconditions(ctx, repeatData))
 }
 
-func (n *NodeApplyableResourceInstance) managedResourcePostconditions(ctx EvalContext, repeatData instances.RepetitionData) (diags tfdiags.Diagnostics) {
+func (n *NodeApplyableResourceInstance) managedResourcePostconditions(ctx EvalContext, repeatData lang.RepetitionData) (diags tfdiags.Diagnostics) {
 
 	checkDiags := evalCheckRules(
 		addrs.ResourcePostcondition,

--- a/internal/terraform/node_resource_apply_test.go
+++ b/internal/terraform/node_resource_apply_test.go
@@ -17,7 +17,7 @@ func TestNodeExpandApplyableResourceExecute(t *testing.T) {
 	t.Run("no config", func(t *testing.T) {
 		ctx := &MockEvalContext{
 			StateState:               state.SyncWrapper(),
-			InstanceExpanderExpander: instances.NewExpander(),
+			InstanceExpanderExpander: instances.NewExpander(nil),
 		}
 
 		node := &nodeExpandApplyableResource{
@@ -40,7 +40,7 @@ func TestNodeExpandApplyableResourceExecute(t *testing.T) {
 	t.Run("simple", func(t *testing.T) {
 		ctx := &MockEvalContext{
 			StateState:               state.SyncWrapper(),
-			InstanceExpanderExpander: instances.NewExpander(),
+			InstanceExpanderExpander: instances.NewExpander(nil),
 		}
 
 		node := &nodeExpandApplyableResource{

--- a/internal/terraform/node_resource_destroy.go
+++ b/internal/terraform/node_resource_destroy.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/hashicorp/terraform/internal/instances"
+	"github.com/hashicorp/terraform/internal/lang"
 	"github.com/hashicorp/terraform/internal/plans"
 	"github.com/hashicorp/terraform/internal/tfdiags"
 
@@ -206,7 +206,7 @@ func (n *NodeDestroyResourceInstance) managedResourceExecute(ctx EvalContext) (d
 	// Managed resources need to be destroyed, while data sources
 	// are only removed from state.
 	// we pass a nil configuration to apply because we are destroying
-	s, d := n.apply(ctx, state, changeApply, nil, instances.RepetitionData{}, false)
+	s, d := n.apply(ctx, state, changeApply, nil, lang.RepetitionData{}, false)
 	state, diags = s, diags.Append(d)
 	// we don't return immediately here on error, so that the state can be
 	// finalized

--- a/internal/terraform/node_resource_destroy_deposed.go
+++ b/internal/terraform/node_resource_destroy_deposed.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/dag"
-	"github.com/hashicorp/terraform/internal/instances"
+	"github.com/hashicorp/terraform/internal/lang"
 	"github.com/hashicorp/terraform/internal/plans"
 	"github.com/hashicorp/terraform/internal/states"
 	"github.com/hashicorp/terraform/internal/tfdiags"
@@ -277,7 +277,7 @@ func (n *NodeDestroyDeposedResourceInstanceObject) Execute(ctx EvalContext, op w
 	}
 
 	// we pass a nil configuration to apply because we are destroying
-	state, applyDiags := n.apply(ctx, state, change, nil, instances.RepetitionData{}, false)
+	state, applyDiags := n.apply(ctx, state, change, nil, lang.RepetitionData{}, false)
 	diags = diags.Append(applyDiags)
 	// don't return immediately on errors, we need to handle the state
 

--- a/internal/terraform/node_resource_plan.go
+++ b/internal/terraform/node_resource_plan.go
@@ -119,7 +119,7 @@ func (n *nodeExpandPlannableResource) DynamicExpand(ctx EvalContext) (*Graph, tf
 	}
 
 	expander := ctx.InstanceExpander()
-	moduleInstances := expander.ExpandModule(n.Addr.Module)
+	moduleInstances := expander.ExpandModule(n.Addr.Module, false)
 
 	// The possibility of partial-expanded modules and resources is
 	// currently guarded by a language experiment, and so to minimize the
@@ -141,7 +141,7 @@ func (n *nodeExpandPlannableResource) DynamicExpand(ctx EvalContext) (*Graph, tf
 	// these two codepaths back together, so that the behavior is less likely
 	// to diverge under future maintenence.
 	if n.unknownInstancesExperimentEnabled {
-		pem := expander.UnknownModuleInstances(n.Addr.Module)
+		pem := expander.UnknownModuleInstances(n.Addr.Module, false)
 		return n.dynamicExpandWithUnknownInstancesExperiment(ctx, moduleInstances, pem)
 	}
 

--- a/internal/terraform/node_resource_plan_instance.go
+++ b/internal/terraform/node_resource_plan_instance.go
@@ -17,7 +17,7 @@ import (
 	"github.com/hashicorp/terraform/internal/configs"
 	"github.com/hashicorp/terraform/internal/configs/configschema"
 	"github.com/hashicorp/terraform/internal/genconfig"
-	"github.com/hashicorp/terraform/internal/instances"
+	"github.com/hashicorp/terraform/internal/lang"
 	"github.com/hashicorp/terraform/internal/moduletest/mocking"
 	"github.com/hashicorp/terraform/internal/plans"
 	"github.com/hashicorp/terraform/internal/providers"
@@ -233,7 +233,7 @@ func (n *NodePlannableResourceInstance) managedResourceExecute(ctx EvalContext) 
 
 		// add this instance to n.forceReplace if replacement is triggered by
 		// another change
-		repData := instances.RepetitionData{}
+		repData := lang.RepetitionData{}
 		switch k := addr.Resource.Key.(type) {
 		case addrs.IntKey:
 			repData.CountIndex = k.Value()
@@ -410,7 +410,7 @@ func (n *NodePlannableResourceInstance) managedResourceExecute(ctx EvalContext) 
 // replaceTriggered checks if this instance needs to be replace due to a change
 // in a replace_triggered_by reference. If replacement is required, the
 // instance address is added to forceReplace
-func (n *NodePlannableResourceInstance) replaceTriggered(ctx EvalContext, repData instances.RepetitionData) tfdiags.Diagnostics {
+func (n *NodePlannableResourceInstance) replaceTriggered(ctx EvalContext, repData lang.RepetitionData) tfdiags.Diagnostics {
 	var diags tfdiags.Diagnostics
 	if n.Config == nil {
 		return diags

--- a/internal/terraform/node_resource_plan_orphan.go
+++ b/internal/terraform/node_resource_plan_orphan.go
@@ -283,7 +283,7 @@ func (n *NodePlannableResourceInstanceOrphan) deleteActionReason(ctx EvalContext
 		// First we'll check whether our containing module instance still
 		// exists, so we can talk about that differently in the reason.
 		declared := false
-		for _, inst := range expander.ExpandModule(n.Addr.Module.Module()) {
+		for _, inst := range expander.ExpandModule(n.Addr.Module.Module(), false) {
 			if n.Addr.Module.Equal(inst) {
 				declared = true
 				break

--- a/internal/terraform/node_resource_plan_orphan_test.go
+++ b/internal/terraform/node_resource_plan_orphan_test.go
@@ -6,12 +6,13 @@ package terraform
 import (
 	"testing"
 
+	"github.com/zclconf/go-cty/cty"
+
 	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/instances"
 	"github.com/hashicorp/terraform/internal/plans"
 	"github.com/hashicorp/terraform/internal/providers"
 	"github.com/hashicorp/terraform/internal/states"
-	"github.com/zclconf/go-cty/cty"
 )
 
 func TestNodeResourcePlanOrphanExecute(t *testing.T) {
@@ -40,7 +41,7 @@ func TestNodeResourcePlanOrphanExecute(t *testing.T) {
 		StateState:               state.SyncWrapper(),
 		RefreshStateState:        state.DeepCopy().SyncWrapper(),
 		PrevRunStateState:        state.DeepCopy().SyncWrapper(),
-		InstanceExpanderExpander: instances.NewExpander(),
+		InstanceExpanderExpander: instances.NewExpander(nil),
 		ProviderProvider:         p,
 		ProviderSchemaSchema: providers.ProviderSchema{
 			ResourceTypes: map[string]providers.Schema{
@@ -106,7 +107,7 @@ func TestNodeResourcePlanOrphanExecute_alreadyDeleted(t *testing.T) {
 		StateState:               state.SyncWrapper(),
 		RefreshStateState:        refreshState.SyncWrapper(),
 		PrevRunStateState:        prevRunState.SyncWrapper(),
-		InstanceExpanderExpander: instances.NewExpander(),
+		InstanceExpanderExpander: instances.NewExpander(nil),
 		ProviderProvider:         p,
 		ProviderSchemaSchema: providers.ProviderSchema{
 			ResourceTypes: map[string]providers.Schema{
@@ -188,7 +189,7 @@ func TestNodeResourcePlanOrphanExecute_deposed(t *testing.T) {
 		StateState:               state.SyncWrapper(),
 		RefreshStateState:        refreshState.SyncWrapper(),
 		PrevRunStateState:        prevRunState.SyncWrapper(),
-		InstanceExpanderExpander: instances.NewExpander(),
+		InstanceExpanderExpander: instances.NewExpander(nil),
 		ProviderProvider:         p,
 		ProviderSchemaSchema: providers.ProviderSchema{
 			ResourceTypes: map[string]providers.Schema{

--- a/internal/terraform/node_resource_plan_partialexp.go
+++ b/internal/terraform/node_resource_plan_partialexp.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/configs"
-	"github.com/hashicorp/terraform/internal/instances"
+	"github.com/hashicorp/terraform/internal/lang"
 	"github.com/hashicorp/terraform/internal/plans/objchange"
 	"github.com/hashicorp/terraform/internal/providers"
 	"github.com/hashicorp/terraform/internal/tfdiags"
@@ -156,20 +156,20 @@ func (n *nodePlannablePartialExpandedResource) managedResourceExecute(ctx EvalCo
 	// suitable unknown values for count.index, each.key, and each.value
 	// so that anything that varies between the instances will be unknown
 	// but we can still check the arguments that they all have in common.
-	var keyData instances.RepetitionData
+	var keyData lang.RepetitionData
 	switch {
 	case n.config.ForEach != nil:
 		// We don't actually know the `for_each` type here, but we do at least
 		// know it's for_each.
-		keyData = instances.UnknownForEachRepetitionData(cty.DynamicPseudoType)
+		keyData = lang.UnknownForEachRepetitionData(cty.DynamicPseudoType)
 	case n.config.Count != nil:
-		keyData = instances.UnknownCountRepetitionData
+		keyData = lang.UnknownCountRepetitionData
 	default:
 		// If we get here then we're presumably a single-instance resource
 		// inside a multi-instance module whose instances aren't known yet,
 		// and so we'll evaluate without any of the repetition symbols to
 		// still generate the usual errors if someone tries to use them here.
-		keyData = instances.RepetitionData{
+		keyData = lang.RepetitionData{
 			CountIndex: cty.NilVal,
 			EachKey:    cty.NilVal,
 			EachValue:  cty.NilVal,

--- a/internal/terraform/node_resource_validate.go
+++ b/internal/terraform/node_resource_validate.go
@@ -14,7 +14,6 @@ import (
 	"github.com/hashicorp/terraform/internal/configs"
 	"github.com/hashicorp/terraform/internal/configs/configschema"
 	"github.com/hashicorp/terraform/internal/didyoumean"
-	"github.com/hashicorp/terraform/internal/instances"
 	"github.com/hashicorp/terraform/internal/lang"
 	"github.com/hashicorp/terraform/internal/providers"
 	"github.com/hashicorp/terraform/internal/provisioners"
@@ -469,7 +468,7 @@ func (n *NodeValidatableResource) validateResource(ctx EvalContext) tfdiags.Diag
 	return diags
 }
 
-func (n *NodeValidatableResource) evaluateExpr(ctx EvalContext, expr hcl.Expression, wantTy cty.Type, self addrs.Referenceable, keyData instances.RepetitionData) (cty.Value, tfdiags.Diagnostics) {
+func (n *NodeValidatableResource) evaluateExpr(ctx EvalContext, expr hcl.Expression, wantTy cty.Type, self addrs.Referenceable, keyData lang.RepetitionData) (cty.Value, tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
 
 	refs, refDiags := lang.ReferencesInExpr(addrs.ParseRef, expr)
@@ -486,7 +485,7 @@ func (n *NodeValidatableResource) evaluateExpr(ctx EvalContext, expr hcl.Express
 	return result, diags
 }
 
-func (n *NodeValidatableResource) stubRepetitionData(hasCount, hasForEach bool) (instances.RepetitionData, addrs.Referenceable) {
+func (n *NodeValidatableResource) stubRepetitionData(hasCount, hasForEach bool) (lang.RepetitionData, addrs.Referenceable) {
 	keyData := EvalDataForNoInstanceKey
 	selfAddr := n.ResourceAddr().Resource.Instance(addrs.NoKey)
 

--- a/internal/terraform/transform_output.go
+++ b/internal/terraform/transform_output.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/configs"
+	"github.com/hashicorp/terraform/internal/moduletest/mocking"
 )
 
 // OutputTransformer is a GraphTransformer that adds all the outputs
@@ -30,6 +31,10 @@ type OutputTransformer struct {
 	// If this is a planned destroy, root outputs are still in the configuration
 	// so we need to record that we wish to remove them.
 	Destroying bool
+
+	// Overrides supplies the values for any output variables that should be
+	// overridden by the testing framework.
+	Overrides *mocking.Overrides
 }
 
 func (t *OutputTransformer) Transform(g *Graph) error {
@@ -61,6 +66,7 @@ func (t *OutputTransformer) transform(g *Graph, c *configs.Config) error {
 			Destroying:  t.Destroying,
 			RefreshOnly: t.RefreshOnly,
 			Planning:    t.Planning,
+			Overrides:   t.Overrides,
 		}
 
 		log.Printf("[TRACE] OutputTransformer: adding %s as %T", o.Name, node)


### PR DESCRIPTION
Manual backport of #35030. Automatic backport failed in #35070.

Relates to #35019.

This backport also makes a small additional change of moving the instance_key_data file into the `lang` package. This resolves a cycle in the imports that doesn't exist in the `main` branch. Given no active development is happening in this branch, this should be an acceptable tradeoff to ensure we don't need to backport additional changes from `main` to resolve the import cycle in the same way here.