### PR TITLE
Support for provisioners in `removed` blocks

### DIFF
--- a/internal/configs/removed.go
+++ b/internal/configs/removed.go
@@ -4,6 +4,8 @@
 package configs
 
 import (
+	"fmt"
+
 	"github.com/hashicorp/terraform/internal/addrs"
 
 	"github.com/hashicorp/hcl/v2"
@@ -19,6 +21,12 @@ type Removed struct {
 	// from state. Defaults to true.
 	Destroy bool
 
+	// Managed captures a number of metadata fields that are applicable only
+	// for managed resources, and not for other resource modes.
+	//
+	// "removed" blocks support only a subset of the fields in [ManagedResource].
+	Managed *ManagedResource
+
 	DeclRange hcl.Range
 }
 
@@ -31,6 +39,8 @@ func decodeRemovedBlock(block *hcl.Block) (*Removed, hcl.Diagnostics) {
 	content, moreDiags := block.Body.Content(removedBlockSchema)
 	diags = append(diags, moreDiags...)
 
+	var targetKind addrs.RemoveTargetKind
+	var resourceMode addrs.ResourceMode // only valid if targetKind is addrs.RemoveTargetResource
 	if attr, exists := content.Attributes["from"]; exists {
 		from, traversalDiags := hcl.AbsTraversalForExpr(attr.Expr)
 		diags = append(diags, traversalDiags...)
@@ -38,11 +48,21 @@ func decodeRemovedBlock(block *hcl.Block) (*Removed, hcl.Diagnostics) {
 			from, fromDiags := addrs.ParseRemoveTarget(from)
 			diags = append(diags, fromDiags.ToHCL()...)
 			removed.From = from
+			if removed.From != nil {
+				targetKind = removed.From.ObjectKind()
+				if targetKind == addrs.RemoveTargetResource {
+					resourceMode = removed.From.RelSubject.(addrs.ConfigResource).Resource.Mode
+				}
+			}
 		}
 	}
 
 	removed.Destroy = true
+	if resourceMode == addrs.ManagedResourceMode {
+		removed.Managed = &ManagedResource{}
+	}
 
+	var seenConnection *hcl.Block
 	for _, block := range content.Blocks {
 		switch block.Type {
 		case "lifecycle":
@@ -52,6 +72,61 @@ func decodeRemovedBlock(block *hcl.Block) (*Removed, hcl.Diagnostics) {
 			if attr, exists := lcContent.Attributes["destroy"]; exists {
 				valDiags := gohcl.DecodeExpression(attr.Expr, nil, &removed.Destroy)
 				diags = append(diags, valDiags...)
+			}
+
+		case "connection":
+			if removed.Managed == nil {
+				// target is not a managed resource, then
+				diags = append(diags, &hcl.Diagnostic{
+					Severity: hcl.DiagError,
+					Summary:  "Invalid connection block",
+					Detail:   "Provisioner connection configuration is valid only when a removed block targets a managed resource.",
+					Subject:  &block.DefRange,
+				})
+				continue
+			}
+
+			if seenConnection != nil {
+				diags = append(diags, &hcl.Diagnostic{
+					Severity: hcl.DiagError,
+					Summary:  "Duplicate connection block",
+					Detail:   fmt.Sprintf("This \"removed\" block already has a connection block at %s.", seenConnection.DefRange),
+					Subject:  &block.DefRange,
+				})
+				continue
+			}
+			seenConnection = block
+
+			removed.Managed.Connection = &Connection{
+				Config:    block.Body,
+				DeclRange: block.DefRange,
+			}
+
+		case "provisioner":
+			if removed.Managed == nil {
+				// target is not a managed resource, then
+				diags = append(diags, &hcl.Diagnostic{
+					Severity: hcl.DiagError,
+					Summary:  "Invalid provisioner block",
+					Detail:   "Provisioners are valid only when a removed block targets a managed resource.",
+					Subject:  &block.DefRange,
+				})
+				continue
+			}
+
+			pv, pvDiags := decodeProvisionerBlock(block)
+			diags = append(diags, pvDiags...)
+			if pv != nil {
+				removed.Managed.Provisioners = append(removed.Managed.Provisioners, pv)
+
+				if pv.When != ProvisionerWhenDestroy {
+					diags = append(diags, &hcl.Diagnostic{
+						Severity: hcl.DiagError,
+						Summary:  "Invalid provisioner block",
+						Detail:   "Only destroy-time provisioners are valid in \"removed\" blocks. To declare a destroy-time provisioner, use:\n    when = destroy",
+						Subject:  &block.DefRange,
+					})
+				}
 			}
 		}
 	}
@@ -67,9 +142,9 @@ var removedBlockSchema = &hcl.BodySchema{
 		},
 	},
 	Blocks: []hcl.BlockHeaderSchema{
-		{
-			Type: "lifecycle",
-		},
+		{Type: "lifecycle"},
+		{Type: "connection"},
+		{Type: "provisioner", LabelNames: []string{"type"}},
 	},
 }
 

--- a/internal/terraform/context_apply_test.go
+++ b/internal/terraform/context_apply_test.go
@@ -4908,6 +4908,57 @@ func TestContext2Apply_provisionerDestroy(t *testing.T) {
 	}
 }
 
+func TestContext2Apply_provisionerDestroyRemoved(t *testing.T) {
+	m := testModule(t, "apply-provisioner-destroy-removed")
+	p := testProvider("aws")
+	pr := testProvisioner()
+	p.PlanResourceChangeFn = testDiffFn
+	pr.ProvisionResourceFn = func(req provisioners.ProvisionResourceRequest) (resp provisioners.ProvisionResourceResponse) {
+		val := req.Config.GetAttr("command").AsString()
+		// The following is "destroy ${each.key} ${self.foo}"
+		if val != "destroy a bar" {
+			t.Fatalf("wrong value for command: %q", val)
+		}
+
+		return
+	}
+
+	state := states.NewState()
+	root := state.RootModule()
+	root.SetResourceInstanceCurrent(
+		mustResourceInstanceAddr(`aws_instance.foo["a"]`).Resource,
+		&states.ResourceInstanceObjectSrc{
+			Status:    states.ObjectReady,
+			AttrsJSON: []byte(`{"id":"bar","foo":"bar"}`),
+		},
+		mustProviderConfig(`provider["registry.terraform.io/hashicorp/aws"]`),
+	)
+
+	ctx := testContext2(t, &ContextOpts{
+		Providers: map[addrs.Provider]providers.Factory{
+			addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
+		},
+		Provisioners: map[string]provisioners.Factory{
+			"shell": testProvisionerFuncFixed(pr),
+		},
+	})
+
+	plan, diags := ctx.Plan(m, state, SimplePlanOpts(plans.NormalMode, testInputValuesUnset(m.Module.Variables)))
+	assertNoErrors(t, diags)
+
+	state, diags = ctx.Apply(plan, m, nil)
+	if diags.HasErrors() {
+		t.Fatalf("diags: %s", diags.Err())
+	}
+
+	checkStateString(t, state, `<no state>`)
+
+	// Verify apply was invoked
+	if !pr.ProvisionResourceCalled {
+		t.Fatalf("provisioner not invoked")
+	}
+}
+
 // Verify that on destroy provisioner failure, nothing happens to the instance
 func TestContext2Apply_provisionerDestroyFail(t *testing.T) {
 	m := testModule(t, "apply-provisioner-destroy")

--- a/internal/terraform/node_resource_abstract.go
+++ b/internal/terraform/node_resource_abstract.go
@@ -55,7 +55,11 @@ type NodeAbstractResource struct {
 
 	Schema        *configschema.Block // Schema for processing the configuration body
 	SchemaVersion uint64              // Schema version of "Schema", as decided by the provider
-	Config        *configs.Resource   // Config is the resource in the config
+
+	// Config and RemovedConfig are mutally-exclusive, because a
+	// resource can't be both declared and removed at the same time.
+	Config        *configs.Resource // Config is the resource in the config, if any
+	RemovedConfig *configs.Removed  // RemovedConfig is the "removed" block for this resource, if any
 
 	// ProviderMetas is the provider_meta configs for the module this resource belongs to
 	ProviderMetas map[addrs.Provider]*configs.ProviderMeta
@@ -359,8 +363,9 @@ func (n *NodeAbstractResource) AttachDataResourceDependsOn(deps []addrs.ConfigRe
 }
 
 // GraphNodeAttachResourceConfig
-func (n *NodeAbstractResource) AttachResourceConfig(c *configs.Resource) {
+func (n *NodeAbstractResource) AttachResourceConfig(c *configs.Resource, rc *configs.Removed) {
 	n.Config = c
+	n.RemovedConfig = rc
 }
 
 // GraphNodeAttachResourceSchema impl

--- a/internal/terraform/testdata/apply-provisioner-destroy-removed/main.tf
+++ b/internal/terraform/testdata/apply-provisioner-destroy-removed/main.tf
@@ -1,0 +1,8 @@
+removed {
+  from = aws_instance.foo
+
+  provisioner "shell" {
+    when     = "destroy"
+    command  = "destroy ${each.key} ${self.foo}"
+  }
+}

--- a/internal/terraform/testdata/apply-provisioner-destroy-removed/main.tf
+++ b/internal/terraform/testdata/apply-provisioner-destroy-removed/main.tf
@@ -3,6 +3,10 @@ removed {
 
   provisioner "shell" {
     when     = "destroy"
-    command  = "destroy ${each.key} ${self.foo}"
+
+    // Capture that we can reference either count.index or each.key from a
+    // removed block, and it's up to the user to ensure the provisioner is
+    // correct for the now removed resources.
+    command  = "destroy ${try(count.index, each.key)} ${self.foo}"
   }
 }

--- a/internal/terraform/transform_attach_config_resource.go
+++ b/internal/terraform/transform_attach_config_resource.go
@@ -6,6 +6,7 @@ package terraform
 import (
 	"log"
 
+	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/configs"
 	"github.com/hashicorp/terraform/internal/dag"
 )
@@ -15,8 +16,11 @@ import (
 type GraphNodeAttachResourceConfig interface {
 	GraphNodeConfigResource
 
-	// Sets the configuration
-	AttachResourceConfig(*configs.Resource)
+	// Sets the configuration, either to a present resource block or to
+	// a "removed" block commemorating a resource that has since been
+	// removed. Callers should always leave at least one of these
+	// arguments set to nil.
+	AttachResourceConfig(*configs.Resource, *configs.Removed)
 }
 
 // AttachResourceConfigTransformer goes through the graph and attaches
@@ -51,7 +55,7 @@ func (t *AttachResourceConfigTransformer) Transform(g *Graph) error {
 
 		if r := config.Module.ResourceByAddr(addr.Resource); r != nil {
 			log.Printf("[TRACE] AttachResourceConfigTransformer: attaching to %q (%T) config from %#v", dag.VertexName(v), v, r.DeclRange)
-			arn.AttachResourceConfig(r)
+			arn.AttachResourceConfig(r, nil)
 			if gnapmc, ok := v.(GraphNodeAttachProviderMetaConfigs); ok {
 				log.Printf("[TRACE] AttachResourceConfigTransformer: attaching provider meta configs to %s", dag.VertexName(v))
 				if config.Module.ProviderMetas != nil {
@@ -60,6 +64,27 @@ func (t *AttachResourceConfigTransformer) Transform(g *Graph) error {
 					log.Printf("[TRACE] AttachResourceConfigTransformer: no provider meta configs available to attach to %s", dag.VertexName(v))
 				}
 			}
+		}
+
+		for _, r := range config.Module.Removed {
+			crAddr, ok := r.From.RelSubject.(addrs.ConfigResource)
+			if !ok {
+				// Not for a resource at all, so can't possibly match
+				continue
+			}
+			rAddr := crAddr.Resource
+			if rAddr != addr.Resource {
+				// Not the same resource
+				continue
+			}
+
+			log.Printf("[TRACE] AttachResourceConfigTransformer: attaching to %q (%T) removed block from %#v", dag.VertexName(v), v, r.DeclRange)
+
+			// Validation ensures that there can't be both a resource/data block
+			// and a removed block referring to the same configuration, so
+			// we can assume that this isn't clobbering a non-removed resource
+			// configuration we already attached above.
+			arn.AttachResourceConfig(nil, r)
 		}
 	}
 


### PR DESCRIPTION
During the apply phase, we'll check if there are provisioners either in the matching resource block or the matching removed block -- whichever of the two is present -- and execute the destroy-time subset of them either way.

This also establishes a standard way to attach a removed block to a NodeResourceAbstract when one is defined, which is likely to be useful for supporting other resource-related meta arguments in removed blocks in future.

```
removed {
  from = aws_instance.example

  provisioner "local-exec" {
    # All provisioners must have when = destroy in this context,
    # because "removed" resources can only be destroyed.
    when = destroy

    # ...
  }
}
```

References within the destroy provisioner will be limited in scope just as if it were written within the original `resource` block, meaning that only `count.index`, `each.key`, and `self` will be valid identifiers. Terraform will not be able to validate wether `count.index` or `each.key` will be valid beforehand, because the instances being destroyed could technically have either if the configuration had been changed between `count` and `for_each` and failed to delete, so it is up to the user to ensure any references to those values are correct for the instances being destroyed.

If the user specifies `destroy = false` in the `removed` `lifecycle`, then the provisioner will not be be executed, as there is no `destroy` step during which to execute it. 

Closes #34711
Closes #13549

