### PR TITLE
Promote JUnit output 'terraform test' feature from experimental status, make incompatibility with remote test execution explicit via flag validation

### DIFF
--- a/.changes/unreleased/NEW FEATURES-20250115-110818.yaml
+++ b/.changes/unreleased/NEW FEATURES-20250115-110818.yaml
@@ -1,0 +1,5 @@
+kind: NEW FEATURES
+body: '`terraform test`: The `-junit-xml` option for the terraform test command is now generally available. This option allows the command to create a test report in JUnit XML format. Feedback during the experimental phase helped map terraform test concepts to the JUnit XML format, and new additons may happen in future releases.'
+time: 2025-01-15T11:08:18.566206Z
+custom:
+    Issue: "36324"

--- a/internal/command/arguments/test.go
+++ b/internal/command/arguments/test.go
@@ -66,6 +66,13 @@ func ParseTest(args []string) (*Test, tfdiags.Diagnostics) {
 			err.Error()))
 	}
 
+	if len(test.JUnitXMLFile) > 0 && len(test.CloudRunSource) > 0 {
+		diags = diags.Append(tfdiags.Sourceless(
+			tfdiags.Error,
+			"Incompatible command-line flags",
+			"The -junit-xml option is currently not compatible with remote test execution via the -cloud-run flag. If you are interested in JUnit XML output for remotely-executed tests please open an issue in GitHub."))
+	}
+
 	switch {
 	case jsonOutput:
 		test.ViewType = ViewJSON

--- a/internal/command/arguments/test_test.go
+++ b/internal/command/arguments/test_test.go
@@ -137,6 +137,24 @@ func TestParseTest(t *testing.T) {
 				),
 			},
 		},
+		"incompatible flags: -junit-xml and -cloud-run": {
+			args: []string{"-junit-xml=./output.xml", "-cloud-run=foobar"},
+			want: &Test{
+				CloudRunSource: "foobar",
+				JUnitXMLFile:   "./output.xml",
+				Filter:         nil,
+				TestDirectory:  "tests",
+				ViewType:       ViewHuman,
+				Vars:           &Vars{},
+			},
+			wantDiags: tfdiags.Diagnostics{
+				tfdiags.Sourceless(
+					tfdiags.Error,
+					"Incompatible command-line flags",
+					"The -junit-xml option is currently not compatible with remote test execution via the -cloud-run flag. If you are interested in JUnit XML output for remotely-executed tests please open an issue in GitHub.",
+				),
+			},
+		},
 	}
 
 	cmpOpts := cmpopts.IgnoreUnexported(Operation{}, Vars{}, State{})

--- a/internal/command/test.go
+++ b/internal/command/test.go
@@ -201,14 +201,7 @@ func (c *TestCommand) Run(rawArgs []string) int {
 		}
 	} else {
 
-		// JUnit output is only compatible with local test execution
-		var junitFile junit.JUnit
-		if args.JUnitXMLFile != "" {
-			// Make sure TestCommand's calls loadConfigWithTests before this code, so configLoader is not nil
-			junitFile = junit.NewTestJUnitXMLFile(args.JUnitXMLFile, c.configLoader)
-		}
-
-		runner = &local.TestSuiteRunner{
+		localRunner := &local.TestSuiteRunner{
 			Config: config,
 			// The GlobalVariables are loaded from the
 			// main configuration directory
@@ -219,7 +212,6 @@ func (c *TestCommand) Run(rawArgs []string) int {
 			TestingDirectory:    args.TestDirectory,
 			Opts:                opts,
 			View:                view,
-			JUnit:               junitFile,
 			Stopped:             false,
 			Cancelled:           false,
 			StoppedCtx:          stopCtx,
@@ -227,6 +219,14 @@ func (c *TestCommand) Run(rawArgs []string) int {
 			Filter:              args.Filter,
 			Verbose:             args.Verbose,
 		}
+
+		// JUnit output is only compatible with local test execution
+		if args.JUnitXMLFile != "" {
+			// Make sure TestCommand's calls loadConfigWithTests before this code, so configLoader is not nil
+			localRunner.JUnit = junit.NewTestJUnitXMLFile(args.JUnitXMLFile, c.configLoader)
+		}
+
+		runner = localRunner
 	}
 
 	var testDiags tfdiags.Diagnostics

--- a/internal/command/test.go
+++ b/internal/command/test.go
@@ -121,12 +121,6 @@ func (c *TestCommand) Run(rawArgs []string) int {
 		return 1
 	}
 
-	var junitFile junit.JUnit
-	if args.JUnitXMLFile != "" {
-		// This line must happen after the TestCommand's calls loadConfigWithTests and has the configLoader field set
-		junitFile = junit.NewTestJUnitXMLFile(args.JUnitXMLFile, c.configLoader)
-	}
-
 	// Users can also specify variables via the command line, so we'll parse
 	// all that here.
 	var items []arguments.FlagNameValue
@@ -206,6 +200,14 @@ func (c *TestCommand) Run(rawArgs []string) int {
 			Streams:          c.Streams,
 		}
 	} else {
+
+		// JUnit output is only compatible with local test execution
+		var junitFile junit.JUnit
+		if args.JUnitXMLFile != "" {
+			// Make sure TestCommand's calls loadConfigWithTests before this code, so configLoader is not nil
+			junitFile = junit.NewTestJUnitXMLFile(args.JUnitXMLFile, c.configLoader)
+		}
+
 		runner = &local.TestSuiteRunner{
 			Config: config,
 			// The GlobalVariables are loaded from the

--- a/internal/command/test.go
+++ b/internal/command/test.go
@@ -123,24 +123,6 @@ func (c *TestCommand) Run(rawArgs []string) int {
 
 	var junitFile junit.JUnit
 	if args.JUnitXMLFile != "" {
-		// JUnit XML output is currently experimental, so that we can gather
-		// feedback on exactly how we should map the test results to this
-		// JUnit-oriented format before anyone starts depending on it for real.
-		if !c.AllowExperimentalFeatures {
-			diags = diags.Append(tfdiags.Sourceless(
-				tfdiags.Error,
-				"JUnit XML output is not available",
-				"The -junit-xml option is currently experimental and therefore available only in alpha releases of Terraform CLI.",
-			))
-			view.Diagnostics(nil, nil, diags)
-			return 1
-		}
-		diags = diags.Append(tfdiags.Sourceless(
-			tfdiags.Warning,
-			"JUnit XML output is experimental",
-			"The -junit-xml option is currently experimental and therefore subject to breaking changes or removal, even in patch releases.",
-		))
-
 		// This line must happen after the TestCommand's calls loadConfigWithTests and has the configLoader field set
 		junitFile = junit.NewTestJUnitXMLFile(args.JUnitXMLFile, c.configLoader)
 	}


### PR DESCRIPTION
This PR promotes the `-junit-xml` flag and JUnit output from `terraform test` out of experimental status.

Documentation changes for this are in another PR: https://github.com/hashicorp/terraform/pull/36307

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.11.x

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory.

-->

- [x] This change is user-facing and I added a changelog entry.
- [ ] This change is not user-facing.
