### PR TITLE
relax import for_each validation

### DIFF
--- a/internal/terraform/context_apply_deferred_test.go
+++ b/internal/terraform/context_apply_deferred_test.go
@@ -2915,7 +2915,7 @@ import {
 				wantDeferred: make(map[string]ExpectedDeferred),
 				wantDiagnostic: func(diags tfdiags.Diagnostics) bool {
 					for _, diag := range diags {
-						if diag.Description().Summary == "Use of import for_each in an invalid context" {
+						if diag.Description().Summary == "Resource has no configuration" {
 							return true
 						}
 					}

--- a/internal/terraform/node_resource_validate.go
+++ b/internal/terraform/node_resource_validate.go
@@ -572,20 +572,7 @@ func (n *NodeValidatableResource) validateImportTargets(ctx EvalContext) tfdiags
 			return diags
 		}
 
-		// Resource config might be nil here since we are also validating config generation.
-		expanded := n.Config != nil && (n.Config.ForEach != nil || n.Config.Count != nil)
-
 		if imp.Config.ForEach != nil {
-			if !expanded {
-				diags = diags.Append(&hcl.Diagnostic{
-					Severity: hcl.DiagError,
-					Summary:  "Use of import for_each in an invalid context",
-					Detail:   "Use of for_each in import requires a resource using count or for_each.",
-					// FIXME: minor issue, but this points to the for_each expression rather than for_each itself.
-					Subject: imp.Config.ForEach.Range().Ptr(),
-				})
-			}
-
 			forEachData, _, forEachDiags := newForEachEvaluator(imp.Config.ForEach, ctx, true).ImportValues()
 			diags = diags.Append(forEachDiags)
 			if forEachDiags.HasErrors() {


### PR DESCRIPTION
Import blocks with for_each were intended to require resource blocks with a matching expansion. This validation however did not take place in prior releases, and configurations with this mismatch currently exist in production.

That simple validation also does not take into account a single resource instance inside of an expanded module, which is a valid use case and harder to check for at the point of validation. That will still fail correctly during plan if the targets are not available.

We can skip this validation for now, and work on generating static validation errors later on if possible, taking into account the expanded module case.

Fixes #36111