### PR TITLE
Don't do a DeepCopy in the remote state backend to avoid double copying

### DIFF
--- a/internal/states/remote/state.go
+++ b/internal/states/remote/state.go
@@ -85,10 +85,8 @@ func (s *State) WriteState(state *states.State) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	// We create a deep copy of the state here, because the caller also has
-	// a reference to the given object and can potentially go on to mutate
-	// it after we return, but we want the snapshot at this point in time.
-	s.state = state.DeepCopy()
+	// We don't create a DeepCopy because it's already created in the `update_state_hook`
+	s.state = state
 
 	return nil
 }


### PR DESCRIPTION
The `updateStateHook` performs `DeepCopy` to create a `state` object that is then pushed to the `StateMgr.WriteState`.  If we use remote state backend, then it's doing `DeepCopy` again leading to increased pressure on the garbage collection in case of big states (couple of hundreds megabytes).

<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Fixes #35113

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.8.x

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

### NEW FEATURES | UPGRADE NOTES | ENHANCEMENTS | BUG FIXES | EXPERIMENTS

<!--

Write a short description of the user-facing change. Examples:

- `terraform show -json`: Fixed crash with sensitive set values.
- When rendering a diff, Terraform now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 

-  Bug fix: improve performance of remote state backend on huge plans
