### PR TITLE
stacks: return dynamic types when referencing partial components

### DIFF
--- a/internal/stacks/stackruntime/internal/stackeval/component.go
+++ b/internal/stacks/stackruntime/internal/stackeval/component.go
@@ -205,7 +205,7 @@ func (c *Component) ResultValue(ctx context.Context, phase EvalPhase) cty.Value 
 		// exact type constraints for its output values and so each instance of
 		// a component can potentially produce a different object type.
 
-		if insts == nil {
+		if _, exists := insts[addrs.WildcardKey]; exists || insts == nil {
 			// If we don't even know what instances we have then we can't
 			// predict anything about our result.
 			return cty.DynamicVal
@@ -220,6 +220,9 @@ func (c *Component) ResultValue(ctx context.Context, phase EvalPhase) cty.Value 
 				panic(fmt.Sprintf("stack call with for_each has invalid instance key of type %T", instKey))
 			}
 			elems[string(k)] = inst.ResultValue(ctx, phase)
+		}
+		if len(elems) == 0 {
+			return cty.EmptyObjectVal
 		}
 		return cty.ObjectVal(elems)
 

--- a/internal/stacks/stackruntime/internal/stackeval/component_test.go
+++ b/internal/stacks/stackruntime/internal/stackeval/component_test.go
@@ -10,12 +10,13 @@ import (
 
 	"github.com/davecgh/go-spew/spew"
 	"github.com/google/go-cmp/cmp"
+	"github.com/zclconf/go-cty-debug/ctydebug"
+	"github.com/zclconf/go-cty/cty"
+
 	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/instances"
 	"github.com/hashicorp/terraform/internal/stacks/stackaddrs"
 	"github.com/hashicorp/terraform/internal/tfdiags"
-	"github.com/zclconf/go-cty-debug/ctydebug"
-	"github.com/zclconf/go-cty/cty"
 )
 
 // TestComponentInstances is a test of the [Component.CheckInstances] function.
@@ -393,10 +394,8 @@ func TestComponentResultValue(t *testing.T) {
 			component := getComponent(ctx, t, main)
 			got := component.ResultValue(ctx, InspectPhase)
 			// When the for_each expression is unknown, the result value
-			// is an instance map with the wildcard key and an empty object
-			want := cty.ObjectVal(map[string]cty.Value{
-				"*": cty.EmptyObjectVal,
-			})
+			// is aa dynamic instance.
+			want := cty.DynamicVal
 
 			if diff := cmp.Diff(want, got, ctydebug.CmpOptions); diff != "" {
 				t.Fatalf("wrong result\n%s", diff)

--- a/internal/stacks/stackruntime/testdata/mainbundle/test/with-single-input-and-output/deferred-component-for-each/deferred-component-for-each.tfstack.hcl
+++ b/internal/stacks/stackruntime/testdata/mainbundle/test/with-single-input-and-output/deferred-component-for-each/deferred-component-for-each.tfstack.hcl
@@ -1,0 +1,48 @@
+required_providers {
+  testing = {
+    source  = "hashicorp/testing"
+    version = "0.1.0"
+  }
+}
+
+variable "components" {
+  type = set(string)
+}
+
+provider "testing" "default" {}
+
+component "self" {
+  // This component validates the behaviour of an unknown for_each value.
+
+  source = "../"
+
+  providers = {
+    testing = provider.testing.default
+  }
+
+  inputs = {
+    input = each.value
+  }
+
+  for_each = var.components
+}
+
+component "child" {
+  // This component validates the behaviour of referencing a partial component
+  // with a known key. Since we don't know the available keys of the component
+  // yet, this should use the outputs of the partial instance.
+
+  source = "../"
+
+  providers = {
+    testing = provider.testing.default
+  }
+
+  inputs = {
+    // It's really unlikely that `const` is actually going to exist once
+    // component.self has known keys, but for now we don't know it doesn't
+    // exist so we should defer this component and make a reasonable attempt
+    // at planning something.
+    input = component.self["const"].id
+  }
+}

--- a/internal/stacks/stackruntime/testdata/mainbundle/test/with-single-input-and-output/deferred-component-references/deferred-component-references.tfstack.hcl
+++ b/internal/stacks/stackruntime/testdata/mainbundle/test/with-single-input-and-output/deferred-component-references/deferred-component-references.tfstack.hcl
@@ -1,0 +1,48 @@
+required_providers {
+  testing = {
+    source  = "hashicorp/testing"
+    version = "0.1.0"
+  }
+}
+
+variable "known_components" {
+  type = set(string)
+}
+
+variable "unknown_components" {
+  type = set(string)
+}
+
+provider "testing" "default" {}
+
+component "self" {
+  source = "../"
+
+  providers = {
+    testing = provider.testing.default
+  }
+
+  inputs = {
+    input = each.value
+  }
+
+  for_each = var.known_components
+}
+
+component "children" {
+  // This component validates the behaviour of referencing a known component
+  // with an unknown key.
+  source = "../"
+
+  providers = {
+    testing = provider.testing.default
+  }
+
+  inputs = {
+    // each.key is unknown, but we should still get a typed reference to an
+    // output here so we can plan using unknown values.
+    input = component.self[each.key].id
+  }
+
+  for_each = var.unknown_components
+}

--- a/internal/stacks/stackruntime/testdata/mainbundle/test/with-single-input-and-output/single-input-and-output.tf
+++ b/internal/stacks/stackruntime/testdata/mainbundle/test/with-single-input-and-output/single-input-and-output.tf
@@ -1,0 +1,27 @@
+terraform {
+  required_providers {
+    testing = {
+      source  = "hashicorp/testing"
+      version = "0.1.0"
+    }
+  }
+}
+
+variable "id" {
+  type     = string
+  default  = null
+  nullable = true # We'll generate an ID if none provided.
+}
+
+variable "input" {
+  type = string
+}
+
+resource "testing_resource" "data" {
+  id    = var.id
+  value = var.input
+}
+
+output "id" {
+  value = testing_resource.data.id
+}


### PR DESCRIPTION
This PR makes the stacks runtime explicitly return unknown values when referencing another component that has an unknown `for_each`.

We mark components with unknown as having the wildcard instance: `component.name[*]`. This introduced the bug that when a known variable attempts to reference the unknown component, we get an "reference doesn't exist" error. This is not the correct behaviour with deferred components, instead we should get an unknown value back.