### PR TITLE
Add support for formatting `.tfbackend` files

### DIFF
--- a/.changes/v1.12/ENHANCEMENTS-20250224-182152.yaml
+++ b/.changes/v1.12/ENHANCEMENTS-20250224-182152.yaml
@@ -1,0 +1,5 @@
+kind: ENHANCEMENTS
+body: 'fmt: Added the ability to format .tfbackend files'
+time: 2025-02-24T18:21:52.181981Z
+custom:
+    Issue: "36570"

--- a/.changes/v1.12/ENHANCEMENTS-20250224-182152.yaml
+++ b/.changes/v1.12/ENHANCEMENTS-20250224-182152.yaml
@@ -2,4 +2,4 @@ kind: ENHANCEMENTS
 body: 'fmt: Added the ability to format .tfbackend files'
 time: 2025-02-24T18:21:52.181981Z
 custom:
-    Issue: "36570"
+    Issue: "36564"

--- a/internal/command/fmt.go
+++ b/internal/command/fmt.go
@@ -33,6 +33,7 @@ var (
 		".tfvars",
 		".tftest.hcl",
 		".tfmock.hcl",
+		".tfbackend",
 	}
 )
 

--- a/internal/command/fmt_test.go
+++ b/internal/command/fmt_test.go
@@ -16,6 +16,70 @@ import (
 	"github.com/hashicorp/cli"
 )
 
+func TestFmt_tfBackendFiles(t *testing.T) {
+	const inSuffix = "_in.tfbackend"
+	const outSuffix = "_out.tfbackend"
+	const gotSuffix = "_got.tfbackend"
+	entries, err := ioutil.ReadDir("testdata/tfbackend-fmt")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tmpDir, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, info := range entries {
+		if info.IsDir() {
+			continue
+		}
+		filename := info.Name()
+		if !strings.HasSuffix(filename, inSuffix) {
+			continue
+		}
+		testName := filename[:len(filename)-len(inSuffix)]
+		t.Run(testName, func(t *testing.T) {
+			inFile := filepath.Join("testdata", "tfbackend-fmt", testName+inSuffix)
+			wantFile := filepath.Join("testdata", "tfbackend-fmt", testName+outSuffix)
+			gotFile := filepath.Join(tmpDir, testName+gotSuffix)
+			input, err := ioutil.ReadFile(inFile)
+			if err != nil {
+				t.Fatal(err)
+			}
+			want, err := ioutil.ReadFile(wantFile)
+			if err != nil {
+				t.Fatal(err)
+			}
+			err = ioutil.WriteFile(gotFile, input, 0700)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			ui := cli.NewMockUi()
+			c := &FmtCommand{
+				Meta: Meta{
+					testingOverrides: metaOverridesForProvider(testProvider()),
+					Ui:               ui,
+				},
+			}
+			args := []string{gotFile}
+			if code := c.Run(args); code != 0 {
+				t.Fatalf("fmt command was unsuccessful:\n%s", ui.ErrorWriter.String())
+			}
+
+			got, err := ioutil.ReadFile(gotFile)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if diff := cmp.Diff(string(want), string(got)); diff != "" {
+				t.Errorf("wrong result\n%s", diff)
+			}
+		})
+	}
+}
+
 func TestFmt_MockDataFiles(t *testing.T) {
 	const inSuffix = "_in.tfmock.hcl"
 	const outSuffix = "_out.tfmock.hcl"

--- a/internal/command/testdata/tfbackend-fmt/main_in.tfbackend
+++ b/internal/command/testdata/tfbackend-fmt/main_in.tfbackend
@@ -1,0 +1,3 @@
+variable_one      =  "value-1"
+variable_two=    "value-2"
+variable_three     = "value-3"

--- a/internal/command/testdata/tfbackend-fmt/main_out.tfbackend
+++ b/internal/command/testdata/tfbackend-fmt/main_out.tfbackend
@@ -1,0 +1,3 @@
+variable_one   = "value-1"
+variable_two   = "value-2"
+variable_three = "value-3"


### PR DESCRIPTION


Fixes https://github.com/hashicorp/terraform/issues/36564

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.12.x

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [x] This change is user-facing and I added a changelog entry.
- [ ] This change is not user-facing.
