### PR TITLE
deferred actions: fix config generation when importing an unknown resource

### DIFF
--- a/internal/terraform/context_apply_deferred_test.go
+++ b/internal/terraform/context_apply_deferred_test.go
@@ -2621,6 +2621,36 @@ import {
 		},
 	}
 
+	unknownImportDefersConfigGeneration = deferredActionsTest{
+		configs: map[string]string{
+			"main.tf": `
+variable "id" {
+	type = string
+}
+
+import {
+	id = var.id
+	to = test.a
+}
+`,
+		},
+		stages: []deferredActionsTestStage{
+			{
+				buildOpts: func(opts *PlanOpts) {
+					opts.GenerateConfigPath = "generated.tf"
+				},
+				inputs: map[string]cty.Value{
+					"id": cty.UnknownVal(cty.String),
+				},
+				wantPlanned: make(map[string]cty.Value),
+				wantActions: make(map[string]plans.Action),
+				wantDeferred: map[string]ExpectedDeferred{
+					"test.a": {Reason: providers.DeferredReasonResourceConfigUnknown, Action: plans.NoOp},
+				},
+			},
+		},
+	}
+
 	unknownImportTo = deferredActionsTest{
 		configs: map[string]string{
 			"main.tf": `
@@ -2929,6 +2959,7 @@ func TestContextApply_deferredActions(t *testing.T) {
 		"module_deferred_for_each_value":                    moduleDeferredForEachValue,
 		"module_inner_resource_instance_deferred":           moduleInnerResourceInstanceDeferred,
 		"unknown_import_id":                                 unknownImportId,
+		"unknown_import_defers_config_generation":           unknownImportDefersConfigGeneration,
 		"unknown_import_to":                                 unknownImportTo,
 		"unknown_import_to_existing_state":                  unknownImportToExistingState,
 		"unknown_import_to_partial_existing_state":          unknownImportToPartialExistingState,


### PR DESCRIPTION
This PR fixes config generation when importing a resource with an unknown ID.

Previously, we would return an error and then crash when generating config for a resource with an unknown import ID. This PR updates the planning process so it exits early with a dummy value instead of attempting to validate configuration that doesn't exist.

The config will be properly generated in a follow up plan when the import ID is known.
