### PR TITLE
Remove unneeded change file from v1.11 release branch

### DIFF
--- a/.changes/unreleased/ENHANCEMENTS-20250108-104335.yaml
+++ b/.changes/unreleased/ENHANCEMENTS-20250108-104335.yaml
@@ -1,5 +1,0 @@
-kind: ENHANCEMENTS
-body: Changed the text in errors returned from Terraform when a non-null value is found for a write-only attribute.
-time: 2025-01-08T10:43:35.241109Z
-custom:
-    Issue: "36274"


### PR DESCRIPTION
This change log entry isn't needed, and instead of deleting it from the generated changelog content we're removing the file. This will allow the changelog to be re-generated correctly.

Addresses https://github.com/hashicorp/terraform/pull/36328#discussion_r1916672632