### PR TITLE
Add changelog and version scripts to automate releases

### DIFF
--- a/scripts/changelog.sh
+++ b/scripts/changelog.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
 
 set -uo pipefail
 

--- a/scripts/changelog.sh
+++ b/scripts/changelog.sh
@@ -4,15 +4,27 @@ set -uo pipefail
 
 function usage {
   cat <<-'EOF'
-Usage: ./changelog.sh <version> <date>
+Usage: ./changelog.sh <command> [<options>]
 
 Description:
-  This script will update the first line in the CHANGELOG.md file with the given
-  version and date.
+  This script will update CHANGELOG.md with the given version and date.
+
+Commands:
+  prepare <version> <date>
+    prepare updates the first line in the CHANGELOG.md file with the
+    given version and date.
+
+    ./changelog.sh prepare 1.0.0 "November 1, 2021"
+
+  cleanup <released-version> <next-version>
+    cleanup prepends a new section to the CHANGELOG.md file with the given
+    version and (Unreleased) as the date. If the released version contains a
+    pre-release tag, the next version will replace the top line instead of
+    inserting a new section.
 EOF
 }
 
-function update_changelog {
+function prepare {
   VERSION="${1:-}"
   DATE="${2:-}"
 
@@ -25,5 +37,41 @@ function update_changelog {
   sed -i '' -e "1s/.*/## $VERSION ($DATE)/" CHANGELOG.md
 }
 
-update_changelog "$@"
+function cleanup {
+  RELEASED_VERSION="${1:-}"
+  NEXT_VERSION="${2:-}"
+
+  if [[ -z "$RELEASED_VERSION" || -z "$NEXT_VERSION" ]]; then
+    echo "missing at least one of [<released-version>, <next-version>] arguments"
+    usage
+    exit 1
+  fi
+
+  if [[ "$RELEASED_VERSION" == *-* ]]; then
+    # then we have a pre-release version, so we should replace the top line
+    sed -i '' -e "1s/.*/## $NEXT_VERSION (Unreleased)/" CHANGELOG.md
+  else
+    sed -i '' -e "1s/^/## $NEXT_VERSION (Unreleased)\n\n/" CHANGELOG.md
+  fi
+}
+
+function main {
+  case "$1" in
+    prepare)
+      prepare "${@:2}"
+
+      ;;
+    cleanup)
+      cleanup "${@:2}"
+
+      ;;
+    *)
+      usage
+      exit 1
+
+      ;;
+  esac
+}
+
+main "$@"
 exit $?

--- a/scripts/changelog.sh
+++ b/scripts/changelog.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+set -uo pipefail
+
+function usage {
+  cat <<-'EOF'
+Usage: ./changelog.sh <version> <date>
+
+Description:
+  This script will update the first line in the CHANGELOG.md file with the given
+  version and date.
+EOF
+}
+
+function update_changelog {
+  VERSION="${1:-}"
+  DATE="${2:-}"
+
+  if [[ -z "$VERSION" || -z "$DATE" ]]; then
+    echo "missing at least one of [<version>, <date>] arguments"
+    usage
+    exit 1
+  fi
+
+  sed -i '' -e "1s/.*/## $VERSION ($DATE)/" CHANGELOG.md
+}
+
+update_changelog "$@"
+exit $?

--- a/scripts/version-bump.sh
+++ b/scripts/version-bump.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
 
 set -uo pipefail
 

--- a/scripts/version-bump.sh
+++ b/scripts/version-bump.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+set -uo pipefail
+
+function usage {
+  cat <<-'EOF'
+Usage: ./version-bump.sh <version>
+
+Description:
+  This script will update the version/VERSION file with the given version.
+EOF
+}
+
+function update_version {
+  VERSION="${1:-}"
+
+  if [[ -z "$VERSION" ]]; then
+    echo "missing at least one of [<version>] arguments"
+    usage
+    exit 1
+  fi
+
+  echo "$VERSION" > version/VERSION
+}
+
+update_version "$@"
+exit $?


### PR DESCRIPTION
This PR adds two new scripts. One updates the first line of the CHANGELOG.md file to the required version number and date. The second bumps the version number in version/VERSION.

Both of these will be called by the new release tooling when it is ready.