### PR TITLE
Serialize `AttrSensitivePaths` in a consistent order

### DIFF
--- a/.changes/unreleased/BUG FIXES-20250210-163038.yaml
+++ b/.changes/unreleased/BUG FIXES-20250210-163038.yaml
@@ -1,0 +1,5 @@
+kind: BUG FIXES
+body: Changes to the order of sensitive attributes in the state format would erroneously indicate a plan contained changes when there were none.
+time: 2025-02-10T16:30:38.78853-05:00
+custom:
+    Issue: "36465"

--- a/internal/lang/format/format.go
+++ b/internal/lang/format/format.go
@@ -1,0 +1,68 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package format
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/zclconf/go-cty/cty"
+)
+
+// CtyPath is a helper function to produce a user-friendly string
+// representation of a cty.Path. The result uses a syntax similar to the
+// HCL expression language in the hope of it being familiar to users.
+func CtyPath(path cty.Path) string {
+	var buf strings.Builder
+	for _, step := range path {
+		switch ts := step.(type) {
+		case cty.GetAttrStep:
+			fmt.Fprintf(&buf, ".%s", ts.Name)
+		case cty.IndexStep:
+			buf.WriteByte('[')
+			key := ts.Key
+			keyTy := key.Type()
+			switch {
+			case key.IsNull():
+				buf.WriteString("null")
+			case !key.IsKnown():
+				buf.WriteString("(not yet known)")
+			case keyTy == cty.Number:
+				bf := key.AsBigFloat()
+				buf.WriteString(bf.Text('g', -1))
+			case keyTy == cty.String:
+				buf.WriteString(strconv.Quote(key.AsString()))
+			default:
+				buf.WriteString("...")
+			}
+			buf.WriteByte(']')
+		}
+	}
+	return buf.String()
+}
+
+// ErrorDiag is a helper function to produce a user-friendly string
+// representation of certain special error types that we might want to
+// include in diagnostic messages.
+func ErrorDiag(err error) string {
+	perr, ok := err.(cty.PathError)
+	if !ok || len(perr.Path) == 0 {
+		return err.Error()
+	}
+
+	return fmt.Sprintf("%s: %s", CtyPath(perr.Path), perr.Error())
+}
+
+// ErrorDiagPrefixed is like Error except that it presents any path
+// information after the given prefix string, which is assumed to contain
+// an HCL syntax representation of the value that errors are relative to.
+func ErrorDiagPrefixed(err error, prefix string) string {
+	perr, ok := err.(cty.PathError)
+	if !ok || len(perr.Path) == 0 {
+		return fmt.Sprintf("%s: %s", prefix, err.Error())
+	}
+
+	return fmt.Sprintf("%s%s: %s", prefix, CtyPath(perr.Path), perr.Error())
+}

--- a/internal/lang/marks/paths.go
+++ b/internal/lang/marks/paths.go
@@ -4,9 +4,10 @@
 package marks
 
 import (
-	"fmt"
 	"sort"
+	"strings"
 
+	"github.com/hashicorp/terraform/internal/lang/format"
 	"github.com/zclconf/go-cty/cty"
 )
 
@@ -77,9 +78,17 @@ func MarksEqual(a, b []cty.PathValueMarks) bool {
 
 	less := func(s []cty.PathValueMarks) func(i, j int) bool {
 		return func(i, j int) bool {
+			cmp := strings.Compare(format.CtyPath(s[i].Path), format.CtyPath(s[j].Path))
+
+			switch {
+			case cmp < 0:
+				return true
+			case cmp > 0:
+				return false
+			}
 			// the sort only needs to be consistent, so use the GoString format
 			// to get a comparable value
-			return fmt.Sprintf("%#v", s[i]) < fmt.Sprintf("%#v", s[j])
+			return s[i].Marks.GoString() < s[j].Marks.GoString()
 		}
 	}
 

--- a/internal/moduletest/mocking/values.go
+++ b/internal/moduletest/mocking/values.go
@@ -220,7 +220,7 @@ func (data MockedData) makeKnown(attribute *configschema.Attribute, with cty.Val
 			diags = diags.Append(tfdiags.AttributeValue(
 				tfdiags.Error,
 				"Failed to compute attribute",
-				fmt.Sprintf("Terraform could not compute a value for the target type %s with the mocked data defined at %s with the attribute %q: %s.", attribute.ImpliedType().FriendlyName(), data.Range, fmtPath(append(path, relPath...)), err),
+				fmt.Sprintf("Terraform could not compute a value for the target type %s with the mocked data defined at %s with the attribute %q: %s.", attribute.ImpliedType().FriendlyName(), data.Range, tfdiags.FormatCtyPath(append(path, relPath...)), err),
 				path))
 
 			// We still want to return a valid value here. If the conversion did
@@ -285,7 +285,7 @@ func (data MockedData) getMockedDataForPath(path cty.Path) (cty.Value, tfdiags.D
 				diags = diags.Append(tfdiags.AttributeValue(
 					tfdiags.Error,
 					"Failed to compute attribute",
-					fmt.Sprintf("Terraform expected an object type for attribute %q defined within the mocked data at %s, but found %s.", fmtPath(currentPath), data.Range, current.Type().FriendlyName()),
+					fmt.Sprintf("Terraform expected an object type for attribute %q defined within the mocked data at %s, but found %s.", tfdiags.FormatCtyPath(currentPath), data.Range, current.Type().FriendlyName()),
 					currentPath))
 
 				return cty.NilVal, diags
@@ -303,24 +303,4 @@ func (data MockedData) getMockedDataForPath(path cty.Path) (cty.Value, tfdiags.D
 	}
 
 	return current, diags
-}
-
-func fmtPath(path cty.Path) string {
-	var current string
-
-	first := true
-	for _, step := range path {
-		// Since we only ever parse the attribute steps when finding replacement
-		// values, we can do the same again here.
-		switch step := step.(type) {
-		case cty.GetAttrStep:
-			if first {
-				first = false
-				current = step.Name
-				continue
-			}
-			current = fmt.Sprintf("%s.%s", current, step.Name)
-		}
-	}
-	return current
 }

--- a/internal/moduletest/mocking/values_test.go
+++ b/internal/moduletest/mocking/values_test.go
@@ -809,7 +809,7 @@ func TestComputedValuesForDataSource(t *testing.T) {
 				}),
 			}),
 			expectedFailures: []string{
-				"Terraform expected an object type for attribute \"nested_object\" defined within the mocked data at :0,0-0, but found string.",
+				"Terraform expected an object type for attribute \".nested_object[...]\" defined within the mocked data at :0,0-0, but found string.",
 			},
 		},
 		"invalid_replacement_path_nested_block": {
@@ -846,7 +846,7 @@ func TestComputedValuesForDataSource(t *testing.T) {
 				}),
 			}),
 			expectedFailures: []string{
-				"Terraform expected an object type for attribute \"nested_object\" defined within the mocked data at :0,0-0, but found string.",
+				"Terraform expected an object type for attribute \".nested_object[...]\" defined within the mocked data at :0,0-0, but found string.",
 			},
 		},
 		"invalid_replacement_type": {
@@ -863,7 +863,7 @@ func TestComputedValuesForDataSource(t *testing.T) {
 				"value": cty.StringVal("Hello, world!"),
 			}),
 			expectedFailures: []string{
-				"Terraform could not compute a value for the target type string with the mocked data defined at :0,0-0 with the attribute \"id\": string required.",
+				"Terraform could not compute a value for the target type string with the mocked data defined at :0,0-0 with the attribute \".id\": string required.",
 			},
 		},
 		"invalid_replacement_type_nested": {
@@ -899,7 +899,7 @@ func TestComputedValuesForDataSource(t *testing.T) {
 				}),
 			}),
 			expectedFailures: []string{
-				"Terraform could not compute a value for the target type string with the mocked data defined at :0,0-0 with the attribute \"nested.id\": string required.",
+				`Terraform could not compute a value for the target type string with the mocked data defined at :0,0-0 with the attribute ".nested[\"one\"].id": string required.`,
 			},
 		},
 		"invalid_replacement_type_nested_block": {
@@ -933,7 +933,7 @@ func TestComputedValuesForDataSource(t *testing.T) {
 				}),
 			}),
 			expectedFailures: []string{
-				"Terraform could not compute a value for the target type string with the mocked data defined at :0,0-0 with the attribute \"block.id\": string required.",
+				"Terraform could not compute a value for the target type string with the mocked data defined at :0,0-0 with the attribute \".block[0].id\": string required.",
 			},
 		},
 		"dynamic_attribute_unset": {

--- a/internal/terraform/node_resource_abstract_instance.go
+++ b/internal/terraform/node_resource_abstract_instance.go
@@ -18,6 +18,7 @@ import (
 	"github.com/hashicorp/terraform/internal/configs/configschema"
 	"github.com/hashicorp/terraform/internal/instances"
 	"github.com/hashicorp/terraform/internal/lang/ephemeral"
+	"github.com/hashicorp/terraform/internal/lang/format"
 	"github.com/hashicorp/terraform/internal/lang/marks"
 	"github.com/hashicorp/terraform/internal/moduletest/mocking"
 	"github.com/hashicorp/terraform/internal/plans"
@@ -2483,7 +2484,7 @@ func (n *NodeAbstractResourceInstance) apply(
 		var unknownPaths []string
 		cty.Transform(configVal, func(p cty.Path, v cty.Value) (cty.Value, error) {
 			if !v.IsKnown() {
-				unknownPaths = append(unknownPaths, fmt.Sprintf("%#v", p))
+				unknownPaths = append(unknownPaths, format.CtyPath(p))
 			}
 			return v, nil
 		})

--- a/internal/tfdiags/config_traversals.go
+++ b/internal/tfdiags/config_traversals.go
@@ -4,68 +4,23 @@
 package tfdiags
 
 import (
-	"fmt"
-	"strconv"
-	"strings"
-
-	"github.com/zclconf/go-cty/cty"
+	"github.com/hashicorp/terraform/internal/lang/format"
 )
+
+// These functions have been moved to the format package to allow for imports
+// which would otherwise cause cycles.
 
 // FormatCtyPath is a helper function to produce a user-friendly string
 // representation of a cty.Path. The result uses a syntax similar to the
 // HCL expression language in the hope of it being familiar to users.
-func FormatCtyPath(path cty.Path) string {
-	var buf strings.Builder
-	for _, step := range path {
-		switch ts := step.(type) {
-		case cty.GetAttrStep:
-			fmt.Fprintf(&buf, ".%s", ts.Name)
-		case cty.IndexStep:
-			buf.WriteByte('[')
-			key := ts.Key
-			keyTy := key.Type()
-			switch {
-			case key.IsNull():
-				buf.WriteString("null")
-			case !key.IsKnown():
-				buf.WriteString("(not yet known)")
-			case keyTy == cty.Number:
-				bf := key.AsBigFloat()
-				buf.WriteString(bf.Text('g', -1))
-			case keyTy == cty.String:
-				buf.WriteString(strconv.Quote(key.AsString()))
-			default:
-				buf.WriteString("...")
-			}
-			buf.WriteByte(']')
-		}
-	}
-	return buf.String()
-}
+var FormatCtyPath = format.CtyPath
 
 // FormatError is a helper function to produce a user-friendly string
 // representation of certain special error types that we might want to
 // include in diagnostic messages.
-//
-// This currently has special behavior only for cty.PathError, where a
-// non-empty path is rendered in a HCL-like syntax as context.
-func FormatError(err error) string {
-	perr, ok := err.(cty.PathError)
-	if !ok || len(perr.Path) == 0 {
-		return err.Error()
-	}
-
-	return fmt.Sprintf("%s: %s", FormatCtyPath(perr.Path), perr.Error())
-}
+var FormatError = format.ErrorDiag
 
 // FormatErrorPrefixed is like FormatError except that it presents any path
 // information after the given prefix string, which is assumed to contain
 // an HCL syntax representation of the value that errors are relative to.
-func FormatErrorPrefixed(err error, prefix string) string {
-	perr, ok := err.(cty.PathError)
-	if !ok || len(perr.Path) == 0 {
-		return fmt.Sprintf("%s: %s", prefix, err.Error())
-	}
-
-	return fmt.Sprintf("%s%s: %s", prefix, FormatCtyPath(perr.Path), perr.Error())
-}
+var FormatErrorPrefixed = format.ErrorDiagPrefixed

--- a/internal/tfdiags/config_traversals.go
+++ b/internal/tfdiags/config_traversals.go
@@ -4,9 +4,9 @@
 package tfdiags
 
 import (
-	"bytes"
 	"fmt"
 	"strconv"
+	"strings"
 
 	"github.com/zclconf/go-cty/cty"
 )
@@ -15,7 +15,7 @@ import (
 // representation of a cty.Path. The result uses a syntax similar to the
 // HCL expression language in the hope of it being familiar to users.
 func FormatCtyPath(path cty.Path) string {
-	var buf bytes.Buffer
+	var buf strings.Builder
 	for _, step := range path {
 		switch ts := step.(type) {
 		case cty.GetAttrStep:


### PR DESCRIPTION
Sensitive paths in a resource instance value were not serialized in a consistent order, which could cause comparison of the state to erroneously indicate a change. While the UI would not report any changes to the user because the states were functionally the same, the machine readable outputs, like the plan `applyable' field and the detailed exitcode would indicate that the plan was not empty.

The canonical user-readable version of a cty.Path is was created by the tfdiags package, but in order to reuse this everywhere we need, the formatting function needs to be split out to it's own package. This PR creates the `lang/format` package, delegates the `tfgdiags` format functions to the new package, then replaces any other `fmt.Sprintf` formatting of `cty.Path` I could find with the new more efficient formatter.

Once we have a single format for `cty.Path`, use that to sort the `AttrSensitivePaths` used in state so that the order is deterministic.

Fixes #36403
