### PR TITLE
Update CHANGELOG.md using new Changie automation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.11.0-beta1 (January 15, 2025)
+## 1.11.0-beta1 (January 16, 2025)
 
 
 NEW FEATURES:
@@ -17,6 +17,8 @@ ENHANCEMENTS:
 * New command `modules -json`: Displays a full list of all installed modules in a working directory, including whether each module is currently referenced by the working directory's configuration. ([#35884](https://github.com/hashicorp/terraform/issues/35884))
 
 * `terraform test`: Test runs now support using mocked or overridden values during unit test runs (e.g., with command = "plan"). Set `override_during = plan` in the test configuration to use the overridden values during the plan phase. The default value is `override_during = apply`. ([#36227](https://github.com/hashicorp/terraform/issues/36227))
+
+* `terraform test`: Add new `state_key` attribute for `run` blocks, allowing test authors control over which internal state file should be used for the current test run. ([#36185](https://github.com/hashicorp/terraform/issues/36185))
 
 
 BUG FIXES:


### PR DESCRIPTION
Last update to the CHANGELOG before releasing 1.11-beta1.

These changes include running `./scripts/changelog.sh generate beta` which pulled in new change files from .changie/unreleased. We also needed to stop the automation from deleting a direct edit that was made to the CHANGELOG file and didn't have a matching change file.

We need to discuss processes around this, but we're likely to want change files to be the only source of truth in future.