### PR TITLE
initwd: Allow language experiment enablement in tests

### DIFF
--- a/internal/backend/local/backend_local_test.go
+++ b/internal/backend/local/backend_local_test.go
@@ -34,7 +34,7 @@ func TestLocalRun(t *testing.T) {
 	configDir := "./testdata/empty"
 	b := TestLocal(t)
 
-	_, configLoader, configCleanup := initwd.MustLoadConfigForTests(t, configDir, "tests")
+	_, configLoader, configCleanup := initwd.MustLoadConfigForTests(t, configDir, "tests", false)
 	defer configCleanup()
 
 	streams, _ := terminal.StreamsForTesting(t)
@@ -65,7 +65,7 @@ func TestLocalRun_error(t *testing.T) {
 	// should then cause LocalRun to return with the state unlocked.
 	b.Backend = backendWithStateStorageThatFailsRefresh{}
 
-	_, configLoader, configCleanup := initwd.MustLoadConfigForTests(t, configDir, "tests")
+	_, configLoader, configCleanup := initwd.MustLoadConfigForTests(t, configDir, "tests", false)
 	defer configCleanup()
 
 	streams, _ := terminal.StreamsForTesting(t)
@@ -92,7 +92,7 @@ func TestLocalRun_cloudPlan(t *testing.T) {
 	configDir := "./testdata/apply"
 	b := TestLocal(t)
 
-	_, configLoader, configCleanup := initwd.MustLoadConfigForTests(t, configDir, "tests")
+	_, configLoader, configCleanup := initwd.MustLoadConfigForTests(t, configDir, "tests", false)
 	defer configCleanup()
 
 	planPath := "./testdata/plan-bookmark/bookmark.json"
@@ -127,7 +127,7 @@ func TestLocalRun_stalePlan(t *testing.T) {
 	configDir := "./testdata/apply"
 	b := TestLocal(t)
 
-	_, configLoader, configCleanup := initwd.MustLoadConfigForTests(t, configDir, "tests")
+	_, configLoader, configCleanup := initwd.MustLoadConfigForTests(t, configDir, "tests", false)
 	defer configCleanup()
 
 	// Write an empty state file with serial 3

--- a/internal/backend/local/backend_plan_test.go
+++ b/internal/backend/local/backend_plan_test.go
@@ -717,7 +717,7 @@ func TestLocal_planOutPathNoChange(t *testing.T) {
 func testOperationPlan(t *testing.T, configDir string) (*backendrun.Operation, func(), func(*testing.T) *terminal.TestOutput) {
 	t.Helper()
 
-	_, configLoader, configCleanup := initwd.MustLoadConfigForTests(t, configDir, "tests")
+	_, configLoader, configCleanup := initwd.MustLoadConfigForTests(t, configDir, "tests", false)
 
 	streams, done := terminal.StreamsForTesting(t)
 	view := views.NewOperation(arguments.ViewHuman, false, views.NewView(streams))

--- a/internal/backend/local/backend_refresh_test.go
+++ b/internal/backend/local/backend_refresh_test.go
@@ -267,7 +267,7 @@ func TestLocal_refreshEmptyState(t *testing.T) {
 func testOperationRefresh(t *testing.T, configDir string) (*backendrun.Operation, func(), func(*testing.T) *terminal.TestOutput) {
 	t.Helper()
 
-	_, configLoader, configCleanup := initwd.MustLoadConfigForTests(t, configDir, "tests")
+	_, configLoader, configCleanup := initwd.MustLoadConfigForTests(t, configDir, "tests", false)
 
 	streams, done := terminal.StreamsForTesting(t)
 	view := views.NewOperation(arguments.ViewHuman, false, views.NewView(streams))

--- a/internal/backend/remote/backend_apply_test.go
+++ b/internal/backend/remote/backend_apply_test.go
@@ -43,7 +43,7 @@ func testOperationApply(t *testing.T, configDir string) (*backendrun.Operation, 
 func testOperationApplyWithTimeout(t *testing.T, configDir string, timeout time.Duration) (*backendrun.Operation, func(), func(*testing.T) *terminal.TestOutput) {
 	t.Helper()
 
-	_, configLoader, configCleanup := initwd.MustLoadConfigForTests(t, configDir, "tests")
+	_, configLoader, configCleanup := initwd.MustLoadConfigForTests(t, configDir, "tests", false)
 
 	streams, done := terminal.StreamsForTesting(t)
 	view := views.NewView(streams)

--- a/internal/backend/remote/backend_context_test.go
+++ b/internal/backend/remote/backend_context_test.go
@@ -187,7 +187,7 @@ func TestRemoteContextWithVars(t *testing.T) {
 			b, bCleanup := testBackendDefault(t)
 			defer bCleanup()
 
-			_, configLoader, configCleanup := initwd.MustLoadConfigForTests(t, configDir, "tests")
+			_, configLoader, configCleanup := initwd.MustLoadConfigForTests(t, configDir, "tests", false)
 			defer configCleanup()
 
 			workspaceID, err := b.getRemoteWorkspaceID(context.Background(), backend.DefaultStateName)
@@ -410,7 +410,7 @@ func TestRemoteVariablesDoNotOverride(t *testing.T) {
 			b, bCleanup := testBackendDefault(t)
 			defer bCleanup()
 
-			_, configLoader, configCleanup := initwd.MustLoadConfigForTests(t, configDir, "tests")
+			_, configLoader, configCleanup := initwd.MustLoadConfigForTests(t, configDir, "tests", false)
 			defer configCleanup()
 
 			workspaceID, err := b.getRemoteWorkspaceID(context.Background(), backend.DefaultStateName)

--- a/internal/backend/remote/backend_plan_test.go
+++ b/internal/backend/remote/backend_plan_test.go
@@ -41,7 +41,7 @@ func testOperationPlan(t *testing.T, configDir string) (*backendrun.Operation, f
 func testOperationPlanWithTimeout(t *testing.T, configDir string, timeout time.Duration) (*backendrun.Operation, func(), func(*testing.T) *terminal.TestOutput) {
 	t.Helper()
 
-	_, configLoader, configCleanup := initwd.MustLoadConfigForTests(t, configDir, "tests")
+	_, configLoader, configCleanup := initwd.MustLoadConfigForTests(t, configDir, "tests", false)
 
 	streams, done := terminal.StreamsForTesting(t)
 	view := views.NewView(streams)

--- a/internal/cloud/backend_apply_test.go
+++ b/internal/cloud/backend_apply_test.go
@@ -46,7 +46,7 @@ func testOperationApply(t *testing.T, configDir string) (*backendrun.Operation, 
 func testOperationApplyWithTimeout(t *testing.T, configDir string, timeout time.Duration) (*backendrun.Operation, func(), func(*testing.T) *terminal.TestOutput) {
 	t.Helper()
 
-	_, configLoader, configCleanup := initwd.MustLoadConfigForTests(t, configDir, "tests")
+	_, configLoader, configCleanup := initwd.MustLoadConfigForTests(t, configDir, "tests", false)
 
 	streams, done := terminal.StreamsForTesting(t)
 	view := views.NewView(streams)

--- a/internal/cloud/backend_context_test.go
+++ b/internal/cloud/backend_context_test.go
@@ -186,7 +186,7 @@ func TestRemoteContextWithVars(t *testing.T) {
 			b, bCleanup := testBackendWithName(t)
 			defer bCleanup()
 
-			_, configLoader, configCleanup := initwd.MustLoadConfigForTests(t, configDir, "tests")
+			_, configLoader, configCleanup := initwd.MustLoadConfigForTests(t, configDir, "tests", false)
 			defer configCleanup()
 
 			workspaceID, err := b.getRemoteWorkspaceID(context.Background(), testBackendSingleWorkspaceName)
@@ -409,7 +409,7 @@ func TestRemoteVariablesDoNotOverride(t *testing.T) {
 			b, bCleanup := testBackendWithName(t)
 			defer bCleanup()
 
-			_, configLoader, configCleanup := initwd.MustLoadConfigForTests(t, configDir, "tests")
+			_, configLoader, configCleanup := initwd.MustLoadConfigForTests(t, configDir, "tests", false)
 			defer configCleanup()
 
 			workspaceID, err := b.getRemoteWorkspaceID(context.Background(), testBackendSingleWorkspaceName)

--- a/internal/cloud/backend_plan_test.go
+++ b/internal/cloud/backend_plan_test.go
@@ -43,7 +43,7 @@ func testOperationPlan(t *testing.T, configDir string) (*backendrun.Operation, f
 func testOperationPlanWithTimeout(t *testing.T, configDir string, timeout time.Duration) (*backendrun.Operation, func(), func(*testing.T) *terminal.TestOutput) {
 	t.Helper()
 
-	_, configLoader, configCleanup := initwd.MustLoadConfigForTests(t, configDir, "tests")
+	_, configLoader, configCleanup := initwd.MustLoadConfigForTests(t, configDir, "tests", false)
 
 	streams, done := terminal.StreamsForTesting(t)
 	view := views.NewView(streams)

--- a/internal/cloud/backend_refresh_test.go
+++ b/internal/cloud/backend_refresh_test.go
@@ -30,7 +30,7 @@ func testOperationRefresh(t *testing.T, configDir string) (*backendrun.Operation
 func testOperationRefreshWithTimeout(t *testing.T, configDir string, timeout time.Duration) (*backendrun.Operation, func(), func(*testing.T) *terminal.TestOutput) {
 	t.Helper()
 
-	_, configLoader, configCleanup := initwd.MustLoadConfigForTests(t, configDir, "tests")
+	_, configLoader, configCleanup := initwd.MustLoadConfigForTests(t, configDir, "tests", false)
 
 	streams, done := terminal.StreamsForTesting(t)
 	view := views.NewView(streams)

--- a/internal/command/views/show_test.go
+++ b/internal/command/views/show_test.go
@@ -169,7 +169,7 @@ func TestShowJSON(t *testing.T) {
 		},
 	}
 
-	config, _, configCleanup := initwd.MustLoadConfigForTests(t, "./testdata/show", "tests")
+	config, _, configCleanup := initwd.MustLoadConfigForTests(t, "./testdata/show", "tests", false)
 	defer configCleanup()
 
 	for name, testCase := range testCases {

--- a/internal/initwd/testing.go
+++ b/internal/initwd/testing.go
@@ -31,12 +31,14 @@ import (
 // As with NewLoaderForTests, a cleanup function is returned which must be
 // called before the test completes in order to remove the temporary
 // modules directory.
-func LoadConfigForTests(t *testing.T, rootDir string, testsDir string) (*configs.Config, *configload.Loader, func(), tfdiags.Diagnostics) {
+func LoadConfigForTests(t *testing.T, rootDir string, testsDir string, allowExp bool) (*configs.Config, *configload.Loader, func(), tfdiags.Diagnostics) {
 	t.Helper()
 
 	var diags tfdiags.Diagnostics
 
 	loader, cleanup := configload.NewLoaderForTests(t)
+	loader.AllowLanguageExperiments(allowExp)
+
 	inst := NewModuleInstaller(loader.ModulesDir(), loader, registry.NewClient(nil, nil))
 
 	_, moreDiags := inst.InstallModules(context.Background(), rootDir, testsDir, true, false, ModuleInstallHooksImpl{})
@@ -65,10 +67,10 @@ func LoadConfigForTests(t *testing.T, rootDir string, testsDir string) (*configs
 // This is useful for concisely writing tests that don't expect errors at
 // all. For tests that expect errors and need to assert against them, use
 // LoadConfigForTests instead.
-func MustLoadConfigForTests(t *testing.T, rootDir, testsDir string) (*configs.Config, *configload.Loader, func()) {
+func MustLoadConfigForTests(t *testing.T, rootDir, testsDir string, allowExp bool) (*configs.Config, *configload.Loader, func()) {
 	t.Helper()
 
-	config, loader, cleanup, diags := LoadConfigForTests(t, rootDir, testsDir)
+	config, loader, cleanup, diags := LoadConfigForTests(t, rootDir, testsDir, allowExp)
 	if diags.HasErrors() {
 		cleanup()
 		t.Fatal(diags.Err())

--- a/internal/repl/session_test.go
+++ b/internal/repl/session_test.go
@@ -275,7 +275,7 @@ func testSession(t *testing.T, test testSessionTest) {
 		},
 	}
 
-	config, _, cleanup, configDiags := initwd.LoadConfigForTests(t, "testdata/config-fixture", "tests")
+	config, _, cleanup, configDiags := initwd.LoadConfigForTests(t, "testdata/config-fixture", "tests", false)
 	defer cleanup()
 	if configDiags.HasErrors() {
 		t.Fatalf("unexpected problems loading config: %s", configDiags.Err())


### PR DESCRIPTION
I don't particularly like the idea of a third argument but aside from swapping the 3 args for 1 struct argument I can't think of a better solution.

We will to be able to test ephemeral values beyond just config parsing, ideally without taking them out of experimental phase.

Some other tests [I found](https://github.com/hashicorp/terraform/blob/7660d8d0860c5c29617025aec1a2cd94d002afbc/internal/configs/parser_config_test.go#L202-L204) handle this problem by scanning first line of a config file but outside of simple parser tests it would be difficult if the expectation was that there's always a single file as majority of the higher-level APIs assume directories of config files.