### PR TITLE
stacks: include existing components when deferring nested stacks

### DIFF
--- a/internal/promising/once.go
+++ b/internal/promising/once.go
@@ -46,13 +46,13 @@ type Once[T any] struct {
 // and so all calls to Do will return [ErrUnresolved]. However, there is
 // no built-in facility to catch and recover from such panics since they occur
 // in a separate goroutine from all of the waiters.
-func (o *Once[T]) Do(ctx context.Context, f func(ctx context.Context) (T, error)) (T, error) {
+func (o *Once[T]) Do(ctx context.Context, name string, f func(ctx context.Context) (T, error)) (T, error) {
 	AssertContextInTask(ctx)
 	o.mu.Lock()
 	if o.get == nil {
 		// We seem to be the first call, so we'll get the asynchronous task
 		// running and then block on its result.
-		resolver, get := NewPromise[T](ctx)
+		resolver, get := NewPromise[T](ctx, name)
 		o.get = get
 		o.promiseID = resolver.PromiseID()
 		o.mu.Unlock()

--- a/internal/promising/once_test.go
+++ b/internal/promising/once_test.go
@@ -25,7 +25,7 @@ func TestOnce(t *testing.T) {
 		// The "Once" mechanism expects to be run inside a task so that
 		// it can create promises and detect self-dependency problems.
 		result, err := promising.MainTask(ctx, func(ctx context.Context) (*FakeResult, error) {
-			return o.Do(ctx, func(ctx context.Context) (*FakeResult, error) {
+			return o.Do(ctx, "test", func(ctx context.Context) (*FakeResult, error) {
 				callCount.Add(1)
 				return &FakeResult{
 					msg: "hello",

--- a/internal/promising/public_test.go
+++ b/internal/promising/public_test.go
@@ -33,7 +33,7 @@ func TestPromiseResolveSimple(t *testing.T) {
 
 	ctx := context.Background()
 	gotVal, err := promising.MainTask(ctx, func(ctx context.Context) (string, error) {
-		resolver, get := promising.NewPromise[string](ctx)
+		resolver, get := promising.NewPromise[string](ctx, "test")
 
 		promising.AsyncTask(
 			ctx, resolver,
@@ -56,7 +56,7 @@ func TestPromiseUnresolvedMainWithoutGet(t *testing.T) {
 	ctx := context.Background()
 	var promiseID promising.PromiseID
 	gotVal, err := promising.MainTask(ctx, func(ctx context.Context) (string, error) {
-		resolver, _ := promising.NewPromise[string](ctx)
+		resolver, _ := promising.NewPromise[string](ctx, "test")
 		promiseID = resolver.PromiseID()
 		// Call to PromiseResolver.Resolve intentionally omitted to cause error
 		// Also not calling the getter to prevent this from being classified as
@@ -81,7 +81,7 @@ func TestPromiseUnresolvedMainWithGet(t *testing.T) {
 	ctx := context.Background()
 	var promiseID promising.PromiseID
 	gotVal, gotErr := promising.MainTask(ctx, func(ctx context.Context) (string, error) {
-		resolver, get := promising.NewPromise[string](ctx)
+		resolver, get := promising.NewPromise[string](ctx, "test")
 		promiseID = resolver.PromiseID()
 		// Call to PromiseResolver.Resolve intentionally omitted to cause error
 		return get(ctx)
@@ -111,7 +111,7 @@ func TestPromiseUnresolvedAsync(t *testing.T) {
 	ctx := context.Background()
 	var promiseID promising.PromiseID
 	gotVal, err := promising.MainTask(ctx, func(ctx context.Context) (string, error) {
-		resolver, get := promising.NewPromise[string](ctx)
+		resolver, get := promising.NewPromise[string](ctx, "test")
 		promiseID = resolver.PromiseID()
 
 		promising.AsyncTask(
@@ -140,8 +140,8 @@ func TestPromiseSelfDependentSibling(t *testing.T) {
 	ctx := context.Background()
 	var err1, err2 error
 	promising.MainTask(ctx, func(ctx context.Context) (string, error) {
-		resolver1, get1 := promising.NewPromise[string](ctx)
-		resolver2, get2 := promising.NewPromise[string](ctx)
+		resolver1, get1 := promising.NewPromise[string](ctx, "test")
+		resolver2, get2 := promising.NewPromise[string](ctx, "test")
 
 		// The following is an intentional self-dependency, though its
 		// unpredictable which of the two tasks will actually detect the error,
@@ -196,8 +196,8 @@ func TestPromiseSelfDependentNested(t *testing.T) {
 	ctx := context.Background()
 	var err1, err2 error
 	promising.MainTask(ctx, func(ctx context.Context) (string, error) {
-		resolver1, get1 := promising.NewPromise[string](ctx)
-		resolver2, get2 := promising.NewPromise[string](ctx)
+		resolver1, get1 := promising.NewPromise[string](ctx, "test")
+		resolver2, get2 := promising.NewPromise[string](ctx, "test")
 		pair := promising.PromiseResolverPair[string, string]{A: resolver1, B: resolver2}
 
 		// The following is an intentional self-dependency. Both calls should

--- a/internal/stacks/stackaddrs/component.go
+++ b/internal/stacks/stackaddrs/component.go
@@ -40,6 +40,16 @@ type ConfigComponent = InStackConfig[Component]
 // AbsComponent places a [Component] in the context of a particular [StackInstance].
 type AbsComponent = InStackInstance[Component]
 
+func AbsComponentToInstance(ist AbsComponent, ik addrs.InstanceKey) AbsComponentInstance {
+	return AbsComponentInstance{
+		Stack: ist.Stack,
+		Item: ComponentInstance{
+			Component: ist.Item,
+			Key:       ik,
+		},
+	}
+}
+
 // ComponentInstance is the address of a dynamic instance of a component.
 type ComponentInstance struct {
 	Component Component

--- a/internal/stacks/stackaddrs/in_stack.go
+++ b/internal/stacks/stackaddrs/in_stack.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
+
 	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/collections"
 	"github.com/hashicorp/terraform/internal/tfdiags"
@@ -182,8 +183,8 @@ Steps:
 		}
 		traversal = traversal[2:] // consume the first two steps that we already dealt with
 		if len(traversal) > 0 {
-			idxStep, ok := traversal[0].(hcl.TraverseIndex)
-			if ok {
+			switch idxStep := traversal[0].(type) {
+			case hcl.TraverseIndex:
 				var err error
 				addrStep.Key, err = addrs.ParseInstanceKey(idxStep.Key)
 				if err != nil {
@@ -196,6 +197,9 @@ Steps:
 					return nil, nil, diags
 				}
 				traversal = traversal[1:] // consume the step we just dealt with
+			case hcl.TraverseSplat:
+				addrStep.Key = addrs.WildcardKey
+				traversal = traversal[1:]
 			}
 		}
 		stackInst = append(stackInst, addrStep)

--- a/internal/stacks/stackaddrs/provider_config.go
+++ b/internal/stacks/stackaddrs/provider_config.go
@@ -84,3 +84,13 @@ type ConfigProviderConfigInstance = InStackConfig[ProviderConfigInstance]
 
 // AbsProviderConfigInstance places a [ProviderConfigInstance] in the context of a particular [StackInstance].
 type AbsProviderConfigInstance = InStackInstance[ProviderConfigInstance]
+
+func AbsProviderToInstance(addr AbsProviderConfig, ik addrs.InstanceKey) AbsProviderConfigInstance {
+	return AbsProviderConfigInstance{
+		Stack: addr.Stack,
+		Item: ProviderConfigInstance{
+			ProviderConfig: addr.Item,
+			Key:            ik,
+		},
+	}
+}

--- a/internal/stacks/stackplan/plan.go
+++ b/internal/stacks/stackplan/plan.go
@@ -107,6 +107,27 @@ func (p *Plan) ComponentInstances(addr stackaddrs.AbsComponent) collections.Set[
 	return ret
 }
 
+func (p *Plan) StackInstances(addr stackaddrs.AbsStackCall) []stackaddrs.StackInstanceStep {
+	var ret []stackaddrs.StackInstanceStep
+	for key := range p.Components.All() {
+		if len(key.Stack) == 0 {
+			continue
+		}
+
+		last := key.Stack[len(key.Stack)-1]
+		path := key.Stack[:len(key.Stack)-1]
+
+		if path.String() != addr.Stack.String() {
+			continue
+		}
+		if last.Name != addr.Item.Name {
+			continue
+		}
+		ret = append(ret, last)
+	}
+	return ret
+}
+
 // RequiredProviderInstances returns a description of all of the provider
 // instance slots that are required to satisfy the resource instances
 // belonging to the given component instance.

--- a/internal/stacks/stackruntime/internal/stackeval/change_exec.go
+++ b/internal/stacks/stackruntime/internal/stackeval/change_exec.go
@@ -58,8 +58,8 @@ func ChangeExec[Main any](
 	// "execution" phase, where the registered tasks will all become runnable
 	// simultaneously.
 
-	setupComplete, waitSetupComplete := promising.NewPromise[struct{}](ctx)
-	beginExec, waitBeginExec := promising.NewPromise[Main](ctx)
+	setupComplete, waitSetupComplete := promising.NewPromise[struct{}](ctx, "setupComplete")
+	beginExec, waitBeginExec := promising.NewPromise[Main](ctx, "beginExec")
 
 	reg := &ChangeExecRegistry[Main]{
 		waitBeginExec: waitBeginExec,
@@ -108,7 +108,7 @@ func (r *ChangeExecRegistry[Main]) RegisterComponentInstanceChange(
 	addr stackaddrs.AbsComponentInstance,
 	run func(ctx context.Context, main Main) (*ComponentInstanceApplyResult, tfdiags.Diagnostics),
 ) {
-	resultProvider, waitResult := promising.NewPromise[withDiagnostics[*ComponentInstanceApplyResult]](ctx)
+	resultProvider, waitResult := promising.NewPromise[withDiagnostics[*ComponentInstanceApplyResult]](ctx, "resultProvider")
 	r.mu.Lock()
 	if r.results.componentInstances.HasKey(addr) {
 		// This is always a bug in the caller.

--- a/internal/stacks/stackruntime/internal/stackeval/component.go
+++ b/internal/stacks/stackruntime/internal/stackeval/component.go
@@ -104,7 +104,7 @@ func (c *Component) ForEachValue(ctx context.Context, phase EvalPhase) cty.Value
 // that we cannot know the for_each value.
 func (c *Component) CheckForEachValue(ctx context.Context, phase EvalPhase) (cty.Value, tfdiags.Diagnostics) {
 	val, diags := doOnceWithDiags(
-		ctx, c.forEachValue.For(phase), c.main,
+		ctx, c.tracingName()+" for_each", c.forEachValue.For(phase),
 		func(ctx context.Context) (cty.Value, tfdiags.Diagnostics) {
 			var diags tfdiags.Diagnostics
 			cfg := c.Declaration(ctx)
@@ -158,7 +158,7 @@ func (c *Component) Instances(ctx context.Context, phase EvalPhase) (map[addrs.I
 
 func (c *Component) CheckInstances(ctx context.Context, phase EvalPhase) (map[addrs.InstanceKey]*ComponentInstance, bool, tfdiags.Diagnostics) {
 	result, diags := doOnceWithDiags(
-		ctx, c.instances.For(phase), c.main,
+		ctx, c.tracingName()+" instances", c.instances.For(phase),
 		func(ctx context.Context) (instancesResult[*ComponentInstance], tfdiags.Diagnostics) {
 			var diags tfdiags.Diagnostics
 			forEachVal, forEachValueDiags := c.CheckForEachValue(ctx, phase)
@@ -169,7 +169,7 @@ func (c *Component) CheckInstances(ctx context.Context, phase EvalPhase) (map[ad
 			}
 
 			result := instancesMap(forEachVal, func(ik addrs.InstanceKey, rd instances.RepetitionData) *ComponentInstance {
-				return newComponentInstance(c, ik, rd, false)
+				return newComponentInstance(c, stackaddrs.AbsComponentToInstance(c.addr, ik), rd, false)
 			})
 
 			addrs := make([]stackaddrs.AbsComponentInstance, 0, len(result.insts))
@@ -190,8 +190,8 @@ func (c *Component) CheckInstances(ctx context.Context, phase EvalPhase) (map[ad
 }
 
 func (c *Component) UnknownInstance(ctx context.Context, phase EvalPhase) *ComponentInstance {
-	inst, err := c.unknownInstance.For(phase).Do(ctx, func(ctx context.Context) (*ComponentInstance, error) {
-		return newComponentInstance(c, addrs.WildcardKey, instances.UnknownForEachRepetitionData(c.ForEachValue(ctx, phase).Type()), true), nil
+	inst, err := c.unknownInstance.For(phase).Do(ctx, c.tracingName()+" unknown instance", func(ctx context.Context) (*ComponentInstance, error) {
+		return newComponentInstance(c, stackaddrs.AbsComponentToInstance(c.addr, addrs.WildcardKey), instances.UnknownForEachRepetitionData(c.ForEachValue(ctx, phase).Type()), true), nil
 	})
 	if err != nil {
 		// Since we never return an error from the function we pass to Do,
@@ -373,25 +373,4 @@ func (c *Component) ApplySuccessful(ctx context.Context) bool {
 
 func (c *Component) tracingName() string {
 	return c.Addr().String()
-}
-
-// reportNamedPromises implements namedPromiseReporter.
-func (c *Component) reportNamedPromises(cb func(id promising.PromiseID, name string)) {
-	name := c.Addr().String()
-	instsName := name + " instances"
-	forEachName := name + " for_each"
-	c.instances.Each(func(ep EvalPhase, o *promising.Once[withDiagnostics[instancesResult[*ComponentInstance]]]) {
-		cb(o.PromiseID(), instsName)
-	})
-	// FIXME: We should call reportNamedPromises on the individual
-	// ComponentInstance objects too, but promising.Once doesn't allow us
-	// to peek to see if the Once was already resolved without blocking on
-	// it, and we don't want to block on any promises in here.
-	// Without this, any promises belonging to the individual instances will
-	// not be named in a self-dependency error report, but since references
-	// to component instances are always indirect through the component this
-	// shouldn't be a big deal in most cases.
-	c.forEachValue.Each(func(ep EvalPhase, o *promising.Once[withDiagnostics[cty.Value]]) {
-		cb(o.PromiseID(), forEachName)
-	})
 }

--- a/internal/stacks/stackruntime/internal/stackeval/component_config.go
+++ b/internal/stacks/stackruntime/internal/stackeval/component_config.go
@@ -43,8 +43,8 @@ type ComponentConfig struct {
 
 	main *Main
 
-	validate   promising.Once[tfdiags.Diagnostics]
-	moduleTree promising.Once[withDiagnostics[*configs.Config]]
+	validate   perEvalPhase[promising.Once[tfdiags.Diagnostics]]
+	moduleTree promising.Once[withDiagnostics[*configs.Config]] // moduleTree is constant across all phases
 }
 
 func newComponentConfig(main *Main, addr stackaddrs.ConfigComponent, config *stackconfig.Component) *ComponentConfig {
@@ -288,7 +288,7 @@ func (c *ComponentConfig) PlanTimestamp() time.Time {
 }
 
 func (c *ComponentConfig) checkValid(ctx context.Context, phase EvalPhase) tfdiags.Diagnostics {
-	diags, err := c.validate.Do(ctx, c.tracingName(), func(ctx context.Context) (tfdiags.Diagnostics, error) {
+	diags, err := c.validate.For(phase).Do(ctx, c.tracingName(), func(ctx context.Context) (tfdiags.Diagnostics, error) {
 		var diags tfdiags.Diagnostics
 
 		moduleTree, moreDiags := c.CheckModuleTree(ctx)

--- a/internal/stacks/stackruntime/internal/stackeval/component_config.go
+++ b/internal/stacks/stackruntime/internal/stackeval/component_config.go
@@ -91,7 +91,7 @@ func (c *ComponentConfig) ModuleTree(ctx context.Context) *configs.Config {
 // this instead returns diagnostics and a nil configuration object.
 func (c *ComponentConfig) CheckModuleTree(ctx context.Context) (*configs.Config, tfdiags.Diagnostics) {
 	return doOnceWithDiags(
-		ctx, &c.moduleTree, c.main,
+		ctx, c.tracingName()+" modules", &c.moduleTree,
 		func(ctx context.Context) (*configs.Config, tfdiags.Diagnostics) {
 			var diags tfdiags.Diagnostics
 
@@ -288,7 +288,7 @@ func (c *ComponentConfig) PlanTimestamp() time.Time {
 }
 
 func (c *ComponentConfig) checkValid(ctx context.Context, phase EvalPhase) tfdiags.Diagnostics {
-	diags, err := c.validate.Do(ctx, func(ctx context.Context) (tfdiags.Diagnostics, error) {
+	diags, err := c.validate.Do(ctx, c.tracingName(), func(ctx context.Context) (tfdiags.Diagnostics, error) {
 		var diags tfdiags.Diagnostics
 
 		moduleTree, moreDiags := c.CheckModuleTree(ctx)
@@ -407,12 +407,6 @@ func (c *ComponentConfig) PlanChanges(ctx context.Context) ([]stackplan.PlannedC
 
 func (c *ComponentConfig) tracingName() string {
 	return c.Addr().String()
-}
-
-// reportNamedPromises implements namedPromiseReporter.
-func (c *ComponentConfig) reportNamedPromises(cb func(id promising.PromiseID, name string)) {
-	cb(c.validate.PromiseID(), c.Addr().String())
-	cb(c.moduleTree.PromiseID(), c.Addr().String()+" modules")
 }
 
 // sourceBundleModuleWalker is an implementation of [configs.ModuleWalker]

--- a/internal/stacks/stackruntime/internal/stackeval/component_instance.go
+++ b/internal/stacks/stackruntime/internal/stackeval/component_instance.go
@@ -38,7 +38,7 @@ type ComponentInstance struct {
 
 	repetition instances.RepetitionData
 
-	moduleTreePlan promising.Once[withDiagnostics[*plans.Plan]]
+	moduleTreePlan promising.Once[withDiagnostics[*plans.Plan]] // moduleTreePlan is only called during the plan phase
 }
 
 var _ Applyable = (*ComponentInstance)(nil)

--- a/internal/stacks/stackruntime/internal/stackeval/component_instance.go
+++ b/internal/stacks/stackruntime/internal/stackeval/component_instance.go
@@ -617,8 +617,7 @@ func (c *ComponentInstance) ResultValue(ctx context.Context, phase EvalPhase) ct
 
 // ResolveExpressionReference implements ExpressionScope.
 func (c *ComponentInstance) ResolveExpressionReference(ctx context.Context, ref stackaddrs.Reference) (Referenceable, tfdiags.Diagnostics) {
-	stack := c.call.Stack(ctx)
-	return stack.resolveExpressionReference(ctx, ref, nil, c.repetition)
+	return c.call.stack.resolveExpressionReference(ctx, ref, nil, c.repetition)
 }
 
 // ExternalFunctions implements ExpressionScope.

--- a/internal/stacks/stackruntime/internal/stackeval/diagnostics_test.go
+++ b/internal/stacks/stackruntime/internal/stackeval/diagnostics_test.go
@@ -7,21 +7,17 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/zclconf/go-cty/cty"
 
 	"github.com/hashicorp/terraform/internal/addrs"
-	"github.com/hashicorp/terraform/internal/collections"
 	"github.com/hashicorp/terraform/internal/configs/configschema"
 	"github.com/hashicorp/terraform/internal/depsfile"
 	"github.com/hashicorp/terraform/internal/getproviders/providerreqs"
 	"github.com/hashicorp/terraform/internal/plans"
-	"github.com/hashicorp/terraform/internal/promising"
 	"github.com/hashicorp/terraform/internal/providers"
 	providertest "github.com/hashicorp/terraform/internal/providers/testing"
 	"github.com/hashicorp/terraform/internal/stacks/stackaddrs"
 	"github.com/hashicorp/terraform/internal/stacks/stackstate"
-	"github.com/hashicorp/terraform/internal/tfdiags"
 )
 
 func TestNamedPromisesPlan(t *testing.T) {
@@ -85,150 +81,4 @@ func TestNamedPromisesPlan(t *testing.T) {
 	// we'll then ask about below.
 	_, diags := testPlan(t, main)
 	assertNoDiagnostics(t, diags)
-
-	wantNames := collections.NewSetCmp[string](
-		// Component-related
-		`component.foo`,
-		`component.foo modules`,
-		`component.foo for_each`,
-		`component.foo instances`,
-
-		// Nested-stack-related
-		`stack.child collected outputs`,
-		`stack.child inputs`,
-		`stack.child for_each`,
-		`stack.child instances`,
-
-		// Provider-related
-		`example.com/test/happycloud schema`,
-		`provider["example.com/test/happycloud"].main`,
-		`provider["example.com/test/happycloud"].main for_each`,
-		`provider["example.com/test/happycloud"].main instances`,
-
-		// Output-value-related
-		`output.out value`,
-		`stack.child.output.out value`,
-		`output.out`,
-		`stack.child.output.out`,
-
-		// Input-variable-related
-		`var.in`,
-		`stack.child.var.in`,
-	)
-	gotNames := collections.NewSetCmp[string]()
-	ids := map[string]promising.PromiseID{}
-	main.reportNamedPromises(func(id promising.PromiseID, name string) {
-		gotNames.Add(name)
-		// We'll also remember the id associated with each name so that
-		// we can test the diagnostic message rendering below.
-		ids[name] = id
-		// NOTE: Some of the names get reused across both a config object
-		// and its associated dynamic object when there are no dynamic
-		// instance keys involved, and for those it's unspecified which
-		// promise ID will "win", but that's fine for our purposes here
-		// because we're only testing that some specific names get
-		// included into the error messages and so it doesn't matter which
-		// of the promise ids we use to achieve that.
-	})
-
-	if diff := cmp.Diff(wantNames, gotNames, collections.CmpOptions); diff != "" {
-		// If you're here because you've seen a failure where some of the
-		// wanted names seem to have vanished, and you weren't intentionally
-		// trying to remove them, check to make sure that the type that was
-		// supposed to report that name is still reachable indirectly from the
-		// Main.reportNamedPromises implementation.
-		t.Errorf("wrong promise names\n%s", diff)
-	}
-
-	// Since we're now holding all of the information required, let's also
-	// test that we can render some self-dependency and resolution failure
-	// diagnostic messages.
-	t.Run("diagnostics", func(t *testing.T) {
-		// For this we need to choose some specific promise ids to report.
-		// It doesn't matter which ones we use but we can only proceed if
-		// they were ones detected by the reportNamedPromises call earlier.
-		providerSchemaPromise := ids[`example.com/test/happycloud schema`]
-		stackCallInstancesPromise := ids[`stack.child instances`]
-		if providerSchemaPromise == promising.NoPromise || stackCallInstancesPromise == promising.NoPromise {
-			t.Fatalf("don't have the promise ids required to test diagnostic rendering")
-		}
-
-		t.Run("just one self-reference", func(t *testing.T) {
-			err := promising.ErrSelfDependent{stackCallInstancesPromise}
-			diag := taskSelfDependencyDiagnostic{
-				err:  err,
-				root: main,
-			}
-			got := diag.Description()
-			want := tfdiags.Description{
-				Summary: `Self-dependent item in configuration`,
-				Detail:  `The item "stack.child instances" depends on its own results, so there is no correct order of operations.`,
-			}
-			if diff := cmp.Diff(want, got); diff != "" {
-				t.Errorf("wrong diagnostic description\n%s", diff)
-			}
-		})
-		t.Run("multiple self-references", func(t *testing.T) {
-			err := promising.ErrSelfDependent{
-				providerSchemaPromise,
-				stackCallInstancesPromise,
-			}
-			diag := taskSelfDependencyDiagnostic{
-				err:  err,
-				root: main,
-			}
-			got := diag.Description()
-			want := tfdiags.Description{
-				Summary: `Self-dependent items in configuration`,
-				Detail: `The following items in your configuration form a circular dependency chain through their references:
-  - example.com/test/happycloud schema
-  - stack.child instances
-
-Terraform uses references to decide a suitable order for performing operations, so configuration items may not refer to their own results either directly or indirectly.`,
-			}
-			if diff := cmp.Diff(want, got); diff != "" {
-				t.Errorf("wrong diagnostic description\n%s", diff)
-			}
-		})
-		t.Run("just one failure to resolve", func(t *testing.T) {
-			err := promising.ErrUnresolved{stackCallInstancesPromise}
-			diag := taskPromisesUnresolvedDiagnostic{
-				err:  err,
-				root: main,
-			}
-			got := diag.Description()
-			want := tfdiags.Description{
-				Summary: `Stack language evaluation error`,
-				Detail: `While evaluating the stack configuration, the following items were left unresolved:
-  - stack.child instances
-
-Other errors returned along with this one may provide more details. This is a bug in Teraform; please report it!`,
-			}
-			if diff := cmp.Diff(want, got); diff != "" {
-				t.Errorf("wrong diagnostic description\n%s", diff)
-			}
-		})
-		t.Run("multiple failures to resolve", func(t *testing.T) {
-			err := promising.ErrUnresolved{
-				providerSchemaPromise,
-				stackCallInstancesPromise,
-			}
-			diag := taskPromisesUnresolvedDiagnostic{
-				err:  err,
-				root: main,
-			}
-			got := diag.Description()
-			want := tfdiags.Description{
-				Summary: `Stack language evaluation error`,
-				Detail: `While evaluating the stack configuration, the following items were left unresolved:
-  - example.com/test/happycloud schema
-  - stack.child instances
-
-Other errors returned along with this one may provide more details. This is a bug in Teraform; please report it!`,
-			}
-			if diff := cmp.Diff(want, got); diff != "" {
-				t.Errorf("wrong diagnostic description\n%s", diff)
-			}
-		})
-	})
 }

--- a/internal/stacks/stackruntime/internal/stackeval/expression_refs.go
+++ b/internal/stacks/stackruntime/internal/stackeval/expression_refs.go
@@ -133,6 +133,7 @@ func (m *Main) requiredComponentsForReferrer(ctx context.Context, obj Referrer, 
 		// do not have a direct reference to their internal components (it
 		// actually goes the other way).
 		if stackCallAddr, ok := targetAddr.Item.(stackaddrs.StackCall); ok {
+
 			// We're just adding all the components within the stack to the
 			// queue. We could be a bit clever if, for example, the reference
 			// is to an output of the stack call. We could only add the
@@ -140,11 +141,11 @@ func (m *Main) requiredComponentsForReferrer(ctx context.Context, obj Referrer, 
 			// now, in which the apply will wait for the whole stack to finish
 			// before moving on.
 			currentStack := m.Stack(ctx, targetAddr.Stack, phase)
-			for step, nextStack := range currentStack.childStacks {
-				if step.Name != stackCallAddr.Name {
-					// Then this child stack isn't from the current stack call.
-					continue
-				}
+			stackCall := currentStack.EmbeddedStackCall(ctx, stackCallAddr)
+
+			insts, _ := stackCall.Instances(ctx, PlanPhase)
+			for _, inst := range insts {
+				nextStack := inst.Stack(ctx, PlanPhase)
 
 				for _, component := range nextStack.Components(ctx) {
 					ref := stackaddrs.AbsReferenceable{

--- a/internal/stacks/stackruntime/internal/stackeval/input_variable.go
+++ b/internal/stacks/stackruntime/internal/stackeval/input_variable.go
@@ -108,7 +108,7 @@ func (v *InputVariable) Value(ctx context.Context, phase EvalPhase) cty.Value {
 
 func (v *InputVariable) CheckValue(ctx context.Context, phase EvalPhase) (cty.Value, tfdiags.Diagnostics) {
 	return doOnceWithDiags(
-		ctx, v.value.For(phase), v.main,
+		ctx, v.tracingName(), v.value.For(phase),
 		func(ctx context.Context) (cty.Value, tfdiags.Diagnostics) {
 			var diags tfdiags.Diagnostics
 
@@ -357,14 +357,6 @@ func (v *InputVariable) CheckApply(ctx context.Context) ([]stackstate.AppliedCha
 
 func (v *InputVariable) tracingName() string {
 	return v.Addr().String()
-}
-
-// reportNamedPromises implements namedPromiseReporter.
-func (v *InputVariable) reportNamedPromises(cb func(id promising.PromiseID, name string)) {
-	name := v.Addr().String()
-	v.value.Each(func(ep EvalPhase, o *promising.Once[withDiagnostics[cty.Value]]) {
-		cb(o.PromiseID(), name)
-	})
 }
 
 // ExternalInputValue represents the value of an input variable provided

--- a/internal/stacks/stackruntime/internal/stackeval/input_variable.go
+++ b/internal/stacks/stackruntime/internal/stackeval/input_variable.go
@@ -24,7 +24,8 @@ import (
 
 // InputVariable represents an input variable belonging to a [Stack].
 type InputVariable struct {
-	addr stackaddrs.AbsInputVariable
+	stack *Stack
+	addr  stackaddrs.AbsInputVariable
 
 	main *Main
 
@@ -34,10 +35,11 @@ type InputVariable struct {
 var _ Plannable = (*InputVariable)(nil)
 var _ Referenceable = (*InputVariable)(nil)
 
-func newInputVariable(main *Main, addr stackaddrs.AbsInputVariable) *InputVariable {
+func newInputVariable(main *Main, addr stackaddrs.AbsInputVariable, stack *Stack) *InputVariable {
 	return &InputVariable{
-		addr: addr,
-		main: main,
+		stack: stack,
+		addr:  addr,
+		main:  main,
 	}
 }
 
@@ -307,7 +309,7 @@ func (v *InputVariable) References(ctx context.Context) []stackaddrs.AbsReferenc
 		return nil
 	}
 	stackAddr := addr.Stack
-	parentStack := v.main.StackUnchecked(ctx, stackAddr.Parent())
+	parentStack := v.stack.parent
 	if parentStack == nil {
 		// Weird, but we'll tolerate it for robustness.
 		return nil

--- a/internal/stacks/stackruntime/internal/stackeval/input_variable_config.go
+++ b/internal/stacks/stackruntime/internal/stackeval/input_variable_config.go
@@ -9,14 +9,14 @@ import (
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/ext/typeexpr"
+	"github.com/zclconf/go-cty/cty"
+	"github.com/zclconf/go-cty/cty/convert"
+
 	"github.com/hashicorp/terraform/internal/lang/marks"
-	"github.com/hashicorp/terraform/internal/promising"
 	"github.com/hashicorp/terraform/internal/stacks/stackaddrs"
 	"github.com/hashicorp/terraform/internal/stacks/stackconfig"
 	"github.com/hashicorp/terraform/internal/stacks/stackplan"
 	"github.com/hashicorp/terraform/internal/tfdiags"
-	"github.com/zclconf/go-cty/cty"
-	"github.com/zclconf/go-cty/cty/convert"
 )
 
 // InputVariableConfig represents a "variable" block in a stack configuration.
@@ -29,7 +29,6 @@ type InputVariableConfig struct {
 
 var _ Validatable = (*InputVariableConfig)(nil)
 var _ Referenceable = (*InputVariableConfig)(nil)
-var _ namedPromiseReporter = (*InputVariableConfig)(nil)
 
 func newInputVariableConfig(main *Main, addr stackaddrs.ConfigInputVariable, config *stackconfig.InputVariable) *InputVariableConfig {
 	if config == nil {
@@ -174,9 +173,4 @@ func (v *InputVariableConfig) Validate(ctx context.Context) tfdiags.Diagnostics 
 // PlanChanges implements Plannable.
 func (v *InputVariableConfig) PlanChanges(ctx context.Context) ([]stackplan.PlannedChange, tfdiags.Diagnostics) {
 	return nil, v.checkValid(ctx, PlanPhase)
-}
-
-// reportNamedPromises implements namedPromiseReporter.
-func (s *InputVariableConfig) reportNamedPromises(cb func(id promising.PromiseID, name string)) {
-	// Nothing to report yet
 }

--- a/internal/stacks/stackruntime/internal/stackeval/local_value.go
+++ b/internal/stacks/stackruntime/internal/stackeval/local_value.go
@@ -74,7 +74,7 @@ func (v *LocalValue) checkValid(ctx context.Context, phase EvalPhase) tfdiags.Di
 
 func (v *LocalValue) CheckValue(ctx context.Context, phase EvalPhase) (cty.Value, tfdiags.Diagnostics) {
 	return withCtyDynamicValPlaceholder(doOnceWithDiags(
-		ctx, v.value.For(phase), v.main,
+		ctx, v.tracingName(), v.value.For(phase),
 		func(ctx context.Context) (cty.Value, tfdiags.Diagnostics) {
 			var diags tfdiags.Diagnostics
 

--- a/internal/stacks/stackruntime/internal/stackeval/local_value_config.go
+++ b/internal/stacks/stackruntime/internal/stackeval/local_value_config.go
@@ -6,12 +6,13 @@ package stackeval
 import (
 	"context"
 
+	"github.com/zclconf/go-cty/cty"
+
 	"github.com/hashicorp/terraform/internal/promising"
 	"github.com/hashicorp/terraform/internal/stacks/stackaddrs"
 	"github.com/hashicorp/terraform/internal/stacks/stackconfig"
 	"github.com/hashicorp/terraform/internal/stacks/stackplan"
 	"github.com/hashicorp/terraform/internal/tfdiags"
-	"github.com/zclconf/go-cty/cty"
 )
 
 // LocalValueConfig represents a "locals" block in a stack configuration.
@@ -25,9 +26,8 @@ type LocalValueConfig struct {
 }
 
 var (
-	_ Validatable          = (*LocalValueConfig)(nil)
-	_ Referenceable        = (*LocalValueConfig)(nil)
-	_ namedPromiseReporter = (*LocalValueConfig)(nil)
+	_ Validatable   = (*LocalValueConfig)(nil)
+	_ Referenceable = (*LocalValueConfig)(nil)
 )
 
 func newLocalValueConfig(main *Main, addr stackaddrs.ConfigLocalValue, config *stackconfig.LocalValue) *LocalValueConfig {
@@ -75,7 +75,7 @@ func (v *LocalValueConfig) ExprReferenceValue(ctx context.Context, phase EvalPha
 // declared type constraint.
 func (v *LocalValueConfig) ValidateValue(ctx context.Context, phase EvalPhase) (cty.Value, tfdiags.Diagnostics) {
 	return withCtyDynamicValPlaceholder(doOnceWithDiags(
-		ctx, v.validatedValue.For(phase), v.main,
+		ctx, v.tracingName(), v.validatedValue.For(phase),
 		v.validateValueInner,
 	))
 }
@@ -83,17 +83,17 @@ func (v *LocalValueConfig) ValidateValue(ctx context.Context, phase EvalPhase) (
 // validateValueInner is the real implementation of ValidateValue, which runs
 // in the background only once per instance of [OutputValueConfig] and then
 // provides the result for all ValidateValue callers simultaneously.
-func (lv *LocalValueConfig) validateValueInner(ctx context.Context) (cty.Value, tfdiags.Diagnostics) {
+func (v *LocalValueConfig) validateValueInner(ctx context.Context) (cty.Value, tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
 
-	result, moreDiags := EvalExprAndEvalContext(ctx, lv.config.Value, ValidatePhase, lv.StackConfig(ctx))
-	v := result.Value
+	result, moreDiags := EvalExprAndEvalContext(ctx, v.config.Value, ValidatePhase, v.StackConfig(ctx))
+	value := result.Value
 	diags = diags.Append(moreDiags)
 	if moreDiags.HasErrors() {
-		v = cty.UnknownVal(cty.DynamicPseudoType)
+		value = cty.UnknownVal(cty.DynamicPseudoType)
 	}
 
-	return v, diags
+	return value, diags
 }
 
 func (v *LocalValueConfig) checkValid(ctx context.Context, phase EvalPhase) tfdiags.Diagnostics {
@@ -111,9 +111,4 @@ func (v *LocalValueConfig) Validate(ctx context.Context) tfdiags.Diagnostics {
 // PlanChanges implements Plannable.
 func (v *LocalValueConfig) PlanChanges(ctx context.Context) ([]stackplan.PlannedChange, tfdiags.Diagnostics) {
 	return nil, v.checkValid(ctx, PlanPhase)
-}
-
-// reportNamedPromises implements namedPromiseReporter.
-func (s *LocalValueConfig) reportNamedPromises(cb func(id promising.PromiseID, name string)) {
-	// Nothing to report yet
 }

--- a/internal/stacks/stackruntime/internal/stackeval/main.go
+++ b/internal/stacks/stackruntime/internal/stackeval/main.go
@@ -21,7 +21,6 @@ import (
 	"github.com/hashicorp/terraform/internal/collections"
 	"github.com/hashicorp/terraform/internal/depsfile"
 	"github.com/hashicorp/terraform/internal/lang"
-	"github.com/hashicorp/terraform/internal/promising"
 	"github.com/hashicorp/terraform/internal/providers"
 	"github.com/hashicorp/terraform/internal/provisioners"
 	"github.com/hashicorp/terraform/internal/stacks/stackaddrs"
@@ -88,8 +87,6 @@ type Main struct {
 	providerFunctionResults *providers.FunctionResults
 	cleanupFuncs            []func(context.Context) tfdiags.Diagnostics
 }
-
-var _ namedPromiseReporter = (*Main)(nil)
 
 type mainValidating struct {
 	opts ValidateOpts
@@ -613,21 +610,6 @@ func (m *Main) StackCallConfig(ctx context.Context, addr stackaddrs.ConfigStackC
 		return nil
 	}
 	return caller.StackCall(ctx, addr.Item)
-}
-
-// reportNamedPromises implements namedPromiseReporter.
-func (m *Main) reportNamedPromises(cb func(id promising.PromiseID, name string)) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	if m.mainStackConfig != nil {
-		m.mainStackConfig.reportNamedPromises(cb)
-	}
-	if m.mainStack != nil {
-		m.mainStack.reportNamedPromises(cb)
-	}
-	for _, pty := range m.providerTypes {
-		pty.reportNamedPromises(cb)
-	}
 }
 
 // availableProvisioners returns the table of provisioner factories that should

--- a/internal/stacks/stackruntime/internal/stackeval/main.go
+++ b/internal/stacks/stackruntime/internal/stackeval/main.go
@@ -297,7 +297,7 @@ func (m *Main) MainStack(ctx context.Context) *Stack {
 	defer m.mu.Unlock()
 
 	if m.mainStack == nil {
-		m.mainStack = newStack(m, stackaddrs.RootStackInstance, collections.NewMap[stackaddrs.ConfigComponent, []*Removed]())
+		m.mainStack = newStack(m, nil, stackaddrs.RootStackInstance, collections.NewMap[stackaddrs.ConfigComponent, []*Removed](), false)
 	}
 	return m.mainStack
 }
@@ -308,25 +308,6 @@ func (m *Main) StackConfig(ctx context.Context, addr stackaddrs.Stack) *StackCon
 	ret := m.MainStackConfig(ctx)
 	for _, step := range addr {
 		ret = ret.ChildConfig(ctx, step)
-		if ret == nil {
-			return nil
-		}
-	}
-	return ret
-}
-
-// StackUnchecked returns the [Stack] object representing the stack instance
-// with the given address, or nil if the address traverses through an embedded
-// stack call that doesn't exist at all.
-//
-// This function cannot check whether the instance keys in the path correspond
-// to instances actually declared by the configuration. If you need to check
-// that use [Main.Stack] instead, but consider the additional overhead that
-// extra checking implies.
-func (m *Main) StackUnchecked(ctx context.Context, addr stackaddrs.StackInstance) *Stack {
-	ret := m.MainStack(ctx)
-	for _, step := range addr {
-		ret = ret.ChildStackUnchecked(ctx, step)
 		if ret == nil {
 			return nil
 		}
@@ -355,7 +336,7 @@ func (m *Main) StackUnchecked(ctx context.Context, addr stackaddrs.StackInstance
 func (m *Main) Stack(ctx context.Context, addr stackaddrs.StackInstance, phase EvalPhase) *Stack {
 	ret := m.MainStack(ctx)
 	for _, step := range addr {
-		ret = ret.ChildStackChecked(ctx, step, phase)
+		ret = ret.ChildStack(ctx, step, phase)
 		if ret == nil {
 			return nil
 		}

--- a/internal/stacks/stackruntime/internal/stackeval/main_apply.go
+++ b/internal/stacks/stackruntime/internal/stackeval/main_apply.go
@@ -349,7 +349,7 @@ func ApplyPlan(ctx context.Context, config *stackconfig.Config, plan *stackplan.
 	})
 	diags := withDiags.Diagnostics
 	main := withDiags.Result
-	diags = diags.Append(diagnosticsForPromisingTaskError(err, main))
+	diags = diags.Append(diagnosticsForPromisingTaskError(err))
 	if len(diags) > 0 {
 		outp.AnnounceDiagnostics(ctx, diags)
 	}

--- a/internal/stacks/stackruntime/internal/stackeval/main_inspect.go
+++ b/internal/stacks/stackruntime/internal/stackeval/main_inspect.go
@@ -8,10 +8,11 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/hcl/v2"
+	"github.com/zclconf/go-cty/cty"
+
 	"github.com/hashicorp/terraform/internal/promising"
 	"github.com/hashicorp/terraform/internal/stacks/stackaddrs"
 	"github.com/hashicorp/terraform/internal/tfdiags"
-	"github.com/zclconf/go-cty/cty"
 )
 
 type InspectOpts struct {
@@ -78,7 +79,7 @@ func (m *Main) EvalExpr(ctx context.Context, expr hcl.Expression, scopeStackInst
 		}, nil
 	})
 	if err != nil {
-		ret.Diagnostics = ret.Diagnostics.Append(diagnosticsForPromisingTaskError(err, m))
+		ret.Diagnostics = ret.Diagnostics.Append(diagnosticsForPromisingTaskError(err))
 	}
 	return ret.Result, ret.Diagnostics
 }

--- a/internal/stacks/stackruntime/internal/stackeval/main_plan.go
+++ b/internal/stacks/stackruntime/internal/stackeval/main_plan.go
@@ -141,7 +141,7 @@ func (m *Main) PlanAll(ctx context.Context, outp PlanOutput) {
 		// of blocking until all of the async jobs are complete.
 		return complete(), nil
 	})
-	diags = diags.Append(diagnosticsForPromisingTaskError(err, m))
+	diags = diags.Append(diagnosticsForPromisingTaskError(err))
 	if len(diags) > 0 {
 		outp.AnnounceDiagnostics(ctx, diags)
 	}

--- a/internal/stacks/stackruntime/internal/stackeval/main_validate.go
+++ b/internal/stacks/stackruntime/internal/stackeval/main_validate.go
@@ -6,9 +6,10 @@ package stackeval
 import (
 	"context"
 
+	"go.opentelemetry.io/otel/codes"
+
 	"github.com/hashicorp/terraform/internal/promising"
 	"github.com/hashicorp/terraform/internal/tfdiags"
-	"go.opentelemetry.io/otel/codes"
 )
 
 // ValidateAll checks the validation rules for declared in the configuration
@@ -47,7 +48,7 @@ func (m *Main) ValidateAll(ctx context.Context) tfdiags.Diagnostics {
 
 		return complete(), nil
 	})
-	diags = diags.Append(diagnosticsForPromisingTaskError(err, m))
+	diags = diags.Append(diagnosticsForPromisingTaskError(err))
 	return finalDiagnosticsFromEval(diags)
 }
 

--- a/internal/stacks/stackruntime/internal/stackeval/output_value.go
+++ b/internal/stacks/stackruntime/internal/stackeval/output_value.go
@@ -113,7 +113,7 @@ func (v *OutputValue) ResultValue(ctx context.Context, phase EvalPhase) cty.Valu
 
 func (v *OutputValue) CheckResultValue(ctx context.Context, phase EvalPhase) (cty.Value, tfdiags.Diagnostics) {
 	return withCtyDynamicValPlaceholder(doOnceWithDiags(
-		ctx, v.resultValue.For(phase), v.main,
+		ctx, v.tracingName(), v.resultValue.For(phase),
 		func(ctx context.Context) (cty.Value, tfdiags.Diagnostics) {
 			var diags tfdiags.Diagnostics
 
@@ -329,12 +329,4 @@ func (v *OutputValue) CheckApply(ctx context.Context) ([]stackstate.AppliedChang
 
 func (v *OutputValue) tracingName() string {
 	return v.Addr().String()
-}
-
-// reportNamedPromises implements namedPromiseReporter.
-func (v *OutputValue) reportNamedPromises(cb func(id promising.PromiseID, name string)) {
-	name := v.Addr().String()
-	v.resultValue.Each(func(ep EvalPhase, o *promising.Once[withDiagnostics[cty.Value]]) {
-		cb(o.PromiseID(), name)
-	})
 }

--- a/internal/stacks/stackruntime/internal/stackeval/output_value_test.go
+++ b/internal/stacks/stackruntime/internal/stackeval/output_value_test.go
@@ -8,12 +8,13 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/zclconf/go-cty-debug/ctydebug"
+	"github.com/zclconf/go-cty/cty"
+
 	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/lang/marks"
 	"github.com/hashicorp/terraform/internal/promising"
 	"github.com/hashicorp/terraform/internal/stacks/stackaddrs"
-	"github.com/zclconf/go-cty-debug/ctydebug"
-	"github.com/zclconf/go-cty/cty"
 )
 
 func TestOutputValueResultValue(t *testing.T) {
@@ -329,7 +330,7 @@ func TestOutputValueEphemeralInChildStack(t *testing.T) {
 					Name: "child",
 					Key:  addrs.NoKey,
 				}
-				stack := rootStack.ChildStackChecked(ctx, childStackStep, ValidatePhase)
+				stack := rootStack.ChildStack(ctx, childStackStep, ValidatePhase)
 				output := stack.OutputValues(ctx)[outputAddr]
 				if output == nil {
 					t.Fatalf("missing %s", outputAddr)

--- a/internal/stacks/stackruntime/internal/stackeval/provider_config.go
+++ b/internal/stacks/stackruntime/internal/stackeval/provider_config.go
@@ -103,7 +103,7 @@ func CheckProviderInLockfile(locks depsfile.Locks, providerType *ProviderType, d
 
 func (p *ProviderConfig) CheckProviderArgs(ctx context.Context, phase EvalPhase) (cty.Value, tfdiags.Diagnostics) {
 	return doOnceWithDiags(
-		ctx, &p.providerArgs, p.main,
+		ctx, p.tracingName(), &p.providerArgs,
 		func(ctx context.Context) (cty.Value, tfdiags.Diagnostics) {
 			var diags tfdiags.Diagnostics
 
@@ -267,9 +267,4 @@ func (p *ProviderConfig) PlanChanges(ctx context.Context) ([]stackplan.PlannedCh
 // tracingName implements Validatable.
 func (p *ProviderConfig) tracingName() string {
 	return p.Addr().String()
-}
-
-// reportNamedPromises implements namedPromiseReporter.
-func (p *ProviderConfig) reportNamedPromises(cb func(id promising.PromiseID, name string)) {
-	cb(p.providerArgs.PromiseID(), p.Addr().String())
 }

--- a/internal/stacks/stackruntime/internal/stackeval/provider_config.go
+++ b/internal/stacks/stackruntime/internal/stackeval/provider_config.go
@@ -33,7 +33,7 @@ type ProviderConfig struct {
 
 	main *Main
 
-	providerArgs promising.Once[withDiagnostics[cty.Value]]
+	providerArgs perEvalPhase[promising.Once[withDiagnostics[cty.Value]]]
 }
 
 func newProviderConfig(main *Main, addr stackaddrs.ConfigProviderConfig, config *stackconfig.ProviderConfig) *ProviderConfig {
@@ -103,7 +103,7 @@ func CheckProviderInLockfile(locks depsfile.Locks, providerType *ProviderType, d
 
 func (p *ProviderConfig) CheckProviderArgs(ctx context.Context, phase EvalPhase) (cty.Value, tfdiags.Diagnostics) {
 	return doOnceWithDiags(
-		ctx, p.tracingName(), &p.providerArgs,
+		ctx, p.tracingName(), p.providerArgs.For(phase),
 		func(ctx context.Context) (cty.Value, tfdiags.Diagnostics) {
 			var diags tfdiags.Diagnostics
 

--- a/internal/stacks/stackruntime/internal/stackeval/provider_instance.go
+++ b/internal/stacks/stackruntime/internal/stackeval/provider_instance.go
@@ -273,8 +273,7 @@ func (p *ProviderInstance) CheckClient(ctx context.Context, phase EvalPhase) (pr
 // than the for_each argument inside a provider block, which get evaluated
 // once per provider instance.
 func (p *ProviderInstance) ResolveExpressionReference(ctx context.Context, ref stackaddrs.Reference) (Referenceable, tfdiags.Diagnostics) {
-	stack := p.provider.Stack(ctx)
-	return stack.resolveExpressionReference(ctx, ref, nil, p.repetition)
+	return p.provider.stack.resolveExpressionReference(ctx, ref, nil, p.repetition)
 }
 
 // ExternalFunctions implements ExpressionScope.

--- a/internal/stacks/stackruntime/internal/stackeval/provider_type.go
+++ b/internal/stacks/stackruntime/internal/stackeval/provider_type.go
@@ -84,7 +84,7 @@ func (pt *ProviderType) UnconfiguredClient() (providers.Interface, error) {
 }
 
 func (pt *ProviderType) Schema(ctx context.Context) (providers.GetProviderSchemaResponse, error) {
-	return pt.schema.Do(ctx, func(ctx context.Context) (providers.GetProviderSchemaResponse, error) {
+	return pt.schema.Do(ctx, pt.Addr().String()+" schema", func(ctx context.Context) (providers.GetProviderSchemaResponse, error) {
 		client, err := pt.UnconfiguredClient()
 		if err != nil {
 			return providers.GetProviderSchemaResponse{}, fmt.Errorf("provider startup failed: %w", err)
@@ -96,9 +96,4 @@ func (pt *ProviderType) Schema(ctx context.Context) (providers.GetProviderSchema
 		}
 		return ret, nil
 	})
-}
-
-// reportNamedPromises implements namedPromiseReporter.
-func (pt *ProviderType) reportNamedPromises(cb func(id promising.PromiseID, name string)) {
-	cb(pt.schema.PromiseID(), pt.Addr().String()+" schema")
 }

--- a/internal/stacks/stackruntime/internal/stackeval/refresh_instance.go
+++ b/internal/stacks/stackruntime/internal/stackeval/refresh_instance.go
@@ -35,15 +35,9 @@ func newRefreshInstance(component *ComponentInstance) *RefreshInstance {
 	}
 }
 
-// reportNamedPromises implements namedPromiseReporter.
-func (r *RefreshInstance) reportNamedPromises(cb func(id promising.PromiseID, name string)) {
-	cb(r.moduleTreePlan.PromiseID(), r.component.Addr().String()+" instance")
-	cb(r.result.PromiseID(), r.component.Addr().String()+" result")
-}
-
 // Result returns the outputs of the refresh action for this instance.
 func (r *RefreshInstance) Result(ctx context.Context) map[string]cty.Value {
-	result, err := r.result.Do(ctx, func(ctx context.Context) (map[string]cty.Value, error) {
+	result, err := r.result.Do(ctx, r.component.Addr().String()+" result", func(ctx context.Context) (map[string]cty.Value, error) {
 		config := r.component.ModuleTree(ctx)
 
 		plan, _ := r.Plan(ctx)
@@ -68,7 +62,7 @@ func (r *RefreshInstance) Result(ctx context.Context) map[string]cty.Value {
 }
 
 func (r *RefreshInstance) Plan(ctx context.Context) (*plans.Plan, tfdiags.Diagnostics) {
-	return doOnceWithDiags(ctx, &r.moduleTreePlan, r, func(ctx context.Context) (*plans.Plan, tfdiags.Diagnostics) {
+	return doOnceWithDiags(ctx, r.component.Addr().String()+" plan", &r.moduleTreePlan, func(ctx context.Context) (*plans.Plan, tfdiags.Diagnostics) {
 		opts, diags := r.component.PlanOpts(ctx, plans.NormalMode, false)
 		if opts == nil {
 			return nil, diags

--- a/internal/stacks/stackruntime/internal/stackeval/removed_config.go
+++ b/internal/stacks/stackruntime/internal/stackeval/removed_config.go
@@ -36,8 +36,8 @@ type RemovedConfig struct {
 
 	main *Main
 
-	validate   promising.Once[tfdiags.Diagnostics]
-	moduleTree promising.Once[withDiagnostics[*configs.Config]]
+	validate   perEvalPhase[promising.Once[tfdiags.Diagnostics]]
+	moduleTree promising.Once[withDiagnostics[*configs.Config]] // moduleTree is constant for every phase
 }
 
 func newRemovedConfig(main *Main, source stackaddrs.Stack, target stackaddrs.ConfigComponent, config *stackconfig.Removed) *RemovedConfig {
@@ -126,7 +126,7 @@ func (r *RemovedConfig) CheckModuleTree(ctx context.Context) (*configs.Config, t
 // CheckValid validates the module tree and provider configurations for the
 // component being removed.
 func (r *RemovedConfig) CheckValid(ctx context.Context, phase EvalPhase) tfdiags.Diagnostics {
-	diags, err := r.validate.Do(ctx, r.tracingName(), func(ctx context.Context) (tfdiags.Diagnostics, error) {
+	diags, err := r.validate.For(phase).Do(ctx, r.tracingName(), func(ctx context.Context) (tfdiags.Diagnostics, error) {
 		var diags tfdiags.Diagnostics
 
 		moduleTree, moreDiags := r.CheckModuleTree(ctx)

--- a/internal/stacks/stackruntime/internal/stackeval/removed_config.go
+++ b/internal/stacks/stackruntime/internal/stackeval/removed_config.go
@@ -49,12 +49,6 @@ func newRemovedConfig(main *Main, source stackaddrs.Stack, target stackaddrs.Con
 	}
 }
 
-// reportNamedPromises implements namedPromiseReporter.
-func (r *RemovedConfig) reportNamedPromises(cb func(id promising.PromiseID, name string)) {
-	cb(r.validate.PromiseID(), r.tracingName())
-	cb(r.moduleTree.PromiseID(), r.tracingName()+" modules")
-}
-
 // TargetComponentAbsolute implements ConfigComponentExpressionScope
 func (r *RemovedConfig) TargetComponentAbsolute() stackaddrs.ConfigComponent {
 	return stackaddrs.ConfigComponent{
@@ -81,7 +75,7 @@ func (r *RemovedConfig) ModuleTree(ctx context.Context) *configs.Config {
 // CheckModuleTree loads and validates the module tree for the component that
 // is being removed.
 func (r *RemovedConfig) CheckModuleTree(ctx context.Context) (*configs.Config, tfdiags.Diagnostics) {
-	return doOnceWithDiags(ctx, &r.moduleTree, r.main, func(ctx context.Context) (*configs.Config, tfdiags.Diagnostics) {
+	return doOnceWithDiags(ctx, r.tracingName()+" modules", &r.moduleTree, func(ctx context.Context) (*configs.Config, tfdiags.Diagnostics) {
 		var diags tfdiags.Diagnostics
 
 		decl := r.config
@@ -132,7 +126,7 @@ func (r *RemovedConfig) CheckModuleTree(ctx context.Context) (*configs.Config, t
 // CheckValid validates the module tree and provider configurations for the
 // component being removed.
 func (r *RemovedConfig) CheckValid(ctx context.Context, phase EvalPhase) tfdiags.Diagnostics {
-	diags, err := r.validate.Do(ctx, func(ctx context.Context) (tfdiags.Diagnostics, error) {
+	diags, err := r.validate.Do(ctx, r.tracingName(), func(ctx context.Context) (tfdiags.Diagnostics, error) {
 		var diags tfdiags.Diagnostics
 
 		moduleTree, moreDiags := r.CheckModuleTree(ctx)

--- a/internal/stacks/stackruntime/internal/stackeval/removed_instance.go
+++ b/internal/stacks/stackruntime/internal/stackeval/removed_instance.go
@@ -265,8 +265,7 @@ func (r *RemovedInstance) CheckApply(ctx context.Context) ([]stackstate.AppliedC
 
 // ResolveExpressionReference implements ExpressionScope.
 func (r *RemovedInstance) ResolveExpressionReference(ctx context.Context, ref stackaddrs.Reference) (Referenceable, tfdiags.Diagnostics) {
-	stack := r.call.Stack(ctx)
-	return stack.resolveExpressionReference(ctx, ref, nil, r.repetition)
+	return r.call.stack.resolveExpressionReference(ctx, ref, nil, r.repetition)
 }
 
 // PlanTimestamp implements ExpressionScope.

--- a/internal/stacks/stackruntime/internal/stackeval/removed_instance.go
+++ b/internal/stacks/stackruntime/internal/stackeval/removed_instance.go
@@ -57,11 +57,6 @@ func newRemovedInstance(call *Removed, from stackaddrs.AbsComponentInstance, rep
 	}
 }
 
-// reportNamedPromises implements namedPromiseReporter.
-func (r *RemovedInstance) reportNamedPromises(cb func(id promising.PromiseID, name string)) {
-	cb(r.moduleTreePlan.PromiseID(), r.tracingName()+" plan")
-}
-
 func (r *RemovedInstance) Addr() stackaddrs.AbsComponentInstance {
 	return r.from
 }
@@ -71,7 +66,7 @@ func (r *RemovedInstance) TargetComponentAbsolute() stackaddrs.AbsComponentInsta
 }
 
 func (r *RemovedInstance) ModuleTreePlan(ctx context.Context) (*plans.Plan, tfdiags.Diagnostics) {
-	return doOnceWithDiags(ctx, &r.moduleTreePlan, r.main, func(ctx context.Context) (*plans.Plan, tfdiags.Diagnostics) {
+	return doOnceWithDiags(ctx, r.tracingName()+" plan", &r.moduleTreePlan, func(ctx context.Context) (*plans.Plan, tfdiags.Diagnostics) {
 		var diags tfdiags.Diagnostics
 
 		known, unknown, moreDiags := EvalProviderValues(ctx, r.main, r.call.Config(ctx).config.ProviderConfigs, PlanPhase, r)

--- a/internal/stacks/stackruntime/internal/stackeval/stack.go
+++ b/internal/stacks/stackruntime/internal/stackeval/stack.go
@@ -18,7 +18,6 @@ import (
 	"github.com/hashicorp/terraform/internal/lang"
 	"github.com/hashicorp/terraform/internal/lang/marks"
 	"github.com/hashicorp/terraform/internal/plans"
-	"github.com/hashicorp/terraform/internal/promising"
 	"github.com/hashicorp/terraform/internal/stacks/stackaddrs"
 	"github.com/hashicorp/terraform/internal/stacks/stackconfig"
 	"github.com/hashicorp/terraform/internal/stacks/stackconfig/typeexpr"
@@ -945,29 +944,4 @@ func (s *Stack) tracingName() string {
 		return "root stack"
 	}
 	return addr.String()
-}
-
-// reportNamedPromises implements namedPromiseReporter.
-func (s *Stack) reportNamedPromises(cb func(id promising.PromiseID, name string)) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	for _, child := range s.childStacks {
-		child.reportNamedPromises(cb)
-	}
-	for _, child := range s.inputVariables {
-		child.reportNamedPromises(cb)
-	}
-	for _, child := range s.outputValues {
-		child.reportNamedPromises(cb)
-	}
-	for _, child := range s.stackCalls {
-		child.reportNamedPromises(cb)
-	}
-	for _, child := range s.components {
-		child.reportNamedPromises(cb)
-	}
-	for _, child := range s.providers {
-		child.reportNamedPromises(cb)
-	}
 }

--- a/internal/stacks/stackruntime/internal/stackeval/stack_call.go
+++ b/internal/stacks/stackruntime/internal/stackeval/stack_call.go
@@ -95,7 +95,7 @@ func (c *StackCall) ForEachValue(ctx context.Context, phase EvalPhase) cty.Value
 // that we cannot know the for_each value.
 func (c *StackCall) CheckForEachValue(ctx context.Context, phase EvalPhase) (cty.Value, tfdiags.Diagnostics) {
 	val, diags := doOnceWithDiags(
-		ctx, c.forEachValue.For(phase), c.main,
+		ctx, c.tracingName()+" for_each", c.forEachValue.For(phase),
 		func(ctx context.Context) (cty.Value, tfdiags.Diagnostics) {
 			var diags tfdiags.Diagnostics
 			cfg := c.Declaration(ctx)
@@ -149,7 +149,7 @@ func (c *StackCall) Instances(ctx context.Context, phase EvalPhase) (map[addrs.I
 
 func (c *StackCall) CheckInstances(ctx context.Context, phase EvalPhase) (map[addrs.InstanceKey]*StackCallInstance, bool, tfdiags.Diagnostics) {
 	result, diags := doOnceWithDiags(
-		ctx, c.instances.For(phase), c.main,
+		ctx, c.tracingName()+" instances", c.instances.For(phase),
 		func(ctx context.Context) (instancesResult[*StackCallInstance], tfdiags.Diagnostics) {
 			var diags tfdiags.Diagnostics
 			forEachVal, forEachValueDiags := c.CheckForEachValue(ctx, phase)
@@ -168,7 +168,7 @@ func (c *StackCall) CheckInstances(ctx context.Context, phase EvalPhase) (map[ad
 }
 
 func (c *StackCall) UnknownInstance(ctx context.Context, phase EvalPhase) *StackCallInstance {
-	inst, err := c.unknownInstance.For(phase).Do(ctx, func(ctx context.Context) (*StackCallInstance, error) {
+	inst, err := c.unknownInstance.For(phase).Do(ctx, c.tracingName()+" unknown instace", func(ctx context.Context) (*StackCallInstance, error) {
 		return newStackCallInstance(c, addrs.WildcardKey, instances.UnknownForEachRepetitionData(c.ForEachValue(ctx, phase).Type())), nil
 	})
 	if err != nil {
@@ -283,25 +283,4 @@ func (c *StackCall) CheckApply(ctx context.Context) ([]stackstate.AppliedChange,
 
 func (c *StackCall) tracingName() string {
 	return c.Addr().String()
-}
-
-// reportNamedPromises implements namedPromiseReporter.
-func (c *StackCall) reportNamedPromises(cb func(id promising.PromiseID, name string)) {
-	name := c.Addr().String()
-	instsName := name + " instances"
-	forEachName := name + " for_each"
-	c.instances.Each(func(ep EvalPhase, o *promising.Once[withDiagnostics[instancesResult[*StackCallInstance]]]) {
-		cb(o.PromiseID(), instsName)
-	})
-	// FIXME: We should call reportNamedPromises on the individual
-	// StackCallInstance objects too, but promising.Once doesn't allow us
-	// to peek to see if the Once was already resolved without blocking on
-	// it, and we don't want to block on any promises in here.
-	// Without this, any promises belonging to the individual instances will
-	// not be named in a self-dependency error report, but since references
-	// to stack call instances are always indirect through the stack call this
-	// shouldn't be a big deal in most cases.
-	c.forEachValue.Each(func(ep EvalPhase, o *promising.Once[withDiagnostics[cty.Value]]) {
-		cb(o.PromiseID(), forEachName)
-	})
 }

--- a/internal/stacks/stackruntime/internal/stackeval/stack_call_config.go
+++ b/internal/stacks/stackruntime/internal/stackeval/stack_call_config.go
@@ -37,7 +37,6 @@ type StackCallConfig struct {
 var _ Validatable = (*StackCallConfig)(nil)
 var _ Referenceable = (*StackCallConfig)(nil)
 var _ ExpressionScope = (*StackCallConfig)(nil)
-var _ namedPromiseReporter = (*StackCallConfig)(nil)
 
 func newStackCallConfig(main *Main, addr stackaddrs.ConfigStackCall, config *stackconfig.EmbeddedStack) *StackCallConfig {
 	return &StackCallConfig{
@@ -104,7 +103,7 @@ func (s *StackCallConfig) ResultType(ctx context.Context) cty.Type {
 // unknown value.
 func (s *StackCallConfig) ValidateForEachValue(ctx context.Context, phase EvalPhase) (cty.Value, tfdiags.Diagnostics) {
 	return withCtyDynamicValPlaceholder(doOnceWithDiags(
-		ctx, s.forEachValue.For(phase), s.main,
+		ctx, s.tracingName()+" for_each", s.forEachValue.For(phase),
 		s.validateForEachValueInner,
 	))
 }
@@ -136,7 +135,7 @@ func (s *StackCallConfig) validateForEachValueInner(ctx context.Context) (cty.Va
 // variable declarations.
 func (s *StackCallConfig) ValidateInputVariableValues(ctx context.Context, phase EvalPhase) (map[stackaddrs.InputVariable]cty.Value, tfdiags.Diagnostics) {
 	return doOnceWithDiags(
-		ctx, s.inputVariableValues.For(phase), s.main,
+		ctx, s.tracingName()+" inputs", s.inputVariableValues.For(phase),
 		s.validateInputVariableValuesInner,
 	)
 }
@@ -269,7 +268,7 @@ func (s *StackCallConfig) ResultValue(ctx context.Context, phase EvalPhase) cty.
 // errors.
 func (s *StackCallConfig) ValidateResultValue(ctx context.Context, phase EvalPhase) (cty.Value, tfdiags.Diagnostics) {
 	return withCtyDynamicValPlaceholder(doOnceWithDiags(
-		ctx, s.resultValue.For(phase), s.main,
+		ctx, s.tracingName()+" collected outputs", s.resultValue.For(phase),
 		func(ctx context.Context) (cty.Value, tfdiags.Diagnostics) {
 			var diags tfdiags.Diagnostics
 
@@ -378,24 +377,4 @@ func (s *StackCallConfig) PlanChanges(ctx context.Context) ([]stackplan.PlannedC
 // ExprReferenceValue implements Referenceable.
 func (s *StackCallConfig) ExprReferenceValue(ctx context.Context, phase EvalPhase) cty.Value {
 	return s.ResultValue(ctx, phase)
-}
-
-// reportNamedPromises implements namedPromiseReporter.
-func (s *StackCallConfig) reportNamedPromises(cb func(id promising.PromiseID, name string)) {
-	// We'll report the same names for each promise in a given category
-	// because promises from different phases should not typically interact
-	// with one another and so mentioning phase here will typically just
-	// make error messages more confusing.
-	forEachName := s.Addr().String() + " for_each"
-	s.forEachValue.Each(func(ep EvalPhase, once *promising.Once[withDiagnostics[cty.Value]]) {
-		cb(once.PromiseID(), forEachName)
-	})
-	inputsName := s.Addr().String() + " inputs"
-	s.inputVariableValues.Each(func(ep EvalPhase, once *promising.Once[withDiagnostics[map[stackaddrs.InputVariable]cty.Value]]) {
-		cb(once.PromiseID(), inputsName)
-	})
-	resultName := s.Addr().String() + " collected outputs"
-	s.resultValue.Each(func(ep EvalPhase, once *promising.Once[withDiagnostics[cty.Value]]) {
-		cb(once.PromiseID(), resultName)
-	})
 }

--- a/internal/stacks/stackruntime/internal/stackeval/stack_call_instance.go
+++ b/internal/stacks/stackruntime/internal/stackeval/stack_call_instance.go
@@ -16,7 +16,6 @@ import (
 	"github.com/hashicorp/terraform/internal/instances"
 	"github.com/hashicorp/terraform/internal/lang"
 	"github.com/hashicorp/terraform/internal/lang/marks"
-	"github.com/hashicorp/terraform/internal/promising"
 	"github.com/hashicorp/terraform/internal/stacks/stackaddrs"
 	"github.com/hashicorp/terraform/internal/stacks/stackplan"
 	"github.com/hashicorp/terraform/internal/stacks/stackstate"
@@ -266,9 +265,4 @@ func (c *StackCallInstance) CheckApply(ctx context.Context) ([]stackstate.Applie
 // tracingName implements Plannable.
 func (c *StackCallInstance) tracingName() string {
 	return fmt.Sprintf("%s call", c.CalledStackAddr())
-}
-
-// reportNamedPromises implements namedPromiseReporter.
-func (c *StackCallInstance) reportNamedPromises(cb func(id promising.PromiseID, name string)) {
-	// StackCallInstance does not currently own any promises
 }

--- a/internal/stacks/stackruntime/internal/stackeval/stack_config.go
+++ b/internal/stacks/stackruntime/internal/stackeval/stack_config.go
@@ -16,7 +16,6 @@ import (
 	"github.com/hashicorp/terraform/internal/collections"
 	"github.com/hashicorp/terraform/internal/instances"
 	"github.com/hashicorp/terraform/internal/lang"
-	"github.com/hashicorp/terraform/internal/promising"
 	"github.com/hashicorp/terraform/internal/stacks/stackaddrs"
 	"github.com/hashicorp/terraform/internal/stacks/stackconfig"
 	"github.com/hashicorp/terraform/internal/tfdiags"
@@ -56,8 +55,7 @@ type StackConfig struct {
 }
 
 var (
-	_ ExpressionScope      = (*StackConfig)(nil)
-	_ namedPromiseReporter = (*StackConfig)(nil)
+	_ ExpressionScope = (*StackConfig)(nil)
 )
 
 func newStackConfig(main *Main, addr stackaddrs.Stack, config *stackconfig.ConfigNode, externalRemovedBlocks collections.Map[stackaddrs.ConfigComponent, []*RemovedConfig]) *StackConfig {
@@ -678,29 +676,4 @@ func (s *StackConfig) ExternalFunctions(ctx context.Context) (lang.ExternalFuncs
 // the current plan is being run.
 func (s *StackConfig) PlanTimestamp() time.Time {
 	return s.main.PlanTimestamp()
-}
-
-// reportNamedPromises implements namedPromiseReporter.
-func (s *StackConfig) reportNamedPromises(cb func(id promising.PromiseID, name string)) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	for _, child := range s.children {
-		child.reportNamedPromises(cb)
-	}
-	for _, child := range s.inputVariables {
-		child.reportNamedPromises(cb)
-	}
-	for _, child := range s.outputValues {
-		child.reportNamedPromises(cb)
-	}
-	for _, child := range s.stackCalls {
-		child.reportNamedPromises(cb)
-	}
-	for _, child := range s.components {
-		child.reportNamedPromises(cb)
-	}
-	for _, child := range s.providers {
-		child.reportNamedPromises(cb)
-	}
 }

--- a/internal/stacks/stackruntime/internal/stackeval/walk_dynamic.go
+++ b/internal/stacks/stackruntime/internal/stackeval/walk_dynamic.go
@@ -179,7 +179,10 @@ func walkDynamicObjectsInStack[Output any](
 					} else {
 						// Otherwise, the key is a known key and the instance
 						// actually does exist.
-						inst := newComponentInstance(component, inst.Key, instances.RepetitionData{
+						inst := newComponentInstance(component, stackaddrs.AbsComponentInstance{
+							Stack: stack.addr,
+							Item:  inst,
+						}, instances.RepetitionData{
 							EachKey:   inst.Key.Value(),
 							EachValue: cty.UnknownVal(cty.DynamicPseudoType),
 						}, true)

--- a/internal/stacks/stackruntime/plan_test.go
+++ b/internal/stacks/stackruntime/plan_test.go
@@ -1346,6 +1346,340 @@ func TestPlan(t *testing.T) {
 				}),
 			},
 		},
+		"deferred-embedded-stack-update": {
+			path: path.Join("with-single-input", "deferred-embedded-stack-for-each"),
+			state: stackstate.NewStateBuilder().
+				AddComponentInstance(stackstate.NewComponentInstanceBuilder(mustAbsComponentInstance("stack.a[\"deferred\"].component.self")).
+					AddInputVariable("id", cty.StringVal("deferred")).
+					AddInputVariable("input", cty.StringVal("deferred"))).
+				AddResourceInstance(stackstate.NewResourceInstanceBuilder().
+					SetAddr(mustAbsResourceInstanceObject("stack.a[\"deferred\"].component.self.testing_resource.data")).
+					SetProviderAddr(mustDefaultRootProvider("testing")).
+					SetResourceInstanceObjectSrc(states.ResourceInstanceObjectSrc{
+						Status: states.ObjectReady,
+						AttrsJSON: mustMarshalJSONAttrs(map[string]any{
+							"id":    "deferred",
+							"value": "deferred",
+						}),
+					})).
+				AddInput("stacks", cty.MapVal(map[string]cty.Value{
+					"deferred": cty.StringVal("deferred"),
+				})).
+				Build(),
+			store: stacks_testing_provider.NewResourceStoreBuilder().
+				AddResource("deferred", cty.ObjectVal(map[string]cty.Value{
+					"id":    cty.StringVal("deferred"),
+					"value": cty.StringVal("deferred"),
+				})).
+				Build(),
+			cycle: TestCycle{
+				planInputs: map[string]cty.Value{
+					"stacks": cty.UnknownVal(cty.Map(cty.String)),
+				},
+				wantPlannedChanges: []stackplan.PlannedChange{
+					&stackplan.PlannedChangeApplyable{
+						Applyable: true,
+					},
+					&stackplan.PlannedChangeHeader{
+						TerraformVersion: version.SemVer,
+					},
+					&stackplan.PlannedChangePlannedTimestamp{
+						PlannedTimestamp: fakePlanTimestamp,
+					},
+					&stackplan.PlannedChangeComponentInstance{
+						Addr: stackaddrs.Absolute(
+							stackaddrs.RootStackInstance.Child("a", addrs.StringKey("deferred")),
+							stackaddrs.ComponentInstance{
+								Component: stackaddrs.Component{Name: "self"},
+							},
+						),
+						PlanApplyable: false, // Everything is deferred, so nothing to apply.
+						PlanComplete:  false,
+						Action:        plans.Update,
+						PlannedInputValues: map[string]plans.DynamicValue{
+							"id":    mustPlanDynamicValueDynamicType(cty.UnknownVal(cty.String)),
+							"input": mustPlanDynamicValueDynamicType(cty.UnknownVal(cty.String)),
+						},
+						PlannedOutputValues: map[string]cty.Value{},
+						PlannedCheckResults: &states.CheckResults{},
+						PlanTimestamp:       fakePlanTimestamp,
+						PlannedInputValueMarks: map[string][]cty.PathValueMarks{
+							"id":    nil,
+							"input": nil,
+						},
+					},
+					&stackplan.PlannedChangeDeferredResourceInstancePlanned{
+						DeferredReason: providers.DeferredReasonDeferredPrereq,
+						ResourceInstancePlanned: stackplan.PlannedChangeResourceInstancePlanned{
+							ResourceInstanceObjectAddr: stackaddrs.AbsResourceInstanceObject{
+								Component: stackaddrs.Absolute(
+									stackaddrs.RootStackInstance.Child("a", addrs.StringKey("deferred")),
+									stackaddrs.ComponentInstance{
+										Component: stackaddrs.Component{Name: "self"},
+									},
+								),
+								Item: addrs.AbsResourceInstanceObject{
+									ResourceInstance: addrs.Resource{
+										Mode: addrs.ManagedResourceMode,
+										Type: "testing_resource",
+										Name: "data",
+									}.Instance(addrs.NoKey).Absolute(addrs.RootModuleInstance),
+								},
+							},
+							ProviderConfigAddr: addrs.AbsProviderConfig{
+								Module:   addrs.RootModule,
+								Provider: addrs.MustParseProviderSourceString("hashicorp/testing"),
+							},
+							ChangeSrc: &plans.ResourceInstanceChangeSrc{
+								Addr: addrs.Resource{
+									Mode: addrs.ManagedResourceMode,
+									Type: "testing_resource",
+									Name: "data",
+								}.Instance(addrs.NoKey).Absolute(addrs.RootModuleInstance),
+								PrevRunAddr: addrs.Resource{
+									Mode: addrs.ManagedResourceMode,
+									Type: "testing_resource",
+									Name: "data",
+								}.Instance(addrs.NoKey).Absolute(addrs.RootModuleInstance),
+								ProviderAddr: addrs.AbsProviderConfig{
+									Module:   addrs.RootModule,
+									Provider: addrs.MustParseProviderSourceString("hashicorp/testing"),
+								},
+								ActionReason: plans.ResourceInstanceReplaceBecauseCannotUpdate,
+								RequiredReplace: cty.NewPathSet(
+									cty.GetAttrPath("id"),
+								),
+								ChangeSrc: plans.ChangeSrc{
+									Action: plans.DeleteThenCreate,
+									Before: mustPlanDynamicValueSchema(cty.ObjectVal(map[string]cty.Value{
+										"id":    cty.StringVal("deferred"),
+										"value": cty.StringVal("deferred"),
+									}), stacks_testing_provider.TestingResourceSchema.Body),
+									After: mustPlanDynamicValueSchema(cty.ObjectVal(map[string]cty.Value{
+										"id":    cty.UnknownVal(cty.String),
+										"value": cty.UnknownVal(cty.String),
+									}), stacks_testing_provider.TestingResourceSchema.Body),
+									AfterSensitivePaths: nil,
+								},
+							},
+							PriorStateSrc: &states.ResourceInstanceObjectSrc{
+								Status: states.ObjectReady,
+								AttrsJSON: mustMarshalJSONAttrs(map[string]any{
+									"id":    "deferred",
+									"value": "deferred",
+								}),
+								Dependencies: make([]addrs.ConfigResource, 0),
+							},
+							Schema: stacks_testing_provider.TestingResourceSchema,
+						},
+					},
+					&stackplan.PlannedChangeRootInputValue{
+						Addr:   stackaddrs.InputVariable{Name: "stacks"},
+						Action: plans.Update,
+						Before: cty.MapVal(map[string]cty.Value{
+							"deferred": cty.StringVal("deferred"),
+						}),
+						After: cty.UnknownVal(cty.Map(cty.String)),
+					},
+				},
+			},
+		},
+		"deferred-embedded-stack-create": {
+			path: path.Join("with-single-input", "deferred-embedded-stack-for-each"),
+			cycle: TestCycle{
+				planInputs: map[string]cty.Value{
+					"stacks": cty.UnknownVal(cty.Map(cty.String)),
+				},
+				wantPlannedChanges: []stackplan.PlannedChange{
+					&stackplan.PlannedChangeApplyable{
+						Applyable: true,
+					},
+					&stackplan.PlannedChangeHeader{
+						TerraformVersion: version.SemVer,
+					},
+					&stackplan.PlannedChangePlannedTimestamp{
+						PlannedTimestamp: fakePlanTimestamp,
+					},
+					&stackplan.PlannedChangeComponentInstance{
+						Addr: stackaddrs.Absolute(
+							stackaddrs.RootStackInstance.Child("a", addrs.WildcardKey),
+							stackaddrs.ComponentInstance{
+								Component: stackaddrs.Component{Name: "self"},
+							},
+						),
+						PlanApplyable: false, // Everything is deferred, so nothing to apply.
+						PlanComplete:  false,
+						Action:        plans.Create,
+						PlannedInputValues: map[string]plans.DynamicValue{
+							"id":    mustPlanDynamicValueDynamicType(cty.UnknownVal(cty.String)),
+							"input": mustPlanDynamicValueDynamicType(cty.UnknownVal(cty.String)),
+						},
+						PlannedOutputValues: map[string]cty.Value{},
+						PlannedCheckResults: &states.CheckResults{},
+						PlanTimestamp:       fakePlanTimestamp,
+						PlannedInputValueMarks: map[string][]cty.PathValueMarks{
+							"id":    nil,
+							"input": nil,
+						},
+					},
+					&stackplan.PlannedChangeDeferredResourceInstancePlanned{
+						DeferredReason: providers.DeferredReasonDeferredPrereq,
+						ResourceInstancePlanned: stackplan.PlannedChangeResourceInstancePlanned{
+							ResourceInstanceObjectAddr: stackaddrs.AbsResourceInstanceObject{
+								Component: stackaddrs.Absolute(
+									stackaddrs.RootStackInstance.Child("a", addrs.WildcardKey),
+									stackaddrs.ComponentInstance{
+										Component: stackaddrs.Component{Name: "self"},
+									},
+								),
+								Item: addrs.AbsResourceInstanceObject{
+									ResourceInstance: addrs.Resource{
+										Mode: addrs.ManagedResourceMode,
+										Type: "testing_resource",
+										Name: "data",
+									}.Instance(addrs.NoKey).Absolute(addrs.RootModuleInstance),
+								},
+							},
+							ProviderConfigAddr: addrs.AbsProviderConfig{
+								Module:   addrs.RootModule,
+								Provider: addrs.MustParseProviderSourceString("hashicorp/testing"),
+							},
+							ChangeSrc: &plans.ResourceInstanceChangeSrc{
+								Addr: addrs.Resource{
+									Mode: addrs.ManagedResourceMode,
+									Type: "testing_resource",
+									Name: "data",
+								}.Instance(addrs.NoKey).Absolute(addrs.RootModuleInstance),
+								PrevRunAddr: addrs.Resource{
+									Mode: addrs.ManagedResourceMode,
+									Type: "testing_resource",
+									Name: "data",
+								}.Instance(addrs.NoKey).Absolute(addrs.RootModuleInstance),
+								ProviderAddr: addrs.AbsProviderConfig{
+									Module:   addrs.RootModule,
+									Provider: addrs.MustParseProviderSourceString("hashicorp/testing"),
+								},
+								ChangeSrc: plans.ChangeSrc{
+									Action: plans.Create,
+									Before: mustPlanDynamicValue(cty.NullVal(cty.DynamicPseudoType)),
+									After: mustPlanDynamicValueSchema(cty.ObjectVal(map[string]cty.Value{
+										"id":    cty.UnknownVal(cty.String),
+										"value": cty.UnknownVal(cty.String),
+									}), stacks_testing_provider.TestingResourceSchema.Body),
+									AfterSensitivePaths: nil,
+								},
+							},
+							Schema: stacks_testing_provider.TestingResourceSchema,
+						},
+					},
+					&stackplan.PlannedChangeRootInputValue{
+						Addr:   stackaddrs.InputVariable{Name: "stacks"},
+						Action: plans.Create,
+						Before: cty.NullVal(cty.DynamicPseudoType),
+						After:  cty.UnknownVal(cty.Map(cty.String)),
+					},
+				},
+			},
+		},
+		"deferred-embedded-stack-and-component-for-each": {
+			path: path.Join("with-single-input", "deferred-embedded-stack-and-component-for-each"),
+			cycle: TestCycle{
+				planInputs: map[string]cty.Value{
+					"stacks": cty.UnknownVal(cty.Map(cty.Set(cty.String))),
+				},
+				wantPlannedChanges: []stackplan.PlannedChange{
+					&stackplan.PlannedChangeApplyable{
+						Applyable: true,
+					},
+					&stackplan.PlannedChangeHeader{
+						TerraformVersion: version.SemVer,
+					},
+					&stackplan.PlannedChangePlannedTimestamp{
+						PlannedTimestamp: fakePlanTimestamp,
+					},
+					&stackplan.PlannedChangeComponentInstance{
+						Addr: stackaddrs.Absolute(
+							stackaddrs.RootStackInstance.Child("a", addrs.WildcardKey),
+							stackaddrs.ComponentInstance{
+								Component: stackaddrs.Component{Name: "self"},
+								Key:       addrs.WildcardKey,
+							},
+						),
+						PlanApplyable: false, // Everything is deferred, so nothing to apply.
+						PlanComplete:  false,
+						Action:        plans.Create,
+						PlannedInputValues: map[string]plans.DynamicValue{
+							"id":    mustPlanDynamicValueDynamicType(cty.NullVal(cty.String)),
+							"input": mustPlanDynamicValueDynamicType(cty.UnknownVal(cty.String)),
+						},
+						PlannedOutputValues: map[string]cty.Value{},
+						PlannedCheckResults: &states.CheckResults{},
+						PlanTimestamp:       fakePlanTimestamp,
+						PlannedInputValueMarks: map[string][]cty.PathValueMarks{
+							"id":    nil,
+							"input": nil,
+						},
+					},
+					&stackplan.PlannedChangeDeferredResourceInstancePlanned{
+						DeferredReason: providers.DeferredReasonDeferredPrereq,
+						ResourceInstancePlanned: stackplan.PlannedChangeResourceInstancePlanned{
+							ResourceInstanceObjectAddr: stackaddrs.AbsResourceInstanceObject{
+								Component: stackaddrs.Absolute(
+									stackaddrs.RootStackInstance.Child("a", addrs.WildcardKey),
+									stackaddrs.ComponentInstance{
+										Component: stackaddrs.Component{Name: "self"},
+										Key:       addrs.WildcardKey,
+									},
+								),
+								Item: addrs.AbsResourceInstanceObject{
+									ResourceInstance: addrs.Resource{
+										Mode: addrs.ManagedResourceMode,
+										Type: "testing_resource",
+										Name: "data",
+									}.Instance(addrs.NoKey).Absolute(addrs.RootModuleInstance),
+								},
+							},
+							ProviderConfigAddr: addrs.AbsProviderConfig{
+								Module:   addrs.RootModule,
+								Provider: addrs.MustParseProviderSourceString("hashicorp/testing"),
+							},
+							ChangeSrc: &plans.ResourceInstanceChangeSrc{
+								Addr: addrs.Resource{
+									Mode: addrs.ManagedResourceMode,
+									Type: "testing_resource",
+									Name: "data",
+								}.Instance(addrs.NoKey).Absolute(addrs.RootModuleInstance),
+								PrevRunAddr: addrs.Resource{
+									Mode: addrs.ManagedResourceMode,
+									Type: "testing_resource",
+									Name: "data",
+								}.Instance(addrs.NoKey).Absolute(addrs.RootModuleInstance),
+								ProviderAddr: addrs.AbsProviderConfig{
+									Module:   addrs.RootModule,
+									Provider: addrs.MustParseProviderSourceString("hashicorp/testing"),
+								},
+								ChangeSrc: plans.ChangeSrc{
+									Action: plans.Create,
+									Before: mustPlanDynamicValue(cty.NullVal(cty.DynamicPseudoType)),
+									After: mustPlanDynamicValueSchema(cty.ObjectVal(map[string]cty.Value{
+										"id":    cty.UnknownVal(cty.String),
+										"value": cty.UnknownVal(cty.String),
+									}), stacks_testing_provider.TestingResourceSchema.Body),
+									AfterSensitivePaths: nil,
+								},
+							},
+							Schema: stacks_testing_provider.TestingResourceSchema,
+						},
+					},
+					&stackplan.PlannedChangeRootInputValue{
+						Addr:   stackaddrs.InputVariable{Name: "stacks"},
+						Action: plans.Create,
+						Before: cty.NullVal(cty.DynamicPseudoType),
+						After:  cty.UnknownVal(cty.Map(cty.Set(cty.String))),
+					},
+				},
+			},
+		},
 	}
 	for name, tc := range tcs {
 		t.Run(name, func(t *testing.T) {
@@ -3929,304 +4263,6 @@ func TestPlanWithDeferredComponentReferences(t *testing.T) {
 			Action: plans.Create,
 			Before: cty.NullVal(cty.DynamicPseudoType),
 			After:  cty.UnknownVal(cty.Set(cty.String)),
-		},
-	}
-
-	if diff := cmp.Diff(wantChanges, gotChanges, changesCmpOpts); diff != "" {
-		t.Errorf("wrong changes\n%s", diff)
-	}
-}
-
-// This test verifies that if an embedded stack is configured with a for_each value that is unknown / deferred
-// that the plan will use the wildcard key for the embedded stack and that the components within are planned with
-// unknown values.
-func TestPlanWithDeferredEmbeddedStackForEach(t *testing.T) {
-	ctx := context.Background()
-	cfg := loadMainBundleConfigForTest(t, path.Join("with-single-input", "deferred-embedded-stack-for-each"))
-
-	fakePlanTimestamp, err := time.Parse(time.RFC3339, "1991-08-25T20:57:08Z")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	changesCh := make(chan stackplan.PlannedChange, 8)
-	diagsCh := make(chan tfdiags.Diagnostic, 2)
-	lock := depsfile.NewLocks()
-	lock.SetProvider(
-		addrs.NewDefaultProvider("testing"),
-		providerreqs.MustParseVersion("0.0.0"),
-		providerreqs.MustParseVersionConstraints("=0.0.0"),
-		providerreqs.PreferredHashes([]providerreqs.Hash{}),
-	)
-	req := PlanRequest{
-		Config: cfg,
-		ProviderFactories: map[addrs.Provider]providers.Factory{
-			addrs.NewDefaultProvider("testing"): func() (providers.Interface, error) {
-				return stacks_testing_provider.NewProvider(t), nil
-			},
-		},
-		DependencyLocks:    *lock,
-		ForcePlanTimestamp: &fakePlanTimestamp,
-		InputValues: map[stackaddrs.InputVariable]ExternalInputValue{
-			{Name: "stacks"}: {
-				Value:    cty.UnknownVal(cty.Set(cty.String)),
-				DefRange: tfdiags.SourceRange{},
-			},
-		},
-	}
-	resp := PlanResponse{
-		PlannedChanges: changesCh,
-		Diagnostics:    diagsCh,
-	}
-	go Plan(ctx, &req, &resp)
-	gotChanges, diags := collectPlanOutput(changesCh, diagsCh)
-
-	reportDiagnosticsForTest(t, diags)
-	if len(diags) != 0 {
-		t.FailNow() // We reported the diags above/
-	}
-
-	sort.SliceStable(gotChanges, func(i, j int) bool {
-		return plannedChangeSortKey(gotChanges[i]) < plannedChangeSortKey(gotChanges[j])
-	})
-
-	wantChanges := []stackplan.PlannedChange{
-		&stackplan.PlannedChangeApplyable{
-			Applyable: true,
-		},
-		&stackplan.PlannedChangeHeader{
-			TerraformVersion: version.SemVer,
-		},
-		&stackplan.PlannedChangePlannedTimestamp{
-			PlannedTimestamp: fakePlanTimestamp,
-		},
-		&stackplan.PlannedChangeComponentInstance{
-			Addr: stackaddrs.Absolute(
-				stackaddrs.RootStackInstance.Child("a", addrs.WildcardKey),
-				stackaddrs.ComponentInstance{
-					Component: stackaddrs.Component{Name: "self"},
-				},
-			),
-			PlanApplyable: false, // Everything is deferred, so nothing to apply.
-			PlanComplete:  false,
-			Action:        plans.Create,
-			PlannedInputValues: map[string]plans.DynamicValue{
-				"id":    mustPlanDynamicValueDynamicType(cty.NullVal(cty.String)),
-				"input": mustPlanDynamicValueDynamicType(cty.UnknownVal(cty.String)),
-			},
-			PlannedOutputValues: map[string]cty.Value{},
-			PlannedCheckResults: &states.CheckResults{},
-			PlanTimestamp:       fakePlanTimestamp,
-			PlannedInputValueMarks: map[string][]cty.PathValueMarks{
-				"id":    nil,
-				"input": nil,
-			},
-		},
-		&stackplan.PlannedChangeDeferredResourceInstancePlanned{
-			DeferredReason: providers.DeferredReasonDeferredPrereq,
-			ResourceInstancePlanned: stackplan.PlannedChangeResourceInstancePlanned{
-				ResourceInstanceObjectAddr: stackaddrs.AbsResourceInstanceObject{
-					Component: stackaddrs.Absolute(
-						stackaddrs.RootStackInstance.Child("a", addrs.WildcardKey),
-						stackaddrs.ComponentInstance{
-							Component: stackaddrs.Component{Name: "self"},
-						},
-					),
-					Item: addrs.AbsResourceInstanceObject{
-						ResourceInstance: addrs.Resource{
-							Mode: addrs.ManagedResourceMode,
-							Type: "testing_resource",
-							Name: "data",
-						}.Instance(addrs.NoKey).Absolute(addrs.RootModuleInstance),
-					},
-				},
-				ProviderConfigAddr: addrs.AbsProviderConfig{
-					Module:   addrs.RootModule,
-					Provider: addrs.MustParseProviderSourceString("hashicorp/testing"),
-				},
-				ChangeSrc: &plans.ResourceInstanceChangeSrc{
-					Addr: addrs.Resource{
-						Mode: addrs.ManagedResourceMode,
-						Type: "testing_resource",
-						Name: "data",
-					}.Instance(addrs.NoKey).Absolute(addrs.RootModuleInstance),
-					PrevRunAddr: addrs.Resource{
-						Mode: addrs.ManagedResourceMode,
-						Type: "testing_resource",
-						Name: "data",
-					}.Instance(addrs.NoKey).Absolute(addrs.RootModuleInstance),
-					ProviderAddr: addrs.AbsProviderConfig{
-						Module:   addrs.RootModule,
-						Provider: addrs.MustParseProviderSourceString("hashicorp/testing"),
-					},
-					ChangeSrc: plans.ChangeSrc{
-						Action: plans.Create,
-						Before: mustPlanDynamicValue(cty.NullVal(cty.DynamicPseudoType)),
-						After: mustPlanDynamicValueSchema(cty.ObjectVal(map[string]cty.Value{
-							"id":    cty.UnknownVal(cty.String),
-							"value": cty.UnknownVal(cty.String),
-						}), stacks_testing_provider.TestingResourceSchema.Body),
-						AfterSensitivePaths: nil,
-					},
-				},
-				Schema: stacks_testing_provider.TestingResourceSchema,
-			},
-		},
-		&stackplan.PlannedChangeRootInputValue{
-			Addr:   stackaddrs.InputVariable{Name: "stacks"},
-			Action: plans.Create,
-			Before: cty.NullVal(cty.DynamicPseudoType),
-			After:  cty.UnknownVal(cty.Set(cty.String)),
-		},
-	}
-
-	if diff := cmp.Diff(wantChanges, gotChanges, changesCmpOpts); diff != "" {
-		t.Errorf("wrong changes\n%s", diff)
-	}
-}
-
-// This test checks that a stack with an embedded stack with unknown for-each value
-// and within the embedded stack a component with a for-each value that is deferred
-// will plan successfully.
-func TestPlanWithDeferredEmbeddedStackAndComponentForEach(t *testing.T) {
-	ctx := context.Background()
-	cfg := loadMainBundleConfigForTest(t, path.Join("with-single-input", "deferred-embedded-stack-and-component-for-each"))
-
-	fakePlanTimestamp, err := time.Parse(time.RFC3339, "1991-08-25T20:57:08Z")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	changesCh := make(chan stackplan.PlannedChange, 8)
-	diagsCh := make(chan tfdiags.Diagnostic, 2)
-	lock := depsfile.NewLocks()
-	lock.SetProvider(
-		addrs.NewDefaultProvider("testing"),
-		providerreqs.MustParseVersion("0.0.0"),
-		providerreqs.MustParseVersionConstraints("=0.0.0"),
-		providerreqs.PreferredHashes([]providerreqs.Hash{}),
-	)
-	req := PlanRequest{
-		Config: cfg,
-		ProviderFactories: map[addrs.Provider]providers.Factory{
-			addrs.NewDefaultProvider("testing"): func() (providers.Interface, error) {
-				return stacks_testing_provider.NewProvider(t), nil
-			},
-		},
-		DependencyLocks:    *lock,
-		ForcePlanTimestamp: &fakePlanTimestamp,
-		InputValues: map[stackaddrs.InputVariable]ExternalInputValue{
-			{Name: "stacks"}: {
-				Value:    cty.UnknownVal(cty.Map(cty.Set(cty.String))),
-				DefRange: tfdiags.SourceRange{},
-			},
-		},
-	}
-	resp := PlanResponse{
-		PlannedChanges: changesCh,
-		Diagnostics:    diagsCh,
-	}
-	go Plan(ctx, &req, &resp)
-	gotChanges, diags := collectPlanOutput(changesCh, diagsCh)
-
-	reportDiagnosticsForTest(t, diags)
-	if len(diags) != 0 {
-		t.FailNow() // We reported the diags above/
-	}
-
-	sort.SliceStable(gotChanges, func(i, j int) bool {
-		return plannedChangeSortKey(gotChanges[i]) < plannedChangeSortKey(gotChanges[j])
-	})
-
-	wantChanges := []stackplan.PlannedChange{
-		&stackplan.PlannedChangeApplyable{
-			Applyable: true,
-		},
-		&stackplan.PlannedChangeHeader{
-			TerraformVersion: version.SemVer,
-		},
-		&stackplan.PlannedChangePlannedTimestamp{
-			PlannedTimestamp: fakePlanTimestamp,
-		},
-		&stackplan.PlannedChangeComponentInstance{
-			Addr: stackaddrs.Absolute(
-				stackaddrs.RootStackInstance.Child("a", addrs.WildcardKey),
-				stackaddrs.ComponentInstance{
-					Component: stackaddrs.Component{Name: "self"},
-					Key:       addrs.WildcardKey,
-				},
-			),
-			PlanApplyable: false, // Everything is deferred, so nothing to apply.
-			PlanComplete:  false,
-			Action:        plans.Create,
-			PlannedInputValues: map[string]plans.DynamicValue{
-				"id":    mustPlanDynamicValueDynamicType(cty.NullVal(cty.String)),
-				"input": mustPlanDynamicValueDynamicType(cty.UnknownVal(cty.String)),
-			},
-			PlannedOutputValues: map[string]cty.Value{},
-			PlannedCheckResults: &states.CheckResults{},
-			PlanTimestamp:       fakePlanTimestamp,
-			PlannedInputValueMarks: map[string][]cty.PathValueMarks{
-				"id":    nil,
-				"input": nil,
-			},
-		},
-		&stackplan.PlannedChangeDeferredResourceInstancePlanned{
-			DeferredReason: providers.DeferredReasonDeferredPrereq,
-			ResourceInstancePlanned: stackplan.PlannedChangeResourceInstancePlanned{
-				ResourceInstanceObjectAddr: stackaddrs.AbsResourceInstanceObject{
-					Component: stackaddrs.Absolute(
-						stackaddrs.RootStackInstance.Child("a", addrs.WildcardKey),
-						stackaddrs.ComponentInstance{
-							Component: stackaddrs.Component{Name: "self"},
-							Key:       addrs.WildcardKey,
-						},
-					),
-					Item: addrs.AbsResourceInstanceObject{
-						ResourceInstance: addrs.Resource{
-							Mode: addrs.ManagedResourceMode,
-							Type: "testing_resource",
-							Name: "data",
-						}.Instance(addrs.NoKey).Absolute(addrs.RootModuleInstance),
-					},
-				},
-				ProviderConfigAddr: addrs.AbsProviderConfig{
-					Module:   addrs.RootModule,
-					Provider: addrs.MustParseProviderSourceString("hashicorp/testing"),
-				},
-				ChangeSrc: &plans.ResourceInstanceChangeSrc{
-					Addr: addrs.Resource{
-						Mode: addrs.ManagedResourceMode,
-						Type: "testing_resource",
-						Name: "data",
-					}.Instance(addrs.NoKey).Absolute(addrs.RootModuleInstance),
-					PrevRunAddr: addrs.Resource{
-						Mode: addrs.ManagedResourceMode,
-						Type: "testing_resource",
-						Name: "data",
-					}.Instance(addrs.NoKey).Absolute(addrs.RootModuleInstance),
-					ProviderAddr: addrs.AbsProviderConfig{
-						Module:   addrs.RootModule,
-						Provider: addrs.MustParseProviderSourceString("hashicorp/testing"),
-					},
-					ChangeSrc: plans.ChangeSrc{
-						Action: plans.Create,
-						Before: mustPlanDynamicValue(cty.NullVal(cty.DynamicPseudoType)),
-						After: mustPlanDynamicValueSchema(cty.ObjectVal(map[string]cty.Value{
-							"id":    cty.UnknownVal(cty.String),
-							"value": cty.UnknownVal(cty.String),
-						}), stacks_testing_provider.TestingResourceSchema.Body),
-						AfterSensitivePaths: nil,
-					},
-				},
-				Schema: stacks_testing_provider.TestingResourceSchema,
-			},
-		},
-		&stackplan.PlannedChangeRootInputValue{
-			Addr:   stackaddrs.InputVariable{Name: "stacks"},
-			Action: plans.Create,
-			Before: cty.NullVal(cty.DynamicPseudoType),
-			After:  cty.UnknownVal(cty.Map(cty.Set(cty.String))),
 		},
 	}
 

--- a/internal/stacks/stackruntime/testdata/mainbundle/test/with-single-input/deferred-embedded-stack-for-each/deferred-embedded-stack-for-each.tfstack.hcl
+++ b/internal/stacks/stackruntime/testdata/mainbundle/test/with-single-input/deferred-embedded-stack-for-each/deferred-embedded-stack-for-each.tfstack.hcl
@@ -6,7 +6,7 @@ required_providers {
 }
 
 variable "stacks" {
-  type = set(string)
+  type = map(string)
 }
 
 provider "testing" "default" {}
@@ -16,6 +16,7 @@ stack "a" {
   for_each = var.stacks
 
   inputs = {
+    id = each.key
     input = each.value
   }
 }

--- a/internal/stacks/stackruntime/validate_test.go
+++ b/internal/stacks/stackruntime/validate_test.go
@@ -445,7 +445,7 @@ func TestValidate(t *testing.T) {
 					"Self-dependent items in configuration",
 					`The following items in your configuration form a circular dependency chain through their references:
   - stack.a collected outputs
-  - stack.a.output.a value
+  - stack.a.output.a
   - stack.a inputs
 
 Terraform uses references to decide a suitable order for performing operations, so configuration items may not refer to their own results either directly or indirectly.`,

--- a/internal/stacks/stackstate/state.go
+++ b/internal/stacks/stackstate/state.go
@@ -118,6 +118,27 @@ func (s *State) ComponentInstances(addr stackaddrs.AbsComponent) collections.Set
 	return ret
 }
 
+func (s *State) StackInstances(addr stackaddrs.AbsStackCall) []stackaddrs.StackInstanceStep {
+	var ret []stackaddrs.StackInstanceStep
+	for key := range s.componentInstances.All() {
+		if len(key.Stack) == 0 {
+			continue
+		}
+
+		last := key.Stack[len(key.Stack)-1]
+		path := key.Stack[:len(key.Stack)-1]
+
+		if path.String() != addr.Stack.String() {
+			continue
+		}
+		if last.Name != addr.Item.Name {
+			continue
+		}
+		ret = append(ret, last)
+	}
+	return ret
+}
+
 func (s *State) componentInstanceState(addr stackaddrs.AbsComponentInstance) *componentInstanceState {
 	return s.componentInstances.Get(addr)
 }


### PR DESCRIPTION
Currently, components in nested stacks are just ignored during the plan when the nested stack call is deferred.

This PR updates the stacks runtime so a deferred stack call still triggers deferred updates of any components in the nested stack that already exist.

The big change required to do this is to push the instantiation of nested stacks into the embedded stack call instance, where the deferral status of the instance is actually known. Previously, all embedded stacks where just being initialised lazily without looking at the actual values in the call that was triggering it.

In addition, I've refactored all the components of a stack so that the stack that created them is actually provided to them directly at creation time, instead of them always having to go back and look up their own stacks whenever it is needed.