### PR TITLE
github: Bump BA to 0.4.7 & let it create draft PRs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
   backport:
     if: github.event.pull_request.merged
     runs-on: ubuntu-latest
-    container: hashicorpdev/backport-assistant:0.4.6@sha256:4216e0662085278a6e5b8fd8fbc84fc5e55e598b08a3608b54ba96e81decebcd
+    container: hashicorpdev/backport-assistant:0.4.7@sha256:36f9d4fba82b9454f1f62bf76c8078fafe3ab0be71356cb96af6d56ac4482cd8
     steps:
       - name: Run Backport Assistant
         run: |
@@ -22,4 +22,5 @@ jobs:
         env:
           BACKPORT_LABEL_REGEXP: "(?P<target>\\d+\\.\\d+)-backport"
           BACKPORT_TARGET_TEMPLATE: "v{{.target}}"
+          BACKPORT_CREATE_DRAFT_ALWAYS: true
           GITHUB_TOKEN: ${{ github.token }}


### PR DESCRIPTION
While #35554 helped in re-enabling the backport assistant, it came with a caveat that was unknown until after merging that PR - Checks on PRs opened by `github-actions` bot are not triggered due to GitHub's own limitation to avoid cycles in dependent workflows.

This PR changes the default behaviour of the BA in that it will create _draft PRs_ and then let human users mark it ready for review. As a result, the human will be the triggering user (rather than bot), which bypasses the limitation.
