### PR TITLE
stacks: add tests for state manipulation failure cases

### DIFF
--- a/internal/stacks/stackruntime/apply_test.go
+++ b/internal/stacks/stackruntime/apply_test.go
@@ -1382,12 +1382,13 @@ func TestApplyWithStateManipulation(t *testing.T) {
 	)
 
 	tcs := map[string]struct {
-		state            *stackstate.State
-		store            *stacks_testing_provider.ResourceStore
-		inputs           map[string]cty.Value
-		changes          []stackstate.AppliedChange
-		counts           collections.Map[stackaddrs.AbsComponentInstance, *hooks.ComponentInstanceChange]
-		expectedWarnings []string
+		state      *stackstate.State
+		store      *stacks_testing_provider.ResourceStore
+		inputs     map[string]cty.Value
+		changes    []stackstate.AppliedChange
+		counts     collections.Map[stackaddrs.AbsComponentInstance, *hooks.ComponentInstanceChange]
+		planDiags  []expectedDiagnostic
+		applyDiags []expectedDiagnostic
 	}{
 		"moved": {
 			state: stackstate.NewStateBuilder().
@@ -1438,6 +1439,72 @@ func TestApplyWithStateManipulation(t *testing.T) {
 					},
 				}),
 		},
+		"moved-failed-dep": {
+			state: stackstate.NewStateBuilder().
+				AddResourceInstance(stackstate.NewResourceInstanceBuilder().
+					SetAddr(mustAbsResourceInstanceObject("component.self.testing_resource.before")).
+					SetProviderAddr(mustDefaultRootProvider("testing")).
+					SetResourceInstanceObjectSrc(states.ResourceInstanceObjectSrc{
+						Status: states.ObjectReady,
+						AttrsJSON: mustMarshalJSONAttrs(map[string]any{
+							"id":    "moved",
+							"value": "moved",
+						}),
+					})).
+				Build(),
+			store: stacks_testing_provider.NewResourceStoreBuilder().
+				AddResource("moved", cty.ObjectVal(map[string]cty.Value{
+					"id":    cty.StringVal("moved"),
+					"value": cty.StringVal("moved"),
+				})).
+				Build(),
+			changes: []stackstate.AppliedChange{
+				&stackstate.AppliedChangeComponentInstance{
+					ComponentAddr:         mustAbsComponent("component.self"),
+					ComponentInstanceAddr: mustAbsComponentInstance("component.self"),
+					OutputValues:          make(map[addrs.OutputValue]cty.Value),
+				},
+				&stackstate.AppliedChangeResourceInstanceObject{
+					ResourceInstanceObjectAddr: mustAbsResourceInstanceObject("component.self.testing_failed_resource.resource"),
+					ProviderConfigAddr:         mustDefaultRootProvider("testing"),
+				},
+				&stackstate.AppliedChangeResourceInstanceObject{
+					ResourceInstanceObjectAddr: mustAbsResourceInstanceObject("component.self.testing_resource.after"),
+					NewStateSrc: &states.ResourceInstanceObjectSrc{
+						AttrsJSON: mustMarshalJSONAttrs(map[string]interface{}{
+							"id":    "moved",
+							"value": "moved",
+						}),
+						Status:             states.ObjectReady,
+						AttrSensitivePaths: make([]cty.Path, 0),
+						Dependencies: []addrs.ConfigResource{
+							{
+								Resource: addrs.Resource{
+									Mode: addrs.ManagedResourceMode,
+									Type: "testing_failed_resource",
+									Name: "resource",
+								},
+							},
+						},
+					},
+					ProviderConfigAddr:                 mustDefaultRootProvider("testing"),
+					PreviousResourceInstanceObjectAddr: mustAbsResourceInstanceObjectPtr("component.self.testing_resource.before"),
+					Schema:                             stacks_testing_provider.TestingResourceSchema,
+				},
+			},
+			counts: collections.NewMap[stackaddrs.AbsComponentInstance, *hooks.ComponentInstanceChange](
+				collections.MapElem[stackaddrs.AbsComponentInstance, *hooks.ComponentInstanceChange]{
+					K: mustAbsComponentInstance("component.self"),
+					V: &hooks.ComponentInstanceChange{
+						Addr: mustAbsComponentInstance("component.self"),
+						Move: 1,
+					},
+				}),
+			applyDiags: []expectedDiagnostic{
+				// This error comes from the testing_failed_resource
+				expectDiagnostic(tfdiags.Error, "planned failure", "apply failure"),
+			},
+		},
 		"import": {
 			state: stackstate.NewStateBuilder().Build(), // We start with an empty state for this.
 			store: stacks_testing_provider.NewResourceStoreBuilder().
@@ -1478,6 +1545,63 @@ func TestApplyWithStateManipulation(t *testing.T) {
 					},
 				}),
 		},
+		"import-failed-dep": {
+			state: stackstate.NewStateBuilder().Build(), // We start with an empty state for this.
+			store: stacks_testing_provider.NewResourceStoreBuilder().
+				AddResource("imported", cty.ObjectVal(map[string]cty.Value{
+					"id":    cty.StringVal("imported"),
+					"value": cty.StringVal("imported"),
+				})).
+				Build(),
+			inputs: map[string]cty.Value{
+				"id": cty.StringVal("imported"),
+			},
+			changes: []stackstate.AppliedChange{
+				&stackstate.AppliedChangeComponentInstance{
+					ComponentAddr:         mustAbsComponent("component.self"),
+					ComponentInstanceAddr: mustAbsComponentInstance("component.self"),
+					OutputValues:          make(map[addrs.OutputValue]cty.Value),
+				},
+				&stackstate.AppliedChangeResourceInstanceObject{
+					ResourceInstanceObjectAddr: mustAbsResourceInstanceObject("component.self.testing_failed_resource.resource"),
+					ProviderConfigAddr:         mustDefaultRootProvider("testing"),
+				},
+				&stackstate.AppliedChangeResourceInstanceObject{
+					ResourceInstanceObjectAddr: mustAbsResourceInstanceObject("component.self.testing_resource.data"),
+					NewStateSrc: &states.ResourceInstanceObjectSrc{
+						AttrsJSON: mustMarshalJSONAttrs(map[string]interface{}{
+							"id":    "imported",
+							"value": "imported",
+						}),
+						Status:             states.ObjectReady,
+						AttrSensitivePaths: make([]cty.Path, 0),
+						Dependencies: []addrs.ConfigResource{
+							{
+								Resource: addrs.Resource{
+									Mode: addrs.ManagedResourceMode,
+									Type: "testing_failed_resource",
+									Name: "resource",
+								},
+							},
+						},
+					},
+					ProviderConfigAddr: mustDefaultRootProvider("testing"),
+					Schema:             stacks_testing_provider.TestingResourceSchema,
+				},
+			},
+			counts: collections.NewMap[stackaddrs.AbsComponentInstance, *hooks.ComponentInstanceChange](
+				collections.MapElem[stackaddrs.AbsComponentInstance, *hooks.ComponentInstanceChange]{
+					K: mustAbsComponentInstance("component.self"),
+					V: &hooks.ComponentInstanceChange{
+						Addr:   mustAbsComponentInstance("component.self"),
+						Import: 1,
+					},
+				}),
+			applyDiags: []expectedDiagnostic{
+				// This error comes from the testing_failed_resource
+				expectDiagnostic(tfdiags.Error, "planned failure", "apply failure"),
+			},
+		},
 		"removed": {
 			state: stackstate.NewStateBuilder().
 				AddResourceInstance(stackstate.NewResourceInstanceBuilder().
@@ -1517,7 +1641,60 @@ func TestApplyWithStateManipulation(t *testing.T) {
 						Forget: 1,
 					},
 				}),
-			expectedWarnings: []string{"Some objects will no longer be managed by Terraform"},
+			planDiags: []expectedDiagnostic{
+				expectDiagnostic(tfdiags.Warning, "Some objects will no longer be managed by Terraform", "If you apply this plan, Terraform will discard its tracking information for the following objects, but it will not delete them:\n - testing_resource.resource\n\nAfter applying this plan, Terraform will no longer manage these objects. You will need to import them into Terraform to manage them again."),
+			},
+		},
+		"removed-failed-dep": {
+			state: stackstate.NewStateBuilder().
+				AddResourceInstance(stackstate.NewResourceInstanceBuilder().
+					SetAddr(mustAbsResourceInstanceObject("component.self.testing_resource.resource")).
+					SetProviderAddr(mustDefaultRootProvider("testing")).
+					SetResourceInstanceObjectSrc(states.ResourceInstanceObjectSrc{
+						Status: states.ObjectReady,
+						AttrsJSON: mustMarshalJSONAttrs(map[string]any{
+							"id":    "removed",
+							"value": "removed",
+						}),
+					})).
+				Build(),
+			store: stacks_testing_provider.NewResourceStoreBuilder().
+				AddResource("removed", cty.ObjectVal(map[string]cty.Value{
+					"id":    cty.StringVal("removed"),
+					"value": cty.StringVal("removed"),
+				})).
+				Build(),
+			changes: []stackstate.AppliedChange{
+				&stackstate.AppliedChangeComponentInstance{
+					ComponentAddr:         mustAbsComponent("component.self"),
+					ComponentInstanceAddr: mustAbsComponentInstance("component.self"),
+					OutputValues:          make(map[addrs.OutputValue]cty.Value),
+				},
+				&stackstate.AppliedChangeResourceInstanceObject{
+					ResourceInstanceObjectAddr: mustAbsResourceInstanceObject("component.self.testing_failed_resource.resource"),
+					ProviderConfigAddr:         mustDefaultRootProvider("testing"),
+				},
+				&stackstate.AppliedChangeResourceInstanceObject{
+					ResourceInstanceObjectAddr: mustAbsResourceInstanceObject("component.self.testing_resource.resource"),
+					NewStateSrc:                nil, // Deleted, so is nil.
+					ProviderConfigAddr:         mustDefaultRootProvider("testing"),
+				},
+			},
+			counts: collections.NewMap[stackaddrs.AbsComponentInstance, *hooks.ComponentInstanceChange](
+				collections.MapElem[stackaddrs.AbsComponentInstance, *hooks.ComponentInstanceChange]{
+					K: mustAbsComponentInstance("component.self"),
+					V: &hooks.ComponentInstanceChange{
+						Addr:   mustAbsComponentInstance("component.self"),
+						Forget: 1,
+					},
+				}),
+			planDiags: []expectedDiagnostic{
+				expectDiagnostic(tfdiags.Warning, "Some objects will no longer be managed by Terraform", "If you apply this plan, Terraform will discard its tracking information for the following objects, but it will not delete them:\n - testing_resource.resource\n\nAfter applying this plan, Terraform will no longer manage these objects. You will need to import them into Terraform to manage them again."),
+			},
+			applyDiags: []expectedDiagnostic{
+				// This error comes from the testing_failed_resource
+				expectDiagnostic(tfdiags.Error, "planned failure", "apply failure"),
+			},
 		},
 		"deferred": {
 			store: stacks_testing_provider.NewResourceStoreBuilder().
@@ -1608,19 +1785,9 @@ func TestApplyWithStateManipulation(t *testing.T) {
 			}
 			go Plan(ctx, &planReq, &planResp)
 			planChanges, diags := collectPlanOutput(planChangeCh, diagsCh)
-			reportDiagnosticsForTest(t, diags)
-			if diags.HasErrors() {
-				// we reported the diagnostics above, so we can just fail now
-				t.FailNow()
-			}
-			if len(diags) > len(tc.expectedWarnings) {
-				t.Fatalf("had unexpected warnings")
-			}
-			for i, diag := range diags {
-				if diag.Description().Summary != tc.expectedWarnings[i] {
-					t.Fatalf("expected diagnostic with summary %q, got %q", tc.expectedWarnings[i], diag.Description().Summary)
-				}
-			}
+
+			sort.SliceStable(diags, diagnosticSortFunc(diags))
+			expectDiagnosticsForTest(t, diags, tc.planDiags...)
 
 			// Check the counts during the apply for this test.
 			gotCounts := collections.NewMap[stackaddrs.AbsComponentInstance, *hooks.ComponentInstanceChange]()
@@ -1665,14 +1832,9 @@ func TestApplyWithStateManipulation(t *testing.T) {
 
 			go Apply(ctx, &applyReq, &applyResp)
 			applyChanges, diags := collectApplyOutput(applyChangesCh, diagsCh)
-			reportDiagnosticsForTest(t, diags)
-			if diags.HasErrors() {
-				// we reported the diagnostics above, so we can just fail now
-				t.FailNow()
-			}
-			if len(diags) > 0 {
-				t.Fatalf("expected no diagnostics, got %s", diags.ErrWithWarnings())
-			}
+
+			sort.SliceStable(diags, diagnosticSortFunc(diags))
+			expectDiagnosticsForTest(t, diags, tc.applyDiags...)
 
 			sort.SliceStable(applyChanges, func(i, j int) bool {
 				return appliedChangeSortKey(applyChanges[i]) < appliedChangeSortKey(applyChanges[j])

--- a/internal/stacks/stackruntime/internal/stackeval/component_instance.go
+++ b/internal/stacks/stackruntime/internal/stackeval/component_instance.go
@@ -921,7 +921,7 @@ func (c *ComponentInstance) ApplyModuleTreePlan(ctx context.Context, plan *plans
 			cic.CountNewAction(action)
 		}
 
-		// The state management actions (create, import, forget) don't emit
+		// The state management actions (move, import, forget) don't emit
 		// actions during an apply so they're not being counted by looking
 		// at the ResourceInstanceObjectAppliedAction above.
 		//

--- a/internal/stacks/stackruntime/testdata/mainbundle/test/state-manipulation/import-failed-dep/import.tf
+++ b/internal/stacks/stackruntime/testdata/mainbundle/test/state-manipulation/import-failed-dep/import.tf
@@ -11,6 +11,10 @@ variable "id" {
   type = string
 }
 
+resource "testing_failed_resource" "resource" {
+  fail_apply = true
+}
+
 import {
   to = testing_resource.data
   id = var.id
@@ -19,4 +23,6 @@ import {
 resource "testing_resource" "data" {
   id = var.id
   value = "imported"
+
+  depends_on = [testing_failed_resource.resource]
 }

--- a/internal/stacks/stackruntime/testdata/mainbundle/test/state-manipulation/import-failed-dep/import.tfstack.hcl
+++ b/internal/stacks/stackruntime/testdata/mainbundle/test/state-manipulation/import-failed-dep/import.tfstack.hcl
@@ -1,0 +1,24 @@
+required_providers {
+  testing = {
+    source  = "hashicorp/testing"
+    version = "0.1.0"
+  }
+}
+
+provider "testing" "default" {}
+
+variable "id" {
+  type = string
+}
+
+component "self" {
+  source = "./"
+
+  providers = {
+    testing = provider.testing.default
+  }
+
+  inputs = {
+    id = var.id
+  }
+}

--- a/internal/stacks/stackruntime/testdata/mainbundle/test/state-manipulation/moved-failed-dep/moved.tf
+++ b/internal/stacks/stackruntime/testdata/mainbundle/test/state-manipulation/moved-failed-dep/moved.tf
@@ -1,0 +1,24 @@
+terraform {
+  required_providers {
+    testing = {
+      source  = "hashicorp/testing"
+      version = "0.1.0"
+    }
+  }
+}
+
+resource "testing_failed_resource" "resource" {
+  fail_apply = true
+}
+
+moved {
+  from = testing_resource.before
+  to   = testing_resource.after
+}
+
+resource "testing_resource" "after" {
+  id = "moved"
+  value = "moved"
+
+  depends_on = [testing_failed_resource.resource]
+}

--- a/internal/stacks/stackruntime/testdata/mainbundle/test/state-manipulation/moved-failed-dep/moved.tfstack.hcl
+++ b/internal/stacks/stackruntime/testdata/mainbundle/test/state-manipulation/moved-failed-dep/moved.tfstack.hcl
@@ -1,0 +1,16 @@
+required_providers {
+  testing = {
+    source  = "hashicorp/testing"
+    version = "0.1.0"
+  }
+}
+
+provider "testing" "default" {}
+
+component "self" {
+  source = "./"
+
+  providers = {
+    testing = provider.testing.default
+  }
+}

--- a/internal/stacks/stackruntime/testdata/mainbundle/test/state-manipulation/removed-failed-dep/removed.tf
+++ b/internal/stacks/stackruntime/testdata/mainbundle/test/state-manipulation/removed-failed-dep/removed.tf
@@ -1,0 +1,20 @@
+terraform {
+  required_providers {
+    testing = {
+      source  = "hashicorp/testing"
+      version = "0.1.0"
+    }
+  }
+}
+
+resource "testing_failed_resource" "resource" {
+  fail_apply = true
+}
+
+removed {
+  from = testing_resource.resource
+
+  lifecycle {
+    destroy = false
+  }
+}

--- a/internal/stacks/stackruntime/testdata/mainbundle/test/state-manipulation/removed-failed-dep/removed.tfstack.hcl
+++ b/internal/stacks/stackruntime/testdata/mainbundle/test/state-manipulation/removed-failed-dep/removed.tfstack.hcl
@@ -1,0 +1,16 @@
+required_providers {
+  testing = {
+    source  = "hashicorp/testing"
+    version = "0.1.0"
+  }
+}
+
+provider "testing" "default" {}
+
+component "self" {
+  source = "./"
+
+  providers = {
+    testing = provider.testing.default
+  }
+}


### PR DESCRIPTION
This PR adds extra tests around the state manipulation functions. The new states verify the correct state and counts are still emitted by the API when an error occurs during applying but after the state manipulation operations have already happened.

Everything worked as expected so there's only changes to the tests in here.