### PR TITLE
docs: update `dnf config-manager` usage

### DIFF
--- a/website/docs/cli/install/yum.mdx
+++ b/website/docs/cli/install/yum.mdx
@@ -47,7 +47,7 @@ If you are using a DNF-based distribution, add the repository using
 
 ```bash
 sudo dnf install -y dnf-plugins-core
-sudo dnf config-manager --add-repo https://rpm.releases.hashicorp.com/$release/hashicorp.repo
+sudo dnf config-manager addrepo --from-repofile=https://rpm.releases.hashicorp.com/$release/hashicorp.repo
 ```
 
 In both cases, the Terraform package name is `terraform`. For example:

--- a/website/docs/language/stacks/reference/tfstacks-cli.mdx
+++ b/website/docs/language/stacks/reference/tfstacks-cli.mdx
@@ -54,7 +54,7 @@ Run the following commands to install the `terraform-stacks-cli` using Fedora.
 
 ```shell-session
 $ sudo dnf install -y dnf-plugins-core
-$ sudo dnf config-manager --add-repo https://rpm.releases.hashicorp.com/fedora/hashicorp.repo
+$ sudo dnf config-manager addrepo --from-repofile=https://rpm.releases.hashicorp.com/fedora/hashicorp.repo
 $ sudo dnf -y install terraform-stacks-cli
 ```
 


### PR DESCRIPTION
Closes #35979 

In Fedora Linux 41 which uses DNF5, backward compatibility with DNF4 was intentionally broken. The `dnf config-manager` now uses new sub-commands, like `addrepo`, for adding repositories.

Since F41 is the latest supported Fedora Linux release, this PR proposes updating the instructions to reflect DNF5 installation.

* See https://github.com/rpm-software-management/dnf5/issues/405 which states the maintainers broke DNF4 backwards compatibility intentionally in DNF5.
* See for a cross-reference documentation fix in the Fedora docs: https://pagure.io/fedora-docs/quick-docs/pull-request/783