### PR TITLE
fix ephemeral evaluation during with console

### DIFF
--- a/internal/terraform/evaluate.go
+++ b/internal/terraform/evaluate.go
@@ -629,9 +629,9 @@ func (d *evaluationStateData) GetResource(addr addrs.Resource, rng tfdiags.Sourc
 			}
 
 		default:
-			// We should only end up here during the validate walk,
-			// since later walks should have at least partial states populated
-			// for all resources in the configuration.
+			// We should only end up here during the validate walk (or
+			// console/eval), since later walks should have at least partial
+			// states populated for all resources in the configuration.
 			return cty.DynamicVal, diags
 		}
 	}
@@ -790,8 +790,10 @@ func (d *evaluationStateData) GetResource(addr addrs.Resource, rng tfdiags.Sourc
 func (d *evaluationStateData) getEphemeralResource(addr addrs.Resource, rng tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
 
-	if d.Operation == walkValidate {
-		// Ephemeral instances are never live during the validate walk
+	if d.Operation == walkValidate || d.Operation == walkEval {
+		// Ephemeral instances are never live during the validate walk. Eval is
+		// similarly offline, and since there is no value stored we can't return
+		// anything other than dynamic.
 		return cty.DynamicVal.Mark(marks.Ephemeral), diags
 	}
 


### PR DESCRIPTION
The console eval walk is a special case where only state is evaluated, however since ephemeral resources will never have stored state we need to make sure that their evaluation always returns an unknown value.

Fixes #35912

