### PR TITLE
Return error when the template's single interpolation results in null value

### DIFF
--- a/.changes/v1.12/BUG FIXES-20250310-093153.yaml
+++ b/.changes/v1.12/BUG FIXES-20250310-093153.yaml
@@ -1,5 +1,5 @@
 kind: BUG FIXES
-body: Return error when the template's single interpolation results in null value
+body: Return error when the templatestring function contains only a single interpolation that evaluates to a null value
 time: 2025-03-10T09:31:53.479704+01:00
 custom:
     Issue: "36652"

--- a/.changes/v1.12/BUG FIXES-20250310-093153.yaml
+++ b/.changes/v1.12/BUG FIXES-20250310-093153.yaml
@@ -1,0 +1,5 @@
+kind: BUG FIXES
+body: Return error when the template's single interpolation results in null value
+time: 2025-03-10T09:31:53.479704+01:00
+custom:
+    Issue: "36652"

--- a/internal/lang/funcs/string.go
+++ b/internal/lang/funcs/string.go
@@ -380,6 +380,14 @@ func makeRenderTemplateFunc(funcsCb func() (funcs map[string]function.Function, 
 		if diags.HasErrors() {
 			return cty.DynamicVal, diags
 		}
+		if val.IsNull() {
+			return cty.DynamicVal, &hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  "Template result is null",
+				Detail:   "The result of the template is null, which is not a valid result for a templatestring call.",
+				Subject:  expr.Range().Ptr(),
+			}
+		}
 		return val, nil
 	}
 }

--- a/internal/lang/funcs/string_test.go
+++ b/internal/lang/funcs/string_test.go
@@ -273,6 +273,28 @@ func TestTemplateString(t *testing.T) {
 		want         cty.Value
 		wantErr      string
 	}{
+		{ // a single string interpolation that evaluates to null should fail
+			`template`,
+			map[string]cty.Value{
+				"template": cty.StringVal(`${test}`),
+			},
+			cty.ObjectVal(map[string]cty.Value{
+				"test": cty.NullVal(cty.String),
+			}),
+			cty.NilVal,
+			`<templatestring argument>:1,1-8: Template result is null; The result of the template is null, which is not a valid result for a templatestring call.`,
+		},
+		{ // a single string interpolation that evaluates to unknown should not fail
+			`template`,
+			map[string]cty.Value{
+				"template": cty.StringVal(`${test}`),
+			},
+			cty.ObjectVal(map[string]cty.Value{
+				"test": cty.UnknownVal(cty.String),
+			}),
+			cty.UnknownVal(cty.String).RefineNotNull(),
+			``,
+		},
 		{
 			`template`,
 			map[string]cty.Value{


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Fixes #36652 

When a string interpolation contains only one expression sequence, HCL optimizes by wrapping and directly delegating evaluation to that expression. The `templatestring` function tries to refine the expression value as non-null, and if null, this refinement leads to a panic. For compatibility reasons, HCL has to continue to support this unwrapping logic ([See attempted PR](https://github.com/hashicorp/hcl/pull/736)), thus we will simply return an error in `templatestring` when the single evaluated expression is null

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.12.x

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [ ] This change is not user-facing.
