### PR TITLE
views: move retryLog hook to init view

### DIFF
--- a/internal/command/views/hook_cloud.go
+++ b/internal/command/views/hook_cloud.go
@@ -1,6 +1,3 @@
-// Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: BUSL-1.1
-
 package views
 
 import (
@@ -8,13 +5,24 @@ import (
 	"net/http"
 	"strings"
 	"time"
+
+	"github.com/hashicorp/terraform/internal/terraform"
 )
 
-// CloudHooks provides functions that help with integrating directly into
-// the go-tfe tfe.Client struct.
-type CloudHooks struct {
-	// lastRetry is set to the last time a request was retried.
+type RetryLogHook struct {
+	terraform.NilHook
+
+	view *View
+
 	lastRetry time.Time
+}
+
+var _ terraform.Hook = (*UiHook)(nil)
+
+func NewRetryLoghook(view *View) *RetryLogHook {
+	return &RetryLogHook{
+		view: view,
+	}
 }
 
 // RetryLogHook returns a string providing an update about a request from the
@@ -22,7 +30,7 @@ type CloudHooks struct {
 //
 // If colorize is true, then the value returned by this function should be
 // processed by a colorizer.
-func (hooks *CloudHooks) RetryLogHook(attemptNum int, resp *http.Response, colorize bool) string {
+func (hooks *RetryLogHook) RetryLogHook(attemptNum int, resp *http.Response, colorize bool) string {
 	// Ignore the first retry to make sure any delayed output will
 	// be written to the console before we start logging retries.
 	//

--- a/internal/command/views/hook_cloud.go
+++ b/internal/command/views/hook_cloud.go
@@ -52,7 +52,7 @@ func (hooks *RetryLogHook) RetryLogHook(attemptNum int, resp *http.Response, col
 	if colorize {
 		return strings.TrimSpace(fmt.Sprintf("[reset][yellow]%s[reset]", msg))
 	}
-	return strings.TrimSpace(msg)
+	return hooks.view.colorize.Color(strings.TrimSpace(msg))
 }
 
 // The newline in this error is to make it look good in the CLI!

--- a/internal/command/views/init.go
+++ b/internal/command/views/init.go
@@ -10,12 +10,14 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform/internal/command/arguments"
+	"github.com/hashicorp/terraform/internal/terraform"
 	"github.com/hashicorp/terraform/internal/tfdiags"
 )
 
 // The Init view is used for the init command.
 type Init interface {
 	Diagnostics(diags tfdiags.Diagnostics)
+	Hooks() []terraform.Hook
 	Output(messageCode InitMessageCode, params ...any)
 	LogInitMessage(messageCode InitMessageCode, params ...any)
 	Log(message string, params ...any)
@@ -48,6 +50,12 @@ var _ Init = (*InitHuman)(nil)
 
 func (v *InitHuman) Diagnostics(diags tfdiags.Diagnostics) {
 	v.view.Diagnostics(diags)
+}
+
+func (v *InitHuman) Hooks() []terraform.Hook {
+	return []terraform.Hook{
+		NewRetryLoghook(v.view),
+	}
 }
 
 func (v *InitHuman) Output(messageCode InitMessageCode, params ...any) {
@@ -88,6 +96,12 @@ var _ Init = (*InitJSON)(nil)
 
 func (v *InitJSON) Diagnostics(diags tfdiags.Diagnostics) {
 	v.view.Diagnostics(diags)
+}
+
+func (v *InitJSON) Hooks() []terraform.Hook {
+	return []terraform.Hook{
+		NewRetryLoghook(v.view.view),
+	}
 }
 
 func (v *InitJSON) Output(messageCode InitMessageCode, params ...any) {


### PR DESCRIPTION
The cloud backend includes a retry hook that relies on a [go-tfe](https://github.com/hashicorp/go-tfe) implementation. Since the retry messages from the retry hook were not rendered through a view, the `-json` flag was not respected, leading to mixed (non-pure JSON) output in the terminal whenever retry messages were printed.

This PR proposes moving the retryLog hook into the init view and invoking it from the cloud backend through this view.