### PR TITLE
backport all latest changes to the codeowners into v1.10

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,6 +1,10 @@
 # Each line is a file pattern followed by one or more owners.
 # More on CODEOWNERS files: https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners
 
+# The rules are evaluated in order, if a file matches multiple patterns, the last match "wins".
+# We want to have a default rule for all files
+* @hashicorp/terraform-core
+
 # Entries that are commented out have maintainers that are not in the
 # HashiCorp organization and so cannot be automatically added as reviewers.
 #
@@ -9,27 +13,20 @@
 # make GitHub consider this file invalid if not commented.
 
 # Remote-state backend                  # Maintainer
-/internal/backend/remote-state/azure             @hashicorp/terraform-azure
+/internal/backend/remote-state/azure             @hashicorp/terraform-core @hashicorp/terraform-azure
 #/internal/backend/remote-state/consul           Unmaintained
 #/internal/backend/remote-state/cos              @likexian
-/internal/backend/remote-state/gcs               @hashicorp/tf-eco-hybrid-cloud
+/internal/backend/remote-state/gcs               @hashicorp/terraform-core @hashicorp/tf-eco-hybrid-cloud
 /internal/backend/remote-state/http              @hashicorp/terraform-core
 #/internal/backend/remote-state/oss              @xiaozhu36
 #/internal/backend/remote-state/pg               @remilapeyre
-/internal/backend/remote-state/s3                @hashicorp/terraform-aws
-/internal/backend/remote-state/kubernetes        @hashicorp/tf-eco-hybrid-cloud
+/internal/backend/remote-state/s3                @hashicorp/terraform-core @hashicorp/terraform-aws
+/internal/backend/remote-state/kubernetes        @hashicorp/terraform-core @hashicorp/tf-eco-hybrid-cloud
 
 # Provisioners
 builtin/provisioners/file               @hashicorp/terraform-core
 builtin/provisioners/local-exec         @hashicorp/terraform-core
 builtin/provisioners/remote-exec        @hashicorp/terraform-core
 
-# go.sum files should never cause automatic review requests because they only
-# ever change in response to go.mod files (our PR checks would fail if not) and
-# if a specific module has _only_ a go.sum update without an associated go.mod
-# update then that represents that the update cannot affect the module, and
-# the Go toolchain just needed to download something new to prove that.
-#
-# (The last match in the file "wins", so this overrides any explicit owner
-# specified above when go.sum is the only file that changed.)
-*/go.sum   # no owner for these
+# Docs on developer.hashicorp.com/terraform/docs
+website/        @hashicorp/terraform-core @hashicorp/terraform-education @hashicorp/web-presence


### PR DESCRIPTION
I can't merge this [backport PR](https://github.com/hashicorp/terraform/pull/36264) because the codeowners of this branch isn't up to date with the codeowners of our main branch.

This PR pulls the following changes into our v1.10:
- https://github.com/hashicorp/terraform/pull/36000
- https://github.com/hashicorp/terraform/pull/35988
- https://github.com/hashicorp/terraform/pull/35971