### PR TITLE
deferred actions: always enable deferred actions in stacks

### DIFF
--- a/internal/stacks/stackruntime/internal/stackeval/component.go
+++ b/internal/stacks/stackruntime/internal/stackeval/component.go
@@ -167,17 +167,9 @@ func (c *Component) CheckInstances(ctx context.Context, phase EvalPhase) (map[ad
 				return instancesResult[*ComponentInstance]{}, diags
 			}
 
-			allowUnknowns := true
-			if c.main.Planning() {
-				// We'll set this to false during planning if deferrals are not
-				// allowed. It's fine to always be true during apply, as this
-				// would have failed during planning if it was not allowed.
-				allowUnknowns = c.main.PlanningOpts().DeferralAllowed
-			}
-
 			result := instancesMap(forEachVal, func(ik addrs.InstanceKey, rd instances.RepetitionData) *ComponentInstance {
 				return newComponentInstance(c, ik, rd)
-			}, allowUnknowns)
+			})
 
 			addrs := make([]stackaddrs.AbsComponentInstance, 0, len(result.insts))
 			for _, ci := range result.insts {

--- a/internal/stacks/stackruntime/internal/stackeval/component_instance.go
+++ b/internal/stacks/stackruntime/internal/stackeval/component_instance.go
@@ -604,7 +604,7 @@ func (c *ComponentInstance) CheckModuleTreePlan(ctx context.Context) (*plans.Pla
 				Mode:                       stackPlanOpts.PlanningMode,
 				SetVariables:               inputValues,
 				ExternalProviders:          providerClients,
-				DeferralAllowed:            stackPlanOpts.DeferralAllowed,
+				DeferralAllowed:            true,
 				ExternalDependencyDeferred: deferred,
 
 				// This is set by some tests but should not be used in main code.

--- a/internal/stacks/stackruntime/internal/stackeval/for_each.go
+++ b/internal/stacks/stackruntime/internal/stackeval/for_each.go
@@ -153,7 +153,7 @@ func evaluateForEachExpr(ctx context.Context, expr hcl.Expression, phase EvalPha
 // If maybeForEach value is non-nil but not a valid value produced by
 // [evaluateForEachExpr] then the behavior is unpredictable, including the
 // possibility of a panic.
-func instancesMap[T any](maybeForEachVal cty.Value, makeInst func(addrs.InstanceKey, instances.RepetitionData) T, allowsUnknown bool) instancesResult[T] {
+func instancesMap[T any](maybeForEachVal cty.Value, makeInst func(addrs.InstanceKey, instances.RepetitionData) T) instancesResult[T] {
 	switch {
 	case maybeForEachVal == cty.NilVal:
 		// No for_each expression at all, then. We have exactly one instance
@@ -162,7 +162,7 @@ func instancesMap[T any](maybeForEachVal cty.Value, makeInst func(addrs.Instance
 
 	case !maybeForEachVal.IsKnown():
 		// This is temporary to gradually rollout support for unknown for_each values
-		return instancesResult[T]{nil, allowsUnknown}
+		return instancesResult[T]{nil, true}
 
 	default:
 		// Otherwise we should be able to assume the value is valid per the

--- a/internal/stacks/stackruntime/internal/stackeval/for_each_test.go
+++ b/internal/stacks/stackruntime/internal/stackeval/for_each_test.go
@@ -451,22 +451,13 @@ func TestInstancesMap(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.Name, func(t *testing.T) {
-			t.Run("unknown for_each supported", func(t *testing.T) {
-				got := instancesMap(test.Input, makeObj, true)
-				if got.unknown != test.Want.UnknownValue {
-					t.Errorf("wrong unknown value\ngot:  %#v\nwant: %#v", got.unknown, test.Want.UnknownValue)
-				}
-				if diff := cmp.Diff(test.Want.UnknownForEachSupported, got.insts, ctydebug.CmpOptions); diff != "" {
-					t.Errorf("wrong result\ninput: %#v\n%s", test.Input, diff)
-				}
-			})
-			t.Run("unknown for_each unsupported", func(t *testing.T) {
-				got := instancesMap(test.Input, makeObj, false)
-				assertFalse(t, got.unknown)
-				if diff := cmp.Diff(test.Want.UnknownForEachUnsupported, got.insts, ctydebug.CmpOptions); diff != "" {
-					t.Errorf("wrong result\ninput: %#v\n%s", test.Input, diff)
-				}
-			})
+			got := instancesMap(test.Input, makeObj)
+			if got.unknown != test.Want.UnknownValue {
+				t.Errorf("wrong unknown value\ngot:  %#v\nwant: %#v", got.unknown, test.Want.UnknownValue)
+			}
+			if diff := cmp.Diff(test.Want.UnknownForEachSupported, got.insts, ctydebug.CmpOptions); diff != "" {
+				t.Errorf("wrong result\ninput: %#v\n%s", test.Input, diff)
+			}
 		})
 	}
 }

--- a/internal/stacks/stackruntime/internal/stackeval/planning.go
+++ b/internal/stacks/stackruntime/internal/stackeval/planning.go
@@ -16,13 +16,6 @@ import (
 type PlanOpts struct {
 	PlanningMode plans.Mode
 
-	// DeferralAllowed is the counterpart of the field of the same name on
-	// terraform.PlanOpts.
-	// TODO: We actually want stacks to always allow deferred
-	// actions, but the feature needs more time in the oven before
-	// it can be enabled without regressions.
-	DeferralAllowed bool
-
 	InputVariableValues map[stackaddrs.InputVariable]ExternalInputValue
 
 	ProviderFactories ProviderFactories

--- a/internal/stacks/stackruntime/internal/stackeval/planning_test.go
+++ b/internal/stacks/stackruntime/internal/stackeval/planning_test.go
@@ -595,12 +595,6 @@ func TestPlanning_DeferredChangesPropagation(t *testing.T) {
 	cfg := testStackConfig(t, "planning", "deferred_changes_propagation")
 	main := NewForPlanning(cfg, stackstate.NewState(), PlanOpts{
 		PlanningMode: plans.NormalMode,
-		// TEMP: Currently there's no way in normal operation to set this to
-		// true in the PlanOpts, because it would regress other features. So,
-		// the test has to set it manually. In the future, deferred actions will
-		// always be enabled for stacks, and we'll remove this option from the
-		// stackeval.PlanOpts struct.
-		DeferralAllowed: true,
 		InputVariableValues: map[stackaddrs.InputVariable]ExternalInputValue{
 			// This causes the first component to have a module whose
 			// instance count isn't known yet.

--- a/internal/stacks/stackruntime/internal/stackeval/provider.go
+++ b/internal/stacks/stackruntime/internal/stackeval/provider.go
@@ -170,17 +170,9 @@ func (p *Provider) CheckInstances(ctx context.Context, phase EvalPhase) (map[add
 				return instancesResult[*ProviderInstance]{}, diags
 			}
 
-			allowUnknowns := true
-			if p.main.Planning() {
-				// We'll set this to false during planning if deferrals are not
-				// allowed. It's fine to always be true during apply, as this
-				// would have failed during planning if it was not allowed.
-				allowUnknowns = p.main.PlanningOpts().DeferralAllowed
-			}
-
 			return instancesMap(forEachVal, func(ik addrs.InstanceKey, rd instances.RepetitionData) *ProviderInstance {
 				return newProviderInstance(p, ik, rd)
-			}, allowUnknowns), diags
+			}), diags
 		},
 	)
 	return result.insts, result.unknown, diags

--- a/internal/stacks/stackruntime/internal/stackeval/provider_instance.go
+++ b/internal/stacks/stackruntime/internal/stackeval/provider_instance.go
@@ -233,11 +233,6 @@ func (p *ProviderInstance) CheckClient(ctx context.Context, phase EvalPhase) (pr
 				return diags
 			})
 
-			allowUnknowns := true
-			if p.main.Planning() {
-				allowUnknowns = p.main.PlanningOpts().DeferralAllowed
-			}
-
 			// TODO: Some providers will malfunction if the caller doesn't
 			// fetch their schema at least once before use. That's not something
 			// the provider protocol promises but it's an implementation
@@ -256,7 +251,7 @@ func (p *ProviderInstance) CheckClient(ctx context.Context, phase EvalPhase) (pr
 				TerraformVersion: version.SemVer.String(),
 				Config:           unmarkedArgs,
 				ClientCapabilities: providers.ClientCapabilities{
-					DeferralAllowed: allowUnknowns,
+					DeferralAllowed: true,
 				},
 			})
 			diags = diags.Append(resp.Diagnostics)

--- a/internal/stacks/stackruntime/internal/stackeval/stack_call.go
+++ b/internal/stacks/stackruntime/internal/stackeval/stack_call.go
@@ -160,17 +160,9 @@ func (c *StackCall) CheckInstances(ctx context.Context, phase EvalPhase) (map[ad
 				return instancesResult[*StackCallInstance]{}, diags
 			}
 
-			allowUnknowns := true
-			if c.main.Planning() {
-				// We'll set this to false during planning if deferrals are not
-				// allowed. It's fine to always be true during apply, as this
-				// would have failed during planning if it was not allowed.
-				allowUnknowns = c.main.PlanningOpts().DeferralAllowed
-			}
-
 			return instancesMap(forEachVal, func(ik addrs.InstanceKey, rd instances.RepetitionData) *StackCallInstance {
 				return newStackCallInstance(c, ik, rd)
-			}, allowUnknowns), diags
+			}), diags
 		},
 	)
 	return result.insts, result.unknown, diags

--- a/internal/stacks/stackruntime/plan.go
+++ b/internal/stacks/stackruntime/plan.go
@@ -48,7 +48,6 @@ func Plan(ctx context.Context, req *PlanRequest, resp *PlanResponse) {
 		ProviderFactories:   req.ProviderFactories,
 
 		ForcePlanTimestamp: req.ForcePlanTimestamp,
-		DeferralAllowed:    req.DeferralAllowed,
 	})
 	main.AllowLanguageExperiments(req.ExperimentsAllowed)
 	main.PlanAll(ctx, stackeval.PlanOutput{
@@ -101,7 +100,6 @@ type PlanRequest struct {
 	ForcePlanTimestamp *time.Time
 
 	ExperimentsAllowed bool
-	DeferralAllowed    bool
 }
 
 // PlanResponse is used by [Plan] to describe the results of planning.

--- a/internal/stacks/stackruntime/plan_test.go
+++ b/internal/stacks/stackruntime/plan_test.go
@@ -1603,12 +1603,6 @@ func TestPlanWithDeferredResource(t *testing.T) {
 				Value: cty.BoolVal(true),
 			},
 		},
-		// TEMP: Currently there's no way in normal operation to set this to
-		// true in the PlanOpts, because it would regress other features. So,
-		// the test has to set it manually. In the future, deferred actions will
-		// always be enabled for stacks, and we'll remove this option from the
-		// stackeval.PlanOpts struct.
-		DeferralAllowed: true,
 	}
 	resp := PlanResponse{
 		PlannedChanges: changesCh,
@@ -1751,7 +1745,6 @@ func TestPlanWithDeferredComponentForEach(t *testing.T) {
 				DefRange: tfdiags.SourceRange{},
 			},
 		},
-		DeferralAllowed: true,
 	}
 	resp := PlanResponse{
 		PlannedChanges: changesCh,
@@ -1982,7 +1975,6 @@ func TestPlanWithDeferredComponentReferences(t *testing.T) {
 				DefRange: tfdiags.SourceRange{},
 			},
 		},
-		DeferralAllowed: true,
 	}
 	resp := PlanResponse{
 		PlannedChanges: changesCh,
@@ -2225,7 +2217,6 @@ func TestPlanWithDeferredEmbeddedStackForEach(t *testing.T) {
 				DefRange: tfdiags.SourceRange{},
 			},
 		},
-		DeferralAllowed: true,
 	}
 	resp := PlanResponse{
 		PlannedChanges: changesCh,
@@ -2361,7 +2352,6 @@ func TestPlanWithDeferredEmbeddedStackAndComponentForEach(t *testing.T) {
 				DefRange: tfdiags.SourceRange{},
 			},
 		},
-		DeferralAllowed: true,
 	}
 	resp := PlanResponse{
 		PlannedChanges: changesCh,
@@ -2550,7 +2540,6 @@ func TestPlanWithDeferredProviderForEach(t *testing.T) {
 				DefRange: tfdiags.SourceRange{},
 			},
 		},
-		DeferralAllowed: true,
 	}
 	resp := PlanResponse{
 		PlannedChanges: changesCh,


### PR DESCRIPTION
This PR turns on deferred actions for all Stacks operations. Currently, it was only enabled within the specific tests that required it. Now that implementation is (nearly) complete, we'll enable this for everything. This means that in the next release of Terraform Core, stacks will start to see deferred actions in everything.