### PR TITLE
Make it easier to find literal planning options from apply page

### DIFF
--- a/website/docs/cli/commands/apply.mdx
+++ b/website/docs/cli/commands/apply.mdx
@@ -41,8 +41,8 @@ decisions.
 
 Without a saved plan file, `terraform apply` supports all planning modes and planning options available for `terraform plan`.
 
--  **[Planning Modes](/terraform/cli/commands/plan#planning-modes):** These include `-destroy`, which creates a plan to destroy all remote objects, and `-refresh-only`, which creates a plan to update Terraform state and root module output values.
-- **[Planning Options](/terraform/cli/commands/plan#planning-options):** These include specifying which resource instances Terraform should replace, setting Terraform input variables, etc.
+- **[Planning Modes](/terraform/cli/commands/plan#planning-modes):** These include `-destroy`, which creates a plan to destroy all remote objects, and `-refresh-only`, which creates a plan to update Terraform state and root module output values.
+- **[Planning Options](/terraform/cli/commands/plan#planning-options):** These include specifying which resource instances Terraform should replace (`-replace`), setting Terraform input variables (`-var` and `-var-file`), etc.
 
 ### Apply Options
 


### PR DESCRIPTION
Fixes #29268 

We link to the planning options from the apply page (since apply runs an "automatic plan") but don't make it easy to find common planning options that are mentioned using ctrl-f

## Target Release

1.10.0

