### PR TITLE
Handle unknown values in ephemeral resource config

### DIFF
--- a/internal/command/views/hook_json.go
+++ b/internal/command/views/hook_json.go
@@ -167,6 +167,13 @@ func (h *jsonHook) PostRefresh(id terraform.HookResourceIdentity, dk addrs.Depos
 }
 
 func (h *jsonHook) PreEphemeralOp(id terraform.HookResourceIdentity, action plans.Action) (terraform.HookAction, error) {
+	// this uses the same plans.Read action as a data source to indicate that
+	// the ephemeral resource can't be processed until apply, so there is no
+	// progress hook
+	if action == plans.Read {
+		return terraform.HookActionContinue, nil
+	}
+
 	h.view.Hook(json.NewEphemeralOpStart(id.Addr, action))
 	progress := resourceProgress{
 		addr:          id.Addr,

--- a/internal/resources/ephemeral/ephemeral_resources.go
+++ b/internal/resources/ephemeral/ephemeral_resources.go
@@ -212,6 +212,11 @@ type resourceInstanceInternal struct {
 func (r *resourceInstanceInternal) close(ctx context.Context) tfdiags.Diagnostics {
 	var diags tfdiags.Diagnostics
 
+	// if the resource could not be opened, there will not be anything to close either
+	if r.impl == nil {
+		return diags
+	}
+
 	// Stop renewing, if indeed we are. If we previously saw any errors during
 	// renewing then they finally get returned here, to be reported along with
 	// any errors during close.

--- a/internal/terraform/context_plan_ephemeral_test.go
+++ b/internal/terraform/context_plan_ephemeral_test.go
@@ -652,3 +652,84 @@ ephemeral "ephem_resource" "data" {
 		})
 	}
 }
+
+func TestContext2Apply_ephemeralUnknownPlan(t *testing.T) {
+	m := testModuleInline(t, map[string]string{
+		"main.tf": `
+resource "test_instance" "test" {
+}
+
+ephemeral "ephem_resource" "data" {
+  input = test_instance.test.id
+  lifecycle {
+    postcondition {
+      condition = self.value != nil
+      error_message = "should return a value"
+	}
+  }
+}
+
+locals {
+  value = ephemeral.ephem_resource.data.value
+}
+
+// create a sink for the ephemeral value to test
+provider "sink" {
+  test_string = local.value
+}
+
+// we need a resource to ensure the sink provider is configured
+resource "sink_object" "empty" {
+}
+`,
+	})
+
+	ephem := &testing_provider.MockProvider{
+		GetProviderSchemaResponse: &providers.GetProviderSchemaResponse{
+			EphemeralResourceTypes: map[string]providers.Schema{
+				"ephem_resource": {
+					Block: &configschema.Block{
+						Attributes: map[string]*configschema.Attribute{
+							"value": {
+								Type:     cty.String,
+								Computed: true,
+							},
+							"input": {
+								Type:     cty.String,
+								Required: true,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	sink := simpleMockProvider()
+	sink.GetProviderSchemaResponse.ResourceTypes = map[string]providers.Schema{
+		"sink_object": {Block: simpleTestSchema()},
+	}
+	sink.ConfigureProviderFn = func(req providers.ConfigureProviderRequest) (resp providers.ConfigureProviderResponse) {
+		if req.Config.GetAttr("test_string").IsKnown() {
+			t.Error("sink provider config should not be known in this test")
+		}
+		return resp
+	}
+
+	p := testProvider("test")
+
+	ctx := testContext2(t, &ContextOpts{
+		Providers: map[addrs.Provider]providers.Factory{
+			addrs.NewDefaultProvider("ephem"): testProviderFuncFixed(ephem),
+			addrs.NewDefaultProvider("test"):  testProviderFuncFixed(p),
+			addrs.NewDefaultProvider("sink"):  testProviderFuncFixed(sink),
+		},
+	})
+
+	_, diags := ctx.Plan(m, nil, DefaultPlanOpts)
+	assertNoDiagnostics(t, diags)
+
+	if ephem.OpenEphemeralResourceCalled {
+		t.Error("OpenEphemeralResourceCalled called when config was not known")
+	}
+}

--- a/internal/terraform/context_plan_ephemeral_test.go
+++ b/internal/terraform/context_plan_ephemeral_test.go
@@ -665,7 +665,7 @@ ephemeral "ephem_resource" "data" {
     postcondition {
       condition = self.value != nil
       error_message = "should return a value"
-	}
+    }
   }
 }
 


### PR DESCRIPTION
If an ephemeral resource configuration contains any unknown values, that resource cannot be opened with the provider. This works in the same was as a data source, in that a placeholder is created by Terraform for evaluation, taking the configuration values and inserting unknown values for any computed attributes.

We also add a UI hook for ephemeral resources which can't be read due to unknown values:

```
  ephemeral.random_password.example: Configuration unknown, deferring...
```

This is a stopgap to give users some feedback when an ephemeral resource can't be opened, since there is no artifact in the plan which could otherwise be inspected. While the results could generally be inferred, hopefully this helps users more easily figure out what may be happening if they are seeing unexpected results.

There is no json hook implementation so that the machine-readable spec is not bound to the new output until further review. It doesn't really fit with the current json ui model to have messages about what isn't going to happen, so we can determine if that is necessary later.