### PR TITLE
Fix changelog generation for patch releases

### DIFF
--- a/scripts/changelog.sh
+++ b/scripts/changelog.sh
@@ -93,7 +93,6 @@ function generate {
 
         patch)
         COMPLETE_VERSION=$(npx -y changie@$CHANGIE_VERSION next patch)
-        COMPLETE_VERSION=${COMPLETE_VERSION:1} # remove the v prefix
         npx -y changie@$CHANGIE_VERSION batch patch
         npx -y changie@$CHANGIE_VERSION merge
         ;;


### PR DESCRIPTION
We don't need to remove the `v` prefix from the version file as it doesn't exist. This was removing the major version number instead of the intended behaviour.