### PR TITLE
stacks: apply automatic type conversion before comparing inputs

### DIFF
--- a/internal/plans/objchange/compatible.go
+++ b/internal/plans/objchange/compatible.go
@@ -196,6 +196,13 @@ func assertObjectCompatible(schema *configschema.Block, planned, actual cty.Valu
 	return errs
 }
 
+// AssertValueCompatible matches the behavior of AssertObjectCompatible but
+// for a single value rather than a whole object. This is used by the stacks
+// package to compare before and after values of inputs.
+func AssertValueCompatible(planned, actual cty.Value) []error {
+	return assertValueCompatible(planned, actual, nil)
+}
+
 func assertValueCompatible(planned, actual cty.Value, path cty.Path) []error {
 	// NOTE: We don't normally use the GoString rendering of cty.Value in
 	// user-facing error messages as a rule, but we make an exception

--- a/internal/stacks/stackruntime/apply_test.go
+++ b/internal/stacks/stackruntime/apply_test.go
@@ -1707,7 +1707,7 @@ func TestApplyWithStateManipulation(t *testing.T) {
 	}
 }
 
-func TestApplyWithChangedValues(t *testing.T) {
+func TestApplyWithChangedComponentValues(t *testing.T) {
 	ctx := context.Background()
 	cfg := loadMainBundleConfigForTest(t, filepath.Join("with-single-input", "valid"))
 
@@ -1795,13 +1795,10 @@ func TestApplyWithChangedValues(t *testing.T) {
 	}
 
 	go Apply(ctx, &applyReq, &applyResp)
-	_, applyDiags := collectApplyOutput(applyChangesCh, diagsCh)
+	applyChanges, applyDiags := collectApplyOutput(applyChangesCh, diagsCh)
 	if len(applyDiags) != 1 {
 		t.Fatalf("expected exactly one diagnostic, got %s", applyDiags.ErrWithWarnings())
 	}
-
-	// We don't care about the changes here, just that we got the diagnostic
-	// we expected when we messed the plan up earlier.
 
 	gotSeverity, wantSeverity := applyDiags[0].Severity(), tfdiags.Error
 	gotSummary, wantSummary := applyDiags[0].Description().Summary, "Planned input variable value changed"
@@ -1815,6 +1812,587 @@ func TestApplyWithChangedValues(t *testing.T) {
 	}
 	if gotDetail != wantDetail {
 		t.Errorf("expected detail %q, got %q", wantDetail, gotDetail)
+	}
+
+	wantChanges := []stackstate.AppliedChange{
+		&stackstate.AppliedChangeComponentInstance{
+			ComponentAddr:         mustAbsComponent("component.self"),
+			ComponentInstanceAddr: mustAbsComponentInstance("component.self"),
+			OutputValues:          make(map[addrs.OutputValue]cty.Value),
+		},
+		// no resources should have been created because the input variable was
+		// invalid.
+	}
+
+	sort.SliceStable(applyChanges, func(i, j int) bool {
+		return appliedChangeSortKey(applyChanges[i]) < appliedChangeSortKey(applyChanges[j])
+	})
+
+	if diff := cmp.Diff(wantChanges, applyChanges, ctydebug.CmpOptions, cmpCollectionsSet); diff != "" {
+		t.Errorf("wrong changes\n%s", diff)
+	}
+}
+
+func TestApplyWithChangedInputValues(t *testing.T) {
+	ctx := context.Background()
+	cfg := loadMainBundleConfigForTest(t, filepath.Join("with-single-input", "valid"))
+
+	fakePlanTimestamp, err := time.Parse(time.RFC3339, "1991-08-25T20:57:08Z")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	changesCh := make(chan stackplan.PlannedChange)
+	diagsCh := make(chan tfdiags.Diagnostic)
+	lock := depsfile.NewLocks()
+	lock.SetProvider(
+		addrs.NewDefaultProvider("testing"),
+		providerreqs.MustParseVersion("0.0.0"),
+		providerreqs.MustParseVersionConstraints("=0.0.0"),
+		providerreqs.PreferredHashes([]providerreqs.Hash{}),
+	)
+	req := PlanRequest{
+		Config: cfg,
+		ProviderFactories: map[addrs.Provider]providers.Factory{
+			addrs.NewDefaultProvider("testing"): func() (providers.Interface, error) {
+				return stacks_testing_provider.NewProvider(), nil
+			},
+		},
+		DependencyLocks: *lock,
+
+		ForcePlanTimestamp: &fakePlanTimestamp,
+
+		InputValues: map[stackaddrs.InputVariable]ExternalInputValue{
+			stackaddrs.InputVariable{Name: "input"}: {
+				Value: cty.StringVal("hello"),
+			},
+		},
+	}
+	resp := PlanResponse{
+		PlannedChanges: changesCh,
+		Diagnostics:    diagsCh,
+	}
+
+	go Plan(ctx, &req, &resp)
+	planChanges, diags := collectPlanOutput(changesCh, diagsCh)
+	if len(diags) > 0 {
+		t.Fatalf("expected no diagnostics, got %s", diags.ErrWithWarnings())
+	}
+
+	planLoader := stackplan.NewLoader()
+	for _, change := range planChanges {
+		proto, err := change.PlannedChangeProto()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		for _, rawMsg := range proto.Raw {
+			err = planLoader.AddRaw(rawMsg)
+			if err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+	plan, err := planLoader.Plan()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	applyReq := ApplyRequest{
+		Config: cfg,
+		Plan:   plan,
+		ProviderFactories: map[addrs.Provider]providers.Factory{
+			addrs.NewDefaultProvider("testing"): func() (providers.Interface, error) {
+				return stacks_testing_provider.NewProvider(), nil
+			},
+		},
+		DependencyLocks: *lock,
+		InputValues: map[stackaddrs.InputVariable]ExternalInputValue{
+			// This time we're deliberately changing the values we're giving
+			// to the apply operation. We expect this to fail earlier than
+			// the previous test.
+			stackaddrs.InputVariable{Name: "input"}: {
+				Value: cty.StringVal("world"),
+			},
+		},
+	}
+
+	applyChangesCh := make(chan stackstate.AppliedChange)
+	diagsCh = make(chan tfdiags.Diagnostic)
+
+	applyResp := ApplyResponse{
+		AppliedChanges: applyChangesCh,
+		Diagnostics:    diagsCh,
+	}
+
+	go Apply(ctx, &applyReq, &applyResp)
+	applyChanges, applyDiags := collectApplyOutput(applyChangesCh, diagsCh)
+	if len(applyDiags) != 2 {
+		t.Fatalf("expected exactly two diagnostics, got %s", applyDiags.ErrWithWarnings())
+	}
+
+	gotSeverity, wantSeverity := applyDiags[0].Severity(), tfdiags.Error
+	gotSummary, wantSummary := applyDiags[0].Description().Summary, "Inconsistent value for input variable during apply"
+	gotDetail, wantDetail := applyDiags[0].Description().Detail, "The value for non-ephemeral input variable \"input\" was set to a different value during apply than was set during plan. Only ephemeral input variables can change between the plan and apply phases."
+
+	if gotSeverity != wantSeverity {
+		t.Errorf("expected severity %q, got %q", wantSeverity, gotSeverity)
+	}
+	if gotSummary != wantSummary {
+		t.Errorf("expected summary %q, got %q", wantSummary, gotSummary)
+	}
+	if gotDetail != wantDetail {
+		t.Errorf("expected detail %q, got %q", wantDetail, gotDetail)
+	}
+
+	// We'll also receive a second error message here, since the invalid input
+	// has affected the component as well.
+
+	gotSeverity, wantSeverity = applyDiags[1].Severity(), tfdiags.Error
+	gotSummary, wantSummary = applyDiags[1].Description().Summary, "Planned input variable value changed"
+	gotDetail, wantDetail = applyDiags[1].Description().Detail, "The planned value for input variable \"input\" has changed between the planning and apply phases for component.self. This is a bug in Terraform - please report it."
+
+	if gotSeverity != wantSeverity {
+		t.Errorf("expected severity %q, got %q", wantSeverity, gotSeverity)
+	}
+	if gotSummary != wantSummary {
+		t.Errorf("expected summary %q, got %q", wantSummary, gotSummary)
+	}
+	if gotDetail != wantDetail {
+		t.Errorf("expected detail %q, got %q", wantDetail, gotDetail)
+	}
+
+	wantChanges := []stackstate.AppliedChange{
+		&stackstate.AppliedChangeComponentInstance{
+			ComponentAddr:         mustAbsComponent("component.self"),
+			ComponentInstanceAddr: mustAbsComponentInstance("component.self"),
+			OutputValues:          make(map[addrs.OutputValue]cty.Value),
+		},
+		// no resources should have been created because the input variable was
+		// invalid.
+	}
+
+	sort.SliceStable(applyChanges, func(i, j int) bool {
+		return appliedChangeSortKey(applyChanges[i]) < appliedChangeSortKey(applyChanges[j])
+	})
+
+	if diff := cmp.Diff(wantChanges, applyChanges, ctydebug.CmpOptions, cmpCollectionsSet); diff != "" {
+		t.Errorf("wrong changes\n%s", diff)
+	}
+}
+
+func TestApplyAutomaticInputConversion(t *testing.T) {
+	ctx := context.Background()
+	cfg := loadMainBundleConfigForTest(t, filepath.Join("with-single-input", "for-each-component"))
+
+	fakePlanTimestamp, err := time.Parse(time.RFC3339, "1991-08-25T20:57:08Z")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	changesCh := make(chan stackplan.PlannedChange)
+	diagsCh := make(chan tfdiags.Diagnostic)
+	lock := depsfile.NewLocks()
+	lock.SetProvider(
+		addrs.NewDefaultProvider("testing"),
+		providerreqs.MustParseVersion("0.0.0"),
+		providerreqs.MustParseVersionConstraints("=0.0.0"),
+		providerreqs.PreferredHashes([]providerreqs.Hash{}),
+	)
+	req := PlanRequest{
+		Config: cfg,
+		ProviderFactories: map[addrs.Provider]providers.Factory{
+			addrs.NewDefaultProvider("testing"): func() (providers.Interface, error) {
+				return stacks_testing_provider.NewProvider(), nil
+			},
+		},
+		DependencyLocks: *lock,
+
+		ForcePlanTimestamp: &fakePlanTimestamp,
+
+		InputValues: map[stackaddrs.InputVariable]ExternalInputValue{
+			stackaddrs.InputVariable{Name: "input"}: {
+				// The stack expects a map of strings, but we're giving it
+				// an object. Terraform should automatically convert this to
+				// the expected type.
+				Value: cty.ObjectVal(map[string]cty.Value{
+					"hello": cty.StringVal("hello"),
+					"world": cty.StringVal("world"),
+				}),
+			},
+		},
+	}
+
+	resp := PlanResponse{
+		PlannedChanges: changesCh,
+		Diagnostics:    diagsCh,
+	}
+
+	go Plan(ctx, &req, &resp)
+	planChanges, planDiags := collectPlanOutput(changesCh, diagsCh)
+	if len(planDiags) > 0 {
+		t.Fatalf("expected no diagnostics, got %s", planDiags.ErrWithWarnings())
+	}
+
+	planLoader := stackplan.NewLoader()
+	for _, change := range planChanges {
+		proto, err := change.PlannedChangeProto()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		for _, rawMsg := range proto.Raw {
+			err = planLoader.AddRaw(rawMsg)
+			if err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+	plan, err := planLoader.Plan()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	applyReq := ApplyRequest{
+		Config: cfg,
+		Plan:   plan,
+		ProviderFactories: map[addrs.Provider]providers.Factory{
+			addrs.NewDefaultProvider("testing"): func() (providers.Interface, error) {
+				return stacks_testing_provider.NewProvider(), nil
+			},
+		},
+		DependencyLocks: *lock,
+		InputValues: map[stackaddrs.InputVariable]ExternalInputValue{
+			stackaddrs.InputVariable{Name: "input"}: {
+				// The stack expects a map of strings, but we're giving it
+				// an object. Terraform should automatically convert this to
+				// the expected type.
+				Value: cty.ObjectVal(map[string]cty.Value{
+					"hello": cty.StringVal("hello"),
+					"world": cty.StringVal("world"),
+				}),
+			},
+		},
+	}
+
+	applyChangesCh := make(chan stackstate.AppliedChange)
+	diagsCh = make(chan tfdiags.Diagnostic)
+
+	applyResp := ApplyResponse{
+		AppliedChanges: applyChangesCh,
+		Diagnostics:    diagsCh,
+	}
+
+	go Apply(ctx, &applyReq, &applyResp)
+	applyChanges, applyDiags := collectApplyOutput(applyChangesCh, diagsCh)
+	if len(applyDiags) > 0 {
+		t.Fatalf("expected no diagnostics, got %s", applyDiags.ErrWithWarnings())
+	}
+
+	sort.SliceStable(applyChanges, func(i, j int) bool {
+		return appliedChangeSortKey(applyChanges[i]) < appliedChangeSortKey(applyChanges[j])
+	})
+
+	wantChanges := []stackstate.AppliedChange{
+		&stackstate.AppliedChangeComponentInstance{
+			ComponentAddr:         mustAbsComponent("component.self"),
+			ComponentInstanceAddr: mustAbsComponentInstance("component.self[\"hello\"]"),
+			OutputValues:          make(map[addrs.OutputValue]cty.Value),
+		},
+		&stackstate.AppliedChangeResourceInstanceObject{
+			ResourceInstanceObjectAddr: mustAbsResourceInstanceObject("component.self[\"hello\"].testing_resource.data"),
+			NewStateSrc: &states.ResourceInstanceObjectSrc{
+				AttrsJSON: mustMarshalJSONAttrs(map[string]interface{}{
+					"id":    "hello",
+					"value": "hello",
+				}),
+				Status:       states.ObjectReady,
+				Dependencies: make([]addrs.ConfigResource, 0),
+			},
+			ProviderConfigAddr: mustDefaultRootProvider("testing"),
+			Schema:             stacks_testing_provider.TestingResourceSchema,
+		},
+		&stackstate.AppliedChangeComponentInstance{
+			ComponentAddr:         mustAbsComponent("component.self"),
+			ComponentInstanceAddr: mustAbsComponentInstance("component.self[\"world\"]"),
+			OutputValues:          make(map[addrs.OutputValue]cty.Value),
+		},
+		&stackstate.AppliedChangeResourceInstanceObject{
+			ResourceInstanceObjectAddr: mustAbsResourceInstanceObject("component.self[\"world\"].testing_resource.data"),
+			NewStateSrc: &states.ResourceInstanceObjectSrc{
+				AttrsJSON: mustMarshalJSONAttrs(map[string]interface{}{
+					"id":    "world",
+					"value": "world",
+				}),
+				Status:       states.ObjectReady,
+				Dependencies: make([]addrs.ConfigResource, 0),
+			},
+			ProviderConfigAddr: mustDefaultRootProvider("testing"),
+			Schema:             stacks_testing_provider.TestingResourceSchema,
+		},
+	}
+
+	if diff := cmp.Diff(wantChanges, applyChanges, ctydebug.CmpOptions, cmpCollectionsSet); diff != "" {
+		t.Errorf("wrong changes\n%s", diff)
+	}
+}
+
+func TestApplyEphemeralInput(t *testing.T) {
+	ctx := context.Background()
+	cfg := loadMainBundleConfigForTest(t, filepath.Join("with-single-input", "ephemeral"))
+
+	fakePlanTimestamp, err := time.Parse(time.RFC3339, "1991-08-25T20:57:08Z")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	changesCh := make(chan stackplan.PlannedChange)
+	diagsCh := make(chan tfdiags.Diagnostic)
+	lock := depsfile.NewLocks()
+	lock.SetProvider(
+		addrs.NewDefaultProvider("testing"),
+		providerreqs.MustParseVersion("0.0.0"),
+		providerreqs.MustParseVersionConstraints("=0.0.0"),
+		providerreqs.PreferredHashes([]providerreqs.Hash{}),
+	)
+	req := PlanRequest{
+		Config: cfg,
+		ProviderFactories: map[addrs.Provider]providers.Factory{
+			addrs.NewDefaultProvider("testing"): func() (providers.Interface, error) {
+				return stacks_testing_provider.NewProvider(), nil
+			},
+		},
+		DependencyLocks: *lock,
+
+		ForcePlanTimestamp: &fakePlanTimestamp,
+
+		InputValues: map[stackaddrs.InputVariable]ExternalInputValue{
+			stackaddrs.InputVariable{Name: "input"}: {
+				Value: cty.StringVal("hello"),
+			},
+			stackaddrs.InputVariable{Name: "ephemeral"}: {
+				Value: cty.StringVal("ephemeral"),
+			},
+		},
+	}
+
+	resp := PlanResponse{
+		PlannedChanges: changesCh,
+		Diagnostics:    diagsCh,
+	}
+
+	go Plan(ctx, &req, &resp)
+	planChanges, planDiags := collectPlanOutput(changesCh, diagsCh)
+	if len(planDiags) > 0 {
+		t.Fatalf("expected no diagnostics, got %s", planDiags.ErrWithWarnings())
+	}
+
+	planLoader := stackplan.NewLoader()
+	for _, change := range planChanges {
+		proto, err := change.PlannedChangeProto()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		for _, rawMsg := range proto.Raw {
+			err = planLoader.AddRaw(rawMsg)
+			if err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+	plan, err := planLoader.Plan()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	applyReq := ApplyRequest{
+		Config: cfg,
+		Plan:   plan,
+		ProviderFactories: map[addrs.Provider]providers.Factory{
+			addrs.NewDefaultProvider("testing"): func() (providers.Interface, error) {
+				return stacks_testing_provider.NewProvider(), nil
+			},
+		},
+		DependencyLocks: *lock,
+		InputValues: map[stackaddrs.InputVariable]ExternalInputValue{
+			stackaddrs.InputVariable{Name: "input"}: {
+				Value: cty.StringVal("hello"),
+			},
+			stackaddrs.InputVariable{Name: "ephemeral"}: {
+				// This has changed, and that should be okay.
+				Value: cty.StringVal("applying"),
+			},
+		},
+	}
+
+	applyChangesCh := make(chan stackstate.AppliedChange)
+	diagsCh = make(chan tfdiags.Diagnostic)
+
+	applyResp := ApplyResponse{
+		AppliedChanges: applyChangesCh,
+		Diagnostics:    diagsCh,
+	}
+
+	go Apply(ctx, &applyReq, &applyResp)
+	applyChanges, applyDiags := collectApplyOutput(applyChangesCh, diagsCh)
+	if len(applyDiags) > 0 {
+		t.Fatalf("expected no diagnostics, got %s", applyDiags.ErrWithWarnings())
+	}
+
+	sort.SliceStable(applyChanges, func(i, j int) bool {
+		return appliedChangeSortKey(applyChanges[i]) < appliedChangeSortKey(applyChanges[j])
+	})
+
+	wantChanges := []stackstate.AppliedChange{
+		&stackstate.AppliedChangeComponentInstance{
+			ComponentAddr:         mustAbsComponent("component.self"),
+			ComponentInstanceAddr: mustAbsComponentInstance("component.self"),
+			OutputValues:          make(map[addrs.OutputValue]cty.Value),
+		},
+		&stackstate.AppliedChangeResourceInstanceObject{
+			ResourceInstanceObjectAddr: mustAbsResourceInstanceObject("component.self.testing_resource.data"),
+			NewStateSrc: &states.ResourceInstanceObjectSrc{
+				AttrsJSON: mustMarshalJSONAttrs(map[string]interface{}{
+					"id":    "2f9f3b84",
+					"value": "hello",
+				}),
+				Status:       states.ObjectReady,
+				Dependencies: make([]addrs.ConfigResource, 0),
+			},
+			ProviderConfigAddr: mustDefaultRootProvider("testing"),
+			Schema:             stacks_testing_provider.TestingResourceSchema,
+		},
+	}
+
+	if diff := cmp.Diff(wantChanges, applyChanges, ctydebug.CmpOptions, cmpCollectionsSet); diff != "" {
+		t.Errorf("wrong changes\n%s", diff)
+	}
+}
+
+func TestApplyEphemeralInputWithDefault(t *testing.T) {
+	ctx := context.Background()
+	cfg := loadMainBundleConfigForTest(t, filepath.Join("with-single-input", "ephemeral-default"))
+
+	fakePlanTimestamp, err := time.Parse(time.RFC3339, "1991-08-25T20:57:08Z")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	changesCh := make(chan stackplan.PlannedChange)
+	diagsCh := make(chan tfdiags.Diagnostic)
+	lock := depsfile.NewLocks()
+	lock.SetProvider(
+		addrs.NewDefaultProvider("testing"),
+		providerreqs.MustParseVersion("0.0.0"),
+		providerreqs.MustParseVersionConstraints("=0.0.0"),
+		providerreqs.PreferredHashes([]providerreqs.Hash{}),
+	)
+	req := PlanRequest{
+		Config: cfg,
+		ProviderFactories: map[addrs.Provider]providers.Factory{
+			addrs.NewDefaultProvider("testing"): func() (providers.Interface, error) {
+				return stacks_testing_provider.NewProvider(), nil
+			},
+		},
+		DependencyLocks: *lock,
+
+		ForcePlanTimestamp: &fakePlanTimestamp,
+
+		InputValues: map[stackaddrs.InputVariable]ExternalInputValue{
+			stackaddrs.InputVariable{Name: "input"}: {
+				Value: cty.StringVal("hello"),
+			},
+		},
+	}
+
+	resp := PlanResponse{
+		PlannedChanges: changesCh,
+		Diagnostics:    diagsCh,
+	}
+
+	go Plan(ctx, &req, &resp)
+	planChanges, planDiags := collectPlanOutput(changesCh, diagsCh)
+	if len(planDiags) > 0 {
+		t.Fatalf("expected no diagnostics, got %s", planDiags.ErrWithWarnings())
+	}
+
+	planLoader := stackplan.NewLoader()
+	for _, change := range planChanges {
+		proto, err := change.PlannedChangeProto()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		for _, rawMsg := range proto.Raw {
+			err = planLoader.AddRaw(rawMsg)
+			if err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+	plan, err := planLoader.Plan()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	applyReq := ApplyRequest{
+		Config: cfg,
+		Plan:   plan,
+		ProviderFactories: map[addrs.Provider]providers.Factory{
+			addrs.NewDefaultProvider("testing"): func() (providers.Interface, error) {
+				return stacks_testing_provider.NewProvider(), nil
+			},
+		},
+		DependencyLocks: *lock,
+		InputValues: map[stackaddrs.InputVariable]ExternalInputValue{
+			stackaddrs.InputVariable{Name: "input"}: {
+				Value: cty.StringVal("hello"),
+			},
+		},
+	}
+
+	applyChangesCh := make(chan stackstate.AppliedChange)
+	diagsCh = make(chan tfdiags.Diagnostic)
+
+	applyResp := ApplyResponse{
+		AppliedChanges: applyChangesCh,
+		Diagnostics:    diagsCh,
+	}
+
+	go Apply(ctx, &applyReq, &applyResp)
+	applyChanges, applyDiags := collectApplyOutput(applyChangesCh, diagsCh)
+	if len(applyDiags) > 0 {
+		t.Fatalf("expected no diagnostics, got %s", applyDiags.ErrWithWarnings())
+	}
+
+	sort.SliceStable(applyChanges, func(i, j int) bool {
+		return appliedChangeSortKey(applyChanges[i]) < appliedChangeSortKey(applyChanges[j])
+	})
+
+	wantChanges := []stackstate.AppliedChange{
+		&stackstate.AppliedChangeComponentInstance{
+			ComponentAddr:         mustAbsComponent("component.self"),
+			ComponentInstanceAddr: mustAbsComponentInstance("component.self"),
+			OutputValues:          make(map[addrs.OutputValue]cty.Value),
+		},
+		&stackstate.AppliedChangeResourceInstanceObject{
+			ResourceInstanceObjectAddr: mustAbsResourceInstanceObject("component.self.testing_resource.data"),
+			NewStateSrc: &states.ResourceInstanceObjectSrc{
+				AttrsJSON: mustMarshalJSONAttrs(map[string]interface{}{
+					"id":    "2f9f3b84",
+					"value": "hello",
+				}),
+				Status:       states.ObjectReady,
+				Dependencies: make([]addrs.ConfigResource, 0),
+			},
+			ProviderConfigAddr: mustDefaultRootProvider("testing"),
+			Schema:             stacks_testing_provider.TestingResourceSchema,
+		},
+	}
+
+	if diff := cmp.Diff(wantChanges, applyChanges, ctydebug.CmpOptions, cmpCollectionsSet); diff != "" {
+		t.Errorf("wrong changes\n%s", diff)
 	}
 }
 

--- a/internal/stacks/stackruntime/apply_test.go
+++ b/internal/stacks/stackruntime/apply_test.go
@@ -2270,6 +2270,149 @@ func TestApplyEphemeralInput(t *testing.T) {
 	}
 }
 
+func TestApplyMissingEphemeralInput(t *testing.T) {
+	ctx := context.Background()
+	cfg := loadMainBundleConfigForTest(t, filepath.Join("with-single-input", "ephemeral"))
+
+	fakePlanTimestamp, err := time.Parse(time.RFC3339, "1991-08-25T20:57:08Z")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	changesCh := make(chan stackplan.PlannedChange)
+	diagsCh := make(chan tfdiags.Diagnostic)
+	lock := depsfile.NewLocks()
+	lock.SetProvider(
+		addrs.NewDefaultProvider("testing"),
+		providerreqs.MustParseVersion("0.0.0"),
+		providerreqs.MustParseVersionConstraints("=0.0.0"),
+		providerreqs.PreferredHashes([]providerreqs.Hash{}),
+	)
+	req := PlanRequest{
+		Config: cfg,
+		ProviderFactories: map[addrs.Provider]providers.Factory{
+			addrs.NewDefaultProvider("testing"): func() (providers.Interface, error) {
+				return stacks_testing_provider.NewProvider(), nil
+			},
+		},
+		DependencyLocks: *lock,
+
+		ForcePlanTimestamp: &fakePlanTimestamp,
+
+		InputValues: map[stackaddrs.InputVariable]ExternalInputValue{
+			stackaddrs.InputVariable{Name: "input"}: {
+				Value: cty.StringVal("hello"),
+			},
+			stackaddrs.InputVariable{Name: "ephemeral"}: {
+				Value: cty.StringVal("ephemeral"),
+			},
+		},
+	}
+
+	resp := PlanResponse{
+		PlannedChanges: changesCh,
+		Diagnostics:    diagsCh,
+	}
+
+	go Plan(ctx, &req, &resp)
+	planChanges, planDiags := collectPlanOutput(changesCh, diagsCh)
+	if len(planDiags) > 0 {
+		t.Fatalf("expected no diagnostics, got %s", planDiags.ErrWithWarnings())
+	}
+
+	planLoader := stackplan.NewLoader()
+	for _, change := range planChanges {
+		proto, err := change.PlannedChangeProto()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		for _, rawMsg := range proto.Raw {
+			err = planLoader.AddRaw(rawMsg)
+			if err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+	plan, err := planLoader.Plan()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	applyReq := ApplyRequest{
+		Config: cfg,
+		Plan:   plan,
+		ProviderFactories: map[addrs.Provider]providers.Factory{
+			addrs.NewDefaultProvider("testing"): func() (providers.Interface, error) {
+				return stacks_testing_provider.NewProvider(), nil
+			},
+		},
+		DependencyLocks: *lock,
+		InputValues: map[stackaddrs.InputVariable]ExternalInputValue{
+			stackaddrs.InputVariable{Name: "input"}: {
+				Value: cty.StringVal("hello"),
+			},
+		},
+	}
+
+	applyChangesCh := make(chan stackstate.AppliedChange)
+	diagsCh = make(chan tfdiags.Diagnostic)
+
+	applyResp := ApplyResponse{
+		AppliedChanges: applyChangesCh,
+		Diagnostics:    diagsCh,
+	}
+
+	go Apply(ctx, &applyReq, &applyResp)
+	applyChanges, applyDiags := collectApplyOutput(applyChangesCh, diagsCh)
+	if len(applyDiags) != 1 {
+		t.Fatalf("expected exactly 1 diagnostic, got %s", applyDiags.ErrWithWarnings())
+	}
+
+	gotSeverity, wantSeverity := applyDiags[0].Severity(), tfdiags.Error
+	gotSummary, wantSummary := applyDiags[0].Description().Summary, "No value for required variable"
+	gotDetail, wantDetail := applyDiags[0].Description().Detail, "The root input variable \"var.ephemeral\" is not set, and has no default value."
+
+	if gotSeverity != wantSeverity {
+		t.Errorf("expected severity %q, got %q", wantSeverity, gotSeverity)
+	}
+	if gotSummary != wantSummary {
+		t.Errorf("expected summary %q, got %q", wantSummary, gotSummary)
+	}
+	if gotDetail != wantDetail {
+		t.Errorf("expected detail %q, got %q", wantDetail, gotDetail)
+	}
+
+	sort.SliceStable(applyChanges, func(i, j int) bool {
+		return appliedChangeSortKey(applyChanges[i]) < appliedChangeSortKey(applyChanges[j])
+	})
+
+	wantChanges := []stackstate.AppliedChange{
+		&stackstate.AppliedChangeComponentInstance{
+			ComponentAddr:         mustAbsComponent("component.self"),
+			ComponentInstanceAddr: mustAbsComponentInstance("component.self"),
+			OutputValues:          make(map[addrs.OutputValue]cty.Value),
+		},
+		&stackstate.AppliedChangeResourceInstanceObject{
+			ResourceInstanceObjectAddr: mustAbsResourceInstanceObject("component.self.testing_resource.data"),
+			NewStateSrc: &states.ResourceInstanceObjectSrc{
+				AttrsJSON: mustMarshalJSONAttrs(map[string]interface{}{
+					"id":    "2f9f3b84",
+					"value": "hello",
+				}),
+				Status:       states.ObjectReady,
+				Dependencies: make([]addrs.ConfigResource, 0),
+			},
+			ProviderConfigAddr: mustDefaultRootProvider("testing"),
+			Schema:             stacks_testing_provider.TestingResourceSchema,
+		},
+	}
+
+	if diff := cmp.Diff(wantChanges, applyChanges, ctydebug.CmpOptions, cmpCollectionsSet); diff != "" {
+		t.Errorf("wrong changes\n%s", diff)
+	}
+}
+
 func TestApplyEphemeralInputWithDefault(t *testing.T) {
 	ctx := context.Background()
 	cfg := loadMainBundleConfigForTest(t, filepath.Join("with-single-input", "ephemeral-default"))

--- a/internal/stacks/stackruntime/internal/stackeval/main.go
+++ b/internal/stacks/stackruntime/internal/stackeval/main.go
@@ -443,10 +443,13 @@ func (m *Main) RootVariableValue(ctx context.Context, addr stackaddrs.InputVaria
 			}
 		}
 
-		// This shouldn't happen because we should always have a value for
-		// every declared root input variable in the plan.
+		// If we had nothing set, we'll return a null value. This means the
+		// default value will be applied, if any, or an error will be raised
+		// if no default is available. This should only be possible for an
+		// ephemeral value in which the caller didn't provide a value during
+		// the apply operation.
 		return ExternalInputValue{
-			Value: cty.DynamicVal,
+			Value: cty.NullVal(cty.DynamicPseudoType),
 		}
 
 	case InspectPhase:

--- a/internal/stacks/stackruntime/internal/stackeval/main.go
+++ b/internal/stacks/stackruntime/internal/stackeval/main.go
@@ -94,10 +94,9 @@ type mainPlanning struct {
 }
 
 type mainApplying struct {
-	opts          ApplyOpts
-	plan          *stackplan.Plan
-	rootInputVals map[stackaddrs.InputVariable]cty.Value
-	results       *ChangeExecResults
+	opts    ApplyOpts
+	plan    *stackplan.Plan
+	results *ChangeExecResults
 }
 
 type mainInspecting struct {
@@ -133,14 +132,13 @@ func NewForPlanning(config *stackconfig.Config, prevState *stackstate.State, opt
 	}
 }
 
-func NewForApplying(config *stackconfig.Config, rootInputs map[stackaddrs.InputVariable]cty.Value, plan *stackplan.Plan, execResults *ChangeExecResults, opts ApplyOpts) *Main {
+func NewForApplying(config *stackconfig.Config, plan *stackplan.Plan, execResults *ChangeExecResults, opts ApplyOpts) *Main {
 	return &Main{
 		config: config,
 		applying: &mainApplying{
-			opts:          opts,
-			plan:          plan,
-			rootInputVals: rootInputs,
-			results:       execResults,
+			opts:    opts,
+			plan:    plan,
+			results: execResults,
 		},
 		providerFactories: opts.ProviderFactories,
 		providerTypes:     make(map[addrs.Provider]*ProviderType),
@@ -430,22 +428,25 @@ func (m *Main) RootVariableValue(ctx context.Context, addr stackaddrs.InputVaria
 		if !m.Applying() {
 			panic("using ApplyPhase input variable values when not configured for applying")
 		}
-		ret, ok := m.applying.rootInputVals[addr]
-		if !ok {
-			// We should not get here if the given plan was created from the
-			// given configuration, since we should always record a value
-			// for every declared root input variable in the plan.
+
+		// First, check the values given to use directly by the caller.
+		if ret, ok := m.applying.opts.InputVariableValues[addr]; ok {
+			return ret
+		}
+
+		// If the caller didn't provide a value, we need to look up the value
+		// that was used during planning.
+
+		if ret, ok := m.applying.plan.RootInputValues[addr]; ok {
 			return ExternalInputValue{
-				Value: cty.DynamicVal,
+				Value: ret,
 			}
 		}
-		return ExternalInputValue{
-			Value: ret,
 
-			// We don't save source location information for variable
-			// definitions in the plan, but that's okay because if we were
-			// going to report any errors for these values then we should've
-			// already done it during the plan phase, and so couldn't get here..
+		// This shouldn't happen because we should always have a value for
+		// every declared root input variable in the plan.
+		return ExternalInputValue{
+			Value: cty.DynamicVal,
 		}
 
 	case InspectPhase:

--- a/internal/stacks/stackruntime/internal/stackeval/main_apply.go
+++ b/internal/stacks/stackruntime/internal/stackeval/main_apply.go
@@ -7,10 +7,8 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"maps"
 	"sync/atomic"
 
-	"github.com/zclconf/go-cty/cty"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
@@ -67,19 +65,6 @@ func ApplyPlan(ctx context.Context, config *stackconfig.Config, plan *stackplan.
 	hooks := hooksFromContext(ctx)
 	hs, ctx := hookBegin(ctx, hooks.BeginApply, hooks.ContextAttach, struct{}{})
 	defer hookMore(ctx, hs, hooks.EndApply, struct{}{})
-
-	canBeginApply := true
-	applyTimeVariables, varDiags := checkApplyTimeVariables(plan, opts.InputVariableValues)
-	if len(varDiags) != 0 {
-		outp.AnnounceDiagnostics(ctx, varDiags)
-		// We intentionally continue here because we've made applyTimeVariables
-		// valid enough that it shouldn't indirectly cause any other problems.
-		// We'll still halt before the apply phase begins, but we'll still
-		// create the *Main value that we need to satisfy our signature.
-		if varDiags.HasErrors() {
-			canBeginApply = false
-		}
-	}
 
 	// Before doing anything else we'll emit zero or more events to deal
 	// with discarding the previous run state data that's no longer needed.
@@ -215,16 +200,8 @@ func ApplyPlan(ctx context.Context, config *stackconfig.Config, plan *stackplan.
 			}
 		})
 
-		main := NewForApplying(config, applyTimeVariables, plan, results, opts)
+		main := NewForApplying(config, plan, results, opts)
 		main.AllowLanguageExperiments(opts.ExperimentsAllowed)
-		if !canBeginApply {
-			// Some eariler error means that it's unsafe to begin. The earlier
-			// code that set this should already have emitted its error
-			// diagnostics through outp directly, so we'll just return now.
-			return withDiagnostics[*Main]{
-				Result: main,
-			}, nil
-		}
 		begin(ctx, main) // the change tasks registered above become runnable
 
 		// With the planned changes now in progress, we'll visit everything and
@@ -296,55 +273,6 @@ func ApplyPlan(ctx context.Context, config *stackconfig.Config, plan *stackplan.
 	log.Printf("[TRACE] stackeval.ApplyPlan complete")
 
 	return main, nil
-}
-
-func checkApplyTimeVariables(plan *stackplan.Plan, providedValues map[stackaddrs.InputVariable]ExternalInputValue) (map[stackaddrs.InputVariable]cty.Value, tfdiags.Diagnostics) {
-	var diags tfdiags.Diagnostics
-
-	ret := make(map[stackaddrs.InputVariable]cty.Value, len(plan.RootInputValues)+plan.ApplyTimeInputVariables.Len())
-	maps.Copy(ret, plan.RootInputValues)
-	for _, varAddr := range plan.ApplyTimeInputVariables.Elems() {
-		applyTimeVal := providedValues[varAddr]
-		if applyTimeVal.Value == cty.NilVal || applyTimeVal.Value.IsNull() {
-			diags = diags.Append(tfdiags.Sourceless(
-				tfdiags.Error,
-				"No value for required input variable",
-				fmt.Sprintf("Ephemeral input variable %s was set during planning, and so it must be set again to apply the plan.", varAddr),
-			))
-			ret[varAddr] = cty.DynamicVal // placeholder just to allow us to continue below and potentially collect other errors
-			continue
-		}
-		ret[varAddr] = applyTimeVal.Value
-	}
-
-	// All of the provided variable values must either be apply-time
-	// variables or must match the value used during planning.
-	for varAddr, applyTimeVal := range providedValues {
-		if plan.ApplyTimeInputVariables.Has(varAddr) {
-			continue // This is the main case, with nothing further to do
-		}
-		planTimeVal := plan.RootInputValues[varAddr]
-		eq := false
-		if planTimeVal != cty.NilVal {
-			eqV := applyTimeVal.Value.Equals(planTimeVal)
-			if eqV.IsKnown() { // Should always be true because there's no reason for stack root input values to be unknown
-				eq = eqV.True()
-			}
-		}
-		if !eq {
-			diags = diags.Append(tfdiags.Sourceless(
-				tfdiags.Error,
-				"Inconsistent value for input variable during apply",
-				fmt.Sprintf("The value for non-ephemeral input variable %s was set to a different value during apply than was set during plan. Only ephemeral input variables can change between the plan and apply phases.", varAddr),
-			))
-			// We'll prefer the plan-time value as we continue to minimize the
-			// risk of triggering weird errors downstream by violating the
-			// assumption that these values don't change between plan and apply.
-			ret[varAddr] = planTimeVal
-		}
-	}
-
-	return ret, diags
 }
 
 type ApplyOutput struct {

--- a/internal/stacks/stackruntime/testdata/mainbundle/test/with-single-input/ephemeral-default/ephemeral-default.tfstack.hcl
+++ b/internal/stacks/stackruntime/testdata/mainbundle/test/with-single-input/ephemeral-default/ephemeral-default.tfstack.hcl
@@ -1,0 +1,35 @@
+required_providers {
+  testing = {
+    source  = "hashicorp/testing"
+    version = "0.1.0"
+  }
+}
+
+provider "testing" "default" {
+  config {
+    ignored = var.ephemeral
+  }
+}
+
+variable "ephemeral" {
+  type      = string
+  default   = "Hello, world!"
+  ephemeral = true
+}
+
+variable "input" {
+  type = string
+}
+
+component "self" {
+  source = "../"
+
+  providers = {
+    testing = provider.testing.default
+  }
+
+  inputs = {
+    input = var.input
+    id = "2f9f3b84"
+  }
+}

--- a/internal/stacks/stackruntime/testdata/mainbundle/test/with-single-input/ephemeral/ephemeral.tfstack.hcl
+++ b/internal/stacks/stackruntime/testdata/mainbundle/test/with-single-input/ephemeral/ephemeral.tfstack.hcl
@@ -1,0 +1,34 @@
+required_providers {
+  testing = {
+    source  = "hashicorp/testing"
+    version = "0.1.0"
+  }
+}
+
+provider "testing" "default" {
+  config {
+    ignored = var.ephemeral
+  }
+}
+
+variable "ephemeral" {
+  type      = string
+  ephemeral = true
+}
+
+variable "input" {
+  type = string
+}
+
+component "self" {
+  source = "../"
+
+  providers = {
+    testing = provider.testing.default
+  }
+
+  inputs = {
+    input = var.input
+    id = "2f9f3b84"
+  }
+}

--- a/internal/stacks/stackruntime/testdata/mainbundle/test/with-single-input/for-each-component/for-each-component.tfstack.hcl
+++ b/internal/stacks/stackruntime/testdata/mainbundle/test/with-single-input/for-each-component/for-each-component.tfstack.hcl
@@ -1,0 +1,28 @@
+
+required_providers {
+  testing = {
+    source  = "hashicorp/testing"
+    version = "0.1.0"
+  }
+}
+
+provider "testing" "default" {}
+
+variable "input" {
+  type = map(string)
+}
+
+component "self" {
+  for_each = var.input
+
+  source = "../"
+
+  providers = {
+    testing = provider.testing.default
+  }
+
+  inputs = {
+    id = each.key
+    input = each.value
+  }
+}

--- a/internal/stacks/stackruntime/testing/provider.go
+++ b/internal/stacks/stackruntime/testing/provider.go
@@ -77,6 +77,10 @@ func NewProviderWithData(store *ResourceStore) *MockProvider {
 								Type:     cty.String,
 								Optional: true,
 							},
+							"ignored": {
+								Type:     cty.String,
+								Optional: true,
+							},
 						},
 					},
 				},


### PR DESCRIPTION
This PR ensures that any automatic conversions that are applied to root input values are applied *before* we compare the plan and apply input values for consistency. This fixes a bug that occurred when using collections as inputs. The agent would parse these as objects or tuples, and Terraform would then automatically convert them to the correct types. This behaviour is totally valid, and matches the behaviour of Terraform proper. We were then checking the plan values against the apply values at apply time before the apply operation had been given the chance to apply the automatic conversion and naturally the types were different and so it was failing.

I've pushed the evaluation of plan and apply time input variables into the `input_variable.go` file, after the automatic conversion. In order to make sure we don't continue execution of anything in the path of the bad variable, I return a `cty.NilValue` to make sure nothing can use it.

In addition, this PR opens up the Terraform enhanced comparisons within the `objchange` package to stacks. I've updated the two places we compare inputs (component inputs and root stack inputs) to share this code path with Terraform proper.

Internal ticket: https://hashicorp.atlassian.net/browse/TF-18936