### PR TITLE
Move logic about managing state in local filesystem into new local-state directory/`local_state` package

### DIFF
--- a/internal/backend/backendrun/cli.go
+++ b/internal/backend/backendrun/cli.go
@@ -61,14 +61,15 @@ type CLIOpts struct {
 	Streams *terminal.Streams
 
 	// StatePath is the local path where state is read from.
-	//
+	// Derived from -state CLI opt
+	StatePath string
 	// StateOutPath is the local path where the state will be written.
 	// If this is empty, it will default to StatePath.
-	//
+	// Derived from -state-out CLI opt
+	StateOutPath string
 	// StateBackupPath is the local path where a backup file will be written.
 	// If this is empty, no backup will be taken.
-	StatePath       string
-	StateOutPath    string
+	// Derived from -backup CLI opt
 	StateBackupPath string
 
 	// ContextOpts are the base context options to set when initializing a

--- a/internal/backend/local-state/backend.go
+++ b/internal/backend/local-state/backend.go
@@ -1,0 +1,267 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package local_state
+
+import (
+	"errors"
+	"io/ioutil"
+	"log"
+	"os"
+	"path/filepath"
+	"sort"
+
+	"github.com/hashicorp/terraform/internal/backend"
+	"github.com/hashicorp/terraform/internal/configs/configschema"
+	"github.com/hashicorp/terraform/internal/states/statemgr"
+	"github.com/hashicorp/terraform/internal/tfdiags"
+	"github.com/zclconf/go-cty/cty"
+)
+
+const (
+	DefaultWorkspaceDir    = "terraform.tfstate.d"
+	DefaultWorkspaceFile   = "environment"
+	DefaultStateFilename   = "terraform.tfstate"
+	DefaultBackupExtension = ".backup"
+)
+
+type Local struct {
+	// The State* paths are set from the backend config, and may be left blank
+	// to use the defaults. If the actual paths for the local backend state are
+	// needed, use the StatePaths method.
+	//
+	// StatePath is the local path where state is read from.
+	//
+	// StateOutPath is the local path where the state will be written.
+	// If this is empty, it will default to StatePath.
+	//
+	// StateBackupPath is the local path where a backup file will be written.
+	// Set this to "-" to disable state backup.
+	//
+	// StateWorkspaceDir is the path to the folder containing data for
+	// non-default workspaces. This defaults to DefaultWorkspaceDir if not set.
+	StatePath         string
+	StateOutPath      string
+	StateBackupPath   string
+	StateWorkspaceDir string
+
+	// The OverrideState* paths are set based on per-operation CLI arguments
+	// and will override what'd be built from the State* fields if non-empty.
+	// While the interpretation of the State* fields depends on the active
+	// workspace, the OverrideState* fields are always used literally.
+	OverrideStatePath       string
+	OverrideStateOutPath    string
+	OverrideStateBackupPath string
+
+	// We only want to create a single instance of a local state, so store them
+	// here as they're loaded.
+	states map[string]statemgr.Full
+}
+
+var _ backend.Backend = (*Local)(nil)
+
+func New() *Local {
+	return &Local{}
+}
+
+func (b *Local) ConfigSchema() *configschema.Block {
+	return &configschema.Block{
+		Attributes: map[string]*configschema.Attribute{
+			"path": {
+				Type:     cty.String,
+				Optional: true,
+			},
+			"workspace_dir": {
+				Type:     cty.String,
+				Optional: true,
+			},
+		},
+	}
+}
+
+func (b *Local) PrepareConfig(obj cty.Value) (cty.Value, tfdiags.Diagnostics) {
+	var diags tfdiags.Diagnostics
+
+	if val := obj.GetAttr("path"); !val.IsNull() {
+		p := val.AsString()
+		if p == "" {
+			diags = diags.Append(tfdiags.AttributeValue(
+				tfdiags.Error,
+				"Invalid local state file path",
+				`The "path" attribute value must not be empty.`,
+				cty.Path{cty.GetAttrStep{Name: "path"}},
+			))
+		}
+	}
+
+	if val := obj.GetAttr("workspace_dir"); !val.IsNull() {
+		p := val.AsString()
+		if p == "" {
+			diags = diags.Append(tfdiags.AttributeValue(
+				tfdiags.Error,
+				"Invalid local workspace directory path",
+				`The "workspace_dir" attribute value must not be empty.`,
+				cty.Path{cty.GetAttrStep{Name: "workspace_dir"}},
+			))
+		}
+	}
+
+	return obj, diags
+}
+
+func (b *Local) Configure(obj cty.Value) tfdiags.Diagnostics {
+	var diags tfdiags.Diagnostics
+
+	if val := obj.GetAttr("path"); !val.IsNull() {
+		p := val.AsString()
+		b.StatePath = p
+		b.StateOutPath = p
+	} else {
+		b.StatePath = DefaultStateFilename
+		b.StateOutPath = DefaultStateFilename
+	}
+
+	if val := obj.GetAttr("workspace_dir"); !val.IsNull() {
+		p := val.AsString()
+		b.StateWorkspaceDir = p
+	} else {
+		b.StateWorkspaceDir = DefaultWorkspaceDir
+	}
+
+	return diags
+}
+
+func (b *Local) Workspaces() ([]string, error) {
+	// the listing always start with "default"
+	envs := []string{backend.DefaultStateName}
+
+	entries, err := ioutil.ReadDir(b.stateWorkspaceDir())
+	// no error if there's no envs configured
+	if os.IsNotExist(err) {
+		return envs, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	var listed []string
+	for _, entry := range entries {
+		if entry.IsDir() {
+			listed = append(listed, filepath.Base(entry.Name()))
+		}
+	}
+
+	sort.Strings(listed)
+	envs = append(envs, listed...)
+
+	return envs, nil
+}
+
+// DeleteWorkspace removes a workspace.
+//
+// The "default" workspace cannot be removed.
+func (b *Local) DeleteWorkspace(name string, force bool) error {
+	if name == "" {
+		return errors.New("empty state name")
+	}
+
+	if name == backend.DefaultStateName {
+		return errors.New("cannot delete default state")
+	}
+
+	delete(b.states, name)
+	return os.RemoveAll(filepath.Join(b.stateWorkspaceDir(), name))
+}
+
+func (b *Local) StateMgr(name string) (statemgr.Full, error) {
+	if s, ok := b.states[name]; ok {
+		return s, nil
+	}
+
+	if err := b.createState(name); err != nil {
+		return nil, err
+	}
+
+	statePath, stateOutPath, backupPath := b.StatePaths(name)
+	log.Printf("[TRACE] backend/local: state manager for workspace %q will:\n - read initial snapshot from %s\n - write new snapshots to %s\n - create any backup at %s", name, statePath, stateOutPath, backupPath)
+
+	s := statemgr.NewFilesystemBetweenPaths(statePath, stateOutPath)
+	if backupPath != "" {
+		s.SetBackupPath(backupPath)
+	}
+
+	if b.states == nil {
+		b.states = map[string]statemgr.Full{}
+	}
+	b.states[name] = s
+	return s, nil
+}
+
+// this only ensures that the named directory exists
+func (b *Local) createState(name string) error {
+	if name == backend.DefaultStateName {
+		return nil
+	}
+
+	stateDir := filepath.Join(b.stateWorkspaceDir(), name)
+	s, err := os.Stat(stateDir)
+	if err == nil && s.IsDir() {
+		// no need to check for os.IsNotExist, since that is covered by os.MkdirAll
+		// which will catch the other possible errors as well.
+		return nil
+	}
+
+	err = os.MkdirAll(stateDir, 0755)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// stateWorkspaceDir returns the directory where state environments are stored.
+func (b *Local) stateWorkspaceDir() string {
+	if b.StateWorkspaceDir != "" {
+		return b.StateWorkspaceDir
+	}
+
+	return DefaultWorkspaceDir
+}
+
+// StatePaths returns the StatePath, StateOutPath, and StateBackupPath as
+// configured from the CLI.
+func (b *Local) StatePaths(name string) (stateIn, stateOut, backupOut string) {
+	statePath := b.OverrideStatePath
+	stateOutPath := b.OverrideStateOutPath
+	backupPath := b.OverrideStateBackupPath
+
+	isDefault := name == backend.DefaultStateName || name == ""
+
+	baseDir := ""
+	if !isDefault {
+		baseDir = filepath.Join(b.stateWorkspaceDir(), name)
+	}
+
+	if statePath == "" {
+		if isDefault {
+			statePath = b.StatePath // s.StatePath applies only to the default workspace, since StateWorkspaceDir is used otherwise
+		}
+		if statePath == "" {
+			statePath = filepath.Join(baseDir, DefaultStateFilename)
+		}
+	}
+	if stateOutPath == "" {
+		stateOutPath = statePath
+	}
+	if backupPath == "" {
+		backupPath = b.StateBackupPath
+	}
+	switch backupPath {
+	case "-":
+		backupPath = ""
+	case "":
+		backupPath = stateOutPath + DefaultBackupExtension
+	}
+
+	return statePath, stateOutPath, backupPath
+}

--- a/internal/backend/local-state/backend.go
+++ b/internal/backend/local-state/backend.go
@@ -265,3 +265,39 @@ func (b *Local) StatePaths(name string) (stateIn, stateOut, backupOut string) {
 
 	return statePath, stateOutPath, backupPath
 }
+
+// PathsConflictWith returns true if any state path used by a workspace in
+// the receiver is the same as any state path used by the other given
+// local backend instance.
+//
+// This should be used when "migrating" from one local backend configuration to
+// another in order to avoid deleting the "old" state snapshots if they are
+// in the same files as the "new" state snapshots.
+func (b *Local) PathsConflictWith(other *Local) bool {
+	otherPaths := map[string]struct{}{}
+	otherWorkspaces, err := other.Workspaces()
+	if err != nil {
+		// If we can't enumerate the workspaces then we'll conservatively
+		// assume that paths _do_ overlap, since we can't be certain.
+		return true
+	}
+	for _, name := range otherWorkspaces {
+		p, _, _ := other.StatePaths(name)
+		otherPaths[p] = struct{}{}
+	}
+
+	ourWorkspaces, err := other.Workspaces()
+	if err != nil {
+		// If we can't enumerate the workspaces then we'll conservatively
+		// assume that paths _do_ overlap, since we can't be certain.
+		return true
+	}
+
+	for _, name := range ourWorkspaces {
+		p, _, _ := b.StatePaths(name)
+		if _, exists := otherPaths[p]; exists {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/backend/local-state/backend_test.go
+++ b/internal/backend/local-state/backend_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
 package local_state
 
 import (

--- a/internal/backend/local-state/backend_test.go
+++ b/internal/backend/local-state/backend_test.go
@@ -1,21 +1,303 @@
 package local_state
 
 import (
+	"fmt"
+	"os"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform/internal/backend"
+	"github.com/hashicorp/terraform/internal/states"
+	"github.com/zclconf/go-cty/cty"
 )
 
 func TestLocal_backend(t *testing.T) {
-	backend.TestTmpDir(t)
+	_ = testTmpDir(t)
 	b := New()
 	backend.TestBackendStates(t, b)
 	backend.TestBackendStateLocks(t, b, b)
 }
 
+func TestLocal_PrepareConfig(t *testing.T) {
+	// Setup
+	_ = testTmpDir(t)
+
+	b := New()
+
+	// PATH ATTR
+	// Empty string path attribute isn't valid
+	config := cty.ObjectVal(map[string]cty.Value{
+		"path":          cty.StringVal(""),
+		"workspace_dir": cty.NullVal(cty.String),
+	})
+	_, diags := b.PrepareConfig(config)
+	if !diags.HasErrors() {
+		t.Fatalf("expected an error from PrepareConfig but got none")
+	}
+	expectedErr := `The "path" attribute value must not be empty`
+	if !strings.Contains(diags.Err().Error(), expectedErr) {
+		t.Fatalf("expected an error containing %q, got: %q", expectedErr, diags.Err())
+	}
+
+	// PrepareConfig doesn't enforce the path value has .tfstate extension
+	config = cty.ObjectVal(map[string]cty.Value{
+		"path":          cty.StringVal("path/to/state/my-state.docx"),
+		"workspace_dir": cty.NullVal(cty.String),
+	})
+	_, diags = b.PrepareConfig(config)
+	if diags.HasErrors() {
+		t.Fatalf("unexpected error returned from PrepareConfig")
+	}
+
+	// WORKSPACE_DIR ATTR
+	// Empty string workspace_dir attribute isn't valid
+	config = cty.ObjectVal(map[string]cty.Value{
+		"path":          cty.NullVal(cty.String),
+		"workspace_dir": cty.StringVal(""),
+	})
+	_, diags = b.PrepareConfig(config)
+	if !diags.HasErrors() {
+		t.Fatalf("expected an error from PrepareConfig but got none")
+	}
+	expectedErr = `The "workspace_dir" attribute value must not be empty`
+	if !strings.Contains(diags.Err().Error(), expectedErr) {
+		t.Fatalf("expected an error containing %q, got: %q", expectedErr, diags.Err())
+	}
+
+	// Existence of directory isn't checked during PrepareConfig
+	// (Non-existent directories are created as a side-effect of WriteState)
+	config = cty.ObjectVal(map[string]cty.Value{
+		"path":          cty.NullVal(cty.String),
+		"workspace_dir": cty.StringVal("this/does/not/exist"),
+	})
+	_, diags = b.PrepareConfig(config)
+	if diags.HasErrors() {
+		t.Fatalf("unexpected error returned from PrepareConfig")
+	}
+}
+
+// The `path` attribute should only affect the default workspace's state
+// file location and name.
+//
+// Non-default workspaces' states names and locations are unaffected.
+func TestLocal_useOfPathAttribute(t *testing.T) {
+	// Setup
+	td := testTmpDir(t)
+
+	b := New()
+
+	// Configure local state-storage backend (skip call to PrepareConfig)
+	path := "path/to/foobar.tfstate"
+	config := cty.ObjectVal(map[string]cty.Value{
+		"path":          cty.StringVal(path), // Set
+		"workspace_dir": cty.NullVal(cty.String),
+	})
+	diags := b.Configure(config)
+	if diags.HasErrors() {
+		t.Fatalf("unexpected error returned from Configure")
+	}
+
+	// State file at the `path` location doesn't exist yet
+	workspace := backend.DefaultStateName
+	stmgr, err := b.StateMgr(workspace)
+	if err != nil {
+		t.Fatalf("unexpected error returned from StateMgr")
+	}
+	defaultStatePath := fmt.Sprintf("%s/%s", td, path)
+	if _, err := os.Stat(defaultStatePath); !strings.Contains(err.Error(), "no such file or directory") {
+		if err != nil {
+			t.Fatalf("expected \"no such file or directory\" error when accessing file %q, got: %s", path, err)
+		}
+		t.Fatalf("expected the state file %q to not exist, but it did", path)
+	}
+
+	// Writing to the default workspace's state creates a file
+	// at the `path` location.
+	// Directories are created to enable the path.
+	s := states.NewState()
+	s.RootOutputValues = map[string]*states.OutputValue{
+		"foobar": {
+			Value: cty.StringVal("foobar"),
+		},
+	}
+	err = stmgr.WriteState(s)
+	if err != nil {
+		t.Fatalf("unexpected error returned from WriteState")
+	}
+	_, err = os.Stat(defaultStatePath)
+	if err != nil {
+		// The file should exist post-WriteState
+		t.Fatalf("unexpected error when getting stats on the state file %q", path)
+	}
+
+	// Writing to a non-default workspace's state creates a file
+	// that's unaffected by the `path` location
+	workspace = "fizzbuzz"
+	stmgr, err = b.StateMgr(workspace)
+	if err != nil {
+		t.Fatalf("unexpected error returned from StateMgr")
+	}
+	fizzbuzzStatePath := fmt.Sprintf("%s/terraform.tfstate.d/%s/terraform.tfstate", td, workspace)
+	err = stmgr.WriteState(s)
+	if err != nil {
+		t.Fatalf("unexpected error returned from WriteState")
+	}
+	_, err = os.Stat(fizzbuzzStatePath)
+	if err != nil {
+		t.Fatalf("unexpected error when getting stats on the state file \"terraform.tfstate.d/%s/terraform.tfstate\"", workspace)
+	}
+}
+
+// Using non-tfstate file extensions in the value of the `path` attribute
+// doesn't affect writing to state
+func TestLocal_pathAttributeWrongExtension(t *testing.T) {
+	// Setup
+	td := testTmpDir(t)
+
+	b := New()
+
+	// The path value doesn't have the expected .tfstate file extension
+	path := "foobar.docx"
+	fullPath := fmt.Sprintf("%s/%s", td, path)
+	config := cty.ObjectVal(map[string]cty.Value{
+		"path":          cty.StringVal(path), // Set
+		"workspace_dir": cty.NullVal(cty.String),
+	})
+	diags := b.Configure(config)
+	if diags.HasErrors() {
+		t.Fatalf("unexpected error returned from Configure")
+	}
+
+	// Writing to the default workspace's state creates a file
+	workspace := backend.DefaultStateName
+	stmgr, err := b.StateMgr(workspace)
+	if err != nil {
+		t.Fatalf("unexpected error returned from StateMgr")
+	}
+	s := states.NewState()
+	s.RootOutputValues = map[string]*states.OutputValue{
+		"foobar": {
+			Value: cty.StringVal("foobar"),
+		},
+	}
+	err = stmgr.WriteState(s)
+	if err != nil {
+		t.Fatalf("unexpected error returned from WriteState")
+	}
+	_, err = os.Stat(fullPath)
+	if err != nil {
+		// The file should exist post-WriteState, despite the odd file extension
+		t.Fatalf("unexpected error when getting stats on the state file %q", path)
+	}
+}
+
+// The `workspace_dir` attribute should only affect where non-default workspaces'
+// state files are saved.
+//
+// The default workspace's name and location are unaffected by this attribute.
+func TestLocal_useOfWorkspaceDirAttribute(t *testing.T) {
+	// Setup
+	td := testTmpDir(t)
+
+	b := New()
+
+	// Configure local state-storage backend (skip call to PrepareConfig)
+	workspaceDir := "path/to/workspaces"
+	config := cty.ObjectVal(map[string]cty.Value{
+		"path":          cty.NullVal(cty.String),
+		"workspace_dir": cty.StringVal(workspaceDir), // set
+	})
+	diags := b.Configure(config)
+	if diags.HasErrors() {
+		t.Fatalf("unexpected error returned from Configure")
+	}
+
+	// Writing to the default workspace's state creates a file.
+	// As path attribute was left null, the default location
+	// ./terraform.tfstate is used.
+	// Unaffected by the `workspace_dir` location.
+	workspace := backend.DefaultStateName
+	defaultStatePath := fmt.Sprintf("%s/terraform.tfstate", td)
+	stmgr, err := b.StateMgr(workspace)
+	if err != nil {
+		t.Fatalf("unexpected error returned from StateMgr")
+	}
+	s := states.NewState()
+	s.RootOutputValues = map[string]*states.OutputValue{
+		"foobar": {
+			Value: cty.StringVal("foobar"),
+		},
+	}
+	err = stmgr.WriteState(s)
+	if err != nil {
+		t.Fatalf("unexpected error returned from WriteState")
+	}
+	_, err = os.Stat(defaultStatePath)
+	if err != nil {
+		// The file should exist post-WriteState
+		t.Fatal("unexpected error when getting stats on the state file for the default state")
+	}
+
+	// Writing to a non-default workspace's state creates a file
+	// that's affected by the `workspace_dir` location
+	workspace = "fizzbuzz"
+	fizzbuzzStatePath := fmt.Sprintf("%s/%s/%s/terraform.tfstate", td, workspaceDir, workspace)
+	stmgr, err = b.StateMgr(workspace)
+	if err != nil {
+		t.Fatalf("unexpected error returned from StateMgr")
+	}
+	err = stmgr.WriteState(s)
+	if err != nil {
+		t.Fatalf("unexpected error returned from WriteState")
+	}
+	_, err = os.Stat(fizzbuzzStatePath)
+	if err != nil {
+		// The file should exist post-WriteState
+		t.Fatalf("unexpected error when getting stats on the state file \"%s/%s/terraform.tfstate\"", workspaceDir, workspace)
+	}
+}
+
+func TestLocal_cannotDeleteDefaultState(t *testing.T) {
+	// Setup
+	_ = testTmpDir(t)
+	dflt := backend.DefaultStateName
+	expectedStates := []string{dflt}
+
+	b := New()
+
+	// Only default workspace exists initially.
+	states, err := b.Workspaces()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(states, expectedStates) {
+		t.Fatalf("expected []string{%q}, got %q", dflt, states)
+	}
+
+	// Attempt to delete default state - force=false
+	err = b.DeleteWorkspace(dflt, false)
+	if err == nil {
+		t.Fatal("expected error but there was none")
+	}
+	expectedErr := "cannot delete default state"
+	if err.Error() != expectedErr {
+		t.Fatalf("expected error %q, got: %q", expectedErr, err)
+	}
+
+	// Setting force=true doesn't change outcome
+	err = b.DeleteWorkspace(dflt, true)
+	if err == nil {
+		t.Fatal("expected error but there was none")
+	}
+	if err.Error() != expectedErr {
+		t.Fatalf("expected error %q, got: %q", expectedErr, err)
+	}
+}
+
 func TestLocal_addAndRemoveStates(t *testing.T) {
 	// Setup
+	_ = testTmpDir(t)
 	dflt := backend.DefaultStateName
 	expectedStates := []string{dflt}
 
@@ -95,4 +377,26 @@ func TestLocal_addAndRemoveStates(t *testing.T) {
 	if err := b.DeleteWorkspace(dflt, true); err == nil {
 		t.Fatal("expected error deleting default state")
 	}
+}
+
+// testTmpDir changes into a tmp dir and change back automatically when the test
+// and all its subtests complete.
+func testTmpDir(t *testing.T) string {
+	tmp := t.TempDir()
+
+	old, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.Chdir(tmp); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Cleanup(func() {
+		// ignore errors and try to clean up
+		os.Chdir(old)
+	})
+
+	return tmp
 }

--- a/internal/backend/local-state/backend_test.go
+++ b/internal/backend/local-state/backend_test.go
@@ -15,20 +15,22 @@ func TestLocal_backend(t *testing.T) {
 }
 
 func TestLocal_addAndRemoveStates(t *testing.T) {
-	backend.TestTmpDir(t)
+	// Setup
 	dflt := backend.DefaultStateName
 	expectedStates := []string{dflt}
 
 	b := New()
+
+	// Only default workspace exists initially.
 	states, err := b.Workspaces()
 	if err != nil {
 		t.Fatal(err)
 	}
-
 	if !reflect.DeepEqual(states, expectedStates) {
 		t.Fatalf("expected []string{%q}, got %q", dflt, states)
 	}
 
+	// Calling StateMgr with a new workspace/state name creates it.
 	expectedA := "test_A"
 	if _, err := b.StateMgr(expectedA); err != nil {
 		t.Fatal(err)
@@ -44,6 +46,7 @@ func TestLocal_addAndRemoveStates(t *testing.T) {
 		t.Fatalf("expected %q, got %q", expectedStates, states)
 	}
 
+	// Test further by adding a third workspace/state.
 	expectedB := "test_B"
 	if _, err := b.StateMgr(expectedB); err != nil {
 		t.Fatal(err)
@@ -59,6 +62,7 @@ func TestLocal_addAndRemoveStates(t *testing.T) {
 		t.Fatalf("expected %q, got %q", expectedStates, states)
 	}
 
+	// Can delete a given workspace
 	if err := b.DeleteWorkspace(expectedA, true); err != nil {
 		t.Fatal(err)
 	}
@@ -73,6 +77,7 @@ func TestLocal_addAndRemoveStates(t *testing.T) {
 		t.Fatalf("expected %q, got %q", expectedStates, states)
 	}
 
+	// Can reduce workspaces down to only the default workspace
 	if err := b.DeleteWorkspace(expectedB, true); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/backend/local-state/backend_test.go
+++ b/internal/backend/local-state/backend_test.go
@@ -1,0 +1,93 @@
+package local_state
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/hashicorp/terraform/internal/backend"
+)
+
+func TestLocal_backend(t *testing.T) {
+	backend.TestTmpDir(t)
+	b := New()
+	backend.TestBackendStates(t, b)
+	backend.TestBackendStateLocks(t, b, b)
+}
+
+func TestLocal_addAndRemoveStates(t *testing.T) {
+	backend.TestTmpDir(t)
+	dflt := backend.DefaultStateName
+	expectedStates := []string{dflt}
+
+	b := New()
+	states, err := b.Workspaces()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !reflect.DeepEqual(states, expectedStates) {
+		t.Fatalf("expected []string{%q}, got %q", dflt, states)
+	}
+
+	expectedA := "test_A"
+	if _, err := b.StateMgr(expectedA); err != nil {
+		t.Fatal(err)
+	}
+
+	states, err = b.Workspaces()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expectedStates = append(expectedStates, expectedA)
+	if !reflect.DeepEqual(states, expectedStates) {
+		t.Fatalf("expected %q, got %q", expectedStates, states)
+	}
+
+	expectedB := "test_B"
+	if _, err := b.StateMgr(expectedB); err != nil {
+		t.Fatal(err)
+	}
+
+	states, err = b.Workspaces()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expectedStates = append(expectedStates, expectedB)
+	if !reflect.DeepEqual(states, expectedStates) {
+		t.Fatalf("expected %q, got %q", expectedStates, states)
+	}
+
+	if err := b.DeleteWorkspace(expectedA, true); err != nil {
+		t.Fatal(err)
+	}
+
+	states, err = b.Workspaces()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expectedStates = []string{dflt, expectedB}
+	if !reflect.DeepEqual(states, expectedStates) {
+		t.Fatalf("expected %q, got %q", expectedStates, states)
+	}
+
+	if err := b.DeleteWorkspace(expectedB, true); err != nil {
+		t.Fatal(err)
+	}
+
+	states, err = b.Workspaces()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expectedStates = []string{dflt}
+	if !reflect.DeepEqual(states, expectedStates) {
+		t.Fatalf("expected %q, got %q", expectedStates, states)
+	}
+
+	if err := b.DeleteWorkspace(dflt, true); err == nil {
+		t.Fatal("expected error deleting default state")
+	}
+}

--- a/internal/backend/local/backend.go
+++ b/internal/backend/local/backend.go
@@ -41,33 +41,6 @@ var (
 // locally. This is the "default" backend and implements normal Terraform
 // behavior as it is well known.
 type Local struct {
-	// The State* paths are set from the backend config, and may be left blank
-	// to use the defaults. If the actual paths for the local backend state are
-	// needed, use the StatePaths method.
-	//
-	// StatePath is the local path where state is read from.
-	//
-	// StateOutPath is the local path where the state will be written.
-	// If this is empty, it will default to StatePath.
-	//
-	// StateBackupPath is the local path where a backup file will be written.
-	// Set this to "-" to disable state backup.
-	//
-	// StateWorkspaceDir is the path to the folder containing data for
-	// non-default workspaces. This defaults to DefaultWorkspaceDir if not set.
-	StatePath         string
-	StateOutPath      string
-	StateBackupPath   string
-	StateWorkspaceDir string
-
-	// The OverrideState* paths are set based on per-operation CLI arguments
-	// and will override what'd be built from the State* fields if non-empty.
-	// While the interpretation of the State* fields depends on the active
-	// workspace, the OverrideState* fields are always used literally.
-	OverrideStatePath       string
-	OverrideStateOutPath    string
-	OverrideStateBackupPath string
-
 	// We only want to create a single instance of a local state, so store them
 	// here as they're loaded.
 	states map[string]statemgr.Full

--- a/internal/backend/local/backend.go
+++ b/internal/backend/local/backend.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"os"
 	"path/filepath"
 	"sync"
 
@@ -379,28 +378,6 @@ func (b *Local) PathsConflictWith(other *Local) bool {
 		}
 	}
 	return false
-}
-
-// this only ensures that the named directory exists
-func (b *Local) createState(name string) error {
-	if name == backend.DefaultStateName {
-		return nil
-	}
-
-	stateDir := filepath.Join(b.stateWorkspaceDir(), name)
-	s, err := os.Stat(stateDir)
-	if err == nil && s.IsDir() {
-		// no need to check for os.IsNotExist, since that is covered by os.MkdirAll
-		// which will catch the other possible errors as well.
-		return nil
-	}
-
-	err = os.MkdirAll(stateDir, 0755)
-	if err != nil {
-		return err
-	}
-
-	return nil
 }
 
 // stateWorkspaceDir returns the directory where state environments are stored.

--- a/internal/backend/local/backend.go
+++ b/internal/backend/local/backend.go
@@ -106,15 +106,23 @@ var _ backendrun.OperationsBackend = (*Local)(nil)
 // an instance of the local state backend is provided as default.
 func New() *Local {
 	backend := localState.New()
-	return NewWithBackend(backend)
+	b, err := NewWithBackend(backend)
+	if err != nil {
+		// We cannot return an error here
+		panic(fmt.Sprintf("error encountered in backendLocal.New. This is a bug in Terraform and should be reported. Error: %s", err))
+	}
+	return b
 }
 
 // NewWithBackend returns a new local backend initialized with a
 // dedicated backend for non-enhanced behavior.
-func NewWithBackend(backend backend.Backend) *Local {
+func NewWithBackend(backend backend.Backend) (*Local, error) {
+	if backend == nil {
+		return nil, fmt.Errorf("nil backend.Backend pointer received when creating a local backend. This is an error in Terraform and should be reported.")
+	}
 	return &Local{
 		Backend: backend,
-	}
+	}, nil
 }
 
 func (b *Local) ConfigSchema() *configschema.Block {

--- a/internal/backend/local/backend_apply_test.go
+++ b/internal/backend/local/backend_apply_test.go
@@ -31,7 +31,7 @@ import (
 )
 
 func TestLocal_applyBasic(t *testing.T) {
-	b := TestLocal(t)
+	b, stateBackend := TestLocal(t)
 
 	p := TestLocalProvider(t, b, "test", applyFixtureSchema())
 	p.ApplyResourceChangeResponse = &providers.ApplyResourceChangeResponse{NewState: cty.ObjectVal(map[string]cty.Value{
@@ -63,7 +63,7 @@ func TestLocal_applyBasic(t *testing.T) {
 		t.Fatal("apply should be called")
 	}
 
-	checkState(t, b.StateOutPath, `
+	checkState(t, stateBackend.StateOutPath, `
 test_instance.foo:
   ID = yes
   provider = provider["registry.terraform.io/hashicorp/test"]
@@ -75,7 +75,7 @@ test_instance.foo:
 	}
 }
 func TestLocal_applyCheck(t *testing.T) {
-	b := TestLocal(t)
+	b, _ := TestLocal(t)
 
 	p := TestLocalProvider(t, b, "test", applyFixtureSchema())
 	p.ApplyResourceChangeResponse = &providers.ApplyResourceChangeResponse{NewState: cty.ObjectVal(map[string]cty.Value{
@@ -120,7 +120,7 @@ func TestLocal_applyCheck(t *testing.T) {
 }
 
 func TestLocal_applyEmptyDir(t *testing.T) {
-	b := TestLocal(t)
+	b, stateBackend := TestLocal(t)
 
 	p := TestLocalProvider(t, b, "test", providers.ProviderSchema{})
 	p.ApplyResourceChangeResponse = &providers.ApplyResourceChangeResponse{NewState: cty.ObjectVal(map[string]cty.Value{"id": cty.StringVal("yes")})}
@@ -141,7 +141,7 @@ func TestLocal_applyEmptyDir(t *testing.T) {
 		t.Fatal("apply should not be called")
 	}
 
-	if _, err := os.Stat(b.StateOutPath); err == nil {
+	if _, err := os.Stat(stateBackend.StateOutPath); err == nil {
 		t.Fatal("should not exist")
 	}
 
@@ -154,7 +154,7 @@ func TestLocal_applyEmptyDir(t *testing.T) {
 }
 
 func TestLocal_applyEmptyDirDestroy(t *testing.T) {
-	b := TestLocal(t)
+	b, stateBackend := TestLocal(t)
 
 	p := TestLocalProvider(t, b, "test", providers.ProviderSchema{})
 	p.ApplyResourceChangeResponse = &providers.ApplyResourceChangeResponse{}
@@ -176,7 +176,7 @@ func TestLocal_applyEmptyDirDestroy(t *testing.T) {
 		t.Fatal("apply should not be called")
 	}
 
-	checkState(t, b.StateOutPath, `<no state>`)
+	checkState(t, stateBackend.StateOutPath, `<no state>`)
 
 	if errOutput := done(t).Stderr(); errOutput != "" {
 		t.Fatalf("unexpected error output:\n%s", errOutput)
@@ -184,7 +184,7 @@ func TestLocal_applyEmptyDirDestroy(t *testing.T) {
 }
 
 func TestLocal_applyError(t *testing.T) {
-	b := TestLocal(t)
+	b, stateBackend := TestLocal(t)
 
 	schema := providers.ProviderSchema{
 		ResourceTypes: map[string]providers.Schema{
@@ -238,7 +238,7 @@ func TestLocal_applyError(t *testing.T) {
 		t.Fatal("operation succeeded; want failure")
 	}
 
-	checkState(t, b.StateOutPath, `
+	checkState(t, stateBackend.StateOutPath, `
 test_instance.foo:
   ID = foo
   provider = provider["registry.terraform.io/hashicorp/test"]
@@ -254,7 +254,7 @@ test_instance.foo:
 }
 
 func TestLocal_applyBackendFail(t *testing.T) {
-	b := TestLocal(t)
+	b, _ := TestLocal(t)
 
 	p := TestLocalProvider(t, b, "test", applyFixtureSchema())
 
@@ -317,7 +317,7 @@ test_instance.foo: (tainted)
 }
 
 func TestLocal_applyRefreshFalse(t *testing.T) {
-	b := TestLocal(t)
+	b, _ := TestLocal(t)
 
 	p := TestLocalProvider(t, b, "test", planFixtureSchema())
 	testStateFile(t, b.StatePath, testPlanState())
@@ -403,7 +403,7 @@ func applyFixtureSchema() providers.ProviderSchema {
 }
 
 func TestApply_applyCanceledAutoApprove(t *testing.T) {
-	b := TestLocal(t)
+	b, _ := TestLocal(t)
 
 	TestLocalProvider(t, b, "test", applyFixtureSchema())
 

--- a/internal/backend/local/backend_local_test.go
+++ b/internal/backend/local/backend_local_test.go
@@ -32,7 +32,7 @@ import (
 
 func TestLocalRun(t *testing.T) {
 	configDir := "./testdata/empty"
-	b := TestLocal(t)
+	b, _ := TestLocal(t)
 
 	_, configLoader, configCleanup := initwd.MustLoadConfigForTests(t, configDir, "tests")
 	defer configCleanup()
@@ -59,7 +59,7 @@ func TestLocalRun(t *testing.T) {
 
 func TestLocalRun_error(t *testing.T) {
 	configDir := "./testdata/invalid"
-	b := TestLocal(t)
+	b, _ := TestLocal(t)
 
 	// This backend will return an error when asked to RefreshState, which
 	// should then cause LocalRun to return with the state unlocked.
@@ -90,7 +90,7 @@ func TestLocalRun_error(t *testing.T) {
 
 func TestLocalRun_cloudPlan(t *testing.T) {
 	configDir := "./testdata/apply"
-	b := TestLocal(t)
+	b, _ := TestLocal(t)
 
 	_, configLoader, configCleanup := initwd.MustLoadConfigForTests(t, configDir, "tests")
 	defer configCleanup()
@@ -125,22 +125,22 @@ func TestLocalRun_cloudPlan(t *testing.T) {
 
 func TestLocalRun_stalePlan(t *testing.T) {
 	configDir := "./testdata/apply"
-	b := TestLocal(t)
+	b, localState := TestLocal(t)
 
 	_, configLoader, configCleanup := initwd.MustLoadConfigForTests(t, configDir, "tests")
 	defer configCleanup()
 
 	// Write an empty state file with serial 3
-	sf, err := os.Create(b.StatePath)
+	sf, err := os.Create(localState.StatePath)
 	if err != nil {
-		t.Fatalf("unexpected error creating state file %s: %s", b.StatePath, err)
+		t.Fatalf("unexpected error creating state file %s: %s", localState.StatePath, err)
 	}
 	if err := statefile.Write(statefile.New(states.NewState(), "boop", 3), sf); err != nil {
 		t.Fatalf("unexpected error writing state file: %s", err)
 	}
 
 	// Refresh the state
-	sm, err := b.StateMgr("")
+	sm, err := localState.StateMgr("")
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}

--- a/internal/backend/local/backend_refresh_test.go
+++ b/internal/backend/local/backend_refresh_test.go
@@ -26,10 +26,10 @@ import (
 )
 
 func TestLocal_refresh(t *testing.T) {
-	b := TestLocal(t)
+	b, localState := TestLocal(t)
 
 	p := TestLocalProvider(t, b, "test", refreshFixtureSchema())
-	testStateFile(t, b.StatePath, testRefreshState())
+	testStateFile(t, localState.StatePath, testRefreshState())
 
 	p.ReadResourceFn = nil
 	p.ReadResourceResponse = &providers.ReadResourceResponse{NewState: cty.ObjectVal(map[string]cty.Value{
@@ -50,7 +50,7 @@ func TestLocal_refresh(t *testing.T) {
 		t.Fatal("ReadResource should be called")
 	}
 
-	checkState(t, b.StateOutPath, `
+	checkState(t, localState.StateOutPath, `
 test_instance.foo:
   ID = yes
   provider = provider["registry.terraform.io/hashicorp/test"]
@@ -61,7 +61,7 @@ test_instance.foo:
 }
 
 func TestLocal_refreshInput(t *testing.T) {
-	b := TestLocal(t)
+	b, localState := TestLocal(t)
 
 	schema := providers.ProviderSchema{
 		Provider: providers.Schema{
@@ -85,7 +85,7 @@ func TestLocal_refreshInput(t *testing.T) {
 	}
 
 	p := TestLocalProvider(t, b, "test", schema)
-	testStateFile(t, b.StatePath, testRefreshState())
+	testStateFile(t, localState.StatePath, testRefreshState())
 
 	p.ReadResourceFn = nil
 	p.ReadResourceResponse = &providers.ReadResourceResponse{NewState: cty.ObjectVal(map[string]cty.Value{
@@ -119,7 +119,7 @@ func TestLocal_refreshInput(t *testing.T) {
 		t.Fatal("ReadResource should be called")
 	}
 
-	checkState(t, b.StateOutPath, `
+	checkState(t, localState.StateOutPath, `
 test_instance.foo:
   ID = yes
   provider = provider["registry.terraform.io/hashicorp/test"]
@@ -127,9 +127,9 @@ test_instance.foo:
 }
 
 func TestLocal_refreshValidate(t *testing.T) {
-	b := TestLocal(t)
+	b, localState := TestLocal(t)
 	p := TestLocalProvider(t, b, "test", refreshFixtureSchema())
-	testStateFile(t, b.StatePath, testRefreshState())
+	testStateFile(t, localState.StatePath, testRefreshState())
 	p.ReadResourceFn = nil
 	p.ReadResourceResponse = &providers.ReadResourceResponse{NewState: cty.ObjectVal(map[string]cty.Value{
 		"id": cty.StringVal("yes"),
@@ -148,7 +148,7 @@ func TestLocal_refreshValidate(t *testing.T) {
 	}
 	<-run.Done()
 
-	checkState(t, b.StateOutPath, `
+	checkState(t, localState.StateOutPath, `
 test_instance.foo:
   ID = yes
   provider = provider["registry.terraform.io/hashicorp/test"]
@@ -156,7 +156,7 @@ test_instance.foo:
 }
 
 func TestLocal_refreshValidateProviderConfigured(t *testing.T) {
-	b := TestLocal(t)
+	b, localState := TestLocal(t)
 
 	schema := providers.ProviderSchema{
 		Provider: providers.Schema{
@@ -179,7 +179,7 @@ func TestLocal_refreshValidateProviderConfigured(t *testing.T) {
 	}
 
 	p := TestLocalProvider(t, b, "test", schema)
-	testStateFile(t, b.StatePath, testRefreshState())
+	testStateFile(t, localState.StatePath, testRefreshState())
 	p.ReadResourceFn = nil
 	p.ReadResourceResponse = &providers.ReadResourceResponse{NewState: cty.ObjectVal(map[string]cty.Value{
 		"id": cty.StringVal("yes"),
@@ -202,7 +202,7 @@ func TestLocal_refreshValidateProviderConfigured(t *testing.T) {
 		t.Fatal("Validate provider config should be called")
 	}
 
-	checkState(t, b.StateOutPath, `
+	checkState(t, localState.StateOutPath, `
 test_instance.foo:
   ID = yes
   provider = provider["registry.terraform.io/hashicorp/test"]
@@ -212,8 +212,8 @@ test_instance.foo:
 // This test validates the state lacking behavior when the inner call to
 // Context() fails
 func TestLocal_refresh_context_error(t *testing.T) {
-	b := TestLocal(t)
-	testStateFile(t, b.StatePath, testRefreshState())
+	b, localState := TestLocal(t)
+	testStateFile(t, localState.StatePath, testRefreshState())
 	op, configCleanup, done := testOperationRefresh(t, "./testdata/apply")
 	defer configCleanup()
 	defer done(t)
@@ -232,10 +232,10 @@ func TestLocal_refresh_context_error(t *testing.T) {
 }
 
 func TestLocal_refreshEmptyState(t *testing.T) {
-	b := TestLocal(t)
+	b, localState := TestLocal(t)
 
 	p := TestLocalProvider(t, b, "test", refreshFixtureSchema())
-	testStateFile(t, b.StatePath, states.NewState())
+	testStateFile(t, localState.StatePath, states.NewState())
 
 	p.ReadResourceFn = nil
 	p.ReadResourceResponse = &providers.ReadResourceResponse{NewState: cty.ObjectVal(map[string]cty.Value{

--- a/internal/backend/local/backend_test.go
+++ b/internal/backend/local/backend_test.go
@@ -7,11 +7,9 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
-	"reflect"
 	"strings"
 	"testing"
 
-	"github.com/hashicorp/terraform/internal/backend"
 	"github.com/hashicorp/terraform/internal/backend/backendrun"
 	"github.com/hashicorp/terraform/internal/states/statefile"
 	"github.com/hashicorp/terraform/internal/states/statemgr"
@@ -21,13 +19,6 @@ func TestLocal_impl(t *testing.T) {
 	var _ backendrun.OperationsBackend = New()
 	var _ backendrun.Local = New()
 	var _ backendrun.CLI = New()
-}
-
-func TestLocal_backend(t *testing.T) {
-	testTmpDir(t)
-	b := New()
-	backend.TestBackendStates(t, b)
-	backend.TestBackendStateLocks(t, b, b)
 }
 
 func checkState(t *testing.T, path, expected string) {
@@ -92,84 +83,6 @@ func TestLocal_StatePaths(t *testing.T) {
 
 }
 
-func TestLocal_addAndRemoveStates(t *testing.T) {
-	testTmpDir(t)
-	dflt := backend.DefaultStateName
-	expectedStates := []string{dflt}
-
-	b := New()
-	states, err := b.Workspaces()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if !reflect.DeepEqual(states, expectedStates) {
-		t.Fatalf("expected []string{%q}, got %q", dflt, states)
-	}
-
-	expectedA := "test_A"
-	if _, err := b.StateMgr(expectedA); err != nil {
-		t.Fatal(err)
-	}
-
-	states, err = b.Workspaces()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	expectedStates = append(expectedStates, expectedA)
-	if !reflect.DeepEqual(states, expectedStates) {
-		t.Fatalf("expected %q, got %q", expectedStates, states)
-	}
-
-	expectedB := "test_B"
-	if _, err := b.StateMgr(expectedB); err != nil {
-		t.Fatal(err)
-	}
-
-	states, err = b.Workspaces()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	expectedStates = append(expectedStates, expectedB)
-	if !reflect.DeepEqual(states, expectedStates) {
-		t.Fatalf("expected %q, got %q", expectedStates, states)
-	}
-
-	if err := b.DeleteWorkspace(expectedA, true); err != nil {
-		t.Fatal(err)
-	}
-
-	states, err = b.Workspaces()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	expectedStates = []string{dflt, expectedB}
-	if !reflect.DeepEqual(states, expectedStates) {
-		t.Fatalf("expected %q, got %q", expectedStates, states)
-	}
-
-	if err := b.DeleteWorkspace(expectedB, true); err != nil {
-		t.Fatal(err)
-	}
-
-	states, err = b.Workspaces()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	expectedStates = []string{dflt}
-	if !reflect.DeepEqual(states, expectedStates) {
-		t.Fatalf("expected %q, got %q", expectedStates, states)
-	}
-
-	if err := b.DeleteWorkspace(dflt, true); err == nil {
-		t.Fatal("expected error deleting default state")
-	}
-}
-
 // a local backend which returns sentinel errors for NamedState methods to
 // verify it's being called.
 type testDelegateBackend struct {
@@ -227,24 +140,4 @@ func TestLocal_multiStateBackend(t *testing.T) {
 	if err := b.DeleteWorkspace("test", true); err != errTestDelegateDeleteState {
 		t.Fatal("expected errTestDelegateDeleteState, got:", err)
 	}
-}
-
-// testTmpDir changes into a tmp dir and change back automatically when the test
-// and all its subtests complete.
-func testTmpDir(t *testing.T) {
-	tmp := t.TempDir()
-
-	old, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if err := os.Chdir(tmp); err != nil {
-		t.Fatal(err)
-	}
-
-	t.Cleanup(func() {
-		// ignore errors and try to clean up
-		os.Chdir(old)
-	})
 }

--- a/internal/backend/local/backend_test.go
+++ b/internal/backend/local/backend_test.go
@@ -6,7 +6,6 @@ package local
 import (
 	"errors"
 	"os"
-	"path/filepath"
 	"strings"
 	"testing"
 
@@ -40,47 +39,6 @@ func checkState(t *testing.T, path, expected string) {
 	if actual != expected {
 		t.Fatalf("state does not match! actual:\n%s\n\nexpected:\n%s", actual, expected)
 	}
-}
-
-func TestLocal_StatePaths(t *testing.T) {
-	b := New()
-
-	// Test the defaults
-	path, out, back := b.StatePaths("")
-
-	if path != DefaultStateFilename {
-		t.Fatalf("expected %q, got %q", DefaultStateFilename, path)
-	}
-
-	if out != DefaultStateFilename {
-		t.Fatalf("expected %q, got %q", DefaultStateFilename, out)
-	}
-
-	dfltBackup := DefaultStateFilename + DefaultBackupExtension
-	if back != dfltBackup {
-		t.Fatalf("expected %q, got %q", dfltBackup, back)
-	}
-
-	// check with env
-	testEnv := "test_env"
-	path, out, back = b.StatePaths(testEnv)
-
-	expectedPath := filepath.Join(DefaultWorkspaceDir, testEnv, DefaultStateFilename)
-	expectedOut := expectedPath
-	expectedBackup := expectedPath + DefaultBackupExtension
-
-	if path != expectedPath {
-		t.Fatalf("expected %q, got %q", expectedPath, path)
-	}
-
-	if out != expectedOut {
-		t.Fatalf("expected %q, got %q", expectedOut, out)
-	}
-
-	if back != expectedBackup {
-		t.Fatalf("expected %q, got %q", expectedBackup, back)
-	}
-
 }
 
 // a local backend which returns sentinel errors for NamedState methods to

--- a/internal/backend/local/backend_test.go
+++ b/internal/backend/local/backend_test.go
@@ -123,7 +123,7 @@ func (b *testDelegateBackend) DeleteWorkspace(name string, force bool) error {
 // verify that the MultiState methods are dispatched to the correct Backend.
 func TestLocal_multiStateBackend(t *testing.T) {
 	// assign a separate backend where we can read the state
-	b := NewWithBackend(&testDelegateBackend{
+	b, _ := NewWithBackend(&testDelegateBackend{
 		stateErr:  true,
 		statesErr: true,
 		deleteErr: true,

--- a/internal/backend/local/cli.go
+++ b/internal/backend/local/cli.go
@@ -7,6 +7,7 @@ import (
 	"log"
 
 	"github.com/hashicorp/terraform/internal/backend/backendrun"
+	localState "github.com/hashicorp/terraform/internal/backend/local-state"
 )
 
 // backendrun.CLI impl.
@@ -15,20 +16,23 @@ func (b *Local) CLIInit(opts *backendrun.CLIOpts) error {
 	b.OpInput = opts.Input
 	b.OpValidation = opts.Validation
 
-	// configure any new cli options
-	if opts.StatePath != "" {
-		log.Printf("[TRACE] backend/local: CLI option -state is overriding state path to %s", opts.StatePath)
-		b.OverrideStatePath = opts.StatePath
-	}
+	// If CLI options affect how local state is stored, set on
+	// the internal Backend
+	if be, ok := b.Backend.(*localState.Local); ok {
+		if opts.StatePath != "" {
+			log.Printf("[TRACE] backend/local: CLI option -state is overriding state path to %s", opts.StatePath)
+			be.OverrideStatePath = opts.StatePath
+		}
 
-	if opts.StateOutPath != "" {
-		log.Printf("[TRACE] backend/local: CLI option -state-out is overriding state output path to %s", opts.StateOutPath)
-		b.OverrideStateOutPath = opts.StateOutPath
-	}
+		if opts.StateOutPath != "" {
+			log.Printf("[TRACE] backend/local: CLI option -state-out is overriding state output path to %s", opts.StateOutPath)
+			be.OverrideStateOutPath = opts.StateOutPath
+		}
 
-	if opts.StateBackupPath != "" {
-		log.Printf("[TRACE] backend/local: CLI option -backup is overriding state backup path to %s", opts.StateBackupPath)
-		b.OverrideStateBackupPath = opts.StateBackupPath
+		if opts.StateBackupPath != "" {
+			log.Printf("[TRACE] backend/local: CLI option -backup is overriding state backup path to %s", opts.StateBackupPath)
+			be.OverrideStateBackupPath = opts.StateBackupPath
+		}
 	}
 
 	return nil

--- a/internal/backend/local/testing.go
+++ b/internal/backend/local/testing.go
@@ -41,7 +41,7 @@ func TestLocal(t *testing.T) (*Local, *localState.Local) {
 	be.StateWorkspaceDir = filepath.Join(tempDir, "state.tfstate.d")
 
 	// Create the Local enhanced backend, using the state backend
-	local := NewWithBackend(&be)
+	local, _ := NewWithBackend(&be)
 	local.StatePath = filepath.Join(tempDir, "state.tfstate")
 	local.StateOutPath = filepath.Join(tempDir, "state.tfstate")
 	local.StateBackupPath = filepath.Join(tempDir, "state.tfstate.bak")

--- a/internal/backend/remote/backend.go
+++ b/internal/backend/remote/backend.go
@@ -368,7 +368,11 @@ func (b *Remote) Configure(obj cty.Value) tfdiags.Diagnostics {
 	}
 
 	// Configure a local backend for when we need to run operations locally.
-	b.local = backendLocal.NewWithBackend(b)
+	b.local, err = backendLocal.NewWithBackend(b)
+	if err != nil {
+		diags = diags.Append(err)
+		return diags
+	}
 	b.forceLocal = b.forceLocal || !entitlements.Operations
 
 	// Enable retries for server errors as the backend is now fully configured.

--- a/internal/backend/remote/testing.go
+++ b/internal/backend/remote/testing.go
@@ -180,7 +180,10 @@ func testBackend(t *testing.T, obj cty.Value) (*Remote, func()) {
 }
 
 func testLocalBackend(t *testing.T, remote *Remote) backendrun.OperationsBackend {
-	b := backendLocal.NewWithBackend(remote)
+	if remote == nil {
+		t.Fatal("nil remote pointer")
+	}
+	b, _ := backendLocal.NewWithBackend(remote)
 
 	// Add a test provider to the local backend.
 	p := backendLocal.TestLocalProvider(t, b, "null", providers.ProviderSchema{

--- a/internal/backend/testing.go
+++ b/internal/backend/testing.go
@@ -4,7 +4,6 @@
 package backend
 
 import (
-	"os"
 	"reflect"
 	"sort"
 	"testing"
@@ -426,24 +425,4 @@ func testLocksInWorkspace(t *testing.T, b1, b2 Backend, testForceUnlock bool, wo
 		unlock()
 		t.Fatalf("could not unlock with the reported ID %q: %s", infoErr.Info.ID, err)
 	}
-}
-
-// testTmpDir changes into a tmp dir and change back automatically when the test
-// and all its subtests complete.
-func TestTmpDir(t *testing.T) {
-	tmp := t.TempDir()
-
-	old, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if err := os.Chdir(tmp); err != nil {
-		t.Fatal(err)
-	}
-
-	t.Cleanup(func() {
-		// ignore errors and try to clean up
-		os.Chdir(old)
-	})
 }

--- a/internal/backend/testing.go
+++ b/internal/backend/testing.go
@@ -4,6 +4,7 @@
 package backend
 
 import (
+	"os"
 	"reflect"
 	"sort"
 	"testing"
@@ -425,4 +426,24 @@ func testLocksInWorkspace(t *testing.T, b1, b2 Backend, testForceUnlock bool, wo
 		unlock()
 		t.Fatalf("could not unlock with the reported ID %q: %s", infoErr.Info.ID, err)
 	}
+}
+
+// testTmpDir changes into a tmp dir and change back automatically when the test
+// and all its subtests complete.
+func TestTmpDir(t *testing.T) {
+	tmp := t.TempDir()
+
+	old, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.Chdir(tmp); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Cleanup(func() {
+		// ignore errors and try to clean up
+		os.Chdir(old)
+	})
 }

--- a/internal/cloud/backend.go
+++ b/internal/cloud/backend.go
@@ -421,7 +421,11 @@ func (b *Cloud) Configure(obj cty.Value) tfdiags.Diagnostics {
 	}
 
 	// Configure a local backend for when we need to run operations locally.
-	b.local = backendLocal.NewWithBackend(b)
+	b.local, err = backendLocal.NewWithBackend(b)
+	if err != nil {
+		diags = diags.Append(err)
+		return diags
+	}
 
 	// Determine if we are forced to use the local backend.
 	b.forceLocal = os.Getenv("TF_FORCE_LOCAL_BACKEND") != "" || !entitlements.Operations

--- a/internal/cloud/testing.go
+++ b/internal/cloud/testing.go
@@ -372,7 +372,10 @@ func testUnconfiguredBackend(t *testing.T) (*Cloud, func()) {
 }
 
 func testLocalBackend(t *testing.T, cloud *Cloud) backendrun.OperationsBackend {
-	b := backendLocal.NewWithBackend(cloud)
+	if cloud == nil {
+		t.Fatal("nil cloud pointer")
+	}
+	b, _ := backendLocal.NewWithBackend(cloud)
 
 	// Add a test provider to the local backend.
 	p := backendLocal.TestLocalProvider(t, b, "null", providers.ProviderSchema{

--- a/internal/command/state_meta.go
+++ b/internal/command/state_meta.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform/internal/tfdiags"
 
 	backendLocal "github.com/hashicorp/terraform/internal/backend/local"
+	localState "github.com/hashicorp/terraform/internal/backend/local-state"
 )
 
 // StateMeta is the meta struct that should be embedded in state subcommands.
@@ -65,7 +66,8 @@ func (c *StateMeta) State() (statemgr.Full, error) {
 			panic(backendDiags.Err())
 		}
 		localB := localRaw.(*backendLocal.Local)
-		_, stateOutPath, _ = localB.StatePaths(workspace)
+		localStateB := localB.Backend.(*localState.Local)
+		_, stateOutPath, _ = localStateB.StatePaths(workspace)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
This PR separates the local method of storing state (backend.Backend implementation) from the local method of managing Terraform operations (backendrun.OperationsBackend implementation).

Naming is hard, and this PR covers things that use overloaded terms. To help make communication clearer, here are some definitions for when discussing this PR:
* **"local OperationsBackend"** = the struct that implements the backendrun.OperationsBackend interface. This manages how different Terraform operations are performed, and part of managing operations means interacting with state.
* **"local backend.Backend"** = the struct that implements the backend.Backend interface and contains the logic for interacting with the local filesystem to manage state. This logic is invoked while operations are managed.
* **"local backend"** = referring to the original struct, prior to this PR, that contained both operations management logic and logic for managing state on the local filesystem.

## How things were before

Previously the local backend was a single struct that contained both logic for managing operations and for interacting with the local filesystem to manage state. If an instance of the local backend was created with an alternative state-storage backend (via [NewWithBackend](https://github.com/hashicorp/terraform/blob/71dbc7d726ce4d45e3df940f4ded20e947fe6bea/internal/backend/local/backend.go#L102-L108)) the local backend would delegate any calls to backend.Backend methods to the contained backend: 

```go
var b backend.Backend
// logic to initialise the b Backend value
local := backendLocal.NewWithBackend(b)

// logic to prepare values from the "backend" block in a user's config
local.Configure(config)
```

```go
func (b *Local) Configure(obj cty.Value) tfdiags.Diagnostics {
    if b.Backend != nil {
        return b.Backend.Configure(obj)
    }

    // fallback logic for configuring local state storage when a different
    // state-storage backend isn't present
}
```

As shown above, if there was no alternative backend for storing state then the local backend would use its own implementation of backend.Backend methods to store state on local disk. This is how local state storage is the default behaviour in Terraform.

## How things are after this PR

This PR pulls the 'fallback' logic for managing state in the local filesystem out of the `local` package and into a new `local_state` package. The new package contains a Local struct that only implements backend.Backend methods.

The local OperationsBackend will now always require an internal backend.Backend to be set. Code will default to setting that internal backend using the local_state package, unless a user's configuration specifies an alternative storage method through a `"backend"` block.

## Remaining complexity to be aware of

The backendrun.OperationsBackend interface embeds the backend.Backend interface. This means that, despite pulling the logic about how state should be managed locally out of `local` and into `local_state`, code will still call backend.Backend methods on the local OperationsBackend implementation. Internally there is still delegation of those method calls.


## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.12.x

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
