### PR TITLE
stacks+promising: Better error messages for promise resolution failure

### DIFF
--- a/internal/promising/errors.go
+++ b/internal/promising/errors.go
@@ -3,16 +3,13 @@
 
 package promising
 
-import (
-	"errors"
-)
+// ErrUnresolved is the error type returned by a promise getter or a main
+// task execution if a task fails to resolve all of the promises it is
+// responsible for before it returns.
+type ErrUnresolved []PromiseID
 
-// ErrUnresolved is the error returned by a promise getter if the task
-// responsible for resolving the promise returns before resolving the promise.
-var ErrUnresolved error
-
-func init() {
-	ErrUnresolved = errors.New("promise unresolved")
+func (err ErrUnresolved) Error() string {
+	return "promise unresolved"
 }
 
 // ErrSelfDependent is the error type returned by a promise getter if the


### PR DESCRIPTION
We were previously just treating `promising.ErrUnresolved` as a singleton that doesn't carry any context along with it. This particular error always represents a bug in the stack runtime rather than a problem with the input, because resolving all of the promises is a key part of the contract for package promising, but it's still helpful to know a little more about what exactly has failed when debugging it.

Therefore `promising.ErrUnresolved` is now a type rather than a value, and its carries with it a set of promise ids that were left unresolved. `stackeval` then recognizes this error type and uses its own records of what each promise was supposed to produce to hopefully return a useful error message that would narrow down what part of the system is buggy.

Since this message always reflects a bug in Terraform the error message will probably just be copy-pasted into a bug report, and so this particular diagnostic type (unlike the one we use for promise self-references) only has one presentation form that we use regardless of how many promises we have to return.

I learned of the unhelpful way this case was previously being reported by receiving a bug report that only said that promise resolution failed, without any context about what had failed. I've changed this now, then, in the hope of future similar situations having a little more information to go on. :grinning: 