### PR TITLE
chore: fix typos  "recieve" to "receive"

### DIFF
--- a/internal/addrs/instance_key_test.go
+++ b/internal/addrs/instance_key_test.go
@@ -71,7 +71,7 @@ func TestInstanceKeyString(t *testing.T) {
 			got := test.Key.String()
 			want := test.Want
 			if got != want {
-				t.Errorf("wrong result\nreciever: %s\ngot:      %s\nwant:     %s", testName, got, want)
+				t.Errorf("wrong result\nreceiver: %s\ngot:      %s\nwant:     %s", testName, got, want)
 			}
 		})
 	}

--- a/internal/addrs/module_instance.go
+++ b/internal/addrs/module_instance.go
@@ -431,7 +431,7 @@ func (m ModuleInstance) CallInstance() (ModuleInstance, ModuleCallInstance) {
 // TargetContains implements Targetable by returning true if the given other
 // address either matches the receiver, is a sub-module-instance of the
 // receiver, or is a targetable absolute address within a module that
-// is contained within the reciever.
+// is contained within the receiver.
 func (m ModuleInstance) TargetContains(other Targetable) bool {
 	switch to := other.(type) {
 	case Module:

--- a/internal/addrs/module_source.go
+++ b/internal/addrs/module_source.go
@@ -179,7 +179,7 @@ func (s ModuleSourceRemote) ForDisplay() string {
 // given path are both respected.
 //
 // This will return nonsense if given a registry address other than the one
-// that generated the reciever via a registry lookup.
+// that generated the receiver via a registry lookup.
 func (s ModuleSourceRemote) FromRegistry(given ModuleSourceRegistry) ModuleSourceRemote {
 	ret := s // not a pointer, so this is a shallow copy
 

--- a/internal/addrs/move_endpoint.go
+++ b/internal/addrs/move_endpoint.go
@@ -70,7 +70,7 @@ func (e *MoveEndpoint) Equal(other *MoveEndpoint) bool {
 }
 
 // MightUnifyWith returns true if it is possible that a later call to
-// UnifyMoveEndpoints might succeed if given the reciever and the other
+// UnifyMoveEndpoints might succeed if given the receiver and the other
 // given endpoint.
 //
 // This is intended for early static validation of obviously-wrong situations,
@@ -84,7 +84,7 @@ func (e *MoveEndpoint) MightUnifyWith(other *MoveEndpoint) bool {
 	return from != nil && to != nil
 }
 
-// ConfigMoveable transforms the reciever into a ConfigMoveable by resolving it
+// ConfigMoveable transforms the receiver into a ConfigMoveable by resolving it
 // relative to the given base module, which should be the module where
 // the MoveEndpoint expression was found.
 //

--- a/internal/addrs/move_endpoint_module.go
+++ b/internal/addrs/move_endpoint_module.go
@@ -82,7 +82,7 @@ func (e *MoveEndpointInModule) ObjectKind() MoveEndpointKind {
 }
 
 // String produces a string representation of the object matching pattern
-// represented by the reciever.
+// represented by the receiver.
 //
 // Since there is no direct syntax for representing such an object matching
 // pattern, this function uses a splat-operator-like representation to stand
@@ -111,7 +111,7 @@ func (e *MoveEndpointInModule) String() string {
 	return buf.String()
 }
 
-// Equal returns true if the reciever represents the same matching pattern
+// Equal returns true if the receiver represents the same matching pattern
 // as the other given endpoint, ignoring the source location information.
 //
 // This is not an optimized function and is here primarily to help with
@@ -243,7 +243,7 @@ func (e *MoveEndpointInModule) synthModuleInstance() ModuleInstance {
 	return inst
 }
 
-// SelectsModule returns true if the reciever directly selects either
+// SelectsModule returns true if the receiver directly selects either
 // the given module or a resource nested directly inside that module.
 //
 // This is a good function to use to decide which modules in a state
@@ -329,11 +329,11 @@ func moduleInstanceCanMatch(modA, modB ModuleInstance) bool {
 	return true
 }
 
-// CanChainFrom returns true if the reciever describes an address that could
+// CanChainFrom returns true if the receiver describes an address that could
 // potentially select an object that the other given address could select.
 //
 // In other words, this decides whether the move chaining rule applies, if
-// the reciever is the "to" from one statement and the other given address
+// the receiver is the "to" from one statement and the other given address
 // is the "from" of another statement.
 func (e *MoveEndpointInModule) CanChainFrom(other *MoveEndpointInModule) bool {
 	eMod := e.synthModuleInstance()
@@ -488,7 +488,7 @@ func (m ModuleInstance) MoveDestination(fromMatch, toMatch *MoveEndpointInModule
 		return nil, false
 	}
 
-	// The rest of our work will be against the part of the reciever that's
+	// The rest of our work will be against the part of the receiver that's
 	// relative to the declaration module. mRel is a weird abuse of
 	// ModuleInstance that represents a relative module address, similar to
 	// what we do for MoveEndpointInModule.relSubject.
@@ -582,7 +582,7 @@ func (r AbsResource) MoveDestination(fromMatch, toMatch *MoveEndpointInModule) (
 			return AbsResource{}, false
 		}
 
-		// fromMatch can only possibly match the reciever if the resource
+		// fromMatch can only possibly match the receiver if the resource
 		// portions are identical, regardless of the module paths.
 		if fromRelSubject.Resource != r.Resource {
 			return AbsResource{}, false
@@ -664,7 +664,7 @@ func (r AbsResourceInstance) MoveDestination(fromMatch, toMatch *MoveEndpointInM
 				return AbsResourceInstance{}, false
 			}
 
-			// fromMatch can only possibly match the reciever if the resource
+			// fromMatch can only possibly match the receiver if the resource
 			// portions are identical, regardless of the module paths.
 			if fromRelSubject.Resource != r.Resource {
 				return AbsResourceInstance{}, false

--- a/internal/addrs/move_endpoint_module_test.go
+++ b/internal/addrs/move_endpoint_module_test.go
@@ -284,7 +284,7 @@ func TestModuleInstanceMoveDestination(t *testing.T) {
 					var diags tfdiags.Diagnostics
 					receiverAddr, diags = ParseModuleInstanceStr(test.Receiver)
 					if diags.HasErrors() {
-						t.Fatalf("invalid reciever address: %s", diags.Err().Error())
+						t.Fatalf("invalid receiver address: %s", diags.Err().Error())
 					}
 				}
 				gotAddr, gotMatch := receiverAddr.MoveDestination(fromEP, toEP)
@@ -392,7 +392,7 @@ func TestAbsResourceInstanceMoveDestination(t *testing.T) {
 			`test_object.beep`,
 			`test_object.boop`,
 			`test_object.boop`,
-			false, // the reciever is already the "to" address
+			false, // the receiver is already the "to" address
 			``,
 		},
 		{
@@ -682,7 +682,7 @@ func TestAbsResourceInstanceMoveDestination(t *testing.T) {
 
 				receiverAddr, diags := ParseAbsResourceInstanceStr(test.Receiver)
 				if diags.HasErrors() {
-					t.Fatalf("invalid reciever address: %s", diags.Err().Error())
+					t.Fatalf("invalid receiver address: %s", diags.Err().Error())
 				}
 				gotAddr, gotMatch := receiverAddr.MoveDestination(fromEP, toEP)
 				if !test.WantMatch {
@@ -765,7 +765,7 @@ func TestAbsResourceMoveDestination(t *testing.T) {
 			`test_object.beep`,
 			`test_object.boop`,
 			`test_object.boop`,
-			false, // the reciever is already the "to" address
+			false, // the receiver is already the "to" address
 			``,
 		},
 		{
@@ -1052,10 +1052,10 @@ func TestAbsResourceMoveDestination(t *testing.T) {
 				// key.
 				receiverInstanceAddr, diags := ParseAbsResourceInstanceStr(test.Receiver)
 				if diags.HasErrors() {
-					t.Fatalf("invalid reciever address: %s", diags.Err().Error())
+					t.Fatalf("invalid receiver address: %s", diags.Err().Error())
 				}
 				if receiverInstanceAddr.Resource.Key != NoKey {
-					t.Fatalf("invalid reciever address: must be a resource, not a resource instance")
+					t.Fatalf("invalid receiver address: must be a resource, not a resource instance")
 				}
 				receiverAddr := receiverInstanceAddr.ContainingResource()
 				gotAddr, gotMatch := receiverAddr.MoveDestination(fromEP, toEP)

--- a/internal/addrs/parse_ref.go
+++ b/internal/addrs/parse_ref.go
@@ -23,7 +23,7 @@ type Reference struct {
 }
 
 // DisplayString returns a string that approximates the subject and remaining
-// traversal of the reciever in a way that resembles the Terraform language
+// traversal of the receiver in a way that resembles the Terraform language
 // syntax that could've produced it.
 //
 // It's not guaranteed to actually be a valid Terraform language expression,

--- a/internal/addrs/parse_target.go
+++ b/internal/addrs/parse_target.go
@@ -430,7 +430,7 @@ func ParseAbsResourceInstanceStr(str string) (AbsResourceInstance, tfdiags.Diagn
 }
 
 // ModuleAddr returns the module address portion of the subject of
-// the recieving target.
+// the receiving target.
 //
 // Regardless of specific address type, all targets always include
 // a module address. They might also include something in that

--- a/internal/addrs/partial_expanded.go
+++ b/internal/addrs/partial_expanded.go
@@ -74,7 +74,7 @@ func (pem PartialExpandedModule) LevelsKnown() int {
 }
 
 // MatchesInstance returns true if and only if the given module instance
-// belongs to the recieving partially-expanded module address pattern.
+// belongs to the receiving partially-expanded module address pattern.
 func (pem PartialExpandedModule) MatchesInstance(inst ModuleInstance) bool {
 	// Total length must always match.
 	if len(inst) != (len(pem.expandedPrefix) + len(pem.unexpandedSuffix)) {
@@ -308,7 +308,7 @@ func (per PartialExpandedResource) UnknownResourceInstance() AbsResourceInstance
 }
 
 // MatchesInstance returns true if and only if the given resource instance
-// belongs to the recieving partially-expanded resource address pattern.
+// belongs to the receiving partially-expanded resource address pattern.
 func (per PartialExpandedResource) MatchesInstance(inst AbsResourceInstance) bool {
 	if !per.module.MatchesInstance(inst.Module) {
 		return false
@@ -317,7 +317,7 @@ func (per PartialExpandedResource) MatchesInstance(inst AbsResourceInstance) boo
 }
 
 // MatchesResource returns true if and only if the given resource belongs to
-// the recieving partially-expanded resource address pattern.
+// the receiving partially-expanded resource address pattern.
 func (per PartialExpandedResource) MatchesResource(inst AbsResource) bool {
 	if !per.module.MatchesInstance(inst.Module) {
 		return false

--- a/internal/addrs/provider_config.go
+++ b/internal/addrs/provider_config.go
@@ -333,7 +333,7 @@ func ParseLegacyAbsProviderConfig(traversal hcl.Traversal) (AbsProviderConfig, t
 }
 
 // ProviderConfigDefault returns the address of the default provider config of
-// the given type inside the recieving module instance.
+// the given type inside the receiving module instance.
 func (m ModuleInstance) ProviderConfigDefault(provider Provider) AbsProviderConfig {
 	return AbsProviderConfig{
 		Module:   m.Module(),
@@ -342,7 +342,7 @@ func (m ModuleInstance) ProviderConfigDefault(provider Provider) AbsProviderConf
 }
 
 // ProviderConfigAliased returns the address of an aliased provider config of
-// the given type and alias inside the recieving module instance.
+// the given type and alias inside the receiving module instance.
 func (m ModuleInstance) ProviderConfigAliased(provider Provider, alias string) AbsProviderConfig {
 	return AbsProviderConfig{
 		Module:   m.Module(),
@@ -484,7 +484,7 @@ func (p RootProviderConfig) String() string {
 	return p.AbsProviderConfig().String()
 }
 
-// UniqueKey returns a comparable unique key for the reciever suitable for
+// UniqueKey returns a comparable unique key for the receiver suitable for
 // use in generic collection types such as [Set] and [Map].
 func (p RootProviderConfig) UniqueKey() UniqueKey {
 	// A RootProviderConfig is inherently comparable and so can be its own key

--- a/internal/addrs/resource_test.go
+++ b/internal/addrs/resource_test.go
@@ -236,7 +236,7 @@ func TestAbsResourceUniqueKey(t *testing.T) {
 	}.Absolute(RootModuleInstance.Child("boop", NoKey))
 
 	tests := []struct {
-		Reciever  AbsResource
+		Receiver  AbsResource
 		Other     UniqueKeyer
 		WantEqual bool
 	}{
@@ -273,15 +273,15 @@ func TestAbsResourceUniqueKey(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		t.Run(fmt.Sprintf("%s matches %T %s?", test.Reciever, test.Other, test.Other), func(t *testing.T) {
-			rKey := test.Reciever.UniqueKey()
+		t.Run(fmt.Sprintf("%s matches %T %s?", test.Receiver, test.Other, test.Other), func(t *testing.T) {
+			rKey := test.Receiver.UniqueKey()
 			oKey := test.Other.UniqueKey()
 
 			gotEqual := rKey == oKey
 			if gotEqual != test.WantEqual {
 				t.Errorf(
 					"wrong result\nreceiver: %s\nother:    %s (%T)\ngot:  %t\nwant: %t",
-					test.Reciever, test.Other, test.Other,
+					test.Receiver, test.Other, test.Other,
 					gotEqual, test.WantEqual,
 				)
 			}

--- a/internal/addrs/set.go
+++ b/internal/addrs/set.go
@@ -50,7 +50,7 @@ func (s Set[T]) Remove(addr T) {
 }
 
 // Union returns a new set which contains the union of all of the elements
-// of both the reciever and the given other set.
+// of both the receiver and the given other set.
 func (s Set[T]) Union(other Set[T]) Set[T] {
 	ret := make(Set[T])
 	for k, addr := range s {
@@ -63,7 +63,7 @@ func (s Set[T]) Union(other Set[T]) Set[T] {
 }
 
 // Intersection returns a new set which contains the intersection of all of the
-// elements of both the reciever and the given other set.
+// elements of both the receiver and the given other set.
 func (s Set[T]) Intersection(other Set[T]) Set[T] {
 	ret := make(Set[T])
 	for k, addr := range s {

--- a/internal/checks/state.go
+++ b/internal/checks/state.go
@@ -88,7 +88,7 @@ func NewState(config *configs.Config) *State {
 }
 
 // ConfigHasChecks returns true if and only if the given address refers to
-// a configuration object that this State object is expecting to recieve
+// a configuration object that this State object is expecting to receive
 // statuses for.
 //
 // Other methods of Checks will typically panic if given a config address

--- a/internal/collections/map.go
+++ b/internal/collections/map.go
@@ -119,7 +119,7 @@ func (m Map[K, V]) Delete(k K) {
 // and so callers MUST NOT modify it. If a caller is using locks to ensure
 // safe concurrent access then any reads of the resulting map must be
 // guarded by the same lock as would be used for other methods that read
-// data from the reciever.
+// data from the receiver.
 //
 // The only correct use of this function is as part of a "for ... range"
 // statement using only the values of the resulting map:

--- a/internal/collections/unique_key.go
+++ b/internal/collections/unique_key.go
@@ -28,7 +28,7 @@ type UniqueKey[T any] interface {
 
 // A UniqueKeyer is a type that knows how to calculate a unique key itself.
 type UniqueKeyer[T any] interface {
-	// UniqueKey returns the unique key of the reciever.
+	// UniqueKey returns the unique key of the receiver.
 	//
 	// A correct implementation of UniqueKey must return a distinct value
 	// for each unique value of T, where the uniqueness of T values is decided

--- a/internal/command/views/view.go
+++ b/internal/command/views/view.go
@@ -54,7 +54,7 @@ func NewView(streams *terminal.Streams) *View {
 // instead for situations where the user isn't running Terraform directly.
 //
 // For convenient use during initialization (in conjunction with NewView),
-// SetRunningInAutomation returns the reciever after modifying it.
+// SetRunningInAutomation returns the receiver after modifying it.
 func (v *View) SetRunningInAutomation(new bool) *View {
 	v.runningInAutomation = new
 	return v

--- a/internal/command/webbrowser/mock.go
+++ b/internal/command/webbrowser/mock.go
@@ -61,7 +61,7 @@ type MockLauncher struct {
 	// would naturally complete.
 	Context context.Context
 
-	// Responses is a log of all of the responses recieved from the launcher's
+	// Responses is a log of all of the responses received from the launcher's
 	// requests, in the order requested.
 	Responses []*http.Response
 

--- a/internal/command/workdir/backend_state.go
+++ b/internal/command/workdir/backend_state.go
@@ -177,7 +177,7 @@ func (s *BackendState) SetConfig(val cty.Value, schema *configschema.Block) erro
 	return nil
 }
 
-// ForPlan produces an alternative representation of the reciever that is
+// ForPlan produces an alternative representation of the receiver that is
 // suitable for storing in a plan. The current workspace must additionally
 // be provided, to be stored alongside the backend configuration.
 //

--- a/internal/command/workdir/dir.go
+++ b/internal/command/workdir/dir.go
@@ -82,7 +82,7 @@ func NewDir(mainPath string) *Dir {
 }
 
 // OverrideOriginalWorkingDir records a different path as the
-// "original working directory" for the reciever.
+// "original working directory" for the receiver.
 //
 // Use this only to record the original working directory when Terraform is run
 // with the -chdir=... global option. In that case, the directory given in
@@ -123,7 +123,7 @@ func (d *Dir) OriginalWorkingDir() string {
 	return d.originalDir
 }
 
-// DataDir returns the base path where the reciever keeps all of the settings
+// DataDir returns the base path where the receiver keeps all of the settings
 // and artifacts that must persist between consecutive commands in a single
 // session.
 //

--- a/internal/configs/backend.go
+++ b/internal/configs/backend.go
@@ -29,7 +29,7 @@ func decodeBackendBlock(block *hcl.Block) (*Backend, hcl.Diagnostics) {
 	}, nil
 }
 
-// Hash produces a hash value for the reciever that covers the type and the
+// Hash produces a hash value for the receiver that covers the type and the
 // portions of the config that conform to the given schema.
 //
 // If the config does not conform to the schema then the result is not

--- a/internal/configs/config.go
+++ b/internal/configs/config.go
@@ -251,7 +251,7 @@ func (c *Config) EntersNewPackage() bool {
 
 // VerifyDependencySelections checks whether the given locked dependencies
 // are acceptable for all of the version constraints reported in the
-// configuration tree represented by the reciever.
+// configuration tree represented by the receiver.
 //
 // This function will errors only if any of the locked dependencies are out of
 // range for corresponding constraints in the configuration. If there are

--- a/internal/configs/configschema/empty_value.go
+++ b/internal/configs/configschema/empty_value.go
@@ -7,12 +7,12 @@ import (
 	"github.com/zclconf/go-cty/cty"
 )
 
-// EmptyValue returns the "empty value" for the recieving block, which for
+// EmptyValue returns the "empty value" for the receiving block, which for
 // a block type is a non-null object where all of the attribute values are
 // the empty values of the block's attributes and nested block types.
 //
 // In other words, it returns the value that would be returned if an empty
-// block were decoded against the recieving schema, assuming that no required
+// block were decoded against the receiving schema, assuming that no required
 // attribute or block constraints were honored.
 func (b *Block) EmptyValue() cty.Value {
 	vals := make(map[string]cty.Value)

--- a/internal/dag/graph.go
+++ b/internal/dag/graph.go
@@ -235,13 +235,13 @@ func (g *Graph) Connect(edge Edge) {
 }
 
 // Subsume imports all of the nodes and edges from the given graph into the
-// reciever, leaving the given graph unchanged.
+// receiver, leaving the given graph unchanged.
 //
-// If any of the nodes in the given graph are already present in the reciever
+// If any of the nodes in the given graph are already present in the receiver
 // then the existing node will be retained and any new edges from the given
 // graph will be connected with it.
 //
-// If the given graph has edges in common with the reciever then they will be
+// If the given graph has edges in common with the receiver then they will be
 // ignored, because each pair of nodes can only be connected once.
 func (g *Graph) Subsume(other *Graph) {
 	// We're using Set.Filter just as a "visit each element" here, so we're

--- a/internal/depsfile/locks.go
+++ b/internal/depsfile/locks.go
@@ -125,7 +125,7 @@ func (l *Locks) RemoveProvider(addr addrs.Provider) {
 //
 // This is an in-memory-only annotation which lives only inside a particular
 // Locks object, and is never persisted as part of a saved lock file on disk.
-// It's valid to still use other methods of the reciever to access
+// It's valid to still use other methods of the receiver to access
 // already-stored lock information and to update lock information for an
 // overridden provider, but some callers may need to use ProviderIsOverridden
 // to selectively disregard stored lock information for overridden providers,
@@ -149,7 +149,7 @@ func (l *Locks) ProviderIsOverridden(addr addrs.Provider) bool {
 //
 // This allows propagating override information between different lock objects,
 // as if calling SetProviderOverridden for each address already overridden
-// in the other given locks. If the reciever already has overridden providers,
+// in the other given locks. If the receiver already has overridden providers,
 // SetSameOverriddenProviders will preserve them.
 func (l *Locks) SetSameOverriddenProviders(other *Locks) {
 	if other == nil {
@@ -262,7 +262,7 @@ func (l *Locks) Equal(other *Locks) bool {
 
 		// Although "hashes" is declared as a slice, it's logically an
 		// unordered set. However, we normalize the slice of hashes when
-		// recieving it in NewProviderLock, so we can just do a simple
+		// receiving it in NewProviderLock, so we can just do a simple
 		// item-by-item equality test here.
 		if len(thisLock.hashes) != len(otherLock.hashes) {
 			return false

--- a/internal/getmodules/moduleaddrs/package.go
+++ b/internal/getmodules/moduleaddrs/package.go
@@ -13,7 +13,7 @@ package moduleaddrs
 // one of those other functions instead. The addrs package can potentially
 // perform other processing in addition to just the go-getter detection.
 //
-// Note that this function expects to recieve only a package address, not
+// Note that this function expects to receive only a package address, not
 // a full source address that might also include a subdirectory portion.
 // The caller must trim off any subdirectory portion using
 // [SplitPackageSubdir] before calling this function, passing in

--- a/internal/getmodules/moduleaddrs/source_parsing_test.go
+++ b/internal/getmodules/moduleaddrs/source_parsing_test.go
@@ -364,7 +364,7 @@ func TestModuleSourceRemoteFromRegistry(t *testing.T) {
 		}
 		gotAddr := remote.FromRegistry(registry)
 		if remote.Subdir != "foo" {
-			t.Errorf("FromRegistry modified the reciever; should be pure function")
+			t.Errorf("FromRegistry modified the receiver; should be pure function")
 		}
 		if registry.Subdir != "bar" {
 			t.Errorf("FromRegistry modified the given address; should be pure function")
@@ -383,7 +383,7 @@ func TestModuleSourceRemoteFromRegistry(t *testing.T) {
 		}
 		gotAddr := remote.FromRegistry(registry)
 		if remote.Subdir != "foo" {
-			t.Errorf("FromRegistry modified the reciever; should be pure function")
+			t.Errorf("FromRegistry modified the receiver; should be pure function")
 		}
 		if registry.Subdir != "" {
 			t.Errorf("FromRegistry modified the given address; should be pure function")
@@ -402,7 +402,7 @@ func TestModuleSourceRemoteFromRegistry(t *testing.T) {
 		}
 		gotAddr := remote.FromRegistry(registry)
 		if remote.Subdir != "" {
-			t.Errorf("FromRegistry modified the reciever; should be pure function")
+			t.Errorf("FromRegistry modified the receiver; should be pure function")
 		}
 		if registry.Subdir != "bar" {
 			t.Errorf("FromRegistry modified the given address; should be pure function")

--- a/internal/getproviders/hash.go
+++ b/internal/getproviders/hash.go
@@ -310,7 +310,7 @@ func PackageHashV1(loc PackageLocation) (providerreqs.Hash, error) {
 }
 
 // Hash computes a hash of the contents of the package at the location
-// associated with the reciever, using whichever hash algorithm is the current
+// associated with the receiver, using whichever hash algorithm is the current
 // default.
 //
 // This method will change to use new hash versions as they are introduced

--- a/internal/getproviders/providerreqs/hash.go
+++ b/internal/getproviders/providerreqs/hash.go
@@ -60,7 +60,7 @@ func MustParseHash(s string) Hash {
 	return hash
 }
 
-// Scheme returns the scheme of the recieving hash. If the receiver is not
+// Scheme returns the scheme of the receiving hash. If the receiver is not
 // using valid syntax then this method will panic.
 func (h Hash) Scheme() HashScheme {
 	colon := strings.Index(string(h), ":")
@@ -78,7 +78,7 @@ func (h Hash) HasScheme(want HashScheme) bool {
 	return h.Scheme() == want
 }
 
-// Value returns the scheme-specific value from the recieving hash. The
+// Value returns the scheme-specific value from the receiving hash. The
 // meaning of this value depends on the scheme.
 //
 // If the receiver is not using valid syntax then this method will panic.

--- a/internal/lang/functions.go
+++ b/internal/lang/functions.go
@@ -401,7 +401,7 @@ func baseFunctions(baseDir string) map[string]function.Function {
 }
 
 // experimentalFunction checks whether the given experiment is enabled for
-// the recieving scope. If so, it will return the given function verbatim.
+// the receiving scope. If so, it will return the given function verbatim.
 // If not, it will return a placeholder function that just returns an
 // error explaining that the function requires the experiment to be enabled.
 //

--- a/internal/lang/globalref/reference.go
+++ b/internal/lang/globalref/reference.go
@@ -113,7 +113,7 @@ func (r Reference) ResourceInstance() (addrs.AbsResourceInstance, bool) {
 }
 
 // DebugString returns an internal (but still somewhat Terraform-language-like)
-// compact string representation of the reciever, which isn't an address that
+// compact string representation of the receiver, which isn't an address that
 // any of our usual address parsers could accept but still captures the
 // essence of what the reference represents.
 //

--- a/internal/plans/changes.go
+++ b/internal/plans/changes.go
@@ -253,7 +253,7 @@ type ResourceInstanceChange struct {
 	Private []byte
 }
 
-// Encode produces a variant of the reciever that has its change values
+// Encode produces a variant of the receiver that has its change values
 // serialized so it can be written to a plan file. Pass the implied type of the
 // corresponding resource type schema for correct operation.
 func (rc *ResourceInstanceChange) Encode(ty cty.Type) (*ResourceInstanceChangeSrc, error) {
@@ -490,7 +490,7 @@ type OutputChange struct {
 	Sensitive bool
 }
 
-// Encode produces a variant of the reciever that has its change values
+// Encode produces a variant of the receiver that has its change values
 // serialized so it can be written to a plan file.
 func (oc *OutputChange) Encode() (*OutputChangeSrc, error) {
 	cs, err := oc.Change.Encode(cty.DynamicPseudoType)
@@ -550,7 +550,7 @@ type Change struct {
 	GeneratedConfig string
 }
 
-// Encode produces a variant of the reciever that has its change values
+// Encode produces a variant of the receiver that has its change values
 // serialized so it can be written to a plan file. Pass the type constraint
 // that the values are expected to conform to; to properly decode the values
 // later an identical type constraint must be provided at that time.

--- a/internal/plans/objchange/compatible.go
+++ b/internal/plans/objchange/compatible.go
@@ -330,7 +330,7 @@ func indexStrForErrors(v cty.Value) string {
 // with sets that may contain unknown values as long as the unknown case is
 // addressed in some reasonable way in the callback function.
 //
-// The callback always recieves values from set a as its first argument and
+// The callback always receives values from set a as its first argument and
 // values from set b in its second argument, so it is safe to use with
 // non-commutative functions.
 //

--- a/internal/rpcapi/handles.go
+++ b/internal/rpcapi/handles.go
@@ -29,7 +29,7 @@ func (hnd handle[T]) ForProtobuf() int64 {
 	return int64(hnd)
 }
 
-// IsNil returns true if the reciever is the "nil handle", which is also the
+// IsNil returns true if the receiver is the "nil handle", which is also the
 // zero value of any handle type and represents the absense of a handle.
 func (hnd handle[T]) IsNil() bool {
 	return int64(hnd) == 0

--- a/internal/stacks/stackaddrs/stack.go
+++ b/internal/stacks/stackaddrs/stack.go
@@ -28,7 +28,7 @@ func (s Stack) IsRoot() bool {
 	return len(s) == 0
 }
 
-// Parent returns the parent of the reciever, or panics if the receiver is
+// Parent returns the parent of the receiver, or panics if the receiver is
 // representing the root stack.
 func (s Stack) Parent() Stack {
 	newLen := len(s) - 1
@@ -95,7 +95,7 @@ func (s StackInstance) IsRoot() bool {
 	return len(s) == 0
 }
 
-// Parent returns the parent of the reciever, or panics if the receiver is
+// Parent returns the parent of the receiver, or panics if the receiver is
 // representing the root stack.
 func (s StackInstance) Parent() StackInstance {
 	newLen := len(s) - 1

--- a/internal/stacks/stackplan/component.go
+++ b/internal/stacks/stackplan/component.go
@@ -79,7 +79,7 @@ type Component struct {
 //
 // Conversion with this method should always succeed if the given previous
 // run state is truly the one that the plan was created from. If this method
-// returns an error then that suggests that the recieving plan is inconsistent
+// returns an error then that suggests that the receiving plan is inconsistent
 // with the given previous run state, which should not happen if the caller
 // is using Terraform Core correctly.
 func (c *Component) ForModulesRuntime() (*plans.Plan, error) {

--- a/internal/stacks/stackruntime/hooks/callbacks.go
+++ b/internal/stacks/stackruntime/hooks/callbacks.go
@@ -32,7 +32,7 @@ type BeginFunc[Msg any] func(context.Context, Msg) any
 // context was passed to the top-level [stackruntime.Plan] or
 // [stackruntime.Apply] call.
 //
-// The hook callback recieves an additional argument which is guaranteed to be
+// The hook callback receives an additional argument which is guaranteed to be
 // the same value returned from the corresponding [BeginFunc]. See
 // [BeginFunc]'s documentation for more information.
 //

--- a/internal/stacks/stackruntime/internal/stackeval/diagnostics.go
+++ b/internal/stacks/stackruntime/internal/stackeval/diagnostics.go
@@ -363,7 +363,7 @@ type namedPromiseReporter interface {
 	// reportNamedPromises should also delegate to the same method on any
 	// directly-nested objects that might themselves have promises, so that
 	// collectPromiseNames can walk the whole tree. This should be done only
-	// in situations where the original reciever's implementation is itself
+	// in situations where the original receiver's implementation is itself
 	// acting as the physical container for the child objects, and not just
 	// when an object is _logically_ nested within another object.
 	reportNamedPromises(func(id promising.PromiseID, name string))

--- a/internal/stacks/stackruntime/internal/stackeval/input_variable.go
+++ b/internal/stacks/stackruntime/internal/stackeval/input_variable.go
@@ -58,7 +58,7 @@ func (v *InputVariable) Declaration(ctx context.Context) *stackconfig.InputVaria
 //
 // Returns nil if this input variable belongs to the main stack, because
 // the main stack's input variables come from the planning options instead.
-// Also returns nil if the reciever belongs to a stack config instance
+// Also returns nil if the receiver belongs to a stack config instance
 // that isn't actually declared in the configuration, which typically suggests
 // that we don't yet know the number of instances of one of the stack calls
 // along the chain.

--- a/internal/stacks/stackruntime/internal/stackeval/planning.go
+++ b/internal/stacks/stackruntime/internal/stackeval/planning.go
@@ -37,7 +37,7 @@ type PlanOpts struct {
 type Plannable interface {
 	// PlanChanges produces zero or more [stackplan.PlannedChange] objects
 	// representing changes needed to converge the current and desired states
-	// for the reciever, and zero or more diagnostics that represent any
+	// for the receiver, and zero or more diagnostics that represent any
 	// problems encountered while calcuating the changes.
 	//
 	// The diagnostics returned by PlanChanges must be shallow, which is to

--- a/internal/stacks/stackruntime/internal/stackeval/testing_test.go
+++ b/internal/stacks/stackruntime/internal/stackeval/testing_test.go
@@ -419,7 +419,7 @@ type testEvaluatorOpts struct {
 // main evaluator.
 //
 // This may be used only from unit tests in this package and must be called
-// before performing any other operations against the reciever. It's invalid
+// before performing any other operations against the receiver. It's invalid
 // to change the test-only globals after some evaluation has already been
 // performed, because the evaluator expects its input to be immutable and
 // caches values derived from that input, and there's no mechanism to

--- a/internal/stacks/stackruntime/internal/stackeval/validating.go
+++ b/internal/stacks/stackruntime/internal/stackeval/validating.go
@@ -15,7 +15,7 @@ type ValidateOpts struct {
 
 // Validateable is implemented by objects that can participate in validation.
 type Validatable interface {
-	// Validate returns diagnostics for any part of the reciever which
+	// Validate returns diagnostics for any part of the receiver which
 	// has an invalid configuration.
 	//
 	// Validate implementations should be shallow, which is to say that

--- a/internal/states/state_deepcopy.go
+++ b/internal/states/state_deepcopy.go
@@ -14,11 +14,11 @@ import (
 // in this file comprehensively copy all parts of the state data structure
 // that could be mutated via pointers.
 
-// DeepCopy returns a new state that contains equivalent data to the reciever
+// DeepCopy returns a new state that contains equivalent data to the receiver
 // but shares no backing memory in common.
 //
 // As with all methods on State, this method is not safe to use concurrently
-// with writing to any portion of the recieving data structure. It is the
+// with writing to any portion of the receiving data structure. It is the
 // caller's responsibility to ensure mutual exclusion for the duration of the
 // operation, but may then freely modify the receiver and the returned copy
 // independently once this method returns.
@@ -46,7 +46,7 @@ func (s *State) DeepCopy() *State {
 // receiver but shares no backing memory in common.
 //
 // As with all methods on Module, this method is not safe to use concurrently
-// with writing to any portion of the recieving data structure. It is the
+// with writing to any portion of the receiving data structure. It is the
 // caller's responsibility to ensure mutual exclusion for the duration of the
 // operation, but may then freely modify the receiver and the returned copy
 // independently once this method returns.
@@ -70,7 +70,7 @@ func (ms *Module) DeepCopy() *Module {
 // receiver but shares no backing memory in common.
 //
 // As with all methods on Resource, this method is not safe to use concurrently
-// with writing to any portion of the recieving data structure. It is the
+// with writing to any portion of the receiving data structure. It is the
 // caller's responsibility to ensure mutual exclusion for the duration of the
 // operation, but may then freely modify the receiver and the returned copy
 // independently once this method returns.
@@ -95,7 +95,7 @@ func (rs *Resource) DeepCopy() *Resource {
 // to the receiver but shares no backing memory in common.
 //
 // As with all methods on ResourceInstance, this method is not safe to use
-// concurrently with writing to any portion of the recieving data structure. It
+// concurrently with writing to any portion of the receiving data structure. It
 // is the caller's responsibility to ensure mutual exclusion for the duration
 // of the operation, but may then freely modify the receiver and the returned
 // copy independently once this method returns.
@@ -119,7 +119,7 @@ func (i *ResourceInstance) DeepCopy() *ResourceInstance {
 // to the receiver but shares no backing memory in common.
 //
 // As with all methods on ResourceInstanceObjectSrc, this method is not safe to
-// use concurrently with writing to any portion of the recieving data structure.
+// use concurrently with writing to any portion of the receiving data structure.
 // It is the caller's responsibility to ensure mutual exclusion for the duration
 // of the operation, but may then freely modify the receiver and the returned
 // copy independently once this method returns.
@@ -178,7 +178,7 @@ func (os *ResourceInstanceObjectSrc) DeepCopy() *ResourceInstanceObjectSrc {
 // to the receiver but shares no backing memory in common.
 //
 // As with all methods on ResourceInstanceObject, this method is not safe to use
-// concurrently with writing to any portion of the recieving data structure. It
+// concurrently with writing to any portion of the receiving data structure. It
 // is the caller's responsibility to ensure mutual exclusion for the duration
 // of the operation, but may then freely modify the receiver and the returned
 // copy independently once this method returns.
@@ -214,7 +214,7 @@ func (o *ResourceInstanceObject) DeepCopy() *ResourceInstanceObject {
 // to the receiver but shares no backing memory in common.
 //
 // As with all methods on OutputValue, this method is not safe to use
-// concurrently with writing to any portion of the recieving data structure. It
+// concurrently with writing to any portion of the receiving data structure. It
 // is the caller's responsibility to ensure mutual exclusion for the duration
 // of the operation, but may then freely modify the receiver and the returned
 // copy independently once this method returns.

--- a/internal/states/state_equal.go
+++ b/internal/states/state_equal.go
@@ -23,7 +23,7 @@ func (s *State) Equal(other *State) bool {
 }
 
 // ManagedResourcesEqual returns true if all of the managed resources tracked
-// in the reciever are functionally equivalent to the same tracked in the
+// in the receiver are functionally equivalent to the same tracked in the
 // other given state.
 //
 // This is a more constrained version of Equal that disregards other

--- a/internal/terraform/context.go
+++ b/internal/terraform/context.go
@@ -337,7 +337,7 @@ func (c *Context) watchStop(walker *ContextGraphWalker) (chan struct{}, <-chan s
 	return stop, wait
 }
 
-// checkConfigDependencies checks whether the recieving context is able to
+// checkConfigDependencies checks whether the receiving context is able to
 // support the given configuration, returning error diagnostics if not.
 //
 // Currently this function checks whether the current Terraform CLI version

--- a/internal/terraform/context_plan2_test.go
+++ b/internal/terraform/context_plan2_test.go
@@ -960,7 +960,7 @@ resource "test_object" "a" {
 		// In the destroy-with-refresh codepath we end up calling
 		// UpgradeResourceState twice, because we do so once during refreshing
 		// (as part making a normal plan) and then again during the plan-destroy
-		// walk. The second call recieves the result of the earlier refresh,
+		// walk. The second call receives the result of the earlier refresh,
 		// so we need to tolerate both "before" and "current" as possible
 		// inputs here.
 		if !bytes.Contains(req.RawStateJSON, []byte("before")) {

--- a/internal/terraform/eval_context_builtin.go
+++ b/internal/terraform/eval_context_builtin.go
@@ -61,7 +61,7 @@ type BuiltinEvalContext struct {
 	// ExternalProviderConfigs are pre-configured provider instances passed
 	// in by the caller, for situations like Stack components where the
 	// root module isn't designed to be planned and applied in isolation and
-	// instead expects to recieve certain provider configurations from the
+	// instead expects to receive certain provider configurations from the
 	// stack configuration.
 	ExternalProviderConfigs map[addrs.RootProviderConfig]providers.Interface
 

--- a/internal/terraform/node_variable_validation.go
+++ b/internal/terraform/node_variable_validation.go
@@ -84,7 +84,7 @@ func (n *nodeVariableValidation) References() []*addrs.Reference {
 
 // appendRefsFilterSelf is a specialized version of builtin [append] that
 // ignores any new references to the input variable represented by the
-// reciever.
+// receiver.
 func (n *nodeVariableValidation) appendRefsFilterSelf(to []*addrs.Reference, new ...*addrs.Reference) []*addrs.Reference {
 	// We need to filter out any self-references, because those would
 	// make the resulting graph invalid and we don't need them because

--- a/internal/terraform/variables.go
+++ b/internal/terraform/variables.go
@@ -115,13 +115,13 @@ func (v *InputValue) GoString() string {
 	}
 }
 
-// HasSourceRange returns true if the reciever has a source type for which
+// HasSourceRange returns true if the receiver has a source type for which
 // we expect the SourceRange field to be populated with a valid range.
 func (v *InputValue) HasSourceRange() bool {
 	return v.SourceType.HasSourceRange()
 }
 
-// HasSourceRange returns true if the reciever is one of the source types
+// HasSourceRange returns true if the receiver is one of the source types
 // that is used along with a valid SourceRange field when appearing inside an
 // InputValue object.
 func (v ValueSourceType) HasSourceRange() bool {
@@ -212,7 +212,7 @@ func (vv InputValues) SameValues(other InputValues) bool {
 	return true
 }
 
-// HasValues returns true if the reciever has the same values as in the given
+// HasValues returns true if the receiver has the same values as in the given
 // map, disregarding the source types and source ranges.
 //
 // Values are compared using the cty "RawEquals" method, which means that

--- a/internal/tfdiags/consolidate_warnings.go
+++ b/internal/tfdiags/consolidate_warnings.go
@@ -15,7 +15,7 @@ import "fmt"
 // particularly if they are going to be interpreted by software rather than
 // by a human reader.
 //
-// The returned slice always has a separate backing array from the reciever,
+// The returned slice always has a separate backing array from the receiver,
 // but some diagnostic values themselves might be shared.
 //
 // The definition of "unreasonable" is given as the threshold argument. At most

--- a/internal/tfdiags/diagnostic_extra.go
+++ b/internal/tfdiags/diagnostic_extra.go
@@ -85,7 +85,7 @@ func ExtraInfoNext[T any](previous interface{}) T {
 //
 // Diagnostic recipients which want to examine "Extra" values to sniff for
 // particular types of extra data can either type-assert this interface
-// directly and repeatedly unwrap until they recieve nil, or can use the
+// directly and repeatedly unwrap until they receive nil, or can use the
 // helper function DiagnosticExtra.
 //
 // This interface intentionally matches hcl.DiagnosticExtraUnwrapper, so that
@@ -93,7 +93,7 @@ func ExtraInfoNext[T any](previous interface{}) T {
 // tfdiags API, but that non-HCL uses of this will not need to implement HCL
 // just to get this interface.
 type DiagnosticExtraUnwrapper interface {
-	// If the reciever is wrapping another "diagnostic extra" value, returns
+	// If the receiver is wrapping another "diagnostic extra" value, returns
 	// that value. Otherwise returns nil to indicate dynamically that nothing
 	// is wrapped.
 	//


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Fixes No issue

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.8.x

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

### NEW FEATURES | UPGRADE NOTES | ENHANCEMENTS | BUG FIXES | EXPERIMENTS

<!--

Write a short description of the user-facing change. Examples:

- `terraform show -json`: Fixed crash with sensitive set values.
- When rendering a diff, Terraform now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 

-  Tiny internal tweak
