### PR TITLE
Use go1.23 iterators for internal collection types

### DIFF
--- a/internal/backend/local/backend_apply.go
+++ b/internal/backend/local/backend_apply.go
@@ -273,7 +273,7 @@ func (b *Local) opApply(
 					// ephemeral variable that was set (non-null) during the
 					// planning phase.
 					applyTimeVar := false
-					for _, avName := range plan.ApplyTimeVariables.Elems() {
+					for avName := range plan.ApplyTimeVariables.All() {
 						if varName == avName {
 							applyTimeVar = true
 						}

--- a/internal/collections/cmp.go
+++ b/internal/collections/cmp.go
@@ -40,7 +40,7 @@ func (s Set[T]) transformForCmp() any {
 	ret := make(map[any]any, s.Len())
 	// It's okay to access the keys here because this package is allowed to
 	// depend on its own implementation details.
-	for k, v := range s.Elems() {
+	for k, v := range s.members {
 		ret[k] = v
 	}
 	return ret
@@ -50,7 +50,7 @@ func (m Map[K, V]) transformForCmp() any {
 	ret := make(map[any]any, m.Len())
 	// It's okay to access the keys here because this package is allowed to
 	// depend on its own implementation details.
-	for k, v := range m.Elems() {
+	for k, v := range m.elems {
 		ret[k] = v
 	}
 	return ret

--- a/internal/collections/map.go
+++ b/internal/collections/map.go
@@ -3,6 +3,8 @@
 
 package collections
 
+import "iter"
+
 // Set represents an associative array from keys of type K to values of type V.
 //
 // A caller-provided "key function" defines how to produce a comparable unique
@@ -116,31 +118,26 @@ func (m Map[K, V]) Delete(k K) {
 	delete(m.elems, uniq)
 }
 
-// Elems exposes the internal underlying representation of the map directly,
-// as a pragmatic compromise for efficient iteration.
+// All returns an iterator over the elements of the map, in an unspecified
+// order.
 //
-// The result of this function is part of the internal state of the receiver
-// and so callers MUST NOT modify it. If a caller is using locks to ensure
-// safe concurrent access then any reads of the resulting map must be
-// guarded by the same lock as would be used for other methods that read
-// data from the reciever.
+// This is intended for use in a range-over-func statement, like this:
 //
-// The only correct use of this function is as part of a "for ... range"
-// statement using only the values of the resulting map:
-//
-//	for _, elem := range map.Elems() {
-//	    k := elem.K
-//	    v := elem.V
-//	    // ...
+//	for k, v := range map.All() {
+//		// do something with k and/or v
 //	}
 //
-// Do not access or make any assumptions about the keys of the resulting
-// map. Their exact values are an implementation detail of the receiver.
-func (m Map[K, V]) Elems() map[UniqueKey[K]]MapElem[K, V] {
-	// This is regrettable but the only viable way to support efficient
-	// iteration over map elements until Go gains support for range
-	// loops over custom iterator functions.
-	return m.elems
+// Modifying the map during iteration causes unspecified results. Modifying
+// the map concurrently with advancing the iterator causes undefined behavior
+// including possible memory unsafety.
+func (m Map[K, V]) All() iter.Seq2[K, V] {
+	return func(yield func(K, V) bool) {
+		for _, elem := range m.elems {
+			if !yield(elem.K, elem.V) {
+				return
+			}
+		}
+	}
 }
 
 // Len returns the number of elements in the map.

--- a/internal/collections/set.go
+++ b/internal/collections/set.go
@@ -3,6 +3,8 @@
 
 package collections
 
+import "iter"
+
 // Set represents an unordered set of values of a particular type.
 //
 // A caller-provided "key function" defines how to produce a comparable unique
@@ -81,8 +83,8 @@ func (s Set[T]) Remove(v T) {
 	delete(s.members, k)
 }
 
-// Elems exposes the internal underlying map representation of the set
-// directly, as a pragmatic compromise for efficient iteration.
+// All returns an iterator over the elements of the set, in an unspecified
+// order.
 //
 // The result of this function is part of the internal state of the set
 // and so callers MUST NOT modify it. If a caller is using locks to ensure
@@ -90,20 +92,24 @@ func (s Set[T]) Remove(v T) {
 // guarded by the same lock as would be used for other methods that read
 // data from the set.
 //
-// The only correct use of this function is as part of a "for ... range"
-// statement using only the values of the resulting map:
+// All returns an iterator over the elements of the set, in an unspecified
+// order.
 //
-//	for _, elem := range set.Elems() {
-//	    // ...
+//	for elem := range set.All() {
+//		// do something with elem
 //	}
 //
-// Do not access or make any assumptions about the keys of the resulting
-// map. Their exact values are an implementation detail of the set.
-func (s Set[T]) Elems() map[UniqueKey[T]]T {
-	// This is regrettable but the only viable way to support efficient
-	// iteration over set members until Go gains support for range
-	// loops over custom iterator functions.
-	return s.members
+// Modifying the set during iteration causes unspecified results. Modifying
+// the set concurrently with advancing the iterator causes undefined behavior
+// including possible memory unsafety.
+func (s Set[T]) All() iter.Seq[T] {
+	return func(yield func(T) bool) {
+		for _, v := range s.members {
+			if !yield(v) {
+				return
+			}
+		}
+	}
 }
 
 // Len returns the number of unique elements in the set.

--- a/internal/plans/planfile/tfplan.go
+++ b/internal/plans/planfile/tfplan.go
@@ -599,7 +599,7 @@ func writeTfplan(plan *plans.Plan, w io.Writer) error {
 	}
 	if plan.ApplyTimeVariables.Len() != 0 {
 		rawPlan.ApplyTimeVariables = make([]string, 0, plan.ApplyTimeVariables.Len())
-		for _, name := range plan.ApplyTimeVariables.Elems() {
+		for name := range plan.ApplyTimeVariables.All() {
 			rawPlan.ApplyTimeVariables = append(rawPlan.ApplyTimeVariables, name)
 		}
 	}

--- a/internal/stacks/stackplan/from_proto.go
+++ b/internal/stacks/stackplan/from_proto.go
@@ -329,28 +329,26 @@ func (l *Loader) Plan() (*Plan, error) {
 	}
 
 	// Before we return we'll calculate the reverse dependency information
-	// based on the forward dependency information we loaded earlier.
-	for _, elem := range l.ret.Components.Elems() {
-		dependentInstAddr := elem.K
+	// based on the forward dependency information we loaded above.
+	for dependentInstAddr, dependencyInst := range l.ret.Components.All() {
 		dependentAddr := stackaddrs.AbsComponent{
 			Stack: dependentInstAddr.Stack,
 			Item:  dependentInstAddr.Item.Component,
 		}
 
-		for _, dependencyAddr := range elem.V.Dependencies.Elems() {
+		for dependencyAddr := range dependencyInst.Dependencies.All() {
 			// FIXME: This is very inefficient because the current data structure doesn't
 			// allow looking up all of the component instances that have a particular
 			// component. This'll be okay as long as the number of components is
 			// small, but we'll need to improve this if we ever want to support stacks
 			// with a large number of components.
-			for _, elem := range l.ret.Components.Elems() {
-				maybeDependencyInstAddr := elem.K
+			for maybeDependencyInstAddr, dependencyInst := range l.ret.Components.All() {
 				maybeDependencyAddr := stackaddrs.AbsComponent{
 					Stack: maybeDependencyInstAddr.Stack,
 					Item:  maybeDependencyInstAddr.Item.Component,
 				}
 				if dependencyAddr.UniqueKey() == maybeDependencyAddr.UniqueKey() {
-					elem.V.Dependents.Add(dependentAddr)
+					dependencyInst.Dependents.Add(dependentAddr)
 				}
 			}
 		}

--- a/internal/stacks/stackplan/from_proto_test.go
+++ b/internal/stacks/stackplan/from_proto_test.go
@@ -107,7 +107,7 @@ func cmpCollectionsSet[V any]() cmp.Option {
 			return false
 		}
 
-		for _, v := range x.Elems() {
+		for v := range x.All() {
 			if !y.Has(v) {
 				return false
 			}
@@ -123,12 +123,12 @@ func cmpCollectionsMap[K, V any]() cmp.Option {
 			return false
 		}
 
-		for _, entry := range x.Elems() {
-			if !y.HasKey(entry.K) {
+		for key, entry := range x.All() {
+			if !y.HasKey(key) {
 				return false
 			}
 
-			if !cmp.Equal(entry.V, y.Get(entry.K)) {
+			if !cmp.Equal(entry, y.Get(key)) {
 				return false
 			}
 		}

--- a/internal/stacks/stackplan/plan.go
+++ b/internal/stacks/stackplan/plan.go
@@ -94,15 +94,15 @@ type Plan struct {
 // the given component.
 func (p *Plan) ComponentInstances(addr stackaddrs.AbsComponent) collections.Set[stackaddrs.ComponentInstance] {
 	ret := collections.NewSet[stackaddrs.ComponentInstance]()
-	for _, elem := range p.Components.Elems() {
-		if elem.K.Stack.String() != addr.Stack.String() {
+	for elem := range p.Components.All() {
+		if elem.Stack.String() != addr.Stack.String() {
 			// Then
 			continue
 		}
-		if elem.K.Item.Component.Name != addr.Item.Name {
+		if elem.Item.Component.Name != addr.Item.Name {
 			continue
 		}
-		ret.Add(elem.K.Item)
+		ret.Add(elem.Item)
 	}
 	return ret
 }

--- a/internal/stacks/stackplan/planned_change.go
+++ b/internal/stacks/stackplan/planned_change.go
@@ -270,7 +270,7 @@ func (pc *PlannedChangeComponentInstance) PlannedChangeProto() (*stacks.PlannedC
 	}
 
 	componentAddrsRaw := make([]string, 0, pc.RequiredComponents.Len())
-	for _, componentAddr := range pc.RequiredComponents.Elems() {
+	for componentAddr := range pc.RequiredComponents.All() {
 		componentAddrsRaw = append(componentAddrsRaw, componentAddr.String())
 	}
 

--- a/internal/stacks/stackruntime/apply_test.go
+++ b/internal/stacks/stackruntime/apply_test.go
@@ -2711,24 +2711,24 @@ func TestApplyWithStateManipulation(t *testing.T) {
 			}
 
 			wantCounts := tc.counts
-			for _, elem := range wantCounts.Elems() {
+			for key, elem := range wantCounts.All() {
 				// First, make sure everything we wanted is present.
-				if !gotCounts.HasKey(elem.K) {
-					t.Errorf("wrong counts: wanted %s but didn't get it", elem.K)
+				if !gotCounts.HasKey(key) {
+					t.Errorf("wrong counts: wanted %s but didn't get it", key)
 				}
 
 				// And that the values actually match.
-				got, want := gotCounts.Get(elem.K), elem.V
+				got, want := gotCounts.Get(key), elem
 				if diff := cmp.Diff(want, got); diff != "" {
 					t.Errorf("wrong counts for %s: %s", want.Addr, diff)
 				}
 
 			}
 
-			for _, elem := range gotCounts.Elems() {
+			for key := range gotCounts.All() {
 				// Then, make sure we didn't get anything we didn't want.
-				if !wantCounts.HasKey(elem.K) {
-					t.Errorf("wrong counts: got %s but didn't want it", elem.K)
+				if !wantCounts.HasKey(key) {
+					t.Errorf("wrong counts: got %s but didn't want it", key)
 				}
 			}
 		})

--- a/internal/stacks/stackruntime/internal/stackeval/change_exec.go
+++ b/internal/stacks/stackruntime/internal/stackeval/change_exec.go
@@ -176,8 +176,8 @@ func (r *ChangeExecResults) AwaitCompletion(ctx context.Context) {
 	// We don't have any single signal that everything is complete here,
 	// but it's sufficient for us to just visit each of our saved promise
 	// getters in turn and read from them.
-	for _, elem := range r.componentInstances.Elems() {
-		elem.V(ctx) // intentionally discards result; we only care that it's complete
+	for _, elem := range r.componentInstances.All() {
+		elem(ctx) // intentionally discards result; we only care that it's complete
 	}
 }
 

--- a/internal/stacks/stackruntime/internal/stackeval/component_instance.go
+++ b/internal/stacks/stackruntime/internal/stackeval/component_instance.go
@@ -247,7 +247,7 @@ func (c *ComponentInstance) CheckModuleTreePlan(ctx context.Context) (*plans.Pla
 					// should be reversed. Unfortunately, we can't compute that
 					// easily so instead we'll use the dependents computed at the
 					// last apply operation.
-					for _, depAddr := range c.PlanPrevDependents(ctx).Elems() {
+					for depAddr := range c.PlanPrevDependents(ctx).All() {
 						depStack := c.main.Stack(ctx, depAddr.Stack, PlanPhase)
 						if depStack == nil {
 							// something weird has happened, but this means that
@@ -280,7 +280,7 @@ func (c *ComponentInstance) CheckModuleTreePlan(ctx context.Context) (*plans.Pla
 			// If any of our upstream components have incomplete plans then
 			// we need to force treating everything in this component as
 			// deferred so we can preserve the correct dependency ordering.
-			for _, depAddr := range c.call.RequiredComponents(ctx).Elems() {
+			for depAddr := range c.call.RequiredComponents(ctx).All() {
 				depStack := c.main.Stack(ctx, depAddr.Stack, PlanPhase)
 				if depStack == nil {
 					opts.ExternalDependencyDeferred = true // to be conservative

--- a/internal/stacks/stackruntime/internal/stackeval/main_apply.go
+++ b/internal/stacks/stackruntime/internal/stackeval/main_apply.go
@@ -76,9 +76,9 @@ func ApplyPlan(ctx context.Context, config *stackconfig.Config, plan *stackplan.
 		// can error rather than deadlock if something goes wrong and causes
 		// us to try to depend on a result that isn't coming.
 		results, begin := ChangeExec(ctx, func(ctx context.Context, reg *ChangeExecRegistry[*Main]) {
-			for _, elem := range plan.Components.Elems() {
-				addr := elem.K
-				componentInstPlan := elem.V
+			for key, elem := range plan.Components.All() {
+				addr := key
+				componentInstPlan := elem
 				action := componentInstPlan.PlannedAction
 				dependencyAddrs := componentInstPlan.Dependencies
 				dependentAddrs := componentInstPlan.Dependents
@@ -206,7 +206,7 @@ func ApplyPlan(ctx context.Context, config *stackconfig.Config, plan *stackplan.
 						if depCount := waitForComponents.Len(); depCount != 0 {
 							log.Printf("[TRACE] stackeval: %s waiting for its predecessors (%d) to complete", addr, depCount)
 						}
-						for _, waitComponentAddr := range waitForComponents.Elems() {
+						for waitComponentAddr := range waitForComponents.All() {
 							if stack := main.Stack(ctx, waitComponentAddr.Stack, ApplyPhase); stack != nil {
 								if component := stack.Component(ctx, waitComponentAddr.Item); component != nil {
 									span.AddEvent("awaiting predecessor", trace.WithAttributes(
@@ -232,7 +232,7 @@ func ApplyPlan(ctx context.Context, config *stackconfig.Config, plan *stackplan.
 								}
 							}
 						}
-						for _, waitComponentAddr := range waitForRemoveds.Elems() {
+						for waitComponentAddr := range waitForRemoveds.All() {
 							if stack := main.Stack(ctx, waitComponentAddr.Stack, ApplyPhase); stack != nil {
 								if removed := stack.Removed(ctx, waitComponentAddr.Item); removed != nil {
 									span.AddEvent("awaiting predecessor", trace.WithAttributes(

--- a/internal/stacks/stackruntime/internal/stackeval/removed_instance.go
+++ b/internal/stacks/stackruntime/internal/stackeval/removed_instance.go
@@ -112,7 +112,7 @@ func (r *RemovedInstance) ModuleTreePlan(ctx context.Context) (*plans.Plan, tfdi
 		providerClients := configuredProviderClients(ctx, r.main, known, unknown, PlanPhase)
 
 		deferred := r.deferred
-		for _, depAddr := range r.PlanPrevDependents(ctx).Elems() {
+		for depAddr := range r.PlanPrevDependents(ctx).All() {
 			depStack := r.main.Stack(ctx, depAddr.Stack, PlanPhase)
 			if depStack == nil {
 				// something weird has happened, but this means that

--- a/internal/stacks/stackruntime/internal/stackeval/stack.go
+++ b/internal/stacks/stackruntime/internal/stackeval/stack.go
@@ -688,7 +688,7 @@ func (s *Stack) PlanChanges(ctx context.Context) ([]stackplan.PlannedChange, tfd
 	// if a component is targeted.
 
 	var changes []stackplan.PlannedChange
-	for _, inst := range s.main.PlanPrevState().AllComponentInstances().Elems() {
+	for inst := range s.main.PlanPrevState().AllComponentInstances().All() {
 
 		// We track here whether this component instance has any associated
 		// resources. If this component is empty, and not referenced in the
@@ -911,21 +911,21 @@ func (s *Stack) CheckApply(ctx context.Context) ([]stackstate.AppliedChange, tfd
 	// values are basically just everything that have been in the configuration
 	// in the past but is no longer and so needs to be removed from the state.
 
-	for _, value := range deletedOutputValues.Elems() {
+	for value := range deletedOutputValues.All() {
 		changes = append(changes, &stackstate.AppliedChangeOutputValue{
 			Addr:  value,
 			Value: cty.NilVal,
 		})
 	}
 
-	for _, value := range s.main.PlanBeingApplied().DeletedInputVariables.Elems() {
+	for value := range s.main.PlanBeingApplied().DeletedInputVariables.All() {
 		changes = append(changes, &stackstate.AppliedChangeInputVariable{
 			Addr:    value,
 			Removed: true,
 		})
 	}
 
-	for _, value := range s.main.PlanBeingApplied().DeletedComponents.Elems() {
+	for value := range s.main.PlanBeingApplied().DeletedComponents.All() {
 		changes = append(changes, &stackstate.AppliedChangeComponentInstanceRemoved{
 			ComponentAddr: stackaddrs.AbsComponent{
 				Stack: value.Stack,

--- a/internal/stacks/stackruntime/internal/stackeval/walk_dynamic.go
+++ b/internal/stacks/stackruntime/internal/stackeval/walk_dynamic.go
@@ -157,7 +157,7 @@ func walkDynamicObjectsInStack[Output any](
 					}
 				}
 
-				for _, inst := range knownInstances.Elems() {
+				for inst := range knownInstances.All() {
 					if claimedInstances.Has(inst) {
 						// Then this instance is claimed by the removed block.
 						continue
@@ -218,7 +218,7 @@ func walkDynamicObjectsInStack[Output any](
 					}
 				}
 
-				for _, inst := range knownInstances.Elems() {
+				for inst := range knownInstances.All() {
 					if claimedInstances.Has(inst) {
 						// Then this instance is claimed by the component block.
 						continue

--- a/internal/stacks/stackruntime/plan_test.go
+++ b/internal/stacks/stackruntime/plan_test.go
@@ -3783,24 +3783,24 @@ func TestPlanWithStateManipulation(t *testing.T) {
 			}
 
 			wantCounts := tc.counts
-			for _, elem := range wantCounts.Elems() {
+			for key, elem := range wantCounts.All() {
 				// First, make sure everything we wanted is present.
-				if !gotCounts.HasKey(elem.K) {
-					t.Errorf("wrong counts: wanted %s but didn't get it", elem.K)
+				if !gotCounts.HasKey(key) {
+					t.Errorf("wrong counts: wanted %s but didn't get it", key)
 				}
 
 				// And that the values actually match.
-				got, want := gotCounts.Get(elem.K), elem.V
+				got, want := gotCounts.Get(key), elem
 				if diff := cmp.Diff(want, got); diff != "" {
 					t.Errorf("wrong counts for %s: %s", want.Addr, diff)
 				}
 
 			}
 
-			for _, elem := range gotCounts.Elems() {
+			for key := range gotCounts.All() {
 				// Then, make sure we didn't get anything we didn't want.
-				if !wantCounts.HasKey(elem.K) {
-					t.Errorf("wrong counts: got %s but didn't want it", elem.K)
+				if !wantCounts.HasKey(key) {
+					t.Errorf("wrong counts: got %s but didn't want it", key)
 				}
 			}
 		})
@@ -5233,7 +5233,7 @@ var cmpCollectionsSet = cmp.Comparer(func(x, y collections.Set[stackaddrs.AbsCom
 		return false
 	}
 
-	for _, v := range x.Elems() {
+	for v := range x.All() {
 		if !y.Has(v) {
 			return false
 		}

--- a/internal/stacks/stackstate/applied_change.go
+++ b/internal/stacks/stackstate/applied_change.go
@@ -311,14 +311,14 @@ func (ac *AppliedChangeComponentInstance) AppliedChangeProto() (*stacks.AppliedC
 		}(),
 		DependencyAddrs: func() []string {
 			var dependencies []string
-			for _, dependency := range ac.Dependencies.Elems() {
+			for dependency := range ac.Dependencies.All() {
 				dependencies = append(dependencies, dependency.String())
 			}
 			return dependencies
 		}(),
 		DependentAddrs: func() []string {
 			var dependents []string
-			for _, dependent := range ac.Dependents.Elems() {
+			for dependent := range ac.Dependents.All() {
 				dependents = append(dependents, dependent.String())
 			}
 			return dependents
@@ -500,13 +500,13 @@ func (ac *AppliedChangeDiscardKeys) AppliedChangeProto() (*stacks.AppliedChange,
 		Raw:          make([]*stacks.AppliedChange_RawChange, 0, ac.DiscardRawKeys.Len()),
 		Descriptions: make([]*stacks.AppliedChange_ChangeDescription, 0, ac.DiscardDescKeys.Len()),
 	}
-	for _, key := range ac.DiscardRawKeys.Elems() {
+	for key := range ac.DiscardRawKeys.All() {
 		ret.Raw = append(ret.Raw, &stacks.AppliedChange_RawChange{
 			Key:   statekeys.String(key),
 			Value: nil, // nil represents deletion
 		})
 	}
-	for _, key := range ac.DiscardDescKeys.Elems() {
+	for key := range ac.DiscardDescKeys.All() {
 		ret.Descriptions = append(ret.Descriptions, &stacks.AppliedChange_ChangeDescription{
 			Key:         statekeys.String(key),
 			Description: &stacks.AppliedChange_ChangeDescription_Deleted{

--- a/internal/stacks/stackstate/state.go
+++ b/internal/stacks/stackstate/state.go
@@ -95,8 +95,8 @@ func (s *State) AllComponentInstances() collections.Set[stackaddrs.AbsComponentI
 		return ret
 	}
 	ret = collections.NewSet[stackaddrs.AbsComponentInstance]()
-	for _, elem := range s.componentInstances.Elems() {
-		ret.Add(elem.K)
+	for key := range s.componentInstances.All() {
+		ret.Add(key)
 	}
 	return ret
 }
@@ -108,15 +108,15 @@ func (s *State) AllComponentInstances() collections.Set[stackaddrs.AbsComponentI
 // This will always be a subset of AllComponentInstances.
 func (s *State) ComponentInstances(addr stackaddrs.AbsComponent) collections.Set[stackaddrs.ComponentInstance] {
 	ret := collections.NewSet[stackaddrs.ComponentInstance]()
-	for _, elem := range s.componentInstances.Elems() {
-		if elem.K.Stack.String() != addr.Stack.String() {
+	for key := range s.componentInstances.All() {
+		if key.Stack.String() != addr.Stack.String() {
 			// Then
 			continue
 		}
-		if elem.K.Item.Component.Name != addr.Item.Name {
+		if key.Item.Component.Name != addr.Item.Name {
 			continue
 		}
-		ret.Add(elem.K.Item)
+		ret.Add(key.Item)
 	}
 	return ret
 }
@@ -191,9 +191,9 @@ func (s *State) ComponentInstanceResourceInstanceObjects(addr stackaddrs.AbsComp
 // instance objects that are tracked in the state, across all components.
 func (s *State) AllResourceInstanceObjects() collections.Set[stackaddrs.AbsResourceInstanceObject] {
 	ret := collections.NewSet[stackaddrs.AbsResourceInstanceObject]()
-	for _, elem := range s.componentInstances.Elems() {
-		componentAddr := elem.K
-		for _, elem := range elem.V.resourceInstanceObjects.Elems {
+	for key, elem := range s.componentInstances.All() {
+		componentAddr := key
+		for _, elem := range elem.resourceInstanceObjects.Elems {
 			objKey := stackaddrs.AbsResourceInstanceObject{
 				Component: componentAddr,
 				Item:      elem.Key,
@@ -256,7 +256,7 @@ func (s *State) resourceInstanceObjectState(addr stackaddrs.AbsResourceInstanceO
 func (s *State) ComponentInstanceStateForModulesRuntime(addr stackaddrs.AbsComponentInstance) *states.State {
 	return states.BuildState(func(ss *states.SyncState) {
 		objAddrs := s.ComponentInstanceResourceInstanceObjects(addr)
-		for _, objAddr := range objAddrs.Elems() {
+		for objAddr := range objAddrs.All() {
 			rios := s.resourceInstanceObjectState(objAddr)
 
 			if objAddr.Item.IsCurrent() {

--- a/internal/stacks/stackstate/state_builder.go
+++ b/internal/stacks/stackstate/state_builder.go
@@ -51,10 +51,10 @@ func (s *StateBuilder) AddComponentInstance(builder *ComponentInstanceBuilder) *
 	component.outputValues = builder.outputValues
 	component.inputVariables = builder.inputVariables
 
-	for _, dep := range builder.dependencies.Elems() {
+	for dep := range builder.dependencies.All() {
 		component.dependencies.Add(dep)
 	}
-	for _, dep := range builder.dependents.Elems() {
+	for dep := range builder.dependents.All() {
 		component.dependents.Add(dep)
 	}
 	return s

--- a/internal/terraform/context_apply.go
+++ b/internal/terraform/context_apply.go
@@ -253,7 +253,7 @@ Note that the -target option is not suitable for routine use, and is provided on
 
 func checkApplyTimeVariables(needed collections.Set[string], gotValues InputValues, config *configs.Config) tfdiags.Diagnostics {
 	var diags tfdiags.Diagnostics
-	for _, name := range needed.Elems() {
+	for name := range needed.All() {
 		if vv, exists := gotValues[name]; !exists || vv.Value == cty.NilVal || vv.Value.IsNull() {
 			// This error message assumes that the only possible reason for
 			// an apply-time variable is because the variable is ephemeral,


### PR DESCRIPTION
This is an updated version of the changes tested out in #35426. We can mostly hide the internal details of the data types now, however the `MapElem` and it's `K` `V` fields are still exported in order to allow the creation of a populated map with a single expression, which is used in a number of tests already. The `MapElem` type is only exposed to provide a structure for the pairs of inputs to the constructor, and no longer needed for any external manipulation of the data. 

I also evaluated the use of `addrs.Map` and `addrs.Set`, which uses some similar ideas but the structure is different enough that there is no straightforward way to translate the code and unify the use of these types. All the types in the `addrs` package already have their own `UniqueKey` methods tied to the package types, so rewriting those and all the calling code would be considerable amount of work. There's also some code which is setting and checking the internal `Elems` map to signal certain conditions which needs to be fixed before we can encapsulate the code with the new iterator pattern or replace the code with `collections.Map`.