### PR TITLE
backport/v1.11: Backend/azure: Update go-azure-sdk version to v0.20250131.1134653

### DIFF
--- a/.changes/unreleased/ENHANCEMENTS-20250207-164803.yaml
+++ b/.changes/unreleased/ENHANCEMENTS-20250207-164803.yaml
@@ -1,0 +1,5 @@
+kind: ENHANCEMENTS
+body: Azure Backend supports ADO Pipelines OIDC token refresh by using the `oidc_request_url`, `oidc_request_token` and (the new) `ado_pipeline_service_connection_id`.
+time: 2025-02-07T16:48:03.902464157+11:00
+custom:
+    Issue: "36458"

--- a/go.mod
+++ b/go.mod
@@ -179,8 +179,8 @@ require (
 	github.com/hashicorp/consul/api v1.13.0 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-azure-helpers v0.71.0 // indirect
-	github.com/hashicorp/go-azure-sdk/resource-manager v0.20241212.1154051 // indirect
-	github.com/hashicorp/go-azure-sdk/sdk v0.20241212.1154051 // indirect
+	github.com/hashicorp/go-azure-sdk/resource-manager v0.20250131.1134653 // indirect
+	github.com/hashicorp/go-azure-sdk/sdk v0.20250131.1134653 // indirect
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320 // indirect
 	github.com/hashicorp/go-immutable-radix v1.0.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -616,10 +616,10 @@ github.com/hashicorp/errwrap v1.1.0 h1:OxrOeh75EUXMY8TBjag2fzXGZ40LB6IKw45YeGUDY
 github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-azure-helpers v0.71.0 h1:ra3aIRzg01g6MLKQ+yABcb6WJtrqRUDDgyuPLmyZ9lY=
 github.com/hashicorp/go-azure-helpers v0.71.0/go.mod h1:BmbF4JDYXK5sEmFeU5hcn8Br21uElcqLfdQxjatwQKw=
-github.com/hashicorp/go-azure-sdk/resource-manager v0.20241212.1154051 h1:jFgd3bzeRViGTzicIn9gDw2O/Gk6WjVJCTTefPNOGPY=
-github.com/hashicorp/go-azure-sdk/resource-manager v0.20241212.1154051/go.mod h1:XapOZ9HiCtXz3qb5yNFiCuWbOBj2I3WU1K2jwqgK2zA=
-github.com/hashicorp/go-azure-sdk/sdk v0.20241212.1154051 h1:4fCKJPSeLVvwl7ZCqU7MOUKyx/M7kl/J6wlw2O3xn40=
-github.com/hashicorp/go-azure-sdk/sdk v0.20241212.1154051/go.mod h1:oI5R0fTbBx3K/sJBK5R/OlEy8ozdQjvctxVU9v3EDkc=
+github.com/hashicorp/go-azure-sdk/resource-manager v0.20250131.1134653 h1:KuDCZKWoOByX5MUyFRNWLl4Gy6wpZCwJ7Ez1mbUwouo=
+github.com/hashicorp/go-azure-sdk/resource-manager v0.20250131.1134653/go.mod h1:AawbnS/Kkp/IURMJVzmvD+Co2zK91lKFqYYDbenCpGU=
+github.com/hashicorp/go-azure-sdk/sdk v0.20250131.1134653 h1:Bd+glHUD1mdal1zn0NgoS4wDFhUB8Qfw61j0nZEnC5A=
+github.com/hashicorp/go-azure-sdk/sdk v0.20250131.1134653/go.mod h1:oI5R0fTbBx3K/sJBK5R/OlEy8ozdQjvctxVU9v3EDkc=
 github.com/hashicorp/go-checkpoint v0.5.0 h1:MFYpPZCnQqQTE18jFwSII6eUQrD/oxMFp3mlgcqk5mU=
 github.com/hashicorp/go-checkpoint v0.5.0/go.mod h1:7nfLNL10NsxqO4iWuW6tWW0HjZuDrwkBuEQsVcpCOgg=
 github.com/hashicorp/go-cleanhttp v0.5.0/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=

--- a/internal/backend/remote-state/azure/backend.go
+++ b/internal/backend/remote-state/azure/backend.go
@@ -156,17 +156,24 @@ func New() backend.Backend {
 				Description: "Allow OpenID Connect to be used for authentication",
 			},
 
+			"ado_pipeline_service_connection_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				DefaultFunc: schema.MultiEnvDefaultFunc([]string{"ARM_ADO_PIPELINE_SERVICE_CONNECTION_ID", "ARM_OIDC_AZURE_SERVICE_CONNECTION_ID"}, nil),
+				Description: "The Azure DevOps Pipeline Service Connection ID.",
+			},
+
 			"oidc_request_token": {
 				Type:        schema.TypeString,
 				Optional:    true,
-				DefaultFunc: schema.MultiEnvDefaultFunc([]string{"ARM_OIDC_REQUEST_TOKEN", "ACTIONS_ID_TOKEN_REQUEST_TOKEN"}, ""),
+				DefaultFunc: schema.MultiEnvDefaultFunc([]string{"ARM_OIDC_REQUEST_TOKEN", "ACTIONS_ID_TOKEN_REQUEST_TOKEN", "SYSTEM_ACCESSTOKEN"}, nil),
 				Description: "The bearer token for the request to the OIDC provider. For use when authenticating as a Service Principal using OpenID Connect.",
 			},
 
 			"oidc_request_url": {
 				Type:        schema.TypeString,
 				Optional:    true,
-				DefaultFunc: schema.MultiEnvDefaultFunc([]string{"ARM_OIDC_REQUEST_URL", "ACTIONS_ID_TOKEN_REQUEST_URL"}, ""),
+				DefaultFunc: schema.MultiEnvDefaultFunc([]string{"ARM_OIDC_REQUEST_URL", "ACTIONS_ID_TOKEN_REQUEST_URL", "SYSTEM_OIDCREQUESTURI"}, nil),
 				Description: "The URL for the OIDC provider from which to request an ID token. For use when authenticating as a Service Principal using OpenID Connect.",
 			},
 
@@ -329,9 +336,10 @@ func (b *Backend) configure(ctx context.Context) error {
 		ClientCertificatePassword: data.Get("client_certificate_password").(string),
 		ClientSecret:              *clientSecret,
 
-		OIDCAssertionToken:          *oidcToken,
-		GitHubOIDCTokenRequestURL:   data.Get("oidc_request_url").(string),
-		GitHubOIDCTokenRequestToken: data.Get("oidc_request_token").(string),
+		OIDCAssertionToken:             *oidcToken,
+		OIDCTokenRequestURL:            data.Get("oidc_request_url").(string),
+		OIDCTokenRequestToken:          data.Get("oidc_request_token").(string),
+		ADOPipelineServiceConnectionID: data.Get("ado_pipeline_service_connection_id").(string),
 
 		CustomManagedIdentityEndpoint: data.Get("msi_endpoint").(string),
 
@@ -341,6 +349,7 @@ func (b *Backend) configure(ctx context.Context) error {
 		EnableAuthenticatingUsingManagedIdentity:   enableManagedIdentity,
 		EnableAuthenticationUsingOIDC:              enableOidc,
 		EnableAuthenticationUsingGitHubOIDC:        enableOidc,
+		EnableAuthenticationUsingADOPipelineOIDC:   enableOidc,
 	}
 
 	backendConfig := BackendConfig{

--- a/internal/backend/remote-state/azure/client_test.go
+++ b/internal/backend/remote-state/azure/client_test.go
@@ -29,7 +29,7 @@ func TestRemoteClientAccessKeyBasic(t *testing.T) {
 	}
 	defer m.destroyTestResources(ctx)
 
-	clearEnv()
+	clearARMEnv()
 	b := backend.TestBackendConfig(t, New(), backend.TestWrapConfig(map[string]interface{}{
 		"storage_account_name": m.names.storageAccountName,
 		"container_name":       m.names.storageContainerName,
@@ -61,7 +61,7 @@ func TestRemoteClientManagedServiceIdentityBasic(t *testing.T) {
 	}
 	defer m.destroyTestResources(ctx)
 
-	clearEnv()
+	clearARMEnv()
 	b := backend.TestBackendConfig(t, New(), backend.TestWrapConfig(map[string]interface{}{
 		"subscription_id":      m.subscriptionId,
 		"resource_group_name":  m.names.resourceGroup,
@@ -101,7 +101,7 @@ func TestRemoteClientSasTokenBasic(t *testing.T) {
 		t.Fatalf("Error building SAS Token: %+v", err)
 	}
 
-	clearEnv()
+	clearARMEnv()
 	b := backend.TestBackendConfig(t, New(), backend.TestWrapConfig(map[string]interface{}{
 		"storage_account_name": m.names.storageAccountName,
 		"container_name":       m.names.storageContainerName,
@@ -133,7 +133,7 @@ func TestRemoteClientServicePrincipalBasic(t *testing.T) {
 	}
 	defer m.destroyTestResources(ctx)
 
-	clearEnv()
+	clearARMEnv()
 	b := backend.TestBackendConfig(t, New(), backend.TestWrapConfig(map[string]interface{}{
 		"subscription_id":      m.subscriptionId,
 		"resource_group_name":  m.names.resourceGroup,
@@ -169,7 +169,7 @@ func TestRemoteClientAccessKeyLocks(t *testing.T) {
 	}
 	defer m.destroyTestResources(ctx)
 
-	clearEnv()
+	clearARMEnv()
 
 	b1 := backend.TestBackendConfig(t, New(), backend.TestWrapConfig(map[string]interface{}{
 		"storage_account_name": m.names.storageAccountName,
@@ -215,7 +215,7 @@ func TestRemoteClientServicePrincipalLocks(t *testing.T) {
 	}
 	defer m.destroyTestResources(ctx)
 
-	clearEnv()
+	clearARMEnv()
 
 	b1 := backend.TestBackendConfig(t, New(), backend.TestWrapConfig(map[string]interface{}{
 		"subscription_id":      m.subscriptionId,

--- a/internal/backend/remote-state/azure/go.mod
+++ b/internal/backend/remote-state/azure/go.mod
@@ -4,8 +4,8 @@ go 1.23.3
 
 require (
 	github.com/hashicorp/go-azure-helpers v0.71.0
-	github.com/hashicorp/go-azure-sdk/resource-manager v0.20241212.1154051
-	github.com/hashicorp/go-azure-sdk/sdk v0.20241212.1154051
+	github.com/hashicorp/go-azure-sdk/resource-manager v0.20250131.1134653
+	github.com/hashicorp/go-azure-sdk/sdk v0.20250131.1134653
 	github.com/hashicorp/go-uuid v1.0.3
 	github.com/hashicorp/terraform v0.0.0-00010101000000-000000000000
 	github.com/hashicorp/terraform/internal/legacy v0.0.0-00010101000000-000000000000

--- a/internal/backend/remote-state/azure/go.sum
+++ b/internal/backend/remote-state/azure/go.sum
@@ -180,10 +180,10 @@ github.com/hashicorp/errwrap v1.1.0 h1:OxrOeh75EUXMY8TBjag2fzXGZ40LB6IKw45YeGUDY
 github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-azure-helpers v0.71.0 h1:ra3aIRzg01g6MLKQ+yABcb6WJtrqRUDDgyuPLmyZ9lY=
 github.com/hashicorp/go-azure-helpers v0.71.0/go.mod h1:BmbF4JDYXK5sEmFeU5hcn8Br21uElcqLfdQxjatwQKw=
-github.com/hashicorp/go-azure-sdk/resource-manager v0.20241212.1154051 h1:jFgd3bzeRViGTzicIn9gDw2O/Gk6WjVJCTTefPNOGPY=
-github.com/hashicorp/go-azure-sdk/resource-manager v0.20241212.1154051/go.mod h1:XapOZ9HiCtXz3qb5yNFiCuWbOBj2I3WU1K2jwqgK2zA=
-github.com/hashicorp/go-azure-sdk/sdk v0.20241212.1154051 h1:4fCKJPSeLVvwl7ZCqU7MOUKyx/M7kl/J6wlw2O3xn40=
-github.com/hashicorp/go-azure-sdk/sdk v0.20241212.1154051/go.mod h1:oI5R0fTbBx3K/sJBK5R/OlEy8ozdQjvctxVU9v3EDkc=
+github.com/hashicorp/go-azure-sdk/resource-manager v0.20250131.1134653 h1:KuDCZKWoOByX5MUyFRNWLl4Gy6wpZCwJ7Ez1mbUwouo=
+github.com/hashicorp/go-azure-sdk/resource-manager v0.20250131.1134653/go.mod h1:AawbnS/Kkp/IURMJVzmvD+Co2zK91lKFqYYDbenCpGU=
+github.com/hashicorp/go-azure-sdk/sdk v0.20250131.1134653 h1:Bd+glHUD1mdal1zn0NgoS4wDFhUB8Qfw61j0nZEnC5A=
+github.com/hashicorp/go-azure-sdk/sdk v0.20250131.1134653/go.mod h1:oI5R0fTbBx3K/sJBK5R/OlEy8ozdQjvctxVU9v3EDkc=
 github.com/hashicorp/go-cleanhttp v0.5.2 h1:035FKYIWjmULyFRBKPs8TBQoi0x6d9G4xc9neXJWAZQ=
 github.com/hashicorp/go-cleanhttp v0.5.2/go.mod h1:kO/YDlP8L1346E6Sodw+PrpBSV4/SoxCXGY6BqNFT48=
 github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320 h1:1/D3zfFHttUKaCaGKZ/dR2roBXv0vKbSCnssIldfQdI=

--- a/internal/backend/remote-state/azure/helpers_test.go
+++ b/internal/backend/remote-state/azure/helpers_test.go
@@ -56,7 +56,16 @@ func testAccAzureBackendRunningInGitHubActions(t *testing.T) {
 	}
 }
 
-// clearEnv cleans up the azure related environment variables.
+// these kind of tests can only run when within ADO Pipelines (e.g. OIDC)
+func testAccAzureBackendRunningInADOPipelines(t *testing.T) {
+	testAccAzureBackend(t)
+
+	if os.Getenv("TF_RUNNING_IN_ADO_PIPELINES") == "" {
+		t.Skip("Skipping test since not running in ADO Pipelines")
+	}
+}
+
+// clearARMEnv cleans up the azure related environment variables.
 // This is to ensure the configuration only comes from HCL, which avoids
 // env vars for test setup interfere the behavior.
 //
@@ -65,7 +74,7 @@ func testAccAzureBackendRunningInGitHubActions(t *testing.T) {
 // impact can be eliminated given all the tests are implemented in a similar
 // pattern that those env vars will be consumed at the very begining. The test
 // runner has to ensure to set a **big enough parallelism**.
-func clearEnv() {
+func clearARMEnv() {
 	for _, evexp := range os.Environ() {
 		k, _, ok := strings.Cut(evexp, "=")
 		if !ok {
@@ -178,19 +187,21 @@ func BuildTestMeta(t *testing.T, ctx context.Context) *TestMeta {
 	// - MSI: For MSI related tests
 	// - OIDC: For OIDC related tests
 	authConfig := &auth.Credentials{
-		Environment:                 *env,
-		TenantID:                    tenantID,
-		ClientID:                    clientID,
-		ClientSecret:                clientSecret,
-		ClientCertificatePath:       os.Getenv("ARM_CLIENT_CERTIFICATE_PATH"),
-		ClientCertificatePassword:   os.Getenv("ARM_CLIENT_CERTIFICATE_PASSWORD"),
-		GitHubOIDCTokenRequestURL:   os.Getenv("ACTIONS_ID_TOKEN_REQUEST_URL"),
-		GitHubOIDCTokenRequestToken: os.Getenv("ACTIONS_ID_TOKEN_REQUEST_TOKEN"),
+		Environment:                    *env,
+		TenantID:                       tenantID,
+		ClientID:                       clientID,
+		ClientSecret:                   clientSecret,
+		ClientCertificatePath:          os.Getenv("ARM_CLIENT_CERTIFICATE_PATH"),
+		ClientCertificatePassword:      os.Getenv("ARM_CLIENT_CERTIFICATE_PASSWORD"),
+		OIDCTokenRequestURL:            getEnvvars("ACTIONS_ID_TOKEN_REQUEST_URL", "SYSTEM_OIDCREQUESTURI"),
+		OIDCTokenRequestToken:          getEnvvars("ACTIONS_ID_TOKEN_REQUEST_TOKEN", "SYSTEM_ACCESSTOKEN"),
+		ADOPipelineServiceConnectionID: os.Getenv("ARM_ADO_PIPELINE_SERVICE_CONNECTION_ID"),
 
 		EnableAuthenticatingUsingClientSecret:      true,
 		EnableAuthenticatingUsingClientCertificate: true,
 		EnableAuthenticatingUsingManagedIdentity:   true,
 		EnableAuthenticationUsingGitHubOIDC:        true,
+		EnableAuthenticationUsingADOPipelineOIDC:   true,
 	}
 
 	resourceManagerAuth, err := auth.NewAuthorizerFromCredentials(ctx, *authConfig, env.ResourceManager)
@@ -324,4 +335,14 @@ func randString(strlen int) string {
 		result[i] = charSet[rand.Intn(len(charSet))]
 	}
 	return string(result)
+}
+
+// getEnvvars return the first non-empty env var specified. If none is found, it returns empty string.
+func getEnvvars(envvars ...string) string {
+	for _, envvar := range envvars {
+		if v := os.Getenv(envvar); v != "" {
+			return v
+		}
+	}
+	return ""
 }

--- a/website/docs/language/backend/azurerm.mdx
+++ b/website/docs/language/backend/azurerm.mdx
@@ -540,9 +540,11 @@ When authenticating using a Managed Identity (MSI) - the following fields are al
 
 When authenticating using a Service Principal with OpenID Connect (OIDC / Workload Identity Federation) - the following fields are also supported:
 
-* `oidc_request_url` - (Optional) The URL for the OIDC provider from which to request an ID token. This can also be sourced from the `ARM_OIDC_REQUEST_URL` or `ACTIONS_ID_TOKEN_REQUEST_URL` environment variables.
+* `ado_pipeline_service_connection_id` - (Optional) The Azure DevOps Pipeline Service Connection ID. This can also be sourced from the `ARM_ADO_PIPELINE_SERVICE_CONNECTION_ID` or `ARM_OIDC_AZURE_SERVICE_CONNECTION_ID` Environment Variables. The provider will look for values in this order and use the first it finds configured.
 
-* `oidc_request_token` - (Optional) The bearer token for the request to the OIDC provider. This can also be sourced from the `ARM_OIDC_REQUEST_TOKEN` or `ACTIONS_ID_TOKEN_REQUEST_TOKEN` environment variables.
+* `oidc_request_url` - (Optional) The URL for the OIDC provider from which to request an ID token. This can also be sourced from the `ARM_OIDC_REQUEST_URL`, `ACTIONS_ID_TOKEN_REQUEST_URL` or `SYSTEM_OIDCREQUESTURI` Environment Variables. The provider will look for values in this order and use the first it finds configured.
+
+* `oidc_request_token` - (Optional) The bearer token for the request to the OIDC provider. This can also be sourced from the `ARM_OIDC_REQUEST_TOKEN`, `ACTIONS_ID_TOKEN_REQUEST_TOKEN` or `SYSTEM_ACCESSTOKEN` Environment Variables. The provider will look for values in this order and use the first it finds configured.
 
 * `oidc_token` - (Optional) The ID token when authenticating using OpenID Connect (OIDC). This can also be sourced from the `ARM_OIDC_TOKEN` environment variable.
 


### PR DESCRIPTION
This is a manual backport of https://github.com/hashicorp/terraform/pull/36458 since the automated backporting [has failed](https://github.com/hashicorp/terraform/actions/runs/13327264942/job/37223191321) - probably because the branch in the forked repo has since been deleted.

---

> :warning: **DO NOT MERGE** until `v1.11.0`

---

## Target Release


1.11.x

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [ ] This change is not user-facing.
