### PR TITLE
docs: fixed orchestration example, variables

### DIFF
--- a/website/docs/language/stacks/deploy/conditions.mdx
+++ b/website/docs/language/stacks/deploy/conditions.mdx
@@ -61,7 +61,7 @@ orchestrate "replan" "replan_prod_for_errors" {
 }
 ```
 
-The above `orchestrate` block triggers a replan if the production development of a Stack errors out and if HCP Terraform hasn't already attempted to replan.
+The above `orchestrate` block triggers a replan if the production deployment of a Stack errors out and if HCP Terraform hasn't already attempted to replan.
 
 ### Leverage orchestration context
 
@@ -72,9 +72,9 @@ Use `context` to create more sophisticated checks and conditions. For example, y
 ```hcl
 # deployments.tfdeploy.hcl
 
-orchestrate "auto_approve" "no_pet_changes" {
+orchestrate "auto_approve" "allow_plans" {
     check {
-        # Check that the pet component has no changes
+        # Check that the operation is a plan
         condition = context.operation == "plan"
         reason = "Apply operations need manual approval."
     }
@@ -92,7 +92,7 @@ orchestrate "auto_approve" "safe_plans" {
         reason    = "Plan is destroying ${context.plan.changes.remove} resources."
     }
 
-    # Ensure that the deployment is not your production environment. 
+    # Ensure that the deployment is not to your production environment. 
     check {
         condition = context.plan.deployment != deployment.production
         reason    = "Production plans are not eligible for auto_approve."

--- a/website/docs/language/stacks/deploy/conditions.mdx
+++ b/website/docs/language/stacks/deploy/conditions.mdx
@@ -92,7 +92,7 @@ orchestrate "auto_approve" "safe_plans" {
         reason    = "Plan is destroying ${context.plan.changes.remove} resources."
     }
 
-    # Ensure that the deployment is not to your production environment. 
+    # Ensure that the deployment is not your production environment. 
     check {
         condition = context.plan.deployment != deployment.production
         reason    = "Production plans are not eligible for auto_approve."

--- a/website/docs/language/stacks/deploy/config.mdx
+++ b/website/docs/language/stacks/deploy/config.mdx
@@ -38,17 +38,17 @@ The `deployment` block accepts a map of `inputs` where you can specify any uniqu
 # deployments.tfdeploy.hcl
 
 deployment "production" {
-    inputs = {
-        aws_region     = "us-west-1"
-        instance_count = 2
-    }
+  inputs = {
+    aws_region     = "us-west-1"
+    instance_count = 2
+  }
 }
 
 deployment "staging" {
-    inputs = {
-        aws_region     = "us-west-1"
-        instance_count = 1
-    }
+  inputs = {
+    aws_region     = "us-west-1"
+    instance_count = 1
+  }
 }
 ```
 
@@ -62,15 +62,15 @@ The `identity_token` block tells HCP Terraform to generate a JSON Web Token (JWT
 # deployments.tfdeploy.hcl
 
 identity_token "aws" {
-    audience = ["aws.workload.identity"]
+  audience = ["aws.workload.identity"]
 }
 
 deployment "staging" {
-    inputs = {
-        aws_region     = "eu-west-1"
-        role_arn       = "arn:aws:iam::123456789101:role/my-oidc-role"
-        aws_token      = identity_token.aws.jwt
-    }
+  inputs = {
+    aws_region = "eu-west-1"
+    role_arn   = "arn:aws:iam::123456789101:role/my-oidc-role"
+    aws_token  = identity_token.aws.jwt
+  }
 }
 ```
 
@@ -80,13 +80,13 @@ That deployment generates a JWT token named `aws_token`, which is available to t
 # providers.tfstack.hcl
 
 provider "aws" "this" {
-    config {
-        region = var.region
-        assume_role_with_web_identity {
-            role_arn           = var.aws_role
-            web_identity_token = var.aws_token
-        }
+  config {
+    region = var.aws_region
+    assume_role_with_web_identity {
+      role_arn           = var.aws_role
+      web_identity_token = var.aws_token
     }
+  }
 }
 ```
 
@@ -100,11 +100,11 @@ The `orchestrate` block lets you codify your stack’s behavior by creating orch
 # deployments.tfdeploy.hcl
 
 orchestrate "auto_approve" "no_pet_changes" {
-    check {
-        # Check that the pet component has no changes
-        condition = context.plan.component_changes["component.pet"].total == 0
-        reason = "Changes proposed to pet component."
-    }
+  check {
+    # Check that the pet component has no changes
+    condition = context.plan.component_changes["component.pet"].total == 0
+    reason    = "Changes proposed to pet component."
+  }
 }
 ```
 

--- a/website/docs/language/stacks/reference/tfdeploy.mdx
+++ b/website/docs/language/stacks/reference/tfdeploy.mdx
@@ -200,9 +200,9 @@ identity_token "aws" {
 
 deployment "staging" {
   inputs = {
-    aws_region     = "eu-west-1"
-    role_arn       = "arn:aws:iam::123456789101:role/my-oidc-role"
-    aws_token = identity_token.aws.jwt
+    aws_region = "eu-west-1"
+    role_arn   = "arn:aws:iam::123456789101:role/my-oidc-role"
+    aws_token  = identity_token.aws.jwt
   }
 }
 ```
@@ -227,7 +227,7 @@ variable "aws_role" {
 
 provider "aws" "this" {
   config {
-    region = var.region
+    region = var.aws_region
     assume_role_with_web_identity {
       role_arn           = var.aws_role
       web_identity_token = var.aws_token
@@ -289,8 +289,8 @@ store "varset" "available_regions" {
 
 deployment "main" {
   inputs = {
-    regions = store.varset.available_regions.regions
-    tfe_token        = store.varset.tokens.tfe_token
+    regions   = store.varset.available_regions.regions
+    tfe_token = store.varset.tokens.tfe_token
   }
 }
 ```
@@ -303,14 +303,14 @@ For example, if you have an HCP Terraform [variable set](/terraform/cloud-docs/w
 
 ```hcl
 store "varset" "tokens" {
-    id       = "<variable_set_id>"
-    category = "terraform"
+  id       = "<variable_set_id>"
+  category = "terraform"
 }
 
 deployment "main" {
-    inputs = {
-        token = store.varset.tokens.example_token
-    }
+  inputs = {
+    token = store.varset.tokens.example_token
+  }
 }
 ```
 
@@ -324,7 +324,7 @@ A local value assigns a name to an expression, so you can use the name multiple 
 
 The `publish_output` block requires at least Terraform version `terraform_1.10.0-alpha20241009` or higher. Download [latest version of Terraform](https://releases.hashicorp.com/terraform/) to use the most up-to-date functionality.
 
-The `publish_output` block specifies a value to export from your current Stack, which other Stacks in the same project can consume. Declare one `publish_output` block for each value to export your Stack.
+The `publish_output` block specifies a value to export from your current Stack, which other Stacks in the same project can consume. Declare one `publish_output` block for each value to export from your Stack.
 
 ### Complete configuration
 
@@ -347,8 +347,8 @@ This section provides details about the fields you can configure in the output b
 
 | Field | Description | Type | Required |
 | :---- | :---- | :---- | :---- |
-| `value` | The value to output.  | any | Required |
 | `description` | A human-friendly description for the output. | string | Optional |
+| `value` | The value to output.  | any | Required |
 
 ### Reference
 


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

* Updated `auto_approve` example which referenced a plan condition check, but had `no component changes` details.
* Ran tfstacks fmt on config examples.
* Updated the providers variable to reference the var name defined.
* `development`  to `deployment` in a location.

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.11.x

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
