### PR TITLE
github: Ensure the `.changes` dir is included for checking

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -169,6 +169,7 @@ jobs:
           ref: ${{ github.head_ref }}
           sparse-checkout: |
             .changie.yaml
+            .changes/
           sparse-checkout-cone-mode: false
       - name: Validate changie fragment is valid
         uses: miniscruff/changie-action@6dcc2533cac0495148ed4046c438487e4dceaa23 # v2.0.0


### PR DESCRIPTION
This is how I feel about GitHub Actions and the PR based debugging experience by now:

![frustrated](https://github.com/user-attachments/assets/77136006-0347-46b2-8067-559f3fb94ff3)

Worth noting I did test this inside our private fork, so 🤞🏻 there should be no more PRs needed.

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.11.x

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
