### PR TITLE
changelog: add entry for #35806

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ ENHANCEMENTS:
 - Import block validation has been improved to provide more useful errors and catch more invalid cases during `terraform validate` ([#35543](https://github.com/hashicorp/terraform/issues/35543))
 - Performance enhancements for resource evaluation, especially when large numbers of resource instances are involved ([#35558](https://github.com/hashicorp/terraform/issues/35558))
 - The `plan`, `apply`, and `refresh` commands now produce a deprecated warning when using the `-state` flag. Instead use the `path` attribute within the `local` backend to modify the state file. ([#35660](https://github.com/hashicorp/terraform/issues/35660))
+- Refresh-only mode behavior: Plans are now correctly marked as “applyable” if only root output values change between states. Previously, plans required changes in managed resources to be marked “applyable,” which missed modules with only root output value changes. ([#35806](https://github.com/hashicorp/terraform/issues/35806))
 
 UPGRADE NOTES:
 


### PR DESCRIPTION
Plans are now correctly marked as “applyable” if only root output values change between states. Previously, plans required changes in managed resources to be marked “applyable,” which missed modules with only root output value changes. ([#35806](https://github.com/hashicorp/terraform/issues/35806)).