### PR TITLE
github: Ensure changie merge actually fails

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -174,4 +174,4 @@ jobs:
         uses: miniscruff/changie-action@6dcc2533cac0495148ed4046c438487e4dceaa23 # v2.0.0
         with:
           version: latest
-          args: merge --dry-run
+          args: merge -u "." --dry-run


### PR DESCRIPTION
For some reason the merging doesn't actually seem to do anything - or at least does not trigger the failure unless we also attempt to update the changelog via `-u`. It looks like a changie bug to me but this is a simple enough work around.

Hopefully this is the last commit to make the check finally work 🙈 

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.11.x

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
