### PR TITLE
github: Update CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -28,3 +28,5 @@ builtin/provisioners/file               @hashicorp/terraform-core
 builtin/provisioners/local-exec         @hashicorp/terraform-core
 builtin/provisioners/remote-exec        @hashicorp/terraform-core
 
+# Docs on hashicorp.com
+website/        @hashicorp/terraform-core @hashicorp/terraform-education

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -28,5 +28,5 @@ builtin/provisioners/file               @hashicorp/terraform-core
 builtin/provisioners/local-exec         @hashicorp/terraform-core
 builtin/provisioners/remote-exec        @hashicorp/terraform-core
 
-# Docs on hashicorp.com
+# Docs on developer.hashicorp.com/terraform/docs
 website/        @hashicorp/terraform-core @hashicorp/terraform-education


### PR DESCRIPTION
Make the Education team (shared) codeowners of the docs on the website so that they can approve docs-only PRs as well. We don't need to be gatekeepers for those kinds of changes.
