### PR TITLE
build: Ensure license is actually copied into linux packages

### DIFF
--- a/.github/workflows/build-terraform-cli.yml
+++ b/.github/workflows/build-terraform-cli.yml
@@ -61,7 +61,7 @@ jobs:
             go build -ldflags "${{ inputs.ld-flags }}" -o "$BIN_PATH" -trimpath -buildvcs=false
             cp LICENSE "$TARGET_DIR/LICENSE.txt"
       - name: Copy license file to config_dir
-        if: ${{ matrix.goos == 'linux' }}
+        if: ${{ inputs.goos == 'linux' }}
         env:
           LICENSE_DIR: ".release/linux/package/usr/share/doc/${{ inputs.package-name }}"
         run: |


### PR DESCRIPTION
Manual backport of #35547, the automatic backport failed here: https://github.com/hashicorp/terraform/actions/runs/10319304751/job/28567562184.