### PR TITLE
deferred actions: fix missing features in deletions

### DIFF
--- a/internal/terraform/node_resource_destroy_deposed_test.go
+++ b/internal/terraform/node_resource_destroy_deposed_test.go
@@ -6,12 +6,14 @@ package terraform
 import (
 	"testing"
 
+	"github.com/zclconf/go-cty/cty"
+
 	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/configs/configschema"
 	"github.com/hashicorp/terraform/internal/plans"
+	"github.com/hashicorp/terraform/internal/plans/deferring"
 	"github.com/hashicorp/terraform/internal/providers"
 	"github.com/hashicorp/terraform/internal/states"
-	"github.com/zclconf/go-cty/cty"
 )
 
 func TestNodePlanDeposedResourceInstanceObject_Execute(t *testing.T) {
@@ -127,6 +129,7 @@ func TestNodeDestroyDeposedResourceInstanceObject_Execute(t *testing.T) {
 		ProviderProvider:     p,
 		ProviderSchemaSchema: schema,
 		ChangesChanges:       plans.NewChanges().SyncWrapper(),
+		DeferralsState:       deferring.NewDeferred(false),
 	}
 
 	node := NodeDestroyDeposedResourceInstanceObject{

--- a/internal/terraform/node_resource_plan_instance.go
+++ b/internal/terraform/node_resource_plan_instance.go
@@ -496,7 +496,9 @@ func (n *NodePlannableResourceInstance) managedResourceExecute(ctx EvalContext) 
 		// here, if there was one.
 		if refreshDeferred != nil {
 			ctx.Deferrals().ReportResourceInstanceDeferred(addr, deferred.Reason, &plans.ResourceInstanceChange{
-				Addr: n.Addr,
+				Addr:         n.Addr,
+				PrevRunAddr:  n.Addr,
+				ProviderAddr: n.ResolvedProvider,
 				Change: plans.Change{
 					Action: plans.Read,
 					Before: priorInstanceRefreshState.Value,

--- a/internal/terraform/node_resource_plan_orphan_test.go
+++ b/internal/terraform/node_resource_plan_orphan_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/instances"
 	"github.com/hashicorp/terraform/internal/plans"
+	"github.com/hashicorp/terraform/internal/plans/deferring"
 	"github.com/hashicorp/terraform/internal/providers"
 	"github.com/hashicorp/terraform/internal/states"
 )
@@ -51,6 +52,7 @@ func TestNodeResourcePlanOrphanExecute(t *testing.T) {
 			},
 		},
 		ChangesChanges: plans.NewChanges().SyncWrapper(),
+		DeferralsState: deferring.NewDeferred(false),
 	}
 
 	node := NodePlannableResourceInstanceOrphan{
@@ -117,6 +119,7 @@ func TestNodeResourcePlanOrphanExecute_alreadyDeleted(t *testing.T) {
 			},
 		},
 		ChangesChanges: changes.SyncWrapper(),
+		DeferralsState: deferring.NewDeferred(false),
 	}
 
 	node := NodePlannableResourceInstanceOrphan{
@@ -199,6 +202,7 @@ func TestNodeResourcePlanOrphanExecute_deposed(t *testing.T) {
 			},
 		},
 		ChangesChanges: changes.SyncWrapper(),
+		DeferralsState: deferring.NewDeferred(false),
 	}
 
 	node := NodePlannableResourceInstanceOrphan{


### PR DESCRIPTION
The deferred actions deletion story was a bit inconsistent. This PR updates the destroy paths so they follow the same logic as the create and destroy operations. Namely: 

- They complete the full operation even if an early call defers. This means if a refresh defers, we'll still do the plan and work out a proper diff and then defer with that change instead of a partial change.
- We always set the provider address, where previously we were only setting it some of the time which was causing problems later when trying to read/render the plan.
- Finally, we respect the "defer all changes" part of the plan options. Previously, destroy operations would still apply even when the entire plan was supposed to be deferred.

