### PR TITLE
Move mocking framework out of beta for 1.10

### DIFF
--- a/website/docs/language/tests/mocking.mdx
+++ b/website/docs/language/tests/mocking.mdx
@@ -6,7 +6,7 @@ description: >-
 
 # Mocks
 
--> **Note**: Test mocking is available in Terraform v1.7.0 and later. This feature is in beta.
+-> **Note**: Test mocking is available in Terraform v1.7.0 and later.
 
 Terraform lets you mock providers, resources, and data sources for your tests. This allows you to test parts of your module without creating infrastructure or requiring credentials. In a Terraform test, a mocked provider or resource will generate fake data for all computed attributes that would normally be provided by the underlying provider APIs.
 


### PR DESCRIPTION
It's been 3 minor versions since we introduced mocking and we haven't received feedback that it missed the mark dramatically. It's time to move it out of beta.

I should have done this earlier in the release cycle, but since it's just a docs change hopefully that is okay.