### PR TITLE
Address `go vet` 1.24 failures

### DIFF
--- a/internal/backend/remote/backend_common.go
+++ b/internal/backend/remote/backend_common.go
@@ -339,7 +339,7 @@ func (b *Remote) costEstimate(stopCtx, cancelCtx context.Context, op *backendrun
 			b.CLI.Output("\n------------------------------------------------------------------------")
 			return nil
 		case tfe.CostEstimateCanceled:
-			return fmt.Errorf(msgPrefix + " canceled.")
+			return fmt.Errorf("%s canceled.", msgPrefix)
 		default:
 			return fmt.Errorf("Unknown or unexpected cost estimate state: %s", ce.Status)
 		}
@@ -416,15 +416,15 @@ func (b *Remote) checkPolicy(stopCtx, cancelCtx context.Context, op *backendrun.
 			}
 			continue
 		case tfe.PolicyErrored:
-			return fmt.Errorf(msgPrefix + " errored.")
+			return fmt.Errorf("%s errored.", msgPrefix)
 		case tfe.PolicyHardFailed:
-			return fmt.Errorf(msgPrefix + " hard failed.")
+			return fmt.Errorf("%s hard failed.", msgPrefix)
 		case tfe.PolicySoftFailed:
 			runURL := fmt.Sprintf(runHeaderErr, b.hostname, b.organization, op.Workspace, r.ID)
 
 			if op.Type == backendrun.OperationTypePlan || op.UIOut == nil || op.UIIn == nil ||
 				!pc.Actions.IsOverridable || !pc.Permissions.CanOverride {
-				return fmt.Errorf(msgPrefix + " soft failed.\n" + runURL)
+				return fmt.Errorf("%s soft failed.\n%s", msgPrefix, runURL)
 			}
 
 			if op.AutoApprove {

--- a/internal/cloud/backend_common.go
+++ b/internal/cloud/backend_common.go
@@ -310,7 +310,7 @@ func (b *Cloud) costEstimate(stopCtx, cancelCtx context.Context, op *backendrun.
 			b.CLI.Output("\n------------------------------------------------------------------------")
 			return nil
 		case tfe.CostEstimateCanceled:
-			return fmt.Errorf(msgPrefix + " canceled.")
+			return fmt.Errorf("%s canceled.", msgPrefix)
 		default:
 			return fmt.Errorf("Unknown or unexpected cost estimate state: %s", ce.Status)
 		}
@@ -387,15 +387,15 @@ func (b *Cloud) checkPolicy(stopCtx, cancelCtx context.Context, op *backendrun.O
 			}
 			continue
 		case tfe.PolicyErrored:
-			return fmt.Errorf(msgPrefix + " errored.")
+			return fmt.Errorf("%s errored.", msgPrefix)
 		case tfe.PolicyHardFailed:
-			return fmt.Errorf(msgPrefix + " hard failed.")
+			return fmt.Errorf("%s hard failed.", msgPrefix)
 		case tfe.PolicySoftFailed:
 			runURL := fmt.Sprintf(runHeaderErr, b.Hostname, b.Organization, op.Workspace, r.ID)
 
 			if op.Type == backendrun.OperationTypePlan || op.UIOut == nil || op.UIIn == nil ||
 				!pc.Actions.IsOverridable || !pc.Permissions.CanOverride {
-				return fmt.Errorf(msgPrefix + " soft failed.\n" + runURL)
+				return fmt.Errorf("%s soft failed.\n%s", msgPrefix, runURL)
 			}
 
 			if op.AutoApprove {

--- a/internal/command/jsonformat/plan_test.go
+++ b/internal/command/jsonformat/plan_test.go
@@ -7849,12 +7849,12 @@ func runTestCases(t *testing.T, testCases map[string]testCase) {
 
 			beforeDynamicValue, err := plans.NewDynamicValue(beforeVal, ty)
 			if err != nil {
-				t.Fatalf("failed to create dynamic before value: " + err.Error())
+				t.Fatalf("failed to create dynamic before value: %s", err.Error())
 			}
 
 			afterDynamicValue, err := plans.NewDynamicValue(afterVal, ty)
 			if err != nil {
-				t.Fatalf("failed to create dynamic after value: " + err.Error())
+				t.Fatalf("failed to create dynamic after value: %s", err.Error())
 			}
 
 			src := &plans.ResourceInstanceChangeSrc{
@@ -7895,7 +7895,7 @@ func runTestCases(t *testing.T, testCases map[string]testCase) {
 			}
 			jsonchanges, err := jsonplan.MarshalResourceChanges([]*plans.ResourceInstanceChangeSrc{src}, tfschemas)
 			if err != nil {
-				t.Errorf("failed to marshal resource changes: " + err.Error())
+				t.Errorf("failed to marshal resource changes: %s", err.Error())
 				return
 			}
 

--- a/internal/command/jsonformat/plan_test.go
+++ b/internal/command/jsonformat/plan_test.go
@@ -7849,12 +7849,12 @@ func runTestCases(t *testing.T, testCases map[string]testCase) {
 
 			beforeDynamicValue, err := plans.NewDynamicValue(beforeVal, ty)
 			if err != nil {
-				t.Fatalf("failed to create dynamic before value: %s", err.Error())
+				t.Fatalf("failed to create dynamic before value: %s", err)
 			}
 
 			afterDynamicValue, err := plans.NewDynamicValue(afterVal, ty)
 			if err != nil {
-				t.Fatalf("failed to create dynamic after value: %s", err.Error())
+				t.Fatalf("failed to create dynamic after value: %s", err)
 			}
 
 			src := &plans.ResourceInstanceChangeSrc{
@@ -7895,7 +7895,7 @@ func runTestCases(t *testing.T, testCases map[string]testCase) {
 			}
 			jsonchanges, err := jsonplan.MarshalResourceChanges([]*plans.ResourceInstanceChangeSrc{src}, tfschemas)
 			if err != nil {
-				t.Errorf("failed to marshal resource changes: %s", err.Error())
+				t.Errorf("failed to marshal resource changes: %s", err)
 				return
 			}
 

--- a/internal/command/views/operation.go
+++ b/internal/command/views/operation.go
@@ -146,26 +146,26 @@ func (v *OperationHuman) PlanNextStep(planPath string, genConfigPath string) {
 	v.view.outputHorizRule()
 
 	if genConfigPath != "" {
-		v.view.streams.Printf(
+		v.view.streams.Println(
 			format.WordWrap(
 				"\n"+strings.TrimSpace(fmt.Sprintf(planHeaderGenConfig, genConfigPath)),
 				v.view.outputColumns(),
-			) + "\n")
+			))
 	}
 
 	if planPath == "" {
-		v.view.streams.Print(
+		v.view.streams.Println(
 			format.WordWrap(
 				"\n"+strings.TrimSpace(planHeaderNoOutput),
 				v.view.outputColumns(),
-			) + "\n",
+			),
 		)
 	} else {
-		v.view.streams.Printf(
+		v.view.streams.Println(
 			format.WordWrap(
 				"\n"+strings.TrimSpace(fmt.Sprintf(planHeaderYesOutput, planPath, planPath)),
 				v.view.outputColumns(),
-			) + "\n",
+			),
 		)
 	}
 }

--- a/internal/lang/funcs/collection.go
+++ b/internal/lang/funcs/collection.go
@@ -515,7 +515,7 @@ var SumFunc = function.New(&function.Spec{
 		ty := args[0].Type()
 
 		if !ty.IsListType() && !ty.IsSetType() && !ty.IsTupleType() {
-			return cty.NilVal, function.NewArgErrorf(0, fmt.Sprintf("argument must be list, set, or tuple. Received %s", ty.FriendlyName()))
+			return cty.NilVal, function.NewArgErrorf(0, "argument must be list, set, or tuple. Received %s", ty.FriendlyName())
 		}
 
 		if !args[0].IsWhollyKnown() {

--- a/internal/lang/funcs/crypto.go
+++ b/internal/lang/funcs/crypto.go
@@ -12,6 +12,7 @@ import (
 	"encoding/asn1"
 	"encoding/base64"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"hash"
 	"io"
@@ -175,7 +176,7 @@ var RsaDecryptFunc = function.New(&function.Spec{
 			default:
 				errStr = fmt.Sprintf("invalid private key: %s", e)
 			}
-			return cty.UnknownVal(cty.String), function.NewArgErrorf(1, errStr)
+			return cty.UnknownVal(cty.String), function.NewArgError(1, errors.New(errStr))
 		}
 		privateKey, ok := rawKey.(*rsa.PrivateKey)
 		if !ok {

--- a/internal/legacy/helper/schema/shims_test.go
+++ b/internal/legacy/helper/schema/shims_test.go
@@ -78,7 +78,7 @@ func testApplyDiff(t *testing.T,
 	}
 
 	if !cmp.Equal(expectedState, newState, equateEmpty, typeComparer, valueComparer) {
-		t.Fatalf(cmp.Diff(expectedState, newState, equateEmpty, typeComparer, valueComparer))
+		t.Fatal(cmp.Diff(expectedState, newState, equateEmpty, typeComparer, valueComparer))
 	}
 }
 

--- a/internal/plans/objchange/compatible.go
+++ b/internal/plans/objchange/compatible.go
@@ -38,11 +38,11 @@ func assertObjectCompatible(schema *configschema.Block, planned, actual cty.Valu
 	}
 
 	if planned.IsNull() && !actual.IsNull() {
-		errs = append(errs, path.NewErrorf(fmt.Sprintf("%swas absent, but now present", atRoot)))
+		errs = append(errs, path.NewErrorf("%swas absent, but now present", atRoot))
 		return errs
 	}
 	if actual.IsNull() && !planned.IsNull() {
-		errs = append(errs, path.NewErrorf(fmt.Sprintf("%swas present, but now absent", atRoot)))
+		errs = append(errs, path.NewErrorf("%swas present, but now absent", atRoot))
 		return errs
 	}
 	if planned.IsNull() {

--- a/internal/plugin/grpc_provider.go
+++ b/internal/plugin/grpc_provider.go
@@ -393,7 +393,7 @@ func (p *GRPCProvider) ReadResource(r providers.ReadResourceRequest) (resp provi
 
 	resSchema, ok := schema.ResourceTypes[r.TypeName]
 	if !ok {
-		resp.Diagnostics = resp.Diagnostics.Append(fmt.Errorf("unknown resource type " + r.TypeName))
+		resp.Diagnostics = resp.Diagnostics.Append(fmt.Errorf("unknown resource type %s", r.TypeName))
 		return resp
 	}
 

--- a/internal/plugin6/grpc_provider.go
+++ b/internal/plugin6/grpc_provider.go
@@ -382,7 +382,7 @@ func (p *GRPCProvider) ReadResource(r providers.ReadResourceRequest) (resp provi
 
 	resSchema, ok := schema.ResourceTypes[r.TypeName]
 	if !ok {
-		resp.Diagnostics = resp.Diagnostics.Append(fmt.Errorf("unknown resource type " + r.TypeName))
+		resp.Diagnostics = resp.Diagnostics.Append(fmt.Errorf("unknown resource type %s", r.TypeName))
 		return resp
 	}
 

--- a/internal/rpcapi/dependencies.go
+++ b/internal/rpcapi/dependencies.go
@@ -566,7 +566,7 @@ func (s *dependenciesServer) GetProviderSchema(ctx context.Context, req *depende
 
 	schemaResp, err := loadProviderSchema(providerAddr, providerVersion, cacheDir)
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, err.Error())
+		return nil, status.Error(codes.Internal, err.Error())
 	}
 
 	return &dependencies.GetProviderSchema_Response{


### PR DESCRIPTION
This is in preparation for https://github.com/hashicorp/terraform/pull/36478

I'm making it a separate PR to ease review and also to make it easier to back-port (without having to backport Go upgrade) as it highlighted some valid issues that aren't 1.24 specific.

## Target Release

1.11.x

## CHANGELOG entry


- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
