### PR TITLE
releases: trigger the build action only after the unit tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,13 +7,17 @@ name: build
 
 on:
   workflow_dispatch:
-  push:
+  workflow_run:
+    workflows: ["Quick Checks"]
+    types:
+      - completed
     branches:
       - main
       - 'v[0-9]+.[0-9]+'
       - releng/**
       - tsccr-auto-pinning/**
       - dependabot/**
+  push:
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+*'
 
@@ -27,6 +31,7 @@ permissions:
 jobs:
   get-product-version:
     name: "Determine intended Terraform version"
+    if: ${{ github.event.action != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     outputs:
       product-version: ${{ steps.get-product-version.outputs.product-version }}


### PR DESCRIPTION
This PR updates the `build` action so that on pushes to branches, it only triggers after the `Quick Checks` action. We then check that if the event type was `workflow_run`, we'll only trigger if the quick checks were successful.

This should ensure that we only build on pushes where the unit tests are passing. Pushes to tags, or direct builds via workflow_dispatch should continue working as before.

Closes hashicorp/terraform-releases#133