### PR TITLE
lang/funcs/transpose: Avoid crash on map with null value

### DIFF
--- a/internal/lang/funcs/collection_test.go
+++ b/internal/lang/funcs/collection_test.go
@@ -1833,6 +1833,18 @@ func TestTranspose(t *testing.T) {
 			}).WithMarks(cty.NewValueMarks("beep", "boop", "bloop")),
 			false,
 		},
+		{
+			cty.NilVal,
+			cty.NilVal,
+			true,
+		},
+		{
+			cty.MapVal(map[string]cty.Value{
+				"test": cty.NilVal,
+			}),
+			cty.NilVal,
+			false,
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Fixes #36547

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.12.x

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [ ] This change is not user-facing.
