### PR TITLE
ephemeral resource addresses and interface definitions

### DIFF
--- a/internal/addrs/parse_ref_test.go
+++ b/internal/addrs/parse_ref_test.go
@@ -363,6 +363,104 @@ func TestParseRef(t *testing.T) {
 			`The "data" object must be followed by two attribute names: the data source type and the resource name.`,
 		},
 
+		// ephemeral
+		{
+			`ephemeral.external.foo`,
+			&Reference{
+				Subject: Resource{
+					Mode: EphemeralResourceMode,
+					Type: "external",
+					Name: "foo",
+				},
+				SourceRange: tfdiags.SourceRange{
+					Start: tfdiags.SourcePos{Line: 1, Column: 1, Byte: 0},
+					End:   tfdiags.SourcePos{Line: 1, Column: 23, Byte: 22},
+				},
+			},
+			``,
+		},
+		{
+			`ephemeral.external.foo.bar`,
+			&Reference{
+				Subject: ResourceInstance{
+					Resource: Resource{
+						Mode: EphemeralResourceMode,
+						Type: "external",
+						Name: "foo",
+					},
+				},
+				SourceRange: tfdiags.SourceRange{
+					Start: tfdiags.SourcePos{Line: 1, Column: 1, Byte: 0},
+					End:   tfdiags.SourcePos{Line: 1, Column: 23, Byte: 22},
+				},
+				Remaining: hcl.Traversal{
+					hcl.TraverseAttr{
+						Name: "bar",
+						SrcRange: hcl.Range{
+							Start: hcl.Pos{Line: 1, Column: 23, Byte: 22},
+							End:   hcl.Pos{Line: 1, Column: 27, Byte: 26},
+						},
+					},
+				},
+			},
+			``,
+		},
+		{
+			`ephemeral.external.foo["baz"].bar`,
+			&Reference{
+				Subject: ResourceInstance{
+					Resource: Resource{
+						Mode: EphemeralResourceMode,
+						Type: "external",
+						Name: "foo",
+					},
+					Key: StringKey("baz"),
+				},
+				SourceRange: tfdiags.SourceRange{
+					Start: tfdiags.SourcePos{Line: 1, Column: 1, Byte: 0},
+					End:   tfdiags.SourcePos{Line: 1, Column: 30, Byte: 29},
+				},
+				Remaining: hcl.Traversal{
+					hcl.TraverseAttr{
+						Name: "bar",
+						SrcRange: hcl.Range{
+							Start: hcl.Pos{Line: 1, Column: 30, Byte: 29},
+							End:   hcl.Pos{Line: 1, Column: 34, Byte: 33},
+						},
+					},
+				},
+			},
+			``,
+		},
+		{
+			`ephemeral.external.foo["baz"]`,
+			&Reference{
+				Subject: ResourceInstance{
+					Resource: Resource{
+						Mode: EphemeralResourceMode,
+						Type: "external",
+						Name: "foo",
+					},
+					Key: StringKey("baz"),
+				},
+				SourceRange: tfdiags.SourceRange{
+					Start: tfdiags.SourcePos{Line: 1, Column: 1, Byte: 0},
+					End:   tfdiags.SourcePos{Line: 1, Column: 30, Byte: 29},
+				},
+			},
+			``,
+		},
+		{
+			`ephemeral`,
+			nil,
+			`The "ephemeral" object must be followed by two attribute names: the ephemeral resource type and the resource name.`,
+		},
+		{
+			`ephemeral.external`,
+			nil,
+			`The "ephemeral" object must be followed by two attribute names: the ephemeral resource type and the resource name.`,
+		},
+
 		// local
 		{
 			`local.foo`,

--- a/internal/addrs/parse_target.go
+++ b/internal/addrs/parse_target.go
@@ -170,10 +170,14 @@ func parseResourceInstanceUnderModule(moduleAddr ModuleInstance, allowPartial bo
 	var diags tfdiags.Diagnostics
 
 	mode := ManagedResourceMode
-	if remain.RootName() == "data" {
+	switch remain.RootName() {
+	case "data":
 		mode = DataResourceMode
 		remain = remain[1:]
-	} else if remain.RootName() == "resource" {
+	case "ephemeral":
+		mode = EphemeralResourceMode
+		remain = remain[1:]
+	case "resource":
 		// Starting a resource address with "resource" is optional, so we'll
 		// just ignore it.
 		remain = remain[1:]
@@ -209,6 +213,13 @@ func parseResourceInstanceUnderModule(moduleAddr ModuleInstance, allowPartial bo
 				Severity: hcl.DiagError,
 				Summary:  "Invalid address",
 				Detail:   "A data source name is required.",
+				Subject:  remain[0].SourceRange().Ptr(),
+			})
+		case EphemeralResourceMode:
+			diags = diags.Append(&hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  "Invalid address",
+				Detail:   "An ephemeral resource type name is required.",
 				Subject:  remain[0].SourceRange().Ptr(),
 			})
 		default:

--- a/internal/addrs/parse_target_test.go
+++ b/internal/addrs/parse_target_test.go
@@ -166,6 +166,45 @@ func TestParseTarget(t *testing.T) {
 			``,
 		},
 		{
+			`ephemeral.aws_instance.foo`,
+			&Target{
+				Subject: AbsResource{
+					Resource: Resource{
+						Mode: EphemeralResourceMode,
+						Type: "aws_instance",
+						Name: "foo",
+					},
+					Module: RootModuleInstance,
+				},
+				SourceRange: tfdiags.SourceRange{
+					Start: tfdiags.SourcePos{Line: 1, Column: 1, Byte: 0},
+					End:   tfdiags.SourcePos{Line: 1, Column: 27, Byte: 26},
+				},
+			},
+			``,
+		},
+		{
+			`ephemeral.aws_instance.foo[1]`,
+			&Target{
+				Subject: AbsResourceInstance{
+					Resource: ResourceInstance{
+						Resource: Resource{
+							Mode: EphemeralResourceMode,
+							Type: "aws_instance",
+							Name: "foo",
+						},
+						Key: IntKey(1),
+					},
+					Module: RootModuleInstance,
+				},
+				SourceRange: tfdiags.SourceRange{
+					Start: tfdiags.SourcePos{Line: 1, Column: 1, Byte: 0},
+					End:   tfdiags.SourcePos{Line: 1, Column: 30, Byte: 29},
+				},
+			},
+			``,
+		},
+		{
 			`module.foo.aws_instance.bar`,
 			&Target{
 				Subject: AbsResource{
@@ -267,6 +306,27 @@ func TestParseTarget(t *testing.T) {
 				SourceRange: tfdiags.SourceRange{
 					Start: tfdiags.SourcePos{Line: 1, Column: 1, Byte: 0},
 					End:   tfdiags.SourcePos{Line: 1, Column: 44, Byte: 43},
+				},
+			},
+			``,
+		},
+		{
+			`module.foo.module.bar.ephemeral.aws_instance.baz`,
+			&Target{
+				Subject: AbsResource{
+					Resource: Resource{
+						Mode: EphemeralResourceMode,
+						Type: "aws_instance",
+						Name: "baz",
+					},
+					Module: ModuleInstance{
+						{Name: "foo"},
+						{Name: "bar"},
+					},
+				},
+				SourceRange: tfdiags.SourceRange{
+					Start: tfdiags.SourcePos{Line: 1, Column: 1, Byte: 0},
+					End:   tfdiags.SourcePos{Line: 1, Column: 49, Byte: 48},
 				},
 			},
 			``,

--- a/internal/addrs/resource.go
+++ b/internal/addrs/resource.go
@@ -27,6 +27,8 @@ func (r Resource) String() string {
 		return fmt.Sprintf("%s.%s", r.Type, r.Name)
 	case DataResourceMode:
 		return fmt.Sprintf("data.%s.%s", r.Type, r.Name)
+	case EphemeralResourceMode:
+		return fmt.Sprintf("ephemeral.%s.%s", r.Type, r.Name)
 	default:
 		// Should never happen, but we'll return a string here rather than
 		// crashing just in case it does.
@@ -505,6 +507,10 @@ const (
 	// DataResourceMode indicates a data resource, as defined by
 	// "data" blocks in configuration.
 	DataResourceMode ResourceMode = 'D'
+
+	// EphemeralResourceMode indicates an ephemeral resource, as defined by
+	// "ephemeral" blocks in configuration.
+	EphemeralResourceMode ResourceMode = 'E'
 )
 
 // AbsResourceInstanceObject represents one of the specific remote objects

--- a/internal/addrs/resourcemode_string.go
+++ b/internal/addrs/resourcemode_string.go
@@ -11,20 +11,26 @@ func _() {
 	_ = x[InvalidResourceMode-0]
 	_ = x[ManagedResourceMode-77]
 	_ = x[DataResourceMode-68]
+	_ = x[EphemeralResourceMode-69]
 }
 
 const (
 	_ResourceMode_name_0 = "InvalidResourceMode"
-	_ResourceMode_name_1 = "DataResourceMode"
+	_ResourceMode_name_1 = "DataResourceModeEphemeralResourceMode"
 	_ResourceMode_name_2 = "ManagedResourceMode"
+)
+
+var (
+	_ResourceMode_index_1 = [...]uint8{0, 16, 37}
 )
 
 func (i ResourceMode) String() string {
 	switch {
 	case i == 0:
 		return _ResourceMode_name_0
-	case i == 68:
-		return _ResourceMode_name_1
+	case 68 <= i && i <= 69:
+		i -= 68
+		return _ResourceMode_name_1[_ResourceMode_index_1[i]:_ResourceMode_index_1[i+1]]
 	case i == 77:
 		return _ResourceMode_name_2
 	default:

--- a/internal/builtin/providers/terraform/provider.go
+++ b/internal/builtin/providers/terraform/provider.go
@@ -33,6 +33,7 @@ func (p *Provider) GetProviderSchema() providers.GetProviderSchemaResponse {
 		ResourceTypes: map[string]providers.Schema{
 			"terraform_data": dataStoreResourceSchema(),
 		},
+		EphemeralResourceTypes: map[string]providers.Schema{},
 		Functions: map[string]providers.FunctionDecl{
 			"encode_tfvars": {
 				Summary:     "Produce a string representation of an object using the same syntax as for `.tfvars` files",
@@ -172,7 +173,7 @@ func (p *Provider) ImportResourceState(req providers.ImportResourceStateRequest)
 		return importDataStore(req)
 	}
 
-	panic("unimplemented - terraform_remote_state has no resources")
+	panic("unimplemented: cannot import resource type " + req.TypeName)
 }
 
 // MoveResourceState requests that the given resource be moved.
@@ -192,6 +193,27 @@ func (p *Provider) MoveResourceState(req providers.MoveResourceStateRequest) pro
 // ValidateResourceConfig is used to to validate the resource configuration values.
 func (p *Provider) ValidateResourceConfig(req providers.ValidateResourceConfigRequest) providers.ValidateResourceConfigResponse {
 	return validateDataStoreResourceConfig(req)
+}
+
+// OpenEphemeral implements providers.Interface.
+func (p *Provider) OpenEphemeral(req providers.OpenEphemeralRequest) providers.OpenEphemeralResponse {
+	var resp providers.OpenEphemeralResponse
+	resp.Diagnostics.Append(fmt.Errorf("unsupported ephemeral resource type %q", req.TypeName))
+	return resp
+}
+
+// RenewEphemeral implements providers.Interface.
+func (p *Provider) RenewEphemeral(req providers.RenewEphemeralRequest) providers.RenewEphemeralResponse {
+	var resp providers.RenewEphemeralResponse
+	resp.Diagnostics.Append(fmt.Errorf("unsupported ephemeral resource type %q", req.TypeName))
+	return resp
+}
+
+// CloseEphemeral implements providers.Interface.
+func (p *Provider) CloseEphemeral(req providers.CloseEphemeralRequest) providers.CloseEphemeralResponse {
+	var resp providers.CloseEphemeralResponse
+	resp.Diagnostics.Append(fmt.Errorf("unsupported ephemeral resource type %q", req.TypeName))
+	return resp
 }
 
 // CallFunction would call a function contributed by this provider, but this

--- a/internal/plugin/grpc_provider.go
+++ b/internal/plugin/grpc_provider.go
@@ -767,6 +767,21 @@ func (p *GRPCProvider) ReadDataSource(r providers.ReadDataSourceRequest) (resp p
 	return resp
 }
 
+func (p *GRPCProvider) OpenEphemeral(r providers.OpenEphemeralRequest) (resp providers.OpenEphemeralResponse) {
+	logger.Trace("GRPCProvider: OpenEphemeral")
+	panic("ephemeral resources not supported")
+}
+
+func (p *GRPCProvider) RenewEphemeral(r providers.RenewEphemeralRequest) (resp providers.RenewEphemeralResponse) {
+	logger.Trace("GRPCProvider: RenewEphemeral")
+	panic("ephemeral resources not supported")
+}
+
+func (p *GRPCProvider) CloseEphemeral(r providers.CloseEphemeralRequest) (resp providers.CloseEphemeralResponse) {
+	logger.Trace("GRPCProvider: CloseEphemeral")
+	panic("ephemeral resources not supported")
+}
+
 func (p *GRPCProvider) CallFunction(r providers.CallFunctionRequest) (resp providers.CallFunctionResponse) {
 	logger.Trace("GRPCProvider", "CallFunction", r.FunctionName)
 

--- a/internal/plugin6/grpc_provider.go
+++ b/internal/plugin6/grpc_provider.go
@@ -756,6 +756,21 @@ func (p *GRPCProvider) ReadDataSource(r providers.ReadDataSourceRequest) (resp p
 	return resp
 }
 
+func (p *GRPCProvider) OpenEphemeral(r providers.OpenEphemeralRequest) (resp providers.OpenEphemeralResponse) {
+	logger.Trace("GRPCProvide.v6: OpenEphemeral")
+	panic("ephemeral resources not supported")
+}
+
+func (p *GRPCProvider) RenewEphemeral(r providers.RenewEphemeralRequest) (resp providers.RenewEphemeralResponse) {
+	logger.Trace("GRPCProvider.v6: RenewEphemeral")
+	panic("ephemeral resources not supported")
+}
+
+func (p *GRPCProvider) CloseEphemeral(r providers.CloseEphemeralRequest) (resp providers.CloseEphemeralResponse) {
+	logger.Trace("GRPCProvider.v6: CloseEphemeral")
+	panic("ephemeral resources not supported")
+}
+
 func (p *GRPCProvider) CallFunction(r providers.CallFunctionRequest) (resp providers.CallFunctionResponse) {
 	logger.Trace("GRPCProvider.v6", "CallFunction", r.FunctionName)
 

--- a/internal/provider-simple-v6/provider.go
+++ b/internal/provider-simple-v6/provider.go
@@ -171,6 +171,24 @@ func (s simple) ReadDataSource(req providers.ReadDataSourceRequest) (resp provid
 	return resp
 }
 
+func (s simple) OpenEphemeral(providers.OpenEphemeralRequest) providers.OpenEphemeralResponse {
+	// Our schema doesn't include any ephemeral resource types, so it should be
+	// impossible to get in here.
+	panic("OpenEphemeral on provider that didn't declare any ephemeral resource types")
+}
+
+func (s simple) RenewEphemeral(providers.RenewEphemeralRequest) providers.RenewEphemeralResponse {
+	// Our schema doesn't include any ephemeral resource types, so it should be
+	// impossible to get in here.
+	panic("RenewEphemeral on provider that didn't declare any ephemeral resource types")
+}
+
+func (s simple) CloseEphemeral(providers.CloseEphemeralRequest) providers.CloseEphemeralResponse {
+	// Our schema doesn't include any ephemeral resource types, so it should be
+	// impossible to get in here.
+	panic("CloseEphemeral on provider that didn't declare any ephemeral resource types")
+}
+
 func (s simple) CallFunction(req providers.CallFunctionRequest) (resp providers.CallFunctionResponse) {
 	if req.FunctionName != "noop" {
 		resp.Err = fmt.Errorf("CallFunction for undefined function %q", req.FunctionName)

--- a/internal/provider-simple/provider.go
+++ b/internal/provider-simple/provider.go
@@ -144,6 +144,24 @@ func (s simple) ReadDataSource(req providers.ReadDataSourceRequest) (resp provid
 	return resp
 }
 
+func (s simple) OpenEphemeral(providers.OpenEphemeralRequest) providers.OpenEphemeralResponse {
+	// Our schema doesn't include any ephemeral resource types, so it should be
+	// impossible to get in here.
+	panic("OpenEphemeral on provider that didn't declare any ephemeral resource types")
+}
+
+func (s simple) RenewEphemeral(providers.RenewEphemeralRequest) providers.RenewEphemeralResponse {
+	// Our schema doesn't include any ephemeral resource types, so it should be
+	// impossible to get in here.
+	panic("RenewEphemeral on provider that didn't declare any ephemeral resource types")
+}
+
+func (s simple) CloseEphemeral(providers.CloseEphemeralRequest) providers.CloseEphemeralResponse {
+	// Our schema doesn't include any ephemeral resource types, so it should be
+	// impossible to get in here.
+	panic("CloseEphemeral on provider that didn't declare any ephemeral resource types")
+}
+
 func (s simple) CallFunction(req providers.CallFunctionRequest) (resp providers.CallFunctionResponse) {
 	// Our schema doesn't include any functions, so it should be impossible
 	// to get in here.

--- a/internal/providers/ephemeral.go
+++ b/internal/providers/ephemeral.go
@@ -1,0 +1,187 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package providers
+
+import (
+	"time"
+
+	"github.com/hashicorp/terraform/internal/tfdiags"
+	"github.com/zclconf/go-cty/cty"
+)
+
+// OpenEphemeralRequest represents the arguments for the OpenEphemeral
+// operation on a provider.
+type OpenEphemeralRequest struct {
+	// TypeName is the type of ephemeral resource to open. This should
+	// only be one of the type names previously reported in the provider's
+	// schema.
+	TypeName string
+
+	// Config is an object-typed value representing the configuration for
+	// the ephemeral resource instance that the caller is trying to open.
+	//
+	// The object type of this value always conforms to the resource type
+	// schema's implied type, and uses null values to represent attributes
+	// that were not explicitly assigned in the configuration block.
+	// Computed-only attributes are always null in the configuration, because
+	// they can be set only in the response.
+	Config cty.Value
+}
+
+// OpenEphemeralRequest represents the response from an OpenEphemeral
+// operation on a provider.
+type OpenEphemeralResponse struct {
+	// Deferred, if present, signals that the provider doesn't have enough
+	// information to open this ephemeral resource instance.
+	//
+	// This implies that any other side-effect-performing object must have its
+	// planning deferred if its planning operation indirectly depends on this
+	// ephemeral resource result. For example, if a provider configuration
+	// refers to an ephemeral resource whose opening is deferred then the
+	// affected provider configuration must not be instantiated and any resource
+	// instances that belong to it must have their planning immediately
+	// deferred.
+	Deferred *Deferred
+
+	// Result is an object-typed value representing the newly-opened session
+	// with the opened ephemeral object.
+	//
+	// The object type of this value always conforms to the resource type
+	// schema's implied type. Unknown values are forbidden unless the Deferred
+	// field is set, in which case the Result represents the provider's best
+	// approximation of the final object using unknown values in any location
+	// where a final value cannot be predicted.
+	Result cty.Value
+
+	// InternalContext is any internal data needed by the provider to perform a
+	// subsequent [Interface.CloseEphemeral] request for the same object. The
+	// provider may choose any encoding format to represent the needed data,
+	// because Terraform Core treats this field as opaque.
+	//
+	// Providers should aim to keep this data relatively compact to minimize
+	// overhead. Although Terraform Core does not enforce a specific limit just
+	// for this field, it would be very unusual for the internal context to be
+	// more than 256 bytes in size, and in most cases it should be on the order
+	// of only tens of bytes. For example, a lease ID for the remote system is a
+	// reasonable thing to encode here.
+	//
+	// Because ephemeral resource instances never outlive a single Terraform
+	// Core phase, it's guaranteed that a CloseEphemeral request will be
+	// received by exactly the same plugin instance that returned this value,
+	// and so it's valid for this to refer to in-memory state belonging to the
+	// provider instance.
+	InternalContext []byte
+
+	// Renew, if set, signals that the opened object has an inherent expration
+	// time and so must be "renewed" if Terraform needs to use it beyond that
+	// expiration time.
+	//
+	// If a provider sets this field then it may receive a subsequent
+	// [Interface.RenewEphemeral] call, if Terraform expects to need the
+	// object beyond the expiration time.
+	Renew *EphemeralRenew
+
+	// Diagnostics describes any problems encountered while opening the
+	// ephemeral resource. If this contains errors then the other response
+	// fields must be assumed invalid.
+	Diagnostics tfdiags.Diagnostics
+}
+
+// EphemeralRenew describes when and how Terraform Core must request renewal
+// of an ephemeral resource instance in order to continue using it.
+type EphemeralRenew struct {
+	// ExpireTime is the deadline before which Terraform must renew the
+	// ephemeral resource instance. Terraform will make the renew request
+	// at least one minute before the expiration time.
+	ExpireTime time.Time
+
+	// InternalContext is any internal data needed by the provider to
+	// perform a subsequent [Interface.RenewEphemeral] request. The provider
+	// may choose any encoding format to represent the needed data, because
+	// Terraform Core treats this field as opaque.
+	//
+	// Providers should aim to keep this data relatively compact to minimize
+	// overhead. Although Terraform Core does not enforce a specific limit
+	// just for this field, it would be very unusual for the internal context
+	// to be more than 256 bytes in size, and in most cases it should be
+	// on the order of only tens of bytes. For example, a lease ID for the
+	// remote system is a reasonable thing to encode here.
+	//
+	// Because ephemeral resource instances never outlive a single Terraform
+	// Core phase, it's guaranteed that a RenewEphemeral request will be
+	// received by exactly the same plugin instance that previously handled
+	// the OpenEphemeral or RenewEphemeral request that produced this internal
+	// context, and so it's valid for this to refer to in-memory state in the
+	// provider object.
+	InternalContext []byte
+}
+
+// RenewEphemeralRequest represents the arguments for the RenewEphemeral
+// operation on a provider.
+type RenewEphemeralRequest struct {
+	// TypeName is the type of ephemeral resource being renewed. This should
+	// only be one of the type names previously sent in a successful
+	// [OpenEphemeralRequest].
+	TypeName string
+
+	// InternalContext echoes verbatim the value from the field of the same
+	// name from the most recent [EphemeralRenew] object, received from either
+	// an [OpenEphemeralResponse] or a [RenewEphemeralResponse] object.
+	InternalContext []byte
+}
+
+// RenewEphemeralRequest represents the response from a RenewEphemeral
+// operation on a provider.
+type RenewEphemeralResponse struct {
+	// RenewAgain, if set, describes a new expiration deadline for the
+	// object, possibly causing a further call to [Interface.RenewEphemeral]
+	// if Terraform needs to exceed the updated deadline.
+	//
+	// If this is not set then Terraform Core will not make any further
+	// renewal requests for the remaining life of the object.
+	RenewAgain *EphemeralRenew
+
+	// Diagnostics describes any problems encountered while renewing the
+	// ephemeral resource instance. If this contains errors then the other
+	// response fields must be assumed invalid.
+	//
+	// Because renewals happen asynchronously from other uses of the
+	// ephemeral object, it's unspecified whether a renewal error will block
+	// any specific usage of the object. For example, a request using the
+	// object might already be in progress when a renewal error occurs,
+	// in which case that other request might also fail trying to use a
+	// now-invalid object, or it might by chance succeed in completing its
+	// operation before the ephemeral object truly expires.
+	Diagnostics tfdiags.Diagnostics
+}
+
+// CloseEphemeralRequest represents the arguments for the CloseEphemeral
+// operation on a provider.
+type CloseEphemeralRequest struct {
+	// TypeName is the type of ephemeral resource being closed. This should
+	// only be one of the type names previously sent in a successful
+	// [OpenEphemeralRequest].
+	TypeName string
+
+	// InternalContext echoes verbatim the value from the field of the same
+	// name from the corresponding [OpenEphemeralResponse] object.
+	InternalContext []byte
+}
+
+// CloseEphemeralRequest represents the response from a CloseEphemeral
+// operation on a provider.
+type CloseEphemeralResponse struct {
+	// Diagnostics describes any problems encountered while closing the
+	// ephemeral resource instance. If this contains errors then the other
+	// response fields must be assumed invalid.
+	//
+	// If closing an ephemeral resource instance fails then it's unspecified
+	// whether a corresponding remote object remains valid or not.
+	//
+	// Providers should make a best effort to treat the closure of an
+	// already-expired ephemeral object as a success in order to exhibit
+	// idemponent behavior for closing, but some remote systems do not allow
+	// distinguishing that case from other error conditions.
+	Diagnostics tfdiags.Diagnostics
+}

--- a/internal/providers/functions_test.go
+++ b/internal/providers/functions_test.go
@@ -9,6 +9,9 @@ import (
 
 	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/zclconf/go-cty/cty"
+
+	// set the correct global logger for tests
+	_ "github.com/hashicorp/terraform/internal/logging"
 )
 
 func TestFunctionCache(t *testing.T) {
@@ -179,7 +182,6 @@ func TestFunctionCache(t *testing.T) {
 			if originalErr != reloadedErr {
 				t.Fatalf("original check returned err:%t, reloaded check returned err:%t", originalErr, reloadedErr)
 			}
-
 		})
 	}
 }

--- a/internal/providers/mock.go
+++ b/internal/providers/mock.go
@@ -289,6 +289,48 @@ func (m *Mock) ReadDataSource(request ReadDataSourceRequest) ReadDataSourceRespo
 	return response
 }
 
+func (m *Mock) OpenEphemeral(OpenEphemeralRequest) OpenEphemeralResponse {
+	// FIXME: Design some means to mock an ephemeral resource type.
+	var diags tfdiags.Diagnostics
+	diags = diags.Append(tfdiags.AttributeValue(
+		tfdiags.Error,
+		"No ephemeral resource types in mock providers",
+		"The provider mocking mechanism does not yet support ephemeral resource types.",
+		nil, // the topmost configuration object
+	))
+	return OpenEphemeralResponse{
+		Diagnostics: diags,
+	}
+}
+
+func (m *Mock) RenewEphemeral(RenewEphemeralRequest) RenewEphemeralResponse {
+	// FIXME: Design some means to mock an ephemeral resource type.
+	var diags tfdiags.Diagnostics
+	diags = diags.Append(tfdiags.AttributeValue(
+		tfdiags.Error,
+		"No ephemeral resource types in mock providers",
+		"The provider mocking mechanism does not yet support ephemeral resource types.",
+		nil, // the topmost configuration object
+	))
+	return RenewEphemeralResponse{
+		Diagnostics: diags,
+	}
+}
+
+func (m *Mock) CloseEphemeral(CloseEphemeralRequest) CloseEphemeralResponse {
+	// FIXME: Design some means to mock an ephemeral resource type.
+	var diags tfdiags.Diagnostics
+	diags = diags.Append(tfdiags.AttributeValue(
+		tfdiags.Error,
+		"No ephemeral resource types in mock providers",
+		"The provider mocking mechanism does not yet support ephemeral resource types.",
+		nil, // the topmost configuration object
+	))
+	return CloseEphemeralResponse{
+		Diagnostics: diags,
+	}
+}
+
 func (m *Mock) CallFunction(request CallFunctionRequest) CallFunctionResponse {
 	return m.Provider.CallFunction(request)
 }

--- a/internal/providers/provider.go
+++ b/internal/providers/provider.go
@@ -74,6 +74,15 @@ type Interface interface {
 	// ReadDataSource returns the data source's current state.
 	ReadDataSource(ReadDataSourceRequest) ReadDataSourceResponse
 
+	// OpenEphemeral opens an ephemeral resource instance.
+	OpenEphemeral(OpenEphemeralRequest) OpenEphemeralResponse
+	// RenewEphemeral extends the validity of a previously-opened ephemeral
+	// resource instance.
+	RenewEphemeral(RenewEphemeralRequest) RenewEphemeralResponse
+	// CloseEphemeral closes an ephemeral resource instance, with the intent
+	// of rendering it invalid as soon as possible.
+	CloseEphemeral(CloseEphemeralRequest) CloseEphemeralResponse
+
 	// CallFunction calls a provider-contributed function.
 	CallFunction(CallFunctionRequest) CallFunctionResponse
 
@@ -98,6 +107,10 @@ type GetProviderSchemaResponse struct {
 
 	// DataSources maps the data source name to that data source's schema.
 	DataSources map[string]Schema
+
+	// EphemeralResourceTypes maps the name of an ephemeral resource type
+	// to its schema.
+	EphemeralResourceTypes map[string]Schema
 
 	// Functions maps from local function name (not including an namespace
 	// prefix) to the declaration of a function.

--- a/internal/providers/schemas.go
+++ b/internal/providers/schemas.go
@@ -23,6 +23,9 @@ func (ss ProviderSchema) SchemaForResourceType(mode addrs.ResourceMode, typeName
 	case addrs.DataResourceMode:
 		// Data resources don't have schema versions right now, since state is discarded for each refresh
 		return ss.DataSources[typeName].Block, 0
+	case addrs.EphemeralResourceMode:
+		// Ephemeral resources don't have schema versions because their objects never outlive a single phase
+		return ss.EphemeralResourceTypes[typeName].Block, 0
 	default:
 		// Shouldn't happen, because the above cases are comprehensive.
 		return nil, 0

--- a/internal/providers/testing/provider_mock.go
+++ b/internal/providers/testing/provider_mock.go
@@ -94,6 +94,19 @@ type MockProvider struct {
 	ReadDataSourceRequest  providers.ReadDataSourceRequest
 	ReadDataSourceFn       func(providers.ReadDataSourceRequest) providers.ReadDataSourceResponse
 
+	OpenEphemeralCalled    bool
+	OpenEphemeralResponse  *providers.OpenEphemeralResponse
+	OpenEphemeralRequest   providers.OpenEphemeralRequest
+	OpenEphemeralFn        func(providers.OpenEphemeralRequest) providers.OpenEphemeralResponse
+	RenewEphemeralCalled   bool
+	RenewEphemeralResponse *providers.RenewEphemeralResponse
+	RenewEphemeralRequest  providers.RenewEphemeralRequest
+	RenewEphemeralFn       func(providers.RenewEphemeralRequest) providers.RenewEphemeralResponse
+	CloseEphemeralCalled   bool
+	CloseEphemeralResponse *providers.CloseEphemeralResponse
+	CloseEphemeralRequest  providers.CloseEphemeralRequest
+	CloseEphemeralFn       func(providers.CloseEphemeralRequest) providers.CloseEphemeralResponse
+
 	CallFunctionCalled   bool
 	CallFunctionResponse providers.CallFunctionResponse
 	CallFunctionRequest  providers.CallFunctionRequest
@@ -548,6 +561,75 @@ func (p *MockProvider) ReadDataSource(r providers.ReadDataSourceRequest) (resp p
 
 	if p.ReadDataSourceResponse != nil {
 		resp = *p.ReadDataSourceResponse
+	}
+
+	return resp
+}
+
+func (p *MockProvider) OpenEphemeral(r providers.OpenEphemeralRequest) (resp providers.OpenEphemeralResponse) {
+	p.Lock()
+	defer p.Unlock()
+
+	if !p.ConfigureProviderCalled {
+		resp.Diagnostics = resp.Diagnostics.Append(fmt.Errorf("Configure not called before OpenEphemeral %q", r.TypeName))
+		return resp
+	}
+
+	p.OpenEphemeralCalled = true
+	p.OpenEphemeralRequest = r
+
+	if p.OpenEphemeralFn != nil {
+		return p.OpenEphemeralFn(r)
+	}
+
+	if p.OpenEphemeralResponse != nil {
+		resp = *p.OpenEphemeralResponse
+	}
+
+	return resp
+}
+
+func (p *MockProvider) RenewEphemeral(r providers.RenewEphemeralRequest) (resp providers.RenewEphemeralResponse) {
+	p.Lock()
+	defer p.Unlock()
+
+	if !p.ConfigureProviderCalled {
+		resp.Diagnostics = resp.Diagnostics.Append(fmt.Errorf("Configure not called before RenewEphemeral %q", r.TypeName))
+		return resp
+	}
+
+	p.RenewEphemeralCalled = true
+	p.RenewEphemeralRequest = r
+
+	if p.RenewEphemeralFn != nil {
+		return p.RenewEphemeralFn(r)
+	}
+
+	if p.RenewEphemeralResponse != nil {
+		resp = *p.RenewEphemeralResponse
+	}
+
+	return resp
+}
+
+func (p *MockProvider) CloseEphemeral(r providers.CloseEphemeralRequest) (resp providers.CloseEphemeralResponse) {
+	p.Lock()
+	defer p.Unlock()
+
+	if !p.ConfigureProviderCalled {
+		resp.Diagnostics = resp.Diagnostics.Append(fmt.Errorf("Configure not called before CloseEphemeral %q", r.TypeName))
+		return resp
+	}
+
+	p.CloseEphemeralCalled = true
+	p.CloseEphemeralRequest = r
+
+	if p.CloseEphemeralFn != nil {
+		return p.CloseEphemeralFn(r)
+	}
+
+	if p.CloseEphemeralResponse != nil {
+		resp = *p.CloseEphemeralResponse
 	}
 
 	return resp

--- a/internal/refactoring/mock_provider.go
+++ b/internal/refactoring/mock_provider.go
@@ -85,6 +85,18 @@ func (provider *mockProvider) ReadDataSource(providers.ReadDataSourceRequest) pr
 	panic("not implemented in mock")
 }
 
+func (provider *mockProvider) OpenEphemeral(providers.OpenEphemeralRequest) providers.OpenEphemeralResponse {
+	panic("not implemented in mock")
+}
+
+func (provider *mockProvider) RenewEphemeral(providers.RenewEphemeralRequest) providers.RenewEphemeralResponse {
+	panic("not implemented in mock")
+}
+
+func (provider *mockProvider) CloseEphemeral(providers.CloseEphemeralRequest) providers.CloseEphemeralResponse {
+	panic("not implemented in mock")
+}
+
 func (provider *mockProvider) CallFunction(providers.CallFunctionRequest) providers.CallFunctionResponse {
 	panic("not implemented in mock")
 }

--- a/internal/stacks/stackruntime/internal/stackeval/stubs/errored.go
+++ b/internal/stacks/stackruntime/internal/stackeval/stubs/errored.go
@@ -128,6 +128,34 @@ func (p *erroredProvider) ReadResource(req providers.ReadResourceRequest) provid
 	}
 }
 
+// OpenEphemeral implements providers.Interface.
+func (p *erroredProvider) OpenEphemeral(providers.OpenEphemeralRequest) providers.OpenEphemeralResponse {
+	var diags tfdiags.Diagnostics
+	diags = diags.Append(tfdiags.AttributeValue(
+		tfdiags.Error,
+		"Provider configuration is invalid",
+		"Cannot open this ephemeral resource instance because its associated provider configuration is invalid.",
+		nil, // nil attribute path means the overall configuration block
+	))
+	return providers.OpenEphemeralResponse{
+		Diagnostics: diags,
+	}
+}
+
+// RenewEphemeral implements providers.Interface.
+func (p *erroredProvider) RenewEphemeral(providers.RenewEphemeralRequest) providers.RenewEphemeralResponse {
+	// We don't have anything to do here because OpenEphemeral didn't really
+	// actually "open" anything.
+	return providers.RenewEphemeralResponse{}
+}
+
+// CloseEphemeral implements providers.Interface.
+func (p *erroredProvider) CloseEphemeral(providers.CloseEphemeralRequest) providers.CloseEphemeralResponse {
+	// We don't have anything to do here because OpenEphemeral didn't really
+	// actually "open" anything.
+	return providers.CloseEphemeralResponse{}
+}
+
 // Stop implements providers.Interface.
 func (p *erroredProvider) Stop() error {
 	// This stub provider never actually does any real work, so there's nothing

--- a/internal/stacks/stackruntime/internal/stackeval/stubs/offline.go
+++ b/internal/stacks/stackruntime/internal/stackeval/stubs/offline.go
@@ -172,6 +172,34 @@ func (o *offlineProvider) ReadDataSource(request providers.ReadDataSourceRequest
 	}
 }
 
+// OpenEphemeral implements providers.Interface.
+func (u *offlineProvider) OpenEphemeral(providers.OpenEphemeralRequest) providers.OpenEphemeralResponse {
+	var diags tfdiags.Diagnostics
+	diags = diags.Append(tfdiags.AttributeValue(
+		tfdiags.Error,
+		"Called OpenEphemeral on an unconfigured provider",
+		"Cannot open this resource instance because this provider is not configured. This is a bug in Terraform - please report it.",
+		nil, // nil attribute path means the overall configuration block
+	))
+	return providers.OpenEphemeralResponse{
+		Diagnostics: diags,
+	}
+}
+
+// RenewEphemeral implements providers.Interface.
+func (u *offlineProvider) RenewEphemeral(providers.RenewEphemeralRequest) providers.RenewEphemeralResponse {
+	// We don't have anything to do here because OpenEphemeral didn't really
+	// actually "open" anything.
+	return providers.RenewEphemeralResponse{}
+}
+
+// CloseEphemeral implements providers.Interface.
+func (u *offlineProvider) CloseEphemeral(providers.CloseEphemeralRequest) providers.CloseEphemeralResponse {
+	// We don't have anything to do here because OpenEphemeral didn't really
+	// actually "open" anything.
+	return providers.CloseEphemeralResponse{}
+}
+
 func (o *offlineProvider) CallFunction(request providers.CallFunctionRequest) providers.CallFunctionResponse {
 	return o.unconfiguredClient.CallFunction(request)
 }

--- a/internal/stacks/stackruntime/internal/stackeval/stubs/unknown.go
+++ b/internal/stacks/stackruntime/internal/stackeval/stubs/unknown.go
@@ -233,6 +233,40 @@ func (u *unknownProvider) ReadDataSource(request providers.ReadDataSourceRequest
 	}
 }
 
+// OpenEphemeral implements providers.Interface.
+func (u *unknownProvider) OpenEphemeral(providers.OpenEphemeralRequest) providers.OpenEphemeralResponse {
+	// TODO: Once there's a definition for how deferred actions ought to work
+	// for ephemeral resource instances, make this report that this one needs
+	// to be deferred if the client announced that it supports deferral.
+	//
+	// For now this is just always an error, because ephemeral resources are
+	// just a prototype being developed concurrently with deferred actions.
+	var diags tfdiags.Diagnostics
+	diags = diags.Append(tfdiags.AttributeValue(
+		tfdiags.Error,
+		"Provider configuration is unknown",
+		"Cannot open this resource instance because its associated provider configuration is unknown.",
+		nil, // nil attribute path means the overall configuration block
+	))
+	return providers.OpenEphemeralResponse{
+		Diagnostics: diags,
+	}
+}
+
+// RenewEphemeral implements providers.Interface.
+func (u *unknownProvider) RenewEphemeral(providers.RenewEphemeralRequest) providers.RenewEphemeralResponse {
+	// We don't have anything to do here because OpenEphemeral didn't really
+	// actually "open" anything.
+	return providers.RenewEphemeralResponse{}
+}
+
+// CloseEphemeral implements providers.Interface.
+func (u *unknownProvider) CloseEphemeral(providers.CloseEphemeralRequest) providers.CloseEphemeralResponse {
+	// We don't have anything to do here because OpenEphemeral didn't really
+	// actually "open" anything.
+	return providers.CloseEphemeralResponse{}
+}
+
 func (u *unknownProvider) CallFunction(request providers.CallFunctionRequest) providers.CallFunctionResponse {
 	return providers.CallFunctionResponse{
 		Err: fmt.Errorf("CallFunction shouldn't be called on an unknown provider; this is a bug in Terraform - please report this error"),


### PR DESCRIPTION
Implement some foundation required to start work on the ephemeral resource type. Nothing here is actually functional yet, but the scope of changes is pretty large so I'm splitting this up into smaller segments while keeping everything working.

- Add a new resource mode in the `addrs` package to differentiate the new resources, but still allow the same language semantics as references to other resource types.
- Add the internal interface definition for the ephemeral actions. This also requires updating all implementations of the interface, though none of those methods can be called yet.