### PR TITLE
funcs: Don't panic if templatefile path is sensitive

### DIFF
--- a/internal/lang/funcs/filesystem_test.go
+++ b/internal/lang/funcs/filesystem_test.go
@@ -187,6 +187,18 @@ func TestTemplateFile(t *testing.T) {
 			cty.True, // since this template contains only an interpolation, its true value shines through
 			``,
 		},
+		{
+			// If the template filename is sensitive then we also treat the
+			// rendered result as sensitive, because the rendered result
+			// is likely to imply which filename was used.
+			// (Sensitive filenames seem pretty unlikely, but if they do
+			// crop up then we should handle them consistently with our
+			// usual sensitivity rules.)
+			cty.StringVal("testdata/hello.txt").Mark(marks.Sensitive),
+			cty.EmptyObjectVal,
+			cty.StringVal("Hello World").Mark(marks.Sensitive),
+			``,
+		},
 	}
 
 	funcs := map[string]function.Function{


### PR DESCRIPTION
Previously we were partially propagating any marks from the path, but not going all the way so we still ran into trouble when trying to use the string containing the file contents.

Now we'll have `loadTmpl` also return the marks it had to read through to actually parse the template, and then we'll use those (instead of the original path marks) to mark the result. In practice the `pathMarks` and the `tmplMarks` should always match today, but this is intentionally structured to make the data flow clearer -- the marks always travel along with whatever they related to -- so we're less likely to break this accidentally under future maintenance.

This fixes https://github.com/hashicorp/terraform/issues/31119.