### PR TITLE
Fix #32601 Update Set data type description

### DIFF
--- a/website/docs/language/expressions/types.mdx
+++ b/website/docs/language/expressions/types.mdx
@@ -81,7 +81,7 @@ require a comma between values. A comma after the final value is allowed,
 but not required. Values in a list can be arbitrary expressions.
 ### Sets
 
-Accessing elements of a set directly by index is not supported because sets are unordered collections. However, you can convert a set to a list to access elements by index.
+Terraform does not support directly accessing elements of a set by index because sets are unordered collections. To access elements in a set by index, first convert the set to a list.
 
 Example: Accessing Elements of a Set
 

--- a/website/docs/language/expressions/types.mdx
+++ b/website/docs/language/expressions/types.mdx
@@ -79,6 +79,7 @@ comma-separated sequence of values, like `["a", 15, true]`.
 List literals can be split into multiple lines for readability, but always
 require a comma between values. A comma after the final value is allowed,
 but not required. Values in a list can be arbitrary expressions.
+
 ### Sets
 
 Terraform does not support directly accessing elements of a set by index because sets are unordered collections. To access elements in a set by index, first convert the set to a list.

--- a/website/docs/language/expressions/types.mdx
+++ b/website/docs/language/expressions/types.mdx
@@ -79,6 +79,35 @@ comma-separated sequence of values, like `["a", 15, true]`.
 List literals can be split into multiple lines for readability, but always
 require a comma between values. A comma after the final value is allowed,
 but not required. Values in a list can be arbitrary expressions.
+### Sets
+
+Accessing elements of a set directly by index is not supported because sets are unordered collections. However, you can convert a set to a list to access elements by index.
+
+Example: Accessing Elements of a Set
+
+1. Define a Set:
+```hcl
+variable "example_set" {
+type    = set(string)
+default = ["foo", "bar"]
+}
+```
+3. Convert Set to List: 
+```hcl
+locals {
+  example_list = tolist(var.example_set)
+}
+```
+
+5. Access Elements by Index:
+```hcl
+output "first_element" {
+  value = local.example_list[0]
+}
+output "second_element" {
+  value = local.example_list[1]
+}
+```
 
 ### Maps/Objects
 

--- a/website/docs/language/expressions/types.mdx
+++ b/website/docs/language/expressions/types.mdx
@@ -86,7 +86,7 @@ Terraform does not support directly accessing elements of a set by index because
 
 1. Define a set. The following example specifies a set name `example_set`:
 
-        ```hcl
+    ```hcl
     variable "example_set" {
       type    = set(string)
       default = ["foo", "bar"]

--- a/website/docs/language/expressions/types.mdx
+++ b/website/docs/language/expressions/types.mdx
@@ -83,31 +83,34 @@ but not required. Values in a list can be arbitrary expressions.
 
 Terraform does not support directly accessing elements of a set by index because sets are unordered collections. To access elements in a set by index, first convert the set to a list.
 
-Example: Accessing Elements of a Set
 
-1. Define a Set:
-```hcl
-variable "example_set" {
-type    = set(string)
-default = ["foo", "bar"]
-}
-```
-3. Convert Set to List: 
-```hcl
-locals {
-  example_list = tolist(var.example_set)
-}
-```
+1. Define a set. The following example specifies a set name `example_set`:
 
-5. Access Elements by Index:
-```hcl
-output "first_element" {
-  value = local.example_list[0]
-}
-output "second_element" {
-  value = local.example_list[1]
-}
-```
+        ```hcl
+    variable "example_set" {
+      type    = set(string)
+      default = ["foo", "bar"]
+    }
+    ```
+
+1. Use the `tolist` function to convert the set to a list. The following example stores the converted list as a local variable called `example_list`: 
+
+    ```hcl
+    locals {
+      example_list = tolist(var.example_set)
+    }
+    ```
+
+1. You can then reference an element in the list:
+
+    ```hcl
+    output "first_element" {
+      value = local.example_list[0]
+    }
+    output "second_element" {
+      value = local.example_list[1]
+    }
+    ```
 
 ### Maps/Objects
 


### PR DESCRIPTION
Update Set data type description

<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Fixes #32601

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.8.x

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

### NEW FEATURES | UPGRADE NOTES | ENHANCEMENTS | BUG FIXES | EXPERIMENTS

<!--

Write a short description of the user-facing change. Examples:

- `terraform show -json`: Fixed crash with sensitive set values.
- When rendering a diff, Terraform now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 

-  
