### PR TITLE
Renaming `terraform workspace new` command to `terraform workspace create`

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -160,8 +160,8 @@ func initCommands(
 			}, nil
 		},
 
-		"env new": func() (cli.Command, error) {
-			return &command.WorkspaceNewCommand{
+		"env create": func() (cli.Command, error) {
+			return &command.WorkspaceCreateCommand{
 				Meta:       meta,
 				LegacyName: true,
 			}, nil
@@ -340,8 +340,8 @@ func initCommands(
 			}, nil
 		},
 
-		"workspace new": func() (cli.Command, error) {
-			return &command.WorkspaceNewCommand{
+		"workspace create": func() (cli.Command, error) {
+			return &command.WorkspaceCreateCommand{
 				Meta: meta,
 			}, nil
 		},

--- a/internal/command/apply_test.go
+++ b/internal/command/apply_test.go
@@ -1881,12 +1881,12 @@ func TestApply_terraformEnvNonDefault(t *testing.T) {
 	// Create new env
 	{
 		ui := new(cli.MockUi)
-		newCmd := &WorkspaceCreateCommand{
+		createCmd := &WorkspaceCreateCommand{
 			Meta: Meta{
 				Ui: ui,
 			},
 		}
-		if code := newCmd.Run([]string{"test"}); code != 0 {
+		if code := createCmd.Run([]string{"test"}); code != 0 {
 			t.Fatal("error creating workspace")
 		}
 	}

--- a/internal/command/apply_test.go
+++ b/internal/command/apply_test.go
@@ -1881,7 +1881,7 @@ func TestApply_terraformEnvNonDefault(t *testing.T) {
 	// Create new env
 	{
 		ui := new(cli.MockUi)
-		newCmd := &WorkspaceNewCommand{
+		newCmd := &WorkspaceCreateCommand{
 			Meta: Meta{
 				Ui: ui,
 			},

--- a/internal/command/state_push_test.go
+++ b/internal/command/state_push_test.go
@@ -254,7 +254,7 @@ func TestStatePush_forceRemoteState(t *testing.T) {
 
 	// create a new workspace
 	ui = new(cli.MockUi)
-	newCmd := &WorkspaceNewCommand{
+	newCmd := &WorkspaceCreateCommand{
 		Meta: Meta{Ui: ui, View: view},
 	}
 	if code := newCmd.Run([]string{"test"}); code != 0 {

--- a/internal/command/state_push_test.go
+++ b/internal/command/state_push_test.go
@@ -254,10 +254,10 @@ func TestStatePush_forceRemoteState(t *testing.T) {
 
 	// create a new workspace
 	ui = new(cli.MockUi)
-	newCmd := &WorkspaceCreateCommand{
+	createCmd := &WorkspaceCreateCommand{
 		Meta: Meta{Ui: ui, View: view},
 	}
-	if code := newCmd.Run([]string{"test"}); code != 0 {
+	if code := createCmd.Run([]string{"test"}); code != 0 {
 		t.Fatalf("bad: %d\n\n%s", code, ui.ErrorWriter)
 	}
 

--- a/internal/command/workspace_command.go
+++ b/internal/command/workspace_command.go
@@ -31,7 +31,7 @@ func (c *WorkspaceCommand) Help() string {
 	helpText := `
 Usage: terraform [global options] workspace
 
-  new, list, show, select and delete Terraform workspaces.
+  create, list, show, select and delete Terraform workspaces.
 
 `
 	return strings.TrimSpace(helpText)
@@ -70,7 +70,7 @@ const (
 	envDoesNotExist = `
 Workspace %q doesn't exist.
 
-You can create this workspace with the "new" subcommand 
+You can create this workspace with the "create" subcommand 
 or include the "-or-create" flag with the "select" subcommand.`
 
 	envChanged = `[reset][green]Switched to workspace %q.`

--- a/internal/command/workspace_command_test.go
+++ b/internal/command/workspace_command_test.go
@@ -27,9 +27,9 @@ func TestWorkspace_createAndChange(t *testing.T) {
 	os.MkdirAll(td, 0755)
 	defer testChdir(t, td)()
 
-	newCmd := &WorkspaceNewCommand{}
+	createCmd := &WorkspaceCreateCommand{}
 
-	current, _ := newCmd.Workspace()
+	current, _ := createCmd.Workspace()
 	if current != backend.DefaultStateName {
 		t.Fatal("current workspace should be 'default'")
 	}
@@ -37,12 +37,12 @@ func TestWorkspace_createAndChange(t *testing.T) {
 	args := []string{"test"}
 	ui := new(cli.MockUi)
 	view, _ := testView(t)
-	newCmd.Meta = Meta{Ui: ui, View: view}
-	if code := newCmd.Run(args); code != 0 {
+	createCmd.Meta = Meta{Ui: ui, View: view}
+	if code := createCmd.Run(args); code != 0 {
 		t.Fatalf("bad: %d\n\n%s", code, ui.ErrorWriter)
 	}
 
-	current, _ = newCmd.Workspace()
+	current, _ = createCmd.Workspace()
 	if current != "test" {
 		t.Fatalf("current workspace should be 'test', got %q", current)
 	}
@@ -55,7 +55,7 @@ func TestWorkspace_createAndChange(t *testing.T) {
 		t.Fatalf("bad: %d\n\n%s", code, ui.ErrorWriter)
 	}
 
-	current, _ = newCmd.Workspace()
+	current, _ = createCmd.Workspace()
 	if current != backend.DefaultStateName {
 		t.Fatal("current workspace should be 'default'")
 	}
@@ -86,10 +86,10 @@ func TestWorkspace_createAndList(t *testing.T) {
 	for _, env := range envs {
 		ui := new(cli.MockUi)
 		view, _ := testView(t)
-		newCmd := &WorkspaceNewCommand{
+		createCmd := &WorkspaceCreateCommand{
 			Meta: Meta{Ui: ui, View: view},
 		}
-		if code := newCmd.Run([]string{env}); code != 0 {
+		if code := createCmd.Run([]string{env}); code != 0 {
 			t.Fatalf("bad: %d\n\n%s", code, ui.ErrorWriter)
 		}
 	}
@@ -145,14 +145,14 @@ func TestWorkspace_createAndShow(t *testing.T) {
 		t.Fatalf("\nexpected: %q\nactual:  %q", expected, actual)
 	}
 
-	newCmd := &WorkspaceNewCommand{}
+	createCmd := &WorkspaceCreateCommand{}
 
 	env := []string{"test_a"}
 
 	// create test_a workspace
 	ui = new(cli.MockUi)
-	newCmd.Meta = Meta{Ui: ui, View: view}
-	if code := newCmd.Run(env); code != 0 {
+	createCmd.Meta = Meta{Ui: ui, View: view}
+	if code := createCmd.Run(env); code != 0 {
 		t.Fatalf("bad: %d\n\n%s", code, ui.ErrorWriter)
 	}
 
@@ -192,10 +192,10 @@ func TestWorkspace_createInvalid(t *testing.T) {
 	for _, env := range envs {
 		ui := new(cli.MockUi)
 		view, _ := testView(t)
-		newCmd := &WorkspaceNewCommand{
+		createCmd := &WorkspaceCreateCommand{
 			Meta: Meta{Ui: ui, View: view},
 		}
-		if code := newCmd.Run([]string{env}); code == 0 {
+		if code := createCmd.Run([]string{env}); code == 0 {
 			t.Fatalf("expected failure: \n%s", ui.OutputWriter)
 		}
 	}
@@ -261,10 +261,10 @@ func TestWorkspace_createWithState(t *testing.T) {
 
 	args := []string{"-state", "test.tfstate", workspace}
 	ui = new(cli.MockUi)
-	newCmd := &WorkspaceNewCommand{
+	createCmd := &WorkspaceCreateCommand{
 		Meta: Meta{Ui: ui, View: view},
 	}
-	if code := newCmd.Run(args); code != 0 {
+	if code := createCmd.Run(args); code != 0 {
 		t.Fatalf("bad: %d\n\n%s", code, ui.ErrorWriter)
 	}
 

--- a/internal/command/workspace_create.go
+++ b/internal/command/workspace_create.go
@@ -18,19 +18,19 @@ import (
 	"github.com/posener/complete"
 )
 
-type WorkspaceNewCommand struct {
+type WorkspaceCreateCommand struct {
 	Meta
 	LegacyName bool
 }
 
-func (c *WorkspaceNewCommand) Run(args []string) int {
+func (c *WorkspaceCreateCommand) Run(args []string) int {
 	args = c.Meta.process(args)
 	envCommandShowWarning(c.Ui, c.LegacyName)
 
 	var stateLock bool
 	var stateLockTimeout time.Duration
 	var statePath string
-	cmdFlags := c.Meta.defaultFlagSet("workspace new")
+	cmdFlags := c.Meta.defaultFlagSet("workspace create")
 	cmdFlags.BoolVar(&stateLock, "lock", true, "lock state")
 	cmdFlags.DurationVar(&stateLockTimeout, "lock-timeout", 0, "lock timeout")
 	cmdFlags.StringVar(&statePath, "state", "", "terraform state file")
@@ -129,7 +129,7 @@ func (c *WorkspaceNewCommand) Run(args []string) int {
 
 	if stateLock {
 		stateLocker := clistate.NewLocker(c.stateLockTimeout, views.NewStateLocker(arguments.ViewHuman, c.View))
-		if diags := stateLocker.Lock(stateMgr, "workspace-new"); diags.HasErrors() {
+		if diags := stateLocker.Lock(stateMgr, "workspace-create"); diags.HasErrors() {
 			c.showDiagnostics(diags)
 			return 1
 		}
@@ -168,22 +168,22 @@ func (c *WorkspaceNewCommand) Run(args []string) int {
 	return 0
 }
 
-func (c *WorkspaceNewCommand) AutocompleteArgs() complete.Predictor {
+func (c *WorkspaceCreateCommand) AutocompleteArgs() complete.Predictor {
 	return completePredictSequence{
 		complete.PredictAnything,
 		complete.PredictDirs(""),
 	}
 }
 
-func (c *WorkspaceNewCommand) AutocompleteFlags() complete.Flags {
+func (c *WorkspaceCreateCommand) AutocompleteFlags() complete.Flags {
 	return complete.Flags{
 		"-state": complete.PredictFiles("*.tfstate"),
 	}
 }
 
-func (c *WorkspaceNewCommand) Help() string {
+func (c *WorkspaceCreateCommand) Help() string {
 	helpText := `
-Usage: terraform [global options] workspace new [OPTIONS] NAME
+Usage: terraform [global options] workspace create [OPTIONS] NAME
 
   Create a new Terraform workspace.
 
@@ -201,6 +201,6 @@ Options:
 	return strings.TrimSpace(helpText)
 }
 
-func (c *WorkspaceNewCommand) Synopsis() string {
+func (c *WorkspaceCreateCommand) Synopsis() string {
 	return "Create a new workspace"
 }


### PR DESCRIPTION
Renaming `terraform workspace new` to `terraform workspace create` to ensure subcommands for `terraform workspace` are all the same part of speech

Fixes #35789 

## Target Release

This will likely constitute a breaking change

## Draft CHANGELOG entry

### ENHANCEMENTS
Ensuring all `terraform workspace` subcommands are the same part of speech

-  Users creating a new workspace via the Terraform CLI should use `terraform workspace create` instead of `terraform workspace new`
