### PR TITLE
Remove square bracket from end of hyperlink in docs/architecture.md

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -107,7 +107,7 @@ is represented by
 
 The `configs` package contains some low-level functionality for constructing
 configuration objects, but the main entry point is in the sub-package
-[`configload`](http://localhost:8080/github.com/hashicorp/terraform/internal/configs/configload]),
+[`configload`](http://localhost:8080/github.com/hashicorp/terraform/internal/configs/configload),
 via
 [`configload.Loader`](http://localhost:8080/github.com/hashicorp/terraform/internal/configs/configload#Loader).
 A loader deals with all of the details of installing child modules


### PR DESCRIPTION
Fixes a link in the docs/architecture.md file that otherwise would link to http://localhost:8080/github.com/hashicorp/terraform/internal/configs/configload%5D

_"Saving the world, one character at a time"_

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

N/A

## Draft CHANGELOG entry

N/A