### PR TITLE
stacks: mark input and output changes as no-ops when no changes

### DIFF
--- a/internal/stacks/stackruntime/apply_test.go
+++ b/internal/stacks/stackruntime/apply_test.go
@@ -159,6 +159,54 @@ func TestApply(t *testing.T) {
 				},
 			},
 		},
+		"updating inputs and outputs (noop)": {
+			path: "component-input-output",
+			cycles: []TestCycle{
+				{
+					planInputs: map[string]cty.Value{
+						"value": cty.StringVal("foo"),
+					},
+				},
+				{
+					planInputs: map[string]cty.Value{
+						"value": cty.StringVal("foo"),
+					},
+					wantPlannedChanges: []stackplan.PlannedChange{
+						&stackplan.PlannedChangeApplyable{
+							Applyable: true,
+						},
+						&stackplan.PlannedChangeHeader{
+							TerraformVersion: version.SemVer,
+						},
+						&stackplan.PlannedChangeOutputValue{
+							Addr:   mustStackOutputValue("value"),
+							Action: plans.NoOp,
+							Before: cty.StringVal("foo"),
+							After:  cty.StringVal("foo"),
+						},
+						&stackplan.PlannedChangePlannedTimestamp{
+							PlannedTimestamp: fakePlanTimestamp,
+						},
+						&stackplan.PlannedChangeRootInputValue{
+							Addr:   mustStackInputVariable("value"),
+							Action: plans.NoOp,
+							Before: cty.StringVal("foo"),
+							After:  cty.StringVal("foo"),
+						},
+					},
+					wantAppliedChanges: []stackstate.AppliedChange{
+						&stackstate.AppliedChangeOutputValue{
+							Addr:  mustStackOutputValue("value"),
+							Value: cty.StringVal("foo"),
+						},
+						&stackstate.AppliedChangeInputVariable{
+							Addr:  mustStackInputVariable("value"),
+							Value: cty.StringVal("foo"),
+						},
+					},
+				},
+			},
+		},
 		"deleting inputs and outputs": {
 			path: "component-input-output",
 			state: stackstate.NewStateBuilder().

--- a/internal/stacks/stackruntime/internal/stackeval/stack.go
+++ b/internal/stacks/stackruntime/internal/stackeval/stack.go
@@ -773,8 +773,13 @@ func (s *Stack) PlanChanges(ctx context.Context) ([]stackplan.PlannedChange, tfd
 		action := plans.Create
 
 		if actualBefore, exists := beforeVal[addr]; exists {
-			action = plans.Update
 			before = actualBefore
+
+			if result := before.Equals(after); result.IsKnown() && result.True() {
+				action = plans.NoOp
+			} else {
+				action = plans.Update
+			}
 		}
 
 		changes = append(changes, &stackplan.PlannedChangeOutputValue{


### PR DESCRIPTION
This is a super quick follow up to #35724, which makes sure we set the action as Update and NoOp appropriately based on if the value in the input or outputs has actually changed or not.