### PR TITLE
Update issensitive.mdx - Fixed function name typo

### DIFF
--- a/website/docs/language/functions/issensitive.mdx
+++ b/website/docs/language/functions/issensitive.mdx
@@ -22,6 +22,6 @@ See [`sensitive`](/terraform/language/functions/sensitive), [`nonsensitive`](/te
 true
 > issensitive("hello")
 false
-> sensitive(var.my-var-with-sensitive-set-to-true)
+> issensitive(var.my-var-with-sensitive-set-to-true)
 true
 ```


### PR DESCRIPTION
Example with variable as argument was using `sensitive()` instead of `issensitive()`.

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.12.x
1.8.x-backport