### PR TITLE
feat: add NetRC support to the provider installer

### DIFF
--- a/internal/providercache/package_install.go
+++ b/internal/providercache/package_install.go
@@ -6,8 +6,7 @@ package providercache
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
-	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 
@@ -26,54 +25,41 @@ import (
 var unzip = getter.ZipDecompressor{}
 
 func installFromHTTPURL(ctx context.Context, meta getproviders.PackageMeta, targetDir string, allowedHashes []getproviders.Hash) (*getproviders.PackageAuthenticationResult, error) {
-	url := meta.Location.String()
+	urlStr := meta.Location.String()
 
 	// When we're installing from an HTTP URL we expect the URL to refer to
 	// a zip file. We'll fetch that into a temporary file here and then
 	// delegate to installFromLocalArchive below to actually extract it.
-	// (We're not using go-getter here because its HTTP getter has a bunch
-	// of extraneous functionality we don't need or want, like indirection
-	// through X-Terraform-Get header, attempting partial fetches for
-	// files that already exist, etc.)
+	httpGetter := getter.HttpGetter{
+		Client:                httpclient.New(),
+		Netrc:                 true,
+		XTerraformGetDisabled: true,
+	}
 
-	httpClient := httpclient.New()
-	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	urlObj, err := url.Parse(urlStr)
 	if err != nil {
+		// We don't expect to get non-HTTP locations here because we're
+		// using the registry source, so this seems like a bug in the
+		// registry source.
 		return nil, fmt.Errorf("invalid provider download request: %s", err)
 	}
-	resp, err := httpClient.Do(req)
+	f, err := os.CreateTemp("", "terraform-provider")
+	if err != nil {
+		return nil, fmt.Errorf("failed to open temporary file to download from %s: %w", urlStr, err)
+	}
+	defer f.Close()
+	defer os.Remove(f.Name())
+
+	archiveFilename := f.Name()
+	err = httpGetter.GetFile(archiveFilename, urlObj)
 	if err != nil {
 		if ctx.Err() == context.Canceled {
 			// "context canceled" is not a user-friendly error message,
 			// so we'll return a more appropriate one here.
 			return nil, fmt.Errorf("provider download was interrupted")
 		}
-		return nil, fmt.Errorf("%s: %w", getproviders.HostFromRequest(req), err)
+		return nil, fmt.Errorf("%s: %w", urlObj.Host, err)
 	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("unsuccessful request to %s: %s", url, resp.Status)
-	}
-
-	f, err := ioutil.TempFile("", "terraform-provider")
-	if err != nil {
-		return nil, fmt.Errorf("failed to open temporary file to download from %s: %w", url, err)
-	}
-	defer f.Close()
-	defer os.Remove(f.Name())
-
-	// We'll borrow go-getter's "cancelable copy" implementation here so that
-	// the download can potentially be interrupted partway through.
-	n, err := getter.Copy(ctx, f, resp.Body)
-	if err == nil && n < resp.ContentLength {
-		err = fmt.Errorf("incorrect response size: expected %d bytes, but got %d bytes", resp.ContentLength, n)
-	}
-	if err != nil {
-		return nil, err
-	}
-
-	archiveFilename := f.Name()
 	localLocation := getproviders.PackageLocalArchive(archiveFilename)
 
 	var authResult *getproviders.PackageAuthenticationResult


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->
An [interim solution](https://github.com/hashicorp/terraform/issues/29349#issuecomment-899881338) to lack of credential while downloading provider archives.
<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Fixes #29349 

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.10.x

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

### ENHANCEMENTS

<!--

Write a short description of the user-facing change. Examples:

- `terraform show -json`: Fixed crash with sensitive set values.
- When rendering a diff, Terraform now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 

-  Provider installation now support NetRC and utilises the credentials configured in `.netrc` file. Similar to module downloads.
