### PR TITLE
website: Enable highlighting for HCL snippets

### DIFF
--- a/website/docs/cli/import/usage.mdx
+++ b/website/docs/cli/import/usage.mdx
@@ -23,7 +23,7 @@ behavior. For more information on this assumption, see
 To import a resource, first write a resource block for it in your
 configuration, establishing the name by which it will be known to Terraform:
 
-```
+```hcl
 resource "aws_instance" "example" {
   # ...instance configuration...
 }

--- a/website/docs/internals/credentials-helpers.mdx
+++ b/website/docs/internals/credentials-helpers.mdx
@@ -40,7 +40,7 @@ block in the CLI configuration.
 For the following examples, we'll assume a "credstore" credentials helper
 configured as follows:
 
-```
+```hcl
 credentials_helper "credstore" {
   args = ["--host=credstore.example.com"]
 }

--- a/website/docs/intro/core-workflow.mdx
+++ b/website/docs/intro/core-workflow.mdx
@@ -232,7 +232,7 @@ input variables and state while also bringing back a tight feedback loop for
 speculative plans for config authors. Terraform configuration can interact with
 HCP Terraform through the [CLI integration](/terraform/cli/cloud).
 
-```
+```hcl
 terraform {
   cloud {
     organization = "my-org"

--- a/website/docs/language/expressions/conditionals.mdx
+++ b/website/docs/language/expressions/conditionals.mdx
@@ -26,7 +26,7 @@ If `condition` is `true` then the result is `true_val`. If `condition` is
 A common use of conditional expressions is to define defaults to replace
 invalid values:
 
-```
+```hcl
 var.a != "" ? var.a : "default-a"
 ```
 

--- a/website/docs/language/expressions/for.mdx
+++ b/website/docs/language/expressions/for.mdx
@@ -86,7 +86,7 @@ A `for` expression can also include an optional `if` clause to filter elements
 from the source collection, producing a value with fewer elements than
 the source value:
 
-```
+```hcl
 [for s in var.list : upper(s) if s != ""]
 ```
 

--- a/website/docs/language/expressions/splat.mdx
+++ b/website/docs/language/expressions/splat.mdx
@@ -65,7 +65,7 @@ empty tuple.
 This special behavior can be useful for modules that accept optional input
 variables whose default value is `null` to represent the absence of any value. This allows the module to adapt the variable value for Terraform language features designed to work with collections. For example:
 
-```
+```hcl
 variable "website_setting" {
   type = object({
     index_document = string

--- a/website/docs/language/expressions/type-constraints.mdx
+++ b/website/docs/language/expressions/type-constraints.mdx
@@ -224,7 +224,7 @@ contents. For example, it's okay to use a variable of type `any` if you use
 it only with `jsonencode` to pass the full value directly to a resource, as
 shown in the following example:
 
-```
+```hcl
 variable "settings" {
   type = any
 }

--- a/website/docs/language/functions/can.mdx
+++ b/website/docs/language/functions/can.mdx
@@ -20,7 +20,7 @@ validation result when writing
 [custom variable validation rules](/terraform/language/values/variables#custom-validation-rules).
 For example:
 
-```
+```hcl
 variable "timestamp" {
   type        = string
 

--- a/website/docs/language/functions/list.mdx
+++ b/website/docs/language/functions/list.mdx
@@ -11,7 +11,7 @@ but Terraform v0.12 introduced a new first-class syntax.
 
 To update an expression like `list(a, b, c)`, write the following instead:
 
-```
+```hcl
 tolist([a, b, c])
 ```
 

--- a/website/docs/language/functions/lookup.mdx
+++ b/website/docs/language/functions/lookup.mdx
@@ -8,7 +8,7 @@ description: The lookup function retrieves an element value from a map given its
 `lookup` retrieves the value of a single element from a map, given its key.
 If the given key does not exist, the given default value is returned instead.
 
-```
+```hcl
 lookup(map, key, default)
 ```
 

--- a/website/docs/language/functions/map.mdx
+++ b/website/docs/language/functions/map.mdx
@@ -11,7 +11,7 @@ but Terraform v0.12 introduced a new first-class syntax.
 
 To update an expression like `map("a", "b", "c", "d")`, write the following instead:
 
-```
+```hcl
 tomap({
   a = "b"
   c = "d"

--- a/website/docs/language/functions/sensitive.mdx
+++ b/website/docs/language/functions/sensitive.mdx
@@ -20,7 +20,7 @@ The `sensitive` function might be useful in some less-common situations where a
 sensitive value arises from a definition _within_ your module, such as if you've
 loaded sensitive data from a file on disk as part of your configuration:
 
-```
+```hcl
 locals {
   sensitive_content = sensitive(file("${path.module}/sensitive.txt"))
 }

--- a/website/docs/language/functions/templatefile.mdx
+++ b/website/docs/language/functions/templatefile.mdx
@@ -60,7 +60,6 @@ The `templatefile` function renders the template:
 > templatefile("${path.module}/backends.tftpl", { port = 8080, ip_addrs = ["10.0.0.1", "10.0.0.2"] })
 backend 10.0.0.1:8080
 backend 10.0.0.2:8080
-
 ```
 
 ### Maps

--- a/website/docs/language/import/generating-configuration.mdx
+++ b/website/docs/language/import/generating-configuration.mdx
@@ -117,7 +117,6 @@ aws_iot_thing.bar: Importing... [id=foo]
 aws_iot_thing.bar: Import complete [id=foo]
 
 Apply complete! Resources: 1 imported, 0 added, 0 changed, 0 destroyed.
-
 ```
 
 Commit your new resource configuration to your version control system.

--- a/website/docs/language/resources/syntax.mdx
+++ b/website/docs/language/resources/syntax.mdx
@@ -139,7 +139,7 @@ The `lifecycle` block is required. The `destroy` argument determines whether Ter
 
 A `removed` block may also contain a [Destroy-Time Provisioner](/terraform/language/resources/provisioners/syntax#destroy-time-provisioners), so that the provisioner can remain in the configuration even though the `resource` block has been removed.
 
-```
+```hcl
 removed {
   from = aws_instance.example
 

--- a/website/docs/language/settings/backends/oss.mdx
+++ b/website/docs/language/settings/backends/oss.mdx
@@ -55,7 +55,7 @@ terraform {
 The `terraform_remote_state` data source will return all of the root outputs
 defined in the referenced remote state, an example output might look like:
 
-```
+```hcl
 data "terraform_remote_state" "network" {
     backend   = "oss"
     config    = {

--- a/website/docs/language/settings/backends/remote.mdx
+++ b/website/docs/language/settings/backends/remote.mdx
@@ -81,7 +81,7 @@ which workspace you set with the `terraform workspace select` command. Therefore
 
 If you need to determine whether a run is local or remote in your Terraform configuration, we recommend using [HCP Terraform run environment variables](/terraform/cloud-docs/run/run-environment#environment-variables). The example below uses `HCP_TERRAFORM_RUN_ID`.
 
-```
+```hcl
 output "current_workspace_name" {
   value = terraform.workspace
 }

--- a/website/docs/language/style.mdx
+++ b/website/docs/language/style.mdx
@@ -381,7 +381,7 @@ The above example will create the following output:
 
 <CodeBlockConfig hideClipboard>
 
-```
+```hcl
 web_private_ips = {
   "api" = "172.31.25.29"
   "db" = "172.31.18.33"

--- a/website/docs/language/tests/index.mdx
+++ b/website/docs/language/tests/index.mdx
@@ -655,7 +655,6 @@ run "loader" {
     source = "./testing/loader"
   }
 }
-
 ```
 
 #### Modules Cleanup

--- a/website/docs/language/values/locals.mdx
+++ b/website/docs/language/values/locals.mdx
@@ -63,7 +63,7 @@ Once a local value is declared, you can reference it in
 _reference_ them as attributes on an object named `local` (singular). Make sure
 to leave off the "s" when referencing a local value!
 
-```
+```hcl
 resource "aws_instance" "example" {
   # ...
 


### PR DESCRIPTION
I noticed this originally when reading https://developer.hashicorp.com/terraform/language/v1.9.x/resources/syntax#removing-resources and decided to look up places where we were missing the HCL language ID in the snippets that contain HCL using an imperfect regex `\n\n```\n`.
