### PR TITLE
changes: Fix escaping in changelog entry

### DIFF
--- a/.changes/unreleased/ENHANCEMENTS-20250206-162053.yaml
+++ b/.changes/unreleased/ENHANCEMENTS-20250206-162053.yaml
@@ -1,5 +1,0 @@
-kind: ENHANCEMENTS
-body: Terraform Test: Continue subsequent test execution when an expected failure is not encountered.
-time: 2025-02-06T16:20:53.83763+01:00
-custom:
-    Issue: "34969"

--- a/.changes/unreleased/ENHANCEMENTS-20250206-34969.yaml
+++ b/.changes/unreleased/ENHANCEMENTS-20250206-34969.yaml
@@ -1,0 +1,5 @@
+kind: ENHANCEMENTS
+body: 'Terraform Test: Continue subsequent test execution when an expected failure is not encountered.'
+time: 2025-02-06T16:20:53.83763+01:00
+custom:
+    Issue: "34969"


### PR DESCRIPTION
This prevents a problem we came across in the last alpha release:

```
Error: unmarshaling change file '.changes/unreleased/ENHANCEMENTS-20250206-162053.yaml': yaml: line 2: mapping values are not allowed in this context
```

As far as I can tell, `changie new` does actually do the escaping, which implies the file was not generated by changie or some version of it that didn't do the escaping? 🤔 

I will also propose some updates to our release automation to try to highlight this problem earlier.

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.11.x

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
