### PR TITLE
Revert some minor performance enhancements which turn into severe bottlenecks with complex configs

### DIFF
--- a/internal/terraform/context_apply2_test.go
+++ b/internal/terraform/context_apply2_test.go
@@ -3575,56 +3575,6 @@ resource "test_instance" "obj" {
 	}
 }
 
-// each resource only needs to record the first dependency in a chain
-func TestContext2Apply_limitDependencies(t *testing.T) {
-	m := testModuleInline(t, map[string]string{
-		"main.tf": `
-resource "test_object" "a" {
-}
-
-resource "test_object" "b" {
-  test_string = test_object.a.test_string
-}
-
-resource "test_object" "c" {
-  test_string = test_object.b.test_string
-}
-`,
-	})
-
-	p := simpleMockProvider()
-
-	ctx := testContext2(t, &ContextOpts{
-		Providers: map[addrs.Provider]providers.Factory{
-			addrs.NewDefaultProvider("test"): testProviderFuncFixed(p),
-		},
-	})
-
-	plan, diags := ctx.Plan(m, states.NewState(), SimplePlanOpts(plans.NormalMode, testInputValuesUnset(m.Module.Variables)))
-	assertNoErrors(t, diags)
-
-	state, diags := ctx.Apply(plan, m, nil)
-	assertNoErrors(t, diags)
-
-	for _, res := range state.RootModule().Resources {
-		deps := res.Instances[addrs.NoKey].Current.Dependencies
-		switch res.Addr.Resource.Name {
-		case "a":
-			if len(deps) > 0 {
-				t.Error(res.Addr, "should have no dependencies")
-			}
-		case "b":
-			if len(deps) != 1 || deps[0].Resource.Name != "a" {
-				t.Error(res.Addr, "should only depend on 'a', got", deps)
-			}
-		case "c":
-			if len(deps) != 1 || deps[0].Resource.Name != "b" {
-				t.Error(res.Addr, "should only record a dependency of 'b', got", deps)
-			}
-		}
-	}
-}
-
 func TestContext2Apply_updateForcedCreateBeforeDestroy(t *testing.T) {
 	m := testModuleInline(t, map[string]string{
 		"main.tf": `

--- a/internal/terraform/node_resource_abstract.go
+++ b/internal/terraform/node_resource_abstract.go
@@ -70,8 +70,7 @@ type NodeAbstractResource struct {
 	Targets []addrs.Targetable
 
 	// Set from AttachDataResourceDependsOn
-	dependsOn      []addrs.ConfigResource
-	forceDependsOn bool
+	dependsOn []addrs.ConfigResource
 
 	// The address of the provider this resource will use
 	ResolvedProvider addrs.AbsProviderConfig
@@ -378,9 +377,8 @@ func (n *NodeAbstractResource) SetTargets(targets []addrs.Targetable) {
 }
 
 // graphNodeAttachDataResourceDependsOn
-func (n *NodeAbstractResource) AttachDataResourceDependsOn(deps []addrs.ConfigResource, force bool) {
+func (n *NodeAbstractResource) AttachDataResourceDependsOn(deps []addrs.ConfigResource) {
 	n.dependsOn = deps
-	n.forceDependsOn = force
 }
 
 // GraphNodeAttachResourceConfig

--- a/internal/terraform/transform_reference.go
+++ b/internal/terraform/transform_reference.go
@@ -256,26 +256,25 @@ func (t AttachDependenciesTransformer) Transform(g *Graph) error {
 		// since we need to type-switch over the nodes anyway, we're going to
 		// insert the address directly into depMap and forget about the returned
 		// set.
-		g.FirstAncestorsWith(v, func(d dag.Vertex) bool {
+		for _, d := range g.Ancestors(v) {
 			var addr addrs.ConfigResource
+
 			switch d := d.(type) {
-			case GraphNodeCreator:
-				// most of the time we'll hit a GraphNodeConfigResource first since that represents the config structure, but
-				instAddr := d.CreateAddr()
+			case GraphNodeResourceInstance:
+				instAddr := d.ResourceInstanceAddr()
 				addr = instAddr.ContainingResource().Config()
 			case GraphNodeConfigResource:
 				addr = d.ResourceAddr()
 			default:
-				return false
+				continue
 			}
 
 			if matchesSelf(addr) {
-				return false
+				continue
 			}
 
 			depMap[addr.String()] = addr
-			return true
-		})
+		}
 
 		deps := make([]addrs.ConfigResource, 0, len(depMap))
 		for _, d := range depMap {


### PR DESCRIPTION
The `dependsOn` method of the `ReferenceMap` is only used to resolve `depends_on` dependencies for data resources. It therefor needs to return all possible managed dependencies, and cant rely on the same optimizations made for the normal `AttachDependenciesTransformer`. While data resources will need to continue keeping the entire dependency tree of managed resources available, data resources are obviously used far less than managed resource within normal configurations, and the data resource dependencies are not recorded to state at all, so the loss of this possible optimization is very minor.

We also can remove the `forceDependsOn` data resource field and associated return values, since they are never used by the resource, and the assumption that it was functioning made debugging the change quite difficult. The "from parent module" concept of `forceDependsOn` was a remnant from when data sources were read during a separate refresh step which no longer exists.

Finally, storing limited destroy dependencies for resources is not useful yet, since they need to be re-calculated during apply, and that recalculation of dependencies needs more work. Revert that part of the change too just to be safe.


