### PR TITLE
Fix incorrect example in the docs

### DIFF
--- a/website/docs/language/expressions/operators.mdx
+++ b/website/docs/language/expressions/operators.mdx
@@ -104,4 +104,4 @@ Terraform does not have an operator for the "exclusive OR" operation. If you
 know that both operators are boolean values then exclusive OR is equivalent
 to the `!=` ("not equal") operator.
 
-The logical operators in Terraform do not short-circuit, meaning `var.foo || var.foo.bar` will produce an error message if `var.foo` is `null` because both `var.foo` and `var.foo.bar` are evaluated.
+The logical operators in Terraform do not short-circuit, meaning `var.foo && var.foo.bar` will produce an error message if `var.foo` is `null` because both `var.foo` and `var.foo.bar` are evaluated.


### PR DESCRIPTION
The example given to illustrate the behaviour of logical operators is incorrect. `var.foo || var.foo.bar` would also produce an error if the operator  was short-circuiting. The example should be with `var.foo && var.foo.bar`, that produces an error in terraform, but wouldn't if `&&` was short-circuiting.