### PR TITLE
lang/functions: Introduce `ephemeral()` function

### DIFF
--- a/internal/lang/funcs/descriptions.go
+++ b/internal/lang/funcs/descriptions.go
@@ -162,6 +162,10 @@ var DescriptionList = map[string]descriptionEntry{
 		Description:      "`endswith` takes two values: a string to check and a suffix string. The function returns true if the first string ends with that exact suffix.",
 		ParamDescription: []string{"", ""},
 	},
+	"ephemeral": {
+		Description:      "`ephemeral` takes a value of any type and marks it as ephemeral.",
+		ParamDescription: []string{""},
+	},
 	"ephemeralasnull": {
 		Description:      "`ephemeralasnull` takes a value of any type and returns a similar value of the same type with any ephemeral values replaced with non-ephemeral null values and all non-ephemeral values preserved.",
 		ParamDescription: []string{""},

--- a/internal/lang/functions.go
+++ b/internal/lang/functions.go
@@ -89,6 +89,7 @@ func (s *Scope) Functions() map[string]function.Function {
 			"distinct":         stdlib.DistinctFunc,
 			"element":          stdlib.ElementFunc,
 			"endswith":         funcs.EndsWithFunc,
+			"ephemeral":        funcs.EphemeralFunc,
 			"ephemeralasnull":  funcs.EphemeralAsNullFunc,
 			"chunklist":        stdlib.ChunklistFunc,
 			"file":             funcs.MakeFileFunc(s.BaseDir, false),

--- a/internal/lang/functions_test.go
+++ b/internal/lang/functions_test.go
@@ -363,6 +363,13 @@ func TestFunctions(t *testing.T) {
 			},
 		},
 
+		"ephemeral": {
+			{
+				`ephemeral("ephemeral")`,
+				cty.StringVal("ephemeral").Mark(marks.Ephemeral),
+			},
+		},
+
 		"ephemeralasnull": {
 			{
 				`ephemeralasnull(local.ephemeral)`,


### PR DESCRIPTION
This introduces a new `ephemeral()` function to let users mark arbitrary expressions as ephemeral. This is effectively the opposite of `ephemeralasnull()`.

More context is in https://github.com/hashicorp/terraform/pull/35672