### PR TITLE
internal/command: Avoid ignoring `ephemeralasnull` function

### DIFF
--- a/internal/command/metadata_functions.go
+++ b/internal/command/metadata_functions.go
@@ -12,7 +12,7 @@ import (
 )
 
 var (
-	ignoredFunctions = []string{"map", "list", "core::map", "core::list", "ephemeralasnull", "core::ephemeralasnull"}
+	ignoredFunctions = []string{"map", "list", "core::map", "core::list"}
 )
 
 // MetadataFunctionsCommand is a Command implementation that prints out information


### PR DESCRIPTION
In the context of ephemeral values [no longer being an experiment](https://github.com/hashicorp/terraform/pull/35636) there is no point in ignoring the function when printing out machine-readable signatures.

### Before

```
$ terraform metadata functions -json | jq '.function_signatures | keys' | grep -c ephemeral
0
```

### After

```
$ terraform metadata functions -json | jq '.function_signatures | keys' | grep ephemeral
  "core::ephemeralasnull",
  "ephemeralasnull",
```