### PR TITLE
docs: correct function name in `textencodebase64` documentation

### DIFF
--- a/website/docs/language/functions/textencodebase64.mdx
+++ b/website/docs/language/functions/textencodebase64.mdx
@@ -16,7 +16,7 @@ specified character encoding, returning the result base64 encoded because
 Terraform language strings are always sequences of unicode characters.
 
 ```hcl
-substr(string, encoding_name)
+textencodebase64(string, encoding_name)
 ```
 
 Terraform uses the "standard" Base64 alphabet as defined in


### PR DESCRIPTION
`substr` → `textencodebase64`

https://developer.hashicorp.com/terraform/language/functions/textencodebase64