### PR TITLE
stacks: don't execute components when they have a failed dependency

### DIFF
--- a/internal/stacks/stackruntime/helper_test.go
+++ b/internal/stacks/stackruntime/helper_test.go
@@ -121,6 +121,32 @@ func expectDiagnosticsForTest(t *testing.T, actual tfdiags.Diagnostics, expected
 	}
 }
 
+func expectDiagnosticsForTestUnordered(t *testing.T, actual tfdiags.Diagnostics, expected ...expectedDiagnostic) {
+	t.Helper()
+
+	for _, diag := range expected {
+		found := false
+		for ix, actualDiag := range actual {
+			if actualDiag.Severity() == diag.severity &&
+				actualDiag.Description().Summary == diag.summary &&
+				actualDiag.Description().Detail == diag.detail {
+				found = true
+				actual = append(actual[:ix], actual[ix+1:]...)
+				break
+			}
+		}
+		if !found {
+			t.Errorf("missing diagnostic:    %s - %s", diag.summary, diag.detail)
+		}
+
+	}
+
+	for _, diag := range actual {
+		// Anything left over is unexpected.
+		t.Errorf("unexpected diagnostic: %s - %s", diag.Description().Summary, diag.Description().Detail)
+	}
+}
+
 // reportDiagnosticsForTest creates a test log entry for every diagnostic in
 // the given diags, and halts the test if any of them are error diagnostics.
 func reportDiagnosticsForTest(t *testing.T, diags tfdiags.Diagnostics) {

--- a/internal/stacks/stackruntime/testdata/mainbundle/test/failed-component/failed-component.tf
+++ b/internal/stacks/stackruntime/testdata/mainbundle/test/failed-component/failed-component.tf
@@ -1,0 +1,41 @@
+terraform {
+  required_providers {
+    testing = {
+      source  = "hashicorp/testing"
+      version = "0.1.0"
+    }
+  }
+}
+
+variable "id" {
+  type     = string
+  default  = null
+  nullable = true # We'll generate an ID if none provided.
+}
+
+variable "input" {
+  type = string
+}
+
+variable "fail_plan" {
+  type = bool
+  default = null
+  nullable = true
+}
+
+variable "fail_apply" {
+  type = bool
+  default = null
+  nullable = true
+}
+
+resource "testing_failed_resource" "data" {
+  id    = var.id
+  value = var.input
+  fail_plan = var.fail_plan
+  fail_apply = var.fail_apply
+}
+
+output "value" {
+    value = testing_failed_resource.data.value
+}

--- a/internal/stacks/stackruntime/testdata/mainbundle/test/with-single-input/failed-parent/failed-parent.tfstack.hcl
+++ b/internal/stacks/stackruntime/testdata/mainbundle/test/with-single-input/failed-parent/failed-parent.tfstack.hcl
@@ -1,0 +1,30 @@
+required_providers {
+  testing = {
+    source  = "hashicorp/testing"
+    version = "0.1.0"
+  }
+}
+
+provider "testing" "default" {}
+
+component "parent" {
+  source = "../../failed-component"
+
+  providers = {
+    testing = provider.testing.default
+  }
+  inputs = {
+    input = "Hello, world!"
+    fail_apply = true // This will cause the component to fail during apply.
+  }
+}
+
+component "self" {
+  source = "../"
+  providers = {
+    testing = provider.testing.default
+  }
+  inputs = {
+    input = component.parent.value
+  }
+}

--- a/internal/stacks/stackruntime/testing/provider.go
+++ b/internal/stacks/stackruntime/testing/provider.go
@@ -31,6 +31,15 @@ var (
 		},
 	}
 
+	FailedResourceSchema = &configschema.Block{
+		Attributes: map[string]*configschema.Attribute{
+			"id":         {Type: cty.String, Optional: true, Computed: true},
+			"value":      {Type: cty.String, Optional: true},
+			"fail_plan":  {Type: cty.Bool, Optional: true, Computed: true},
+			"fail_apply": {Type: cty.Bool, Optional: true, Computed: true},
+		},
+	}
+
 	TestingDataSourceSchema = &configschema.Block{
 		Attributes: map[string]*configschema.Attribute{
 			"id":    {Type: cty.String, Required: true},
@@ -77,6 +86,9 @@ func NewProviderWithData(store *ResourceStore) *MockProvider {
 					},
 					"testing_deferred_resource": {
 						Block: DeferredResourceSchema,
+					},
+					"testing_failed_resource": {
+						Block: FailedResourceSchema,
 					},
 				},
 				DataSources: map[string]providers.Schema{
@@ -126,6 +138,31 @@ func NewProviderWithData(store *ResourceStore) *MockProvider {
 					}
 				}
 
+				if request.TypeName == "testing_failed_resource" {
+					// First, populate the fail attributes with null if they are
+					// null
+					if value.GetAttr("fail_apply").IsNull() {
+						vals := value.AsValueMap()
+						vals["fail_apply"] = cty.False
+						value = cty.ObjectVal(vals)
+					}
+					if value.GetAttr("fail_plan").IsNull() {
+						vals := value.AsValueMap()
+						vals["fail_plan"] = cty.False
+						value = cty.ObjectVal(vals)
+					}
+
+					// If fail_plan is set, return a planned failure.
+					if value.GetAttr("fail_plan").True() {
+						return providers.PlanResourceChangeResponse{
+							PlannedState: value,
+							Diagnostics: tfdiags.Diagnostics{
+								tfdiags.Sourceless(tfdiags.Error, "planned failure", "plan failure"),
+							},
+						}
+					}
+				}
+
 				return providers.PlanResourceChangeResponse{
 					PlannedState: value,
 				}
@@ -147,6 +184,16 @@ func NewProviderWithData(store *ResourceStore) *MockProvider {
 					vals := value.AsValueMap()
 					vals["id"] = cty.StringVal(mustGenerateUUID())
 					value = cty.ObjectVal(vals)
+				}
+
+				if request.TypeName == "testing_failed_resource" {
+					if value.GetAttr("fail_apply").True() {
+						return providers.ApplyResourceChangeResponse{
+							Diagnostics: tfdiags.Diagnostics{
+								tfdiags.Sourceless(tfdiags.Error, "planned failure", "apply failure"),
+							},
+						}
+					}
 				}
 
 				// Finally, update the store and return.


### PR DESCRIPTION
This PR updates the stack runtime so that we check that the dependencies for a given component were all successfully applied before applying that component. Previously, we'd just try and apply the dependency with the partial results of the previous components. This works sometimes, as long as all the outputs of the previous components were successfully calculated but most of the time it leads to this error:

```
╷
│ Error: Unsupported attribute
│
│   on ./main.tfstack.hcl line 11, in provider "tfcoremock" "second":
│   11:         resource_directory = component.one.password
│ This object does not have an attribute named "password".
╵
```

The above error is more confusing than helpful, and doesn't address the root cause of the problem.

I think it also makes sense not to apply children of errored components anyway, as users will generally expect that previous components were successful when writing components anyway.