### PR TITLE
stacks: ensure that all components in state are referenced in configuration

### DIFF
--- a/internal/stacks/stackruntime/apply_test.go
+++ b/internal/stacks/stackruntime/apply_test.go
@@ -3149,8 +3149,6 @@ func TestApply_RemovedBlocks(t *testing.T) {
 	// TODO: Add tests for and implement the following cases:
 	//   - Removed and component blocks that target the same instance.
 	//   - Edge cases around missing providers and type mismatches.
-	//   - Make sure all instances in state are targeted by a component or a
-	//     removed block.
 	//   - Validate what happens when a removed block foreach evaluates to
 	//     unknown.
 	//   - Add a test for a removed block in an embedded stack.

--- a/internal/stacks/stackruntime/helper_test.go
+++ b/internal/stacks/stackruntime/helper_test.go
@@ -113,12 +113,12 @@ func expectDiagnosticsForTest(t *testing.T, actual tfdiags.Diagnostics, expected
 			t.Errorf("diagnostic [%d] has wrong severity: %s (expected %s)", ix, actual[ix].Severity(), expected[ix].severity)
 		}
 
-		if actual[ix].Description().Summary != expected[ix].summary {
-			t.Errorf("diagnostic [%d] has wrong summary: %s (expected %s)", ix, actual[ix].Description().Summary, expected[ix].summary)
+		if diff := cmp.Diff(actual[ix].Description().Summary, expected[ix].summary); len(diff) > 0 {
+			t.Errorf("diagnostic [%d] has wrong summary: %s", ix, diff)
 		}
 
-		if actual[ix].Description().Detail != expected[ix].detail {
-			t.Errorf("diagnostic [%d] has wrong detail: %s (expected %s)", ix, actual[ix].Description().Detail, expected[ix].detail)
+		if diff := cmp.Diff(actual[ix].Description().Detail, expected[ix].detail); len(diff) > 0 {
+			t.Errorf("diagnostic [%d] has wrong detail: %s", ix, diff)
 		}
 	}
 }

--- a/internal/stacks/stackruntime/plan_test.go
+++ b/internal/stacks/stackruntime/plan_test.go
@@ -4453,7 +4453,7 @@ func TestPlan_RemovedBlocks(t *testing.T) {
 
 			providers := map[addrs.Provider]providers.Factory{
 				addrs.NewDefaultProvider("testing"): func() (providers.Interface, error) {
-					return stacks_testing_provider.NewProviderWithData(tc.store), nil
+					return stacks_testing_provider.NewProviderWithData(t, tc.store), nil
 				},
 			}
 


### PR DESCRIPTION
This PR adds a check to the root Stack object such that it will add diagnostics if it discovers any components within state that are not referenced by a component or a removed block. This ensures that users don't think they are deleting resources by removing a component block and forgetting to add a removed block.