### PR TITLE
plan renderer: fix crash when updating a null attribute to unknown

### DIFF
--- a/internal/command/jsonformat/computed/renderers/block.go
+++ b/internal/command/jsonformat/computed/renderers/block.go
@@ -158,7 +158,7 @@ func (renderer blockRenderer) RenderHuman(diff computed.Diff, indent int, opts c
 			sort.Strings(keys)
 
 			if renderer.blocks.UnknownBlocks[key] {
-				renderBlock(computed.NewDiff(Unknown(computed.Diff{}), plans.Create, false), "", opts)
+				renderBlock(computed.NewDiff(Unknown(computed.Diff{}), diff.Action, false), "", opts)
 			}
 
 			for _, innerKey := range keys {
@@ -170,7 +170,7 @@ func (renderer blockRenderer) RenderHuman(diff computed.Diff, indent int, opts c
 			setOpts.ForceForcesReplacement = diff.Replace
 
 			if renderer.blocks.UnknownBlocks[key] {
-				renderBlock(computed.NewDiff(Unknown(computed.Diff{}), plans.Create, false), "", opts)
+				renderBlock(computed.NewDiff(Unknown(computed.Diff{}), diff.Action, false), "", opts)
 			}
 
 			for _, block := range renderer.blocks.SetBlocks[key] {
@@ -179,7 +179,7 @@ func (renderer blockRenderer) RenderHuman(diff computed.Diff, indent int, opts c
 		case renderer.blocks.IsListBlock(key):
 
 			if renderer.blocks.UnknownBlocks[key] {
-				renderBlock(computed.NewDiff(Unknown(computed.Diff{}), plans.Create, false), "", opts)
+				renderBlock(computed.NewDiff(Unknown(computed.Diff{}), diff.Action, false), "", opts)
 			}
 
 			for _, block := range renderer.blocks.ListBlocks[key] {

--- a/internal/command/jsonformat/computed/renderers/renderer_test.go
+++ b/internal/command/jsonformat/computed/renderers/renderer_test.go
@@ -433,6 +433,13 @@ jsonencode(
 			},
 			expected: "0 -> (known after apply)",
 		},
+		"computed_update_from_null": {
+			diff: computed.Diff{
+				Renderer: Unknown(computed.Diff{}),
+				Action:   plans.Update,
+			},
+			expected: "(known after apply)",
+		},
 		"computed_create_forces_replacement": {
 			diff: computed.Diff{
 				Renderer: Unknown(computed.Diff{}),

--- a/internal/command/jsonformat/computed/renderers/unknown.go
+++ b/internal/command/jsonformat/computed/renderers/unknown.go
@@ -26,7 +26,12 @@ type unknownRenderer struct {
 }
 
 func (renderer unknownRenderer) RenderHuman(diff computed.Diff, indent int, opts computed.RenderHumanOpts) string {
-	if diff.Action == plans.Create {
+
+	// the before renderer can be nil and not a create action when the provider
+	// previously returned a null value for the computed attribute and is now
+	// declaring they will recompute it as part of the next update.
+
+	if diff.Action == plans.Create || renderer.before.Renderer == nil {
 		return fmt.Sprintf("(known after apply)%s", forcesReplacement(diff.Replace, opts))
 	}
 

--- a/internal/command/jsonformat/plan_test.go
+++ b/internal/command/jsonformat/plan_test.go
@@ -3548,7 +3548,7 @@ func TestResourceChange_nestedList(t *testing.T) {
         id    = "i-02ae66f368e8518a9"
         # (1 unchanged attribute hidden)
 
-      + root_block_device (known after apply)
+      ~ root_block_device (known after apply)
       - root_block_device {
           - new_field   = "new_value" -> null
           - volume_type = "gp1" -> null
@@ -3607,7 +3607,7 @@ func TestResourceChange_nestedList(t *testing.T) {
         id    = "i-02ae66f368e8518a9"
         # (1 unchanged attribute hidden)
 
-      + root_block_device (known after apply)
+      ~ root_block_device (known after apply)
       - root_block_device {
           - new_field   = "new_value" -> null
           - volume_type = "gp1" -> null # forces replacement
@@ -4275,7 +4275,7 @@ func TestResourceChange_nestedSet(t *testing.T) {
         id    = "i-02ae66f368e8518a9"
         # (1 unchanged attribute hidden)
 
-      + root_block_device (known after apply)
+      ~ root_block_device (known after apply)
       - root_block_device {
           - new_field   = "new_value" -> null
           - volume_type = "gp1" -> null
@@ -4334,7 +4334,7 @@ func TestResourceChange_nestedSet(t *testing.T) {
         id    = "i-02ae66f368e8518a9"
         # (1 unchanged attribute hidden)
 
-      + root_block_device (known after apply)
+      ~ root_block_device (known after apply)
       - root_block_device {
           - new_field   = "new_value" -> null
           - volume_type = "gp1" -> null # forces replacement
@@ -4805,7 +4805,7 @@ func TestResourceChange_nestedMap(t *testing.T) {
         id    = "i-02ae66f368e8518a9"
         # (1 unchanged attribute hidden)
 
-      + root_block_device (known after apply)
+      ~ root_block_device (known after apply)
       - root_block_device "gp1" {
           - new_field   = "new_value" -> null
           - volume_type = "gp1" -> null
@@ -4864,7 +4864,7 @@ func TestResourceChange_nestedMap(t *testing.T) {
         id    = "i-02ae66f368e8518a9"
         # (1 unchanged attribute hidden)
 
-      + root_block_device (known after apply)
+      ~ root_block_device (known after apply)
       - root_block_device "gp1" {
           - new_field   = "new_value" -> null
           - volume_type = "gp1" -> null # forces replacement


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

This PR fixes a crash in the plan renderer that occurs when a plan marks an attribute that was null as becoming unknown.

The renderer had assumed that all computed attributes would have a value if the resource was being updated, so was only checking for `plans.Create` actions before deciding whether to render the "before" part of an unknown change. Now, we explicitly check whether the before part has a renderer at all when deciding whether to render the before part rather than simply relying on a logical consistency based on the false assumption it would only ever be create actions doing this.

There's also a flyby fix of the block renderers which can now successfully render blocks becoming unknown as update actions instead of create since that does not crash anymore.

Note, we could render this as something like `~ attr = null -> (known after apply)`, instead of just `~ attr = (known after apply)`, but I don't think we do that elsewhere (like when an optional attribute is set during an update operation) so I didn't implement it here but it would be trivial to do.

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Fixes #35630 

## Target Release

v1.9.7

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->


## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

### BUG FIXES

<!--

Write a short description of the user-facing change. Examples:

- `terraform show -json`: Fixed crash with sensitive set values.
- When rendering a diff, Terraform now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 

-  Plan renderer: Fix crash that occurs when updating a null attribute to unknown
