### PR TITLE
temporarily disable updated Go Windows symlink behavior

### DIFF
--- a/.changes/v1.11/BUG FIXES-20250225-083056.yaml
+++ b/.changes/v1.11/BUG FIXES-20250225-083056.yaml
@@ -1,0 +1,5 @@
+kind: BUG FIXES
+body: Temporarily revert updated Windows symlink handling until we can account for known existing configurations using non-symlink junctions.
+time: 2025-02-25T08:30:56.226882-05:00
+custom:
+    Issue: "36575"

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/hashicorp/terraform
 
 go 1.24.0
 
+godebug winsymlink=0
+
 require (
 	github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2
 	github.com/ProtonMail/go-crypto v1.0.0


### PR DESCRIPTION
EvalSymlinks and Readlink on Windows used to return incorrect information for windows junctions which were specifically not symlinks prior to go1.23. Unfortunately Terraform uses `EvalSymlinks` in situations where Windows users had come to expect their configuration to work as if it were symlinked even though it used a different filesystem structure. Set `winsymlink=0` to restore the existing behavior until we can determine the best course of action for Windows users.


Fixes #36545
Fixes #36357
