### PR TITLE
cmd/modules: Ensure modules are sorted by reference key

### DIFF
--- a/internal/command/views/modules.go
+++ b/internal/command/views/modules.go
@@ -6,6 +6,7 @@ package views
 import (
 	encJson "encoding/json"
 	"fmt"
+	"sort"
 
 	"github.com/hashicorp/terraform/internal/command/arguments"
 	"github.com/hashicorp/terraform/internal/moduleref"
@@ -44,6 +45,10 @@ func (v *ModulesHuman) Display(manifest moduleref.Manifest) int {
 		return 0
 	}
 	printRoot := treeprint.New()
+
+	// ensure output is deterministic
+	sort.Sort(manifest.Records)
+
 	populateTreeNode(printRoot, &moduleref.Record{
 		Children: manifest.Records,
 	})

--- a/internal/moduleref/record.go
+++ b/internal/moduleref/record.go
@@ -17,14 +17,14 @@ type Record struct {
 	Source             addrs.ModuleSource
 	Version            *version.Version
 	VersionConstraints version.Constraints
-	Children           []*Record
+	Children           Records
 }
 
 // ModuleRecordManifest is the view implementation of module entries declared
 // in configuration
 type Manifest struct {
 	FormatVersion string
-	Records       []*Record
+	Records       Records
 }
 
 func (m *Manifest) addModuleEntry(entry *Record) {
@@ -33,4 +33,16 @@ func (m *Manifest) addModuleEntry(entry *Record) {
 
 func (r *Record) addChild(child *Record) {
 	r.Children = append(r.Children, child)
+}
+
+type Records []*Record
+
+func (r Records) Len() int {
+	return len(r)
+}
+func (r Records) Less(i, j int) bool {
+	return r[i].Key < r[j].Key
+}
+func (r Records) Swap(i, j int) {
+	r[i], r[j] = r[j], r[i]
 }

--- a/internal/moduleref/resolver.go
+++ b/internal/moduleref/resolver.go
@@ -36,7 +36,7 @@ func NewResolver(internalManifest modsdir.Manifest) *Resolver {
 		internalManifest: internalManifestCopy,
 		manifest: &Manifest{
 			FormatVersion: FormatVersion,
-			Records:       []*Record{},
+			Records:       Records{},
 		},
 	}
 }

--- a/internal/moduleref/resolver_test.go
+++ b/internal/moduleref/resolver_test.go
@@ -185,7 +185,7 @@ func TestResolver_ResolveNestedChildren(t *testing.T) {
 	}
 }
 
-func countAndListSources(records []*Record) (count int, sources []string) {
+func countAndListSources(records Records) (count int, sources []string) {
 	for _, record := range records {
 		sources = append(sources, record.Source.String())
 		count++


### PR DESCRIPTION
This should avoid the flakiness of underlying tests as exhibited recently in https://github.com/hashicorp/terraform/actions/runs/12633442691/job/35199838982?pr=36267#step:6:81
