### PR TITLE
Ensure that the file teardown summary is displayed before the run's teardown summary

### DIFF
--- a/internal/moduletest/graph/transform_state_cleanup.go
+++ b/internal/moduletest/graph/transform_state_cleanup.go
@@ -47,6 +47,9 @@ func (t *TestStateCleanupTransformer) Transform(g *terraform.Graph) error {
 			// All the runs that share the same state, must share the same cleanup node,
 			// which only executes once after all the dependent runs have completed.
 			g.Connect(dag.BasicEdge(rootCleanupNode, node))
+		case *NodeStateCleanup:
+			// Connect the cleanup node to the root cleanup node.
+			g.Connect(dag.BasicEdge(node, rootCleanupNode))
 		}
 	}
 


### PR DESCRIPTION

<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Fixes flakiness for the `TestTest_LongRunningTestJSON ` test as seen in https://github.com/hashicorp/terraform/actions/runs/13268393627/job/37041624584

You can test this locally by setting count to a large number and running the test many times
```
go test -timeout 600s -run ^TestTest_LongRunningTestJSON$ github.com/hashicorp/terraform/internal/command -count 30
```

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.11.x

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
