### PR TITLE
Clarify single-removal behavior in `trimsuffix` and `trimprefix` docs

### DIFF
--- a/website/docs/language/functions/trimprefix.mdx
+++ b/website/docs/language/functions/trimprefix.mdx
@@ -7,7 +7,7 @@ description: |-
 
 # `trimprefix` Function
 
-`trimprefix` removes the specified prefix from the start of the given string. If the string does not start with the prefix, the string is returned unchanged.
+`trimprefix` removes the specified prefix from the start of the given string, but only once. If the string does not begin with the prefix, the original string is returned unchanged.
 
 ## Examples
 
@@ -19,6 +19,11 @@ world
 ```
 > trimprefix("helloworld", "cat")
 helloworld
+```
+
+```
+> trimprefix("--hello", "-")
+-hello
 ```
 
 ## Related Functions

--- a/website/docs/language/functions/trimsuffix.mdx
+++ b/website/docs/language/functions/trimsuffix.mdx
@@ -7,13 +7,23 @@ description: |-
 
 # `trimsuffix` Function
 
-`trimsuffix` removes the specified suffix from the end of the given string.
+`trimsuffix` removes the specified suffix from the end of the given string, but only once, even if the suffix appears multiple times. If the suffix does not appear at the very end of the string, the original string is returned unchanged.
 
 ## Examples
 
 ```
 > trimsuffix("helloworld", "world")
 hello
+```
+
+```
+> trimsuffix("helloworld", "cat")
+helloworld
+```
+
+```
+> trimsuffix("hello--", "-")
+hello-
 ```
 
 ## Related Functions


### PR DESCRIPTION
The doc was not so clear if the suffix was removed multiple times. There is a difference in behavior to `trim`. The documentation is clarified with this MR.

## Target Release

1.10.x

## Draft CHANGELOG entry

### Doc Update
- Clarify single-removal behavior in `trimsuffix` and `trimprefix` docs