### PR TITLE
Rename provider schema Block to Body

### DIFF
--- a/internal/backend/local/backend_apply_test.go
+++ b/internal/backend/local/backend_apply_test.go
@@ -189,7 +189,7 @@ func TestLocal_applyError(t *testing.T) {
 	schema := providers.ProviderSchema{
 		ResourceTypes: map[string]providers.Schema{
 			"test_instance": {
-				Block: &configschema.Block{
+				Body: &configschema.Block{
 					Attributes: map[string]*configschema.Attribute{
 						"ami": {Type: cty.String, Optional: true},
 						"id":  {Type: cty.String, Computed: true},
@@ -391,7 +391,7 @@ func applyFixtureSchema() providers.ProviderSchema {
 	return providers.ProviderSchema{
 		ResourceTypes: map[string]providers.Schema{
 			"test_instance": {
-				Block: &configschema.Block{
+				Body: &configschema.Block{
 					Attributes: map[string]*configschema.Attribute{
 						"ami": {Type: cty.String, Optional: true},
 						"id":  {Type: cty.String, Computed: true},

--- a/internal/backend/local/backend_plan_test.go
+++ b/internal/backend/local/backend_plan_test.go
@@ -860,7 +860,7 @@ func planFixtureSchema() providers.ProviderSchema {
 	return providers.ProviderSchema{
 		ResourceTypes: map[string]providers.Schema{
 			"test_instance": {
-				Block: &configschema.Block{
+				Body: &configschema.Block{
 					Attributes: map[string]*configschema.Attribute{
 						"ami": {Type: cty.String, Optional: true},
 					},
@@ -880,7 +880,7 @@ func planFixtureSchema() providers.ProviderSchema {
 		},
 		DataSources: map[string]providers.Schema{
 			"test_ds": {
-				Block: &configschema.Block{
+				Body: &configschema.Block{
 					Attributes: map[string]*configschema.Attribute{
 						"filter": {Type: cty.String, Required: true},
 					},

--- a/internal/backend/local/backend_refresh_test.go
+++ b/internal/backend/local/backend_refresh_test.go
@@ -65,7 +65,7 @@ func TestLocal_refreshInput(t *testing.T) {
 
 	schema := providers.ProviderSchema{
 		Provider: providers.Schema{
-			Block: &configschema.Block{
+			Body: &configschema.Block{
 				Attributes: map[string]*configschema.Attribute{
 					"value": {Type: cty.String, Optional: true},
 				},
@@ -73,7 +73,7 @@ func TestLocal_refreshInput(t *testing.T) {
 		},
 		ResourceTypes: map[string]providers.Schema{
 			"test_instance": {
-				Block: &configschema.Block{
+				Body: &configschema.Block{
 					Attributes: map[string]*configschema.Attribute{
 						"id":  {Type: cty.String, Computed: true},
 						"foo": {Type: cty.String, Optional: true},
@@ -160,7 +160,7 @@ func TestLocal_refreshValidateProviderConfigured(t *testing.T) {
 
 	schema := providers.ProviderSchema{
 		Provider: providers.Schema{
-			Block: &configschema.Block{
+			Body: &configschema.Block{
 				Attributes: map[string]*configschema.Attribute{
 					"value": {Type: cty.String, Optional: true},
 				},
@@ -168,7 +168,7 @@ func TestLocal_refreshValidateProviderConfigured(t *testing.T) {
 		},
 		ResourceTypes: map[string]providers.Schema{
 			"test_instance": {
-				Block: &configschema.Block{
+				Body: &configschema.Block{
 					Attributes: map[string]*configschema.Attribute{
 						"id":  {Type: cty.String, Computed: true},
 						"ami": {Type: cty.String, Optional: true},
@@ -309,7 +309,7 @@ func refreshFixtureSchema() providers.ProviderSchema {
 	return providers.ProviderSchema{
 		ResourceTypes: map[string]providers.Schema{
 			"test_instance": {
-				Block: &configschema.Block{
+				Body: &configschema.Block{
 					Attributes: map[string]*configschema.Attribute{
 						"ami": {Type: cty.String, Optional: true},
 						"id":  {Type: cty.String, Computed: true},

--- a/internal/backend/remote/testing.go
+++ b/internal/backend/remote/testing.go
@@ -186,7 +186,7 @@ func testLocalBackend(t *testing.T, remote *Remote) backendrun.OperationsBackend
 	p := backendLocal.TestLocalProvider(t, b, "null", providers.ProviderSchema{
 		ResourceTypes: map[string]providers.Schema{
 			"null_resource": {
-				Block: &configschema.Block{
+				Body: &configschema.Block{
 					Attributes: map[string]*configschema.Attribute{
 						"id": {Type: cty.String, Computed: true},
 					},

--- a/internal/builtin/providers/terraform/data_source_state.go
+++ b/internal/builtin/providers/terraform/data_source_state.go
@@ -19,7 +19,7 @@ import (
 
 func dataSourceRemoteStateGetSchema() providers.Schema {
 	return providers.Schema{
-		Block: &configschema.Block{
+		Body: &configschema.Block{
 			Attributes: map[string]*configschema.Attribute{
 				"backend": {
 					Type:            cty.String,

--- a/internal/builtin/providers/terraform/data_source_state_test.go
+++ b/internal/builtin/providers/terraform/data_source_state_test.go
@@ -19,7 +19,7 @@ import (
 )
 
 func TestResource(t *testing.T) {
-	if err := dataSourceRemoteStateGetSchema().Block.InternalValidate(); err != nil {
+	if err := dataSourceRemoteStateGetSchema().Body.InternalValidate(); err != nil {
 		t.Fatalf("err: %s", err)
 	}
 }
@@ -290,7 +290,7 @@ func TestState_basic(t *testing.T) {
 	}
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			schema := dataSourceRemoteStateGetSchema().Block
+			schema := dataSourceRemoteStateGetSchema().Body
 			config, err := schema.CoerceValue(test.Config)
 			if err != nil {
 				t.Fatalf("unexpected error: %s", err)
@@ -335,7 +335,7 @@ func TestState_validation(t *testing.T) {
 		overrideBackendFactories = nil
 	}()
 
-	schema := dataSourceRemoteStateGetSchema().Block
+	schema := dataSourceRemoteStateGetSchema().Body
 	config, err := schema.CoerceValue(cty.ObjectVal(map[string]cty.Value{
 		"backend": cty.StringVal("failsconfigure"),
 		"config":  cty.EmptyObjectVal,

--- a/internal/builtin/providers/terraform/resource_data.go
+++ b/internal/builtin/providers/terraform/resource_data.go
@@ -17,7 +17,7 @@ import (
 
 func dataStoreResourceSchema() providers.Schema {
 	return providers.Schema{
-		Block: &configschema.Block{
+		Body: &configschema.Block{
 			Attributes: map[string]*configschema.Attribute{
 				"input":            {Type: cty.DynamicPseudoType, Optional: true},
 				"output":           {Type: cty.DynamicPseudoType, Computed: true},
@@ -44,7 +44,7 @@ func validateDataStoreResourceConfig(req providers.ValidateResourceConfigRequest
 }
 
 func upgradeDataStoreResourceState(req providers.UpgradeResourceStateRequest) (resp providers.UpgradeResourceStateResponse) {
-	ty := dataStoreResourceSchema().Block.ImpliedType()
+	ty := dataStoreResourceSchema().Body.ImpliedType()
 	val, err := ctyjson.Unmarshal(req.RawStateJSON, ty)
 	if err != nil {
 		resp.Diagnostics = resp.Diagnostics.Append(err)
@@ -160,7 +160,7 @@ func importDataStore(req providers.ImportResourceStateRequest) (resp providers.I
 	v := cty.ObjectVal(map[string]cty.Value{
 		"id": cty.StringVal(req.ID),
 	})
-	state, err := schema.Block.CoerceValue(v)
+	state, err := schema.Body.CoerceValue(v)
 	resp.Diagnostics = resp.Diagnostics.Append(err)
 
 	resp.ImportedResources = []providers.ImportedResource{
@@ -200,7 +200,7 @@ func moveDataStoreResourceState(req providers.MoveResourceStateRequest) (resp pr
 		return resp
 	}
 
-	nullResourceSchemaType := nullResourceSchema().Block.ImpliedType()
+	nullResourceSchemaType := nullResourceSchema().Body.ImpliedType()
 	nullResourceValue, err := ctyjson.Unmarshal(req.SourceStateJSON, nullResourceSchemaType)
 
 	if err != nil {
@@ -233,7 +233,7 @@ func moveDataStoreResourceState(req providers.MoveResourceStateRequest) (resp pr
 		"triggers_replace": triggersReplace,
 	})
 
-	state, err := schema.Block.CoerceValue(v)
+	state, err := schema.Body.CoerceValue(v)
 
 	// null_resource did not use private state, so it is unnecessary to move.
 	resp.Diagnostics = resp.Diagnostics.Append(err)
@@ -244,7 +244,7 @@ func moveDataStoreResourceState(req providers.MoveResourceStateRequest) (resp pr
 
 func nullResourceSchema() providers.Schema {
 	return providers.Schema{
-		Block: &configschema.Block{
+		Body: &configschema.Block{
 			Attributes: map[string]*configschema.Attribute{
 				"id":       {Type: cty.String, Computed: true},
 				"triggers": {Type: cty.Map(cty.String), Optional: true},

--- a/internal/builtin/providers/terraform/resource_data_test.go
+++ b/internal/builtin/providers/terraform/resource_data_test.go
@@ -48,7 +48,7 @@ func TestManagedDataValidate(t *testing.T) {
 
 func TestManagedDataUpgradeState(t *testing.T) {
 	schema := dataStoreResourceSchema()
-	ty := schema.Block.ImpliedType()
+	ty := schema.Body.ImpliedType()
 
 	state := cty.ObjectVal(map[string]cty.Value{
 		"input":  cty.StringVal("input"),
@@ -104,7 +104,7 @@ func TestManagedDataRead(t *testing.T) {
 }
 
 func TestManagedDataPlan(t *testing.T) {
-	schema := dataStoreResourceSchema().Block
+	schema := dataStoreResourceSchema().Body
 	ty := schema.ImpliedType()
 
 	for name, tc := range map[string]struct {
@@ -256,7 +256,7 @@ func TestManagedDataApply(t *testing.T) {
 		testUUIDHook = nil
 	}()
 
-	schema := dataStoreResourceSchema().Block
+	schema := dataStoreResourceSchema().Body
 	ty := schema.ImpliedType()
 
 	for name, tc := range map[string]struct {

--- a/internal/cloud/testing.go
+++ b/internal/cloud/testing.go
@@ -378,7 +378,7 @@ func testLocalBackend(t *testing.T, cloud *Cloud) backendrun.OperationsBackend {
 	p := backendLocal.TestLocalProvider(t, b, "null", providers.ProviderSchema{
 		ResourceTypes: map[string]providers.Schema{
 			"null_resource": {
-				Block: &configschema.Block{
+				Body: &configschema.Block{
 					Attributes: map[string]*configschema.Attribute{
 						"id": {Type: cty.String, Computed: true},
 					},

--- a/internal/command/apply_destroy_test.go
+++ b/internal/command/apply_destroy_test.go
@@ -48,7 +48,7 @@ func TestApply_destroy(t *testing.T) {
 	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
 		ResourceTypes: map[string]providers.Schema{
 			"test_instance": {
-				Block: &configschema.Block{
+				Body: &configschema.Block{
 					Attributes: map[string]*configschema.Attribute{
 						"id":  {Type: cty.String, Computed: true},
 						"ami": {Type: cty.String, Optional: true},
@@ -431,14 +431,14 @@ func TestApply_destroyTargetedDependencies(t *testing.T) {
 	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
 		ResourceTypes: map[string]providers.Schema{
 			"test_instance": {
-				Block: &configschema.Block{
+				Body: &configschema.Block{
 					Attributes: map[string]*configschema.Attribute{
 						"id": {Type: cty.String, Computed: true},
 					},
 				},
 			},
 			"test_load_balancer": {
-				Block: &configschema.Block{
+				Body: &configschema.Block{
 					Attributes: map[string]*configschema.Attribute{
 						"id":        {Type: cty.String, Computed: true},
 						"instances": {Type: cty.List(cty.String), Optional: true},
@@ -582,14 +582,14 @@ func TestApply_destroyTargeted(t *testing.T) {
 	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
 		ResourceTypes: map[string]providers.Schema{
 			"test_instance": {
-				Block: &configschema.Block{
+				Body: &configschema.Block{
 					Attributes: map[string]*configschema.Attribute{
 						"id": {Type: cty.String, Computed: true},
 					},
 				},
 			},
 			"test_load_balancer": {
-				Block: &configschema.Block{
+				Body: &configschema.Block{
 					Attributes: map[string]*configschema.Attribute{
 						"id":        {Type: cty.String, Computed: true},
 						"instances": {Type: cty.List(cty.String), Optional: true},

--- a/internal/command/apply_test.go
+++ b/internal/command/apply_test.go
@@ -308,7 +308,7 @@ func TestApply_parallelism(t *testing.T) {
 		provider := &testing_provider.MockProvider{}
 		provider.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
 			ResourceTypes: map[string]providers.Schema{
-				name + "_instance": {Block: &configschema.Block{}},
+				name + "_instance": {Body: &configschema.Block{}},
 			},
 		}
 		provider.PlanResourceChangeFn = func(req providers.PlanResourceChangeRequest) providers.PlanResourceChangeResponse {
@@ -493,7 +493,7 @@ func TestApply_error(t *testing.T) {
 	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
 		ResourceTypes: map[string]providers.Schema{
 			"test_instance": {
-				Block: &configschema.Block{
+				Body: &configschema.Block{
 					Attributes: map[string]*configschema.Attribute{
 						"id":    {Type: cty.String, Optional: true, Computed: true},
 						"ami":   {Type: cty.String, Optional: true},
@@ -881,7 +881,7 @@ func TestApply_planWithVarFile(t *testing.T) {
 	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
 		ResourceTypes: map[string]providers.Schema{
 			"test_instance": {
-				Block: &configschema.Block{
+				Body: &configschema.Block{
 					Attributes: map[string]*configschema.Attribute{
 						"id":    {Type: cty.String, Computed: true},
 						"value": {Type: cty.String, Optional: true},
@@ -1657,7 +1657,7 @@ func TestApply_shutdown(t *testing.T) {
 	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
 		ResourceTypes: map[string]providers.Schema{
 			"test_instance": {
-				Block: &configschema.Block{
+				Body: &configschema.Block{
 					Attributes: map[string]*configschema.Attribute{
 						"ami": {Type: cty.String, Optional: true},
 					},
@@ -1869,7 +1869,7 @@ func TestApply_vars(t *testing.T) {
 	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
 		ResourceTypes: map[string]providers.Schema{
 			"test_instance": {
-				Block: &configschema.Block{
+				Body: &configschema.Block{
 					Attributes: map[string]*configschema.Attribute{
 						"value": {Type: cty.String, Optional: true},
 					},
@@ -1931,7 +1931,7 @@ func TestApply_varFile(t *testing.T) {
 	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
 		ResourceTypes: map[string]providers.Schema{
 			"test_instance": {
-				Block: &configschema.Block{
+				Body: &configschema.Block{
 					Attributes: map[string]*configschema.Attribute{
 						"value": {Type: cty.String, Optional: true},
 					},
@@ -1993,7 +1993,7 @@ func TestApply_varFileDefault(t *testing.T) {
 	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
 		ResourceTypes: map[string]providers.Schema{
 			"test_instance": {
-				Block: &configschema.Block{
+				Body: &configschema.Block{
 					Attributes: map[string]*configschema.Attribute{
 						"value": {Type: cty.String, Optional: true},
 					},
@@ -2054,7 +2054,7 @@ func TestApply_varFileDefaultJSON(t *testing.T) {
 	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
 		ResourceTypes: map[string]providers.Schema{
 			"test_instance": {
-				Block: &configschema.Block{
+				Body: &configschema.Block{
 					Attributes: map[string]*configschema.Attribute{
 						"value": {Type: cty.String, Optional: true},
 					},
@@ -2353,7 +2353,7 @@ func TestApply_targeted(t *testing.T) {
 	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
 		ResourceTypes: map[string]providers.Schema{
 			"test_instance": {
-				Block: &configschema.Block{
+				Body: &configschema.Block{
 					Attributes: map[string]*configschema.Attribute{
 						"id": {Type: cty.String, Computed: true},
 					},
@@ -2460,7 +2460,7 @@ func TestApply_replace(t *testing.T) {
 	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
 		ResourceTypes: map[string]providers.Schema{
 			"test_instance": {
-				Block: &configschema.Block{
+				Body: &configschema.Block{
 					Attributes: map[string]*configschema.Attribute{
 						"id": {Type: cty.String, Computed: true},
 					},
@@ -2683,7 +2683,7 @@ func applyFixtureSchema() *providers.GetProviderSchemaResponse {
 	return &providers.GetProviderSchemaResponse{
 		ResourceTypes: map[string]providers.Schema{
 			"test_instance": {
-				Block: &configschema.Block{
+				Body: &configschema.Block{
 					Attributes: map[string]*configschema.Attribute{
 						"id":  {Type: cty.String, Optional: true, Computed: true},
 						"ami": {Type: cty.String, Optional: true},

--- a/internal/command/console_test.go
+++ b/internal/command/console_test.go
@@ -69,7 +69,7 @@ func TestConsole_tfvars(t *testing.T) {
 	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
 		ResourceTypes: map[string]providers.Schema{
 			"test_instance": {
-				Block: &configschema.Block{
+				Body: &configschema.Block{
 					Attributes: map[string]*configschema.Attribute{
 						"value": {Type: cty.String, Optional: true},
 					},
@@ -121,7 +121,7 @@ func TestConsole_unsetRequiredVars(t *testing.T) {
 	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
 		ResourceTypes: map[string]providers.Schema{
 			"test_instance": {
-				Block: &configschema.Block{
+				Body: &configschema.Block{
 					Attributes: map[string]*configschema.Attribute{
 						"value": {Type: cty.String, Optional: true},
 					},

--- a/internal/command/graph_test.go
+++ b/internal/command/graph_test.go
@@ -234,7 +234,7 @@ func TestGraph_resourcesOnly(t *testing.T) {
 	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
 		ResourceTypes: map[string]providers.Schema{
 			"foo": {
-				Block: &configschema.Block{
+				Body: &configschema.Block{
 					Attributes: map[string]*configschema.Attribute{
 						"arg": {
 							Type:     cty.String,

--- a/internal/command/import_test.go
+++ b/internal/command/import_test.go
@@ -50,7 +50,7 @@ func TestImport(t *testing.T) {
 	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
 		ResourceTypes: map[string]providers.Schema{
 			"test_instance": {
-				Block: &configschema.Block{
+				Body: &configschema.Block{
 					Attributes: map[string]*configschema.Attribute{
 						"id": {Type: cty.String, Optional: true, Computed: true},
 					},
@@ -104,7 +104,7 @@ func TestImport_providerConfig(t *testing.T) {
 	}
 	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
 		Provider: providers.Schema{
-			Block: &configschema.Block{
+			Body: &configschema.Block{
 				Attributes: map[string]*configschema.Attribute{
 					"foo": {Type: cty.String, Optional: true},
 				},
@@ -112,7 +112,7 @@ func TestImport_providerConfig(t *testing.T) {
 		},
 		ResourceTypes: map[string]providers.Schema{
 			"test_instance": {
-				Block: &configschema.Block{
+				Body: &configschema.Block{
 					Attributes: map[string]*configschema.Attribute{
 						"id": {Type: cty.String, Optional: true, Computed: true},
 					},
@@ -217,7 +217,7 @@ func TestImport_remoteState(t *testing.T) {
 	}
 	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
 		Provider: providers.Schema{
-			Block: &configschema.Block{
+			Body: &configschema.Block{
 				Attributes: map[string]*configschema.Attribute{
 					"foo": {Type: cty.String, Optional: true},
 				},
@@ -225,7 +225,7 @@ func TestImport_remoteState(t *testing.T) {
 		},
 		ResourceTypes: map[string]providers.Schema{
 			"test_instance": {
-				Block: &configschema.Block{
+				Body: &configschema.Block{
 					Attributes: map[string]*configschema.Attribute{
 						"id": {Type: cty.String, Optional: true, Computed: true},
 					},
@@ -372,7 +372,7 @@ func TestImport_providerConfigWithVar(t *testing.T) {
 	}
 	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
 		Provider: providers.Schema{
-			Block: &configschema.Block{
+			Body: &configschema.Block{
 				Attributes: map[string]*configschema.Attribute{
 					"foo": {Type: cty.String, Optional: true},
 				},
@@ -380,7 +380,7 @@ func TestImport_providerConfigWithVar(t *testing.T) {
 		},
 		ResourceTypes: map[string]providers.Schema{
 			"test_instance": {
-				Block: &configschema.Block{
+				Body: &configschema.Block{
 					Attributes: map[string]*configschema.Attribute{
 						"id": {Type: cty.String, Optional: true, Computed: true},
 					},
@@ -452,7 +452,7 @@ func TestImport_providerConfigWithDataSource(t *testing.T) {
 	}
 	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
 		Provider: providers.Schema{
-			Block: &configschema.Block{
+			Body: &configschema.Block{
 				Attributes: map[string]*configschema.Attribute{
 					"foo": {Type: cty.String, Optional: true},
 				},
@@ -460,7 +460,7 @@ func TestImport_providerConfigWithDataSource(t *testing.T) {
 		},
 		ResourceTypes: map[string]providers.Schema{
 			"test_instance": {
-				Block: &configschema.Block{
+				Body: &configschema.Block{
 					Attributes: map[string]*configschema.Attribute{
 						"id": {Type: cty.String, Optional: true, Computed: true},
 					},
@@ -469,7 +469,7 @@ func TestImport_providerConfigWithDataSource(t *testing.T) {
 		},
 		DataSources: map[string]providers.Schema{
 			"test_data": {
-				Block: &configschema.Block{
+				Body: &configschema.Block{
 					Attributes: map[string]*configschema.Attribute{
 						"foo": {Type: cty.String, Optional: true},
 					},
@@ -517,7 +517,7 @@ func TestImport_providerConfigWithVarDefault(t *testing.T) {
 	}
 	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
 		Provider: providers.Schema{
-			Block: &configschema.Block{
+			Body: &configschema.Block{
 				Attributes: map[string]*configschema.Attribute{
 					"foo": {Type: cty.String, Optional: true},
 				},
@@ -525,7 +525,7 @@ func TestImport_providerConfigWithVarDefault(t *testing.T) {
 		},
 		ResourceTypes: map[string]providers.Schema{
 			"test_instance": {
-				Block: &configschema.Block{
+				Body: &configschema.Block{
 					Attributes: map[string]*configschema.Attribute{
 						"id": {Type: cty.String, Optional: true, Computed: true},
 					},
@@ -596,7 +596,7 @@ func TestImport_providerConfigWithVarFile(t *testing.T) {
 	}
 	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
 		Provider: providers.Schema{
-			Block: &configschema.Block{
+			Body: &configschema.Block{
 				Attributes: map[string]*configschema.Attribute{
 					"foo": {Type: cty.String, Optional: true},
 				},
@@ -604,7 +604,7 @@ func TestImport_providerConfigWithVarFile(t *testing.T) {
 		},
 		ResourceTypes: map[string]providers.Schema{
 			"test_instance": {
-				Block: &configschema.Block{
+				Body: &configschema.Block{
 					Attributes: map[string]*configschema.Attribute{
 						"id": {Type: cty.String, Optional: true, Computed: true},
 					},
@@ -754,7 +754,7 @@ func TestImportModuleVarFile(t *testing.T) {
 	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
 		ResourceTypes: map[string]providers.Schema{
 			"test_instance": {
-				Block: &configschema.Block{
+				Body: &configschema.Block{
 					Attributes: map[string]*configschema.Attribute{
 						"foo": {Type: cty.String, Optional: true},
 					},
@@ -828,7 +828,7 @@ func TestImportModuleInputVariableEvaluation(t *testing.T) {
 	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
 		ResourceTypes: map[string]providers.Schema{
 			"test_instance": {
-				Block: &configschema.Block{
+				Body: &configschema.Block{
 					Attributes: map[string]*configschema.Attribute{
 						"foo": {Type: cty.String, Optional: true},
 					},

--- a/internal/command/jsonformat/plan_test.go
+++ b/internal/command/jsonformat/plan_test.go
@@ -7882,12 +7882,12 @@ func runTestCases(t *testing.T, testCases map[string]testCase) {
 					src.ProviderAddr.Provider: {
 						ResourceTypes: map[string]providers.Schema{
 							src.Addr.Resource.Resource.Type: {
-								Block: tc.Schema,
+								Body: tc.Schema,
 							},
 						},
 						DataSources: map[string]providers.Schema{
 							src.Addr.Resource.Resource.Type: {
-								Block: tc.Schema,
+								Body: tc.Schema,
 							},
 						},
 					},
@@ -8226,7 +8226,7 @@ func TestResourceChange_deferredActions(t *testing.T) {
 					providerAddr.Provider: {
 						ResourceTypes: map[string]providers.Schema{
 							"test_instance": {
-								Block: blockSchema,
+								Body: blockSchema,
 							},
 						},
 					},

--- a/internal/command/jsonformat/state_test.go
+++ b/internal/command/jsonformat/state_test.go
@@ -113,7 +113,7 @@ func testProvider() *testing_provider.MockProvider {
 func testProviderSchema() *providers.GetProviderSchemaResponse {
 	return &providers.GetProviderSchemaResponse{
 		Provider: providers.Schema{
-			Block: &configschema.Block{
+			Body: &configschema.Block{
 				Attributes: map[string]*configschema.Attribute{
 					"region": {Type: cty.String, Optional: true},
 				},
@@ -121,7 +121,7 @@ func testProviderSchema() *providers.GetProviderSchemaResponse {
 		},
 		ResourceTypes: map[string]providers.Schema{
 			"test_resource": {
-				Block: &configschema.Block{
+				Body: &configschema.Block{
 					Attributes: map[string]*configschema.Attribute{
 						"id":      {Type: cty.String, Computed: true},
 						"foo":     {Type: cty.String, Optional: true},
@@ -143,7 +143,7 @@ func testProviderSchema() *providers.GetProviderSchemaResponse {
 		},
 		DataSources: map[string]providers.Schema{
 			"test_data_source": {
-				Block: &configschema.Block{
+				Body: &configschema.Block{
 					Attributes: map[string]*configschema.Attribute{
 						"compute": {Type: cty.String, Optional: true},
 						"value":   {Type: cty.String, Computed: true},

--- a/internal/command/jsonplan/values_test.go
+++ b/internal/command/jsonplan/values_test.go
@@ -351,7 +351,7 @@ func testSchemas() *terraform.Schemas {
 				ResourceTypes: map[string]providers.Schema{
 					"test_thing": {
 						Version: 1,
-						Block: &configschema.Block{
+						Body: &configschema.Block{
 							Attributes: map[string]*configschema.Attribute{
 								"woozles": {Type: cty.String, Optional: true, Computed: true},
 								"foozles": {Type: cty.String, Optional: true},

--- a/internal/command/jsonprovider/provider_test.go
+++ b/internal/command/jsonprovider/provider_test.go
@@ -224,7 +224,7 @@ func TestMarshalProvider(t *testing.T) {
 func testProvider() providers.ProviderSchema {
 	return providers.ProviderSchema{
 		Provider: providers.Schema{
-			Block: &configschema.Block{
+			Body: &configschema.Block{
 				Attributes: map[string]*configschema.Attribute{
 					"region": {Type: cty.String, Required: true},
 				},
@@ -233,7 +233,7 @@ func testProvider() providers.ProviderSchema {
 		ResourceTypes: map[string]providers.Schema{
 			"test_instance": {
 				Version: 42,
-				Block: &configschema.Block{
+				Body: &configschema.Block{
 					Attributes: map[string]*configschema.Attribute{
 						"id":  {Type: cty.String, Optional: true, Computed: true},
 						"ami": {Type: cty.String, Optional: true},
@@ -265,7 +265,7 @@ func testProvider() providers.ProviderSchema {
 		DataSources: map[string]providers.Schema{
 			"test_data_source": {
 				Version: 3,
-				Block: &configschema.Block{
+				Body: &configschema.Block{
 					Attributes: map[string]*configschema.Attribute{
 						"id":  {Type: cty.String, Optional: true, Computed: true},
 						"ami": {Type: cty.String, Optional: true},
@@ -286,7 +286,7 @@ func testProvider() providers.ProviderSchema {
 		},
 		EphemeralResourceTypes: map[string]providers.Schema{
 			"test_eph_instance": {
-				Block: &configschema.Block{
+				Body: &configschema.Block{
 					Attributes: map[string]*configschema.Attribute{
 						"id":  {Type: cty.String, Optional: true, Computed: true},
 						"ami": {Type: cty.String, Optional: true},

--- a/internal/command/jsonprovider/schema.go
+++ b/internal/command/jsonprovider/schema.go
@@ -15,12 +15,12 @@ type Schema struct {
 // marshalSchema is a convenience wrapper around mashalBlock. Schema version
 // should be set by the caller.
 func marshalSchema(schema providers.Schema) *Schema {
-	if schema.Block == nil {
+	if schema.Body == nil {
 		return &Schema{}
 	}
 
 	var ret Schema
-	ret.Block = marshalBlock(schema.Block)
+	ret.Block = marshalBlock(schema.Body)
 	ret.Version = uint64(schema.Version)
 
 	return &ret

--- a/internal/command/jsonstate/state_test.go
+++ b/internal/command/jsonstate/state_test.go
@@ -844,7 +844,7 @@ func testSchemas() *terraform.Schemas {
 			addrs.NewDefaultProvider("test"): {
 				ResourceTypes: map[string]providers.Schema{
 					"test_thing": {
-						Block: &configschema.Block{
+						Body: &configschema.Block{
 							Attributes: map[string]*configschema.Attribute{
 								"woozles": {Type: cty.String, Optional: true, Computed: true},
 								"foozles": {Type: cty.String, Optional: true, Sensitive: true},
@@ -852,7 +852,7 @@ func testSchemas() *terraform.Schemas {
 						},
 					},
 					"test_instance": {
-						Block: &configschema.Block{
+						Body: &configschema.Block{
 							Attributes: map[string]*configschema.Attribute{
 								"id":  {Type: cty.String, Optional: true, Computed: true},
 								"foo": {Type: cty.String, Optional: true},
@@ -861,7 +861,7 @@ func testSchemas() *terraform.Schemas {
 						},
 					},
 					"test_map_attr": {
-						Block: &configschema.Block{
+						Body: &configschema.Block{
 							Attributes: map[string]*configschema.Attribute{
 								"data": {Type: cty.Map(cty.String), Optional: true, Computed: true, Sensitive: true},
 							},

--- a/internal/command/plan_test.go
+++ b/internal/command/plan_test.go
@@ -187,7 +187,7 @@ func TestPlan_noState(t *testing.T) {
 
 	// Verify that the provider was called with the existing state
 	actual := p.PlanResourceChangeRequest.PriorState
-	expected := cty.NullVal(p.GetProviderSchemaResponse.ResourceTypes["test_instance"].Block.ImpliedType())
+	expected := cty.NullVal(p.GetProviderSchemaResponse.ResourceTypes["test_instance"].Body.ImpliedType())
 	if !expected.RawEquals(actual) {
 		t.Fatalf("wrong prior state\ngot:  %#v\nwant: %#v", actual, expected)
 	}
@@ -403,7 +403,7 @@ func TestPlan_outBackend(t *testing.T) {
 	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
 		ResourceTypes: map[string]providers.Schema{
 			"test_instance": {
-				Block: &configschema.Block{
+				Body: &configschema.Block{
 					Attributes: map[string]*configschema.Attribute{
 						"id": {
 							Type:     cty.String,
@@ -660,7 +660,7 @@ func TestPlan_validate(t *testing.T) {
 	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
 		ResourceTypes: map[string]providers.Schema{
 			"test_instance": {
-				Block: &configschema.Block{
+				Body: &configschema.Block{
 					Attributes: map[string]*configschema.Attribute{
 						"id": {Type: cty.String, Optional: true, Computed: true},
 					},
@@ -831,7 +831,7 @@ func TestPlan_providerArgumentUnset(t *testing.T) {
 	// override the planFixtureProvider schema to include a required provider argument
 	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
 		Provider: providers.Schema{
-			Block: &configschema.Block{
+			Body: &configschema.Block{
 				Attributes: map[string]*configschema.Attribute{
 					"region": {Type: cty.String, Required: true},
 				},
@@ -839,7 +839,7 @@ func TestPlan_providerArgumentUnset(t *testing.T) {
 		},
 		ResourceTypes: map[string]providers.Schema{
 			"test_instance": {
-				Block: &configschema.Block{
+				Body: &configschema.Block{
 					Attributes: map[string]*configschema.Attribute{
 						"id":  {Type: cty.String, Optional: true, Computed: true},
 						"ami": {Type: cty.String, Optional: true, Computed: true},
@@ -860,7 +860,7 @@ func TestPlan_providerArgumentUnset(t *testing.T) {
 		},
 		DataSources: map[string]providers.Schema{
 			"test_data_source": {
-				Block: &configschema.Block{
+				Body: &configschema.Block{
 					Attributes: map[string]*configschema.Attribute{
 						"id": {
 							Type:     cty.String,
@@ -910,7 +910,7 @@ func TestPlan_providerConfigMerge(t *testing.T) {
 	// override the planFixtureProvider schema to include a required provider argument and a nested block
 	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
 		Provider: providers.Schema{
-			Block: &configschema.Block{
+			Body: &configschema.Block{
 				Attributes: map[string]*configschema.Attribute{
 					"region": {Type: cty.String, Required: true},
 					"url":    {Type: cty.String, Required: true},
@@ -930,7 +930,7 @@ func TestPlan_providerConfigMerge(t *testing.T) {
 		},
 		ResourceTypes: map[string]providers.Schema{
 			"test_instance": {
-				Block: &configschema.Block{
+				Body: &configschema.Block{
 					Attributes: map[string]*configschema.Attribute{
 						"id": {Type: cty.String, Optional: true, Computed: true},
 					},
@@ -1205,7 +1205,7 @@ func TestPlan_shutdown(t *testing.T) {
 	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
 		ResourceTypes: map[string]providers.Schema{
 			"test_instance": {
-				Block: &configschema.Block{
+				Body: &configschema.Block{
 					Attributes: map[string]*configschema.Attribute{
 						"ami": {Type: cty.String, Optional: true},
 					},
@@ -1262,7 +1262,7 @@ func TestPlan_targeted(t *testing.T) {
 	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
 		ResourceTypes: map[string]providers.Schema{
 			"test_instance": {
-				Block: &configschema.Block{
+				Body: &configschema.Block{
 					Attributes: map[string]*configschema.Attribute{
 						"id": {Type: cty.String, Computed: true},
 					},
@@ -1367,7 +1367,7 @@ func TestPlan_replace(t *testing.T) {
 	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
 		ResourceTypes: map[string]providers.Schema{
 			"test_instance": {
-				Block: &configschema.Block{
+				Body: &configschema.Block{
 					Attributes: map[string]*configschema.Attribute{
 						"id": {Type: cty.String, Computed: true},
 					},
@@ -1443,7 +1443,7 @@ func TestPlan_parallelism(t *testing.T) {
 		provider := &testing_provider.MockProvider{}
 		provider.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
 			ResourceTypes: map[string]providers.Schema{
-				name + "_instance": {Block: &configschema.Block{}},
+				name + "_instance": {Body: &configschema.Block{}},
 			},
 		}
 		provider.PlanResourceChangeFn = func(req providers.PlanResourceChangeRequest) providers.PlanResourceChangeResponse {
@@ -1594,7 +1594,7 @@ func planFixtureSchema() *providers.GetProviderSchemaResponse {
 	return &providers.GetProviderSchemaResponse{
 		ResourceTypes: map[string]providers.Schema{
 			"test_instance": {
-				Block: &configschema.Block{
+				Body: &configschema.Block{
 					Attributes: map[string]*configschema.Attribute{
 						"id":  {Type: cty.String, Optional: true, Computed: true},
 						"ami": {Type: cty.String, Optional: true},
@@ -1615,7 +1615,7 @@ func planFixtureSchema() *providers.GetProviderSchemaResponse {
 		},
 		DataSources: map[string]providers.Schema{
 			"test_data_source": {
-				Block: &configschema.Block{
+				Body: &configschema.Block{
 					Attributes: map[string]*configschema.Attribute{
 						"id": {
 							Type:     cty.String,
@@ -1662,7 +1662,7 @@ func planVarsFixtureSchema() *providers.GetProviderSchemaResponse {
 	return &providers.GetProviderSchemaResponse{
 		ResourceTypes: map[string]providers.Schema{
 			"test_instance": {
-				Block: &configschema.Block{
+				Body: &configschema.Block{
 					Attributes: map[string]*configschema.Attribute{
 						"id":    {Type: cty.String, Optional: true, Computed: true},
 						"value": {Type: cty.String, Optional: true},

--- a/internal/command/providers_schema_test.go
+++ b/internal/command/providers_schema_test.go
@@ -127,7 +127,7 @@ func providersSchemaFixtureProvider() *testing_provider.MockProvider {
 func providersSchemaFixtureSchema() *providers.GetProviderSchemaResponse {
 	return &providers.GetProviderSchemaResponse{
 		Provider: providers.Schema{
-			Block: &configschema.Block{
+			Body: &configschema.Block{
 				Attributes: map[string]*configschema.Attribute{
 					"region": {Type: cty.String, Optional: true},
 				},
@@ -135,7 +135,7 @@ func providersSchemaFixtureSchema() *providers.GetProviderSchemaResponse {
 		},
 		ResourceTypes: map[string]providers.Schema{
 			"test_instance": {
-				Block: &configschema.Block{
+				Body: &configschema.Block{
 					Attributes: map[string]*configschema.Attribute{
 						"id":  {Type: cty.String, Optional: true, Computed: true},
 						"ami": {Type: cty.String, Optional: true},

--- a/internal/command/refresh_test.go
+++ b/internal/command/refresh_test.go
@@ -529,7 +529,7 @@ func TestRefresh_varsUnset(t *testing.T) {
 	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
 		ResourceTypes: map[string]providers.Schema{
 			"test_instance": {
-				Block: &configschema.Block{
+				Body: &configschema.Block{
 					Attributes: map[string]*configschema.Attribute{
 						"id":  {Type: cty.String, Optional: true, Computed: true},
 						"ami": {Type: cty.String, Optional: true},
@@ -729,7 +729,7 @@ func TestRefresh_displaysOutputs(t *testing.T) {
 	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
 		ResourceTypes: map[string]providers.Schema{
 			"test_instance": {
-				Block: &configschema.Block{
+				Body: &configschema.Block{
 					Attributes: map[string]*configschema.Attribute{
 						"id":  {Type: cty.String, Optional: true, Computed: true},
 						"ami": {Type: cty.String, Optional: true},
@@ -769,7 +769,7 @@ func TestRefresh_targeted(t *testing.T) {
 	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
 		ResourceTypes: map[string]providers.Schema{
 			"test_instance": {
-				Block: &configschema.Block{
+				Body: &configschema.Block{
 					Attributes: map[string]*configschema.Attribute{
 						"id": {Type: cty.String, Computed: true},
 					},
@@ -927,7 +927,7 @@ func refreshFixtureSchema() *providers.GetProviderSchemaResponse {
 	return &providers.GetProviderSchemaResponse{
 		ResourceTypes: map[string]providers.Schema{
 			"test_instance": {
-				Block: &configschema.Block{
+				Body: &configschema.Block{
 					Attributes: map[string]*configschema.Attribute{
 						"id":  {Type: cty.String, Optional: true, Computed: true},
 						"ami": {Type: cty.String, Optional: true},
@@ -944,7 +944,7 @@ func refreshFixtureSchema() *providers.GetProviderSchemaResponse {
 func refreshVarFixtureSchema() *providers.GetProviderSchemaResponse {
 	return &providers.GetProviderSchemaResponse{
 		Provider: providers.Schema{
-			Block: &configschema.Block{
+			Body: &configschema.Block{
 				Attributes: map[string]*configschema.Attribute{
 					"value": {Type: cty.String, Optional: true},
 				},
@@ -952,7 +952,7 @@ func refreshVarFixtureSchema() *providers.GetProviderSchemaResponse {
 		},
 		ResourceTypes: map[string]providers.Schema{
 			"test_instance": {
-				Block: &configschema.Block{
+				Body: &configschema.Block{
 					Attributes: map[string]*configschema.Attribute{
 						"id": {Type: cty.String, Optional: true, Computed: true},
 					},

--- a/internal/command/show_test.go
+++ b/internal/command/show_test.go
@@ -1015,7 +1015,7 @@ func TestShow_corruptStatefile(t *testing.T) {
 func showFixtureSchema() *providers.GetProviderSchemaResponse {
 	return &providers.GetProviderSchemaResponse{
 		Provider: providers.Schema{
-			Block: &configschema.Block{
+			Body: &configschema.Block{
 				Attributes: map[string]*configschema.Attribute{
 					"region": {Type: cty.String, Optional: true},
 				},
@@ -1023,7 +1023,7 @@ func showFixtureSchema() *providers.GetProviderSchemaResponse {
 		},
 		ResourceTypes: map[string]providers.Schema{
 			"test_instance": {
-				Block: &configschema.Block{
+				Body: &configschema.Block{
 					Attributes: map[string]*configschema.Attribute{
 						"id":  {Type: cty.String, Optional: true, Computed: true},
 						"ami": {Type: cty.String, Optional: true},
@@ -1040,7 +1040,7 @@ func showFixtureSchema() *providers.GetProviderSchemaResponse {
 func showFixtureSensitiveSchema() *providers.GetProviderSchemaResponse {
 	return &providers.GetProviderSchemaResponse{
 		Provider: providers.Schema{
-			Block: &configschema.Block{
+			Body: &configschema.Block{
 				Attributes: map[string]*configschema.Attribute{
 					"region": {Type: cty.String, Optional: true},
 				},
@@ -1048,7 +1048,7 @@ func showFixtureSensitiveSchema() *providers.GetProviderSchemaResponse {
 		},
 		ResourceTypes: map[string]providers.Schema{
 			"test_instance": {
-				Block: &configschema.Block{
+				Body: &configschema.Block{
 					Attributes: map[string]*configschema.Attribute{
 						"id":       {Type: cty.String, Optional: true, Computed: true},
 						"ami":      {Type: cty.String, Optional: true},

--- a/internal/command/state_show_test.go
+++ b/internal/command/state_show_test.go
@@ -39,7 +39,7 @@ func TestStateShow(t *testing.T) {
 	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
 		ResourceTypes: map[string]providers.Schema{
 			"test_instance": {
-				Block: &configschema.Block{
+				Body: &configschema.Block{
 					Attributes: map[string]*configschema.Attribute{
 						"id":  {Type: cty.String, Optional: true, Computed: true},
 						"foo": {Type: cty.String, Optional: true},
@@ -116,7 +116,7 @@ func TestStateShow_multi(t *testing.T) {
 	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
 		ResourceTypes: map[string]providers.Schema{
 			"test_instance": {
-				Block: &configschema.Block{
+				Body: &configschema.Block{
 					Attributes: map[string]*configschema.Attribute{
 						"id":  {Type: cty.String, Optional: true, Computed: true},
 						"foo": {Type: cty.String, Optional: true},
@@ -227,7 +227,7 @@ func TestStateShow_configured_provider(t *testing.T) {
 	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
 		ResourceTypes: map[string]providers.Schema{
 			"test_instance": {
-				Block: &configschema.Block{
+				Body: &configschema.Block{
 					Attributes: map[string]*configschema.Attribute{
 						"id":  {Type: cty.String, Optional: true, Computed: true},
 						"foo": {Type: cty.String, Optional: true},

--- a/internal/command/testing/test_provider.go
+++ b/internal/command/testing/test_provider.go
@@ -22,7 +22,7 @@ import (
 var (
 	ProviderSchema = &providers.GetProviderSchemaResponse{
 		Provider: providers.Schema{
-			Block: &configschema.Block{
+			Body: &configschema.Block{
 				Attributes: map[string]*configschema.Attribute{
 					"data_prefix":     {Type: cty.String, Optional: true},
 					"resource_prefix": {Type: cty.String, Optional: true},
@@ -31,7 +31,7 @@ var (
 		},
 		ResourceTypes: map[string]providers.Schema{
 			"test_resource": {
-				Block: &configschema.Block{
+				Body: &configschema.Block{
 					Attributes: map[string]*configschema.Attribute{
 						"id":                   {Type: cty.String, Optional: true, Computed: true},
 						"value":                {Type: cty.String, Optional: true},
@@ -45,7 +45,7 @@ var (
 		},
 		DataSources: map[string]providers.Schema{
 			"test_data_source": {
-				Block: &configschema.Block{
+				Body: &configschema.Block{
 					Attributes: map[string]*configschema.Attribute{
 						"id":    {Type: cty.String, Required: true},
 						"value": {Type: cty.String, Computed: true},
@@ -65,7 +65,7 @@ var (
 		},
 		EphemeralResourceTypes: map[string]providers.Schema{
 			"test_ephemeral_resource": {
-				Block: &configschema.Block{
+				Body: &configschema.Block{
 					Attributes: map[string]*configschema.Attribute{
 						"value": {
 							Type:     cty.String,

--- a/internal/command/validate_test.go
+++ b/internal/command/validate_test.go
@@ -28,7 +28,7 @@ func setupTest(t *testing.T, fixturepath string, args ...string) (*terminal.Test
 	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
 		ResourceTypes: map[string]providers.Schema{
 			"test_instance": {
-				Block: &configschema.Block{
+				Body: &configschema.Block{
 					Attributes: map[string]*configschema.Attribute{
 						"ami": {Type: cty.String, Optional: true},
 					},

--- a/internal/command/views/plan_test.go
+++ b/internal/command/views/plan_test.go
@@ -157,11 +157,11 @@ func testProvider() *testing_provider.MockProvider {
 func testProviderSchema() *providers.GetProviderSchemaResponse {
 	return &providers.GetProviderSchemaResponse{
 		Provider: providers.Schema{
-			Block: &configschema.Block{},
+			Body: &configschema.Block{},
 		},
 		ResourceTypes: map[string]providers.Schema{
 			"test_resource": {
-				Block: &configschema.Block{
+				Body: &configschema.Block{
 					Attributes: map[string]*configschema.Attribute{
 						"id":  {Type: cty.String, Computed: true},
 						"foo": {Type: cty.String, Optional: true},
@@ -171,7 +171,7 @@ func testProviderSchema() *providers.GetProviderSchemaResponse {
 		},
 		DataSources: map[string]providers.Schema{
 			"test_data_source": {
-				Block: &configschema.Block{
+				Body: &configschema.Block{
 					Attributes: map[string]*configschema.Attribute{
 						"id":  {Type: cty.String, Required: true},
 						"bar": {Type: cty.String, Optional: true},

--- a/internal/command/views/show_test.go
+++ b/internal/command/views/show_test.go
@@ -184,7 +184,7 @@ func TestShowJSON(t *testing.T) {
 					addrs.NewDefaultProvider("test"): {
 						ResourceTypes: map[string]providers.Schema{
 							"test_resource": {
-								Block: &configschema.Block{
+								Body: &configschema.Block{
 									Attributes: map[string]*configschema.Attribute{
 										"id":  {Type: cty.String, Optional: true, Computed: true},
 										"foo": {Type: cty.String, Optional: true},

--- a/internal/command/views/test_test.go
+++ b/internal/command/views/test_test.go
@@ -626,7 +626,7 @@ something bad happened during this test
 						}: {
 							ResourceTypes: map[string]providers.Schema{
 								"test_resource": {
-									Block: &configschema.Block{
+									Body: &configschema.Block{
 										Attributes: map[string]*configschema.Attribute{
 											"value": {
 												Type: cty.String,
@@ -699,7 +699,7 @@ Plan: 1 to add, 0 to change, 0 to destroy.
 						}: {
 							ResourceTypes: map[string]providers.Schema{
 								"test_resource": {
-									Block: &configschema.Block{
+									Body: &configschema.Block{
 										Attributes: map[string]*configschema.Attribute{
 											"value": {
 												Type: cty.String,
@@ -2747,7 +2747,7 @@ func TestTestJSON_Run(t *testing.T) {
 						}: {
 							ResourceTypes: map[string]providers.Schema{
 								"test_resource": {
-									Block: &configschema.Block{
+									Body: &configschema.Block{
 										Attributes: map[string]*configschema.Attribute{
 											"value": {
 												Type: cty.String,
@@ -2875,7 +2875,7 @@ func TestTestJSON_Run(t *testing.T) {
 						}: {
 							ResourceTypes: map[string]providers.Schema{
 								"test_resource": {
-									Block: &configschema.Block{
+									Body: &configschema.Block{
 										Attributes: map[string]*configschema.Attribute{
 											"value": {
 												Type: cty.String,

--- a/internal/grpcwrap/provider.go
+++ b/internal/grpcwrap/provider.go
@@ -47,27 +47,27 @@ func (p *provider) GetSchema(_ context.Context, req *tfplugin5.GetProviderSchema
 	resp.Provider = &tfplugin5.Schema{
 		Block: &tfplugin5.Schema_Block{},
 	}
-	if p.schema.Provider.Block != nil {
-		resp.Provider.Block = convert.ConfigSchemaToProto(p.schema.Provider.Block)
+	if p.schema.Provider.Body != nil {
+		resp.Provider.Block = convert.ConfigSchemaToProto(p.schema.Provider.Body)
 	}
 
 	resp.ProviderMeta = &tfplugin5.Schema{
 		Block: &tfplugin5.Schema_Block{},
 	}
-	if p.schema.ProviderMeta.Block != nil {
-		resp.ProviderMeta.Block = convert.ConfigSchemaToProto(p.schema.ProviderMeta.Block)
+	if p.schema.ProviderMeta.Body != nil {
+		resp.ProviderMeta.Block = convert.ConfigSchemaToProto(p.schema.ProviderMeta.Body)
 	}
 
 	for typ, res := range p.schema.ResourceTypes {
 		resp.ResourceSchemas[typ] = &tfplugin5.Schema{
 			Version: res.Version,
-			Block:   convert.ConfigSchemaToProto(res.Block),
+			Block:   convert.ConfigSchemaToProto(res.Body),
 		}
 	}
 	for typ, dat := range p.schema.DataSources {
 		resp.DataSourceSchemas[typ] = &tfplugin5.Schema{
 			Version: dat.Version,
-			Block:   convert.ConfigSchemaToProto(dat.Block),
+			Block:   convert.ConfigSchemaToProto(dat.Body),
 		}
 	}
 	if decls, err := convert.FunctionDeclsToProto(p.schema.Functions); err == nil {
@@ -91,7 +91,7 @@ func (p *provider) GetSchema(_ context.Context, req *tfplugin5.GetProviderSchema
 
 func (p *provider) PrepareProviderConfig(_ context.Context, req *tfplugin5.PrepareProviderConfig_Request) (*tfplugin5.PrepareProviderConfig_Response, error) {
 	resp := &tfplugin5.PrepareProviderConfig_Response{}
-	ty := p.schema.Provider.Block.ImpliedType()
+	ty := p.schema.Provider.Body.ImpliedType()
 
 	configVal, err := decodeDynamicValue(req.Config, ty)
 	if err != nil {
@@ -110,7 +110,7 @@ func (p *provider) PrepareProviderConfig(_ context.Context, req *tfplugin5.Prepa
 
 func (p *provider) ValidateResourceTypeConfig(_ context.Context, req *tfplugin5.ValidateResourceTypeConfig_Request) (*tfplugin5.ValidateResourceTypeConfig_Response, error) {
 	resp := &tfplugin5.ValidateResourceTypeConfig_Response{}
-	ty := p.schema.ResourceTypes[req.TypeName].Block.ImpliedType()
+	ty := p.schema.ResourceTypes[req.TypeName].Body.ImpliedType()
 
 	configVal, err := decodeDynamicValue(req.Config, ty)
 	if err != nil {
@@ -133,7 +133,7 @@ func (p *provider) ValidateResourceTypeConfig(_ context.Context, req *tfplugin5.
 
 func (p *provider) ValidateDataSourceConfig(_ context.Context, req *tfplugin5.ValidateDataSourceConfig_Request) (*tfplugin5.ValidateDataSourceConfig_Response, error) {
 	resp := &tfplugin5.ValidateDataSourceConfig_Response{}
-	ty := p.schema.DataSources[req.TypeName].Block.ImpliedType()
+	ty := p.schema.DataSources[req.TypeName].Body.ImpliedType()
 
 	configVal, err := decodeDynamicValue(req.Config, ty)
 	if err != nil {
@@ -152,7 +152,7 @@ func (p *provider) ValidateDataSourceConfig(_ context.Context, req *tfplugin5.Va
 
 func (p *provider) ValidateEphemeralResourceConfig(_ context.Context, req *tfplugin5.ValidateEphemeralResourceConfig_Request) (*tfplugin5.ValidateEphemeralResourceConfig_Response, error) {
 	resp := &tfplugin5.ValidateEphemeralResourceConfig_Response{}
-	ty := p.schema.DataSources[req.TypeName].Block.ImpliedType()
+	ty := p.schema.DataSources[req.TypeName].Body.ImpliedType()
 
 	configVal, err := decodeDynamicValue(req.Config, ty)
 	if err != nil {
@@ -171,7 +171,7 @@ func (p *provider) ValidateEphemeralResourceConfig(_ context.Context, req *tfplu
 
 func (p *provider) UpgradeResourceState(_ context.Context, req *tfplugin5.UpgradeResourceState_Request) (*tfplugin5.UpgradeResourceState_Response, error) {
 	resp := &tfplugin5.UpgradeResourceState_Response{}
-	ty := p.schema.ResourceTypes[req.TypeName].Block.ImpliedType()
+	ty := p.schema.ResourceTypes[req.TypeName].Body.ImpliedType()
 
 	upgradeResp := p.provider.UpgradeResourceState(providers.UpgradeResourceStateRequest{
 		TypeName:     req.TypeName,
@@ -197,7 +197,7 @@ func (p *provider) UpgradeResourceState(_ context.Context, req *tfplugin5.Upgrad
 
 func (p *provider) Configure(_ context.Context, req *tfplugin5.Configure_Request) (*tfplugin5.Configure_Response, error) {
 	resp := &tfplugin5.Configure_Response{}
-	ty := p.schema.Provider.Block.ImpliedType()
+	ty := p.schema.Provider.Body.ImpliedType()
 
 	configVal, err := decodeDynamicValue(req.Config, ty)
 	if err != nil {
@@ -216,7 +216,7 @@ func (p *provider) Configure(_ context.Context, req *tfplugin5.Configure_Request
 
 func (p *provider) ReadResource(_ context.Context, req *tfplugin5.ReadResource_Request) (*tfplugin5.ReadResource_Response, error) {
 	resp := &tfplugin5.ReadResource_Response{}
-	ty := p.schema.ResourceTypes[req.TypeName].Block.ImpliedType()
+	ty := p.schema.ResourceTypes[req.TypeName].Body.ImpliedType()
 
 	stateVal, err := decodeDynamicValue(req.CurrentState, ty)
 	if err != nil {
@@ -224,7 +224,7 @@ func (p *provider) ReadResource(_ context.Context, req *tfplugin5.ReadResource_R
 		return resp, nil
 	}
 
-	metaTy := p.schema.ProviderMeta.Block.ImpliedType()
+	metaTy := p.schema.ProviderMeta.Body.ImpliedType()
 	metaVal, err := decodeDynamicValue(req.ProviderMeta, metaTy)
 	if err != nil {
 		resp.Diagnostics = convert.AppendProtoDiag(resp.Diagnostics, err)
@@ -255,7 +255,7 @@ func (p *provider) ReadResource(_ context.Context, req *tfplugin5.ReadResource_R
 
 func (p *provider) PlanResourceChange(_ context.Context, req *tfplugin5.PlanResourceChange_Request) (*tfplugin5.PlanResourceChange_Response, error) {
 	resp := &tfplugin5.PlanResourceChange_Response{}
-	ty := p.schema.ResourceTypes[req.TypeName].Block.ImpliedType()
+	ty := p.schema.ResourceTypes[req.TypeName].Body.ImpliedType()
 
 	priorStateVal, err := decodeDynamicValue(req.PriorState, ty)
 	if err != nil {
@@ -275,7 +275,7 @@ func (p *provider) PlanResourceChange(_ context.Context, req *tfplugin5.PlanReso
 		return resp, nil
 	}
 
-	metaTy := p.schema.ProviderMeta.Block.ImpliedType()
+	metaTy := p.schema.ProviderMeta.Body.ImpliedType()
 	metaVal, err := decodeDynamicValue(req.ProviderMeta, metaTy)
 	if err != nil {
 		resp.Diagnostics = convert.AppendProtoDiag(resp.Diagnostics, err)
@@ -312,7 +312,7 @@ func (p *provider) PlanResourceChange(_ context.Context, req *tfplugin5.PlanReso
 
 func (p *provider) ApplyResourceChange(_ context.Context, req *tfplugin5.ApplyResourceChange_Request) (*tfplugin5.ApplyResourceChange_Response, error) {
 	resp := &tfplugin5.ApplyResourceChange_Response{}
-	ty := p.schema.ResourceTypes[req.TypeName].Block.ImpliedType()
+	ty := p.schema.ResourceTypes[req.TypeName].Body.ImpliedType()
 
 	priorStateVal, err := decodeDynamicValue(req.PriorState, ty)
 	if err != nil {
@@ -332,7 +332,7 @@ func (p *provider) ApplyResourceChange(_ context.Context, req *tfplugin5.ApplyRe
 		return resp, nil
 	}
 
-	metaTy := p.schema.ProviderMeta.Block.ImpliedType()
+	metaTy := p.schema.ProviderMeta.Body.ImpliedType()
 	metaVal, err := decodeDynamicValue(req.ProviderMeta, metaTy)
 	if err != nil {
 		resp.Diagnostics = convert.AppendProtoDiag(resp.Diagnostics, err)
@@ -373,7 +373,7 @@ func (p *provider) ImportResourceState(_ context.Context, req *tfplugin5.ImportR
 	resp.Diagnostics = convert.AppendProtoDiag(resp.Diagnostics, importResp.Diagnostics)
 
 	for _, res := range importResp.ImportedResources {
-		ty := p.schema.ResourceTypes[res.TypeName].Block.ImpliedType()
+		ty := p.schema.ResourceTypes[res.TypeName].Body.ImpliedType()
 		state, err := encodeDynamicValue(res.State, ty)
 		if err != nil {
 			resp.Diagnostics = convert.AppendProtoDiag(resp.Diagnostics, err)
@@ -406,7 +406,7 @@ func (p *provider) MoveResourceState(_ context.Context, request *tfplugin5.MoveR
 		return resp, nil
 	}
 
-	targetType := p.schema.ResourceTypes[request.TargetTypeName].Block.ImpliedType()
+	targetType := p.schema.ResourceTypes[request.TargetTypeName].Body.ImpliedType()
 	targetState, err := encodeDynamicValue(moveResp.TargetState, targetType)
 	if err != nil {
 		resp.Diagnostics = convert.AppendProtoDiag(resp.Diagnostics, err)
@@ -419,7 +419,7 @@ func (p *provider) MoveResourceState(_ context.Context, request *tfplugin5.MoveR
 
 func (p *provider) ReadDataSource(_ context.Context, req *tfplugin5.ReadDataSource_Request) (*tfplugin5.ReadDataSource_Response, error) {
 	resp := &tfplugin5.ReadDataSource_Response{}
-	ty := p.schema.DataSources[req.TypeName].Block.ImpliedType()
+	ty := p.schema.DataSources[req.TypeName].Body.ImpliedType()
 
 	configVal, err := decodeDynamicValue(req.Config, ty)
 	if err != nil {
@@ -427,7 +427,7 @@ func (p *provider) ReadDataSource(_ context.Context, req *tfplugin5.ReadDataSour
 		return resp, nil
 	}
 
-	metaTy := p.schema.ProviderMeta.Block.ImpliedType()
+	metaTy := p.schema.ProviderMeta.Body.ImpliedType()
 	metaVal, err := decodeDynamicValue(req.ProviderMeta, metaTy)
 	if err != nil {
 		resp.Diagnostics = convert.AppendProtoDiag(resp.Diagnostics, err)

--- a/internal/grpcwrap/provider6.go
+++ b/internal/grpcwrap/provider6.go
@@ -49,33 +49,33 @@ func (p *provider6) GetProviderSchema(_ context.Context, req *tfplugin6.GetProvi
 	resp.Provider = &tfplugin6.Schema{
 		Block: &tfplugin6.Schema_Block{},
 	}
-	if p.schema.Provider.Block != nil {
-		resp.Provider.Block = convert.ConfigSchemaToProto(p.schema.Provider.Block)
+	if p.schema.Provider.Body != nil {
+		resp.Provider.Block = convert.ConfigSchemaToProto(p.schema.Provider.Body)
 	}
 
 	resp.ProviderMeta = &tfplugin6.Schema{
 		Block: &tfplugin6.Schema_Block{},
 	}
-	if p.schema.ProviderMeta.Block != nil {
-		resp.ProviderMeta.Block = convert.ConfigSchemaToProto(p.schema.ProviderMeta.Block)
+	if p.schema.ProviderMeta.Body != nil {
+		resp.ProviderMeta.Block = convert.ConfigSchemaToProto(p.schema.ProviderMeta.Body)
 	}
 
 	for typ, res := range p.schema.ResourceTypes {
 		resp.ResourceSchemas[typ] = &tfplugin6.Schema{
 			Version: res.Version,
-			Block:   convert.ConfigSchemaToProto(res.Block),
+			Block:   convert.ConfigSchemaToProto(res.Body),
 		}
 	}
 	for typ, dat := range p.schema.DataSources {
 		resp.DataSourceSchemas[typ] = &tfplugin6.Schema{
 			Version: dat.Version,
-			Block:   convert.ConfigSchemaToProto(dat.Block),
+			Block:   convert.ConfigSchemaToProto(dat.Body),
 		}
 	}
 	for typ, dat := range p.schema.EphemeralResourceTypes {
 		resp.EphemeralResourceSchemas[typ] = &tfplugin6.Schema{
 			Version: dat.Version,
-			Block:   convert.ConfigSchemaToProto(dat.Block),
+			Block:   convert.ConfigSchemaToProto(dat.Body),
 		}
 	}
 	if decls, err := convert.FunctionDeclsToProto(p.schema.Functions); err == nil {
@@ -99,7 +99,7 @@ func (p *provider6) GetProviderSchema(_ context.Context, req *tfplugin6.GetProvi
 
 func (p *provider6) ValidateProviderConfig(_ context.Context, req *tfplugin6.ValidateProviderConfig_Request) (*tfplugin6.ValidateProviderConfig_Response, error) {
 	resp := &tfplugin6.ValidateProviderConfig_Response{}
-	ty := p.schema.Provider.Block.ImpliedType()
+	ty := p.schema.Provider.Body.ImpliedType()
 
 	configVal, err := decodeDynamicValue6(req.Config, ty)
 	if err != nil {
@@ -118,7 +118,7 @@ func (p *provider6) ValidateProviderConfig(_ context.Context, req *tfplugin6.Val
 
 func (p *provider6) ValidateResourceConfig(_ context.Context, req *tfplugin6.ValidateResourceConfig_Request) (*tfplugin6.ValidateResourceConfig_Response, error) {
 	resp := &tfplugin6.ValidateResourceConfig_Response{}
-	ty := p.schema.ResourceTypes[req.TypeName].Block.ImpliedType()
+	ty := p.schema.ResourceTypes[req.TypeName].Body.ImpliedType()
 
 	configVal, err := decodeDynamicValue6(req.Config, ty)
 	if err != nil {
@@ -137,7 +137,7 @@ func (p *provider6) ValidateResourceConfig(_ context.Context, req *tfplugin6.Val
 
 func (p *provider6) ValidateDataResourceConfig(_ context.Context, req *tfplugin6.ValidateDataResourceConfig_Request) (*tfplugin6.ValidateDataResourceConfig_Response, error) {
 	resp := &tfplugin6.ValidateDataResourceConfig_Response{}
-	ty := p.schema.DataSources[req.TypeName].Block.ImpliedType()
+	ty := p.schema.DataSources[req.TypeName].Body.ImpliedType()
 
 	configVal, err := decodeDynamicValue6(req.Config, ty)
 	if err != nil {
@@ -156,7 +156,7 @@ func (p *provider6) ValidateDataResourceConfig(_ context.Context, req *tfplugin6
 
 func (p *provider6) ValidateEphemeralResourceConfig(_ context.Context, req *tfplugin6.ValidateEphemeralResourceConfig_Request) (*tfplugin6.ValidateEphemeralResourceConfig_Response, error) {
 	resp := &tfplugin6.ValidateEphemeralResourceConfig_Response{}
-	ty := p.schema.DataSources[req.TypeName].Block.ImpliedType()
+	ty := p.schema.DataSources[req.TypeName].Body.ImpliedType()
 
 	configVal, err := decodeDynamicValue6(req.Config, ty)
 	if err != nil {
@@ -175,7 +175,7 @@ func (p *provider6) ValidateEphemeralResourceConfig(_ context.Context, req *tfpl
 
 func (p *provider6) UpgradeResourceState(_ context.Context, req *tfplugin6.UpgradeResourceState_Request) (*tfplugin6.UpgradeResourceState_Response, error) {
 	resp := &tfplugin6.UpgradeResourceState_Response{}
-	ty := p.schema.ResourceTypes[req.TypeName].Block.ImpliedType()
+	ty := p.schema.ResourceTypes[req.TypeName].Body.ImpliedType()
 
 	upgradeResp := p.provider.UpgradeResourceState(providers.UpgradeResourceStateRequest{
 		TypeName:     req.TypeName,
@@ -201,7 +201,7 @@ func (p *provider6) UpgradeResourceState(_ context.Context, req *tfplugin6.Upgra
 
 func (p *provider6) ConfigureProvider(_ context.Context, req *tfplugin6.ConfigureProvider_Request) (*tfplugin6.ConfigureProvider_Response, error) {
 	resp := &tfplugin6.ConfigureProvider_Response{}
-	ty := p.schema.Provider.Block.ImpliedType()
+	ty := p.schema.Provider.Body.ImpliedType()
 
 	configVal, err := decodeDynamicValue6(req.Config, ty)
 	if err != nil {
@@ -220,7 +220,7 @@ func (p *provider6) ConfigureProvider(_ context.Context, req *tfplugin6.Configur
 
 func (p *provider6) ReadResource(_ context.Context, req *tfplugin6.ReadResource_Request) (*tfplugin6.ReadResource_Response, error) {
 	resp := &tfplugin6.ReadResource_Response{}
-	ty := p.schema.ResourceTypes[req.TypeName].Block.ImpliedType()
+	ty := p.schema.ResourceTypes[req.TypeName].Body.ImpliedType()
 
 	stateVal, err := decodeDynamicValue6(req.CurrentState, ty)
 	if err != nil {
@@ -228,7 +228,7 @@ func (p *provider6) ReadResource(_ context.Context, req *tfplugin6.ReadResource_
 		return resp, nil
 	}
 
-	metaTy := p.schema.ProviderMeta.Block.ImpliedType()
+	metaTy := p.schema.ProviderMeta.Body.ImpliedType()
 	metaVal, err := decodeDynamicValue6(req.ProviderMeta, metaTy)
 	if err != nil {
 		resp.Diagnostics = convert.AppendProtoDiag(resp.Diagnostics, err)
@@ -259,7 +259,7 @@ func (p *provider6) ReadResource(_ context.Context, req *tfplugin6.ReadResource_
 
 func (p *provider6) PlanResourceChange(_ context.Context, req *tfplugin6.PlanResourceChange_Request) (*tfplugin6.PlanResourceChange_Response, error) {
 	resp := &tfplugin6.PlanResourceChange_Response{}
-	ty := p.schema.ResourceTypes[req.TypeName].Block.ImpliedType()
+	ty := p.schema.ResourceTypes[req.TypeName].Body.ImpliedType()
 
 	priorStateVal, err := decodeDynamicValue6(req.PriorState, ty)
 	if err != nil {
@@ -279,7 +279,7 @@ func (p *provider6) PlanResourceChange(_ context.Context, req *tfplugin6.PlanRes
 		return resp, nil
 	}
 
-	metaTy := p.schema.ProviderMeta.Block.ImpliedType()
+	metaTy := p.schema.ProviderMeta.Body.ImpliedType()
 	metaVal, err := decodeDynamicValue6(req.ProviderMeta, metaTy)
 	if err != nil {
 		resp.Diagnostics = convert.AppendProtoDiag(resp.Diagnostics, err)
@@ -316,7 +316,7 @@ func (p *provider6) PlanResourceChange(_ context.Context, req *tfplugin6.PlanRes
 
 func (p *provider6) ApplyResourceChange(_ context.Context, req *tfplugin6.ApplyResourceChange_Request) (*tfplugin6.ApplyResourceChange_Response, error) {
 	resp := &tfplugin6.ApplyResourceChange_Response{}
-	ty := p.schema.ResourceTypes[req.TypeName].Block.ImpliedType()
+	ty := p.schema.ResourceTypes[req.TypeName].Body.ImpliedType()
 
 	priorStateVal, err := decodeDynamicValue6(req.PriorState, ty)
 	if err != nil {
@@ -336,7 +336,7 @@ func (p *provider6) ApplyResourceChange(_ context.Context, req *tfplugin6.ApplyR
 		return resp, nil
 	}
 
-	metaTy := p.schema.ProviderMeta.Block.ImpliedType()
+	metaTy := p.schema.ProviderMeta.Body.ImpliedType()
 	metaVal, err := decodeDynamicValue6(req.ProviderMeta, metaTy)
 	if err != nil {
 		resp.Diagnostics = convert.AppendProtoDiag(resp.Diagnostics, err)
@@ -377,7 +377,7 @@ func (p *provider6) ImportResourceState(_ context.Context, req *tfplugin6.Import
 	resp.Diagnostics = convert.AppendProtoDiag(resp.Diagnostics, importResp.Diagnostics)
 
 	for _, res := range importResp.ImportedResources {
-		ty := p.schema.ResourceTypes[res.TypeName].Block.ImpliedType()
+		ty := p.schema.ResourceTypes[res.TypeName].Body.ImpliedType()
 		state, err := encodeDynamicValue6(res.State, ty)
 		if err != nil {
 			resp.Diagnostics = convert.AppendProtoDiag(resp.Diagnostics, err)
@@ -410,7 +410,7 @@ func (p *provider6) MoveResourceState(_ context.Context, request *tfplugin6.Move
 		return resp, nil
 	}
 
-	targetType := p.schema.ResourceTypes[request.TargetTypeName].Block.ImpliedType()
+	targetType := p.schema.ResourceTypes[request.TargetTypeName].Body.ImpliedType()
 	targetState, err := encodeDynamicValue6(moveResp.TargetState, targetType)
 	if err != nil {
 		resp.Diagnostics = convert.AppendProtoDiag(resp.Diagnostics, err)
@@ -423,7 +423,7 @@ func (p *provider6) MoveResourceState(_ context.Context, request *tfplugin6.Move
 
 func (p *provider6) ReadDataSource(_ context.Context, req *tfplugin6.ReadDataSource_Request) (*tfplugin6.ReadDataSource_Response, error) {
 	resp := &tfplugin6.ReadDataSource_Response{}
-	ty := p.schema.DataSources[req.TypeName].Block.ImpliedType()
+	ty := p.schema.DataSources[req.TypeName].Body.ImpliedType()
 
 	configVal, err := decodeDynamicValue6(req.Config, ty)
 	if err != nil {
@@ -431,7 +431,7 @@ func (p *provider6) ReadDataSource(_ context.Context, req *tfplugin6.ReadDataSou
 		return resp, nil
 	}
 
-	metaTy := p.schema.ProviderMeta.Block.ImpliedType()
+	metaTy := p.schema.ProviderMeta.Body.ImpliedType()
 	metaVal, err := decodeDynamicValue6(req.ProviderMeta, metaTy)
 	if err != nil {
 		resp.Diagnostics = convert.AppendProtoDiag(resp.Diagnostics, err)
@@ -459,7 +459,7 @@ func (p *provider6) ReadDataSource(_ context.Context, req *tfplugin6.ReadDataSou
 
 func (p *provider6) OpenEphemeralResource(_ context.Context, req *tfplugin6.OpenEphemeralResource_Request) (*tfplugin6.OpenEphemeralResource_Response, error) {
 	resp := &tfplugin6.OpenEphemeralResource_Response{}
-	ty := p.schema.EphemeralResourceTypes[req.TypeName].Block.ImpliedType()
+	ty := p.schema.EphemeralResourceTypes[req.TypeName].Body.ImpliedType()
 
 	configVal, err := decodeDynamicValue6(req.Config, ty)
 	if err != nil {

--- a/internal/lang/globalref/analyzer_test.go
+++ b/internal/lang/globalref/analyzer_test.go
@@ -91,12 +91,12 @@ func testAnalyzer(t *testing.T, fixtureName string) *Analyzer {
 		addrs.MustParseProviderSourceString("hashicorp/test"): {
 			ResourceTypes: map[string]providers.Schema{
 				"test_thing": {
-					Block: resourceTypeSchema,
+					Body: resourceTypeSchema,
 				},
 			},
 			DataSources: map[string]providers.Schema{
 				"test_thing": {
-					Block: resourceTypeSchema,
+					Body: resourceTypeSchema,
 				},
 			},
 		},

--- a/internal/legacy/helper/schema/shims_test.go
+++ b/internal/legacy/helper/schema/shims_test.go
@@ -36,15 +36,15 @@ func testApplyDiff(t *testing.T,
 
 	testSchema := providers.Schema{
 		Version: int64(resource.SchemaVersion),
-		Block:   resourceSchemaToBlock(resource.Schema),
+		Body:    resourceSchemaToBlock(resource.Schema),
 	}
 
-	stateVal, err := StateValueFromInstanceState(state, testSchema.Block.ImpliedType())
+	stateVal, err := StateValueFromInstanceState(state, testSchema.Body.ImpliedType())
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	newState, err := ApplyDiff(stateVal, diff, testSchema.Block)
+	newState, err := ApplyDiff(stateVal, diff, testSchema.Body)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -72,7 +72,7 @@ func testApplyDiff(t *testing.T,
 
 	// Resource.Meta will be hanlded separately, so it's OK that we lose the
 	// timeout values here.
-	expectedState, err := StateValueFromInstanceState(expected, testSchema.Block.ImpliedType())
+	expectedState, err := StateValueFromInstanceState(expected, testSchema.Body.ImpliedType())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -334,15 +334,15 @@ func TestShimResourceDiff_Timeout_diff(t *testing.T) {
 
 	testSchema := providers.Schema{
 		Version: int64(r.SchemaVersion),
-		Block:   resourceSchemaToBlock(r.Schema),
+		Body:    resourceSchemaToBlock(r.Schema),
 	}
 
-	initialVal, err := StateValueFromInstanceState(createdState, testSchema.Block.ImpliedType())
+	initialVal, err := StateValueFromInstanceState(createdState, testSchema.Body.ImpliedType())
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	appliedVal, err := StateValueFromInstanceState(applied, testSchema.Block.ImpliedType())
+	appliedVal, err := StateValueFromInstanceState(applied, testSchema.Body.ImpliedType())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/moduletest/graph/eval_context_test.go
+++ b/internal/moduletest/graph/eval_context_test.go
@@ -88,7 +88,7 @@ func TestEvalContext_Evaluate(t *testing.T) {
 				GetProviderSchemaResponse: &providers.GetProviderSchemaResponse{
 					ResourceTypes: map[string]providers.Schema{
 						"test_resource": {
-							Block: &configschema.Block{
+							Body: &configschema.Block{
 								Attributes: map[string]*configschema.Attribute{
 									"value": {
 										Type:     cty.String,
@@ -157,7 +157,7 @@ func TestEvalContext_Evaluate(t *testing.T) {
 				GetProviderSchemaResponse: &providers.GetProviderSchemaResponse{
 					ResourceTypes: map[string]providers.Schema{
 						"test_resource": {
-							Block: &configschema.Block{
+							Body: &configschema.Block{
 								Attributes: map[string]*configschema.Attribute{
 									"value": {
 										Type:     cty.String,
@@ -213,7 +213,7 @@ func TestEvalContext_Evaluate(t *testing.T) {
 				GetProviderSchemaResponse: &providers.GetProviderSchemaResponse{
 					ResourceTypes: map[string]providers.Schema{
 						"test_resource": {
-							Block: &configschema.Block{
+							Body: &configschema.Block{
 								Attributes: map[string]*configschema.Attribute{
 									"value": {
 										Type:     cty.String,
@@ -280,7 +280,7 @@ func TestEvalContext_Evaluate(t *testing.T) {
 				GetProviderSchemaResponse: &providers.GetProviderSchemaResponse{
 					ResourceTypes: map[string]providers.Schema{
 						"test_resource": {
-							Block: &configschema.Block{
+							Body: &configschema.Block{
 								Attributes: map[string]*configschema.Attribute{
 									"value": {
 										Type:     cty.String,
@@ -459,7 +459,7 @@ func TestEvalContext_Evaluate(t *testing.T) {
 				GetProviderSchemaResponse: &providers.GetProviderSchemaResponse{
 					ResourceTypes: map[string]providers.Schema{
 						"test_resource": {
-							Block: &configschema.Block{
+							Body: &configschema.Block{
 								Attributes: map[string]*configschema.Attribute{
 									"value": {
 										Type:     cty.String,
@@ -538,7 +538,7 @@ func TestEvalContext_Evaluate(t *testing.T) {
 				GetProviderSchemaResponse: &providers.GetProviderSchemaResponse{
 					ResourceTypes: map[string]providers.Schema{
 						"test_resource": {
-							Block: &configschema.Block{
+							Body: &configschema.Block{
 								Attributes: map[string]*configschema.Attribute{
 									"value": {
 										Type:     cty.String,
@@ -607,7 +607,7 @@ func TestEvalContext_Evaluate(t *testing.T) {
 				GetProviderSchemaResponse: &providers.GetProviderSchemaResponse{
 					ResourceTypes: map[string]providers.Schema{
 						"test_resource": {
-							Block: &configschema.Block{
+							Body: &configschema.Block{
 								Attributes: map[string]*configschema.Attribute{
 									"value": {
 										Type:     cty.String,

--- a/internal/plans/changes.go
+++ b/internal/plans/changes.go
@@ -60,11 +60,11 @@ func (c *Changes) Encode(schemas *schemarepo.Schemas) (*ChangesSrc, error) {
 			panic(fmt.Sprintf("unexpected resource mode %s", rc.Addr.Resource.Resource.Mode))
 		}
 
-		if schema.Block == nil {
+		if schema.Body == nil {
 			return changesSrc, fmt.Errorf("Changes.Encode: missing schema for %s", rc.Addr)
 		}
 
-		rcs, err := rc.Encode(schema.Block.ImpliedType())
+		rcs, err := rc.Encode(schema.Body.ImpliedType())
 		if err != nil {
 			return changesSrc, fmt.Errorf("Changes.Encode: %w", err)
 		}

--- a/internal/plans/changes_src.go
+++ b/internal/plans/changes_src.go
@@ -118,11 +118,11 @@ func (c *ChangesSrc) Decode(schemas *schemarepo.Schemas) (*Changes, error) {
 			panic(fmt.Sprintf("unexpected resource mode %s", rcs.Addr.Resource.Resource.Mode))
 		}
 
-		if schema.Block == nil {
+		if schema.Body == nil {
 			return nil, fmt.Errorf("ChangesSrc.Decode: missing schema for %s", rcs.Addr)
 		}
 
-		rc, err := rcs.Decode(schema.Block.ImpliedType())
+		rc, err := rcs.Decode(schema.Body.ImpliedType())
 		if err != nil {
 			return nil, err
 		}

--- a/internal/plugin/convert/schema.go
+++ b/internal/plugin/convert/schema.go
@@ -93,7 +93,7 @@ func protoSchemaNestedBlock(name string, b *configschema.NestedBlock) *proto.Sch
 func ProtoToProviderSchema(s *proto.Schema) providers.Schema {
 	return providers.Schema{
 		Version: s.Version,
-		Block:   ProtoToConfigSchema(s.Block),
+		Body:    ProtoToConfigSchema(s.Block),
 	}
 }
 

--- a/internal/plugin/grpc_provider.go
+++ b/internal/plugin/grpc_provider.go
@@ -93,7 +93,7 @@ func (p *GRPCProvider) GetProviderSchema() providers.GetProviderSchemaResponse {
 
 	// If the local cache is non-zero, we know this instance has called
 	// GetProviderSchema at least once and we can return early.
-	if p.schema.Provider.Block != nil {
+	if p.schema.Provider.Body != nil {
 		return p.schema
 	}
 
@@ -185,7 +185,7 @@ func (p *GRPCProvider) ValidateProviderConfig(r providers.ValidateProviderConfig
 		return resp
 	}
 
-	ty := schema.Provider.Block.ImpliedType()
+	ty := schema.Provider.Body.ImpliedType()
 
 	mp, err := msgpack.Marshal(r.Config, ty)
 	if err != nil {
@@ -229,7 +229,7 @@ func (p *GRPCProvider) ValidateResourceConfig(r providers.ValidateResourceConfig
 		return resp
 	}
 
-	mp, err := msgpack.Marshal(r.Config, resourceSchema.Block.ImpliedType())
+	mp, err := msgpack.Marshal(r.Config, resourceSchema.Body.ImpliedType())
 	if err != nil {
 		resp.Diagnostics = resp.Diagnostics.Append(err)
 		return resp
@@ -266,7 +266,7 @@ func (p *GRPCProvider) ValidateDataResourceConfig(r providers.ValidateDataResour
 		return resp
 	}
 
-	mp, err := msgpack.Marshal(r.Config, dataSchema.Block.ImpliedType())
+	mp, err := msgpack.Marshal(r.Config, dataSchema.Body.ImpliedType())
 	if err != nil {
 		resp.Diagnostics = resp.Diagnostics.Append(err)
 		return resp
@@ -317,7 +317,7 @@ func (p *GRPCProvider) UpgradeResourceState(r providers.UpgradeResourceStateRequ
 	}
 	resp.Diagnostics = resp.Diagnostics.Append(convert.ProtoToDiagnostics(protoResp.Diagnostics))
 
-	ty := resSchema.Block.ImpliedType()
+	ty := resSchema.Body.ImpliedType()
 	resp.UpgradedState = cty.NullVal(ty)
 	if protoResp.UpgradedState == nil {
 		return resp
@@ -345,7 +345,7 @@ func (p *GRPCProvider) ConfigureProvider(r providers.ConfigureProviderRequest) (
 	var mp []byte
 
 	// we don't have anything to marshal if there's no config
-	mp, err := msgpack.Marshal(r.Config, schema.Provider.Block.ImpliedType())
+	mp, err := msgpack.Marshal(r.Config, schema.Provider.Body.ImpliedType())
 	if err != nil {
 		resp.Diagnostics = resp.Diagnostics.Append(err)
 		return resp
@@ -399,7 +399,7 @@ func (p *GRPCProvider) ReadResource(r providers.ReadResourceRequest) (resp provi
 
 	metaSchema := schema.ProviderMeta
 
-	mp, err := msgpack.Marshal(r.PriorState, resSchema.Block.ImpliedType())
+	mp, err := msgpack.Marshal(r.PriorState, resSchema.Body.ImpliedType())
 	if err != nil {
 		resp.Diagnostics = resp.Diagnostics.Append(err)
 		return resp
@@ -412,8 +412,8 @@ func (p *GRPCProvider) ReadResource(r providers.ReadResourceRequest) (resp provi
 		ClientCapabilities: clientCapabilitiesToProto(r.ClientCapabilities),
 	}
 
-	if metaSchema.Block != nil {
-		metaMP, err := msgpack.Marshal(r.ProviderMeta, metaSchema.Block.ImpliedType())
+	if metaSchema.Body != nil {
+		metaMP, err := msgpack.Marshal(r.ProviderMeta, metaSchema.Body.ImpliedType())
 		if err != nil {
 			resp.Diagnostics = resp.Diagnostics.Append(err)
 			return resp
@@ -429,7 +429,7 @@ func (p *GRPCProvider) ReadResource(r providers.ReadResourceRequest) (resp provi
 	resp.Deferred = convert.ProtoToDeferred(protoResp.Deferred)
 	resp.Diagnostics = resp.Diagnostics.Append(convert.ProtoToDiagnostics(protoResp.Diagnostics))
 
-	state, err := decodeDynamicValue(protoResp.NewState, resSchema.Block.ImpliedType())
+	state, err := decodeDynamicValue(protoResp.NewState, resSchema.Body.ImpliedType())
 	if err != nil {
 		resp.Diagnostics = resp.Diagnostics.Append(err)
 		return resp
@@ -466,19 +466,19 @@ func (p *GRPCProvider) PlanResourceChange(r providers.PlanResourceChangeRequest)
 		return resp
 	}
 
-	priorMP, err := msgpack.Marshal(r.PriorState, resSchema.Block.ImpliedType())
+	priorMP, err := msgpack.Marshal(r.PriorState, resSchema.Body.ImpliedType())
 	if err != nil {
 		resp.Diagnostics = resp.Diagnostics.Append(err)
 		return resp
 	}
 
-	configMP, err := msgpack.Marshal(r.Config, resSchema.Block.ImpliedType())
+	configMP, err := msgpack.Marshal(r.Config, resSchema.Body.ImpliedType())
 	if err != nil {
 		resp.Diagnostics = resp.Diagnostics.Append(err)
 		return resp
 	}
 
-	propMP, err := msgpack.Marshal(r.ProposedNewState, resSchema.Block.ImpliedType())
+	propMP, err := msgpack.Marshal(r.ProposedNewState, resSchema.Body.ImpliedType())
 	if err != nil {
 		resp.Diagnostics = resp.Diagnostics.Append(err)
 		return resp
@@ -493,8 +493,8 @@ func (p *GRPCProvider) PlanResourceChange(r providers.PlanResourceChangeRequest)
 		ClientCapabilities: clientCapabilitiesToProto(r.ClientCapabilities),
 	}
 
-	if metaSchema.Block != nil {
-		metaTy := metaSchema.Block.ImpliedType()
+	if metaSchema.Body != nil {
+		metaTy := metaSchema.Body.ImpliedType()
 		metaVal := r.ProviderMeta
 		if metaVal == cty.NilVal {
 			metaVal = cty.NullVal(metaTy)
@@ -514,7 +514,7 @@ func (p *GRPCProvider) PlanResourceChange(r providers.PlanResourceChangeRequest)
 	}
 	resp.Diagnostics = resp.Diagnostics.Append(convert.ProtoToDiagnostics(protoResp.Diagnostics))
 
-	state, err := decodeDynamicValue(protoResp.PlannedState, resSchema.Block.ImpliedType())
+	state, err := decodeDynamicValue(protoResp.PlannedState, resSchema.Body.ImpliedType())
 	if err != nil {
 		resp.Diagnostics = resp.Diagnostics.Append(err)
 		return resp
@@ -551,17 +551,17 @@ func (p *GRPCProvider) ApplyResourceChange(r providers.ApplyResourceChangeReques
 
 	metaSchema := schema.ProviderMeta
 
-	priorMP, err := msgpack.Marshal(r.PriorState, resSchema.Block.ImpliedType())
+	priorMP, err := msgpack.Marshal(r.PriorState, resSchema.Body.ImpliedType())
 	if err != nil {
 		resp.Diagnostics = resp.Diagnostics.Append(err)
 		return resp
 	}
-	plannedMP, err := msgpack.Marshal(r.PlannedState, resSchema.Block.ImpliedType())
+	plannedMP, err := msgpack.Marshal(r.PlannedState, resSchema.Body.ImpliedType())
 	if err != nil {
 		resp.Diagnostics = resp.Diagnostics.Append(err)
 		return resp
 	}
-	configMP, err := msgpack.Marshal(r.Config, resSchema.Block.ImpliedType())
+	configMP, err := msgpack.Marshal(r.Config, resSchema.Body.ImpliedType())
 	if err != nil {
 		resp.Diagnostics = resp.Diagnostics.Append(err)
 		return resp
@@ -575,8 +575,8 @@ func (p *GRPCProvider) ApplyResourceChange(r providers.ApplyResourceChangeReques
 		PlannedPrivate: r.PlannedPrivate,
 	}
 
-	if metaSchema.Block != nil {
-		metaTy := metaSchema.Block.ImpliedType()
+	if metaSchema.Body != nil {
+		metaTy := metaSchema.Body.ImpliedType()
 		metaVal := r.ProviderMeta
 		if metaVal == cty.NilVal {
 			metaVal = cty.NullVal(metaTy)
@@ -598,7 +598,7 @@ func (p *GRPCProvider) ApplyResourceChange(r providers.ApplyResourceChangeReques
 
 	resp.Private = protoResp.Private
 
-	state, err := decodeDynamicValue(protoResp.NewState, resSchema.Block.ImpliedType())
+	state, err := decodeDynamicValue(protoResp.NewState, resSchema.Body.ImpliedType())
 	if err != nil {
 		resp.Diagnostics = resp.Diagnostics.Append(err)
 		return resp
@@ -645,7 +645,7 @@ func (p *GRPCProvider) ImportResourceState(r providers.ImportResourceStateReques
 			continue
 		}
 
-		state, err := decodeDynamicValue(imported.State, resSchema.Block.ImpliedType())
+		state, err := decodeDynamicValue(imported.State, resSchema.Body.ImpliedType())
 		if err != nil {
 			resp.Diagnostics = resp.Diagnostics.Append(err)
 			return resp
@@ -695,7 +695,7 @@ func (p *GRPCProvider) MoveResourceState(r providers.MoveResourceStateRequest) (
 		resp.Diagnostics = resp.Diagnostics.Append(fmt.Errorf("unknown resource type %q; this is a bug in Terraform - please report it", r.TargetTypeName))
 		return resp
 	}
-	resp.TargetState, err = decodeDynamicValue(protoResp.TargetState, targetType.Block.ImpliedType())
+	resp.TargetState, err = decodeDynamicValue(protoResp.TargetState, targetType.Body.ImpliedType())
 	if err != nil {
 		resp.Diagnostics = resp.Diagnostics.Append(err)
 		return resp
@@ -722,7 +722,7 @@ func (p *GRPCProvider) ReadDataSource(r providers.ReadDataSourceRequest) (resp p
 
 	metaSchema := schema.ProviderMeta
 
-	config, err := msgpack.Marshal(r.Config, dataSchema.Block.ImpliedType())
+	config, err := msgpack.Marshal(r.Config, dataSchema.Body.ImpliedType())
 	if err != nil {
 		resp.Diagnostics = resp.Diagnostics.Append(err)
 		return resp
@@ -736,8 +736,8 @@ func (p *GRPCProvider) ReadDataSource(r providers.ReadDataSourceRequest) (resp p
 		ClientCapabilities: clientCapabilitiesToProto(r.ClientCapabilities),
 	}
 
-	if metaSchema.Block != nil {
-		metaMP, err := msgpack.Marshal(r.ProviderMeta, metaSchema.Block.ImpliedType())
+	if metaSchema.Body != nil {
+		metaMP, err := msgpack.Marshal(r.ProviderMeta, metaSchema.Body.ImpliedType())
 		if err != nil {
 			resp.Diagnostics = resp.Diagnostics.Append(err)
 			return resp
@@ -752,7 +752,7 @@ func (p *GRPCProvider) ReadDataSource(r providers.ReadDataSourceRequest) (resp p
 	}
 	resp.Diagnostics = resp.Diagnostics.Append(convert.ProtoToDiagnostics(protoResp.Diagnostics))
 
-	state, err := decodeDynamicValue(protoResp.State, dataSchema.Block.ImpliedType())
+	state, err := decodeDynamicValue(protoResp.State, dataSchema.Body.ImpliedType())
 	if err != nil {
 		resp.Diagnostics = resp.Diagnostics.Append(err)
 		return resp
@@ -778,7 +778,7 @@ func (p *GRPCProvider) ValidateEphemeralResourceConfig(r providers.ValidateEphem
 		return resp
 	}
 
-	mp, err := msgpack.Marshal(r.Config, ephemSchema.Block.ImpliedType())
+	mp, err := msgpack.Marshal(r.Config, ephemSchema.Body.ImpliedType())
 	if err != nil {
 		resp.Diagnostics = resp.Diagnostics.Append(err)
 		return resp
@@ -813,7 +813,7 @@ func (p *GRPCProvider) OpenEphemeralResource(r providers.OpenEphemeralResourceRe
 		return resp
 	}
 
-	config, err := msgpack.Marshal(r.Config, ephemSchema.Block.ImpliedType())
+	config, err := msgpack.Marshal(r.Config, ephemSchema.Body.ImpliedType())
 	if err != nil {
 		resp.Diagnostics = resp.Diagnostics.Append(err)
 		return resp
@@ -834,7 +834,7 @@ func (p *GRPCProvider) OpenEphemeralResource(r providers.OpenEphemeralResourceRe
 	}
 	resp.Diagnostics = resp.Diagnostics.Append(convert.ProtoToDiagnostics(protoResp.Diagnostics))
 
-	state, err := decodeDynamicValue(protoResp.Result, ephemSchema.Block.ImpliedType())
+	state, err := decodeDynamicValue(protoResp.Result, ephemSchema.Body.ImpliedType())
 	if err != nil {
 		resp.Diagnostics = resp.Diagnostics.Append(err)
 		return resp

--- a/internal/plugin6/convert/schema.go
+++ b/internal/plugin6/convert/schema.go
@@ -99,7 +99,7 @@ func protoSchemaNestedBlock(name string, b *configschema.NestedBlock) *proto.Sch
 func ProtoToProviderSchema(s *proto.Schema) providers.Schema {
 	return providers.Schema{
 		Version: s.Version,
-		Block:   ProtoToConfigSchema(s.Block),
+		Body:    ProtoToConfigSchema(s.Block),
 	}
 }
 

--- a/internal/provider-simple-v6/provider.go
+++ b/internal/provider-simple-v6/provider.go
@@ -23,7 +23,7 @@ type simple struct {
 
 func Provider() providers.Interface {
 	simpleResource := providers.Schema{
-		Block: &configschema.Block{
+		Body: &configschema.Block{
 			Attributes: map[string]*configschema.Attribute{
 				"id": {
 					Computed: true,
@@ -40,7 +40,7 @@ func Provider() providers.Interface {
 	return simple{
 		schema: providers.GetProviderSchemaResponse{
 			Provider: providers.Schema{
-				Block: nil,
+				Body: nil,
 			},
 			ResourceTypes: map[string]providers.Schema{
 				"simple_resource": simpleResource,
@@ -93,7 +93,7 @@ func (s simple) ValidateDataResourceConfig(req providers.ValidateDataResourceCon
 }
 
 func (p simple) UpgradeResourceState(req providers.UpgradeResourceStateRequest) (resp providers.UpgradeResourceStateResponse) {
-	ty := p.schema.ResourceTypes[req.TypeName].Block.ImpliedType()
+	ty := p.schema.ResourceTypes[req.TypeName].Body.ImpliedType()
 	val, err := ctyjson.Unmarshal(req.RawStateJSON, ty)
 	resp.Diagnostics = resp.Diagnostics.Append(err)
 	resp.UpgradedState = val

--- a/internal/provider-simple/provider.go
+++ b/internal/provider-simple/provider.go
@@ -21,7 +21,7 @@ type simple struct {
 
 func Provider() providers.Interface {
 	simpleResource := providers.Schema{
-		Block: &configschema.Block{
+		Body: &configschema.Block{
 			Attributes: map[string]*configschema.Attribute{
 				"id": {
 					Computed: true,
@@ -38,7 +38,7 @@ func Provider() providers.Interface {
 	return simple{
 		schema: providers.GetProviderSchemaResponse{
 			Provider: providers.Schema{
-				Block: nil,
+				Body: nil,
 			},
 			ResourceTypes: map[string]providers.Schema{
 				"simple_resource": simpleResource,
@@ -70,7 +70,7 @@ func (s simple) ValidateDataResourceConfig(req providers.ValidateDataResourceCon
 }
 
 func (p simple) UpgradeResourceState(req providers.UpgradeResourceStateRequest) (resp providers.UpgradeResourceStateResponse) {
-	ty := p.schema.ResourceTypes[req.TypeName].Block.ImpliedType()
+	ty := p.schema.ResourceTypes[req.TypeName].Body.ImpliedType()
 	val, err := ctyjson.Unmarshal(req.RawStateJSON, ty)
 	resp.Diagnostics = resp.Diagnostics.Append(err)
 	resp.UpgradedState = val

--- a/internal/providers/mock.go
+++ b/internal/providers/mock.go
@@ -54,7 +54,7 @@ func (m *Mock) GetProviderSchema() GetProviderSchemaResponse {
 		// that could be in use elsewhere.
 		schema.Provider = Schema{
 			Version: schema.Provider.Version,
-			Block:   nil, // Empty - we support no blocks or attributes in mock provider configurations.
+			Body:    nil, // Empty - we support no blocks or attributes in mock provider configurations.
 		}
 
 		// Note, we leave the resource and data source schemas as they are since
@@ -107,7 +107,7 @@ func (m *Mock) UpgradeResourceState(request UpgradeResourceStateRequest) (respon
 		panic(fmt.Errorf("failed to retrieve schema for resource %s", request.TypeName))
 	}
 
-	schemaType := resource.Block.ImpliedType()
+	schemaType := resource.Body.ImpliedType()
 
 	var value cty.Value
 	var err error
@@ -193,7 +193,7 @@ func (m *Mock) PlanResourceChange(request PlanResourceChangeRequest) PlanResourc
 			replacement.ComputedAsUnknown = false
 		}
 
-		value, diags := mocking.PlanComputedValuesForResource(request.ProposedNewState, replacement, resource.Block)
+		value, diags := mocking.PlanComputedValuesForResource(request.ProposedNewState, replacement, resource.Body)
 		response.Diagnostics = response.Diagnostics.Append(diags)
 		response.PlannedState = value
 		response.PlannedPrivate = []byte("create")
@@ -239,7 +239,7 @@ func (m *Mock) ApplyResourceChange(request ApplyResourceChangeRequest) ApplyReso
 			replacement.Range = mockedResource.DefaultsRange
 		}
 
-		value, diags := mocking.ApplyComputedValuesForResource(request.PlannedState, replacement, resource.Block)
+		value, diags := mocking.ApplyComputedValuesForResource(request.PlannedState, replacement, resource.Body)
 		response.Diagnostics = response.Diagnostics.Append(diags)
 		response.NewState = value
 		return response
@@ -294,7 +294,7 @@ func (m *Mock) ReadDataSource(request ReadDataSourceRequest) ReadDataSourceRespo
 		mockedData.Range = mockedDataSource.DefaultsRange
 	}
 
-	value, diags := mocking.ComputedValuesForDataSource(request.Config, mockedData, datasource.Block)
+	value, diags := mocking.ComputedValuesForDataSource(request.Config, mockedData, datasource.Body)
 	response.Diagnostics = response.Diagnostics.Append(diags)
 	response.State = value
 	return response

--- a/internal/providers/provider.go
+++ b/internal/providers/provider.go
@@ -135,7 +135,7 @@ type GetProviderSchemaResponse struct {
 // for everything within a particular provider.
 type Schema struct {
 	Version int64
-	Block   *configschema.Block
+	Body    *configschema.Block
 }
 
 // ServerCapabilities allows providers to communicate extra information

--- a/internal/providers/schemas.go
+++ b/internal/providers/schemas.go
@@ -19,13 +19,13 @@ func (ss ProviderSchema) SchemaForResourceType(mode addrs.ResourceMode, typeName
 	switch mode {
 	case addrs.ManagedResourceMode:
 		res := ss.ResourceTypes[typeName]
-		return res.Block, uint64(res.Version)
+		return res.Body, uint64(res.Version)
 	case addrs.DataResourceMode:
 		// Data resources don't have schema versions right now, since state is discarded for each refresh
-		return ss.DataSources[typeName].Block, 0
+		return ss.DataSources[typeName].Body, 0
 	case addrs.EphemeralResourceMode:
 		// Ephemeral resources don't have schema versions because their objects never outlive a single phase
-		return ss.EphemeralResourceTypes[typeName].Block, 0
+		return ss.EphemeralResourceTypes[typeName].Body, 0
 	default:
 		// Shouldn't happen, because the above cases are comprehensive.
 		return nil, 0

--- a/internal/providers/testing/provider_mock.go
+++ b/internal/providers/testing/provider_mock.go
@@ -175,7 +175,7 @@ func (p *MockProvider) ValidateResourceConfig(r providers.ValidateResourceConfig
 		return resp
 	}
 
-	_, err := msgpack.Marshal(r.Config, resourceSchema.Block.ImpliedType())
+	_, err := msgpack.Marshal(r.Config, resourceSchema.Body.ImpliedType())
 	if err != nil {
 		resp.Diagnostics = resp.Diagnostics.Append(err)
 		return resp
@@ -205,7 +205,7 @@ func (p *MockProvider) ValidateDataResourceConfig(r providers.ValidateDataResour
 		resp.Diagnostics = resp.Diagnostics.Append(fmt.Errorf("no schema found for %q", r.TypeName))
 		return resp
 	}
-	_, err := msgpack.Marshal(r.Config, dataSchema.Block.ImpliedType())
+	_, err := msgpack.Marshal(r.Config, dataSchema.Body.ImpliedType())
 	if err != nil {
 		resp.Diagnostics = resp.Diagnostics.Append(err)
 		return resp
@@ -235,7 +235,7 @@ func (p *MockProvider) ValidateEphemeralResourceConfig(r providers.ValidateEphem
 		resp.Diagnostics = resp.Diagnostics.Append(fmt.Errorf("no schema found for %q", r.TypeName))
 		return resp
 	}
-	_, err := msgpack.Marshal(r.Config, dataSchema.Block.ImpliedType())
+	_, err := msgpack.Marshal(r.Config, dataSchema.Body.ImpliedType())
 	if err != nil {
 		resp.Diagnostics = resp.Diagnostics.Append(err)
 		return resp
@@ -272,7 +272,7 @@ func (p *MockProvider) UpgradeResourceState(r providers.UpgradeResourceStateRequ
 		return resp
 	}
 
-	schemaType := schema.Block.ImpliedType()
+	schemaType := schema.Body.ImpliedType()
 
 	p.UpgradeResourceStateCalled = true
 	p.UpgradeResourceStateRequest = r
@@ -365,7 +365,7 @@ func (p *MockProvider) ReadResource(r providers.ReadResourceRequest) (resp provi
 			return resp
 		}
 
-		newState, err := schema.Block.CoerceValue(resp.NewState)
+		newState, err := schema.Body.CoerceValue(resp.NewState)
 		if err != nil {
 			resp.Diagnostics = resp.Diagnostics.Append(err)
 		}
@@ -384,7 +384,7 @@ func (p *MockProvider) ReadResource(r providers.ReadResourceRequest) (resp provi
 				return v, nil
 			}
 
-			attrSchema := schema.Block.AttributeByPath(path)
+			attrSchema := schema.Body.AttributeByPath(path)
 			if attrSchema == nil {
 				// this is an intermediate path which does not represent an attribute
 				return v, nil
@@ -451,7 +451,7 @@ func (p *MockProvider) PlanResourceChange(r providers.PlanResourceChangeRequest)
 			return v, nil
 		}
 
-		attrSchema := schema.Block.AttributeByPath(path)
+		attrSchema := schema.Body.AttributeByPath(path)
 		if attrSchema == nil {
 			// this is an intermediate path which does not represent an attribute
 			return v, nil
@@ -586,7 +586,7 @@ func (p *MockProvider) ImportResourceState(r providers.ImportResourceStateReques
 			}
 
 			var err error
-			res.State, err = schema.Block.CoerceValue(res.State)
+			res.State, err = schema.Body.CoerceValue(res.State)
 			if err != nil {
 				resp.Diagnostics = resp.Diagnostics.Append(err)
 				return resp

--- a/internal/refactoring/mock_provider.go
+++ b/internal/refactoring/mock_provider.go
@@ -20,8 +20,8 @@ type mockProvider struct {
 func (provider *mockProvider) GetProviderSchema() providers.GetProviderSchemaResponse {
 	return providers.GetProviderSchemaResponse{
 		ResourceTypes: map[string]providers.Schema{
-			"foo": {Block: &configschema.Block{}},
-			"bar": {Block: &configschema.Block{}},
+			"foo": {Body: &configschema.Block{}},
+			"bar": {Body: &configschema.Block{}},
 		},
 		ServerCapabilities: providers.ServerCapabilities{
 			MoveResourceState: provider.moveResourceState,

--- a/internal/repl/session_test.go
+++ b/internal/repl/session_test.go
@@ -266,7 +266,7 @@ func testSession(t *testing.T, test testSessionTest) {
 	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
 		ResourceTypes: map[string]providers.Schema{
 			"test_instance": {
-				Block: &configschema.Block{
+				Body: &configschema.Block{
 					Attributes: map[string]*configschema.Attribute{
 						"id": {Type: cty.String, Computed: true},
 					},

--- a/internal/rpcapi/dependencies_provider_schema.go
+++ b/internal/rpcapi/dependencies_provider_schema.go
@@ -158,7 +158,7 @@ func providerSchemaToProto(schemaResp providers.GetProviderSchemaResponse) *depe
 
 func schemaElementToProto(elem providers.Schema) *dependencies.Schema {
 	return &dependencies.Schema{
-		Block: schemaBlockToProto(elem.Block),
+		Block: schemaBlockToProto(elem.Body),
 	}
 }
 

--- a/internal/schemarepo/loadschemas/plugins.go
+++ b/internal/schemarepo/loadschemas/plugins.go
@@ -135,7 +135,7 @@ func (cp *Plugins) ProviderSchema(addr addrs.Provider) (providers.ProviderSchema
 	}
 
 	for t, r := range resp.ResourceTypes {
-		if err := r.Block.InternalValidate(); err != nil {
+		if err := r.Body.InternalValidate(); err != nil {
 			return resp, fmt.Errorf("provider %s has invalid schema for managed resource type %q, which is a bug in the provider: %q", addr, t, err)
 		}
 		if r.Version < 0 {
@@ -144,7 +144,7 @@ func (cp *Plugins) ProviderSchema(addr addrs.Provider) (providers.ProviderSchema
 	}
 
 	for t, d := range resp.DataSources {
-		if err := d.Block.InternalValidate(); err != nil {
+		if err := d.Body.InternalValidate(); err != nil {
 			return resp, fmt.Errorf("provider %s has invalid schema for data resource type %q, which is a bug in the provider: %q", addr, t, err)
 		}
 		if d.Version < 0 {
@@ -155,7 +155,7 @@ func (cp *Plugins) ProviderSchema(addr addrs.Provider) (providers.ProviderSchema
 	}
 
 	for t, r := range resp.EphemeralResourceTypes {
-		if err := r.Block.InternalValidate(); err != nil {
+		if err := r.Body.InternalValidate(); err != nil {
 			return resp, fmt.Errorf("provider %s has invalid schema for ephemeral resource type %q, which is a bug in the provider: %q", addr, t, err)
 		}
 	}
@@ -200,7 +200,7 @@ func (cp *Plugins) ProviderConfigSchema(providerAddr addrs.Provider) (*configsch
 		return nil, err
 	}
 
-	return providerSchema.Provider.Block, nil
+	return providerSchema.Provider.Body, nil
 }
 
 // ResourceTypeSchema is a helper wrapper around ProviderSchema which first

--- a/internal/schemarepo/schemas.go
+++ b/internal/schemarepo/schemas.go
@@ -28,7 +28,7 @@ func (ss *Schemas) ProviderSchema(provider addrs.Provider) providers.ProviderSch
 // ProviderConfig returns the schema for the provider configuration of the
 // given provider type, or nil if no such schema is available.
 func (ss *Schemas) ProviderConfig(provider addrs.Provider) *configschema.Block {
-	return ss.ProviderSchema(provider).Provider.Block
+	return ss.ProviderSchema(provider).Provider.Body
 }
 
 // ResourceTypeConfig returns the schema for the configuration of a given

--- a/internal/stacks/stackruntime/internal/stackeval/applying_test.go
+++ b/internal/stacks/stackruntime/internal/stackeval/applying_test.go
@@ -67,7 +67,7 @@ func TestApply_componentOrdering(t *testing.T) {
 	testProviderSchema := providers.GetProviderSchemaResponse{
 		ResourceTypes: map[string]providers.Schema{
 			"test_report": {
-				Block: &configschema.Block{
+				Body: &configschema.Block{
 					Attributes: map[string]*configschema.Attribute{
 						"marker": {
 							Type:     cty.String,

--- a/internal/stacks/stackruntime/internal/stackeval/diagnostics_test.go
+++ b/internal/stacks/stackruntime/internal/stackeval/diagnostics_test.go
@@ -65,11 +65,11 @@ func TestNamedPromisesPlan(t *testing.T) {
 				&providertest.MockProvider{
 					GetProviderSchemaResponse: &providers.GetProviderSchemaResponse{
 						Provider: providers.Schema{
-							Block: &configschema.Block{},
+							Body: &configschema.Block{},
 						},
 						ResourceTypes: map[string]providers.Schema{
 							"happycloud_thingy": providers.Schema{
-								Block: &configschema.Block{},
+								Body: &configschema.Block{},
 							},
 						},
 					},

--- a/internal/stacks/stackruntime/internal/stackeval/planning_test.go
+++ b/internal/stacks/stackruntime/internal/stackeval/planning_test.go
@@ -171,11 +171,11 @@ func TestPlanning_DestroyMode(t *testing.T) {
 				return &providerTesting.MockProvider{
 					GetProviderSchemaResponse: &providers.GetProviderSchemaResponse{
 						Provider: providers.Schema{
-							Block: &configschema.Block{},
+							Body: &configschema.Block{},
 						},
 						ResourceTypes: map[string]providers.Schema{
 							"test": {
-								Block: resourceTypeSchema,
+								Body: resourceTypeSchema,
 							},
 						},
 						ServerCapabilities: providers.ServerCapabilities{
@@ -358,7 +358,7 @@ func TestPlanning_RequiredComponents(t *testing.T) {
 				return &providerTesting.MockProvider{
 					GetProviderSchemaResponse: &providers.GetProviderSchemaResponse{
 						Provider: providers.Schema{
-							Block: &configschema.Block{
+							Body: &configschema.Block{
 								Attributes: map[string]*configschema.Attribute{
 									"in": {
 										Type:     cty.Map(cty.String),
@@ -545,11 +545,11 @@ func TestPlanning_DeferredChangesPropagation(t *testing.T) {
 				return &providerTesting.MockProvider{
 					GetProviderSchemaResponse: &providers.GetProviderSchemaResponse{
 						Provider: providers.Schema{
-							Block: &configschema.Block{},
+							Body: &configschema.Block{},
 						},
 						ResourceTypes: map[string]providers.Schema{
 							"test": {
-								Block: &configschema.Block{},
+								Body: &configschema.Block{},
 							},
 						},
 					},
@@ -635,7 +635,7 @@ func TestPlanning_RemoveDataResource(t *testing.T) {
 				GetProviderSchemaResponse: &providers.GetProviderSchemaResponse{
 					DataSources: map[string]providers.Schema{
 						"test": {
-							Block: &configschema.Block{},
+							Body: &configschema.Block{},
 						},
 					},
 				},

--- a/internal/stacks/stackruntime/internal/stackeval/provider.go
+++ b/internal/stacks/stackruntime/internal/stackeval/provider.go
@@ -251,7 +251,7 @@ func (p *Provider) References(ctx context.Context) []stackaddrs.AbsReference {
 	var ret []stackaddrs.Reference
 	ret = append(ret, ReferencesInExpr(ctx, cfg.ForEach)...)
 	if schema, err := p.ProviderType(ctx).Schema(ctx); err == nil {
-		ret = append(ret, ReferencesInBody(ctx, cfg.Config, schema.Provider.Block.DecoderSpec())...)
+		ret = append(ret, ReferencesInBody(ctx, cfg.Config, schema.Provider.Body.DecoderSpec())...)
 	}
 	return makeReferencesAbsolute(ret, p.Addr().Stack)
 }

--- a/internal/stacks/stackruntime/internal/stackeval/provider_config.go
+++ b/internal/stacks/stackruntime/internal/stackeval/provider_config.go
@@ -67,10 +67,10 @@ func (p *ProviderConfig) ProviderArgsDecoderSpec(ctx context.Context) (hcldec.Sp
 	if err != nil {
 		return nil, err
 	}
-	if schema.Provider.Block == nil {
+	if schema.Provider.Body == nil {
 		return hcldec.ObjectSpec{}, nil
 	}
-	return schema.Provider.Block.DecoderSpec(), nil
+	return schema.Provider.Body.DecoderSpec(), nil
 }
 
 // ProviderArgs returns an object value representing an approximation of all

--- a/internal/stacks/stackruntime/internal/stackeval/provider_config_test.go
+++ b/internal/stacks/stackruntime/internal/stackeval/provider_config_test.go
@@ -101,7 +101,7 @@ func TestProviderConfig_CheckProviderArgs(t *testing.T) {
 		mockProvider := &testing_provider.MockProvider{
 			GetProviderSchemaResponse: &providers.GetProviderSchemaResponse{
 				Provider: providers.Schema{
-					Block: &configschema.Block{
+					Body: &configschema.Block{
 						Attributes: map[string]*configschema.Attribute{
 							"test": {
 								Type:     cty.String,

--- a/internal/stacks/stackruntime/internal/stackeval/provider_instance_test.go
+++ b/internal/stacks/stackruntime/internal/stackeval/provider_instance_test.go
@@ -29,7 +29,7 @@ func TestProviderInstanceCheckProviderArgs(t *testing.T) {
 		mockProvider := &testing_provider.MockProvider{
 			GetProviderSchemaResponse: &providers.GetProviderSchemaResponse{
 				Provider: providers.Schema{
-					Block: &configschema.Block{
+					Body: &configschema.Block{
 						Attributes: map[string]*configschema.Attribute{
 							"test": {
 								Type:     cty.String,
@@ -304,7 +304,7 @@ func TestProviderInstanceCheckClient(t *testing.T) {
 		mockProvider := &testing_provider.MockProvider{
 			GetProviderSchemaResponse: &providers.GetProviderSchemaResponse{
 				Provider: providers.Schema{
-					Block: &configschema.Block{
+					Body: &configschema.Block{
 						Attributes: map[string]*configschema.Attribute{
 							"test": {
 								Type:     cty.String,

--- a/internal/stacks/stackruntime/internal/stackeval/stubs/unknown.go
+++ b/internal/stacks/stackruntime/internal/stackeval/stubs/unknown.go
@@ -115,7 +115,7 @@ func (u *unknownProvider) PlanResourceChange(request providers.PlanResourceChang
 		// library, but it is doing exactly what we need it to do.
 
 		schema := u.GetProviderSchema().ResourceTypes[request.TypeName]
-		val, diags := mocking.PlanComputedValuesForResource(request.ProposedNewState, nil, schema.Block)
+		val, diags := mocking.PlanComputedValuesForResource(request.ProposedNewState, nil, schema.Body)
 		if diags.HasErrors() {
 			// All the potential errors we get back from this function are
 			// related to the user badly defining mocks. We should never hit
@@ -169,7 +169,7 @@ func (u *unknownProvider) ImportResourceState(request providers.ImportResourceSt
 			ImportedResources: []providers.ImportedResource{
 				{
 					TypeName: request.TypeName,
-					State:    cty.UnknownVal(schema.Block.ImpliedType()),
+					State:    cty.UnknownVal(schema.Body.ImpliedType()),
 				},
 			},
 			Deferred: &providers.Deferred{
@@ -213,7 +213,7 @@ func (u *unknownProvider) ReadDataSource(request providers.ReadDataSourceRequest
 		// library, but it is doing exactly what we need it to do.
 
 		schema := u.GetProviderSchema().DataSources[request.TypeName]
-		val, diags := mocking.PlanComputedValuesForResource(request.Config, nil, schema.Block)
+		val, diags := mocking.PlanComputedValuesForResource(request.Config, nil, schema.Body)
 		if diags.HasErrors() {
 			// All the potential errors we get back from this function are
 			// related to the user badly defining mocks. We should never hit

--- a/internal/stacks/stackruntime/plan_test.go
+++ b/internal/stacks/stackruntime/plan_test.go
@@ -1535,7 +1535,7 @@ func TestPlanWithProviderConfig(t *testing.T) {
 	providerAddr := addrs.MustParseProviderSourceString("example.com/test/test")
 	providerSchema := &providers.GetProviderSchemaResponse{
 		Provider: providers.Schema{
-			Block: &configschema.Block{
+			Body: &configschema.Block{
 				Attributes: map[string]*configschema.Attribute{
 					"name": {
 						Type:     cty.String,

--- a/internal/stacks/stackruntime/testing/provider.go
+++ b/internal/stacks/stackruntime/testing/provider.go
@@ -92,7 +92,7 @@ func NewProviderWithData(t *testing.T, store *ResourceStore) *MockProvider {
 		MockProvider: &testing_provider.MockProvider{
 			GetProviderSchemaResponse: &providers.GetProviderSchemaResponse{
 				Provider: providers.Schema{
-					Block: &configschema.Block{
+					Body: &configschema.Block{
 						Attributes: map[string]*configschema.Attribute{
 							// if the configuration sets require_auth then it
 							// must also provide the correct value for
@@ -127,21 +127,21 @@ func NewProviderWithData(t *testing.T, store *ResourceStore) *MockProvider {
 				},
 				ResourceTypes: map[string]providers.Schema{
 					"testing_resource": {
-						Block: TestingResourceSchema,
+						Body: TestingResourceSchema,
 					},
 					"testing_deferred_resource": {
-						Block: DeferredResourceSchema,
+						Body: DeferredResourceSchema,
 					},
 					"testing_failed_resource": {
-						Block: FailedResourceSchema,
+						Body: FailedResourceSchema,
 					},
 					"testing_blocked_resource": {
-						Block: BlockedResourceSchema,
+						Body: BlockedResourceSchema,
 					},
 				},
 				DataSources: map[string]providers.Schema{
 					"testing_data_source": {
-						Block: TestingDataSourceSchema,
+						Body: TestingDataSourceSchema,
 					},
 				},
 				Functions: map[string]providers.FunctionDecl{

--- a/internal/terraform/context_apply2_test.go
+++ b/internal/terraform/context_apply2_test.go
@@ -1246,13 +1246,13 @@ output "out" {
 
 	testProvider := &testing_provider.MockProvider{
 		GetProviderSchemaResponse: &providers.GetProviderSchemaResponse{
-			Provider: providers.Schema{Block: simpleTestSchema()},
+			Provider: providers.Schema{Body: simpleTestSchema()},
 			ResourceTypes: map[string]providers.Schema{
-				"test_object": providers.Schema{Block: simpleTestSchema()},
+				"test_object": providers.Schema{Body: simpleTestSchema()},
 			},
 			DataSources: map[string]providers.Schema{
 				"test_object": providers.Schema{
-					Block: &configschema.Block{
+					Body: &configschema.Block{
 						Attributes: map[string]*configschema.Attribute{
 							"test_string": {
 								Type:     cty.String,
@@ -1285,7 +1285,7 @@ output "out" {
 	otherProvider := &testing_provider.MockProvider{
 		GetProviderSchemaResponse: &providers.GetProviderSchemaResponse{
 			Provider: providers.Schema{
-				Block: &configschema.Block{
+				Body: &configschema.Block{
 					Attributes: map[string]*configschema.Attribute{
 						"output": {
 							Type:     cty.List(cty.String),
@@ -1303,7 +1303,7 @@ output "out" {
 				},
 			},
 			ResourceTypes: map[string]providers.Schema{
-				"other_object": providers.Schema{Block: simpleTestSchema()},
+				"other_object": providers.Schema{Body: simpleTestSchema()},
 			},
 		},
 	}
@@ -1744,7 +1744,7 @@ resource "test_object" "y" {
 
 	p := simpleMockProvider()
 	// make sure we can compute the attr
-	testString := p.GetProviderSchemaResponse.ResourceTypes["test_object"].Block.Attributes["test_string"]
+	testString := p.GetProviderSchemaResponse.ResourceTypes["test_object"].Body.Attributes["test_string"]
 	testString.Computed = true
 	testString.Optional = false
 
@@ -2472,7 +2472,7 @@ resource "test_object" "foo" {
 		GetProviderSchemaResponse: &providers.GetProviderSchemaResponse{
 			ResourceTypes: map[string]providers.Schema{
 				"test_object": {
-					Block: &configschema.Block{
+					Body: &configschema.Block{
 						Attributes: map[string]*configschema.Attribute{
 							"value": {
 								Type:     cty.String,
@@ -2488,7 +2488,7 @@ resource "test_object" "foo" {
 			},
 			DataSources: map[string]providers.Schema{
 				"test_object": {
-					Block: &configschema.Block{
+					Body: &configschema.Block{
 						Attributes: map[string]*configschema.Attribute{
 							"output": {
 								Type:     cty.String,
@@ -2606,7 +2606,7 @@ resource "test_object" "foo" {
 	testProvider := &testing_provider.MockProvider{
 		GetProviderSchemaResponse: &providers.GetProviderSchemaResponse{
 			Provider: providers.Schema{
-				Block: &configschema.Block{
+				Body: &configschema.Block{
 					Attributes: map[string]*configschema.Attribute{
 						"required": {
 							Type:     cty.String,
@@ -2617,7 +2617,7 @@ resource "test_object" "foo" {
 			},
 			ResourceTypes: map[string]providers.Schema{
 				"test_object": {
-					Block: &configschema.Block{
+					Body: &configschema.Block{
 						Attributes: map[string]*configschema.Attribute{
 							"value": {
 								Type:     cty.String,
@@ -2633,7 +2633,7 @@ resource "test_object" "foo" {
 			},
 			DataSources: map[string]providers.Schema{
 				"test_object": {
-					Block: &configschema.Block{
+					Body: &configschema.Block{
 						Attributes: map[string]*configschema.Attribute{
 							"output": {
 								Type:     cty.String,
@@ -2830,7 +2830,7 @@ func TestContext2Apply_destroy_and_forget(t *testing.T) {
             resource "test_object" "a" {
                 test_string = "foo"
             }
-            
+
             resource "test_object" "b" {
                 test_string = "foo"
             }
@@ -2876,7 +2876,7 @@ func TestContext2Apply_destroy_and_forget(t *testing.T) {
     		}
     		resource "test_object" "a" {
               for_each = local.items
-      
+
     		  test_string = each.value
             }
             `,
@@ -2982,7 +2982,7 @@ func TestContext2Apply_destroy_and_forget_single_resource(t *testing.T) {
 		"main.tf": `
             removed {
               from = test_object.a
-            
+
               lifecycle {
                 destroy = false
               }
@@ -3267,7 +3267,7 @@ func TestContext2Apply_applyingFlag(t *testing.T) {
 	p := new(testing_provider.MockProvider)
 	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
 		Provider: providers.Schema{
-			Block: &configschema.Block{
+			Body: &configschema.Block{
 				Attributes: map[string]*configschema.Attribute{
 					"applying": {
 						Type:     cty.Bool,
@@ -3278,7 +3278,7 @@ func TestContext2Apply_applyingFlag(t *testing.T) {
 		},
 		ResourceTypes: map[string]providers.Schema{
 			"test_thing": {
-				Block: &configschema.Block{},
+				Body: &configschema.Block{},
 			},
 		},
 	}
@@ -3449,7 +3449,7 @@ resource "test_object" "obj" {
 	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
 		ResourceTypes: map[string]providers.Schema{
 			"test_object": {
-				Block: &configschema.Block{
+				Body: &configschema.Block{
 					Attributes: map[string]*configschema.Attribute{
 						"output": {
 							Type:     cty.String,
@@ -3600,7 +3600,7 @@ resource "test_object" "c" {
 	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
 		ResourceTypes: map[string]providers.Schema{
 			"test_object": {
-				Block: &configschema.Block{
+				Body: &configschema.Block{
 					Attributes: map[string]*configschema.Attribute{
 						"id": {
 							Type:     cty.String,
@@ -3677,7 +3677,7 @@ resource "test_object" "c" {
 	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
 		ResourceTypes: map[string]providers.Schema{
 			"test_object": {
-				Block: &configschema.Block{
+				Body: &configschema.Block{
 					Attributes: map[string]*configschema.Attribute{
 						"id": {
 							Type:     cty.String,
@@ -3778,10 +3778,10 @@ resource "test_object" "x" {
 
 	p := &testing_provider.MockProvider{}
 	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
-		Provider: providers.Schema{Block: simpleTestSchema()},
+		Provider: providers.Schema{Body: simpleTestSchema()},
 		ResourceTypes: map[string]providers.Schema{
 			"test_object": providers.Schema{
-				Block: &configschema.Block{
+				Body: &configschema.Block{
 					Attributes: map[string]*configschema.Attribute{
 						"test_string": {
 							Type:     cty.String,
@@ -3841,10 +3841,10 @@ resource "test_object" "x" {
 
 	p := &testing_provider.MockProvider{}
 	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
-		Provider: providers.Schema{Block: simpleTestSchema()},
+		Provider: providers.Schema{Body: simpleTestSchema()},
 		ResourceTypes: map[string]providers.Schema{
 			"test_object": providers.Schema{
-				Block: &configschema.Block{
+				Body: &configschema.Block{
 					Attributes: map[string]*configschema.Attribute{
 						"test_string": {
 							Type:     cty.String,

--- a/internal/terraform/context_apply_checks_test.go
+++ b/internal/terraform/context_apply_checks_test.go
@@ -72,7 +72,7 @@ check "passing" {
 				GetProviderSchemaResponse: &providers.GetProviderSchemaResponse{
 					DataSources: map[string]providers.Schema{
 						"checks_object": {
-							Block: &configschema.Block{
+							Body: &configschema.Block{
 								Attributes: map[string]*configschema.Attribute{
 									"number": {
 										Type:     cty.Number,
@@ -126,7 +126,7 @@ check "failing" {
 				GetProviderSchemaResponse: &providers.GetProviderSchemaResponse{
 					DataSources: map[string]providers.Schema{
 						"checks_object": {
-							Block: &configschema.Block{
+							Body: &configschema.Block{
 								Attributes: map[string]*configschema.Attribute{
 									"number": {
 										Type:     cty.Number,
@@ -185,7 +185,7 @@ check "failing" {
 				GetProviderSchemaResponse: &providers.GetProviderSchemaResponse{
 					DataSources: map[string]providers.Schema{
 						"checks_object": {
-							Block: &configschema.Block{
+							Body: &configschema.Block{
 								Attributes: map[string]*configschema.Attribute{
 									"number": {
 										Type:     cty.Number,
@@ -255,7 +255,7 @@ check "nested_data_block" {
 				GetProviderSchemaResponse: &providers.GetProviderSchemaResponse{
 					DataSources: map[string]providers.Schema{
 						"checks_object": {
-							Block: &configschema.Block{
+							Body: &configschema.Block{
 								Attributes: map[string]*configschema.Attribute{
 									"number": {
 										Type:     cty.Number,
@@ -323,7 +323,7 @@ check "resource_block" {
 				GetProviderSchemaResponse: &providers.GetProviderSchemaResponse{
 					ResourceTypes: map[string]providers.Schema{
 						"checks_object": {
-							Block: &configschema.Block{
+							Body: &configschema.Block{
 								Attributes: map[string]*configschema.Attribute{
 									"id": {
 										Type:     cty.String,
@@ -335,7 +335,7 @@ check "resource_block" {
 					},
 					DataSources: map[string]providers.Schema{
 						"checks_object": {
-							Block: &configschema.Block{
+							Body: &configschema.Block{
 								Attributes: map[string]*configschema.Attribute{
 									"id": {
 										Type:     cty.String,
@@ -421,7 +421,7 @@ check "error" {
 				GetProviderSchemaResponse: &providers.GetProviderSchemaResponse{
 					DataSources: map[string]providers.Schema{
 						"checks_object": {
-							Block: &configschema.Block{
+							Body: &configschema.Block{
 								Attributes: map[string]*configschema.Attribute{
 									"number": {
 										Type:     cty.Number,
@@ -496,7 +496,7 @@ check "error" {
 				GetProviderSchemaResponse: &providers.GetProviderSchemaResponse{
 					ResourceTypes: map[string]providers.Schema{
 						"checks_object": {
-							Block: &configschema.Block{
+							Body: &configschema.Block{
 								Attributes: map[string]*configschema.Attribute{
 									"number": {
 										Type:     cty.Number,
@@ -508,7 +508,7 @@ check "error" {
 					},
 					DataSources: map[string]providers.Schema{
 						"checks_object": {
-							Block: &configschema.Block{
+							Body: &configschema.Block{
 								Attributes: map[string]*configschema.Attribute{
 									"number": {
 										Type:     cty.Number,
@@ -588,7 +588,7 @@ check "passing" {
 				GetProviderSchemaResponse: &providers.GetProviderSchemaResponse{
 					ResourceTypes: map[string]providers.Schema{
 						"checks_object": {
-							Block: &configschema.Block{
+							Body: &configschema.Block{
 								Attributes: map[string]*configschema.Attribute{
 									"number": {
 										Type:     cty.Number,
@@ -636,7 +636,7 @@ check "error" {
 				GetProviderSchemaResponse: &providers.GetProviderSchemaResponse{
 					DataSources: map[string]providers.Schema{
 						"checks_object": {
-							Block: &configschema.Block{
+							Body: &configschema.Block{
 								Attributes: map[string]*configschema.Attribute{
 									"number": {
 										Type:     cty.Number,
@@ -679,7 +679,7 @@ check "error" {
 				GetProviderSchemaResponse: &providers.GetProviderSchemaResponse{
 					DataSources: map[string]providers.Schema{
 						"checks_object": {
-							Block: &configschema.Block{
+							Body: &configschema.Block{
 								Attributes: map[string]*configschema.Attribute{
 									"id": {
 										Type:     cty.String,

--- a/internal/terraform/context_apply_deferred_test.go
+++ b/internal/terraform/context_apply_deferred_test.go
@@ -3345,7 +3345,7 @@ ephemeral "test" "dep" {
 	ephemeralResourceOpenDeferralExpanded = deferredActionsTest{
 		configs: map[string]string{
 			"main.tf": `
-			
+
 variable "each" {
   type = set(string)
 }
@@ -3952,7 +3952,7 @@ func (provider *deferredActionsProvider) Provider() providers.Interface {
 		GetProviderSchemaResponse: &providers.GetProviderSchemaResponse{
 			ResourceTypes: map[string]providers.Schema{
 				"test": {
-					Block: &configschema.Block{
+					Body: &configschema.Block{
 						Attributes: map[string]*configschema.Attribute{
 							"name": {
 								Type:     cty.String,
@@ -3972,7 +3972,7 @@ func (provider *deferredActionsProvider) Provider() providers.Interface {
 			},
 			DataSources: map[string]providers.Schema{
 				"test": {
-					Block: &configschema.Block{
+					Body: &configschema.Block{
 						Attributes: map[string]*configschema.Attribute{
 							"name": {
 								Type:     cty.String,
@@ -3988,7 +3988,7 @@ func (provider *deferredActionsProvider) Provider() providers.Interface {
 			},
 			EphemeralResourceTypes: map[string]providers.Schema{
 				"test": {
-					Block: &configschema.Block{
+					Body: &configschema.Block{
 						Attributes: map[string]*configschema.Attribute{
 							"name": {
 								Type:     cty.String,

--- a/internal/terraform/context_apply_ephemeral_test.go
+++ b/internal/terraform/context_apply_ephemeral_test.go
@@ -38,7 +38,7 @@ resource "test_object" "test" {
 		GetProviderSchemaResponse: &providers.GetProviderSchemaResponse{
 			EphemeralResourceTypes: map[string]providers.Schema{
 				"ephem_resource": {
-					Block: &configschema.Block{
+					Body: &configschema.Block{
 						Attributes: map[string]*configschema.Attribute{
 							"value": {
 								Type:     cty.String,
@@ -161,7 +161,7 @@ output "data" {
 		GetProviderSchemaResponse: &providers.GetProviderSchemaResponse{
 			EphemeralResourceTypes: map[string]providers.Schema{
 				"ephem_resource": {
-					Block: &configschema.Block{
+					Body: &configschema.Block{
 						Attributes: map[string]*configschema.Attribute{
 							"value": {
 								Type:     cty.String,
@@ -313,7 +313,7 @@ resource "test_object" "test" {
 		GetProviderSchemaResponse: &providers.GetProviderSchemaResponse{
 			EphemeralResourceTypes: map[string]providers.Schema{
 				"ephem_resource": {
-					Block: &configschema.Block{
+					Body: &configschema.Block{
 						Attributes: map[string]*configschema.Attribute{
 							"value": {
 								Type:     cty.String,
@@ -381,7 +381,7 @@ resource "ephem_write_only" "wo" {
 		GetProviderSchemaResponse: &providers.GetProviderSchemaResponse{
 			ResourceTypes: map[string]providers.Schema{
 				"ephem_write_only": {
-					Block: &configschema.Block{
+					Body: &configschema.Block{
 						Attributes: map[string]*configschema.Attribute{
 							"normal": {
 								Type:     cty.String,
@@ -493,7 +493,7 @@ resource "ephem_write_only" "wo" {
 		GetProviderSchemaResponse: &providers.GetProviderSchemaResponse{
 			ResourceTypes: map[string]providers.Schema{
 				"ephem_write_only": {
-					Block: &configschema.Block{
+					Body: &configschema.Block{
 						Attributes: map[string]*configschema.Attribute{
 							"normal": {
 								Type:     cty.String,
@@ -621,7 +621,7 @@ resource "ephem_write_only" "wo" {
 		GetProviderSchemaResponse: &providers.GetProviderSchemaResponse{
 			ResourceTypes: map[string]providers.Schema{
 				"ephem_write_only": {
-					Block: &configschema.Block{
+					Body: &configschema.Block{
 						Attributes: map[string]*configschema.Attribute{
 							"normal": {
 								Type:     cty.String,
@@ -760,7 +760,7 @@ resource "ephem_write_only" "wo" {
 		GetProviderSchemaResponse: &providers.GetProviderSchemaResponse{
 			ResourceTypes: map[string]providers.Schema{
 				"ephem_write_only": {
-					Block: &configschema.Block{
+					Body: &configschema.Block{
 						Attributes: map[string]*configschema.Attribute{
 							"normal": {
 								Type:     cty.String,
@@ -840,7 +840,7 @@ resource "ephem_write_only" "wo" {
 		GetProviderSchemaResponse: &providers.GetProviderSchemaResponse{
 			ResourceTypes: map[string]providers.Schema{
 				"ephem_write_only": {
-					Block: &configschema.Block{
+					Body: &configschema.Block{
 						Attributes: map[string]*configschema.Attribute{
 							"normal": {
 								Type:     cty.String,
@@ -912,7 +912,7 @@ resource "ephem_write_only" "wo" {
 		GetProviderSchemaResponse: &providers.GetProviderSchemaResponse{
 			ResourceTypes: map[string]providers.Schema{
 				"ephem_write_only": {
-					Block: &configschema.Block{
+					Body: &configschema.Block{
 						Attributes: map[string]*configschema.Attribute{
 							"normal": {
 								Type:     cty.String,

--- a/internal/terraform/context_apply_overrides_test.go
+++ b/internal/terraform/context_apply_overrides_test.go
@@ -758,7 +758,7 @@ resource "test_instance" "resource" {
 var underlyingOverridesProvider = &testing_provider.MockProvider{
 	GetProviderSchemaResponse: &providers.GetProviderSchemaResponse{
 		Provider: providers.Schema{
-			Block: &configschema.Block{
+			Body: &configschema.Block{
 				Attributes: map[string]*configschema.Attribute{
 					"value": {
 						Type:     cty.String,
@@ -769,7 +769,7 @@ var underlyingOverridesProvider = &testing_provider.MockProvider{
 		},
 		ResourceTypes: map[string]providers.Schema{
 			"test_instance": {
-				Block: &configschema.Block{
+				Body: &configschema.Block{
 					Attributes: map[string]*configschema.Attribute{
 						"id": {
 							Type:     cty.String,
@@ -785,7 +785,7 @@ var underlyingOverridesProvider = &testing_provider.MockProvider{
 		},
 		DataSources: map[string]providers.Schema{
 			"test_instance": {
-				Block: &configschema.Block{
+				Body: &configschema.Block{
 					Attributes: map[string]*configschema.Attribute{
 						"id": {
 							Type:     cty.String,

--- a/internal/terraform/context_apply_test.go
+++ b/internal/terraform/context_apply_test.go
@@ -81,7 +81,7 @@ func TestContext2Apply_stop(t *testing.T) {
 			ResourceTypes: map[string]providers.Schema{
 				"indefinite": {
 					Version: 1,
-					Block: &configschema.Block{
+					Body: &configschema.Block{
 						Attributes: map[string]*configschema.Attribute{
 							"result": {
 								Type:     cty.String,
@@ -273,7 +273,7 @@ func TestContext2Apply_unstable(t *testing.T) {
 		Type: "test_resource",
 		Name: "foo",
 	}.Instance(addrs.NoKey).Absolute(addrs.RootModuleInstance)
-	schema := p.GetProviderSchemaResponse.ResourceTypes["test_resource"].Block
+	schema := p.GetProviderSchemaResponse.ResourceTypes["test_resource"].Body
 	rds := plan.Changes.ResourceInstance(addr)
 	rd, err := rds.Decode(schema.ImpliedType())
 	if err != nil {
@@ -8322,7 +8322,7 @@ func TestContext2Apply_ignoreChangesCreate(t *testing.T) {
 	p.PlanResourceChangeFn = testDiffFn
 	p.ApplyResourceChangeFn = testApplyFn
 
-	instanceSchema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
+	instanceSchema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Body
 	instanceSchema.Attributes["required_field"] = &configschema.Attribute{
 		Type:     cty.String,
 		Required: true,
@@ -8463,7 +8463,7 @@ func TestContext2Apply_ignoreChangesAll(t *testing.T) {
 	p.PlanResourceChangeFn = testDiffFn
 	p.ApplyResourceChangeFn = testApplyFn
 
-	instanceSchema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
+	instanceSchema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Body
 	instanceSchema.Attributes["required_field"] = &configschema.Attribute{
 		Type:     cty.String,
 		Required: true,
@@ -10414,7 +10414,7 @@ func TestContext2Apply_ProviderMeta_refresh_set(t *testing.T) {
 	rrcPMs := map[string]cty.Value{}
 	p.ReadResourceFn = func(req providers.ReadResourceRequest) (resp providers.ReadResourceResponse) {
 		rrcPMs[req.TypeName] = req.ProviderMeta
-		newState, err := p.GetProviderSchemaResponse.ResourceTypes[req.TypeName].Block.CoerceValue(req.PriorState)
+		newState, err := p.GetProviderSchemaResponse.ResourceTypes[req.TypeName].Body.CoerceValue(req.PriorState)
 		if err != nil {
 			panic(err)
 		}

--- a/internal/terraform/context_eval_test.go
+++ b/internal/terraform/context_eval_test.go
@@ -148,7 +148,7 @@ func TestContextPlanAndEval(t *testing.T) {
 		GetProviderSchemaResponse: &providers.GetProviderSchemaResponse{
 			ResourceTypes: map[string]providers.Schema{
 				"test_thing": {
-					Block: &configschema.Block{
+					Body: &configschema.Block{
 						Attributes: map[string]*configschema.Attribute{
 							"arg": {
 								Type:     cty.String,
@@ -243,7 +243,7 @@ func TestContextApplyAndEval(t *testing.T) {
 		GetProviderSchemaResponse: &providers.GetProviderSchemaResponse{
 			ResourceTypes: map[string]providers.Schema{
 				"test_thing": {
-					Block: &configschema.Block{
+					Body: &configschema.Block{
 						Attributes: map[string]*configschema.Attribute{
 							"arg": {
 								Type:     cty.String,
@@ -350,7 +350,7 @@ locals {
 		GetProviderSchemaResponse: &providers.GetProviderSchemaResponse{
 			EphemeralResourceTypes: map[string]providers.Schema{
 				"ephem_resource": {
-					Block: &configschema.Block{
+					Body: &configschema.Block{
 						Attributes: map[string]*configschema.Attribute{
 							"value": {
 								Type:     cty.String,

--- a/internal/terraform/context_functions_test.go
+++ b/internal/terraform/context_functions_test.go
@@ -168,12 +168,12 @@ func TestContext2Plan_providerFunctionImpureApply(t *testing.T) {
 
 	p := &testing_provider.MockProvider{
 		GetProviderSchemaResponse: &providers.GetProviderSchemaResponse{
-			Provider: providers.Schema{Block: simpleTestSchema()},
+			Provider: providers.Schema{Body: simpleTestSchema()},
 			ResourceTypes: map[string]providers.Schema{
-				"test_object": providers.Schema{Block: simpleTestSchema()},
+				"test_object": providers.Schema{Body: simpleTestSchema()},
 			},
 			DataSources: map[string]providers.Schema{
-				"test_object": providers.Schema{Block: simpleTestSchema()},
+				"test_object": providers.Schema{Body: simpleTestSchema()},
 			},
 			Functions: map[string]providers.FunctionDecl{
 				"echo": providers.FunctionDecl{
@@ -231,7 +231,7 @@ func TestContext2Plan_providerFunctionImpureApply(t *testing.T) {
 func TestContext2Validate_providerFunctionDiagnostics(t *testing.T) {
 	provider := &testing_provider.MockProvider{
 		GetProviderSchemaResponse: &providers.GetProviderSchemaResponse{
-			Provider: providers.Schema{Block: simpleTestSchema()},
+			Provider: providers.Schema{Body: simpleTestSchema()},
 			Functions: map[string]providers.FunctionDecl{
 				"echo": providers.FunctionDecl{
 					Parameters: []providers.FunctionParam{

--- a/internal/terraform/context_plan2_test.go
+++ b/internal/terraform/context_plan2_test.go
@@ -45,10 +45,10 @@ resource "test_object" "a" {
 
 	p := simpleMockProvider()
 	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
-		Provider: providers.Schema{Block: simpleTestSchema()},
+		Provider: providers.Schema{Body: simpleTestSchema()},
 		ResourceTypes: map[string]providers.Schema{
 			"test_object": {
-				Block: &configschema.Block{
+				Body: &configschema.Block{
 					Attributes: map[string]*configschema.Attribute{
 						"arg": {Type: cty.String, Optional: true},
 					},
@@ -427,11 +427,11 @@ func TestContext2Plan_resourceChecksInExpandedModule(t *testing.T) {
 	p := testProvider("test")
 	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
 		Provider: providers.Schema{
-			Block: &configschema.Block{},
+			Body: &configschema.Block{},
 		},
 		ResourceTypes: map[string]providers.Schema{
 			"test": {
-				Block: &configschema.Block{},
+				Body: &configschema.Block{},
 			},
 		},
 	}
@@ -551,11 +551,11 @@ func TestContext2Plan_dataResourceChecksManagedResourceChange(t *testing.T) {
 	p := testProvider("test")
 	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
 		Provider: providers.Schema{
-			Block: &configschema.Block{},
+			Body: &configschema.Block{},
 		},
 		ResourceTypes: map[string]providers.Schema{
 			"test_resource": {
-				Block: &configschema.Block{
+				Body: &configschema.Block{
 					Attributes: map[string]*configschema.Attribute{
 						"id": {
 							Type:     cty.String,
@@ -571,7 +571,7 @@ func TestContext2Plan_dataResourceChecksManagedResourceChange(t *testing.T) {
 		},
 		DataSources: map[string]providers.Schema{
 			"test_data_source": {
-				Block: &configschema.Block{
+				Body: &configschema.Block{
 					Attributes: map[string]*configschema.Attribute{
 						"id": {
 							Type:     cty.String,
@@ -750,11 +750,11 @@ func TestContext2Plan_managedResourceChecksOtherManagedResourceChange(t *testing
 	p := testProvider("test")
 	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
 		Provider: providers.Schema{
-			Block: &configschema.Block{},
+			Body: &configschema.Block{},
 		},
 		ResourceTypes: map[string]providers.Schema{
 			"test_resource": {
-				Block: &configschema.Block{
+				Body: &configschema.Block{
 					Attributes: map[string]*configschema.Attribute{
 						"id": {
 							Type:     cty.String,
@@ -770,7 +770,7 @@ func TestContext2Plan_managedResourceChecksOtherManagedResourceChange(t *testing
 		},
 		DataSources: map[string]providers.Schema{
 			"test_data_source": {
-				Block: &configschema.Block{
+				Body: &configschema.Block{
 					Attributes: map[string]*configschema.Attribute{
 						"id": {
 							Type:     cty.String,
@@ -919,10 +919,10 @@ resource "test_object" "a" {
 
 	p := simpleMockProvider()
 	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
-		Provider: providers.Schema{Block: simpleTestSchema()},
+		Provider: providers.Schema{Body: simpleTestSchema()},
 		ResourceTypes: map[string]providers.Schema{
 			"test_object": {
-				Block: &configschema.Block{
+				Body: &configschema.Block{
 					Attributes: map[string]*configschema.Attribute{
 						"arg": {Type: cty.String, Optional: true},
 					},
@@ -1045,10 +1045,10 @@ resource "test_object" "a" {
 
 	p := simpleMockProvider()
 	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
-		Provider: providers.Schema{Block: simpleTestSchema()},
+		Provider: providers.Schema{Body: simpleTestSchema()},
 		ResourceTypes: map[string]providers.Schema{
 			"test_object": {
-				Block: &configschema.Block{
+				Body: &configschema.Block{
 					Attributes: map[string]*configschema.Attribute{
 						"arg": {Type: cty.String, Optional: true},
 					},
@@ -1798,7 +1798,7 @@ func TestContext2Plan_crossResourceMoveBasic(t *testing.T) {
 	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
 		ResourceTypes: map[string]providers.Schema{
 			"test_object_one": {
-				Block: &configschema.Block{
+				Body: &configschema.Block{
 					Attributes: map[string]*configschema.Attribute{
 						"value": {
 							Type:     cty.String,
@@ -1808,7 +1808,7 @@ func TestContext2Plan_crossResourceMoveBasic(t *testing.T) {
 				},
 			},
 			"test_object_two": {
-				Block: &configschema.Block{
+				Body: &configschema.Block{
 					Attributes: map[string]*configschema.Attribute{
 						"value": {
 							Type:     cty.String,
@@ -1896,7 +1896,7 @@ func TestContext2Plan_crossProviderMove(t *testing.T) {
 	one.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
 		ResourceTypes: map[string]providers.Schema{
 			"one_object": {
-				Block: &configschema.Block{
+				Body: &configschema.Block{
 					Attributes: map[string]*configschema.Attribute{
 						"value": {
 							Type:     cty.String,
@@ -1912,7 +1912,7 @@ func TestContext2Plan_crossProviderMove(t *testing.T) {
 	two.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
 		ResourceTypes: map[string]providers.Schema{
 			"two_object": {
-				Block: &configschema.Block{
+				Body: &configschema.Block{
 					Attributes: map[string]*configschema.Attribute{
 						"value": {
 							Type:     cty.String,
@@ -1999,7 +1999,7 @@ func TestContext2Plan_crossResourceMoveMissingConfig(t *testing.T) {
 		Provider: providers.Schema{},
 		ResourceTypes: map[string]providers.Schema{
 			"test_object_one": {
-				Block: &configschema.Block{
+				Body: &configschema.Block{
 					Attributes: map[string]*configschema.Attribute{
 						"value": {
 							Type:     cty.String,
@@ -2009,7 +2009,7 @@ func TestContext2Plan_crossResourceMoveMissingConfig(t *testing.T) {
 				},
 			},
 			"test_object_two": {
-				Block: &configschema.Block{
+				Body: &configschema.Block{
 					Attributes: map[string]*configschema.Attribute{
 						"value": {
 							Type:     cty.String,
@@ -2218,10 +2218,10 @@ func TestContext2Plan_refreshOnlyMode(t *testing.T) {
 
 	p := simpleMockProvider()
 	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
-		Provider: providers.Schema{Block: simpleTestSchema()},
+		Provider: providers.Schema{Body: simpleTestSchema()},
 		ResourceTypes: map[string]providers.Schema{
 			"test_object": {
-				Block: &configschema.Block{
+				Body: &configschema.Block{
 					Attributes: map[string]*configschema.Attribute{
 						"arg": {Type: cty.String, Optional: true},
 					},
@@ -2355,10 +2355,10 @@ func TestContext2Plan_refreshOnlyMode_deposed(t *testing.T) {
 
 	p := simpleMockProvider()
 	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
-		Provider: providers.Schema{Block: simpleTestSchema()},
+		Provider: providers.Schema{Body: simpleTestSchema()},
 		ResourceTypes: map[string]providers.Schema{
 			"test_object": {
-				Block: &configschema.Block{
+				Body: &configschema.Block{
 					Attributes: map[string]*configschema.Attribute{
 						"arg": {Type: cty.String, Optional: true},
 					},
@@ -2496,10 +2496,10 @@ func TestContext2Plan_refreshOnlyMode_orphan(t *testing.T) {
 
 	p := simpleMockProvider()
 	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
-		Provider: providers.Schema{Block: simpleTestSchema()},
+		Provider: providers.Schema{Body: simpleTestSchema()},
 		ResourceTypes: map[string]providers.Schema{
 			"test_object": {
-				Block: &configschema.Block{
+				Body: &configschema.Block{
 					Attributes: map[string]*configschema.Attribute{
 						"arg": {Type: cty.String, Optional: true},
 					},
@@ -4277,7 +4277,7 @@ resource "test_object" "b" {
 	testProvider := &testing_provider.MockProvider{
 		GetProviderSchemaResponse: &providers.GetProviderSchemaResponse{
 			Provider: providers.Schema{
-				Block: &configschema.Block{
+				Body: &configschema.Block{
 					Attributes: map[string]*configschema.Attribute{
 						"in": {
 							Type:     cty.String,
@@ -4288,7 +4288,7 @@ resource "test_object" "b" {
 			},
 			ResourceTypes: map[string]providers.Schema{
 				"test_object": providers.Schema{
-					Block: &configschema.Block{
+					Body: &configschema.Block{
 						Attributes: map[string]*configschema.Attribute{
 							"in": {
 								Type:     cty.String,
@@ -4524,7 +4524,7 @@ resource "test_object" "a" {
 		GetProviderSchemaResponse: &providers.GetProviderSchemaResponse{
 			ResourceTypes: map[string]providers.Schema{
 				"test_object": providers.Schema{
-					Block: &configschema.Block{
+					Body: &configschema.Block{
 						Attributes: map[string]*configschema.Attribute{
 							"map": {
 								Type:     cty.Map(cty.String),
@@ -4592,7 +4592,7 @@ func TestContext2Plan_externalProvidersWithState(t *testing.T) {
 		GetProviderSchemaResponse: &providers.GetProviderSchemaResponse{
 			ResourceTypes: map[string]providers.Schema{
 				"foo": {
-					Block: &configschema.Block{},
+					Body: &configschema.Block{},
 				},
 			},
 		},
@@ -4677,7 +4677,7 @@ func TestContext2Plan_externalProviders(t *testing.T) {
 	fooProvider := &testing_provider.MockProvider{
 		GetProviderSchemaResponse: &providers.GetProviderSchemaResponse{
 			Provider: providers.Schema{
-				Block: &configschema.Block{
+				Body: &configschema.Block{
 					Attributes: map[string]*configschema.Attribute{
 						// We have a required argument here just so that the
 						// plan will fail if the runtime erroneously tries
@@ -4697,7 +4697,7 @@ func TestContext2Plan_externalProviders(t *testing.T) {
 			},
 			ResourceTypes: map[string]providers.Schema{
 				"foo": {
-					Block: &configschema.Block{},
+					Body: &configschema.Block{},
 				},
 			},
 		},
@@ -4711,7 +4711,7 @@ func TestContext2Plan_externalProviders(t *testing.T) {
 		GetProviderSchemaResponse: &providers.GetProviderSchemaResponse{
 			ResourceTypes: map[string]providers.Schema{
 				"bar": {
-					Block: &configschema.Block{},
+					Body: &configschema.Block{},
 				},
 			},
 		},
@@ -4726,7 +4726,7 @@ func TestContext2Plan_externalProviders(t *testing.T) {
 		GetProviderSchemaResponse: &providers.GetProviderSchemaResponse{
 			ResourceTypes: map[string]providers.Schema{
 				"baz": {
-					Block: &configschema.Block{},
+					Body: &configschema.Block{},
 				},
 			},
 		},
@@ -4826,7 +4826,7 @@ func TestContext2Apply_externalDependencyDeferred(t *testing.T) {
 		GetProviderSchemaResponse: &providers.GetProviderSchemaResponse{
 			ResourceTypes: map[string]providers.Schema{
 				"test": {
-					Block: &configschema.Block{
+					Body: &configschema.Block{
 						Attributes: map[string]*configschema.Attribute{
 							"name": {
 								Type:     cty.String,
@@ -5776,7 +5776,7 @@ resource "test_object" "obj" {
 	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
 		ResourceTypes: map[string]providers.Schema{
 			"test_object": {
-				Block: &configschema.Block{
+				Body: &configschema.Block{
 					Attributes: map[string]*configschema.Attribute{
 						"value": {
 							Type:      cty.String,
@@ -5836,7 +5836,7 @@ resource "test_object" "obj" {
 	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
 		ResourceTypes: map[string]providers.Schema{
 			"test_object": {
-				Block: &configschema.Block{
+				Body: &configschema.Block{
 					Attributes: map[string]*configschema.Attribute{
 						"value": {
 							Type:      cty.String,
@@ -5931,7 +5931,7 @@ resource "test_object" "obj" {
 	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
 		ResourceTypes: map[string]providers.Schema{
 			"test_object": {
-				Block: &configschema.Block{
+				Body: &configschema.Block{
 					Attributes: map[string]*configschema.Attribute{
 						"value": {
 							Type:      cty.String,
@@ -6343,7 +6343,7 @@ resource "test_object" "a" {
 	plan, diags := ctx.Plan(m, state, DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
-	resourceType := p.GetProviderSchemaResponse.ResourceTypes["test_object"].Block.ImpliedType()
+	resourceType := p.GetProviderSchemaResponse.ResourceTypes["test_object"].Body.ImpliedType()
 	change, err := plan.Changes.ResourceInstance(mustResourceInstanceAddr(`test_object.a["old"]`)).Decode(resourceType)
 	if err != nil {
 		t.Fatal(err)

--- a/internal/terraform/context_plan_ephemeral_test.go
+++ b/internal/terraform/context_plan_ephemeral_test.go
@@ -49,7 +49,7 @@ ephemeral "ephem_resource" "data" {
 output "value" {
     value = terraform.applying
     # Testing that this errors in the best way to ensure the symbol is ephemeral
-    ephemeral = false 
+    ephemeral = false
 }
 `,
 				"main.tf": `
@@ -295,7 +295,7 @@ module "child" {
 		"provider-defined functions": {
 			module: map[string]string{
 				"child/main.tf": `
-				
+
 terraform {
     required_providers {
         ephem = {
@@ -517,13 +517,13 @@ ephemeral "ephem_resource" "data" {
 variable "ephem" {
   type        = string
   ephemeral   = true
-  
+
   validation {
     condition     = length(var.ephem) > 4
     error_message = "This should fail but not show the value: ${var.ephem}"
   }
 }
-  
+
 output "out" {
   value = ephemeralasnull(var.ephem)
 }
@@ -573,7 +573,7 @@ resource "ephem_write_only" "test" {
 				GetProviderSchemaResponse: &providers.GetProviderSchemaResponse{
 					EphemeralResourceTypes: map[string]providers.Schema{
 						"ephem_resource": {
-							Block: &configschema.Block{
+							Body: &configschema.Block{
 								Attributes: map[string]*configschema.Attribute{
 									"value": {
 										Type:     cty.String,
@@ -600,7 +600,7 @@ resource "ephem_write_only" "test" {
 					},
 					ResourceTypes: map[string]providers.Schema{
 						"ephem_write_only": {
-							Block: &configschema.Block{
+							Body: &configschema.Block{
 								Attributes: map[string]*configschema.Attribute{
 									"write_only": {
 										Type:      cty.String,
@@ -752,7 +752,7 @@ resource "sink_object" "empty" {
 		GetProviderSchemaResponse: &providers.GetProviderSchemaResponse{
 			EphemeralResourceTypes: map[string]providers.Schema{
 				"ephem_resource": {
-					Block: &configschema.Block{
+					Body: &configschema.Block{
 						Attributes: map[string]*configschema.Attribute{
 							"value": {
 								Type:     cty.String,
@@ -771,7 +771,7 @@ resource "sink_object" "empty" {
 
 	sink := simpleMockProvider()
 	sink.GetProviderSchemaResponse.ResourceTypes = map[string]providers.Schema{
-		"sink_object": {Block: simpleTestSchema()},
+		"sink_object": {Body: simpleTestSchema()},
 	}
 	sink.ConfigureProviderFn = func(req providers.ConfigureProviderRequest) (resp providers.ConfigureProviderResponse) {
 		if req.Config.GetAttr("test_string").IsKnown() {

--- a/internal/terraform/context_plan_import_test.go
+++ b/internal/terraform/context_plan_import_test.go
@@ -747,7 +747,7 @@ import {
 
 	p.GetProviderSchemaResponse.ResourceTypes = map[string]providers.Schema{
 		"test_object": {
-			Block: &configschema.Block{
+			Body: &configschema.Block{
 				Attributes: map[string]*configschema.Attribute{
 					"test_id": {
 						Type:     cty.String,
@@ -1486,13 +1486,13 @@ import {
 
 	p := simpleMockProvider()
 	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
-		Provider: providers.Schema{Block: simpleTestSchema()},
+		Provider: providers.Schema{Body: simpleTestSchema()},
 		ResourceTypes: map[string]providers.Schema{
-			"test_object": providers.Schema{Block: simpleTestSchema()},
+			"test_object": providers.Schema{Body: simpleTestSchema()},
 		},
 		DataSources: map[string]providers.Schema{
 			"test_object": providers.Schema{
-				Block: &configschema.Block{
+				Body: &configschema.Block{
 					Attributes: map[string]*configschema.Attribute{
 						"objects": {
 							Type:     cty.List(cty.String),
@@ -1609,7 +1609,7 @@ import {
 		GetProviderSchemaResponse: &providers.GetProviderSchemaResponse{
 			ResourceTypes: map[string]providers.Schema{
 				"test_object": {
-					Block: &configschema.Block{
+					Body: &configschema.Block{
 						Attributes: map[string]*configschema.Attribute{
 							"sensitive_string": {
 								Type:      cty.String,

--- a/internal/terraform/context_plan_test.go
+++ b/internal/terraform/context_plan_test.go
@@ -50,7 +50,7 @@ func TestContext2Plan_basic(t *testing.T) {
 		t.Fatalf("wrong number of resources %d; want fewer than two\n%s", l, spew.Sdump(plan.Changes.Resources))
 	}
 
-	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
+	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Body
 	ty := schema.ImpliedType()
 	for _, r := range plan.Changes.Resources {
 		ric, err := r.Decode(ty)
@@ -129,7 +129,7 @@ func TestContext2Plan_createBefore_deposed(t *testing.T) {
 		t.Fatalf("\nexpected: %q\ngot:      %q\n", expectedState, plan.PriorState.String())
 	}
 
-	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
+	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Body
 	ty := schema.ImpliedType()
 
 	type InstanceGen struct {
@@ -290,7 +290,7 @@ func TestContext2Plan_escapedVar(t *testing.T) {
 		t.Fatalf("expected resource creation, got %s", res.Action)
 	}
 
-	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
+	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Body
 	ty := schema.ImpliedType()
 
 	ric, err := res.Decode(ty)
@@ -363,7 +363,7 @@ func TestContext2Plan_modules(t *testing.T) {
 		t.Error("expected 3 resource in plan, got", len(plan.Changes.Resources))
 	}
 
-	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
+	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Body
 	ty := schema.ImpliedType()
 
 	expectFoo := objectVal(t, schema, map[string]cty.Value{
@@ -417,7 +417,7 @@ func TestContext2Plan_moduleExpand(t *testing.T) {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
 
-	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
+	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Body
 	ty := schema.ImpliedType()
 
 	expected := map[string]struct{}{
@@ -477,7 +477,7 @@ func TestContext2Plan_moduleCycle(t *testing.T) {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
 
-	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
+	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Body
 	ty := schema.ImpliedType()
 
 	if len(plan.Changes.Resources) != 2 {
@@ -531,7 +531,7 @@ func TestContext2Plan_moduleDeadlock(t *testing.T) {
 			t.Fatalf("err: %s", err)
 		}
 
-		schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
+		schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Body
 		ty := schema.ImpliedType()
 
 		for _, res := range plan.Changes.Resources {
@@ -575,7 +575,7 @@ func TestContext2Plan_moduleInput(t *testing.T) {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
 
-	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
+	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Body
 	ty := schema.ImpliedType()
 
 	if len(plan.Changes.Resources) != 2 {
@@ -629,7 +629,7 @@ func TestContext2Plan_moduleInputComputed(t *testing.T) {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
 
-	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
+	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Body
 	ty := schema.ImpliedType()
 
 	if len(plan.Changes.Resources) != 2 {
@@ -688,7 +688,7 @@ func TestContext2Plan_moduleInputFromVar(t *testing.T) {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
 
-	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
+	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Body
 	ty := schema.ImpliedType()
 
 	if len(plan.Changes.Resources) != 2 {
@@ -749,7 +749,7 @@ func TestContext2Plan_moduleMultiVar(t *testing.T) {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
 
-	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
+	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Body
 	ty := schema.ImpliedType()
 
 	if len(plan.Changes.Resources) != 5 {
@@ -822,7 +822,7 @@ func TestContext2Plan_moduleOrphans(t *testing.T) {
 	if diags.HasErrors() {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
-	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
+	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Body
 	ty := schema.ImpliedType()
 
 	if len(plan.Changes.Resources) != 2 {
@@ -916,7 +916,7 @@ func TestContext2Plan_moduleOrphansWithProvisioner(t *testing.T) {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
 
-	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
+	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Body
 	ty := schema.ImpliedType()
 
 	if len(plan.Changes.Resources) != 3 {
@@ -1187,7 +1187,7 @@ func TestContext2Plan_moduleProviderVar(t *testing.T) {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
 
-	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
+	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Body
 	ty := schema.ImpliedType()
 
 	if len(plan.Changes.Resources) != 1 {
@@ -1229,7 +1229,7 @@ func TestContext2Plan_moduleVar(t *testing.T) {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
 
-	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
+	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Body
 	ty := schema.ImpliedType()
 
 	if len(plan.Changes.Resources) != 2 {
@@ -1330,7 +1330,7 @@ func TestContext2Plan_moduleVarComputed(t *testing.T) {
 	if diags.HasErrors() {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
-	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
+	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Body
 	ty := schema.ImpliedType()
 
 	if len(plan.Changes.Resources) != 2 {
@@ -1660,7 +1660,7 @@ func TestContext2Plan_computed(t *testing.T) {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
 
-	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
+	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Body
 	ty := schema.ImpliedType()
 
 	if len(plan.Changes.Resources) != 2 {
@@ -1804,7 +1804,7 @@ func TestContext2Plan_computedDataResource(t *testing.T) {
 	if diags.HasErrors() {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
-	schema := p.GetProviderSchemaResponse.DataSources["aws_vpc"].Block
+	schema := p.GetProviderSchemaResponse.DataSources["aws_vpc"].Body
 	ty := schema.ImpliedType()
 
 	if rc := plan.Changes.ResourceInstance(addrs.Resource{Mode: addrs.ManagedResourceMode, Type: "aws_instance", Name: "foo"}.Instance(addrs.NoKey).Absolute(addrs.RootModuleInstance)); rc == nil {
@@ -1988,7 +1988,7 @@ func TestContext2Plan_dataResourceBecomesComputed(t *testing.T) {
 		}
 	}
 
-	schema := p.GetProviderSchemaResponse.DataSources["aws_data_source"].Block
+	schema := p.GetProviderSchemaResponse.DataSources["aws_data_source"].Body
 	ty := schema.ImpliedType()
 
 	p.ReadDataSourceResponse = &providers.ReadDataSourceResponse{
@@ -2073,7 +2073,7 @@ func TestContext2Plan_computedList(t *testing.T) {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
 
-	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
+	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Body
 	ty := schema.ImpliedType()
 
 	if len(plan.Changes.Resources) != 2 {
@@ -2136,7 +2136,7 @@ func TestContext2Plan_computedMultiIndex(t *testing.T) {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
 
-	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
+	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Body
 	ty := schema.ImpliedType()
 
 	if len(plan.Changes.Resources) != 3 {
@@ -2190,7 +2190,7 @@ func TestContext2Plan_count(t *testing.T) {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
 
-	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
+	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Body
 	ty := schema.ImpliedType()
 
 	if len(plan.Changes.Resources) != 6 {
@@ -2298,7 +2298,7 @@ func TestContext2Plan_countModuleStatic(t *testing.T) {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
 
-	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
+	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Body
 	ty := schema.ImpliedType()
 
 	if len(plan.Changes.Resources) != 3 {
@@ -2351,7 +2351,7 @@ func TestContext2Plan_countModuleStaticGrandchild(t *testing.T) {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
 
-	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
+	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Body
 	ty := schema.ImpliedType()
 
 	if len(plan.Changes.Resources) != 3 {
@@ -2404,7 +2404,7 @@ func TestContext2Plan_countIndex(t *testing.T) {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
 
-	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
+	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Body
 	ty := schema.ImpliedType()
 
 	if len(plan.Changes.Resources) != 2 {
@@ -2461,7 +2461,7 @@ func TestContext2Plan_countVar(t *testing.T) {
 	if diags.HasErrors() {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
-	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
+	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Body
 	ty := schema.ImpliedType()
 
 	if len(plan.Changes.Resources) != 4 {
@@ -2538,7 +2538,7 @@ func TestContext2Plan_countZero(t *testing.T) {
 	if diags.HasErrors() {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
-	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
+	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Body
 	ty := schema.ImpliedType()
 
 	if len(plan.Changes.Resources) != 1 {
@@ -2579,7 +2579,7 @@ func TestContext2Plan_countOneIndex(t *testing.T) {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
 
-	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
+	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Body
 	ty := schema.ImpliedType()
 
 	if len(plan.Changes.Resources) != 2 {
@@ -2656,7 +2656,7 @@ func TestContext2Plan_countDecreaseToOne(t *testing.T) {
 	if diags.HasErrors() {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
-	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
+	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Body
 	ty := schema.ImpliedType()
 
 	if len(plan.Changes.Resources) != 4 {
@@ -2740,7 +2740,7 @@ func TestContext2Plan_countIncreaseFromNotSet(t *testing.T) {
 	if diags.HasErrors() {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
-	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
+	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Body
 	ty := schema.ImpliedType()
 
 	if len(plan.Changes.Resources) != 4 {
@@ -2817,7 +2817,7 @@ func TestContext2Plan_countIncreaseFromOne(t *testing.T) {
 	if diags.HasErrors() {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
-	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
+	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Body
 	ty := schema.ImpliedType()
 
 	if len(plan.Changes.Resources) != 4 {
@@ -2908,7 +2908,7 @@ func TestContext2Plan_countIncreaseFromOneCorrupted(t *testing.T) {
 	if diags.HasErrors() {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
-	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
+	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Body
 	ty := schema.ImpliedType()
 
 	if len(plan.Changes.Resources) != 5 {
@@ -3033,7 +3033,7 @@ func TestContext2Plan_countIncreaseWithSplatReference(t *testing.T) {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
 
-	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
+	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Body
 	ty := schema.ImpliedType()
 
 	if len(plan.Changes.Resources) != 6 {
@@ -3087,7 +3087,7 @@ func TestContext2Plan_forEach(t *testing.T) {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
 
-	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
+	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Body
 	ty := schema.ImpliedType()
 
 	if len(plan.Changes.Resources) != 8 {
@@ -3183,7 +3183,7 @@ func TestContext2Plan_destroy(t *testing.T) {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
 
-	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
+	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Body
 	ty := schema.ImpliedType()
 
 	if len(plan.Changes.Resources) != 2 {
@@ -3244,7 +3244,7 @@ func TestContext2Plan_moduleDestroy(t *testing.T) {
 	if diags.HasErrors() {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
-	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
+	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Body
 	ty := schema.ImpliedType()
 
 	if len(plan.Changes.Resources) != 2 {
@@ -3307,7 +3307,7 @@ func TestContext2Plan_moduleDestroyCycle(t *testing.T) {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
 
-	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
+	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Body
 	ty := schema.ImpliedType()
 
 	if len(plan.Changes.Resources) != 2 {
@@ -3368,7 +3368,7 @@ func TestContext2Plan_moduleDestroyMultivar(t *testing.T) {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
 
-	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
+	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Body
 	ty := schema.ImpliedType()
 
 	if len(plan.Changes.Resources) != 2 {
@@ -3424,7 +3424,7 @@ func TestContext2Plan_pathVar(t *testing.T) {
 		t.Fatalf("err: %s", diags.Err())
 	}
 
-	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
+	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Body
 	ty := schema.ImpliedType()
 
 	if len(plan.Changes.Resources) != 1 {
@@ -3479,7 +3479,7 @@ func TestContext2Plan_diffVar(t *testing.T) {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
 
-	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
+	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Body
 	ty := schema.ImpliedType()
 
 	if len(plan.Changes.Resources) != 2 {
@@ -3594,7 +3594,7 @@ func TestContext2Plan_orphan(t *testing.T) {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
 
-	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
+	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Body
 	ty := schema.ImpliedType()
 
 	if len(plan.Changes.Resources) != 2 {
@@ -3678,7 +3678,7 @@ func TestContext2Plan_state(t *testing.T) {
 	if len(plan.Changes.Resources) < 2 {
 		t.Fatalf("bad: %#v", plan.Changes.Resources)
 	}
-	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
+	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Body
 	ty := schema.ImpliedType()
 
 	if len(plan.Changes.Resources) != 2 {
@@ -3732,11 +3732,11 @@ func TestContext2Plan_requiresReplace(t *testing.T) {
 	p := testProvider("test")
 	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
 		Provider: providers.Schema{
-			Block: &configschema.Block{},
+			Body: &configschema.Block{},
 		},
 		ResourceTypes: map[string]providers.Schema{
 			"test_thing": {
-				Block: &configschema.Block{
+				Body: &configschema.Block{
 					Attributes: map[string]*configschema.Attribute{
 						"v": {
 							Type:     cty.String,
@@ -3778,7 +3778,7 @@ func TestContext2Plan_requiresReplace(t *testing.T) {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
 
-	schema := p.GetProviderSchemaResponse.ResourceTypes["test_thing"].Block
+	schema := p.GetProviderSchemaResponse.ResourceTypes["test_thing"].Body
 	ty := schema.ImpliedType()
 
 	if got, want := len(plan.Changes.Resources), 1; got != want {
@@ -3844,7 +3844,7 @@ func TestContext2Plan_taint(t *testing.T) {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
 
-	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
+	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Body
 	ty := schema.ImpliedType()
 
 	if len(plan.Changes.Resources) != 2 {
@@ -3922,7 +3922,7 @@ func TestContext2Plan_taintIgnoreChanges(t *testing.T) {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
 
-	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
+	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Body
 	ty := schema.ImpliedType()
 
 	if len(plan.Changes.Resources) != 1 {
@@ -4003,7 +4003,7 @@ func TestContext2Plan_taintDestroyInterpolatedCountRace(t *testing.T) {
 			t.Fatalf("unexpected errors: %s", diags.Err())
 		}
 
-		schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
+		schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Body
 		ty := schema.ImpliedType()
 
 		if len(plan.Changes.Resources) != 3 {
@@ -4069,7 +4069,7 @@ func TestContext2Plan_targeted(t *testing.T) {
 		t.Error("plan marked as complete; should not be because it used targeting")
 	}
 
-	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
+	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Body
 	ty := schema.ImpliedType()
 
 	if len(plan.Changes.Resources) != 1 {
@@ -4124,7 +4124,7 @@ func TestContext2Plan_targetedCrossModule(t *testing.T) {
 		t.Error("plan marked as complete; should not be because it used targeting")
 	}
 
-	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
+	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Body
 	ty := schema.ImpliedType()
 
 	if len(plan.Changes.Resources) != 2 {
@@ -4194,7 +4194,7 @@ func TestContext2Plan_targetedModuleWithProvider(t *testing.T) {
 		t.Error("plan marked as complete; should not be because it used targeting")
 	}
 
-	schema := p.GetProviderSchemaResponse.ResourceTypes["null_resource"].Block
+	schema := p.GetProviderSchemaResponse.ResourceTypes["null_resource"].Body
 	ty := schema.ImpliedType()
 
 	if len(plan.Changes.Resources) != 1 {
@@ -4257,7 +4257,7 @@ func TestContext2Plan_targetedOrphan(t *testing.T) {
 		t.Error("plan marked as complete; should not be because it used targeting")
 	}
 
-	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
+	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Body
 	ty := schema.ImpliedType()
 
 	if len(plan.Changes.Resources) != 1 {
@@ -4327,7 +4327,7 @@ func TestContext2Plan_targetedModuleOrphan(t *testing.T) {
 		t.Error("plan marked as complete; should not be because it used targeting")
 	}
 
-	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
+	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Body
 	ty := schema.ImpliedType()
 
 	if len(plan.Changes.Resources) != 1 {
@@ -4374,7 +4374,7 @@ func TestContext2Plan_targetedModuleUntargetedVariable(t *testing.T) {
 		t.Error("plan marked as complete; should not be because it used targeting")
 	}
 
-	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
+	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Body
 	ty := schema.ImpliedType()
 
 	if len(plan.Changes.Resources) != 2 {
@@ -4479,7 +4479,7 @@ func TestContext2Plan_targetedOverTen(t *testing.T) {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
 
-	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
+	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Body
 	ty := schema.ImpliedType()
 
 	for _, res := range plan.Changes.Resources {
@@ -4578,7 +4578,7 @@ func TestContext2Plan_ignoreChanges(t *testing.T) {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
 
-	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
+	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Body
 	ty := schema.ImpliedType()
 
 	if len(plan.Changes.Resources) != 1 {
@@ -4713,7 +4713,7 @@ func TestContext2Plan_ignoreChangesInMap(t *testing.T) {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
 
-	schema := p.GetProviderSchemaResponse.ResourceTypes["test_ignore_changes_map"].Block
+	schema := p.GetProviderSchemaResponse.ResourceTypes["test_ignore_changes_map"].Body
 	ty := schema.ImpliedType()
 
 	if got, want := len(plan.Changes.Resources), 1; got != want {
@@ -4776,7 +4776,7 @@ func TestContext2Plan_ignoreChangesSensitive(t *testing.T) {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
 
-	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
+	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Body
 	ty := schema.ImpliedType()
 
 	if len(plan.Changes.Resources) != 1 {
@@ -4885,7 +4885,7 @@ func TestContext2Plan_computedValueInMap(t *testing.T) {
 	}
 
 	for _, res := range plan.Changes.Resources {
-		schema := p.GetProviderSchemaResponse.ResourceTypes[res.Addr.Resource.Resource.Type].Block
+		schema := p.GetProviderSchemaResponse.ResourceTypes[res.Addr.Resource.Resource.Type].Body
 
 		ric, err := res.Decode(schema.ImpliedType())
 		if err != nil {
@@ -4940,7 +4940,7 @@ func TestContext2Plan_moduleVariableFromSplat(t *testing.T) {
 	}
 
 	for _, res := range plan.Changes.Resources {
-		schema := p.GetProviderSchemaResponse.ResourceTypes[res.Addr.Resource.Resource.Type].Block
+		schema := p.GetProviderSchemaResponse.ResourceTypes[res.Addr.Resource.Resource.Type].Body
 
 		ric, err := res.Decode(schema.ImpliedType())
 		if err != nil {
@@ -5022,9 +5022,9 @@ func TestContext2Plan_createBeforeDestroy_depends_datasource(t *testing.T) {
 		var schema *configschema.Block
 		switch res.Addr.Resource.Resource.Mode {
 		case addrs.DataResourceMode:
-			schema = p.GetProviderSchemaResponse.DataSources[res.Addr.Resource.Resource.Type].Block
+			schema = p.GetProviderSchemaResponse.DataSources[res.Addr.Resource.Resource.Type].Body
 		case addrs.ManagedResourceMode:
-			schema = p.GetProviderSchemaResponse.ResourceTypes[res.Addr.Resource.Resource.Type].Block
+			schema = p.GetProviderSchemaResponse.ResourceTypes[res.Addr.Resource.Resource.Type].Body
 		}
 
 		ric, err := res.Decode(schema.ImpliedType())
@@ -5164,7 +5164,7 @@ func TestContext2Plan_ignoreChangesWithFlatmaps(t *testing.T) {
 	}
 
 	res := plan.Changes.Resources[0]
-	schema := p.GetProviderSchemaResponse.ResourceTypes[res.Addr.Resource.Resource.Type].Block
+	schema := p.GetProviderSchemaResponse.ResourceTypes[res.Addr.Resource.Resource.Type].Body
 
 	ric, err := res.Decode(schema.ImpliedType())
 	if err != nil {
@@ -5588,7 +5588,7 @@ func TestContext2Plan_variableSensitivity(t *testing.T) {
 	if diags.HasErrors() {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
-	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
+	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Body
 	ty := schema.ImpliedType()
 
 	if len(plan.Changes.Resources) != 1 {
@@ -5654,7 +5654,7 @@ func TestContext2Plan_variableSensitivityModule(t *testing.T) {
 	if diags.HasErrors() {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
-	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
+	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Body
 	ty := schema.ImpliedType()
 
 	if len(plan.Changes.Resources) != 1 {
@@ -5754,7 +5754,7 @@ func TestContext2Plan_requiredModuleOutput(t *testing.T) {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
 
-	schema := p.GetProviderSchemaResponse.ResourceTypes["test_resource"].Block
+	schema := p.GetProviderSchemaResponse.ResourceTypes["test_resource"].Body
 	ty := schema.ImpliedType()
 
 	if len(plan.Changes.Resources) != 2 {
@@ -5817,7 +5817,7 @@ func TestContext2Plan_requiredModuleObject(t *testing.T) {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
 
-	schema := p.GetProviderSchemaResponse.ResourceTypes["test_resource"].Block
+	schema := p.GetProviderSchemaResponse.ResourceTypes["test_resource"].Body
 	ty := schema.ImpliedType()
 
 	if len(plan.Changes.Resources) != 2 {
@@ -6286,7 +6286,7 @@ func TestContext2Plan_targetedModuleInstance(t *testing.T) {
 	if diags.HasErrors() {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
-	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
+	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Body
 	ty := schema.ImpliedType()
 
 	if len(plan.Changes.Resources) != 1 {

--- a/internal/terraform/context_refresh_test.go
+++ b/internal/terraform/context_refresh_test.go
@@ -43,7 +43,7 @@ func TestContext2Refresh(t *testing.T) {
 		},
 	})
 
-	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
+	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Body
 	ty := schema.ImpliedType()
 	readState, err := hcl2shim.HCL2ValueFromFlatmap(map[string]string{"id": "foo", "foo": "baz"}, ty)
 	if err != nil {
@@ -130,7 +130,7 @@ func TestContext2Refresh_dynamicAttr(t *testing.T) {
 		},
 	})
 
-	schema := p.GetProviderSchemaResponse.ResourceTypes["test_instance"].Block
+	schema := p.GetProviderSchemaResponse.ResourceTypes["test_instance"].Body
 	ty := schema.ImpliedType()
 
 	s, diags := ctx.Refresh(m, startingState, &PlanOpts{Mode: plans.NormalMode})
@@ -516,7 +516,7 @@ func TestContext2Refresh_delete(t *testing.T) {
 	})
 
 	p.ReadResourceResponse = &providers.ReadResourceResponse{
-		NewState: cty.NullVal(p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block.ImpliedType()),
+		NewState: cty.NullVal(p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Body.ImpliedType()),
 	}
 
 	s, diags := ctx.Refresh(m, state, &PlanOpts{Mode: plans.NormalMode})
@@ -768,7 +768,7 @@ func TestContext2Refresh_outputPartial(t *testing.T) {
 	})
 
 	p.ReadResourceResponse = &providers.ReadResourceResponse{
-		NewState: cty.NullVal(p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block.ImpliedType()),
+		NewState: cty.NullVal(p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Body.ImpliedType()),
 	}
 
 	state := states.NewState()
@@ -807,7 +807,7 @@ func TestContext2Refresh_stateBasic(t *testing.T) {
 		},
 	})
 
-	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
+	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Body
 	ty := schema.ImpliedType()
 
 	readStateVal, err := schema.CoerceValue(cty.ObjectVal(map[string]cty.Value{

--- a/internal/terraform/context_validate_test.go
+++ b/internal/terraform/context_validate_test.go
@@ -121,7 +121,7 @@ func TestContext2Validate_computedVar(t *testing.T) {
 	p := testProvider("aws")
 	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
 		Provider: providers.Schema{
-			Block: &configschema.Block{
+			Body: &configschema.Block{
 				Attributes: map[string]*configschema.Attribute{
 					"value": {Type: cty.String, Optional: true},
 				},
@@ -129,7 +129,7 @@ func TestContext2Validate_computedVar(t *testing.T) {
 		},
 		ResourceTypes: map[string]providers.Schema{
 			"aws_instance": {
-				Block: &configschema.Block{
+				Body: &configschema.Block{
 					Attributes: map[string]*configschema.Attribute{},
 				},
 			},
@@ -139,7 +139,7 @@ func TestContext2Validate_computedVar(t *testing.T) {
 	pt.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
 		ResourceTypes: map[string]providers.Schema{
 			"test_instance": {
-				Block: &configschema.Block{
+				Body: &configschema.Block{
 					Attributes: map[string]*configschema.Attribute{
 						"id":    {Type: cty.String, Computed: true},
 						"value": {Type: cty.String, Optional: true},
@@ -180,7 +180,7 @@ func TestContext2Validate_computedInFunction(t *testing.T) {
 	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
 		ResourceTypes: map[string]providers.Schema{
 			"aws_instance": {
-				Block: &configschema.Block{
+				Body: &configschema.Block{
 					Attributes: map[string]*configschema.Attribute{
 						"attr": {Type: cty.Number, Optional: true},
 					},
@@ -189,7 +189,7 @@ func TestContext2Validate_computedInFunction(t *testing.T) {
 		},
 		DataSources: map[string]providers.Schema{
 			"aws_data_source": {
-				Block: &configschema.Block{
+				Body: &configschema.Block{
 					Attributes: map[string]*configschema.Attribute{
 						"optional_attr": {Type: cty.String, Optional: true},
 						"computed":      {Type: cty.String, Computed: true},
@@ -220,14 +220,14 @@ func TestContext2Validate_countComputed(t *testing.T) {
 	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
 		ResourceTypes: map[string]providers.Schema{
 			"aws_instance": {
-				Block: &configschema.Block{
+				Body: &configschema.Block{
 					Attributes: map[string]*configschema.Attribute{},
 				},
 			},
 		},
 		DataSources: map[string]providers.Schema{
 			"aws_data_source": {
-				Block: &configschema.Block{
+				Body: &configschema.Block{
 					Attributes: map[string]*configschema.Attribute{
 						"compute": {Type: cty.String, Optional: true},
 						"value":   {Type: cty.String, Computed: true},
@@ -255,7 +255,7 @@ func TestContext2Validate_countNegative(t *testing.T) {
 	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
 		ResourceTypes: map[string]providers.Schema{
 			"aws_instance": {
-				Block: &configschema.Block{
+				Body: &configschema.Block{
 					Attributes: map[string]*configschema.Attribute{},
 				},
 			},
@@ -279,7 +279,7 @@ func TestContext2Validate_countVariable(t *testing.T) {
 	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
 		ResourceTypes: map[string]providers.Schema{
 			"aws_instance": {
-				Block: &configschema.Block{
+				Body: &configschema.Block{
 					Attributes: map[string]*configschema.Attribute{
 						"foo": {Type: cty.String, Optional: true},
 					},
@@ -306,7 +306,7 @@ func TestContext2Validate_countVariableNoDefault(t *testing.T) {
 	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
 		ResourceTypes: map[string]providers.Schema{
 			"aws_instance": {
-				Block: &configschema.Block{
+				Body: &configschema.Block{
 					Attributes: map[string]*configschema.Attribute{
 						"foo": {Type: cty.String, Optional: true},
 					},
@@ -333,7 +333,7 @@ func TestContext2Validate_moduleBadOutput(t *testing.T) {
 	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
 		ResourceTypes: map[string]providers.Schema{
 			"aws_instance": {
-				Block: &configschema.Block{
+				Body: &configschema.Block{
 					Attributes: map[string]*configschema.Attribute{
 						"foo": {Type: cty.String, Optional: true},
 					},
@@ -359,7 +359,7 @@ func TestContext2Validate_moduleGood(t *testing.T) {
 	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
 		ResourceTypes: map[string]providers.Schema{
 			"aws_instance": {
-				Block: &configschema.Block{
+				Body: &configschema.Block{
 					Attributes: map[string]*configschema.Attribute{
 						"foo": {Type: cty.String, Optional: true},
 					},
@@ -386,7 +386,7 @@ func TestContext2Validate_moduleBadResource(t *testing.T) {
 	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
 		ResourceTypes: map[string]providers.Schema{
 			"aws_instance": {
-				Block: &configschema.Block{
+				Body: &configschema.Block{
 					Attributes: map[string]*configschema.Attribute{},
 				},
 			},
@@ -415,7 +415,7 @@ func TestContext2Validate_moduleDepsShouldNotCycle(t *testing.T) {
 	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
 		ResourceTypes: map[string]providers.Schema{
 			"aws_instance": {
-				Block: &configschema.Block{
+				Body: &configschema.Block{
 					Attributes: map[string]*configschema.Attribute{
 						"id": {Type: cty.String, Optional: true},
 					},
@@ -441,7 +441,7 @@ func TestContext2Validate_moduleProviderVar(t *testing.T) {
 	p := testProvider("aws")
 	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
 		Provider: providers.Schema{
-			Block: &configschema.Block{
+			Body: &configschema.Block{
 				Attributes: map[string]*configschema.Attribute{
 					"foo": {Type: cty.String, Optional: true},
 				},
@@ -449,7 +449,7 @@ func TestContext2Validate_moduleProviderVar(t *testing.T) {
 		},
 		ResourceTypes: map[string]providers.Schema{
 			"aws_instance": {
-				Block: &configschema.Block{
+				Body: &configschema.Block{
 					Attributes: map[string]*configschema.Attribute{
 						"foo": {Type: cty.String, Optional: true},
 					},
@@ -482,7 +482,7 @@ func TestContext2Validate_moduleProviderInheritUnused(t *testing.T) {
 	p := testProvider("aws")
 	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
 		Provider: providers.Schema{
-			Block: &configschema.Block{
+			Body: &configschema.Block{
 				Attributes: map[string]*configschema.Attribute{
 					"foo": {Type: cty.String, Optional: true},
 				},
@@ -490,7 +490,7 @@ func TestContext2Validate_moduleProviderInheritUnused(t *testing.T) {
 		},
 		ResourceTypes: map[string]providers.Schema{
 			"aws_instance": {
-				Block: &configschema.Block{
+				Body: &configschema.Block{
 					Attributes: map[string]*configschema.Attribute{
 						"foo": {Type: cty.String, Optional: true},
 					},
@@ -523,7 +523,7 @@ func TestContext2Validate_orphans(t *testing.T) {
 	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
 		ResourceTypes: map[string]providers.Schema{
 			"aws_instance": {
-				Block: &configschema.Block{
+				Body: &configschema.Block{
 					Attributes: map[string]*configschema.Attribute{
 						"foo": {Type: cty.String, Optional: true},
 						"num": {Type: cty.String, Optional: true},
@@ -562,7 +562,7 @@ func TestContext2Validate_providerConfig_bad(t *testing.T) {
 	p := testProvider("aws")
 	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
 		Provider: providers.Schema{
-			Block: &configschema.Block{
+			Body: &configschema.Block{
 				Attributes: map[string]*configschema.Attribute{
 					"foo": {Type: cty.String, Optional: true},
 				},
@@ -570,7 +570,7 @@ func TestContext2Validate_providerConfig_bad(t *testing.T) {
 		},
 		ResourceTypes: map[string]providers.Schema{
 			"aws_instance": {
-				Block: &configschema.Block{
+				Body: &configschema.Block{
 					Attributes: map[string]*configschema.Attribute{},
 				},
 			},
@@ -601,7 +601,7 @@ func TestContext2Validate_providerConfig_skippedEmpty(t *testing.T) {
 	p := testProvider("aws")
 	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
 		Provider: providers.Schema{
-			Block: &configschema.Block{
+			Body: &configschema.Block{
 				Attributes: map[string]*configschema.Attribute{
 					"foo": {Type: cty.String, Optional: true},
 				},
@@ -609,7 +609,7 @@ func TestContext2Validate_providerConfig_skippedEmpty(t *testing.T) {
 		},
 		ResourceTypes: map[string]providers.Schema{
 			"aws_instance": {
-				Block: &configschema.Block{
+				Body: &configschema.Block{
 					Attributes: map[string]*configschema.Attribute{},
 				},
 			},
@@ -637,7 +637,7 @@ func TestContext2Validate_providerConfig_good(t *testing.T) {
 	p := testProvider("aws")
 	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
 		Provider: providers.Schema{
-			Block: &configschema.Block{
+			Body: &configschema.Block{
 				Attributes: map[string]*configschema.Attribute{
 					"foo": {Type: cty.String, Optional: true},
 				},
@@ -645,7 +645,7 @@ func TestContext2Validate_providerConfig_good(t *testing.T) {
 		},
 		ResourceTypes: map[string]providers.Schema{
 			"aws_instance": {
-				Block: &configschema.Block{
+				Body: &configschema.Block{
 					Attributes: map[string]*configschema.Attribute{},
 				},
 			},
@@ -672,7 +672,7 @@ func TestContext2Validate_requiredProviderConfig(t *testing.T) {
 
 	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
 		Provider: providers.Schema{
-			Block: &configschema.Block{
+			Body: &configschema.Block{
 				Attributes: map[string]*configschema.Attribute{
 					"required_attribute": {Type: cty.String, Required: true},
 				},
@@ -680,7 +680,7 @@ func TestContext2Validate_requiredProviderConfig(t *testing.T) {
 		},
 		ResourceTypes: map[string]providers.Schema{
 			"aws_instance": {
-				Block: &configschema.Block{
+				Body: &configschema.Block{
 					Attributes: map[string]*configschema.Attribute{},
 				},
 			},
@@ -705,7 +705,7 @@ func TestContext2Validate_provisionerConfig_bad(t *testing.T) {
 	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
 		ResourceTypes: map[string]providers.Schema{
 			"aws_instance": {
-				Block: &configschema.Block{
+				Body: &configschema.Block{
 					Attributes: map[string]*configschema.Attribute{
 						"foo": {Type: cty.String, Optional: true},
 					},
@@ -741,7 +741,7 @@ func TestContext2Validate_badResourceConnection(t *testing.T) {
 	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
 		ResourceTypes: map[string]providers.Schema{
 			"aws_instance": {
-				Block: &configschema.Block{
+				Body: &configschema.Block{
 					Attributes: map[string]*configschema.Attribute{
 						"foo": {Type: cty.String, Optional: true},
 					},
@@ -774,7 +774,7 @@ func TestContext2Validate_badProvisionerConnection(t *testing.T) {
 	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
 		ResourceTypes: map[string]providers.Schema{
 			"aws_instance": {
-				Block: &configschema.Block{
+				Body: &configschema.Block{
 					Attributes: map[string]*configschema.Attribute{
 						"foo": {Type: cty.String, Optional: true},
 					},
@@ -806,7 +806,7 @@ func TestContext2Validate_provisionerConfig_good(t *testing.T) {
 	p := testProvider("aws")
 	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
 		Provider: providers.Schema{
-			Block: &configschema.Block{
+			Body: &configschema.Block{
 				Attributes: map[string]*configschema.Attribute{
 					"foo": {Type: cty.String, Optional: true},
 				},
@@ -814,7 +814,7 @@ func TestContext2Validate_provisionerConfig_good(t *testing.T) {
 		},
 		ResourceTypes: map[string]providers.Schema{
 			"aws_instance": {
-				Block: &configschema.Block{
+				Body: &configschema.Block{
 					Attributes: map[string]*configschema.Attribute{
 						"foo": {Type: cty.String, Optional: true},
 					},
@@ -855,7 +855,7 @@ func TestContext2Validate_requiredVar(t *testing.T) {
 	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
 		ResourceTypes: map[string]providers.Schema{
 			"aws_instance": {
-				Block: &configschema.Block{
+				Body: &configschema.Block{
 					Attributes: map[string]*configschema.Attribute{
 						"ami": {Type: cty.String, Optional: true},
 					},
@@ -891,7 +891,7 @@ func TestContext2Validate_resourceConfig_bad(t *testing.T) {
 	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
 		ResourceTypes: map[string]providers.Schema{
 			"aws_instance": {
-				Block: &configschema.Block{
+				Body: &configschema.Block{
 					Attributes: map[string]*configschema.Attribute{
 						"foo": {Type: cty.String, Optional: true},
 					},
@@ -921,7 +921,7 @@ func TestContext2Validate_resourceConfig_good(t *testing.T) {
 	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
 		ResourceTypes: map[string]providers.Schema{
 			"aws_instance": {
-				Block: &configschema.Block{
+				Body: &configschema.Block{
 					Attributes: map[string]*configschema.Attribute{
 						"foo": {Type: cty.String, Optional: true},
 					},
@@ -946,7 +946,7 @@ func TestContext2Validate_tainted(t *testing.T) {
 	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
 		ResourceTypes: map[string]providers.Schema{
 			"aws_instance": {
-				Block: &configschema.Block{
+				Body: &configschema.Block{
 					Attributes: map[string]*configschema.Attribute{
 						"foo": {Type: cty.String, Optional: true},
 						"num": {Type: cty.String, Optional: true},
@@ -986,7 +986,7 @@ func TestContext2Validate_targetedDestroy(t *testing.T) {
 	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
 		ResourceTypes: map[string]providers.Schema{
 			"aws_instance": {
-				Block: &configschema.Block{
+				Body: &configschema.Block{
 					Attributes: map[string]*configschema.Attribute{
 						"foo": {Type: cty.String, Optional: true},
 						"num": {Type: cty.String, Optional: true},
@@ -1022,7 +1022,7 @@ func TestContext2Validate_varRefUnknown(t *testing.T) {
 	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
 		ResourceTypes: map[string]providers.Schema{
 			"aws_instance": {
-				Block: &configschema.Block{
+				Body: &configschema.Block{
 					Attributes: map[string]*configschema.Attribute{
 						"foo": {Type: cty.String, Optional: true},
 					},
@@ -1062,7 +1062,7 @@ func TestContext2Validate_interpolateVar(t *testing.T) {
 	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
 		ResourceTypes: map[string]providers.Schema{
 			"template_file": {
-				Block: &configschema.Block{
+				Body: &configschema.Block{
 					Attributes: map[string]*configschema.Attribute{
 						"template": {Type: cty.String, Optional: true},
 					},
@@ -1094,7 +1094,7 @@ func TestContext2Validate_interpolateComputedModuleVarDef(t *testing.T) {
 	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
 		ResourceTypes: map[string]providers.Schema{
 			"aws_instance": {
-				Block: &configschema.Block{
+				Body: &configschema.Block{
 					Attributes: map[string]*configschema.Attribute{
 						"attr": {Type: cty.String, Optional: true},
 					},
@@ -1778,7 +1778,7 @@ resource "test_instance" "a" {
 	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
 		ResourceTypes: map[string]providers.Schema{
 			"test_instance": {
-				Block: &configschema.Block{
+				Body: &configschema.Block{
 					Attributes: map[string]*configschema.Attribute{
 						"id": {Type: cty.String, Computed: true},
 					},
@@ -1819,7 +1819,7 @@ func TestContext2Validate_sensitiveProvisionerConfig(t *testing.T) {
 	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
 		ResourceTypes: map[string]providers.Schema{
 			"aws_instance": {
-				Block: &configschema.Block{
+				Body: &configschema.Block{
 					Attributes: map[string]*configschema.Attribute{
 						"foo": {Type: cty.String, Optional: true},
 					},
@@ -2920,7 +2920,7 @@ resource "bar_instance" "test" {
 	provider := &testing_provider.MockProvider{
 		GetProviderSchemaResponse: &providers.GetProviderSchemaResponse{
 			Provider: providers.Schema{
-				Block: &configschema.Block{
+				Body: &configschema.Block{
 					Attributes: map[string]*configschema.Attribute{
 						// We have a required attribute that is not set, we're
 						// expecting this to not matter as we shouldn't validate
@@ -2935,7 +2935,7 @@ resource "bar_instance" "test" {
 			},
 			ResourceTypes: map[string]providers.Schema{
 				"bar_instance": {
-					Block: &configschema.Block{
+					Body: &configschema.Block{
 						Attributes: map[string]*configschema.Attribute{
 							// We should still validate this attribute as being
 							// incorrect, even though we have an external
@@ -3006,7 +3006,7 @@ output "foo" {
 	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
 		ResourceTypes: map[string]providers.Schema{
 			"test_instance": {
-				Block: &configschema.Block{
+				Body: &configschema.Block{
 					Attributes: map[string]*configschema.Attribute{
 						"id": {Type: cty.String, Computed: true},
 					},

--- a/internal/terraform/evaluate_test.go
+++ b/internal/terraform/evaluate_test.go
@@ -295,7 +295,7 @@ func TestEvaluatorGetResource(t *testing.T) {
 			addrs.NewDefaultProvider("test"): {
 				ResourceTypes: map[string]providers.Schema{
 					"test_resource": {
-						Block: &configschema.Block{
+						Body: &configschema.Block{
 							Attributes: map[string]*configschema.Attribute{
 								"id": {
 									Type:     cty.String,
@@ -469,7 +469,7 @@ func TestEvaluatorGetResource_changes(t *testing.T) {
 			addrs.NewDefaultProvider("test"): {
 				ResourceTypes: map[string]providers.Schema{
 					"test_resource": {
-						Block: &configschema.Block{
+						Body: &configschema.Block{
 							Attributes: map[string]*configschema.Attribute{
 								"id": {
 									Type:     cty.String,

--- a/internal/terraform/evaluate_valid_test.go
+++ b/internal/terraform/evaluate_valid_test.go
@@ -104,7 +104,7 @@ For example, to correlate with indices of a referring resource, use:
 			addrs.NewDefaultProvider("aws"): {
 				ResourceTypes: map[string]providers.Schema{
 					"aws_instance": {
-						Block: &configschema.Block{},
+						Body: &configschema.Block{},
 					},
 				},
 			},
@@ -112,12 +112,12 @@ For example, to correlate with indices of a referring resource, use:
 				ResourceTypes: map[string]providers.Schema{
 					// intentional mismatch between resource type prefix and provider type
 					"boop_instance": {
-						Block: &configschema.Block{},
+						Body: &configschema.Block{},
 					},
 				},
 				DataSources: map[string]providers.Schema{
 					"boop_data": {
-						Block: &configschema.Block{
+						Body: &configschema.Block{
 							Attributes: map[string]*configschema.Attribute{
 								"id": {
 									Type:     cty.String,
@@ -129,7 +129,7 @@ For example, to correlate with indices of a referring resource, use:
 				},
 				EphemeralResourceTypes: map[string]providers.Schema{
 					"beep": {
-						Block: &configschema.Block{},
+						Body: &configschema.Block{},
 					},
 				},
 			},

--- a/internal/terraform/graph_builder_apply_test.go
+++ b/internal/terraform/graph_builder_apply_test.go
@@ -467,12 +467,12 @@ func TestApplyGraphBuilder_updateFromOrphan(t *testing.T) {
 		cty.ObjectVal(map[string]cty.Value{
 			"id":          cty.StringVal("b_id"),
 			"test_string": cty.StringVal("a_id"),
-		}), instanceSchema.Block.ImpliedType())
+		}), instanceSchema.Body.ImpliedType())
 	bAfter, _ := plans.NewDynamicValue(
 		cty.ObjectVal(map[string]cty.Value{
 			"id":          cty.StringVal("b_id"),
 			"test_string": cty.StringVal("changed"),
-		}), instanceSchema.Block.ImpliedType())
+		}), instanceSchema.Body.ImpliedType())
 
 	changes := &plans.ChangesSrc{
 		Resources: []*plans.ResourceInstanceChangeSrc{
@@ -572,12 +572,12 @@ func TestApplyGraphBuilder_updateFromCBDOrphan(t *testing.T) {
 		cty.ObjectVal(map[string]cty.Value{
 			"id":          cty.StringVal("b_id"),
 			"test_string": cty.StringVal("a_id"),
-		}), instanceSchema.Block.ImpliedType())
+		}), instanceSchema.Body.ImpliedType())
 	bAfter, _ := plans.NewDynamicValue(
 		cty.ObjectVal(map[string]cty.Value{
 			"id":          cty.StringVal("b_id"),
 			"test_string": cty.StringVal("changed"),
-		}), instanceSchema.Block.ImpliedType())
+		}), instanceSchema.Body.ImpliedType())
 
 	changes := &plans.ChangesSrc{
 		Resources: []*plans.ResourceInstanceChangeSrc{

--- a/internal/terraform/graph_builder_plan_test.go
+++ b/internal/terraform/graph_builder_plan_test.go
@@ -23,11 +23,11 @@ func TestPlanGraphBuilder_impl(t *testing.T) {
 func TestPlanGraphBuilder(t *testing.T) {
 	awsProvider := &testing_provider.MockProvider{
 		GetProviderSchemaResponse: &providers.GetProviderSchemaResponse{
-			Provider: providers.Schema{Block: simpleTestSchema()},
+			Provider: providers.Schema{Body: simpleTestSchema()},
 			ResourceTypes: map[string]providers.Schema{
-				"aws_security_group": {Block: simpleTestSchema()},
-				"aws_instance":       {Block: simpleTestSchema()},
-				"aws_load_balancer":  {Block: simpleTestSchema()},
+				"aws_security_group": {Body: simpleTestSchema()},
+				"aws_instance":       {Body: simpleTestSchema()},
+				"aws_load_balancer":  {Body: simpleTestSchema()},
 			},
 		},
 	}

--- a/internal/terraform/node_provider.go
+++ b/internal/terraform/node_provider.go
@@ -69,7 +69,7 @@ func (n *NodeApplyableProvider) ValidateProvider(ctx EvalContext, provider provi
 		return diags
 	}
 
-	configSchema := schemaResp.Provider.Block
+	configSchema := schemaResp.Provider.Body
 	if configSchema == nil {
 		// Should never happen in real code, but often comes up in tests where
 		// mock schemas are being used that tend to be incomplete.
@@ -111,7 +111,7 @@ func (n *NodeApplyableProvider) ConfigureProvider(ctx EvalContext, provider prov
 		return diags
 	}
 
-	configSchema := resp.Provider.Block
+	configSchema := resp.Provider.Body
 	configVal, configBody, evalDiags := ctx.EvaluateBlock(configBody, configSchema, nil, EvalDataForNoInstanceKey)
 	diags = diags.Append(evalDiags)
 	if evalDiags.HasErrors() {

--- a/internal/terraform/node_resource_abstract_instance.go
+++ b/internal/terraform/node_resource_abstract_instance.go
@@ -1692,7 +1692,7 @@ func (n *NodeAbstractResourceInstance) providerMetas(ctx EvalContext) (cty.Value
 	if n.ProviderMetas != nil {
 		if m, ok := n.ProviderMetas[n.ResolvedProvider.Provider]; ok && m != nil {
 			// if the provider doesn't support this feature, throw an error
-			if providerSchema.ProviderMeta.Block == nil {
+			if providerSchema.ProviderMeta.Body == nil {
 				diags = diags.Append(&hcl.Diagnostic{
 					Severity: hcl.DiagError,
 					Summary:  fmt.Sprintf("Provider %s doesn't support provider_meta", n.ResolvedProvider.Provider.String()),
@@ -1701,7 +1701,7 @@ func (n *NodeAbstractResourceInstance) providerMetas(ctx EvalContext) (cty.Value
 				})
 			} else {
 				var configDiags tfdiags.Diagnostics
-				metaConfigVal, _, configDiags = ctx.EvaluateBlock(m.Config, providerSchema.ProviderMeta.Block, nil, EvalDataForNoInstanceKey)
+				metaConfigVal, _, configDiags = ctx.EvaluateBlock(m.Config, providerSchema.ProviderMeta.Body, nil, EvalDataForNoInstanceKey)
 				diags = diags.Append(configDiags)
 			}
 		}

--- a/internal/terraform/node_resource_destroy_deposed_test.go
+++ b/internal/terraform/node_resource_destroy_deposed_test.go
@@ -45,7 +45,7 @@ func TestNodePlanDeposedResourceInstanceObject_Execute(t *testing.T) {
 		ProviderSchemaSchema: providers.ProviderSchema{
 			ResourceTypes: map[string]providers.Schema{
 				"test_instance": {
-					Block: &configschema.Block{
+					Body: &configschema.Block{
 						Attributes: map[string]*configschema.Attribute{
 							"id": {
 								Type:     cty.String,
@@ -103,7 +103,7 @@ func TestNodeDestroyDeposedResourceInstanceObject_Execute(t *testing.T) {
 	schema := providers.ProviderSchema{
 		ResourceTypes: map[string]providers.Schema{
 			"test_instance": {
-				Block: &configschema.Block{
+				Body: &configschema.Block{
 					Attributes: map[string]*configschema.Attribute{
 						"id": {
 							Type:     cty.String,

--- a/internal/terraform/node_resource_plan_instance.go
+++ b/internal/terraform/node_resource_plan_instance.go
@@ -234,7 +234,7 @@ func (n *NodePlannableResourceInstance) managedResourceExecute(ctx EvalContext) 
 				// function isn't doing anything as there is no configuration
 				// to validate.
 
-				impliedType := providerSchema.ResourceTypes[addr.Resource.Resource.Type].Block.ImpliedType()
+				impliedType := providerSchema.ResourceTypes[addr.Resource.Resource.Type].Body.ImpliedType()
 				ctx.Deferrals().ReportResourceInstanceDeferred(addr, providers.DeferredReasonResourceConfigUnknown, &plans.ResourceInstanceChange{
 					Addr:         addr,
 					PrevRunAddr:  addr,

--- a/internal/terraform/node_resource_plan_orphan_test.go
+++ b/internal/terraform/node_resource_plan_orphan_test.go
@@ -47,7 +47,7 @@ func TestNodeResourcePlanOrphanExecute(t *testing.T) {
 		ProviderSchemaSchema: providers.ProviderSchema{
 			ResourceTypes: map[string]providers.Schema{
 				"test_object": {
-					Block: simpleTestSchema(),
+					Body: simpleTestSchema(),
 				},
 			},
 		},
@@ -103,7 +103,7 @@ func TestNodeResourcePlanOrphanExecute_alreadyDeleted(t *testing.T) {
 	p := simpleMockProvider()
 	p.ConfigureProvider(providers.ConfigureProviderRequest{})
 	p.ReadResourceResponse = &providers.ReadResourceResponse{
-		NewState: cty.NullVal(p.GetProviderSchemaResponse.ResourceTypes["test_string"].Block.ImpliedType()),
+		NewState: cty.NullVal(p.GetProviderSchemaResponse.ResourceTypes["test_string"].Body.ImpliedType()),
 	}
 	ctx := &MockEvalContext{
 		StateState:               state.SyncWrapper(),
@@ -114,7 +114,7 @@ func TestNodeResourcePlanOrphanExecute_alreadyDeleted(t *testing.T) {
 		ProviderSchemaSchema: providers.ProviderSchema{
 			ResourceTypes: map[string]providers.Schema{
 				"test_object": {
-					Block: simpleTestSchema(),
+					Body: simpleTestSchema(),
 				},
 			},
 		},
@@ -186,7 +186,7 @@ func TestNodeResourcePlanOrphanExecute_deposed(t *testing.T) {
 	p := simpleMockProvider()
 	p.ConfigureProvider(providers.ConfigureProviderRequest{})
 	p.ReadResourceResponse = &providers.ReadResourceResponse{
-		NewState: cty.NullVal(p.GetProviderSchemaResponse.ResourceTypes["test_string"].Block.ImpliedType()),
+		NewState: cty.NullVal(p.GetProviderSchemaResponse.ResourceTypes["test_string"].Body.ImpliedType()),
 	}
 	ctx := &MockEvalContext{
 		StateState:               state.SyncWrapper(),
@@ -197,7 +197,7 @@ func TestNodeResourcePlanOrphanExecute_deposed(t *testing.T) {
 		ProviderSchemaSchema: providers.ProviderSchema{
 			ResourceTypes: map[string]providers.Schema{
 				"test_object": {
-					Block: simpleTestSchema(),
+					Body: simpleTestSchema(),
 				},
 			},
 		},

--- a/internal/terraform/node_resource_validate_test.go
+++ b/internal/terraform/node_resource_validate_test.go
@@ -622,9 +622,9 @@ func TestNodeValidatableResource_ValidateResource_invalidIgnoreChangesComputed(t
 
 	mp := &testing_provider.MockProvider{
 		GetProviderSchemaResponse: &providers.GetProviderSchemaResponse{
-			Provider: providers.Schema{Block: ms},
+			Provider: providers.Schema{Body: ms},
 			ResourceTypes: map[string]providers.Schema{
-				"test_object": providers.Schema{Block: ms},
+				"test_object": providers.Schema{Body: ms},
 			},
 		},
 	}

--- a/internal/terraform/resource_provider_mock_test.go
+++ b/internal/terraform/resource_provider_mock_test.go
@@ -16,7 +16,7 @@ import (
 func mockProviderWithConfigSchema(schema *configschema.Block) *testing_provider.MockProvider {
 	return &testing_provider.MockProvider{
 		GetProviderSchemaResponse: &providers.GetProviderSchemaResponse{
-			Provider: providers.Schema{Block: schema},
+			Provider: providers.Schema{Body: schema},
 		},
 	}
 }
@@ -27,7 +27,7 @@ func mockProviderWithResourceTypeSchema(name string, schema *configschema.Block)
 	return &testing_provider.MockProvider{
 		GetProviderSchemaResponse: &providers.GetProviderSchemaResponse{
 			Provider: providers.Schema{
-				Block: &configschema.Block{
+				Body: &configschema.Block{
 					Attributes: map[string]*configschema.Attribute{
 						"string": {
 							Type:     cty.String,
@@ -45,7 +45,7 @@ func mockProviderWithResourceTypeSchema(name string, schema *configschema.Block)
 				},
 			},
 			ResourceTypes: map[string]providers.Schema{
-				name: providers.Schema{Block: schema},
+				name: providers.Schema{Body: schema},
 			},
 		},
 	}
@@ -71,12 +71,12 @@ func mockProviderWithResourceTypeSchema(name string, schema *configschema.Block)
 func simpleMockProvider() *testing_provider.MockProvider {
 	return &testing_provider.MockProvider{
 		GetProviderSchemaResponse: &providers.GetProviderSchemaResponse{
-			Provider: providers.Schema{Block: simpleTestSchema()},
+			Provider: providers.Schema{Body: simpleTestSchema()},
 			ResourceTypes: map[string]providers.Schema{
-				"test_object": providers.Schema{Block: simpleTestSchema()},
+				"test_object": providers.Schema{Body: simpleTestSchema()},
 			},
 			DataSources: map[string]providers.Schema{
-				"test_object": providers.Schema{Block: simpleTestSchema()},
+				"test_object": providers.Schema{Body: simpleTestSchema()},
 			},
 		},
 	}
@@ -97,20 +97,20 @@ func getProviderSchema(p *testing_provider.MockProvider) *providerSchema {
 	resp := p.GetProviderSchemaResponse
 
 	schema := &providerSchema{
-		Provider:                   resp.Provider.Block,
-		ProviderMeta:               resp.ProviderMeta.Block,
+		Provider:                   resp.Provider.Body,
+		ProviderMeta:               resp.ProviderMeta.Body,
 		ResourceTypes:              map[string]*configschema.Block{},
 		DataSources:                map[string]*configschema.Block{},
 		ResourceTypeSchemaVersions: map[string]uint64{},
 	}
 
 	for resType, s := range resp.ResourceTypes {
-		schema.ResourceTypes[resType] = s.Block
+		schema.ResourceTypes[resType] = s.Body
 		schema.ResourceTypeSchemaVersions[resType] = uint64(s.Version)
 	}
 
 	for dataSource, s := range resp.DataSources {
-		schema.DataSources[dataSource] = s.Block
+		schema.DataSources[dataSource] = s.Body
 	}
 
 	return schema
@@ -130,21 +130,21 @@ type providerSchema struct {
 // providerSchema to a GetProviderSchemaResponse for use when building a mock provider.
 func getProviderSchemaResponseFromProviderSchema(providerSchema *providerSchema) *providers.GetProviderSchemaResponse {
 	resp := &providers.GetProviderSchemaResponse{
-		Provider:      providers.Schema{Block: providerSchema.Provider},
-		ProviderMeta:  providers.Schema{Block: providerSchema.ProviderMeta},
+		Provider:      providers.Schema{Body: providerSchema.Provider},
+		ProviderMeta:  providers.Schema{Body: providerSchema.ProviderMeta},
 		ResourceTypes: map[string]providers.Schema{},
 		DataSources:   map[string]providers.Schema{},
 	}
 
 	for name, schema := range providerSchema.ResourceTypes {
 		resp.ResourceTypes[name] = providers.Schema{
-			Block:   schema,
+			Body:    schema,
 			Version: int64(providerSchema.ResourceTypeSchemaVersions[name]),
 		}
 	}
 
 	for name, schema := range providerSchema.DataSources {
-		resp.DataSources[name] = providers.Schema{Block: schema}
+		resp.DataSources[name] = providers.Schema{Body: schema}
 	}
 
 	return resp

--- a/internal/terraform/transform_import_state_test.go
+++ b/internal/terraform/transform_import_state_test.go
@@ -36,7 +36,7 @@ func TestGraphNodeImportStateExecute(t *testing.T) {
 		ProviderSchemaSchema: providers.GetProviderSchemaResponse{
 			ResourceTypes: map[string]providers.Schema{
 				"aws_instance": {
-					Block: &configschema.Block{
+					Body: &configschema.Block{
 						Attributes: map[string]*configschema.Attribute{
 							"id": {
 								Type:     cty.String,
@@ -90,7 +90,7 @@ func TestGraphNodeImportStateSubExecute(t *testing.T) {
 		ProviderSchemaSchema: providers.ProviderSchema{
 			ResourceTypes: map[string]providers.Schema{
 				"aws_instance": {
-					Block: &configschema.Block{
+					Body: &configschema.Block{
 						Attributes: map[string]*configschema.Attribute{
 							"id": {
 								Type:     cty.String,
@@ -152,7 +152,7 @@ func TestGraphNodeImportStateSubExecuteNull(t *testing.T) {
 		ProviderSchemaSchema: providers.ProviderSchema{
 			ResourceTypes: map[string]providers.Schema{
 				"aws_instance": {
-					Block: &configschema.Block{
+					Body: &configschema.Block{
 						Attributes: map[string]*configschema.Attribute{
 							"id": {
 								Type:     cty.String,

--- a/internal/terraform/transform_transitive_reduction_test.go
+++ b/internal/terraform/transform_transitive_reduction_test.go
@@ -38,7 +38,7 @@ func TestTransitiveReductionTransformer(t *testing.T) {
 				addrs.NewDefaultProvider("aws"): {
 					ResourceTypes: map[string]providers.Schema{
 						"aws_instance": {
-							Block: &configschema.Block{
+							Body: &configschema.Block{
 								Attributes: map[string]*configschema.Attribute{
 									"A": {
 										Type:     cty.String,

--- a/internal/terraform/validate_selfref_test.go
+++ b/internal/terraform/validate_selfref_test.go
@@ -87,7 +87,7 @@ func TestValidateSelfRef(t *testing.T) {
 			ps := providers.ProviderSchema{
 				ResourceTypes: map[string]providers.Schema{
 					"aws_instance": {
-						Block: &configschema.Block{
+						Body: &configschema.Block{
 							Attributes: map[string]*configschema.Attribute{
 								"foo": {
 									Type:     cty.String,


### PR DESCRIPTION
This PR renames `Block` to `Body` in the internal providers package. I'm doing this in a separate PR to remove some noise from #36464.

https://github.com/hashicorp/terraform/blob/ace2100299c1e684efbefe396c6f743c7060392c/internal/providers/provider.go#L130-L139

We're adding the resource identity schemas to that struct in #36464, so having the schema for the resource itself in the `Body` instead of `Block` field makes more sense. 

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.12.x

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
