### PR TITLE
deferred actions: allow unknown foreach attributes within import blocks

### DIFF
--- a/internal/addrs/partial_expanded.go
+++ b/internal/addrs/partial_expanded.go
@@ -430,6 +430,10 @@ func ParsePartialExpandedResource(traversal hcl.Traversal) (PartialExpandedResou
 		return PartialExpandedResource{}, nil, diags
 	}
 
+	// We know that remain[0] is a hcl.TraverseRoot object as the
+	// ParsePartialExpandedModule function always returns a hcl.TraverseRoot
+	// object as the first element in the remain slice.
+
 	mode := ManagedResourceMode
 	if remain.RootName() == "data" {
 		mode = DataResourceMode

--- a/internal/addrs/partial_expanded.go
+++ b/internal/addrs/partial_expanded.go
@@ -6,6 +6,12 @@ package addrs
 import (
 	"fmt"
 	"strings"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/zclconf/go-cty/cty"
+	"github.com/zclconf/go-cty/cty/gocty"
+
+	"github.com/hashicorp/terraform/internal/tfdiags"
 )
 
 // PartialExpandedModule represents a set of module instances which all share
@@ -27,6 +33,155 @@ type PartialExpandedModule struct {
 	// zero-length in a publicly-exposed PartialExpandedModule because that
 	// would make this just a degenerate ModuleInstance.
 	unexpandedSuffix Module
+}
+
+// ParsePartialExpandedModule parses a module address traversal and returns a
+// PartialExpandedModule representing the known and unknown parts of the
+// address.
+//
+// It returns the parsed PartialExpandedModule, the remaining traversal steps
+// that were not consumed by this function, and any diagnostics that were
+// generated during parsing.
+func ParsePartialExpandedModule(traversal hcl.Traversal) (PartialExpandedModule, hcl.Traversal, tfdiags.Diagnostics) {
+	var diags tfdiags.Diagnostics
+
+	remain := traversal
+	var partial PartialExpandedModule
+
+	// We'll step through the traversal steps and build up the known prefix
+	// of the module address. When we reach a call with an unknown index, we'll
+	// switch to building up the unexpanded suffix.
+	expanded := true
+
+LOOP:
+	for len(remain) > 0 {
+		var next string
+		switch tt := remain[0].(type) {
+		case hcl.TraverseRoot:
+			next = tt.Name
+		case hcl.TraverseAttr:
+			next = tt.Name
+		default:
+			diags = diags.Append(&hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  "Invalid address operator",
+				Detail:   "Module address prefix must be followed by dot and then a name.",
+				Subject:  remain[0].SourceRange().Ptr(),
+			})
+			break LOOP
+		}
+
+		if next != "module" {
+			break
+		}
+
+		kwRange := remain[0].SourceRange()
+		remain = remain[1:]
+		if len(remain) == 0 {
+			diags = diags.Append(&hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  "Invalid address operator",
+				Detail:   "Prefix \"module.\" must be followed by a module name.",
+				Subject:  &kwRange,
+			})
+			break
+		}
+
+		var moduleName string
+		switch tt := remain[0].(type) {
+		case hcl.TraverseAttr:
+			moduleName = tt.Name
+		default:
+			diags = diags.Append(&hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  "Invalid address operator",
+				Detail:   "Prefix \"module.\" must be followed by a module name.",
+				Subject:  remain[0].SourceRange().Ptr(),
+			})
+			break LOOP
+		}
+		remain = remain[1:]
+
+		if expanded {
+
+			step := ModuleInstanceStep{
+				Name: moduleName,
+			}
+
+			if len(remain) > 0 {
+				if idx, ok := remain[0].(hcl.TraverseIndex); ok {
+					remain = remain[1:]
+
+					if !idx.Key.IsKnown() {
+						// We'll switch to building up the unexpanded suffix
+						// starting with this step.
+						expanded = false
+						partial.unexpandedSuffix = append(partial.unexpandedSuffix, moduleName)
+						continue
+					}
+
+					switch idx.Key.Type() {
+					case cty.String:
+						step.InstanceKey = StringKey(idx.Key.AsString())
+					case cty.Number:
+						var idxInt int
+						err := gocty.FromCtyValue(idx.Key, &idxInt)
+						if err == nil {
+							step.InstanceKey = IntKey(idxInt)
+						} else {
+							diags = diags.Append(&hcl.Diagnostic{
+								Severity: hcl.DiagError,
+								Summary:  "Invalid address operator",
+								Detail:   fmt.Sprintf("Invalid module index: %s.", err),
+								Subject:  idx.SourceRange().Ptr(),
+							})
+						}
+					default:
+						// Should never happen, because no other types are allowed in traversal indices.
+						diags = diags.Append(&hcl.Diagnostic{
+							Severity: hcl.DiagError,
+							Summary:  "Invalid address operator",
+							Detail:   "Invalid module key: must be either a string or an integer.",
+							Subject:  idx.SourceRange().Ptr(),
+						})
+					}
+				}
+			}
+
+			partial.expandedPrefix = append(partial.expandedPrefix, step)
+			continue
+		}
+
+		// Otherwise, we'll process this as an unexpanded suffix.
+		partial.unexpandedSuffix = append(partial.unexpandedSuffix, moduleName)
+
+		if len(remain) > 0 {
+			if _, ok := remain[0].(hcl.TraverseIndex); ok {
+				// Then we have a module instance key. We're now parsing the
+				// unexpanded suffix of the module address, so we'll just
+				// ignore it.
+				remain = remain[1:]
+			}
+		}
+	}
+
+	var retRemain hcl.Traversal
+	if len(remain) > 0 {
+		retRemain = make(hcl.Traversal, len(remain))
+		copy(retRemain, remain)
+		// The first element here might be either a TraverseRoot or a
+		// TraverseAttr, depending on whether we had a module address on the
+		// front. To make life easier for callers, we'll normalize to always
+		// start with a TraverseRoot.
+		if tt, ok := retRemain[0].(hcl.TraverseAttr); ok {
+			retRemain[0] = hcl.TraverseRoot{
+				Name:     tt.Name,
+				SrcRange: tt.SrcRange,
+			}
+		}
+	}
+
+	return partial, retRemain, diags
 }
 
 func (m ModuleInstance) UnexpandedChild(call ModuleCall) PartialExpandedModule {
@@ -258,6 +413,99 @@ type PartialExpandedResource struct {
 	resource Resource
 }
 
+// ParsePartialExpandedResource parses a resource address traversal and returns
+// a PartialExpandedResource representing the known and unknown parts of the
+// address.
+func ParsePartialExpandedResource(traversal hcl.Traversal) (PartialExpandedResource, hcl.Traversal, tfdiags.Diagnostics) {
+	var diags tfdiags.Diagnostics
+
+	pem, remain, diags := ParsePartialExpandedModule(traversal)
+	if len(remain) == 0 {
+		diags = diags.Append(&hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  "Invalid address",
+			Detail:   "Resource address must be a module address followed by a resource address.",
+			Subject:  traversal.SourceRange().Ptr(),
+		})
+		return PartialExpandedResource{}, nil, diags
+	}
+
+	mode := ManagedResourceMode
+	if remain.RootName() == "data" {
+		mode = DataResourceMode
+		remain = remain[1:]
+	}
+
+	if len(remain) < 2 {
+		diags = diags.Append(&hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  "Invalid address",
+			Detail:   "Resource specification must include a resource type and name.",
+			Subject:  remain.SourceRange().Ptr(),
+		})
+		return PartialExpandedResource{}, nil, diags
+	}
+
+	var typeName, name string
+	switch tt := remain[0].(type) {
+	case hcl.TraverseRoot:
+		typeName = tt.Name
+	case hcl.TraverseAttr:
+		typeName = tt.Name
+	default:
+		switch mode {
+		case ManagedResourceMode:
+			diags = diags.Append(&hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  "Invalid address",
+				Detail:   "A resource type name is required.",
+				Subject:  remain[0].SourceRange().Ptr(),
+			})
+		case DataResourceMode:
+			diags = diags.Append(&hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  "Invalid address",
+				Detail:   "A data source name is required.",
+				Subject:  remain[0].SourceRange().Ptr(),
+			})
+		default:
+			panic("unknown mode")
+		}
+		return PartialExpandedResource{}, nil, diags
+	}
+
+	switch tt := remain[1].(type) {
+	case hcl.TraverseAttr:
+		name = tt.Name
+	default:
+		diags = diags.Append(&hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  "Invalid address",
+			Detail:   "A resource name is required.",
+			Subject:  remain[1].SourceRange().Ptr(),
+		})
+		return PartialExpandedResource{}, nil, diags
+	}
+
+	remain = remain[2:]
+	if len(remain) > 0 {
+		if _, ok := remain[0].(hcl.TraverseIndex); ok {
+			// Then we have a resource instance key. Since, we're building a
+			// PartialExpandedResource, we'll just ignore it.
+			remain = remain[1:]
+		}
+	}
+
+	return PartialExpandedResource{
+		module: pem,
+		resource: Resource{
+			Mode: mode,
+			Type: typeName,
+			Name: name,
+		},
+	}, remain, diags
+}
+
 // UnexpandedResource returns the address of a child resource expressed as a
 // [PartialExpandedResource].
 //
@@ -323,6 +571,16 @@ func (per PartialExpandedResource) MatchesResource(inst AbsResource) bool {
 		return false
 	}
 	return inst.Resource.Equal(per.resource)
+}
+
+// MatchesPartial returns true if the underlying partial module address matches
+// the given partial module address and the resource type and name match the
+// receiver's resource type and name.
+func (per PartialExpandedResource) MatchesPartial(other PartialExpandedResource) bool {
+	if !per.module.MatchesPartial(other.module) {
+		return false
+	}
+	return per.resource.Equal(other.resource)
 }
 
 // AbsResource returns the single [AbsResource] that this address represents

--- a/internal/addrs/partial_expanded_test.go
+++ b/internal/addrs/partial_expanded_test.go
@@ -368,7 +368,7 @@ func TestParsePartialExpandedResource(t *testing.T) {
 
 			partial, rest, diags := ParsePartialExpandedResource(traversal)
 			if len(diags) > 0 {
-
+				t.Fatalf("unexpected diagnostics: %s", diags)
 			}
 
 			if !partial.module.expandedPrefix.Equal(tc.want.module.expandedPrefix) {

--- a/internal/addrs/partial_expanded_test.go
+++ b/internal/addrs/partial_expanded_test.go
@@ -6,6 +6,10 @@ package addrs
 import (
 	"fmt"
 	"testing"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/zclconf/go-cty/cty"
 )
 
 func TestPartialExpandedResourceIsTargetedBy(t *testing.T) {
@@ -109,4 +113,276 @@ func TestPartialExpandedResourceIsTargetedBy(t *testing.T) {
 		})
 	}
 
+}
+
+func TestParsePartialExpandedModule(t *testing.T) {
+
+	// these functions are a bit weird, as the normal parsing supported by
+	// HCL can't put unknown values into the instance keys. So we need to
+	// build the traversals in the same way the thing that is calling these
+	// functions does.
+
+	tcs := []struct {
+		traversal func(t *testing.T) (string, hcl.Traversal)
+		want      PartialExpandedModule
+		remain    int
+	}{
+		{
+			traversal: func(t *testing.T) (string, hcl.Traversal) {
+				addr := "module.mod"
+				traversal, diags := hclsyntax.ParseTraversalAbs([]byte(addr), "", hcl.InitialPos)
+				if len(diags) > 0 {
+					t.Fatalf("unexpected diagnostics: %v", diags)
+				}
+				return addr, traversal
+			},
+			want: PartialExpandedModule{
+				expandedPrefix: ModuleInstance{
+					{
+						Name: "mod",
+					},
+				},
+			},
+			remain: 0,
+		},
+		{
+			traversal: func(t *testing.T) (string, hcl.Traversal) {
+				addr := "module.mod[0]"
+				traversal, diags := hclsyntax.ParseTraversalAbs([]byte(addr), "", hcl.InitialPos)
+				if len(diags) > 0 {
+					t.Fatalf("unexpected diagnostics: %v", diags)
+				}
+				// Hack the key into an unknown value.
+				traversal[2] = hcl.TraverseIndex{
+					Key: cty.UnknownVal(cty.Number),
+				}
+				return "module.mod[*]", traversal
+			},
+			want: PartialExpandedModule{
+				unexpandedSuffix: Module{
+					"mod",
+				},
+			},
+			remain: 0,
+		},
+		{
+			traversal: func(t *testing.T) (string, hcl.Traversal) {
+				addr := "module.child.module.grandchild"
+				traversal, diags := hclsyntax.ParseTraversalAbs([]byte(addr), "", hcl.InitialPos)
+				if len(diags) > 0 {
+					t.Fatalf("unexpected diagnostics: %v", diags)
+				}
+				return addr, traversal
+			},
+			want: PartialExpandedModule{
+				expandedPrefix: ModuleInstance{
+					{
+						Name: "child",
+					},
+					{
+						Name: "grandchild",
+					},
+				},
+			},
+			remain: 0,
+		},
+		{
+			traversal: func(t *testing.T) (string, hcl.Traversal) {
+				addr := "module.child[0].module.grandchild"
+				traversal, diags := hclsyntax.ParseTraversalAbs([]byte(addr), "", hcl.InitialPos)
+				if len(diags) > 0 {
+					t.Fatalf("unexpected diagnostics: %v", diags)
+				}
+				return addr, traversal
+			},
+			want: PartialExpandedModule{
+				expandedPrefix: ModuleInstance{
+					{
+						Name:        "child",
+						InstanceKey: IntKey(0),
+					},
+					{
+						Name: "grandchild",
+					},
+				},
+			},
+			remain: 0,
+		},
+		{
+			traversal: func(t *testing.T) (string, hcl.Traversal) {
+				addr := "module.child[0].module.grandchild"
+				traversal, diags := hclsyntax.ParseTraversalAbs([]byte(addr), "", hcl.InitialPos)
+				if len(diags) > 0 {
+					t.Fatalf("unexpected diagnostics: %v", diags)
+				}
+				traversal[2] = hcl.TraverseIndex{
+					Key: cty.UnknownVal(cty.Number),
+				}
+				return "module.child[*].module.grandchild", traversal
+			},
+			want: PartialExpandedModule{
+				unexpandedSuffix: Module{
+					"child",
+					"grandchild",
+				},
+			},
+			remain: 0,
+		},
+		{
+			traversal: func(t *testing.T) (string, hcl.Traversal) {
+				addr := "module.child.module.grandchild[0]"
+				traversal, diags := hclsyntax.ParseTraversalAbs([]byte(addr), "", hcl.InitialPos)
+				if len(diags) > 0 {
+					t.Fatalf("unexpected diagnostics: %v", diags)
+				}
+				traversal[4] = hcl.TraverseIndex{
+					Key: cty.UnknownVal(cty.Number),
+				}
+				return "module.child.module.grandchild[*]", traversal
+			},
+			want: PartialExpandedModule{
+				expandedPrefix: ModuleInstance{
+					{
+						Name: "child",
+					},
+				},
+				unexpandedSuffix: Module{
+					"grandchild",
+				},
+			},
+			remain: 0,
+		},
+		{
+			traversal: func(t *testing.T) (string, hcl.Traversal) {
+				addr := "module.child.module.grandchild[0].resource_type.resource_name"
+				traversal, diags := hclsyntax.ParseTraversalAbs([]byte(addr), "", hcl.InitialPos)
+				if len(diags) > 0 {
+					t.Fatalf("unexpected diagnostics: %v", diags)
+				}
+				traversal[4] = hcl.TraverseIndex{
+					Key: cty.UnknownVal(cty.Number),
+				}
+				return "module.child.module.grandchild[*].resource_type.resource_name", traversal
+			},
+			want: PartialExpandedModule{
+				expandedPrefix: ModuleInstance{
+					{
+						Name: "child",
+					},
+				},
+				unexpandedSuffix: Module{
+					"grandchild",
+				},
+			},
+			remain: 2,
+		},
+	}
+
+	for _, tc := range tcs {
+		addr, traversal := tc.traversal(t)
+		t.Run(addr, func(t *testing.T) {
+			module, rest, diags := ParsePartialExpandedModule(traversal)
+			if len(diags) > 0 {
+				t.Fatalf("unexpected diagnostics: %s", diags)
+			}
+
+			if !module.expandedPrefix.Equal(tc.want.expandedPrefix) {
+				t.Errorf("got expandedPrefix %v; want %v", module.expandedPrefix, tc.want.expandedPrefix)
+			}
+			if !module.unexpandedSuffix.Equal(tc.want.unexpandedSuffix) {
+				t.Errorf("got unexpandedSuffix %v; want %v", module.unexpandedSuffix, tc.want.unexpandedSuffix)
+			}
+			if len(rest) != tc.remain {
+				t.Errorf("got %d remaining traversals; want %d", len(rest), tc.remain)
+			}
+		})
+	}
+
+}
+
+func TestParsePartialExpandedResource(t *testing.T) {
+
+	tcs := []struct {
+		addr   string
+		want   PartialExpandedResource
+		remain int
+	}{
+		{
+			addr: "resource_type.resource_name",
+			want: PartialExpandedResource{
+				resource: Resource{
+					Mode: ManagedResourceMode,
+					Type: "resource_type",
+					Name: "resource_name",
+				},
+			},
+			remain: 0,
+		},
+		{
+			addr: "module.mod.resource_type.resource_name",
+			want: PartialExpandedResource{
+				module: PartialExpandedModule{
+					expandedPrefix: ModuleInstance{
+						{
+							Name: "mod",
+						},
+					},
+				},
+				resource: Resource{
+					Mode: ManagedResourceMode,
+					Type: "resource_type",
+					Name: "resource_name",
+				},
+			},
+		},
+		{
+			addr: "resource_type.resource_name[0]",
+			want: PartialExpandedResource{
+				resource: Resource{
+					Mode: ManagedResourceMode,
+					Type: "resource_type",
+					Name: "resource_name",
+				},
+			},
+			remain: 0,
+		},
+		{
+			addr: "resource_type.resource_name[0].attr",
+			want: PartialExpandedResource{
+				resource: Resource{
+					Mode: ManagedResourceMode,
+					Type: "resource_type",
+					Name: "resource_name",
+				},
+			},
+			remain: 1,
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.addr, func(t *testing.T) {
+			traversal, traversalDiags := hclsyntax.ParseTraversalAbs([]byte(tc.addr), "", hcl.InitialPos)
+			if len(traversalDiags) > 0 {
+				t.Fatalf("unexpected diagnostics: %v", traversalDiags)
+			}
+
+			partial, rest, diags := ParsePartialExpandedResource(traversal)
+			if len(diags) > 0 {
+
+			}
+
+			if !partial.module.expandedPrefix.Equal(tc.want.module.expandedPrefix) {
+				t.Errorf("got expandedPrefix %v; want %v", partial.module.expandedPrefix, tc.want.module.expandedPrefix)
+			}
+			if !partial.module.unexpandedSuffix.Equal(tc.want.module.unexpandedSuffix) {
+				t.Errorf("got unexpandedSuffix %v; want %v", partial.module.unexpandedSuffix, tc.want.module.unexpandedSuffix)
+			}
+			if !partial.resource.Equal(tc.want.resource) {
+				t.Errorf("got resource %v; want %v", partial.resource, tc.want.resource)
+			}
+			if len(rest) != tc.remain {
+				t.Errorf("got %d remaining traversals; want %d", len(rest), tc.remain)
+			}
+		})
+	}
 }

--- a/internal/states/sync.go
+++ b/internal/states/sync.go
@@ -7,9 +7,10 @@ import (
 	"log"
 	"sync"
 
+	"github.com/zclconf/go-cty/cty"
+
 	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/checks"
-	"github.com/zclconf/go-cty/cty"
 )
 
 // SyncState is a wrapper around State that provides concurrency-safe access to
@@ -51,6 +52,20 @@ func (s *SyncState) Module(addr addrs.ModuleInstance) *Module {
 	ret := s.state.Module(addr).DeepCopy()
 	s.lock.RUnlock()
 	return ret
+}
+
+// ModuleInstances returns the addresses of the module instances currently
+// store within state for the given module.
+func (s *SyncState) ModuleInstances(addr addrs.Module) []addrs.ModuleInstance {
+	s.lock.RLock()
+	ret := s.state.ModuleInstances(addr)
+	s.lock.RUnlock()
+
+	insts := make([]addrs.ModuleInstance, len(ret))
+	for i, inst := range ret {
+		insts[i] = inst.Addr
+	}
+	return insts
 }
 
 // RemoveModule removes the entire state for the given module, taking with

--- a/internal/terraform/context_apply_deferred_test.go
+++ b/internal/terraform/context_apply_deferred_test.go
@@ -2620,6 +2620,280 @@ import {
 			},
 		},
 	}
+
+	unknownImportTo = deferredActionsTest{
+		configs: map[string]string{
+			"main.tf": `
+variable "strings" {
+	type = set(string)
+}
+
+resource "test" "a" {
+	for_each = toset(["a", "b"])
+	name = each.value
+}
+
+import {
+	for_each = var.strings
+	id = each.value
+	to = test.a[each.key]
+}
+`,
+		},
+		stages: []deferredActionsTestStage{
+			{
+				inputs: map[string]cty.Value{
+					"strings": cty.UnknownVal(cty.Set(cty.String)),
+				},
+				wantPlanned: map[string]cty.Value{
+					"a": cty.ObjectVal(map[string]cty.Value{
+						"name":           cty.StringVal("a"),
+						"upstream_names": cty.NullVal(cty.Set(cty.String)),
+						"output":         cty.UnknownVal(cty.String),
+					}),
+					"b": cty.ObjectVal(map[string]cty.Value{
+						"name":           cty.StringVal("b"),
+						"upstream_names": cty.NullVal(cty.Set(cty.String)),
+						"output":         cty.UnknownVal(cty.String),
+					}),
+				},
+				wantActions: make(map[string]plans.Action),
+				wantDeferred: map[string]ExpectedDeferred{
+					// Both should be deferred, as we don't know which one is
+					// being imported.
+					"test.a[\"a\"]": {Reason: providers.DeferredReasonResourceConfigUnknown, Action: plans.Create},
+					"test.a[\"b\"]": {Reason: providers.DeferredReasonResourceConfigUnknown, Action: plans.Create},
+				},
+				wantApplied: make(map[string]cty.Value),
+				wantOutputs: make(map[string]cty.Value),
+			},
+			{
+				inputs: map[string]cty.Value{
+					"strings": cty.SetVal([]cty.Value{cty.StringVal("a")}),
+				},
+				wantPlanned: map[string]cty.Value{
+					"a": cty.ObjectVal(map[string]cty.Value{
+						"name":           cty.StringVal("a"),
+						"upstream_names": cty.NullVal(cty.Set(cty.String)),
+						"output":         cty.StringVal("a"),
+					}),
+					"b": cty.ObjectVal(map[string]cty.Value{
+						"name":           cty.StringVal("b"),
+						"upstream_names": cty.NullVal(cty.Set(cty.String)),
+						"output":         cty.UnknownVal(cty.String),
+					}),
+				},
+				wantDeferred: make(map[string]ExpectedDeferred),
+				wantActions: map[string]plans.Action{
+					"test.a[\"a\"]": plans.NoOp,
+					"test.a[\"b\"]": plans.Create,
+				},
+				wantApplied: map[string]cty.Value{
+					"b": cty.ObjectVal(map[string]cty.Value{
+						"name":           cty.StringVal("b"),
+						"upstream_names": cty.NullVal(cty.Set(cty.String)),
+						"output":         cty.StringVal("b"),
+					}),
+				},
+				wantOutputs: make(map[string]cty.Value),
+				complete:    true,
+			},
+		},
+	}
+
+	unknownImportToExistingState = deferredActionsTest{
+		configs: map[string]string{
+			"main.tf": `
+variable "strings" {
+	type = set(string)
+}
+
+resource "test" "a" {
+	for_each = toset(["a", "b"])
+	name = each.value
+}
+
+import {
+	for_each = var.strings
+	id = each.value
+	to = test.a[each.key]
+}
+`,
+		},
+		state: states.BuildState(func(state *states.SyncState) {
+			state.SetResourceInstanceCurrent(mustResourceInstanceAddr("test.a[\"a\"]"), &states.ResourceInstanceObjectSrc{
+				Status: states.ObjectReady,
+				AttrsJSON: mustParseJson(map[string]interface{}{
+					"name":   "a",
+					"output": "a",
+				}),
+			}, addrs.AbsProviderConfig{
+				Provider: addrs.NewDefaultProvider("test"),
+				Module:   addrs.RootModule,
+			})
+			state.SetResourceInstanceCurrent(mustResourceInstanceAddr("test.a[\"b\"]"), &states.ResourceInstanceObjectSrc{
+				Status: states.ObjectReady,
+				AttrsJSON: mustParseJson(map[string]interface{}{
+					"name":   "b",
+					"output": "b",
+				}),
+			}, addrs.AbsProviderConfig{
+				Provider: addrs.NewDefaultProvider("test"),
+				Module:   addrs.RootModule,
+			})
+		}),
+		stages: []deferredActionsTestStage{
+			{
+				inputs: map[string]cty.Value{
+					"strings": cty.UnknownVal(cty.Set(cty.String)),
+				},
+				wantPlanned: map[string]cty.Value{
+					"a": cty.ObjectVal(map[string]cty.Value{
+						"name":           cty.StringVal("a"),
+						"upstream_names": cty.NullVal(cty.Set(cty.String)),
+						"output":         cty.StringVal("a"),
+					}),
+					"b": cty.ObjectVal(map[string]cty.Value{
+						"name":           cty.StringVal("b"),
+						"upstream_names": cty.NullVal(cty.Set(cty.String)),
+						"output":         cty.StringVal("b"),
+					}),
+				},
+				wantActions: map[string]plans.Action{
+					// In this case, both the resources exist in state so
+					// even though they might be targeted by the unknown import
+					// it is still safe to apply the changes.
+					"test.a[\"a\"]": plans.NoOp,
+					"test.a[\"b\"]": plans.NoOp,
+				},
+				wantDeferred: make(map[string]ExpectedDeferred),
+				wantApplied:  make(map[string]cty.Value),
+				wantOutputs:  make(map[string]cty.Value),
+				complete:     true,
+			},
+			{
+				// The second stage demonstrates the known or unknown status of
+				// the import block doesn't impact the actual behaviour.
+				inputs: map[string]cty.Value{
+					"strings": cty.SetVal([]cty.Value{cty.StringVal("a")}),
+				},
+				wantPlanned: map[string]cty.Value{
+					"a": cty.ObjectVal(map[string]cty.Value{
+						"name":           cty.StringVal("a"),
+						"upstream_names": cty.NullVal(cty.Set(cty.String)),
+						"output":         cty.StringVal("a"),
+					}),
+					"b": cty.ObjectVal(map[string]cty.Value{
+						"name":           cty.StringVal("b"),
+						"upstream_names": cty.NullVal(cty.Set(cty.String)),
+						"output":         cty.StringVal("b"),
+					}),
+				},
+				wantDeferred: make(map[string]ExpectedDeferred),
+				wantActions: map[string]plans.Action{
+					"test.a[\"a\"]": plans.NoOp,
+					"test.a[\"b\"]": plans.NoOp,
+				},
+				wantApplied: make(map[string]cty.Value),
+				wantOutputs: make(map[string]cty.Value),
+				complete:    true,
+			},
+		},
+	}
+
+	unknownImportToPartialExistingState = deferredActionsTest{
+		configs: map[string]string{
+			"main.tf": `
+variable "strings" {
+	type = set(string)
+}
+
+resource "test" "a" {
+	for_each = toset(["a", "b"])
+	name = each.value
+}
+
+import {
+	for_each = var.strings
+	id = each.value
+	to = test.a[each.key]
+}
+`,
+		},
+		state: states.BuildState(func(state *states.SyncState) {
+			state.SetResourceInstanceCurrent(mustResourceInstanceAddr("test.a[\"a\"]"), &states.ResourceInstanceObjectSrc{
+				Status: states.ObjectReady,
+				AttrsJSON: mustParseJson(map[string]interface{}{
+					"name":   "a",
+					"output": "a",
+				}),
+			}, addrs.AbsProviderConfig{
+				Provider: addrs.NewDefaultProvider("test"),
+				Module:   addrs.RootModule,
+			})
+		}),
+		stages: []deferredActionsTestStage{
+			{
+				inputs: map[string]cty.Value{
+					"strings": cty.UnknownVal(cty.Set(cty.String)),
+				},
+				wantPlanned: map[string]cty.Value{
+					"a": cty.ObjectVal(map[string]cty.Value{
+						"name":           cty.StringVal("a"),
+						"upstream_names": cty.NullVal(cty.Set(cty.String)),
+						"output":         cty.StringVal("a"),
+					}),
+					"b": cty.ObjectVal(map[string]cty.Value{
+						"name":           cty.StringVal("b"),
+						"upstream_names": cty.NullVal(cty.Set(cty.String)),
+						"output":         cty.UnknownVal(cty.String),
+					}),
+				},
+				wantActions: map[string]plans.Action{
+					"test.a[\"a\"]": plans.NoOp,
+				},
+				wantDeferred: map[string]ExpectedDeferred{
+					"test.a[\"b\"]": {Reason: providers.DeferredReasonResourceConfigUnknown, Action: plans.Create},
+				},
+				wantApplied: make(map[string]cty.Value),
+				wantOutputs: make(map[string]cty.Value),
+			},
+		},
+	}
+
+	unknownImportReportsMissingConfiguration = deferredActionsTest{
+		configs: map[string]string{
+			"main.tf": `
+variable "strings" {
+	type = set(string)
+}
+
+import {
+	for_each = var.strings
+	id = each.value
+	to = test.a[each.key]
+}
+`,
+		},
+		stages: []deferredActionsTestStage{
+			{
+				inputs: map[string]cty.Value{
+					"strings": cty.UnknownVal(cty.Set(cty.String)),
+				},
+				wantPlanned:  make(map[string]cty.Value),
+				wantActions:  make(map[string]plans.Action),
+				wantDeferred: make(map[string]ExpectedDeferred),
+				wantDiagnostic: func(diags tfdiags.Diagnostics) bool {
+					for _, diag := range diags {
+						if diag.Description().Summary == "Configuration for import target does not exist" {
+							return true
+						}
+					}
+					return false
+				},
+			},
+		},
+	}
 )
 
 func TestContextApply_deferredActions(t *testing.T) {
@@ -2655,6 +2929,10 @@ func TestContextApply_deferredActions(t *testing.T) {
 		"module_deferred_for_each_value":                    moduleDeferredForEachValue,
 		"module_inner_resource_instance_deferred":           moduleInnerResourceInstanceDeferred,
 		"unknown_import_id":                                 unknownImportId,
+		"unknown_import_to":                                 unknownImportTo,
+		"unknown_import_to_existing_state":                  unknownImportToExistingState,
+		"unknown_import_to_partial_existing_state":          unknownImportToPartialExistingState,
+		"unknown_import_reports_missing_configuration":      unknownImportReportsMissingConfiguration,
 	}
 
 	for name, test := range tests {


### PR DESCRIPTION
This PR adds support for unknown `for_each` values within `import` blocks when deferred actions is enabled.

This can result in the `to` argument being essentially unknown. To combat this we parse the `to` argument as a partial resource, and defer all resources that it **might** refer to once the unknown values are resolved.

Any resources that are already in state and might be targeted by a partial `to` address are not deferred. The behaviour of the import block when targeting a resource already in state is simply a no-op. So, when the unknown `to` is eventually resolved and would point to a resource already in state it doesn't matter.

This builds on the work in the previous PR allowing unknown `id` values: #35300. The way we mark a resource as being deferred due to an import block is to simply mark the target ID value as being unknown.