### PR TITLE
No state to cleaup when it is empty

### DIFF
--- a/internal/command/test_test.go
+++ b/internal/command/test_test.go
@@ -127,6 +127,12 @@ func TestTest_Runs(t *testing.T) {
 			expectedOut: []string{"1 passed, 0 failed"},
 			code:        0,
 		},
+		"no_state": {
+			expectedOut: []string{"0 passed, 1 failed"},
+			expectedErr: []string{"No value for required variable"},
+			description: "the run apply fails, causing it to produce a nil state.",
+			code:        1,
+		},
 		"variables": {
 			expectedOut: []string{"2 passed, 0 failed"},
 			code:        0,
@@ -664,9 +670,6 @@ func TestTest_Parallel(t *testing.T) {
 	// Find the positions of "test_d", "test_c", "test_setup" in the log output
 	var testDIndex, testCIndex, testSetupIndex int
 	for i, line := range lines {
-		// if strings.Contains(line, "run \"") {
-		// 	fmt.Println(line)
-		// }
 		if strings.Contains(line, "run \"setup\"") {
 			testSetupIndex = i
 		} else if strings.Contains(line, "run \"test_d\"") {

--- a/internal/command/testdata/test/no_state/main.tf
+++ b/internal/command/testdata/test/no_state/main.tf
@@ -1,0 +1,14 @@
+
+variable "input" {
+  type = number
+}
+
+variable "input2" {
+  type = number
+  ephemeral = true
+  default = 0
+}
+
+output "output" {
+  value = var.input > 5 ? var.input : null
+}

--- a/internal/command/testdata/test/no_state/main.tftest.hcl
+++ b/internal/command/testdata/test/no_state/main.tftest.hcl
@@ -1,0 +1,13 @@
+
+run "first" {
+  variables {
+    input = 2
+  }
+
+// var.input2 is ephemeral, and this would cause it to not be set during the plan phase,
+// but will be set to default during the apply phase. This leads to the apply update being null
+  assert {
+    condition = output.output == var.input2
+    error_message = "output should have been null"
+  }
+}

--- a/internal/moduletest/graph/node_state_cleanup.go
+++ b/internal/moduletest/graph/node_state_cleanup.go
@@ -44,11 +44,13 @@ func (n *NodeStateCleanup) Execute(evalCtx *EvalContext) tfdiags.Diagnostics {
 	}
 
 	empty := true
-	for _, module := range state.State.Modules {
-		for _, resource := range module.Resources {
-			if resource.Addr.Resource.Mode == addrs.ManagedResourceMode {
-				empty = false
-				break
+	if !state.State.Empty() {
+		for _, module := range state.State.Modules {
+			for _, resource := range module.Resources {
+				if resource.Addr.Resource.Mode == addrs.ManagedResourceMode {
+					empty = false
+					break
+				}
 			}
 		}
 	}


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

If the state is empty, it may be nil, and we need to check that before cleanup

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.11.0

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
