### PR TITLE
Fix typo: correct "infrastruture" to "infrastructure"

### DIFF
--- a/website/docs/language/backend/index.mdx
+++ b/website/docs/language/backend/index.mdx
@@ -84,7 +84,7 @@ or state operations.
 
 After you initialize, Terraform creates a `.terraform/` directory locally. This directory contains the most recent backend configuration, including any authentication parameters you provided to the Terraform CLI. Do not check this directory into Git, as it may contain sensitive credentials for your remote backend.
 
-The local backend configuration is different and entirely separate from the `terraform.tfstate` file that contains [state data](/terraform/language/state) about your real-world infrastruture. Terraform stores the `terraform.tfstate` file in your remote backend.
+The local backend configuration is different and entirely separate from the `terraform.tfstate` file that contains [state data](/terraform/language/state) about your real-world infrastructure. Terraform stores the `terraform.tfstate` file in your remote backend.
 
 When you change backends, Terraform gives you the option to migrate
 your state to the new backend. This lets you adopt backends without losing


### PR DESCRIPTION
This PR addresses a minor typo in the documentation. The word "infrastruture" has been corrected to "infrastructure" to ensure clarity and accuracy.