### PR TITLE
make sure all resource apply nodes implement `GraphNodeDestroyerCBD`

### DIFF
--- a/internal/terraform/graph_builder_apply.go
+++ b/internal/terraform/graph_builder_apply.go
@@ -194,6 +194,11 @@ func (b *ApplyGraphBuilder) Steps() []GraphTransformer {
 
 		// Detect when create_before_destroy must be forced on for a particular
 		// node due to dependency edges, to avoid graph cycles during apply.
+		//
+		// FIXME: this should not need to be recalculated during apply.
+		// Currently however, the instance object which stores the planned
+		// information is lost for newly created instances because it contains
+		// no state value, and we end up recalculating CBD for all nodes.
 		&ForcedCBDTransformer{},
 
 		// Destruction ordering

--- a/internal/terraform/node_resource_abstract_instance.go
+++ b/internal/terraform/node_resource_abstract_instance.go
@@ -337,11 +337,7 @@ func (n *NodeAbstractResourceInstance) writeResourceInstanceStateImpl(ctx EvalCo
 		return nil
 	}
 
-	if obj != nil {
-		log.Printf("[TRACE] %s: writing state object for %s", logFuncName, absAddr)
-	} else {
-		log.Printf("[TRACE] %s: removing state object for %s", logFuncName, absAddr)
-	}
+	log.Printf("[TRACE] %s: writing state object for %s", logFuncName, absAddr)
 
 	schema, currentVersion := providerSchema.SchemaForResourceAddr(absAddr.ContainingResource().Resource)
 	if schema == nil {

--- a/internal/terraform/node_resource_apply_instance.go
+++ b/internal/terraform/node_resource_apply_instance.go
@@ -29,10 +29,6 @@ type NodeApplyableResourceInstance struct {
 
 	graphNodeDeposer // implementation of GraphNodeDeposerConfig
 
-	// If this node is forced to be CreateBeforeDestroy, we need to record that
-	// in the state to.
-	ForceCreateBeforeDestroy bool
-
 	// forceReplace are resource instance addresses where the user wants to
 	// force generating a replace action. This set isn't pre-filtered, so
 	// it might contain addresses that have nothing to do with the resource
@@ -49,24 +45,6 @@ var (
 	_ GraphNodeExecutable         = (*NodeApplyableResourceInstance)(nil)
 	_ GraphNodeAttachDependencies = (*NodeApplyableResourceInstance)(nil)
 )
-
-// CreateBeforeDestroy returns this node's CreateBeforeDestroy status.
-func (n *NodeApplyableResourceInstance) CreateBeforeDestroy() bool {
-	if n.ForceCreateBeforeDestroy {
-		return n.ForceCreateBeforeDestroy
-	}
-
-	if n.Config != nil && n.Config.Managed != nil {
-		return n.Config.Managed.CreateBeforeDestroy
-	}
-
-	return false
-}
-
-func (n *NodeApplyableResourceInstance) ModifyCreateBeforeDestroy(v bool) error {
-	n.ForceCreateBeforeDestroy = v
-	return nil
-}
 
 // GraphNodeCreator
 func (n *NodeApplyableResourceInstance) CreateAddr() *addrs.AbsResourceInstance {
@@ -330,6 +308,7 @@ func (n *NodeApplyableResourceInstance) managedResourceExecute(ctx EvalContext) 
 	}
 
 	state, applyDiags := n.apply(ctx, state, diffApply, n.Config, repeatData, n.CreateBeforeDestroy())
+
 	diags = diags.Append(applyDiags)
 
 	// We clear the change out here so that future nodes don't see a change


### PR DESCRIPTION
If an instance was forced to be CreateBeforeDestroy due to a dependent, and that dependent had no changes to apply, the dependent would not be in the graph to force the CBD status on the change, and the result would be lost from the state.

This rarely made any difference, because the status would be restored during the next plan, which is why it was not noticed until now. However if the resource was immediately removed from the configuration, the incorrect state would be the only source of the destroy order, which could result in a cycle during the next apply.

While it would be better to use the destroy order calculated during plan, when there is a newly created object its plan state is not stored because the instance has a null state value. This means we still need to recompute the CBD status again during apply until a new way to transfer the information from plan to apply is developed.

While instances without changes are not present in the apply graph, their resource expansion nodes do happen to be there and hold the configuration (and while they were previously an implementation quirk of the expansion system, they now play an important role in the ephemeral resource evaluation). Those resource expansion nodes didn't implement the `GraphNodeDestroyerCBD` interface though, which was why the CBD status was not picked up during apply.

The fix is relatively easy, move the `GraphNodeDestroyerCBD` implementation down to the abstract resource node, to make sure all resources nodes implement the behavior. The nodes which need a different implementation already have it, and thus will override the embedded methods.

Fixes #35959 