### PR TITLE
github: Enable backporting closed PRs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,6 +5,9 @@ on:
   pull_request_target:
     types:
       - closed
+  pull_request:
+    types:
+      - labeled
 
 permissions:
   contents: write # to push to a new branch


### PR DESCRIPTION
The primary backporting workflow involves us labeling a PR _prior_ to merging it, which then triggers the backport assistant.

Sometimes we can forget to add the label and backporting then becomes more manual and tedious process.

This PR intends to allow us to run the BA whenever a PR is labeled - typically an already closed/merged PR.

I originally thought this would bring a conflict where PRs are created _before_ the PR is merged and perhaps even duplicated but after some brief testing in a private fork I believe the BA can handle this just fine.