### PR TITLE
stacks: remove wildcard key from computed instances

### DIFF
--- a/internal/stacks/stackruntime/internal/stackeval/component.go
+++ b/internal/stacks/stackruntime/internal/stackeval/component.go
@@ -386,7 +386,7 @@ func (c *Component) reportNamedPromises(cb func(id promising.PromiseID, name str
 	name := c.Addr().String()
 	instsName := name + " instances"
 	forEachName := name + " for_each"
-	c.instances.Each(func(ep EvalPhase, o *promising.Once[withDiagnostics[map[addrs.InstanceKey]*ComponentInstance]]) {
+	c.instances.Each(func(ep EvalPhase, o *promising.Once[withDiagnostics[instancesResult[*ComponentInstance]]]) {
 		cb(o.PromiseID(), instsName)
 	})
 	// FIXME: We should call reportNamedPromises on the individual

--- a/internal/stacks/stackruntime/internal/stackeval/component_instance.go
+++ b/internal/stacks/stackruntime/internal/stackeval/component_instance.go
@@ -422,7 +422,13 @@ func (c *ComponentInstance) neededProviderClients(ctx context.Context, phase Eva
 		if provider == nil {
 			continue
 		}
-		insts := provider.Instances(ctx, phase)
+		insts, unknown := provider.Instances(ctx, phase)
+		if unknown {
+			// an unknown provider should have been added to the unknown
+			// providers and not the known providers, so this is a bug if we get
+			// here.
+			panic(fmt.Errorf("provider %s returned unknown instances", callerAddr))
+		}
 		if insts == nil {
 			continue
 		}

--- a/internal/stacks/stackruntime/internal/stackeval/input_variable.go
+++ b/internal/stacks/stackruntime/internal/stackeval/input_variable.go
@@ -84,10 +84,13 @@ func (v *InputVariable) DefinedByStackCallInstance(ctx context.Context, phase Ev
 		// actually exist, which is odd but we'll tolerate it.
 		return nil
 	}
-	callInsts := call.Instances(ctx, phase)
+	callInsts, unknown := call.Instances(ctx, phase)
+	if unknown {
+		// Return our static unknown instance for this variable.
+		return call.UnknownInstance(ctx, phase)
+	}
 	if callInsts == nil {
-		// Could get here if the call's for_each is unknown or invalid,
-		// in which case we'll assume unknown.
+		// Could get here if the call's for_each is invalid.
 		return nil
 	}
 

--- a/internal/stacks/stackruntime/internal/stackeval/main.go
+++ b/internal/stacks/stackruntime/internal/stackeval/main.go
@@ -16,7 +16,6 @@ import (
 	"github.com/hashicorp/terraform/internal/addrs"
 	fileProvisioner "github.com/hashicorp/terraform/internal/builtin/provisioners/file"
 	remoteExecProvisioner "github.com/hashicorp/terraform/internal/builtin/provisioners/remote-exec"
-	"github.com/hashicorp/terraform/internal/instances"
 	"github.com/hashicorp/terraform/internal/promising"
 	"github.com/hashicorp/terraform/internal/provisioners"
 	"github.com/hashicorp/terraform/internal/stacks/stackaddrs"
@@ -385,40 +384,6 @@ func (m *Main) ProviderType(ctx context.Context, addr addrs.Provider) *ProviderT
 
 func (m *Main) ProviderRefTypes() map[addrs.Provider]cty.Type {
 	return m.config.ProviderRefTypes
-}
-
-// ProviderInstance returns the provider instance with the given address,
-// or nil if there is no such provider instance.
-//
-// This function needs to evaluate the for_each expression of each stack along
-// the path and of a final multi-instance provider configuration, and so will
-// block on whatever those expressions depend on.
-//
-// If any of the objects along the path have an as-yet-unknown set of
-// instances, this function will optimistically return a non-nil provider
-// configuration but further operations with that configuration are likely
-// to return unknown values themselves.
-func (m *Main) ProviderInstance(ctx context.Context, addr stackaddrs.AbsProviderConfigInstance, phase EvalPhase) *ProviderInstance {
-	stack := m.Stack(ctx, addr.Stack, phase)
-	if stack == nil {
-		return nil
-	}
-	provider := stack.Provider(ctx, addr.Item.ProviderConfig)
-	if provider == nil {
-		return nil
-	}
-	insts := provider.Instances(ctx, phase)
-	if insts == nil {
-		// A nil result means that the for_each expression is unknown, and
-		// so we must optimistically return an instance referring to the
-		// given address which will then presumably yield unknown values
-		// of some kind when used.
-		return newProviderInstance(provider, addr.Item.Key, instances.RepetitionData{
-			EachKey:   cty.UnknownVal(cty.String),
-			EachValue: cty.DynamicVal,
-		})
-	}
-	return insts[addr.Item.Key]
 }
 
 // PreviousProviderInstances fetches the set of providers that are required

--- a/internal/stacks/stackruntime/internal/stackeval/provider.go
+++ b/internal/stacks/stackruntime/internal/stackeval/provider.go
@@ -288,7 +288,7 @@ func (p *Provider) reportNamedPromises(cb func(id promising.PromiseID, name stri
 	p.forEachValue.Each(func(ep EvalPhase, o *promising.Once[withDiagnostics[cty.Value]]) {
 		cb(o.PromiseID(), forEachName)
 	})
-	p.instances.Each(func(ep EvalPhase, o *promising.Once[withDiagnostics[map[addrs.InstanceKey]*ProviderInstance]]) {
+	p.instances.Each(func(ep EvalPhase, o *promising.Once[withDiagnostics[instancesResult[*ProviderInstance]]]) {
 		cb(o.PromiseID(), instsName)
 	})
 	// FIXME: We should call reportNamedPromises on the individual

--- a/internal/stacks/stackruntime/internal/stackeval/provider_instance_test.go
+++ b/internal/stacks/stackruntime/internal/stackeval/provider_instance_test.go
@@ -68,7 +68,8 @@ func TestProviderInstanceCheckProviderArgs(t *testing.T) {
 		if provider == nil {
 			t.Fatal("no provider.foo.bar is available")
 		}
-		insts := provider.Instances(ctx, InspectPhase)
+		insts, unknown := provider.Instances(ctx, InspectPhase)
+		assertFalse(t, unknown)
 		inst, ok := insts[addrs.NoKey]
 		if !ok {
 			t.Fatal("missing NoKey instance of provider.foo.bar")
@@ -341,7 +342,8 @@ func TestProviderInstanceCheckClient(t *testing.T) {
 		if provider == nil {
 			t.Fatal("no provider.foo.bar is available")
 		}
-		insts := provider.Instances(ctx, InspectPhase)
+		insts, unknown := provider.Instances(ctx, InspectPhase)
+		assertFalse(t, unknown)
 		inst, ok := insts[addrs.NoKey]
 		if !ok {
 			t.Fatal("missing NoKey instance of provider.foo.bar")

--- a/internal/stacks/stackruntime/internal/stackeval/stack.go
+++ b/internal/stacks/stackruntime/internal/stackeval/stack.go
@@ -79,7 +79,7 @@ func (s *Stack) ParentStack(ctx context.Context) *Stack {
 	return s.main.StackUnchecked(ctx, parentAddr)
 }
 
-// ChildStackUnckecked returns an object representing a child of this stack, or
+// ChildStackUnchecked returns an object representing a child of this stack, or
 // nil if the "name" part of the step doesn't correspond to a declared
 // embedded stack call.
 //
@@ -139,14 +139,13 @@ func (s *Stack) ChildStackChecked(ctx context.Context, addr stackaddrs.StackInst
 	callAddr := stackaddrs.StackCall{Name: addr.Name}
 	call := calls[callAddr]
 
-	instances := call.Instances(ctx, phase)
-	if instances == nil {
-		// Totally-nil instances (as opposed to a non-nil zero-length map)
-		// means that we don't actually know what the instances for this
-		// stack call are, and so we optimistically assume that the given
-		// key was intended to exist and assume that later work with the
-		// resulting object will also return unknown/indeterminate values.
+	instances, unknown := call.Instances(ctx, phase)
+	if unknown {
 		return candidate
+	}
+
+	if instances == nil {
+		return nil
 	}
 	if _, exists := instances[addr.Key]; !exists {
 		return nil

--- a/internal/stacks/stackruntime/internal/stackeval/stack_call.go
+++ b/internal/stacks/stackruntime/internal/stackeval/stack_call.go
@@ -303,7 +303,7 @@ func (c *StackCall) reportNamedPromises(cb func(id promising.PromiseID, name str
 	name := c.Addr().String()
 	instsName := name + " instances"
 	forEachName := name + " for_each"
-	c.instances.Each(func(ep EvalPhase, o *promising.Once[withDiagnostics[map[addrs.InstanceKey]*StackCallInstance]]) {
+	c.instances.Each(func(ep EvalPhase, o *promising.Once[withDiagnostics[instancesResult[*StackCallInstance]]]) {
 		cb(o.PromiseID(), instsName)
 	})
 	// FIXME: We should call reportNamedPromises on the individual

--- a/internal/stacks/stackruntime/internal/stackeval/testing_test.go
+++ b/internal/stacks/stackruntime/internal/stackeval/testing_test.go
@@ -435,6 +435,20 @@ func (m *Main) SetTestOnlyGlobals(t *testing.T, vals map[string]cty.Value) {
 	m.testOnlyGlobals = vals
 }
 
+func assertFalse(t *testing.T, value bool) {
+	t.Helper()
+	if value {
+		t.Fatalf("expected false but got true")
+	}
+}
+
+func assertTrue(t *testing.T, value bool) {
+	t.Helper()
+	if !value {
+		t.Fatalf("expected true but got false")
+	}
+}
+
 func assertNoDiags(t *testing.T, diags tfdiags.Diagnostics) {
 	t.Helper()
 	if len(diags) != 0 {

--- a/internal/stacks/stackruntime/internal/stackeval/walk_dynamic.go
+++ b/internal/stacks/stackruntime/internal/stackeval/walk_dynamic.go
@@ -58,7 +58,19 @@ func walkDynamicObjectsInStack[Output any](
 		// because it involves evaluating for_each expressions, and one
 		// stack call's for_each might depend on the results of another.
 		walk.AsyncTask(ctx, func(ctx context.Context) {
-			insts := call.Instances(ctx, phase)
+			insts, unknown := call.Instances(ctx, phase)
+
+			// If unknown, then process the unknown instance and skip the rest.
+			if unknown {
+				inst := call.UnknownInstance(ctx, phase)
+				visit(ctx, walk, inst)
+
+				childStack := inst.CalledStack(ctx)
+				walkDynamicObjectsInStack(ctx, walk, childStack, phase, visit)
+				return
+			}
+
+			// Otherwise, process the instances and their child stacks.
 			for _, inst := range insts {
 				visit(ctx, walk, inst)
 
@@ -78,7 +90,14 @@ func walkDynamicObjectsInStack[Output any](
 		// because it involves potentially evaluating a for_each expression.
 		// and that might depend on data from elsewhere in the same stack.
 		walk.AsyncTask(ctx, func(ctx context.Context) {
-			insts := component.Instances(ctx, phase)
+			insts, unknown := component.Instances(ctx, phase)
+
+			if unknown {
+				inst := component.UnknownInstance(ctx, phase)
+				visit(ctx, walk, inst)
+				return
+			}
+
 			for _, inst := range insts {
 				visit(ctx, walk, inst)
 			}
@@ -93,7 +112,13 @@ func walkDynamicObjectsInStack[Output any](
 		// task because it involves potentially evaluating a for_each expression,
 		// and that might depend on data from elsewhere in the same stack.
 		walk.AsyncTask(ctx, func(ctx context.Context) {
-			insts := provider.Instances(ctx, phase)
+			insts, unknown := provider.Instances(ctx, phase)
+			if unknown {
+				// We use the unconfigured client for unknown instances of a
+				// provider so there is nothing for us to do here.
+				return
+			}
+
 			for _, inst := range insts {
 				visit(ctx, walk, inst)
 			}


### PR DESCRIPTION
This PR refactors the handling of unknown components, providers, and stack calls from the stacks runtime.

Previously, we were just including the unknown instance as part of the set of returned instances with the Wildcard key eg. `["*"]`. This meant the rest of the runtime just handled this by looking up the unknown instance whenever matching variables via a HCL context. However, this was broken in the case of referencing a known value into an unknown instance (for example referencing `component.name["known"]` when `component.name` has an unknown set of instances should return an unknown value but would instead return "instance not found"), and also was only working at all because we haven't yet fixed the wildcard key to render properly (eg. `[*]` and not `["*"]`.

With this PR we turn the treatment of unknown instances into something similar as used within Terraform Core. This is where we return an additional boolean that indicates the instances are unknown instead of just including an instance mapped to the wildcard key.

We then create an additional `promising.Once` that returns a single static unknown instance for components and embedded stacks. This is then manually referenced whenever the instances are requested and an unknown is returned. This ensures we aren't corrupting the known instances with the wildcard key, and gives a clearly defined separation between known and unknown instances. It also fixes both of the problems mentioned above.