### PR TITLE
fix(docs): typo in variables example

### DIFF
--- a/website/docs/language/values/variables.mdx
+++ b/website/docs/language/values/variables.mdx
@@ -537,7 +537,7 @@ variable "moose" {
 And the following `.tfvars` file:
 
 ```hcl
-mosse = "Moose"
+moose = "Moose"
 ```
 
 Will cause Terraform to warn you that there is no variable declared `"mosse"`, which can help


### PR DESCRIPTION
Fixes a typo in input variables documentation

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
