### PR TITLE
Check for nested computed values in all structural types when planning data sources

### DIFF
--- a/.changes/v1.12/BUG FIXES-20250310-100230.yaml
+++ b/.changes/v1.12/BUG FIXES-20250310-100230.yaml
@@ -1,0 +1,5 @@
+kind: BUG FIXES
+body: Deferred data resources with nested structural types may not have some computed attributes set to unknown during plan
+time: 2025-03-10T10:02:30.202497-04:00
+custom:
+    Issue: "36663"

--- a/internal/plans/objchange/objchange.go
+++ b/internal/plans/objchange/objchange.go
@@ -229,7 +229,6 @@ func proposedNewNestingList(schema nestedSchema, prior, config cty.Value) cty.Va
 
 func proposedNewNestingMap(schema nestedSchema, prior, config cty.Value) cty.Value {
 	newV := config
-
 	newVals := map[string]cty.Value{}
 
 	if config.IsNull() || !config.IsKnown() || config.LengthInt() == 0 {
@@ -239,7 +238,7 @@ func proposedNewNestingMap(schema nestedSchema, prior, config cty.Value) cty.Val
 	}
 	cfgMap := config.AsValueMap()
 
-	// prior may be null or empty
+	// prior may be null, empty or unknown
 	priorMap := map[string]cty.Value{}
 	if !prior.IsNull() && prior.IsKnown() && prior.LengthInt() > 0 {
 		priorMap = prior.AsValueMap()
@@ -248,10 +247,13 @@ func proposedNewNestingMap(schema nestedSchema, prior, config cty.Value) cty.Val
 	for name, configEV := range cfgMap {
 		priorEV, inPrior := priorMap[name]
 		if !inPrior {
-			// If there is no corresponding prior element then
-			// we just take the config value as-is.
-			newVals[name] = configEV
-			continue
+			// if the prior cty.Map value was unknown the map won't have any
+			// keys, so generate an unknown value.
+			if !prior.IsKnown() {
+				priorEV = cty.UnknownVal(configEV.Type())
+			} else {
+				priorEV = cty.NullVal(configEV.Type())
+			}
 		}
 
 		newVals[name] = proposedNewBlockOrObject(schema, priorEV, configEV)
@@ -339,9 +341,7 @@ func proposedNewAttributes(attrs map[string]*configschema.Attribute, prior, conf
 		} else {
 			priorV = prior.GetAttr(name)
 		}
-
 		configV := config.GetAttr(name)
-
 		var newV cty.Value
 		switch {
 		// required isn't considered when constructing the plan, so attributes

--- a/internal/plans/objchange/objchange.go
+++ b/internal/plans/objchange/objchange.go
@@ -336,9 +336,13 @@ func proposedNewAttributes(attrs map[string]*configschema.Attribute, prior, conf
 	newAttrs := make(map[string]cty.Value, len(attrs))
 	for name, attr := range attrs {
 		var priorV cty.Value
-		if prior.IsNull() {
+
+		switch {
+		case prior.IsNull():
 			priorV = cty.NullVal(prior.Type().AttributeType(name))
-		} else {
+		case !prior.IsKnown():
+			priorV = cty.UnknownVal(prior.Type().AttributeType(name))
+		default:
 			priorV = prior.GetAttr(name)
 		}
 		configV := config.GetAttr(name)

--- a/internal/plans/objchange/objchange_test.go
+++ b/internal/plans/objchange/objchange_test.go
@@ -954,7 +954,7 @@ func TestProposedNew(t *testing.T) {
 					}),
 					"c": cty.ObjectVal(map[string]cty.Value{
 						"bar": cty.StringVal("bosh"),
-						"baz": cty.NullVal(cty.List(cty.String)),
+						"baz": cty.NullVal(cty.DynamicPseudoType),
 					}),
 				}),
 				"bloop": cty.ObjectVal(map[string]cty.Value{
@@ -1920,7 +1920,7 @@ func TestProposedNew(t *testing.T) {
 							Attributes: map[string]*configschema.Attribute{
 								"map": {
 									NestedType: &configschema.Object{
-										Nesting: configschema.NestingList,
+										Nesting: configschema.NestingMap,
 										Attributes: map[string]*configschema.Attribute{
 											"foo": {
 												Type: cty.String,
@@ -1942,7 +1942,7 @@ func TestProposedNew(t *testing.T) {
 					})),
 				}),
 				"map": cty.Map(cty.Object(map[string]cty.Type{
-					"list": cty.List(cty.Object(map[string]cty.Type{
+					"map": cty.List(cty.Object(map[string]cty.Type{
 						"foo": cty.String,
 					})),
 				})),
@@ -1960,11 +1960,11 @@ func TestProposedNew(t *testing.T) {
 				}),
 				"map": cty.MapVal(map[string]cty.Value{
 					"one": cty.ObjectVal(map[string]cty.Value{
-						"list": cty.ListVal([]cty.Value{
-							cty.ObjectVal(map[string]cty.Value{
+						"map": cty.MapVal(map[string]cty.Value{
+							"one": cty.ObjectVal(map[string]cty.Value{
 								"foo": cty.StringVal("a"),
 							}),
-							cty.ObjectVal(map[string]cty.Value{
+							"two": cty.ObjectVal(map[string]cty.Value{
 								"foo": cty.StringVal("b"),
 							}),
 						}),
@@ -1984,11 +1984,11 @@ func TestProposedNew(t *testing.T) {
 				}),
 				"map": cty.MapVal(map[string]cty.Value{
 					"one": cty.ObjectVal(map[string]cty.Value{
-						"list": cty.ListVal([]cty.Value{
-							cty.ObjectVal(map[string]cty.Value{
+						"map": cty.MapVal(map[string]cty.Value{
+							"one": cty.ObjectVal(map[string]cty.Value{
 								"foo": cty.StringVal("a"),
 							}),
-							cty.ObjectVal(map[string]cty.Value{
+							"two": cty.ObjectVal(map[string]cty.Value{
 								"foo": cty.StringVal("b"),
 							}),
 						}),

--- a/internal/plans/objchange/objchange_test.go
+++ b/internal/plans/objchange/objchange_test.go
@@ -2729,6 +2729,139 @@ func TestProposedNew(t *testing.T) {
 				}),
 			}),
 		},
+		"planned data source": {
+			&configschema.Block{
+				Attributes: map[string]*configschema.Attribute{
+					"single_computed_obj": {
+						NestedType: &configschema.Object{
+							Nesting: configschema.NestingSingle,
+							Attributes: map[string]*configschema.Attribute{
+								"computed": {Type: cty.String, Computed: true},
+							},
+						},
+						Computed: true,
+					},
+					"single": {
+						NestedType: &configschema.Object{
+							Nesting: configschema.NestingSingle,
+							Attributes: map[string]*configschema.Attribute{
+								"optional": {Type: cty.String, Optional: true},
+								"computed": {Type: cty.String, Computed: true},
+							},
+						},
+						Optional: true,
+					},
+					"map": {
+						NestedType: &configschema.Object{
+							Nesting: configschema.NestingMap,
+							Attributes: map[string]*configschema.Attribute{
+								"optional": {Type: cty.String, Optional: true},
+								"computed": {Type: cty.String, Computed: true},
+							},
+						},
+						Optional: true,
+					},
+					"list": {
+						NestedType: &configschema.Object{
+							Nesting: configschema.NestingList,
+							Attributes: map[string]*configschema.Attribute{
+								"optional": {Type: cty.String, Optional: true},
+								"computed": {Type: cty.String, Computed: true},
+							},
+						},
+						Optional: true,
+					},
+				},
+				BlockTypes: map[string]*configschema.NestedBlock{
+					"list_block": {
+						Nesting: configschema.NestingList,
+						Block: configschema.Block{
+							Attributes: map[string]*configschema.Attribute{
+								"optional": {Type: cty.String, Optional: true},
+								"computed": {Type: cty.String, Computed: true},
+							},
+						},
+					},
+				},
+			},
+			// planning a data resousrce starts with an uknown prior to fill in
+			// all posible computed attributes
+			cty.UnknownVal(cty.Object(map[string]cty.Type{
+				"single_computed_obj": cty.Object(map[string]cty.Type{
+					"computed": cty.String,
+				}),
+				"single": cty.Object(map[string]cty.Type{
+					"optional": cty.String,
+					"computed": cty.String,
+				}),
+				"map": cty.Map(cty.Object(map[string]cty.Type{
+					"optional": cty.String,
+					"computed": cty.String,
+				})),
+				"list": cty.List(cty.Object(map[string]cty.Type{
+					"optional": cty.String,
+					"computed": cty.String,
+				})),
+				"list_block": cty.List(cty.Object(map[string]cty.Type{
+					"optional": cty.String,
+					"computed": cty.String,
+				})),
+			})),
+			cty.ObjectVal(map[string]cty.Value{
+				"single_computed_obj": cty.NullVal(cty.Object(map[string]cty.Type{
+					"computed": cty.String,
+				})),
+				"single": cty.ObjectVal(map[string]cty.Value{
+					"optional": cty.StringVal("config"),
+					"computed": cty.NullVal(cty.String),
+				}),
+				"map": cty.MapVal(map[string]cty.Value{
+					"one": cty.ObjectVal(map[string]cty.Value{
+						"optional": cty.StringVal("config"),
+						"computed": cty.NullVal(cty.String),
+					}),
+				}),
+				"list": cty.ListVal([]cty.Value{
+					cty.ObjectVal(map[string]cty.Value{
+						"optional": cty.StringVal("config"),
+						"computed": cty.NullVal(cty.String),
+					}),
+				}),
+				"list_block": cty.ListVal([]cty.Value{
+					cty.ObjectVal(map[string]cty.Value{
+						"optional": cty.StringVal("config"),
+						"computed": cty.NullVal(cty.String),
+					}),
+				}),
+			}),
+			cty.ObjectVal(map[string]cty.Value{
+				"single_computed_obj": cty.UnknownVal(cty.Object(map[string]cty.Type{
+					"computed": cty.String,
+				})),
+				"single": cty.ObjectVal(map[string]cty.Value{
+					"optional": cty.StringVal("config"),
+					"computed": cty.UnknownVal(cty.String),
+				}),
+				"map": cty.MapVal(map[string]cty.Value{
+					"one": cty.ObjectVal(map[string]cty.Value{
+						"optional": cty.StringVal("config"),
+						"computed": cty.UnknownVal(cty.String),
+					}),
+				}),
+				"list": cty.ListVal([]cty.Value{
+					cty.ObjectVal(map[string]cty.Value{
+						"optional": cty.StringVal("config"),
+						"computed": cty.UnknownVal(cty.String),
+					}),
+				}),
+				"list_block": cty.ListVal([]cty.Value{
+					cty.ObjectVal(map[string]cty.Value{
+						"optional": cty.StringVal("config"),
+						"computed": cty.UnknownVal(cty.String),
+					}),
+				}),
+			}),
+		},
 	}
 
 	for name, test := range tests {


### PR DESCRIPTION
While the proposed plan value for managed resource is only a suggestion for providers, deferred data sources must be completely planed by core, and hence set appropriate unknown values. We do this by creating an entirely unknown prior value to plan against, which will be used to fill in any `null` `computed` attributes when generating the proposed new value. There were a couple combinations of nested types where we need to specifically check for and handle unknown in the prior value to translate that "unknown-ness" to what would be an unknown value extracted from an unknown container.

Fixes #36653
