### PR TITLE
plan renderer: render unknown nested blocks properly

### DIFF
--- a/internal/command/jsonformat/computed/diff.go
+++ b/internal/command/jsonformat/computed/diff.go
@@ -78,13 +78,21 @@ type RenderHumanOpts struct {
 	// deleted.
 	OverrideNullSuffix bool
 
-	// OverrideForcesReplacement tells the Renderer to display the
+	// ForceForcesReplacement tells the Renderer to display the
 	// `# forces replacement` suffix, even if a diff doesn't have the Replace
 	// field set.
 	//
 	// Some renderers (like the Set renderer) don't display the suffix
 	// themselves but force their child diffs to display it instead.
-	OverrideForcesReplacement bool
+	ForceForcesReplacement bool
+
+	// ForbidForcesReplacement is the opposite of ForceForcesReplacement. It
+	// tells the Renderer to not display the '# forces replacement' suffix, even
+	// if a diff does have the Replace field set.
+	//
+	// Some renderers (like the Unknown renderer) want to capture the
+	// forceReplacement setting at their level instead of within the children.
+	ForbidForcesReplacement bool
 
 	// ShowUnchangedChildren instructs the Renderer to render all children of a
 	// given complex change, instead of hiding unchanged items and compressing
@@ -114,10 +122,12 @@ func (opts RenderHumanOpts) Clone() RenderHumanOpts {
 		ShowUnchangedChildren: opts.ShowUnchangedChildren,
 		HideDiffActionSymbols: opts.HideDiffActionSymbols,
 
-		// OverrideForcesReplacement is a special case in that it doesn't
-		// cascade. So each diff should decide independently whether it's direct
-		// children should override their internal Replace logic, instead of
-		// an ancestor making the switch and affecting the entire tree.
-		OverrideForcesReplacement: false,
+		// ForceForcesReplacement and ForbidForcesReplacement are special cases
+		// in that they don't cascade. So each diff should decide independently
+		// whether it's direct children should override their internal Replace
+		// logic, instead of an ancestor making the switch and affecting the
+		// entire tree.
+		ForceForcesReplacement:  false,
+		ForbidForcesReplacement: false,
 	}
 }

--- a/internal/command/jsonformat/computed/renderers/block.go
+++ b/internal/command/jsonformat/computed/renderers/block.go
@@ -138,7 +138,7 @@ func (renderer blockRenderer) RenderHuman(diff computed.Diff, indent int, opts c
 			// know about the replace function if it was set on them
 			// specifically, and not if it was set for all the blocks.
 			blockOpts := opts.Clone()
-			blockOpts.OverrideForcesReplacement = renderer.blocks.ReplaceBlocks[key]
+			blockOpts.ForceForcesReplacement = renderer.blocks.ReplaceBlocks[key]
 
 			for _, warning := range diff.WarningsHuman(indent+1, blockOpts) {
 				buf.WriteString(fmt.Sprintf("%s%s\n", formatIndent(indent+1), warning))
@@ -157,18 +157,31 @@ func (renderer blockRenderer) RenderHuman(diff computed.Diff, indent int, opts c
 			}
 			sort.Strings(keys)
 
+			if renderer.blocks.UnknownBlocks[key] {
+				renderBlock(computed.NewDiff(Unknown(computed.Diff{}), plans.Create, false), "", opts)
+			}
+
 			for _, innerKey := range keys {
 				renderBlock(renderer.blocks.MapBlocks[key][innerKey], fmt.Sprintf(" %q", innerKey), opts)
 			}
 		case renderer.blocks.IsSetBlock(key):
 
 			setOpts := opts.Clone()
-			setOpts.OverrideForcesReplacement = diff.Replace
+			setOpts.ForceForcesReplacement = diff.Replace
+
+			if renderer.blocks.UnknownBlocks[key] {
+				renderBlock(computed.NewDiff(Unknown(computed.Diff{}), plans.Create, false), "", opts)
+			}
 
 			for _, block := range renderer.blocks.SetBlocks[key] {
 				renderBlock(block, "", opts)
 			}
 		case renderer.blocks.IsListBlock(key):
+
+			if renderer.blocks.UnknownBlocks[key] {
+				renderBlock(computed.NewDiff(Unknown(computed.Diff{}), plans.Create, false), "", opts)
+			}
+
 			for _, block := range renderer.blocks.ListBlocks[key] {
 				renderBlock(block, "", opts)
 			}

--- a/internal/command/jsonformat/computed/renderers/blocks.go
+++ b/internal/command/jsonformat/computed/renderers/blocks.go
@@ -27,6 +27,7 @@ type Blocks struct {
 	ReplaceBlocks         map[string]bool
 	BeforeSensitiveBlocks map[string]bool
 	AfterSensitiveBlocks  map[string]bool
+	UnknownBlocks         map[string]bool
 }
 
 func (blocks *Blocks) GetAllKeys() []string {
@@ -67,30 +68,34 @@ func (blocks *Blocks) IsSetBlock(key string) bool {
 	return ok
 }
 
-func (blocks *Blocks) AddSingleBlock(key string, diff computed.Diff, replace, beforeSensitive, afterSensitive bool) {
+func (blocks *Blocks) AddSingleBlock(key string, diff computed.Diff, replace, beforeSensitive, afterSensitive, unknown bool) {
 	blocks.SingleBlocks[key] = diff
 	blocks.ReplaceBlocks[key] = replace
 	blocks.BeforeSensitiveBlocks[key] = beforeSensitive
 	blocks.AfterSensitiveBlocks[key] = afterSensitive
+	blocks.UnknownBlocks[key] = unknown
 }
 
-func (blocks *Blocks) AddAllListBlock(key string, diffs []computed.Diff, replace, beforeSensitive, afterSensitive bool) {
+func (blocks *Blocks) AddAllListBlock(key string, diffs []computed.Diff, replace, beforeSensitive, afterSensitive, unknown bool) {
 	blocks.ListBlocks[key] = diffs
 	blocks.ReplaceBlocks[key] = replace
 	blocks.BeforeSensitiveBlocks[key] = beforeSensitive
 	blocks.AfterSensitiveBlocks[key] = afterSensitive
+	blocks.UnknownBlocks[key] = unknown
 }
 
-func (blocks *Blocks) AddAllSetBlock(key string, diffs []computed.Diff, replace, beforeSensitive, afterSensitive bool) {
+func (blocks *Blocks) AddAllSetBlock(key string, diffs []computed.Diff, replace, beforeSensitive, afterSensitive, unknown bool) {
 	blocks.SetBlocks[key] = diffs
 	blocks.ReplaceBlocks[key] = replace
 	blocks.BeforeSensitiveBlocks[key] = beforeSensitive
 	blocks.AfterSensitiveBlocks[key] = afterSensitive
+	blocks.UnknownBlocks[key] = unknown
 }
 
-func (blocks *Blocks) AddAllMapBlocks(key string, diffs map[string]computed.Diff, replace, beforeSensitive, afterSensitive bool) {
+func (blocks *Blocks) AddAllMapBlocks(key string, diffs map[string]computed.Diff, replace, beforeSensitive, afterSensitive, unknown bool) {
 	blocks.MapBlocks[key] = diffs
 	blocks.ReplaceBlocks[key] = replace
 	blocks.BeforeSensitiveBlocks[key] = beforeSensitive
 	blocks.AfterSensitiveBlocks[key] = afterSensitive
+	blocks.UnknownBlocks[key] = unknown
 }

--- a/internal/command/jsonformat/computed/renderers/map.go
+++ b/internal/command/jsonformat/computed/renderers/map.go
@@ -71,7 +71,7 @@ func (renderer mapRenderer) RenderHuman(diff computed.Diff, indent int, opts com
 
 	elementOpts := opts.Clone()
 	elementOpts.OverrideNullSuffix = diff.Action == plans.Delete || renderer.overrideNullSuffix
-	elementOpts.OverrideForcesReplacement = forcesReplacementChildren
+	elementOpts.ForceForcesReplacement = forcesReplacementChildren
 
 	var buf bytes.Buffer
 	buf.WriteString(fmt.Sprintf("{%s\n", forcesReplacement(forcesReplacementSelf, opts)))

--- a/internal/command/jsonformat/computed/renderers/set.go
+++ b/internal/command/jsonformat/computed/renderers/set.go
@@ -48,7 +48,7 @@ func (renderer setRenderer) RenderHuman(diff computed.Diff, indent int, opts com
 
 	elementOpts := opts.Clone()
 	elementOpts.OverrideNullSuffix = true
-	elementOpts.OverrideForcesReplacement = displayForcesReplacementInChildren
+	elementOpts.ForceForcesReplacement = displayForcesReplacementInChildren
 
 	unchangedElements := 0
 

--- a/internal/command/jsonformat/computed/renderers/unknown.go
+++ b/internal/command/jsonformat/computed/renderers/unknown.go
@@ -30,7 +30,13 @@ func (renderer unknownRenderer) RenderHuman(diff computed.Diff, indent int, opts
 		return fmt.Sprintf("(known after apply)%s", forcesReplacement(diff.Replace, opts))
 	}
 
+	beforeOpts := opts.Clone()
 	// Never render null suffix for children of unknown changes.
-	opts.OverrideNullSuffix = true
-	return fmt.Sprintf("%s -> (known after apply)%s", renderer.before.RenderHuman(indent, opts), forcesReplacement(diff.Replace, opts))
+	beforeOpts.OverrideNullSuffix = true
+	if diff.Replace {
+		// If we're displaying forces replacement for the overall unknown
+		// change, then do not display it for the before specifically.
+		beforeOpts.ForbidForcesReplacement = true
+	}
+	return fmt.Sprintf("%s -> (known after apply)%s", renderer.before.RenderHuman(indent, beforeOpts), forcesReplacement(diff.Replace, opts))
 }

--- a/internal/command/jsonformat/computed/renderers/util.go
+++ b/internal/command/jsonformat/computed/renderers/util.go
@@ -37,7 +37,7 @@ func nullSuffix(action plans.Action, opts computed.RenderHumanOpts) string {
 // forcesReplacement returns the `# forces replacement` suffix if this change is
 // driving the entire resource to be replaced.
 func forcesReplacement(replace bool, opts computed.RenderHumanOpts) string {
-	if replace || opts.OverrideForcesReplacement {
+	if (replace || opts.ForceForcesReplacement) && !opts.ForbidForcesReplacement {
 		return opts.Colorize.Color(" [red]# forces replacement[reset]")
 	}
 	return ""

--- a/internal/command/jsonformat/differ/block.go
+++ b/internal/command/jsonformat/differ/block.go
@@ -56,6 +56,7 @@ func ComputeDiffForBlock(change structured.Change, block *jsonprovider.Block) co
 		ReplaceBlocks:         make(map[string]bool),
 		BeforeSensitiveBlocks: make(map[string]bool),
 		AfterSensitiveBlocks:  make(map[string]bool),
+		UnknownBlocks:         make(map[string]bool),
 		SingleBlocks:          make(map[string]computed.Diff),
 		ListBlocks:            make(map[string][]computed.Diff),
 		SetBlocks:             make(map[string][]computed.Diff),
@@ -73,46 +74,40 @@ func ComputeDiffForBlock(change structured.Change, block *jsonprovider.Block) co
 		beforeSensitive := childValue.IsBeforeSensitive()
 		afterSensitive := childValue.IsAfterSensitive()
 		forcesReplacement := childValue.ReplacePaths.Matches()
-
-		if unknown, ok := checkForUnknownBlock(childValue, block); ok {
-			// An unknown block doesn't render any type information, so we can
-			// render it as a single block rather than switching on all types.
-			blocks.AddSingleBlock(key, unknown, forcesReplacement, beforeSensitive, afterSensitive)
-			continue
-		}
+		unknown := childValue.IsUnknown()
 
 		switch NestingMode(blockType.NestingMode) {
 		case nestingModeSet:
 			diffs, action := computeBlockDiffsAsSet(childValue, blockType.Block)
-			if action == plans.NoOp && childValue.Before == nil && childValue.After == nil {
+			if action == plans.NoOp && childValue.Before == nil && childValue.After == nil && !unknown {
 				// Don't record nil values in blocks.
 				continue
 			}
-			blocks.AddAllSetBlock(key, diffs, forcesReplacement, beforeSensitive, afterSensitive)
+			blocks.AddAllSetBlock(key, diffs, forcesReplacement, beforeSensitive, afterSensitive, unknown)
 			current = collections.CompareActions(current, action)
 		case nestingModeList:
 			diffs, action := computeBlockDiffsAsList(childValue, blockType.Block)
-			if action == plans.NoOp && childValue.Before == nil && childValue.After == nil {
+			if action == plans.NoOp && childValue.Before == nil && childValue.After == nil && !unknown {
 				// Don't record nil values in blocks.
 				continue
 			}
-			blocks.AddAllListBlock(key, diffs, forcesReplacement, beforeSensitive, afterSensitive)
+			blocks.AddAllListBlock(key, diffs, forcesReplacement, beforeSensitive, afterSensitive, unknown)
 			current = collections.CompareActions(current, action)
 		case nestingModeMap:
 			diffs, action := computeBlockDiffsAsMap(childValue, blockType.Block)
-			if action == plans.NoOp && childValue.Before == nil && childValue.After == nil {
+			if action == plans.NoOp && childValue.Before == nil && childValue.After == nil && !unknown {
 				// Don't record nil values in blocks.
 				continue
 			}
-			blocks.AddAllMapBlocks(key, diffs, forcesReplacement, beforeSensitive, afterSensitive)
+			blocks.AddAllMapBlocks(key, diffs, forcesReplacement, beforeSensitive, afterSensitive, unknown)
 			current = collections.CompareActions(current, action)
 		case nestingModeSingle, nestingModeGroup:
 			diff := ComputeDiffForBlock(childValue, blockType.Block)
-			if diff.Action == plans.NoOp && childValue.Before == nil && childValue.After == nil {
+			if diff.Action == plans.NoOp && childValue.Before == nil && childValue.After == nil && !unknown {
 				// Don't record nil values in blocks.
 				continue
 			}
-			blocks.AddSingleBlock(key, diff, forcesReplacement, beforeSensitive, afterSensitive)
+			blocks.AddSingleBlock(key, diff, forcesReplacement, beforeSensitive, afterSensitive, unknown)
 			current = collections.CompareActions(current, diff.Action)
 		default:
 			panic("unrecognized nesting mode: " + blockType.NestingMode)

--- a/internal/command/jsonformat/plan_test.go
+++ b/internal/command/jsonformat/plan_test.go
@@ -3469,6 +3469,155 @@ func TestResourceChange_nestedList(t *testing.T) {
         # (1 unchanged block hidden)
     }`,
 		},
+		"in-place create - unknown block": {
+			Action: plans.Create,
+			Mode:   addrs.ManagedResourceMode,
+			Before: cty.NullVal(testSchemaPlus(configschema.NestingList).ImpliedType()),
+			After: cty.ObjectVal(map[string]cty.Value{
+				"id":  cty.StringVal("i-02ae66f368e8518a9"),
+				"ami": cty.StringVal("ami-AFTER"),
+				"disks": cty.ListVal([]cty.Value{
+					cty.ObjectVal(map[string]cty.Value{
+						"mount_point": cty.StringVal("/var/diska"),
+						"size":        cty.StringVal("50GB"),
+					}),
+				}),
+				"root_block_device": cty.UnknownVal(cty.List(cty.Object(map[string]cty.Type{
+					"volume_type": cty.String,
+					"new_field":   cty.String,
+				}))),
+			}),
+			RequiredReplace: cty.NewPathSet(),
+			Schema:          testSchemaPlus(configschema.NestingList),
+			ExpectedOutput: `  # test_instance.example will be created
+  + resource "test_instance" "example" {
+      + ami   = "ami-AFTER"
+      + disks = [
+          + {
+              + mount_point = "/var/diska"
+              + size        = "50GB"
+            },
+        ]
+      + id    = "i-02ae66f368e8518a9"
+
+      + root_block_device (known after apply)
+    }`,
+		},
+		"in-place update - unknown block": {
+			Action: plans.Update,
+			Mode:   addrs.ManagedResourceMode,
+			Before: cty.ObjectVal(map[string]cty.Value{
+				"id":  cty.StringVal("i-02ae66f368e8518a9"),
+				"ami": cty.StringVal("ami-BEFORE"),
+				"disks": cty.ListVal([]cty.Value{
+					cty.ObjectVal(map[string]cty.Value{
+						"mount_point": cty.StringVal("/var/diska"),
+						"size":        cty.StringVal("50GB"),
+					}),
+				}),
+				"root_block_device": cty.ListVal([]cty.Value{
+					cty.ObjectVal(map[string]cty.Value{
+						"volume_type": cty.StringVal("gp1"),
+						"new_field":   cty.StringVal("new_value"),
+					}),
+					cty.ObjectVal(map[string]cty.Value{
+						"volume_type": cty.StringVal("gp2"),
+						"new_field":   cty.StringVal("new_value"),
+					}),
+				}),
+			}),
+			After: cty.ObjectVal(map[string]cty.Value{
+				"id":  cty.StringVal("i-02ae66f368e8518a9"),
+				"ami": cty.StringVal("ami-AFTER"),
+				"disks": cty.ListVal([]cty.Value{
+					cty.ObjectVal(map[string]cty.Value{
+						"mount_point": cty.StringVal("/var/diska"),
+						"size":        cty.StringVal("50GB"),
+					}),
+				}),
+				"root_block_device": cty.UnknownVal(cty.List(cty.Object(map[string]cty.Type{
+					"volume_type": cty.String,
+					"new_field":   cty.String,
+				}))),
+			}),
+			RequiredReplace: cty.NewPathSet(),
+			Schema:          testSchemaPlus(configschema.NestingList),
+			ExpectedOutput: `  # test_instance.example will be updated in-place
+  ~ resource "test_instance" "example" {
+      ~ ami   = "ami-BEFORE" -> "ami-AFTER"
+        id    = "i-02ae66f368e8518a9"
+        # (1 unchanged attribute hidden)
+
+      + root_block_device (known after apply)
+      - root_block_device {
+          - new_field   = "new_value" -> null
+          - volume_type = "gp1" -> null
+        }
+      - root_block_device {
+          - new_field   = "new_value" -> null
+          - volume_type = "gp2" -> null
+        }
+    }`,
+		},
+		"in-place update - unknown block with replace": {
+			Action: plans.CreateThenDelete,
+			Mode:   addrs.ManagedResourceMode,
+			Before: cty.ObjectVal(map[string]cty.Value{
+				"id":  cty.StringVal("i-02ae66f368e8518a9"),
+				"ami": cty.StringVal("ami-BEFORE"),
+				"disks": cty.ListVal([]cty.Value{
+					cty.ObjectVal(map[string]cty.Value{
+						"mount_point": cty.StringVal("/var/diska"),
+						"size":        cty.StringVal("50GB"),
+					}),
+				}),
+				"root_block_device": cty.ListVal([]cty.Value{
+					cty.ObjectVal(map[string]cty.Value{
+						"volume_type": cty.StringVal("gp1"),
+						"new_field":   cty.StringVal("new_value"),
+					}),
+					cty.ObjectVal(map[string]cty.Value{
+						"volume_type": cty.StringVal("gp2"),
+						"new_field":   cty.StringVal("new_value"),
+					}),
+				}),
+			}),
+			After: cty.ObjectVal(map[string]cty.Value{
+				"id":  cty.StringVal("i-02ae66f368e8518a9"),
+				"ami": cty.StringVal("ami-AFTER"),
+				"disks": cty.ListVal([]cty.Value{
+					cty.ObjectVal(map[string]cty.Value{
+						"mount_point": cty.StringVal("/var/diska"),
+						"size":        cty.StringVal("50GB"),
+					}),
+				}),
+				"root_block_device": cty.UnknownVal(cty.List(cty.Object(map[string]cty.Type{
+					"volume_type": cty.String,
+					"new_field":   cty.String,
+				}))),
+			}),
+			RequiredReplace: cty.NewPathSet(
+				cty.GetAttrPath("root_block_device").IndexInt(0).GetAttr("volume_type"),
+				cty.GetAttrPath("root_block_device").IndexInt(1).GetAttr("volume_type"),
+			),
+			Schema: testSchemaPlus(configschema.NestingList),
+			ExpectedOutput: `  # test_instance.example must be replaced
++/- resource "test_instance" "example" {
+      ~ ami   = "ami-BEFORE" -> "ami-AFTER"
+        id    = "i-02ae66f368e8518a9"
+        # (1 unchanged attribute hidden)
+
+      + root_block_device (known after apply)
+      - root_block_device {
+          - new_field   = "new_value" -> null
+          - volume_type = "gp1" -> null # forces replacement
+        }
+      - root_block_device {
+          - new_field   = "new_value" -> null
+          - volume_type = "gp2" -> null # forces replacement
+        }
+    }`,
+		},
 		"in-place update - modification": {
 			Action: plans.Update,
 			Mode:   addrs.ManagedResourceMode,
@@ -4047,6 +4196,155 @@ func TestResourceChange_nestedSet(t *testing.T) {
         # (1 unchanged block hidden)
     }`,
 		},
+		"in-place create - unknown block": {
+			Action: plans.Create,
+			Mode:   addrs.ManagedResourceMode,
+			Before: cty.NullVal(testSchemaPlus(configschema.NestingSet).ImpliedType()),
+			After: cty.ObjectVal(map[string]cty.Value{
+				"id":  cty.StringVal("i-02ae66f368e8518a9"),
+				"ami": cty.StringVal("ami-AFTER"),
+				"disks": cty.SetVal([]cty.Value{
+					cty.ObjectVal(map[string]cty.Value{
+						"mount_point": cty.StringVal("/var/diska"),
+						"size":        cty.StringVal("50GB"),
+					}),
+				}),
+				"root_block_device": cty.UnknownVal(cty.Set(cty.Object(map[string]cty.Type{
+					"volume_type": cty.String,
+					"new_field":   cty.String,
+				}))),
+			}),
+			RequiredReplace: cty.NewPathSet(),
+			Schema:          testSchemaPlus(configschema.NestingSet),
+			ExpectedOutput: `  # test_instance.example will be created
+  + resource "test_instance" "example" {
+      + ami   = "ami-AFTER"
+      + disks = [
+          + {
+              + mount_point = "/var/diska"
+              + size        = "50GB"
+            },
+        ]
+      + id    = "i-02ae66f368e8518a9"
+
+      + root_block_device (known after apply)
+    }`,
+		},
+		"in-place update - unknown block": {
+			Action: plans.Update,
+			Mode:   addrs.ManagedResourceMode,
+			Before: cty.ObjectVal(map[string]cty.Value{
+				"id":  cty.StringVal("i-02ae66f368e8518a9"),
+				"ami": cty.StringVal("ami-BEFORE"),
+				"disks": cty.SetVal([]cty.Value{
+					cty.ObjectVal(map[string]cty.Value{
+						"mount_point": cty.StringVal("/var/diska"),
+						"size":        cty.StringVal("50GB"),
+					}),
+				}),
+				"root_block_device": cty.SetVal([]cty.Value{
+					cty.ObjectVal(map[string]cty.Value{
+						"volume_type": cty.StringVal("gp1"),
+						"new_field":   cty.StringVal("new_value"),
+					}),
+					cty.ObjectVal(map[string]cty.Value{
+						"volume_type": cty.StringVal("gp2"),
+						"new_field":   cty.StringVal("new_value"),
+					}),
+				}),
+			}),
+			After: cty.ObjectVal(map[string]cty.Value{
+				"id":  cty.StringVal("i-02ae66f368e8518a9"),
+				"ami": cty.StringVal("ami-AFTER"),
+				"disks": cty.SetVal([]cty.Value{
+					cty.ObjectVal(map[string]cty.Value{
+						"mount_point": cty.StringVal("/var/diska"),
+						"size":        cty.StringVal("50GB"),
+					}),
+				}),
+				"root_block_device": cty.UnknownVal(cty.Set(cty.Object(map[string]cty.Type{
+					"volume_type": cty.String,
+					"new_field":   cty.String,
+				}))),
+			}),
+			RequiredReplace: cty.NewPathSet(),
+			Schema:          testSchemaPlus(configschema.NestingSet),
+			ExpectedOutput: `  # test_instance.example will be updated in-place
+  ~ resource "test_instance" "example" {
+      ~ ami   = "ami-BEFORE" -> "ami-AFTER"
+        id    = "i-02ae66f368e8518a9"
+        # (1 unchanged attribute hidden)
+
+      + root_block_device (known after apply)
+      - root_block_device {
+          - new_field   = "new_value" -> null
+          - volume_type = "gp1" -> null
+        }
+      - root_block_device {
+          - new_field   = "new_value" -> null
+          - volume_type = "gp2" -> null
+        }
+    }`,
+		},
+		"in-place update - unknown block with replace": {
+			Action: plans.CreateThenDelete,
+			Mode:   addrs.ManagedResourceMode,
+			Before: cty.ObjectVal(map[string]cty.Value{
+				"id":  cty.StringVal("i-02ae66f368e8518a9"),
+				"ami": cty.StringVal("ami-BEFORE"),
+				"disks": cty.SetVal([]cty.Value{
+					cty.ObjectVal(map[string]cty.Value{
+						"mount_point": cty.StringVal("/var/diska"),
+						"size":        cty.StringVal("50GB"),
+					}),
+				}),
+				"root_block_device": cty.SetVal([]cty.Value{
+					cty.ObjectVal(map[string]cty.Value{
+						"volume_type": cty.StringVal("gp1"),
+						"new_field":   cty.StringVal("new_value"),
+					}),
+					cty.ObjectVal(map[string]cty.Value{
+						"volume_type": cty.StringVal("gp2"),
+						"new_field":   cty.StringVal("new_value"),
+					}),
+				}),
+			}),
+			After: cty.ObjectVal(map[string]cty.Value{
+				"id":  cty.StringVal("i-02ae66f368e8518a9"),
+				"ami": cty.StringVal("ami-AFTER"),
+				"disks": cty.SetVal([]cty.Value{
+					cty.ObjectVal(map[string]cty.Value{
+						"mount_point": cty.StringVal("/var/diska"),
+						"size":        cty.StringVal("50GB"),
+					}),
+				}),
+				"root_block_device": cty.UnknownVal(cty.Set(cty.Object(map[string]cty.Type{
+					"volume_type": cty.String,
+					"new_field":   cty.String,
+				}))),
+			}),
+			RequiredReplace: cty.NewPathSet(
+				cty.GetAttrPath("root_block_device").IndexInt(0).GetAttr("volume_type"),
+				cty.GetAttrPath("root_block_device").IndexInt(1).GetAttr("volume_type"),
+			),
+			Schema: testSchemaPlus(configschema.NestingSet),
+			ExpectedOutput: `  # test_instance.example must be replaced
++/- resource "test_instance" "example" {
+      ~ ami   = "ami-BEFORE" -> "ami-AFTER"
+        id    = "i-02ae66f368e8518a9"
+        # (1 unchanged attribute hidden)
+
+      + root_block_device (known after apply)
+      - root_block_device {
+          - new_field   = "new_value" -> null
+          - volume_type = "gp1" -> null # forces replacement
+        }
+      - root_block_device {
+          - new_field   = "new_value" -> null
+          - volume_type = "gp2" -> null # forces replacement
+        }
+    }`,
+		},
 	}
 	runTestCases(t, testCases)
 }
@@ -4426,6 +4724,155 @@ func TestResourceChange_nestedMap(t *testing.T) {
         id    = "i-02ae66f368e8518a9"
 
         # (1 unchanged block hidden)
+    }`,
+		},
+		"in-place create - unknown block": {
+			Action: plans.Create,
+			Mode:   addrs.ManagedResourceMode,
+			Before: cty.NullVal(testSchemaPlus(configschema.NestingMap).ImpliedType()),
+			After: cty.ObjectVal(map[string]cty.Value{
+				"id":  cty.StringVal("i-02ae66f368e8518a9"),
+				"ami": cty.StringVal("ami-AFTER"),
+				"disks": cty.MapVal(map[string]cty.Value{
+					"diska": cty.ObjectVal(map[string]cty.Value{
+						"mount_point": cty.StringVal("/var/diska"),
+						"size":        cty.StringVal("50GB"),
+					}),
+				}),
+				"root_block_device": cty.UnknownVal(cty.Map(cty.Object(map[string]cty.Type{
+					"volume_type": cty.String,
+					"new_field":   cty.String,
+				}))),
+			}),
+			RequiredReplace: cty.NewPathSet(),
+			Schema:          testSchemaPlus(configschema.NestingMap),
+			ExpectedOutput: `  # test_instance.example will be created
+  + resource "test_instance" "example" {
+      + ami   = "ami-AFTER"
+      + disks = {
+          + "diska" = {
+              + mount_point = "/var/diska"
+              + size        = "50GB"
+            },
+        }
+      + id    = "i-02ae66f368e8518a9"
+
+      + root_block_device (known after apply)
+    }`,
+		},
+		"in-place update - unknown block": {
+			Action: plans.Update,
+			Mode:   addrs.ManagedResourceMode,
+			Before: cty.ObjectVal(map[string]cty.Value{
+				"id":  cty.StringVal("i-02ae66f368e8518a9"),
+				"ami": cty.StringVal("ami-BEFORE"),
+				"disks": cty.MapVal(map[string]cty.Value{
+					"diska": cty.ObjectVal(map[string]cty.Value{
+						"mount_point": cty.StringVal("/var/diska"),
+						"size":        cty.StringVal("50GB"),
+					}),
+				}),
+				"root_block_device": cty.MapVal(map[string]cty.Value{
+					"gp1": cty.ObjectVal(map[string]cty.Value{
+						"volume_type": cty.StringVal("gp1"),
+						"new_field":   cty.StringVal("new_value"),
+					}),
+					"gp2": cty.ObjectVal(map[string]cty.Value{
+						"volume_type": cty.StringVal("gp2"),
+						"new_field":   cty.StringVal("new_value"),
+					}),
+				}),
+			}),
+			After: cty.ObjectVal(map[string]cty.Value{
+				"id":  cty.StringVal("i-02ae66f368e8518a9"),
+				"ami": cty.StringVal("ami-AFTER"),
+				"disks": cty.MapVal(map[string]cty.Value{
+					"diska": cty.ObjectVal(map[string]cty.Value{
+						"mount_point": cty.StringVal("/var/diska"),
+						"size":        cty.StringVal("50GB"),
+					}),
+				}),
+				"root_block_device": cty.UnknownVal(cty.Map(cty.Object(map[string]cty.Type{
+					"volume_type": cty.String,
+					"new_field":   cty.String,
+				}))),
+			}),
+			RequiredReplace: cty.NewPathSet(),
+			Schema:          testSchemaPlus(configschema.NestingMap),
+			ExpectedOutput: `  # test_instance.example will be updated in-place
+  ~ resource "test_instance" "example" {
+      ~ ami   = "ami-BEFORE" -> "ami-AFTER"
+        id    = "i-02ae66f368e8518a9"
+        # (1 unchanged attribute hidden)
+
+      + root_block_device (known after apply)
+      - root_block_device "gp1" {
+          - new_field   = "new_value" -> null
+          - volume_type = "gp1" -> null
+        }
+      - root_block_device "gp2" {
+          - new_field   = "new_value" -> null
+          - volume_type = "gp2" -> null
+        }
+    }`,
+		},
+		"in-place update - unknown block with replace": {
+			Action: plans.CreateThenDelete,
+			Mode:   addrs.ManagedResourceMode,
+			Before: cty.ObjectVal(map[string]cty.Value{
+				"id":  cty.StringVal("i-02ae66f368e8518a9"),
+				"ami": cty.StringVal("ami-BEFORE"),
+				"disks": cty.MapVal(map[string]cty.Value{
+					"diska": cty.ObjectVal(map[string]cty.Value{
+						"mount_point": cty.StringVal("/var/diska"),
+						"size":        cty.StringVal("50GB"),
+					}),
+				}),
+				"root_block_device": cty.MapVal(map[string]cty.Value{
+					"gp1": cty.ObjectVal(map[string]cty.Value{
+						"volume_type": cty.StringVal("gp1"),
+						"new_field":   cty.StringVal("new_value"),
+					}),
+					"gp2": cty.ObjectVal(map[string]cty.Value{
+						"volume_type": cty.StringVal("gp2"),
+						"new_field":   cty.StringVal("new_value"),
+					}),
+				}),
+			}),
+			After: cty.ObjectVal(map[string]cty.Value{
+				"id":  cty.StringVal("i-02ae66f368e8518a9"),
+				"ami": cty.StringVal("ami-AFTER"),
+				"disks": cty.MapVal(map[string]cty.Value{
+					"diska": cty.ObjectVal(map[string]cty.Value{
+						"mount_point": cty.StringVal("/var/diska"),
+						"size":        cty.StringVal("50GB"),
+					}),
+				}),
+				"root_block_device": cty.UnknownVal(cty.Map(cty.Object(map[string]cty.Type{
+					"volume_type": cty.String,
+					"new_field":   cty.String,
+				}))),
+			}),
+			RequiredReplace: cty.NewPathSet(
+				cty.GetAttrPath("root_block_device").IndexString("gp1").GetAttr("volume_type"),
+				cty.GetAttrPath("root_block_device").IndexString("gp2").GetAttr("volume_type"),
+			),
+			Schema: testSchemaPlus(configschema.NestingMap),
+			ExpectedOutput: `  # test_instance.example must be replaced
++/- resource "test_instance" "example" {
+      ~ ami   = "ami-BEFORE" -> "ami-AFTER"
+        id    = "i-02ae66f368e8518a9"
+        # (1 unchanged attribute hidden)
+
+      + root_block_device (known after apply)
+      - root_block_device "gp1" {
+          - new_field   = "new_value" -> null
+          - volume_type = "gp1" -> null # forces replacement
+        }
+      - root_block_device "gp2" {
+          - new_field   = "new_value" -> null
+          - volume_type = "gp2" -> null # forces replacement
+        }
     }`,
 		},
 		"in-place update - insertion sensitive": {
@@ -5353,6 +5800,120 @@ func TestResourceChange_nestedSingle(t *testing.T) {
         id   = "i-02ae66f368e8518a9"
 
         # (1 unchanged block hidden)
+    }`,
+		},
+		"in-place create - unknown block": {
+			Action: plans.Create,
+			Mode:   addrs.ManagedResourceMode,
+			Before: cty.NullVal(testSchemaPlus(configschema.NestingSingle).ImpliedType()),
+			After: cty.ObjectVal(map[string]cty.Value{
+				"id":  cty.StringVal("i-02ae66f368e8518a9"),
+				"ami": cty.StringVal("ami-AFTER"),
+				"disk": cty.ObjectVal(map[string]cty.Value{
+					"mount_point": cty.StringVal("/var/diska"),
+					"size":        cty.StringVal("50GB"),
+				}),
+				"root_block_device": cty.UnknownVal(cty.Object(map[string]cty.Type{
+					"volume_type": cty.String,
+					"new_field":   cty.String,
+				})),
+			}),
+			RequiredReplace: cty.NewPathSet(),
+			Schema:          testSchemaPlus(configschema.NestingSingle),
+			ExpectedOutput: `  # test_instance.example will be created
+  + resource "test_instance" "example" {
+      + ami  = "ami-AFTER"
+      + disk = {
+          + mount_point = "/var/diska"
+          + size        = "50GB"
+        }
+      + id   = "i-02ae66f368e8518a9"
+
+      + root_block_device (known after apply)
+    }`,
+		},
+		"in-place update - unknown block": {
+			Action: plans.Update,
+			Mode:   addrs.ManagedResourceMode,
+			Before: cty.ObjectVal(map[string]cty.Value{
+				"id":  cty.StringVal("i-02ae66f368e8518a9"),
+				"ami": cty.StringVal("ami-BEFORE"),
+				"disk": cty.ObjectVal(map[string]cty.Value{
+					"mount_point": cty.StringVal("/var/diska"),
+					"size":        cty.StringVal("50GB"),
+				}),
+				"root_block_device": cty.ObjectVal(map[string]cty.Value{
+					"volume_type": cty.StringVal("gp1"),
+					"new_field":   cty.StringVal("new_value"),
+				}),
+			}),
+			After: cty.ObjectVal(map[string]cty.Value{
+				"id":  cty.StringVal("i-02ae66f368e8518a9"),
+				"ami": cty.StringVal("ami-AFTER"),
+				"disk": cty.ObjectVal(map[string]cty.Value{
+					"mount_point": cty.StringVal("/var/diska"),
+					"size":        cty.StringVal("50GB"),
+				}),
+				"root_block_device": cty.UnknownVal(cty.Object(map[string]cty.Type{
+					"volume_type": cty.String,
+					"new_field":   cty.String,
+				})),
+			}),
+			RequiredReplace: cty.NewPathSet(),
+			Schema:          testSchemaPlus(configschema.NestingSingle),
+			ExpectedOutput: `  # test_instance.example will be updated in-place
+  ~ resource "test_instance" "example" {
+      ~ ami  = "ami-BEFORE" -> "ami-AFTER"
+        id   = "i-02ae66f368e8518a9"
+        # (1 unchanged attribute hidden)
+
+      ~ root_block_device {
+          ~ new_field   = "new_value" -> (known after apply)
+          ~ volume_type = "gp1" -> (known after apply)
+        } -> (known after apply)
+    }`,
+		},
+		"in-place update - unknown block with replace": {
+			Action: plans.CreateThenDelete,
+			Mode:   addrs.ManagedResourceMode,
+			Before: cty.ObjectVal(map[string]cty.Value{
+				"id":  cty.StringVal("i-02ae66f368e8518a9"),
+				"ami": cty.StringVal("ami-BEFORE"),
+				"disk": cty.ObjectVal(map[string]cty.Value{
+					"mount_point": cty.StringVal("/var/diska"),
+					"size":        cty.StringVal("50GB"),
+				}),
+				"root_block_device": cty.ObjectVal(map[string]cty.Value{
+					"volume_type": cty.StringVal("gp1"),
+					"new_field":   cty.StringVal("new_value"),
+				}),
+			}),
+			After: cty.ObjectVal(map[string]cty.Value{
+				"id":  cty.StringVal("i-02ae66f368e8518a9"),
+				"ami": cty.StringVal("ami-AFTER"),
+				"disk": cty.ObjectVal(map[string]cty.Value{
+					"mount_point": cty.StringVal("/var/diska"),
+					"size":        cty.StringVal("50GB"),
+				}),
+				"root_block_device": cty.UnknownVal(cty.Object(map[string]cty.Type{
+					"volume_type": cty.String,
+					"new_field":   cty.String,
+				})),
+			}),
+			RequiredReplace: cty.NewPathSet(
+				cty.GetAttrPath("root_block_device").GetAttr("volume_type"),
+			),
+			Schema: testSchemaPlus(configschema.NestingSingle),
+			ExpectedOutput: `  # test_instance.example must be replaced
++/- resource "test_instance" "example" {
+      ~ ami  = "ami-BEFORE" -> "ami-AFTER"
+        id   = "i-02ae66f368e8518a9"
+        # (1 unchanged attribute hidden)
+
+      ~ root_block_device {
+          ~ new_field   = "new_value" -> (known after apply)
+          ~ volume_type = "gp1" -> (known after apply) # forces replacement
+        } -> (known after apply)
     }`,
 		},
 		"in-place update - modification": {


### PR DESCRIPTION
This PR updates the rendering logic so that it properly renders the contents of a nested block that is becoming unknown. Previously, we'd only render a single item for the whole nested block. Now we should a single item being created that is unknown, and all existing entries being marked as deleted.

In addition, this change fixes a crash that would occur when nested blocks were becoming unknown and contained attributes that were forcing the resource to be replaced. We weren't properly accounting for the nested indices within the replacement list, and now since we are properly computing the diffs we are.

Fixes #35556 

## Target Release

v1.9.7

## CHANGELOG entry

### BUG FIXES

- Plan renderer: Fix crash that occurs when attempting to render unknown nested blocks that contain attributes forcing replacement.
- Plan renderer: Render complete changes within unknown nested blocks. 