### PR TITLE
Change JUnit `terraform test` output to include test failure details inside `<failure>` elements, use the error message as the `message` attribute

### DIFF
--- a/internal/command/junit/junit.go
+++ b/internal/command/junit/junit.go
@@ -328,7 +328,7 @@ func skipDetails(runIndex int, file *moduletest.File, suiteStopped bool) *withMe
 	}
 
 	// Unhandled case: This results in <skipped></skipped> with no attributes or body
-	return nil
+	return &withMessage{}
 }
 
 func suiteFilesAsSortedList(files map[string]*moduletest.File) []*moduletest.File {

--- a/internal/command/junit/junit.go
+++ b/internal/command/junit/junit.go
@@ -216,12 +216,10 @@ func junitXMLTestReport(suite *moduletest.Suite, suiteRunnerStopped bool, source
 					Body:    body,
 				}
 			case moduletest.Fail:
-				var diagsStr strings.Builder
 				var failedAssertion tfdiags.Diagnostic
 				for _, diag := range run.Diagnostics {
 					// Find the diag resulting from a failed assertion
 					if diag.Description().Summary == failedTestSummary {
-						diagsStr.WriteString(format.DiagnosticPlain(diag, sources, 80))
 						failedAssertion = diag
 						break
 					}

--- a/internal/command/junit/junit_internal_test.go
+++ b/internal/command/junit/junit_internal_test.go
@@ -70,7 +70,6 @@ func Test_TestJUnitXMLFile_save(t *testing.T) {
 	}
 }
 
-
 func Test_getWarnings(t *testing.T) {
 
 	errorDiag := &hcl.Diagnostic{

--- a/internal/command/junit/junit_internal_test.go
+++ b/internal/command/junit/junit_internal_test.go
@@ -8,7 +8,10 @@ import (
 	"os"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/terraform/internal/moduletest"
+	"github.com/hashicorp/terraform/internal/tfdiags"
 )
 
 func Test_TestJUnitXMLFile_save(t *testing.T) {
@@ -62,6 +65,66 @@ func Test_TestJUnitXMLFile_save(t *testing.T) {
 
 			if !bytes.Equal(fileContent, xml) {
 				t.Fatalf("wanted XML:\n%s\n got XML:\n%s\n", string(xml), string(fileContent))
+			}
+		})
+	}
+}
+
+
+func Test_getWarnings(t *testing.T) {
+
+	errorDiag := &hcl.Diagnostic{
+		Severity: hcl.DiagError,
+		Summary:  "error",
+		Detail:   "this is an error",
+	}
+
+	warnDiag := &hcl.Diagnostic{
+		Severity: hcl.DiagWarning,
+		Summary:  "warning",
+		Detail:   "this is a warning",
+	}
+
+	cases := map[string]struct {
+		diags    tfdiags.Diagnostics
+		expected tfdiags.Diagnostics
+	}{
+		"empty diags": {
+			diags:    tfdiags.Diagnostics{},
+			expected: tfdiags.Diagnostics{},
+		},
+		"nil diags": {
+			diags:    nil,
+			expected: tfdiags.Diagnostics{},
+		},
+		"all error diags": {
+			diags: func() tfdiags.Diagnostics {
+				var d tfdiags.Diagnostics
+				d = d.Append(errorDiag, errorDiag, errorDiag)
+				return d
+			}(),
+			expected: tfdiags.Diagnostics{},
+		},
+		"mixture of error and warning diags": {
+			diags: func() tfdiags.Diagnostics {
+				var d tfdiags.Diagnostics
+				d = d.Append(errorDiag, errorDiag, warnDiag) // 1 warning
+				return d
+			}(),
+			expected: func() tfdiags.Diagnostics {
+				var d tfdiags.Diagnostics
+				d = d.Append(warnDiag) // 1 warning
+				return d
+			}(),
+		},
+	}
+
+	for tn, tc := range cases {
+		t.Run(tn, func(t *testing.T) {
+			warnings := getWarnings(tc.diags)
+
+			if diff := cmp.Diff(tc.expected, warnings, cmp.Comparer(diagnosticComparer)); diff != "" {
+				t.Errorf("wrong diagnostics\n%s", diff)
 			}
 		})
 	}
@@ -150,4 +213,22 @@ func Test_suiteFilesAsSortedList(t *testing.T) {
 			}
 		})
 	}
+}
+
+// From internal/backend/remote-state/s3/testing_test.go
+// diagnosticComparer is a Comparer function for use with cmp.Diff to compare two tfdiags.Diagnostic values
+func diagnosticComparer(l, r tfdiags.Diagnostic) bool {
+	if l.Severity() != r.Severity() {
+		return false
+	}
+	if l.Description() != r.Description() {
+		return false
+	}
+
+	lp := tfdiags.GetAttribute(l)
+	rp := tfdiags.GetAttribute(r)
+	if len(lp) != len(rp) {
+		return false
+	}
+	return lp.Equals(rp)
 }

--- a/internal/command/testdata/test/junit-output/1pass-1fail/expected-output.xml
+++ b/internal/command/testdata/test/junit-output/1pass-1fail/expected-output.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><testsuites>
   <testsuite name="main.tftest.hcl" tests="2" skipped="0" failures="1" errors="0">
     <testcase name="failing_assertion" classname="main.tftest.hcl" time="TIME_REDACTED" timestamp="TIMESTAMP_REDACTED">
-      <failure message="Test run failed"><![CDATA[Test failed on assertion 2 of 3]]></failure>
+      <failure message="local variable &#39;number&#39; has a value greater than zero, so assertion 2 will fail"><![CDATA[Test failed on assertion 2 of 3]]></failure>
       <system-err><![CDATA[
 Error: Test assertion failed
 

--- a/internal/command/testdata/test/junit-output/1pass-1fail/expected-output.xml
+++ b/internal/command/testdata/test/junit-output/1pass-1fail/expected-output.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><testsuites>
   <testsuite name="main.tftest.hcl" tests="2" skipped="0" failures="1" errors="0">
     <testcase name="failing_assertion" classname="main.tftest.hcl" time="TIME_REDACTED" timestamp="TIMESTAMP_REDACTED">
-      <failure message="local variable &#39;number&#39; has a value greater than zero, so assertion 2 will fail"><![CDATA[
+      <failure message="1 of 3 assertions failed: local variable &#39;number&#39; has a value greater than zero, so assertion 2 will fail"><![CDATA[
 Error: Test assertion failed
 
   on main.tftest.hcl line 7, in run "failing_assertion":

--- a/internal/command/testdata/test/junit-output/1pass-1fail/expected-output.xml
+++ b/internal/command/testdata/test/junit-output/1pass-1fail/expected-output.xml
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><testsuites>
   <testsuite name="main.tftest.hcl" tests="2" skipped="0" failures="1" errors="0">
     <testcase name="failing_assertion" classname="main.tftest.hcl" time="TIME_REDACTED" timestamp="TIMESTAMP_REDACTED">
-      <failure message="local variable &#39;number&#39; has a value greater than zero, so assertion 2 will fail"><![CDATA[Test failed on assertion 2 of 3]]></failure>
-      <system-err><![CDATA[
+      <failure message="local variable &#39;number&#39; has a value greater than zero, so assertion 2 will fail"><![CDATA[
 Error: Test assertion failed
 
   on main.tftest.hcl line 7, in run "failing_assertion":
@@ -11,7 +10,7 @@ Error: Test assertion failed
     │ local.number is 10
 
 local variable 'number' has a value greater than zero, so assertion 2 will fail
-]]></system-err>
+]]></failure>
     </testcase>
     <testcase name="passing_assertion" classname="main.tftest.hcl" time="TIME_REDACTED" timestamp="TIMESTAMP_REDACTED"></testcase>
   </testsuite>

--- a/internal/command/testdata/test/junit-output/1pass-1fail/expected-output.xml
+++ b/internal/command/testdata/test/junit-output/1pass-1fail/expected-output.xml
@@ -1,17 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?><testsuites>
   <testsuite name="main.tftest.hcl" tests="2" skipped="0" failures="1" errors="0">
     <testcase name="failing_assertion" classname="main.tftest.hcl" time="TIME_REDACTED" timestamp="TIMESTAMP_REDACTED">
-      <failure message="Test run failed"></failure>
+      <failure message="Test run failed"><![CDATA[Test failed on assertion 2 of 3]]></failure>
       <system-err><![CDATA[
 Error: Test assertion failed
 
-  on main.tftest.hcl line 3, in run "failing_assertion":
-   3:     condition     = local.number < 0
+  on main.tftest.hcl line 7, in run "failing_assertion":
+   7:     condition     = local.number < 0
     ├────────────────
     │ local.number is 10
 
-local variable 'number' has a value greater than zero, so this assertion will
-fail
+local variable 'number' has a value greater than zero, so assertion 2 will fail
 ]]></system-err>
     </testcase>
     <testcase name="passing_assertion" classname="main.tftest.hcl" time="TIME_REDACTED" timestamp="TIMESTAMP_REDACTED"></testcase>

--- a/internal/command/testdata/test/junit-output/1pass-1fail/main.tftest.hcl
+++ b/internal/command/testdata/test/junit-output/1pass-1fail/main.tftest.hcl
@@ -1,7 +1,15 @@
 run "failing_assertion" {
   assert {
+    condition     = local.number == 10
+    error_message = "assertion 1 should pass"
+  }
+  assert {
     condition     = local.number < 0
-    error_message = "local variable 'number' has a value greater than zero, so this assertion will fail"
+    error_message = "local variable 'number' has a value greater than zero, so assertion 2 will fail"
+  }
+  assert {
+    condition     = local.number == 10
+    error_message = "assertion 3 should pass"
   }
 }
 


### PR DESCRIPTION
This PR

- 1) Updates the `message` attribute on a `<failure>` element to summarise how many assertions are failing out of a given total, and includes the first failed assertion's error message.
    - This is a remaining piece of feedback on the JUnit test report shared in the Discuss forum: https://discuss.hashicorp.com/t/request-for-feedback-on-terraform-test-junit-xml-output/62307/16?u=sarah.french
- 2) Moves the rendering of the failured message diag into the <failure> element's body
    - This matches [the docs for Azure Devops's use of JUnit XML format](https://learn.microsoft.com/en-us/azure/devops/pipelines/tasks/reference/publish-test-results-v2?view=azure-pipelines&tabs=junit%2Ctrxattachments%2Cyaml)
    - This also matches feedback in [this message from the Discuss forum thread](https://discuss.hashicorp.com/t/request-for-feedback-on-terraform-test-junit-xml-output/62307/7?u=sarah.french)

Related:
- [x] Update docs for -junit-xml flag

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.11.x

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory.

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.

This change relates to a feature that isn't released yet