### PR TITLE
stacks: stop encoding values into msgpack twice

### DIFF
--- a/internal/stacks/stackplan/planned_change_test.go
+++ b/internal/stacks/stackplan/planned_change_test.go
@@ -846,7 +846,7 @@ func TestPlannedChangeAsProto(t *testing.T) {
 				Before: cty.NullVal(cty.String),
 				After:  cty.StringVal("boop").Mark(marks.Ephemeral),
 			},
-			WantErr: "failed to encode raw state for var.thingy_id: can't serialize value marked with cty.NewValueMarks(marks.Ephemeral) (this is a bug in Terraform)", // Ephemeral values should never make it this far.
+			WantErr: "failed to encode after planned input variable var.thingy_id: : unhandled value marks cty.NewValueMarks(marks.Ephemeral) (this is a bug in Terraform)", // Ephemeral values should never make it this far.
 		},
 		"update root input variable": {
 			Receiver: &PlannedChangeRootInputValue{

--- a/internal/stacks/stackruntime/internal/stackeval/planning_test.go
+++ b/internal/stacks/stackruntime/internal/stackeval/planning_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/hashicorp/terraform/internal/promising"
 	"github.com/hashicorp/terraform/internal/providers"
 	providerTesting "github.com/hashicorp/terraform/internal/providers/testing"
+	"github.com/hashicorp/terraform/internal/rpcapi/terraform1/stacks"
 	"github.com/hashicorp/terraform/internal/stacks/stackaddrs"
 	"github.com/hashicorp/terraform/internal/stacks/stackplan"
 	stacks_testing_provider "github.com/hashicorp/terraform/internal/stacks/stackruntime/testing"
@@ -1053,9 +1054,9 @@ func TestPlanning_LocalsDataSource(t *testing.T) {
 }
 
 func mustPlanDynamicValue(t *testing.T, v cty.Value) *tfstackdata1.DynamicValue {
-	ret, err := tfstackdata1.DynamicValueToTFStackData1(v, cty.DynamicPseudoType)
+	ret, err := stacks.ToDynamicValue(v, cty.DynamicPseudoType)
 	if err != nil {
 		t.Fatal(err)
 	}
-	return ret
+	return tfstackdata1.Terraform1ToStackDataDynamicValue(ret)
 }

--- a/internal/stacks/tfstackdata1/convert_test.go
+++ b/internal/stacks/tfstackdata1/convert_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/hashicorp/terraform/internal/lang/marks"
 	"github.com/hashicorp/terraform/internal/plans/planproto"
+	"github.com/hashicorp/terraform/internal/rpcapi/terraform1/stacks"
 )
 
 func TestDynamicValueToTFStackData1(t *testing.T) {
@@ -26,10 +27,11 @@ func TestDynamicValueToTFStackData1(t *testing.T) {
 	})
 	ty := startVal.Type()
 
-	got, err := DynamicValueToTFStackData1(startVal, ty)
+	partial, err := stacks.ToDynamicValue(startVal, ty)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
+	got := Terraform1ToStackDataDynamicValue(partial)
 	want := &DynamicValue{
 		Value: &planproto.DynamicValue{
 			// The following is cty's canonical MessagePack encoding of


### PR DESCRIPTION
This PR stops the stacks runtime encoding values into the msgpack representation twice. We write the dynamic value into the raw data and planned / applied changes in different wrappers. Previously, we were encoding the value into msgpack independently for both representations. This PR updates the `tfstackdata1` package so that it accepts the `stacks` representation of a dynamic value and reuses the already encoded data instead of encoding it again.