### PR TITLE
fix: skip check evaluation when context is not prepared successfully

### DIFF
--- a/internal/moduletest/eval_context.go
+++ b/internal/moduletest/eval_context.go
@@ -93,6 +93,14 @@ func (ec *EvalContext) Evaluate() (Status, cty.Value, tfdiags.Diagnostics) {
 
 		hclCtx, moreDiags := scope.EvalContext(refs)
 		ruleDiags = ruleDiags.Append(moreDiags)
+		if moreDiags.HasErrors() {
+			// if we can't evaluate the context properly, we can't evaulate the rule
+			// we add the diagnostics to the main diags and continue to the next rule
+			log.Printf("[TRACE] EvalContext.Evaluate: check rule %d for %s is invalid, could not evalaute the context, so cannot evaluate it", i, ec.run.Addr())
+			status = status.Merge(Error)
+			diags = diags.Append(ruleDiags)
+			continue
+		}
 
 		errorMessage, moreDiags := lang.EvalCheckErrorMessage(rule.ErrorMessage, hclCtx)
 		ruleDiags = ruleDiags.Append(moreDiags)


### PR DESCRIPTION
This PR fixes the `terraform test` cmd logging additional errorenous error message while referencing invalid attributes. While evaluating a check, a HCL evaluation context is created for the test command. Some validation is done during the creation of the context, failing which an empty context is returned with the expected diagnostic. This PR stops the evaluation of a check as soon as a diagnostic is returned with an error.

Fixes #35265 

## Target Release

1.9.1

## Draft CHANGELOG entry

### BUG FIXES

-  The `terraform test` command is expected to not show confusing message when context does not contain variables due to validation error
- The expected behaviour is shown for the case mentioned in the issue description:
<img width="790" alt="image" src="https://github.com/hashicorp/terraform/assets/55936223/d1b92342-3414-4a58-8276-6b0864461c99">

