### PR TITLE
add suggestion to run `terraform providers` on provider installation failure

### DIFF
--- a/internal/command/init.go
+++ b/internal/command/init.go
@@ -686,11 +686,12 @@ func (c *InitCommand) getProviders(ctx context.Context, config *configs.Config, 
 				// the end, by checking ctx.Err().
 
 			default:
+				suggestion := fmt.Sprintf("\n\nTo see which modules are currently depending on %s and what versions are specified, run the following command:\n    terraform providers", provider.ForDisplay())
 				diags = diags.Append(tfdiags.Sourceless(
 					tfdiags.Error,
 					"Failed to query available provider packages",
-					fmt.Sprintf("Could not retrieve the list of available versions for provider %s: %s",
-						provider.ForDisplay(), err,
+					fmt.Sprintf("Could not retrieve the list of available versions for provider %s: %s%s",
+						provider.ForDisplay(), err, suggestion,
 					),
 				))
 			}

--- a/internal/command/init_test.go
+++ b/internal/command/init_test.go
@@ -2939,6 +2939,10 @@ Error: Failed to query available provider packages
 Could not retrieve the list of available versions for provider
 hashicorp/test: no available releases match the given constraints 1.0.1,
 1.0.2
+
+To see which modules are currently depending on hashicorp/test and what
+versions are specified, run the following command:
+    terraform providers
 `
 	if diff := cmp.Diff(got, want); len(diff) > 0 {
 		t.Fatalf("wrong error message: \ngot:\n%s\nwant:\n%s\ndiff:\n%s", got, want, diff)


### PR DESCRIPTION
On a default provider install failure we can always suggest running `terraform providers` to help in cases where it's not apparent to the user how to proceed. This would most commonly be encountered by conflicting provider requirements, but if we find there are other common situations we may want to generate a more precise error type for better diagnostics.

Closes #35435