### PR TITLE
Detect circular references during Validation

### DIFF
--- a/internal/stacks/stackruntime/internal/stackeval/component_config.go
+++ b/internal/stacks/stackruntime/internal/stackeval/component_config.go
@@ -259,8 +259,9 @@ func (c *ComponentConfig) ExprReferenceValue(ctx context.Context, phase EvalPhas
 	// phase, so this is sufficient for all phases. (See [Component] for how
 	// component results get calculated during the plan and apply phases.)
 
-	// Validating this component after it was found in a reference here, so
-	// that we can detect cycles between components.
+	// By calling `checkValid` on ourself here, we will cause a cycle error to be exposed if we ended
+	// up within this function while executing c.checkValid initially. This just makes sure that there
+	// are no cycles between components.
 	c.checkValid(ctx, phase)
 	return cty.DynamicVal
 }

--- a/internal/stacks/stackruntime/internal/stackeval/main.go
+++ b/internal/stacks/stackruntime/internal/stackeval/main.go
@@ -216,6 +216,17 @@ func (m *Main) Inspecting() bool {
 	return m.inspecting != nil
 }
 
+// ValidatingOpts returns the validation options to use during the validate phase,
+// or panics if this [Main] was not instantiated for validation.
+//
+// Do not modify anything reachable through the returned pointer.
+func (m *Main) ValidatingOpts() *ValidateOpts {
+	if !m.Validating() {
+		panic("stacks language runtime is not instantiated for validating")
+	}
+	return &m.validating.opts
+}
+
 // PlanningOpts returns the planning options to use during the planning phase,
 // or panics if this [Main] was not instantiated for planning.
 //
@@ -678,7 +689,7 @@ func (m *Main) PlanTimestamp() time.Time {
 func (m *Main) DependencyLocks(phase EvalPhase) *depsfile.Locks {
 	switch phase {
 	case ValidatePhase:
-		return &m.validating.opts.DependencyLocks
+		return &m.ValidatingOpts().DependencyLocks
 	case PlanPhase:
 		return &m.PlanningOpts().DependencyLocks
 	case ApplyPhase:

--- a/internal/stacks/stackruntime/testdata/mainbundle/test/validate-cyclic-dependency/validate-cyclic-dependency.tfstack.hcl
+++ b/internal/stacks/stackruntime/testdata/mainbundle/test/validate-cyclic-dependency/validate-cyclic-dependency.tfstack.hcl
@@ -1,0 +1,13 @@
+component "vault-config" {
+  source = "./"
+  inputs = {
+    ssh_key_private = component.boundary.ssh_key_private
+  }
+}
+
+component "boundary" {
+  source = "./"
+  inputs = {
+    boundary_vault_token = component.vault-config.boundary_vault_token
+  }
+}

--- a/internal/stacks/stackruntime/testdata/mainbundle/test/validate-cyclic-dependency/validate-cyclic-dependency.tfstack.hcl
+++ b/internal/stacks/stackruntime/testdata/mainbundle/test/validate-cyclic-dependency/validate-cyclic-dependency.tfstack.hcl
@@ -1,7 +1,12 @@
+locals {
+  foo = "bar"
+}
+
 component "vault-config" {
   source = "./"
   inputs = {
     ssh_key_private = component.boundary.ssh_key_private
+    bar = local.foo
   }
 }
 

--- a/internal/stacks/stackruntime/validate_test.go
+++ b/internal/stacks/stackruntime/validate_test.go
@@ -452,6 +452,20 @@ Terraform uses references to decide a suitable order for performing operations, 
 				))
 			}),
 		},
+		"cyclic-component-dependency": {
+			path: "validate-cyclic-dependency",
+			wantDiags: initDiags(func(diags tfdiags.Diagnostics) tfdiags.Diagnostics {
+				return diags.Append(tfdiags.Sourceless(
+					tfdiags.Error,
+					"Self-dependent items in configuration",
+					`The following items in your configuration form a circular dependency chain through their references:
+  - component.boundary
+  - component.vault-config
+
+Terraform uses references to decide a suitable order for performing operations, so configuration items may not refer to their own results either directly or indirectly.`,
+				))
+			}),
+		},
 		"missing-provider-from-lockfile": {
 			path: filepath.Join("with-single-input", "input-from-component"),
 			providers: map[addrs.Provider]providers.Factory{


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Before this PR, circular references between components were never caught during validation, but during plan/apply. In plan/apply, the promises resolving some of those tasks are un-named, thus resulting in a lot of generic reference error messages in the diagnostics. e.g  `The following items in your configuration form a circular dependency chain through their references: │ - (...) │ - (...) │ - (...)`.

This PR detects the cycles when validating the component configuration itself, allowing us to display better error messages, and also not proceed to planning of invalid configuration

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.12.x

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [ ] This change is not user-facing.
