### PR TITLE
Functions that allow marks must also deal with unknown values

### DIFF
--- a/internal/lang/funcs/collection_test.go
+++ b/internal/lang/funcs/collection_test.go
@@ -169,6 +169,10 @@ func TestLength(t *testing.T) {
 			}).Mark("secret"),
 			cty.NumberIntVal(3).Mark("secret"),
 		},
+		{ // Marked objects return a marked length
+			cty.UnknownVal(cty.String).Mark("secret"),
+			cty.UnknownVal(cty.Number).Refine().NotNull().NumberRangeLowerBound(cty.NumberIntVal(0), true).NewValue().Mark("secret"),
+		},
 		{ // Marks on object attribute values do not propagate
 			cty.ObjectVal(map[string]cty.Value{
 				"a": cty.StringVal("hello").Mark("a"),
@@ -882,6 +886,15 @@ func TestLookup(t *testing.T) {
 				cty.StringVal("nope"),
 			},
 			cty.StringVal("beep").Mark("a"),
+			false,
+		},
+		{ // propagate marks from unknown map
+			[]cty.Value{
+				cty.UnknownVal(cty.Map(cty.String)).Mark("a"),
+				cty.StringVal("boop").Mark("b"),
+				cty.StringVal("nope"),
+			},
+			cty.UnknownVal(cty.String).Mark("a").Mark("b"),
 			false,
 		},
 	}

--- a/internal/lang/funcs/conversion.go
+++ b/internal/lang/funcs/conversion.go
@@ -37,6 +37,7 @@ func MakeToFunc(wantTy cty.Type) function.Function {
 				AllowNull:        true,
 				AllowMarked:      true,
 				AllowDynamicType: true,
+				AllowUnknown:     true,
 			},
 		},
 		Type: func(args []cty.Value) (cty.Type, error) {
@@ -61,8 +62,10 @@ func MakeToFunc(wantTy cty.Type) function.Function {
 			return wantTy, nil
 		},
 		Impl: func(args []cty.Value, retType cty.Type) (cty.Value, error) {
-			// We didn't set "AllowUnknown" on our argument, so it is guaranteed
-			// to be known here but may still be null.
+			if !args[0].IsKnown() {
+				return cty.UnknownVal(retType).WithSameMarks(args[0]), nil
+			}
+
 			ret, err := convert.Convert(args[0], retType)
 			if err != nil {
 				val, _ := args[0].UnmarkDeep()

--- a/internal/lang/funcs/conversion_test.go
+++ b/internal/lang/funcs/conversion_test.go
@@ -181,6 +181,24 @@ func TestTo(t *testing.T) {
 			cty.DynamicVal,
 			`incompatible object type for conversion: attribute "foo" is required`,
 		},
+		{
+			cty.UnknownVal(cty.Object(map[string]cty.Type{"foo": cty.String})).Mark(marks.Ephemeral).Mark("boop"),
+			cty.Map(cty.String),
+			cty.UnknownVal(cty.Map(cty.String)).Mark(marks.Ephemeral).Mark("boop"),
+			``,
+		},
+		{
+			cty.ObjectVal(map[string]cty.Value{
+				"foo": cty.StringVal("hello"),
+				"bar": cty.StringVal("world").Mark("beep"),
+			}).Mark("boop"),
+			cty.Map(cty.String),
+			cty.MapVal(map[string]cty.Value{
+				"foo": cty.StringVal("hello"),
+				"bar": cty.StringVal("world").Mark("beep"),
+			}).Mark("boop"),
+			``,
+		},
 	}
 
 	for _, test := range tests {
@@ -322,13 +340,15 @@ func TestEphemeralAsNull(t *testing.T) {
 		{
 			cty.ObjectVal(map[string]cty.Value{
 				"addr":  cty.StringVal("127.0.0.1:12654").Mark(marks.Ephemeral),
-				"greet": cty.StringVal("hello"),
+				"greet": cty.StringVal("hello").Mark(marks.Sensitive),
 				"happy": cty.True,
+				"both":  cty.NumberIntVal(2).WithMarks(cty.NewValueMarks(marks.Sensitive, marks.Ephemeral)),
 			}),
 			cty.ObjectVal(map[string]cty.Value{
 				"addr":  cty.NullVal(cty.String),
-				"greet": cty.StringVal("hello"),
+				"greet": cty.StringVal("hello").Mark(marks.Sensitive),
 				"happy": cty.True,
+				"both":  cty.NullVal(cty.Number).Mark(marks.Sensitive),
 			}),
 		},
 	}

--- a/internal/lang/funcs/encoding.go
+++ b/internal/lang/funcs/encoding.go
@@ -21,15 +21,20 @@ import (
 var Base64DecodeFunc = function.New(&function.Spec{
 	Params: []function.Parameter{
 		{
-			Name:        "str",
-			Type:        cty.String,
-			AllowMarked: true,
+			Name:         "str",
+			Type:         cty.String,
+			AllowMarked:  true,
+			AllowUnknown: true,
 		},
 	},
 	Type:         function.StaticReturnType(cty.String),
 	RefineResult: refineNotNull,
 	Impl: func(args []cty.Value, retType cty.Type) (cty.Value, error) {
 		str, strMarks := args[0].Unmark()
+		if !str.IsKnown() {
+			return cty.UnknownVal(cty.String).WithMarks(strMarks), nil
+		}
+
 		s := str.AsString()
 		sDec, err := base64.StdEncoding.DecodeString(s)
 		if err != nil {

--- a/internal/lang/funcs/encoding_test.go
+++ b/internal/lang/funcs/encoding_test.go
@@ -37,6 +37,12 @@ func TestBase64Decode(t *testing.T) {
 			cty.UnknownVal(cty.String),
 			true,
 		},
+		// unknown marked
+		{
+			cty.UnknownVal(cty.String).Mark("a").Mark("b"),
+			cty.UnknownVal(cty.String).RefineNotNull().Mark("a").Mark("b"),
+			false,
+		},
 	}
 
 	for _, test := range tests {

--- a/internal/lang/funcs/filesystem.go
+++ b/internal/lang/funcs/filesystem.go
@@ -28,15 +28,21 @@ func MakeFileFunc(baseDir string, encBase64 bool) function.Function {
 	return function.New(&function.Spec{
 		Params: []function.Parameter{
 			{
-				Name:        "path",
-				Type:        cty.String,
-				AllowMarked: true,
+				Name:         "path",
+				Type:         cty.String,
+				AllowMarked:  true,
+				AllowUnknown: true,
 			},
 		},
 		Type:         function.StaticReturnType(cty.String),
 		RefineResult: refineNotNull,
 		Impl: func(args []cty.Value, retType cty.Type) (cty.Value, error) {
 			pathArg, pathMarks := args[0].Unmark()
+
+			if !pathArg.IsKnown() {
+				return cty.UnknownVal(cty.String).WithMarks(pathMarks), nil
+			}
+
 			path := pathArg.AsString()
 			src, err := readFileBytes(baseDir, path, pathMarks)
 			if err != nil {
@@ -94,13 +100,16 @@ func MakeTemplateFileFunc(baseDir string, funcsCb func() (funcs map[string]funct
 	return function.New(&function.Spec{
 		Params: []function.Parameter{
 			{
-				Name:        "path",
-				Type:        cty.String,
-				AllowMarked: true,
+				Name:         "path",
+				Type:         cty.String,
+				AllowMarked:  true,
+				AllowUnknown: true,
 			},
 			{
-				Name: "vars",
-				Type: cty.DynamicPseudoType,
+				Name:         "vars",
+				Type:         cty.DynamicPseudoType,
+				AllowMarked:  true,
+				AllowUnknown: true,
 			},
 		},
 		Type: func(args []cty.Value) (cty.Type, error) {
@@ -125,12 +134,19 @@ func MakeTemplateFileFunc(baseDir string, funcsCb func() (funcs map[string]funct
 		},
 		Impl: func(args []cty.Value, retType cty.Type) (cty.Value, error) {
 			pathArg, pathMarks := args[0].Unmark()
+
+			vars, varsMarks := args[1].UnmarkDeep()
+
+			if !pathArg.IsKnown() {
+				return cty.UnknownVal(retType).WithMarks(pathMarks, varsMarks), nil
+			}
+
 			expr, tmplMarks, err := loadTmpl(pathArg.AsString(), pathMarks)
 			if err != nil {
 				return cty.DynamicVal, err
 			}
-			result, err := renderTmpl(expr, args[1])
-			return result.WithMarks(tmplMarks), err
+			result, err := renderTmpl(expr, vars)
+			return result.WithMarks(tmplMarks, varsMarks), err
 		},
 	})
 

--- a/internal/lang/funcs/filesystem_test.go
+++ b/internal/lang/funcs/filesystem_test.go
@@ -314,6 +314,11 @@ func TestFileExists(t *testing.T) {
 			cty.BoolVal(false),
 			`failed to stat (sensitive value)`,
 		},
+		{
+			cty.UnknownVal(cty.String).Mark(marks.Sensitive),
+			cty.UnknownVal(cty.Bool).RefineNotNull().Mark(marks.Sensitive),
+			``,
+		},
 	}
 
 	// Ensure "unreadable" directory cannot be listed during the test run
@@ -544,6 +549,18 @@ func TestFileSet(t *testing.T) {
 				cty.StringVal("hello.tmpl"),
 				cty.StringVal("hello.txt"),
 			}),
+			``,
+		},
+		{
+			cty.StringVal("testdata"),
+			cty.UnknownVal(cty.String),
+			cty.UnknownVal(cty.Set(cty.String)).RefineNotNull(),
+			``,
+		},
+		{
+			cty.StringVal("testdata"),
+			cty.UnknownVal(cty.String).Mark(marks.Sensitive),
+			cty.UnknownVal(cty.Set(cty.String)).RefineNotNull().Mark(marks.Sensitive),
 			``,
 		},
 	}

--- a/internal/lang/funcs/filesystem_test.go
+++ b/internal/lang/funcs/filesystem_test.go
@@ -30,6 +30,11 @@ func TestFile(t *testing.T) {
 			``,
 		},
 		{
+			cty.UnknownVal(cty.String).Mark(marks.Sensitive),
+			cty.UnknownVal(cty.String).RefineNotNull().Mark(marks.Sensitive),
+			``,
+		},
+		{
 			cty.StringVal("testdata/icon.png"),
 			cty.NilVal,
 			`contents of "testdata/icon.png" are not valid UTF-8; use the filebase64 function to obtain the Base64 encoded contents or the other file functions (e.g. filemd5, filesha256) to obtain file hashing results instead`,
@@ -197,6 +202,38 @@ func TestTemplateFile(t *testing.T) {
 			cty.StringVal("testdata/hello.txt").Mark(marks.Sensitive),
 			cty.EmptyObjectVal,
 			cty.StringVal("Hello World").Mark(marks.Sensitive),
+			``,
+		},
+		{
+			cty.StringVal("testdata/list.tmpl").Mark("path"),
+			cty.ObjectVal(map[string]cty.Value{
+				"list": cty.ListVal([]cty.Value{
+					cty.StringVal("a"),
+					cty.StringVal("b").Mark("var"),
+					cty.StringVal("c"),
+				}),
+			}),
+			cty.StringVal("- a\n- b\n- c\n").Mark("path").Mark("var"),
+			``,
+		},
+		{
+			cty.StringVal("testdata/list.tmpl").Mark("path"),
+			cty.ObjectVal(map[string]cty.Value{
+				"list": cty.ListVal([]cty.Value{
+					cty.StringVal("a"),
+					cty.UnknownVal(cty.String).Mark("var"),
+					cty.StringVal("c"),
+				}),
+			}),
+			cty.UnknownVal(cty.String).RefineNotNull().Mark("path").Mark("var"),
+			``,
+		},
+		{
+			cty.UnknownVal(cty.String).Mark("path"),
+			cty.ObjectVal(map[string]cty.Value{
+				"key": cty.StringVal("value").Mark("var"),
+			}),
+			cty.DynamicVal.Mark("path").Mark("var"),
 			``,
 		},
 	}

--- a/internal/lang/funcs/funcs_test.go
+++ b/internal/lang/funcs/funcs_test.go
@@ -1,0 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package funcs
+
+import _ "github.com/hashicorp/terraform/internal/logging"

--- a/internal/lang/funcs/number.go
+++ b/internal/lang/funcs/number.go
@@ -101,14 +101,16 @@ var SignumFunc = function.New(&function.Spec{
 var ParseIntFunc = function.New(&function.Spec{
 	Params: []function.Parameter{
 		{
-			Name:        "number",
-			Type:        cty.DynamicPseudoType,
-			AllowMarked: true,
+			Name:         "number",
+			Type:         cty.DynamicPseudoType,
+			AllowMarked:  true,
+			AllowUnknown: true,
 		},
 		{
-			Name:        "base",
-			Type:        cty.Number,
-			AllowMarked: true,
+			Name:         "base",
+			Type:         cty.Number,
+			AllowMarked:  true,
+			AllowUnknown: true,
 		},
 	},
 
@@ -126,11 +128,16 @@ var ParseIntFunc = function.New(&function.Spec{
 		var err error
 
 		numArg, numMarks := args[0].Unmark()
+		baseArg, baseMarks := args[1].Unmark()
+
+		if !numArg.IsKnown() || !baseArg.IsKnown() {
+			return cty.UnknownVal(retType).WithMarks(numMarks, baseMarks), nil
+		}
+
 		if err = gocty.FromCtyValue(numArg, &numstr); err != nil {
 			return cty.UnknownVal(cty.String), function.NewArgError(0, err)
 		}
 
-		baseArg, baseMarks := args[1].Unmark()
 		if err = gocty.FromCtyValue(baseArg, &base); err != nil {
 			return cty.UnknownVal(cty.Number), function.NewArgError(1, err)
 		}

--- a/internal/lang/funcs/number_test.go
+++ b/internal/lang/funcs/number_test.go
@@ -218,6 +218,12 @@ func TestParseInt(t *testing.T) {
 			``,
 		},
 		{
+			cty.StringVal("128").Mark(marks.Sensitive),
+			cty.UnknownVal(cty.Number).Mark(marks.Sensitive),
+			cty.UnknownVal(cty.Number).RefineNotNull().Mark(marks.Sensitive),
+			``,
+		},
+		{
 			cty.StringVal("128").Mark("boop"),
 			cty.NumberIntVal(10).Mark(marks.Sensitive),
 			cty.NumberIntVal(128).WithMarks(cty.NewValueMarks("boop", marks.Sensitive)),

--- a/internal/lang/funcs/sensitive.go
+++ b/internal/lang/funcs/sensitive.go
@@ -28,8 +28,7 @@ var SensitiveFunc = function.New(&function.Spec{
 		return args[0].Type(), nil
 	},
 	Impl: func(args []cty.Value, retType cty.Type) (ret cty.Value, err error) {
-		val, _ := args[0].Unmark()
-		return val.Mark(marks.Sensitive), nil
+		return args[0].Mark(marks.Sensitive), nil
 	},
 })
 

--- a/internal/lang/funcs/sensitive_test.go
+++ b/internal/lang/funcs/sensitive_test.go
@@ -46,14 +46,6 @@ func TestSensitive(t *testing.T) {
 			``,
 		},
 		{
-			// A value with some non-standard mark gets "fixed" to be marked
-			// with the standard "sensitive" mark. (This situation occurring
-			// would imply an inconsistency/bug elsewhere, so we're just
-			// being robust about it here.)
-			cty.NumberIntVal(1).Mark("bloop"),
-			``,
-		},
-		{
 			// A value deep already marked is allowed and stays marked,
 			// _and_ we'll also mark the outer collection as sensitive.
 			cty.ListVal([]cty.Value{cty.NumberIntVal(1).Mark(marks.Sensitive)}),
@@ -81,17 +73,7 @@ func TestSensitive(t *testing.T) {
 				t.Errorf("result is not marked sensitive")
 			}
 
-			gotRaw, gotMarks := got.Unmark()
-			if len(gotMarks) != 1 {
-				// We're only expecting to have the "sensitive" mark we checked
-				// above. Any others are an error, even if they happen to
-				// appear alongside "sensitive". (We might change this rule
-				// if someday we decide to use marks for some additional
-				// unrelated thing in Terraform, but currently we assume that
-				// _all_ marks imply sensitive, and so returning any other
-				// marks would be confusing.)
-				t.Errorf("extraneous marks %#v", gotMarks)
-			}
+			gotRaw, _ := got.Unmark()
 
 			// Disregarding shallow marks, the result should have the same
 			// effective value as the input.

--- a/internal/terraform/context_plan_ephemeral_test.go
+++ b/internal/terraform/context_plan_ephemeral_test.go
@@ -159,7 +159,7 @@ resource "test_object" "test" {
 }
 `,
 			},
-			expectPlanDiagnostics: func(m *configs.Config) (diags tfdiags.Diagnostics) {
+			expectValidateDiagnostics: func(m *configs.Config) (diags tfdiags.Diagnostics) {
 				return diags.Append(&hcl.Diagnostic{
 					Severity: hcl.DiagError,
 					Summary:  "Invalid for_each argument",
@@ -205,7 +205,7 @@ module "child" {
 `,
 			},
 
-			expectPlanDiagnostics: func(m *configs.Config) (diags tfdiags.Diagnostics) {
+			expectValidateDiagnostics: func(m *configs.Config) (diags tfdiags.Diagnostics) {
 				return diags.Append(&hcl.Diagnostic{
 					Severity: hcl.DiagError,
 					Summary:  "Invalid for_each argument",
@@ -255,13 +255,8 @@ resource "test_object" "test" {
 }
 `,
 			},
-			expectPlanDiagnostics: func(m *configs.Config) (diags tfdiags.Diagnostics) {
+			expectValidateDiagnostics: func(m *configs.Config) (diags tfdiags.Diagnostics) {
 				return diags.Append(
-					&hcl.Diagnostic{
-						Severity: hcl.DiagError,
-						Summary:  "Invalid for_each argument",
-						Detail:   `The given "for_each" value is derived from an ephemeral value, which means that Terraform cannot persist it between plan/apply rounds. Use only non-ephemeral values to specify a resource's instance keys.`,
-					},
 					&hcl.Diagnostic{
 						Severity: hcl.DiagError,
 						Summary:  "Invalid for_each argument",

--- a/internal/terraform/context_plan_ephemeral_test.go
+++ b/internal/terraform/context_plan_ephemeral_test.go
@@ -179,7 +179,7 @@ resource "test_object" "test" {
 }
 `,
 			},
-			expectPlanDiagnostics: func(m *configs.Config) (diags tfdiags.Diagnostics) {
+			expectValidateDiagnostics: func(m *configs.Config) (diags tfdiags.Diagnostics) {
 				return diags.Append(&hcl.Diagnostic{
 					Severity: hcl.DiagError,
 					Summary:  "Invalid count argument",

--- a/internal/terraform/node_resource_validate.go
+++ b/internal/terraform/node_resource_validate.go
@@ -300,7 +300,7 @@ func (n *NodeValidatableResource) validateResource(ctx EvalContext) tfdiags.Diag
 
 		// Basic type-checking of the count argument. More complete validation
 		// of this will happen when we DynamicExpand during the plan walk.
-		countDiags := validateCount(ctx, n.Config.Count)
+		_, countDiags := evaluateCountExpressionValue(n.Config.Count, ctx)
 		diags = diags.Append(countDiags)
 
 	case n.Config.ForEach != nil:
@@ -724,21 +724,6 @@ func (n *NodeValidatableResource) validateConfigGen(ctx EvalContext) tfdiags.Dia
 			})
 		}
 	}
-	return diags
-}
-
-func validateCount(ctx EvalContext, expr hcl.Expression) (diags tfdiags.Diagnostics) {
-	val, countDiags := evaluateCountExpressionValue(expr, ctx)
-	// If the value isn't known then that's the best we can do for now, but
-	// we'll check more thoroughly during the plan walk
-	if !val.IsKnown() {
-		return diags
-	}
-
-	if countDiags.HasErrors() {
-		diags = diags.Append(countDiags)
-	}
-
 	return diags
 }
 


### PR DESCRIPTION
You can't deal with marks in a function without also dealing with unknowns. If `AllowMarked` is true, but `AllowKnown` is not, the caller will short-circuit evaluation with an unknown, without being able to deal with marks from all arguments. The cty package can't guarantee that an unknown value contains all possible marks (some functions could alter marks based on the value), but it definitely helps to catch unexpected marks as early as possible during evaluation.