### PR TITLE
render entirely unknown blocks in the plan output

### DIFF
--- a/internal/command/jsonformat/differ/block.go
+++ b/internal/command/jsonformat/differ/block.go
@@ -74,6 +74,13 @@ func ComputeDiffForBlock(change structured.Change, block *jsonprovider.Block) co
 		afterSensitive := childValue.IsAfterSensitive()
 		forcesReplacement := childValue.ReplacePaths.Matches()
 
+		if unknown, ok := checkForUnknownBlock(childValue, block); ok {
+			// An unknown block doesn't render any type information, so we can
+			// render it as a single block rather than switching on all types.
+			blocks.AddSingleBlock(key, unknown, forcesReplacement, beforeSensitive, afterSensitive)
+			continue
+		}
+
 		switch NestingMode(blockType.NestingMode) {
 		case nestingModeSet:
 			diffs, action := computeBlockDiffsAsSet(childValue, blockType.Block)

--- a/internal/command/jsonformat/differ/differ_test.go
+++ b/internal/command/jsonformat/differ/differ_test.go
@@ -99,6 +99,41 @@ func TestValue_SimpleBlocks(t *testing.T) {
 				"normal_attribute": renderers.ValidatePrimitive(nil, "some value", plans.Create, false),
 			}, nil, nil, nil, nil, plans.Create, false),
 		},
+		"create_with_unknown_block": {
+			input: structured.Change{
+				Before: nil,
+				After: map[string]interface{}{
+					"normal_attribute": "some value",
+				},
+				Unknown: map[string]any{
+					"nested": true,
+				},
+			},
+			block: &jsonprovider.Block{
+				Attributes: map[string]*jsonprovider.Attribute{
+					"normal_attribute": {
+						AttributeType: unmarshalType(t, cty.String),
+					},
+				},
+				BlockTypes: map[string]*jsonprovider.BlockType{
+					"nested": {
+						NestingMode: "single",
+						Block: &jsonprovider.Block{
+							Attributes: map[string]*jsonprovider.Attribute{
+								"attr": {
+									AttributeType: unmarshalType(t, cty.String),
+									Optional:      true,
+								},
+							},
+						},
+					},
+				},
+			},
+			validate: renderers.ValidateBlock(map[string]renderers.ValidateDiffFunction{
+				"normal_attribute": renderers.ValidatePrimitive(nil, "some value", plans.Create, false),
+			}, map[string]renderers.ValidateDiffFunction{
+				"nested": renderers.ValidateUnknown(nil, plans.Create, false),
+			}, nil, nil, nil, plans.Create, false)},
 	}
 	for name, tc := range tcs {
 		// Set some default values


### PR DESCRIPTION
An unknown block can happen when using an unknown for_each value in a dynamic block assignment. The plan renderer was missing a check for entirely unknown blocks, causing them to be omitted from the human readable output.

Fixes #34933