### PR TITLE
build: always build on successful pushes rather than waiting for tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,22 +7,13 @@ name: build
 
 on:
   workflow_dispatch:
-    inputs:
-      target-branch:
-        description: "The branch, tag, or git commit sha to build"
-        required: true
-        default: "main"
-  workflow_run:
-    workflows: ["Quick Checks"]
-    types:
-      - completed
+  push:
     branches:
       - main
       - 'v[0-9]+.[0-9]+'
       - releng/**
       - tsccr-auto-pinning/**
       - dependabot/**
-  push:
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+*'
 
@@ -34,33 +25,9 @@ permissions:
   statuses: write
 
 jobs:
-  get-target-branch:
-    name: "Determine target branch based on event"
-    runs-on: ubuntu-latest
-    outputs:
-      target-branch: ${{ steps.get-target-branch.outputs.target-branch }}
-    steps:
-      - name: Determine target branch
-        id: get-target-branch
-        run: |
-          if [[ "${{ github.event_name }}" == "workflow_run" ]]; then
-            target_branch=${{ github.event.workflow_run.head_sha }}
-          elif [[ "${{ github.event_name }}" == "push" ]]; then
-            target_branch=${{ github.ref }}
-          elif [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            target_branch=${{ github.event.inputs.target-branch }}
-          else
-            echo "Unexpected event name: ${{ github.event_name }}"
-            exit 1
-          fi
-          echo "target-branch=${target_branch}" | tee -a "${GITHUB_OUTPUT}"
-
   get-product-version:
     name: "Determine intended Terraform version"
-    if: ${{ github.event.action != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
-    needs:
-      - get-target-branch
     outputs:
       product-version: ${{ steps.get-product-version.outputs.product-version }}
       product-version-base: ${{ steps.get-product-version.outputs.base-product-version }}
@@ -71,8 +38,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          ref: ${{ needs.get-target-branch.outputs.target-branch }}
       - name: Get Package Name
         id: get-pkg-name
         run: |


### PR DESCRIPTION
Stop trying to get the build action to execute only if the unit tests pass.

Chaining actions together isn't as straightforward as it feels like it should be, and getting it to trigger at the right time and to build the right branch isn't coming together in a nice way. The relatively minor gains we get from this don't make up for risking releasing the wrong build or missing a failing build because it didn't execute.