### PR TITLE
remote: retry workspace unlock on retryable errors

### DIFF
--- a/internal/backend/remote/backend_state_test.go
+++ b/internal/backend/remote/backend_state_test.go
@@ -6,6 +6,7 @@ package remote
 import (
 	"bytes"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform/internal/backend"
@@ -13,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform/internal/states"
 	"github.com/hashicorp/terraform/internal/states/remote"
 	"github.com/hashicorp/terraform/internal/states/statefile"
+	"github.com/hashicorp/terraform/internal/states/statemgr"
 )
 
 func TestRemoteClient_impl(t *testing.T) {
@@ -39,6 +41,47 @@ func TestRemoteClient_stateLock(t *testing.T) {
 	}
 
 	remote.TestRemoteLocks(t, s1.(*remote.State).Client, s2.(*remote.State).Client)
+}
+
+func TestRemoteClient_Unlock_invalidID(t *testing.T) {
+	b, bCleanup := testBackendDefault(t)
+	defer bCleanup()
+
+	s1, err := b.StateMgr(backend.DefaultStateName)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	err = s1.Unlock("no")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	if !strings.Contains(err.Error(), "does not match existing lock ID") {
+		t.Fatalf("expected erroor containing \"does not match existing lock ID\", got %v", err)
+	}
+}
+
+func TestRemoteClient_Unlock(t *testing.T) {
+	b, bCleanup := testBackendDefault(t)
+	defer bCleanup()
+
+	s1, err := b.StateMgr(backend.DefaultStateName)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	id, err := s1.Lock(&statemgr.LockInfo{
+		ID: "test",
+	})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	err = s1.Unlock(id)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
 }
 
 func TestRemoteClient_Put_withRunID(t *testing.T) {

--- a/internal/backend/remote/retry.go
+++ b/internal/backend/remote/retry.go
@@ -1,0 +1,101 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package remote
+
+import (
+	"context"
+	"log"
+	"sync/atomic"
+	"time"
+)
+
+// Fatal implements a RetryBackoff func return value that, if encountered,
+// signals that the func should not be retried. In that case, the error
+// returned by the interface method will be returned by RetryBackoff
+type Fatal interface {
+	FatalError() error
+}
+
+// NonRetryableError is a simple implementation of Fatal that wraps an error
+type NonRetryableError struct {
+	InnerError error
+}
+
+// FatalError returns the inner error, but also implements Fatal, which
+// signals to RetryBackoff that a non-retryable error occurred.
+func (e NonRetryableError) FatalError() error {
+	return e.InnerError
+}
+
+// Error returns the inner error string
+func (e NonRetryableError) Error() string {
+	return e.InnerError.Error()
+}
+
+var (
+	initialBackoffDelay = time.Second
+	maxBackoffDelay     = 3 * time.Second
+)
+
+// RetryBackoff retries function f until nil or a FatalError is returned.
+// RetryBackoff only returns an error if the context is in error or if a
+// FatalError was encountered.
+func RetryBackoff(ctx context.Context, f func() error) error {
+	// doneCh signals that the routine is done and sends the last error
+	var doneCh = make(chan struct{})
+	var errVal atomic.Value
+	type errWrap struct {
+		E error
+	}
+
+	go func() {
+		// the retry delay between each attempt
+		var delay time.Duration = 0
+		defer close(doneCh)
+
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(delay):
+			}
+
+			err := f()
+			switch e := err.(type) {
+			case nil:
+				return
+			case Fatal:
+				errVal.Store(errWrap{e.FatalError()})
+				return
+			}
+
+			delay *= 2
+			if delay == 0 {
+				delay = initialBackoffDelay
+			}
+
+			delay = min(delay, maxBackoffDelay)
+
+			log.Printf("[WARN] retryable error: %q, delaying for %s", err, delay)
+		}
+	}()
+
+	// Wait until done or deadline
+	select {
+	case <-doneCh:
+	case <-ctx.Done():
+	}
+
+	err, hadErr := errVal.Load().(errWrap)
+	var lastErr error
+	if hadErr {
+		lastErr = err.E
+	}
+
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+
+	return lastErr
+}


### PR DESCRIPTION
Release 1.10.0 contained an enhancement to the cloud backend to more gracefully handle retryable workspace unlock errors after saving state, but this change was not ported to the remote backend.

Fixes #36155

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.10.x

## Draft CHANGELOG entry


### BUG FIXES

remote: fixes handling of workspace unlock error "unable to unlock workspace while state version upload is still pending" after saving state

