### PR TITLE
CLI command for listing state identities

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -378,6 +378,12 @@ func initCommands(
 			}, nil
 		},
 
+		"state identities": func() (cli.Command, error) {
+			return &command.StateIdentitiesCommand{
+				Meta: meta,
+			}, nil
+		},
+
 		"state rm": func() (cli.Command, error) {
 			return &command.StateRmCommand{
 				StateMeta: command.StateMeta{

--- a/internal/command/command_test.go
+++ b/internal/command/command_test.go
@@ -322,6 +322,53 @@ func testState() *states.State {
 	}).DeepCopy()
 }
 
+func testStateWithIdentity() *states.State {
+	return states.BuildState(func(s *states.SyncState) {
+		s.SetResourceInstanceCurrent(
+			addrs.Resource{
+				Mode: addrs.ManagedResourceMode,
+				Type: "test_instance",
+				Name: "foo",
+			}.Instance(addrs.NoKey).Absolute(addrs.RootModuleInstance),
+			&states.ResourceInstanceObjectSrc{
+				// The weird whitespace here is reflective of how this would
+				// get written out in a real state file, due to the indentation
+				// of all of the containing wrapping objects and arrays.
+				AttrsJSON:             []byte("{\n            \"id\": \"foo\"\n          }"),
+				Status:                states.ObjectReady,
+				Dependencies:          []addrs.ConfigResource{},
+				IdentitySchemaVersion: 0,
+				IdentityJSON:          []byte("{\n            \"id\": \"my-foo-id\"\n          }"),
+			},
+			addrs.AbsProviderConfig{
+				Provider: addrs.NewDefaultProvider("test"),
+				Module:   addrs.RootModule,
+			},
+		)
+		s.SetResourceInstanceCurrent(
+			addrs.Resource{
+				Mode: addrs.ManagedResourceMode,
+				Type: "test_instance",
+				Name: "bar",
+			}.Instance(addrs.NoKey).Absolute(addrs.RootModuleInstance),
+			&states.ResourceInstanceObjectSrc{
+				AttrsJSON:             []byte("{\n            \"id\": \"bar\"\n          }"),
+				Status:                states.ObjectReady,
+				Dependencies:          []addrs.ConfigResource{},
+				IdentitySchemaVersion: 0,
+				IdentityJSON:          []byte("{\n            \"id\": \"my-bar-id\"\n          }"),
+			},
+			addrs.AbsProviderConfig{
+				Provider: addrs.NewDefaultProvider("test"),
+				Module:   addrs.RootModule,
+			},
+		)
+		// DeepCopy is used here to ensure our synthetic state matches exactly
+		// with a state that will have been copied during the command
+		// operation, and all fields have been copied correctly.
+	}).DeepCopy()
+}
+
 // writeStateForTesting is a helper that writes the given naked state to the
 // given writer, generating a stub *statefile.File wrapper which is then
 // immediately discarded.

--- a/internal/command/state_identities.go
+++ b/internal/command/state_identities.go
@@ -86,6 +86,9 @@ func (c *StateIdentitiesCommand) Run(args []string) int {
 		if is := state.ResourceInstance(addr); is != nil {
 			if *lookupId == "" || *lookupId == states.LegacyInstanceObjectID(is.Current) {
 				var rawIdentity map[string]interface{}
+				if is.Current.IdentityJSON == nil {
+					continue
+				}
 				if err := json.Unmarshal(is.Current.IdentityJSON, &rawIdentity); err != nil {
 					c.Ui.Error(fmt.Sprintf("Failed to unmarshal identity JSON: %s", err))
 					return 1

--- a/internal/command/state_identities.go
+++ b/internal/command/state_identities.go
@@ -1,0 +1,147 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package command
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/cli"
+	"github.com/hashicorp/terraform/internal/addrs"
+	"github.com/hashicorp/terraform/internal/states"
+	"github.com/hashicorp/terraform/internal/tfdiags"
+)
+
+// StateIdentitiesCommand is a Command implementation that lists the resource identities
+// within a state file.
+type StateIdentitiesCommand struct {
+	Meta
+	StateMeta
+}
+
+func (c *StateIdentitiesCommand) Run(args []string) int {
+	args = c.Meta.process(args)
+	var statePath string
+	cmdFlags := c.Meta.defaultFlagSet("state identities")
+	cmdFlags.StringVar(&statePath, "state", "", "path")
+	lookupId := cmdFlags.String("id", "", "Restrict output to paths with a resource having the specified ID.")
+	if err := cmdFlags.Parse(args); err != nil {
+		c.Ui.Error(fmt.Sprintf("Error parsing command-line flags: %s\n", err.Error()))
+		return cli.RunResultHelp
+	}
+	args = cmdFlags.Args()
+
+	if statePath != "" {
+		c.Meta.statePath = statePath
+	}
+
+	// Load the backend
+	b, backendDiags := c.Backend(nil)
+	if backendDiags.HasErrors() {
+		c.showDiagnostics(backendDiags)
+		return 1
+	}
+
+	// This is a read-only command
+	c.ignoreRemoteVersionConflict(b)
+
+	// Get the state
+	env, err := c.Workspace()
+	if err != nil {
+		c.Ui.Error(fmt.Sprintf("Error selecting workspace: %s", err))
+		return 1
+	}
+	stateMgr, err := b.StateMgr(env)
+	if err != nil {
+		c.Ui.Error(fmt.Sprintf(errStateLoadingState, err))
+		return 1
+	}
+	if err := stateMgr.RefreshState(); err != nil {
+		c.Ui.Error(fmt.Sprintf("Failed to load state: %s", err))
+		return 1
+	}
+
+	state := stateMgr.State()
+	if state == nil {
+		c.Ui.Error(errStateNotFound)
+		return 1
+	}
+
+	var addrs []addrs.AbsResourceInstance
+	var diags tfdiags.Diagnostics
+	if len(args) == 0 {
+		addrs, diags = c.lookupAllResourceInstanceAddrs(state)
+	} else {
+		addrs, diags = c.lookupResourceInstanceAddrs(state, args...)
+	}
+	if diags.HasErrors() {
+		c.showDiagnostics(diags)
+		return 1
+	}
+
+	output := make(map[string]interface{})
+	for _, addr := range addrs {
+		if is := state.ResourceInstance(addr); is != nil {
+			if *lookupId == "" || *lookupId == states.LegacyInstanceObjectID(is.Current) {
+				var rawIdentity map[string]interface{}
+				if err := json.Unmarshal(is.Current.IdentityJSON, &rawIdentity); err != nil {
+					c.Ui.Error(fmt.Sprintf("Failed to unmarshal identity JSON: %s", err))
+					return 1
+				}
+				output[addr.String()] = rawIdentity
+			}
+		}
+	}
+
+	outputJSON, err := json.MarshalIndent(output, "", "  ")
+	if err != nil {
+		c.Ui.Error(fmt.Sprintf("Failed to marshal output JSON: %s", err))
+		return 1
+	}
+
+	c.Ui.Output(string(outputJSON))
+	c.showDiagnostics(diags)
+
+	return 0
+}
+
+func (c *StateIdentitiesCommand) Help() string {
+	helpText := `
+Usage: terraform [global options] state identities [options] [address...]
+
+  List the identities of resources in the Terraform state.
+
+  This command lists the identities of resource instances in the Terraform state. The address
+  argument can be used to filter the instances by resource or module. If
+  no pattern is given, identities for all resource instances are listed.
+
+  The addresses must either be module addresses or absolute resource
+  addresses, such as:
+      aws_instance.example
+      module.example
+      module.example.module.child
+      module.example.aws_instance.example
+
+  An error will be returned if any of the resources or modules given as
+  filter addresses do not exist in the state.
+
+Options:
+
+  -state=statefile    Path to a Terraform state file to use to look
+                      up Terraform-managed resources. By default, Terraform
+                      will consult the state of the currently-selected
+                      workspace.
+
+  -id=ID              Filters the results to include only instances whose
+                      resource types have an attribute named "id" whose value
+                      equals the given id string.
+
+`
+	return strings.TrimSpace(helpText)
+}
+
+func (c *StateIdentitiesCommand) Synopsis() string {
+	return "List the identities of resources in the state"
+}

--- a/internal/command/state_identities_test.go
+++ b/internal/command/state_identities_test.go
@@ -1,0 +1,360 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package command
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/hashicorp/cli"
+)
+
+func TestStateIdentities(t *testing.T) {
+	state := testStateWithIdentity()
+	statePath := testStateFile(t, state)
+
+	p := testProvider()
+	ui := cli.NewMockUi()
+	c := &StateIdentitiesCommand{
+		Meta: Meta{
+			testingOverrides: metaOverridesForProvider(p),
+			Ui:               ui,
+		},
+	}
+
+	args := []string{
+		"-state", statePath,
+	}
+	if code := c.Run(args); code != 0 {
+		t.Fatalf("bad: %d\n\n%s", code, ui.ErrorWriter.String())
+	}
+
+	// Test that outputs were displayed
+	expected := `{
+		"test_instance.foo": {"id": "my-foo-id"},
+		"test_instance.bar": {"id": "my-bar-id"}
+	}`
+	actual := ui.OutputWriter.String()
+
+	// Normalize JSON strings
+	var expectedJSON, actualJSON map[string]interface{}
+	if err := json.Unmarshal([]byte(expected), &expectedJSON); err != nil {
+		t.Fatalf("Failed to unmarshal expected JSON: %s", err)
+	}
+	if err := json.Unmarshal([]byte(actual), &actualJSON); err != nil {
+		t.Fatalf("Failed to unmarshal actual JSON: %s", err)
+	}
+
+	if !reflect.DeepEqual(expectedJSON, actualJSON) {
+		t.Fatalf("Expected:\n%q\n\nTo equal: %q", expected, actual)
+	}
+}
+
+func TestStateIdentitiesFilterByID(t *testing.T) {
+	state := testStateWithIdentity()
+	statePath := testStateFile(t, state)
+
+	p := testProvider()
+	ui := cli.NewMockUi()
+	c := &StateIdentitiesCommand{
+		Meta: Meta{
+			testingOverrides: metaOverridesForProvider(p),
+			Ui:               ui,
+		},
+	}
+
+	args := []string{
+		"-state", statePath,
+		"-id", "foo",
+	}
+	if code := c.Run(args); code != 0 {
+		t.Fatalf("bad: %d\n\n%s", code, ui.ErrorWriter.String())
+	}
+
+	// Test that outputs were displayed
+	expected := `{
+		"test_instance.foo": {"id": "my-foo-id"}
+	}`
+	actual := ui.OutputWriter.String()
+
+	// Normalize JSON strings
+	var expectedJSON, actualJSON map[string]interface{}
+	if err := json.Unmarshal([]byte(expected), &expectedJSON); err != nil {
+		t.Fatalf("Failed to unmarshal expected JSON: %s", err)
+	}
+	if err := json.Unmarshal([]byte(actual), &actualJSON); err != nil {
+		t.Fatalf("Failed to unmarshal actual JSON: %s", err)
+	}
+
+	if !reflect.DeepEqual(expectedJSON, actualJSON) {
+		t.Fatalf("Expected:\n%q\n\nTo equal: %q", expected, actual)
+	}
+}
+
+func TestStateIdentitiesWithNonExistentID(t *testing.T) {
+	state := testState()
+	statePath := testStateFile(t, state)
+
+	p := testProvider()
+	ui := cli.NewMockUi()
+	c := &StateIdentitiesCommand{
+		Meta: Meta{
+			testingOverrides: metaOverridesForProvider(p),
+			Ui:               ui,
+		},
+	}
+
+	args := []string{
+		"-state", statePath,
+		"-id", "baz",
+	}
+	if code := c.Run(args); code != 0 {
+		t.Fatalf("bad: %d\n\n%s", code, ui.ErrorWriter.String())
+	}
+
+	// Test that output is empty
+	if ui.OutputWriter != nil {
+		actual := ui.OutputWriter.String()
+		if actual != "{}\n" {
+			t.Fatalf("Expected an empty output but got: %q", actual)
+		}
+	}
+}
+
+func TestStateIdentities_backendDefaultState(t *testing.T) {
+	// Create a temporary working directory that is empty
+	td := t.TempDir()
+	testCopyDir(t, testFixturePath("state-identities-backend-default"), td)
+	defer testChdir(t, td)()
+
+	p := testProvider()
+	ui := cli.NewMockUi()
+	c := &StateIdentitiesCommand{
+		Meta: Meta{
+			testingOverrides: metaOverridesForProvider(p),
+			Ui:               ui,
+		},
+	}
+
+	args := []string{}
+	if code := c.Run(args); code != 0 {
+		t.Fatalf("bad: %d\n\n%s", code, ui.ErrorWriter.String())
+	}
+
+	// Test that outputs were displayed
+	expected := `{
+		"null_resource.a": {
+			"project": "my-project",
+			"role": "roles/viewer",
+			"member": "user:peter@example.com"
+		}
+	}`
+	actual := ui.OutputWriter.String()
+
+	// Normalize JSON strings
+	var expectedJSON, actualJSON map[string]interface{}
+	if err := json.Unmarshal([]byte(expected), &expectedJSON); err != nil {
+		t.Fatalf("Failed to unmarshal expected JSON: %s", err)
+	}
+	if err := json.Unmarshal([]byte(actual), &actualJSON); err != nil {
+		t.Fatalf("Failed to unmarshal actual JSON: %s", err)
+	}
+
+	if !reflect.DeepEqual(expectedJSON, actualJSON) {
+		t.Fatalf("Expected:\n%q\n\nTo equal: %q", expected, actual)
+	}
+}
+
+func TestStateIdentities_backendOverrideState(t *testing.T) {
+	// Create a temporary working directory that is empty
+	td := t.TempDir()
+	testCopyDir(t, testFixturePath("state-identities-backend-default"), td)
+
+	// Rename the state file to a custom name to simulate a custom state file
+	err := os.Rename(filepath.Join(td, "terraform.tfstate"), filepath.Join(td, "custom.tfstate"))
+	if err != nil {
+		t.Fatalf("Failed to rename state file: %s", err)
+	}
+	defer testChdir(t, td)()
+
+	p := testProvider()
+	ui := cli.NewMockUi()
+	c := &StateIdentitiesCommand{
+		Meta: Meta{
+			testingOverrides: metaOverridesForProvider(p),
+			Ui:               ui,
+		},
+	}
+
+	// Run the command with a custom state file
+	args := []string{"-state=custom.tfstate"}
+	if code := c.Run(args); code != 0 {
+		t.Fatalf("bad: %d", code)
+	}
+
+	// Test that outputs were displayed
+	expected := `{
+		"null_resource.a": {
+			"project": "my-project",
+			"role": "roles/viewer",
+			"member": "user:peter@example.com"
+		}
+	}`
+	actual := ui.OutputWriter.String()
+
+	// Normalize JSON strings
+	var expectedJSON, actualJSON map[string]interface{}
+	if err := json.Unmarshal([]byte(expected), &expectedJSON); err != nil {
+		t.Fatalf("Failed to unmarshal expected JSON: %s", err)
+	}
+	if err := json.Unmarshal([]byte(actual), &actualJSON); err != nil {
+		t.Fatalf("Failed to unmarshal actual JSON: %s", err)
+	}
+
+	if !reflect.DeepEqual(expectedJSON, actualJSON) {
+		t.Fatalf("Expected:\n%q\n\nTo equal: %q", expected, actual)
+	}
+}
+
+func TestStateIdentities_noState(t *testing.T) {
+	testCwd(t)
+
+	p := testProvider()
+	ui := cli.NewMockUi()
+	c := &StateIdentitiesCommand{
+		Meta: Meta{
+			testingOverrides: metaOverridesForProvider(p),
+			Ui:               ui,
+		},
+	}
+
+	args := []string{}
+	if code := c.Run(args); code != 1 {
+		t.Fatalf("bad: %d", code)
+	}
+}
+
+func TestStateIdentities_modules(t *testing.T) {
+	// Create a temporary working directory that is empty
+	td := t.TempDir()
+	testCopyDir(t, testFixturePath("state-identities-nested-modules"), td)
+	defer testChdir(t, td)()
+
+	p := testProvider()
+	ui := cli.NewMockUi()
+	c := &StateIdentitiesCommand{
+		Meta: Meta{
+			testingOverrides: metaOverridesForProvider(p),
+			Ui:               ui,
+		},
+	}
+
+	t.Run("list resources in module and submodules", func(t *testing.T) {
+		args := []string{"module.nest"}
+		if code := c.Run(args); code != 0 {
+			t.Fatalf("bad: %d", code)
+		}
+
+		// resources in the module and any submodules should be included in the outputs
+		expected := `{
+			"module.nest.test_instance.nest": {
+				"project": "my-project-nest",
+				"role": "roles/viewer-nest"
+			},
+			"module.nest.module.subnest.test_instance.subnest": {
+				"project": "my-project-subnest",
+				"role": "roles/viewer-subnest"
+			}
+		}`
+		actual := ui.OutputWriter.String()
+
+		// Normalize JSON strings
+		var expectedJSON, actualJSON map[string]interface{}
+		if err := json.Unmarshal([]byte(expected), &expectedJSON); err != nil {
+			t.Fatalf("Failed to unmarshal expected JSON: %s", err)
+		}
+		if err := json.Unmarshal([]byte(actual), &actualJSON); err != nil {
+			t.Fatalf("Failed to unmarshal actual JSON: %s", err)
+		}
+
+		if !reflect.DeepEqual(expectedJSON, actualJSON) {
+			t.Fatalf("Expected:\n%q\n\nTo equal: %q", expected, actual)
+		}
+	})
+
+	t.Run("submodule has resources only", func(t *testing.T) {
+		// now get the state for a module that has no resources, only another nested module
+		ui.OutputWriter.Reset()
+		args := []string{"module.nonexist"}
+		if code := c.Run(args); code != 0 {
+			t.Fatalf("bad: %d", code)
+		}
+		expected := `{
+			"module.nonexist.module.child.test_instance.child": {
+				"project": "my-project-child",
+				"role": "roles/viewer-child"
+			}
+		}`
+		actual := ui.OutputWriter.String()
+
+		// Normalize JSON strings
+		var expectedJSON, actualJSON map[string]interface{}
+		if err := json.Unmarshal([]byte(expected), &expectedJSON); err != nil {
+			t.Fatalf("Failed to unmarshal expected JSON: %s", err)
+		}
+		if err := json.Unmarshal([]byte(actual), &actualJSON); err != nil {
+			t.Fatalf("Failed to unmarshal actual JSON: %s", err)
+		}
+
+		if !reflect.DeepEqual(expectedJSON, actualJSON) {
+			t.Fatalf("Expected:\n%q\n\nTo equal: %q", expected, actual)
+		}
+	})
+
+	t.Run("expanded module", func(t *testing.T) {
+		// finally get the state for a module with an index
+		ui.OutputWriter.Reset()
+		args := []string{"module.count"}
+		if code := c.Run(args); code != 0 {
+			t.Fatalf("bad: %d", code)
+		}
+		expected := `{
+			"module.count[0].test_instance.count": {
+				"project": "my-project-count-0",
+				"role": "roles/viewer-count-0"
+			},
+			"module.count[1].test_instance.count": {
+				"project": "my-project-count-1",
+				"role": "roles/viewer-count-1"
+			}
+		}`
+		actual := ui.OutputWriter.String()
+
+		// Normalize JSON strings
+		var expectedJSON, actualJSON map[string]interface{}
+		if err := json.Unmarshal([]byte(expected), &expectedJSON); err != nil {
+			t.Fatalf("Failed to unmarshal expected JSON: %s", err)
+		}
+		if err := json.Unmarshal([]byte(actual), &actualJSON); err != nil {
+			t.Fatalf("Failed to unmarshal actual JSON: %s", err)
+		}
+
+		if !reflect.DeepEqual(expectedJSON, actualJSON) {
+			t.Fatalf("Expected:\n%q\n\nTo equal: %q", expected, actual)
+		}
+	})
+
+	t.Run("completely nonexistent module", func(t *testing.T) {
+		// finally get the state for a module with an index
+		ui.OutputWriter.Reset()
+		args := []string{"module.notevenalittlebit"}
+		if code := c.Run(args); code != 1 {
+			t.Fatalf("bad: %d", code)
+		}
+	})
+
+}

--- a/internal/command/state_identities_test.go
+++ b/internal/command/state_identities_test.go
@@ -54,6 +54,44 @@ func TestStateIdentities(t *testing.T) {
 	}
 }
 
+func TestStateIdentitiesWithNoIdentityInfo(t *testing.T) {
+	state := testState()
+	statePath := testStateFile(t, state)
+
+	p := testProvider()
+	ui := cli.NewMockUi()
+	c := &StateIdentitiesCommand{
+		Meta: Meta{
+			testingOverrides: metaOverridesForProvider(p),
+			Ui:               ui,
+		},
+	}
+
+	args := []string{
+		"-state", statePath,
+	}
+	if code := c.Run(args); code != 0 {
+		t.Fatalf("bad: %d\n\n%s", code, ui.ErrorWriter.String())
+	}
+
+	// Test that outputs were displayed
+	expected := `{}`
+	actual := ui.OutputWriter.String()
+
+	// Normalize JSON strings
+	var expectedJSON, actualJSON map[string]interface{}
+	if err := json.Unmarshal([]byte(expected), &expectedJSON); err != nil {
+		t.Fatalf("Failed to unmarshal expected JSON: %s", err)
+	}
+	if err := json.Unmarshal([]byte(actual), &actualJSON); err != nil {
+		t.Fatalf("Failed to unmarshal actual JSON: %s", err)
+	}
+
+	if !reflect.DeepEqual(expectedJSON, actualJSON) {
+		t.Fatalf("Expected:\n%q\n\nTo equal: %q", expected, actual)
+	}
+}
+
 func TestStateIdentitiesFilterByID(t *testing.T) {
 	state := testStateWithIdentity()
 	statePath := testStateFile(t, state)

--- a/internal/command/testdata/state-identities-backend-default/.terraform/terraform.tfstate
+++ b/internal/command/testdata/state-identities-backend-default/.terraform/terraform.tfstate
@@ -1,0 +1,23 @@
+{
+    "version": 3,
+    "serial": 0,
+    "lineage": "666f9301-7e65-4b19-ae23-71184bb19b03",
+    "backend": {
+        "type": "local",
+        "config": {
+            "path": null,
+            "workspace_dir": null
+        },
+        "hash": 666019178
+    },
+    "modules": [
+        {
+            "path": [
+                "root"
+            ],
+            "outputs": {},
+            "resources": {},
+            "depends_on": []
+        }
+    ]
+}

--- a/internal/command/testdata/state-identities-backend-default/main.tf
+++ b/internal/command/testdata/state-identities-backend-default/main.tf
@@ -1,0 +1,4 @@
+terraform {
+    backend "local" {
+    }
+}

--- a/internal/command/testdata/state-identities-backend-default/terraform.tfstate
+++ b/internal/command/testdata/state-identities-backend-default/terraform.tfstate
@@ -1,0 +1,30 @@
+{
+  "version": 4,
+  "terraform_version": "0.12.0",
+  "serial": 7,
+  "lineage": "configuredUnchanged",
+  "outputs": {},
+  "resources": [
+    {
+      "mode": "managed",
+      "type": "null_resource",
+      "name": "a",
+      "provider": "provider[\"registry.terraform.io/-/null\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "8521602373864259745",
+            "triggers": null
+          },
+          "identity_schema_version": 0,
+          "identity": {
+            "project": "my-project",
+            "role": "roles/viewer",
+            "member": "user:peter@example.com"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/internal/command/testdata/state-identities-nested-modules/terraform.tfstate
+++ b/internal/command/testdata/state-identities-nested-modules/terraform.tfstate
@@ -1,0 +1,133 @@
+{
+    "version": 4,
+    "terraform_version": "0.15.0",
+    "serial": 8,
+    "lineage": "00bfda35-ad61-ec8d-c013-14b0320bc416",
+    "resources": [
+        {
+            "mode": "managed",
+            "type": "test_instance",
+            "name": "root",
+            "provider": "provider[\"registry.terraform.io/hashicorp/test\"]",
+            "instances": [
+                {
+                    "schema_version": 0,
+                    "attributes": {
+                        "id": "root",
+                        "triggers": null
+                    },
+                    "identity_schema_version": 0,
+                    "identity": {
+                        "project": "my-project-root",
+                        "role": "roles/viewer-root"
+                    }
+                }
+            ]
+        },
+        {
+            "module": "module.nest",
+            "mode": "managed",
+            "type": "test_instance",
+            "name": "nest",
+            "provider": "provider[\"registry.terraform.io/hashicorp/test\"]",
+            "instances": [
+                {
+                    "schema_version": 0,
+                    "attributes": {
+                        "ami": "nested",
+                        "triggers": null
+                    },
+                    "identity_schema_version": 0,
+                    "identity": {
+                        "project": "my-project-nest",
+                        "role": "roles/viewer-nest"
+                    }
+                }
+            ]
+        },
+        {
+            "module": "module.nest.module.subnest",
+            "mode": "managed",
+            "type": "test_instance",
+            "name": "subnest",
+            "provider": "provider[\"registry.terraform.io/hashicorp/test\"]",
+            "instances": [
+                {
+                    "schema_version": 0,
+                    "attributes": {
+                        "id": "subnested",
+                        "triggers": null
+                    },
+                    "identity_schema_version": 0,
+                    "identity": {
+                        "project": "my-project-subnest",
+                        "role": "roles/viewer-subnest"
+                    }
+                }
+            ]
+        },
+        {
+            "module": "module.nonexist.module.child",
+            "mode": "managed",
+            "type": "test_instance",
+            "name": "child",
+            "provider": "provider[\"registry.terraform.io/hashicorp/test\"]",
+            "instances": [
+                {
+                    "schema_version": 0,
+                    "attributes": {
+                        "id": "child",
+                        "triggers": null
+                    },
+                    "identity_schema_version": 0,
+                    "identity": {
+                        "project": "my-project-child",
+                        "role": "roles/viewer-child"
+                    }
+                }
+            ]
+        },
+        {
+            "module": "module.count[0]",
+            "mode": "managed",
+            "type": "test_instance",
+            "name": "count",
+            "provider": "provider[\"registry.terraform.io/hashicorp/test\"]",
+            "instances": [
+                {
+                    "schema_version": 0,
+                    "attributes": {
+                        "id": "zero",
+                        "triggers": null
+                    },
+                    "identity_schema_version": 0,
+                    "identity": {
+                        "project": "my-project-count-0",
+                        "role": "roles/viewer-count-0"
+                    }
+                }
+            ]
+        },
+        {
+            "module": "module.count[1]",
+            "mode": "managed",
+            "type": "test_instance",
+            "name": "count",
+            "provider": "provider[\"registry.terraform.io/hashicorp/test\"]",
+            "instances": [
+                {
+                    "schema_version": 0,
+                    "attributes": {
+                        "id": "one",
+                        "triggers": null
+                    },
+                    "identity_schema_version": 0,
+                    "identity": {
+                        "project": "my-project-count-1",
+                        "role": "roles/viewer-count-1"
+                    }
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

This allows listing the identities in state via `terraform state identities`. All options that apply to `terraform state list` also apply here.

Example output:

<img width="1006" alt="image" src="https://github.com/user-attachments/assets/0419144a-f344-4139-a188-940a6ecd7202" />


## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.12.x

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [ ] This change is not user-facing.
