### PR TITLE
Validate write-only attributes returned from providers during the UpgradeResourceState RPC 

### DIFF
--- a/.changes/unreleased/ENHANCEMENTS-20250110-134832.yaml
+++ b/.changes/unreleased/ENHANCEMENTS-20250110-134832.yaml
@@ -1,5 +1,0 @@
-kind: ENHANCEMENTS
-body: Added validation that prevented providers returning non-null values for write-only attributes when upgrading resource state
-time: 2025-01-10T13:48:32.210045Z
-custom:
-    Issue: "36305"

--- a/.changes/unreleased/ENHANCEMENTS-20250110-134832.yaml
+++ b/.changes/unreleased/ENHANCEMENTS-20250110-134832.yaml
@@ -1,0 +1,5 @@
+kind: ENHANCEMENTS
+body: Added validation that prevented providers returning non-null values for write-only attributes when upgrading resource state
+time: 2025-01-10T13:48:32.210045Z
+custom:
+    Issue: "36305"

--- a/internal/providers/testing/provider_mock.go
+++ b/internal/providers/testing/provider_mock.go
@@ -252,6 +252,11 @@ func (p *MockProvider) ValidateEphemeralResourceConfig(r providers.ValidateEphem
 	return resp
 }
 
+// UpgradeResourceState mocks out the response from the provider during an UpgradeResourceState RPC
+// The default logic will return the resource's state unchanged, unless other logic is defined on the mock (e.g. UpgradeResourceStateFn)
+//
+// When using this mock you may need to provide custom logic if the plugin-framework alters values in state,
+// e.g. when handling write-only attributes.
 func (p *MockProvider) UpgradeResourceState(r providers.UpgradeResourceStateRequest) (resp providers.UpgradeResourceStateResponse) {
 	p.Lock()
 	defer p.Unlock()

--- a/internal/terraform/context_apply_ephemeral_test.go
+++ b/internal/terraform/context_apply_ephemeral_test.go
@@ -660,8 +660,6 @@ resource "ephem_write_only" "wo" {
 		SourceType: ValueFromCLIArg,
 	}
 
-	// Non-empty prior state is required to trigger UpgradeResourceState logic
-	// during planning
 	priorState := states.BuildState(func(state *states.SyncState) {
 		state.SetResourceInstanceCurrent(
 			mustResourceInstanceAddr("ephem_write_only.wo"),

--- a/internal/terraform/context_apply_ephemeral_test.go
+++ b/internal/terraform/context_apply_ephemeral_test.go
@@ -638,6 +638,14 @@ resource "ephem_write_only" "wo" {
 			},
 		},
 	}
+	ephem.UpgradeResourceStateFn = func(ursr providers.UpgradeResourceStateRequest) providers.UpgradeResourceStateResponse {
+		return providers.UpgradeResourceStateResponse{
+			UpgradedState: cty.ObjectVal(map[string]cty.Value{
+				"normal":     cty.StringVal("normal"),
+				"write_only": cty.NullVal(cty.String),
+			}),
+		}
+	}
 
 	ctx := testContext2(t, &ContextOpts{
 		Providers: map[addrs.Provider]providers.Factory{

--- a/internal/terraform/context_apply_ephemeral_test.go
+++ b/internal/terraform/context_apply_ephemeral_test.go
@@ -638,6 +638,8 @@ resource "ephem_write_only" "wo" {
 			},
 		},
 	}
+	// Below we force the write_only attribute's returned state to be Null, mimicking what the plugin-framework would
+	// return during an UpgradeResourceState RPC
 	ephem.UpgradeResourceStateFn = func(ursr providers.UpgradeResourceStateRequest) providers.UpgradeResourceStateResponse {
 		return providers.UpgradeResourceStateResponse{
 			UpgradedState: cty.ObjectVal(map[string]cty.Value{
@@ -658,6 +660,8 @@ resource "ephem_write_only" "wo" {
 		SourceType: ValueFromCLIArg,
 	}
 
+	// Non-empty prior state is required to trigger UpgradeResourceState logic
+	// during planning
 	priorState := states.BuildState(func(state *states.SyncState) {
 		state.SetResourceInstanceCurrent(
 			mustResourceInstanceAddr("ephem_write_only.wo"),


### PR DESCRIPTION
This PR add validation to ensure providers don't return values for write-only attributes during UpgradeResourceState. Terraform core doesn't know if a provider has been updated since the last time the state was updated, and this RPC allows providers to upgrade state to match any schema changes for a particular resource.

The relevant changes for WO attributes are:
1) A field has been changed to become write-only
2) A field has changed to stop being write-only

In case number 2 there is no concern. The state will contain `null` from when the field was write-only, and then the provider may return a new non-null value on state upgrade.

For case number 1 we don't want a value to be returned to TF core. That is what this PR's changes protects against.

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.11.x

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory.

-->

- [ ] ~This change is user-facing and I added a changelog entry.~
- [ ] ~This change is not user-facing.~

This change is for a feature that is not yet released; no changelog needed
