### PR TITLE
Replace state get/set functions with existing helpers

### DIFF
--- a/internal/command/test_test.go
+++ b/internal/command/test_test.go
@@ -3783,7 +3783,7 @@ supplied_input_value = value-from-run-that-controls-backend`,
 			}
 
 			actualState := testStateRead(t, localStatePath)
-			if diff := cmp.Diff(actualState, tc.expectedState); len(diff) > 0 {
+			if diff := cmp.Diff(actualState.String(), tc.expectedState); len(diff) > 0 {
 				t.Fatalf("state didn't match expected:\nexpected:\n%s\nactual:\n%s\ndiff:\n%s", tc.expectedState, actualState, diff)
 			}
 

--- a/internal/command/test_test.go
+++ b/internal/command/test_test.go
@@ -3745,7 +3745,7 @@ supplied_input_value = value-from-run-that-controls-backend`,
 				testStateFileDefault(t, tc.priorState)
 
 				actualState := testStateRead(t, localStatePath)
-				if diff := cmp.Diff(actualState, tc.priorState.String()); len(diff) > 0 {
+				if diff := cmp.Diff(actualState.String(), tc.priorState.String()); len(diff) > 0 {
 					t.Errorf("prior state didn't match expected:\nexpected:\n%s\nactual:\n%s\ndiff:\n%s", tc.expectedState, actualState, diff)
 				}
 			}


### PR DESCRIPTION
Replaces new test state get/set helpers with preexisting ones

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.12.x

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
