### PR TITLE
fix: ensure changie config is available for dry-run

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -163,6 +163,8 @@ jobs:
 
             // Nothing to complain about, so delete any existing comment
             await createOrUpdateChangelogComment("", true);
+      - name: Checkout changie config
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Validate changie fragment is valid
         uses: miniscruff/changie-action@6dcc2533cac0495148ed4046c438487e4dceaa23 # v2.0.0
         with:

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -165,6 +165,8 @@ jobs:
             await createOrUpdateChangelogComment("", true);
       - name: Checkout changie config
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: github.head_ref
       - name: Validate changie fragment is valid
         uses: miniscruff/changie-action@6dcc2533cac0495148ed4046c438487e4dceaa23 # v2.0.0
         with:

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -167,6 +167,9 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: github.head_ref
+          sparse-checkout: |
+            .changie.yaml
+          sparse-checkout-cone-mode: false
       - name: Validate changie fragment is valid
         uses: miniscruff/changie-action@6dcc2533cac0495148ed4046c438487e4dceaa23 # v2.0.0
         with:


### PR DESCRIPTION
This is to address the failure shown in https://github.com/hashicorp/terraform/actions/runs/13308340454/job/37164401027

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.11.x

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
