### PR TITLE
jsonplan: sort the relevant attributes in the correct plan

### DIFF
--- a/internal/command/jsonplan/plan.go
+++ b/internal/command/jsonplan/plan.go
@@ -763,7 +763,7 @@ func (p *plan) marshalRelevantAttrs(plan *plans.Plan) error {
 	// here. The order of the attributes is not important, as long as it is
 	// stable.
 
-	sort.SliceStable(plan.RelevantAttributes, func(i, j int) bool {
+	sort.SliceStable(p.RelevantAttributes, func(i, j int) bool {
 		return strings.Compare(fmt.Sprintf("%#v", plan.RelevantAttributes[i]), fmt.Sprintf("%#v", plan.RelevantAttributes[j])) < 0
 	})
 


### PR DESCRIPTION
Fixes a typo that meant the wrong list was being sorted.