### PR TITLE
Reduce redundant walks when resolving module `depends_on`

### DIFF
--- a/internal/dag/dag.go
+++ b/internal/dag/dag.go
@@ -30,14 +30,21 @@ func (g *AcyclicGraph) DirectedGraph() Grapher {
 
 // Returns a Set that includes every Vertex yielded by walking down from the
 // provided starting Vertex v.
-func (g *AcyclicGraph) Ancestors(v Vertex) (Set, error) {
+func (g *AcyclicGraph) Ancestors(vs ...Vertex) (Set, error) {
 	s := make(Set)
 	memoFunc := func(v Vertex, d int) error {
 		s.Add(v)
 		return nil
 	}
 
-	if err := g.DepthFirstWalk(g.downEdgesNoCopy(v), memoFunc); err != nil {
+	start := make(Set)
+	for _, v := range vs {
+		for _, dep := range g.downEdgesNoCopy(v) {
+			start.Add(dep)
+		}
+	}
+
+	if err := g.DepthFirstWalk(start, memoFunc); err != nil {
 		return nil, err
 	}
 
@@ -46,14 +53,21 @@ func (g *AcyclicGraph) Ancestors(v Vertex) (Set, error) {
 
 // Returns a Set that includes every Vertex yielded by walking up from the
 // provided starting Vertex v.
-func (g *AcyclicGraph) Descendents(v Vertex) (Set, error) {
+func (g *AcyclicGraph) Descendents(vs ...Vertex) (Set, error) {
 	s := make(Set)
 	memoFunc := func(v Vertex, d int) error {
 		s.Add(v)
 		return nil
 	}
 
-	if err := g.ReverseDepthFirstWalk(g.upEdgesNoCopy(v), memoFunc); err != nil {
+	start := make(Set)
+	for _, v := range vs {
+		for _, dep := range g.upEdgesNoCopy(v) {
+			start.Add(dep)
+		}
+	}
+
+	if err := g.ReverseDepthFirstWalk(start, memoFunc); err != nil {
 		return nil, err
 	}
 

--- a/internal/terraform/transform_reference.go
+++ b/internal/terraform/transform_reference.go
@@ -437,17 +437,18 @@ func (m ReferenceMap) parentModuleDependsOn(g *Graph, depender graphNodeDependsO
 
 		deps, fromParentModule := m.dependsOn(g, mod)
 		for _, dep := range deps {
-			// add the dependency
-			res = append(res, dep)
-
-			// and check any transitive resource dependencies for more resources
-			ans, _ := g.Ancestors(dep)
-			for _, v := range ans {
-				if isDependableResource(v) {
-					res = append(res, v)
-				}
+			if isDependableResource(dep) {
+				res = append(res, dep)
 			}
 		}
+
+		ans, _ := g.Ancestors(deps...)
+		for _, v := range ans {
+			if isDependableResource(v) {
+				res = append(res, v)
+			}
+		}
+
 		fromModule = fromModule || fromParentModule
 	}
 


### PR DESCRIPTION
The use of `depends_on` in modules can cause large numbers of nodes to become connected to all of the same dependencies. When using `Ancestors` to walk the graph and find all of these dependencies, there can be a lot of redundant ancestors shared between each of the original nodes, causing an exponential increase in processing time and memory use. 

Instead of traversing the graph from each dependency individually, which can frequently end up duplicating results, we can start a walk from all nodes at once, reducing the redundant graph traversals and automatically removing duplicates.

Fixes #35154

## Target Release

v1.8.4