### PR TITLE
command/views: Fix flaky hook tests

### DIFF
--- a/internal/command/views/hook_json_test.go
+++ b/internal/command/views/hook_json_test.go
@@ -6,6 +6,7 @@ package views
 import (
 	"errors"
 	"fmt"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -497,7 +498,14 @@ func TestJSONHook_EphemeralOp_progress(t *testing.T) {
 		},
 	}
 
-	testJSONViewOutputEquals(t, done(t).Stdout(), want)
+	stdout := done(t).Stdout()
+
+	// time.Sleep can take longer than declared time
+	// so we only test the first lines we expect to see after sleeping
+	lines := strings.SplitN(stdout, "\n", 4)
+	firstLines := strings.Join(lines[:4], "\n")
+
+	testJSONViewOutputEquals(t, firstLines, want)
 }
 
 func TestJSONHook_EphemeralOp_error(t *testing.T) {


### PR DESCRIPTION
This aims to eliminate the failures of a handful of tests I've seen failing lately just because `time.Sleep` takes longer to "wake up" than the declared _minimum_ time period.

As per [official docs](https://pkg.go.dev/time#Sleep):

> Sleep pauses the current goroutine for **_at least_** the duration d.