### PR TITLE
backend/local: Allow experiments when loading config from snapshot

### DIFF
--- a/internal/backend/local/backend_local.go
+++ b/internal/backend/local/backend_local.go
@@ -239,6 +239,7 @@ func (b *Local) localRunForPlanFile(op *backendrun.Operation, pf *planfile.Reade
 		return nil, snap, diags
 	}
 	loader := configload.NewLoaderFromSnapshot(snap)
+	loader.AllowLanguageExperiments(op.ConfigLoader.AllowsLanguageExperiments())
 	config, configDiags := loader.LoadConfig(snap.Modules[""].Dir)
 	diags = diags.Append(configDiags)
 	if configDiags.HasErrors() {

--- a/internal/configs/configload/loader.go
+++ b/internal/configs/configload/loader.go
@@ -164,3 +164,10 @@ func (l *Loader) ImportSourcesFromSnapshot(snap *Snapshot) {
 func (l *Loader) AllowLanguageExperiments(allowed bool) {
 	l.parser.AllowLanguageExperiments(allowed)
 }
+
+// AllowsLanguageExperiments returns the value most recently passed to
+// [Loader.AllowLanguageExperiments], or false if that method has not been
+// called on this object.
+func (l *Loader) AllowsLanguageExperiments() bool {
+	return l.parser.AllowsLanguageExperiments()
+}

--- a/internal/configs/parser.go
+++ b/internal/configs/parser.go
@@ -121,3 +121,10 @@ func (p *Parser) ForceFileSource(filename string, src []byte) {
 func (p *Parser) AllowLanguageExperiments(allowed bool) {
 	p.allowExperiments = allowed
 }
+
+// AllowsLanguageExperiments returns the value most recently passed to
+// [Parser.AllowLanguageExperiments], or false if that method has not been
+// called on this object.
+func (p *Parser) AllowsLanguageExperiments() bool {
+	return p.allowExperiments
+}


### PR DESCRIPTION
If a saved plan is being applied using a Terraform CLI/Core build that allows use of language experiments then that should be allowed when the configuration is being loaded from the snapshot saved in a plan file, in the same way as it would've been handled when preparing to generate that plan file.

The local backend doesn't get told directly whether it should allow experiments, and instead its operation comes with a pre-configured configuration loader that may have the experiment flag set internally.

When we load from snapshot we can't use the operation's own config loader because that loads from the real filesystem, and so we'll copy over the experiments-allowed flag from the operation's config loader to achieve consistency while still loading the configuration from the snapshot in the plan file.

Without this a plan successfully created with experiments would fail with confusing errors during apply, because the snapshot config loader would not accept the same experiments that the plan-time config loader did.

---

There are no updates to automated tests here because unfortunately we don't really have good ways to test for correct propagation of the experiments-allowed flag, but I've tested this manually as part of my work on https://github.com/hashicorp/terraform/pull/35078 (which was how I found the bug in the first place).
