### PR TITLE
add discrete codepaths for ephemeral apply nodes

### DIFF
--- a/internal/providers/testing/provider_mock.go
+++ b/internal/providers/testing/provider_mock.go
@@ -632,11 +632,6 @@ func (p *MockProvider) RenewEphemeralResource(r providers.RenewEphemeralResource
 		return resp
 	}
 
-	if p.CloseEphemeralResourceCalled {
-		resp.Diagnostics = resp.Diagnostics.Append(fmt.Errorf("CloseEphemeralResource called on %q before RenewEphemeralResource", r.TypeName))
-		return resp
-	}
-
 	p.RenewEphemeralResourceCalled = true
 	p.RenewEphemeralResourceRequest = r
 

--- a/internal/resources/ephemeral/ephemeral_resources.go
+++ b/internal/resources/ephemeral/ephemeral_resources.go
@@ -91,7 +91,14 @@ func (r *Resources) InstanceValue(addr addrs.AbsResourceInstance) (val cty.Value
 	}
 	inst, ok := insts.GetOk(addr)
 	if !ok {
-		return cty.DynamicVal, false
+		// Here we can assume that if the entire resource exists, the instance
+		// is valid because Close removes resources as a whole. Individual
+		// instances may not actually be present when checks are evaluated,
+		// because they are evaluated from instance nodes that are using "self".
+		// The way an instance gets "self" is to call GetResource which needs to
+		// compile all instances into a suitable value, so we may be missing
+		// instances which have not yet been opened.
+		return cty.DynamicVal, true
 	}
 	// If renewal has failed then we can't assume that the object is still
 	// live, but we can still return the original value regardless.

--- a/internal/terraform/context_apply_ephemeral_test.go
+++ b/internal/terraform/context_apply_ephemeral_test.go
@@ -285,6 +285,7 @@ variable "input" {
 }
 
 ephemeral "ephem_resource" "data" {
+  for_each = toset(["a", "b"])
   lifecycle {
     precondition {
       condition = var.input == "ok"
@@ -298,7 +299,7 @@ ephemeral "ephem_resource" "data" {
 }
 
 provider "test" {
-  test_string = ephemeral.ephem_resource.data.value
+  test_string = ephemeral.ephem_resource.data["a"].value
 }
 
 resource "test_object" "test" {

--- a/internal/terraform/context_apply_ephemeral_test.go
+++ b/internal/terraform/context_apply_ephemeral_test.go
@@ -353,6 +353,9 @@ resource "test_object" "test" {
 	})
 	assertNoDiagnostics(t, diags)
 
+	// reset the ephemeral call flags
+	ephem.ConfigureProviderCalled = false
+
 	_, diags = ctx.Apply(plan, m, nil)
 	assertNoDiagnostics(t, diags)
 }

--- a/internal/terraform/context_apply_ephemeral_test.go
+++ b/internal/terraform/context_apply_ephemeral_test.go
@@ -275,3 +275,83 @@ output "data" {
 		t.Error("CloseEphemeralResourceCalled not called")
 	}
 }
+
+func TestContext2Apply_ephemeralChecks(t *testing.T) {
+	// test the full validate-plan-apply lifecycle for ephemeral conditions
+	m := testModuleInline(t, map[string]string{
+		"main.tf": `
+variable "input" {
+  type = string
+}
+
+ephemeral "ephem_resource" "data" {
+  lifecycle {
+    precondition {
+      condition = var.input == "ok"
+      error_message = "input not ok"
+    }
+    postcondition {
+      condition = self.value != null
+      error_message = "value is null"
+    }
+  }
+}
+
+provider "test" {
+  test_string = ephemeral.ephem_resource.data.value
+}
+
+resource "test_object" "test" {
+}
+`,
+	})
+
+	ephem := &testing_provider.MockProvider{
+		GetProviderSchemaResponse: &providers.GetProviderSchemaResponse{
+			EphemeralResourceTypes: map[string]providers.Schema{
+				"ephem_resource": {
+					Block: &configschema.Block{
+						Attributes: map[string]*configschema.Attribute{
+							"value": {
+								Type:     cty.String,
+								Computed: true,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	ephem.OpenEphemeralResourceFn = func(providers.OpenEphemeralResourceRequest) (resp providers.OpenEphemeralResourceResponse) {
+		resp.Result = cty.ObjectVal(map[string]cty.Value{
+			"value": cty.StringVal("test string"),
+		})
+		return resp
+	}
+
+	p := simpleMockProvider()
+
+	ctx := testContext2(t, &ContextOpts{
+		Providers: map[addrs.Provider]providers.Factory{
+			addrs.NewDefaultProvider("ephem"): testProviderFuncFixed(ephem),
+			addrs.NewDefaultProvider("test"):  testProviderFuncFixed(p),
+		},
+	})
+
+	diags := ctx.Validate(m, &ValidateOpts{})
+	assertNoDiagnostics(t, diags)
+
+	plan, diags := ctx.Plan(m, nil, &PlanOpts{
+		SetVariables: InputValues{
+			"input": &InputValue{
+				Value:      cty.StringVal("ok"),
+				SourceType: ValueFromConfig,
+			},
+		},
+	})
+	assertNoDiagnostics(t, diags)
+
+	_, diags = ctx.Apply(plan, m, nil)
+	assertNoDiagnostics(t, diags)
+}

--- a/internal/terraform/node_resource_apply_instance.go
+++ b/internal/terraform/node_resource_apply_instance.go
@@ -145,9 +145,21 @@ func (n *NodeApplyableResourceInstance) Execute(ctx EvalContext, op walkOperatio
 		return n.managedResourceExecute(ctx)
 	case addrs.DataResourceMode:
 		return n.dataResourceExecute(ctx)
+	case addrs.EphemeralResourceMode:
+		return n.ephemeralResourceExecute(ctx)
 	default:
 		panic(fmt.Errorf("unsupported resource mode %s", n.Config.Mode))
 	}
+}
+
+func (n *NodeApplyableResourceInstance) ephemeralResourceExecute(ctx EvalContext) tfdiags.Diagnostics {
+	_, diags := ephemeralResourceOpen(ctx, ephemeralResourceInput{
+		addr:           n.Addr,
+		config:         n.Config,
+		providerConfig: n.ResolvedProvider,
+	})
+
+	return diags
 }
 
 func (n *NodeApplyableResourceInstance) dataResourceExecute(ctx EvalContext) (diags tfdiags.Diagnostics) {


### PR DESCRIPTION
It turns out the reuse of the plan nodes for ephemerals during apply was interfering with how checks are handled in the plan. Since checks already have an established pattern of use, we can avoid the whole issue by using only the resource apply nodes to kick of ephemeral values.

This copies the subset of expansion logic needed from the resource plan node into the apply node. Since the apply time evaluation is much simpler, duplicated code is not overly complex, but we may want to revisit this for refactoring in the future.

Fixes #35924