### PR TITLE
backend/local: Indicate ephemerality in variable prompts

### DIFF
--- a/internal/backend/local/backend_local.go
+++ b/internal/backend/local/backend_local.go
@@ -405,9 +405,13 @@ func (b *Local) interactiveCollectVariables(ctx context.Context, existing map[st
 	}
 	for _, name := range needed {
 		vc := vcs[name]
+		query := fmt.Sprintf("var.%s", name)
+		if vc.Ephemeral {
+			query += " (ephemeral)"
+		}
 		rawValue, err := uiInput.Input(ctx, &terraform.InputOpts{
 			Id:          fmt.Sprintf("var.%s", name),
-			Query:       fmt.Sprintf("var.%s", name),
+			Query:       query,
 			Description: vc.Description,
 			Secret:      vc.Sensitive,
 		})


### PR DESCRIPTION
This is to ensure users are aware of any side effects when entering value of a variable.

One alternative I considered was to extend `InputOpts` by introducing `Ephemeral bool`, just to ensure that the "(ephemeral)" note is not formatted as bold.

![Screenshot 2024-09-09 at 16 45 25](https://github.com/user-attachments/assets/790b4928-9010-4ee6-b83f-e67934d13ffe)

```hcl
variable "test" {
  ephemeral = true
  description = "test description"
}
```

We could also consider different wording to make the side effects more obvious but I can't think of anything more obvious that also happens to be short.