### PR TITLE
stacks: fix errors processing index keys of removed blocks

### DIFF
--- a/internal/stacks/stackconfig/config_test.go
+++ b/internal/stacks/stackconfig/config_test.go
@@ -37,6 +37,8 @@ func TestLoadConfigDirErrors(t *testing.T) {
 
 	wantDiags := tfdiags.Diagnostics{
 		tfdiags.Sourceless(tfdiags.Error, "Component exists for removed block", "A removed block for component \"a\" was declared without an index, but a component block with the same name was declared at git::https://example.com/errored.git//main.tfstack.hcl:10,1-14.\n\nA removed block without an index indicates that the component and all instances were removed from the configuration, and this is not the case."),
+		tfdiags.Sourceless(tfdiags.Error, "Invalid for_each expression", "A removed block with a for_each expression must reference that expression within the `from` attribute."),
+		tfdiags.Sourceless(tfdiags.Error, "Invalid for_each expression", "A removed block with a for_each expression must reference that expression within the `from` attribute."),
 	}
 
 	count := len(wantDiags)

--- a/internal/stacks/stackconfig/testdata/basics-bundle/errored/main.tfstack.hcl
+++ b/internal/stacks/stackconfig/testdata/basics-bundle/errored/main.tfstack.hcl
@@ -30,3 +30,32 @@ removed {
     null = provider.null.a
   }
 }
+
+
+removed {
+  // This is invalid, you must reference the for_each somewhere in the
+  // from attribute if both are present.
+  from = component.b["something"]
+
+  for_each = ["a", "b"]
+
+  source = "./"
+
+  providers = {
+    null = provider.null.a
+  }
+}
+
+removed {
+  // This is invalid, you must reference the for_each somewhere in the
+  // from attribute if both are present.
+  from = component.c
+
+  for_each = ["a", "b"]
+
+  source = "./"
+
+  providers = {
+    null = provider.null.a
+  }
+}

--- a/internal/stacks/stackruntime/internal/stackeval/main_apply.go
+++ b/internal/stacks/stackruntime/internal/stackeval/main_apply.go
@@ -108,15 +108,18 @@ func ApplyPlan(ctx context.Context, config *stackconfig.Config, plan *stackplan.
 								// it.
 								log.Printf("[TRACE]: %s has planned changes, but was unknown. Check further messages to find out if this was an error.", addr)
 							} else {
-								i, ok := insts[addr.Item.Key]
-								if !ok {
+								for _, i := range insts {
+									if i.from.Item.Key == addr.Item.Key {
+										inst = i
+										break
+									}
+								}
+								if inst == nil {
 									// Again, this might be okay if the component
 									// block was deferred but the removed block had
 									// proper changes (or vice versa). We'll note
 									// this in the logs but just skip processing it.
 									log.Printf("[TRACE]: %s has planned changes, but does not seem to be declared. Check further messages to find out if this was an error.", addr)
-								} else {
-									inst = i
 								}
 							}
 						}

--- a/internal/stacks/stackruntime/internal/stackeval/removed.go
+++ b/internal/stacks/stackruntime/internal/stackeval/removed.go
@@ -5,11 +5,15 @@ package stackeval
 
 import (
 	"context"
+	"fmt"
+	"time"
 
+	"github.com/hashicorp/hcl/v2"
 	"github.com/zclconf/go-cty/cty"
 
 	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/instances"
+	"github.com/hashicorp/terraform/internal/lang"
 	"github.com/hashicorp/terraform/internal/promising"
 	"github.com/hashicorp/terraform/internal/stacks/stackaddrs"
 	"github.com/hashicorp/terraform/internal/stacks/stackplan"
@@ -107,7 +111,56 @@ func (r *Removed) Instances(ctx context.Context, phase EvalPhase) (map[addrs.Ins
 		// First, evaluate the for_each value to get the set of instances the
 		// user has asked to be removed.
 		result := instancesMap(forEachValue, func(ik addrs.InstanceKey, rd instances.RepetitionData) *RemovedInstance {
-			return newRemovedInstance(r, ik, rd, false)
+			expr := r.Config(ctx).config.FromIndex
+			if expr == nil {
+				if ik != addrs.NoKey {
+					// error, but this shouldn't happen as we validate there is
+					// no for each if the expression is null when parsing the
+					// configuration.
+					panic("has FromIndex expression, but no ForEach attribute")
+				}
+
+				from := stackaddrs.AbsComponentInstance{
+					Stack: r.addr.Stack,
+					Item: stackaddrs.ComponentInstance{
+						Component: r.addr.Item,
+						Key:       addrs.NoKey,
+					},
+				}
+
+				return newRemovedInstance(r, from, rd, false)
+			}
+
+			// Otherwise, we're going to parse the FromIndex expression now.
+
+			result, moreDiags := EvalExprAndEvalContext(ctx, expr, phase, &removedInstanceExpressionScope{r, rd})
+			diags = diags.Append(moreDiags)
+			if moreDiags.HasErrors() {
+				return nil
+			}
+
+			key, err := addrs.ParseInstanceKey(result.Value)
+			if err != nil {
+				diags = diags.Append(&hcl.Diagnostic{
+					Severity:    hcl.DiagError,
+					Summary:     "Failed to parse instance key",
+					Detail:      fmt.Sprintf("The `from` attribute contains an invalid instance key for the given address: %s.", err),
+					Subject:     result.Expression.Range().Ptr(),
+					Expression:  result.Expression,
+					EvalContext: result.EvalContext,
+				})
+				return nil
+			}
+
+			from := stackaddrs.AbsComponentInstance{
+				Stack: r.addr.Stack,
+				Item: stackaddrs.ComponentInstance{
+					Component: r.addr.Item,
+					Key:       key,
+				},
+			}
+
+			return newRemovedInstance(r, from, rd, false)
 		})
 
 		// Now, filter out any instances that are not known to the previous
@@ -119,6 +172,12 @@ func (r *Removed) Instances(ctx context.Context, phase EvalPhase) (map[addrs.Ins
 		knownAddrs := make([]stackaddrs.AbsComponentInstance, 0, len(result.insts))
 		knownInstances := make(map[addrs.InstanceKey]*RemovedInstance, len(result.insts))
 		for key, ci := range result.insts {
+			if ci == nil {
+				// if ci is nil, then it means we couldn't process the address
+				// for this instance above
+				continue
+			}
+
 			switch phase {
 			case PlanPhase:
 				if r.main.PlanPrevState().HasComponentInstance(ci.Addr()) {
@@ -151,17 +210,6 @@ func (r *Removed) Instances(ctx context.Context, phase EvalPhase) (map[addrs.Ins
 		return result, diags
 	})
 	return result.insts, result.unknown, diags
-}
-
-func (r *Removed) UnknownInstance(ctx context.Context, phase EvalPhase) *RemovedInstance {
-	inst, err := r.unknownInstance.For(phase).Do(ctx, func(ctx context.Context) (*RemovedInstance, error) {
-		forEachValue, _ := r.ForEachValue(ctx, phase)
-		return newRemovedInstance(r, addrs.WildcardKey, instances.UnknownForEachRepetitionData(forEachValue.Type()), true), nil
-	})
-	if err != nil {
-		panic(err)
-	}
-	return inst
 }
 
 func (r *Removed) PlanIsComplete(ctx context.Context) bool {
@@ -233,4 +281,27 @@ func (r *Removed) ApplySuccessful(ctx context.Context) bool {
 func (r *Removed) CheckApply(ctx context.Context) ([]stackstate.AppliedChange, tfdiags.Diagnostics) {
 	_, _, diags := r.Instances(ctx, ApplyPhase)
 	return nil, diags
+}
+
+var _ ExpressionScope = (*removedInstanceExpressionScope)(nil)
+
+// removedInstanceExpressionScope is wrapper around the Removed expression
+// scope that also includes repetition data for a specific instance of this
+// removed block.
+type removedInstanceExpressionScope struct {
+	call *Removed
+	rd   instances.RepetitionData
+}
+
+func (r *removedInstanceExpressionScope) ResolveExpressionReference(ctx context.Context, ref stackaddrs.Reference) (Referenceable, tfdiags.Diagnostics) {
+	stack := r.call.Stack(ctx)
+	return stack.resolveExpressionReference(ctx, ref, nil, r.rd)
+}
+
+func (r *removedInstanceExpressionScope) PlanTimestamp() time.Time {
+	return r.call.main.PlanTimestamp()
+}
+
+func (r *removedInstanceExpressionScope) ExternalFunctions(ctx context.Context) (lang.ExternalFuncs, tfdiags.Diagnostics) {
+	return r.call.main.ProviderFunctions(ctx, r.call.Config(ctx).StackConfig(ctx))
 }

--- a/internal/stacks/stackruntime/internal/stackeval/stack.go
+++ b/internal/stacks/stackruntime/internal/stackeval/stack.go
@@ -692,6 +692,7 @@ func (s *Stack) PlanChanges(ctx context.Context) ([]stackplan.PlannedChange, tfd
 	// if a component is targeted.
 
 	var changes []stackplan.PlannedChange
+Instance:
 	for inst := range s.main.PlanPrevState().AllComponentInstances().All() {
 
 		// We track here whether this component instance has any associated
@@ -747,10 +748,13 @@ func (s *Stack) PlanChanges(ctx context.Context) ([]stackplan.PlannedChange, tfd
 				continue
 			}
 
-			if _, exists := insts[inst.Item.Key]; exists {
-				// This component is targeted by a removed block, so we won't
-				// add an error.
-				continue
+			for _, i := range insts {
+				// the instance key for a removed block doesn't always translate
+				// directly into the instance key in the address, so we have
+				// to check for the correct one.
+				if i.from.Item.Key == inst.Item.Key {
+					continue Instance
+				}
 			}
 		}
 

--- a/internal/stacks/stackruntime/internal/stackeval/walk_dynamic.go
+++ b/internal/stacks/stackruntime/internal/stackeval/walk_dynamic.go
@@ -239,7 +239,10 @@ func walkDynamicObjectsInStack[Output any](
 
 					// This instance is not claimed by the component block, so
 					// we'll mark it as being removed by the removed block.
-					inst := newRemovedInstance(removed, inst.Key, instances.RepetitionData{
+					inst := newRemovedInstance(removed, stackaddrs.AbsComponentInstance{
+						Stack: stack.addr,
+						Item:  inst,
+					}, instances.RepetitionData{
 						EachKey:   inst.Key.Value(),
 						EachValue: cty.UnknownVal(cty.DynamicPseudoType),
 					}, true)

--- a/internal/stacks/stackruntime/testdata/mainbundle/test/with-single-input/removed-component-instance-direct/removed-component-instance-direct.tfstack.hcl
+++ b/internal/stacks/stackruntime/testdata/mainbundle/test/with-single-input/removed-component-instance-direct/removed-component-instance-direct.tfstack.hcl
@@ -1,0 +1,37 @@
+required_providers {
+  testing = {
+    source  = "hashicorp/testing"
+    version = "0.1.0"
+  }
+}
+
+provider "testing" "default" {}
+
+variable "input" {
+  type = set(string)
+}
+
+component "self" {
+  source = "../"
+
+  for_each = var.input
+
+  providers = {
+    testing = provider.testing.default
+  }
+
+  inputs = {
+    id   = each.key
+    input = each.key
+  }
+}
+
+removed {
+  from = component.self["removed"]
+
+  source = "../"
+
+  providers = {
+    testing = provider.testing.default
+  }
+}


### PR DESCRIPTION
This is part of the work addressing feedback for the `removed` block in Stacks.

Currently, we were assuming that the `for_each` attribute was always being copied directly into the key of the `from` attribute. This isn't necessarily true - there's a test case that has been added that demonstrates this.

This PR updates the Stacks internals to differentiate between the "instance key" of a removed block (which is the output of the for_each evaluation) and the instance key of the address in the from attribute. The each attribute needs to be mentioned in the from attribute, but it doesn't have to be a 1:1 mapping. Previously, we would just check the instance key for direct matches between instances in state, components and removed blocks. Now, we actively check the from attribute of the removed block when making such comparisons.