### PR TITLE
broken link in architecture.md #35184

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -280,7 +280,7 @@ a plan operation would include the following high-level steps:
   this operation.
 
 Each execution step for a vertex is an implementation of
-[`terraform.Execute`](https://pkg.go.dev/github.com/hashicorp/terraform/internal/erraform#Execute).
+[`terraform.Execute`](https://pkg.go.dev/github.com/hashicorp/terraform/internal/terraform#Execute).
 As with graph transforms, the behavior of these implementations varies widely:
 whereas graph transforms can take any action against the graph, an `Execute`
 implementation can take any action against the `EvalContext`.


### PR DESCRIPTION
Description
 The link goes to a broken package in pkg, this PR resolves the bug by updating the spelling of the link to appropriately go to the correct location within the `architecture.md` . This PR fixes issue #35184.

**Fix proposal**
The link in question that is broken is:
`https://pkg.go.dev/github.com/hashicorp/terraform/internal/erraform#Execute`
this is fixed with
`https://pkg.go.dev/github.com/hashicorp/terraform/internal/terraform#Execute`

**Version**
Fixes documentation in the current version # 1.8.3
```
terraform.exe --version
Terraform v1.8.3
on windows_amd64
```

**Change log entry**
BUG FIX
* broken link within `architecture.md` updated to correct location


