### PR TITLE
Migrate more testing helpers into tfdiags package

### DIFF
--- a/internal/configs/configload/loader_load_test.go
+++ b/internal/configs/configload/loader_load_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/zclconf/go-cty/cty"
 
 	"github.com/hashicorp/terraform/internal/configs"
-	"github.com/hashicorp/terraform/internal/tfdiags"
 )
 
 func TestLoaderLoadConfig_okay(t *testing.T) {
@@ -27,7 +26,7 @@ func TestLoaderLoadConfig_okay(t *testing.T) {
 	}
 
 	cfg, diags := loader.LoadConfig(fixtureDir)
-	tfdiags.AssertNoDiagnostics(t, diags)
+	assertNoDiagnostics(t, diags)
 	if cfg == nil {
 		t.Fatalf("config is nil; want non-nil")
 	}

--- a/internal/configs/configload/loader_load_test.go
+++ b/internal/configs/configload/loader_load_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/zclconf/go-cty/cty"
 
 	"github.com/hashicorp/terraform/internal/configs"
+	"github.com/hashicorp/terraform/internal/tfdiags"
 )
 
 func TestLoaderLoadConfig_okay(t *testing.T) {
@@ -26,7 +27,7 @@ func TestLoaderLoadConfig_okay(t *testing.T) {
 	}
 
 	cfg, diags := loader.LoadConfig(fixtureDir)
-	assertNoDiagnostics(t, diags)
+	tfdiags.AssertNoDiagnostics(t, diags)
 	if cfg == nil {
 		t.Fatalf("config is nil; want non-nil")
 	}

--- a/internal/initwd/from_module_test.go
+++ b/internal/initwd/from_module_test.go
@@ -44,7 +44,7 @@ func TestDirFromModule_registry(t *testing.T) {
 	loader, cleanup := configload.NewLoaderForTests(t)
 	defer cleanup()
 	diags := DirFromModule(context.Background(), loader, dir, modsDir, "hashicorp/module-installer-acctest/aws//examples/main", reg, hooks)
-	assertNoDiagnostics(t, diags)
+	tfdiags.AssertNoDiagnostics(t, diags)
 
 	v := version.Must(version.NewVersion("0.0.2"))
 
@@ -108,7 +108,7 @@ func TestDirFromModule_registry(t *testing.T) {
 	// Make sure the configuration is loadable now.
 	// (This ensures that correct information is recorded in the manifest.)
 	config, loadDiags := loader.LoadConfig(".")
-	if assertNoDiagnostics(t, tfdiags.Diagnostics{}.Append(loadDiags)) {
+	if tfdiags.AssertNoDiagnostics(t, tfdiags.Diagnostics{}.Append(loadDiags)) {
 		return
 	}
 
@@ -162,7 +162,7 @@ func TestDirFromModule_submodules(t *testing.T) {
 	loader, cleanup := configload.NewLoaderForTests(t)
 	defer cleanup()
 	diags := DirFromModule(context.Background(), loader, dir, modInstallDir, fromModuleDir, nil, hooks)
-	assertNoDiagnostics(t, diags)
+	tfdiags.AssertNoDiagnostics(t, diags)
 	wantCalls := []testInstallHookCall{
 		{
 			Name:       "Install",
@@ -190,7 +190,7 @@ func TestDirFromModule_submodules(t *testing.T) {
 	// Make sure the configuration is loadable now.
 	// (This ensures that correct information is recorded in the manifest.)
 	config, loadDiags := loader.LoadConfig(".")
-	if assertNoDiagnostics(t, tfdiags.Diagnostics{}.Append(loadDiags)) {
+	if tfdiags.AssertNoDiagnostics(t, tfdiags.Diagnostics{}.Append(loadDiags)) {
 		return
 	}
 	wantTraces := map[string]string{
@@ -288,7 +288,7 @@ func TestDirFromModule_rel_submodules(t *testing.T) {
 	loader, cleanup := configload.NewLoaderForTests(t)
 	defer cleanup()
 	diags := DirFromModule(context.Background(), loader, ".", modInstallDir, sourceDir, nil, hooks)
-	assertNoDiagnostics(t, diags)
+	tfdiags.AssertNoDiagnostics(t, diags)
 	wantCalls := []testInstallHookCall{
 		{
 			Name:       "Install",
@@ -316,7 +316,7 @@ func TestDirFromModule_rel_submodules(t *testing.T) {
 	// Make sure the configuration is loadable now.
 	// (This ensures that correct information is recorded in the manifest.)
 	config, loadDiags := loader.LoadConfig(".")
-	if assertNoDiagnostics(t, tfdiags.Diagnostics{}.Append(loadDiags)) {
+	if tfdiags.AssertNoDiagnostics(t, tfdiags.Diagnostics{}.Append(loadDiags)) {
 		return
 	}
 	wantTraces := map[string]string{

--- a/internal/initwd/from_module_test.go
+++ b/internal/initwd/from_module_test.go
@@ -108,9 +108,7 @@ func TestDirFromModule_registry(t *testing.T) {
 	// Make sure the configuration is loadable now.
 	// (This ensures that correct information is recorded in the manifest.)
 	config, loadDiags := loader.LoadConfig(".")
-	if tfdiags.AssertNoDiagnostics(t, tfdiags.Diagnostics{}.Append(loadDiags)) {
-		return
-	}
+	tfdiags.AssertNoDiagnostics(t, tfdiags.Diagnostics{}.Append(loadDiags))
 
 	wantTraces := map[string]string{
 		"":                     "in example",
@@ -190,9 +188,8 @@ func TestDirFromModule_submodules(t *testing.T) {
 	// Make sure the configuration is loadable now.
 	// (This ensures that correct information is recorded in the manifest.)
 	config, loadDiags := loader.LoadConfig(".")
-	if tfdiags.AssertNoDiagnostics(t, tfdiags.Diagnostics{}.Append(loadDiags)) {
-		return
-	}
+	tfdiags.AssertNoDiagnostics(t, tfdiags.Diagnostics{}.Append(loadDiags))
+
 	wantTraces := map[string]string{
 		"":                "in root module",
 		"child_a":         "in child_a module",
@@ -316,9 +313,8 @@ func TestDirFromModule_rel_submodules(t *testing.T) {
 	// Make sure the configuration is loadable now.
 	// (This ensures that correct information is recorded in the manifest.)
 	config, loadDiags := loader.LoadConfig(".")
-	if tfdiags.AssertNoDiagnostics(t, tfdiags.Diagnostics{}.Append(loadDiags)) {
-		return
-	}
+	tfdiags.AssertNoDiagnostics(t, tfdiags.Diagnostics{}.Append(loadDiags))
+
 	wantTraces := map[string]string{
 		"":                "in root module",
 		"child_a":         "in child_a module",

--- a/internal/initwd/module_install_test.go
+++ b/internal/initwd/module_install_test.go
@@ -47,7 +47,7 @@ func TestModuleInstaller(t *testing.T) {
 	defer close()
 	inst := NewModuleInstaller(modulesDir, loader, nil)
 	_, diags := inst.InstallModules(context.Background(), ".", "tests", false, false, hooks)
-	assertNoDiagnostics(t, diags)
+	tfdiags.AssertNoDiagnostics(t, diags)
 
 	wantCalls := []testInstallHookCall{
 		{
@@ -78,7 +78,7 @@ func TestModuleInstaller(t *testing.T) {
 	// Make sure the configuration is loadable now.
 	// (This ensures that correct information is recorded in the manifest.)
 	config, loadDiags := loader.LoadConfig(".")
-	assertNoDiagnostics(t, tfdiags.Diagnostics{}.Append(loadDiags))
+	tfdiags.AssertNoDiagnostics(t, tfdiags.Diagnostics{}.Append(loadDiags))
 
 	wantTraces := map[string]string{
 		"":                "in root module",
@@ -380,7 +380,7 @@ func TestModuleInstaller_symlink(t *testing.T) {
 	defer close()
 	inst := NewModuleInstaller(modulesDir, loader, nil)
 	_, diags := inst.InstallModules(context.Background(), ".", "tests", false, false, hooks)
-	assertNoDiagnostics(t, diags)
+	tfdiags.AssertNoDiagnostics(t, diags)
 
 	wantCalls := []testInstallHookCall{
 		{
@@ -411,7 +411,7 @@ func TestModuleInstaller_symlink(t *testing.T) {
 	// Make sure the configuration is loadable now.
 	// (This ensures that correct information is recorded in the manifest.)
 	config, loadDiags := loader.LoadConfig(".")
-	assertNoDiagnostics(t, tfdiags.Diagnostics{}.Append(loadDiags))
+	tfdiags.AssertNoDiagnostics(t, tfdiags.Diagnostics{}.Append(loadDiags))
 
 	wantTraces := map[string]string{
 		"":                "in root module",
@@ -460,7 +460,7 @@ func TestLoaderInstallModules_invalidRegistry(t *testing.T) {
 	if !diags.HasErrors() {
 		t.Fatal("expected error")
 	} else {
-		assertDiagnosticCount(t, diags, 1)
+		tfdiags.AssertDiagnosticCount(t, diags, 1)
 		assertDiagnosticSummary(t, diags, "Unreadable module subdirectory")
 
 		// the diagnostic should specifically call out the submodule that failed
@@ -495,7 +495,7 @@ func TestLoaderInstallModules_registry(t *testing.T) {
 	defer close()
 	inst := NewModuleInstaller(modulesDir, loader, registry.NewClient(nil, nil))
 	_, diags := inst.InstallModules(context.Background(), dir, "tests", false, false, hooks)
-	assertNoDiagnostics(t, diags)
+	tfdiags.AssertNoDiagnostics(t, diags)
 
 	v := version.Must(version.NewVersion("0.0.1"))
 
@@ -609,7 +609,7 @@ func TestLoaderInstallModules_registry(t *testing.T) {
 	// Make sure the configuration is loadable now.
 	// (This ensures that correct information is recorded in the manifest.)
 	config, loadDiags := loader.LoadConfig(".")
-	assertNoDiagnostics(t, tfdiags.Diagnostics{}.Append(loadDiags))
+	tfdiags.AssertNoDiagnostics(t, tfdiags.Diagnostics{}.Append(loadDiags))
 
 	wantTraces := map[string]string{
 		"":                             "in local caller for registry-modules",
@@ -658,7 +658,7 @@ func TestLoaderInstallModules_goGetter(t *testing.T) {
 	defer close()
 	inst := NewModuleInstaller(modulesDir, loader, registry.NewClient(nil, nil))
 	_, diags := inst.InstallModules(context.Background(), dir, "tests", false, false, hooks)
-	assertNoDiagnostics(t, diags)
+	tfdiags.AssertNoDiagnostics(t, diags)
 
 	wantCalls := []testInstallHookCall{
 		// the configuration builder visits each level of calls in lexicographical
@@ -739,7 +739,7 @@ func TestLoaderInstallModules_goGetter(t *testing.T) {
 	// Make sure the configuration is loadable now.
 	// (This ensures that correct information is recorded in the manifest.)
 	config, loadDiags := loader.LoadConfig(".")
-	assertNoDiagnostics(t, tfdiags.Diagnostics{}.Append(loadDiags))
+	tfdiags.AssertNoDiagnostics(t, tfdiags.Diagnostics{}.Append(loadDiags))
 
 	wantTraces := map[string]string{
 		"":                             "in local caller for go-getter-modules",
@@ -776,7 +776,7 @@ func TestModuleInstaller_fromTests(t *testing.T) {
 	defer close()
 	inst := NewModuleInstaller(modulesDir, loader, nil)
 	_, diags := inst.InstallModules(context.Background(), ".", "tests", false, false, hooks)
-	assertNoDiagnostics(t, diags)
+	tfdiags.AssertNoDiagnostics(t, diags)
 
 	wantCalls := []testInstallHookCall{
 		{
@@ -801,7 +801,7 @@ func TestModuleInstaller_fromTests(t *testing.T) {
 	// Make sure the configuration is loadable now.
 	// (This ensures that correct information is recorded in the manifest.)
 	config, loadDiags := loader.LoadConfigWithTests(".", "tests")
-	assertNoDiagnostics(t, tfdiags.Diagnostics{}.Append(loadDiags))
+	tfdiags.AssertNoDiagnostics(t, tfdiags.Diagnostics{}.Append(loadDiags))
 
 	if config.Module.Tests["tests/main.tftest.hcl"].Runs[0].ConfigUnderTest == nil {
 		t.Fatalf("should have loaded config into the relevant run block but did not")
@@ -833,7 +833,7 @@ func TestLoadInstallModules_registryFromTest(t *testing.T) {
 	defer close()
 	inst := NewModuleInstaller(modulesDir, loader, registry.NewClient(nil, nil))
 	_, diags := inst.InstallModules(context.Background(), dir, "tests", false, false, hooks)
-	assertNoDiagnostics(t, diags)
+	tfdiags.AssertNoDiagnostics(t, diags)
 
 	v := version.Must(version.NewVersion("0.0.1"))
 	wantCalls := []testInstallHookCall{
@@ -910,7 +910,7 @@ func TestLoadInstallModules_registryFromTest(t *testing.T) {
 	// Make sure the configuration is loadable now.
 	// (This ensures that correct information is recorded in the manifest.)
 	config, loadDiags := loader.LoadConfigWithTests(".", "tests")
-	assertNoDiagnostics(t, tfdiags.Diagnostics{}.Append(loadDiags))
+	tfdiags.AssertNoDiagnostics(t, tfdiags.Diagnostics{}.Append(loadDiags))
 
 	if config.Module.Tests["main.tftest.hcl"].Runs[0].ConfigUnderTest == nil {
 		t.Fatalf("should have loaded config into the relevant run block but did not")
@@ -995,23 +995,6 @@ func tempChdir(t *testing.T, sourceDir string) (string, func()) {
 			os.RemoveAll(tmpDir)
 		}
 	}
-}
-
-func assertNoDiagnostics(t *testing.T, diags tfdiags.Diagnostics) bool {
-	t.Helper()
-	return assertDiagnosticCount(t, diags, 0)
-}
-
-func assertDiagnosticCount(t *testing.T, diags tfdiags.Diagnostics, want int) bool {
-	t.Helper()
-	if len(diags) != want {
-		t.Errorf("wrong number of diagnostics %d; want %d", len(diags), want)
-		for _, diag := range diags {
-			t.Logf("- %#v", diag)
-		}
-		return true
-	}
-	return false
 }
 
 func assertDiagnosticSummary(t *testing.T, diags tfdiags.Diagnostics, want string) bool {

--- a/internal/terraform/context_apply2_test.go
+++ b/internal/terraform/context_apply2_test.go
@@ -251,7 +251,7 @@ resource "test_instance" "a" {
 	})
 
 	plan, diags := ctx.Plan(m, state, DefaultPlanOpts)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	_, diags = ctx.Apply(plan, m, nil)
 	if diags.HasErrors() {
@@ -339,7 +339,7 @@ resource "aws_instance" "bin" {
 	})
 
 	plan, diags := ctx.Plan(m, state, DefaultPlanOpts)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	bar := plan.PriorState.ResourceInstance(barAddr)
 	if len(bar.Current.Dependencies) == 0 || !bar.Current.Dependencies[0].Equal(fooAddr.ContainingResource().Config()) {
@@ -440,7 +440,7 @@ resource "test_resource" "b" {
 	})
 
 	plan, diags := ctx.Plan(m, state, SimplePlanOpts(plans.NormalMode, testInputValuesUnset(m.Module.Variables)))
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	_, diags = ctx.Apply(plan, m, nil)
 	if diags.HasErrors() {
@@ -481,7 +481,7 @@ output "out" {
 	})
 
 	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	state, diags := ctx.Apply(plan, m, nil)
 	if diags.HasErrors() {
@@ -494,7 +494,7 @@ output "out" {
 	}
 
 	plan, diags = ctx.Plan(m, state, DefaultPlanOpts)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	// make sure the same marks are compared in the next plan as well
 	for _, c := range plan.Changes.Resources {
@@ -544,14 +544,14 @@ resource "test_object" "y" {
 	})
 
 	plan, diags := ctx.Plan(m, states.NewState(), SimplePlanOpts(plans.NormalMode, testInputValuesUnset(m.Module.Variables)))
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	state, diags := ctx.Apply(plan, m, nil)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	// FINAL PLAN:
 	plan, diags = ctx.Plan(m, state, SimplePlanOpts(plans.NormalMode, testInputValuesUnset(m.Module.Variables)))
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	// make sure the same marks are compared in the next plan as well
 	for _, c := range plan.Changes.Resources {
@@ -679,17 +679,17 @@ resource "test_object" "s" {
 	})
 
 	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	state, diags := ctx.Apply(plan, m, nil)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	// destroy only a single instance not included in the moved statements
 	_, diags = ctx.Plan(m, state, &PlanOpts{
 		Mode:    plans.DestroyMode,
 		Targets: []addrs.Targetable{mustResourceInstanceAddr(`module.modb["a"].test_object.a`)},
 	})
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 }
 
 func TestContext2Apply_graphError(t *testing.T) {
@@ -818,7 +818,7 @@ resource "test_resource" "c" {
 				},
 			},
 		})
-		assertNoErrors(t, diags)
+		tfdiags.AssertNoErrors(t, diags)
 		if len(plan.Changes.Resources) != 3 {
 			t.Fatalf("unexpected plan changes: %#v", plan.Changes)
 		}
@@ -831,7 +831,7 @@ resource "test_resource" "c" {
 			return resp
 		}
 		state, diags := ctx.Apply(plan, m, nil)
-		assertNoErrors(t, diags)
+		tfdiags.AssertNoErrors(t, diags)
 
 		wantResourceAttrs := map[string]struct{ value, output string }{
 			"a": {"boop", "new-boop"},
@@ -877,7 +877,7 @@ resource "test_resource" "c" {
 				},
 			},
 		})
-		assertNoErrors(t, diags)
+		tfdiags.AssertNoErrors(t, diags)
 		if len(plan.Changes.Resources) != 3 {
 			t.Fatalf("unexpected plan changes: %#v", plan.Changes)
 		}
@@ -999,7 +999,7 @@ func TestContext2Apply_outputValuePrecondition(t *testing.T) {
 				},
 			},
 		})
-		assertNoDiagnostics(t, diags)
+		tfdiags.AssertNoDiagnostics(t, diags)
 
 		for _, addr := range checkableObjects {
 			result := plan.Checks.GetObjectResult(addr)
@@ -1012,7 +1012,7 @@ func TestContext2Apply_outputValuePrecondition(t *testing.T) {
 		}
 
 		state, diags := ctx.Apply(plan, m, nil)
-		assertNoDiagnostics(t, diags)
+		tfdiags.AssertNoDiagnostics(t, diags)
 		for _, addr := range checkableObjects {
 			result := state.CheckResults.GetObjectResult(addr)
 			if result == nil {
@@ -1154,7 +1154,7 @@ func TestContext2Apply_resourceConditionApplyTimeFail(t *testing.T) {
 				},
 			},
 		})
-		assertNoErrors(t, diags)
+		tfdiags.AssertNoErrors(t, diags)
 		planA := plan.Changes.ResourceInstance(instA)
 		if planA == nil || planA.Action != plans.Create {
 			t.Fatalf("incorrect initial plan for instance A\nwant a 'create' change\ngot: %s", spew.Sdump(planA))
@@ -1165,7 +1165,7 @@ func TestContext2Apply_resourceConditionApplyTimeFail(t *testing.T) {
 		}
 
 		state, diags := ctx.Apply(plan, m, nil)
-		assertNoErrors(t, diags)
+		tfdiags.AssertNoErrors(t, diags)
 
 		stateA := state.ResourceInstance(instA)
 		if stateA == nil || stateA.Current == nil || !bytes.Contains(stateA.Current.AttrsJSON, []byte(`"beep"`)) {
@@ -1191,7 +1191,7 @@ func TestContext2Apply_resourceConditionApplyTimeFail(t *testing.T) {
 				},
 			},
 		})
-		assertNoErrors(t, diags)
+		tfdiags.AssertNoErrors(t, diags)
 		planA := plan.Changes.ResourceInstance(instA)
 		if planA == nil || planA.Action != plans.Update {
 			t.Fatalf("incorrect initial plan for instance A\nwant an 'update' change\ngot: %s", spew.Sdump(planA))
@@ -1337,10 +1337,10 @@ output "out" {
 
 	opts := SimplePlanOpts(plans.NormalMode, testInputValuesUnset(m.Module.Variables))
 	plan, diags := ctx.Plan(m, states.NewState(), opts)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	state, diags := ctx.Apply(plan, m, nil)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	// Resource changes which have dependencies across providers which
 	// themselves depend on resources can result in cycles.
@@ -1358,7 +1358,7 @@ output "out" {
 	testObjA.Current.AttrsJSON = []byte(`{"test_bool":null,"test_list":null,"test_map":null,"test_number":null,"test_string":"changed"}`)
 
 	_, diags = ctx.Plan(m, state, opts)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	otherProvider.ConfigureProviderCalled = false
 	otherProvider.ConfigureProviderFn = func(req providers.ConfigureProviderRequest) (resp providers.ConfigureProviderResponse) {
@@ -1389,7 +1389,7 @@ got:      %#v`,
 
 	// destroy only a single instance not included in the moved statements
 	_, diags = ctx.Plan(m, state, opts)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	if !otherProvider.ConfigureProviderCalled {
 		t.Fatal("failed to configure provider during destroy plan")
@@ -1505,10 +1505,10 @@ resource "test_object" "y" {
 
 	opts := SimplePlanOpts(plans.NormalMode, nil)
 	plan, diags := ctx.Plan(m, state, opts)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	_, diags = ctx.Apply(plan, m, nil)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 }
 
 // Outputs should not cause evaluation errors during destroy
@@ -1587,18 +1587,18 @@ output "data" {
 	// apply the state
 	opts := SimplePlanOpts(plans.NormalMode, nil)
 	plan, diags := ctx.Plan(m, states.NewState(), opts)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	state, diags := ctx.Apply(plan, m, nil)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	// and destroy
 	opts = SimplePlanOpts(plans.DestroyMode, nil)
 	plan, diags = ctx.Plan(m, state, opts)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	state, diags = ctx.Apply(plan, m, nil)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	// and destroy again with no state
 	if !state.Empty() {
@@ -1607,10 +1607,10 @@ output "data" {
 
 	opts = SimplePlanOpts(plans.DestroyMode, nil)
 	plan, diags = ctx.Plan(m, state, opts)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	_, diags = ctx.Apply(plan, m, nil)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 }
 
 // don't evaluate conditions on outputs when destroying
@@ -1661,10 +1661,10 @@ output "from_resource" {
 
 	opts := SimplePlanOpts(plans.DestroyMode, nil)
 	plan, diags := ctx.Plan(m, state, opts)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	_, diags = ctx.Apply(plan, m, nil)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 }
 
 // -refresh-only should update checks
@@ -1720,10 +1720,10 @@ output "from_resource" {
 
 	opts := SimplePlanOpts(plans.RefreshOnlyMode, nil)
 	plan, diags := ctx.Plan(m, state, opts)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	state, diags = ctx.Apply(plan, m, nil)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	resCheck := state.CheckResults.GetObjectResult(mustResourceInstanceAddr("test_object.x"))
 	if resCheck.Status != checks.StatusPass {
@@ -1789,7 +1789,7 @@ resource "test_object" "y" {
 
 	opts := SimplePlanOpts(plans.NormalMode, nil)
 	plan, diags := ctx.Plan(m, state, opts)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	for _, c := range plan.Changes.Resources {
 		if c.Addr.Equal(yAddr) && c.Action != plans.NoOp {
@@ -1810,7 +1810,7 @@ resource "test_object" "y" {
 	}
 
 	_, diags = ctx.Apply(plan, m, nil)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 }
 
 // ensure all references from preconditions are tracked through plan and apply
@@ -1856,9 +1856,9 @@ output "a" {
 	plan, diags := ctx.Plan(m, states.NewState(), &PlanOpts{
 		Mode: plans.NormalMode,
 	})
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 	_, diags = ctx.Apply(plan, m, nil)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 }
 
 func TestContext2Apply_destroyNullModuleOutput(t *testing.T) {
@@ -1903,17 +1903,17 @@ output "null_module_test" {
 	plan, diags := ctx.Plan(m, states.NewState(), &PlanOpts{
 		Mode: plans.NormalMode,
 	})
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 	state, diags := ctx.Apply(plan, m, nil)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	// now destroy
 	plan, diags = ctx.Plan(m, state, &PlanOpts{
 		Mode: plans.DestroyMode,
 	})
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 	_, diags = ctx.Apply(plan, m, nil)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 }
 
 func TestContext2Apply_moduleOutputWithSensitiveAttrs(t *testing.T) {
@@ -1978,9 +1978,9 @@ output "resources" {
 	plan, diags := ctx.Plan(m, states.NewState(), &PlanOpts{
 		Mode: plans.NormalMode,
 	})
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 	_, diags = ctx.Apply(plan, m, nil)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 }
 
 func TestContext2Apply_timestamps(t *testing.T) {
@@ -2065,10 +2065,10 @@ resource "test_resource" "b" {
 	plan, diags := ctx.Plan(m, states.NewState(), &PlanOpts{
 		Mode: plans.NormalMode,
 	})
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	_, diags = ctx.Apply(plan, m, nil)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 }
 
 func TestContext2Apply_destroyUnusedModuleProvider(t *testing.T) {
@@ -2109,9 +2109,9 @@ resource "unused_resource" "test" {
 	plan, diags := ctx.Plan(m, states.NewState(), &PlanOpts{
 		Mode: plans.DestroyMode,
 	})
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 	_, diags = ctx.Apply(plan, m, nil)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 }
 
 func TestContext2Apply_import(t *testing.T) {
@@ -2168,10 +2168,10 @@ import {
 	plan, diags := ctx.Plan(m, states.NewState(), &PlanOpts{
 		Mode: plans.NormalMode,
 	})
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	_, diags = ctx.Apply(plan, m, nil)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	if !hook.PreApplyImportCalled {
 		t.Fatalf("PreApplyImport hook not called")
@@ -2310,7 +2310,7 @@ locals {
 	}
 
 	g, _, diags := ctx.applyGraph(plan, m, &ApplyOpts{}, true)
-	assertNoDiagnostics(t, diags)
+	tfdiags.AssertNoDiagnostics(t, diags)
 
 	// The local value should've been pruned from the graph because nothing
 	// refers to it and this was a destroy run.
@@ -2424,7 +2424,7 @@ locals {
 	}
 
 	g, _, diags := ctx.applyGraph(plan, m, &ApplyOpts{}, true)
-	assertNoDiagnostics(t, diags)
+	tfdiags.AssertNoDiagnostics(t, diags)
 
 	// Although nothing refers to the local value, it should remain in the graph
 	// because this was NOT a destroy run and the prune transform exits early.
@@ -3128,7 +3128,7 @@ resource "test_resource" "a" {
 			},
 		},
 	})
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	state, diags = ctx.Apply(plan, m, nil)
 	if diags.HasErrors() {
@@ -3207,7 +3207,7 @@ resource "test_object" "a" {
 	})
 
 	plan, diags := ctx.Plan(m, states.NewState(), SimplePlanOpts(plans.NormalMode, testInputValuesUnset(m.Module.Variables)))
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	state, diags := ctx.Apply(plan, m, nil)
 	if diags.HasErrors() {
@@ -3219,7 +3219,7 @@ resource "test_object" "a" {
 	}
 
 	plan, diags = ctx.Plan(m, state, SimplePlanOpts(plans.NormalMode, testInputValuesUnset(m.Module.Variables)))
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	if c := plan.Changes.ResourceInstance(mustResourceInstanceAddr("test_object.a")); c.Action != plans.NoOp {
 		t.Errorf("Unexpected %s change for %s", c.Action, c.Addr)
@@ -3251,11 +3251,11 @@ resource "test_object" "obj" {
 	})
 
 	plan, diags := ctx.Plan(m, states.NewState(), SimplePlanOpts(plans.NormalMode, testInputValuesUnset(m.Module.Variables)))
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	// Just don't crash.
 	_, diags = ctx.Apply(plan, m, nil)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 }
 
 func TestContext2Apply_applyingFlag(t *testing.T) {
@@ -3310,7 +3310,7 @@ func TestContext2Apply_applyingFlag(t *testing.T) {
 	})
 
 	plan, diags := ctx.Plan(m, states.NewState(), SimplePlanOpts(plans.NormalMode, testInputValuesUnset(m.Module.Variables)))
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	if !p.ConfigureProviderCalled {
 		t.Fatalf("ConfigureProvider was not called during planning")
@@ -3330,7 +3330,7 @@ func TestContext2Apply_applyingFlag(t *testing.T) {
 	p.ConfigureProviderRequest = providers.ConfigureProviderRequest{}
 
 	_, diags = ctx.Apply(plan, m, &ApplyOpts{})
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	if !p.ConfigureProviderCalled {
 		t.Fatalf("ConfigureProvider was not called while applying")
@@ -3371,7 +3371,7 @@ func TestContext2Apply_applyTimeVariables(t *testing.T) {
 				"p": {Value: cty.StringVal("p value")},
 			}),
 		)
-		assertNoErrors(t, diags)
+		tfdiags.AssertNoErrors(t, diags)
 
 		{
 			got := plan.ApplyTimeVariables
@@ -3405,7 +3405,7 @@ func TestContext2Apply_applyTimeVariables(t *testing.T) {
 				"e": {Value: cty.StringVal("different e value")},
 			},
 		})
-		assertNoErrors(t, diags)
+		tfdiags.AssertNoErrors(t, diags)
 	})
 
 	t.Run("unset during plan", func(t *testing.T) {
@@ -3417,7 +3417,7 @@ func TestContext2Apply_applyTimeVariables(t *testing.T) {
 				"p": {Value: cty.StringVal("p value")},
 			}),
 		)
-		assertNoErrors(t, diags)
+		tfdiags.AssertNoErrors(t, diags)
 
 		{
 			got := plan.ApplyTimeVariables
@@ -3452,7 +3452,7 @@ func TestContext2Apply_applyTimeVariables(t *testing.T) {
 		_, diags = ctx.Apply(plan, m, &ApplyOpts{
 			// Applying with 'e' still unset should be valid.
 		})
-		assertNoErrors(t, diags)
+		tfdiags.AssertNoErrors(t, diags)
 	})
 }
 
@@ -3509,7 +3509,7 @@ resource "test_object" "obj" {
 	})
 
 	plan, diags := ctx.Plan(m, states.NewState(), SimplePlanOpts(plans.NormalMode, testInputValuesUnset(m.Module.Variables)))
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	// Just don't crash, should report an error about the provider.
 	_, diags = ctx.Apply(plan, m, nil)
@@ -3586,10 +3586,10 @@ resource "test_instance" "obj" {
 		SkipRefresh: true,
 		Mode:        plans.NormalMode,
 	})
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	_, diags = ctx.Apply(plan, m, nil)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	if !destroyCalled {
 		t.Fatal("old instance not destroyed")
@@ -3665,10 +3665,10 @@ resource "test_object" "c" {
 	})
 
 	plan, diags := ctx.Plan(m, state, SimplePlanOpts(plans.NormalMode, testInputValuesUnset(m.Module.Variables)))
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	state, diags = ctx.Apply(plan, m, nil)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	for _, res := range state.RootModule().Resources {
 		if !res.Instances[addrs.NoKey].Current.CreateBeforeDestroy {
@@ -3740,10 +3740,10 @@ resource "test_object" "c" {
 	// because because the test also depends on how the dependencies are stored
 	// during the plan.
 	plan, diags := ctx.Plan(m, states.NewState(), SimplePlanOpts(plans.NormalMode, testInputValuesUnset(m.Module.Variables)))
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	state, diags := ctx.Apply(plan, m, nil)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	// update the config to force replacement on a, c, and an update with b
 	m = testModuleInline(t, map[string]string{
@@ -3762,13 +3762,13 @@ resource "test_object" "c" {
 `})
 
 	plan, diags = ctx.Plan(m, state, SimplePlanOpts(plans.NormalMode, testInputValuesUnset(m.Module.Variables)))
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	// grab the graph we build during apply to check the actual dependencies,
 	// rather than the observed order which may not be stable if the
 	// dependencies are not correct.
 	g, _, diags := ctx.applyGraph(plan, m, nil, false)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	// the destroy node for "a" must depend on the destroy node for "c"
 	for _, v := range g.Vertices() {

--- a/internal/terraform/context_apply_checks_test.go
+++ b/internal/terraform/context_apply_checks_test.go
@@ -791,10 +791,10 @@ check "check_should_not_panic" {
 			mustProviderConfig(`provider["registry.terraform.io/hashicorp/test"]`),
 		)
 	}), DefaultPlanOpts)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	_, diags = ctx.Apply(plan, m, nil)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 }
 
 func validateCheckDiagnostics(t *testing.T, stage string, expectedWarning, expectedError string, actual tfdiags.Diagnostics) bool {
@@ -822,7 +822,7 @@ func validateCheckDiagnostics(t *testing.T, stage string, expectedWarning, expec
 		}
 	}
 
-	assertNoErrors(t, actual)
+	tfdiags.AssertNoErrors(t, actual)
 	return false
 }
 

--- a/internal/terraform/context_apply_deferred_test.go
+++ b/internal/terraform/context_apply_deferred_test.go
@@ -3813,9 +3813,9 @@ func TestContextApply_deferredActions(t *testing.T) {
 						if stage.wantDiagnostic == nil {
 							// We expect the correct planned changes and no diagnostics.
 							if stage.allowWarnings {
-								assertNoErrors(t, diags)
+								tfdiags.AssertNoErrors(t, diags)
 							} else {
-								assertNoDiagnostics(t, diags)
+								tfdiags.AssertNoDiagnostics(t, diags)
 							}
 						} else {
 							if !stage.wantDiagnostic(diags) {
@@ -3885,9 +3885,9 @@ func TestContextApply_deferredActions(t *testing.T) {
 
 						// We expect the correct applied changes and no diagnostics.
 						if stage.allowWarnings {
-							assertNoErrors(t, diags)
+							tfdiags.AssertNoErrors(t, diags)
 						} else {
-							assertNoDiagnostics(t, diags)
+							tfdiags.AssertNoDiagnostics(t, diags)
 						}
 						provider.appliedChanges.Test(t, stage.wantApplied)
 

--- a/internal/terraform/context_apply_ephemeral_test.go
+++ b/internal/terraform/context_apply_ephemeral_test.go
@@ -94,7 +94,7 @@ resource "test_object" "test" {
 	})
 
 	plan, diags := ctx.Plan(m, nil, DefaultPlanOpts)
-	assertNoDiagnostics(t, diags)
+	tfdiags.AssertNoDiagnostics(t, diags)
 
 	if !ephem.OpenEphemeralResourceCalled {
 		t.Error("OpenEphemeralResourceCalled not called")
@@ -114,7 +114,7 @@ resource "test_object" "test" {
 	renewDone = sync.OnceFunc(func() { close(renewed) })
 
 	_, diags = ctx.Apply(plan, m, nil)
-	assertNoDiagnostics(t, diags)
+	tfdiags.AssertNoDiagnostics(t, diags)
 
 	if !ephem.OpenEphemeralResourceCalled {
 		t.Error("OpenEphemeralResourceCalled not called")
@@ -235,7 +235,7 @@ output "data" {
 	})
 
 	plan, diags := ctx.Plan(m, nil, DefaultPlanOpts)
-	assertNoDiagnostics(t, diags)
+	tfdiags.AssertNoDiagnostics(t, diags)
 
 	if !ephem.OpenEphemeralResourceCalled {
 		t.Error("OpenEphemeralResourceCalled not called")
@@ -249,7 +249,7 @@ output "data" {
 	ephem.CloseEphemeralResourceCalled = false
 
 	state, diags := ctx.Apply(plan, m, nil)
-	assertNoDiagnostics(t, diags)
+	tfdiags.AssertNoDiagnostics(t, diags)
 
 	if !ephem.OpenEphemeralResourceCalled {
 		t.Error("OpenEphemeralResourceCalled not called")
@@ -263,7 +263,7 @@ output "data" {
 	ephem.CloseEphemeralResourceCalled = false
 
 	plan, diags = ctx.Plan(m, state, &PlanOpts{Mode: plans.DestroyMode})
-	assertNoDiagnostics(t, diags)
+	tfdiags.AssertNoDiagnostics(t, diags)
 
 	if !ephem.OpenEphemeralResourceCalled {
 		t.Error("OpenEphemeralResourceCalled not called")
@@ -276,7 +276,7 @@ output "data" {
 	ephem.CloseEphemeralResourceCalled = false
 
 	_, diags = ctx.Apply(plan, m, nil)
-	assertNoDiagnostics(t, diags)
+	tfdiags.AssertNoDiagnostics(t, diags)
 
 	if !ephem.OpenEphemeralResourceCalled {
 		t.Error("OpenEphemeralResourceCalled not called")
@@ -351,7 +351,7 @@ resource "test_object" "test" {
 	})
 
 	diags := ctx.Validate(m, &ValidateOpts{})
-	assertNoDiagnostics(t, diags)
+	tfdiags.AssertNoDiagnostics(t, diags)
 
 	plan, diags := ctx.Plan(m, nil, &PlanOpts{
 		SetVariables: InputValues{
@@ -361,13 +361,13 @@ resource "test_object" "test" {
 			},
 		},
 	})
-	assertNoDiagnostics(t, diags)
+	tfdiags.AssertNoDiagnostics(t, diags)
 
 	// reset the ephemeral call flags
 	ephem.ConfigureProviderCalled = false
 
 	_, diags = ctx.Apply(plan, m, nil)
-	assertNoDiagnostics(t, diags)
+	tfdiags.AssertNoDiagnostics(t, diags)
 }
 
 func TestContext2Apply_write_only_attribute_not_in_plan_and_state(t *testing.T) {
@@ -425,14 +425,14 @@ resource "ephem_write_only" "wo" {
 			"ephem": ephemVar,
 		},
 	})
-	assertNoDiagnostics(t, diags)
+	tfdiags.AssertNoDiagnostics(t, diags)
 
 	if len(plan.Changes.Resources) != 1 {
 		t.Fatalf("Expected 1 resource change, got %d", len(plan.Changes.Resources))
 	}
 
 	schemas, schemaDiags := ctx.Schemas(m, plan.PriorState)
-	assertNoDiagnostics(t, schemaDiags)
+	tfdiags.AssertNoDiagnostics(t, schemaDiags)
 	planChanges, err := plan.Changes.Decode(schemas)
 	if err != nil {
 		t.Fatalf("Failed to decode plan changes: %v.", err)
@@ -447,7 +447,7 @@ resource "ephem_write_only" "wo" {
 			"ephem": ephemVar,
 		},
 	})
-	assertNoDiagnostics(t, diags)
+	tfdiags.AssertNoDiagnostics(t, diags)
 
 	resource := state.Resource(addrs.AbsResource{
 		Module: addrs.RootModuleInstance,
@@ -551,14 +551,14 @@ resource "ephem_write_only" "wo" {
 			"ephem": ephemVar,
 		},
 	})
-	assertNoDiagnostics(t, diags)
+	tfdiags.AssertNoDiagnostics(t, diags)
 
 	if len(plan.Changes.Resources) != 1 {
 		t.Fatalf("Expected 1 resource change, got %d", len(plan.Changes.Resources))
 	}
 
 	schemas, schemaDiags := ctx.Schemas(m, plan.PriorState)
-	assertNoDiagnostics(t, schemaDiags)
+	tfdiags.AssertNoDiagnostics(t, schemaDiags)
 	planChanges, err := plan.Changes.Decode(schemas)
 	if err != nil {
 		t.Fatalf("Failed to decode plan changes: %v.", err)
@@ -573,7 +573,7 @@ resource "ephem_write_only" "wo" {
 			"ephem": ephemVar,
 		},
 	})
-	assertNoDiagnostics(t, diags)
+	tfdiags.AssertNoDiagnostics(t, diags)
 
 	resource := state.Resource(addrs.AbsResource{
 		Module: addrs.RootModuleInstance,
@@ -688,14 +688,14 @@ resource "ephem_write_only" "wo" {
 			"ephem": ephemVar,
 		},
 	})
-	assertNoDiagnostics(t, diags)
+	tfdiags.AssertNoDiagnostics(t, diags)
 
 	if len(plan.Changes.Resources) != 1 {
 		t.Fatalf("Expected 1 resource change, got %d", len(plan.Changes.Resources))
 	}
 
 	schemas, schemaDiags := ctx.Schemas(m, plan.PriorState)
-	assertNoDiagnostics(t, schemaDiags)
+	tfdiags.AssertNoDiagnostics(t, schemaDiags)
 	planChanges, err := plan.Changes.Decode(schemas)
 	if err != nil {
 		t.Fatalf("Failed to decode plan changes: %v.", err)
@@ -710,7 +710,7 @@ resource "ephem_write_only" "wo" {
 			"ephem": ephemVar,
 		},
 	})
-	assertNoDiagnostics(t, diags)
+	tfdiags.AssertNoDiagnostics(t, diags)
 
 	resource := state.Resource(addrs.AbsResource{
 		Module: addrs.RootModuleInstance,
@@ -805,7 +805,7 @@ resource "ephem_write_only" "wo" {
 		},
 	})
 
-	assertNoDiagnostics(t, planDiags)
+	tfdiags.AssertNoDiagnostics(t, planDiags)
 
 	_, diags := ctx.Apply(plan, m, &ApplyOpts{
 		SetVariables: InputValues{

--- a/internal/terraform/context_apply_identity_test.go
+++ b/internal/terraform/context_apply_identity_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform/internal/plans"
 	"github.com/hashicorp/terraform/internal/providers"
 	"github.com/hashicorp/terraform/internal/states"
+	"github.com/hashicorp/terraform/internal/tfdiags"
 )
 
 func TestContext2Apply_identity(t *testing.T) {
@@ -165,10 +166,10 @@ func TestContext2Apply_identity(t *testing.T) {
 			}
 
 			plan, diags := ctx.Plan(m, tc.prevRunState, &PlanOpts{Mode: tc.mode})
-			assertNoDiagnostics(t, diags)
+			tfdiags.AssertNoDiagnostics(t, diags)
 
 			state, diags := ctx.Apply(plan, m, nil)
-			assertNoDiagnostics(t, diags)
+			tfdiags.AssertNoDiagnostics(t, diags)
 
 			if !tc.expectedIdentity.IsNull() {
 				schema := p.GetProviderSchemaResponse.ResourceTypes["test_resource"]

--- a/internal/terraform/context_apply_test.go
+++ b/internal/terraform/context_apply_test.go
@@ -48,7 +48,7 @@ func TestContext2Apply_basic(t *testing.T) {
 	})
 
 	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	state, diags := ctx.Apply(plan, m, nil)
 	if diags.HasErrors() {
@@ -143,7 +143,7 @@ func TestContext2Apply_stop(t *testing.T) {
 	})
 
 	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	// We'll reset the hook events before we apply because we only care about
 	// the apply-time events.
@@ -320,7 +320,7 @@ func TestContext2Apply_escape(t *testing.T) {
 	})
 
 	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	state, diags := ctx.Apply(plan, m, nil)
 	if diags.HasErrors() {
@@ -348,10 +348,10 @@ func TestContext2Apply_resourceCountOneList(t *testing.T) {
 	})
 
 	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	state, diags := ctx.Apply(plan, m, nil)
-	assertNoDiagnostics(t, diags)
+	tfdiags.AssertNoDiagnostics(t, diags)
 
 	got := strings.TrimSpace(state.String())
 	want := strings.TrimSpace(`null_resource.foo.0:
@@ -376,7 +376,7 @@ func TestContext2Apply_resourceCountZeroList(t *testing.T) {
 	})
 
 	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	state, diags := ctx.Apply(plan, m, nil)
 	if diags.HasErrors() {
@@ -429,7 +429,7 @@ func TestContext2Apply_resourceDependsOnModule(t *testing.T) {
 	})
 
 	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	state, diags := ctx.Apply(plan, m, nil)
 	if diags.HasErrors() {
@@ -501,10 +501,10 @@ func TestContext2Apply_resourceDependsOnModuleStateOnly(t *testing.T) {
 		})
 
 		plan, diags := ctx.Plan(m, state, DefaultPlanOpts)
-		assertNoErrors(t, diags)
+		tfdiags.AssertNoErrors(t, diags)
 
 		state, diags := ctx.Apply(plan, m, nil)
-		assertNoErrors(t, diags)
+		tfdiags.AssertNoErrors(t, diags)
 
 		if !reflect.DeepEqual(order, []string{"child", "parent"}) {
 			t.Fatal("resources applied out of order")
@@ -528,7 +528,7 @@ func TestContext2Apply_resourceDependsOnModuleDestroy(t *testing.T) {
 		})
 
 		plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
-		assertNoErrors(t, diags)
+		tfdiags.AssertNoErrors(t, diags)
 
 		state, diags := ctx.Apply(plan, m, nil)
 		if diags.HasErrors() {
@@ -571,7 +571,7 @@ func TestContext2Apply_resourceDependsOnModuleDestroy(t *testing.T) {
 		plan, diags := ctx.Plan(m, globalState, &PlanOpts{
 			Mode: plans.DestroyMode,
 		})
-		assertNoErrors(t, diags)
+		tfdiags.AssertNoErrors(t, diags)
 
 		state, diags := ctx.Apply(plan, m, nil)
 		if diags.HasErrors() {
@@ -622,7 +622,7 @@ func TestContext2Apply_resourceDependsOnModuleGrandchild(t *testing.T) {
 		})
 
 		plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
-		assertNoErrors(t, diags)
+		tfdiags.AssertNoErrors(t, diags)
 
 		state, diags := ctx.Apply(plan, m, nil)
 		if diags.HasErrors() {
@@ -673,7 +673,7 @@ func TestContext2Apply_resourceDependsOnModuleInModule(t *testing.T) {
 		})
 
 		plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
-		assertNoErrors(t, diags)
+		tfdiags.AssertNoErrors(t, diags)
 
 		state, diags := ctx.Apply(plan, m, nil)
 		if diags.HasErrors() {
@@ -700,7 +700,7 @@ func TestContext2Apply_mapVarBetweenModules(t *testing.T) {
 	})
 
 	plan, diags := ctx.Plan(m, states.NewState(), SimplePlanOpts(plans.NormalMode, testInputValuesUnset(m.Module.Variables)))
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	state, diags := ctx.Apply(plan, m, nil)
 	if diags.HasErrors() {
@@ -735,7 +735,7 @@ func TestContext2Apply_refCount(t *testing.T) {
 	})
 
 	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	state, diags := ctx.Apply(plan, m, nil)
 	if diags.HasErrors() {
@@ -772,7 +772,7 @@ func TestContext2Apply_providerAlias(t *testing.T) {
 	})
 
 	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	state, diags := ctx.Apply(plan, m, nil)
 	if diags.HasErrors() {
@@ -875,7 +875,7 @@ func TestContext2Apply_providerWarning(t *testing.T) {
 	})
 
 	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	state, diags := ctx.Apply(plan, m, nil)
 	if diags.HasErrors() {
@@ -910,7 +910,7 @@ func TestContext2Apply_emptyModule(t *testing.T) {
 	})
 
 	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	state, diags := ctx.Apply(plan, m, nil)
 	if diags.HasErrors() {
@@ -1327,14 +1327,14 @@ func TestContext2Apply_destroyComputed(t *testing.T) {
 		Mode: plans.DestroyMode,
 	})
 	if diags.HasErrors() {
-		logDiagnostics(t, diags)
+		tfdiags.LogDiagnostics(t, diags)
 		t.Fatal("plan failed")
 	} else {
 		t.Logf("plan:\n\n%s", legacyDiffComparisonString(plan.Changes))
 	}
 
 	if _, diags := ctx.Apply(plan, m, nil); diags.HasErrors() {
-		logDiagnostics(t, diags)
+		tfdiags.LogDiagnostics(t, diags)
 		t.Fatal("apply failed")
 	}
 }
@@ -1395,7 +1395,7 @@ func testContext2Apply_destroyDependsOn(t *testing.T) {
 	plan, diags := ctx.Plan(m, state, &PlanOpts{
 		Mode: plans.DestroyMode,
 	})
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	if _, diags := ctx.Apply(plan, m, nil); diags.HasErrors() {
 		t.Fatalf("apply errors: %s", diags.Err())
@@ -1489,7 +1489,7 @@ func testContext2Apply_destroyDependsOnStateOnly(t *testing.T, state *states.Sta
 	plan, diags := ctx.Plan(m, state, &PlanOpts{
 		Mode: plans.DestroyMode,
 	})
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	if _, diags := ctx.Apply(plan, m, nil); diags.HasErrors() {
 		t.Fatalf("apply errors: %s", diags.Err())
@@ -1584,7 +1584,7 @@ func testContext2Apply_destroyDependsOnStateOnlyModule(t *testing.T, state *stat
 	plan, diags := ctx.Plan(m, state, &PlanOpts{
 		Mode: plans.DestroyMode,
 	})
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	if _, diags := ctx.Apply(plan, m, nil); diags.HasErrors() {
 		t.Fatalf("apply errors: %s", diags.Err())
@@ -1623,7 +1623,7 @@ func TestContext2Apply_dataBasic(t *testing.T) {
 	}
 
 	state, diags := ctx.Apply(plan, m, nil)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	actual := strings.TrimSpace(state.String())
 	expected := strings.TrimSpace(testTerraformApplyDataBasicStr)
@@ -1773,7 +1773,7 @@ func TestContext2Apply_destroyModuleVarProviderConfig(t *testing.T) {
 	plan, diags := ctx.Plan(m, state, &PlanOpts{
 		Mode: plans.DestroyMode,
 	})
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	_, diags = ctx.Apply(plan, m, nil)
 	if diags.HasErrors() {
@@ -1821,10 +1821,10 @@ func TestContext2Apply_destroyCrossProviders(t *testing.T) {
 	plan, diags := ctx.Plan(m, state, &PlanOpts{
 		Mode: plans.DestroyMode,
 	})
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	if _, diags := ctx.Apply(plan, m, nil); diags.HasErrors() {
-		logDiagnostics(t, diags)
+		tfdiags.LogDiagnostics(t, diags)
 		t.Fatal("apply failed")
 	}
 }
@@ -1869,7 +1869,7 @@ func TestContext2Apply_minimal(t *testing.T) {
 	})
 
 	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	state, diags := ctx.Apply(plan, m, nil)
 	if diags.HasErrors() {
@@ -1911,7 +1911,7 @@ func TestContext2Apply_cancel(t *testing.T) {
 	p.PlanResourceChangeFn = testDiffFn
 
 	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	// Start the Apply in a goroutine
 	var applyDiags tfdiags.Diagnostics
@@ -1973,7 +1973,7 @@ func TestContext2Apply_cancelBlock(t *testing.T) {
 	}
 
 	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	// Start the Apply in a goroutine
 	var applyDiags tfdiags.Diagnostics
@@ -2070,7 +2070,7 @@ func TestContext2Apply_cancelProvisioner(t *testing.T) {
 	}
 
 	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	// Start the Apply in a goroutine
 	var applyDiags tfdiags.Diagnostics
@@ -2166,7 +2166,7 @@ func TestContext2Apply_compute(t *testing.T) {
 			},
 		},
 	})
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	state, diags := ctx.Apply(plan, m, nil)
 	if diags.HasErrors() {
@@ -2219,10 +2219,10 @@ func TestContext2Apply_countDecrease(t *testing.T) {
 	})
 
 	plan, diags := ctx.Plan(m, state, DefaultPlanOpts)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	s, diags := ctx.Apply(plan, m, nil)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	actual := strings.TrimSpace(s.String())
 	expected := strings.TrimSpace(testTerraformApplyCountDecStr)
@@ -2269,7 +2269,7 @@ func TestContext2Apply_countDecreaseToOneX(t *testing.T) {
 	})
 
 	plan, diags := ctx.Plan(m, state, DefaultPlanOpts)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	s, diags := ctx.Apply(plan, m, nil)
 	if diags.HasErrors() {
@@ -2331,7 +2331,7 @@ func TestContext2Apply_countDecreaseToOneCorrupted(t *testing.T) {
 	})
 
 	plan, diags := ctx.Plan(m, state, DefaultPlanOpts)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 	{
 		got := strings.TrimSpace(legacyPlanComparisonString(state, plan.Changes))
 		want := strings.TrimSpace(testTerraformApplyCountDecToOneCorruptedPlanStr)
@@ -2398,7 +2398,7 @@ func TestContext2Apply_countTainted(t *testing.T) {
 	})
 
 	plan, diags := ctx.Plan(m, state, DefaultPlanOpts)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 	{
 		got := strings.TrimSpace(legacyDiffComparisonString(plan.Changes))
 		want := strings.TrimSpace(`
@@ -2417,7 +2417,7 @@ CREATE: aws_instance.foo[1]
 	}
 
 	s, diags := ctx.Apply(plan, m, nil)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	got := strings.TrimSpace(s.String())
 	want := strings.TrimSpace(`
@@ -2449,7 +2449,7 @@ func TestContext2Apply_countVariable(t *testing.T) {
 	})
 
 	plan, diags := ctx.Plan(m, states.NewState(), SimplePlanOpts(plans.NormalMode, testInputValuesUnset(m.Module.Variables)))
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	state, diags := ctx.Apply(plan, m, nil)
 	if diags.HasErrors() {
@@ -2475,7 +2475,7 @@ func TestContext2Apply_countVariableRef(t *testing.T) {
 	})
 
 	plan, diags := ctx.Plan(m, states.NewState(), SimplePlanOpts(plans.NormalMode, testInputValuesUnset(m.Module.Variables)))
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	state, diags := ctx.Apply(plan, m, nil)
 	if diags.HasErrors() {
@@ -2514,7 +2514,7 @@ func TestContext2Apply_provisionerInterpCount(t *testing.T) {
 	})
 
 	plan, diags := ctx.Plan(m, states.NewState(), SimplePlanOpts(plans.NormalMode, testInputValuesUnset(m.Module.Variables)))
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	// We'll marshal and unmarshal the plan here, to ensure that we have
 	// a clean new context as would be created if we separately ran
@@ -2561,7 +2561,7 @@ func TestContext2Apply_foreachVariable(t *testing.T) {
 			},
 		},
 	})
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	state, diags := ctx.Apply(plan, m, nil)
 	if diags.HasErrors() {
@@ -2587,7 +2587,7 @@ func TestContext2Apply_moduleBasic(t *testing.T) {
 	})
 
 	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	state, diags := ctx.Apply(plan, m, nil)
 	if diags.HasErrors() {
@@ -2668,7 +2668,7 @@ func TestContext2Apply_moduleDestroyOrder(t *testing.T) {
 	plan, diags := ctx.Plan(m, state, &PlanOpts{
 		Mode: plans.DestroyMode,
 	})
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	state, diags = ctx.Apply(plan, m, nil)
 	if diags.HasErrors() {
@@ -2716,7 +2716,7 @@ func TestContext2Apply_moduleInheritAlias(t *testing.T) {
 	})
 
 	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	state, diags := ctx.Apply(plan, m, nil)
 	if diags.HasErrors() {
@@ -2762,9 +2762,9 @@ func TestContext2Apply_orphanResource(t *testing.T) {
 		},
 	})
 	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 	state, diags := ctx.Apply(plan, m, nil)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	// At this point both resources should be recorded in the state, along
 	// with the single instance associated with test_thing.one.
@@ -2797,7 +2797,7 @@ func TestContext2Apply_orphanResource(t *testing.T) {
 		},
 	})
 	plan, diags = ctx.Plan(m, state, DefaultPlanOpts)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 	{
 		addr := mustResourceInstanceAddr("test_thing.one[0]")
 		change := plan.Changes.ResourceInstance(addr)
@@ -2813,7 +2813,7 @@ func TestContext2Apply_orphanResource(t *testing.T) {
 	}
 
 	state, diags = ctx.Apply(plan, m, nil)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	// The state should now be _totally_ empty, with just an empty root module
 	// (since that always exists) and no resources at all.
@@ -2863,7 +2863,7 @@ func TestContext2Apply_moduleOrphanInheritAlias(t *testing.T) {
 	})
 
 	plan, diags := ctx.Plan(m, state, DefaultPlanOpts)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 	{
 		addr := mustResourceInstanceAddr("module.child.aws_instance.bar")
 		change := plan.Changes.ResourceInstance(addr)
@@ -2926,7 +2926,7 @@ func TestContext2Apply_moduleOrphanProvider(t *testing.T) {
 	})
 
 	plan, diags := ctx.Plan(m, state, DefaultPlanOpts)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	if _, diags := ctx.Apply(plan, m, nil); diags.HasErrors() {
 		t.Fatalf("apply errors: %s", diags.Err())
@@ -2966,7 +2966,7 @@ func TestContext2Apply_moduleOrphanGrandchildProvider(t *testing.T) {
 	})
 
 	plan, diags := ctx.Plan(m, state, DefaultPlanOpts)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	if _, diags := ctx.Apply(plan, m, nil); diags.HasErrors() {
 		t.Fatalf("apply errors: %s", diags.Err())
@@ -3000,7 +3000,7 @@ func TestContext2Apply_moduleGrandchildProvider(t *testing.T) {
 	})
 
 	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	if _, diags := ctx.Apply(plan, m, nil); diags.HasErrors() {
 		t.Fatalf("apply errors: %s", diags.Err())
@@ -3034,7 +3034,7 @@ func TestContext2Apply_moduleOnlyProvider(t *testing.T) {
 	})
 
 	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	state, diags := ctx.Apply(plan, m, nil)
 	if diags.HasErrors() {
@@ -3060,7 +3060,7 @@ func TestContext2Apply_moduleProviderAlias(t *testing.T) {
 	})
 
 	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	state, diags := ctx.Apply(plan, m, nil)
 	if diags.HasErrors() {
@@ -3097,7 +3097,7 @@ func TestContext2Apply_moduleProviderAliasTargets(t *testing.T) {
 			},
 		},
 	})
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	state, diags := ctx.Apply(plan, m, nil)
 	if diags.HasErrors() {
@@ -3137,7 +3137,7 @@ func TestContext2Apply_moduleProviderCloseNested(t *testing.T) {
 	plan, diags := ctx.Plan(m, state, &PlanOpts{
 		Mode: plans.DestroyMode,
 	})
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	if _, diags := ctx.Apply(plan, m, nil); diags.HasErrors() {
 		t.Fatalf("apply errors: %s", diags.Err())
@@ -3172,7 +3172,7 @@ func TestContext2Apply_moduleVarRefExisting(t *testing.T) {
 	})
 
 	plan, diags := ctx.Plan(m, state, DefaultPlanOpts)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	state, diags = ctx.Apply(plan, m, nil)
 	if diags.HasErrors() {
@@ -3205,10 +3205,10 @@ func TestContext2Apply_moduleVarResourceCount(t *testing.T) {
 			},
 		},
 	})
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	state, diags := ctx.Apply(plan, m, nil)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	ctx = testContext2(t, &ContextOpts{
 		Providers: map[addrs.Provider]providers.Factory{
@@ -3225,7 +3225,7 @@ func TestContext2Apply_moduleVarResourceCount(t *testing.T) {
 			},
 		},
 	})
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	if _, diags := ctx.Apply(plan, m, nil); diags.HasErrors() {
 		t.Fatalf("apply errors: %s", diags.Err())
@@ -3245,7 +3245,7 @@ func TestContext2Apply_moduleBool(t *testing.T) {
 	})
 
 	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	state, diags := ctx.Apply(plan, m, nil)
 	if diags.HasErrors() {
@@ -3278,7 +3278,7 @@ func TestContext2Apply_moduleTarget(t *testing.T) {
 			addrs.RootModuleInstance.Child("B", addrs.NoKey),
 		},
 	})
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	state, diags := ctx.Apply(plan, m, nil)
 	if diags.HasErrors() {
@@ -3323,7 +3323,7 @@ func TestContext2Apply_multiProvider(t *testing.T) {
 	})
 
 	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	state, diags := ctx.Apply(plan, m, nil)
 	if diags.HasErrors() {
@@ -3387,10 +3387,10 @@ func TestContext2Apply_multiProviderDestroy(t *testing.T) {
 		})
 
 		plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
-		assertNoErrors(t, diags)
+		tfdiags.AssertNoErrors(t, diags)
 
 		s, diags := ctx.Apply(plan, m, nil)
-		assertNoErrors(t, diags)
+		tfdiags.AssertNoErrors(t, diags)
 
 		state = s
 	}
@@ -3436,10 +3436,10 @@ func TestContext2Apply_multiProviderDestroy(t *testing.T) {
 		plan, diags := ctx.Plan(m, state, &PlanOpts{
 			Mode: plans.DestroyMode,
 		})
-		assertNoErrors(t, diags)
+		tfdiags.AssertNoErrors(t, diags)
 
 		s, diags := ctx.Apply(plan, m, nil)
-		assertNoErrors(t, diags)
+		tfdiags.AssertNoErrors(t, diags)
 
 		if !checked {
 			t.Fatal("should be checked")
@@ -3500,7 +3500,7 @@ func TestContext2Apply_multiProviderDestroyChild(t *testing.T) {
 		})
 
 		plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
-		assertNoErrors(t, diags)
+		tfdiags.AssertNoErrors(t, diags)
 
 		s, diags := ctx.Apply(plan, m, nil)
 		if diags.HasErrors() {
@@ -3551,7 +3551,7 @@ func TestContext2Apply_multiProviderDestroyChild(t *testing.T) {
 		plan, diags := ctx.Plan(m, state, &PlanOpts{
 			Mode: plans.DestroyMode,
 		})
-		assertNoErrors(t, diags)
+		tfdiags.AssertNoErrors(t, diags)
 
 		s, diags := ctx.Apply(plan, m, nil)
 		if diags.HasErrors() {
@@ -3591,7 +3591,7 @@ func TestContext2Apply_multiVar(t *testing.T) {
 			},
 		},
 	})
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	state, diags := ctx.Apply(plan, m, nil)
 	if diags.HasErrors() {
@@ -3623,7 +3623,7 @@ func TestContext2Apply_multiVar(t *testing.T) {
 				},
 			},
 		})
-		assertNoErrors(t, diags)
+		tfdiags.AssertNoErrors(t, diags)
 
 		state, diags := ctx.Apply(plan, m, nil)
 		if diags.HasErrors() {
@@ -3728,7 +3728,7 @@ func TestContext2Apply_multiVarComprehensive(t *testing.T) {
 			},
 		},
 	})
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	checkConfig := func(key string, want cty.Value) {
 		configsLock.Lock()
@@ -3866,7 +3866,7 @@ func TestContext2Apply_multiVarOrder(t *testing.T) {
 	})
 
 	plan, diags := ctx.Plan(m, states.NewState(), SimplePlanOpts(plans.NormalMode, testInputValuesUnset(m.Module.Variables)))
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	state, diags := ctx.Apply(plan, m, nil)
 	if diags.HasErrors() {
@@ -3897,7 +3897,7 @@ func TestContext2Apply_multiVarOrderInterp(t *testing.T) {
 	})
 
 	plan, diags := ctx.Plan(m, states.NewState(), SimplePlanOpts(plans.NormalMode, testInputValuesUnset(m.Module.Variables)))
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	state, diags := ctx.Apply(plan, m, nil)
 	if diags.HasErrors() {
@@ -3940,7 +3940,7 @@ func TestContext2Apply_multiVarCountDec(t *testing.T) {
 				},
 			},
 		})
-		assertNoErrors(t, diags)
+		tfdiags.AssertNoErrors(t, diags)
 
 		log.Print("\n========\nStep 1 Apply\n========")
 		state, diags := ctx.Apply(plan, m, nil)
@@ -4004,7 +4004,7 @@ func TestContext2Apply_multiVarCountDec(t *testing.T) {
 				},
 			},
 		})
-		assertNoErrors(t, diags)
+		tfdiags.AssertNoErrors(t, diags)
 
 		t.Logf("Step 2 plan:\n%s", legacyDiffComparisonString(plan.Changes))
 
@@ -4047,7 +4047,7 @@ func TestContext2Apply_multiVarMissingState(t *testing.T) {
 	})
 
 	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	// Before the relevant bug was fixed, Terraform would panic during apply.
 	if _, diags := ctx.Apply(plan, m, nil); diags.HasErrors() {
@@ -4079,7 +4079,7 @@ func TestContext2Apply_outputOrphan(t *testing.T) {
 	})
 
 	plan, diags := ctx.Plan(m, state, DefaultPlanOpts)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	state, diags = ctx.Apply(plan, m, nil)
 	if diags.HasErrors() {
@@ -4112,7 +4112,7 @@ func TestContext2Apply_outputOrphanModule(t *testing.T) {
 	})
 
 	plan, diags := ctx.Plan(m, state, DefaultPlanOpts)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	s, diags := ctx.Apply(plan, m, nil)
 	if diags.HasErrors() {
@@ -4142,7 +4142,7 @@ func TestContext2Apply_outputOrphanModule(t *testing.T) {
 	// it to avoid changing the flow of this test in case that's important
 	// for some reason.
 	plan, diags = ctx.Plan(emptyConfig, state.DeepCopy(), DefaultPlanOpts)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	state, diags = ctx.Apply(plan, emptyConfig, nil)
 	if diags.HasErrors() {
@@ -4180,7 +4180,7 @@ func TestContext2Apply_providerComputedVar(t *testing.T) {
 	}
 
 	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	if _, diags := ctx.Apply(plan, m, nil); diags.HasErrors() {
 		t.Fatalf("apply errors: %s", diags.Err())
@@ -4208,7 +4208,7 @@ func TestContext2Apply_providerConfigureDisabled(t *testing.T) {
 	})
 
 	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	if _, diags := ctx.Apply(plan, m, nil); diags.HasErrors() {
 		t.Fatalf("apply errors: %s", diags.Err())
@@ -4245,7 +4245,7 @@ func TestContext2Apply_provisionerModule(t *testing.T) {
 	})
 
 	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	state, diags := ctx.Apply(plan, m, nil)
 	if diags.HasErrors() {
@@ -4300,7 +4300,7 @@ func TestContext2Apply_Provisioner_compute(t *testing.T) {
 			},
 		},
 	})
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	state, diags := ctx.Apply(plan, m, nil)
 	if diags.HasErrors() {
@@ -4350,7 +4350,7 @@ func TestContext2Apply_provisionerCreateFail(t *testing.T) {
 	})
 
 	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	state, diags := ctx.Apply(plan, m, nil)
 	if diags == nil {
@@ -4385,7 +4385,7 @@ func TestContext2Apply_provisionerCreateFailNoId(t *testing.T) {
 	})
 
 	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	state, diags := ctx.Apply(plan, m, nil)
 	if diags == nil {
@@ -4420,7 +4420,7 @@ func TestContext2Apply_provisionerFail(t *testing.T) {
 	})
 
 	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	state, diags := ctx.Apply(plan, m, nil)
 	if diags == nil {
@@ -4466,7 +4466,7 @@ func TestContext2Apply_provisionerFail_createBeforeDestroy(t *testing.T) {
 	})
 
 	plan, diags := ctx.Plan(m, state, DefaultPlanOpts)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	state, diags = ctx.Apply(plan, m, nil)
 	if !diags.HasErrors() {
@@ -4507,7 +4507,7 @@ func TestContext2Apply_error_createBeforeDestroy(t *testing.T) {
 	p.PlanResourceChangeFn = testDiffFn
 
 	plan, diags := ctx.Plan(m, state, DefaultPlanOpts)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	state, diags = ctx.Apply(plan, m, nil)
 	if !diags.HasErrors() {
@@ -4559,7 +4559,7 @@ func TestContext2Apply_errorDestroy_createBeforeDestroy(t *testing.T) {
 	p.PlanResourceChangeFn = testDiffFn
 
 	plan, diags := ctx.Plan(m, state, DefaultPlanOpts)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	state, diags = ctx.Apply(plan, m, nil)
 	if !diags.HasErrors() {
@@ -4635,7 +4635,7 @@ func TestContext2Apply_multiDepose_createBeforeDestroy(t *testing.T) {
 			},
 		},
 	})
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	// Destroy is broken, so even though CBD successfully replaces the instance,
 	// we'll have to save the Deposed instance to destroy later
@@ -4665,7 +4665,7 @@ aws_instance.web: (1 deposed)
 			},
 		},
 	})
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	// We're replacing the primary instance once again. Destroy is _still_
 	// broken, so the Deposed list gets longer
@@ -4730,7 +4730,7 @@ aws_instance.web: (1 deposed)
 			},
 		},
 	})
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	state, diags = ctx.Apply(plan, m, nil)
 	// Expect error because 1/2 of Deposed destroys failed
@@ -4765,7 +4765,7 @@ aws_instance.web: (1 deposed)
 			},
 		},
 	})
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 	state, diags = ctx.Apply(plan, m, nil)
 	if diags.HasErrors() {
 		t.Fatal("should not have error:", diags.Err())
@@ -4804,7 +4804,7 @@ func TestContext2Apply_provisionerFailContinue(t *testing.T) {
 	})
 
 	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	state, diags := ctx.Apply(plan, m, nil)
 	if diags.HasErrors() {
@@ -4849,7 +4849,7 @@ func TestContext2Apply_provisionerFailContinueHook(t *testing.T) {
 	})
 
 	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	if _, diags := ctx.Apply(plan, m, nil); diags.HasErrors() {
 		t.Fatalf("apply errors: %s", diags.Err())
@@ -4898,7 +4898,7 @@ func TestContext2Apply_provisionerDestroy(t *testing.T) {
 	})
 
 	plan, diags := ctx.Plan(m, state, SimplePlanOpts(plans.DestroyMode, testInputValuesUnset(m.Module.Variables)))
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	state, diags = ctx.Apply(plan, m, nil)
 	if diags.HasErrors() {
@@ -4949,7 +4949,7 @@ func TestContext2Apply_provisionerDestroyRemoved(t *testing.T) {
 	})
 
 	plan, diags := ctx.Plan(m, state, SimplePlanOpts(plans.NormalMode, testInputValuesUnset(m.Module.Variables)))
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	state, diags = ctx.Apply(plan, m, nil)
 	if diags.HasErrors() {
@@ -4996,7 +4996,7 @@ func TestContext2Apply_provisionerDestroyFail(t *testing.T) {
 	})
 
 	plan, diags := ctx.Plan(m, state, SimplePlanOpts(plans.DestroyMode, testInputValuesUnset(m.Module.Variables)))
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	state, diags = ctx.Apply(plan, m, nil)
 	if diags == nil {
@@ -5062,7 +5062,7 @@ func TestContext2Apply_provisionerDestroyFailContinue(t *testing.T) {
 	plan, diags := ctx.Plan(m, state, &PlanOpts{
 		Mode: plans.DestroyMode,
 	})
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	state, diags = ctx.Apply(plan, m, nil)
 	if diags.HasErrors() {
@@ -5129,7 +5129,7 @@ func TestContext2Apply_provisionerDestroyFailContinueFail(t *testing.T) {
 	plan, diags := ctx.Plan(m, state, &PlanOpts{
 		Mode: plans.DestroyMode,
 	})
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	state, diags = ctx.Apply(plan, m, nil)
 	if diags == nil {
@@ -5203,7 +5203,7 @@ func TestContext2Apply_provisionerDestroyTainted(t *testing.T) {
 			},
 		},
 	})
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	state, diags = ctx.Apply(plan, m, nil)
 	if diags.HasErrors() {
@@ -5254,7 +5254,7 @@ func TestContext2Apply_provisionerResourceRef(t *testing.T) {
 	})
 
 	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	state, diags := ctx.Apply(plan, m, nil)
 	if diags.HasErrors() {
@@ -5298,7 +5298,7 @@ func TestContext2Apply_provisionerSelfRef(t *testing.T) {
 	})
 
 	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	state, diags := ctx.Apply(plan, m, nil)
 	if diags.HasErrors() {
@@ -5349,7 +5349,7 @@ func TestContext2Apply_provisionerMultiSelfRef(t *testing.T) {
 	})
 
 	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	state, diags := ctx.Apply(plan, m, nil)
 	if diags.HasErrors() {
@@ -5407,7 +5407,7 @@ func TestContext2Apply_provisionerMultiSelfRefSingle(t *testing.T) {
 	})
 
 	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	state, diags := ctx.Apply(plan, m, nil)
 	if diags.HasErrors() {
@@ -5525,7 +5525,7 @@ func TestContext2Apply_provisionerForEachSelfRef(t *testing.T) {
 	})
 
 	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	_, diags = ctx.Apply(plan, m, nil)
 	if diags.HasErrors() {
@@ -5550,11 +5550,11 @@ func TestContext2Apply_Provisioner_Diff(t *testing.T) {
 	})
 
 	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	state, diags := ctx.Apply(plan, m, nil)
 	if diags.HasErrors() {
-		logDiagnostics(t, diags)
+		tfdiags.LogDiagnostics(t, diags)
 		t.Fatal("apply failed")
 	}
 
@@ -5595,11 +5595,11 @@ func TestContext2Apply_Provisioner_Diff(t *testing.T) {
 	})
 
 	plan, diags = ctx.Plan(m, state, DefaultPlanOpts)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	state2, diags := ctx.Apply(plan, m, nil)
 	if diags.HasErrors() {
-		logDiagnostics(t, diags)
+		tfdiags.LogDiagnostics(t, diags)
 		t.Fatal("apply failed")
 	}
 
@@ -5664,10 +5664,10 @@ func TestContext2Apply_outputDiffVars(t *testing.T) {
 	//}
 
 	plan, diags := ctx.Plan(m, state, DefaultPlanOpts)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	_, diags = ctx.Apply(plan, m, nil)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 }
 
 func TestContext2Apply_destroyX(t *testing.T) {
@@ -5684,7 +5684,7 @@ func TestContext2Apply_destroyX(t *testing.T) {
 
 	// First plan and apply a create operation
 	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	state, diags := ctx.Apply(plan, m, nil)
 	if diags.HasErrors() {
@@ -5703,7 +5703,7 @@ func TestContext2Apply_destroyX(t *testing.T) {
 	plan, diags = ctx.Plan(m, state, &PlanOpts{
 		Mode: plans.DestroyMode,
 	})
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	state, diags = ctx.Apply(plan, m, nil)
 	if diags.HasErrors() {
@@ -5739,7 +5739,7 @@ func TestContext2Apply_destroyOrder(t *testing.T) {
 
 	// First plan and apply a create operation
 	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	state, diags := ctx.Apply(plan, m, nil)
 	if diags.HasErrors() {
@@ -5760,7 +5760,7 @@ func TestContext2Apply_destroyOrder(t *testing.T) {
 	plan, diags = ctx.Plan(m, state, &PlanOpts{
 		Mode: plans.DestroyMode,
 	})
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	state, diags = ctx.Apply(plan, m, nil)
 	if diags.HasErrors() {
@@ -5797,7 +5797,7 @@ func TestContext2Apply_destroyModulePrefix(t *testing.T) {
 
 	// First plan and apply a create operation
 	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	state, diags := ctx.Apply(plan, m, nil)
 	if diags.HasErrors() {
@@ -5821,7 +5821,7 @@ func TestContext2Apply_destroyModulePrefix(t *testing.T) {
 	plan, diags = ctx.Plan(m, state, &PlanOpts{
 		Mode: plans.DestroyMode,
 	})
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	_, diags = ctx.Apply(plan, m, nil)
 	if diags.HasErrors() {
@@ -5858,7 +5858,7 @@ func TestContext2Apply_destroyNestedModule(t *testing.T) {
 
 	// First plan and apply a create operation
 	plan, diags := ctx.Plan(m, state, DefaultPlanOpts)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	s, diags := ctx.Apply(plan, m, nil)
 	if diags.HasErrors() {
@@ -5896,7 +5896,7 @@ func TestContext2Apply_destroyDeeplyNestedModule(t *testing.T) {
 
 	// First plan and apply a create operation
 	plan, diags := ctx.Plan(m, state, DefaultPlanOpts)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	s, diags := ctx.Apply(plan, m, nil)
 	if diags.HasErrors() {
@@ -6003,7 +6003,7 @@ func TestContext2Apply_destroyWithModuleVariableAndCount(t *testing.T) {
 
 		// First plan and apply a create operation
 		plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
-		assertNoErrors(t, diags)
+		tfdiags.AssertNoErrors(t, diags)
 
 		state, diags = ctx.Apply(plan, m, nil)
 		if diags.HasErrors() {
@@ -6075,7 +6075,7 @@ func TestContext2Apply_destroyTargetWithModuleVariableAndCount(t *testing.T) {
 
 		// First plan and apply a create operation
 		plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
-		assertNoErrors(t, diags)
+		tfdiags.AssertNoErrors(t, diags)
 
 		state, diags = ctx.Apply(plan, m, nil)
 		if diags.HasErrors() {
@@ -6149,7 +6149,7 @@ func TestContext2Apply_destroyWithModuleVariableAndCountNested(t *testing.T) {
 
 		// First plan and apply a create operation
 		plan, diags := ctx.Plan(m, states.NewState(), SimplePlanOpts(plans.NormalMode, testInputValuesUnset(m.Module.Variables)))
-		assertNoErrors(t, diags)
+		tfdiags.AssertNoErrors(t, diags)
 
 		state, diags = ctx.Apply(plan, m, nil)
 		if diags.HasErrors() {
@@ -6227,7 +6227,7 @@ func TestContext2Apply_destroyOutputs(t *testing.T) {
 
 	// First plan and apply a create operation
 	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	state, diags := ctx.Apply(plan, m, nil)
 
@@ -6245,7 +6245,7 @@ func TestContext2Apply_destroyOutputs(t *testing.T) {
 	plan, diags = ctx.Plan(m, state, &PlanOpts{
 		Mode: plans.DestroyMode,
 	})
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	state, diags = ctx.Apply(plan, m, nil)
 	if diags.HasErrors() {
@@ -6266,7 +6266,7 @@ func TestContext2Apply_destroyOutputs(t *testing.T) {
 	plan, diags = ctx.Plan(m, state, &PlanOpts{
 		Mode: plans.DestroyMode,
 	})
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	if _, diags := ctx.Apply(plan, m, nil); diags.HasErrors() {
 		t.Fatal(diags.Err())
@@ -6295,7 +6295,7 @@ func TestContext2Apply_destroyOrphan(t *testing.T) {
 	p.PlanResourceChangeFn = testDiffFn
 
 	plan, diags := ctx.Plan(m, state, DefaultPlanOpts)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	s, diags := ctx.Apply(plan, m, nil)
 	if diags.HasErrors() {
@@ -6337,7 +6337,7 @@ func TestContext2Apply_destroyTaintedProvisioner(t *testing.T) {
 	plan, diags := ctx.Plan(m, state, &PlanOpts{
 		Mode: plans.DestroyMode,
 	})
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	s, diags := ctx.Apply(plan, m, nil)
 	if diags.HasErrors() {
@@ -6379,7 +6379,7 @@ func TestContext2Apply_error(t *testing.T) {
 	p.PlanResourceChangeFn = testDiffFn
 
 	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	state, diags := ctx.Apply(plan, m, nil)
 	if diags == nil {
@@ -6446,7 +6446,7 @@ func TestContext2Apply_errorDestroy(t *testing.T) {
 		)
 	})
 	plan, diags := ctx.Plan(m, state, DefaultPlanOpts)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	state, diags = ctx.Apply(plan, m, nil)
 	if !diags.HasErrors() {
@@ -6503,7 +6503,7 @@ func TestContext2Apply_errorCreateInvalidNew(t *testing.T) {
 	})
 
 	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	state, diags := ctx.Apply(plan, m, nil)
 	if diags == nil {
@@ -6578,7 +6578,7 @@ func TestContext2Apply_errorUpdateNullNew(t *testing.T) {
 		)
 	})
 	plan, diags := ctx.Plan(m, state, DefaultPlanOpts)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	state, diags = ctx.Apply(plan, m, nil)
 	if !diags.HasErrors() {
@@ -6645,7 +6645,7 @@ func TestContext2Apply_errorPartial(t *testing.T) {
 	p.PlanResourceChangeFn = testDiffFn
 
 	plan, diags := ctx.Plan(m, state, DefaultPlanOpts)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	s, diags := ctx.Apply(plan, m, nil)
 	if diags == nil {
@@ -6677,7 +6677,7 @@ func TestContext2Apply_hook(t *testing.T) {
 	})
 
 	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	if _, diags := ctx.Apply(plan, m, nil); diags.HasErrors() {
 		t.Fatalf("apply errors: %s", diags.Err())
@@ -6719,7 +6719,7 @@ func TestContext2Apply_hookOrphan(t *testing.T) {
 	})
 
 	plan, diags := ctx.Plan(m, state, DefaultPlanOpts)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	if _, diags := ctx.Apply(plan, m, nil); diags.HasErrors() {
 		t.Fatalf("apply errors: %s", diags.Err())
@@ -6749,7 +6749,7 @@ func TestContext2Apply_idAttr(t *testing.T) {
 	p.ApplyResourceChangeFn = testApplyFn
 
 	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	state, diags := ctx.Apply(plan, m, nil)
 	if diags.HasErrors() {
@@ -6783,7 +6783,7 @@ func TestContext2Apply_outputBasic(t *testing.T) {
 	})
 
 	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	state, diags := ctx.Apply(plan, m, nil)
 	if diags.HasErrors() {
@@ -6809,7 +6809,7 @@ func TestContext2Apply_outputAdd(t *testing.T) {
 	})
 
 	plan1, diags := ctx1.Plan(m1, states.NewState(), DefaultPlanOpts)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	state1, diags := ctx1.Apply(plan1, m1, nil)
 	if diags.HasErrors() {
@@ -6827,7 +6827,7 @@ func TestContext2Apply_outputAdd(t *testing.T) {
 	})
 
 	plan2, diags := ctx1.Plan(m2, state1, DefaultPlanOpts)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	state2, diags := ctx2.Apply(plan2, m2, nil)
 	if diags.HasErrors() {
@@ -6853,7 +6853,7 @@ func TestContext2Apply_outputList(t *testing.T) {
 	})
 
 	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	state, diags := ctx.Apply(plan, m, nil)
 	if diags.HasErrors() {
@@ -6879,7 +6879,7 @@ func TestContext2Apply_outputMulti(t *testing.T) {
 	})
 
 	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	state, diags := ctx.Apply(plan, m, nil)
 	if diags.HasErrors() {
@@ -6905,7 +6905,7 @@ func TestContext2Apply_outputMultiIndex(t *testing.T) {
 	})
 
 	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	state, diags := ctx.Apply(plan, m, nil)
 	if diags.HasErrors() {
@@ -7100,7 +7100,7 @@ func TestContext2Apply_targeted(t *testing.T) {
 			),
 		},
 	})
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	state, diags := ctx.Apply(plan, m, nil)
 	if diags.HasErrors() {
@@ -7140,7 +7140,7 @@ func TestContext2Apply_targetedCount(t *testing.T) {
 			),
 		},
 	})
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	state, diags := ctx.Apply(plan, m, nil)
 	if diags.HasErrors() {
@@ -7182,7 +7182,7 @@ func TestContext2Apply_targetedCountIndex(t *testing.T) {
 			),
 		},
 	})
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	state, diags := ctx.Apply(plan, m, nil)
 	if diags.HasErrors() {
@@ -7245,7 +7245,7 @@ func TestContext2Apply_targetedDestroy(t *testing.T) {
 			),
 		},
 	})
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	state, diags = ctx.Apply(plan, m, nil)
 	if diags.HasErrors() {
@@ -7324,7 +7324,7 @@ func TestContext2Apply_targetedDestroyCountDeps(t *testing.T) {
 			),
 		},
 	})
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	state, diags = ctx.Apply(plan, m, nil)
 	if diags.HasErrors() {
@@ -7390,7 +7390,7 @@ func TestContext2Apply_targetedDestroyModule(t *testing.T) {
 			),
 		},
 	})
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	state, diags = ctx.Apply(plan, m, nil)
 	if diags.HasErrors() {
@@ -7476,7 +7476,7 @@ func TestContext2Apply_targetedDestroyCountIndex(t *testing.T) {
 			),
 		},
 	})
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	state, diags = ctx.Apply(plan, m, nil)
 	if diags.HasErrors() {
@@ -7516,7 +7516,7 @@ func TestContext2Apply_targetedModule(t *testing.T) {
 			addrs.RootModuleInstance.Child("child", addrs.NoKey),
 		},
 	})
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	state, diags := ctx.Apply(plan, m, nil)
 	if diags.HasErrors() {
@@ -7620,7 +7620,7 @@ func TestContext2Apply_targetedModuleUnrelatedOutputs(t *testing.T) {
 			addrs.RootModuleInstance.Child("child2", addrs.NoKey),
 		},
 	})
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	s, diags := ctx.Apply(plan, m, nil)
 	if diags.HasErrors() {
@@ -7664,7 +7664,7 @@ func TestContext2Apply_targetedModuleResource(t *testing.T) {
 			),
 		},
 	})
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	state, diags := ctx.Apply(plan, m, nil)
 	if diags.HasErrors() {
@@ -7717,7 +7717,7 @@ func TestContext2Apply_targetedResourceOrphanModule(t *testing.T) {
 			),
 		},
 	})
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	if _, diags := ctx.Apply(plan, m, nil); diags.HasErrors() {
 		t.Fatalf("apply errors: %s", diags.Err())
@@ -7756,7 +7756,7 @@ func TestContext2Apply_unknownAttribute(t *testing.T) {
 	})
 
 	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	state, diags := ctx.Apply(plan, m, nil)
 	if !diags.HasErrors() {
@@ -7834,7 +7834,7 @@ func TestContext2Apply_vars(t *testing.T) {
 		Mode:         plans.NormalMode,
 		SetVariables: variables,
 	})
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	state, diags := ctx.Apply(plan, m, nil)
 	if diags.HasErrors() {
@@ -7885,7 +7885,7 @@ func TestContext2Apply_varsEnv(t *testing.T) {
 		Mode:         plans.NormalMode,
 		SetVariables: variables,
 	})
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	state, diags := ctx.Apply(plan, m, nil)
 	if diags.HasErrors() {
@@ -7958,7 +7958,7 @@ func TestContext2Apply_createBefore_depends(t *testing.T) {
 
 	plan, diags := ctx.Plan(m, state, DefaultPlanOpts)
 	if diags.HasErrors() {
-		logDiagnostics(t, diags)
+		tfdiags.LogDiagnostics(t, diags)
 		t.Fatal("plan failed")
 	} else {
 		t.Logf("plan:\n%s", legacyDiffComparisonString(plan.Changes))
@@ -7967,7 +7967,7 @@ func TestContext2Apply_createBefore_depends(t *testing.T) {
 	h.Active = true
 	state, diags = ctx.Apply(plan, m, nil)
 	if diags.HasErrors() {
-		logDiagnostics(t, diags)
+		tfdiags.LogDiagnostics(t, diags)
 		t.Fatal("apply failed")
 	}
 
@@ -8085,7 +8085,7 @@ func TestContext2Apply_singleDestroy(t *testing.T) {
 	})
 
 	plan, diags := ctx.Plan(m, state, DefaultPlanOpts)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	h.Active = true
 	_, diags = ctx.Apply(plan, m, nil)
@@ -8445,10 +8445,10 @@ func TestContext2Apply_ignoreChangesWithDep(t *testing.T) {
 	})
 
 	plan, diags := ctx.Plan(m, state.DeepCopy(), DefaultPlanOpts)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	s, diags := ctx.Apply(plan, m, nil)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	actual := strings.TrimSpace(s.String())
 	expected := strings.TrimSpace(state.String())
@@ -8477,14 +8477,14 @@ func TestContext2Apply_ignoreChangesAll(t *testing.T) {
 
 	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
 	if diags.HasErrors() {
-		logDiagnostics(t, diags)
+		tfdiags.LogDiagnostics(t, diags)
 		t.Fatal("plan failed")
 	} else {
 		t.Log(legacyDiffComparisonString(plan.Changes))
 	}
 
 	state, diags := ctx.Apply(plan, m, nil)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	mod := state.RootModule()
 	if len(mod.Resources) != 1 {
@@ -8521,7 +8521,7 @@ func TestContext2Apply_destroyNestedModuleWithAttrsReferencingResource(t *testin
 
 		// First plan and apply a create operation
 		plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
-		assertNoErrors(t, diags)
+		tfdiags.AssertNoErrors(t, diags)
 
 		state, diags = ctx.Apply(plan, m, nil)
 		if diags.HasErrors() {
@@ -8616,10 +8616,10 @@ resource "null_instance" "depends" {
 	}
 
 	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	state, diags := ctx.Apply(plan, m, nil)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	root := state.Module(addrs.RootModuleInstance)
 	is := root.ResourceInstance(addrs.Resource{
@@ -8643,7 +8643,7 @@ resource "null_instance" "depends" {
 
 	// run another plan to make sure the data source doesn't show as a change
 	plan, diags = ctx.Plan(m, state, DefaultPlanOpts)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	for _, c := range plan.Changes.Resources {
 		if c.Action != plans.NoOp {
@@ -8682,7 +8682,7 @@ resource "null_instance" "depends" {
 	})
 
 	plan, diags = ctx.Plan(m, state, DefaultPlanOpts)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	expectedChanges := map[string]plans.Action{
 		"null_instance.write":        plans.Update,
@@ -8710,7 +8710,7 @@ func TestContext2Apply_terraformWorkspace(t *testing.T) {
 	})
 
 	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	state, diags := ctx.Apply(plan, m, nil)
 	if diags.HasErrors() {
@@ -8736,7 +8736,7 @@ func TestContext2Apply_multiRef(t *testing.T) {
 	})
 
 	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	state, diags := ctx.Apply(plan, m, nil)
 	if diags.HasErrors() {
@@ -8766,7 +8766,7 @@ func TestContext2Apply_targetedModuleRecursive(t *testing.T) {
 			addrs.RootModuleInstance.Child("child", addrs.NoKey),
 		},
 	})
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	state, diags := ctx.Apply(plan, m, nil)
 	if diags.HasErrors() {
@@ -8801,7 +8801,7 @@ func TestContext2Apply_localVal(t *testing.T) {
 	})
 
 	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	state, diags := ctx.Apply(plan, m, nil)
 	if diags.HasErrors() {
@@ -8850,7 +8850,7 @@ func TestContext2Apply_destroyWithLocals(t *testing.T) {
 	plan, diags := ctx.Plan(m, state, &PlanOpts{
 		Mode: plans.DestroyMode,
 	})
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	s, diags := ctx.Apply(plan, m, nil)
 	if diags.HasErrors() {
@@ -8887,7 +8887,7 @@ func TestContext2Apply_providerWithLocals(t *testing.T) {
 	})
 
 	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	state, diags := ctx.Apply(plan, m, nil)
 	if diags.HasErrors() {
@@ -8903,7 +8903,7 @@ func TestContext2Apply_providerWithLocals(t *testing.T) {
 	plan, diags = ctx.Plan(m, state, &PlanOpts{
 		Mode: plans.DestroyMode,
 	})
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	state, diags = ctx.Apply(plan, m, nil)
 	if diags.HasErrors() {
@@ -8958,7 +8958,7 @@ func TestContext2Apply_destroyWithProviders(t *testing.T) {
 	plan, diags := ctx.Plan(m, state, &PlanOpts{
 		Mode: plans.DestroyMode,
 	})
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	state, diags = ctx.Apply(plan, m, nil)
 	if diags.HasErrors() {
@@ -9227,7 +9227,7 @@ func TestContext2Apply_scaleInMultivarRef(t *testing.T) {
 			},
 		},
 	})
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 	{
 		addr := mustResourceInstanceAddr("aws_instance.one[0]")
 		change := plan.Changes.ResourceInstance(addr)
@@ -9268,7 +9268,7 @@ func TestContext2Apply_scaleInMultivarRef(t *testing.T) {
 
 	// Applying the plan should now succeed
 	_, diags = ctx.Apply(plan, m, nil)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 }
 
 func TestContext2Apply_inconsistentWithPlan(t *testing.T) {
@@ -9306,7 +9306,7 @@ func TestContext2Apply_inconsistentWithPlan(t *testing.T) {
 	})
 
 	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	_, diags = ctx.Apply(plan, m, nil)
 	if !diags.HasErrors() {
@@ -9371,7 +9371,7 @@ func TestContext2Apply_issue19908(t *testing.T) {
 	})
 
 	plan, diags := ctx.Plan(m, state, DefaultPlanOpts)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	state, diags = ctx.Apply(plan, m, nil)
 	if !diags.HasErrors() {
@@ -10093,10 +10093,10 @@ func TestContext2Apply_ProviderMeta_apply_set(t *testing.T) {
 	})
 
 	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	_, diags = ctx.Apply(plan, m, nil)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	if !p.ApplyResourceChangeCalled {
 		t.Fatalf("ApplyResourceChange not called")
@@ -10173,10 +10173,10 @@ func TestContext2Apply_ProviderMeta_apply_unset(t *testing.T) {
 	})
 
 	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	_, diags = ctx.Apply(plan, m, nil)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	if !p.ApplyResourceChangeCalled {
 		t.Fatalf("ApplyResourceChange not called")
@@ -10222,7 +10222,7 @@ func TestContext2Apply_ProviderMeta_plan_set(t *testing.T) {
 	})
 
 	_, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	if !p.PlanResourceChangeCalled {
 		t.Fatalf("PlanResourceChange not called")
@@ -10289,7 +10289,7 @@ func TestContext2Apply_ProviderMeta_plan_unset(t *testing.T) {
 	})
 
 	_, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	if !p.PlanResourceChangeCalled {
 		t.Fatalf("PlanResourceChange not called")
@@ -10429,13 +10429,13 @@ func TestContext2Apply_ProviderMeta_refresh_set(t *testing.T) {
 	})
 
 	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	state, diags := ctx.Apply(plan, m, nil)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	_, diags = ctx.Refresh(m, state, DefaultPlanOpts)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	if !p.ReadResourceCalled {
 		t.Fatalf("ReadResource not called")
@@ -10498,10 +10498,10 @@ func TestContext2Apply_ProviderMeta_refresh_setNoSchema(t *testing.T) {
 	})
 
 	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	state, diags := ctx.Apply(plan, m, nil)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	// drop the schema before refresh, to test that it errors
 	schema.ProviderMeta = nil
@@ -10563,10 +10563,10 @@ func TestContext2Apply_ProviderMeta_refresh_setInvalid(t *testing.T) {
 	})
 
 	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	state, diags := ctx.Apply(plan, m, nil)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	// change the schema before refresh, to test that it errors
 	schema.ProviderMeta = &configschema.Block{
@@ -10664,13 +10664,13 @@ func TestContext2Apply_ProviderMeta_refreshdata_set(t *testing.T) {
 	}
 
 	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	state, diags := ctx.Apply(plan, m, nil)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	_, diags = ctx.Refresh(m, state, DefaultPlanOpts)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	if !p.ReadDataSourceCalled {
 		t.Fatalf("ReadDataSource not called")
@@ -10755,10 +10755,10 @@ func TestContext2Apply_ProviderMeta_refreshdata_unset(t *testing.T) {
 	}
 
 	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	_, diags = ctx.Apply(plan, m, nil)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	if !p.ReadDataSourceCalled {
 		t.Fatalf("ReadDataSource not called")
@@ -11540,7 +11540,7 @@ func TestContext2Apply_destroyProviderReference(t *testing.T) {
 	})
 
 	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	state, diags := ctx.Apply(plan, m, nil)
 	if diags.HasErrors() {
@@ -11558,7 +11558,7 @@ func TestContext2Apply_destroyProviderReference(t *testing.T) {
 	plan, diags = ctx.Plan(m, state, &PlanOpts{
 		Mode: plans.DestroyMode,
 	})
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	// We'll marshal and unmarshal the plan here, to ensure that we have
 	// a clean new context as would be created if we separately ran
@@ -11647,7 +11647,7 @@ output "outputs" {
 	})
 
 	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	state, diags := ctx.Apply(plan, m, nil)
 	if diags.HasErrors() {
@@ -11664,7 +11664,7 @@ output "outputs" {
 		plan, diags = ctx.Plan(m, state, &PlanOpts{
 			Mode: plans.DestroyMode,
 		})
-		assertNoErrors(t, diags)
+		tfdiags.AssertNoErrors(t, diags)
 
 		state, diags = ctx.Apply(plan, m, nil)
 		if diags.HasErrors() {
@@ -11734,7 +11734,7 @@ resource "test_resource" "a" {
 			},
 		},
 	})
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	state, diags := ctx.Apply(plan, m, nil)
 	if diags.HasErrors() {
@@ -11755,7 +11755,7 @@ resource "test_resource" "a" {
 			},
 		},
 	})
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	_, diags = ctx.Apply(plan, m, nil)
 	if diags.HasErrors() {
@@ -11797,7 +11797,7 @@ resource "test_instance" "b" {
 			},
 		},
 	})
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	state, diags := ctx.Apply(plan, m, nil)
 	if diags.HasErrors() {
@@ -11818,7 +11818,7 @@ resource "test_instance" "b" {
 			},
 		},
 	})
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	_, diags = ctx.Apply(plan, m, nil)
 	if diags.HasErrors() {
@@ -11858,7 +11858,7 @@ resource "test_resource" "c" {
 			},
 		},
 	})
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	state, diags := ctx.Apply(plan, m, nil)
 	if diags.HasErrors() {
@@ -11879,7 +11879,7 @@ resource "test_resource" "c" {
 			},
 		},
 	})
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	_, diags = ctx.Apply(plan, m, nil)
 	if diags.HasErrors() {
@@ -11951,7 +11951,7 @@ resource "test_resource" "foo" {
 	})
 
 	plan, diags := ctx.Plan(m, states.NewState(), SimplePlanOpts(plans.NormalMode, testInputValuesUnset(m.Module.Variables)))
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	state, diags := ctx.Apply(plan, m, nil)
 	if diags.HasErrors() {
@@ -11966,7 +11966,7 @@ resource "test_resource" "foo" {
 	})
 
 	plan, diags = ctx.Plan(m, state, SimplePlanOpts(plans.NormalMode, testInputValuesUnset(m.Module.Variables)))
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	state, diags = ctx.Apply(plan, m, nil)
 	if diags.HasErrors() {
@@ -11989,7 +11989,7 @@ resource "test_resource" "foo" {
 			},
 		},
 	})
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	_, diags = ctx.Apply(plan, m, nil)
 	if diags.HasErrors() {
@@ -12179,12 +12179,12 @@ resource "test_resource" "foo" {
 	})
 
 	plan, diags := ctx.Plan(m, state, SimplePlanOpts(plans.NormalMode, testInputValuesUnset(m.Module.Variables)))
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	addr := mustResourceInstanceAddr("test_resource.foo")
 
 	state, diags = ctx.Apply(plan, m, nil)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	fooState := state.ResourceInstance(addr)
 
@@ -12221,9 +12221,9 @@ resource "test_resource" "foo" {
 	})
 
 	plan, diags = ctx.Plan(m2, state, SimplePlanOpts(plans.NormalMode, testInputValuesUnset(m.Module.Variables)))
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 	stateWithoutSensitive, diags := ctx.Apply(plan, m2, nil)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	fooState2 := stateWithoutSensitive.ResourceInstance(addr)
 	if len(fooState2.Current.AttrSensitivePaths) != 1 {
@@ -12535,14 +12535,14 @@ func TestContext2Apply_provisionerMarks(t *testing.T) {
 					},
 				},
 			})
-			assertNoErrors(t, diags)
+			tfdiags.AssertNoErrors(t, diags)
 
 			// "restart" provisioner
 			pr.CloseCalled = false
 
 			state, diags := ctx.Apply(plan, m, tc.opts)
 			if diags.HasErrors() {
-				logDiagnostics(t, diags)
+				tfdiags.LogDiagnostics(t, diags)
 				t.Fatal("apply failed")
 			}
 
@@ -12595,7 +12595,7 @@ resource "test_resource" "foo" {
 	})
 
 	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	state, diags := ctx.Apply(plan, m, nil)
 	if diags.HasErrors() {
@@ -12689,7 +12689,7 @@ func TestContext2Apply_dataSensitive(t *testing.T) {
 	}
 
 	state, diags := ctx.Apply(plan, m, nil)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	addr := mustResourceInstanceAddr("data.null_data_source.testing")
 

--- a/internal/terraform/context_eval_test.go
+++ b/internal/terraform/context_eval_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/hashicorp/terraform/internal/providers"
 	testing_provider "github.com/hashicorp/terraform/internal/providers/testing"
 	"github.com/hashicorp/terraform/internal/states"
+	"github.com/hashicorp/terraform/internal/tfdiags"
 )
 
 func TestContextEval(t *testing.T) {
@@ -134,7 +135,7 @@ output "out" {
 	_, diags := ctx.Eval(m, states.NewState(), addrs.RootModuleInstance, &EvalOpts{
 		SetVariables: testInputValuesUnset(m.Module.Variables),
 	})
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 }
 
 func TestContextPlanAndEval(t *testing.T) {
@@ -174,7 +175,7 @@ func TestContextPlanAndEval(t *testing.T) {
 			},
 		},
 	})
-	assertNoDiagnostics(t, diags)
+	tfdiags.AssertNoDiagnostics(t, diags)
 
 	// This test isn't really about whether the plan is correct, but we'll
 	// do some basic checks on it anyway because if the plan is incorrect
@@ -212,7 +213,7 @@ func TestContextPlanAndEval(t *testing.T) {
 		expr := hcltest.MockExprTraversalSrc(`var.a`)
 		want := cty.StringVal("a value")
 		got, diags := scope.EvalExpr(expr, cty.String)
-		assertNoDiagnostics(t, diags)
+		tfdiags.AssertNoDiagnostics(t, diags)
 
 		if !want.RawEquals(got) {
 			t.Errorf("wrong result\ngot:  %#v\nwant: %#v", got, want)
@@ -224,7 +225,7 @@ func TestContextPlanAndEval(t *testing.T) {
 			"arg": cty.StringVal("a value"),
 		})
 		got, diags := scope.EvalExpr(expr, cty.DynamicPseudoType)
-		assertNoDiagnostics(t, diags)
+		tfdiags.AssertNoDiagnostics(t, diags)
 
 		if !want.RawEquals(got) {
 			t.Errorf("wrong result\ngot:  %#v\nwant: %#v", got, want)
@@ -269,7 +270,7 @@ func TestContextApplyAndEval(t *testing.T) {
 			},
 		},
 	})
-	assertNoDiagnostics(t, diags)
+	tfdiags.AssertNoDiagnostics(t, diags)
 
 	// This test isn't really about whether the plan is correct, but we'll
 	// do some basic checks on it anyway because if the plan is incorrect
@@ -298,7 +299,7 @@ func TestContextApplyAndEval(t *testing.T) {
 	}
 
 	finalState, scope, diags := ctx.ApplyAndEval(plan, m, nil)
-	assertNoDiagnostics(t, diags)
+	tfdiags.AssertNoDiagnostics(t, diags)
 	if finalState == nil {
 		t.Fatalf("no final state")
 	}
@@ -313,7 +314,7 @@ func TestContextApplyAndEval(t *testing.T) {
 		expr := hcltest.MockExprTraversalSrc(`var.a`)
 		want := cty.StringVal("a value")
 		got, diags := scope.EvalExpr(expr, cty.String)
-		assertNoDiagnostics(t, diags)
+		tfdiags.AssertNoDiagnostics(t, diags)
 
 		if !want.RawEquals(got) {
 			t.Errorf("wrong result\ngot:  %#v\nwant: %#v", got, want)
@@ -325,7 +326,7 @@ func TestContextApplyAndEval(t *testing.T) {
 			"arg": cty.StringVal("a value"),
 		})
 		got, diags := scope.EvalExpr(expr, cty.DynamicPseudoType)
-		assertNoDiagnostics(t, diags)
+		tfdiags.AssertNoDiagnostics(t, diags)
 
 		if !want.RawEquals(got) {
 			t.Errorf("wrong result\ngot:  %#v\nwant: %#v", got, want)
@@ -372,5 +373,5 @@ locals {
 	_, diags := ctx.Eval(m, states.NewState(), addrs.RootModuleInstance, &EvalOpts{
 		SetVariables: testInputValuesUnset(m.Module.Variables),
 	})
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 }

--- a/internal/terraform/context_functions_test.go
+++ b/internal/terraform/context_functions_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/hashicorp/terraform/internal/providers"
 	testing_provider "github.com/hashicorp/terraform/internal/providers/testing"
 	"github.com/hashicorp/terraform/internal/states"
+	"github.com/hashicorp/terraform/internal/tfdiags"
 )
 
 func TestContext2Plan_providerFunctionBasic(t *testing.T) {
@@ -76,7 +77,7 @@ output "noop_equals" {
 	})
 
 	plan, diags := ctx.Plan(m, states.NewState(), SimplePlanOpts(plans.NormalMode, testInputValuesUnset(m.Module.Variables)))
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	expect, err := msgpack.Marshal(cty.StringVal("ok"), cty.DynamicPseudoType)
 	if err != nil {
@@ -204,7 +205,7 @@ func TestContext2Plan_providerFunctionImpureApply(t *testing.T) {
 	})
 
 	plan, diags := ctx.Plan(m, states.NewState(), SimplePlanOpts(plans.NormalMode, testInputValuesUnset(m.Module.Variables)))
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	// Write / Read plan to simulate running it through a Plan file
 	ctxOpts, m, plan, err := contextOptsForPlanViaFile(t, snap, plan)

--- a/internal/terraform/context_input_test.go
+++ b/internal/terraform/context_input_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hashicorp/terraform/internal/plans"
 	"github.com/hashicorp/terraform/internal/providers"
 	"github.com/hashicorp/terraform/internal/states"
+	"github.com/hashicorp/terraform/internal/tfdiags"
 )
 
 func TestContext2Input_provider(t *testing.T) {
@@ -74,7 +75,7 @@ func TestContext2Input_provider(t *testing.T) {
 	}
 
 	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	if _, diags := ctx.Apply(plan, m, nil); diags.HasErrors() {
 		t.Fatalf("apply errors: %s", diags.Err())
@@ -145,7 +146,7 @@ func TestContext2Input_providerMulti(t *testing.T) {
 	}
 
 	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	providerFactory = func() (providers.Interface, error) {
 		p := testProvider("aws")
@@ -233,7 +234,7 @@ func TestContext2Input_providerId(t *testing.T) {
 	}
 
 	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	if _, diags := ctx.Apply(plan, m, nil); diags.HasErrors() {
 		t.Fatalf("apply errors: %s", diags.Err())
@@ -307,7 +308,7 @@ func TestContext2Input_providerOnly(t *testing.T) {
 			},
 		},
 	})
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	state, err := ctx.Apply(plan, m, nil)
 	if err != nil {
@@ -358,7 +359,7 @@ func TestContext2Input_providerVars(t *testing.T) {
 			},
 		},
 	})
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	if _, diags := ctx.Apply(plan, m, nil); diags.HasErrors() {
 		t.Fatalf("apply errors: %s", diags.Err())

--- a/internal/terraform/context_plan2_test.go
+++ b/internal/terraform/context_plan2_test.go
@@ -2415,7 +2415,7 @@ func TestContext2Plan_crossResourceMoveWithIdentity(t *testing.T) {
 	plan, diags := ctx.Plan(m, state, &PlanOpts{
 		Mode: plans.NormalMode,
 	})
-	assertNoDiagnostics(t, diags)
+	tfdiags.AssertNoDiagnostics(t, diags)
 
 	if string(expectedSourceIdentity) != string(sourceIdentity) {
 		t.Fatalf("unexpected source identity; expected %s, got %s", string(expectedSourceIdentity), string(sourceIdentity))
@@ -6820,7 +6820,7 @@ data "test_data_source" "foo" {
 	})
 
 	plan, diags := ctx.Plan(m, states.NewState(), SimplePlanOpts(plans.NormalMode, testInputValuesUnset(m.Module.Variables)))
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	dataSchemaType := p.GetProviderSchemaResponse.DataSources["test_data_source"].Body.ImpliedType()
 	after, err := plan.Changes.ResourceInstance(mustResourceInstanceAddr("data.test_data_source.foo")).After.Decode(dataSchemaType)

--- a/internal/terraform/context_plan2_test.go
+++ b/internal/terraform/context_plan2_test.go
@@ -90,7 +90,7 @@ resource "test_object" "a" {
 	})
 
 	plan, diags := ctx.Plan(m, state, DefaultPlanOpts)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	if !p.UpgradeResourceStateCalled {
 		t.Errorf("Provider's UpgradeResourceState wasn't called; should've been")
@@ -215,7 +215,7 @@ data "test_data_source" "foo" {
 	})
 
 	plan, diags := ctx.Plan(m, state, SimplePlanOpts(plans.NormalMode, testInputValuesUnset(m.Module.Variables)))
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	for _, res := range plan.Changes.Resources {
 		if res.Action != plans.NoOp {
@@ -258,7 +258,7 @@ output "out" {
 	})
 
 	plan, diags := ctx.Plan(m, state, DefaultPlanOpts)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	change, err := plan.Changes.Outputs[0].Decode()
 	if err != nil {
@@ -323,7 +323,7 @@ resource "test_object" "a" {
 	})
 
 	_, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 }
 
 func TestContext2Plan_dataReferencesResourceInModules(t *testing.T) {
@@ -396,7 +396,7 @@ resource "test_resource" "b" {
 	})
 
 	plan, diags := ctx.Plan(m, state, DefaultPlanOpts)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	oldMod := oldDataAddr.Module
 
@@ -496,7 +496,7 @@ func TestContext2Plan_resourceChecksInExpandedModule(t *testing.T) {
 
 	priorState := states.NewState()
 	plan, diags := ctx.Plan(m, priorState, DefaultPlanOpts)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	resourceInsts := []addrs.AbsResourceInstance{
 		mustResourceInstanceAddr("module.child[0].test.test1"),
@@ -681,7 +681,7 @@ data "test_data_source" "a" {
 	})
 
 	plan, diags := ctx.Plan(m, priorState, DefaultPlanOpts)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	if rc := plan.Changes.ResourceInstance(dataAddr); rc != nil {
 		if got, want := rc.Action, plans.Read; got != want {
@@ -709,7 +709,7 @@ data "test_data_source" "a" {
 	// data resources is a plan-time concern, but we'll still try applying the
 	// plan here just to make sure it's valid.
 	newState, diags := ctx.Apply(plan, m, nil)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	if rs := newState.ResourceInstance(dataAddr); rs != nil {
 		if !rs.HasCurrent() {
@@ -996,7 +996,7 @@ resource "test_object" "a" {
 		Mode:        plans.DestroyMode,
 		SkipRefresh: false, // the default
 	})
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	if !upgradeResourceStateCalled {
 		t.Errorf("Provider's UpgradeResourceState wasn't called; should've been")
@@ -1096,7 +1096,7 @@ resource "test_object" "a" {
 		Mode:        plans.DestroyMode,
 		SkipRefresh: true,
 	})
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	if !p.UpgradeResourceStateCalled {
 		t.Errorf("Provider's UpgradeResourceState wasn't called; should've been")
@@ -1186,7 +1186,7 @@ output "result" {
 	})
 
 	plan, diags := ctx.Plan(m, state, DefaultPlanOpts)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	for _, res := range plan.Changes.Resources {
 		if res.Action != plans.Create {
@@ -1235,7 +1235,7 @@ provider "test" {
 	_, diags := ctx.Plan(m, state, &PlanOpts{
 		Mode: plans.DestroyMode,
 	})
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 }
 
 func TestContext2Plan_movedResourceBasic(t *testing.T) {
@@ -2497,7 +2497,7 @@ resource "test_object" "b" {
 		},
 	})
 	//
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 }
 
 func TestContext2Plan_movedResourceRefreshOnly(t *testing.T) {
@@ -3101,7 +3101,7 @@ data "test_data_source" "foo" {
 	})
 
 	plan, diags := ctx.Plan(m, state, DefaultPlanOpts)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	for _, res := range plan.Changes.Resources {
 		switch res.Addr.String() {
@@ -3356,7 +3356,7 @@ output "output" {
 	})
 
 	plan, diags := ctx.Plan(m, state, DefaultPlanOpts)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	for _, res := range plan.Changes.Resources {
 		// both existing data sources should be read during plan
@@ -3538,7 +3538,7 @@ resource "test_resource" "a" {
 				},
 			},
 		})
-		assertNoErrors(t, diags)
+		tfdiags.AssertNoErrors(t, diags)
 		for _, res := range plan.Changes.Resources {
 			switch res.Addr.String() {
 			case "test_resource.a":
@@ -3600,7 +3600,7 @@ resource "test_resource" "a" {
 				},
 			},
 		})
-		assertNoErrors(t, diags)
+		tfdiags.AssertNoErrors(t, diags)
 		if len(diags) == 0 {
 			t.Fatalf("no diags, but should have warnings")
 		}
@@ -3706,7 +3706,7 @@ resource "test_resource" "a" {
 				},
 			},
 		})
-		assertNoErrors(t, diags)
+		tfdiags.AssertNoErrors(t, diags)
 		if len(diags) == 0 {
 			t.Fatalf("no diags, but should have warnings")
 		}
@@ -3759,7 +3759,7 @@ resource "test_resource" "a" {
 				},
 			},
 		})
-		assertNoErrors(t, diags)
+		tfdiags.AssertNoErrors(t, diags)
 		if got, want := len(diags), 2; got != want {
 			t.Errorf("wrong number of warnings, got %d, want %d", got, want)
 		}
@@ -3858,7 +3858,7 @@ resource "test_resource" "a" {
 				},
 			},
 		})
-		assertNoErrors(t, diags)
+		tfdiags.AssertNoErrors(t, diags)
 		for _, res := range plan.Changes.Resources {
 			switch res.Addr.String() {
 			case "test_resource.a":
@@ -3928,7 +3928,7 @@ resource "test_resource" "a" {
 				},
 			},
 		})
-		assertNoErrors(t, diags)
+		tfdiags.AssertNoErrors(t, diags)
 		if len(diags) == 0 {
 			t.Fatalf("no diags, but should have warnings")
 		}
@@ -4004,7 +4004,7 @@ resource "test_resource" "a" {
 				},
 			},
 		})
-		assertNoErrors(t, diags)
+		tfdiags.AssertNoErrors(t, diags)
 		if got, want := diags.ErrWithWarnings().Error(), "Resource postcondition failed: Results cannot be empty."; got != want {
 			t.Fatalf("wrong error:\ngot:  %s\nwant: %q", got, want)
 		}
@@ -4045,7 +4045,7 @@ resource "test_resource" "a" {
 				},
 			},
 		})
-		assertNoErrors(t, diags)
+		tfdiags.AssertNoErrors(t, diags)
 		if got, want := len(diags), 2; got != want {
 			t.Errorf("wrong number of warnings, got %d, want %d", got, want)
 		}
@@ -4097,7 +4097,7 @@ output "a" {
 				},
 			},
 		})
-		assertNoErrors(t, diags)
+		tfdiags.AssertNoErrors(t, diags)
 		addr := addrs.RootModuleInstance.OutputValue("a")
 		outputPlan := plan.Changes.OutputValue(addr)
 		if outputPlan == nil {
@@ -4149,7 +4149,7 @@ output "a" {
 				},
 			},
 		})
-		assertNoErrors(t, diags)
+		tfdiags.AssertNoErrors(t, diags)
 		if len(diags) == 0 {
 			t.Fatalf("no diags, but should have warnings")
 		}
@@ -4459,7 +4459,7 @@ data "test_object" "a" {
 	})
 
 	_, diags := ctx.Plan(m, state, DefaultPlanOpts)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 }
 
 func TestContext2Plan_applyGraphError(t *testing.T) {
@@ -4557,7 +4557,7 @@ output "out" {
 		Mode: plans.DestroyMode,
 	})
 
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	// ensure that the given states are valid and can be serialized
 	if plan.PrevRunState == nil {
@@ -4631,7 +4631,7 @@ resource "test_object" "b" {
 	_, diags := ctx.Plan(m, state, &PlanOpts{
 		Mode: plans.NormalMode,
 	})
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 }
 
 // make sure there are no cycles with changes around a provider configured via
@@ -4694,9 +4694,9 @@ resource "test_object" "b" {
 	// plan+apply to create the initial state
 	opts := SimplePlanOpts(plans.NormalMode, testInputValuesUnset(m.Module.Variables))
 	plan, diags := ctx.Plan(m, states.NewState(), opts)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 	state, diags := ctx.Apply(plan, m, nil)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	// Resource changes which have dependencies across providers which
 	// themselves depend on resources can result in cycles.
@@ -4710,7 +4710,7 @@ resource "test_object" "b" {
 	opts.ForceReplace = []addrs.AbsResourceInstance{addrA, addrB}
 
 	_, diags = ctx.Plan(m, state, opts)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 }
 
 func TestContext2Plan_destroyPartialState(t *testing.T) {
@@ -4810,7 +4810,7 @@ output "out" {
 	_, diags := ctx.Plan(m, state, &PlanOpts{
 		Mode: plans.DestroyMode,
 	})
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 }
 
 func TestContext2Plan_destroyPartialStateLocalRef(t *testing.T) {
@@ -4852,7 +4852,7 @@ output "out" {
 	_, diags := ctx.Plan(m, state, &PlanOpts{
 		Mode: plans.DestroyMode,
 	})
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 }
 
 // Make sure the data sources in the prior state are serializeable even if
@@ -4943,7 +4943,7 @@ resource "test_object" "a" {
 	// plan+apply to create the initial state
 	opts := SimplePlanOpts(plans.NormalMode, testInputValuesUnset(m.Module.Variables))
 	plan, diags := ctx.Plan(m, state, opts)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	for _, c := range plan.Changes.Resources {
 		if c.Action != plans.NoOp {
@@ -4994,7 +4994,7 @@ func TestContext2Plan_externalProvidersWithState(t *testing.T) {
 			addrs.MustParseProviderSourceString("hashicorp/foo"): *fooProvider.GetProviderSchemaResponse,
 		},
 	})
-	assertNoDiagnostics(t, diags)
+	tfdiags.AssertNoDiagnostics(t, diags)
 
 	fooProvider.ConfigureProviderCalled = true
 	_, diags = ctx.Plan(m, state, &PlanOpts{
@@ -5005,7 +5005,7 @@ func TestContext2Plan_externalProvidersWithState(t *testing.T) {
 			}: fooProvider,
 		},
 	})
-	assertNoDiagnostics(t, diags)
+	tfdiags.AssertNoDiagnostics(t, diags)
 }
 
 func TestContext2Plan_externalProviders(t *testing.T) {
@@ -5120,7 +5120,7 @@ func TestContext2Plan_externalProviders(t *testing.T) {
 			bazAddr: *bazProvider.GetProviderSchemaResponse,
 		},
 	})
-	assertNoDiagnostics(t, diags)
+	tfdiags.AssertNoDiagnostics(t, diags)
 
 	// Many of the MockProvider methods check whether Configure was called and
 	// return an error if not, and so we'll set that flag ahead of time to
@@ -5138,7 +5138,7 @@ func TestContext2Plan_externalProviders(t *testing.T) {
 			bazConfigAddr: bazProvider,
 		},
 	})
-	assertNoDiagnostics(t, diags)
+	tfdiags.AssertNoDiagnostics(t, diags)
 
 	// If everything has worked as intended, the Plan call should've skipped
 	// configuring and closing all of the providers, because that's the
@@ -5252,7 +5252,7 @@ func TestContext2Apply_externalDependencyDeferred(t *testing.T) {
 		DeferralAllowed:            true,
 		ExternalDependencyDeferred: true,
 	})
-	assertNoDiagnostics(t, diags)
+	tfdiags.AssertNoDiagnostics(t, diags)
 	if plan.Applyable {
 		t.Fatal("plan is applyable; should not be, because there's nothing to do yet")
 	}
@@ -5795,7 +5795,7 @@ resource "test_resource" "a" {
 			},
 		},
 	})
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 	for _, res := range plan.Changes.Resources {
 		switch res.Addr.String() {
 		case "test_resource.a":
@@ -5850,7 +5850,7 @@ resource "test_object" "obj" {
 	})
 
 	plan, diags := ctx.Plan(m, states.NewState(), SimplePlanOpts(plans.NormalMode, testInputValuesUnset(m.Module.Variables)))
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	ch := plan.Changes.ResourceInstance(mustResourceInstanceAddr("test_object.obj"))
 	if len(ch.AfterSensitivePaths) == 0 {
@@ -5917,7 +5917,7 @@ resource "test_object" "obj" {
 	})
 
 	plan, diags := ctx.Plan(m, state, SimplePlanOpts(plans.NormalMode, testInputValuesUnset(m.Module.Variables)))
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	ch := plan.Changes.ResourceInstance(mustResourceInstanceAddr("test_object.obj"))
 	if ch.Action != plans.NoOp {
@@ -6081,7 +6081,7 @@ func TestContext2Plan_ephemeralInProviderConfig(t *testing.T) {
 			},
 		}),
 	)
-	assertNoDiagnostics(t, diags)
+	tfdiags.AssertNoDiagnostics(t, diags)
 
 	if !p.ConfigureProviderCalled {
 		t.Fatal("ConfigureProvider was not called")
@@ -6141,7 +6141,7 @@ output "value" {
 
 	// Just shouldn't crash.
 	_, diags := ctx.Plan(m, states.NewState(), SimplePlanOpts(plans.NormalMode, testInputValuesUnset(m.Module.Variables)))
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 }
 
 func TestContext2Plan_sensitiveRequiredReplace(t *testing.T) {
@@ -6258,7 +6258,7 @@ resource "test_object" "obj" {
 	})
 
 	plan, diags := ctx.Plan(m, state, nil)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	if plan.Changes.Empty() {
 		t.Fatal("unexpected empty plan")
@@ -6287,7 +6287,7 @@ resource "test_object" "obj" {
 	}
 
 	schemas, schemaDiags := ctx.Schemas(m, plan.PriorState)
-	assertNoDiagnostics(t, schemaDiags)
+	tfdiags.AssertNoDiagnostics(t, schemaDiags)
 
 	changes, err := plan.Changes.Decode(schemas)
 	if err != nil {
@@ -6356,7 +6356,7 @@ resource "test_object" "obj" {
 	})
 
 	plan, diags := ctx.Plan(m, state, nil)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	if plan.Changes.Empty() {
 		t.Fatal("unexpected empty plan")
@@ -6385,7 +6385,7 @@ resource "test_object" "obj" {
 	}
 
 	schemas, schemaDiags := ctx.Schemas(m, plan.PriorState)
-	assertNoDiagnostics(t, schemaDiags)
+	tfdiags.AssertNoDiagnostics(t, schemaDiags)
 
 	changes, err := plan.Changes.Decode(schemas)
 	if err != nil {
@@ -6541,7 +6541,7 @@ output "staying" {
 	ctx := testContext2(t, &ContextOpts{})
 
 	plan, diags := ctx.Plan(m, state, DefaultPlanOpts)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	expectedChanges := &plans.Changes{
 		Outputs: []*plans.OutputChange{
@@ -6635,7 +6635,7 @@ data "test_data_source" "foo" {
 	})
 
 	_, diags := ctx.Plan(m, states.NewState(), SimplePlanOpts(plans.NormalMode, testInputValuesUnset(m.Module.Variables)))
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 }
 
 func TestContext2Plan_upgradeState_WriteOnlyAttribute(t *testing.T) {
@@ -6730,7 +6730,7 @@ resource "test_object" "a" {
 	})
 
 	plan, diags := ctx.Plan(m, state, DefaultPlanOpts)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	resourceType := p.GetProviderSchemaResponse.ResourceTypes["test_object"]
 	change, err := plan.Changes.ResourceInstance(mustResourceInstanceAddr(`test_object.a["old"]`)).Decode(resourceType)

--- a/internal/terraform/context_plan_ephemeral_test.go
+++ b/internal/terraform/context_plan_ephemeral_test.go
@@ -790,7 +790,7 @@ resource "ephem_write_only" "test" {
 				// as it will fail.
 				return
 			} else {
-				assertNoDiagnostics(t, diags)
+				tfdiags.AssertNoDiagnostics(t, diags)
 			}
 
 			if tc.expectValidateEphemeralResourceConfigCalled {
@@ -808,7 +808,7 @@ resource "ephem_write_only" "test" {
 			if tc.expectPlanDiagnostics != nil {
 				tfdiags.AssertDiagnosticsMatch(t, diags, tc.expectPlanDiagnostics(m))
 			} else {
-				assertNoDiagnostics(t, diags)
+				tfdiags.AssertNoDiagnostics(t, diags)
 			}
 
 			if tc.assertPlan != nil {
@@ -904,7 +904,7 @@ resource "sink_object" "empty" {
 	})
 
 	_, diags := ctx.Plan(m, nil, DefaultPlanOpts)
-	assertNoDiagnostics(t, diags)
+	tfdiags.AssertNoDiagnostics(t, diags)
 
 	if ephem.OpenEphemeralResourceCalled {
 		t.Error("OpenEphemeralResourceCalled called when config was not known")

--- a/internal/terraform/context_plan_identity_test.go
+++ b/internal/terraform/context_plan_identity_test.go
@@ -781,7 +781,7 @@ func TestContext2Plan_resource_identity_plan(t *testing.T) {
 			if tc.expectDiagnostics != nil {
 				tfdiags.AssertDiagnosticsMatch(t, diags, tc.expectDiagnostics)
 			} else {
-				assertNoDiagnostics(t, diags)
+				tfdiags.AssertNoDiagnostics(t, diags)
 
 				if !tc.expectedPriorIdentity.IsNull() {
 					if !p.PlanResourceChangeCalled {

--- a/internal/terraform/context_plan_test.go
+++ b/internal/terraform/context_plan_test.go
@@ -1851,10 +1851,10 @@ func TestContext2Plan_computedInFunction(t *testing.T) {
 	})
 
 	diags := ctx.Validate(m, nil)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	_, diags = ctx.Plan(m, states.NewState(), DefaultPlanOpts)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	if !p.ReadDataSourceCalled {
 		t.Fatalf("ReadDataSource was not called on provider during plan; should've been called")
@@ -6168,7 +6168,7 @@ resource "test_instance" "b" {
 	})
 
 	plan, diags := ctx.Plan(m, state, DefaultPlanOpts)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	t.Run("test_instance.a[0]", func(t *testing.T) {
 		instAddr := mustResourceInstanceAddr("test_instance.a[0]")
@@ -6336,7 +6336,7 @@ data "test_data_source" "e" {
 	})
 
 	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	rc := plan.Changes.ResourceInstance(addrs.Resource{
 		Mode: addrs.DataResourceMode,
@@ -6457,7 +6457,7 @@ resource "test_instance" "a" {
 		Mode:        plans.NormalMode,
 		SkipRefresh: true,
 	})
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	if p.ReadResourceCalled {
 		t.Fatal("Resource should not have been refreshed")
@@ -6516,7 +6516,7 @@ data "test_data_source" "b" {
 	})
 
 	_, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	// The change to data source a should not prevent data source b from being
 	// read.

--- a/internal/terraform/context_refresh_test.go
+++ b/internal/terraform/context_refresh_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/hashicorp/terraform/internal/providers"
 	testing_provider "github.com/hashicorp/terraform/internal/providers/testing"
 	"github.com/hashicorp/terraform/internal/states"
+	"github.com/hashicorp/terraform/internal/tfdiags"
 )
 
 func TestContext2Refresh(t *testing.T) {
@@ -1048,7 +1049,7 @@ func TestContext2Refresh_unknownProvider(t *testing.T) {
 	c, diags := NewContext(&ContextOpts{
 		Providers: map[addrs.Provider]providers.Factory{},
 	})
-	assertNoDiagnostics(t, diags)
+	tfdiags.AssertNoDiagnostics(t, diags)
 
 	_, diags = c.Refresh(m, states.NewState(), &PlanOpts{Mode: plans.NormalMode})
 	if !diags.HasErrors() {

--- a/internal/terraform/context_validate_test.go
+++ b/internal/terraform/context_validate_test.go
@@ -319,7 +319,7 @@ func TestContext2Validate_countVariableNoDefault(t *testing.T) {
 			addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
 		},
 	})
-	assertNoDiagnostics(t, diags)
+	tfdiags.AssertNoDiagnostics(t, diags)
 
 	_, diags = c.Plan(m, nil, &PlanOpts{})
 	if !diags.HasErrors() {
@@ -868,7 +868,7 @@ func TestContext2Validate_requiredVar(t *testing.T) {
 			addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
 		},
 	})
-	assertNoDiagnostics(t, diags)
+	tfdiags.AssertNoDiagnostics(t, diags)
 
 	// NOTE: This test has grown idiosyncratic because originally Terraform
 	// would (optionally) check variables during validation, and then in
@@ -2957,7 +2957,7 @@ resource "bar_instance" "test" {
 			providerAddr: *provider.GetProviderSchemaResponse,
 		},
 	})
-	assertNoDiagnostics(t, diags)
+	tfdiags.AssertNoDiagnostics(t, diags)
 
 	// Many of the MockProvider methods check for this, so we'll set it to be
 	// true externally.
@@ -3092,5 +3092,5 @@ module "child" {
 
 	ctx := testContext2(t, &ContextOpts{})
 	diags := ctx.Validate(m, &ValidateOpts{})
-	assertNoDiagnostics(t, diags)
+	tfdiags.AssertNoDiagnostics(t, diags)
 }

--- a/internal/terraform/eval_for_each_test.go
+++ b/internal/terraform/eval_for_each_test.go
@@ -265,7 +265,7 @@ func TestEvaluateForEachExpression_allowUnknown(t *testing.T) {
 
 			// With allowUnknown set, all of these expressions should be treated
 			// as valid for_each values.
-			assertNoDiagnostics(t, diags)
+			tfdiags.AssertNoDiagnostics(t, diags)
 
 			if known {
 				t.Errorf("result is known; want unknown")

--- a/internal/terraform/transform_destroy_edge_test.go
+++ b/internal/terraform/transform_destroy_edge_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/terraform/internal/dag"
 	"github.com/hashicorp/terraform/internal/plans"
 	"github.com/hashicorp/terraform/internal/states"
+	"github.com/hashicorp/terraform/internal/tfdiags"
 )
 
 func TestDestroyEdgeTransformer_basic(t *testing.T) {
@@ -400,7 +401,7 @@ func TestPruneUnusedNodesTransformer_rootModuleOutputValues(t *testing.T) {
 		},
 	}
 	graph, diags := builder.Build(addrs.RootModuleInstance)
-	assertNoDiagnostics(t, diags)
+	tfdiags.AssertNoDiagnostics(t, diags)
 
 	// At this point, thanks to pruneUnusedNodesTransformer, we should still
 	// have the node for the output value, but the "test.a (expand)" node

--- a/internal/terraform/transform_reference_test.go
+++ b/internal/terraform/transform_reference_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/terraform/internal/plans"
 	"github.com/hashicorp/terraform/internal/providers"
 	"github.com/hashicorp/terraform/internal/states"
+	"github.com/hashicorp/terraform/internal/tfdiags"
 )
 
 func TestReferenceTransformer_simple(t *testing.T) {
@@ -377,7 +378,7 @@ resource "test_resource" "in_modc" {
 	})
 
 	g, _, diags := ctx.planGraph(cfg, states.NewState(), &PlanOpts{Mode: plans.NormalMode})
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	// find the data resource node
 	for _, v := range g.Vertices() {

--- a/internal/tfdiags/testing.go
+++ b/internal/tfdiags/testing.go
@@ -74,3 +74,51 @@ func AssertDiagnosticCount(t *testing.T, diags Diagnostics, want int) {
 		t.FailNow()
 	}
 }
+
+// tfdiags.AssertNoDiagnostics fails the test in progress (using t.Fatal) if the given
+// diagnostics has any errors.
+func AssertNoErrors(t *testing.T, diags Diagnostics) {
+	t.Helper()
+	if !diags.HasErrors() {
+		return
+	}
+	LogDiagnostics(t, diags)
+	t.FailNow()
+}
+
+// LogDiagnostics is a test helper that logs the given diagnostics to to the
+// given testing.T using t.Log, in a way that is hopefully useful in debugging
+// a test. It does not generate any errors or fail the test. See
+// tfdiags.AssertNoDiagnostics and tfdiags.AssertNoErrors for more specific helpers that can
+// also fail the test.
+func LogDiagnostics(t *testing.T, diags Diagnostics) {
+	t.Helper()
+	for _, diag := range diags {
+		desc := diag.Description()
+		rng := diag.Source()
+
+		var severity string
+		switch diag.Severity() {
+		case Error:
+			severity = "ERROR"
+		case Warning:
+			severity = "WARN"
+		default:
+			severity = "???" // should never happen
+		}
+
+		if subj := rng.Subject; subj != nil {
+			if desc.Detail == "" {
+				t.Logf("[%s@%s] %s", severity, subj.StartString(), desc.Summary)
+			} else {
+				t.Logf("[%s@%s] %s: %s", severity, subj.StartString(), desc.Summary, desc.Detail)
+			}
+		} else {
+			if desc.Detail == "" {
+				t.Logf("[%s] %s", severity, desc.Summary)
+			} else {
+				t.Logf("[%s] %s: %s", severity, desc.Summary, desc.Detail)
+			}
+		}
+	}
+}

--- a/internal/tfdiags/testing.go
+++ b/internal/tfdiags/testing.go
@@ -53,3 +53,24 @@ func assertDiagnosticMatch(got, want Diagnostic) string {
 
 	return cmp.Diff(want, got, DiagnosticComparer)
 }
+
+// AssertNoDiagnostics will fail a test if any diagnostics are present.
+// If diagnostics are present, they will each be logged.
+func AssertNoDiagnostics(t *testing.T, diags Diagnostics) {
+	t.Helper()
+	AssertDiagnosticCount(t, diags, 0)
+}
+
+// AssertDiagnosticCount will fail a test if the number of diagnostics present
+// doesn't match the expected number.
+// If an incorrect number of diagnostics are present, they will each be logged.
+func AssertDiagnosticCount(t *testing.T, diags Diagnostics, want int) {
+	t.Helper()
+	if len(diags) != want {
+		t.Errorf("wrong number of diagnostics %d; want %d", len(diags), want)
+		for _, diag := range diags {
+			t.Logf("- %#v", diag)
+		}
+		t.FailNow()
+	}
+}

--- a/internal/tfdiags/testing.go
+++ b/internal/tfdiags/testing.go
@@ -75,7 +75,7 @@ func AssertDiagnosticCount(t *testing.T, diags Diagnostics, want int) {
 	}
 }
 
-// tfdiags.AssertNoDiagnostics fails the test in progress (using t.Fatal) if the given
+// tfdiags.AssertNoDiagnostics fails the test in progress (using t.FailNow) if the given
 // diagnostics has any errors.
 func AssertNoErrors(t *testing.T, diags Diagnostics) {
 	t.Helper()


### PR DESCRIPTION
Moves these functions into testing.go in the tfdiags package:

* AssertNoDiagnostics
* AssertDiagnosticCount
* AssertNoErrors 
* LogDiagnostics

Removes implementations of these functions from other packages
Refactors existing tests to use the new helpers in tfdiags

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

N/A

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
