### PR TITLE
stack: stacks should be applyable even if no components are

### DIFF
--- a/internal/rpcapi/stacks_test.go
+++ b/internal/rpcapi/stacks_test.go
@@ -449,13 +449,13 @@ func TestStacksPlanStackChanges(t *testing.T) {
 				PlannedChange: &terraform1.PlannedChange{
 					Raw: []*anypb.Any{
 						mustMarshalAnyPb(&tfstackdata1.PlanApplyable{
-							Applyable: false,
+							Applyable: true,
 						}),
 					},
 					Descriptions: []*terraform1.PlannedChange_ChangeDescription{
 						{
 							Description: &terraform1.PlannedChange_ChangeDescription_PlanApplyable{
-								PlanApplyable: false,
+								PlanApplyable: true,
 							},
 						},
 					},

--- a/internal/stacks/stackruntime/plan_test.go
+++ b/internal/stacks/stackruntime/plan_test.go
@@ -359,7 +359,7 @@ func TestPlanWithVariableDefaults(t *testing.T) {
 
 			wantChanges := []stackplan.PlannedChange{
 				&stackplan.PlannedChangeApplyable{
-					Applyable: false,
+					Applyable: true,
 				},
 				&stackplan.PlannedChangeHeader{
 					TerraformVersion: version.SemVer,
@@ -891,7 +891,7 @@ func TestPlanWithEphemeralInputVariables(t *testing.T) {
 
 		wantChanges := []stackplan.PlannedChange{
 			&stackplan.PlannedChangeApplyable{
-				Applyable: false,
+				Applyable: true,
 			},
 			&stackplan.PlannedChangeHeader{
 				TerraformVersion: version.SemVer,
@@ -949,7 +949,7 @@ func TestPlanWithEphemeralInputVariables(t *testing.T) {
 
 		wantChanges := []stackplan.PlannedChange{
 			&stackplan.PlannedChangeApplyable{
-				Applyable: false,
+				Applyable: true,
 			},
 			&stackplan.PlannedChangeHeader{
 				TerraformVersion: version.SemVer,
@@ -1008,7 +1008,7 @@ func TestPlanVariableOutputRoundtripNested(t *testing.T) {
 
 	wantChanges := []stackplan.PlannedChange{
 		&stackplan.PlannedChangeApplyable{
-			Applyable: false,
+			Applyable: true,
 		},
 		&stackplan.PlannedChangeHeader{
 			TerraformVersion: version.SemVer,
@@ -2145,7 +2145,7 @@ func TestPlanWithDeferredResource(t *testing.T) {
 
 	wantChanges := []stackplan.PlannedChange{
 		&stackplan.PlannedChangeApplyable{
-			Applyable: false,
+			Applyable: true,
 		},
 		&stackplan.PlannedChangeComponentInstance{
 			Addr: stackaddrs.Absolute(
@@ -2787,7 +2787,7 @@ func TestPlanWithDeferredEmbeddedStackForEach(t *testing.T) {
 
 	wantChanges := []stackplan.PlannedChange{
 		&stackplan.PlannedChangeApplyable{
-			Applyable: false,
+			Applyable: true,
 		},
 		&stackplan.PlannedChangeHeader{
 			TerraformVersion: version.SemVer,
@@ -2933,7 +2933,7 @@ func TestPlanWithDeferredEmbeddedStackAndComponentForEach(t *testing.T) {
 
 	wantChanges := []stackplan.PlannedChange{
 		&stackplan.PlannedChangeApplyable{
-			Applyable: false,
+			Applyable: true,
 		},
 		&stackplan.PlannedChangeHeader{
 			TerraformVersion: version.SemVer,
@@ -3140,7 +3140,7 @@ func TestPlanWithDeferredProviderForEach(t *testing.T) {
 
 	wantChanges := []stackplan.PlannedChange{
 		&stackplan.PlannedChangeApplyable{
-			Applyable: false,
+			Applyable: true,
 		},
 		&stackplan.PlannedChangeComponentInstance{
 			Addr: stackaddrs.Absolute(


### PR DESCRIPTION
This PR updates stack plans to be applyable even if they will make no changes to the infrastructure. This is because applying a stack plan with no changes will still perform any necessary state migrations, and allows users to upgrade state without making infrastructure changes.

We should revisit this in more detail to decide exactly what it means for something to `errored` and/or `applyable`. See the internal ticket for more detail: https://hashicorp.atlassian.net/browse/TF-18859