### PR TITLE
stacks: add additional provider validation tests

### DIFF
--- a/internal/stacks/stackruntime/plan_test.go
+++ b/internal/stacks/stackruntime/plan_test.go
@@ -76,6 +76,12 @@ func TestPlan_valid(t *testing.T) {
 				providerreqs.MustParseVersionConstraints("=0.0.0"),
 				providerreqs.PreferredHashes([]providerreqs.Hash{}),
 			)
+			lock.SetProvider(
+				addrs.NewDefaultProvider("other"),
+				providerreqs.MustParseVersion("0.0.0"),
+				providerreqs.MustParseVersionConstraints("=0.0.0"),
+				providerreqs.PreferredHashes([]providerreqs.Hash{}),
+			)
 			req := PlanRequest{
 				Config: cfg,
 				ProviderFactories: map[addrs.Provider]providers.Factory{
@@ -87,6 +93,11 @@ func TestPlan_valid(t *testing.T) {
 						return stacks_testing_provider.NewProvider(), nil
 					},
 					addrs.NewBuiltInProvider("testing"): func() (providers.Interface, error) {
+						return stacks_testing_provider.NewProvider(), nil
+					},
+					// We also support an "other" provider out of the box to
+					// test the provider aliasing feature.
+					addrs.NewDefaultProvider("other"): func() (providers.Interface, error) {
 						return stacks_testing_provider.NewProvider(), nil
 					},
 				},

--- a/internal/stacks/stackruntime/testdata/mainbundle/test/aliased-provider/aliased-provider.tf
+++ b/internal/stacks/stackruntime/testdata/mainbundle/test/aliased-provider/aliased-provider.tf
@@ -1,0 +1,4 @@
+
+resource "testing_resource" "data" {
+  provider = other
+}

--- a/internal/stacks/stackruntime/testdata/mainbundle/test/aliased-provider/aliased-provider.tfstack.hcl
+++ b/internal/stacks/stackruntime/testdata/mainbundle/test/aliased-provider/aliased-provider.tfstack.hcl
@@ -1,0 +1,16 @@
+required_providers {
+  other = {
+    source  = "hashicorp/other"
+    version = "0.1.0"
+  }
+}
+
+provider "other" "main" {}
+
+component "self" {
+  source = "./"
+
+  providers = {
+    other = provider.other.main
+  }
+}

--- a/internal/stacks/stackruntime/validate_test.go
+++ b/internal/stacks/stackruntime/validate_test.go
@@ -43,6 +43,7 @@ var (
 		"plan-variable-defaults":           {},
 		"variable-output-roundtrip":        {},
 		"variable-output-roundtrip-nested": {},
+		"aliased-provider":                 {},
 		filepath.Join("with-single-input", "input-from-component"): {},
 		filepath.Join("with-single-input", "input-from-component-list"): {
 			planInputVars: map[string]cty.Value{
@@ -259,6 +260,12 @@ func TestValidate_valid(t *testing.T) {
 				providerreqs.MustParseVersionConstraints("=0.0.0"),
 				providerreqs.PreferredHashes([]providerreqs.Hash{}),
 			)
+			lock.SetProvider(
+				addrs.NewDefaultProvider("other"),
+				providerreqs.MustParseVersion("0.0.0"),
+				providerreqs.MustParseVersionConstraints("=0.0.0"),
+				providerreqs.PreferredHashes([]providerreqs.Hash{}),
+			)
 
 			diags := Validate(ctx, &ValidateRequest{
 				Config: cfg,
@@ -271,6 +278,11 @@ func TestValidate_valid(t *testing.T) {
 						return stacks_testing_provider.NewProvider(), nil
 					},
 					addrs.NewBuiltInProvider("testing"): func() (providers.Interface, error) {
+						return stacks_testing_provider.NewProvider(), nil
+					},
+					// We also support an "other" provider out of the box to
+					// test the provider aliasing feature.
+					addrs.NewDefaultProvider("other"): func() (providers.Interface, error) {
 						return stacks_testing_provider.NewProvider(), nil
 					},
 				},


### PR DESCRIPTION
This PR adds new validation and plan tests that test an old error case where we weren't properly assigning the provider type when an alias provider was in use. We actually fixed this by accident while fixing something else in https://github.com/hashicorp/terraform/pull/35422. I'm coming back and adding these test cases in to prevent any regressions in the future.

Internal ticket: https://hashicorp.atlassian.net/browse/TF-18463