### PR TITLE
stacks: provide more helpful diagnostics when providers types are mismatched

### DIFF
--- a/internal/configs/config.go
+++ b/internal/configs/config.go
@@ -872,6 +872,20 @@ func (c *Config) ProviderForConfigAddr(addr addrs.LocalProviderConfig) addrs.Pro
 	return c.ResolveAbsProviderAddr(addr, addrs.RootModule).Provider
 }
 
+// RequiredProviderConfig represents a provider configuration that is required
+// by a module, either explicitly or implicitly.
+//
+// An explicit provider means the LocalName within the addrs.LocalProviderConfig
+// was defined directly within the configuration via a required_providers block
+// instead of implied due to the name of a resource or data block.
+//
+// This helps callers of the EffectiveRequiredProviderConfigs function tailor
+// error messages around implied or explicit provider types.
+type RequiredProviderConfig struct {
+	Local    addrs.LocalProviderConfig
+	Explicit bool
+}
+
 // EffectiveRequiredProviderConfigs returns a set of all of the provider
 // configurations this config's direct module expects to have passed in
 // (explicitly or implicitly) by its caller. This method only makes sense
@@ -896,7 +910,7 @@ func (c *Config) ProviderForConfigAddr(addr addrs.LocalProviderConfig) addrs.Pro
 //
 // This function assumes that the configuration is valid. It may produce under-
 // or over-constrained results if called on an invalid configuration.
-func (c *Config) EffectiveRequiredProviderConfigs() addrs.Map[addrs.RootProviderConfig, addrs.LocalProviderConfig] {
+func (c *Config) EffectiveRequiredProviderConfigs() addrs.Map[addrs.RootProviderConfig, RequiredProviderConfig] {
 	// The Terraform language has accumulated so many different ways to imply
 	// the need for a provider configuration that answering this is quite a
 	// complicated process that ends up potentially needing to visit the
@@ -905,23 +919,23 @@ func (c *Config) EffectiveRequiredProviderConfigs() addrs.Map[addrs.RootProvider
 	// can avoid any recursion, but that case is rare in practice.
 
 	if c == nil {
-		return addrs.MakeMap[addrs.RootProviderConfig, addrs.LocalProviderConfig]()
+		return addrs.MakeMap[addrs.RootProviderConfig, RequiredProviderConfig]()
 	}
 
 	// We'll start by visiting all of the "provider" blocks in the module and
 	// figuring out which provider configuration address they each declare. Any
 	// configuration addresses we find here cannot be "required" provider
 	// configs because the module instantiates them itself.
-	selfConfigured := addrs.MakeMap[addrs.RootProviderConfig, addrs.LocalProviderConfig]()
+	selfConfigured := addrs.MakeSet[addrs.RootProviderConfig]()
 	for _, pc := range c.Module.ProviderConfigs {
 		localAddr := pc.Addr()
 		sourceAddr := c.Module.ProviderForLocalConfig(localAddr)
-		selfConfigured.Put(addrs.RootProviderConfig{
+		selfConfigured.Add(addrs.RootProviderConfig{
 			Provider: sourceAddr,
 			Alias:    localAddr.Alias,
-		}, localAddr)
+		})
 	}
-	ret := addrs.MakeMap[addrs.RootProviderConfig, addrs.LocalProviderConfig]()
+	ret := addrs.MakeMap[addrs.RootProviderConfig, RequiredProviderConfig]()
 
 	// maybePut looks up the default local provider for the given root provider.
 	maybePut := func(addr addrs.RootProviderConfig) {
@@ -930,14 +944,22 @@ func (c *Config) EffectiveRequiredProviderConfigs() addrs.Map[addrs.RootProvider
 			LocalName: localName,
 			Alias:     addr.Alias,
 		}
-		if !selfConfigured.Has(addr) {
-			ret.Put(addr, localAddr)
+		if !selfConfigured.Has(addr) && !ret.Has(addr) {
+			ret.Put(addr, RequiredProviderConfig{
+				Local: localAddr,
+
+				// Since we look at the required providers first below, and only
+				// the required providers can set explicit local names, this
+				// will always be false as the map entry will already have been
+				// set if this would be true.
+				Explicit: false,
+			})
 		}
 	}
 
 	// maybePutLocal looks up the default provider for the given local provider
 	// address.
-	maybePutLocal := func(localAddr addrs.LocalProviderConfig) {
+	maybePutLocal := func(localAddr addrs.LocalProviderConfig, explicit bool) {
 		// Caution: this function is only correct to use for LocalProviderConfig
 		// in the _current_ module c.Module. It will produce incorrect results
 		// if used for addresses from any child module.
@@ -945,30 +967,35 @@ func (c *Config) EffectiveRequiredProviderConfigs() addrs.Map[addrs.RootProvider
 			Provider: c.Module.ProviderForLocalConfig(localAddr),
 			Alias:    localAddr.Alias,
 		}
-		if !selfConfigured.Has(addr) {
-			ret.Put(addr, localAddr)
+		if !selfConfigured.Has(addr) && !ret.Has(addr) {
+			ret.Put(addr, RequiredProviderConfig{
+				Local:    localAddr,
+				Explicit: explicit,
+			})
 		}
 	}
 
 	if c.Module.ProviderRequirements != nil {
 		for _, req := range c.Module.ProviderRequirements.RequiredProviders {
 			for _, addr := range req.Aliases {
-				maybePutLocal(addr)
+				// The RequiredProviders block always produces explicit provider
+				// names.
+				maybePutLocal(addr, true)
 			}
 		}
 	}
 	for _, rc := range c.Module.ManagedResources {
-		maybePutLocal(rc.ProviderConfigAddr())
+		maybePutLocal(rc.ProviderConfigAddr(), false)
 	}
 	for _, rc := range c.Module.DataResources {
-		maybePutLocal(rc.ProviderConfigAddr())
+		maybePutLocal(rc.ProviderConfigAddr(), false)
 	}
 	for _, ic := range c.Module.Import {
 		if ic.ProviderConfigRef != nil {
 			maybePutLocal(addrs.LocalProviderConfig{
 				LocalName: ic.ProviderConfigRef.Name,
 				Alias:     ic.ProviderConfigRef.Alias,
-			})
+			}, false)
 		} else {
 			maybePut(addrs.RootProviderConfig{
 				Provider: ic.Provider,
@@ -977,7 +1004,7 @@ func (c *Config) EffectiveRequiredProviderConfigs() addrs.Map[addrs.RootProvider
 	}
 	for _, mc := range c.Module.ModuleCalls {
 		for _, pp := range mc.Providers {
-			maybePutLocal(pp.InParent.Addr())
+			maybePutLocal(pp.InParent.Addr(), false)
 		}
 		// If there aren't any explicitly-passed providers then
 		// the module implicitly requires a default configuration
@@ -1017,4 +1044,12 @@ func (c *Config) CheckCoreVersionRequirements() hcl.Diagnostics {
 	}
 
 	return diags
+}
+
+// ImpliedProviderType returns true if the given local provider configuration
+// is not explicitly declared in the required_providers block of this module or
+// any of its descendants. This means the underlying "type" of the provider
+// has been implied to be a Hashicorp internal provider.
+func (c *Config) ImpliedProviderType(config addrs.LocalProviderConfig) bool {
+	panic("implement me")
 }

--- a/internal/configs/config.go
+++ b/internal/configs/config.go
@@ -1045,11 +1045,3 @@ func (c *Config) CheckCoreVersionRequirements() hcl.Diagnostics {
 
 	return diags
 }
-
-// ImpliedProviderType returns true if the given local provider configuration
-// is not explicitly declared in the required_providers block of this module or
-// any of its descendants. This means the underlying "type" of the provider
-// has been implied to be a Hashicorp internal provider.
-func (c *Config) ImpliedProviderType(config addrs.LocalProviderConfig) bool {
-	panic("implement me")
-}

--- a/internal/stacks/stackruntime/internal/stackeval/component_config.go
+++ b/internal/stacks/stackruntime/internal/stackeval/component_config.go
@@ -331,7 +331,7 @@ func (c *ComponentConfig) CheckProviders(ctx context.Context, phase EvalPhase) (
 					// Then the user just hasn't declared the target provider
 					// type or name at all. We'll return a generic error message
 					// asking the user to update the required_providers list.
-					errorDetail = fmt.Sprintf("\n\nDeclare the required provider in the stack's required_providers block, and then assign a configuration for that provider in this component's \"providers\" argument.")
+					errorDetail = "\n\nDeclare the required provider in the stack's required_providers block, and then assign a configuration for that provider in this component's \"providers\" argument."
 				} else if !matchingNameExists {
 					// Then we have a type that matches, but the name doesn't.
 					errorDetail = fmt.Sprintf("\n\nThis stack has a configured provider of the right type under the name %q. Update this component's \"providers\" argument to reference this provider.", stackName)
@@ -346,7 +346,7 @@ func (c *ComponentConfig) CheckProviders(ctx context.Context, phase EvalPhase) (
 						// implied by Terraform and not explicitly set within
 						// the required_providers block. We'll suggest the user
 						// to update the required_providers block of the module.
-						errorDetail = fmt.Sprintf("\n\nThe provider type required by the module has been automatically implied by Terraform, explicitly setting the provider type within the modules required_providers block may resolve this issue.")
+						errorDetail = "\n\nThe provider type required by the module has been automatically implied by Terraform, explicitly setting the provider type within the modules required_providers block may resolve this issue."
 					}
 
 					// Otherwise the user has explicitly set the provider type

--- a/internal/stacks/stackruntime/internal/stackeval/component_config.go
+++ b/internal/stacks/stackruntime/internal/stackeval/component_config.go
@@ -334,7 +334,7 @@ func (c *ComponentConfig) CheckProviders(ctx context.Context, phase EvalPhase) (
 					errorDetail = "\n\nDeclare the required provider in the stack's required_providers block, and then assign a configuration for that provider in this component's \"providers\" argument."
 				} else if !matchingNameExists {
 					// Then we have a type that matches, but the name doesn't.
-					errorDetail = fmt.Sprintf("\n\nThis stack has a configured provider of the right type under the name %q. Update this component's \"providers\" argument to reference this provider.", stackName)
+					errorDetail = fmt.Sprintf("\n\nThis stack has a configured provider of the correct type under the name %q. Update this component's \"providers\" argument to reference this provider.", stackName)
 				} else if !matchingTypeExists {
 					// Then we have a name that matches, but the type doesn't.
 
@@ -346,7 +346,7 @@ func (c *ComponentConfig) CheckProviders(ctx context.Context, phase EvalPhase) (
 						// implied by Terraform and not explicitly set within
 						// the required_providers block. We'll suggest the user
 						// to update the required_providers block of the module.
-						errorDetail = "\n\nThe provider type required by the module has been automatically implied by Terraform, explicitly setting the provider type within the modules required_providers block may resolve this issue."
+						errorDetail = fmt.Sprintf("\n\nThe module does not declare a source address for %q in its required_provider block, so Terraform assumed %q for backward-compatibility with older versions of Terraform", componentAddr.LocalName, elem.Key.Provider.ForDisplay())
 					}
 
 					// Otherwise the user has explicitly set the provider type

--- a/internal/stacks/stackruntime/internal/stackeval/component_config.go
+++ b/internal/stacks/stackruntime/internal/stackeval/component_config.go
@@ -346,7 +346,7 @@ func (c *ComponentConfig) CheckProviders(ctx context.Context, phase EvalPhase) (
 						// implied by Terraform and not explicitly set within
 						// the required_providers block. We'll suggest the user
 						// to update the required_providers block of the module.
-						errorDetail = fmt.Sprintf("\n\nThe module does not declare a source address for %q in its required_provider block, so Terraform assumed %q for backward-compatibility with older versions of Terraform", componentAddr.LocalName, elem.Key.Provider.ForDisplay())
+						errorDetail = fmt.Sprintf("\n\nThe module does not declare a source address for %q in its required_providers block, so Terraform assumed %q for backward-compatibility with older versions of Terraform", componentAddr.LocalName, elem.Key.Provider.ForDisplay())
 					}
 
 					// Otherwise the user has explicitly set the provider type

--- a/internal/stacks/stackruntime/internal/stackeval/component_instance.go
+++ b/internal/stacks/stackruntime/internal/stackeval/component_instance.go
@@ -173,7 +173,7 @@ func (c *ComponentInstance) CheckProviders(ctx context.Context, phase EvalPhase)
 
 		// componentAddr is the addrs.LocalProviderConfig that specifies the
 		// local name and (optional) alias of the provider in the component.
-		componentAddr := elem.Value
+		componentAddr := elem.Value.Local
 
 		// We validated the config providers during the static analysis, so we
 		// know this expression exists and resolves to the correct type.

--- a/internal/stacks/stackruntime/internal/stackeval/stack.go
+++ b/internal/stacks/stackruntime/internal/stackeval/stack.go
@@ -519,7 +519,7 @@ func (s *Stack) resolveExpressionReference(
 			diags = diags.Append(&hcl.Diagnostic{
 				Severity: hcl.DiagError,
 				Summary:  "Reference to undeclared embedded stack",
-				Detail:   fmt.Sprintf("There is no stack %q block declared this stack.", addr.Name),
+				Detail:   fmt.Sprintf("There is no stack %q block declared in this stack.", addr.Name),
 				Subject:  ref.SourceRange.ToHCL().Ptr(),
 			})
 			return nil, diags
@@ -531,7 +531,7 @@ func (s *Stack) resolveExpressionReference(
 			diags = diags.Append(&hcl.Diagnostic{
 				Severity: hcl.DiagError,
 				Summary:  "Reference to undeclared provider configuration",
-				Detail:   fmt.Sprintf("There is no provider %q %q block declared this stack.", addr.ProviderLocalName, addr.Name),
+				Detail:   fmt.Sprintf("There is no provider %q %q block declared in this stack.", addr.ProviderLocalName, addr.Name),
 				Subject:  ref.SourceRange.ToHCL().Ptr(),
 			})
 			return nil, diags

--- a/internal/stacks/stackruntime/internal/stackeval/stack_config.go
+++ b/internal/stacks/stackruntime/internal/stackeval/stack_config.go
@@ -345,6 +345,16 @@ func (s *StackConfig) ProviderLocalName(ctx context.Context, addr addrs.Provider
 	return s.config.Stack.RequiredProviders.LocalNameForProvider(addr)
 }
 
+// ProviderForLocalName returns the provider for the given local name in this
+// particular stack configuration, based on the declarations in the
+// required_providers configuration block.
+//
+// If the second return value is false then there is no provider declared
+// for the given local name, and so the first return value is invalid.
+func (s *StackConfig) ProviderForLocalName(ctx context.Context, localName string) (addrs.Provider, bool) {
+	return s.config.Stack.RequiredProviders.ProviderForLocalName(localName)
+}
+
 // StackCall returns a [StackCallConfig] representing the "stack" block
 // matching the given address declared within this stack config, or nil if
 // there is no such declaration.
@@ -484,7 +494,7 @@ func (s *StackConfig) resolveExpressionReference(
 			diags = diags.Append(&hcl.Diagnostic{
 				Severity: hcl.DiagError,
 				Summary:  "Reference to undeclared embedded stack",
-				Detail:   fmt.Sprintf("There is no stack %q block declared this stack.", addr.Name),
+				Detail:   fmt.Sprintf("There is no stack %q block declared in this stack.", addr.Name),
 				Subject:  ref.SourceRange.ToHCL().Ptr(),
 			})
 			return nil, diags
@@ -496,7 +506,7 @@ func (s *StackConfig) resolveExpressionReference(
 			diags = diags.Append(&hcl.Diagnostic{
 				Severity: hcl.DiagError,
 				Summary:  "Reference to undeclared provider configuration",
-				Detail:   fmt.Sprintf("There is no provider %q %q block declared this stack.", addr.ProviderLocalName, addr.Name),
+				Detail:   fmt.Sprintf("There is no provider %q %q block declared in this stack.", addr.ProviderLocalName, addr.Name),
 				Subject:  ref.SourceRange.ToHCL().Ptr(),
 			})
 			return nil, diags

--- a/internal/stacks/stackruntime/testdata/mainbundle/test/legacy-module/README.md
+++ b/internal/stacks/stackruntime/testdata/mainbundle/test/legacy-module/README.md
@@ -1,0 +1,5 @@
+# legacy-module
+
+This "legacy module" is so named because it lacks a `required_providers` block
+in its configuration. This means that all provider information must be deduced
+from the calling stack components.

--- a/internal/stacks/stackruntime/testdata/mainbundle/test/legacy-module/main.tf
+++ b/internal/stacks/stackruntime/testdata/mainbundle/test/legacy-module/main.tf
@@ -1,0 +1,14 @@
+variable "id" {
+  type     = string
+  default  = null
+  nullable = true # We'll generate an ID if none provided.
+}
+
+variable "input" {
+  type = string
+}
+
+resource "testing_resource" "data" {
+  id    = var.id
+  value = var.input
+}

--- a/internal/stacks/stackruntime/testdata/mainbundle/test/legacy-module/with-hashicorp-provider/with-hashicorp-provider.tfstack.hcl
+++ b/internal/stacks/stackruntime/testdata/mainbundle/test/legacy-module/with-hashicorp-provider/with-hashicorp-provider.tfstack.hcl
@@ -1,0 +1,24 @@
+required_providers {
+  testing = {
+    source  = "hashicorp/testing"
+    version = "0.1.0"
+  }
+}
+
+provider "testing" "default" {}
+
+variable "input" {
+  type = string
+}
+
+component "self" {
+  source = "../"
+
+  providers = {
+    testing = provider.testing.default
+  }
+
+  inputs = {
+    input = var.input
+  }
+}

--- a/internal/stacks/stackruntime/testdata/mainbundle/test/legacy-module/with-non-hashicorp-provider/with-non-hashicorp-provider.tfstack.hcl
+++ b/internal/stacks/stackruntime/testdata/mainbundle/test/legacy-module/with-non-hashicorp-provider/with-non-hashicorp-provider.tfstack.hcl
@@ -1,0 +1,27 @@
+required_providers {
+  testing = {
+    source  = "other/testing"
+    version = "0.1.0"
+  }
+}
+
+provider "testing" "default" {}
+
+variable "input" {
+  type = string
+}
+
+component "self" {
+  source = "../"
+
+  providers = {
+    # We don't actually specify a provider type for testing in the underlying
+    # module. Terraform will assume it's a HashiCorp provider, but it's not.
+    # This should cause an error with a reasonable message.
+    testing = provider.testing.default
+  }
+
+  inputs = {
+    input = var.input
+  }
+}

--- a/internal/stacks/stackruntime/validate_test.go
+++ b/internal/stacks/stackruntime/validate_test.go
@@ -395,8 +395,6 @@ func TestValidate_impliedProviderTypes(t *testing.T) {
 				return diags
 			},
 		},
-		// TODO: Add a test for deeply nested modules, the middle module still needs a required provider block.
-		// TODO: Add a test that contains all the correct providers in the required_providers block, but mismatches the provider type in the providers attribute.
 	}
 
 	for _, tc := range tcs {

--- a/internal/stacks/stackruntime/validate_test.go
+++ b/internal/stacks/stackruntime/validate_test.go
@@ -107,12 +107,12 @@ var (
 				var diags tfdiags.Diagnostics
 				diags = diags.Append(&hcl.Diagnostic{
 					Severity: hcl.DiagError,
-					Summary:  "Component requires undeclared provider",
-					Detail:   "The root module for component.self requires a configuration for provider \"hashicorp/testing\", which isn't declared as a dependency of this stack configuration.\n\nDeclare this provider in the stack's required_providers block, and then assign a configuration for that provider in this component's \"providers\" argument.",
+					Summary:  "Reference to undeclared provider configuration",
+					Detail:   "There is no provider \"testing\" \"default\" block declared in this stack.",
 					Subject: &hcl.Range{
 						Filename: mainBundleSourceAddrStr("with-single-input/undeclared-provider/undeclared-provider.tfstack.hcl"),
-						Start:    hcl.Pos{Line: 5, Column: 1, Byte: 38},
-						End:      hcl.Pos{Line: 5, Column: 17, Byte: 54},
+						Start:    hcl.Pos{Line: 10, Column: 15, Byte: 163},
+						End:      hcl.Pos{Line: 10, Column: 39, Byte: 187},
 					},
 				})
 				return diags
@@ -140,7 +140,7 @@ var (
 				diags = diags.Append(&hcl.Diagnostic{
 					Severity: hcl.DiagError,
 					Summary:  "Invalid provider configuration",
-					Detail:   "The provider configuration slot testing requires a configuration for provider \"registry.terraform.io/hashicorp/testing\", not for provider \"terraform.io/builtin/testing\".",
+					Detail:   "The provider configuration slot \"testing\" requires a configuration for provider \"registry.terraform.io/hashicorp/testing\", not for provider \"terraform.io/builtin/testing\".",
 					Subject: &hcl.Range{
 						Filename: mainBundleSourceAddrStr("with-single-input/invalid-provider-type/invalid-provider-type.tfstack.hcl"),
 						Start:    hcl.Pos{Line: 22, Column: 15, Byte: 378},
@@ -354,5 +354,70 @@ Terraform uses references to decide a suitable order for performing operations, 
 
 	if diff := cmp.Diff(wantDiags, gotDiags); diff != "" {
 		t.Errorf("wrong diagnostics\n%s", diff)
+	}
+}
+
+func TestValidate_impliedProviderTypes(t *testing.T) {
+
+	tcs := []struct {
+		directory string
+		providers map[addrs.Provider]providers.Factory
+		wantDiags func() tfdiags.Diagnostics
+	}{
+		{
+			directory: "with-hashicorp-provider",
+			providers: map[addrs.Provider]providers.Factory{
+				addrs.NewDefaultProvider("testing"): func() (providers.Interface, error) {
+					return stacks_testing_provider.NewProvider(), nil
+				},
+			},
+		},
+		{
+			directory: "with-non-hashicorp-provider",
+			providers: map[addrs.Provider]providers.Factory{
+				addrs.NewProvider(addrs.DefaultProviderRegistryHost, "other", "testing"): func() (providers.Interface, error) {
+					return stacks_testing_provider.NewProvider(), nil
+				},
+			},
+			wantDiags: func() tfdiags.Diagnostics {
+				var diags tfdiags.Diagnostics
+				diags = diags.Append(&hcl.Diagnostic{
+					Severity: hcl.DiagError,
+					Summary:  "Invalid provider configuration",
+					Detail: "The provider configuration slot \"testing\" requires a configuration for provider \"registry.terraform.io/hashicorp/testing\", not for provider \"registry.terraform.io/other/testing\"." +
+						"\n\nThe provider type required by the module has been automatically implied by Terraform, explicitly setting the provider type within the modules required_providers block may resolve this issue.",
+					Subject: &hcl.Range{
+						Filename: mainBundleSourceAddrStr("legacy-module/with-non-hashicorp-provider/with-non-hashicorp-provider.tfstack.hcl"),
+						Start:    hcl.Pos{Line: 21, Column: 15, Byte: 447},
+						End:      hcl.Pos{Line: 21, Column: 39, Byte: 471},
+					},
+				})
+				return diags
+			},
+		},
+		// TODO: Add a test for deeply nested modules, the middle module still needs a required provider block.
+		// TODO: Add a test that contains all the correct providers in the required_providers block, but mismatches the provider type in the providers attribute.
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.directory, func(t *testing.T) {
+
+			ctx := context.Background()
+
+			cfg := loadMainBundleConfigForTest(t, filepath.Join("legacy-module", tc.directory))
+			gotDiags := Validate(ctx, &ValidateRequest{
+				Config:            cfg,
+				ProviderFactories: tc.providers,
+			}).ForRPC()
+
+			wantDiags := tfdiags.Diagnostics{}.ForRPC()
+			if tc.wantDiags != nil {
+				wantDiags = tc.wantDiags().ForRPC()
+			}
+
+			if diff := cmp.Diff(wantDiags, gotDiags); diff != "" {
+				t.Errorf("wrong diagnostics\n%s", diff)
+			}
+		})
 	}
 }

--- a/internal/stacks/stackruntime/validate_test.go
+++ b/internal/stacks/stackruntime/validate_test.go
@@ -385,7 +385,7 @@ func TestValidate_impliedProviderTypes(t *testing.T) {
 					Severity: hcl.DiagError,
 					Summary:  "Invalid provider configuration",
 					Detail: "The provider configuration slot \"testing\" requires a configuration for provider \"registry.terraform.io/hashicorp/testing\", not for provider \"registry.terraform.io/other/testing\"." +
-						"\n\nThe module does not declare a source address for \"testing\" in its required_provider block, so Terraform assumed \"hashicorp/testing\" for backward-compatibility with older versions of Terraform",
+						"\n\nThe module does not declare a source address for \"testing\" in its required_providers block, so Terraform assumed \"hashicorp/testing\" for backward-compatibility with older versions of Terraform",
 					Subject: &hcl.Range{
 						Filename: mainBundleSourceAddrStr("legacy-module/with-non-hashicorp-provider/with-non-hashicorp-provider.tfstack.hcl"),
 						Start:    hcl.Pos{Line: 21, Column: 15, Byte: 447},

--- a/internal/stacks/stackruntime/validate_test.go
+++ b/internal/stacks/stackruntime/validate_test.go
@@ -385,7 +385,7 @@ func TestValidate_impliedProviderTypes(t *testing.T) {
 					Severity: hcl.DiagError,
 					Summary:  "Invalid provider configuration",
 					Detail: "The provider configuration slot \"testing\" requires a configuration for provider \"registry.terraform.io/hashicorp/testing\", not for provider \"registry.terraform.io/other/testing\"." +
-						"\n\nThe provider type required by the module has been automatically implied by Terraform, explicitly setting the provider type within the modules required_providers block may resolve this issue.",
+						"\n\nThe module does not declare a source address for \"testing\" in its required_provider block, so Terraform assumed \"hashicorp/testing\" for backward-compatibility with older versions of Terraform",
 					Subject: &hcl.Range{
 						Filename: mainBundleSourceAddrStr("legacy-module/with-non-hashicorp-provider/with-non-hashicorp-provider.tfstack.hcl"),
 						Start:    hcl.Pos{Line: 21, Column: 15, Byte: 447},

--- a/internal/stacks/stackruntime/validate_test.go
+++ b/internal/stacks/stackruntime/validate_test.go
@@ -460,11 +460,21 @@ func TestValidate_impliedProviderTypes(t *testing.T) {
 		t.Run(tc.directory, func(t *testing.T) {
 
 			ctx := context.Background()
+			lock := depsfile.NewLocks()
+			for addr := range tc.providers {
+				lock.SetProvider(
+					addr,
+					providerreqs.MustParseVersion("0.0.0"),
+					providerreqs.MustParseVersionConstraints("=0.0.0"),
+					providerreqs.PreferredHashes([]providerreqs.Hash{}),
+				)
+			}
 
 			cfg := loadMainBundleConfigForTest(t, filepath.Join("legacy-module", tc.directory))
 			gotDiags := Validate(ctx, &ValidateRequest{
 				Config:            cfg,
 				ProviderFactories: tc.providers,
+				DependencyLocks:   *lock,
 			}).ForRPC()
 
 			wantDiags := tfdiags.Diagnostics{}.ForRPC()


### PR DESCRIPTION
This PR updates the stacks provider-checking logic to automatically deduce if one of the provider types has been implied. If so, we can probably guess the user is trying to use a non-hashicorp provider and Terraform has assumed the wrong type. We can then provide a more helpful error message, this will tell the user that they should add the non-hashicorp provider to a `required_providers` block to set the right type.