### PR TITLE
Fix `terraform console` crash for ephemeral values

### DIFF
--- a/internal/repl/format.go
+++ b/internal/repl/format.go
@@ -23,6 +23,9 @@ func FormatValue(v cty.Value, indent int) string {
 	if v.HasMark(marks.Sensitive) {
 		return "(sensitive value)"
 	}
+	if v.HasMark(marks.Ephemeral) {
+		return "(ephemeral value)"
+	}
 	if v.IsNull() {
 		ty := v.Type()
 		switch {

--- a/internal/repl/format_test.go
+++ b/internal/repl/format_test.go
@@ -177,6 +177,10 @@ EOT_`,
 			cty.StringVal("a sensitive value").Mark(marks.Sensitive),
 			"(sensitive value)",
 		},
+		{
+			cty.StringVal("an ephemeral value").Mark(marks.Ephemeral),
+			"(ephemeral value)",
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
We now check if a value has an ephemeral mark before trying to format it. The check prevents us from passing a marked value to go-cty's AsString function, which leads to a crash.

<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Fixes #36261

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.10.x

I believe this could be backported?

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

### BUG FIXES

<!--

Write a short description of the user-facing change. Examples:

- `terraform show -json`: Fixed crash with sensitive set values.
- When rendering a diff, Terraform now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 

-  Fix Terraform Console crash when printing ephemeral values
