### PR TITLE
Fix typo in null_resource.mdx

### DIFF
--- a/website/docs/language/resources/provisioners/null_resource.mdx
+++ b/website/docs/language/resources/provisioners/null_resource.mdx
@@ -32,18 +32,18 @@ resource "aws_instance" "cluster" {
 
 resource "terraform_data" "cluster" {
   # Replacement of any instance of the cluster requires re-provisioning
-  triggers_replace = aws_instance.cluster.[*].id
+  triggers_replace = aws_instance.cluster[*].id
 
   # Bootstrap script can run on any instance of the cluster
   # So we just choose the first in this case
   connection {
-    host = aws_instance.cluster.[0].public_ip
+    host = aws_instance.cluster[0].public_ip
   }
 
   provisioner "remote-exec" {
     # Bootstrap script called with private_ip of each node in the cluster
     inline = [
-      "bootstrap-cluster.sh ${join(" ", aws_instance.cluster.*.private_ip)}",
+      "bootstrap-cluster.sh ${join(" ", aws_instance.cluster[*].private_ip)}",
     ]
   }
 }


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Fixes #

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.8.x

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

### NEW FEATURES | UPGRADE NOTES | ENHANCEMENTS | BUG FIXES | EXPERIMENTS

<!--

Write a short description of the user-facing change. Examples:

- `terraform show -json`: Fixed crash with sensitive set values.
- When rendering a diff, Terraform now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 

-  
