### PR TITLE
core: simplify cycle check for inter-provider deps

### DIFF
--- a/internal/terraform/transform_destroy_edge.go
+++ b/internal/terraform/transform_destroy_edge.go
@@ -129,7 +129,7 @@ func (t *DestroyEdgeTransformer) tryInterProviderDestroyEdge(g *Graph, from, to 
 	// Check for cycles, and back out the edge if there are any.
 	// The cycles we are looking for only appears between providers, so don't
 	// waste time checking for cycles if both nodes use the same provider.
-	if fromProvider != toProvider && len(g.Cycles()) > 0 {
+	if fromProvider != toProvider && g.Ancestors(to).Include(from) {
 		log.Printf("[DEBUG] DestroyEdgeTransformer: skipping inter-provider edge %s->%s which creates a cycle",
 			dag.VertexName(from), dag.VertexName(to))
 		g.RemoveEdge(e)


### PR DESCRIPTION
The design of Terraform inherently can create cycles for replacement across providers, and the interim solution was to simply check for any cycles and skip these dependencies. Checking the entire graph for cycles after each edge is added was bit silly, but doesn't pose any problems for most configurations. This is quadratic though, so extremely large numbers of interdependent replacement ops may slow down to the point of making a plan impossible.

While we don't have a solution for configuring the provider out of band, or quickly checking the provider dependencies as noted in the FIXME, we can do nearly the same thing just by making sure our `from` node isn't already an ancestor of the `to` node, essentially preemptively checking for the cycle.

See #31857 for an explanation of the cycle problem.

Existing tests fully cover the resolution order.