### PR TITLE
stacks: skip full plan/apply cycles when deleting empty state

### DIFF
--- a/internal/stacks/stackruntime/apply_destroy_test.go
+++ b/internal/stacks/stackruntime/apply_destroy_test.go
@@ -999,6 +999,193 @@ func TestApplyDestroy(t *testing.T) {
 				},
 			},
 		},
+		"empty-destroy-with-data-source": {
+			path: path.Join("with-data-source", "dependent"),
+			cycles: []TestCycle{
+				{
+					planMode: plans.DestroyMode,
+					planInputs: map[string]cty.Value{
+						"id": cty.StringVal("foo"),
+					},
+					// deliberately empty, as we expect no changes from an
+					// empty state.
+					wantAppliedChanges: []stackstate.AppliedChange{
+						&stackstate.AppliedChangeComponentInstanceRemoved{
+							ComponentAddr:         mustAbsComponent("component.data"),
+							ComponentInstanceAddr: mustAbsComponentInstance("component.data"),
+						},
+						&stackstate.AppliedChangeComponentInstanceRemoved{
+							ComponentAddr:         mustAbsComponent("component.self"),
+							ComponentInstanceAddr: mustAbsComponentInstance("component.self"),
+						},
+						&stackstate.AppliedChangeInputVariable{
+							Addr: mustStackInputVariable("id"),
+						},
+					},
+				},
+			},
+		},
+		"partial destroy recovery": {
+			path:        "component-chain",
+			description: "this test simulates a partial destroy recovery",
+			state: stackstate.NewStateBuilder().
+				// we only have data for the first component, indicating that
+				// the second and third components were destroyed but not the
+				// first one for some reason
+				AddComponentInstance(stackstate.NewComponentInstanceBuilder(mustAbsComponentInstance("component.one")).
+					AddDependent(mustAbsComponent("component.two")).
+					AddInputVariable("id", cty.StringVal("one")).
+					AddInputVariable("value", cty.StringVal("foo")).
+					AddOutputValue("value", cty.StringVal("foo"))).
+				AddResourceInstance(stackstate.NewResourceInstanceBuilder().
+					SetAddr(mustAbsResourceInstanceObject("component.one.testing_resource.data")).
+					SetProviderAddr(mustDefaultRootProvider("testing")).
+					SetResourceInstanceObjectSrc(states.ResourceInstanceObjectSrc{
+						AttrsJSON: mustMarshalJSONAttrs(map[string]interface{}{
+							"id":    "one",
+							"value": "foo",
+						}),
+						Status: states.ObjectReady,
+					})).
+				AddInput("value", cty.StringVal("foo")).
+				AddOutput("value", cty.StringVal("foo")).
+				Build(),
+			store: stacks_testing_provider.NewResourceStoreBuilder().
+				AddResource("one", cty.ObjectVal(map[string]cty.Value{
+					"id":    cty.StringVal("one"),
+					"value": cty.StringVal("foo"),
+				})).
+				Build(),
+			cycles: []TestCycle{
+				{
+					planMode: plans.DestroyMode,
+					planInputs: map[string]cty.Value{
+						"value": cty.StringVal("foo"),
+					},
+					wantPlannedChanges: []stackplan.PlannedChange{
+						&stackplan.PlannedChangeApplyable{
+							Applyable: true,
+						},
+						&stackplan.PlannedChangeComponentInstance{
+							Addr:          mustAbsComponentInstance("component.one"),
+							Action:        plans.Delete,
+							Mode:          plans.DestroyMode,
+							PlanComplete:  true,
+							PlanApplyable: true,
+							PlannedInputValues: map[string]plans.DynamicValue{
+								"id":    mustPlanDynamicValueDynamicType(cty.StringVal("one")),
+								"value": mustPlanDynamicValueDynamicType(cty.StringVal("foo")),
+							},
+							PlannedInputValueMarks: map[string][]cty.PathValueMarks{
+								"id":    nil,
+								"value": nil,
+							},
+							PlannedOutputValues: map[string]cty.Value{
+								"value": cty.StringVal("foo"),
+							},
+							PlannedCheckResults: &states.CheckResults{},
+							PlanTimestamp:       fakePlanTimestamp,
+						},
+						&stackplan.PlannedChangeResourceInstancePlanned{
+							ResourceInstanceObjectAddr: mustAbsResourceInstanceObject("component.one.testing_resource.data"),
+							ChangeSrc: &plans.ResourceInstanceChangeSrc{
+								Addr:         mustAbsResourceInstance("testing_resource.data"),
+								PrevRunAddr:  mustAbsResourceInstance("testing_resource.data"),
+								ProviderAddr: mustDefaultRootProvider("testing"),
+								ChangeSrc: plans.ChangeSrc{
+									Action: plans.Delete,
+									Before: mustPlanDynamicValue(cty.ObjectVal(map[string]cty.Value{
+										"id":    cty.StringVal("one"),
+										"value": cty.StringVal("foo"),
+									})),
+									After: mustPlanDynamicValue(cty.NullVal(cty.Object(map[string]cty.Type{
+										"id":    cty.String,
+										"value": cty.String,
+									}))),
+								},
+							},
+							PriorStateSrc: &states.ResourceInstanceObjectSrc{
+								AttrsJSON: mustMarshalJSONAttrs(map[string]interface{}{
+									"id":    "one",
+									"value": "foo",
+								}),
+								Status:       states.ObjectReady,
+								Dependencies: make([]addrs.ConfigResource, 0),
+							},
+							ProviderConfigAddr: mustDefaultRootProvider("testing"),
+							Schema:             stacks_testing_provider.TestingResourceSchema,
+						},
+						&stackplan.PlannedChangeComponentInstance{
+							Addr:               mustAbsComponentInstance("component.three"),
+							Action:             plans.Delete,
+							Mode:               plans.DestroyMode,
+							PlanComplete:       true,
+							PlanApplyable:      true,
+							RequiredComponents: collections.NewSet(mustAbsComponent("component.two")),
+							PlannedOutputValues: map[string]cty.Value{
+								"value": cty.DynamicVal,
+							},
+							PlanTimestamp: fakePlanTimestamp,
+						},
+						&stackplan.PlannedChangeComponentInstance{
+							Addr:               mustAbsComponentInstance("component.two"),
+							Action:             plans.Delete,
+							Mode:               plans.DestroyMode,
+							PlanComplete:       true,
+							PlanApplyable:      true,
+							RequiredComponents: collections.NewSet(mustAbsComponent("component.one")),
+							PlannedOutputValues: map[string]cty.Value{
+								"value": cty.DynamicVal,
+							},
+							PlanTimestamp: fakePlanTimestamp,
+						},
+						&stackplan.PlannedChangeHeader{
+							TerraformVersion: version.SemVer,
+						},
+						&stackplan.PlannedChangeOutputValue{
+							Addr:   mustStackOutputValue("value"),
+							Action: plans.Delete,
+							Before: cty.StringVal("foo"),
+							After:  cty.NullVal(cty.String),
+						},
+						&stackplan.PlannedChangePlannedTimestamp{
+							PlannedTimestamp: fakePlanTimestamp,
+						},
+						&stackplan.PlannedChangeRootInputValue{
+							Addr:          mustStackInputVariable("value"),
+							Action:        plans.NoOp,
+							Before:        cty.StringVal("foo"),
+							After:         cty.StringVal("foo"),
+							DeleteOnApply: true,
+						},
+					},
+					wantAppliedChanges: []stackstate.AppliedChange{
+						&stackstate.AppliedChangeComponentInstanceRemoved{
+							ComponentAddr:         mustAbsComponent("component.one"),
+							ComponentInstanceAddr: mustAbsComponentInstance("component.one"),
+						},
+						&stackstate.AppliedChangeResourceInstanceObject{
+							ResourceInstanceObjectAddr: mustAbsResourceInstanceObject("component.one.testing_resource.data"),
+							ProviderConfigAddr:         mustDefaultRootProvider("testing"),
+						},
+						&stackstate.AppliedChangeComponentInstanceRemoved{
+							ComponentAddr:         mustAbsComponent("component.three"),
+							ComponentInstanceAddr: mustAbsComponentInstance("component.three"),
+						},
+						&stackstate.AppliedChangeComponentInstanceRemoved{
+							ComponentAddr:         mustAbsComponent("component.two"),
+							ComponentInstanceAddr: mustAbsComponentInstance("component.two"),
+						},
+						&stackstate.AppliedChangeOutputValue{
+							Addr: mustStackOutputValue("value"),
+						},
+						&stackstate.AppliedChangeInputVariable{
+							Addr: mustStackInputVariable("value"),
+						},
+					},
+				},
+			},
+		},
 	}
 	for name, tc := range tcs {
 		t.Run(name, func(t *testing.T) {

--- a/internal/stacks/stackruntime/testdata/mainbundle/test/auth-provider-w-data/auth-provider-w-data.tfstack.hcl
+++ b/internal/stacks/stackruntime/testdata/mainbundle/test/auth-provider-w-data/auth-provider-w-data.tfstack.hcl
@@ -10,6 +10,7 @@ provider "testing" "main" {}
 
 provider "testing" "credentialed" {
   config {
+    require_auth = true
     authentication = component.load.credentials
   }
 }

--- a/internal/stacks/stackruntime/testdata/mainbundle/test/auth-provider-w-data/removed/removed.tfstack.hcl
+++ b/internal/stacks/stackruntime/testdata/mainbundle/test/auth-provider-w-data/removed/removed.tfstack.hcl
@@ -10,6 +10,7 @@ provider "testing" "main" {}
 
 provider "testing" "credentialed" {
   config {
+    require_auth = true
     authentication = component.load.credentials
   }
 }

--- a/internal/stacks/stackruntime/testdata/mainbundle/test/component-chain/component-chain.tf
+++ b/internal/stacks/stackruntime/testdata/mainbundle/test/component-chain/component-chain.tf
@@ -1,0 +1,28 @@
+terraform {
+  required_providers {
+    testing = {
+      source  = "hashicorp/testing"
+      version = "0.1.0"
+    }
+  }
+}
+
+
+variable "id" {
+  type     = string
+  default  = null
+  nullable = true # We'll generate an ID if none provided.
+}
+
+variable "value" {
+  type = string
+}
+
+resource "testing_resource" "data" {
+  id    = var.id
+  value = var.value
+}
+
+output "value" {
+  value = testing_resource.data.value
+}

--- a/internal/stacks/stackruntime/testdata/mainbundle/test/component-chain/component-chain.tfstack.hcl
+++ b/internal/stacks/stackruntime/testdata/mainbundle/test/component-chain/component-chain.tfstack.hcl
@@ -1,0 +1,56 @@
+required_providers {
+  testing = {
+    source  = "hashicorp/testing"
+    version = "0.1.0"
+  }
+}
+
+provider "testing" "default" {}
+
+variable "value" {
+  type = string
+}
+
+component "one" {
+  source = "./"
+
+  providers = {
+    testing = provider.testing.default
+  }
+
+  inputs = {
+    id = "one"
+    value = var.value
+  }
+}
+
+component "two" {
+  source = "./"
+
+  providers = {
+    testing = provider.testing.default
+  }
+
+  inputs = {
+    id = "two"
+    value = component.one.value
+  }
+}
+
+component "three" {
+  source = "./"
+
+  providers = {
+    testing = provider.testing.default
+  }
+
+  inputs = {
+    id = "three"
+    value = component.two.value
+  }
+}
+
+output "value" {
+  value = component.three.value
+  type = string
+}

--- a/internal/stacks/stackruntime/testdata/mainbundle/test/with-data-source/dependent/dependent.tf
+++ b/internal/stacks/stackruntime/testdata/mainbundle/test/with-data-source/dependent/dependent.tf
@@ -1,0 +1,21 @@
+terraform {
+  required_providers {
+    testing = {
+      source  = "hashicorp/testing"
+      version = "0.1.0"
+    }
+  }
+}
+
+variable "id" {
+  type = string
+}
+
+resource "testing_resource" "data" {
+  count = 1
+  id    = var.id
+}
+
+output "id" {
+  value = try(testing_resource.data[0].id, null)
+}

--- a/internal/stacks/stackruntime/testdata/mainbundle/test/with-data-source/dependent/dependent.tfstack.hcl
+++ b/internal/stacks/stackruntime/testdata/mainbundle/test/with-data-source/dependent/dependent.tfstack.hcl
@@ -1,0 +1,37 @@
+required_providers {
+  testing = {
+    source  = "hashicorp/testing"
+    version = "0.1.0"
+  }
+}
+
+provider "testing" "default" {}
+
+variable "id" {
+  type = string
+}
+
+component "self" {
+  source = "./"
+
+  providers = {
+    testing = provider.testing.default
+  }
+
+  inputs = {
+    id = var.id
+  }
+}
+
+component "data" {
+  source = "../"
+
+  providers = {
+    testing = provider.testing.default
+  }
+
+  inputs = {
+    id = component.self.id
+    resource = "resource"
+  }
+}


### PR DESCRIPTION
This PR updates the component instance plan and apply operations so that if there is no state during the plan, or no changes during the apply, we no longer actually execute a full plan or apply operation.

This was causing issues during the refresh with modules that return null or unknown values for non-existent resources. These values were then being used as inputs into the delete and refresh operations for other empty components. Since data sources are still loaded during the refresh we would then see errors as a result of null or unknown values during the apply operation.

After this PR if the whole component is not in state (so it's already been deleted or was never created) then we skip the actual operation and return pre-built values for the plan and state that don't require interactions with the other components.