### PR TITLE
Make test fail if the JUnit `terraform test` feature is experimental

### DIFF
--- a/internal/command/test_test.go
+++ b/internal/command/test_test.go
@@ -2378,9 +2378,8 @@ func TestTest_JUnitOutput(t *testing.T) {
 
 			c := &TestCommand{
 				Meta: Meta{
-					testingOverrides:          metaOverridesForProvider(provider.Provider),
-					View:                      view,
-					AllowExperimentalFeatures: true,
+					testingOverrides: metaOverridesForProvider(provider.Provider),
+					View:             view,
 				},
 			}
 


### PR DESCRIPTION
This change protects against the JUnit `terraform test` feature accidentally becoming experimental again.

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.11.x

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
