### PR TITLE
stacks: allow dynamic provider configurations during validation

### DIFF
--- a/internal/stacks/stackruntime/internal/stackeval/component_config.go
+++ b/internal/stacks/stackruntime/internal/stackeval/component_config.go
@@ -338,10 +338,6 @@ func (c *ComponentConfig) CheckProviders(ctx context.Context, phase EvalPhase) (
 				})
 				continue
 			}
-		} else if actualTy.Equals(cty.DynamicPseudoType) {
-			// This is a dynamic type, which means we don't know what it is. This can happen if the for_each
-			// contains unknown values, for example.
-			// We can't do any more validation here, so we'll just skip it.
 		} else {
 			// We got something that isn't a provider reference at all.
 			diags = diags.Append(&hcl.Diagnostic{

--- a/internal/stacks/stackruntime/testdata/mainbundle/test/with-single-input/provider-for-each/provider-for-each.tfstack.hcl
+++ b/internal/stacks/stackruntime/testdata/mainbundle/test/with-single-input/provider-for-each/provider-for-each.tfstack.hcl
@@ -1,0 +1,32 @@
+required_providers {
+  testing = {
+    source  = "hashicorp/testing"
+    version = "0.1.0"
+  }
+}
+
+variable "provider_set" {
+  type = set(string)
+  default = ["a", "b"]
+}
+
+provider "testing" "configurations" {
+  for_each = var.provider_set
+}
+
+variable "input" {
+  type = string
+}
+
+component "self" {
+  source = "../"
+  for_each = var.provider_set
+
+  providers = {
+    testing = provider.testing.configurations[each.value]
+  }
+
+  inputs = {
+    input = var.input
+  }
+}

--- a/internal/stacks/stackruntime/testdata/mainbundle/test/with-single-input/provider-for-each1/provider-for-each.tfstack.hcl
+++ b/internal/stacks/stackruntime/testdata/mainbundle/test/with-single-input/provider-for-each1/provider-for-each.tfstack.hcl
@@ -10,14 +10,15 @@ variable "provider_set" {
   default = ["a", "b"]
 }
 
-provider "testing" "configurations" {
-  for_each = var.provider_set
-}
 
 variable "input" {
   type = string
 }
 
+
+provider "testing" "configurations" {
+  for_each = var.provider_set
+}
 component "self" {
   source = "../"
   for_each = var.provider_set

--- a/internal/stacks/stackruntime/testdata/mainbundle/test/with-single-input/provider-for-each2/provider-for-each.tfstack.hcl
+++ b/internal/stacks/stackruntime/testdata/mainbundle/test/with-single-input/provider-for-each2/provider-for-each.tfstack.hcl
@@ -1,0 +1,31 @@
+required_providers {
+  testing = {
+    source  = "hashicorp/testing"
+    version = "0.1.0"
+  }
+}
+
+variable "provider_set" {
+  type = set(string)
+  default = ["a", "b"]
+}
+
+
+
+variable "input" {
+  type = string
+}
+
+provider "testing" "configurations" {}
+component "self" {
+    source = "../"
+    for_each = var.provider_set
+
+    providers = {
+        testing = provider.testing.configurations
+    }
+
+    inputs = {
+    input = var.input
+    }
+}

--- a/internal/stacks/stackruntime/validate_test.go
+++ b/internal/stacks/stackruntime/validate_test.go
@@ -61,9 +61,22 @@ var (
 				"input": cty.StringVal("input"),
 			},
 		},
-		filepath.Join("with-single-input", "provider-for-each"): {
+		filepath.Join("with-single-input", "provider-for-each1"): {
 			planInputVars: map[string]cty.Value{
 				"input": cty.StringVal("input"),
+				"provider_set": cty.SetVal([]cty.Value{
+					cty.StringVal("a"),
+					cty.StringVal("b"),
+				}),
+			},
+		},
+		filepath.Join("with-single-input", "provider-for-each2"): {
+			planInputVars: map[string]cty.Value{
+				"input": cty.StringVal("input"),
+				"provider_set": cty.SetVal([]cty.Value{
+					cty.StringVal("a"),
+					cty.StringVal("b"),
+				}),
 			},
 		},
 	}

--- a/internal/stacks/stackruntime/validate_test.go
+++ b/internal/stacks/stackruntime/validate_test.go
@@ -61,6 +61,11 @@ var (
 				"input": cty.StringVal("input"),
 			},
 		},
+		filepath.Join("with-single-input", "provider-for-each"): {
+			planInputVars: map[string]cty.Value{
+				"input": cty.StringVal("input"),
+			},
+		},
 	}
 
 	// invalidConfigurations are shared between the validate and plan tests.


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

For testing one can create a stack with a provider for_each and validate that it gets passed through correctly.

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.8.x

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

### BUG FIXES

<!--

Write a short description of the user-facing change. Examples:

- `terraform show -json`: Fixed crash with sensitive set values.
- When rendering a diff, Terraform now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 

- stacks: fix provider for_each references erroring with diagnostics
