### PR TITLE
core: do not refresh when forgetting instances

### DIFF
--- a/internal/terraform/context_apply2_test.go
+++ b/internal/terraform/context_apply2_test.go
@@ -2743,6 +2743,11 @@ removed {
 		t.Fatalf("diags: %s", diags.Err())
 	}
 
+	// check that the provider was not asked to refresh the resource
+	if p.ReadResourceCalled {
+		t.Fatalf("Expected ReadResource not to be called, but it was called")
+	}
+
 	// check that the provider was not asked to destroy the resource
 	if p.ApplyResourceChangeCalled {
 		t.Fatalf("Expected ApplyResourceChange not to be called, but it was called")
@@ -2787,6 +2792,11 @@ removed {
 	state, diags = ctx.Apply(plan, m, nil)
 	if diags.HasErrors() {
 		t.Fatalf("diags: %s", diags.Err())
+	}
+
+	// check that the provider was not asked to refresh the resource
+	if p.ReadResourceCalled {
+		t.Fatalf("Expected ReadResource not to be called, but it was called")
 	}
 
 	// check that the provider was not asked to destroy the resource


### PR DESCRIPTION
Fixes #35436 

When destroying a resource instance, we always refresh first, to give the provider a chance to tell us that the instance no longer exists. This prevents issues with providers that cannot handle delete requests for already deleted resources.

When forgetting, however, this is unnecessary, since no further requests to the provider will be made for this instance. Indeed, since a main use case for the forget functionality is removing instances from state for which there is no longer a configurable provider, attempting to refresh is both unnecessary and often problematic.