### PR TITLE
feat(types.mdx): add hint for difference of tuples and lists

### DIFF
--- a/website/docs/language/expressions/types.mdx
+++ b/website/docs/language/expressions/types.mdx
@@ -80,6 +80,9 @@ List literals can be split into multiple lines for readability, but always
 require a comma between values. A comma after the final value is allowed,
 but not required. Values in a list can be arbitrary expressions.
 
+Tuples do allow elements to have mixed data types, like `["a", 15, true]`. 
+Lists on the other hand have strictly one data type (as seen in the conversion function [tolist](/terraform/language/functions/tolist)).
+
 ### Sets
 
 Terraform does not support directly accessing elements of a set by index because sets are unordered collections. To access elements in a set by index, first convert the set to a list.

--- a/website/docs/language/expressions/types.mdx
+++ b/website/docs/language/expressions/types.mdx
@@ -80,8 +80,7 @@ List literals can be split into multiple lines for readability, but always
 require a comma between values. A comma after the final value is allowed,
 but not required. Values in a list can be arbitrary expressions.
 
-Tuples do allow elements to have mixed data types, like `["a", 15, true]`. 
-Lists on the other hand have strictly one data type (as seen in the conversion function [tolist](/terraform/language/functions/tolist)).
+List and tuples have differences regarding allowed types. See [tuples](/language/expressions/type-constraints#tuple) and [lists](/terraform/language/expressions/type-constraints#list)
 
 ### Sets
 

--- a/website/docs/language/expressions/types.mdx
+++ b/website/docs/language/expressions/types.mdx
@@ -80,7 +80,7 @@ List literals can be split into multiple lines for readability, but always
 require a comma between values. A comma after the final value is allowed,
 but not required. Values in a list can be arbitrary expressions.
 
-List and tuples have differences regarding allowed types. See [tuples](/terraform/language/expressions/type-constraints#tuple) and [lists](/terraform/language/expressions/type-constraints#list)
+Lists and tuples each have different constraints on the types they allow. For more information on the types that each allows, refer to [tuples](/terraform/language/expressions/type-constraints#tuple) and [lists](/terraform/language/expressions/type-constraints#list).
 
 ### Sets
 

--- a/website/docs/language/expressions/types.mdx
+++ b/website/docs/language/expressions/types.mdx
@@ -80,7 +80,7 @@ List literals can be split into multiple lines for readability, but always
 require a comma between values. A comma after the final value is allowed,
 but not required. Values in a list can be arbitrary expressions.
 
-List and tuples have differences regarding allowed types. See [tuples](/language/expressions/type-constraints#tuple) and [lists](/terraform/language/expressions/type-constraints#list)
+List and tuples have differences regarding allowed types. See [tuples](/terraform/language/expressions/type-constraints#tuple) and [lists](/terraform/language/expressions/type-constraints#list)
 
 ### Sets
 


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->
This PR adds a section to the Types list of the terraform docs. On this page, it wasn't explained on how lists and tuples differ. As seen in the documentation of the [`tolist`](https://developer.hashicorp.com/terraform/language/functions/tolist) function, they do clearly have a difference.
<!--

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.10.x

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

### ENHANCEMENTS
- Added the differences between tuples and lists to the [Types](https://developer.hashicorp.com/terraform/language/expressions/types#lists-tuples) documentation

<!--

Write a short description of the user-facing change. Examples:

- `terraform show -json`: Fixed crash with sensitive set values.
- When rendering a diff, Terraform now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 
