### PR TITLE
core: ephemeral resources

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,7 @@ require (
 	github.com/hashicorp/go-uuid v1.0.3
 	github.com/hashicorp/go-version v1.6.0
 	github.com/hashicorp/hcl v1.0.0
-	github.com/hashicorp/hcl/v2 v2.21.0
+	github.com/hashicorp/hcl/v2 v2.22.1-0.20240924195505-78fe99307e88
 	github.com/hashicorp/jsonapi v1.3.1
 	github.com/hashicorp/terraform-registry-address v0.2.3
 	github.com/hashicorp/terraform-svchost v0.1.1

--- a/go.sum
+++ b/go.sum
@@ -699,8 +699,8 @@ github.com/hashicorp/golang-lru v0.5.1 h1:0hERBMJE1eitiLkihrMvRVBYAkpHzc/J3QdDN+
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
-github.com/hashicorp/hcl/v2 v2.21.0 h1:lve4q/o/2rqwYOgUg3y3V2YPyD1/zkCLGjIV74Jit14=
-github.com/hashicorp/hcl/v2 v2.21.0/go.mod h1:62ZYHrXgPoX8xBnzl8QzbWq4dyDsDtfCRgIq1rbJEvA=
+github.com/hashicorp/hcl/v2 v2.22.1-0.20240924195505-78fe99307e88 h1:zxDgi0q8lcFZUBzoIJ8+EyGqSxalMT8802t31gpfrxc=
+github.com/hashicorp/hcl/v2 v2.22.1-0.20240924195505-78fe99307e88/go.mod h1:62ZYHrXgPoX8xBnzl8QzbWq4dyDsDtfCRgIq1rbJEvA=
 github.com/hashicorp/jsonapi v1.3.1 h1:GtPvnmcWgYwCuDGvYT5VZBHcUyFdq9lSyCzDjn1DdPo=
 github.com/hashicorp/jsonapi v1.3.1/go.mod h1:kWfdn49yCjQvbpnvY1dxxAuAFzISwrrMDQOcu6NsFoM=
 github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO+LraFDTW64=

--- a/internal/backend/remote-state/azure/go.mod
+++ b/internal/backend/remote-state/azure/go.mod
@@ -37,7 +37,7 @@ require (
 	github.com/hashicorp/go-retryablehttp v0.7.7 // indirect
 	github.com/hashicorp/go-slug v0.15.0 // indirect
 	github.com/hashicorp/go-version v1.6.0 // indirect
-	github.com/hashicorp/hcl/v2 v2.21.0 // indirect
+	github.com/hashicorp/hcl/v2 v2.22.1-0.20240924195505-78fe99307e88 // indirect
 	github.com/hashicorp/terraform-registry-address v0.2.3 // indirect
 	github.com/hashicorp/terraform-svchost v0.1.1 // indirect
 	github.com/manicminer/hamilton-autorest v0.2.0 // indirect

--- a/internal/backend/remote-state/azure/go.sum
+++ b/internal/backend/remote-state/azure/go.sum
@@ -232,8 +232,8 @@ github.com/hashicorp/go-version v1.6.0 h1:feTTfFNnjP967rlCxM/I9g701jU+RN74YKx2mO
 github.com/hashicorp/go-version v1.6.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
-github.com/hashicorp/hcl/v2 v2.21.0 h1:lve4q/o/2rqwYOgUg3y3V2YPyD1/zkCLGjIV74Jit14=
-github.com/hashicorp/hcl/v2 v2.21.0/go.mod h1:62ZYHrXgPoX8xBnzl8QzbWq4dyDsDtfCRgIq1rbJEvA=
+github.com/hashicorp/hcl/v2 v2.22.1-0.20240924195505-78fe99307e88 h1:zxDgi0q8lcFZUBzoIJ8+EyGqSxalMT8802t31gpfrxc=
+github.com/hashicorp/hcl/v2 v2.22.1-0.20240924195505-78fe99307e88/go.mod h1:62ZYHrXgPoX8xBnzl8QzbWq4dyDsDtfCRgIq1rbJEvA=
 github.com/hashicorp/terraform-registry-address v0.2.3 h1:2TAiKJ1A3MAkZlH1YI/aTVcLZRu7JseiXNRHbOAyoTI=
 github.com/hashicorp/terraform-registry-address v0.2.3/go.mod h1:lFHA76T8jfQteVfT7caREqguFrW3c4MFSPhZB7HHgUM=
 github.com/hashicorp/terraform-svchost v0.1.1 h1:EZZimZ1GxdqFRinZ1tpJwVxxt49xc/S52uzrw4x0jKQ=

--- a/internal/backend/remote-state/consul/go.mod
+++ b/internal/backend/remote-state/consul/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/hashicorp/go-uuid v1.0.3 // indirect
 	github.com/hashicorp/go-version v1.6.0 // indirect
 	github.com/hashicorp/golang-lru v0.5.1 // indirect
-	github.com/hashicorp/hcl/v2 v2.21.0 // indirect
+	github.com/hashicorp/hcl/v2 v2.22.1-0.20240924195505-78fe99307e88 // indirect
 	github.com/hashicorp/serf v0.9.6 // indirect
 	github.com/hashicorp/terraform-registry-address v0.2.3 // indirect
 	github.com/hashicorp/terraform-svchost v0.1.1 // indirect

--- a/internal/backend/remote-state/consul/go.sum
+++ b/internal/backend/remote-state/consul/go.sum
@@ -206,8 +206,8 @@ github.com/hashicorp/go-version v1.6.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1 h1:0hERBMJE1eitiLkihrMvRVBYAkpHzc/J3QdDN+dAcgU=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
-github.com/hashicorp/hcl/v2 v2.21.0 h1:lve4q/o/2rqwYOgUg3y3V2YPyD1/zkCLGjIV74Jit14=
-github.com/hashicorp/hcl/v2 v2.21.0/go.mod h1:62ZYHrXgPoX8xBnzl8QzbWq4dyDsDtfCRgIq1rbJEvA=
+github.com/hashicorp/hcl/v2 v2.22.1-0.20240924195505-78fe99307e88 h1:zxDgi0q8lcFZUBzoIJ8+EyGqSxalMT8802t31gpfrxc=
+github.com/hashicorp/hcl/v2 v2.22.1-0.20240924195505-78fe99307e88/go.mod h1:62ZYHrXgPoX8xBnzl8QzbWq4dyDsDtfCRgIq1rbJEvA=
 github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO+LraFDTW64=
 github.com/hashicorp/mdns v1.0.4/go.mod h1:mtBihi+LeNXGtG8L9dX59gAEa12BDtBQSp4v/YAJqrc=
 github.com/hashicorp/memberlist v0.3.0 h1:8+567mCcFDnS5ADl7lrpxPMWiFCElyUEeW0gtj34fMA=

--- a/internal/backend/remote-state/cos/go.mod
+++ b/internal/backend/remote-state/cos/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/hashicorp/go-slug v0.15.0 // indirect
 	github.com/hashicorp/go-uuid v1.0.3 // indirect
 	github.com/hashicorp/go-version v1.6.0 // indirect
-	github.com/hashicorp/hcl/v2 v2.21.0 // indirect
+	github.com/hashicorp/hcl/v2 v2.22.1-0.20240924195505-78fe99307e88 // indirect
 	github.com/hashicorp/terraform-registry-address v0.2.3 // indirect
 	github.com/hashicorp/terraform-svchost v0.1.1 // indirect
 	github.com/mitchellh/copystructure v1.2.0 // indirect

--- a/internal/backend/remote-state/cos/go.sum
+++ b/internal/backend/remote-state/cos/go.sum
@@ -174,8 +174,8 @@ github.com/hashicorp/go-version v1.6.0 h1:feTTfFNnjP967rlCxM/I9g701jU+RN74YKx2mO
 github.com/hashicorp/go-version v1.6.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
-github.com/hashicorp/hcl/v2 v2.21.0 h1:lve4q/o/2rqwYOgUg3y3V2YPyD1/zkCLGjIV74Jit14=
-github.com/hashicorp/hcl/v2 v2.21.0/go.mod h1:62ZYHrXgPoX8xBnzl8QzbWq4dyDsDtfCRgIq1rbJEvA=
+github.com/hashicorp/hcl/v2 v2.22.1-0.20240924195505-78fe99307e88 h1:zxDgi0q8lcFZUBzoIJ8+EyGqSxalMT8802t31gpfrxc=
+github.com/hashicorp/hcl/v2 v2.22.1-0.20240924195505-78fe99307e88/go.mod h1:62ZYHrXgPoX8xBnzl8QzbWq4dyDsDtfCRgIq1rbJEvA=
 github.com/hashicorp/terraform-registry-address v0.2.3 h1:2TAiKJ1A3MAkZlH1YI/aTVcLZRu7JseiXNRHbOAyoTI=
 github.com/hashicorp/terraform-registry-address v0.2.3/go.mod h1:lFHA76T8jfQteVfT7caREqguFrW3c4MFSPhZB7HHgUM=
 github.com/hashicorp/terraform-svchost v0.1.1 h1:EZZimZ1GxdqFRinZ1tpJwVxxt49xc/S52uzrw4x0jKQ=

--- a/internal/backend/remote-state/gcs/go.mod
+++ b/internal/backend/remote-state/gcs/go.mod
@@ -32,7 +32,7 @@ require (
 	github.com/hashicorp/go-slug v0.15.0 // indirect
 	github.com/hashicorp/go-uuid v1.0.3 // indirect
 	github.com/hashicorp/go-version v1.6.0 // indirect
-	github.com/hashicorp/hcl/v2 v2.21.0 // indirect
+	github.com/hashicorp/hcl/v2 v2.22.1-0.20240924195505-78fe99307e88 // indirect
 	github.com/hashicorp/terraform-registry-address v0.2.3 // indirect
 	github.com/hashicorp/terraform-svchost v0.1.1 // indirect
 	github.com/mitchellh/go-wordwrap v1.0.1 // indirect

--- a/internal/backend/remote-state/gcs/go.sum
+++ b/internal/backend/remote-state/gcs/go.sum
@@ -185,8 +185,8 @@ github.com/hashicorp/go-version v1.6.0 h1:feTTfFNnjP967rlCxM/I9g701jU+RN74YKx2mO
 github.com/hashicorp/go-version v1.6.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
-github.com/hashicorp/hcl/v2 v2.21.0 h1:lve4q/o/2rqwYOgUg3y3V2YPyD1/zkCLGjIV74Jit14=
-github.com/hashicorp/hcl/v2 v2.21.0/go.mod h1:62ZYHrXgPoX8xBnzl8QzbWq4dyDsDtfCRgIq1rbJEvA=
+github.com/hashicorp/hcl/v2 v2.22.1-0.20240924195505-78fe99307e88 h1:zxDgi0q8lcFZUBzoIJ8+EyGqSxalMT8802t31gpfrxc=
+github.com/hashicorp/hcl/v2 v2.22.1-0.20240924195505-78fe99307e88/go.mod h1:62ZYHrXgPoX8xBnzl8QzbWq4dyDsDtfCRgIq1rbJEvA=
 github.com/hashicorp/terraform-registry-address v0.2.3 h1:2TAiKJ1A3MAkZlH1YI/aTVcLZRu7JseiXNRHbOAyoTI=
 github.com/hashicorp/terraform-registry-address v0.2.3/go.mod h1:lFHA76T8jfQteVfT7caREqguFrW3c4MFSPhZB7HHgUM=
 github.com/hashicorp/terraform-svchost v0.1.1 h1:EZZimZ1GxdqFRinZ1tpJwVxxt49xc/S52uzrw4x0jKQ=

--- a/internal/backend/remote-state/kubernetes/go.mod
+++ b/internal/backend/remote-state/kubernetes/go.mod
@@ -40,7 +40,7 @@ require (
 	github.com/hashicorp/go-slug v0.15.0 // indirect
 	github.com/hashicorp/go-uuid v1.0.3 // indirect
 	github.com/hashicorp/go-version v1.6.0 // indirect
-	github.com/hashicorp/hcl/v2 v2.21.0 // indirect
+	github.com/hashicorp/hcl/v2 v2.22.1-0.20240924195505-78fe99307e88 // indirect
 	github.com/hashicorp/terraform-registry-address v0.2.3 // indirect
 	github.com/hashicorp/terraform-svchost v0.1.1 // indirect
 	github.com/imdario/mergo v0.3.13 // indirect

--- a/internal/backend/remote-state/kubernetes/go.sum
+++ b/internal/backend/remote-state/kubernetes/go.sum
@@ -217,8 +217,8 @@ github.com/hashicorp/go-version v1.6.0 h1:feTTfFNnjP967rlCxM/I9g701jU+RN74YKx2mO
 github.com/hashicorp/go-version v1.6.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
-github.com/hashicorp/hcl/v2 v2.21.0 h1:lve4q/o/2rqwYOgUg3y3V2YPyD1/zkCLGjIV74Jit14=
-github.com/hashicorp/hcl/v2 v2.21.0/go.mod h1:62ZYHrXgPoX8xBnzl8QzbWq4dyDsDtfCRgIq1rbJEvA=
+github.com/hashicorp/hcl/v2 v2.22.1-0.20240924195505-78fe99307e88 h1:zxDgi0q8lcFZUBzoIJ8+EyGqSxalMT8802t31gpfrxc=
+github.com/hashicorp/hcl/v2 v2.22.1-0.20240924195505-78fe99307e88/go.mod h1:62ZYHrXgPoX8xBnzl8QzbWq4dyDsDtfCRgIq1rbJEvA=
 github.com/hashicorp/terraform-registry-address v0.2.3 h1:2TAiKJ1A3MAkZlH1YI/aTVcLZRu7JseiXNRHbOAyoTI=
 github.com/hashicorp/terraform-registry-address v0.2.3/go.mod h1:lFHA76T8jfQteVfT7caREqguFrW3c4MFSPhZB7HHgUM=
 github.com/hashicorp/terraform-svchost v0.1.1 h1:EZZimZ1GxdqFRinZ1tpJwVxxt49xc/S52uzrw4x0jKQ=

--- a/internal/backend/remote-state/oss/go.mod
+++ b/internal/backend/remote-state/oss/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/google/go-cmp v0.6.0 // indirect
 	github.com/hashicorp/go-slug v0.15.0 // indirect
 	github.com/hashicorp/go-version v1.6.0 // indirect
-	github.com/hashicorp/hcl/v2 v2.21.0 // indirect
+	github.com/hashicorp/hcl/v2 v2.22.1-0.20240924195505-78fe99307e88 // indirect
 	github.com/hashicorp/terraform-registry-address v0.2.3 // indirect
 	github.com/hashicorp/terraform-svchost v0.1.1 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect

--- a/internal/backend/remote-state/oss/go.sum
+++ b/internal/backend/remote-state/oss/go.sum
@@ -178,8 +178,8 @@ github.com/hashicorp/go-version v1.6.0 h1:feTTfFNnjP967rlCxM/I9g701jU+RN74YKx2mO
 github.com/hashicorp/go-version v1.6.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
-github.com/hashicorp/hcl/v2 v2.21.0 h1:lve4q/o/2rqwYOgUg3y3V2YPyD1/zkCLGjIV74Jit14=
-github.com/hashicorp/hcl/v2 v2.21.0/go.mod h1:62ZYHrXgPoX8xBnzl8QzbWq4dyDsDtfCRgIq1rbJEvA=
+github.com/hashicorp/hcl/v2 v2.22.1-0.20240924195505-78fe99307e88 h1:zxDgi0q8lcFZUBzoIJ8+EyGqSxalMT8802t31gpfrxc=
+github.com/hashicorp/hcl/v2 v2.22.1-0.20240924195505-78fe99307e88/go.mod h1:62ZYHrXgPoX8xBnzl8QzbWq4dyDsDtfCRgIq1rbJEvA=
 github.com/hashicorp/terraform-registry-address v0.2.3 h1:2TAiKJ1A3MAkZlH1YI/aTVcLZRu7JseiXNRHbOAyoTI=
 github.com/hashicorp/terraform-registry-address v0.2.3/go.mod h1:lFHA76T8jfQteVfT7caREqguFrW3c4MFSPhZB7HHgUM=
 github.com/hashicorp/terraform-svchost v0.1.1 h1:EZZimZ1GxdqFRinZ1tpJwVxxt49xc/S52uzrw4x0jKQ=

--- a/internal/backend/remote-state/pg/go.mod
+++ b/internal/backend/remote-state/pg/go.mod
@@ -4,7 +4,7 @@ go 1.23.1
 
 require (
 	github.com/hashicorp/go-uuid v1.0.3
-	github.com/hashicorp/hcl/v2 v2.21.0
+	github.com/hashicorp/hcl/v2 v2.22.1-0.20240924195505-78fe99307e88
 	github.com/hashicorp/terraform v0.0.0-00010101000000-000000000000
 	github.com/lib/pq v1.10.3
 	github.com/zclconf/go-cty v1.15.0

--- a/internal/backend/remote-state/pg/go.sum
+++ b/internal/backend/remote-state/pg/go.sum
@@ -167,8 +167,8 @@ github.com/hashicorp/go-version v1.6.0 h1:feTTfFNnjP967rlCxM/I9g701jU+RN74YKx2mO
 github.com/hashicorp/go-version v1.6.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
-github.com/hashicorp/hcl/v2 v2.21.0 h1:lve4q/o/2rqwYOgUg3y3V2YPyD1/zkCLGjIV74Jit14=
-github.com/hashicorp/hcl/v2 v2.21.0/go.mod h1:62ZYHrXgPoX8xBnzl8QzbWq4dyDsDtfCRgIq1rbJEvA=
+github.com/hashicorp/hcl/v2 v2.22.1-0.20240924195505-78fe99307e88 h1:zxDgi0q8lcFZUBzoIJ8+EyGqSxalMT8802t31gpfrxc=
+github.com/hashicorp/hcl/v2 v2.22.1-0.20240924195505-78fe99307e88/go.mod h1:62ZYHrXgPoX8xBnzl8QzbWq4dyDsDtfCRgIq1rbJEvA=
 github.com/hashicorp/terraform-registry-address v0.2.3 h1:2TAiKJ1A3MAkZlH1YI/aTVcLZRu7JseiXNRHbOAyoTI=
 github.com/hashicorp/terraform-registry-address v0.2.3/go.mod h1:lFHA76T8jfQteVfT7caREqguFrW3c4MFSPhZB7HHgUM=
 github.com/hashicorp/terraform-svchost v0.1.1 h1:EZZimZ1GxdqFRinZ1tpJwVxxt49xc/S52uzrw4x0jKQ=

--- a/internal/backend/remote-state/s3/go.mod
+++ b/internal/backend/remote-state/s3/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/hashicorp/aws-sdk-go-base/v2 v2.0.0-beta.45
 	github.com/hashicorp/go-hclog v1.6.3
 	github.com/hashicorp/go-uuid v1.0.3
-	github.com/hashicorp/hcl/v2 v2.21.0
+	github.com/hashicorp/hcl/v2 v2.22.1-0.20240924195505-78fe99307e88
 	github.com/hashicorp/terraform v0.0.0-00010101000000-000000000000
 	github.com/zclconf/go-cty v1.15.0
 )

--- a/internal/backend/remote-state/s3/go.sum
+++ b/internal/backend/remote-state/s3/go.sum
@@ -226,8 +226,8 @@ github.com/hashicorp/go-version v1.6.0 h1:feTTfFNnjP967rlCxM/I9g701jU+RN74YKx2mO
 github.com/hashicorp/go-version v1.6.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
-github.com/hashicorp/hcl/v2 v2.21.0 h1:lve4q/o/2rqwYOgUg3y3V2YPyD1/zkCLGjIV74Jit14=
-github.com/hashicorp/hcl/v2 v2.21.0/go.mod h1:62ZYHrXgPoX8xBnzl8QzbWq4dyDsDtfCRgIq1rbJEvA=
+github.com/hashicorp/hcl/v2 v2.22.1-0.20240924195505-78fe99307e88 h1:zxDgi0q8lcFZUBzoIJ8+EyGqSxalMT8802t31gpfrxc=
+github.com/hashicorp/hcl/v2 v2.22.1-0.20240924195505-78fe99307e88/go.mod h1:62ZYHrXgPoX8xBnzl8QzbWq4dyDsDtfCRgIq1rbJEvA=
 github.com/hashicorp/terraform-plugin-log v0.9.0 h1:i7hOA+vdAItN1/7UrfBqBwvYPQ9TFvymaRGZED3FCV0=
 github.com/hashicorp/terraform-plugin-log v0.9.0/go.mod h1:rKL8egZQ/eXSyDqzLUuwUYLVdlYeamldAHSxjUFADow=
 github.com/hashicorp/terraform-registry-address v0.2.3 h1:2TAiKJ1A3MAkZlH1YI/aTVcLZRu7JseiXNRHbOAyoTI=

--- a/internal/legacy/go.mod
+++ b/internal/legacy/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/apparentlymart/go-versions v1.0.2 // indirect
 	github.com/hashicorp/go-slug v0.15.0 // indirect
 	github.com/hashicorp/go-version v1.6.0 // indirect
-	github.com/hashicorp/hcl/v2 v2.21.0 // indirect
+	github.com/hashicorp/hcl/v2 v2.22.1-0.20240924195505-78fe99307e88 // indirect
 	github.com/hashicorp/terraform-registry-address v0.2.3 // indirect
 	github.com/hashicorp/terraform-svchost v0.1.1 // indirect
 	github.com/mitchellh/go-wordwrap v1.0.1 // indirect

--- a/internal/legacy/go.sum
+++ b/internal/legacy/go.sum
@@ -165,8 +165,8 @@ github.com/hashicorp/go-version v1.6.0 h1:feTTfFNnjP967rlCxM/I9g701jU+RN74YKx2mO
 github.com/hashicorp/go-version v1.6.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
-github.com/hashicorp/hcl/v2 v2.21.0 h1:lve4q/o/2rqwYOgUg3y3V2YPyD1/zkCLGjIV74Jit14=
-github.com/hashicorp/hcl/v2 v2.21.0/go.mod h1:62ZYHrXgPoX8xBnzl8QzbWq4dyDsDtfCRgIq1rbJEvA=
+github.com/hashicorp/hcl/v2 v2.22.1-0.20240924195505-78fe99307e88 h1:zxDgi0q8lcFZUBzoIJ8+EyGqSxalMT8802t31gpfrxc=
+github.com/hashicorp/hcl/v2 v2.22.1-0.20240924195505-78fe99307e88/go.mod h1:62ZYHrXgPoX8xBnzl8QzbWq4dyDsDtfCRgIq1rbJEvA=
 github.com/hashicorp/terraform-registry-address v0.2.3 h1:2TAiKJ1A3MAkZlH1YI/aTVcLZRu7JseiXNRHbOAyoTI=
 github.com/hashicorp/terraform-registry-address v0.2.3/go.mod h1:lFHA76T8jfQteVfT7caREqguFrW3c4MFSPhZB7HHgUM=
 github.com/hashicorp/terraform-svchost v0.1.1 h1:EZZimZ1GxdqFRinZ1tpJwVxxt49xc/S52uzrw4x0jKQ=

--- a/internal/terraform/context_plan_ephemeral_test.go
+++ b/internal/terraform/context_plan_ephemeral_test.go
@@ -1,0 +1,146 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package terraform
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/internal/addrs"
+	"github.com/hashicorp/terraform/internal/configs/configschema"
+	"github.com/hashicorp/terraform/internal/providers"
+	testing_provider "github.com/hashicorp/terraform/internal/providers/testing"
+	"github.com/zclconf/go-cty/cty"
+)
+
+func TestContext2Plan_ephemeralBasic(t *testing.T) {
+	m := testModuleInline(t, map[string]string{
+		"main.tf": `
+ephemeral "test_resource" "data" {
+}
+
+output "data" {
+  ephemeral = true
+  value = ephemeral.test_resource.data.value
+}
+`,
+	})
+
+	p := &testing_provider.MockProvider{
+		GetProviderSchemaResponse: &providers.GetProviderSchemaResponse{
+			EphemeralTypes: map[string]providers.Schema{
+				"test_resource": {
+					Block: &configschema.Block{
+						Attributes: map[string]*configschema.Attribute{
+							"value": {
+								Type:     cty.String,
+								Computed: true,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	p.OpenEphemeralResourceFn = func(providers.OpenEphemeralResourceRequest) (resp providers.OpenEphemeralResourceResponse) {
+		resp.Result = cty.ObjectVal(map[string]cty.Value{
+			"value": cty.StringVal("test string"),
+		})
+		return resp
+	}
+
+	ctx := testContext2(t, &ContextOpts{
+		Providers: map[addrs.Provider]providers.Factory{
+			// The providers never actually going to get called here, we should
+			// catch the error long before anything happens.
+			addrs.NewDefaultProvider("test"): testProviderFuncFixed(p),
+		},
+	})
+
+	diags := ctx.Validate(m, &ValidateOpts{})
+	assertNoDiagnostics(t, diags)
+
+	if !p.ValidateEphemeralResourceConfigCalled {
+		t.Fatal("ValidateEphemeralResourceConfig not called")
+	}
+
+	_, diags = ctx.Plan(m, nil, DefaultPlanOpts)
+	assertNoDiagnostics(t, diags)
+
+	if !p.OpenEphemeralResourceCalled {
+		t.Fatal("OpenEphemeralResource not called")
+	}
+
+	if !p.CloseEphemeralResourceCalled {
+		t.Fatal("CloseEphemeralResource not called")
+	}
+}
+
+func TestContext2Plan_ephemeralProviderRef(t *testing.T) {
+	m := testModuleInline(t, map[string]string{
+		"main.tf": `
+ephemeral "ephem_resource" "data" {
+}
+
+provider "test" {
+  test_string = ephemeral.ephem_resource.data.value
+}
+
+resource "test_object" "test" {
+}
+`,
+	})
+
+	ephem := &testing_provider.MockProvider{
+		GetProviderSchemaResponse: &providers.GetProviderSchemaResponse{
+			EphemeralTypes: map[string]providers.Schema{
+				"ephem_resource": {
+					Block: &configschema.Block{
+						Attributes: map[string]*configschema.Attribute{
+							"value": {
+								Type:     cty.String,
+								Computed: true,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	ephem.OpenEphemeralResourceFn = func(providers.OpenEphemeralResourceRequest) (resp providers.OpenEphemeralResourceResponse) {
+		resp.Result = cty.ObjectVal(map[string]cty.Value{
+			"value": cty.StringVal("test string"),
+		})
+		return resp
+	}
+
+	p := simpleMockProvider()
+	p.ConfigureProviderFn = func(req providers.ConfigureProviderRequest) (resp providers.ConfigureProviderResponse) {
+		if req.Config.GetAttr("test_string").AsString() != "test string" {
+			resp.Diagnostics = resp.Diagnostics.Append(fmt.Errorf("received config did not contain \"test string\", got %#v\n", req.Config))
+		}
+		return resp
+	}
+
+	ctx := testContext2(t, &ContextOpts{
+		Providers: map[addrs.Provider]providers.Factory{
+			// The providers never actually going to get called here, we should
+			// catch the error long before anything happens.
+			addrs.NewDefaultProvider("ephem"): testProviderFuncFixed(ephem),
+			addrs.NewDefaultProvider("test"):  testProviderFuncFixed(p),
+		},
+	})
+
+	diags := ctx.Validate(m, &ValidateOpts{})
+	assertNoDiagnostics(t, diags)
+
+	if !ephem.ValidateEphemeralResourceConfigCalled {
+		t.Fatal("ValidateEphemeralResourceConfig not called")
+	}
+
+	_, diags = ctx.Plan(m, nil, DefaultPlanOpts)
+	assertNoDiagnostics(t, diags)
+}

--- a/internal/terraform/context_walk.go
+++ b/internal/terraform/context_walk.go
@@ -17,6 +17,7 @@ import (
 	"github.com/hashicorp/terraform/internal/plans/deferring"
 	"github.com/hashicorp/terraform/internal/providers"
 	"github.com/hashicorp/terraform/internal/refactoring"
+	"github.com/hashicorp/terraform/internal/resources/ephemeral"
 	"github.com/hashicorp/terraform/internal/states"
 	"github.com/hashicorp/terraform/internal/tfdiags"
 )
@@ -186,6 +187,7 @@ func (c *Context) graphWalker(graph *Graph, operation walkOperation, opts *graph
 		PrevRunState:            prevRunState,
 		Changes:                 changes.SyncWrapper(),
 		NamedValues:             namedvals.NewState(),
+		EphemeralResources:      ephemeral.NewResources(),
 		Deferrals:               deferred,
 		Checks:                  checkState,
 		InstanceExpander:        instances.NewExpander(opts.Overrides),

--- a/internal/terraform/eval_context.go
+++ b/internal/terraform/eval_context.go
@@ -21,6 +21,7 @@ import (
 	"github.com/hashicorp/terraform/internal/providers"
 	"github.com/hashicorp/terraform/internal/provisioners"
 	"github.com/hashicorp/terraform/internal/refactoring"
+	"github.com/hashicorp/terraform/internal/resources/ephemeral"
 	"github.com/hashicorp/terraform/internal/states"
 	"github.com/hashicorp/terraform/internal/tfdiags"
 )
@@ -140,6 +141,10 @@ type EvalContext interface {
 	// active in the module associated with this EvalContext, or false
 	// otherwise.
 	LanguageExperimentActive(experiment experiments.Experiment) bool
+
+	// EphemeralResources returns a helper object for tracking active
+	// instances of ephemeral resources declared in the configuration.
+	EphemeralResources() *ephemeral.Resources
 
 	// NamedValues returns the object that tracks the gradual evaluation of
 	// all input variables, local values, and output values during a graph

--- a/internal/terraform/eval_context_builtin.go
+++ b/internal/terraform/eval_context_builtin.go
@@ -27,6 +27,7 @@ import (
 	"github.com/hashicorp/terraform/internal/providers"
 	"github.com/hashicorp/terraform/internal/provisioners"
 	"github.com/hashicorp/terraform/internal/refactoring"
+	"github.com/hashicorp/terraform/internal/resources/ephemeral"
 	"github.com/hashicorp/terraform/internal/states"
 	"github.com/hashicorp/terraform/internal/tfdiags"
 	"github.com/hashicorp/terraform/version"
@@ -72,23 +73,24 @@ type BuiltinEvalContext struct {
 	// only allowd in the context of a destroy plan.
 	forget bool
 
-	Hooks                 []Hook
-	InputValue            UIInput
-	ProviderCache         map[string]providers.Interface
-	ProviderFuncCache     map[string]providers.Interface
-	ProviderFuncResults   *providers.FunctionResults
-	ProviderInputConfig   map[string]map[string]cty.Value
-	ProviderLock          *sync.Mutex
-	ProvisionerCache      map[string]provisioners.Interface
-	ProvisionerLock       *sync.Mutex
-	ChangesValue          *plans.ChangesSync
-	StateValue            *states.SyncState
-	ChecksValue           *checks.State
-	RefreshStateValue     *states.SyncState
-	PrevRunStateValue     *states.SyncState
-	InstanceExpanderValue *instances.Expander
-	MoveResultsValue      refactoring.MoveResults
-	OverrideValues        *mocking.Overrides
+	Hooks                   []Hook
+	InputValue              UIInput
+	ProviderCache           map[string]providers.Interface
+	ProviderFuncCache       map[string]providers.Interface
+	ProviderFuncResults     *providers.FunctionResults
+	ProviderInputConfig     map[string]map[string]cty.Value
+	ProviderLock            *sync.Mutex
+	ProvisionerCache        map[string]provisioners.Interface
+	ProvisionerLock         *sync.Mutex
+	ChangesValue            *plans.ChangesSync
+	StateValue              *states.SyncState
+	ChecksValue             *checks.State
+	EphemeralResourcesValue *ephemeral.Resources
+	RefreshStateValue       *states.SyncState
+	PrevRunStateValue       *states.SyncState
+	InstanceExpanderValue   *instances.Expander
+	MoveResultsValue        refactoring.MoveResults
+	OverrideValues          *mocking.Overrides
 }
 
 // BuiltinEvalContext implements EvalContext
@@ -605,4 +607,8 @@ func (ctx *BuiltinEvalContext) Overrides() *mocking.Overrides {
 
 func (ctx *BuiltinEvalContext) Forget() bool {
 	return ctx.forget
+}
+
+func (ctx *BuiltinEvalContext) EphemeralResources() *ephemeral.Resources {
+	return ctx.EphemeralResourcesValue
 }

--- a/internal/terraform/eval_context_mock.go
+++ b/internal/terraform/eval_context_mock.go
@@ -23,6 +23,7 @@ import (
 	"github.com/hashicorp/terraform/internal/providers"
 	"github.com/hashicorp/terraform/internal/provisioners"
 	"github.com/hashicorp/terraform/internal/refactoring"
+	"github.com/hashicorp/terraform/internal/resources/ephemeral"
 	"github.com/hashicorp/terraform/internal/states"
 	"github.com/hashicorp/terraform/internal/tfdiags"
 )
@@ -149,6 +150,9 @@ type MockEvalContext struct {
 
 	InstanceExpanderCalled   bool
 	InstanceExpanderExpander *instances.Expander
+
+	EphemeralResourcesCalled    bool
+	EphemeralResourcesResources *ephemeral.Resources
 
 	OverridesCalled bool
 	OverrideValues  *mocking.Overrides
@@ -359,6 +363,11 @@ func (c *MockEvalContext) LanguageExperimentActive(experiment experiments.Experi
 func (c *MockEvalContext) NamedValues() *namedvals.State {
 	c.NamedValuesCalled = true
 	return c.NamedValuesState
+}
+
+func (c *MockEvalContext) EphemeralResources() *ephemeral.Resources {
+	c.EphemeralResourcesCalled = true
+	return c.EphemeralResourcesResources
 }
 
 func (c *MockEvalContext) Deferrals() *deferring.Deferred {

--- a/internal/terraform/evaluate.go
+++ b/internal/terraform/evaluate.go
@@ -563,6 +563,17 @@ func (d *evaluationStateData) GetResource(addr addrs.Resource, rng tfdiags.Sourc
 	}
 	ty := schema.ImpliedType()
 
+	if addr.Mode == addrs.EphemeralResourceMode {
+		// FIXME: This does not yet work with deferrals, and it would be nice to
+		// find some way to refactor this so that the following code is not so
+		// tethered to the current implementation details. Instead we should
+		// have an abstract idea of first determining what instances the
+		// resource has (using d.Evaluator.Instances.ResourceInstanceKeys) and
+		// then retrieving the value for each instance to assemble into the
+		// result, using some per-resource-mode logic maintained elsewhere.
+		return d.getEphemeralResource(addr, rng)
+	}
+
 	rs := d.Evaluator.State.Resource(addr.Absolute(d.ModulePath))
 
 	if rs == nil {
@@ -769,6 +780,106 @@ func (d *evaluationStateData) GetResource(addr addrs.Resource, rng tfdiags.Sourc
 	}
 
 	return ret, diags
+}
+
+func (d *evaluationStateData) getEphemeralResource(addr addrs.Resource, rng tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics) {
+	var diags tfdiags.Diagnostics
+
+	if d.Operation == walkValidate {
+		// Ephemeral instances are never live during the validate walk
+		return cty.DynamicVal.Mark(marks.Ephemeral), diags
+	}
+
+	// Now, we're going to build up a value that represents the resource
+	// or resources that are in the state.
+	instances := map[addrs.InstanceKey]cty.Value{}
+
+	// First, we're going to load any instances that we have written into the
+	// deferrals system. A deferred resource overrides anything that might be
+	// in the state for the resource, so we do this first.
+	for key, value := range d.Evaluator.Deferrals.GetDeferredResourceInstances(addr.Absolute(d.ModulePath)) {
+		instances[key] = value
+	}
+
+	absAddr := addr.Absolute(d.ModulePath)
+	keyType, keys, haveUnknownKeys := d.Evaluator.Instances.ResourceInstanceKeys(absAddr)
+	if haveUnknownKeys {
+		// We can probably do better than totally unknown at least for a
+		// single-instance resource, but we'll just keep it simple for now.
+		// Result must be marked as ephemeral so that we can still catch
+		// attempts to use the results in non-ephemeral locations, so that
+		// the operator doesn't end up trapped with an error on a subsequent
+		// plan/apply round.
+		return cty.DynamicVal.Mark(marks.Ephemeral), diags
+	}
+
+	ephems := d.Evaluator.EphemeralResources
+	getInstValue := func(addr addrs.AbsResourceInstance) (cty.Value, tfdiags.Diagnostics) {
+		var diags tfdiags.Diagnostics
+		val, isLive := ephems.InstanceValue(addr)
+		if !isLive {
+			// If the instance is no longer "live" by the time we're accessing
+			// it then that suggests that it needed renewal and renewal has
+			// failed, and so the object's value is no longer usable. We'll
+			// still return the value in case it's somehow useful for diagnosis,
+			// but we return an error to prevent further evaluation of whatever
+			// other expression depended on the liveness of this object.
+			//
+			// This error message is written on the assumption that it will
+			// always appear alongside the provider's renewal error, but that'll
+			// be exposed only once the (now-zombied) ephemeral resource is
+			// eventually closed, so that we can avoid returning the same error
+			// multiple times.
+			diags = diags.Append(&hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  "Ephemeral resource instance has expired",
+				Detail: fmt.Sprintf(
+					"The remote object for %s is no longer available due to a renewal error, so Terraform cannot evaluate this expression.",
+					addr,
+				),
+				Subject: rng.ToHCL().Ptr(),
+			})
+		}
+		if val == cty.NilVal {
+			val = cty.DynamicVal.Mark(marks.Ephemeral)
+		}
+		return val, diags
+	}
+
+	switch keyType {
+	case addrs.NoKeyType:
+		// For "no key" we're returning just a single object representing
+		// the single instance of this resource.
+		instVal, moreDiags := getInstValue(absAddr.Instance(addrs.NoKey))
+		diags = diags.Append(moreDiags)
+		return instVal, diags
+	case addrs.IntKeyType:
+		// For integer keys we're returning a tuple-typed value whose
+		// indices are the keys.
+		elems := make([]cty.Value, len(keys))
+		for _, key := range keys {
+			idx := int(key.(addrs.IntKey))
+			instAddr := absAddr.Instance(key)
+			instVal, moreDiags := getInstValue(instAddr)
+			diags = diags.Append(moreDiags)
+			elems[idx] = instVal
+		}
+		return cty.TupleVal(elems), diags
+	case addrs.StringKeyType:
+		// For string keys we're returning an object-typed value whose
+		// attributes are the keys.
+		attrs := make(map[string]cty.Value, len(keys))
+		for _, key := range keys {
+			attrName := string(key.(addrs.StringKey))
+			instAddr := absAddr.Instance(key)
+			instVal, moreDiags := getInstValue(instAddr)
+			diags = diags.Append(moreDiags)
+			attrs[attrName] = instVal
+		}
+		return cty.ObjectVal(attrs), diags
+	default:
+		panic(fmt.Sprintf("unhandled instance key type %#v", keyType))
+	}
 }
 
 func (d *evaluationStateData) getResourceSchema(addr addrs.Resource, providerAddr addrs.Provider) *configschema.Block {

--- a/internal/terraform/evaluate.go
+++ b/internal/terraform/evaluate.go
@@ -21,6 +21,7 @@ import (
 	"github.com/hashicorp/terraform/internal/namedvals"
 	"github.com/hashicorp/terraform/internal/plans"
 	"github.com/hashicorp/terraform/internal/plans/deferring"
+	"github.com/hashicorp/terraform/internal/resources/ephemeral"
 	"github.com/hashicorp/terraform/internal/states"
 	"github.com/hashicorp/terraform/internal/tfdiags"
 )
@@ -49,6 +50,10 @@ type Evaluator struct {
 	// NamedValues is where we keep the values of already-evaluated input
 	// variables, local values, and output values.
 	NamedValues *namedvals.State
+
+	// EphemeralResources tracks the currently-open instances of any ephemeral
+	// resources.
+	EphemeralResources *ephemeral.Resources
 
 	// Deferrals tracks resources and modules that have had either their
 	// expansion or their specific planned actions deferred to a future

--- a/internal/terraform/evaluate.go
+++ b/internal/terraform/evaluate.go
@@ -541,6 +541,8 @@ func (d *evaluationStateData) GetResource(addr addrs.Resource, rng tfdiags.Sourc
 			// (We can't get in here for a single-instance resource because in that
 			// case we would know that there's only one key and it's addrs.NoKey,
 			// so we'll fall through to the other logic below.)
+			//
+			// FIXME: this could catch ephemeral values too
 			return cty.DynamicVal, diags
 		}
 	}

--- a/internal/terraform/evaluate_valid.go
+++ b/internal/terraform/evaluate_valid.go
@@ -197,11 +197,15 @@ func staticValidateResourceReference(modCfg *configs.Config, addr addrs.Resource
 	var diags tfdiags.Diagnostics
 
 	var modeAdjective string
+	modeArticleUpper := "A"
 	switch addr.Mode {
 	case addrs.ManagedResourceMode:
 		modeAdjective = "managed"
 	case addrs.DataResourceMode:
 		modeAdjective = "data"
+	case addrs.EphemeralResourceMode:
+		modeAdjective = "ephemeral"
+		modeArticleUpper = "An"
 	default:
 		// should never happen
 		modeAdjective = "<invalid-mode>"
@@ -223,8 +227,14 @@ func staticValidateResourceReference(modCfg *configs.Config, addr addrs.Resource
 		diags = diags.Append(&hcl.Diagnostic{
 			Severity: hcl.DiagError,
 			Summary:  `Reference to undeclared resource`,
-			Detail:   fmt.Sprintf(`A %s resource %q %q has not been declared in %s.%s`, modeAdjective, addr.Type, addr.Name, moduleConfigDisplayAddr(modCfg.Path), suggestion),
-			Subject:  rng.ToHCL().Ptr(),
+			Detail: fmt.Sprintf(
+				`%s %s resource %q %q has not been declared in %s.%s`,
+				modeArticleUpper, modeAdjective,
+				addr.Type, addr.Name,
+				moduleConfigDisplayAddr(modCfg.Path),
+				suggestion,
+			),
+			Subject: rng.ToHCL().Ptr(),
 		})
 		return diags
 	}
@@ -259,8 +269,13 @@ func staticValidateResourceReference(modCfg *configs.Config, addr addrs.Resource
 		diags = diags.Append(&hcl.Diagnostic{
 			Severity: hcl.DiagError,
 			Summary:  `Invalid resource type`,
-			Detail:   fmt.Sprintf(`A %s resource type %q is not supported by provider %q.`, modeAdjective, addr.Type, providerFqn.String()),
-			Subject:  rng.ToHCL().Ptr(),
+			Detail: fmt.Sprintf(
+				`%s %s resource type %q is not supported by provider %q.`,
+				modeArticleUpper, modeAdjective,
+				addr.Type,
+				providerFqn.String(),
+			),
+			Subject: rng.ToHCL().Ptr(),
 		})
 		return diags
 	}

--- a/internal/terraform/evaluate_valid_test.go
+++ b/internal/terraform/evaluate_valid_test.go
@@ -75,6 +75,14 @@ For example, to correlate with indices of a referring resource, use:
 			WantErr: `Reference to scoped resource: The referenced data resource "boop_data" "boop_nested" is not available from this context.`,
 		},
 		{
+			Ref:     "ephemeral.beep.boop",
+			WantErr: ``,
+		},
+		{
+			Ref:     "ephemeral.beep.nonexistant",
+			WantErr: `Reference to undeclared resource: An ephemeral resource "beep" "nonexistant" has not been declared in the root module.`,
+		},
+		{
 			Ref:     "data.boop_data.boop_nested",
 			WantErr: ``,
 			Src:     addrs.Check{Name: "foo"},
@@ -117,6 +125,11 @@ For example, to correlate with indices of a referring resource, use:
 								},
 							},
 						},
+					},
+				},
+				EphemeralTypes: map[string]providers.Schema{
+					"beep": {
+						Block: &configschema.Block{},
 					},
 				},
 			},

--- a/internal/terraform/graph_builder_apply.go
+++ b/internal/terraform/graph_builder_apply.go
@@ -219,6 +219,9 @@ func (b *ApplyGraphBuilder) Steps() []GraphTransformer {
 		// Close opened plugin connections
 		&CloseProviderTransformer{},
 
+		// Close any ephemeral resource instances.
+		&ephemeralResourceCloseTransformer{},
+
 		// close the root module
 		&CloseRootModuleTransformer{},
 

--- a/internal/terraform/graph_builder_plan.go
+++ b/internal/terraform/graph_builder_plan.go
@@ -262,6 +262,9 @@ func (b *PlanGraphBuilder) Steps() []GraphTransformer {
 		// Close opened plugin connections
 		&CloseProviderTransformer{},
 
+		// Close any ephemeral resource instances.
+		&ephemeralResourceCloseTransformer{skip: b.Operation == walkValidate},
+
 		// Close the root module
 		&CloseRootModuleTransformer{},
 

--- a/internal/terraform/graph_walk_context.go
+++ b/internal/terraform/graph_walk_context.go
@@ -21,6 +21,7 @@ import (
 	"github.com/hashicorp/terraform/internal/providers"
 	"github.com/hashicorp/terraform/internal/provisioners"
 	"github.com/hashicorp/terraform/internal/refactoring"
+	"github.com/hashicorp/terraform/internal/resources/ephemeral"
 	"github.com/hashicorp/terraform/internal/states"
 	"github.com/hashicorp/terraform/internal/tfdiags"
 )
@@ -32,14 +33,15 @@ type ContextGraphWalker struct {
 
 	// Configurable values
 	Context                 *Context
-	State                   *states.SyncState   // Used for safe concurrent access to state
-	RefreshState            *states.SyncState   // Used for safe concurrent access to state
-	PrevRunState            *states.SyncState   // Used for safe concurrent access to state
-	Changes                 *plans.ChangesSync  // Used for safe concurrent writes to changes
-	Checks                  *checks.State       // Used for safe concurrent writes of checkable objects and their check results
-	NamedValues             *namedvals.State    // Tracks evaluation of input variables, local values, and output values
-	InstanceExpander        *instances.Expander // Tracks our gradual expansion of module and resource instances
-	Deferrals               *deferring.Deferred // Tracks any deferred actions
+	State                   *states.SyncState    // Used for safe concurrent access to state
+	RefreshState            *states.SyncState    // Used for safe concurrent access to state
+	PrevRunState            *states.SyncState    // Used for safe concurrent access to state
+	Changes                 *plans.ChangesSync   // Used for safe concurrent writes to changes
+	Checks                  *checks.State        // Used for safe concurrent writes of checkable objects and their check results
+	NamedValues             *namedvals.State     // Tracks evaluation of input variables, local values, and output values
+	InstanceExpander        *instances.Expander  // Tracks our gradual expansion of module and resource instances
+	Deferrals               *deferring.Deferred  // Tracks any deferred actions
+	EphemeralResources      *ephemeral.Resources // Tracks active instances of ephemeral resources
 	Imports                 []configs.Import
 	MoveResults             refactoring.MoveResults // Read-only record of earlier processing of move statements
 	Operation               walkOperation
@@ -98,22 +100,24 @@ func (w *ContextGraphWalker) EvalContext() EvalContext {
 	// so that we can safely run multiple evaluations at once across
 	// different modules.
 	evaluator := &Evaluator{
-		Meta:          w.Context.meta,
-		Config:        w.Config,
-		Operation:     w.Operation,
-		State:         w.State,
-		Changes:       w.Changes,
-		Plugins:       w.Context.plugins,
-		Instances:     w.InstanceExpander,
-		NamedValues:   w.NamedValues,
-		Deferrals:     w.Deferrals,
-		PlanTimestamp: w.PlanTimestamp,
+		Meta:               w.Context.meta,
+		Config:             w.Config,
+		Operation:          w.Operation,
+		State:              w.State,
+		Changes:            w.Changes,
+		EphemeralResources: w.EphemeralResources,
+		Plugins:            w.Context.plugins,
+		Instances:          w.InstanceExpander,
+		NamedValues:        w.NamedValues,
+		Deferrals:          w.Deferrals,
+		PlanTimestamp:      w.PlanTimestamp,
 	}
 
 	ctx := &BuiltinEvalContext{
 		StopContext:             w.StopContext,
 		Hooks:                   w.Context.hooks,
 		InputValue:              w.Context.uiInput,
+		EphemeralResourcesValue: w.EphemeralResources,
 		InstanceExpanderValue:   w.InstanceExpander,
 		Plugins:                 w.Context.plugins,
 		ExternalProviderConfigs: w.ExternalProviderConfigs,

--- a/internal/terraform/node_module_expand.go
+++ b/internal/terraform/node_module_expand.go
@@ -4,6 +4,7 @@
 package terraform
 
 import (
+	"context"
 	"log"
 
 	"github.com/hashicorp/terraform/internal/addrs"
@@ -212,6 +213,9 @@ func (n *nodeCloseModule) Execute(ctx EvalContext, op walkOperation) (diags tfdi
 	// If this is the root module, we are cleaning up the walk, so close
 	// any running plugins
 	diags = diags.Append(ctx.ClosePlugins())
+
+	// We also close up the ephemeral resource manager
+	diags = diags.Append(ctx.EphemeralResources().Close(context.TODO()))
 
 	switch op {
 	case walkApply, walkDestroy:

--- a/internal/terraform/node_module_expand_test.go
+++ b/internal/terraform/node_module_expand_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/configs"
 	"github.com/hashicorp/terraform/internal/instances"
+	"github.com/hashicorp/terraform/internal/resources/ephemeral"
 	"github.com/hashicorp/terraform/internal/states"
 )
 
@@ -43,7 +44,8 @@ func TestNodeCloseModuleExecute(t *testing.T) {
 		state := states.NewState()
 		state.EnsureModule(addrs.RootModuleInstance.Child("child", addrs.NoKey))
 		ctx := &MockEvalContext{
-			StateState: state.SyncWrapper(),
+			StateState:                  state.SyncWrapper(),
+			EphemeralResourcesResources: ephemeral.NewResources(),
 		}
 		node := nodeCloseModule{addrs.Module{"child"}}
 		diags := node.Execute(ctx, walkApply)
@@ -74,7 +76,8 @@ func TestNodeCloseModuleExecute(t *testing.T) {
 		state := states.NewState()
 		state.EnsureModule(addrs.RootModuleInstance.Child("child", addrs.NoKey))
 		ctx := &MockEvalContext{
-			StateState: state.SyncWrapper(),
+			StateState:                  state.SyncWrapper(),
+			EphemeralResourcesResources: ephemeral.NewResources(),
 		}
 		node := nodeCloseModule{addrs.Module{"child"}}
 

--- a/internal/terraform/node_output.go
+++ b/internal/terraform/node_output.go
@@ -483,16 +483,6 @@ If you do intend to export this data, annotate the output value as sensitive by 
 		return diags
 	}
 
-	if val.RawEquals(cty.DynamicVal) && n.Config.Ephemeral {
-		// FIXME: During validation ephemeral resources can't be evaluated, and
-		// will result in a DynamicVal. HCL however may not always return marks
-		// here, because traversing into a dynamic value immediately returns a
-		// raw cty.DynamicVal. This should probably be fixed in HCL, however we
-		// need to take care because it has implications for all marks, and
-		// dynamic object attributes.
-		val = val.Mark(marks.Ephemeral)
-	}
-
 	// The checks below this point are intentionally not opted out by
 	// "flagWarnOutputErrors", because they relate to features that were added
 	// more recently than the historical change to treat invalid output values

--- a/internal/terraform/node_output.go
+++ b/internal/terraform/node_output.go
@@ -483,11 +483,20 @@ If you do intend to export this data, annotate the output value as sensitive by 
 		return diags
 	}
 
+	if val.RawEquals(cty.DynamicVal) && n.Config.Ephemeral {
+		// FIXME: During validation ephemeral resources can't be evaluated, and
+		// will result in a DynamicVal. HCL however may not always return marks
+		// here, because traversing into a dynamic value immediately returns a
+		// raw cty.DynamicVal. This should probably be fixed in HCL, however we
+		// need to take care because it has implications for all marks, and
+		// dynamic object attributes.
+		val = val.Mark(marks.Ephemeral)
+	}
+
 	// The checks below this point are intentionally not opted out by
 	// "flagWarnOutputErrors", because they relate to features that were added
 	// more recently than the historical change to treat invalid output values
 	// as errors rather than warnings.
-
 	if n.Config.Ephemeral && !marks.Has(val, marks.Ephemeral) {
 		// An ephemeral output value must always be ephemeral
 		// This is to prevent accidental persistence upstream

--- a/internal/terraform/node_resource_apply.go
+++ b/internal/terraform/node_resource_apply.go
@@ -54,7 +54,7 @@ func (n *nodeExpandApplyableResource) Execute(globalCtx EvalContext, op walkOper
 	moduleInstances := expander.ExpandModule(n.Addr.Module, false)
 	for _, module := range moduleInstances {
 		moduleCtx := evalContextForModuleInstance(globalCtx, module)
-		diags = diags.Append(n.writeResourceState(moduleCtx, n.Addr.Resource.Absolute(module)))
+		diags = diags.Append(n.recordResourceData(moduleCtx, n.Addr.Resource.Absolute(module)))
 	}
 
 	return diags

--- a/internal/terraform/node_resource_ephemeral.go
+++ b/internal/terraform/node_resource_ephemeral.go
@@ -50,7 +50,7 @@ func ephemeralResourceOpen(ctx EvalContext, inp ephemeralResourceInput) tfdiags.
 		return diags
 	}
 
-	resources := ctx.EphemeralResources()
+	ephemerals := ctx.EphemeralResources()
 	allInsts := ctx.InstanceExpander()
 	keyData := allInsts.GetResourceInstanceRepetitionData(inp.addr)
 
@@ -72,11 +72,12 @@ func ephemeralResourceOpen(ctx EvalContext, inp ephemeralResourceInput) tfdiags.
 	}
 	unmarkedConfigVal, configMarks := configVal.UnmarkDeepWithPaths()
 
-	diags = diags.Append(provider.ValidateEphemeralResourceConfig(providers.ValidateEphemeralResourceConfigRequest{
+	validateResp := provider.ValidateEphemeralResourceConfig(providers.ValidateEphemeralResourceConfigRequest{
 		TypeName: inp.addr.Resource.Resource.Type,
 		Config:   unmarkedConfigVal,
-	}))
+	})
 
+	diags = diags.Append(validateResp.Diagnostics)
 	if diags.HasErrors() {
 		return diags
 	}
@@ -128,7 +129,7 @@ func ephemeralResourceOpen(ctx EvalContext, inp ephemeralResourceInput) tfdiags.
 	// down?
 	// TODO: The context Stopped channel should probably be updated
 	// finally to a Context
-	resources.RegisterInstance(context.TODO(), inp.addr, ephemeral.ResourceInstanceRegistration{
+	ephemerals.RegisterInstance(context.TODO(), inp.addr, ephemeral.ResourceInstanceRegistration{
 		Value:        resultVal,
 		ConfigBody:   config.Config,
 		Impl:         impl,

--- a/internal/terraform/node_resource_ephemeral.go
+++ b/internal/terraform/node_resource_ephemeral.go
@@ -1,0 +1,205 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package terraform
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/zclconf/go-cty/cty"
+
+	"github.com/hashicorp/terraform/internal/addrs"
+	"github.com/hashicorp/terraform/internal/configs"
+	"github.com/hashicorp/terraform/internal/lang/marks"
+	"github.com/hashicorp/terraform/internal/plans/objchange"
+	"github.com/hashicorp/terraform/internal/providers"
+	"github.com/hashicorp/terraform/internal/resources/ephemeral"
+	"github.com/hashicorp/terraform/internal/tfdiags"
+)
+
+type ephemeralResourceInput struct {
+	addr           addrs.AbsResourceInstance
+	config         *configs.Resource
+	providerConfig addrs.AbsProviderConfig
+}
+
+// ephemeralResourceOpen implements the "open" step of the ephemeral resource
+// instance lifecycle, which behaves the same way in both the plan and apply
+// walks.
+func ephemeralResourceOpen(ctx EvalContext, inp ephemeralResourceInput) tfdiags.Diagnostics {
+	log.Printf("[TRACE] ephemeralResourceOpen: opening %s", inp.addr)
+	var diags tfdiags.Diagnostics
+
+	provider, providerSchema, err := getProvider(ctx, inp.providerConfig)
+	if err != nil {
+		diags = diags.Append(err)
+		return diags
+	}
+
+	config := inp.config
+	schema, _ := providerSchema.SchemaForResourceAddr(inp.addr.ContainingResource().Resource)
+	if schema == nil {
+		// Should be caught during validation, so we don't bother with a pretty error here
+		diags = diags.Append(
+			fmt.Errorf("provider %q does not support ephemeral resource %q",
+				inp.providerConfig, inp.addr.ContainingResource().Resource.Type,
+			),
+		)
+		return diags
+	}
+
+	resources := ctx.EphemeralResources()
+	allInsts := ctx.InstanceExpander()
+	keyData := allInsts.GetResourceInstanceRepetitionData(inp.addr)
+
+	checkDiags := evalCheckRules(
+		addrs.ResourcePrecondition,
+		config.Preconditions,
+		ctx, inp.addr, keyData,
+		tfdiags.Error,
+	)
+	diags = diags.Append(checkDiags)
+	if diags.HasErrors() {
+		return diags // failed preconditions prevent further evaluation
+	}
+
+	configVal, _, configDiags := ctx.EvaluateBlock(config.Config, schema, nil, keyData)
+	diags = diags.Append(configDiags)
+	if diags.HasErrors() {
+		return diags
+	}
+	unmarkedConfigVal, configMarks := configVal.UnmarkDeepWithPaths()
+
+	diags = diags.Append(provider.ValidateEphemeralResourceConfig(providers.ValidateEphemeralResourceConfigRequest{
+		TypeName: inp.addr.Resource.Resource.Type,
+		Config:   unmarkedConfigVal,
+	}))
+
+	if diags.HasErrors() {
+		return diags
+	}
+
+	resp := provider.OpenEphemeralResource(providers.OpenEphemeralResourceRequest{
+		TypeName: inp.addr.ContainingResource().Resource.Type,
+		Config:   unmarkedConfigVal,
+	})
+	if resp.Deferred != nil {
+		// FIXME: Actually implement this.
+		diags = diags.Append(fmt.Errorf("we don't support deferral of ephemeral resource instances yet"))
+	}
+	diags = diags.Append(resp.Diagnostics.InConfigBody(config.Config, inp.addr.String()))
+	if diags.HasErrors() {
+		return diags
+	}
+	resultVal := resp.Result.MarkWithPaths(configMarks)
+
+	errs := objchange.AssertPlanValid(schema, cty.NullVal(schema.ImpliedType()), configVal, resultVal)
+	for _, err := range errs {
+		diags = diags.Append(tfdiags.AttributeValue(
+			tfdiags.Error,
+			"Provider produced invalid ephemeral resource instance",
+			fmt.Sprintf(
+				"The provider for %s produced an inconsistent result: %s.",
+				inp.addr.Resource.Resource.Type,
+				tfdiags.FormatError(err),
+			),
+			nil,
+		)).InConfigBody(config.Config, inp.addr.String())
+	}
+	if diags.HasErrors() {
+		return diags
+	}
+
+	// We are going to wholesale mark the entire resource as ephemeral. This
+	// simplifies the model as any references to ephemeral resources can be
+	// considered as such. Any input values that don't need to be ephemeral can
+	// be referenced directly.
+	resultVal = resultVal.Mark(marks.Ephemeral)
+
+	impl := &ephemeralResourceInstImpl{
+		addr:     inp.addr,
+		provider: provider,
+		internal: resp.InternalContext,
+	}
+	// TODO: What can we use as a signal to cancel the context we're passing in
+	// here, so that the object will stop renewing things when we start shutting
+	// down?
+	// TODO: The context Stopped channel should probably be updated
+	// finally to a Context
+	resources.RegisterInstance(context.TODO(), inp.addr, ephemeral.ResourceInstanceRegistration{
+		Value:        resultVal,
+		ConfigBody:   config.Config,
+		Impl:         impl,
+		FirstRenewal: resp.Renew,
+	})
+
+	return diags
+}
+
+// nodeEphemeralResourceClose is the node type for closing the previously-opened
+// instances of a particular ephemeral resource.
+//
+// Although ephemeral resource instances will always all get closed once a
+// graph walk has completed anyway, the inclusion of explicit nodes for this
+// allows closing ephemeral resource instances more promptly after all work
+// that uses them has been completed, rather than always just waiting until
+// the end of the graph walk.
+//
+// This is scoped to config-level resources rather than dynamic resource
+// instances as a concession to allow using the same node type in both the plan
+// and apply graphs, where the former only deals in whole resources while the
+// latter contains individual instances.
+type nodeEphemeralResourceClose struct {
+	addr addrs.ConfigResource
+}
+
+var _ GraphNodeExecutable = (*nodeEphemeralResourceClose)(nil)
+var _ GraphNodeModulePath = (*nodeEphemeralResourceClose)(nil)
+
+func (n *nodeEphemeralResourceClose) Name() string {
+	return n.addr.String() + " (close)"
+}
+
+// ModulePath implements GraphNodeModulePath.
+func (n *nodeEphemeralResourceClose) ModulePath() addrs.Module {
+	return n.addr.Module
+}
+
+// Execute implements GraphNodeExecutable.
+func (n *nodeEphemeralResourceClose) Execute(ctx EvalContext, op walkOperation) tfdiags.Diagnostics {
+	log.Printf("[TRACE] nodeEphemeralResourceClose: closing all instances of %s", n.addr)
+	resources := ctx.EphemeralResources()
+	return resources.CloseInstances(context.TODO(), n.addr)
+}
+
+// ephemeralResourceInstImpl implements ephemeral.ResourceInstance as an
+// adapter to the relevant provider API calls.
+type ephemeralResourceInstImpl struct {
+	addr     addrs.AbsResourceInstance
+	provider providers.Interface
+	internal []byte
+}
+
+var _ ephemeral.ResourceInstance = (*ephemeralResourceInstImpl)(nil)
+
+// Close implements ephemeral.ResourceInstance.
+func (impl *ephemeralResourceInstImpl) Close(ctx context.Context) tfdiags.Diagnostics {
+	log.Printf("[TRACE] ephemeralResourceInstImpl: closing %s", impl.addr)
+	resp := impl.provider.CloseEphemeralResource(providers.CloseEphemeralResourceRequest{
+		TypeName:        impl.addr.Resource.Resource.Type,
+		InternalContext: impl.internal,
+	})
+	return resp.Diagnostics
+}
+
+// Renew implements ephemeral.ResourceInstance.
+func (impl *ephemeralResourceInstImpl) Renew(ctx context.Context, req providers.EphemeralRenew) (nextRenew *providers.EphemeralRenew, diags tfdiags.Diagnostics) {
+	log.Printf("[TRACE] ephemeralResourceInstImpl: renewing %s", impl.addr)
+	resp := impl.provider.RenewEphemeralResource(providers.RenewEphemeralResourceRequest{
+		TypeName:        impl.addr.Resource.Resource.Type,
+		InternalContext: req.InternalContext,
+	})
+	return resp.RenewAgain, resp.Diagnostics
+}

--- a/internal/terraform/node_resource_partial_plan.go
+++ b/internal/terraform/node_resource_partial_plan.go
@@ -216,7 +216,7 @@ func (n *nodeExpandPlannableResource) expandKnownModule(globalCtx EvalContext, r
 
 	moduleCtx := evalContextForModuleInstance(globalCtx, resAddr.Module)
 
-	moreDiags := n.writeResourceState(moduleCtx, resAddr)
+	moreDiags := n.recordResourceData(moduleCtx, resAddr)
 	diags = diags.Append(moreDiags)
 	if moreDiags.HasErrors() {
 		return nil, nil, nil, diags

--- a/internal/terraform/node_resource_plan_instance.go
+++ b/internal/terraform/node_resource_plan_instance.go
@@ -76,6 +76,8 @@ func (n *NodePlannableResourceInstance) Execute(ctx EvalContext, op walkOperatio
 		return n.managedResourceExecute(ctx)
 	case addrs.DataResourceMode:
 		return n.dataResourceExecute(ctx)
+	case addrs.EphemeralResourceMode:
+		return n.ephemeralResourceExecute(ctx)
 	default:
 		panic(fmt.Errorf("unsupported resource mode %s", n.Config.Mode))
 	}
@@ -150,6 +152,14 @@ func (n *NodePlannableResourceInstance) dataResourceExecute(ctx EvalContext) (di
 	}
 
 	return diags
+}
+
+func (n *NodePlannableResourceInstance) ephemeralResourceExecute(ctx EvalContext) (diags tfdiags.Diagnostics) {
+	return ephemeralResourceOpen(ctx, ephemeralResourceInput{
+		addr:           n.Addr,
+		config:         n.Config,
+		providerConfig: n.ResolvedProvider,
+	})
 }
 
 func (n *NodePlannableResourceInstance) managedResourceExecute(ctx EvalContext) (diags tfdiags.Diagnostics) {

--- a/internal/terraform/node_resource_validate.go
+++ b/internal/terraform/node_resource_validate.go
@@ -441,8 +441,31 @@ func (n *NodeValidatableResource) validateResource(ctx EvalContext) tfdiags.Diag
 		resp := provider.ValidateDataResourceConfig(req)
 		diags = diags.Append(resp.Diagnostics.InConfigBody(n.Config.Config, n.Addr.String()))
 	case addrs.EphemeralResourceMode:
-		// TODO!!
-		panic("not implemented")
+		schema, _ := providerSchema.SchemaForResourceType(n.Config.Mode, n.Config.Type)
+		if schema == nil {
+			diags = diags.Append(&hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  "Invalid ephemeral resource",
+				Detail:   fmt.Sprintf("The provider %s does not support ephemeral resource %q.", n.Provider().ForDisplay(), n.Config.Type),
+				Subject:  &n.Config.TypeRange,
+			})
+			return diags
+		}
+
+		configVal, _, valDiags := ctx.EvaluateBlock(n.Config.Config, schema, nil, keyData)
+		diags = diags.Append(valDiags)
+		if valDiags.HasErrors() {
+			return diags
+		}
+		// Use unmarked value for validate request
+		unmarkedConfigVal, _ := configVal.UnmarkDeep()
+		req := providers.ValidateEphemeralResourceConfigRequest{
+			TypeName: n.Config.Type,
+			Config:   unmarkedConfigVal,
+		}
+
+		resp := provider.ValidateEphemeralResourceConfig(req)
+		diags = diags.Append(resp.Diagnostics.InConfigBody(n.Config.Config, n.Addr.String()))
 	}
 
 	return diags

--- a/internal/terraform/node_resource_validate.go
+++ b/internal/terraform/node_resource_validate.go
@@ -440,6 +440,9 @@ func (n *NodeValidatableResource) validateResource(ctx EvalContext) tfdiags.Diag
 
 		resp := provider.ValidateDataResourceConfig(req)
 		diags = diags.Append(resp.Diagnostics.InConfigBody(n.Config.Config, n.Addr.String()))
+	case addrs.EphemeralResourceMode:
+		// TODO!!
+		panic("not implemented")
 	}
 
 	return diags

--- a/internal/terraform/testdata/static-validate-refs/static-validate-refs.tf
+++ b/internal/terraform/testdata/static-validate-refs/static-validate-refs.tf
@@ -22,6 +22,10 @@ resource "boop_whatever" "nope" {
 data "beep" "boop" {
 }
 
+ephemeral "beep" "boop" {
+  provider = boop
+}
+
 check "foo" {
   data "boop_data" "boop_nested" {}
 

--- a/internal/terraform/transform_config.go
+++ b/internal/terraform/transform_config.go
@@ -96,11 +96,14 @@ func (t *ConfigTransformer) transformSingle(g *Graph, config *configs.Config) er
 	module := config.Module
 	log.Printf("[TRACE] ConfigTransformer: Starting for path: %v", path)
 
-	allResources := make([]*configs.Resource, 0, len(module.ManagedResources)+len(module.DataResources))
+	var allResources []*configs.Resource
 	for _, r := range module.ManagedResources {
 		allResources = append(allResources, r)
 	}
 	for _, r := range module.DataResources {
+		allResources = append(allResources, r)
+	}
+	for _, r := range module.EphemeralResources {
 		allResources = append(allResources, r)
 	}
 

--- a/internal/terraform/transform_ephemeral_resource_close.go
+++ b/internal/terraform/transform_ephemeral_resource_close.go
@@ -1,0 +1,86 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package terraform
+
+import (
+	"log"
+
+	"github.com/hashicorp/terraform/internal/addrs"
+	"github.com/hashicorp/terraform/internal/dag"
+)
+
+// ephemeralResourceCloseTransformer is a graph transformer that inserts a
+// nodeEphemeralResourceClose node for each ephemeral resource, and arranges for
+// the close node to depend on any other node that consumes the relevant
+// ephemeral resource.
+type ephemeralResourceCloseTransformer struct {
+	// This does not need to run during validate walks since the ephemeral
+	// resources will never be opened.
+	skip bool
+}
+
+func (t *ephemeralResourceCloseTransformer) Transform(g *Graph) error {
+	if t.skip {
+		// Nothing to do if ephemeral resources are not opened
+		return nil
+	}
+
+	verts := g.Vertices()
+	for _, v := range verts {
+		// find any ephemeral resource nodes
+		v, ok := v.(GraphNodeConfigResource)
+		if !ok {
+			continue
+		}
+		addr := v.ResourceAddr()
+		if addr.Resource.Mode != addrs.EphemeralResourceMode {
+			continue
+		}
+
+		// Now we have an ephemeral resource, we need to depend on all
+		// dependents of that resource. Rather than connect directly to them all
+		// however, we'll only connect to leaf nodes by finding those that have
+		// no up edges.
+		descendents, _ := g.Descendents(v)
+		// FIXME: some of these graph methods still return unused errors. It
+		// would be nice to be able to use Descendants and a range argument for
+		// example.
+		for _, des := range descendents {
+			// We want something which is both a referencer and has no incoming
+			// edges from referencers. While it wouldn't be incorrect to just
+			// check for all leaf nodes, we are trying to connect to the end of
+			// evaluation chain, otherwise we may just as well wait til the end
+			// of the walk and close everything together.
+			//
+			// FIXME: This can still get delayed excessively when intermediary
+			// non-referencing nodes exist in the chain, like a nested  module
+			// close node for example. What we've needed a couple times already
+			// is some sort of breadth-first descend-until walk, which will stop
+			// the current branch descent on some condition to act on that node,
+			// yet still continue the rest of the walk.
+			if _, ok := des.(GraphNodeReferencer); !ok {
+				continue
+			}
+
+			up := g.UpEdges(des)
+			up.Filter(func(v any) bool {
+				_, ok := v.(GraphNodeReferencer)
+				return ok
+			})
+
+			// This node has a referencer
+			if len(up) > 0 {
+				continue
+			}
+
+			closeNode := &nodeEphemeralResourceClose{
+				addr: addr,
+			}
+			log.Printf("[TRACE] ephemeralResourceCloseTransformer: adding close node for %s", addr)
+			g.Add(closeNode)
+			g.Connect(dag.BasicEdge(closeNode, des))
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
Enable the use of ephemeral resources is Terraform core.

One step closer to supporting ephemeral resources, this adds the core support implementation, and connects a lot of the individual pieces needed for evaluation.

A few key points which we can address separately are
 - Deferrals are not yet accounted for in ephemeral resources
 - The prune transformer needs to take care of ephemerals too in order to continue partial destroys. This is always a very difficult part of graph resolution, so I left that as a separate task.

