### PR TITLE
Enhance elapsed time display in UI Hook with minutes and seconds

### DIFF
--- a/.changes/v1.12/ENHANCEMENTS-20250303-151031.yaml
+++ b/.changes/v1.12/ENHANCEMENTS-20250303-151031.yaml
@@ -1,0 +1,5 @@
+kind: ENHANCEMENTS
+body: Improved elapsed time display in UI Hook to show minutes and seconds in `mm:ss` format.
+time: 2025-03-03T15:10:31.423108698-03:00
+custom:
+    Issue: "36368"

--- a/internal/command/views/hook_ui.go
+++ b/internal/command/views/hook_ui.go
@@ -188,12 +188,17 @@ func (h *UiHook) stillRunning(state uiResourceState) {
 			idSuffix = fmt.Sprintf("%s=%s, ", state.IDKey, truncateId(state.IDValue, maxIdLen))
 		}
 
+		elapsed := time.Now().Round(time.Second).Sub(state.Start)
+		minutes := int(elapsed.Seconds()) / 60
+		seconds := int(elapsed.Seconds()) % 60
+
 		h.println(fmt.Sprintf(
-			h.view.colorize.Color("[reset][bold]%s: %s [%s%s elapsed][reset]"),
+			h.view.colorize.Color("[reset][bold]%s: %s [%s%02dm%02ds elapsed][reset]"),
 			state.Address,
 			msg,
 			idSuffix,
-			time.Now().Round(time.Second).Sub(state.Start),
+			minutes,
+			seconds,
 		))
 	}
 }

--- a/internal/command/views/hook_ui_test.go
+++ b/internal/command/views/hook_ui_test.go
@@ -137,9 +137,9 @@ func TestUiHookPreApply_periodicTimer(t *testing.T) {
 	<-uiState.done
 
 	expectedOutput := `test_instance.foo: Modifying... [id=test]
-test_instance.foo: Still modifying... [id=test, 1s elapsed]
-test_instance.foo: Still modifying... [id=test, 2s elapsed]
-test_instance.foo: Still modifying... [id=test, 3s elapsed]
+test_instance.foo: Still modifying... [id=test, 00m01s elapsed]
+test_instance.foo: Still modifying... [id=test, 00m02s elapsed]
+test_instance.foo: Still modifying... [id=test, 00m03s elapsed]
 `
 	result := done(t)
 	output := result.Stdout()
@@ -637,8 +637,8 @@ func TestUiHookEphemeralOp_progress(t *testing.T) {
 
 	// we do not test for equality because time.Sleep can take longer than declared time
 	wantPrefix := `ephemeral.test_instance.foo: Opening...
-ephemeral.test_instance.foo: Still opening... [1s elapsed]
-ephemeral.test_instance.foo: Still opening... [2s elapsed]`
+ephemeral.test_instance.foo: Still opening... [00m01s elapsed]
+ephemeral.test_instance.foo: Still opening... [00m02s elapsed]`
 	if !strings.HasPrefix(stdout, wantPrefix) {
 		t.Fatalf("unexpected prefix\n got: %q\nwant: %q", stdout, wantPrefix)
 	}


### PR DESCRIPTION
This PR improves the elapsed time display in the UI Hook by changing it from seconds-only to a more readable mm:ss format.

Previously, elapsed time was displayed in seconds only, making it hard to interpret for longer durations. Now, it follows the 00m00s format, making it more user-friendly.

This improvement directly addresses [Issue #36368](https://github.com/hashicorp/terraform/issues/36368), which requests better readability for elapsed time display.

Main Changes:
Added separate calculations for minutes and seconds.
Updated the display string format to include mm:ss.
Kept the existing rounding logic for time calculations.

now:
![Screenshot 2025-03-03 152509](https://github.com/user-attachments/assets/779a718b-4d14-402a-a3e6-c55c7495f602)

before:
![Screenshot 2025-03-03 152441](https://github.com/user-attachments/assets/ba93b6c6-2acd-45f2-bf6b-177a9ec0c207)

Fixes #36368

## Target Release

1.12.x

## CHANGELOG entry

- [x] This change is user-facing and I added a changelog entry.
- [ ] This change is not user-facing.
