### PR TITLE
build: Set up Dependabot for go security updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,15 @@
 version: 2
 updates:
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: daily
+    labels:
+      - dependencies
+      - go
+      - security
+    # Disable regular version updates and only use Dependabot for security updates
+    open-pull-requests-limit: 0
   - package-ecosystem: github-actions
     directory: /
     schedule:


### PR DESCRIPTION
This sets up Dependabot to automatically create PRs for Go dependencies with security vulnerabilities. The trick here is the `open-pull-requests-limit: 0` [setting](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#open-pull-requests-limit), which is essentially the part that says "don't have Dependabot create PRs for regular dependency upgrades, only for security issues". The `schedule.interval: daily` ensures that once a security vulnerability is flagged and a dependency upgrade is available that solves the issue, Dependabot will create a new PR within 24 hours. That seems appropriate for security issues.

Eventually we'd like to see if we can scale up to more regular (non-security) dependency upgrades using Dependabot, but given the concern about the maintenance of backends, let's start here first and see how it goes.