### PR TITLE
Copy deferred data sources into the plan, and use deferred values in references/outputs

### DIFF
--- a/internal/plans/deferring/deferred.go
+++ b/internal/plans/deferring/deferred.go
@@ -190,28 +190,6 @@ func (d *Deferred) HaveAnyDeferrals() bool {
 			len(d.partialExpandedModulesDeferred) != 0)
 }
 
-// IsResourceInstanceDeferred returns true if the receiver knows some reason
-// why the resource instance with the given address should have its planned
-// action deferred for a future plan/apply round.
-// TODO NF: This is dead code, and we always ignore the instructions below
-// to use it before ShouldDeferResourceInstanceChanges.
-func (d *Deferred) IsResourceInstanceDeferred(addr addrs.AbsResourceInstance) bool {
-	if !d.deferralAllowed {
-		return false
-	}
-
-	if d.externalDependencyDeferred {
-		return true
-	}
-
-	// Our resource graph describes relationships between the static resource
-	// configuration blocks, not their dynamic instances, so we need to start
-	// with the config address that the given instance belongs to.
-	configAddr := addr.ConfigResource()
-
-	return d.resourceInstancesDeferred.Get(configAddr).Has(addr)
-}
-
 // GetDeferredResourceInstanceValue returns the deferred value for the given
 // resource instance, if any.
 func (d *Deferred) GetDeferredResourceInstanceValue(addr addrs.AbsResourceInstance) (cty.Value, bool) {
@@ -257,14 +235,7 @@ func (d *Deferred) GetDeferredResourceInstanceValue(addr addrs.AbsResourceInstan
 //
 // It's invalid to call this method for an address that was already reported
 // as deferred using [Deferred.ReportResourceInstanceDeferred], and so this
-// method will panic in that case. Callers should always test whether a resource
-// instance action should be deferred _before_ reporting that it has been by
-// calling [Deferred.IsResourceInstanceDeferred].
-//
-// The deps argument should be the set of configuration blocks that the given
-// resource instance depends on. This is then compared against the set of
-// deferred resources to determine if the given resource instance should be
-// deferred.
+// method will panic in that case.
 func (d *Deferred) ShouldDeferResourceInstanceChanges(addr addrs.AbsResourceInstance, deps []addrs.ConfigResource) bool {
 	if !d.deferralAllowed {
 		return false

--- a/internal/plans/deferring/deferred.go
+++ b/internal/plans/deferring/deferred.go
@@ -132,6 +132,11 @@ func (d *Deferred) GetDeferredChanges() []*plans.DeferredResourceInstanceChange 
 			changes = append(changes, changeElem.Value)
 		}
 	}
+	for _, configMapElem := range d.dataSourceInstancesDeferred.Elems {
+		for _, changeElem := range configMapElem.Value.Elems {
+			changes = append(changes, changeElem.Value)
+		}
+	}
 	for _, configMapElem := range d.partialExpandedResourcesDeferred.Elems {
 		for _, changeElem := range configMapElem.Value.Elems {
 			changes = append(changes, changeElem.Value)

--- a/internal/plans/deferring/deferred.go
+++ b/internal/plans/deferring/deferred.go
@@ -86,7 +86,7 @@ type Deferred struct {
 	// Data sources are never written into the plan, even when deferred, so we
 	// are tracking these for purely internal reasons. If a resource depends on
 	// a deferred data source, then that resource should be deferred as well.
-	partialExpandedDataSourcesDeferred addrs.Map[addrs.ConfigResource, addrs.Map[addrs.PartialExpandedResource, cty.Value]]
+	partialExpandedDataSourcesDeferred addrs.Map[addrs.ConfigResource, addrs.Map[addrs.PartialExpandedResource, *plans.DeferredResourceInstanceChange]]
 
 	// partialExpandedModulesDeferred tracks all of the partial-expanded module
 	// prefixes we were notified about.
@@ -113,7 +113,7 @@ func NewDeferred(enabled bool) *Deferred {
 		resourceInstancesDeferred:          addrs.MakeMap[addrs.ConfigResource, addrs.Map[addrs.AbsResourceInstance, *plans.DeferredResourceInstanceChange]](),
 		dataSourceInstancesDeferred:        addrs.MakeMap[addrs.ConfigResource, addrs.Map[addrs.AbsResourceInstance, *plans.DeferredResourceInstanceChange]](),
 		partialExpandedResourcesDeferred:   addrs.MakeMap[addrs.ConfigResource, addrs.Map[addrs.PartialExpandedResource, *plans.DeferredResourceInstanceChange]](),
-		partialExpandedDataSourcesDeferred: addrs.MakeMap[addrs.ConfigResource, addrs.Map[addrs.PartialExpandedResource, cty.Value]](),
+		partialExpandedDataSourcesDeferred: addrs.MakeMap[addrs.ConfigResource, addrs.Map[addrs.PartialExpandedResource, *plans.DeferredResourceInstanceChange]](),
 		partialExpandedModulesDeferred:     addrs.MakeSet[addrs.PartialExpandedModule](),
 	}
 }
@@ -383,7 +383,7 @@ func (d *Deferred) ReportResourceExpansionDeferred(addr addrs.PartialExpandedRes
 // ReportDataSourceExpansionDeferred reports that we cannot even predict which
 // instances of a data source will be declared and thus we must defer all
 // planning for that data source.
-func (d *Deferred) ReportDataSourceExpansionDeferred(addr addrs.PartialExpandedResource, value cty.Value) {
+func (d *Deferred) ReportDataSourceExpansionDeferred(addr addrs.PartialExpandedResource, change *plans.ResourceInstanceChange) {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 
@@ -394,7 +394,7 @@ func (d *Deferred) ReportDataSourceExpansionDeferred(addr addrs.PartialExpandedR
 
 	configAddr := addr.ConfigResource()
 	if !d.partialExpandedDataSourcesDeferred.Has(configAddr) {
-		d.partialExpandedDataSourcesDeferred.Put(configAddr, addrs.MakeMap[addrs.PartialExpandedResource, cty.Value]())
+		d.partialExpandedDataSourcesDeferred.Put(configAddr, addrs.MakeMap[addrs.PartialExpandedResource, *plans.DeferredResourceInstanceChange]())
 	}
 
 	configMap := d.partialExpandedDataSourcesDeferred.Get(configAddr)
@@ -404,7 +404,10 @@ func (d *Deferred) ReportDataSourceExpansionDeferred(addr addrs.PartialExpandedR
 		// prefix only once.
 		panic(fmt.Sprintf("duplicate deferral report for %s", addr))
 	}
-	configMap.Put(addr, value)
+	configMap.Put(addr, &plans.DeferredResourceInstanceChange{
+		DeferredReason: providers.DeferredReasonInstanceCountUnknown,
+		Change:         change,
+	})
 }
 
 // ReportResourceInstanceDeferred records that a fully-expanded resource

--- a/internal/plans/deferring/deferred.go
+++ b/internal/plans/deferring/deferred.go
@@ -142,6 +142,11 @@ func (d *Deferred) GetDeferredChanges() []*plans.DeferredResourceInstanceChange 
 			changes = append(changes, changeElem.Value)
 		}
 	}
+	for _, configMapElem := range d.partialExpandedDataSourcesDeferred.Elems {
+		for _, changeElem := range configMapElem.Value.Elems {
+			changes = append(changes, changeElem.Value)
+		}
+	}
 	return changes
 }
 

--- a/internal/plans/deferring/deferred_test.go
+++ b/internal/plans/deferring/deferred_test.go
@@ -158,7 +158,7 @@ func TestDeferred_absDataSourceInstanceDeferred(t *testing.T) {
 	})
 
 	// Instance A has its Read action deferred for some reason.
-	deferred.ReportDataSourceInstanceDeferred(instAAddr)
+	deferred.ReportDataSourceInstanceDeferred(instAAddr, cty.DynamicVal)
 
 	t.Run("with one resource instance deferred", func(t *testing.T) {
 		if !deferred.ShouldDeferResourceInstanceChanges(instCAddr, dependencies.Get(instCAddr.ConfigResource())) {
@@ -223,7 +223,7 @@ func TestDeferred_partialExpandedDatasource(t *testing.T) {
 	})
 
 	// Resource A hasn't been expanded fully, so is deferred.
-	deferred.ReportDataSourceExpansionDeferred(instAPartial)
+	deferred.ReportDataSourceExpansionDeferred(instAPartial, cty.DynamicVal)
 
 	t.Run("with one resource instance deferred", func(t *testing.T) {
 		if !deferred.ShouldDeferResourceInstanceChanges(instCAddr, dependencies.Get(instCAddr.ConfigResource())) {

--- a/internal/plans/deferring/deferred_test.go
+++ b/internal/plans/deferring/deferred_test.go
@@ -231,7 +231,13 @@ func TestDeferred_partialExpandedDatasource(t *testing.T) {
 	})
 
 	// Resource A hasn't been expanded fully, so is deferred.
-	deferred.ReportDataSourceExpansionDeferred(instAPartial, cty.DynamicVal)
+	deferred.ReportDataSourceExpansionDeferred(instAPartial, &plans.ResourceInstanceChange{
+		Addr: instAAddr,
+		Change: plans.Change{
+			Action: plans.Read,
+			After:  cty.DynamicVal,
+		},
+	})
 
 	t.Run("with one resource instance deferred", func(t *testing.T) {
 		if !deferred.ShouldDeferResourceInstanceChanges(instCAddr, dependencies.Get(instCAddr.ConfigResource())) {

--- a/internal/plans/deferring/deferred_test.go
+++ b/internal/plans/deferring/deferred_test.go
@@ -158,7 +158,15 @@ func TestDeferred_absDataSourceInstanceDeferred(t *testing.T) {
 	})
 
 	// Instance A has its Read action deferred for some reason.
-	deferred.ReportDataSourceInstanceDeferred(instAAddr, cty.DynamicVal)
+	deferred.ReportDataSourceInstanceDeferred(instAAddr, providers.DeferredReasonProviderConfigUnknown, &plans.ResourceInstanceChange{
+		Addr:        instAAddr,
+		PrevRunAddr: instAAddr,
+		Change: plans.Change{
+			Action: plans.Read,
+			After:  cty.DynamicVal,
+		},
+		ActionReason: plans.ResourceInstanceReadBecauseDependencyPending,
+	})
 
 	t.Run("with one resource instance deferred", func(t *testing.T) {
 		if !deferred.ShouldDeferResourceInstanceChanges(instCAddr, dependencies.Get(instCAddr.ConfigResource())) {

--- a/internal/terraform/context_apply_deferred_test.go
+++ b/internal/terraform/context_apply_deferred_test.go
@@ -229,7 +229,7 @@ output "from_resource" {
 				wantApplied: map[string]cty.Value{},
 				// TODO: These deferred output values are wrong, but outputs are a separate ticket.
 				wantOutputs: map[string]cty.Value{
-					"from_data":     cty.EmptyTupleVal,
+					"from_data":     cty.DynamicVal,
 					"from_resource": cty.NullVal(cty.DynamicPseudoType),
 				},
 				complete:      false,
@@ -381,10 +381,10 @@ output "c" {
 					// during the apply phase, and so it incorrectly decides
 					// that there are no instances due to the lack of
 					// instances in the state.
-					"b": cty.EmptyObjectVal,
+					//"b": cty.EmptyObjectVal,
 					// We can't say anything about test.b until we know what
 					// its instance keys are.
-					// "b": cty.DynamicVal,
+					"b": cty.DynamicVal,
 
 					// Currently we produce an incorrect result for output
 					// value "c" because the expression evaluator doesn't
@@ -392,14 +392,14 @@ output "c" {
 					// during the apply phase, and so it incorrectly decides
 					// that there is instance due to the lack of instances
 					// in the state.
-					"c": cty.NullVal(cty.DynamicPseudoType),
+					//"c": cty.NullVal(cty.DynamicPseudoType),
 					// test.c evaluates to the placeholder value that shows
 					// what we're expecting this object to look like in the
 					// next round.
-					// "c": cty.ObjectVal(map[string]cty.Value{
-					// 	"name":           cty.StringVal("c"),
-					// 	"upstream_names": cty.UnknownVal(cty.Set(cty.String)).RefineNotNull(),
-					// }),
+					"c": cty.ObjectVal(map[string]cty.Value{
+						"name":           cty.StringVal("c"),
+						"upstream_names": cty.UnknownVal(cty.Set(cty.String)).RefineNotNull(),
+					}),
 				},
 			},
 			{
@@ -2135,9 +2135,9 @@ output "a" {
 				},
 				wantOutputs: map[string]cty.Value{
 					"a": cty.ObjectVal(map[string]cty.Value{
-						"name":           cty.StringVal("old_value"),
+						"name":           cty.StringVal("deferred_resource_change"),
 						"upstream_names": cty.NullVal(cty.Set(cty.String)),
-						"output":         cty.StringVal("mark_for_replacement"),
+						"output":         cty.UnknownVal(cty.String),
 					}),
 				},
 				wantDeferred: map[string]ExpectedDeferred{

--- a/internal/terraform/context_apply_deferred_test.go
+++ b/internal/terraform/context_apply_deferred_test.go
@@ -1743,17 +1743,16 @@ output "a" {
 					// The resource will be deferred, so shouldn't
 					// have any action at this stage.
 				},
+				// The output refers to a resource that is unready, so in the
+				// state it becomes a null value of the appropriate type,
+				// despite the fact that we can predict *some* information (i.e.
+				// the future `name`) about the eventual value.
 				wantOutputs: map[string]cty.Value{
-					// TODO NF: In both the refresh-only stage and the real-plan stage below, the output is
-					// getting the new `name` value from the partially-planned deferred change rather than the
-					// old `name` value from the state. Is that right? For both cases? I couldn't quite
-					// decide, but currently that's what happens because of where the early-out happens over
-					// in GetResource while we're building the hcl eval context.
-					"a": cty.ObjectVal(map[string]cty.Value{
-						"name":           cty.StringVal("a"),
-						"upstream_names": cty.NullVal(cty.Set(cty.String)),
-						"output":         cty.NullVal(cty.String),
-					}),
+					"a": cty.NullVal(cty.Object(map[string]cty.Type{
+						"name":           cty.String,
+						"upstream_names": cty.Set(cty.String),
+						"output":         cty.String,
+					})),
 				},
 				wantDeferred: map[string]ExpectedDeferred{
 					"test.a": {Reason: providers.DeferredReasonProviderConfigUnknown, Action: plans.Read},
@@ -1779,11 +1778,11 @@ output "a" {
 					// have any action at this stage.
 				},
 				wantOutputs: map[string]cty.Value{
-					"a": cty.ObjectVal(map[string]cty.Value{
-						"name":           cty.StringVal("a"),
-						"upstream_names": cty.NullVal(cty.Set(cty.String)),
-						"output":         cty.NullVal(cty.String),
-					}),
+					"a": cty.NullVal(cty.Object(map[string]cty.Type{
+						"name":           cty.String,
+						"upstream_names": cty.Set(cty.String),
+						"output":         cty.String,
+					})),
 				},
 				wantDeferred: map[string]ExpectedDeferred{
 					"test.a": {Reason: providers.DeferredReasonProviderConfigUnknown, Action: plans.Update},
@@ -2042,11 +2041,11 @@ output "a" {
 					// have any action at this stage.
 				},
 				wantOutputs: map[string]cty.Value{
-					"a": cty.ObjectVal(map[string]cty.Value{
-						"name":           cty.StringVal("deferred_resource_change"),
-						"upstream_names": cty.NullVal(cty.Set(cty.String)),
-						"output":         cty.NullVal(cty.String),
-					}),
+					"a": cty.NullVal(cty.Object(map[string]cty.Type{
+						"name":           cty.String,
+						"upstream_names": cty.Set(cty.String),
+						"output":         cty.String,
+					})),
 				},
 				wantDeferred: map[string]ExpectedDeferred{
 					"test.a": {Reason: providers.DeferredReasonProviderConfigUnknown, Action: plans.Update},
@@ -2100,6 +2099,12 @@ output "a" {
 					// The all resources will be deferred, so shouldn't
 					// have any action at this stage.
 				},
+				// This example is strange (possibly unrealistic?) because the
+				// provider deferred the PlanResourceChange call but responded
+				// immediately on the ReadResource call; usually you would
+				// expect to defer both or defer neither. So the output is still
+				// the current concrete value (not a cty.NullVal), even though
+				// the resource "is deferred."
 				wantOutputs: map[string]cty.Value{
 					"a": cty.ObjectVal(map[string]cty.Value{
 						"name":           cty.StringVal("deferred_resource_change"),
@@ -2160,11 +2165,11 @@ output "a" {
 					// have any action at this stage.
 				},
 				wantOutputs: map[string]cty.Value{
-					"a": cty.ObjectVal(map[string]cty.Value{
-						"name":           cty.StringVal("deferred_resource_change"),
-						"upstream_names": cty.NullVal(cty.Set(cty.String)),
-						"output":         cty.NullVal(cty.String),
-					}),
+					"a": cty.NullVal(cty.Object(map[string]cty.Type{
+						"name":           cty.String,
+						"upstream_names": cty.Set(cty.String),
+						"output":         cty.String,
+					})),
 				},
 				wantDeferred: map[string]ExpectedDeferred{
 					"test.a": {Reason: providers.DeferredReasonProviderConfigUnknown, Action: plans.DeleteThenCreate},
@@ -2233,11 +2238,11 @@ output "a" {
 					// have any action at this stage.
 				},
 				wantOutputs: map[string]cty.Value{
-					"a": cty.ObjectVal(map[string]cty.Value{
-						"name":           cty.StringVal("deferred_resource_change"),
-						"upstream_names": cty.NullVal(cty.Set(cty.String)),
-						"output":         cty.NullVal(cty.String),
-					}),
+					"a": cty.NullVal(cty.Object(map[string]cty.Type{
+						"name":           cty.String,
+						"upstream_names": cty.Set(cty.String),
+						"output":         cty.String,
+					})),
 				},
 				wantDeferred: map[string]ExpectedDeferred{
 					"test.a": {Reason: providers.DeferredReasonProviderConfigUnknown, Action: plans.DeleteThenCreate},

--- a/internal/terraform/context_apply_deferred_test.go
+++ b/internal/terraform/context_apply_deferred_test.go
@@ -97,15 +97,22 @@ variable "each" {
 	type = set(string)
 }
 
+# Partial-expanded and deferred due to unknown for_each
 data "test" "a" {
 	for_each = var.each
 
 	name = "a:${each.key}"
 }
 
+# Instance deferred due to dependency on deferred data source
 resource "test" "b" {
 	name = "b"
 	upstream_names = [for v in data.test.a : v.name]
+}
+
+# Instance deferred due to dependency on deferred resource
+data "test" "c" {
+	name = test.b.output
 }
 
 output "from_data" {
@@ -133,13 +140,31 @@ output "from_resource" {
 				},
 				wantActions: map[string]plans.Action{},
 				wantDeferred: map[string]ExpectedDeferred{
-					"test.b": {Reason: providers.DeferredReasonDeferredPrereq, Action: plans.Create},
+					// Much like a data source with unknown config results in a
+					// planned Read action to be performed in the apply, a
+					// deferred data source results in a *deferred* Read action
+					// to be performed in a future plan/apply round.
+					`data.test.a["*"]`: {Reason: providers.DeferredReasonInstanceCountUnknown, Action: plans.Read},
+					"test.b":           {Reason: providers.DeferredReasonDeferredPrereq, Action: plans.Create},
+					"data.test.c":      {Reason: providers.DeferredReasonDeferredPrereq, Action: plans.Read},
 				},
 				wantApplied: map[string]cty.Value{},
-				// TODO: These deferred output values are wrong, but outputs are a separate ticket.
 				wantOutputs: map[string]cty.Value{
-					"from_data":     cty.EmptyTupleVal,
-					"from_resource": cty.NullVal(cty.DynamicPseudoType),
+					// To start with: outputs that refer to deferred values are
+					// null values of some type.
+
+					// The from_data output's value is the result of a [for]
+					// expression that maps over an object of objects (the value
+					// of the data.test.a block). Since the for_each keys of the
+					// whole data source object are unknown (and the keys are an
+					// inherent part of the object type), we can't say anything
+					// about the type... and thus, can't say anything about the
+					// type of the tuple value that the [for] would derive from it.
+					"from_data": cty.NullVal(cty.DynamicPseudoType),
+					// The from_resource output's value is just a string
+					// attribute from a singleton resource instance, but it's
+					// still null because the resource got deferred.
+					"from_resource": cty.NullVal(cty.String),
 				},
 				complete:      false,
 				allowWarnings: false,
@@ -158,6 +183,9 @@ output "from_resource" {
 				},
 				wantActions: map[string]plans.Action{
 					"test.b": plans.Create,
+					// Not deferred anymore, but Read still gets delayed til
+					// apply due to unknown config.
+					"data.test.c": plans.Read,
 				},
 				wantDeferred: map[string]ExpectedDeferred{},
 				wantApplied: map[string]cty.Value{
@@ -224,13 +252,16 @@ output "from_resource" {
 				},
 				wantActions: map[string]plans.Action{},
 				wantDeferred: map[string]ExpectedDeferred{
-					"test.b": {Reason: providers.DeferredReasonDeferredPrereq, Action: plans.Create},
+					`data.test.a["*"]`: {Reason: providers.DeferredReasonInstanceCountUnknown, Action: plans.Read},
+					"test.b":           {Reason: providers.DeferredReasonDeferredPrereq, Action: plans.Create},
 				},
 				wantApplied: map[string]cty.Value{},
-				// TODO: These deferred output values are wrong, but outputs are a separate ticket.
 				wantOutputs: map[string]cty.Value{
-					"from_data":     cty.DynamicVal,
-					"from_resource": cty.NullVal(cty.DynamicPseudoType),
+					// Although this will be a TupleVal later, the count of
+					// items in the tuple is part of the type itself, and that's
+					// unknown at this point, so, DynamicPseudoType.
+					"from_data":     cty.NullVal(cty.DynamicPseudoType),
+					"from_resource": cty.NullVal(cty.String),
 				},
 				complete:      false,
 				allowWarnings: false,
@@ -362,44 +393,27 @@ output "c" {
 						"output":         cty.StringVal("a"),
 					}),
 
-					// FIXME: The system is currently producing incorrect
-					//   results for output values that are derived from
-					//   resources that had deferred actions, because we're
-					//   not quite reconstructing all of the deferral state
-					//   correctly during the apply phase. The commented-out
-					//   lines below show how this _ought_ to look, but
-					//   we're accepting the incorrect answer for now so we
-					//   can start to gather feedback on the experiment
-					//   sooner, since the output value state at the interim
-					//   steps isn't really that important for demonstrating
-					//   the overall effect. We should fix this before
-					//   stabilizing the experiment, though.
+					// To start with: outputs that refer to deferred values are
+					// null values of some type.
 
-					// Currently we produce an incorrect result for output
-					// value "b" because the expression evaluator doesn't
-					// realize it's supposed to be treating this as deferred
-					// during the apply phase, and so it incorrectly decides
-					// that there are no instances due to the lack of
-					// instances in the state.
-					//"b": cty.EmptyObjectVal,
-					// We can't say anything about test.b until we know what
-					// its instance keys are.
-					"b": cty.DynamicVal,
+					// Output b is the value of the test.b resource block. The
+					// "b" resource has a for_each, so the type of the entire
+					// resource block will be an object of objects. (for_each
+					// key => resource instance.) But since the keys of an
+					// object are an inherent part of the object type, and our
+					// for_each keys are unknown, the object type is totally
+					// unknowable.
+					"b": cty.NullVal(cty.DynamicPseudoType),
 
-					// Currently we produce an incorrect result for output
-					// value "c" because the expression evaluator doesn't
-					// realize it's supposed to be treating this as deferred
-					// during the apply phase, and so it incorrectly decides
-					// that there is instance due to the lack of instances
-					// in the state.
-					//"c": cty.NullVal(cty.DynamicPseudoType),
-					// test.c evaluates to the placeholder value that shows
-					// what we're expecting this object to look like in the
-					// next round.
-					"c": cty.ObjectVal(map[string]cty.Value{
-						"name":           cty.StringVal("c"),
-						"upstream_names": cty.UnknownVal(cty.Set(cty.String)).RefineNotNull(),
-					}),
+					// Output c is the value of the test.c resource block. The
+					// "c" resource is a singleton instance, so its type is
+					// wholly known from the schema! But it's still a null
+					// value, because the resource got transitively deferred.
+					"c": cty.NullVal(cty.Object(map[string]cty.Type{
+						"name":           cty.String,
+						"output":         cty.String,
+						"upstream_names": cty.Set(cty.String),
+					})),
 				},
 			},
 			{
@@ -1721,19 +1735,24 @@ output "a" {
 				},
 				inputs:      map[string]cty.Value{},
 				wantPlanned: map[string]cty.Value{
-					// The all resources will be deferred, so shouldn't
-					// have any action at this stage.
+					// Empty because it's a refresh-only plan in this stage.
 				},
 
 				wantActions: map[string]plans.Action{},
 				wantApplied: map[string]cty.Value{
-					// The all resources will be deferred, so shouldn't
+					// The resource will be deferred, so shouldn't
 					// have any action at this stage.
 				},
 				wantOutputs: map[string]cty.Value{
+					// TODO NF: In both the refresh-only stage and the real-plan stage below, the output is
+					// getting the new `name` value from the partially-planned deferred change rather than the
+					// old `name` value from the state. Is that right? For both cases? I couldn't quite
+					// decide, but currently that's what happens because of where the early-out happens over
+					// in GetResource while we're building the hcl eval context.
 					"a": cty.ObjectVal(map[string]cty.Value{
 						"name":           cty.StringVal("a"),
 						"upstream_names": cty.NullVal(cty.Set(cty.String)),
+						"output":         cty.NullVal(cty.String),
 					}),
 				},
 				wantDeferred: map[string]ExpectedDeferred{
@@ -1761,7 +1780,7 @@ output "a" {
 				},
 				wantOutputs: map[string]cty.Value{
 					"a": cty.ObjectVal(map[string]cty.Value{
-						"name":           cty.StringVal("deferred_read"),
+						"name":           cty.StringVal("a"),
 						"upstream_names": cty.NullVal(cty.Set(cty.String)),
 						"output":         cty.NullVal(cty.String),
 					}),
@@ -1872,12 +1891,15 @@ output "b" {
 						"name":   cty.String,
 						"output": cty.String,
 					})),
-					"b": cty.NullVal(cty.DynamicPseudoType),
+					"b": cty.NullVal(cty.Object(map[string]cty.Type{
+						"name":           cty.String,
+						"output":         cty.String,
+						"upstream_names": cty.Set(cty.String),
+					})),
 				},
 				wantDeferred: map[string]ExpectedDeferred{
-					// data.test.a is not part of the plan so we can only
-					// observe the indirect consequence on the resource.
-					"test.b": {Reason: providers.DeferredReasonDeferredPrereq, Action: plans.Create},
+					"data.test.a": {Reason: providers.DeferredReasonProviderConfigUnknown, Action: plans.Read},
+					"test.b":      {Reason: providers.DeferredReasonDeferredPrereq, Action: plans.Create},
 				},
 				complete: false,
 			},
@@ -1962,7 +1984,11 @@ output "a" {
 					// have any action at this stage.
 				},
 				wantOutputs: map[string]cty.Value{
-					"a": cty.NullVal(cty.DynamicPseudoType),
+					"a": cty.NullVal(cty.Object(map[string]cty.Type{
+						"name":           cty.String,
+						"output":         cty.String,
+						"upstream_names": cty.Set(cty.String),
+					})),
 				},
 				wantDeferred: map[string]ExpectedDeferred{
 					"test.a": {Reason: providers.DeferredReasonProviderConfigUnknown, Action: plans.Create},
@@ -2017,7 +2043,7 @@ output "a" {
 				},
 				wantOutputs: map[string]cty.Value{
 					"a": cty.ObjectVal(map[string]cty.Value{
-						"name":           cty.StringVal("old_value"),
+						"name":           cty.StringVal("deferred_resource_change"),
 						"upstream_names": cty.NullVal(cty.Set(cty.String)),
 						"output":         cty.NullVal(cty.String),
 					}),
@@ -2137,7 +2163,7 @@ output "a" {
 					"a": cty.ObjectVal(map[string]cty.Value{
 						"name":           cty.StringVal("deferred_resource_change"),
 						"upstream_names": cty.NullVal(cty.Set(cty.String)),
-						"output":         cty.UnknownVal(cty.String),
+						"output":         cty.NullVal(cty.String),
 					}),
 				},
 				wantDeferred: map[string]ExpectedDeferred{
@@ -2208,9 +2234,9 @@ output "a" {
 				},
 				wantOutputs: map[string]cty.Value{
 					"a": cty.ObjectVal(map[string]cty.Value{
-						"name":           cty.StringVal("old_value"),
+						"name":           cty.StringVal("deferred_resource_change"),
 						"upstream_names": cty.NullVal(cty.Set(cty.String)),
-						"output":         cty.StringVal("computed_output"),
+						"output":         cty.NullVal(cty.String),
 					}),
 				},
 				wantDeferred: map[string]ExpectedDeferred{

--- a/internal/terraform/evaluate_test.go
+++ b/internal/terraform/evaluate_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/hashicorp/terraform/internal/lang/marks"
 	"github.com/hashicorp/terraform/internal/namedvals"
 	"github.com/hashicorp/terraform/internal/plans"
+	"github.com/hashicorp/terraform/internal/plans/deferring"
 	"github.com/hashicorp/terraform/internal/providers"
 	"github.com/hashicorp/terraform/internal/states"
 	"github.com/hashicorp/terraform/internal/tfdiags"
@@ -289,6 +290,7 @@ func TestEvaluatorGetResource(t *testing.T) {
 		},
 		State:       stateSync,
 		NamedValues: namedvals.NewState(),
+		Deferrals:   deferring.NewDeferred(false),
 		Plugins: schemaOnlyProvidersForTesting(map[addrs.Provider]providers.ProviderSchema{
 			addrs.NewDefaultProvider("test"): {
 				ResourceTypes: map[string]providers.Schema{
@@ -529,6 +531,7 @@ func TestEvaluatorGetResource_changes(t *testing.T) {
 		},
 		State:       stateSync,
 		NamedValues: namedvals.NewState(),
+		Deferrals:   deferring.NewDeferred(false),
 		Plugins:     schemaOnlyProvidersForTesting(schemas.Providers),
 	}
 

--- a/internal/terraform/graph_builder_apply.go
+++ b/internal/terraform/graph_builder_apply.go
@@ -206,10 +206,12 @@ func (b *ApplyGraphBuilder) Steps() []GraphTransformer {
 			State:  b.State,
 		},
 
-		// We need to remove configuration nodes that are not used at all, as
-		// they may not be able to evaluate, especially during destroy.
-		// These include variables, locals, and instance expanders.
-		&pruneUnusedNodesTransformer{},
+		// In a destroy, we need to remove configuration nodes that are not used
+		// at all, as they may not be able to evaluate. These include variables,
+		// locals, and instance expanders.
+		&pruneUnusedNodesTransformer{
+			skip: b.Operation != walkDestroy,
+		},
 
 		// Target
 		&TargetsTransformer{Targets: b.Targets},

--- a/internal/terraform/node_output.go
+++ b/internal/terraform/node_output.go
@@ -781,6 +781,14 @@ func (n *NodeApplyableOutput) setValue(namedVals *namedvals.State, state *states
 		// not serialized.
 		if n.Addr.Module.IsRoot() {
 			val, _ = val.UnmarkDeep()
+			if val.IsKnown() && !val.IsWhollyKnown() {
+				// For the version of the value that ends up in state, treat
+				// partially-unknown values as wholly unknown. The goal is to avoid
+				// confusion with outputs that reference deferred values; since the
+				// referenced resource is still unready, we don't want to store
+				// planned-but-not-verified speculations in the source of truth.
+				val = cty.UnknownVal(val.Type())
+			}
 			val = cty.UnknownAsNull(val)
 		}
 		state.SetOutputValue(n.Addr, val, n.Config.Sensitive)

--- a/internal/terraform/node_output.go
+++ b/internal/terraform/node_output.go
@@ -782,14 +782,13 @@ func (n *NodeApplyableOutput) setValue(namedVals *namedvals.State, state *states
 		if n.Addr.Module.IsRoot() {
 			val, _ = val.UnmarkDeep()
 			if val.IsKnown() && !val.IsWhollyKnown() {
-				// For the version of the value that ends up in state, treat
-				// partially-unknown values as wholly unknown. The goal is to avoid
-				// confusion with outputs that reference deferred values; since the
-				// referenced resource is still unready, we don't want to store
-				// planned-but-not-verified speculations in the source of truth.
-				val = cty.UnknownVal(val.Type())
+				// If the value is partially unknown, act like it's fully
+				// unknown and store a null value in state. This can happen if
+				// an output references a deferred value.
+				val = cty.NullVal(val.Type())
+			} else {
+				val = cty.UnknownAsNull(val)
 			}
-			val = cty.UnknownAsNull(val)
 		}
 		state.SetOutputValue(n.Addr, val, n.Config.Sensitive)
 	}

--- a/internal/terraform/node_resource_abstract_instance.go
+++ b/internal/terraform/node_resource_abstract_instance.go
@@ -1676,14 +1676,23 @@ func (n *NodeAbstractResourceInstance) providerMetas(ctx EvalContext) (cty.Value
 // value, but it still matches the previous state, then we can record a NoNop
 // change. If the states don't match then we record a Read change so that the
 // new value is applied to the state.
-func (n *NodeAbstractResourceInstance) planDataSource(ctx EvalContext, checkRuleSeverity tfdiags.Severity, skipPlanChanges bool) (*plans.ResourceInstanceChange, *states.ResourceInstanceObject, instances.RepetitionData, tfdiags.Diagnostics) {
+//
+// The cases where a data source will generate a planned change instead
+// of finishing during the plan are:
+//
+//   - Its config has unknown values or it depends on a resource with pending changes.
+//     (Note that every data source that is DeferredPrereq should also fit this description.)
+//   - We attempted a read request, but the provider says we're deferred.
+//   - It's nested in a check block, and should always read again during apply.
+func (n *NodeAbstractResourceInstance) planDataSource(ctx EvalContext, checkRuleSeverity tfdiags.Severity, skipPlanChanges bool) (*plans.ResourceInstanceChange, *states.ResourceInstanceObject, *providers.Deferred, instances.RepetitionData, tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
 	var keyData instances.RepetitionData
 	var configVal cty.Value
+	var deferred *providers.Deferred
 
 	_, providerSchema, err := getProvider(ctx, n.ResolvedProvider)
 	if err != nil {
-		return nil, nil, keyData, diags.Append(err)
+		return nil, nil, deferred, keyData, diags.Append(err)
 	}
 
 	config := *n.Config
@@ -1691,7 +1700,7 @@ func (n *NodeAbstractResourceInstance) planDataSource(ctx EvalContext, checkRule
 	if schema == nil {
 		// Should be caught during validation, so we don't bother with a pretty error here
 		diags = diags.Append(fmt.Errorf("provider %q does not support data source %q", n.ResolvedProvider, n.Addr.ContainingResource().Resource.Type))
-		return nil, nil, keyData, diags
+		return nil, nil, deferred, keyData, diags
 	}
 
 	objTy := schema.ImpliedType()
@@ -1708,7 +1717,7 @@ func (n *NodeAbstractResourceInstance) planDataSource(ctx EvalContext, checkRule
 	)
 	diags = diags.Append(checkDiags)
 	if diags.HasErrors() {
-		return nil, nil, keyData, diags // failed preconditions prevent further evaluation
+		return nil, nil, deferred, keyData, diags // failed preconditions prevent further evaluation
 	}
 
 	var configDiags tfdiags.Diagnostics
@@ -1718,7 +1727,7 @@ func (n *NodeAbstractResourceInstance) planDataSource(ctx EvalContext, checkRule
 		validateResourceForbiddenEphemeralValues(ctx, configVal, schema).InConfigBody(n.Config.Config, n.Addr.String()),
 	)
 	if diags.HasErrors() {
-		return nil, nil, keyData, diags
+		return nil, nil, deferred, keyData, diags
 	}
 	unmarkedConfigVal, unmarkedPaths := configVal.UnmarkDeepWithPaths()
 
@@ -1763,7 +1772,7 @@ func (n *NodeAbstractResourceInstance) planDataSource(ctx EvalContext, checkRule
 				Status: states.ObjectReady,
 			}
 
-			return nil, plannedNewState, keyData, diags
+			return nil, plannedNewState, deferred, keyData, diags
 		}
 
 		var reason plans.ResourceInstanceChangeActionReason
@@ -1812,7 +1821,7 @@ func (n *NodeAbstractResourceInstance) planDataSource(ctx EvalContext, checkRule
 			return h.PostDiff(n.HookResourceIdentity(), addrs.NotDeposed, plans.Read, priorVal, proposedNewVal)
 		}))
 
-		return plannedChange, plannedNewState, keyData, diags
+		return plannedChange, plannedNewState, deferred, keyData, diags
 	}
 
 	// We have a complete configuration with no dependencies to wait on, so we
@@ -1821,7 +1830,7 @@ func (n *NodeAbstractResourceInstance) planDataSource(ctx EvalContext, checkRule
 	newVal, readDeferred, readDiags := n.readDataSource(ctx, configVal)
 
 	if readDeferred != nil {
-		ctx.Deferrals().ReportDataSourceInstanceDeferred(n.Addr, newVal)
+		deferred = readDeferred
 	}
 
 	// Now we've loaded the data, and diags tells us whether we were successful
@@ -1875,9 +1884,10 @@ func (n *NodeAbstractResourceInstance) planDataSource(ctx EvalContext, checkRule
 			}
 		})
 
-		if !skipPlanChanges && readDeferred == nil {
-			// refreshOnly plans cannot produce planned changes, so we only do
-			// this if skipPlanChanges is false.
+		// refreshOnly plans cannot produce planned changes, so we only do
+		// this if skipPlanChanges is false. Conversely, provider-deferred data
+		// sources always generate a planned change with a different ActionReason.
+		if !skipPlanChanges && deferred == nil {
 			plannedChange = &plans.ResourceInstanceChange{
 				Addr:         n.Addr,
 				PrevRunAddr:  n.prevRunAddr(ctx),
@@ -1892,8 +1902,30 @@ func (n *NodeAbstractResourceInstance) planDataSource(ctx EvalContext, checkRule
 		}
 	}
 
+	// Provider-deferred data sources always generate a planned change.
+	if deferred != nil {
+		plannedChange = &plans.ResourceInstanceChange{
+			Addr:         n.Addr,
+			PrevRunAddr:  n.prevRunAddr(ctx),
+			ProviderAddr: n.ResolvedProvider,
+			Change: plans.Change{
+				Action: plans.Read,
+				Before: priorVal,
+				After:  newVal,
+			},
+			// The caller should be more interested in the deferral reason, but this
+			// action reason is a reasonable description of what's happening.
+			ActionReason: plans.ResourceInstanceReadBecauseDependencyPending,
+		}
+
+		plannedNewState = &states.ResourceInstanceObject{
+			Value:  newVal,
+			Status: states.ObjectPlanned,
+		}
+	}
+
 	diags = diags.Append(readDiags)
-	if !diags.HasErrors() && readDeferred == nil {
+	if !diags.HasErrors() && deferred == nil {
 		// Finally, let's make our new state.
 		plannedNewState = &states.ResourceInstanceObject{
 			Value:  newVal,
@@ -1901,7 +1933,7 @@ func (n *NodeAbstractResourceInstance) planDataSource(ctx EvalContext, checkRule
 		}
 	}
 
-	return plannedChange, plannedNewState, keyData, diags
+	return plannedChange, plannedNewState, deferred, keyData, diags
 }
 
 // nestedInCheckBlock determines if this resource is nested in a Check config

--- a/internal/terraform/node_resource_abstract_instance.go
+++ b/internal/terraform/node_resource_abstract_instance.go
@@ -1821,7 +1821,7 @@ func (n *NodeAbstractResourceInstance) planDataSource(ctx EvalContext, checkRule
 	newVal, readDeferred, readDiags := n.readDataSource(ctx, configVal)
 
 	if readDeferred != nil {
-		ctx.Deferrals().ReportDataSourceInstanceDeferred(n.Addr)
+		ctx.Deferrals().ReportDataSourceInstanceDeferred(n.Addr, newVal)
 	}
 
 	// Now we've loaded the data, and diags tells us whether we were successful
@@ -2063,7 +2063,8 @@ func (n *NodeAbstractResourceInstance) applyDataSource(ctx EvalContext, planned 
 	}
 
 	if readDeferred != nil {
-		ctx.Deferrals().ReportDataSourceInstanceDeferred(n.Addr)
+		// Just skip data sources that are being deferred. Nothing, that
+		// references them should be calling them.
 		return nil, keyData, diags
 	}
 

--- a/internal/terraform/node_resource_apply.go
+++ b/internal/terraform/node_resource_apply.go
@@ -49,35 +49,10 @@ func (n *nodeExpandApplyableResource) Name() string {
 }
 
 func (n *nodeExpandApplyableResource) Execute(globalCtx EvalContext, op walkOperation) tfdiags.Diagnostics {
-
-	// TODO: When validating support for modules (TF-13952), we should check
-	// here if the whole module is partially expanded and skip the .ExpandModule
-	// call below.
-	//
-	//  for _, per := range n.PartialExpansions {
-	//    if _, ok := per.PartialExpandedModule(); ok {
-	//      return nil // don't even try to expand the modules
-	//    }
-	//  }
-	//
-	//  The above checks if the module is partially expanded and if it is, it
-	//  skips the expansion of the module. This isn't implemented yet, because
-	//  partial module expansion is not implemented properly yet.
-
 	var diags tfdiags.Diagnostics
 	expander := globalCtx.InstanceExpander()
 	moduleInstances := expander.ExpandModule(n.Addr.Module, false)
-Insts:
 	for _, module := range moduleInstances {
-
-		// First check if this resource in this module instance in part of a
-		// partial expansion. If it is, we can't and don't need to expand it.
-		for _, per := range n.PartialExpansions {
-			if per.MatchesResource(n.Addr.Absolute(module)) {
-				continue Insts
-			}
-		}
-
 		moduleCtx := evalContextForModuleInstance(globalCtx, module)
 		diags = diags.Append(n.writeResourceState(moduleCtx, n.Addr.Resource.Absolute(module)))
 	}

--- a/internal/terraform/node_resource_apply_deferred.go
+++ b/internal/terraform/node_resource_apply_deferred.go
@@ -26,14 +26,14 @@ type nodeApplyableDeferredInstance struct {
 }
 
 func (n *nodeApplyableDeferredInstance) Execute(ctx EvalContext, _ walkOperation) tfdiags.Diagnostics {
+	var diags tfdiags.Diagnostics
 	change, err := n.ChangeSrc.Decode(n.Schema.ImpliedType())
 	if err != nil {
-		var diags tfdiags.Diagnostics
 		diags = diags.Append(tfdiags.Sourceless(tfdiags.Error, "Failed to decode ", fmt.Sprintf("Terraform failed to decode a deferred change: %v\n\nThis is a bug in Terraform; please report it!", err)))
 	}
 
 	ctx.Deferrals().ReportResourceInstanceDeferred(n.Addr, n.Reason, change)
-	return nil
+	return diags
 }
 
 // nodeApplyableDeferredPartialInstance is a node that represents a deferred
@@ -47,12 +47,12 @@ type nodeApplyableDeferredPartialInstance struct {
 }
 
 func (n *nodeApplyableDeferredPartialInstance) Execute(ctx EvalContext, _ walkOperation) tfdiags.Diagnostics {
+	var diags tfdiags.Diagnostics
 	change, err := n.ChangeSrc.Decode(n.Schema.ImpliedType())
 	if err != nil {
-		var diags tfdiags.Diagnostics
 		diags = diags.Append(tfdiags.Sourceless(tfdiags.Error, "Failed to decode ", fmt.Sprintf("Terraform failed to decode a deferred change: %v\n\nThis is a bug in Terraform; please report it!", err)))
 	}
 
 	ctx.Deferrals().ReportResourceExpansionDeferred(n.PartialAddr, change)
-	return nil
+	return diags
 }

--- a/internal/terraform/node_resource_plan_partialexp.go
+++ b/internal/terraform/node_resource_plan_partialexp.go
@@ -94,8 +94,9 @@ func (n *nodePlannablePartialExpandedResource) Execute(ctx EvalContext, op walkO
 		diags = diags.Append(changeDiags)
 		ctx.Deferrals().ReportResourceExpansionDeferred(n.addr, change)
 	case addrs.DataResourceMode:
-		_, diags = n.dataResourceExecute(ctx)
-		ctx.Deferrals().ReportDataSourceExpansionDeferred(n.addr)
+		value, valueDiags := n.dataResourceExecute(ctx)
+		diags = diags.Append(valueDiags)
+		ctx.Deferrals().ReportDataSourceExpansionDeferred(n.addr, value)
 	default:
 		panic(fmt.Errorf("unsupported resource mode %s", n.config.Mode))
 	}

--- a/internal/terraform/transform_deferred.go
+++ b/internal/terraform/transform_deferred.go
@@ -4,6 +4,8 @@
 package terraform
 
 import (
+	"github.com/hashicorp/terraform/internal/addrs"
+	"github.com/hashicorp/terraform/internal/dag"
 	"github.com/hashicorp/terraform/internal/plans"
 	"github.com/hashicorp/terraform/internal/providers"
 )
@@ -23,9 +25,32 @@ func (t *DeferredTransformer) Transform(g *Graph) error {
 		return nil
 	}
 
+	// As with the DiffTransformer, DeferredTransformer creates resource
+	// instance nodes. If there are any whole-resource nodes already in the
+	// graph, we must ensure they get evaluated before any of the corresponding
+	// instances by creating dependency edges.
+	resourceNodes := addrs.MakeMap[addrs.ConfigResource, []GraphNodeConfigResource]()
+	for _, node := range g.Vertices() {
+		rn, ok := node.(GraphNodeConfigResource)
+		if !ok {
+			continue
+		}
+		// We ignore any instances that _also_ implement
+		// GraphNodeResourceInstance, since in the unlikely event that they
+		// do exist we'd probably end up creating cycles by connecting them.
+		if _, ok := node.(GraphNodeResourceInstance); ok {
+			continue
+		}
+
+		rAddr := rn.ResourceAddr()
+		resourceNodes.Put(rAddr, append(resourceNodes.Get(rAddr), rn))
+	}
+
 	for _, change := range t.DeferredChanges {
 		node := &nodeApplyableDeferredInstance{
 			NodeAbstractResourceInstance: NewNodeAbstractResourceInstance(change.ChangeSrc.Addr),
+			Reason:                       change.DeferredReason,
+			ChangeSrc:                    change.ChangeSrc,
 		}
 
 		// Create a special node for partial instances, that handles the
@@ -35,10 +60,11 @@ func (t *DeferredTransformer) Transform(g *Graph) error {
 
 			// This is a partial instance, so we need to create a partial node
 			// instead of a full instance node.
-			g.Add(&nodeApplyableDeferredPartialInstance{
+			node := &nodeApplyableDeferredPartialInstance{
 				nodeApplyableDeferredInstance: node,
 				PartialAddr:                   per,
-			})
+			}
+			g.Add(node)
 
 			// Now we want to find the expansion node that would be applied for
 			// this resource, and tell it that it is performing a partial
@@ -51,11 +77,23 @@ func (t *DeferredTransformer) Transform(g *Graph) error {
 				}
 			}
 
+			// Also connect the deferred instance node to the underlying
+			// resource node to make sure any expansion happens first.
+			for _, resourceNode := range resourceNodes.Get(node.Addr.ConfigResource()) {
+				g.Connect(dag.BasicEdge(node, resourceNode))
+			}
+
 			continue
 		}
 
 		// Otherwise, just add the normal deferred instance node.
 		g.Add(node)
+
+		// Still connect the deferred instance node to the underlying resource
+		// node.
+		for _, resourceNode := range resourceNodes.Get(node.Addr.ConfigResource()) {
+			g.Connect(dag.BasicEdge(node, resourceNode))
+		}
 	}
 
 	return nil


### PR DESCRIPTION
This PR has two authors and two goals — @liamcervante was already working on wiring deferred values into outputs, and I needed to build on some of what he'd already done in order to finish implementing deferral for data sources. 

### Data sources can cause deferred changes

Previously, we weren't copying any information about deferred data sources into the plan; the theory was that data sources are handled during plan, and any resource that refers to them will already be listed as deferred, so we can just reconstruct things during the apply as needed. 

This turned out to be not quite coherent, mostly because data sources CAN in fact produce planned changes that get processed during an apply! To observe this, just make a data source reference a computed attribute from a resource that hasn't been applied yet; the data source will plan a `Read` action. This caused at least one bug with the prior approach, when a data source was both deferred due to a deferred prereq AND delayed due to unknown configuration -- it would plan a change that would blow up during apply. 

So, since deferral is conceptually nearly the same thing as a delayed read (it just gets delayed til a future plan/apply cycle instead of the upcoming apply), we're now making deferred data sources produce a deferred Read change in the plan. This makes the storage formats for data sources and resources in the `Deferred` struct identical, which simplifies several things. It also lets us easily produce deferred graph nodes for data sources in the apply, which simplifies getting their incomplete values for use in outputs. 

### Outputs use deferred change values

When building the hcl eval context for evaluating expressions, we now use the deferred change planned value for resources and data sources if one is available. This generally seems to result in outputs getting appropriately null values for things that can't be known due to deferral. 

## Questions for reviewers

- Is the new behavior of outputs coherent, in the case where a resource previously existed in the state but we've got a deferred planned change coming up? They're now returning the (partial or unknown) planned value, rather than the old fully-known (but soon-to-be invalidated) value. I went in circles on this.
- In the new logic for partial-expanding data sources, do we need to do anything to handle data sources that are nested in check blocks? I didn't think so, but I'm also new to check blocks. 
- For @liamcervante: Could you expand a bit on the changes to transform_destroy_edge and node_resource_apply? This was part of the outputs stuff, and it's the one bit I didn't fully understand. I think it's ultimately because outputs might be referring to partially-expanded resources inside modules that have unknown for_each, but I couldn't fully connect the dots yet.

## Target Release

1.9.x

## Draft CHANGELOG entry

### EXPERIMENTS

The deferred actions experiment now handles data sources and outputs more thoroughly.