### PR TITLE
core: check preconditions and postconditions for ephemeral resources

### DIFF
--- a/internal/checks/state_init.go
+++ b/internal/checks/state_init.go
@@ -33,6 +33,10 @@ func collectInitialStatuses(into addrs.Map[addrs.ConfigCheckable, *configCheckab
 		addr := rc.Addr().InModule(moduleAddr)
 		collectInitialStatusForResource(into, addr, rc)
 	}
+	for _, rc := range cfg.Module.EphemeralResources {
+		addr := rc.Addr().InModule(moduleAddr)
+		collectInitialStatusForResource(into, addr, rc)
+	}
 
 	for _, oc := range cfg.Module.Outputs {
 		addr := oc.Addr().InModule(moduleAddr)

--- a/internal/terraform/node_module_variable.go
+++ b/internal/terraform/node_module_variable.go
@@ -230,7 +230,6 @@ func (n *nodeModuleVariable) Execute(ctx EvalContext, op walkOperation) (diags t
 		val, err = n.evalModuleVariable(ctx, false)
 		diags = diags.Append(err)
 	}
-
 	if diags.HasErrors() {
 		return diags
 	}

--- a/internal/terraform/node_module_variable.go
+++ b/internal/terraform/node_module_variable.go
@@ -230,6 +230,7 @@ func (n *nodeModuleVariable) Execute(ctx EvalContext, op walkOperation) (diags t
 		val, err = n.evalModuleVariable(ctx, false)
 		diags = diags.Append(err)
 	}
+
 	if diags.HasErrors() {
 		return diags
 	}

--- a/internal/terraform/node_resource_ephemeral.go
+++ b/internal/terraform/node_resource_ephemeral.go
@@ -132,6 +132,18 @@ func ephemeralResourceOpen(ctx EvalContext, inp ephemeralResourceInput) (*provid
 		Private:    resp.Private,
 	})
 
+	// Postconditions for ephemerals validate only what is returned by
+	// OpenEphemeralResource. These will block downstream dependency operations
+	// if an error is returned, but don't prevent renewal or closing of the
+	// resource.
+	checkDiags = evalCheckRules(
+		addrs.ResourcePostcondition,
+		config.Postconditions,
+		ctx, inp.addr, keyData,
+		tfdiags.Error,
+	)
+	diags = diags.Append(checkDiags)
+
 	return nil, diags
 }
 


### PR DESCRIPTION
Complete custom condition checks for ephemeral resources. These essentially work the same as they do for managed resources, however an ephemeral resource will continue "run" after a failed postcondition, to give the provider a chance to eventually call `Close` if needed.