### PR TITLE
addrs: ModuleCallOutput to ConfigOutputValue translation

### DIFF
--- a/internal/addrs/module_call.go
+++ b/internal/addrs/module_call.go
@@ -210,3 +210,28 @@ func (co ModuleCallInstanceOutput) AbsOutputValue(caller ModuleInstance) AbsOutp
 	moduleAddr := co.Call.ModuleInstance(caller)
 	return moduleAddr.OutputValue(co.Name)
 }
+
+type AbsModuleCallOutput struct {
+	Call AbsModuleCall
+	Name string
+}
+
+func (c AbsModuleCall) Output(name string) AbsModuleCallOutput {
+	return AbsModuleCallOutput{
+		Call: c,
+		Name: name,
+	}
+}
+
+func (m AbsModuleCallOutput) ConfigOutputValue() ConfigOutputValue {
+	return ConfigOutputValue{
+		Module: m.Call.StaticModule(),
+		OutputValue: OutputValue{
+			Name: m.Name,
+		},
+	}
+}
+
+func (co AbsModuleCallOutput) String() string {
+	return fmt.Sprintf("%s.%s", co.Call.String(), co.Name)
+}

--- a/internal/addrs/module_call_test.go
+++ b/internal/addrs/module_call_test.go
@@ -1,0 +1,88 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package addrs
+
+import (
+	"testing"
+)
+
+func TestAbsModuleCallOutput(t *testing.T) {
+	testCases := map[string]struct {
+		input    AbsModuleCall
+		expected string
+	}{
+		"simple": {
+			input: AbsModuleCall{
+				Module: ModuleInstance{},
+				Call: ModuleCall{
+					Name: "hello",
+				},
+			},
+			expected: "module.hello.foo",
+		},
+		"nested": {
+			input: AbsModuleCall{
+				Module: ModuleInstance{
+					ModuleInstanceStep{
+						Name:        "child",
+						InstanceKey: NoKey,
+					},
+				},
+				Call: ModuleCall{
+					Name: "hello",
+				},
+			},
+			expected: "module.child.module.hello.foo",
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			output := tc.input.Output("foo")
+			if output.String() != tc.expected {
+				t.Errorf("expected %s, got %s", tc.expected, output.String())
+			}
+		})
+	}
+}
+
+func TestAbsModuleCallOutput_ConfigOutputValue(t *testing.T) {
+	testCases := map[string]struct {
+		input    AbsModuleCall
+		expected string
+	}{
+		"simple": {
+			input: AbsModuleCall{
+				Module: ModuleInstance{},
+				Call: ModuleCall{
+					Name: "hello",
+				},
+			},
+			expected: "module.hello.output.foo",
+		},
+		"nested": {
+			input: AbsModuleCall{
+				Module: ModuleInstance{
+					ModuleInstanceStep{
+						Name:        "child",
+						InstanceKey: NoKey,
+					},
+				},
+				Call: ModuleCall{
+					Name: "hello",
+				},
+			},
+			expected: "module.child.module.hello.output.foo",
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			output := tc.input.Output("foo").ConfigOutputValue()
+			if output.String() != tc.expected {
+				t.Errorf("expected %s, got %s", tc.expected, output.String())
+			}
+		})
+	}
+}


### PR DESCRIPTION
The end-goal is to retrieve ConfigOutputValues for References. This ties in with the work on deprecated outputs.

<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Fixes #

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.11.x

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

### NEW FEATURES | UPGRADE NOTES | ENHANCEMENTS | BUG FIXES | EXPERIMENTS

<!--

Write a short description of the user-facing change. Examples:

- `terraform show -json`: Fixed crash with sensitive set values.
- When rendering a diff, Terraform now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 

-  