### PR TITLE
Add start time timestamps to `<testcase>`/Run data in JUnit XML output from `terraform test`

### DIFF
--- a/internal/backend/local/test.go
+++ b/internal/backend/local/test.go
@@ -370,6 +370,7 @@ func (runner *TestFileRunner) Test(file *moduletest.File) {
 		// If we got far enough to actually execute the run then we'll give
 		// the view some additional metadata about the execution.
 		run.ExecutionMeta = &moduletest.RunExecutionMeta{
+			Start:    startTime,
 			Duration: runDuration,
 		}
 		runner.Suite.View.Run(run, file, moduletest.Complete, 0)

--- a/internal/command/views/test.go
+++ b/internal/command/views/test.go
@@ -898,7 +898,8 @@ func junitXMLTestReport(suite *moduletest.Suite) ([]byte, error) {
 				// "not known", and thus omit that case. (In practice many
 				// JUnit XML consumers treat the absense of this attribute
 				// as zero anyway.)
-				RunTime float64 `xml:"time,attr,omitempty"`
+				RunTime   float64 `xml:"time,attr,omitempty"`
+				Timestamp string  `xml:"timestamp,attr,omitempty"`
 			}
 
 			testCase := TestCase{
@@ -913,6 +914,7 @@ func junitXMLTestReport(suite *moduletest.Suite) ([]byte, error) {
 			}
 			if execMeta := run.ExecutionMeta; execMeta != nil {
 				testCase.RunTime = execMeta.Duration.Seconds()
+				testCase.Timestamp = execMeta.StartTimestamp()
 			}
 			switch run.Status {
 			case moduletest.Skip:

--- a/internal/moduletest/run.go
+++ b/internal/moduletest/run.go
@@ -47,6 +47,15 @@ type RunExecutionMeta struct {
 	Duration time.Duration
 }
 
+// StartTimestamp returns the start time metadata as a timestamp formatted as YYYY-MM-DDTHH:MM:SS.
+// If the start time is unset an empty string is returned.
+func (m *RunExecutionMeta) StartTimestamp() string {
+	if m.Start.IsZero() {
+		return ""
+	}
+	return m.Start.Format(time.RFC3339)
+}
+
 // Verbose is a utility struct that holds all the information required for a run
 // to render the results verbosely.
 //

--- a/internal/moduletest/run.go
+++ b/internal/moduletest/run.go
@@ -43,6 +43,7 @@ type Run struct {
 }
 
 type RunExecutionMeta struct {
+	Start    time.Time
 	Duration time.Duration
 }
 


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Fixes #

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.11.x

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory.

-->

- [ ] This change is user-facing and I added a changelog entry.
- [ ] This change is not user-facing.
