### PR TITLE
docs: add a note on `?` and `:` in operators.mdx

### DIFF
--- a/website/docs/language/expressions/operators.mdx
+++ b/website/docs/language/expressions/operators.mdx
@@ -42,6 +42,8 @@ given values to be of a particular type. Terraform will attempt to convert
 values to the required type automatically, or will produce an error message
 if automatic conversion is impossible.
 
+**Note**: The `?` symbol, when combined with `:`, is part of a conditional expression in Terraform and not considered an operator. For more informaton on how to use conditional expressions, see [Conditional Expressions](/docs/language/expressions/conditionals#conditional-expressions).
+
 ## Arithmetic Operators
 
 The arithmetic operators all expect number values and produce number values


### PR DESCRIPTION
Adds a note clarifying that the `?` symbol is not considered a standalone operator in Terraform. Instead, it is part of the conditional expression syntax when combined with `:`.

Fixes https://github.com/hashicorp/terraform/issues/35799