### PR TITLE
Fix validation of values against schemas with write-only attributes

### DIFF
--- a/internal/configs/configschema/marks.go
+++ b/internal/configs/configschema/marks.go
@@ -5,18 +5,10 @@ package configschema
 
 import (
 	"fmt"
+	"slices"
 
 	"github.com/zclconf/go-cty/cty"
 )
-
-// copyAndExtendPath returns a copy of a cty.Path with some additional
-// `cty.PathStep`s appended to its end, to simplify creating new child paths.
-func copyAndExtendPath(path cty.Path, nextSteps ...cty.PathStep) cty.Path {
-	newPath := make(cty.Path, len(path), len(path)+len(nextSteps))
-	copy(newPath, path)
-	newPath = append(newPath, nextSteps...)
-	return newPath
-}
 
 // WARNING: SensitivePaths must exactly mirror the WriteOnlyPaths method, since
 // they both use the same process just for different attribute types. Any fixes
@@ -30,7 +22,7 @@ func (b *Block) SensitivePaths(val cty.Value, basePath cty.Path) []cty.Path {
 	// We can mark attributes as sensitive even if the value is null
 	for name, attrS := range b.Attributes {
 		if attrS.Sensitive {
-			attrPath := copyAndExtendPath(basePath, cty.GetAttrStep{Name: name})
+			attrPath := slices.Concat(basePath, cty.GetAttrPath(name))
 			ret = append(ret, attrPath)
 		}
 	}
@@ -40,7 +32,7 @@ func (b *Block) SensitivePaths(val cty.Value, basePath cty.Path) []cty.Path {
 		return ret
 	}
 
-	// Extract marks for nested attribute type values
+	// Extract paths for marks from nested attribute type values
 	for name, attrS := range b.Attributes {
 		// If the attribute has no nested type, or the nested type doesn't
 		// contain any sensitive attributes, skip inspecting it
@@ -49,11 +41,11 @@ func (b *Block) SensitivePaths(val cty.Value, basePath cty.Path) []cty.Path {
 		}
 
 		// Create a copy of the path, with this step added, to add to our PathValueMarks slice
-		attrPath := copyAndExtendPath(basePath, cty.GetAttrStep{Name: name})
+		attrPath := slices.Concat(basePath, cty.GetAttrPath(name))
 		ret = append(ret, attrS.NestedType.SensitivePaths(val.GetAttr(name), attrPath)...)
 	}
 
-	// Extract marks for nested blocks
+	// Extract paths for marks from nested blocks
 	for name, blockS := range b.BlockTypes {
 		// If our block doesn't contain any sensitive attributes, skip inspecting it
 		if !blockS.Block.ContainsSensitive() {
@@ -66,7 +58,7 @@ func (b *Block) SensitivePaths(val cty.Value, basePath cty.Path) []cty.Path {
 		}
 
 		// Create a copy of the path, with this step added, to add to our PathValueMarks slice
-		blockPath := copyAndExtendPath(basePath, cty.GetAttrStep{Name: name})
+		blockPath := slices.Concat(basePath, cty.GetAttrPath(name))
 
 		switch blockS.Nesting {
 		case NestingSingle, NestingGroup:
@@ -77,7 +69,7 @@ func (b *Block) SensitivePaths(val cty.Value, basePath cty.Path) []cty.Path {
 				idx, blockEV := it.Element()
 				// Create a copy of the path, with this block instance's index
 				// step added, to add to our PathValueMarks slice
-				blockInstancePath := copyAndExtendPath(blockPath, cty.IndexStep{Key: idx})
+				blockInstancePath := slices.Concat(blockPath, cty.IndexPath(idx))
 				morePaths := blockS.Block.SensitivePaths(blockEV, blockInstancePath)
 				ret = append(ret, morePaths...)
 			}
@@ -106,7 +98,7 @@ func (o *Object) SensitivePaths(val cty.Value, basePath cty.Path) []cty.Path {
 		switch o.Nesting {
 		case NestingSingle, NestingGroup:
 			// Create a path to this attribute
-			attrPath := copyAndExtendPath(basePath, cty.GetAttrStep{Name: name})
+			attrPath := slices.Concat(basePath, cty.GetAttrPath(name))
 
 			if attrS.Sensitive {
 				// If the entire attribute is sensitive, mark it so
@@ -129,7 +121,7 @@ func (o *Object) SensitivePaths(val cty.Value, basePath cty.Path) []cty.Path {
 				// of the loops: index into the collection, then the contained
 				// attribute name. This is because we have one type
 				// representing multiple collection elements.
-				attrPath := copyAndExtendPath(basePath, cty.IndexStep{Key: idx}, cty.GetAttrStep{Name: name})
+				attrPath := slices.Concat(basePath, cty.IndexPath(idx).GetAttr(name))
 
 				if attrS.Sensitive {
 					// If the entire attribute is sensitive, mark it so

--- a/internal/configs/configschema/marks.go
+++ b/internal/configs/configschema/marks.go
@@ -18,6 +18,10 @@ func copyAndExtendPath(path cty.Path, nextSteps ...cty.PathStep) cty.Path {
 	return newPath
 }
 
+// WARNING: SensitivePaths must exactly mirror the WriteOnlyPaths method, since
+// they both use the same process just for different attribute types. Any fixes
+// here must be made in WriteOnlyPaths, and vice versa.
+
 // SensitivePaths returns a set of paths into the given value that should
 // be marked as sensitive based on the static declarations in the schema.
 func (b *Block) SensitivePaths(val cty.Value, basePath cty.Path) []cty.Path {

--- a/internal/configs/configschema/write_only.go
+++ b/internal/configs/configschema/write_only.go
@@ -98,7 +98,6 @@ func (o *Object) writeOnlyPaths(val cty.Value, basePath cty.Path) []cty.Path {
 		case NestingSingle, NestingGroup:
 			// Create a path to this attribute
 			attrPath := copyAndExtendPath(basePath, cty.GetAttrStep{Name: name})
-
 			if attrS.WriteOnly {
 				// If the entire attribute is write-only, mark it so
 				ret = append(ret, attrPath)
@@ -130,7 +129,7 @@ func (o *Object) writeOnlyPaths(val cty.Value, basePath cty.Path) []cty.Path {
 				}
 			}
 		default:
-			panic(fmt.Sprintf("unsupported nesting mode %s", attrS.NestedType.Nesting))
+			panic(fmt.Sprintf("unsupported nesting mode %s", o.Nesting))
 		}
 	}
 	return ret

--- a/internal/configs/configschema/write_only.go
+++ b/internal/configs/configschema/write_only.go
@@ -9,37 +9,52 @@ import (
 	"github.com/zclconf/go-cty/cty"
 )
 
-// WriteOnlyPaths returns a set of paths into the given value that
-// are considered write only based on the declarations in the schema.
+// WARNING: WriteOnlyPaths must exactly mirror the SensitivePaths method, since
+// they both use the same process just for different attribute types. Any fixes
+// here must be made in SensitivePaths, and vice versa.
+
+// WriteOnlyPaths returns a set of paths into the given value that should
+// be marked as write-only based on the static declarations in the schema.
 func (b *Block) WriteOnlyPaths(val cty.Value, basePath cty.Path) []cty.Path {
 	var ret []cty.Path
 
+	// We can mark attributes as write-only even if the value is null
 	for name, attrS := range b.Attributes {
 		if attrS.WriteOnly {
 			attrPath := copyAndExtendPath(basePath, cty.GetAttrStep{Name: name})
 			ret = append(ret, attrPath)
 		}
+	}
 
+	// If the value is null, no other marks are possible
+	if val.IsNull() {
+		return ret
+	}
+
+	// Extract marks for nested attribute type values
+	for name, attrS := range b.Attributes {
+		// If the attribute has no nested type, or the nested type doesn't
+		// contain any write-only attributes, skip inspecting it
 		if attrS.NestedType == nil || !attrS.NestedType.ContainsWriteOnly() {
 			continue
 		}
 
+		// Create a copy of the path, with this step added, to add to our PathValueMarks slice
 		attrPath := copyAndExtendPath(basePath, cty.GetAttrStep{Name: name})
-		ret = append(ret, attrS.NestedType.WriteOnlyPaths(attrPath)...)
+		ret = append(ret, attrS.NestedType.writeOnlyPaths(val.GetAttr(name), attrPath)...)
 	}
 
-	// Extract from nested blocks
+	// Extract marks for nested blocks
 	for name, blockS := range b.BlockTypes {
-		// If our block doesn't contain any write only attributes, skip inspecting it
+		// If our block doesn't contain any write-only attributes, skip inspecting it
 		if !blockS.Block.ContainsWriteOnly() {
 			continue
 		}
 
-		if val.IsNull() {
-			return ret
-		}
-
 		blockV := val.GetAttr(name)
+		if blockV.IsNull() || !blockV.IsKnown() {
+			continue
+		}
 
 		// Create a copy of the path, with this step added, to add to our PathValueMarks slice
 		blockPath := copyAndExtendPath(basePath, cty.GetAttrStep{Name: name})
@@ -49,14 +64,10 @@ func (b *Block) WriteOnlyPaths(val cty.Value, basePath cty.Path) []cty.Path {
 			ret = append(ret, blockS.Block.WriteOnlyPaths(blockV, blockPath)...)
 		case NestingList, NestingMap, NestingSet:
 			blockV, _ = blockV.Unmark() // peel off one level of marking so we can iterate
-
-			if blockV.IsNull() || !blockV.IsKnown() {
-				return ret
-			}
-
 			for it := blockV.ElementIterator(); it.Next(); {
 				idx, blockEV := it.Element()
-
+				// Create a copy of the path, with this block instance's index
+				// step added, to add to our PathValueMarks slice
 				blockInstancePath := copyAndExtendPath(blockPath, cty.IndexStep{Key: idx})
 				morePaths := blockS.Block.WriteOnlyPaths(blockEV, blockInstancePath)
 				ret = append(ret, morePaths...)
@@ -68,30 +79,55 @@ func (b *Block) WriteOnlyPaths(val cty.Value, basePath cty.Path) []cty.Path {
 	return ret
 }
 
-// WriteOnlyPaths returns a set of paths into the given value that
-// are considered write only based on the declarations in the schema.
-func (o *Object) WriteOnlyPaths(basePath cty.Path) []cty.Path {
+// writeOnlyPaths returns a set of paths into the given value that should be
+// marked as write-only based on the static declarations in the schema.
+func (o *Object) writeOnlyPaths(val cty.Value, basePath cty.Path) []cty.Path {
 	var ret []cty.Path
 
+	if val.IsNull() || !val.IsKnown() {
+		return ret
+	}
+
 	for name, attrS := range o.Attributes {
-		// Create a path to this attribute
-		attrPath := copyAndExtendPath(basePath, cty.GetAttrStep{Name: name})
+		// Skip attributes which can never produce write-only path value marks
+		if !attrS.WriteOnly && (attrS.NestedType == nil || !attrS.NestedType.ContainsWriteOnly()) {
+			continue
+		}
 
 		switch o.Nesting {
 		case NestingSingle, NestingGroup:
+			// Create a path to this attribute
+			attrPath := copyAndExtendPath(basePath, cty.GetAttrStep{Name: name})
+
 			if attrS.WriteOnly {
+				// If the entire attribute is write-only, mark it so
 				ret = append(ret, attrPath)
 			} else {
-				// The attribute has a nested type which contains write only
+				// The attribute has a nested type which contains write-only
 				// attributes, so recurse
-				ret = append(ret, attrS.NestedType.WriteOnlyPaths(attrPath)...)
+				ret = append(ret, attrS.NestedType.writeOnlyPaths(val.GetAttr(name), attrPath)...)
 			}
 		case NestingList, NestingMap, NestingSet:
-			// If the attribute is iterable type we assume that
-			// it is write only in its entirety since we cannot
-			// construct indexes from a null value.
-			if attrS.WriteOnly {
-				ret = append(ret, attrPath)
+			// For nested attribute types which have a non-single nesting mode,
+			// we add path value marks for each element of the collection
+			val, _ = val.Unmark() // peel off one level of marking so we can iterate
+			for it := val.ElementIterator(); it.Next(); {
+				idx, attrEV := it.Element()
+				attrV := attrEV.GetAttr(name)
+
+				// Create a path to this element of the attribute's collection. Note
+				// that the path is extended in opposite order to the iteration order
+				// of the loops: index into the collection, then the contained
+				// attribute name. This is because we have one type
+				// representing multiple collection elements.
+				attrPath := copyAndExtendPath(basePath, cty.IndexStep{Key: idx}, cty.GetAttrStep{Name: name})
+
+				if attrS.WriteOnly {
+					// If the entire attribute is write-only, mark it so
+					ret = append(ret, attrPath)
+				} else {
+					ret = append(ret, attrS.NestedType.writeOnlyPaths(attrV, attrPath)...)
+				}
 			}
 		default:
 			panic(fmt.Sprintf("unsupported nesting mode %s", attrS.NestedType.Nesting))

--- a/internal/configs/configschema/write_only_test.go
+++ b/internal/configs/configschema/write_only_test.go
@@ -18,20 +18,58 @@ func TestBlock_WriteOnlyPaths(t *testing.T) {
 			},
 			"wo": {
 				Type:      cty.String,
+				Optional:  true,
 				WriteOnly: true,
 			},
 			"nested": {
+				Optional: true,
 				NestedType: &Object{
 					Attributes: map[string]*Attribute{
 						"boop": {
-							Type: cty.String,
+							Type:     cty.String,
+							Optional: true,
 						},
 						"honk": {
 							Type:      cty.String,
+							Optional:  true,
 							WriteOnly: true,
 						},
 					},
 					Nesting: NestingList,
+				},
+			},
+			"single": {
+				Optional: true,
+				NestedType: &Object{
+					Nesting: NestingSingle,
+					Attributes: map[string]*Attribute{
+						"not_wo": {
+							Optional: true,
+							Type:     cty.String,
+						},
+						"wo": {
+							Type:      cty.String,
+							Optional:  true,
+							WriteOnly: true,
+						},
+						"nested_single": {
+							Optional: true,
+							NestedType: &Object{
+								Nesting: NestingSingle,
+								Attributes: map[string]*Attribute{
+									"not_wo": {
+										Optional: true,
+										Type:     cty.String,
+									},
+									"wo": {
+										Type:      cty.String,
+										Optional:  true,
+										WriteOnly: true,
+									},
+								},
+							},
+						},
+					},
 				},
 			},
 		},
@@ -47,12 +85,28 @@ func TestBlock_WriteOnlyPaths(t *testing.T) {
 						},
 						"wo": {
 							Type:      cty.String,
+							Optional:  true,
 							WriteOnly: true,
 						},
 					},
 				},
 			},
-		},
+			"single_block": {
+				Nesting: NestingSingle,
+				Block: Block{
+					Attributes: map[string]*Attribute{
+						"not_wo": {
+							Type:     cty.String,
+							Optional: true,
+						},
+						"wo": {
+							Type:      cty.String,
+							Optional:  true,
+							WriteOnly: true,
+						},
+					},
+				},
+			}},
 	}
 
 	testCases := map[string]struct {
@@ -89,10 +143,6 @@ func TestBlock_WriteOnlyPaths(t *testing.T) {
 			cty.ObjectVal(map[string]cty.Value{
 				"wo":     cty.NullVal(cty.String),
 				"not_wo": cty.UnknownVal(cty.String),
-				"nested": cty.NullVal(cty.List(cty.Object(map[string]cty.Type{
-					"boop": cty.String,
-					"honk": cty.String,
-				}))),
 				"list": cty.ListVal([]cty.Value{
 					cty.ObjectVal(map[string]cty.Value{
 						"wo":     cty.UnknownVal(cty.String),
@@ -129,8 +179,8 @@ func TestBlock_WriteOnlyPaths(t *testing.T) {
 					}),
 				}),
 				"list": cty.NullVal(cty.List(cty.Object(map[string]cty.Type{
-					"sensitive":   cty.String,
-					"unsensitive": cty.String,
+					"not_wo": cty.String,
+					"wo":     cty.String,
 				}))),
 			}),
 			[]cty.Path{
@@ -140,11 +190,55 @@ func TestBlock_WriteOnlyPaths(t *testing.T) {
 				{cty.GetAttrStep{Name: "nested"}, cty.IndexStep{Key: cty.NumberIntVal(2)}, cty.GetAttrStep{Name: "honk"}},
 			},
 		},
+		"object with single nested block and attribute": {
+			cty.ObjectVal(map[string]cty.Value{
+				"wo":     cty.StringVal("foo"),
+				"not_wo": cty.StringVal("bar"),
+				"single": cty.ObjectVal(map[string]cty.Value{
+					"not_wo": cty.StringVal("foo"),
+					"wo":     cty.StringVal("bar"),
+				}),
+				"single_block": cty.ObjectVal(map[string]cty.Value{
+					"not_wo": cty.StringVal("test"),
+					"wo":     cty.StringVal("secret"),
+				}),
+			}),
+			[]cty.Path{
+				{cty.GetAttrStep{Name: "wo"}},
+				{cty.GetAttrStep{Name: "single"}, cty.GetAttrStep{Name: "wo"}},
+				{cty.GetAttrStep{Name: "single_block"}, cty.GetAttrStep{Name: "wo"}},
+			},
+		},
+		"object with doubly single-nested attribute": {
+			cty.ObjectVal(map[string]cty.Value{
+				"single": cty.ObjectVal(map[string]cty.Value{
+					"not_wo": cty.StringVal("foo"),
+					"wo":     cty.NullVal(cty.String),
+					"nested_single": cty.ObjectVal(map[string]cty.Value{
+						"not_wo": cty.StringVal("foo"),
+						"wo":     cty.NullVal(cty.String),
+					}),
+				}),
+			}),
+			[]cty.Path{
+				{cty.GetAttrStep{Name: "wo"}},
+				{cty.GetAttrStep{Name: "single"}, cty.GetAttrStep{Name: "wo"}},
+				{cty.GetAttrStep{Name: "single"}, cty.GetAttrStep{Name: "nested_single"}, cty.GetAttrStep{Name: "wo"}},
+			},
+		},
 	}
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			woPaths := schema.WriteOnlyPaths(tc.value, nil)
+			val := tc.value
+			if err := schema.InternalValidate(); err != nil {
+				t.Fatal(err)
+			}
+			val, err := schema.CoerceValue(tc.value)
+			if err != nil {
+				t.Fatal(err)
+			}
+			woPaths := schema.WriteOnlyPaths(val, nil)
 			if !cty.NewPathSet(tc.expected...).Equal(cty.NewPathSet(woPaths...)) {
 				t.Fatalf("\nexpected: %#v\ngot:      %#v\n", tc.expected, woPaths)
 			}

--- a/internal/configs/configschema/write_only_test.go
+++ b/internal/configs/configschema/write_only_test.go
@@ -230,7 +230,6 @@ func TestBlock_WriteOnlyPaths(t *testing.T) {
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			val := tc.value
 			if err := schema.InternalValidate(); err != nil {
 				t.Fatal(err)
 			}

--- a/internal/configs/configschema/write_only_test.go
+++ b/internal/configs/configschema/write_only_test.go
@@ -63,14 +63,12 @@ func TestBlock_WriteOnlyPaths(t *testing.T) {
 			cty.UnknownVal(schema.ImpliedType()),
 			[]cty.Path{
 				{cty.GetAttrStep{Name: "wo"}},
-				{cty.GetAttrStep{Name: "nested"}, cty.GetAttrStep{Name: "honk"}},
 			},
 		},
 		"null object": {
 			cty.NullVal(schema.ImpliedType()),
 			[]cty.Path{
 				{cty.GetAttrStep{Name: "wo"}},
-				{cty.GetAttrStep{Name: "nested"}, cty.GetAttrStep{Name: "honk"}},
 			},
 		},
 		"object with unknown attributes and blocks": {
@@ -85,7 +83,6 @@ func TestBlock_WriteOnlyPaths(t *testing.T) {
 			}),
 			[]cty.Path{
 				{cty.GetAttrStep{Name: "wo"}},
-				{cty.GetAttrStep{Name: "nested"}, cty.GetAttrStep{Name: "honk"}},
 			},
 		},
 		"object with block value": {
@@ -109,7 +106,6 @@ func TestBlock_WriteOnlyPaths(t *testing.T) {
 			}),
 			[]cty.Path{
 				{cty.GetAttrStep{Name: "wo"}},
-				{cty.GetAttrStep{Name: "nested"}, cty.GetAttrStep{Name: "honk"}},
 				{cty.GetAttrStep{Name: "list"}, cty.IndexStep{Key: cty.NumberIntVal(0)}, cty.GetAttrStep{Name: "wo"}},
 				{cty.GetAttrStep{Name: "list"}, cty.IndexStep{Key: cty.NumberIntVal(1)}, cty.GetAttrStep{Name: "wo"}},
 			},
@@ -139,7 +135,9 @@ func TestBlock_WriteOnlyPaths(t *testing.T) {
 			}),
 			[]cty.Path{
 				{cty.GetAttrStep{Name: "wo"}},
-				{cty.GetAttrStep{Name: "nested"}, cty.GetAttrStep{Name: "honk"}},
+				{cty.GetAttrStep{Name: "nested"}, cty.IndexStep{Key: cty.NumberIntVal(0)}, cty.GetAttrStep{Name: "honk"}},
+				{cty.GetAttrStep{Name: "nested"}, cty.IndexStep{Key: cty.NumberIntVal(1)}, cty.GetAttrStep{Name: "honk"}},
+				{cty.GetAttrStep{Name: "nested"}, cty.IndexStep{Key: cty.NumberIntVal(2)}, cty.GetAttrStep{Name: "honk"}},
 			},
 		},
 	}

--- a/internal/lang/ephemeral/validate.go
+++ b/internal/lang/ephemeral/validate.go
@@ -4,6 +4,8 @@
 package ephemeral
 
 import (
+	"fmt"
+
 	"github.com/hashicorp/terraform/internal/configs/configschema"
 	"github.com/hashicorp/terraform/internal/tfdiags"
 	"github.com/zclconf/go-cty/cty"
@@ -12,7 +14,15 @@ import (
 // ValidateWriteOnlyAttributes identifies all instances of write-only paths that contain non-null values
 // and returns a diagnostic for each instance
 func ValidateWriteOnlyAttributes(summary string, detail func(cty.Path) string, newVal cty.Value, schema *configschema.Block) (diags tfdiags.Diagnostics) {
-	if writeOnlyPaths := NonNullWriteOnlyPaths(newVal, schema, nil); len(writeOnlyPaths) != 0 {
+	writeOnlyPaths, err := nonNullWriteOnlyPaths(newVal, schema, nil)
+	if err != nil {
+		return diags.Append(tfdiags.Sourceless(
+			tfdiags.Error,
+			summary,
+			fmt.Sprintf("Error validating write-only attributes: %s.", err),
+		))
+	}
+	if len(writeOnlyPaths) != 0 {
 		for _, p := range writeOnlyPaths {
 			diags = diags.Append(tfdiags.Sourceless(
 				tfdiags.Error,
@@ -24,26 +34,27 @@ func ValidateWriteOnlyAttributes(summary string, detail func(cty.Path) string, n
 	return diags
 }
 
-// NonNullWriteOnlyPaths returns a list of paths to attributes that are write-only
+// nonNullWriteOnlyPaths returns a list of paths to attributes that are write-only
 // and non-null in the given value.
-func NonNullWriteOnlyPaths(val cty.Value, schema *configschema.Block, p cty.Path) (paths []cty.Path) {
+func nonNullWriteOnlyPaths(val cty.Value, schema *configschema.Block, p cty.Path) ([]cty.Path, error) {
 	if schema == nil {
-		return paths
+		panic("nonNullWriteOnlyPaths called wih nil schema")
 	}
+	var paths []cty.Path
 
-	for name, attr := range schema.Attributes {
-		attrPath := append(p, cty.GetAttrStep{Name: name})
-		attrVal, _ := attrPath.Apply(val)
-		if attr.WriteOnly && !attrVal.IsNull() {
-			paths = append(paths, attrPath)
+	for _, path := range schema.WriteOnlyPaths(val, nil) {
+		// Note that path.Apply will fail if the path traverses a set, but ephemeral
+		// values won't work in a set anyway, and they are prohibited by the
+		// plugin framework.
+		v, err := path.Apply(val)
+		if err != nil {
+			return nil, err
 		}
+		if !v.IsNull() {
+			paths = append(paths, path)
+		}
+
 	}
 
-	for name, blockS := range schema.BlockTypes {
-		blockPath := append(p, cty.GetAttrStep{Name: name})
-		x := NonNullWriteOnlyPaths(val, &blockS.Block, blockPath)
-		paths = append(paths, x...)
-	}
-
-	return paths
+	return paths, nil
 }

--- a/internal/lang/ephemeral/validate_test.go
+++ b/internal/lang/ephemeral/validate_test.go
@@ -69,20 +69,30 @@ func TestNonNullWriteOnlyPaths(t *testing.T) {
 
 		"write-only attributes in blocks": {
 			val: cty.ObjectVal(map[string]cty.Value{
-				"foo": cty.ObjectVal(map[string]cty.Value{
-					"valid-write-only": cty.NullVal(cty.String),
-					"valid":            cty.StringVal("valid"),
-					"id":               cty.StringVal("i-abc123"),
-					"bar": cty.ObjectVal(map[string]cty.Value{
+				"foo": cty.ListVal([]cty.Value{
+					cty.ObjectVal(map[string]cty.Value{
 						"valid-write-only": cty.NullVal(cty.String),
 						"valid":            cty.StringVal("valid"),
 						"id":               cty.StringVal("i-abc123"),
+						"bar": cty.ListVal([]cty.Value{
+							cty.ObjectVal(map[string]cty.Value{
+								"valid-write-only": cty.NullVal(cty.String),
+								"valid":            cty.StringVal("valid"),
+								"id":               cty.StringVal("i-abc123"),
+							}),
+							cty.ObjectVal(map[string]cty.Value{
+								"valid-write-only": cty.NullVal(cty.String),
+								"valid":            cty.StringVal("valid"),
+								"id":               cty.StringVal("i-xyz123"),
+							}),
+						}),
 					}),
 				}),
 			}),
 			schema: &configschema.Block{
 				BlockTypes: map[string]*configschema.NestedBlock{
 					"foo": {
+						Nesting: configschema.NestingList,
 						Block: configschema.Block{
 							Attributes: map[string]*configschema.Attribute{
 								"valid-write-only": {
@@ -102,6 +112,7 @@ func TestNonNullWriteOnlyPaths(t *testing.T) {
 							},
 							BlockTypes: map[string]*configschema.NestedBlock{
 								"bar": {
+									Nesting: configschema.NestingList,
 									Block: configschema.Block{
 										Attributes: map[string]*configschema.Attribute{
 											"valid-write-only": {
@@ -126,11 +137,18 @@ func TestNonNullWriteOnlyPaths(t *testing.T) {
 					},
 				},
 			},
-			expectedPaths: []cty.Path{cty.GetAttrPath("foo").GetAttr("id"), cty.GetAttrPath("foo").GetAttr("bar").GetAttr("id")},
+			expectedPaths: []cty.Path{
+				cty.GetAttrPath("foo").Index(cty.NumberIntVal(0)).GetAttr("id"),
+				cty.GetAttrPath("foo").Index(cty.NumberIntVal(0)).GetAttr("bar").Index(cty.NumberIntVal(0)).GetAttr("id"),
+				cty.GetAttrPath("foo").Index(cty.NumberIntVal(0)).GetAttr("bar").Index(cty.NumberIntVal(1)).GetAttr("id"),
+			},
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
-			paths := NonNullWriteOnlyPaths(tc.val, tc.schema, nil)
+			paths, err := nonNullWriteOnlyPaths(tc.val, tc.schema, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
 
 			if len(paths) != len(tc.expectedPaths) {
 				t.Fatalf("expected %d write-only paths, got %d", len(tc.expectedPaths), len(paths))

--- a/internal/refactoring/cross_provider_move.go
+++ b/internal/refactoring/cross_provider_move.go
@@ -100,9 +100,7 @@ func (m *crossTypeMover) prepareCrossTypeMove(stmt *MoveStatement, source, targe
 		})
 		return nil, diags
 	}
-
 	targetResourceSchema, targetResourceSchemaVersion := targetSchema.SchemaForResourceAddr(target.Resource)
-
 	return &crossTypeMove{
 		targetProvider:              targetProvider,
 		targetProviderAddr:          *targetProviderAddr,

--- a/internal/refactoring/mock_provider.go
+++ b/internal/refactoring/mock_provider.go
@@ -3,6 +3,7 @@ package refactoring
 import (
 	"github.com/zclconf/go-cty/cty"
 
+	"github.com/hashicorp/terraform/internal/configs/configschema"
 	"github.com/hashicorp/terraform/internal/providers"
 	"github.com/hashicorp/terraform/internal/tfdiags"
 )
@@ -19,8 +20,8 @@ type mockProvider struct {
 func (provider *mockProvider) GetProviderSchema() providers.GetProviderSchemaResponse {
 	return providers.GetProviderSchemaResponse{
 		ResourceTypes: map[string]providers.Schema{
-			"foo": {},
-			"bar": {},
+			"foo": {Block: &configschema.Block{}},
+			"bar": {Block: &configschema.Block{}},
 		},
 		ServerCapabilities: providers.ServerCapabilities{
 			MoveResourceState: provider.moveResourceState,

--- a/internal/terraform/context_plan2_test.go
+++ b/internal/terraform/context_plan2_test.go
@@ -5603,7 +5603,7 @@ func TestContext2Plan_ephemeralInResource(t *testing.T) {
 	wantDiags = wantDiags.Append(&hcl.Diagnostic{
 		Severity: hcl.DiagError,
 		Summary:  "Invalid use of ephemeral value",
-		Detail:   "Ephemeral values are not valid in resource arguments, because resource instances must persist between Terraform phases.",
+		Detail:   `Ephemeral values are not valid for "in", because it is not a write-only attribute and must be persisted to state.`,
 		Subject: &hcl.Range{
 			Filename: filepath.Join(m.Module.SourceDir, "main.tf"),
 			Start: hcl.Pos{
@@ -5617,7 +5617,7 @@ func TestContext2Plan_ephemeralInResource(t *testing.T) {
 	wantDiags = wantDiags.Append(&hcl.Diagnostic{
 		Severity: hcl.DiagError,
 		Summary:  "Invalid use of ephemeral value",
-		Detail:   "Ephemeral values are not valid in resource arguments, because resource instances must persist between Terraform phases.",
+		Detail:   `Ephemeral values are not valid for "in", because it is not a write-only attribute and must be persisted to state.`,
 		Subject: &hcl.Range{
 			Filename: filepath.Join(m.Module.SourceDir, "main.tf"),
 			Start: hcl.Pos{

--- a/internal/terraform/context_plan_ephemeral_test.go
+++ b/internal/terraform/context_plan_ephemeral_test.go
@@ -108,7 +108,7 @@ resource "test_object" "test" {
 				return diags.Append(&hcl.Diagnostic{
 					Severity: hcl.DiagError,
 					Summary:  "Invalid use of ephemeral value",
-					Detail:   "Ephemeral values are not valid in resource arguments, because resource instances must persist between Terraform phases.",
+					Detail:   `Ephemeral values are not valid for "test_string", because it is not a write-only attribute and must be persisted to state.`,
 				})
 			},
 		},

--- a/internal/terraform/context_test.go
+++ b/internal/terraform/context_test.go
@@ -1063,6 +1063,7 @@ type SummaryAndDetail struct {
 // assertDiagnosticsSummaryAndDetailMatch fails the test in progress (using t.Fatal) if the
 // two sets of diagnostics don't match their subjects / descriptions after being normalized using the "ForRPC" processing step.
 func assertDiagnosticsSummaryAndDetailMatch(t *testing.T, got, want tfdiags.Diagnostics) {
+	t.Helper()
 	got = got.ForRPC()
 	want = want.ForRPC()
 

--- a/internal/terraform/node_resource_validate.go
+++ b/internal/terraform/node_resource_validate.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hashicorp/terraform/internal/didyoumean"
 	"github.com/hashicorp/terraform/internal/instances"
 	"github.com/hashicorp/terraform/internal/lang/ephemeral"
+	"github.com/hashicorp/terraform/internal/lang/format"
 	"github.com/hashicorp/terraform/internal/lang/langrefs"
 	"github.com/hashicorp/terraform/internal/providers"
 	"github.com/hashicorp/terraform/internal/provisioners"
@@ -752,22 +753,29 @@ func validateDependsOn(ctx EvalContext, dependsOn []hcl.Traversal) (diags tfdiag
 func validateResourceForbiddenEphemeralValues(ctx EvalContext, value cty.Value, schema *configschema.Block) (diags tfdiags.Diagnostics) {
 	for _, path := range ephemeral.EphemeralValuePaths(value) {
 		attr := schema.AttributeByPath(path)
+		// We know the config decoded, so the "attribute" exists in the
+		// schema somehow. If the ephemeral mark ended up being hoisted into
+		// a container however, especially if that container is a block,
+		// it's not actually an assignable attribute so we need to make a
+		// generic sounding error with a little more context because the
+		// AttributeValue diagnostic won't point to anything except the
+		// resource block.
+		//
 		if attr == nil {
 			diags = diags.Append(tfdiags.AttributeValue(
 				tfdiags.Error,
-				"Could not find schema for attribute",
-				"This is most likely a bug in Terraform, please report it.",
+				"Invalid use of ephemeral value",
+				fmt.Sprintf("Ephemeral values are not valid for %q, because it is not an assignable attribute.", strings.TrimPrefix(format.CtyPath(path), ".")),
 				path,
 			))
 		} else if !attr.WriteOnly {
 			diags = diags.Append(tfdiags.AttributeValue(
 				tfdiags.Error,
 				"Invalid use of ephemeral value",
-				"Ephemeral values are not valid in resource arguments, because resource instances must persist between Terraform phases.",
+				fmt.Sprintf("Ephemeral values are not valid for %q, because it is not a write-only attribute and must be persisted to state.", strings.TrimPrefix(format.CtyPath(path), ".")),
 				path,
 			))
 		}
-
 	}
 	return diags
 }


### PR DESCRIPTION
This cleans up some validation problems with write-only attributes, which would produce confusing errors, or allow write-only attributes to be stored in the state.

The first validation which failed was if an ephemeral value ended up in a nested object which cannot be directly declared as write-only. The diagnostic would only state `Could not find schema for attribute`, so we can rewrite that to better indicate that an ephemeral value was inappropriately assigned, and where it was assigned to.

`ValidateWriteOnlyAttributes` did not properly descent through nested blocks and structural attributes, and would allow invalid values to be returned from the provider. The schema already contains code to walk a value in conjunction with its schema,`WriteOnlyPaths`, which should allow us to directly check the attribute values without writing the same recursive walk again.

`WriteOnlyPaths` was not working correctly however, as it was returning some paths from values which did not exist, while missing others which did. The process is exactly the same as for `SensitivePaths`, so replace the methods with an exact copy, swapping out the appropriate field and method names.