### PR TITLE
Upgraded github.com/hashicorp/go-slug v0.16.0 => v0.16.3

### DIFF
--- a/.changes/backported/BUG FIXES-20250122-083138.yaml
+++ b/.changes/backported/BUG FIXES-20250122-083138.yaml
@@ -1,0 +1,5 @@
+kind: BUG FIXES
+body: Updated dependency github.com/hashicorp/go-slug v0.16.0 => v0.16.3 to integrate latest changes (fix for CVE-2025-0377)
+time: 2025-01-22T08:31:38.004275+01:00
+custom:
+    Issue: "36273"


### PR DESCRIPTION
We backported the security fix in https://github.com/hashicorp/terraform/pull/36375. The relevant changelog entry should go into the next v1.10 release instead of the v1.11 release.