### PR TITLE
init: detect and report invalid submodules

### DIFF
--- a/internal/initwd/testdata/invalid-registry-modules/.gitignore
+++ b/internal/initwd/testdata/invalid-registry-modules/.gitignore
@@ -1,0 +1,1 @@
+.terraform/*

--- a/internal/initwd/testdata/invalid-registry-modules/root.tf
+++ b/internal/initwd/testdata/invalid-registry-modules/root.tf
@@ -1,0 +1,28 @@
+# This fixture indirectly depends on a github repo at:
+#     https://github.com/hashicorp/terraform-aws-module-installer-acctest
+# ...and expects its v0.0.1 tag to be pointing at the following commit:
+#     d676ab2559d4e0621d59e3c3c4cbb33958ac4608
+#
+# This repository is accessed indirectly via:
+#     https://registry.terraform.io/modules/hashicorp/module-installer-acctest/aws/0.0.1
+#
+# Since the tag's id is included in a downloaded archive, it is expected to
+# have the following id:
+#     853d03855b3290a3ca491d4c3a7684572dd42237
+# (this particular assumption is encoded in the tests that use this fixture)
+
+
+variable "v" {
+  description = "in local caller for registry-modules"
+  default     = ""
+}
+
+// see ../registry-modules/root.tf for more info, and for valid usages to the
+// acceptance test module
+
+// this sub module is not available in the registry, we should see an error
+// message in the output
+module "acctest_child_c" {
+  source  = "hashicorp/module-installer-acctest/aws//modules/child_c"
+  version = "0.0.1"
+}


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

This PR updates `terraform init` so that if a module source is requesting a subdirectory within a registry module, where the registry module itself does exist and is successfully downloaded but the subdirectory is missing, Terraform correctly highlights the missing subdirectory as the problem rather than a generic "This is a bug in Terraform" message.

### Before

```
╷
│ Error: Unreadable module directory
│ 
│ The directory .terraform/modules/karpenter_fg_profile/modules/fargate_profile could not be read. This is a bug in Terraform and should be reported.
╵
```

### After

```
╷
│ Error: Unreadable module subdirectory
│ 
│ The directory .terraform/modules/karpenter_fg_profile/modules/fargate_profile does not exist. The target submodule modules/fargate_profile does not exist within the target module.
╵
```

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Fixes #35836 

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.9.x

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

### BUG FIXES

<!--

Write a short description of the user-facing change. Examples:

- `terraform show -json`: Fixed crash with sensitive set values.
- When rendering a diff, Terraform now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 

-  `terraform init`: Highlight missing subdirectories of registry modules in error message.
