### PR TITLE
stacks: validate lockfile containing all providers

### DIFF
--- a/internal/rpcapi/stacks.go
+++ b/internal/rpcapi/stacks.go
@@ -302,6 +302,7 @@ func (s *stacksServer) PlanStackChanges(req *terraform1.PlanStackChanges_Request
 		ProviderFactories:  providerFactories,
 		InputValues:        inputValues,
 		ExperimentsAllowed: s.experimentsAllowed,
+		DependencyLocks:    *deps,
 	}
 	rtResp := stackruntime.PlanResponse{
 		PlannedChanges: changesCh,

--- a/internal/rpcapi/stacks.go
+++ b/internal/rpcapi/stacks.go
@@ -463,6 +463,7 @@ func (s *stacksServer) ApplyStackChanges(req *terraform1.ApplyStackChanges_Reque
 		ProviderFactories:  providerFactories,
 		RawPlan:            req.PlannedChanges,
 		ExperimentsAllowed: s.experimentsAllowed,
+		DependencyLocks:    *deps,
 	}
 	rtResp := stackruntime.ApplyResponse{
 		AppliedChanges: changesCh,

--- a/internal/rpcapi/stacks.go
+++ b/internal/rpcapi/stacks.go
@@ -143,6 +143,7 @@ func (s *stacksServer) ValidateStackConfiguration(ctx context.Context, req *terr
 		Config:             cfg,
 		ExperimentsAllowed: s.experimentsAllowed,
 		ProviderFactories:  providerFactories,
+		DependencyLocks:    *deps,
 	})
 	return &terraform1.ValidateStackConfiguration_Response{
 		Diagnostics: diagnosticsToProto(diags),

--- a/internal/rpcapi/stacks_test.go
+++ b/internal/rpcapi/stacks_test.go
@@ -22,6 +22,8 @@ import (
 	"google.golang.org/protobuf/types/known/anypb"
 
 	"github.com/hashicorp/terraform/internal/addrs"
+	"github.com/hashicorp/terraform/internal/depsfile"
+	"github.com/hashicorp/terraform/internal/getproviders/providerreqs"
 	"github.com/hashicorp/terraform/internal/providers"
 	"github.com/hashicorp/terraform/internal/rpcapi/terraform1"
 	"github.com/hashicorp/terraform/internal/stacks/stackconfig"
@@ -665,6 +667,14 @@ func TestStackChangeProgress(t *testing.T) {
 			stacksServer.providerCacheOverride[addrs.NewDefaultProvider("testing")] = func() (providers.Interface, error) {
 				return stacks_testing_provider.NewProviderWithData(tc.store), nil
 			}
+			lock := depsfile.NewLocks()
+			lock.SetProvider(
+				addrs.NewDefaultProvider("testing"),
+				providerreqs.MustParseVersion("0.0.0"),
+				providerreqs.MustParseVersionConstraints("=0.0.0"),
+				providerreqs.PreferredHashes([]providerreqs.Hash{}),
+			)
+			stacksServer.providerDependencyLockOverride = lock
 
 			sb, err := sourcebundle.OpenDir("testdata/sourcebundle")
 			if err != nil {

--- a/internal/stacks/stackruntime/apply.go
+++ b/internal/stacks/stackruntime/apply.go
@@ -11,6 +11,7 @@ import (
 	"google.golang.org/protobuf/types/known/anypb"
 
 	"github.com/hashicorp/terraform/internal/addrs"
+	"github.com/hashicorp/terraform/internal/depsfile"
 	"github.com/hashicorp/terraform/internal/providers"
 	"github.com/hashicorp/terraform/internal/stacks/stackaddrs"
 	"github.com/hashicorp/terraform/internal/stacks/stackconfig"
@@ -63,6 +64,7 @@ func Apply(ctx context.Context, req *ApplyRequest, resp *ApplyResponse) {
 			InputVariableValues: req.InputValues,
 			ProviderFactories:   req.ProviderFactories,
 			ExperimentsAllowed:  req.ExperimentsAllowed,
+			DependencyLocks:     req.DependencyLocks,
 		},
 		outp,
 	)
@@ -102,6 +104,7 @@ type ApplyRequest struct {
 	ProviderFactories map[addrs.Provider]providers.Factory
 
 	ExperimentsAllowed bool
+	DependencyLocks    depsfile.Locks
 }
 
 // ApplyResponse is used by [Apply] to describe the results of applying.

--- a/internal/stacks/stackruntime/apply_test.go
+++ b/internal/stacks/stackruntime/apply_test.go
@@ -21,6 +21,8 @@ import (
 	"github.com/hashicorp/terraform/internal/addrs"
 	terraformProvider "github.com/hashicorp/terraform/internal/builtin/providers/terraform"
 	"github.com/hashicorp/terraform/internal/collections"
+	"github.com/hashicorp/terraform/internal/depsfile"
+	"github.com/hashicorp/terraform/internal/getproviders/providerreqs"
 	"github.com/hashicorp/terraform/internal/lang/marks"
 	"github.com/hashicorp/terraform/internal/providers"
 	"github.com/hashicorp/terraform/internal/stacks/stackaddrs"
@@ -41,7 +43,7 @@ func TestApplyWithRemovedResource(t *testing.T) {
 
 	ctx := context.Background()
 	cfg := loadMainBundleConfigForTest(t, path.Join("empty-component", "valid-providers"))
-
+	lock := depsfile.NewLocks()
 	planReq := PlanRequest{
 		Config: cfg,
 		ProviderFactories: map[addrs.Provider]providers.Factory{
@@ -49,6 +51,7 @@ func TestApplyWithRemovedResource(t *testing.T) {
 				return terraformProvider.NewProvider(), nil
 			},
 		},
+		DependencyLocks: *lock,
 
 		ForcePlanTimestamp: &fakePlanTimestamp,
 
@@ -220,6 +223,13 @@ func TestApplyWithSensitivePropagation(t *testing.T) {
 
 	changesCh := make(chan stackplan.PlannedChange)
 	diagsCh := make(chan tfdiags.Diagnostic)
+	lock := depsfile.NewLocks()
+	lock.SetProvider(
+		addrs.NewDefaultProvider("testing"),
+		providerreqs.MustParseVersion("0.0.0"),
+		providerreqs.MustParseVersionConstraints("=0.0.0"),
+		providerreqs.PreferredHashes([]providerreqs.Hash{}),
+	)
 	req := PlanRequest{
 		Config: cfg,
 		ProviderFactories: map[addrs.Provider]providers.Factory{
@@ -227,6 +237,7 @@ func TestApplyWithSensitivePropagation(t *testing.T) {
 				return stacks_testing_provider.NewProvider(), nil
 			},
 		},
+		DependencyLocks: *lock,
 
 		ForcePlanTimestamp: &fakePlanTimestamp,
 
@@ -264,6 +275,7 @@ func TestApplyWithSensitivePropagation(t *testing.T) {
 				return stacks_testing_provider.NewProvider(), nil
 			},
 		},
+		DependencyLocks: *lock,
 	}
 
 	applyChangesCh := make(chan stackstate.AppliedChange)
@@ -372,6 +384,13 @@ func TestApplyWithCheckableObjects(t *testing.T) {
 
 	changesCh := make(chan stackplan.PlannedChange)
 	diagsCh := make(chan tfdiags.Diagnostic)
+	lock := depsfile.NewLocks()
+	lock.SetProvider(
+		addrs.NewDefaultProvider("testing"),
+		providerreqs.MustParseVersion("0.0.0"),
+		providerreqs.MustParseVersionConstraints("=0.0.0"),
+		providerreqs.PreferredHashes([]providerreqs.Hash{}),
+	)
 	req := PlanRequest{
 		Config: cfg,
 		ProviderFactories: map[addrs.Provider]providers.Factory{
@@ -379,6 +398,7 @@ func TestApplyWithCheckableObjects(t *testing.T) {
 				return stacks_testing_provider.NewProvider(), nil
 			},
 		},
+		DependencyLocks: *lock,
 
 		ForcePlanTimestamp: &fakePlanTimestamp,
 
@@ -429,6 +449,7 @@ func TestApplyWithCheckableObjects(t *testing.T) {
 				return stacks_testing_provider.NewProvider(), nil
 			},
 		},
+		DependencyLocks: *lock,
 	}
 
 	applyChangesCh := make(chan stackstate.AppliedChange)

--- a/internal/stacks/stackruntime/apply_test.go
+++ b/internal/stacks/stackruntime/apply_test.go
@@ -963,6 +963,14 @@ func TestApplyWithStateManipulation(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	lock := depsfile.NewLocks()
+	lock.SetProvider(
+		addrs.NewDefaultProvider("testing"),
+		providerreqs.MustParseVersion("0.0.0"),
+		providerreqs.MustParseVersionConstraints("=0.0.0"),
+		providerreqs.PreferredHashes([]providerreqs.Hash{}),
+	)
+
 	tcs := map[string]struct {
 		state            *stackstate.State
 		store            *stacks_testing_provider.ResourceStore
@@ -1130,6 +1138,7 @@ func TestApplyWithStateManipulation(t *testing.T) {
 				InputValues:        inputs,
 				ForcePlanTimestamp: &fakePlanTimestamp,
 				PrevState:          tc.state,
+				DependencyLocks:    *lock,
 			}
 			planResp := PlanResponse{
 				PlannedChanges: planChangeCh,
@@ -1175,6 +1184,7 @@ func TestApplyWithStateManipulation(t *testing.T) {
 				Config:            cfg,
 				RawPlan:           raw,
 				ProviderFactories: providers,
+				DependencyLocks:   *lock,
 			}
 			applyResp := ApplyResponse{
 				AppliedChanges: applyChangesCh,

--- a/internal/stacks/stackruntime/internal/stackeval/applying.go
+++ b/internal/stacks/stackruntime/internal/stackeval/applying.go
@@ -7,6 +7,7 @@ import (
 	"context"
 
 	"github.com/hashicorp/terraform/internal/collections"
+	"github.com/hashicorp/terraform/internal/depsfile"
 	"github.com/hashicorp/terraform/internal/stacks/stackaddrs"
 	"github.com/hashicorp/terraform/internal/stacks/stackstate"
 	"github.com/hashicorp/terraform/internal/stacks/stackstate/statekeys"
@@ -15,6 +16,7 @@ import (
 
 type ApplyOpts struct {
 	ProviderFactories ProviderFactories
+	DependencyLocks   depsfile.Locks
 
 	// PrevStateDescKeys is a set of all of the state description keys currently
 	// known by the caller.

--- a/internal/stacks/stackruntime/internal/stackeval/component_instance.go
+++ b/internal/stacks/stackruntime/internal/stackeval/component_instance.go
@@ -390,6 +390,13 @@ func (c *ComponentInstance) neededProviderSchemas(ctx context.Context) (map[addr
 			continue // not our job to report a missing provider type
 		}
 		schema, err := pTy.Schema(ctx)
+
+		providerLockfileDiags := CheckProviderInLockfile(c.main.validating.opts.DependencyLocks, pTy, decl.DeclRange)
+		// We report these diagnostics in a different place
+		if providerLockfileDiags.HasErrors() {
+			continue
+		}
+
 		if err != nil {
 			// FIXME: it's not technically our job to report a schema
 			// fetch failure, but currently there is no single other

--- a/internal/stacks/stackruntime/internal/stackeval/main.go
+++ b/internal/stacks/stackruntime/internal/stackeval/main.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hashicorp/terraform/internal/addrs"
 	fileProvisioner "github.com/hashicorp/terraform/internal/builtin/provisioners/file"
 	remoteExecProvisioner "github.com/hashicorp/terraform/internal/builtin/provisioners/remote-exec"
+	"github.com/hashicorp/terraform/internal/depsfile"
 	"github.com/hashicorp/terraform/internal/promising"
 	"github.com/hashicorp/terraform/internal/provisioners"
 	"github.com/hashicorp/terraform/internal/stacks/stackaddrs"
@@ -608,4 +609,15 @@ func (m *Main) PlanTimestamp() time.Time {
 
 	// This is the default case, we are not planning / applying
 	return time.Now().UTC()
+}
+
+// DependencyLocks returns the dependency locks for the given phase.
+func (m *Main) DependencyLocks(phase EvalPhase) *depsfile.Locks {
+	switch phase {
+	case ValidatePhase:
+		return &m.validating.opts.DependencyLocks
+	default:
+		return nil
+
+	}
 }

--- a/internal/stacks/stackruntime/internal/stackeval/main.go
+++ b/internal/stacks/stackruntime/internal/stackeval/main.go
@@ -616,6 +616,8 @@ func (m *Main) DependencyLocks(phase EvalPhase) *depsfile.Locks {
 	switch phase {
 	case ValidatePhase:
 		return &m.validating.opts.DependencyLocks
+	case PlanPhase:
+		return &m.PlanningOpts().DependencyLocks
 	default:
 		return nil
 

--- a/internal/stacks/stackruntime/internal/stackeval/main.go
+++ b/internal/stacks/stackruntime/internal/stackeval/main.go
@@ -618,6 +618,8 @@ func (m *Main) DependencyLocks(phase EvalPhase) *depsfile.Locks {
 		return &m.validating.opts.DependencyLocks
 	case PlanPhase:
 		return &m.PlanningOpts().DependencyLocks
+	case ApplyPhase:
+		return &m.applying.opts.DependencyLocks
 	default:
 		return nil
 

--- a/internal/stacks/stackruntime/internal/stackeval/planning.go
+++ b/internal/stacks/stackruntime/internal/stackeval/planning.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/hashicorp/terraform/internal/depsfile"
 	"github.com/hashicorp/terraform/internal/plans"
 	"github.com/hashicorp/terraform/internal/stacks/stackaddrs"
 	"github.com/hashicorp/terraform/internal/stacks/stackplan"
@@ -21,6 +22,8 @@ type PlanOpts struct {
 	ProviderFactories ProviderFactories
 
 	PlanTimestamp time.Time
+
+	DependencyLocks depsfile.Locks
 }
 
 // Plannable is implemented by objects that can participate in planning.

--- a/internal/stacks/stackruntime/internal/stackeval/provider_config.go
+++ b/internal/stacks/stackruntime/internal/stackeval/provider_config.go
@@ -82,9 +82,10 @@ func (p *ProviderConfig) ProviderArgs(ctx context.Context, phase EvalPhase) cty.
 }
 
 func CheckProviderInLockfile(locks depsfile.Locks, providerType *ProviderType, declRange tfdiags.SourceRange) (diags tfdiags.Diagnostics) {
-	if providerType.addr.IsBuiltIn() {
-		return diags // built-in providers are not in the lockfile
+	if !depsfile.ProviderIsLockable(providerType.Addr()) {
+		return diags
 	}
+
 	if p := locks.Provider(providerType.Addr()); p == nil {
 		diags = diags.Append(&hcl.Diagnostic{
 			Severity: hcl.DiagError,

--- a/internal/stacks/stackruntime/internal/stackeval/provider_config.go
+++ b/internal/stacks/stackruntime/internal/stackeval/provider_config.go
@@ -108,13 +108,16 @@ func (p *ProviderConfig) CheckProviderArgs(ctx context.Context, phase EvalPhase)
 			providerType := p.ProviderType(ctx)
 			decl := p.Declaration(ctx)
 
-			// Check if the provider is in the lockfile,
-			// if it is not we can not read the provider schema
-			lockfileDiags := CheckProviderInLockfile(p.main.validating.opts.DependencyLocks, providerType, decl.DeclRange)
-			if lockfileDiags.HasErrors() {
-				return cty.DynamicVal, lockfileDiags
+			depLocks := p.main.DependencyLocks(phase)
+			if depLocks != nil {
+				// Check if the provider is in the lockfile,
+				// if it is not we can not read the provider schema
+				lockfileDiags := CheckProviderInLockfile(*depLocks, providerType, decl.DeclRange)
+				if lockfileDiags.HasErrors() {
+					return cty.DynamicVal, lockfileDiags
+				}
+				diags = diags.Append(lockfileDiags)
 			}
-			diags = diags.Append(lockfileDiags)
 
 			spec, err := p.ProviderArgsDecoderSpec(ctx)
 			if err != nil {

--- a/internal/stacks/stackruntime/internal/stackeval/provider_config_test.go
+++ b/internal/stacks/stackruntime/internal/stackeval/provider_config_test.go
@@ -72,7 +72,7 @@ func TestProviderConfig_CheckProviderArgs_EmptyConfig(t *testing.T) {
 		config := getProviderConfig(ctx, t, main)
 
 		want := cty.EmptyObjectVal
-		got, diags := config.CheckProviderArgs(ctx, ValidatePhase)
+		got, diags := config.CheckProviderArgs(ctx, InspectPhase)
 		assertNoDiags(t, diags)
 
 		if diff := cmp.Diff(want, got, ctydebug.CmpOptions); diff != "" {
@@ -159,7 +159,7 @@ func TestProviderConfig_CheckProviderArgs(t *testing.T) {
 		want := cty.ObjectVal(map[string]cty.Value{
 			"test": cty.StringVal("yep"),
 		})
-		got, diags := config.CheckProviderArgs(ctx, ValidatePhase)
+		got, diags := config.CheckProviderArgs(ctx, InspectPhase)
 		assertNoDiags(t, diags)
 
 		if diff := cmp.Diff(want, got, ctydebug.CmpOptions); diff != "" {
@@ -196,7 +196,7 @@ func TestProviderConfig_CheckProviderArgs(t *testing.T) {
 		want := cty.ObjectVal(map[string]cty.Value{
 			"test": cty.StringVal("yep").Mark("nope"),
 		})
-		got, diags := config.CheckProviderArgs(ctx, ValidatePhase)
+		got, diags := config.CheckProviderArgs(ctx, InspectPhase)
 		assertNoDiags(t, diags)
 
 		if diff := cmp.Diff(want, got, ctydebug.CmpOptions); diff != "" {

--- a/internal/stacks/stackruntime/internal/stackeval/validating.go
+++ b/internal/stacks/stackruntime/internal/stackeval/validating.go
@@ -6,11 +6,13 @@ package stackeval
 import (
 	"context"
 
+	"github.com/hashicorp/terraform/internal/depsfile"
 	"github.com/hashicorp/terraform/internal/tfdiags"
 )
 
 type ValidateOpts struct {
 	ProviderFactories ProviderFactories
+	DependencyLocks   depsfile.Locks
 }
 
 // Validateable is implemented by objects that can participate in validation.

--- a/internal/stacks/stackruntime/plan.go
+++ b/internal/stacks/stackruntime/plan.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform/internal/addrs"
+	"github.com/hashicorp/terraform/internal/depsfile"
 	"github.com/hashicorp/terraform/internal/plans"
 	"github.com/hashicorp/terraform/internal/providers"
 	"github.com/hashicorp/terraform/internal/stacks/stackaddrs"
@@ -49,6 +50,7 @@ func Plan(ctx context.Context, req *PlanRequest, resp *PlanResponse) {
 		PlanningMode:        req.PlanMode,
 		InputVariableValues: req.InputValues,
 		ProviderFactories:   req.ProviderFactories,
+		DependencyLocks:     req.DependencyLocks,
 
 		PlanTimestamp: planTimestamp,
 	})

--- a/internal/stacks/stackruntime/plan.go
+++ b/internal/stacks/stackruntime/plan.go
@@ -104,6 +104,7 @@ type PlanRequest struct {
 
 	InputValues       map[stackaddrs.InputVariable]ExternalInputValue
 	ProviderFactories map[addrs.Provider]providers.Factory
+	DependencyLocks   depsfile.Locks
 
 	// ForcePlanTimestamp, if not nil, will force the plantimestamp function
 	// to return the given value instead of whatever real time the plan

--- a/internal/stacks/stackruntime/plan_test.go
+++ b/internal/stacks/stackruntime/plan_test.go
@@ -21,6 +21,8 @@ import (
 	"github.com/zclconf/go-cty/cty"
 
 	"github.com/hashicorp/terraform/internal/checks"
+	"github.com/hashicorp/terraform/internal/depsfile"
+	"github.com/hashicorp/terraform/internal/getproviders/providerreqs"
 	"github.com/hashicorp/terraform/internal/stacks/stackruntime/hooks"
 
 	"github.com/hashicorp/terraform/internal/addrs"
@@ -67,6 +69,13 @@ func TestPlan_valid(t *testing.T) {
 
 			changesCh := make(chan stackplan.PlannedChange, 8)
 			diagsCh := make(chan tfdiags.Diagnostic, 2)
+			lock := depsfile.NewLocks()
+			lock.SetProvider(
+				addrs.NewDefaultProvider("testing"),
+				providerreqs.MustParseVersion("0.0.0"),
+				providerreqs.MustParseVersionConstraints("=0.0.0"),
+				providerreqs.PreferredHashes([]providerreqs.Hash{}),
+			)
 			req := PlanRequest{
 				Config: cfg,
 				ProviderFactories: map[addrs.Provider]providers.Factory{
@@ -81,6 +90,7 @@ func TestPlan_valid(t *testing.T) {
 						return stacks_testing_provider.NewProvider(), nil
 					},
 				},
+				DependencyLocks: *lock,
 				InputValues: func() map[stackaddrs.InputVariable]ExternalInputValue {
 					inputs := map[stackaddrs.InputVariable]ExternalInputValue{}
 					for k, v := range tc.planInputVars {
@@ -148,6 +158,13 @@ func TestPlan_invalid(t *testing.T) {
 
 			changesCh := make(chan stackplan.PlannedChange, 8)
 			diagsCh := make(chan tfdiags.Diagnostic, 2)
+			lock := depsfile.NewLocks()
+			lock.SetProvider(
+				addrs.NewDefaultProvider("testing"),
+				providerreqs.MustParseVersion("0.0.0"),
+				providerreqs.MustParseVersionConstraints("=0.0.0"),
+				providerreqs.PreferredHashes([]providerreqs.Hash{}),
+			)
 			req := PlanRequest{
 				Config: cfg,
 				ProviderFactories: map[addrs.Provider]providers.Factory{
@@ -162,6 +179,7 @@ func TestPlan_invalid(t *testing.T) {
 						return stacks_testing_provider.NewProvider(), nil
 					},
 				},
+				DependencyLocks: *lock,
 				InputValues: func() map[stackaddrs.InputVariable]ExternalInputValue {
 					inputs := map[stackaddrs.InputVariable]ExternalInputValue{}
 					for k, v := range tc.planInputVars {
@@ -396,6 +414,13 @@ func TestPlanWithComplexVariableDefaults(t *testing.T) {
 
 	changesCh := make(chan stackplan.PlannedChange)
 	diagsCh := make(chan tfdiags.Diagnostic)
+	lock := depsfile.NewLocks()
+	lock.SetProvider(
+		addrs.NewDefaultProvider("testing"),
+		providerreqs.MustParseVersion("0.0.0"),
+		providerreqs.MustParseVersionConstraints("=0.0.0"),
+		providerreqs.PreferredHashes([]providerreqs.Hash{}),
+	)
 	req := PlanRequest{
 		Config: cfg,
 		ProviderFactories: map[addrs.Provider]providers.Factory{
@@ -403,6 +428,7 @@ func TestPlanWithComplexVariableDefaults(t *testing.T) {
 				return stacks_testing_provider.NewProvider(), nil
 			},
 		},
+		DependencyLocks: *lock,
 		InputValues: map[stackaddrs.InputVariable]ExternalInputValue{
 			{Name: "optional"}: {
 				Value:    cty.EmptyObjectVal, // This should be populated by defaults.
@@ -1277,6 +1303,13 @@ func TestPlanWithProviderConfig(t *testing.T) {
 	fakeSrcRng := tfdiags.SourceRange{
 		Filename: "fake-source",
 	}
+	lock := depsfile.NewLocks()
+	lock.SetProvider(
+		providerAddr,
+		providerreqs.MustParseVersion("0.0.0"),
+		providerreqs.MustParseVersionConstraints("=0.0.0"),
+		providerreqs.PreferredHashes([]providerreqs.Hash{}),
+	)
 
 	t.Run("valid", func(t *testing.T) {
 		changesCh := make(chan stackplan.PlannedChange, 8)
@@ -1301,6 +1334,7 @@ func TestPlanWithProviderConfig(t *testing.T) {
 					return provider, nil
 				},
 			},
+			DependencyLocks: *lock,
 		}
 		resp := PlanResponse{
 			PlannedChanges: changesCh,
@@ -1457,6 +1491,13 @@ func TestPlanWithSensitivePropagation(t *testing.T) {
 
 	changesCh := make(chan stackplan.PlannedChange, 8)
 	diagsCh := make(chan tfdiags.Diagnostic, 2)
+	lock := depsfile.NewLocks()
+	lock.SetProvider(
+		addrs.NewDefaultProvider("testing"),
+		providerreqs.MustParseVersion("0.0.0"),
+		providerreqs.MustParseVersionConstraints("=0.0.0"),
+		providerreqs.PreferredHashes([]providerreqs.Hash{}),
+	)
 	req := PlanRequest{
 		Config: cfg,
 		ProviderFactories: map[addrs.Provider]providers.Factory{
@@ -1464,7 +1505,7 @@ func TestPlanWithSensitivePropagation(t *testing.T) {
 				return stacks_testing_provider.NewProvider(), nil
 			},
 		},
-
+		DependencyLocks:    *lock,
 		ForcePlanTimestamp: &fakePlanTimestamp,
 	}
 	resp := PlanResponse{
@@ -1613,6 +1654,13 @@ func TestPlanWithSensitivePropagationNested(t *testing.T) {
 
 	changesCh := make(chan stackplan.PlannedChange, 8)
 	diagsCh := make(chan tfdiags.Diagnostic, 2)
+	lock := depsfile.NewLocks()
+	lock.SetProvider(
+		addrs.NewDefaultProvider("testing"),
+		providerreqs.MustParseVersion("0.0.0"),
+		providerreqs.MustParseVersionConstraints("=0.0.0"),
+		providerreqs.PreferredHashes([]providerreqs.Hash{}),
+	)
 	req := PlanRequest{
 		Config: cfg,
 		ProviderFactories: map[addrs.Provider]providers.Factory{
@@ -1620,6 +1668,7 @@ func TestPlanWithSensitivePropagationNested(t *testing.T) {
 				return stacks_testing_provider.NewProvider(), nil
 			},
 		},
+		DependencyLocks: *lock,
 
 		ForcePlanTimestamp: &fakePlanTimestamp,
 	}
@@ -1763,6 +1812,13 @@ func TestPlanWithForEach(t *testing.T) {
 
 	changesCh := make(chan stackplan.PlannedChange, 8)
 	diagsCh := make(chan tfdiags.Diagnostic, 2)
+	lock := depsfile.NewLocks()
+	lock.SetProvider(
+		addrs.NewDefaultProvider("testing"),
+		providerreqs.MustParseVersion("0.0.0"),
+		providerreqs.MustParseVersionConstraints("=0.0.0"),
+		providerreqs.PreferredHashes([]providerreqs.Hash{}),
+	)
 	req := PlanRequest{
 		Config: cfg,
 		ProviderFactories: map[addrs.Provider]providers.Factory{
@@ -1770,6 +1826,7 @@ func TestPlanWithForEach(t *testing.T) {
 				return stacks_testing_provider.NewProvider(), nil
 			},
 		},
+		DependencyLocks: *lock,
 
 		ForcePlanTimestamp: &fakePlanTimestamp,
 
@@ -1805,6 +1862,13 @@ func TestPlanWithCheckableObjects(t *testing.T) {
 
 	changesCh := make(chan stackplan.PlannedChange, 8)
 	diagsCh := make(chan tfdiags.Diagnostic, 2)
+	lock := depsfile.NewLocks()
+	lock.SetProvider(
+		addrs.NewDefaultProvider("testing"),
+		providerreqs.MustParseVersion("0.0.0"),
+		providerreqs.MustParseVersionConstraints("=0.0.0"),
+		providerreqs.PreferredHashes([]providerreqs.Hash{}),
+	)
 	req := PlanRequest{
 		Config: cfg,
 		ProviderFactories: map[addrs.Provider]providers.Factory{
@@ -1812,6 +1876,7 @@ func TestPlanWithCheckableObjects(t *testing.T) {
 				return stacks_testing_provider.NewProvider(), nil
 			},
 		},
+		DependencyLocks: *lock,
 
 		ForcePlanTimestamp: &fakePlanTimestamp,
 
@@ -2017,6 +2082,13 @@ func TestPlanWithDeferredResource(t *testing.T) {
 
 	changesCh := make(chan stackplan.PlannedChange)
 	diagsCh := make(chan tfdiags.Diagnostic)
+	lock := depsfile.NewLocks()
+	lock.SetProvider(
+		addrs.NewDefaultProvider("testing"),
+		providerreqs.MustParseVersion("0.0.0"),
+		providerreqs.MustParseVersionConstraints("=0.0.0"),
+		providerreqs.PreferredHashes([]providerreqs.Hash{}),
+	)
 	req := PlanRequest{
 		Config: cfg,
 		ProviderFactories: map[addrs.Provider]providers.Factory{
@@ -2024,6 +2096,7 @@ func TestPlanWithDeferredResource(t *testing.T) {
 				return stacks_testing_provider.NewProvider(), nil
 			},
 		},
+		DependencyLocks:    *lock,
 		ForcePlanTimestamp: &fakePlanTimestamp,
 		InputValues: map[stackaddrs.InputVariable]ExternalInputValue{
 			{Name: "id"}: {
@@ -2159,6 +2232,13 @@ func TestPlanWithDeferredComponentForEach(t *testing.T) {
 
 	changesCh := make(chan stackplan.PlannedChange, 8)
 	diagsCh := make(chan tfdiags.Diagnostic, 2)
+	lock := depsfile.NewLocks()
+	lock.SetProvider(
+		addrs.NewDefaultProvider("testing"),
+		providerreqs.MustParseVersion("0.0.0"),
+		providerreqs.MustParseVersionConstraints("=0.0.0"),
+		providerreqs.PreferredHashes([]providerreqs.Hash{}),
+	)
 	req := PlanRequest{
 		Config: cfg,
 		ProviderFactories: map[addrs.Provider]providers.Factory{
@@ -2166,6 +2246,7 @@ func TestPlanWithDeferredComponentForEach(t *testing.T) {
 				return stacks_testing_provider.NewProvider(), nil
 			},
 		},
+		DependencyLocks:    *lock,
 		ForcePlanTimestamp: &fakePlanTimestamp,
 		InputValues: map[stackaddrs.InputVariable]ExternalInputValue{
 			{Name: "components"}: {
@@ -2388,6 +2469,13 @@ func TestPlanWithDeferredComponentReferences(t *testing.T) {
 
 	changesCh := make(chan stackplan.PlannedChange, 8)
 	diagsCh := make(chan tfdiags.Diagnostic, 2)
+	lock := depsfile.NewLocks()
+	lock.SetProvider(
+		addrs.NewDefaultProvider("testing"),
+		providerreqs.MustParseVersion("0.0.0"),
+		providerreqs.MustParseVersionConstraints("=0.0.0"),
+		providerreqs.PreferredHashes([]providerreqs.Hash{}),
+	)
 	req := PlanRequest{
 		Config: cfg,
 		ProviderFactories: map[addrs.Provider]providers.Factory{
@@ -2395,6 +2483,7 @@ func TestPlanWithDeferredComponentReferences(t *testing.T) {
 				return stacks_testing_provider.NewProvider(), nil
 			},
 		},
+		DependencyLocks:    *lock,
 		ForcePlanTimestamp: &fakePlanTimestamp,
 		InputValues: map[stackaddrs.InputVariable]ExternalInputValue{
 			{Name: "known_components"}: {
@@ -2637,6 +2726,13 @@ func TestPlanWithDeferredEmbeddedStackForEach(t *testing.T) {
 
 	changesCh := make(chan stackplan.PlannedChange, 8)
 	diagsCh := make(chan tfdiags.Diagnostic, 2)
+	lock := depsfile.NewLocks()
+	lock.SetProvider(
+		addrs.NewDefaultProvider("testing"),
+		providerreqs.MustParseVersion("0.0.0"),
+		providerreqs.MustParseVersionConstraints("=0.0.0"),
+		providerreqs.PreferredHashes([]providerreqs.Hash{}),
+	)
 	req := PlanRequest{
 		Config: cfg,
 		ProviderFactories: map[addrs.Provider]providers.Factory{
@@ -2644,6 +2740,7 @@ func TestPlanWithDeferredEmbeddedStackForEach(t *testing.T) {
 				return stacks_testing_provider.NewProvider(), nil
 			},
 		},
+		DependencyLocks:    *lock,
 		ForcePlanTimestamp: &fakePlanTimestamp,
 		InputValues: map[stackaddrs.InputVariable]ExternalInputValue{
 			{Name: "stacks"}: {
@@ -2775,6 +2872,13 @@ func TestPlanWithDeferredEmbeddedStackAndComponentForEach(t *testing.T) {
 
 	changesCh := make(chan stackplan.PlannedChange, 8)
 	diagsCh := make(chan tfdiags.Diagnostic, 2)
+	lock := depsfile.NewLocks()
+	lock.SetProvider(
+		addrs.NewDefaultProvider("testing"),
+		providerreqs.MustParseVersion("0.0.0"),
+		providerreqs.MustParseVersionConstraints("=0.0.0"),
+		providerreqs.PreferredHashes([]providerreqs.Hash{}),
+	)
 	req := PlanRequest{
 		Config: cfg,
 		ProviderFactories: map[addrs.Provider]providers.Factory{
@@ -2782,6 +2886,7 @@ func TestPlanWithDeferredEmbeddedStackAndComponentForEach(t *testing.T) {
 				return stacks_testing_provider.NewProvider(), nil
 			},
 		},
+		DependencyLocks:    *lock,
 		ForcePlanTimestamp: &fakePlanTimestamp,
 		InputValues: map[stackaddrs.InputVariable]ExternalInputValue{
 			{Name: "stacks"}: {
@@ -2912,6 +3017,13 @@ func TestPlanWithDeferredComponentForEachOfInvalidType(t *testing.T) {
 
 	changesCh := make(chan stackplan.PlannedChange, 8)
 	diagsCh := make(chan tfdiags.Diagnostic, 2)
+	lock := depsfile.NewLocks()
+	lock.SetProvider(
+		addrs.NewDefaultProvider("testing"),
+		providerreqs.MustParseVersion("0.0.0"),
+		providerreqs.MustParseVersionConstraints("=0.0.0"),
+		providerreqs.PreferredHashes([]providerreqs.Hash{}),
+	)
 	req := PlanRequest{
 		Config: cfg,
 		ProviderFactories: map[addrs.Provider]providers.Factory{
@@ -2919,6 +3031,7 @@ func TestPlanWithDeferredComponentForEachOfInvalidType(t *testing.T) {
 				return stacks_testing_provider.NewProvider(), nil
 			},
 		},
+		DependencyLocks: *lock,
 
 		ForcePlanTimestamp: &fakePlanTimestamp,
 
@@ -2966,6 +3079,13 @@ func TestPlanWithDeferredProviderForEach(t *testing.T) {
 
 	changesCh := make(chan stackplan.PlannedChange)
 	diagsCh := make(chan tfdiags.Diagnostic)
+	lock := depsfile.NewLocks()
+	lock.SetProvider(
+		addrs.NewDefaultProvider("testing"),
+		providerreqs.MustParseVersion("0.0.0"),
+		providerreqs.MustParseVersionConstraints("=0.0.0"),
+		providerreqs.PreferredHashes([]providerreqs.Hash{}),
+	)
 	req := PlanRequest{
 		Config: cfg,
 		ProviderFactories: map[addrs.Provider]providers.Factory{
@@ -2973,6 +3093,7 @@ func TestPlanWithDeferredProviderForEach(t *testing.T) {
 				return stacks_testing_provider.NewProvider(), nil
 			},
 		},
+		DependencyLocks:    *lock,
 		ForcePlanTimestamp: &fakePlanTimestamp,
 		InputValues: map[stackaddrs.InputVariable]ExternalInputValue{
 			{Name: "providers"}: {
@@ -3171,6 +3292,13 @@ func TestPlanInvalidProvidersFailGracefully(t *testing.T) {
 
 	changesCh := make(chan stackplan.PlannedChange)
 	diagsCh := make(chan tfdiags.Diagnostic)
+	lock := depsfile.NewLocks()
+	lock.SetProvider(
+		addrs.NewDefaultProvider("testing"),
+		providerreqs.MustParseVersion("0.0.0"),
+		providerreqs.MustParseVersionConstraints("=0.0.0"),
+		providerreqs.PreferredHashes([]providerreqs.Hash{}),
+	)
 	req := PlanRequest{
 		Config: cfg,
 		ProviderFactories: map[addrs.Provider]providers.Factory{
@@ -3181,6 +3309,7 @@ func TestPlanInvalidProvidersFailGracefully(t *testing.T) {
 				return stacks_testing_provider.NewProvider(), nil
 			},
 		},
+		DependencyLocks:    *lock,
 		ForcePlanTimestamp: &fakePlanTimestamp,
 	}
 	resp := PlanResponse{
@@ -3231,6 +3360,13 @@ func TestPlanWithStateManipulation(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	lock := depsfile.NewLocks()
+	lock.SetProvider(
+		addrs.NewDefaultProvider("testing"),
+		providerreqs.MustParseVersion("0.0.0"),
+		providerreqs.MustParseVersionConstraints("=0.0.0"),
+		providerreqs.PreferredHashes([]providerreqs.Hash{}),
+	)
 
 	tcs := map[string]struct {
 		state            *stackstate.State
@@ -3521,6 +3657,7 @@ func TestPlanWithStateManipulation(t *testing.T) {
 						return stacks_testing_provider.NewProviderWithData(tc.store), nil
 					},
 				},
+				DependencyLocks:    *lock,
 				InputValues:        inputs,
 				ForcePlanTimestamp: &fakePlanTimestamp,
 				PrevState:          tc.state,

--- a/internal/stacks/stackruntime/validate.go
+++ b/internal/stacks/stackruntime/validate.go
@@ -9,6 +9,7 @@ import (
 	"go.opentelemetry.io/otel/codes"
 
 	"github.com/hashicorp/terraform/internal/addrs"
+	"github.com/hashicorp/terraform/internal/depsfile"
 	"github.com/hashicorp/terraform/internal/providers"
 	"github.com/hashicorp/terraform/internal/stacks/stackconfig"
 	"github.com/hashicorp/terraform/internal/stacks/stackruntime/internal/stackeval"
@@ -23,6 +24,7 @@ func Validate(ctx context.Context, req *ValidateRequest) tfdiags.Diagnostics {
 
 	main := stackeval.NewForValidating(req.Config, stackeval.ValidateOpts{
 		ProviderFactories: req.ProviderFactories,
+		DependencyLocks:   req.DependencyLocks,
 	})
 	main.AllowLanguageExperiments(req.ExperimentsAllowed)
 	diags := main.ValidateAll(ctx)
@@ -38,6 +40,7 @@ func Validate(ctx context.Context, req *ValidateRequest) tfdiags.Diagnostics {
 type ValidateRequest struct {
 	Config            *stackconfig.Config
 	ProviderFactories map[addrs.Provider]providers.Factory
+	DependencyLocks   depsfile.Locks
 
 	ExperimentsAllowed bool
 }

--- a/internal/stacks/stackruntime/validate_test.go
+++ b/internal/stacks/stackruntime/validate_test.go
@@ -375,3 +375,43 @@ Terraform uses references to decide a suitable order for performing operations, 
 		t.Errorf("wrong diagnostics\n%s", diff)
 	}
 }
+
+func TestValidate_missing_provider_from_lockfile(t *testing.T) {
+	ctx := context.Background()
+	cfg := loadMainBundleConfigForTest(t, filepath.Join("with-single-input", "input-from-component"))
+	lock := depsfile.NewLocks()
+
+	diags := Validate(ctx, &ValidateRequest{
+		Config: cfg,
+		ProviderFactories: map[addrs.Provider]providers.Factory{
+			// We support both hashicorp/testing and
+			// terraform.io/builtin/testing as providers. This lets us
+			// test the provider aliasing feature. Both providers
+			// support the same set of resources and data sources.
+			addrs.NewDefaultProvider("testing"): func() (providers.Interface, error) {
+				return stacks_testing_provider.NewProvider(), nil
+			},
+			addrs.NewBuiltInProvider("testing"): func() (providers.Interface, error) {
+				return stacks_testing_provider.NewProvider(), nil
+			},
+		},
+		DependencyLocks: *lock,
+	})
+
+	if len(diags) != 1 {
+		t.Fatalf("expected exactly one diagnostic, got %d", len(diags))
+	}
+
+	diag := diags[0]
+	if diag.Severity() != tfdiags.Error {
+		t.Fatalf("expected error diagnostic, got %s", diag.Severity())
+	}
+
+	if diag.Description().Summary != "Provider missing from lockfile" {
+		t.Fatalf("expected diagnostic summary 'Provider missing from lockfile', got %q", diag.Description().Summary)
+	}
+
+	if diag.Description().Detail != "Provider \"registry.terraform.io/hashicorp/testing\" is not in the lockfile. This provider must be in the lockfile to be used in the configuration. Please run `tfstacks provider lock` to update the lockfile and run this operation again with an updated configuration." {
+		t.Fatalf("expected diagnostic detail to be a specific message, got %q", diag.Description().Detail)
+	}
+}


### PR DESCRIPTION
If the providers are not in the lockfile fetching the schema fails.
This leads to follow up diagnostics that send an unclear message.
Now we validate the lockfile and if something is missing we skip further validation that relies on
the provider schema being present.

<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

[Jira](https://hashicorp.atlassian.net/browse/TF-17949)

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.10.x

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

### ENHANCEMENTS

<!--

Write a short description of the user-facing change. Examples:

- `terraform show -json`: Fixed crash with sensitive set values.
- When rendering a diff, Terraform now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 

-  stacks: improve validation of lockfiles

