### PR TITLE
Ephemeral expansion and add tests for ephemeral values

### DIFF
--- a/internal/terraform/context_plan_ephemeral_test.go
+++ b/internal/terraform/context_plan_ephemeral_test.go
@@ -11,71 +11,34 @@ import (
 	"github.com/hashicorp/terraform/internal/configs/configschema"
 	"github.com/hashicorp/terraform/internal/providers"
 	testing_provider "github.com/hashicorp/terraform/internal/providers/testing"
+	"github.com/hashicorp/terraform/internal/tfdiags"
 	"github.com/zclconf/go-cty/cty"
 )
 
-func TestContext2Plan_ephemeralBasic(t *testing.T) {
-	m := testModuleInline(t, map[string]string{
-		"main.tf": `
-ephemeral "test_resource" "data" {
+func TestContext2Plan_ephemeralValues(t *testing.T) {
+	for name, tc := range map[string]struct {
+		module                                      map[string]string
+		expectValidateDiagnostics                   []tfdiags.Diagnostic
+		expectPlanDiagnostics                       []tfdiags.Diagnostic
+		expectOpenEphemeralResourceCalled           bool
+		expectValidateEphemeralResourceConfigCalled bool
+		expectCloseEphemeralResourceCalled          bool
+		assertTestProviderConfigure                 func(req providers.ConfigureProviderRequest) (resp providers.ConfigureProviderResponse)
+	}{
+		"basic": {
+			module: map[string]string{
+				"main.tf": `
+ephemeral "ephem_resource" "data" {
 }
-`,
-	})
-
-	p := &testing_provider.MockProvider{
-		GetProviderSchemaResponse: &providers.GetProviderSchemaResponse{
-			EphemeralResourceTypes: map[string]providers.Schema{
-				"test_resource": {
-					Block: &configschema.Block{
-						Attributes: map[string]*configschema.Attribute{
-							"value": {
-								Type:     cty.String,
-								Computed: true,
-							},
-						},
-					},
-				},
-			},
+`},
+			expectOpenEphemeralResourceCalled:           true,
+			expectValidateEphemeralResourceConfigCalled: true,
+			expectCloseEphemeralResourceCalled:          true,
 		},
-	}
 
-	p.OpenEphemeralResourceFn = func(providers.OpenEphemeralResourceRequest) (resp providers.OpenEphemeralResourceResponse) {
-		resp.Result = cty.ObjectVal(map[string]cty.Value{
-			"value": cty.StringVal("test string"),
-		})
-		return resp
-	}
-
-	ctx := testContext2(t, &ContextOpts{
-		Providers: map[addrs.Provider]providers.Factory{
-			// The providers never actually going to get called here, we should
-			// catch the error long before anything happens.
-			addrs.NewDefaultProvider("test"): testProviderFuncFixed(p),
-		},
-	})
-
-	diags := ctx.Validate(m, &ValidateOpts{})
-	assertNoDiagnostics(t, diags)
-
-	if !p.ValidateEphemeralResourceConfigCalled {
-		t.Fatal("ValidateEphemeralResourceConfig not called")
-	}
-
-	_, diags = ctx.Plan(m, nil, DefaultPlanOpts)
-	assertNoDiagnostics(t, diags)
-
-	if !p.OpenEphemeralResourceCalled {
-		t.Fatal("OpenEphemeralResource not called")
-	}
-
-	if !p.CloseEphemeralResourceCalled {
-		t.Fatal("CloseEphemeralResource not called")
-	}
-}
-
-func TestContext2Plan_ephemeralProviderRef(t *testing.T) {
-	m := testModuleInline(t, map[string]string{
-		"main.tf": `
+		"provider reference": {
+			module: map[string]string{
+				"main.tf": `
 ephemeral "ephem_resource" "data" {
 }
 
@@ -86,56 +49,93 @@ provider "test" {
 resource "test_object" "test" {
 }
 `,
-	})
+			},
+			expectOpenEphemeralResourceCalled:           true,
+			expectValidateEphemeralResourceConfigCalled: true,
+			expectCloseEphemeralResourceCalled:          true,
+			assertTestProviderConfigure: func(req providers.ConfigureProviderRequest) (resp providers.ConfigureProviderResponse) {
+				if req.Config.GetAttr("test_string").AsString() != "test string" {
+					resp.Diagnostics = resp.Diagnostics.Append(fmt.Errorf("received config did not contain \"test string\", got %#v\n", req.Config))
+				}
+				return resp
+			},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			m := testModuleInline(t, tc.module)
 
-	ephem := &testing_provider.MockProvider{
-		GetProviderSchemaResponse: &providers.GetProviderSchemaResponse{
-			EphemeralResourceTypes: map[string]providers.Schema{
-				"ephem_resource": {
-					Block: &configschema.Block{
-						Attributes: map[string]*configschema.Attribute{
-							"value": {
-								Type:     cty.String,
-								Computed: true,
+			ephem := &testing_provider.MockProvider{
+				GetProviderSchemaResponse: &providers.GetProviderSchemaResponse{
+					EphemeralResourceTypes: map[string]providers.Schema{
+						"ephem_resource": {
+							Block: &configschema.Block{
+								Attributes: map[string]*configschema.Attribute{
+									"value": {
+										Type:     cty.String,
+										Computed: true,
+									},
+								},
 							},
 						},
 					},
 				},
-			},
-		},
-	}
+			}
 
-	ephem.OpenEphemeralResourceFn = func(providers.OpenEphemeralResourceRequest) (resp providers.OpenEphemeralResourceResponse) {
-		resp.Result = cty.ObjectVal(map[string]cty.Value{
-			"value": cty.StringVal("test string"),
+			ephem.OpenEphemeralResourceFn = func(providers.OpenEphemeralResourceRequest) (resp providers.OpenEphemeralResourceResponse) {
+				resp.Result = cty.ObjectVal(map[string]cty.Value{
+					"value": cty.StringVal("test string"),
+				})
+				return resp
+			}
+
+			p := simpleMockProvider()
+			p.ConfigureProviderFn = func(req providers.ConfigureProviderRequest) (resp providers.ConfigureProviderResponse) {
+				if tc.assertTestProviderConfigure != nil {
+					return tc.assertTestProviderConfigure(req)
+				}
+				return resp
+			}
+
+			ctx := testContext2(t, &ContextOpts{
+				Providers: map[addrs.Provider]providers.Factory{
+					// The providers never actually going to get called here, we should
+					// catch the error long before anything happens.
+					addrs.NewDefaultProvider("ephem"): testProviderFuncFixed(ephem),
+					addrs.NewDefaultProvider("test"):  testProviderFuncFixed(p),
+				},
+			})
+
+			diags := ctx.Validate(m, &ValidateOpts{})
+			if len(tc.expectValidateDiagnostics) > 0 {
+				assertDiagnosticsMatch(t, diags, tc.expectValidateDiagnostics)
+			} else {
+				assertNoDiagnostics(t, diags)
+			}
+
+			if tc.expectValidateEphemeralResourceConfigCalled {
+				if !ephem.ValidateEphemeralResourceConfigCalled {
+					t.Fatal("ValidateEphemeralResourceConfig not called")
+				}
+			}
+
+			_, diags = ctx.Plan(m, nil, DefaultPlanOpts)
+			if len(tc.expectPlanDiagnostics) > 0 {
+				assertDiagnosticsMatch(t, diags, tc.expectPlanDiagnostics)
+			} else {
+				assertNoDiagnostics(t, diags)
+			}
+
+			if tc.expectOpenEphemeralResourceCalled {
+				if !ephem.OpenEphemeralResourceCalled {
+					t.Fatal("OpenEphemeralResource not called")
+				}
+			}
+
+			if tc.expectCloseEphemeralResourceCalled {
+				if !ephem.CloseEphemeralResourceCalled {
+					t.Fatal("CloseEphemeralResource not called")
+				}
+			}
 		})
-		return resp
 	}
-
-	p := simpleMockProvider()
-	p.ConfigureProviderFn = func(req providers.ConfigureProviderRequest) (resp providers.ConfigureProviderResponse) {
-		if req.Config.GetAttr("test_string").AsString() != "test string" {
-			resp.Diagnostics = resp.Diagnostics.Append(fmt.Errorf("received config did not contain \"test string\", got %#v\n", req.Config))
-		}
-		return resp
-	}
-
-	ctx := testContext2(t, &ContextOpts{
-		Providers: map[addrs.Provider]providers.Factory{
-			// The providers never actually going to get called here, we should
-			// catch the error long before anything happens.
-			addrs.NewDefaultProvider("ephem"): testProviderFuncFixed(ephem),
-			addrs.NewDefaultProvider("test"):  testProviderFuncFixed(p),
-		},
-	})
-
-	diags := ctx.Validate(m, &ValidateOpts{})
-	assertNoDiagnostics(t, diags)
-
-	if !ephem.ValidateEphemeralResourceConfigCalled {
-		t.Fatal("ValidateEphemeralResourceConfig not called")
-	}
-
-	_, diags = ctx.Plan(m, nil, DefaultPlanOpts)
-	assertNoDiagnostics(t, diags)
 }

--- a/internal/terraform/context_plan_ephemeral_test.go
+++ b/internal/terraform/context_plan_ephemeral_test.go
@@ -89,6 +89,26 @@ resource "test_object" "test" {
 			},
 		},
 
+		"normal attribute": {
+			module: map[string]string{
+				"main.tf": `
+ephemeral "ephem_resource" "data" {
+}
+
+resource "test_object" "test" {
+  test_string = ephemeral.ephem_resource.data.value
+}
+`,
+			},
+			expectValidateDiagnostics: func(m *configs.Config) (diags tfdiags.Diagnostics) {
+				return diags.Append(&hcl.Diagnostic{
+					Severity: hcl.DiagError,
+					Summary:  "Invalid use of ephemeral value",
+					Detail:   "Ephemeral values are not valid in resource arguments, because resource instances must persist between Terraform phases.",
+				})
+			},
+		},
+
 		"provider reference through module": {
 			module: map[string]string{
 				"child/main.tf": `

--- a/internal/terraform/context_plan_ephemeral_test.go
+++ b/internal/terraform/context_plan_ephemeral_test.go
@@ -376,32 +376,6 @@ module "child" {
 			expectValidateEphemeralResourceConfigCalled: true,
 			expectCloseEphemeralResourceCalled:          true,
 		},
-
-		"function ephemeral": {
-			toBeImplemented: true,
-			module: map[string]string{
-				"child/main.tf": `
-
-# We expect this to error since it should be an ephemeral value
-output "value" {
-    value = ephemeral("hello world")
-}
-`,
-				"main.tf": `
-module "child" {
-    source = "./child"
-}
-			`,
-			},
-
-			expectValidateDiagnostics: func(m *configs.Config) (diags tfdiags.Diagnostics) {
-				return diags.Append(&hcl.Diagnostic{
-					Severity: hcl.DiagError,
-					Summary:  "Ephemeral value not allowed",
-					Detail:   "This output value is not declared as returning an ephemeral value, so it cannot be set to a result derived from an ephemeral value.",
-				})
-			},
-		},
 	} {
 		t.Run(name, func(t *testing.T) {
 			if tc.toBeImplemented {

--- a/internal/terraform/context_test.go
+++ b/internal/terraform/context_test.go
@@ -1020,6 +1020,35 @@ func assertDiagnosticsMatch(t *testing.T, got, want tfdiags.Diagnostics) {
 	}
 }
 
+type SummaryAndDetail struct {
+	Subject     string
+	Description string
+}
+
+// assertDiagnosticsSummaryAndDetailMatch fails the test in progress (using t.Fatal) if the
+// two sets of diagnostics don't match their subjects / descriptions after being normalized using the "ForRPC" processing step.
+func assertDiagnosticsSummaryAndDetailMatch(t *testing.T, got, want tfdiags.Diagnostics) {
+
+	got = got.ForRPC()
+	want = want.ForRPC()
+	got.Sort()
+	want.Sort()
+
+	gotSummaryAndDetail := make([]SummaryAndDetail, len(got))
+	for i, diag := range got {
+		gotSummaryAndDetail[i] = SummaryAndDetail{diag.Description().Summary, diag.Description().Detail}
+	}
+
+	wantSummaryAndDetail := make([]SummaryAndDetail, len(want))
+	for i, diag := range want {
+		wantSummaryAndDetail[i] = SummaryAndDetail{diag.Description().Summary, diag.Description().Detail}
+	}
+
+	if diff := cmp.Diff(wantSummaryAndDetail, gotSummaryAndDetail); diff != "" {
+		t.Fatalf("wrong diagnostics\n%s", diff)
+	}
+}
+
 // checkPlanCompleteAndApplyable reports testing errors if the plan is not
 // flagged as being both complete and applyable.
 //

--- a/internal/terraform/context_test.go
+++ b/internal/terraform/context_test.go
@@ -1029,7 +1029,6 @@ type SummaryAndDetail struct {
 // assertDiagnosticsSummaryAndDetailMatch fails the test in progress (using t.Fatal) if the
 // two sets of diagnostics don't match their subjects / descriptions after being normalized using the "ForRPC" processing step.
 func assertDiagnosticsSummaryAndDetailMatch(t *testing.T, got, want tfdiags.Diagnostics) {
-
 	got = got.ForRPC()
 	want = want.ForRPC()
 
@@ -1038,7 +1037,6 @@ func assertDiagnosticsSummaryAndDetailMatch(t *testing.T, got, want tfdiags.Diag
 
 	gotSummaryAndDetail := make([]SummaryAndDetail, len(got))
 	for i, diag := range got {
-
 		gotSummaryAndDetail[i] = SummaryAndDetail{diag.Severity(), diag.Description().Summary, diag.Description().Detail}
 	}
 

--- a/internal/terraform/context_test.go
+++ b/internal/terraform/context_test.go
@@ -1021,6 +1021,7 @@ func assertDiagnosticsMatch(t *testing.T, got, want tfdiags.Diagnostics) {
 }
 
 type SummaryAndDetail struct {
+	Severity    tfdiags.Severity
 	Subject     string
 	Description string
 }
@@ -1031,17 +1032,19 @@ func assertDiagnosticsSummaryAndDetailMatch(t *testing.T, got, want tfdiags.Diag
 
 	got = got.ForRPC()
 	want = want.ForRPC()
+
 	got.Sort()
 	want.Sort()
 
 	gotSummaryAndDetail := make([]SummaryAndDetail, len(got))
 	for i, diag := range got {
-		gotSummaryAndDetail[i] = SummaryAndDetail{diag.Description().Summary, diag.Description().Detail}
+
+		gotSummaryAndDetail[i] = SummaryAndDetail{diag.Severity(), diag.Description().Summary, diag.Description().Detail}
 	}
 
 	wantSummaryAndDetail := make([]SummaryAndDetail, len(want))
 	for i, diag := range want {
-		wantSummaryAndDetail[i] = SummaryAndDetail{diag.Description().Summary, diag.Description().Detail}
+		wantSummaryAndDetail[i] = SummaryAndDetail{diag.Severity(), diag.Description().Summary, diag.Description().Detail}
 	}
 
 	if diff := cmp.Diff(wantSummaryAndDetail, gotSummaryAndDetail); diff != "" {

--- a/internal/terraform/eval_count.go
+++ b/internal/terraform/eval_count.go
@@ -56,7 +56,7 @@ func evaluateCountExpression(expr hcl.Expression, ctx EvalContext, allowUnknown 
 		diags = diags.Append(&hcl.Diagnostic{
 			Severity: hcl.DiagError,
 			Summary:  "Invalid count argument",
-			Detail:   "The count value cannot depend on ephemeral values.",
+			Detail:   `The given "count" value is derived from an ephemeral value, which means that Terraform cannot persist it between plan/apply rounds. Use only non-ephemeral values here.`,
 			Subject:  expr.Range().Ptr(),
 			Extra:    diagnosticCausedByEphemeral(true),
 		})

--- a/internal/terraform/eval_count.go
+++ b/internal/terraform/eval_count.go
@@ -51,6 +51,18 @@ func evaluateCountExpression(expr hcl.Expression, ctx EvalContext, allowUnknown 
 		})
 	}
 
+	// Ephemeral values are not allowed in count expressions.
+	if countVal.HasMark(marks.Ephemeral) {
+		diags = diags.Append(&hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  "Invalid count argument",
+			Detail:   "The count value cannot depend on ephemeral values.",
+			Subject:  expr.Range().Ptr(),
+			Extra:    diagnosticCausedByEphemeral(true),
+		})
+		return -1, diags
+	}
+
 	if countVal.IsNull() || !countVal.IsKnown() {
 		return -1, diags
 	}

--- a/internal/terraform/eval_for_each.go
+++ b/internal/terraform/eval_for_each.go
@@ -130,6 +130,9 @@ func (ev *forEachEvaluator) ImportValues() ([]instances.RepetitionData, bool, tf
 		return res, false, diags
 	}
 
+	// ensure the value is not ephemeral
+	diags = diags.Append(ev.ensureNotEphemeral(forEachVal))
+
 	if forEachVal.IsNull() {
 		return res, true, diags
 	}
@@ -254,6 +257,27 @@ func (ev *forEachEvaluator) ensureKnownForResource(forEachVal cty.Value) tfdiags
 	return diags
 }
 
+// ensureNotEphemeral makes sure no ephemeral values are used in the for_each expression.
+func (ev *forEachEvaluator) ensureNotEphemeral(forEachVal cty.Value) tfdiags.Diagnostics {
+	var diags tfdiags.Diagnostics
+	// Ephemeral values are not allowed because instance keys persist from
+	// plan to apply and between plan/apply rounds, whereas ephemeral values
+	// do not.
+	if forEachVal.HasMark(marks.Ephemeral) {
+		diags = diags.Append(&hcl.Diagnostic{
+			Severity:    hcl.DiagError,
+			Summary:     "Invalid for_each argument",
+			Detail:      `The given "for_each" value is derived from an ephemeral value, which means that Terraform cannot persist it between plan/apply rounds. Use only non-ephemeral values to specify a resource's instance keys.`,
+			Subject:     ev.expr.Range().Ptr(),
+			Expression:  ev.expr,
+			EvalContext: ev.hclCtx,
+			Extra:       diagnosticCausedByEphemeral(true),
+		})
+	}
+
+	return diags
+}
+
 // ValidateResourceValue is used from validation walks to verify the validity
 // of the resource for_Each expression, while still allowing for unknown
 // values.
@@ -284,20 +308,8 @@ func (ev *forEachEvaluator) validateResource(forEachVal cty.Value) tfdiags.Diagn
 			Extra:       diagnosticCausedBySensitive(true),
 		})
 	}
-	// Ephemeral values are not allowed because instance keys persist from
-	// plan to apply and between plan/apply rounds, whereas ephemeral values
-	// do not.
-	if forEachVal.HasMark(marks.Ephemeral) {
-		diags = diags.Append(&hcl.Diagnostic{
-			Severity:    hcl.DiagError,
-			Summary:     "Invalid for_each argument",
-			Detail:      `The given "for_each" value is derived from an ephemeral value, which means that Terraform cannot persist it between plan/apply rounds. Use only non-ephemeral values to specify a resource's instance keys.`,
-			Subject:     ev.expr.Range().Ptr(),
-			Expression:  ev.expr,
-			EvalContext: ev.hclCtx,
-			Extra:       diagnosticCausedByEphemeral(true),
-		})
-	}
+
+	diags = diags.Append(ev.ensureNotEphemeral(forEachVal))
 
 	if diags.HasErrors() {
 		return diags


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

This PR ensures we check for ephemeral values for all possible expansions (for_each / count on resource / module / import).
It also refactors the plan tests and adds a lot of new tests for everything I could find in the RFC, some are skipped to leave the implementation to future PRs.

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.10.x

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

### ENHANCEMENTS

<!--

Write a short description of the user-facing change. Examples:

- `terraform show -json`: Fixed crash with sensitive set values.
- When rendering a diff, Terraform now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 

-  Ephemeral Values: Error if ephemeral values are used in the context of count or for_each