### PR TITLE
Fix panic in proxyDialer

### DIFF
--- a/internal/communicator/ssh/http_proxy.go
+++ b/internal/communicator/ssh/http_proxy.go
@@ -100,7 +100,6 @@ func (p *proxyDialer) Dial(network, addr string) (net.Conn, error) {
 	res, err := http.ReadResponse(bufio.NewReader(c), req)
 
 	if err != nil {
-		res.Body.Close()
 		c.Close()
 		return nil, err
 	}


### PR DESCRIPTION
Incase of error, the response from net/HTTP ReadResponse is always nil and no need to close the Body.

<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x40 pc=0x103e5bf00]

goroutine 1847 [running]:
github.com/hashicorp/terraform/internal/communicator/ssh.(*proxyDialer).Dial(0x140017fddc0, {0x103f1cf9a?, 0x1060351c0?}, {0x14000709600, 0xf})
	github.com/hashicorp/terraform/internal/communicator/ssh/http_proxy.go:103 +0x520
github.com/hashicorp/terraform/internal/communicator/ssh.newHttpProxyConn(0x14000ef30b0, {0x14000709600, 0xf})
	github.com/hashicorp/terraform/internal/communicator/ssh/http_proxy.go:148 +0xd0
github.com/hashicorp/terraform/internal/communicator/ssh.prepareSSHConfig.ConnectFunc.func1()
	github.com/hashicorp/terraform/internal/communicator/ssh/communicator.go:804 +0x48
github.com/hashicorp/terraform/internal/communicator/ssh.(*Communicator).Connect(0x1400101a500, {0x104af1be0, 0x14000dea5e8})
	github.com/hashicorp/terraform/internal/communicator/ssh/communicator.go:194 +0x600
github.com/hashicorp/terraform/internal/builtin/provisioners/remote-exec.runScripts.func1()
	github.com/hashicorp/terraform/internal/builtin/provisioners/remote-exec/resource_provisioner.go:238 +0x30
github.com/hashicorp/terraform/internal/communicator.Retry.func1()
	github.com/hashicorp/terraform/internal/communicator/communicator.go:115 +0x1a4
created by github.com/hashicorp/terraform/internal/communicator.Retry in goroutine 1587
	github.com/hashicorp/terraform/internal/communicator/communicator.go:98 +0xc8
make: *** [apply] Error 2
```

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.12.x

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
