### PR TITLE
Support moving from null_resource to terraform_data

### DIFF
--- a/internal/builtin/providers/terraform/provider_test.go
+++ b/internal/builtin/providers/terraform/provider_test.go
@@ -4,10 +4,66 @@
 package terraform
 
 import (
+	"testing"
+
 	backendInit "github.com/hashicorp/terraform/internal/backend/init"
+	"github.com/hashicorp/terraform/internal/providers"
+	"github.com/zclconf/go-cty/cty"
+	ctyjson "github.com/zclconf/go-cty/cty/json"
 )
 
 func init() {
 	// Initialize the backends
 	backendInit.Init(nil)
+}
+
+func TestMoveResourceState_DataStore(t *testing.T) {
+	t.Parallel()
+
+	nullResourceStateValue := cty.ObjectVal(map[string]cty.Value{
+		"id": cty.StringVal("test"),
+	})
+	nullResourceStateJSON, err := ctyjson.Marshal(nullResourceStateValue, nullResourceStateValue.Type())
+
+	if err != nil {
+		t.Fatalf("failed to marshal null resource state: %s", err)
+	}
+
+	provider := &Provider{}
+	req := providers.MoveResourceStateRequest{
+		SourceProviderAddress: "registry.terraform.io/hashicorp/null",
+		SourceStateJSON:       nullResourceStateJSON,
+		SourceTypeName:        "null_resource",
+		TargetTypeName:        "terraform_data",
+	}
+	resp := provider.MoveResourceState(req)
+
+	if resp.Diagnostics.HasErrors() {
+		t.Errorf("unexpected diagnostics: %s", resp.Diagnostics.Err())
+	}
+
+	expectedTargetState := cty.ObjectVal(map[string]cty.Value{
+		"id":               cty.StringVal("test"),
+		"input":            cty.NullVal(cty.DynamicPseudoType),
+		"output":           cty.NullVal(cty.DynamicPseudoType),
+		"triggers_replace": cty.NullVal(cty.DynamicPseudoType),
+	})
+
+	if !resp.TargetState.RawEquals(expectedTargetState) {
+		t.Errorf("expected state was:\n%#v\ngot state is:\n%#v\n", expectedTargetState, resp.TargetState)
+	}
+}
+
+func TestMoveResourceState_NonExistentResource(t *testing.T) {
+	t.Parallel()
+
+	provider := &Provider{}
+	req := providers.MoveResourceStateRequest{
+		TargetTypeName: "nonexistent_resource",
+	}
+	resp := provider.MoveResourceState(req)
+
+	if !resp.Diagnostics.HasErrors() {
+		t.Fatal("expected diagnostics")
+	}
 }


### PR DESCRIPTION
This change enables the built-in provider's `terraform_data` managed resource to work with the `moved` configuration block where the `from` address is a `null_resource` managed resource type from the official `hashicorp/null` provider. It produces no plan differences for typical configurations and specifically helps practitioners from re-running provisioners while moving resource types.

In addition to the unit testing, this was manually tested with the following configurations and outputs:

Initial configuration (no `triggers`):

```terraform
terraform {
  required_providers {
    null = {
      source  = "hashicorp/null"
      version = "3.2.2"
    }
  }
}

resource "null_resource" "example" {
  provisioner "local-exec" {
    command = "echo 'Hello, World!'"
  }
}
```

Moved configuration (no `triggers`):

```terraform
resource "terraform_data" "example" {
  provisioner "local-exec" {
    command = "echo 'Hello, World!'"
  }
}

moved {
  from = null_resource.example
  to   = terraform_data.example
}
```

Moved output (no `triggers`):

```console
$ terraform apply
terraform_data.example: Refreshing state... [id=892002337455008838]

Terraform will perform the following actions:

  # null_resource.example has moved to terraform_data.example
    resource "terraform_data" "example" {
        id = "892002337455008838"
    }

Plan: 0 to add, 0 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

Apply complete! Resources: 0 added, 0 changed, 0 destroyed.
```

Initial configuration (with `triggers`):

```terraform
terraform {
  required_providers {
    null = {
      source  = "hashicorp/null"
      version = "3.2.2"
    }
  }
}

resource "null_resource" "example" {
  triggers = {
    examplekey = "examplevalue"
  }

  provisioner "local-exec" {
    command = "echo 'Hello, World!'"
  }
}
```

Moved configuration (with `triggers`):

```terraform
resource "terraform_data" "example" {
  triggers_replace = {
    examplekey = "examplevalue"
  }

  provisioner "local-exec" {
    command = "echo 'Hello, World!'"
  }
}

moved {
  from = null_resource.example
  to   = terraform_data.example
}
```

Moved output (with `triggers`):

```console
$ terraform apply
terraform_data.example: Refreshing state... [id=1651348367769440250]

Terraform will perform the following actions:

  # null_resource.example has moved to terraform_data.example
    resource "terraform_data" "example" {
        id               = "1651348367769440250"
        # (1 unchanged attribute hidden)
    }

Plan: 0 to add, 0 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

Apply complete! Resources: 0 added, 0 changed, 0 destroyed.
```

## Target Release

1.9.0

## Draft CHANGELOG entry

### ENHANCEMENTS

-  terraform_data: Enabled `moved` configuration refactoring from the `hashicorp/null` provider `null_resource` managed resource
