### PR TITLE
stacks: allow removed blocks to target components in nested stacks

### DIFF
--- a/internal/rpcapi/stacks.go
+++ b/internal/rpcapi/stacks.go
@@ -227,12 +227,12 @@ func stackConfigMetaforProto(cfgNode *stackconfig.ConfigNode, stackAddr stackadd
 	}
 
 	// Currently Components are the only thing that can be removed
-	for name, rc := range cfgNode.Stack.Removed {
+	for name, rc := range cfgNode.Stack.Removed.All() {
 		var blocks []*stacks.FindStackConfigurationComponents_Removed_Block
 		for _, rc := range rc {
 			cProto := &stacks.FindStackConfigurationComponents_Removed_Block{
 				SourceAddr:    rc.FinalSourceAddr.String(),
-				ComponentAddr: stackaddrs.Config(stackAddr, stackaddrs.Component{Name: rc.FromComponent.Name}).String(),
+				ComponentAddr: rc.From.ConfigComponent().String(),
 				Destroy:       rc.Destroy,
 			}
 			switch {
@@ -243,7 +243,7 @@ func stackConfigMetaforProto(cfgNode *stackconfig.ConfigNode, stackAddr stackadd
 			}
 			blocks = append(blocks, cProto)
 		}
-		ret.Removed[name] = &stacks.FindStackConfigurationComponents_Removed{
+		ret.Removed[name.String()] = &stacks.FindStackConfigurationComponents_Removed{
 			// in order to ensure as much backwards and forwards compatibility
 			// as possible, we're going to set the deprecated single fields
 			// with the first run block
@@ -257,7 +257,7 @@ func stackConfigMetaforProto(cfgNode *stackconfig.ConfigNode, stackAddr stackadd
 					return stacks.FindStackConfigurationComponents_SINGLE
 				}
 			}(),
-			ComponentAddr: stackaddrs.Config(stackAddr, stackaddrs.Component{Name: rc[0].FromComponent.Name}).String(),
+			ComponentAddr: rc[0].From.ConfigComponent().String(),
 			Destroy:       rc[0].Destroy,
 
 			// We return all the values here:

--- a/internal/stacks/stackaddrs/removed.go
+++ b/internal/stacks/stackaddrs/removed.go
@@ -66,7 +66,7 @@ func (rf RemovedFrom) AbsComponentInstance(ctx *hcl.EvalContext, parent StackIns
 	var stackInstance StackInstance
 	for _, stack := range rf.Stack {
 		step, moreDiags := stack.StackInstanceStep(ctx)
-		diags = append(moreDiags)
+		diags = diags.Append(moreDiags)
 
 		stackInstance = append(stackInstance, step)
 	}
@@ -145,11 +145,10 @@ func ParseRemovedFrom(expr hcl.Expression) (RemovedFrom, tfdiags.Diagnostics) {
 
 		// we're going to parse the traversal in sets of 2-3 depending on
 		// the indices, so we'll check that now.
-		currentTraversal := current.Current
 		nextTraversal := current.Current
 
 		for len(nextTraversal) > 0 {
-
+			var currentTraversal hcl.Traversal
 			var indexExpr hcl.Expression
 
 			switch {

--- a/internal/stacks/stackaddrs/removed.go
+++ b/internal/stacks/stackaddrs/removed.go
@@ -4,11 +4,124 @@
 package stackaddrs
 
 import (
+	"fmt"
+
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/zclconf/go-cty/cty"
 
+	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/tfdiags"
 )
+
+type RemovedFrom struct {
+	Stack     []StackRemovedFrom
+	Component ComponentRemovedFrom
+}
+
+func (rf RemovedFrom) Equals(other RemovedFrom) bool {
+	if len(rf.Stack) != len(other.Stack) {
+		return false
+	}
+	for ix, rf := range rf.Stack {
+		other := other.Stack[ix]
+		if !rf.Equals(other) {
+			return false
+		}
+	}
+	return rf.Component.Equals(other.Component)
+}
+
+func (rf RemovedFrom) ConfigComponent() ConfigComponent {
+	return ConfigComponent{
+		Stack: func() Stack {
+			stack := make(Stack, 0, len(rf.Stack))
+			for _, step := range rf.Stack {
+				stack = append(stack, StackStep{Name: step.Name})
+			}
+			return stack
+		}(),
+		Item: Component{
+			rf.Component.Name,
+		},
+	}
+}
+
+func (rf RemovedFrom) Variables() []hcl.Traversal {
+	var traversals []hcl.Traversal
+	for _, step := range rf.Stack {
+		if step.Index != nil {
+			traversals = append(traversals, step.Index.Variables()...)
+		}
+	}
+	if rf.Component.Index != nil {
+		traversals = append(traversals, rf.Component.Index.Variables()...)
+	}
+	return traversals
+}
+
+func (rf RemovedFrom) AbsComponentInstance(ctx *hcl.EvalContext, parent StackInstance) (AbsComponentInstance, tfdiags.Diagnostics) {
+	var diags tfdiags.Diagnostics
+
+	var stackInstance StackInstance
+	for _, stack := range rf.Stack {
+		step, moreDiags := stack.StackInstanceStep(ctx)
+		diags = append(moreDiags)
+
+		stackInstance = append(stackInstance, step)
+	}
+
+	componentInstance, moreDiags := rf.Component.ComponentInstance(ctx)
+	diags = diags.Append(moreDiags)
+
+	return AbsComponentInstance{Stack: append(parent, stackInstance...), Item: componentInstance}, diags
+}
+
+type StackRemovedFrom struct {
+	Name  string
+	Index hcl.Expression
+}
+
+func (rf StackRemovedFrom) Equals(other StackRemovedFrom) bool {
+	return rf.Name == other.Name && rf.Index == other.Index
+}
+
+func (rf StackRemovedFrom) StackStep() StackStep {
+	return StackStep{Name: rf.Name}
+}
+
+func (rf StackRemovedFrom) StackInstanceStep(ctx *hcl.EvalContext) (StackInstanceStep, tfdiags.Diagnostics) {
+	key, diags := exprAsKey(rf.Index, ctx)
+	return StackInstanceStep{
+		Name: rf.Name,
+		Key:  key,
+	}, diags
+}
+
+type ComponentRemovedFrom struct {
+	Name  string
+	Index hcl.Expression
+}
+
+func (rf ComponentRemovedFrom) Equals(other ComponentRemovedFrom) bool {
+	return rf.Name == other.Name && rf.Index == other.Index
+}
+
+func (rf ComponentRemovedFrom) Component() Component {
+	return Component{
+		Name: rf.Name,
+	}
+}
+
+func (rf ComponentRemovedFrom) ComponentInstance(ctx *hcl.EvalContext) (ComponentInstance, tfdiags.Diagnostics) {
+	key, diags := exprAsKey(rf.Index, ctx)
+	return ComponentInstance{
+		Component: Component{
+			Name: rf.Name,
+		},
+		Key: key,
+	}, diags
+}
 
 // ParseRemovedFrom parses the "from" attribute of a "removed" block in a
 // configuration and returns the address of the configuration object being
@@ -17,121 +130,285 @@ import (
 // In addition to the address, this function also returns a traversal that
 // represents the unparsed index within the from expression. Users can
 // optionally specify a specific index of a component to target.
-func ParseRemovedFrom(expr hcl.Expression) (Component, hcl.Expression, tfdiags.Diagnostics) {
-	var component Component
+func ParseRemovedFrom(expr hcl.Expression) (RemovedFrom, tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
 
-	traversal, index, hclDiags := exprToComponentTraversal(expr)
-	diags = diags.Append(hclDiags)
-	if hclDiags.HasErrors() {
-		return component, index, diags
+	removedFrom := RemovedFrom{}
+
+	current, moreDiags := exprToComponentTraversal(expr)
+	diags = diags.Append(moreDiags)
+	if moreDiags.HasErrors() {
+		return RemovedFrom{}, diags
 	}
 
-	if len(traversal) < 2 {
-		return component, index, diags.Append(&hcl.Diagnostic{
-			Severity: hcl.DiagError,
-			Summary:  "Invalid 'from' attribute",
-			Detail:   "The 'from' attribute must designate a component that has been removed, in the form `component.component_name` or `component.component_name[\"key\"].",
-			Subject:  expr.Range().Ptr(),
-		})
+	for current != nil {
+
+		// we're going to parse the traversal in sets of 2-3 depending on
+		// the indices, so we'll check that now.
+		currentTraversal := current.Current
+		nextTraversal := current.Current
+
+		for len(nextTraversal) > 0 {
+
+			var indexExpr hcl.Expression
+
+			switch {
+			case len(nextTraversal) < 2:
+				// this is simply an error, we always need at least 2 values
+				// for either stack.name or component.name.
+				return RemovedFrom{}, diags.Append(&hcl.Diagnostic{
+					Severity: hcl.DiagError,
+					Summary:  "Invalid 'from' attribute",
+					Detail:   "The 'from' attribute must designate a component that has been removed, in the form `component.component_name` or `component.component_name[\"key\"].",
+					Subject:  expr.Range().Ptr(),
+				})
+			case len(nextTraversal) == 2:
+				indexExpr = current.Index
+				currentTraversal = nextTraversal
+				nextTraversal = nil
+			case len(nextTraversal) == 3:
+				if current.Index != nil {
+					// this is an error, the last traversal should be taking
+					// it's index from the outer value if it exists, and to
+					// exactly three means something is invalid somewhere.
+					return RemovedFrom{}, diags.Append(&hcl.Diagnostic{
+						Severity: hcl.DiagError,
+						Summary:  "Invalid 'from' attribute",
+						Detail:   "The 'from' attribute must designate a component that has been removed, in the form `component.component_name` or `component.component_name[\"key\"].",
+						Subject:  expr.Range().Ptr(),
+					})
+				}
+
+				index, ok := nextTraversal[2].(hcl.TraverseIndex)
+				if !ok {
+					// This is an error, with exactly 3 we don't have another
+					// traversal to go to after this so the last entry must
+					// be the index.
+					return RemovedFrom{}, diags.Append(&hcl.Diagnostic{
+						Severity: hcl.DiagError,
+						Summary:  "Invalid 'from' attribute",
+						Detail:   "The 'from' attribute must designate a component that has been removed, in the form `component.component_name` or `component.component_name[\"key\"].",
+						Subject:  expr.Range().Ptr(),
+					})
+				}
+
+				currentTraversal = nextTraversal
+				nextTraversal = nil
+				indexExpr = hcl.StaticExpr(index.Key, index.SrcRange)
+
+			default: // len(nextTraversal) > 3
+				if index, ok := nextTraversal[2].(hcl.TraverseIndex); ok {
+					currentTraversal = nextTraversal[:3]
+					nextTraversal = nextTraversal[3:]
+					indexExpr = hcl.StaticExpr(index.Key, index.SrcRange)
+					break
+				}
+				currentTraversal = nextTraversal[:2]
+				nextTraversal = nextTraversal[2:]
+			}
+
+			var name string
+
+			switch root := currentTraversal[0].(type) {
+			case hcl.TraverseRoot:
+				name = root.Name
+			case hcl.TraverseAttr:
+				name = root.Name
+			default:
+				return RemovedFrom{}, diags.Append(&hcl.Diagnostic{
+					Severity: hcl.DiagError,
+					Summary:  "Invalid 'from' attribute",
+					Detail:   "The 'from' attribute must designate a component that has been removed, in the form `component.component_name` or `component.component_name[\"key\"].",
+					Subject:  expr.Range().Ptr(),
+				})
+			}
+
+			switch name {
+			case "component":
+				name, ok := currentTraversal[1].(hcl.TraverseAttr)
+				if !ok {
+					return RemovedFrom{}, diags.Append(&hcl.Diagnostic{
+						Severity: hcl.DiagError,
+						Summary:  "Invalid 'from' attribute",
+						Detail:   "The 'from' attribute must designate a component that has been removed, in the form `component.component_name` or `component.component_name[\"key\"].",
+						Subject:  expr.Range().Ptr(),
+					})
+				}
+
+				if len(nextTraversal) > 0 || current.Rest != nil {
+					return RemovedFrom{}, diags.Append(&hcl.Diagnostic{
+						Severity: hcl.DiagError,
+						Summary:  "Invalid 'from' attribute",
+						Detail:   "The 'from' attribute must designate a component that has been removed, in the form `component.component_name` or `component.component_name[\"key\"].",
+						Subject:  expr.Range().Ptr(),
+					})
+				}
+
+				removedFrom.Component = ComponentRemovedFrom{
+					Name:  name.Name,
+					Index: indexExpr,
+				}
+				return removedFrom, diags
+			case "stack":
+				name, ok := currentTraversal[1].(hcl.TraverseAttr)
+				if !ok {
+					return RemovedFrom{}, diags.Append(&hcl.Diagnostic{
+						Severity: hcl.DiagError,
+						Summary:  "Invalid 'from' attribute",
+						Detail:   "The 'from' attribute must designate a component that has been removed, in the form `component.component_name` or `component.component_name[\"key\"].",
+						Subject:  expr.Range().Ptr(),
+					})
+				}
+
+				removedFrom.Stack = append(removedFrom.Stack, StackRemovedFrom{
+					Name:  name.Name,
+					Index: indexExpr,
+				})
+
+			default:
+				return RemovedFrom{}, diags.Append(&hcl.Diagnostic{
+					Severity: hcl.DiagError,
+					Summary:  "Invalid 'from' attribute",
+					Detail:   "The 'from' attribute must designate a component that has been removed, in the form `component.component_name` or `component.component_name[\"key\"].",
+					Subject:  expr.Range().Ptr(),
+				})
+			}
+		}
+
+		current = current.Rest
 	}
 
-	root, ok := traversal[0].(hcl.TraverseRoot)
-	if !ok || root.Name != "component" {
-		return component, index, diags.Append(&hcl.Diagnostic{
-			Severity: hcl.DiagError,
-			Summary:  "Invalid 'from' attribute",
-			Detail:   "The 'from' attribute must designate a component that has been removed, in the form `component.component_name` or `component.component_name[\"key\"].",
-			Subject:  expr.Range().Ptr(),
-		})
-	}
+	return RemovedFrom{}, diags.Append(&hcl.Diagnostic{
+		Severity: hcl.DiagError,
+		Summary:  "Invalid 'from' attribute",
+		Detail:   "The 'from' attribute must designate a component that has been removed, in the form `component.component_name` or `component.component_name[\"key\"].",
+		Subject:  expr.Range().Ptr(),
+	})
+}
 
-	name, ok := traversal[1].(hcl.TraverseAttr)
-	if !ok {
-		return component, index, diags.Append(&hcl.Diagnostic{
-			Severity: hcl.DiagError,
-			Summary:  "Invalid 'from' attribute",
-			Detail:   "The 'from' attribute must designate a component that has been removed, in the form `component.component_name` or `component.component_name[\"key\"].",
-			Subject:  expr.Range().Ptr(),
-		})
-	}
-	component.Name = name.Name
-
-	return component, index, diags
+type parsedFromExpr struct {
+	Current hcl.Traversal
+	Index   hcl.Expression
+	Rest    *parsedFromExpr
 }
 
 // exprToComponentTraversal converts an HCL expression into a traversal that
 // represents the component being targeted. We have to handle parsing this
 // ourselves because removed block from arguments can contain index expressions
 // which are not supported by hcl.AbsTraversalForExpr.
-func exprToComponentTraversal(expr hcl.Expression) (hcl.Traversal, hcl.Expression, hcl.Diagnostics) {
-	var diags hcl.Diagnostics
-
+//
+// The return values are (1) the part of the expression that can be converted
+// into a traversal, (2) the index at the end of the traversal if it is an
+// expression, (3) the remainder of the expression that needs to be parsed
+// after (1) has been, and (4) the diagnostics.
+func exprToComponentTraversal(expr hcl.Expression) (*parsedFromExpr, hcl.Diagnostics) {
 	switch e := expr.(type) {
 	case *hclsyntax.IndexExpr:
-		t, d := hcl.AbsTraversalForExpr(e.Collection)
-		diags = diags.Extend(d)
-		if d.HasErrors() {
-			return nil, nil, diags
+
+		current, diags := exprToComponentTraversal(e.Collection)
+		if diags.HasErrors() {
+			return nil, diags
 		}
-		return t, e.Key, diags
+
+		for next := current; next != nil; next = next.Rest {
+			if next.Rest == nil {
+				next.Index = e.Key
+			}
+		}
+
+		return current, diags
+
 	case *hclsyntax.RelativeTraversalExpr:
 
-		// This is an expression of the form `component.component_name[each.key].attribute`.
-		// This is invalid at the moment, as we only support direct component
-		// references. We'll return our own diagnostic here.
+		current, diags := exprToComponentTraversal(e.Source)
+		if diags.HasErrors() {
+			return nil, diags
+		}
 
-		return nil, nil, diags.Append(&hcl.Diagnostic{
-			Severity: hcl.DiagError,
-			Summary:  "Invalid 'from' attribute",
-			Detail:   "The 'from' attribute must designate a component that has been removed, in the form `component.component_name` or `component.component_name[\"key\"].",
-			Subject:  expr.Range().Ptr(),
-		})
+		for next := current; next != nil; next = next.Rest {
+			if next.Rest == nil {
+				next.Rest = &parsedFromExpr{
+					Current: e.Traversal,
+				}
+				break
+			}
+		}
+
+		return current, diags
 
 	default:
 
 		// For anything else, just rely on the default traversal logic.
 
-		t, d := hcl.AbsTraversalForExpr(expr)
-		diags = diags.Extend(d)
-		if d.HasErrors() {
-			return nil, nil, diags
+		t, diags := hcl.AbsTraversalForExpr(expr)
+		if diags.HasErrors() {
+			return nil, diags
 		}
+		return &parsedFromExpr{
+			Current: t,
+			Index:   nil,
+			Rest:    nil,
+		}, diags
 
-		if len(t) < 2 {
-			return nil, nil, diags.Append(&hcl.Diagnostic{
-				Severity: hcl.DiagError,
-				Summary:  "Invalid 'from' attribute",
-				Detail:   "The 'from' attribute must designate a component that has been removed, in the form `component.component_name` or `component.component_name[\"key\"].",
-				Subject:  expr.Range().Ptr(),
-			})
-		}
+	}
+}
 
-		// For now, removed blocks only support direct component references.
-		// ie. you can't target a resource within a component, the next check
-		// ensures this is true.
+func exprAsKey(expr hcl.Expression, ctx *hcl.EvalContext) (addrs.InstanceKey, tfdiags.Diagnostics) {
+	if expr == nil {
+		return addrs.NoKey, nil
+	}
+	var diags tfdiags.Diagnostics
 
-		if len(t) > 3 {
-			return nil, nil, diags.Append(&hcl.Diagnostic{
-				Severity: hcl.DiagError,
-				Summary:  "Invalid 'from' attribute",
-				Detail:   "The 'from' attribute must designate a component that has been removed, in the form `component.component_name` or `component.component_name[\"key\"].",
-				Subject:  expr.Range().Ptr(),
-			})
-		}
+	value, moreDiags := expr.Value(ctx)
+	diags = diags.Append(moreDiags)
+	if moreDiags.HasErrors() {
+		return addrs.WildcardKey, diags
+	}
 
-		if len(t) == 2 {
-			return t, nil, diags
-		}
-
-		if index, ok := t[2].(hcl.TraverseIndex); ok {
-			return t[:2], hcl.StaticExpr(index.Key, index.SrcRange), diags
-		}
-
-		return nil, nil, diags.Append(&hcl.Diagnostic{
-			Severity: hcl.DiagError,
-			Summary:  "Invalid 'from' attribute",
-			Detail:   "The 'from' attribute must designate a component that has been removed, in the form `component.component_name` or `component.component_name[\"key\"].",
+	if value.IsNull() {
+		return addrs.WildcardKey, diags.Append(&hcl.Diagnostic{
+			Severity:    hcl.DiagError,
+			Summary:     "Invalid `from` attribute",
+			Detail:      "The `from` attribute has an invalid index: cannot be null.",
+			Subject:     expr.Range().Ptr(),
+			Expression:  expr,
+			EvalContext: ctx,
 		})
 	}
+
+	if !value.IsKnown() {
+		switch value.Type() {
+		case cty.String, cty.Number:
+			// this is potentially the right type, so we'll allow this
+			return addrs.WildcardKey, diags
+		case cty.DynamicPseudoType:
+			// not ideal, but we can't confirm this for sure so we'll allow it
+			return addrs.WildcardKey, diags
+		default:
+			// bad, this isn't the right type even if we don't know what the
+			// value actually will be in the end
+			return addrs.WildcardKey, diags.Append(&hcl.Diagnostic{
+				Severity:    hcl.DiagError,
+				Summary:     "Invalid `from` attribute",
+				Detail:      "The `from` attribute has an invalid index: either a string or integer is required.",
+				Subject:     expr.Range().Ptr(),
+				Expression:  expr,
+				EvalContext: ctx,
+			})
+		}
+	}
+
+	key, err := addrs.ParseInstanceKey(value)
+	if err != nil {
+		return addrs.WildcardKey, diags.Append(&hcl.Diagnostic{
+			Severity:    hcl.DiagError,
+			Summary:     "Invalid `from` attribute",
+			Detail:      fmt.Sprintf("The `from` attribute has an invalid index: %s.", err),
+			Subject:     expr.Range().Ptr(),
+			Expression:  expr,
+			EvalContext: ctx,
+		})
+	}
+
+	return key, diags
 }

--- a/internal/stacks/stackaddrs/removed_test.go
+++ b/internal/stacks/stackaddrs/removed_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
-	"github.com/zclconf/go-cty-debug/ctydebug"
 	"github.com/zclconf/go-cty/cty"
 
 	"github.com/hashicorp/terraform/internal/tfdiags"
@@ -26,38 +25,27 @@ func TestParseRemovedFrom(t *testing.T) {
 	}
 
 	tcs := []struct {
-		from      string
-		component Component
-		index     cty.Value
-		vars      map[string]cty.Value
-		diags     func() tfdiags.Diagnostics
+		from       string
+		want       AbsComponentInstance
+		vars       map[string]cty.Value
+		parseDiags func() tfdiags.Diagnostics
+		addrDiags  func() tfdiags.Diagnostics
 	}{
 		{
 			from: "component.component_name",
-			component: Component{
-				Name: "component_name",
-			},
+			want: mustAbsComponentInstance(t, "component.component_name"),
 		},
 		{
 			from: "component.component_name[0]",
-			component: Component{
-				Name: "component_name",
-			},
-			index: cty.NumberIntVal(0),
+			want: mustAbsComponentInstance(t, "component.component_name[0]"),
 		},
 		{
 			from: "component.component_name[\"key\"]",
-			component: Component{
-				Name: "component_name",
-			},
-			index: cty.StringVal("key"),
+			want: mustAbsComponentInstance(t, "component.component_name[\"key\"]"),
 		},
 		{
 			from: "component.component_name[each.key]",
-			component: Component{
-				Name: "component_name",
-			},
-			index: cty.StringVal("key"),
+			want: mustAbsComponentInstance(t, "component.component_name[\"key\"]"),
 			vars: map[string]cty.Value{
 				"each": cty.ObjectVal(map[string]cty.Value{
 					"key": cty.StringVal("key"),
@@ -66,10 +54,7 @@ func TestParseRemovedFrom(t *testing.T) {
 		},
 		{
 			from: "component.component_name[each.value.attribute]",
-			component: Component{
-				Name: "component_name",
-			},
-			index: cty.StringVal("attribute"),
+			want: mustAbsComponentInstance(t, "component.component_name[\"attribute\"]"),
 			vars: map[string]cty.Value{
 				"each": cty.ObjectVal(map[string]cty.Value{
 					"value": cty.ObjectVal(map[string]cty.Value{
@@ -80,10 +65,7 @@ func TestParseRemovedFrom(t *testing.T) {
 		},
 		{
 			from: "component.component_name[each.value[\"key\"]]",
-			component: Component{
-				Name: "component_name",
-			},
-			index: cty.StringVal("key"),
+			want: mustAbsComponentInstance(t, "component.component_name[\"key\"]"),
 			vars: map[string]cty.Value{
 				"each": cty.ObjectVal(map[string]cty.Value{
 					"value": cty.MapVal(map[string]cty.Value{
@@ -94,10 +76,7 @@ func TestParseRemovedFrom(t *testing.T) {
 		},
 		{
 			from: "component.component_name[each.value[\"key\"].attribute]",
-			component: Component{
-				Name: "component_name",
-			},
-			index: cty.StringVal("attribute"),
+			want: mustAbsComponentInstance(t, "component.component_name[\"attribute\"]"),
 			vars: map[string]cty.Value{
 				"each": cty.ObjectVal(map[string]cty.Value{
 					"value": cty.MapVal(map[string]cty.Value{
@@ -110,10 +89,7 @@ func TestParseRemovedFrom(t *testing.T) {
 		},
 		{
 			from: "component.component_name[each.value[local.key]]",
-			component: Component{
-				Name: "component_name",
-			},
-			index: cty.StringVal("key"),
+			want: mustAbsComponentInstance(t, "component.component_name[\"key\"]"),
 			vars: map[string]cty.Value{
 				"each": cty.ObjectVal(map[string]cty.Value{
 					"value": cty.MapVal(map[string]cty.Value{
@@ -127,10 +103,7 @@ func TestParseRemovedFrom(t *testing.T) {
 		},
 		{
 			from: "component.component_name[each.value[local.key].attribute]",
-			component: Component{
-				Name: "component_name",
-			},
-			index: cty.StringVal("attribute"),
+			want: mustAbsComponentInstance(t, "component.component_name[\"attribute\"]"),
 			vars: map[string]cty.Value{
 				"each": cty.ObjectVal(map[string]cty.Value{
 					"value": cty.MapVal(map[string]cty.Value{
@@ -145,73 +118,203 @@ func TestParseRemovedFrom(t *testing.T) {
 			},
 		},
 		{
+			from: "stack.stack_name.component.component_name",
+			want: mustAbsComponentInstance(t, "stack.stack_name.component.component_name"),
+		},
+		{
+			from: "stack.parent.stack.child.component.component_name",
+			want: mustAbsComponentInstance(t, "stack.parent.stack.child.component.component_name"),
+		},
+		{
+			from: "stack.stack_name[\"stack\"].component.component_name",
+			want: mustAbsComponentInstance(t, "stack.stack_name[\"stack\"].component.component_name"),
+		},
+		{
+			from: "stack.stack_name.component.component_name[\"component\"]",
+			want: mustAbsComponentInstance(t, "stack.stack_name.component.component_name[\"component\"]"),
+		},
+		{
+			from: "stack.stack_name[\"stack\"].component.component_name[\"component\"]",
+			want: mustAbsComponentInstance(t, "stack.stack_name[\"stack\"].component.component_name[\"component\"]"),
+		},
+		{
+			from: "stack.stack_name.component.component_name[each.value]",
+			want: mustAbsComponentInstance(t, "stack.stack_name.component.component_name[\"component\"]"),
+			vars: map[string]cty.Value{
+				"each": cty.ObjectVal(map[string]cty.Value{
+					"value": cty.StringVal("component"),
+				}),
+			},
+		},
+		{
+			from: "stack.stack_name[\"stack\"].component.component_name[each.value]",
+			want: mustAbsComponentInstance(t, "stack.stack_name[\"stack\"].component.component_name[\"component\"]"),
+			vars: map[string]cty.Value{
+				"each": cty.ObjectVal(map[string]cty.Value{
+					"value": cty.StringVal("component"),
+				}),
+			},
+		},
+		{
+			from: "stack.stack_name[each.value].component.component_name",
+			want: mustAbsComponentInstance(t, "stack.stack_name[\"stack\"].component.component_name"),
+			vars: map[string]cty.Value{
+				"each": cty.ObjectVal(map[string]cty.Value{
+					"value": cty.StringVal("stack"),
+				}),
+			},
+		},
+		{
+			from: "stack.stack_name[each.value].component.component_name[\"component\"]",
+			want: mustAbsComponentInstance(t, "stack.stack_name[\"stack\"].component.component_name[\"component\"]"),
+			vars: map[string]cty.Value{
+				"each": cty.ObjectVal(map[string]cty.Value{
+					"value": cty.StringVal("stack"),
+				}),
+			},
+		},
+		{
+			from: "stack.stack_name[each.value[\"stack\"]].component.component_name[each.value[\"component\"]]",
+			want: mustAbsComponentInstance(t, "stack.stack_name[\"stack\"].component.component_name[\"component\"]"),
+			vars: map[string]cty.Value{
+				"each": cty.ObjectVal(map[string]cty.Value{
+					"value": cty.ObjectVal(map[string]cty.Value{
+						"stack":     cty.StringVal("stack"),
+						"component": cty.StringVal("component"),
+					}),
+				}),
+			},
+		},
+		{
+			from: "stack.parent[each.value[\"parent\"]].stack.child[each.value[\"child\"]].component.component_name",
+			want: mustAbsComponentInstance(t, "stack.parent[\"parent\"].stack.child[\"child\"].component.component_name"),
+			vars: map[string]cty.Value{
+				"each": cty.ObjectVal(map[string]cty.Value{
+					"value": cty.ObjectVal(map[string]cty.Value{
+						"parent":    cty.StringVal("parent"),
+						"child":     cty.StringVal("child"),
+						"component": cty.StringVal("component"),
+					}),
+				}),
+			},
+		},
+		{
+			from: "stack.parent[each.value[\"parent\"]].stack.child[each.value[\"child\"]].component.component_name[\"component\"]",
+			want: mustAbsComponentInstance(t, "stack.parent[\"parent\"].stack.child[\"child\"].component.component_name[\"component\"]"),
+			vars: map[string]cty.Value{
+				"each": cty.ObjectVal(map[string]cty.Value{
+					"value": cty.ObjectVal(map[string]cty.Value{
+						"parent": cty.StringVal("parent"),
+						"child":  cty.StringVal("child"),
+					}),
+				}),
+			},
+		},
+		{
+			from: "stack.parent[each.value[\"parent\"]].stack.child[each.value[\"child\"]].component.component_name[each.value[\"component\"]]",
+			want: mustAbsComponentInstance(t, "stack.parent[\"parent\"].stack.child[\"child\"].component.component_name[\"component\"]"),
+			vars: map[string]cty.Value{
+				"each": cty.ObjectVal(map[string]cty.Value{
+					"value": cty.ObjectVal(map[string]cty.Value{
+						"parent":    cty.StringVal("parent"),
+						"child":     cty.StringVal("child"),
+						"component": cty.StringVal("component"),
+					}),
+				}),
+			},
+		},
+		{
 			from: "component.component_name.attribute_key",
-			diags: func() tfdiags.Diagnostics {
+			parseDiags: func() tfdiags.Diagnostics {
 				var diags tfdiags.Diagnostics
 				diags = diags.Append(&hcl.Diagnostic{
 					Severity: hcl.DiagError,
 					Summary:  "Invalid 'from' attribute",
 					Detail:   "The 'from' attribute must designate a component that has been removed, in the form `component.component_name` or `component.component_name[\"key\"].",
+					Subject: &hcl.Range{
+						Start: hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:   hcl.Pos{Line: 1, Column: 39, Byte: 38},
+					},
 				})
 				return diags
 			},
 		},
 		{
 			from: "component.component_name[0].attribute_key",
-			diags: func() tfdiags.Diagnostics {
+			parseDiags: func() tfdiags.Diagnostics {
 				var diags tfdiags.Diagnostics
 				diags = diags.Append(&hcl.Diagnostic{
 					Severity: hcl.DiagError,
 					Summary:  "Invalid 'from' attribute",
 					Detail:   "The 'from' attribute must designate a component that has been removed, in the form `component.component_name` or `component.component_name[\"key\"].",
+					Subject: &hcl.Range{
+						Start: hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:   hcl.Pos{Line: 1, Column: 42, Byte: 41},
+					},
 				})
 				return diags
 			},
 		},
 		{
 			from: "component.component_name[\"key\"].attribute_key",
-			diags: func() tfdiags.Diagnostics {
+			parseDiags: func() tfdiags.Diagnostics {
 				var diags tfdiags.Diagnostics
 				diags = diags.Append(&hcl.Diagnostic{
 					Severity: hcl.DiagError,
 					Summary:  "Invalid 'from' attribute",
 					Detail:   "The 'from' attribute must designate a component that has been removed, in the form `component.component_name` or `component.component_name[\"key\"].",
+					Subject: &hcl.Range{
+						Start: hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:   hcl.Pos{Line: 1, Column: 46, Byte: 45},
+					},
 				})
 				return diags
 			},
 		},
 		{
 			from: "component.component_name[each.key].attribute_key",
-			diags: func() tfdiags.Diagnostics {
+			parseDiags: func() tfdiags.Diagnostics {
 				var diags tfdiags.Diagnostics
 				diags = diags.Append(&hcl.Diagnostic{
 					Severity: hcl.DiagError,
 					Summary:  "Invalid 'from' attribute",
 					Detail:   "The 'from' attribute must designate a component that has been removed, in the form `component.component_name` or `component.component_name[\"key\"].",
+					Subject: &hcl.Range{
+						Start: hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:   hcl.Pos{Line: 1, Column: 49, Byte: 48},
+					},
 				})
 				return diags
 			},
 		},
 		{
 			from: "component.component_name.attribute_key[0]",
-			diags: func() tfdiags.Diagnostics {
+			parseDiags: func() tfdiags.Diagnostics {
 				var diags tfdiags.Diagnostics
 				diags = diags.Append(&hcl.Diagnostic{
 					Severity: hcl.DiagError,
 					Summary:  "Invalid 'from' attribute",
 					Detail:   "The 'from' attribute must designate a component that has been removed, in the form `component.component_name` or `component.component_name[\"key\"].",
+					Subject: &hcl.Range{
+						Start: hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:   hcl.Pos{Line: 1, Column: 42, Byte: 41},
+					},
 				})
 				return diags
 			},
 		},
 		{
 			from: "component[0].component_name",
-			diags: func() tfdiags.Diagnostics {
+			parseDiags: func() tfdiags.Diagnostics {
 				var diags tfdiags.Diagnostics
 				diags = diags.Append(&hcl.Diagnostic{
 					Severity: hcl.DiagError,
 					Summary:  "Invalid 'from' attribute",
 					Detail:   "The 'from' attribute must designate a component that has been removed, in the form `component.component_name` or `component.component_name[\"key\"].",
+					Subject: &hcl.Range{
+						Start: hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:   hcl.Pos{Line: 1, Column: 28, Byte: 27},
+					},
 				})
 				return diags
 			},
@@ -221,50 +324,43 @@ func TestParseRemovedFrom(t *testing.T) {
 	for _, tc := range tcs {
 		t.Run(tc.from, func(t *testing.T) {
 			expr := mustExpr(t, tc.from)
-			component, index, gotDiags := ParseRemovedFrom(expr)
+			from, parseDiags := ParseRemovedFrom(expr)
 
-			// validate the component first
-			if diff := cmp.Diff(tc.component, component); len(diff) > 0 {
-				t.Errorf("unexpected result\n%s", diff)
+			var wantParseDiags tfdiags.Diagnostics
+			if tc.parseDiags != nil {
+				wantParseDiags = tc.parseDiags()
 			}
+			tfdiags.AssertDiagnosticsMatch(t, parseDiags, wantParseDiags)
 
-			// validate the index
-			if index == nil {
-				if tc.index != cty.NilVal {
-					t.Errorf("expected index but got nil")
-				}
-			} else {
-				gotIndex, indexDiags := index.Value(&hcl.EvalContext{
-					Variables: tc.vars,
-				})
-				if len(indexDiags) > 0 {
-					t.Errorf("unexpected index diagnostics: %s", indexDiags.Error())
-				}
-				if diff := cmp.Diff(tc.index, gotIndex, ctydebug.CmpOptions); len(diff) > 0 {
-					t.Errorf("unexpected index\n%s", diff)
-				}
+			configAddress := from.ConfigComponent()
+			instanceAddress, addrDiags := from.AbsComponentInstance(&hcl.EvalContext{
+				Variables: tc.vars,
+			}, RootStackInstance)
+			var wantAddrDiags tfdiags.Diagnostics
+			if tc.addrDiags != nil {
+				wantAddrDiags = tc.addrDiags()
 			}
+			tfdiags.AssertDiagnosticsMatch(t, addrDiags, wantAddrDiags)
 
-			// validate the diagnostics
-
-			var wantDiags tfdiags.Diagnostics
-			if tc.diags != nil {
-				wantDiags = tc.diags()
+			wantConfigAddress := ConfigComponent{
+				Stack: tc.want.Stack.ConfigAddr(),
+				Item:  tc.want.Item.Component,
 			}
-			if len(gotDiags) != len(wantDiags) {
-				t.Errorf("wrong number of diagnostics")
+			if diff := cmp.Diff(configAddress.String(), wantConfigAddress.String()); len(diff) > 0 {
+				t.Errorf("wrong config address; %s", diff)
 			}
-			for ix, got := range gotDiags {
-				want := wantDiags[ix]
-
-				if want.Severity() != got.Severity() {
-					t.Errorf("unexpected severity: got %s, want %s", got.Severity(), want.Severity())
-				}
-				if diff := cmp.Diff(want.Description(), got.Description()); len(diff) > 0 {
-					t.Errorf("unexpected description\n%s", diff)
-				}
+			if diff := cmp.Diff(instanceAddress.String(), tc.want.String()); len(diff) > 0 {
+				t.Errorf("wrong instance address: %s", diff)
 			}
 		})
 	}
 
+}
+
+func mustAbsComponentInstance(t *testing.T, str string) AbsComponentInstance {
+	inst, diags := ParseAbsComponentInstanceStr(str)
+	if diags.HasErrors() {
+		t.Fatal(diags.Err())
+	}
+	return inst
 }

--- a/internal/stacks/stackconfig/config.go
+++ b/internal/stacks/stackconfig/config.go
@@ -191,7 +191,7 @@ func loadConfigDir(sourceAddr sourceaddrs.FinalSource, sources *sourcebundle.Bun
 		cmpn.FinalSourceAddr = effectiveSourceAddr
 	}
 
-	for _, blocks := range stack.Removed {
+	for _, blocks := range stack.Removed.All() {
 		for _, rmvd := range blocks {
 			effectiveSourceAddr, err := resolveFinalSourceAddr(sourceAddr, rmvd.SourceAddr, rmvd.VersionConstraints, sources)
 			if err != nil {

--- a/internal/stacks/stackruntime/apply_test.go
+++ b/internal/stacks/stackruntime/apply_test.go
@@ -1041,7 +1041,195 @@ func TestApply(t *testing.T) {
 				},
 			},
 		},
-		"removed embedded component": {
+		"removed embedded dynamic component from stack": {
+			path: filepath.Join("with-single-input", "removed-component-from-stack-dynamic"),
+			state: stackstate.NewStateBuilder().
+				AddComponentInstance(stackstate.NewComponentInstanceBuilder(mustAbsComponentInstance("stack.for_each.component.self[\"removed\"]")).
+					AddInputVariable("id", cty.StringVal("removed")).
+					AddInputVariable("input", cty.StringVal("removed"))).
+				AddResourceInstance(stackstate.NewResourceInstanceBuilder().
+					SetAddr(mustAbsResourceInstanceObject("stack.for_each.component.self[\"removed\"].testing_resource.data")).
+					SetProviderAddr(mustDefaultRootProvider("testing")).
+					SetResourceInstanceObjectSrc(states.ResourceInstanceObjectSrc{
+						Status: states.ObjectReady,
+						AttrsJSON: mustMarshalJSONAttrs(map[string]any{
+							"id":    "removed",
+							"value": "removed",
+						}),
+					})).
+				Build(),
+			store: stacks_testing_provider.NewResourceStoreBuilder().
+				AddResource("removed", cty.ObjectVal(map[string]cty.Value{
+					"id":    cty.StringVal("removed"),
+					"value": cty.StringVal("removed"),
+				})).
+				Build(),
+			cycles: []TestCycle{
+				{
+					planInputs: map[string]cty.Value{
+						"for_each_input": cty.MapVal(map[string]cty.Value{
+							"added": cty.StringVal("added"),
+						}),
+						"for_each_removed": cty.SetVal([]cty.Value{
+							cty.StringVal("removed"),
+						}),
+					},
+					wantAppliedChanges: []stackstate.AppliedChange{
+						&stackstate.AppliedChangeComponentInstance{
+							ComponentAddr:         mustAbsComponent("stack.for_each.component.self"),
+							ComponentInstanceAddr: mustAbsComponentInstance("stack.for_each.component.self[\"added\"]"),
+							OutputValues:          make(map[addrs.OutputValue]cty.Value),
+							InputVariables: map[addrs.InputVariable]cty.Value{
+								mustInputVariable("id"):    cty.StringVal("added"),
+								mustInputVariable("input"): cty.StringVal("added"),
+							},
+						},
+						&stackstate.AppliedChangeResourceInstanceObject{
+							ResourceInstanceObjectAddr: mustAbsResourceInstanceObject("stack.for_each.component.self[\"added\"].testing_resource.data"),
+							NewStateSrc: &states.ResourceInstanceObjectSrc{
+								AttrsJSON: mustMarshalJSONAttrs(map[string]any{
+									"id":    "added",
+									"value": "added",
+								}),
+								Status:       states.ObjectReady,
+								Dependencies: make([]addrs.ConfigResource, 0),
+							},
+							ProviderConfigAddr: mustDefaultRootProvider("testing"),
+							Schema:             stacks_testing_provider.TestingResourceSchema,
+						},
+						&stackstate.AppliedChangeComponentInstanceRemoved{
+							ComponentAddr:         mustAbsComponent("stack.for_each.component.self[\"removed\"]"),
+							ComponentInstanceAddr: mustAbsComponentInstance("stack.for_each.component.self[\"removed\"]"),
+						},
+						&stackstate.AppliedChangeResourceInstanceObject{
+							ResourceInstanceObjectAddr: mustAbsResourceInstanceObject("stack.for_each.component.self[\"removed\"].testing_resource.data"),
+							ProviderConfigAddr:         mustDefaultRootProvider("testing"),
+							NewStateSrc:                nil,
+							Schema:                     providers.Schema{},
+						},
+						&stackstate.AppliedChangeInputVariable{
+							Addr: mustStackInputVariable("for_each_input"),
+							Value: cty.MapVal(map[string]cty.Value{
+								"added": cty.StringVal("added"),
+							}),
+						},
+						&stackstate.AppliedChangeInputVariable{
+							Addr: mustStackInputVariable("for_each_removed"),
+							Value: cty.SetVal([]cty.Value{
+								cty.StringVal("removed"),
+							}),
+						},
+						&stackstate.AppliedChangeInputVariable{
+							Addr:  mustStackInputVariable("simple_input"),
+							Value: cty.MapValEmpty(cty.String),
+						},
+						&stackstate.AppliedChangeInputVariable{
+							Addr:  mustStackInputVariable("simple_removed"),
+							Value: cty.SetValEmpty(cty.String),
+						},
+					},
+				},
+			},
+		},
+		"removed embedded component relative": {
+			path: filepath.Join("with-single-input", "removed-component-from-stack"),
+			state: stackstate.NewStateBuilder().
+				AddComponentInstance(stackstate.NewComponentInstanceBuilder(mustAbsComponentInstance("stack.nested.component.self[\"foo\"]")).
+					AddInputVariable("id", cty.StringVal("removed")).
+					AddInputVariable("input", cty.StringVal("removed"))).
+				AddResourceInstance(stackstate.NewResourceInstanceBuilder().
+					SetAddr(mustAbsResourceInstanceObject("stack.nested.component.self[\"foo\"].testing_resource.data")).
+					SetProviderAddr(mustDefaultRootProvider("testing")).
+					SetResourceInstanceObjectSrc(states.ResourceInstanceObjectSrc{
+						Status: states.ObjectReady,
+						AttrsJSON: mustMarshalJSONAttrs(map[string]any{
+							"id":    "removed",
+							"value": "removed",
+						}),
+					})).
+				Build(),
+			store: stacks_testing_provider.NewResourceStoreBuilder().
+				AddResource("removed", cty.ObjectVal(map[string]cty.Value{
+					"id":    cty.StringVal("removed"),
+					"value": cty.StringVal("removed"),
+				})).
+				Build(),
+			cycles: []TestCycle{
+				{
+					wantPlannedChanges: []stackplan.PlannedChange{
+						&stackplan.PlannedChangeApplyable{
+							Applyable: true,
+						},
+						&stackplan.PlannedChangeHeader{
+							TerraformVersion: version.SemVer,
+						},
+						&stackplan.PlannedChangePlannedTimestamp{
+							PlannedTimestamp: fakePlanTimestamp,
+						},
+						&stackplan.PlannedChangeComponentInstance{
+							Addr:          mustAbsComponentInstance("stack.nested.component.self[\"foo\"]"),
+							PlanComplete:  true,
+							PlanApplyable: true,
+							Mode:          plans.DestroyMode,
+							Action:        plans.Delete,
+							PlannedInputValues: map[string]plans.DynamicValue{
+								"id":    mustPlanDynamicValueDynamicType(cty.StringVal("removed")),
+								"input": mustPlanDynamicValueDynamicType(cty.StringVal("removed")),
+							},
+							PlannedInputValueMarks: map[string][]cty.PathValueMarks{
+								"input": nil,
+								"id":    nil,
+							},
+							PlannedOutputValues: make(map[string]cty.Value),
+							PlannedCheckResults: &states.CheckResults{},
+							PlanTimestamp:       fakePlanTimestamp,
+						},
+						&stackplan.PlannedChangeResourceInstancePlanned{
+							ResourceInstanceObjectAddr: mustAbsResourceInstanceObject("stack.nested.component.self[\"foo\"].testing_resource.data"),
+							ChangeSrc: &plans.ResourceInstanceChangeSrc{
+								Addr:        mustAbsResourceInstance("testing_resource.data"),
+								PrevRunAddr: mustAbsResourceInstance("testing_resource.data"),
+								ChangeSrc: plans.ChangeSrc{
+									Action: plans.Delete,
+									Before: mustPlanDynamicValue(cty.ObjectVal(map[string]cty.Value{
+										"id":    cty.StringVal("removed"),
+										"value": cty.StringVal("removed"),
+									})),
+									After: mustPlanDynamicValue(cty.NullVal(cty.Object(map[string]cty.Type{
+										"id":    cty.String,
+										"value": cty.String,
+									}))),
+								},
+								ProviderAddr: mustDefaultRootProvider("testing"),
+							},
+							PriorStateSrc: &states.ResourceInstanceObjectSrc{
+								AttrsJSON: mustMarshalJSONAttrs(map[string]any{
+									"id":    "removed",
+									"value": "removed",
+								}),
+								Dependencies: make([]addrs.ConfigResource, 0),
+								Status:       states.ObjectReady,
+							},
+							ProviderConfigAddr: mustDefaultRootProvider("testing"),
+							Schema:             stacks_testing_provider.TestingResourceSchema,
+						},
+					},
+					wantAppliedChanges: []stackstate.AppliedChange{
+						&stackstate.AppliedChangeComponentInstanceRemoved{
+							ComponentAddr:         mustAbsComponent("stack.nested.component.self[\"foo\"]"),
+							ComponentInstanceAddr: mustAbsComponentInstance("stack.nested.component.self[\"foo\"]"),
+						},
+						&stackstate.AppliedChangeResourceInstanceObject{
+							ResourceInstanceObjectAddr: mustAbsResourceInstanceObject("stack.nested.component.self[\"foo\"].testing_resource.data"),
+							ProviderConfigAddr:         mustDefaultRootProvider("testing"),
+							NewStateSrc:                nil,
+							Schema:                     providers.Schema{},
+						},
+					},
+				},
+			},
+		},
+		"removed embedded component local": {
 			path: filepath.Join("with-single-input", "removed-embedded-component"),
 			state: stackstate.NewStateBuilder().
 				AddComponentInstance(stackstate.NewComponentInstanceBuilder(mustAbsComponentInstance("stack.a.component.self")).

--- a/internal/stacks/stackruntime/hooks/component.go
+++ b/internal/stacks/stackruntime/hooks/component.go
@@ -12,3 +12,9 @@ type ComponentInstances struct {
 	ComponentAddr stackaddrs.AbsComponent
 	InstanceAddrs []stackaddrs.AbsComponentInstance
 }
+
+// RemovedInstances is the argument type for the RemovedExpanded hook callback.
+type RemovedInstances struct {
+	Source        stackaddrs.StackInstance
+	InstanceAddrs []stackaddrs.AbsComponentInstance
+}

--- a/internal/stacks/stackruntime/internal/stackeval/component_config.go
+++ b/internal/stacks/stackruntime/internal/stackeval/component_config.go
@@ -55,6 +55,10 @@ func newComponentConfig(main *Main, addr stackaddrs.ConfigComponent, config *sta
 	}
 }
 
+func (c *ComponentConfig) TargetComponentAbsolute() stackaddrs.ConfigComponent {
+	return c.Addr()
+}
+
 func (c *ComponentConfig) Addr() stackaddrs.ConfigComponent {
 	return c.addr
 }
@@ -314,7 +318,7 @@ func (c *ComponentConfig) checkValid(ctx context.Context, phase EvalPhase) tfdia
 			return diags, nil
 		}
 
-		providerSchemas, moreDiags, skipFurtherValidation := neededProviderSchemas(ctx, c.main, phase, c)
+		providerSchemas, moreDiags, skipFurtherValidation := neededProviderSchemas[stackaddrs.ConfigComponent](ctx, c.main, phase, c)
 		if skipFurtherValidation {
 			return diags.Append(moreDiags), nil
 		}

--- a/internal/stacks/stackruntime/internal/stackeval/component_instance.go
+++ b/internal/stacks/stackruntime/internal/stackeval/component_instance.go
@@ -58,6 +58,10 @@ func newComponentInstance(call *Component, key addrs.InstanceKey, repetition ins
 	return component
 }
 
+func (c *ComponentInstance) TargetComponentAbsolute() stackaddrs.AbsComponentInstance {
+	return c.Addr()
+}
+
 func (c *ComponentInstance) Addr() stackaddrs.AbsComponentInstance {
 	callAddr := c.call.Addr()
 	stackAddr := callAddr.Stack

--- a/internal/stacks/stackruntime/internal/stackeval/expressions.go
+++ b/internal/stacks/stackruntime/internal/stackeval/expressions.go
@@ -85,24 +85,25 @@ type ExpressionScope interface {
 // [EvalExprAndEvalContext] is a convenient wrapper around this which also does
 // the final step of evaluating the expression, returning both the value
 // and the evaluation context that was used to build it.
-func EvalContextForExpr(ctx context.Context, expr hcl.Expression, functions lang.ExternalFuncs, phase EvalPhase, scope ExpressionScope) (*hcl.EvalContext, tfdiags.Diagnostics) {
-	return evalContextForTraversals(ctx, expr.Variables(), functions, phase, scope)
+func EvalContextForExpr(ctx context.Context, expr hcl.Expression, phase EvalPhase, scope ExpressionScope) (*hcl.EvalContext, tfdiags.Diagnostics) {
+	return evalContextForTraversals(ctx, expr.Variables(), phase, scope)
 }
 
 // EvalContextForBody produces an HCL expression context for decoding the
 // given [hcl.Body] into a value using the given [hcldec.Spec].
-func EvalContextForBody(ctx context.Context, body hcl.Body, spec hcldec.Spec, functions lang.ExternalFuncs, phase EvalPhase, scope ExpressionScope) (*hcl.EvalContext, tfdiags.Diagnostics) {
+func EvalContextForBody(ctx context.Context, body hcl.Body, spec hcldec.Spec, phase EvalPhase, scope ExpressionScope) (*hcl.EvalContext, tfdiags.Diagnostics) {
 	if body == nil {
 		panic("EvalContextForBody with nil body")
 	}
 	if spec == nil {
 		panic("EvalContextForBody with nil spec")
 	}
-	return evalContextForTraversals(ctx, hcldec.Variables(body, spec), functions, phase, scope)
+	return evalContextForTraversals(ctx, hcldec.Variables(body, spec), phase, scope)
 }
 
-func evalContextForTraversals(ctx context.Context, traversals []hcl.Traversal, functions lang.ExternalFuncs, phase EvalPhase, scope ExpressionScope) (*hcl.EvalContext, tfdiags.Diagnostics) {
-	var diags tfdiags.Diagnostics
+func evalContextForTraversals(ctx context.Context, traversals []hcl.Traversal, phase EvalPhase, scope ExpressionScope) (*hcl.EvalContext, tfdiags.Diagnostics) {
+	functions, diags := scope.ExternalFunctions(ctx)
+
 	refs := make(map[stackaddrs.Referenceable]Referenceable)
 	for _, traversal := range traversals {
 		ref, _, moreDiags := stackaddrs.ParseReference(traversal)
@@ -355,10 +356,7 @@ func EvalComponentInputVariables(ctx context.Context, decls map[string]*configs.
 // the caller will need the HCL evaluation context in order to construct
 // a fully-annotated diagnostic object.
 func EvalExprAndEvalContext(ctx context.Context, expr hcl.Expression, phase EvalPhase, scope ExpressionScope) (ExprResultValue, tfdiags.Diagnostics) {
-	functions, diags := scope.ExternalFunctions(ctx)
-
-	hclCtx, evalDiags := EvalContextForExpr(ctx, expr, functions, phase, scope)
-	diags = diags.Append(evalDiags)
+	hclCtx, diags := EvalContextForExpr(ctx, expr, phase, scope)
 	if hclCtx == nil {
 		return ExprResultValue{
 			Value:       cty.NilVal,
@@ -393,10 +391,7 @@ func EvalExpr(ctx context.Context, expr hcl.Expression, phase EvalPhase, scope E
 // EvalBody evaluates the expressions in the given body using hcldec with
 // the given schema, returning the resulting value.
 func EvalBody(ctx context.Context, body hcl.Body, spec hcldec.Spec, phase EvalPhase, scope ExpressionScope) (cty.Value, tfdiags.Diagnostics) {
-	functions, diags := scope.ExternalFunctions(ctx)
-
-	hclCtx, moreDiags := EvalContextForBody(ctx, body, spec, functions, phase, scope)
-	diags = diags.Append(moreDiags)
+	hclCtx, diags := EvalContextForBody(ctx, body, spec, phase, scope)
 	if hclCtx == nil {
 		return cty.NilVal, diags
 	}

--- a/internal/stacks/stackruntime/internal/stackeval/hooks.go
+++ b/internal/stacks/stackruntime/internal/stackeval/hooks.go
@@ -54,6 +54,10 @@ type Hooks struct {
 	// expansion argument for a component, resulting in zero or more instances.
 	ComponentExpanded hooks.SingleFunc[*hooks.ComponentInstances]
 
+	// RemovedExpanded is called when a plan operation evaluates the expansion
+	// argument for a removed block.
+	RemovedExpanded hooks.SingleFunc[*hooks.RemovedInstances]
+
 	// PendingComponentInstancePlan is called at the start of the plan
 	// operation, before evaluating the component instance's inputs and
 	// providers.

--- a/internal/stacks/stackruntime/internal/stackeval/main.go
+++ b/internal/stacks/stackruntime/internal/stackeval/main.go
@@ -18,6 +18,7 @@ import (
 	"github.com/hashicorp/terraform/internal/addrs"
 	fileProvisioner "github.com/hashicorp/terraform/internal/builtin/provisioners/file"
 	remoteExecProvisioner "github.com/hashicorp/terraform/internal/builtin/provisioners/remote-exec"
+	"github.com/hashicorp/terraform/internal/collections"
 	"github.com/hashicorp/terraform/internal/depsfile"
 	"github.com/hashicorp/terraform/internal/lang"
 	"github.com/hashicorp/terraform/internal/promising"
@@ -287,7 +288,7 @@ func (m *Main) MainStackConfig(ctx context.Context) *StackConfig {
 	defer m.mu.Unlock()
 
 	if m.mainStackConfig == nil {
-		m.mainStackConfig = newStackConfig(m, stackaddrs.RootStack, m.config.Root)
+		m.mainStackConfig = newStackConfig(m, stackaddrs.RootStack, m.config.Root, collections.NewMap[stackaddrs.ConfigComponent, []*RemovedConfig]())
 	}
 	return m.mainStackConfig
 }
@@ -299,7 +300,7 @@ func (m *Main) MainStack(ctx context.Context) *Stack {
 	defer m.mu.Unlock()
 
 	if m.mainStack == nil {
-		m.mainStack = newStack(m, stackaddrs.RootStackInstance)
+		m.mainStack = newStack(m, stackaddrs.RootStackInstance, collections.NewMap[stackaddrs.ConfigComponent, []*Removed]())
 	}
 	return m.mainStack
 }

--- a/internal/stacks/stackruntime/internal/stackeval/main_apply.go
+++ b/internal/stacks/stackruntime/internal/stackeval/main_apply.go
@@ -102,7 +102,7 @@ func ApplyPlan(ctx context.Context, config *stackconfig.Config, plan *stackplan.
 						if removed != nil {
 						Blocks:
 							for _, block := range removed {
-								if insts, unknown, _ := block.Instances(ctx, ApplyPhase); unknown {
+								if insts, unknown, _ := block.InstancesFor(ctx, addr.Stack, ApplyPhase); unknown {
 									// It might be that either the removed block
 									// or component block was deferred but the
 									// other one had proper changes. We'll note
@@ -240,7 +240,7 @@ func ApplyPlan(ctx context.Context, config *stackconfig.Config, plan *stackplan.
 						}
 						for waitComponentAddr := range waitForRemoveds.All() {
 							if stack := main.Stack(ctx, waitComponentAddr.Stack, ApplyPhase); stack != nil {
-								if removed := stack.Removed(ctx, waitComponentAddr.Item); removed != nil {
+								if removed := stack.LocalRemovedBlocks(ctx, waitComponentAddr.Item); removed != nil {
 									span.AddEvent("awaiting predecessor", trace.WithAttributes(
 										attribute.String("component_addr", waitComponentAddr.String()),
 									))

--- a/internal/stacks/stackruntime/internal/stackeval/planning.go
+++ b/internal/stacks/stackruntime/internal/stackeval/planning.go
@@ -61,7 +61,7 @@ type Plannable interface {
 func PlanComponentInstance(ctx context.Context, main *Main, state *states.State, opts *terraform.PlanOpts, scope ConfigComponentExpressionScope[stackaddrs.AbsComponentInstance]) (*plans.Plan, tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
 
-	addr := scope.Addr()
+	addr := scope.TargetComponentAbsolute()
 
 	h := hooksFromContext(ctx)
 	hookSingle(ctx, hooksFromContext(ctx).PendingComponentInstancePlan, addr)

--- a/internal/stacks/stackruntime/internal/stackeval/provider_expressions.go
+++ b/internal/stacks/stackruntime/internal/stackeval/provider_expressions.go
@@ -28,7 +28,7 @@ import (
 type ConfigComponentExpressionScope[Addr any] interface {
 	ExpressionScope
 
-	Addr() Addr
+	TargetComponentAbsolute() Addr
 	ModuleTree(ctx context.Context) *configs.Config
 	DeclRange(ctx context.Context) *hcl.Range
 }
@@ -66,7 +66,7 @@ func EvalProviderTypes(ctx context.Context, stack *StackConfig, providers map[ad
 				Summary:  "Missing required provider configuration",
 				Detail: fmt.Sprintf(
 					"The root module for %s requires a provider configuration named %q for provider %q, which is not assigned in the block's \"providers\" argument.",
-					scope.Addr(), componentAddr.StringCompact(), typeAddr.ForDisplay(),
+					scope.TargetComponentAbsolute(), componentAddr.StringCompact(), typeAddr.ForDisplay(),
 				),
 				Subject: scope.DeclRange(ctx),
 			})
@@ -219,7 +219,7 @@ func EvalProviderValues(ctx context.Context, main *Main, providers map[addrs.Loc
 	//   store the additional information we need. Once this is fixed we can
 	//   come and tidy this up as well.
 
-	stackConfig := main.StackConfig(ctx, scope.Addr().Stack.ConfigAddr())
+	stackConfig := main.StackConfig(ctx, scope.TargetComponentAbsolute().Stack.ConfigAddr())
 	moduleTree := scope.ModuleTree(ctx)
 
 	// We'll search through the declConfigs to find any keys that match the
@@ -227,7 +227,7 @@ func EvalProviderValues(ctx context.Context, main *Main, providers map[addrs.Loc
 	// when compared to how we resolved the configProviders. But we don't have
 	// the information we need to do it the other way around.
 
-	previousProviders := main.PreviousProviderInstances(scope.Addr(), phase)
+	previousProviders := main.PreviousProviderInstances(scope.TargetComponentAbsolute(), phase)
 	for localProviderAddr, expr := range providers {
 		provider := moduleTree.ProviderForConfigAddr(localProviderAddr)
 
@@ -270,7 +270,7 @@ func EvalProviderValues(ctx context.Context, main *Main, providers map[addrs.Loc
 				Summary:  "Block requires undeclared provider",
 				Detail: fmt.Sprintf(
 					"The root module for %s has resources in state that require a configuration for provider %q, which isn't declared as a dependency of this stack configuration.\n\nDeclare this provider in the stack's required_providers block, and then assign a configuration for that provider in this block's \"providers\" argument.",
-					scope.Addr(), provider.ForDisplay(),
+					scope.TargetComponentAbsolute(), provider.ForDisplay(),
 				),
 				Subject: scope.DeclRange(ctx),
 			})
@@ -301,7 +301,7 @@ func EvalProviderValues(ctx context.Context, main *Main, providers map[addrs.Loc
 			Summary:  "Missing required provider configuration",
 			Detail: fmt.Sprintf(
 				"The root module for %s has resources in state that require a provider configuration named %q for provider %q, which is not assigned in the block's \"providers\" argument.",
-				scope.Addr(), localAddr.StringCompact(), previousProvider.Provider.ForDisplay(),
+				scope.TargetComponentAbsolute(), localAddr.StringCompact(), previousProvider.Provider.ForDisplay(),
 			),
 			Subject: scope.DeclRange(ctx),
 		})

--- a/internal/stacks/stackruntime/internal/stackeval/removed_instance.go
+++ b/internal/stacks/stackruntime/internal/stackeval/removed_instance.go
@@ -66,27 +66,13 @@ func (r *RemovedInstance) Addr() stackaddrs.AbsComponentInstance {
 	return r.from
 }
 
+func (r *RemovedInstance) TargetComponentAbsolute() stackaddrs.AbsComponentInstance {
+	return r.from
+}
+
 func (r *RemovedInstance) ModuleTreePlan(ctx context.Context) (*plans.Plan, tfdiags.Diagnostics) {
 	return doOnceWithDiags(ctx, &r.moduleTreePlan, r.main, func(ctx context.Context) (*plans.Plan, tfdiags.Diagnostics) {
 		var diags tfdiags.Diagnostics
-
-		component := r.main.Stack(ctx, r.Addr().Stack, PlanPhase).Component(ctx, r.Addr().Item.Component)
-		if component != nil {
-			insts, unknown := component.Instances(ctx, PlanPhase)
-			if !unknown {
-				if _, exists := insts[r.Addr().Item.Key]; exists {
-					// The instance we're planning to remove is also targeted
-					// by a component block. We won't remove it, and we'll
-					// report a diagnostic to that effect.
-					return nil, diags.Append(&hcl.Diagnostic{
-						Severity: hcl.DiagError,
-						Summary:  "Cannot remove component instance",
-						Detail:   fmt.Sprintf("The component instance %s is targeted by a component block and cannot be removed. The relevant component is defined at %s.", r.Addr(), component.Declaration(ctx).DeclRange.ToHCL()),
-						Subject:  r.DeclRange(ctx),
-					})
-				}
-			}
-		}
 
 		known, unknown, moreDiags := EvalProviderValues(ctx, r.main, r.call.Config(ctx).config.ProviderConfigs, PlanPhase, r)
 		if moreDiags.HasErrors() {

--- a/internal/stacks/stackruntime/internal/stackeval/walk_static.go
+++ b/internal/stacks/stackruntime/internal/stackeval/walk_static.go
@@ -64,7 +64,7 @@ func walkStaticObjectsInStackConfig[Output any](
 		visit(ctx, walk, obj)
 	}
 
-	for _, objs := range stackConfig.Removeds(ctx) {
+	for _, objs := range stackConfig.AllLocalRemovedBlocks(ctx) {
 		for _, obj := range objs {
 			visit(ctx, walk, obj)
 		}

--- a/internal/stacks/stackruntime/testdata/mainbundle/test/with-single-input/removed-component-from-stack-dynamic/removed-component-from-stack-dynamic.tfstack.hcl
+++ b/internal/stacks/stackruntime/testdata/mainbundle/test/with-single-input/removed-component-from-stack-dynamic/removed-component-from-stack-dynamic.tfstack.hcl
@@ -1,0 +1,69 @@
+required_providers {
+  testing = {
+    source  = "hashicorp/testing"
+    version = "0.1.0"
+  }
+}
+
+provider "testing" "default" {}
+
+variable "for_each_input" {
+  type = map(string)
+  default = {}
+}
+
+variable "for_each_removed" {
+  type = set(string)
+  default = []
+}
+
+variable "simple_input" {
+  type = map(string)
+  default = {}
+}
+
+variable "simple_removed" {
+  type = set(string)
+  default = []
+}
+
+stack "for_each" {
+  source = "../for-each-component"
+
+  inputs = {
+    input = var.for_each_input
+  }
+}
+
+removed {
+  for_each = var.for_each_removed
+
+  from = stack.for_each.component.self[each.key]
+  source = "../"
+
+  providers = {
+    testing = provider.testing.default
+  }
+}
+
+stack "simple" {
+  for_each = var.simple_input
+
+  source = "../valid"
+
+  inputs = {
+    id = each.key
+    input = each.value
+  }
+}
+
+removed {
+  for_each = var.simple_removed
+
+  from = stack.simple[each.key].component.self
+  source = "../"
+
+  providers = {
+    testing = provider.testing.default
+  }
+}

--- a/internal/stacks/stackruntime/testdata/mainbundle/test/with-single-input/removed-component-from-stack/removed-component-from-stack.tfstack.hcl
+++ b/internal/stacks/stackruntime/testdata/mainbundle/test/with-single-input/removed-component-from-stack/removed-component-from-stack.tfstack.hcl
@@ -1,0 +1,25 @@
+required_providers {
+  testing = {
+    source  = "hashicorp/testing"
+    version = "0.1.0"
+  }
+}
+
+provider "testing" "default" {}
+
+stack "nested" {
+  source = "../for-each-component"
+
+  inputs = {
+    input = {}
+  }
+}
+
+removed {
+  from = stack.nested.component.self["foo"]
+  source = "../"
+
+  providers = {
+    testing = provider.testing.default
+  }
+}


### PR DESCRIPTION
This PR updates removed blocks in stacks so that you can target components within nested stacks. This means that users can change input values into embedded stacks that might edit the number of components internally, and add removed blocks within the root stack that target any components removed by the change.

Unfortunately, this is a very complicated change - so perhaps I can sit down with anyone who wants to review this and go through it with them.

The general approach is that the `from` attribute of removed blocks now resolves to a full absolute address. Stack instances are now initialised with any external removed blocks in the constructor. So parent stacks pass in any removed blocks they have that target child stacks directly into the child stack. Then the removed blocks are still processed by the stack that actually contains the components that they target, this allows us to ensure that component and removed blocks don't target the same instance easily, and that removed blocks defined locally don't clash with removed blocks defined externally.

There is a "very large ™️" change to the plan_test file, that involves moving tests around to group similar tests into the same execution block to simplify things overall. For that, I am sorry.