### PR TITLE
Let the web presence team approve PRs to the website directory

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -29,4 +29,4 @@ builtin/provisioners/local-exec         @hashicorp/terraform-core
 builtin/provisioners/remote-exec        @hashicorp/terraform-core
 
 # Docs on developer.hashicorp.com/terraform/docs
-website/        @hashicorp/terraform-core @hashicorp/terraform-education
+website/        @hashicorp/terraform-core @hashicorp/terraform-education @hashicorp/web-presence


### PR DESCRIPTION
I'm trying to standardize who has permission to merge docs PRs across all our code repos. Please let me know if you have feedback; Thank you! 

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Fixes #

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.11.x

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

### NEW FEATURES | UPGRADE NOTES | ENHANCEMENTS | BUG FIXES | EXPERIMENTS

<!--

Write a short description of the user-facing change. Examples:

- `terraform show -json`: Fixed crash with sensitive set values.
- When rendering a diff, Terraform now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 

-  
