### PR TITLE
github: Update checks triggers for BA workflow

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -17,6 +17,11 @@ name: Quick Checks
 
 on:
   pull_request:
+    types:
+      - opened
+      - ready_for_review
+      - reopened
+      - synchronize
   push:
     branches:
       - '*'


### PR DESCRIPTION
This is a PR complimenting https://github.com/hashicorp/terraform/pull/35574 by updating the triggers such that whenever a PR is opened against any _release branch_ and it is marked as ready for review (`ready_for_review`), the checks are triggered.

To my knowledge, the current default for `pull_request:` does _not_ include `ready_for_review` but I couldn't find conclusive docs to confirm this, I just could not make it work in a private fork.