### PR TITLE
stackruntime: Pass the apply-time variable values to stackeval

### DIFF
--- a/internal/stacks/stackruntime/apply.go
+++ b/internal/stacks/stackruntime/apply.go
@@ -60,8 +60,9 @@ func Apply(ctx context.Context, req *ApplyRequest, resp *ApplyResponse) {
 		req.Config,
 		req.RawPlan,
 		stackeval.ApplyOpts{
-			ProviderFactories:  req.ProviderFactories,
-			ExperimentsAllowed: req.ExperimentsAllowed,
+			InputVariableValues: req.InputValues,
+			ProviderFactories:   req.ProviderFactories,
+			ExperimentsAllowed:  req.ExperimentsAllowed,
 		},
 		outp,
 	)


### PR DESCRIPTION
This seems to have got lost while resolving some conflicts in https://github.com/hashicorp/terraform/pull/35346.

Without this, apply-time input variable values just get ignored entirely and if any are required the plan is not applyable at all. Now we'll pass through what the caller provided so stackeval can validate and use it properly.
