### PR TITLE
terraform test: Disallow version constraints within test files

### DIFF
--- a/internal/command/providers_test.go
+++ b/internal/command/providers_test.go
@@ -192,7 +192,6 @@ func TestProviders_tests(t *testing.T) {
 	}
 
 	wantOutput := []string{
-		"provider[registry.terraform.io/hashicorp/foo]",
 		"test.main",
 		"provider[registry.terraform.io/hashicorp/bar]",
 	}

--- a/internal/command/testdata/init-with-tests-external-providers/main.tf
+++ b/internal/command/testdata/init-with-tests-external-providers/main.tf
@@ -1,0 +1,3 @@
+resource "testing_instance" "baz" {
+  ami = "baz"
+}

--- a/internal/command/testdata/init-with-tests-external-providers/main.tftest.hcl
+++ b/internal/command/testdata/init-with-tests-external-providers/main.tftest.hcl
@@ -1,0 +1,25 @@
+
+// configure is not a "hashicorp" provider, so it won't be able to load
+// this using the default behaviour. Terraform will need to look into the setup
+// module to find the provider configuration.
+provider "configure" {}
+
+// testing is a "hashicorp" provider, so it can load this using the defaults
+// even though not required provider block providers a definition for it.
+provider "testing" {}
+
+run "setup" {
+  module {
+    source = "./setup"
+  }
+
+  providers = {
+    configure = configure
+  }
+}
+
+run "test" {
+  providers = {
+    testing = testing
+  }
+}

--- a/internal/command/testdata/init-with-tests-external-providers/setup/main.tf
+++ b/internal/command/testdata/init-with-tests-external-providers/setup/main.tf
@@ -1,0 +1,11 @@
+terraform {
+  required_providers {
+    configure = {
+      source = "testing/configure"
+    }
+  }
+}
+
+resource "configure_instance" "baz" {
+  ami = "baz"
+}

--- a/internal/command/testdata/providers/tests/main.tftest.hcl
+++ b/internal/command/testdata/providers/tests/main.tftest.hcl
@@ -1,3 +1,5 @@
+// This won't actually show up in the providers list, as nothing is actually
+// using it.
 provider "foo" {
 
 }

--- a/internal/configs/config.go
+++ b/internal/configs/config.go
@@ -384,10 +384,6 @@ func (c *Config) ProviderRequirementsByModule() (*ModuleRequirements, hcl.Diagno
 			Runs:         make(map[string]*ModuleRequirements),
 		}
 
-		for _, provider := range test.Providers {
-			diags = append(diags, c.addProviderRequirementsFromProviderBlock(testReqs.Requirements, provider)...)
-		}
-
 		for _, run := range test.Runs {
 			if run.ConfigUnderTest == nil {
 				continue
@@ -556,20 +552,13 @@ func (c *Config) addProviderRequirements(reqs providerreqs.Requirements, recurse
 
 	// We may have provider blocks and required_providers set in some testing
 	// files.
-	if tests {
+	if tests && recurse {
 		for _, file := range c.Module.Tests {
-			for _, provider := range file.Providers {
-				moreDiags := c.addProviderRequirementsFromProviderBlock(reqs, provider)
-				diags = append(diags, moreDiags...)
-			}
-
-			if recurse {
-				// Then we'll also look for requirements in testing modules.
-				for _, run := range file.Runs {
-					if run.ConfigUnderTest != nil {
-						moreDiags := run.ConfigUnderTest.addProviderRequirements(reqs, true, false)
-						diags = append(diags, moreDiags...)
-					}
+			// Then we'll also look for requirements in testing modules.
+			for _, run := range file.Runs {
+				if run.ConfigUnderTest != nil {
+					moreDiags := run.ConfigUnderTest.addProviderRequirements(reqs, true, false)
+					diags = append(diags, moreDiags...)
 				}
 			}
 		}

--- a/internal/configs/config_test.go
+++ b/internal/configs/config_test.go
@@ -165,12 +165,7 @@ func TestConfigProviderRequirements(t *testing.T) {
 
 func TestConfigProviderRequirementsInclTests(t *testing.T) {
 	cfg, diags := testNestedModuleConfigFromDirWithTests(t, "testdata/provider-reqs-with-tests")
-	// TODO: Version Constraint Deprecation.
-	// Once we've removed the version argument from provider configuration
-	// blocks, this can go back to expected 0 diagnostics.
-	// assertNoDiagnostics(t, diags)
-	assertDiagnosticCount(t, diags, 1)
-	assertDiagnosticSummary(t, diags, "Version constraints inside provider configuration blocks are deprecated")
+	assertDiagnosticCount(t, diags, 0)
 
 	tlsProvider := addrs.NewProvider(
 		addrs.DefaultProviderRegistryHost,
@@ -189,7 +184,7 @@ func TestConfigProviderRequirementsInclTests(t *testing.T) {
 		nullProvider:       providerreqs.MustParseVersionConstraints("~> 2.0.0"),
 		randomProvider:     providerreqs.MustParseVersionConstraints("~> 1.2.0"),
 		tlsProvider:        providerreqs.MustParseVersionConstraints("~> 3.0"),
-		configuredProvider: providerreqs.MustParseVersionConstraints("~> 1.4"),
+		configuredProvider: nil,
 		impliedProvider:    nil,
 		terraformProvider:  nil,
 	}
@@ -243,12 +238,7 @@ func TestConfigProviderRequirementsShallow(t *testing.T) {
 
 func TestConfigProviderRequirementsShallowInclTests(t *testing.T) {
 	cfg, diags := testNestedModuleConfigFromDirWithTests(t, "testdata/provider-reqs-with-tests")
-	// TODO: Version Constraint Deprecation.
-	// Once we've removed the version argument from provider configuration
-	// blocks, this can go back to expected 0 diagnostics.
-	// assertNoDiagnostics(t, diags)
-	assertDiagnosticCount(t, diags, 1)
-	assertDiagnosticSummary(t, diags, "Version constraints inside provider configuration blocks are deprecated")
+	assertDiagnosticCount(t, diags, 0)
 
 	tlsProvider := addrs.NewProvider(
 		addrs.DefaultProviderRegistryHost,
@@ -256,15 +246,13 @@ func TestConfigProviderRequirementsShallowInclTests(t *testing.T) {
 	)
 	impliedProvider := addrs.NewDefaultProvider("implied")
 	terraformProvider := addrs.NewBuiltInProvider("terraform")
-	configuredProvider := addrs.NewDefaultProvider("configured")
 
 	got, diags := cfg.ProviderRequirementsShallow()
 	assertNoDiagnostics(t, diags)
 	want := providerreqs.Requirements{
-		tlsProvider:        providerreqs.MustParseVersionConstraints("~> 3.0"),
-		configuredProvider: providerreqs.MustParseVersionConstraints("~> 1.4"),
-		impliedProvider:    nil,
-		terraformProvider:  nil,
+		tlsProvider:       providerreqs.MustParseVersionConstraints("~> 3.0"),
+		impliedProvider:   nil,
+		terraformProvider: nil,
 	}
 
 	if diff := cmp.Diff(want, got); diff != "" {
@@ -346,12 +334,7 @@ func TestConfigProviderRequirementsByModule(t *testing.T) {
 
 func TestConfigProviderRequirementsByModuleInclTests(t *testing.T) {
 	cfg, diags := testNestedModuleConfigFromDirWithTests(t, "testdata/provider-reqs-with-tests")
-	// TODO: Version Constraint Deprecation.
-	// Once we've removed the version argument from provider configuration
-	// blocks, this can go back to expected 0 diagnostics.
-	// assertNoDiagnostics(t, diags)
-	assertDiagnosticCount(t, diags, 1)
-	assertDiagnosticSummary(t, diags, "Version constraints inside provider configuration blocks are deprecated")
+	assertDiagnosticCount(t, diags, 0)
 
 	tlsProvider := addrs.NewProvider(
 		addrs.DefaultProviderRegistryHost,
@@ -378,17 +361,16 @@ func TestConfigProviderRequirementsByModuleInclTests(t *testing.T) {
 		Children: make(map[string]*ModuleRequirements),
 		Tests: map[string]*TestFileModuleRequirements{
 			"provider-reqs-root.tftest.hcl": {
-				Requirements: providerreqs.Requirements{
-					configuredProvider: providerreqs.MustParseVersionConstraints("~> 1.4"),
-				},
+				Requirements: providerreqs.Requirements{},
 				Runs: map[string]*ModuleRequirements{
 					"setup": {
 						Name:       "setup",
 						SourceAddr: addrs.ModuleSourceLocal("./setup"),
 						SourceDir:  "testdata/provider-reqs-with-tests/setup",
 						Requirements: providerreqs.Requirements{
-							nullProvider:   providerreqs.MustParseVersionConstraints("~> 2.0.0"),
-							randomProvider: providerreqs.MustParseVersionConstraints("~> 1.2.0"),
+							nullProvider:       providerreqs.MustParseVersionConstraints("~> 2.0.0"),
+							randomProvider:     providerreqs.MustParseVersionConstraints("~> 1.2.0"),
+							configuredProvider: nil,
 						},
 						Children: make(map[string]*ModuleRequirements),
 						Tests:    make(map[string]*TestFileModuleRequirements),

--- a/internal/configs/parser_config.go
+++ b/internal/configs/parser_config.go
@@ -147,7 +147,7 @@ func parseConfigFile(body hcl.Body, diags hcl.Diagnostics, override, allowExperi
 			})
 
 		case "provider":
-			cfg, cfgDiags := decodeProviderBlock(block)
+			cfg, cfgDiags := decodeProviderBlock(block, false)
 			diags = append(diags, cfgDiags...)
 			if cfg != nil {
 				file.ProviderConfigs = append(file.ProviderConfigs, cfg)

--- a/internal/configs/test_file.go
+++ b/internal/configs/test_file.go
@@ -337,7 +337,7 @@ func loadTestFile(body hcl.Body) (*TestFile, hcl.Diagnostics) {
 				tf.Variables[v.Name] = v.Expr
 			}
 		case "provider":
-			provider, providerDiags := decodeProviderBlock(block)
+			provider, providerDiags := decodeProviderBlock(block, true)
 			diags = append(diags, providerDiags...)
 			if provider != nil {
 				key := provider.moduleUniqueKey()

--- a/internal/configs/testdata/provider-reqs-with-tests/provider-reqs-root.tftest.hcl
+++ b/internal/configs/testdata/provider-reqs-with-tests/provider-reqs-root.tftest.hcl
@@ -1,8 +1,6 @@
-# There is no provider in required_providers called "configured", so the version
-# constraint should come from this configuration block.
-provider "configured" {
-  version = "~> 1.4"
-}
+# There is no provider in required_providers called "configured", so we won't
+# have a version constraint for it.
+provider "configured" {}
 
 run "setup" {
   module {

--- a/internal/configs/testdata/provider-reqs-with-tests/setup/setup.tf
+++ b/internal/configs/testdata/provider-reqs-with-tests/setup/setup.tf
@@ -6,3 +6,5 @@ terraform {
     }
   }
 }
+
+resource "configured_resource" "resource" {}

--- a/internal/moduletest/config/config.go
+++ b/internal/moduletest/config/config.go
@@ -87,7 +87,6 @@ func TransformConfigForTest(config *configs.Config, run *moduletest.Run, file *m
 				NameRange:  ref.InChild.NameRange,
 				Alias:      ref.InChild.Alias,
 				AliasRange: ref.InChild.AliasRange,
-				Version:    testProvider.Version,
 				Config: &hcltest.ProviderConfig{
 					Original:            testProvider.Config,
 					VariableCache:       variableCaches.GetCache(run.Name, config),
@@ -114,7 +113,6 @@ func TransformConfigForTest(config *configs.Config, run *moduletest.Run, file *m
 				NameRange:  provider.NameRange,
 				Alias:      provider.Alias,
 				AliasRange: provider.AliasRange,
-				Version:    provider.Version,
 				Config: &hcltest.ProviderConfig{
 					Original:            provider.Config,
 					VariableCache:       variableCaches.GetCache(run.Name, config),


### PR DESCRIPTION
This PR fixes a bug in which non-hashicorp providers defined within test files and referenced within alternate testing modules were wrongly being assumed as hashicorp providers and were failing to install.

We do this by no longer actually looking at test files for provider information. Since test files don't actually use providers directly and just hand them off to the main files, we don't need to consider the provider blocks in test files when calculating provider address and version constraints. This simplifies the provider constraint gathering and solves the underlying bug since the provider types don't need to be assumed within the test file at all now. It does mean that version constraints within provider blocks within test files will no longer be consulted. As such, I've updated the configuration parsing so that it errors if test files contain version constraints. (as an aside, I wish I'd done this when we first launched the test framework but oh well should have been braver)

Unfortunately, this is a breaking change so I won't backport this change. Instead, we should launch it in 1.9.0 with warnings in the changelog and upgrade guide. There is a fairly simple workaround in 1.8 currently so there is no urgency requiring a quick backport.

I did notice that it's been 4 years since we deprecated the version constraint within provider blocks at all, so maybe we could remove it entirely? I suspect this is a bad idea, as modules with embedded version constraints will just start completely failing to load and there would generally nothing a user could do to fix this as the module maybe downloaded remotely. Note, that the testing framework doesn't have this issue as it doesn't recursively load testing files from linked modules, so there will never be a case where the user can't fix this simply by updating their own configuration.

<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Fixes #35160 

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.9.0

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

### BUG FIXES

- `terraform test`: Fix bug in which non-Hashicorp providers required by testing modules and initialised within the test files were assigned incorrect registry addresses.

### UPGRADE NOTES

<!--

Write a short description of the user-facing change. Examples:

- `terraform show -json`: Fixed crash with sensitive set values.
- When rendering a diff, Terraform now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 

-  `terraform test`: It is no longer valid to specify version constraints within `provider` blocks within `.tftest.hcl` files. Instead, version constraints must be supplied within the main configuration where the provider is in use.
