### PR TITLE
stacks: sort diags in test before comparison

### DIFF
--- a/internal/stacks/stackruntime/plan_test.go
+++ b/internal/stacks/stackruntime/plan_test.go
@@ -3350,9 +3350,10 @@ func TestPlanInvalidProvidersFailGracefully(t *testing.T) {
 	go Plan(ctx, &req, &resp)
 	changes, diags := collectPlanOutput(changesCh, diagsCh)
 
+	sort.SliceStable(diags, diagnosticSortFunc(diags))
 	expectDiagnosticsForTest(t, diags,
-		expectDiagnostic(tfdiags.Error, "invalid configuration", "configure_error attribute was set"),
-		expectDiagnostic(tfdiags.Error, "Provider configuration is invalid", "Cannot plan changes for this resource because its associated provider configuration is invalid."))
+		expectDiagnostic(tfdiags.Error, "Provider configuration is invalid", "Cannot plan changes for this resource because its associated provider configuration is invalid."),
+		expectDiagnostic(tfdiags.Error, "invalid configuration", "configure_error attribute was set"))
 
 	sort.SliceStable(changes, func(i, j int) bool {
 		return plannedChangeSortKey(changes[i]) < plannedChangeSortKey(changes[j])


### PR DESCRIPTION
This fixes flaky tests by making sure the diagnostics are in a consistent order before we compare them. In all cases here, the order of the diags doesn't matter to us, just that the right ones were included.