### PR TITLE
jsonformat: render deferred actions

### DIFF
--- a/internal/command/jsonformat/plan.go
+++ b/internal/command/jsonformat/plan.go
@@ -25,11 +25,12 @@ const (
 )
 
 type Plan struct {
-	PlanFormatVersion  string                     `json:"plan_format_version"`
-	OutputChanges      map[string]jsonplan.Change `json:"output_changes,omitempty"`
-	ResourceChanges    []jsonplan.ResourceChange  `json:"resource_changes,omitempty"`
-	ResourceDrift      []jsonplan.ResourceChange  `json:"resource_drift,omitempty"`
-	RelevantAttributes []jsonplan.ResourceAttr    `json:"relevant_attributes,omitempty"`
+	PlanFormatVersion  string                            `json:"plan_format_version"`
+	OutputChanges      map[string]jsonplan.Change        `json:"output_changes,omitempty"`
+	ResourceChanges    []jsonplan.ResourceChange         `json:"resource_changes,omitempty"`
+	ResourceDrift      []jsonplan.ResourceChange         `json:"resource_drift,omitempty"`
+	RelevantAttributes []jsonplan.ResourceAttr           `json:"relevant_attributes,omitempty"`
+	DeferredChanges    []jsonplan.DeferredResourceChange `json:"deferred_changes,omitempty"`
 
 	ProviderFormatVersion string                            `json:"provider_format_version"`
 	ProviderSchemas       map[string]*jsonprovider.Provider `json:"provider_schemas,omitempty"`
@@ -176,6 +177,12 @@ func (plan Plan) renderHuman(renderer Renderer, mode plans.Mode, opts ...plans.Q
 	}
 
 	if haveRefreshChanges {
+		renderer.Streams.Print(format.HorizontalRule(renderer.Colorize, renderer.Streams.Stdout.Columns()))
+		renderer.Streams.Println()
+	}
+
+	haveDeferredChanges := renderHumanDeferredChanges(renderer, diffs, mode)
+	if haveDeferredChanges {
 		renderer.Streams.Print(format.HorizontalRule(renderer.Colorize, renderer.Streams.Stdout.Columns()))
 		renderer.Streams.Println()
 	}
@@ -334,6 +341,24 @@ func renderHumanDiffDrift(renderer Renderer, diffs diffs, mode plans.Mode) bool 
 	return true
 }
 
+func renderHumanDeferredChanges(renderer Renderer, diffs diffs, mode plans.Mode) bool {
+	if len(diffs.deferred) == 0 {
+		return false
+	}
+
+	renderer.Streams.Print(renderer.Colorize.Color("\n[bold][cyan]Note:[reset][bold] This is a partial plan, parts can only be known in the next plan / apply cycle.\n"))
+	renderer.Streams.Println()
+
+	for _, deferred := range diffs.deferred {
+		diff, render := renderHumanDeferredDiff(renderer, deferred)
+		if render {
+			renderer.Streams.Println()
+			renderer.Streams.Println(diff)
+		}
+	}
+	return true
+}
+
 func renderHumanDiff(renderer Renderer, diff diff, cause string) (string, bool) {
 
 	// Internally, our computed diffs can't tell the difference between a
@@ -356,6 +381,47 @@ func renderHumanDiff(renderer Renderer, diff diff, cause string) (string, bool) 
 	opts.ShowUnchangedChildren = diff.Importing()
 
 	buf.WriteString(fmt.Sprintf("%s %s %s", renderer.Colorize.Color(format.DiffActionSymbol(action)), resourceChangeHeader(diff.change), diff.diff.RenderHuman(0, opts)))
+	return buf.String(), true
+}
+
+func renderHumanDeferredDiff(renderer Renderer, deferred deferredDiff) (string, bool) {
+
+	// Internally, our computed diffs can't tell the difference between a
+	// replace action (eg. CreateThenDestroy, DestroyThenCreate) and a simple
+	// update action. So, at the top most level we rely on the action provided
+	// by the plan itself instead of what we compute. Nested attributes and
+	// blocks however don't have the replace type of actions, so we can trust
+	// the computed actions of these.
+	action := jsonplan.UnmarshalActions(deferred.diff.change.Change.Actions)
+	if action == plans.NoOp && !deferred.diff.Moved() && !deferred.diff.Importing() {
+		// Skip resource changes that have nothing interesting to say.
+		return "", false
+	}
+
+	var buf bytes.Buffer
+	var explanation string
+	switch deferred.reason {
+	// TODO: Add other cases
+	case jsonplan.DeferredReasonInstanceCountUnknown:
+		explanation = "The number of resource instances is unknown."
+	case jsonplan.DeferredReasonResourceConfigUnknown:
+		explanation = "The resource configuration is unknown."
+	case jsonplan.DeferredReasonProviderConfigUnknown:
+		explanation = "The provider configuration is unknown."
+	case jsonplan.DeferredReasonDeferredPrereq:
+		explanation = "A prerequisite for this resource is deferred."
+	case jsonplan.DeferredReasonAbsentPrereq:
+		explanation = "A prerequisite for this resource is absent."
+	default:
+		explanation = "Unknown / Not supported by this version of Terraform."
+	}
+
+	buf.WriteString(renderer.Colorize.Color(fmt.Sprintf("%s was deferred: \nReason: %s\n", deferred.diff.change.Address, explanation)))
+
+	opts := computed.NewRenderHumanOpts(renderer.Colorize)
+	opts.ShowUnchangedChildren = deferred.diff.Importing()
+
+	buf.WriteString(fmt.Sprintf("%s %s %s", renderer.Colorize.Color(format.DiffActionSymbol(action)), resourceChangeHeader(deferred.diff.change), deferred.diff.diff.RenderHuman(0, opts)))
 	return buf.String(), true
 }
 

--- a/internal/command/jsonformat/plan.go
+++ b/internal/command/jsonformat/plan.go
@@ -106,19 +106,16 @@ func (plan Plan) renderHuman(renderer Renderer, mode plans.Mode, opts ...plans.Q
 			renderer.Streams.Print(
 				renderer.Colorize.Color("\n[reset][bold][red]Planning failed.[reset][bold] Terraform encountered an error while generating this plan.[reset]\n\n"),
 			)
-		} else {
-			// We had no changes, but deferred changes
-			if len(diffs.deferred) > 0 {
-				if haveRefreshChanges {
-					renderer.Streams.Print(format.HorizontalRule(renderer.Colorize, renderer.Streams.Stdout.Columns()))
-					renderer.Streams.Println("")
-				}
-				renderer.Streams.Print(
-					renderer.Colorize.Color("\n[reset][bold][green]No current changes.[reset][bold] This plan requires another plan to be applied first.[reset]\n\n"),
-				)
-				return
+		} else if len(diffs.deferred) > 0 {
+			// We had no current changes, but deferred changes
+			if haveRefreshChanges {
+				renderer.Streams.Print(format.HorizontalRule(renderer.Colorize, renderer.Streams.Stdout.Columns()))
+				renderer.Streams.Println("")
 			}
-
+			renderer.Streams.Print(
+				renderer.Colorize.Color("\n[reset][bold][green]No current changes.[reset][bold] This plan requires another plan to be applied first.[reset]\n\n"),
+			)
+		} else {
 			switch mode {
 			case plans.RefreshOnlyMode:
 				if haveRefreshChanges {

--- a/internal/command/jsonformat/plan.go
+++ b/internal/command/jsonformat/plan.go
@@ -426,7 +426,7 @@ func renderHumanDeferredDiff(renderer Renderer, deferred deferredDiff) (string, 
 	}
 
 	buf.WriteString(renderer.Colorize.Color(fmt.Sprintf("[bold]  # %s[reset] was deferred\n", deferred.diff.change.Address)))
-	buf.WriteString(renderer.Colorize.Color(fmt.Sprintf("  #[reset] %s\n", explanation)))
+	buf.WriteString(renderer.Colorize.Color(fmt.Sprintf("  #[reset] (%s)\n", explanation)))
 
 	opts := computed.NewRenderHumanOpts(renderer.Colorize)
 	opts.ShowUnchangedChildren = deferred.diff.Importing()

--- a/internal/command/jsonformat/plan.go
+++ b/internal/command/jsonformat/plan.go
@@ -426,7 +426,7 @@ func renderHumanDeferredDiff(renderer Renderer, deferred deferredDiff) (string, 
 	}
 
 	buf.WriteString(renderer.Colorize.Color(fmt.Sprintf("[bold]  # %s[reset] was deferred\n", deferred.diff.change.Address)))
-	buf.WriteString(renderer.Colorize.Color(fmt.Sprintf("  #[reset] (s)\n", explanation)))
+	buf.WriteString(renderer.Colorize.Color(fmt.Sprintf("  #[reset] %s\n", explanation)))
 
 	opts := computed.NewRenderHumanOpts(renderer.Colorize)
 	opts.ShowUnchangedChildren = deferred.diff.Importing()

--- a/internal/command/jsonformat/plan.go
+++ b/internal/command/jsonformat/plan.go
@@ -114,7 +114,7 @@ func (plan Plan) renderHuman(renderer Renderer, mode plans.Mode, opts ...plans.Q
 					renderer.Streams.Println("")
 				}
 				renderer.Streams.Print(
-					renderer.Colorize.Color("\n[reset][bold][green]No changes.[reset][bold] This plan requires another plan to be applied first.[reset]\n\n"),
+					renderer.Colorize.Color("\n[reset][bold][green]No current changes.[reset][bold] This plan requires another plan to be applied first.[reset]\n\n"),
 				)
 				return
 			}
@@ -415,20 +415,21 @@ func renderHumanDeferredDiff(renderer Renderer, deferred deferredDiff) (string, 
 	switch deferred.reason {
 	// TODO: Add other cases
 	case jsonplan.DeferredReasonInstanceCountUnknown:
-		explanation = "The number of resource instances is unknown."
+		explanation = "because the number of resource instances is unknown"
 	case jsonplan.DeferredReasonResourceConfigUnknown:
-		explanation = "The resource configuration is unknown."
+		explanation = "because the resource configuration is unknown"
 	case jsonplan.DeferredReasonProviderConfigUnknown:
-		explanation = "The provider configuration is unknown."
+		explanation = "because the provider configuration is unknown"
 	case jsonplan.DeferredReasonDeferredPrereq:
-		explanation = "A prerequisite for this resource is deferred."
+		explanation = "because a prerequisite for this resource is deferred"
 	case jsonplan.DeferredReasonAbsentPrereq:
-		explanation = "A prerequisite for this resource is absent."
+		explanation = "because a prerequisite for this resource has not yet been created"
 	default:
-		explanation = "Unknown / Not supported by this version of Terraform."
+		explanation = "for an unknown reason"
 	}
 
-	buf.WriteString(renderer.Colorize.Color(fmt.Sprintf("%s was deferred: \nReason: %s\n", deferred.diff.change.Address, explanation)))
+	buf.WriteString(renderer.Colorize.Color(fmt.Sprintf("[bold]  # %s[reset] was deferred\n", deferred.diff.change.Address)))
+	buf.WriteString(renderer.Colorize.Color(fmt.Sprintf("  #[reset] (s)\n", explanation)))
 
 	opts := computed.NewRenderHumanOpts(renderer.Colorize)
 	opts.ShowUnchangedChildren = deferred.diff.Importing()

--- a/internal/command/jsonformat/plan.go
+++ b/internal/command/jsonformat/plan.go
@@ -107,6 +107,18 @@ func (plan Plan) renderHuman(renderer Renderer, mode plans.Mode, opts ...plans.Q
 				renderer.Colorize.Color("\n[reset][bold][red]Planning failed.[reset][bold] Terraform encountered an error while generating this plan.[reset]\n\n"),
 			)
 		} else {
+			// We had no changes, but deferred changes
+			if len(diffs.deferred) > 0 {
+				if haveRefreshChanges {
+					renderer.Streams.Print(format.HorizontalRule(renderer.Colorize, renderer.Streams.Stdout.Columns()))
+					renderer.Streams.Println("")
+				}
+				renderer.Streams.Print(
+					renderer.Colorize.Color("\n[reset][bold][green]No changes.[reset][bold] This plan requires another plan to be applied first.[reset]\n\n"),
+				)
+				return
+			}
+
 			switch mode {
 			case plans.RefreshOnlyMode:
 				if haveRefreshChanges {

--- a/internal/command/jsonformat/plan_test.go
+++ b/internal/command/jsonformat/plan_test.go
@@ -101,8 +101,19 @@ func TestRenderHuman_DeferredPlan(t *testing.T) {
 	plan.renderHuman(renderer, plans.NormalMode)
 
 	want := `
-No changes. This plan requires another plan to be applied first.
+No current changes. This plan requires another plan to be applied first.
 
+
+Note: This is a partial plan, parts can only be known in the next plan / apply cycle.
+
+
+  # aws_instance.foo was deferred
+  # because a prerequisite for this resource is deferred
+  ~ resource "aws_instance" "foo" {
+        id = "1D5F5E9E-F2E5-401B-9ED5-692A215AC67E"
+    }
+
+─────────────────────────────────────────────────────────────────────────────
 `
 
 	got := done(t).Stdout()
@@ -7229,8 +7240,8 @@ func TestResourceChange_deferredActions(t *testing.T) {
 					},
 				},
 			},
-			output: `test_instance.instance was deferred: 
-Reason: A prerequisite for this resource is absent.
+			output: `  # test_instance.instance was deferred
+  # because a prerequisite for this resource has not yet been created
   + resource "test_instance" "instance" {
       + ami  = "bar"
       + disk = (known after apply)
@@ -7269,8 +7280,8 @@ Reason: A prerequisite for this resource is absent.
 					},
 				},
 			},
-			output: `test_instance.instance[*] was deferred: 
-Reason: The number of resource instances is unknown.
+			output: `  # test_instance.instance[*] was deferred
+  # because the number of resource instances is unknown
   + resource "test_instance" "instance" {
       + ami  = "bar"
       + disk = (known after apply)
@@ -7319,8 +7330,8 @@ Reason: The number of resource instances is unknown.
 					},
 				},
 			},
-			output: `test_instance.instance was deferred: 
-Reason: The provider configuration is unknown.
+			output: `  # test_instance.instance was deferred
+  # because the provider configuration is unknown
   ~ resource "test_instance" "instance" {
       ~ ami = "bar" -> "baz"
         id  = "foo"
@@ -7366,8 +7377,8 @@ Reason: The provider configuration is unknown.
 					},
 				},
 			},
-			output: `test_instance.instance was deferred: 
-Reason: The resource configuration is unknown.
+			output: `  # test_instance.instance was deferred
+  # because the resource configuration is unknown
   ~ resource "test_instance" "instance" {
       - ami = "bar" -> null
       - id  = "foo" -> null

--- a/internal/command/jsonformat/plan_test.go
+++ b/internal/command/jsonformat/plan_test.go
@@ -108,7 +108,7 @@ Note: This is a partial plan, parts can only be known in the next plan / apply c
 
 
   # aws_instance.foo was deferred
-  # because a prerequisite for this resource is deferred
+  # (because a prerequisite for this resource is deferred)
   ~ resource "aws_instance" "foo" {
         id = "1D5F5E9E-F2E5-401B-9ED5-692A215AC67E"
     }
@@ -7241,7 +7241,7 @@ func TestResourceChange_deferredActions(t *testing.T) {
 				},
 			},
 			output: `  # test_instance.instance was deferred
-  # because a prerequisite for this resource has not yet been created
+  # (because a prerequisite for this resource has not yet been created)
   + resource "test_instance" "instance" {
       + ami  = "bar"
       + disk = (known after apply)
@@ -7281,7 +7281,7 @@ func TestResourceChange_deferredActions(t *testing.T) {
 				},
 			},
 			output: `  # test_instance.instance[*] was deferred
-  # because the number of resource instances is unknown
+  # (because the number of resource instances is unknown)
   + resource "test_instance" "instance" {
       + ami  = "bar"
       + disk = (known after apply)
@@ -7331,7 +7331,7 @@ func TestResourceChange_deferredActions(t *testing.T) {
 				},
 			},
 			output: `  # test_instance.instance was deferred
-  # because the provider configuration is unknown
+  # (because the provider configuration is unknown)
   ~ resource "test_instance" "instance" {
       ~ ami = "bar" -> "baz"
         id  = "foo"
@@ -7378,7 +7378,7 @@ func TestResourceChange_deferredActions(t *testing.T) {
 				},
 			},
 			output: `  # test_instance.instance was deferred
-  # because the resource configuration is unknown
+  # (because the resource configuration is unknown)
   ~ resource "test_instance" "instance" {
       - ami = "bar" -> null
       - id  = "foo" -> null

--- a/internal/command/jsonformat/plan_test.go
+++ b/internal/command/jsonformat/plan_test.go
@@ -7127,6 +7127,236 @@ func TestOutputChanges(t *testing.T) {
 	}
 }
 
+func TestResourceChange_deferredActions(t *testing.T) {
+	color := &colorstring.Colorize{Colors: colorstring.DefaultColors, Disable: true}
+	providerAddr := addrs.AbsProviderConfig{
+		Provider: addrs.NewDefaultProvider("test"),
+		Module:   addrs.RootModule,
+	}
+	testCases := map[string]struct {
+		changes []*plans.DeferredResourceInstanceChange
+		output  string
+	}{
+		"deferred create action": {
+			changes: []*plans.DeferredResourceInstanceChange{
+				{
+					DeferredReason: providers.DeferredReasonAbsentPrereq,
+					Change: &plans.ResourceInstanceChange{
+						Addr: addrs.Resource{
+							Mode: addrs.ManagedResourceMode,
+							Type: "test_instance",
+							Name: "instance",
+						}.Instance(addrs.NoKey).Absolute(addrs.RootModuleInstance),
+						ProviderAddr: providerAddr,
+						Change: plans.Change{
+							Action: plans.Create,
+							Before: cty.NullVal(cty.DynamicPseudoType),
+							After: cty.ObjectVal(map[string]cty.Value{
+								"id":  cty.UnknownVal(cty.String),
+								"ami": cty.StringVal("bar"),
+								"disk": cty.UnknownVal(cty.Object(map[string]cty.Type{
+									"mount_point": cty.String,
+									"size":        cty.Number,
+								})),
+								"root_block_device": cty.UnknownVal(cty.Object(map[string]cty.Type{
+									"volume_type": cty.String,
+								})),
+							}),
+						},
+					},
+				},
+			},
+			output: `test_instance.instance was deferred: 
+Reason: A prerequisite for this resource is absent.
+  + resource "test_instance" "instance" {
+      + ami  = "bar"
+      + disk = (known after apply)
+      + id   = (known after apply)
+
+      + root_block_device (known after apply)
+    }`,
+		},
+
+		"deferred create action unknown for_each": {
+			changes: []*plans.DeferredResourceInstanceChange{
+				{
+					DeferredReason: providers.DeferredReasonInstanceCountUnknown,
+					Change: &plans.ResourceInstanceChange{
+						Addr: addrs.Resource{
+							Mode: addrs.ManagedResourceMode,
+							Type: "test_instance",
+							Name: "instance",
+						}.Instance(addrs.WildcardKey).Absolute(addrs.RootModuleInstance),
+						ProviderAddr: providerAddr,
+						Change: plans.Change{
+							Action: plans.Create,
+							Before: cty.NullVal(cty.DynamicPseudoType),
+							After: cty.ObjectVal(map[string]cty.Value{
+								"id":  cty.UnknownVal(cty.String),
+								"ami": cty.StringVal("bar"),
+								"disk": cty.UnknownVal(cty.Object(map[string]cty.Type{
+									"mount_point": cty.String,
+									"size":        cty.Number,
+								})),
+								"root_block_device": cty.UnknownVal(cty.Object(map[string]cty.Type{
+									"volume_type": cty.String,
+								})),
+							}),
+						},
+					},
+				},
+			},
+			output: `test_instance.instance[*] was deferred: 
+Reason: The number of resource instances is unknown.
+  + resource "test_instance" "instance" {
+      + ami  = "bar"
+      + disk = (known after apply)
+      + id   = (known after apply)
+
+      + root_block_device (known after apply)
+    }`,
+		},
+
+		"deferred update action": {
+			changes: []*plans.DeferredResourceInstanceChange{
+				{
+					DeferredReason: providers.DeferredReasonProviderConfigUnknown,
+					Change: &plans.ResourceInstanceChange{
+						Addr: addrs.Resource{
+							Mode: addrs.ManagedResourceMode,
+							Type: "test_instance",
+							Name: "instance",
+						}.Instance(addrs.NoKey).Absolute(addrs.RootModuleInstance),
+						ProviderAddr: providerAddr,
+						Change: plans.Change{
+							Action: plans.Update,
+							Before: cty.ObjectVal(map[string]cty.Value{
+								"id":  cty.StringVal("foo"),
+								"ami": cty.StringVal("bar"),
+								"disk": cty.NullVal(cty.Object(map[string]cty.Type{
+									"mount_point": cty.String,
+									"size":        cty.Number,
+								})),
+								"root_block_device": cty.NullVal(cty.Object(map[string]cty.Type{
+									"volume_type": cty.String,
+								})),
+							}),
+							After: cty.ObjectVal(map[string]cty.Value{
+								"id":  cty.StringVal("foo"),
+								"ami": cty.StringVal("baz"),
+								"disk": cty.NullVal(cty.Object(map[string]cty.Type{
+									"mount_point": cty.String,
+									"size":        cty.Number,
+								})),
+								"root_block_device": cty.NullVal(cty.Object(map[string]cty.Type{
+									"volume_type": cty.String,
+								})),
+							}),
+						},
+					},
+				},
+			},
+			output: `test_instance.instance was deferred: 
+Reason: The provider configuration is unknown.
+  ~ resource "test_instance" "instance" {
+      ~ ami = "bar" -> "baz"
+        id  = "foo"
+    }`,
+		},
+
+		"deferred destroy action": {
+			changes: []*plans.DeferredResourceInstanceChange{
+				{
+					DeferredReason: providers.DeferredReasonResourceConfigUnknown,
+					Change: &plans.ResourceInstanceChange{
+						Addr: addrs.Resource{
+							Mode: addrs.ManagedResourceMode,
+							Type: "test_instance",
+							Name: "instance",
+						}.Instance(addrs.NoKey).Absolute(addrs.RootModuleInstance),
+						ProviderAddr: providerAddr,
+						Change: plans.Change{
+							Action: plans.Update,
+							Before: cty.ObjectVal(map[string]cty.Value{
+								"id":  cty.StringVal("foo"),
+								"ami": cty.StringVal("bar"),
+								"disk": cty.NullVal(cty.Object(map[string]cty.Type{
+									"mount_point": cty.String,
+									"size":        cty.Number,
+								})),
+								"root_block_device": cty.NullVal(cty.Object(map[string]cty.Type{
+									"volume_type": cty.String,
+								})),
+							}),
+							After: cty.NullVal(cty.Object(map[string]cty.Type{
+								"id":  cty.String,
+								"ami": cty.String,
+								"disk": cty.Object(map[string]cty.Type{
+									"mount_point": cty.String,
+									"size":        cty.Number,
+								}),
+								"root_block_device": cty.Object(map[string]cty.Type{
+									"volume_type": cty.String,
+								}),
+							})),
+						},
+					},
+				},
+			},
+			output: `test_instance.instance was deferred: 
+Reason: The resource configuration is unknown.
+  ~ resource "test_instance" "instance" {
+      - ami = "bar" -> null
+      - id  = "foo" -> null
+    }`,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			blockSchema := testSchema(configschema.NestingSingle)
+			fullSchema := &terraform.Schemas{
+				Providers: map[addrs.Provider]providers.ProviderSchema{
+					providerAddr.Provider: {
+						ResourceTypes: map[string]providers.Schema{
+							"test_instance": {
+								Block: blockSchema,
+							},
+						},
+					},
+				},
+			}
+			var changes []*plans.DeferredResourceInstanceChangeSrc
+			for _, change := range tc.changes {
+				changeSrc, err := change.Encode(blockSchema.ImpliedType())
+				if err != nil {
+					t.Fatalf("Failed to encode change: %s", err)
+				}
+				changes = append(changes, changeSrc)
+			}
+
+			deferredChanges, err := jsonplan.MarshalDeferredResourceChanges(changes, fullSchema)
+			if err != nil {
+				t.Fatalf("failed to marshal deferred changes: %s", err)
+			}
+
+			renderer := Renderer{Colorize: color}
+			jsonschemas := jsonprovider.MarshalForRenderer(fullSchema)
+			diffs := precomputeDiffs(Plan{
+				DeferredChanges: deferredChanges,
+				ProviderSchemas: jsonschemas,
+			}, plans.NormalMode)
+
+			// TODO: Add diffing for outputs
+			// TODO: Make sure it's true and either make it a single entity in the test case or deal with a list here
+			output, _ := renderHumanDeferredDiff(renderer, diffs.deferred[0])
+			if diff := cmp.Diff(tc.output, output); len(diff) > 0 {
+				t.Errorf("unexpected output\ngot:\n%s\nwant:\n%s\ndiff:\n%s", output, tc.output, diff)
+			}
+		})
+	}
+}
+
 func outputChange(name string, before, after cty.Value, sensitive bool) *plans.OutputChangeSrc {
 	addr := addrs.AbsOutputValue{
 		OutputValue: addrs.OutputValue{Name: name},

--- a/internal/command/jsonplan/plan.go
+++ b/internal/command/jsonplan/plan.go
@@ -292,7 +292,7 @@ func Marshal(
 	}
 
 	if p.DeferredResources != nil {
-		output.DeferredChanges, err = marshalDeferredResourceChanges(p.DeferredResources, schemas)
+		output.DeferredChanges, err = MarshalDeferredResourceChanges(p.DeferredResources, schemas)
 		if err != nil {
 			return nil, fmt.Errorf("error in marshaling deferred resource changes: %s", err)
 		}
@@ -583,10 +583,11 @@ func marshalResourceChange(rc *plans.ResourceInstanceChangeSrc, schemas *terrafo
 	return r, nil
 }
 
-// marshalDeferredResourceChanges converts the provided internal representation
+// MarshalDeferredResourceChanges converts the provided internal representation
 // of DeferredResourceInstanceChangeSrc objects into the public structured JSON
 // changes.
-func marshalDeferredResourceChanges(resources []*plans.DeferredResourceInstanceChangeSrc, schemas *terraform.Schemas) ([]DeferredResourceChange, error) {
+// This is public to make testing easier.
+func MarshalDeferredResourceChanges(resources []*plans.DeferredResourceInstanceChangeSrc, schemas *terraform.Schemas) ([]DeferredResourceChange, error) {
 	var ret []DeferredResourceChange
 
 	var sortedResources []*plans.DeferredResourceInstanceChangeSrc


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Adds support to the plan renderer for rendering deferred actions.

[Jira: TF-19059](https://hashicorp.atlassian.net/browse/TF-19059)

Example output from a completely deferred component:

<img width="1151" alt="Screenshot 2024-08-09 at 10 19 08" src="https://github.com/user-attachments/assets/c5f8841f-e65d-42ff-a15d-c73659924cb3">

Example output from a partially deferred component
<img width="1283" alt="Screenshot 2024-08-09 at 10 20 13" src="https://github.com/user-attachments/assets/dbf7fa39-a0aa-4f9a-8dd3-3cfa0118b545">



## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.10.x

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

### ENHANCEMENTS

<!--

Write a short description of the user-facing change. Examples:

- `terraform show -json`: Fixed crash with sensitive set values.
- When rendering a diff, Terraform now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 

-  plan: can render deferred actions
