### PR TITLE
Add `TF_STATE_PERSIST_INTERVAL` environment variable. 

### DIFF
--- a/internal/backend/backendrun/operation.go
+++ b/internal/backend/backendrun/operation.go
@@ -108,11 +108,12 @@ type Operation struct {
 
 	// The options below are more self-explanatory and affect the runtime
 	// behavior of the operation.
-	PlanMode     plans.Mode
-	AutoApprove  bool
-	Targets      []addrs.Targetable
-	ForceReplace []addrs.AbsResourceInstance
-	Variables    map[string]UnparsedVariableValue
+	PlanMode             plans.Mode
+	AutoApprove          bool
+	Targets              []addrs.Targetable
+	ForceReplace         []addrs.AbsResourceInstance
+	Variables            map[string]UnparsedVariableValue
+	StatePersistInterval int
 
 	// Some operations use root module variables only opportunistically or
 	// don't need them at all. If this flag is set, the backend must treat

--- a/internal/backend/local/backend_apply.go
+++ b/internal/backend/local/backend_apply.go
@@ -8,8 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"log"
-	"os"
-	"strconv"
 	"time"
 
 	"github.com/hashicorp/terraform/internal/addrs"
@@ -26,22 +24,6 @@ import (
 
 // test hook called between plan+apply during opApply
 var testHookStopPlanApply func()
-
-var (
-	defaultPersistInterval                 = 20 // arbitrary interval that's hopefully a sweet spot
-	persistIntervalEnvironmentVariableName = "TF_BACKEND_PERSIST_INTERVAL_SECONDS"
-)
-
-func getEnvAsInt(envName string, defaultValue int) int {
-	if val, exists := os.LookupEnv(envName); exists {
-		parsedVal, err := strconv.Atoi(val)
-		if err == nil {
-			return parsedVal
-		}
-		log.Printf("[ERROR] Can't parse value '%s' of environment variable '%s'", val, envName)
-	}
-	return defaultValue
-}
 
 func (b *Local) opApply(
 	stopCtx context.Context,
@@ -100,8 +82,7 @@ func (b *Local) opApply(
 	// stateHook uses schemas for when it periodically persists state to the
 	// persistent storage backend.
 	stateHook.Schemas = schemas
-	persistInterval := getEnvAsInt(persistIntervalEnvironmentVariableName, defaultPersistInterval)
-	stateHook.PersistInterval = time.Duration(persistInterval) * time.Second
+	stateHook.PersistInterval = time.Duration(op.StatePersistInterval) * time.Second
 
 	var plan *plans.Plan
 	// If we weren't given a plan, then we refresh/plan

--- a/internal/command/apply.go
+++ b/internal/command/apply.go
@@ -283,6 +283,7 @@ func (c *ApplyCommand) OperationRequest(
 	opReq.ForceReplace = args.ForceReplace
 	opReq.Type = backendrun.OperationTypeApply
 	opReq.View = view.Operation()
+	opReq.StatePersistInterval = c.Meta.StatePersistInterval()
 
 	// EXPERIMENTAL: maybe enable deferred actions
 	if c.AllowExperimentalFeatures {

--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -30,6 +30,10 @@ const DefaultPluginVendorDir = "terraform.d/plugins/" + pluginMachineName
 // DefaultStateFilename is the default filename used for the state file.
 const DefaultStateFilename = "terraform.tfstate"
 
+// DefaultStatePersistInterval is the default interval a backend should persist
+// Terraform state, if applicable. Backends can set their own custom defaults.
+const DefaultStatePersistInterval = 20
+
 // DefaultVarsFilename is the default filename used for vars
 const DefaultVarsFilename = "terraform.tfvars"
 

--- a/internal/command/meta.go
+++ b/internal/command/meta.go
@@ -736,6 +736,28 @@ func (m *Meta) showDiagnostics(vals ...interface{}) {
 	}
 }
 
+const (
+	// StatePersistIntervalEnvVar is the environment variable that can be set
+	// to control the interval at which Terraform persists state. The interval
+	// itself defaults to 20 seconds.
+	StatePersistIntervalEnvVar = "TF_STATE_PERSIST_INTERVAL"
+)
+
+// StatePersistInterval returns the configured interval that Terraform should
+// persist statefiles to the desired backend. Backends may choose to override
+// the default value.
+func (m *Meta) StatePersistInterval() int {
+	if val, ok := os.LookupEnv(StatePersistIntervalEnvVar); ok {
+		if interval, err := strconv.Atoi(val); err == nil && interval > DefaultStatePersistInterval {
+			// The user-specified interval must be greater than the default minimum
+			return interval
+		} else if err != nil {
+			log.Printf("[ERROR] Can't parse state persist interval %q of environment variable %q", val, StatePersistIntervalEnvVar)
+		}
+	}
+	return DefaultStatePersistInterval
+}
+
 // WorkspaceNameEnvVar is the name of the environment variable that can be used
 // to set the name of the Terraform workspace, overriding the workspace chosen
 // by `terraform workspace select`.

--- a/internal/command/meta_test.go
+++ b/internal/command/meta_test.go
@@ -219,6 +219,60 @@ func TestMeta_Env(t *testing.T) {
 	}
 }
 
+func TestMeta_StatePersistInterval(t *testing.T) {
+	m := new(Meta)
+	t.Run("when the env var is not defined", func(t *testing.T) {
+		interval := m.StatePersistInterval()
+		if interval != DefaultStatePersistInterval {
+			t.Fatalf("expected state persist interval to be %d, got: %d", DefaultStatePersistInterval, interval)
+		}
+	})
+	t.Run("with valid interval greater than the default", func(t *testing.T) {
+		os.Setenv(StatePersistIntervalEnvVar, "25")
+		t.Cleanup(func() {
+			os.Unsetenv(StatePersistIntervalEnvVar)
+		})
+
+		interval := m.StatePersistInterval()
+		if interval != 25 {
+			t.Fatalf("expected state persist interval to be 25, got: %d", interval)
+		}
+	})
+	t.Run("with a valid interval less than the default", func(t *testing.T) {
+		os.Setenv(StatePersistIntervalEnvVar, "10")
+		t.Cleanup(func() {
+			os.Unsetenv(StatePersistIntervalEnvVar)
+		})
+
+		interval := m.StatePersistInterval()
+		if interval != DefaultStatePersistInterval {
+			t.Fatalf("expected state persist interval to be %d, got: %d", DefaultStatePersistInterval, interval)
+		}
+	})
+	t.Run("with invalid integer interval", func(t *testing.T) {
+		os.Setenv(StatePersistIntervalEnvVar, "foo")
+		t.Cleanup(func() {
+			os.Unsetenv(StatePersistIntervalEnvVar)
+		})
+
+		interval := m.StatePersistInterval()
+		if interval != DefaultStatePersistInterval {
+			t.Fatalf("expected state persist interval to be %d, got: %d", DefaultStatePersistInterval, interval)
+		}
+	})
+	t.Run("with negative integer interval", func(t *testing.T) {
+		os.Setenv(StatePersistIntervalEnvVar, "-10")
+		t.Cleanup(func() {
+			os.Unsetenv(StatePersistIntervalEnvVar)
+		})
+
+		interval := m.StatePersistInterval()
+		if interval != DefaultStatePersistInterval {
+			t.Fatalf("expected state persist interval to be %d, got: %d", DefaultStatePersistInterval, interval)
+		}
+	})
+}
+
 func TestMeta_Workspace_override(t *testing.T) {
 	defer func(value string) {
 		os.Setenv(WorkspaceNameEnvVar, value)

--- a/website/docs/cli/config/environment-variables.mdx
+++ b/website/docs/cli/config/environment-variables.mdx
@@ -143,6 +143,14 @@ The default client timeout for requests to the remote registry is 10s. `TF_REGIS
 export TF_REGISTRY_CLIENT_TIMEOUT=15
 ```
 
+## TF_STATE_PERSIST_INTERVAL
+
+The interval in seconds that Terraform attempts to persist state to a remote backend during an apply operation. The default minimum interval for all remote backends is 20 seconds. Backends may override the default minimum value. If the value of `TF_STATE_PERSIST_INTERVAL` is lower than the default interval specified by a remote backend, the default interval will be used.
+
+```shell
+export TF_STATE_PERSIST_INTERVAL=100
+```
+
 ## TF_CLI_CONFIG_FILE
 
 The location of the [Terraform CLI configuration file](/terraform/cli/config/config-file).


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->
This PR stems from the initial work done by @alexott (#35116), which fixes #35115. These changes are a simple refactor to delegate handling this env var to `command.Meta`. This allows us to pass the user specified persist interval to `backendrun.Operation` and keep env var handling (with existing vars such as `TF_WORKSPACE`, `TF_INPUT`) centralized within `command.Meta`.

The default interval remains 20 seconds and serves as a global minimum interval. Remote backends such as `cloud` may override the default using the `X-Terraform-Snapshot-Interval` header. If the default interval value is greater than the user-specified value, the default will be used. 

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.9.x

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

### ENHANCEMENTS

<!--

Write a short description of the user-facing change. Examples:

- `terraform show -json`: Fixed crash with sensitive set values.
- When rendering a diff, Terraform now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 

-  Added TF_STATE_PERSIST_INTERVAL environment variable to control persist interval in the remote state backend.
