### PR TITLE
stacks: remove stale state during Stack apply operations

### DIFF
--- a/internal/stacks/stackruntime/apply_destroy_test.go
+++ b/internal/stacks/stackruntime/apply_destroy_test.go
@@ -1,0 +1,621 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package stackruntime
+
+import (
+	"context"
+	"path/filepath"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/zclconf/go-cty/cty"
+
+	"github.com/hashicorp/terraform/internal/addrs"
+	"github.com/hashicorp/terraform/internal/depsfile"
+	"github.com/hashicorp/terraform/internal/getproviders/providerreqs"
+	"github.com/hashicorp/terraform/internal/plans"
+	"github.com/hashicorp/terraform/internal/providers"
+	"github.com/hashicorp/terraform/internal/stacks/stackaddrs"
+	"github.com/hashicorp/terraform/internal/stacks/stackplan"
+	stacks_testing_provider "github.com/hashicorp/terraform/internal/stacks/stackruntime/testing"
+	"github.com/hashicorp/terraform/internal/stacks/stackstate"
+	"github.com/hashicorp/terraform/internal/states"
+	"github.com/hashicorp/terraform/internal/tfdiags"
+)
+
+func TestApplyDestroyMissingResource(t *testing.T) {
+
+	ctx := context.Background()
+	cfg := loadMainBundleConfigForTest(t, filepath.Join("with-single-input", "valid"))
+
+	fakePlanTimestamp, err := time.Parse(time.RFC3339, "2021-01-01T00:00:00Z")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	lock := depsfile.NewLocks()
+	lock.SetProvider(
+		addrs.NewDefaultProvider("testing"),
+		providerreqs.MustParseVersion("0.0.0"),
+		providerreqs.MustParseVersionConstraints("=0.0.0"),
+		providerreqs.PreferredHashes([]providerreqs.Hash{}),
+	)
+
+	planReq := PlanRequest{
+		PlanMode: plans.DestroyMode,
+
+		Config: cfg,
+		ProviderFactories: map[addrs.Provider]providers.Factory{
+			addrs.NewDefaultProvider("testing"): func() (providers.Interface, error) {
+				return stacks_testing_provider.NewProvider(), nil
+			},
+		},
+		DependencyLocks:    *lock,
+		ForcePlanTimestamp: &fakePlanTimestamp,
+		InputValues: map[stackaddrs.InputVariable]ExternalInputValue{
+			stackaddrs.InputVariable{Name: "input"}: {
+				Value: cty.StringVal("hello"),
+			},
+		},
+
+		// We have in the previous state a resource that is not in our
+		// underlying data store. This simulates the case where someone went
+		// in and manually deleted a resource that Terraform is managing.
+		//
+		// Some providers will return an error in this case, but some will
+		// not. We need to ensure that we handle the second case gracefully.
+		PrevState: stackstate.NewStateBuilder().
+			AddResourceInstance(stackstate.NewResourceInstanceBuilder().
+				SetAddr(mustAbsResourceInstanceObject("component.self.testing_resource.data")).
+				SetProviderAddr(mustDefaultRootProvider("testing")).
+				SetResourceInstanceObjectSrc(states.ResourceInstanceObjectSrc{
+					SchemaVersion: 0,
+					AttrsJSON: mustMarshalJSONAttrs(map[string]interface{}{
+						"id":    "e84b59f2",
+						"value": "hello",
+					}),
+					Status: states.ObjectReady,
+				})).
+			Build(),
+	}
+
+	planChangesCh := make(chan stackplan.PlannedChange)
+	planDiagsCh := make(chan tfdiags.Diagnostic)
+	planResp := PlanResponse{
+		PlannedChanges: planChangesCh,
+		Diagnostics:    planDiagsCh,
+	}
+
+	go Plan(ctx, &planReq, &planResp)
+	planChanges, planDiags := collectPlanOutput(planChangesCh, planDiagsCh)
+	if len(planDiags) > 0 {
+		t.Fatalf("unexpected diagnostics during planning: %s", planDiags)
+	}
+
+	planLoader := stackplan.NewLoader()
+	for _, change := range planChanges {
+		proto, err := change.PlannedChangeProto()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		for _, rawMsg := range proto.Raw {
+			err = planLoader.AddRaw(rawMsg)
+			if err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+	plan, err := planLoader.Plan()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	applyReq := ApplyRequest{
+		Config: cfg,
+		Plan:   plan,
+		ProviderFactories: map[addrs.Provider]providers.Factory{
+			addrs.NewDefaultProvider("testing"): func() (providers.Interface, error) {
+				return stacks_testing_provider.NewProvider(), nil
+			},
+		},
+		DependencyLocks: *lock,
+	}
+
+	applyChangesCh := make(chan stackstate.AppliedChange)
+	applyDiagsCh := make(chan tfdiags.Diagnostic)
+	applyResp := ApplyResponse{
+		AppliedChanges: applyChangesCh,
+		Diagnostics:    applyDiagsCh,
+	}
+
+	go Apply(ctx, &applyReq, &applyResp)
+	applyChanges, applyDiags := collectApplyOutput(applyChangesCh, applyDiagsCh)
+	if len(applyDiags) > 0 {
+		t.Fatalf("unexpected diagnostics during apply: %s", applyDiags)
+	}
+
+	wantChanges := []stackstate.AppliedChange{
+		&stackstate.AppliedChangeComponentInstance{
+			ComponentAddr:         mustAbsComponent("component.self"),
+			ComponentInstanceAddr: mustAbsComponentInstance("component.self"),
+			OutputValues:          make(map[addrs.OutputValue]cty.Value),
+		},
+		// The resource that was in state but not in the data store should still
+		// be included to be destroyed.
+		&stackstate.AppliedChangeResourceInstanceObject{
+			ResourceInstanceObjectAddr: mustAbsResourceInstanceObject("component.self.testing_resource.data"),
+			ProviderConfigAddr:         mustDefaultRootProvider("testing"),
+			NewStateSrc:                nil, // We should be removing this from the state file.
+			Schema:                     nil,
+		},
+	}
+
+	sort.SliceStable(applyChanges, func(i, j int) bool {
+		return appliedChangeSortKey(applyChanges[i]) < appliedChangeSortKey(applyChanges[j])
+	})
+
+	if diff := cmp.Diff(wantChanges, applyChanges, changesCmpOpts); diff != "" {
+		t.Errorf("wrong changes\n%s", diff)
+	}
+}
+
+func TestApplyDestroyWithDataSourceInState(t *testing.T) {
+	ctx := context.Background()
+	cfg := loadMainBundleConfigForTest(t, "with-data-source")
+
+	fakePlanTimestamp, err := time.Parse(time.RFC3339, "2021-01-01T00:00:00Z")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	lock := depsfile.NewLocks()
+	lock.SetProvider(
+		addrs.NewDefaultProvider("testing"),
+		providerreqs.MustParseVersion("0.0.0"),
+		providerreqs.MustParseVersionConstraints("=0.0.0"),
+		providerreqs.PreferredHashes([]providerreqs.Hash{}),
+	)
+
+	store := stacks_testing_provider.NewResourceStoreBuilder().
+		AddResource("foo", cty.ObjectVal(map[string]cty.Value{
+			"id":    cty.StringVal("foo"),
+			"value": cty.StringVal("hello"),
+		})).Build()
+
+	planReq := PlanRequest{
+		PlanMode: plans.DestroyMode,
+
+		Config: cfg,
+		ProviderFactories: map[addrs.Provider]providers.Factory{
+			addrs.NewDefaultProvider("testing"): func() (providers.Interface, error) {
+				return stacks_testing_provider.NewProviderWithData(store), nil
+			},
+		},
+		DependencyLocks:    *lock,
+		ForcePlanTimestamp: &fakePlanTimestamp,
+		InputValues: map[stackaddrs.InputVariable]ExternalInputValue{
+			stackaddrs.InputVariable{Name: "id"}: {
+				Value: cty.StringVal("foo"),
+			},
+			stackaddrs.InputVariable{Name: "resource"}: {
+				Value: cty.StringVal("bar"),
+			},
+		},
+
+		// We have a forgotten data source in the state file, this basically
+		// means we've removed it from the config file since the last apply.
+		// We should get a notice telling us that it is being removed.
+		PrevState: stackstate.NewStateBuilder().
+			AddResourceInstance(stackstate.NewResourceInstanceBuilder().
+				SetAddr(mustAbsResourceInstanceObject("component.self.data.testing_data_source.missing")).
+				SetProviderAddr(mustDefaultRootProvider("testing")).
+				SetResourceInstanceObjectSrc(states.ResourceInstanceObjectSrc{
+					SchemaVersion: 0,
+					AttrsJSON: mustMarshalJSONAttrs(map[string]interface{}{
+						"id":    "e84b59f2",
+						"value": "hello",
+					}),
+					Status: states.ObjectReady,
+				})).
+			Build(),
+	}
+
+	planChangesCh := make(chan stackplan.PlannedChange)
+	planDiagsCh := make(chan tfdiags.Diagnostic)
+	planResp := PlanResponse{
+		PlannedChanges: planChangesCh,
+		Diagnostics:    planDiagsCh,
+	}
+
+	go Plan(ctx, &planReq, &planResp)
+	planChanges, planDiags := collectPlanOutput(planChangesCh, planDiagsCh)
+	if len(planDiags) > 0 {
+		t.Fatalf("unexpected diagnostics during planning: %s", planDiags)
+	}
+
+	planLoader := stackplan.NewLoader()
+	for _, change := range planChanges {
+		proto, err := change.PlannedChangeProto()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		for _, rawMsg := range proto.Raw {
+			err = planLoader.AddRaw(rawMsg)
+			if err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+
+	plan, err := planLoader.Plan()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	applyReq := ApplyRequest{
+		Config: cfg,
+		Plan:   plan,
+		ProviderFactories: map[addrs.Provider]providers.Factory{
+			addrs.NewDefaultProvider("testing"): func() (providers.Interface, error) {
+				return stacks_testing_provider.NewProviderWithData(store), nil
+			},
+		},
+		DependencyLocks: *lock,
+	}
+
+	applyChangesCh := make(chan stackstate.AppliedChange)
+	applyDiagsCh := make(chan tfdiags.Diagnostic)
+	applyResp := ApplyResponse{
+		AppliedChanges: applyChangesCh,
+		Diagnostics:    applyDiagsCh,
+	}
+
+	go Apply(ctx, &applyReq, &applyResp)
+	applyChanges, applyDiags := collectApplyOutput(applyChangesCh, applyDiagsCh)
+	if len(applyDiags) > 0 {
+		t.Fatalf("unexpected diagnostics during apply: %s", applyDiags)
+	}
+
+	wantChanges := []stackstate.AppliedChange{
+		&stackstate.AppliedChangeComponentInstance{
+			ComponentAddr:         mustAbsComponent("component.self"),
+			ComponentInstanceAddr: mustAbsComponentInstance("component.self"),
+			OutputValues:          make(map[addrs.OutputValue]cty.Value),
+		},
+
+		// This is a bit of a quirk of the system, this wasn't in the state
+		// file before so we don't need to emit this. But since Terraform
+		// pushes data sources into the refresh state, it's very difficult to
+		// tell the difference between this kind of change that doesn't need to
+		// be emitted, and the next change that does need to be emitted. It's
+		// better to emit both than to miss one, and emitting this doesn't
+		// actually harm anything.
+		&stackstate.AppliedChangeResourceInstanceObject{
+			ResourceInstanceObjectAddr: mustAbsResourceInstanceObject("component.self.data.testing_data_source.data"),
+			ProviderConfigAddr:         mustDefaultRootProvider("testing"),
+			Schema:                     nil,
+			NewStateSrc:                nil, // deleted
+		},
+
+		// This was in the state file, so we're emitting the destroy notice.
+		&stackstate.AppliedChangeResourceInstanceObject{
+			ResourceInstanceObjectAddr: mustAbsResourceInstanceObject("component.self.data.testing_data_source.missing"),
+			ProviderConfigAddr:         mustDefaultRootProvider("testing"),
+			Schema:                     nil,
+			NewStateSrc:                nil,
+		},
+	}
+
+	sort.SliceStable(applyChanges, func(i, j int) bool {
+		return appliedChangeSortKey(applyChanges[i]) < appliedChangeSortKey(applyChanges[j])
+	})
+
+	if diff := cmp.Diff(wantChanges, applyChanges, changesCmpOpts); diff != "" {
+		t.Fatalf("wrong changes\n%s", diff)
+	}
+}
+
+func TestApplyDestroyWithDataSource(t *testing.T) {
+	ctx := context.Background()
+	cfg := loadMainBundleConfigForTest(t, "with-data-source")
+
+	fakePlanTimestamp, err := time.Parse(time.RFC3339, "2021-01-01T00:00:00Z")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	lock := depsfile.NewLocks()
+	lock.SetProvider(
+		addrs.NewDefaultProvider("testing"),
+		providerreqs.MustParseVersion("0.0.0"),
+		providerreqs.MustParseVersionConstraints("=0.0.0"),
+		providerreqs.PreferredHashes([]providerreqs.Hash{}),
+	)
+
+	store := stacks_testing_provider.NewResourceStoreBuilder().
+		AddResource("foo", cty.ObjectVal(map[string]cty.Value{
+			"id":    cty.StringVal("foo"),
+			"value": cty.StringVal("hello"),
+		})).Build()
+
+	planReq := PlanRequest{
+		PlanMode: plans.NormalMode,
+
+		Config: cfg,
+		ProviderFactories: map[addrs.Provider]providers.Factory{
+			addrs.NewDefaultProvider("testing"): func() (providers.Interface, error) {
+				return stacks_testing_provider.NewProviderWithData(store), nil
+			},
+		},
+		DependencyLocks:    *lock,
+		ForcePlanTimestamp: &fakePlanTimestamp,
+		InputValues: map[stackaddrs.InputVariable]ExternalInputValue{
+			stackaddrs.InputVariable{Name: "id"}: {
+				Value: cty.StringVal("foo"),
+			},
+			stackaddrs.InputVariable{Name: "resource"}: {
+				Value: cty.StringVal("bar"),
+			},
+		},
+
+		// We have a forgotten data source in the state file, this basically
+		// means we've removed it from the config file since the last apply.
+		// We should get a notice telling us that it is being removed.
+		PrevState: stackstate.NewStateBuilder().
+			AddResourceInstance(stackstate.NewResourceInstanceBuilder().
+				SetAddr(mustAbsResourceInstanceObject("component.self.data.testing_data_source.missing")).
+				SetProviderAddr(mustDefaultRootProvider("testing")).
+				SetResourceInstanceObjectSrc(states.ResourceInstanceObjectSrc{
+					SchemaVersion: 0,
+					AttrsJSON: mustMarshalJSONAttrs(map[string]interface{}{
+						"id":    "e84b59f2",
+						"value": "hello",
+					}),
+					Status: states.ObjectReady,
+				})).
+			Build(),
+	}
+
+	planChangesCh := make(chan stackplan.PlannedChange)
+	planDiagsCh := make(chan tfdiags.Diagnostic)
+	planResp := PlanResponse{
+		PlannedChanges: planChangesCh,
+		Diagnostics:    planDiagsCh,
+	}
+
+	go Plan(ctx, &planReq, &planResp)
+	planChanges, planDiags := collectPlanOutput(planChangesCh, planDiagsCh)
+	if len(planDiags) > 0 {
+		t.Fatalf("unexpected diagnostics during planning: %s", planDiags)
+	}
+
+	planLoader := stackplan.NewLoader()
+	for _, change := range planChanges {
+		proto, err := change.PlannedChangeProto()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		for _, rawMsg := range proto.Raw {
+			err = planLoader.AddRaw(rawMsg)
+			if err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+
+	plan, err := planLoader.Plan()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	applyReq := ApplyRequest{
+		Config: cfg,
+		Plan:   plan,
+		ProviderFactories: map[addrs.Provider]providers.Factory{
+			addrs.NewDefaultProvider("testing"): func() (providers.Interface, error) {
+				return stacks_testing_provider.NewProviderWithData(store), nil
+			},
+		},
+		DependencyLocks: *lock,
+	}
+
+	applyChangesCh := make(chan stackstate.AppliedChange)
+	applyDiagsCh := make(chan tfdiags.Diagnostic)
+	applyResp := ApplyResponse{
+		AppliedChanges: applyChangesCh,
+		Diagnostics:    applyDiagsCh,
+	}
+
+	go Apply(ctx, &applyReq, &applyResp)
+	applyChanges, applyDiags := collectApplyOutput(applyChangesCh, applyDiagsCh)
+	if len(applyDiags) > 0 {
+		t.Fatalf("unexpected diagnostics during apply: %s", applyDiags)
+	}
+
+	wantChanges := []stackstate.AppliedChange{
+		&stackstate.AppliedChangeComponentInstance{
+			ComponentAddr:         mustAbsComponent("component.self"),
+			ComponentInstanceAddr: mustAbsComponentInstance("component.self"),
+			OutputValues:          make(map[addrs.OutputValue]cty.Value),
+		},
+		&stackstate.AppliedChangeResourceInstanceObject{
+			ResourceInstanceObjectAddr: mustAbsResourceInstanceObject("component.self.data.testing_data_source.data"),
+			NewStateSrc: &states.ResourceInstanceObjectSrc{
+				AttrsJSON: mustMarshalJSONAttrs(map[string]interface{}{
+					"id":    "foo",
+					"value": "hello",
+				}),
+				AttrSensitivePaths: make([]cty.Path, 0),
+				Status:             states.ObjectReady,
+			},
+			ProviderConfigAddr: mustDefaultRootProvider("testing"),
+			Schema:             stacks_testing_provider.TestingDataSourceSchema,
+		},
+		// This data source should be removed from the state file as it is no
+		// longer in the configuration.
+		&stackstate.AppliedChangeResourceInstanceObject{
+			ResourceInstanceObjectAddr: mustAbsResourceInstanceObject("component.self.data.testing_data_source.missing"),
+			ProviderConfigAddr:         mustDefaultRootProvider("testing"),
+			Schema:                     nil,
+			NewStateSrc:                nil, // deleted
+		},
+		&stackstate.AppliedChangeResourceInstanceObject{
+			ResourceInstanceObjectAddr: mustAbsResourceInstanceObject("component.self.testing_resource.data"),
+			NewStateSrc: &states.ResourceInstanceObjectSrc{
+				AttrsJSON: mustMarshalJSONAttrs(map[string]interface{}{
+					"id":    "bar",
+					"value": "hello",
+				}),
+				Status: states.ObjectReady,
+				Dependencies: []addrs.ConfigResource{
+					mustAbsResourceInstance("data.testing_data_source.data").ConfigResource(),
+				},
+			},
+			ProviderConfigAddr: mustDefaultRootProvider("testing"),
+			Schema:             stacks_testing_provider.TestingResourceSchema,
+		},
+	}
+
+	sort.SliceStable(applyChanges, func(i, j int) bool {
+		return appliedChangeSortKey(applyChanges[i]) < appliedChangeSortKey(applyChanges[j])
+	})
+
+	if diff := cmp.Diff(wantChanges, applyChanges, changesCmpOpts); diff != "" {
+		t.Fatalf("wrong changes\n%s", diff)
+	}
+
+	// Now, let's destroy everything.
+
+	stateLoader := stackstate.NewLoader()
+	for _, change := range applyChanges {
+		proto, err := change.AppliedChangeProto()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		for _, rawMsg := range proto.Raw {
+			if rawMsg.Value == nil {
+				// This is a removal notice, so we don't need to add it to the
+				// state.
+				continue
+			}
+			err = stateLoader.AddRaw(rawMsg.Key, rawMsg.Value)
+			if err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+
+	planReq = PlanRequest{
+		PlanMode: plans.DestroyMode,
+
+		Config: cfg,
+		ProviderFactories: map[addrs.Provider]providers.Factory{
+			addrs.NewDefaultProvider("testing"): func() (providers.Interface, error) {
+				return stacks_testing_provider.NewProviderWithData(store), nil
+			},
+		},
+		DependencyLocks:    *lock,
+		ForcePlanTimestamp: &fakePlanTimestamp,
+		InputValues: map[stackaddrs.InputVariable]ExternalInputValue{
+			stackaddrs.InputVariable{Name: "id"}: {
+				Value: cty.StringVal("foo"),
+			},
+			stackaddrs.InputVariable{Name: "resource"}: {
+				Value: cty.StringVal("bar"),
+			},
+		},
+		PrevState: stateLoader.State(),
+	}
+
+	planChangesCh = make(chan stackplan.PlannedChange)
+	planDiagsCh = make(chan tfdiags.Diagnostic)
+	planResp = PlanResponse{
+		PlannedChanges: planChangesCh,
+		Diagnostics:    planDiagsCh,
+	}
+
+	go Plan(ctx, &planReq, &planResp)
+	planChanges, planDiags = collectPlanOutput(planChangesCh, planDiagsCh)
+	if len(planDiags) > 0 {
+		t.Fatalf("unexpected diagnostics during planning: %s", planDiags)
+	}
+
+	planLoader = stackplan.NewLoader()
+	for _, change := range planChanges {
+		proto, err := change.PlannedChangeProto()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		for _, rawMsg := range proto.Raw {
+			err = planLoader.AddRaw(rawMsg)
+			if err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+
+	plan, err = planLoader.Plan()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	applyReq = ApplyRequest{
+		Config: cfg,
+		Plan:   plan,
+		ProviderFactories: map[addrs.Provider]providers.Factory{
+			addrs.NewDefaultProvider("testing"): func() (providers.Interface, error) {
+				return stacks_testing_provider.NewProviderWithData(store), nil
+			},
+		},
+		DependencyLocks: *lock,
+	}
+
+	applyChangesCh = make(chan stackstate.AppliedChange)
+	applyDiagsCh = make(chan tfdiags.Diagnostic)
+	applyResp = ApplyResponse{
+		AppliedChanges: applyChangesCh,
+		Diagnostics:    applyDiagsCh,
+	}
+
+	go Apply(ctx, &applyReq, &applyResp)
+	applyChanges, applyDiags = collectApplyOutput(applyChangesCh, applyDiagsCh)
+	if len(applyDiags) > 0 {
+		t.Fatalf("unexpected diagnostics during apply: %s", applyDiags)
+	}
+
+	wantChanges = []stackstate.AppliedChange{
+		&stackstate.AppliedChangeComponentInstance{
+			ComponentAddr:         mustAbsComponent("component.self"),
+			ComponentInstanceAddr: mustAbsComponentInstance("component.self"),
+			OutputValues:          make(map[addrs.OutputValue]cty.Value),
+		},
+		&stackstate.AppliedChangeResourceInstanceObject{
+			ResourceInstanceObjectAddr: mustAbsResourceInstanceObject("component.self.data.testing_data_source.data"),
+			ProviderConfigAddr:         mustDefaultRootProvider("testing"),
+			Schema:                     nil,
+			NewStateSrc:                nil, // deleted
+		},
+		&stackstate.AppliedChangeResourceInstanceObject{
+			ResourceInstanceObjectAddr: mustAbsResourceInstanceObject("component.self.testing_resource.data"),
+			ProviderConfigAddr:         mustDefaultRootProvider("testing"),
+			Schema:                     nil,
+			NewStateSrc:                nil, // deleted
+		},
+	}
+
+	sort.SliceStable(applyChanges, func(i, j int) bool {
+		return appliedChangeSortKey(applyChanges[i]) < appliedChangeSortKey(applyChanges[j])
+	})
+
+	if diff := cmp.Diff(wantChanges, applyChanges, changesCmpOpts); diff != "" {
+		t.Fatalf("wrong changes\n%s", diff)
+	}
+}

--- a/internal/stacks/stackruntime/testdata/mainbundle/test/failed-dependency/failed-dependency.tf
+++ b/internal/stacks/stackruntime/testdata/mainbundle/test/failed-dependency/failed-dependency.tf
@@ -1,0 +1,57 @@
+terraform {
+  required_providers {
+    testing = {
+      source  = "hashicorp/testing"
+      version = "0.1.0"
+    }
+  }
+}
+
+variable "failed_id" {
+  type     = string
+  default  = null
+  nullable = true # We'll generate an ID if none provided.
+}
+
+variable "resource_id" {
+  type     = string
+  default  = null
+  nullable = true # We'll generate an ID if none provided.
+}
+
+variable "input" {
+  type = string
+  default = null
+  nullable = true
+}
+
+variable "fail_plan" {
+  type = bool
+  default = null
+  nullable = true
+}
+
+variable "fail_apply" {
+  type = bool
+  default = null
+  nullable = true
+}
+
+resource "testing_failed_resource" "data" {
+  id    = var.failed_id
+  value = var.input
+  fail_plan = var.fail_plan
+  fail_apply = var.fail_apply
+}
+
+resource "testing_resource" "data" {
+  id = var.resource_id
+
+  depends_on = [
+    testing_failed_resource.data
+  ]
+}
+
+output "value" {
+  value = testing_failed_resource.data.value
+}

--- a/internal/stacks/stackruntime/testdata/mainbundle/test/failed-dependency/failed-dependency.tfstack.hcl
+++ b/internal/stacks/stackruntime/testdata/mainbundle/test/failed-dependency/failed-dependency.tfstack.hcl
@@ -1,0 +1,31 @@
+required_providers {
+  testing = {
+    source  = "hashicorp/testing"
+    version = "0.1.0"
+  }
+}
+
+provider "testing" "default" {}
+
+variable "fail_plan" {
+  type = bool
+  default = false
+}
+
+variable "fail_apply" {
+  type = bool
+  default = false
+}
+
+component "self" {
+  source = "./"
+  providers = {
+    testing = provider.testing.default
+  }
+  inputs = {
+    failed_id = "failed"
+    resource_id = "resource"
+    fail_plan = var.fail_plan
+    fail_apply = var.fail_apply
+  }
+}

--- a/internal/stacks/stackruntime/testdata/mainbundle/test/with-data-source/with-data-source.tf
+++ b/internal/stacks/stackruntime/testdata/mainbundle/test/with-data-source/with-data-source.tf
@@ -1,0 +1,25 @@
+terraform {
+  required_providers {
+    testing = {
+      source  = "hashicorp/testing"
+      version = "0.1.0"
+    }
+  }
+}
+
+variable "id" {
+  type = string
+}
+
+variable "resource" {
+  type = string
+}
+
+data "testing_data_source" "data" {
+  id = var.id
+}
+
+resource "testing_resource" "data" {
+  id    = var.resource
+  value = data.testing_data_source.data.value
+}

--- a/internal/stacks/stackruntime/testdata/mainbundle/test/with-data-source/with-data-source.tfstack.hcl
+++ b/internal/stacks/stackruntime/testdata/mainbundle/test/with-data-source/with-data-source.tfstack.hcl
@@ -7,17 +7,16 @@ required_providers {
 
 provider "testing" "default" {}
 
-variable "input" {
+variable "id" {
   type = string
 }
 
-variable "id" {
+variable "resource" {
   type = string
-  default = null
 }
 
 component "self" {
-  source = "../"
+  source = "./"
 
   providers = {
     testing = provider.testing.default
@@ -25,6 +24,6 @@ component "self" {
 
   inputs = {
     id = var.id
-    input = var.input
+    resource = var.resource
   }
 }


### PR DESCRIPTION
This PR fixes a bug in Terraform Stacks whereby "stale" state was not being cleaned up during normal apply operations and, in some cases, destroy operations.

[This comment](https://github.com/hashicorp/terraform/blob/main/internal/stacks/stackruntime/internal/stackeval/component_instance.go#L1517-L1523) sums up what we're trying to do. This isn't working though. We're preserving the previous run state inside the prior state when we write things into the stack plan format. But, when we write the stack plan format back into core format we don't recreate or preserve the objects in the previous run state through a combination of [this](https://github.com/hashicorp/terraform/blob/main/internal/stacks/stackplan/component.go#L145) and [this](https://github.com/hashicorp/terraform/blob/main/internal/states/module.go#L83). This means that anything in the previous run state and not in the refresh state is just ignored by Stacks post apply, even though we should still be emitting updates instructing those objects are removed from the state.

This PR updates the `resourceInstanceObjectsAffectedByPlan` function so that it now returns the objects that stacks thinks is affected by the plan (which includes objects that are in prevRunState and not in priorState) instead of things that Terraform Core thinks are affected by the plan. Previously, it was trying to look at the prevRunState but, as discussed above, this was always empty because the prevRunState was being combined with the priorState and then silently dropped when the plan was being rebuilt. With this change, we are correctly including any stale state post apply, and are now successfully emitting applied changes instructing that the state should be updated and remove the stale objects.