### PR TITLE
Apply and destroy evaluation of ephemeral resources (partial)

### DIFF
--- a/internal/addrs/graph.go
+++ b/internal/addrs/graph.go
@@ -107,12 +107,7 @@ func (g DirectedGraph[T]) DirectDependenciesOf(addr T) Set[T] {
 func (g DirectedGraph[T]) TransitiveDependenciesOf(addr T) Set[T] {
 	k := addr.UniqueKey()
 	ret := MakeSet[T]()
-	raw, err := g.g.Ancestors(k)
-	if err != nil {
-		// It should be impossible for "Ancestors" to fail
-		panic(err)
-	}
-	for otherKI := range raw {
+	for otherKI := range g.g.Ancestors(k) {
 		ret.Add(g.nodes[otherKI.(UniqueKey)])
 	}
 	return ret

--- a/internal/builtin/providers/terraform/provider.go
+++ b/internal/builtin/providers/terraform/provider.go
@@ -24,6 +24,7 @@ func NewProvider() providers.Interface {
 // GetSchema returns the complete schema for the provider.
 func (p *Provider) GetProviderSchema() providers.GetProviderSchemaResponse {
 	resp := providers.GetProviderSchemaResponse{
+		Provider: providers.Schema{},
 		ServerCapabilities: providers.ServerCapabilities{
 			MoveResourceState: true,
 		},

--- a/internal/dag/dag.go
+++ b/internal/dag/dag.go
@@ -30,7 +30,7 @@ func (g *AcyclicGraph) DirectedGraph() Grapher {
 
 // Returns a Set that includes every Vertex yielded by walking down from the
 // provided starting Vertex v.
-func (g *AcyclicGraph) Ancestors(vs ...Vertex) (Set, error) {
+func (g *AcyclicGraph) Ancestors(vs ...Vertex) Set {
 	s := make(Set)
 	memoFunc := func(v Vertex, d int) error {
 		s.Add(v)
@@ -45,10 +45,10 @@ func (g *AcyclicGraph) Ancestors(vs ...Vertex) (Set, error) {
 	}
 
 	if err := g.DepthFirstWalk(start, memoFunc); err != nil {
-		return nil, err
+		return nil
 	}
 
-	return s, nil
+	return s
 }
 
 // Descendants returns a Set that includes every Vertex yielded by walking up

--- a/internal/dag/dag_test.go
+++ b/internal/dag/dag_test.go
@@ -241,10 +241,7 @@ func TestAcyclicGraphAncestors(t *testing.T) {
 	g.Connect(BasicEdge(3, 4))
 	g.Connect(BasicEdge(4, 5))
 
-	actual, err := g.Ancestors(2)
-	if err != nil {
-		t.Fatalf("err: %#v", err)
-	}
+	actual := g.Ancestors(2)
 
 	expected := []Vertex{3, 4, 5}
 
@@ -454,10 +451,7 @@ func BenchmarkDAG(b *testing.B) {
 		b.StartTimer()
 		// Find dependencies for every node
 		for _, v := range g.Vertices() {
-			_, err := g.Ancestors(v)
-			if err != nil {
-				b.Fatal(err)
-			}
+			_ = g.Ancestors(v)
 		}
 
 		// reduce the final graph

--- a/internal/terraform/context_plan.go
+++ b/internal/terraform/context_plan.go
@@ -378,6 +378,7 @@ func (c *Context) checkApplyGraph(plan *plans.Plan, config *configs.Config, opts
 		return nil
 	}
 	log.Println("[DEBUG] building apply graph to check for errors")
+
 	_, _, diags := c.applyGraph(plan, config, opts.ApplyOpts(), true)
 	return diags
 }

--- a/internal/terraform/graph_builder_plan.go
+++ b/internal/terraform/graph_builder_plan.go
@@ -137,7 +137,7 @@ func (b *PlanGraphBuilder) Steps() []GraphTransformer {
 		&ConfigTransformer{
 			Concrete: b.ConcreteResource,
 			Config:   b.Config,
-			skip:     b.Operation == walkDestroy || b.Operation == walkPlanDestroy,
+			destroy:  b.Operation == walkDestroy || b.Operation == walkPlanDestroy,
 
 			importTargets: b.ImportTargets,
 

--- a/internal/terraform/graph_test.go
+++ b/internal/terraform/graph_test.go
@@ -40,13 +40,8 @@ func testGraphHappensBefore(t *testing.T, g *Graph, A, B string) {
 	}
 
 	// Look at ancestors
-	deps, err := g.Ancestors(vertexB)
-	if err != nil {
-		t.Fatalf("Error: %s in graph:\n\n%s", err, g.String())
-	}
-
 	// Make sure B is in there
-	for _, v := range deps.List() {
+	for _, v := range g.Ancestors(vertexB) {
 		if dag.VertexName(v) == A {
 			// Success
 			return

--- a/internal/terraform/node_resource_apply_test.go
+++ b/internal/terraform/node_resource_apply_test.go
@@ -26,7 +26,7 @@ func TestNodeExpandApplyableResourceExecute(t *testing.T) {
 				Config: nil,
 			},
 		}
-		diags := node.Execute(ctx, walkApply)
+		_, diags := node.DynamicExpand(ctx)
 		if diags.HasErrors() {
 			t.Fatalf("unexpected error: %s", diags.Err())
 		}
@@ -57,10 +57,11 @@ func TestNodeExpandApplyableResourceExecute(t *testing.T) {
 				},
 			},
 		}
-		diags := node.Execute(ctx, walkApply)
+		_, diags := node.DynamicExpand(ctx)
 		if diags.HasErrors() {
 			t.Fatalf("unexpected error: %s", diags.Err())
 		}
+
 		if state.Empty() {
 			t.Fatal("expected resources in state, got empty state")
 		}

--- a/internal/terraform/transform_destroy_edge.go
+++ b/internal/terraform/transform_destroy_edge.go
@@ -346,6 +346,16 @@ func (t *pruneUnusedNodesTransformer) Transform(g *Graph) error {
 					}
 
 				case graphNodeExpandsInstances:
+					// FIXME: Ephemeral resources have kind of broken this
+					// transformer. They work like temporary values in that they
+					// should not exist when there are no dependencies, but also
+					// share expansion nodes with all other resource modes. We
+					// can't use graphNodeTemporaryValue because then all
+					// resources will be caught by the previous case here.
+					if n, ok := n.(GraphNodeConfigResource); ok && n.ResourceAddr().Resource.Mode == addrs.EphemeralResourceMode {
+						return
+					}
+
 					// Any nodes that expand instances are kept when their
 					// instances may need to be evaluated.
 					for _, v := range g.UpEdges(n) {

--- a/internal/terraform/transform_reference.go
+++ b/internal/terraform/transform_reference.go
@@ -254,15 +254,10 @@ func (t AttachDependenciesTransformer) Transform(g *Graph) error {
 			}
 		}
 
-		ans, err := g.Ancestors(v)
-		if err != nil {
-			return err
-		}
-
 		// dedupe addrs when there's multiple instances involved, or
 		// multiple paths in the un-reduced graph
 		depMap := map[string]addrs.ConfigResource{}
-		for _, d := range ans {
+		for _, d := range g.Ancestors(v) {
 			var addr addrs.ConfigResource
 
 			switch d := d.(type) {
@@ -386,8 +381,7 @@ func (m ReferenceMap) dependsOn(g *Graph, depender graphNodeDependsOn) ([]dag.Ve
 			// upstream managed resource in order to check for a planned
 			// change.
 			if _, ok := rv.(GraphNodeConfigResource); !ok {
-				ans, _ := g.Ancestors(rv)
-				for _, v := range ans {
+				for _, v := range g.Ancestors(rv) {
 					if isDependableResource(v) {
 						res = append(res, v)
 					}
@@ -460,8 +454,7 @@ func (m ReferenceMap) parentModuleDependsOn(g *Graph, depender graphNodeDependsO
 			}
 		}
 
-		ans, _ := g.Ancestors(deps...)
-		for _, v := range ans {
+		for _, v := range g.Ancestors(deps...) {
 			if isDependableResource(v) {
 				res = append(res, v)
 			}

--- a/internal/terraform/transform_targets.go
+++ b/internal/terraform/transform_targets.go
@@ -64,8 +64,7 @@ func (t *TargetsTransformer) selectTargetedNodes(g *Graph, addrs []addrs.Targeta
 				tn.SetTargets(addrs)
 			}
 
-			deps, _ := g.Ancestors(v)
-			for _, d := range deps {
+			for _, d := range g.Ancestors(v) {
 				targetedNodes.Add(d)
 			}
 		}
@@ -91,7 +90,7 @@ func (t *TargetsTransformer) selectTargetedNodes(g *Graph, addrs []addrs.Targeta
 
 		// If this output is descended only from targeted resources, then we
 		// will keep it
-		deps, _ := g.Ancestors(v)
+		deps := g.Ancestors(v)
 		found := 0
 		for _, d := range deps {
 			switch d.(type) {


### PR DESCRIPTION
Make sure ephemeral resources are inserted into the graph and evaluated during both apply and destroy operations. We make sure we insert ephemeral `nodeExpandApplyableResource` from the configuration during destroy, and that it can always correctly call the ephemeral planning path in both situations.

`CloseProviderTransformer` was fixed to use the `GraphNodeProviderConsumer` to connect the close nodes, so that ephemeral resource close nodes can be inserted into the graph without special casing them.

Some minor refactor from various experiment was left in here too, like change `AcyclicGraph.Ancestors` to not return an error which matches the `Descendants` behavior. 

This does not yet fix the hard problem of pruning unused/unusable ephemeral resource nodes from the graph when executing a partial destroy, as denoted with a `FIXME` in the source. These types of failures aren't quite as troublesome as the equivalent temporary value failures, because ephemeral resources typically will have very few inputs from managed resources in practice, whereas other temporary values are used to process anything and everything in a configuration.