### PR TITLE
deferred actions: remove resource graph

### DIFF
--- a/internal/plans/deferring/deferred_test.go
+++ b/internal/plans/deferring/deferred_test.go
@@ -14,11 +14,7 @@ import (
 )
 
 func TestDeferred_externalDependency(t *testing.T) {
-	// The resource graph is irrelevant for this case, because we're going to
-	// defer any resource instance changes regardless. Therefore an empty
-	// graph is just fine.
-	resourceGraph := addrs.NewDirectedGraph[addrs.ConfigResource]()
-	deferred := NewDeferred(resourceGraph, true)
+	deferred := NewDeferred(true)
 
 	// This reports that something outside of the modules runtime knows that
 	// everything in this configuration depends on some elsewhere-action
@@ -37,7 +33,7 @@ func TestDeferred_externalDependency(t *testing.T) {
 				Name: "really-anything",
 			},
 		},
-	})
+	}, nil)
 	if !got {
 		t.Errorf("did not report that the instance should have its changes deferred; should have")
 	}
@@ -75,16 +71,19 @@ func TestDeferred_absResourceInstanceDeferred(t *testing.T) {
 		},
 	}
 
-	resourceGraph := addrs.NewDirectedGraph[addrs.ConfigResource]()
-	resourceGraph.AddDependency(instCAddr.ConfigResource(), instBAddr.ConfigResource())
-	resourceGraph.AddDependency(instCAddr.ConfigResource(), instAAddr.ConfigResource())
-	deferred := NewDeferred(resourceGraph, true)
+	dependencies := addrs.MakeMap[addrs.ConfigResource, []addrs.ConfigResource](
+		addrs.MapElem[addrs.ConfigResource, []addrs.ConfigResource]{
+			Key:   instCAddr.ConfigResource(),
+			Value: []addrs.ConfigResource{instBAddr.ConfigResource(), instAAddr.ConfigResource()},
+		})
+
+	deferred := NewDeferred(true)
 
 	// Before we report anything, all three addresses should indicate that
 	// they don't need to have their actions deferred.
 	t.Run("without any deferrals yet", func(t *testing.T) {
 		for _, instAddr := range []addrs.AbsResourceInstance{instAAddr, instBAddr, instCAddr} {
-			if deferred.ShouldDeferResourceInstanceChanges(instAddr) {
+			if deferred.ShouldDeferResourceInstanceChanges(instAddr, dependencies.Get(instAddr.ConfigResource())) {
 				t.Errorf("%s reported as needing deferred; should not be, yet", instAddr)
 			}
 		}
@@ -100,10 +99,10 @@ func TestDeferred_absResourceInstanceDeferred(t *testing.T) {
 	})
 
 	t.Run("with one resource instance deferred", func(t *testing.T) {
-		if !deferred.ShouldDeferResourceInstanceChanges(instCAddr) {
+		if !deferred.ShouldDeferResourceInstanceChanges(instCAddr, dependencies.Get(instCAddr.ConfigResource())) {
 			t.Errorf("%s was not reported as needing deferred; should be deferred", instCAddr)
 		}
-		if deferred.ShouldDeferResourceInstanceChanges(instBAddr) {
+		if deferred.ShouldDeferResourceInstanceChanges(instBAddr, dependencies.Get(instBAddr.ConfigResource())) {
 			t.Errorf("%s reported as needing deferred; should not be", instCAddr)
 		}
 	})
@@ -141,16 +140,18 @@ func TestDeferred_absDataSourceInstanceDeferred(t *testing.T) {
 		},
 	}
 
-	resourceGraph := addrs.NewDirectedGraph[addrs.ConfigResource]()
-	resourceGraph.AddDependency(instCAddr.ConfigResource(), instBAddr.ConfigResource())
-	resourceGraph.AddDependency(instCAddr.ConfigResource(), instAAddr.ConfigResource())
-	deferred := NewDeferred(resourceGraph, true)
+	dependencies := addrs.MakeMap[addrs.ConfigResource, []addrs.ConfigResource](
+		addrs.MapElem[addrs.ConfigResource, []addrs.ConfigResource]{
+			Key:   instCAddr.ConfigResource(),
+			Value: []addrs.ConfigResource{instBAddr.ConfigResource(), instAAddr.ConfigResource()},
+		})
+	deferred := NewDeferred(true)
 
 	// Before we report anything, all three addresses should indicate that
 	// they don't need to have their actions deferred.
 	t.Run("without any deferrals yet", func(t *testing.T) {
 		for _, instAddr := range []addrs.AbsResourceInstance{instAAddr, instBAddr, instCAddr} {
-			if deferred.ShouldDeferResourceInstanceChanges(instAddr) {
+			if deferred.ShouldDeferResourceInstanceChanges(instAddr, dependencies.Get(instAddr.ConfigResource())) {
 				t.Errorf("%s reported as needing deferred; should not be, yet", instAddr)
 			}
 		}
@@ -160,10 +161,10 @@ func TestDeferred_absDataSourceInstanceDeferred(t *testing.T) {
 	deferred.ReportDataSourceInstanceDeferred(instAAddr)
 
 	t.Run("with one resource instance deferred", func(t *testing.T) {
-		if !deferred.ShouldDeferResourceInstanceChanges(instCAddr) {
+		if !deferred.ShouldDeferResourceInstanceChanges(instCAddr, dependencies.Get(instCAddr.ConfigResource())) {
 			t.Errorf("%s was not reported as needing deferred; should be deferred", instCAddr)
 		}
-		if deferred.ShouldDeferResourceInstanceChanges(instBAddr) {
+		if deferred.ShouldDeferResourceInstanceChanges(instBAddr, dependencies.Get(instBAddr.ConfigResource())) {
 			t.Errorf("%s reported as needing deferred; should not be", instCAddr)
 		}
 	})
@@ -204,16 +205,18 @@ func TestDeferred_partialExpandedDatasource(t *testing.T) {
 		UnexpandedChild(addrs.ModuleCall{Name: "foo"}).
 		Resource(instAAddr.Resource.Resource)
 
-	resourceGraph := addrs.NewDirectedGraph[addrs.ConfigResource]()
-	resourceGraph.AddDependency(instCAddr.ConfigResource(), instBAddr.ConfigResource())
-	resourceGraph.AddDependency(instCAddr.ConfigResource(), instAAddr.ConfigResource())
-	deferred := NewDeferred(resourceGraph, true)
+	dependencies := addrs.MakeMap[addrs.ConfigResource, []addrs.ConfigResource](
+		addrs.MapElem[addrs.ConfigResource, []addrs.ConfigResource]{
+			Key:   instCAddr.ConfigResource(),
+			Value: []addrs.ConfigResource{instBAddr.ConfigResource(), instAAddr.ConfigResource()},
+		})
+	deferred := NewDeferred(true)
 
 	// Before we report anything, all three addresses should indicate that
 	// they don't need to have their actions deferred.
 	t.Run("without any deferrals yet", func(t *testing.T) {
 		for _, instAddr := range []addrs.AbsResourceInstance{instAAddr, instBAddr, instCAddr} {
-			if deferred.ShouldDeferResourceInstanceChanges(instAddr) {
+			if deferred.ShouldDeferResourceInstanceChanges(instAddr, dependencies.Get(instAddr.ConfigResource())) {
 				t.Errorf("%s reported as needing deferred; should not be, yet", instAddr)
 			}
 		}
@@ -223,10 +226,10 @@ func TestDeferred_partialExpandedDatasource(t *testing.T) {
 	deferred.ReportDataSourceExpansionDeferred(instAPartial)
 
 	t.Run("with one resource instance deferred", func(t *testing.T) {
-		if !deferred.ShouldDeferResourceInstanceChanges(instCAddr) {
+		if !deferred.ShouldDeferResourceInstanceChanges(instCAddr, dependencies.Get(instCAddr.ConfigResource())) {
 			t.Errorf("%s was not reported as needing deferred; should be deferred", instCAddr)
 		}
-		if deferred.ShouldDeferResourceInstanceChanges(instBAddr) {
+		if deferred.ShouldDeferResourceInstanceChanges(instBAddr, dependencies.Get(instBAddr.ConfigResource())) {
 			t.Errorf("%s reported as needing deferred; should not be", instCAddr)
 		}
 	})
@@ -268,16 +271,18 @@ func TestDeferred_partialExpandedResource(t *testing.T) {
 		UnexpandedChild(addrs.ModuleCall{Name: "foo"}).
 		Resource(instAAddr.Resource.Resource)
 
-	resourceGraph := addrs.NewDirectedGraph[addrs.ConfigResource]()
-	resourceGraph.AddDependency(instCAddr.ConfigResource(), instBAddr.ConfigResource())
-	resourceGraph.AddDependency(instCAddr.ConfigResource(), instAAddr.ConfigResource())
-	deferred := NewDeferred(resourceGraph, true)
+	dependencies := addrs.MakeMap[addrs.ConfigResource, []addrs.ConfigResource](
+		addrs.MapElem[addrs.ConfigResource, []addrs.ConfigResource]{
+			Key:   instCAddr.ConfigResource(),
+			Value: []addrs.ConfigResource{instBAddr.ConfigResource(), instAAddr.ConfigResource()},
+		})
+	deferred := NewDeferred(true)
 
 	// Before we report anything, all three addresses should indicate that
 	// they don't need to have their actions deferred.
 	t.Run("without any deferrals yet", func(t *testing.T) {
 		for _, instAddr := range []addrs.AbsResourceInstance{instAAddr, instBAddr, instCAddr} {
-			if deferred.ShouldDeferResourceInstanceChanges(instAddr) {
+			if deferred.ShouldDeferResourceInstanceChanges(instAddr, dependencies.Get(instAddr.ConfigResource())) {
 				t.Errorf("%s reported as needing deferred; should not be, yet", instAddr)
 			}
 		}
@@ -293,10 +298,10 @@ func TestDeferred_partialExpandedResource(t *testing.T) {
 	})
 
 	t.Run("with one resource instance deferred", func(t *testing.T) {
-		if !deferred.ShouldDeferResourceInstanceChanges(instCAddr) {
+		if !deferred.ShouldDeferResourceInstanceChanges(instCAddr, dependencies.Get(instCAddr.ConfigResource())) {
 			t.Errorf("%s was not reported as needing deferred; should be deferred", instCAddr)
 		}
-		if deferred.ShouldDeferResourceInstanceChanges(instBAddr) {
+		if deferred.ShouldDeferResourceInstanceChanges(instBAddr, dependencies.Get(instBAddr.ConfigResource())) {
 			t.Errorf("%s reported as needing deferred; should not be", instCAddr)
 		}
 	})

--- a/internal/terraform/context_walk.go
+++ b/internal/terraform/context_walk.go
@@ -168,17 +168,7 @@ func (c *Context) graphWalker(graph *Graph, operation walkOperation, opts *graph
 		}
 	}
 
-	var resourceGraph addrs.DirectedGraph[addrs.ConfigResource]
-	if opts.DeferralAllowed && (operation == walkPlan || operation == walkPlanDestroy) {
-		// We'll produce a derived graph that only includes the static resource
-		// blocks, since we need that for deferral tracking.
-		resourceGraph = graph.ResourceGraph()
-	} else {
-		// Temporary (hopefully) optimization: skip building the expensive resource graph.
-		resourceGraph = addrs.NewDirectedGraph[addrs.ConfigResource]()
-	}
-
-	deferred := deferring.NewDeferred(resourceGraph, opts.DeferralAllowed)
+	deferred := deferring.NewDeferred(opts.DeferralAllowed)
 	if opts.ExternalDependencyDeferred {
 		deferred.SetExternalDependencyDeferred()
 	}

--- a/internal/terraform/node_resource_abstract_instance_test.go
+++ b/internal/terraform/node_resource_abstract_instance_test.go
@@ -7,13 +7,14 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/zclconf/go-cty/cty"
+
 	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/configs"
 	"github.com/hashicorp/terraform/internal/configs/configschema"
 	"github.com/hashicorp/terraform/internal/plans/deferring"
 	"github.com/hashicorp/terraform/internal/providers"
 	"github.com/hashicorp/terraform/internal/states"
-	"github.com/zclconf/go-cty/cty"
 )
 
 func TestNodeAbstractResourceInstanceProvider(t *testing.T) {
@@ -229,8 +230,7 @@ func TestNodeAbstractResourceInstance_refresh_with_deferred_read(t *testing.T) {
 	}
 	evalCtx.ProviderProvider = mockProvider
 	evalCtx.ProviderSchemaSchema = mockProvider.GetProviderSchema()
-	resourceGraph := addrs.NewDirectedGraph[addrs.ConfigResource]()
-	evalCtx.DeferralsState = deferring.NewDeferred(resourceGraph, true)
+	evalCtx.DeferralsState = deferring.NewDeferred(true)
 
 	rio, deferred, diags := node.refresh(evalCtx, states.NotDeposed, obj, true)
 	if diags.HasErrors() {

--- a/internal/terraform/node_resource_plan_instance.go
+++ b/internal/terraform/node_resource_plan_instance.go
@@ -311,7 +311,7 @@ func (n *NodePlannableResourceInstance) managedResourceExecute(ctx EvalContext) 
 			// refresh or planning stage. We'll report the deferral and
 			// store what we could produce in the deferral tracker.
 			deferrals.ReportResourceInstanceDeferred(addr, deferred.Reason, change)
-		} else if !deferrals.ShouldDeferResourceInstanceChanges(n.Addr) {
+		} else if !deferrals.ShouldDeferResourceInstanceChanges(n.Addr, n.Dependencies) {
 			// We intentionally write the change before the subsequent checks, because
 			// all of the checks below this point are for problems caused by the
 			// context surrounding the change, rather than the change itself, and


### PR DESCRIPTION
Currently, the deferred actions data structure maintains an internal `ResourceGraph` that it uses to track dependencies of resources. It uses this to work out if a resource should be deferred because it depends on a resource that has been deferred. This led to significant performance degradation within Terraform as we are now creating, holding, and searching two (potentially) large graphs within Terraform.

This PR deletes the internal resource graph from the deferred actions data structure. Instead, we now expect the callers to pass in addresses to their dependencies to be looked at directly instead of relying on the deferred actions data structure to handle this look up internally.

Terraform already computes the dependencies and provides them to where we need them in the `AttachDependenciesTransformer`, so with this approach there is no extra work in computing the dependencies. There is a small performance cost in checking the deferrals as previously we'd only look at direct dependencies while now we are looking at all dependencies. However this is definitely better than building and maintaining the second graph.