### PR TITLE
Backport #35511

### DIFF
--- a/internal/terraform/context_apply2_test.go
+++ b/internal/terraform/context_apply2_test.go
@@ -2177,6 +2177,13 @@ variable "input" {
     }
 }
 
+# In order for the variable to be validated during destroy, it must be required
+# by the destroy plan. This is done by having the test provider require the
+# value in order to destroy the test_object instance.
+provider "test" {
+  test_string = var.input
+}
+
 resource "test_object" "a" {
 	test_string = var.input
 }

--- a/internal/terraform/context_plan2_test.go
+++ b/internal/terraform/context_plan2_test.go
@@ -5658,3 +5658,66 @@ resource "test_object" "a" {
 	}
 
 }
+
+func TestContext2Plan_destroySkipsVariableValidations(t *testing.T) {
+	// this validation cannot block destroy, because we can't be sure arbitrary
+	// expressions can be evaluated at all during destroy.
+	m := testModuleInline(t, map[string]string{
+		"main.tf": `
+variable "input" {
+  type = string
+
+  validation {
+    condition = var.input == "foo"
+    error_message = "bad input"
+  }
+}
+
+resource "test_object" "a" {
+  test_string = var.input
+}
+`,
+	})
+
+	p := simpleMockProvider()
+	ctx := testContext2(t, &ContextOpts{
+		Providers: map[addrs.Provider]providers.Factory{
+			addrs.NewDefaultProvider("test"): testProviderFuncFixed(p),
+		},
+	})
+
+	plan, diags := ctx.Plan(m, states.BuildState(func(state *states.SyncState) {
+		state.SetResourceInstanceCurrent(
+			mustResourceInstanceAddr("test_object.a"),
+			&states.ResourceInstanceObjectSrc{
+				Status:    states.ObjectReady,
+				AttrsJSON: []byte(`{"test_string":"foo"}`),
+			},
+			mustProviderConfig(`provider["registry.terraform.io/hashicorp/test"]`),
+		)
+	}), &PlanOpts{
+		Mode: plans.DestroyMode,
+		SetVariables: InputValues{
+			"input": {
+				Value:       cty.StringVal("foo"),
+				SourceType:  ValueFromCLIArg,
+				SourceRange: tfdiags.SourceRange{},
+			},
+		},
+	})
+	if diags.HasErrors() {
+		t.Errorf("expected no errors, but got %s", diags)
+	}
+
+	planResult := plan.Checks.GetObjectResult(addrs.AbsInputVariableInstance{
+		Variable: addrs.InputVariable{
+			Name: "input",
+		},
+		Module: addrs.RootModuleInstance,
+	})
+
+	if planResult.Status != checks.StatusUnknown {
+		// checks should not have been evaluated, because the variable is not required for destroy.
+		t.Errorf("expected checks to be pass but was %s", planResult.Status)
+	}
+}

--- a/internal/terraform/node_variable_validation.go
+++ b/internal/terraform/node_variable_validation.go
@@ -40,6 +40,7 @@ var _ GraphNodeModulePath = (*nodeVariableValidation)(nil)
 var _ GraphNodeReferenceable = (*nodeVariableValidation)(nil)
 var _ GraphNodeReferencer = (*nodeVariableValidation)(nil)
 var _ GraphNodeExecutable = (*nodeVariableValidation)(nil)
+var _ graphNodeTemporaryValue = (*nodeVariableValidation)(nil)
 
 func (n *nodeVariableValidation) Name() string {
 	return fmt.Sprintf("%s (validation)", n.configAddr.String())
@@ -55,6 +56,15 @@ func (n *nodeVariableValidation) ModulePath() addrs.Module {
 // validating, and must therefore run before any nodes that refer to it.
 func (n *nodeVariableValidation) ReferenceableAddrs() []addrs.Referenceable {
 	return []addrs.Referenceable{n.configAddr.Variable}
+}
+
+// nodeVariableValidation must act as if it's part of the associated variable
+// node, and that means mirroring all that node's graph behavior. Root module
+// variable are not temporary however, but because during a destroy we can't
+// ensure that all references can be evaluated, we must skip validation unless
+// absolutely necessary to avoid blocking the destroy from proceeding.
+func (n *nodeVariableValidation) temporaryValue() bool {
+	return true
 }
 
 // References implements [GraphNodeReferencer], announcing anything that


### PR DESCRIPTION
manual backport of #35511

---

Arbitrary expressions cannot be evaluated during destroy, because the "state" of the state is unknown. Missing resources or invalid data will cause evaluations to fail, preventing any progress in the destroy operations.

The way we handle this with providers and temporary values that need to be re-evaluated during destroy, is that they are selectively pruned out of the graph during the destroy process. Now that variable validations can reference other values in the configuration (#34947), which added another evaluation node type to the graph, that new node type must also act like it's a temporary value akin to variables, locals, and outputs.

This has some implications for validations in general, since they were always run during a destroy (#34101). Now that validations can reference other objects, we cannot be sure the evaluation is possible, and they must be subject to the same rules as all temporary values and be skipped when not required in the destroy graph. In order to preserve some of the behavior decided on in 34011, rather than skip the validation nodes entirely during destroy, we use the `graphNodeTemporaryValue` behavior to selectively prune them from the graph. 