### PR TITLE
`WriteOnlyPaths` cannot traverse null values

### DIFF
--- a/internal/configs/configschema/marks.go
+++ b/internal/configs/configschema/marks.go
@@ -19,17 +19,16 @@ import (
 func (b *Block) SensitivePaths(val cty.Value, basePath cty.Path) []cty.Path {
 	var ret []cty.Path
 
-	// We can mark attributes as sensitive even if the value is null
+	// A block as a whole cannot be sensitive, so nothing to return
+	if val.IsNull() || !val.IsKnown() {
+		return ret
+	}
+
 	for name, attrS := range b.Attributes {
 		if attrS.Sensitive {
 			attrPath := slices.Concat(basePath, cty.GetAttrPath(name))
 			ret = append(ret, attrPath)
 		}
-	}
-
-	// If the value is null, no other marks are possible
-	if val.IsNull() {
-		return ret
 	}
 
 	// Extract paths for marks from nested attribute type values

--- a/internal/configs/configschema/marks_test.go
+++ b/internal/configs/configschema/marks_test.go
@@ -35,6 +35,18 @@ func TestBlockValueMarks(t *testing.T) {
 					Nesting: NestingList,
 				},
 			},
+			"nested_sensitive": {
+				NestedType: &Object{
+					Attributes: map[string]*Attribute{
+						"boop": {
+							Type: cty.String,
+						},
+					},
+					Nesting: NestingList,
+				},
+				Sensitive: true,
+				Optional:  true,
+			},
 		},
 
 		BlockTypes: map[string]*NestedBlock{
@@ -76,6 +88,9 @@ func TestBlockValueMarks(t *testing.T) {
 					"boop": cty.String,
 					"honk": cty.String,
 				}))),
+				"nested_sensitive": cty.NullVal(cty.List(cty.Object(map[string]cty.Type{
+					"boop": cty.String,
+				}))),
 				"list": cty.UnknownVal(schema.BlockTypes["list"].ImpliedType()),
 			}),
 			cty.ObjectVal(map[string]cty.Value{
@@ -85,6 +100,9 @@ func TestBlockValueMarks(t *testing.T) {
 					"boop": cty.String,
 					"honk": cty.String,
 				}))),
+				"nested_sensitive": cty.NullVal(cty.List(cty.Object(map[string]cty.Type{
+					"boop": cty.String,
+				}))).Mark(marks.Sensitive),
 				"list": cty.UnknownVal(schema.BlockTypes["list"].ImpliedType()),
 			}),
 		},
@@ -93,6 +111,10 @@ func TestBlockValueMarks(t *testing.T) {
 				"sensitive":   cty.NullVal(cty.String),
 				"unsensitive": cty.UnknownVal(cty.String),
 				"nested": cty.NullVal(cty.List(cty.Object(map[string]cty.Type{
+					"boop": cty.String,
+					"honk": cty.String,
+				}))),
+				"nested_sensitive": cty.NullVal(cty.List(cty.Object(map[string]cty.Type{
 					"boop": cty.String,
 					"honk": cty.String,
 				}))),
@@ -114,6 +136,9 @@ func TestBlockValueMarks(t *testing.T) {
 					"boop": cty.String,
 					"honk": cty.String,
 				}))),
+				"nested_sensitive": cty.NullVal(cty.List(cty.Object(map[string]cty.Type{
+					"boop": cty.String,
+				}))).Mark(marks.Sensitive),
 				"list": cty.ListVal([]cty.Value{
 					cty.ObjectVal(map[string]cty.Value{
 						"sensitive":   cty.UnknownVal(cty.String).Mark(marks.Sensitive),
@@ -144,6 +169,9 @@ func TestBlockValueMarks(t *testing.T) {
 						"honk": cty.UnknownVal(cty.String),
 					}),
 				}),
+				"nested_sensitive": cty.NullVal(cty.List(cty.Object(map[string]cty.Type{
+					"boop": cty.String,
+				}))),
 				"list": cty.NullVal(cty.List(cty.Object(map[string]cty.Type{
 					"sensitive":   cty.String,
 					"unsensitive": cty.String,
@@ -166,6 +194,9 @@ func TestBlockValueMarks(t *testing.T) {
 						"honk": cty.UnknownVal(cty.String).Mark(marks.Sensitive),
 					}),
 				}),
+				"nested_sensitive": cty.NullVal(cty.List(cty.Object(map[string]cty.Type{
+					"boop": cty.String,
+				}))).Mark(marks.Sensitive),
 				"list": cty.NullVal(cty.List(cty.Object(map[string]cty.Type{
 					"sensitive":   cty.String,
 					"unsensitive": cty.String,
@@ -176,10 +207,19 @@ func TestBlockValueMarks(t *testing.T) {
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			sensitivePaths := schema.SensitivePaths(tc.given, nil)
-			got := marks.MarkPaths(tc.given, marks.Sensitive, sensitivePaths)
-			if !tc.expect.RawEquals(got) {
-				t.Fatalf("\nexpected: %#v\ngot:      %#v\n", tc.expect, got)
+			given, err := schema.CoerceValue(tc.given)
+			if err != nil {
+				t.Fatal(err)
+			}
+			expect, err := schema.CoerceValue(tc.expect)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			sensitivePaths := schema.SensitivePaths(given, nil)
+			got := marks.MarkPaths(given, marks.Sensitive, sensitivePaths)
+			if !expect.RawEquals(got) {
+				t.Fatalf("\nexpected: %#v\ngot:      %#v\n", expect, got)
 			}
 		})
 	}

--- a/internal/configs/configschema/write_only.go
+++ b/internal/configs/configschema/write_only.go
@@ -19,17 +19,16 @@ import (
 func (b *Block) WriteOnlyPaths(val cty.Value, basePath cty.Path) []cty.Path {
 	var ret []cty.Path
 
-	// We can mark attributes as write-only even if the value is null
+	// the value as a whole cannot be write-only, so nothing to return
+	if val.IsNull() || !val.IsKnown() {
+		return ret
+	}
+
 	for name, attrS := range b.Attributes {
 		if attrS.WriteOnly {
 			attrPath := slices.Concat(basePath, cty.GetAttrPath(name))
 			ret = append(ret, attrPath)
 		}
-	}
-
-	// If the value is null, no other marks are possible
-	if val.IsNull() {
-		return ret
 	}
 
 	// Extract paths for marks from nested attribute type values

--- a/internal/configs/configschema/write_only.go
+++ b/internal/configs/configschema/write_only.go
@@ -19,7 +19,7 @@ import (
 func (b *Block) WriteOnlyPaths(val cty.Value, basePath cty.Path) []cty.Path {
 	var ret []cty.Path
 
-	// the value as a whole cannot be write-only, so nothing to return
+	// a block cannot be write-only, so nothing to return
 	if val.IsNull() || !val.IsKnown() {
 		return ret
 	}

--- a/internal/configs/configschema/write_only_test.go
+++ b/internal/configs/configschema/write_only_test.go
@@ -115,15 +115,11 @@ func TestBlock_WriteOnlyPaths(t *testing.T) {
 	}{
 		"unknown value": {
 			cty.UnknownVal(schema.ImpliedType()),
-			[]cty.Path{
-				{cty.GetAttrStep{Name: "wo"}},
-			},
+			[]cty.Path{},
 		},
 		"null object": {
 			cty.NullVal(schema.ImpliedType()),
-			[]cty.Path{
-				{cty.GetAttrStep{Name: "wo"}},
-			},
+			[]cty.Path{},
 		},
 		"object with unknown attributes and blocks": {
 			cty.ObjectVal(map[string]cty.Value{

--- a/internal/configs/configschema/write_only_test.go
+++ b/internal/configs/configschema/write_only_test.go
@@ -69,6 +69,19 @@ func TestBlock_WriteOnlyPaths(t *testing.T) {
 								},
 							},
 						},
+						"single_wo": {
+							Optional:  true,
+							WriteOnly: true,
+							NestedType: &Object{
+								Nesting: NestingSingle,
+								Attributes: map[string]*Attribute{
+									"not_wo": {
+										Optional: true,
+										Type:     cty.String,
+									},
+								},
+							},
+						},
 					},
 				},
 			},
@@ -202,6 +215,7 @@ func TestBlock_WriteOnlyPaths(t *testing.T) {
 			[]cty.Path{
 				{cty.GetAttrStep{Name: "wo"}},
 				{cty.GetAttrStep{Name: "single"}, cty.GetAttrStep{Name: "wo"}},
+				cty.GetAttrPath("single").GetAttr(("single_wo")),
 				{cty.GetAttrStep{Name: "single_block"}, cty.GetAttrStep{Name: "wo"}},
 			},
 		},
@@ -219,7 +233,40 @@ func TestBlock_WriteOnlyPaths(t *testing.T) {
 			[]cty.Path{
 				{cty.GetAttrStep{Name: "wo"}},
 				{cty.GetAttrStep{Name: "single"}, cty.GetAttrStep{Name: "wo"}},
+				cty.GetAttrPath("single").GetAttr(("single_wo")),
 				{cty.GetAttrStep{Name: "single"}, cty.GetAttrStep{Name: "nested_single"}, cty.GetAttrStep{Name: "wo"}},
+			},
+		},
+		"single nested write-only attr": {
+			cty.ObjectVal(map[string]cty.Value{
+				"single": cty.ObjectVal(map[string]cty.Value{
+					"single_wo": cty.ObjectVal(map[string]cty.Value{
+						"not_wo": cty.StringVal("foo").Mark("test"),
+					}),
+				}),
+			}),
+			[]cty.Path{
+				cty.GetAttrPath("wo"),
+				cty.GetAttrPath("single").GetAttr(("wo")),
+				cty.GetAttrPath("single").GetAttr(("single_wo")),
+			},
+		},
+		"single nested null write-only attr": {
+			cty.ObjectVal(map[string]cty.Value{
+				"single": cty.NullVal(cty.Object(map[string]cty.Type{
+					"not_wo": cty.String,
+					"wo":     cty.String,
+					"nested_single": cty.Object(map[string]cty.Type{
+						"not_wo": cty.String,
+						"wo":     cty.String,
+					}),
+					"single_wo": cty.Object(map[string]cty.Type{
+						"not_wo": cty.String,
+					}),
+				})),
+			}),
+			[]cty.Path{
+				{cty.GetAttrStep{Name: "wo"}},
 			},
 		},
 	}

--- a/internal/terraform/context_apply2_test.go
+++ b/internal/terraform/context_apply2_test.go
@@ -3766,3 +3766,139 @@ resource "test_object" "c" {
 	}
 	t.Fatal("failed to find destroy destroy dependency between test_object.a(destroy) and test_object.c(destroy)")
 }
+
+func TestContext2Apply_writeOnlyDestroy(t *testing.T) {
+	m := testModuleInline(t, map[string]string{
+		"main.tf": `
+resource "test_object" "x" {
+  test_string = "ok"
+  test_wo = "secret"
+}`,
+	})
+
+	p := &testing_provider.MockProvider{}
+	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
+		Provider: providers.Schema{Block: simpleTestSchema()},
+		ResourceTypes: map[string]providers.Schema{
+			"test_object": providers.Schema{
+				Block: &configschema.Block{
+					Attributes: map[string]*configschema.Attribute{
+						"test_string": {
+							Type:     cty.String,
+							Optional: true,
+						},
+						"test_wo": {
+							Type:      cty.Number,
+							Optional:  true,
+							WriteOnly: true,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	state := states.NewState()
+	root := state.EnsureModule(addrs.RootModuleInstance)
+	root.SetResourceInstanceCurrent(
+		mustResourceInstanceAddr("test_object.x").Resource,
+		&states.ResourceInstanceObjectSrc{
+			Status:    states.ObjectReady,
+			AttrsJSON: []byte(`{"test_string":"ok", "test_wo": null}`),
+		},
+		mustProviderConfig(`provider["registry.terraform.io/hashicorp/test"]`),
+	)
+
+	ctx := testContext2(t, &ContextOpts{
+		Providers: map[addrs.Provider]providers.Factory{
+			addrs.NewDefaultProvider("test"): testProviderFuncFixed(p),
+		},
+	})
+
+	plan, diags := ctx.Plan(m, state, &PlanOpts{
+		Mode: plans.DestroyMode,
+		// we don't want to refresh, because that actually runs a normal plan
+		SkipRefresh: true,
+	})
+	if diags.HasErrors() {
+		t.Fatalf("plan: %s", diags.Err())
+	}
+
+	_, diags = ctx.Apply(plan, m, nil)
+	if diags.HasErrors() {
+		t.Fatalf("apply: %s", diags.Err())
+	}
+}
+
+func TestContext2Apply_writeOnlyApplyError(t *testing.T) {
+	m := testModuleInline(t, map[string]string{
+		"main.tf": `
+resource "test_object" "x" {
+  test_string = "ok"
+  test_wo = "secret"
+}`,
+	})
+
+	p := &testing_provider.MockProvider{}
+	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
+		Provider: providers.Schema{Block: simpleTestSchema()},
+		ResourceTypes: map[string]providers.Schema{
+			"test_object": providers.Schema{
+				Block: &configschema.Block{
+					Attributes: map[string]*configschema.Attribute{
+						"test_string": {
+							Type:     cty.String,
+							Optional: true,
+						},
+						"test_wo": {
+							Type:      cty.Number,
+							Optional:  true,
+							WriteOnly: true,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	p.ApplyResourceChangeFn = func(req providers.ApplyResourceChangeRequest) (resp providers.ApplyResourceChangeResponse) {
+		resp.Diagnostics = resp.Diagnostics.Append(errors.New("provider oops"))
+		return resp
+	}
+
+	state := states.NewState()
+	root := state.EnsureModule(addrs.RootModuleInstance)
+	root.SetResourceInstanceCurrent(
+		mustResourceInstanceAddr("test_object.x").Resource,
+		&states.ResourceInstanceObjectSrc{
+			Status:    states.ObjectReady,
+			AttrsJSON: []byte(`{"test_string":"ok", "test_wo": null}`),
+		},
+		mustProviderConfig(`provider["registry.terraform.io/hashicorp/test"]`),
+	)
+
+	ctx := testContext2(t, &ContextOpts{
+		Providers: map[addrs.Provider]providers.Factory{
+			addrs.NewDefaultProvider("test"): testProviderFuncFixed(p),
+		},
+	})
+
+	plan, diags := ctx.Plan(m, state, &PlanOpts{
+		Mode: plans.DestroyMode,
+		// we don't want to refresh, because that actually runs a normal plan
+		SkipRefresh: true,
+	})
+	if diags.HasErrors() {
+		t.Fatalf("plan: %s", diags.Err())
+	}
+
+	_, diags = ctx.Apply(plan, m, nil)
+	if !diags.HasErrors() {
+		t.Fatal("expected error")
+	}
+
+	msg := diags.ErrWithWarnings().Error()
+	if len(diags) != 1 && !strings.Contains(msg, "provider oops") {
+		t.Fatalf("expected only 'provider oops', but got: %s", msg)
+	}
+}


### PR DESCRIPTION
There were 2 remaining incorrect tests for `WriteOnlyPaths` which traversed a null value (and of course, the code to make those tests pass ;) ). While we can _return_ a path to a null value, we cannot return a path which traverses a null value, because that path cannot be applied.

Fixes #36538