### PR TITLE
Update build action to build correct branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,11 @@ name: build
 
 on:
   workflow_dispatch:
+    inputs:
+      target-branch:
+        description: "The branch, tag, or git commit sha to build"
+        required: true
+        default: "main"
   workflow_run:
     workflows: ["Quick Checks"]
     types:
@@ -29,10 +34,33 @@ permissions:
   statuses: write
 
 jobs:
+  get-target-branch:
+    name: "Determine target branch based on event"
+    runs-on: ubuntu-latest
+    outputs:
+      target-branch: ${{ steps.get-target-branch.outputs.target-branch }}
+    steps:
+      - name: Determine target branch
+        id: get-target-branch
+        run: |
+          if [[ "${{ github.event_name }}" == "workflow_run" ]]; then
+            target_branch=${{ github.event.workflow_run.head_sha }}
+          elif [[ "${{ github.event_name }}" == "push" ]]; then
+            target_branch=${{ github.ref }}
+          elif [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            target_branch=${{ github.event.inputs.target-branch }}
+          else
+            echo "Unexpected event name: ${{ github.event_name }}"
+            exit 1
+          fi
+          echo "target-branch=${target_branch}" | tee -a "${GITHUB_OUTPUT}"
+
   get-product-version:
     name: "Determine intended Terraform version"
     if: ${{ github.event.action != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
+    needs:
+      - get-target-branch
     outputs:
       product-version: ${{ steps.get-product-version.outputs.product-version }}
       product-version-base: ${{ steps.get-product-version.outputs.base-product-version }}
@@ -43,6 +71,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ needs.get-target-branch.outputs.target-branch }}
       - name: Get Package Name
         id: get-pkg-name
         run: |


### PR DESCRIPTION
We haven't been building the correct branches recently because we've just been checking out whatever `main` is for all the `build` actions.

This updates the build action to work out the correct branch based on the method the build action was triggered.