### PR TITLE
github/changelog: Dry-run `changie merge` & mention `changie new`

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -161,3 +161,8 @@ jobs:
 
             // Nothing to complain about, so delete any existing comment
             await createOrUpdateChangelogComment("", true);
+      - name: Validate changie fragment is valid
+        uses: miniscruff/changie-action@6dcc2533cac0495148ed4046c438487e4dceaa23 # v2.0.0
+        with:
+          version: latest
+          args: merge --dry-run

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -137,6 +137,8 @@ jobs:
                 return;
             }
             
+            const changieInstruction = 'You can use [`changie new`](https://changie.dev/cli/changie_new/) (without flags) to generate it. ';
+            
             if (backportLabel) {
                 if (unreleasedChangesPresent) {
                     await createOrUpdateChangelogComment("Please move the changelog entry from `./.changes/unreleased` to `./.changes/backported` for this change. If you believe this change does not need a changelog entry, please add the 'no-changelog-needed' label.");
@@ -144,7 +146,7 @@ jobs:
                 }
                 
                 if (!backportedChangesPresent) {
-                    await createOrUpdateChangelogComment("Please add a changelog entry to `./.changes/backported` for this change. If you believe this change does not need a changelog entry, please add the 'no-changelog-needed' label.");
+                    await createOrUpdateChangelogComment("Please add a changelog entry to `./.changes/backported` for this change. "+ changieInstruction +"If you believe this change does not need a changelog entry, please add the 'no-changelog-needed' label.");
                     return;
                 }
             } else {
@@ -154,7 +156,7 @@ jobs:
                 }
 
                 if (!unreleasedChangesPresent) {
-                    await createOrUpdateChangelogComment("Please add a changelog entry to `./.changes/unreleased` for this change. If you believe this change does not need a changelog entry, please add the 'no-changelog-needed' label.");
+                    await createOrUpdateChangelogComment("Please add a changelog entry to `./.changes/unreleased` for this change. "+ changieInstruction +"If you believe this change does not need a changelog entry, please add the 'no-changelog-needed' label.");
                     return;
                 }
             }


### PR DESCRIPTION
This is to prevent issues such as https://github.com/hashicorp/terraform/pull/36496 or rather surface them as part of the PR before they reach a point of release.

I also think that changie installation in CI should be handled by the official GHA and updated on demand but that's a separate concern for another PR.

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.11.x

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
