### PR TITLE
Update version-constraints.mdx

### DIFF
--- a/website/docs/language/expressions/version-constraints.mdx
+++ b/website/docs/language/expressions/version-constraints.mdx
@@ -18,7 +18,7 @@ constraint. Version constraints are used when configuring:
 ## Version Constraint Syntax
 
 Terraform's syntax for version constraints is very similar to the syntax used by
-other dependency management systems like [Bundler](https://bundler.io/) and [npm](https://www.npmjs.com/).
+other dependency management systems like Bundler and npm.
 
 ```hcl
 version = ">= 1.2.0, < 2.0.0"

--- a/website/docs/language/expressions/version-constraints.mdx
+++ b/website/docs/language/expressions/version-constraints.mdx
@@ -18,7 +18,7 @@ constraint. Version constraints are used when configuring:
 ## Version Constraint Syntax
 
 Terraform's syntax for version constraints is very similar to the syntax used by
-other dependency management systems like Bundler and NPM.
+other dependency management systems like [Bundler](https://bundler.io/) and [npm](https://www.npmjs.com/).
 
 ```hcl
 version = ">= 1.2.0, < 2.0.0"


### PR DESCRIPTION
npm is supposed to be lowercase, so this is a bug in the docs. I fixed this bug and decided to linkify it for good measure.