### PR TITLE
backport 35262

### DIFF
--- a/internal/terraform/context_plan_import_test.go
+++ b/internal/terraform/context_plan_import_test.go
@@ -1564,3 +1564,67 @@ import {
 		t.Fatalf("unexpected errors\n%s", diags.Err().Error())
 	}
 }
+func TestContext2Plan_importDuringDestroy(t *testing.T) {
+	m := testModuleInline(t, map[string]string{
+		"main.tf": `
+	resource "test_object" "a" {
+	  test_string = "foo"
+	}
+
+	import {
+	  to   = test_object.a
+	  id   = "missing"
+	}
+
+	resource "test_object" "b" {
+		test_string = "foo"
+	  }
+	`,
+	})
+
+	p := simpleMockProvider()
+	ctx := testContext2(t, &ContextOpts{
+		Providers: map[addrs.Provider]providers.Factory{
+			addrs.NewDefaultProvider("test"): testProviderFuncFixed(p),
+		},
+	})
+	p.ReadResourceFn = func(req providers.ReadResourceRequest) (resp providers.ReadResourceResponse) {
+		// this resource has already been deleted, so return nothing during refresh
+		if req.PriorState.GetAttr("test_string").AsString() == "missing" {
+			resp.NewState = cty.NullVal(req.PriorState.Type())
+			return resp
+		}
+
+		resp.NewState = req.PriorState
+		return resp
+	}
+
+	p.ImportResourceStateResponse = &providers.ImportResourceStateResponse{
+		ImportedResources: []providers.ImportedResource{
+			{
+				TypeName: "test_object",
+				State: cty.ObjectVal(map[string]cty.Value{
+					"test_string": cty.StringVal("missing"),
+				}),
+			},
+		},
+	}
+
+	state := states.NewState()
+	root := state.EnsureModule(addrs.RootModuleInstance)
+	root.SetResourceInstanceCurrent(
+		mustResourceInstanceAddr("test_object.b").Resource,
+		&states.ResourceInstanceObjectSrc{
+			Status:    states.ObjectReady,
+			AttrsJSON: []byte(`{"test_string":"foo"}`),
+		},
+		mustProviderConfig(`provider["registry.terraform.io/hashicorp/test"]`),
+	)
+
+	_, diags := ctx.Plan(m, state, &PlanOpts{
+		Mode: plans.DestroyMode,
+	})
+	if diags.HasErrors() {
+		t.Fatalf("unexpected errors\n%s", diags.Err().Error())
+	}
+}

--- a/internal/terraform/node_resource_plan_instance.go
+++ b/internal/terraform/node_resource_plan_instance.go
@@ -161,7 +161,7 @@ func (n *NodePlannableResourceInstance) managedResourceExecute(ctx EvalContext) 
 		}
 	}
 
-	importing := n.importTarget.IDString != ""
+	importing := n.importTarget.IDString != "" && !n.preDestroyRefresh
 	importId := n.importTarget.IDString
 
 	var deferred *providers.Deferred


### PR DESCRIPTION
Manual backport of #35262 

---
Don't attempt to import during a destroy operation

A full destroy requires Terraform to refresh everything beforehand, but if an instance is missing from the state and has an `import` block, Terraform was attempting to re-import that resource before destroy. The most common reason this could happen would be when resuming a partially completed destroy, where some of the state has already been deleted. In that case the import will fail with an error because the resource no longer exists, and end up blocking the rest of the operation.
