### PR TITLE
build: Set up Dependabot to manage HashiCorp-owned GitHub Actions versioning

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,7 +13,6 @@ updates:
     # only update HashiCorp actions, external actions managed by TSCCR
     allow:
       - dependency-name: hashicorp/*
-      - dependency-name: hashicorp-dev/*
     groups:
     	github-actions-breaking:
         update-types:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,10 +14,10 @@ updates:
     allow:
       - dependency-name: hashicorp/*
     groups:
-    	github-actions-breaking:
+      github-actions-breaking:
         update-types:
           - major
-    	github-actions-backward-compatible:
+      github-actions-backward-compatible:
         update-types:
           - minor
           - patch

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,24 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly
+    labels:
+      - dependencies
+      - build
+      - security
+    reviewers:
+      - hashicorp/terraform-core
+    # only update HashiCorp actions, external actions managed by TSCCR
+    allow:
+      - dependency-name: hashicorp/*
+      - dependency-name: hashicorp-dev/*
+    groups:
+    	github-actions-breaking:
+        update-types:
+          - major
+    	github-actions-backward-compatible:
+        update-types:
+          - minor
+          - patch

--- a/.github/workflows/build-terraform-cli.yml
+++ b/.github/workflows/build-terraform-cli.yml
@@ -67,7 +67,7 @@ jobs:
         run: |
           mkdir -p "$LICENSE_DIR" && cp LICENSE "$LICENSE_DIR/LICENSE.txt"
       - if: ${{ inputs.goos == 'linux' }}
-        uses: hashicorp/actions-packaging-linux@v1
+        uses: hashicorp/actions-packaging-linux@0596d94121d44bd00463ac9d245efea64ee282d0 # v1.7
         with:
           name: "terraform"
           description: "Terraform enables you to safely and predictably create, change, and improve infrastructure. It is a tool that codifies APIs into declarative configuration files that can be shared amongst team members, treated as code, edited, reviewed, and versioned."

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,7 +43,7 @@ jobs:
           echo "pkg-name=${pkg_name}" | tee -a "${GITHUB_OUTPUT}"
       - name: Decide version number
         id: get-product-version
-        uses: hashicorp/actions-set-product-version@v1
+        uses: hashicorp/actions-set-product-version@e2c49d61aff17b1280ddfe7bb031331d02ca0140 # v1.0.1
       - name: Determine experiments
         id: get-ldflags
         env:
@@ -78,7 +78,7 @@ jobs:
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
       - name: Generate package metadata
         id: generate-metadata-file
-        uses: hashicorp/actions-generate-metadata@v1
+        uses: hashicorp/actions-generate-metadata@fdbc8803a0e53bcbb912ddeee3808329033d6357 # v1.1.1
         with:
           version: ${{ needs.get-product-version.outputs.product-version }}
           product: ${{ env.PKG_NAME }}
@@ -139,7 +139,7 @@ jobs:
     steps:
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
       - name: Build Docker images
-        uses: hashicorp/actions-docker-build@v1
+        uses: hashicorp/actions-docker-build@f6278ea21555b4b4737e4cf366e808ba2bb59146 # v1.6.1
         with:
           pkg_name: "terraform_${{env.version}}"
           version: ${{env.version}}


### PR DESCRIPTION
This sets up Dependabot to manage version updates for HashiCorp-owned GitHub Actions; all other (third-party) version updates will be handled by HashiCorp's internal TSCCR tooling. TSCCR does not/cannot manage HashiCorp-owned Actions versioning which is why we need to bring in Dependabot to handle this component; see [this memo](https://hermes.hashicorp.services/document/151w0ldYS3Z3arAiSTRuFImV73VabC0rhZJPCv6fzl4Q) (internal HashiCorp link) for details.

This PR also pins all HashiCorp-owned Actions used in this repo to using SHA hashes which is considered a security best-practice these days. This will force Dependabot to continue with this convention, and it is smart enough to update the comment on each of these lines to let us know which is the actual version that's being used.

## Target Release

N/A

## Draft CHANGELOG entry

N/A
