### PR TITLE
lang/funcs: Allow some more expression types in templatestring (v1.9 Backport)

### DIFF
--- a/internal/lang/funcs/string_test.go
+++ b/internal/lang/funcs/string_test.go
@@ -336,6 +336,55 @@ func TestTemplateString(t *testing.T) {
 			``,
 		},
 		{
+			`data.whatever.whatever[each.key].result`,
+			map[string]cty.Value{
+				"data": cty.ObjectVal(map[string]cty.Value{
+					"whatever": cty.ObjectVal(map[string]cty.Value{
+						"whatever": cty.MapVal(map[string]cty.Value{
+							"foo": cty.ObjectVal(map[string]cty.Value{
+								"result": cty.StringVal("it's ${a}"),
+							}),
+						}),
+					}),
+				}),
+				"each": cty.ObjectVal(map[string]cty.Value{
+					"key": cty.StringVal("foo"),
+				}),
+			},
+			cty.ObjectVal(map[string]cty.Value{
+				"a": cty.StringVal("a value"),
+			}),
+			cty.StringVal(`it's a value`),
+			``,
+		},
+		{
+			`data.whatever.whatever[*].result`,
+			map[string]cty.Value{
+				"data": cty.ObjectVal(map[string]cty.Value{
+					"whatever": cty.ObjectVal(map[string]cty.Value{
+						"whatever": cty.TupleVal([]cty.Value{
+							cty.ObjectVal(map[string]cty.Value{
+								"result": cty.StringVal("it's ${a}"),
+							}),
+						}),
+					}),
+				}),
+				"each": cty.ObjectVal(map[string]cty.Value{
+					"key": cty.StringVal("foo"),
+				}),
+			},
+			cty.ObjectVal(map[string]cty.Value{
+				"a": cty.StringVal("a value"),
+			}),
+			cty.NilVal,
+			// We have an intentional hole in our heuristic for whether the
+			// first argument is a suitable expression which permits splat
+			// expressions just so that we can return the type mismatch error
+			// from the result not being a string, instead of the more general
+			// error about it not being a supported expression type.
+			`invalid template value: a string is required`,
+		},
+		{
 			`"can't write $${not_allowed}"`,
 			map[string]cty.Value{},
 			cty.ObjectVal(map[string]cty.Value{

--- a/website/docs/language/functions/templatestring.mdx
+++ b/website/docs/language/functions/templatestring.mdx
@@ -8,13 +8,13 @@ description: |-
 
 -> **Note:** The `templatestring` function is intended for advanced use cases. Most use cases require only a [string template expression](/terraform/language/expressions/strings#string-templates). To render a template from a file, use the [`templatefile` function](/terraform/language/functions/templatefile).
 
-`templatestring` renders a template using a supplied set of template variables.
+`templatestring` renders a template given as a string value, using a supplied set of template variables.
 
 ```hcl
-templatefile(ref, vars)
+templatestring(ref, vars)
 ```
 
-The first parameter must be a simple reference to string value containing the template: for example, `data.aws_s3_object.example.body` or `local.inline_template`.
+The first parameter must be a direct reference to string value containing the template: for example, `data.aws_s3_object.example.body` or `local.inline_template`.
 
 It is **not** valid to supply the template expression directly as the first argument:
 
@@ -25,23 +25,18 @@ templatestring("Hello, $${name}", {
 })
 ```
 
-Instead of the above, you should instead use a string template expression:
+Instead of the above, you should use a normal string template expression:
 
 ```hcl
 "Hello, ${var.name}"
 ```
 
-The `templatestring` function is needed only when the template is available as a named object in the current module.
+The `templatestring` function is needed only when the template is available from a named object, such as a data resource, declared in the current module.
 
 The template syntax is the same as for
 [string templates](/terraform/language/expressions/strings#string-templates)
 in the main Terraform language, including interpolation sequences delimited with
-`${` ... `}`. 
-
-Strings in the Terraform language are sequences of Unicode characters, so
-this function will interpret the file contents as UTF-8 encoded text and
-return the resulting Unicode characters. If the template contains invalid UTF-8
-sequences then this function will produce an error.
+`${` ... `}`.
 
 ## Example
 
@@ -60,7 +55,17 @@ output "example" {
 }
 ```
 
-For more examples of how to use templates, please see the documentation for the [`templatefile`](/terraform/language/functions/templatefile#Examples) function.
+For more examples of how to use templates, refer to the documentation for [the `templatefile` function](/terraform/language/functions/templatefile#Examples).
+
+## Dynamic Template Construction
+
+This function is primarily intended for rendering templates fetched as a single string from remote locations, often using data resources.
+
+You can also use this as a way to construct a template dynamically and then render it, but we recommend treating that only as a last resort because the result tends to be hard to understand, hard to maintain, and fragile to unexpected input.
+
+The restrictions on what kind of syntax is allowed in the first argument are a guardrail to help avoid those new to Terraform thinking that this function is the primary way to render templates in Terraform, but you can bypass those restrictions if you wish by writing an expression that builds a template dynamically and then assigning that expression to a [local value](/terraform/language/values/locals). You can then use a reference to that local value as the first argument to `templatestring`.
+
+If you _do_ choose to construct templates from parts dynamically, be mindful that Terraform has built-in functions that can interact with the local filesystem, and so maliciously-crafted input might produce a template whose result includes data from arbitrary files on the system where Terraform is running.
 
 ## Related Functions
 


### PR DESCRIPTION
This is a backport of https://github.com/hashicorp/terraform/pull/35285 to the `v1.9` branch, created manually since the backport automation is currently broken.
