### PR TITLE
Revert "fix: skip check evaluation when context is not prepared successfully"

### DIFF
--- a/internal/moduletest/eval_context.go
+++ b/internal/moduletest/eval_context.go
@@ -93,14 +93,6 @@ func (ec *EvalContext) Evaluate() (Status, cty.Value, tfdiags.Diagnostics) {
 
 		hclCtx, moreDiags := scope.EvalContext(refs)
 		ruleDiags = ruleDiags.Append(moreDiags)
-		if moreDiags.HasErrors() {
-			// if we can't evaluate the context properly, we can't evaulate the rule
-			// we add the diagnostics to the main diags and continue to the next rule
-			log.Printf("[TRACE] EvalContext.Evaluate: check rule %d for %s is invalid, could not evalaute the context, so cannot evaluate it", i, ec.run.Addr())
-			status = status.Merge(Error)
-			diags = diags.Append(ruleDiags)
-			continue
-		}
 
 		errorMessage, moreDiags := lang.EvalCheckErrorMessage(rule.ErrorMessage, hclCtx)
 		ruleDiags = ruleDiags.Append(moreDiags)


### PR DESCRIPTION
Reverts hashicorp/terraform#35408