### PR TITLE
config generation: stop editing the original schema when filtering

### DIFF
--- a/internal/configs/configschema/copy.go
+++ b/internal/configs/configschema/copy.go
@@ -1,0 +1,68 @@
+package configschema
+
+// DeepCopy returns a deep copy of the schema.
+func (b *Block) DeepCopy() *Block {
+	block := &Block{
+		Description:     b.Description,
+		DescriptionKind: b.DescriptionKind,
+		Deprecated:      b.Deprecated,
+	}
+
+	if b.Attributes != nil {
+		block.Attributes = make(map[string]*Attribute, len(b.Attributes))
+	}
+	for name, a := range b.Attributes {
+		block.Attributes[name] = a.DeepCopy()
+	}
+
+	if b.BlockTypes != nil {
+		block.BlockTypes = make(map[string]*NestedBlock, len(b.BlockTypes))
+	}
+	for name, bt := range b.BlockTypes {
+		inner := bt.Block.DeepCopy()
+		block.BlockTypes[name] = &NestedBlock{
+			Block:    *inner,
+			Nesting:  bt.Nesting,
+			MinItems: bt.MinItems,
+			MaxItems: bt.MaxItems,
+		}
+	}
+
+	return block
+}
+
+// DeepCopy returns a deep copy of the schema.
+func (a *Attribute) DeepCopy() *Attribute {
+	attr := &Attribute{
+		Type:            a.Type,
+		Description:     a.Description,
+		DescriptionKind: a.DescriptionKind,
+		Deprecated:      a.Deprecated,
+		Required:        a.Required,
+		Computed:        a.Computed,
+		Optional:        a.Optional,
+		Sensitive:       a.Sensitive,
+
+		// NestedType is not copied here because it will be copied
+		// separately if it is set.
+		NestedType: nil,
+	}
+	if a.NestedType != nil {
+		attr.NestedType = a.NestedType.DeepCopy()
+	}
+	return attr
+}
+
+// DeepCopy returns a deep copy of the schema.
+func (o *Object) DeepCopy() *Object {
+	object := &Object{
+		Nesting: o.Nesting,
+	}
+	if o.Attributes != nil {
+		object.Attributes = make(map[string]*Attribute, len(o.Attributes))
+		for name, a := range o.Attributes {
+			object.Attributes[name] = a.DeepCopy()
+		}
+	}
+	return object
+}

--- a/internal/configs/configschema/copy.go
+++ b/internal/configs/configschema/copy.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
 package configschema
 
 // DeepCopy returns a deep copy of the schema.

--- a/internal/configs/configschema/filter.go
+++ b/internal/configs/configschema/filter.go
@@ -56,10 +56,11 @@ func (b *Block) filter(path cty.Path, filterAttribute FilterT[*Attribute], filte
 	for name, attrS := range b.Attributes {
 		path := path.GetAttr(name)
 		if filterAttribute == nil || !filterAttribute(path, attrS) {
-			ret.Attributes[name] = attrS
+			attr := *attrS
 			if attrS.NestedType != nil {
-				ret.Attributes[name].NestedType = filterNestedType(attrS.NestedType, path, filterAttribute)
+				attr.NestedType = filterNestedType(attrS.NestedType, path, filterAttribute)
 			}
+			ret.Attributes[name] = &attr
 		}
 	}
 
@@ -95,10 +96,11 @@ func filterNestedType(obj *Object, path cty.Path, filterAttribute FilterT[*Attri
 	for name, attrS := range obj.Attributes {
 		path := path.GetAttr(name)
 		if filterAttribute == nil || !filterAttribute(path, attrS) {
-			ret.Attributes[name] = attrS
+			attr := *attrS
 			if attrS.NestedType != nil {
-				ret.Attributes[name].NestedType = filterNestedType(attrS.NestedType, path, filterAttribute)
+				attr.NestedType = filterNestedType(attrS.NestedType, path, filterAttribute)
 			}
+			ret.Attributes[name] = &attr
 		}
 	}
 

--- a/internal/configs/configschema/filter_test.go
+++ b/internal/configs/configschema/filter_test.go
@@ -278,9 +278,16 @@ func TestFilter(t *testing.T) {
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
+			original := tc.schema.DeepCopy()
+
 			got := tc.schema.Filter(tc.filterAttribute, tc.filterBlock)
 			if !cmp.Equal(got, tc.want, cmp.Comparer(cty.Type.Equals), cmpopts.EquateEmpty()) {
-				t.Fatal(cmp.Diff(got, tc.want, cmp.Comparer(cty.Type.Equals), cmpopts.EquateEmpty()))
+				t.Error(cmp.Diff(got, tc.want, cmp.Comparer(cty.Type.Equals), cmpopts.EquateEmpty()))
+			}
+
+			// We shouldn't have edited the original schema.
+			if !cmp.Equal(tc.schema, original, cmp.Comparer(cty.Type.Equals), cmpopts.EquateEmpty()) {
+				t.Errorf("the original schema was edited when it shouldn't have been: %s", cmp.Diff(tc.schema, original, cmp.Comparer(cty.Type.Equals), cmpopts.EquateEmpty()))
 			}
 		})
 	}


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

This PR updates the schema filtering functions so they don't side-effect edit the original schema with the changes made while filtering. This was causing strange behaviour when generating config, as the value that had already been imported to state started disagreeing with the schema after the config had been generated.

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Fixes #35478 

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.9.3

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

### BUG FIXES

<!--

Write a short description of the user-facing change. Examples:

- `terraform show -json`: Fixed crash with sensitive set values.
- When rendering a diff, Terraform now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 

-  config generation: fix validation error when using nested computed and/or deprecated attributes
