### PR TITLE
Add additional validation that the backend used in a run is a supported type

### DIFF
--- a/internal/command/test_test.go
+++ b/internal/command/test_test.go
@@ -2564,12 +2564,13 @@ Failure! 0 passed, 1 failed.
 	}
 }
 
-// TestTest_ReusedBackendConfiguration asserts that it's not valid to re-use the same backend config (i.e the same state file)
-// in parallel runs. This would result in multiple actions attempting to set state, potentially with different resource configurations.
+// TestTest_ValidateBackendConfiguration tests validation of how backends are declared in test files:
+// * it's not valid to re-use the same backend config (i.e the same state file)
+// * it's not valid to use a deprecated backend type
+// * it's not valid to use a non-existent backend type
 //
-// Note - this test is written to assert that diagnostics are returned about re-used backend blocks between run blocks, but it allows either
-// of the conflicting run blocks to cause the error to be raised. This is because run blocks without matching state keys aren't run in a
-// deterministic order.
+// Backend validaton performed in the command package is dependent on the internal/backend/init package,
+// which cannot be imported in configuration parsing packages without creating an import cycle.
 func TestTest_ReusedBackendConfiguration(t *testing.T) {
 
 	testCases := map[string]struct {
@@ -2600,6 +2601,28 @@ Error: Repeat use of the same backend block
 The run "test_2" contains a backend configuration that's already been used in
 run "test_1". Sharing the same backend configuration between separate runs
 will result in conflicting state updates.
+`,
+		},
+		"validation detects when a deprecated backend type is used": {
+			dirName: "removed-backend-type",
+			expectErr: `
+Error: Unsupported backend type
+
+  on main.tftest.hcl line 7, in run "test_removed_backend":
+   7:   backend "etcd" {
+
+The "etcd" backend is not supported in Terraform v1.3 or later.
+`,
+		},
+		"validation detects when a non-existent backend type": {
+			dirName: "non-existent-backend-type",
+			expectErr: `
+Error: Unsupported backend type
+
+  on main.tftest.hcl line 7, in run "test_invalid_backend":
+   7:   backend "foobar" {
+
+There is no backend type named "foobar".
 `,
 		},
 	}

--- a/internal/command/testdata/test/non-existent-backend-type/main.tf
+++ b/internal/command/testdata/test/non-existent-backend-type/main.tf
@@ -1,0 +1,10 @@
+
+variable "input" {
+  type = string
+}
+
+resource "test_resource" "a" {
+  value = var.input
+}
+
+resource "test_resource" "c" {}

--- a/internal/command/testdata/test/non-existent-backend-type/main.tftest.hcl
+++ b/internal/command/testdata/test/non-existent-backend-type/main.tftest.hcl
@@ -1,0 +1,9 @@
+# The "foobar" backend does not exist and isn't a removed backend either
+run "test_invalid_backend" {
+  variables {
+    input = "foobar"
+  }
+
+  backend "foobar" {
+  }
+}

--- a/internal/command/testdata/test/removed-backend-type/main.tf
+++ b/internal/command/testdata/test/removed-backend-type/main.tf
@@ -1,0 +1,10 @@
+
+variable "input" {
+  type = string
+}
+
+resource "test_resource" "a" {
+  value = var.input
+}
+
+resource "test_resource" "c" {}

--- a/internal/command/testdata/test/removed-backend-type/main.tftest.hcl
+++ b/internal/command/testdata/test/removed-backend-type/main.tftest.hcl
@@ -1,0 +1,9 @@
+# The "etcd" backend has been removed from Terraform versions 1.3+
+run "test_removed_backend" {
+  variables {
+    input = "foobar"
+  }
+
+  backend "etcd" {
+  }
+}


### PR DESCRIPTION
This PR builds on https://github.com/hashicorp/terraform/pull/36541

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.12.x

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.


Will add a changelog in the final PR into main