### PR TITLE
lang/functions: Add test for `ephemeralasnull`

### DIFF
--- a/internal/lang/functions_test.go
+++ b/internal/lang/functions_test.go
@@ -364,10 +364,10 @@ func TestFunctions(t *testing.T) {
 		},
 
 		"ephemeralasnull": {
-			// We can't actually test the main behavior of this one here
-			// because we don't have any ephemeral values in scope, so
-			// this is just to check that the function is registered. The
-			// real tests for this function are in package funcs.
+			{
+				`ephemeralasnull(local.ephemeral)`,
+				cty.NullVal(cty.String),
+			},
 			{
 				`ephemeralasnull("not ephemeral")`,
 				cty.StringVal("not ephemeral"),
@@ -1340,6 +1340,7 @@ func TestFunctions(t *testing.T) {
 					data := &dataForTests{
 						LocalValues: map[string]cty.Value{
 							"greeting_template": cty.StringVal("Hello, ${name}!"),
+							"ephemeral":         cty.StringVal("ephemeral").Mark(marks.Ephemeral),
 						},
 					}
 					scope := &Scope{


### PR DESCRIPTION
Just adding tests where there were previously missing - I can't think of a reason for them missing - probably just because testing experiments was/is difficult.

I couldn't figure out a way of testing unknown values - or to put it differently - I couldn't find any existing tests for unknown values. We can always add those later.