### PR TITLE
Small docu typo fixes in debugging.md

### DIFF
--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -1,6 +1,6 @@
 # How to Debug Terraform
 
-As Terraform is written in Go you may use [delve](https://github.com/go-delve/delve) to debug it.
+As Terraform is written in Go you may use [Delve](https://github.com/go-delve/delve) to debug it.
 
 ## 1. Compile & Start Debug Server
 
@@ -10,7 +10,7 @@ One way to do it is to compile a binary with the [appropriate compiler flags](ht
 go install -gcflags="all=-N -l"
 ```
 
-This enables you to then execute the compiled binary via delve, pass any arguments as spin up a debug server which you can then connect to:
+This enables you to then execute the compiled binary via Delve, pass any arguments and spin up a debug server which you can then connect to:
 
 ```sh
 dlv exec $GOBIN/terraform --headless --listen :2345 --log -- apply
@@ -18,7 +18,7 @@ dlv exec $GOBIN/terraform --headless --listen :2345 --log -- apply
 
 ## 2a. Connect via CLI
 
-You may connect to the headless debug server via delve CLI
+You may connect to the headless debug server via Delve CLI
 
 ```sh
 dlv connect :2345


### PR DESCRIPTION
fixed a typo and changed all lower case delve to Delve since thats how delve them selfs write it

<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Fixes #

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.11.x

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [ ] This change is not user-facing.
