### PR TITLE
github: fix ref variable in configuration

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -166,7 +166,7 @@ jobs:
       - name: Checkout changie config
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          ref: github.head_ref
+          ref: ${{ github.head_ref }}
           sparse-checkout: |
             .changie.yaml
           sparse-checkout-cone-mode: false


### PR DESCRIPTION
This is an attempt to fix failure reported in https://github.com/hashicorp/terraform/actions/runs/13333888743/job/37244515892?pr=36496#step:4:56

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.11.x

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
