### PR TITLE
add changelog entry for write-only attributes

### DIFF
--- a/.changes/unreleased/NEW FEATURES-20250107-125354.yaml
+++ b/.changes/unreleased/NEW FEATURES-20250107-125354.yaml
@@ -1,5 +1,5 @@
 kind: NEW FEATURES
-body: Add write-only attributes to resources. Providers can specify that certain attributes are write-only, they can not be referenced and are not presisted in state. You can use ephemeral values in write-only attributes.
+body: Add write-only attributes to resources. Providers can specify that certain attributes are write-only. They are not persisted in state. You can use ephemeral values in write-only attributes.
 time: 2025-01-07T12:53:54.752027+01:00
 custom:
     Issue: "36031"

--- a/.changes/unreleased/NEW FEATURES-20250107-125354.yaml
+++ b/.changes/unreleased/NEW FEATURES-20250107-125354.yaml
@@ -1,0 +1,5 @@
+kind: NEW FEATURES
+body: Add write-only attributes to resources. Providers can specify that certain attributes are write-only, they can not be referenced and are not presisted in state. You can use ephemeral values in write-only attributes.
+time: 2025-01-07T12:53:54.752027+01:00
+custom:
+    Issue: "36031"


### PR DESCRIPTION
I noticed that we missed adding a changelog entry for this in the past.

<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Fixes #

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.11.x

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory.

-->

- [ ] This change is user-facing and I added a changelog entry.
- [ ] This change is not user-facing.