### PR TITLE
Fix typo in local-exec.mdx

### DIFF
--- a/website/docs/language/resources/provisioners/local-exec.mdx
+++ b/website/docs/language/resources/provisioners/local-exec.mdx
@@ -39,7 +39,7 @@ The following arguments are supported:
 
 * `command` - (Required) This is the command to execute. It can be provided
   as a relative path to the current working directory or as an absolute path.
-  The `command` is is evaluated in a shell and can use environment variables for
+  The `command` is evaluated in a shell and can use environment variables for
   variable substitution. We do not recommend using Terraform variables for variable
   substitution because doing so can lead to shell injection vulnerabilities. Instead, you should pass Terraform variables to a command
   through the `environment` parameter and use environment variable substitution


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Fixes #

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.8.x

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

### NEW FEATURES | UPGRADE NOTES | ENHANCEMENTS | BUG FIXES | EXPERIMENTS

<!--

Write a short description of the user-facing change. Examples:

- `terraform show -json`: Fixed crash with sensitive set values.
- When rendering a diff, Terraform now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 

-  
