### PR TITLE
terraform test: allow computed/mocked values override during planning

### DIFF
--- a/.changes/unreleased/ENHANCEMENTS-20250108-113433.yaml
+++ b/.changes/unreleased/ENHANCEMENTS-20250108-113433.yaml
@@ -1,0 +1,5 @@
+kind: ENHANCEMENTS
+body: '`terraform test`: Test runs now support using mocked or overridden values during unit test runs (e.g., with command = "plan"). When override_during = "plan"'
+time: 2025-01-08T11:34:33.709443+01:00
+custom:
+    Issue: "36227"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,6 @@ ENHANCEMENTS:
 
 * New command `modules -json`: Displays a full list of all installed modules in a working directory, including whether each module is currently referenced by the working directory's configuration. ([#35884](https://github.com/hashicorp/terraform/issues/35884))
 
-* `terraform test`: Test runs now support using mocked or overridden values during unit test runs (e.g., with command = "plan"). When override_during = "plan" is specified, the mocked values will take effect during the plan phase. If not set, override_during defaults to apply. (#36227)
-
 EXPERIMENTS:
 
 Experiments are only enabled in alpha releases of Terraform CLI. The following features are not yet available in stable releases.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ ENHANCEMENTS:
 
 * New command `modules -json`: Displays a full list of all installed modules in a working directory, including whether each module is currently referenced by the working directory's configuration. ([#35884](https://github.com/hashicorp/terraform/issues/35884))
 
+* `terraform test`: Test runs now support using mocked or overridden values during unit test runs (e.g., with command = "plan"). When override_during = "plan" is specified, the mocked values will take effect during the plan phase. If not set, override_during defaults to apply. (#36227)
 
 EXPERIMENTS:
 

--- a/internal/command/test_test.go
+++ b/internal/command/test_test.go
@@ -223,11 +223,15 @@ func TestTest_Runs(t *testing.T) {
 			code:        0,
 		},
 		"mocking-invalid": {
-			expectedErr: []string{"Invalid outputs attribute"},
-			initCode:    1,
+			expectedErr: []string{
+				"Invalid outputs attribute",
+				"The override_computed attribute must be a boolean.",
+			},
+			initCode: 1,
 		},
 		"mocking-error": {
-			expectedErr: []string{"Unknown condition value",
+			expectedErr: []string{
+				"Unknown condition value",
 				"test_resource.primary[0].id",
 			},
 			code: 1,

--- a/internal/command/test_test.go
+++ b/internal/command/test_test.go
@@ -225,7 +225,7 @@ func TestTest_Runs(t *testing.T) {
 		"mocking-invalid": {
 			expectedErr: []string{
 				"Invalid outputs attribute",
-				"The override_computed attribute must be a boolean.",
+				"The override_target attribute must be a value of plan or apply.",
 			},
 			initCode: 1,
 		},
@@ -1763,7 +1763,7 @@ condition depended on is not known until after the plan has been applied.
 Either remove this value from your condition, or execute an %s command
 from this %s block. Alternatively, if there is an override for this value,
 you can make it available during the plan phase by setting %s in the %s block.
-`, "`run`", "`command = plan`", "`apply`", "`run`", "`override_computed\n= true`", "`override_`"),
+`, "`run`", "`command = plan`", "`apply`", "`run`", "`override_target\n= plan`", "`override_`"),
 		},
 		"unknown_value_in_vars": {
 			code: 1,

--- a/internal/command/test_test.go
+++ b/internal/command/test_test.go
@@ -225,7 +225,7 @@ func TestTest_Runs(t *testing.T) {
 		"mocking-invalid": {
 			expectedErr: []string{
 				"Invalid outputs attribute",
-				"The override_target attribute must be a value of plan or apply.",
+				"The override_during attribute must be a value of plan or apply.",
 			},
 			initCode: 1,
 		},
@@ -1763,7 +1763,7 @@ condition depended on is not known until after the plan has been applied.
 Either remove this value from your condition, or execute an %s command
 from this %s block. Alternatively, if there is an override for this value,
 you can make it available during the plan phase by setting %s in the %s block.
-`, "`run`", "`command = plan`", "`apply`", "`run`", "`override_target\n= plan`", "`override_`"),
+`, "`run`", "`command = plan`", "`apply`", "`run`", "`override_during =\nplan`", "`override_`"),
 		},
 		"unknown_value_in_vars": {
 			code: 1,

--- a/internal/command/test_test.go
+++ b/internal/command/test_test.go
@@ -219,7 +219,7 @@ func TestTest_Runs(t *testing.T) {
 			code:        0,
 		},
 		"mocking": {
-			expectedOut: []string{"7 passed, 0 failed."},
+			expectedOut: []string{"8 passed, 0 failed."},
 			code:        0,
 		},
 		"mocking-invalid": {

--- a/internal/command/test_test.go
+++ b/internal/command/test_test.go
@@ -1761,8 +1761,9 @@ Condition expression could not be evaluated at this time. This means you have
 executed a %s block with %s and one of the values your
 condition depended on is not known until after the plan has been applied.
 Either remove this value from your condition, or execute an %s command
-from this %s block.
-`, "`run`", "`command = plan`", "`apply`", "`run`"),
+from this %s block. Alternatively, if there is an override for this value,
+you can make it available during the plan phase by setting %s in the %s block.
+`, "`run`", "`command = plan`", "`apply`", "`run`", "`override_computed\n= true`", "`override_`"),
 		},
 		"unknown_value_in_vars": {
 			code: 1,

--- a/internal/command/test_test.go
+++ b/internal/command/test_test.go
@@ -219,12 +219,18 @@ func TestTest_Runs(t *testing.T) {
 			code:        0,
 		},
 		"mocking": {
-			expectedOut: []string{"6 passed, 0 failed."},
+			expectedOut: []string{"7 passed, 0 failed."},
 			code:        0,
 		},
 		"mocking-invalid": {
 			expectedErr: []string{"Invalid outputs attribute"},
 			initCode:    1,
+		},
+		"mocking-error": {
+			expectedErr: []string{"Unknown condition value",
+				"test_resource.primary[0].id",
+			},
+			code: 1,
 		},
 		"dangling_data_block": {
 			expectedOut: []string{"2 passed, 0 failed."},

--- a/internal/command/test_test.go
+++ b/internal/command/test_test.go
@@ -219,7 +219,7 @@ func TestTest_Runs(t *testing.T) {
 			code:        0,
 		},
 		"mocking": {
-			expectedOut: []string{"8 passed, 0 failed."},
+			expectedOut: []string{"9 passed, 0 failed."},
 			code:        0,
 		},
 		"mocking-invalid": {
@@ -232,7 +232,10 @@ func TestTest_Runs(t *testing.T) {
 		"mocking-error": {
 			expectedErr: []string{
 				"Unknown condition value",
+				"plan_mocked_overridden.tftest.hcl",
 				"test_resource.primary[0].id",
+				"plan_mocked_provider.tftest.hcl",
+				"test_resource.secondary[0].id",
 			},
 			code: 1,
 		},

--- a/internal/command/testdata/test/mocking-error/child/main.tf
+++ b/internal/command/testdata/test/mocking-error/child/main.tf
@@ -1,0 +1,30 @@
+terraform {
+  required_providers {
+    test = {
+      source = "hashicorp/test"
+      configuration_aliases = [test.primary, test.secondary]
+    }
+  }
+}
+
+variable "instances" {
+  type = number
+}
+
+resource "test_resource" "primary" {
+  provider = test.primary
+  count = var.instances
+}
+
+resource "test_resource" "secondary" {
+  provider = test.secondary
+  count = var.instances
+}
+
+output "primary" {
+  value = test_resource.primary
+}
+
+output "secondary" {
+  value = test_resource.secondary
+}

--- a/internal/command/testdata/test/mocking-error/main.tf
+++ b/internal/command/testdata/test/mocking-error/main.tf
@@ -1,0 +1,46 @@
+terraform {
+  required_providers {
+    test = {
+      source = "hashicorp/test"
+    }
+  }
+}
+
+provider "test" {
+  alias = "primary"
+}
+
+provider "test" {
+  alias = "secondary"
+}
+
+variable "instances" {
+  type = number
+}
+
+variable "child_instances" {
+  type = number
+}
+
+resource "test_resource" "primary" {
+  provider = test.primary
+  count = var.instances
+}
+
+resource "test_resource" "secondary" {
+  provider = test.secondary
+  count = var.instances
+}
+
+module "child" {
+  count = var.instances
+
+  source = "./child"
+
+  providers = {
+    test.primary = test.primary
+    test.secondary = test.secondary
+  }
+
+  instances = var.child_instances
+}

--- a/internal/command/testdata/test/mocking-error/tests/plan_mocked_overridden.tftest.hcl
+++ b/internal/command/testdata/test/mocking-error/tests/plan_mocked_overridden.tftest.hcl
@@ -1,0 +1,33 @@
+mock_provider "test" {
+  alias = "primary"
+
+  mock_resource "test_resource" {
+    defaults = {
+      id = "aaaa"
+    }
+  }
+
+  override_resource {
+    target = test_resource.primary
+    values = {
+      id = "bbbb"
+    }
+  }
+}
+
+variables {
+  instances = 1
+  child_instances = 1
+}
+
+// This test will fail because the plan command does not use the
+// overridden values, making the left-hand side of the condition unknown.
+run "test" {
+  command = plan
+
+  assert {
+    condition = test_resource.primary[0].id != "bbbb"
+    error_message = "plan should not have the overridden value"
+  }
+
+}

--- a/internal/command/testdata/test/mocking-error/tests/plan_mocked_overridden.tftest.hcl
+++ b/internal/command/testdata/test/mocking-error/tests/plan_mocked_overridden.tftest.hcl
@@ -21,7 +21,8 @@ variables {
 }
 
 // This test will fail because the plan command does not use the
-// overridden values, making the left-hand side of the condition unknown.
+// overridden values for computed properties, 
+// making the left-hand side of the condition unknown.
 run "test" {
   command = plan
 

--- a/internal/command/testdata/test/mocking-error/tests/plan_mocked_overridden.tftest.hcl
+++ b/internal/command/testdata/test/mocking-error/tests/plan_mocked_overridden.tftest.hcl
@@ -26,7 +26,7 @@ run "test" {
   command = plan
 
   assert {
-    condition = test_resource.primary[0].id != "bbbb"
+    condition = test_resource.primary[0].id == "bbbb"
     error_message = "plan should not have the overridden value"
   }
 

--- a/internal/command/testdata/test/mocking-error/tests/plan_mocked_provider.tftest.hcl
+++ b/internal/command/testdata/test/mocking-error/tests/plan_mocked_provider.tftest.hcl
@@ -19,7 +19,7 @@ run "test" {
 
   assert {
     condition = test_resource.secondary[0].id == "ffff"
-    error_message = "plan should use the mocked provider value when override_computed is true"
+    error_message = "plan should use the mocked provider value when override_target is plan"
   }
 
 }

--- a/internal/command/testdata/test/mocking-error/tests/plan_mocked_provider.tftest.hcl
+++ b/internal/command/testdata/test/mocking-error/tests/plan_mocked_provider.tftest.hcl
@@ -1,0 +1,25 @@
+mock_provider "test" {
+  alias = "secondary"
+
+  mock_resource "test_resource" {
+    defaults = {
+      id = "ffff"
+    }
+  }
+}
+
+
+variables {
+  instances = 2
+  child_instances = 1
+}
+
+run "test" {
+  command = plan
+
+  assert {
+    condition = test_resource.secondary[0].id == "ffff"
+    error_message = "plan should use the mocked provider value when override_computed is true"
+  }
+
+}

--- a/internal/command/testdata/test/mocking-error/tests/plan_mocked_provider.tftest.hcl
+++ b/internal/command/testdata/test/mocking-error/tests/plan_mocked_provider.tftest.hcl
@@ -19,7 +19,7 @@ run "test" {
 
   assert {
     condition = test_resource.secondary[0].id == "ffff"
-    error_message = "plan should use the mocked provider value when override_target is plan"
+    error_message = "plan should use the mocked provider value when override_during is plan"
   }
 
 }

--- a/internal/command/testdata/test/mocking-invalid/tests/override_computed_invalid_boolean.tftest.hcl
+++ b/internal/command/testdata/test/mocking-invalid/tests/override_computed_invalid_boolean.tftest.hcl
@@ -1,0 +1,30 @@
+mock_provider "test" {
+  alias = "primary"
+  override_computed = foo // This should be a boolean value, therefore this test should fail
+
+  mock_resource "test_resource" {
+    defaults = {
+      id = "aaaa"
+    }
+  }
+
+  override_resource {
+    target = test_resource.primary
+    values = {
+      id = "bbbb"
+    }
+  }
+}
+
+variables {
+  instances = 1
+  child_instances = 1
+}
+
+run "test" {
+
+  assert {
+    condition = test_resource.primary[0].id == "bbbb"
+    error_message = "mock not applied"
+  }
+}

--- a/internal/command/testdata/test/mocking-invalid/tests/override_computed_invalid_boolean.tftest.hcl
+++ b/internal/command/testdata/test/mocking-invalid/tests/override_computed_invalid_boolean.tftest.hcl
@@ -1,6 +1,6 @@
 mock_provider "test" {
   alias = "primary"
-  override_target = baz // This should either be plan or apply, therefore this test should fail
+  override_during = baz // This should either be plan or apply, therefore this test should fail
 
   mock_resource "test_resource" {
     defaults = {

--- a/internal/command/testdata/test/mocking-invalid/tests/override_computed_invalid_boolean.tftest.hcl
+++ b/internal/command/testdata/test/mocking-invalid/tests/override_computed_invalid_boolean.tftest.hcl
@@ -1,6 +1,6 @@
 mock_provider "test" {
   alias = "primary"
-  override_computed = foo // This should be a boolean value, therefore this test should fail
+  override_target = baz // This should either be plan or apply, therefore this test should fail
 
   mock_resource "test_resource" {
     defaults = {

--- a/internal/command/testdata/test/mocking/tests/plan_mocked_overridden.tftest.hcl
+++ b/internal/command/testdata/test/mocking/tests/plan_mocked_overridden.tftest.hcl
@@ -9,7 +9,7 @@ mock_provider "test" {
 
   override_resource {
     target = test_resource.primary
-    override_target = plan
+    override_during = plan
     values = {
       id = "bbbb"
     }
@@ -26,7 +26,7 @@ run "test" {
 
   assert {
     condition = test_resource.primary[0].id == "bbbb"
-    error_message = "plan should override the value when override_target is plan"
+    error_message = "plan should override the value when override_during is plan"
   }
 
 }

--- a/internal/command/testdata/test/mocking/tests/plan_mocked_overridden.tftest.hcl
+++ b/internal/command/testdata/test/mocking/tests/plan_mocked_overridden.tftest.hcl
@@ -1,0 +1,32 @@
+mock_provider "test" {
+  alias = "primary"
+
+  mock_resource "test_resource" {
+    defaults = {
+      id = "aaaa"
+    }
+  }
+
+  override_resource {
+    target = test_resource.primary
+    trigger_when_plan = true
+    values = {
+      id = "bbbb"
+    }
+  }
+}
+
+variables {
+  instances = 1
+  child_instances = 1
+}
+
+run "test" {
+  command = plan
+
+  assert {
+    condition = test_resource.primary[0].id == "bbbb"
+    error_message = "plan should override the value when trigger_when_plan is true"
+  }
+
+}

--- a/internal/command/testdata/test/mocking/tests/plan_mocked_overridden.tftest.hcl
+++ b/internal/command/testdata/test/mocking/tests/plan_mocked_overridden.tftest.hcl
@@ -9,7 +9,7 @@ mock_provider "test" {
 
   override_resource {
     target = test_resource.primary
-    override_computed = true
+    override_target = plan
     values = {
       id = "bbbb"
     }
@@ -26,7 +26,7 @@ run "test" {
 
   assert {
     condition = test_resource.primary[0].id == "bbbb"
-    error_message = "plan should override the value when override_computed is true"
+    error_message = "plan should override the value when override_target is plan"
   }
 
 }

--- a/internal/command/testdata/test/mocking/tests/plan_mocked_overridden.tftest.hcl
+++ b/internal/command/testdata/test/mocking/tests/plan_mocked_overridden.tftest.hcl
@@ -9,7 +9,7 @@ mock_provider "test" {
 
   override_resource {
     target = test_resource.primary
-    force_computed_override = true
+    override_computed = true
     values = {
       id = "bbbb"
     }
@@ -26,7 +26,7 @@ run "test" {
 
   assert {
     condition = test_resource.primary[0].id == "bbbb"
-    error_message = "plan should override the value when force_computed_override is true"
+    error_message = "plan should override the value when override_computed is true"
   }
 
 }

--- a/internal/command/testdata/test/mocking/tests/plan_mocked_overridden.tftest.hcl
+++ b/internal/command/testdata/test/mocking/tests/plan_mocked_overridden.tftest.hcl
@@ -9,7 +9,7 @@ mock_provider "test" {
 
   override_resource {
     target = test_resource.primary
-    trigger_when_plan = true
+    force_computed_override = true
     values = {
       id = "bbbb"
     }
@@ -26,7 +26,7 @@ run "test" {
 
   assert {
     condition = test_resource.primary[0].id == "bbbb"
-    error_message = "plan should override the value when trigger_when_plan is true"
+    error_message = "plan should override the value when force_computed_override is true"
   }
 
 }

--- a/internal/command/testdata/test/mocking/tests/plan_mocked_provider.tftest.hcl
+++ b/internal/command/testdata/test/mocking/tests/plan_mocked_provider.tftest.hcl
@@ -1,6 +1,6 @@
 mock_provider "test" {
   alias = "secondary"
-  override_target = plan
+  override_during = plan
 
   mock_resource "test_resource" {
     defaults = {
@@ -20,7 +20,7 @@ run "test" {
 
   assert {
     condition = test_resource.secondary[0].id == "ffff"
-    error_message = "plan should use the mocked provider value when override_target is plan"
+    error_message = "plan should use the mocked provider value when override_during is plan"
   }
 
 }

--- a/internal/command/testdata/test/mocking/tests/plan_mocked_provider.tftest.hcl
+++ b/internal/command/testdata/test/mocking/tests/plan_mocked_provider.tftest.hcl
@@ -1,6 +1,6 @@
 mock_provider "test" {
   alias = "secondary"
-  override_computed = true
+  override_target = plan
 
   mock_resource "test_resource" {
     defaults = {
@@ -20,7 +20,7 @@ run "test" {
 
   assert {
     condition = test_resource.secondary[0].id == "ffff"
-    error_message = "plan should use the mocked provider value when override_computed is true"
+    error_message = "plan should use the mocked provider value when override_target is plan"
   }
 
 }

--- a/internal/command/testdata/test/mocking/tests/plan_mocked_provider.tftest.hcl
+++ b/internal/command/testdata/test/mocking/tests/plan_mocked_provider.tftest.hcl
@@ -1,0 +1,26 @@
+mock_provider "test" {
+  alias = "secondary"
+  override_computed = true
+
+  mock_resource "test_resource" {
+    defaults = {
+      id = "ffff"
+    }
+  }
+}
+
+
+variables {
+  instances = 2
+  child_instances = 1
+}
+
+run "test" {
+  command = plan
+
+  assert {
+    condition = test_resource.secondary[0].id == "ffff"
+    error_message = "plan should use the mocked provider value when override_computed is true"
+  }
+
+}

--- a/internal/command/testdata/test/mocking/tests/plan_mocked_provider_overridden.tftest.hcl
+++ b/internal/command/testdata/test/mocking/tests/plan_mocked_provider_overridden.tftest.hcl
@@ -1,6 +1,6 @@
 mock_provider "test" {
   alias = "primary"
-  override_computed = true
+  override_target = plan
 
   mock_resource "test_resource" {
     defaults = {
@@ -17,7 +17,7 @@ mock_provider "test" {
 
   override_resource {
     target = test_resource.primary[1]
-    override_computed = false // this should take precedence over the provider-level override_computed
+    override_target = apply // this should take precedence over the provider-level override_target
     values = {
       id = "bbbb"
     }
@@ -27,7 +27,7 @@ mock_provider "test" {
 
 override_resource {
   target = test_resource.secondary[0]
-  override_computed = true
+  override_target = plan
   values = {
     id = "ssss"
   }
@@ -44,12 +44,12 @@ run "test" {
 
   assert {
     condition = test_resource.primary[0].id == "bbbb"
-    error_message = "plan should override the value when override_computed is true"
+    error_message = "plan should override the value when override_target is plan"
   }
 
   assert {
     condition = test_resource.secondary[0].id == "ssss"
-    error_message = "plan should override the value when override_computed is true"
+    error_message = "plan should override the value when override_target is plan"
   }
 
 }

--- a/internal/command/testdata/test/mocking/tests/plan_mocked_provider_overridden.tftest.hcl
+++ b/internal/command/testdata/test/mocking/tests/plan_mocked_provider_overridden.tftest.hcl
@@ -24,6 +24,16 @@ mock_provider "test" {
   }
 }
 
+
+override_resource {
+  target = test_resource.secondary[0]
+  override_computed = true
+  values = {
+    id = "ssss"
+  }
+}
+
+
 variables {
   instances = 2
   child_instances = 1
@@ -34,6 +44,11 @@ run "test" {
 
   assert {
     condition = test_resource.primary[0].id == "bbbb"
+    error_message = "plan should override the value when override_computed is true"
+  }
+
+  assert {
+    condition = test_resource.secondary[0].id == "ssss"
     error_message = "plan should override the value when override_computed is true"
   }
 

--- a/internal/command/testdata/test/mocking/tests/plan_mocked_provider_overridden.tftest.hcl
+++ b/internal/command/testdata/test/mocking/tests/plan_mocked_provider_overridden.tftest.hcl
@@ -1,0 +1,40 @@
+mock_provider "test" {
+  alias = "primary"
+  override_computed = true
+
+  mock_resource "test_resource" {
+    defaults = {
+      id = "aaaa"
+    }
+  }
+
+  override_resource {
+    target = test_resource.primary
+    values = {
+      id = "bbbb"
+    }
+  }
+
+  override_resource {
+    target = test_resource.primary[1]
+    override_computed = false // this should take precedence over the provider-level override_computed
+    values = {
+      id = "bbbb"
+    }
+  }
+}
+
+variables {
+  instances = 2
+  child_instances = 1
+}
+
+run "test" {
+  command = plan
+
+  assert {
+    condition = test_resource.primary[0].id == "bbbb"
+    error_message = "plan should override the value when override_computed is true"
+  }
+
+}

--- a/internal/command/testdata/test/mocking/tests/plan_mocked_provider_overridden.tftest.hcl
+++ b/internal/command/testdata/test/mocking/tests/plan_mocked_provider_overridden.tftest.hcl
@@ -1,6 +1,6 @@
 mock_provider "test" {
   alias = "primary"
-  override_target = plan
+  override_during = plan
 
   mock_resource "test_resource" {
     defaults = {
@@ -17,7 +17,7 @@ mock_provider "test" {
 
   override_resource {
     target = test_resource.primary[1]
-    override_target = apply // this should take precedence over the provider-level override_target
+    override_during = apply // this should take precedence over the provider-level override_during
     values = {
       id = "bbbb"
     }
@@ -27,7 +27,7 @@ mock_provider "test" {
 
 override_resource {
   target = test_resource.secondary[0]
-  override_target = plan
+  override_during = plan
   values = {
     id = "ssss"
   }
@@ -44,12 +44,12 @@ run "test" {
 
   assert {
     condition = test_resource.primary[0].id == "bbbb"
-    error_message = "plan should override the value when override_target is plan"
+    error_message = "plan should override the value when override_during is plan"
   }
 
   assert {
     condition = test_resource.secondary[0].id == "ssss"
-    error_message = "plan should override the value when override_target is plan"
+    error_message = "plan should override the value when override_during is plan"
   }
 
 }

--- a/internal/command/testdata/test/mocking/tests/primary_mocked_overridden.tftest.hcl
+++ b/internal/command/testdata/test/mocking/tests/primary_mocked_overridden.tftest.hcl
@@ -49,4 +49,10 @@ run "test" {
     error_message = "did not apply mocks"
   }
 
+  assert {
+    // Override should not affect the other instances
+    condition = !contains(["aaaa", "cccc"], test_resource.secondary[0].id)
+    error_message = "override from another instance affected this instance"
+  }
+
 }

--- a/internal/command/testdata/test/mocking/tests/primary_mocked_overridden.tftest.hcl
+++ b/internal/command/testdata/test/mocking/tests/primary_mocked_overridden.tftest.hcl
@@ -55,4 +55,10 @@ run "test" {
     error_message = "override from another instance affected this instance"
   }
 
+    assert {
+    // Provider Override should propagate to the child module
+    condition = module.child[0].primary[0].id == "aaaa"
+    error_message = "did not apply mocks"
+  }
+
 }

--- a/internal/configs/mock_provider.go
+++ b/internal/configs/mock_provider.go
@@ -459,7 +459,7 @@ func decodeOverrideBlock(block *hcl.Block, attributeName string, blockName strin
 				// should not happen as we already checked the type
 				diags = diags.Append(&hcl.Diagnostic{
 					Severity: hcl.DiagError,
-					Summary:  "Invalid trigger_when_plan attribute",
+					Summary:  fmt.Sprintf("Invalid %s value", triggerWhenPlan),
 					Detail:   fmt.Sprintf("The %s attribute must be a boolean.", triggerWhenPlan),
 					Subject:  attribute.Range.Ptr(),
 				})
@@ -468,7 +468,7 @@ func decodeOverrideBlock(block *hcl.Block, attributeName string, blockName strin
 		} else {
 			diags = diags.Append(&hcl.Diagnostic{
 				Severity: hcl.DiagError,
-				Summary:  "Invalid trigger_when_plan attribute",
+				Summary:  fmt.Sprintf("Invalid %s value", triggerWhenPlan),
 				Detail:   fmt.Sprintf("The %s attribute must be a boolean.", triggerWhenPlan),
 				Subject:  attribute.Range.Ptr(),
 			})

--- a/internal/configs/mock_provider.go
+++ b/internal/configs/mock_provider.go
@@ -98,13 +98,9 @@ type MockData struct {
 	MockDataSources map[string]*MockResource
 	Overrides       addrs.Map[addrs.Targetable, *Override]
 
-	useForPlan *bool // If true, the mock data can be used for planning.
-}
-
-// UseForPlan returns true if the provider-level setting for overrideComputed
-// is true, meaning that computed values can be overridden with the mocked values.
-func (data *MockData) UseForPlan() bool {
-	return data.useForPlan != nil && *data.useForPlan
+	// UseForPlan returns true if the provider-level setting for overrideComputed
+	// is true, meaning that computed values can be overridden with the mocked values during planning.
+	UseForPlan bool
 }
 
 // Merge will merge the target MockData object into the current MockData.
@@ -242,7 +238,7 @@ func decodeMockDataBody(body hcl.Body, source OverrideSource) (*MockData, hcl.Di
 		MockResources:   make(map[string]*MockResource),
 		MockDataSources: make(map[string]*MockResource),
 		Overrides:       addrs.MakeMap[addrs.Targetable, *Override](),
-		useForPlan:      &useForPlan,
+		UseForPlan:      useForPlan,
 	}
 
 	for _, block := range content.Blocks {

--- a/internal/configs/mock_provider.go
+++ b/internal/configs/mock_provider.go
@@ -411,7 +411,7 @@ var (
 	// When this attribute is set to true, the values specified in the override
 	// block will be used for computed attributes even when planning. Otherwise,
 	// the computed values will be set to unknown, just like in a real plan.
-	forceComputedOverride = "force_computed_override"
+	overrideComputed = "override_computed"
 )
 
 func decodeOverrideBlock(block *hcl.Block, attributeName string, blockName string, source OverrideSource) (*Override, hcl.Diagnostics) {
@@ -420,7 +420,7 @@ func decodeOverrideBlock(block *hcl.Block, attributeName string, blockName strin
 	content, contentDiags := block.Body.Content(&hcl.BodySchema{
 		Attributes: []hcl.AttributeSchema{
 			{Name: "target"},
-			{Name: forceComputedOverride},
+			{Name: overrideComputed},
 			{Name: attributeName},
 		},
 	})
@@ -462,8 +462,8 @@ func decodeOverrideBlock(block *hcl.Block, attributeName string, blockName strin
 		override.Values = cty.EmptyObjectVal
 	}
 
-	// Override computed values during planning if force_computed_override is true.
-	if attribute, exists := content.Attributes[forceComputedOverride]; exists {
+	// Override computed values during planning if override_computed is true.
+	if attribute, exists := content.Attributes[overrideComputed]; exists {
 		var valueDiags hcl.Diagnostics
 		val, valueDiags := attribute.Expr.Value(nil)
 		diags = append(diags, valueDiags...)
@@ -474,8 +474,8 @@ func decodeOverrideBlock(block *hcl.Block, attributeName string, blockName strin
 				// should not happen as we already checked the type
 				diags = diags.Append(&hcl.Diagnostic{
 					Severity: hcl.DiagError,
-					Summary:  fmt.Sprintf("Invalid %s value", forceComputedOverride),
-					Detail:   fmt.Sprintf("The %s attribute must be a boolean.", forceComputedOverride),
+					Summary:  fmt.Sprintf("Invalid %s value", overrideComputed),
+					Detail:   fmt.Sprintf("The %s attribute must be a boolean.", overrideComputed),
 					Subject:  attribute.Range.Ptr(),
 				})
 			}
@@ -483,8 +483,8 @@ func decodeOverrideBlock(block *hcl.Block, attributeName string, blockName strin
 		} else {
 			diags = diags.Append(&hcl.Diagnostic{
 				Severity: hcl.DiagError,
-				Summary:  fmt.Sprintf("Invalid %s value", forceComputedOverride),
-				Detail:   fmt.Sprintf("The %s attribute must be a boolean.", forceComputedOverride),
+				Summary:  fmt.Sprintf("Invalid %s value", overrideComputed),
+				Detail:   fmt.Sprintf("The %s attribute must be a boolean.", overrideComputed),
 				Subject:  attribute.Range.Ptr(),
 			})
 		}

--- a/internal/configs/mock_provider.go
+++ b/internal/configs/mock_provider.go
@@ -208,7 +208,7 @@ type Override struct {
 	// of a real plan. This attribute indicates that the computed values
 	// should be overridden with the values specified in the override block,
 	// even when planning.
-	planComputedOverride *bool
+	useForPlan *bool
 
 	// Source tells us where this Override was defined.
 	Source OverrideSource
@@ -219,10 +219,10 @@ type Override struct {
 	ValuesRange hcl.Range
 }
 
-// UseOverridesForPlan returns true if the computed values in the target
+// UseForPlan returns true if the computed values in the target
 // resource can be overridden with the values specified in the override block.
-func (o *Override) UseOverridesForPlan() bool {
-	return o.planComputedOverride != nil && *o.planComputedOverride
+func (o *Override) UseForPlan() bool {
+	return o.useForPlan != nil && *o.useForPlan
 }
 
 func decodeMockDataBody(body hcl.Body, source OverrideSource) (*MockData, hcl.Diagnostics) {
@@ -313,8 +313,8 @@ func decodeMockDataBody(body hcl.Body, source OverrideSource) (*MockData, hcl.Di
 
 	for _, elem := range data.Overrides.Elements() {
 		// use the provider-level setting if there is none set for this override
-		if elem.Value.planComputedOverride == nil {
-			elem.Value.planComputedOverride = providerOverrideComputed
+		if elem.Value.useForPlan == nil {
+			elem.Value.useForPlan = providerOverrideComputed
 		}
 		data.Overrides.Put(elem.Key, elem.Value)
 	}
@@ -508,7 +508,7 @@ func decodeOverrideBlock(block *hcl.Block, attributeName string, blockName strin
 	// Override computed values during planning if override_computed is true.
 	overrideComputedBool, valueDiags := extractOverrideComputed(content)
 	diags = append(diags, valueDiags...)
-	override.planComputedOverride = overrideComputedBool
+	override.useForPlan = overrideComputedBool
 
 	if !override.Values.Type().IsObjectType() {
 

--- a/internal/configs/mock_provider.go
+++ b/internal/configs/mock_provider.go
@@ -83,26 +83,17 @@ func extractOverrideComputed(content *hcl.BodyContent) (*bool, hcl.Diagnostics) 
 	if attr, exists := content.Attributes[overrideComputed]; exists {
 		val, valueDiags := attr.Expr.Value(nil)
 		diags = append(diags, valueDiags...)
-		if val.Type().Equals(cty.Bool) {
-			var overrideComputedBool bool
-			err := gocty.FromCtyValue(val, &overrideComputedBool)
-			if err != nil {
-				// should not happen as we already checked the type
-				diags = diags.Append(&hcl.Diagnostic{
-					Severity: hcl.DiagError,
-					Summary:  fmt.Sprintf("Invalid %s value", overrideComputed),
-					Detail:   fmt.Sprintf("The %s attribute must be a boolean.", overrideComputed),
-					Subject:  attr.Range.Ptr(),
-				})
-			}
-			return &overrideComputedBool, diags
+		var overrideComputedBool bool
+		err := gocty.FromCtyValue(val, &overrideComputedBool)
+		if err != nil {
+			diags = diags.Append(&hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  fmt.Sprintf("Invalid %s value", overrideComputed),
+				Detail:   fmt.Sprintf("The %s attribute must be a boolean.", overrideComputed),
+				Subject:  attr.Range.Ptr(),
+			})
 		}
-		diags = diags.Append(&hcl.Diagnostic{
-			Severity: hcl.DiagError,
-			Summary:  fmt.Sprintf("Invalid %s value", overrideComputed),
-			Detail:   fmt.Sprintf("The %s attribute must be a boolean.", overrideComputed),
-			Subject:  attr.Range.Ptr(),
-		})
+		return &overrideComputedBool, diags
 	}
 
 	return nil, diags
@@ -545,10 +536,6 @@ var mockProviderSchema = &hcl.BodySchema{
 }
 
 var mockDataSchema = &hcl.BodySchema{
-	Attributes: []hcl.AttributeSchema{
-		{Name: overrideComputed},
-		{Name: "alias"},
-	},
 	Blocks: []hcl.BlockHeaderSchema{
 		{Type: "mock_resource", LabelNames: []string{"type"}},
 		{Type: "mock_data", LabelNames: []string{"type"}},

--- a/internal/configs/mock_provider.go
+++ b/internal/configs/mock_provider.go
@@ -94,6 +94,14 @@ type MockData struct {
 	MockResources   map[string]*MockResource
 	MockDataSources map[string]*MockResource
 	Overrides       addrs.Map[addrs.Targetable, *Override]
+
+	useForPlan *bool // If true, the mock data can be used for planning.
+}
+
+// UseForPlan returns true if the provider-level setting for overrideComputed
+// is true, meaning that computed values can be overridden with the mocked values.
+func (data *MockData) UseForPlan() bool {
+	return data.useForPlan != nil && *data.useForPlan
 }
 
 // Merge will merge the target MockData object into the current MockData.
@@ -212,7 +220,7 @@ type Override struct {
 }
 
 // UseOverridesForPlan returns true if the computed values in the target
-// resource should be overridden with the values specified in the override block.
+// resource can be overridden with the values specified in the override block.
 func (o *Override) UseOverridesForPlan() bool {
 	return o.planComputedOverride != nil && *o.planComputedOverride
 }
@@ -231,6 +239,7 @@ func decodeMockDataBody(body hcl.Body, source OverrideSource) (*MockData, hcl.Di
 		MockResources:   make(map[string]*MockResource),
 		MockDataSources: make(map[string]*MockResource),
 		Overrides:       addrs.MakeMap[addrs.Targetable, *Override](),
+		useForPlan:      providerOverrideComputed,
 	}
 
 	for _, block := range content.Blocks {

--- a/internal/moduletest/eval_context.go
+++ b/internal/moduletest/eval_context.go
@@ -141,7 +141,7 @@ func (ec *EvalContext) Evaluate() (Status, cty.Value, tfdiags.Diagnostics) {
 			diags = diags.Append(&hcl.Diagnostic{
 				Severity:    hcl.DiagError,
 				Summary:     "Unknown condition value",
-				Detail:      "Condition expression could not be evaluated at this time. This means you have executed a `run` block with `command = plan` and one of the values your condition depended on is not known until after the plan has been applied. Either remove this value from your condition, or execute an `apply` command from this `run` block.",
+				Detail:      "Condition expression could not be evaluated at this time. This means you have executed a `run` block with `command = plan` and one of the values your condition depended on is not known until after the plan has been applied. Either remove this value from your condition, or execute an `apply` command from this `run` block. Alternatively, if there is an override for this value, you can make it available during the plan phase by setting `override_computed = true` in the `override_` block.",
 				Subject:     rule.Condition.Range().Ptr(),
 				Expression:  rule.Condition,
 				EvalContext: hclCtx,

--- a/internal/moduletest/eval_context.go
+++ b/internal/moduletest/eval_context.go
@@ -141,7 +141,7 @@ func (ec *EvalContext) Evaluate() (Status, cty.Value, tfdiags.Diagnostics) {
 			diags = diags.Append(&hcl.Diagnostic{
 				Severity:    hcl.DiagError,
 				Summary:     "Unknown condition value",
-				Detail:      "Condition expression could not be evaluated at this time. This means you have executed a `run` block with `command = plan` and one of the values your condition depended on is not known until after the plan has been applied. Either remove this value from your condition, or execute an `apply` command from this `run` block. Alternatively, if there is an override for this value, you can make it available during the plan phase by setting `override_target = plan` in the `override_` block.",
+				Detail:      "Condition expression could not be evaluated at this time. This means you have executed a `run` block with `command = plan` and one of the values your condition depended on is not known until after the plan has been applied. Either remove this value from your condition, or execute an `apply` command from this `run` block. Alternatively, if there is an override for this value, you can make it available during the plan phase by setting `override_during = plan` in the `override_` block.",
 				Subject:     rule.Condition.Range().Ptr(),
 				Expression:  rule.Condition,
 				EvalContext: hclCtx,

--- a/internal/moduletest/eval_context.go
+++ b/internal/moduletest/eval_context.go
@@ -141,7 +141,7 @@ func (ec *EvalContext) Evaluate() (Status, cty.Value, tfdiags.Diagnostics) {
 			diags = diags.Append(&hcl.Diagnostic{
 				Severity:    hcl.DiagError,
 				Summary:     "Unknown condition value",
-				Detail:      "Condition expression could not be evaluated at this time. This means you have executed a `run` block with `command = plan` and one of the values your condition depended on is not known until after the plan has been applied. Either remove this value from your condition, or execute an `apply` command from this `run` block. Alternatively, if there is an override for this value, you can make it available during the plan phase by setting `override_computed = true` in the `override_` block.",
+				Detail:      "Condition expression could not be evaluated at this time. This means you have executed a `run` block with `command = plan` and one of the values your condition depended on is not known until after the plan has been applied. Either remove this value from your condition, or execute an `apply` command from this `run` block. Alternatively, if there is an override for this value, you can make it available during the plan phase by setting `override_target = plan` in the `override_` block.",
 				Subject:     rule.Condition.Range().Ptr(),
 				Expression:  rule.Condition,
 				EvalContext: hclCtx,

--- a/internal/moduletest/mocking/values.go
+++ b/internal/moduletest/mocking/values.go
@@ -188,7 +188,7 @@ func makeUnknown(target *configschema.Attribute, _ cty.Value, _ cty.Path) (cty.V
 type MockedData struct {
 	Value             cty.Value
 	Range             hcl.Range
-	ComputedAsUnknown bool // If true, computed values are replaced with unknown.
+	ComputedAsUnknown bool // If true, computed values are replaced with unknown, otherwise they are replaced with generated values.
 }
 
 // NewMockedData creates a new MockedData struct with the given value and range.

--- a/internal/moduletest/mocking/values.go
+++ b/internal/moduletest/mocking/values.go
@@ -192,11 +192,11 @@ type MockedData struct {
 }
 
 // NewMockedData creates a new MockedData struct with the given value and range.
-func NewMockedData(value cty.Value, computedAsUnknown bool, range_ hcl.Range) MockedData {
+func NewMockedData(value cty.Value, computedAsUnknown bool, rng hcl.Range) MockedData {
 	return MockedData{
 		Value:             value,
 		ComputedAsUnknown: computedAsUnknown,
-		Range:             range_,
+		Range:             rng,
 	}
 }
 

--- a/internal/moduletest/mocking/values.go
+++ b/internal/moduletest/mocking/values.go
@@ -188,7 +188,7 @@ func makeUnknown(target *configschema.Attribute, _ cty.Value, _ cty.Path) (cty.V
 type MockedData struct {
 	Value             cty.Value
 	Range             hcl.Range
-	ComputedAsUnknown bool // If true, computed values are replaced with unknown, otherwise they are replaced with generated values.
+	ComputedAsUnknown bool // If true, computed values are replaced with unknown, otherwise they are replaced with overridden or generated values.
 }
 
 // NewMockedData creates a new MockedData struct with the given value and range.

--- a/internal/moduletest/mocking/values.go
+++ b/internal/moduletest/mocking/values.go
@@ -20,14 +20,13 @@ import (
 // The latter behaviour simulates the behaviour of a plan request in a real
 // provider.
 func PlanComputedValuesForResource(original cty.Value, with *MockedData, schema *configschema.Block) (cty.Value, tfdiags.Diagnostics) {
-	mocked := with
 	if with == nil {
-		mocked = &MockedData{
+		with = &MockedData{
 			Value:             cty.NilVal,
 			ComputedAsUnknown: true,
 		}
 	}
-	return populateComputedValues(original, mocked, schema, isNull)
+	return populateComputedValues(original, *with, schema, isNull)
 }
 
 // ApplyComputedValuesForResource accepts a target value, and populates it
@@ -38,13 +37,12 @@ func PlanComputedValuesForResource(original cty.Value, with *MockedData, schema 
 // This method basically simulates the behaviour of an apply request in a real
 // provider.
 func ApplyComputedValuesForResource(original cty.Value, with *MockedData, schema *configschema.Block) (cty.Value, tfdiags.Diagnostics) {
-	mocked := with
 	if with == nil {
-		mocked = &MockedData{
+		with = &MockedData{
 			Value: cty.NilVal,
 		}
 	}
-	return populateComputedValues(original, mocked, schema, isUnknown)
+	return populateComputedValues(original, *with, schema, isUnknown)
 }
 
 // ComputedValuesForDataSource accepts a target value, and populates it either
@@ -58,26 +56,20 @@ func ApplyComputedValuesForResource(original cty.Value, with *MockedData, schema
 // This method basically simulates the behaviour of a get data source request
 // in a real provider.
 func ComputedValuesForDataSource(original cty.Value, with *MockedData, schema *configschema.Block) (cty.Value, tfdiags.Diagnostics) {
-	mocked := with
 	if with == nil {
-		mocked = &MockedData{
+		with = &MockedData{
 			Value: cty.NilVal,
 		}
 	}
-	return populateComputedValues(original, mocked, schema, isNull)
+	return populateComputedValues(original, *with, schema, isNull)
 }
 
 type processValue func(value cty.Value) bool
 
 type generateValue func(attribute *configschema.Attribute, with cty.Value, path cty.Path) (cty.Value, tfdiags.Diagnostics)
 
-func populateComputedValues(target cty.Value, mocked *MockedData, schema *configschema.Block, processValue processValue) (cty.Value, tfdiags.Diagnostics) {
+func populateComputedValues(target cty.Value, with MockedData, schema *configschema.Block, processValue processValue) (cty.Value, tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
-
-	with := MockedData{}
-	if mocked != nil {
-		with = *mocked
-	}
 
 	var generateValue generateValue
 	// If the computed attributes should be ignored, then we will generate

--- a/internal/moduletest/mocking/values_test.go
+++ b/internal/moduletest/mocking/values_test.go
@@ -983,7 +983,7 @@ func TestComputedValuesForDataSource(t *testing.T) {
 				testRand = nil
 			}()
 
-			actual, diags := ComputedValuesForDataSource(tc.target, MockedData{
+			actual, diags := ComputedValuesForDataSource(tc.target, &MockedData{
 				Value: tc.with,
 			}, tc.schema)
 

--- a/internal/providers/mock.go
+++ b/internal/providers/mock.go
@@ -222,7 +222,7 @@ func (m *Mock) ApplyResourceChange(request ApplyResourceChangeRequest) ApplyReso
 			panic(fmt.Errorf("failed to retrieve schema for resource %s", request.TypeName))
 		}
 
-		replacement := mocking.MockedData{
+		replacement := &mocking.MockedData{
 			Value: cty.NilVal, // If we have no data then we use cty.NilVal.
 		}
 		if mockedResource, exists := m.Data.MockResources[request.TypeName]; exists {
@@ -277,7 +277,7 @@ func (m *Mock) ReadDataSource(request ReadDataSourceRequest) ReadDataSourceRespo
 		panic(fmt.Errorf("failed to retrieve schema for data source %s", request.TypeName))
 	}
 
-	mockedData := mocking.MockedData{
+	mockedData := &mocking.MockedData{
 		Value: cty.NilVal, // If we have no mocked data we use cty.NilVal.
 	}
 	if mockedDataSource, exists := m.Data.MockDataSources[request.TypeName]; exists {

--- a/internal/providers/mock.go
+++ b/internal/providers/mock.go
@@ -187,7 +187,7 @@ func (m *Mock) PlanResourceChange(request PlanResourceChangeRequest) PlanResourc
 			ComputedAsUnknown: true,
 		}
 		// if we are allowed to use the mock defaults for plan, we can populate the computed fields with the mock defaults.
-		if mockedResource, exists := m.Data.MockResources[request.TypeName]; exists && m.Data.UseForPlan() {
+		if mockedResource, exists := m.Data.MockResources[request.TypeName]; exists && m.Data.UseForPlan {
 			replacement.Value = mockedResource.Defaults
 			replacement.Range = mockedResource.DefaultsRange
 			replacement.ComputedAsUnknown = false

--- a/internal/providers/mock.go
+++ b/internal/providers/mock.go
@@ -182,7 +182,9 @@ func (m *Mock) PlanResourceChange(request PlanResourceChangeRequest) PlanResourc
 			panic(fmt.Errorf("failed to retrieve schema for resource %s", request.TypeName))
 		}
 
-		value, diags := mocking.PlanComputedValuesForResource(request.ProposedNewState, resource.Block)
+		// If the provider was overriden in the test (via override_*), the mock provider is not called at all,
+		// so we can be certain that this provider is not mocked.
+		value, diags := mocking.PlanComputedValuesForResource(request.ProposedNewState, nil, resource.Block)
 		response.Diagnostics = response.Diagnostics.Append(diags)
 		response.PlannedState = value
 		response.PlannedPrivate = []byte("create")

--- a/internal/providers/mock.go
+++ b/internal/providers/mock.go
@@ -184,7 +184,9 @@ func (m *Mock) PlanResourceChange(request PlanResourceChangeRequest) PlanResourc
 
 		// If the provider was overriden in the test (via override_*), the mock provider is not called at all,
 		// so we can be certain that this provider is not mocked.
-		value, diags := mocking.PlanComputedValuesForResource(request.ProposedNewState, nil, resource.Block)
+		value, diags := mocking.PlanComputedValuesForResource(request.ProposedNewState, &mocking.MockedData{
+			ComputedAsUnknown: true,
+		}, resource.Block)
 		response.Diagnostics = response.Diagnostics.Append(diags)
 		response.PlannedState = value
 		response.PlannedPrivate = []byte("create")

--- a/internal/providers/mock.go
+++ b/internal/providers/mock.go
@@ -182,8 +182,8 @@ func (m *Mock) PlanResourceChange(request PlanResourceChangeRequest) PlanResourc
 			panic(fmt.Errorf("failed to retrieve schema for resource %s", request.TypeName))
 		}
 
-		// If the provider was overriden in the test (via override_*), the mock provider is not called at all,
-		// so we can be certain that this provider is not mocked.
+		// If the provider was overriden via override_* blocks, the mock provider is not called at all,
+		// so we can continue to make computed values as unknown here (until mock defaults support plan command).
 		value, diags := mocking.PlanComputedValuesForResource(request.ProposedNewState, &mocking.MockedData{
 			ComputedAsUnknown: true,
 		}, resource.Block)

--- a/internal/stacks/stackruntime/internal/stackeval/stubs/unknown.go
+++ b/internal/stacks/stackruntime/internal/stackeval/stubs/unknown.go
@@ -115,7 +115,7 @@ func (u *unknownProvider) PlanResourceChange(request providers.PlanResourceChang
 		// library, but it is doing exactly what we need it to do.
 
 		schema := u.GetProviderSchema().ResourceTypes[request.TypeName]
-		val, diags := mocking.PlanComputedValuesForResource(request.ProposedNewState, schema.Block)
+		val, diags := mocking.PlanComputedValuesForResource(request.ProposedNewState, nil, schema.Block)
 		if diags.HasErrors() {
 			// All the potential errors we get back from this function are
 			// related to the user badly defining mocks. We should never hit
@@ -213,7 +213,7 @@ func (u *unknownProvider) ReadDataSource(request providers.ReadDataSourceRequest
 		// library, but it is doing exactly what we need it to do.
 
 		schema := u.GetProviderSchema().DataSources[request.TypeName]
-		val, diags := mocking.PlanComputedValuesForResource(request.Config, schema.Block)
+		val, diags := mocking.PlanComputedValuesForResource(request.Config, nil, schema.Block)
 		if diags.HasErrors() {
 			// All the potential errors we get back from this function are
 			// related to the user badly defining mocks. We should never hit

--- a/internal/terraform/node_resource_abstract_instance.go
+++ b/internal/terraform/node_resource_abstract_instance.go
@@ -904,7 +904,7 @@ func (n *NodeAbstractResourceInstance) plan(
 		if priorVal.IsNull() {
 			// Then we are actually creating something, so let's populate the
 			// computed values from our override value.
-			override, overrideDiags := mocking.PlanComputedValuesForResource(proposedNewVal, schema)
+			override, overrideDiags := mocking.PlanComputedValuesForResource(proposedNewVal, getPlanMockedData(n.override), schema)
 			resp = providers.PlanResourceChangeResponse{
 				PlannedState: override,
 				Diagnostics:  overrideDiags,
@@ -1082,7 +1082,7 @@ func (n *NodeAbstractResourceInstance) plan(
 		if n.override != nil {
 			// In this case, we are always creating the resource so we don't
 			// do any validation, and just call out to the mocking library.
-			override, overrideDiags := mocking.PlanComputedValuesForResource(proposedNewVal, schema)
+			override, overrideDiags := mocking.PlanComputedValuesForResource(proposedNewVal, getPlanMockedData(n.override), schema)
 			resp = providers.PlanResourceChangeResponse{
 				PlannedState: override,
 				Diagnostics:  overrideDiags,
@@ -1229,6 +1229,17 @@ func (n *NodeAbstractResourceInstance) plan(
 	}
 
 	return plan, state, deferred, keyData, diags
+}
+
+func getPlanMockedData(override *configs.Override) *mocking.MockedData {
+	if override == nil {
+		return nil
+	}
+	return &mocking.MockedData{
+		Value:  override.Values,
+		Range:  override.Range,
+		Ignore: override.Ignore,
+	}
 }
 
 func (n *NodeAbstractResource) processIgnoreChanges(prior, config cty.Value, schema *configschema.Block) (cty.Value, tfdiags.Diagnostics) {

--- a/internal/terraform/node_resource_abstract_instance.go
+++ b/internal/terraform/node_resource_abstract_instance.go
@@ -904,7 +904,11 @@ func (n *NodeAbstractResourceInstance) plan(
 		if priorVal.IsNull() {
 			// Then we are actually creating something, so let's populate the
 			// computed values from our override value.
-			override, overrideDiags := mocking.PlanComputedValuesForResource(proposedNewVal, getMockedData(n.override, true), schema)
+			override, overrideDiags := mocking.PlanComputedValuesForResource(proposedNewVal, &mocking.MockedData{
+				Value:             n.override.Values,
+				Range:             n.override.Range,
+				ComputedAsUnknown: n.override.IgnoreValues,
+			}, schema)
 			resp = providers.PlanResourceChangeResponse{
 				PlannedState: override,
 				Diagnostics:  overrideDiags,
@@ -1082,7 +1086,11 @@ func (n *NodeAbstractResourceInstance) plan(
 		if n.override != nil {
 			// In this case, we are always creating the resource so we don't
 			// do any validation, and just call out to the mocking library.
-			override, overrideDiags := mocking.PlanComputedValuesForResource(proposedNewVal, getMockedData(n.override, true), schema)
+			override, overrideDiags := mocking.PlanComputedValuesForResource(proposedNewVal, &mocking.MockedData{
+				Value:             n.override.Values,
+				Range:             n.override.Range,
+				ComputedAsUnknown: n.override.IgnoreValues,
+			}, schema)
 			resp = providers.PlanResourceChangeResponse{
 				PlannedState: override,
 				Diagnostics:  overrideDiags,
@@ -1231,18 +1239,18 @@ func (n *NodeAbstractResourceInstance) plan(
 	return plan, state, deferred, keyData, diags
 }
 
-func getMockedData(override *configs.Override, isPlan bool) *mocking.MockedData {
-	if override == nil {
-		return nil
-	}
-	return &mocking.MockedData{
-		Value: override.Values,
-		Range: override.Range,
-		// Apply never ignores computed values. This attribute only matters
-		// when we are planning.
-		ComputedAsUnknown: override.IgnoreValues && isPlan,
-	}
-}
+// func getMockedData(override *configs.Override, isPlan bool) *mocking.MockedData {
+// 	if override == nil {
+// 		return nil
+// 	}
+// 	return &mocking.MockedData{
+// 		Value: override.Values,
+// 		Range: override.Range,
+// 		// Apply never ignores computed values. This attribute only matters
+// 		// when we are planning.
+// 		ComputedAsUnknown: override.IgnoreValues && isPlan,
+// 	}
+// }
 
 func (n *NodeAbstractResource) processIgnoreChanges(prior, config cty.Value, schema *configschema.Block) (cty.Value, tfdiags.Diagnostics) {
 	// ignore_changes only applies when an object already exists, since we
@@ -1556,7 +1564,11 @@ func (n *NodeAbstractResourceInstance) readDataSource(ctx EvalContext, configVal
 
 	var resp providers.ReadDataSourceResponse
 	if n.override != nil {
-		override, overrideDiags := mocking.ComputedValuesForDataSource(configVal, getMockedData(n.override, false), schema)
+		override, overrideDiags := mocking.ComputedValuesForDataSource(configVal, &mocking.MockedData{
+			Value:             n.override.Values,
+			Range:             n.override.Range,
+			ComputedAsUnknown: false,
+		}, schema)
 		resp = providers.ReadDataSourceResponse{
 			State:       override,
 			Diagnostics: overrideDiags,
@@ -2508,7 +2520,11 @@ func (n *NodeAbstractResourceInstance) apply(
 		// values the first time the object is created. Otherwise, we're happy
 		// to just apply whatever the user asked for.
 		if change.Action == plans.Create {
-			override, overrideDiags := mocking.ApplyComputedValuesForResource(unmarkedAfter, getMockedData(n.override, false), schema)
+			override, overrideDiags := mocking.ApplyComputedValuesForResource(unmarkedAfter, &mocking.MockedData{
+				Value:             n.override.Values,
+				Range:             n.override.Range,
+				ComputedAsUnknown: false,
+			}, schema)
 			resp = providers.ApplyResourceChangeResponse{
 				NewState:    override,
 				Diagnostics: overrideDiags,

--- a/internal/terraform/node_resource_abstract_instance.go
+++ b/internal/terraform/node_resource_abstract_instance.go
@@ -1240,7 +1240,7 @@ func getMockedData(override *configs.Override, isPlan bool) *mocking.MockedData 
 		Range: override.Range,
 		// Apply never ignores computed values. This attribute only matters
 		// when we are planning.
-		ComputedAsUnknown: override.Ignore && isPlan,
+		ComputedAsUnknown: override.IgnoreValues && isPlan,
 	}
 }
 

--- a/internal/terraform/node_resource_abstract_instance.go
+++ b/internal/terraform/node_resource_abstract_instance.go
@@ -904,7 +904,7 @@ func (n *NodeAbstractResourceInstance) plan(
 		if priorVal.IsNull() {
 			// Then we are actually creating something, so let's populate the
 			// computed values from our override value.
-			override, overrideDiags := mocking.PlanComputedValuesForResource(proposedNewVal, getPlanMockedData(n.override), schema)
+			override, overrideDiags := mocking.PlanComputedValuesForResource(proposedNewVal, getMockedData(n.override), schema)
 			resp = providers.PlanResourceChangeResponse{
 				PlannedState: override,
 				Diagnostics:  overrideDiags,
@@ -1082,7 +1082,7 @@ func (n *NodeAbstractResourceInstance) plan(
 		if n.override != nil {
 			// In this case, we are always creating the resource so we don't
 			// do any validation, and just call out to the mocking library.
-			override, overrideDiags := mocking.PlanComputedValuesForResource(proposedNewVal, getPlanMockedData(n.override), schema)
+			override, overrideDiags := mocking.PlanComputedValuesForResource(proposedNewVal, getMockedData(n.override), schema)
 			resp = providers.PlanResourceChangeResponse{
 				PlannedState: override,
 				Diagnostics:  overrideDiags,
@@ -1231,14 +1231,14 @@ func (n *NodeAbstractResourceInstance) plan(
 	return plan, state, deferred, keyData, diags
 }
 
-func getPlanMockedData(override *configs.Override) *mocking.MockedData {
+func getMockedData(override *configs.Override) *mocking.MockedData {
 	if override == nil {
 		return nil
 	}
 	return &mocking.MockedData{
-		Value:  override.Values,
-		Range:  override.Range,
-		Ignore: override.Ignore,
+		Value:          override.Values,
+		Range:          override.Range,
+		IgnoreComputed: override.Ignore,
 	}
 }
 
@@ -1554,10 +1554,7 @@ func (n *NodeAbstractResourceInstance) readDataSource(ctx EvalContext, configVal
 
 	var resp providers.ReadDataSourceResponse
 	if n.override != nil {
-		override, overrideDiags := mocking.ComputedValuesForDataSource(configVal, mocking.MockedData{
-			Value: n.override.Values,
-			Range: n.override.ValuesRange,
-		}, schema)
+		override, overrideDiags := mocking.ComputedValuesForDataSource(configVal, getMockedData(n.override), schema)
 		resp = providers.ReadDataSourceResponse{
 			State:       override,
 			Diagnostics: overrideDiags,
@@ -2509,10 +2506,7 @@ func (n *NodeAbstractResourceInstance) apply(
 		// values the first time the object is created. Otherwise, we're happy
 		// to just apply whatever the user asked for.
 		if change.Action == plans.Create {
-			override, overrideDiags := mocking.ApplyComputedValuesForResource(unmarkedAfter, mocking.MockedData{
-				Value: n.override.Values,
-				Range: n.override.ValuesRange,
-			}, schema)
+			override, overrideDiags := mocking.ApplyComputedValuesForResource(unmarkedAfter, getMockedData(n.override), schema)
 			resp = providers.ApplyResourceChangeResponse{
 				NewState:    override,
 				Diagnostics: overrideDiags,

--- a/internal/terraform/node_resource_abstract_instance.go
+++ b/internal/terraform/node_resource_abstract_instance.go
@@ -907,7 +907,7 @@ func (n *NodeAbstractResourceInstance) plan(
 			override, overrideDiags := mocking.PlanComputedValuesForResource(proposedNewVal, &mocking.MockedData{
 				Value:             n.override.Values,
 				Range:             n.override.Range,
-				ComputedAsUnknown: n.override.IgnoreValues,
+				ComputedAsUnknown: !n.override.UseOverridesForPlan(),
 			}, schema)
 			resp = providers.PlanResourceChangeResponse{
 				PlannedState: override,
@@ -1089,7 +1089,7 @@ func (n *NodeAbstractResourceInstance) plan(
 			override, overrideDiags := mocking.PlanComputedValuesForResource(proposedNewVal, &mocking.MockedData{
 				Value:             n.override.Values,
 				Range:             n.override.Range,
-				ComputedAsUnknown: n.override.IgnoreValues,
+				ComputedAsUnknown: !n.override.UseOverridesForPlan(),
 			}, schema)
 			resp = providers.PlanResourceChangeResponse{
 				PlannedState: override,

--- a/internal/terraform/node_resource_abstract_instance.go
+++ b/internal/terraform/node_resource_abstract_instance.go
@@ -907,7 +907,7 @@ func (n *NodeAbstractResourceInstance) plan(
 			override, overrideDiags := mocking.PlanComputedValuesForResource(proposedNewVal, &mocking.MockedData{
 				Value:             n.override.Values,
 				Range:             n.override.Range,
-				ComputedAsUnknown: !n.override.UseOverridesForPlan(),
+				ComputedAsUnknown: !n.override.UseForPlan(),
 			}, schema)
 			resp = providers.PlanResourceChangeResponse{
 				PlannedState: override,
@@ -1089,7 +1089,7 @@ func (n *NodeAbstractResourceInstance) plan(
 			override, overrideDiags := mocking.PlanComputedValuesForResource(proposedNewVal, &mocking.MockedData{
 				Value:             n.override.Values,
 				Range:             n.override.Range,
-				ComputedAsUnknown: !n.override.UseOverridesForPlan(),
+				ComputedAsUnknown: !n.override.UseForPlan(),
 			}, schema)
 			resp = providers.PlanResourceChangeResponse{
 				PlannedState: override,

--- a/internal/terraform/node_resource_abstract_instance.go
+++ b/internal/terraform/node_resource_abstract_instance.go
@@ -1239,19 +1239,6 @@ func (n *NodeAbstractResourceInstance) plan(
 	return plan, state, deferred, keyData, diags
 }
 
-// func getMockedData(override *configs.Override, isPlan bool) *mocking.MockedData {
-// 	if override == nil {
-// 		return nil
-// 	}
-// 	return &mocking.MockedData{
-// 		Value: override.Values,
-// 		Range: override.Range,
-// 		// Apply never ignores computed values. This attribute only matters
-// 		// when we are planning.
-// 		ComputedAsUnknown: override.IgnoreValues && isPlan,
-// 	}
-// }
-
 func (n *NodeAbstractResource) processIgnoreChanges(prior, config cty.Value, schema *configschema.Block) (cty.Value, tfdiags.Diagnostics) {
 	// ignore_changes only applies when an object already exists, since we
 	// can't ignore changes to a thing we've not created yet.

--- a/internal/terraform/node_resource_plan_instance.go
+++ b/internal/terraform/node_resource_plan_instance.go
@@ -634,7 +634,7 @@ func (n *NodePlannableResourceInstance) importState(ctx EvalContext, addr addrs.
 
 		// Let's pretend we're reading the value as a data source so we
 		// pre-compute values now as if the resource has already been created.
-		override, overrideDiags := mocking.ComputedValuesForDataSource(configVal, getMockedData(n.override), schema)
+		override, overrideDiags := mocking.ComputedValuesForDataSource(configVal, getMockedData(n.override, false), schema)
 		resp = providers.ImportResourceStateResponse{
 			ImportedResources: []providers.ImportedResource{
 				{

--- a/internal/terraform/node_resource_plan_instance.go
+++ b/internal/terraform/node_resource_plan_instance.go
@@ -634,7 +634,11 @@ func (n *NodePlannableResourceInstance) importState(ctx EvalContext, addr addrs.
 
 		// Let's pretend we're reading the value as a data source so we
 		// pre-compute values now as if the resource has already been created.
-		override, overrideDiags := mocking.ComputedValuesForDataSource(configVal, getMockedData(n.override, false), schema)
+		override, overrideDiags := mocking.ComputedValuesForDataSource(configVal, &mocking.MockedData{
+			Value:             n.override.Values,
+			Range:             n.override.Range,
+			ComputedAsUnknown: false,
+		}, schema)
 		resp = providers.ImportResourceStateResponse{
 			ImportedResources: []providers.ImportedResource{
 				{

--- a/internal/terraform/node_resource_plan_instance.go
+++ b/internal/terraform/node_resource_plan_instance.go
@@ -634,10 +634,7 @@ func (n *NodePlannableResourceInstance) importState(ctx EvalContext, addr addrs.
 
 		// Let's pretend we're reading the value as a data source so we
 		// pre-compute values now as if the resource has already been created.
-		override, overrideDiags := mocking.ComputedValuesForDataSource(configVal, mocking.MockedData{
-			Value: n.override.Values,
-			Range: n.override.ValuesRange,
-		}, schema)
+		override, overrideDiags := mocking.ComputedValuesForDataSource(configVal, getMockedData(n.override), schema)
 		resp = providers.ImportResourceStateResponse{
 			ImportedResources: []providers.ImportedResource{
 				{


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Fixes https://github.com/hashicorp/terraform/issues/35851

This PR enables users to use mocked or overridden values when running a plan command. The attribute `override_during` can be set to plan or apply. This attribute can be set in the blocks for `override_*`, and `mock_provider`.

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.11.0

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

### NEW FEATURES | UPGRADE NOTES | ENHANCEMENTS | BUG FIXES | EXPERIMENTS

<!--

Write a short description of the user-facing change. Examples:

- `terraform show -json`: Fixed crash with sensitive set values.
- When rendering a diff, Terraform now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 

-  
