### PR TITLE
orphaned resources must be refreshed before plan

### DIFF
--- a/.changes/unreleased/BUG FIXES-20250123-150746.yaml
+++ b/.changes/unreleased/BUG FIXES-20250123-150746.yaml
@@ -1,0 +1,5 @@
+kind: BUG FIXES
+body: Refreshed state was not used in the plan for orphaned resource instances
+time: 2025-01-23T15:07:46.789595-05:00
+custom:
+    Issue: "36394"


### PR DESCRIPTION
The order of operations was incorrect here, with the refresh happening after the plan was already created. Invert the calls so the updated state is reflected in the plan output.

We don't need to carry forward the defer response from refresh, since in the rare case that a read does need to be deferred, the PlanResourceChange call will return the same response.


Fixes #35568

## Target Release

1.11.x

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [x] This change is user-facing and I added a changelog entry.
- [ ] This change is not user-facing.
