### PR TITLE
stacks: fix suggested command when lock file is out of date

### DIFF
--- a/internal/stacks/stackruntime/internal/stackeval/provider_config.go
+++ b/internal/stacks/stackruntime/internal/stackeval/provider_config.go
@@ -91,7 +91,7 @@ func CheckProviderInLockfile(locks depsfile.Locks, providerType *ProviderType, d
 			Severity: hcl.DiagError,
 			Summary:  "Provider missing from lockfile",
 			Detail: fmt.Sprintf(
-				"Provider %q is not in the lockfile. This provider must be in the lockfile to be used in the configuration. Please run `tfstacks provider lock` to update the lockfile and run this operation again with an updated configuration.",
+				"Provider %q is not in the lockfile. This provider must be in the lockfile to be used in the configuration. Please run `tfstacks providers lock` to update the lockfile and run this operation again with an updated configuration.",
 				providerType.Addr(),
 			),
 			Subject: declRange.ToHCL().Ptr(),

--- a/internal/stacks/stackruntime/validate_test.go
+++ b/internal/stacks/stackruntime/validate_test.go
@@ -486,7 +486,7 @@ func TestValidate_missing_provider_from_lockfile(t *testing.T) {
 		t.Fatalf("expected diagnostic summary 'Provider missing from lockfile', got %q", diag.Description().Summary)
 	}
 
-	if diag.Description().Detail != "Provider \"registry.terraform.io/hashicorp/testing\" is not in the lockfile. This provider must be in the lockfile to be used in the configuration. Please run `tfstacks provider lock` to update the lockfile and run this operation again with an updated configuration." {
+	if diag.Description().Detail != "Provider \"registry.terraform.io/hashicorp/testing\" is not in the lockfile. This provider must be in the lockfile to be used in the configuration. Please run `tfstacks providers lock` to update the lockfile and run this operation again with an updated configuration." {
 		t.Fatalf("expected diagnostic detail to be a specific message, got %q", diag.Description().Detail)
 	}
 }


### PR DESCRIPTION
Quick fix on the error message we print when recommending users to run `tfstacks providers lock`.