### PR TITLE
remove go-slug upgrade from v1.11 changelog

### DIFF
--- a/.changes/backported/BUG FIXES-20250108-173554.yaml
+++ b/.changes/backported/BUG FIXES-20250108-173554.yaml
@@ -1,5 +1,0 @@
-kind: BUG FIXES
-body: Updated dependency `github.com/hashicorp/go-slug` `v0.16.0` => `v0.16.3` to integrate latest changes (fix for CVE-2025-0377)
-time: 2025-01-08T17:35:54.566608Z
-custom:
-    Issue: "36273"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,11 +19,6 @@ ENHANCEMENTS:
 * `terraform test`: Add new `state_key` attribute for `run` blocks, allowing test authors control over which internal state file should be used for the current test run. ([#36185](https://github.com/hashicorp/terraform/issues/36185))
 
 
-BUG FIXES:
-
-* Updated dependency `github.com/hashicorp/go-slug` `v0.16.0` => `v0.16.3` to integrate latest changes (fix for CVE-2025-0377) ([#36273](https://github.com/hashicorp/terraform/issues/36273))
-
-
 ## Previous Releases
 
 For information on prior major and minor releases, refer to their changelogs:


### PR DESCRIPTION
We want the security fix to be released in v1.10 instead of v1.11. This has all been made to happen in https://github.com/hashicorp/terraform/pull/36375 and https://github.com/hashicorp/terraform/pull/36377. The last thing is that because the CHANGELOG entry is going into v1.10 we should remove it from v1.11 as well.