### PR TITLE
stacks: root level outputs should not allow ephemeral values

### DIFF
--- a/internal/stacks/stackruntime/internal/stackeval/output_value.go
+++ b/internal/stacks/stackruntime/internal/stackeval/output_value.go
@@ -146,7 +146,26 @@ func (v *OutputValue) CheckResultValue(ctx context.Context, phase EvalPhase) (ct
 				return cfg.markResultValue(cty.UnknownVal(ty)), diags
 			}
 
-			if !cfg.Declaration(ctx).Ephemeral {
+			if cfg.Declaration(ctx).Ephemeral {
+				// Verify that ephemeral outputs are not declared on the root stack.
+				if v.Addr().Stack.IsRoot() {
+					diags = diags.Append(result.Diagnostic(
+						tfdiags.Error,
+						"Ephemeral output value not allowed on root stack",
+						fmt.Sprintf("Output value %q is marked as ephemeral, this is only allowed in embedded stacks.", v.Addr().Item.Name),
+					))
+				}
+
+				// Verify that the value is ephemeral.
+				if !marks.Contains(result.Value, marks.Ephemeral) {
+					diags = diags.Append(result.Diagnostic(
+						tfdiags.Error,
+						"Expected ephemeral value",
+						fmt.Sprintf("The output value %q is marked as ephemeral, but the value is not ephemeral.", v.Addr().Item.Name),
+					))
+				}
+
+			} else {
 				_, markses := result.Value.UnmarkDeepWithPaths()
 				problemPaths, _ := marks.PathsWithMark(markses, marks.Ephemeral)
 				var moreDiags tfdiags.Diagnostics

--- a/internal/stacks/stackruntime/internal/stackeval/output_value_test.go
+++ b/internal/stacks/stackruntime/internal/stackeval/output_value_test.go
@@ -196,30 +196,34 @@ func TestOutputValueEphemeral(t *testing.T) {
 	ctx := context.Background()
 
 	tests := map[string]struct {
-		fixtureName string
-		givenVal    cty.Value
-		allowed     bool
-		wantVal     cty.Value
+		fixtureName                 string
+		givenVal                    cty.Value
+		allowed                     bool
+		expectedDiagnosticSummaries []string
+		wantVal                     cty.Value
 	}{
-		"ephemeral and allowed": {
-			fixtureName: "ephemeral_yes",
-			givenVal:    cty.StringVal("beep").Mark(marks.Ephemeral),
-			allowed:     true,
-			wantVal:     cty.StringVal("beep").Mark(marks.Ephemeral),
+		"ephemeral and declared as ephemeral": {
+			fixtureName:                 "ephemeral_yes",
+			givenVal:                    cty.StringVal("beep").Mark(marks.Ephemeral),
+			allowed:                     false,
+			expectedDiagnosticSummaries: []string{"Ephemeral output value not allowed on root stack"},
+			wantVal:                     cty.StringVal("beep").Mark(marks.Ephemeral),
 		},
-		"ephemeral and not allowed": {
-			fixtureName: "ephemeral_no",
-			givenVal:    cty.StringVal("beep").Mark(marks.Ephemeral),
-			allowed:     false,
-			wantVal:     cty.UnknownVal(cty.String),
+		"ephemeral and not declared as ephemeral": {
+			fixtureName:                 "ephemeral_no",
+			givenVal:                    cty.StringVal("beep").Mark(marks.Ephemeral),
+			allowed:                     false,
+			expectedDiagnosticSummaries: []string{"Ephemeral value not allowed"},
+			wantVal:                     cty.UnknownVal(cty.String),
 		},
-		"non-ephemeral and allowed": {
-			fixtureName: "ephemeral_yes",
-			givenVal:    cty.StringVal("beep"),
-			allowed:     true,
-			wantVal:     cty.StringVal("beep").Mark(marks.Ephemeral),
+		"non-ephemeral and declared as ephemeral": {
+			fixtureName:                 "ephemeral_yes",
+			givenVal:                    cty.StringVal("beep"),
+			allowed:                     false,
+			expectedDiagnosticSummaries: []string{"Ephemeral output value not allowed on root stack", "Expected ephemeral value"},
+			wantVal:                     cty.StringVal("beep").Mark(marks.Ephemeral),
 		},
-		"non-ephemeral and not allowed": {
+		"non-ephemeral and not declared as ephemeral": {
 			fixtureName: "ephemeral_no",
 			givenVal:    cty.StringVal("beep"),
 			allowed:     true,
@@ -259,22 +263,110 @@ func TestOutputValueEphemeral(t *testing.T) {
 					if !diags.HasErrors() {
 						t.Fatalf("no errors; should have failed")
 					}
-					found := 0
+
+					foundDiagSummaries := make(map[string]bool)
 					for _, diag := range diags {
 						summary := diag.Description().Summary
-						if summary == "Ephemeral value not allowed" {
-							found++
-						}
+						foundDiagSummaries[summary] = true
 					}
-					if found == 0 {
-						t.Errorf("no diagnostics about disallowed ephemeral values\n%s", diags.Err().Error())
-					} else if found > 1 {
-						t.Errorf("found %d errors about disallowed ephemeral values, but wanted only one\n%s", found, diags.Err().Error())
+
+					if len(foundDiagSummaries) != len(test.expectedDiagnosticSummaries) {
+						t.Fatalf("wrong number of diagnostics, expected %v, got \n%s", test.expectedDiagnosticSummaries, diags.Err().Error())
+					}
+
+					for _, expectedSummary := range test.expectedDiagnosticSummaries {
+						if !foundDiagSummaries[expectedSummary] {
+							t.Fatalf("missing diagnostic with summary %s", expectedSummary)
+						}
 					}
 				}
 				return struct{}{}, nil
 			})
 		})
 	}
+}
 
+func TestOutputValueEphemeralInChildStack(t *testing.T) {
+	ctx := context.Background()
+
+	tests := map[string]struct {
+		fixtureName                 string
+		givenVal                    cty.Value
+		allowed                     bool
+		expectedDiagnosticSummaries []string
+		wantVal                     cty.Value
+	}{
+		"ephemeral and declared as ephemeral": {
+			fixtureName: "ephemeral_child",
+			givenVal:    cty.StringVal("beep").Mark(marks.Ephemeral),
+			allowed:     true,
+			wantVal:     cty.StringVal("beep").Mark(marks.Ephemeral),
+		},
+		"non-ephemeral and declared as ephemeral": {
+			fixtureName:                 "ephemeral_child",
+			givenVal:                    cty.StringVal("beep"),
+			allowed:                     false,
+			expectedDiagnosticSummaries: []string{"Expected ephemeral value"},
+			wantVal:                     cty.StringVal("beep").Mark(marks.Ephemeral),
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			cfg := testStackConfig(t, "output_value", test.fixtureName)
+			outputAddr := stackaddrs.OutputValue{Name: "result"}
+
+			main := testEvaluator(t, testEvaluatorOpts{
+				Config: cfg,
+				TestOnlyGlobals: map[string]cty.Value{
+					"result": test.givenVal,
+				},
+			})
+
+			promising.MainTask(ctx, func(ctx context.Context) (struct{}, error) {
+				rootStack := main.MainStack(ctx)
+				childStackStep := stackaddrs.StackInstanceStep{
+					Name: "child",
+					Key:  addrs.NoKey,
+				}
+				stack := rootStack.ChildStackChecked(ctx, childStackStep, ValidatePhase)
+				output := stack.OutputValues(ctx)[outputAddr]
+				if output == nil {
+					t.Fatalf("missing %s", outputAddr)
+				}
+				want := test.wantVal
+				got, diags := output.CheckResultValue(ctx, InspectPhase)
+				if diff := cmp.Diff(want, got, ctydebug.CmpOptions); diff != "" {
+					t.Errorf("wrong value for %s\n%s", outputAddr, diff)
+				}
+
+				if test.allowed {
+					if diags.HasErrors() {
+						t.Errorf("unexpected errors\n%s", diags.Err().Error())
+					}
+				} else {
+					if !diags.HasErrors() {
+						t.Fatalf("no errors; should have failed")
+					}
+
+					foundDiagSummaries := make(map[string]bool)
+					for _, diag := range diags {
+						summary := diag.Description().Summary
+						foundDiagSummaries[summary] = true
+					}
+
+					if len(foundDiagSummaries) != len(test.expectedDiagnosticSummaries) {
+						t.Fatalf("wrong number of diagnostics, expected %v, got \n%s", test.expectedDiagnosticSummaries, diags.Err().Error())
+					}
+
+					for _, expectedSummary := range test.expectedDiagnosticSummaries {
+						if !foundDiagSummaries[expectedSummary] {
+							t.Fatalf("missing diagnostic with summary %s", expectedSummary)
+						}
+					}
+				}
+				return struct{}{}, nil
+			})
+		})
+	}
 }

--- a/internal/stacks/stackruntime/internal/stackeval/testdata/sourcebundle/output_value/ephemeral_child/child/ephemeral-child-child.tfstack.hcl
+++ b/internal/stacks/stackruntime/internal/stackeval/testdata/sourcebundle/output_value/ephemeral_child/child/ephemeral-child-child.tfstack.hcl
@@ -1,0 +1,5 @@
+output "result" {
+  type      = string
+  value     = _test_only_global.result
+  ephemeral = true
+}

--- a/internal/stacks/stackruntime/internal/stackeval/testdata/sourcebundle/output_value/ephemeral_child/ephemeral-child.tfstack.hcl
+++ b/internal/stacks/stackruntime/internal/stackeval/testdata/sourcebundle/output_value/ephemeral_child/ephemeral-child.tfstack.hcl
@@ -1,0 +1,3 @@
+stack "child" {
+  source = "./child"
+}


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

[Jira: TF-18610](https://hashicorp.atlassian.net/browse/TF-18610)


## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.10.x

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

### NEW FEATURES | UPGRADE NOTES | ENHANCEMENTS | BUG FIXES | EXPERIMENTS

<!--

Write a short description of the user-facing change. Examples:

- `terraform show -json`: Fixed crash with sensitive set values.
- When rendering a diff, Terraform now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 

-  