### PR TITLE
stacks: applyable status should be dependent on applyable components

### DIFF
--- a/internal/rpcapi/stacks_test.go
+++ b/internal/rpcapi/stacks_test.go
@@ -288,13 +288,13 @@ func TestStacksPlanStackChanges(t *testing.T) {
 				PlannedChange: &terraform1.PlannedChange{
 					Raw: []*anypb.Any{
 						mustMarshalAnyPb(&tfstackdata1.PlanApplyable{
-							Applyable: true,
+							Applyable: false,
 						}),
 					},
 					Descriptions: []*terraform1.PlannedChange_ChangeDescription{
 						{
 							Description: &terraform1.PlannedChange_ChangeDescription_PlanApplyable{
-								PlanApplyable: true,
+								PlanApplyable: false,
 							},
 						},
 					},

--- a/internal/stacks/stackruntime/internal/stackeval/stack.go
+++ b/internal/stacks/stackruntime/internal/stackeval/stack.go
@@ -575,7 +575,9 @@ func (s *Stack) PlanChanges(ctx context.Context) ([]stackplan.PlannedChange, tfd
 
 		// TODO: For now we just assume that all values are being created.
 		// Once we have a prior state we should compare with that to
-		// produce accurate change actions.
+		// produce accurate change actions. Also, once outputs are stored in
+		// state, we should update the definition of Applyable for a stack to
+		// reflect updates to outputs making a stack "applyable".
 
 		v, markses := v.UnmarkDeepWithPaths()
 		sensitivePaths, otherMarkses := marks.PathsWithMark(markses, marks.Sensitive)

--- a/internal/stacks/stackruntime/plan_test.go
+++ b/internal/stacks/stackruntime/plan_test.go
@@ -333,7 +333,7 @@ func TestPlanWithVariableDefaults(t *testing.T) {
 
 			wantChanges := []stackplan.PlannedChange{
 				&stackplan.PlannedChangeApplyable{
-					Applyable: true,
+					Applyable: false,
 				},
 				&stackplan.PlannedChangeHeader{
 					TerraformVersion: version.SemVer,
@@ -559,7 +559,7 @@ func TestPlanVariableOutputRoundtripNested(t *testing.T) {
 
 	wantChanges := []stackplan.PlannedChange{
 		&stackplan.PlannedChangeApplyable{
-			Applyable: true,
+			Applyable: false,
 		},
 		&stackplan.PlannedChangeHeader{
 			TerraformVersion: version.SemVer,
@@ -1622,12 +1622,7 @@ func TestPlanWithDeferredResource(t *testing.T) {
 
 	wantChanges := []stackplan.PlannedChange{
 		&stackplan.PlannedChangeApplyable{
-			// It's slightly confusing that this is true, but the only component
-			// is not applyable. This is because this is based on the presence
-			// of any diagnostics, while the component is not applyable because
-			// it has no pending changes. This difference seems to be
-			// deliberate. (TODO(TF-15445): Consider revisiting this.)
-			Applyable: true,
+			Applyable: false,
 		},
 		&stackplan.PlannedChangeComponentInstance{
 			Addr: stackaddrs.Absolute(
@@ -2236,7 +2231,7 @@ func TestPlanWithDeferredEmbeddedStackForEach(t *testing.T) {
 
 	wantChanges := []stackplan.PlannedChange{
 		&stackplan.PlannedChangeApplyable{
-			Applyable: true,
+			Applyable: false,
 		},
 		&stackplan.PlannedChangeHeader{
 			TerraformVersion: version.SemVer,
@@ -2371,7 +2366,7 @@ func TestPlanWithDeferredEmbeddedStackAndComponentForEach(t *testing.T) {
 
 	wantChanges := []stackplan.PlannedChange{
 		&stackplan.PlannedChangeApplyable{
-			Applyable: true,
+			Applyable: false,
 		},
 		&stackplan.PlannedChangeHeader{
 			TerraformVersion: version.SemVer,
@@ -2559,7 +2554,7 @@ func TestPlanWithDeferredProviderForEach(t *testing.T) {
 
 	wantChanges := []stackplan.PlannedChange{
 		&stackplan.PlannedChangeApplyable{
-			Applyable: true,
+			Applyable: false,
 		},
 		&stackplan.PlannedChangeComponentInstance{
 			Addr: stackaddrs.Absolute(


### PR DESCRIPTION
This PR updates the logic for deciding whether an overall stack is "applyable" so that it takes into account the applyable status of all component instances.

Previously, a stack was "applyable" as long as it had no error diagnostics. Now, a stack is applyable if it (a) has no error diagnostics and (b) at least one component is "applyable".

Finally, stack outputs are not currently stored as part of the state of a stack anywhere. This means that there is no need for the applyable status of a stack to depend on outputs. I've updated a TODO within the code that is calling for outputs to be added to state so that it also calls out that if/when this happens the applyable status of a stack should be updated to reflect that status of any outputs.