### PR TITLE
Fix flaky test in views package

### DIFF
--- a/internal/command/views/hook_json_test.go
+++ b/internal/command/views/hook_json_test.go
@@ -9,11 +9,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/zclconf/go-cty/cty"
+
 	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/plans"
 	"github.com/hashicorp/terraform/internal/terminal"
 	"github.com/hashicorp/terraform/internal/terraform"
-	"github.com/zclconf/go-cty/cty"
 )
 
 func testJSONHookResourceID(addr addrs.AbsResourceInstance) terraform.HookResourceIdentity {
@@ -76,7 +77,7 @@ func TestJSONHook_create(t *testing.T) {
 	now = now.Add(10 * time.Second)
 	after <- now
 	nowMu.Unlock()
-	time.Sleep(1 * time.Millisecond)
+	time.Sleep(10 * time.Millisecond)
 
 	// Travel 10s into the future, notify the progress goroutine, and sleep
 	// briefly to allow it to execute
@@ -84,7 +85,7 @@ func TestJSONHook_create(t *testing.T) {
 	now = now.Add(10 * time.Second)
 	after <- now
 	nowMu.Unlock()
-	time.Sleep(1 * time.Millisecond)
+	time.Sleep(10 * time.Millisecond)
 
 	// Travel 2s into the future. We have arrived!
 	nowMu.Lock()


### PR DESCRIPTION
According to my testing this was failing 4-5 times every 10000 runs so it wasn't extremely flaky to begin with. What I think was happening was that the test was advancing through the "time travel" portion too quickly so messages were being missing or processed out of order occasionally.

This PR increases the waiting time between "time travel" events, so that the system has longer to process the last event before starting the next one. I successfully got 0 flakes out of 10000 run execution, so while this at least makes future flakes even more unlikely, but maybe we could could make a note of this and revisit as part of some tech debt pay down or product excellence kind of thing.