### PR TITLE
plan: also validate provider requirements from state

### DIFF
--- a/internal/configs/config.go
+++ b/internal/configs/config.go
@@ -347,6 +347,15 @@ func (c *Config) ProviderRequirements() (providerreqs.Requirements, hcl.Diagnost
 	return reqs, diags
 }
 
+// ProviderRequirementsConfigOnly searches the full tree of configuration
+// files for all providers. This function does not consider any test files.
+func (c *Config) ProviderRequirementsConfigOnly() (providerreqs.Requirements, hcl.Diagnostics) {
+	reqs := make(providerreqs.Requirements)
+	diags := c.addProviderRequirements(reqs, true, false)
+
+	return reqs, diags
+}
+
 // ProviderRequirementsShallow searches only the direct receiver for explicit
 // and implicit dependencies on providers. Descendant modules are ignored.
 //

--- a/internal/terraform/context.go
+++ b/internal/terraform/context.go
@@ -10,6 +10,8 @@ import (
 	"sort"
 	"sync"
 
+	"github.com/zclconf/go-cty/cty"
+
 	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/configs"
 	"github.com/hashicorp/terraform/internal/logging"
@@ -17,7 +19,6 @@ import (
 	"github.com/hashicorp/terraform/internal/provisioners"
 	"github.com/hashicorp/terraform/internal/states"
 	"github.com/hashicorp/terraform/internal/tfdiags"
-	"github.com/zclconf/go-cty/cty"
 )
 
 // InputMode defines what sort of input will be asked for when Input
@@ -337,6 +338,51 @@ func (c *Context) watchStop(walker *ContextGraphWalker) (chan struct{}, <-chan s
 	return stop, wait
 }
 
+func (c *Context) checkStateDependencies(state *states.State) tfdiags.Diagnostics {
+	if state == nil {
+		// no state is fine, first time execution etc
+		return nil
+	}
+
+	var diags tfdiags.Diagnostics
+	for providerAddr := range state.ProviderRequirements() {
+		if !c.plugins.HasProvider(providerAddr) {
+			if c.plugins.HasPreloadedSchemaForProvider(providerAddr) {
+				// If the caller provided a preloaded schema for this provider
+				// then we'll take that as a hint that the caller is intending
+				// to handle some of these pre-validation tasks itself and
+				// so we'll just optimistically assume that the caller
+				// has arranged for this to work some other way, or will
+				// return its own version of this error before calling
+				// into here if not.
+				continue
+			}
+			if !providerAddr.IsBuiltIn() {
+				diags = diags.Append(tfdiags.Sourceless(
+					tfdiags.Error,
+					"Missing required provider",
+					fmt.Sprintf(
+						"This state requires provider %s, but that provider isn't available. You may be able to install it automatically by running:\n  terraform init",
+						providerAddr,
+					),
+				))
+			} else {
+				// Built-in providers can never be installed by "terraform init",
+				// so no point in confusing the user by suggesting that.
+				diags = diags.Append(tfdiags.Sourceless(
+					tfdiags.Error,
+					"Missing required provider",
+					fmt.Sprintf(
+						"This state requires built-in provider %s, but that provider isn't available in this Terraform version.",
+						providerAddr,
+					),
+				))
+			}
+		}
+	}
+	return diags
+}
+
 // checkConfigDependencies checks whether the recieving context is able to
 // support the given configuration, returning error diagnostics if not.
 //
@@ -364,7 +410,7 @@ func (c *Context) checkConfigDependencies(config *configs.Config) tfdiags.Diagno
 	// We only check that we have a factory for each required provider, and
 	// assume the caller already assured that any separately-installed
 	// plugins are of a suitable version, match expected checksums, etc.
-	providerReqs, hclDiags := config.ProviderRequirements()
+	providerReqs, hclDiags := config.ProviderRequirementsConfigOnly()
 	diags = diags.Append(hclDiags)
 	if hclDiags.HasErrors() {
 		return diags

--- a/internal/terraform/context_apply_checks_test.go
+++ b/internal/terraform/context_apply_checks_test.go
@@ -469,7 +469,7 @@ check "error" {
 						AttrsJSON: []byte(`{"number": -1}`),
 					},
 					addrs.AbsProviderConfig{
-						Provider: addrs.NewDefaultProvider("test"),
+						Provider: addrs.NewDefaultProvider("checks"),
 						Module:   addrs.RootModule,
 					})
 			}),
@@ -569,7 +569,7 @@ check "passing" {
 						AttrsJSON: []byte(`{"number": -1}`),
 					},
 					addrs.AbsProviderConfig{
-						Provider: addrs.NewDefaultProvider("test"),
+						Provider: addrs.NewDefaultProvider("checks"),
 						Module:   addrs.RootModule,
 					})
 			}),

--- a/internal/terraform/context_plan.go
+++ b/internal/terraform/context_plan.go
@@ -187,6 +187,9 @@ func (c *Context) PlanAndEval(config *configs.Config, prevRunState *states.State
 
 	moreDiags := c.checkConfigDependencies(config)
 	diags = diags.Append(moreDiags)
+	moreDiags = c.checkStateDependencies(prevRunState)
+	diags = diags.Append(moreDiags)
+
 	// If required dependencies are not available then we'll bail early since
 	// otherwise we're likely to just see a bunch of other errors related to
 	// incompatibilities, which could be overwhelming for the user.

--- a/internal/terraform/context_test.go
+++ b/internal/terraform/context_test.go
@@ -203,6 +203,29 @@ resource "implicit_thing" "b" {
 		"main.tf": configSrc,
 	})
 
+	state := states.BuildState(func(state *states.SyncState) {
+		state.SetResourceInstanceCurrent(addrs.AbsResourceInstance{
+			Resource: addrs.ResourceInstance{
+				Resource: addrs.Resource{
+					Mode: addrs.ManagedResourceMode,
+					Type: "implicit3_thing",
+					Name: "c",
+				},
+			},
+		},
+			&states.ResourceInstanceObjectSrc{
+				AttrsJSON: mustParseJson(map[string]interface{}{}),
+				Status:    states.ObjectReady,
+			},
+			addrs.AbsProviderConfig{
+				Provider: addrs.Provider{
+					Type:      "implicit3",
+					Namespace: "hashicorp",
+					Hostname:  "registry.terraform.io",
+				},
+			})
+	})
+
 	// Validate and Plan are the two entry points where we explicitly verify
 	// the available plugins match what the configuration needs. For other
 	// operations we typically fail more deeply in Terraform Core, with
@@ -211,7 +234,7 @@ resource "implicit_thing" "b" {
 	// be worth the complexity to check for them.
 
 	validateDiags := ctx.Validate(cfg, nil)
-	_, planDiags := ctx.Plan(cfg, nil, DefaultPlanOpts)
+	_, planDiags := ctx.Plan(cfg, state, DefaultPlanOpts)
 
 	tests := map[string]tfdiags.Diagnostics{
 		"validate": validateDiags,
@@ -248,6 +271,17 @@ resource "implicit_thing" "b" {
 					`This configuration requires provisioner plugin "nonexist", which isn't available. If you're intending to use an external provisioner plugin, you must install it manually into one of the plugin search directories before running Terraform.`,
 				),
 			)
+
+			if testName == "plan" {
+				// the plan also validates the state
+				wantDiags = wantDiags.Append(
+					tfdiags.Sourceless(
+						tfdiags.Error,
+						"Missing required provider",
+						"This state requires provider registry.terraform.io/hashicorp/implicit3, but that provider isn't available. You may be able to install it automatically by running:\n  terraform init",
+					),
+				)
+			}
 			assertDiagnosticsMatch(t, gotDiags, wantDiags)
 		})
 	}


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

This PR updates the validation of required providers so that it also makes sure any providers required by the state are included. This improves the error message returned when a resource is in state but not in config and has no included provider.

Before

```
╷
│ Error: failed to read schema for null_resource.resource in registry.terraform.io/hashicorp/null: failed to instantiate provider "registry.terraform.io/hashicorp/null" to obtain schema: unavailable provider "registry.terraform.io/hashicorp/null"
│ 
│ 
╵
```

After

```
╷
│ Error: Missing required provider
│ 
│ This state requires provider registry.terraform.io/hashicorp/null, but that provider isn't available. You may be able to install it automatically by
│ running:
│   terraform init
╵
```

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Fixes #35860 

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.9.x

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

### ENHANCEMENTS

<!--

Write a short description of the user-facing change. Examples:

- `terraform show -json`: Fixed crash with sensitive set values.
- When rendering a diff, Terraform now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 

-  Improve error message when provider is required by state but has not been downloaded.
