### PR TITLE
Finish implementation of unknown count/for_each in data sources

### DIFF
--- a/internal/plans/deferring/deferred.go
+++ b/internal/plans/deferring/deferred.go
@@ -139,6 +139,11 @@ func NewDeferred(resourceGraph addrs.DirectedGraph[addrs.ConfigResource], enable
 // been reported to the receiver.
 func (d *Deferred) GetDeferredChanges() []*plans.DeferredResourceInstanceChange {
 	var changes []*plans.DeferredResourceInstanceChange
+
+	if !d.deferralAllowed {
+		return changes
+	}
+
 	for _, configMapElem := range d.resourceInstancesDeferred.Elems {
 		for _, changeElem := range configMapElem.Value.Elems {
 			changes = append(changes, changeElem.Value)
@@ -196,6 +201,10 @@ func (d *Deferred) HaveAnyDeferrals() bool {
 // why the resource instance with the given address should have its planned
 // action deferred for a future plan/apply round.
 func (d *Deferred) IsResourceInstanceDeferred(addr addrs.AbsResourceInstance) bool {
+	if !d.deferralAllowed {
+		return false
+	}
+
 	if d.externalDependencyDeferred {
 		return true
 	}
@@ -230,6 +239,10 @@ func (d *Deferred) IsResourceInstanceDeferred(addr addrs.AbsResourceInstance) bo
 // instance action should be deferred _before_ reporting that it has been by calling
 // [Deferred.IsResourceInstanceDeferred].
 func (d *Deferred) ShouldDeferResourceInstanceChanges(addr addrs.AbsResourceInstance) bool {
+	if !d.deferralAllowed {
+		return false
+	}
+
 	d.mu.Lock()
 	defer d.mu.Unlock()
 

--- a/internal/terraform/context_apply.go
+++ b/internal/terraform/context_apply.go
@@ -154,6 +154,8 @@ func (c *Context) ApplyAndEval(plan *plans.Plan, config *configs.Config, opts *A
 		Overrides:               plan.Overrides,
 		ExternalProviderConfigs: opts.ExternalProviders,
 
+		DeferralAllowed: true,
+
 		// We need to propagate the check results from the plan phase,
 		// because that will tell us which checkable objects we're expecting
 		// to see updated results from during the apply step.

--- a/internal/terraform/context_apply2_test.go
+++ b/internal/terraform/context_apply2_test.go
@@ -1336,7 +1336,6 @@ output "out" {
 
 	_, diags = ctx.Plan(m, state, opts)
 	assertNoErrors(t, diags)
-	return
 
 	otherProvider.ConfigureProviderCalled = false
 	otherProvider.ConfigureProviderFn = func(req providers.ConfigureProviderRequest) (resp providers.ConfigureProviderResponse) {
@@ -2101,7 +2100,7 @@ resource "test_resource" "a" {
 
 import {
   to = test_resource.a
-  id = "importable" 
+  id = "importable"
 }
 `,
 	})

--- a/internal/terraform/context_apply_deferred_test.go
+++ b/internal/terraform/context_apply_deferred_test.go
@@ -82,6 +82,188 @@ var (
 	// We build some fairly complex configurations here, so we'll use separate
 	// variables for each one outside of the test function itself for clarity.
 
+	// dataForEachTest is a test for deferral of data sources due to unknown
+	// for_each values. Since data sources don't result in planned changes,
+	// deferral has to be observed indirectly by checking for deferral of
+	// downstream objects that would otherwise have no reason to be deferred.
+	dataForEachTest = deferredActionsTest{
+		configs: map[string]string{
+			"main.tf": `
+variable "each" {
+	type = set(string)
+}
+
+data "test" "a" {
+	for_each = var.each
+
+	name = "a:${each.key}"
+}
+
+resource "test" "b" {
+	name = "b"
+	upstream_names = [for v in data.test.a : v.name]
+}
+
+output "from_data" {
+	value = [for v in data.test.a : v.output]
+}
+
+output "from_resource" {
+	value = test.b.output
+}
+`,
+		},
+		stages: []deferredActionsTestStage{
+			// Stage 0. Unknown for_each in data source. The resource and
+			// outputs get transitively deferred.
+			{
+				inputs: map[string]cty.Value{
+					"each": cty.DynamicVal,
+				},
+				wantPlanned: map[string]cty.Value{
+					"b": cty.ObjectVal(map[string]cty.Value{
+						"name":           cty.StringVal("b"),
+						"output":         cty.UnknownVal(cty.String),
+						"upstream_names": cty.UnknownVal(cty.Set(cty.String)),
+					}),
+				},
+				wantActions: map[string]plans.Action{},
+				wantDeferred: map[string]ExpectedDeferred{
+					"test.b": {Reason: providers.DeferredReasonDeferredPrereq, Action: plans.Create},
+				},
+				wantApplied: map[string]cty.Value{},
+				// TODO: These deferred output values are wrong, but outputs are a separate ticket.
+				wantOutputs: map[string]cty.Value{
+					"from_data":     cty.EmptyTupleVal,
+					"from_resource": cty.NullVal(cty.DynamicPseudoType),
+				},
+				complete:      false,
+				allowWarnings: false,
+			},
+			// Stage 1. Everything's known now, so it converges.
+			{
+				inputs: map[string]cty.Value{
+					"each": cty.SetVal([]cty.Value{cty.StringVal("hey"), cty.StringVal("ho"), cty.StringVal("let's go")}),
+				},
+				wantPlanned: map[string]cty.Value{
+					"b": cty.ObjectVal(map[string]cty.Value{
+						"name":           cty.StringVal("b"),
+						"output":         cty.UnknownVal(cty.String),
+						"upstream_names": cty.SetVal([]cty.Value{cty.StringVal("a:hey"), cty.StringVal("a:ho"), cty.StringVal("a:let's go")}),
+					}),
+				},
+				wantActions: map[string]plans.Action{
+					"test.b": plans.Create,
+				},
+				wantDeferred: map[string]ExpectedDeferred{},
+				wantApplied: map[string]cty.Value{
+					"b": cty.ObjectVal(map[string]cty.Value{
+						"name":           cty.StringVal("b"),
+						"output":         cty.StringVal("b"),
+						"upstream_names": cty.SetVal([]cty.Value{cty.StringVal("a:hey"), cty.StringVal("a:ho"), cty.StringVal("a:let's go")}),
+					}),
+				},
+				wantOutputs: map[string]cty.Value{
+					"from_data":     cty.TupleVal([]cty.Value{cty.StringVal("a:hey"), cty.StringVal("a:ho"), cty.StringVal("a:let's go")}),
+					"from_resource": cty.StringVal("b"),
+				},
+				complete:      true,
+				allowWarnings: false,
+			},
+		},
+	}
+
+	// dataCountTest is a test for deferral of data sources due to unknown
+	// count values. Since data sources don't result in planned changes,
+	// deferral has to be observed indirectly by checking for deferral of
+	// downstream objects that would otherwise have no reason to be deferred.
+	dataCountTest = deferredActionsTest{
+		configs: map[string]string{
+			"main.tf": `
+variable "data_count" {
+	type = number
+}
+
+data "test" "a" {
+	count = var.data_count
+
+	name = "a:${count.index}"
+}
+
+resource "test" "b" {
+	name = "b"
+	upstream_names = [for v in data.test.a : v.name]
+}
+
+output "from_data" {
+	value = [for v in data.test.a : v.output]
+}
+
+output "from_resource" {
+	value = test.b.output
+}
+`,
+		},
+		stages: []deferredActionsTestStage{
+			// Stage 0. Unknown count in data source. The resource and
+			// outputs get transitively deferred.
+			{
+				inputs: map[string]cty.Value{
+					"data_count": cty.DynamicVal,
+				},
+				wantPlanned: map[string]cty.Value{
+					"b": cty.ObjectVal(map[string]cty.Value{
+						"name":           cty.StringVal("b"),
+						"output":         cty.UnknownVal(cty.String),
+						"upstream_names": cty.UnknownVal(cty.Set(cty.String)),
+					}),
+				},
+				wantActions: map[string]plans.Action{},
+				wantDeferred: map[string]ExpectedDeferred{
+					"test.b": {Reason: providers.DeferredReasonDeferredPrereq, Action: plans.Create},
+				},
+				wantApplied: map[string]cty.Value{},
+				// TODO: These deferred output values are wrong, but outputs are a separate ticket.
+				wantOutputs: map[string]cty.Value{
+					"from_data":     cty.EmptyTupleVal,
+					"from_resource": cty.NullVal(cty.DynamicPseudoType),
+				},
+				complete:      false,
+				allowWarnings: false,
+			},
+			// Stage 1. Everything's known now, so it converges.
+			{
+				inputs: map[string]cty.Value{
+					"data_count": cty.NumberIntVal(3),
+				},
+				wantPlanned: map[string]cty.Value{
+					"b": cty.ObjectVal(map[string]cty.Value{
+						"name":           cty.StringVal("b"),
+						"output":         cty.UnknownVal(cty.String),
+						"upstream_names": cty.SetVal([]cty.Value{cty.StringVal("a:0"), cty.StringVal("a:1"), cty.StringVal("a:2")}),
+					}),
+				},
+				wantActions: map[string]plans.Action{
+					"test.b": plans.Create,
+				},
+				wantDeferred: map[string]ExpectedDeferred{},
+				wantApplied: map[string]cty.Value{
+					"b": cty.ObjectVal(map[string]cty.Value{
+						"name":           cty.StringVal("b"),
+						"output":         cty.StringVal("b"),
+						"upstream_names": cty.SetVal([]cty.Value{cty.StringVal("a:0"), cty.StringVal("a:1"), cty.StringVal("a:2")}),
+					}),
+				},
+				wantOutputs: map[string]cty.Value{
+					"from_data":     cty.TupleVal([]cty.Value{cty.StringVal("a:0"), cty.StringVal("a:1"), cty.StringVal("a:2")}),
+					"from_resource": cty.StringVal("b"),
+				},
+				complete:      true,
+				allowWarnings: false,
+			},
+		},
+	}
+
 	// resourceForEachTest is a test that exercises the deferred actions
 	// mechanism with a configuration that has a resource with an unknown
 	// for_each attribute.
@@ -2101,6 +2283,8 @@ func TestContextApply_deferredActions(t *testing.T) {
 		"custom_conditions_with_orphans":                    customConditionsWithOrphansTest,
 		"resource_read":                                     resourceReadTest,
 		"data_read":                                         readDataSourceTest,
+		"data_for_each":                                     dataForEachTest,
+		"data_count":                                        dataCountTest,
 		"plan_create_resource_change":                       planCreateResourceChange,
 		"plan_update_resource_change":                       planUpdateResourceChange,
 		"plan_noop_resource_change":                         planNoOpResourceChange,

--- a/internal/terraform/context_apply_deferred_test.go
+++ b/internal/terraform/context_apply_deferred_test.go
@@ -1627,7 +1627,8 @@ output "b" {
 				},
 				wantOutputs: map[string]cty.Value{
 					"a": cty.NullVal(cty.Object(map[string]cty.Type{
-						"name": cty.String,
+						"name":   cty.String,
+						"output": cty.String,
 					})),
 					"b": cty.NullVal(cty.DynamicPseudoType),
 				},
@@ -2311,6 +2312,10 @@ func (provider *deferredActionsProvider) Provider() providers.Interface {
 								Type:     cty.String,
 								Required: true,
 							},
+							"output": {
+								Computed: true,
+								Type:     cty.String,
+							},
 						},
 					},
 				},
@@ -2340,7 +2345,10 @@ func (provider *deferredActionsProvider) Provider() providers.Interface {
 				}
 			}
 			return providers.ReadDataSourceResponse{
-				State: req.Config,
+				State: cty.ObjectVal(map[string]cty.Value{
+					"name":   req.Config.GetAttr("name"),
+					"output": req.Config.GetAttr("name"),
+				}),
 			}
 		},
 		PlanResourceChangeFn: func(req providers.PlanResourceChangeRequest) providers.PlanResourceChangeResponse {

--- a/internal/terraform/context_walk.go
+++ b/internal/terraform/context_walk.go
@@ -168,18 +168,19 @@ func (c *Context) graphWalker(graph *Graph, operation walkOperation, opts *graph
 		}
 	}
 
-	var deferred *deferring.Deferred
-
+	var resourceGraph addrs.DirectedGraph[addrs.ConfigResource]
 	if opts.DeferralAllowed {
 		// We'll produce a derived graph that only includes the static resource
 		// blocks, since we need that for deferral tracking.
-		resourceGraph := graph.ResourceGraph()
-		deferred = deferring.NewDeferred(resourceGraph, opts.DeferralAllowed)
-		if opts.ExternalDependencyDeferred {
-			deferred.SetExternalDependencyDeferred()
-		}
+		resourceGraph = graph.ResourceGraph()
 	} else {
-		deferred = deferring.NewDeferred(addrs.NewDirectedGraph[addrs.ConfigResource](), false)
+		// Temporary (hopefully) optimization: skip building the expensive resource graph.
+		resourceGraph = addrs.NewDirectedGraph[addrs.ConfigResource]()
+	}
+
+	deferred := deferring.NewDeferred(resourceGraph, opts.DeferralAllowed)
+	if opts.ExternalDependencyDeferred {
+		deferred.SetExternalDependencyDeferred()
 	}
 
 	return &ContextGraphWalker{

--- a/internal/terraform/context_walk.go
+++ b/internal/terraform/context_walk.go
@@ -169,7 +169,7 @@ func (c *Context) graphWalker(graph *Graph, operation walkOperation, opts *graph
 	}
 
 	var resourceGraph addrs.DirectedGraph[addrs.ConfigResource]
-	if opts.DeferralAllowed {
+	if opts.DeferralAllowed && (operation == walkPlan || operation == walkPlanDestroy) {
 		// We'll produce a derived graph that only includes the static resource
 		// blocks, since we need that for deferral tracking.
 		resourceGraph = graph.ResourceGraph()


### PR DESCRIPTION
This PR adds tests for deferring data sources due to unknown count/for_each values, and makes the necessary behavior changes to get those tests passing. 

For reviewers: here's the main things to validate about this PR.

- Is it logically and practically sound to _always_ set `deferralAllowed = true` in applies? If not, can we think of a safer way to re-process data sources that should be deferred (preferably without significantly changing the semantics of the plan)?
- Does it make sense for `Deferred`'s informational methods to do early negative returns if `deferralAllowed == false`?
- Can we think of any additional ways to directly or indirectly observe the effect of deferring a data source? I had a brief thought about spying on data source read requests in the mock provider, but in practice it turned out to be kinda awkward and not informative enough. More iteration might make something useful of it, tho. 🤔 

## Target Release

1.9.x

## Draft CHANGELOG entry

### EXPERIMENTS

The deferred actions experiment now supports deferring data sources due to unknown count/for_each values. 