### PR TITLE
Allow to write state using compact representation

### DIFF
--- a/internal/states/statefile/version4.go
+++ b/internal/states/statefile/version4.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"os"
 	"sort"
 
 	version "github.com/hashicorp/go-version"
@@ -410,8 +411,13 @@ func writeStateV4(file *File, w io.Writer) tfdiags.Diagnostics {
 	sV4.CheckResults = encodeCheckResultsV4(file.State.CheckResults)
 
 	sV4.normalize()
-
-	src, err := json.MarshalIndent(sV4, "", "  ")
+	var src []byte
+	var err error
+	if _, exists := os.LookupEnv("TF_USE_COMPACT_STATE_FORMAT"); exists {
+		src, err = json.Marshal(sV4)
+	} else {
+		src, err = json.MarshalIndent(sV4, "", "  ")
+	}
 	if err != nil {
 		// Shouldn't happen if we do our conversion to *stateV4 correctly above.
 		diags = diags.Append(tfdiags.Sourceless(


### PR DESCRIPTION
This PR allows to write JSON using compact (non-indented) representation if the `TF_USE_COMPACT_STATE_FORMAT` environment variable is defined.  This significantly improves performance when working with huge states.

For example (on ~450k objects in the state):

* state size is decreased from 510.1MB to 386.6MB
* Time to write to S3 decreased from 112 seconds to 94 seconds
* Time to read from S3 decreased from 87 seconds -> 55 seconds



<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Fixes #35174

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.8.x

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

### NEW FEATURES | UPGRADE NOTES | ENHANCEMENTS | BUG FIXES | EXPERIMENTS

<!--

Write a short description of the user-facing change. Examples:

- `terraform show -json`: Fixed crash with sensitive set values.
- When rendering a diff, Terraform now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 

-  
