### PR TITLE
Update comments about Backend interface implementation, add implementation assertion

### DIFF
--- a/internal/backend/local/backend.go
+++ b/internal/backend/local/backend.go
@@ -92,6 +92,7 @@ type Local struct {
 }
 
 var _ backend.Backend = (*Local)(nil)
+var _ backendrun.OperationsBackend = (*Local)(nil)
 
 // New returns a new initialized local backend.
 func New() *Local {

--- a/internal/backend/remote/backend.go
+++ b/internal/backend/remote/backend.go
@@ -107,7 +107,7 @@ func New(services *disco.Disco) *Remote {
 	}
 }
 
-// ConfigSchema implements backend.Enhanced.
+// ConfigSchema implements backend.Backend.
 func (b *Remote) ConfigSchema() *configschema.Block {
 	return &configschema.Block{
 		Attributes: map[string]*configschema.Attribute{
@@ -221,7 +221,7 @@ func (b *Remote) ServiceDiscoveryAliases() ([]backendrun.HostAlias, error) {
 	}, nil
 }
 
-// Configure implements backend.Enhanced.
+// Configure implements backend.Backend.
 func (b *Remote) Configure(obj cty.Value) tfdiags.Diagnostics {
 	var diags tfdiags.Diagnostics
 	if obj.IsNull() {
@@ -545,7 +545,7 @@ func (b *Remote) retryLogHook(attemptNum int, resp *http.Response) {
 	}
 }
 
-// Workspaces implements backend.Enhanced.
+// Workspaces implements backend.Backend.
 func (b *Remote) Workspaces() ([]string, error) {
 	if b.prefix == "" {
 		return nil, backend.ErrWorkspacesNotSupported
@@ -608,7 +608,7 @@ func (b *Remote) WorkspaceNamePattern() string {
 	return ""
 }
 
-// DeleteWorkspace implements backend.Enhanced.
+// DeleteWorkspace implements backend.Backend.
 func (b *Remote) DeleteWorkspace(name string, _ bool) error {
 	if b.workspace == "" && name == backend.DefaultStateName {
 		return backend.ErrDefaultWorkspaceNotSupported
@@ -636,7 +636,7 @@ func (b *Remote) DeleteWorkspace(name string, _ bool) error {
 	return client.Delete()
 }
 
-// StateMgr implements backend.Enhanced.
+// StateMgr implements backend.Backend.
 func (b *Remote) StateMgr(name string) (statemgr.Full, error) {
 	if b.workspace == "" && name == backend.DefaultStateName {
 		return nil, backend.ErrDefaultWorkspaceNotSupported
@@ -744,7 +744,7 @@ func (b *Remote) fetchWorkspace(ctx context.Context, organization string, name s
 	return w, nil
 }
 
-// Operation implements backend.Enhanced.
+// Operation implements backendrun.OperationsBackend.
 func (b *Remote) Operation(ctx context.Context, op *backendrun.Operation) (*backendrun.RunningOperation, error) {
 	w, err := b.fetchWorkspace(ctx, b.organization, op.Workspace)
 

--- a/internal/cloud/backend.go
+++ b/internal/cloud/backend.go
@@ -689,7 +689,7 @@ func (b *Cloud) Workspaces() ([]string, error) {
 	return names, nil
 }
 
-// DeleteWorkspace implements backend.Enhanced.
+// DeleteWorkspace implements backend.Backend.
 func (b *Cloud) DeleteWorkspace(name string, force bool) error {
 	if name == backend.DefaultStateName {
 		return backend.ErrDefaultWorkspaceNotSupported


### PR DESCRIPTION
While working through the docs at [docs/architecture.md
](https://github.com/hashicorp/terraform/blob/main/docs/architecture.md) I realised that the backend package has some old comments that predate when the backend.Enhanced interface was replaced in https://github.com/hashicorp/terraform/pull/34818.

This PR:
- Updates old comments
- Adds a missing check that the Local backend implements the new interface `backendrun.OperationsBackend`


## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

N/A

## Draft CHANGELOG entry

N/A
