### PR TITLE
Fix diagnostic & avoid variable override via environment

### DIFF
--- a/.changes/backported/BUG FIXES-20250205-36435.yaml
+++ b/.changes/backported/BUG FIXES-20250205-36435.yaml
@@ -1,0 +1,5 @@
+kind: BUG FIXES
+body: Attempting to override a variable during `apply` via `TF_VAR_` environment variable will now yield warning instead of misleading error.
+time: 2025-02-05T12:53:26.000+00:00
+custom:
+    Issue: "36435"

--- a/internal/command/testdata/apply-output-only/main.tf
+++ b/internal/command/testdata/apply-output-only/main.tf
@@ -1,0 +1,7 @@
+variable "shadow" {
+  type = string
+}
+
+output "foo" {
+  value = var.shadow
+}


### PR DESCRIPTION
Fixes #36410

It turns out the ordering of variable source evaluation is correct, it's just the diagnostic message that is wrong due to mixed ordering of arguments to `fmt.Sprintf`.

While the original report in #36410 suggests overriding variables via environment variables to be silently ignored, I think we cannot just make the same argument as was made in https://github.com/hashicorp/terraform/pull/36180

Specifically - We cannot expect users to be deleting autoloadable tfvars files. I do think it's reasonable to expect them to unset environment variables between plan and apply. Also, more importantly we only raise the diagnostic when values differ anyway.

That said after some consideration I chose to propose a warning that is still somewhat ignorable, just possibly noisy. I believe that is a good compromise that will not break workflows but still highlight what we consider anti-pattern.

## Target Release

1.10.x

## CHANGELOG entry

- [x] This change is user-facing and I added a changelog entry.
- [ ] This change is not user-facing.
