### PR TITLE
changelog: handle dev releases without changes on non-empty changelogs

### DIFF
--- a/scripts/changelog.sh
+++ b/scripts/changelog.sh
@@ -64,9 +64,11 @@ function generate {
         npx -y changie@$CHANGIE_VERSION merge -u "## $LATEST_VERSION (Unreleased)"
         
         # If we have no changes yet, the changelog is empty now, so we need to add a header
-        if [[ ! -s CHANGELOG.md ]]; then
+        if ! grep -q "## $LATEST_VERSION" CHANGELOG.md; then
+            CURRENT_CHANGELOG=$(cat CHANGELOG.md)
             echo "## $LATEST_VERSION (Unreleased)" > CHANGELOG.md
             echo "" >> CHANGELOG.md
+            echo "$CURRENT_CHANGELOG" >> CHANGELOG.md
         fi
         ;;
 


### PR DESCRIPTION
Small adjustment to make sure we habe the `## 1.X.X (Unreleased)` line even if patch releases already exist on the branch.

<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Fixes #

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.11.x

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.