### PR TITLE
stacks: represent ephemeral inputs and outputs as null

### DIFF
--- a/internal/stacks/stackplan/from_proto.go
+++ b/internal/stacks/stackplan/from_proto.go
@@ -119,15 +119,14 @@ func (l *Loader) AddRaw(rawMsg *anypb.Any) error {
 		addr := stackaddrs.InputVariable{
 			Name: msg.Name,
 		}
-		if msg.Value != nil {
-			val, err := tfstackdata1.DynamicValueFromTFStackData1(msg.Value, cty.DynamicPseudoType)
-			if err != nil {
-				return fmt.Errorf("invalid stored value for %s: %w", addr, err)
-			}
-			l.ret.RootInputValues[addr] = val
+
+		val, err := tfstackdata1.DynamicValueFromTFStackData1(msg.Value, cty.DynamicPseudoType)
+		if err != nil {
+			return fmt.Errorf("invalid stored value for %s: %w", addr, err)
 		}
+		l.ret.RootInputValues[addr] = val
 		if msg.RequiredOnApply {
-			if msg.Value != nil {
+			if !val.IsNull() {
 				// A variable can't be both persisted _and_ required on apply.
 				return fmt.Errorf("plan has value for required-on-apply input variable %s", addr)
 			}

--- a/internal/stacks/stackplan/planned_change.go
+++ b/internal/stacks/stackplan/planned_change.go
@@ -102,29 +102,20 @@ func (pc *PlannedChangeRootInputValue) PlannedChangeProto() (*stacks.PlannedChan
 		raws = append(raws, &raw)
 	}
 
-	var before, after *stacks.DynamicValue
-	if pc.Before != cty.NilVal {
-		before, err = stacks.ToDynamicValue(pc.Before, cty.DynamicPseudoType)
-		if err != nil {
-			return nil, fmt.Errorf("failed to encode before planned input variable %s: %w", pc.Addr, err)
-		}
+	before, err := stacks.ToDynamicValue(pc.Before, cty.DynamicPseudoType)
+	if err != nil {
+		return nil, fmt.Errorf("failed to encode before planned input variable %s: %w", pc.Addr, err)
 	}
-	if pc.After != cty.NilVal {
-		after, err = stacks.ToDynamicValue(pc.After, cty.DynamicPseudoType)
-		if err != nil {
-			return nil, fmt.Errorf("failed to encode after planned input variable %s: %w", pc.Addr, err)
-		}
+	after, err := stacks.ToDynamicValue(pc.After, cty.DynamicPseudoType)
+	if err != nil {
+		return nil, fmt.Errorf("failed to encode after planned input variable %s: %w", pc.Addr, err)
 	}
 
 	if pc.Action != plans.Delete {
-		var ppdv *tfstackdata1.DynamicValue
-		if after != nil {
-			ppdv = tfstackdata1.Terraform1ToStackDataDynamicValue(after)
-		}
 		var raw anypb.Any
 		if err := anypb.MarshalFrom(&raw, &tfstackdata1.PlanRootInputValue{
 			Name:            pc.Addr.Name,
-			Value:           ppdv,
+			Value:           tfstackdata1.Terraform1ToStackDataDynamicValue(after),
 			RequiredOnApply: pc.RequiredOnApply,
 		}, proto.MarshalOptions{}); err != nil {
 			return nil, err

--- a/internal/stacks/stackplan/planned_change_test.go
+++ b/internal/stacks/stackplan/planned_change_test.go
@@ -888,17 +888,21 @@ func TestPlannedChangeAsProto(t *testing.T) {
 		},
 		"root input variable that must be re-supplied during apply": {
 			Receiver: &PlannedChangeRootInputValue{
-				Addr:   stackaddrs.InputVariable{Name: "thingy_id"},
-				Action: plans.Create,
-				Before: cty.NullVal(cty.String),
-				// No after in this case: the value must be re-supplied during
-				// apply specifically so that we can avoid the need to store it.
+				Addr:            stackaddrs.InputVariable{Name: "thingy_id"},
+				Action:          plans.Create,
+				Before:          cty.NullVal(cty.String),
+				After:           cty.NullVal(cty.String),
 				RequiredOnApply: true,
 			},
 			Want: &stacks.PlannedChange{
 				Raw: []*anypb.Any{
 					mustMarshalAnyPb(&tfstackdata1.PlanRootInputValue{
-						Name:            "thingy_id",
+						Name: "thingy_id",
+						Value: &tfstackdata1.DynamicValue{
+							Value: &planproto.DynamicValue{
+								Msgpack: mustMsgPack(t, cty.NullVal(cty.String)),
+							},
+						},
 						RequiredOnApply: true,
 					}),
 				},
@@ -912,7 +916,9 @@ func TestPlannedChangeAsProto(t *testing.T) {
 									Old: &stacks.DynamicValue{
 										Msgpack: mustMsgPack(t, cty.NullVal(cty.String)),
 									},
-									// New is empty because it is ephemeral.
+									New: &stacks.DynamicValue{
+										Msgpack: mustMsgPack(t, cty.NullVal(cty.String)),
+									},
 								},
 								RequiredDuringApply: true,
 							},

--- a/internal/stacks/stackruntime/apply_destroy_test.go
+++ b/internal/stacks/stackruntime/apply_destroy_test.go
@@ -85,8 +85,8 @@ func TestApplyDestroy(t *testing.T) {
 							Value: cty.NilVal, // destroyed
 						},
 						&stackstate.AppliedChangeInputVariable{
-							Addr:    mustStackInputVariable("value"),
-							Removed: true, // destroyed
+							Addr:  mustStackInputVariable("value"),
+							Value: cty.NilVal, // destroyed
 						},
 					},
 				},
@@ -131,12 +131,12 @@ func TestApplyDestroy(t *testing.T) {
 							Schema:                     nil,
 						},
 						&stackstate.AppliedChangeInputVariable{
-							Addr:    mustStackInputVariable("id"),
-							Removed: true,
+							Addr:  mustStackInputVariable("id"),
+							Value: cty.NilVal, // destroyed
 						},
 						&stackstate.AppliedChangeInputVariable{
-							Addr:    mustStackInputVariable("input"),
-							Removed: true,
+							Addr:  mustStackInputVariable("input"),
+							Value: cty.NilVal, // destroyed
 						},
 					},
 				},
@@ -197,12 +197,12 @@ func TestApplyDestroy(t *testing.T) {
 							NewStateSrc:                nil,
 						},
 						&stackstate.AppliedChangeInputVariable{
-							Addr:    mustStackInputVariable("id"),
-							Removed: true,
+							Addr:  mustStackInputVariable("id"),
+							Value: cty.NilVal, // destroyed
 						},
 						&stackstate.AppliedChangeInputVariable{
-							Addr:    mustStackInputVariable("resource"),
-							Removed: true,
+							Addr:  mustStackInputVariable("resource"),
+							Value: cty.NilVal, // destroyed
 						},
 					},
 				},
@@ -316,12 +316,12 @@ func TestApplyDestroy(t *testing.T) {
 							NewStateSrc:                nil, // deleted
 						},
 						&stackstate.AppliedChangeInputVariable{
-							Addr:    mustStackInputVariable("id"),
-							Removed: true,
+							Addr:  mustStackInputVariable("id"),
+							Value: cty.NilVal, // destroyed
 						},
 						&stackstate.AppliedChangeInputVariable{
-							Addr:    mustStackInputVariable("resource"),
-							Removed: true,
+							Addr:  mustStackInputVariable("resource"),
+							Value: cty.NilVal, // destroyed
 						},
 					},
 				},
@@ -465,12 +465,12 @@ func TestApplyDestroy(t *testing.T) {
 							Schema: stacks_testing_provider.FailedResourceSchema,
 						},
 						&stackstate.AppliedChangeInputVariable{
-							Addr:    mustStackInputVariable("fail_apply"),
-							Removed: true,
+							Addr:  mustStackInputVariable("fail_apply"),
+							Value: cty.NilVal, // destroyed
 						},
 						&stackstate.AppliedChangeInputVariable{
-							Addr:    mustStackInputVariable("fail_plan"),
-							Removed: true,
+							Addr:  mustStackInputVariable("fail_plan"),
+							Value: cty.NilVal, // destroyed
 						},
 					},
 					wantAppliedDiags: initDiags(func(diags tfdiags.Diagnostics) tfdiags.Diagnostics {

--- a/internal/stacks/stackruntime/apply_test.go
+++ b/internal/stacks/stackruntime/apply_test.go
@@ -261,8 +261,8 @@ func TestApply(t *testing.T) {
 							Value: cty.StringVal("foo"),
 						},
 						&stackstate.AppliedChangeInputVariable{
-							Addr:    mustStackInputVariable("removed"),
-							Removed: true,
+							Addr:  mustStackInputVariable("removed"),
+							Value: cty.NilVal, // destroyed
 						},
 						&stackstate.AppliedChangeInputVariable{
 							Addr:  mustStackInputVariable("value"),
@@ -1203,6 +1203,171 @@ After applying this plan, Terraform will no longer manage these objects. You wil
 							},
 							ProviderConfigAddr: mustDefaultRootProvider("testing"),
 							Schema:             stacks_testing_provider.TestingDataSourceSchema,
+						},
+					},
+				},
+			},
+		},
+		"ephemeral": {
+			path: path.Join("with-single-input", "ephemeral"),
+			cycles: []TestCycle{
+				{
+					planMode: plans.NormalMode,
+					planInputs: map[string]cty.Value{
+						"input":     cty.StringVal("hello"),
+						"ephemeral": cty.StringVal("planning"),
+					},
+					applyInputs: map[string]cty.Value{
+						"ephemeral": cty.StringVal("applying"),
+					},
+					wantAppliedChanges: []stackstate.AppliedChange{
+						&stackstate.AppliedChangeComponentInstance{
+							ComponentAddr:         mustAbsComponent("component.self"),
+							ComponentInstanceAddr: mustAbsComponentInstance("component.self"),
+							OutputValues:          make(map[addrs.OutputValue]cty.Value),
+							InputVariables: map[addrs.InputVariable]cty.Value{
+								mustInputVariable("id"):    cty.StringVal("2f9f3b84"),
+								mustInputVariable("input"): cty.StringVal("hello"),
+							},
+						},
+						&stackstate.AppliedChangeResourceInstanceObject{
+							ResourceInstanceObjectAddr: mustAbsResourceInstanceObject("component.self.testing_resource.data"),
+							NewStateSrc: &states.ResourceInstanceObjectSrc{
+								AttrsJSON: mustMarshalJSONAttrs(map[string]interface{}{
+									"id":    "2f9f3b84",
+									"value": "hello",
+								}),
+								Status:       states.ObjectReady,
+								Dependencies: make([]addrs.ConfigResource, 0),
+							},
+							ProviderConfigAddr: mustDefaultRootProvider("testing"),
+							Schema:             stacks_testing_provider.TestingResourceSchema,
+						},
+						&stackstate.AppliedChangeOutputValue{
+							Addr:  mustStackOutputValue("ephemeral"),
+							Value: cty.NullVal(cty.String), // ephemeral
+						},
+						&stackstate.AppliedChangeInputVariable{
+							Addr:  mustStackInputVariable("ephemeral"),
+							Value: cty.NullVal(cty.String), // ephemeral
+						},
+						&stackstate.AppliedChangeInputVariable{
+							Addr:  mustStackInputVariable("input"),
+							Value: cty.StringVal("hello"),
+						},
+					},
+				},
+			},
+		},
+		"missing-ephemeral": {
+			path: path.Join("with-single-input", "ephemeral"),
+			cycles: []TestCycle{
+				{
+					planMode: plans.NormalMode,
+					planInputs: map[string]cty.Value{
+						"input":     cty.StringVal("hello"),
+						"ephemeral": cty.StringVal("planning"),
+					},
+					applyInputs: make(map[string]cty.Value), // deliberately omitting ephemeral
+					wantAppliedChanges: []stackstate.AppliedChange{
+						&stackstate.AppliedChangeComponentInstance{
+							ComponentAddr:         mustAbsComponent("component.self"),
+							ComponentInstanceAddr: mustAbsComponentInstance("component.self"),
+							OutputValues:          make(map[addrs.OutputValue]cty.Value),
+							InputVariables: map[addrs.InputVariable]cty.Value{
+								mustInputVariable("id"):    cty.StringVal("2f9f3b84"),
+								mustInputVariable("input"): cty.StringVal("hello"),
+							},
+						},
+						&stackstate.AppliedChangeResourceInstanceObject{
+							ResourceInstanceObjectAddr: mustAbsResourceInstanceObject("component.self.testing_resource.data"),
+							NewStateSrc: &states.ResourceInstanceObjectSrc{
+								AttrsJSON: mustMarshalJSONAttrs(map[string]interface{}{
+									"id":    "2f9f3b84",
+									"value": "hello",
+								}),
+								Status:       states.ObjectReady,
+								Dependencies: make([]addrs.ConfigResource, 0),
+							},
+							ProviderConfigAddr: mustDefaultRootProvider("testing"),
+							Schema:             stacks_testing_provider.TestingResourceSchema,
+						},
+						&stackstate.AppliedChangeOutputValue{
+							Addr:  mustStackOutputValue("ephemeral"),
+							Value: cty.NullVal(cty.String), // ephemeral
+						},
+						&stackstate.AppliedChangeInputVariable{
+							Addr:  mustStackInputVariable("input"),
+							Value: cty.StringVal("hello"),
+						},
+					},
+					wantAppliedDiags: initDiags(func(diags tfdiags.Diagnostics) tfdiags.Diagnostics {
+						return diags.Append(&hcl.Diagnostic{
+							Severity: hcl.DiagError,
+							Summary:  "No value for required variable",
+							Detail:   "The root input variable \"var.ephemeral\" is not set, and has no default value.",
+							Subject: &hcl.Range{
+								Filename: "git::https://example.com/test.git//with-single-input/ephemeral/ephemeral.tfstack.hcl",
+								Start: hcl.Pos{
+									Line:   14,
+									Column: 1,
+									Byte:   175,
+								},
+								End: hcl.Pos{
+									Line:   14,
+									Column: 21,
+									Byte:   195,
+								},
+							},
+						})
+					}),
+				},
+			},
+		},
+		"ephemeral-default": {
+			path: path.Join("with-single-input", "ephemeral-default"),
+			cycles: []TestCycle{
+				{
+					planMode: plans.NormalMode,
+					planInputs: map[string]cty.Value{
+						"input": cty.StringVal("hello"),
+						// deliberately omitting ephemeral
+					},
+					applyInputs: make(map[string]cty.Value), // deliberately omitting ephemeral
+					wantAppliedChanges: []stackstate.AppliedChange{
+						&stackstate.AppliedChangeComponentInstance{
+							ComponentAddr:         mustAbsComponent("component.self"),
+							ComponentInstanceAddr: mustAbsComponentInstance("component.self"),
+							OutputValues:          make(map[addrs.OutputValue]cty.Value),
+							InputVariables: map[addrs.InputVariable]cty.Value{
+								mustInputVariable("id"):    cty.StringVal("2f9f3b84"),
+								mustInputVariable("input"): cty.StringVal("hello"),
+							},
+						},
+						&stackstate.AppliedChangeResourceInstanceObject{
+							ResourceInstanceObjectAddr: mustAbsResourceInstanceObject("component.self.testing_resource.data"),
+							NewStateSrc: &states.ResourceInstanceObjectSrc{
+								AttrsJSON: mustMarshalJSONAttrs(map[string]interface{}{
+									"id":    "2f9f3b84",
+									"value": "hello",
+								}),
+								Status:       states.ObjectReady,
+								Dependencies: make([]addrs.ConfigResource, 0),
+							},
+							ProviderConfigAddr: mustDefaultRootProvider("testing"),
+							Schema:             stacks_testing_provider.TestingResourceSchema,
+						},
+						&stackstate.AppliedChangeOutputValue{
+							Addr:  mustStackOutputValue("ephemeral"),
+							Value: cty.NullVal(cty.String), // ephemeral
+						},
+						&stackstate.AppliedChangeInputVariable{
+							Addr:  mustStackInputVariable("ephemeral"),
+							Value: cty.NullVal(cty.String), // ephemeral
+						},
+						&stackstate.AppliedChangeInputVariable{
+							Addr:  mustStackInputVariable("input"),
+							Value: cty.StringVal("hello"),
 						},
 					},
 				},
@@ -3028,440 +3193,6 @@ func TestApplyAutomaticInputConversion(t *testing.T) {
 				"hello": cty.StringVal("hello"),
 				"world": cty.StringVal("world"),
 			}),
-		},
-	}
-
-	if diff := cmp.Diff(wantChanges, applyChanges, changesCmpOpts); diff != "" {
-		t.Errorf("wrong changes\n%s", diff)
-	}
-}
-
-func TestApplyEphemeralInput(t *testing.T) {
-	ctx := context.Background()
-	cfg := loadMainBundleConfigForTest(t, filepath.Join("with-single-input", "ephemeral"))
-
-	fakePlanTimestamp, err := time.Parse(time.RFC3339, "1991-08-25T20:57:08Z")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	changesCh := make(chan stackplan.PlannedChange)
-	diagsCh := make(chan tfdiags.Diagnostic)
-	lock := depsfile.NewLocks()
-	lock.SetProvider(
-		addrs.NewDefaultProvider("testing"),
-		providerreqs.MustParseVersion("0.0.0"),
-		providerreqs.MustParseVersionConstraints("=0.0.0"),
-		providerreqs.PreferredHashes([]providerreqs.Hash{}),
-	)
-	req := PlanRequest{
-		Config: cfg,
-		ProviderFactories: map[addrs.Provider]providers.Factory{
-			addrs.NewDefaultProvider("testing"): func() (providers.Interface, error) {
-				return stacks_testing_provider.NewProvider(t), nil
-			},
-		},
-		DependencyLocks: *lock,
-
-		ForcePlanTimestamp: &fakePlanTimestamp,
-
-		InputValues: map[stackaddrs.InputVariable]ExternalInputValue{
-			stackaddrs.InputVariable{Name: "input"}: {
-				Value: cty.StringVal("hello"),
-			},
-			stackaddrs.InputVariable{Name: "ephemeral"}: {
-				Value: cty.StringVal("ephemeral"),
-			},
-		},
-	}
-
-	resp := PlanResponse{
-		PlannedChanges: changesCh,
-		Diagnostics:    diagsCh,
-	}
-
-	go Plan(ctx, &req, &resp)
-	planChanges, planDiags := collectPlanOutput(changesCh, diagsCh)
-	if len(planDiags) > 0 {
-		t.Fatalf("expected no diagnostics, got %s", planDiags.ErrWithWarnings())
-	}
-
-	planLoader := stackplan.NewLoader()
-	for _, change := range planChanges {
-		proto, err := change.PlannedChangeProto()
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		for _, rawMsg := range proto.Raw {
-			err = planLoader.AddRaw(rawMsg)
-			if err != nil {
-				t.Fatal(err)
-			}
-		}
-	}
-	plan, err := planLoader.Plan()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	applyReq := ApplyRequest{
-		Config: cfg,
-		Plan:   plan,
-		ProviderFactories: map[addrs.Provider]providers.Factory{
-			addrs.NewDefaultProvider("testing"): func() (providers.Interface, error) {
-				return stacks_testing_provider.NewProvider(t), nil
-			},
-		},
-		DependencyLocks: *lock,
-		InputValues: map[stackaddrs.InputVariable]ExternalInputValue{
-			stackaddrs.InputVariable{Name: "input"}: {
-				Value: cty.StringVal("hello"),
-			},
-			stackaddrs.InputVariable{Name: "ephemeral"}: {
-				// This has changed, and that should be okay.
-				Value: cty.StringVal("applying"),
-			},
-		},
-	}
-
-	applyChangesCh := make(chan stackstate.AppliedChange)
-	diagsCh = make(chan tfdiags.Diagnostic)
-
-	applyResp := ApplyResponse{
-		AppliedChanges: applyChangesCh,
-		Diagnostics:    diagsCh,
-	}
-
-	go Apply(ctx, &applyReq, &applyResp)
-	applyChanges, applyDiags := collectApplyOutput(applyChangesCh, diagsCh)
-	if len(applyDiags) > 0 {
-		t.Fatalf("expected no diagnostics, got %s", applyDiags.ErrWithWarnings())
-	}
-
-	sort.SliceStable(applyChanges, func(i, j int) bool {
-		return appliedChangeSortKey(applyChanges[i]) < appliedChangeSortKey(applyChanges[j])
-	})
-
-	wantChanges := []stackstate.AppliedChange{
-		&stackstate.AppliedChangeComponentInstance{
-			ComponentAddr:         mustAbsComponent("component.self"),
-			ComponentInstanceAddr: mustAbsComponentInstance("component.self"),
-			OutputValues:          make(map[addrs.OutputValue]cty.Value),
-			InputVariables: map[addrs.InputVariable]cty.Value{
-				mustInputVariable("id"):    cty.StringVal("2f9f3b84"),
-				mustInputVariable("input"): cty.StringVal("hello"),
-			},
-		},
-		&stackstate.AppliedChangeResourceInstanceObject{
-			ResourceInstanceObjectAddr: mustAbsResourceInstanceObject("component.self.testing_resource.data"),
-			NewStateSrc: &states.ResourceInstanceObjectSrc{
-				AttrsJSON: mustMarshalJSONAttrs(map[string]interface{}{
-					"id":    "2f9f3b84",
-					"value": "hello",
-				}),
-				Status:       states.ObjectReady,
-				Dependencies: make([]addrs.ConfigResource, 0),
-			},
-			ProviderConfigAddr: mustDefaultRootProvider("testing"),
-			Schema:             stacks_testing_provider.TestingResourceSchema,
-		},
-		&stackstate.AppliedChangeInputVariable{
-			Addr:  mustStackInputVariable("ephemeral"),
-			Value: cty.NilVal, // ephemeral
-		},
-		&stackstate.AppliedChangeInputVariable{
-			Addr:  mustStackInputVariable("input"),
-			Value: cty.StringVal("hello"),
-		},
-	}
-
-	if diff := cmp.Diff(wantChanges, applyChanges, changesCmpOpts); diff != "" {
-		t.Errorf("wrong changes\n%s", diff)
-	}
-}
-
-func TestApplyMissingEphemeralInput(t *testing.T) {
-	ctx := context.Background()
-	cfg := loadMainBundleConfigForTest(t, filepath.Join("with-single-input", "ephemeral"))
-
-	fakePlanTimestamp, err := time.Parse(time.RFC3339, "1991-08-25T20:57:08Z")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	changesCh := make(chan stackplan.PlannedChange)
-	diagsCh := make(chan tfdiags.Diagnostic)
-	lock := depsfile.NewLocks()
-	lock.SetProvider(
-		addrs.NewDefaultProvider("testing"),
-		providerreqs.MustParseVersion("0.0.0"),
-		providerreqs.MustParseVersionConstraints("=0.0.0"),
-		providerreqs.PreferredHashes([]providerreqs.Hash{}),
-	)
-	req := PlanRequest{
-		Config: cfg,
-		ProviderFactories: map[addrs.Provider]providers.Factory{
-			addrs.NewDefaultProvider("testing"): func() (providers.Interface, error) {
-				return stacks_testing_provider.NewProvider(t), nil
-			},
-		},
-		DependencyLocks: *lock,
-
-		ForcePlanTimestamp: &fakePlanTimestamp,
-
-		InputValues: map[stackaddrs.InputVariable]ExternalInputValue{
-			stackaddrs.InputVariable{Name: "input"}: {
-				Value: cty.StringVal("hello"),
-			},
-			stackaddrs.InputVariable{Name: "ephemeral"}: {
-				Value: cty.StringVal("ephemeral"),
-			},
-		},
-	}
-
-	resp := PlanResponse{
-		PlannedChanges: changesCh,
-		Diagnostics:    diagsCh,
-	}
-
-	go Plan(ctx, &req, &resp)
-	planChanges, planDiags := collectPlanOutput(changesCh, diagsCh)
-	if len(planDiags) > 0 {
-		t.Fatalf("expected no diagnostics, got %s", planDiags.ErrWithWarnings())
-	}
-
-	planLoader := stackplan.NewLoader()
-	for _, change := range planChanges {
-		proto, err := change.PlannedChangeProto()
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		for _, rawMsg := range proto.Raw {
-			err = planLoader.AddRaw(rawMsg)
-			if err != nil {
-				t.Fatal(err)
-			}
-		}
-	}
-	plan, err := planLoader.Plan()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	applyReq := ApplyRequest{
-		Config: cfg,
-		Plan:   plan,
-		ProviderFactories: map[addrs.Provider]providers.Factory{
-			addrs.NewDefaultProvider("testing"): func() (providers.Interface, error) {
-				return stacks_testing_provider.NewProvider(t), nil
-			},
-		},
-		DependencyLocks: *lock,
-		InputValues: map[stackaddrs.InputVariable]ExternalInputValue{
-			stackaddrs.InputVariable{Name: "input"}: {
-				Value: cty.StringVal("hello"),
-			},
-		},
-	}
-
-	applyChangesCh := make(chan stackstate.AppliedChange)
-	diagsCh = make(chan tfdiags.Diagnostic)
-
-	applyResp := ApplyResponse{
-		AppliedChanges: applyChangesCh,
-		Diagnostics:    diagsCh,
-	}
-
-	go Apply(ctx, &applyReq, &applyResp)
-	applyChanges, applyDiags := collectApplyOutput(applyChangesCh, diagsCh)
-	if len(applyDiags) != 1 {
-		t.Fatalf("expected exactly 1 diagnostic, got %s", applyDiags.ErrWithWarnings())
-	}
-
-	gotSeverity, wantSeverity := applyDiags[0].Severity(), tfdiags.Error
-	gotSummary, wantSummary := applyDiags[0].Description().Summary, "No value for required variable"
-	gotDetail, wantDetail := applyDiags[0].Description().Detail, "The root input variable \"var.ephemeral\" is not set, and has no default value."
-
-	if gotSeverity != wantSeverity {
-		t.Errorf("expected severity %q, got %q", wantSeverity, gotSeverity)
-	}
-	if gotSummary != wantSummary {
-		t.Errorf("expected summary %q, got %q", wantSummary, gotSummary)
-	}
-	if gotDetail != wantDetail {
-		t.Errorf("expected detail %q, got %q", wantDetail, gotDetail)
-	}
-
-	sort.SliceStable(applyChanges, func(i, j int) bool {
-		return appliedChangeSortKey(applyChanges[i]) < appliedChangeSortKey(applyChanges[j])
-	})
-
-	wantChanges := []stackstate.AppliedChange{
-		&stackstate.AppliedChangeComponentInstance{
-			ComponentAddr:         mustAbsComponent("component.self"),
-			ComponentInstanceAddr: mustAbsComponentInstance("component.self"),
-			OutputValues:          make(map[addrs.OutputValue]cty.Value),
-			InputVariables: map[addrs.InputVariable]cty.Value{
-				mustInputVariable("id"):    cty.StringVal("2f9f3b84"),
-				mustInputVariable("input"): cty.StringVal("hello"),
-			},
-		},
-		&stackstate.AppliedChangeResourceInstanceObject{
-			ResourceInstanceObjectAddr: mustAbsResourceInstanceObject("component.self.testing_resource.data"),
-			NewStateSrc: &states.ResourceInstanceObjectSrc{
-				AttrsJSON: mustMarshalJSONAttrs(map[string]interface{}{
-					"id":    "2f9f3b84",
-					"value": "hello",
-				}),
-				Status:       states.ObjectReady,
-				Dependencies: make([]addrs.ConfigResource, 0),
-			},
-			ProviderConfigAddr: mustDefaultRootProvider("testing"),
-			Schema:             stacks_testing_provider.TestingResourceSchema,
-		},
-		&stackstate.AppliedChangeInputVariable{
-			Addr:  mustStackInputVariable("input"),
-			Value: cty.StringVal("hello"),
-		},
-	}
-
-	if diff := cmp.Diff(wantChanges, applyChanges, changesCmpOpts); diff != "" {
-		t.Errorf("wrong changes\n%s", diff)
-	}
-}
-
-func TestApplyEphemeralInputWithDefault(t *testing.T) {
-	ctx := context.Background()
-	cfg := loadMainBundleConfigForTest(t, filepath.Join("with-single-input", "ephemeral-default"))
-
-	fakePlanTimestamp, err := time.Parse(time.RFC3339, "1991-08-25T20:57:08Z")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	changesCh := make(chan stackplan.PlannedChange)
-	diagsCh := make(chan tfdiags.Diagnostic)
-	lock := depsfile.NewLocks()
-	lock.SetProvider(
-		addrs.NewDefaultProvider("testing"),
-		providerreqs.MustParseVersion("0.0.0"),
-		providerreqs.MustParseVersionConstraints("=0.0.0"),
-		providerreqs.PreferredHashes([]providerreqs.Hash{}),
-	)
-	req := PlanRequest{
-		Config: cfg,
-		ProviderFactories: map[addrs.Provider]providers.Factory{
-			addrs.NewDefaultProvider("testing"): func() (providers.Interface, error) {
-				return stacks_testing_provider.NewProvider(t), nil
-			},
-		},
-		DependencyLocks: *lock,
-
-		ForcePlanTimestamp: &fakePlanTimestamp,
-
-		InputValues: map[stackaddrs.InputVariable]ExternalInputValue{
-			stackaddrs.InputVariable{Name: "input"}: {
-				Value: cty.StringVal("hello"),
-			},
-		},
-	}
-
-	resp := PlanResponse{
-		PlannedChanges: changesCh,
-		Diagnostics:    diagsCh,
-	}
-
-	go Plan(ctx, &req, &resp)
-	planChanges, planDiags := collectPlanOutput(changesCh, diagsCh)
-	if len(planDiags) > 0 {
-		t.Fatalf("expected no diagnostics, got %s", planDiags.ErrWithWarnings())
-	}
-
-	planLoader := stackplan.NewLoader()
-	for _, change := range planChanges {
-		proto, err := change.PlannedChangeProto()
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		for _, rawMsg := range proto.Raw {
-			err = planLoader.AddRaw(rawMsg)
-			if err != nil {
-				t.Fatal(err)
-			}
-		}
-	}
-	plan, err := planLoader.Plan()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	applyReq := ApplyRequest{
-		Config: cfg,
-		Plan:   plan,
-		ProviderFactories: map[addrs.Provider]providers.Factory{
-			addrs.NewDefaultProvider("testing"): func() (providers.Interface, error) {
-				return stacks_testing_provider.NewProvider(t), nil
-			},
-		},
-		DependencyLocks: *lock,
-		InputValues: map[stackaddrs.InputVariable]ExternalInputValue{
-			stackaddrs.InputVariable{Name: "input"}: {
-				Value: cty.StringVal("hello"),
-			},
-		},
-	}
-
-	applyChangesCh := make(chan stackstate.AppliedChange)
-	diagsCh = make(chan tfdiags.Diagnostic)
-
-	applyResp := ApplyResponse{
-		AppliedChanges: applyChangesCh,
-		Diagnostics:    diagsCh,
-	}
-
-	go Apply(ctx, &applyReq, &applyResp)
-	applyChanges, applyDiags := collectApplyOutput(applyChangesCh, diagsCh)
-	if len(applyDiags) > 0 {
-		t.Fatalf("expected no diagnostics, got %s", applyDiags.ErrWithWarnings())
-	}
-
-	sort.SliceStable(applyChanges, func(i, j int) bool {
-		return appliedChangeSortKey(applyChanges[i]) < appliedChangeSortKey(applyChanges[j])
-	})
-
-	wantChanges := []stackstate.AppliedChange{
-		&stackstate.AppliedChangeComponentInstance{
-			ComponentAddr:         mustAbsComponent("component.self"),
-			ComponentInstanceAddr: mustAbsComponentInstance("component.self"),
-			OutputValues:          make(map[addrs.OutputValue]cty.Value),
-			InputVariables: map[addrs.InputVariable]cty.Value{
-				mustInputVariable("id"):    cty.StringVal("2f9f3b84"),
-				mustInputVariable("input"): cty.StringVal("hello"),
-			},
-		},
-		&stackstate.AppliedChangeResourceInstanceObject{
-			ResourceInstanceObjectAddr: mustAbsResourceInstanceObject("component.self.testing_resource.data"),
-			NewStateSrc: &states.ResourceInstanceObjectSrc{
-				AttrsJSON: mustMarshalJSONAttrs(map[string]interface{}{
-					"id":    "2f9f3b84",
-					"value": "hello",
-				}),
-				Status:       states.ObjectReady,
-				Dependencies: make([]addrs.ConfigResource, 0),
-			},
-			ProviderConfigAddr: mustDefaultRootProvider("testing"),
-			Schema:             stacks_testing_provider.TestingResourceSchema,
-		},
-		&stackstate.AppliedChangeInputVariable{
-			Addr:  mustStackInputVariable("ephemeral"),
-			Value: cty.NilVal, // ephemeral
-		},
-		&stackstate.AppliedChangeInputVariable{
-			Addr:  mustStackInputVariable("input"),
-			Value: cty.StringVal("hello"),
 		},
 	}
 

--- a/internal/stacks/stackruntime/internal/stackeval/output_value.go
+++ b/internal/stacks/stackruntime/internal/stackeval/output_value.go
@@ -12,6 +12,7 @@ import (
 	"github.com/zclconf/go-cty/cty/convert"
 
 	"github.com/hashicorp/terraform/internal/lang/marks"
+	"github.com/hashicorp/terraform/internal/plans"
 	"github.com/hashicorp/terraform/internal/promising"
 	"github.com/hashicorp/terraform/internal/stacks/stackaddrs"
 	"github.com/hashicorp/terraform/internal/stacks/stackconfig"
@@ -199,7 +200,72 @@ func (v *OutputValue) checkValid(ctx context.Context, phase EvalPhase) tfdiags.D
 // PlanChanges implements Plannable as a plan-time validation of the variable's
 // declaration and of the caller's definition of the variable.
 func (v *OutputValue) PlanChanges(ctx context.Context) ([]stackplan.PlannedChange, tfdiags.Diagnostics) {
-	return nil, v.checkValid(ctx, PlanPhase)
+	diags := v.checkValid(ctx, PlanPhase)
+	if diags.HasErrors() {
+		return nil, diags
+	}
+
+	// Only the root stack's outputs are exposed externally.
+	if !v.Addr().Stack.IsRoot() {
+		return nil, diags
+	}
+
+	before := v.main.PlanPrevState().RootOutputValue(v.Addr().Item)
+	if v.main.PlanningOpts().PlanningMode == plans.DestroyMode {
+		if before == cty.NilVal {
+			// If the value didn't exist before and we're in destroy mode,
+			// then we'll just ignore this value.
+			return nil, diags
+		}
+
+		// Otherwise, return a planned change deleting the value.
+		ty, _ := v.ResultType(ctx)
+		return []stackplan.PlannedChange{
+			&stackplan.PlannedChangeOutputValue{
+				Addr:   v.Addr().Item,
+				Action: plans.Delete,
+				Before: before,
+				After:  cty.NullVal(ty),
+			},
+		}, diags
+	}
+
+	decl := v.Declaration(ctx)
+	after := v.ResultValue(ctx, PlanPhase)
+	if decl.Ephemeral {
+		after = cty.NullVal(after.Type())
+	}
+
+	var action plans.Action
+	if before != cty.NilVal {
+		if decl.Ephemeral {
+			// if the value is ephemeral, we always consider it to be updated
+			action = plans.Update
+		} else {
+			unmarkedBefore, beforePaths := before.UnmarkDeepWithPaths()
+			unmarkedAfter, afterPaths := after.UnmarkDeepWithPaths()
+			result := unmarkedBefore.Equals(unmarkedAfter)
+			if result.IsKnown() && result.True() && marks.MarksEqual(beforePaths, afterPaths) {
+				action = plans.NoOp
+			} else {
+				// If we don't know for sure that the values are equal, then we'll
+				// call this an update.
+				action = plans.Update
+			}
+		}
+	} else {
+		action = plans.Create
+		before = cty.NullVal(cty.DynamicPseudoType)
+	}
+
+	return []stackplan.PlannedChange{
+		&stackplan.PlannedChangeOutputValue{
+			Addr:   v.Addr().Item,
+			Action: action,
+			Before: before,
+			After:  after,
+		},
+	}, diags
 }
 
 // References implements Referrer
@@ -212,7 +278,34 @@ func (v *OutputValue) References(ctx context.Context) []stackaddrs.AbsReference 
 
 // CheckApply implements Applyable.
 func (v *OutputValue) CheckApply(ctx context.Context) ([]stackstate.AppliedChange, tfdiags.Diagnostics) {
-	return nil, v.checkValid(ctx, ApplyPhase)
+	if !v.Addr().Stack.IsRoot() {
+		return nil, v.checkValid(ctx, ApplyPhase)
+	}
+
+	diags := v.checkValid(ctx, ApplyPhase)
+	if diags.HasErrors() {
+		return nil, diags
+	}
+
+	if v.main.PlanBeingApplied().DeletedOutputValues.Has(v.Addr().Item) {
+		// If the plan being applied has marked this output value for deletion,
+		// we won't handle it here. The stack will take care of removing
+		// everything related to this output value.
+		return nil, diags
+	}
+
+	decl := v.Declaration(ctx)
+	value := v.ResultValue(ctx, ApplyPhase)
+	if decl.Ephemeral {
+		value = cty.NullVal(value.Type())
+	}
+
+	return []stackstate.AppliedChange{
+		&stackstate.AppliedChangeOutputValue{
+			Addr:  v.Addr().Item,
+			Value: value,
+		},
+	}, diags
 }
 
 func (v *OutputValue) tracingName() string {

--- a/internal/stacks/stackruntime/internal/stackeval/stack.go
+++ b/internal/stacks/stackruntime/internal/stackeval/stack.go
@@ -479,6 +479,10 @@ func (s *Stack) OutputValues(ctx context.Context) map[stackaddrs.OutputValue]*Ou
 	return ret
 }
 
+func (s *Stack) OutputValue(ctx context.Context, addr stackaddrs.OutputValue) *OutputValue {
+	return s.OutputValues(ctx)[addr]
+}
+
 func (s *Stack) ResultValue(ctx context.Context, phase EvalPhase) cty.Value {
 	ovs := s.OutputValues(ctx)
 	elems := make(map[string]cty.Value, len(ovs))
@@ -769,74 +773,13 @@ func (s *Stack) PlanChanges(ctx context.Context) ([]stackplan.PlannedChange, tfd
 		))
 	}
 
-	// Now, we'll process all the output values for this stack.
+	// Finally, we'll look at the input and output values we have in state
+	// and any that do not appear in the configuration we'll mark as deleted.
 
-	afterVal := s.ResultValue(ctx, PlanPhase)
-	if !afterVal.Type().IsObjectType() || afterVal.IsNull() || !afterVal.IsKnown() {
-		// None of these situations should be possible if Stack.ResultValue is
-		// correctly implemented.
-		panic(fmt.Sprintf("invalid result from Stack.ResultValue: %#v", afterVal))
-	}
-	beforeVal := s.main.PlanPrevState().RootOutputValues()
-
-	if s.main.PlanningOpts().PlanningMode == plans.DestroyMode {
-		// For a destroy plan, we'll actually cheat a little bit and swap out
-		// the values for null and destroy actions. We do this here because
-		// for most stacks and outputs we might have components that rely on
-		// the output being calculated based on the prior state rather than
-		// returning null. So, we leave the internals to compute the value
-		// in a helpful way and then just blanket say that all outputs will be
-		// destroyed during the plan.
-		for name, attr := range afterVal.Type().AttributeTypes() {
-			addr := stackaddrs.OutputValue{Name: name}
-			if before, exists := beforeVal[addr]; exists {
-
-				// If the before doesn't exist, then we'll emit nothing for this
-				// change as it doesn't already exist in state so doesn't need
-				// to be destroyed.
-				changes = append(changes, &stackplan.PlannedChangeOutputValue{
-					Addr:   stackaddrs.OutputValue{Name: name},
-					Action: plans.Delete,
-					Before: before,
-					// We can set the right type here, as do have the
-					// configuration.
-					After: cty.NullVal(attr),
-				})
-			}
-		}
-	} else {
-		for it := afterVal.ElementIterator(); it.Next(); {
-			k, after := it.Element()
-
-			addr := stackaddrs.OutputValue{Name: k.AsString()}
-			before := cty.NullVal(cty.DynamicPseudoType)
-			action := plans.Create
-
-			if actualBefore, exists := beforeVal[addr]; exists {
-				before = actualBefore
-
-				unmarkedBefore, beforePaths := before.UnmarkDeepWithPaths()
-				unmarkedAfter, afterPaths := after.UnmarkDeepWithPaths()
-				result := unmarkedBefore.Equals(unmarkedAfter)
-				if result.IsKnown() && result.True() && marks.MarksEqual(beforePaths, afterPaths) {
-					action = plans.NoOp
-				} else {
-					action = plans.Update
-				}
-			}
-
-			changes = append(changes, &stackplan.PlannedChangeOutputValue{
-				Addr:   addr,
-				Action: action,
-				Before: before,
-				After:  after,
-			})
-		}
-	}
-
-	for addr, before := range beforeVal {
-		if afterVal.Type().HasAttribute(addr.Name) {
-			// Then we already processed this.
+	for addr, value := range s.main.PlanPrevState().RootOutputValues() {
+		if s.OutputValue(ctx, addr) != nil {
+			// Then this output value is in the configuration, and will be
+			// processed independently.
 			continue
 		}
 
@@ -844,7 +787,7 @@ func (s *Stack) PlanChanges(ctx context.Context) ([]stackplan.PlannedChange, tfd
 		changes = append(changes, &stackplan.PlannedChangeOutputValue{
 			Addr:   addr,
 			Action: plans.Delete,
-			Before: before,
+			Before: value,
 			After:  cty.NullVal(cty.DynamicPseudoType),
 		})
 	}
@@ -879,39 +822,13 @@ func (s *Stack) CheckApply(ctx context.Context) ([]stackstate.AppliedChange, tfd
 	}
 
 	var diags tfdiags.Diagnostics
-
-	resultVal := s.ResultValue(ctx, ApplyPhase)
-	if !resultVal.Type().IsObjectType() || resultVal.IsNull() || !resultVal.IsKnown() {
-		// None of these situations should be possible if Stack.ResultValue is
-		// correctly implemented.
-		panic(fmt.Sprintf("invalid result from Stack.ResultValue: %#v", resultVal))
-	}
-
-	deletedOutputValues := s.main.PlanBeingApplied().DeletedOutputValues
-
 	var changes []stackstate.AppliedChange
-	for it := resultVal.ElementIterator(); it.Next(); {
-		k, v := it.Element()
-
-		addr := stackaddrs.OutputValue{Name: k.AsString()}
-		if deletedOutputValues.Has(addr) {
-			// Then we are deleting this output value even though it is in the
-			// configuration for some reason (probably because this is a
-			// delete plan and we're deleting everything). So, we won't process
-			// it here and only below.
-			continue
-		}
-		changes = append(changes, &stackstate.AppliedChangeOutputValue{
-			Addr:  addr,
-			Value: v,
-		})
-	}
 
 	// We're also just going to quickly emit any cleanup . These remaining
 	// values are basically just everything that have been in the configuration
 	// in the past but is no longer and so needs to be removed from the state.
 
-	for value := range deletedOutputValues.All() {
+	for value := range s.main.PlanBeingApplied().DeletedOutputValues.All() {
 		changes = append(changes, &stackstate.AppliedChangeOutputValue{
 			Addr:  value,
 			Value: cty.NilVal,
@@ -920,8 +837,8 @@ func (s *Stack) CheckApply(ctx context.Context) ([]stackstate.AppliedChange, tfd
 
 	for value := range s.main.PlanBeingApplied().DeletedInputVariables.All() {
 		changes = append(changes, &stackstate.AppliedChangeInputVariable{
-			Addr:    value,
-			Removed: true,
+			Addr:  value,
+			Value: cty.NilVal,
 		})
 	}
 

--- a/internal/stacks/stackruntime/plan_test.go
+++ b/internal/stacks/stackruntime/plan_test.go
@@ -876,7 +876,7 @@ func TestPlanWithEphemeralInputVariables(t *testing.T) {
 				},
 				Action:          plans.Create,
 				Before:          cty.NullVal(cty.DynamicPseudoType),
-				After:           cty.NilVal, // ephemeral
+				After:           cty.NullVal(cty.String), // ephemeral
 				RequiredOnApply: true,
 			},
 			&stackplan.PlannedChangeRootInputValue{
@@ -939,7 +939,7 @@ func TestPlanWithEphemeralInputVariables(t *testing.T) {
 				},
 				Action:          plans.Create,
 				Before:          cty.NullVal(cty.DynamicPseudoType),
-				After:           cty.NilVal, // ephemeral
+				After:           cty.NullVal(cty.String), // ephemeral
 				RequiredOnApply: false,
 			},
 			&stackplan.PlannedChangeRootInputValue{

--- a/internal/stacks/stackruntime/testdata/mainbundle/test/with-single-input/ephemeral-default/ephemeral-default.tfstack.hcl
+++ b/internal/stacks/stackruntime/testdata/mainbundle/test/with-single-input/ephemeral-default/ephemeral-default.tfstack.hcl
@@ -33,3 +33,9 @@ component "self" {
     id = "2f9f3b84"
   }
 }
+
+output "ephemeral" {
+  value = var.ephemeral
+  type = string
+  ephemeral = true
+}

--- a/internal/stacks/stackruntime/testdata/mainbundle/test/with-single-input/ephemeral/ephemeral.tfstack.hcl
+++ b/internal/stacks/stackruntime/testdata/mainbundle/test/with-single-input/ephemeral/ephemeral.tfstack.hcl
@@ -32,3 +32,9 @@ component "self" {
     id = "2f9f3b84"
   }
 }
+
+output "ephemeral" {
+  value = var.ephemeral
+  type = string
+  ephemeral = true
+}

--- a/internal/stacks/stackstate/applied_change.go
+++ b/internal/stacks/stackstate/applied_change.go
@@ -9,7 +9,6 @@ import (
 	"github.com/zclconf/go-cty/cty"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
-	"google.golang.org/protobuf/types/known/emptypb"
 
 	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/collections"
@@ -386,19 +385,13 @@ func (ac *AppliedChangeInputVariable) AppliedChangeProto() (*stacks.AppliedChang
 		Name: ac.Addr.Name,
 	}
 
-	if ac.Value == cty.NilVal {
-		if err := anypb.MarshalFrom(&raw, new(emptypb.Empty), proto.MarshalOptions{}); err != nil {
-			return nil, fmt.Errorf("encoding raw state for %s: %w", ac.Addr, err)
-		}
-	} else {
-		value, err := stacks.ToDynamicValue(ac.Value, cty.DynamicPseudoType)
-		if err != nil {
-			return nil, fmt.Errorf("encoding new state for %s in preparation for saving it: %w", ac.Addr, err)
-		}
-		description.NewValue = value
-		if err := anypb.MarshalFrom(&raw, tfstackdata1.Terraform1ToStackDataDynamicValue(value), proto.MarshalOptions{}); err != nil {
-			return nil, fmt.Errorf("encoding raw state for %s: %w", ac.Addr, err)
-		}
+	value, err := stacks.ToDynamicValue(ac.Value, cty.DynamicPseudoType)
+	if err != nil {
+		return nil, fmt.Errorf("encoding new state for %s in preparation for saving it: %w", ac.Addr, err)
+	}
+	description.NewValue = value
+	if err := anypb.MarshalFrom(&raw, tfstackdata1.Terraform1ToStackDataDynamicValue(value), proto.MarshalOptions{}); err != nil {
+		return nil, fmt.Errorf("encoding raw state for %s: %w", ac.Addr, err)
 	}
 
 	return &stacks.AppliedChange{

--- a/internal/stacks/stackstate/applied_change.go
+++ b/internal/stacks/stackstate/applied_change.go
@@ -352,11 +352,6 @@ func (ac *AppliedChangeComponentInstance) AppliedChangeProto() (*stacks.AppliedC
 type AppliedChangeInputVariable struct {
 	Addr  stackaddrs.InputVariable
 	Value cty.Value
-
-	// A Value field of cty.NilValue indicates the input variable is ephemeral
-	// rather than being deleted. We have a dedicated field to indicate
-	// deletion to make up for this.
-	Removed bool
 }
 
 var _ AppliedChange = (*AppliedChangeInputVariable)(nil)
@@ -366,7 +361,7 @@ func (ac *AppliedChangeInputVariable) AppliedChangeProto() (*stacks.AppliedChang
 		VariableAddr: ac.Addr,
 	})
 
-	if ac.Removed {
+	if ac.Value == cty.NilVal {
 		// Then we're deleting this input variable from the state.
 		return &stacks.AppliedChange{
 			Raw: []*stacks.AppliedChange_RawChange{

--- a/internal/stacks/stackstate/from_proto.go
+++ b/internal/stacks/stackstate/from_proto.go
@@ -259,7 +259,10 @@ func handleProtoMsg(key statekeys.Key, msg protoreflect.ProtoMessage, state *Sta
 func handleVariableMsg(key statekeys.Variable, msg protoreflect.ProtoMessage, state *State) error {
 	switch msg := msg.(type) {
 	case *emptypb.Empty:
-		state.addInputVariable(key.VariableAddr, cty.NilVal)
+		// for backwards compatibility reasons, ephemeral values used to be
+		// stored in state as empty messages. We'll upgrade these to null
+		// values with ephemeral marks.
+		state.addInputVariable(key.VariableAddr, cty.NullVal(cty.DynamicPseudoType))
 		return nil
 	case *tfstackdata1.DynamicValue:
 		value, err := tfstackdata1.DynamicValueFromTFStackData1(msg, cty.DynamicPseudoType)

--- a/internal/stacks/stackstate/state.go
+++ b/internal/stacks/stackstate/state.go
@@ -61,11 +61,8 @@ func (s *State) RootInputVariables() map[stackaddrs.InputVariable]cty.Value {
 // If the second return value is true, then the value is present but is
 // ephemeral and not known. If the first returned value is cty.NilVal and the
 // second is false then the value isn't present in the state.
-func (s *State) RootInputVariable(addr stackaddrs.InputVariable) (cty.Value, bool) {
-	if input, exists := s.inputs[addr]; exists {
-		return input, input == cty.NilVal
-	}
-	return cty.NilVal, false
+func (s *State) RootInputVariable(addr stackaddrs.InputVariable) cty.Value {
+	return s.inputs[addr]
 }
 
 func (s *State) RootOutputValues() map[stackaddrs.OutputValue]cty.Value {


### PR DESCRIPTION
This PR updates the behaviour of ephemeral inputs and outputs within stacks to match equivalent behaviour within core.

Previously, Stacks was removing all ephemeral values by encoding them as cty.NilVal or an empty pointer within the protocol buffer definitions.

Now, we use an unmarked null value to represent ephemeral values in line with the principles being implemented in Terraform Core.

Tapping @Uk1288 as an FYI, though I don't think this will change any of the required integrations.

There's a small refactor here where the processing of output values is pulled from the stack level into the individual output nodes. This matches the behaviour of the input variables, and makes discovering ephemeral values easier which is what led to the given approach for input variable as well.