### PR TITLE
stacks: fix tests broken now that ephemeral outputs aren't allowed

### DIFF
--- a/internal/stacks/stackruntime/apply_test.go
+++ b/internal/stacks/stackruntime/apply_test.go
@@ -1243,10 +1243,6 @@ After applying this plan, Terraform will no longer manage these objects. You wil
 							ProviderConfigAddr: mustDefaultRootProvider("testing"),
 							Schema:             stacks_testing_provider.TestingResourceSchema,
 						},
-						&stackstate.AppliedChangeOutputValue{
-							Addr:  mustStackOutputValue("ephemeral"),
-							Value: cty.NullVal(cty.String), // ephemeral
-						},
 						&stackstate.AppliedChangeInputVariable{
 							Addr:  mustStackInputVariable("ephemeral"),
 							Value: cty.NullVal(cty.String), // ephemeral
@@ -1291,10 +1287,6 @@ After applying this plan, Terraform will no longer manage these objects. You wil
 							},
 							ProviderConfigAddr: mustDefaultRootProvider("testing"),
 							Schema:             stacks_testing_provider.TestingResourceSchema,
-						},
-						&stackstate.AppliedChangeOutputValue{
-							Addr:  mustStackOutputValue("ephemeral"),
-							Value: cty.NullVal(cty.String), // ephemeral
 						},
 						&stackstate.AppliedChangeInputVariable{
 							Addr:  mustStackInputVariable("input"),
@@ -1356,10 +1348,6 @@ After applying this plan, Terraform will no longer manage these objects. You wil
 							},
 							ProviderConfigAddr: mustDefaultRootProvider("testing"),
 							Schema:             stacks_testing_provider.TestingResourceSchema,
-						},
-						&stackstate.AppliedChangeOutputValue{
-							Addr:  mustStackOutputValue("ephemeral"),
-							Value: cty.NullVal(cty.String), // ephemeral
 						},
 						&stackstate.AppliedChangeInputVariable{
 							Addr:  mustStackInputVariable("ephemeral"),

--- a/internal/stacks/stackruntime/testdata/mainbundle/test/with-single-input/ephemeral-default/ephemeral-default.tfstack.hcl
+++ b/internal/stacks/stackruntime/testdata/mainbundle/test/with-single-input/ephemeral-default/ephemeral-default.tfstack.hcl
@@ -33,9 +33,3 @@ component "self" {
     id = "2f9f3b84"
   }
 }
-
-output "ephemeral" {
-  value = var.ephemeral
-  type = string
-  ephemeral = true
-}

--- a/internal/stacks/stackruntime/testdata/mainbundle/test/with-single-input/ephemeral/ephemeral.tfstack.hcl
+++ b/internal/stacks/stackruntime/testdata/mainbundle/test/with-single-input/ephemeral/ephemeral.tfstack.hcl
@@ -32,9 +32,3 @@ component "self" {
     id = "2f9f3b84"
   }
 }
-
-output "ephemeral" {
-  value = var.ephemeral
-  type = string
-  ephemeral = true
-}


### PR DESCRIPTION
I merged https://github.com/hashicorp/terraform/pull/35831 updating ephemeral values within stacks to be represented as null values when exposed to the plan and state files. This PR affected both inputs and outputs, so both were updated.

Simultaneously, @DanielMSchmidt merged https://github.com/hashicorp/terraform/pull/35826 which actually prevent ephemeral values being used as outputs at all.

The combination of these two PRs broke the test pipeline on main without interacting with each other as I introduced tests untouched by Daniel's change that were incompatible. This PR removes the broken parts of the tests (namely the ephemeral outputs) and fixes the build (hopefully).