### PR TITLE
Remove handling of ephemeral root outputs

### DIFF
--- a/internal/backend/backendrun/operation.go
+++ b/internal/backend/backendrun/operation.go
@@ -237,12 +237,6 @@ type RunningOperation struct {
 	// this state is managed by the backend. This should only be read
 	// after the operation completes to avoid read/write races.
 	State *states.State
-
-	// EphemeralOutputValues is populated only after an Apply operation
-	// completes, and contains the value for each ephemeral output in the root
-	// module.
-	// Ephemeral output values are not stored in the state file.
-	EphemeralOutputValues map[string]*states.OutputValue
 }
 
 // OperationResult describes the result status of an operation.

--- a/internal/backend/local/backend_apply.go
+++ b/internal/backend/local/backend_apply.go
@@ -376,8 +376,6 @@ func (b *Local) opApply(
 		return
 	}
 
-	runningOp.EphemeralOutputValues = applyState.EphemeralRootOutputValues
-
 	// Store the final state
 	runningOp.State = applyState
 	err := statemgr.WriteAndPersist(opState, applyState, schemas)

--- a/internal/backend/local/backend_local_test.go
+++ b/internal/backend/local/backend_local_test.go
@@ -266,10 +266,6 @@ func (s *stateStorageThatFailsRefresh) GetRootOutputValues(ctx context.Context) 
 	return nil, fmt.Errorf("unimplemented")
 }
 
-func (s *stateStorageThatFailsRefresh) GetEphemeralRootOutputValues(ctx context.Context) (map[string]*states.OutputValue, error) {
-	return nil, fmt.Errorf("unimplemented")
-}
-
 func (s *stateStorageThatFailsRefresh) WriteState(*states.State) error {
 	return fmt.Errorf("unimplemented")
 }

--- a/internal/backend/local/test.go
+++ b/internal/backend/local/test.go
@@ -781,6 +781,9 @@ func (runner *TestFileRunner) apply(tfCtx *terraform.Context, plan *plans.Plan, 
 		defer done()
 		log.Printf("[DEBUG] TestFileRunner: starting apply for %s/%s", file.Name, run.Name)
 		updated, newScope, applyDiags = tfCtx.ApplyAndEval(plan, config, nil)
+		// if updated == nil {
+		// 	updated = state
+		// }
 		log.Printf("[DEBUG] TestFileRunner: completed apply for %s/%s", file.Name, run.Name)
 	}()
 	waitDiags, cancelled := runner.wait(tfCtx, runningCtx, run, file, created, progress, start)
@@ -903,6 +906,7 @@ func (runner *TestFileRunner) cleanup(file *moduletest.File) {
 	for key, state := range runner.RelevantStates {
 
 		empty := true
+		// TODO: Why is state.State nil here during cleanup?
 		for _, module := range state.State.Modules {
 			for _, resource := range module.Resources {
 				if resource.Addr.Resource.Mode == addrs.ManagedResourceMode {

--- a/internal/backend/local/test.go
+++ b/internal/backend/local/test.go
@@ -781,9 +781,6 @@ func (runner *TestFileRunner) apply(tfCtx *terraform.Context, plan *plans.Plan, 
 		defer done()
 		log.Printf("[DEBUG] TestFileRunner: starting apply for %s/%s", file.Name, run.Name)
 		updated, newScope, applyDiags = tfCtx.ApplyAndEval(plan, config, nil)
-		// if updated == nil {
-		// 	updated = state
-		// }
 		log.Printf("[DEBUG] TestFileRunner: completed apply for %s/%s", file.Name, run.Name)
 	}()
 	waitDiags, cancelled := runner.wait(tfCtx, runningCtx, run, file, created, progress, start)
@@ -906,7 +903,6 @@ func (runner *TestFileRunner) cleanup(file *moduletest.File) {
 	for key, state := range runner.RelevantStates {
 
 		empty := true
-		// TODO: Why is state.State nil here during cleanup?
 		for _, module := range state.State.Modules {
 			for _, resource := range module.Resources {
 				if resource.Addr.Resource.Mode == addrs.ManagedResourceMode {

--- a/internal/cloud/state.go
+++ b/internal/cloud/state.go
@@ -621,11 +621,6 @@ func (s *State) GetRootOutputValues(ctx context.Context) (map[string]*states.Out
 	return result, nil
 }
 
-func (s *State) GetEphemeralRootOutputValues(ctx context.Context) (map[string]*states.OutputValue, error) {
-	// NOTE Ephemeral output values are not yet supported by the cloud backend.
-	return nil, nil
-}
-
 func clamp(val, min, max int64) int64 {
 	if val < min {
 		return min

--- a/internal/command/jsonstate/state.go
+++ b/internal/command/jsonstate/state.go
@@ -221,12 +221,6 @@ func MarshalOutputs(outputs map[string]*states.OutputValue) (map[string]Output, 
 
 	ret := make(map[string]Output)
 	for k, v := range outputs {
-
-		if v.Ephemeral {
-			// should never happen
-			panic(fmt.Sprintf("Ephemeral output value %s passed to state.MarshalOutputs. This is a bug in Terraform - please report it.", k))
-		}
-
 		ty := v.Value.Type()
 		ov, err := ctyjson.Marshal(v.Value, ty)
 		if err != nil {

--- a/internal/command/output.go
+++ b/internal/command/output.go
@@ -7,8 +7,6 @@ import (
 	"fmt"
 	"strings"
 
-	"maps"
-
 	"github.com/hashicorp/terraform/internal/command/arguments"
 	"github.com/hashicorp/terraform/internal/command/views"
 	"github.com/hashicorp/terraform/internal/states"
@@ -91,17 +89,12 @@ func (c *OutputCommand) Outputs(statePath string) (map[string]*states.OutputValu
 		return nil, diags
 	}
 
-	outputs, err := stateStore.GetRootOutputValues(ctx)
+	output, err := stateStore.GetRootOutputValues(ctx)
 	if err != nil {
 		return nil, diags.Append(err)
 	}
-	ephemeralOutputs, err := stateStore.GetEphemeralRootOutputValues(ctx)
-	if err != nil {
-		return nil, diags.Append(err)
-	}
-	maps.Copy(outputs, ephemeralOutputs)
 
-	return outputs, diags
+	return output, diags
 }
 
 func (c *OutputCommand) Help() string {

--- a/internal/command/output_test.go
+++ b/internal/command/output_test.go
@@ -80,43 +80,7 @@ func TestOutput_json(t *testing.T) {
 	}
 
 	actual := strings.TrimSpace(output.Stdout())
-	expected := "{\n  \"foo\": {\n    \"ephemeral\": false,\n    \"sensitive\": false,\n    \"type\": \"string\",\n    \"value\": \"bar\"\n  }\n}"
-	if actual != expected {
-		t.Fatalf("wrong output\ngot:  %#v\nwant: %#v", actual, expected)
-	}
-}
-
-func TestOutput_jsonEphemeral(t *testing.T) {
-	originalState := states.BuildState(func(s *states.SyncState) {
-		s.SetEphemeralOutputValue(
-			addrs.OutputValue{Name: "foo"}.Absolute(addrs.RootModuleInstance),
-			cty.StringVal("bar"),
-			false,
-		)
-	})
-
-	statePath := testStateFile(t, originalState)
-
-	view, done := testView(t)
-	c := &OutputCommand{
-		Meta: Meta{
-			testingOverrides: metaOverridesForProvider(testProvider()),
-			View:             view,
-		},
-	}
-
-	args := []string{
-		"-state", statePath,
-		"-json",
-	}
-	code := c.Run(args)
-	output := done(t)
-	if code != 0 {
-		t.Fatalf("bad: \n%s", output.Stderr())
-	}
-
-	actual := strings.TrimSpace(output.Stdout())
-	expected := "{\n  \"foo\": {\n    \"ephemeral\": true,\n    \"sensitive\": false,\n    \"type\": \"string\",\n    \"value\": null\n  }\n}"
+	expected := "{\n  \"foo\": {\n    \"sensitive\": false,\n    \"type\": \"string\",\n    \"value\": \"bar\"\n  }\n}"
 	if actual != expected {
 		t.Fatalf("wrong output\ngot:  %#v\nwant: %#v", actual, expected)
 	}

--- a/internal/command/views/output.go
+++ b/internal/command/views/output.go
@@ -217,11 +217,7 @@ func (v *OutputJSON) Output(name string, outputs map[string]*states.OutputValue)
 	// show in the single value case. We must now maintain that behavior
 	// for compatibility, so this is an emulation of the JSON
 	// serialization of outputs used in state format version 3.
-	//
-	// Note that when running the output command, the value of an ephemeral
-	// output is always nil and its type is always cty.DynamicPseudoType.
 	type OutputMeta struct {
-		Ephemeral bool            `json:"ephemeral"`
 		Sensitive bool            `json:"sensitive"`
 		Type      json.RawMessage `json:"type"`
 		Value     json.RawMessage `json:"value"`
@@ -240,7 +236,6 @@ func (v *OutputJSON) Output(name string, outputs map[string]*states.OutputValue)
 			return diags
 		}
 		outputMetas[n] = OutputMeta{
-			Ephemeral: os.Ephemeral,
 			Sensitive: os.Sensitive,
 			Type:      json.RawMessage(jsonType),
 			Value:     json.RawMessage(jsonVal),

--- a/internal/command/views/output_test.go
+++ b/internal/command/views/output_test.go
@@ -149,7 +149,6 @@ foo = <sensitive>
 			arguments.ViewJSON,
 			`{
   "bar": {
-    "ephemeral": false,
     "sensitive": false,
     "type": [
       "list",
@@ -162,7 +161,6 @@ foo = <sensitive>
     ]
   },
   "baz": {
-    "ephemeral": false,
     "sensitive": false,
     "type": [
       "object",
@@ -177,7 +175,6 @@ foo = <sensitive>
     }
   },
   "foo": {
-    "ephemeral": false,
     "sensitive": true,
     "type": "string",
     "value": "secret"

--- a/internal/states/output_value.go
+++ b/internal/states/output_value.go
@@ -16,5 +16,4 @@ type OutputValue struct {
 	Addr      addrs.AbsOutputValue
 	Value     cty.Value
 	Sensitive bool
-	Ephemeral bool
 }

--- a/internal/states/remote/state.go
+++ b/internal/states/remote/state.go
@@ -73,19 +73,6 @@ func (s *State) GetRootOutputValues(ctx context.Context) (map[string]*states.Out
 	return state.RootOutputValues, nil
 }
 
-func (s *State) GetEphemeralRootOutputValues(ctx context.Context) (map[string]*states.OutputValue, error) {
-	if err := s.RefreshState(); err != nil {
-		return nil, fmt.Errorf("Failed to load state: %s", err)
-	}
-
-	state := s.State()
-	if state == nil {
-		state = states.NewState()
-	}
-
-	return state.EphemeralRootOutputValues, nil
-}
-
 // StateForMigration is part of our implementation of statemgr.Migrator.
 func (s *State) StateForMigration() *statefile.File {
 	s.mu.Lock()

--- a/internal/states/state_deepcopy.go
+++ b/internal/states/state_deepcopy.go
@@ -35,15 +35,10 @@ func (s *State) DeepCopy() *State {
 	for k, v := range s.RootOutputValues {
 		outputValues[k] = v.DeepCopy()
 	}
-	ephemeralOutputValues := make(map[string]*OutputValue, len(s.EphemeralRootOutputValues))
-	for k, v := range s.EphemeralRootOutputValues {
-		ephemeralOutputValues[k] = v.DeepCopy()
-	}
 	return &State{
-		Modules:                   modules,
-		RootOutputValues:          outputValues,
-		EphemeralRootOutputValues: ephemeralOutputValues,
-		CheckResults:              s.CheckResults.DeepCopy(),
+		Modules:          modules,
+		RootOutputValues: outputValues,
+		CheckResults:     s.CheckResults.DeepCopy(),
 	}
 }
 
@@ -233,6 +228,5 @@ func (os *OutputValue) DeepCopy() *OutputValue {
 		Addr:      os.Addr,
 		Value:     os.Value,
 		Sensitive: os.Sensitive,
-		Ephemeral: os.Ephemeral,
 	}
 }

--- a/internal/states/statemgr/filesystem.go
+++ b/internal/states/statemgr/filesystem.go
@@ -251,20 +251,6 @@ func (s *Filesystem) GetRootOutputValues(ctx context.Context) (map[string]*state
 	return state.RootOutputValues, nil
 }
 
-func (s *Filesystem) GetEphemeralRootOutputValues(ctx context.Context) (map[string]*states.OutputValue, error) {
-	err := s.RefreshState()
-	if err != nil {
-		return nil, err
-	}
-
-	state := s.State()
-	if state == nil {
-		state = states.NewState()
-	}
-
-	return state.EphemeralRootOutputValues, nil
-}
-
 func (s *Filesystem) refreshState() error {
 	var reader io.Reader
 

--- a/internal/states/statemgr/lock.go
+++ b/internal/states/statemgr/lock.go
@@ -27,10 +27,6 @@ func (s *LockDisabled) GetRootOutputValues(ctx context.Context) (map[string]*sta
 	return s.Inner.GetRootOutputValues(ctx)
 }
 
-func (s *LockDisabled) GetEphemeralRootOutputValues(ctx context.Context) (map[string]*states.OutputValue, error) {
-	return s.Inner.GetEphemeralRootOutputValues(ctx)
-}
-
 func (s *LockDisabled) WriteState(v *states.State) error {
 	return s.Inner.WriteState(v)
 }

--- a/internal/states/statemgr/persistent.go
+++ b/internal/states/statemgr/persistent.go
@@ -33,13 +33,8 @@ type Persistent interface {
 // the output values from it because enhanced backends can apply special permissions
 // to differentiate reading the state and reading the outputs within the state.
 type OutputReader interface {
-	// GetRootOutputValues fetches the non-ephemeral root module output values
-	// from state or another source.
+	// GetRootOutputValues fetches the root module output values from state or another source
 	GetRootOutputValues(ctx context.Context) (map[string]*states.OutputValue, error)
-
-	// GetEphemeralRootOutputValues fetches the ephemeral root module output values
-	// from state or another source.
-	GetEphemeralRootOutputValues(ctx context.Context) (map[string]*states.OutputValue, error)
 }
 
 // Refresher is the interface for managers that can read snapshots from

--- a/internal/states/statemgr/statemgr_fake.go
+++ b/internal/states/statemgr/statemgr_fake.go
@@ -74,10 +74,6 @@ func (m *fakeFull) GetRootOutputValues(ctx context.Context) (map[string]*states.
 	return m.State().RootOutputValues, nil
 }
 
-func (m *fakeFull) GetEphemeralRootOutputValues(ctx context.Context) (map[string]*states.OutputValue, error) {
-	return m.State().EphemeralRootOutputValues, nil
-}
-
 func (m *fakeFull) Lock(info *LockInfo) (string, error) {
 	m.lockLock.Lock()
 	defer m.lockLock.Unlock()
@@ -125,10 +121,6 @@ func (m *fakeErrorFull) State() *states.State {
 }
 
 func (m *fakeErrorFull) GetRootOutputValues(ctx context.Context) (map[string]*states.OutputValue, error) {
-	return nil, errors.New("fake state manager error")
-}
-
-func (m *fakeErrorFull) GetEphemeralRootOutputValues(ctx context.Context) (map[string]*states.OutputValue, error) {
 	return nil, errors.New("fake state manager error")
 }
 

--- a/internal/states/sync.go
+++ b/internal/states/sync.go
@@ -118,47 +118,6 @@ func (s *SyncState) RemoveOutputValue(addr addrs.AbsOutputValue) {
 	s.state.RemoveOutputValue(addr)
 }
 
-// EphemeralOutputValue returns a snapshot of the state of the ephemeral output
-// value with the given address, or nil if no such ephemeral output value is
-// tracked.
-//
-// The return value is a pointer to a copy of the output value state, which the
-// caller may then freely access and mutate.
-func (s *SyncState) EphemeralOutputValue(addr addrs.AbsOutputValue) *OutputValue {
-	s.lock.RLock()
-	ret := s.state.EphemeralOutputValue(addr).DeepCopy()
-	s.lock.RUnlock()
-	return ret
-}
-
-// SetEphemeralOutputValue writes a given ephemeral output value into the
-// state, overwriting any existing value of the same name.
-//
-// The state only tracks output values for the root module, so attempts to
-// write output values for any other module will be silently ignored.
-func (s *SyncState) SetEphemeralOutputValue(addr addrs.AbsOutputValue, value cty.Value, sensitive bool) {
-	if !addr.Module.IsRoot() {
-		return
-	}
-
-	defer s.beginWrite()()
-	s.state.SetEphemeralOutputValue(addr, value, sensitive)
-}
-
-// RemoveEphemeralOutputValue removes the stored value for the ephemeral output
-// value with the given address.
-//
-// The state only tracks output values for the root module, so attempts to
-// remove output values for any other module will be silently ignored.
-func (s *SyncState) RemoveEphemeralOutputValue(addr addrs.AbsOutputValue) {
-	if !addr.Module.IsRoot() {
-		return
-	}
-
-	defer s.beginWrite()()
-	s.state.RemoveEphemeralOutputValue(addr)
-}
-
 // Resource returns a snapshot of the state of the resource with the given
 // address, or nil if no such resource is tracked.
 //

--- a/internal/terraform/context_apply_test.go
+++ b/internal/terraform/context_apply_test.go
@@ -4071,10 +4071,6 @@ func TestContext2Apply_outputOrphan(t *testing.T) {
 		addrs.OutputValue{Name: "bar"}.Absolute(addrs.RootModuleInstance),
 		cty.StringVal("bar-val"), false,
 	)
-	state.SetEphemeralOutputValue(
-		addrs.OutputValue{Name: "eph"}.Absolute(addrs.RootModuleInstance),
-		cty.StringVal("eph-val"), false,
-	)
 
 	ctx := testContext2(t, &ContextOpts{
 		Providers: map[addrs.Provider]providers.Factory{

--- a/internal/terraform/context_plan2_test.go
+++ b/internal/terraform/context_plan2_test.go
@@ -5915,7 +5915,6 @@ output "staying" {
 	state := states.BuildState(func(s *states.SyncState) {
 		s.SetOutputValue(mustAbsOutputValue("output.old"), cty.StringVal("old_value"), false)
 		s.SetOutputValue(mustAbsOutputValue("output.staying"), cty.StringVal("foo"), false)
-		s.SetEphemeralOutputValue(mustAbsOutputValue("output.old_ephemeral"), cty.NullVal(cty.String), false)
 	})
 
 	ctx := testContext2(t, &ContextOpts{})
@@ -5930,14 +5929,6 @@ output "staying" {
 				Change: plans.Change{
 					Action: plans.Delete,
 					Before: cty.StringVal("old_value"),
-					After:  cty.NullVal(cty.DynamicPseudoType),
-				},
-			},
-			{
-				Addr: mustAbsOutputValue("output.old_ephemeral"),
-				Change: plans.Change{
-					Action: plans.Delete,
-					Before: cty.NullVal(cty.String),
 					After:  cty.NullVal(cty.DynamicPseudoType),
 				},
 			},

--- a/internal/terraform/evaluate.go
+++ b/internal/terraform/evaluate.go
@@ -935,7 +935,6 @@ func (d *evaluationStateData) GetOutput(addr addrs.OutputValue, rng tfdiags.Sour
 			Addr:      addr.Absolute(d.ModulePath),
 			Value:     cty.NilVal,
 			Sensitive: config.Sensitive,
-			Ephemeral: config.Ephemeral,
 		}
 	} else if output.Value == cty.NilVal || output.Value.IsNull() {
 		// Then we did get a value but Terraform itself thought it was NilVal
@@ -946,9 +945,6 @@ func (d *evaluationStateData) GetOutput(addr addrs.OutputValue, rng tfdiags.Sour
 	val := output.Value
 	if output.Sensitive {
 		val = val.Mark(marks.Sensitive)
-	}
-	if output.Ephemeral {
-		val = val.Mark(marks.Ephemeral)
 	}
 
 	return val, diags

--- a/internal/terraform/transform_orphan_output.go
+++ b/internal/terraform/transform_orphan_output.go
@@ -32,20 +32,8 @@ func (t *OrphanOutputTransformer) Transform(g *Graph) error {
 			continue
 		}
 		g.Add(&NodeDestroyableOutput{
-			Addr:        addrs.OutputValue{Name: name}.Absolute(addrs.RootModuleInstance),
-			Planning:    t.Planning,
-			IsEphemeral: false,
-		})
-	}
-
-	for name := range t.State.EphemeralRootOutputValues {
-		if _, exists := cfgs[name]; exists {
-			continue
-		}
-		g.Add(&NodeDestroyableOutput{
-			Addr:        addrs.OutputValue{Name: name}.Absolute(addrs.RootModuleInstance),
-			Planning:    t.Planning,
-			IsEphemeral: true,
+			Addr:     addrs.OutputValue{Name: name}.Absolute(addrs.RootModuleInstance),
+			Planning: t.Planning,
 		})
 	}
 


### PR DESCRIPTION
This is effectively reverting ~99% of https://github.com/hashicorp/terraform/pull/35676 The only changes not being reverted are some formatting and deprecation fixes which remain relevant.

The code being removed is basically dead code now in the context of root ephemeral outputs being rejected per https://github.com/hashicorp/terraform/pull/35791
