### PR TITLE
remove extra state.DeepCopy from updateStateHook

### DIFF
--- a/internal/terraform/hook.go
+++ b/internal/terraform/hook.go
@@ -114,9 +114,11 @@ type Hook interface {
 	// function is called.
 	Stopping()
 
-	// PostStateUpdate is called each time the state is updated. It receives
-	// a deep copy of the state, which it may therefore access freely without
-	// any need for locks to protect from concurrent writes from the caller.
+	// PostStateUpdate is called each time the state is updated. The caller must
+	// coordinate a lock for the state if necessary, such that the Hook may
+	// access it freely without any need for additional locks to protect from
+	// concurrent writes. Implementations which modify or retain the state after
+	// the call has returned must copy the state.
 	PostStateUpdate(new *states.State) (HookAction, error)
 }
 

--- a/internal/terraform/update_state_hook.go
+++ b/internal/terraform/update_state_hook.go
@@ -5,13 +5,10 @@ package terraform
 
 // updateStateHook calls the PostStateUpdate hook with the current state.
 func updateStateHook(ctx EvalContext) error {
-	// In principle we could grab the lock here just long enough to take a
-	// deep copy and then pass that to our hooks below, but we'll instead
-	// hold the hook for the duration to avoid the potential confusing
-	// situation of us racing to call PostStateUpdate concurrently with
-	// different state snapshots.
+	// PostStateUpdate requires that the state be locked and safe to read for
+	// the duration of the call.
 	stateSync := ctx.State()
-	state := stateSync.Lock().DeepCopy()
+	state := stateSync.Lock()
 	defer stateSync.Unlock()
 
 	// Call the hook


### PR DESCRIPTION
All state implementations copy the given state when storing it to temporary or permanent storage[^1][^2][^3][^4], either explicitly with DeepCopy, or implicitly by serializing the state. Since `updateStateHook` is called with every resource instance state change, a second call to `DeepCopy` with that hook doubles the overhead of `PostStateUpdate` which may be a significant portion of the running time.

Since all Hook implementations which handle `PostStateUpdate` (which is exactly 1 in non-test code[^5]) only call state methods that eventually copy the state, we can remove the extra copy from the `updateStateHook` itself. The state was already locked for the duration of the `PostStateUpdate` call previously, so no additional delay should result.

For consistency this also updates the documentation for `PostStateUpdate` to record the new caller and callee expectations based on the existing implementation. The Hook interface predated the `statemgr` which provides a better interface for synchronizing state access and therefor required extra copying at that time, while now we can more easily declare that the method requires concurrent access be locked for the duration of the call.

Fixes #35113

## Target Release

v1.9

[^1]:https://github.com/hashicorp/terraform/blob/0efd586490cd84aa735517c291c2b5ad63e0b009/internal/cloud/state.go#L150
[^2]:https://github.com/hashicorp/terraform/blob/716fcce2397c996893eff7cfa6d02a9f944e1bc0/internal/states/remote/state.go#L85
[^3]:https://github.com/hashicorp/terraform/blob/716fcce2397c996893eff7cfa6d02a9f944e1bc0/internal/states/statemgr/filesystem.go#L126
[^4]:https://github.com/hashicorp/terraform/blob/53c34ff49cfbc1f70d7cdd3dca8040551c53737a/internal/states/statemgr/transient_inmem.go#L38


[^5]:https://github.com/hashicorp/terraform/blob/f058de612c56066803aa46b2ec7bfec8181acd76/internal/backend/local/hook_state.go#L42