### PR TITLE
stacks: stacks destroy ordering should match Terraform

### DIFF
--- a/internal/stacks/stackruntime/apply_destroy_test.go
+++ b/internal/stacks/stackruntime/apply_destroy_test.go
@@ -940,29 +940,36 @@ func TestApplyDestroy(t *testing.T) {
 				},
 			},
 		},
-		"destroy-with-provider-req": {
-			path: "auth-provider-w-data",
+		"destroy-with-provider-req-and-removed": {
+			path: path.Join("auth-provider-w-data", "removed"),
+			state: stackstate.NewStateBuilder().
+				AddComponentInstance(stackstate.NewComponentInstanceBuilder(mustAbsComponentInstance("component.load")).
+					AddDependent(mustAbsComponent("component.create")).
+					AddOutputValue("credentials", cty.StringVal("wrong"))). // must reload the credentials
+				AddComponentInstance(stackstate.NewComponentInstanceBuilder(mustAbsComponentInstance("component.create")).
+					AddDependency(mustAbsComponent("component.load"))).
+				AddResourceInstance(stackstate.NewResourceInstanceBuilder().
+					SetAddr(mustAbsResourceInstanceObject("component.create.testing_resource.resource")).
+					SetResourceInstanceObjectSrc(states.ResourceInstanceObjectSrc{
+						AttrsJSON: mustMarshalJSONAttrs(map[string]interface{}{
+							"id":    "resource",
+							"value": nil,
+						}),
+						Status: states.ObjectReady,
+					}).
+					SetProviderAddr(mustDefaultRootProvider("testing"))).
+				Build(),
+			store: stacks_testing_provider.NewResourceStoreBuilder().AddResource("credentials", cty.ObjectVal(map[string]cty.Value{
+				"id": cty.StringVal("credentials"),
+				// we have the wrong value in state, so this correct value must
+				// be loaded for this test to work.
+				"value": cty.StringVal("authn"),
+			})).Build(),
 			mutators: []func(store *stacks_testing_provider.ResourceStore, testContext TestContext) TestContext{
 				func(store *stacks_testing_provider.ResourceStore, testContext TestContext) TestContext {
-					store.Set("credentials", cty.ObjectVal(map[string]cty.Value{
-						"id":    cty.StringVal("credentials"),
-						"value": cty.StringVal("zero"),
-					}))
 					testContext.providers[addrs.NewDefaultProvider("testing")] = func() (providers.Interface, error) {
 						provider := stacks_testing_provider.NewProviderWithData(t, store)
-						provider.Authentication = "zero"
-						return provider, nil
-					}
-					return testContext
-				},
-				func(store *stacks_testing_provider.ResourceStore, testContext TestContext) TestContext {
-					store.Set("credentials", cty.ObjectVal(map[string]cty.Value{
-						"id":    cty.StringVal("credentials"),
-						"value": cty.StringVal("one"),
-					}))
-					testContext.providers[addrs.NewDefaultProvider("testing")] = func() (providers.Interface, error) {
-						provider := stacks_testing_provider.NewProviderWithData(t, store)
-						provider.Authentication = "one" // So we must reload the data source in order to authenticate.
+						provider.Authentication = "authn" // So we must reload the data source in order to authenticate.
 						return provider, nil
 					}
 					return testContext
@@ -970,12 +977,24 @@ func TestApplyDestroy(t *testing.T) {
 			},
 			cycles: []TestCycle{
 				{
-					planMode: plans.NormalMode,
-				},
-				{
-					planMode:           plans.DestroyMode,
+					planMode: plans.DestroyMode,
 					wantAppliedChanges: []stackstate.AppliedChange{
-						// TODO: Populate these with the correct values.
+						&stackstate.AppliedChangeComponentInstanceRemoved{
+							ComponentAddr:         mustAbsComponent("component.create"),
+							ComponentInstanceAddr: mustAbsComponentInstance("component.create"),
+						},
+						&stackstate.AppliedChangeResourceInstanceObject{
+							ResourceInstanceObjectAddr: mustAbsResourceInstanceObject("component.create.testing_resource.resource"),
+							ProviderConfigAddr:         mustDefaultRootProvider("testing"),
+						},
+						&stackstate.AppliedChangeComponentInstanceRemoved{
+							ComponentAddr:         mustAbsComponent("component.load"),
+							ComponentInstanceAddr: mustAbsComponentInstance("component.load"),
+						},
+						&stackstate.AppliedChangeResourceInstanceObject{
+							ResourceInstanceObjectAddr: mustAbsResourceInstanceObject("component.load.data.testing_data_source.credentials"),
+							ProviderConfigAddr:         mustDefaultRootProvider("testing"),
+						},
 					},
 				},
 			},

--- a/internal/stacks/stackruntime/apply_destroy_test.go
+++ b/internal/stacks/stackruntime/apply_destroy_test.go
@@ -940,6 +940,46 @@ func TestApplyDestroy(t *testing.T) {
 				},
 			},
 		},
+		"destroy-with-provider-req": {
+			path: "auth-provider-w-data",
+			mutators: []func(store *stacks_testing_provider.ResourceStore, testContext TestContext) TestContext{
+				func(store *stacks_testing_provider.ResourceStore, testContext TestContext) TestContext {
+					store.Set("credentials", cty.ObjectVal(map[string]cty.Value{
+						"id":    cty.StringVal("credentials"),
+						"value": cty.StringVal("zero"),
+					}))
+					testContext.providers[addrs.NewDefaultProvider("testing")] = func() (providers.Interface, error) {
+						provider := stacks_testing_provider.NewProviderWithData(t, store)
+						provider.Authentication = "zero"
+						return provider, nil
+					}
+					return testContext
+				},
+				func(store *stacks_testing_provider.ResourceStore, testContext TestContext) TestContext {
+					store.Set("credentials", cty.ObjectVal(map[string]cty.Value{
+						"id":    cty.StringVal("credentials"),
+						"value": cty.StringVal("one"),
+					}))
+					testContext.providers[addrs.NewDefaultProvider("testing")] = func() (providers.Interface, error) {
+						provider := stacks_testing_provider.NewProviderWithData(t, store)
+						provider.Authentication = "one" // So we must reload the data source in order to authenticate.
+						return provider, nil
+					}
+					return testContext
+				},
+			},
+			cycles: []TestCycle{
+				{
+					planMode: plans.NormalMode,
+				},
+				{
+					planMode:           plans.DestroyMode,
+					wantAppliedChanges: []stackstate.AppliedChange{
+						// TODO: Populate these with the correct values.
+					},
+				},
+			},
+		},
 	}
 	for name, tc := range tcs {
 		t.Run(name, func(t *testing.T) {

--- a/internal/stacks/stackruntime/apply_test.go
+++ b/internal/stacks/stackruntime/apply_test.go
@@ -1144,6 +1144,38 @@ After applying this plan, Terraform will no longer manage these objects. You wil
 				},
 			},
 		},
+		"removed block with provider-to-component dep": {
+			path: path.Join("auth-provider-w-data", "removed"),
+			state: stackstate.NewStateBuilder().
+				AddComponentInstance(stackstate.NewComponentInstanceBuilder(mustAbsComponentInstance("component.load")).
+					AddDependent(mustAbsComponent("component.create")).
+					AddOutputValue("credentials", cty.StringVal("wrong"))). // must reload the credentials
+				AddComponentInstance(stackstate.NewComponentInstanceBuilder(mustAbsComponentInstance("component.create")).
+					AddDependency(mustAbsComponent("component.load"))).
+				AddResourceInstance(stackstate.NewResourceInstanceBuilder().
+					SetAddr(mustAbsResourceInstanceObject("component.create.testing_resource.resource")).
+					SetResourceInstanceObjectSrc(states.ResourceInstanceObjectSrc{
+						AttrsJSON: mustMarshalJSONAttrs(map[string]interface{}{
+							"id":    "resource",
+							"value": nil,
+						}),
+						Status: states.ObjectReady,
+					}).
+					SetProviderAddr(mustDefaultRootProvider("testing"))).
+				Build(),
+			store: stacks_testing_provider.NewResourceStoreBuilder().AddResource("credentials", cty.ObjectVal(map[string]cty.Value{
+				"id": cty.StringVal("credentials"),
+				// we have the wrong value in state, so this correct value must
+				// be loaded for this test to work.
+				"value": cty.StringVal("authn"),
+			})).Build(),
+			cycles: []TestCycle{
+				{
+					planMode:           plans.NormalMode,
+					wantAppliedChanges: []stackstate.AppliedChange{},
+				},
+			},
+		},
 	}
 
 	for name, tc := range tcs {
@@ -1168,7 +1200,9 @@ After applying this plan, Terraform will no longer manage these objects. You wil
 				config:    loadMainBundleConfigForTest(t, tc.path),
 				providers: map[addrs.Provider]providers.Factory{
 					addrs.NewDefaultProvider("testing"): func() (providers.Interface, error) {
-						return stacks_testing_provider.NewProviderWithData(t, store), nil
+						provider := stacks_testing_provider.NewProviderWithData(t, store)
+						provider.Authentication = "authn"
+						return provider, nil
 					},
 				},
 				dependencyLocks: *lock,

--- a/internal/stacks/stackruntime/internal/stackeval/component_instance.go
+++ b/internal/stacks/stackruntime/internal/stackeval/component_instance.go
@@ -300,6 +300,9 @@ func (c *ComponentInstance) CheckModuleTreePlan(ctx context.Context) (*plans.Pla
 					break
 				}
 
+				// TODO: Remove from here if we want to implement the
+				//  workaround.
+
 				// We're also going to look through any upstream components
 				// that are being removed to make sure they are removed first.
 				for _, depAddr := range c.PlanPrevDependents(ctx).Elems() {

--- a/internal/stacks/stackruntime/internal/stackeval/main_apply.go
+++ b/internal/stacks/stackruntime/internal/stackeval/main_apply.go
@@ -197,25 +197,11 @@ func ApplyPlan(ctx context.Context, config *stackconfig.Config, plan *stackplan.
 
 							// If we're being destroyed, then we're waiting for
 							// everything that depended on us anyway.
-							waitForRemoveds = collections.NewSet[stackaddrs.AbsComponent]()
+							waitForRemoveds = dependencyAddrs
 						} else {
 							// For all other actions, we must wait for our
 							// dependencies to finish applying their changes.
 							waitForComponents = dependencyAddrs
-
-							// TODO: Remove from here if we want to implement
-							//  the workaround.
-
-							// If we're not being destroyed we might have some
-							// depdendents that are being destroyed, and we need
-							// to wait for them to finish before we can start.
-							waitForRemoveds = collections.NewSet[stackaddrs.AbsComponent]()
-							for _, dependent := range dependentAddrs.Elems() {
-								dependentStack := main.Stack(ctx, dependent.Stack, ApplyPhase)
-								if dependentStack.Removed(ctx, dependent.Item) != nil {
-									waitForRemoveds.Add(dependent)
-								}
-							}
 						}
 						if depCount := waitForComponents.Len(); depCount != 0 {
 							log.Printf("[TRACE] stackeval: %s waiting for its predecessors (%d) to complete", addr, depCount)

--- a/internal/stacks/stackruntime/internal/stackeval/main_apply.go
+++ b/internal/stacks/stackruntime/internal/stackeval/main_apply.go
@@ -203,6 +203,9 @@ func ApplyPlan(ctx context.Context, config *stackconfig.Config, plan *stackplan.
 							// dependencies to finish applying their changes.
 							waitForComponents = dependencyAddrs
 
+							// TODO: Remove from here if we want to implement
+							//  the workaround.
+
 							// If we're not being destroyed we might have some
 							// depdendents that are being destroyed, and we need
 							// to wait for them to finish before we can start.

--- a/internal/stacks/stackruntime/internal/stackeval/removed_instance.go
+++ b/internal/stacks/stackruntime/internal/stackeval/removed_instance.go
@@ -120,16 +120,12 @@ func (r *RemovedInstance) ModuleTreePlan(ctx context.Context) (*plans.Plan, tfdi
 				// doesn't exist so it's fine.
 				break
 			}
-			depComponent := depStack.Component(ctx, depAddr.Item)
-			if depComponent == nil {
-				// again, the thing we need to wait to be deleted
-				// doesn't exist so it's fine.
+			depComponent, depRemoved := depStack.ApplyableComponents(ctx, depAddr.Item)
+			if depComponent != nil && !depComponent.PlanIsComplete(ctx) {
+				deferred = true
 				break
 			}
-			if !depComponent.PlanIsComplete(ctx) {
-				// The other component couldn't be deleted in a single
-				// go, so to be safe we'll defer our deletions until
-				// the other one is complete.
+			if depRemoved != nil && !depRemoved.PlanIsComplete(ctx) {
 				deferred = true
 				break
 			}


### PR DESCRIPTION
This PR modifies the order of the dependency graph of components in Stacks to match the ordering applied to resources within Terraform Core.

When the dependency graph was originally written, I thought the "reversed ordering" applied during the destroy graph of Terraform was also applied on normal destroy operations in the regular graph. This isn't the case because it introduces cycles into the graph whenever providers require outputs from previous resources and are required to destroy a resource. It is clear that the resource being destroyed cannot become a dependency of the earlier resource, otherwise we'd definitely have a cycle.

The current implementation of Stacks, however, does this. And we have discovered the cycles with providers being a natural consequence. This PR modifies the dependency graph ordering of Stacks so that removed blocks still execute after any dependencies their previous component used to have. This does mean that users need to be more careful about the order in which they apply destroy and update operations, but this matches the behaviour in Terraform so that should be okay.

With this PR a removed block will execute after any dependencies the old component block had, and still execute after any dependent removed blocks. So, removed blocks will still be deleted in the reverse-order the equivalent components were created in, but they won't try and execute before any dependencies that haven't also been converted into removed blocks ensuring we don't get cycles if some sticks a provider block in the middle of two components.

In addition, this PR does also include removed blocks in the dependency graph for complete destroy plans, in which component blocks and removed blocks behave exactly the same. This was missed previously.

