### PR TITLE
[Docs] Clarify Dependency Management in Style Guide

### DIFF
--- a/website/docs/language/style.mdx
+++ b/website/docs/language/style.mdx
@@ -20,7 +20,7 @@ Writing Terraform code in a consistent style makes it easier to read and maintai
 - Use `#` for single and multi-line comments.
 - Use nouns for resource names and do not include the resource type in the name. 
 - Use underscores to separate multiple words in names. Wrap the resource type and name in double quotes in your resource definition.
-- Let your code build on itself: define dependent resources after the resources that reference them.
+- Let your code build on itself: define dependent resources after the resources they reference.
 - Include a type and description for every variable.
 - Include a description for every output.
 - Avoid overuse of variables and local values.


### PR DESCRIPTION
I was reading through the Terraform docs and got confused by a statement which I believe is unclear or incorrect. This is on the "Style Guide" page under "Code style":

> Let your code build on itself: define dependent resources after the resources that reference them.

The line above states that dependent resources should be defined after the resources that reference them (so other dependent resources that depend on this dependent resource). However, shouldn't resources always be defined before the resources that reference them? That's what I gather from the "Let your code build on itself" principle and examples elsewhere in the docs.

I think the following change would make this clearer and self-explanatory:

> Let your code build on itself: define dependent resources after the resources _they reference_.

This change clarifies that referenced resources should be defined before the resources that depend on them, which isn't what the original text seems to describe.