### PR TITLE
Add test case to ensure no regression of already fixed crash

### DIFF
--- a/internal/command/test_test.go
+++ b/internal/command/test_test.go
@@ -314,6 +314,11 @@ func TestTest_Runs(t *testing.T) {
 			expectedErr: []string{"Test assertion failed", "resource renamed without moved block"},
 			code:        1,
 		},
+		"unapplyable-plan": {
+			expectedOut: []string{"0 passed, 1 failed."},
+			expectedErr: []string{"Cannot apply non-applyable plan"},
+			code:        1,
+		},
 	}
 	for name, tc := range tcs {
 		t.Run(name, func(t *testing.T) {

--- a/internal/command/testdata/test/unapplyable-plan/main.tf
+++ b/internal/command/testdata/test/unapplyable-plan/main.tf
@@ -1,0 +1,8 @@
+
+resource "test_resource" "example" {
+  value = "bar"
+}
+
+output "value" {
+  value = test_resource.example.value
+}

--- a/internal/command/testdata/test/unapplyable-plan/main.tftest.hcl
+++ b/internal/command/testdata/test/unapplyable-plan/main.tftest.hcl
@@ -1,0 +1,11 @@
+
+run "test" {
+  command = apply
+  plan_options {
+    mode = refresh-only
+  }
+  assert {
+    condition = test_resource.example.value == "bar"
+    error_message = "wrong value"
+  }
+}


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

Add a test for an already fixed crash to avoid regressions in the future. See also: https://github.com/hashicorp/terraform/pull/36582

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Fixes #

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.12.x

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
