### PR TITLE
template variables may be entirely unknown

### DIFF
--- a/internal/lang/funcs/filesystem.go
+++ b/internal/lang/funcs/filesystem.go
@@ -137,7 +137,7 @@ func MakeTemplateFileFunc(baseDir string, funcsCb func() (funcs map[string]funct
 
 			vars, varsMarks := args[1].UnmarkDeep()
 
-			if !pathArg.IsKnown() {
+			if !pathArg.IsKnown() || !vars.IsKnown() {
 				return cty.UnknownVal(retType).WithMarks(pathMarks, varsMarks), nil
 			}
 

--- a/internal/lang/funcs/filesystem_test.go
+++ b/internal/lang/funcs/filesystem_test.go
@@ -218,6 +218,12 @@ func TestTemplateFile(t *testing.T) {
 		},
 		{
 			cty.StringVal("testdata/list.tmpl").Mark("path"),
+			cty.UnknownVal(cty.Map(cty.String)),
+			cty.DynamicVal.Mark("path"),
+			``,
+		},
+		{
+			cty.StringVal("testdata/list.tmpl").Mark("path"),
 			cty.ObjectVal(map[string]cty.Value{
 				"list": cty.ListVal([]cty.Value{
 					cty.StringVal("a"),


### PR DESCRIPTION
While the evaluator can deal with unknown template variables, if the entire map of variables is unknown, we can't create the map and need to short-circuit the call.

Fixes #36110