### PR TITLE
stacks: fix deferred data sources and unknown component applies

### DIFF
--- a/internal/stacks/stackplan/from_proto.go
+++ b/internal/stacks/stackplan/from_proto.go
@@ -142,7 +142,7 @@ func (l *Loader) AddRaw(rawMsg *anypb.Any) error {
 		}
 
 	case *tfstackdata1.PlanComponentInstance:
-		addr, diags := stackaddrs.ParseAbsComponentInstanceStr(msg.ComponentInstanceAddr)
+		addr, diags := stackaddrs.ParsePartialComponentInstanceStr(msg.ComponentInstanceAddr)
 		if diags.HasErrors() {
 			// Should not get here because the address we're parsing
 			// should've been produced by this same version of Terraform.

--- a/internal/stacks/stackruntime/helper_test.go
+++ b/internal/stacks/stackruntime/helper_test.go
@@ -510,7 +510,7 @@ func mustAbsResourceInstanceObjectPtr(addr string) *stackaddrs.AbsResourceInstan
 }
 
 func mustAbsComponentInstance(addr string) stackaddrs.AbsComponentInstance {
-	ret, diags := stackaddrs.ParseAbsComponentInstanceStr(addr)
+	ret, diags := stackaddrs.ParsePartialComponentInstanceStr(addr)
 	if len(diags) > 0 {
 		panic(fmt.Sprintf("failed to parse component instance address %q: %s", addr, diags))
 	}
@@ -518,7 +518,7 @@ func mustAbsComponentInstance(addr string) stackaddrs.AbsComponentInstance {
 }
 
 func mustAbsComponent(addr string) stackaddrs.AbsComponent {
-	ret, diags := stackaddrs.ParseAbsComponentInstanceStr(addr)
+	ret, diags := stackaddrs.ParsePartialComponentInstanceStr(addr)
 	if len(diags) > 0 {
 		panic(fmt.Sprintf("failed to parse component instance address %q: %s", addr, diags))
 	}

--- a/internal/stacks/stackruntime/internal/stackeval/stubs/unknown.go
+++ b/internal/stacks/stackruntime/internal/stackeval/stubs/unknown.go
@@ -212,7 +212,7 @@ func (u *unknownProvider) ReadDataSource(request providers.ReadDataSourceRequest
 		// unknown values. This isn't the original use case for the mocking
 		// library, but it is doing exactly what we need it to do.
 
-		schema := u.GetProviderSchema().ResourceTypes[request.TypeName]
+		schema := u.GetProviderSchema().DataSources[request.TypeName]
 		val, diags := mocking.PlanComputedValuesForResource(request.Config, schema.Block)
 		if diags.HasErrors() {
 			// All the potential errors we get back from this function are

--- a/internal/stacks/stackruntime/testdata/mainbundle/test/map-object-input/for-each-input/for-each-input.tf
+++ b/internal/stacks/stackruntime/testdata/mainbundle/test/map-object-input/for-each-input/for-each-input.tf
@@ -1,0 +1,7 @@
+variable "input" {
+  type = string
+}
+
+output "value" {
+  value = var.input
+}

--- a/internal/stacks/stackruntime/testdata/mainbundle/test/map-object-input/for-each-input/for-each-input.tfstack.hcl
+++ b/internal/stacks/stackruntime/testdata/mainbundle/test/map-object-input/for-each-input/for-each-input.tfstack.hcl
@@ -1,0 +1,38 @@
+required_providers {
+  testing = {
+    source  = "hashicorp/testing"
+    version = "0.1.0"
+  }
+}
+
+variable "inputs" {
+  type = map(string)
+}
+
+provider "testing" "default" {}
+
+component "self" {
+    for_each = var.inputs
+
+    source = "./"
+
+    providers = {
+        testing = provider.testing.default
+    }
+
+    inputs = {
+        input = each.value
+    }
+}
+
+component "main" {
+    source = "../"
+
+    providers = {
+        testing = provider.testing.default
+    }
+
+    inputs = {
+        input = component.self
+    }
+}

--- a/internal/stacks/stackruntime/testdata/mainbundle/test/map-object-input/map-object-input.tf
+++ b/internal/stacks/stackruntime/testdata/mainbundle/test/map-object-input/map-object-input.tf
@@ -1,0 +1,12 @@
+
+variable "input" {
+  type = map(object({
+    output = string
+  }))
+}
+
+resource "testing_resource" "main" {
+  for_each = var.input
+  id = each.key
+  value = each.value.output
+}

--- a/internal/stacks/stackruntime/testdata/mainbundle/test/with-data-source/deferred-provider-for-each/deferred-provider-for-each.tfstack.hcl
+++ b/internal/stacks/stackruntime/testdata/mainbundle/test/with-data-source/deferred-provider-for-each/deferred-provider-for-each.tfstack.hcl
@@ -1,0 +1,45 @@
+required_providers {
+  testing = {
+    source  = "hashicorp/testing"
+    version = "0.1.0"
+  }
+}
+
+variable "providers" {
+  type = set(string)
+}
+
+provider "testing" "main" {
+  for_each = var.providers
+}
+
+provider "testing" "const" {}
+
+component "main" {
+  source = "../"
+
+  for_each = var.providers
+
+  providers = {
+    // We're testing an unknown component referencing a known provider here.
+    testing = provider.testing.main[each.key]
+  }
+
+  inputs = {
+    id = "data_unknown"
+    resource = "resource_unknown"
+  }
+}
+
+component "const" {
+  source = "../"
+
+  providers = {
+    testing = provider.testing.const
+  }
+
+  inputs = {
+    id = "data_known"
+    resource = "resource_known"
+  }
+}


### PR DESCRIPTION
This PR fixes two bugs within Stacks:

1. A crash that occurs when a deferred provider tries to read data sources.
    * We were wrongly retrieving schemas for data sources from the resource list.
2. Reload totally deferred components during the apply stage to get a properly typed for_each value.
    * Previously, we were loading the instance key type of a deferred component via the `addrs.WildcardKey` object which always returns a totally unknown value.
    * Now, if we would load the type from a wildcard key instead we ask the component to recompute the unknown instance which in turn refetches the instance key type.
    * This fix means that references from deferred components work again during the apply operation.

