### PR TITLE
backend/oss: Add new argument `tablestore_instance_name` used in VPC context

### DIFF
--- a/.changes/v1.11/ENHANCEMENTS-20250219-094101.yaml
+++ b/.changes/v1.11/ENHANCEMENTS-20250219-094101.yaml
@@ -1,0 +1,5 @@
+kind: ENHANCEMENTS
+body: 'backend/oss: Add new argument tablestore_instance_name used in VPC context'
+time: 2025-02-19T09:41:01.733881+08:00
+custom:
+    Issue: "36253"

--- a/website/docs/language/backend/oss.mdx
+++ b/website/docs/language/backend/oss.mdx
@@ -95,6 +95,9 @@ The following configuration options or environment variables are supported:
 
 * `tablestore_endpoint` / `ALICLOUD_TABLESTORE_ENDPOINT` - (Optional) A custom endpoint for the TableStore API.
 
+* `tablestore_instance_name` - (Optional) Specifies the name of an instance that `TableStore` belongs to. By default, Terraform parses the name from `tablestore_endpoint`.
+  You should set the access URL explicitly when the `tablestore` endpoint is a VPC access URL.
+
 * `tablestore_table` - (Optional) A TableStore table for state locking and consistency. The table must have a primary key named `LockID` of type `String`.
 
 * `sts_endpoint` - (Optional, Available in 1.0.11+) Custom endpoint for the AliCloud Security Token Service (STS) API. It supports environment variable `ALICLOUD_STS_ENDPOINT`.


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->
Terraform State OSS Backend uses Alibaba Cloud Tablestore to store state lock. There needs setting an instance name when putting lock data. Before, the instance name defaults to parsing from argument `tablestore_endpoint`, but it will not work when it is a VPC endpoint. This PR provides a new argument tablestore_instance_name explicitly the instance name to meet 
 VPC access scenario.

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.11.x

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

### ENHANCEMENTS

- `backend/oss`: Adds new arguement tablestore_instance_name used to VPC scenario

<!--

Write a short description of the user-facing change. Examples:

- `terraform show -json`: Fixed crash with sensitive set values.
- When rendering a diff, Terraform now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 

