### PR TITLE
make sure ephemeral nodes with zero instances work

### DIFF
--- a/internal/terraform/context_apply_ephemeral_test.go
+++ b/internal/terraform/context_apply_ephemeral_test.go
@@ -142,6 +142,13 @@ provider "test" {
 
 resource "test_object" "test" {
 }
+
+# make sure ephemerals with zero instances are processed correctly too
+module "zero" {
+  count = 0
+  source = "./mod"
+  input = "test"
+}
 `,
 		"./mod/main.tf": `
 variable input {
@@ -154,6 +161,7 @@ output "data" {
   ephemeral = true
   value = ephemeral.ephem_resource.data.value
 }
+
 `,
 	})
 

--- a/internal/terraform/node_resource_apply.go
+++ b/internal/terraform/node_resource_apply.go
@@ -84,6 +84,8 @@ func (n *nodeExpandApplyableResource) dynamicExpandEphemeral(ctx EvalContext) (*
 		diags = diags.Append(expDiags)
 	}
 
+	addRootNodeToGraph(&g)
+
 	return &g, diags
 }
 


### PR DESCRIPTION
The graph expansion code always wants a valid, non-empty graph now, but the ephemeral apply nodes could expand into zero instances and result in an empty graph. Make sure there is at least a root node to satisfy the graph validator during the apply walk.

Fixes # 36714

## Target Release

1.11.x


