### PR TITLE
Add a catalog-info.yaml file for Backstage

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,17 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+#
+# Intended for internal HashiCorp use only
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: terraform
+  description: HashiCorp Terraform
+  annotations:
+    github.com/project-slug: hashicorp/terraform
+    jira/project-key: TF
+    jira/label: terraform
+spec:
+  type: library
+  owner: terraform-core
+  lifecycle: production


### PR DESCRIPTION
Includes basic metadata for registering terraform as a library component in our internal Backstage installation. See DW-481. There is no public GitHub issue associated with this change.

## Target Release

Release schedule will have no effect on this change. Our installation reads the contents of this file on the main branch.

## Draft CHANGELOG entry

No user facing changes.
