### PR TITLE
Fix typo in test.go

### DIFF
--- a/internal/command/test.go
+++ b/internal/command/test.go
@@ -43,7 +43,7 @@ Usage: terraform [global options] test [options]
 Options:
 
   -cloud-run=source     If specified, Terraform will execute this test run 
-                        remotely using HCP Terraform or Terraform Enterpise. 
+                        remotely using HCP Terraform or Terraform Enterprise. 
 						You must specify the source of a module registered in 
 						a private module registry as the argument to this flag. 
 						This allows Terraform to associate the cloud run with 


### PR DESCRIPTION
Fixes a tiny typo.

## Target Release

1.8.x

## Draft CHANGELOG entry

### BUG FIXES
-  `terraform test -help`: Fixed a tiny typo ("Enterpise" -> "Enterprise").
