### PR TITLE
stacks: fix dependency handling in component forget

### DIFF
--- a/internal/stacks/stackruntime/helper_test.go
+++ b/internal/stacks/stackruntime/helper_test.go
@@ -468,7 +468,12 @@ func diagnosticSortFunc(diags tfdiags.Diagnostics) func(i, j int) bool {
 		if !cmp.Equal(id.Description(), jd.Description()) {
 			return sortDescription(id.Description(), jd.Description())
 		}
-		return sortRange(id.Source().Subject, jd.Source().Subject)
+		if id.Source().Subject != nil && jd.Source().Subject != nil {
+
+			return sortRange(id.Source().Subject, jd.Source().Subject)
+		}
+
+		return false
 	}
 }
 

--- a/internal/stacks/stackruntime/internal/stackeval/component_instance.go
+++ b/internal/stacks/stackruntime/internal/stackeval/component_instance.go
@@ -519,7 +519,8 @@ func (c *ComponentInstance) ResultValue(ctx context.Context, phase EvalPhase) ct
 				// Weird, but we'll tolerate it.
 				return cty.DynamicVal
 			}
-			if ourPlan.PlannedAction == plans.Delete {
+
+			if ourPlan.PlannedAction == plans.Delete || ourPlan.PlannedAction == plans.Forget {
 				// In this case our result was already decided during the
 				// planning phase, because we can't block on anything else
 				// here to make sure we don't create a self-dependency

--- a/internal/stacks/stackruntime/internal/stackeval/main_apply.go
+++ b/internal/stacks/stackruntime/internal/stackeval/main_apply.go
@@ -182,7 +182,7 @@ func ApplyPlan(ctx context.Context, config *stackconfig.Config, plan *stackplan.
 
 						var waitForComponents collections.Set[stackaddrs.AbsComponent]
 						var waitForRemoveds collections.Set[stackaddrs.AbsComponent]
-						if action == plans.Delete {
+						if action == plans.Delete || action == plans.Forget {
 							// If the effect of this apply will be to destroy this
 							// component instance then we need to wait for all
 							// of our dependents to be destroyed first, because

--- a/internal/stacks/stackruntime/testdata/mainbundle/test/forget_with_dependency/forget_with_dependency.tf
+++ b/internal/stacks/stackruntime/testdata/mainbundle/test/forget_with_dependency/forget_with_dependency.tf
@@ -1,0 +1,11 @@
+variable "value" {
+  type = string
+}
+
+resource "testing_resource" "resource" {
+  value = var.value
+}
+
+output "id" {
+  value = testing_resource.resource.id
+}

--- a/internal/stacks/stackruntime/testdata/mainbundle/test/forget_with_dependency/forget_with_dependency.tfstack.hcl
+++ b/internal/stacks/stackruntime/testdata/mainbundle/test/forget_with_dependency/forget_with_dependency.tfstack.hcl
@@ -1,0 +1,33 @@
+required_providers {
+  testing = {
+    source  = "hashicorp/testing"
+    version = "0.1.0"
+  }
+}
+
+provider "testing" "default" {}
+
+component "one" {
+  source = "./"
+
+  providers = {
+    testing = provider.testing.default
+  }
+
+  inputs = {
+    value = "bar"
+  }
+}
+
+removed {
+  source = "./"
+  from = component.two
+
+  providers = {
+    testing = provider.testing.default
+  }
+
+  lifecycle {
+    destroy = false
+  }
+}

--- a/internal/stacks/stackruntime/testdata/mainbundle/test/forget_with_dependency_to_forget/forget_with_dependency_to_forget.tf
+++ b/internal/stacks/stackruntime/testdata/mainbundle/test/forget_with_dependency_to_forget/forget_with_dependency_to_forget.tf
@@ -1,0 +1,11 @@
+variable "value" {
+  type = string
+}
+
+resource "testing_resource" "resource" {
+  value = var.value
+}
+
+output "id" {
+  value = testing_resource.resource.id
+}

--- a/internal/stacks/stackruntime/testdata/mainbundle/test/forget_with_dependency_to_forget/forget_with_dependency_to_forget.tfstack.hcl
+++ b/internal/stacks/stackruntime/testdata/mainbundle/test/forget_with_dependency_to_forget/forget_with_dependency_to_forget.tfstack.hcl
@@ -1,0 +1,34 @@
+required_providers {
+  testing = {
+    source  = "hashicorp/testing"
+    version = "0.1.0"
+  }
+}
+
+provider "testing" "default" {}
+
+removed {
+  source = "./"
+  from = component.one
+  
+  providers = {
+    testing = provider.testing.default
+  }
+
+  lifecycle {
+      destroy = false
+    }
+}
+
+removed {
+  source = "./"
+  from = component.two
+
+  providers = {
+    testing = provider.testing.default
+  }
+
+  lifecycle {
+    destroy = false
+  }
+}


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Fixes #

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.8.x

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

### NEW FEATURES | UPGRADE NOTES | ENHANCEMENTS | BUG FIXES | EXPERIMENTS

<!--

Write a short description of the user-facing change. Examples:

- `terraform show -json`: Fixed crash with sensitive set values.
- When rendering a diff, Terraform now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 

-  