### PR TITLE
Update language-nav-data.json

### DIFF
--- a/website/data/language-nav-data.json
+++ b/website/data/language-nav-data.json
@@ -1102,7 +1102,7 @@
     ]
   },
   {
-    "title": "Upgrading to Terraform v1.7",
+    "title": "Upgrading to Terraform v1.x",
     "path": "upgrade-guides"
   },
   {


### PR DESCRIPTION
The upgrade guides shows as Terraform 1.7, but the latest stable release is 1.8, which is the base we actually browse once we click it.

We also have a link called "v1.x Compatibility Promises", so it makes sense to also display it to 1.x because we don't know which version a user is on Terraform.

Since on the page we can select different Terraform releases to understand the upgrade path, this settles the whole mindset to change this from 1.7 to 1.x.

<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Fixes #

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.8.x

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

### NEW FEATURES | UPGRADE NOTES | ENHANCEMENTS | BUG FIXES | EXPERIMENTS

<!--

Write a short description of the user-facing change. Examples:

- `terraform show -json`: Fixed crash with sensitive set values.
- When rendering a diff, Terraform now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 

-  
