### PR TITLE
stacks: insert unknown values for missing outputs during applies

### DIFF
--- a/internal/stacks/stackruntime/apply_test.go
+++ b/internal/stacks/stackruntime/apply_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"path"
+	"path/filepath"
 	"sort"
 	"strings"
 	"testing"
@@ -955,6 +956,206 @@ func TestApplyWithDefaultPlanTimestamp(t *testing.T) {
 			}
 		}
 	}
+}
+
+func TestApplyWithFailedComponent(t *testing.T) {
+	ctx := context.Background()
+	cfg := loadMainBundleConfigForTest(t, filepath.Join("with-single-input", "failed-parent"))
+
+	fakePlanTimestamp, err := time.Parse(time.RFC3339, "1991-08-25T20:57:08Z")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	changesCh := make(chan stackplan.PlannedChange)
+	diagsCh := make(chan tfdiags.Diagnostic)
+	lock := depsfile.NewLocks()
+	lock.SetProvider(
+		addrs.NewDefaultProvider("testing"),
+		providerreqs.MustParseVersion("0.0.0"),
+		providerreqs.MustParseVersionConstraints("=0.0.0"),
+		providerreqs.PreferredHashes([]providerreqs.Hash{}),
+	)
+	req := PlanRequest{
+		Config: cfg,
+		ProviderFactories: map[addrs.Provider]providers.Factory{
+			addrs.NewDefaultProvider("testing"): func() (providers.Interface, error) {
+				return stacks_testing_provider.NewProvider(), nil
+			},
+		},
+		DependencyLocks:    *lock,
+		ForcePlanTimestamp: &fakePlanTimestamp,
+	}
+	resp := PlanResponse{
+		PlannedChanges: changesCh,
+		Diagnostics:    diagsCh,
+	}
+	go Plan(ctx, &req, &resp)
+	planChanges, diags := collectPlanOutput(changesCh, diagsCh)
+	if len(diags) > 0 {
+		t.Fatalf("expected no diagnostics, got %s", diags.ErrWithWarnings())
+	}
+
+	var raw []*anypb.Any
+	for _, change := range planChanges {
+		proto, err := change.PlannedChangeProto()
+		if err != nil {
+			t.Fatal(err)
+		}
+		raw = append(raw, proto.Raw...)
+	}
+
+	applyReq := ApplyRequest{
+		Config:  cfg,
+		RawPlan: raw,
+		ProviderFactories: map[addrs.Provider]providers.Factory{
+			addrs.NewDefaultProvider("testing"): func() (providers.Interface, error) {
+				return stacks_testing_provider.NewProvider(), nil
+			},
+		},
+		DependencyLocks: *lock,
+	}
+
+	applyChangesCh := make(chan stackstate.AppliedChange)
+	diagsCh = make(chan tfdiags.Diagnostic)
+
+	applyResp := ApplyResponse{
+		AppliedChanges: applyChangesCh,
+		Diagnostics:    diagsCh,
+	}
+
+	go Apply(ctx, &applyReq, &applyResp)
+	applyChanges, applyDiags := collectApplyOutput(applyChangesCh, diagsCh)
+
+	expectDiagnosticsForTest(t, applyDiags,
+		// This is the expected failure, from our testing_failed_resource.
+		expectDiagnostic(tfdiags.Error, "planned failure", "apply failure"))
+
+	wantChanges := []stackstate.AppliedChange{
+		&stackstate.AppliedChangeComponentInstance{
+			ComponentAddr:         mustAbsComponent("component.parent"),
+			ComponentInstanceAddr: mustAbsComponentInstance("component.parent"),
+			OutputValues:          make(map[addrs.OutputValue]cty.Value),
+		},
+		&stackstate.AppliedChangeResourceInstanceObject{
+			ResourceInstanceObjectAddr: mustAbsResourceInstanceObject("component.parent.testing_failed_resource.data"),
+			ProviderConfigAddr:         mustDefaultRootProvider("testing"),
+		},
+		&stackstate.AppliedChangeComponentInstance{
+			ComponentAddr:         mustAbsComponent("component.self"),
+			ComponentInstanceAddr: mustAbsComponentInstance("component.self"),
+			OutputValues:          make(map[addrs.OutputValue]cty.Value),
+		},
+	}
+
+	sort.SliceStable(applyChanges, func(i, j int) bool {
+		return appliedChangeSortKey(applyChanges[i]) < appliedChangeSortKey(applyChanges[j])
+	})
+
+	if diff := cmp.Diff(wantChanges, applyChanges, ctydebug.CmpOptions, cmpCollectionsSet); diff != "" {
+		t.Errorf("wrong changes\n%s", diff)
+	}
+
+}
+
+func TestApplyWithFailedProviderLinkedComponent(t *testing.T) {
+	ctx := context.Background()
+	cfg := loadMainBundleConfigForTest(t, filepath.Join("with-single-input", "failed-component-to-provider"))
+
+	fakePlanTimestamp, err := time.Parse(time.RFC3339, "1991-08-25T20:57:08Z")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	changesCh := make(chan stackplan.PlannedChange)
+	diagsCh := make(chan tfdiags.Diagnostic)
+	lock := depsfile.NewLocks()
+	lock.SetProvider(
+		addrs.NewDefaultProvider("testing"),
+		providerreqs.MustParseVersion("0.0.0"),
+		providerreqs.MustParseVersionConstraints("=0.0.0"),
+		providerreqs.PreferredHashes([]providerreqs.Hash{}),
+	)
+	req := PlanRequest{
+		Config: cfg,
+		ProviderFactories: map[addrs.Provider]providers.Factory{
+			addrs.NewDefaultProvider("testing"): func() (providers.Interface, error) {
+				return stacks_testing_provider.NewProvider(), nil
+			},
+		},
+		DependencyLocks:    *lock,
+		ForcePlanTimestamp: &fakePlanTimestamp,
+	}
+	resp := PlanResponse{
+		PlannedChanges: changesCh,
+		Diagnostics:    diagsCh,
+	}
+	go Plan(ctx, &req, &resp)
+	planChanges, diags := collectPlanOutput(changesCh, diagsCh)
+	if len(diags) > 0 {
+		t.Fatalf("expected no diagnostics, got %s", diags.ErrWithWarnings())
+	}
+
+	var raw []*anypb.Any
+	for _, change := range planChanges {
+		proto, err := change.PlannedChangeProto()
+		if err != nil {
+			t.Fatal(err)
+		}
+		raw = append(raw, proto.Raw...)
+	}
+
+	applyReq := ApplyRequest{
+		Config:  cfg,
+		RawPlan: raw,
+		ProviderFactories: map[addrs.Provider]providers.Factory{
+			addrs.NewDefaultProvider("testing"): func() (providers.Interface, error) {
+				return stacks_testing_provider.NewProvider(), nil
+			},
+		},
+		DependencyLocks: *lock,
+	}
+
+	applyChangesCh := make(chan stackstate.AppliedChange)
+	diagsCh = make(chan tfdiags.Diagnostic)
+
+	applyResp := ApplyResponse{
+		AppliedChanges: applyChangesCh,
+		Diagnostics:    diagsCh,
+	}
+
+	go Apply(ctx, &applyReq, &applyResp)
+	applyChanges, applyDiags := collectApplyOutput(applyChangesCh, diagsCh)
+
+	expectDiagnosticsForTest(t, applyDiags,
+		// This is the expected failure, from our testing_failed_resource.
+		expectDiagnostic(tfdiags.Error, "planned failure", "apply failure"))
+
+	wantChanges := []stackstate.AppliedChange{
+		&stackstate.AppliedChangeComponentInstance{
+			ComponentAddr:         mustAbsComponent("component.parent"),
+			ComponentInstanceAddr: mustAbsComponentInstance("component.parent"),
+			OutputValues:          make(map[addrs.OutputValue]cty.Value),
+		},
+		&stackstate.AppliedChangeResourceInstanceObject{
+			ResourceInstanceObjectAddr: mustAbsResourceInstanceObject("component.parent.testing_failed_resource.data"),
+			ProviderConfigAddr:         mustDefaultRootProvider("testing"),
+		},
+		&stackstate.AppliedChangeComponentInstance{
+			ComponentAddr:         mustAbsComponent("component.self"),
+			ComponentInstanceAddr: mustAbsComponentInstance("component.self"),
+			OutputValues:          make(map[addrs.OutputValue]cty.Value),
+		},
+	}
+
+	sort.SliceStable(applyChanges, func(i, j int) bool {
+		return appliedChangeSortKey(applyChanges[i]) < appliedChangeSortKey(applyChanges[j])
+	})
+
+	if diff := cmp.Diff(wantChanges, applyChanges, ctydebug.CmpOptions, cmpCollectionsSet); diff != "" {
+		t.Errorf("wrong changes\n%s", diff)
+	}
+
 }
 
 func TestApplyWithStateManipulation(t *testing.T) {

--- a/internal/stacks/stackruntime/helper_test.go
+++ b/internal/stacks/stackruntime/helper_test.go
@@ -92,7 +92,7 @@ func expectDiagnosticsForTest(t *testing.T, actual tfdiags.Diagnostics, expected
 	t.Helper()
 
 	max := len(expected)
-	if len(actual) < max {
+	if len(actual) > max {
 		max = len(actual)
 	}
 

--- a/internal/stacks/stackruntime/internal/stackeval/component_test.go
+++ b/internal/stacks/stackruntime/internal/stackeval/component_test.go
@@ -260,11 +260,11 @@ func TestComponentResultValue(t *testing.T) {
 		component := getComponent(ctx, t, main)
 		got := component.ResultValue(ctx, InspectPhase)
 		want := cty.ObjectVal(map[string]cty.Value{
-			// FIXME: This currently returns empty object because we
+			// FIXME: This currently returns an unknown value because we
 			// aren't tracking component output values in prior state.
 			// Once we fix that, we should see an output value called "test"
 			// here.
-			//"test": cty.StringVal("hello"),
+			"test": cty.DynamicVal,
 		})
 		if diff := cmp.Diff(want, got, ctydebug.CmpOptions); diff != "" {
 			t.Fatalf("wrong result\n%s", diff)
@@ -308,16 +308,18 @@ func TestComponentResultValue(t *testing.T) {
 			got := component.ResultValue(ctx, InspectPhase)
 			want := cty.ObjectVal(map[string]cty.Value{
 				"a": cty.ObjectVal(map[string]cty.Value{
-					// FIXME: This currently returns empty object because we
+					// FIXME: This currently returns an unknown value because we
 					// aren't tracking component output values in prior state.
 					// Once we fix that, we should see an output value called "test"
 					// here.
+					"test": cty.DynamicVal,
 				}),
 				"b": cty.ObjectVal(map[string]cty.Value{
-					// FIXME: This currently returns empty object because we
+					// FIXME: This currently returns an unknown value because we
 					// aren't tracking component output values in prior state.
 					// Once we fix that, we should see an output value called "test"
 					// here.
+					"test": cty.DynamicVal,
 				}),
 			})
 			// FIXME: the cmp transformer ctydebug.CmpOptions seems to find

--- a/internal/stacks/stackruntime/testdata/mainbundle/test/failed-component/failed-component.tf
+++ b/internal/stacks/stackruntime/testdata/mainbundle/test/failed-component/failed-component.tf
@@ -1,0 +1,43 @@
+terraform {
+  required_providers {
+    testing = {
+      source  = "hashicorp/testing"
+      version = "0.1.0"
+    }
+  }
+}
+
+variable "id" {
+  type     = string
+  default  = null
+  nullable = true # We'll generate an ID if none provided.
+}
+
+variable "input" {
+  type = string
+  default = null
+  nullable = true
+}
+
+variable "fail_plan" {
+  type = bool
+  default = null
+  nullable = true
+}
+
+variable "fail_apply" {
+  type = bool
+  default = null
+  nullable = true
+}
+
+resource "testing_failed_resource" "data" {
+  id    = var.id
+  value = var.input
+  fail_plan = var.fail_plan
+  fail_apply = var.fail_apply
+}
+
+output "value" {
+  value = testing_failed_resource.data.value
+}

--- a/internal/stacks/stackruntime/testdata/mainbundle/test/with-single-input/failed-component-to-provider/failed-component-to-provider.tfstack.hcl
+++ b/internal/stacks/stackruntime/testdata/mainbundle/test/with-single-input/failed-component-to-provider/failed-component-to-provider.tfstack.hcl
@@ -1,0 +1,35 @@
+required_providers {
+  testing = {
+    source  = "hashicorp/testing"
+    version = "0.1.0"
+  }
+}
+
+provider "testing" "default" {}
+
+component "parent" {
+  source = "../../failed-component"
+
+  providers = {
+    testing = provider.testing.default
+  }
+  inputs = {
+    fail_apply = true // This will cause the component to fail during apply.
+  }
+}
+
+provider "testing" "next" {
+  config {
+    configure_error = component.parent.value
+  }
+}
+
+component "self" {
+  source = "../"
+  providers = {
+    testing = provider.testing.next
+  }
+  inputs = {
+    input = "Hello, world!"
+  }
+}

--- a/internal/stacks/stackruntime/testdata/mainbundle/test/with-single-input/failed-parent/failed-parent.tfstack.hcl
+++ b/internal/stacks/stackruntime/testdata/mainbundle/test/with-single-input/failed-parent/failed-parent.tfstack.hcl
@@ -1,0 +1,30 @@
+required_providers {
+  testing = {
+    source  = "hashicorp/testing"
+    version = "0.1.0"
+  }
+}
+
+provider "testing" "default" {}
+
+component "parent" {
+  source = "../../failed-component"
+
+  providers = {
+    testing = provider.testing.default
+  }
+  inputs = {
+    input = "Hello, world!"
+    fail_apply = true // This will cause the component to fail during apply.
+  }
+}
+
+component "self" {
+  source = "../"
+  providers = {
+    testing = provider.testing.default
+  }
+  inputs = {
+    input = component.parent.value
+  }
+}


### PR DESCRIPTION
This PR updates the stack runtime to insert unknown values for outputs that are missing after a components apply operation. A missing component output generally implies the operation failed, and the output was never written to state.

The success status of a component is tracked elsewhere, so while this does insert unknown values where they shouldn't be (ie. during an apply operation at all), this should be okay as anything that depends on the failed component will not execute anyway.

Separately to actual execution, these missing values were causing problems as we validate the component outputs separately (in the `CheckApply` functions) and these missing outputs were causing "missing output" errors to be thrown leading to confusion about the real source of an error.

This is an alternate approach to https://github.com/hashicorp/terraform/pull/35457. @apparentlymart, I'm not sure if we are actually expecting Terraform Core to insert unknown values in the state during failed operations? If so, this is probably not the right fix and there is a bug somewhere in Core. Otherwise, I thought it best to do this here so this new behaviour remains something that Terraform Stacks is responsible for instead of modifying the behaviour of Core in a way that could be a breaking change for anything consuming the state. 