### PR TITLE
Update pull_request_template.md to default to 1.12.x

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -31,7 +31,7 @@ label to enable the backport bot.
 
 -->
 
-1.11.x
+1.12.x
 
 ## CHANGELOG entry
 


### PR DESCRIPTION
Given that we've released release candidates for 1.11 and made an alpha release for 1.12 I figured that updating this template to default to 1.12 makes sense.

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

N/A

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
