### PR TITLE
stacks: convert sourcebundle source into directory for config SourceDir field

### DIFF
--- a/internal/configs/source_bundle_parser.go
+++ b/internal/configs/source_bundle_parser.go
@@ -58,7 +58,16 @@ func (p *SourceBundleParser) LoadConfigDir(source sourceaddrs.FinalSource) (*Mod
 	mod, modDiags := NewModule(primary, override)
 	diags = append(diags, modDiags...)
 
-	mod.SourceDir = source.String()
+	sourceDir, err := p.sources.LocalPathForSource(source)
+	if err != nil {
+		diags = diags.Append(&hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  "Cannot find configuration source code",
+			Detail:   fmt.Sprintf("Failed to load %s from the pre-installed source packages: %s. This is a bug in Terraform - please report it.", source, err),
+		})
+		return nil, diags
+	}
+	mod.SourceDir = sourceDir
 
 	return mod, diags
 }

--- a/internal/stacks/stackruntime/internal/stackeval/component_instance.go
+++ b/internal/stacks/stackruntime/internal/stackeval/component_instance.go
@@ -995,6 +995,12 @@ func (c *ComponentInstance) ResultValue(ctx context.Context, phase EvalPhase) ct
 		if plan.UIMode != plans.DestroyMode {
 			outputChanges := plan.Changes.Outputs
 			for _, changeSrc := range outputChanges {
+				if len(changeSrc.Addr.Module) > 0 {
+					// Only include output values of the root module as part
+					// of the component.
+					continue
+				}
+
 				name := changeSrc.Addr.OutputValue.Name
 				change, err := changeSrc.Decode()
 				if err != nil {

--- a/internal/stacks/stackruntime/internal/stackeval/testdata/sourcebundle/planning/path_values/module/child/main.tf
+++ b/internal/stacks/stackruntime/internal/stackeval/testdata/sourcebundle/planning/path_values/module/child/main.tf
@@ -1,0 +1,12 @@
+
+output "cwd" {
+  value = path.cwd
+}
+
+output "root" {
+  value = path.root
+}
+
+output "module" {
+  value = path.module
+}

--- a/internal/stacks/stackruntime/internal/stackeval/testdata/sourcebundle/planning/path_values/module/main.tf
+++ b/internal/stacks/stackruntime/internal/stackeval/testdata/sourcebundle/planning/path_values/module/main.tf
@@ -1,0 +1,25 @@
+
+
+module "child" {
+  source = "./child"
+}
+
+output "child_module" {
+  value = module.child.module
+}
+
+output "child_root" {
+  value = module.child.root
+}
+
+output "module" {
+    value = path.module
+}
+
+output "root" {
+    value = path.root
+}
+
+output "cwd" {
+    value = path.cwd
+}

--- a/internal/stacks/stackruntime/internal/stackeval/testdata/sourcebundle/planning/path_values/path_values.tfstack.hcl
+++ b/internal/stacks/stackruntime/internal/stackeval/testdata/sourcebundle/planning/path_values/path_values.tfstack.hcl
@@ -1,0 +1,4 @@
+
+component "path_values" {
+  source = "./module"
+}


### PR DESCRIPTION
This PR updates the stacks `source_bundle_parser` so the `SourceDir` field of the configuration is still set to a local path instead of the source bundle path. AFAICT the `SourceDir` field is only used to compute the `path.root` and `path.module` variables, so this PR should restore the functionality of those attributes within stacks.

With this PR `path.root` resolves to the directory of the root Terraform module of the current component, and `path.module` resolves to the directory of the current module. `path.cwd` is behaving normally.

I wondered if this is the right behaviour for `path.root` in stacks. Possibly it should resolve to the current component directory instead of the root module of that component? Maybe we need to look into how this is being used more before making that decision. This PR at least restores some explainable functionality so I think is a good place to start.

There's a small modification to component_instance that fixes another bug exposed by my added test case. If a root and non-root output share the same name then stacks would pick either one of them to populate the final output value exposed in the stack plan. This PR makes stacks ignore non-root outputs when computing result values for components.