### PR TITLE
terraform test: fix crash when non-applyable plans are applied

### DIFF
--- a/.changes/v1.11/BUG FIXES-20250226-140931.yaml
+++ b/.changes/v1.11/BUG FIXES-20250226-140931.yaml
@@ -1,0 +1,5 @@
+kind: BUG FIXES
+body: '`terraform test`: Fix crash when a run block attempts to cleanup after a non-applyable plan.'
+time: 2025-02-26T14:09:31.83904+01:00
+custom:
+    Issue: "36582"

--- a/internal/backend/local/test.go
+++ b/internal/backend/local/test.go
@@ -937,11 +937,13 @@ func (runner *TestFileRunner) cleanup(file *moduletest.File) {
 	for key, state := range runner.RelevantStates {
 
 		empty := true
-		for _, module := range state.State.Modules {
-			for _, resource := range module.Resources {
-				if resource.Addr.Resource.Mode == addrs.ManagedResourceMode {
-					empty = false
-					break
+		if !state.State.Empty() {
+			for _, module := range state.State.Modules {
+				for _, resource := range module.Resources {
+					if resource.Addr.Resource.Mode == addrs.ManagedResourceMode {
+						empty = false
+						break
+					}
 				}
 			}
 		}

--- a/internal/command/test_test.go
+++ b/internal/command/test_test.go
@@ -295,6 +295,11 @@ func TestTest_Runs(t *testing.T) {
 			expectedErr: []string{"Test assertion failed", "resource renamed without moved block"},
 			code:        1,
 		},
+		"unapplyable-plan": {
+			expectedOut: []string{"0 passed, 1 failed."},
+			expectedErr: []string{"Cannot apply non-applyable plan"},
+			code:        1,
+		},
 	}
 	for name, tc := range tcs {
 		t.Run(name, func(t *testing.T) {

--- a/internal/command/testdata/test/unapplyable-plan/main.tf
+++ b/internal/command/testdata/test/unapplyable-plan/main.tf
@@ -1,0 +1,8 @@
+
+resource "test_resource" "example" {
+  value = "bar"
+}
+
+output "value" {
+  value = test_resource.example.value
+}

--- a/internal/command/testdata/test/unapplyable-plan/main.tftest.hcl
+++ b/internal/command/testdata/test/unapplyable-plan/main.tftest.hcl
@@ -1,0 +1,11 @@
+
+run "test" {
+  command = apply
+  plan_options {
+    mode = refresh-only
+  }
+  assert {
+    condition = test_resource.example.value == "bar"
+    error_message = "wrong value"
+  }
+}


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

This fixes a crash in 1.11 branch that occurs when a run block in a test file fails due to a non-applyable plan. It later tries to deference the null state and crashes. This was already fixed in `main` during a larger refactor in which the actual crash wasn't detected, so I'm pushing directly to 1.11.

We shouldn't merge this until after the 1.11.0 release happens later this week, with the target release for this PR being 1.11.1 next week.

I will forward port the test that was added here so we don't accidentally cause a regression in main.

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Fixes #

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.11.1

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [x] This change is user-facing and I added a changelog entry.
- [ ] This change is not user-facing.
