### PR TITLE
terraform: Reject root ephemeral outputs

### DIFF
--- a/internal/terraform/context_plan_ephemeral_test.go
+++ b/internal/terraform/context_plan_ephemeral_test.go
@@ -19,11 +19,6 @@ func TestContext2Plan_ephemeralBasic(t *testing.T) {
 		"main.tf": `
 ephemeral "test_resource" "data" {
 }
-
-output "data" {
-  ephemeral = true
-  value = ephemeral.test_resource.data.value
-}
 `,
 	})
 

--- a/internal/terraform/context_validate_test.go
+++ b/internal/terraform/context_validate_test.go
@@ -6,12 +6,14 @@ package terraform
 import (
 	"errors"
 	"fmt"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/zclconf/go-cty/cty"
 
+	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/configs/configschema"
 	"github.com/hashicorp/terraform/internal/providers"
@@ -3031,4 +3033,64 @@ output "foo" {
 			t.Errorf("unexpected error: %s", detail)
 		}
 	}
+}
+
+func TestContext2Validate_ephemeralOutput_root(t *testing.T) {
+	m := testModuleInline(t, map[string]string{
+		"main.tf": `
+variable "foo" {
+  ephemeral = true
+  default   = "foo"
+}
+output "test" {
+  ephemeral = true
+  value     = var.foo
+}
+`,
+	})
+
+	ctx := testContext2(t, &ContextOpts{})
+	diags := ctx.Validate(m, &ValidateOpts{})
+	var wantDiags tfdiags.Diagnostics
+	wantDiags = wantDiags.Append(
+		&hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  "Ephemeral output not allowed",
+			Detail:   "Ephemeral outputs are not allowed in context of a root module",
+			Subject: &hcl.Range{
+				Filename: filepath.Join(m.Module.SourceDir, "main.tf"),
+				Start:    hcl.Pos{Line: 6, Column: 1, Byte: 59},
+				End:      hcl.Pos{Line: 6, Column: 14, Byte: 72},
+			},
+		},
+	)
+	assertDiagnosticsMatch(t, diags, wantDiags)
+}
+
+func TestContext2Validate_ephemeralOutput_child(t *testing.T) {
+	m := testModuleInline(t, map[string]string{
+		"child/main.tf": `
+variable "child-eph" {
+  ephemeral = true
+}
+output "out" {
+  ephemeral = true
+  value     = var.child-eph
+}`,
+		"main.tf": `
+variable "eph" {
+  ephemeral = true
+  default   = "foo"
+}
+
+module "child" {
+  source    = "./child"
+  child-eph = var.eph
+}
+`,
+	})
+
+	ctx := testContext2(t, &ContextOpts{})
+	diags := ctx.Validate(m, &ValidateOpts{})
+	assertNoDiagnostics(t, diags)
 }

--- a/internal/terraform/node_output.go
+++ b/internal/terraform/node_output.go
@@ -395,6 +395,16 @@ func (n *NodeApplyableOutput) Execute(ctx EvalContext, op walkOperation) (diags 
 		val = n.Change.After
 	}
 
+	if n.Addr.Module.IsRoot() && n.Config.Ephemeral {
+		diags = diags.Append(&hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  "Ephemeral output not allowed",
+			Detail:   "Ephemeral outputs are not allowed in context of a root module",
+			Subject:  n.Config.DeclRange.Ptr(),
+		})
+		return
+	}
+
 	// Checks are not evaluated during a destroy. The checks may fail, may not
 	// be valid, or may not have been registered at all.
 	// We also don't evaluate checks for overridden outputs. This is because


### PR DESCRIPTION
This is an alternative to https://github.com/hashicorp/terraform/pull/35719 as discussed at length in Slack.

The assumptions are that we know of no valid use cases for _root_ ephemeral outputs and conversely know of negative consequences, such as those being exposed in logs etc. and leading to unintentional persistence - which would effectively violate the original promise of "ephemerality".

## Target Release

1.10.x

## Draft CHANGELOG entry

### ENHANCEMENTS

-  Ephemeral root outputs are now rejected to avoid values in such outputs to be mistakenly persisted
