### PR TITLE
build: Produce a Windows arm64 binary

### DIFF
--- a/.changes/v1.15/NEW FEATURES-20250926-164134.yaml
+++ b/.changes/v1.15/NEW FEATURES-20250926-164134.yaml
@@ -1,0 +1,5 @@
+kind: NEW FEATURES
+body: We now produce builds for Windows ARM64
+time: 2025-09-26T16:41:34.771437+02:00
+custom:
+    Issue: "32719"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -121,6 +121,7 @@ jobs:
           - {goos: "solaris", goarch: "amd64", runson: "ubuntu-latest", cgo-enabled: "0"}
           - {goos: "windows", goarch: "386", runson: "ubuntu-latest", cgo-enabled: "0"}
           - {goos: "windows", goarch: "amd64", runson: "ubuntu-latest", cgo-enabled: "0"}
+          - {goos: "windows", goarch: "arm64", runson: "ubuntu-latest", cgo-enabled: "0"}
           - {goos: "darwin", goarch: "amd64", runson: "ubuntu-latest", cgo-enabled: "0"}
           - {goos: "darwin", goarch: "arm64", runson: "ubuntu-latest", cgo-enabled: "0"}
       fail-fast: false
@@ -169,6 +170,7 @@ jobs:
           - {goos: "darwin", goarch: "amd64"}
           - {goos: "darwin", goarch: "arm64"}
           - {goos: "windows", goarch: "amd64"}
+          - {goos: "windows", goarch: "arm64"}
           - {goos: "windows", goarch: "386"}
           - {goos: "linux", goarch: "386"}
           - {goos: "linux", goarch: "amd64"}
@@ -228,6 +230,7 @@ jobs:
           - { runson: ubuntu-latest, goos: linux, goarch: "arm64" }
           - { runson: macos-latest, goos: darwin, goarch: "amd64" }
           - { runson: windows-latest, goos: windows, goarch: "amd64" }
+          - { runson: windows-latest, goos: windows, goarch: "arm64" }
           - { runson: windows-latest, goos: windows, goarch: "386" }
       fail-fast: false
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -270,7 +270,7 @@ jobs:
           unzip "./terraform_${{env.version}}_${{ env.os }}_${{ env.arch }}.zip"
       - name: Set up QEMU
         uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
-        if: ${{ contains(matrix.goarch, 'arm') }}
+        if: ${{ contains(matrix.goarch, 'arm') && matrix.goos != 'windows' }}
         with:
           platforms: all
       - name: Run E2E Tests (Darwin & Linux)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -170,7 +170,6 @@ jobs:
           - {goos: "darwin", goarch: "amd64"}
           - {goos: "darwin", goarch: "arm64"}
           - {goos: "windows", goarch: "amd64"}
-          - {goos: "windows", goarch: "arm64"}
           - {goos: "windows", goarch: "386"}
           - {goos: "linux", goarch: "386"}
           - {goos: "linux", goarch: "amd64"}
@@ -230,7 +229,6 @@ jobs:
           - { runson: ubuntu-latest, goos: linux, goarch: "arm64" }
           - { runson: macos-latest, goos: darwin, goarch: "amd64" }
           - { runson: windows-latest, goos: windows, goarch: "amd64" }
-          - { runson: windows-latest, goos: windows, goarch: "arm64" }
           - { runson: windows-latest, goos: windows, goarch: "386" }
       fail-fast: false
 
@@ -270,7 +268,7 @@ jobs:
           unzip "./terraform_${{env.version}}_${{ env.os }}_${{ env.arch }}.zip"
       - name: Set up QEMU
         uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
-        if: ${{ contains(matrix.goarch, 'arm') && matrix.goos != 'windows' }}
+        if: ${{ contains(matrix.goarch, 'arm') }}
         with:
           platforms: all
       - name: Run E2E Tests (Darwin & Linux)


### PR DESCRIPTION
I'm not familiar enough with platform-specific differences to know whether our ability to produce a build is enough confidence that this will work, or whether we need to do manual testing to verify. We did unfortunately figure out that our existing E2E tests won't work for this platform, so any verification will need to be manual.


Fixes #32719

## Target Release

1.15.x, or we could backport to 1.14.x, this is relatively flexible

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

n/a

## CHANGELOG entry

- [x] This change is user-facing and I added a changelog entry.
- [ ] This change is not user-facing.