### PR TITLE
Fix cloud block documentation bug

### DIFF
--- a/website/docs/cli/cloud/settings.mdx
+++ b/website/docs/cli/cloud/settings.mdx
@@ -62,8 +62,8 @@ The `cloud` block supports the following configuration arguments:
   workspace(s) the current configuration should use.
 
 - `workspaces` - (Required) A nested block that specifies which remote HCP Terraform workspaces to
-  use for the current configuration. The `workspaces` block must contain **exactly one** of the
-  following arguments, each denoting a strategy for how workspaces should be mapped:
+  use for the current configuration. The `workspaces` block must contain **exactly one** of either `tags`
+  or `name` argument, each denoting a strategy for how workspaces should be mapped:
 
   - `tags` - (Optional) A set of HCP Terraform workspace tags. You will be able to use
     this working directory with any workspaces that have all of the specified tags,


### PR DESCRIPTION
The docs for HCP Terraform settings suggest that the `project` argument is mutually exclusive with both "tags" and "name" arguments.

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.9.x

## Draft CHANGELOG entry

### BUG FIXES

- Fixed documentation bug that suggested the cloud block `project` argument is mutually exclusive with both "tags" and "name" arguments.