### PR TITLE
Add automated testing GHA specific to the version package

### DIFF
--- a/.github/workflows/check-version.yml
+++ b/.github/workflows/check-version.yml
@@ -1,0 +1,61 @@
+# This workflow is intended to run on PRs for preparing a new release. Those PRs may
+# contain diffs for only the CHANGELOG and version/VERSION files, so we skip running
+# the complete set of 'Quick Checks'. Instead we only run the tests present in the
+# version package. This ensures that edits to the version/VERSION file are valid.
+name: Check version package
+
+on:
+  workflow_dispatch:
+  pull_request:
+    types:
+      - opened
+      - ready_for_review
+      - reopened
+      - synchronize
+    paths:
+      - 'version/**'
+  push:
+    branches:
+      - '*'
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+*'
+    paths:
+      - 'version/**'
+
+
+permissions:
+  contents: read
+
+
+jobs:
+  check-version-package:
+    name: "Check version/VERSION value"
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: "Fetch source code"
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Determine Go version
+        id: go
+        uses: ./.github/actions/go-version
+
+      - name: Install Go toolchain
+        uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed # v5.1.0
+        with:
+          go-version: ${{ steps.go.outputs.version }}
+
+      # NOTE: This cache is shared so the following step must always be
+      # identical across the unit-tests, e2e-tests, and consistency-checks
+      # jobs, or else weird things could happen.
+      - name: Cache Go modules
+        uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a # v4.1.2
+        with:
+          path: "~/go/pkg"
+          key: go-mod-${{ hashFiles('go.sum') }}
+          restore-keys: |
+            go-mod-
+
+      - name: "Test version package"
+        run: |
+          go test -v github.com/hashicorp/terraform/version


### PR DESCRIPTION
If accepted, this PR is paired with https://github.com/hashicorp/terraform/pull/36215

That PR avoids the full suite of tests in the repo being run on PRs that are part of preparing a release, and this PR ensures that we still protect against bad changes to the version package (specifically the version/VERSION file).

## Target Release

N/A

## Draft CHANGELOG entry

N/A
