### PR TITLE
fix panic when updating a sensitive field that requires replacement

### DIFF
--- a/internal/terraform/node_resource_abstract_instance.go
+++ b/internal/terraform/node_resource_abstract_instance.go
@@ -1068,7 +1068,7 @@ func (n *NodeAbstractResourceInstance) plan(
 		plannedNewVal = marks.MarkPaths(plannedNewVal, marks.Sensitive, sensitivePaths)
 	}
 
-	reqRep, reqRepDiags := getRequiredReplaces(priorVal, plannedNewVal, resp.RequiresReplace, n.ResolvedProvider.Provider, n.Addr)
+	reqRep, reqRepDiags := getRequiredReplaces(unmarkedPriorVal, unmarkedPlannedNewVal, resp.RequiresReplace, n.ResolvedProvider.Provider, n.Addr)
 	diags = diags.Append(reqRepDiags)
 	if diags.HasErrors() {
 		return nil, nil, deferred, keyData, diags
@@ -2804,6 +2804,11 @@ func getAction(addr addrs.AbsResourceInstance, priorVal, plannedNewVal cty.Value
 // actually changed -- particularly after we may have undone some of the
 // changes in processIgnoreChanges -- so now we'll filter that list to
 // include only where changes are detected.
+//
+// Both the priorVal and plannedNewVal should be unmarked before calling this
+// function. This function exposes nothing about the priorVal or plannedVal
+// except for the paths that require replacement which can be deduced from the
+// type with or without marks.
 func getRequiredReplaces(priorVal, plannedNewVal cty.Value, requiredReplaces []cty.Path, providerAddr tfaddr.Provider, addr addrs.AbsResourceInstance) (cty.PathSet, tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
 
@@ -2848,10 +2853,7 @@ func getRequiredReplaces(priorVal, plannedNewVal cty.Value, requiredReplaces []c
 				plannedChangedVal = cty.NullVal(priorChangedVal.Type())
 			}
 
-			// Unmark for this value for the equality test. If only sensitivity has changed,
-			// this does not require an Update or Replace
-			unmarkedPlannedChangedVal, _ := plannedChangedVal.UnmarkDeep()
-			eqV := unmarkedPlannedChangedVal.Equals(priorChangedVal)
+			eqV := plannedChangedVal.Equals(priorChangedVal)
 			if !eqV.IsKnown() || eqV.False() {
 				reqRep.Add(path)
 			}


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

This PR fixes a panic that occurs during a plan when a sensitive value update forces a resource to be replaced. We refactored the logic for gathering the required replace paths into a separate function in https://github.com/hashicorp/terraform/commit/ddabb6a2eebcdb0141a803bcd99b68f8b52cf86e. This refactor missed that previously it was the `unmarkedPriorVal` that was being used for comparison rather than the basic `priorVal`. When the values are then compared for equality, one of the values was marked which meant the overall returned boolean value was also marked, and then the panic occurs at line 2857.

This PR simply passes in the unmarked values for both the planned and prior values, instead of recomputing the unmarked values internally. This should be acceptable as nothing about the values are actually exposed via the function, it is only the paths and there is nothing sensitive about the paths.

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->


## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.9.0 (hopefully)

## Draft CHANGELOG entry

N/A, this bug was introduced in between releases so as long as we fix before 1.9.0 we don't need a changelog entry.