### PR TITLE
config generation: escape map keys with whitespace

### DIFF
--- a/internal/genconfig/generate_config_test.go
+++ b/internal/genconfig/generate_config_test.go
@@ -600,6 +600,94 @@ resource "tfcoremock_sensitive_values" "values" {
   string       = null # sensitive
 }`,
 		},
+		"simple_map_with_whitespace_in_keys": {
+			schema: &configschema.Block{
+				Attributes: map[string]*configschema.Attribute{
+					"map": {
+						Type:     cty.Map(cty.String),
+						Optional: true,
+					},
+				},
+			},
+			addr: addrs.AbsResourceInstance{
+				Module: addrs.RootModuleInstance,
+				Resource: addrs.ResourceInstance{
+					Resource: addrs.Resource{
+						Mode: addrs.ManagedResourceMode,
+						Type: "testing_resource",
+						Name: "resource",
+					},
+					Key: addrs.NoKey,
+				},
+			},
+			provider: addrs.LocalProviderConfig{
+				LocalName: "testing",
+			},
+			value: cty.ObjectVal(map[string]cty.Value{
+				"map": cty.MapVal(map[string]cty.Value{
+					"key with spaces":      cty.StringVal("spaces"),
+					"key_with_underscores": cty.StringVal("underscores"),
+				}),
+			}),
+			expected: `resource "testing_resource" "resource" {
+  map = {
+    "key with spaces"    = "spaces"
+    key_with_underscores = "underscores"
+  }
+}`,
+		},
+		"nested_map_with_whitespace_in_keys": {
+			schema: &configschema.Block{
+				Attributes: map[string]*configschema.Attribute{
+					"map": {
+						NestedType: &configschema.Object{
+							Attributes: map[string]*configschema.Attribute{
+								"value": {
+									Type:     cty.String,
+									Optional: true,
+								},
+							},
+							Nesting: configschema.NestingMap,
+						},
+						Optional: true,
+					},
+				},
+			},
+			addr: addrs.AbsResourceInstance{
+				Module: addrs.RootModuleInstance,
+				Resource: addrs.ResourceInstance{
+					Resource: addrs.Resource{
+						Mode: addrs.ManagedResourceMode,
+						Type: "testing_resource",
+						Name: "resource",
+					},
+					Key: addrs.NoKey,
+				},
+			},
+			provider: addrs.LocalProviderConfig{
+				LocalName: "testing",
+			},
+			value: cty.ObjectVal(map[string]cty.Value{
+				"map": cty.MapVal(map[string]cty.Value{
+					"key with spaces": cty.ObjectVal(map[string]cty.Value{
+						"value": cty.StringVal("spaces"),
+					}),
+					"key_with_underscores": cty.ObjectVal(map[string]cty.Value{
+						"value": cty.StringVal("underscores"),
+					}),
+				}),
+			}),
+			expected: `resource "testing_resource" "resource" {
+  map = {
+    "key with spaces" = {
+      value = "spaces"
+    }
+    key_with_underscores = {
+      value = "underscores"
+    }
+  }
+}`,
+		},
 	}
 	for name, tc := range tcs {
 		t.Run(name, func(t *testing.T) {


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

This PR updates the config generation package so map keys with whitespace are escaped with quotes. This is already handled automatically for the normal attribute generation, and nested blocks are also escaped by default. This PR updates the nested attributes so the keys of nested maps are validated and escaped if necessary. It is only maps that have this problem, attributes in objects cannot contain whitespace and other types (lists, sets, tuples) do not render keys anyway.

The rendering package has this same problem, and so far we've not handled it perfectly but just well enough. We'll continue to do so here, but the code calls out we could modify the HCL library so it exposes the internal functions it uses to detect when escaping is necessary and share those between HCL and Terraform. But so far, we've not had any need to take this too seriously.

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Fixes #35752

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.9.x

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

### BUG FIXES

<!--

Write a short description of the user-facing change. Examples:

- `terraform show -json`: Fixed crash with sensitive set values.
- When rendering a diff, Terraform now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 

-  config generation: escape map keys with whitespaces
