### PR TITLE
test: also allow mock_data and mock_resource blocks to generate data during planning

### DIFF
--- a/internal/command/test_test.go
+++ b/internal/command/test_test.go
@@ -221,7 +221,7 @@ func TestTest_Runs(t *testing.T) {
 			code:        0,
 		},
 		"mocking": {
-			expectedOut: []string{"9 passed, 0 failed."},
+			expectedOut: []string{"10 passed, 0 failed."},
 			code:        0,
 		},
 		"mocking-invalid": {

--- a/internal/command/testdata/test/mocking/tests/mocks/data.tfmock.hcl
+++ b/internal/command/testdata/test/mocking/tests/mocks/data.tfmock.hcl
@@ -1,0 +1,6 @@
+mock_resource "test_resource" {
+  override_during = plan
+  defaults = {
+    id = "aaaa"
+  }
+}

--- a/internal/command/testdata/test/mocking/tests/primary_mocked_external.tftest.hcl
+++ b/internal/command/testdata/test/mocking/tests/primary_mocked_external.tftest.hcl
@@ -1,0 +1,47 @@
+mock_provider "test" {
+  alias = "primary"
+
+  source ="./tests/mocks"
+}
+
+mock_provider "test" {
+  alias = "secondary"
+
+  mock_resource "test_resource" {
+    override_during = plan
+    defaults = {
+      id = "bbbb"
+    }
+  }
+}
+
+variables {
+  instances = 1
+  child_instances = 1
+}
+
+
+run "test" {
+  command = plan
+
+  assert {
+    condition = test_resource.primary[0].id == "aaaa"
+    error_message = "did not apply mocks"
+  }
+
+  assert {
+    condition = module.child[0].primary[0].id == "aaaa"
+    error_message = "did not apply mocks"
+  }
+
+  assert {
+    condition = test_resource.secondary[0].id == "bbbb"
+    error_message = "wrongly applied mocks"
+  }
+
+  assert {
+    condition = module.child[0].secondary[0].id == "bbbb"
+    error_message = "wrongly applied mocks"
+  }
+
+}

--- a/internal/configs/config_build_test.go
+++ b/internal/configs/config_build_test.go
@@ -308,7 +308,7 @@ func TestBuildConfig_WithMockDataSources(t *testing.T) {
 
 	cfg, diags := BuildConfig(mod, nil, MockDataLoaderFunc(func(provider *Provider) (*MockData, hcl.Diagnostics) {
 		sourcePath := filepath.Join("testdata/valid-modules/with-mock-sources", provider.MockDataExternalSource)
-		return parser.LoadMockDataDir(sourcePath, hcl.Range{})
+		return parser.LoadMockDataDir(sourcePath, provider.MockDataDuringPlan, hcl.Range{})
 	}))
 	assertNoDiagnostics(t, diags)
 	if cfg == nil {
@@ -339,7 +339,7 @@ func TestBuildConfig_WithMockDataSourcesInline(t *testing.T) {
 
 	cfg, diags := BuildConfig(mod, nil, MockDataLoaderFunc(func(provider *Provider) (*MockData, hcl.Diagnostics) {
 		sourcePath := filepath.Join("testdata/valid-modules/with-mock-sources-inline", provider.MockDataExternalSource)
-		return parser.LoadMockDataDir(sourcePath, hcl.Range{})
+		return parser.LoadMockDataDir(sourcePath, provider.MockDataDuringPlan, hcl.Range{})
 	}))
 	assertNoDiagnostics(t, diags)
 	if cfg == nil {

--- a/internal/configs/configload/loader_load.go
+++ b/internal/configs/configload/loader_load.go
@@ -58,7 +58,7 @@ func (l *Loader) LoadExternalMockData(provider *configs.Provider) (*configs.Mock
 	}
 
 	// Otherwise, just hand this off to the parser to handle.
-	return l.parser.LoadMockDataDir(provider.MockDataExternalSource, provider.DeclRange)
+	return l.parser.LoadMockDataDir(provider.MockDataExternalSource, provider.MockDataDuringPlan, provider.DeclRange)
 }
 
 // moduleWalkerLoad is a configs.ModuleWalkerFunc for loading modules that

--- a/internal/configs/parser_config.go
+++ b/internal/configs/parser_config.go
@@ -53,13 +53,13 @@ func (p *Parser) LoadTestFile(path string) (*TestFile, hcl.Diagnostics) {
 //
 // It references the same LoadHCLFile as LoadConfigFile, so inherits the same
 // syntax selection behaviours.
-func (p *Parser) LoadMockDataFile(path string) (*MockData, hcl.Diagnostics) {
+func (p *Parser) LoadMockDataFile(path string, useForPlanDefault bool) (*MockData, hcl.Diagnostics) {
 	body, diags := p.LoadHCLFile(path)
 	if body == nil {
 		return nil, diags
 	}
 
-	data, dataDiags := decodeMockDataBody(body, MockDataFileOverrideSource)
+	data, dataDiags := decodeMockDataBody(body, useForPlanDefault, MockDataFileOverrideSource)
 	diags = append(diags, dataDiags...)
 	return data, diags
 }

--- a/internal/configs/parser_config_dir.go
+++ b/internal/configs/parser_config_dir.go
@@ -78,7 +78,7 @@ func (p *Parser) LoadConfigDirWithTests(path string, testDirectory string) (*Mod
 	return mod, diags
 }
 
-func (p *Parser) LoadMockDataDir(dir string, source hcl.Range) (*MockData, hcl.Diagnostics) {
+func (p *Parser) LoadMockDataDir(dir string, useForPlanDefault bool, source hcl.Range) (*MockData, hcl.Diagnostics) {
 	var diags hcl.Diagnostics
 
 	infos, err := p.fs.ReadDir(dir)
@@ -113,7 +113,7 @@ func (p *Parser) LoadMockDataDir(dir string, source hcl.Range) (*MockData, hcl.D
 
 	var data *MockData
 	for _, file := range files {
-		current, currentDiags := p.LoadMockDataFile(file)
+		current, currentDiags := p.LoadMockDataFile(file, useForPlanDefault)
 		diags = append(diags, currentDiags...)
 		if data != nil {
 			diags = append(diags, data.Merge(current, false)...)

--- a/internal/configs/provider.go
+++ b/internal/configs/provider.go
@@ -38,9 +38,12 @@ type Provider struct {
 
 	// Mock and MockData declare this provider as a "mock_provider", which means
 	// it should use the data in MockData instead of actually initialising the
-	// provider.
-	Mock     bool
-	MockData *MockData
+	// provider. MockDataDuringPlan tells the provider that, by default, it
+	// should generate values during the planning stage instead of waiting for
+	// the apply stage.
+	Mock               bool
+	MockDataDuringPlan bool
+	MockData           *MockData
 
 	// MockDataExternalSource is a file path pointing to the external data
 	// file for a mock provider. An empty string indicates all data should be

--- a/internal/configs/test_file.go
+++ b/internal/configs/test_file.go
@@ -369,7 +369,7 @@ func loadTestFile(body hcl.Body) (*TestFile, hcl.Diagnostics) {
 				tf.Providers[key] = provider
 			}
 		case "override_resource":
-			override, overrideDiags := decodeOverrideResourceBlock(block, TestFileOverrideSource)
+			override, overrideDiags := decodeOverrideResourceBlock(block, false, TestFileOverrideSource)
 			diags = append(diags, overrideDiags...)
 
 			if override != nil && override.Target != nil {
@@ -386,7 +386,7 @@ func loadTestFile(body hcl.Body) (*TestFile, hcl.Diagnostics) {
 				tf.Overrides.Put(subject, override)
 			}
 		case "override_data":
-			override, overrideDiags := decodeOverrideDataBlock(block, TestFileOverrideSource)
+			override, overrideDiags := decodeOverrideDataBlock(block, false, TestFileOverrideSource)
 			diags = append(diags, overrideDiags...)
 
 			if override != nil && override.Target != nil {
@@ -403,7 +403,7 @@ func loadTestFile(body hcl.Body) (*TestFile, hcl.Diagnostics) {
 				tf.Overrides.Put(subject, override)
 			}
 		case "override_module":
-			override, overrideDiags := decodeOverrideModuleBlock(block, TestFileOverrideSource)
+			override, overrideDiags := decodeOverrideModuleBlock(block, false, TestFileOverrideSource)
 			diags = append(diags, overrideDiags...)
 
 			if override != nil && override.Target != nil {
@@ -507,7 +507,7 @@ func decodeTestRunBlock(block *hcl.Block) (*TestRun, hcl.Diagnostics) {
 				r.Module = module
 			}
 		case "override_resource":
-			override, overrideDiags := decodeOverrideResourceBlock(block, RunBlockOverrideSource)
+			override, overrideDiags := decodeOverrideResourceBlock(block, false, RunBlockOverrideSource)
 			diags = append(diags, overrideDiags...)
 
 			if override != nil && override.Target != nil {
@@ -524,7 +524,7 @@ func decodeTestRunBlock(block *hcl.Block) (*TestRun, hcl.Diagnostics) {
 				r.Overrides.Put(subject, override)
 			}
 		case "override_data":
-			override, overrideDiags := decodeOverrideDataBlock(block, RunBlockOverrideSource)
+			override, overrideDiags := decodeOverrideDataBlock(block, false, RunBlockOverrideSource)
 			diags = append(diags, overrideDiags...)
 
 			if override != nil && override.Target != nil {
@@ -541,7 +541,7 @@ func decodeTestRunBlock(block *hcl.Block) (*TestRun, hcl.Diagnostics) {
 				r.Overrides.Put(subject, override)
 			}
 		case "override_module":
-			override, overrideDiags := decodeOverrideModuleBlock(block, RunBlockOverrideSource)
+			override, overrideDiags := decodeOverrideModuleBlock(block, false, RunBlockOverrideSource)
 			diags = append(diags, overrideDiags...)
 
 			if override != nil && override.Target != nil {

--- a/internal/providers/mock.go
+++ b/internal/providers/mock.go
@@ -187,7 +187,7 @@ func (m *Mock) PlanResourceChange(request PlanResourceChangeRequest) PlanResourc
 			ComputedAsUnknown: true,
 		}
 		// if we are allowed to use the mock defaults for plan, we can populate the computed fields with the mock defaults.
-		if mockedResource, exists := m.Data.MockResources[request.TypeName]; exists && m.Data.UseForPlan {
+		if mockedResource, exists := m.Data.MockResources[request.TypeName]; exists && mockedResource.UseForPlan {
 			replacement.Value = mockedResource.Defaults
 			replacement.Range = mockedResource.DefaultsRange
 			replacement.ComputedAsUnknown = false

--- a/internal/terraform/node_resource_abstract_instance.go
+++ b/internal/terraform/node_resource_abstract_instance.go
@@ -917,7 +917,7 @@ func (n *NodeAbstractResourceInstance) plan(
 			override, overrideDiags := mocking.PlanComputedValuesForResource(proposedNewVal, &mocking.MockedData{
 				Value:             n.override.Values,
 				Range:             n.override.Range,
-				ComputedAsUnknown: !n.override.UseForPlan(),
+				ComputedAsUnknown: !n.override.UseForPlan,
 			}, schema)
 			resp = providers.PlanResourceChangeResponse{
 				PlannedState: override,
@@ -1109,7 +1109,7 @@ func (n *NodeAbstractResourceInstance) plan(
 			override, overrideDiags := mocking.PlanComputedValuesForResource(proposedNewVal, &mocking.MockedData{
 				Value:             n.override.Values,
 				Range:             n.override.Range,
-				ComputedAsUnknown: !n.override.UseForPlan(),
+				ComputedAsUnknown: !n.override.UseForPlan,
 			}, schema)
 			resp = providers.PlanResourceChangeResponse{
 				PlannedState: override,


### PR DESCRIPTION
This is a quick follow up to #36227. We're extending the same functionality to the `mock_resource` and `mock_data` blocks that wasn't included in the last PR.

There's a small refactor to compute the `override_during` value at the provider level instead of at the mock_data level. This means we can also use the value defined on the provider if we're loading mock data from external sources. In addition, the refactor lets us get rid of the boolean pointer fields that I found confusing. Now, the functions all require a default value that can be provided by the source value at the provider level.