### PR TITLE
fix: Allow WriteOnly attributes to require replacement

### DIFF
--- a/internal/configs/configschema/implied_type.go
+++ b/internal/configs/configschema/implied_type.go
@@ -59,6 +59,29 @@ func (b *Block) ContainsSensitive() bool {
 	return false
 }
 
+// ContainsWriteOnly returns true if any of the attributes of the receiving
+// block or any of its descendant blocks are considered write only
+// based on the declarations in the schema.
+//
+// Blocks themselves cannot be write only as a whole -- write only is a
+// per-attribute idea.
+func (b *Block) ContainsWriteOnly() bool {
+	for _, attrS := range b.Attributes {
+		if attrS.WriteOnly {
+			return true
+		}
+		if attrS.NestedType != nil && attrS.NestedType.ContainsWriteOnly() {
+			return true
+		}
+	}
+	for _, blockS := range b.BlockTypes {
+		if blockS.ContainsWriteOnly() {
+			return true
+		}
+	}
+	return false
+}
+
 // ImpliedType returns the cty.Type that would result from decoding a Block's
 // ImpliedType and getting the resulting AttributeType.
 //
@@ -129,6 +152,20 @@ func (o *Object) ContainsSensitive() bool {
 			return true
 		}
 		if attrS.NestedType != nil && attrS.NestedType.ContainsSensitive() {
+			return true
+		}
+	}
+	return false
+}
+
+// ContainsWriteOnly returns true if any of the attributes of the receiving
+// Object are considered write only based on the declarations in the schema.
+func (o *Object) ContainsWriteOnly() bool {
+	for _, attrS := range o.Attributes {
+		if attrS.WriteOnly {
+			return true
+		}
+		if attrS.NestedType != nil && attrS.NestedType.ContainsWriteOnly() {
 			return true
 		}
 	}

--- a/internal/configs/configschema/implied_type_test.go
+++ b/internal/configs/configschema/implied_type_test.go
@@ -218,6 +218,69 @@ func TestBlockContainsSensitive(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestBlockContainsWriteOnly(t *testing.T) {
+	tests := map[string]struct {
+		Schema *Block
+		Want   bool
+	}{
+		"object contains write only": {
+			&Block{
+				Attributes: map[string]*Attribute{
+					"wo": {WriteOnly: true},
+				},
+			},
+			true,
+		},
+		"no write only attrs": {
+			&Block{
+				Attributes: map[string]*Attribute{
+					"not_wo": {},
+				},
+			},
+			false,
+		},
+		"nested object contains write only": {
+			&Block{
+				Attributes: map[string]*Attribute{
+					"nested": {
+						NestedType: &Object{
+							Nesting: NestingSingle,
+							Attributes: map[string]*Attribute{
+								"wo": {WriteOnly: true},
+							},
+						},
+					},
+				},
+			},
+			true,
+		},
+		"nested obj, no write only attrs": {
+			&Block{
+				Attributes: map[string]*Attribute{
+					"nested": {
+						NestedType: &Object{
+							Nesting: NestingSingle,
+							Attributes: map[string]*Attribute{
+								"public": {},
+							},
+						},
+					},
+				},
+			},
+			false,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := test.Schema.ContainsWriteOnly()
+			if got != test.Want {
+				t.Errorf("wrong result\ngot:  %#v\nwant: %#v", got, test.Want)
+			}
+		})
+	}
 
 }
 
@@ -456,6 +519,101 @@ func TestObjectContainsSensitive(t *testing.T) {
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			got := test.Schema.ContainsSensitive()
+			if got != test.Want {
+				t.Errorf("wrong result\ngot:  %#v\nwant: %#v", got, test.Want)
+			}
+		})
+	}
+
+}
+
+func TestObjectContainsWriteOnly(t *testing.T) {
+	tests := map[string]struct {
+		Schema *Object
+		Want   bool
+	}{
+		"object contains write only": {
+			&Object{
+				Attributes: map[string]*Attribute{
+					"wo": {WriteOnly: true},
+				},
+			},
+			true,
+		},
+		"no write only attrs": {
+			&Object{
+				Attributes: map[string]*Attribute{
+					"not_wo": {},
+				},
+			},
+			false,
+		},
+		"nested object contains write only": {
+			&Object{
+				Attributes: map[string]*Attribute{
+					"nested": {
+						NestedType: &Object{
+							Nesting: NestingSingle,
+							Attributes: map[string]*Attribute{
+								"wo": {WriteOnly: true},
+							},
+						},
+					},
+				},
+			},
+			true,
+		},
+		"nested obj, no write only attrs": {
+			&Object{
+				Attributes: map[string]*Attribute{
+					"nested": {
+						NestedType: &Object{
+							Nesting: NestingSingle,
+							Attributes: map[string]*Attribute{
+								"public": {},
+							},
+						},
+					},
+				},
+			},
+			false,
+		},
+		"several nested objects, one contains write only": {
+			&Object{
+				Attributes: map[string]*Attribute{
+					"alpha": {
+						NestedType: &Object{
+							Nesting: NestingSingle,
+							Attributes: map[string]*Attribute{
+								"not_wo": {},
+							},
+						},
+					},
+					"beta": {
+						NestedType: &Object{
+							Nesting: NestingSingle,
+							Attributes: map[string]*Attribute{
+								"wo": {WriteOnly: true},
+							},
+						},
+					},
+					"gamma": {
+						NestedType: &Object{
+							Nesting: NestingSingle,
+							Attributes: map[string]*Attribute{
+								"not_wo": {},
+							},
+						},
+					},
+				},
+			},
+			true,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := test.Schema.ContainsWriteOnly()
 			if got != test.Want {
 				t.Errorf("wrong result\ngot:  %#v\nwant: %#v", got, test.Want)
 			}

--- a/internal/configs/configschema/write_only.go
+++ b/internal/configs/configschema/write_only.go
@@ -1,0 +1,101 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package configschema
+
+import (
+	"fmt"
+
+	"github.com/zclconf/go-cty/cty"
+)
+
+// WriteOnlyPaths returns a set of paths into the given value that
+// are considered write only based on the declarations in the schema.
+func (b *Block) WriteOnlyPaths(val cty.Value, basePath cty.Path) []cty.Path {
+	var ret []cty.Path
+
+	for name, attrS := range b.Attributes {
+		if attrS.WriteOnly {
+			attrPath := copyAndExtendPath(basePath, cty.GetAttrStep{Name: name})
+			ret = append(ret, attrPath)
+		}
+
+		if attrS.NestedType == nil || !attrS.NestedType.ContainsWriteOnly() {
+			continue
+		}
+
+		attrPath := copyAndExtendPath(basePath, cty.GetAttrStep{Name: name})
+		ret = append(ret, attrS.NestedType.WriteOnlyPaths(attrPath)...)
+	}
+
+	// Extract from nested blocks
+	for name, blockS := range b.BlockTypes {
+		// If our block doesn't contain any write only attributes, skip inspecting it
+		if !blockS.Block.ContainsWriteOnly() {
+			continue
+		}
+
+		if val.IsNull() {
+			return ret
+		}
+
+		blockV := val.GetAttr(name)
+
+		// Create a copy of the path, with this step added, to add to our PathValueMarks slice
+		blockPath := copyAndExtendPath(basePath, cty.GetAttrStep{Name: name})
+
+		switch blockS.Nesting {
+		case NestingSingle, NestingGroup:
+			ret = append(ret, blockS.Block.WriteOnlyPaths(blockV, blockPath)...)
+		case NestingList, NestingMap, NestingSet:
+			blockV, _ = blockV.Unmark() // peel off one level of marking so we can iterate
+
+			if blockV.IsNull() || !blockV.IsKnown() {
+				return ret
+			}
+
+			for it := blockV.ElementIterator(); it.Next(); {
+				idx, blockEV := it.Element()
+
+				blockInstancePath := copyAndExtendPath(blockPath, cty.IndexStep{Key: idx})
+				morePaths := blockS.Block.WriteOnlyPaths(blockEV, blockInstancePath)
+				ret = append(ret, morePaths...)
+			}
+		default:
+			panic(fmt.Sprintf("unsupported nesting mode %s", blockS.Nesting))
+		}
+	}
+	return ret
+}
+
+// WriteOnlyPaths returns a set of paths into the given value that
+// are considered write only based on the declarations in the schema.
+func (o *Object) WriteOnlyPaths(basePath cty.Path) []cty.Path {
+	var ret []cty.Path
+
+	for name, attrS := range o.Attributes {
+		// Create a path to this attribute
+		attrPath := copyAndExtendPath(basePath, cty.GetAttrStep{Name: name})
+
+		switch o.Nesting {
+		case NestingSingle, NestingGroup:
+			if attrS.WriteOnly {
+				ret = append(ret, attrPath)
+			} else {
+				// The attribute has a nested type which contains write only
+				// attributes, so recurse
+				ret = append(ret, attrS.NestedType.WriteOnlyPaths(attrPath)...)
+			}
+		case NestingList, NestingMap, NestingSet:
+			// If the attribute is iterable type we assume that
+			// it is write only in its entirety since we cannot
+			// construct indexes from a null value.
+			if attrS.WriteOnly {
+				ret = append(ret, attrPath)
+			}
+		default:
+			panic(fmt.Sprintf("unsupported nesting mode %s", attrS.NestedType.Nesting))
+		}
+	}
+	return ret
+}

--- a/internal/configs/configschema/write_only_test.go
+++ b/internal/configs/configschema/write_only_test.go
@@ -1,0 +1,155 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package configschema
+
+import (
+	"testing"
+
+	"github.com/zclconf/go-cty/cty"
+)
+
+func TestBlock_WriteOnlyPaths(t *testing.T) {
+	schema := &Block{
+		Attributes: map[string]*Attribute{
+			"not_wo": {
+				Type:     cty.String,
+				Optional: true,
+			},
+			"wo": {
+				Type:      cty.String,
+				WriteOnly: true,
+			},
+			"nested": {
+				NestedType: &Object{
+					Attributes: map[string]*Attribute{
+						"boop": {
+							Type: cty.String,
+						},
+						"honk": {
+							Type:      cty.String,
+							WriteOnly: true,
+						},
+					},
+					Nesting: NestingList,
+				},
+			},
+		},
+
+		BlockTypes: map[string]*NestedBlock{
+			"list": {
+				Nesting: NestingList,
+				Block: Block{
+					Attributes: map[string]*Attribute{
+						"not_wo": {
+							Type:     cty.String,
+							Optional: true,
+						},
+						"wo": {
+							Type:      cty.String,
+							WriteOnly: true,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	testCases := map[string]struct {
+		value    cty.Value
+		expected []cty.Path
+	}{
+		"unknown value": {
+			cty.UnknownVal(schema.ImpliedType()),
+			[]cty.Path{
+				{cty.GetAttrStep{Name: "wo"}},
+				{cty.GetAttrStep{Name: "nested"}, cty.GetAttrStep{Name: "honk"}},
+			},
+		},
+		"null object": {
+			cty.NullVal(schema.ImpliedType()),
+			[]cty.Path{
+				{cty.GetAttrStep{Name: "wo"}},
+				{cty.GetAttrStep{Name: "nested"}, cty.GetAttrStep{Name: "honk"}},
+			},
+		},
+		"object with unknown attributes and blocks": {
+			cty.ObjectVal(map[string]cty.Value{
+				"wo":     cty.UnknownVal(cty.String),
+				"not_wo": cty.UnknownVal(cty.String),
+				"nested": cty.NullVal(cty.List(cty.Object(map[string]cty.Type{
+					"boop": cty.String,
+					"honk": cty.String,
+				}))),
+				"list": cty.UnknownVal(schema.BlockTypes["list"].ImpliedType()),
+			}),
+			[]cty.Path{
+				{cty.GetAttrStep{Name: "wo"}},
+				{cty.GetAttrStep{Name: "nested"}, cty.GetAttrStep{Name: "honk"}},
+			},
+		},
+		"object with block value": {
+			cty.ObjectVal(map[string]cty.Value{
+				"wo":     cty.NullVal(cty.String),
+				"not_wo": cty.UnknownVal(cty.String),
+				"nested": cty.NullVal(cty.List(cty.Object(map[string]cty.Type{
+					"boop": cty.String,
+					"honk": cty.String,
+				}))),
+				"list": cty.ListVal([]cty.Value{
+					cty.ObjectVal(map[string]cty.Value{
+						"wo":     cty.UnknownVal(cty.String),
+						"not_wo": cty.UnknownVal(cty.String),
+					}),
+					cty.ObjectVal(map[string]cty.Value{
+						"wo":     cty.NullVal(cty.String),
+						"not_wo": cty.NullVal(cty.String),
+					}),
+				}),
+			}),
+			[]cty.Path{
+				{cty.GetAttrStep{Name: "wo"}},
+				{cty.GetAttrStep{Name: "nested"}, cty.GetAttrStep{Name: "honk"}},
+				{cty.GetAttrStep{Name: "list"}, cty.IndexStep{Key: cty.NumberIntVal(0)}, cty.GetAttrStep{Name: "wo"}},
+				{cty.GetAttrStep{Name: "list"}, cty.IndexStep{Key: cty.NumberIntVal(1)}, cty.GetAttrStep{Name: "wo"}},
+			},
+		},
+		"object with known values and nested attribute": {
+			cty.ObjectVal(map[string]cty.Value{
+				"wo":     cty.StringVal("foo"),
+				"not_wo": cty.StringVal("bar"),
+				"nested": cty.ListVal([]cty.Value{
+					cty.ObjectVal(map[string]cty.Value{
+						"boop": cty.StringVal("foo"),
+						"honk": cty.StringVal("bar"),
+					}),
+					cty.ObjectVal(map[string]cty.Value{
+						"boop": cty.NullVal(cty.String),
+						"honk": cty.NullVal(cty.String),
+					}),
+					cty.ObjectVal(map[string]cty.Value{
+						"boop": cty.UnknownVal(cty.String),
+						"honk": cty.UnknownVal(cty.String),
+					}),
+				}),
+				"list": cty.NullVal(cty.List(cty.Object(map[string]cty.Type{
+					"sensitive":   cty.String,
+					"unsensitive": cty.String,
+				}))),
+			}),
+			[]cty.Path{
+				{cty.GetAttrStep{Name: "wo"}},
+				{cty.GetAttrStep{Name: "nested"}, cty.GetAttrStep{Name: "honk"}},
+			},
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			woPaths := schema.WriteOnlyPaths(tc.value, nil)
+			if !cty.NewPathSet(tc.expected...).Equal(cty.NewPathSet(woPaths...)) {
+				t.Fatalf("\nexpected: %#v\ngot:      %#v\n", tc.expected, woPaths)
+			}
+		})
+	}
+}

--- a/internal/terraform/context_plan2_test.go
+++ b/internal/terraform/context_plan2_test.go
@@ -5923,6 +5923,101 @@ resource "test_object" "obj" {
 	}
 }
 
+func TestContext2Plan_writeOnlyRequiredReplace_createBeforeDestroy(t *testing.T) {
+	m := testModuleInline(t, map[string]string{
+		"main.tf": `
+resource "test_object" "obj" {
+	value = "changed"
+	lifecycle {
+		create_before_destroy = true
+	}
+}
+`,
+	})
+	p := new(testing_provider.MockProvider)
+	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
+		ResourceTypes: map[string]providers.Schema{
+			"test_object": {
+				Block: &configschema.Block{
+					Attributes: map[string]*configschema.Attribute{
+						"value": {
+							Type:      cty.String,
+							Required:  true,
+							WriteOnly: true,
+						},
+					},
+				},
+			},
+		},
+	}
+	p.PlanResourceChangeResponse = &providers.PlanResourceChangeResponse{
+		PlannedState: cty.ObjectVal(map[string]cty.Value{
+			"value": cty.NullVal(cty.String),
+		}),
+		RequiresReplace: []cty.Path{
+			cty.GetAttrPath("value"),
+		},
+	}
+
+	ctx := testContext2(t, &ContextOpts{
+		Providers: map[addrs.Provider]providers.Factory{
+			addrs.NewDefaultProvider("test"): testProviderFuncFixed(p),
+		},
+	})
+
+	rAddr := mustResourceInstanceAddr("test_object.obj")
+	pAddr := mustProviderConfig(`provider["registry.terraform.io/hashicorp/test"]`)
+	state := states.BuildState(func(s *states.SyncState) {
+		s.SetResourceInstanceCurrent(
+			rAddr,
+			&states.ResourceInstanceObjectSrc{
+				AttrsJSON: mustParseJson(map[string]any{
+					"value": nil,
+				}),
+				Status: states.ObjectReady,
+			},
+			pAddr)
+	})
+
+	plan, diags := ctx.Plan(m, state, nil)
+	assertNoErrors(t, diags)
+
+	if plan.Changes.Empty() {
+		t.Fatal("unexpected empty plan")
+	}
+	expectedChanges := &plans.Changes{
+		Resources: []*plans.ResourceInstanceChange{
+			{
+				Addr:         rAddr,
+				PrevRunAddr:  rAddr,
+				ProviderAddr: pAddr,
+				Change: plans.Change{
+					Action: plans.CreateThenDelete,
+					Before: cty.ObjectVal(map[string]cty.Value{
+						"value": cty.NullVal(cty.String),
+					}),
+					After: cty.ObjectVal(map[string]cty.Value{
+						"value": cty.NullVal(cty.String),
+					}),
+				},
+				ActionReason:    plans.ResourceInstanceReplaceBecauseCannotUpdate,
+				RequiredReplace: cty.NewPathSet(cty.GetAttrPath("value")),
+			},
+		},
+	}
+
+	schemas, schemaDiags := ctx.Schemas(m, plan.PriorState)
+	assertNoDiagnostics(t, schemaDiags)
+
+	changes, err := plan.Changes.Decode(schemas)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if diff := cmp.Diff(expectedChanges, changes, ctydebug.CmpOptions); diff != "" {
+		t.Fatalf("unexpected changes: %s", diff)
+	}
+}
+
 func TestContext2Plan_selfReferences(t *testing.T) {
 	tcs := []struct {
 		attribute string

--- a/internal/terraform/context_plan2_test.go
+++ b/internal/terraform/context_plan2_test.go
@@ -5831,6 +5831,98 @@ resource "test_object" "obj" {
 	}
 }
 
+func TestContext2Plan_writeOnlyRequiredReplace(t *testing.T) {
+	m := testModuleInline(t, map[string]string{
+		"main.tf": `
+resource "test_object" "obj" {
+	value = "changed"
+}
+`,
+	})
+	p := new(testing_provider.MockProvider)
+	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
+		ResourceTypes: map[string]providers.Schema{
+			"test_object": {
+				Block: &configschema.Block{
+					Attributes: map[string]*configschema.Attribute{
+						"value": {
+							Type:      cty.String,
+							Required:  true,
+							WriteOnly: true,
+						},
+					},
+				},
+			},
+		},
+	}
+	p.PlanResourceChangeResponse = &providers.PlanResourceChangeResponse{
+		PlannedState: cty.ObjectVal(map[string]cty.Value{
+			"value": cty.NullVal(cty.String),
+		}),
+		RequiresReplace: []cty.Path{
+			cty.GetAttrPath("value"),
+		},
+	}
+
+	ctx := testContext2(t, &ContextOpts{
+		Providers: map[addrs.Provider]providers.Factory{
+			addrs.NewDefaultProvider("test"): testProviderFuncFixed(p),
+		},
+	})
+
+	rAddr := mustResourceInstanceAddr("test_object.obj")
+	pAddr := mustProviderConfig(`provider["registry.terraform.io/hashicorp/test"]`)
+	state := states.BuildState(func(s *states.SyncState) {
+		s.SetResourceInstanceCurrent(
+			rAddr,
+			&states.ResourceInstanceObjectSrc{
+				AttrsJSON: mustParseJson(map[string]any{
+					"value": nil,
+				}),
+				Status: states.ObjectReady,
+			},
+			pAddr)
+	})
+
+	plan, diags := ctx.Plan(m, state, nil)
+	assertNoErrors(t, diags)
+
+	if plan.Changes.Empty() {
+		t.Fatal("unexpected empty plan")
+	}
+	expectedChanges := &plans.Changes{
+		Resources: []*plans.ResourceInstanceChange{
+			{
+				Addr:         rAddr,
+				PrevRunAddr:  rAddr,
+				ProviderAddr: pAddr,
+				Change: plans.Change{
+					Action: plans.DeleteThenCreate,
+					Before: cty.ObjectVal(map[string]cty.Value{
+						"value": cty.NullVal(cty.String),
+					}),
+					After: cty.ObjectVal(map[string]cty.Value{
+						"value": cty.NullVal(cty.String),
+					}),
+				},
+				ActionReason:    plans.ResourceInstanceReplaceBecauseCannotUpdate,
+				RequiredReplace: cty.NewPathSet(cty.GetAttrPath("value")),
+			},
+		},
+	}
+
+	schemas, schemaDiags := ctx.Schemas(m, plan.PriorState)
+	assertNoDiagnostics(t, schemaDiags)
+
+	changes, err := plan.Changes.Decode(schemas)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if diff := cmp.Diff(expectedChanges, changes, ctydebug.CmpOptions); diff != "" {
+		t.Fatalf("unexpected changes: %s", diff)
+	}
+}
+
 func TestContext2Plan_selfReferences(t *testing.T) {
 	tcs := []struct {
 		attribute string

--- a/internal/terraform/node_resource_abstract_instance.go
+++ b/internal/terraform/node_resource_abstract_instance.go
@@ -2843,12 +2843,7 @@ func getAction(addr addrs.AbsResourceInstance, priorVal, plannedNewVal cty.Value
 	switch {
 	case priorVal.IsNull():
 		action = plans.Create
-	case !writeOnly.Intersection(reqRep).Empty():
-		action = plans.DeleteThenCreate
-		actionReason = plans.ResourceInstanceReplaceBecauseCannotUpdate
-	case eq && !matchedForceReplace:
-		action = plans.NoOp
-	case matchedForceReplace || !reqRep.Empty():
+	case matchedForceReplace || !reqRep.Empty() || !writeOnly.Intersection(reqRep).Empty():
 		// If the user "forced replace" of this instance of if there are any
 		// "requires replace" paths left _after our filtering above_ then this
 		// is a replace action.
@@ -2863,6 +2858,8 @@ func getAction(addr addrs.AbsResourceInstance, priorVal, plannedNewVal cty.Value
 		case !reqRep.Empty():
 			actionReason = plans.ResourceInstanceReplaceBecauseCannotUpdate
 		}
+	case eq && !matchedForceReplace:
+		action = plans.NoOp
 	default:
 		action = plans.Update
 		// "Delete" is never chosen here, because deletion plans are always


### PR DESCRIPTION
## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.11.x

## CHANGELOG entry

WriteOnly attributes are still pre-release.