### PR TITLE
Fix and clarify error message when -plugin-dir can't be saved to working directory

### DIFF
--- a/internal/command/init.go
+++ b/internal/command/init.go
@@ -92,7 +92,7 @@ func (c *InitCommand) Run(args []string) int {
 	}
 
 	if err := c.storePluginPath(c.pluginPath); err != nil {
-		diags = diags.Append(fmt.Errorf("Error saving -plugin-path values: %s", err))
+		diags = diags.Append(fmt.Errorf("Error saving -plugin-dir to workspace directory: %s", err))
 		view.Diagnostics(diags)
 		return 1
 	}


### PR DESCRIPTION
## Target Release

1.8.x

## Draft CHANGELOG entry

* Fixed and improved error message when `-plugin-dir` is used with `terraform init` and the values can't be saved into the workspace directory.

<!--

Choose a category, delete the others:

-->

### BUG FIXES

* The error message would say `-plugin-path` when the option is actually `-plugin-dir`.
* Improved said error message a bit to clarify where that value was going to be saved to.
