### PR TITLE
internal/lang: `ephemeralasnull`: Add test for unknown values

### DIFF
--- a/internal/lang/functions_test.go
+++ b/internal/lang/functions_test.go
@@ -372,6 +372,14 @@ func TestFunctions(t *testing.T) {
 				`ephemeralasnull("not ephemeral")`,
 				cty.StringVal("not ephemeral"),
 			},
+			{
+				`ephemeralasnull(local.unknown)`,
+				cty.UnknownVal(cty.String),
+			},
+			{
+				`ephemeralasnull(local.unknown_sensitive)`,
+				cty.UnknownVal(cty.String).Mark(marks.Sensitive),
+			},
 		},
 
 		"file": {
@@ -1341,6 +1349,8 @@ func TestFunctions(t *testing.T) {
 						LocalValues: map[string]cty.Value{
 							"greeting_template": cty.StringVal("Hello, ${name}!"),
 							"ephemeral":         cty.StringVal("ephemeral").Mark(marks.Ephemeral),
+							"unknown":           cty.UnknownVal(cty.String),
+							"unknown_sensitive": cty.UnknownVal(cty.String).Mark(marks.Sensitive),
 						},
 					}
 					scope := &Scope{


### PR DESCRIPTION
This is a small PR following up on https://github.com/hashicorp/terraform/pull/35652 which I wanted to split from https://github.com/hashicorp/terraform/pull/35653 as that PR may require some further discussions.

It covers the extra logic present in the function implementation concerning unknown values:

https://github.com/hashicorp/terraform/blob/e312ffc2d821901e982f897de952944070f74f19/internal/lang/funcs/conversion.go#L132-L144

In other words, the test (and underlying logic under test) ensures that other marks (other than ephemerality) are retained while passing through that function.