### PR TITLE
Marshall resource identity schemas in `jsonprovider` (TF-23824)

### DIFF
--- a/internal/command/jsonprovider/attribute.go
+++ b/internal/command/jsonprovider/attribute.go
@@ -70,3 +70,27 @@ func marshalAttribute(attr *configschema.Attribute) *Attribute {
 
 	return ret
 }
+
+type IdentityAttribute struct {
+	IdentityType      json.RawMessage `json:"type,omitempty"`
+	Description       string          `json:"description,omitempty"`
+	RequiredForImport bool            `json:"required_for_import,omitempty"`
+	OptionalForImport bool            `json:"optional_for_import,omitempty"`
+}
+
+func marshalIdentityAttribute(attr *configschema.Attribute) *IdentityAttribute {
+	ret := &IdentityAttribute{
+		Description:       attr.Description,
+		RequiredForImport: attr.Required,
+		OptionalForImport: attr.Optional,
+	}
+
+	// we're not concerned about errors because at this point the schema has
+	// already been checked and re-checked.
+	if attr.Type != cty.NilType {
+		attrTy, _ := attr.Type.MarshalJSON()
+		ret.IdentityType = attrTy
+	}
+
+	return ret
+}

--- a/internal/command/jsonprovider/attribute_test.go
+++ b/internal/command/jsonprovider/attribute_test.go
@@ -46,3 +46,33 @@ func TestMarshalAttribute(t *testing.T) {
 		}
 	}
 }
+
+func TestMarshalIdentityAttribute(t *testing.T) {
+	tests := []struct {
+		Input *configschema.Attribute
+		Want  *IdentityAttribute
+	}{
+		{
+			&configschema.Attribute{Type: cty.String, Optional: true},
+			&IdentityAttribute{
+				IdentityType:      json.RawMessage(`"string"`),
+				OptionalForImport: true,
+			},
+		},
+		{ // collection types look a little odd.
+			&configschema.Attribute{Type: cty.List(cty.String), Required: true},
+			&IdentityAttribute{
+				IdentityType:      json.RawMessage(`["list","string"]`),
+				RequiredForImport: true,
+			},
+		},
+	}
+
+	for _, test := range tests {
+		got := marshalIdentityAttribute(test.Input)
+		if !cmp.Equal(got, test.Want) {
+			t.Fatalf("wrong result:\n %v\n", cmp.Diff(got, test.Want))
+		}
+	}
+
+}

--- a/internal/command/jsonprovider/provider.go
+++ b/internal/command/jsonprovider/provider.go
@@ -28,6 +28,7 @@ type Provider struct {
 	DataSourceSchemas        map[string]*Schema                         `json:"data_source_schemas,omitempty"`
 	EphemeralResourceSchemas map[string]*Schema                         `json:"ephemeral_resource_schemas,omitempty"`
 	Functions                map[string]*jsonfunction.FunctionSignature `json:"functions,omitempty"`
+	ResourceIdentitySchemas  map[string]*IdentitySchema                 `json:"resource_identity_schemas,omitempty"`
 }
 
 func newProviders() *Providers {
@@ -64,5 +65,6 @@ func marshalProvider(tps providers.ProviderSchema) *Provider {
 		DataSourceSchemas:        marshalSchemas(tps.DataSources),
 		EphemeralResourceSchemas: marshalSchemas(tps.EphemeralResourceTypes),
 		Functions:                jsonfunction.MarshalProviderFunctions(tps.Functions),
+		ResourceIdentitySchemas:  marshalIdentitySchemas(tps.ResourceTypes),
 	}
 }

--- a/internal/command/jsonprovider/provider_test.go
+++ b/internal/command/jsonprovider/provider_test.go
@@ -30,6 +30,7 @@ func TestMarshalProvider(t *testing.T) {
 				ResourceSchemas:          map[string]*Schema{},
 				DataSourceSchemas:        map[string]*Schema{},
 				EphemeralResourceSchemas: map[string]*Schema{},
+				ResourceIdentitySchemas:  map[string]*IdentitySchema{},
 			},
 		},
 		{
@@ -207,6 +208,7 @@ func TestMarshalProvider(t *testing.T) {
 						},
 					},
 				},
+				ResourceIdentitySchemas: map[string]*IdentitySchema{},
 			},
 		},
 	}

--- a/internal/command/jsonprovider/schema.go
+++ b/internal/command/jsonprovider/schema.go
@@ -36,3 +36,35 @@ func marshalSchemas(schemas map[string]providers.Schema) map[string]*Schema {
 	}
 	return ret
 }
+
+type IdentitySchema struct {
+	Version    uint64                        `json:"version"`
+	Attributes map[string]*IdentityAttribute `json:"attributes,omitempty"`
+}
+
+func marshalIdentitySchema(schema providers.Schema) *IdentitySchema {
+	var ret IdentitySchema
+	ret.Version = uint64(schema.IdentityVersion)
+	ret.Attributes = make(map[string]*IdentityAttribute, len(schema.Identity.Attributes))
+
+	for k, v := range schema.Identity.Attributes {
+		ret.Attributes[k] = marshalIdentityAttribute(v)
+	}
+
+	return &ret
+}
+
+func marshalIdentitySchemas(schemas map[string]providers.Schema) map[string]*IdentitySchema {
+	if schemas == nil {
+		return map[string]*IdentitySchema{}
+	}
+
+	ret := make(map[string]*IdentitySchema, len(schemas))
+	for k, v := range schemas {
+		if v.Identity != nil {
+			ret[k] = marshalIdentitySchema(v)
+		}
+	}
+
+	return ret
+}


### PR DESCRIPTION
This PR updates the `terraform providers schema --json` command to include the resource identity schemas.

![CleanShot 2025-03-11 at 21 22 46@2x](https://github.com/user-attachments/assets/daa083ae-6f8a-4569-b203-d9e726f46b17)


## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.12.x

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [ ] This change is not user-facing.
