### PR TITLE
stacks: error if provider emits deferred action when it's not supported

### DIFF
--- a/internal/plans/deferring/deferred.go
+++ b/internal/plans/deferring/deferred.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/plans"
 	"github.com/hashicorp/terraform/internal/providers"
+	"github.com/hashicorp/terraform/internal/tfdiags"
 )
 
 // Deferred keeps track of deferrals that have already happened, to help
@@ -434,4 +435,10 @@ func (d *Deferred) ReportModuleExpansionDeferred(addr addrs.PartialExpandedModul
 		panic(fmt.Sprintf("duplicate deferral report for %s", addr))
 	}
 	d.partialExpandedModulesDeferred.Add(addr)
+}
+
+// UnexpectedProviderDeferralDiagnostic is a diagnostic that indicates that a
+// provider was deferred although deferrals were not allowed.
+func UnexpectedProviderDeferralDiagnostic(addrs addrs.AbsResourceInstance) tfdiags.Diagnostic {
+	return tfdiags.Sourceless(tfdiags.Error, "Provider deferred changes when Terraform did not allow deferrals", fmt.Sprintf("The provider signaled a deferred action for %q, but in this context deferrals are disabled. This is a bug in the provider, please file an issue.", addrs.String()))
 }

--- a/internal/plans/deferring/deferred.go
+++ b/internal/plans/deferring/deferred.go
@@ -440,5 +440,5 @@ func (d *Deferred) ReportModuleExpansionDeferred(addr addrs.PartialExpandedModul
 // UnexpectedProviderDeferralDiagnostic is a diagnostic that indicates that a
 // provider was deferred although deferrals were not allowed.
 func UnexpectedProviderDeferralDiagnostic(addrs addrs.AbsResourceInstance) tfdiags.Diagnostic {
-	return tfdiags.Sourceless(tfdiags.Error, "Provider deferred changes when Terraform did not allow deferrals", fmt.Sprintf("The provider signaled a deferred action for %q, but in this context deferrals are disabled. This is a bug in the provider, please file an issue.", addrs.String()))
+	return tfdiags.Sourceless(tfdiags.Error, "Provider deferred changes when Terraform did not allow deferrals", fmt.Sprintf("The provider signaled a deferred action for %q, but in this context deferrals are disabled. This is a bug in the provider, please file an issue with the provider developers.", addrs.String()))
 }

--- a/internal/terraform/node_resource_plan_instance.go
+++ b/internal/terraform/node_resource_plan_instance.go
@@ -20,6 +20,7 @@ import (
 	"github.com/hashicorp/terraform/internal/instances"
 	"github.com/hashicorp/terraform/internal/moduletest/mocking"
 	"github.com/hashicorp/terraform/internal/plans"
+	"github.com/hashicorp/terraform/internal/plans/deferring"
 	"github.com/hashicorp/terraform/internal/providers"
 	"github.com/hashicorp/terraform/internal/states"
 	"github.com/hashicorp/terraform/internal/tfdiags"
@@ -477,6 +478,7 @@ func (n *NodePlannableResourceInstance) replaceTriggered(ctx EvalContext, repDat
 }
 
 func (n *NodePlannableResourceInstance) importState(ctx EvalContext, addr addrs.AbsResourceInstance, importId string, provider providers.Interface, providerSchema providers.ProviderSchema) (*states.ResourceInstanceObject, *providers.Deferred, tfdiags.Diagnostics) {
+	deferralAllowed := ctx.Deferrals().DeferralAllowed()
 	var diags tfdiags.Diagnostics
 	absAddr := addr.Resource.Absolute(ctx.Path())
 	hookResourceID := HookResourceIdentity{
@@ -558,9 +560,14 @@ func (n *NodePlannableResourceInstance) importState(ctx EvalContext, addr addrs.
 			TypeName: addr.Resource.Resource.Type,
 			ID:       importId,
 			ClientCapabilities: providers.ClientCapabilities{
-				DeferralAllowed: ctx.Deferrals().DeferralAllowed(),
+				DeferralAllowed: deferralAllowed,
 			},
 		})
+	}
+	// If we don't support deferrals, but the provider reports a deferral and does not
+	// emit any error level diagnostics, we should emit an error.
+	if resp.Deferred != nil && !deferralAllowed && !resp.Diagnostics.HasErrors() {
+		diags = diags.Append(deferring.UnexpectedProviderDeferralDiagnostic(n.Addr))
 	}
 	diags = diags.Append(resp.Diagnostics)
 	deferred = resp.Deferred


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Fixes #

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.8.x

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

### ENHANCEMENTS
<!--

Write a short description of the user-facing change. Examples:

- `terraform show -json`: Fixed crash with sensitive set values.
- When rendering a diff, Terraform now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 

-  stacks: if a provider uses deferred actions while terraform does not support this we will emit a diagnostic
