### PR TITLE
Don't set default parallelism for cloud runs

### DIFF
--- a/internal/command/arguments/test.go
+++ b/internal/command/arguments/test.go
@@ -78,7 +78,10 @@ func ParseTest(args []string) (*Test, tfdiags.Diagnostics) {
 			"The -junit-xml option is currently not compatible with remote test execution via the -cloud-run flag. If you are interested in JUnit XML output for remotely-executed tests please open an issue in GitHub."))
 	}
 
-	if test.OperationParallelism < 1 {
+	// Only set the default parallelism if this is not a cloud-run test.
+	// A cloud-run test will eventually run its own local test, and if the
+	// user still hasn't set the parallelism, that run will use the default.
+	if test.OperationParallelism < 1 && len(test.CloudRunSource) == 0 {
 		test.OperationParallelism = DefaultParallelism
 	}
 

--- a/internal/command/arguments/test_test.go
+++ b/internal/command/arguments/test_test.go
@@ -146,6 +146,18 @@ func TestParseTest(t *testing.T) {
 			},
 			wantDiags: nil,
 		},
+		"cloud-with-parallelism-0": {
+			args: []string{"-parallelism=0", "-cloud-run=foobar"},
+			want: &Test{
+				CloudRunSource:       "foobar",
+				Filter:               nil,
+				TestDirectory:        "tests",
+				ViewType:             ViewHuman,
+				Vars:                 &Vars{},
+				OperationParallelism: 0,
+			},
+			wantDiags: nil,
+		},
 		"unknown flag": {
 			args: []string{"-boop"},
 			want: &Test{


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Don't set default parallelism for cloud runs. This would just cause the API to upload a parallelism value of `DefaultParallelism`. The cloud run will eventually trigger a local run that would use the default if unset.

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.11.x

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [ ] This change is not user-facing.
