### PR TITLE
jsonplan: deterministic relevant attribute order

### DIFF
--- a/internal/command/jsonplan/plan.go
+++ b/internal/command/jsonplan/plan.go
@@ -764,41 +764,7 @@ func (p *plan) marshalRelevantAttrs(plan *plans.Plan) error {
 	// stable.
 
 	sort.SliceStable(plan.RelevantAttributes, func(i, j int) bool {
-		if !plan.RelevantAttributes[i].Resource.Equal(plan.RelevantAttributes[j].Resource) {
-			return plan.RelevantAttributes[i].Resource.Less(plan.RelevantAttributes[j].Resource)
-		}
-
-		str := func(step cty.PathStep) string {
-			// sorting steps and values is hard, so we'll just use the GoString
-			// representation of the step to achieve a stable sort.
-			switch step := step.(type) {
-			case cty.GetAttrStep:
-				return step.GoString()
-			case cty.IndexStep:
-				return step.GoString()
-			default:
-				return "<unknown>"
-			}
-		}
-
-		for k := 0; k < len(plan.RelevantAttributes[i].Attr); k++ {
-			if k >= len(plan.RelevantAttributes[j].Attr) {
-				return false // i is longer, so it's greater
-			}
-
-			cmp := strings.Compare(str(plan.RelevantAttributes[i].Attr[k]), str(plan.RelevantAttributes[j].Attr[k]))
-			if cmp < 0 {
-				return true
-			} else if cmp > 0 {
-				return false
-			}
-
-			// then the step is equal, so we'll move onto the next one.
-		}
-
-		// then j was longer, so it's greater, or they're equal, so it doesn't
-		// matter
-		return true
+		return strings.Compare(fmt.Sprintf("%#v", plan.RelevantAttributes[i]), fmt.Sprintf("%#v", plan.RelevantAttributes[j])) < 0
 	})
 
 	return nil


### PR DESCRIPTION
This PR updates the ordering of the relevant attribute field in the `jsonplan` output so that is deterministic. This helps with some of our testing, but also just ensures stable outputs going forward.