### PR TITLE
allow slashes in git url parameters

### DIFF
--- a/internal/command/hook_module_install.go
+++ b/internal/command/hook_module_install.go
@@ -42,7 +42,9 @@ func (h uiModuleInstallHooks) Install(modulePath string, v *version.Version, loc
 func (h uiModuleInstallHooks) log(message string) {
 	switch h.View.(type) {
 	case view:
-		h.View.Log(message)
+		// there is no unformatted option for the View interface, so we need to
+		// pass message as a parameter to avoid double escaping % characters
+		h.View.Log("%s", message)
 	default:
 		h.Ui.Info(message)
 	}

--- a/internal/getmodules/moduleaddrs/detect_git.go
+++ b/internal/getmodules/moduleaddrs/detect_git.go
@@ -40,6 +40,8 @@ func detectGitHub(src string) (string, bool, error) {
 	}
 
 	if strings.HasPrefix(src, "github.com/") {
+		src, rawQuery, _ := strings.Cut(src, "?")
+
 		parts := strings.Split(src, "/")
 		if len(parts) < 3 {
 			return "", false, fmt.Errorf(
@@ -51,6 +53,7 @@ func detectGitHub(src string) (string, bool, error) {
 		if err != nil {
 			return "", true, fmt.Errorf("error parsing GitHub URL: %s", err)
 		}
+		url.RawQuery = rawQuery
 
 		if !strings.HasSuffix(url.Path, ".git") {
 			url.Path += ".git"

--- a/internal/getmodules/moduleaddrs/detect_git_test.go
+++ b/internal/getmodules/moduleaddrs/detect_git_test.go
@@ -74,6 +74,10 @@ func TestDetectGitHub(t *testing.T) {
 			"github.com/hashicorp/foo.git?foo=bar",
 			"git::https://github.com/hashicorp/foo.git?foo=bar",
 		},
+		{
+			"github.com/hashicorp/foo.git?foo=bar/baz",
+			"git::https://github.com/hashicorp/foo.git?foo=bar/baz",
+		},
 	})
 }
 


### PR DESCRIPTION
Git URL refs often contain slashes, and while it's technically not correct to have unencoded slashes in the query, they were being split off and incorrectly appended to the path as a go-getter subdir. (This was likely part of the PR which pulled a lot of the behavior into the Terraform repo #34847) The behavior was definitely incorrect, and since Terraform apparently accepted unencoded slashes in query parameters in the past, we can just restore the prior behavior rather than rejecting unencoded slashes entirely.

Fixes #34554
