### PR TITLE
add tests that highlight known issues in the destroy mechanism

### DIFF
--- a/internal/stacks/stackruntime/apply_destroy_test.go
+++ b/internal/stacks/stackruntime/apply_destroy_test.go
@@ -40,6 +40,7 @@ func TestApplyDestroy(t *testing.T) {
 		description string
 		state       *stackstate.State
 		store       *stacks_testing_provider.ResourceStore
+		mutators    []func(*stacks_testing_provider.ResourceStore, TestContext) TestContext
 		cycles      []TestCycle
 	}{
 		"inputs-and-outputs": {
@@ -975,6 +976,46 @@ func TestApplyDestroy(t *testing.T) {
 				},
 			},
 		},
+		"destroy-with-provider-req": {
+			path: "auth-provider-w-data",
+			mutators: []func(store *stacks_testing_provider.ResourceStore, testContext TestContext) TestContext{
+				func(store *stacks_testing_provider.ResourceStore, testContext TestContext) TestContext {
+					store.Set("credentials", cty.ObjectVal(map[string]cty.Value{
+						"id":    cty.StringVal("credentials"),
+						"value": cty.StringVal("zero"),
+					}))
+					testContext.providers[addrs.NewDefaultProvider("testing")] = func() (providers.Interface, error) {
+						provider := stacks_testing_provider.NewProviderWithData(t, store)
+						provider.Authentication = "zero"
+						return provider, nil
+					}
+					return testContext
+				},
+				func(store *stacks_testing_provider.ResourceStore, testContext TestContext) TestContext {
+					store.Set("credentials", cty.ObjectVal(map[string]cty.Value{
+						"id":    cty.StringVal("credentials"),
+						"value": cty.StringVal("one"),
+					}))
+					testContext.providers[addrs.NewDefaultProvider("testing")] = func() (providers.Interface, error) {
+						provider := stacks_testing_provider.NewProviderWithData(t, store)
+						provider.Authentication = "one" // So we must reload the data source in order to authenticate.
+						return provider, nil
+					}
+					return testContext
+				},
+			},
+			cycles: []TestCycle{
+				{
+					planMode: plans.NormalMode,
+				},
+				{
+					planMode:           plans.DestroyMode,
+					wantAppliedChanges: []stackstate.AppliedChange{
+						// TODO: Populate these with the correct values.
+					},
+				},
+			},
+		},
 	}
 	for name, tc := range tcs {
 		t.Run(name, func(t *testing.T) {
@@ -1006,6 +1047,11 @@ func TestApplyDestroy(t *testing.T) {
 
 			state := tc.state
 			for ix, cycle := range tc.cycles {
+
+				if tc.mutators != nil {
+					testContext = tc.mutators[ix](store, testContext)
+				}
+
 				t.Run(strconv.FormatInt(int64(ix), 10), func(t *testing.T) {
 					var plan *stackplan.Plan
 					t.Run("plan", func(t *testing.T) {

--- a/internal/stacks/stackruntime/apply_test.go
+++ b/internal/stacks/stackruntime/apply_test.go
@@ -273,6 +273,38 @@ func TestApply(t *testing.T) {
 				},
 			},
 		},
+		"removed block with provider-to-component dep": {
+			path: path.Join("auth-provider-w-data", "removed"),
+			state: stackstate.NewStateBuilder().
+				AddComponentInstance(stackstate.NewComponentInstanceBuilder(mustAbsComponentInstance("component.load")).
+					AddDependent(mustAbsComponent("component.create")).
+					AddOutputValue("credentials", cty.StringVal("wrong"))). // must reload the credentials
+				AddComponentInstance(stackstate.NewComponentInstanceBuilder(mustAbsComponentInstance("component.create")).
+					AddDependency(mustAbsComponent("component.load"))).
+				AddResourceInstance(stackstate.NewResourceInstanceBuilder().
+					SetAddr(mustAbsResourceInstanceObject("component.create.testing_resource.resource")).
+					SetResourceInstanceObjectSrc(states.ResourceInstanceObjectSrc{
+						AttrsJSON: mustMarshalJSONAttrs(map[string]interface{}{
+							"id":    "resource",
+							"value": nil,
+						}),
+						Status: states.ObjectReady,
+					}).
+					SetProviderAddr(mustDefaultRootProvider("testing"))).
+				Build(),
+			store: stacks_testing_provider.NewResourceStoreBuilder().AddResource("credentials", cty.ObjectVal(map[string]cty.Value{
+				"id": cty.StringVal("credentials"),
+				// we have the wrong value in state, so this correct value must
+				// be loaded for this test to work.
+				"value": cty.StringVal("authn"),
+			})).Build(),
+			cycles: []TestCycle{
+				{
+					planMode:           plans.NormalMode,
+					wantAppliedChanges: []stackstate.AppliedChange{},
+				},
+			},
+		},
 	}
 
 	for name, tc := range tcs {
@@ -297,7 +329,9 @@ func TestApply(t *testing.T) {
 				config:    loadMainBundleConfigForTest(t, tc.path),
 				providers: map[addrs.Provider]providers.Factory{
 					addrs.NewDefaultProvider("testing"): func() (providers.Interface, error) {
-						return stacks_testing_provider.NewProviderWithData(t, store), nil
+						provider := stacks_testing_provider.NewProviderWithData(t, store)
+						provider.Authentication = "authn"
+						return provider, nil
 					},
 				},
 				dependencyLocks: *lock,

--- a/internal/stacks/stackruntime/internal/stackeval/component_instance.go
+++ b/internal/stacks/stackruntime/internal/stackeval/component_instance.go
@@ -239,6 +239,9 @@ func (c *ComponentInstance) CheckModuleTreePlan(ctx context.Context) (*plans.Pla
 					}
 				}
 
+				// TODO: Remove from here if we want to implement the
+				//  workaround.
+
 				// We're also going to look through any upstream components
 				// that are being removed to make sure they are removed first.
 				for _, depAddr := range c.PlanPrevDependents(ctx).Elems() {

--- a/internal/stacks/stackruntime/internal/stackeval/main_apply.go
+++ b/internal/stacks/stackruntime/internal/stackeval/main_apply.go
@@ -203,6 +203,9 @@ func ApplyPlan(ctx context.Context, config *stackconfig.Config, plan *stackplan.
 							// dependencies to finish applying their changes.
 							waitForComponents = dependencyAddrs
 
+							// TODO: Remove from here if we want to implement
+							//  the workaround.
+
 							// If we're not being destroyed we might have some
 							// depdendents that are being destroyed, and we need
 							// to wait for them to finish before we can start.

--- a/internal/stacks/stackruntime/internal/stackeval/provider_instance.go
+++ b/internal/stacks/stackruntime/internal/stackeval/provider_instance.go
@@ -249,6 +249,12 @@ func (p *ProviderInstance) CheckClient(ctx context.Context, phase EvalPhase) (pr
 			// We unmark the config before making the RPC call, as marks cannot
 			// be serialized.
 			unmarkedArgs, _ := p.ProviderArgs(ctx, phase).UnmarkDeep()
+			if unmarkedArgs == cty.NilVal {
+				// Then we had an error previously, so we'll rely on that error
+				// being exposed elsewhere.
+				return stubs.ErroredProvider(), diags
+			}
+
 			resp := client.ConfigureProvider(providers.ConfigureProviderRequest{
 				TerraformVersion: version.SemVer.String(),
 				Config:           unmarkedArgs,

--- a/internal/stacks/stackruntime/testdata/mainbundle/test/auth-provider-w-data/auth-provider-w-data.tfstack.hcl
+++ b/internal/stacks/stackruntime/testdata/mainbundle/test/auth-provider-w-data/auth-provider-w-data.tfstack.hcl
@@ -1,0 +1,32 @@
+
+required_providers {
+  testing = {
+    source  = "hashicorp/testing"
+    version = "0.1.0"
+  }
+}
+
+provider "testing" "main" {}
+
+provider "testing" "credentialed" {
+  config {
+    authentication = component.load.credentials
+  }
+}
+
+component "load" {
+  source = "./load"
+
+  providers = {
+    testing = provider.testing.main
+  }
+}
+
+component "create" {
+  source = "./create"
+
+  providers = {
+    testing = provider.testing.credentialed
+  }
+}
+

--- a/internal/stacks/stackruntime/testdata/mainbundle/test/auth-provider-w-data/create/create.tf
+++ b/internal/stacks/stackruntime/testdata/mainbundle/test/auth-provider-w-data/create/create.tf
@@ -1,0 +1,3 @@
+resource "testing_resource" "resource" {
+  id = "resource"
+}

--- a/internal/stacks/stackruntime/testdata/mainbundle/test/auth-provider-w-data/load/load.tf
+++ b/internal/stacks/stackruntime/testdata/mainbundle/test/auth-provider-w-data/load/load.tf
@@ -1,0 +1,8 @@
+data "testing_data_source" "credentials" {
+  id = "credentials"
+}
+
+output "credentials" {
+  value = data.testing_data_source.credentials.value
+  sensitive = true
+}

--- a/internal/stacks/stackruntime/testdata/mainbundle/test/auth-provider-w-data/removed/removed.tfstack.hcl
+++ b/internal/stacks/stackruntime/testdata/mainbundle/test/auth-provider-w-data/removed/removed.tfstack.hcl
@@ -1,0 +1,31 @@
+
+required_providers {
+  testing = {
+    source  = "hashicorp/testing"
+    version = "0.1.0"
+  }
+}
+
+provider "testing" "main" {}
+
+provider "testing" "credentialed" {
+  config {
+    authentication = component.load.credentials
+  }
+}
+
+component "load" {
+  source = "../load"
+
+  providers = {
+    testing = provider.testing.main
+  }
+}
+
+removed {
+  source = "../create"
+  from = component.create
+  providers = {
+    testing = provider.testing.credentialed
+  }
+}


### PR DESCRIPTION
This PR adds two tests that are currently failing, highlighting some issues in the Terraform Stacks destroy mechanism.