### PR TITLE
Backport of #35261

### DIFF
--- a/internal/terraform/node_resource_plan_instance.go
+++ b/internal/terraform/node_resource_plan_instance.go
@@ -243,7 +243,7 @@ func (n *NodePlannableResourceInstance) managedResourceExecute(ctx EvalContext) 
 	}
 
 	if n.skipRefresh && !importing && updatedCBD {
-		// CreateBeforeDestroy must be set correctly in the state which us used
+		// CreateBeforeDestroy must be set correctly in the state which is used
 		// to create the apply graph, so if we did not refresh the state make
 		// sure we still update any changes to CreateBeforeDestroy.
 		diags = diags.Append(n.writeResourceInstanceState(ctx, instanceRefreshState, refreshState))

--- a/internal/terraform/transform_destroy_cbd.go
+++ b/internal/terraform/transform_destroy_cbd.go
@@ -115,9 +115,16 @@ func (t *ForcedCBDTransformer) hasCBDDescendent(g *Graph, v dag.Vertex) bool {
 // DiffTransformer when building the apply graph.
 type CBDEdgeTransformer struct {
 	// Module and State are only needed to look up dependencies in
-	// any way possible. Either can be nil if not availabile.
+	// any way possible. Either can be nil if not available.
 	Config *configs.Config
 	State  *states.State
+
+	// FIXME: This should optimally be decided entirely during plan, and then we
+	// can rely on the planned changes to determine the CreateBeforeDestroy
+	// status. This would require very careful auditing however, since not all
+	// nodes are represented exactly in the changes, and the way
+	// CreateBeforeDestroy propagates through the graph is extremely important
+	// for correctness and to prevent cycles.
 }
 
 func (t *CBDEdgeTransformer) Transform(g *Graph) error {


### PR DESCRIPTION
Manual backport of #35261

---
The ordering for `CreateBeforeDestroy` is determined by the value stored in the resource instance state. If the destroy plan was created with `-refresh=false`, _and_ the configuration changed the value of `create_before_destroy`, then there was no chance for the state to be updated, and we now have a mismatch between the configuration and the state. This disagreement causes the plan to record the resource replacement as destroy-then-create, but later order the apply actions as create-before-destroy, and since the create is expected to be last, the destroy operation ends up showing a noop and is skipped.

The fix is relatively small, just ensure that we re-write the state when there is no refresh but there was a change in `CreateBeforeDestroy`.

The replacement ordering optimally should be decided entirely by the plan, and then we can rely on the planned changes to determine the CreateBeforeDestroy status without re-inspecting the config and state. This would require very careful auditing however, since not all nodes are represented exactly in the changes, and the way `CreateBeforeDestroy` propagates through the graph is extremely important for correctness and to prevent cycles.