### PR TITLE
Add test coverage for `local` backend's backend.Backend methods and behaviours

### DIFF
--- a/internal/backend/local/backend_test.go
+++ b/internal/backend/local/backend_test.go
@@ -89,27 +89,6 @@ func TestLocal_PrepareConfig(t *testing.T) {
 	}
 }
 
-func checkState(t *testing.T, path, expected string) {
-	t.Helper()
-	// Read the state
-	f, err := os.Open(path)
-	if err != nil {
-		t.Fatalf("err: %s", err)
-	}
-
-	state, err := statefile.Read(f)
-	f.Close()
-	if err != nil {
-		t.Fatalf("err: %s", err)
-	}
-
-	actual := state.State.String()
-	expected = strings.TrimSpace(expected)
-	if actual != expected {
-		t.Fatalf("state does not match! actual:\n%s\n\nexpected:\n%s", actual, expected)
-	}
-}
-
 func TestLocal_StatePaths(t *testing.T) {
 	b := New()
 
@@ -316,4 +295,25 @@ func testTmpDir(t *testing.T) string {
 	})
 
 	return tmp
+}
+
+func checkState(t *testing.T, path, expected string) {
+	t.Helper()
+	// Read the state
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	state, err := statefile.Read(f)
+	f.Close()
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	actual := state.State.String()
+	expected = strings.TrimSpace(expected)
+	if actual != expected {
+		t.Fatalf("state does not match! actual:\n%s\n\nexpected:\n%s", actual, expected)
+	}
 }

--- a/internal/backend/local/backend_test.go
+++ b/internal/backend/local/backend_test.go
@@ -302,47 +302,6 @@ func TestLocal_cannotDeleteDefaultState(t *testing.T) {
 	}
 }
 
-func TestLocal_StatePaths(t *testing.T) {
-	b := New()
-
-	// Test the defaults
-	path, out, back := b.StatePaths("")
-
-	if path != DefaultStateFilename {
-		t.Fatalf("expected %q, got %q", DefaultStateFilename, path)
-	}
-
-	if out != DefaultStateFilename {
-		t.Fatalf("expected %q, got %q", DefaultStateFilename, out)
-	}
-
-	dfltBackup := DefaultStateFilename + DefaultBackupExtension
-	if back != dfltBackup {
-		t.Fatalf("expected %q, got %q", dfltBackup, back)
-	}
-
-	// check with env
-	testEnv := "test_env"
-	path, out, back = b.StatePaths(testEnv)
-
-	expectedPath := filepath.Join(DefaultWorkspaceDir, testEnv, DefaultStateFilename)
-	expectedOut := expectedPath
-	expectedBackup := expectedPath + DefaultBackupExtension
-
-	if path != expectedPath {
-		t.Fatalf("expected %q, got %q", expectedPath, path)
-	}
-
-	if out != expectedOut {
-		t.Fatalf("expected %q, got %q", expectedOut, out)
-	}
-
-	if back != expectedBackup {
-		t.Fatalf("expected %q, got %q", expectedBackup, back)
-	}
-
-}
-
 func TestLocal_addAndRemoveStates(t *testing.T) {
 	// Setup
 	_ = testTmpDir(t)
@@ -427,6 +386,47 @@ func TestLocal_addAndRemoveStates(t *testing.T) {
 	if err := b.DeleteWorkspace(dflt, true); err == nil {
 		t.Fatal("expected error deleting default state")
 	}
+}
+
+func TestLocal_StatePaths(t *testing.T) {
+	b := New()
+
+	// Test the defaults
+	path, out, back := b.StatePaths("")
+
+	if path != DefaultStateFilename {
+		t.Fatalf("expected %q, got %q", DefaultStateFilename, path)
+	}
+
+	if out != DefaultStateFilename {
+		t.Fatalf("expected %q, got %q", DefaultStateFilename, out)
+	}
+
+	dfltBackup := DefaultStateFilename + DefaultBackupExtension
+	if back != dfltBackup {
+		t.Fatalf("expected %q, got %q", dfltBackup, back)
+	}
+
+	// check with env
+	testEnv := "test_env"
+	path, out, back = b.StatePaths(testEnv)
+
+	expectedPath := filepath.Join(DefaultWorkspaceDir, testEnv, DefaultStateFilename)
+	expectedOut := expectedPath
+	expectedBackup := expectedPath + DefaultBackupExtension
+
+	if path != expectedPath {
+		t.Fatalf("expected %q, got %q", expectedPath, path)
+	}
+
+	if out != expectedOut {
+		t.Fatalf("expected %q, got %q", expectedOut, out)
+	}
+
+	if back != expectedBackup {
+		t.Fatalf("expected %q, got %q", expectedBackup, back)
+	}
+
 }
 
 // a local backend which returns sentinel errors for NamedState methods to

--- a/internal/backend/local/backend_test.go
+++ b/internal/backend/local/backend_test.go
@@ -152,11 +152,14 @@ func TestLocal_StatePaths(t *testing.T) {
 }
 
 func TestLocal_addAndRemoveStates(t *testing.T) {
+	// Setup
 	_ = testTmpDir(t)
 	dflt := backend.DefaultStateName
 	expectedStates := []string{dflt}
 
 	b := New()
+
+	// Only the default workspace exists initially.
 	states, err := b.Workspaces()
 	if err != nil {
 		t.Fatal(err)
@@ -166,6 +169,7 @@ func TestLocal_addAndRemoveStates(t *testing.T) {
 		t.Fatalf("expected []string{%q}, got %q", dflt, states)
 	}
 
+	// Calling StateMgr with a new workspace name creates that workspace's state file.
 	expectedA := "test_A"
 	if _, err := b.StateMgr(expectedA); err != nil {
 		t.Fatal(err)
@@ -181,6 +185,7 @@ func TestLocal_addAndRemoveStates(t *testing.T) {
 		t.Fatalf("expected %q, got %q", expectedStates, states)
 	}
 
+	// Creating another workspace appends it to the list of present workspaces.
 	expectedB := "test_B"
 	if _, err := b.StateMgr(expectedB); err != nil {
 		t.Fatal(err)
@@ -196,6 +201,7 @@ func TestLocal_addAndRemoveStates(t *testing.T) {
 		t.Fatalf("expected %q, got %q", expectedStates, states)
 	}
 
+	// Can delete a given workspace
 	if err := b.DeleteWorkspace(expectedA, true); err != nil {
 		t.Fatal(err)
 	}
@@ -210,6 +216,7 @@ func TestLocal_addAndRemoveStates(t *testing.T) {
 		t.Fatalf("expected %q, got %q", expectedStates, states)
 	}
 
+	// Can delete another workspace
 	if err := b.DeleteWorkspace(expectedB, true); err != nil {
 		t.Fatal(err)
 	}
@@ -224,6 +231,7 @@ func TestLocal_addAndRemoveStates(t *testing.T) {
 		t.Fatalf("expected %q, got %q", expectedStates, states)
 	}
 
+	// You cannot delete the default workspace
 	if err := b.DeleteWorkspace(dflt, true); err == nil {
 		t.Fatal("expected error deleting default state")
 	}

--- a/internal/backend/local/backend_test.go
+++ b/internal/backend/local/backend_test.go
@@ -14,9 +14,11 @@ import (
 
 	"github.com/hashicorp/terraform/internal/backend"
 	"github.com/hashicorp/terraform/internal/backend/backendrun"
+	"github.com/hashicorp/terraform/internal/configs/configschema"
 	"github.com/hashicorp/terraform/internal/states"
 	"github.com/hashicorp/terraform/internal/states/statefile"
 	"github.com/hashicorp/terraform/internal/states/statemgr"
+	"github.com/hashicorp/terraform/internal/tfdiags"
 	"github.com/zclconf/go-cty/cty"
 )
 

--- a/internal/backend/local/backend_test.go
+++ b/internal/backend/local/backend_test.go
@@ -25,7 +25,7 @@ func TestLocal_impl(t *testing.T) {
 }
 
 func TestLocal_backend(t *testing.T) {
-	testTmpDir(t)
+	_ = testTmpDir(t)
 	b := New()
 	backend.TestBackendStates(t, b)
 	backend.TestBackendStateLocks(t, b, b)
@@ -33,7 +33,7 @@ func TestLocal_backend(t *testing.T) {
 
 func TestLocal_PrepareConfig(t *testing.T) {
 	// Setup
-	testTmpDir(t)
+	_ = testTmpDir(t)
 
 	b := New()
 
@@ -152,7 +152,7 @@ func TestLocal_StatePaths(t *testing.T) {
 }
 
 func TestLocal_addAndRemoveStates(t *testing.T) {
-	testTmpDir(t)
+	_ = testTmpDir(t)
 	dflt := backend.DefaultStateName
 	expectedStates := []string{dflt}
 
@@ -290,7 +290,7 @@ func TestLocal_multiStateBackend(t *testing.T) {
 
 // testTmpDir changes into a tmp dir and change back automatically when the test
 // and all its subtests complete.
-func testTmpDir(t *testing.T) {
+func testTmpDir(t *testing.T) string {
 	tmp := t.TempDir()
 
 	old, err := os.Getwd()
@@ -306,4 +306,6 @@ func testTmpDir(t *testing.T) {
 		// ignore errors and try to clean up
 		os.Chdir(old)
 	})
+
+	return tmp
 }


### PR DESCRIPTION
This PR adds some more test coverage to the local backend's backend.Backend methods and behaviours storing state.

These tests are being pulled out of https://github.com/hashicorp/terraform/pull/36718

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.12.x

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
