### PR TITLE
stacks: support forgetting components

### DIFF
--- a/internal/plans/planproto/convert.go
+++ b/internal/plans/planproto/convert.go
@@ -75,6 +75,8 @@ func NewAction(action plans.Action) Action {
 		return Action_DELETE_THEN_CREATE
 	case plans.CreateThenDelete:
 		return Action_CREATE_THEN_DELETE
+	case plans.Forget:
+		return Action_FORGET
 	default:
 		// The above should be exhaustive for all possible actions
 		panic(fmt.Sprintf("unsupported change action %s", action))
@@ -97,6 +99,8 @@ func FromAction(protoAction Action) (plans.Action, error) {
 		return plans.DeleteThenCreate, nil
 	case Action_CREATE_THEN_DELETE:
 		return plans.CreateThenDelete, nil
+	case Action_FORGET:
+		return plans.Forget, nil
 	default:
 		return plans.NoOp, fmt.Errorf("unsupported action %s", protoAction)
 	}

--- a/internal/stacks/stackruntime/apply_test.go
+++ b/internal/stacks/stackruntime/apply_test.go
@@ -3146,9 +3146,6 @@ func TestApply_RemovedBlocks(t *testing.T) {
 		providerreqs.PreferredHashes([]providerreqs.Hash{}),
 	)
 
-	// TODO: Add tests for and implement the following cases:
-	//   - Add a test for a removed block that forgets instead of destroys.
-
 	tcs := map[string]struct {
 		source           string
 		initialState     *stackstate.State

--- a/internal/stacks/stackruntime/apply_test.go
+++ b/internal/stacks/stackruntime/apply_test.go
@@ -3545,6 +3545,119 @@ func TestApply_RemovedBlocks(t *testing.T) {
 			},
 			wantApplyDiags: []expectedDiagnostic{},
 		},
+		"forgotten component": {
+			source: filepath.Join("with-single-input", "forgotten-component"),
+			initialState: stackstate.NewStateBuilder().
+				AddComponentInstance(stackstate.NewComponentInstanceBuilder(mustAbsComponentInstance("component.self")).
+					AddInputVariable("id", cty.StringVal("removed")).
+					AddInputVariable("input", cty.StringVal("removed"))).
+				AddResourceInstance(stackstate.NewResourceInstanceBuilder().
+					SetAddr(mustAbsResourceInstanceObject("component.self.testing_resource.data")).
+					SetProviderAddr(mustDefaultRootProvider("testing")).
+					SetResourceInstanceObjectSrc(states.ResourceInstanceObjectSrc{
+						Status: states.ObjectReady,
+						AttrsJSON: mustMarshalJSONAttrs(map[string]any{
+							"id":    "removed",
+							"value": "removed",
+						}),
+					})).
+				Build(),
+			store: stacks_testing_provider.NewResourceStoreBuilder().
+				AddResource("removed", cty.ObjectVal(map[string]cty.Value{
+					"id":    cty.StringVal("removed"),
+					"value": cty.StringVal("removed"),
+				})).
+				Build(),
+			inputs: map[string]cty.Value{
+				"destroy": cty.BoolVal(false),
+			},
+			wantPlanChanges: []stackplan.PlannedChange{
+				&stackplan.PlannedChangeApplyable{
+					Applyable: true,
+				},
+				&stackplan.PlannedChangeComponentInstance{
+					Addr:          mustAbsComponentInstance("component.self"),
+					PlanComplete:  true,
+					PlanApplyable: true,
+					Mode:          plans.DestroyMode,
+					Action:        plans.Forget,
+					PlannedInputValues: map[string]plans.DynamicValue{
+						"id":    mustPlanDynamicValueDynamicType(cty.StringVal("removed")),
+						"input": mustPlanDynamicValueDynamicType(cty.StringVal("removed")),
+					},
+					PlannedInputValueMarks: map[string][]cty.PathValueMarks{
+						"input": nil,
+						"id":    nil,
+					},
+					PlannedOutputValues: make(map[string]cty.Value),
+					PlannedCheckResults: &states.CheckResults{},
+					PlanTimestamp:       fakePlanTimestamp,
+				},
+				&stackplan.PlannedChangeResourceInstancePlanned{
+					ResourceInstanceObjectAddr: mustAbsResourceInstanceObject("component.self.testing_resource.data"),
+					ChangeSrc: &plans.ResourceInstanceChangeSrc{
+						Addr:        mustAbsResourceInstance("testing_resource.data"),
+						PrevRunAddr: mustAbsResourceInstance("testing_resource.data"),
+						ChangeSrc: plans.ChangeSrc{
+							Action: plans.Forget,
+							Before: mustPlanDynamicValue(cty.ObjectVal(map[string]cty.Value{
+								"id":    cty.StringVal("removed"),
+								"value": cty.StringVal("removed"),
+							})),
+							After: mustPlanDynamicValue(cty.NullVal(cty.Object(map[string]cty.Type{
+								"id":    cty.String,
+								"value": cty.String,
+							}))),
+						},
+						ProviderAddr: mustDefaultRootProvider("testing"),
+					},
+					PriorStateSrc: &states.ResourceInstanceObjectSrc{
+						AttrsJSON: mustMarshalJSONAttrs(map[string]any{
+							"id":    "removed",
+							"value": "removed",
+						}),
+						Dependencies: make([]addrs.ConfigResource, 0),
+						Status:       states.ObjectReady,
+					},
+					ProviderConfigAddr: mustDefaultRootProvider("testing"),
+					Schema:             stacks_testing_provider.TestingResourceSchema,
+				},
+				&stackplan.PlannedChangeHeader{
+					TerraformVersion: version.SemVer,
+				},
+				&stackplan.PlannedChangePlannedTimestamp{
+					PlannedTimestamp: fakePlanTimestamp,
+				},
+			},
+			wantPlanDiags: []expectedDiagnostic{
+				{
+					severity: tfdiags.Warning,
+					summary:  "Some objects will no longer be managed by Terraform",
+					detail: `If you apply this plan, Terraform will discard its tracking information for the following objects, but it will not delete them:
+ - testing_resource.data
+
+After applying this plan, Terraform will no longer manage these objects. You will need to import them into Terraform to manage them again.`,
+				},
+			},
+			wantApplyChanges: []stackstate.AppliedChange{
+				&stackstate.AppliedChangeComponentInstance{
+					ComponentAddr:         mustAbsComponent("component.self"),
+					ComponentInstanceAddr: mustAbsComponentInstance("component.self"),
+					OutputValues:          make(map[addrs.OutputValue]cty.Value),
+					InputVariables: map[addrs.InputVariable]cty.Value{
+						mustInputVariable("id"):    cty.StringVal("removed"),
+						mustInputVariable("input"): cty.StringVal("removed"),
+					},
+				},
+				&stackstate.AppliedChangeResourceInstanceObject{
+					ResourceInstanceObjectAddr: mustAbsResourceInstanceObject("component.self.testing_resource.data"),
+					ProviderConfigAddr:         mustDefaultRootProvider("testing"),
+					NewStateSrc:                nil,
+					Schema:                     nil,
+				},
+			},
+			wantApplyDiags: []expectedDiagnostic{},
+		},
 	}
 
 	for name, tc := range tcs {

--- a/internal/stacks/stackruntime/testdata/mainbundle/test/with-single-input/forgotten-component/forgotten-component.tfstack.hcl
+++ b/internal/stacks/stackruntime/testdata/mainbundle/test/with-single-input/forgotten-component/forgotten-component.tfstack.hcl
@@ -1,0 +1,22 @@
+required_providers {
+  testing = {
+    source  = "hashicorp/testing"
+    version = "0.1.0"
+  }
+}
+
+provider "testing" "default" {}
+
+removed {
+  from = component.self
+
+  source = "../"
+  
+  lifecycle {
+    destroy = false
+  }
+
+  providers = {
+    testing = provider.testing.default
+  }
+}

--- a/internal/states/module.go
+++ b/internal/states/module.go
@@ -184,6 +184,32 @@ func (ms *Module) ForgetResourceInstanceAll(addr addrs.ResourceInstance) {
 	}
 }
 
+// ForgetResourceInstanceCurrent removes the record of the current object with
+// the given address, if present. If not present, this is a no-op.
+func (ms *Module) ForgetResourceInstanceCurrent(addr addrs.ResourceInstance) {
+	rs := ms.Resource(addr.Resource)
+	if rs == nil {
+		return
+	}
+	is := rs.Instance(addr.Key)
+	if is == nil {
+		return
+	}
+
+	is.Current = nil
+
+	if !is.HasObjects() {
+		// If we have no objects at all then we'll clean up.
+		delete(rs.Instances, addr.Key)
+	}
+	if len(rs.Instances) == 0 {
+		// Also clean up if we only expect to have one instance anyway
+		// and there are none. We leave the resource behind if an each mode
+		// is active because an empty list or map of instances is a valid state.
+		delete(ms.Resources, addr.Resource.String())
+	}
+}
+
 // ForgetResourceInstanceDeposed removes the record of the deposed object with
 // the given address and key, if present. If not present, this is a no-op.
 func (ms *Module) ForgetResourceInstanceDeposed(addr addrs.ResourceInstance, key DeposedKey) {

--- a/internal/states/sync.go
+++ b/internal/states/sync.go
@@ -365,6 +365,19 @@ func (s *SyncState) ForgetResourceInstanceAll(addr addrs.AbsResourceInstance) {
 	s.maybePruneModule(addr.Module)
 }
 
+// ForgetResourceInstanceCurrent removes the record of the current object with
+// the given address, if present. If not present, this is a no-op.
+func (s *SyncState) ForgetResourceInstanceCurrent(addr addrs.AbsResourceInstance) {
+	defer s.beginWrite()()
+
+	ms := s.state.Module(addr.Module)
+	if ms == nil {
+		return
+	}
+	ms.ForgetResourceInstanceCurrent(addr.Resource)
+	s.maybePruneModule(addr.Module)
+}
+
 // ForgetResourceInstanceDeposed removes the record of the deposed object with
 // the given address and key, if present. If not present, this is a no-op.
 func (s *SyncState) ForgetResourceInstanceDeposed(addr addrs.AbsResourceInstance, key DeposedKey) {

--- a/internal/terraform/context_apply2_test.go
+++ b/internal/terraform/context_apply2_test.go
@@ -2856,11 +2856,18 @@ resource "test_object" "b" {
 		t.Fatalf("diags: %s", diags.Err())
 	}
 
-	// We expect all actions to be forget
+	expectedChangeAddresses := []string{"test_object.a", "test_object.b"}
+	actualChangeAddresses := make([]string, len(plan.Changes.Resources))
+	// We expect a forget action for each resource
 	for i, change := range plan.Changes.Resources {
+		actualChangeAddresses[i] = change.Addr.String()
 		if change.Action != plans.Forget {
 			t.Fatalf("Expected all actions to be forget, but got %s at plan.Changes.Resources[%d]", change.Action, i)
 		}
+	}
+
+	if diff := cmp.Diff(actualChangeAddresses, expectedChangeAddresses); len(diff) > 0 {
+		t.Errorf("expected:\n%s\nactual:\n%s\ndiff:\n%s", expectedChangeAddresses, actualChangeAddresses, diff)
 	}
 
 	state, diags = ctx.Apply(plan, m, nil)

--- a/internal/terraform/context_walk.go
+++ b/internal/terraform/context_walk.go
@@ -73,6 +73,10 @@ type graphWalkOpts struct {
 	MoveResults refactoring.MoveResults
 
 	ProviderFuncResults *providers.FunctionResults
+
+	// Forget if set to true will cause the plan to forget all resources. This is
+	// only allowd in the context of a destroy plan.
+	Forget bool
 }
 
 func (c *Context) walk(graph *Graph, operation walkOperation, opts *graphWalkOpts) (*ContextGraphWalker, tfdiags.Diagnostics) {
@@ -191,5 +195,6 @@ func (c *Context) graphWalker(graph *Graph, operation walkOperation, opts *graph
 		StopContext:             c.runContext,
 		PlanTimestamp:           opts.PlanTimeTimestamp,
 		providerFuncResults:     opts.ProviderFuncResults,
+		Forget:                  opts.Forget,
 	}
 }

--- a/internal/terraform/eval_context.go
+++ b/internal/terraform/eval_context.go
@@ -199,6 +199,10 @@ type EvalContext interface {
 	// withScope derives a new EvalContext that has all of the same global
 	// context, but a new evaluation scope.
 	withScope(scope evalContextScope) EvalContext
+
+	// Forget if set to true will cause the plan to forget all resources. This is
+	// only allowed in the context of a destroy plan.
+	Forget() bool
 }
 
 func evalContextForModuleInstance(baseCtx EvalContext, addr addrs.ModuleInstance) EvalContext {

--- a/internal/terraform/eval_context_builtin.go
+++ b/internal/terraform/eval_context_builtin.go
@@ -68,6 +68,10 @@ type BuiltinEvalContext struct {
 	// DeferralsValue is the object returned by [BuiltinEvalContext.Deferrals].
 	DeferralsValue *deferring.Deferred
 
+	// forget if set to true will cause the plan to forget all resources. This is
+	// only allowd in the context of a destroy plan.
+	forget bool
+
 	Hooks                 []Hook
 	InputValue            UIInput
 	ProviderCache         map[string]providers.Interface
@@ -597,4 +601,8 @@ func (ctx *BuiltinEvalContext) MoveResults() refactoring.MoveResults {
 
 func (ctx *BuiltinEvalContext) Overrides() *mocking.Overrides {
 	return ctx.OverrideValues
+}
+
+func (ctx *BuiltinEvalContext) Forget() bool {
+	return ctx.forget
 }

--- a/internal/terraform/eval_context_mock.go
+++ b/internal/terraform/eval_context_mock.go
@@ -152,6 +152,9 @@ type MockEvalContext struct {
 
 	OverridesCalled bool
 	OverrideValues  *mocking.Overrides
+
+	ForgetCalled bool
+	ForgetValues bool
 }
 
 // MockEvalContext implements EvalContext
@@ -401,4 +404,9 @@ func (c *MockEvalContext) InstanceExpander() *instances.Expander {
 func (c *MockEvalContext) Overrides() *mocking.Overrides {
 	c.OverridesCalled = true
 	return c.OverrideValues
+}
+
+func (c *MockEvalContext) Forget() bool {
+	c.ForgetCalled = true
+	return c.ForgetValues
 }

--- a/internal/terraform/graph_walk_context.go
+++ b/internal/terraform/graph_walk_context.go
@@ -48,6 +48,9 @@ type ContextGraphWalker struct {
 	Config                  *configs.Config
 	PlanTimestamp           time.Time
 	Overrides               *mocking.Overrides
+	// Forget if set to true will cause the plan to forget all resources. This is
+	// only allowd in the context of a destroy plan.
+	Forget bool
 
 	// This is an output. Do not set this, nor read it while a graph walk
 	// is in progress.
@@ -131,6 +134,7 @@ func (w *ContextGraphWalker) EvalContext() EvalContext {
 		PrevRunStateValue:       w.PrevRunState,
 		Evaluator:               evaluator,
 		OverrideValues:          w.Overrides,
+		forget:                  w.Forget,
 	}
 
 	return ctx

--- a/internal/terraform/node_resource_abstract_instance.go
+++ b/internal/terraform/node_resource_abstract_instance.go
@@ -398,6 +398,13 @@ func (n *NodeAbstractResourceInstance) planDestroy(ctx EvalContext, currentState
 		return noop, deferred, nil
 	}
 
+	// If we are in a context where we forget instead of destroying, we can
+	// just return the forget change without consulting the provider.
+	if ctx.Forget() {
+		forget, diags := n.planForget(ctx, currentState, deposedKey)
+		return forget, deferred, diags
+	}
+
 	unmarkedPriorVal, _ := currentState.Value.UnmarkDeep()
 
 	// The config and new value are null to signify that this is a destroy

--- a/internal/terraform/node_resource_forget.go
+++ b/internal/terraform/node_resource_forget.go
@@ -76,9 +76,7 @@ func (n *NodeForgetResourceInstance) Execute(ctx EvalContext, op walkOperation) 
 		return diags
 	}
 
-	// TODO: Forget single resource instance
-
-	ctx.State().ForgetResourceInstanceAll(n.Addr)
+	ctx.State().ForgetResourceInstanceCurrent(n.Addr)
 
 	diags = diags.Append(updateStateHook(ctx))
 	return diags

--- a/internal/terraform/node_resource_forget.go
+++ b/internal/terraform/node_resource_forget.go
@@ -76,6 +76,8 @@ func (n *NodeForgetResourceInstance) Execute(ctx EvalContext, op walkOperation) 
 		return diags
 	}
 
+	// TODO: Forget single resource instance
+
 	ctx.State().ForgetResourceInstanceAll(n.Addr)
 
 	diags = diags.Append(updateStateHook(ctx))


### PR DESCRIPTION

<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

[Jira](https://hashicorp.atlassian.net/browse/TF-18437)

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.10.x

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

### ENHANCEMENTS

<!--

Write a short description of the user-facing change. Examples:

- `terraform show -json`: Fixed crash with sensitive set values.
- When rendering a diff, Terraform now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 

-  stacks: removed block supports forgetting components