### PR TITLE
Support -lock for "console" command

### DIFF
--- a/internal/command/console.go
+++ b/internal/command/console.go
@@ -30,6 +30,7 @@ func (c *ConsoleCommand) Run(args []string) int {
 	args = c.Meta.process(args)
 	var evalFromPlan bool
 	cmdFlags := c.Meta.extendedFlagSet("console")
+	cmdFlags.BoolVar(&c.Meta.stateLock, "lock", true, "use state locking")
 	cmdFlags.StringVar(&c.Meta.statePath, "state", DefaultStateFilename, "path")
 	cmdFlags.BoolVar(&evalFromPlan, "plan", false, "evaluate from plan")
 	cmdFlags.Usage = func() { c.Ui.Error(c.Help()) }
@@ -226,6 +227,10 @@ Options:
 
   -state=path       Legacy option for the local backend only. See the local
                     backend's documentation for more information.
+
+  -lock=false       Don't hold a state lock during the operation. This is
+					dangerous if others might concurrently run commands
+					against the same workspace.
 
   -plan             Create a new plan (as if running "terraform plan") and
                     then evaluate expressions against its planned state,


### PR DESCRIPTION
Simply align console command to plan and apply ect allow lock to be disabled.

My usecase is to generate template files given a json blob without locking the context.

Fixes #23655

## Target Release

next once merged?

## Draft CHANGELOG entry


###  ENHANCEMENTS 
- added abuility to provide -lock=boolean to terraform console

![image](https://github.com/hashicorp/terraform/assets/5182053/ac8a1b2c-ca6a-4029-bd29-110fb2a626b7)
![image](https://github.com/hashicorp/terraform/assets/5182053/f3fcd350-35d2-4398-9b74-82a3110bf5a8)


