### PR TITLE
moved: error if not targeting a resource address

### DIFF
--- a/internal/addrs/parse_target.go
+++ b/internal/addrs/parse_target.go
@@ -181,6 +181,15 @@ func parseResourceInstanceUnderModule(moduleAddr ModuleInstance, allowPartial bo
 		// Starting a resource address with "resource" is optional, so we'll
 		// just ignore it.
 		remain = remain[1:]
+	case "count", "each", "local", "module", "path", "self", "terraform", "var", "template", "lazy", "arg":
+		// These are all reserved words that are not valid as resource types.
+		diags = diags.Append(&hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  "Invalid address",
+			Detail:   fmt.Sprintf("The keyword %q is reserved and cannot be used to target a resource address. If you are targeting a resource type that uses a reserved keyword, please prefix your address with \"resource.\".", remain.RootName()),
+			Subject:  remain.SourceRange().Ptr(),
+		})
+		return AbsResourceInstance{}, diags
 	}
 
 	if len(remain) < 2 {

--- a/internal/addrs/parse_target_test.go
+++ b/internal/addrs/parse_target_test.go
@@ -431,6 +431,61 @@ func TestParseTarget(t *testing.T) {
 			nil,
 			`Unexpected extra operators after address.`,
 		},
+		{
+			`each.key`,
+			nil,
+			`The keyword "each" is reserved and cannot be used to target a resource address. If you are targeting a resource type that uses a reserved keyword, please prefix your address with "resource.".`,
+		},
+		{
+			`module.foo[1].each`,
+			nil,
+			`The keyword "each" is reserved and cannot be used to target a resource address. If you are targeting a resource type that uses a reserved keyword, please prefix your address with "resource.".`,
+		},
+		{
+			`count.index`,
+			nil,
+			`The keyword "count" is reserved and cannot be used to target a resource address. If you are targeting a resource type that uses a reserved keyword, please prefix your address with "resource.".`,
+		},
+		{
+			`local.value`,
+			nil,
+			`The keyword "local" is reserved and cannot be used to target a resource address. If you are targeting a resource type that uses a reserved keyword, please prefix your address with "resource.".`,
+		},
+		{
+			`path.root`,
+			nil,
+			`The keyword "path" is reserved and cannot be used to target a resource address. If you are targeting a resource type that uses a reserved keyword, please prefix your address with "resource.".`,
+		},
+		{
+			`self.id`,
+			nil,
+			`The keyword "self" is reserved and cannot be used to target a resource address. If you are targeting a resource type that uses a reserved keyword, please prefix your address with "resource.".`,
+		},
+		{
+			`terraform.planning`,
+			nil,
+			`The keyword "terraform" is reserved and cannot be used to target a resource address. If you are targeting a resource type that uses a reserved keyword, please prefix your address with "resource.".`,
+		},
+		{
+			`var.foo`,
+			nil,
+			`The keyword "var" is reserved and cannot be used to target a resource address. If you are targeting a resource type that uses a reserved keyword, please prefix your address with "resource.".`,
+		},
+		{
+			`template`,
+			nil,
+			`The keyword "template" is reserved and cannot be used to target a resource address. If you are targeting a resource type that uses a reserved keyword, please prefix your address with "resource.".`,
+		},
+		{
+			`lazy`,
+			nil,
+			`The keyword "lazy" is reserved and cannot be used to target a resource address. If you are targeting a resource type that uses a reserved keyword, please prefix your address with "resource.".`,
+		},
+		{
+			`arg`,
+			nil,
+			`The keyword "arg" is reserved and cannot be used to target a resource address. If you are targeting a resource type that uses a reserved keyword, please prefix your address with "resource.".`,
+		},
 	}
 
 	for _, test := range tests {

--- a/website/docs/language/moved.mdx
+++ b/website/docs/language/moved.mdx
@@ -16,8 +16,8 @@ The `moved` block programmatically changes the address of a resource. Refer to [
 The following list outlines field hierarchy, language-specific data types, and requirements in the `moved` block. 
 
 - [`moved`](#moved): map
-  - [`from`](#moved): instance address
-  - [`to`](#moved): instance address
+  - [`from`](#moved): reference
+  - [`to`](#moved): reference
 
 ## Complete configuration
 

--- a/website/docs/language/moved.mdx
+++ b/website/docs/language/moved.mdx
@@ -16,8 +16,8 @@ The `moved` block programmatically changes the address of a resource. Refer to [
 The following list outlines field hierarchy, language-specific data types, and requirements in the `moved` block. 
 
 - [`moved`](#moved): map
-  - [`from`](#moved): string
-  - [`to`](#moved): string
+  - [`from`](#moved): instance address
+  - [`to`](#moved): instance address
 
 ## Complete configuration
 


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

This PR updates the parsing of targets (such as within import and moved blocks) so that they respect the keywords reserved by the top level references within Terraform.

These keywords include things like `local`, `each`, `count`, `self`, and `terraform`. Previously it was possible to reference these from within `moved` as resource types without prefixing them with the normally required `resource.` identifier to differentiate between a resource with the type name `local` and just referencing a `local` variable.

I'm not backporting this change, as it is technically a breaking change though I doubt anyone will be affected. Anyone who uses a resource that is simple called `local` (or any other reserved keyword) would previously have been able to reference it directly from a `moved` block. This will start failing, and they must add in the `.resource` prefix to make things work again.

The purpose of this change is to protect users from trying to reference input or local variables, which currently makes Terraform just ignore the moved block. I don't think many (if any) providers have actually made resource types that match keywords so this should hopefully not breaking anything.

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Fixes #35840 

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.10.x

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

### UPGRADE NOTES

<!--

Write a short description of the user-facing change. Examples:

- `terraform show -json`: Fixed crash with sensitive set values.
- When rendering a diff, Terraform now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 

-  `moved` blocks: Moved blocks now respect reserved keywords when parsing resource addresses. Configurations that reference resources with type names that match top level blocks and keywords will need to be updated to 
