### PR TITLE
stacks: include plan and state providers when validating external providers

### DIFF
--- a/internal/terraform/context_apply.go
+++ b/internal/terraform/context_apply.go
@@ -162,7 +162,7 @@ func (c *Context) ApplyAndEval(plan *plans.Plan, config *configs.Config, opts *A
 		return nil, nil, diags
 	}
 
-	moreDiags = checkExternalProviders(config, opts.ExternalProviders)
+	moreDiags = checkExternalProviders(config, plan, nil, opts.ExternalProviders)
 	diags = diags.Append(moreDiags)
 	if moreDiags.HasErrors() {
 		return nil, nil, diags

--- a/internal/terraform/context_plan.go
+++ b/internal/terraform/context_plan.go
@@ -197,7 +197,7 @@ func (c *Context) PlanAndEval(config *configs.Config, prevRunState *states.State
 		return nil, nil, diags
 	}
 
-	providerCfgDiags := checkExternalProviders(config, opts.ExternalProviders)
+	providerCfgDiags := checkExternalProviders(config, nil, prevRunState, opts.ExternalProviders)
 	diags = diags.Append(providerCfgDiags)
 	if providerCfgDiags.HasErrors() {
 		return nil, nil, diags


### PR DESCRIPTION
This PR updates the external provider validation within Terraform Core such that it now includes the plan and/or state files when checking for "required providers". This means that when a user deletes all usages of a given provider they don't need to explicitly add that provider to the required providers block.

This improves the UX for users, since adding providers to the required providers block isn't required, making them do it only after they have removed resources is counter intuitive.