### PR TITLE
Added Document for provider version in Terraform 0.12 and patched versions

### DIFF
--- a/.changes/v1.12/Documentation-for-terraform.yaml
+++ b/.changes/v1.12/Documentation-for-terraform.yaml
@@ -1,0 +1,10 @@
+---
+type: documentation
+description: >
+  Added documentation for specifying provider versions in Terraform 0.12 and its patched versions.
+  This update provides guidance on using explicit provider versioning since Terraform 0.12 does not support 
+  the `required_providers` block introduced in later versions.
+issue: 36586
+author: Sheersagar
+signed-off-by: vishavdeshwal@gmail.com
+---

--- a/docs/dependency-upgrades.md
+++ b/docs/dependency-upgrades.md
@@ -151,3 +151,37 @@ special constraints due to how Terraform uses them:
     to upgrade because they tend to have dependencies that overlap with ours
     and so might affect non-telemetry-related behavior, and so it's acceptable
     for those to lag slightly behind to reduce risk in routine upgrades.
+
+
+# Provider Compatibility for Terraform 0.12
+  If you are using any version of Terraform 0.12.31 and all of it's 0.12 patch
+  versions, it requires explicit providerversioning as it does not supports the
+  required_providers block introduced in the later versions. Below are the
+  recommended provider versions for common infrastructure providers when using
+  Terraform 0.12
+    AWS Provider  ---> Use version 2.x as 3.x or above requires Terraform 0.13+
+      provider "aws" {
+        version = "~> 2.70"
+        region  = "us-east-1"
+      }
+    
+    GCP Provider ---> Use version 3.x as 4.x or above requires Terraform 0.13+
+      provider "google" {
+        version = "~> 3.5"
+        project = "your-gcp-project"
+        region  = "us-central1"
+      }
+
+    Azure Provider ---> Use version 2.x, as 3.x and later require Terraform 0.13+
+      provider "azurerm" {
+        version = "~> 2.30"
+        features {}
+      }
+    
+    Kubernetes Provider ---> Use version 1.x, as newer versions require Terraform 0.13+
+      provider "kubernetes" {
+        version                = "~> 1.11"
+        host                   = "https://your-k8s-api-server"
+        token                  = "your-access-token"
+        cluster_ca_certificate = "your-ca-cert"
+      }

--- a/website/docs/language/providers/configuration.mdx
+++ b/website/docs/language/providers/configuration.mdx
@@ -19,6 +19,18 @@ require so that Terraform can install and use them. The
 [Provider Requirements](/terraform/language/providers/requirements)
 page documents how to declare providers so Terraform can install them.
 
+# Provider Compatibility for Terraform 0.12
+
+If you are using any version of Terraform 0.12.31 and all of its 0.12 patch versions, you must explicitly specify the provider version. Terraform 0.12 does not support the `required_providers` block introduced in later versions. Below are the recommended provider versions for common infrastructure providers when using Terraform 0.12.
+
+| Provider   | Recommended Version | Terraform Compatibility | Example Configuration |
+|------------|--------------------|-------------------------|-----------------------|
+| **AWS**    | `~> 2.70`          | Use version 2.x (3.x+ requires Terraform 0.13+) | ```hcl<br>provider "aws" {<br>  version = "~> 2.70"<br>  region  = "us-east-1"<br>}``` |
+| **GCP**    | `~> 3.5`           | Use version 3.x (4.x+ requires Terraform 0.13+) | ```hcl<br>provider "google" {<br>  version = "~> 3.5"<br>  project = "your-gcp-project"<br>  region  = "us-central1"<br>}``` |
+| **Azure**  | `~> 2.30`          | Use version 2.x (3.x+ requires Terraform 0.13+) | ```hcl<br>provider "azurerm" {<br>  version = "~> 2.30"<br>  features {}<br>}``` |
+| **Kubernetes** | `~> 1.11`       | Use version 1.x (newer versions require Terraform 0.13+) | ```hcl<br>provider "kubernetes" {<br>  version = "~> 1.11"<br>  host = "https://your-k8s-api-server"<br>  token = "your-access-token"<br>  cluster_ca_certificate = "your-ca-cert"<br>}``` |
+
+> **Note:** Ensure that the provider versions specified are compatible with your Terraform 0.12 setup.
 ## Provider Configuration
 
 Provider configurations belong in the root module of a Terraform configuration.


### PR DESCRIPTION
This change resolves #36586 by adding the documentation for providing information about provider versions.
Signed-off-by: Sheersagar <vishavdeshwal@gmail.com>