### PR TITLE
Hide ephemeral values in diagnostics output

### DIFF
--- a/internal/tfdiags/format.go
+++ b/internal/tfdiags/format.go
@@ -39,10 +39,10 @@ func CompactValueStr(val cty.Value) string {
 			// that are both ephemeral and sensitive should have both markings
 			// and should therefore get caught by the marks.Sensitive case
 			// above.
-			continue
+			return "(ephemeral value)"
 		default:
 			// We don't know about any other marks, so we'll be conservative.
-			// This shouldn't actuallyr eachable since the caller should've
+			// This shouldn't actually reachable since the caller should've
 			// checked this and skipped calling compactValueStr anyway.
 			return "value with unrecognized marks (this is a bug in Terraform)"
 		}

--- a/internal/tfdiags/format_test.go
+++ b/internal/tfdiags/format_test.go
@@ -1,0 +1,110 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package tfdiags
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/internal/lang/marks"
+	"github.com/zclconf/go-cty/cty"
+)
+
+func TestCompactValueStr(t *testing.T) {
+	tests := []struct {
+		Val  cty.Value
+		Want string
+	}{
+		{
+			cty.NullVal(cty.DynamicPseudoType),
+			"null",
+		},
+		{
+			cty.UnknownVal(cty.DynamicPseudoType),
+			"(not yet known)",
+		},
+		{
+			cty.False,
+			"false",
+		},
+		{
+			cty.True,
+			"true",
+		},
+		{
+			cty.NumberIntVal(5),
+			"5",
+		},
+		{
+			cty.NumberFloatVal(5.2),
+			"5.2",
+		},
+		{
+			cty.StringVal(""),
+			`""`,
+		},
+		{
+			cty.StringVal("hello"),
+			`"hello"`,
+		},
+		{
+			cty.ListValEmpty(cty.String),
+			"empty list of string",
+		},
+		{
+			cty.SetValEmpty(cty.String),
+			"empty set of string",
+		},
+		{
+			cty.EmptyTupleVal,
+			"empty tuple",
+		},
+		{
+			cty.MapValEmpty(cty.String),
+			"empty map of string",
+		},
+		{
+			cty.EmptyObjectVal,
+			"object with no attributes",
+		},
+		{
+			cty.ListVal([]cty.Value{cty.StringVal("a")}),
+			"list of string with 1 element",
+		},
+		{
+			cty.ListVal([]cty.Value{cty.StringVal("a"), cty.StringVal("b")}),
+			"list of string with 2 elements",
+		},
+		{
+			cty.ObjectVal(map[string]cty.Value{
+				"a": cty.StringVal("b"),
+			}),
+			`object with 1 attribute "a"`,
+		},
+		{
+			cty.ObjectVal(map[string]cty.Value{
+				"a": cty.StringVal("b"),
+				"c": cty.StringVal("d"),
+			}),
+			"object with 2 attributes",
+		},
+		{
+			cty.StringVal("a sensitive value").Mark(marks.Sensitive),
+			"(sensitive value)",
+		},
+		{
+			cty.StringVal("an ephemeral value").Mark(marks.Ephemeral),
+			"(ephemeral value)",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("%#v", test.Val), func(t *testing.T) {
+			got := CompactValueStr(test.Val)
+			if got != test.Want {
+				t.Errorf("wrong result\nvalue: %#v\ngot:   %s\nwant:  %s", test.Val, got, test.Want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
While working on https://github.com/hashicorp/terraform/pull/36267 we discussed that ephemeral values are currently implemented as _hidden_ in other places in the codebase.

This PR aligns the behaviour in `CompactValueStr` with the rest of the codebase and also adds a test case for the function.

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.11.x

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory.

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
