### PR TITLE
stacks: include move, forget, import counts in apply summaries

### DIFF
--- a/internal/collections/map.go
+++ b/internal/collections/map.go
@@ -24,8 +24,12 @@ type MapElem[K, V any] struct {
 
 // NewMap constructs a new map whose key type knows how to calculate its own
 // unique keys, by implementing [UniqueKeyer] of itself.
-func NewMap[K UniqueKeyer[K], V any]() Map[K, V] {
-	return NewMapFunc[K, V](K.UniqueKey)
+func NewMap[K UniqueKeyer[K], V any](elems ...MapElem[K, V]) Map[K, V] {
+	m := NewMapFunc[K, V](K.UniqueKey)
+	for _, elems := range elems {
+		m.Put(elems.K, elems.V)
+	}
+	return m
 }
 
 // NewMapFunc constructs a new map with the given "map function".

--- a/internal/stacks/stackruntime/helper_test.go
+++ b/internal/stacks/stackruntime/helper_test.go
@@ -235,12 +235,28 @@ func mustAbsResourceInstanceObject(addr string) stackaddrs.AbsResourceInstanceOb
 	return ret
 }
 
+func mustAbsResourceInstanceObjectPtr(addr string) *stackaddrs.AbsResourceInstanceObject {
+	ret := mustAbsResourceInstanceObject(addr)
+	return &ret
+}
+
 func mustAbsComponentInstance(addr string) stackaddrs.AbsComponentInstance {
 	ret, diags := stackaddrs.ParseAbsComponentInstanceStr(addr)
 	if len(diags) > 0 {
 		panic(fmt.Sprintf("failed to parse component instance address %q: %s", addr, diags))
 	}
 	return ret
+}
+
+func mustAbsComponent(addr string) stackaddrs.AbsComponent {
+	ret, diags := stackaddrs.ParseAbsComponentInstanceStr(addr)
+	if len(diags) > 0 {
+		panic(fmt.Sprintf("failed to parse component instance address %q: %s", addr, diags))
+	}
+	return stackaddrs.AbsComponent{
+		Stack: ret.Stack,
+		Item:  ret.Item.Component,
+	}
 }
 
 // mustPlanDynamicValue is a helper function that constructs a


### PR DESCRIPTION
This PR updates the stacks runtime to include counts for the state management actions (import, forget, move) in the apply-time summaries.

Essentially, these actions don't actually map to real actions during an apply. They're actually already "applied" during the plan, as the state is just modified to reflect the state management before the graph starts. This means they don't get emitted as successful changes during the apply, and as such aren't included in the counts.

After this PR, we look at the set of "affected resources" and validate that each of them is either included in the applied list or counted if they were imported, moved, or forgotten.
