### PR TITLE
Docs Day: Update `indent` function reference

### DIFF
--- a/website/docs/language/functions/indent.mdx
+++ b/website/docs/language/functions/indent.mdx
@@ -23,14 +23,13 @@ Use the `indent` function with the following syntax:
 indent(num_spaces, string)
 ```
 
-- The first argument is numeric.
-It specifies the number of spaces you want to add to each line except the first.
-- The second argument is a string.
-It specifies the multi-line string to which you want to add spaces.
+- The first argument is numeric. It specifies the number of spaces you want to add to each line except the first.
+- The second argument is a string. It specifies the multi-line string to which you want to add spaces.
 
-In the following example, the `indent` function adds two spaces to the beginning of each line of the `json_config` variable to make it easier to read:
+In the following example, the `indent` function adds two spaces to the beginning of each line of the `description` variable to make it easier to read:
 
 ```hcl
-output "formatted_json" {
-  value = indent(2,var.json_config)
+output "formatted_description" {
+  value = indent(2, var.description)
 }
+```

--- a/website/docs/language/functions/indent.mdx
+++ b/website/docs/language/functions/indent.mdx
@@ -1,31 +1,36 @@
 ---
 page_title: indent - Functions - Configuration Language
 description: |-
-  The indent function adds a number of spaces to the beginnings of all but the
-  first line of a given multi-line string.
+  The indent function adds spaces to the beginning of each line but the first in a multi-line string.
 ---
 
-# `indent` Function
+# `indent` function reference
 
-`indent` adds a given number of spaces to the beginnings of all but the first
-line in a given multi-line string.
+This topic provides reference information about the `indent` function.
+You can use the `indent` function to add indentation to the beginning of each line, except the first, in a multi-line string.
+
+## Introduction
+
+The `indent` function adds a specified number of spaces to the beginning of each line in a multi-line string, except for the first line.
+You can use the `indent` function to help ensure that complex strings are properly formatted, consistent, and readable.
+The function can be especially useful when you work with YAML, JSON, Kubernetes, or other formats that require complex, structured text.
+
+## Syntax
+
+Use the `indent` function with the following syntax:
 
 ```hcl
 indent(num_spaces, string)
 ```
 
-## Examples
+- The first argument is numeric.
+It specifies the number of spaces you want to add to each line except the first.
+- The second argument is a string.
+It specifies the multi-line string to which you want to add spaces.
 
-This function is useful for inserting a multi-line string into an
-already-indented context in another string:
+In the following example, the `indent` function adds two spaces to the beginning of each line of the `json_config` variable to make it easier to read:
 
-```
-> "  items: ${indent(2, "[\n  foo,\n  bar,\n]\n")}"
-  items: [
-    foo,
-    bar,
-  ]
-```
-
-The first line of the string is not indented so that, as above, it can be
-placed after an introduction sequence that has already begun the line.
+```hcl
+output "formatted_json" {
+  value = indent(2,var.json_config)
+}


### PR DESCRIPTION
This was a Docs Day project as listed in the task spreadsheet.

I updated the existing topic to be in the new format of the templatestring function reference [document](https://terraform-rmt1u78ff-hashicorp.vercel.app/terraform/language/functions/templatestring). Added the following new sections:

- Introduction
- Syntax

I worked with Tu and Brian, and we couldn't think of an Example use case. If anyone has an idea, it might be nice to add to this topic :) I deleted the existing example b/c I thought it was difficult to understand, but you could also bring that back.

Please let me know if you have any questions or if there's anything that I can do to help finish this up.

[Deploy Preview](https://terraform-git-fork-dan-heath-patch-2-hashicorp.vercel.app/terraform/language/functions/indent)
