### PR TITLE
Prototype: Take arbitrary actions in response to events

### DIFF
--- a/internal/builtin/providers/terraform/provider.go
+++ b/internal/builtin/providers/terraform/provider.go
@@ -191,6 +191,16 @@ func (p *Provider) ValidateResourceConfig(req providers.ValidateResourceConfigRe
 	return validateDataStoreResourceConfig(req)
 }
 
+func (p *Provider) PlanAction(req providers.PlanActionRequest) providers.PlanActionResponse {
+	// This provider doesn't declare any actions, so we should not get here.
+	panic("unimplemented - terraform provider has no actions")
+}
+
+func (p *Provider) ApplyAction(req providers.ApplyActionRequest) providers.ApplyActionResponse {
+	// This provider doesn't declare any actions, so we should not get here.
+	panic("unimplemented - terraform provider has no actions")
+}
+
 // CallFunction would call a function contributed by this provider, but this
 // provider has no functions and so this function just panics.
 func (p *Provider) CallFunction(req providers.CallFunctionRequest) providers.CallFunctionResponse {

--- a/internal/plugin/grpc_provider.go
+++ b/internal/plugin/grpc_provider.go
@@ -75,6 +75,8 @@ type GRPCProvider struct {
 	schema providers.GetProviderSchemaResponse
 }
 
+var _ providers.Interface = (*GRPCProvider)(nil)
+
 func (p *GRPCProvider) GetProviderSchema() providers.GetProviderSchemaResponse {
 	logger.Trace("GRPCProvider: GetProviderSchema")
 	p.mu.Lock()
@@ -764,6 +766,20 @@ func (p *GRPCProvider) ReadDataSource(r providers.ReadDataSourceRequest) (resp p
 	resp.State = state
 	resp.Deferred = convert.ProtoToDeferred(protoResp.Deferred)
 
+	return resp
+}
+
+func (p *GRPCProvider) PlanAction(providers.PlanActionRequest) providers.PlanActionResponse {
+	// TODO: Implement this
+	var resp providers.PlanActionResponse
+	resp.Diagnostics = resp.Diagnostics.Append(fmt.Errorf("actions are not yet supported for plugin-based providers"))
+	return resp
+}
+
+func (p *GRPCProvider) ApplyAction(providers.ApplyActionRequest) providers.ApplyActionResponse {
+	// TODO: Implement this
+	var resp providers.ApplyActionResponse
+	resp.Diagnostics = resp.Diagnostics.Append(fmt.Errorf("actions are not yet supported for plugin-based providers"))
 	return resp
 }
 

--- a/internal/plugin6/grpc_provider.go
+++ b/internal/plugin6/grpc_provider.go
@@ -75,6 +75,8 @@ type GRPCProvider struct {
 	schema providers.GetProviderSchemaResponse
 }
 
+var _ providers.Interface = (*GRPCProvider)(nil)
+
 func (p *GRPCProvider) GetProviderSchema() providers.GetProviderSchemaResponse {
 	p.mu.Lock()
 	defer p.mu.Unlock()
@@ -753,6 +755,20 @@ func (p *GRPCProvider) ReadDataSource(r providers.ReadDataSourceRequest) (resp p
 	resp.State = state
 	resp.Deferred = convert.ProtoToDeferred(protoResp.Deferred)
 
+	return resp
+}
+
+func (p *GRPCProvider) PlanAction(providers.PlanActionRequest) providers.PlanActionResponse {
+	// TODO: Implement this
+	var resp providers.PlanActionResponse
+	resp.Diagnostics = resp.Diagnostics.Append(fmt.Errorf("actions are not yet supported for plugin-based providers"))
+	return resp
+}
+
+func (p *GRPCProvider) ApplyAction(providers.ApplyActionRequest) providers.ApplyActionResponse {
+	// TODO: Implement this
+	var resp providers.ApplyActionResponse
+	resp.Diagnostics = resp.Diagnostics.Append(fmt.Errorf("actions are not yet supported for plugin-based providers"))
 	return resp
 }
 

--- a/internal/provider-simple-v6/provider.go
+++ b/internal/provider-simple-v6/provider.go
@@ -47,6 +47,26 @@ func Provider() providers.Interface {
 			DataSources: map[string]providers.Schema{
 				"simple_resource": simpleResource,
 			},
+			ActionTypes: map[string]providers.RequestResponseSchema{
+				"simple_action": {
+					RequestBlock: &configschema.Block{
+						Attributes: map[string]*configschema.Attribute{
+							"value": {
+								Optional: true,
+								Type:     cty.String,
+							},
+						},
+					},
+					ResponseBlock: &configschema.Block{
+						Attributes: map[string]*configschema.Attribute{
+							"value": {
+								Computed: true,
+								Type:     cty.String,
+							},
+						},
+					},
+				},
+			},
 			ServerCapabilities: providers.ServerCapabilities{
 				PlanDestroy:               true,
 				GetProviderSchemaOptional: true,
@@ -168,6 +188,22 @@ func (s simple) ReadDataSource(req providers.ReadDataSourceRequest) (resp provid
 	m := req.Config.AsValueMap()
 	m["id"] = cty.StringVal("static_id")
 	resp.State = cty.ObjectVal(m)
+	return resp
+}
+
+func (s simple) PlanAction(req providers.PlanActionRequest) (resp providers.PlanActionResponse) {
+	// The simple action type has an identical schema for request and response,
+	// so it's valid to assign like this even though that wouldn't be true for
+	// a realistic action type.
+	resp.PlannedResult = req.Arguments
+	return resp
+}
+
+func (s simple) ApplyAction(req providers.ApplyActionRequest) (resp providers.ApplyActionResponse) {
+	// The simple action type has an identical schema for request and response,
+	// so it's valid to assign like this even though that wouldn't be true for
+	// a realistic action type.
+	resp.Result = req.Arguments
 	return resp
 }
 

--- a/internal/provider-simple/provider.go
+++ b/internal/provider-simple/provider.go
@@ -46,6 +46,26 @@ func Provider() providers.Interface {
 			DataSources: map[string]providers.Schema{
 				"simple_resource": simpleResource,
 			},
+			ActionTypes: map[string]providers.RequestResponseSchema{
+				"simple_action": {
+					RequestBlock: &configschema.Block{
+						Attributes: map[string]*configschema.Attribute{
+							"value": {
+								Optional: true,
+								Type:     cty.String,
+							},
+						},
+					},
+					ResponseBlock: &configschema.Block{
+						Attributes: map[string]*configschema.Attribute{
+							"value": {
+								Computed: true,
+								Type:     cty.String,
+							},
+						},
+					},
+				},
+			},
 			ServerCapabilities: providers.ServerCapabilities{
 				PlanDestroy: true,
 			},
@@ -141,6 +161,22 @@ func (s simple) ReadDataSource(req providers.ReadDataSourceRequest) (resp provid
 	m := req.Config.AsValueMap()
 	m["id"] = cty.StringVal("static_id")
 	resp.State = cty.ObjectVal(m)
+	return resp
+}
+
+func (s simple) PlanAction(req providers.PlanActionRequest) (resp providers.PlanActionResponse) {
+	// The simple action type has an identical schema for request and response,
+	// so it's valid to assign like this even though that wouldn't be true for
+	// a realistic action type.
+	resp.PlannedResult = req.Arguments
+	return resp
+}
+
+func (s simple) ApplyAction(req providers.ApplyActionRequest) (resp providers.ApplyActionResponse) {
+	// The simple action type has an identical schema for request and response,
+	// so it's valid to assign like this even though that wouldn't be true for
+	// a realistic action type.
+	resp.Result = req.Arguments
 	return resp
 }
 

--- a/internal/providers/mock.go
+++ b/internal/providers/mock.go
@@ -289,6 +289,20 @@ func (m *Mock) ReadDataSource(request ReadDataSourceRequest) ReadDataSourceRespo
 	return response
 }
 
+func (m *Mock) PlanAction(request PlanActionRequest) PlanActionResponse {
+	// TODO: Implement this
+	var response PlanActionResponse
+	response.Diagnostics = response.Diagnostics.Append(fmt.Errorf("mock providers don't support actions yet"))
+	return response
+}
+
+func (m *Mock) ApplyAction(request ApplyActionRequest) ApplyActionResponse {
+	// TODO: Implement this
+	var response ApplyActionResponse
+	response.Diagnostics = response.Diagnostics.Append(fmt.Errorf("mock providers don't support actions yet"))
+	return response
+}
+
 func (m *Mock) CallFunction(request CallFunctionRequest) CallFunctionResponse {
 	return m.Provider.CallFunction(request)
 }

--- a/internal/refactoring/mock_provider.go
+++ b/internal/refactoring/mock_provider.go
@@ -85,6 +85,14 @@ func (provider *mockProvider) ReadDataSource(providers.ReadDataSourceRequest) pr
 	panic("not implemented in mock")
 }
 
+func (provider *mockProvider) ApplyAction(providers.ApplyActionRequest) providers.ApplyActionResponse {
+	panic("not implemented in mock")
+}
+
+func (provider *mockProvider) PlanAction(providers.PlanActionRequest) providers.PlanActionResponse {
+	panic("not implemented in mock")
+}
+
 func (provider *mockProvider) CallFunction(providers.CallFunctionRequest) providers.CallFunctionResponse {
 	panic("not implemented in mock")
 }

--- a/internal/stacks/stackruntime/internal/stackeval/provider_instance.go
+++ b/internal/stacks/stackruntime/internal/stackeval/provider_instance.go
@@ -486,6 +486,40 @@ func (stubConfiguredProvider) ReadResource(req providers.ReadResourceRequest) pr
 	}
 }
 
+// PlanAction implements providers.Interface.
+func (p stubConfiguredProvider) PlanAction(providers.PlanActionRequest) providers.PlanActionResponse {
+	if p.unknown {
+		return providers.PlanActionResponse{
+			PlannedResult: cty.DynamicVal,
+		}
+	}
+	var diags tfdiags.Diagnostics
+	diags = diags.Append(tfdiags.AttributeValue(
+		tfdiags.Error,
+		"Provider configuration is invalid",
+		"Cannot plan this action because its associated provider configuration is invalid.",
+		nil, // nil attribute path means the overall configuration block
+	))
+	return providers.PlanActionResponse{
+		Diagnostics: diags,
+	}
+}
+
+// ApplyAction implements providers.Interface.
+func (p stubConfiguredProvider) ApplyAction(providers.ApplyActionRequest) providers.ApplyActionResponse {
+	var diags tfdiags.Diagnostics
+	diags = diags.Append(tfdiags.AttributeValue(
+		tfdiags.Error,
+		"Provider configuration is invalid",
+		"Cannot execute this action because its associated provider configuration is invalid.",
+		nil, // nil attribute path means the overall configuration block
+	))
+	return providers.ApplyActionResponse{
+		Diagnostics: diags,
+	}
+
+}
+
 // Stop implements providers.Interface.
 func (stubConfiguredProvider) Stop() error {
 	// This stub provider never actually does any real work, so there's nothing


### PR DESCRIPTION
This is a prototype of a fresh take on my earlier proposal https://github.com/hashicorp/terraform/issues/6810 which proposed one way to fill a current gap in Terraform's model in representing arbitrary non-CRUD actions that might appear in a remote API. For example:

- Invalidating a cache.
- Restarting a service in-place as an attempt to clear a fault.
- Sending a notification somewhere.
- CRUD-like operations that aren't a good fit for Terraform's managed resource model, like creating a backup.

The general goal is to model anything that doesn't really make sense to treat as declarative, and then to allow both triggering those actions directly and also describing situations where Terraform should take those actions automatically in reaction to other changes made declaratively.

The following describes the initial ideas I'm trying for here. I'm writing this before I've done much prototyping, so the details are likely to change as I learn from the prototyping exercise.

# Actions

An "action" is an imperative action that can be exposed either directly by a provider or indirectly through a module. 

Terraform already uses the word "action" to refer to the built-in actions "create", "update", "delete", etc, so another way to think about it is that these are _additional_ actions that can extend the built-in behaviors of Terraform to deal with situations Terraform's default model cannot represent.

Actions _when used alone_ are something you can trigger manually when creating a plan, in which case Terraform would perform the custom actions at the end of the apply phase after all of the normally-planned actions have completed.

However, the more interesting way to use actions is to associate them with _events_ so that Terraform can trigger them automatically based on other changes.

An action declared in a module wraps a sequence of actions defined either in providers or in child modules, allowing module authors to expose higher-level actions as part of their abstraction. For example, a provider-level action for "invalidate a CloudFront distribution's caches" would require specifying which CloudFront distribution to use, while a module that encapsulates a CloudFront distribution could expose an action for invalidating the caches for _that specific CloudFront distribution_, avoiding the need for the operator to look up the id manually.

# Events

The idea of "events" helps Terraform model the side-effects from applying a plan in a way that allows automatically triggering actions.

Since Terraform is active only during plan/apply steps, "events" are not realtime notifications but are instead recognized during the plan phase, potentially causing additional actions to be added to the plan in response to those events. The idea is that during planning the provider _predicts_ the events that would occur during the apply phase, which then allows Terraform Core to plan any additional actions those events will cause, and then those additional actions are included when applying the overall plan.

As with the previous form of this proposal, I imagine Terraform providing its own event types that correspond to the side-effects being performed by Terraform itself: objects being created, destroyed, updated, or just generally "changed" (all of the previous actions together).

This proposal also includes the possibility of providers to define their own resource-type-specific event types for modelling more specific events that Terraform Core cannot recognize alone. For example, the `consul_key_prefix` resource type in the `hashicorp/consul` provider might choose to announce a separate event for each individual key that is being changed so that actions can be triggered for only a subset of them.

For provider-specific event types, the `PlanResourceChange` provider API function would grow to allow the provider to return in its response zero or more events that the action implies, and then Terraform would use that information to decide which actions to plan using the automation rules as described in the next section.

# Automation Rules

An automation rule represents glue between events and actions. I expect to follow the typical "if this, then that" model commonly used for high-level automations, where "this" are events with optional custom filter expressions and "that" are sequences of actions.

An example automation rule might be "if any instance of `aws_s3_object.website` is changed, trigger the `hashicorp/aws` provider's CloudFormation cache invalidate action".

In the case of that rule, Terraform would check during the plan phase whether there's any change action associated with `aws_s3_object.website`. If so, Terraform would then ask the provider to plan the "cache invalidate" action with the module author's configured arguments. The result of planning the action is a planned result, similar to the "planned new state" for a managed resource instance change, but since actions are non-declarative the results would be marked as [ephemeral values](https://github.com/hashicorp/terraform/pull/35078).

In the result of planning the action the provider might announce _even more_ events that the action implies, which could then cause even more actions to be planned. That could potentially continue infinitely, so we'll need some way to curtail infinite or excessive recursive triggering. Perhaps that would be an application of the "deferred actions" ideas, generalized to arbitrary actions triggered by the provider.


