### PR TITLE
ephemeral: render write-only attributes in plan UI

### DIFF
--- a/internal/command/jsonformat/computed/renderers/write_only.go
+++ b/internal/command/jsonformat/computed/renderers/write_only.go
@@ -1,0 +1,33 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package renderers
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform/internal/command/jsonformat/computed"
+)
+
+var _ computed.DiffRenderer = (*writeOnlyRenderer)(nil)
+
+func WriteOnly(sensitive bool) computed.DiffRenderer {
+	return &writeOnlyRenderer{
+		sensitive,
+	}
+}
+
+type writeOnlyRenderer struct {
+	sensitive bool
+}
+
+func (renderer writeOnlyRenderer) RenderHuman(diff computed.Diff, indent int, opts computed.RenderHumanOpts) string {
+	if renderer.sensitive {
+		return fmt.Sprintf("(sensitive, write-only attribute)%s%s", nullSuffix(diff.Action, opts), forcesReplacement(diff.Replace, opts))
+	}
+	return fmt.Sprintf("(write-only attribute)%s%s", nullSuffix(diff.Action, opts), forcesReplacement(diff.Replace, opts))
+}
+
+func (renderer writeOnlyRenderer) WarningsHuman(diff computed.Diff, indent int, opts computed.RenderHumanOpts) []string {
+	return []string{}
+}

--- a/internal/command/jsonformat/differ/attribute.go
+++ b/internal/command/jsonformat/differ/attribute.go
@@ -4,23 +4,21 @@
 package differ
 
 import (
+	"github.com/zclconf/go-cty/cty"
+	ctyjson "github.com/zclconf/go-cty/cty/json"
+
 	"github.com/hashicorp/terraform/internal/command/jsonformat/computed/renderers"
 	"github.com/hashicorp/terraform/internal/command/jsonformat/structured"
 	"github.com/hashicorp/terraform/internal/plans"
-	"github.com/zclconf/go-cty/cty"
-	ctyjson "github.com/zclconf/go-cty/cty/json"
 
 	"github.com/hashicorp/terraform/internal/command/jsonformat/computed"
 
 	"github.com/hashicorp/terraform/internal/command/jsonprovider"
 )
 
-func ComputeDiffForAttribute(change structured.Change, attribute *jsonprovider.Attribute, blockAction plans.Action) computed.Diff {
+func ComputeDiffForAttribute(change structured.Change, attribute *jsonprovider.Attribute) computed.Diff {
 	if attribute.AttributeNestedType != nil {
 		return computeDiffForNestedAttribute(change, attribute.AttributeNestedType)
-	}
-	if attribute.WriteOnly {
-		return computeDiffForWriteOnlyAttribute(change, blockAction)
 	}
 
 	return ComputeDiffForType(change, unmarshalAttribute(attribute))

--- a/internal/command/jsonformat/differ/block.go
+++ b/internal/command/jsonformat/differ/block.go
@@ -28,6 +28,7 @@ func ComputeDiffForBlock(change structured.Change, block *jsonprovider.Block) co
 	current := change.GetDefaultActionForIteration()
 
 	blockValue := change.AsMap()
+	blockAction := change.CalculateAction()
 
 	attributes := make(map[string]computed.Diff)
 	for key, attr := range block.Attributes {
@@ -42,9 +43,9 @@ func ComputeDiffForBlock(change structured.Change, block *jsonprovider.Block) co
 		childValue.BeforeExplicit = false
 		childValue.AfterExplicit = false
 
-		childChange := ComputeDiffForAttribute(childValue, attr)
-		if childChange.Action == plans.NoOp && childValue.Before == nil && childValue.After == nil {
-			// Don't record nil values at all in blocks.
+		childChange := ComputeDiffForAttribute(childValue, attr, blockAction)
+		if childChange.Action == plans.NoOp && childValue.Before == nil && childValue.After == nil && !attr.WriteOnly {
+			// Don't record nil values at all in blocks except if they are write-only.
 			continue
 		}
 

--- a/internal/command/jsonformat/differ/block.go
+++ b/internal/command/jsonformat/differ/block.go
@@ -47,7 +47,7 @@ func ComputeDiffForBlock(change structured.Change, block *jsonprovider.Block) co
 		childValue.AfterExplicit = false
 
 		childChange := ComputeDiffForAttribute(childValue, attr)
-		if childChange.Action == plans.NoOp && childValue.Before == nil && childValue.After == nil && !attr.WriteOnly {
+		if childChange.Action == plans.NoOp && childValue.Before == nil && childValue.After == nil {
 			// Don't record nil values at all in blocks except if they are write-only.
 			continue
 		}

--- a/internal/command/jsonformat/differ/differ_test.go
+++ b/internal/command/jsonformat/differ/differ_test.go
@@ -779,17 +779,17 @@ func TestValue_ObjectAttributes(t *testing.T) {
 				}
 
 				if tc.validateObject != nil {
-					tc.validateObject(t, ComputeDiffForAttribute(tc.input, attribute))
+					tc.validateObject(t, ComputeDiffForAttribute(tc.input, attribute, plans.Update))
 					return
 				}
 
 				if tc.validateSingleDiff != nil {
-					tc.validateSingleDiff(t, ComputeDiffForAttribute(tc.input, attribute))
+					tc.validateSingleDiff(t, ComputeDiffForAttribute(tc.input, attribute, plans.Update))
 					return
 				}
 
 				validate := renderers.ValidateObject(tc.validateDiffs, tc.validateAction, tc.validateReplace)
-				validate(t, ComputeDiffForAttribute(tc.input, attribute))
+				validate(t, ComputeDiffForAttribute(tc.input, attribute, plans.Update))
 			})
 
 			t.Run("map", func(t *testing.T) {
@@ -803,7 +803,7 @@ func TestValue_ObjectAttributes(t *testing.T) {
 					validate := renderers.ValidateMap(map[string]renderers.ValidateDiffFunction{
 						"element": tc.validateObject,
 					}, collectionDefaultAction, false)
-					validate(t, ComputeDiffForAttribute(input, attribute))
+					validate(t, ComputeDiffForAttribute(input, attribute, plans.Update))
 					return
 				}
 
@@ -811,14 +811,14 @@ func TestValue_ObjectAttributes(t *testing.T) {
 					validate := renderers.ValidateMap(map[string]renderers.ValidateDiffFunction{
 						"element": tc.validateSingleDiff,
 					}, collectionDefaultAction, false)
-					validate(t, ComputeDiffForAttribute(input, attribute))
+					validate(t, ComputeDiffForAttribute(input, attribute, plans.Update))
 					return
 				}
 
 				validate := renderers.ValidateMap(map[string]renderers.ValidateDiffFunction{
 					"element": renderers.ValidateObject(tc.validateDiffs, tc.validateAction, tc.validateReplace),
 				}, collectionDefaultAction, false)
-				validate(t, ComputeDiffForAttribute(input, attribute))
+				validate(t, ComputeDiffForAttribute(input, attribute, plans.Update))
 			})
 
 			t.Run("list", func(t *testing.T) {
@@ -829,7 +829,7 @@ func TestValue_ObjectAttributes(t *testing.T) {
 				input := wrapChangeInSlice(tc.input)
 
 				if tc.validateList != nil {
-					tc.validateList(t, ComputeDiffForAttribute(input, attribute))
+					tc.validateList(t, ComputeDiffForAttribute(input, attribute, plans.Update))
 					return
 				}
 
@@ -837,7 +837,7 @@ func TestValue_ObjectAttributes(t *testing.T) {
 					validate := renderers.ValidateList([]renderers.ValidateDiffFunction{
 						tc.validateObject,
 					}, collectionDefaultAction, false)
-					validate(t, ComputeDiffForAttribute(input, attribute))
+					validate(t, ComputeDiffForAttribute(input, attribute, plans.Update))
 					return
 				}
 
@@ -845,14 +845,14 @@ func TestValue_ObjectAttributes(t *testing.T) {
 					validate := renderers.ValidateList([]renderers.ValidateDiffFunction{
 						tc.validateSingleDiff,
 					}, collectionDefaultAction, false)
-					validate(t, ComputeDiffForAttribute(input, attribute))
+					validate(t, ComputeDiffForAttribute(input, attribute, plans.Update))
 					return
 				}
 
 				validate := renderers.ValidateList([]renderers.ValidateDiffFunction{
 					renderers.ValidateObject(tc.validateDiffs, tc.validateAction, tc.validateReplace),
 				}, collectionDefaultAction, false)
-				validate(t, ComputeDiffForAttribute(input, attribute))
+				validate(t, ComputeDiffForAttribute(input, attribute, plans.Update))
 			})
 
 			t.Run("set", func(t *testing.T) {
@@ -869,7 +869,7 @@ func TestValue_ObjectAttributes(t *testing.T) {
 						ret = append(ret, tc.validateSetDiffs.After.Validate(renderers.ValidateObject))
 						return ret
 					}(), collectionDefaultAction, false)
-					validate(t, ComputeDiffForAttribute(input, attribute))
+					validate(t, ComputeDiffForAttribute(input, attribute, plans.Update))
 					return
 				}
 
@@ -877,7 +877,7 @@ func TestValue_ObjectAttributes(t *testing.T) {
 					validate := renderers.ValidateSet([]renderers.ValidateDiffFunction{
 						tc.validateObject,
 					}, collectionDefaultAction, false)
-					validate(t, ComputeDiffForAttribute(input, attribute))
+					validate(t, ComputeDiffForAttribute(input, attribute, plans.Update))
 					return
 				}
 
@@ -885,14 +885,14 @@ func TestValue_ObjectAttributes(t *testing.T) {
 					validate := renderers.ValidateSet([]renderers.ValidateDiffFunction{
 						tc.validateSingleDiff,
 					}, collectionDefaultAction, false)
-					validate(t, ComputeDiffForAttribute(input, attribute))
+					validate(t, ComputeDiffForAttribute(input, attribute, plans.Update))
 					return
 				}
 
 				validate := renderers.ValidateSet([]renderers.ValidateDiffFunction{
 					renderers.ValidateObject(tc.validateDiffs, tc.validateAction, tc.validateReplace),
 				}, collectionDefaultAction, false)
-				validate(t, ComputeDiffForAttribute(input, attribute))
+				validate(t, ComputeDiffForAttribute(input, attribute, plans.Update))
 			})
 		})
 
@@ -914,17 +914,17 @@ func TestValue_ObjectAttributes(t *testing.T) {
 				}
 
 				if tc.validateNestedObject != nil {
-					tc.validateNestedObject(t, ComputeDiffForAttribute(tc.input, attribute))
+					tc.validateNestedObject(t, ComputeDiffForAttribute(tc.input, attribute, plans.Update))
 					return
 				}
 
 				if tc.validateSingleDiff != nil {
-					tc.validateSingleDiff(t, ComputeDiffForAttribute(tc.input, attribute))
+					tc.validateSingleDiff(t, ComputeDiffForAttribute(tc.input, attribute, plans.Update))
 					return
 				}
 
 				validate := renderers.ValidateNestedObject(tc.validateDiffs, tc.validateAction, tc.validateReplace)
-				validate(t, ComputeDiffForAttribute(tc.input, attribute))
+				validate(t, ComputeDiffForAttribute(tc.input, attribute, plans.Update))
 			})
 
 			t.Run("map", func(t *testing.T) {
@@ -949,7 +949,7 @@ func TestValue_ObjectAttributes(t *testing.T) {
 					validate := renderers.ValidateMap(map[string]renderers.ValidateDiffFunction{
 						"element": tc.validateNestedObject,
 					}, collectionDefaultAction, false)
-					validate(t, ComputeDiffForAttribute(input, attribute))
+					validate(t, ComputeDiffForAttribute(input, attribute, plans.Update))
 					return
 				}
 
@@ -957,14 +957,14 @@ func TestValue_ObjectAttributes(t *testing.T) {
 					validate := renderers.ValidateMap(map[string]renderers.ValidateDiffFunction{
 						"element": tc.validateSingleDiff,
 					}, collectionDefaultAction, false)
-					validate(t, ComputeDiffForAttribute(input, attribute))
+					validate(t, ComputeDiffForAttribute(input, attribute, plans.Update))
 					return
 				}
 
 				validate := renderers.ValidateMap(map[string]renderers.ValidateDiffFunction{
 					"element": renderers.ValidateNestedObject(tc.validateDiffs, tc.validateAction, tc.validateReplace),
 				}, collectionDefaultAction, false)
-				validate(t, ComputeDiffForAttribute(input, attribute))
+				validate(t, ComputeDiffForAttribute(input, attribute, plans.Update))
 			})
 
 			t.Run("list", func(t *testing.T) {
@@ -989,7 +989,7 @@ func TestValue_ObjectAttributes(t *testing.T) {
 					validate := renderers.ValidateNestedList([]renderers.ValidateDiffFunction{
 						tc.validateNestedObject,
 					}, collectionDefaultAction, false)
-					validate(t, ComputeDiffForAttribute(input, attribute))
+					validate(t, ComputeDiffForAttribute(input, attribute, plans.Update))
 					return
 				}
 
@@ -997,14 +997,14 @@ func TestValue_ObjectAttributes(t *testing.T) {
 					validate := renderers.ValidateNestedList([]renderers.ValidateDiffFunction{
 						tc.validateSingleDiff,
 					}, collectionDefaultAction, false)
-					validate(t, ComputeDiffForAttribute(input, attribute))
+					validate(t, ComputeDiffForAttribute(input, attribute, plans.Update))
 					return
 				}
 
 				validate := renderers.ValidateNestedList([]renderers.ValidateDiffFunction{
 					renderers.ValidateNestedObject(tc.validateDiffs, tc.validateAction, tc.validateReplace),
 				}, collectionDefaultAction, false)
-				validate(t, ComputeDiffForAttribute(input, attribute))
+				validate(t, ComputeDiffForAttribute(input, attribute, plans.Update))
 			})
 
 			t.Run("set", func(t *testing.T) {
@@ -1032,7 +1032,7 @@ func TestValue_ObjectAttributes(t *testing.T) {
 						ret = append(ret, tc.validateSetDiffs.After.Validate(renderers.ValidateNestedObject))
 						return ret
 					}(), collectionDefaultAction, false)
-					validate(t, ComputeDiffForAttribute(input, attribute))
+					validate(t, ComputeDiffForAttribute(input, attribute, plans.Update))
 					return
 				}
 
@@ -1040,7 +1040,7 @@ func TestValue_ObjectAttributes(t *testing.T) {
 					validate := renderers.ValidateSet([]renderers.ValidateDiffFunction{
 						tc.validateNestedObject,
 					}, collectionDefaultAction, false)
-					validate(t, ComputeDiffForAttribute(input, attribute))
+					validate(t, ComputeDiffForAttribute(input, attribute, plans.Update))
 					return
 				}
 
@@ -1048,14 +1048,14 @@ func TestValue_ObjectAttributes(t *testing.T) {
 					validate := renderers.ValidateSet([]renderers.ValidateDiffFunction{
 						tc.validateSingleDiff,
 					}, collectionDefaultAction, false)
-					validate(t, ComputeDiffForAttribute(input, attribute))
+					validate(t, ComputeDiffForAttribute(input, attribute, plans.Update))
 					return
 				}
 
 				validate := renderers.ValidateSet([]renderers.ValidateDiffFunction{
 					renderers.ValidateNestedObject(tc.validateDiffs, tc.validateAction, tc.validateReplace),
 				}, collectionDefaultAction, false)
-				validate(t, ComputeDiffForAttribute(input, attribute))
+				validate(t, ComputeDiffForAttribute(input, attribute, plans.Update))
 			})
 		})
 	}
@@ -1840,7 +1840,7 @@ func TestValue_PrimitiveAttributes(t *testing.T) {
 			t.Run("direct", func(t *testing.T) {
 				tc.validateDiff(t, ComputeDiffForAttribute(tc.input, &jsonprovider.Attribute{
 					AttributeType: unmarshalType(t, tc.attribute),
-				}))
+				}, plans.Update))
 			})
 
 			t.Run("map", func(t *testing.T) {
@@ -1852,7 +1852,7 @@ func TestValue_PrimitiveAttributes(t *testing.T) {
 				validate := renderers.ValidateMap(map[string]renderers.ValidateDiffFunction{
 					"element": tc.validateDiff,
 				}, defaultCollectionsAction, false)
-				validate(t, ComputeDiffForAttribute(input, attribute))
+				validate(t, ComputeDiffForAttribute(input, attribute, plans.Update))
 			})
 
 			t.Run("list", func(t *testing.T) {
@@ -1863,14 +1863,14 @@ func TestValue_PrimitiveAttributes(t *testing.T) {
 
 				if tc.validateSliceDiffs != nil {
 					validate := renderers.ValidateList(tc.validateSliceDiffs, defaultCollectionsAction, false)
-					validate(t, ComputeDiffForAttribute(input, attribute))
+					validate(t, ComputeDiffForAttribute(input, attribute, plans.Update))
 					return
 				}
 
 				validate := renderers.ValidateList([]renderers.ValidateDiffFunction{
 					tc.validateDiff,
 				}, defaultCollectionsAction, false)
-				validate(t, ComputeDiffForAttribute(input, attribute))
+				validate(t, ComputeDiffForAttribute(input, attribute, plans.Update))
 			})
 
 			t.Run("set", func(t *testing.T) {
@@ -1881,14 +1881,14 @@ func TestValue_PrimitiveAttributes(t *testing.T) {
 
 				if tc.validateSliceDiffs != nil {
 					validate := renderers.ValidateSet(tc.validateSetDiffs, defaultCollectionsAction, false)
-					validate(t, ComputeDiffForAttribute(input, attribute))
+					validate(t, ComputeDiffForAttribute(input, attribute, plans.Update))
 					return
 				}
 
 				validate := renderers.ValidateSet([]renderers.ValidateDiffFunction{
 					tc.validateDiff,
 				}, defaultCollectionsAction, false)
-				validate(t, ComputeDiffForAttribute(input, attribute))
+				validate(t, ComputeDiffForAttribute(input, attribute, plans.Update))
 			})
 		})
 	}
@@ -2260,7 +2260,7 @@ func TestValue_CollectionAttributes(t *testing.T) {
 		}
 
 		t.Run(name, func(t *testing.T) {
-			tc.validateDiff(t, ComputeDiffForAttribute(tc.input, tc.attribute))
+			tc.validateDiff(t, ComputeDiffForAttribute(tc.input, tc.attribute, plans.Update))
 		})
 	}
 }

--- a/internal/command/jsonformat/differ/differ_test.go
+++ b/internal/command/jsonformat/differ/differ_test.go
@@ -779,17 +779,17 @@ func TestValue_ObjectAttributes(t *testing.T) {
 				}
 
 				if tc.validateObject != nil {
-					tc.validateObject(t, ComputeDiffForAttribute(tc.input, attribute, plans.Update))
+					tc.validateObject(t, ComputeDiffForAttribute(tc.input, attribute))
 					return
 				}
 
 				if tc.validateSingleDiff != nil {
-					tc.validateSingleDiff(t, ComputeDiffForAttribute(tc.input, attribute, plans.Update))
+					tc.validateSingleDiff(t, ComputeDiffForAttribute(tc.input, attribute))
 					return
 				}
 
 				validate := renderers.ValidateObject(tc.validateDiffs, tc.validateAction, tc.validateReplace)
-				validate(t, ComputeDiffForAttribute(tc.input, attribute, plans.Update))
+				validate(t, ComputeDiffForAttribute(tc.input, attribute))
 			})
 
 			t.Run("map", func(t *testing.T) {
@@ -803,7 +803,7 @@ func TestValue_ObjectAttributes(t *testing.T) {
 					validate := renderers.ValidateMap(map[string]renderers.ValidateDiffFunction{
 						"element": tc.validateObject,
 					}, collectionDefaultAction, false)
-					validate(t, ComputeDiffForAttribute(input, attribute, plans.Update))
+					validate(t, ComputeDiffForAttribute(input, attribute))
 					return
 				}
 
@@ -811,14 +811,14 @@ func TestValue_ObjectAttributes(t *testing.T) {
 					validate := renderers.ValidateMap(map[string]renderers.ValidateDiffFunction{
 						"element": tc.validateSingleDiff,
 					}, collectionDefaultAction, false)
-					validate(t, ComputeDiffForAttribute(input, attribute, plans.Update))
+					validate(t, ComputeDiffForAttribute(input, attribute))
 					return
 				}
 
 				validate := renderers.ValidateMap(map[string]renderers.ValidateDiffFunction{
 					"element": renderers.ValidateObject(tc.validateDiffs, tc.validateAction, tc.validateReplace),
 				}, collectionDefaultAction, false)
-				validate(t, ComputeDiffForAttribute(input, attribute, plans.Update))
+				validate(t, ComputeDiffForAttribute(input, attribute))
 			})
 
 			t.Run("list", func(t *testing.T) {
@@ -829,7 +829,7 @@ func TestValue_ObjectAttributes(t *testing.T) {
 				input := wrapChangeInSlice(tc.input)
 
 				if tc.validateList != nil {
-					tc.validateList(t, ComputeDiffForAttribute(input, attribute, plans.Update))
+					tc.validateList(t, ComputeDiffForAttribute(input, attribute))
 					return
 				}
 
@@ -837,7 +837,7 @@ func TestValue_ObjectAttributes(t *testing.T) {
 					validate := renderers.ValidateList([]renderers.ValidateDiffFunction{
 						tc.validateObject,
 					}, collectionDefaultAction, false)
-					validate(t, ComputeDiffForAttribute(input, attribute, plans.Update))
+					validate(t, ComputeDiffForAttribute(input, attribute))
 					return
 				}
 
@@ -845,14 +845,14 @@ func TestValue_ObjectAttributes(t *testing.T) {
 					validate := renderers.ValidateList([]renderers.ValidateDiffFunction{
 						tc.validateSingleDiff,
 					}, collectionDefaultAction, false)
-					validate(t, ComputeDiffForAttribute(input, attribute, plans.Update))
+					validate(t, ComputeDiffForAttribute(input, attribute))
 					return
 				}
 
 				validate := renderers.ValidateList([]renderers.ValidateDiffFunction{
 					renderers.ValidateObject(tc.validateDiffs, tc.validateAction, tc.validateReplace),
 				}, collectionDefaultAction, false)
-				validate(t, ComputeDiffForAttribute(input, attribute, plans.Update))
+				validate(t, ComputeDiffForAttribute(input, attribute))
 			})
 
 			t.Run("set", func(t *testing.T) {
@@ -869,7 +869,7 @@ func TestValue_ObjectAttributes(t *testing.T) {
 						ret = append(ret, tc.validateSetDiffs.After.Validate(renderers.ValidateObject))
 						return ret
 					}(), collectionDefaultAction, false)
-					validate(t, ComputeDiffForAttribute(input, attribute, plans.Update))
+					validate(t, ComputeDiffForAttribute(input, attribute))
 					return
 				}
 
@@ -877,7 +877,7 @@ func TestValue_ObjectAttributes(t *testing.T) {
 					validate := renderers.ValidateSet([]renderers.ValidateDiffFunction{
 						tc.validateObject,
 					}, collectionDefaultAction, false)
-					validate(t, ComputeDiffForAttribute(input, attribute, plans.Update))
+					validate(t, ComputeDiffForAttribute(input, attribute))
 					return
 				}
 
@@ -885,14 +885,14 @@ func TestValue_ObjectAttributes(t *testing.T) {
 					validate := renderers.ValidateSet([]renderers.ValidateDiffFunction{
 						tc.validateSingleDiff,
 					}, collectionDefaultAction, false)
-					validate(t, ComputeDiffForAttribute(input, attribute, plans.Update))
+					validate(t, ComputeDiffForAttribute(input, attribute))
 					return
 				}
 
 				validate := renderers.ValidateSet([]renderers.ValidateDiffFunction{
 					renderers.ValidateObject(tc.validateDiffs, tc.validateAction, tc.validateReplace),
 				}, collectionDefaultAction, false)
-				validate(t, ComputeDiffForAttribute(input, attribute, plans.Update))
+				validate(t, ComputeDiffForAttribute(input, attribute))
 			})
 		})
 
@@ -914,17 +914,17 @@ func TestValue_ObjectAttributes(t *testing.T) {
 				}
 
 				if tc.validateNestedObject != nil {
-					tc.validateNestedObject(t, ComputeDiffForAttribute(tc.input, attribute, plans.Update))
+					tc.validateNestedObject(t, ComputeDiffForAttribute(tc.input, attribute))
 					return
 				}
 
 				if tc.validateSingleDiff != nil {
-					tc.validateSingleDiff(t, ComputeDiffForAttribute(tc.input, attribute, plans.Update))
+					tc.validateSingleDiff(t, ComputeDiffForAttribute(tc.input, attribute))
 					return
 				}
 
 				validate := renderers.ValidateNestedObject(tc.validateDiffs, tc.validateAction, tc.validateReplace)
-				validate(t, ComputeDiffForAttribute(tc.input, attribute, plans.Update))
+				validate(t, ComputeDiffForAttribute(tc.input, attribute))
 			})
 
 			t.Run("map", func(t *testing.T) {
@@ -949,7 +949,7 @@ func TestValue_ObjectAttributes(t *testing.T) {
 					validate := renderers.ValidateMap(map[string]renderers.ValidateDiffFunction{
 						"element": tc.validateNestedObject,
 					}, collectionDefaultAction, false)
-					validate(t, ComputeDiffForAttribute(input, attribute, plans.Update))
+					validate(t, ComputeDiffForAttribute(input, attribute))
 					return
 				}
 
@@ -957,14 +957,14 @@ func TestValue_ObjectAttributes(t *testing.T) {
 					validate := renderers.ValidateMap(map[string]renderers.ValidateDiffFunction{
 						"element": tc.validateSingleDiff,
 					}, collectionDefaultAction, false)
-					validate(t, ComputeDiffForAttribute(input, attribute, plans.Update))
+					validate(t, ComputeDiffForAttribute(input, attribute))
 					return
 				}
 
 				validate := renderers.ValidateMap(map[string]renderers.ValidateDiffFunction{
 					"element": renderers.ValidateNestedObject(tc.validateDiffs, tc.validateAction, tc.validateReplace),
 				}, collectionDefaultAction, false)
-				validate(t, ComputeDiffForAttribute(input, attribute, plans.Update))
+				validate(t, ComputeDiffForAttribute(input, attribute))
 			})
 
 			t.Run("list", func(t *testing.T) {
@@ -989,7 +989,7 @@ func TestValue_ObjectAttributes(t *testing.T) {
 					validate := renderers.ValidateNestedList([]renderers.ValidateDiffFunction{
 						tc.validateNestedObject,
 					}, collectionDefaultAction, false)
-					validate(t, ComputeDiffForAttribute(input, attribute, plans.Update))
+					validate(t, ComputeDiffForAttribute(input, attribute))
 					return
 				}
 
@@ -997,14 +997,14 @@ func TestValue_ObjectAttributes(t *testing.T) {
 					validate := renderers.ValidateNestedList([]renderers.ValidateDiffFunction{
 						tc.validateSingleDiff,
 					}, collectionDefaultAction, false)
-					validate(t, ComputeDiffForAttribute(input, attribute, plans.Update))
+					validate(t, ComputeDiffForAttribute(input, attribute))
 					return
 				}
 
 				validate := renderers.ValidateNestedList([]renderers.ValidateDiffFunction{
 					renderers.ValidateNestedObject(tc.validateDiffs, tc.validateAction, tc.validateReplace),
 				}, collectionDefaultAction, false)
-				validate(t, ComputeDiffForAttribute(input, attribute, plans.Update))
+				validate(t, ComputeDiffForAttribute(input, attribute))
 			})
 
 			t.Run("set", func(t *testing.T) {
@@ -1032,7 +1032,7 @@ func TestValue_ObjectAttributes(t *testing.T) {
 						ret = append(ret, tc.validateSetDiffs.After.Validate(renderers.ValidateNestedObject))
 						return ret
 					}(), collectionDefaultAction, false)
-					validate(t, ComputeDiffForAttribute(input, attribute, plans.Update))
+					validate(t, ComputeDiffForAttribute(input, attribute))
 					return
 				}
 
@@ -1040,7 +1040,7 @@ func TestValue_ObjectAttributes(t *testing.T) {
 					validate := renderers.ValidateSet([]renderers.ValidateDiffFunction{
 						tc.validateNestedObject,
 					}, collectionDefaultAction, false)
-					validate(t, ComputeDiffForAttribute(input, attribute, plans.Update))
+					validate(t, ComputeDiffForAttribute(input, attribute))
 					return
 				}
 
@@ -1048,14 +1048,14 @@ func TestValue_ObjectAttributes(t *testing.T) {
 					validate := renderers.ValidateSet([]renderers.ValidateDiffFunction{
 						tc.validateSingleDiff,
 					}, collectionDefaultAction, false)
-					validate(t, ComputeDiffForAttribute(input, attribute, plans.Update))
+					validate(t, ComputeDiffForAttribute(input, attribute))
 					return
 				}
 
 				validate := renderers.ValidateSet([]renderers.ValidateDiffFunction{
 					renderers.ValidateNestedObject(tc.validateDiffs, tc.validateAction, tc.validateReplace),
 				}, collectionDefaultAction, false)
-				validate(t, ComputeDiffForAttribute(input, attribute, plans.Update))
+				validate(t, ComputeDiffForAttribute(input, attribute))
 			})
 		})
 	}
@@ -1840,7 +1840,7 @@ func TestValue_PrimitiveAttributes(t *testing.T) {
 			t.Run("direct", func(t *testing.T) {
 				tc.validateDiff(t, ComputeDiffForAttribute(tc.input, &jsonprovider.Attribute{
 					AttributeType: unmarshalType(t, tc.attribute),
-				}, plans.Update))
+				}))
 			})
 
 			t.Run("map", func(t *testing.T) {
@@ -1852,7 +1852,7 @@ func TestValue_PrimitiveAttributes(t *testing.T) {
 				validate := renderers.ValidateMap(map[string]renderers.ValidateDiffFunction{
 					"element": tc.validateDiff,
 				}, defaultCollectionsAction, false)
-				validate(t, ComputeDiffForAttribute(input, attribute, plans.Update))
+				validate(t, ComputeDiffForAttribute(input, attribute))
 			})
 
 			t.Run("list", func(t *testing.T) {
@@ -1863,14 +1863,14 @@ func TestValue_PrimitiveAttributes(t *testing.T) {
 
 				if tc.validateSliceDiffs != nil {
 					validate := renderers.ValidateList(tc.validateSliceDiffs, defaultCollectionsAction, false)
-					validate(t, ComputeDiffForAttribute(input, attribute, plans.Update))
+					validate(t, ComputeDiffForAttribute(input, attribute))
 					return
 				}
 
 				validate := renderers.ValidateList([]renderers.ValidateDiffFunction{
 					tc.validateDiff,
 				}, defaultCollectionsAction, false)
-				validate(t, ComputeDiffForAttribute(input, attribute, plans.Update))
+				validate(t, ComputeDiffForAttribute(input, attribute))
 			})
 
 			t.Run("set", func(t *testing.T) {
@@ -1881,14 +1881,14 @@ func TestValue_PrimitiveAttributes(t *testing.T) {
 
 				if tc.validateSliceDiffs != nil {
 					validate := renderers.ValidateSet(tc.validateSetDiffs, defaultCollectionsAction, false)
-					validate(t, ComputeDiffForAttribute(input, attribute, plans.Update))
+					validate(t, ComputeDiffForAttribute(input, attribute))
 					return
 				}
 
 				validate := renderers.ValidateSet([]renderers.ValidateDiffFunction{
 					tc.validateDiff,
 				}, defaultCollectionsAction, false)
-				validate(t, ComputeDiffForAttribute(input, attribute, plans.Update))
+				validate(t, ComputeDiffForAttribute(input, attribute))
 			})
 		})
 	}
@@ -2260,7 +2260,7 @@ func TestValue_CollectionAttributes(t *testing.T) {
 		}
 
 		t.Run(name, func(t *testing.T) {
-			tc.validateDiff(t, ComputeDiffForAttribute(tc.input, tc.attribute, plans.Update))
+			tc.validateDiff(t, ComputeDiffForAttribute(tc.input, tc.attribute))
 		})
 	}
 }

--- a/internal/command/jsonformat/differ/object.go
+++ b/internal/command/jsonformat/differ/object.go
@@ -23,7 +23,7 @@ func computeAttributeDiffAsObject(change structured.Change, attributes map[strin
 
 func computeAttributeDiffAsNestedObject(change structured.Change, attributes map[string]*jsonprovider.Attribute) computed.Diff {
 	attributeDiffs, action := processObject(change, attributes, func(value structured.Change, attribute *jsonprovider.Attribute) computed.Diff {
-		return ComputeDiffForAttribute(value, attribute)
+		return ComputeDiffForAttribute(value, attribute, change.CalculateAction())
 	})
 	return computed.NewDiff(renderers.NestedObject(attributeDiffs), action, change.ReplacePaths.Matches())
 }

--- a/internal/command/jsonformat/differ/object.go
+++ b/internal/command/jsonformat/differ/object.go
@@ -15,15 +15,29 @@ import (
 )
 
 func computeAttributeDiffAsObject(change structured.Change, attributes map[string]cty.Type) computed.Diff {
-	attributeDiffs, action := processObject(change, attributes, func(value structured.Change, ctype cty.Type) computed.Diff {
+	attributeDiffs, action := processObject(change, attributes, nil, func(value structured.Change, ctype cty.Type, _ plans.Action) computed.Diff {
 		return ComputeDiffForType(value, ctype)
 	})
 	return computed.NewDiff(renderers.Object(attributeDiffs), action, change.ReplacePaths.Matches())
 }
 
 func computeAttributeDiffAsNestedObject(change structured.Change, attributes map[string]*jsonprovider.Attribute) computed.Diff {
-	attributeDiffs, action := processObject(change, attributes, func(value structured.Change, attribute *jsonprovider.Attribute) computed.Diff {
-		return ComputeDiffForAttribute(value, attribute, change.CalculateAction())
+
+	otherAttributes := make(map[string]*jsonprovider.Attribute)
+	writeOnlyAttributes := make(map[string]*jsonprovider.Attribute)
+	for key, attr := range attributes {
+		if attr.WriteOnly {
+			writeOnlyAttributes[key] = attr
+		} else {
+			otherAttributes[key] = attr
+		}
+	}
+
+	attributeDiffs, action := processObject(change, otherAttributes, writeOnlyAttributes, func(value structured.Change, attribute *jsonprovider.Attribute, currentAction plans.Action) computed.Diff {
+		if attribute.WriteOnly {
+			return computeDiffForWriteOnlyAttribute(value, currentAction)
+		}
+		return ComputeDiffForAttribute(value, attribute)
 	})
 	return computed.NewDiff(renderers.NestedObject(attributeDiffs), action, change.ReplacePaths.Matches())
 }
@@ -39,7 +53,7 @@ func computeAttributeDiffAsNestedObject(change structured.Change, attributes map
 // Also, as it generic we cannot make this function a method on Change as you
 // can't create generic methods on structs. Instead, we make this a generic
 // function that receives the value as an argument.
-func processObject[T any](v structured.Change, attributes map[string]T, computeDiff func(structured.Change, T) computed.Diff) (map[string]computed.Diff, plans.Action) {
+func processObject[T any](v structured.Change, attributes map[string]T, writeOnlyAttributes map[string]T, computeDiff func(structured.Change, T, plans.Action) computed.Diff) (map[string]computed.Diff, plans.Action) {
 	attributeDiffs := make(map[string]computed.Diff)
 	mapValue := v.AsMap()
 
@@ -56,7 +70,7 @@ func processObject[T any](v structured.Change, attributes map[string]T, computeD
 		attributeValue.BeforeExplicit = false
 		attributeValue.AfterExplicit = false
 
-		attributeDiff := computeDiff(attributeValue, attribute)
+		attributeDiff := computeDiff(attributeValue, attribute, currentAction)
 		if attributeDiff.Action == plans.NoOp && attributeValue.Before == nil && attributeValue.After == nil {
 			// We skip attributes of objects that are null both before and
 			// after. We don't even count these as unchanged attributes.
@@ -64,6 +78,21 @@ func processObject[T any](v structured.Change, attributes map[string]T, computeD
 		}
 		attributeDiffs[key] = attributeDiff
 		currentAction = collections.CompareActions(currentAction, attributeDiff.Action)
+	}
+	for key, attribute := range writeOnlyAttributes {
+		attributeValue := mapValue.GetChild(key)
+
+		if !attributeValue.RelevantAttributes.MatchesPartial() {
+			// Mark non-relevant attributes as unchanged.
+			attributeValue = attributeValue.AsNoOp()
+		}
+
+		// We always assume changes to object are implicit.
+		attributeValue.BeforeExplicit = false
+		attributeValue.AfterExplicit = false
+
+		attributeDiff := computeDiff(attributeValue, attribute, currentAction)
+		attributeDiffs[key] = attributeDiff
 	}
 
 	return attributeDiffs, currentAction

--- a/internal/command/jsonformat/plan_test.go
+++ b/internal/command/jsonformat/plan_test.go
@@ -7452,6 +7452,184 @@ func TestResourceChange_sensitiveVariable(t *testing.T) {
 	runTestCases(t, testCases)
 }
 
+func TestResourceChange_writeOnlyAttributes(t *testing.T) {
+	testCases := map[string]testCase{
+		"create": {
+			Action: plans.Create,
+			Mode:   addrs.ManagedResourceMode,
+			Before: cty.NullVal(cty.Object(map[string]cty.Type{
+				"id":         cty.String,
+				"write_only": cty.String,
+				"conn_info": cty.Object(map[string]cty.Type{
+					"user":                    cty.String,
+					"write_only_set_password": cty.String,
+				}),
+			})),
+			After: cty.ObjectVal(map[string]cty.Value{
+				"id":         cty.StringVal("i-02ae66f368e8518a9"),
+				"write_only": cty.NullVal(cty.String),
+				"conn_info": cty.ObjectVal(map[string]cty.Value{
+					"user":                    cty.StringVal("not-secret"),
+					"write_only_set_password": cty.NullVal(cty.String),
+				}),
+			}),
+			Schema: &configschema.Block{
+				Attributes: map[string]*configschema.Attribute{
+					"id":         {Type: cty.String, Optional: true, Computed: true},
+					"write_only": {Type: cty.String, WriteOnly: true},
+					"conn_info": {
+						NestedType: &configschema.Object{
+							Nesting: configschema.NestingSingle,
+							Attributes: map[string]*configschema.Attribute{
+								"user":                    {Type: cty.String, Optional: true},
+								"write_only_set_password": {Type: cty.String, Optional: true, Sensitive: true, WriteOnly: true},
+							},
+						},
+					},
+				},
+			},
+			ExpectedOutput: `  # test_instance.example will be created
+  + resource "test_instance" "example" {
+      + conn_info  = {
+          + user                    = "not-secret"
+          + write_only_set_password = (sensitive, write-only attribute)
+        }
+      + id         = "i-02ae66f368e8518a9"
+      + write_only = (write-only attribute)
+    }`,
+		},
+		"update attribute": {
+			Action: plans.Update,
+			Mode:   addrs.ManagedResourceMode,
+			Before: cty.ObjectVal(map[string]cty.Value{
+				"id":         cty.StringVal("i-02ae66f368e8518a9"),
+				"write_only": cty.NullVal(cty.String),
+				"conn_info": cty.ObjectVal(map[string]cty.Value{
+					"user":                    cty.StringVal("not-secret"),
+					"write_only_set_password": cty.NullVal(cty.String),
+				}),
+			}),
+			After: cty.ObjectVal(map[string]cty.Value{
+				"id":         cty.StringVal("i-02ae66f368e8518a10"),
+				"write_only": cty.NullVal(cty.String),
+				"conn_info": cty.ObjectVal(map[string]cty.Value{
+					"user":                    cty.StringVal("not-secret"),
+					"write_only_set_password": cty.NullVal(cty.String),
+				}),
+			}),
+			Schema: &configschema.Block{
+				Attributes: map[string]*configschema.Attribute{
+					"id":         {Type: cty.String, Optional: true, Computed: true},
+					"write_only": {Type: cty.String, WriteOnly: true},
+					"conn_info": {
+						NestedType: &configschema.Object{
+							Nesting: configschema.NestingSingle,
+							Attributes: map[string]*configschema.Attribute{
+								"user":                    {Type: cty.String, Optional: true},
+								"write_only_set_password": {Type: cty.String, Optional: true, Sensitive: true, WriteOnly: true},
+							},
+						},
+					},
+				},
+			},
+			ExpectedOutput: `  # test_instance.example will be updated in-place
+  ~ resource "test_instance" "example" {
+      ~ id         = "i-02ae66f368e8518a9" -> "i-02ae66f368e8518a10"
+        # (2 unchanged attributes hidden)
+    }`,
+		},
+		"update - delete block": {
+			Action: plans.Update,
+			Mode:   addrs.ManagedResourceMode,
+			Before: cty.ObjectVal(map[string]cty.Value{
+				"id":         cty.StringVal("i-02ae66f368e8518a9"),
+				"write_only": cty.NullVal(cty.String),
+				"conn_info": cty.ObjectVal(map[string]cty.Value{
+					"user":                    cty.StringVal("not-secret"),
+					"write_only_set_password": cty.NullVal(cty.String),
+				}),
+			}),
+			After: cty.ObjectVal(map[string]cty.Value{
+				"id":         cty.StringVal("i-02ae66f368e8518a9"),
+				"write_only": cty.NullVal(cty.String),
+				"conn_info": cty.NullVal(cty.Object(map[string]cty.Type{
+					"user":                    cty.String,
+					"write_only_set_password": cty.String,
+				})),
+			}),
+			Schema: &configschema.Block{
+				Attributes: map[string]*configschema.Attribute{
+					"id":         {Type: cty.String, Optional: true, Computed: true},
+					"write_only": {Type: cty.String, WriteOnly: true},
+					"conn_info": {
+						NestedType: &configschema.Object{
+							Nesting: configschema.NestingSingle,
+							Attributes: map[string]*configschema.Attribute{
+								"user":                    {Type: cty.String, Optional: true},
+								"write_only_set_password": {Type: cty.String, Optional: true, Sensitive: true, WriteOnly: true},
+							},
+						},
+					},
+				},
+			},
+			ExpectedOutput: `  # test_instance.example will be updated in-place
+  ~ resource "test_instance" "example" {
+      - conn_info  = {
+          - user                    = "not-secret" -> null
+          - write_only_set_password = (sensitive, write-only attribute) -> null
+        } -> null
+        id         = "i-02ae66f368e8518a9"
+        # (1 unchanged attribute hidden)
+    }`,
+		},
+		"delete": {
+			Action: plans.Delete,
+			Mode:   addrs.ManagedResourceMode,
+			Before: cty.ObjectVal(map[string]cty.Value{
+				"id":         cty.StringVal("i-02ae66f368e8518a9"),
+				"write_only": cty.NullVal(cty.String),
+				"conn_info": cty.ObjectVal(map[string]cty.Value{
+					"user":                    cty.StringVal("not-secret"),
+					"write_only_set_password": cty.NullVal(cty.String),
+				}),
+			}),
+			After: cty.NullVal(cty.Object(map[string]cty.Type{
+				"id":         cty.String,
+				"write_only": cty.String,
+				"conn_info": cty.Object(map[string]cty.Type{
+					"user":                    cty.String,
+					"write_only_set_password": cty.String,
+				}),
+			})),
+			Schema: &configschema.Block{
+				Attributes: map[string]*configschema.Attribute{
+					"id":         {Type: cty.String, Optional: true, Computed: true},
+					"write_only": {Type: cty.String, WriteOnly: true},
+					"conn_info": {
+						NestedType: &configschema.Object{
+							Nesting: configschema.NestingSingle,
+							Attributes: map[string]*configschema.Attribute{
+								"user":                    {Type: cty.String, Optional: true},
+								"write_only_set_password": {Type: cty.String, Optional: true, Sensitive: true, WriteOnly: true},
+							},
+						},
+					},
+				},
+			},
+			ExpectedOutput: `  # test_instance.example will be destroyed
+  - resource "test_instance" "example" {
+      - conn_info  = {
+          - user                    = "not-secret" -> null
+          - write_only_set_password = (sensitive, write-only attribute) -> null
+        } -> null
+      - id         = "i-02ae66f368e8518a9" -> null
+      - write_only = (write-only attribute) -> null
+    }`,
+		},
+	}
+	runTestCases(t, testCases)
+}
+
 func TestResourceChange_moved(t *testing.T) {
 	prevRunAddr := addrs.Resource{
 		Mode: addrs.ManagedResourceMode,

--- a/internal/command/jsonformat/plan_test.go
+++ b/internal/command/jsonformat/plan_test.go
@@ -7464,6 +7464,10 @@ func TestResourceChange_writeOnlyAttributes(t *testing.T) {
 					"user":                    cty.String,
 					"write_only_set_password": cty.String,
 				}),
+				"block": cty.List(cty.Object(map[string]cty.Type{
+					"user":               cty.String,
+					"block_set_password": cty.String,
+				})),
 			})),
 			After: cty.ObjectVal(map[string]cty.Value{
 				"id":         cty.StringVal("i-02ae66f368e8518a9"),
@@ -7472,6 +7476,10 @@ func TestResourceChange_writeOnlyAttributes(t *testing.T) {
 					"user":                    cty.StringVal("not-secret"),
 					"write_only_set_password": cty.NullVal(cty.String),
 				}),
+				"block": cty.ListVal([]cty.Value{cty.ObjectVal(map[string]cty.Value{
+					"user":               cty.StringVal("this-is-not-secret"),
+					"block_set_password": cty.NullVal(cty.String),
+				})}),
 			}),
 			Schema: &configschema.Block{
 				Attributes: map[string]*configschema.Attribute{
@@ -7483,6 +7491,17 @@ func TestResourceChange_writeOnlyAttributes(t *testing.T) {
 							Attributes: map[string]*configschema.Attribute{
 								"user":                    {Type: cty.String, Optional: true},
 								"write_only_set_password": {Type: cty.String, Optional: true, Sensitive: true, WriteOnly: true},
+							},
+						},
+					},
+				},
+				BlockTypes: map[string]*configschema.NestedBlock{
+					"block": {
+						Nesting: configschema.NestingList,
+						Block: configschema.Block{
+							Attributes: map[string]*configschema.Attribute{
+								"user":               {Type: cty.String, Optional: true},
+								"block_set_password": {Type: cty.String, Optional: true, Sensitive: true, WriteOnly: true},
 							},
 						},
 					},
@@ -7496,6 +7515,11 @@ func TestResourceChange_writeOnlyAttributes(t *testing.T) {
         }
       + id         = "i-02ae66f368e8518a9"
       + write_only = (write-only attribute)
+
+      + block {
+          + block_set_password = (write-only attribute)
+          + user               = "this-is-not-secret"
+        }
     }`,
 		},
 		"update attribute": {
@@ -7508,6 +7532,10 @@ func TestResourceChange_writeOnlyAttributes(t *testing.T) {
 					"user":                    cty.StringVal("not-secret"),
 					"write_only_set_password": cty.NullVal(cty.String),
 				}),
+				"block": cty.ListVal([]cty.Value{cty.ObjectVal(map[string]cty.Value{
+					"user":               cty.StringVal("not-so-secret"),
+					"block_set_password": cty.NullVal(cty.String),
+				})}),
 			}),
 			After: cty.ObjectVal(map[string]cty.Value{
 				"id":         cty.StringVal("i-02ae66f368e8518a10"),
@@ -7516,6 +7544,10 @@ func TestResourceChange_writeOnlyAttributes(t *testing.T) {
 					"user":                    cty.StringVal("not-secret"),
 					"write_only_set_password": cty.NullVal(cty.String),
 				}),
+				"block": cty.ListVal([]cty.Value{cty.ObjectVal(map[string]cty.Value{
+					"user":               cty.StringVal("not-so-secret"),
+					"block_set_password": cty.NullVal(cty.String),
+				})}),
 			}),
 			Schema: &configschema.Block{
 				Attributes: map[string]*configschema.Attribute{
@@ -7531,11 +7563,24 @@ func TestResourceChange_writeOnlyAttributes(t *testing.T) {
 						},
 					},
 				},
+				BlockTypes: map[string]*configschema.NestedBlock{
+					"block": {
+						Nesting: configschema.NestingList,
+						Block: configschema.Block{
+							Attributes: map[string]*configschema.Attribute{
+								"user":               {Type: cty.String, Optional: true},
+								"block_set_password": {Type: cty.String, Optional: true, Sensitive: true, WriteOnly: true},
+							},
+						},
+					},
+				},
 			},
 			ExpectedOutput: `  # test_instance.example will be updated in-place
   ~ resource "test_instance" "example" {
       ~ id         = "i-02ae66f368e8518a9" -> "i-02ae66f368e8518a10"
         # (2 unchanged attributes hidden)
+
+        # (1 unchanged block hidden)
     }`,
 		},
 		"update - delete block": {
@@ -7548,6 +7593,10 @@ func TestResourceChange_writeOnlyAttributes(t *testing.T) {
 					"user":                    cty.StringVal("not-secret"),
 					"write_only_set_password": cty.NullVal(cty.String),
 				}),
+				"block": cty.ListVal([]cty.Value{cty.ObjectVal(map[string]cty.Value{
+					"user":               cty.StringVal("not-secret"),
+					"block_set_password": cty.NullVal(cty.String),
+				})}),
 			}),
 			After: cty.ObjectVal(map[string]cty.Value{
 				"id":         cty.StringVal("i-02ae66f368e8518a9"),
@@ -7556,6 +7605,10 @@ func TestResourceChange_writeOnlyAttributes(t *testing.T) {
 					"user":                    cty.String,
 					"write_only_set_password": cty.String,
 				})),
+				"block": cty.NullVal(cty.List(cty.Object(map[string]cty.Type{
+					"user":               cty.String,
+					"block_set_password": cty.String,
+				}))),
 			}),
 			Schema: &configschema.Block{
 				Attributes: map[string]*configschema.Attribute{
@@ -7567,6 +7620,17 @@ func TestResourceChange_writeOnlyAttributes(t *testing.T) {
 							Attributes: map[string]*configschema.Attribute{
 								"user":                    {Type: cty.String, Optional: true},
 								"write_only_set_password": {Type: cty.String, Optional: true, Sensitive: true, WriteOnly: true},
+							},
+						},
+					},
+				},
+				BlockTypes: map[string]*configschema.NestedBlock{
+					"block": {
+						Nesting: configschema.NestingList,
+						Block: configschema.Block{
+							Attributes: map[string]*configschema.Attribute{
+								"user":               {Type: cty.String, Optional: true},
+								"block_set_password": {Type: cty.String, Optional: true, Sensitive: true, WriteOnly: true},
 							},
 						},
 					},
@@ -7580,6 +7644,11 @@ func TestResourceChange_writeOnlyAttributes(t *testing.T) {
         } -> null
         id         = "i-02ae66f368e8518a9"
         # (1 unchanged attribute hidden)
+
+      - block {
+          - block_set_password = (write-only attribute) -> null
+          - user               = "not-secret" -> null
+        }
     }`,
 		},
 		"delete": {
@@ -7592,6 +7661,10 @@ func TestResourceChange_writeOnlyAttributes(t *testing.T) {
 					"user":                    cty.StringVal("not-secret"),
 					"write_only_set_password": cty.NullVal(cty.String),
 				}),
+				"block": cty.ListVal([]cty.Value{cty.ObjectVal(map[string]cty.Value{
+					"user":               cty.StringVal("not-secret"),
+					"block_set_password": cty.NullVal(cty.String),
+				})}),
 			}),
 			After: cty.NullVal(cty.Object(map[string]cty.Type{
 				"id":         cty.String,
@@ -7600,6 +7673,10 @@ func TestResourceChange_writeOnlyAttributes(t *testing.T) {
 					"user":                    cty.String,
 					"write_only_set_password": cty.String,
 				}),
+				"block": cty.List(cty.Object(map[string]cty.Type{
+					"user":               cty.String,
+					"block_set_password": cty.String,
+				})),
 			})),
 			Schema: &configschema.Block{
 				Attributes: map[string]*configschema.Attribute{
@@ -7615,6 +7692,17 @@ func TestResourceChange_writeOnlyAttributes(t *testing.T) {
 						},
 					},
 				},
+				BlockTypes: map[string]*configschema.NestedBlock{
+					"block": {
+						Nesting: configschema.NestingList,
+						Block: configschema.Block{
+							Attributes: map[string]*configschema.Attribute{
+								"user":               {Type: cty.String, Optional: true},
+								"block_set_password": {Type: cty.String, Optional: true, Sensitive: true, WriteOnly: true},
+							},
+						},
+					},
+				},
 			},
 			ExpectedOutput: `  # test_instance.example will be destroyed
   - resource "test_instance" "example" {
@@ -7624,6 +7712,11 @@ func TestResourceChange_writeOnlyAttributes(t *testing.T) {
         } -> null
       - id         = "i-02ae66f368e8518a9" -> null
       - write_only = (write-only attribute) -> null
+
+      - block {
+          - block_set_password = (write-only attribute) -> null
+          - user               = "not-secret" -> null
+        }
     }`,
 		},
 	}


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Fixes [TF-18619](https://hashicorp.atlassian.net/browse/TF-18619)


## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.11.x

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

### NEW FEATURES | UPGRADE NOTES | ENHANCEMENTS | BUG FIXES | EXPERIMENTS

<!--

Write a short description of the user-facing change. Examples:

- `terraform show -json`: Fixed crash with sensitive set values.
- When rendering a diff, Terraform now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 

-  

[TF-18619]: https://hashicorp.atlassian.net/browse/TF-18619?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ