### PR TITLE
Clarify use of backend-config file

### DIFF
--- a/website/docs/language/settings/backends/configuration.mdx
+++ b/website/docs/language/settings/backends/configuration.mdx
@@ -156,6 +156,17 @@ naming pattern. Terraform will not prevent you from using other names but follow
 this convention will help your editor understand the content and likely provide
 better editing experience as a result.
 
+- Using a backend configuration file  or CLI key-value pairs overrides the contents, 
+but not the type of `backend`. (e.g. Use a Partial Configuration in the primary config.)
+
+```hcl
+terraform {
+  backaned {
+    # values provided by backend-config file
+  }
+}
+```
+
 ### Command-line key/value pairs
 
 The same settings can alternatively be specified on the command line as


### PR DESCRIPTION
`-backend-config` It is not a "full override" as one might expect. It works only within the context of an existing  partial configuration.

I'm not confident that my docs changes are exactly correct-- but hopefully this will make things a little clearer. I realize this is within the "Partial Configuration" section, but I still found the behavior a little surprising. 

(Why do I need to do this? I am using multiple tf environments, which must store their state separately.)

I (as suggested by a confused ChatGPT) attempted:

```
terraform init -backend-config myfile.tf
```

**myfile.tf**
```hcl
terraform {
  backend "s3" {
    bucket =  "mybucket"
    key = "terraform.tfstate"
    region = "us-east-2"
    encrypt = true
    dynamodb_table = "my-tf-lock"
  }
}
```

IMO this seems like a pretty reasonable expectation. I did receive a warning that it wasn't overriding any specific config, but I thought that seemed ok. What I absolutely did not expect was that tf would proceed and store my tfstate locally. 

The `helptext` was a little more helpful.

```
  -backend-config=path    Configuration to be merged with what is in the
                          configuration file's 'backend' block. This can be
                          either a path to an HCL file with key/value
                          assignments (same format as terraform.tfvars) or a
                          'key=value' format, and can be specified multiple
                          times. The backend type must be in the configuration
                          itself.
```

What ended up working for me: 

backend.tf
```hcl
terraform {
  backend "s3" {
    # NOTHING
  }
}
```
terraform init -backend-config myfile.tf
```

**myfile.tf**
```hcl
bucket =  "mybucket"
key = "terraform.tfstate"
region = "us-east-2"
encrypt = true
dynamodb_table = "my-tf-lock"
```
