### PR TITLE
Remove irrelevant link to issue.

### DIFF
--- a/website/docs/language/resources/provisioners/syntax.mdx
+++ b/website/docs/language/resources/provisioners/syntax.mdx
@@ -282,7 +282,7 @@ fail, Terraform will error and rerun the provisioners again on the next
 `terraform apply`. Due to this behavior, care should be taken for destroy
 provisioners to be safe to run multiple times.
 
-~> **Note**: Destroy provisioners of this resource do not run if `create_before_destroy` is set to `true`. This [GitHub issue](https://github.com/hashicorp/terraform/issues/13549) contains more details.
+~> **Note**: Destroy provisioners of this resource do not run if `create_before_destroy` is set to `true`.
 
 Destroy-time provisioners can only run if they remain in the configuration
 at the time a resource is destroyed. If a resource block with a destroy-time

--- a/website/docs/language/resources/provisioners/syntax.mdx
+++ b/website/docs/language/resources/provisioners/syntax.mdx
@@ -282,7 +282,7 @@ fail, Terraform will error and rerun the provisioners again on the next
 `terraform apply`. Due to this behavior, care should be taken for destroy
 provisioners to be safe to run multiple times.
 
-~> **Note**: Destroy provisioners of this resource do not run if `create_before_destroy` is set to `true`.
+~> **Note**: A resource's destroy-time provisioners do not run if you enable [`create_before_destroy`](/terraform/language/meta-arguments/lifecycle#syntax-and-arguments) on that resource.
 
 Destroy-time provisioners can only run if they remain in the configuration
 at the time a resource is destroyed. If a resource block with a destroy-time


### PR DESCRIPTION
The docs link to https://github.com/hashicorp/terraform/issues/13549 which was closed. Gathering anything relevant or of use from that ~100 comment long issue thread is not a particularly useful endeavor, so given that the information is true and not likely to be changed, simply removing the issue link and leaving the warning.
