### PR TITLE
stacks: ensure providers that should not be configured cannot be

### DIFF
--- a/internal/stacks/stackruntime/internal/stackeval/component_config.go
+++ b/internal/stacks/stackruntime/internal/stackeval/component_config.go
@@ -26,6 +26,7 @@ import (
 	"github.com/hashicorp/terraform/internal/stacks/stackconfig"
 	"github.com/hashicorp/terraform/internal/stacks/stackconfig/stackconfigtypes"
 	"github.com/hashicorp/terraform/internal/stacks/stackplan"
+	"github.com/hashicorp/terraform/internal/stacks/stackruntime/internal/stackeval/stubs"
 	"github.com/hashicorp/terraform/internal/terraform"
 	"github.com/hashicorp/terraform/internal/tfdiags"
 )
@@ -544,7 +545,12 @@ func (c *ComponentConfig) checkValid(ctx context.Context, phase EvalPhase) tfdia
 			providerFactories[addr] = func() (providers.Interface, error) {
 				// Lazily fetch the unconfigured client for the provider
 				// as and when we need it.
-				return c.main.ProviderType(ctx, addr).UnconfiguredClient(ctx)
+				provider, err := c.main.ProviderType(ctx, addr).UnconfiguredClient(ctx)
+				if err != nil {
+					return nil, err
+				}
+				// this provider should only be used for selected operations
+				return stubs.OfflineProvider(provider), nil
 			}
 		}
 

--- a/internal/stacks/stackruntime/internal/stackeval/component_instance.go
+++ b/internal/stacks/stackruntime/internal/stackeval/component_instance.go
@@ -559,7 +559,12 @@ func (c *ComponentInstance) CheckModuleTreePlan(ctx context.Context) (*plans.Pla
 				providerFactories[addr] = func() (providers.Interface, error) {
 					// Lazily fetch the unconfigured client for the provider
 					// as and when we need it.
-					return c.main.ProviderType(ctx, addr).UnconfiguredClient(ctx)
+					provider, err := c.main.ProviderType(ctx, addr).UnconfiguredClient(ctx)
+					if err != nil {
+						return nil, err
+					}
+					// this provider should only be used for selected operations
+					return stubs.OfflineProvider(provider), nil
 				}
 			}
 
@@ -814,7 +819,12 @@ func (c *ComponentInstance) ApplyModuleTreePlan(ctx context.Context, plan *plans
 		providerFactories[addr] = func() (providers.Interface, error) {
 			// Lazily fetch the unconfigured client for the provider
 			// as and when we need it.
-			return c.main.ProviderType(ctx, addr).UnconfiguredClient(ctx)
+			provider, err := c.main.ProviderType(ctx, addr).UnconfiguredClient(ctx)
+			if err != nil {
+				return nil, err
+			}
+			// this provider should only be used for selected operations
+			return stubs.OfflineProvider(provider), nil
 		}
 	}
 

--- a/internal/stacks/stackruntime/internal/stackeval/provider_factory.go
+++ b/internal/stacks/stackruntime/internal/stackeval/provider_factory.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/providers"
+	"github.com/hashicorp/terraform/internal/tfdiags"
 )
 
 // ProviderFactories is a collection of factory functions for starting new
@@ -174,4 +175,20 @@ var _ providers.Interface = providerClose{}
 
 func (p providerClose) Close() error {
 	return p.close()
+}
+
+func (p providerClose) ConfigureProvider(request providers.ConfigureProviderRequest) providers.ConfigureProviderResponse {
+	// the real provider should either already have been configured by the time
+	// we get here or should never get configured, so we should never see this
+	// method called.
+	return providers.ConfigureProviderResponse{
+		Diagnostics: tfdiags.Diagnostics{
+			tfdiags.AttributeValue(
+				tfdiags.Error,
+				"Called ConfigureProvider on an unconfigurable provider",
+				"This provider should have already been configured, or should never be configured. This is a bug in Terraform - please report it.",
+				nil, // nil attribute path means the overall configuration block
+			),
+		},
+	}
 }

--- a/internal/stacks/stackruntime/internal/stackeval/provider_instance.go
+++ b/internal/stacks/stackruntime/internal/stackeval/provider_instance.go
@@ -197,7 +197,7 @@ func (p *ProviderInstance) CheckClient(ctx context.Context, phase EvalPhase) (pr
 					),
 					Subject: decl.DeclRange.ToHCL().Ptr(),
 				})
-				return &stubs.ErroredProvider{}, diags
+				return stubs.ErroredProvider(), diags
 			}
 
 			// If the context we recieved gets cancelled then we want providers
@@ -265,7 +265,7 @@ func (p *ProviderInstance) CheckClient(ctx context.Context, phase EvalPhase) (pr
 				// stub instead. (The real provider stays running until it
 				// gets cleaned up by the cleanup function above, despite being
 				// inaccessible to the caller.)
-				return &stubs.ErroredProvider{}, diags
+				return stubs.ErroredProvider(), diags
 			}
 
 			return providerClose{

--- a/internal/stacks/stackruntime/internal/stackeval/stubs/errored.go
+++ b/internal/stacks/stackruntime/internal/stackeval/stubs/errored.go
@@ -4,22 +4,26 @@
 package stubs
 
 import (
+	"fmt"
+
 	"github.com/hashicorp/terraform/internal/providers"
 	"github.com/hashicorp/terraform/internal/tfdiags"
 )
 
-// ErroredProvider is a stub provider that is used in place of a provider that
-// failed the configuration step. This provider will return an error for all
-// operations that would have otherwise caused side-effects or modified the
-// plan.
-type ErroredProvider struct {
-	failedProvider providers.Interface
+// erroredProvider is a stub provider that is used in place of a provider that
+// failed the configuration step. Within the context of Stacks, an errored
+// provider would have been configured by Stacks, and therefore should not be
+// configured again, or used for any offline functionality.
+type erroredProvider struct{}
+
+var _ providers.Interface = &erroredProvider{}
+
+func ErroredProvider() providers.Interface {
+	return &erroredProvider{}
 }
 
-var _ providers.Interface = &ErroredProvider{}
-
 // ApplyResourceChange implements providers.Interface.
-func (p *ErroredProvider) ApplyResourceChange(req providers.ApplyResourceChangeRequest) providers.ApplyResourceChangeResponse {
+func (p *erroredProvider) ApplyResourceChange(req providers.ApplyResourceChangeRequest) providers.ApplyResourceChangeResponse {
 	var diags tfdiags.Diagnostics
 	diags = diags.Append(tfdiags.AttributeValue(
 		tfdiags.Error,
@@ -32,19 +36,19 @@ func (p *ErroredProvider) ApplyResourceChange(req providers.ApplyResourceChangeR
 	}
 }
 
-func (p *ErroredProvider) CallFunction(request providers.CallFunctionRequest) providers.CallFunctionResponse {
-	// this is an offline operation, so we can just use the unconfigured
-	// provider.
-	return p.failedProvider.CallFunction(request)
+func (p *erroredProvider) CallFunction(request providers.CallFunctionRequest) providers.CallFunctionResponse {
+	return providers.CallFunctionResponse{
+		Err: fmt.Errorf("CallFunction shouldn't be called on an errored provider; this is a bug in Terraform - please report this error"),
+	}
 }
 
 // Close implements providers.Interface.
-func (p *ErroredProvider) Close() error {
+func (p *erroredProvider) Close() error {
 	return nil
 }
 
 // ConfigureProvider implements providers.Interface.
-func (p *ErroredProvider) ConfigureProvider(req providers.ConfigureProviderRequest) providers.ConfigureProviderResponse {
+func (p *erroredProvider) ConfigureProvider(req providers.ConfigureProviderRequest) providers.ConfigureProviderResponse {
 	// This provider is used only in situations where ConfigureProvider on
 	// a real provider fails and the recipient was expecting a configured
 	// provider, so it doesn't make sense to configure it.
@@ -52,12 +56,12 @@ func (p *ErroredProvider) ConfigureProvider(req providers.ConfigureProviderReque
 }
 
 // GetProviderSchema implements providers.Interface.
-func (p *ErroredProvider) GetProviderSchema() providers.GetProviderSchemaResponse {
+func (p *erroredProvider) GetProviderSchema() providers.GetProviderSchemaResponse {
 	return providers.GetProviderSchemaResponse{}
 }
 
 // ImportResourceState implements providers.Interface.
-func (p *ErroredProvider) ImportResourceState(req providers.ImportResourceStateRequest) providers.ImportResourceStateResponse {
+func (p *erroredProvider) ImportResourceState(req providers.ImportResourceStateRequest) providers.ImportResourceStateResponse {
 	var diags tfdiags.Diagnostics
 	diags = diags.Append(tfdiags.AttributeValue(
 		tfdiags.Error,
@@ -71,12 +75,12 @@ func (p *ErroredProvider) ImportResourceState(req providers.ImportResourceStateR
 }
 
 // MoveResourceState implements providers.Interface.
-func (p *ErroredProvider) MoveResourceState(req providers.MoveResourceStateRequest) providers.MoveResourceStateResponse {
+func (p *erroredProvider) MoveResourceState(req providers.MoveResourceStateRequest) providers.MoveResourceStateResponse {
 	var diags tfdiags.Diagnostics
 	diags = diags.Append(tfdiags.AttributeValue(
 		tfdiags.Error,
-		"Provider configuration is invalid",
-		"Cannot move an existing object to this resource because its associated provider configuration is invalid.",
+		"Called MoveResourceState on a configured provider",
+		"Terraform called MoveResourceState on an errored provider. This is a bug in Terraform - please report this error.",
 		nil, // nil attribute path means the overall configuration block
 	))
 	return providers.MoveResourceStateResponse{
@@ -85,7 +89,7 @@ func (p *ErroredProvider) MoveResourceState(req providers.MoveResourceStateReque
 }
 
 // PlanResourceChange implements providers.Interface.
-func (p *ErroredProvider) PlanResourceChange(req providers.PlanResourceChangeRequest) providers.PlanResourceChangeResponse {
+func (p *erroredProvider) PlanResourceChange(req providers.PlanResourceChangeRequest) providers.PlanResourceChangeResponse {
 	var diags tfdiags.Diagnostics
 	diags = diags.Append(tfdiags.AttributeValue(
 		tfdiags.Error,
@@ -99,7 +103,7 @@ func (p *ErroredProvider) PlanResourceChange(req providers.PlanResourceChangeReq
 }
 
 // ReadDataSource implements providers.Interface.
-func (p *ErroredProvider) ReadDataSource(req providers.ReadDataSourceRequest) providers.ReadDataSourceResponse {
+func (p *erroredProvider) ReadDataSource(req providers.ReadDataSourceRequest) providers.ReadDataSourceResponse {
 	var diags tfdiags.Diagnostics
 	diags = diags.Append(tfdiags.AttributeValue(
 		tfdiags.Error,
@@ -113,7 +117,7 @@ func (p *ErroredProvider) ReadDataSource(req providers.ReadDataSourceRequest) pr
 }
 
 // ReadResource implements providers.Interface.
-func (p *ErroredProvider) ReadResource(req providers.ReadResourceRequest) providers.ReadResourceResponse {
+func (p *erroredProvider) ReadResource(req providers.ReadResourceRequest) providers.ReadResourceResponse {
 	// For this one we'll just optimistically assume that the remote object
 	// hasn't changed. In many cases we'll fail calling PlanResourceChange
 	// right afterwards anyway, and even if not we'll get another opportunity
@@ -125,14 +129,14 @@ func (p *ErroredProvider) ReadResource(req providers.ReadResourceRequest) provid
 }
 
 // Stop implements providers.Interface.
-func (p *ErroredProvider) Stop() error {
+func (p *erroredProvider) Stop() error {
 	// This stub provider never actually does any real work, so there's nothing
 	// for us to stop.
 	return nil
 }
 
 // UpgradeResourceState implements providers.Interface.
-func (p *ErroredProvider) UpgradeResourceState(req providers.UpgradeResourceStateRequest) providers.UpgradeResourceStateResponse {
+func (p *erroredProvider) UpgradeResourceState(req providers.UpgradeResourceStateRequest) providers.UpgradeResourceStateResponse {
 	// Ideally we'd just skip this altogether and echo back what the caller
 	// provided, but the request is in a different serialization format than
 	// the response and so only the real provider can deal with this one.
@@ -149,7 +153,7 @@ func (p *ErroredProvider) UpgradeResourceState(req providers.UpgradeResourceStat
 }
 
 // ValidateDataResourceConfig implements providers.Interface.
-func (p *ErroredProvider) ValidateDataResourceConfig(req providers.ValidateDataResourceConfigRequest) providers.ValidateDataResourceConfigResponse {
+func (p *erroredProvider) ValidateDataResourceConfig(req providers.ValidateDataResourceConfigRequest) providers.ValidateDataResourceConfigResponse {
 	// We'll just optimistically assume the configuration is valid, so that
 	// we can progress to planning and return an error there instead.
 	return providers.ValidateDataResourceConfigResponse{
@@ -158,7 +162,7 @@ func (p *ErroredProvider) ValidateDataResourceConfig(req providers.ValidateDataR
 }
 
 // ValidateProviderConfig implements providers.Interface.
-func (p *ErroredProvider) ValidateProviderConfig(req providers.ValidateProviderConfigRequest) providers.ValidateProviderConfigResponse {
+func (p *erroredProvider) ValidateProviderConfig(req providers.ValidateProviderConfigRequest) providers.ValidateProviderConfigResponse {
 	// It doesn't make sense to call this one on stubProvider, because
 	// we only use stubProvider for situations where ConfigureProvider failed
 	// on a real provider and we should already have called
@@ -170,7 +174,7 @@ func (p *ErroredProvider) ValidateProviderConfig(req providers.ValidateProviderC
 }
 
 // ValidateResourceConfig implements providers.Interface.
-func (p *ErroredProvider) ValidateResourceConfig(req providers.ValidateResourceConfigRequest) providers.ValidateResourceConfigResponse {
+func (p *erroredProvider) ValidateResourceConfig(req providers.ValidateResourceConfigRequest) providers.ValidateResourceConfigResponse {
 	// We'll just optimistically assume the configuration is valid, so that
 	// we can progress to reading and return an error there instead.
 	return providers.ValidateResourceConfigResponse{

--- a/internal/stacks/stackruntime/internal/stackeval/stubs/errored.go
+++ b/internal/stacks/stackruntime/internal/stackeval/stubs/errored.go
@@ -79,7 +79,7 @@ func (p *erroredProvider) MoveResourceState(req providers.MoveResourceStateReque
 	var diags tfdiags.Diagnostics
 	diags = diags.Append(tfdiags.AttributeValue(
 		tfdiags.Error,
-		"Called MoveResourceState on a configured provider",
+		"Called MoveResourceState on an errored provider",
 		"Terraform called MoveResourceState on an errored provider. This is a bug in Terraform - please report this error.",
 		nil, // nil attribute path means the overall configuration block
 	))

--- a/internal/stacks/stackruntime/internal/stackeval/stubs/offline.go
+++ b/internal/stacks/stackruntime/internal/stackeval/stubs/offline.go
@@ -1,0 +1,179 @@
+package stubs
+
+import (
+	"github.com/hashicorp/terraform/internal/providers"
+	"github.com/hashicorp/terraform/internal/tfdiags"
+)
+
+// offlineProvider is a stub provider that is used in place of a provider that
+// is not configured  and should never be configured by the current Terraform
+// configuration.
+//
+// The only functionality that should be called on an offlineProvider are
+// provider function calls and move resource state.
+//
+// For everything else, Stacks should have provided a pre-configured provider
+// that should be used instead.
+type offlineProvider struct {
+	unconfiguredClient providers.Interface
+}
+
+func OfflineProvider(unconfiguredClient providers.Interface) providers.Interface {
+	return &offlineProvider{
+		unconfiguredClient: unconfiguredClient,
+	}
+}
+
+func (o *offlineProvider) GetProviderSchema() providers.GetProviderSchemaResponse {
+	// We do actually use the schema to work out which functions are available
+	// and whether cross-resource moves are even supported.
+	return o.unconfiguredClient.GetProviderSchema()
+}
+
+func (o *offlineProvider) ValidateProviderConfig(request providers.ValidateProviderConfigRequest) providers.ValidateProviderConfigResponse {
+	var diags tfdiags.Diagnostics
+	diags = diags.Append(tfdiags.AttributeValue(
+		tfdiags.Error,
+		"Called ValidateProviderConfig on an unconfigured provider",
+		"Cannot validate provider configuration because this provider is not configured. This is a bug in Terraform - please report it.",
+		nil, // nil attribute path means the overall configuration block
+	))
+	return providers.ValidateProviderConfigResponse{
+		Diagnostics: diags,
+	}
+}
+
+func (o *offlineProvider) ValidateResourceConfig(request providers.ValidateResourceConfigRequest) providers.ValidateResourceConfigResponse {
+	var diags tfdiags.Diagnostics
+	diags = diags.Append(tfdiags.AttributeValue(
+		tfdiags.Error,
+		"Called ValidateResourceConfig on an unconfigured provider",
+		"Cannot validate resource configuration because this provider is not configured. This is a bug in Terraform - please report it.",
+		nil, // nil attribute path means the overall configuration block
+	))
+	return providers.ValidateResourceConfigResponse{
+		Diagnostics: diags,
+	}
+}
+
+func (o *offlineProvider) ValidateDataResourceConfig(request providers.ValidateDataResourceConfigRequest) providers.ValidateDataResourceConfigResponse {
+	var diags tfdiags.Diagnostics
+	diags = diags.Append(tfdiags.AttributeValue(
+		tfdiags.Error,
+		"Called ValidateDataResourceConfig on an unconfigured provider",
+		"Cannot validate data source configuration because this provider is not configured. This is a bug in Terraform - please report it.",
+		nil, // nil attribute path means the overall configuration block
+	))
+	return providers.ValidateDataResourceConfigResponse{
+		Diagnostics: diags,
+	}
+}
+
+func (o *offlineProvider) UpgradeResourceState(request providers.UpgradeResourceStateRequest) providers.UpgradeResourceStateResponse {
+	var diags tfdiags.Diagnostics
+	diags = diags.Append(tfdiags.AttributeValue(
+		tfdiags.Error,
+		"Called UpgradeResourceState on an unconfigured provider",
+		"Cannot upgrade the state of this resource because this provider is not configured. This is a bug in Terraform - please report it.",
+		nil, // nil attribute path means the overall configuration block
+	))
+	return providers.UpgradeResourceStateResponse{
+		Diagnostics: diags,
+	}
+}
+
+func (o *offlineProvider) ConfigureProvider(request providers.ConfigureProviderRequest) providers.ConfigureProviderResponse {
+	var diags tfdiags.Diagnostics
+	diags = diags.Append(tfdiags.AttributeValue(
+		tfdiags.Error,
+		"Called ConfigureProvider on an unconfigured provider",
+		"Cannot configure this provider because it is not configured. This is a bug in Terraform - please report it.",
+		nil, // nil attribute path means the overall configuration block
+	))
+	return providers.ConfigureProviderResponse{
+		Diagnostics: diags,
+	}
+}
+
+func (o *offlineProvider) Stop() error {
+	// pass the stop call to the underlying unconfigured client
+	return o.unconfiguredClient.Stop()
+}
+
+func (o *offlineProvider) ReadResource(request providers.ReadResourceRequest) providers.ReadResourceResponse {
+	var diags tfdiags.Diagnostics
+	diags = diags.Append(tfdiags.AttributeValue(
+		tfdiags.Error,
+		"Called ReadResource on an unconfigured provider",
+		"Cannot read from this resource because this provider is not configured. This is a bug in Terraform - please report it.",
+		nil, // nil attribute path means the overall configuration block
+	))
+	return providers.ReadResourceResponse{
+		Diagnostics: diags,
+	}
+}
+
+func (o *offlineProvider) PlanResourceChange(request providers.PlanResourceChangeRequest) providers.PlanResourceChangeResponse {
+	var diags tfdiags.Diagnostics
+	diags = diags.Append(tfdiags.AttributeValue(
+		tfdiags.Error,
+		"Called PlanResourceChange on an unconfigured provider",
+		"Cannot plan changes to this resource because this provider is not configured. This is a bug in Terraform - please report it.",
+		nil, // nil attribute path means the overall configuration block
+	))
+	return providers.PlanResourceChangeResponse{
+		Diagnostics: diags,
+	}
+}
+
+func (o *offlineProvider) ApplyResourceChange(request providers.ApplyResourceChangeRequest) providers.ApplyResourceChangeResponse {
+	var diags tfdiags.Diagnostics
+	diags = diags.Append(tfdiags.AttributeValue(
+		tfdiags.Error,
+		"Called ApplyResourceChange on an unconfigured provider",
+		"Cannot apply changes to this resource because this provider is not configured. This is a bug in Terraform - please report it.",
+		nil, // nil attribute path means the overall configuration block
+	))
+	return providers.ApplyResourceChangeResponse{
+		Diagnostics: diags,
+	}
+}
+
+func (o *offlineProvider) ImportResourceState(request providers.ImportResourceStateRequest) providers.ImportResourceStateResponse {
+	var diags tfdiags.Diagnostics
+	diags = diags.Append(tfdiags.AttributeValue(
+		tfdiags.Error,
+		"Called ImportResourceState on an unconfigured provider",
+		"Cannot import an existing object into this resource because this provider is not configured. This is a bug in Terraform - please report it.",
+		nil, // nil attribute path means the overall configuration block
+	))
+	return providers.ImportResourceStateResponse{
+		Diagnostics: diags,
+	}
+}
+
+func (o *offlineProvider) MoveResourceState(request providers.MoveResourceStateRequest) providers.MoveResourceStateResponse {
+	return o.unconfiguredClient.MoveResourceState(request)
+}
+
+func (o *offlineProvider) ReadDataSource(request providers.ReadDataSourceRequest) providers.ReadDataSourceResponse {
+	var diags tfdiags.Diagnostics
+	diags = diags.Append(tfdiags.AttributeValue(
+		tfdiags.Error,
+		"Called ReadDataSource on an unconfigured provider",
+		"Cannot read from this data source because this provider is not configured. This is a bug in Terraform - please report it.",
+		nil, // nil attribute path means the overall configuration block
+	))
+	return providers.ReadDataSourceResponse{
+		Diagnostics: diags,
+	}
+}
+
+func (o *offlineProvider) CallFunction(request providers.CallFunctionRequest) providers.CallFunctionResponse {
+	return o.unconfiguredClient.CallFunction(request)
+}
+
+func (o *offlineProvider) Close() error {
+	// pass the close call to the underlying unconfigured client
+	return o.unconfiguredClient.Close()
+}

--- a/internal/stacks/stackruntime/internal/stackeval/stubs/offline.go
+++ b/internal/stacks/stackruntime/internal/stackeval/stubs/offline.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
 package stubs
 
 import (

--- a/internal/stacks/stackruntime/internal/stackeval/stubs/unknown.go
+++ b/internal/stacks/stackruntime/internal/stackeval/stubs/unknown.go
@@ -22,7 +22,7 @@ var _ providers.Interface = (*unknownProvider)(nil)
 // An unknownProvider is only returned in the context of a provider that should
 // have been configured by Stacks. This provider should not be configured again,
 // or used for any dedicated offline functionality (such as moving resources and
-// .
+// provider functions).
 type unknownProvider struct {
 	unconfiguredClient providers.Interface
 }
@@ -186,7 +186,7 @@ func (u *unknownProvider) MoveResourceState(request providers.MoveResourceStateR
 	var diags tfdiags.Diagnostics
 	diags = diags.Append(tfdiags.AttributeValue(
 		tfdiags.Error,
-		"Called MoveResourceState on a configured provider",
+		"Called MoveResourceState on an unknown provider",
 		"Terraform called MoveResourceState on an unknown provider. This is a bug in Terraform - please report this error.",
 		nil, // nil attribute path means the overall configuration block
 	))

--- a/internal/stacks/stackruntime/internal/stackeval/stubs/unknown.go
+++ b/internal/stacks/stackruntime/internal/stackeval/stubs/unknown.go
@@ -4,6 +4,8 @@
 package stubs
 
 import (
+	"fmt"
+
 	"github.com/zclconf/go-cty/cty"
 
 	"github.com/hashicorp/terraform/internal/moduletest/mocking"
@@ -17,8 +19,10 @@ var _ providers.Interface = (*unknownProvider)(nil)
 // unknown to the current Terraform configuration. This is used when a reference
 // to a provider is unknown, or the provider itself has unknown instances.
 //
-// This provider wraps an unconfigured provider client, which is used to handle
-// offline functionality.
+// An unknownProvider is only returned in the context of a provider that should
+// have been configured by Stacks. This provider should not be configured again,
+// or used for any dedicated offline functionality (such as moving resources and
+// .
 type unknownProvider struct {
 	unconfiguredClient providers.Interface
 }
@@ -179,9 +183,16 @@ func (u *unknownProvider) ImportResourceState(request providers.ImportResourceSt
 }
 
 func (u *unknownProvider) MoveResourceState(request providers.MoveResourceStateRequest) providers.MoveResourceStateResponse {
-	// This is offline functionality, so we can hand it off to the unconfigured
-	// client.
-	return u.unconfiguredClient.MoveResourceState(request)
+	var diags tfdiags.Diagnostics
+	diags = diags.Append(tfdiags.AttributeValue(
+		tfdiags.Error,
+		"Called MoveResourceState on a configured provider",
+		"Terraform called MoveResourceState on an unknown provider. This is a bug in Terraform - please report this error.",
+		nil, // nil attribute path means the overall configuration block
+	))
+	return providers.MoveResourceStateResponse{
+		Diagnostics: diags,
+	}
 }
 
 func (u *unknownProvider) ReadDataSource(request providers.ReadDataSourceRequest) providers.ReadDataSourceResponse {
@@ -223,9 +234,9 @@ func (u *unknownProvider) ReadDataSource(request providers.ReadDataSourceRequest
 }
 
 func (u *unknownProvider) CallFunction(request providers.CallFunctionRequest) providers.CallFunctionResponse {
-	// This is offline functionality, so we can hand it off to the unconfigured
-	// client.
-	return u.unconfiguredClient.CallFunction(request)
+	return providers.CallFunctionResponse{
+		Err: fmt.Errorf("CallFunction shouldn't be called on an unknown provider; this is a bug in Terraform - please report this error"),
+	}
 }
 
 func (u *unknownProvider) Close() error {


### PR DESCRIPTION
This PR adds additional protections around the providers created by the stacks runtime and used within Terraform Core. Essentially, Terraform Core should not be calling configure on any of the providers that it has access to during a stacks operation. Either a provider should never be configured as it only used for offline operations, or it should already have been configured by Stacks before being passed into Terraform Core.

We essentially do two things:

- First, the `providerClose` provider that is returned by the stacks factory now intercepts and prevents the configure function being called on the underlying provider returning an error if this is attempted. Any providers that should be configured are configured by stacks before they are wrapped into the `providerClose` implementation.
- Second, I've introduced an `offlineProvider` stub that is used for providers that are passed into Terraform Core for "offline" operations. These are the cross-provider move functions, and provider function calls. This provider also fails if configure is attempted.

This means now that if we ever make a mistake and Terraform tries to configure a provider when it shouldn't, we'll get an error back instead of causing some crazy unknown behaviour.

I've also updated the other provider stubs (unknown and errored) so they can't be used for the offline operations. Terraform Core should only be using our totally unconfigured providers for these operations, not providers that couldn't be configured either because of unknown values or bad configuration.