### PR TITLE
feat: allow mocking of provisioners with terraform test

### DIFF
--- a/.changes/unreleased/ENHANCEMENTS-20250211-164824.yaml
+++ b/.changes/unreleased/ENHANCEMENTS-20250211-164824.yaml
@@ -1,0 +1,5 @@
+kind: ENHANCEMENTS
+body: The terraform test command now supports a override_provision block in test runs. This feature allows to skip or mock provisioners on entire resources.
+time: 2025-02-11T16:48:24.83763+01:00
+custom:
+    Issue: "35459"

--- a/internal/configs/testdata/invalid-test-files/duplicate_provisioner_overrides.tftest.hcl
+++ b/internal/configs/testdata/invalid-test-files/duplicate_provisioner_overrides.tftest.hcl
@@ -1,0 +1,33 @@
+mock_provider "aws" {
+  override_provisioner {
+    target = aws_instance.test
+    values = {}
+  }
+
+  override_provisioner {
+    target = aws_instance.test
+    values = {}
+  }
+}
+
+override_provisioner {
+  target = aws_instance.test
+  values = {}
+}
+
+override_provisioner {
+  target = aws_instance.test
+  values = {}
+}
+
+run "test" {
+  override_provisioner {
+    target = aws_instance.test
+    values = {}
+  }
+
+  override_provisioner {
+    target = aws_instance.test
+    values = {}
+  }
+}

--- a/internal/configs/testdata/invalid-test-files/invalid_provisioner_override.tftest.hcl
+++ b/internal/configs/testdata/invalid-test-files/invalid_provisioner_override.tftest.hcl
@@ -1,0 +1,9 @@
+override_provisioner {
+  target = aws_instance.target
+}
+
+override_provisioner {
+  values = {}
+}
+
+run "test" {}

--- a/internal/configs/testdata/invalid-test-files/invalid_provisioner_override_target.tftest.hcl
+++ b/internal/configs/testdata/invalid-test-files/invalid_provisioner_override_target.tftest.hcl
@@ -1,0 +1,11 @@
+override_provisioner {
+  target = data.aws_instance.target
+  values = {}
+}
+
+override_provisioner {
+  target = module.child
+  values = {}
+}
+
+run "test" {}

--- a/internal/configs/testdata/valid-modules/with-mocks/main.tf
+++ b/internal/configs/testdata/valid-modules/with-mocks/main.tf
@@ -12,6 +12,12 @@ resource "aws_instance" "second" {}
 
 resource "aws_instance" "third" {}
 
+resource "aws_instance" "fourth" {
+  provisioner "local-exec" {
+    command = ""
+  }
+}
+
 data "aws_secretsmanager_secret" "creds" {}
 
 module "child" {

--- a/internal/configs/testdata/valid-modules/with-mocks/test_case_two.tftest.hcl
+++ b/internal/configs/testdata/valid-modules/with-mocks/test_case_two.tftest.hcl
@@ -8,6 +8,11 @@ override_data {
   }
 }
 
+override_provisioner {
+  target = aws_instance.fourth
+  values = {}
+}
+
 run "test" {
   override_resource {
     target = aws_instance.first
@@ -21,5 +26,10 @@ run "test" {
     values = {
       arn = "aws:secretsmanager"
     }
+  }
+
+  override_provisioner {
+    target = aws_instance.fourth
+    values = {}
   }
 }


### PR DESCRIPTION
This PR introduces a `override_provisioner` block allowing users to skip / mock provisioners on resources entirely when running terraform test.  
The implementation tries to follow conventions from the override_resource, override_data, and override_module blocks.
 
Fixes #35459

## Target Release

1.11.x

## Draft CHANGELOG entry

The terraform test command now supports a override_provision block in test runs. This feature allows to skip or mock provisioners on entire resources.