### PR TITLE
stacks: add depends_on for embedded stacks and components

### DIFF
--- a/internal/configs/depends_on.go
+++ b/internal/configs/depends_on.go
@@ -7,7 +7,7 @@ import (
 	"github.com/hashicorp/hcl/v2"
 )
 
-func decodeDependsOn(attr *hcl.Attribute) ([]hcl.Traversal, hcl.Diagnostics) {
+func DecodeDependsOn(attr *hcl.Attribute) ([]hcl.Traversal, hcl.Diagnostics) {
 	var ret []hcl.Traversal
 	exprs, diags := hcl.ExprList(attr.Expr)
 

--- a/internal/configs/module_call.go
+++ b/internal/configs/module_call.go
@@ -152,7 +152,7 @@ func decodeModuleBlock(block *hcl.Block, override bool) (*ModuleCall, hcl.Diagno
 	}
 
 	if attr, exists := content.Attributes["depends_on"]; exists {
-		deps, depsDiags := decodeDependsOn(attr)
+		deps, depsDiags := DecodeDependsOn(attr)
 		diags = append(diags, depsDiags...)
 		mc.DependsOn = append(mc.DependsOn, deps...)
 	}

--- a/internal/configs/named_values.go
+++ b/internal/configs/named_values.go
@@ -403,7 +403,7 @@ func decodeOutputBlock(block *hcl.Block, override bool) (*Output, hcl.Diagnostic
 	}
 
 	if attr, exists := content.Attributes["depends_on"]; exists {
-		deps, depsDiags := decodeDependsOn(attr)
+		deps, depsDiags := DecodeDependsOn(attr)
 		diags = append(diags, depsDiags...)
 		o.DependsOn = append(o.DependsOn, deps...)
 	}

--- a/internal/configs/resource.go
+++ b/internal/configs/resource.go
@@ -160,7 +160,7 @@ func decodeResourceBlock(block *hcl.Block, override bool) (*Resource, hcl.Diagno
 	}
 
 	if attr, exists := content.Attributes["depends_on"]; exists {
-		deps, depsDiags := decodeDependsOn(attr)
+		deps, depsDiags := DecodeDependsOn(attr)
 		diags = append(diags, depsDiags...)
 		r.DependsOn = append(r.DependsOn, deps...)
 	}
@@ -429,7 +429,7 @@ func decodeDataBlock(block *hcl.Block, override, nested bool) (*Resource, hcl.Di
 	}
 
 	if attr, exists := content.Attributes["depends_on"]; exists {
-		deps, depsDiags := decodeDependsOn(attr)
+		deps, depsDiags := DecodeDependsOn(attr)
 		diags = append(diags, depsDiags...)
 		r.DependsOn = append(r.DependsOn, deps...)
 	}

--- a/internal/configs/test_file.go
+++ b/internal/configs/test_file.go
@@ -601,7 +601,7 @@ func decodeTestRunBlock(block *hcl.Block) (*TestRun, hcl.Diagnostics) {
 	}
 
 	if attr, exists := content.Attributes["expect_failures"]; exists {
-		failures, failDiags := decodeDependsOn(attr)
+		failures, failDiags := DecodeDependsOn(attr)
 		diags = append(diags, failDiags...)
 		r.ExpectFailures = failures
 	}
@@ -749,13 +749,13 @@ func decodeTestRunOptionsBlock(block *hcl.Block) (*TestRunOptions, hcl.Diagnosti
 	}
 
 	if attr, exists := content.Attributes["replace"]; exists {
-		reps, repsDiags := decodeDependsOn(attr)
+		reps, repsDiags := DecodeDependsOn(attr)
 		diags = append(diags, repsDiags...)
 		opts.Replace = reps
 	}
 
 	if attr, exists := content.Attributes["target"]; exists {
-		tars, tarsDiags := decodeDependsOn(attr)
+		tars, tarsDiags := DecodeDependsOn(attr)
 		diags = append(diags, tarsDiags...)
 		opts.Target = tars
 	}

--- a/internal/stacks/stackconfig/embedded_stack.go
+++ b/internal/stacks/stackconfig/embedded_stack.go
@@ -8,6 +8,8 @@ import (
 	"github.com/hashicorp/go-slug/sourceaddrs"
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
+
+	"github.com/hashicorp/terraform/internal/configs"
 	"github.com/hashicorp/terraform/internal/tfdiags"
 )
 
@@ -37,6 +39,8 @@ type EmbeddedStack struct {
 	// declarations, and whose attribute values will then be used to populate
 	// those input variables.
 	Inputs hcl.Expression
+
+	DependsOn []hcl.Traversal
 
 	DeclRange tfdiags.SourceRange
 }
@@ -87,6 +91,10 @@ func decodeEmbeddedStackBlock(block *hcl.Block) (*EmbeddedStack, tfdiags.Diagnos
 	if attr, ok := content.Attributes["inputs"]; ok {
 		ret.Inputs = attr.Expr
 	}
+	if attr, ok := content.Attributes["depends_on"]; ok {
+		ret.DependsOn, hclDiags = configs.DecodeDependsOn(attr)
+		diags = diags.Append(hclDiags)
+	}
 
 	return ret, diags
 }
@@ -97,5 +105,6 @@ var embeddedStackBlockSchema = &hcl.BodySchema{
 		{Name: "version", Required: false},
 		{Name: "for_each", Required: false},
 		{Name: "inputs", Required: false},
+		{Name: "depends_on", Required: false},
 	},
 }

--- a/internal/stacks/stackruntime/apply_test.go
+++ b/internal/stacks/stackruntime/apply_test.go
@@ -2539,6 +2539,103 @@ func TestApplyEphemeralInputWithDefault(t *testing.T) {
 	}
 }
 
+func TestApply_DependsOnComponentWithNoInstances(t *testing.T) {
+	ctx := context.Background()
+	cfg := loadMainBundleConfigForTest(t, path.Join("with-single-input", "depends-on"))
+
+	fakePlanTimestamp, err := time.Parse(time.RFC3339, "1991-08-25T20:57:08Z")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	lock := depsfile.NewLocks()
+	lock.SetProvider(
+		addrs.NewDefaultProvider("testing"),
+		providerreqs.MustParseVersion("0.0.0"),
+		providerreqs.MustParseVersionConstraints("=0.0.0"),
+		providerreqs.PreferredHashes([]providerreqs.Hash{}),
+	)
+
+	changesCh := make(chan stackplan.PlannedChange)
+	diagsCh := make(chan tfdiags.Diagnostic)
+	planRequest := PlanRequest{
+		Config: cfg,
+		ProviderFactories: map[addrs.Provider]providers.Factory{
+			addrs.NewDefaultProvider("testing"): func() (providers.Interface, error) {
+				return stacks_testing_provider.NewProvider(), nil
+			},
+		},
+		DependencyLocks:    *lock,
+		ForcePlanTimestamp: &fakePlanTimestamp,
+		InputValues: map[stackaddrs.InputVariable]ExternalInputValue{
+			{Name: "input"}: {
+				Value: cty.StringVal("hello, world!"),
+			},
+		},
+	}
+
+	planResponse := PlanResponse{
+		PlannedChanges: changesCh,
+		Diagnostics:    diagsCh,
+	}
+
+	go Plan(ctx, &planRequest, &planResponse)
+	planChanges, planDiags := collectPlanOutput(changesCh, diagsCh)
+
+	reportDiagnosticsForTest(t, planDiags)
+	if len(planDiags) != 0 {
+		t.FailNow()
+	}
+
+	planLoader := stackplan.NewLoader()
+	for _, change := range planChanges {
+		proto, err := change.PlannedChangeProto()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		for _, rawMsg := range proto.Raw {
+			err = planLoader.AddRaw(rawMsg)
+			if err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+	plan, err := planLoader.Plan()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	applyReq := ApplyRequest{
+		Config: cfg,
+		Plan:   plan,
+		ProviderFactories: map[addrs.Provider]providers.Factory{
+			addrs.NewDefaultProvider("testing"): func() (providers.Interface, error) {
+				return stacks_testing_provider.NewProvider(), nil
+			},
+		},
+		DependencyLocks: *lock,
+	}
+
+	applyChangesCh := make(chan stackstate.AppliedChange)
+	diagsCh = make(chan tfdiags.Diagnostic)
+
+	applyResp := ApplyResponse{
+		AppliedChanges: applyChangesCh,
+		Diagnostics:    diagsCh,
+	}
+
+	go Apply(ctx, &applyReq, &applyResp)
+	_, applyDiags := collectApplyOutput(applyChangesCh, diagsCh)
+	reportDiagnosticsForTest(t, applyDiags)
+	if len(applyDiags) != 0 {
+		t.FailNow()
+	}
+
+	// don't care about the changes - just want to make sure that depends_on
+	// reference to a component with zero instances doesn't break anything
+}
+
 func collectApplyOutput(changesCh <-chan stackstate.AppliedChange, diagsCh <-chan tfdiags.Diagnostic) ([]stackstate.AppliedChange, tfdiags.Diagnostics) {
 	var changes []stackstate.AppliedChange
 	var diags tfdiags.Diagnostics

--- a/internal/stacks/stackruntime/internal/stackeval/component.go
+++ b/internal/stacks/stackruntime/internal/stackeval/component.go
@@ -332,6 +332,7 @@ func (c *Component) References(ctx context.Context) []stackaddrs.AbsReference {
 	for _, expr := range cfg.ProviderConfigs {
 		ret = append(ret, ReferencesInExpr(ctx, expr)...)
 	}
+	ret = append(ret, referencesInTraversals(ctx, cfg.DependsOn)...)
 	return makeReferencesAbsolute(ret, c.Addr().Stack)
 }
 

--- a/internal/stacks/stackruntime/internal/stackeval/component_config.go
+++ b/internal/stacks/stackruntime/internal/stackeval/component_config.go
@@ -505,8 +505,13 @@ func (c *ComponentConfig) checkValid(ctx context.Context, phase EvalPhase) tfdia
 
 		variableDiags := c.CheckInputVariableValues(ctx, phase)
 		diags = diags.Append(variableDiags)
-		// We don't actually exit if we found errors with the input variables,
-		// we can still validate the actual module tree without them.
+
+		dependsOnDiags := ValidateDependsOn(ctx, c.StackConfig(ctx), c.config.DependsOn)
+		diags = diags.Append(dependsOnDiags)
+
+		// We don't actually exit if we found errors with the input variables
+		// or depends_on attribute, we can still validate the actual module tree
+		// without them.
 
 		_, providerDiags := c.CheckProviders(ctx, phase)
 		diags = diags.Append(providerDiags)

--- a/internal/stacks/stackruntime/internal/stackeval/stack_call.go
+++ b/internal/stacks/stackruntime/internal/stackeval/stack_call.go
@@ -273,6 +273,7 @@ func (c *StackCall) References(ctx context.Context) []stackaddrs.AbsReference {
 	var ret []stackaddrs.Reference
 	ret = append(ret, ReferencesInExpr(ctx, cfg.ForEach)...)
 	ret = append(ret, ReferencesInExpr(ctx, cfg.Inputs)...)
+	ret = append(ret, referencesInTraversals(ctx, cfg.DependsOn)...)
 	return makeReferencesAbsolute(ret, c.Addr().Stack)
 }
 

--- a/internal/stacks/stackruntime/internal/stackeval/stack_call_config.go
+++ b/internal/stacks/stackruntime/internal/stackeval/stack_call_config.go
@@ -354,6 +354,8 @@ func (s *StackCallConfig) checkValid(ctx context.Context, phase EvalPhase) tfdia
 	diags = diags.Append(moreDiags)
 	_, moreDiags = s.ValidateResultValue(ctx, phase)
 	diags = diags.Append(moreDiags)
+	moreDiags = ValidateDependsOn(ctx, s.CallerConfig(ctx), s.config.DependsOn)
+	diags = diags.Append(moreDiags)
 	return diags
 }
 

--- a/internal/stacks/stackruntime/testdata/mainbundle/test/with-single-input/depends-on-invalid/depends-on-invalid.tfstack.hcl
+++ b/internal/stacks/stackruntime/testdata/mainbundle/test/with-single-input/depends-on-invalid/depends-on-invalid.tfstack.hcl
@@ -1,0 +1,53 @@
+required_providers {
+  testing = {
+    source  = "hashicorp/testing"
+    version = "0.1.0"
+  }
+}
+
+provider "testing" "default" {}
+
+variable "input" {
+  type = string
+}
+
+stack "first" {
+  source = "../valid"
+
+  inputs = {
+    input = var.input
+  }
+
+  # nu-uh, this isn't valid.
+  depends_on = [var.input, component.missing]
+}
+
+component "first" {
+  source = "../"
+
+  providers = {
+    testing = provider.testing.default
+  }
+
+  inputs = {
+    input = var.input
+  }
+
+  # nu-uh, this isn't valid.
+  depends_on = [var.input, stack.missing]
+}
+
+component "second" {
+  source = "../"
+
+  providers = {
+    testing = provider.testing.default
+  }
+
+  inputs = {
+    input = var.input
+  }
+
+  # nu-uh, this isn't valid.
+  depends_on = [component.first[1]]
+}

--- a/internal/stacks/stackruntime/testdata/mainbundle/test/with-single-input/depends-on/depends-on.tfstack.hcl
+++ b/internal/stacks/stackruntime/testdata/mainbundle/test/with-single-input/depends-on/depends-on.tfstack.hcl
@@ -1,0 +1,77 @@
+required_providers {
+  testing = {
+    source  = "hashicorp/testing"
+    version = "0.1.0"
+  }
+}
+
+provider "testing" "default" {}
+
+variable "input" {
+  type = string
+}
+
+variable "empty" {
+  type    = set(string)
+  default = []
+}
+
+component "empty" {
+  source = "../"
+
+  // This is a test to validate what happens when depending on a
+  // component that dynamically has no instances.
+  for_each = var.empty
+
+  providers = {
+      testing = provider.testing.default
+  }
+
+  inputs = {
+      input = var.input
+  }
+}
+
+component "first" {
+  source = "../"
+
+  providers = {
+    testing = provider.testing.default
+  }
+
+  inputs = {
+    input = var.input
+  }
+}
+
+component "second" {
+  source = "../"
+
+  providers = {
+    testing = provider.testing.default
+  }
+
+  inputs = {
+    input = var.input
+  }
+
+  depends_on = [component.first, stack.second]
+}
+
+stack "first" {
+  source = "../valid"
+
+  inputs = {
+    input = var.input
+  }
+
+  depends_on = [component.first, component.empty]
+}
+
+stack "second" {
+  source = "../valid"
+
+  inputs = {
+    input = var.input
+  }
+}


### PR DESCRIPTION
This PR adds `depends_on` attributes to the `component` and `stack` blocks within `.tfstack.hcl` files.

Components actually depend on other components, so a component depending on an embedded stack is actually just adding dependencies against all the components within the embedded stack. This was actually missing from the current implementation for other references. For example a normal reference to the output of an embedded stack should result in a dependency to the component within the embedded stack that generated that output. This was not happening. I fixed this, with the change to the `requiredComponentsForReferrer`. This fix accounts for the additional changes you can see in some of the other unrelated tests.

With the above bug fixed, connecting the new dependencies to the dependency graph is straight forward - we need to add them to the relevant `References` function. You can see this change in the `component.go` and `stack_call.go` files. The current implementation of the dependency graph in Stacks does not consider instances at all, so our implementation of depends on reflects this. Basically, you have to refer to something like `component.self` entirely, rather than any potential individual instances eg. `component.self[0]`, `component.self[1]`, etc.

In addition, we want to validate the new references. The depends on attribute can only refer to components or embedded stacks, and we want to make sure the references exist. A new function was added, `ValidateDependsOn`, which is shared by the validate calls of both `stack_call_config.go` and `component_config.go`.

Finally, I added new tests to the validate, plan, and apply operations to make sure everything is being connected properly.