### PR TITLE
docs: Modify passing-providers-explicitly section #35781

### DIFF
--- a/website/docs/language/modules/develop/providers.mdx
+++ b/website/docs/language/modules/develop/providers.mdx
@@ -182,10 +182,10 @@ The keys of the `providers` map are provider configuration names as expected by
 the child module, and the values are the names of corresponding configurations
 in the _current_ module.
 
-Once the `providers` argument is used in a `module` block, it overrides all of
-the default inheritance behavior, so it is necessary to enumerate mappings
-for _all_ of the required providers. This is to avoid confusion and surprises
-that may result when mixing both implicit and explicit provider passing.
+If the unaliased `provider` name is not present in the providers map, 
+it will still be inherited in the same way as implicit provider inheritance.
+`providers` argument used in `module` block will not override the default 
+inheritance behavior.
 
 Additional provider configurations (those with the `alias` argument set) are
 _never_ inherited automatically by child modules, and so must always be passed


### PR DESCRIPTION
<!--

passing-providers-explicitly section states as "Once the providers argument is used in a module block, it overrides all of the default inheritance behavior, so it is necessary to enumerate mappings for all of the required providers." but it's not true.
Even if there is provider argument in module block the default/unaliased provider if not present then inheritance works same way as it works for aliased provider.

-->

<!--

https://github.com/hashicorp/terraform/issues/35781

-->

This is a doc issue so updated the affected documentation page terraform\website\docs\language\modules\develop\providers.mdx

<!--

Target Release

-->

1.10.x

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

### DOC UPDATE

<!--

This is documentation issue, no functionality issue by user. Attaching output of code snipped tested.
![SNS-Topics-Created](https://github.com/user-attachments/assets/40d8a271-c93a-4f43-be0b-2cde2dbc4442)
![Code-with-default-aliased-provider](https://github.com/user-attachments/assets/4d64ca19-ce2b-453b-8601-55ac58915c93)


--> 

-  
