### PR TITLE
fix(workspaces): URL for Kubernetes secret backend

### DIFF
--- a/website/docs/language/state/workspaces.mdx
+++ b/website/docs/language/state/workspaces.mdx
@@ -22,7 +22,7 @@ You can use multiple workspaces with the following backends:
 - [Consul](/terraform/language/backend/consul)
 - [COS](/terraform/language/backend/cos)
 - [GCS](/terraform/language/backend/gcs)
-- [Kubernetes](/terraform/backend/kubernetes)
+- [Kubernetes](/terraform/language/backend/kubernetes)
 - [Local](/terraform/language/backend/local)
 - [OSS](/terraform/language/backend/oss)
 - [Postgres](/terraform/language/backend/pg)


### PR DESCRIPTION
Documentation link goes in 404 due to the missing `language` prefix in the URL.
