### PR TITLE
deferred resources: fix crash when a non-deferred data source depends on deferred resources

### DIFF
--- a/internal/plans/deferring/deferred.go
+++ b/internal/plans/deferring/deferred.go
@@ -333,6 +333,14 @@ func (d *Deferred) ShouldDeferResourceInstanceChanges(addr addrs.AbsResourceInst
 // instances of a resource will be declared and thus we must defer all planning
 // for that resource.
 func (d *Deferred) ReportResourceExpansionDeferred(addr addrs.PartialExpandedResource, change *plans.ResourceInstanceChange) {
+	if change == nil {
+		// This indicates a bug in Terraform, we shouldn't ever be setting a
+		// null change. Note, if we don't make this check here, then we'll
+		// just crash later anyway. This way the stack trace points to the
+		// source of the problem.
+		panic("change must not be nil")
+	}
+
 	d.mu.Lock()
 	defer d.mu.Unlock()
 
@@ -363,6 +371,14 @@ func (d *Deferred) ReportResourceExpansionDeferred(addr addrs.PartialExpandedRes
 // instances of a data source will be declared and thus we must defer all
 // planning for that data source.
 func (d *Deferred) ReportDataSourceExpansionDeferred(addr addrs.PartialExpandedResource, change *plans.ResourceInstanceChange) {
+	if change == nil {
+		// This indicates a bug in Terraform, we shouldn't ever be setting a
+		// null change. Note, if we don't make this check here, then we'll
+		// just crash later anyway. This way the stack trace points to the
+		// source of the problem.
+		panic("change must not be nil")
+	}
+
 	d.mu.Lock()
 	defer d.mu.Unlock()
 
@@ -393,6 +409,14 @@ func (d *Deferred) ReportDataSourceExpansionDeferred(addr addrs.PartialExpandedR
 // instance has had its planned action deferred to a future round for a reason
 // other than its address being only partially-decided.
 func (d *Deferred) ReportResourceInstanceDeferred(addr addrs.AbsResourceInstance, reason providers.DeferredReason, change *plans.ResourceInstanceChange) {
+	if change == nil {
+		// This indicates a bug in Terraform, we shouldn't ever be setting a
+		// null change. Note, if we don't make this check here, then we'll
+		// just crash later anyway. This way the stack trace points to the
+		// source of the problem.
+		panic("change must not be nil")
+	}
+
 	d.mu.Lock()
 	defer d.mu.Unlock()
 
@@ -414,6 +438,14 @@ func (d *Deferred) ReportResourceInstanceDeferred(addr addrs.AbsResourceInstance
 }
 
 func (d *Deferred) ReportDataSourceInstanceDeferred(addr addrs.AbsResourceInstance, reason providers.DeferredReason, change *plans.ResourceInstanceChange) {
+	if change == nil {
+		// This indicates a bug in Terraform, we shouldn't ever be setting a
+		// null change. Note, if we don't make this check here, then we'll
+		// just crash later anyway. This way the stack trace points to the
+		// source of the problem.
+		panic("change must not be nil")
+	}
+
 	d.mu.Lock()
 	defer d.mu.Unlock()
 


### PR DESCRIPTION

<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

This PR fixes two crashes that would occur when a data source that does not get deferred depends on a resource (or data source) that is being deferred.

Essentially, we have the fact that the `planDataSource` function that only returns a change if it is either (a) deferring the data source to a future plan or (b) reloading it during the apply. In addition, during refresh only plans the function does not return a change even if the above conditions are true. 

This leads to the two crashes. One is where the neither of the two conditions are true, and the function returns a `nil` change. The second is during a refresh plan, when Terraform decides not to even attempts to refresh the data source it would always return a `nil` change.

In both cases, if the data source itself was not being deferred but did depend on another resource being deferred we would then write the `nil` planned change into the list of deferred changes. Later, we'd try and read the deferred changes for post processing and crash as a result of one the entries being nil.

I've changed the order of operations a little bit so that in this case the `planDataSource` function is notified up front that this change will be deferred later regardless of what it does. It now knows to produce a change when it is going to be deferred even if wasn't requested to be deferred internally. In addition, the caller now knows that a `nil` returned change means that either this data source shouldn't be deferred, or that even if we would otherwise defer it, no change was actually attempted and therefore there is nothing to defer.

Finally, I've updated the deferral tracking logic itself so that it directly panics when someone tries to insert a nil change. This is always an error, and will panic later anyway, but now the stack trace will point to exactly where the nil change is being created instead of the place it is later referenced which isn't particularly helpful.

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Internal Ticket: [TF-18566](https://hashicorp.atlassian.net/browse/TF-18566)

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

N/A, deferred actions are still in alpha.

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

### NEW FEATURES | UPGRADE NOTES | ENHANCEMENTS | BUG FIXES | EXPERIMENTS

<!--

Write a short description of the user-facing change. Examples:

- `terraform show -json`: Fixed crash with sensitive set values.
- When rendering a diff, Terraform now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 

N/A, deferred actions are still in alpha.


[TF-18566]: https://hashicorp.atlassian.net/browse/TF-18566?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ