### PR TITLE
Use context instead of channel to signal cancellation from the caller to child nodes in the graph

### DIFF
--- a/internal/dag/dag.go
+++ b/internal/dag/dag.go
@@ -4,6 +4,7 @@
 package dag
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"sort"
@@ -272,9 +273,11 @@ func (g *AcyclicGraph) Cycles() [][]Vertex {
 // Walk walks the graph, calling your callback as each node is visited.
 // This will walk nodes in parallel if it can. The resulting diagnostics
 // contains problems from all graphs visited, in no particular order.
-func (g *AcyclicGraph) Walk(cb WalkFunc) tfdiags.Diagnostics {
-	w := &Walker{Callback: cb, Reverse: true}
-	w.Update(g)
+// The context here will be inherited by all nodes in the graph, and
+// the caller can use this to signal cancellation of the graph walk.
+func (g *AcyclicGraph) Walk(ctx context.Context, cb WalkFunc) tfdiags.Diagnostics {
+	w := NewWalker(cb)
+	w.Update(ctx, g)
 	return w.Wait()
 }
 

--- a/internal/dag/dag_test.go
+++ b/internal/dag/dag_test.go
@@ -4,6 +4,7 @@
 package dag
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"os"
@@ -396,7 +397,7 @@ func TestAcyclicGraphWalk(t *testing.T) {
 
 	var visits []Vertex
 	var lock sync.Mutex
-	err := g.Walk(func(v Vertex) tfdiags.Diagnostics {
+	err := g.Walk(context.Background(), func(v Vertex) tfdiags.Diagnostics {
 		lock.Lock()
 		defer lock.Unlock()
 		visits = append(visits, v)
@@ -431,7 +432,7 @@ func TestAcyclicGraphWalk_error(t *testing.T) {
 
 	var visits []Vertex
 	var lock sync.Mutex
-	err := g.Walk(func(v Vertex) tfdiags.Diagnostics {
+	err := g.Walk(context.Background(), func(v Vertex) tfdiags.Diagnostics {
 		lock.Lock()
 		defer lock.Unlock()
 

--- a/internal/dag/walk_test.go
+++ b/internal/dag/walk_test.go
@@ -4,6 +4,7 @@
 package dag
 
 import (
+	"context"
 	"fmt"
 	"reflect"
 	"sync"
@@ -23,7 +24,7 @@ func TestWalker_basic(t *testing.T) {
 	for i := 0; i < 50; i++ {
 		var order []interface{}
 		w := &Walker{Callback: walkCbRecord(&order)}
-		w.Update(&g)
+		w.Update(context.Background(), &g)
 
 		// Wait
 		if err := w.Wait(); err != nil {
@@ -48,8 +49,8 @@ func TestWalker_updateNilGraph(t *testing.T) {
 	for i := 0; i < 50; i++ {
 		var order []interface{}
 		w := &Walker{Callback: walkCbRecord(&order)}
-		w.Update(&g)
-		w.Update(nil)
+		w.Update(context.Background(), &g)
+		w.Update(context.Background(), nil)
 
 		// Wait
 		if err := w.Wait(); err != nil {
@@ -84,7 +85,7 @@ func TestWalker_error(t *testing.T) {
 	}
 
 	w := &Walker{Callback: cb}
-	w.Update(&g)
+	w.Update(context.Background(), &g)
 
 	// Wait
 	if err := w.Wait(); err == nil {
@@ -120,18 +121,18 @@ func TestWalker_newVertex(t *testing.T) {
 
 	// Add the initial vertices
 	w = &Walker{Callback: cb}
-	w.Update(&g)
+	w.Update(context.Background(), &g)
 
 	// if 2 has been visited, the walk is complete so far
 	<-done2
 
 	// Update the graph
 	g.Add(3)
-	w.Update(&g)
+	w.Update(context.Background(), &g)
 
 	// Update the graph again but with the same vertex
 	g.Add(3)
-	w.Update(&g)
+	w.Update(context.Background(), &g)
 
 	// Wait
 	if err := w.Wait(); err != nil {
@@ -159,7 +160,7 @@ func TestWalker_removeVertex(t *testing.T) {
 	cb := func(v Vertex) tfdiags.Diagnostics {
 		if v == 1 {
 			g.Remove(2)
-			w.Update(&g)
+			w.Update(context.Background(), &g)
 		}
 
 		return recordF(v)
@@ -167,7 +168,7 @@ func TestWalker_removeVertex(t *testing.T) {
 
 	// Add the initial vertices
 	w = &Walker{Callback: cb}
-	w.Update(&g)
+	w.Update(context.Background(), &g)
 
 	// Wait
 	if err := w.Wait(); err != nil {
@@ -200,14 +201,14 @@ func TestWalker_newEdge(t *testing.T) {
 		if v == 1 {
 			g.Add(3)
 			g.Connect(BasicEdge(3, 2))
-			w.Update(&g)
+			w.Update(context.Background(), &g)
 		}
 		return diags
 	}
 
 	// Add the initial vertices
 	w = &Walker{Callback: cb}
-	w.Update(&g)
+	w.Update(context.Background(), &g)
 
 	// Wait
 	if err := w.Wait(); err != nil {
@@ -248,7 +249,7 @@ func TestWalker_removeEdge(t *testing.T) {
 		switch v {
 		case 1:
 			g.RemoveEdge(BasicEdge(3, 2))
-			w.Update(&g)
+			w.Update(context.Background(), &g)
 			t.Logf("removed edge from 3 to 2")
 
 		case 2:
@@ -275,7 +276,7 @@ func TestWalker_removeEdge(t *testing.T) {
 
 	// Add the initial vertices
 	w = &Walker{Callback: cb}
-	w.Update(&g)
+	w.Update(context.Background(), &g)
 
 	// Wait
 	if diags := w.Wait(); diags.HasErrors() {

--- a/internal/terraform/eval_context.go
+++ b/internal/terraform/eval_context.go
@@ -32,7 +32,7 @@ type hookFunc func(func(Hook) (HookAction, error)) error
 
 // EvalContext is the interface that is given to eval nodes to execute.
 type EvalContext interface {
-	// Stopped returns a context that is canceled when evaluation is stopped via
+	// StopCtx returns a context that is canceled when evaluation is stopped via
 	// Terraform.Context.Stop()
 	StopCtx() context.Context
 


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Fixes #

Using context allows us to signal all child nodes for cancellation from the caller that built the graph. This will be useful in Terraform test, where user might cancel the running tests, and we want to shutdown gracefully.

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.11.x

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [ ] This change is not user-facing.
