### PR TITLE
stacks: allow unknown variables during apply operations

### DIFF
--- a/internal/stacks/stackruntime/apply_destroy_test.go
+++ b/internal/stacks/stackruntime/apply_destroy_test.go
@@ -1025,6 +1025,139 @@ func TestApplyDestroy(t *testing.T) {
 				},
 			},
 		},
+		"destroy after manual removal": {
+			path: "removed-offline",
+			state: stackstate.NewStateBuilder().
+				AddComponentInstance(stackstate.NewComponentInstanceBuilder(mustAbsComponentInstance("component.parent")).
+					AddDependent(mustAbsComponent("component.child")).
+					AddOutputValue("value", cty.StringVal("hello"))).
+				AddResourceInstance(stackstate.NewResourceInstanceBuilder().
+					SetAddr(mustAbsResourceInstanceObject("component.parent.testing_resource.resource")).
+					SetProviderAddr(mustDefaultRootProvider("testing")).
+					SetResourceInstanceObjectSrc(states.ResourceInstanceObjectSrc{
+						AttrsJSON: mustMarshalJSONAttrs(map[string]interface{}{
+							"id":    "parent",
+							"value": "hello",
+						}),
+						Status: states.ObjectReady,
+					})).
+				AddComponentInstance(stackstate.NewComponentInstanceBuilder(mustAbsComponentInstance("component.child")).
+					AddDependency(mustAbsComponent("component.parent")).
+					AddInputVariable("value", cty.StringVal("hello"))).
+				AddResourceInstance(stackstate.NewResourceInstanceBuilder().
+					SetAddr(mustAbsResourceInstanceObject("component.child.testing_resource.resource")).
+					SetProviderAddr(mustDefaultRootProvider("testing")).
+					SetResourceInstanceObjectSrc(states.ResourceInstanceObjectSrc{
+						AttrsJSON: mustMarshalJSONAttrs(map[string]interface{}{
+							"id":    "child",
+							"value": "hello",
+						}),
+						Status: states.ObjectReady,
+					})).
+				Build(),
+			store: stacks_testing_provider.NewResourceStoreBuilder().
+				AddResource("child", cty.ObjectVal(map[string]cty.Value{
+					"id":    cty.StringVal("child"),
+					"value": cty.StringVal("hello"),
+				})).Build(),
+			cycles: []TestCycle{
+				{
+					planMode: plans.DestroyMode,
+					wantPlannedChanges: []stackplan.PlannedChange{
+						&stackplan.PlannedChangeApplyable{
+							Applyable: true,
+						},
+						&stackplan.PlannedChangeComponentInstance{
+							Addr:               mustAbsComponentInstance("component.child"),
+							Action:             plans.Delete,
+							Mode:               plans.DestroyMode,
+							PlanComplete:       true,
+							PlanApplyable:      true,
+							RequiredComponents: collections.NewSet(mustAbsComponent("component.parent")),
+							PlannedInputValues: map[string]plans.DynamicValue{
+								"value": mustPlanDynamicValueDynamicType(cty.UnknownVal(cty.String)),
+							},
+							PlannedInputValueMarks: map[string][]cty.PathValueMarks{
+								"value": nil,
+							},
+							PlannedOutputValues: make(map[string]cty.Value),
+							PlannedCheckResults: &states.CheckResults{},
+							PlanTimestamp:       fakePlanTimestamp,
+						},
+						&stackplan.PlannedChangeResourceInstancePlanned{
+							ResourceInstanceObjectAddr: mustAbsResourceInstanceObject("component.child.testing_resource.resource"),
+							ChangeSrc: &plans.ResourceInstanceChangeSrc{
+								Addr:         mustAbsResourceInstance("testing_resource.resource"),
+								PrevRunAddr:  mustAbsResourceInstance("testing_resource.resource"),
+								ProviderAddr: mustDefaultRootProvider("testing"),
+								ChangeSrc: plans.ChangeSrc{
+									Action: plans.Delete,
+									Before: mustPlanDynamicValue(cty.ObjectVal(map[string]cty.Value{
+										"id":    cty.StringVal("child"),
+										"value": cty.StringVal("hello"),
+									})),
+									After: mustPlanDynamicValue(cty.NullVal(cty.Object(map[string]cty.Type{
+										"id":    cty.String,
+										"value": cty.String,
+									}))),
+								},
+							},
+							PriorStateSrc: &states.ResourceInstanceObjectSrc{
+								AttrsJSON: mustMarshalJSONAttrs(map[string]interface{}{
+									"id":    "child",
+									"value": "hello",
+								}),
+								Status:       states.ObjectReady,
+								Dependencies: make([]addrs.ConfigResource, 0),
+							},
+							ProviderConfigAddr: mustDefaultRootProvider("testing"),
+							Schema:             stacks_testing_provider.TestingResourceSchema,
+						},
+						&stackplan.PlannedChangeComponentInstance{
+							Addr:               mustAbsComponentInstance("component.parent"),
+							Action:             plans.Delete,
+							Mode:               plans.DestroyMode,
+							PlanComplete:       true,
+							PlanApplyable:      false,
+							PlannedInputValues: make(map[string]plans.DynamicValue),
+							PlannedOutputValues: map[string]cty.Value{
+								"value": cty.DynamicVal,
+							},
+							PlannedCheckResults: &states.CheckResults{},
+							PlanTimestamp:       fakePlanTimestamp,
+						},
+						&stackplan.PlannedChangeResourceInstancePlanned{
+							ResourceInstanceObjectAddr: mustAbsResourceInstanceObject("component.parent.testing_resource.resource"),
+							ProviderConfigAddr:         mustDefaultRootProvider("testing"),
+						},
+						&stackplan.PlannedChangeHeader{
+							TerraformVersion: version.SemVer,
+						},
+						&stackplan.PlannedChangePlannedTimestamp{
+							PlannedTimestamp: fakePlanTimestamp,
+						},
+					},
+					wantAppliedChanges: []stackstate.AppliedChange{
+						&stackstate.AppliedChangeComponentInstanceRemoved{
+							ComponentAddr:         mustAbsComponent("component.child"),
+							ComponentInstanceAddr: mustAbsComponentInstance("component.child"),
+						},
+						&stackstate.AppliedChangeResourceInstanceObject{
+							ResourceInstanceObjectAddr: mustAbsResourceInstanceObject("component.child.testing_resource.resource"),
+							ProviderConfigAddr:         mustDefaultRootProvider("testing"),
+						},
+						&stackstate.AppliedChangeComponentInstanceRemoved{
+							ComponentAddr:         mustAbsComponent("component.parent"),
+							ComponentInstanceAddr: mustAbsComponentInstance("component.parent"),
+						},
+						&stackstate.AppliedChangeResourceInstanceObject{
+							ResourceInstanceObjectAddr: mustAbsResourceInstanceObject("component.parent.testing_resource.resource"),
+							ProviderConfigAddr:         mustDefaultRootProvider("testing"),
+						},
+					},
+				},
+			},
+		},
 		"partial destroy recovery": {
 			path:        "component-chain",
 			description: "this test simulates a partial destroy recovery",

--- a/internal/stacks/stackruntime/internal/stackeval/component_instance.go
+++ b/internal/stacks/stackruntime/internal/stackeval/component_instance.go
@@ -96,18 +96,9 @@ func (c *ComponentInstance) CheckInputVariableValues(ctx context.Context, phase 
 	// We actually checked the errors statically already, so we only care about
 	// the value here.
 	val, diags := EvalComponentInputVariables(ctx, varDecls, wantTy, defs, decl, phase, c)
-	if phase == ApplyPhase {
-		if !val.IsWhollyKnown() {
-			// We can't apply a configuration that has unknown values in it.
-			// This means an error has occured somewhere else, while gathering
-			// the input variables. We return a nil value here, whatever caused
-			// the error should have raised an error diagnostic separately.
-			return cty.NilVal, diags
-		}
-
-		// Note, that unknown values during the planning phase are totally fine.
+	if diags.HasErrors() {
+		return cty.NilVal, diags
 	}
-
 	return val, diags
 }
 

--- a/internal/stacks/stackruntime/internal/stackeval/input_variable.go
+++ b/internal/stacks/stackruntime/internal/stackeval/input_variable.go
@@ -107,7 +107,7 @@ func (v *InputVariable) Value(ctx context.Context, phase EvalPhase) cty.Value {
 }
 
 func (v *InputVariable) CheckValue(ctx context.Context, phase EvalPhase) (cty.Value, tfdiags.Diagnostics) {
-	return withCtyDynamicValPlaceholder(doOnceWithDiags(
+	return doOnceWithDiags(
 		ctx, v.value.For(phase), v.main,
 		func(ctx context.Context) (cty.Value, tfdiags.Diagnostics) {
 			var diags tfdiags.Diagnostics
@@ -211,7 +211,7 @@ func (v *InputVariable) CheckValue(ctx context.Context, phase EvalPhase) (cty.Va
 				return cfg.markValue(val), diags
 			}
 		},
-	))
+	)
 }
 
 // ExprReferenceValue implements Referenceable.

--- a/internal/stacks/stackruntime/testdata/mainbundle/test/removed-offline/child/child.tf
+++ b/internal/stacks/stackruntime/testdata/mainbundle/test/removed-offline/child/child.tf
@@ -1,0 +1,16 @@
+terraform {
+  required_providers {
+    testing = {
+      source  = "hashicorp/testing"
+      version = "0.1.0"
+    }
+  }
+}
+
+variable "value" {
+  type = string
+}
+
+resource "testing_resource" "resource" {
+  value = var.value
+}

--- a/internal/stacks/stackruntime/testdata/mainbundle/test/removed-offline/parent/parent.tf
+++ b/internal/stacks/stackruntime/testdata/mainbundle/test/removed-offline/parent/parent.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_providers {
+    testing = {
+      source  = "hashicorp/testing"
+      version = "0.1.0"
+    }
+  }
+}
+
+resource "testing_resource" "resource" {}
+
+output "value" {
+  value = testing_resource.resource.id
+}

--- a/internal/stacks/stackruntime/testdata/mainbundle/test/removed-offline/removed-offline.tfstack.hcl
+++ b/internal/stacks/stackruntime/testdata/mainbundle/test/removed-offline/removed-offline.tfstack.hcl
@@ -1,0 +1,28 @@
+required_providers {
+  testing = {
+    source  = "hashicorp/testing"
+    version = "0.1.0"
+  }
+}
+
+provider "testing" "default" {}
+
+component "parent" {
+  source = "./parent"
+
+  providers = {
+    testing = provider.testing.default
+  }
+}
+
+component "child" {
+  source = "./child"
+
+  providers = {
+    testing = provider.testing.default
+  }
+
+  inputs = {
+    value = component.parent.value
+  }
+}


### PR DESCRIPTION
An assumption was made in Stacks that unknown variables should not be available at all during apply operations. This assumption was not true - we can have unknown values during refresh, destroy and deferred operations.

This PR removes the part of Stacks that was skipping components that found unknown variables - this was causing endless loops of undestroyable configuration in practice. 

This PR also updates the part where variables are loaded for components to allow a specific error to result in a completely unapplyable component. This is the case where a variable has changed between the plan and apply operations. Previously, this was resulting in an unknown value that was just leaving the component to be skipped. Now, we aren't skipping that component anymore so we need to find a way to make that error stronger. This does result in an extra diagnostic being written in this specific error case, but as this error represents a problem in Terraform we should hopefully never see this case in practice.

A side effect of this, is that components with unknown variables now return slightly more complete state updates which has resulted in several tests being updated.