### PR TITLE
`plantimestamp` can be unknown during validation

### DIFF
--- a/internal/lang/funcs/datetime.go
+++ b/internal/lang/funcs/datetime.go
@@ -28,6 +28,9 @@ func MakeStaticTimestampFunc(static time.Time) function.Function {
 		Params: []function.Parameter{},
 		Type:   function.StaticReturnType(cty.String),
 		Impl: func(args []cty.Value, retType cty.Type) (cty.Value, error) {
+			if static.IsZero() {
+				return cty.UnknownVal(cty.String), nil
+			}
 			return cty.StringVal(static.Format(time.RFC3339)), nil
 		},
 	})

--- a/internal/lang/functions_test.go
+++ b/internal/lang/functions_test.go
@@ -1377,6 +1377,26 @@ func TestFunctions(t *testing.T) {
 	}
 }
 
+func TestPlanTimeStampUnknown(t *testing.T) {
+	// plantimestamp should return an unknown if there is no timestamp, which
+	// happens during validation
+	expr, parseDiags := hclsyntax.ParseExpression([]byte("plantimestamp()"), "test.hcl", hcl.Pos{Line: 1, Column: 1})
+	if parseDiags.HasErrors() {
+		t.Fatal(parseDiags)
+	}
+
+	scope := &Scope{}
+	got, diags := scope.EvalExpr(expr, cty.DynamicPseudoType)
+	if diags.HasErrors() {
+		t.Fatal(diags.Err())
+
+	}
+
+	if got.IsKnown() {
+		t.Fatalf("plantimestamp() should be unknown, got %#v\n", got)
+	}
+}
+
 const (
 	CipherBase64 = "eczGaDhXDbOFRZGhjx2etVzWbRqWDlmq0bvNt284JHVbwCgObiuyX9uV0LSAMY707IEgMkExJqXmsB4OWKxvB7epRB9G/3+F+pcrQpODlDuL9oDUAsa65zEpYF0Wbn7Oh7nrMQncyUPpyr9WUlALl0gRWytOA23S+y5joa4M34KFpawFgoqTu/2EEH4Xl1zo+0fy73fEto+nfkUY+meuyGZ1nUx/+DljP7ZqxHBFSlLODmtuTMdswUbHbXbWneW51D7Jm7xB8nSdiA2JQNK5+Sg5x8aNfgvFTt/m2w2+qpsyFa5Wjeu6fZmXSl840CA07aXbk9vN4I81WmJyblD/ZA=="
 	PrivateKey   = `


### PR DESCRIPTION
Before a timestamp is assigned during plan, the `time.Time` value will be the zero value for that type. This represents a case where the timestamp is not yet known, but the handling of that timestamp isn't using our usual cty value system for representing unknowns. Rather than refactor the use of the timestamp itself throughout the code, we can simply have the function return an unknown if it encounters a zero value.

Fixes #35898
