### PR TITLE
build: Ensure license is actually copied into linux packages

### DIFF
--- a/.github/workflows/build-terraform-cli.yml
+++ b/.github/workflows/build-terraform-cli.yml
@@ -61,7 +61,7 @@ jobs:
             go build -ldflags "${{ inputs.ld-flags }}" -o "$BIN_PATH" -trimpath -buildvcs=false
             cp LICENSE "$TARGET_DIR/LICENSE.txt"
       - name: Copy license file to config_dir
-        if: ${{ matrix.goos == 'linux' }}
+        if: ${{ inputs.goos == 'linux' }}
         env:
           LICENSE_DIR: ".release/linux/package/usr/share/doc/${{ inputs.package-name }}"
         run: |


### PR DESCRIPTION
The RelEng team has been working on adding some validation to ensure that the work we did in #34977 to include a copy of the license file in all distributed packages is done correctly. While it's working correctly in the build .zips and Docker images, it wasn't being copied over into Linux debs/rpms because of what I'm guessing was a copypasta on my end. Thankfully, this is easily fixed.

I assume this doesn't have to be called out in the changelog, but if anyone disagrees, let me know.