### PR TITLE
trace: add more logging around variable validations

### DIFF
--- a/internal/checks/state_report.go
+++ b/internal/checks/state_report.go
@@ -5,6 +5,7 @@ package checks
 
 import (
 	"fmt"
+	"log"
 
 	"github.com/hashicorp/terraform/internal/addrs"
 )
@@ -50,6 +51,7 @@ func (c *State) ReportCheckableObjects(configAddr addrs.ConfigCheckable, objectA
 			checks[checkType] = make([]Status, count)
 		}
 
+		log.Printf("[TRACE] ReportCheckableObjects: %s -> %s", configAddr, objectAddr)
 		st.objects.Put(objectAddr, checks)
 	}
 }

--- a/internal/terraform/node_module_variable.go
+++ b/internal/terraform/node_module_variable.go
@@ -68,6 +68,7 @@ func (n *nodeExpandModuleVariable) DynamicExpand(ctx EvalContext) (*Graph, tfdia
 	forEachModuleInstance(expander, n.Module, false, func(module addrs.ModuleInstance) {
 		addr := n.Addr.Absolute(module)
 		if checkableAddrs != nil {
+			log.Printf("[TRACE] nodeExpandModuleVariable: found checkable object %s", addr)
 			checkableAddrs.Add(addr)
 		}
 


### PR DESCRIPTION
Relates to #35477 

I haven't been able to replicate or work out exactly what's happening in the crashes here. I'm adding some logging around the variable validations here to see if this might reveal more about what's happening after the next release.