### PR TITLE
stacks: add support for unknown for_each expressions in providers

### DIFF
--- a/internal/stacks/stackruntime/internal/stackeval/stubs/configured.go
+++ b/internal/stacks/stackruntime/internal/stackeval/stubs/configured.go
@@ -1,0 +1,237 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package stubs
+
+import (
+	"github.com/zclconf/go-cty/cty"
+
+	"github.com/hashicorp/terraform/internal/providers"
+	"github.com/hashicorp/terraform/internal/tfdiags"
+)
+
+// ConfiguredProvider is a placeholder provider used when ConfigureProvider
+// on a real provider fails, so that callers can still receieve a usable client
+// that will just produce placeholder values from its operations.
+//
+// This is essentially the cty.DynamicVal equivalent for providers.Interface,
+// allowing us to follow our usual pattern that only one return path carries
+// diagnostics up to the caller and all other codepaths just do their best
+// to unwind with placeholder values. It's intended only for use in situations
+// that would expect an already-configured provider, so it's incorrect to call
+// [ConfigureProvider] on a value of this type.
+//
+// Some methods of this type explicitly return errors saying that the provider
+// configuration was invalid, while others just optimistically do nothing at
+// all. The general rule is that anything that would for a normal provider
+// be expected to perform externally-visible side effects must return an error
+// to be explicit that those side effects did not occur, but we can silently
+// skip anything that is a Terraform-only detail.
+//
+// As usual with provider calls, the returned diagnostics must be annotated
+// using [tfdiags.Diagnostics.InConfigBody] with the relevant configuration body
+// so that they can be attributed to the appropriate configuration element.
+type ConfiguredProvider struct {
+	// If unknown is true then the implementation will assume it's acting
+	// as a placeholder for a provider whose configuration isn't yet
+	// sufficiently known to be properly instantiated, which means that
+	// plan-time operations will return totally-unknown values.
+	// Otherwise any operation that is supposed to perform a side-effect
+	// will fail with an error saying that the provider configuration
+	// is invalid.
+	Unknown bool
+}
+
+var _ providers.Interface = ConfiguredProvider{}
+
+// ApplyResourceChange implements providers.Interface.
+func (ConfiguredProvider) ApplyResourceChange(req providers.ApplyResourceChangeRequest) providers.ApplyResourceChangeResponse {
+	var diags tfdiags.Diagnostics
+	diags = diags.Append(tfdiags.AttributeValue(
+		tfdiags.Error,
+		"Provider configuration is invalid",
+		"Cannot apply changes because this resource's associated provider configuration is invalid.",
+		nil, // nil attribute path means the overall configuration block
+	))
+	return providers.ApplyResourceChangeResponse{
+		Diagnostics: diags,
+	}
+}
+
+func (ConfiguredProvider) CallFunction(providers.CallFunctionRequest) providers.CallFunctionResponse {
+	panic("can't call functions on the stub provider")
+}
+
+// Close implements providers.Interface.
+func (ConfiguredProvider) Close() error {
+	return nil
+}
+
+// ConfigureProvider implements providers.Interface.
+func (ConfiguredProvider) ConfigureProvider(req providers.ConfigureProviderRequest) providers.ConfigureProviderResponse {
+	// This provider is used only in situations where ConfigureProvider on
+	// a real provider fails and the recipient was expecting a configured
+	// provider, so it doesn't make sense to configure it.
+	panic("can't configure the stub provider")
+}
+
+// GetProviderSchema implements providers.Interface.
+func (ConfiguredProvider) GetProviderSchema() providers.GetProviderSchemaResponse {
+	return providers.GetProviderSchemaResponse{}
+}
+
+// ImportResourceState implements providers.Interface.
+func (p ConfiguredProvider) ImportResourceState(req providers.ImportResourceStateRequest) providers.ImportResourceStateResponse {
+	var diags tfdiags.Diagnostics
+	if p.Unknown {
+		diags = diags.Append(tfdiags.AttributeValue(
+			tfdiags.Error,
+			"Provider configuration is deferred",
+			"Cannot import an existing object into this resource because its associated provider configuration is deferred to a later operation due to unknown expansion.",
+			nil, // nil attribute path means the overall configuration block
+		))
+	} else {
+		diags = diags.Append(tfdiags.AttributeValue(
+			tfdiags.Error,
+			"Provider configuration is invalid",
+			"Cannot import an existing object into this resource because its associated provider configuration is invalid.",
+			nil, // nil attribute path means the overall configuration block
+		))
+	}
+	return providers.ImportResourceStateResponse{
+		Diagnostics: diags,
+	}
+}
+
+// MoveResourceState implements providers.Interface.
+func (p ConfiguredProvider) MoveResourceState(req providers.MoveResourceStateRequest) providers.MoveResourceStateResponse {
+	var diags tfdiags.Diagnostics
+	if p.Unknown {
+		diags = diags.Append(tfdiags.AttributeValue(
+			tfdiags.Error,
+			"Provider configuration is deferred",
+			"Cannot move an existing object to this resource because its associated provider configuration is deferred to a later operation due to unknown expansion.",
+			nil, // nil attribute path means the overall configuration block
+		))
+	} else {
+		diags = diags.Append(tfdiags.AttributeValue(
+			tfdiags.Error,
+			"Provider configuration is invalid",
+			"Cannot move an existing object to this resource because its associated provider configuration is invalid.",
+			nil, // nil attribute path means the overall configuration block
+		))
+	}
+	return providers.MoveResourceStateResponse{
+		Diagnostics: diags,
+	}
+}
+
+// PlanResourceChange implements providers.Interface.
+func (p ConfiguredProvider) PlanResourceChange(req providers.PlanResourceChangeRequest) providers.PlanResourceChangeResponse {
+	if p.Unknown {
+		return providers.PlanResourceChangeResponse{
+			PlannedState: cty.DynamicVal,
+		}
+	}
+	var diags tfdiags.Diagnostics
+	diags = diags.Append(tfdiags.AttributeValue(
+		tfdiags.Error,
+		"Provider configuration is invalid",
+		"Cannot plan changes for this resource because its associated provider configuration is invalid.",
+		nil, // nil attribute path means the overall configuration block
+	))
+	return providers.PlanResourceChangeResponse{
+		Diagnostics: diags,
+	}
+}
+
+// ReadDataSource implements providers.Interface.
+func (p ConfiguredProvider) ReadDataSource(req providers.ReadDataSourceRequest) providers.ReadDataSourceResponse {
+	if p.Unknown {
+		return providers.ReadDataSourceResponse{
+			State: cty.DynamicVal,
+		}
+	}
+	var diags tfdiags.Diagnostics
+	diags = diags.Append(tfdiags.AttributeValue(
+		tfdiags.Error,
+		"Provider configuration is invalid",
+		"Cannot read from this data source because its associated provider configuration is invalid.",
+		nil, // nil attribute path means the overall configuration block
+	))
+	return providers.ReadDataSourceResponse{
+		Diagnostics: diags,
+	}
+}
+
+// ReadResource implements providers.Interface.
+func (ConfiguredProvider) ReadResource(req providers.ReadResourceRequest) providers.ReadResourceResponse {
+	// For this one we'll just optimistically assume that the remote object
+	// hasn't changed. In many cases we'll fail calling PlanResourceChange
+	// right afterwards anyway, and even if not we'll get another opportunity
+	// to refresh on a future run once the provider configuration is fixed.
+	return providers.ReadResourceResponse{
+		NewState: req.PriorState,
+		Private:  req.Private,
+	}
+}
+
+// Stop implements providers.Interface.
+func (ConfiguredProvider) Stop() error {
+	// This stub provider never actually does any real work, so there's nothing
+	// for us to stop.
+	return nil
+}
+
+// UpgradeResourceState implements providers.Interface.
+func (p ConfiguredProvider) UpgradeResourceState(req providers.UpgradeResourceStateRequest) providers.UpgradeResourceStateResponse {
+	if p.Unknown {
+		return providers.UpgradeResourceStateResponse{
+			UpgradedState: cty.DynamicVal,
+		}
+	}
+
+	// Ideally we'd just skip this altogether and echo back what the caller
+	// provided, but the request is in a different serialization format than
+	// the response and so only the real provider can deal with this one.
+	var diags tfdiags.Diagnostics
+	diags = diags.Append(tfdiags.AttributeValue(
+		tfdiags.Error,
+		"Provider configuration is invalid",
+		"Cannot decode the prior state for this resource instance because its provider configuration is invalid.",
+		nil, // nil attribute path means the overall configuration block
+	))
+	return providers.UpgradeResourceStateResponse{
+		Diagnostics: diags,
+	}
+}
+
+// ValidateDataResourceConfig implements providers.Interface.
+func (ConfiguredProvider) ValidateDataResourceConfig(req providers.ValidateDataResourceConfigRequest) providers.ValidateDataResourceConfigResponse {
+	// We'll just optimistically assume the configuration is valid, so that
+	// we can progress to planning and return an error there instead.
+	return providers.ValidateDataResourceConfigResponse{
+		Diagnostics: nil,
+	}
+}
+
+// ValidateProviderConfig implements providers.Interface.
+func (ConfiguredProvider) ValidateProviderConfig(req providers.ValidateProviderConfigRequest) providers.ValidateProviderConfigResponse {
+	// It doesn't make sense to call this one on stubProvider, because
+	// we only use stubProvider for situations where ConfigureProvider failed
+	// on a real provider and we should already have called
+	// ValidateProviderConfig on that provider by then anyway.
+	return providers.ValidateProviderConfigResponse{
+		PreparedConfig: req.Config,
+		Diagnostics:    nil,
+	}
+}
+
+// ValidateResourceConfig implements providers.Interface.
+func (ConfiguredProvider) ValidateResourceConfig(req providers.ValidateResourceConfigRequest) providers.ValidateResourceConfigResponse {
+	// We'll just optimistically assume the configuration is valid, so that
+	// we can progress to reading and return an error there instead.
+	return providers.ValidateResourceConfigResponse{
+		Diagnostics: nil,
+	}
+}

--- a/internal/stacks/stackruntime/internal/stackeval/stubs/unknown.go
+++ b/internal/stacks/stackruntime/internal/stackeval/stubs/unknown.go
@@ -1,0 +1,191 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package stubs
+
+import (
+	"github.com/zclconf/go-cty/cty"
+
+	"github.com/hashicorp/terraform/internal/providers"
+	"github.com/hashicorp/terraform/internal/tfdiags"
+)
+
+var _ providers.Interface = (*unknownProvider)(nil)
+
+// unknownProvider is a stub provider that represents a provider that is
+// unknown to the current Terraform configuration. This is used when a reference
+// to a provider is unknown, or the provider itself has unknown instances.
+//
+// This provider wraps an unconfigured provider client, which is used to handle
+// offline functionality.
+//
+// TODO: We can return more specific values than cty.DynamicVal.
+type unknownProvider struct {
+	unconfiguredClient providers.Interface
+}
+
+func UnknownProvider(unconfiguredClient providers.Interface) providers.Interface {
+	return &unknownProvider{
+		unconfiguredClient: unconfiguredClient,
+	}
+}
+
+func (u *unknownProvider) GetProviderSchema() providers.GetProviderSchemaResponse {
+	// This is offline functionality, so we can hand it off to the unconfigured
+	// client.
+	return u.unconfiguredClient.GetProviderSchema()
+}
+
+func (u *unknownProvider) ValidateProviderConfig(request providers.ValidateProviderConfigRequest) providers.ValidateProviderConfigResponse {
+	// This is offline functionality, so we can hand it off to the unconfigured
+	// client.
+	return u.unconfiguredClient.ValidateProviderConfig(request)
+}
+
+func (u *unknownProvider) ValidateResourceConfig(request providers.ValidateResourceConfigRequest) providers.ValidateResourceConfigResponse {
+	// This is offline functionality, so we can hand it off to the unconfigured
+	// client.
+	return u.unconfiguredClient.ValidateResourceConfig(request)
+}
+
+func (u *unknownProvider) ValidateDataResourceConfig(request providers.ValidateDataResourceConfigRequest) providers.ValidateDataResourceConfigResponse {
+	// This is offline functionality, so we can hand it off to the unconfigured
+	// client.
+	return u.unconfiguredClient.ValidateDataResourceConfig(request)
+}
+
+func (u *unknownProvider) UpgradeResourceState(request providers.UpgradeResourceStateRequest) providers.UpgradeResourceStateResponse {
+	// This is offline functionality, so we can hand it off to the unconfigured
+	// client.
+	return u.unconfiguredClient.UpgradeResourceState(request)
+}
+
+func (u *unknownProvider) ConfigureProvider(request providers.ConfigureProviderRequest) providers.ConfigureProviderResponse {
+	// This shouldn't be called, we don't configure an unknown provider within
+	// stacks and Terraform Core shouldn't call this method.
+	panic("attempted to configure an unknown provider")
+}
+
+func (u *unknownProvider) Stop() error {
+	// the underlying unconfiguredClient is managed elsewhere.
+	return nil
+}
+
+func (u *unknownProvider) ReadResource(request providers.ReadResourceRequest) providers.ReadResourceResponse {
+	if request.ClientCapabilities.DeferralAllowed {
+		return providers.ReadResourceResponse{
+			NewState: cty.DynamicVal,
+			Deferred: &providers.Deferred{
+				Reason: providers.DeferredReasonProviderConfigUnknown,
+			},
+		}
+	}
+	return providers.ReadResourceResponse{
+		Diagnostics: []tfdiags.Diagnostic{
+			tfdiags.AttributeValue(
+				tfdiags.Error,
+				"Provider configuration is unknown",
+				"Cannot read from this data source because its associated provider configuration is unknown.",
+				nil, // nil attribute path means the overall configuration block
+			),
+		},
+	}
+}
+
+func (u *unknownProvider) PlanResourceChange(request providers.PlanResourceChangeRequest) providers.PlanResourceChangeResponse {
+	if request.ClientCapabilities.DeferralAllowed {
+		return providers.PlanResourceChangeResponse{
+			PlannedState: cty.DynamicVal,
+			Deferred: &providers.Deferred{
+				Reason: providers.DeferredReasonProviderConfigUnknown,
+			},
+		}
+	}
+	return providers.PlanResourceChangeResponse{
+		Diagnostics: []tfdiags.Diagnostic{
+			tfdiags.AttributeValue(
+				tfdiags.Error,
+				"Provider configuration is unknown",
+				"Cannot plan changes for this resource because its associated provider configuration is unknown.",
+				nil, // nil attribute path means the overall configuration block
+			),
+		},
+	}
+}
+
+func (u *unknownProvider) ApplyResourceChange(request providers.ApplyResourceChangeRequest) providers.ApplyResourceChangeResponse {
+	return providers.ApplyResourceChangeResponse{
+		Diagnostics: []tfdiags.Diagnostic{
+			tfdiags.AttributeValue(
+				tfdiags.Error,
+				"Provider configuration is unknown",
+				"Cannot apply changes for this resource because its associated provider configuration is unknown.",
+				nil, // nil attribute path means the overall configuration block
+			),
+		},
+	}
+}
+
+func (u *unknownProvider) ImportResourceState(request providers.ImportResourceStateRequest) providers.ImportResourceStateResponse {
+	if request.ClientCapabilities.DeferralAllowed {
+		return providers.ImportResourceStateResponse{
+			ImportedResources: []providers.ImportedResource{
+				{
+					TypeName: request.TypeName,
+					State:    cty.DynamicVal,
+				},
+			},
+			Deferred: &providers.Deferred{
+				Reason: providers.DeferredReasonProviderConfigUnknown,
+			},
+		}
+	}
+	return providers.ImportResourceStateResponse{
+		Diagnostics: []tfdiags.Diagnostic{
+			tfdiags.AttributeValue(
+				tfdiags.Error,
+				"Provider configuration is unknown",
+				"Cannot import an existing object into this resource because its associated provider configuration is unknown.",
+				nil, // nil attribute path means the overall configuration block
+			),
+		},
+	}
+}
+
+func (u *unknownProvider) MoveResourceState(request providers.MoveResourceStateRequest) providers.MoveResourceStateResponse {
+	// This is offline functionality, so we can hand it off to the unconfigured
+	// client.
+	return u.unconfiguredClient.MoveResourceState(request)
+}
+
+func (u *unknownProvider) ReadDataSource(request providers.ReadDataSourceRequest) providers.ReadDataSourceResponse {
+	if request.ClientCapabilities.DeferralAllowed {
+		return providers.ReadDataSourceResponse{
+			State: cty.DynamicVal,
+			Deferred: &providers.Deferred{
+				Reason: providers.DeferredReasonProviderConfigUnknown,
+			},
+		}
+	}
+	return providers.ReadDataSourceResponse{
+		Diagnostics: []tfdiags.Diagnostic{
+			tfdiags.AttributeValue(
+				tfdiags.Error,
+				"Provider configuration is unknown",
+				"Cannot read from this data source because its associated provider configuration is unknown.",
+				nil, // nil attribute path means the overall configuration block
+			),
+		},
+	}
+}
+
+func (u *unknownProvider) CallFunction(request providers.CallFunctionRequest) providers.CallFunctionResponse {
+	// This is offline functionality, so we can hand it off to the unconfigured
+	// client.
+	return u.unconfiguredClient.CallFunction(request)
+}
+
+func (u *unknownProvider) Close() error {
+	// the underlying unconfiguredClient is managed elsewhere.
+	return nil
+}

--- a/internal/stacks/stackruntime/plan_test.go
+++ b/internal/stacks/stackruntime/plan_test.go
@@ -2631,7 +2631,10 @@ func TestPlanWithDeferredProviderForEach(t *testing.T) {
 					ChangeSrc: plans.ChangeSrc{
 						Action: plans.Create,
 						Before: mustPlanDynamicValue(cty.NullVal(cty.DynamicPseudoType)),
-						After:  mustPlanDynamicValueSchema(cty.DynamicVal, stacks_testing_provider.TestingResourceSchema),
+						After: mustPlanDynamicValueSchema(cty.ObjectVal(map[string]cty.Value{
+							"id":    cty.UnknownVal(cty.String),
+							"value": cty.StringVal("primary"),
+						}), stacks_testing_provider.TestingResourceSchema),
 					},
 				},
 				Schema: stacks_testing_provider.TestingResourceSchema,
@@ -2700,7 +2703,10 @@ func TestPlanWithDeferredProviderForEach(t *testing.T) {
 					ChangeSrc: plans.ChangeSrc{
 						Action: plans.Create,
 						Before: mustPlanDynamicValue(cty.NullVal(cty.DynamicPseudoType)),
-						After:  mustPlanDynamicValueSchema(cty.DynamicVal, stacks_testing_provider.TestingResourceSchema),
+						After: mustPlanDynamicValueSchema(cty.ObjectVal(map[string]cty.Value{
+							"id":    cty.UnknownVal(cty.String),
+							"value": cty.StringVal("secondary"),
+						}), stacks_testing_provider.TestingResourceSchema),
 					},
 				},
 				Schema: stacks_testing_provider.TestingResourceSchema,

--- a/internal/stacks/stackruntime/plan_test.go
+++ b/internal/stacks/stackruntime/plan_test.go
@@ -2524,6 +2524,203 @@ func TestPlanWithDeferredComponentForEachOfInvalidType(t *testing.T) {
 	}
 }
 
+func TestPlanWithDeferredProviderForEach(t *testing.T) {
+	ctx := context.Background()
+	cfg := loadMainBundleConfigForTest(t, path.Join("with-single-input", "deferred-provider-for-each"))
+
+	fakePlanTimestamp, err := time.Parse(time.RFC3339, "1991-08-25T20:57:08Z")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	changesCh := make(chan stackplan.PlannedChange)
+	diagsCh := make(chan tfdiags.Diagnostic)
+	req := PlanRequest{
+		Config: cfg,
+		ProviderFactories: map[addrs.Provider]providers.Factory{
+			addrs.NewDefaultProvider("testing"): func() (providers.Interface, error) {
+				return stacks_testing_provider.NewProvider(), nil
+			},
+		},
+		ForcePlanTimestamp: &fakePlanTimestamp,
+		InputValues: map[stackaddrs.InputVariable]ExternalInputValue{
+			{Name: "providers"}: {
+				Value:    cty.UnknownVal(cty.Set(cty.String)),
+				DefRange: tfdiags.SourceRange{},
+			},
+		},
+		DeferralAllowed: true,
+	}
+	resp := PlanResponse{
+		PlannedChanges: changesCh,
+		Diagnostics:    diagsCh,
+	}
+	go Plan(ctx, &req, &resp)
+	gotChanges, diags := collectPlanOutput(changesCh, diagsCh)
+
+	reportDiagnosticsForTest(t, diags)
+	if len(diags) != 0 {
+		t.FailNow() // We reported the diags above
+	}
+
+	sort.SliceStable(gotChanges, func(i, j int) bool {
+		return plannedChangeSortKey(gotChanges[i]) < plannedChangeSortKey(gotChanges[j])
+	})
+
+	wantChanges := []stackplan.PlannedChange{
+		&stackplan.PlannedChangeApplyable{
+			Applyable: true,
+		},
+		&stackplan.PlannedChangeComponentInstance{
+			Addr: stackaddrs.Absolute(
+				stackaddrs.RootStackInstance,
+				stackaddrs.ComponentInstance{
+					Component: stackaddrs.Component{Name: "known"},
+				}),
+			PlanComplete:  false,
+			PlanApplyable: false,
+			Action:        plans.Create,
+			PlannedInputValues: map[string]plans.DynamicValue{
+				"id":    mustPlanDynamicValueDynamicType(cty.NullVal(cty.String)),
+				"input": mustPlanDynamicValueDynamicType(cty.StringVal("primary")),
+			},
+			PlannedOutputValues: map[string]cty.Value{},
+			PlannedCheckResults: &states.CheckResults{},
+			PlanTimestamp:       fakePlanTimestamp,
+			PlannedInputValueMarks: map[string][]cty.PathValueMarks{
+				"id":    nil,
+				"input": nil,
+			},
+		},
+		&stackplan.PlannedChangeDeferredResourceInstancePlanned{
+			ResourceInstancePlanned: stackplan.PlannedChangeResourceInstancePlanned{
+				ResourceInstanceObjectAddr: stackaddrs.AbsResourceInstanceObject{
+					Component: stackaddrs.Absolute(
+						stackaddrs.RootStackInstance,
+						stackaddrs.ComponentInstance{
+							Component: stackaddrs.Component{Name: "known"},
+						},
+					),
+					Item: addrs.AbsResourceInstanceObject{
+						ResourceInstance: addrs.Resource{
+							Mode: addrs.ManagedResourceMode,
+							Type: "testing_resource",
+							Name: "data",
+						}.Instance(addrs.NoKey).Absolute(addrs.RootModuleInstance),
+					},
+				},
+				ProviderConfigAddr: addrs.AbsProviderConfig{
+					Module:   addrs.RootModule,
+					Provider: addrs.MustParseProviderSourceString("hashicorp/testing"),
+				},
+				ChangeSrc: &plans.ResourceInstanceChangeSrc{
+					Addr: addrs.Resource{
+						Mode: addrs.ManagedResourceMode,
+						Type: "testing_resource",
+						Name: "data",
+					}.Instance(addrs.NoKey).Absolute(addrs.RootModuleInstance),
+					PrevRunAddr: addrs.Resource{
+						Mode: addrs.ManagedResourceMode,
+						Type: "testing_resource",
+						Name: "data",
+					}.Instance(addrs.NoKey).Absolute(addrs.RootModuleInstance),
+					ProviderAddr: addrs.AbsProviderConfig{
+						Module:   addrs.RootModule,
+						Provider: addrs.MustParseProviderSourceString("hashicorp/testing"),
+					},
+					ChangeSrc: plans.ChangeSrc{
+						Action: plans.Create,
+						Before: mustPlanDynamicValue(cty.NullVal(cty.DynamicPseudoType)),
+						After:  mustPlanDynamicValueSchema(cty.DynamicVal, stacks_testing_provider.TestingResourceSchema),
+					},
+				},
+				Schema: stacks_testing_provider.TestingResourceSchema,
+			},
+			DeferredReason: providers.DeferredReasonProviderConfigUnknown,
+		},
+		&stackplan.PlannedChangeComponentInstance{
+			Addr: stackaddrs.Absolute(
+				stackaddrs.RootStackInstance,
+				stackaddrs.ComponentInstance{
+					Component: stackaddrs.Component{Name: "unknown"},
+					Key:       addrs.WildcardKey,
+				}),
+			PlanComplete:  false,
+			PlanApplyable: false,
+			Action:        plans.Create,
+			PlannedInputValues: map[string]plans.DynamicValue{
+				"id":    mustPlanDynamicValueDynamicType(cty.NullVal(cty.String)),
+				"input": mustPlanDynamicValueDynamicType(cty.StringVal("secondary")),
+			},
+			PlannedOutputValues: map[string]cty.Value{},
+			PlannedCheckResults: &states.CheckResults{},
+			PlanTimestamp:       fakePlanTimestamp,
+			PlannedInputValueMarks: map[string][]cty.PathValueMarks{
+				"id":    nil,
+				"input": nil,
+			},
+		},
+		&stackplan.PlannedChangeDeferredResourceInstancePlanned{
+			ResourceInstancePlanned: stackplan.PlannedChangeResourceInstancePlanned{
+				ResourceInstanceObjectAddr: stackaddrs.AbsResourceInstanceObject{
+					Component: stackaddrs.Absolute(
+						stackaddrs.RootStackInstance,
+						stackaddrs.ComponentInstance{
+							Component: stackaddrs.Component{Name: "unknown"},
+							Key:       addrs.WildcardKey,
+						},
+					),
+					Item: addrs.AbsResourceInstanceObject{
+						ResourceInstance: addrs.Resource{
+							Mode: addrs.ManagedResourceMode,
+							Type: "testing_resource",
+							Name: "data",
+						}.Instance(addrs.NoKey).Absolute(addrs.RootModuleInstance),
+					},
+				},
+				ProviderConfigAddr: addrs.AbsProviderConfig{
+					Module:   addrs.RootModule,
+					Provider: addrs.MustParseProviderSourceString("hashicorp/testing"),
+				},
+				ChangeSrc: &plans.ResourceInstanceChangeSrc{
+					Addr: addrs.Resource{
+						Mode: addrs.ManagedResourceMode,
+						Type: "testing_resource",
+						Name: "data",
+					}.Instance(addrs.NoKey).Absolute(addrs.RootModuleInstance),
+					PrevRunAddr: addrs.Resource{
+						Mode: addrs.ManagedResourceMode,
+						Type: "testing_resource",
+						Name: "data",
+					}.Instance(addrs.NoKey).Absolute(addrs.RootModuleInstance),
+					ProviderAddr: addrs.AbsProviderConfig{
+						Module:   addrs.RootModule,
+						Provider: addrs.MustParseProviderSourceString("hashicorp/testing"),
+					},
+					ChangeSrc: plans.ChangeSrc{
+						Action: plans.Create,
+						Before: mustPlanDynamicValue(cty.NullVal(cty.DynamicPseudoType)),
+						After:  mustPlanDynamicValueSchema(cty.DynamicVal, stacks_testing_provider.TestingResourceSchema),
+					},
+				},
+				Schema: stacks_testing_provider.TestingResourceSchema,
+			},
+			DeferredReason: providers.DeferredReasonProviderConfigUnknown,
+		},
+		&stackplan.PlannedChangeHeader{
+			TerraformVersion: version.SemVer,
+		},
+		&stackplan.PlannedChangeRootInputValue{
+			Addr:  stackaddrs.InputVariable{Name: "providers"},
+			Value: cty.UnknownVal(cty.Set(cty.String)),
+		},
+	}
+
+	if diff := cmp.Diff(wantChanges, gotChanges, ctydebug.CmpOptions, cmpCollectionsSet); diff != "" {
+		t.Errorf("wrong changes\n%s", diff)
+	}
+}
+
 // collectPlanOutput consumes the two output channels emitting results from
 // a call to [Plan], and collects all of the data written to them before
 // returning once changesCh has been closed by the sender to indicate that

--- a/internal/stacks/stackruntime/testdata/mainbundle/test/with-single-input/deferred-provider-for-each/deferred-provider-for-each.tfstack.hcl
+++ b/internal/stacks/stackruntime/testdata/mainbundle/test/with-single-input/deferred-provider-for-each/deferred-provider-for-each.tfstack.hcl
@@ -1,0 +1,46 @@
+required_providers {
+  testing = {
+    source  = "hashicorp/testing"
+    version = "0.1.0"
+  }
+}
+
+variable "providers" {
+  type = set(string)
+}
+
+provider "testing" "unknown" {
+  for_each = var.providers
+}
+
+provider "testing" "known" {
+  for_each = toset(["primary"])
+}
+
+component "known" {
+  source = "../"
+
+  providers = {
+    // We're testing a known component referencing an unknown provider here.
+    testing = provider.testing.unknown["primary"]
+  }
+
+  inputs = {
+    input = "primary"
+  }
+}
+
+component "unknown" {
+  source = "../"
+
+  for_each = var.providers
+
+  providers = {
+    // We're testing an unknown component referencing a known provider here.
+    testing = provider.testing.known[each.key]
+  }
+
+  inputs = {
+    input = "secondary"
+  }
+}


### PR DESCRIPTION
This PR adds support for unknown providers to the stacks runtime.

The provider instance functionality now returns an instanced addressed by the wildcard key to represent an unknown but otherwise valid provider configuration. We still return nil to represent an invalid provider configuration.

The components will now load a unknown provider stub when they encounter the requirement for an unknown provider. The unknown provider stub wraps an unconfigured provider so we can still function completely for offline functionality. For online functionality the unknown provider either errors if deferred responses are not supported, or returns a deferred response if deferrals are supported.

There's a small refactor where I've pushed the other stub provider into a separate package to live alongside the new unknown stub provider. Seemed to make sense to keep the alternate provider implementations together.