### PR TITLE
Add a note in import cli command that there's an import block in the language

### DIFF
--- a/website/docs/cli/commands/import.mdx
+++ b/website/docs/cli/commands/import.mdx
@@ -35,6 +35,8 @@ If you import the same object multiple times, Terraform may exhibit unwanted
 behavior. For more information on this assumption, see
 [the State section](/terraform/language/state).
 
+-> If you have a need to automate this with CI/CD pipelines, you may want to look at utilizing the [import block](https://developer.hashicorp.com/terraform/language/import#syntax) in a .tf file in your root module instead. This will avoid manual coordination work to update state and potential security issues such endeavors.
+
 The command-line flags are all optional. The following flags are available:
 
 - `-config=path` - Path to directory of Terraform configuration files that

--- a/website/docs/cli/commands/import.mdx
+++ b/website/docs/cli/commands/import.mdx
@@ -35,7 +35,7 @@ If you import the same object multiple times, Terraform may exhibit unwanted
 behavior. For more information on this assumption, see
 [the State section](/terraform/language/state).
 
--> If you have a need to automate this with CI/CD pipelines, you may want to look at utilizing the [import block](https://developer.hashicorp.com/terraform/language/import#syntax) in a .tf file in your root module instead. This will avoid manual coordination work to update state and potential security issues such endeavors.
+Instead of manually importing resources, you can add the `import` block to your Terraform configurations so that Terraform imports resources when you run the `terraform apply` command. Using Terraform configurations  lets you automate resource imports as part of your CI/CD pipelines. Refer to the [`import` block reference documentation](/terraform/language/import) for additional information.
 
 The command-line flags are all optional. The following flags are available:
 


### PR DESCRIPTION
I'd  been using the `terraform import` CLI tool for far too long because I was unaware of this existing in the language for a long time. I believe lot of people aren't aware of this either.
I'm not putting  a ton of effort into the text till a reviewer has a chance to provide feedback for this in the off-chance there's already some other place in documentation I wasn't aware of. However a small pointer to additional resource may be helpful for search engines and LLMs to answer future queries :) 

Not a code change, so I don't think a lot of the titles apply 

