### PR TITLE
stacks: improve error message for component and removed blocks colliding

### DIFF
--- a/internal/stacks/stackconfig/declarations.go
+++ b/internal/stacks/stackconfig/declarations.go
@@ -92,9 +92,9 @@ func (d *Declarations) addComponent(decl *Component) tfdiags.Diagnostics {
 		// method for more information.
 		diags = diags.Append(&hcl.Diagnostic{
 			Severity: hcl.DiagError,
-			Summary:  "Component exists for removed block",
+			Summary:  "Component exists for removed block without index",
 			Detail: fmt.Sprintf(
-				"A removed block for component %q was declared without an index, but a component block with the same name was declared at %s.\n\nA removed block without an index indicates that the component and all instances were removed from the configuration, and this is not the case.",
+				"A removed block for component %q was declared, but a component with the same address exists at %q. This is invalid, please either specify an index for the removed block or remove the component block if you want to remove the component or component instance.",
 				name, decl.DeclRange.ToHCL(),
 			),
 			Subject: removed.DeclRange.ToHCL().Ptr(),
@@ -284,9 +284,9 @@ func (d *Declarations) addRemoved(decl *Removed) tfdiags.Diagnostics {
 		if component, exists := d.Components[name]; exists {
 			diags = diags.Append(&hcl.Diagnostic{
 				Severity: hcl.DiagError,
-				Summary:  "Component exists for removed block",
+				Summary:  "Component exists for removed block without index",
 				Detail: fmt.Sprintf(
-					"A removed block for component %q was declared without an index, but a component block with the same name was declared at %s.\n\nA removed block without an index indicates that the component and all instances were removed from the configuration, and this is not the case.",
+					"A removed block for component %q was declared, but a component with the same address exists at %q. This is invalid, please either specify an index for the removed block or remove the component block if you want to remove the component or component instance.",
 					name, component.DeclRange.ToHCL(),
 				),
 				Subject: decl.DeclRange.ToHCL().Ptr(),


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Fixes #

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.8.x

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

### NEW FEATURES | UPGRADE NOTES | ENHANCEMENTS | BUG FIXES | EXPERIMENTS

<!--

Write a short description of the user-facing change. Examples:

- `terraform show -json`: Fixed crash with sensitive set values.
- When rendering a diff, Terraform now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 

-  