### PR TITLE
stacks: track resource deferrals in apply

### DIFF
--- a/internal/stacks/stackruntime/internal/stackeval/component_instance.go
+++ b/internal/stacks/stackruntime/internal/stackeval/component_instance.go
@@ -948,6 +948,7 @@ func (c *ComponentInstance) ApplyModuleTreePlan(ctx context.Context, plan *plans
 				cic.Forget++
 			}
 		}
+		cic.Defer = plan.DeferredResourceInstanceChanges.Len()
 
 		hookMore(ctx, seq, h.ReportComponentInstanceApplied, cic)
 	}

--- a/internal/stacks/stackruntime/testdata/mainbundle/test/state-manipulation/deferred/deferred.tfstack.hcl
+++ b/internal/stacks/stackruntime/testdata/mainbundle/test/state-manipulation/deferred/deferred.tfstack.hcl
@@ -1,0 +1,24 @@
+required_providers {
+  testing = {
+    source  = "hashicorp/testing"
+    version = "0.1.0"
+  }
+}
+
+provider "testing" "default" {}
+
+component "ok" {
+  source = "./ok"
+
+  providers = {
+    testing = provider.testing.default
+  }
+}
+
+component "deferred" {
+  source = "./deferred"
+
+  providers = {
+    testing = provider.testing.default
+  }
+}

--- a/internal/stacks/stackruntime/testdata/mainbundle/test/state-manipulation/deferred/deferred/deferred.tf
+++ b/internal/stacks/stackruntime/testdata/mainbundle/test/state-manipulation/deferred/deferred/deferred.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_providers {
+    testing = {
+      source  = "hashicorp/testing"
+      version = "0.1.0"
+    }
+  }
+}
+
+resource "testing_deferred_resource" "resource" {
+  id       = "hello"
+  value    = "world"
+  deferred = true
+}

--- a/internal/stacks/stackruntime/testdata/mainbundle/test/state-manipulation/deferred/ok/ok.tf
+++ b/internal/stacks/stackruntime/testdata/mainbundle/test/state-manipulation/deferred/ok/ok.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_providers {
+    testing = {
+      source  = "hashicorp/testing"
+      version = "0.1.0"
+    }
+  }
+}
+
+resource "testing_resource" "self" {
+  id    = "ok"
+  value = "ok"
+}


### PR DESCRIPTION
The apply also needs to know how many resources have been deferred so that orchestration rules might react to it.