### PR TITLE
core: move change encoding outside of core

### DIFF
--- a/internal/backend/local/backend_local_test.go
+++ b/internal/backend/local/backend_local_test.go
@@ -159,7 +159,7 @@ func TestLocalRun_stalePlan(t *testing.T) {
 	}
 	plan := &plans.Plan{
 		UIMode:  plans.NormalMode,
-		Changes: plans.NewChanges(),
+		Changes: plans.NewChangesSrc(),
 		Backend: plans.Backend{
 			Type:   "local",
 			Config: backendConfigRaw,

--- a/internal/builtin/providers/terraform/provider.go
+++ b/internal/builtin/providers/terraform/provider.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/zclconf/go-cty/cty"
 
+	tfaddr "github.com/hashicorp/terraform-registry-address"
 	"github.com/hashicorp/terraform/internal/providers"
 )
 
@@ -22,7 +23,7 @@ func NewProvider() providers.Interface {
 
 // GetSchema returns the complete schema for the provider.
 func (p *Provider) GetProviderSchema() providers.GetProviderSchemaResponse {
-	return providers.GetProviderSchemaResponse{
+	resp := providers.GetProviderSchemaResponse{
 		ServerCapabilities: providers.ServerCapabilities{
 			MoveResourceState: true,
 		},
@@ -70,6 +71,8 @@ func (p *Provider) GetProviderSchema() providers.GetProviderSchemaResponse {
 			},
 		},
 	}
+	providers.SchemaCache.Set(tfaddr.NewProvider(tfaddr.BuiltInProviderHost, tfaddr.BuiltInProviderNamespace, "terraform"), resp)
+	return resp
 }
 
 // ValidateProviderConfig is used to validate the configuration values.

--- a/internal/command/apply_test.go
+++ b/internal/command/apply_test.go
@@ -818,7 +818,7 @@ func TestApply_plan_remoteState(t *testing.T) {
 			Type:   "http",
 			Config: backendConfigRaw,
 		},
-		Changes: plans.NewChanges(),
+		Changes: plans.NewChangesSrc(),
 	})
 
 	p := testProvider()
@@ -2211,7 +2211,7 @@ func applyFixturePlanFileMatchState(t *testing.T, stateMeta statemgr.SnapshotMet
 		t.Fatal(err)
 	}
 	plan := testPlan(t)
-	plan.Changes.SyncWrapper().AppendResourceInstanceChange(&plans.ResourceInstanceChangeSrc{
+	plan.Changes.AppendResourceInstanceChange(&plans.ResourceInstanceChangeSrc{
 		Addr: addrs.Resource{
 			Mode: addrs.ManagedResourceMode,
 			Type: "test_instance",

--- a/internal/command/command_test.go
+++ b/internal/command/command_test.go
@@ -195,7 +195,7 @@ func testPlan(t *testing.T) *plans.Plan {
 			Type:   "local",
 			Config: backendConfigRaw,
 		},
-		Changes: plans.NewChanges(),
+		Changes: plans.NewChangesSrc(),
 
 		// We'll default to the fake plan being both applyable and complete,
 		// since that's what most tests expect. Tests can override these

--- a/internal/command/graph.go
+++ b/internal/command/graph.go
@@ -154,7 +154,7 @@ func (c *GraphCommand) Run(args []string) int {
 		// here, though perhaps one day this should be an error.
 		if lr.Plan == nil {
 			plan = &plans.Plan{
-				Changes:      plans.NewChanges(),
+				Changes:      &plans.ChangesSrc{}, //plans.NewChanges(),
 				UIMode:       plans.NormalMode,
 				PriorState:   lr.InputState,
 				PrevRunState: lr.InputState,

--- a/internal/command/graph_test.go
+++ b/internal/command/graph_test.go
@@ -176,8 +176,18 @@ digraph G {
 func TestGraph_applyPhaseSavedPlan(t *testing.T) {
 	testCwd(t)
 
+	emptyObj, err := plans.NewDynamicValue(cty.EmptyObjectVal, cty.EmptyObject)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	nullEmptyObj, err := plans.NewDynamicValue(cty.NullVal((cty.EmptyObject)), cty.EmptyObject)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	plan := &plans.Plan{
-		Changes: plans.NewChanges(),
+		Changes: plans.NewChangesSrc(),
 	}
 	plan.Changes.Resources = append(plan.Changes.Resources, &plans.ResourceInstanceChangeSrc{
 		Addr: addrs.Resource{
@@ -187,24 +197,21 @@ func TestGraph_applyPhaseSavedPlan(t *testing.T) {
 		}.Instance(addrs.NoKey).Absolute(addrs.RootModuleInstance),
 		ChangeSrc: plans.ChangeSrc{
 			Action: plans.Delete,
-			Before: plans.DynamicValue(`{}`),
-			After:  plans.DynamicValue(`null`),
+			Before: emptyObj,
+			After:  nullEmptyObj,
 		},
 		ProviderAddr: addrs.AbsProviderConfig{
 			Provider: addrs.NewDefaultProvider("test"),
 			Module:   addrs.RootModule,
 		},
 	})
-	emptyConfig, err := plans.NewDynamicValue(cty.EmptyObjectVal, cty.EmptyObject)
-	if err != nil {
-		t.Fatal(err)
-	}
+
 	plan.Backend = plans.Backend{
 		// Doesn't actually matter since we aren't going to activate the backend
 		// for this command anyway, but we need something here for the plan
 		// file writer to succeed.
 		Type:   "placeholder",
-		Config: emptyConfig,
+		Config: emptyObj,
 	}
 	_, configSnap := testModuleWithSnapshot(t, "graph")
 

--- a/internal/command/jsonformat/plan_test.go
+++ b/internal/command/jsonformat/plan_test.go
@@ -7179,7 +7179,7 @@ func TestOutputChanges(t *testing.T) {
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			changes := &plans.Changes{
+			changes := &plans.ChangesSrc{
 				Outputs: tc.changes,
 			}
 

--- a/internal/command/jsonplan/plan.go
+++ b/internal/command/jsonplan/plan.go
@@ -640,7 +640,7 @@ func MarshalDeferredResourceChanges(resources []*plans.DeferredResourceInstanceC
 // This function is referenced directly from the structured renderer tests, to
 // ensure parity between the renderers. It probably shouldn't be used anywhere
 // else.
-func MarshalOutputChanges(changes *plans.Changes) (map[string]Change, error) {
+func MarshalOutputChanges(changes *plans.ChangesSrc) (map[string]Change, error) {
 	if changes == nil {
 		// Nothing to do!
 		return nil, nil
@@ -730,7 +730,7 @@ func MarshalOutputChanges(changes *plans.Changes) (map[string]Change, error) {
 	return outputChanges, nil
 }
 
-func (p *plan) marshalPlannedValues(changes *plans.Changes, schemas *terraform.Schemas) error {
+func (p *plan) marshalPlannedValues(changes *plans.ChangesSrc, schemas *terraform.Schemas) error {
 	// marshal the planned changes into a module
 	plan, err := marshalPlannedValues(changes, schemas)
 	if err != nil {

--- a/internal/command/jsonplan/plan_test.go
+++ b/internal/command/jsonplan/plan_test.go
@@ -333,11 +333,11 @@ func TestOutputs(t *testing.T) {
 	}
 
 	tests := map[string]struct {
-		changes  *plans.Changes
+		changes  *plans.ChangesSrc
 		expected map[string]Change
 	}{
 		"copies all outputs": {
-			changes: &plans.Changes{
+			changes: &plans.ChangesSrc{
 				Outputs: []*plans.OutputChangeSrc{
 					{
 						Addr: root.OutputValue("first"),
@@ -373,7 +373,7 @@ func TestOutputs(t *testing.T) {
 			},
 		},
 		"skips non root modules": {
-			changes: &plans.Changes{
+			changes: &plans.ChangesSrc{
 				Outputs: []*plans.OutputChangeSrc{
 					{
 						Addr: root.OutputValue("first"),

--- a/internal/command/jsonplan/values.go
+++ b/internal/command/jsonplan/values.go
@@ -47,7 +47,7 @@ func marshalAttributeValues(value cty.Value, schema *configschema.Block) attribu
 
 // marshalPlannedOutputs takes a list of changes and returns a map of output
 // values
-func marshalPlannedOutputs(changes *plans.Changes) (map[string]output, error) {
+func marshalPlannedOutputs(changes *plans.ChangesSrc) (map[string]output, error) {
 	if changes.Outputs == nil {
 		// No changes - we're done here!
 		return nil, nil
@@ -93,7 +93,7 @@ func marshalPlannedOutputs(changes *plans.Changes) (map[string]output, error) {
 
 }
 
-func marshalPlannedValues(changes *plans.Changes, schemas *terraform.Schemas) (module, error) {
+func marshalPlannedValues(changes *plans.ChangesSrc, schemas *terraform.Schemas) (module, error) {
 	var ret module
 
 	// build two maps:
@@ -166,7 +166,7 @@ func marshalPlannedValues(changes *plans.Changes, schemas *terraform.Schemas) (m
 }
 
 // marshalPlanResources
-func marshalPlanResources(changes *plans.Changes, ris []addrs.AbsResourceInstance, schemas *terraform.Schemas) ([]resource, error) {
+func marshalPlanResources(changes *plans.ChangesSrc, ris []addrs.AbsResourceInstance, schemas *terraform.Schemas) ([]resource, error) {
 	var ret []resource
 
 	for _, ri := range ris {
@@ -247,7 +247,7 @@ func marshalPlanResources(changes *plans.Changes, ris []addrs.AbsResourceInstanc
 // marshalPlanModules iterates over a list of modules to recursively describe
 // the full module tree.
 func marshalPlanModules(
-	changes *plans.Changes,
+	changes *plans.ChangesSrc,
 	schemas *terraform.Schemas,
 	childModules []addrs.ModuleInstance,
 	moduleMap map[string][]addrs.ModuleInstance,

--- a/internal/command/jsonplan/values_test.go
+++ b/internal/command/jsonplan/values_test.go
@@ -117,17 +117,17 @@ func TestMarshalPlannedOutputs(t *testing.T) {
 	after, _ := plans.NewDynamicValue(cty.StringVal("after"), cty.DynamicPseudoType)
 
 	tests := []struct {
-		Changes *plans.Changes
+		Changes *plans.ChangesSrc
 		Want    map[string]output
 		Err     bool
 	}{
 		{
-			&plans.Changes{},
+			&plans.ChangesSrc{},
 			nil,
 			false,
 		},
 		{
-			&plans.Changes{
+			&plans.ChangesSrc{
 				Outputs: []*plans.OutputChangeSrc{
 					{
 						Addr: addrs.OutputValue{Name: "bar"}.Absolute(addrs.RootModuleInstance),
@@ -149,7 +149,7 @@ func TestMarshalPlannedOutputs(t *testing.T) {
 			false,
 		},
 		{ // Delete action
-			&plans.Changes{
+			&plans.ChangesSrc{
 				Outputs: []*plans.OutputChangeSrc{
 					{
 						Addr: addrs.OutputValue{Name: "bar"}.Absolute(addrs.RootModuleInstance),
@@ -270,7 +270,7 @@ func TestMarshalPlanResources(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			testChange := &plans.Changes{
+			testChange := &plans.ChangesSrc{
 				Resources: []*plans.ResourceInstanceChangeSrc{
 					{
 						Addr: addrs.Resource{
@@ -316,7 +316,7 @@ func TestMarshalPlanValuesNoopDeposed(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	testChange := &plans.Changes{
+	testChange := &plans.ChangesSrc{
 		Resources: []*plans.ResourceInstanceChangeSrc{
 			{
 				Addr: addrs.Resource{

--- a/internal/command/show_test.go
+++ b/internal/command/show_test.go
@@ -377,7 +377,7 @@ func TestShow_planWithForceReplaceChange(t *testing.T) {
 		t.Fatal(err)
 	}
 	plan := testPlan(t)
-	plan.Changes.SyncWrapper().AppendResourceInstanceChange(&plans.ResourceInstanceChangeSrc{
+	plan.Changes.AppendResourceInstanceChange(&plans.ResourceInstanceChangeSrc{
 		Addr: addrs.Resource{
 			Mode: addrs.ManagedResourceMode,
 			Type: "test_instance",
@@ -1179,7 +1179,7 @@ func showFixturePlanFile(t *testing.T, action plans.Action) string {
 		t.Fatal(err)
 	}
 	plan := testPlan(t)
-	plan.Changes.SyncWrapper().AppendResourceInstanceChange(&plans.ResourceInstanceChangeSrc{
+	plan.Changes.AppendResourceInstanceChange(&plans.ResourceInstanceChangeSrc{
 		Addr: addrs.Resource{
 			Mode: addrs.ManagedResourceMode,
 			Type: "test_instance",

--- a/internal/command/views/operation_test.go
+++ b/internal/command/views/operation_test.go
@@ -88,7 +88,7 @@ func TestOperation_planNoChanges(t *testing.T) {
 			func(schemas *terraform.Schemas) *plans.Plan {
 				return &plans.Plan{
 					UIMode:  plans.NormalMode,
-					Changes: plans.NewChanges(),
+					Changes: plans.NewChangesSrc(),
 				}
 			},
 			"no differences, so no changes are needed.",
@@ -97,7 +97,7 @@ func TestOperation_planNoChanges(t *testing.T) {
 			func(schemas *terraform.Schemas) *plans.Plan {
 				return &plans.Plan{
 					UIMode:  plans.RefreshOnlyMode,
-					Changes: plans.NewChanges(),
+					Changes: plans.NewChangesSrc(),
 				}
 			},
 			"Terraform has checked that the real remote objects still match",
@@ -106,7 +106,7 @@ func TestOperation_planNoChanges(t *testing.T) {
 			func(schemas *terraform.Schemas) *plans.Plan {
 				return &plans.Plan{
 					UIMode:  plans.DestroyMode,
-					Changes: plans.NewChanges(),
+					Changes: plans.NewChangesSrc(),
 				}
 			},
 			"No objects need to be destroyed.",
@@ -146,7 +146,7 @@ func TestOperation_planNoChanges(t *testing.T) {
 				drs := []*plans.ResourceInstanceChangeSrc{rcs}
 				return &plans.Plan{
 					UIMode:           plans.NormalMode,
-					Changes:          plans.NewChanges(),
+					Changes:          plans.NewChangesSrc(),
 					DriftedResources: drs,
 				}
 			},
@@ -185,7 +185,7 @@ func TestOperation_planNoChanges(t *testing.T) {
 					panic(err)
 				}
 				drs := []*plans.ResourceInstanceChangeSrc{rcs}
-				changes := plans.NewChanges()
+				changes := plans.NewChangesSrc()
 				changes.Resources = drs
 				return &plans.Plan{
 					UIMode:           plans.NormalMode,
@@ -234,7 +234,7 @@ func TestOperation_planNoChanges(t *testing.T) {
 				drs := []*plans.ResourceInstanceChangeSrc{rcs}
 				return &plans.Plan{
 					UIMode:           plans.RefreshOnlyMode,
-					Changes:          plans.NewChanges(),
+					Changes:          plans.NewChangesSrc(),
 					DriftedResources: drs,
 				}
 			},
@@ -283,7 +283,7 @@ func TestOperation_planNoChanges(t *testing.T) {
 				drs := []*plans.ResourceInstanceChangeSrc{rcs}
 				return &plans.Plan{
 					UIMode:           plans.RefreshOnlyMode,
-					Changes:          plans.NewChanges(),
+					Changes:          plans.NewChangesSrc(),
 					DriftedResources: drs,
 				}
 			},
@@ -293,7 +293,7 @@ func TestOperation_planNoChanges(t *testing.T) {
 			func(schemas *terraform.Schemas) *plans.Plan {
 				return &plans.Plan{
 					UIMode:  plans.DestroyMode,
-					Changes: plans.NewChanges(),
+					Changes: plans.NewChangesSrc(),
 					PrevRunState: states.BuildState(func(state *states.SyncState) {
 						state.SetResourceInstanceCurrent(
 							addrs.Resource{
@@ -563,7 +563,7 @@ func TestOperationJSON_planNoChanges(t *testing.T) {
 	v := &OperationJSON{view: NewJSONView(NewView(streams))}
 
 	plan := &plans.Plan{
-		Changes: plans.NewChanges(),
+		Changes: plans.NewChangesSrc(),
 	}
 	v.Plan(plan, nil)
 
@@ -600,7 +600,7 @@ func TestOperationJSON_plan(t *testing.T) {
 	derp := addrs.Resource{Mode: addrs.DataResourceMode, Type: "test_source", Name: "derp"}
 
 	plan := &plans.Plan{
-		Changes: &plans.Changes{
+		Changes: &plans.ChangesSrc{
 			Resources: []*plans.ResourceInstanceChangeSrc{
 				{
 					Addr:        boop.Instance(addrs.IntKey(0)).Absolute(root),
@@ -767,7 +767,7 @@ func TestOperationJSON_planWithImport(t *testing.T) {
 	beep := addrs.Resource{Mode: addrs.ManagedResourceMode, Type: "test_resource", Name: "beep"}
 
 	plan := &plans.Plan{
-		Changes: &plans.Changes{
+		Changes: &plans.ChangesSrc{
 			Resources: []*plans.ResourceInstanceChangeSrc{
 				{
 					Addr:        boop.Instance(addrs.IntKey(0)).Absolute(vpc),
@@ -913,7 +913,7 @@ func TestOperationJSON_planDriftWithMove(t *testing.T) {
 
 	plan := &plans.Plan{
 		UIMode: plans.NormalMode,
-		Changes: &plans.Changes{
+		Changes: &plans.ChangesSrc{
 			Resources: []*plans.ResourceInstanceChangeSrc{
 				{
 					Addr:        honk.Instance(addrs.StringKey("bonk")).Absolute(root),
@@ -1050,7 +1050,7 @@ func TestOperationJSON_planDriftWithMoveRefreshOnly(t *testing.T) {
 
 	plan := &plans.Plan{
 		UIMode: plans.RefreshOnlyMode,
-		Changes: &plans.Changes{
+		Changes: &plans.ChangesSrc{
 			Resources: []*plans.ResourceInstanceChangeSrc{},
 		},
 		DriftedResources: []*plans.ResourceInstanceChangeSrc{
@@ -1176,7 +1176,7 @@ func TestOperationJSON_planOutputChanges(t *testing.T) {
 	root := addrs.RootModuleInstance
 
 	plan := &plans.Plan{
-		Changes: &plans.Changes{
+		Changes: &plans.ChangesSrc{
 			Resources: []*plans.ResourceInstanceChangeSrc{},
 			Outputs: []*plans.OutputChangeSrc{
 				{

--- a/internal/command/views/plan_test.go
+++ b/internal/command/views/plan_test.go
@@ -67,14 +67,14 @@ func testPlan(t *testing.T) *plans.Plan {
 		t.Fatal(err)
 	}
 
-	changes := plans.NewChanges()
+	changes := plans.NewChangesSrc()
 	addr := addrs.Resource{
 		Mode: addrs.ManagedResourceMode,
 		Type: "test_resource",
 		Name: "foo",
 	}.Instance(addrs.NoKey).Absolute(addrs.RootModuleInstance)
 
-	changes.SyncWrapper().AppendResourceInstanceChange(&plans.ResourceInstanceChangeSrc{
+	changes.AppendResourceInstanceChange(&plans.ResourceInstanceChangeSrc{
 		Addr:        addr,
 		PrevRunAddr: addr,
 		ProviderAddr: addrs.AbsProviderConfig{
@@ -117,7 +117,7 @@ func testPlanWithDatasource(t *testing.T) *plans.Plan {
 		t.Fatal(err)
 	}
 
-	plan.Changes.SyncWrapper().AppendResourceInstanceChange(&plans.ResourceInstanceChangeSrc{
+	plan.Changes.AppendResourceInstanceChange(&plans.ResourceInstanceChangeSrc{
 		Addr:        addr,
 		PrevRunAddr: addr,
 		ProviderAddr: addrs.AbsProviderConfig{

--- a/internal/command/views/test_test.go
+++ b/internal/command/views/test_test.go
@@ -570,7 +570,7 @@ something bad happened during this test
 				},
 				Verbose: &moduletest.Verbose{
 					Plan: &plans.Plan{
-						Changes: &plans.Changes{
+						Changes: &plans.ChangesSrc{
 							Resources: []*plans.ResourceInstanceChangeSrc{
 								{
 									Addr: addrs.AbsResourceInstance{
@@ -2687,7 +2687,7 @@ func TestTestJSON_Run(t *testing.T) {
 				},
 				Verbose: &moduletest.Verbose{
 					Plan: &plans.Plan{
-						Changes: &plans.Changes{
+						Changes: &plans.ChangesSrc{
 							Resources: []*plans.ResourceInstanceChangeSrc{
 								{
 									Addr: addrs.AbsResourceInstance{

--- a/internal/configs/configload/testing.go
+++ b/internal/configs/configload/testing.go
@@ -20,7 +20,7 @@ import (
 // In the case of any errors, t.Fatal (or similar) will be called to halt
 // execution of the test, so the calling test does not need to handle errors
 // itself.
-func NewLoaderForTests(t *testing.T) (*Loader, func()) {
+func NewLoaderForTests(t testing.TB) (*Loader, func()) {
 	t.Helper()
 
 	modulesDir, err := ioutil.TempDir("", "tf-configs")

--- a/internal/moduletest/eval_context_test.go
+++ b/internal/moduletest/eval_context_test.go
@@ -63,7 +63,7 @@ func TestEvalContext_Evaluate(t *testing.T) {
 				`,
 			},
 			plan: &plans.Plan{
-				Changes: plans.NewChanges(),
+				Changes: plans.NewChangesSrc(),
 			},
 			state: states.BuildState(func(state *states.SyncState) {
 				state.SetResourceInstanceCurrent(
@@ -127,7 +127,7 @@ func TestEvalContext_Evaluate(t *testing.T) {
 				`,
 			},
 			plan: &plans.Plan{
-				Changes: plans.NewChanges(),
+				Changes: plans.NewChangesSrc(),
 			},
 			state: states.BuildState(func(state *states.SyncState) {
 				state.SetResourceInstanceCurrent(
@@ -188,7 +188,7 @@ func TestEvalContext_Evaluate(t *testing.T) {
 				`,
 			},
 			plan: &plans.Plan{
-				Changes: plans.NewChanges(),
+				Changes: plans.NewChangesSrc(),
 			},
 			state: states.BuildState(func(state *states.SyncState) {
 				state.SetResourceInstanceCurrent(
@@ -255,7 +255,7 @@ func TestEvalContext_Evaluate(t *testing.T) {
 				`,
 			},
 			plan: &plans.Plan{
-				Changes: plans.NewChanges(),
+				Changes: plans.NewChangesSrc(),
 			},
 			state: states.BuildState(func(state *states.SyncState) {
 				state.SetResourceInstanceCurrent(
@@ -326,7 +326,7 @@ func TestEvalContext_Evaluate(t *testing.T) {
 				`,
 			},
 			plan: &plans.Plan{
-				Changes: plans.NewChanges(),
+				Changes: plans.NewChangesSrc(),
 			},
 			state: states.NewState(),
 			variables: terraform.InputValues{
@@ -367,7 +367,7 @@ func TestEvalContext_Evaluate(t *testing.T) {
 				`,
 			},
 			plan: &plans.Plan{
-				Changes: plans.NewChanges(),
+				Changes: plans.NewChangesSrc(),
 			},
 			state: states.NewState(),
 			variables: terraform.InputValues{
@@ -431,7 +431,7 @@ func TestEvalContext_Evaluate(t *testing.T) {
 					})
 			}),
 			plan: &plans.Plan{
-				Changes: &plans.Changes{
+				Changes: &plans.ChangesSrc{
 					Resources: []*plans.ResourceInstanceChangeSrc{
 						{
 							Addr: addrs.Resource{
@@ -510,7 +510,7 @@ func TestEvalContext_Evaluate(t *testing.T) {
 					})
 			}),
 			plan: &plans.Plan{
-				Changes: &plans.Changes{
+				Changes: &plans.ChangesSrc{
 					Resources: []*plans.ResourceInstanceChangeSrc{
 						{
 							Addr: addrs.Resource{
@@ -577,7 +577,7 @@ func TestEvalContext_Evaluate(t *testing.T) {
 				`,
 			},
 			plan: &plans.Plan{
-				Changes: plans.NewChanges(),
+				Changes: plans.NewChangesSrc(),
 			},
 			state: states.BuildState(func(state *states.SyncState) {
 				state.SetResourceInstanceCurrent(
@@ -636,7 +636,7 @@ func TestEvalContext_Evaluate(t *testing.T) {
 				`,
 			},
 			plan: &plans.Plan{
-				Changes: plans.NewChanges(),
+				Changes: plans.NewChangesSrc(),
 			},
 			state:          states.NewState(),
 			provider:       &testing_provider.MockProvider{},
@@ -670,7 +670,7 @@ func TestEvalContext_Evaluate(t *testing.T) {
 					`,
 			},
 			plan: &plans.Plan{
-				Changes: plans.NewChanges(),
+				Changes: plans.NewChangesSrc(),
 			},
 			state: states.NewState(),
 			provider: &testing_provider.MockProvider{

--- a/internal/plans/changes.go
+++ b/internal/plans/changes.go
@@ -14,12 +14,12 @@ import (
 	"github.com/hashicorp/terraform/internal/tfdiags"
 )
 
-// Changes describes various actions that Terraform will attempt to take if
+// ChangesSrc describes various actions that Terraform will attempt to take if
 // the corresponding plan is applied.
 //
 // A Changes object can be rendered into a visual diff (by the caller, using
 // code in another package) for display to the user.
-type Changes struct {
+type ChangesSrc struct {
 	// Resources tracks planned changes to resource instance objects.
 	Resources []*ResourceInstanceChangeSrc
 
@@ -34,9 +34,49 @@ type Changes struct {
 	Outputs []*OutputChangeSrc
 }
 
+func (c *ChangesSrc) Empty() bool {
+	for _, res := range c.Resources {
+		if res.Action != NoOp || res.Moved() {
+			return false
+		}
+
+		if res.Importing != nil {
+			return false
+		}
+	}
+
+	for _, out := range c.Outputs {
+		if out.Addr.Module.IsRoot() && out.Action != NoOp {
+			return false
+		}
+	}
+
+	return true
+}
+
+// Changes describes various actions that Terraform will attempt to take if
+// the corresponding plan is applied.
+type Changes struct {
+	// Resources tracks planned changes to resource instance objects.
+	Resources []*ResourceInstanceChange
+
+	// Outputs tracks planned changes output values.
+	//
+	// Note that although an in-memory plan contains planned changes for
+	// outputs throughout the configuration, a plan serialized
+	// to disk retains only the root outputs because they are
+	// externally-visible, while other outputs are implementation details and
+	// can be easily re-calculated during the apply phase. Therefore only root
+	// module outputs will survive a round-trip through a plan file.
+	Outputs []*OutputChange
+}
+
 // NewChanges returns a valid Changes object that describes no changes.
 func NewChanges() *Changes {
 	return &Changes{}
+}
+func NewChangesSrc() *ChangesSrc {
+	return &ChangesSrc{}
 }
 
 func (c *Changes) Empty() bool {
@@ -62,7 +102,21 @@ func (c *Changes) Empty() bool {
 // ResourceInstance returns the planned change for the current object of the
 // resource instance of the given address, if any. Returns nil if no change is
 // planned.
-func (c *Changes) ResourceInstance(addr addrs.AbsResourceInstance) *ResourceInstanceChangeSrc {
+func (c *Changes) ResourceInstance(addr addrs.AbsResourceInstance) *ResourceInstanceChange {
+	for _, rc := range c.Resources {
+		if rc.Addr.Equal(addr) && rc.DeposedKey == states.NotDeposed {
+			return rc
+		}
+	}
+
+	return nil
+
+}
+
+// ResourceInstance returns the planned change for the current object of the
+// resource instance of the given address, if any. Returns nil if no change is
+// planned.
+func (c *ChangesSrc) ResourceInstance(addr addrs.AbsResourceInstance) *ResourceInstanceChangeSrc {
 	for _, rc := range c.Resources {
 		if rc.Addr.Equal(addr) && rc.DeposedKey == states.NotDeposed {
 			return rc
@@ -76,8 +130,8 @@ func (c *Changes) ResourceInstance(addr addrs.AbsResourceInstance) *ResourceInst
 // InstancesForAbsResource returns the planned change for the current objects
 // of the resource instances of the given address, if any. Returns nil if no
 // changes are planned.
-func (c *Changes) InstancesForAbsResource(addr addrs.AbsResource) []*ResourceInstanceChangeSrc {
-	var changes []*ResourceInstanceChangeSrc
+func (c *Changes) InstancesForAbsResource(addr addrs.AbsResource) []*ResourceInstanceChange {
+	var changes []*ResourceInstanceChange
 	for _, rc := range c.Resources {
 		resAddr := rc.Addr.ContainingResource()
 		if resAddr.Equal(addr) && rc.DeposedKey == states.NotDeposed {
@@ -91,8 +145,8 @@ func (c *Changes) InstancesForAbsResource(addr addrs.AbsResource) []*ResourceIns
 // InstancesForConfigResource returns the planned change for the current objects
 // of the resource instances of the given address, if any. Returns nil if no
 // changes are planned.
-func (c *Changes) InstancesForConfigResource(addr addrs.ConfigResource) []*ResourceInstanceChangeSrc {
-	var changes []*ResourceInstanceChangeSrc
+func (c *Changes) InstancesForConfigResource(addr addrs.ConfigResource) []*ResourceInstanceChange {
+	var changes []*ResourceInstanceChange
 	for _, rc := range c.Resources {
 		resAddr := rc.Addr.ContainingResource().Config()
 		if resAddr.Equal(addr) && rc.DeposedKey == states.NotDeposed {
@@ -106,7 +160,7 @@ func (c *Changes) InstancesForConfigResource(addr addrs.ConfigResource) []*Resou
 // ResourceInstanceDeposed returns the plan change of a deposed object of
 // the resource instance of the given address, if any. Returns nil if no change
 // is planned.
-func (c *Changes) ResourceInstanceDeposed(addr addrs.AbsResourceInstance, key states.DeposedKey) *ResourceInstanceChangeSrc {
+func (c *Changes) ResourceInstanceDeposed(addr addrs.AbsResourceInstance, key states.DeposedKey) *ResourceInstanceChange {
 	for _, rc := range c.Resources {
 		if rc.Addr.Equal(addr) && rc.DeposedKey == key {
 			return rc
@@ -119,7 +173,7 @@ func (c *Changes) ResourceInstanceDeposed(addr addrs.AbsResourceInstance, key st
 // OutputValue returns the planned change for the output value with the
 //
 //	given address, if any. Returns nil if no change is planned.
-func (c *Changes) OutputValue(addr addrs.AbsOutputValue) *OutputChangeSrc {
+func (c *Changes) OutputValue(addr addrs.AbsOutputValue) *OutputChange {
 	for _, oc := range c.Outputs {
 		if oc.Addr.Equal(addr) {
 			return oc
@@ -130,8 +184,8 @@ func (c *Changes) OutputValue(addr addrs.AbsOutputValue) *OutputChangeSrc {
 }
 
 // RootOutputValues returns planned changes for all outputs of the root module.
-func (c *Changes) RootOutputValues() []*OutputChangeSrc {
-	var res []*OutputChangeSrc
+func (c *Changes) RootOutputValues() []*OutputChange {
+	var res []*OutputChange
 
 	for _, oc := range c.Outputs {
 		// we can't evaluate root module outputs
@@ -149,8 +203,8 @@ func (c *Changes) RootOutputValues() []*OutputChangeSrc {
 // OutputValues returns planned changes for all outputs for all module
 // instances that reside in the parent path.  Returns nil if no changes are
 // planned.
-func (c *Changes) OutputValues(parent addrs.ModuleInstance, module addrs.ModuleCall) []*OutputChangeSrc {
-	var res []*OutputChangeSrc
+func (c *Changes) OutputValues(parent addrs.ModuleInstance, module addrs.ModuleCall) []*OutputChange {
+	var res []*OutputChange
 
 	for _, oc := range c.Outputs {
 		// we can't evaluate root module outputs
@@ -277,6 +331,15 @@ func (rc *ResourceInstanceChange) Encode(ty cty.Type) (*ResourceInstanceChangeSr
 		RequiredReplace: rc.RequiredReplace,
 		Private:         rc.Private,
 	}, err
+}
+
+func (rc *ResourceInstanceChange) DeepCopy() *ResourceInstanceChange {
+	if rc == nil {
+		return rc
+	}
+
+	ret := *rc
+	return &ret
 }
 
 func (rc *ResourceInstanceChange) Moved() bool {

--- a/internal/plans/changes.go
+++ b/internal/plans/changes.go
@@ -14,46 +14,6 @@ import (
 	"github.com/hashicorp/terraform/internal/tfdiags"
 )
 
-// ChangesSrc describes various actions that Terraform will attempt to take if
-// the corresponding plan is applied.
-//
-// A Changes object can be rendered into a visual diff (by the caller, using
-// code in another package) for display to the user.
-type ChangesSrc struct {
-	// Resources tracks planned changes to resource instance objects.
-	Resources []*ResourceInstanceChangeSrc
-
-	// Outputs tracks planned changes output values.
-	//
-	// Note that although an in-memory plan contains planned changes for
-	// outputs throughout the configuration, a plan serialized
-	// to disk retains only the root outputs because they are
-	// externally-visible, while other outputs are implementation details and
-	// can be easily re-calculated during the apply phase. Therefore only root
-	// module outputs will survive a round-trip through a plan file.
-	Outputs []*OutputChangeSrc
-}
-
-func (c *ChangesSrc) Empty() bool {
-	for _, res := range c.Resources {
-		if res.Action != NoOp || res.Moved() {
-			return false
-		}
-
-		if res.Importing != nil {
-			return false
-		}
-	}
-
-	for _, out := range c.Outputs {
-		if out.Addr.Module.IsRoot() && out.Action != NoOp {
-			return false
-		}
-	}
-
-	return true
-}
-
 // Changes describes various actions that Terraform will attempt to take if
 // the corresponding plan is applied.
 type Changes struct {
@@ -74,9 +34,6 @@ type Changes struct {
 // NewChanges returns a valid Changes object that describes no changes.
 func NewChanges() *Changes {
 	return &Changes{}
-}
-func NewChangesSrc() *ChangesSrc {
-	return &ChangesSrc{}
 }
 
 func (c *Changes) Empty() bool {
@@ -103,20 +60,6 @@ func (c *Changes) Empty() bool {
 // resource instance of the given address, if any. Returns nil if no change is
 // planned.
 func (c *Changes) ResourceInstance(addr addrs.AbsResourceInstance) *ResourceInstanceChange {
-	for _, rc := range c.Resources {
-		if rc.Addr.Equal(addr) && rc.DeposedKey == states.NotDeposed {
-			return rc
-		}
-	}
-
-	return nil
-
-}
-
-// ResourceInstance returns the planned change for the current object of the
-// resource instance of the given address, if any. Returns nil if no change is
-// planned.
-func (c *ChangesSrc) ResourceInstance(addr addrs.AbsResourceInstance) *ResourceInstanceChangeSrc {
 	for _, rc := range c.Resources {
 		if rc.Addr.Equal(addr) && rc.DeposedKey == states.NotDeposed {
 			return rc

--- a/internal/plans/changes_src.go
+++ b/internal/plans/changes_src.go
@@ -13,6 +13,89 @@ import (
 	"github.com/hashicorp/terraform/internal/states"
 )
 
+// ChangesSrc describes various actions that Terraform will attempt to take if
+// the corresponding plan is applied.
+//
+// A Changes object can be rendered into a visual diff (by the caller, using
+// code in another package) for display to the user.
+type ChangesSrc struct {
+	// Resources tracks planned changes to resource instance objects.
+	Resources []*ResourceInstanceChangeSrc
+
+	// Outputs tracks planned changes output values.
+	//
+	// Note that although an in-memory plan contains planned changes for
+	// outputs throughout the configuration, a plan serialized
+	// to disk retains only the root outputs because they are
+	// externally-visible, while other outputs are implementation details and
+	// can be easily re-calculated during the apply phase. Therefore only root
+	// module outputs will survive a round-trip through a plan file.
+	Outputs []*OutputChangeSrc
+}
+
+func NewChangesSrc() *ChangesSrc {
+	return &ChangesSrc{}
+}
+
+func (c *ChangesSrc) Empty() bool {
+	for _, res := range c.Resources {
+		if res.Action != NoOp || res.Moved() {
+			return false
+		}
+
+		if res.Importing != nil {
+			return false
+		}
+	}
+
+	for _, out := range c.Outputs {
+		if out.Addr.Module.IsRoot() && out.Action != NoOp {
+			return false
+		}
+	}
+
+	return true
+}
+
+// ResourceInstance returns the planned change for the current object of the
+// resource instance of the given address, if any. Returns nil if no change is
+// planned.
+func (c *ChangesSrc) ResourceInstance(addr addrs.AbsResourceInstance) *ResourceInstanceChangeSrc {
+	for _, rc := range c.Resources {
+		if rc.Addr.Equal(addr) && rc.DeposedKey == states.NotDeposed {
+			return rc
+		}
+	}
+
+	return nil
+}
+
+// ResourceInstanceDeposed returns the plan change of a deposed object of
+// the resource instance of the given address, if any. Returns nil if no change
+// is planned.
+func (c *ChangesSrc) ResourceInstanceDeposed(addr addrs.AbsResourceInstance, key states.DeposedKey) *ResourceInstanceChangeSrc {
+	for _, rc := range c.Resources {
+		if rc.Addr.Equal(addr) && rc.DeposedKey == key {
+			return rc
+		}
+	}
+
+	return nil
+}
+
+// OutputValue returns the planned change for the output value with the
+//
+//	given address, if any. Returns nil if no change is planned.
+func (c *ChangesSrc) OutputValue(addr addrs.AbsOutputValue) *OutputChangeSrc {
+	for _, oc := range c.Outputs {
+		if oc.Addr.Equal(addr) {
+			return oc
+		}
+	}
+
+	return nil
+}
+
 // ResourceInstanceChangeSrc is a not-yet-decoded ResourceInstanceChange.
 // Pass the associated resource type's schema type to method Decode to
 // obtain a ResourceInstanceChange.

--- a/internal/plans/changes_src.go
+++ b/internal/plans/changes_src.go
@@ -143,6 +143,17 @@ func (c *ChangesSrc) Decode(schemas *schemarepo.Schemas) (*Changes, error) {
 	return changes, nil
 }
 
+// AppendResourceInstanceChange records the given resource instance change in
+// the set of planned resource changes.
+func (c *ChangesSrc) AppendResourceInstanceChange(change *ResourceInstanceChangeSrc) {
+	if c == nil {
+		panic("AppendResourceInstanceChange on nil ChangesSync")
+	}
+
+	s := change.DeepCopy()
+	c.Resources = append(c.Resources, s)
+}
+
 // ResourceInstanceChangeSrc is a not-yet-decoded ResourceInstanceChange.
 // Pass the associated resource type's schema type to method Decode to
 // obtain a ResourceInstanceChange.

--- a/internal/plans/changes_sync.go
+++ b/internal/plans/changes_sync.go
@@ -28,7 +28,7 @@ type ChangesSync struct {
 // The caller must ensure that there are no concurrent writes to the given
 // change while this method is running, but it is safe to resume mutating
 // it after this method returns without affecting the saved change.
-func (cs *ChangesSync) AppendResourceInstanceChange(changeSrc *ResourceInstanceChangeSrc) {
+func (cs *ChangesSync) AppendResourceInstanceChange(changeSrc *ResourceInstanceChange) {
 	if cs == nil {
 		panic("AppendResourceInstanceChange on nil ChangesSync")
 	}
@@ -49,7 +49,7 @@ func (cs *ChangesSync) AppendResourceInstanceChange(changeSrc *ResourceInstanceC
 // The returned object is a deep copy of the change recorded in the plan, so
 // callers may mutate it although it's generally better (less confusing) to
 // treat planned changes as immutable after they've been initially constructed.
-func (cs *ChangesSync) GetResourceInstanceChange(addr addrs.AbsResourceInstance, dk addrs.DeposedKey) *ResourceInstanceChangeSrc {
+func (cs *ChangesSync) GetResourceInstanceChange(addr addrs.AbsResourceInstance, dk addrs.DeposedKey) *ResourceInstanceChange {
 	if cs == nil {
 		panic("GetResourceInstanceChange on nil ChangesSync")
 	}
@@ -72,13 +72,13 @@ func (cs *ChangesSync) GetResourceInstanceChange(addr addrs.AbsResourceInstance,
 // The returned objects are a deep copy of the change recorded in the plan, so
 // callers may mutate them although it's generally better (less confusing) to
 // treat planned changes as immutable after they've been initially constructed.
-func (cs *ChangesSync) GetChangesForConfigResource(addr addrs.ConfigResource) []*ResourceInstanceChangeSrc {
+func (cs *ChangesSync) GetChangesForConfigResource(addr addrs.ConfigResource) []*ResourceInstanceChange {
 	if cs == nil {
 		panic("GetChangesForConfigResource on nil ChangesSync")
 	}
 	cs.lock.Lock()
 	defer cs.lock.Unlock()
-	var changes []*ResourceInstanceChangeSrc
+	var changes []*ResourceInstanceChange
 	for _, c := range cs.changes.InstancesForConfigResource(addr) {
 		changes = append(changes, c.DeepCopy())
 	}
@@ -93,13 +93,13 @@ func (cs *ChangesSync) GetChangesForConfigResource(addr addrs.ConfigResource) []
 // The returned objects are a deep copy of the change recorded in the plan, so
 // callers may mutate them although it's generally better (less confusing) to
 // treat planned changes as immutable after they've been initially constructed.
-func (cs *ChangesSync) GetChangesForAbsResource(addr addrs.AbsResource) []*ResourceInstanceChangeSrc {
+func (cs *ChangesSync) GetChangesForAbsResource(addr addrs.AbsResource) []*ResourceInstanceChange {
 	if cs == nil {
 		panic("GetChangesForAbsResource on nil ChangesSync")
 	}
 	cs.lock.Lock()
 	defer cs.lock.Unlock()
-	var changes []*ResourceInstanceChangeSrc
+	var changes []*ResourceInstanceChange
 	for _, c := range cs.changes.InstancesForAbsResource(addr) {
 		changes = append(changes, c.DeepCopy())
 	}
@@ -133,15 +133,14 @@ func (cs *ChangesSync) RemoveResourceInstanceChange(addr addrs.AbsResourceInstan
 // The caller must ensure that there are no concurrent writes to the given
 // change while this method is running, but it is safe to resume mutating
 // it after this method returns without affecting the saved change.
-func (cs *ChangesSync) AppendOutputChange(changeSrc *OutputChangeSrc) {
+func (cs *ChangesSync) AppendOutputChange(changeSrc *OutputChange) {
 	if cs == nil {
 		panic("AppendOutputChange on nil ChangesSync")
 	}
 	cs.lock.Lock()
 	defer cs.lock.Unlock()
 
-	s := changeSrc.DeepCopy()
-	cs.changes.Outputs = append(cs.changes.Outputs, s)
+	cs.changes.Outputs = append(cs.changes.Outputs, changeSrc)
 }
 
 // GetOutputChange searches the set of output value changes for one matching
@@ -152,7 +151,7 @@ func (cs *ChangesSync) AppendOutputChange(changeSrc *OutputChangeSrc) {
 // The returned object is a deep copy of the change recorded in the plan, so
 // callers may mutate it although it's generally better (less confusing) to
 // treat planned changes as immutable after they've been initially constructed.
-func (cs *ChangesSync) GetOutputChange(addr addrs.AbsOutputValue) *OutputChangeSrc {
+func (cs *ChangesSync) GetOutputChange(addr addrs.AbsOutputValue) *OutputChange {
 	if cs == nil {
 		panic("GetOutputChange on nil ChangesSync")
 	}
@@ -168,7 +167,7 @@ func (cs *ChangesSync) GetOutputChange(addr addrs.AbsOutputValue) *OutputChangeS
 // The returned objects are a deep copy of the change recorded in the plan, so
 // callers may mutate them although it's generally better (less confusing) to
 // treat planned changes as immutable after they've been initially constructed.
-func (cs *ChangesSync) GetRootOutputChanges() []*OutputChangeSrc {
+func (cs *ChangesSync) GetRootOutputChanges() []*OutputChange {
 	if cs == nil {
 		panic("GetRootOutputChanges on nil ChangesSync")
 	}
@@ -185,7 +184,7 @@ func (cs *ChangesSync) GetRootOutputChanges() []*OutputChangeSrc {
 // The returned objects are a deep copy of the change recorded in the plan, so
 // callers may mutate them although it's generally better (less confusing) to
 // treat planned changes as immutable after they've been initially constructed.
-func (cs *ChangesSync) GetOutputChanges(parent addrs.ModuleInstance, module addrs.ModuleCall) []*OutputChangeSrc {
+func (cs *ChangesSync) GetOutputChanges(parent addrs.ModuleInstance, module addrs.ModuleCall) []*OutputChange {
 	if cs == nil {
 		panic("GetOutputChange on nil ChangesSync")
 	}

--- a/internal/plans/changes_sync.go
+++ b/internal/plans/changes_sync.go
@@ -28,14 +28,14 @@ type ChangesSync struct {
 // The caller must ensure that there are no concurrent writes to the given
 // change while this method is running, but it is safe to resume mutating
 // it after this method returns without affecting the saved change.
-func (cs *ChangesSync) AppendResourceInstanceChange(changeSrc *ResourceInstanceChange) {
+func (cs *ChangesSync) AppendResourceInstanceChange(change *ResourceInstanceChange) {
 	if cs == nil {
 		panic("AppendResourceInstanceChange on nil ChangesSync")
 	}
 	cs.lock.Lock()
 	defer cs.lock.Unlock()
 
-	s := changeSrc.DeepCopy()
+	s := change.DeepCopy()
 	cs.changes.Resources = append(cs.changes.Resources, s)
 }
 

--- a/internal/plans/changes_test.go
+++ b/internal/plans/changes_test.go
@@ -23,7 +23,7 @@ func TestChangesEmpty(t *testing.T) {
 		},
 		"resource change": {
 			&Changes{
-				Resources: []*ResourceInstanceChangeSrc{
+				Resources: []*ResourceInstanceChange{
 					{
 						Addr: addrs.Resource{
 							Mode: addrs.ManagedResourceMode,
@@ -35,7 +35,7 @@ func TestChangesEmpty(t *testing.T) {
 							Type: "test_thing",
 							Name: "woot",
 						}.Instance(addrs.NoKey).Absolute(addrs.RootModuleInstance),
-						ChangeSrc: ChangeSrc{
+						Change: Change{
 							Action: Update,
 						},
 					},
@@ -45,7 +45,7 @@ func TestChangesEmpty(t *testing.T) {
 		},
 		"resource change with no-op action": {
 			&Changes{
-				Resources: []*ResourceInstanceChangeSrc{
+				Resources: []*ResourceInstanceChange{
 					{
 						Addr: addrs.Resource{
 							Mode: addrs.ManagedResourceMode,
@@ -57,7 +57,7 @@ func TestChangesEmpty(t *testing.T) {
 							Type: "test_thing",
 							Name: "woot",
 						}.Instance(addrs.NoKey).Absolute(addrs.RootModuleInstance),
-						ChangeSrc: ChangeSrc{
+						Change: Change{
 							Action: NoOp,
 						},
 					},
@@ -67,7 +67,7 @@ func TestChangesEmpty(t *testing.T) {
 		},
 		"resource moved with no-op change": {
 			&Changes{
-				Resources: []*ResourceInstanceChangeSrc{
+				Resources: []*ResourceInstanceChange{
 					{
 						Addr: addrs.Resource{
 							Mode: addrs.ManagedResourceMode,
@@ -79,7 +79,7 @@ func TestChangesEmpty(t *testing.T) {
 							Type: "test_thing",
 							Name: "toot",
 						}.Instance(addrs.NoKey).Absolute(addrs.RootModuleInstance),
-						ChangeSrc: ChangeSrc{
+						Change: Change{
 							Action: NoOp,
 						},
 					},
@@ -89,12 +89,12 @@ func TestChangesEmpty(t *testing.T) {
 		},
 		"output change": {
 			&Changes{
-				Outputs: []*OutputChangeSrc{
+				Outputs: []*OutputChange{
 					{
 						Addr: addrs.OutputValue{
 							Name: "result",
 						}.Absolute(addrs.RootModuleInstance),
-						ChangeSrc: ChangeSrc{
+						Change: Change{
 							Action: Update,
 						},
 					},
@@ -104,12 +104,12 @@ func TestChangesEmpty(t *testing.T) {
 		},
 		"output change no-op": {
 			&Changes{
-				Outputs: []*OutputChangeSrc{
+				Outputs: []*OutputChange{
 					{
 						Addr: addrs.OutputValue{
 							Name: "result",
 						}.Absolute(addrs.RootModuleInstance),
-						ChangeSrc: ChangeSrc{
+						Change: Change{
 							Action: NoOp,
 						},
 					},

--- a/internal/plans/plan.go
+++ b/internal/plans/plan.go
@@ -64,7 +64,7 @@ type Plan struct {
 	VariableMarks      map[string][]cty.PathValueMarks
 	ApplyTimeVariables collections.Set[string]
 
-	Changes           *Changes
+	Changes           *ChangesSrc
 	DriftedResources  []*ResourceInstanceChangeSrc
 	DeferredResources []*DeferredResourceInstanceChangeSrc
 	TargetAddrs       []addrs.Targetable

--- a/internal/plans/plan_test.go
+++ b/internal/plans/plan_test.go
@@ -15,7 +15,7 @@ func TestProviderAddrs(t *testing.T) {
 
 	plan := &Plan{
 		VariableValues: map[string]DynamicValue{},
-		Changes: &Changes{
+		Changes: &ChangesSrc{
 			Resources: []*ResourceInstanceChangeSrc{
 				{
 					Addr: addrs.Resource{
@@ -74,7 +74,7 @@ func TestProviderAddrs(t *testing.T) {
 
 // Module outputs should not effect the result of Empty
 func TestModuleOutputChangesEmpty(t *testing.T) {
-	changes := &Changes{
+	changes := &ChangesSrc{
 		Outputs: []*OutputChangeSrc{
 			{
 				Addr: addrs.AbsOutputValue{

--- a/internal/plans/planfile/planfile_test.go
+++ b/internal/plans/planfile/planfile_test.go
@@ -54,7 +54,7 @@ func TestRoundtrip(t *testing.T) {
 	// Minimal plan too, since the serialization of the tfplan portion of the
 	// file is tested more fully in tfplan_test.go .
 	planIn := &plans.Plan{
-		Changes: &plans.Changes{
+		Changes: &plans.ChangesSrc{
 			Resources: []*plans.ResourceInstanceChangeSrc{},
 			Outputs:   []*plans.OutputChangeSrc{},
 		},

--- a/internal/plans/planfile/tfplan.go
+++ b/internal/plans/planfile/tfplan.go
@@ -59,7 +59,7 @@ func readTfplan(r io.Reader) (*plans.Plan, error) {
 
 	plan := &plans.Plan{
 		VariableValues: map[string]plans.DynamicValue{},
-		Changes: &plans.Changes{
+		Changes: &plans.ChangesSrc{
 			Outputs:   []*plans.OutputChangeSrc{},
 			Resources: []*plans.ResourceInstanceChangeSrc{},
 		},

--- a/internal/plans/planfile/tfplan_test.go
+++ b/internal/plans/planfile/tfplan_test.go
@@ -33,7 +33,7 @@ func TestTFPlanRoundTrip(t *testing.T) {
 			"foo": mustNewDynamicValueStr("foo value"),
 		},
 		ApplyTimeVariables: applyTimeVariables,
-		Changes: &plans.Changes{
+		Changes: &plans.ChangesSrc{
 			Outputs: []*plans.OutputChangeSrc{
 				{
 					Addr: addrs.OutputValue{Name: "bar"}.Absolute(addrs.RootModuleInstance),
@@ -382,7 +382,7 @@ func TestTFPlanRoundTripDestroy(t *testing.T) {
 	})
 
 	plan := &plans.Plan{
-		Changes: &plans.Changes{
+		Changes: &plans.ChangesSrc{
 			Outputs: []*plans.OutputChangeSrc{
 				{
 					Addr: addrs.OutputValue{Name: "bar"}.Absolute(addrs.RootModuleInstance),

--- a/internal/stacks/stackplan/component.go
+++ b/internal/stacks/stackplan/component.go
@@ -90,7 +90,7 @@ type Component struct {
 // with the given previous run state, which should not happen if the caller
 // is using Terraform Core correctly.
 func (c *Component) ForModulesRuntime() (*plans.Plan, error) {
-	changes := plans.NewChanges()
+	changes := &plans.ChangesSrc{}
 	plan := &plans.Plan{
 		UIMode:    c.Mode,
 		Changes:   changes,
@@ -100,11 +100,12 @@ func (c *Component) ForModulesRuntime() (*plans.Plan, error) {
 		Checks:    c.PlannedChecks,
 	}
 
-	sc := changes.SyncWrapper()
+	// sc := changes.SyncWrapper()
 	for _, elem := range c.ResourceInstancePlanned.Elems {
 		changeSrc := elem.Value
 		if changeSrc != nil {
-			sc.AppendResourceInstanceChange(changeSrc)
+			changes.Resources = append(changes.Resources, changeSrc)
+			// sc.AppendResourceInstanceChange(changeSrc)
 		}
 	}
 

--- a/internal/terraform/context_apply.go
+++ b/internal/terraform/context_apply.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform/internal/collections"
 	"github.com/hashicorp/terraform/internal/configs"
 	"github.com/hashicorp/terraform/internal/lang"
+	"github.com/hashicorp/terraform/internal/lang/marks"
 	"github.com/hashicorp/terraform/internal/plans"
 	"github.com/hashicorp/terraform/internal/providers"
 	"github.com/hashicorp/terraform/internal/states"
@@ -168,11 +169,55 @@ func (c *Context) ApplyAndEval(plan *plans.Plan, config *configs.Config, opts *A
 		return nil, nil, diags
 	}
 
+	changes := plans.NewChanges()
+
+	{
+		// FIXME Changes.Decode HACK??
+		// Or is this actually just fine???
+
+		schemas, diags := c.Schemas(config, plan.PriorState)
+		if diags.HasErrors() {
+			return nil, nil, diags
+		}
+
+		for _, rcs := range plan.Changes.Resources {
+			p := schemas.Providers[rcs.ProviderAddr.Provider]
+			var schema providers.Schema
+			switch rcs.Addr.Resource.Resource.Mode {
+			case addrs.ManagedResourceMode:
+				schema = p.ResourceTypes[rcs.Addr.Resource.Resource.Type]
+			case addrs.DataResourceMode:
+				schema = p.DataSources[rcs.Addr.Resource.Resource.Type]
+			default:
+				panic(fmt.Sprintf("unexpected resource mode %s", rcs.Addr.Resource.Resource.Mode))
+			}
+
+			rc, err := rcs.Decode(schema.Block.ImpliedType())
+			if err != nil {
+				diags = diags.Append(err)
+				return nil, nil, diags
+			}
+			rc.Before = marks.MarkPaths(rc.Before, marks.Sensitive, rcs.BeforeSensitivePaths)
+			rc.After = marks.MarkPaths(rc.After, marks.Sensitive, rcs.AfterSensitivePaths)
+			changes.Resources = append(changes.Resources, rc)
+		}
+
+		for _, ocs := range plan.Changes.Outputs {
+			oc, err := ocs.Decode()
+			if err != nil {
+				diags = diags.Append(err)
+				return nil, nil, diags
+			}
+			changes.Outputs = append(changes.Outputs, oc)
+		}
+
+	}
+
 	workingState := plan.PriorState.DeepCopy()
 	walker, walkDiags := c.walk(graph, operation, &graphWalkOpts{
 		Config:                  config,
 		InputState:              workingState,
-		Changes:                 plan.Changes,
+		Changes:                 changes,
 		Overrides:               plan.Overrides,
 		ExternalProviderConfigs: opts.ExternalProviders,
 
@@ -345,9 +390,53 @@ func (c *Context) applyGraph(plan *plans.Plan, config *configs.Config, opts *App
 		externalProviderConfigs = opts.ExternalProviders
 	}
 
+	changes := plans.NewChanges()
+	{
+		// FIXME Changes.Decode HACK??
+		// Or is this actually just fine???
+
+		schemas, diags := c.Schemas(config, plan.PriorState)
+		if diags.HasErrors() {
+			return nil, walkApply, diags
+		}
+
+		for _, rcs := range plan.Changes.Resources {
+			p := schemas.Providers[rcs.ProviderAddr.Provider]
+			var schema providers.Schema
+			switch rcs.Addr.Resource.Resource.Mode {
+			case addrs.ManagedResourceMode:
+				schema = p.ResourceTypes[rcs.Addr.Resource.Resource.Type]
+			case addrs.DataResourceMode:
+				schema = p.DataSources[rcs.Addr.Resource.Resource.Type]
+			default:
+				panic(fmt.Sprintf("unexpected resource mode %s", rcs.Addr.Resource.Resource.Mode))
+			}
+			rc, err := rcs.Decode(schema.Block.ImpliedType())
+			if err != nil {
+				diags = diags.Append(err)
+				return nil, walkApply, diags
+			}
+			// FIXME mark on decode!
+			rc.Before = marks.MarkPaths(rc.Before, marks.Sensitive, rcs.BeforeSensitivePaths)
+			rc.After = marks.MarkPaths(rc.After, marks.Sensitive, rcs.AfterSensitivePaths)
+
+			changes.Resources = append(changes.Resources, rc)
+		}
+
+		for _, ocs := range plan.Changes.Outputs {
+			oc, err := ocs.Decode()
+			if err != nil {
+				diags = diags.Append(err)
+				return nil, walkApply, diags
+			}
+			changes.Outputs = append(changes.Outputs, oc)
+		}
+
+	}
+
 	graph, moreDiags := (&ApplyGraphBuilder{
 		Config:                  config,
-		Changes:                 plan.Changes,
+		Changes:                 changes,
 		DeferredChanges:         plan.DeferredResources,
 		State:                   plan.PriorState,
 		RootVariableValues:      variables,

--- a/internal/terraform/context_apply_deferred_test.go
+++ b/internal/terraform/context_apply_deferred_test.go
@@ -3304,6 +3304,10 @@ func TestContextApply_deferredActions(t *testing.T) {
 					}
 
 					t.Run("apply", func(t *testing.T) {
+						if plan == nil {
+							// if the previous step failed we won't know because it was another subtest
+							t.Fatal("cannot apply a nil plan")
+						}
 
 						updatedState, diags := ctx.Apply(plan, cfg, nil)
 

--- a/internal/terraform/context_apply_test.go
+++ b/internal/terraform/context_apply_test.go
@@ -9533,7 +9533,7 @@ func TestContext2Apply_moduleReplaceCycle(t *testing.T) {
 			},
 		})
 
-		changes := &plans.Changes{
+		changes := &plans.ChangesSrc{
 			Resources: []*plans.ResourceInstanceChangeSrc{
 				{
 					Addr: addrs.Resource{

--- a/internal/terraform/context_test.go
+++ b/internal/terraform/context_test.go
@@ -800,7 +800,7 @@ func contextOptsForPlanViaFile(t *testing.T, configSnap *configload.Snapshot, pl
 // new plan and state types, and should not be used in new tests. Instead, use
 // a library like "cmp" to do a deep equality check and diff on the two
 // data structures.
-func legacyPlanComparisonString(state *states.State, changes *plans.Changes) string {
+func legacyPlanComparisonString(state *states.State, changes *plans.ChangesSrc) string {
 	return fmt.Sprintf(
 		"DIFF:\n\n%s\n\nSTATE:\n\n%s",
 		legacyDiffComparisonString(changes),
@@ -815,7 +815,7 @@ func legacyPlanComparisonString(state *states.State, changes *plans.Changes) str
 // This is here only for compatibility with existing tests that predate our
 // new plan types, and should not be used in new tests. Instead, use a library
 // like "cmp" to do a deep equality check and diff on the two data structures.
-func legacyDiffComparisonString(changes *plans.Changes) string {
+func legacyDiffComparisonString(changes *plans.ChangesSrc) string {
 	// The old string representation of a plan was grouped by module, but
 	// our new plan structure is not grouped in that way and so we'll need
 	// to preprocess it in order to produce that grouping.

--- a/internal/terraform/context_test.go
+++ b/internal/terraform/context_test.go
@@ -299,7 +299,7 @@ func TestContext_preloadedProviderSchemas(t *testing.T) {
 	}
 }
 
-func testContext2(t *testing.T, opts *ContextOpts) *Context {
+func testContext2(t testing.TB, opts *ContextOpts) *Context {
 	t.Helper()
 
 	ctx, diags := NewContext(opts)

--- a/internal/terraform/eval_context_builtin.go
+++ b/internal/terraform/eval_context_builtin.go
@@ -333,7 +333,7 @@ func (ctx *BuiltinEvalContext) EvaluateReplaceTriggeredBy(expr hcl.Expression, r
 		return nil, false, diags
 	}
 
-	var changes []*plans.ResourceInstanceChangeSrc
+	var changes []*plans.ResourceInstanceChange
 	// store the address once we get it for validation
 	var resourceAddr addrs.Resource
 
@@ -376,7 +376,7 @@ func (ctx *BuiltinEvalContext) EvaluateReplaceTriggeredBy(expr hcl.Expression, r
 	// for any change.
 	if len(ref.Remaining) == 0 {
 		for _, c := range changes {
-			switch c.ChangeSrc.Action {
+			switch c.Change.Action {
 			// Only immediate changes to the resource will trigger replacement.
 			case plans.Update, plans.DeleteThenCreate, plans.CreateThenDelete:
 				return ref, true, diags
@@ -393,7 +393,7 @@ func (ctx *BuiltinEvalContext) EvaluateReplaceTriggeredBy(expr hcl.Expression, r
 
 	// Make sure the change is actionable. A create or delete action will have
 	// a change in value, but are not valid for our purposes here.
-	switch change.ChangeSrc.Action {
+	switch change.Change.Action {
 	case plans.Update, plans.DeleteThenCreate, plans.CreateThenDelete:
 		// OK
 	default:
@@ -402,28 +402,29 @@ func (ctx *BuiltinEvalContext) EvaluateReplaceTriggeredBy(expr hcl.Expression, r
 
 	// Since we have a traversal after the resource reference, we will need to
 	// decode the changes, which means we need a schema.
-	providerAddr := change.ProviderAddr
-	schema, err := ctx.ProviderSchema(providerAddr)
-	if err != nil {
-		diags = diags.Append(err)
-		return nil, false, diags
-	}
+	// providerAddr := change.ProviderAddr
+	// schema, err := ctx.ProviderSchema(providerAddr)
+	// if err != nil {
+	// 	diags = diags.Append(err)
+	// 	return nil, false, diags
+	// }
 
-	resAddr := change.Addr.ContainingResource().Resource
-	resSchema, _ := schema.SchemaForResourceType(resAddr.Mode, resAddr.Type)
-	ty := resSchema.ImpliedType()
+	// resAddr := change.Addr.ContainingResource().Resource
+	//resSchema, _ := schema.SchemaForResourceType(resAddr.Mode, resAddr.Type)
+	//ty := resSchema.ImpliedType()
 
-	before, err := change.ChangeSrc.Before.Decode(ty)
-	if err != nil {
-		diags = diags.Append(err)
-		return nil, false, diags
-	}
+	// before, err := change.Change.Before.Decode(ty)
+	// if err != nil {
+	// 	diags = diags.Append(err)
+	// 	return nil, false, diags
+	// }
 
-	after, err := change.ChangeSrc.After.Decode(ty)
-	if err != nil {
-		diags = diags.Append(err)
-		return nil, false, diags
-	}
+	// after, err := change.ChangeSrc.After.Decode(ty)
+	// if err != nil {
+	// 	diags = diags.Append(err)
+	// 	return nil, false, diags
+	// }
+	before, after := change.Before, change.After
 
 	path := traversalToPath(ref.Remaining)
 	attrBefore, _ := path.Apply(before)

--- a/internal/terraform/evaluate.go
+++ b/internal/terraform/evaluate.go
@@ -671,23 +671,6 @@ func (d *evaluationStateData) GetResource(addr addrs.Resource, rng tfdiags.Sourc
 				continue
 			}
 			instances[key] = change.After
-			// val, err := change.After.Decode(ty)
-			// if err != nil {
-			// 	diags = diags.Append(&hcl.Diagnostic{
-			// 		Severity: hcl.DiagError,
-			// 		Summary:  "Invalid resource instance data in plan",
-			// 		Detail:   fmt.Sprintf("Instance %s data could not be decoded from the plan: %s.", instAddr, err),
-			// 		Subject:  &config.DeclRange,
-			// 	})
-			// 	continue
-			// }
-
-			// Unlike decoding state, decoding a change does not automatically
-			// mark values.
-			// FIXME: Correct that inconsistency by moving this logic into
-			// the decoder function in the plans package, so that we can
-			// test that behavior being implemented in only one place.
-			//instances[key] = marks.MarkPaths(val, marks.Sensitive, change.AfterSensitivePaths)
 			continue
 		}
 

--- a/internal/terraform/evaluate.go
+++ b/internal/terraform/evaluate.go
@@ -670,23 +670,24 @@ func (d *evaluationStateData) GetResource(addr addrs.Resource, rng tfdiags.Sourc
 				})
 				continue
 			}
-			val, err := change.After.Decode(ty)
-			if err != nil {
-				diags = diags.Append(&hcl.Diagnostic{
-					Severity: hcl.DiagError,
-					Summary:  "Invalid resource instance data in plan",
-					Detail:   fmt.Sprintf("Instance %s data could not be decoded from the plan: %s.", instAddr, err),
-					Subject:  &config.DeclRange,
-				})
-				continue
-			}
+			instances[key] = change.After
+			// val, err := change.After.Decode(ty)
+			// if err != nil {
+			// 	diags = diags.Append(&hcl.Diagnostic{
+			// 		Severity: hcl.DiagError,
+			// 		Summary:  "Invalid resource instance data in plan",
+			// 		Detail:   fmt.Sprintf("Instance %s data could not be decoded from the plan: %s.", instAddr, err),
+			// 		Subject:  &config.DeclRange,
+			// 	})
+			// 	continue
+			// }
 
 			// Unlike decoding state, decoding a change does not automatically
 			// mark values.
 			// FIXME: Correct that inconsistency by moving this logic into
 			// the decoder function in the plans package, so that we can
 			// test that behavior being implemented in only one place.
-			instances[key] = marks.MarkPaths(val, marks.Sensitive, change.AfterSensitivePaths)
+			//instances[key] = marks.MarkPaths(val, marks.Sensitive, change.AfterSensitivePaths)
 			continue
 		}
 

--- a/internal/terraform/evaluate_test.go
+++ b/internal/terraform/evaluate_test.go
@@ -503,10 +503,8 @@ func TestEvaluatorGetResource_changes(t *testing.T) {
 		Type: "test_resource",
 		Name: "foo",
 	}
-	schema, _ := schemas.ResourceTypeConfig(addrs.NewDefaultProvider("test"), addr.Mode, addr.Type)
-	// This encoding separates out the After's marks into its AfterValMarks
-	csrc, _ := change.Encode(schema.ImpliedType())
-	changesSync.AppendResourceInstanceChange(csrc)
+
+	changesSync.AppendResourceInstanceChange(change)
 
 	evaluator := &Evaluator{
 		Meta: &ContextMeta{

--- a/internal/terraform/node_resource_abstract_instance.go
+++ b/internal/terraform/node_resource_abstract_instance.go
@@ -171,16 +171,18 @@ func (n *NodeAbstractResourceInstance) readDiff(ctx EvalContext, providerSchema 
 		return nil, fmt.Errorf("provider does not support resource type %q", addr.Resource.Resource.Type)
 	}
 
-	csrc := changes.GetResourceInstanceChange(addr, addrs.NotDeposed)
-	if csrc == nil {
-		log.Printf("[TRACE] readDiff: No planned change recorded for %s", n.Addr)
-		return nil, nil
-	}
+	change := changes.GetResourceInstanceChange(addr, addrs.NotDeposed)
 
-	change, err := csrc.Decode(schema.ImpliedType())
-	if err != nil {
-		return nil, fmt.Errorf("failed to decode planned changes for %s: %s", n.Addr, err)
-	}
+	// csrc := changes.GetResourceInstanceChange(addr, addrs.NotDeposed)
+	// if csrc == nil {
+	// 	log.Printf("[TRACE] readDiff: No planned change recorded for %s", n.Addr)
+	// 	return nil, nil
+	// }
+
+	// change, err := csrc.Decode(schema.ImpliedType())
+	// if err != nil {
+	// 	return nil, fmt.Errorf("failed to decode planned changes for %s: %s", n.Addr, err)
+	// }
 
 	log.Printf("[TRACE] readDiff: Read %s change from plan for %s", change.Action, n.Addr)
 
@@ -556,10 +558,10 @@ func (n *NodeAbstractResourceInstance) writeChange(ctx EvalContext, change *plan
 		return nil
 	}
 
-	_, providerSchema, err := getProvider(ctx, n.ResolvedProvider)
-	if err != nil {
-		return err
-	}
+	// _, providerSchema, err := getProvider(ctx, n.ResolvedProvider)
+	// if err != nil {
+	// 	return err
+	// }
 
 	if change.Addr.String() != n.Addr.String() || change.DeposedKey != deposedKey {
 		// Should never happen, and indicates a bug in the caller.
@@ -576,19 +578,19 @@ func (n *NodeAbstractResourceInstance) writeChange(ctx EvalContext, change *plan
 		panic("unpopulated ResourceInstanceChange.PrevRunAddr in writeChange")
 	}
 
-	ri := n.Addr.Resource
-	schema, _ := providerSchema.SchemaForResourceAddr(ri.Resource)
-	if schema == nil {
-		// Should be caught during validation, so we don't bother with a pretty error here
-		return fmt.Errorf("provider does not support resource type %q", ri.Resource.Type)
-	}
+	// ri := n.Addr.Resource
+	// schema, _ := providerSchema.SchemaForResourceAddr(ri.Resource)
+	// if schema == nil {
+	// 	// Should be caught during validation, so we don't bother with a pretty error here
+	// 	return fmt.Errorf("provider does not support resource type %q", ri.Resource.Type)
+	// }
 
-	csrc, err := change.Encode(schema.ImpliedType())
-	if err != nil {
-		return fmt.Errorf("failed to encode planned changes for %s: %s", n.Addr, err)
-	}
+	// csrc, err := change.Encode(schema.ImpliedType())
+	// if err != nil {
+	// 	return fmt.Errorf("failed to encode planned changes for %s: %s", n.Addr, err)
+	// }
 
-	changes.AppendResourceInstanceChange(csrc)
+	changes.AppendResourceInstanceChange(change)
 	if deposedKey == states.NotDeposed {
 		log.Printf("[TRACE] writeChange: recorded %s change for %s", change.Action, n.Addr)
 	} else {

--- a/internal/terraform/node_resource_destroy_deposed_test.go
+++ b/internal/terraform/node_resource_destroy_deposed_test.go
@@ -79,7 +79,7 @@ func TestNodePlanDeposedResourceInstanceObject_Execute(t *testing.T) {
 	}
 
 	change := ctx.Changes().GetResourceInstanceChange(absResource, deposedKey)
-	if got, want := change.ChangeSrc.Action, plans.Delete; got != want {
+	if got, want := change.Change.Action, plans.Delete; got != want {
 		t.Fatalf("wrong planned action\ngot:  %s\nwant: %s", got, want)
 	}
 }

--- a/internal/terraform/plan_benchmark_test.go
+++ b/internal/terraform/plan_benchmark_test.go
@@ -1,0 +1,74 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package terraform
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/internal/addrs"
+	"github.com/hashicorp/terraform/internal/configs/configschema"
+	"github.com/hashicorp/terraform/internal/providers"
+	testing_provider "github.com/hashicorp/terraform/internal/providers/testing"
+	"github.com/hashicorp/terraform/internal/states"
+	"github.com/zclconf/go-cty/cty"
+)
+
+// Benchmark that stresses resource instance evaluation during plan
+func BenchmarkPlanLargeCountRefs(b *testing.B) {
+	m := testModuleInline(b, map[string]string{
+		"main.tf": `
+resource "test_resource" "a" {
+  count = 512
+  input = "ok"
+}
+
+resource "test_resource" "b" {
+  count = length(test_resource.a)
+  input = test_resource.a
+}
+
+module "mod" {
+  count = length(test_resource.a)
+  source = "./mod"
+  in = [test_resource.a[count.index].id, test_resource.b[count.index].id]
+}
+
+output out {
+  value = module.mod
+}`,
+		"./mod/main.tf": `
+variable "in" {
+}
+
+output "out" {
+  value = var.in
+}
+`})
+
+	p := new(testing_provider.MockProvider)
+	p.GetProviderSchemaResponse = getProviderSchemaResponseFromProviderSchema(&providerSchema{
+		ResourceTypes: map[string]*configschema.Block{
+			"test_resource": {
+				Attributes: map[string]*configschema.Attribute{
+					"id":    {Type: cty.String, Computed: true},
+					"input": {Type: cty.DynamicPseudoType, Optional: true},
+				},
+			},
+		},
+	})
+
+	ctx := testContext2(b, &ContextOpts{
+		Providers: map[addrs.Provider]providers.Factory{
+			addrs.NewDefaultProvider("test"): testProviderFuncFixed(p),
+		},
+	})
+
+	b.ResetTimer()
+	for range b.N {
+		_, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+		if diags.HasErrors() {
+			b.Fatal(diags.Err())
+		}
+	}
+}

--- a/internal/terraform/terraform_test.go
+++ b/internal/terraform/terraform_test.go
@@ -89,7 +89,7 @@ func testModuleWithSnapshot(t *testing.T, name string) (*configs.Config, *config
 
 // testModuleInline takes a map of path -> config strings and yields a config
 // structure with those files loaded from disk
-func testModuleInline(t *testing.T, sources map[string]string) *configs.Config {
+func testModuleInline(t testing.TB, sources map[string]string) *configs.Config {
 	t.Helper()
 
 	cfgPath := t.TempDir()

--- a/internal/terraform/transform_destroy_cbd_test.go
+++ b/internal/terraform/transform_destroy_cbd_test.go
@@ -78,16 +78,16 @@ func filterInstances(g *Graph) *Graph {
 
 func TestCBDEdgeTransformer(t *testing.T) {
 	changes := &plans.Changes{
-		Resources: []*plans.ResourceInstanceChangeSrc{
+		Resources: []*plans.ResourceInstanceChange{
 			{
 				Addr: mustResourceInstanceAddr("test_object.A"),
-				ChangeSrc: plans.ChangeSrc{
+				Change: plans.Change{
 					Action: plans.CreateThenDelete,
 				},
 			},
 			{
 				Addr: mustResourceInstanceAddr("test_object.B"),
-				ChangeSrc: plans.ChangeSrc{
+				Change: plans.Change{
 					Action: plans.Update,
 				},
 			},
@@ -133,22 +133,22 @@ test_object.B
 
 func TestCBDEdgeTransformerMulti(t *testing.T) {
 	changes := &plans.Changes{
-		Resources: []*plans.ResourceInstanceChangeSrc{
+		Resources: []*plans.ResourceInstanceChange{
 			{
 				Addr: mustResourceInstanceAddr("test_object.A"),
-				ChangeSrc: plans.ChangeSrc{
+				Change: plans.Change{
 					Action: plans.CreateThenDelete,
 				},
 			},
 			{
 				Addr: mustResourceInstanceAddr("test_object.B"),
-				ChangeSrc: plans.ChangeSrc{
+				Change: plans.Change{
 					Action: plans.CreateThenDelete,
 				},
 			},
 			{
 				Addr: mustResourceInstanceAddr("test_object.C"),
-				ChangeSrc: plans.ChangeSrc{
+				Change: plans.Change{
 					Action: plans.Update,
 				},
 			},
@@ -209,22 +209,22 @@ test_object.C
 
 func TestCBDEdgeTransformer_depNonCBDCount(t *testing.T) {
 	changes := &plans.Changes{
-		Resources: []*plans.ResourceInstanceChangeSrc{
+		Resources: []*plans.ResourceInstanceChange{
 			{
 				Addr: mustResourceInstanceAddr("test_object.A"),
-				ChangeSrc: plans.ChangeSrc{
+				Change: plans.Change{
 					Action: plans.CreateThenDelete,
 				},
 			},
 			{
 				Addr: mustResourceInstanceAddr("test_object.B[0]"),
-				ChangeSrc: plans.ChangeSrc{
+				Change: plans.Change{
 					Action: plans.Update,
 				},
 			},
 			{
 				Addr: mustResourceInstanceAddr("test_object.B[1]"),
-				ChangeSrc: plans.ChangeSrc{
+				Change: plans.Change{
 					Action: plans.Update,
 				},
 			},
@@ -280,28 +280,28 @@ test_object.B\[1\]
 
 func TestCBDEdgeTransformer_depNonCBDCountBoth(t *testing.T) {
 	changes := &plans.Changes{
-		Resources: []*plans.ResourceInstanceChangeSrc{
+		Resources: []*plans.ResourceInstanceChange{
 			{
 				Addr: mustResourceInstanceAddr("test_object.A[0]"),
-				ChangeSrc: plans.ChangeSrc{
+				Change: plans.Change{
 					Action: plans.CreateThenDelete,
 				},
 			},
 			{
 				Addr: mustResourceInstanceAddr("test_object.A[1]"),
-				ChangeSrc: plans.ChangeSrc{
+				Change: plans.Change{
 					Action: plans.CreateThenDelete,
 				},
 			},
 			{
 				Addr: mustResourceInstanceAddr("test_object.B[0]"),
-				ChangeSrc: plans.ChangeSrc{
+				Change: plans.Change{
 					Action: plans.Update,
 				},
 			},
 			{
 				Addr: mustResourceInstanceAddr("test_object.B[1]"),
-				ChangeSrc: plans.ChangeSrc{
+				Change: plans.Change{
 					Action: plans.Update,
 				},
 			},

--- a/internal/terraform/transform_destroy_edge_test.go
+++ b/internal/terraform/transform_destroy_edge_test.go
@@ -338,14 +338,8 @@ func TestPruneUnusedNodesTransformer_rootModuleOutputValues(t *testing.T) {
 		Module:   addrs.RootModule,
 		Provider: addrs.MustParseProviderSourceString("foo/test"),
 	}
-	emptyObjDynamicVal, err := plans.NewDynamicValue(cty.EmptyObjectVal, cty.EmptyObject)
-	if err != nil {
-		t.Fatal(err)
-	}
-	nullObjDynamicVal, err := plans.NewDynamicValue(cty.NullVal(cty.EmptyObject), cty.EmptyObject)
-	if err != nil {
-		t.Fatal(err)
-	}
+	emptyObjDynamicVal := cty.EmptyObjectVal
+	nullObjDynamicVal := cty.NullVal(cty.EmptyObject)
 
 	config := testModuleInline(t, map[string]string{
 		"main.tf": `
@@ -368,11 +362,11 @@ func TestPruneUnusedNodesTransformer_rootModuleOutputValues(t *testing.T) {
 		)
 	})
 	changes := plans.NewChanges()
-	changes.SyncWrapper().AppendResourceInstanceChange(&plans.ResourceInstanceChangeSrc{
+	changes.SyncWrapper().AppendResourceInstanceChange(&plans.ResourceInstanceChange{
 		Addr:         resourceInstAddr,
 		PrevRunAddr:  resourceInstAddr,
 		ProviderAddr: providerCfgAddr,
-		ChangeSrc: plans.ChangeSrc{
+		Change: plans.Change{
 			Action: plans.Delete,
 			Before: emptyObjDynamicVal,
 			After:  nullObjDynamicVal,
@@ -488,10 +482,10 @@ func TestDestroyEdgeTransformer_noOp(t *testing.T) {
 		// We only need a minimal object to indicate GraphNodeCreator change is
 		// a NoOp here.
 		Changes: &plans.Changes{
-			Resources: []*plans.ResourceInstanceChangeSrc{
+			Resources: []*plans.ResourceInstanceChange{
 				{
-					Addr:      mustResourceInstanceAddr("test_object.B"),
-					ChangeSrc: plans.ChangeSrc{Action: plans.NoOp},
+					Addr:   mustResourceInstanceAddr("test_object.B"),
+					Change: plans.Change{Action: plans.NoOp},
 				},
 			},
 		},

--- a/internal/terraform/transform_diff_test.go
+++ b/internal/terraform/transform_diff_test.go
@@ -28,18 +28,12 @@ func TestDiffTransformer_nilDiff(t *testing.T) {
 func TestDiffTransformer(t *testing.T) {
 	g := Graph{Path: addrs.RootModuleInstance}
 
-	beforeVal, err := plans.NewDynamicValue(cty.StringVal(""), cty.String)
-	if err != nil {
-		t.Fatal(err)
-	}
-	afterVal, err := plans.NewDynamicValue(cty.StringVal(""), cty.String)
-	if err != nil {
-		t.Fatal(err)
-	}
+	beforeVal := cty.StringVal("")
+	afterVal := cty.StringVal("")
 
 	tf := &DiffTransformer{
 		Changes: &plans.Changes{
-			Resources: []*plans.ResourceInstanceChangeSrc{
+			Resources: []*plans.ResourceInstanceChange{
 				{
 					Addr: addrs.Resource{
 						Mode: addrs.ManagedResourceMode,
@@ -50,7 +44,7 @@ func TestDiffTransformer(t *testing.T) {
 						Provider: addrs.NewDefaultProvider("aws"),
 						Module:   addrs.RootModule,
 					},
-					ChangeSrc: plans.ChangeSrc{
+					Change: plans.Change{
 						Action: plans.Update,
 						Before: beforeVal,
 						After:  afterVal,
@@ -106,15 +100,12 @@ resource "aws_instance" "foo" {
 
 	g := Graph{Path: addrs.RootModuleInstance}
 
-	beforeVal, err := plans.NewDynamicValue(cty.StringVal(""), cty.String)
-	if err != nil {
-		t.Fatal(err)
-	}
+	beforeVal := cty.StringVal("")
 
 	tf := &DiffTransformer{
 		Config: m,
 		Changes: &plans.Changes{
-			Resources: []*plans.ResourceInstanceChangeSrc{
+			Resources: []*plans.ResourceInstanceChange{
 				{
 					Addr: addrs.Resource{
 						Mode: addrs.ManagedResourceMode,
@@ -125,7 +116,7 @@ resource "aws_instance" "foo" {
 						Provider: addrs.NewDefaultProvider("aws"),
 						Module:   addrs.RootModule,
 					},
-					ChangeSrc: plans.ChangeSrc{
+					Change: plans.Change{
 						// A "no-op" change has the no-op action and has the
 						// same object as both Before and After.
 						Action: plans.NoOp,
@@ -143,7 +134,7 @@ resource "aws_instance" "foo" {
 						Provider: addrs.NewDefaultProvider("aws"),
 						Module:   addrs.RootModule,
 					},
-					ChangeSrc: plans.ChangeSrc{
+					Change: plans.Change{
 						// A "no-op" change has the no-op action and has the
 						// same object as both Before and After.
 						Action: plans.NoOp,


### PR DESCRIPTION
Currently all resource changes are stored in an encoded format, similar to how the state is stored. This requires decoding the changes of any resource instance for evaluation elsewhere in the configuration. On top of the extra round-trip through the encoding-decoding process, resources with multiple instances must decode all instances in order to return the resource value for evaluation. This is where the overhead makes itself most apparent, as when each instance is referenced all instances are decoded over and over again.

Here we refactor the `plans.Changes` type to contain `ResourceInstanceChange` and `OutputChange` values, which are the unencoded equivalent of the values which were previously used in the change set. We then create a second container, `plans.ChangesSrc` to hold the encoded values which also happens to better match the names of the container elements, `ResourceInstanceChangeSrc` and  `OutputChangeSrc`. Refactoring in this way allows us to make very few changes in order to handle this in core, and the majority of work is cascading the type and name changes throughout the codebase.

Resource state also has a similar issue with decoding for evaluation, but that isn't quite as simple a change and can be tackled separately.