### PR TITLE
fix element function documentation

### DIFF
--- a/website/docs/language/functions/element.mdx
+++ b/website/docs/language/functions/element.mdx
@@ -12,7 +12,7 @@ element(list, index)
 ```
 
 The index is zero-based. This function produces an error if used with an
-empty list. The index must be a non-negative integer.
+empty list. The index can be a negative integer.
 
 Use the built-in index syntax `list[index]` in most cases. Use this function
 only for the special additional "wrap-around" behavior described below.
@@ -21,7 +21,7 @@ only for the special additional "wrap-around" behavior described below.
 
 ```
 > element(["a", "b", "c"], 1)
-b
+"b"
 ```
 
 If the given index is greater than the length of the list then the index is
@@ -29,16 +29,14 @@ If the given index is greater than the length of the list then the index is
 
 ```
 > element(["a", "b", "c"], 3)
-a
+"a"
 ```
 
-To get the last element from the list use [`length`](/terraform/language/functions/length) to find
-the size of the list (minus 1 as the list is zero-based) and then pick the
-last element:
+To get the last element from the list use the index `-1`:
 
 ```
-> element(["a", "b", "c"], length(["a", "b", "c"])-1)
-c
+> element(["a", "b", "c"], -1)
+"c"
 ```
 
 ## Related Functions


### PR DESCRIPTION
element function support negative index starting in version 1.10.0, but documentation still says that it doesn't support it.

## Target Release

1.12.x

## CHANGELOG entry

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
