### PR TITLE
1.10 upgrade guide: sidebar update and -reconfigure callout

### DIFF
--- a/website/data/language-nav-data.json
+++ b/website/data/language-nav-data.json
@@ -1087,7 +1087,7 @@
     ]
   },
   {
-    "title": "Upgrading to Terraform v1.9",
+    "title": "Upgrading to Terraform v1.10",
     "path": "upgrade-guides"
   },
   {

--- a/website/docs/language/upgrade-guides/index.mdx
+++ b/website/docs/language/upgrade-guides/index.mdx
@@ -29,6 +29,8 @@ keywords from moved blocks will need to prepend the reference identifier with `r
 
 ## S3 Backend 
 
+Executing `terraform init -reconfigure` is required after updating to Terraform v1.10. This removes the [deprecated fields](#root-assume-role-attribute-removal) from the internal state file.
+
 ### S3 Native State Locking
 
 The S3 backend now supports S3 native state locking as an opt-in, experimental feature.
@@ -56,6 +58,7 @@ In a future minor version of Terraform the experimental label will be removed fr
 
 Several root level attributes related to IAM role assumption which were previously deprecated have been removed.
 Each removed field has an analogous field inside the [`assume_role` block](https://developer.hashicorp.com/terraform/language/backend/s3#assume-role-configuration) which should be used instead.
+
 
 | Removed | Replacement |
 | --- | --- |


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

This PR updates the sidebar in the docs to correctly say 1.10.

Also, users with an S3 backend must run `terraform init -reconfigure` due to the removal of deprecated fields. The upgrade guide now says this.

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Fixes #36150

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.10.x

