### PR TITLE
provider meta: don't return providers with invalid names

### DIFF
--- a/internal/configs/provider_meta.go
+++ b/internal/configs/provider_meta.go
@@ -29,7 +29,11 @@ func decodeProviderMetaBlock(block *hcl.Block) (*ProviderMeta, hcl.Diagnostics) 
 	}
 
 	// verify that the local name is already localized or produce an error.
-	diags = append(diags, checkProviderNameNormalized(block.Labels[0], block.DefRange)...)
+	nameDiags := checkProviderNameNormalized(block.Labels[0], block.DefRange)
+	diags = append(diags, nameDiags...)
+	if nameDiags.HasErrors() {
+		return nil, diags
+	}
 
 	return &ProviderMeta{
 		Provider:      block.Labels[0],


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

This PR updates the parsing of the `provider_meta` blocks so that providers with invalid names aren't returned. This prevents a crash that occurs later when the names are parsed, and doesn't affect behaviour otherwise as the diagnostic explaining the error is still returned.

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Fixes #35835 

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.9.x

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

### BUG FIXES

<!--

Write a short description of the user-facing change. Examples:

- `terraform show -json`: Fixed crash with sensitive set values.
- When rendering a diff, Terraform now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 

-  Prevent crash when loading `provider_meta` blocks with invalid names.
