### PR TITLE
test: Add support for ephemeral values and an error for ephemeral resources

### DIFF
--- a/internal/backend/local/test.go
+++ b/internal/backend/local/test.go
@@ -528,7 +528,7 @@ func (runner *TestFileRunner) run(run *moduletest.Run, file *moduletest.File, st
 	}
 	run.Diagnostics = filteredDiags
 
-	applyScope, updated, applyDiags := runner.apply(tfCtx, plan, state, config, run, file, moduletest.Running, start)
+	applyScope, updated, applyDiags := runner.apply(tfCtx, plan, state, config, run, file, moduletest.Running, start, variables)
 
 	// Remove expected diagnostics, and add diagnostics in case anything that should have failed didn't.
 	applyDiags = run.ValidateExpectedFailures(applyDiags)
@@ -684,7 +684,7 @@ func (runner *TestFileRunner) destroy(config *configs.Config, state *states.Stat
 		return state, diags
 	}
 
-	_, updated, applyDiags := runner.apply(tfCtx, plan, state, config, run, file, moduletest.TearDown, start)
+	_, updated, applyDiags := runner.apply(tfCtx, plan, state, config, run, file, moduletest.TearDown, start, variables)
 	diags = diags.Append(applyDiags)
 	return updated, diags
 }
@@ -746,7 +746,7 @@ func (runner *TestFileRunner) plan(tfCtx *terraform.Context, config *configs.Con
 	return planScope, plan, diags
 }
 
-func (runner *TestFileRunner) apply(tfCtx *terraform.Context, plan *plans.Plan, state *states.State, config *configs.Config, run *moduletest.Run, file *moduletest.File, progress moduletest.Progress, start int64) (*lang.Scope, *states.State, tfdiags.Diagnostics) {
+func (runner *TestFileRunner) apply(tfCtx *terraform.Context, plan *plans.Plan, state *states.State, config *configs.Config, run *moduletest.Run, file *moduletest.File, progress moduletest.Progress, start int64, variables terraform.InputValues) (*lang.Scope, *states.State, tfdiags.Diagnostics) {
 	log.Printf("[TRACE] TestFileRunner: called apply for %s/%s", file.Name, run.Name)
 
 	var diags tfdiags.Diagnostics
@@ -776,11 +776,26 @@ func (runner *TestFileRunner) apply(tfCtx *terraform.Context, plan *plans.Plan, 
 	var applyDiags tfdiags.Diagnostics
 	var newScope *lang.Scope
 
+	// We only need to pass ephemeral variables to the apply operation, as the
+	// plan has already been evaluated with the full set of variables.
+	ephermeralVariables := make(terraform.InputValues)
+	for k, v := range config.Root.Module.Variables {
+		if v.EphemeralSet {
+			if value, ok := variables[k]; ok {
+				ephermeralVariables[k] = value
+			}
+		}
+	}
+
+	applyOpts := &terraform.ApplyOpts{
+		SetVariables: ephermeralVariables,
+	}
+
 	go func() {
 		defer logging.PanicHandler()
 		defer done()
 		log.Printf("[DEBUG] TestFileRunner: starting apply for %s/%s", file.Name, run.Name)
-		updated, newScope, applyDiags = tfCtx.ApplyAndEval(plan, config, nil)
+		updated, newScope, applyDiags = tfCtx.ApplyAndEval(plan, config, applyOpts)
 		log.Printf("[DEBUG] TestFileRunner: completed apply for %s/%s", file.Name, run.Name)
 	}()
 	waitDiags, cancelled := runner.wait(tfCtx, runningCtx, run, file, created, progress, start)

--- a/internal/backend/local/test.go
+++ b/internal/backend/local/test.go
@@ -778,17 +778,17 @@ func (runner *TestFileRunner) apply(tfCtx *terraform.Context, plan *plans.Plan, 
 
 	// We only need to pass ephemeral variables to the apply operation, as the
 	// plan has already been evaluated with the full set of variables.
-	ephermeralVariables := make(terraform.InputValues)
+	ephemeralVariables := make(terraform.InputValues)
 	for k, v := range config.Root.Module.Variables {
 		if v.EphemeralSet {
 			if value, ok := variables[k]; ok {
-				ephermeralVariables[k] = value
+				ephemeralVariables[k] = value
 			}
 		}
 	}
 
 	applyOpts := &terraform.ApplyOpts{
-		SetVariables: ephermeralVariables,
+		SetVariables: ephemeralVariables,
 	}
 
 	go func() {

--- a/internal/command/test_test.go
+++ b/internal/command/test_test.go
@@ -27,7 +27,7 @@ func TestTest_Runs(t *testing.T) {
 		override              string
 		args                  []string
 		envVars               map[string]string
-		expectedOut           string
+		expectedOut           []string
 		expectedErr           []string
 		expectedResourceCount int
 		code                  int
@@ -35,27 +35,27 @@ func TestTest_Runs(t *testing.T) {
 		skip                  bool
 	}{
 		"simple_pass": {
-			expectedOut: "1 passed, 0 failed.",
+			expectedOut: []string{"1 passed, 0 failed."},
 			code:        0,
 		},
 		"simple_pass_nested": {
-			expectedOut: "1 passed, 0 failed.",
+			expectedOut: []string{"1 passed, 0 failed."},
 			code:        0,
 		},
 		"simple_pass_nested_alternate": {
 			args:        []string{"-test-directory", "other"},
-			expectedOut: "1 passed, 0 failed.",
+			expectedOut: []string{"1 passed, 0 failed."},
 			code:        0,
 		},
 		"simple_pass_very_nested": {
 			args:        []string{"-test-directory", "tests/subdir"},
-			expectedOut: "1 passed, 0 failed.",
+			expectedOut: []string{"1 passed, 0 failed."},
 			code:        0,
 		},
 		"simple_pass_very_nested_alternate": {
 			override:    "simple_pass_very_nested",
 			args:        []string{"-test-directory", "./tests/subdir"},
-			expectedOut: "1 passed, 0 failed.",
+			expectedOut: []string{"1 passed, 0 failed."},
 			code:        0,
 		},
 		"simple_pass_bad_test_directory": {
@@ -71,155 +71,155 @@ func TestTest_Runs(t *testing.T) {
 			code:        1,
 		},
 		"pass_with_locals": {
-			expectedOut: "1 passed, 0 failed.",
+			expectedOut: []string{"1 passed, 0 failed."},
 			code:        0,
 		},
 		"pass_with_outputs": {
-			expectedOut: "1 passed, 0 failed.",
+			expectedOut: []string{"1 passed, 0 failed."},
 			code:        0,
 		},
 		"pass_with_variables": {
-			expectedOut: "2 passed, 0 failed.",
+			expectedOut: []string{"2 passed, 0 failed."},
 			code:        0,
 		},
 		"plan_then_apply": {
-			expectedOut: "2 passed, 0 failed.",
+			expectedOut: []string{"2 passed, 0 failed."},
 			code:        0,
 		},
 		"expect_failures_checks": {
-			expectedOut: "1 passed, 0 failed.",
+			expectedOut: []string{"1 passed, 0 failed."},
 			code:        0,
 		},
 		"expect_failures_inputs": {
-			expectedOut: "1 passed, 0 failed.",
+			expectedOut: []string{"1 passed, 0 failed."},
 			code:        0,
 		},
 		"expect_failures_outputs": {
-			expectedOut: "1 passed, 0 failed.",
+			expectedOut: []string{"1 passed, 0 failed."},
 			code:        0,
 		},
 		"expect_failures_resources": {
-			expectedOut: "1 passed, 0 failed.",
+			expectedOut: []string{"1 passed, 0 failed."},
 			code:        0,
 		},
 		"multiple_files": {
-			expectedOut: "2 passed, 0 failed",
+			expectedOut: []string{"2 passed, 0 failed"},
 			code:        0,
 		},
 		"multiple_files_with_filter": {
 			override:    "multiple_files",
 			args:        []string{"-filter=one.tftest.hcl"},
-			expectedOut: "1 passed, 0 failed",
+			expectedOut: []string{"1 passed, 0 failed"},
 			code:        0,
 		},
 		"variables": {
-			expectedOut: "2 passed, 0 failed",
+			expectedOut: []string{"2 passed, 0 failed"},
 			code:        0,
 		},
 		"variables_overridden": {
 			override:    "variables",
 			args:        []string{"-var=input=foo"},
-			expectedOut: "1 passed, 1 failed",
+			expectedOut: []string{"1 passed, 1 failed"},
 			expectedErr: []string{`invalid value`},
 			code:        1,
 		},
 		"simple_fail": {
-			expectedOut: "0 passed, 1 failed.",
+			expectedOut: []string{"0 passed, 1 failed."},
 			expectedErr: []string{"invalid value"},
 			code:        1,
 		},
 		"custom_condition_checks": {
-			expectedOut: "0 passed, 1 failed.",
+			expectedOut: []string{"0 passed, 1 failed."},
 			expectedErr: []string{"this really should fail"},
 			code:        1,
 		},
 		"custom_condition_inputs": {
-			expectedOut: "0 passed, 1 failed.",
+			expectedOut: []string{"0 passed, 1 failed."},
 			expectedErr: []string{"this should definitely fail"},
 			code:        1,
 		},
 		"custom_condition_outputs": {
-			expectedOut: "0 passed, 1 failed.",
+			expectedOut: []string{"0 passed, 1 failed."},
 			expectedErr: []string{"this should fail"},
 			code:        1,
 		},
 		"custom_condition_resources": {
-			expectedOut: "0 passed, 1 failed.",
+			expectedOut: []string{"0 passed, 1 failed."},
 			expectedErr: []string{"this really should fail"},
 			code:        1,
 		},
 		"no_providers_in_main": {
-			expectedOut: "1 passed, 0 failed",
+			expectedOut: []string{"1 passed, 0 failed"},
 			code:        0,
 		},
 		"default_variables": {
-			expectedOut: "1 passed, 0 failed.",
+			expectedOut: []string{"1 passed, 0 failed."},
 			code:        0,
 		},
 		"undefined_variables": {
-			expectedOut: "1 passed, 0 failed.",
+			expectedOut: []string{"1 passed, 0 failed."},
 			code:        0,
 		},
 		"shared_state": {
-			expectedOut: "2 passed, 0 failed.",
+			expectedOut: []string{"2 passed, 0 failed."},
 			code:        0,
 		},
 		"shared_state_object": {
-			expectedOut: "2 passed, 0 failed.",
+			expectedOut: []string{"2 passed, 0 failed."},
 			code:        0,
 		},
 		"variable_references": {
-			expectedOut: "2 passed, 0 failed.",
+			expectedOut: []string{"2 passed, 0 failed."},
 			args:        []string{"-var=global=\"triple\""},
 			code:        0,
 		},
 		"unreferenced_global_variable": {
 			override:    "variable_references",
-			expectedOut: "2 passed, 0 failed.",
+			expectedOut: []string{"2 passed, 0 failed."},
 			// The other variable shouldn't pass validation, but it won't be
 			// referenced anywhere so should just be ignored.
 			args: []string{"-var=global=\"triple\"", "-var=other=bad"},
 			code: 0,
 		},
 		"variables_types": {
-			expectedOut: "1 passed, 0 failed.",
+			expectedOut: []string{"1 passed, 0 failed."},
 			args:        []string{"-var=number_input=0", "-var=string_input=Hello, world!", "-var=list_input=[\"Hello\",\"world\"]"},
 			code:        0,
 		},
 		"null-outputs": {
-			expectedOut: "2 passed, 0 failed.",
+			expectedOut: []string{"2 passed, 0 failed."},
 			code:        0,
 		},
 		"destroy_fail": {
-			expectedOut:           "1 passed, 0 failed.",
+			expectedOut:           []string{"1 passed, 0 failed."},
 			expectedErr:           []string{`Terraform left the following resources in state`},
 			code:                  1,
 			expectedResourceCount: 1,
 		},
 		"default_optional_values": {
-			expectedOut: "4 passed, 0 failed.",
+			expectedOut: []string{"4 passed, 0 failed."},
 			code:        0,
 		},
 		"tfvars_in_test_dir": {
-			expectedOut: "2 passed, 0 failed.",
+			expectedOut: []string{"2 passed, 0 failed."},
 			code:        0,
 		},
 		"auto_tfvars_in_test_dir": {
 			override:    "tfvars_in_test_dir",
 			args:        []string{"-test-directory=alternate"},
-			expectedOut: "2 passed, 0 failed.",
+			expectedOut: []string{"2 passed, 0 failed."},
 			code:        0,
 		},
 		"functions_available": {
-			expectedOut: "2 passed, 0 failed.",
+			expectedOut: []string{"2 passed, 0 failed."},
 			code:        0,
 		},
 		"provider-functions-available": {
-			expectedOut: "1 passed, 0 failed.",
+			expectedOut: []string{"1 passed, 0 failed."},
 			code:        0,
 		},
 		"mocking": {
-			expectedOut: "6 passed, 0 failed.",
+			expectedOut: []string{"6 passed, 0 failed."},
 			code:        0,
 		},
 		"mocking-invalid": {
@@ -227,52 +227,51 @@ func TestTest_Runs(t *testing.T) {
 			initCode:    1,
 		},
 		"dangling_data_block": {
-			expectedOut: "2 passed, 0 failed.",
+			expectedOut: []string{"2 passed, 0 failed."},
 			code:        0,
 		},
 		"skip_destroy_on_empty": {
-			expectedOut: "3 passed, 0 failed.",
+			expectedOut: []string{"3 passed, 0 failed."},
 			code:        0,
 		},
 		"empty_module_with_output": {
-			expectedOut: "1 passed, 0 failed.",
+			expectedOut: []string{"1 passed, 0 failed."},
 			code:        0,
 		},
 		"global_var_refs": {
-			expectedOut: "1 passed, 2 failed.",
+			expectedOut: []string{"1 passed, 2 failed."},
 			expectedErr: []string{"The input variable \"env_var_input\" is not available to the current context", "The input variable \"setup\" is not available to the current context"},
 			code:        1,
 		},
 		"global_var_ref_in_suite_var": {
-			expectedOut: "1 passed, 0 failed.",
+			expectedOut: []string{"1 passed, 0 failed."},
 			code:        0,
 		},
 		"env-vars": {
-			expectedOut: "1 passed, 0 failed.",
+			expectedOut: []string{"1 passed, 0 failed."},
 			envVars: map[string]string{
 				"TF_VAR_input": "foo",
 			},
 			code: 0,
 		},
 		"env-vars-in-module": {
-			expectedOut: "2 passed, 0 failed.",
+			expectedOut: []string{"2 passed, 0 failed."},
 			envVars: map[string]string{
 				"TF_VAR_input": "foo",
 			},
 			code: 0,
 		},
 		"ephemeral_input": {
-			expectedOut: "2 passed, 0 failed.",
+			expectedOut: []string{"2 passed, 0 failed."},
 			code:        0,
 		},
 		"ephemeral_input_with_error": {
-			expectedOut: "1 passed, 1 failed.",
-			// TODO: This error should not print baz but display the ephemeral value otherwise
-			expectedErr: []string{"Expecting this to fail, real value is: baz"},
+			expectedOut: []string{"Error message refers to ephemeral values", "1 passed, 1 failed."},
+			expectedErr: []string{"Test assertion failed"},
 			code:        1,
 		},
 		"ephemeral_resource": {
-			expectedOut: "0 passed, 1 failed.",
+			expectedOut: []string{"0 passed, 1 failed."},
 			// TODO: Improve error message, say something about ephemeral resources not being accessible in tests due to their ephemeral nature
 			expectedErr: []string{"Ephemeral resource instance has expired"},
 			code:        1,
@@ -335,8 +334,12 @@ func TestTest_Runs(t *testing.T) {
 				output := done(t).All()
 				stdout, stderr := output, output
 
-				if !strings.Contains(stdout, tc.expectedOut) {
-					t.Errorf("output didn't contain expected string:\n\n%s", stdout)
+				if len(tc.expectedOut) > 0 {
+					for _, expectedOut := range tc.expectedOut {
+						if !strings.Contains(stdout, expectedOut) {
+							t.Errorf("output didn't contain expected string:\n\n%s", stdout)
+						}
+					}
 				}
 
 				if len(tc.expectedErr) > 0 {
@@ -374,8 +377,12 @@ func TestTest_Runs(t *testing.T) {
 				t.Errorf("expected status code %d but got %d:\n\n%s", tc.code, code, output.All())
 			}
 
-			if !strings.Contains(output.Stdout(), tc.expectedOut) {
-				t.Errorf("output didn't contain expected string:\n\n%s", output.Stdout())
+			if len(tc.expectedOut) > 0 {
+				for _, expectedOut := range tc.expectedOut {
+					if !strings.Contains(output.Stdout(), expectedOut) {
+						t.Errorf("output didn't contain expected string:\n\n%s", output.Stdout())
+					}
+				}
 			}
 
 			if len(tc.expectedErr) > 0 {

--- a/internal/command/test_test.go
+++ b/internal/command/test_test.go
@@ -273,7 +273,7 @@ func TestTest_Runs(t *testing.T) {
 		"ephemeral_resource": {
 			expectedOut: []string{"0 passed, 1 failed."},
 			// TODO: Improve error message, say something about ephemeral resources not being accessible in tests due to their ephemeral nature
-			expectedErr: []string{"Ephemeral resource instance has expired"},
+			expectedErr: []string{"Ephemeral resource instance has expired", "Ephemeral resources not supported in the context of tests"},
 			code:        1,
 		},
 	}

--- a/internal/command/test_test.go
+++ b/internal/command/test_test.go
@@ -272,8 +272,7 @@ func TestTest_Runs(t *testing.T) {
 		},
 		"ephemeral_resource": {
 			expectedOut: []string{"0 passed, 1 failed."},
-			// TODO: Improve error message, say something about ephemeral resources not being accessible in tests due to their ephemeral nature
-			expectedErr: []string{"Ephemeral resource instance has expired", "Ephemeral resources not supported in the context of tests"},
+			expectedErr: []string{"Ephemeral resource instance has expired", "Ephemeral resources cannot be asserted"},
 			code:        1,
 		},
 	}

--- a/internal/command/test_test.go
+++ b/internal/command/test_test.go
@@ -261,6 +261,22 @@ func TestTest_Runs(t *testing.T) {
 			},
 			code: 0,
 		},
+		"ephemeral_input": {
+			expectedOut: "2 passed, 0 failed.",
+			code:        0,
+		},
+		"ephemeral_input_with_error": {
+			expectedOut: "1 passed, 1 failed.",
+			// TODO: This error should not print baz but display the ephemeral value otherwise
+			expectedErr: []string{"Expecting this to fail, real value is: baz"},
+			code:        1,
+		},
+		"ephemeral_resource": {
+			expectedOut: "0 passed, 1 failed.",
+			// TODO: Improve error message, say something about ephemeral resources not being accessible in tests due to their ephemeral nature
+			expectedErr: []string{"Ephemeral resource instance has expired"},
+			code:        1,
+		},
 	}
 	for name, tc := range tcs {
 		t.Run(name, func(t *testing.T) {

--- a/internal/command/test_test.go
+++ b/internal/command/test_test.go
@@ -267,7 +267,7 @@ func TestTest_Runs(t *testing.T) {
 		},
 		"ephemeral_input_with_error": {
 			expectedOut: []string{"Error message refers to ephemeral values", "1 passed, 1 failed."},
-			expectedErr: []string{"Test assertion failed"},
+			expectedErr: []string{"Test assertion failed", "has an ephemeral value"},
 			code:        1,
 		},
 		"ephemeral_resource": {

--- a/internal/command/testdata/test/ephemeral_input/main.tf
+++ b/internal/command/testdata/test/ephemeral_input/main.tf
@@ -1,0 +1,7 @@
+variable "foo" {
+    ephemeral = true
+    type = string
+}
+output "value" {
+  value = "Hello, World!"
+}

--- a/internal/command/testdata/test/ephemeral_input/main.tftest.hcl
+++ b/internal/command/testdata/test/ephemeral_input/main.tftest.hcl
@@ -1,0 +1,19 @@
+run "validate_ephemeral_input" {
+  variables {
+    foo = "bar"
+  }
+  assert {
+    condition = var.foo == "bar"
+    error_message = "Should be accessible"
+  }
+}
+
+run "validate_ephemeral_input_is_ephemeral" {
+  variables {
+    foo = "bar"
+  }
+  assert {
+    condition = ephemeralasnull(var.foo) == null
+    error_message = "Should be ephemeral"
+  }
+}

--- a/internal/command/testdata/test/ephemeral_input_with_error/main.tf
+++ b/internal/command/testdata/test/ephemeral_input_with_error/main.tf
@@ -1,0 +1,7 @@
+variable "foo" {
+    ephemeral = true
+    type = string
+}
+output "value" {
+  value = "Hello, World!"
+}

--- a/internal/command/testdata/test/ephemeral_input_with_error/main.tftest.hcl
+++ b/internal/command/testdata/test/ephemeral_input_with_error/main.tftest.hcl
@@ -1,0 +1,19 @@
+run "validate_ephemeral_input" {
+  variables {
+    foo = "baz"
+  }
+  assert {
+    condition = var.foo == "bar"
+    error_message = "Expecting this to fail, real value is: ${var.foo}"
+  }
+}
+
+run "validate_ephemeral_input_is_ephemeral" {
+  variables {
+    foo = "bar"
+  }
+  assert {
+    condition = ephemeralasnull(var.foo) == null
+    error_message = "Should be ephemeral"
+  }
+}

--- a/internal/command/testdata/test/ephemeral_resource/main.tf
+++ b/internal/command/testdata/test/ephemeral_resource/main.tf
@@ -1,0 +1,2 @@
+ephemeral "test_ephemeral_resource" "data" {
+}

--- a/internal/command/testdata/test/ephemeral_resource/main.tftest.hcl
+++ b/internal/command/testdata/test/ephemeral_resource/main.tftest.hcl
@@ -1,0 +1,6 @@
+run "validate_ephemeral_resource" {
+  assert {
+    condition = ephemeral.test_ephemeral_resource.data.value == "bar"
+    error_message = "We expect this to fail since ephemeral resources should be closed when this is evaluated"
+  }
+}

--- a/internal/command/testing/test_provider.go
+++ b/internal/command/testing/test_provider.go
@@ -63,6 +63,18 @@ var (
 				},
 			},
 		},
+		EphemeralResourceTypes: map[string]providers.Schema{
+			"test_ephemeral_resource": {
+				Block: &configschema.Block{
+					Attributes: map[string]*configschema.Attribute{
+						"value": {
+							Type:     cty.String,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
 		Functions: map[string]providers.FunctionDecl{
 			"is_true": {
 				Parameters: []providers.FunctionParam{
@@ -110,6 +122,8 @@ func NewProvider(store *ResourceStore) *TestProvider {
 	provider.Provider.ReadResourceFn = provider.ReadResource
 	provider.Provider.ReadDataSourceFn = provider.ReadDataSource
 	provider.Provider.CallFunctionFn = provider.CallFunction
+	provider.Provider.OpenEphemeralResourceFn = provider.OpenEphemeralResource
+	provider.Provider.CloseEphemeralResourceFn = provider.CloseEphemeralResource
 
 	return provider
 }
@@ -338,6 +352,17 @@ func (provider *TestProvider) CallFunction(request providers.CallFunctionRequest
 			Err: fmt.Errorf("unknown function %q", request.FunctionName),
 		}
 	}
+}
+
+func (provider *TestProvider) OpenEphemeralResource(providers.OpenEphemeralResourceRequest) (resp providers.OpenEphemeralResourceResponse) {
+	resp.Result = cty.ObjectVal(map[string]cty.Value{
+		"value": cty.StringVal("bar"),
+	})
+	return resp
+}
+
+func (provider *TestProvider) CloseEphemeralResource(providers.CloseEphemeralResourceRequest) (resp providers.CloseEphemeralResourceResponse) {
+	return resp
 }
 
 // ResourceStore manages a set of cty.Value resources that can be shared between

--- a/internal/command/views/json/diagnostic.go
+++ b/internal/command/views/json/diagnostic.go
@@ -313,6 +313,17 @@ func NewDiagnostic(diag tfdiags.Diagnostic, sources map[string][]byte) *Diagnost
 							}
 						}
 						switch {
+						case val.HasMark(marks.Sensitive) && val.HasMark(marks.Ephemeral):
+							// We only mention the combination of sensitive and ephemeral
+							// values if the diagnostic we're rendering is explicitly
+							// marked as being caused by sensitive and ephemeral values,
+							// because otherwise readers tend to be misled into thinking the error
+							// is caused by the sensitive value even when it isn't.
+							if !includeSensitive || !includeEphemeral {
+								continue Traversals
+							}
+
+							value.Statement = "has an ephemeral, sensitive value"
 						case val.HasMark(marks.Sensitive):
 							// We only mention a sensitive value if the diagnostic
 							// we're rendering is explicitly marked as being

--- a/internal/command/views/json/diagnostic.go
+++ b/internal/command/views/json/diagnostic.go
@@ -326,6 +326,11 @@ func NewDiagnostic(diag tfdiags.Diagnostic, sources map[string][]byte) *Diagnost
 							// in order to minimize the chance of giving away
 							// whatever was sensitive about it.
 							value.Statement = "has a sensitive value"
+						case val.HasMark(marks.Ephemeral):
+							if !includeEphemeral {
+								continue Traversals
+							}
+							value.Statement = "has an ephemeral value"
 						case !val.IsKnown():
 							// We'll avoid saying anything about unknown or
 							// "known after apply" unless the diagnostic is
@@ -367,9 +372,6 @@ func NewDiagnostic(diag tfdiags.Diagnostic, sources map[string][]byte) *Diagnost
 							}
 						default:
 							value.Statement = fmt.Sprintf("is %s", compactValueStr(val))
-						}
-						if includeEphemeral && val.HasMark(marks.Ephemeral) {
-							value.Statement += ", and is ephemeral"
 						}
 						values = append(values, value)
 						seen[traversalStr] = struct{}{}

--- a/internal/lang/checks.go
+++ b/internal/lang/checks.go
@@ -79,9 +79,7 @@ You can correct this by removing references to sensitive values, or by carefully
 			Detail: `The error expression used to explain this condition refers to ephemeral values, so Terraform will not display the resulting message.
 
 You can correct this by removing references to ephemeral values, or by using the ephemeralasnull() function on the references to not reveal ephemeral data.`,
-			Subject:     expr.Range().Ptr(),
-			Expression:  expr,
-			EvalContext: hclCtx,
+			Subject: expr.Range().Ptr(),
 		})
 		return "", diags
 	}

--- a/internal/lang/checks.go
+++ b/internal/lang/checks.go
@@ -72,6 +72,20 @@ You can correct this by removing references to sensitive values, or by carefully
 		return "", diags
 	}
 
+	if _, ephemeral := valMarks[marks.Ephemeral]; ephemeral {
+		diags = diags.Append(&hcl.Diagnostic{
+			Severity: hcl.DiagWarning,
+			Summary:  "Error message refers to ephemeral values",
+			Detail: `The error expression used to explain this condition refers to ephemeral values, so Terraform will not display the resulting message.
+
+You can correct this by removing references to ephemeral values, or by using the ephemeralasnull() function on the references to not reveal ephemeral data.`,
+			Subject:     expr.Range().Ptr(),
+			Expression:  expr,
+			EvalContext: hclCtx,
+		})
+		return "", diags
+	}
+
 	// NOTE: We've discarded any other marks the string might have been carrying,
 	// aside from the sensitive mark.
 

--- a/internal/moduletest/eval_context.go
+++ b/internal/moduletest/eval_context.go
@@ -179,6 +179,8 @@ func (ec *EvalContext) Evaluate() (Status, cty.Value, tfdiags.Diagnostics) {
 				Subject:     rule.Condition.Range().Ptr(),
 				Expression:  rule.Condition,
 				EvalContext: hclCtx,
+				// Make the ephemerality visible
+				Extra: terraform.DiagnosticCausedByEphemeral(true),
 			})
 			continue
 		} else {

--- a/internal/moduletest/eval_context.go
+++ b/internal/moduletest/eval_context.go
@@ -211,8 +211,8 @@ func diagsForEphemeralResources(refs []*addrs.Reference) (diags tfdiags.Diagnost
 			if v.Resource.Mode == addrs.EphemeralResourceMode {
 				diags = diags.Append(&hcl.Diagnostic{
 					Severity: hcl.DiagError,
-					Summary:  "Ephemeral resources not supported in the context of tests",
-					Detail:   "Ephemeral resources are not supported in the context of terraform test.",
+					Summary:  "Ephemeral resources cannot be asserted",
+					Detail:   "Ephemeral resources are closed when the test is finished, and are not available within the test context for assertions.",
 					Subject:  ref.SourceRange.ToHCL().Ptr(),
 				})
 			}

--- a/internal/terraform/diagnostics.go
+++ b/internal/terraform/diagnostics.go
@@ -27,20 +27,20 @@ func (e diagnosticCausedByUnknown) DiagnosticCausedByUnknown() bool {
 	return bool(e)
 }
 
-// diagnosticCausedByEphemeral is an implementation of
+// DiagnosticCausedByEphemeral is an implementation of
 // tfdiags.DiagnosticExtraBecauseEphemeral which we can use in the "Extra" field
 // of a diagnostic to indicate that the problem was caused by ephemeral values
 // being involved in an expression evaluation.
 //
-// When using this, set the Extra to diagnosticCausedByEphemeral(true) and also
+// When using this, set the Extra to DiagnosticCausedByEphemeral(true) and also
 // populate the EvalContext and Expression fields of the diagnostic so that
 // the diagnostic renderer can use all of that information together to assist
 // the user in understanding what was ephemeral.
-type diagnosticCausedByEphemeral bool
+type DiagnosticCausedByEphemeral bool
 
-var _ tfdiags.DiagnosticExtraBecauseEphemeral = diagnosticCausedByEphemeral(true)
+var _ tfdiags.DiagnosticExtraBecauseEphemeral = DiagnosticCausedByEphemeral(true)
 
-func (e diagnosticCausedByEphemeral) DiagnosticCausedByEphemeral() bool {
+func (e DiagnosticCausedByEphemeral) DiagnosticCausedByEphemeral() bool {
 	return bool(e)
 }
 

--- a/internal/terraform/eval_count.go
+++ b/internal/terraform/eval_count.go
@@ -58,7 +58,7 @@ func evaluateCountExpression(expr hcl.Expression, ctx EvalContext, allowUnknown 
 			Summary:  "Invalid count argument",
 			Detail:   `The given "count" value is derived from an ephemeral value, which means that Terraform cannot persist it between plan/apply rounds. Use only non-ephemeral values here.`,
 			Subject:  expr.Range().Ptr(),
-			Extra:    diagnosticCausedByEphemeral(true),
+			Extra:    DiagnosticCausedByEphemeral(true),
 		})
 		return -1, diags
 	}
@@ -98,7 +98,7 @@ func evaluateCountExpressionValue(expr hcl.Expression, ctx EvalContext) (cty.Val
 			// we can't easily do that right now because the hcl.EvalContext
 			// (which is not the same as the ctx we have in scope here) is
 			// hidden away inside ctx.EvaluateExpr.
-			Extra: diagnosticCausedByEphemeral(true),
+			Extra: DiagnosticCausedByEphemeral(true),
 		})
 	}
 

--- a/internal/terraform/eval_for_each.go
+++ b/internal/terraform/eval_for_each.go
@@ -271,7 +271,7 @@ func (ev *forEachEvaluator) ensureNotEphemeral(forEachVal cty.Value) tfdiags.Dia
 			Subject:     ev.expr.Range().Ptr(),
 			Expression:  ev.expr,
 			EvalContext: ev.hclCtx,
-			Extra:       diagnosticCausedByEphemeral(true),
+			Extra:       DiagnosticCausedByEphemeral(true),
 		})
 	}
 


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Adds support for ephemeral values and an error for ephemeral resources to terraform test

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.10.x

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

### ENHANCEMENTS

<!--

Write a short description of the user-facing change. Examples:

- `terraform show -json`: Fixed crash with sensitive set values.
- When rendering a diff, Terraform now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 

- terraform test: Adding support for ephemeral values and an error for ephemeral resources