### PR TITLE
Update the docs for tfstack config output blocks

### DIFF
--- a/website/docs/language/stacks/reference/tfstack.mdx
+++ b/website/docs/language/stacks/reference/tfstack.mdx
@@ -100,7 +100,7 @@ This section provides details about the fields you can configure in the `variabl
 
 Use the `output` block to make information about your infrastructure available in the HCP Terraform UI to expose information about your Stack. The `output` block functions the same way in Stack configuration as it does in traditional Terraform configurations with a few small differences. 
 
-In Stack configurations, `output` blocks do not support the `type` or `sensitive` fields, and they do not support the `preconditions` argument. Learn more about [Outputs](/terraform/language/values/outputs).
+In Stack configurations, `output` blocks require the `type` argument, and they do not support the `preconditions` block. Learn more about [Outputs](/terraform/language/values/outputs).
 
 ### Complete configuration
 
@@ -108,7 +108,10 @@ When every field is defined, an `output` block has the following form:
 ```hcl
 output "unique_name_of_output" {
   description = "Description of the purpose of this output"
+  type        = string
   value       = component.component_name.some_value
+  sensitive   = false
+  ephemeral   = false
 }
 ```
 
@@ -119,7 +122,10 @@ This section provides details about the fields you can configure in the `output`
 | Field | Description | Type | Required |
 | :---- | :---- | :---- | :---- |
 | `description` | A human-friendly description for the output. | string | Optional |
+| `type` | The type of the output. | type constraint | Required |
 | `value` | The value to output. | any | Required |
+| `sensitive` | Whether to hide the output in UI. | bool | Optional |
+| `ephemeral` | Whether to exclude the value from plans and state data. | bool | Optional |
 
 ## `required_providers` and `provider` block configuration
 

--- a/website/docs/language/stacks/reference/tfstack.mdx
+++ b/website/docs/language/stacks/reference/tfstack.mdx
@@ -124,7 +124,7 @@ This section provides details about the fields you can configure in the `output`
 | `description` | A human-friendly description for the output. | string | Optional |
 | `type` | The type of the output. | type constraint | Required |
 | `value` | The value to output. | any | Required |
-| `sensitive` | Whether to hide the output in UI. | bool | Optional |
+| `sensitive` | Marks the variable as sensitive, which prevents its value from being displayed in logs or in the HCP Terraform UI.  | bool | Optional |
 | `ephemeral` | Whether to exclude the value from plans and state data. | bool | Optional |
 
 ## `required_providers` and `provider` block configuration


### PR DESCRIPTION
The docs for the variant of the `output` block available in tfstack configurations were wrong — here's the fix.

To verify the schema for yourself, check its definition at the bottom of `internal/stacks/stackconfig/output_value.go` in this repo. (I also ran an experiment to make sure, and yep: sensitive is supported as optional, and type is mandatory.)

Q for education team reviewers: which branch is the [web version of these docs](https://developer.hashicorp.com/terraform/language/stacks/reference/tfstack#output-block-configuration) sourced from? Does it come straight out of main? 

## Target Release

1.11.x

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory.

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
