### PR TITLE
Terraform Test: Allow skipping cleanup of entire test file or individual run blocks

### DIFF
--- a/internal/command/testdata/test/skip_cleanup/main.tf
+++ b/internal/command/testdata/test/skip_cleanup/main.tf
@@ -1,0 +1,11 @@
+variable "id" {
+  type = string
+}
+
+resource "test_resource" "resource" {
+  value = var.id
+}
+
+output "id" {
+  value = test_resource.resource.id
+}

--- a/internal/command/testdata/test/skip_cleanup/main.tftest.hcl
+++ b/internal/command/testdata/test/skip_cleanup/main.tftest.hcl
@@ -1,0 +1,31 @@
+run "test" {
+  variables {
+    id = "test"
+  }
+}
+
+run "test_two" {
+  skip_cleanup = true
+  variables {
+    id = "test_two"
+  }
+}
+
+run "test_three" {
+  skip_cleanup = true
+  variables {
+    id = "test_three"
+  }
+}
+
+run "test_four" {
+  variables {
+    id = "test_four"
+  }
+}
+
+run "test_five" {
+  variables {
+    id = "test_five"
+  }
+}

--- a/internal/command/testdata/test/skip_file_cleanup/main.tf
+++ b/internal/command/testdata/test/skip_file_cleanup/main.tf
@@ -1,0 +1,11 @@
+variable "id" {
+  type = string
+}
+
+resource "test_resource" "resource" {
+  value = var.id
+}
+
+output "id" {
+  value = test_resource.resource.id
+}

--- a/internal/command/testdata/test/skip_file_cleanup/main.tftest.hcl
+++ b/internal/command/testdata/test/skip_file_cleanup/main.tftest.hcl
@@ -1,0 +1,33 @@
+test {
+  skip_cleanup = true
+}
+
+run "test" {
+  variables {
+    id = "test"
+  }
+}
+
+run "test_two" {
+  variables {
+    id = "test_two"
+  }
+}
+
+run "test_three" {
+  variables {
+    id = "test_three"
+  }
+}
+
+run "test_four" {
+  variables {
+    id = "test_four"
+  }
+}
+
+run "test_five" {
+  variables {
+    id = "test_five"
+  }
+}

--- a/internal/command/views/test.go
+++ b/internal/command/views/test.go
@@ -275,7 +275,8 @@ func (t *TestHuman) DestroySummary(diags tfdiags.Diagnostics, run *moduletest.Ru
 	}
 	t.Diagnostics(run, file, diags)
 
-	if state.HasManagedResourceInstanceObjects() && !run.Config.SkipCleanup {
+	skipCleanup := run != nil && run.Config.SkipCleanup
+	if state.HasManagedResourceInstanceObjects() && !skipCleanup {
 		// FIXME: This message says "resources" but this is actually a list
 		// of resource instance objects.
 		t.view.streams.Eprint(format.WordWrap(fmt.Sprintf("\nTerraform left the following resources in state after executing %s, and they need to be cleaned up manually:\n", identifier), t.view.errorColumns()))
@@ -602,7 +603,8 @@ func (t *TestJSON) Run(run *moduletest.Run, file *moduletest.File, progress modu
 }
 
 func (t *TestJSON) DestroySummary(diags tfdiags.Diagnostics, run *moduletest.Run, file *moduletest.File, state *states.State) {
-	if state.HasManagedResourceInstanceObjects() && !run.Config.SkipCleanup {
+	skipCleanup := run != nil && run.Config.SkipCleanup
+	if state.HasManagedResourceInstanceObjects() && !skipCleanup {
 		cleanup := json.TestFileCleanup{}
 		for _, resource := range addrs.SetSortedNatural(state.AllManagedResourceInstanceObjectAddrs()) {
 			cleanup.FailedResources = append(cleanup.FailedResources, json.TestFailedResource{

--- a/internal/command/views/test.go
+++ b/internal/command/views/test.go
@@ -50,7 +50,7 @@ type Test interface {
 
 	// DestroySummary prints out the summary of the destroy step of each test
 	// file. If everything goes well, this should be empty.
-	DestroySummary(diags tfdiags.Diagnostics, run *moduletest.Run, file *moduletest.File, state *states.State)
+	DestroySummary(diags tfdiags.Diagnostics, run *moduletest.Run, file *moduletest.File, state *states.State, allowNonEmpty bool)
 
 	// Diagnostics prints out the provided diagnostics.
 	Diagnostics(run *moduletest.Run, file *moduletest.File, diags tfdiags.Diagnostics)
@@ -264,7 +264,7 @@ func (t *TestHuman) Run(run *moduletest.Run, file *moduletest.File, progress mod
 	}
 }
 
-func (t *TestHuman) DestroySummary(diags tfdiags.Diagnostics, run *moduletest.Run, file *moduletest.File, state *states.State) {
+func (t *TestHuman) DestroySummary(diags tfdiags.Diagnostics, run *moduletest.Run, file *moduletest.File, state *states.State, allowNonEmpty bool) {
 	identifier := file.Name
 	if run != nil {
 		identifier = fmt.Sprintf("%s/%s", identifier, run.Name)
@@ -275,7 +275,7 @@ func (t *TestHuman) DestroySummary(diags tfdiags.Diagnostics, run *moduletest.Ru
 	}
 	t.Diagnostics(run, file, diags)
 
-	if state.HasManagedResourceInstanceObjects() {
+	if state.HasManagedResourceInstanceObjects() && !allowNonEmpty {
 		// FIXME: This message says "resources" but this is actually a list
 		// of resource instance objects.
 		t.view.streams.Eprint(format.WordWrap(fmt.Sprintf("\nTerraform left the following resources in state after executing %s, and they need to be cleaned up manually:\n", identifier), t.view.errorColumns()))
@@ -601,8 +601,8 @@ func (t *TestJSON) Run(run *moduletest.Run, file *moduletest.File, progress modu
 	t.Diagnostics(run, file, run.Diagnostics)
 }
 
-func (t *TestJSON) DestroySummary(diags tfdiags.Diagnostics, run *moduletest.Run, file *moduletest.File, state *states.State) {
-	if state.HasManagedResourceInstanceObjects() {
+func (t *TestJSON) DestroySummary(diags tfdiags.Diagnostics, run *moduletest.Run, file *moduletest.File, state *states.State, allowNonEmpty bool) {
+	if state.HasManagedResourceInstanceObjects() && !allowNonEmpty {
 		cleanup := json.TestFileCleanup{}
 		for _, resource := range addrs.SetSortedNatural(state.AllManagedResourceInstanceObjectAddrs()) {
 			cleanup.FailedResources = append(cleanup.FailedResources, json.TestFailedResource{

--- a/internal/command/views/test_test.go
+++ b/internal/command/views/test_test.go
@@ -480,7 +480,7 @@ func TestTestHuman_Run(t *testing.T) {
 		StdErr   string
 	}{
 		"pass": {
-			Run:      &moduletest.Run{Name: "run_block", Status: moduletest.Pass},
+			Run:      &moduletest.Run{Name: "run_block", Config: &configs.TestRun{}, Status: moduletest.Pass},
 			Progress: moduletest.Complete,
 			StdOut:   "  run \"run_block\"... pass\n",
 		},
@@ -502,19 +502,19 @@ some warning happened during this test
 		},
 
 		"pending": {
-			Run:      &moduletest.Run{Name: "run_block", Status: moduletest.Pending},
+			Run:      &moduletest.Run{Name: "run_block", Config: &configs.TestRun{}, Status: moduletest.Pending},
 			Progress: moduletest.Complete,
 			StdOut:   "  run \"run_block\"... pending\n",
 		},
 
 		"skip": {
-			Run:      &moduletest.Run{Name: "run_block", Status: moduletest.Skip},
+			Run:      &moduletest.Run{Name: "run_block", Config: &configs.TestRun{}, Status: moduletest.Skip},
 			Progress: moduletest.Complete,
 			StdOut:   "  run \"run_block\"... skip\n",
 		},
 
 		"fail": {
-			Run:      &moduletest.Run{Name: "run_block", Status: moduletest.Fail},
+			Run:      &moduletest.Run{Name: "run_block", Config: &configs.TestRun{}, Status: moduletest.Fail},
 			Progress: moduletest.Complete,
 			StdOut:   "  run \"run_block\"... fail\n",
 		},
@@ -542,7 +542,7 @@ other details
 		},
 
 		"error": {
-			Run:      &moduletest.Run{Name: "run_block", Status: moduletest.Error},
+			Run:      &moduletest.Run{Name: "run_block", Config: &configs.TestRun{}, Status: moduletest.Error},
 			Progress: moduletest.Complete,
 			StdOut:   "  run \"run_block\"... fail\n",
 		},
@@ -725,15 +725,15 @@ resource "test_resource" "creating" {
 		// These next three tests should print nothing, as we only report on
 		// progress complete.
 		"progress_starting": {
-			Run:      &moduletest.Run{Name: "run_block", Status: moduletest.Pass},
+			Run:      &moduletest.Run{Name: "run_block", Config: &configs.TestRun{}, Status: moduletest.Pass},
 			Progress: moduletest.Starting,
 		},
 		"progress_running": {
-			Run:      &moduletest.Run{Name: "run_block", Status: moduletest.Pass},
+			Run:      &moduletest.Run{Name: "run_block", Config: &configs.TestRun{}, Status: moduletest.Pass},
 			Progress: moduletest.Running,
 		},
 		"progress_teardown": {
-			Run:      &moduletest.Run{Name: "run_block", Status: moduletest.Pass},
+			Run:      &moduletest.Run{Name: "run_block", Config: &configs.TestRun{}, Status: moduletest.Pass},
 			Progress: moduletest.TearDown,
 		},
 	}
@@ -822,7 +822,7 @@ this time it is very bad
 			diags: tfdiags.Diagnostics{
 				tfdiags.Sourceless(tfdiags.Error, "first error", "this time it is very bad"),
 			},
-			run:   &moduletest.Run{Name: "run_block"},
+			run:   &moduletest.Run{Name: "run_block", Config: &configs.TestRun{}},
 			file:  &moduletest.File{Name: "main.tftest.hcl"},
 			state: states.NewState(),
 			stderr: `Terraform encountered an error destroying resources created while executing
@@ -1973,7 +1973,7 @@ func TestTestJSON_DestroySummary(t *testing.T) {
 		},
 		"state_from_run": {
 			file: &moduletest.File{Name: "main.tftest.hcl"},
-			run:  &moduletest.Run{Name: "run_block"},
+			run:  &moduletest.Run{Name: "run_block", Config: &configs.TestRun{}},
 			state: states.BuildState(func(state *states.SyncState) {
 				state.SetResourceInstanceCurrent(
 					addrs.Resource{
@@ -2380,7 +2380,7 @@ func TestTestJSON_Run(t *testing.T) {
 		want     []map[string]interface{}
 	}{
 		"starting": {
-			run:      &moduletest.Run{Name: "run_block", Status: moduletest.Pass},
+			run:      &moduletest.Run{Name: "run_block", Config: &configs.TestRun{}, Status: moduletest.Pass},
 			progress: moduletest.Starting,
 			want: []map[string]interface{}{
 				{
@@ -2401,7 +2401,7 @@ func TestTestJSON_Run(t *testing.T) {
 		},
 
 		"running": {
-			run:      &moduletest.Run{Name: "run_block", Status: moduletest.Pass},
+			run:      &moduletest.Run{Name: "run_block", Config: &configs.TestRun{}, Status: moduletest.Pass},
 			progress: moduletest.Running,
 			elapsed:  2024,
 			want: []map[string]interface{}{
@@ -2423,7 +2423,7 @@ func TestTestJSON_Run(t *testing.T) {
 		},
 
 		"teardown": {
-			run:      &moduletest.Run{Name: "run_block", Status: moduletest.Pass},
+			run:      &moduletest.Run{Name: "run_block", Config: &configs.TestRun{}, Status: moduletest.Pass},
 			progress: moduletest.TearDown,
 			want: []map[string]interface{}{
 				{
@@ -2444,7 +2444,7 @@ func TestTestJSON_Run(t *testing.T) {
 		},
 
 		"pass": {
-			run:      &moduletest.Run{Name: "run_block", Status: moduletest.Pass},
+			run:      &moduletest.Run{Name: "run_block", Config: &configs.TestRun{}, Status: moduletest.Pass},
 			progress: moduletest.Complete,
 			want: []map[string]interface{}{
 				{
@@ -2503,7 +2503,7 @@ func TestTestJSON_Run(t *testing.T) {
 		},
 
 		"pending": {
-			run:      &moduletest.Run{Name: "run_block", Status: moduletest.Pending},
+			run:      &moduletest.Run{Name: "run_block", Config: &configs.TestRun{}, Status: moduletest.Pending},
 			progress: moduletest.Complete,
 			want: []map[string]interface{}{
 				{
@@ -2524,7 +2524,7 @@ func TestTestJSON_Run(t *testing.T) {
 		},
 
 		"skip": {
-			run:      &moduletest.Run{Name: "run_block", Status: moduletest.Skip},
+			run:      &moduletest.Run{Name: "run_block", Config: &configs.TestRun{}, Status: moduletest.Skip},
 			progress: moduletest.Complete,
 			want: []map[string]interface{}{
 				{
@@ -2545,7 +2545,7 @@ func TestTestJSON_Run(t *testing.T) {
 		},
 
 		"fail": {
-			run:      &moduletest.Run{Name: "run_block", Status: moduletest.Fail},
+			run:      &moduletest.Run{Name: "run_block", Config: &configs.TestRun{}, Status: moduletest.Fail},
 			progress: moduletest.Complete,
 			want: []map[string]interface{}{
 				{
@@ -2620,7 +2620,7 @@ func TestTestJSON_Run(t *testing.T) {
 		},
 
 		"error": {
-			run:      &moduletest.Run{Name: "run_block", Status: moduletest.Error},
+			run:      &moduletest.Run{Name: "run_block", Config: &configs.TestRun{}, Status: moduletest.Error},
 			progress: moduletest.Complete,
 			want: []map[string]interface{}{
 				{

--- a/internal/command/views/test_test.go
+++ b/internal/command/views/test_test.go
@@ -976,7 +976,7 @@ main.tftest.hcl, and they need to be cleaned up manually:
 			streams, done := terminal.StreamsForTesting(t)
 			view := NewTest(arguments.ViewHuman, NewView(streams))
 
-			view.DestroySummary(tc.diags, tc.run, tc.file, tc.state, false)
+			view.DestroySummary(tc.diags, tc.run, tc.file, tc.state)
 
 			output := done(t)
 			actual, expected := output.Stdout(), tc.stdout
@@ -2218,7 +2218,7 @@ func TestTestJSON_DestroySummary(t *testing.T) {
 			streams, done := terminal.StreamsForTesting(t)
 			view := NewTest(arguments.ViewJSON, NewView(streams))
 
-			view.DestroySummary(tc.diags, tc.run, tc.file, tc.state, false)
+			view.DestroySummary(tc.diags, tc.run, tc.file, tc.state)
 			testJSONViewOutputEquals(t, done(t).All(), tc.want)
 		})
 	}

--- a/internal/command/views/test_test.go
+++ b/internal/command/views/test_test.go
@@ -976,7 +976,7 @@ main.tftest.hcl, and they need to be cleaned up manually:
 			streams, done := terminal.StreamsForTesting(t)
 			view := NewTest(arguments.ViewHuman, NewView(streams))
 
-			view.DestroySummary(tc.diags, tc.run, tc.file, tc.state)
+			view.DestroySummary(tc.diags, tc.run, tc.file, tc.state, false)
 
 			output := done(t)
 			actual, expected := output.Stdout(), tc.stdout
@@ -2218,7 +2218,7 @@ func TestTestJSON_DestroySummary(t *testing.T) {
 			streams, done := terminal.StreamsForTesting(t)
 			view := NewTest(arguments.ViewJSON, NewView(streams))
 
-			view.DestroySummary(tc.diags, tc.run, tc.file, tc.state)
+			view.DestroySummary(tc.diags, tc.run, tc.file, tc.state, false)
 			testJSONViewOutputEquals(t, done(t).All(), tc.want)
 		})
 	}

--- a/internal/configs/test_file.go
+++ b/internal/configs/test_file.go
@@ -168,7 +168,8 @@ type TestRun struct {
 	Backend *Backend
 
 	// SkipCleanup: Indicates if the test run should skip the cleanup phase.
-	SkipCleanup bool
+	SkipCleanup    bool
+	SkipCleanupSet bool
 
 	NameDeclRange      hcl.Range
 	VariablesDeclRange hcl.Range
@@ -582,7 +583,7 @@ func decodeFileConfigBlock(fileContent *hcl.BodyContent) (*TestFileConfig, hcl.D
 	}
 
 	if attr, exists := content.Attributes["skip_cleanup"]; exists {
-		rawDiags := gohcl.DecodeExpression(attr.Expr, nil, &ret.Parallel)
+		rawDiags := gohcl.DecodeExpression(attr.Expr, nil, &ret.SkipCleanup)
 		diags = append(diags, rawDiags...)
 	}
 
@@ -837,6 +838,7 @@ func decodeTestRunBlock(block *hcl.Block, file *TestFile) (*TestRun, hcl.Diagnos
 	if attr, exists := content.Attributes["skip_cleanup"]; exists {
 		rawDiags := gohcl.DecodeExpression(attr.Expr, nil, &r.SkipCleanup)
 		diags = append(diags, rawDiags...)
+		r.SkipCleanupSet = true
 	}
 
 	return &r, diags

--- a/internal/moduletest/graph/transform_state_cleanup.go
+++ b/internal/moduletest/graph/transform_state_cleanup.go
@@ -4,6 +4,7 @@
 package graph
 
 import (
+	"fmt"
 	"slices"
 
 	"github.com/hashicorp/terraform/internal/dag"
@@ -20,49 +21,68 @@ type TestStateCleanupTransformer struct {
 
 func (t *TestStateCleanupTransformer) Transform(g *terraform.Graph) error {
 	cleanupMap := make(map[string]*NodeStateCleanup)
-
-	for node := range dag.SelectSeq(g.VerticesSeq(), runFilter) {
-		key := node.run.Config.StateKey
-		if _, exists := cleanupMap[key]; !exists {
-			cleanupMap[key] = &NodeStateCleanup{stateKey: key, opts: t.opts}
-			g.Add(cleanupMap[key])
-		}
-
-		// Connect the cleanup node to the test run node.
-		g.Connect(dag.BasicEdge(cleanupMap[key], node))
-	}
+	runsMap := make(map[string]*NodeTestRun)
 
 	// Add a root cleanup node that runs before cleanup nodes for each state.
 	// Right now it just simply renders a teardown summary, so as to maintain
 	// existing CLI output.
 	rootCleanupNode := t.addRootCleanupNode(g)
 
-	for v := range g.VerticesSeq() {
-		switch node := v.(type) {
-		case *NodeTestRun:
-			// All the runs that share the same state, must share the same cleanup node,
-			// which only executes once after all the dependent runs have completed.
-			g.Connect(dag.BasicEdge(rootCleanupNode, node))
-		case *NodeStateCleanup:
-			// Connect the cleanup node to the root cleanup node.
-			g.Connect(dag.BasicEdge(node, rootCleanupNode))
+	for node := range dag.SelectSeq(g.VerticesSeq(), runFilter) {
+		runsMap[node.run.Config.Name] = node // Add all runs to the map, so we can reference them by name later
+
+		// Create a cleanup node for each state key
+		key := node.run.Config.StateKey
+		if _, exists := cleanupMap[key]; !exists {
+			cleanupMap[key] = &NodeStateCleanup{stateKey: key, opts: t.opts}
+			g.Add(cleanupMap[key])
 		}
+
+		// All the runs that share the same state, must share the same cleanup node,
+		// which only executes once after all the dependent runs have completed.
+		g.Connect(dag.BasicEdge(cleanupMap[key], node))
+
+		// Connect cleanup nodes to root cleanup node
+		g.Connect(dag.BasicEdge(cleanupMap[key], rootCleanupNode))
+
+		// All runs must be executed before the root cleanup node
+		g.Connect(dag.BasicEdge(rootCleanupNode, node))
+
 	}
 
-	// connect all cleanup nodes in reverse-sequential order of run index to
-	// preserve existing behavior, starting from the root cleanup node.
-	// TODO: Parallelize cleanup nodes execution instead of sequential.
+	// Keep track of processed state keys to avoid duplicate connections
 	added := make(map[string]bool)
 	var prev dag.Vertex
+
+	// Process skip_cleanup attributes and connect all cleanup nodes in
+	// reverse order of run index to preserve existing behavior.
+	// TODO: Parallelize cleanup nodes execution instead of sequential.
 	for _, v := range slices.Backward(t.opts.File.Runs) {
 		key := v.Config.StateKey
+		node := cleanupMap[key]
+
+		// Process each state key only once
 		if _, exists := added[key]; !exists {
-			node := cleanupMap[key]
 			if prev != nil {
 				g.Connect(dag.BasicEdge(node, prev))
 			}
 			prev = node
 			added[key] = true
+		}
+
+		// Handle skip_cleanup attribute
+		if v.Config.SkipCleanup {
+			if node.applyOverride != nil { // the node already has an applyOverride from a later run
+				v.Diagnostics = v.Diagnostics.Append(tfdiags.Sourceless(
+					tfdiags.Warning,
+					"Multiple runs with skip_cleanup set",
+					fmt.Sprintf(`The run %q has skip_cleanup set to true, but shares state with a later run %q that also has skip_cleanup set. The later run takes precedence, and this attribute is ignored for the earlier run.`,
+						v.Config.Name, node.applyOverride.Config.Name),
+				))
+				continue
+			}
+
+			node.applyOverride = v
 		}
 	}
 

--- a/internal/moduletest/graph/transform_test_run.go
+++ b/internal/moduletest/graph/transform_test_run.go
@@ -112,7 +112,7 @@ func (t *TestRunTransformer) connectDependencies(g *terraform.Graph, nodes []*No
 		}
 
 		// Connect to all previous runs
-		for j := 0; j < i; j++ {
+		for j := range i {
 			g.Connect(dag.BasicEdge(node, nodes[j]))
 		}
 

--- a/internal/moduletest/graph/wait.go
+++ b/internal/moduletest/graph/wait.go
@@ -72,7 +72,7 @@ func NewOperationWaiter(ctx *terraform.Context, evalCtx *EvalContext, n *NodeTes
 }
 
 // Run executes the given function in a goroutine and waits for it to finish.
-// If the function finishes, it returns false. If the function is cancelled or
+// If the function finishes successfully, it returns false. If the function is cancelled or
 // interrupted, it returns true.
 func (w *operationWaiter) Run(fn func()) bool {
 	runningCtx, doneRunning := context.WithCancel(context.Background())


### PR DESCRIPTION

<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Implements `skip_cleanup`, which allows skipping the cleanup of individual run blocks or the entire test file. This simply ensures that the cleanup stage for the state is an apply of the run requesting the skip, instead of the normal destroy

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.12.x

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [ ] This change is not user-facing.
