### PR TITLE
New `resources/ephemeral` package for tracking ephemeral resource lifecycle

### DIFF
--- a/internal/providers/ephemeral.go
+++ b/internal/providers/ephemeral.go
@@ -92,12 +92,7 @@ type OpenEphemeralResponse struct {
 // of an ephemeral resource instance in order to continue using it.
 type EphemeralRenew struct {
 	// ExpireTime is the deadline before which Terraform must renew the
-	// ephemeral resource instance. Terraform will make the renew request at
-	// least one minute before the expiration time.
-	//
-	// TODO: reevaluate the arbitrary 1 minute pre-renew buffer. What is that
-	// supposed to accomplish, if something requires a minute to work correctly,
-	// what is stopping it from requiring 2 minutes?
+	// ephemeral resource instance.
 	ExpireTime time.Time
 
 	// InternalContext is any internal data needed by the provider to

--- a/internal/providers/ephemeral.go
+++ b/internal/providers/ephemeral.go
@@ -92,8 +92,12 @@ type OpenEphemeralResponse struct {
 // of an ephemeral resource instance in order to continue using it.
 type EphemeralRenew struct {
 	// ExpireTime is the deadline before which Terraform must renew the
-	// ephemeral resource instance. Terraform will make the renew request
-	// at least one minute before the expiration time.
+	// ephemeral resource instance. Terraform will make the renew request at
+	// least one minute before the expiration time.
+	//
+	// TODO: reevaluate the arbitrary 1 minute pre-renew buffer. What is that
+	// supposed to accomplish, if something requires a minute to work correctly,
+	// what is stopping it from requiring 2 minutes?
 	ExpireTime time.Time
 
 	// InternalContext is any internal data needed by the provider to

--- a/internal/resources/ephemeral/ephemeral_resource_instance.go
+++ b/internal/resources/ephemeral/ephemeral_resource_instance.go
@@ -1,0 +1,31 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package ephemeral
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform/internal/providers"
+	"github.com/hashicorp/terraform/internal/tfdiags"
+)
+
+// ResourceInstance is an interface that must be implemented for each
+// active ephemeral resource instance to determine how it should be renewed
+// and eventually closed.
+type ResourceInstance interface {
+	// Renew attempts to extend the life of the remote object associated with
+	// this resource instance, optionally returning a new renewal request to be
+	// passed to a subsequent call to this method.
+	//
+	// If the object's life is not extended successfully then Renew returns
+	// error diagnostics explaining why not, and future requests that might
+	// have made use of the object will fail.
+	Renew(ctx context.Context, req providers.EphemeralRenew) (nextRenew *providers.EphemeralRenew, diags tfdiags.Diagnostics)
+
+	// Close proactively ends the life of the remote object associated with
+	// this resource instance, if possible. For example, if the remote object
+	// is a temporary lease for a dynamically-generated secret then this
+	// might end that lease and thus cause the secret to be promptly revoked.
+	Close(ctx context.Context) tfdiags.Diagnostics
+}

--- a/internal/resources/ephemeral/ephemeral_resource_test.go
+++ b/internal/resources/ephemeral/ephemeral_resource_test.go
@@ -1,0 +1,289 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package ephemeral
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/terraform/internal/addrs"
+	"github.com/hashicorp/terraform/internal/providers"
+	"github.com/hashicorp/terraform/internal/tfdiags"
+	"github.com/zclconf/go-cty/cty"
+)
+
+func TestResources(t *testing.T) {
+	resources := NewResources()
+
+	ephemA0 := addrs.ResourceInstance{
+		Resource: addrs.Resource{
+			Mode: addrs.EphemeralResourceMode,
+			Type: "test",
+			Name: "a",
+		},
+		Key: addrs.IntKey(0),
+	}.Absolute(addrs.RootModuleInstance)
+	ephemA1 := addrs.ResourceInstance{
+		Resource: addrs.Resource{
+			Mode: addrs.EphemeralResourceMode,
+			Type: "test",
+			Name: "a",
+		},
+		Key: addrs.IntKey(1),
+	}.Absolute(addrs.RootModuleInstance)
+
+	ephemB := addrs.ResourceInstance{
+		Resource: addrs.Resource{
+			Mode: addrs.EphemeralResourceMode,
+			Type: "test",
+			Name: "b",
+		},
+		Key: addrs.NoKey,
+	}.Absolute(addrs.RootModuleInstance)
+
+	ctx := context.TODO()
+
+	testA0 := &testResourceInstance{
+		// FIXME: renewals are done one minute early, but this is not validated anywhere
+		renewInterval: time.Minute + time.Millisecond,
+		// allow some extra space to make sure no unexpected renew calls were made
+		notifyRenew: make(chan int, 10),
+	}
+	testA1 := &testResourceInstance{
+		renewInterval: time.Minute + time.Millisecond,
+		notifyRenew:   make(chan int, 10),
+	}
+	testB := &testResourceInstance{}
+
+	resources.RegisterInstance(ctx, ephemA0, ResourceInstanceRegistration{
+		Value: cty.ObjectVal(map[string]cty.Value{
+			"test": cty.StringVal("ephemeral.test.a[0]"),
+		}),
+		Impl:         testA0,
+		FirstRenewal: &providers.EphemeralRenew{ExpireTime: time.Now().Add(time.Millisecond)},
+	})
+
+	resources.RegisterInstance(ctx, ephemA1, ResourceInstanceRegistration{
+		Value: cty.ObjectVal(map[string]cty.Value{
+			"test": cty.StringVal("ephemeral.test.a[1]"),
+		}),
+		Impl:         testA1,
+		FirstRenewal: &providers.EphemeralRenew{ExpireTime: time.Now().Add(time.Millisecond)},
+	})
+
+	resources.RegisterInstance(ctx, ephemB, ResourceInstanceRegistration{
+		Value: cty.ObjectVal(map[string]cty.Value{
+			"test": cty.StringVal("ephemeral.test.b"),
+		}),
+		Impl: testB,
+	})
+
+	for _, addr := range []addrs.AbsResourceInstance{ephemA0, ephemA1, ephemB} {
+		val, live := resources.InstanceValue(addr)
+		if !live {
+			t.Fatalf("%s should be live", addr)
+		}
+		want := cty.ObjectVal(map[string]cty.Value{
+			"test": cty.StringVal(addr.String()),
+		})
+		if !want.RawEquals(val) {
+			t.Fatalf("wanted: %#v\ngot: %#v\n", want, val)
+		}
+	}
+
+	select {
+	case <-testA0.notifyRenew:
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for renew")
+	}
+	select {
+	case <-testA1.notifyRenew:
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for renew")
+	}
+
+	testB.Lock()
+	if testB.renewed > 0 {
+		t.Fatalf("%s should not be renewed", ephemB)
+	}
+	testB.Unlock()
+
+	// close all instances, which should indicate the values are no longer "live"
+	diags := resources.CloseInstances(ctx, ephemA0.ConfigResource())
+	if diags.HasErrors() {
+		t.Fatal(diags.ErrWithWarnings())
+	}
+	diags = resources.CloseInstances(ctx, ephemB.ConfigResource())
+	if diags.HasErrors() {
+		t.Fatal(diags.ErrWithWarnings())
+	}
+
+	if !testA0.closed {
+		t.Fatalf("%s not closed", ephemA0)
+	}
+	if !testA1.closed {
+		t.Fatalf("%s not closed", ephemA1)
+	}
+	if !testB.closed {
+		t.Fatalf("%s not closed", ephemB)
+	}
+
+	for _, addr := range []addrs.AbsResourceInstance{ephemA0, ephemA1, ephemB} {
+		val, live := resources.InstanceValue(addr)
+		if live {
+			t.Fatalf("%s should not be live", addr)
+		}
+		if !val.RawEquals(cty.DynamicVal) {
+			t.Fatalf("unexpected value %#v\n", val)
+		}
+	}
+}
+
+func TestResourcesCancellation(t *testing.T) {
+	resources := NewResources()
+
+	ephemA0 := addrs.ResourceInstance{
+		Resource: addrs.Resource{
+			Mode: addrs.EphemeralResourceMode,
+			Type: "test",
+			Name: "a",
+		},
+		Key: addrs.IntKey(0),
+	}.Absolute(addrs.RootModuleInstance)
+	ephemA1 := addrs.ResourceInstance{
+		Resource: addrs.Resource{
+			Mode: addrs.EphemeralResourceMode,
+			Type: "test",
+			Name: "a",
+		},
+		Key: addrs.IntKey(1),
+	}.Absolute(addrs.RootModuleInstance)
+
+	ephemB := addrs.ResourceInstance{
+		Resource: addrs.Resource{
+			Mode: addrs.EphemeralResourceMode,
+			Type: "test",
+			Name: "b",
+		},
+		Key: addrs.NoKey,
+	}.Absolute(addrs.RootModuleInstance)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	// cancelling now should cause the first renew op to report the cancellation
+	cancel()
+
+	testA0 := &testResourceInstance{
+		renewInterval: 2 * time.Minute,
+		// allow some extra space to make sure no unexpected renew calls were made
+		notifyRenew: make(chan int, 10),
+	}
+	testA1 := &testResourceInstance{
+		renewInterval: 2 * time.Minute,
+		notifyRenew:   make(chan int, 10),
+	}
+	testB := &testResourceInstance{}
+
+	resources.RegisterInstance(ctx, ephemA0, ResourceInstanceRegistration{
+		Value: cty.ObjectVal(map[string]cty.Value{
+			"test": cty.StringVal("ephemeral.test.a[0]"),
+		}),
+		Impl:         testA0,
+		FirstRenewal: &providers.EphemeralRenew{ExpireTime: time.Now().Add(time.Millisecond)},
+	})
+
+	resources.RegisterInstance(ctx, ephemA1, ResourceInstanceRegistration{
+		Value: cty.ObjectVal(map[string]cty.Value{
+			"test": cty.StringVal("ephemeral.test.a[1]"),
+		}),
+		Impl:         testA1,
+		FirstRenewal: &providers.EphemeralRenew{ExpireTime: time.Now().Add(time.Millisecond)},
+	})
+
+	resources.RegisterInstance(ctx, ephemB, ResourceInstanceRegistration{
+		Value: cty.ObjectVal(map[string]cty.Value{
+			"test": cty.StringVal("ephemeral.test.b"),
+		}),
+		Impl: testB,
+	})
+
+	// FIXME: we need a sleep because the renew goroutines are not synchronized anywhere
+	time.Sleep(100 * time.Millisecond)
+
+	// ephemB has no call for renew, so shouldn't know about the cancel yet
+	_, live := resources.InstanceValue(ephemB)
+	if !live {
+		t.Fatalf("%s should still be live", ephemB)
+	}
+
+	for _, addr := range []addrs.AbsResourceInstance{ephemA0, ephemA1} {
+		_, live := resources.InstanceValue(addr)
+		if live {
+			t.Fatalf("%s was canceled, should not be live", addr)
+		}
+	}
+
+	testB.Lock()
+	if testB.renewed > 0 {
+		t.Fatalf("%s should not be renewed", ephemB)
+	}
+	testB.Unlock()
+
+	// close all instances, which should indicate the values are no longer "live"
+	diags := resources.CloseInstances(ctx, ephemA0.ConfigResource())
+	// FIXME: error string matching
+	diagStr := diags.Err().Error()
+	if strings.Count(diagStr, "context canceled") != 2 {
+		t.Fatal("expected 2 context canceled errors, got:\n", diagStr)
+	}
+
+	diags = resources.CloseInstances(ctx, ephemB.ConfigResource())
+	if diags.HasErrors() {
+		t.Fatal(diags.ErrWithWarnings())
+	}
+
+	if !testA0.closed {
+		t.Fatalf("%s not closed", ephemA0)
+	}
+	if !testA1.closed {
+		t.Fatalf("%s not closed", ephemA1)
+	}
+	if !testB.closed {
+		t.Fatalf("%s not closed", ephemB)
+	}
+}
+
+type testResourceInstance struct {
+	sync.Mutex
+
+	renewInterval time.Duration
+	renewed       int
+	notifyRenew   chan int
+	closed        bool
+}
+
+func (r *testResourceInstance) Renew(ctx context.Context, req providers.EphemeralRenew) (*providers.EphemeralRenew, tfdiags.Diagnostics) {
+	nextRenew := &providers.EphemeralRenew{
+		ExpireTime: time.Now().Add(r.renewInterval),
+	}
+	r.Lock()
+	defer r.Unlock()
+	r.renewed++
+	select {
+	case r.notifyRenew <- r.renewed:
+	default:
+		panic("blocked on unexpected renew call")
+	}
+
+	return nextRenew, nil
+}
+
+func (r *testResourceInstance) Close(ctx context.Context) tfdiags.Diagnostics {
+	r.Lock()
+	defer r.Unlock()
+	r.closed = true
+	return nil
+}

--- a/internal/resources/ephemeral/ephemeral_resources.go
+++ b/internal/resources/ephemeral/ephemeral_resources.go
@@ -213,10 +213,9 @@ func (r *resourceInstanceInternal) close(ctx context.Context) tfdiags.Diagnostic
 	return diags
 }
 
-// FIXME: a renew time of less than a minute will cause a runaway loop of renewals
 func (r *resourceInstanceInternal) handleRenewal(ctx context.Context, wg *sync.WaitGroup, firstRenewal *providers.EphemeralRenew) {
 	defer wg.Done()
-	t := time.NewTimer(time.Until(firstRenewal.ExpireTime.Add(-60 * time.Second)))
+	t := time.NewTimer(time.Until(firstRenewal.ExpireTime))
 	nextRenew := firstRenewal
 	for {
 		select {
@@ -238,7 +237,7 @@ func (r *resourceInstanceInternal) handleRenewal(ctx context.Context, wg *sync.W
 				return
 			}
 			nextRenew = anotherRenew
-			t.Reset(time.Until(anotherRenew.ExpireTime.Add(-60 * time.Second)))
+			t.Reset(time.Until(anotherRenew.ExpireTime))
 			r.renewMu.Unlock()
 		case <-ctx.Done():
 			// If we're cancelled then we'll halt renewing immediately.

--- a/internal/resources/ephemeral/ephemeral_resources.go
+++ b/internal/resources/ephemeral/ephemeral_resources.go
@@ -1,0 +1,229 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package ephemeral
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/terraform/internal/addrs"
+	"github.com/hashicorp/terraform/internal/providers"
+	"github.com/hashicorp/terraform/internal/tfdiags"
+
+	"github.com/zclconf/go-cty/cty"
+)
+
+// Resources is a tracking structure for active instances of ephemeral
+// resources.
+//
+// The lifecycle of an ephemeral resource instance is quite different than
+// other resource modes because it's live for at most the duration of a single
+// graph walk, and because it might need periodic "renewing" in order to
+// remain live for the necessary duration.
+type Resources struct {
+	active addrs.Map[addrs.ConfigResource, addrs.Map[addrs.AbsResourceInstance, *resourceInstanceInternal]]
+	mu     sync.Mutex
+}
+
+func NewResources() *Resources {
+	return &Resources{
+		active: addrs.MakeMap[addrs.ConfigResource, addrs.Map[addrs.AbsResourceInstance, *resourceInstanceInternal]](),
+	}
+}
+
+type ResourceInstanceRegistration struct {
+	Value        cty.Value
+	ConfigBody   hcl.Body
+	Impl         ResourceInstance
+	FirstRenewal *providers.EphemeralRenew
+}
+
+func (r *Resources) RegisterInstance(ctx context.Context, addr addrs.AbsResourceInstance, reg ResourceInstanceRegistration) {
+	if addr.Resource.Resource.Mode != addrs.EphemeralResourceMode {
+		panic(fmt.Sprintf("can't register %s as an ephemeral resource instance", addr))
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	configAddr := addr.ConfigResource()
+	if !r.active.Has(configAddr) {
+		r.active.Put(configAddr, addrs.MakeMap[addrs.AbsResourceInstance, *resourceInstanceInternal]())
+	}
+	ri := &resourceInstanceInternal{
+		value:       reg.Value,
+		configBody:  reg.ConfigBody,
+		impl:        reg.Impl,
+		renewCancel: noopCancel,
+	}
+	if reg.FirstRenewal != nil {
+		ctx, cancel := context.WithCancel(ctx)
+		ri.renewCancel = cancel
+		go ri.handleRenewal(ctx, reg.FirstRenewal)
+	}
+	r.active.Get(configAddr).Put(addr, ri)
+}
+
+func (r *Resources) InstanceValue(addr addrs.AbsResourceInstance) (val cty.Value, live bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	configAddr := addr.ConfigResource()
+	insts, ok := r.active.GetOk(configAddr)
+	if !ok {
+		return cty.DynamicVal, false
+	}
+	inst, ok := insts.GetOk(addr)
+	if !ok {
+		return cty.DynamicVal, false
+	}
+	// If renewal has failed then we can't assume that the object is still
+	// live, but we can still return the original value regardless.
+	return inst.value, !inst.renewDiags.HasErrors()
+}
+
+// CloseInstances shuts down any live ephemeral resource instances that are
+// associated with the given resource address.
+//
+// This is the "happy path" way to shut down ephemeral resource instances,
+// intended to be called during the visit to a graph node that depends on
+// all other nodes that might make use of the instances of this ephemeral
+// resource.
+//
+// The runtime should also eventually call [Resources.Close] once the graph
+// walk is complete, to catch any stragglers that we didn't reach for
+// piecemeal shutdown, e.g. due to errors during the graph walk.
+func (r *Resources) CloseInstances(ctx context.Context, configAddr addrs.ConfigResource) tfdiags.Diagnostics {
+	r.mu.Lock()
+
+	// TODO upgrade this to a RWMutex so we don't need to serialize all Close
+	// operations which may require network access
+
+	var diags tfdiags.Diagnostics
+	for _, elem := range r.active.Get(configAddr).Elems {
+		moreDiags := elem.Value.close(ctx)
+		diags = diags.Append(moreDiags.InConfigBody(elem.Value.configBody, elem.Key.String()))
+	}
+
+	// Stop tracking the objects we've just closed, so that we know we don't
+	// still need to close them.
+	r.active.Remove(configAddr)
+
+	// Unlock immediately because the Close operation may take some time.
+	r.mu.Unlock()
+
+	return diags
+}
+
+// Close shuts down any ephemeral resource instances that are still running
+// at the time of the call.
+//
+// This is intended to catch any "stragglers" that we weren't able to clean
+// up during the graph walk, such as if an error prevents us from reaching
+// the cleanup node.
+func (r *Resources) Close(ctx context.Context) tfdiags.Diagnostics {
+	// FIXME: The following really ought to take into account dependency
+	// relationships between what's still running, because it's possible that
+	// one ephemeral resource depends on another ephemeral resource to operate
+	// correctly. Investigate making sure individual close calls are always
+	// called even after runtime errors.
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	// We might be closing due to a context cancellation, but we still need
+	// to be able to make non-canceled Close requests.
+	ctx = context.WithoutCancel(ctx)
+
+	var diags tfdiags.Diagnostics
+	for _, elem := range r.active.Elems {
+		for _, elem := range elem.Value.Elems {
+			moreDiags := elem.Value.close(ctx)
+			diags = diags.Append(moreDiags.InConfigBody(elem.Value.configBody, elem.Key.String()))
+		}
+	}
+	r.active = addrs.MakeMap[addrs.ConfigResource, addrs.Map[addrs.AbsResourceInstance, *resourceInstanceInternal]]()
+	return diags
+}
+
+type resourceInstanceInternal struct {
+	value      cty.Value
+	configBody hcl.Body
+	impl       ResourceInstance
+
+	renewCancel func()
+	renewDiags  tfdiags.Diagnostics
+	renewMu     sync.Mutex // hold when accessing renewCancel/renewDiags, and while actually renewing
+}
+
+// close halts this instance's asynchronous renewal loop, if any, and then
+// calls Close on the resource instance's implementation object.
+//
+// The returned diagnostics are contextual diagnostics that should have
+// [tfdiags.Diagnostics.WithConfigBody] called on them before returning to
+// a context-unaware caller.
+func (r *resourceInstanceInternal) close(ctx context.Context) tfdiags.Diagnostics {
+	var diags tfdiags.Diagnostics
+
+	// Stop renewing, if indeed we are. If we previously saw any errors during
+	// renewing then they finally get returned here, to be reported along with
+	// any errors during close.
+	r.renewMu.Lock()
+	r.renewCancel()
+	diags = diags.Append(r.renewDiags)
+	r.renewDiags = nil // just to avoid any risk of double-reporting
+	r.renewMu.Unlock()
+
+	// FIXME: If renewal failed earlier then it's pretty likely that closing
+	// would fail too. For now this is assuming that it's the provider's
+	// own responsibility to remember that it previously failed a renewal
+	// and to avoid returning redundant errors from close, but perhaps we'll
+	// revisit that in later work.
+	// FIXME: this should still be cancellable somehow, why are we stripping the cancel here?
+	diags = diags.Append(r.impl.Close(context.WithoutCancel(ctx)))
+
+	return diags
+}
+
+// FIXME: a renew time of less than a minute will cause a runaway loop of renewals
+func (r *resourceInstanceInternal) handleRenewal(ctx context.Context, firstRenewal *providers.EphemeralRenew) {
+	t := time.NewTimer(time.Until(firstRenewal.ExpireTime.Add(-60 * time.Second)))
+	nextRenew := firstRenewal
+	for {
+		select {
+		case <-t.C:
+			// It's time to renew
+			r.renewMu.Lock()
+			anotherRenew, diags := r.impl.Renew(ctx, *nextRenew)
+			r.renewDiags.Append(diags)
+			if diags.HasErrors() {
+				// If renewal fails then we'll stop trying to renew.
+				r.renewCancel = noopCancel
+				r.renewMu.Unlock()
+				return
+			}
+			if anotherRenew == nil {
+				// If we don't have another round of renew to do then we'll stop.
+				r.renewCancel = noopCancel
+				r.renewMu.Unlock()
+				return
+			}
+			nextRenew = anotherRenew
+			t.Reset(time.Until(anotherRenew.ExpireTime.Add(-60 * time.Second)))
+			r.renewMu.Unlock()
+		case <-ctx.Done():
+			// If we're cancelled then we'll halt renewing immediately.
+			r.renewMu.Lock()
+			t.Stop()
+			r.renewCancel = noopCancel
+			r.renewDiags = r.renewDiags.Append(ctx.Err())
+			r.renewMu.Unlock()
+			return // we don't need to run this loop anymore
+		}
+	}
+}
+
+func noopCancel() {}


### PR DESCRIPTION
The `resources/ephemeral` package manages ephemeral resources and and the lifecycle.

Ephemeral resources have a very different lifecycle from managed resources, and need to be managed more similarly to named values than resources. The `resources/ephemeral` package is a separate database for tracking ephemeral resource values, refreshing those resources as required, and closing down the resources when they are no longer needed.