### PR TITLE
Update changelog.yml so there are necessary permissions to run on PRs from forked repos

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -3,7 +3,7 @@
 name: Changelog
 
 on:
-  pull_request:
+  pull_request_target:
     types:
       - opened
       - ready_for_review

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,8 +1,13 @@
 # This workflow makes sure contributors don't forget to add a changelog entry or explicitly opt-out of it.
+# 
+# Do not extend this workflow to include checking out the code (e.g. for building and testing purposes) while the pull_request_target trigger is used.
+# Instead, see use of workflow_run in https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/
 
 name: Changelog
 
 on:
+  # The pull_request_target trigger event allows PRs raised from forks to have write permissions and access secrets.
+  # We uses it in this workflow to enable writing comments to the PR.
   pull_request_target:
     types:
       - opened
@@ -12,9 +17,9 @@ on:
       - labeled
       - unlabeled
 
-# This workflow runs for not-yet-reviewed external contributions and so it
-# intentionally has no write access and only limited read access to the
-# repository.
+# This workflow runs for not-yet-reviewed external contributions.
+# Following a pull_request_target trigger the workflow would have write permissions,
+# so we intentionally restrict the permissions to only include write access on pull-requests.
 permissions:
   contents: read
   pull-requests: write


### PR DESCRIPTION
Currently the GHA that prompts for users to add a change file or label a PR as not user-facing will fail on PRs raised from forked repos, due to 403 errors when trying to post a comment to the PR. This is because [the GITHUB_TOKEN made in that context](https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#permissions-for-the-github_token) will not include write permissions to pull requests.

Examples of 403 errors resulting from this:
- https://github.com/hashicorp/terraform/actions/runs/13140859146/job/36711885284
- https://github.com/hashicorp/terraform/actions/runs/13151146235/job/36698675615


We cannot save a token as a secret in this repo to be used by PRs from forked repos, as secrets (and variables) are not not passed to the runner when a workflow is triggered from a forked repository.

I think the only solution is to swap to using the [pull_request_target](https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#pull_request_target) trigger event:

> For workflows that are triggered by the pull_request_target event, the GITHUB_TOKEN is granted read/write repository permission unless the permissions key is specified and the workflow can access secrets, even when it is triggered from a fork.

This requires us to be mindful about permissions and to not allow the workflow to be expanded and start to run unsafe code - I've added comments about this to the workflow.

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

N/A

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
