### PR TITLE
Deprecation Warning For Outputs

### DIFF
--- a/internal/configs/named_values.go
+++ b/internal/configs/named_values.go
@@ -345,12 +345,14 @@ type Output struct {
 	DependsOn   []hcl.Traversal
 	Sensitive   bool
 	Ephemeral   bool
+	Deprecated  string
 
 	Preconditions []*CheckRule
 
 	DescriptionSet bool
 	SensitiveSet   bool
 	EphemeralSet   bool
+	DeprecatedSet  bool
 
 	DeclRange hcl.Range
 }
@@ -400,6 +402,12 @@ func decodeOutputBlock(block *hcl.Block, override bool) (*Output, hcl.Diagnostic
 		valDiags := gohcl.DecodeExpression(attr.Expr, nil, &o.Ephemeral)
 		diags = append(diags, valDiags...)
 		o.EphemeralSet = true
+	}
+
+	if attr, exists := content.Attributes["deprecated"]; exists {
+		valDiags := gohcl.DecodeExpression(attr.Expr, nil, &o.Deprecated)
+		diags = append(diags, valDiags...)
+		o.DeprecatedSet = true
 	}
 
 	if attr, exists := content.Attributes["depends_on"]; exists {
@@ -524,6 +532,9 @@ var outputBlockSchema = &hcl.BodySchema{
 		},
 		{
 			Name: "ephemeral",
+		},
+		{
+			Name: "deprecated",
 		},
 	},
 	Blocks: []hcl.BlockHeaderSchema{

--- a/internal/configs/named_values_test.go
+++ b/internal/configs/named_values_test.go
@@ -48,3 +48,30 @@ func TestVariableInvalidDefault(t *testing.T) {
 		}
 	}
 }
+
+func TestOutputDeprecation(t *testing.T) {
+	src := `
+		output "foo" {
+			value = "bar"
+			deprecated = "This output is deprecated"
+		}
+	`
+
+	hclF, diags := hclsyntax.ParseConfig([]byte(src), "test.tf", hcl.InitialPos)
+	if diags.HasErrors() {
+		t.Fatal(diags.Error())
+	}
+
+	b, diags := parseConfigFile(hclF.Body, nil, false, false)
+	if diags.HasErrors() {
+		t.Fatalf("unexpected error: %q", diags)
+	}
+
+	if !b.Outputs[0].DeprecatedSet {
+		t.Fatalf("expected output to be deprecated")
+	}
+
+	if b.Outputs[0].Deprecated != "This output is deprecated" {
+		t.Fatalf("expected output to have deprecation message")
+	}
+}

--- a/internal/terraform/graph_builder_apply.go
+++ b/internal/terraform/graph_builder_apply.go
@@ -188,6 +188,8 @@ func (b *ApplyGraphBuilder) Steps() []GraphTransformer {
 		&ReferenceTransformer{},
 		&AttachDependenciesTransformer{},
 
+		&OutputReferencesTransformer{},
+
 		// Nested data blocks should be loaded after every other resource has
 		// done its thing.
 		&checkStartTransformer{Config: b.Config, Operation: b.Operation},

--- a/internal/terraform/graph_builder_plan.go
+++ b/internal/terraform/graph_builder_plan.go
@@ -236,6 +236,8 @@ func (b *PlanGraphBuilder) Steps() []GraphTransformer {
 
 		&ReferenceTransformer{},
 
+		&OutputReferencesTransformer{},
+
 		&AttachDependenciesTransformer{},
 
 		// Make sure data sources are aware of any depends_on from the

--- a/internal/terraform/node_output.go
+++ b/internal/terraform/node_output.go
@@ -384,6 +384,17 @@ func (n *NodeApplyableOutput) References() []*addrs.Reference {
 
 // GraphNodeExecutable
 func (n *NodeApplyableOutput) Execute(ctx EvalContext, op walkOperation) (diags tfdiags.Diagnostics) {
+	if op == walkValidate && n.Config.DeprecatedSet && len(n.Dependants) > 0 {
+		for _, d := range n.Dependants {
+			diags = diags.Append(&hcl.Diagnostic{
+				Severity: hcl.DiagWarning,
+				Summary:  "Usage of deprecated output",
+				Detail:   n.Config.Deprecated,
+				Subject:  d.SourceRange.ToHCL().Ptr(),
+			})
+		}
+	}
+
 	state := ctx.State()
 	if state == nil {
 		return

--- a/internal/terraform/node_output.go
+++ b/internal/terraform/node_output.go
@@ -46,6 +46,8 @@ type nodeExpandOutput struct {
 	Overrides *mocking.Overrides
 
 	Dependencies []addrs.ConfigResource
+
+	Dependants []*addrs.Reference
 }
 
 var (
@@ -136,6 +138,7 @@ func (n *nodeExpandOutput) DynamicExpand(ctx EvalContext) (*Graph, tfdiags.Diagn
 					Planning:     n.Planning,
 					Override:     n.getOverrideValue(absAddr.Module),
 					Dependencies: n.Dependencies,
+					Dependants:   n.Dependants,
 				}
 			}
 
@@ -283,6 +286,8 @@ type NodeApplyableOutput struct {
 	// Dependencies is the full set of resources that are referenced by this
 	// output.
 	Dependencies []addrs.ConfigResource
+
+	Dependants []*addrs.Reference
 }
 
 var (

--- a/internal/terraform/transform_output.go
+++ b/internal/terraform/transform_output.go
@@ -67,6 +67,7 @@ func (t *OutputTransformer) transform(g *Graph, c *configs.Config) error {
 			RefreshOnly: t.RefreshOnly,
 			Planning:    t.Planning,
 			Overrides:   t.Overrides,
+			Dependants:  []*addrs.Reference{},
 		}
 
 		log.Printf("[TRACE] OutputTransformer: adding %s as %T", o.Name, node)

--- a/internal/terraform/transform_output_references.go
+++ b/internal/terraform/transform_output_references.go
@@ -1,0 +1,30 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package terraform
+
+// OutputReferencesTransformer is a GraphTransformer that adds meta-information
+// about references to output values in the configuration. This is used to
+// determine when deprecated outputs are used.
+type OutputReferencesTransformer struct{}
+
+func (t *OutputReferencesTransformer) Transform(g *Graph) error {
+	// Build a reference map so we can efficiently look up the references
+	vs := g.Vertices()
+	m := NewReferenceMap(vs)
+
+	// Find the things that reference things and connect them
+	for _, v := range vs {
+		if dependant, ok := v.(GraphNodeReferencer); ok {
+			parents := m.References(v)
+
+			for _, parent := range parents {
+				if output, ok := parent.(*nodeExpandOutput); ok {
+					output.Dependants = append(output.Dependants, dependant.References()...)
+				}
+			}
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
In this PR @DanielMSchmidt and I take a first stab at https://github.com/hashicorp/terraform/issues/18381 and add a new attribute to the `output` block to allow it to be marked as deprecated.

### UX

![CleanShot 2024-11-15 at 18 08 51@2x](https://github.com/user-attachments/assets/d3d990dc-a95f-4eda-b91a-a94f639eca68)

If this is the right approach, my suggestion would be to deal with the deprecation of inputs in a separate PR.

Partially resolves #18381

## Target Release

1.11.x