### PR TITLE
Variable validation rules must still reference the containing variable.

### DIFF
--- a/internal/configs/testdata/invalid-files/variable-validation-condition-noself.tf
+++ b/internal/configs/testdata/invalid-files/variable-validation-condition-noself.tf
@@ -1,0 +1,10 @@
+locals {
+  something = "else"
+}
+
+variable "validation" {
+  validation {
+    condition     = local.something == "else"
+    error_message = "Something else."
+  }
+}


### PR DESCRIPTION
While variable validation rules can now include other references, they also still need to reference the variable itself. If the containing variable wasn't referenced, then the resulting `Invalid value for variable` error would not make sense.

Having no self-references will also cause a panic when trying to reinsert the variable name into the evaluation context, because the context variables map could be nil. A check for a nil map does not need to be added however, because ensuring that a self-reference exists means there will always be at least 1 variable in scope.

This will currently panic:
```
locals {
  else = "?"
}

variable "validated" {
  type    = string
  default = ""

  validation {
    condition     = "something" == local.else
    error_message = "Error message"
  }
}
```

But should return a diagnostic error about a missing variable reference:
```
╷
│ Error: Invalid variable validation condition
│
│   on main.tf line 10, in variable "validated":
│   10:     condition     = "something" == local.else
│
│ The condition for variable "validated" must refer to var.validated in order to test incoming values.
╵
```