### PR TITLE
convert write-only structural attrs to and from protobuf

### DIFF
--- a/internal/plugin6/convert/diagnostics_test.go
+++ b/internal/plugin6/convert/diagnostics_test.go
@@ -19,6 +19,7 @@ var ignoreUnexported = cmpopts.IgnoreUnexported(
 	proto.Schema_Block{},
 	proto.Schema_NestedBlock{},
 	proto.Schema_Attribute{},
+	proto.Schema_Object{},
 )
 
 func TestProtoDiagnostics(t *testing.T) {

--- a/internal/plugin6/convert/schema.go
+++ b/internal/plugin6/convert/schema.go
@@ -215,6 +215,7 @@ func protoObjectToConfigSchema(b *proto.Schema_Object) *configschema.Object {
 			Computed:        a.Computed,
 			Sensitive:       a.Sensitive,
 			Deprecated:      a.Deprecated,
+			WriteOnly:       a.WriteOnly,
 		}
 
 		if a.Type != nil {
@@ -268,7 +269,6 @@ func configschemaObjectToProto(b *configschema.Object) *proto.Schema_Object {
 
 	for _, name := range sortedKeys(b.Attributes) {
 		a := b.Attributes[name]
-
 		attr := &proto.Schema_Attribute{
 			Name:            name,
 			Description:     a.Description,
@@ -278,6 +278,7 @@ func configschemaObjectToProto(b *configschema.Object) *proto.Schema_Object {
 			Required:        a.Required,
 			Sensitive:       a.Sensitive,
 			Deprecated:      a.Deprecated,
+			WriteOnly:       a.WriteOnly,
 		}
 
 		if a.Type != cty.NilType {

--- a/internal/plugin6/convert/schema_test.go
+++ b/internal/plugin6/convert/schema_test.go
@@ -110,6 +110,12 @@ func TestConvertSchemaBlocks(t *testing.T) {
 												Type:     []byte(`"number"`),
 												Required: true,
 											},
+											{
+												Name:      "write_only",
+												Type:      []byte(`"string"`),
+												Optional:  true,
+												WriteOnly: true,
+											},
 										},
 									},
 									Computed: true,
@@ -229,6 +235,11 @@ func TestConvertSchemaBlocks(t *testing.T) {
 											"required": {
 												Type:     cty.Number,
 												Required: true,
+											},
+											"write_only": {
+												Type:      cty.String,
+												Optional:  true,
+												WriteOnly: true,
 											},
 										},
 									},
@@ -411,6 +422,25 @@ func TestConvertProtoSchemaBlocks(t *testing.T) {
 						Computed: true,
 					},
 					{
+						Name: "object",
+						NestedType: &proto.Schema_Object{
+							Nesting: proto.Schema_Object_SINGLE,
+							Attributes: []*proto.Schema_Attribute{
+								{
+									Name:     "optional",
+									Type:     []byte(`"string"`),
+									Optional: true,
+								},
+								{
+									Name:      "write_only",
+									Type:      []byte(`"string"`),
+									Optional:  true,
+									WriteOnly: true,
+								},
+							},
+						},
+					},
+					{
 						Name:     "optional",
 						Type:     []byte(`"string"`),
 						Optional: true,
@@ -426,6 +456,12 @@ func TestConvertProtoSchemaBlocks(t *testing.T) {
 						Type:     []byte(`"number"`),
 						Required: true,
 					},
+					{
+						Name:      "write_only",
+						Type:      []byte(`"string"`),
+						Optional:  true,
+						WriteOnly: true,
+					},
 				},
 			},
 			&configschema.Block{
@@ -433,6 +469,22 @@ func TestConvertProtoSchemaBlocks(t *testing.T) {
 					"computed": {
 						Type:     cty.List(cty.Bool),
 						Computed: true,
+					},
+					"object": {
+						NestedType: &configschema.Object{
+							Nesting: configschema.NestingSingle,
+							Attributes: map[string]*configschema.Attribute{
+								"optional": {
+									Type:     cty.String,
+									Optional: true,
+								},
+								"write_only": {
+									Type:      cty.String,
+									Optional:  true,
+									WriteOnly: true,
+								},
+							},
+						},
 					},
 					"optional": {
 						Type:     cty.String,
@@ -446,6 +498,11 @@ func TestConvertProtoSchemaBlocks(t *testing.T) {
 					"required": {
 						Type:     cty.Number,
 						Required: true,
+					},
+					"write_only": {
+						Type:      cty.String,
+						Optional:  true,
+						WriteOnly: true,
 					},
 				},
 			},


### PR DESCRIPTION
Nested structural attributes were missing write-only flags when converted to and from the wire protocol. Nested objects like this are only supported in proto v6.
