### PR TITLE
Config-driven importing through identity (TF-23179)

### DIFF
--- a/internal/command/import.go
+++ b/internal/command/import.go
@@ -236,7 +236,7 @@ func (c *ImportCommand) Run(args []string) int {
 		Targets: []*terraform.ImportTarget{
 			{
 				LegacyAddr: addr,
-				IDString:   args[1],
+				LegacyID:   args[1],
 			},
 		},
 

--- a/internal/command/views/hook_ui.go
+++ b/internal/command/views/hook_ui.go
@@ -323,11 +323,19 @@ func (h *UiHook) PostImportState(id terraform.HookResourceIdentity, imported []p
 	return terraform.HookActionContinue, nil
 }
 
-func (h *UiHook) PrePlanImport(id terraform.HookResourceIdentity, importID string) (terraform.HookAction, error) {
-	h.println(fmt.Sprintf(
-		h.view.colorize.Color("[reset][bold]%s: Preparing import... [id=%s]"),
-		id.Addr, importID,
-	))
+func (h *UiHook) PrePlanImport(id terraform.HookResourceIdentity, importTarget cty.Value) (terraform.HookAction, error) {
+	if importTarget.Type().IsObjectType() {
+		h.println(fmt.Sprintf(
+			h.view.colorize.Color("[reset][bold]%s: Preparing import... [identity=%s]"),
+			id.Addr, importTarget.GoString(), // TODO improve
+		))
+	} else {
+		h.println(fmt.Sprintf(
+			h.view.colorize.Color("[reset][bold]%s: Preparing import... [id=%s]"),
+			id.Addr, importTarget.AsString(),
+		))
+
+	}
 
 	return terraform.HookActionContinue, nil
 }

--- a/internal/command/views/hook_ui.go
+++ b/internal/command/views/hook_ui.go
@@ -19,6 +19,7 @@ import (
 	"github.com/hashicorp/terraform/internal/plans"
 	"github.com/hashicorp/terraform/internal/providers"
 	"github.com/hashicorp/terraform/internal/terraform"
+	"github.com/hashicorp/terraform/internal/tfdiags"
 )
 
 // How long to wait between sending heartbeat/progress messages
@@ -327,7 +328,7 @@ func (h *UiHook) PrePlanImport(id terraform.HookResourceIdentity, importTarget c
 	if importTarget.Type().IsObjectType() {
 		h.println(fmt.Sprintf(
 			h.view.colorize.Color("[reset][bold]%s: Preparing import... [identity=%s]"),
-			id.Addr, importTarget.GoString(), // TODO improve
+			id.Addr, tfdiags.ObjectToString(importTarget),
 		))
 	} else {
 		h.println(fmt.Sprintf(

--- a/internal/plans/changes.go
+++ b/internal/plans/changes.go
@@ -551,7 +551,7 @@ func (oc *OutputChange) Encode() (*OutputChangeSrc, error) {
 // The fields in here are subject to change, so downstream consumers should be
 // prepared for backwards compatibility in case the contents changes.
 type Importing struct {
-	ID cty.Value
+	Target cty.Value
 }
 
 // Encode converts the Importing object into a form suitable for serialization
@@ -560,9 +560,15 @@ func (i *Importing) Encode() *ImportingSrc {
 	if i == nil {
 		return nil
 	}
-	if i.ID.IsKnown() {
-		return &ImportingSrc{
-			ID: i.ID.AsString(),
+	if i.Target.IsKnown() {
+		if i.Target.Type().IsObjectType() {
+			return &ImportingSrc{
+				Identity: i.Target,
+			}
+		} else {
+			return &ImportingSrc{
+				ID: i.Target.AsString(),
+			}
 		}
 	}
 	return &ImportingSrc{

--- a/internal/plans/changes.go
+++ b/internal/plans/changes.go
@@ -560,7 +560,7 @@ func (i *Importing) Encode() *ImportingSrc {
 	if i == nil {
 		return nil
 	}
-	if i.Target.IsKnown() {
+	if i.Target.IsWhollyKnown() {
 		if i.Target.Type().IsObjectType() {
 			return &ImportingSrc{
 				Identity: i.Target,

--- a/internal/plans/changes_src.go
+++ b/internal/plans/changes_src.go
@@ -349,6 +349,9 @@ type ImportingSrc struct {
 	// ID is the original ID of the imported resource.
 	ID string
 
+	// Identity is the original identity of the imported resource.
+	Identity cty.Value
+
 	// Unknown is true if the ID was unknown when we tried to import it. This
 	// should only be true if the overall change is embedded within a deferred
 	// action.
@@ -361,12 +364,25 @@ func (is *ImportingSrc) Decode() *Importing {
 		return nil
 	}
 	if is.Unknown {
+		if is.Identity.IsNull() {
+			return &Importing{
+				Target: cty.UnknownVal(cty.String),
+			}
+		}
+
 		return &Importing{
-			ID: cty.UnknownVal(cty.String),
+			Target: cty.UnknownVal(cty.EmptyObject),
 		}
 	}
+
+	if is.Identity.IsNull() {
+		return &Importing{
+			Target: cty.StringVal(is.ID),
+		}
+	}
+
 	return &Importing{
-		ID: cty.StringVal(is.ID),
+		Target: is.Identity,
 	}
 }
 

--- a/internal/states/instance_object.go
+++ b/internal/states/instance_object.go
@@ -69,9 +69,10 @@ type ResourceInstanceObject struct {
 // the receiver.
 func NewResourceInstanceObjectFromIR(ir providers.ImportedResource) *ResourceInstanceObject {
 	return &ResourceInstanceObject{
-		Status:  ObjectReady,
-		Value:   ir.State,
-		Private: ir.Private,
+		Status:   ObjectReady,
+		Value:    ir.State,
+		Private:  ir.Private,
+		Identity: ir.Identity,
 	}
 }
 

--- a/internal/states/state_deepcopy.go
+++ b/internal/states/state_deepcopy.go
@@ -213,6 +213,7 @@ func (o *ResourceInstanceObject) DeepCopy() *ResourceInstanceObject {
 
 	return &ResourceInstanceObject{
 		Value:               o.Value,
+		Identity:            o.Identity,
 		Status:              o.Status,
 		Private:             private,
 		Dependencies:        dependencies,

--- a/internal/terraform/context_apply2_test.go
+++ b/internal/terraform/context_apply2_test.go
@@ -2114,7 +2114,7 @@ resource "unused_resource" "test" {
 	tfdiags.AssertNoErrors(t, diags)
 }
 
-func TestContext2Apply_import(t *testing.T) {
+func TestContext2Apply_import_ID(t *testing.T) {
 	m := testModuleInline(t, map[string]string{
 		"main.tf": `
 resource "test_resource" "a" {
@@ -2172,6 +2172,95 @@ import {
 
 	_, diags = ctx.Apply(plan, m, nil)
 	tfdiags.AssertNoErrors(t, diags)
+
+	if !hook.PreApplyImportCalled {
+		t.Fatalf("PreApplyImport hook not called")
+	}
+	if addr, wantAddr := hook.PreApplyImportAddr, mustResourceInstanceAddr("test_resource.a"); !addr.Equal(wantAddr) {
+		t.Errorf("expected addr to be %s, but was %s", wantAddr, addr)
+	}
+
+	if !hook.PostApplyImportCalled {
+		t.Fatalf("PostApplyImport hook not called")
+	}
+	if addr, wantAddr := hook.PostApplyImportAddr, mustResourceInstanceAddr("test_resource.a"); !addr.Equal(wantAddr) {
+		t.Errorf("expected addr to be %s, but was %s", wantAddr, addr)
+	}
+}
+
+func TestContext2Apply_import_identity(t *testing.T) {
+	m := testModuleInline(t, map[string]string{
+		"main.tf": `
+resource "test_resource" "a" {
+  id = "importable"
+}
+
+import {
+  to = test_resource.a
+  identity = {
+    id = "importable"
+  }
+}
+`,
+	})
+
+	p := testProvider("test")
+	p.GetProviderSchemaResponse = getProviderSchemaResponseFromProviderSchema(&providerSchema{
+		ResourceTypes: map[string]*configschema.Block{
+			"test_resource": {
+				Attributes: map[string]*configschema.Attribute{
+					"id": {
+						Type:     cty.String,
+						Required: true,
+					},
+				},
+			},
+		},
+		IdentityTypes: map[string]*configschema.Object{
+			"test_resource": {
+				Attributes: map[string]*configschema.Attribute{
+					"id": {
+						Type:     cty.String,
+						Required: true,
+					},
+				},
+			},
+		},
+	})
+	p.PlanResourceChangeFn = func(req providers.PlanResourceChangeRequest) providers.PlanResourceChangeResponse {
+		return providers.PlanResourceChangeResponse{
+			PlannedState: req.ProposedNewState,
+		}
+	}
+	p.ImportResourceStateFn = func(req providers.ImportResourceStateRequest) providers.ImportResourceStateResponse {
+		return providers.ImportResourceStateResponse{
+			ImportedResources: []providers.ImportedResource{
+				{
+					TypeName: "test_instance",
+					State: cty.ObjectVal(map[string]cty.Value{
+						"id": cty.StringVal("importable"),
+					}),
+					Identity: cty.ObjectVal(map[string]cty.Value{
+						"id": cty.StringVal("importable"),
+					}),
+				},
+			},
+		}
+	}
+	hook := new(MockHook)
+	ctx := testContext2(t, &ContextOpts{
+		Hooks: []Hook{hook},
+		Providers: map[addrs.Provider]providers.Factory{
+			addrs.NewDefaultProvider("test"): testProviderFuncFixed(p),
+		},
+	})
+	plan, diags := ctx.Plan(m, states.NewState(), &PlanOpts{
+		Mode: plans.NormalMode,
+	})
+	assertNoErrors(t, diags)
+
+	_, diags = ctx.Apply(plan, m, nil)
+	assertNoErrors(t, diags)
 
 	if !hook.PreApplyImportCalled {
 		t.Fatalf("PreApplyImport hook not called")

--- a/internal/terraform/context_apply2_test.go
+++ b/internal/terraform/context_apply2_test.go
@@ -2257,10 +2257,10 @@ import {
 	plan, diags := ctx.Plan(m, states.NewState(), &PlanOpts{
 		Mode: plans.NormalMode,
 	})
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	_, diags = ctx.Apply(plan, m, nil)
-	assertNoErrors(t, diags)
+	tfdiags.AssertNoErrors(t, diags)
 
 	if !hook.PreApplyImportCalled {
 		t.Fatalf("PreApplyImport hook not called")

--- a/internal/terraform/context_import.go
+++ b/internal/terraform/context_import.go
@@ -33,10 +33,9 @@ type ImportTarget struct {
 	// when using the import command.
 	LegacyAddr addrs.AbsResourceInstance
 
-	// IDString stores the evaluated ID from the Config for the import process.
-	// This is also used by the legacy import command to directly set the ID
-	// given from the CLI.
-	IDString string
+	// LegacyID stores the ID from the command line arguments when using the
+	// import command.
+	LegacyID string
 }
 
 // Import takes already-created external resources and brings them

--- a/internal/terraform/context_import_test.go
+++ b/internal/terraform/context_import_test.go
@@ -43,7 +43,7 @@ func TestContextImport_basic(t *testing.T) {
 				LegacyAddr: addrs.RootModuleInstance.ResourceInstance(
 					addrs.ManagedResourceMode, "aws_instance", "foo", addrs.NoKey,
 				),
-				IDString: "bar",
+				LegacyID: "bar",
 			},
 		},
 	})
@@ -94,7 +94,7 @@ resource "aws_instance" "foo" {
 				LegacyAddr: addrs.RootModuleInstance.ResourceInstance(
 					addrs.ManagedResourceMode, "aws_instance", "foo", addrs.IntKey(0),
 				),
-				IDString: "bar",
+				LegacyID: "bar",
 			},
 		},
 	})
@@ -155,7 +155,7 @@ func TestContextImport_collision(t *testing.T) {
 				LegacyAddr: addrs.RootModuleInstance.ResourceInstance(
 					addrs.ManagedResourceMode, "aws_instance", "foo", addrs.NoKey,
 				),
-				IDString: "bar",
+				LegacyID: "bar",
 			},
 		},
 	})
@@ -199,7 +199,7 @@ func TestContextImport_missingType(t *testing.T) {
 				LegacyAddr: addrs.RootModuleInstance.ResourceInstance(
 					addrs.ManagedResourceMode, "aws_instance", "foo", addrs.NoKey,
 				),
-				IDString: "bar",
+				LegacyID: "bar",
 			},
 		},
 	})
@@ -250,7 +250,7 @@ func TestContextImport_moduleProvider(t *testing.T) {
 				LegacyAddr: addrs.RootModuleInstance.ResourceInstance(
 					addrs.ManagedResourceMode, "aws_instance", "foo", addrs.NoKey,
 				),
-				IDString: "bar",
+				LegacyID: "bar",
 			},
 		},
 	})
@@ -305,7 +305,7 @@ func TestContextImport_providerModule(t *testing.T) {
 				LegacyAddr: addrs.RootModuleInstance.Child("child", addrs.IntKey(0)).ResourceInstance(
 					addrs.ManagedResourceMode, "aws_instance", "foo", addrs.NoKey,
 				),
-				IDString: "bar",
+				LegacyID: "bar",
 			},
 		},
 	})
@@ -361,7 +361,7 @@ func TestContextImport_providerConfig(t *testing.T) {
 						LegacyAddr: addrs.RootModuleInstance.ResourceInstance(
 							addrs.ManagedResourceMode, "aws_instance", "foo", addrs.NoKey,
 						),
-						IDString: "bar",
+						LegacyID: "bar",
 					},
 				},
 				SetVariables: InputValues{
@@ -421,7 +421,7 @@ func TestContextImport_providerConfigResources(t *testing.T) {
 				LegacyAddr: addrs.RootModuleInstance.ResourceInstance(
 					addrs.ManagedResourceMode, "aws_instance", "foo", addrs.NoKey,
 				),
-				IDString: "bar",
+				LegacyID: "bar",
 			},
 		},
 	})
@@ -492,7 +492,7 @@ data "aws_data_source" "bar" {
 				LegacyAddr: addrs.RootModuleInstance.ResourceInstance(
 					addrs.ManagedResourceMode, "aws_instance", "foo", addrs.NoKey,
 				),
-				IDString: "bar",
+				LegacyID: "bar",
 			},
 		},
 	})
@@ -543,7 +543,7 @@ func TestContextImport_refreshNil(t *testing.T) {
 				LegacyAddr: addrs.RootModuleInstance.ResourceInstance(
 					addrs.ManagedResourceMode, "aws_instance", "foo", addrs.NoKey,
 				),
-				IDString: "bar",
+				LegacyID: "bar",
 			},
 		},
 	})
@@ -584,7 +584,7 @@ func TestContextImport_module(t *testing.T) {
 				LegacyAddr: addrs.RootModuleInstance.Child("child", addrs.IntKey(0)).ResourceInstance(
 					addrs.ManagedResourceMode, "aws_instance", "foo", addrs.NoKey,
 				),
-				IDString: "bar",
+				LegacyID: "bar",
 			},
 		},
 	})
@@ -625,7 +625,7 @@ func TestContextImport_moduleDepth2(t *testing.T) {
 				LegacyAddr: addrs.RootModuleInstance.Child("child", addrs.IntKey(0)).Child("nested", addrs.NoKey).ResourceInstance(
 					addrs.ManagedResourceMode, "aws_instance", "foo", addrs.NoKey,
 				),
-				IDString: "baz",
+				LegacyID: "baz",
 			},
 		},
 	})
@@ -666,7 +666,7 @@ func TestContextImport_moduleDiff(t *testing.T) {
 				LegacyAddr: addrs.RootModuleInstance.Child("child", addrs.IntKey(0)).ResourceInstance(
 					addrs.ManagedResourceMode, "aws_instance", "foo", addrs.NoKey,
 				),
-				IDString: "baz",
+				LegacyID: "baz",
 			},
 		},
 	})
@@ -734,7 +734,7 @@ func TestContextImport_multiState(t *testing.T) {
 				LegacyAddr: addrs.RootModuleInstance.ResourceInstance(
 					addrs.ManagedResourceMode, "aws_instance", "foo", addrs.NoKey,
 				),
-				IDString: "bar",
+				LegacyID: "bar",
 			},
 		},
 	})
@@ -808,7 +808,7 @@ func TestContextImport_multiStateSame(t *testing.T) {
 				LegacyAddr: addrs.RootModuleInstance.ResourceInstance(
 					addrs.ManagedResourceMode, "aws_instance", "foo", addrs.NoKey,
 				),
-				IDString: "bar",
+				LegacyID: "bar",
 			},
 		},
 	})
@@ -902,7 +902,7 @@ resource "test_resource" "unused" {
 				LegacyAddr: addrs.RootModuleInstance.ResourceInstance(
 					addrs.ManagedResourceMode, "test_resource", "test", addrs.NoKey,
 				),
-				IDString: "test",
+				LegacyID: "test",
 			},
 		},
 	})
@@ -972,7 +972,7 @@ resource "test_resource" "test" {
 				LegacyAddr: addrs.RootModuleInstance.ResourceInstance(
 					addrs.ManagedResourceMode, "test_resource", "test", addrs.NoKey,
 				),
-				IDString: "test",
+				LegacyID: "test",
 			},
 		},
 	})
@@ -1017,7 +1017,7 @@ func TestContextImport_33572(t *testing.T) {
 				LegacyAddr: addrs.RootModuleInstance.ResourceInstance(
 					addrs.ManagedResourceMode, "aws_instance", "foo", addrs.NoKey,
 				),
-				IDString: "bar",
+				LegacyID: "bar",
 			},
 		},
 	})

--- a/internal/terraform/context_plan_import_test.go
+++ b/internal/terraform/context_plan_import_test.go
@@ -1926,3 +1926,215 @@ func TestContext2Plan_importSelfReferenceInForEach(t *testing.T) {
 		t.Fatalf("unexpected error\n%s", cmp.Diff(want, got))
 	}
 }
+
+func TestContext2Plan_importIdentityModule(t *testing.T) {
+	p := testProvider("aws")
+	m := testModule(t, "import-identity-module")
+
+	p.GetProviderSchemaResponse = getProviderSchemaResponseFromProviderSchema(&providerSchema{
+		ResourceTypes: map[string]*configschema.Block{
+			"aws_lb": {
+				Attributes: map[string]*configschema.Attribute{
+					"id": {
+						Type:     cty.String,
+						Computed: true,
+					},
+				},
+			},
+		},
+		IdentityTypes: map[string]*configschema.Object{
+			"aws_lb": {
+				Attributes: map[string]*configschema.Attribute{
+					"name": {
+						Type:     cty.String,
+						Required: true,
+					},
+				},
+				Nesting: configschema.NestingSingle,
+			},
+		},
+	})
+	p.ImportResourceStateResponse = &providers.ImportResourceStateResponse{
+		ImportedResources: []providers.ImportedResource{
+			{
+				TypeName: "aws_lb",
+				State: cty.ObjectVal(map[string]cty.Value{
+					"id": cty.StringVal("foo"),
+				}),
+			},
+		},
+	}
+	ctx := testContext2(t, &ContextOpts{
+		Providers: map[addrs.Provider]providers.Factory{
+			addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
+		},
+	})
+
+	diags := ctx.Validate(m, &ValidateOpts{})
+	if diags.HasErrors() {
+		t.Fatalf("unexpected errors\n%s", diags.Err().Error())
+	}
+
+	_, diags = ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	if diags.HasErrors() {
+		t.Fatalf("unexpected errors: %s", diags.Err())
+	}
+}
+
+func TestContext2Plan_importIdentityMissingRequired(t *testing.T) {
+	p := testProvider("aws")
+	m := testModule(t, "import-identity-module")
+
+	p.GetProviderSchemaResponse = getProviderSchemaResponseFromProviderSchema(&providerSchema{
+		ResourceTypes: map[string]*configschema.Block{
+			"aws_lb": {
+				Attributes: map[string]*configschema.Attribute{
+					"id": {
+						Type:     cty.String,
+						Computed: true,
+					},
+				},
+			},
+		},
+		IdentityTypes: map[string]*configschema.Object{
+			"aws_lb": {
+				Attributes: map[string]*configschema.Attribute{
+					"name": {
+						Type:     cty.String,
+						Required: true,
+					},
+					"id": {
+						Type:     cty.String,
+						Required: true,
+					},
+				},
+				Nesting: configschema.NestingSingle,
+			},
+		},
+	})
+
+	ctx := testContext2(t, &ContextOpts{
+		Providers: map[addrs.Provider]providers.Factory{
+			addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
+		},
+	})
+
+	diags := ctx.Validate(m, &ValidateOpts{})
+
+	if len(diags) != 1 {
+		t.Fatalf("expected one diag, got %d: %s", len(diags), diags.ErrWithWarnings())
+	}
+
+	got := diags.Err().Error()
+	if !strings.Contains(got, "Invalid expression value:") {
+		t.Errorf("should have reported an invalid expression value, but got %s", got)
+	}
+}
+
+func TestContext2Plan_importIdentityResourceAlreadyInState(t *testing.T) {
+	addr := mustResourceInstanceAddr("test_object.a")
+	m := testModuleInline(t, map[string]string{
+		"main.tf": `
+resource "test_object" "a" {
+  test_string = "foo"
+}
+
+import {
+  to       = test_object.a
+  identity = {
+    id = "123"
+  }
+}
+`,
+	})
+
+	p := simpleMockProvider()
+	ctx := testContext2(t, &ContextOpts{
+		Providers: map[addrs.Provider]providers.Factory{
+			addrs.NewDefaultProvider("test"): testProviderFuncFixed(p),
+		},
+	})
+	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
+		Provider: providers.Schema{Body: simpleTestSchema()},
+		ResourceTypes: map[string]providers.Schema{
+			"test_object": {
+				Body: simpleTestSchema(),
+				Identity: &configschema.Object{
+					Attributes: map[string]*configschema.Attribute{
+						"id": {
+							Type:     cty.String,
+							Required: true,
+						},
+					},
+					Nesting: configschema.NestingSingle,
+				},
+			},
+		},
+	}
+	p.ReadResourceResponse = &providers.ReadResourceResponse{
+		NewState: cty.ObjectVal(map[string]cty.Value{
+			"test_string": cty.StringVal("foo"),
+		}),
+		Identity: cty.ObjectVal(map[string]cty.Value{
+			"id": cty.StringVal("123"),
+		}),
+	}
+	p.ImportResourceStateResponse = &providers.ImportResourceStateResponse{
+		ImportedResources: []providers.ImportedResource{
+			{
+				TypeName: "test_object",
+				State: cty.ObjectVal(map[string]cty.Value{
+					"test_string": cty.StringVal("foo"),
+				}),
+				Identity: cty.ObjectVal(map[string]cty.Value{
+					"id": cty.StringVal("123"),
+				}),
+			},
+		},
+	}
+
+	state := states.NewState()
+	root := state.EnsureModule(addrs.RootModuleInstance)
+	root.SetResourceInstanceCurrent(
+		mustResourceInstanceAddr("test_object.a").Resource,
+		&states.ResourceInstanceObjectSrc{
+			Status:       states.ObjectReady,
+			AttrsJSON:    []byte(`{"test_string":"foo"}`),
+			IdentityJSON: []byte(`{"id":"123"}`),
+		},
+		mustProviderConfig(`provider["registry.terraform.io/hashicorp/test"]`),
+	)
+
+	diags := ctx.Validate(m, &ValidateOpts{})
+	if diags.HasErrors() {
+		t.Fatalf("unexpected errors\n%s", diags.Err().Error())
+	}
+
+	plan, diags := ctx.Plan(m, state, DefaultPlanOpts)
+	if diags.HasErrors() {
+		t.Fatalf("unexpected errors\n%s", diags.Err().Error())
+	}
+
+	t.Run(addr.String(), func(t *testing.T) {
+		instPlan := plan.Changes.ResourceInstance(addr)
+		if instPlan == nil {
+			t.Fatalf("no plan for %s at all", addr)
+		}
+
+		if got, want := instPlan.Addr, addr; !got.Equal(want) {
+			t.Errorf("wrong current address\ngot:  %s\nwant: %s", got, want)
+		}
+		if got, want := instPlan.PrevRunAddr, addr; !got.Equal(want) {
+			t.Errorf("wrong previous run address\ngot:  %s\nwant: %s", got, want)
+		}
+		if got, want := instPlan.Action, plans.NoOp; got != want {
+			t.Errorf("wrong planned action\ngot:  %s\nwant: %s", got, want)
+		}
+		if got, want := instPlan.ActionReason, plans.ResourceInstanceChangeNoReason; got != want {
+			t.Errorf("wrong action reason\ngot:  %s\nwant: %s", got, want)
+		}
+		if instPlan.Importing != nil {
+			t.Errorf("expected non-import change, got import change %#v", instPlan.Importing)
+		}
+	})
+}

--- a/internal/terraform/eval_import.go
+++ b/internal/terraform/eval_import.go
@@ -102,7 +102,7 @@ func evaluateImportIdentityExpression(expr hcl.Expression, identity *configschem
 			Subject:  expr.Range().Ptr(),
 		})
 	}
-	if !allowUnknown && !importIdentityVal.IsKnown() {
+	if !allowUnknown && !importIdentityVal.IsWhollyKnown() {
 		return cty.NilVal, diags.Append(&hcl.Diagnostic{
 			Severity: hcl.DiagError,
 			Summary:  "Invalid import identity argument",

--- a/internal/terraform/eval_import.go
+++ b/internal/terraform/eval_import.go
@@ -11,22 +11,18 @@ import (
 	"github.com/zclconf/go-cty/cty"
 
 	"github.com/hashicorp/terraform/internal/addrs"
+	"github.com/hashicorp/terraform/internal/configs/configschema"
 	"github.com/hashicorp/terraform/internal/instances"
 	"github.com/hashicorp/terraform/internal/lang/marks"
 	"github.com/hashicorp/terraform/internal/tfdiags"
 )
 
+// evaluateImportIdExpression evaluates the given expression to determine the
+// import Id for a resource. It should evaluate to a non-empty string.
+//
+// The given expression must be non-nil or the function will panic.
 func evaluateImportIdExpression(expr hcl.Expression, ctx EvalContext, keyData instances.RepetitionData, allowUnknown bool) (cty.Value, tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
-
-	if expr == nil {
-		return cty.NilVal, diags.Append(&hcl.Diagnostic{
-			Severity: hcl.DiagError,
-			Summary:  "Invalid import id argument",
-			Detail:   "The import ID cannot be null.",
-			Subject:  expr.Range().Ptr(),
-		})
-	}
 
 	// import blocks only exist in the root module, and must be evaluated in
 	// that context.
@@ -78,6 +74,49 @@ func evaluateImportIdExpression(expr hcl.Expression, ctx EvalContext, keyData in
 	}
 
 	return importIdVal, diags
+}
+
+// evaluateImportIdentityExpression evaluates the given expression to determine the
+// import identity for a resource. It uses the resource identity schema to validate
+// the structure of the object..
+//
+// The given expression must be non-nil or the function will panic.
+func evaluateImportIdentityExpression(expr hcl.Expression, identity *configschema.Object, ctx EvalContext, keyData instances.RepetitionData, allowUnknown bool) (cty.Value, tfdiags.Diagnostics) {
+	var diags tfdiags.Diagnostics
+
+	// import blocks only exist in the root module, and must be evaluated in
+	// that context.
+	ctx = evalContextForModuleInstance(ctx, addrs.RootModuleInstance)
+	scope := ctx.EvaluationScope(nil, nil, keyData)
+	importIdentityVal, evalDiags := scope.EvalExpr(expr, identity.ImpliedType())
+	if evalDiags.HasErrors() {
+		// TODO? Do we need to improve the error message?
+		return cty.NilVal, evalDiags
+	}
+
+	if importIdentityVal.IsNull() {
+		return cty.NilVal, diags.Append(&hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  "Invalid import identity argument",
+			Detail:   "The import identity cannot be null.",
+			Subject:  expr.Range().Ptr(),
+		})
+	}
+	if !allowUnknown && !importIdentityVal.IsKnown() {
+		return cty.NilVal, diags.Append(&hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  "Invalid import identity argument",
+			Detail:   `The import block "identity" argument depends on resource attributes that cannot be determined until apply, so Terraform cannot plan to import this resource.`, // FIXME and what should I do about that?
+			Subject:  expr.Range().Ptr(),
+			Extra:    diagnosticCausedByUnknown(true),
+		})
+	}
+
+	// Import data may have marks, which we can discard because the id is only
+	// sent to the provider.
+	importIdentityVal, _ = importIdentityVal.Unmark()
+
+	return importIdentityVal, diags
 }
 
 func evalImportToExpression(expr hcl.Expression, keyData instances.RepetitionData) (addrs.AbsResourceInstance, tfdiags.Diagnostics) {

--- a/internal/terraform/hook.go
+++ b/internal/terraform/hook.go
@@ -90,7 +90,7 @@ type Hook interface {
 
 	// PrePlanImport and PostPlanImport are called during a plan before and after planning to import
 	// a new resource using the configuration-driven import workflow.
-	PrePlanImport(id HookResourceIdentity, importID string) (HookAction, error)
+	PrePlanImport(id HookResourceIdentity, importTarget cty.Value) (HookAction, error)
 	PostPlanImport(id HookResourceIdentity, imported []providers.ImportedResource) (HookAction, error)
 
 	// PreApplyImport and PostApplyImport are called during an apply for each imported resource when
@@ -185,7 +185,7 @@ func (*NilHook) PostImportState(id HookResourceIdentity, imported []providers.Im
 	return HookActionContinue, nil
 }
 
-func (h *NilHook) PrePlanImport(id HookResourceIdentity, importID string) (HookAction, error) {
+func (h *NilHook) PrePlanImport(id HookResourceIdentity, importTarget cty.Value) (HookAction, error) {
 	return HookActionContinue, nil
 }
 

--- a/internal/terraform/hook_mock.go
+++ b/internal/terraform/hook_mock.go
@@ -300,7 +300,7 @@ func (h *MockHook) PostImportState(id HookResourceIdentity, imported []providers
 	return h.PostImportStateReturn, h.PostImportStateError
 }
 
-func (h *MockHook) PrePlanImport(id HookResourceIdentity, importID string) (HookAction, error) {
+func (h *MockHook) PrePlanImport(id HookResourceIdentity, importTarget cty.Value) (HookAction, error) {
 	h.PrePlanImportCalled = true
 	h.PrePlanImportAddr = id.Addr
 	return h.PrePlanImportReturn, h.PrePlanImportError

--- a/internal/terraform/hook_stop.go
+++ b/internal/terraform/hook_stop.go
@@ -74,7 +74,7 @@ func (h *stopHook) PostImportState(id HookResourceIdentity, imported []providers
 	return h.hook()
 }
 
-func (h *stopHook) PrePlanImport(id HookResourceIdentity, importID string) (HookAction, error) {
+func (h *stopHook) PrePlanImport(id HookResourceIdentity, importTarget cty.Value) (HookAction, error) {
 	return h.hook()
 }
 

--- a/internal/terraform/hook_test.go
+++ b/internal/terraform/hook_test.go
@@ -127,7 +127,7 @@ func (h *testHook) PostImportState(id HookResourceIdentity, imported []providers
 	return HookActionContinue, nil
 }
 
-func (h *testHook) PrePlanImport(id HookResourceIdentity, importID string) (HookAction, error) {
+func (h *testHook) PrePlanImport(id HookResourceIdentity, importTarget cty.Value) (HookAction, error) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 	h.Calls = append(h.Calls, &testHookCall{"PrePlanImport", id.Addr.String()})

--- a/internal/terraform/node_resource_abstract.go
+++ b/internal/terraform/node_resource_abstract.go
@@ -244,6 +244,8 @@ func (n *NodeAbstractResource) ImportReferences() []*addrs.Reference {
 
 		refs, _ := langrefs.ReferencesInExpr(addrs.ParseRef, importTarget.Config.ID)
 		result = append(result, refs...)
+		refs, _ = langrefs.ReferencesInExpr(addrs.ParseRef, importTarget.Config.Identity)
+		result = append(result, refs...)
 		refs, _ = langrefs.ReferencesInExpr(addrs.ParseRef, importTarget.Config.ForEach)
 		result = append(result, refs...)
 	}

--- a/internal/terraform/node_resource_plan.go
+++ b/internal/terraform/node_resource_plan.go
@@ -188,7 +188,7 @@ func (n *nodeExpandPlannableResource) expandResourceImports(ctx EvalContext, all
 			if imp.Config.ID != nil {
 				importID, evalDiags = evaluateImportIdExpression(imp.Config.ID, ctx, EvalDataForNoInstanceKey, allowUnknown)
 			} else if imp.Config.Identity != nil {
-				_, providerSchema, err := getProvider(ctx, n.ResolvedProvider)
+				providerSchema, err := ctx.ProviderSchema(n.ResolvedProvider)
 				if err != nil {
 					diags = diags.Append(err)
 					return knownImports, unknownImports, diags

--- a/internal/terraform/node_resource_plan.go
+++ b/internal/terraform/node_resource_plan.go
@@ -163,7 +163,7 @@ func (n *nodeExpandPlannableResource) expandResourceImports(ctx EvalContext, all
 			// if we have a legacy addr, it was supplied on the commandline so
 			// there is nothing to expand
 			if !imp.LegacyAddr.Equal(addrs.AbsResourceInstance{}) {
-				knownImports.Put(imp.LegacyAddr, cty.StringVal(imp.IDString))
+				knownImports.Put(imp.LegacyAddr, cty.StringVal(imp.LegacyID))
 				return knownImports, unknownImports, diags
 			}
 

--- a/internal/terraform/node_resource_plan.go
+++ b/internal/terraform/node_resource_plan.go
@@ -264,7 +264,7 @@ func (n *nodeExpandPlannableResource) expandResourceImports(ctx EvalContext, all
 			if imp.Config.ID != nil {
 				importID, evalDiags = evaluateImportIdExpression(imp.Config.ID, ctx, keyData, allowUnknown)
 			} else if imp.Config.Identity != nil {
-				_, providerSchema, err := getProvider(ctx, n.ResolvedProvider)
+				providerSchema, err := ctx.ProviderSchema(n.ResolvedProvider)
 				if err != nil {
 					diags = diags.Append(err)
 					return knownImports, unknownImports, diags

--- a/internal/terraform/node_resource_plan_instance.go
+++ b/internal/terraform/node_resource_plan_instance.go
@@ -681,7 +681,7 @@ func (n *NodePlannableResourceInstance) importState(ctx EvalContext, addr addrs.
 	var importValue string
 	if importTarget.Type().IsObjectType() {
 		importType = "Identity"
-		importValue = importTarget.GoString() // TODO improve
+		importValue = tfdiags.ObjectToString(importTarget)
 	} else {
 		importValue = importTarget.AsString()
 	}

--- a/internal/terraform/node_resource_plan_instance.go
+++ b/internal/terraform/node_resource_plan_instance.go
@@ -209,7 +209,7 @@ func (n *NodePlannableResourceInstance) managedResourceExecute(ctx EvalContext) 
 	// and a Refresh, and save the resulting state to instanceRefreshState.
 
 	if importing {
-		if n.importTarget.IsKnown() {
+		if n.importTarget.IsWhollyKnown() {
 			var importDiags tfdiags.Diagnostics
 			instanceRefreshState, deferred, importDiags = n.importState(ctx, addr, n.importTarget, provider, providerSchema)
 			diags = diags.Append(importDiags)

--- a/internal/terraform/node_resource_validate.go
+++ b/internal/terraform/node_resource_validate.go
@@ -589,6 +589,7 @@ func (n *NodeValidatableResource) validateImportTargets(ctx EvalContext) tfdiags
 			}
 
 			for _, keyData := range forEachData {
+				var evalDiags tfdiags.Diagnostics
 				to, evalDiags := evalImportToExpression(imp.Config.To, keyData)
 				diags = diags.Append(evalDiags)
 				if diags.HasErrors() {
@@ -598,7 +599,20 @@ func (n *NodeValidatableResource) validateImportTargets(ctx EvalContext) tfdiags
 				if diags.HasErrors() {
 					return diags
 				}
-				_, evalDiags = evaluateImportIdExpression(imp.Config.ID, ctx, keyData, true)
+
+				if imp.Config.ID != nil {
+					_, evalDiags = evaluateImportIdExpression(imp.Config.ID, ctx, keyData, true)
+				} else if imp.Config.Identity != nil {
+					_, providerSchema, err := getProvider(ctx, n.ResolvedProvider)
+					if err != nil {
+						diags = diags.Append(err)
+						return diags
+					}
+					schema := providerSchema.SchemaForResourceAddr(to.Resource.Resource)
+
+					_, evalDiags = evaluateImportIdentityExpression(imp.Config.Identity, schema.Identity, ctx, keyData, true)
+				}
+
 				diags = diags.Append(evalDiags)
 				if diags.HasErrors() {
 					return diags
@@ -618,7 +632,20 @@ func (n *NodeValidatableResource) validateImportTargets(ctx EvalContext) tfdiags
 				return diags
 			}
 
-			_, evalDiags := evaluateImportIdExpression(imp.Config.ID, ctx, EvalDataForNoInstanceKey, true)
+			var evalDiags tfdiags.Diagnostics
+			if imp.Config.ID != nil {
+				_, evalDiags = evaluateImportIdExpression(imp.Config.ID, ctx, EvalDataForNoInstanceKey, true)
+			} else if imp.Config.Identity != nil {
+				_, providerSchema, err := getProvider(ctx, n.ResolvedProvider)
+				if err != nil {
+					diags = diags.Append(err)
+					return diags
+				}
+				schema := providerSchema.SchemaForResourceAddr(to.Resource.Resource)
+
+				_, evalDiags = evaluateImportIdentityExpression(imp.Config.Identity, schema.Identity, ctx, EvalDataForNoInstanceKey, true)
+			}
+
 			diags = diags.Append(evalDiags)
 			if diags.HasErrors() {
 				return diags

--- a/internal/terraform/node_resource_validate.go
+++ b/internal/terraform/node_resource_validate.go
@@ -603,7 +603,7 @@ func (n *NodeValidatableResource) validateImportTargets(ctx EvalContext) tfdiags
 				if imp.Config.ID != nil {
 					_, evalDiags = evaluateImportIdExpression(imp.Config.ID, ctx, keyData, true)
 				} else if imp.Config.Identity != nil {
-					_, providerSchema, err := getProvider(ctx, n.ResolvedProvider)
+					providerSchema, err := ctx.ProviderSchema(n.ResolvedProvider)
 					if err != nil {
 						diags = diags.Append(err)
 						return diags
@@ -636,7 +636,7 @@ func (n *NodeValidatableResource) validateImportTargets(ctx EvalContext) tfdiags
 			if imp.Config.ID != nil {
 				_, evalDiags = evaluateImportIdExpression(imp.Config.ID, ctx, EvalDataForNoInstanceKey, true)
 			} else if imp.Config.Identity != nil {
-				_, providerSchema, err := getProvider(ctx, n.ResolvedProvider)
+				providerSchema, err := ctx.ProviderSchema(n.ResolvedProvider)
 				if err != nil {
 					diags = diags.Append(err)
 					return diags

--- a/internal/terraform/testdata/import-identity-module/child/main.tf
+++ b/internal/terraform/testdata/import-identity-module/child/main.tf
@@ -1,0 +1,3 @@
+output "lb_id" {
+  value = 1
+}

--- a/internal/terraform/testdata/import-identity-module/main.tf
+++ b/internal/terraform/testdata/import-identity-module/main.tf
@@ -1,0 +1,12 @@
+module "child" {
+  source = "./child"
+}
+
+import {
+  to = aws_lb.foo
+  identity = {
+    name = "bar"
+  }
+}
+
+resource "aws_lb" "foo" {}

--- a/internal/tfdiags/object.go
+++ b/internal/tfdiags/object.go
@@ -1,0 +1,72 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+package tfdiags
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/zclconf/go-cty/cty"
+)
+
+// ObjectToString is a helper function that converts a go-cty object to a string representation
+func ObjectToString(obj cty.Value) string {
+	if obj.IsNull() {
+		return "<null>"
+	}
+
+	if !obj.IsKnown() {
+		return "<unknown>"
+	}
+
+	if obj.Type().IsObjectType() && len(obj.Type().AttributeTypes()) == 0 {
+		return "<empty>"
+	}
+
+	if obj.Type().IsObjectType() {
+		result := ""
+		it := obj.ElementIterator()
+		for it.Next() {
+			key, val := it.Element()
+			keyStr := key.AsString()
+
+			if result != "" {
+				result += ","
+			}
+
+			switch val.Type() {
+			case cty.Bool:
+				result += fmt.Sprintf("%s=%t", keyStr, val.True())
+			case cty.Number:
+				result += fmt.Sprintf("%s=%s", keyStr, val.AsBigFloat().String())
+			case cty.String:
+				result += fmt.Sprintf("%s=%s", keyStr, val.AsString())
+			case cty.List(cty.Bool):
+				elements := val.AsValueSlice()
+				parts := make([]string, len(elements))
+				for i, element := range elements {
+					parts[i] = fmt.Sprintf("%t", element.True())
+				}
+				result += fmt.Sprintf("%s=[%s]", keyStr, strings.Join(parts, ","))
+			case cty.List(cty.Number):
+				elements := val.AsValueSlice()
+				parts := make([]string, len(elements))
+				for i, element := range elements {
+					parts[i] = element.AsBigFloat().String()
+				}
+				result += fmt.Sprintf("%s=[%s]", keyStr, strings.Join(parts, ","))
+			case cty.List(cty.String):
+				elements := val.AsValueSlice()
+				parts := make([]string, len(elements))
+				for i, element := range elements {
+					parts[i] = element.AsString()
+				}
+				result += fmt.Sprintf("%s=[%s]", keyStr, strings.Join(parts, ","))
+			}
+		}
+
+		return result
+	}
+
+	panic("not an object")
+}

--- a/internal/tfdiags/object.go
+++ b/internal/tfdiags/object.go
@@ -15,7 +15,7 @@ func ObjectToString(obj cty.Value) string {
 		return "<null>"
 	}
 
-	if !obj.IsKnown() {
+	if !obj.IsWhollyKnown() {
 		return "<unknown>"
 	}
 

--- a/internal/tfdiags/object_test.go
+++ b/internal/tfdiags/object_test.go
@@ -1,0 +1,64 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+package tfdiags
+
+import (
+	"testing"
+
+	"github.com/zclconf/go-cty/cty"
+)
+
+func Test_ObjectToString(t *testing.T) {
+	testCases := []struct {
+		name     string
+		value    cty.Value
+		expected string
+	}{
+		{
+			name:     "null",
+			value:    cty.NullVal(cty.Object(map[string]cty.Type{})),
+			expected: "<null>",
+		},
+		{
+			name:     "unknown",
+			value:    cty.UnknownVal(cty.Object(map[string]cty.Type{})),
+			expected: "<unknown>",
+		},
+		{
+			name:     "empty",
+			value:    cty.EmptyObjectVal,
+			expected: "<empty>",
+		},
+		{
+			name: "primitive",
+			value: cty.ObjectVal(map[string]cty.Value{
+				"number": cty.NumberIntVal(42),
+				"string": cty.StringVal("hello"),
+				"bool":   cty.BoolVal(true),
+			}),
+			expected: "bool=true,number=42,string=hello",
+		},
+		{
+			name: "list",
+			value: cty.ObjectVal(map[string]cty.Value{
+				"string": cty.StringVal("hello"),
+				"list": cty.ListVal([]cty.Value{
+					cty.StringVal("a"),
+					cty.StringVal("b"),
+					cty.StringVal("c"),
+				}),
+			}),
+			expected: "list=[a,b,c],string=hello",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := ObjectToString(tc.value)
+
+			if actual != tc.expected {
+				t.Errorf("expected %q, got %q", tc.expected, actual)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR adds support for importing resources via their identity

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.12.x

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

I'm planning to add changelog entries for the whole feature in a separate PR
