### PR TITLE
Make backend maintainers co-owners of their docs pages

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -28,18 +28,24 @@ builtin/provisioners/file               @hashicorp/terraform-core
 builtin/provisioners/local-exec         @hashicorp/terraform-core
 builtin/provisioners/remote-exec        @hashicorp/terraform-core
 
-# engineering and web presence get notified of, and can approve changes to web tooling, but not content at on developer.hashicorp.com/terraform/docs
+# engineering and web presence get notified of, and can approve changes to web tooling, but not content at developer.hashicorp.com/terraform/docs
 
 /website/               @hashicorp/web-presence @hashicorp/terraform-core
 /website/data/
 /website/public/
 /website/content/
 
-# education and engineering get notified of, and can approve changes to web content at on developer.hashicorp.com/terraform/docs
+# education and engineering get notified of, and can approve changes to web content at developer.hashicorp.com/terraform/docs
 
 /website/data/          @hashicorp/terraform-education @hashicorp/terraform-core
 /website/docs/          @hashicorp/terraform-education @hashicorp/terraform-core
-/website/img/          @hashicorp/terraform-education @hashicorp/terraform-core
-/website/README.md          @hashicorp/terraform-education @hashicorp/terraform-core
+/website/img/           @hashicorp/terraform-education @hashicorp/terraform-core
+/website/README.md      @hashicorp/terraform-education @hashicorp/terraform-core
 /website/public/        @hashicorp/terraform-education @hashicorp/terraform-core
 /website/content/       @hashicorp/terraform-education @hashicorp/terraform-core
+
+# Backend maintainers also get co-ownership of their backend docs pages
+/website/docs/language/backend/azurerm.mdx         @hashicorp/terraform-education @hashicorp/terraform-core @hashicorp/terraform-azure
+/website/docs/language/backend/gcs.mdx             @hashicorp/terraform-education @hashicorp/terraform-core @hashicorp/tf-eco-hybrid-cloud
+/website/docs/language/backend/kubernetes.mdx      @hashicorp/terraform-education @hashicorp/terraform-core @hashicorp/tf-eco-hybrid-cloud
+/website/docs/language/backend/s3.mdx              @hashicorp/terraform-education @hashicorp/terraform-core @hashicorp/terraform-aws


### PR DESCRIPTION
Inspired by #36458, that PR made me realize that we currently have a situation where a PR that updates a state backend and its corresponding docs page, it would require an approved review from someone other than the backend maintainer team because the docs pages are currently co-owned only by the Terraform Core team and Education. It seems appropriate to me to make the backend maintainer teams co-owners as well, so that they have the ability to merge these PRs independently.

## Target Release

n/a

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
