### PR TITLE
Add change file for #36273

### DIFF
--- a/.changes/unreleased/BUG FIXES-20250108-173554.yaml
+++ b/.changes/unreleased/BUG FIXES-20250108-173554.yaml
@@ -1,5 +1,5 @@
 kind: BUG FIXES
-body: Updated dependency `github.com/hashicorp/go-slug` `v0.16.0` => `v0.16.3` to integrate latest changes.
+body: Updated dependency `github.com/hashicorp/go-slug` `v0.16.0` => `v0.16.3` to integrate latest changes (fix for CVE-2025-0377)
 time: 2025-01-08T17:35:54.566608Z
 custom:
     Issue: "36273"

--- a/.changes/unreleased/BUG FIXES-20250108-173554.yaml
+++ b/.changes/unreleased/BUG FIXES-20250108-173554.yaml
@@ -1,0 +1,5 @@
+kind: BUG FIXES
+body: Updated dependency `github.com/hashicorp/go-slug` `v0.16.0` => `v0.16.3` to integrate latest changes.
+time: 2025-01-08T17:35:54.566608Z
+custom:
+    Issue: "36273"


### PR DESCRIPTION
Changes how the changelog is affected by the linked PR #36273

Including a change file because it addresses a CVE, and we've historically included CVE fixes in changelogs, e.g. : https://github.com/hashicorp/terraform/blob/v1.9/CHANGELOG.md

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.11.x

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory.

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
