### PR TITLE
configgen: escape any invalid HCL syntax in map keys

### DIFF
--- a/internal/genconfig/generate_config.go
+++ b/internal/genconfig/generate_config.go
@@ -6,11 +6,11 @@ package genconfig
 import (
 	"encoding/json"
 	"fmt"
-	"regexp"
 	"sort"
 	"strings"
 
 	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/hashicorp/hcl/v2/hclwrite"
 	"github.com/zclconf/go-cty/cty"
 	ctyjson "github.com/zclconf/go-cty/cty/json"
@@ -18,12 +18,6 @@ import (
 	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/configs/configschema"
 	"github.com/hashicorp/terraform/internal/tfdiags"
-)
-
-var (
-	// whitespace is a regular expression that matches one or more whitespace
-	// characters.
-	whitespace = regexp.MustCompile(`\s+`)
 )
 
 // GenerateResourceContents generates HCL configuration code for the provided
@@ -592,7 +586,7 @@ func ctyCollectionValues(val cty.Value) []cty.Value {
 func hclEscapeString(str string) string {
 	// TODO: Replace this with more complete HCL logic instead of the simple
 	// go workaround.
-	if whitespace.MatchString(str) {
+	if !hclsyntax.ValidIdentifier(str) {
 		return fmt.Sprintf("%q", str)
 	}
 	return str

--- a/internal/genconfig/generate_config_test.go
+++ b/internal/genconfig/generate_config_test.go
@@ -688,6 +688,94 @@ resource "tfcoremock_sensitive_values" "values" {
   }
 }`,
 		},
+		"simple_map_with_periods_in_keys": {
+			schema: &configschema.Block{
+				Attributes: map[string]*configschema.Attribute{
+					"map": {
+						Type:     cty.Map(cty.String),
+						Optional: true,
+					},
+				},
+			},
+			addr: addrs.AbsResourceInstance{
+				Module: addrs.RootModuleInstance,
+				Resource: addrs.ResourceInstance{
+					Resource: addrs.Resource{
+						Mode: addrs.ManagedResourceMode,
+						Type: "testing_resource",
+						Name: "resource",
+					},
+					Key: addrs.NoKey,
+				},
+			},
+			provider: addrs.LocalProviderConfig{
+				LocalName: "testing",
+			},
+			value: cty.ObjectVal(map[string]cty.Value{
+				"map": cty.MapVal(map[string]cty.Value{
+					"key.with.periods":     cty.StringVal("periods"),
+					"key_with_underscores": cty.StringVal("underscores"),
+				}),
+			}),
+			expected: `resource "testing_resource" "resource" {
+  map = {
+    "key.with.periods"   = "periods"
+    key_with_underscores = "underscores"
+  }
+}`,
+		},
+		"nested_map_with_periods_in_keys": {
+			schema: &configschema.Block{
+				Attributes: map[string]*configschema.Attribute{
+					"map": {
+						NestedType: &configschema.Object{
+							Attributes: map[string]*configschema.Attribute{
+								"value": {
+									Type:     cty.String,
+									Optional: true,
+								},
+							},
+							Nesting: configschema.NestingMap,
+						},
+						Optional: true,
+					},
+				},
+			},
+			addr: addrs.AbsResourceInstance{
+				Module: addrs.RootModuleInstance,
+				Resource: addrs.ResourceInstance{
+					Resource: addrs.Resource{
+						Mode: addrs.ManagedResourceMode,
+						Type: "testing_resource",
+						Name: "resource",
+					},
+					Key: addrs.NoKey,
+				},
+			},
+			provider: addrs.LocalProviderConfig{
+				LocalName: "testing",
+			},
+			value: cty.ObjectVal(map[string]cty.Value{
+				"map": cty.MapVal(map[string]cty.Value{
+					"key.with.periods": cty.ObjectVal(map[string]cty.Value{
+						"value": cty.StringVal("periods"),
+					}),
+					"key_with_underscores": cty.ObjectVal(map[string]cty.Value{
+						"value": cty.StringVal("underscores"),
+					}),
+				}),
+			}),
+			expected: `resource "testing_resource" "resource" {
+  map = {
+    "key.with.periods" = {
+      value = "periods"
+    }
+    key_with_underscores = {
+      value = "underscores"
+    }
+  }
+}`,
+		},
 	}
 	for name, tc := range tcs {
 		t.Run(name, func(t *testing.T) {


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

This PR updates the config generation so that any invalid HCL syntax in generated map keys is escaped and not just whitespace.

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Fixes #35752 

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.9.x

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

### BUG FIXES

<!--

Write a short description of the user-facing change. Examples:

- `terraform show -json`: Fixed crash with sensitive set values.
- When rendering a diff, Terraform now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 

-  config generation: Escape all invalid syntax in generate map keys with quotes.
