### PR TITLE
backends: Fix crash when interrupting during interactive prompt for values'

### DIFF
--- a/.changes/backported/BUG FIXES-20250206-145217.yaml
+++ b/.changes/backported/BUG FIXES-20250206-145217.yaml
@@ -1,0 +1,5 @@
+kind: BUG FIXES
+body: 'backends: Fix crash when interrupting during interactive prompt for values'
+time: 2025-02-06T14:52:17.033964+01:00
+custom:
+    Issue: "36448"

--- a/internal/backend/backendbase/base.go
+++ b/internal/backend/backendbase/base.go
@@ -57,6 +57,13 @@ func (b Base) ConfigSchema() *configschema.Block {
 func (b Base) PrepareConfig(configVal cty.Value) (cty.Value, tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
 
+	if configVal.IsNull() {
+		// We expect the backend configuration to be an object, so if it's
+		// null for some reason (e.g. because of an interrupt), we'll turn
+		// it into an empty object so that we can still coerce it
+		configVal = cty.EmptyObjectVal
+	}
+
 	schema := b.Schema
 
 	v, err := schema.CoerceValue(configVal)


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

This PR fixes a crash that affects all remote state backends that implement the `backendbase.Base`. When interrupting (Ctrl+c) during Terraform's interactive value prompt, we convert the resulting unknown value to a null value. 
Our generic `PrepareConfig` wasn't prepared to handle nulls and crashed when applying the sdk-like defaults.

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Fixes #36420

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.11.x

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [x] This change is user-facing and I added a changelog entry.
- [ ] This change is not user-facing.
