### PR TITLE
backend/s3: Revert IAM role chaining support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,6 @@ ENHANCEMENTS:
 - Import block validation has been improved to provide more useful errors and catch more invalid cases during `terraform validate` ([#35543](https://github.com/hashicorp/terraform/issues/35543))
 - Performance enhancements for resource evaluation, especially when large numbers of resource instances are involved ([#35558](https://github.com/hashicorp/terraform/issues/35558))
 - The `plan`, `apply`, and `refresh` commands now produce a deprecated warning when using the `-state` flag. Instead use the `path` attribute within the `local` backend to modify the state file. ([#35660](https://github.com/hashicorp/terraform/issues/35660))
-- backend/s3: Adds support for IAM role chaining. The backend attribute `assume_role` now accepts multiple elements ([#35720](https://github.com/hashicorp/terraform/issues/35720))
 
 UPGRADE NOTES:
 

--- a/internal/backend/remote-state/s3/backend.go
+++ b/internal/backend/remote-state/s3/backend.go
@@ -287,127 +287,125 @@ func (b *Backend) ConfigSchema() *configschema.Block {
 	}
 }
 
-var assumeRoleSchema = listNestedAttribute{
-	NestedObject: nestedObjectSchema{
-		Attributes: map[string]schemaAttribute{
-			"role_arn": stringAttribute{
-				configschema.Attribute{
-					Type:        cty.String,
-					Required:    true,
-					Description: "The role to be assumed.",
+var assumeRoleSchema = singleNestedAttribute{
+	Attributes: map[string]schemaAttribute{
+		"role_arn": stringAttribute{
+			configschema.Attribute{
+				Type:        cty.String,
+				Required:    true,
+				Description: "The role to be assumed.",
+			},
+			validateString{
+				Validators: []stringValidator{
+					validateStringNotEmpty,
+					validateARN(
+						validateIAMRoleARN,
+					),
 				},
-				validateString{
-					Validators: []stringValidator{
-						validateStringNotEmpty,
+			},
+		},
+
+		"duration": stringAttribute{
+			configschema.Attribute{
+				Type:        cty.String,
+				Optional:    true,
+				Description: "The duration, between 15 minutes and 12 hours, of the role session. Valid time units are ns, us (or µs), ms, s, h, or m.",
+			},
+			validateString{
+				Validators: []stringValidator{
+					validateDuration(
+						validateDurationBetween(15*time.Minute, 12*time.Hour),
+					),
+				},
+			},
+		},
+
+		"external_id": stringAttribute{
+			configschema.Attribute{
+				Type:        cty.String,
+				Optional:    true,
+				Description: "The external ID to use when assuming the role",
+			},
+			validateString{
+				Validators: []stringValidator{
+					validateStringLenBetween(2, 1224),
+					validateStringMatches(
+						regexp.MustCompile(`^[\w+=,.@:\/\-]*$`),
+						`Value can only contain letters, numbers, or the following characters: =,.@/-`,
+					),
+				},
+			},
+		},
+
+		"policy": stringAttribute{
+			configschema.Attribute{
+				Type:        cty.String,
+				Optional:    true,
+				Description: "IAM Policy JSON describing further restricting permissions for the IAM Role being assumed.",
+			},
+			validateString{
+				Validators: []stringValidator{
+					validateStringNotEmpty,
+					validateIAMPolicyDocument,
+				},
+			},
+		},
+
+		"policy_arns": setAttribute{
+			configschema.Attribute{
+				Type:        cty.Set(cty.String),
+				Optional:    true,
+				Description: "Amazon Resource Names (ARNs) of IAM Policies describing further restricting permissions for the IAM Role being assumed.",
+			},
+			validateSet{
+				Validators: []setValidator{
+					validateSetStringElements(
 						validateARN(
-							validateIAMRoleARN,
+							validateIAMPolicyARN,
 						),
-					},
+					),
 				},
 			},
+		},
 
-			"duration": stringAttribute{
-				configschema.Attribute{
-					Type:        cty.String,
-					Optional:    true,
-					Description: "The duration, between 15 minutes and 12 hours, of the role session. Valid time units are ns, us (or µs), ms, s, h, or m.",
-				},
-				validateString{
-					Validators: []stringValidator{
-						validateDuration(
-							validateDurationBetween(15*time.Minute, 12*time.Hour),
-						),
-					},
-				},
+		"session_name": stringAttribute{
+			configschema.Attribute{
+				Type:        cty.String,
+				Optional:    true,
+				Description: "The session name to use when assuming the role.",
 			},
+			validateString{
+				Validators: assumeRoleNameValidator,
+			},
+		},
 
-			"external_id": stringAttribute{
-				configschema.Attribute{
-					Type:        cty.String,
-					Optional:    true,
-					Description: "The external ID to use when assuming the role",
-				},
-				validateString{
-					Validators: []stringValidator{
-						validateStringLenBetween(2, 1224),
-						validateStringMatches(
-							regexp.MustCompile(`^[\w+=,.@:\/\-]*$`),
-							`Value can only contain letters, numbers, or the following characters: =,.@/-`,
-						),
-					},
-				},
+		"source_identity": stringAttribute{
+			configschema.Attribute{
+				Type:        cty.String,
+				Optional:    true,
+				Description: "Source identity specified by the principal assuming the role.",
 			},
+			validateString{
+				Validators: assumeRoleNameValidator,
+			},
+		},
 
-			"policy": stringAttribute{
-				configschema.Attribute{
-					Type:        cty.String,
-					Optional:    true,
-					Description: "IAM Policy JSON describing further restricting permissions for the IAM Role being assumed.",
-				},
-				validateString{
-					Validators: []stringValidator{
-						validateStringNotEmpty,
-						validateIAMPolicyDocument,
-					},
-				},
+		"tags": mapAttribute{
+			configschema.Attribute{
+				Type:        cty.Map(cty.String),
+				Optional:    true,
+				Description: "Assume role session tags.",
 			},
+			validateMap{},
+		},
 
-			"policy_arns": setAttribute{
-				configschema.Attribute{
-					Type:        cty.Set(cty.String),
-					Optional:    true,
-					Description: "Amazon Resource Names (ARNs) of IAM Policies describing further restricting permissions for the IAM Role being assumed.",
-				},
-				validateSet{
-					Validators: []setValidator{
-						validateSetStringElements(
-							validateARN(
-								validateIAMPolicyARN,
-							),
-						),
-					},
-				},
+		"transitive_tag_keys": setAttribute{
+			configschema.Attribute{
+				Type:        cty.Set(cty.String),
+				Optional:    true,
+				Description: "Assume role session tag keys to pass to any subsequent sessions.",
 			},
-
-			"session_name": stringAttribute{
-				configschema.Attribute{
-					Type:        cty.String,
-					Optional:    true,
-					Description: "The session name to use when assuming the role.",
-				},
-				validateString{
-					Validators: assumeRoleNameValidator,
-				},
-			},
-
-			"source_identity": stringAttribute{
-				configschema.Attribute{
-					Type:        cty.String,
-					Optional:    true,
-					Description: "Source identity specified by the principal assuming the role.",
-				},
-				validateString{
-					Validators: assumeRoleNameValidator,
-				},
-			},
-
-			"tags": mapAttribute{
-				configschema.Attribute{
-					Type:        cty.Map(cty.String),
-					Optional:    true,
-					Description: "Assume role session tags.",
-				},
-				validateMap{},
-			},
-
-			"transitive_tag_keys": setAttribute{
-				configschema.Attribute{
-					Type:        cty.Set(cty.String),
-					Optional:    true,
-					Description: "Assume role session tag keys to pass to any subsequent sessions.",
-				},
-				validateSet{},
-			},
+			validateSet{},
 		},
 	},
 }
@@ -668,11 +666,11 @@ func (b *Backend) PrepareConfig(obj cty.Value) (cty.Value, tfdiags.Diagnostics) 
 	}
 
 	if val := obj.GetAttr("assume_role"); !val.IsNull() {
-		validateListNestedAttribute(assumeRoleSchema, val, cty.GetAttrPath("assume_role"), &diags)
+		validateNestedAttribute(assumeRoleSchema, val, cty.GetAttrPath("assume_role"), &diags)
 	}
 
 	if val := obj.GetAttr("assume_role_with_web_identity"); !val.IsNull() {
-		validateSingleNestedAttribute(assumeRoleWithWebIdentitySchema, val, cty.GetAttrPath("assume_role_with_web_identity"), &diags)
+		validateNestedAttribute(assumeRoleWithWebIdentitySchema, val, cty.GetAttrPath("assume_role_with_web_identity"), &diags)
 	}
 
 	validateAttributesConflict(
@@ -715,7 +713,7 @@ func (b *Backend) PrepareConfig(obj cty.Value) (cty.Value, tfdiags.Diagnostics) 
 	}
 
 	if val := obj.GetAttr("endpoints"); !val.IsNull() {
-		validateSingleNestedAttribute(endpointsSchema, val, cty.GetAttrPath("endpoints"), &diags)
+		validateNestedAttribute(endpointsSchema, val, cty.GetAttrPath("endpoints"), &diags)
 	}
 
 	endpointValidators := validateString{
@@ -975,42 +973,37 @@ func (b *Backend) Configure(obj cty.Value) tfdiags.Diagnostics {
 		cfg.StsRegion = v
 	}
 
-	if assumeRoles := obj.GetAttr("assume_role"); !assumeRoles.IsNull() {
-		ars := make([]awsbase.AssumeRole, 0, assumeRoles.LengthInt())
-		assumeRoles.ForEachElement(func(_, assumeRole cty.Value) bool {
-			ar := awsbase.AssumeRole{}
-			if val, ok := stringAttrOk(assumeRole, "role_arn"); ok {
-				ar.RoleARN = val
-			}
-			if val, ok := stringAttrOk(assumeRole, "duration"); ok {
-				duration, _ := time.ParseDuration(val)
-				ar.Duration = duration
-			}
-			if val, ok := stringAttrOk(assumeRole, "external_id"); ok {
-				ar.ExternalID = val
-			}
-			if val, ok := stringAttrOk(assumeRole, "policy"); ok {
-				ar.Policy = strings.TrimSpace(val)
-			}
-			if val, ok := stringSetAttrOk(assumeRole, "policy_arns"); ok {
-				ar.PolicyARNs = val
-			}
-			if val, ok := stringAttrOk(assumeRole, "session_name"); ok {
-				ar.SessionName = val
-			}
-			if val, ok := stringAttrOk(assumeRole, "source_identity"); ok {
-				ar.SourceIdentity = val
-			}
-			if val, ok := stringMapAttrOk(assumeRole, "tags"); ok {
-				ar.Tags = val
-			}
-			if val, ok := stringSetAttrOk(assumeRole, "transitive_tag_keys"); ok {
-				ar.TransitiveTagKeys = val
-			}
-			ars = append(ars, ar)
-			return false
-		})
-		cfg.AssumeRole = ars
+	if assumeRole := obj.GetAttr("assume_role"); !assumeRole.IsNull() {
+		ar := awsbase.AssumeRole{}
+		if val, ok := stringAttrOk(assumeRole, "role_arn"); ok {
+			ar.RoleARN = val
+		}
+		if val, ok := stringAttrOk(assumeRole, "duration"); ok {
+			duration, _ := time.ParseDuration(val)
+			ar.Duration = duration
+		}
+		if val, ok := stringAttrOk(assumeRole, "external_id"); ok {
+			ar.ExternalID = val
+		}
+		if val, ok := stringAttrOk(assumeRole, "policy"); ok {
+			ar.Policy = strings.TrimSpace(val)
+		}
+		if val, ok := stringSetAttrOk(assumeRole, "policy_arns"); ok {
+			ar.PolicyARNs = val
+		}
+		if val, ok := stringAttrOk(assumeRole, "session_name"); ok {
+			ar.SessionName = val
+		}
+		if val, ok := stringAttrOk(assumeRole, "source_identity"); ok {
+			ar.SourceIdentity = val
+		}
+		if val, ok := stringMapAttrOk(assumeRole, "tags"); ok {
+			ar.Tags = val
+		}
+		if val, ok := stringSetAttrOk(assumeRole, "transitive_tag_keys"); ok {
+			ar.TransitiveTagKeys = val
+		}
+		cfg.AssumeRole = []awsbase.AssumeRole{ar}
 	}
 
 	if assumeRoleWithWebIdentity := obj.GetAttr("assume_role_with_web_identity"); !assumeRoleWithWebIdentity.IsNull() {
@@ -1371,73 +1364,23 @@ The "kms_key_id" is used for encryption with KMS-Managed Keys (SSE-KMS)
 while "AWS_SSE_CUSTOMER_KEY" is used for encryption with customer-managed keys (SSE-C).
 Please choose one or the other.`
 
-func validateSingleNestedAttribute(objSchema singleNestedAttribute, obj cty.Value, objPath cty.Path, diags *tfdiags.Diagnostics) {
+func validateNestedAttribute(objSchema schemaAttribute, obj cty.Value, objPath cty.Path, diags *tfdiags.Diagnostics) {
 	if obj.IsNull() {
+		return
+	}
+
+	na, ok := objSchema.(singleNestedAttribute)
+	if !ok {
 		return
 	}
 
 	validator := objSchema.Validator()
 	validator.ValidateAttr(obj, objPath, diags)
 
-	for name, attrSchema := range objSchema.Attributes {
+	for name, attrSchema := range na.Attributes {
 		attrPath := objPath.GetAttr(name)
 		attrVal := obj.GetAttr(name)
 
-		if a, e := attrVal.Type(), attrSchema.SchemaAttribute().Type; a != e {
-			*diags = diags.Append(attributeErrDiag(
-				"Internal Error",
-				fmt.Sprintf(`Expected type to be %s, got: %s`, e.FriendlyName(), a.FriendlyName()),
-				attrPath,
-			))
-			continue
-		}
-
-		if attrVal.IsNull() {
-			if attrSchema.SchemaAttribute().Required {
-				*diags = diags.Append(requiredAttributeErrDiag(attrPath))
-			}
-			continue
-		}
-
-		validator := attrSchema.Validator()
-		validator.ValidateAttr(attrVal, attrPath, diags)
-	}
-}
-
-func validateListNestedAttribute(listSchema listNestedAttribute, val cty.Value, path cty.Path, diags *tfdiags.Diagnostics) {
-	if val.IsNull() {
-		return
-	}
-
-	validator := listSchema.Validator()
-	validator.ValidateAttr(val, path, diags)
-
-	eltPath := make(cty.Path, len(path)+1)
-	copy(eltPath, path)
-	idxIdx := len(path)
-
-	iter := val.ElementIterator()
-	for iter.Next() {
-		idx, elt := iter.Element()
-
-		eltPath[idxIdx] = cty.IndexStep{Key: idx}
-
-		validateNestedObject(listSchema.NestedObject, elt, eltPath, diags)
-	}
-}
-
-func validateNestedObject(objSchema nestedObjectSchema, val cty.Value, path cty.Path, diags *tfdiags.Diagnostics) {
-	if val.IsNull() {
-		return
-	}
-
-	validator := objSchema.Validator()
-	validator.ValidateAttr(val, path, diags)
-
-	for name, attrSchema := range objSchema.Attributes {
-		attrPath := path.GetAttr(name)
-		attrVal := val.GetAttr(name)
-
 		if attrVal.IsNull() {
 			if attrSchema.SchemaAttribute().Required {
 				*diags = diags.Append(requiredAttributeErrDiag(attrPath))
@@ -1451,6 +1394,13 @@ func validateNestedObject(objSchema nestedObjectSchema, val cty.Value, path cty.
 				fmt.Sprintf(`Expected type to be %s, got: %s`, e.FriendlyName(), a.FriendlyName()),
 				attrPath,
 			))
+			continue
+		}
+
+		if attrVal.IsNull() {
+			if attrSchema.SchemaAttribute().Required {
+				*diags = diags.Append(requiredAttributeErrDiag(attrPath))
+			}
 			continue
 		}
 
@@ -1518,10 +1468,6 @@ func (v validateString) ValidateAttr(val cty.Value, attrPath cty.Path, diags *tf
 		}
 	}
 }
-
-type validateList struct{}
-
-func (v validateList) ValidateAttr(val cty.Value, attrPath cty.Path, diags *tfdiags.Diagnostics) {}
 
 type validateMap struct{}
 
@@ -1608,38 +1554,6 @@ func (s objectSchema) SchemaAttributes() map[string]*configschema.Attribute {
 		m[k] = v.SchemaAttribute()
 	}
 	return m
-}
-
-type nestedObjectSchema struct {
-	Attributes objectSchema
-	validateObject
-}
-
-func (a nestedObjectSchema) Validator() validateSchema {
-	return a.validateObject
-}
-
-var _ schemaAttribute = listNestedAttribute{}
-
-type listNestedAttribute struct {
-	NestedObject nestedObjectSchema
-	Required     bool
-	validateList
-}
-
-func (a listNestedAttribute) SchemaAttribute() *configschema.Attribute {
-	return &configschema.Attribute{
-		NestedType: &configschema.Object{
-			Nesting:    configschema.NestingList,
-			Attributes: a.NestedObject.Attributes.SchemaAttributes(),
-		},
-		Required: a.Required,
-		Optional: !a.Required,
-	}
-}
-
-func (a listNestedAttribute) Validator() validateSchema {
-	return a.validateList
 }
 
 var _ schemaAttribute = singleNestedAttribute{}

--- a/internal/backend/remote-state/s3/backend_complete_test.go
+++ b/internal/backend/remote-state/s3/backend_complete_test.go
@@ -726,11 +726,9 @@ func TestBackendConfig_Authentication_AssumeRoleNested(t *testing.T) {
 			config: map[string]any{
 				"access_key": servicemocks.MockStaticAccessKey,
 				"secret_key": servicemocks.MockStaticSecretKey,
-				"assume_role": []any{
-					map[string]any{
-						"role_arn":     servicemocks.MockStsAssumeRoleArn,
-						"session_name": servicemocks.MockStsAssumeRoleSessionName,
-					},
+				"assume_role": map[string]any{
+					"role_arn":     servicemocks.MockStsAssumeRoleArn,
+					"session_name": servicemocks.MockStsAssumeRoleSessionName,
 				},
 			},
 			ExpectedCredentialsValue: mockdata.MockStsAssumeRoleCredentials,
@@ -743,11 +741,9 @@ func TestBackendConfig_Authentication_AssumeRoleNested(t *testing.T) {
 		// WAS: "environment AWS_ACCESS_KEY_ID config AssumeRoleARN access key"
 		"from environment AWS_ACCESS_KEY_ID": {
 			config: map[string]any{
-				"assume_role": []any{
-					map[string]any{
-						"role_arn":     servicemocks.MockStsAssumeRoleArn,
-						"session_name": servicemocks.MockStsAssumeRoleSessionName,
-					},
+				"assume_role": map[string]any{
+					"role_arn":     servicemocks.MockStsAssumeRoleArn,
+					"session_name": servicemocks.MockStsAssumeRoleSessionName,
 				},
 			},
 			EnvironmentVariables: map[string]string{
@@ -848,11 +844,9 @@ aws_secret_access_key = SharedConfigurationSourceSecretKey
 		// WAS: "shared credentials default aws_access_key_id config AssumeRoleARN access key"
 		"from default profile": {
 			config: map[string]any{
-				"assume_role": []any{
-					map[string]any{
-						"role_arn":     servicemocks.MockStsAssumeRoleArn,
-						"session_name": servicemocks.MockStsAssumeRoleSessionName,
-					},
+				"assume_role": map[string]any{
+					"role_arn":     servicemocks.MockStsAssumeRoleArn,
+					"session_name": servicemocks.MockStsAssumeRoleSessionName,
 				},
 			},
 			ExpectedCredentialsValue: mockdata.MockStsAssumeRoleCredentials,
@@ -870,11 +864,9 @@ aws_secret_access_key = DefaultSharedCredentialsSecretKey
 		// WAS: "EC2 metadata access key config AssumeRoleARN access key"
 		"from EC2 metadata": {
 			config: map[string]any{
-				"assume_role": []any{
-					map[string]any{
-						"role_arn":     servicemocks.MockStsAssumeRoleArn,
-						"session_name": servicemocks.MockStsAssumeRoleSessionName,
-					},
+				"assume_role": map[string]any{
+					"role_arn":     servicemocks.MockStsAssumeRoleArn,
+					"session_name": servicemocks.MockStsAssumeRoleSessionName,
 				},
 			},
 			EnableEc2MetadataServer:  true,
@@ -888,11 +880,9 @@ aws_secret_access_key = DefaultSharedCredentialsSecretKey
 		// WAS: "ECS credentials access key config AssumeRoleARN access key"
 		"from ECS credentials": {
 			config: map[string]any{
-				"assume_role": []any{
-					map[string]any{
-						"role_arn":     servicemocks.MockStsAssumeRoleArn,
-						"session_name": servicemocks.MockStsAssumeRoleSessionName,
-					},
+				"assume_role": map[string]any{
+					"role_arn":     servicemocks.MockStsAssumeRoleArn,
+					"session_name": servicemocks.MockStsAssumeRoleSessionName,
 				},
 			},
 			EnableEcsCredentialsServer: true,
@@ -908,12 +898,10 @@ aws_secret_access_key = DefaultSharedCredentialsSecretKey
 			config: map[string]any{
 				"access_key": servicemocks.MockStaticAccessKey,
 				"secret_key": servicemocks.MockStaticSecretKey,
-				"assume_role": []any{
-					map[string]any{
-						"role_arn":     servicemocks.MockStsAssumeRoleArn,
-						"session_name": servicemocks.MockStsAssumeRoleSessionName,
-						"duration":     "1h",
-					},
+				"assume_role": map[string]any{
+					"role_arn":     servicemocks.MockStsAssumeRoleArn,
+					"session_name": servicemocks.MockStsAssumeRoleSessionName,
+					"duration":     "1h",
 				},
 			},
 			ExpectedCredentialsValue: mockdata.MockStsAssumeRoleCredentials,
@@ -928,12 +916,10 @@ aws_secret_access_key = DefaultSharedCredentialsSecretKey
 			config: map[string]any{
 				"access_key": servicemocks.MockStaticAccessKey,
 				"secret_key": servicemocks.MockStaticSecretKey,
-				"assume_role": []any{
-					map[string]any{
-						"role_arn":     servicemocks.MockStsAssumeRoleArn,
-						"session_name": servicemocks.MockStsAssumeRoleSessionName,
-						"external_id":  servicemocks.MockStsAssumeRoleExternalId,
-					},
+				"assume_role": map[string]any{
+					"role_arn":     servicemocks.MockStsAssumeRoleArn,
+					"session_name": servicemocks.MockStsAssumeRoleSessionName,
+					"external_id":  servicemocks.MockStsAssumeRoleExternalId,
 				},
 			},
 			ExpectedCredentialsValue: mockdata.MockStsAssumeRoleCredentials,
@@ -948,12 +934,10 @@ aws_secret_access_key = DefaultSharedCredentialsSecretKey
 			config: map[string]any{
 				"access_key": servicemocks.MockStaticAccessKey,
 				"secret_key": servicemocks.MockStaticSecretKey,
-				"assume_role": []any{
-					map[string]any{
-						"role_arn":     servicemocks.MockStsAssumeRoleArn,
-						"session_name": servicemocks.MockStsAssumeRoleSessionName,
-						"policy":       mockStsAssumeRolePolicy,
-					},
+				"assume_role": map[string]any{
+					"role_arn":     servicemocks.MockStsAssumeRoleArn,
+					"session_name": servicemocks.MockStsAssumeRoleSessionName,
+					"policy":       mockStsAssumeRolePolicy,
 				},
 			},
 			ExpectedCredentialsValue: mockdata.MockStsAssumeRoleCredentials,
@@ -968,12 +952,10 @@ aws_secret_access_key = DefaultSharedCredentialsSecretKey
 			config: map[string]any{
 				"access_key": servicemocks.MockStaticAccessKey,
 				"secret_key": servicemocks.MockStaticSecretKey,
-				"assume_role": []any{
-					map[string]any{
-						"role_arn":     servicemocks.MockStsAssumeRoleArn,
-						"session_name": servicemocks.MockStsAssumeRoleSessionName,
-						"policy_arns":  []any{servicemocks.MockStsAssumeRolePolicyArn},
-					},
+				"assume_role": map[string]any{
+					"role_arn":     servicemocks.MockStsAssumeRoleArn,
+					"session_name": servicemocks.MockStsAssumeRoleSessionName,
+					"policy_arns":  []any{servicemocks.MockStsAssumeRolePolicyArn},
 				},
 			},
 			ExpectedCredentialsValue: mockdata.MockStsAssumeRoleCredentials,
@@ -988,13 +970,11 @@ aws_secret_access_key = DefaultSharedCredentialsSecretKey
 			config: map[string]any{
 				"access_key": servicemocks.MockStaticAccessKey,
 				"secret_key": servicemocks.MockStaticSecretKey,
-				"assume_role": []any{
-					map[string]any{
-						"role_arn":     servicemocks.MockStsAssumeRoleArn,
-						"session_name": servicemocks.MockStsAssumeRoleSessionName,
-						"tags": map[string]any{
-							servicemocks.MockStsAssumeRoleTagKey: servicemocks.MockStsAssumeRoleTagValue,
-						},
+				"assume_role": map[string]any{
+					"role_arn":     servicemocks.MockStsAssumeRoleArn,
+					"session_name": servicemocks.MockStsAssumeRoleSessionName,
+					"tags": map[string]any{
+						servicemocks.MockStsAssumeRoleTagKey: servicemocks.MockStsAssumeRoleTagValue,
 					},
 				},
 			},
@@ -1010,15 +990,13 @@ aws_secret_access_key = DefaultSharedCredentialsSecretKey
 			config: map[string]any{
 				"access_key": servicemocks.MockStaticAccessKey,
 				"secret_key": servicemocks.MockStaticSecretKey,
-				"assume_role": []any{
-					map[string]any{
-						"role_arn":     servicemocks.MockStsAssumeRoleArn,
-						"session_name": servicemocks.MockStsAssumeRoleSessionName,
-						"tags": map[string]any{
-							servicemocks.MockStsAssumeRoleTagKey: servicemocks.MockStsAssumeRoleTagValue,
-						},
-						"transitive_tag_keys": []any{servicemocks.MockStsAssumeRoleTagKey},
+				"assume_role": map[string]any{
+					"role_arn":     servicemocks.MockStsAssumeRoleArn,
+					"session_name": servicemocks.MockStsAssumeRoleSessionName,
+					"tags": map[string]any{
+						servicemocks.MockStsAssumeRoleTagKey: servicemocks.MockStsAssumeRoleTagValue,
 					},
+					"transitive_tag_keys": []any{servicemocks.MockStsAssumeRoleTagKey},
 				},
 			},
 			ExpectedCredentialsValue: mockdata.MockStsAssumeRoleCredentials,
@@ -1033,12 +1011,10 @@ aws_secret_access_key = DefaultSharedCredentialsSecretKey
 			config: map[string]any{
 				"access_key": servicemocks.MockStaticAccessKey,
 				"secret_key": servicemocks.MockStaticSecretKey,
-				"assume_role": []any{
-					map[string]any{
-						"role_arn":        servicemocks.MockStsAssumeRoleArn,
-						"session_name":    servicemocks.MockStsAssumeRoleSessionName,
-						"source_identity": servicemocks.MockStsAssumeRoleSourceIdentity,
-					},
+				"assume_role": map[string]any{
+					"role_arn":        servicemocks.MockStsAssumeRoleArn,
+					"session_name":    servicemocks.MockStsAssumeRoleSessionName,
+					"source_identity": servicemocks.MockStsAssumeRoleSourceIdentity,
 				},
 			},
 			ExpectedCredentialsValue: mockdata.MockStsAssumeRoleCredentials,
@@ -1053,11 +1029,9 @@ aws_secret_access_key = DefaultSharedCredentialsSecretKey
 			config: map[string]any{
 				"access_key": servicemocks.MockStaticAccessKey,
 				"secret_key": servicemocks.MockStaticSecretKey,
-				"assume_role": []any{
-					map[string]any{
-						"role_arn":     servicemocks.MockStsAssumeRoleArn,
-						"session_name": servicemocks.MockStsAssumeRoleSessionName,
-					},
+				"assume_role": map[string]any{
+					"role_arn":     servicemocks.MockStsAssumeRoleArn,
+					"session_name": servicemocks.MockStsAssumeRoleSessionName,
 				},
 			},
 			MockStsEndpoints: []*servicemocks.MockEndpoint{
@@ -1077,17 +1051,15 @@ aws_secret_access_key = DefaultSharedCredentialsSecretKey
 			config: map[string]any{
 				"access_key": servicemocks.MockStaticAccessKey,
 				"secret_key": servicemocks.MockStaticSecretKey,
-				"assume_role": []any{
-					map[string]any{
-						"role_arn": "",
-					},
+				"assume_role": map[string]any{
+					"role_arn": "",
 				},
 			},
 			ValidateDiags: ExpectDiagsEqual(tfdiags.Diagnostics{
 				attributeErrDiag(
 					"Invalid Value",
 					"The value cannot be empty or all whitespace",
-					cty.GetAttrPath("assume_role").IndexInt(0).GetAttr("role_arn"),
+					cty.GetAttrPath("assume_role").GetAttr("role_arn"),
 				),
 			}),
 		},
@@ -1096,18 +1068,16 @@ aws_secret_access_key = DefaultSharedCredentialsSecretKey
 			config: map[string]any{
 				"access_key": servicemocks.MockStaticAccessKey,
 				"secret_key": servicemocks.MockStaticSecretKey,
-				"assume_role": []any{
-					map[string]any{
-						"role_arn": nil,
-					},
+				"assume_role": map[string]any{
+					"role_arn": nil,
 				},
 			},
 			ValidateDiags: ExpectDiagsEqual(tfdiags.Diagnostics{
 				attributeErrDiag(
 					"Missing Required Value",
-					`The attribute "assume_role[0].role_arn" is required by the backend.`+"\n\n"+
+					`The attribute "assume_role.role_arn" is required by the backend.`+"\n\n"+
 						"Refer to the backend documentation for additional information which attributes are required.",
-					cty.GetAttrPath("assume_role").IndexInt(0).GetAttr("role_arn"),
+					cty.GetAttrPath("assume_role").GetAttr("role_arn"),
 				),
 			}),
 		},

--- a/internal/backend/remote-state/s3/backend_test.go
+++ b/internal/backend/remote-state/s3/backend_test.go
@@ -2459,7 +2459,7 @@ func TestAssumeRole_PrepareConfigValidation(t *testing.T) {
 				attributeErrDiag(
 					"Invalid ARN",
 					`The value "not an arn" cannot be parsed as an ARN: arn: invalid prefix`,
-					path.IndexInt(0).GetAttr("role_arn"),
+					path.GetAttr("role_arn"),
 				),
 			},
 		},
@@ -2467,14 +2467,14 @@ func TestAssumeRole_PrepareConfigValidation(t *testing.T) {
 		"no role_arn": {
 			config: map[string]cty.Value{},
 			expectedDiags: tfdiags.Diagnostics{
-				requiredAttributeErrDiag(path.IndexInt(0).GetAttr("role_arn")),
+				requiredAttributeErrDiag(path.GetAttr("role_arn")),
 			},
 		},
 
 		"nil role_arn": {
 			config: map[string]cty.Value{},
 			expectedDiags: tfdiags.Diagnostics{
-				requiredAttributeErrDiag(path.IndexInt(0).GetAttr("role_arn")),
+				requiredAttributeErrDiag(path.GetAttr("role_arn")),
 			},
 		},
 
@@ -2486,7 +2486,7 @@ func TestAssumeRole_PrepareConfigValidation(t *testing.T) {
 				attributeErrDiag(
 					"Invalid Value",
 					"The value cannot be empty or all whitespace",
-					path.IndexInt(0).GetAttr("role_arn"),
+					path.GetAttr("role_arn"),
 				),
 			},
 		},
@@ -2507,7 +2507,7 @@ func TestAssumeRole_PrepareConfigValidation(t *testing.T) {
 				attributeErrDiag(
 					"Invalid Duration",
 					`The value "two hours" cannot be parsed as a duration: time: invalid duration "two hours"`,
-					path.IndexInt(0).GetAttr("duration"),
+					path.GetAttr("duration"),
 				),
 			},
 		},
@@ -2528,7 +2528,7 @@ func TestAssumeRole_PrepareConfigValidation(t *testing.T) {
 				attributeErrDiag(
 					"Invalid Value Length",
 					`Length must be between 2 and 1224, had 0`,
-					path.IndexInt(0).GetAttr("external_id"),
+					path.GetAttr("external_id"),
 				),
 			},
 		},
@@ -2549,7 +2549,7 @@ func TestAssumeRole_PrepareConfigValidation(t *testing.T) {
 				attributeErrDiag(
 					"Invalid Value",
 					`The value cannot be empty or all whitespace`,
-					path.IndexInt(0).GetAttr("policy"),
+					path.GetAttr("policy"),
 				),
 			},
 		},
@@ -2574,7 +2574,7 @@ func TestAssumeRole_PrepareConfigValidation(t *testing.T) {
 				attributeErrDiag(
 					"Invalid ARN",
 					`The value "not an arn" cannot be parsed as an ARN: arn: invalid prefix`,
-					path.IndexInt(0).GetAttr("policy_arns").IndexString("not an arn"),
+					path.GetAttr("policy_arns").IndexString("not an arn"),
 				),
 			},
 		},
@@ -2614,7 +2614,7 @@ func TestAssumeRole_PrepareConfigValidation(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			schema := assumeRoleSchema.NestedObject.Attributes
+			schema := assumeRoleSchema.Attributes
 			vals := make(map[string]cty.Value, len(schema))
 			for name, attrSchema := range schema {
 				if val, ok := tc.config[name]; ok {
@@ -2623,10 +2623,10 @@ func TestAssumeRole_PrepareConfigValidation(t *testing.T) {
 					vals[name] = cty.NullVal(attrSchema.SchemaAttribute().Type)
 				}
 			}
-			config := cty.ListVal([]cty.Value{cty.ObjectVal(vals)})
+			config := cty.ObjectVal(vals)
 
 			var diags tfdiags.Diagnostics
-			validateListNestedAttribute(assumeRoleSchema, config, path, &diags)
+			validateNestedAttribute(assumeRoleSchema, config, path, &diags)
 
 			if diff := cmp.Diff(diags, tc.expectedDiags, cmp.Comparer(diagnosticComparer)); diff != "" {
 				t.Errorf("unexpected diagnostics difference: %s", diff)
@@ -2670,22 +2670,18 @@ func TestBackend_CoerceValue(t *testing.T) {
 			Input: cty.ObjectVal(map[string]cty.Value{
 				"bucket": cty.StringVal("test"),
 				"key":    cty.StringVal("test"),
-				"assume_role": cty.ListVal([]cty.Value{
-					cty.ObjectVal(map[string]cty.Value{
-						"role_arn": cty.StringVal("test"),
-					}),
+				"assume_role": cty.ObjectVal(map[string]cty.Value{
+					"role_arn": cty.StringVal("test"),
 				}),
 			}),
 		},
 		"assume_role missing role_arn": {
 			Input: cty.ObjectVal(map[string]cty.Value{
-				"bucket": cty.StringVal("test"),
-				"key":    cty.StringVal("test"),
-				"assume_role": cty.ListVal([]cty.Value{
-					cty.ObjectVal(map[string]cty.Value{}),
-				}),
+				"bucket":      cty.StringVal("test"),
+				"key":         cty.StringVal("test"),
+				"assume_role": cty.ObjectVal(map[string]cty.Value{}),
 			}),
-			WantErr: `.assume_role: incorrect list element type: attribute "role_arn" is required`,
+			WantErr: `.assume_role: attribute "role_arn" is required`,
 		},
 		"assume_role_with_web_identity": {
 			Input: cty.ObjectVal(map[string]cty.Value{
@@ -2946,8 +2942,8 @@ func unmarshal(value cty.Value, ty cty.Type, path cty.Path) (cty.Value, error) {
 	switch {
 	case ty.IsPrimitiveType():
 		return value, nil
-	case ty.IsListType():
-		return unmarshalList(value, ty.ElementType(), path)
+	// case ty.IsListType():
+	// 	return unmarshalList(value, ty.ElementType(), path)
 	case ty.IsSetType():
 		return unmarshalSet(value, ty.ElementType(), path)
 	case ty.IsMapType():
@@ -2974,7 +2970,6 @@ func unmarshalSet(dec cty.Value, ety cty.Type, path cty.Path) (cty.Value, error)
 
 	vals := make([]cty.Value, 0, length)
 	dec.ForEachElement(func(key, val cty.Value) (stop bool) {
-		// vals = append(vals, must(unmarshal(val, ety, path.Index(key))))
 		vals = append(vals, val)
 		return
 	})
@@ -2982,25 +2977,25 @@ func unmarshalSet(dec cty.Value, ety cty.Type, path cty.Path) (cty.Value, error)
 	return cty.SetVal(vals), nil
 }
 
-func unmarshalList(dec cty.Value, ety cty.Type, path cty.Path) (cty.Value, error) {
-	if dec.IsNull() {
-		return dec, nil
-	}
+// func unmarshalList(dec cty.Value, ety cty.Type, path cty.Path) (cty.Value, error) {
+// 	if dec.IsNull() {
+// 		return dec, nil
+// 	}
 
-	length := dec.LengthInt()
+// 	length := dec.LengthInt()
 
-	if length == 0 {
-		return cty.ListValEmpty(ety), nil
-	}
+// 	if length == 0 {
+// 		return cty.ListValEmpty(ety), nil
+// 	}
 
-	vals := make([]cty.Value, 0, length)
-	dec.ForEachElement(func(key, val cty.Value) (stop bool) {
-		vals = append(vals, must(unmarshal(val, ety, path.Index(key))))
-		return
-	})
+// 	vals := make([]cty.Value, 0, length)
+// 	dec.ForEachElement(func(key, val cty.Value) (stop bool) {
+// 		vals = append(vals, must(unmarshal(val, ety, path.Index(key))))
+// 		return
+// 	})
 
-	return cty.ListVal(vals), nil
-}
+// 	return cty.ListVal(vals), nil
+// }
 
 func unmarshalMap(dec cty.Value, ety cty.Type, path cty.Path) (cty.Value, error) {
 	if dec.IsNull() {
@@ -3016,7 +3011,6 @@ func unmarshalMap(dec cty.Value, ety cty.Type, path cty.Path) (cty.Value, error)
 	vals := make(map[string]cty.Value, length)
 	dec.ForEachElement(func(key, val cty.Value) (stop bool) {
 		k := stringValue(key)
-		// vals[k] = must(unmarshal(val, ety, path.Index(key)))
 		vals[k] = val
 		return
 	})


### PR DESCRIPTION
The PR #35720 introduced a breaking change to the S3 backend

IAM role chaining will be re-introduced at a later date

Fixes #35816

## Draft CHANGELOG entry

No CHANGELOG entry: reverts feature only present in alpha build