### PR TITLE
F output type

### DIFF
--- a/internal/configs/testdata/valid-files/output-type-constraint.tf
+++ b/internal/configs/testdata/valid-files/output-type-constraint.tf
@@ -1,0 +1,11 @@
+output "string" {
+  type  = string
+  value = "Hello"
+}
+
+output "object" {
+  type = object({
+    name = optional(string, "Bart"),
+  })
+  value = {}
+}

--- a/internal/terraform/node_output.go
+++ b/internal/terraform/node_output.go
@@ -8,7 +8,9 @@ import (
 	"log"
 
 	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/ext/typeexpr"
 	"github.com/zclconf/go-cty/cty"
+	"github.com/zclconf/go-cty/cty/convert"
 
 	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/configs"
@@ -436,7 +438,7 @@ func (n *NodeApplyableOutput) Execute(ctx EvalContext, op walkOperation) (diags 
 			// This has to run before we have a state lock, since evaluation also
 			// reads the state
 			var evalDiags tfdiags.Diagnostics
-			val, evalDiags = ctx.EvaluateExpr(n.Config.Expr, cty.DynamicPseudoType, nil)
+			val, evalDiags = evalOutputValue(ctx, n.Config.Expr, n.Config.ConstraintType, n.Config.TypeDefaults)
 			diags = diags.Append(evalDiags)
 
 			// We'll handle errors below, after we have loaded the module.
@@ -527,6 +529,38 @@ If you do intend to export this data, annotate the output value as sensitive by 
 	}
 
 	return diags
+}
+
+// evalOutputValue encapsulates the logic for transforming an author's value
+// expression into a valid value of their declared type constraint, or returning
+// an error describing why that isn't possible.
+func evalOutputValue(ctx EvalContext, expr hcl.Expression, wantType cty.Type, defaults *typeexpr.Defaults) (cty.Value, tfdiags.Diagnostics) {
+	// We can't pass wantType to EvaluateExpr here because we'll need to
+	// possibly apply our defaults before attempting type conversion below.
+	val, diags := ctx.EvaluateExpr(expr, cty.DynamicPseudoType, nil)
+	if diags.HasErrors() {
+		return cty.UnknownVal(wantType), diags
+	}
+
+	if defaults != nil {
+		val = defaults.Apply(val)
+	}
+
+	val, err := convert.Convert(val, wantType)
+	if err != nil {
+		diags = diags.Append(&hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  "Invalid output value",
+			Detail:   fmt.Sprintf("The value expression does not match this output value's type constraint: %s.", tfdiags.FormatError(err)),
+			Subject:  expr.Range().Ptr(),
+			// TODO: Populate EvalContext and Expression, but we can't do that
+			// as long as we're using the ctx.EvaluateExpr helper above because
+			// the EvalContext is hidden from us in that case.
+		})
+		return cty.UnknownVal(wantType), diags
+	}
+
+	return val, diags
 }
 
 // dag.GraphNodeDotter impl.

--- a/internal/terraform/node_output_test.go
+++ b/internal/terraform/node_output_test.go
@@ -25,7 +25,7 @@ func TestNodeApplyableOutputExecute_knownValue(t *testing.T) {
 	ctx.ChecksState = checks.NewState(nil)
 	ctx.DeferralsState = deferring.NewDeferred(false)
 
-	config := &configs.Output{Name: "map-output"}
+	config := &configs.Output{Name: "map-output", ConstraintType: cty.DynamicPseudoType}
 	addr := addrs.OutputValue{Name: config.Name}.Absolute(addrs.RootModuleInstance)
 	node := &NodeApplyableOutput{Config: config, Addr: addr}
 	val := cty.MapVal(map[string]cty.Value{
@@ -55,7 +55,7 @@ func TestNodeApplyableOutputExecute_knownValue(t *testing.T) {
 func TestNodeApplyableOutputExecute_noState(t *testing.T) {
 	ctx := new(MockEvalContext)
 
-	config := &configs.Output{Name: "map-output"}
+	config := &configs.Output{Name: "map-output", ConstraintType: cty.DynamicPseudoType}
 	addr := addrs.OutputValue{Name: config.Name}.Absolute(addrs.RootModuleInstance)
 	node := &NodeApplyableOutput{Config: config, Addr: addr}
 	val := cty.MapVal(map[string]cty.Value{
@@ -83,6 +83,7 @@ func TestNodeApplyableOutputExecute_invalidDependsOn(t *testing.T) {
 				hcl.TraverseAttr{Name: "bar"},
 			},
 		},
+		ConstraintType: cty.DynamicPseudoType,
 	}
 	addr := addrs.OutputValue{Name: config.Name}.Absolute(addrs.RootModuleInstance)
 	node := &NodeApplyableOutput{Config: config, Addr: addr}
@@ -105,7 +106,7 @@ func TestNodeApplyableOutputExecute_sensitiveValueNotOutput(t *testing.T) {
 	ctx.StateState = states.NewState().SyncWrapper()
 	ctx.ChecksState = checks.NewState(nil)
 
-	config := &configs.Output{Name: "map-output"}
+	config := &configs.Output{Name: "map-output", ConstraintType: cty.DynamicPseudoType}
 	addr := addrs.OutputValue{Name: config.Name}.Absolute(addrs.RootModuleInstance)
 	node := &NodeApplyableOutput{Config: config, Addr: addr}
 	val := cty.MapVal(map[string]cty.Value{
@@ -129,8 +130,9 @@ func TestNodeApplyableOutputExecute_sensitiveValueAndOutput(t *testing.T) {
 	ctx.DeferralsState = deferring.NewDeferred(false)
 
 	config := &configs.Output{
-		Name:      "map-output",
-		Sensitive: true,
+		Name:           "map-output",
+		Sensitive:      true,
+		ConstraintType: cty.DynamicPseudoType,
 	}
 	addr := addrs.OutputValue{Name: config.Name}.Absolute(addrs.RootModuleInstance)
 	node := &NodeApplyableOutput{Config: config, Addr: addr}

--- a/internal/terraform/testdata/apply-output-type-constraint/apply-output-type-constraint.tf
+++ b/internal/terraform/testdata/apply-output-type-constraint/apply-output-type-constraint.tf
@@ -1,0 +1,20 @@
+output "string" {
+  type  = string
+  value = true
+}
+
+output "object_default" {
+  type = object({
+    name = optional(string, "Bart")
+  })
+  value = {}
+}
+
+output "object_override" {
+  type = object({
+    name = optional(string, "Bart")
+  })
+  value = {
+    name = "Lisa"
+  }
+}


### PR DESCRIPTION
This PR introduces support for declaring explicit type constraints in output blocks. It picks up the work that Martin did some time ago in https://github.com/hashicorp/terraform/pull/31728.

We could also introduce this as an experiment, available only in alpha releases, if we want to learn if a new argument inside the output block is the most ideal design for it.

## UX

```hcl
output "string" {
  type  = string
  value = var.some_string
}
```

Constraint mismatches are raised as an error

![CleanShot 2025-02-03 at 17 52 56@2x](https://github.com/user-attachments/assets/f4665519-233c-4d0a-9d4a-aed3b021f982)

Fixes #

## Target Release

1.11.x

## CHANGELOG entry

- [x] This change is user-facing and I added a changelog entry.
- [ ] This change is not user-facing.
