### PR TITLE
ephemeral resource deferrals

### DIFF
--- a/internal/terraform/context_apply_deferred_test.go
+++ b/internal/terraform/context_apply_deferred_test.go
@@ -3308,11 +3308,11 @@ ephemeral "test" "data" {
 		},
 		stages: []deferredActionsTestStage{
 			{
-				complete:    false,
-				wantActions: map[string]plans.Action{},
-				wantPlanned: map[string]cty.Value{},
+				complete:     false,
+				wantActions:  map[string]plans.Action{},
+				wantPlanned:  map[string]cty.Value{},
 				wantDeferred: map[string]ExpectedDeferred{
-					"ephemeral.test.data": {Reason: providers.DeferredReasonProviderConfigUnknown, Action: plans.Read},
+					// We don't record the ephemeral deferrals
 				},
 			},
 		},
@@ -3332,12 +3332,11 @@ ephemeral "test" "dep" {
 		},
 		stages: []deferredActionsTestStage{
 			{
-				complete:    false,
-				wantActions: map[string]plans.Action{},
-				wantPlanned: map[string]cty.Value{},
+				complete:     false,
+				wantActions:  map[string]plans.Action{},
+				wantPlanned:  map[string]cty.Value{},
 				wantDeferred: map[string]ExpectedDeferred{
-					"ephemeral.test.data": {Reason: providers.DeferredReasonProviderConfigUnknown, Action: plans.Read},
-					"ephemeral.test.dep":  {Reason: providers.DeferredReasonResourceConfigUnknown, Action: plans.Read},
+					// We don't record the ephemeral deferrals
 				},
 			},
 		},
@@ -3363,11 +3362,11 @@ ephemeral "test" "data" {
 				inputs: map[string]cty.Value{
 					"each": cty.DynamicVal,
 				},
-				complete:    false,
-				wantActions: map[string]plans.Action{},
-				wantPlanned: map[string]cty.Value{},
+				complete:     false,
+				wantActions:  map[string]plans.Action{},
+				wantPlanned:  map[string]cty.Value{},
 				wantDeferred: map[string]ExpectedDeferred{
-					"ephemeral.test.*.data": {Reason: providers.DeferredReasonInstanceCountUnknown, Action: plans.Read},
+					// We don't record the ephemeral deferrals
 				},
 			},
 		},

--- a/internal/terraform/node_resource_partial_plan.go
+++ b/internal/terraform/node_resource_partial_plan.go
@@ -62,6 +62,9 @@ func (n *nodeExpandPlannableResource) dynamicExpandPartial(ctx EvalContext, know
 	func() {
 
 		ss := ctx.PrevRunState()
+		if ss == nil {
+			return // No previous state, so nothing to do here.
+		}
 		state := ss.Lock()
 		defer ss.Unlock()
 
@@ -299,6 +302,12 @@ func (n *nodeExpandPlannableResource) knownModuleSubgraph(ctx EvalContext, addr 
 		}),
 
 		DynamicTransformer(func(graph *Graph) error {
+			// Ephemeral resources don't need to be accounted for in this transform,
+			// since they are not in the state.
+			if addr.Resource.Mode == addrs.EphemeralResourceMode {
+				return nil
+			}
+
 			// We'll add nodes for any orphaned resources.
 			rs := state.Resource(addr)
 			if rs == nil {

--- a/internal/terraform/node_resource_plan.go
+++ b/internal/terraform/node_resource_plan.go
@@ -114,12 +114,6 @@ func (n *nodeExpandPlannableResource) DynamicExpand(ctx EvalContext) (*Graph, tf
 	expander := ctx.InstanceExpander()
 	moduleInstances := expander.ExpandModule(n.Addr.Module, false)
 
-	if n.Addr.Resource.Mode == addrs.EphemeralResourceMode {
-		g, expandDiags := n.dynamicExpand(ctx, moduleInstances, addrs.Map[addrs.AbsResourceInstance, cty.Value]{})
-		diags = diags.Append(expandDiags)
-		return g, diags
-	}
-
 	// The possibility of partial-expanded modules and resources is guarded by a
 	// top-level option for the whole plan, so that we can preserve mainline
 	// behavior for the modules runtime. So, we currently branch off into an

--- a/internal/terraform/node_resource_plan_partialexp.go
+++ b/internal/terraform/node_resource_plan_partialexp.go
@@ -97,6 +97,8 @@ func (n *nodePlannablePartialExpandedResource) Execute(ctx EvalContext, op walkO
 		change, changeDiags := n.dataResourceExecute(ctx)
 		diags = diags.Append(changeDiags)
 		ctx.Deferrals().ReportDataSourceExpansionDeferred(n.addr, change)
+	case addrs.EphemeralResourceMode:
+		ctx.Deferrals().ReportEphemeralResourceExpansionDeferred(n.addr)
 	default:
 		panic(fmt.Errorf("unsupported resource mode %s", n.config.Mode))
 	}


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.
This is waiting for the completion of #35784 since changes in the provider protocol are necessary for this to work end to end.
-->

1.10.x

## Draft CHANGELOG entry


### ENHANCEMENTS


- Ephemeral Resources: Support providers deferring ephemeral resource open calls