### PR TITLE
Remove link to deprecated tutorial

### DIFF
--- a/website/docs/language/providers/requirements.mdx
+++ b/website/docs/language/providers/requirements.mdx
@@ -12,8 +12,6 @@ Terraform configurations must declare which providers they require, so that
 Terraform can install and use them. This page documents how to declare providers
 so Terraform can install them.
 
-> **Hands-on:** Try the [Perform CRUD Operations with Providers](/terraform/tutorials/providers/provider-use) tutorial.
-
 Additionally, some providers require configuration (like endpoint URLs or cloud
 regions) before they can be used. The [Provider
 Configuration](/terraform/language/providers/configuration) page documents how


### PR DESCRIPTION
Fixes #35317 

Remove callout to deprecated tutorial in provider requirements doc