### PR TITLE
`issensitive` must return unknown for unknown args without `sensitive`

### DIFF
--- a/internal/lang/funcs/sensitive.go
+++ b/internal/lang/funcs/sensitive.go
@@ -70,8 +70,14 @@ var IssensitiveFunc = function.New(&function.Spec{
 		return cty.Bool, nil
 	},
 	Impl: func(args []cty.Value, retType cty.Type) (cty.Value, error) {
-		s := args[0].HasMark(marks.Sensitive)
-		return cty.BoolVal(s), nil
+		switch v := args[0]; {
+		case v.HasMark(marks.Sensitive):
+			return cty.True, nil
+		case !v.IsKnown():
+			return cty.UnknownVal(cty.Bool), nil
+		default:
+			return cty.False, nil
+		}
 	},
 })
 

--- a/internal/lang/funcs/sensitive_test.go
+++ b/internal/lang/funcs/sensitive_test.go
@@ -166,47 +166,47 @@ func TestNonsensitive(t *testing.T) {
 func TestIssensitive(t *testing.T) {
 	tests := []struct {
 		Input     cty.Value
-		Sensitive bool
+		Sensitive cty.Value
 		WantErr   string
 	}{
 		{
 			cty.NumberIntVal(1).Mark(marks.Sensitive),
-			true,
+			cty.True,
 			``,
 		},
 		{
 			cty.NumberIntVal(1),
-			false,
+			cty.False,
 			``,
 		},
 		{
 			cty.DynamicVal.Mark(marks.Sensitive),
-			true,
+			cty.True,
 			``,
 		},
 		{
 			cty.UnknownVal(cty.String).Mark(marks.Sensitive),
-			true,
+			cty.True,
 			``,
 		},
 		{
 			cty.NullVal(cty.EmptyObject).Mark(marks.Sensitive),
-			true,
+			cty.True,
 			``,
 		},
 		{
 			cty.NullVal(cty.String),
-			false,
+			cty.False,
 			``,
 		},
 		{
 			cty.DynamicVal,
-			false,
+			cty.UnknownVal(cty.Bool),
 			``,
 		},
 		{
 			cty.UnknownVal(cty.String),
-			false,
+			cty.UnknownVal(cty.Bool),
 			``,
 		},
 	}
@@ -227,7 +227,7 @@ func TestIssensitive(t *testing.T) {
 				t.Fatalf("unexpected error: %s", err)
 			}
 
-			if (got.True() && !test.Sensitive) || (got.False() && test.Sensitive) {
+			if !got.RawEquals(test.Sensitive) {
 				t.Errorf("wrong result \ngot:  %#v\nwant: %#v", got, test.Sensitive)
 			}
 		})


### PR DESCRIPTION
Terraform attempts to track marks as accurately as possible, but unknown values may not always have the same marks as they will when they become known. This is most easily seen with functions, which are allowed to return an unknown value when faced with any unknown arguments, while they are also allowed to manipulate the marks on the values as they see fit. This results in situations where the marks simply cannot be known.

Terraform generally takes the stance that if an unknown has a mark, it will remain in the final value, but the absence of a mark is not indicative of the absence of any marks in the final value. That appears to be something we can continue to maintain throughout the codebase, so given that axiom I'm going to codify it here by only changing the `issensitive` results for unknown, unmarked values, but allowing unknown+sensitive values to return `true`.
