### PR TITLE
1.9 Backport - Remove link to deprecated tutorial (#35326)

### DIFF
--- a/website/docs/language/providers/requirements.mdx
+++ b/website/docs/language/providers/requirements.mdx
@@ -12,8 +12,6 @@ Terraform configurations must declare which providers they require, so that
 Terraform can install and use them. This page documents how to declare providers
 so Terraform can install them.
 
-> **Hands-on:** Try the [Perform CRUD Operations with Providers](/terraform/tutorials/providers/provider-use) tutorial.
-
 Additionally, some providers require configuration (like endpoint URLs or cloud
 regions) before they can be used. The [Provider
 Configuration](/terraform/language/providers/configuration) page documents how


### PR DESCRIPTION
Backport of #35326 to 1.9

Manual backport as an error was encountered with the backport action.