### PR TITLE
getmodules: support `tbz2` module archives

### DIFF
--- a/internal/getmodules/getter.go
+++ b/internal/getmodules/getter.go
@@ -41,10 +41,11 @@ import (
 var goGetterNoDetectors = []getter.Detector{}
 
 var goGetterDecompressors = map[string]getter.Decompressor{
-	"bz2": new(getter.Bzip2Decompressor),
-	"gz":  new(getter.GzipDecompressor),
-	"xz":  new(getter.XzDecompressor),
-	"zip": new(getter.ZipDecompressor),
+	"bz2":  new(getter.Bzip2Decompressor),
+	"tbz2": new(getter.TarBzip2Decompressor),
+	"gz":   new(getter.GzipDecompressor),
+	"xz":   new(getter.XzDecompressor),
+	"zip":  new(getter.ZipDecompressor),
 
 	"tar.bz2":  new(getter.TarBzip2Decompressor),
 	"tar.tbz2": new(getter.TarBzip2Decompressor),

--- a/internal/getmodules/getter.go
+++ b/internal/getmodules/getter.go
@@ -41,30 +41,41 @@ import (
 var goGetterNoDetectors = []getter.Detector{}
 
 var goGetterDecompressors = map[string]getter.Decompressor{
-	"bz2":  new(getter.Bzip2Decompressor),
-	"tbz2": new(getter.TarBzip2Decompressor),
-	"gz":   new(getter.GzipDecompressor),
-	"xz":   new(getter.XzDecompressor),
-	"zip":  new(getter.ZipDecompressor),
-
+	// Bzip2
+	"bz2":      new(getter.Bzip2Decompressor),
+	"tbz2":     new(getter.TarBzip2Decompressor),
 	"tar.bz2":  new(getter.TarBzip2Decompressor),
 	"tar.tbz2": new(getter.TarBzip2Decompressor),
 
+	// Gzip
+	"gz":     new(getter.GzipDecompressor),
 	"tar.gz": new(getter.TarGzipDecompressor),
 	"tgz":    new(getter.TarGzipDecompressor),
 
+	// Xz
+	"xz":     new(getter.XzDecompressor),
 	"tar.xz": new(getter.TarXzDecompressor),
 	"txz":    new(getter.TarXzDecompressor),
+
+	// Zip
+	"zip": new(getter.ZipDecompressor),
 }
 
 var goGetterGetters = map[string]getter.Getter{
-	"file":  new(getter.FileGetter),
-	"gcs":   new(getter.GCSGetter),
-	"git":   new(getter.GitGetter),
-	"hg":    new(getter.HgGetter),
-	"s3":    new(getter.S3Getter),
+	// Protocol-based getters
 	"http":  getterHTTPGetter,
 	"https": getterHTTPGetter,
+
+	// Cloud storage getters
+	"gcs": new(getter.GCSGetter),
+	"s3":  new(getter.S3Getter),
+
+	// Version control getters
+	"git": new(getter.GitGetter),
+	"hg":  new(getter.HgGetter),
+
+	// Local and file-based getters
+	"file": new(getter.FileGetter),
 }
 
 var getterHTTPClient = cleanhttp.DefaultClient()

--- a/website/docs/language/modules/sources.mdx
+++ b/website/docs/language/modules/sources.mdx
@@ -383,7 +383,7 @@ The extensions that Terraform recognizes for this special behavior are:
 - `zip`
 - `bz2`, `tar.bz2`, `tar.tbz2`, and `tbz2`
 - `gz`, `tar.gz`, and `tgz`
-- `xz`, `tar.xz` and `txz`
+- `xz`, `tar.xz`, and `txz`
 
 If your URL _doesn't_ have one of these extensions but refers to an archive
 anyway, use the `archive` argument to force this interpretation:

--- a/website/docs/language/modules/sources.mdx
+++ b/website/docs/language/modules/sources.mdx
@@ -381,7 +381,7 @@ module "vpc" {
 The extensions that Terraform recognizes for this special behavior are:
 
 - `zip`
-- `bz2`, `tar.bz2`, `tar.tbz2` and `tbz2`
+- `bz2`, `tar.bz2`, `tar.tbz2`, and `tbz2`
 - `gz`, `tar.gz` and `tgz`
 - `xz`, `tar.xz` and `txz`
 

--- a/website/docs/language/modules/sources.mdx
+++ b/website/docs/language/modules/sources.mdx
@@ -381,9 +381,9 @@ module "vpc" {
 The extensions that Terraform recognizes for this special behavior are:
 
 - `zip`
-- `tar.bz2` and `tbz2`
-- `tar.gz` and `tgz`
-- `tar.xz` and `txz`
+- `bz2`, `tar.bz2`, `tar.tbz2` and `tbz2`
+- `gz`, `tar.gz` and `tgz`
+- `xz`, `tar.xz` and `txz`
 
 If your URL _doesn't_ have one of these extensions but refers to an archive
 anyway, use the `archive` argument to force this interpretation:

--- a/website/docs/language/modules/sources.mdx
+++ b/website/docs/language/modules/sources.mdx
@@ -382,7 +382,7 @@ The extensions that Terraform recognizes for this special behavior are:
 
 - `zip`
 - `bz2`, `tar.bz2`, `tar.tbz2`, and `tbz2`
-- `gz`, `tar.gz` and `tgz`
+- `gz`, `tar.gz`, and `tgz`
 - `xz`, `tar.xz` and `txz`
 
 If your URL _doesn't_ have one of these extensions but refers to an archive


### PR DESCRIPTION
Closes #36080

Our documentation suggests that file with the `tar.bz2`, `tar.tbz2` and `tbz2` extension can be fetched, unpacked and used as modules—however `tbz2` is currently not supported.

In [go-getter](https://github.com/hashicorp/go-getter) there is a decompressor for tar archives compressed with bzip2 that can handle both  `tar.bz2`, `tar.tbz2` and `tbz2` files. See https://github.com/hashicorp/go-getter/blob/main/decompress_tbz2.go#L28-L48

This PR adds
- Support for decompressing `tbz2` files, enabling the unpacking of `tbz2` module archives
- Improves the ordering of defined go-getter getter sets.
- Updates the documentation to reflect all possible go-getter getters and decompressors we have implemented.