### PR TITLE
Delete .changes/v1.12/BUG FIXES-20250310-100230.yaml

### DIFF
--- a/.changes/v1.12/BUG FIXES-20250310-100230.yaml
+++ b/.changes/v1.12/BUG FIXES-20250310-100230.yaml
@@ -1,5 +1,0 @@
-kind: BUG FIXES
-body: Deferred data resources with nested structural types may not have some computed attributes set to unknown during plan
-time: 2025-03-10T10:02:30.202497-04:00
-custom:
-    Issue: "36663"


### PR DESCRIPTION
We haven't actually released deferred changes yet, so we don't need to do a CHANGELOG entry for bug fixes affecting only them.

@jbardin - did this affect any behaviour outside of deferred changes? If so, we should reword the changelog instead of deleting it. But, if it's only deferred changes then we don't need this at all.

