### PR TITLE
core: move import validation into the validate graph

### DIFF
--- a/internal/terraform/context_plan_import_test.go
+++ b/internal/terraform/context_plan_import_test.go
@@ -1093,14 +1093,6 @@ import {
 	}
 
 	diags := ctx.Validate(m, &ValidateOpts{})
-	if diags.HasErrors() {
-		t.Fatalf("unexpected errors\n%s", diags.Err().Error())
-	}
-
-	_, diags = ctx.Plan(m, states.NewState(), &PlanOpts{
-		Mode:               plans.NormalMode,
-		GenerateConfigPath: "generated.tf",
-	})
 	if !diags.HasErrors() {
 		t.Fatalf("expected plan to error, but it did not")
 	}
@@ -1597,20 +1589,8 @@ import {
 	})
 
 	diags := ctx.Validate(m, &ValidateOpts{})
-	if diags.HasErrors() {
-		t.Fatalf("unexpected errors\n%s", diags.Err().Error())
-	}
-
-	plan, diags := ctx.Plan(m, states.NewState(), &PlanOpts{
-		Mode:               plans.NormalMode,
-		GenerateConfigPath: "generated.tf",
-	})
-	if diags.HasErrors() {
-		t.Fatalf("unexpected errors\n%s", diags.Err().Error())
-	}
-
-	if len(plan.Changes.Resources) != 0 {
-		t.Fatal("expected no resource changes")
+	if !diags.HasErrors() {
+		t.Fatal("expected errors, got none")
 	}
 }
 

--- a/internal/terraform/context_plan_import_test.go
+++ b/internal/terraform/context_plan_import_test.go
@@ -59,6 +59,11 @@ import {
 		},
 	}
 
+	diags := ctx.Validate(m, &ValidateOpts{})
+	if diags.HasErrors() {
+		t.Fatalf("unexpected errors\n%s", diags.Err().Error())
+	}
+
 	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
 	if diags.HasErrors() {
 		t.Fatalf("unexpected errors\n%s", diags.Err().Error())
@@ -150,6 +155,11 @@ import {
 		mustProviderConfig(`provider["registry.terraform.io/hashicorp/test"]`),
 	)
 
+	diags := ctx.Validate(m, &ValidateOpts{})
+	if diags.HasErrors() {
+		t.Fatalf("unexpected errors\n%s", diags.Err().Error())
+	}
+
 	plan, diags := ctx.Plan(m, state, DefaultPlanOpts)
 	if diags.HasErrors() {
 		t.Fatalf("unexpected errors\n%s", diags.Err().Error())
@@ -216,6 +226,11 @@ import {
 		},
 	}
 
+	diags := ctx.Validate(m, &ValidateOpts{})
+	if diags.HasErrors() {
+		t.Fatalf("unexpected errors\n%s", diags.Err().Error())
+	}
+
 	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
 	if diags.HasErrors() {
 		t.Fatalf("unexpected errors\n%s", diags.Err().Error())
@@ -280,6 +295,11 @@ import {
 				}),
 			},
 		},
+	}
+
+	diags := ctx.Validate(m, &ValidateOpts{})
+	if diags.HasErrors() {
+		t.Fatalf("unexpected errors\n%s", diags.Err().Error())
 	}
 
 	plan, diags := ctx.Plan(m, states.NewState(), &PlanOpts{
@@ -358,7 +378,12 @@ import {
 		},
 	}
 
-	_, diags := ctx.Plan(m, states.NewState(), &PlanOpts{
+	diags := ctx.Validate(m, &ValidateOpts{})
+	if diags.HasErrors() {
+		t.Fatalf("unexpected errors\n%s", diags.Err().Error())
+	}
+
+	_, diags = ctx.Plan(m, states.NewState(), &PlanOpts{
 		Mode: plans.NormalMode,
 		ForceReplace: []addrs.AbsResourceInstance{
 			addr,
@@ -410,7 +435,13 @@ import {
 		},
 	}
 
-	_, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	// while the counts are static, the indexes are not fully evaluated during validation
+	diags := ctx.Validate(m, &ValidateOpts{})
+	if diags.HasErrors() {
+		t.Fatalf("unexpected errors\n%s", diags.Err().Error())
+	}
+
+	_, diags = ctx.Plan(m, states.NewState(), DefaultPlanOpts)
 	if !diags.HasErrors() {
 		t.Fatalf("expected error but got none")
 	}
@@ -436,7 +467,12 @@ func TestContext2Plan_importIdVariable(t *testing.T) {
 		},
 	}
 
-	_, diags := ctx.Plan(m, states.NewState(), &PlanOpts{
+	diags := ctx.Validate(m, &ValidateOpts{})
+	if diags.HasErrors() {
+		t.Fatalf("unexpected errors\n%s", diags.Err().Error())
+	}
+
+	_, diags = ctx.Plan(m, states.NewState(), &PlanOpts{
 		SetVariables: InputValues{
 			"the_id": &InputValue{
 				// let var take its default value
@@ -469,7 +505,12 @@ func TestContext2Plan_importIdFunc(t *testing.T) {
 		},
 	}
 
-	_, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	diags := ctx.Validate(m, &ValidateOpts{})
+	if diags.HasErrors() {
+		t.Fatalf("unexpected errors\n%s", diags.Err().Error())
+	}
+
+	_, diags = ctx.Plan(m, states.NewState(), DefaultPlanOpts)
 	if diags.HasErrors() {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
@@ -532,7 +573,12 @@ func TestContext2Plan_importIdDataSource(t *testing.T) {
 		},
 	})
 
-	_, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	diags := ctx.Validate(m, &ValidateOpts{})
+	if diags.HasErrors() {
+		t.Fatalf("unexpected errors\n%s", diags.Err().Error())
+	}
+
+	_, diags = ctx.Plan(m, states.NewState(), DefaultPlanOpts)
 	if diags.HasErrors() {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
@@ -570,7 +616,12 @@ func TestContext2Plan_importIdModule(t *testing.T) {
 		},
 	})
 
-	_, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	diags := ctx.Validate(m, &ValidateOpts{})
+	if diags.HasErrors() {
+		t.Fatalf("unexpected errors\n%s", diags.Err().Error())
+	}
+
+	_, diags = ctx.Plan(m, states.NewState(), DefaultPlanOpts)
 	if diags.HasErrors() {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
@@ -585,7 +636,13 @@ func TestContext2Plan_importIdInvalidNull(t *testing.T) {
 		},
 	})
 
-	_, diags := ctx.Plan(m, states.NewState(), &PlanOpts{
+	// input variables are not evaluated during validation
+	diags := ctx.Validate(m, &ValidateOpts{})
+	if diags.HasErrors() {
+		t.Fatalf("unexpected errors\n%s", diags.Err().Error())
+	}
+
+	_, diags = ctx.Plan(m, states.NewState(), &PlanOpts{
 		SetVariables: InputValues{
 			"the_id": &InputValue{
 				Value: cty.NullVal(cty.String),
@@ -662,7 +719,12 @@ func TestContext2Plan_importIdInvalidUnknown(t *testing.T) {
 		},
 	}
 
-	_, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	diags := ctx.Validate(m, &ValidateOpts{})
+	if diags.HasErrors() {
+		t.Fatalf("unexpected errors\n%s", diags.Err().Error())
+	}
+
+	_, diags = ctx.Plan(m, states.NewState(), DefaultPlanOpts)
 	if !diags.HasErrors() {
 		t.Fatal("succeeded; want errors")
 	}
@@ -735,8 +797,13 @@ import {
 		},
 	}
 
+	diags := ctx.Validate(m, &ValidateOpts{})
+	if diags.HasErrors() {
+		t.Fatalf("unexpected errors\n%s", diags.Err().Error())
+	}
+
 	// Actual plan doesn't matter, just want to make sure there are no errors.
-	_, diags := ctx.Plan(m, states.NewState(), &PlanOpts{
+	_, diags = ctx.Plan(m, states.NewState(), &PlanOpts{
 		Mode:               plans.NormalMode,
 		GenerateConfigPath: "generated.tf", // Actual value here doesn't matter, as long as it is not empty.
 	})
@@ -789,6 +856,11 @@ resource "test_object" "a" {
 				}),
 			},
 		},
+	}
+
+	diags := ctx.Validate(m, &ValidateOpts{})
+	if diags.HasErrors() {
+		t.Fatalf("unexpected errors\n%s", diags.Err().Error())
 	}
 
 	plan, diags := ctx.Plan(m, states.NewState(), &PlanOpts{
@@ -849,6 +921,11 @@ import {
 				}),
 			},
 		},
+	}
+
+	diags := ctx.Validate(m, &ValidateOpts{})
+	if diags.HasErrors() {
+		t.Fatalf("unexpected errors\n%s", diags.Err().Error())
 	}
 
 	plan, diags := ctx.Plan(m, states.NewState(), &PlanOpts{
@@ -933,6 +1010,11 @@ import {
 		},
 	}
 
+	diags := ctx.Validate(m, &ValidateOpts{})
+	if diags.HasErrors() {
+		t.Fatalf("unexpected errors\n%s", diags.Err().Error())
+	}
+
 	plan, diags := ctx.Plan(m, states.NewState(), &PlanOpts{
 		Mode:               plans.NormalMode,
 		GenerateConfigPath: "generated.tf", // Actual value here doesn't matter, as long as it is not empty.
@@ -1010,7 +1092,12 @@ import {
 		},
 	}
 
-	_, diags := ctx.Plan(m, states.NewState(), &PlanOpts{
+	diags := ctx.Validate(m, &ValidateOpts{})
+	if diags.HasErrors() {
+		t.Fatalf("unexpected errors\n%s", diags.Err().Error())
+	}
+
+	_, diags = ctx.Plan(m, states.NewState(), &PlanOpts{
 		Mode:               plans.NormalMode,
 		GenerateConfigPath: "generated.tf",
 	})
@@ -1128,6 +1215,11 @@ import {
 		},
 	}
 
+	diags := ctx.Validate(m, &ValidateOpts{})
+	if diags.HasErrors() {
+		t.Fatalf("unexpected errors\n%s", diags.Err().Error())
+	}
+
 	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
 	if diags.HasErrors() {
 		t.Fatalf("unexpected errors\n%s", diags.Err().Error())
@@ -1241,6 +1333,11 @@ resource "test_object" "a" {
 		},
 	}
 
+	diags := ctx.Validate(m, &ValidateOpts{})
+	if diags.HasErrors() {
+		t.Fatalf("unexpected errors\n%s", diags.Err().Error())
+	}
+
 	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
 	if diags.HasErrors() {
 		t.Fatalf("unexpected errors\n%s", diags.Err().Error())
@@ -1339,6 +1436,11 @@ import {
 		},
 		mustProviderConfig(`provider["registry.terraform.io/hashicorp/test"]`),
 	)
+
+	diags := ctx.Validate(m, &ValidateOpts{})
+	if diags.HasErrors() {
+		t.Fatalf("unexpected errors\n%s", diags.Err().Error())
+	}
 
 	plan, diags := ctx.Plan(m, state, DefaultPlanOpts)
 	if diags.HasErrors() {
@@ -1440,6 +1542,11 @@ import {
 		},
 	}
 
+	diags := ctx.Validate(m, &ValidateOpts{})
+	if diags.HasErrors() {
+		t.Fatalf("unexpected errors\n%s", diags.Err().Error())
+	}
+
 	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
 	if diags.HasErrors() {
 		t.Fatalf("unexpected errors\n%s", diags.Err().Error())
@@ -1488,6 +1595,11 @@ import {
 			addrs.NewDefaultProvider("test"): testProviderFuncFixed(p),
 		},
 	})
+
+	diags := ctx.Validate(m, &ValidateOpts{})
+	if diags.HasErrors() {
+		t.Fatalf("unexpected errors\n%s", diags.Err().Error())
+	}
 
 	plan, diags := ctx.Plan(m, states.NewState(), &PlanOpts{
 		Mode:               plans.NormalMode,
@@ -1555,8 +1667,13 @@ import {
 		},
 	})
 
+	diags := ctx.Validate(m, &ValidateOpts{})
+	if diags.HasErrors() {
+		t.Fatalf("unexpected errors\n%s", diags.Err().Error())
+	}
+
 	// Just don't crash!
-	_, diags := ctx.Plan(m, states.NewState(), &PlanOpts{
+	_, diags = ctx.Plan(m, states.NewState(), &PlanOpts{
 		Mode:               plans.NormalMode,
 		GenerateConfigPath: "generated.tf",
 	})
@@ -1653,7 +1770,7 @@ resource "test_object" "a" {
 		},
 	})
 
-	_, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	diags := ctx.Validate(m, &ValidateOpts{})
 
 	// We're expecting exactly one diag, which is the self-reference error.
 	if len(diags) != 1 {
@@ -1690,7 +1807,7 @@ resource "test_object" "a" {
 		},
 	})
 
-	_, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	diags := ctx.Validate(m, &ValidateOpts{})
 
 	// We're expecting exactly one diag, which is the self-reference error.
 	if len(diags) != 1 {
@@ -1727,7 +1844,7 @@ resource "test_object" "a" {
 		},
 	})
 
-	_, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	diags := ctx.Validate(m, &ValidateOpts{})
 
 	// We're expecting exactly one diag, which is the self-reference error.
 	if len(diags) != 1 {
@@ -1772,7 +1889,7 @@ output "foo" {
 		},
 	})
 
-	_, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	diags := ctx.Validate(m, &ValidateOpts{})
 
 	// We're expecting exactly one diag, which is the self-reference error.
 	if len(diags) != 1 {
@@ -1786,10 +1903,10 @@ output "foo" {
 	if !strings.Contains(got, "Cycle:") {
 		t.Errorf("should have reported a cycle error, but got %s", got)
 	}
-	if !strings.Contains(got, "module.mod.output.foo (expand)") {
+	if !strings.Contains(got, "module.mod.output.foo") {
 		t.Errorf("should have reported the cycle to contain the module output, but got %s", got)
 	}
-	if !strings.Contains(got, "module.mod.test_object.a (expand)") {
+	if !strings.Contains(got, "module.mod.test_object.a") {
 		t.Errorf("should have reported the cycle to contain the target resource, but got %s", got)
 	}
 }

--- a/internal/terraform/context_validate.go
+++ b/internal/terraform/context_validate.go
@@ -103,6 +103,7 @@ func (c *Context) Validate(config *configs.Config, opts *ValidateOpts) tfdiags.D
 		RootVariableValues:      varValues,
 		Operation:               walkValidate,
 		ExternalProviderConfigs: opts.ExternalProviders,
+		ImportTargets:           c.findImportTargets(config),
 	}).Build(addrs.RootModuleInstance)
 	diags = diags.Append(moreDiags)
 	if moreDiags.HasErrors() {

--- a/internal/terraform/eval_for_each.go
+++ b/internal/terraform/eval_for_each.go
@@ -136,6 +136,18 @@ func (ev *forEachEvaluator) ImportValues() ([]instances.RepetitionData, bool, tf
 
 	val, marks := forEachVal.Unmark()
 
+	if !val.CanIterateElements() {
+		diags = diags.Append(&hcl.Diagnostic{
+			Severity:    hcl.DiagError,
+			Summary:     "Invalid for_each argument",
+			Detail:      "The \"for_each\" expression must be a collection.",
+			Subject:     ev.expr.Range().Ptr(),
+			Expression:  ev.expr,
+			EvalContext: ev.hclCtx,
+		})
+		return res, false, diags
+	}
+
 	it := val.ElementIterator()
 	for it.Next() {
 		k, v := it.Element()

--- a/internal/terraform/eval_import.go
+++ b/internal/terraform/eval_import.go
@@ -16,7 +16,7 @@ import (
 	"github.com/hashicorp/terraform/internal/tfdiags"
 )
 
-func evaluateImportIdExpression(expr hcl.Expression, target addrs.AbsResourceInstance, ctx EvalContext, keyData instances.RepetitionData, allowUnknown bool) (cty.Value, tfdiags.Diagnostics) {
+func evaluateImportIdExpression(expr hcl.Expression, ctx EvalContext, keyData instances.RepetitionData, allowUnknown bool) (cty.Value, tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
 
 	if expr == nil {
@@ -26,11 +26,6 @@ func evaluateImportIdExpression(expr hcl.Expression, target addrs.AbsResourceIns
 			Detail:   "The import ID cannot be null.",
 			Subject:  expr.Range().Ptr(),
 		})
-	}
-
-	diags = diags.Append(validateImportSelfRef(target.Resource.Resource, expr))
-	if diags.HasErrors() {
-		return cty.NilVal, diags
 	}
 
 	// import blocks only exist in the root module, and must be evaluated in

--- a/internal/terraform/graph_builder_plan.go
+++ b/internal/terraform/graph_builder_plan.go
@@ -137,9 +137,7 @@ func (b *PlanGraphBuilder) Steps() []GraphTransformer {
 		&ConfigTransformer{
 			Concrete: b.ConcreteResource,
 			Config:   b.Config,
-
-			// Resources are not added from the config on destroy.
-			skip: b.Operation == walkPlanDestroy,
+			skip:     b.Operation == walkDestroy || b.Operation == walkPlanDestroy,
 
 			importTargets: b.ImportTargets,
 

--- a/internal/terraform/node_resource_plan.go
+++ b/internal/terraform/node_resource_plan.go
@@ -282,6 +282,20 @@ func (n *nodeExpandPlannableResource) validateExpandedImportTargets(expandedImpo
 			))
 			return diags
 		}
+
+		if n.Config == nil && n.generateConfigPath == "" && len(n.importTargets) == 1 {
+			// we have no config and aren't generating any. This isn't caught during
+			// validation because generateConfigPath is only a plan option. If we
+			// got this far however, it means this node is eligible for config
+			// generation, so suggest it to the user.
+			diags = diags.Append(&hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  "Configuration for import target does not exist",
+				Detail:   fmt.Sprintf("The configuration for the given import target %s does not exist. If you wish to automatically generate config for this resource, use the -generate-config-out option within terraform plan. Otherwise, make sure the target resource exists within your configuration. For example:\n\n  terraform plan -generate-config-out=generated.tf", n.Addr),
+				Subject:  n.importTargets[0].Config.To.Range().Ptr(),
+			})
+			return diags
+		}
 	}
 
 	return diags

--- a/internal/terraform/node_resource_plan.go
+++ b/internal/terraform/node_resource_plan.go
@@ -185,6 +185,8 @@ func (n *nodeExpandPlannableResource) expandResourceImports(ctx EvalContext, all
 				return knownImports, unknownImports, diags
 			}
 
+			diags = diags.Append(validateImportTargetExpansion(n.Config, to, imp.Config.To))
+
 			importID, evalDiags := evaluateImportIdExpression(imp.Config.ID, ctx, EvalDataForNoInstanceKey, allowUnknown)
 			diags = diags.Append(evalDiags)
 			if diags.HasErrors() {
@@ -241,6 +243,8 @@ func (n *nodeExpandPlannableResource) expandResourceImports(ctx EvalContext, all
 			if diags.HasErrors() {
 				return knownImports, unknownImports, diags
 			}
+
+			diags = diags.Append(validateImportTargetExpansion(n.Config, res, imp.Config.To))
 
 			importID, evalDiags := evaluateImportIdExpression(imp.Config.ID, ctx, keyData, allowUnknown)
 			diags = diags.Append(evalDiags)

--- a/internal/terraform/node_resource_plan.go
+++ b/internal/terraform/node_resource_plan.go
@@ -177,7 +177,6 @@ func (n *nodeExpandPlannableResource) expandResourceImports(ctx EvalContext, all
 		}
 
 		if imp.Config.ForEach == nil {
-
 			traversal, hds := hcl.AbsTraversalForExpr(imp.Config.To)
 			diags = diags.Append(hds)
 			to, tds := addrs.ParseAbsResourceInstance(traversal)
@@ -186,7 +185,7 @@ func (n *nodeExpandPlannableResource) expandResourceImports(ctx EvalContext, all
 				return knownImports, unknownImports, diags
 			}
 
-			importID, evalDiags := evaluateImportIdExpression(imp.Config.ID, to, ctx, EvalDataForNoInstanceKey, allowUnknown)
+			importID, evalDiags := evaluateImportIdExpression(imp.Config.ID, ctx, EvalDataForNoInstanceKey, allowUnknown)
 			diags = diags.Append(evalDiags)
 			if diags.HasErrors() {
 				return knownImports, unknownImports, diags
@@ -243,7 +242,7 @@ func (n *nodeExpandPlannableResource) expandResourceImports(ctx EvalContext, all
 				return knownImports, unknownImports, diags
 			}
 
-			importID, evalDiags := evaluateImportIdExpression(imp.Config.ID, res, ctx, keyData, allowUnknown)
+			importID, evalDiags := evaluateImportIdExpression(imp.Config.ID, ctx, keyData, allowUnknown)
 			diags = diags.Append(evalDiags)
 			if diags.HasErrors() {
 				return knownImports, unknownImports, diags

--- a/internal/terraform/node_resource_validate.go
+++ b/internal/terraform/node_resource_validate.go
@@ -572,7 +572,7 @@ func (n *NodeValidatableResource) validateImportTargets(ctx EvalContext) tfdiags
 				if diags.HasErrors() {
 					return diags
 				}
-				diags = diags.Append(n.validateImportTargetExpansion(to, imp.Config.To))
+				diags = diags.Append(validateImportTargetExpansion(n.Config, to, imp.Config.To))
 				if diags.HasErrors() {
 					return diags
 				}
@@ -591,7 +591,7 @@ func (n *NodeValidatableResource) validateImportTargets(ctx EvalContext) tfdiags
 				return diags
 			}
 
-			diags = diags.Append(n.validateImportTargetExpansion(to, imp.Config.To))
+			diags = diags.Append(validateImportTargetExpansion(n.Config, to, imp.Config.To))
 			if diags.HasErrors() {
 				return diags
 			}
@@ -608,11 +608,11 @@ func (n *NodeValidatableResource) validateImportTargets(ctx EvalContext) tfdiags
 }
 
 // validateImportTargetExpansion ensures that the To address key and resource expansion mode both agree.
-func (n *NodeValidatableResource) validateImportTargetExpansion(to addrs.AbsResourceInstance, toExpr hcl.Expression) tfdiags.Diagnostics {
+func validateImportTargetExpansion(cfg *configs.Resource, to addrs.AbsResourceInstance, toExpr hcl.Expression) tfdiags.Diagnostics {
 	var diags tfdiags.Diagnostics
 
-	forEach := n.Config != nil && n.Config.ForEach != nil
-	count := n.Config != nil && n.Config.Count != nil
+	forEach := cfg != nil && cfg.ForEach != nil
+	count := cfg != nil && cfg.Count != nil
 
 	switch to.Resource.Key.(type) {
 	case addrs.StringKey:

--- a/internal/terraform/node_resource_validate.go
+++ b/internal/terraform/node_resource_validate.go
@@ -315,40 +315,6 @@ func (n *NodeValidatableResource) validateResource(ctx EvalContext) tfdiags.Diag
 
 	diags = diags.Append(validateDependsOn(ctx, n.Config.DependsOn))
 
-	// Validate the provider_meta block for the provider this resource
-	// belongs to, if there is one.
-	//
-	// Note: this will return an error for every resource a provider
-	// uses in a module, if the provider_meta for that module is
-	// incorrect. The only way to solve this that we've found is to
-	// insert a new ProviderMeta graph node in the graph, and make all
-	// that provider's resources in the module depend on the node. That's
-	// an awful heavy hammer to swing for this feature, which should be
-	// used only in limited cases with heavy coordination with the
-	// Terraform team, so we're going to defer that solution for a future
-	// enhancement to this functionality.
-	/*
-		if n.ProviderMetas != nil {
-			if m, ok := n.ProviderMetas[n.ProviderAddr.ProviderConfig.Type]; ok && m != nil {
-				// if the provider doesn't support this feature, throw an error
-				if (*n.ProviderSchema).ProviderMeta == nil {
-					diags = diags.Append(&hcl.Diagnostic{
-						Severity: hcl.DiagError,
-						Summary:  fmt.Sprintf("Provider %s doesn't support provider_meta", cfg.ProviderConfigAddr()),
-						Detail:   fmt.Sprintf("The resource %s belongs to a provider that doesn't support provider_meta blocks", n.Addr),
-						Subject:  &m.ProviderRange,
-					})
-				} else {
-					_, _, metaDiags := ctx.EvaluateBlock(m.Config, (*n.ProviderSchema).ProviderMeta, nil, EvalDataForNoInstanceKey)
-					diags = diags.Append(metaDiags)
-				}
-			}
-		}
-	*/
-	// BUG(paddy): we're not validating provider_meta blocks on EvalValidate right now
-	// because the ProviderAddr for the resource isn't available on the EvalValidate
-	// struct.
-
 	// Provider entry point varies depending on resource mode, because
 	// managed resources and data resources are two distinct concepts
 	// in the provider abstraction.

--- a/internal/terraform/node_resource_validate.go
+++ b/internal/terraform/node_resource_validate.go
@@ -620,7 +620,7 @@ func (n *NodeValidatableResource) validateImportTargetExpansion(to addrs.AbsReso
 			diags = diags.Append(&hcl.Diagnostic{
 				Severity: hcl.DiagError,
 				Summary:  "Invalid import 'to' expression",
-				Detail:   fmt.Sprintf("The target resource does not use for_each."),
+				Detail:   "The target resource does not use for_each.",
 				Subject:  toExpr.Range().Ptr(),
 			})
 		}
@@ -629,7 +629,7 @@ func (n *NodeValidatableResource) validateImportTargetExpansion(to addrs.AbsReso
 			diags = diags.Append(&hcl.Diagnostic{
 				Severity: hcl.DiagError,
 				Summary:  "Invalid import 'to' expression",
-				Detail:   fmt.Sprintf("The target resource does not use count."),
+				Detail:   "The target resource does not use count.",
 				Subject:  toExpr.Range().Ptr(),
 			})
 		}
@@ -638,7 +638,7 @@ func (n *NodeValidatableResource) validateImportTargetExpansion(to addrs.AbsReso
 			diags = diags.Append(&hcl.Diagnostic{
 				Severity: hcl.DiagError,
 				Summary:  "Invalid import 'to' expression",
-				Detail:   fmt.Sprintf("The target resource is using for_each."),
+				Detail:   "The target resource is using for_each.",
 				Subject:  toExpr.Range().Ptr(),
 			})
 		}
@@ -647,7 +647,7 @@ func (n *NodeValidatableResource) validateImportTargetExpansion(to addrs.AbsReso
 			diags = diags.Append(&hcl.Diagnostic{
 				Severity: hcl.DiagError,
 				Summary:  "Invalid import 'to' expression",
-				Detail:   fmt.Sprintf("The target resource is using count."),
+				Detail:   "The target resource is using count.",
 				Subject:  toExpr.Range().Ptr(),
 			})
 		}

--- a/internal/terraform/transform_attach_config_resource.go
+++ b/internal/terraform/transform_attach_config_resource.go
@@ -48,6 +48,7 @@ func (t *AttachResourceConfigTransformer) Transform(g *Graph) error {
 
 		// Get the configuration.
 		config := t.Config.Descendent(addr.Module)
+
 		if config == nil {
 			log.Printf("[TRACE] AttachResourceConfigTransformer: %q (%T) has no configuration available", dag.VertexName(v), v)
 			continue

--- a/internal/terraform/transform_config.go
+++ b/internal/terraform/transform_config.go
@@ -192,9 +192,14 @@ func (t *ConfigTransformer) transformSingle(g *Graph, config *configs.Config) er
 			toDiags = toDiags.Append(hd)
 			to, td := addrs.ParseAbsResourceInstance(traversal)
 			toDiags = toDiags.Append(td)
-			canGenerate := !toDiags.HasErrors() && to.Resource.Key == addrs.NoKey
 
-			if t.generateConfigPathForImportTargets != "" && canGenerate {
+			// Check if we can generate config for this target. During
+			// validation we won't have a valid config path, but we should still
+			// add the Node since it will only be used for further validation.
+			canGenerate := !toDiags.HasErrors() && to.Resource.Key == addrs.NoKey &&
+				(t.op == walkValidate || t.generateConfigPathForImportTargets != "")
+
+			if canGenerate {
 				log.Printf("[DEBUG] ConfigTransformer: adding config generation node for %s", i.Config.ToResource)
 
 				// TODO: if config generation is ever supported for for_each

--- a/internal/terraform/transform_config.go
+++ b/internal/terraform/transform_config.go
@@ -35,7 +35,6 @@ type ConfigTransformer struct {
 	ModeFilter bool
 	Mode       addrs.ResourceMode
 
-	// Do not apply this transformer.
 	skip bool
 
 	// importTargets specifies a slice of addresses that will have state
@@ -53,6 +52,7 @@ type ConfigTransformer struct {
 }
 
 func (t *ConfigTransformer) Transform(g *Graph) error {
+	// no import ops happen during destroy
 	if t.skip {
 		return nil
 	}
@@ -62,8 +62,12 @@ func (t *ConfigTransformer) Transform(g *Graph) error {
 		return nil
 	}
 
-	if err := t.validateImportTargets(); err != nil {
-		return err
+	if t.op != walkValidate {
+		// We can't generate config during validate, so we need to accept
+		// missing targets.
+		if err := t.validateImportTargets(); err != nil {
+			return err
+		}
 	}
 
 	// Start the transformation process

--- a/internal/terraform/transform_config.go
+++ b/internal/terraform/transform_config.go
@@ -62,12 +62,8 @@ func (t *ConfigTransformer) Transform(g *Graph) error {
 		return nil
 	}
 
-	if t.op != walkValidate {
-		// We can't generate config during validate, so we need to accept
-		// missing targets.
-		if err := t.validateImportTargets(); err != nil {
-			return err
-		}
+	if err := t.validateImportTargets(); err != nil {
+		return err
 	}
 
 	// Start the transformation process
@@ -179,54 +175,31 @@ func (t *ConfigTransformer) transformSingle(g *Graph, config *configs.Config) er
 		g.Add(node)
 	}
 
-	// If any import targets were not claimed by resources and we are
-	// generating configuration, then let's add them into the graph now.
+	// If any import targets were not claimed by resources we may be
+	// generating configuration. Add them to the graph for validation.
 	for _, i := range importTargets {
-		if path.IsRoot() {
-			// If we have a single instance import target in the root module, we
-			// can suggest config generation.
-			// We do need to make sure there are no dynamic expressions here
-			// and we can parse this at all.
-			var toDiags tfdiags.Diagnostics
-			traversal, hd := hcl.AbsTraversalForExpr(i.Config.To)
-			toDiags = toDiags.Append(hd)
-			to, td := addrs.ParseAbsResourceInstance(traversal)
-			toDiags = toDiags.Append(td)
+		log.Printf("[DEBUG] ConfigTransformer: adding config generation node for %s", i.Config.ToResource)
 
-			// Check if we can generate config for this target. During
-			// validation we won't have a valid config path, but we should still
-			// add the Node since it will only be used for further validation.
-			canGenerate := !toDiags.HasErrors() && to.Resource.Key == addrs.NoKey &&
-				(t.op == walkValidate || t.generateConfigPathForImportTargets != "")
-
-			if canGenerate {
-				log.Printf("[DEBUG] ConfigTransformer: adding config generation node for %s", i.Config.ToResource)
-
-				// TODO: if config generation is ever supported for for_each
-				// resources, this will add multiple nodes for the same
-				// resource
-				abstract := &NodeAbstractResource{
-					Addr:               i.Config.ToResource,
-					importTargets:      []*ImportTarget{i},
-					generateConfigPath: t.generateConfigPathForImportTargets,
-				}
-				var node dag.Vertex = abstract
-				if f := t.Concrete; f != nil {
-					node = f(abstract)
-				}
-
-				g.Add(node)
-				continue
-			}
+		// TODO: if config generation is ever supported for for_each
+		// resources, this will add multiple nodes for the same
+		// resource
+		abstract := &NodeAbstractResource{
+			Addr:               i.Config.ToResource,
+			importTargets:      []*ImportTarget{i},
+			generateConfigPath: t.generateConfigPathForImportTargets,
 		}
+		var node dag.Vertex = abstract
+		if f := t.Concrete; f != nil {
+			node = f(abstract)
+		}
+
+		g.Add(node)
 	}
 	return nil
 }
 
-// validateImportTargets ensures that the import target resources exist in the
-// configuration. We do this here rather than statically during config loading
-// to have any CLI imports included, and to provide feedback about possible
-// config generation.
+// validateImportTargets ensures that the import target module exists in the
+// configuration. Individual resources will be check by the validation node.
 func (t *ConfigTransformer) validateImportTargets() error {
 	var diags tfdiags.Diagnostics
 
@@ -240,53 +213,14 @@ func (t *ConfigTransformer) validateImportTargets() error {
 		}
 
 		moduleCfg := t.Config.Root.Descendent(toResource.Module)
-		if moduleCfg != nil {
-			res := moduleCfg.Module.ResourceByAddr(toResource.Resource)
-			if res != nil {
-				// the target config exists, which is all we're looking for at this point.
-				continue
-			}
+		if moduleCfg == nil {
+			diags = diags.Append(&hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  "Configuration for import target does not exist",
+				Detail:   fmt.Sprintf("The configuration for the given import target %s does not exist. All target instances must have an associated configuration to be imported.", i.Config.ToResource),
+				Subject:  i.Config.To.Range().Ptr(),
+			})
 		}
-
-		if toResource.Module.IsRoot() {
-			var toDiags tfdiags.Diagnostics
-			traversal, hd := hcl.AbsTraversalForExpr(i.Config.To)
-			toDiags = toDiags.Append(hd)
-			to, td := addrs.ParseAbsResourceInstance(traversal)
-			toDiags = toDiags.Append(td)
-			canGenerate := !toDiags.HasErrors() && to.Resource.Key == addrs.NoKey
-
-			if t.generateConfigPathForImportTargets != "" {
-				if canGenerate {
-					continue
-				}
-
-				diags = diags.Append(&hcl.Diagnostic{
-					Severity: hcl.DiagError,
-					Summary:  "Cannot generate configuration",
-					Detail:   "The given import block is not compatible with config generation. The -generate-config-out option cannot be used with import blocks which use for_each, or resources which use for_each or count.",
-					Subject:  i.Config.To.Range().Ptr(),
-				})
-				continue
-			}
-
-			if canGenerate {
-				diags = diags.Append(&hcl.Diagnostic{
-					Severity: hcl.DiagError,
-					Summary:  "Configuration for import target does not exist",
-					Detail:   fmt.Sprintf("The configuration for the given import target %s does not exist. If you wish to automatically generate config for this resource, use the -generate-config-out option within terraform plan. Otherwise, make sure the target resource exists within your configuration. For example:\n\n  terraform plan -generate-config-out=generated.tf", to),
-					Subject:  i.Config.To.Range().Ptr(),
-				})
-				continue
-			}
-		}
-
-		diags = diags.Append(&hcl.Diagnostic{
-			Severity: hcl.DiagError,
-			Summary:  "Configuration for import target does not exist",
-			Detail:   fmt.Sprintf("The configuration for the given import target %s does not exist. All target instances must have an associated configuration to be imported.", i.Config.ToResource),
-			Subject:  i.Config.To.Range().Ptr(),
-		})
 	}
 
 	return diags.Err()


### PR DESCRIPTION
When import blocks were first introduced they had to be fully static, which allowed them to be validated during the configuration loading process. This early static validation was carried forward as more features were introduced, but that led to some validation in awkward places like the graph builder, and some validation which could not be done like validating the `to` expression.

Moving the import validation into the validate graph allows us to more fully validate the block contents, in the same way as normal resource configuration and mostly unifies where validation happens. We still have a couple outliers due to the possibility of config generation, which requires some checks in the config transformer for entirely missing modules when the resource has no config, and the plan node to suggest config generation if the resource has no configuration.

Now that `Validate` handles most of the actual validation, I inserted `Validate` calls before the import `Plan` calls in tests, or replace the `Plan` calls entirely when it was clear that the desired diagnostics had moved into `Validate. This was to leverage the existing tests both for the new code, and to verify there are no test regressions since `Validate` would always be called during a plan from the command line.

Fixes #35516