### PR TITLE
Allow unknown `error_message` values during validate walk

### DIFF
--- a/internal/terraform/graph_builder_plan.go
+++ b/internal/terraform/graph_builder_plan.go
@@ -159,7 +159,9 @@ func (b *PlanGraphBuilder) Steps() []GraphTransformer {
 			Planning:     true,
 			DestroyApply: false, // always false for planning
 		},
-		&variableValidationTransformer{},
+		&variableValidationTransformer{
+			validateWalk: b.Operation == walkValidate,
+		},
 		&LocalTransformer{Config: b.Config},
 		&OutputTransformer{
 			Config:      b.Config,

--- a/internal/terraform/node_variable_validation.go
+++ b/internal/terraform/node_variable_validation.go
@@ -34,6 +34,12 @@ type nodeVariableValidation struct {
 	// set from a non-configuration location like an environment variable --
 	// it's acceptable to use the declaration location instead.
 	defnRange hcl.Range
+
+	// validateWalk is set to true during a validation walk, where any input
+	// variables are set to unknown values. Since we may have unknown values
+	// which will be known during plan, we need to be more lenient about what
+	// can be unknown in variable validation expressions.
+	validateWalk bool
 }
 
 var _ GraphNodeModulePath = (*nodeVariableValidation)(nil)
@@ -122,6 +128,7 @@ func (n *nodeVariableValidation) Execute(globalCtx EvalContext, op walkOperation
 			moduleCtx,
 			n.rules,
 			n.defnRange,
+			n.validateWalk,
 		))
 	}
 

--- a/internal/terraform/transform_variable_validation.go
+++ b/internal/terraform/transform_variable_validation.go
@@ -53,6 +53,7 @@ var _ graphNodeValidatableVariable = (*nodeExpandModuleVariable)(nil)
 // with the new [nodeVariableValidation] nodes to prevent downstream nodes
 // from relying on unvalidated values.
 type variableValidationTransformer struct {
+	validateWalk bool
 }
 
 var _ GraphTransformer = (*variableValidationTransformer)(nil)
@@ -67,9 +68,10 @@ func (t *variableValidationTransformer) Transform(g *Graph) error {
 
 		configAddr, rules, defnRange := v.variableValidationRules()
 		newV := &nodeVariableValidation{
-			configAddr: configAddr,
-			rules:      rules,
-			defnRange:  defnRange,
+			configAddr:   configAddr,
+			rules:        rules,
+			defnRange:    defnRange,
+			validateWalk: t.validateWalk,
 		}
 
 		if len(rules) != 0 {


### PR DESCRIPTION
When evaluating variable validation, we may have valid `error_message` values which are unknown due to all other referenced input variables being unknown during the validate walk. In the rare case where the variable validation is known but the `error_message` is not, we need to be able to proceed to the plan phase in order to check the validation more thoroughly.

Fixes #35397

## Target Release

1.10

## Draft CHANGELOG entry

### BUG FIXES

- Allow unknown `error_message` values to pass the core validate step, so variable validation can be completed later during plan.
