### PR TITLE
Fix inconsistent `moved` snippets in docs

### DIFF
--- a/website/docs/language/moved.mdx
+++ b/website/docs/language/moved.mdx
@@ -24,7 +24,7 @@ The following list outlines field hierarchy, language-specific data types, and r
 When every field is defined, a `moved` block has the following form:
 
 ```hcl
-moved = {
+moved {
     from = <old address for the resource>
     to = <new address for the resource>
 }


### PR DESCRIPTION
The two code snippets on the docs page for `moved` were different. This patch makes them the same.

## Target Release

This is purely a docs fix.

## Draft CHANGELOG entry

### BUG FIXES

- Fix inconsistent `moved` snippets in docs
