### PR TITLE
Use different summaries and details when reporting errors about non-null write-only attribute values

### DIFF
--- a/.changes/unreleased/ENHANCEMENTS-20250108-104335.yaml
+++ b/.changes/unreleased/ENHANCEMENTS-20250108-104335.yaml
@@ -1,0 +1,5 @@
+kind: ENHANCEMENTS
+body: Changed the text in errors returned from Terraform when a non-null value is found for a write-only attribute.
+time: 2025-01-08T10:43:35.241109Z
+custom:
+    Issue: "36274"

--- a/internal/lang/ephemeral/validate.go
+++ b/internal/lang/ephemeral/validate.go
@@ -12,12 +12,12 @@ import (
 	"github.com/zclconf/go-cty/cty"
 )
 
-func ValidateWriteOnlyAttributes(newVal cty.Value, schema *configschema.Block, provider addrs.AbsProviderConfig, addr addrs.AbsResourceInstance) (diags tfdiags.Diagnostics) {
+func ValidateWriteOnlyAttributes(summary string, newVal cty.Value, schema *configschema.Block, provider addrs.AbsProviderConfig, addr addrs.AbsResourceInstance) (diags tfdiags.Diagnostics) {
 	if writeOnlyPaths := NonNullWriteOnlyPaths(newVal, schema, nil); len(writeOnlyPaths) != 0 {
 		for _, p := range writeOnlyPaths {
 			diags = diags.Append(tfdiags.Sourceless(
 				tfdiags.Error,
-				"Write-only attribute set",
+				summary,
 				fmt.Sprintf(
 					"Provider %q returned a value for the write-only attribute \"%s%s\". Write-only attributes cannot be read back from the provider. This is a bug in the provider, which should be reported in the provider's own issue tracker.",
 					provider.String(), addr.String(), tfdiags.FormatCtyPath(p),

--- a/internal/refactoring/cross_provider_move.go
+++ b/internal/refactoring/cross_provider_move.go
@@ -155,7 +155,17 @@ func (move *crossTypeMove) applyCrossTypeMove(stmt *MoveStatement, source, targe
 	}
 
 	// Providers are supposed to return null values for all write-only attributes
-	writeOnlyDiags := ephemeral.ValidateWriteOnlyAttributes("Provider returned invalid value", resp.TargetState, move.targetResourceSchema, move.targetProviderAddr, target)
+	writeOnlyDiags := ephemeral.ValidateWriteOnlyAttributes(
+		"Provider returned invalid value",
+		func(path cty.Path) string {
+			return fmt.Sprintf(
+				"The provider %q returned a value for the write-only attribute \"%s%s\" during an across type move operation to %s. Write-only attributes cannot be read back from the provider. This is a bug in the provider, which should be reported in the provider's own issue tracker.",
+				move.targetProviderAddr, target, tfdiags.FormatCtyPath(path), target,
+			)
+		},
+		resp.TargetState,
+		move.targetResourceSchema,
+	)
 	diags = diags.Append(writeOnlyDiags)
 
 	if writeOnlyDiags.HasErrors() {

--- a/internal/refactoring/cross_provider_move.go
+++ b/internal/refactoring/cross_provider_move.go
@@ -155,7 +155,7 @@ func (move *crossTypeMove) applyCrossTypeMove(stmt *MoveStatement, source, targe
 	}
 
 	// Providers are supposed to return null values for all write-only attributes
-	writeOnlyDiags := ephemeral.ValidateWriteOnlyAttributes(resp.TargetState, move.targetResourceSchema, move.targetProviderAddr, target)
+	writeOnlyDiags := ephemeral.ValidateWriteOnlyAttributes("Provider returned invalid value", resp.TargetState, move.targetResourceSchema, move.targetProviderAddr, target)
 	diags = diags.Append(writeOnlyDiags)
 
 	if writeOnlyDiags.HasErrors() {

--- a/internal/terraform/context_apply_ephemeral_test.go
+++ b/internal/terraform/context_apply_ephemeral_test.go
@@ -804,8 +804,8 @@ resource "ephem_write_only" "wo" {
 
 	expectedDiags = append(expectedDiags, tfdiags.Sourceless(
 		tfdiags.Error,
-		"Write-only attribute set",
-		`Provider "provider[\"registry.terraform.io/hashicorp/ephem\"]" returned a value for the write-only attribute "ephem_write_only.wo.write_only". Write-only attributes cannot be read back from the provider. This is a bug in the provider, which should be reported in the provider's own issue tracker.`,
+		"Provider produced invalid object",
+		`Provider "provider[\"registry.terraform.io/hashicorp/ephem\"]" returned a value for the write-only attribute "ephem_write_only.wo.write_only" after apply. Write-only attributes cannot be read back from the provider. This is a bug in the provider, which should be reported in the provider's own issue tracker.`,
 	))
 
 	assertDiagnosticsMatch(t, diags, expectedDiags)
@@ -876,8 +876,8 @@ resource "ephem_write_only" "wo" {
 
 	expectedDiags = append(expectedDiags, tfdiags.Sourceless(
 		tfdiags.Error,
-		"Write-only attribute set",
-		`Provider "provider[\"registry.terraform.io/hashicorp/ephem\"]" returned a value for the write-only attribute "ephem_write_only.wo.write_only". Write-only attributes cannot be read back from the provider. This is a bug in the provider, which should be reported in the provider's own issue tracker.`,
+		"Provider produced invalid plan",
+		`Provider "provider[\"registry.terraform.io/hashicorp/ephem\"]" returned a value for the write-only attribute "ephem_write_only.wo.write_only" during planning. Write-only attributes cannot be read back from the provider. This is a bug in the provider, which should be reported in the provider's own issue tracker.`,
 	))
 
 	assertDiagnosticsMatch(t, diags, expectedDiags)
@@ -963,8 +963,8 @@ resource "ephem_write_only" "wo" {
 
 	expectedDiags = append(expectedDiags, tfdiags.Sourceless(
 		tfdiags.Error,
-		"Write-only attribute set",
-		`Provider "provider[\"registry.terraform.io/hashicorp/ephem\"]" returned a value for the write-only attribute "ephem_write_only.wo.write_only". Write-only attributes cannot be read back from the provider. This is a bug in the provider, which should be reported in the provider's own issue tracker.`,
+		"Provider produced invalid object",
+		`Provider "provider[\"registry.terraform.io/hashicorp/ephem\"]" returned a value for the write-only attribute "ephem_write_only.wo.write_only" during refresh. Write-only attributes cannot be read back from the provider. This is a bug in the provider, which should be reported in the provider's own issue tracker.`,
 	))
 
 	assertDiagnosticsMatch(t, diags, expectedDiags)

--- a/internal/terraform/node_resource_abstract_instance.go
+++ b/internal/terraform/node_resource_abstract_instance.go
@@ -693,7 +693,17 @@ func (n *NodeAbstractResourceInstance) refresh(ctx EvalContext, deposedKey state
 	}
 
 	// Providers are supposed to return null values for all write-only attributes
-	writeOnlyDiags := ephemeral.ValidateWriteOnlyAttributes("Provider produced invalid object", resp.NewState, schema, n.ResolvedProvider, n.Addr)
+	writeOnlyDiags := ephemeral.ValidateWriteOnlyAttributes(
+		"Provider produced invalid object",
+		func(path cty.Path) string {
+			return fmt.Sprintf(
+				"Provider %q returned a value for the write-only attribute \"%s%s\" during refresh. Write-only attributes cannot be read back from the provider. This is a bug in the provider, which should be reported in the provider's own issue tracker.",
+				n.ResolvedProvider, n.Addr, tfdiags.FormatCtyPath(path),
+			)
+		},
+		resp.NewState,
+		schema,
+	)
 	diags = diags.Append(writeOnlyDiags)
 
 	if writeOnlyDiags.HasErrors() {
@@ -956,7 +966,17 @@ func (n *NodeAbstractResourceInstance) plan(
 		}
 
 		// Providers are supposed to return null values for all write-only attributes
-		writeOnlyDiags := ephemeral.ValidateWriteOnlyAttributes("Provider produced invalid plan", plannedNewVal, schema, n.ResolvedProvider, n.Addr)
+		writeOnlyDiags := ephemeral.ValidateWriteOnlyAttributes(
+			"Provider produced invalid plan",
+			func(path cty.Path) string {
+				return fmt.Sprintf(
+					"Provider %q returned a value for the write-only attribute \"%s%s\" during planning. Write-only attributes cannot be read back from the provider. This is a bug in the provider, which should be reported in the provider's own issue tracker.",
+					n.ResolvedProvider, n.Addr, tfdiags.FormatCtyPath(path),
+				)
+			},
+			plannedNewVal,
+			schema,
+		)
 		diags = diags.Append(writeOnlyDiags)
 
 		if writeOnlyDiags.HasErrors() {
@@ -1140,7 +1160,17 @@ func (n *NodeAbstractResourceInstance) plan(
 		}
 
 		// Providers are supposed to return null values for all write-only attributes
-		writeOnlyDiags := ephemeral.ValidateWriteOnlyAttributes("Provider produced invalid plan", plannedNewVal, schema, n.ResolvedProvider, n.Addr)
+		writeOnlyDiags := ephemeral.ValidateWriteOnlyAttributes(
+			"Provider produced invalid plan",
+			func(path cty.Path) string {
+				return fmt.Sprintf(
+					"Provider %q returned a value for the write-only attribute \"%s%s\" during planning. Write-only attributes cannot be read back from the provider. This is a bug in the provider, which should be reported in the provider's own issue tracker.",
+					n.ResolvedProvider, n.Addr, tfdiags.FormatCtyPath(path),
+				)
+			},
+			plannedNewVal,
+			schema,
+		)
 		diags = diags.Append(writeOnlyDiags)
 
 		if writeOnlyDiags.HasErrors() {
@@ -2580,7 +2610,17 @@ func (n *NodeAbstractResourceInstance) apply(
 	}
 
 	// Providers are supposed to return null values for all write-only attributes
-	writeOnlyDiags := ephemeral.ValidateWriteOnlyAttributes("Provider produced invalid object", newVal, schema, n.ResolvedProvider, n.Addr)
+	writeOnlyDiags := ephemeral.ValidateWriteOnlyAttributes(
+		"Provider produced invalid object",
+		func(path cty.Path) string {
+			return fmt.Sprintf(
+				"Provider %q returned a value for the write-only attribute \"%s%s\" after apply. Write-only attributes cannot be read back from the provider. This is a bug in the provider, which should be reported in the provider's own issue tracker.",
+				n.ResolvedProvider, n.Addr, tfdiags.FormatCtyPath(path),
+			)
+		},
+		newVal,
+		schema,
+	)
 	diags = diags.Append(writeOnlyDiags)
 
 	if writeOnlyDiags.HasErrors() {

--- a/internal/terraform/node_resource_abstract_instance.go
+++ b/internal/terraform/node_resource_abstract_instance.go
@@ -693,7 +693,7 @@ func (n *NodeAbstractResourceInstance) refresh(ctx EvalContext, deposedKey state
 	}
 
 	// Providers are supposed to return null values for all write-only attributes
-	writeOnlyDiags := ephemeral.ValidateWriteOnlyAttributes(resp.NewState, schema, n.ResolvedProvider, n.Addr)
+	writeOnlyDiags := ephemeral.ValidateWriteOnlyAttributes("Provider produced invalid object", resp.NewState, schema, n.ResolvedProvider, n.Addr)
 	diags = diags.Append(writeOnlyDiags)
 
 	if writeOnlyDiags.HasErrors() {
@@ -956,7 +956,7 @@ func (n *NodeAbstractResourceInstance) plan(
 		}
 
 		// Providers are supposed to return null values for all write-only attributes
-		writeOnlyDiags := ephemeral.ValidateWriteOnlyAttributes(plannedNewVal, schema, n.ResolvedProvider, n.Addr)
+		writeOnlyDiags := ephemeral.ValidateWriteOnlyAttributes("Provider produced invalid plan", plannedNewVal, schema, n.ResolvedProvider, n.Addr)
 		diags = diags.Append(writeOnlyDiags)
 
 		if writeOnlyDiags.HasErrors() {
@@ -1140,7 +1140,7 @@ func (n *NodeAbstractResourceInstance) plan(
 		}
 
 		// Providers are supposed to return null values for all write-only attributes
-		writeOnlyDiags := ephemeral.ValidateWriteOnlyAttributes(plannedNewVal, schema, n.ResolvedProvider, n.Addr)
+		writeOnlyDiags := ephemeral.ValidateWriteOnlyAttributes("Provider produced invalid plan", plannedNewVal, schema, n.ResolvedProvider, n.Addr)
 		diags = diags.Append(writeOnlyDiags)
 
 		if writeOnlyDiags.HasErrors() {
@@ -2580,7 +2580,7 @@ func (n *NodeAbstractResourceInstance) apply(
 	}
 
 	// Providers are supposed to return null values for all write-only attributes
-	writeOnlyDiags := ephemeral.ValidateWriteOnlyAttributes(newVal, schema, n.ResolvedProvider, n.Addr)
+	writeOnlyDiags := ephemeral.ValidateWriteOnlyAttributes("Provider produced invalid object", newVal, schema, n.ResolvedProvider, n.Addr)
 	diags = diags.Append(writeOnlyDiags)
 
 	if writeOnlyDiags.HasErrors() {

--- a/internal/terraform/node_resource_import.go
+++ b/internal/terraform/node_resource_import.go
@@ -115,7 +115,7 @@ func (n *graphNodeImportState) Execute(ctx EvalContext, op walkOperation) (diags
 	// Providers are supposed to return null values for all write-only attributes
 	var writeOnlyDiags tfdiags.Diagnostics
 	for _, imported := range resp.ImportedResources {
-		writeOnlyDiags = ephemeral.ValidateWriteOnlyAttributes(imported.State, schema, n.ResolvedProvider, n.Addr)
+		writeOnlyDiags = ephemeral.ValidateWriteOnlyAttributes("Import returned a non-null value for a write-only attribute", imported.State, schema, n.ResolvedProvider, n.Addr)
 		diags = diags.Append(writeOnlyDiags)
 	}
 

--- a/internal/terraform/node_resource_import.go
+++ b/internal/terraform/node_resource_import.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform/internal/providers"
 	"github.com/hashicorp/terraform/internal/states"
 	"github.com/hashicorp/terraform/internal/tfdiags"
+	"github.com/zclconf/go-cty/cty"
 )
 
 type graphNodeImportState struct {
@@ -115,7 +116,17 @@ func (n *graphNodeImportState) Execute(ctx EvalContext, op walkOperation) (diags
 	// Providers are supposed to return null values for all write-only attributes
 	var writeOnlyDiags tfdiags.Diagnostics
 	for _, imported := range resp.ImportedResources {
-		writeOnlyDiags = ephemeral.ValidateWriteOnlyAttributes("Import returned a non-null value for a write-only attribute", imported.State, schema, n.ResolvedProvider, n.Addr)
+		writeOnlyDiags = ephemeral.ValidateWriteOnlyAttributes(
+			"Import returned a non-null value for a write-only attribute",
+			func(path cty.Path) string {
+				return fmt.Sprintf(
+					"Provider %q returned a value for the write-only attribute \"%s%s\" during import. Write-only attributes cannot be read back from the provider. This is a bug in the provider, which should be reported in the provider's own issue tracker.",
+					n.ResolvedProvider, n.Addr, tfdiags.FormatCtyPath(path),
+				)
+			},
+			imported.State,
+			schema,
+		)
 		diags = diags.Append(writeOnlyDiags)
 	}
 

--- a/internal/terraform/node_resource_plan_instance.go
+++ b/internal/terraform/node_resource_plan_instance.go
@@ -725,7 +725,17 @@ func (n *NodePlannableResourceInstance) importState(ctx EvalContext, addr addrs.
 	}
 
 	// Providers are supposed to return null values for all write-only attributes
-	writeOnlyDiags := ephemeral.ValidateWriteOnlyAttributes("Import returned a non-null value for a write-only attribute", imported[0].State, schema, n.ResolvedProvider, n.Addr)
+	writeOnlyDiags := ephemeral.ValidateWriteOnlyAttributes(
+		"Import returned a non-null value for a write-only attribute",
+		func(path cty.Path) string {
+			return fmt.Sprintf(
+				"While attempting to import with ID %s, the provider %q returned a value for the write-only attribute \"%s%s\". Write-only attributes cannot be read back from the provider. This is a bug in the provider, which should be reported in the provider's own issue tracker.",
+				importId, n.ResolvedProvider, n.Addr, tfdiags.FormatCtyPath(path),
+			)
+		},
+		imported[0].State,
+		schema,
+	)
 	diags = diags.Append(writeOnlyDiags)
 
 	if writeOnlyDiags.HasErrors() {

--- a/internal/terraform/node_resource_plan_instance.go
+++ b/internal/terraform/node_resource_plan_instance.go
@@ -702,7 +702,7 @@ func (n *NodePlannableResourceInstance) importState(ctx EvalContext, addr addrs.
 		}
 
 		// We skip the read and further validation since we make up the state
-		// of the imported resource anyways.
+		// of the imported resource anyways.
 		return state.AsInstanceObject(), deferred, diags
 	}
 
@@ -725,7 +725,7 @@ func (n *NodePlannableResourceInstance) importState(ctx EvalContext, addr addrs.
 	}
 
 	// Providers are supposed to return null values for all write-only attributes
-	writeOnlyDiags := ephemeral.ValidateWriteOnlyAttributes(imported[0].State, schema, n.ResolvedProvider, n.Addr)
+	writeOnlyDiags := ephemeral.ValidateWriteOnlyAttributes("Import returned a non-null value for a write-only attribute", imported[0].State, schema, n.ResolvedProvider, n.Addr)
 	diags = diags.Append(writeOnlyDiags)
 
 	if writeOnlyDiags.HasErrors() {


### PR DESCRIPTION
Responding to internal feedback about how the error messages don't indicate which RPC type is triggering the error

TODO:

- [x] Update affected unit tests
- [x] Changelog entry for Changie

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.11.x

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory.

-->

- [x] This change is user-facing and I added a changelog entry.
- [ ] This change is not user-facing.
