### PR TITLE
terraform: Error message for unknown error_message in variable validation [v1.9 backport]

### DIFF
--- a/internal/terraform/eval_variable.go
+++ b/internal/terraform/eval_variable.go
@@ -397,8 +397,23 @@ func evalVariableValidation(validation *configs.CheckRule, hclCtx *hcl.EvalConte
 		return checkResult{Status: status}, diags
 	}
 
+	if !errorValue.IsKnown() {
+		diags = diags.Append(&hcl.Diagnostic{
+			Severity:    hcl.DiagError,
+			Summary:     "Invalid error message",
+			Detail:      "Unsuitable value for error message: expression refers to values that won't be known until the apply phase.",
+			Subject:     validation.ErrorMessage.Range().Ptr(),
+			Expression:  validation.ErrorMessage,
+			EvalContext: hclCtx,
+			Extra:       diagnosticCausedByUnknown(true),
+		})
+		return checkResult{
+			Status: checks.StatusError,
+		}, diags
+	}
+
 	var errorMessage string
-	if !errorDiags.HasErrors() && errorValue.IsKnown() && !errorValue.IsNull() {
+	if !errorDiags.HasErrors() && !errorValue.IsNull() {
 		var err error
 		errorValue, err = convert.Convert(errorValue, cty.String)
 		if err != nil {


### PR DESCRIPTION
This is a backport of https://github.com/hashicorp/terraform/pull/35400 to the v1.9 branch.

I had intended to use the normal backport process but I forgot to add the label before I merged, so here we are. :man_shrugging: 

This was just a direct cherry-pick with no conflicts.
