### PR TITLE
backend/s3: upgrade guide notes for Terraform 1.10

### DIFF
--- a/website/docs/language/upgrade-guides/index.mdx
+++ b/website/docs/language/upgrade-guides/index.mdx
@@ -26,3 +26,44 @@ to discuss it.
 Moved blocks now respect reserved keywords such as `local`, `each`, `self` etc. when parsing resource addresses.
 Configurations that reference resources with type names that match top level blocks and
 keywords from moved blocks will need to prepend the reference identifier with `resource.`.
+
+## S3 Backend 
+
+### S3 Native State Locking
+
+The S3 backend now supports S3 native state locking as an opt-in, experimental feature.
+An S3 lock can be used alongside a DynamoDB lock, or independently.
+When both locking mechanisms are configured, a lock must be successfully acquired from both locations before subsequent operations will proceed.
+
+To opt-in to S3 native state locking, set `use_lockfile` to `true`.
+
+```terraform
+terraform {
+  backend "s3" {
+    # additional configuration omitted for brevity
+    use_lockfile = true
+  }
+}
+```
+
+With S3 locking enabled, a lock file will be placed in the same location as the state file.
+The lock file will be named identically to the state file, but with a `.tflock` extension.
+**S3 bucket policies and IAM policies attached to the calling principal may need to be adjusted to include permissions for the new lock file.**
+
+In a future minor version of Terraform the experimental label will be removed from the `use_lockfile` attribute and attributes related to DynamoDB based locking will be deprecated.
+
+### Root Assume Role Attribute Removal
+
+Several root level attributes related to IAM role assumption which were previously deprecated have been removed.
+Each removed field has an analogous field inside the [`assume_role` block](https://developer.hashicorp.com/terraform/language/backend/s3#assume-role-configuration) which should be used instead.
+
+| Removed | Replacement |
+| --- | --- |
+| `role_arn` | `assume_role.role_arn` |
+| `session_name` | `assume_role.session_name` |
+| `external_id` | `assume_role.external_id` |
+| `assume_role_duration_seconds` | `assume_role.duration` |
+| `assume_role_policy` | `assume_role.policy` |
+| `assume_role_policy_arns` | `assume_role.policy_arn` |
+| `assume_role_tags` | `assume_role.tags` |
+| `assume_role_transitive_tag_keys` | `assume_role.transitive_tag_keys` |


### PR DESCRIPTION

<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->
This includes sections on the introduction of S3 native state locking and the removal of deprecated root level attributes related to role assumption which have been replaced by the `assume_role` block.


<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Relates #35721
Relates #35661

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.10.0


