### PR TITLE
init: fix invalid + duplicate required provider blocks crashing

### DIFF
--- a/internal/command/init_test.go
+++ b/internal/command/init_test.go
@@ -2949,6 +2949,66 @@ versions are specified, run the following command:
 	}
 }
 
+func TestInit_testsWithOverriddenInvalidRequiredProviders(t *testing.T) {
+	td := t.TempDir()
+	testCopyDir(t, testFixturePath("init-with-overrides-and-duplicates"), td)
+	defer testChdir(t, td)()
+
+	provider := applyFixtureProvider() // We just want the types from this provider.
+
+	providerSource, close := newMockProviderSource(t, map[string][]string{
+		"hashicorp/test": {"1.0.0"},
+	})
+	defer close()
+
+	ui := new(cli.MockUi)
+	view, done := testView(t)
+	c := &InitCommand{
+		Meta: Meta{
+			testingOverrides: metaOverridesForProvider(provider),
+			Ui:               ui,
+			View:             view,
+			ProviderSource:   providerSource,
+		},
+	}
+
+	args := []string{}
+	code := c.Run(args) // just make sure it doesn't crash.
+	if code != 1 {
+		t.Fatalf("expected failure but got: \n%s", done(t).All())
+	}
+}
+
+func TestInit_testsWithInvalidRequiredProviders(t *testing.T) {
+	td := t.TempDir()
+	testCopyDir(t, testFixturePath("init-with-duplicates"), td)
+	defer testChdir(t, td)()
+
+	provider := applyFixtureProvider() // We just want the types from this provider.
+
+	providerSource, close := newMockProviderSource(t, map[string][]string{
+		"hashicorp/test": {"1.0.0"},
+	})
+	defer close()
+
+	ui := new(cli.MockUi)
+	view, done := testView(t)
+	c := &InitCommand{
+		Meta: Meta{
+			testingOverrides: metaOverridesForProvider(provider),
+			Ui:               ui,
+			View:             view,
+			ProviderSource:   providerSource,
+		},
+	}
+
+	args := []string{}
+	code := c.Run(args) // just make sure it doesn't crash.
+	if code != 1 {
+		t.Fatalf("expected failure but got: \n%s", done(t).All())
+	}
+}
+
 func TestInit_testsWithModule(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()

--- a/internal/command/testdata/init-with-duplicates/primary.tf
+++ b/internal/command/testdata/init-with-duplicates/primary.tf
@@ -1,0 +1,12 @@
+terraform {
+  required_providers {
+    test = {
+        source = "hashicorp/test"
+        version = "1.0.0"
+    }
+  }
+}
+
+resource "test_instance" "foo" {
+  ami = "bar"
+}

--- a/internal/command/testdata/init-with-duplicates/secondary.tf
+++ b/internal/command/testdata/init-with-duplicates/secondary.tf
@@ -1,0 +1,12 @@
+terraform {
+  required_providers {
+    test = {
+      source = "hashicorp/test"
+      version = "1.0.0"
+    { // This typo is deliberate, we want to test that the parser can handle it.
+  }
+}
+
+resource "test_instance" "bar" {
+  ami = "foo"
+}

--- a/internal/command/testdata/init-with-overrides-and-duplicates/primary.tf
+++ b/internal/command/testdata/init-with-overrides-and-duplicates/primary.tf
@@ -1,0 +1,12 @@
+terraform {
+  required_providers {
+    test = {
+        source = "hashicorp/test"
+        version = "1.0.0"
+    }
+  }
+}
+
+resource "test_instance" "foo" {
+  ami = "bar"
+}

--- a/internal/command/testdata/init-with-overrides-and-duplicates/secondary.tf
+++ b/internal/command/testdata/init-with-overrides-and-duplicates/secondary.tf
@@ -1,0 +1,12 @@
+terraform {
+  required_providers {
+    test = {
+      source = "hashicorp/test"
+      version = "1.0.0"
+    }
+  }
+}
+
+resource "test_instance" "bar" {
+  ami = "foo"
+}

--- a/internal/command/testdata/init-with-overrides-and-duplicates/secondary_override.tf
+++ b/internal/command/testdata/init-with-overrides-and-duplicates/secondary_override.tf
@@ -1,0 +1,12 @@
+terraform {
+  required_providers {
+    test = {
+      source = "hashicorp/test"
+      version = "1.0.0"
+    { // This typo is deliberate, we want to test that the parser can handle it.
+  }
+}
+
+resource "test_instance" "bar" {
+  ami = "override"
+}

--- a/internal/configs/parser_config.go
+++ b/internal/configs/parser_config.go
@@ -120,7 +120,9 @@ func parseConfigFile(body hcl.Body, diags hcl.Diagnostics, override, allowExperi
 				case "required_providers":
 					reqs, reqsDiags := decodeRequiredProvidersBlock(innerBlock)
 					diags = append(diags, reqsDiags...)
-					file.RequiredProviders = append(file.RequiredProviders, reqs)
+					if reqs != nil {
+						file.RequiredProviders = append(file.RequiredProviders, reqs)
+					}
 
 				case "provider_meta":
 					providerCfg, cfgDiags := decodeProviderMetaBlock(innerBlock)


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

This PR prevents a crash that was occurring whenever Terraform discovers duplicate `required_providers` blocks in which at least one was not syntactically correct.

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Fixes #35532 

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.9.4

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

### BUG FIXES 

<!--

Write a short description of the user-facing change. Examples:

- `terraform show -json`: Fixed crash with sensitive set values.
- When rendering a diff, Terraform now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 

-  `init`: Stop crashing when discovering invalid syntax in a duplicate `required_providers` block.
