### PR TITLE
[WIP] Ephemeral Resources prototype

### DIFF
--- a/internal/addrs/parse_ref.go
+++ b/internal/addrs/parse_ref.go
@@ -226,6 +226,19 @@ func parseRef(traversal hcl.Traversal) (*Reference, tfdiags.Diagnostics) {
 		remain := traversal[1:] // trim off "data" so we can use our shared resource reference parser
 		return parseResourceRef(DataResourceMode, rootRange, remain)
 
+	case "ephemeral":
+		if len(traversal) < 3 {
+			diags = diags.Append(&hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  "Invalid reference",
+				Detail:   `The "ephemeral" object must be followed by two attribute names: the ephemeral resource type and the resource name.`,
+				Subject:  traversal.SourceRange().Ptr(),
+			})
+			return nil, diags
+		}
+		remain := traversal[1:] // trim off "ephemeral" so we can use our shared resource reference parser
+		return parseResourceRef(EphemeralResourceMode, rootRange, remain)
+
 	case "resource":
 		// This is an alias for the normal case of just using a managed resource
 		// type as a top-level symbol, which will serve as an escape mechanism
@@ -396,13 +409,40 @@ func parseResourceRef(mode ResourceMode, startRange hcl.Range, traversal hcl.Tra
 	case hcl.TraverseAttr:
 		typeName = tt.Name
 	default:
-		// If it isn't a TraverseRoot then it must be a "data" reference.
-		diags = diags.Append(&hcl.Diagnostic{
-			Severity: hcl.DiagError,
-			Summary:  "Invalid reference",
-			Detail:   `The "data" object does not support this operation.`,
-			Subject:  traversal[0].SourceRange().Ptr(),
-		})
+		switch mode {
+		case ManagedResourceMode:
+			diags = diags.Append(&hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  "Invalid reference",
+				Detail:   `The "resource" object does not support this operation.`,
+				Subject:  traversal[0].SourceRange().Ptr(),
+			})
+		case DataResourceMode:
+			diags = diags.Append(&hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  "Invalid reference",
+				Detail:   `The "data" object does not support this operation.`,
+				Subject:  traversal[0].SourceRange().Ptr(),
+			})
+		case EphemeralResourceMode:
+			diags = diags.Append(&hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  "Invalid reference",
+				Detail:   `The "ephemeral" object does not support this operation.`,
+				Subject:  traversal[0].SourceRange().Ptr(),
+			})
+		default:
+			// Shouldn't get here because the above should be exhaustive for
+			// all of the resource modes. But we'll still return a
+			// minimally-passable error message so that the won't totally
+			// misbehave if we forget to update this in future.
+			diags = diags.Append(&hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  "Invalid reference",
+				Detail:   `The left operand does not support this operation.`,
+				Subject:  traversal[0].SourceRange().Ptr(),
+			})
+		}
 		return nil, diags
 	}
 
@@ -411,14 +451,16 @@ func parseResourceRef(mode ResourceMode, startRange hcl.Range, traversal hcl.Tra
 		var what string
 		switch mode {
 		case DataResourceMode:
-			what = "data source"
+			what = "a data source"
+		case EphemeralResourceMode:
+			what = "an ephemeral resource type"
 		default:
-			what = "resource type"
+			what = "a resource type"
 		}
 		diags = diags.Append(&hcl.Diagnostic{
 			Severity: hcl.DiagError,
 			Summary:  "Invalid reference",
-			Detail:   fmt.Sprintf(`A reference to a %s must be followed by at least one attribute access, specifying the resource name.`, what),
+			Detail:   fmt.Sprintf(`A reference to %s must be followed by at least one attribute access, specifying the resource name.`, what),
 			Subject:  traversal[1].SourceRange().Ptr(),
 		})
 		return nil, diags

--- a/internal/addrs/parse_ref_test.go
+++ b/internal/addrs/parse_ref_test.go
@@ -363,6 +363,104 @@ func TestParseRef(t *testing.T) {
 			`The "data" object must be followed by two attribute names: the data source type and the resource name.`,
 		},
 
+		// ephemeral
+		{
+			`ephemeral.external.foo`,
+			&Reference{
+				Subject: Resource{
+					Mode: EphemeralResourceMode,
+					Type: "external",
+					Name: "foo",
+				},
+				SourceRange: tfdiags.SourceRange{
+					Start: tfdiags.SourcePos{Line: 1, Column: 1, Byte: 0},
+					End:   tfdiags.SourcePos{Line: 1, Column: 23, Byte: 22},
+				},
+			},
+			``,
+		},
+		{
+			`ephemeral.external.foo.bar`,
+			&Reference{
+				Subject: ResourceInstance{
+					Resource: Resource{
+						Mode: EphemeralResourceMode,
+						Type: "external",
+						Name: "foo",
+					},
+				},
+				SourceRange: tfdiags.SourceRange{
+					Start: tfdiags.SourcePos{Line: 1, Column: 1, Byte: 0},
+					End:   tfdiags.SourcePos{Line: 1, Column: 23, Byte: 22},
+				},
+				Remaining: hcl.Traversal{
+					hcl.TraverseAttr{
+						Name: "bar",
+						SrcRange: hcl.Range{
+							Start: hcl.Pos{Line: 1, Column: 23, Byte: 22},
+							End:   hcl.Pos{Line: 1, Column: 27, Byte: 26},
+						},
+					},
+				},
+			},
+			``,
+		},
+		{
+			`ephemeral.external.foo["baz"].bar`,
+			&Reference{
+				Subject: ResourceInstance{
+					Resource: Resource{
+						Mode: EphemeralResourceMode,
+						Type: "external",
+						Name: "foo",
+					},
+					Key: StringKey("baz"),
+				},
+				SourceRange: tfdiags.SourceRange{
+					Start: tfdiags.SourcePos{Line: 1, Column: 1, Byte: 0},
+					End:   tfdiags.SourcePos{Line: 1, Column: 30, Byte: 29},
+				},
+				Remaining: hcl.Traversal{
+					hcl.TraverseAttr{
+						Name: "bar",
+						SrcRange: hcl.Range{
+							Start: hcl.Pos{Line: 1, Column: 30, Byte: 29},
+							End:   hcl.Pos{Line: 1, Column: 34, Byte: 33},
+						},
+					},
+				},
+			},
+			``,
+		},
+		{
+			`ephemeral.external.foo["baz"]`,
+			&Reference{
+				Subject: ResourceInstance{
+					Resource: Resource{
+						Mode: EphemeralResourceMode,
+						Type: "external",
+						Name: "foo",
+					},
+					Key: StringKey("baz"),
+				},
+				SourceRange: tfdiags.SourceRange{
+					Start: tfdiags.SourcePos{Line: 1, Column: 1, Byte: 0},
+					End:   tfdiags.SourcePos{Line: 1, Column: 30, Byte: 29},
+				},
+			},
+			``,
+		},
+		{
+			`ephemeral`,
+			nil,
+			`The "ephemeral" object must be followed by two attribute names: the ephemeral resource type and the resource name.`,
+		},
+		{
+			`ephemeral.external`,
+			nil,
+			`The "ephemeral" object must be followed by two attribute names: the ephemeral resource type and the resource name.`,
+		},
+
 		// local
 		{
 			`local.foo`,

--- a/internal/addrs/parse_target.go
+++ b/internal/addrs/parse_target.go
@@ -159,10 +159,14 @@ func parseResourceInstanceUnderModule(moduleAddr ModuleInstance, remain hcl.Trav
 	var diags tfdiags.Diagnostics
 
 	mode := ManagedResourceMode
-	if remain.RootName() == "data" {
+	switch remain.RootName() {
+	case "data":
 		mode = DataResourceMode
 		remain = remain[1:]
-	} else if remain.RootName() == "resource" {
+	case "ephemeral":
+		mode = EphemeralResourceMode
+		remain = remain[1:]
+	case "resource":
 		// Starting a resource address with "resource" is optional, so we'll
 		// just ignore it.
 		remain = remain[1:]
@@ -198,6 +202,13 @@ func parseResourceInstanceUnderModule(moduleAddr ModuleInstance, remain hcl.Trav
 				Severity: hcl.DiagError,
 				Summary:  "Invalid address",
 				Detail:   "A data source name is required.",
+				Subject:  remain[0].SourceRange().Ptr(),
+			})
+		case EphemeralResourceMode:
+			diags = diags.Append(&hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  "Invalid address",
+				Detail:   "An ephemeral resource type name is required.",
 				Subject:  remain[0].SourceRange().Ptr(),
 			})
 		default:

--- a/internal/addrs/parse_target_test.go
+++ b/internal/addrs/parse_target_test.go
@@ -166,6 +166,45 @@ func TestParseTarget(t *testing.T) {
 			``,
 		},
 		{
+			`ephemeral.aws_instance.foo`,
+			&Target{
+				Subject: AbsResource{
+					Resource: Resource{
+						Mode: EphemeralResourceMode,
+						Type: "aws_instance",
+						Name: "foo",
+					},
+					Module: RootModuleInstance,
+				},
+				SourceRange: tfdiags.SourceRange{
+					Start: tfdiags.SourcePos{Line: 1, Column: 1, Byte: 0},
+					End:   tfdiags.SourcePos{Line: 1, Column: 27, Byte: 26},
+				},
+			},
+			``,
+		},
+		{
+			`ephemeral.aws_instance.foo[1]`,
+			&Target{
+				Subject: AbsResourceInstance{
+					Resource: ResourceInstance{
+						Resource: Resource{
+							Mode: EphemeralResourceMode,
+							Type: "aws_instance",
+							Name: "foo",
+						},
+						Key: IntKey(1),
+					},
+					Module: RootModuleInstance,
+				},
+				SourceRange: tfdiags.SourceRange{
+					Start: tfdiags.SourcePos{Line: 1, Column: 1, Byte: 0},
+					End:   tfdiags.SourcePos{Line: 1, Column: 30, Byte: 29},
+				},
+			},
+			``,
+		},
+		{
 			`module.foo.aws_instance.bar`,
 			&Target{
 				Subject: AbsResource{
@@ -267,6 +306,27 @@ func TestParseTarget(t *testing.T) {
 				SourceRange: tfdiags.SourceRange{
 					Start: tfdiags.SourcePos{Line: 1, Column: 1, Byte: 0},
 					End:   tfdiags.SourcePos{Line: 1, Column: 44, Byte: 43},
+				},
+			},
+			``,
+		},
+		{
+			`module.foo.module.bar.ephemeral.aws_instance.baz`,
+			&Target{
+				Subject: AbsResource{
+					Resource: Resource{
+						Mode: EphemeralResourceMode,
+						Type: "aws_instance",
+						Name: "baz",
+					},
+					Module: ModuleInstance{
+						{Name: "foo"},
+						{Name: "bar"},
+					},
+				},
+				SourceRange: tfdiags.SourceRange{
+					Start: tfdiags.SourcePos{Line: 1, Column: 1, Byte: 0},
+					End:   tfdiags.SourcePos{Line: 1, Column: 49, Byte: 48},
 				},
 			},
 			``,

--- a/internal/addrs/resource.go
+++ b/internal/addrs/resource.go
@@ -27,6 +27,8 @@ func (r Resource) String() string {
 		return fmt.Sprintf("%s.%s", r.Type, r.Name)
 	case DataResourceMode:
 		return fmt.Sprintf("data.%s.%s", r.Type, r.Name)
+	case EphemeralResourceMode:
+		return fmt.Sprintf("ephemeral.%s.%s", r.Type, r.Name)
 	default:
 		// Should never happen, but we'll return a string here rather than
 		// crashing just in case it does.

--- a/internal/addrs/resource.go
+++ b/internal/addrs/resource.go
@@ -505,6 +505,10 @@ const (
 	// DataResourceMode indicates a data resource, as defined by
 	// "data" blocks in configuration.
 	DataResourceMode ResourceMode = 'D'
+
+	// EphemeralResourceMode indicates an ephemeral resource, as defined by
+	// "ephemeral" blocks in configuration.
+	EphemeralResourceMode ResourceMode = 'E'
 )
 
 // AbsResourceInstanceObject represents one of the specific remote objects

--- a/internal/addrs/resource.go
+++ b/internal/addrs/resource.go
@@ -513,6 +513,30 @@ const (
 	EphemeralResourceMode ResourceMode = 'E'
 )
 
+// PersistsBetweenRounds returns true only if resource instances of this mode
+// persist in the Terraform state from one plan/apply round to the next.
+func (m ResourceMode) PersistsBetweenRounds() bool {
+	switch m {
+	case EphemeralResourceMode:
+		return false
+	default:
+		return true
+	}
+}
+
+// PersistsPlanToApply returns true only if resource instances of this mode
+// can have planned actions that are decided during the plan phase and then
+// carried out during the apply phase, meaning that they must be recorded
+// as part of a saved plan.
+func (m ResourceMode) PersistsPlanToApply() bool {
+	switch m {
+	case EphemeralResourceMode:
+		return false
+	default:
+		return true
+	}
+}
+
 // AbsResourceInstanceObject represents one of the specific remote objects
 // associated with a resource instance.
 //

--- a/internal/addrs/resourcemode_string.go
+++ b/internal/addrs/resourcemode_string.go
@@ -11,20 +11,26 @@ func _() {
 	_ = x[InvalidResourceMode-0]
 	_ = x[ManagedResourceMode-77]
 	_ = x[DataResourceMode-68]
+	_ = x[EphemeralResourceMode-69]
 }
 
 const (
 	_ResourceMode_name_0 = "InvalidResourceMode"
-	_ResourceMode_name_1 = "DataResourceMode"
+	_ResourceMode_name_1 = "DataResourceModeEphemeralResourceMode"
 	_ResourceMode_name_2 = "ManagedResourceMode"
+)
+
+var (
+	_ResourceMode_index_1 = [...]uint8{0, 16, 37}
 )
 
 func (i ResourceMode) String() string {
 	switch {
 	case i == 0:
 		return _ResourceMode_name_0
-	case i == 68:
-		return _ResourceMode_name_1
+	case 68 <= i && i <= 69:
+		i -= 68
+		return _ResourceMode_name_1[_ResourceMode_index_1[i]:_ResourceMode_index_1[i+1]]
 	case i == 77:
 		return _ResourceMode_name_2
 	default:

--- a/internal/builtin/providers/terraform/ephemeral_random.go
+++ b/internal/builtin/providers/terraform/ephemeral_random.go
@@ -1,0 +1,45 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package terraform
+
+import (
+	"math/rand"
+
+	"github.com/zclconf/go-cty/cty"
+
+	"github.com/hashicorp/terraform/internal/configs/configschema"
+	"github.com/hashicorp/terraform/internal/providers"
+)
+
+func ephemeralRandomNumberSchema() providers.Schema {
+	return providers.Schema{
+		Block: &configschema.Block{
+			Attributes: map[string]*configschema.Attribute{
+				"value": {Type: cty.String, Computed: true},
+			},
+		},
+	}
+}
+
+func openEphemeralRandomNumber(req providers.OpenEphemeralRequest) providers.OpenEphemeralResponse {
+	result := rand.NormFloat64()
+	return providers.OpenEphemeralResponse{
+		Result: cty.ObjectVal(map[string]cty.Value{
+			"value": cty.NumberFloatVal(result),
+		}),
+	}
+}
+
+func renewEphemeralRandomNumber(req providers.RenewEphemeralRequest) providers.RenewEphemeralResponse {
+	// This resource type does not need renewing, but if we get asked to do
+	// it for some reason then we'll just say it succeeded.
+	return providers.RenewEphemeralResponse{}
+}
+
+func closeEphemeralRandomNumber(req providers.CloseEphemeralRequest) providers.CloseEphemeralResponse {
+	// This resource type does not need closing because it isn't really
+	// backed by any long-lived object, so we'll just say that closing it
+	// succeeded even though we aren't really doing anything.
+	return providers.CloseEphemeralResponse{}
+}

--- a/internal/builtin/providers/terraform/ephemeral_ssh_tunnels.go
+++ b/internal/builtin/providers/terraform/ephemeral_ssh_tunnels.go
@@ -1,0 +1,419 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package terraform
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"fmt"
+	"io"
+	"log"
+	"net"
+	"sync"
+	"unsafe"
+
+	"github.com/zclconf/go-cty/cty"
+	"golang.org/x/crypto/ssh"
+
+	"github.com/hashicorp/terraform/internal/configs/configschema"
+	"github.com/hashicorp/terraform/internal/providers"
+	"github.com/hashicorp/terraform/internal/tfdiags"
+)
+
+func ephemeralSSHTunnelsSchema() providers.Schema {
+	return providers.Schema{
+		Block: &configschema.Block{
+			Attributes: map[string]*configschema.Attribute{
+				"server":   {Type: cty.String, Required: true},
+				"username": {Type: cty.String, Required: true},
+
+				"auth_methods": {
+					Type: cty.List(
+						// This object type is acting like a sum type rather
+						// than a product type, requiring that exactly one
+						// of its attributes is set to decide which member
+						// to instantiate.
+						cty.Object(map[string]cty.Type{
+							"password": cty.String,
+							// TODO: SSH keys, etc
+						}),
+					),
+					Required: true,
+				},
+
+				"tcp_to_remote": {
+					Type: cty.Map(cty.Object(map[string]cty.Type{
+						"local_host": cty.String,
+						"local_port": cty.String,
+						"local":      cty.String,
+						"remote":     cty.String,
+					})),
+					Computed: true,
+				},
+				"tcp_from_remote": {
+					Type: cty.Map(cty.Object(map[string]cty.Type{
+						"remote_port": cty.String,
+					})),
+					Computed: true,
+				},
+			},
+			BlockTypes: map[string]*configschema.NestedBlock{
+				"tcp_local_to_remote": {
+					Nesting: configschema.NestingMap,
+					Block: configschema.Block{
+						Attributes: map[string]*configschema.Attribute{
+							"remote": {Type: cty.String, Required: true},
+							"local":  {Type: cty.String, Optional: true},
+						},
+					},
+				},
+				"tcp_remote_to_local": {
+					Nesting: configschema.NestingMap,
+					Block: configschema.Block{
+						Attributes: map[string]*configschema.Attribute{
+							"remote": {Type: cty.String, Required: true},
+							"local":  {Type: cty.String, Required: true},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+type ephemeralSSHTunnelsConns struct {
+	// Keys here are the addresses of the corresponding ephemeralSSHTunnelState
+	// objects. This probably isn't a good idea in the long run, but it's
+	// fine for a prototype.
+	active map[uintptr]*ephemeralSSHTunnelConn
+	mu     sync.Mutex
+}
+
+type ephemeralSSHTunnelConn struct {
+	client         *ssh.Client
+	closeListeners func()
+}
+
+var ephemeralSSHTunnels ephemeralSSHTunnelsConns
+
+func init() {
+	ephemeralSSHTunnels.mu.Lock()
+	ephemeralSSHTunnels.active = make(map[uintptr]*ephemeralSSHTunnelConn)
+	ephemeralSSHTunnels.mu.Unlock()
+}
+
+func openEphemeralSSHTunnels(req providers.OpenEphemeralRequest) providers.OpenEphemeralResponse {
+	log.Printf("[TRACE] terraform_ssh_tunnels: opening connection")
+	var resp providers.OpenEphemeralResponse
+
+	serverAddr, clientConfig, diags := makeEphemeralSSHTunnelClientConfig(req.Config)
+	resp.Diagnostics = resp.Diagnostics.Append(diags)
+	if diags.HasErrors() {
+		return resp
+	}
+	log.Printf("[DEBUG] terraform_ssh_tunnels: connecting to %s as %q", serverAddr, clientConfig.User)
+	client, err := ssh.Dial("tcp", serverAddr, clientConfig)
+	if err != nil {
+		resp.Diagnostics = resp.Diagnostics.Append(tfdiags.AttributeValue(
+			tfdiags.Error,
+			"Can't connect to SSH server",
+			fmt.Sprintf("Failed to connect to SSH server to establish tunnels: %s.", err),
+			nil, // A number of different arguments could potentially cause a connection failure
+		))
+		return resp
+	}
+
+	ephemeralSSHTunnels.mu.Lock()
+	defer ephemeralSSHTunnels.mu.Unlock()
+
+	conn := &ephemeralSSHTunnelConn{
+		client: client,
+	}
+	connID := uintptr(unsafe.Pointer(conn))
+	ephemeralSSHTunnels.active[connID] = conn
+
+	var intCtx bytes.Buffer
+	intCtx.Grow(8)
+	binary.Write(&intCtx, binary.LittleEndian, uint64(connID))
+	resp.InternalContext = intCtx.Bytes()
+
+	tcpToRemoteVals := map[string]cty.Value{}
+	tcpFromRemoteVals := map[string]cty.Value{}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	conn.closeListeners = cancel
+	for it := req.Config.GetAttr("tcp_local_to_remote").ElementIterator(); it.Next(); {
+		keyVal, configVal := it.Element()
+		key := keyVal.AsString()
+		log.Printf("[TRACE] terraform_ssh_tunnels: tcp_local_to_remote %q", key)
+
+		// FIXME: The following is not robust against unknown values and
+		// other such oddities.
+		remoteAddr := configVal.GetAttr("remote").AsString()
+
+		listener, err := (&net.ListenConfig{}).Listen(ctx, "tcp", "127.0.0.1:0")
+		if err != nil {
+			resp.Diagnostics = resp.Diagnostics.Append(tfdiags.AttributeValue(
+				tfdiags.Error,
+				"Can't open TCP listen port",
+				fmt.Sprintf("Failed to open local TCP listen port for tcp_local_to_remote %q: %s.", key, err),
+				cty.GetAttrPath("tcp_local_to_remote").IndexString(key),
+			))
+			continue
+		}
+
+		go sshTunnelLocalToRemote(ctx, listener, client, remoteAddr)
+
+		tcpToRemoteVals[key] = cty.ObjectVal(map[string]cty.Value{
+			"local_host": cty.NullVal(cty.String), // TODO: Populate
+			"local_port": cty.NullVal(cty.String), // TODO: Populate
+			"local":      cty.StringVal(listener.Addr().String()),
+			"remote":     cty.NullVal(cty.String), // TODO: Populate
+		})
+	}
+	for it := req.Config.GetAttr("tcp_remote_to_local").ElementIterator(); it.Next(); {
+		log.Printf("[TRACE] terraform_ssh_tunnels: tcp_remote_to_local")
+
+		// TODO: Implement
+	}
+
+	var tcpToRemoteVal cty.Value
+	if len(tcpToRemoteVals) != 0 {
+		tcpToRemoteVal = cty.MapVal(tcpToRemoteVals)
+	} else {
+		tcpToRemoteVal = cty.MapValEmpty(cty.Object(map[string]cty.Type{
+			"local_host": cty.String,
+			"local_port": cty.String,
+			"local":      cty.String,
+			"remote":     cty.String,
+		}))
+	}
+	var tcpFromRemoteVal cty.Value
+	if len(tcpFromRemoteVals) != 0 {
+		tcpFromRemoteVal = cty.MapVal(tcpFromRemoteVals)
+	} else {
+		tcpFromRemoteVal = cty.MapValEmpty(cty.Object(map[string]cty.Type{
+			"remote_port": cty.String,
+		}))
+	}
+
+	resp.Result = cty.ObjectVal(map[string]cty.Value{
+		"server":              req.Config.GetAttr("server"),
+		"username":            req.Config.GetAttr("username"),
+		"auth_methods":        req.Config.GetAttr("auth_methods"),
+		"tcp_local_to_remote": req.Config.GetAttr("tcp_local_to_remote"),
+		"tcp_remote_to_local": req.Config.GetAttr("tcp_remote_to_local"),
+
+		"tcp_to_remote":   tcpToRemoteVal,
+		"tcp_from_remote": tcpFromRemoteVal,
+	})
+
+	return resp
+}
+
+func renewEphemeralSSHTunnels(req providers.RenewEphemeralRequest) providers.RenewEphemeralResponse {
+	// SSH tunnel connections don't need to be explicitly renewed, so this
+	// should never get called. (The SSH library handles keepalives internally
+	// itself, without our help.)
+	return providers.RenewEphemeralResponse{}
+}
+
+func closeEphemeralSSHTunnels(req providers.CloseEphemeralRequest) providers.CloseEphemeralResponse {
+	log.Printf("[TRACE] terraform_ssh_tunnels: closing connection")
+	var resp providers.CloseEphemeralResponse
+
+	intCtx := bytes.NewReader(req.InternalContext)
+	var connIDInt uint64
+	if err := binary.Read(intCtx, binary.LittleEndian, &connIDInt); err != nil {
+		// Should not get here if the client is behaving correctly, because
+		// we should only get InternalContext values that we returned previously
+		// from [openEphemeralSSHTunnels].
+		resp.Diagnostics = resp.Diagnostics.Append(err)
+		return resp
+	}
+	connID := uintptr(connIDInt)
+
+	ephemeralSSHTunnels.mu.Lock()
+	defer ephemeralSSHTunnels.mu.Unlock()
+
+	conn, ok := ephemeralSSHTunnels.active[connID]
+	if !ok {
+		// Should not get here because client should only pass InternalContext
+		// values that we returned previously from [openEphemeralSSHTunnels].
+		resp.Diagnostics = resp.Diagnostics.Append(fmt.Errorf("trying to close unknown connection %#v", connID))
+		return resp
+	}
+
+	if conn.closeListeners != nil {
+		conn.closeListeners()
+	}
+
+	err := conn.client.Close()
+	if err != nil {
+		// Perhaps the connection already got terminated exceptionally before
+		// we got around to closing it?
+		resp.Diagnostics = resp.Diagnostics.Append(tfdiags.AttributeValue(
+			tfdiags.Error,
+			"Could not close SSH connection",
+			fmt.Sprintf("Failed to close tunnel SSH connection: %s.", err),
+			nil,
+		))
+	}
+	// We'll delete it even if we failed to close it, because we're not going
+	// to get any opportunity to do anything with it again anyway, and it
+	// seems to be somehow broken.
+	delete(ephemeralSSHTunnels.active, connID)
+
+	return resp
+}
+
+func makeEphemeralSSHTunnelClientConfig(configVal cty.Value) (serverAddr string, clientConfig *ssh.ClientConfig, diags tfdiags.Diagnostics) {
+	clientConfig = &ssh.ClientConfig{}
+
+	// FIXME: In a real implementation we ought to constrain this better,
+	// such as by having the configuration include a set of allowed host
+	// keys.
+	clientConfig.HostKeyCallback = ssh.InsecureIgnoreHostKey()
+
+	if serverVal := configVal.GetAttr("server"); serverVal.IsKnown() {
+		serverAddr = serverVal.AsString()
+	} else {
+		// FIXME: Terrible error message just for prototype.
+		// In a real implementation we would hopefully be able to "defer"
+		// this, but deferred actions is being implemented concurrently with
+		// this prototype and so this is best to avoid conflicting with that
+		// other project.
+		diags = diags.Append(tfdiags.AttributeValue(
+			tfdiags.Error,
+			"SSH server address not known",
+			"The SSH server address is derived from a value that isn't known yet.",
+			cty.GetAttrPath("server"),
+		))
+	}
+	if usernameVal := configVal.GetAttr("username"); usernameVal.IsKnown() {
+		clientConfig.User = usernameVal.AsString()
+	} else {
+		// FIXME: Terrible error message just for prototype.
+		diags = diags.Append(tfdiags.AttributeValue(
+			tfdiags.Error,
+			"SSH username not known",
+			"The username is derived from a value that isn't known yet.",
+			cty.GetAttrPath("server"),
+		))
+	}
+
+	if authMethodsVal := configVal.GetAttr("auth_methods"); authMethodsVal.IsWhollyKnown() {
+		for it := authMethodsVal.ElementIterator(); it.Next(); {
+			idx, authMethodObj := it.Element()
+			if authMethodObj.IsNull() {
+				continue // FIXME: should probably be an error, actually
+			}
+
+			// The following makes sure that exactly one attribute is set
+			// and checks which it is. This pattern treats the object type
+			// as a sum type rather than as a product type.
+			var attrName string
+			var attrVal cty.Value
+			for n := range authMethodObj.Type().AttributeTypes() {
+				val := authMethodObj.GetAttr(n)
+				if val.IsNull() {
+					continue
+				}
+				if attrName != "" {
+					diags = diags.Append(tfdiags.AttributeValue(
+						tfdiags.Error,
+						"Ambiguous auth method selection",
+						fmt.Sprintf("Cannot set both %q and %q.", attrName, n),
+						cty.GetAttrPath("auth_methods").Index(idx),
+					))
+					continue
+				}
+				attrName = n
+				attrVal = val
+			}
+			if attrName == "" {
+				diags = diags.Append(tfdiags.AttributeValue(
+					tfdiags.Error,
+					"No auth method selection",
+					"Must set one of the possible attributes to select the auth method type.",
+					cty.GetAttrPath("auth_methods").Index(idx),
+				))
+				continue
+			}
+
+			switch attrName {
+			case "password":
+				if attrVal.IsNull() {
+					diags = diags.Append(tfdiags.AttributeValue(
+						tfdiags.Error,
+						"Password cannot be null",
+						"When authenticating using a password, the password must be specified.",
+						cty.GetAttrPath("auth_methods").Index(idx).GetAttr("password"),
+					))
+					continue
+				}
+				clientConfig.Auth = append(clientConfig.Auth, ssh.Password(attrVal.AsString()))
+			}
+		}
+	} else {
+		// FIXME: Terrible error message just for prototype.
+		diags = diags.Append(tfdiags.AttributeValue(
+			tfdiags.Error,
+			"SSH server auth methods not known",
+			"The auth_methods structure contains unknown values.",
+			cty.GetAttrPath("auth_methods"),
+		))
+	}
+
+	return serverAddr, clientConfig, diags
+}
+
+func sshTunnelLocalToRemote(ctx context.Context, listener net.Listener, sshClient *ssh.Client, remoteAddr string) {
+	log.Printf("[TRACE] terraform_ssh_tunnels: forwarding connections from %s to %s", listener.Addr(), remoteAddr)
+
+	for {
+		localConn, err := listener.Accept()
+		if err != nil {
+			log.Printf("[DEBUG] terraform_ssh_tunnels: error accepting connection from %s: %s", listener.Addr(), err)
+			break
+		}
+
+		remoteConn, err := sshClient.DialContext(ctx, "tcp", remoteAddr)
+		if err != nil {
+			localConn.Close()
+			log.Printf("[DEBUG] terraform_ssh_tunnels: error opening connection to %s: %s", remoteAddr, err)
+			break
+		}
+
+		localConnTCP := localConn.(*net.TCPConn)
+
+		// If we managed to open both connections then we just need to pass
+		// arbitrary bytes between them for as long as they're both open.
+		go func() {
+			var wg sync.WaitGroup
+
+			log.Printf("[TRACE] terraform_ssh_tunnels: tunnel connection %s->%s: open", localConnTCP.LocalAddr(), remoteConn.RemoteAddr())
+
+			wg.Add(2)
+			go func() {
+				io.Copy(localConnTCP, remoteConn)
+				localConnTCP.CloseWrite()
+				wg.Done()
+			}()
+			go func() {
+				io.Copy(remoteConn, localConnTCP)
+				// SSH tunnel client conn doesn't support CloseWrite, so
+				// we can't signal that nothing more is coming on that one.
+				wg.Done()
+			}()
+
+			wg.Wait()
+			localConnTCP.Close()
+			remoteConn.Close()
+
+			log.Printf("[TRACE] terraform_ssh_tunnels: tunnel connection %s->%s: closed", localConnTCP.LocalAddr(), remoteConn.RemoteAddr())
+		}()
+	}
+}

--- a/internal/builtin/providers/terraform/provider.go
+++ b/internal/builtin/providers/terraform/provider.go
@@ -169,7 +169,7 @@ func (p *Provider) ImportResourceState(req providers.ImportResourceStateRequest)
 		return importDataStore(req)
 	}
 
-	panic("unimplemented - terraform_remote_state has no resources")
+	panic("unimplemented - terraform.io/builtin/terraform has no managed resource types")
 }
 
 // MoveResourceState requests that the given resource be moved.
@@ -189,6 +189,21 @@ func (p *Provider) MoveResourceState(req providers.MoveResourceStateRequest) pro
 // ValidateResourceConfig is used to to validate the resource configuration values.
 func (p *Provider) ValidateResourceConfig(req providers.ValidateResourceConfigRequest) providers.ValidateResourceConfigResponse {
 	return validateDataStoreResourceConfig(req)
+}
+
+// CloseEphemeral implements providers.Interface.
+func (p *Provider) CloseEphemeral(providers.CloseEphemeralRequest) providers.CloseEphemeralResponse {
+	panic("unimplemented - terraform.io/builtin/terraform has no ephemeral resource types")
+}
+
+// OpenEphemeral implements providers.Interface.
+func (p *Provider) OpenEphemeral(providers.OpenEphemeralRequest) providers.OpenEphemeralResponse {
+	panic("unimplemented - terraform.io/builtin/terraform has no ephemeral resource types")
+}
+
+// RenewEphemeral implements providers.Interface.
+func (p *Provider) RenewEphemeral(providers.RenewEphemeralRequest) providers.RenewEphemeralResponse {
+	panic("unimplemented - terraform.io/builtin/terraform has no ephemeral resource types")
 }
 
 // CallFunction would call a function contributed by this provider, but this

--- a/internal/builtin/providers/terraform/provider.go
+++ b/internal/builtin/providers/terraform/provider.go
@@ -34,6 +34,7 @@ func (p *Provider) GetProviderSchema() providers.GetProviderSchemaResponse {
 		},
 		EphemeralResourceTypes: map[string]providers.Schema{
 			"terraform_random_number": ephemeralRandomNumberSchema(),
+			"terraform_ssh_tunnels":   ephemeralSSHTunnelsSchema(),
 		},
 		Functions: map[string]providers.FunctionDecl{
 			"encode_tfvars": {
@@ -199,6 +200,8 @@ func (p *Provider) OpenEphemeral(req providers.OpenEphemeralRequest) providers.O
 	switch req.TypeName {
 	case "terraform_random_number":
 		return openEphemeralRandomNumber(req)
+	case "terraform_ssh_tunnels":
+		return openEphemeralSSHTunnels(req)
 	default:
 		// This should not happen
 		var resp providers.OpenEphemeralResponse
@@ -212,6 +215,8 @@ func (p *Provider) RenewEphemeral(req providers.RenewEphemeralRequest) providers
 	switch req.TypeName {
 	case "terraform_random_number":
 		return renewEphemeralRandomNumber(req)
+	case "terraform_ssh_tunnels":
+		return renewEphemeralSSHTunnels(req)
 	default:
 		// This should not happen
 		var resp providers.RenewEphemeralResponse
@@ -225,6 +230,8 @@ func (p *Provider) CloseEphemeral(req providers.CloseEphemeralRequest) providers
 	switch req.TypeName {
 	case "terraform_random_number":
 		return closeEphemeralRandomNumber(req)
+	case "terraform_ssh_tunnels":
+		return closeEphemeralSSHTunnels(req)
 	default:
 		// This should not happen
 		var resp providers.CloseEphemeralResponse

--- a/internal/builtin/providers/terraform/provider.go
+++ b/internal/builtin/providers/terraform/provider.go
@@ -196,35 +196,41 @@ func (p *Provider) ValidateResourceConfig(req providers.ValidateResourceConfigRe
 
 // OpenEphemeral implements providers.Interface.
 func (p *Provider) OpenEphemeral(req providers.OpenEphemeralRequest) providers.OpenEphemeralResponse {
-	if req.TypeName != "terraform_random_number" {
+	switch req.TypeName {
+	case "terraform_random_number":
+		return openEphemeralRandomNumber(req)
+	default:
 		// This should not happen
 		var resp providers.OpenEphemeralResponse
 		resp.Diagnostics.Append(fmt.Errorf("unsupported ephemeral resource type %q", req.TypeName))
 		return resp
 	}
-	return openEphemeralRandomNumber(req)
 }
 
 // RenewEphemeral implements providers.Interface.
 func (p *Provider) RenewEphemeral(req providers.RenewEphemeralRequest) providers.RenewEphemeralResponse {
-	if req.TypeName != "terraform_random_number" {
+	switch req.TypeName {
+	case "terraform_random_number":
+		return renewEphemeralRandomNumber(req)
+	default:
 		// This should not happen
 		var resp providers.RenewEphemeralResponse
 		resp.Diagnostics.Append(fmt.Errorf("unsupported ephemeral resource type %q", req.TypeName))
 		return resp
 	}
-	return renewEphemeralRandomNumber(req)
 }
 
 // CloseEphemeral implements providers.Interface.
 func (p *Provider) CloseEphemeral(req providers.CloseEphemeralRequest) providers.CloseEphemeralResponse {
-	if req.TypeName != "terraform_random_number" {
+	switch req.TypeName {
+	case "terraform_random_number":
+		return closeEphemeralRandomNumber(req)
+	default:
 		// This should not happen
 		var resp providers.CloseEphemeralResponse
 		resp.Diagnostics.Append(fmt.Errorf("unsupported ephemeral resource type %q", req.TypeName))
 		return resp
 	}
-	return closeEphemeralRandomNumber(req)
 }
 
 // CallFunction would call a function contributed by this provider, but this

--- a/internal/builtin/providers/terraform/provider.go
+++ b/internal/builtin/providers/terraform/provider.go
@@ -32,6 +32,9 @@ func (p *Provider) GetProviderSchema() providers.GetProviderSchemaResponse {
 		ResourceTypes: map[string]providers.Schema{
 			"terraform_data": dataStoreResourceSchema(),
 		},
+		EphemeralResourceTypes: map[string]providers.Schema{
+			"terraform_random_number": ephemeralRandomNumberSchema(),
+		},
 		Functions: map[string]providers.FunctionDecl{
 			"encode_tfvars": {
 				Summary:     "Produce a string representation of an object using the same syntax as for `.tfvars` files",
@@ -191,19 +194,37 @@ func (p *Provider) ValidateResourceConfig(req providers.ValidateResourceConfigRe
 	return validateDataStoreResourceConfig(req)
 }
 
-// CloseEphemeral implements providers.Interface.
-func (p *Provider) CloseEphemeral(providers.CloseEphemeralRequest) providers.CloseEphemeralResponse {
-	panic("unimplemented - terraform.io/builtin/terraform has no ephemeral resource types")
-}
-
 // OpenEphemeral implements providers.Interface.
-func (p *Provider) OpenEphemeral(providers.OpenEphemeralRequest) providers.OpenEphemeralResponse {
-	panic("unimplemented - terraform.io/builtin/terraform has no ephemeral resource types")
+func (p *Provider) OpenEphemeral(req providers.OpenEphemeralRequest) providers.OpenEphemeralResponse {
+	if req.TypeName != "terraform_random_number" {
+		// This should not happen
+		var resp providers.OpenEphemeralResponse
+		resp.Diagnostics.Append(fmt.Errorf("unsupported ephemeral resource type %q", req.TypeName))
+		return resp
+	}
+	return openEphemeralRandomNumber(req)
 }
 
 // RenewEphemeral implements providers.Interface.
-func (p *Provider) RenewEphemeral(providers.RenewEphemeralRequest) providers.RenewEphemeralResponse {
-	panic("unimplemented - terraform.io/builtin/terraform has no ephemeral resource types")
+func (p *Provider) RenewEphemeral(req providers.RenewEphemeralRequest) providers.RenewEphemeralResponse {
+	if req.TypeName != "terraform_random_number" {
+		// This should not happen
+		var resp providers.RenewEphemeralResponse
+		resp.Diagnostics.Append(fmt.Errorf("unsupported ephemeral resource type %q", req.TypeName))
+		return resp
+	}
+	return renewEphemeralRandomNumber(req)
+}
+
+// CloseEphemeral implements providers.Interface.
+func (p *Provider) CloseEphemeral(req providers.CloseEphemeralRequest) providers.CloseEphemeralResponse {
+	if req.TypeName != "terraform_random_number" {
+		// This should not happen
+		var resp providers.CloseEphemeralResponse
+		resp.Diagnostics.Append(fmt.Errorf("unsupported ephemeral resource type %q", req.TypeName))
+		return resp
+	}
+	return closeEphemeralRandomNumber(req)
 }
 
 // CallFunction would call a function contributed by this provider, but this

--- a/internal/configs/config.go
+++ b/internal/configs/config.go
@@ -466,6 +466,14 @@ func (c *Config) addProviderRequirements(reqs providerreqs.Requirements, recurse
 		}
 		reqs[fqn] = nil
 	}
+	for _, rc := range c.Module.EphemeralResources {
+		fqn := rc.Provider
+		if _, exists := reqs[fqn]; exists {
+			// Explicit dependency already present
+			continue
+		}
+		reqs[fqn] = nil
+	}
 
 	// Import blocks that are generating config may have a custom provider
 	// meta-argument. Like the provider meta-argument used in resource blocks,

--- a/internal/configs/experiments.go
+++ b/internal/configs/experiments.go
@@ -229,6 +229,14 @@ func checkModuleExperiments(m *Module) hcl.Diagnostics {
 				})
 			}
 		}
+		for _, rc := range m.EphemeralResources {
+			diags = append(diags, &hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  "Ephemeral resources are experimental",
+				Detail:   "This feature is currently an opt-in experiment, subject to change in future releases based on feedback.\n\nActivate the feature for this module by adding ephemeral_values to the list of active experiments.",
+				Subject:  rc.DeclRange.Ptr(),
+			})
+		}
 	}
 
 	return diags

--- a/internal/configs/parser_config.go
+++ b/internal/configs/parser_config.go
@@ -193,6 +193,13 @@ func parseConfigFile(body hcl.Body, diags hcl.Diagnostics, override, allowExperi
 				file.DataResources = append(file.DataResources, cfg)
 			}
 
+		case "ephemeral":
+			cfg, cfgDiags := decodeEphemeralBlock(block, override)
+			diags = append(diags, cfgDiags...)
+			if cfg != nil {
+				file.EphemeralResources = append(file.EphemeralResources, cfg)
+			}
+
 		case "moved":
 			cfg, cfgDiags := decodeMovedBlock(block)
 			diags = append(diags, cfgDiags...)
@@ -306,6 +313,10 @@ var configFileSchema = &hcl.BodySchema{
 		},
 		{
 			Type:       "data",
+			LabelNames: []string{"type", "name"},
+		},
+		{
+			Type:       "ephemeral",
 			LabelNames: []string{"type", "name"},
 		},
 		{

--- a/internal/configs/resource.go
+++ b/internal/configs/resource.go
@@ -537,7 +537,7 @@ func decodeDataBlock(block *hcl.Block, override, nested bool) (*Resource, hcl.Di
 func decodeEphemeralBlock(block *hcl.Block, override bool) (*Resource, hcl.Diagnostics) {
 	var diags hcl.Diagnostics
 	r := &Resource{
-		Mode:      addrs.DataResourceMode,
+		Mode:      addrs.EphemeralResourceMode,
 		Type:      block.Labels[0],
 		Name:      block.Labels[1],
 		DeclRange: block.DefRange,

--- a/internal/configs/resource.go
+++ b/internal/configs/resource.go
@@ -534,6 +534,155 @@ func decodeDataBlock(block *hcl.Block, override, nested bool) (*Resource, hcl.Di
 	return r, diags
 }
 
+func decodeEphemeralBlock(block *hcl.Block, override bool) (*Resource, hcl.Diagnostics) {
+	var diags hcl.Diagnostics
+	r := &Resource{
+		Mode:      addrs.DataResourceMode,
+		Type:      block.Labels[0],
+		Name:      block.Labels[1],
+		DeclRange: block.DefRange,
+		TypeRange: block.LabelRanges[0],
+	}
+
+	content, remain, moreDiags := block.Body.PartialContent(ephemeralBlockSchema)
+	diags = append(diags, moreDiags...)
+	r.Config = remain
+
+	if !hclsyntax.ValidIdentifier(r.Type) {
+		diags = append(diags, &hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  "Invalid ephemeral resource type",
+			Detail:   badIdentifierDetail,
+			Subject:  &block.LabelRanges[0],
+		})
+	}
+	if !hclsyntax.ValidIdentifier(r.Name) {
+		diags = append(diags, &hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  "Invalid ephemeral resource name",
+			Detail:   badIdentifierDetail,
+			Subject:  &block.LabelRanges[1],
+		})
+	}
+
+	if attr, exists := content.Attributes["count"]; exists {
+		r.Count = attr.Expr
+	}
+
+	if attr, exists := content.Attributes["for_each"]; exists {
+		r.ForEach = attr.Expr
+		// Cannot have count and for_each on the same ephemeral block
+		if r.Count != nil {
+			diags = append(diags, &hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  `Invalid combination of "count" and "for_each"`,
+				Detail:   `The "count" and "for_each" meta-arguments are mutually-exclusive, only one should be used to be explicit about the number of resources to be created.`,
+				Subject:  &attr.NameRange,
+			})
+		}
+	}
+
+	if attr, exists := content.Attributes["provider"]; exists {
+		var providerDiags hcl.Diagnostics
+		r.ProviderConfigRef, providerDiags = decodeProviderConfigRef(attr.Expr, "provider")
+		diags = append(diags, providerDiags...)
+	}
+
+	if attr, exists := content.Attributes["depends_on"]; exists {
+		deps, depsDiags := decodeDependsOn(attr)
+		diags = append(diags, depsDiags...)
+		r.DependsOn = append(r.DependsOn, deps...)
+	}
+
+	var seenEscapeBlock *hcl.Block
+	var seenLifecycle *hcl.Block
+	for _, block := range content.Blocks {
+		switch block.Type {
+
+		case "_":
+			if seenEscapeBlock != nil {
+				diags = append(diags, &hcl.Diagnostic{
+					Severity: hcl.DiagError,
+					Summary:  "Duplicate escaping block",
+					Detail: fmt.Sprintf(
+						"The special block type \"_\" can be used to force particular arguments to be interpreted as resource-type-specific rather than as meta-arguments, but each data block can have only one such block. The first escaping block was at %s.",
+						seenEscapeBlock.DefRange,
+					),
+					Subject: &block.DefRange,
+				})
+				continue
+			}
+			seenEscapeBlock = block
+
+			// When there's an escaping block its content merges with the
+			// existing config we extracted earlier, so later decoding
+			// will see a blend of both.
+			r.Config = hcl.MergeBodies([]hcl.Body{r.Config, block.Body})
+
+		case "lifecycle":
+			if seenLifecycle != nil {
+				diags = append(diags, &hcl.Diagnostic{
+					Severity: hcl.DiagError,
+					Summary:  "Duplicate lifecycle block",
+					Detail:   fmt.Sprintf("This resource already has a lifecycle block at %s.", seenLifecycle.DefRange),
+					Subject:  block.DefRange.Ptr(),
+				})
+				continue
+			}
+			seenLifecycle = block
+
+			lcContent, lcDiags := block.Body.Content(resourceLifecycleBlockSchema)
+			diags = append(diags, lcDiags...)
+
+			// All of the attributes defined for resource lifecycle are for
+			// managed resources only, so we can emit a common error message
+			// for any given attributes that HCL accepted.
+			for name, attr := range lcContent.Attributes {
+				diags = append(diags, &hcl.Diagnostic{
+					Severity: hcl.DiagError,
+					Summary:  "Invalid ephemeral resource lifecycle argument",
+					Detail:   fmt.Sprintf("The lifecycle argument %q is defined only for managed resources (\"resource\" blocks), and is not valid for ephemeral resources.", name),
+					Subject:  attr.NameRange.Ptr(),
+				})
+			}
+
+			for _, block := range lcContent.Blocks {
+				switch block.Type {
+				case "precondition", "postcondition":
+					cr, moreDiags := decodeCheckRuleBlock(block, override)
+					diags = append(diags, moreDiags...)
+
+					moreDiags = cr.validateSelfReferences(block.Type, r.Addr())
+					diags = append(diags, moreDiags...)
+
+					switch block.Type {
+					case "precondition":
+						r.Preconditions = append(r.Preconditions, cr)
+					case "postcondition":
+						r.Postconditions = append(r.Postconditions, cr)
+					}
+				default:
+					// The cases above should be exhaustive for all block types
+					// defined in the lifecycle schema, so this shouldn't happen.
+					panic(fmt.Sprintf("unexpected lifecycle sub-block type %q", block.Type))
+				}
+			}
+
+		default:
+			// Any other block types are ones we're reserving for future use,
+			// but don't have any defined meaning today.
+			diags = append(diags, &hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  "Reserved block type name in ephemeral block",
+				Detail:   fmt.Sprintf("The block type name %q is reserved for use by Terraform in a future version.", block.Type),
+				Subject:  block.TypeRange.Ptr(),
+			})
+		}
+	}
+
+	return r, diags
+}
+
 // decodeReplaceTriggeredBy decodes and does basic validation of the
 // replace_triggered_by expressions, ensuring they only contains references to
 // a single resource, and the only extra variables are count.index or each.key.
@@ -775,6 +924,15 @@ var ResourceBlockSchema = &hcl.BodySchema{
 }
 
 var dataBlockSchema = &hcl.BodySchema{
+	Attributes: commonResourceAttributes,
+	Blocks: []hcl.BlockHeaderSchema{
+		{Type: "lifecycle"},
+		{Type: "locals"}, // reserved for future use
+		{Type: "_"},      // meta-argument escaping block
+	},
+}
+
+var ephemeralBlockSchema = &hcl.BodySchema{
 	Attributes: commonResourceAttributes,
 	Blocks: []hcl.BlockHeaderSchema{
 		{Type: "lifecycle"},

--- a/internal/lang/eval.go
+++ b/internal/lang/eval.go
@@ -283,6 +283,7 @@ func (s *Scope) evalContext(refs []*addrs.Reference, selfAddr addrs.Referenceabl
 	// that's redundant in the process of populating our values map.
 	dataResources := map[string]map[string]cty.Value{}
 	managedResources := map[string]map[string]cty.Value{}
+	ephemeralResources := map[string]map[string]cty.Value{}
 	wholeModules := map[string]cty.Value{}
 	inputVariables := map[string]cty.Value{}
 	localValues := map[string]cty.Value{}
@@ -365,6 +366,8 @@ func (s *Scope) evalContext(refs []*addrs.Reference, selfAddr addrs.Referenceabl
 				into = managedResources
 			case addrs.DataResourceMode:
 				into = dataResources
+			case addrs.EphemeralResourceMode:
+				into = ephemeralResources
 			default:
 				panic(fmt.Errorf("unsupported ResourceMode %s", subj.Mode))
 			}
@@ -443,8 +446,8 @@ func (s *Scope) evalContext(refs []*addrs.Reference, selfAddr addrs.Referenceabl
 		vals[k] = v
 	}
 	vals["resource"] = cty.ObjectVal(buildResourceObjects(managedResources))
-
 	vals["data"] = cty.ObjectVal(buildResourceObjects(dataResources))
+	vals["ephemeral"] = cty.ObjectVal(buildResourceObjects(ephemeralResources))
 	vals["module"] = cty.ObjectVal(wholeModules)
 	vals["var"] = cty.ObjectVal(inputVariables)
 	vals["local"] = cty.ObjectVal(localValues)

--- a/internal/plans/changes_sync.go
+++ b/internal/plans/changes_sync.go
@@ -32,6 +32,7 @@ func (cs *ChangesSync) AppendResourceInstanceChange(changeSrc *ResourceInstanceC
 	if cs == nil {
 		panic("AppendResourceInstanceChange on nil ChangesSync")
 	}
+	assertPlannableResource(changeSrc.Addr.Resource.Resource)
 	cs.lock.Lock()
 	defer cs.lock.Unlock()
 
@@ -53,6 +54,7 @@ func (cs *ChangesSync) GetResourceInstanceChange(addr addrs.AbsResourceInstance,
 	if cs == nil {
 		panic("GetResourceInstanceChange on nil ChangesSync")
 	}
+	assertPlannableResource(addr.Resource.Resource)
 	cs.lock.Lock()
 	defer cs.lock.Unlock()
 
@@ -76,6 +78,7 @@ func (cs *ChangesSync) GetChangesForConfigResource(addr addrs.ConfigResource) []
 	if cs == nil {
 		panic("GetChangesForConfigResource on nil ChangesSync")
 	}
+	assertPlannableResource(addr.Resource)
 	cs.lock.Lock()
 	defer cs.lock.Unlock()
 	var changes []*ResourceInstanceChangeSrc
@@ -97,6 +100,7 @@ func (cs *ChangesSync) GetChangesForAbsResource(addr addrs.AbsResource) []*Resou
 	if cs == nil {
 		panic("GetChangesForAbsResource on nil ChangesSync")
 	}
+	assertPlannableResource(addr.Resource)
 	cs.lock.Lock()
 	defer cs.lock.Unlock()
 	var changes []*ResourceInstanceChangeSrc
@@ -113,6 +117,7 @@ func (cs *ChangesSync) RemoveResourceInstanceChange(addr addrs.AbsResourceInstan
 	if cs == nil {
 		panic("RemoveResourceInstanceChange on nil ChangesSync")
 	}
+	assertPlannableResource(addr.Resource.Resource)
 	cs.lock.Lock()
 	defer cs.lock.Unlock()
 

--- a/internal/plans/planfile/tfplan.go
+++ b/internal/plans/planfile/tfplan.go
@@ -698,6 +698,9 @@ func resourceChangeToTfplan(change *plans.ResourceInstanceChangeSrc) (*planproto
 		change.PrevRunAddr = change.Addr
 	}
 
+	if mode := change.Addr.Resource.Resource.Mode; !mode.PersistsPlanToApply() {
+		panic(fmt.Sprintf("instance of resource with mode %s cannot have planned actions", mode))
+	}
 	ret.Addr = change.Addr.String()
 	ret.PrevRunAddr = change.PrevRunAddr.String()
 	if ret.PrevRunAddr == ret.Addr {

--- a/internal/plugin/grpc_provider.go
+++ b/internal/plugin/grpc_provider.go
@@ -21,6 +21,7 @@ import (
 	"github.com/hashicorp/terraform/internal/logging"
 	"github.com/hashicorp/terraform/internal/plugin/convert"
 	"github.com/hashicorp/terraform/internal/providers"
+	"github.com/hashicorp/terraform/internal/tfdiags"
 	proto "github.com/hashicorp/terraform/internal/tfplugin5"
 )
 
@@ -764,6 +765,54 @@ func (p *GRPCProvider) ReadDataSource(r providers.ReadDataSourceRequest) (resp p
 	resp.State = state
 	resp.Deferred = convert.ProtoToDeferred(protoResp.Deferred)
 
+	return resp
+}
+
+func (p *GRPCProvider) OpenEphemeral(r providers.OpenEphemeralRequest) (resp providers.OpenEphemeralResponse) {
+	logger.Trace("GRPCProvider: OpenEphemeral")
+
+	// There is not yet any support for plugin-based providers to offer
+	// ephemeral resource types. We should not be able to get here because
+	// a GRPCProvider should never advertise in its schema that it supports
+	// ephemeral resource types.
+	resp.Diagnostics = resp.Diagnostics.Append(tfdiags.AttributeValue(
+		tfdiags.Error,
+		"Ephemeral resources not supported",
+		"This provider does not offer any ephemeral resource types.",
+		nil,
+	))
+	return resp
+}
+
+func (p *GRPCProvider) RenewEphemeral(r providers.RenewEphemeralRequest) (resp providers.RenewEphemeralResponse) {
+	logger.Trace("GRPCProvider: RenewEphemeral")
+
+	// There is not yet any support for plugin-based providers to offer
+	// ephemeral resource types. We should not be able to get here because
+	// a GRPCProvider should never advertise in its schema that it supports
+	// ephemeral resource types.
+	resp.Diagnostics = resp.Diagnostics.Append(tfdiags.AttributeValue(
+		tfdiags.Error,
+		"Ephemeral resources not supported",
+		"This provider does not offer any ephemeral resource types.",
+		nil,
+	))
+	return resp
+}
+
+func (p *GRPCProvider) CloseEphemeral(r providers.CloseEphemeralRequest) (resp providers.CloseEphemeralResponse) {
+	logger.Trace("GRPCProvider: CloseEphemeral")
+
+	// There is not yet any support for plugin-based providers to offer
+	// ephemeral resource types. We should not be able to get here because
+	// a GRPCProvider should never advertise in its schema that it supports
+	// ephemeral resource types.
+	resp.Diagnostics = resp.Diagnostics.Append(tfdiags.AttributeValue(
+		tfdiags.Error,
+		"Ephemeral resources not supported",
+		"This provider does not offer any ephemeral resource types.",
+		nil,
+	))
 	return resp
 }
 

--- a/internal/plugin6/grpc_provider.go
+++ b/internal/plugin6/grpc_provider.go
@@ -21,6 +21,7 @@ import (
 	"github.com/hashicorp/terraform/internal/logging"
 	"github.com/hashicorp/terraform/internal/plugin6/convert"
 	"github.com/hashicorp/terraform/internal/providers"
+	"github.com/hashicorp/terraform/internal/tfdiags"
 	proto6 "github.com/hashicorp/terraform/internal/tfplugin6"
 )
 
@@ -753,6 +754,54 @@ func (p *GRPCProvider) ReadDataSource(r providers.ReadDataSourceRequest) (resp p
 	resp.State = state
 	resp.Deferred = convert.ProtoToDeferred(protoResp.Deferred)
 
+	return resp
+}
+
+func (p *GRPCProvider) OpenEphemeral(r providers.OpenEphemeralRequest) (resp providers.OpenEphemeralResponse) {
+	logger.Trace("GRPCProvider.v6", "OpenEphemeral", r.TypeName)
+
+	// There is not yet any support for plugin-based providers to offer
+	// ephemeral resource types. We should not be able to get here because
+	// a GRPCProvider should never advertise in its schema that it supports
+	// ephemeral resource types.
+	resp.Diagnostics = resp.Diagnostics.Append(tfdiags.AttributeValue(
+		tfdiags.Error,
+		"Ephemeral resources not supported",
+		"This provider does not offer any ephemeral resource types.",
+		nil,
+	))
+	return resp
+}
+
+func (p *GRPCProvider) RenewEphemeral(r providers.RenewEphemeralRequest) (resp providers.RenewEphemeralResponse) {
+	logger.Trace("GRPCProvider.v6", "RenewEphemeral", r.TypeName)
+
+	// There is not yet any support for plugin-based providers to offer
+	// ephemeral resource types. We should not be able to get here because
+	// a GRPCProvider should never advertise in its schema that it supports
+	// ephemeral resource types.
+	resp.Diagnostics = resp.Diagnostics.Append(tfdiags.AttributeValue(
+		tfdiags.Error,
+		"Ephemeral resources not supported",
+		"This provider does not offer any ephemeral resource types.",
+		nil,
+	))
+	return resp
+}
+
+func (p *GRPCProvider) CloseEphemeral(r providers.CloseEphemeralRequest) (resp providers.CloseEphemeralResponse) {
+	logger.Trace("GRPCProvider.v6", "CloseEphemeral", r.TypeName)
+
+	// There is not yet any support for plugin-based providers to offer
+	// ephemeral resource types. We should not be able to get here because
+	// a GRPCProvider should never advertise in its schema that it supports
+	// ephemeral resource types.
+	resp.Diagnostics = resp.Diagnostics.Append(tfdiags.AttributeValue(
+		tfdiags.Error,
+		"Ephemeral resources not supported",
+		"This provider does not offer any ephemeral resource types.",
+		nil,
+	))
 	return resp
 }
 

--- a/internal/provider-simple-v6/provider.go
+++ b/internal/provider-simple-v6/provider.go
@@ -171,6 +171,24 @@ func (s simple) ReadDataSource(req providers.ReadDataSourceRequest) (resp provid
 	return resp
 }
 
+func (s simple) OpenEphemeral(providers.OpenEphemeralRequest) providers.OpenEphemeralResponse {
+	// Our schema doesn't include any ephemeral resource types, so it should be
+	// impossible to get in here.
+	panic("OpenEphemeral on provider that didn't declare any ephemeral resource types")
+}
+
+func (s simple) RenewEphemeral(providers.RenewEphemeralRequest) providers.RenewEphemeralResponse {
+	// Our schema doesn't include any ephemeral resource types, so it should be
+	// impossible to get in here.
+	panic("RenewEphemeral on provider that didn't declare any ephemeral resource types")
+}
+
+func (s simple) CloseEphemeral(providers.CloseEphemeralRequest) providers.CloseEphemeralResponse {
+	// Our schema doesn't include any ephemeral resource types, so it should be
+	// impossible to get in here.
+	panic("CloseEphemeral on provider that didn't declare any ephemeral resource types")
+}
+
 func (s simple) CallFunction(req providers.CallFunctionRequest) (resp providers.CallFunctionResponse) {
 	if req.FunctionName != "noop" {
 		resp.Err = fmt.Errorf("CallFunction for undefined function %q", req.FunctionName)

--- a/internal/provider-simple/provider.go
+++ b/internal/provider-simple/provider.go
@@ -144,6 +144,24 @@ func (s simple) ReadDataSource(req providers.ReadDataSourceRequest) (resp provid
 	return resp
 }
 
+func (s simple) OpenEphemeral(providers.OpenEphemeralRequest) providers.OpenEphemeralResponse {
+	// Our schema doesn't include any ephemeral resource types, so it should be
+	// impossible to get in here.
+	panic("OpenEphemeral on provider that didn't declare any ephemeral resource types")
+}
+
+func (s simple) RenewEphemeral(providers.RenewEphemeralRequest) providers.RenewEphemeralResponse {
+	// Our schema doesn't include any ephemeral resource types, so it should be
+	// impossible to get in here.
+	panic("RenewEphemeral on provider that didn't declare any ephemeral resource types")
+}
+
+func (s simple) CloseEphemeral(providers.CloseEphemeralRequest) providers.CloseEphemeralResponse {
+	// Our schema doesn't include any ephemeral resource types, so it should be
+	// impossible to get in here.
+	panic("CloseEphemeral on provider that didn't declare any ephemeral resource types")
+}
+
 func (s simple) CallFunction(req providers.CallFunctionRequest) (resp providers.CallFunctionResponse) {
 	// Our schema doesn't include any functions, so it should be impossible
 	// to get in here.

--- a/internal/providers/ephemeral.go
+++ b/internal/providers/ephemeral.go
@@ -1,0 +1,187 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package providers
+
+import (
+	"time"
+
+	"github.com/hashicorp/terraform/internal/tfdiags"
+	"github.com/zclconf/go-cty/cty"
+)
+
+// OpenEphemeralRequest represents the arguments for the OpenEphemeral
+// operation on a provider.
+type OpenEphemeralRequest struct {
+	// TypeName is the type of ephemeral resource to open. This should
+	// only be one of the type names previously reported in the provider's
+	// schema.
+	TypeName string
+
+	// Config is an object-typed value representing the configuration for
+	// the ephemeral resource instance that the caller is trying to open.
+	//
+	// The object type of this value always conforms to the resource type
+	// schema's implied type, and uses null values to represent attributes
+	// that were not explicitly assigned in the configuration block.
+	// Computed-only attributes are always null in the configuration, because
+	// they can be set only in the reponse.
+	Config cty.Value
+}
+
+// OpenEphemeralRequest represents the response from an OpenEphemeral
+// operation on a provider.
+type OpenEphemeralResponse struct {
+	// Deferred, if present, signals that the provider doesn't have enough
+	// information to open this ephemeral resource instance.
+	//
+	// This implies that any other side-effect-performing object must have
+	// its planning deferred if its planning operation indirectly depends on
+	// this ephemeral resource result. For example, if a provider configuration
+	// refers to an ephemeral resource whose opening is deferred then the
+	// affected provider configuration must not be instantiated and any
+	// resource instances that belong to it must have their planning immediately
+	// deferred.
+	Deferred *Deferred
+
+	// Result is an object-typed value representing the newly-opened session
+	// with the opened ephemeral object.
+	//
+	// The object type of this value always conforms to the resource type
+	// schema's implied type. Unknown values are forbidden unless the
+	// Deferred field is set, in which case the Result represents the provider's
+	// best approximation of the final object using unknown values in any
+	// location where a final value cannot be predicted.
+	Result cty.Value
+
+	// InternalContext is any internal data needed by the provider to
+	// perform a subsequent [Interface.CloseEphemeral] request for the same
+	// object. The provider may choose any encoding format to represent the
+	// needed data, because Terraform Core treats this field as opaque.
+	//
+	// Providers should aim to keep this data relatively compact to minimize
+	// overhead. Although Terraform Core does not enforce a specific limit
+	// just for this field, it would be very unusual for the internal context
+	// to be more than 256 bytes in size, and in most cases it should be
+	// on the order of only tens of bytes. For example, a lease ID for the
+	// remote system is a reasonable thing to encode here.
+	//
+	// Because ephemeral resource instances never outlive a single Terraform
+	// Core phase, it's guaranteed that a CloseEphemeral request will be
+	// received by exactly the same plugin instance that returned this
+	// value, and so it's valid for this to refer to in-memory state belonging
+	// to the provider instance.
+	InternalContext []byte
+
+	// Renew, if set, signals that the opened object has an inherent expration
+	// time and so must be "renewed" if Terraform needs to use it beyond that
+	// expiration time.
+	//
+	// If a provider sets this field then it may receive a subsequent
+	// [Interface.RenewEphemeral] call, if Terraform expects to need the
+	// object beyond the expiration time.
+	Renew *EphemeralRenew
+
+	// Diagnostics describes any problems encountered while opening the
+	// ephemeral resource. If this contains errors then the other response
+	// fields must be assumed invalid.
+	Diagnostics tfdiags.Diagnostics
+}
+
+// EphemeralRenew describes when and how Terraform Core must request renewal
+// of an ephemeral resource instance in order to continue using it.
+type EphemeralRenew struct {
+	// ExpireTime is the deadline before which Terraform must renew the
+	// ephemeral resource instance. Terraform will make the renew request
+	// at least one minute before the expiration time.
+	ExpireTime time.Time
+
+	// InternalContext is any internal data needed by the provider to
+	// perform a subsequent [Interface.RenewEphemeral] request. The provider
+	// may choose any encoding format to represent the needed data, because
+	// Terraform Core treats this field as opaque.
+	//
+	// Providers should aim to keep this data relatively compact to minimize
+	// overhead. Although Terraform Core does not enforce a specific limit
+	// just for this field, it would be very unusual for the internal context
+	// to be more than 256 bytes in size, and in most cases it should be
+	// on the order of only tens of bytes. For example, a lease ID for the
+	// remote system is a reasonable thing to encode here.
+	//
+	// Because ephemeral resource instances never outlive a single Terraform
+	// Core phase, it's guaranteed that a RenewEphemeral request will be
+	// received by exactly the same plugin instance that previously handled
+	// the OpenEphemeral or RenewEphemeral request that produced this internal
+	// context, and so it's valid for this to refer to in-memory state in the
+	// provider object.
+	InternalContext []byte
+}
+
+// RenewEphemeralRequest represents the arguments for the RenewEphemeral
+// operation on a provider.
+type RenewEphemeralRequest struct {
+	// TypeName is the type of ephemeral resource being renewed. This should
+	// only be one of the type names previously sent in a successful
+	// [OpenEphemeralRequest].
+	TypeName string
+
+	// InternalContext echoes verbatim the value from the field of the same
+	// name from the most recent [EphemeralRenew] object, received from either
+	// an [OpenEphemeralResponse] or a [RenewEphemeralResponse] object.
+	InternalContext []byte
+}
+
+// RenewEphemeralRequest represents the response from a RenewEphemeral
+// operation on a provider.
+type RenewEphemeralResponse struct {
+	// RenewAgain, if set, describes a new expiration deadline for the
+	// object, possibly causing a further call to [Interface.RenewEphemeral]
+	// if Terraform needs to exceed the updated deadline.
+	//
+	// If this is not set then Terraform Core will not make any further
+	// renewal requests for the remaining life of the object.
+	RenewAgain *EphemeralRenew
+
+	// Diagnostics describes any problems encountered while renewing the
+	// ephemeral resource instance. If this contains errors then the other
+	// response fields must be assumed invalid.
+	//
+	// Because renewals happen asynchronously from other uses of the
+	// ephemeral object, it's unspecified whether a renewal error will block
+	// any specific usage of the object. For example, a request using the
+	// object might already be in progress when a renewal error occurs,
+	// in which case that other request might also fail trying to use a
+	// now-invalid object, or it might by chance succeed in completing its
+	// operation before the ephemeral object truly expires.
+	Diagnostics tfdiags.Diagnostics
+}
+
+// CloseEphemeralRequest represents the arguments for the CloseEphemeral
+// operation on a provider.
+type CloseEphemeralRequest struct {
+	// TypeName is the type of ephemeral resource being closed. This should
+	// only be one of the type names previously sent in a successful
+	// [OpenEphemeralRequest].
+	TypeName string
+
+	// InternalContext echoes verbatim the value from the field of the same
+	// name from the corresponding [OpenEphemeralResponse] object.
+	InternalContext []byte
+}
+
+// CloseEphemeralRequest represents the response from a CloseEphemeral
+// operation on a provider.
+type CloseEphemeralResponse struct {
+	// Diagnostics describes any problems encountered while closing the
+	// ephemeral resource instance. If this contains errors then the other
+	// response fields must be assumed invalid.
+	//
+	// If closing an ephemeral resource instance fails then it's unspecified
+	// whether a corresponding remote object remains valid or not.
+	//
+	// Providers should make a best effort to treat the closure of an
+	// already-expired ephemeral object as a success in order to exhibit
+	// idemponent behavior for closing, but some remote systems do not allow
+	// distinguishing that case from other error conditions.
+	Diagnostics tfdiags.Diagnostics
+}

--- a/internal/providers/mock.go
+++ b/internal/providers/mock.go
@@ -289,6 +289,48 @@ func (m *Mock) ReadDataSource(request ReadDataSourceRequest) ReadDataSourceRespo
 	return response
 }
 
+func (m *Mock) OpenEphemeral(OpenEphemeralRequest) OpenEphemeralResponse {
+	// FIXME: Design some means to mock an ephemeral resource type.
+	var diags tfdiags.Diagnostics
+	diags = diags.Append(tfdiags.AttributeValue(
+		tfdiags.Error,
+		"No ephemeral resource types in mock providers",
+		"The provider mocking mechanism does not yet support ephemeral resource types.",
+		nil, // the topmost configuration object
+	))
+	return OpenEphemeralResponse{
+		Diagnostics: diags,
+	}
+}
+
+func (m *Mock) RenewEphemeral(RenewEphemeralRequest) RenewEphemeralResponse {
+	// FIXME: Design some means to mock an ephemeral resource type.
+	var diags tfdiags.Diagnostics
+	diags = diags.Append(tfdiags.AttributeValue(
+		tfdiags.Error,
+		"No ephemeral resource types in mock providers",
+		"The provider mocking mechanism does not yet support ephemeral resource types.",
+		nil, // the topmost configuration object
+	))
+	return RenewEphemeralResponse{
+		Diagnostics: diags,
+	}
+}
+
+func (m *Mock) CloseEphemeral(CloseEphemeralRequest) CloseEphemeralResponse {
+	// FIXME: Design some means to mock an ephemeral resource type.
+	var diags tfdiags.Diagnostics
+	diags = diags.Append(tfdiags.AttributeValue(
+		tfdiags.Error,
+		"No ephemeral resource types in mock providers",
+		"The provider mocking mechanism does not yet support ephemeral resource types.",
+		nil, // the topmost configuration object
+	))
+	return CloseEphemeralResponse{
+		Diagnostics: diags,
+	}
+}
+
 func (m *Mock) CallFunction(request CallFunctionRequest) CallFunctionResponse {
 	return m.Provider.CallFunction(request)
 }

--- a/internal/providers/provider.go
+++ b/internal/providers/provider.go
@@ -74,6 +74,15 @@ type Interface interface {
 	// ReadDataSource returns the data source's current state.
 	ReadDataSource(ReadDataSourceRequest) ReadDataSourceResponse
 
+	// OpenEphemeral opens an ephemeral resource instance.
+	OpenEphemeral(OpenEphemeralRequest) OpenEphemeralResponse
+	// RenewEphemeral extends the validity of a previously-opened ephemeral
+	// resource instance.
+	RenewEphemeral(RenewEphemeralRequest) RenewEphemeralResponse
+	// CloseEphemeral closes an ephemeral resource instance, with the intent
+	// of rendering it invalid as soon as possible.
+	CloseEphemeral(CloseEphemeralRequest) CloseEphemeralResponse
+
 	// CallFunction calls a provider-contributed function.
 	CallFunction(CallFunctionRequest) CallFunctionResponse
 
@@ -98,6 +107,10 @@ type GetProviderSchemaResponse struct {
 
 	// DataSources maps the data source name to that data source's schema.
 	DataSources map[string]Schema
+
+	// EphemeralResourceTypes maps the name of an ephemeral resource type
+	// to its schema.
+	EphemeralResourceTypes map[string]Schema
 
 	// Functions maps from local function name (not including an namespace
 	// prefix) to the declaration of a function.

--- a/internal/providers/schemas.go
+++ b/internal/providers/schemas.go
@@ -23,6 +23,9 @@ func (ss ProviderSchema) SchemaForResourceType(mode addrs.ResourceMode, typeName
 	case addrs.DataResourceMode:
 		// Data resources don't have schema versions right now, since state is discarded for each refresh
 		return ss.DataSources[typeName].Block, 0
+	case addrs.EphemeralResourceMode:
+		// Ephemeral resources don't have schema versions because their objects never outlive a single phase
+		return ss.EphemeralResourceTypes[typeName].Block, 0
 	default:
 		// Shouldn't happen, because the above cases are comprehensive.
 		return nil, 0

--- a/internal/providers/testing/provider_mock.go
+++ b/internal/providers/testing/provider_mock.go
@@ -94,6 +94,19 @@ type MockProvider struct {
 	ReadDataSourceRequest  providers.ReadDataSourceRequest
 	ReadDataSourceFn       func(providers.ReadDataSourceRequest) providers.ReadDataSourceResponse
 
+	OpenEphemeralCalled    bool
+	OpenEphemeralResponse  *providers.OpenEphemeralResponse
+	OpenEphemeralRequest   providers.OpenEphemeralRequest
+	OpenEphemeralFn        func(providers.OpenEphemeralRequest) providers.OpenEphemeralResponse
+	RenewEphemeralCalled   bool
+	RenewEphemeralResponse *providers.RenewEphemeralResponse
+	RenewEphemeralRequest  providers.RenewEphemeralRequest
+	RenewEphemeralFn       func(providers.RenewEphemeralRequest) providers.RenewEphemeralResponse
+	CloseEphemeralCalled   bool
+	CloseEphemeralResponse *providers.CloseEphemeralResponse
+	CloseEphemeralRequest  providers.CloseEphemeralRequest
+	CloseEphemeralFn       func(providers.CloseEphemeralRequest) providers.CloseEphemeralResponse
+
 	CallFunctionCalled   bool
 	CallFunctionResponse providers.CallFunctionResponse
 	CallFunctionRequest  providers.CallFunctionRequest
@@ -548,6 +561,75 @@ func (p *MockProvider) ReadDataSource(r providers.ReadDataSourceRequest) (resp p
 
 	if p.ReadDataSourceResponse != nil {
 		resp = *p.ReadDataSourceResponse
+	}
+
+	return resp
+}
+
+func (p *MockProvider) OpenEphemeral(r providers.OpenEphemeralRequest) (resp providers.OpenEphemeralResponse) {
+	p.Lock()
+	defer p.Unlock()
+
+	if !p.ConfigureProviderCalled {
+		resp.Diagnostics = resp.Diagnostics.Append(fmt.Errorf("Configure not called before OpenEphemeral %q", r.TypeName))
+		return resp
+	}
+
+	p.OpenEphemeralCalled = true
+	p.OpenEphemeralRequest = r
+
+	if p.OpenEphemeralFn != nil {
+		return p.OpenEphemeralFn(r)
+	}
+
+	if p.OpenEphemeralResponse != nil {
+		resp = *p.OpenEphemeralResponse
+	}
+
+	return resp
+}
+
+func (p *MockProvider) RenewEphemeral(r providers.RenewEphemeralRequest) (resp providers.RenewEphemeralResponse) {
+	p.Lock()
+	defer p.Unlock()
+
+	if !p.ConfigureProviderCalled {
+		resp.Diagnostics = resp.Diagnostics.Append(fmt.Errorf("Configure not called before RenewEphemeral %q", r.TypeName))
+		return resp
+	}
+
+	p.RenewEphemeralCalled = true
+	p.RenewEphemeralRequest = r
+
+	if p.RenewEphemeralFn != nil {
+		return p.RenewEphemeralFn(r)
+	}
+
+	if p.RenewEphemeralResponse != nil {
+		resp = *p.RenewEphemeralResponse
+	}
+
+	return resp
+}
+
+func (p *MockProvider) CloseEphemeral(r providers.CloseEphemeralRequest) (resp providers.CloseEphemeralResponse) {
+	p.Lock()
+	defer p.Unlock()
+
+	if !p.ConfigureProviderCalled {
+		resp.Diagnostics = resp.Diagnostics.Append(fmt.Errorf("Configure not called before CloseEphemeral %q", r.TypeName))
+		return resp
+	}
+
+	p.CloseEphemeralCalled = true
+	p.CloseEphemeralRequest = r
+
+	if p.CloseEphemeralFn != nil {
+		return p.CloseEphemeralFn(r)
+	}
+
+	if p.CloseEphemeralResponse != nil {
+		resp = *p.CloseEphemeralResponse
 	}
 
 	return resp

--- a/internal/refactoring/mock_provider.go
+++ b/internal/refactoring/mock_provider.go
@@ -85,6 +85,18 @@ func (provider *mockProvider) ReadDataSource(providers.ReadDataSourceRequest) pr
 	panic("not implemented in mock")
 }
 
+func (provider *mockProvider) OpenEphemeral(providers.OpenEphemeralRequest) providers.OpenEphemeralResponse {
+	panic("not implemented in mock")
+}
+
+func (provider *mockProvider) RenewEphemeral(providers.RenewEphemeralRequest) providers.RenewEphemeralResponse {
+	panic("not implemented in mock")
+}
+
+func (provider *mockProvider) CloseEphemeral(providers.CloseEphemeralRequest) providers.CloseEphemeralResponse {
+	panic("not implemented in mock")
+}
+
 func (provider *mockProvider) CallFunction(providers.CallFunctionRequest) providers.CallFunctionResponse {
 	panic("not implemented in mock")
 }

--- a/internal/resources/ephemeral/ephemeral_resource_instance.go
+++ b/internal/resources/ephemeral/ephemeral_resource_instance.go
@@ -1,0 +1,31 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package ephemeral
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform/internal/providers"
+	"github.com/hashicorp/terraform/internal/tfdiags"
+)
+
+// ResourceInstance is an interface that must be implemented for each
+// active ephemeral resource instance to determine how it should be renewed
+// and eventually closed.
+type ResourceInstance interface {
+	// Renew attempts to extend the life of the remote object associated with
+	// this resource instance, optionally returning a new renewal request to be
+	// passed to a subsequent call to this method.
+	//
+	// If the object's life is not extended successfully then Renew returns
+	// error diagnostics explaining why not, and future requests that might
+	// have made use of the object will fail.
+	Renew(ctx context.Context, req providers.EphemeralRenew) (nextRenew *providers.EphemeralRenew, diags tfdiags.Diagnostics)
+
+	// Close proactively ends the life of the remote object associated with
+	// this resource instance, if possible. For example, if the remote object
+	// is a temporary lease for a dynamically-generated secret then this
+	// might end that lease and thus cause the secret to be promptly revoked.
+	Close(ctx context.Context) tfdiags.Diagnostics
+}

--- a/internal/resources/ephemeral/ephemeral_resources.go
+++ b/internal/resources/ephemeral/ephemeral_resources.go
@@ -1,0 +1,229 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package ephemeral
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/terraform/internal/addrs"
+	"github.com/hashicorp/terraform/internal/providers"
+	"github.com/hashicorp/terraform/internal/tfdiags"
+
+	"github.com/zclconf/go-cty/cty"
+)
+
+// Resources is a tracking structure for active instances of ephemeral
+// resources.
+//
+// The lifecycle of an ephemeral resource instance is quite different than
+// other resource modes because it's live for at most the duration of a single
+// graph walk, and because it might need periodic "renewing" in order to
+// remain live for the necessary duration.
+type Resources struct {
+	active addrs.Map[addrs.ConfigResource, addrs.Map[addrs.AbsResourceInstance, *resourceInstanceInternal]]
+	mu     sync.Mutex
+}
+
+func NewResources() *Resources {
+	return &Resources{
+		active: addrs.MakeMap[addrs.ConfigResource, addrs.Map[addrs.AbsResourceInstance, *resourceInstanceInternal]](),
+	}
+}
+
+type ResourceInstanceRegistration struct {
+	Value        cty.Value
+	ConfigBody   hcl.Body
+	Impl         ResourceInstance
+	FirstRenewal *providers.EphemeralRenew
+}
+
+func (r *Resources) RegisterInstance(ctx context.Context, addr addrs.AbsResourceInstance, reg ResourceInstanceRegistration) {
+	if addr.Resource.Resource.Mode != addrs.EphemeralResourceMode {
+		panic(fmt.Sprintf("can't register %s as an ephemeral resource instance", addr))
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	configAddr := addr.ConfigResource()
+	if !r.active.Has(configAddr) {
+		r.active.Put(configAddr, addrs.MakeMap[addrs.AbsResourceInstance, *resourceInstanceInternal]())
+	}
+	ri := &resourceInstanceInternal{
+		value:       reg.Value,
+		configBody:  reg.ConfigBody,
+		impl:        reg.Impl,
+		renewCancel: noopCancel,
+	}
+	if reg.FirstRenewal != nil {
+		ctx, cancel := context.WithCancel(ctx)
+		ri.renewCancel = cancel
+		go ri.handleRenewal(ctx, reg.FirstRenewal)
+	}
+	r.active.Get(configAddr).Put(addr, ri)
+}
+
+func (r *Resources) InstanceValue(addr addrs.AbsResourceInstance) (val cty.Value, live bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	configAddr := addr.ConfigResource()
+	insts, ok := r.active.GetOk(configAddr)
+	if !ok {
+		return cty.DynamicVal, false
+	}
+	inst, ok := insts.GetOk(addr)
+	if !ok {
+		return cty.DynamicVal, false
+	}
+	// If renewal has failed then we can't assume that the object is still
+	// live, but we can still return the original value regardless.
+	return inst.value, !inst.renewDiags.HasErrors()
+}
+
+// CloseInstances shuts down any live ephemeral resource instances that are
+// associated with the given resource address.
+//
+// This is the "happy path" way to shut down ephemeral resource instances,
+// intended to be called during the visit to a graph node that depends on
+// all other nodes that might make use of the instances of this ephemeral
+// resource.
+//
+// The runtime should also eventually call [Resources.Close] once the graph
+// walk is complete, to catch any stragglers that we didn't reach for
+// piecemeal shutdown, e.g. due to errors during the graph walk.
+func (r *Resources) CloseInstances(ctx context.Context, configAddr addrs.ConfigResource) tfdiags.Diagnostics {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	// TODO: Can we somehow avoid holding the lock for the entire duration?
+	// Closing an instance is likely to perform a network request, so this
+	// could potentially take a while and block other work from starting.
+
+	var diags tfdiags.Diagnostics
+	for _, elem := range r.active.Get(configAddr).Elems {
+		moreDiags := elem.Value.close(ctx)
+		diags = diags.Append(moreDiags.InConfigBody(elem.Value.configBody, elem.Key.String()))
+	}
+
+	// Stop tracking the objects we've just closed, so that we know we don't
+	// still need to close them.
+	r.active.Remove(configAddr)
+
+	return diags
+}
+
+// Close shuts down any ephemeral resource instances that are still running
+// at the time of the call.
+//
+// This is intended to catch any "stragglers" that we weren't able to clean
+// up during the graph walk, such as if an error prevents us from reaching
+// the cleanup node.
+func (r *Resources) Close(ctx context.Context) tfdiags.Diagnostics {
+	// FIXME: The following really ought to take into account dependency
+	// relationships between what's still running, because it's possible
+	// that one ephemeral resource depends on another ephemeral resource
+	// to operate correctly, such as if the HashiCorp Vault provider is
+	// accessing a secret lease through an SSH tunnel: closing the SSH tunnel
+	// before closing the Vault secret lease will make the Vault API
+	// unreachable.
+	//
+	// We'll just ignore that for now since this is just a prototype anyway.
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	// We might be closing due to a context cancellation, but we still need
+	// to be able to make non-canceled Close requests.
+	ctx = context.WithoutCancel(ctx)
+
+	var diags tfdiags.Diagnostics
+	for _, elem := range r.active.Elems {
+		for _, elem := range elem.Value.Elems {
+			moreDiags := elem.Value.close(ctx)
+			diags = diags.Append(moreDiags.InConfigBody(elem.Value.configBody, elem.Key.String()))
+		}
+	}
+	r.active = addrs.MakeMap[addrs.ConfigResource, addrs.Map[addrs.AbsResourceInstance, *resourceInstanceInternal]]()
+	return diags
+}
+
+type resourceInstanceInternal struct {
+	value      cty.Value
+	configBody hcl.Body
+	impl       ResourceInstance
+
+	renewCancel func()
+	renewDiags  tfdiags.Diagnostics
+	renewMu     sync.Mutex // hold when accessing renewCancel/renewDiags, and while actually renewing
+}
+
+// close halts this instance's asynchronous renewal loop, if any, and then
+// calls Close on the resource instance's implementation object.
+//
+// The returned diagnostics are contextual diagnostics that should have
+// [tfdiags.Diagnostics.WithConfigBody] called on them before returning to
+// a context-unaware caller.
+func (r *resourceInstanceInternal) close(ctx context.Context) tfdiags.Diagnostics {
+	var diags tfdiags.Diagnostics
+
+	// Stop renewing, if indeed we are. If we previously saw any errors during
+	// renewing then they finally get returned here, to be reported along with
+	// any errors during close.
+	r.renewMu.Lock()
+	r.renewCancel()
+	diags = diags.Append(r.renewDiags)
+	r.renewDiags = nil // just to avoid any risk of double-reporting
+	r.renewMu.Unlock()
+
+	// FIXME: If renewal failed earlier then it's pretty likely that closing
+	// would fail too. For now this is assuming that it's the provider's
+	// own responsibility to remember that it previously failed a renewal
+	// and to avoid returning redundant errors from close, but perhaps we'll
+	// revisit that in later work.
+	diags = diags.Append(r.impl.Close(context.WithoutCancel(ctx)))
+
+	return diags
+}
+
+func (r *resourceInstanceInternal) handleRenewal(ctx context.Context, firstRenewal *providers.EphemeralRenew) {
+	t := time.NewTimer(time.Until(firstRenewal.ExpireTime.Add(-60 * time.Second)))
+	nextRenew := firstRenewal
+	for {
+		select {
+		case <-t.C:
+			// It's time to renew
+			r.renewMu.Lock()
+			anotherRenew, diags := r.impl.Renew(ctx, *nextRenew)
+			r.renewDiags.Append(diags)
+			if diags.HasErrors() {
+				// If renewal fails then we'll stop trying to renew.
+				r.renewCancel = noopCancel
+				r.renewMu.Unlock()
+				return
+			}
+			if anotherRenew == nil {
+				// If we don't have another round of renew to do then we'll stop.
+				r.renewCancel = noopCancel
+				r.renewMu.Unlock()
+				return
+			}
+			nextRenew = anotherRenew
+			t.Reset(time.Until(anotherRenew.ExpireTime.Add(-60 * time.Second)))
+			r.renewMu.Unlock()
+		case <-ctx.Done():
+			// If we're cancelled then we'll halt renewing immediately.
+			r.renewMu.Lock()
+			t.Stop()
+			r.renewCancel = noopCancel
+			r.renewMu.Unlock()
+			return // we don't need to run this loop anymore
+		}
+	}
+}
+
+func noopCancel() {}

--- a/internal/stacks/stackruntime/internal/stackeval/stubs/errored.go
+++ b/internal/stacks/stackruntime/internal/stackeval/stubs/errored.go
@@ -124,6 +124,34 @@ func (p *ErroredProvider) ReadResource(req providers.ReadResourceRequest) provid
 	}
 }
 
+// OpenEphemeral implements providers.Interface.
+func (p *ErroredProvider) OpenEphemeral(providers.OpenEphemeralRequest) providers.OpenEphemeralResponse {
+	var diags tfdiags.Diagnostics
+	diags = diags.Append(tfdiags.AttributeValue(
+		tfdiags.Error,
+		"Provider configuration is invalid",
+		"Cannot open this ephemeral resource instance because its associated provider configuration is invalid.",
+		nil, // nil attribute path means the overall configuration block
+	))
+	return providers.OpenEphemeralResponse{
+		Diagnostics: diags,
+	}
+}
+
+// RenewEphemeral implements providers.Interface.
+func (p *ErroredProvider) RenewEphemeral(providers.RenewEphemeralRequest) providers.RenewEphemeralResponse {
+	// We don't have anything to do here because OpenEphemeral didn't really
+	// actually "open" anything.
+	return providers.RenewEphemeralResponse{}
+}
+
+// CloseEphemeral implements providers.Interface.
+func (p *ErroredProvider) CloseEphemeral(providers.CloseEphemeralRequest) providers.CloseEphemeralResponse {
+	// We don't have anything to do here because OpenEphemeral didn't really
+	// actually "open" anything.
+	return providers.CloseEphemeralResponse{}
+}
+
 // Stop implements providers.Interface.
 func (p *ErroredProvider) Stop() error {
 	// This stub provider never actually does any real work, so there's nothing

--- a/internal/stacks/stackruntime/internal/stackeval/stubs/unknown.go
+++ b/internal/stacks/stackruntime/internal/stackeval/stubs/unknown.go
@@ -222,6 +222,40 @@ func (u *unknownProvider) ReadDataSource(request providers.ReadDataSourceRequest
 	}
 }
 
+// OpenEphemeral implements providers.Interface.
+func (u *unknownProvider) OpenEphemeral(providers.OpenEphemeralRequest) providers.OpenEphemeralResponse {
+	// TODO: Once there's a definition for how deferred actions ought to work
+	// for ephemeral resource instances, make this report that this one needs
+	// to be deferred if the client announced that it supports deferral.
+	//
+	// For now this is just always an error, because ephemeral resources are
+	// just a prototype being developed concurrently with deferred actions.
+	var diags tfdiags.Diagnostics
+	diags = diags.Append(tfdiags.AttributeValue(
+		tfdiags.Error,
+		"Provider configuration is unknown",
+		"Cannot open this resource instance because its associated provider configuration is unknown.",
+		nil, // nil attribute path means the overall configuration block
+	))
+	return providers.OpenEphemeralResponse{
+		Diagnostics: diags,
+	}
+}
+
+// RenewEphemeral implements providers.Interface.
+func (u *unknownProvider) RenewEphemeral(providers.RenewEphemeralRequest) providers.RenewEphemeralResponse {
+	// We don't have anything to do here because OpenEphemeral didn't really
+	// actually "open" anything.
+	return providers.RenewEphemeralResponse{}
+}
+
+// CloseEphemeral implements providers.Interface.
+func (u *unknownProvider) CloseEphemeral(providers.CloseEphemeralRequest) providers.CloseEphemeralResponse {
+	// We don't have anything to do here because OpenEphemeral didn't really
+	// actually "open" anything.
+	return providers.CloseEphemeralResponse{}
+}
+
 func (u *unknownProvider) CallFunction(request providers.CallFunctionRequest) providers.CallFunctionResponse {
 	// This is offline functionality, so we can hand it off to the unconfigured
 	// client.

--- a/internal/states/statefile/version3_upgrade.go
+++ b/internal/states/statefile/version3_upgrade.go
@@ -91,6 +91,10 @@ func upgradeStateV3ToV4(old *stateV3) (*stateV4, error) {
 				case addrs.DataResourceMode:
 					modeStr = "data"
 				default:
+					// NOTE: the above cases intentionally cover only the subset
+					// of modes where mode.PersistsBetweenRounds() would return
+					// true, because it's a bug for any others to end up in the
+					// state.
 					return nil, fmt.Errorf("state contains resource %s with an unsupported resource mode %#v", resAddr, resAddr.Mode)
 				}
 

--- a/internal/states/statefile/version4.go
+++ b/internal/states/statefile/version4.go
@@ -68,6 +68,10 @@ func prepareStateV4(sV4 *stateV4) (*File, tfdiags.Diagnostics) {
 		case "data":
 			rAddr.Mode = addrs.DataResourceMode
 		default:
+			// NOTE: the above cases intentionally cover only the subset
+			// of modes where rAddr.Mode.PersistsBetweenRounds() would return
+			// true, because it's a bug for any others to end up in the
+			// state.
 			diags = diags.Append(tfdiags.Sourceless(
 				tfdiags.Error,
 				"Invalid resource mode in state",
@@ -368,6 +372,10 @@ func writeStateV4(file *File, w io.Writer) tfdiags.Diagnostics {
 			case addrs.DataResourceMode:
 				mode = "data"
 			default:
+				// NOTE: the above cases intentionally cover only the subset
+				// of modes where mode.PersistsBetweenRounds() would return
+				// true, because it's a bug for any others to end up in the
+				// state.
 				diags = diags.Append(tfdiags.Sourceless(
 					tfdiags.Error,
 					"Failed to serialize resource in state",

--- a/internal/states/sync.go
+++ b/internal/states/sync.go
@@ -150,6 +150,7 @@ func (s *SyncState) ResourceInstance(addr addrs.AbsResourceInstance) *ResourceIn
 // The return value is a pointer to a copy of the object, which the caller may
 // then freely access and mutate.
 func (s *SyncState) ResourceInstanceObject(addr addrs.AbsResourceInstance, dk DeposedKey) *ResourceInstanceObjectSrc {
+	assertPersistableResource(addr.Resource.Resource)
 	s.lock.RLock()
 	defer s.lock.RUnlock()
 
@@ -164,6 +165,7 @@ func (s *SyncState) ResourceInstanceObject(addr addrs.AbsResourceInstance, dk De
 // the given address, creating the containing module state and resource state
 // as a side-effect if not already present.
 func (s *SyncState) SetResourceProvider(addr addrs.AbsResource, provider addrs.AbsProviderConfig) {
+	assertPersistableResource(addr.Resource)
 	defer s.beginWrite()()
 
 	ms := s.state.EnsureModule(addr.Module)
@@ -176,6 +178,7 @@ func (s *SyncState) SetResourceProvider(addr addrs.AbsResource, provider addrs.A
 // but that is not enforced by this method. (Use RemoveResourceIfEmpty instead
 // to safely check first.)
 func (s *SyncState) RemoveResource(addr addrs.AbsResource) {
+	assertPersistableResource(addr.Resource)
 	defer s.beginWrite()()
 
 	ms := s.state.EnsureModule(addr.Module)
@@ -231,6 +234,7 @@ func (s *SyncState) RemoveResourceIfEmpty(addr addrs.AbsResource) bool {
 // If the containing module for this resource or the resource itself are not
 // already tracked in state then they will be added as a side-effect.
 func (s *SyncState) SetResourceInstanceCurrent(addr addrs.AbsResourceInstance, obj *ResourceInstanceObjectSrc, provider addrs.AbsProviderConfig) {
+	assertPersistableResource(addr.Resource.Resource)
 	defer s.beginWrite()()
 
 	ms := s.state.EnsureModule(addr.Module)
@@ -262,6 +266,7 @@ func (s *SyncState) SetResourceInstanceCurrent(addr addrs.AbsResourceInstance, o
 // If the containing module for this resource or the resource itself are not
 // already tracked in state then they will be added as a side-effect.
 func (s *SyncState) SetResourceInstanceDeposed(addr addrs.AbsResourceInstance, key DeposedKey, obj *ResourceInstanceObjectSrc, provider addrs.AbsProviderConfig) {
+	assertPersistableResource(addr.Resource.Resource)
 	defer s.beginWrite()()
 
 	ms := s.state.EnsureModule(addr.Module)
@@ -281,6 +286,7 @@ func (s *SyncState) SetResourceInstanceDeposed(addr addrs.AbsResourceInstance, k
 // given instance, and so NotDeposed will be returned without modifying the
 // state at all.
 func (s *SyncState) DeposeResourceInstanceObject(addr addrs.AbsResourceInstance) DeposedKey {
+	assertPersistableResource(addr.Resource.Resource)
 	defer s.beginWrite()()
 
 	ms := s.state.Module(addr.Module)
@@ -296,6 +302,7 @@ func (s *SyncState) DeposeResourceInstanceObject(addr addrs.AbsResourceInstance)
 // that there aren't any races to use a particular key; this method will panic
 // if the given key is already in use.
 func (s *SyncState) DeposeResourceInstanceObjectForceKey(addr addrs.AbsResourceInstance, forcedKey DeposedKey) {
+	assertPersistableResource(addr.Resource.Resource)
 	defer s.beginWrite()()
 
 	if forcedKey == NotDeposed {
@@ -314,6 +321,7 @@ func (s *SyncState) DeposeResourceInstanceObjectForceKey(addr addrs.AbsResourceI
 // ForgetResourceInstanceAll removes the record of all objects associated with
 // the specified resource instance, if present. If not present, this is a no-op.
 func (s *SyncState) ForgetResourceInstanceAll(addr addrs.AbsResourceInstance) {
+	assertPersistableResource(addr.Resource.Resource)
 	defer s.beginWrite()()
 
 	ms := s.state.Module(addr.Module)
@@ -327,6 +335,7 @@ func (s *SyncState) ForgetResourceInstanceAll(addr addrs.AbsResourceInstance) {
 // ForgetResourceInstanceDeposed removes the record of the deposed object with
 // the given address and key, if present. If not present, this is a no-op.
 func (s *SyncState) ForgetResourceInstanceDeposed(addr addrs.AbsResourceInstance, key DeposedKey) {
+	assertPersistableResource(addr.Resource.Resource)
 	defer s.beginWrite()()
 
 	ms := s.state.Module(addr.Module)
@@ -345,6 +354,7 @@ func (s *SyncState) ForgetResourceInstanceDeposed(addr addrs.AbsResourceInstance
 // Returns true if the object was restored to current, or false if no change
 // was made at all.
 func (s *SyncState) MaybeRestoreResourceInstanceDeposed(addr addrs.AbsResourceInstance, key DeposedKey) bool {
+	assertPersistableResource(addr.Resource.Resource)
 	defer s.beginWrite()()
 
 	if key == NotDeposed {
@@ -491,24 +501,32 @@ func (s *SyncState) maybePruneModule(addr addrs.ModuleInstance) {
 }
 
 func (s *SyncState) MoveAbsResource(src, dst addrs.AbsResource) {
+	assertPersistableResource(src.Resource)
+	assertPersistableResource(dst.Resource)
 	defer s.beginWrite()()
 
 	s.state.MoveAbsResource(src, dst)
 }
 
 func (s *SyncState) MaybeMoveAbsResource(src, dst addrs.AbsResource) bool {
+	assertPersistableResource(src.Resource)
+	assertPersistableResource(dst.Resource)
 	defer s.beginWrite()()
 
 	return s.state.MaybeMoveAbsResource(src, dst)
 }
 
 func (s *SyncState) MoveResourceInstance(src, dst addrs.AbsResourceInstance) {
+	assertPersistableResource(src.Resource.Resource)
+	assertPersistableResource(dst.Resource.Resource)
 	defer s.beginWrite()()
 
 	s.state.MoveAbsResourceInstance(src, dst)
 }
 
 func (s *SyncState) MaybeMoveResourceInstance(src, dst addrs.AbsResourceInstance) bool {
+	assertPersistableResource(src.Resource.Resource)
+	assertPersistableResource(dst.Resource.Resource)
 	defer s.beginWrite()()
 
 	return s.state.MaybeMoveAbsResourceInstance(src, dst)

--- a/internal/terraform/context_apply.go
+++ b/internal/terraform/context_apply.go
@@ -236,6 +236,7 @@ Note that the -target option is not suitable for routine use, and is provided on
 	// expressions, like in "terraform console" or the test harness.
 	evalScope := evalScopeFromGraphWalk(walker, addrs.RootModuleInstance)
 
+	diags = diags.Append(walker.Close())
 	return newState, evalScope, diags
 }
 

--- a/internal/terraform/context_eval.go
+++ b/internal/terraform/context_eval.go
@@ -103,7 +103,10 @@ func (c *Context) Eval(config *configs.Config, state *states.State, moduleAddr a
 		walker = c.graphWalker(graph, walkEval, walkOpts)
 	}
 
-	return evalScopeFromGraphWalk(walker, moduleAddr), diags
+	scope := evalScopeFromGraphWalk(walker, moduleAddr)
+
+	diags = diags.Append(walker.Close())
+	return scope, diags
 }
 
 // evalScopeFromGraphWalk takes a [ContextGraphWalker] that was already used

--- a/internal/terraform/context_plan.go
+++ b/internal/terraform/context_plan.go
@@ -825,6 +825,7 @@ func (c *Context) planWalk(config *configs.Config, prevRunState *states.State, o
 	// expressions, like in "terraform console" or the test harness.
 	evalScope := evalScopeFromGraphWalk(walker, addrs.RootModuleInstance)
 
+	diags = diags.Append(walker.Close())
 	return plan, evalScope, diags
 }
 

--- a/internal/terraform/context_validate.go
+++ b/internal/terraform/context_validate.go
@@ -116,9 +116,6 @@ func (c *Context) Validate(config *configs.Config, opts *ValidateOpts) tfdiags.D
 	})
 	diags = diags.Append(walker.NonFatalDiagnostics)
 	diags = diags.Append(walkDiags)
-	if walkDiags.HasErrors() {
-		return diags
-	}
-
+	diags = diags.Append(walker.Close())
 	return diags
 }

--- a/internal/terraform/context_walk.go
+++ b/internal/terraform/context_walk.go
@@ -17,6 +17,7 @@ import (
 	"github.com/hashicorp/terraform/internal/plans/deferring"
 	"github.com/hashicorp/terraform/internal/providers"
 	"github.com/hashicorp/terraform/internal/refactoring"
+	"github.com/hashicorp/terraform/internal/resources/ephemeral"
 	"github.com/hashicorp/terraform/internal/states"
 	"github.com/hashicorp/terraform/internal/tfdiags"
 )
@@ -184,6 +185,7 @@ func (c *Context) graphWalker(graph *Graph, operation walkOperation, opts *graph
 		NamedValues:             namedvals.NewState(),
 		Deferrals:               deferred,
 		Checks:                  checkState,
+		EphemeralResources:      ephemeral.NewResources(),
 		InstanceExpander:        instances.NewExpander(opts.Overrides),
 		ExternalProviderConfigs: opts.ExternalProviderConfigs,
 		MoveResults:             opts.MoveResults,

--- a/internal/terraform/eval_context.go
+++ b/internal/terraform/eval_context.go
@@ -21,6 +21,7 @@ import (
 	"github.com/hashicorp/terraform/internal/providers"
 	"github.com/hashicorp/terraform/internal/provisioners"
 	"github.com/hashicorp/terraform/internal/refactoring"
+	"github.com/hashicorp/terraform/internal/resources/ephemeral"
 	"github.com/hashicorp/terraform/internal/states"
 	"github.com/hashicorp/terraform/internal/tfdiags"
 )
@@ -168,6 +169,10 @@ type EvalContext interface {
 	// updated only so that object data conforms to current schemas for
 	// meaningful comparison with RefreshState.
 	PrevRunState() *states.SyncState
+
+	// EphemeralResources returns a helper object for tracking active
+	// instances of ephemeral resources declared in the configuration.
+	EphemeralResources() *ephemeral.Resources
 
 	// InstanceExpander returns a helper object for tracking the expansion of
 	// graph nodes during the plan phase in response to "count" and "for_each"

--- a/internal/terraform/eval_context_builtin.go
+++ b/internal/terraform/eval_context_builtin.go
@@ -27,6 +27,7 @@ import (
 	"github.com/hashicorp/terraform/internal/providers"
 	"github.com/hashicorp/terraform/internal/provisioners"
 	"github.com/hashicorp/terraform/internal/refactoring"
+	"github.com/hashicorp/terraform/internal/resources/ephemeral"
 	"github.com/hashicorp/terraform/internal/states"
 	"github.com/hashicorp/terraform/internal/tfdiags"
 	"github.com/hashicorp/terraform/version"
@@ -68,23 +69,24 @@ type BuiltinEvalContext struct {
 	// DeferralsValue is the object returned by [BuiltinEvalContext.Deferrals].
 	DeferralsValue *deferring.Deferred
 
-	Hooks                 []Hook
-	InputValue            UIInput
-	ProviderCache         map[string]providers.Interface
-	ProviderFuncCache     map[string]providers.Interface
-	ProviderFuncResults   *providers.FunctionResults
-	ProviderInputConfig   map[string]map[string]cty.Value
-	ProviderLock          *sync.Mutex
-	ProvisionerCache      map[string]provisioners.Interface
-	ProvisionerLock       *sync.Mutex
-	ChangesValue          *plans.ChangesSync
-	StateValue            *states.SyncState
-	ChecksValue           *checks.State
-	RefreshStateValue     *states.SyncState
-	PrevRunStateValue     *states.SyncState
-	InstanceExpanderValue *instances.Expander
-	MoveResultsValue      refactoring.MoveResults
-	OverrideValues        *mocking.Overrides
+	Hooks                   []Hook
+	InputValue              UIInput
+	ProviderCache           map[string]providers.Interface
+	ProviderFuncCache       map[string]providers.Interface
+	ProviderFuncResults     *providers.FunctionResults
+	ProviderInputConfig     map[string]map[string]cty.Value
+	ProviderLock            *sync.Mutex
+	ProvisionerCache        map[string]provisioners.Interface
+	ProvisionerLock         *sync.Mutex
+	ChangesValue            *plans.ChangesSync
+	StateValue              *states.SyncState
+	ChecksValue             *checks.State
+	RefreshStateValue       *states.SyncState
+	PrevRunStateValue       *states.SyncState
+	EphemeralResourcesValue *ephemeral.Resources
+	InstanceExpanderValue   *instances.Expander
+	MoveResultsValue        refactoring.MoveResults
+	OverrideValues          *mocking.Overrides
 }
 
 // BuiltinEvalContext implements EvalContext
@@ -610,6 +612,10 @@ func (ctx *BuiltinEvalContext) RefreshState() *states.SyncState {
 
 func (ctx *BuiltinEvalContext) PrevRunState() *states.SyncState {
 	return ctx.PrevRunStateValue
+}
+
+func (ctx *BuiltinEvalContext) EphemeralResources() *ephemeral.Resources {
+	return ctx.EphemeralResourcesValue
 }
 
 func (ctx *BuiltinEvalContext) InstanceExpander() *instances.Expander {

--- a/internal/terraform/eval_context_mock.go
+++ b/internal/terraform/eval_context_mock.go
@@ -23,6 +23,7 @@ import (
 	"github.com/hashicorp/terraform/internal/providers"
 	"github.com/hashicorp/terraform/internal/provisioners"
 	"github.com/hashicorp/terraform/internal/refactoring"
+	"github.com/hashicorp/terraform/internal/resources/ephemeral"
 	"github.com/hashicorp/terraform/internal/states"
 	"github.com/hashicorp/terraform/internal/tfdiags"
 )
@@ -146,6 +147,9 @@ type MockEvalContext struct {
 
 	MoveResultsCalled  bool
 	MoveResultsResults refactoring.MoveResults
+
+	EphemeralResourcesCalled    bool
+	EphemeralResourcesResources *ephemeral.Resources
 
 	InstanceExpanderCalled   bool
 	InstanceExpanderExpander *instances.Expander
@@ -391,6 +395,11 @@ func (c *MockEvalContext) PrevRunState() *states.SyncState {
 func (c *MockEvalContext) MoveResults() refactoring.MoveResults {
 	c.MoveResultsCalled = true
 	return c.MoveResultsResults
+}
+
+func (c *MockEvalContext) EphemeralResources() *ephemeral.Resources {
+	c.EphemeralResourcesCalled = true
+	return c.EphemeralResourcesResources
 }
 
 func (c *MockEvalContext) InstanceExpander() *instances.Expander {

--- a/internal/terraform/evaluate_valid.go
+++ b/internal/terraform/evaluate_valid.go
@@ -197,11 +197,15 @@ func staticValidateResourceReference(modCfg *configs.Config, addr addrs.Resource
 	var diags tfdiags.Diagnostics
 
 	var modeAdjective string
+	modeArticleUpper := "A"
 	switch addr.Mode {
 	case addrs.ManagedResourceMode:
 		modeAdjective = "managed"
 	case addrs.DataResourceMode:
 		modeAdjective = "data"
+	case addrs.EphemeralResourceMode:
+		modeAdjective = "ephemeral"
+		modeArticleUpper = "An"
 	default:
 		// should never happen
 		modeAdjective = "<invalid-mode>"
@@ -223,8 +227,14 @@ func staticValidateResourceReference(modCfg *configs.Config, addr addrs.Resource
 		diags = diags.Append(&hcl.Diagnostic{
 			Severity: hcl.DiagError,
 			Summary:  `Reference to undeclared resource`,
-			Detail:   fmt.Sprintf(`A %s resource %q %q has not been declared in %s.%s`, modeAdjective, addr.Type, addr.Name, moduleConfigDisplayAddr(modCfg.Path), suggestion),
-			Subject:  rng.ToHCL().Ptr(),
+			Detail: fmt.Sprintf(
+				`%s %s resource %q %q has not been declared in %s.%s`,
+				modeArticleUpper, modeAdjective,
+				addr.Type, addr.Name,
+				moduleConfigDisplayAddr(modCfg.Path),
+				suggestion,
+			),
+			Subject: rng.ToHCL().Ptr(),
 		})
 		return diags
 	}
@@ -259,8 +269,13 @@ func staticValidateResourceReference(modCfg *configs.Config, addr addrs.Resource
 		diags = diags.Append(&hcl.Diagnostic{
 			Severity: hcl.DiagError,
 			Summary:  `Invalid resource type`,
-			Detail:   fmt.Sprintf(`A %s resource type %q is not supported by provider %q.`, modeAdjective, addr.Type, providerFqn.String()),
-			Subject:  rng.ToHCL().Ptr(),
+			Detail: fmt.Sprintf(
+				`%s %s resource type %q is not supported by provider %q.`,
+				modeArticleUpper, modeAdjective,
+				addr.Type,
+				providerFqn.String(),
+			),
+			Subject: rng.ToHCL().Ptr(),
 		})
 		return diags
 	}

--- a/internal/terraform/evaluate_valid_test.go
+++ b/internal/terraform/evaluate_valid_test.go
@@ -75,6 +75,14 @@ For example, to correlate with indices of a referring resource, use:
 			WantErr: `Reference to scoped resource: The referenced data resource "boop_data" "boop_nested" is not available from this context.`,
 		},
 		{
+			Ref:     "ephemeral.beep.boop",
+			WantErr: ``,
+		},
+		{
+			Ref:     "ephemeral.beep.nonexistant",
+			WantErr: `Reference to undeclared resource: An ephemeral resource "beep" "nonexistant" has not been declared in the root module.`,
+		},
+		{
 			Ref:     "data.boop_data.boop_nested",
 			WantErr: ``,
 			Src:     addrs.Check{Name: "foo"},
@@ -117,6 +125,11 @@ For example, to correlate with indices of a referring resource, use:
 								},
 							},
 						},
+					},
+				},
+				EphemeralResourceTypes: map[string]providers.Schema{
+					"beep": {
+						Block: &configschema.Block{},
 					},
 				},
 			},

--- a/internal/terraform/graph_builder_apply.go
+++ b/internal/terraform/graph_builder_apply.go
@@ -219,6 +219,10 @@ func (b *ApplyGraphBuilder) Steps() []GraphTransformer {
 		// Close opened plugin connections
 		&CloseProviderTransformer{},
 
+		// Close any ephemeral resource instances and prune nodes for
+		// ephemeral resources that aren't being consumed by anything.
+		&ephemeralResourceCloseTransformer{op: walkApply},
+
 		// close the root module
 		&CloseRootModuleTransformer{},
 

--- a/internal/terraform/graph_walk.go
+++ b/internal/terraform/graph_walk.go
@@ -14,6 +14,7 @@ type GraphWalker interface {
 	enterScope(evalContextScope) EvalContext
 	exitScope(evalContextScope)
 	Execute(EvalContext, GraphNodeExecutable) tfdiags.Diagnostics
+	Close() tfdiags.Diagnostics
 }
 
 // NullGraphWalker is a GraphWalker implementation that does nothing.
@@ -25,3 +26,4 @@ func (NullGraphWalker) EvalContext() EvalContext                                
 func (NullGraphWalker) enterScope(evalContextScope) EvalContext                      { return new(MockEvalContext) }
 func (NullGraphWalker) exitScope(evalContextScope)                                   {}
 func (NullGraphWalker) Execute(EvalContext, GraphNodeExecutable) tfdiags.Diagnostics { return nil }
+func (NullGraphWalker) Close() tfdiags.Diagnostics                                   { return nil }

--- a/internal/terraform/graph_walk_context.go
+++ b/internal/terraform/graph_walk_context.go
@@ -97,16 +97,17 @@ func (w *ContextGraphWalker) EvalContext() EvalContext {
 	// so that we can safely run multiple evaluations at once across
 	// different modules.
 	evaluator := &Evaluator{
-		Meta:          w.Context.meta,
-		Config:        w.Config,
-		Operation:     w.Operation,
-		State:         w.State,
-		Changes:       w.Changes,
-		Plugins:       w.Context.plugins,
-		Instances:     w.InstanceExpander,
-		NamedValues:   w.NamedValues,
-		Deferrals:     w.Deferrals,
-		PlanTimestamp: w.PlanTimestamp,
+		Meta:               w.Context.meta,
+		Config:             w.Config,
+		Operation:          w.Operation,
+		State:              w.State,
+		Changes:            w.Changes,
+		Plugins:            w.Context.plugins,
+		Instances:          w.InstanceExpander,
+		EphemeralResources: w.EphemeralResources,
+		NamedValues:        w.NamedValues,
+		Deferrals:          w.Deferrals,
+		PlanTimestamp:      w.PlanTimestamp,
 	}
 
 	ctx := &BuiltinEvalContext{

--- a/internal/terraform/graph_walk_context.go
+++ b/internal/terraform/graph_walk_context.go
@@ -155,3 +155,15 @@ func (w *ContextGraphWalker) Execute(ctx EvalContext, n GraphNodeExecutable) tfd
 
 	return n.Execute(ctx, w.Operation)
 }
+
+func (w *ContextGraphWalker) Close() tfdiags.Diagnostics {
+	var diags tfdiags.Diagnostics
+	if er := w.EphemeralResources; er != nil {
+		// FIXME: The graph walk bits all long predate Go's context.Context
+		// and so we don't have a general ambient context.Context for the
+		// overall operation. Hopefully one day we do, and then it could
+		// be passed in here.
+		diags = diags.Append(er.Close(context.TODO()))
+	}
+	return diags
+}

--- a/internal/terraform/node_output.go
+++ b/internal/terraform/node_output.go
@@ -46,13 +46,12 @@ type nodeExpandOutput struct {
 }
 
 var (
-	_ GraphNodeReferenceable             = (*nodeExpandOutput)(nil)
-	_ GraphNodeReferencer                = (*nodeExpandOutput)(nil)
-	_ GraphNodeReferenceOutside          = (*nodeExpandOutput)(nil)
-	_ GraphNodeDynamicExpandable         = (*nodeExpandOutput)(nil)
-	_ graphNodeTemporaryValue            = (*nodeExpandOutput)(nil)
-	_ graphNodeExpandsInstances          = (*nodeExpandOutput)(nil)
-	_ graphNodeEphemeralResourceConsumer = (*nodeExpandOutput)(nil)
+	_ GraphNodeReferenceable     = (*nodeExpandOutput)(nil)
+	_ GraphNodeReferencer        = (*nodeExpandOutput)(nil)
+	_ GraphNodeReferenceOutside  = (*nodeExpandOutput)(nil)
+	_ GraphNodeDynamicExpandable = (*nodeExpandOutput)(nil)
+	_ graphNodeTemporaryValue    = (*nodeExpandOutput)(nil)
+	_ graphNodeExpandsInstances  = (*nodeExpandOutput)(nil)
 )
 
 func (n *nodeExpandOutput) expandsInstances() {}
@@ -212,13 +211,6 @@ func (n *nodeExpandOutput) References() []*addrs.Reference {
 	}
 
 	return referencesForOutput(n.Config)
-}
-
-// requiredEphemeralResources implements graphNodeEphemeralResourceConsumer.
-func (n *nodeExpandOutput) requiredEphemeralResources(op walkOperation) addrs.Set[addrs.ConfigResource] {
-	// The consumed ephemeral resources are defined entirely by expression
-	// references.
-	return requiredEphemeralResourcesForReferencer(n)
 }
 
 func (n *nodeExpandOutput) getOverrideValue(inst addrs.ModuleInstance) cty.Value {

--- a/internal/terraform/node_output.go
+++ b/internal/terraform/node_output.go
@@ -46,12 +46,13 @@ type nodeExpandOutput struct {
 }
 
 var (
-	_ GraphNodeReferenceable     = (*nodeExpandOutput)(nil)
-	_ GraphNodeReferencer        = (*nodeExpandOutput)(nil)
-	_ GraphNodeReferenceOutside  = (*nodeExpandOutput)(nil)
-	_ GraphNodeDynamicExpandable = (*nodeExpandOutput)(nil)
-	_ graphNodeTemporaryValue    = (*nodeExpandOutput)(nil)
-	_ graphNodeExpandsInstances  = (*nodeExpandOutput)(nil)
+	_ GraphNodeReferenceable             = (*nodeExpandOutput)(nil)
+	_ GraphNodeReferencer                = (*nodeExpandOutput)(nil)
+	_ GraphNodeReferenceOutside          = (*nodeExpandOutput)(nil)
+	_ GraphNodeDynamicExpandable         = (*nodeExpandOutput)(nil)
+	_ graphNodeTemporaryValue            = (*nodeExpandOutput)(nil)
+	_ graphNodeExpandsInstances          = (*nodeExpandOutput)(nil)
+	_ graphNodeEphemeralResourceConsumer = (*nodeExpandOutput)(nil)
 )
 
 func (n *nodeExpandOutput) expandsInstances() {}
@@ -211,6 +212,13 @@ func (n *nodeExpandOutput) References() []*addrs.Reference {
 	}
 
 	return referencesForOutput(n.Config)
+}
+
+// requiredEphemeralResources implements graphNodeEphemeralResourceConsumer.
+func (n *nodeExpandOutput) requiredEphemeralResources(op walkOperation) addrs.Set[addrs.ConfigResource] {
+	// The consumed ephemeral resources are defined entirely by expression
+	// references.
+	return requiredEphemeralResourcesForReferencer(n)
 }
 
 func (n *nodeExpandOutput) getOverrideValue(inst addrs.ModuleInstance) cty.Value {

--- a/internal/terraform/node_resource_ephemeral.go
+++ b/internal/terraform/node_resource_ephemeral.go
@@ -4,8 +4,125 @@
 package terraform
 
 import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/zclconf/go-cty/cty"
+
 	"github.com/hashicorp/terraform/internal/addrs"
+	"github.com/hashicorp/terraform/internal/configs"
+	"github.com/hashicorp/terraform/internal/lang/marks"
+	"github.com/hashicorp/terraform/internal/plans/objchange"
+	"github.com/hashicorp/terraform/internal/providers"
+	"github.com/hashicorp/terraform/internal/resources/ephemeral"
+	"github.com/hashicorp/terraform/internal/tfdiags"
 )
+
+type ephemeralResourceInput struct {
+	addr           addrs.AbsResourceInstance
+	config         *configs.Resource
+	providerConfig addrs.AbsProviderConfig
+}
+
+// ephemeralResourceOpen implements the "open" step of the ephemeral resource
+// instance lifecycle, which behaves the same way in both the plan and apply
+// walks.
+func ephemeralResourceOpen(ctx EvalContext, inp ephemeralResourceInput) tfdiags.Diagnostics {
+	log.Printf("[TRACE] ephemeralResourceOpen: opening %s", inp.addr)
+	var diags tfdiags.Diagnostics
+
+	provider, providerSchema, err := getProvider(ctx, inp.providerConfig)
+	if err != nil {
+		diags = diags.Append(err)
+		return diags
+	}
+
+	config := inp.config
+	schema, _ := providerSchema.SchemaForResourceAddr(inp.addr.ContainingResource().Resource)
+	if schema == nil {
+		// Should be caught during validation, so we don't bother with a pretty error here
+		diags = diags.Append(
+			fmt.Errorf("provider %q does not support data source %q",
+				inp.providerConfig, inp.addr.ContainingResource().Resource.Type,
+			),
+		)
+		return diags
+	}
+
+	resources := ctx.EphemeralResources()
+	allInsts := ctx.InstanceExpander()
+	keyData := allInsts.GetResourceInstanceRepetitionData(inp.addr)
+
+	checkDiags := evalCheckRules(
+		addrs.ResourcePrecondition,
+		config.Preconditions,
+		ctx, inp.addr, keyData,
+		tfdiags.Error,
+	)
+	diags = diags.Append(checkDiags)
+	if diags.HasErrors() {
+		return diags // failed preconditions prevent further evaluation
+	}
+
+	configVal, _, configDiags := ctx.EvaluateBlock(config.Config, schema, nil, keyData)
+	diags = diags.Append(configDiags)
+	if diags.HasErrors() {
+		return diags
+	}
+	unmarkedConfigVal, configMarks := configVal.UnmarkDeepWithPaths()
+
+	// TODO: Call provider.ValidateEphemeralConfig, once such a thing exists.
+	// For prototype we'll just let OpenEphemeral be the first line of validation.
+
+	resp := provider.OpenEphemeral(providers.OpenEphemeralRequest{
+		TypeName: inp.addr.ContainingResource().Resource.Type,
+		Config:   unmarkedConfigVal,
+	})
+	if resp.Deferred != nil {
+		// FIXME: Actually implement this. (Skipped for prototype only because
+		// deferred changes is under development concurrently with this
+		// prototype, and so don't want to conflict.)
+		diags = diags.Append(fmt.Errorf("don't support deferral of ephemeral resource instances yet"))
+	}
+	diags = diags.Append(resp.Diagnostics.InConfigBody(config.Config, inp.addr.String()))
+	if diags.HasErrors() {
+		return diags
+	}
+	resultVal := resp.Result.MarkWithPaths(configMarks)
+
+	errs := objchange.AssertPlanValid(schema, cty.NullVal(schema.ImpliedType()), configVal, resultVal)
+	for _, err := range errs {
+		// FIXME: Should turn these errors into suitable diagnostics.
+		diags = diags.Append(err)
+	}
+	if diags.HasErrors() {
+		return diags
+	}
+
+	// FIXME: Ideally anything that was set in the configuration to a
+	// non-ephemeral value should remain non-ephemeral in the result. For
+	// the sake of initial prototyping though, we'll just make the entire
+	// object ephemeral.
+	resultVal = resultVal.Mark(marks.Ephemeral)
+
+	impl := &ephemeralResourceInstImpl{
+		addr:      inp.addr,
+		provider:  provider,
+		closeData: resp.InternalContext,
+	}
+	// TODO: What can we use as a signal to cancel the context we're passing
+	// in here, so that the object will stop renewing things when we start
+	// shutting down?
+	resources.RegisterInstance(context.TODO(), inp.addr, ephemeral.ResourceInstanceRegistration{
+		Value:        resultVal,
+		ConfigBody:   config.Config,
+		Impl:         impl,
+		FirstRenewal: resp.Renew,
+	})
+
+	return diags
+}
 
 // nodeEphemeralResourceClose is the node type for closing the previously-opened
 // instances of a particular ephemeral resource.
@@ -24,6 +141,51 @@ type nodeEphemeralResourceClose struct {
 	addr addrs.ConfigResource
 }
 
+var _ GraphNodeExecutable = (*nodeEphemeralResourceClose)(nil)
+var _ GraphNodeModulePath = (*nodeEphemeralResourceClose)(nil)
+
 func (n *nodeEphemeralResourceClose) Name() string {
 	return n.addr.String() + " (close)"
+}
+
+// ModulePath implements GraphNodeModulePath.
+func (n *nodeEphemeralResourceClose) ModulePath() addrs.Module {
+	return n.addr.Module
+}
+
+// Execute implements GraphNodeExecutable.
+func (n *nodeEphemeralResourceClose) Execute(ctx EvalContext, op walkOperation) tfdiags.Diagnostics {
+	log.Printf("[TRACE] nodeEphemeralResourceClose: closing all instances of %s", n.addr)
+	resources := ctx.EphemeralResources()
+	return resources.CloseInstances(context.TODO(), n.addr)
+}
+
+// ephemeralResourceInstImpl implements ephemeral.ResourceInstance as an
+// adapter to the relevant provider API calls.
+type ephemeralResourceInstImpl struct {
+	addr      addrs.AbsResourceInstance
+	provider  providers.Interface
+	closeData []byte
+}
+
+var _ ephemeral.ResourceInstance = (*ephemeralResourceInstImpl)(nil)
+
+// Close implements ephemeral.ResourceInstance.
+func (impl *ephemeralResourceInstImpl) Close(ctx context.Context) tfdiags.Diagnostics {
+	log.Printf("[TRACE] ephemeralResourceInstImpl: closing %s", impl.addr)
+	resp := impl.provider.CloseEphemeral(providers.CloseEphemeralRequest{
+		TypeName:        impl.addr.Resource.Resource.Type,
+		InternalContext: impl.closeData,
+	})
+	return resp.Diagnostics
+}
+
+// Renew implements ephemeral.ResourceInstance.
+func (impl *ephemeralResourceInstImpl) Renew(ctx context.Context, req providers.EphemeralRenew) (nextRenew *providers.EphemeralRenew, diags tfdiags.Diagnostics) {
+	log.Printf("[TRACE] ephemeralResourceInstImpl: renewing %s", impl.addr)
+	resp := impl.provider.RenewEphemeral(providers.RenewEphemeralRequest{
+		TypeName:        impl.addr.Resource.Resource.Type,
+		InternalContext: req.InternalContext,
+	})
+	return resp.RenewAgain, resp.Diagnostics
 }

--- a/internal/terraform/node_resource_ephemeral.go
+++ b/internal/terraform/node_resource_ephemeral.go
@@ -1,0 +1,29 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package terraform
+
+import (
+	"github.com/hashicorp/terraform/internal/addrs"
+)
+
+// nodeEphemeralResourceClose is the node type for closing the previously-opened
+// instances of a particular ephemeral resource.
+//
+// Although ephemeral resource instances will always all get closed once a
+// graph walk has completed anyway, the inclusion of explicit nodes for this
+// allows closing ephemeral resource instances more promptly after all work
+// that uses them has been completed, rather than always just waiting until
+// the end of the graph walk.
+//
+// This is scoped to config-level resources rather than dynamic resource
+// instances as a concession to allow using the same node type in both the plan
+// and apply graphs, where the former only deals in whole resources while the
+// latter contains individual instances.
+type nodeEphemeralResourceClose struct {
+	addr addrs.ConfigResource
+}
+
+func (n *nodeEphemeralResourceClose) Name() string {
+	return n.addr.String() + " (close)"
+}

--- a/internal/terraform/node_resource_ephemeral.go
+++ b/internal/terraform/node_resource_ephemeral.go
@@ -93,8 +93,16 @@ func ephemeralResourceOpen(ctx EvalContext, inp ephemeralResourceInput) tfdiags.
 
 	errs := objchange.AssertPlanValid(schema, cty.NullVal(schema.ImpliedType()), configVal, resultVal)
 	for _, err := range errs {
-		// FIXME: Should turn these errors into suitable diagnostics.
-		diags = diags.Append(err)
+		diags = diags.Append(tfdiags.AttributeValue(
+			tfdiags.Error,
+			"Provider produced invalid ephemeral resource instance",
+			fmt.Sprintf(
+				"The provider for %s produced an inconsistent result: %s.",
+				inp.addr.Resource.Resource.Type,
+				tfdiags.FormatError(err),
+			),
+			nil,
+		)).InConfigBody(config.Config, inp.addr.String())
 	}
 	if diags.HasErrors() {
 		return diags

--- a/internal/terraform/node_resource_plan.go
+++ b/internal/terraform/node_resource_plan.go
@@ -295,18 +295,20 @@ func (n *nodeExpandPlannableResource) dynamicExpand(ctx EvalContext, moduleInsta
 	state := ctx.State().Lock()
 
 	var orphans []*states.Resource
-	for _, res := range state.Resources(n.Addr) {
-		found := false
-		for _, m := range moduleInstances {
-			if m.Equal(res.Addr.Module) {
-				found = true
-				break
+	if n.Addr.Resource.Mode.PersistsBetweenRounds() { // only persisted resources can have "orphans"
+		for _, res := range state.Resources(n.Addr) {
+			found := false
+			for _, m := range moduleInstances {
+				if m.Equal(res.Addr.Module) {
+					found = true
+					break
+				}
 			}
-		}
-		// The module instance of the resource in the state doesn't exist
-		// in the current config, so this whole resource is orphaned.
-		if !found {
-			orphans = append(orphans, res)
+			// The module instance of the resource in the state doesn't exist
+			// in the current config, so this whole resource is orphaned.
+			if !found {
+				orphans = append(orphans, res)
+			}
 		}
 	}
 

--- a/internal/terraform/node_resource_plan_instance.go
+++ b/internal/terraform/node_resource_plan_instance.go
@@ -508,20 +508,11 @@ func (n *NodePlannableResourceInstance) managedResourceExecute(ctx EvalContext) 
 }
 
 func (n *NodePlannableResourceInstance) ephemeralResourceExecute(ctx EvalContext) (diags tfdiags.Diagnostics) {
-	config := n.Config
-	addr := n.ResourceInstanceAddr()
-	var diagRng *hcl.Range
-	if config != nil {
-		diagRng = config.DeclRange.Ptr()
-	}
-
-	diags = diags.Append(&hcl.Diagnostic{
-		Severity: hcl.DiagError,
-		Summary:  "Ephemeral resources not yet supported",
-		Detail:   fmt.Sprintf("There is not yet any implementation of planning for %s.", addr),
-		Subject:  diagRng,
+	return ephemeralResourceOpen(ctx, ephemeralResourceInput{
+		addr:           n.Addr,
+		config:         n.Config,
+		providerConfig: n.ResolvedProvider,
 	})
-	return diags
 }
 
 // replaceTriggered checks if this instance needs to be replace due to a change

--- a/internal/terraform/node_resource_plan_instance.go
+++ b/internal/terraform/node_resource_plan_instance.go
@@ -76,6 +76,8 @@ func (n *NodePlannableResourceInstance) Execute(ctx EvalContext, op walkOperatio
 		return n.managedResourceExecute(ctx)
 	case addrs.DataResourceMode:
 		return n.dataResourceExecute(ctx)
+	case addrs.EphemeralResourceMode:
+		return n.ephemeralResourceExecute(ctx)
 	default:
 		panic(fmt.Errorf("unsupported resource mode %s", n.Config.Mode))
 	}
@@ -502,6 +504,23 @@ func (n *NodePlannableResourceInstance) managedResourceExecute(ctx EvalContext) 
 		}
 	}
 
+	return diags
+}
+
+func (n *NodePlannableResourceInstance) ephemeralResourceExecute(ctx EvalContext) (diags tfdiags.Diagnostics) {
+	config := n.Config
+	addr := n.ResourceInstanceAddr()
+	var diagRng *hcl.Range
+	if config != nil {
+		diagRng = config.DeclRange.Ptr()
+	}
+
+	diags = diags.Append(&hcl.Diagnostic{
+		Severity: hcl.DiagError,
+		Summary:  "Ephemeral resources not yet supported",
+		Detail:   fmt.Sprintf("There is not yet any implementation of planning for %s.", addr),
+		Subject:  diagRng,
+	})
 	return diags
 }
 

--- a/internal/terraform/node_resource_validate.go
+++ b/internal/terraform/node_resource_validate.go
@@ -613,6 +613,9 @@ func validateResourceForbiddenEphemeralValues(ctx EvalContext, value cty.Value, 
 		diags = diags.Append(tfdiags.AttributeValue(
 			tfdiags.Error,
 			"Invalid use of ephemeral value",
+			// FIXME: This message should differ if the referrer is a data
+			// resource. In that case the reason is "because data resource
+			// instances must persist from plan to apply".
 			"Ephemeral values are not valid in resource arguments, because resource instances must persist between Terraform phases.",
 			path,
 		))

--- a/internal/terraform/testdata/static-validate-refs/static-validate-refs.tf
+++ b/internal/terraform/testdata/static-validate-refs/static-validate-refs.tf
@@ -4,6 +4,10 @@ terraform {
       source = "foobar/beep" # intentional mismatch between local name and type
     }
   }
+  # TODO: Remove this if ephemeral values / resources get stabilized. If this
+  # experiment is removed without stabilization, also remove the
+  # "ephemeral" block below and the test cases it's supporting.
+  experiments = [ephemeral_values]
 }
 
 resource "aws_instance" "no_count" {
@@ -20,6 +24,10 @@ resource "boop_whatever" "nope" {
 }
 
 data "beep" "boop" {
+}
+
+ephemeral "beep" "boop" {
+  provider = boop
 }
 
 check "foo" {

--- a/internal/terraform/transform_attach_state.go
+++ b/internal/terraform/transform_attach_state.go
@@ -46,6 +46,10 @@ func (t *AttachStateTransformer) Transform(g *Graph) error {
 			continue
 		}
 		addr := an.ResourceInstanceAddr()
+		if !addr.Resource.Resource.Mode.PersistsBetweenRounds() {
+			// Non-persisting resources never have any state to attach.
+			continue
+		}
 
 		rs := t.State.Resource(addr.ContainingResource())
 		if rs == nil {

--- a/internal/terraform/transform_config.go
+++ b/internal/terraform/transform_config.go
@@ -96,11 +96,14 @@ func (t *ConfigTransformer) transformSingle(g *Graph, config *configs.Config) er
 	module := config.Module
 	log.Printf("[TRACE] ConfigTransformer: Starting for path: %v", path)
 
-	allResources := make([]*configs.Resource, 0, len(module.ManagedResources)+len(module.DataResources))
+	allResources := make([]*configs.Resource, 0, len(module.ManagedResources)+len(module.DataResources)+len(module.EphemeralResources))
 	for _, r := range module.ManagedResources {
 		allResources = append(allResources, r)
 	}
 	for _, r := range module.DataResources {
+		allResources = append(allResources, r)
+	}
+	for _, r := range module.EphemeralResources {
 		allResources = append(allResources, r)
 	}
 

--- a/internal/terraform/transform_ephemeral_resource_close.go
+++ b/internal/terraform/transform_ephemeral_resource_close.go
@@ -1,0 +1,191 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package terraform
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/terraform/internal/addrs"
+	"github.com/hashicorp/terraform/internal/collections"
+	"github.com/hashicorp/terraform/internal/dag"
+)
+
+// graphNodeEphemeralResourceConsumer is implemented by graph node types that
+// can validly refer to ephemeral resources, to announce which ephemeral
+// resources they each depend on.
+//
+// This is used to decide the dependencies for [nodeEphemeralResourceClose]
+// nodes.
+type graphNodeEphemeralResourceConsumer interface {
+	// requiredEphemeralResources returns a set of all of the ephemeral
+	// resources that the receiver directly depends on when performing
+	// the given walk operation.
+	//
+	// Although the addrs package types can't constrain this statically,
+	// this method should return only addresses of mode
+	// [addrs.EphemeralResourceMode]. Resources of any other mode are invalid
+	// to return.
+	//
+	// walkOperation is normalized for implementation simplicity: it can be
+	// either [walkPlan] or [walkApply], and no other type.
+	requiredEphemeralResources(op walkOperation) addrs.Set[addrs.ConfigResource]
+}
+
+// requiredEphemeralResourcesForReferencer is a helper for implementing
+// [graphNodeEphemeralResourceConsumer] for any node type which implements
+// [GraphNodeReferencer] and whose reported references can entirely describe
+// the needed ephemeral resources.
+func requiredEphemeralResourcesForReferencer[T GraphNodeReferencer](n T) addrs.Set[addrs.ConfigResource] {
+	moduleAddr := n.ModulePath()
+	refs := n.References()
+	if len(refs) == 0 {
+		return nil
+	}
+	ret := addrs.MakeSet[addrs.ConfigResource]()
+	for _, ref := range refs {
+		var resourceAddr addrs.Resource
+		switch refAddr := ref.Subject.(type) {
+		case addrs.Resource:
+			resourceAddr = refAddr
+		case addrs.ResourceInstance:
+			resourceAddr = refAddr.Resource
+		default:
+			continue
+		}
+		if resourceAddr.Mode != addrs.EphemeralResourceMode {
+			continue // we only care about ephemeral resources here
+		}
+		ret.Add(resourceAddr.InModule(moduleAddr))
+	}
+	return ret
+}
+
+// ephemeralResourceCloseTransformer is a graph transformer that inserts
+// a [nodeEphemeralResourceClose] node for each ephemeral resource whose "open"
+// is represented by at least one existing node, and arranges for the close
+// node to depend on the open node and on any other node that consumes the
+// relevant ephemeral resource.
+//
+// This transformer also prunes nodes for any ephemeral resources that have
+// no consumers for the given walk operation. In particular this means that
+// Terraform will not open any instances of an ephemeral resource that is
+// only used in resource provisioners if the graph is not being built for the
+// apply phase, because only the apply phase actually executes provisioners.
+//
+// This transformer must run after any other transformer that might introduce
+// an ephemeral resource node into the graph, or that might given an existing
+// node information it needs to properly announce any ephemeral resources it
+// consumes.
+type ephemeralResourceCloseTransformer struct {
+	// op must be one of walkValidate, walkPlan, or walkApply. For other walk
+	// operations, choose walkApply if the walk will execute resource
+	// provisioners or walkPlan otherwise.
+	//
+	// if op is walkValidate then this transformer does absolutely nothing,
+	// because we don't open or close ephemeral resources during the validate
+	// walk.
+	op walkOperation
+}
+
+func (t *ephemeralResourceCloseTransformer) Transform(g *Graph) error {
+	if t.op != walkApply && t.op != walkPlan {
+		// Nothing to do for any other walks, because only plan-like or
+		// apply-like walks actually open ephemeral resource instances.
+		return nil
+	}
+
+	// We'll freeze the set of vertices we started with so that we can
+	// visit it multiple times while we're modifying the graph.
+	verts := g.Vertices()
+
+	// First we'll find all of the ephemeral resources that already have
+	// at least one node in the graph, and we'll assume those are all
+	// "open" nodes. Each distinct ephemeral resource address gets one
+	// close node that depends on all of the nodes that might open instances
+	// of it.
+	openNodes := addrs.MakeMap[addrs.ConfigResource, collections.Set[dag.Vertex]]()
+	closeNodes := addrs.MakeMap[addrs.ConfigResource, *nodeEphemeralResourceClose]()
+	for _, v := range verts {
+		v, ok := v.(GraphNodeConfigResource)
+		if !ok {
+			continue
+		}
+		addr := v.ResourceAddr()
+		if addr.Resource.Mode != addrs.EphemeralResourceMode {
+			continue
+		}
+		if !openNodes.Has(addr) {
+			openNodes.Put(addr, collections.NewSetCmp[dag.Vertex]())
+		}
+		openNodes.Get(addr).Add(v)
+
+		if !closeNodes.Has(addr) {
+			closeNode := &nodeEphemeralResourceClose{
+				addr: addr,
+			}
+			closeNodes.Put(addr, closeNode)
+			log.Printf("[TRACE] ephemeralResourceCloseTransformer: adding close node for %s", addr)
+			g.Add(closeNode)
+		}
+		closeNode := closeNodes.Get(addr)
+
+		// The close node depends on the open node, because we can't
+		// close an ephemeral resource instance until we've opened it.
+		g.Connect(dag.BasicEdge(closeNode, v))
+	}
+
+	consumerCount := addrs.MakeMap[addrs.ConfigResource, int]()
+	for _, v := range verts {
+		v, ok := v.(graphNodeEphemeralResourceConsumer)
+		if !ok {
+			continue
+		}
+		for _, consumedAddr := range v.requiredEphemeralResources(t.op) {
+			if consumedAddr.Resource.Mode != addrs.EphemeralResourceMode {
+				// Should not happen: correct implementations of
+				// [graphNodeEphemeralResourceConsumer] only return
+				// ephemeral resource addresses.
+				panic(fmt.Sprintf("node %s incorrectly reported %s as an ephemeral resource", dag.VertexName(v), consumedAddr))
+			}
+			closeNode := closeNodes.Get(consumedAddr)
+			if closeNode == nil {
+				// Suggests that there's a reference to an ephemeral resource
+				// that isn't declared, which is invalid but it's not this
+				// transformer's responsibility to detect that invalidity,
+				// so we'll just ignore it.
+				log.Printf("[TRACE] ephemeralResourceCloseTransformer: %s refers to undeclared ephemeral resource %s", dag.VertexName(v), consumedAddr)
+				continue
+			}
+			consumerCount.Put(consumedAddr, consumerCount.Get(consumedAddr)+1)
+
+			// The close node depends on anything that consumes instances of
+			// the ephemeral resource, because we mustn't close it while
+			// other components are still using it.
+			g.Connect(dag.BasicEdge(closeNode, v))
+		}
+	}
+
+	// Finally, if we found any ephemeral resources that don't have any
+	// consumers then we'll prune out all of their open and close nodes
+	// to avoid redundantly opening and closing something that we aren't
+	// going to use anyway.
+	// (We don't use this transformer in the validate walk,
+	for _, elem := range openNodes.Elems {
+		if consumerCount.Get(elem.Key) == 0 {
+			for _, v := range elem.Value.Elems() {
+				log.Printf("[TRACE] ephemeralResourceCloseTransformer: pruning %s because it has no consumers", dag.VertexName(v))
+				g.Remove(v)
+			}
+		}
+	}
+	for _, elem := range closeNodes.Elems {
+		if consumerCount.Get(elem.Key) == 0 {
+			log.Printf("[TRACE] ephemeralResourceCloseTransformer: pruning %s because it has no consumers", dag.VertexName(elem.Value))
+			g.Remove(elem.Value)
+		}
+	}
+
+	return nil
+}

--- a/internal/terraform/transform_orphan_count.go
+++ b/internal/terraform/transform_orphan_count.go
@@ -27,6 +27,12 @@ type OrphanResourceInstanceCountTransformer struct {
 }
 
 func (t *OrphanResourceInstanceCountTransformer) Transform(g *Graph) error {
+	if !t.Addr.Resource.Mode.PersistsBetweenRounds() {
+		// A resource of a mode that does not persist cannot possibly have
+		// orphan instances.
+		return nil
+	}
+
 	rs := t.State.Resource(t.Addr)
 	if rs == nil {
 		return nil // Resource doesn't exist in state, so nothing to do!


### PR DESCRIPTION
> **NOTE:** This was originally a prototype of ephemeral values as a whole, but the initial work here has since been merged as a language experiment in https://github.com/hashicorp/terraform/pull/35273, https://github.com/hashicorp/terraform/pull/35346, and https://github.com/hashicorp/terraform/pull/35356.
>
> Therefore despite the broader description of the problem space and proposed solution below, the changes in this PR are now focused primarily on what's described in the "Ephemeral Resources" section below.

This is another attempt at introducing to Terraform the idea of objects and values being "ephemeral", which means something like "lives only for the duration of one Terraform phase".

Terraform already has at least two concepts that meet this definition, despite us not previously naming it:

- Provider configurations (`provider` blocks): Terraform re-evaluates the arguments in a `provider` block separately during the plan and apply phases, and doesn't mind if the configuration is different between the two as long as the apply-time configuration allows performing the actions that were proposed during the plan phase.
- Provisioners (`provisioner` and `connection` blocks): Terraform fully evaluates these only during the apply phase, so they aren't really considered during the plan phase _at all_, aside from basic static validation.

However, because the idea of "ephemeral" is not available in the rest of the language, it's tough to actually benefit from this ephemerality. This prototype aims to introduce "ephemeral" as a cross-cutting concern supported broadly across the language.

## Ephemeral Values

The most fundamental idea is that values used in expressions can either be ephemeral or non-ephemeral. This is an idea similar to "sensitive" in that Terraform will perform dynamic analysis such that any value derived from an ephemeral value is itself ephemeral. Ephemeral values can then be used only in parts of the language which would not require persisting the value either between the plan phase and the apply phase, or from one plan/apply round to the next.

Considering only pre-existing language features, ephemeral values can be freely used in `provider` blocks, `provisioner` blocks, `connection` blocks, and in local values. The following sections describe some new additions that either accept or produce ephemeral values.

`resource` blocks (aside from special nested parts like the aforementioned `provisioner` blocks) _do not_ accept ephemeral values, because preserving resource configuration unchanged between the plan and apply phases is a fundamental part of how Terraform works to keep its promise of either doing what the plan described or returning an error explaining why that's not possible.

Because ephemeral values are not expected to persist from plan to apply or between plan/apply rounds, there is no need to save them in saved plan files or state snapshots, thus finally giving a plausible answer for what to do about https://github.com/hashicorp/terraform/issues/516, which has been on my mind since long before I worked at HashiCorp.

## Ephemeral Input Variables

An ephemeral _input variable_ is, in the most general terms, just an input variable that is declared as accepting ephemeral values. A non-ephemeral input variable cannot accept ephemeral values, while an ephemeral value will accept both ephemeral and non-ephemeral values but the value will always be treated as ephemeral when used inside the declaring module.

The main interesting case is when a root module declares an ephemeral input variable. In that case, Terraform will no longer remember the value for the variable provided during planning and will instead expect any ephemeral variable set during the plan step to be provided again -- possibly with a different value -- during the apply step.

The primary goal of this is to be able to use input variables to set arguments in ephemeral contexts. For example, an input variable that's both ephemeral _and_ sensitive could provide a JSON Web Token to be used when configuring a specific provider, and then automation around Terraform could provide separate JSON Web Tokens across the plan and apply phases so that the apply phase isn't subject to the expiration time for the plan-time JWT, and so that the plan-time JWT doesn't get persisted to disk as part of a saved plan.

## Ephemeral Output Values

An ephemeral output value is essentially the opposite of an ephemeral input variable, allowing a module to expose an ephemeral value to its caller. As with input variables, a non-ephemeral output value will reject having an ephemeral value assigned to it. An ephemeral output value can have both ephemeral and non-ephemeral values assigned to it, but the calling module will always see it as ephemeral.

To start the utility of this is limited just to echoing back values derived from ephemeral input variables, since nothing else I've described so far actually _produces_ ephemeral values. However, allowing this is important to ensure that ephemeral values are supported symmetrically and will cooperate well with all other language features.

## Ephemeral Resources

The final idea in this prototype -- one which this prototype probably won't explore fully just yet, and introduce only just enough to validate that it fits in well with everything else -- is a new resource mode for representing remote objects that are ephemeral themselves.

Terraform currently has two "resource modes": managed resources (`resource` blocks) describe objects that Terraform is directly managing, while data resources (`data` blocks) describe objects that are managed elsewhere that the current configuration depends on. But in both cases the assumption is that those objects persist in some sense from plan to apply and from one plan/apply round to the next, and that Terraform is supposed to detect and react to any changes to those objects and therefore needs to persist information about them itself.

_Ephemeral_ resources, (`ephemeral` blocks) on the other hand, represent objects that -- at least, as far as Terraform is concerned -- exist only briefly during a single Terraform phase, and then get cleaned up once the phase is complete. This idea is an evolution of some much earlier design work I did before I even worked at HashiCorp :grinning: in relation to https://github.com/hashicorp/terraform/issues/8367, which was about establishing temporary SSH tunnels, and the HashiCorp Vault provider I wrote in https://github.com/hashicorp/terraform/pull/9158 (which evolved into today's official [`hashicorp/vault`](https://registry.terraform.io/providers/hashicorp/vault/latest)).

The general idea of ephemeral resources, then, is that their lifecycle includes three events:
- `OpenEphemeral`: Prepares the object for use. For some kinds of objects this would represent a "create" action, but for others it might just open a temporary session to something that already exists, such as in the SSH tunnel use-case.

    This operation is the one that establishes the result attributes that can be accessed from other parts of the module where the resource is declared. All of these results would be ephemeral values, so that they can vary from plan to apply. For example, opening an SSH tunnel is likely to cause a different local TCP port number to be allocated each time, and so consistency between plan and apply phases is not expected.
- `RenewEphemeral`: Some ephemeral remote objects need to be periodically refreshed in order to stay "live", such as leases for Vault secrets.

    This optional operation is therefore opted into by the provider's `OpenEphemeral` response, by providing a private set of data that should be sent back to the provider's `RenewEphemeral` implementation and a deadline before which Terraform must renew it. The provider can then do whatever is needed to keep the object from expiring, and optionally return another renew request with a new deadline in order to repeat this renewal process.
- `CloseEphemeral`: Once Terraform has completed work for all objects that refer to the ephemeral resource, this operation gives the provider an explicit signal that the object is not longer required so that it can be promptly destroyed or invalidated.

    This detail is particularly helpful for the Vault provider and fixes a limitation I ran into immediately back in 2016: a dynamic secret fetched using a `data` block can never have its lease explicitly terminated, because data resources were intended only to read information about an object someone else is managing, not to directly manage an object (a Vault lease).

Because the results from ephemeral resources are ephemeral values, they're primarily useful in configuration for other ephemeral objects: `provider` blocks, `provisioner`/`connection` blocks, and of course other `ephemeral` blocks.

Actually changing the provider protocol and implementing real providers is not in scope for my initial prototyping work here, and so I intend to prototype this in a more limited way that just emulates how this mechanism might behave, so we can see how well it interacts with the rest of the language and the other ephemeral values discussed here.

I've also been considering a mechanism to allow managed resource types to declare individual arguments as being "write-only", such as for an RDS database password that only needs to be provided during creation and should not be provided again unless the operator actually intends to reset it. I don't intend to prototype _that_ in here, but I intend to lay the foundations for it by having a convention that ephemeral input values and write-only arguments both treat `null` as meaning "don't set or change" and non-null as "set or change", thereby creating a small imperative-shaped niche in the otherwise-declarative Terraform Language to allow for using Terraform to _manage_ objects that have write-only (typically, sensitive) arguments without needing to persist them in plan and state.

----

I'm still working on this, so not everything described above is in here yet, but the foundations for ephemeral values themselves are already in. I've opened this draft largely just because I need to put this work down for a while for a team offsite and don't want to lose the context.


