### PR TITLE
core: place ephemeral close nodes more acurately

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -101,7 +101,7 @@ described in a later section.
 
 The top-level configuration structure is represented by model types in
 [package `configs`](http://localhost:8080/github.com/hashicorp/terraform/internal/configs).
-A whole configuration (the root module plus all of its descendent modules)
+A whole configuration (the root module plus all of its descendant modules)
 is represented by
 [`configs.Config`](http://localhost:8080/github.com/hashicorp/terraform/internal/configs#Config).
 

--- a/internal/addrs/graph.go
+++ b/internal/addrs/graph.go
@@ -138,9 +138,9 @@ func (g DirectedGraph[T]) DirectDependentsOf(addr T) Set[T] {
 func (g DirectedGraph[T]) TransitiveDependentsOf(addr T) Set[T] {
 	k := addr.UniqueKey()
 	ret := MakeSet[T]()
-	raw, err := g.g.Descendents(k)
+	raw, err := g.g.Descendants(k)
 	if err != nil {
-		// It should be impossible for "Descendents" to fail
+		// It should be impossible for "Descendants" to fail
 		panic(err)
 	}
 	for otherKI := range raw {

--- a/internal/addrs/graph.go
+++ b/internal/addrs/graph.go
@@ -138,12 +138,7 @@ func (g DirectedGraph[T]) DirectDependentsOf(addr T) Set[T] {
 func (g DirectedGraph[T]) TransitiveDependentsOf(addr T) Set[T] {
 	k := addr.UniqueKey()
 	ret := MakeSet[T]()
-	raw, err := g.g.Descendants(k)
-	if err != nil {
-		// It should be impossible for "Descendants" to fail
-		panic(err)
-	}
-	for otherKI := range raw {
+	for otherKI := range g.g.Descendants(k) {
 		ret.Add(g.nodes[otherKI.(UniqueKey)])
 	}
 	return ret

--- a/internal/addrs/move_endpoint_module.go
+++ b/internal/addrs/move_endpoint_module.go
@@ -434,7 +434,7 @@ func (e *MoveEndpointInModule) NestedWithin(other *MoveEndpointInModule) bool {
 
 // matchModuleInstancePrefix is an internal helper to decide whether the given
 // module instance address refers to either the module where the move endpoint
-// was declared or some descendent of that module.
+// was declared or some descendant of that module.
 //
 // If so, it will split the given address into two parts: the "prefix" part
 // which corresponds with the module where the statement was declared, and

--- a/internal/command/import.go
+++ b/internal/command/import.go
@@ -113,7 +113,7 @@ func (c *ImportCommand) Run(args []string) int {
 	// This is to reduce the risk that a typo in the resource address will
 	// import something that Terraform will want to immediately destroy on
 	// the next plan, and generally acts as a reassurance of user intent.
-	targetConfig := config.DescendentForInstance(addr.Module)
+	targetConfig := config.DescendantForInstance(addr.Module)
 	if targetConfig == nil {
 		modulePath := addr.Module.String()
 		diags = diags.Append(&hcl.Diagnostic{

--- a/internal/command/jsonconfig/config.go
+++ b/internal/command/jsonconfig/config.go
@@ -520,9 +520,9 @@ func marshalResources(resources map[string]*configs.Resource, schemas *terraform
 	return rs, nil
 }
 
-// Flatten all resource provider keys in a module and its descendents, such
+// Flatten all resource provider keys in a module and its descendants, such
 // that any resources from providers using a configuration passed through the
-// module call have a direct refernce to that provider configuration.
+// module call have a direct reference to that provider configuration.
 func normalizeModuleProviderKeys(m *module, pcs map[string]providerConfig) {
 	for i, r := range m.Resources {
 		if pc, exists := pcs[r.ProviderConfigKey]; exists {

--- a/internal/command/meta_config.go
+++ b/internal/command/meta_config.go
@@ -36,7 +36,7 @@ func (m *Meta) normalizePath(path string) string {
 }
 
 // loadConfig reads a configuration from the given directory, which should
-// contain a root module and have already have any required descendent modules
+// contain a root module and have already have any required descendant modules
 // installed.
 func (m *Meta) loadConfig(rootDir string) (*configs.Config, tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
@@ -177,7 +177,7 @@ func (m *Meta) loadHCLFile(filename string) (hcl.Body, tfdiags.Diagnostics) {
 }
 
 // installModules reads a root module from the given directory and attempts
-// recursively to install all of its descendent modules.
+// recursively to install all of its descendant modules.
 //
 // The given hooks object will be notified of installation progress, which
 // can then be relayed to the end-user. The uiModuleInstallHooks type in

--- a/internal/command/state_meta.go
+++ b/internal/command/state_meta.go
@@ -105,7 +105,7 @@ func (c *StateMeta) lookupResourceInstanceAddr(state *states.State, allowMissing
 	switch addr := targetAddr.(type) {
 	case addrs.ModuleInstance:
 		// Matches all instances within the indicated module and all of its
-		// descendent modules.
+		// descendant modules.
 
 		// found is used to identify cases where the selected module has no
 		// resources, but one or more of its submodules does.

--- a/internal/command/test.go
+++ b/internal/command/test.go
@@ -128,7 +128,7 @@ func (c *TestCommand) Run(rawArgs []string) int {
 	}
 
 	// The specified testing directory must be a relative path, and it must
-	// point to a directory that is a descendent of the configuration directory.
+	// point to a directory that is a descendant of the configuration directory.
 	if !filepath.IsLocal(args.TestDirectory) {
 		diags = diags.Append(tfdiags.Sourceless(
 			tfdiags.Error,

--- a/internal/configs/config.go
+++ b/internal/configs/config.go
@@ -19,7 +19,7 @@ import (
 // A Config is a node in the tree of modules within a configuration.
 //
 // The module tree is constructed by following ModuleCall instances recursively
-// through the root module transitively into descendent modules.
+// through the root module transitively into descendant modules.
 //
 // A module tree described in *this* package represents the static tree
 // represented by configuration. During evaluation a static ModuleNode may
@@ -145,7 +145,7 @@ func (c *Config) DeepEach(cb func(c *Config)) {
 	}
 }
 
-// AllModules returns a slice of all the receiver and all of its descendent
+// AllModules returns a slice of all the receiver and all of its descendant
 // nodes in the module tree, in the same order they would be visited by
 // DeepEach.
 func (c *Config) AllModules() []*Config {
@@ -156,14 +156,14 @@ func (c *Config) AllModules() []*Config {
 	return ret
 }
 
-// Descendent returns the descendent config that has the given path beneath
+// Descendant returns the descendant config that has the given path beneath
 // the receiver, or nil if there is no such module.
 //
 // The path traverses the static module tree, prior to any expansion to handle
 // count and for_each arguments.
 //
 // An empty path will just return the receiver, and is therefore pointless.
-func (c *Config) Descendent(path addrs.Module) *Config {
+func (c *Config) Descendant(path addrs.Module) *Config {
 	current := c
 	for _, name := range path {
 		current = current.Children[name]
@@ -174,13 +174,13 @@ func (c *Config) Descendent(path addrs.Module) *Config {
 	return current
 }
 
-// DescendentForInstance is like Descendent except that it accepts a path
+// DescendantForInstance is like Descendant except that it accepts a path
 // to a particular module instance in the dynamic module graph, returning
 // the node from the static module graph that corresponds to it.
 //
 // All instances created by a particular module call share the same
 // configuration, so the keys within the given path are disregarded.
-func (c *Config) DescendentForInstance(path addrs.ModuleInstance) *Config {
+func (c *Config) DescendantForInstance(path addrs.ModuleInstance) *Config {
 	current := c
 	for _, step := range path {
 		current = current.Children[step.Name]
@@ -200,7 +200,7 @@ func (c *Config) TargetExists(target addrs.Targetable) bool {
 	switch target.AddrType() {
 	case addrs.ConfigResourceAddrType:
 		addr := target.(addrs.ConfigResource)
-		module := c.Descendent(addr.Module)
+		module := c.Descendant(addr.Module)
 		if module != nil {
 			return module.Module.ResourceByAddr(addr.Resource) != nil
 		} else {
@@ -208,7 +208,7 @@ func (c *Config) TargetExists(target addrs.Targetable) bool {
 		}
 	case addrs.AbsResourceInstanceAddrType:
 		addr := target.(addrs.AbsResourceInstance)
-		module := c.DescendentForInstance(addr.Module)
+		module := c.DescendantForInstance(addr.Module)
 		if module != nil {
 			return module.Module.ResourceByAddr(addr.Resource.Resource) != nil
 		} else {
@@ -216,16 +216,16 @@ func (c *Config) TargetExists(target addrs.Targetable) bool {
 		}
 	case addrs.AbsResourceAddrType:
 		addr := target.(addrs.AbsResource)
-		module := c.DescendentForInstance(addr.Module)
+		module := c.DescendantForInstance(addr.Module)
 		if module != nil {
 			return module.Module.ResourceByAddr(addr.Resource) != nil
 		} else {
 			return false
 		}
 	case addrs.ModuleAddrType:
-		return c.Descendent(target.(addrs.Module)) != nil
+		return c.Descendant(target.(addrs.Module)) != nil
 	case addrs.ModuleInstanceAddrType:
-		return c.DescendentForInstance(target.(addrs.ModuleInstance)) != nil
+		return c.DescendantForInstance(target.(addrs.ModuleInstance)) != nil
 	default:
 		panic(fmt.Errorf("unrecognized targetable type: %d", target.AddrType()))
 	}
@@ -846,9 +846,9 @@ func (c *Config) ResolveAbsProviderAddr(addr addrs.ProviderConfig, inModule addr
 		return addr
 
 	case addrs.LocalProviderConfig:
-		// Find the descendent Config that contains the module that this
+		// Find the descendant Config that contains the module that this
 		// local config belongs to.
-		mc := c.Descendent(inModule)
+		mc := c.Descendant(inModule)
 		if mc == nil {
 			panic(fmt.Sprintf("ResolveAbsProviderAddr with non-existent module %s", inModule.String()))
 		}

--- a/internal/configs/config_build.go
+++ b/internal/configs/config_build.go
@@ -16,7 +16,7 @@ import (
 )
 
 // BuildConfig constructs a Config from a root module by loading all of its
-// descendent modules via the given ModuleWalker. This function also side loads
+// descendant modules via the given ModuleWalker. This function also side loads
 // and installs any mock data files needed by the testing framework via the
 // MockDataLoader.
 //

--- a/internal/configs/configload/loader.go
+++ b/internal/configs/configload/loader.go
@@ -23,7 +23,7 @@ type Loader struct {
 	// parser is used to read configuration
 	parser *configs.Parser
 
-	// modules is used to install and locate descendent modules that are
+	// modules is used to install and locate descendant modules that are
 	// referenced (directly or indirectly) from the root module.
 	modules moduleMgr
 }
@@ -31,7 +31,7 @@ type Loader struct {
 // Config is used with NewLoader to specify configuration arguments for the
 // loader.
 type Config struct {
-	// ModulesDir is a path to a directory where descendent modules are
+	// ModulesDir is a path to a directory where descendant modules are
 	// (or should be) installed. (This is usually the
 	// .terraform/modules directory, in the common case where this package
 	// is being loaded from the main Terraform CLI package.)

--- a/internal/configs/configload/loader_load.go
+++ b/internal/configs/configload/loader_load.go
@@ -14,7 +14,7 @@ import (
 
 // LoadConfig reads the Terraform module in the given directory and uses it as the
 // root module to build the static module tree that represents a configuration,
-// assuming that all required descendent modules have already been installed.
+// assuming that all required descendant modules have already been installed.
 //
 // If error diagnostics are returned, the returned configuration may be either
 // nil or incomplete. In the latter case, cautious static analysis is possible

--- a/internal/configs/configload/module_mgr.go
+++ b/internal/configs/configload/module_mgr.go
@@ -23,7 +23,7 @@ type moduleMgr struct {
 	// abstraction and will always write into the "real" filesystem.
 	CanInstall bool
 
-	// Dir is the path where descendent modules are (or will be) installed.
+	// Dir is the path where descendant modules are (or will be) installed.
 	Dir string
 
 	// Services is a service discovery client that will be used to find

--- a/internal/configs/configschema/implied_type.go
+++ b/internal/configs/configschema/implied_type.go
@@ -36,7 +36,7 @@ func (b *Block) specType() cty.Type {
 }
 
 // ContainsSensitive returns true if any of the attributes of the receiving
-// block or any of its descendent blocks are marked as sensitive.
+// block or any of its descendant blocks are marked as sensitive.
 //
 // Blocks themselves cannot be sensitive as a whole -- sensitivity is a
 // per-attribute idea -- but sometimes we want to include a whole object

--- a/internal/configs/doc.go
+++ b/internal/configs/doc.go
@@ -17,6 +17,6 @@
 //
 // The Parser type is the main entry-point into this package. The LoadConfigDir
 // method can be used to load a single module directory, and then a full
-// configuration (including any descendent modules) can be produced using
+// configuration (including any descendant modules) can be produced using
 // the top-level BuildConfig method.
 package configs

--- a/internal/configs/variable_type_hint.go
+++ b/internal/configs/variable_type_hint.go
@@ -28,7 +28,7 @@ type VariableTypeHint rune
 // ambiguous contexts will be treated as literal strings, as if TypeHintString
 // were selected, but no runtime value checks will be applied. This is reasonable
 // type hint for a module that is never intended to be used at the top-level
-// of a configuration, since descendent modules never receive values from
+// of a configuration, since descendant modules never receive values from
 // ambiguous contexts.
 const TypeHintNone VariableTypeHint = 0
 

--- a/internal/dag/dag.go
+++ b/internal/dag/dag.go
@@ -71,6 +71,56 @@ func (g *AcyclicGraph) Descendants(v Vertex) Set {
 	return s
 }
 
+// FirstDescendantsWith returns a Set that includes every Vertex yielded by
+// walking up from the provided starting Vertex v, and stopping each branch when
+// match returns true. This will return the set of all first descendants
+// encountered which match some criteria.
+func (g *AcyclicGraph) FirstDescendantsWith(v Vertex, match func(Vertex) bool) Set {
+	s := make(Set)
+	searchFunc := func(v Vertex, d int) error {
+		if match(v) {
+			s.Add(v)
+			return errStopWalkBranch
+		}
+
+		return nil
+	}
+
+	start := make(Set)
+	for _, dep := range g.upEdgesNoCopy(v) {
+		start.Add(dep)
+	}
+
+	// our memoFunc doesn't return an error
+	g.ReverseDepthFirstWalk(start, searchFunc)
+
+	return s
+}
+
+// MatchDescendant returns true if the given match function returns true for any
+// descendants of the given Vertex.
+func (g *AcyclicGraph) MatchDescendant(v Vertex, match func(Vertex) bool) bool {
+	var ret bool
+	matchFunc := func(v Vertex, d int) error {
+		if match(v) {
+			ret = true
+			return errStopWalk
+		}
+
+		return nil
+	}
+
+	start := make(Set)
+	for _, dep := range g.upEdgesNoCopy(v) {
+		start.Add(dep)
+	}
+
+	// our memoFunc doesn't return an error
+	g.ReverseDepthFirstWalk(start, matchFunc)
+
+	return ret
+}
+
 // Root returns the root of the DAG, or an error.
 //
 // Complexity: O(V)
@@ -266,6 +316,16 @@ const (
 	upOrder
 )
 
+var (
+	// stopWalkBranch halts the descent in the current branch of the walk
+	// without adding any more edges from the current vertex, and continues with
+	// the next vertex already added to the queue.
+	errStopWalkBranch = errors.New("stop walk branch")
+
+	// stopWalk halts the entire walk.
+	errStopWalk = errors.New("stop walk")
+)
+
 // DepthFirstWalk does a depth-first walk of the graph starting from
 // the vertices in start.
 func (g *AcyclicGraph) DepthFirstWalk(start Set, f DepthWalkFunc) error {
@@ -332,6 +392,12 @@ func (g *AcyclicGraph) walk(order walkType, test bool, start Set, f DepthWalkFun
 
 		// Visit the current node
 		if err := f(current.Vertex, current.Depth); err != nil {
+			switch err {
+			case errStopWalk:
+				return nil
+			case errStopWalkBranch:
+				continue
+			}
 			return err
 		}
 

--- a/internal/dag/dag.go
+++ b/internal/dag/dag.go
@@ -53,7 +53,7 @@ func (g *AcyclicGraph) Ancestors(vs ...Vertex) (Set, error) {
 
 // Returns a Set that includes every Vertex yielded by walking up from the
 // provided starting Vertex v.
-func (g *AcyclicGraph) Descendants(vs ...Vertex) (Set, error) {
+func (g *AcyclicGraph) Descendants(v Vertex) (Set, error) {
 	s := make(Set)
 	memoFunc := func(v Vertex, d int) error {
 		s.Add(v)
@@ -61,10 +61,8 @@ func (g *AcyclicGraph) Descendants(vs ...Vertex) (Set, error) {
 	}
 
 	start := make(Set)
-	for _, v := range vs {
-		for _, dep := range g.upEdgesNoCopy(v) {
-			start.Add(dep)
-		}
+	for _, dep := range g.upEdgesNoCopy(v) {
+		start.Add(dep)
 	}
 
 	if err := g.ReverseDepthFirstWalk(start, memoFunc); err != nil {

--- a/internal/dag/dag.go
+++ b/internal/dag/dag.go
@@ -53,7 +53,7 @@ func (g *AcyclicGraph) Ancestors(vs ...Vertex) (Set, error) {
 
 // Returns a Set that includes every Vertex yielded by walking up from the
 // provided starting Vertex v.
-func (g *AcyclicGraph) Descendents(vs ...Vertex) (Set, error) {
+func (g *AcyclicGraph) Descendants(vs ...Vertex) (Set, error) {
 	s := make(Set)
 	memoFunc := func(v Vertex, d int) error {
 		s.Add(v)

--- a/internal/dag/dag.go
+++ b/internal/dag/dag.go
@@ -51,9 +51,9 @@ func (g *AcyclicGraph) Ancestors(vs ...Vertex) (Set, error) {
 	return s, nil
 }
 
-// Returns a Set that includes every Vertex yielded by walking up from the
-// provided starting Vertex v.
-func (g *AcyclicGraph) Descendants(v Vertex) (Set, error) {
+// Descendants returns a Set that includes every Vertex yielded by walking up
+// from the provided starting Vertex v.
+func (g *AcyclicGraph) Descendants(v Vertex) Set {
 	s := make(Set)
 	memoFunc := func(v Vertex, d int) error {
 		s.Add(v)
@@ -65,11 +65,10 @@ func (g *AcyclicGraph) Descendants(v Vertex) (Set, error) {
 		start.Add(dep)
 	}
 
-	if err := g.ReverseDepthFirstWalk(start, memoFunc); err != nil {
-		return nil, err
-	}
+	// our memoFunc doesn't return an error
+	g.ReverseDepthFirstWalk(start, memoFunc)
 
-	return s, nil
+	return s
 }
 
 // Root returns the root of the DAG, or an error.

--- a/internal/dag/dag_test.go
+++ b/internal/dag/dag_test.go
@@ -259,7 +259,7 @@ func TestAcyclicGraphAncestors(t *testing.T) {
 	}
 }
 
-func TestAcyclicGraphDescendents(t *testing.T) {
+func TestAcyclicGraphDescendants(t *testing.T) {
 	var g AcyclicGraph
 	g.Add(1)
 	g.Add(2)
@@ -272,7 +272,7 @@ func TestAcyclicGraphDescendents(t *testing.T) {
 	g.Connect(BasicEdge(3, 4))
 	g.Connect(BasicEdge(4, 5))
 
-	actual, err := g.Descendents(2)
+	actual, err := g.Descendants(2)
 	if err != nil {
 		t.Fatalf("err: %#v", err)
 	}

--- a/internal/dag/dag_test.go
+++ b/internal/dag/dag_test.go
@@ -272,10 +272,7 @@ func TestAcyclicGraphDescendants(t *testing.T) {
 	g.Connect(BasicEdge(3, 4))
 	g.Connect(BasicEdge(4, 5))
 
-	actual, err := g.Descendants(2)
-	if err != nil {
-		t.Fatalf("err: %#v", err)
-	}
+	actual := g.Descendants(2)
 
 	expected := []Vertex{0, 1}
 

--- a/internal/dag/dag_test.go
+++ b/internal/dag/dag_test.go
@@ -287,6 +287,57 @@ func TestAcyclicGraphDescendants(t *testing.T) {
 	}
 }
 
+func TestAcyclicGraphFindDescendants(t *testing.T) {
+	var g AcyclicGraph
+	g.Add(0)
+	g.Add(1)
+	g.Add(2)
+	g.Add(3)
+	g.Add(4)
+	g.Add(5)
+	g.Add(6)
+	g.Connect(BasicEdge(0, 1))
+	g.Connect(BasicEdge(1, 2))
+	g.Connect(BasicEdge(2, 6))
+	g.Connect(BasicEdge(3, 4))
+	g.Connect(BasicEdge(4, 5))
+	g.Connect(BasicEdge(5, 6))
+
+	actual := g.FirstDescendantsWith(6, func(v Vertex) bool {
+		// looking for first odd descendants
+		return v.(int)%2 != 0
+	})
+
+	expected := make(Set)
+	expected.Add(1)
+	expected.Add(5)
+
+	if expected.Intersection(actual).Len() != expected.Len() {
+		t.Fatalf("expected %#v, got %#v\n", expected, actual)
+	}
+
+	foundOne := g.MatchDescendant(6, func(v Vertex) bool {
+		return v.(int) == 1
+	})
+	if !foundOne {
+		t.Fatal("did not match 6 in the graph")
+	}
+
+	foundSix := g.MatchDescendant(6, func(v Vertex) bool {
+		return v.(int) == 6
+	})
+	if foundSix {
+		t.Fatal("6 should not be a descendant of itself")
+	}
+
+	foundTen := g.MatchDescendant(6, func(v Vertex) bool {
+		return v.(int) == 10
+	})
+	if foundTen {
+		t.Fatal("10 is not in the graph at all")
+	}
+}
+
 func TestAcyclicGraphWalk(t *testing.T) {
 	var g AcyclicGraph
 	g.Add(1)

--- a/internal/initwd/from_module.go
+++ b/internal/initwd/from_module.go
@@ -33,7 +33,7 @@ const initFromModuleRootKeyPrefix = initFromModuleRootCallName + "."
 // DirFromModule populates the given directory (which must exist and be
 // empty) with the contents of the module at the given source address.
 //
-// It does this by installing the given module and all of its descendent
+// It does this by installing the given module and all of its descendant
 // modules in a temporary root directory and then copying the installed
 // files into suitable locations. As a consequence, any diagnostics it
 // generates will reveal the location of this temporary directory to the
@@ -43,7 +43,7 @@ const initFromModuleRootKeyPrefix = initFromModuleRootCallName + "."
 // installation proceeds in a manner identical to normal module installation.
 //
 // If the given source address specifies a sub-directory of the given
-// package then only the sub-directory and its descendents will be copied
+// package then only the sub-directory and its descendants will be copied
 // into the given root directory, which will cause any relative module
 // references using ../ from that module to be unresolvable. Error diagnostics
 // are produced in that case, to prompt the user to rewrite the source strings
@@ -167,7 +167,7 @@ func DirFromModule(ctx context.Context, loader *configload.Loader, rootDir, modu
 	fetcher := getmodules.NewPackageFetcher()
 
 	walker := inst.moduleInstallWalker(ctx, instManifest, true, wrapHooks, fetcher)
-	_, cDiags := inst.installDescendentModules(fakeRootModule, instManifest, walker, true)
+	_, cDiags := inst.installDescendantModules(fakeRootModule, instManifest, walker, true)
 	if cDiags.HasErrors() {
 		return diags.Append(cDiags)
 	}
@@ -252,7 +252,7 @@ func DirFromModule(ctx context.Context, loader *configload.Loader, rootDir, modu
 		if !strings.HasPrefix(record.Key, initFromModuleRootKeyPrefix) {
 			// Ignore the *real* root module, whose key is empty, since
 			// we're only interested in the module named "root" and its
-			// descendents.
+			// descendants.
 			continue
 		}
 
@@ -352,7 +352,7 @@ func DirFromModule(ctx context.Context, loader *configload.Loader, rootDir, modu
 		if err != nil {
 			diags = diags.Append(tfdiags.Sourceless(
 				tfdiags.Error,
-				"Failed to copy descendent module",
+				"Failed to copy descendant module",
 				fmt.Sprintf("Error copying module %q from %s to %s: %s.", newKey, tempPath, rootDir, err),
 			))
 			continue

--- a/internal/initwd/from_module_test.go
+++ b/internal/initwd/from_module_test.go
@@ -50,7 +50,7 @@ func TestDirFromModule_registry(t *testing.T) {
 
 	wantCalls := []testInstallHookCall{
 		// The module specified to populate the root directory is not mentioned
-		// here, because the hook mechanism is defined to talk about descendent
+		// here, because the hook mechanism is defined to talk about descendant
 		// modules only and so a caller to InitDirFromModule is expected to
 		// produce its own user-facing announcement about the root module being
 		// installed.

--- a/internal/initwd/module_install.go
+++ b/internal/initwd/module_install.go
@@ -137,7 +137,7 @@ func (i *ModuleInstaller) InstallModules(ctx context.Context, rootDir, testsDir 
 	}
 	walker := i.moduleInstallWalker(ctx, manifest, upgrade, hooks, fetcher)
 
-	cfg, instDiags := i.installDescendentModules(rootMod, manifest, walker, installErrsOnly)
+	cfg, instDiags := i.installDescendantModules(rootMod, manifest, walker, installErrsOnly)
 	diags = append(diags, instDiags...)
 
 	return cfg, diags
@@ -202,7 +202,7 @@ func (i *ModuleInstaller) moduleInstallWalker(ctx context.Context, manifest mods
 					log.Printf("[TRACE] ModuleInstaller: discarding previous record of %s prior to reinstall", key)
 				}
 				delete(manifest, key)
-				// Deleting a module invalidates all of its descendent modules too.
+				// Deleting a module invalidates all of its descendant modules too.
 				keyPrefix := key + "."
 				for subKey := range manifest {
 					if strings.HasPrefix(subKey, keyPrefix) {
@@ -292,7 +292,7 @@ func (i *ModuleInstaller) moduleInstallWalker(ctx context.Context, manifest mods
 	)
 }
 
-func (i *ModuleInstaller) installDescendentModules(rootMod *configs.Module, manifest modsdir.Manifest, installWalker configs.ModuleWalker, installErrsOnly bool) (*configs.Config, tfdiags.Diagnostics) {
+func (i *ModuleInstaller) installDescendantModules(rootMod *configs.Module, manifest modsdir.Manifest, installWalker configs.ModuleWalker, installErrsOnly bool) (*configs.Config, tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
 
 	// When attempting to initialize the current directory with a module

--- a/internal/initwd/testdata/load-module-package-prefix/package-prefix.tf
+++ b/internal/initwd/testdata/load-module-package-prefix/package-prefix.tf
@@ -8,7 +8,7 @@ module "child" {
   #
   # Note that we're intentionally using the special // delimiter to
   # tell Terraform that it should treat the "package" directory as a
-  # whole as a module package, with all of its descendents "downloaded"
+  # whole as a module package, with all of its descendants "downloaded"
   # (copied) together into ./.terraform/modules/child so that child
   # can refer to ../grandchild successfully.
   source = "%%BASE%%/package//child"

--- a/internal/instances/expander.go
+++ b/internal/instances/expander.go
@@ -555,7 +555,7 @@ type expanderModule struct {
 	resources      map[addrs.Resource]expansion
 	childInstances map[addrs.ModuleInstanceStep]*expanderModule
 
-	// overrides ensures that any overriden modules instances will not be
+	// overrides ensures that any overridden modules instances will not be
 	// returned as options for expansion. A nil overrides indicates there are
 	// no overrides and we're not operating within the testing framework.
 	overrides *mocking.Overrides
@@ -678,7 +678,7 @@ func (m *expanderModule) partialExpandedModuleInstances(addr addrs.Module, paren
 	}
 
 	// If this step already has everything expanded then we need to
-	// search inside it to see if it has any unexpanded descendents.
+	// search inside it to see if it has any unexpanded descendants.
 	if len(addr) > 1 {
 		for step, inst := range m.childInstances {
 			if step.Name != callName {

--- a/internal/lang/blocktoattr/fixup.go
+++ b/internal/lang/blocktoattr/fixup.go
@@ -207,7 +207,7 @@ type fixupBlocksExpr struct {
 
 func (e *fixupBlocksExpr) Value(ctx *hcl.EvalContext) (cty.Value, hcl.Diagnostics) {
 	// In order to produce a suitable value for our expression we need to
-	// now decode the whole descendent block structure under each of our block
+	// now decode the whole descendant block structure under each of our block
 	// bodies.
 	//
 	// That requires us to do something rather strange: we must construct a

--- a/internal/lang/globalref/analyzer.go
+++ b/internal/lang/globalref/analyzer.go
@@ -63,7 +63,7 @@ func NewAnalyzer(cfg *configs.Config, providerSchemas map[addrs.Provider]provide
 // ModuleConfig retrieves a module configuration from the configuration the
 // analyzer belongs to, or nil if there is no module with the given address.
 func (a *Analyzer) ModuleConfig(addr addrs.ModuleInstance) *configs.Module {
-	modCfg := a.cfg.DescendentForInstance(addr)
+	modCfg := a.cfg.DescendantForInstance(addr)
 	if modCfg == nil {
 		return nil
 	}

--- a/internal/moduledeps/module.go
+++ b/internal/moduledeps/module.go
@@ -23,7 +23,7 @@ type Module struct {
 type WalkFunc func(path []string, parent *Module, current *Module) error
 
 // WalkTree calls the given callback once for the receiver and then
-// once for each descendent, in an order such that parents are called
+// once for each descendant, in an order such that parents are called
 // before their children and siblings are called in the order they
 // appear in the Children slice.
 //
@@ -42,7 +42,7 @@ type WalkFunc func(path []string, parent *Module, current *Module) error
 // data structure, so it's the caller's responsibility to arrange for that
 // should it be needed.
 //
-// It is safe for a callback to modify the descendents of the "current"
+// It is safe for a callback to modify the descendants of the "current"
 // module, including the ordering of the Children slice itself, but the
 // callback MUST NOT modify the parent module.
 func (m *Module) WalkTree(cb WalkFunc) error {
@@ -74,9 +74,9 @@ func (m *Module) SortChildren() {
 	sort.Sort(sortModules{m.Children})
 }
 
-// SortDescendents is a convenience wrapper for calling SortChildren on
-// the receiver and all of its descendent modules.
-func (m *Module) SortDescendents() {
+// SortDescendants is a convenience wrapper for calling SortChildren on
+// the receiver and all of its descendant modules.
+func (m *Module) SortDescendants() {
 	m.WalkTree(func(path []string, parent *Module, current *Module) error {
 		current.SortChildren()
 		return nil
@@ -126,7 +126,7 @@ func (m *Module) ProviderRequirements() discovery.PluginRequirements {
 }
 
 // AllProviderRequirements calls ProviderRequirements for the receiver and all
-// of its descendents, and merges the result into a single PluginRequirements
+// of its descendants, and merges the result into a single PluginRequirements
 // structure that would satisfy all of the modules together.
 //
 // Requirements returned by this method include only version constraints,
@@ -145,7 +145,7 @@ func (m *Module) AllProviderRequirements() discovery.PluginRequirements {
 // the equality of all downstream modules too.
 //
 // The children are considered to be ordered, so callers may wish to use
-// SortDescendents first to normalize the order of the slices of child nodes.
+// SortDescendants first to normalize the order of the slices of child nodes.
 //
 // The implementation of this function is not optimized since it is provided
 // primarily for use in tests.

--- a/internal/refactoring/move_statement.go
+++ b/internal/refactoring/move_statement.go
@@ -68,7 +68,7 @@ func findMoveStatements(cfg *configs.Config, into []MoveStatement) []MoveStateme
 			// Only attach providers if we are moving resources, and we attach
 			// the to resource provider from the config. We can retrieve the
 			// from resource provider from the state later.
-			modCfg := cfg.Descendent(toResource.Module)
+			modCfg := cfg.Descendant(toResource.Module)
 			// It's possible that multiple refactorings have left a moved block
 			// that points to a module which no longer exists. This may also be
 			// a mistake, but the user will see the unexpected deletion in the
@@ -180,7 +180,7 @@ func impliedMoveStatements(cfg *configs.Config, prevRunState *states.State, expl
 				// zero as the one to retain.
 				if !haveMoveStatementForResource(rAddr, explicitStmts) {
 
-					resource := cfg.Descendent(addrs.RootModule).Module.ResourceByAddr(rAddr.Resource)
+					resource := cfg.Descendant(addrs.RootModule).Module.ResourceByAddr(rAddr.Resource)
 					provider := &addrs.AbsProviderConfig{
 						Module:   rAddr.Module.Module(),
 						Provider: resource.Provider,

--- a/internal/refactoring/move_validate.go
+++ b/internal/refactoring/move_validate.go
@@ -250,7 +250,7 @@ func movableObjectDeclRange(addr addrs.AbsMoveable, cfg *configs.Config) (tfdiag
 		// (NOTE: This assumes "addr" can never be the root module instance,
 		// because the root module is never moveable.)
 		parentAddr, callAddr := addr.Call()
-		modCfg := cfg.DescendentForInstance(parentAddr)
+		modCfg := cfg.DescendantForInstance(parentAddr)
 		if modCfg == nil {
 			return tfdiags.SourceRange{}, false
 		}
@@ -271,7 +271,7 @@ func movableObjectDeclRange(addr addrs.AbsMoveable, cfg *configs.Config) (tfdiag
 			return tfdiags.SourceRangeFromHCL(call.DeclRange), true
 		}
 	case addrs.AbsModuleCall:
-		modCfg := cfg.DescendentForInstance(addr.Module)
+		modCfg := cfg.DescendantForInstance(addr.Module)
 		if modCfg == nil {
 			return tfdiags.SourceRange{}, false
 		}
@@ -281,7 +281,7 @@ func movableObjectDeclRange(addr addrs.AbsMoveable, cfg *configs.Config) (tfdiag
 		}
 		return tfdiags.SourceRangeFromHCL(call.DeclRange), true
 	case addrs.AbsResourceInstance:
-		modCfg := cfg.DescendentForInstance(addr.Module)
+		modCfg := cfg.DescendantForInstance(addr.Module)
 		if modCfg == nil {
 			return tfdiags.SourceRange{}, false
 		}
@@ -302,7 +302,7 @@ func movableObjectDeclRange(addr addrs.AbsMoveable, cfg *configs.Config) (tfdiag
 			return tfdiags.SourceRangeFromHCL(rc.DeclRange), true
 		}
 	case addrs.AbsResource:
-		modCfg := cfg.DescendentForInstance(addr.Module)
+		modCfg := cfg.DescendantForInstance(addr.Module)
 		if modCfg == nil {
 			return tfdiags.SourceRange{}, false
 		}

--- a/internal/refactoring/move_validate_test.go
+++ b/internal/refactoring/move_validate_test.go
@@ -544,7 +544,7 @@ func loadRefactoringFixture(t *testing.T, dir string) (*configs.Config, instance
 func staticPopulateExpanderModule(t *testing.T, rootCfg *configs.Config, moduleAddr addrs.ModuleInstance, expander *instances.Expander) {
 	t.Helper()
 
-	modCfg := rootCfg.DescendentForInstance(moduleAddr)
+	modCfg := rootCfg.DescendantForInstance(moduleAddr)
 	if modCfg == nil {
 		t.Fatalf("no configuration for %s", moduleAddr)
 	}

--- a/internal/refactoring/remove_statement.go
+++ b/internal/refactoring/remove_statement.go
@@ -43,7 +43,7 @@ func validateRemoveStatements(cfg *configs.Config, stmts addrs.Map[addrs.ConfigM
 	for _, rst := range stmts.Keys() {
 		switch rst := rst.(type) {
 		case addrs.ConfigResource:
-			m := cfg.Descendent(rst.Module)
+			m := cfg.Descendant(rst.Module)
 			if m == nil {
 				break
 			}
@@ -57,7 +57,7 @@ func validateRemoveStatements(cfg *configs.Config, stmts addrs.Map[addrs.ConfigM
 				})
 			}
 		case addrs.Module:
-			if m := cfg.Descendent(rst); m != nil {
+			if m := cfg.Descendant(rst); m != nil {
 				diags = diags.Append(&hcl.Diagnostic{
 					Severity: hcl.DiagError,
 					Summary:  "Removed module still exists",

--- a/internal/stacks/stackruntime/hooks.go
+++ b/internal/stacks/stackruntime/hooks.go
@@ -41,7 +41,7 @@ type Hooks = stackeval.Hooks
 // ContextWithHooks returns a context that carries the given [Hooks] as
 // one of its values.
 //
-// Pass the resulting context -- or a descendent that preserves the values --
+// Pass the resulting context -- or a descendant that preserves the values --
 // to [Plan] or [Apply] to be notified when the different hookable events
 // occur during that plan or apply process.
 func ContextWithHooks(parent context.Context, hooks *Hooks) context.Context {

--- a/internal/stacks/stackruntime/internal/stackeval/hooks.go
+++ b/internal/stacks/stackruntime/internal/stackeval/hooks.go
@@ -192,7 +192,7 @@ type hookSeq struct {
 // calls that are related to whatever multi-step operation this hook sequence
 // represents, so that the hook subscriber can use this mechanism to propagate
 // distributed tracing spans to downstream operations. Callers MUST also use
-// descendents of the resulting context for any subsequent calls to
+// descendants of the resulting context for any subsequent calls to
 // [runHookBegin] using the returned [hookSeq].
 func hookBegin[Msg any](ctx context.Context, cb hooks.BeginFunc[Msg], ctxCb hooks.ContextAttachFunc, msg Msg) (*hookSeq, context.Context) {
 	tracking := runHookBegin(ctx, cb, msg)

--- a/internal/stacks/stackruntime/internal/stackeval/main.go
+++ b/internal/stacks/stackruntime/internal/stackeval/main.go
@@ -559,7 +559,7 @@ func (m *Main) ResolveAbsExpressionReference(ctx context.Context, ref stackaddrs
 //
 // This is intended for cleaning up any resources that would not naturally
 // be cleaned up as a result of garbage-collecting the [Main] object and its
-// many descendents.
+// many descendants.
 //
 // The context passed to a callback function may be already cancelled by the
 // time the callback is running, if the cleanup is running in response to

--- a/internal/stacks/stackruntime/internal/stackeval/validating_test.go
+++ b/internal/stacks/stackruntime/internal/stackeval/validating_test.go
@@ -53,7 +53,7 @@ func TestValidate_modulesWithProviderConfigs(t *testing.T) {
 
 		var wantDiags tfdiags.Diagnostics
 		// Configurations in the root module get a different detail message
-		// than those in descendent modules, because for descendents we don't
+		// than those in descendant modules, because for descendants we don't
 		// assume that the author is empowered to make the module
 		// stacks-compatible, while for the root it's more likely to be
 		// directly intended for stacks use, at least for now while things are

--- a/internal/states/statefile/marshal_equal.go
+++ b/internal/states/statefile/marshal_equal.go
@@ -14,7 +14,7 @@ import (
 //
 // This function compares only the portions of the state that are persisted
 // in state files, so for example it will not return false if the only
-// differences between the two states are local values or descendent module
+// differences between the two states are local values or descendant module
 // outputs.
 func StatesMarshalEqual(a, b *states.State) bool {
 	var aBuf bytes.Buffer

--- a/internal/states/statefile/version4.go
+++ b/internal/states/statefile/version4.go
@@ -248,7 +248,7 @@ func prepareStateV4(sV4 *stateV4) (*File, tfdiags.Diagnostics) {
 	}
 
 	// The root module is special in that we persist its attributes and thus
-	// need to reload them now. (For descendent modules we just re-calculate
+	// need to reload them now. (For descendant modules we just re-calculate
 	// them based on the latest configuration on each run.)
 	{
 		for name, fos := range sV4.RootOutputs {

--- a/internal/terraform/eval_context_builtin.go
+++ b/internal/terraform/eval_context_builtin.go
@@ -360,7 +360,7 @@ func (ctx *BuiltinEvalContext) EvaluateReplaceTriggeredBy(expr hcl.Expression, r
 	}
 
 	// Do some validation to make sure we are expecting a change at all
-	cfg := ctx.Evaluator.Config.Descendent(ctx.Path().Module())
+	cfg := ctx.Evaluator.Config.Descendant(ctx.Path().Module())
 	resCfg := cfg.Module.ResourceByAddr(resourceAddr)
 	if resCfg == nil {
 		diags = diags.Append(&hcl.Diagnostic{
@@ -441,7 +441,7 @@ func (ctx *BuiltinEvalContext) EvaluationScope(self addrs.Referenceable, source 
 		// package itself works. The nil check here is for robustness in
 		// incompletely-mocked testing situations; mc should never be nil in
 		// real situations.
-		if mc := ctx.Evaluator.Config.DescendentForInstance(scope.Addr); mc != nil {
+		if mc := ctx.Evaluator.Config.DescendantForInstance(scope.Addr); mc != nil {
 			evalScope.SetActiveExperiments(mc.Module.ActiveExperiments)
 		}
 		return evalScope
@@ -457,7 +457,7 @@ func (ctx *BuiltinEvalContext) EvaluationScope(self addrs.Referenceable, source 
 			Operation:      ctx.Evaluator.Operation,
 		}
 		evalScope := ctx.Evaluator.Scope(data, self, source, ctx.evaluationExternalFunctions())
-		if mc := ctx.Evaluator.Config.Descendent(scope.Addr.Module()); mc != nil {
+		if mc := ctx.Evaluator.Config.Descendant(scope.Addr.Module()); mc != nil {
 			evalScope.SetActiveExperiments(mc.Module.ActiveExperiments)
 		}
 		return evalScope
@@ -479,7 +479,7 @@ func (ctx *BuiltinEvalContext) evaluationExternalFunctions() lang.ExternalFuncs 
 	// by the module author.
 	ret := lang.ExternalFuncs{}
 
-	cfg := ctx.Evaluator.Config.Descendent(ctx.scope.evalContextScopeModule())
+	cfg := ctx.Evaluator.Config.Descendant(ctx.scope.evalContextScopeModule())
 	if cfg == nil {
 		// It's weird to not have a configuration by this point, but we'll
 		// tolerate it for robustness and just return no functions at all.
@@ -558,7 +558,7 @@ func (ctx *BuiltinEvalContext) LanguageExperimentActive(experiment experiments.E
 		// is module-scoped.
 		return false
 	}
-	cfg := ctx.Evaluator.Config.Descendent(scope.evalContextScopeModule())
+	cfg := ctx.Evaluator.Config.Descendant(scope.evalContextScopeModule())
 	if cfg == nil {
 		return false
 	}

--- a/internal/terraform/eval_variable.go
+++ b/internal/terraform/eval_variable.go
@@ -227,7 +227,7 @@ func prepareFinalInputVariableValue(addr addrs.AbsInputVariableInstance, raw *In
 //
 // This must be used only after any side-effects that make the value of the
 // variable available for use in expression evaluation, such as
-// EvalModuleCallArgument for variables in descendent modules.
+// EvalModuleCallArgument for variables in descendant modules.
 func evalVariableValidations(addr addrs.AbsInputVariableInstance, ctx EvalContext, rules []*configs.CheckRule, valueRng hcl.Range, validateWalk bool) (diags tfdiags.Diagnostics) {
 	if len(rules) == 0 {
 		log.Printf("[TRACE] evalVariableValidations: no validation rules declared for %s, so skipping", addr)

--- a/internal/terraform/evaluate.go
+++ b/internal/terraform/evaluate.go
@@ -236,7 +236,7 @@ func (d *evaluationStateData) GetInputVariable(addr addrs.InputVariable, rng tfd
 
 	// First we'll make sure the requested value is declared in configuration,
 	// so we can produce a nice message if not.
-	moduleConfig := d.Evaluator.Config.DescendentForInstance(d.ModulePath)
+	moduleConfig := d.Evaluator.Config.DescendantForInstance(d.ModulePath)
 	if moduleConfig == nil {
 		// should never happen, since we can't be evaluating in a module
 		// that wasn't mentioned in configuration.
@@ -309,7 +309,7 @@ func (d *evaluationStateData) GetLocalValue(addr addrs.LocalValue, rng tfdiags.S
 
 	// First we'll make sure the requested value is declared in configuration,
 	// so we can produce a nice message if not.
-	moduleConfig := d.Evaluator.Config.DescendentForInstance(d.ModulePath)
+	moduleConfig := d.Evaluator.Config.DescendantForInstance(d.ModulePath)
 	if moduleConfig == nil {
 		// should never happen, since we can't be evaluating in a module
 		// that wasn't mentioned in configuration.
@@ -348,7 +348,7 @@ func (d *evaluationStateData) GetModule(addr addrs.ModuleCall, rng tfdiags.Sourc
 	moduleAddr := d.ModulePath.Module().Child(addr.Name)
 	absAddr := addr.Absolute(d.ModulePath)
 
-	parentCfg := d.Evaluator.Config.DescendentForInstance(d.ModulePath)
+	parentCfg := d.Evaluator.Config.DescendantForInstance(d.ModulePath)
 	callConfig, ok := parentCfg.Module.ModuleCalls[addr.Name]
 	if !ok {
 		diags = diags.Append(&hcl.Diagnostic{
@@ -363,7 +363,7 @@ func (d *evaluationStateData) GetModule(addr addrs.ModuleCall, rng tfdiags.Sourc
 	// We'll consult the configuration to see what output names we are
 	// expecting, so we can ensure the resulting object is of the expected
 	// type even if our data is incomplete for some reason.
-	moduleConfig := d.Evaluator.Config.Descendent(moduleAddr)
+	moduleConfig := d.Evaluator.Config.Descendant(moduleAddr)
 	if moduleConfig == nil {
 		// should never happen, since we have a valid module call above, this
 		// should be caught during static validation.
@@ -498,7 +498,7 @@ func (d *evaluationStateData) GetResource(addr addrs.Resource, rng tfdiags.Sourc
 	// First we'll consult the configuration to see if an resource of this
 	// name is declared at all.
 	moduleAddr := d.ModulePath
-	moduleConfig := d.Evaluator.Config.DescendentForInstance(moduleAddr)
+	moduleConfig := d.Evaluator.Config.DescendantForInstance(moduleAddr)
 	if moduleConfig == nil {
 		// should never happen, since we can't be evaluating in a module
 		// that wasn't mentioned in configuration.
@@ -900,7 +900,7 @@ func (d *evaluationStateData) GetOutput(addr addrs.OutputValue, rng tfdiags.Sour
 
 	// First we'll make sure the requested value is declared in configuration,
 	// so we can produce a nice message if not.
-	moduleConfig := d.Evaluator.Config.DescendentForInstance(d.ModulePath)
+	moduleConfig := d.Evaluator.Config.DescendantForInstance(d.ModulePath)
 	if moduleConfig == nil {
 		// should never happen, since we can't be evaluating in a module
 		// that wasn't mentioned in configuration.

--- a/internal/terraform/evaluate_data.go
+++ b/internal/terraform/evaluate_data.go
@@ -69,7 +69,7 @@ func (d *evaluationData) GetPathAttr(addr addrs.PathAttr, rng tfdiags.SourceRang
 		return cty.StringVal(filepath.ToSlash(wd)), diags
 
 	case "module":
-		moduleConfig := d.Evaluator.Config.Descendent(d.Module)
+		moduleConfig := d.Evaluator.Config.Descendant(d.Module)
 		if moduleConfig == nil {
 			// should never happen, since we can't be evaluating in a module
 			// that wasn't mentioned in configuration.

--- a/internal/terraform/evaluate_placeholder.go
+++ b/internal/terraform/evaluate_placeholder.go
@@ -155,7 +155,7 @@ func (d *evaluationPlaceholderData) GetModule(addr addrs.ModuleCall, rng tfdiags
 		return cty.DynamicVal, diags
 	}
 
-	callerCfg := d.Evaluator.Config.Descendent(d.ModulePath.Module())
+	callerCfg := d.Evaluator.Config.Descendant(d.ModulePath.Module())
 	if callerCfg == nil {
 		// Strange! The above StaticValidateReference should've failed if
 		// the module we're in isn't even declared. But we'll just tolerate
@@ -184,7 +184,7 @@ func (d *evaluationPlaceholderData) GetModule(addr addrs.ModuleCall, rng tfdiags
 	// the child module's declared output values represented, which could
 	// then potentially allow detecting a downstream error referring to
 	// an output value that doesn't actually exist.
-	calledCfg := d.Evaluator.Config.Descendent(d.ModulePath.Module().Child(addr.Name))
+	calledCfg := d.Evaluator.Config.Descendant(d.ModulePath.Module().Child(addr.Name))
 	if calledCfg == nil {
 		// This suggests that the config wasn't constructed correctly, since
 		// there should always be a child config node for any module call,

--- a/internal/terraform/evaluate_valid.go
+++ b/internal/terraform/evaluate_valid.go
@@ -41,7 +41,7 @@ func (e *Evaluator) StaticValidateReferences(refs []*addrs.Reference, modAddr ad
 }
 
 func (e *Evaluator) StaticValidateReference(ref *addrs.Reference, modAddr addrs.Module, self addrs.Referenceable, source addrs.Referenceable) tfdiags.Diagnostics {
-	modCfg := e.Config.Descendent(modAddr)
+	modCfg := e.Config.Descendant(modAddr)
 	if modCfg == nil {
 		// This is a bug in the caller rather than a problem with the
 		// reference, but rather than crashing out here in an unhelpful way

--- a/internal/terraform/node_resource_destroy.go
+++ b/internal/terraform/node_resource_destroy.go
@@ -57,7 +57,7 @@ func (n *NodeDestroyResourceInstance) DestroyAddr() *addrs.AbsResourceInstance {
 func (n *NodeDestroyResourceInstance) CreateBeforeDestroy() bool {
 	// State takes precedence during destroy.
 	// If the resource was removed, there is no config to check.
-	// If CBD was forced from descendent, it should be saved in the state
+	// If CBD was forced from descendant, it should be saved in the state
 	// already.
 	if s := n.instanceState; s != nil {
 		if s.Current != nil {

--- a/internal/terraform/transform_attach_config_resource.go
+++ b/internal/terraform/transform_attach_config_resource.go
@@ -69,7 +69,7 @@ func (t *AttachResourceConfigTransformer) Transform(g *Graph) error {
 		}
 
 		// Get the configuration.
-		config := t.Config.Descendent(addr.Module)
+		config := t.Config.Descendant(addr.Module)
 
 		if config == nil {
 			log.Printf("[TRACE] AttachResourceConfigTransformer: %q (%T) has no configuration available", dag.VertexName(v), v)

--- a/internal/terraform/transform_check_starter.go
+++ b/internal/terraform/transform_check_starter.go
@@ -76,7 +76,7 @@ func (s *checkStartTransformer) Transform(graph *Graph) error {
 
 			config := s.Config
 			if !addr.Module.IsRoot() {
-				config = s.Config.Descendent(addr.Module.Module())
+				config = s.Config.Descendant(addr.Module.Module())
 			}
 			if config == nil {
 				// might have been deleted, so it won't be subject to any checks

--- a/internal/terraform/transform_config.go
+++ b/internal/terraform/transform_config.go
@@ -215,7 +215,7 @@ func (t *ConfigTransformer) validateImportTargets() error {
 			toResource = i.LegacyAddr.ConfigResource()
 		}
 
-		moduleCfg := t.Config.Root.Descendent(toResource.Module)
+		moduleCfg := t.Config.Root.Descendant(toResource.Module)
 		if moduleCfg == nil {
 			diags = diags.Append(&hcl.Diagnostic{
 				Severity: hcl.DiagError,

--- a/internal/terraform/transform_destroy_cbd.go
+++ b/internal/terraform/transform_destroy_cbd.go
@@ -74,20 +74,15 @@ func (t *ForcedCBDTransformer) Transform(g *Graph) error {
 // hasCBDDescendant returns true if any descendant (node that depends on this)
 // has CBD set.
 func (t *ForcedCBDTransformer) hasCBDDescendant(g *Graph, v dag.Vertex) bool {
-	for _, ov := range g.Descendants(v) {
+	return g.MatchDescendant(v, func(ov dag.Vertex) bool {
 		dn, ok := ov.(GraphNodeDestroyerCBD)
-		if !ok {
-			continue
-		}
-
-		if dn.CreateBeforeDestroy() {
+		if ok && dn.CreateBeforeDestroy() {
 			// some descendant is CreateBeforeDestroy, so we need to follow suit
 			log.Printf("[TRACE] ForcedCBDTransformer: %q has CBD descendant %q", dag.VertexName(v), dag.VertexName(ov))
 			return true
 		}
-	}
-
-	return false
+		return false
+	})
 }
 
 // CBDEdgeTransformer modifies the edges of create-before-destroy ("CBD") nodes

--- a/internal/terraform/transform_destroy_cbd.go
+++ b/internal/terraform/transform_destroy_cbd.go
@@ -45,14 +45,14 @@ func (t *ForcedCBDTransformer) Transform(g *Graph) error {
 		}
 
 		if !dn.CreateBeforeDestroy() {
-			// If there are no CBD decendent (dependent nodes), then we
+			// If there are no CBD decendant (dependent nodes), then we
 			// do nothing here.
-			if !t.hasCBDDescendent(g, v) {
-				log.Printf("[TRACE] ForcedCBDTransformer: %q (%T) has no CBD descendent, so skipping", dag.VertexName(v), v)
+			if !t.hasCBDDescendant(g, v) {
+				log.Printf("[TRACE] ForcedCBDTransformer: %q (%T) has no CBD descendant, so skipping", dag.VertexName(v), v)
 				continue
 			}
 
-			// If this isn't naturally a CBD node, this means that an descendent is
+			// If this isn't naturally a CBD node, this means that an descendant is
 			// and we need to auto-upgrade this node to CBD. We do this because
 			// a CBD node depending on non-CBD will result in cycles. To avoid this,
 			// we always attempt to upgrade it.
@@ -71,10 +71,10 @@ func (t *ForcedCBDTransformer) Transform(g *Graph) error {
 	return nil
 }
 
-// hasCBDDescendent returns true if any descendent (node that depends on this)
+// hasCBDDescendant returns true if any descendant (node that depends on this)
 // has CBD set.
-func (t *ForcedCBDTransformer) hasCBDDescendent(g *Graph, v dag.Vertex) bool {
-	s, _ := g.Descendents(v)
+func (t *ForcedCBDTransformer) hasCBDDescendant(g *Graph, v dag.Vertex) bool {
+	s, _ := g.Descendants(v)
 	if s == nil {
 		return true
 	}
@@ -86,8 +86,8 @@ func (t *ForcedCBDTransformer) hasCBDDescendent(g *Graph, v dag.Vertex) bool {
 		}
 
 		if dn.CreateBeforeDestroy() {
-			// some descendent is CreateBeforeDestroy, so we need to follow suit
-			log.Printf("[TRACE] ForcedCBDTransformer: %q has CBD descendent %q", dag.VertexName(v), dag.VertexName(ov))
+			// some descendant is CreateBeforeDestroy, so we need to follow suit
+			log.Printf("[TRACE] ForcedCBDTransformer: %q has CBD descendant %q", dag.VertexName(v), dag.VertexName(ov))
 			return true
 		}
 	}

--- a/internal/terraform/transform_destroy_cbd.go
+++ b/internal/terraform/transform_destroy_cbd.go
@@ -74,7 +74,7 @@ func (t *ForcedCBDTransformer) Transform(g *Graph) error {
 // hasCBDDescendant returns true if any descendant (node that depends on this)
 // has CBD set.
 func (t *ForcedCBDTransformer) hasCBDDescendant(g *Graph, v dag.Vertex) bool {
-	s, _ := g.Descendants(v)
+	s := g.Descendants(v)
 	if s == nil {
 		return true
 	}

--- a/internal/terraform/transform_destroy_cbd.go
+++ b/internal/terraform/transform_destroy_cbd.go
@@ -74,12 +74,7 @@ func (t *ForcedCBDTransformer) Transform(g *Graph) error {
 // hasCBDDescendant returns true if any descendant (node that depends on this)
 // has CBD set.
 func (t *ForcedCBDTransformer) hasCBDDescendant(g *Graph, v dag.Vertex) bool {
-	s := g.Descendants(v)
-	if s == nil {
-		return true
-	}
-
-	for _, ov := range s {
+	for _, ov := range g.Descendants(v) {
 		dn, ok := ov.(GraphNodeDestroyerCBD)
 		if !ok {
 			continue

--- a/internal/terraform/transform_destroy_edge.go
+++ b/internal/terraform/transform_destroy_edge.go
@@ -378,8 +378,7 @@ func (t *pruneUnusedNodesTransformer) Transform(g *Graph) error {
 					// earlier, however there may be more to prune now based on
 					// targeting or a destroy with no related instances in the
 					// state.
-					des, _ := g.Descendants(n)
-					for _, v := range des {
+					for _, v := range g.Descendants(n) {
 						switch v.(type) {
 						case GraphNodeProviderConsumer:
 							return

--- a/internal/terraform/transform_destroy_edge.go
+++ b/internal/terraform/transform_destroy_edge.go
@@ -378,11 +378,13 @@ func (t *pruneUnusedNodesTransformer) Transform(g *Graph) error {
 					// earlier, however there may be more to prune now based on
 					// targeting or a destroy with no related instances in the
 					// state.
-					for _, v := range g.Descendants(n) {
-						switch v.(type) {
-						case GraphNodeProviderConsumer:
-							return
+					if g.MatchDescendant(n, func(v dag.Vertex) bool {
+						if _, ok := v.(GraphNodeProviderConsumer); ok {
+							return true
 						}
+						return false
+					}) {
+						return
 					}
 
 				default:

--- a/internal/terraform/transform_destroy_edge.go
+++ b/internal/terraform/transform_destroy_edge.go
@@ -378,7 +378,7 @@ func (t *pruneUnusedNodesTransformer) Transform(g *Graph) error {
 					// earlier, however there may be more to prune now based on
 					// targeting or a destroy with no related instances in the
 					// state.
-					des, _ := g.Descendents(n)
+					des, _ := g.Descendants(n)
 					for _, v := range des {
 						switch v.(type) {
 						case GraphNodeProviderConsumer:

--- a/internal/terraform/transform_diff.go
+++ b/internal/terraform/transform_diff.go
@@ -32,7 +32,7 @@ func (t *DiffTransformer) hasConfigConditions(addr addrs.AbsResourceInstance) bo
 		return false
 	}
 
-	cfg := t.Config.DescendentForInstance(addr.Module)
+	cfg := t.Config.DescendantForInstance(addr.Module)
 	if cfg == nil {
 		return false
 	}

--- a/internal/terraform/transform_ephemeral_resource_close.go
+++ b/internal/terraform/transform_ephemeral_resource_close.go
@@ -51,11 +51,11 @@ func (t *ephemeralResourceCloseTransformer) Transform(g *Graph) error {
 		// dependents of that resource. Rather than connect directly to them all
 		// however, we'll only connect to leaf nodes by finding those that have
 		// no up edges.
-		descendents, _ := g.Descendents(v)
+		descendants, _ := g.Descendants(v)
 		// FIXME: some of these graph methods still return unused errors. It
-		// would be nice to be able to use Descendents as a range argument for
+		// would be nice to be able to use Descendants as a range argument for
 		// example.
-		for _, des := range descendents {
+		for _, des := range descendants {
 			// We want something which is both a referencer and has no incoming
 			// edges from referencers. While it wouldn't be incorrect to just
 			// check for all leaf nodes, we are trying to connect to the end of

--- a/internal/terraform/transform_ephemeral_resource_close.go
+++ b/internal/terraform/transform_ephemeral_resource_close.go
@@ -47,39 +47,37 @@ func (t *ephemeralResourceCloseTransformer) Transform(g *Graph) error {
 		g.Add(closeNode)
 		g.Connect(dag.BasicEdge(closeNode, v))
 
-		// Now we have an ephemeral resource, we need to depend on all
+		// Now we have an ephemeral resource, and we need to depend on all
 		// dependents of that resource. Rather than connect directly to them all
 		// however, we'll only connect to leaf nodes by finding those that have
 		// no up edges.
-		for _, des := range g.Descendants(v) {
+		lastReferences := g.FirstDescendantsWith(v, func(v dag.Vertex) bool {
 			// We want something which is both a referencer and has no incoming
 			// edges from referencers. While it wouldn't be incorrect to just
 			// check for all leaf nodes, we are trying to connect to the end of
-			// evaluation chain, otherwise we may just as well wait til the end
-			// of the walk and close everything together.
-			//
-			// FIXME: This can still get delayed excessively when intermediary
-			// non-referencing nodes exist in the chain, like a nested  module
-			// close node for example. What we've needed a couple times already
-			// is some sort of breadth-first descend-until walk, which will stop
-			// the current branch descent on some condition to act on that node,
-			// yet still continue the rest of the walk.
-			if _, ok := des.(GraphNodeReferencer); !ok {
-				continue
+			// evaluation chain, otherwise we may just as well wait until the end
+			// of the walk and close everything together. We technically don't
+			// know if these nodes are connected because they reference the
+			// ephemeral value, or if they are connected for some other
+			// dependency reason, but this generally shouldn't matter as we can
+			// count any dependency as a reason to maintain the ephemeral value.
+			if _, ok := v.(GraphNodeReferencer); !ok {
+				return false
 			}
 
-			up := g.UpEdges(des)
+			up := g.UpEdges(v)
 			up = up.Filter(func(v any) bool {
 				_, ok := v.(GraphNodeReferencer)
 				return ok
 			})
 
-			// This node has a referencer
-			if len(up) > 0 {
-				continue
-			}
+			// if there are no references connected to this node, then we can be
+			// sure it's the last referencer in the chain.
+			return len(up) == 0
+		})
 
-			g.Connect(dag.BasicEdge(closeNode, des))
+		for _, last := range lastReferences.List() {
+			g.Connect(dag.BasicEdge(closeNode, last))
 		}
 	}
 	return nil

--- a/internal/terraform/transform_ephemeral_resource_close.go
+++ b/internal/terraform/transform_ephemeral_resource_close.go
@@ -51,11 +51,7 @@ func (t *ephemeralResourceCloseTransformer) Transform(g *Graph) error {
 		// dependents of that resource. Rather than connect directly to them all
 		// however, we'll only connect to leaf nodes by finding those that have
 		// no up edges.
-		descendants, _ := g.Descendants(v)
-		// FIXME: some of these graph methods still return unused errors. It
-		// would be nice to be able to use Descendants as a range argument for
-		// example.
-		for _, des := range descendants {
+		for _, des := range g.Descendants(v) {
 			// We want something which is both a referencer and has no incoming
 			// edges from referencers. While it wouldn't be incorrect to just
 			// check for all leaf nodes, we are trying to connect to the end of

--- a/internal/terraform/transform_module_expansion.go
+++ b/internal/terraform/transform_module_expansion.go
@@ -32,7 +32,7 @@ type ModuleExpansionTransformer struct {
 func (t *ModuleExpansionTransformer) Transform(g *Graph) error {
 	t.closers = make(map[string]*nodeCloseModule)
 	// The root module is always a singleton and so does not need expansion
-	// processing, but any descendent modules do. We'll process them
+	// processing, but any descendant modules do. We'll process them
 	// recursively using t.transform.
 	for _, cfg := range t.Config.Children {
 		err := t.transform(g, cfg, nil)

--- a/internal/terraform/transform_orphan_resource.go
+++ b/internal/terraform/transform_orphan_resource.go
@@ -71,7 +71,7 @@ func (t *OrphanResourceInstanceTransformer) transform(g *Graph, ms *states.Modul
 	// nil if the module was removed from the configuration. This is okay,
 	// this just means that every resource is an orphan.
 	var m *configs.Module
-	if c := t.Config.DescendentForInstance(moduleAddr); c != nil {
+	if c := t.Config.DescendantForInstance(moduleAddr); c != nil {
 		m = c.Module
 	}
 

--- a/internal/terraform/transform_provider.go
+++ b/internal/terraform/transform_provider.go
@@ -741,7 +741,7 @@ func (t *ProviderConfigTransformer) attachProviderConfigs(g *Graph) error {
 		addr := apn.ProviderAddr()
 
 		// Get the configuration.
-		mc := t.Config.Descendent(addr.Module)
+		mc := t.Config.Descendant(addr.Module)
 		if mc == nil {
 			log.Printf("[TRACE] ProviderConfigTransformer: no configuration available for %s", addr.String())
 			continue

--- a/internal/terraform/transform_removed_modules.go
+++ b/internal/terraform/transform_removed_modules.go
@@ -27,7 +27,7 @@ func (t *RemovedModuleTransformer) Transform(g *Graph) error {
 	removed := map[string]addrs.Module{}
 
 	for _, m := range t.State.Modules {
-		cc := t.Config.DescendentForInstance(m.Addr)
+		cc := t.Config.DescendantForInstance(m.Addr)
 		if cc != nil {
 			continue
 		}

--- a/website/docs/cli/state/resource-addressing.mdx
+++ b/website/docs/cli/state/resource-addressing.mdx
@@ -71,7 +71,7 @@ resource_type.resource_name[instance index]
 -> In Terraform v0.12 and later, a resource spec without a module path prefix
 matches only resources in the root module. In earlier versions, a resource spec
 without a module path prefix would match resources with the same type and name
-in any descendent module.
+in any descendant module.
 
 ## Index values for Modules and Resources
 

--- a/website/docs/internals/json-format.mdx
+++ b/website/docs/internals/json-format.mdx
@@ -272,7 +272,7 @@ The following example illustrates the structure of a `<values-representation>`:
 ```javascript
 {
   // "outputs" describes the outputs from the root module. Outputs from
-  // descendent modules are not available because they are not retained in all
+  // descendant modules are not available because they are not retained in all
   // of the underlying structures we will build this values representation from.
   "outputs": {
     "private_ip": {
@@ -404,7 +404,7 @@ Because the configuration models are produced at a stage prior to expression eva
       "alias": "foo",
 
       // "module_address" is included only for provider configurations that are
-      // declared in a descendent module, and gives the opaque address for the
+      // declared in a descendant module, and gives the opaque address for the
       // module that contains the provider configuration.
       "module_address": "module.child",
 
@@ -416,7 +416,7 @@ Because the configuration models are produced at a stage prior to expression eva
   },
 
   // "root_module" describes the root module in the configuration, and serves
-  // as the root of a tree of similar objects describing descendent modules.
+  // as the root of a tree of similar objects describing descendant modules.
   "root_module": {
 
     // "outputs" describes the output value configurations in the module.

--- a/website/docs/language/modules/develop/providers.mdx
+++ b/website/docs/language/modules/develop/providers.mdx
@@ -17,7 +17,7 @@ Terraform, are global to an entire Terraform configuration and can be shared
 across module boundaries. Provider configurations can be defined only in a
 root Terraform module.
 
-Providers can be passed down to descendent modules in two ways: either
+Providers can be passed down to descendant modules in two ways: either
 _implicitly_ through inheritance, or _explicitly_ via the `providers` argument
 within a `module` block. These two options are discussed in more detail in the
 following sections.


### PR DESCRIPTION
The end goal here was to place the ephemeral resource close nodes more accurately in the graph, but there is a little bit of refactoring which came along for the ride.

- Fixed the misspelling of _Descendant_ which has proliferated throughout the code, but wasn't consistently used.

- The use of `Descendants` was mainly to find if something existed in the subgraph at all. Added `AcyclicGraph.MatchDescendant` which does precisely that, and is going to be much more efficient for large graphs since it aborts the walk early.

- Create `AcyclicGraph.FirstDescendantsWith`, which can be used to find the set of all the first descendants which match a particular case. This can be used for efficiency, such that we can abort the walk early for the first matches along any lineage, and can also be used to find the first nodes which "end" an evaluation chain.

The `FirstDescendantsWith` is how we connect the ephemeral close nodes to the tail end of the dependencies, such that they wait for the entire evaluation chain using a particular value, but they will not depend on other ancillary nodes which may be waiting for unrelated actions.