### PR TITLE
stacks: fix bug preventing unconfigured clients within Terraform

### DIFF
--- a/internal/stacks/stackruntime/testdata/mainbundle/test/state-manipulation/cross-type-moved/cross-type-moved.tf
+++ b/internal/stacks/stackruntime/testdata/mainbundle/test/state-manipulation/cross-type-moved/cross-type-moved.tf
@@ -1,0 +1,19 @@
+terraform {
+  required_providers {
+    testing = {
+      source  = "hashicorp/testing"
+      version = "0.1.0"
+    }
+  }
+}
+
+moved {
+  from = testing_resource.before
+  to   = testing_deferred_resource.after
+}
+
+resource "testing_deferred_resource" "after" {
+  id = "moved"
+  value = "moved"
+  deferred = false
+}

--- a/internal/stacks/stackruntime/testdata/mainbundle/test/state-manipulation/cross-type-moved/cross-type-moved.tfstack.hcl
+++ b/internal/stacks/stackruntime/testdata/mainbundle/test/state-manipulation/cross-type-moved/cross-type-moved.tfstack.hcl
@@ -1,0 +1,16 @@
+required_providers {
+  testing = {
+    source  = "hashicorp/testing"
+    version = "0.1.0"
+  }
+}
+
+provider "testing" "default" {}
+
+component "self" {
+  source = "./"
+
+  providers = {
+    testing = provider.testing.default
+  }
+}

--- a/internal/stacks/stackruntime/testdata/mainbundle/test/with-provider-functions/with-provider-functions.tf
+++ b/internal/stacks/stackruntime/testdata/mainbundle/test/with-provider-functions/with-provider-functions.tf
@@ -1,0 +1,27 @@
+terraform {
+  required_providers {
+    testing = {
+      source  = "hashicorp/testing"
+      version = "0.1.0"
+    }
+  }
+}
+
+variable "id" {
+  type     = string
+  default  = null
+  nullable = true # We'll generate an ID if none provided.
+}
+
+variable "input" {
+  type = string
+}
+
+resource "testing_resource" "data" {
+  id    = var.id
+  value = provider::testing::echo(var.input)
+}
+
+output "value" {
+  value = testing_resource.data.value
+}

--- a/internal/stacks/stackruntime/testdata/mainbundle/test/with-provider-functions/with-provider-functions.tfstack.hcl
+++ b/internal/stacks/stackruntime/testdata/mainbundle/test/with-provider-functions/with-provider-functions.tfstack.hcl
@@ -1,0 +1,30 @@
+required_providers {
+  testing = {
+    source  = "hashicorp/testing"
+    version = "0.1.0"
+  }
+}
+
+provider "testing" "default" {}
+
+variable "input" {
+  type = string
+}
+
+component "self" {
+  source = "./"
+
+  providers = {
+    testing = provider.testing.default
+  }
+
+  inputs = {
+    id    = "2f9f3b84"
+    input = var.input
+  }
+}
+
+output "value" {
+  type = string
+  value = component.self.value
+}

--- a/internal/stacks/stackruntime/testing/provider.go
+++ b/internal/stacks/stackruntime/testing/provider.go
@@ -101,6 +101,14 @@ func NewProviderWithData(store *ResourceStore) *MockProvider {
 						Block: TestingDataSourceSchema,
 					},
 				},
+				Functions: map[string]providers.FunctionDecl{
+					"echo": {
+						Parameters: []providers.FunctionParam{
+							{Name: "value", Type: cty.DynamicPseudoType},
+						},
+						ReturnType: cty.DynamicPseudoType,
+					},
+				},
 				ServerCapabilities: providers.ServerCapabilities{
 					MoveResourceState: true,
 				},
@@ -287,6 +295,12 @@ func NewProviderWithData(store *ResourceStore) *MockProvider {
 
 				return providers.MoveResourceStateResponse{
 					TargetState: target,
+				}
+			},
+			CallFunctionFn: func(request providers.CallFunctionRequest) providers.CallFunctionResponse {
+				// Just echo the first argument back as the result.
+				return providers.CallFunctionResponse{
+					Result: request.Arguments[0],
 				}
 			},
 		},


### PR DESCRIPTION
This PR updates the stacks runtime so that cross-provider moves and provider functions start working.

Within Stacks we initialise the providers externally to Terraform Core using the provider configurations from the `.tfstack.hcl` files. These are then provided to Terraform Core in the form of overrides, ensuring that it never attempts to initialise it's own providers internally, instead using the providers controlled by the stacks runtime. 

However, there are some operations within Terraform Core that explicitly require unconfigured clients. These are provider functions and cross-provider move refactorings. This PR updates stacks so that in addition to the configured provider overrides that are provided, we still provide options for Terraform to access unconfigured clients for these alternate operations.

We create our own factories that re-use the shared unconfigured clients that are held within Stacks and used to fetch the initial provider schemas. These are then lazily fetched when Terraform needs to access providers outside the usual lifecycle.