### PR TITLE
core: use more efficient methods for finding ancestors

### DIFF
--- a/internal/dag/dag_test.go
+++ b/internal/dag/dag_test.go
@@ -317,7 +317,7 @@ func TestAcyclicGraphFindDescendants(t *testing.T) {
 		return v.(int) == 1
 	})
 	if !foundOne {
-		t.Fatal("did not match 6 in the graph")
+		t.Fatal("did not match 1 in the graph")
 	}
 
 	foundSix := g.MatchDescendant(6, func(v Vertex) bool {
@@ -328,6 +328,57 @@ func TestAcyclicGraphFindDescendants(t *testing.T) {
 	}
 
 	foundTen := g.MatchDescendant(6, func(v Vertex) bool {
+		return v.(int) == 10
+	})
+	if foundTen {
+		t.Fatal("10 is not in the graph at all")
+	}
+}
+
+func TestAcyclicGraphFindAncestors(t *testing.T) {
+	var g AcyclicGraph
+	g.Add(0)
+	g.Add(1)
+	g.Add(2)
+	g.Add(3)
+	g.Add(4)
+	g.Add(5)
+	g.Add(6)
+	g.Connect(BasicEdge(1, 0))
+	g.Connect(BasicEdge(2, 1))
+	g.Connect(BasicEdge(6, 2))
+	g.Connect(BasicEdge(4, 3))
+	g.Connect(BasicEdge(5, 4))
+	g.Connect(BasicEdge(6, 5))
+
+	actual := g.FirstAncestorsWith(6, func(v Vertex) bool {
+		// looking for first odd ancestors
+		return v.(int)%2 != 0
+	})
+
+	expected := make(Set)
+	expected.Add(1)
+	expected.Add(5)
+
+	if expected.Intersection(actual).Len() != expected.Len() {
+		t.Fatalf("expected %#v, got %#v\n", expected, actual)
+	}
+
+	foundOne := g.MatchAncestor(6, func(v Vertex) bool {
+		return v.(int) == 1
+	})
+	if !foundOne {
+		t.Fatal("did not match 1 in the graph")
+	}
+
+	foundSix := g.MatchAncestor(6, func(v Vertex) bool {
+		return v.(int) == 6
+	})
+	if foundSix {
+		t.Fatal("6 should not be a descendant of itself")
+	}
+
+	foundTen := g.MatchAncestor(6, func(v Vertex) bool {
 		return v.(int) == 10
 	})
 	if foundTen {

--- a/internal/terraform/transform_reference.go
+++ b/internal/terraform/transform_reference.go
@@ -257,25 +257,30 @@ func (t AttachDependenciesTransformer) Transform(g *Graph) error {
 		// dedupe addrs when there's multiple instances involved, or
 		// multiple paths in the un-reduced graph
 		depMap := map[string]addrs.ConfigResource{}
-		for _, d := range g.Ancestors(v) {
-			var addr addrs.ConfigResource
 
+		// since we need to type-switch over the nodes anyway, we're going to
+		// insert the address directly into depMap and forget about the returned
+		// set.
+		g.FirstAncestorsWith(v, func(d dag.Vertex) bool {
+			var addr addrs.ConfigResource
 			switch d := d.(type) {
-			case GraphNodeResourceInstance:
-				instAddr := d.ResourceInstanceAddr()
+			case GraphNodeCreator:
+				// most of the time we'll hit a GraphNodeConfigResource first since that represents the config structure, but
+				instAddr := d.CreateAddr()
 				addr = instAddr.ContainingResource().Config()
 			case GraphNodeConfigResource:
 				addr = d.ResourceAddr()
 			default:
-				continue
+				return false
 			}
 
 			if matchesSelf(addr) {
-				continue
+				return false
 			}
 
 			depMap[addr.String()] = addr
-		}
+			return true
+		})
 
 		deps := make([]addrs.ConfigResource, 0, len(depMap))
 		for _, d := range depMap {

--- a/internal/terraform/transform_reference.go
+++ b/internal/terraform/transform_reference.go
@@ -386,10 +386,10 @@ func (m ReferenceMap) dependsOn(g *Graph, depender graphNodeDependsOn) ([]dag.Ve
 			// upstream managed resource in order to check for a planned
 			// change.
 			if _, ok := rv.(GraphNodeConfigResource); !ok {
-				for _, v := range g.Ancestors(rv) {
-					if isDependableResource(v) {
-						res = append(res, v)
-					}
+				for _, v := range g.FirstAncestorsWith(rv, func(v dag.Vertex) bool {
+					return isDependableResource(v)
+				}) {
+					res = append(res, v)
 				}
 			}
 		}
@@ -459,8 +459,10 @@ func (m ReferenceMap) parentModuleDependsOn(g *Graph, depender graphNodeDependsO
 			}
 		}
 
-		for _, v := range g.Ancestors(deps...) {
-			if isDependableResource(v) {
+		for _, dep := range deps {
+			for _, v := range g.FirstAncestorsWith(dep, func(v dag.Vertex) bool {
+				return isDependableResource(v)
+			}) {
 				res = append(res, v)
 			}
 		}


### PR DESCRIPTION
Add ancestor equivalents of FirstDescendantsWith and MatchDescendant.

In configurations with long chains of dependencies, we spend a lot of time recording redundant dependency edges, and writing all those dependencies in the state.

Rather than record every possible dependency edge, we can use the new methods above to only record the first managed resource in any lineage, such that the resulting graph is topologically equivalent having removed many transitive edges. For some configurations this can save considerable time and space when handling the state.

While this can remove the bulk of transitive dependencies in a lot of cases, this does not reduce the subgraph of direct dependencies. Take for example a resource `X`, and a graph with edges `X->A` `X->B` `A->B`. We will still currently record both `A` and `B` as dependencies even though the final graph will reduce to just `X->A->B`. Doing that extra processing is a harder cost-tradeoff to make however, and doesn't seem necessary at this point, whereas this PR is never less efficient than tracking all possible ancestors.