### PR TITLE
tfdiags: Add Warnings method to filter by severity

### DIFF
--- a/internal/command/junit/junit.go
+++ b/internal/command/junit/junit.go
@@ -250,7 +250,7 @@ func junitXMLTestReport(suite *moduletest.Suite, suiteRunnerStopped bool, source
 				if run.Status == moduletest.Error && run.Diagnostics.HasWarnings() {
 					// If the test case errored, then all Error diags are in the "error" element
 					// Therefore we'd only need to include warnings in "system-err"
-					systemErrDiags = getWarnings(run.Diagnostics)
+					systemErrDiags = run.Diagnostics.Warnings()
 				}
 
 				if run.Status != moduletest.Error {
@@ -353,17 +353,4 @@ func getDiagString(diags tfdiags.Diagnostics, sources map[string][]byte) string 
 		diagsStr.WriteString(format.DiagnosticPlain(d, sources, 80))
 	}
 	return diagsStr.String()
-}
-
-func getWarnings(diags tfdiags.Diagnostics) tfdiags.Diagnostics {
-	// Collect warnings
-	warnDiags := tfdiags.Diagnostics{}
-	if diags.HasWarnings() {
-		for _, d := range diags {
-			if d.Severity() == tfdiags.Warning {
-				warnDiags = warnDiags.Append(d)
-			}
-		}
-	}
-	return warnDiags
 }

--- a/internal/command/junit/junit_internal_test.go
+++ b/internal/command/junit/junit_internal_test.go
@@ -8,10 +8,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/terraform/internal/moduletest"
-	"github.com/hashicorp/terraform/internal/tfdiags"
 )
 
 func Test_TestJUnitXMLFile_save(t *testing.T) {
@@ -65,64 +62,6 @@ func Test_TestJUnitXMLFile_save(t *testing.T) {
 
 			if !bytes.Equal(fileContent, xml) {
 				t.Fatalf("wanted XML:\n%s\n got XML:\n%s\n", string(xml), string(fileContent))
-			}
-		})
-	}
-}
-
-func Test_getWarnings(t *testing.T) {
-	errorDiag := &hcl.Diagnostic{
-		Severity: hcl.DiagError,
-		Summary:  "error",
-		Detail:   "this is an error",
-	}
-
-	warnDiag := &hcl.Diagnostic{
-		Severity: hcl.DiagWarning,
-		Summary:  "warning",
-		Detail:   "this is a warning",
-	}
-
-	cases := map[string]struct {
-		diags    tfdiags.Diagnostics
-		expected tfdiags.Diagnostics
-	}{
-		"empty diags": {
-			diags:    tfdiags.Diagnostics{},
-			expected: tfdiags.Diagnostics{},
-		},
-		"nil diags": {
-			diags:    nil,
-			expected: tfdiags.Diagnostics{},
-		},
-		"all error diags": {
-			diags: func() tfdiags.Diagnostics {
-				var d tfdiags.Diagnostics
-				d = d.Append(errorDiag, errorDiag, errorDiag)
-				return d
-			}(),
-			expected: tfdiags.Diagnostics{},
-		},
-		"mixture of error and warning diags": {
-			diags: func() tfdiags.Diagnostics {
-				var d tfdiags.Diagnostics
-				d = d.Append(errorDiag, errorDiag, warnDiag) // 1 warning
-				return d
-			}(),
-			expected: func() tfdiags.Diagnostics {
-				var d tfdiags.Diagnostics
-				d = d.Append(warnDiag) // 1 warning
-				return d
-			}(),
-		},
-	}
-
-	for tn, tc := range cases {
-		t.Run(tn, func(t *testing.T) {
-			warnings := getWarnings(tc.diags)
-
-			if diff := cmp.Diff(tc.expected, warnings, tfdiags.DiagnosticComparer); diff != "" {
-				t.Errorf("wrong diagnostics\n%s", diff)
 			}
 		})
 	}

--- a/internal/tfdiags/diagnostics.go
+++ b/internal/tfdiags/diagnostics.go
@@ -142,6 +142,17 @@ func diagnosticsForError(err error) []Diagnostic {
 	}
 }
 
+// Warnings returns a Diagnostics list containing only diagnostics with a severity of Warning.
+func (diags Diagnostics) Warnings() Diagnostics {
+	var warns = Diagnostics{}
+	for _, diag := range diags {
+		if diag.Severity() == Warning {
+			warns = append(warns, diag)
+		}
+	}
+	return warns
+}
+
 // HasErrors returns true if any of the diagnostics in the list have
 // a severity of Error.
 func (diags Diagnostics) HasErrors() bool {


### PR DESCRIPTION
Closes #36387

This change adds a new method to the `tfdiags` API: `Warnings` returns a new [Diagnostics](https://pkg.go.dev/github.com/hashicorp/terraform/tfdiags#Diagnostics) list containing only diagnostics with a severity of Warning.

This simplifies iterating over a list of diagnostics by a Warning severity:

```
if diags.HasWarnings() {
	for _, v := range diags.Warnings() {
	}
}
```

Instead of
```
if diags.HasWarnings() {
	for _, diag := range diags {
		if diag.Severity() == Warning {
		}
	}
}
```

It also replaces the existing `getWarnings` function in the `junit` package, which served as a reference for this implementation. Nice work on the `DiagnosticComparer` @SarahFrench!