### PR TITLE
Research Prototype: Finer-grain Concurrency Control for Resource Instance nodes

### DIFF
--- a/internal/terraform/execute.go
+++ b/internal/terraform/execute.go
@@ -3,10 +3,65 @@
 
 package terraform
 
-import "github.com/hashicorp/terraform/internal/tfdiags"
+import (
+	"github.com/hashicorp/terraform/internal/dag"
+	"github.com/hashicorp/terraform/internal/tfdiags"
+)
 
 // GraphNodeExecutable is the interface that graph nodes must implement to
 // enable execution.
+//
+// Don't type-assert for this interface directly. Instead, use
+// [executeGraphNode] which arranges for this interface to be used correctly
+// when called for nodes that implement it.
 type GraphNodeExecutable interface {
 	Execute(EvalContext, walkOperation) tfdiags.Diagnostics
+}
+
+// GraphNodeExecutableSema is a variation of [GraphNodeExecutable] for
+// situations where the node implementation needs to handle acquiring and
+// releasing semaphore slots itself.
+//
+// This can be helpful for node types that encapsulate a large number of
+// sequential steps, to enable the implementation to acquire semaphore
+// only for the duration of each nested step, rather than for the entire
+// duration of the Execute method. Implementations of this interface should
+// hold the given semaphore whenever doing I/O-bound work such as provider
+// plugin calls, but need not hold it while performing simple logic.
+//
+// This interface is intentionally mutually-exclusive with [GraphNodeExecutable].
+// Each node type can only implement one of these interfaces.
+//
+// Don't type-assert for this interface directly. Instead, use
+// [executeGraphNode] which arranges for this interface to be used correctly
+// when called for nodes that implement it.
+type GraphNodeExecutableSema interface {
+	Execute(EvalContext, walkOperation, Semaphore) tfdiags.Diagnostics
+}
+
+// executeGraphNode executes any behavior defined for the given graph node
+// that is expected to run when visiting the node during a graph walk.
+//
+// If the given vertex does not have any executable behavior then this is
+// a safe no-op.
+func executeGraphNode(n dag.Vertex, ctx EvalContext, op walkOperation, concurrencySemaphore Semaphore) tfdiags.Diagnostics {
+	switch n := n.(type) {
+	case GraphNodeExecutable:
+		// Nodes that implement this interface expect us to handle concurrency
+		// limits automatically, so we'll acquire the semaphore ourselves
+		// before calling.
+		concurrencySemaphore.Acquire()
+		diags := n.Execute(ctx, op)
+		concurrencySemaphore.Release()
+		return diags
+	case GraphNodeExecutableSema:
+		// Nodes that implement this interface are signing up to handle the
+		// concurrency limits themselves by interacting directly with the
+		// concurrency semaphore.
+		return n.Execute(ctx, op, concurrencySemaphore)
+	default:
+		// Nodes that implement none of these interfaces are not executable,
+		// so we'll treat them as no-op.
+		return nil
+	}
 }

--- a/internal/terraform/graph.go
+++ b/internal/terraform/graph.go
@@ -130,12 +130,12 @@ func (g *Graph) walk(walker GraphWalker) tfdiags.Diagnostics {
 			log.Printf("[TRACE] vertex %q: does not belong to any module instance", dag.VertexName(v))
 		}
 
-		// If the node is exec-able, then execute it.
-		if ev, ok := v.(GraphNodeExecutable); ok {
-			diags = diags.Append(walker.Execute(vertexCtx, ev))
-			if diags.HasErrors() {
-				return
-			}
+		// Try to execute the graph node's behavior.
+		// (If the graph node isn't actually executable then this is a no-op)
+		execDiags := walker.Execute(vertexCtx, v)
+		diags = diags.Append(execDiags)
+		if execDiags.HasErrors() {
+			return
 		}
 
 		// If the node is dynamically expanded, then expand it

--- a/internal/terraform/graph_walk.go
+++ b/internal/terraform/graph_walk.go
@@ -4,6 +4,7 @@
 package terraform
 
 import (
+	"github.com/hashicorp/terraform/internal/dag"
 	"github.com/hashicorp/terraform/internal/tfdiags"
 )
 
@@ -13,7 +14,7 @@ type GraphWalker interface {
 	EvalContext() EvalContext
 	enterScope(evalContextScope) EvalContext
 	exitScope(evalContextScope)
-	Execute(EvalContext, GraphNodeExecutable) tfdiags.Diagnostics
+	Execute(EvalContext, dag.Vertex) tfdiags.Diagnostics
 }
 
 // NullGraphWalker is a GraphWalker implementation that does nothing.
@@ -21,7 +22,7 @@ type GraphWalker interface {
 // implementing all the required functions.
 type NullGraphWalker struct{}
 
-func (NullGraphWalker) EvalContext() EvalContext                                     { return new(MockEvalContext) }
-func (NullGraphWalker) enterScope(evalContextScope) EvalContext                      { return new(MockEvalContext) }
-func (NullGraphWalker) exitScope(evalContextScope)                                   {}
-func (NullGraphWalker) Execute(EvalContext, GraphNodeExecutable) tfdiags.Diagnostics { return nil }
+func (NullGraphWalker) EvalContext() EvalContext                            { return new(MockEvalContext) }
+func (NullGraphWalker) enterScope(evalContextScope) EvalContext             { return new(MockEvalContext) }
+func (NullGraphWalker) exitScope(evalContextScope)                          {}
+func (NullGraphWalker) Execute(EvalContext, dag.Vertex) tfdiags.Diagnostics { return nil }

--- a/internal/terraform/graph_walk_context.go
+++ b/internal/terraform/graph_walk_context.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform/internal/collections"
 	"github.com/hashicorp/terraform/internal/configs"
 	"github.com/hashicorp/terraform/internal/configs/configschema"
+	"github.com/hashicorp/terraform/internal/dag"
 	"github.com/hashicorp/terraform/internal/instances"
 	"github.com/hashicorp/terraform/internal/moduletest/mocking"
 	"github.com/hashicorp/terraform/internal/namedvals"
@@ -145,10 +146,6 @@ func (w *ContextGraphWalker) init() {
 	w.provisionerSchemas = make(map[string]*configschema.Block)
 }
 
-func (w *ContextGraphWalker) Execute(ctx EvalContext, n GraphNodeExecutable) tfdiags.Diagnostics {
-	// Acquire a lock on the semaphore
-	w.Context.parallelSem.Acquire()
-	defer w.Context.parallelSem.Release()
-
-	return n.Execute(ctx, w.Operation)
+func (w *ContextGraphWalker) Execute(ctx EvalContext, n dag.Vertex) tfdiags.Diagnostics {
+	return executeGraphNode(n, ctx, w.Operation, w.Context.parallelSem)
 }

--- a/internal/terraform/node_resource_abstract_instance_test.go
+++ b/internal/terraform/node_resource_abstract_instance_test.go
@@ -232,7 +232,8 @@ func TestNodeAbstractResourceInstance_refresh_with_deferred_read(t *testing.T) {
 	evalCtx.ProviderSchemaSchema = mockProvider.GetProviderSchema()
 	evalCtx.DeferralsState = deferring.NewDeferred(true)
 
-	rio, deferred, diags := node.refresh(evalCtx, states.NotDeposed, obj, true)
+	sema := NewSemaphore(10)
+	rio, deferred, diags := node.refresh(evalCtx, sema, states.NotDeposed, obj, true)
 	if diags.HasErrors() {
 		t.Fatal(diags.Err())
 	}

--- a/internal/terraform/node_resource_destroy_deposed_test.go
+++ b/internal/terraform/node_resource_destroy_deposed_test.go
@@ -66,7 +66,8 @@ func TestNodePlanDeposedResourceInstanceObject_Execute(t *testing.T) {
 		},
 		DeposedKey: deposedKey,
 	}
-	err := node.Execute(ctx, walkPlan)
+	sema := NewSemaphore(10)
+	err := node.Execute(ctx, walkPlan, sema)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
@@ -138,7 +139,8 @@ func TestNodeDestroyDeposedResourceInstanceObject_Execute(t *testing.T) {
 		},
 		DeposedKey: deposedKey,
 	}
-	err := node.Execute(ctx, walkApply)
+	sema := NewSemaphore(10)
+	err := node.Execute(ctx, walkApply, sema)
 
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
@@ -211,7 +213,8 @@ func TestNodeDestroyDeposedResourceInstanceObject_ExecuteMissingState(t *testing
 		},
 		DeposedKey: states.NewDeposedKey(),
 	}
-	err := node.Execute(ctx, walkApply)
+	sema := NewSemaphore(10)
+	err := node.Execute(ctx, walkApply, sema)
 
 	if err == nil {
 		t.Fatal("expected error")

--- a/internal/terraform/node_resource_plan_orphan_test.go
+++ b/internal/terraform/node_resource_plan_orphan_test.go
@@ -64,7 +64,8 @@ func TestNodeResourcePlanOrphanExecute(t *testing.T) {
 			Addr: mustResourceInstanceAddr("test_object.foo"),
 		},
 	}
-	diags := node.Execute(ctx, walkApply)
+	sema := NewSemaphore(10)
+	diags := node.Execute(ctx, walkApply, sema)
 	if diags.HasErrors() {
 		t.Fatalf("unexpected error: %s", diags.Err())
 	}
@@ -130,7 +131,8 @@ func TestNodeResourcePlanOrphanExecute_alreadyDeleted(t *testing.T) {
 			Addr: mustResourceInstanceAddr("test_object.foo"),
 		},
 	}
-	diags := node.Execute(ctx, walkPlan)
+	sema := NewSemaphore(10)
+	diags := node.Execute(ctx, walkPlan, sema)
 	if diags.HasErrors() {
 		t.Fatalf("unexpected error: %s", diags.Err())
 	}
@@ -212,7 +214,8 @@ func TestNodeResourcePlanOrphanExecute_deposed(t *testing.T) {
 			Addr: mustResourceInstanceAddr("test_object.foo"),
 		},
 	}
-	diags := node.Execute(ctx, walkPlan)
+	sema := NewSemaphore(10)
+	diags := node.Execute(ctx, walkPlan, sema)
 	if diags.HasErrors() {
 		t.Fatalf("unexpected error: %s", diags.Err())
 	}

--- a/internal/terraform/semaphore.go
+++ b/internal/terraform/semaphore.go
@@ -44,3 +44,13 @@ func (s Semaphore) Release() {
 		panic("release without an acquire")
 	}
 }
+
+// whileHoldingSemaphore acquires the given semaphore, calls the given
+// function, and then releases the given semaphore before returning
+// the function's result.
+func whileHoldingSemaphore[Ret any](sema Semaphore, f func() Ret) Ret {
+	sema.Acquire()
+	ret := f()
+	sema.Release()
+	return ret
+}

--- a/internal/terraform/transform_import_state_test.go
+++ b/internal/terraform/transform_import_state_test.go
@@ -51,7 +51,8 @@ func TestGraphNodeImportStateExecute(t *testing.T) {
 		},
 	}
 
-	diags := node.Execute(ctx, walkImport)
+	sema := NewSemaphore(10)
+	diags := node.Execute(ctx, walkImport, sema)
 	if diags.HasErrors() {
 		t.Fatalf("Unexpected error: %s", diags.Err())
 	}
@@ -106,7 +107,8 @@ func TestGraphNodeImportStateSubExecute(t *testing.T) {
 			Module:   addrs.RootModule,
 		},
 	}
-	diags := node.Execute(ctx, walkImport)
+	sema := NewSemaphore(10)
+	diags := node.Execute(ctx, walkImport, sema)
 	if diags.HasErrors() {
 		t.Fatalf("Unexpected error: %s", diags.Err())
 	}
@@ -168,7 +170,8 @@ func TestGraphNodeImportStateSubExecuteNull(t *testing.T) {
 			Module:   addrs.RootModule,
 		},
 	}
-	diags := node.Execute(ctx, walkImport)
+	sema := NewSemaphore(10)
+	diags := node.Execute(ctx, walkImport, sema)
 	if !diags.HasErrors() {
 		t.Fatal("expected error for non-existent resource")
 	}


### PR DESCRIPTION
This PR is not intended to be merged, and is instead just a snapshot of some experimentation I've been working on.

For a long time now we've been interested in the idea of making batch requests to providers in various cases, so that we can reduce the number of roundtrips required when an underlying API allows describing multiple operations in a single request. (For older discussion on that, refer to https://github.com/hashicorp/terraform-plugin-sdk/issues/66 and https://github.com/hashicorp/terraform-plugin-sdk/issues/7.)

I've taken various swings at this problem over the years and one thing that's consistently made these attempts difficult is that Terraform Core's execution model uses entire graph nodes as the unit of scheduling, and applies its concurrency limit in terms of number of concurrent node executions rather than number of concurrent provider requests, and therefore we're not scheduling work at the right granularity to be able to do cleverer things, such as noticing that there are multiple "refresh" requests pending and the provider knows how to coalesce them so we could send them all to the provider in a single round-trip.

This PR was an experiment toward one way to avoid that difficulty: allowing particular graph node types to opt out of the whole-node-level concurrency control in favor of handling concurrency control themselves inline.

To experiment with that idea here I've made all of the resource-instance-related graph node types enter their `Execute` methods without any concurrency limit whatsoever, but then we pass the concurrency-limiting semaphore into the `Execute` method so that the implementation can acquire and release the semaphore itself in a more fine-grain way.

In this case I made it hold the semaphore only while making a request to a provider, which is the most granular approach possible. I don't think that is actually the right level of granularity in practice though, because it causes us to tell the UI layer that all of the operations are happening concurrently, and so e.g. 500 "Refreshing" messages can appear all at once even though Terraform is still chunking through them in blocks of 10. The UI should only signal that an operation is starting once it's actually starting, so if we did this for real we'd want to acquire the semaphore at the same time as signalling that the refresh is starting and release it when we signal that it's finished.

---

Since Terraform's execution is very provider-I/O-bound in most cases, this change alone doesn't make any material difference to the overall execution time: we're still spending most of our time waiting for the provider requests to complete.

However, this new approach would make it more feasible for us to, for example, centralize the handling of "refresh" requests so that they can be queued as soon as they become ready (ignoring the concurrency limit) and then the subsystem reading from that queue can be the one to acquire the semaphore, before taking multiple queued requests from the queue to handle all at once in a single provider round-trip.

That design exploits the fact that the concurrency limit inherently creates delays where requests become ready but cannot actually begin executing, which therefore creates an opportunity for many such requests to become ready before an execution slot becomes available, and then all of those requests can be evaluated together and batched whenever possible.

In practice then, with our default concurrency limit of 10, I expect that a state with 500 objects that need refreshing (and that have no dependencies between them) would start by making 10 individual requests that happened to become runnable first, but then the remaining 490 would all get queued waiting for an execution slot. Terraform could then _in principle_ send a single provider request for all 490 objects in the best case.

In practice it's unlikely to be that ideal for various reasons, including but not limited to:
- There's an upper limit on what is a reasonable number of refresh requests to bundle into a single gRPC request to a provider.
- The objects often won't all be of the same type and in that case are less likely to be mutually-coalescable.
- Underlying APIs often have their own limits for how many objects can be requested concurrently.

...but I expect this optimization would still be pretty profitable, and would be _especially_ profitable in cases like using Terraform to manage user accounts where there tend to be many objects all of the same type, since that's the most commonly-supported batching scenario in underlying APIs. (Generalizations like GraphQL or Multipart-MIME batch processing endpoints can be better, but those facilities are not very common in APIs Terraform is typically used with.)

