### PR TITLE
lang/funcs/transpose: Avoid crash due to map with `null` values

### DIFF
--- a/.changes/v1.11/BUG FIXES-20250303-125722.yaml
+++ b/.changes/v1.11/BUG FIXES-20250303-125722.yaml
@@ -1,0 +1,5 @@
+kind: BUG FIXES
+body: 'lang/funcs/transpose: Avoid crash due to map with null values'
+time: 2025-03-03T12:57:22.400359Z
+custom:
+    Issue: "36611"

--- a/internal/lang/funcs/collection.go
+++ b/internal/lang/funcs/collection.go
@@ -582,8 +582,14 @@ var TransposeFunc = function.New(&function.Spec{
 
 		for it := inputMap.ElementIterator(); it.Next(); {
 			inKey, inVal := it.Element()
+			if inVal.IsNull() {
+				return cty.MapValEmpty(cty.List(cty.String)), errors.New("input must not contain null list")
+			}
 			for iter := inVal.ElementIterator(); iter.Next(); {
 				_, val := iter.Element()
+				if val.IsNull() {
+					return cty.MapValEmpty(cty.List(cty.String)), errors.New("input list must not contain null string")
+				}
 				if !val.Type().Equals(cty.String) {
 					return cty.MapValEmpty(cty.List(cty.String)), errors.New("input must be a map of lists of strings")
 				}

--- a/internal/lang/funcs/collection_test.go
+++ b/internal/lang/funcs/collection_test.go
@@ -1833,6 +1833,37 @@ func TestTranspose(t *testing.T) {
 			}).WithMarks(cty.NewValueMarks("beep", "boop", "bloop")),
 			false,
 		},
+		{
+			cty.NullVal(cty.Map(cty.List(cty.String))),
+			cty.NilVal,
+			true,
+		},
+		{
+			cty.MapVal(map[string]cty.Value{
+				"test": cty.NullVal(cty.List(cty.String)),
+			}),
+			cty.NilVal,
+			true,
+		},
+		{
+			cty.MapVal(map[string]cty.Value{
+				"test": cty.ListVal([]cty.Value{cty.NullVal(cty.String)}),
+			}),
+			cty.NilVal,
+			true,
+		},
+		{
+			cty.UnknownVal(cty.Map(cty.List(cty.String))),
+			cty.UnknownVal(cty.Map(cty.List(cty.String))).RefineNotNull(),
+			false,
+		},
+		{
+			cty.MapVal(map[string]cty.Value{
+				"test": cty.ListVal([]cty.Value{cty.UnknownVal(cty.String)}),
+			}),
+			cty.UnknownVal(cty.Map(cty.List(cty.String))).RefineNotNull(),
+			false,
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Fixes #36547

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.11.x

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [ ] This change is not user-facing.
