### PR TITLE
Check lock file diagnostics in `mirror` command

### DIFF
--- a/internal/command/e2etest/providers_mirror_test.go
+++ b/internal/command/e2etest/providers_mirror_test.go
@@ -19,78 +19,97 @@ import (
 // interacts directly with Terraform Registry and the full details of that are
 // tricky to mock. Such a mock is _possible_, but we're using e2etest as a
 // compromise for now to keep these tests relatively simple.
-
 func TestTerraformProvidersMirror(t *testing.T) {
-	testTerraformProvidersMirror(t, "terraform-providers-mirror", "")
-}
-
-func TestTerraformProvidersMirrorWithLockFile(t *testing.T) {
-	testTerraformProvidersMirror(t, "terraform-providers-mirror-with-lock-file", "")
-}
-
-func TestTerraformProvidersMirrorWithBrokenLockFile(t *testing.T) {
-	testTerraformProvidersMirror(t, "terraform-providers-mirror-with-broken-lock-file", "Inconsistent dependency lock file")
-}
-
-func testTerraformProvidersMirror(t *testing.T, fixture string, errMsg string) {
 	// This test reaches out to releases.hashicorp.com to download the
 	// template and null providers, so it can only run if network access is
 	// allowed.
 	skipIfCannotAccessNetwork(t)
 
-	outputDir := t.TempDir()
-	t.Logf("creating mirror directory in %s", outputDir)
+	for _, test := range []struct {
+		name string
+		args []string
+		err  string
+	}{
+		{
+			name: "terraform-providers-mirror",
+			args: []string{"-platform=linux_amd64", "-platform=windows_386"},
+		},
+		{
+			name: "terraform-providers-mirror-with-lock-file",
+			args: []string{"-platform=linux_amd64", "-platform=windows_386"},
+		},
+		{
+			// should ignore lock file
+			name: "terraform-providers-mirror-with-broken-lock-file",
+			args: []string{"-platform=linux_amd64", "-platform=windows_386", "-lock-file=false"},
+		},
+		{
+			name: "terraform-providers-mirror-with-broken-lock-file",
+			args: []string{"-platform=linux_amd64", "-platform=windows_386", "-lock-file=true"},
+			err:  "Inconsistent dependency lock file",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			outputDir := t.TempDir()
+			t.Logf("creating mirror directory in %s", outputDir)
 
-	fixturePath := filepath.Join("testdata", fixture)
-	tf := e2e.NewBinary(t, terraformBin, fixturePath)
+			fixturePath := filepath.Join("testdata", test.name)
+			tf := e2e.NewBinary(t, terraformBin, fixturePath)
 
-	stdout, stderr, err := tf.Run("providers", "mirror", "-platform=linux_amd64", "-platform=windows_386", outputDir)
-	if errMsg != "" {
-		if !strings.Contains(stderr, errMsg) {
-			t.Fatalf("expected error %q, got %q\n", errMsg, stderr)
-		}
-		return
-	}
+			args := []string{"providers", "mirror"}
+			args = append(args, test.args...)
+			args = append(args, outputDir)
 
-	if err != nil {
-		t.Fatalf("unexpected error: %s\nstdout:\n%s\nstderr:\n%s", err, stdout, stderr)
-	}
+			stdout, stderr, err := tf.Run(args...)
+			if test.err != "" {
+				if !strings.Contains(stderr, test.err) {
+					t.Fatalf("expected error %q, got %q\n", test.err, stderr)
+				}
+				return
+			}
 
-	// The test fixture includes exact version constraints for the two
-	// providers it depends on so that the following should remain stable.
-	// In the (unlikely) event that these particular versions of these
-	// providers are removed from the registry, this test will start to fail.
-	want := []string{
-		"registry.terraform.io/hashicorp/null/2.1.0.json",
-		"registry.terraform.io/hashicorp/null/index.json",
-		"registry.terraform.io/hashicorp/null/terraform-provider-null_2.1.0_linux_amd64.zip",
-		"registry.terraform.io/hashicorp/null/terraform-provider-null_2.1.0_windows_386.zip",
-		"registry.terraform.io/hashicorp/template/2.1.1.json",
-		"registry.terraform.io/hashicorp/template/index.json",
-		"registry.terraform.io/hashicorp/template/terraform-provider-template_2.1.1_linux_amd64.zip",
-		"registry.terraform.io/hashicorp/template/terraform-provider-template_2.1.1_windows_386.zip",
-	}
-	var got []string
-	walkErr := filepath.Walk(outputDir, func(path string, info os.FileInfo, err error) error {
-		if err != nil {
-			return err
-		}
-		if info.IsDir() {
-			return nil // we only care about leaf files for this test
-		}
-		relPath, err := filepath.Rel(outputDir, path)
-		if err != nil {
-			return err
-		}
-		got = append(got, filepath.ToSlash(relPath))
-		return nil
-	})
-	if walkErr != nil {
-		t.Fatal(walkErr)
-	}
-	sort.Strings(got)
+			if err != nil {
+				t.Fatalf("unexpected error: %s\nstdout:\n%s\nstderr:\n%s", err, stdout, stderr)
+			}
 
-	if diff := cmp.Diff(want, got); diff != "" {
-		t.Errorf("unexpected files in result\n%s", diff)
+			// The test fixture includes exact version constraints for the two
+			// providers it depends on so that the following should remain stable.
+			// In the (unlikely) event that these particular versions of these
+			// providers are removed from the registry, this test will start to fail.
+			want := []string{
+				"registry.terraform.io/hashicorp/null/2.1.0.json",
+				"registry.terraform.io/hashicorp/null/index.json",
+				"registry.terraform.io/hashicorp/null/terraform-provider-null_2.1.0_linux_amd64.zip",
+				"registry.terraform.io/hashicorp/null/terraform-provider-null_2.1.0_windows_386.zip",
+				"registry.terraform.io/hashicorp/template/2.1.1.json",
+				"registry.terraform.io/hashicorp/template/index.json",
+				"registry.terraform.io/hashicorp/template/terraform-provider-template_2.1.1_linux_amd64.zip",
+				"registry.terraform.io/hashicorp/template/terraform-provider-template_2.1.1_windows_386.zip",
+			}
+			var got []string
+			walkErr := filepath.Walk(outputDir, func(path string, info os.FileInfo, err error) error {
+				if err != nil {
+					return err
+				}
+				if info.IsDir() {
+					return nil // we only care about leaf files for this test
+				}
+				relPath, err := filepath.Rel(outputDir, path)
+				if err != nil {
+					return err
+				}
+				got = append(got, filepath.ToSlash(relPath))
+				return nil
+			})
+			if walkErr != nil {
+				t.Fatal(walkErr)
+			}
+			sort.Strings(got)
+
+			if diff := cmp.Diff(want, got); diff != "" {
+				t.Errorf("unexpected files in result\n%s", diff)
+			}
+
+		})
 	}
 }

--- a/internal/command/e2etest/testdata/terraform-providers-mirror-with-broken-lock-file/.terraform.lock.hcl
+++ b/internal/command/e2etest/testdata/terraform-providers-mirror-with-broken-lock-file/.terraform.lock.hcl
@@ -1,0 +1,44 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/template" {
+  version     = "2.1.1"
+  constraints = "2.1.1"
+  hashes = [
+    "h1:fBNBluCX4pWlYEw5ZyCTHB00E+3BDSe7GjRzF1ojcvU=",
+    "h1:x2/zuJFN/oOUpE1C1nSk4n86AA2zASOyy2BUdFYcpXw=",
+    "zh:05fddf3cacb607f623c2b221c3e9ab724079deca0b703b2738e9d55c10e31717",
+    "zh:1a250b29274f3e340ea775bf9bd57476e982bca1fb4b59343fb3126e75dfd85c",
+    "zh:284735b9bd0e416ec02c0844e7f4ebbd4b5744140a21606e33f16eb14640cbf1",
+    "zh:2e9d246094ac8a68951015d40f42145e795b31d7c84fee20fa9f997b3d428906",
+    "zh:65e8e73860662a0c0698c8a8d35c857302f1fe3f41947e7c048c49a541a9c7f1",
+    "zh:70dacd22d0c93b2000948c06ded67fa147d992a0353737438f24a61e3f956c41",
+    "zh:aa1a0321e79e08ffb52789ab0af3896c493d436de7396d154d09a0be7d5d50e1",
+    "zh:bea4c276c4df9d117f19c4266d060db9b48c865ac7a71d2e77a27866c19bfaf5",
+    "zh:de04cb0cb046dad184f5bb783659cf98d88c6798db038cbf5a2c3c08e853d444",
+    "zh:de3c45a4fa1f756aa4db3350c021d1c0f9b23640cff77e0ba4df4eeb8eae957f",
+    "zh:e3cf2db204f64ad4e288af00fabc6a8af13a6687aba60a7e1ce0ea215a9580b1",
+    "zh:f795833225207d2eee022b91d26bee18d5e518e70912dd7a1d2a0eff2cbe4f1d",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/broken" {
+  version     = "2.1.1"
+  constraints = "2.1.1"
+  hashes = [
+    "h1:fBNBluCX4pWlYEw5ZyCTHB00E+3BDSe7GjRzF1ojcvU=",
+    "h1:x2/zuJFN/oOUpE1C1nSk4n86AA2zASOyy2BUdFYcpXw=",
+    "zh:05fddf3cacb607f623c2b221c3e9ab724079deca0b703b2738e9d55c10e31717",
+    "zh:1a250b29274f3e340ea775bf9bd57476e982bca1fb4b59343fb3126e75dfd85c",
+    "zh:284735b9bd0e416ec02c0844e7f4ebbd4b5744140a21606e33f16eb14640cbf1",
+    "zh:2e9d246094ac8a68951015d40f42145e795b31d7c84fee20fa9f997b3d428906",
+    "zh:65e8e73860662a0c0698c8a8d35c857302f1fe3f41947e7c048c49a541a9c7f1",
+    "zh:70dacd22d0c93b2000948c06ded67fa147d992a0353737438f24a61e3f956c41",
+    "zh:aa1a0321e79e08ffb52789ab0af3896c493d436de7396d154d09a0be7d5d50e1",
+    "zh:bea4c276c4df9d117f19c4266d060db9b48c865ac7a71d2e77a27866c19bfaf5",
+    "zh:de04cb0cb046dad184f5bb783659cf98d88c6798db038cbf5a2c3c08e853d444",
+    "zh:de3c45a4fa1f756aa4db3350c021d1c0f9b23640cff77e0ba4df4eeb8eae957f",
+    "zh:e3cf2db204f64ad4e288af00fabc6a8af13a6687aba60a7e1ce0ea215a9580b1",
+    "zh:f795833225207d2eee022b91d26bee18d5e518e70912dd7a1d2a0eff2cbe4f1d",
+  ]
+}

--- a/internal/command/e2etest/testdata/terraform-providers-mirror-with-broken-lock-file/terraform-providers-mirror.tf
+++ b/internal/command/e2etest/testdata/terraform-providers-mirror-with-broken-lock-file/terraform-providers-mirror.tf
@@ -1,0 +1,7 @@
+terraform {
+  required_providers {
+    template  = { source = "hashicorp/template" }
+    null      = { source = "hashicorp/null" }
+    terraform = { source = "terraform.io/builtin/terraform" }
+  }
+}

--- a/internal/command/e2etest/testdata/terraform-providers-mirror-with-broken-lock-file/terraform-providers-mirror.tf
+++ b/internal/command/e2etest/testdata/terraform-providers-mirror-with-broken-lock-file/terraform-providers-mirror.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
-    template  = { source = "hashicorp/template" }
-    null      = { source = "hashicorp/null" }
+    template  = { version = "2.1.1" }
+    null      = { source = "hashicorp/null", version = "2.1.0" }
     terraform = { source = "terraform.io/builtin/terraform" }
   }
 }

--- a/internal/command/providers_mirror.go
+++ b/internal/command/providers_mirror.go
@@ -88,12 +88,6 @@ func (c *ProvidersMirrorCommand) Run(args []string) int {
 	lockedDeps, lockedDepsDiags := c.Meta.lockedDependencies()
 	diags = diags.Append(lockedDepsDiags)
 
-	// If we have any error diagnostics already then we won't proceed further.
-	if diags.HasErrors() {
-		c.showDiagnostics(diags)
-		return 1
-	}
-
 	// If lock file is present, validate it against configuration
 	if !lockedDeps.Empty() {
 		if errs := config.VerifyDependencySelections(lockedDeps); len(errs) > 0 {
@@ -103,6 +97,12 @@ func (c *ProvidersMirrorCommand) Run(args []string) int {
 				fmt.Sprintf("To update the locked dependency selections to match a changed configuration, run:\n  terraform init -upgrade\n got:%v", errs),
 			))
 		}
+	}
+
+	// If we have any error diagnostics already then we won't proceed further.
+	if diags.HasErrors() {
+		c.showDiagnostics(diags)
+		return 1
 	}
 
 	// Unlike other commands, this command always consults the origin registry

--- a/internal/command/providers_mirror.go
+++ b/internal/command/providers_mirror.go
@@ -384,5 +384,10 @@ Options:
                      Linux operating system running on an AMD64 or x86_64
                      CPU. Each provider is available only for a limited
                      set of target platforms.
+
+  -lock-file=false  Ignore the provider lock file when fetching providers.
+                    By default the mirror command will use the version info
+                    in the lock file if the configuration directory has been
+                    previously initialized.
 `
 }

--- a/website/docs/cli/commands/providers/mirror.mdx
+++ b/website/docs/cli/commands/providers/mirror.mdx
@@ -55,6 +55,10 @@ This command supports the following additional option:
   architecture. For example, `linux_amd64` selects the Linux operating system
   running on an AMD64 or x86_64 CPU.
 
+* `-lock-file=false` - Ignore the provider lock file when fetching providers.
+By default the mirror command will use the version info in the lock file if the
+configuration directory has been previously initialized.
+
 You can run `terraform providers mirror` again on an existing mirror directory
 to update it with new packages. For example, you can add packages for a new
 target platform by re-running the command with the desired new `-platform=...`


### PR DESCRIPTION
The lock file diagnostic were not being checked in the mirror command, so an incomplete or broken lock file might cause the cli to crash.

Fixes #35318