### PR TITLE
import: only filter id attribute at root level when generating config

### DIFF
--- a/internal/configs/configschema/filter.go
+++ b/internal/configs/configschema/filter.go
@@ -3,33 +3,35 @@
 
 package configschema
 
-type FilterT[T any] func(string, T) bool
+import "github.com/zclconf/go-cty/cty"
+
+type FilterT[T any] func(cty.Path, T) bool
 
 var (
-	FilterReadOnlyAttribute = func(name string, attribute *Attribute) bool {
+	FilterReadOnlyAttribute = func(path cty.Path, attribute *Attribute) bool {
 		return attribute.Computed && !attribute.Optional
 	}
 
-	FilterHelperSchemaIdAttribute = func(name string, attribute *Attribute) bool {
-		if name == "id" && attribute.Computed && attribute.Optional {
+	FilterHelperSchemaIdAttribute = func(path cty.Path, attribute *Attribute) bool {
+		if path.Equals(cty.GetAttrPath("id")) && attribute.Computed && attribute.Optional {
 			return true
 		}
 		return false
 	}
 
-	FilterDeprecatedAttribute = func(name string, attribute *Attribute) bool {
+	FilterDeprecatedAttribute = func(path cty.Path, attribute *Attribute) bool {
 		return attribute.Deprecated
 	}
 
-	FilterDeprecatedBlock = func(name string, block *NestedBlock) bool {
+	FilterDeprecatedBlock = func(path cty.Path, block *NestedBlock) bool {
 		return block.Deprecated
 	}
 )
 
 func FilterOr[T any](filters ...FilterT[T]) FilterT[T] {
-	return func(name string, value T) bool {
+	return func(path cty.Path, value T) bool {
 		for _, f := range filters {
-			if f(name, value) {
+			if f(path, value) {
 				return true
 			}
 		}
@@ -38,6 +40,10 @@ func FilterOr[T any](filters ...FilterT[T]) FilterT[T] {
 }
 
 func (b *Block) Filter(filterAttribute FilterT[*Attribute], filterBlock FilterT[*NestedBlock]) *Block {
+	return b.filter(nil, filterAttribute, filterBlock)
+}
+
+func (b *Block) filter(path cty.Path, filterAttribute FilterT[*Attribute], filterBlock FilterT[*NestedBlock]) *Block {
 	ret := &Block{
 		Description:     b.Description,
 		DescriptionKind: b.DescriptionKind,
@@ -48,10 +54,11 @@ func (b *Block) Filter(filterAttribute FilterT[*Attribute], filterBlock FilterT[
 		ret.Attributes = make(map[string]*Attribute, len(b.Attributes))
 	}
 	for name, attrS := range b.Attributes {
-		if filterAttribute == nil || !filterAttribute(name, attrS) {
+		path := path.GetAttr(name)
+		if filterAttribute == nil || !filterAttribute(path, attrS) {
 			ret.Attributes[name] = attrS
 			if attrS.NestedType != nil {
-				ret.Attributes[name].NestedType = filterNestedType(attrS.NestedType, filterAttribute)
+				ret.Attributes[name].NestedType = filterNestedType(attrS.NestedType, path, filterAttribute)
 			}
 		}
 	}
@@ -60,8 +67,9 @@ func (b *Block) Filter(filterAttribute FilterT[*Attribute], filterBlock FilterT[
 		ret.BlockTypes = make(map[string]*NestedBlock, len(b.BlockTypes))
 	}
 	for name, blockS := range b.BlockTypes {
-		if filterBlock == nil || !filterBlock(name, blockS) {
-			block := blockS.Filter(filterAttribute, filterBlock)
+		path := path.GetAttr(name)
+		if filterBlock == nil || !filterBlock(path, blockS) {
+			block := blockS.filter(path, filterAttribute, filterBlock)
 			ret.BlockTypes[name] = &NestedBlock{
 				Block:    *block,
 				Nesting:  blockS.Nesting,
@@ -74,7 +82,7 @@ func (b *Block) Filter(filterAttribute FilterT[*Attribute], filterBlock FilterT[
 	return ret
 }
 
-func filterNestedType(obj *Object, filterAttribute FilterT[*Attribute]) *Object {
+func filterNestedType(obj *Object, path cty.Path, filterAttribute FilterT[*Attribute]) *Object {
 	if obj == nil {
 		return nil
 	}
@@ -85,10 +93,11 @@ func filterNestedType(obj *Object, filterAttribute FilterT[*Attribute]) *Object 
 	}
 
 	for name, attrS := range obj.Attributes {
-		if filterAttribute == nil || !filterAttribute(name, attrS) {
+		path := path.GetAttr(name)
+		if filterAttribute == nil || !filterAttribute(path, attrS) {
 			ret.Attributes[name] = attrS
 			if attrS.NestedType != nil {
-				ret.Attributes[name].NestedType = filterNestedType(attrS.NestedType, filterAttribute)
+				ret.Attributes[name].NestedType = filterNestedType(attrS.NestedType, path, filterAttribute)
 			}
 		}
 	}


### PR DESCRIPTION
The legacy SDK introduces an `id` attribute at the root level of resources. This caused invalid config to be generated for the legacy SDK. To avoid this we introduced a filter that removed this attribute from the generated config. This workaround is discussed here: https://github.com/hashicorp/terraform/blob/main/internal/terraform/node_resource_plan_instance.go#L751-L761.

The linked issue highlights we were also removing computed and optional `id` attributes from within nested attributes and blocks. These `id` attributes are not introduced by the SDK, so I've changed the filter functionality to accept a path instead of an attribute name and it now only removes attributes at the root level instead of across the whole schema.

<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Fixes #35178 

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.8.4

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

### BUG FIXES

<!--

Write a short description of the user-facing change. Examples:

- `terraform show -json`: Fixed crash with sensitive set values.
- When rendering a diff, Terraform now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 

-  `import` blocks: Fix bug where resources with nested, computed, and optional `id` attributes would fail to generate.
