### PR TITLE
Increase test coverage for local backend's PathsConflictWith and StatePaths methods

### DIFF
--- a/internal/backend/local/backend.go
+++ b/internal/backend/local/backend.go
@@ -388,8 +388,14 @@ func (b *Local) opWait(
 	return
 }
 
-// StatePaths returns the StatePath, StateOutPath, and StateBackupPath as
-// configured from the CLI.
+// StatePaths returns the StatePath, StateOutPath, and StateBackupPath for a given workspace name.
+// This value is affected by:
+//
+// * Default versus non-default workspace.
+//
+// * Values from the configuration.
+//
+// * Values configured from the CLI.
 func (b *Local) StatePaths(name string) (stateIn, stateOut, backupOut string) {
 	statePath := b.OverrideStatePath
 	stateOutPath := b.OverrideStateOutPath

--- a/internal/backend/local/backend.go
+++ b/internal/backend/local/backend.go
@@ -59,6 +59,13 @@ type Local struct {
 	// and will override what'd be built from the State* fields if non-empty.
 	// While the interpretation of the State* fields depends on the active
 	// workspace, the OverrideState* fields are always used literally.
+	//
+	// OverrideStatePath is set as a result of the -state flag
+	// OverrideStateOutPath is set as a result of the -state-out flag
+	// OverrideStateBackupPath is set as a result of the -state-backup flag
+	//
+	// Note: these flags are only accepted by some commands.
+	// Importantly, they are not accepted by `init`.
 	OverrideStatePath       string
 	OverrideStateOutPath    string
 	OverrideStateBackupPath string


### PR DESCRIPTION
Related to https://github.com/hashicorp/terraform/pull/36750

This PR:
* Increases testing of the local backend's PathsConflictWith method
* Increases testing of the related StatePaths method


---



[PathsConflictWith](https://github.com/hashicorp/terraform/blob/052646c3d207619dc8005f81c32b097280743e8a/internal/backend/local/backend.go#L436-L463) is used to detect if two local backends use state in the same file locations.
It is used to help avoid a situation where migration from one local backend configuration to another results in clashes and possible data loss. I.e. a situation where Terraform wants to move State from location A to location A, instead of from location A to B.

**CLI overrides like `-state`, `-state-out` and `-state-backup` aren't relevant to migrations, as those flags aren't accepted by the init command.** Therefore my test only checks the impact of the `path` and `working_dir` attributes in the config when testing PathsConflictWith.


## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.12.x

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
