### PR TITLE
stacks: Enable resource deferrals within stack tests

### DIFF
--- a/internal/stacks/stackruntime/internal/stackeval/applying_test.go
+++ b/internal/stacks/stackruntime/internal/stackeval/applying_test.go
@@ -113,7 +113,6 @@ func TestApply_componentOrdering(t *testing.T) {
 
 	// First we need to create a plan for this configuration, which will
 	// include the calculated component dependencies.
-	t.Log("initial plan")
 	planOutput, err := promising.MainTask(ctx, func(ctx context.Context) (*planOutputTester, error) {
 		main := NewForPlanning(cfg, stackstate.NewState(), PlanOpts{
 			PlanningMode: plans.NormalMode,
@@ -190,7 +189,6 @@ func TestApply_componentOrdering(t *testing.T) {
 
 	// Now we're finally ready for the first apply, during which we expect
 	// the component ordering decided during the plan phase to be respected.
-	t.Log("initial apply")
 	applyResult, err := promising.MainTask(ctx, func(ctx context.Context) (applyResultData, error) {
 		var visitedMarkers []string
 		var visitedMarkersMu sync.Mutex

--- a/internal/stacks/stackruntime/internal/stackeval/component.go
+++ b/internal/stacks/stackruntime/internal/stackeval/component.go
@@ -166,9 +166,17 @@ func (c *Component) CheckInstances(ctx context.Context, phase EvalPhase) (map[ad
 				return nil, diags
 			}
 
+			allowUnknowns := true
+			if c.main.Planning() {
+				// We'll set this to false during planning if deferrals are not
+				// allowed. It's fine to always be true during apply, as this
+				// would have failed during planning if it was not allowed.
+				allowUnknowns = c.main.PlanningOpts().DeferralAllowed
+			}
+
 			ret := instancesMap(forEachVal, func(ik addrs.InstanceKey, rd instances.RepetitionData) *ComponentInstance {
 				return newComponentInstance(c, ik, rd)
-			}, true)
+			}, allowUnknowns)
 
 			addrs := make([]stackaddrs.AbsComponentInstance, 0, len(ret))
 			for _, ci := range ret {

--- a/internal/stacks/stackruntime/internal/stackeval/component_instance.go
+++ b/internal/stacks/stackruntime/internal/stackeval/component_instance.go
@@ -576,9 +576,17 @@ func (c *ComponentInstance) CheckModuleTreePlan(ctx context.Context) (*plans.Pla
 				}
 			}
 
-			// The instance is also upstream deferred if the for_each value for this instance is unknown.
+			// The instance is also upstream deferred if the for_each value for
+			// this instance or any parent stacks is unknown.
 			if c.key == addrs.WildcardKey {
 				deferred = true
+			} else {
+				for _, step := range c.call.addr.Stack {
+					if step.Key == addrs.WildcardKey {
+						deferred = true
+						break
+					}
+				}
 			}
 
 			// NOTE: This ComponentInstance type only deals with component

--- a/internal/stacks/stackruntime/internal/stackeval/stack_call.go
+++ b/internal/stacks/stackruntime/internal/stackeval/stack_call.go
@@ -159,9 +159,17 @@ func (c *StackCall) CheckInstances(ctx context.Context, phase EvalPhase) (map[ad
 				return nil, diags
 			}
 
+			allowUnknowns := true
+			if c.main.Planning() {
+				// We'll set this to false during planning if deferrals are not
+				// allowed. It's fine to always be true during apply, as this
+				// would have failed during planning if it was not allowed.
+				allowUnknowns = c.main.PlanningOpts().DeferralAllowed
+			}
+
 			return instancesMap(forEachVal, func(ik addrs.InstanceKey, rd instances.RepetitionData) *StackCallInstance {
 				return newStackCallInstance(c, ik, rd)
-			}, true), diags
+			}, allowUnknowns), diags
 		},
 	)
 }

--- a/internal/terraform/context_plan2_test.go
+++ b/internal/terraform/context_plan2_test.go
@@ -4838,9 +4838,16 @@ func TestContext2Apply_externalDependencyDeferred(t *testing.T) {
 	if diff := cmp.Diff(wantActions, gotActions, cmpOpts); diff != "" {
 		t.Fatalf("wrong actions in plan\n%s", diff)
 	}
-	// TODO: Once we are including information about the individual
-	// deferred actions in the plan, this would be a good place to
-	// assert that they are correct!
+
+	if len(plan.DeferredResources) != 3 {
+		t.Fatalf("expected exactly 3 deferred resources, got %d", len(plan.DeferredResources))
+	}
+
+	for _, res := range plan.DeferredResources {
+		if res.DeferredReason != providers.DeferredReasonDeferredPrereq {
+			t.Fatalf("expected all resources to be deferred due to deferred prerequisites, but %s was not", res.ChangeSrc.Addr)
+		}
+	}
 }
 
 func TestContext2Plan_removedResourceForgetBasic(t *testing.T) {


### PR DESCRIPTION
This PR updates the stack runtime tests to properly enable deferred actions within Terraform Core. As a result, the tests now properly mark the `Applyable`, `Complete`, and `DeferredResources` responses. The tests have been updated to reflect the correct behaviour.