### PR TITLE
Fix protov6 crash when refreshing resource with identity

### DIFF
--- a/internal/plugin/grpc_provider.go
+++ b/internal/plugin/grpc_provider.go
@@ -188,6 +188,8 @@ func (p *GRPCProvider) GetProviderSchema() providers.GetProviderSchemaResponse {
 }
 
 func (p *GRPCProvider) GetResourceIdentitySchemas() providers.GetResourceIdentitySchemasResponse {
+	logger.Trace("GRPCProvider: GetResourceIdentitySchemas")
+
 	var resp providers.GetResourceIdentitySchemasResponse
 
 	resp.IdentityTypes = make(map[string]providers.IdentitySchema)


### PR DESCRIPTION
> cc @dbanck 

This PR fixes a panic in the most recent `v1.12.0-alpha20250319` release with resource identity when using a protocol v6 provider (protocol v5 seems to be working fine, which was what I was testing on until recently 😆).

My repro-case isn't readily available, but basically any plan/apply cycle with a resource that returns identity will give you this panic on the following refresh.

<details>
  <summary><b>Crash output</b></summary>

```bash
--- FAIL: TestExpectIdentityValue_CheckState_String (0.42s)
    /Users/austin.valle/code/terraform-plugin-testing/statecheck/expect_identity_value_test.go:56: Step 1/1 error: Error running post-apply refresh plan: exit status 11
        
        !!!!!!!!!!!!!!!!!!!!!!!!!!! TERRAFORM CRASH !!!!!!!!!!!!!!!!!!!!!!!!!!!!
        
        Terraform crashed! This is always indicative of a bug within Terraform.
        Please report the crash with Terraform[1] so that we can fix this.
        
        When reporting bugs, please include your terraform version, the stack trace
        shown below, and any additional information which may help replicate the issue.
        
        [1]: https://github.com/hashicorp/terraform/issues
        
        !!!!!!!!!!!!!!!!!!!!!!!!!!! TERRAFORM CRASH !!!!!!!!!!!!!!!!!!!!!!!!!!!!
        
        panic: runtime error: invalid memory address or nil pointer dereference
        goroutine 100 [running]:
        runtime/debug.Stack()
        	runtime/debug/stack.go:26 +0x64
        github.com/hashicorp/terraform/internal/logging.PanicHandler()
        	github.com/hashicorp/terraform/internal/logging/panic.go:84 +0x188
        panic({0x105ec23c0?, 0x107ff63a0?})
        	runtime/panic.go:787 +0x124
        github.com/hashicorp/terraform/internal/terraform.(*Graph).walk.func1.1()
        	github.com/hashicorp/terraform/internal/terraform/graph.go:59 +0x364
        panic({0x105ec23c0?, 0x107ff63a0?})
        	runtime/panic.go:787 +0x124
        github.com/hashicorp/terraform/internal/plugin6.(*GRPCProvider).ReadResource(0x140001761e0, {{0x14000aae2a0, 0x12}, {{{0x1064e2af0, 0x140007a6710}}, {0x105f8ae40, 0x140009f9d10}}, {0x0, 0x0, 0x0}, ...})
        	github.com/hashicorp/terraform/internal/plugin6/grpc_provider.go:500 +0x3bc
        github.com/hashicorp/terraform/internal/terraform.(*NodeAbstractResourceInstance).refresh(0x140009066c8, {0x106507580, 0x140008d2700}, {0x0, 0x0}, 0x140009bec00, 0x0)
        	github.com/hashicorp/terraform/internal/terraform/node_resource_abstract_instance.go:645 +0x900
        github.com/hashicorp/terraform/internal/terraform.(*NodePlannableResourceInstance).managedResourceExecute(0x14000902cc0, {0x106507580, 0x140008d2700})
        	github.com/hashicorp/terraform/internal/terraform/node_resource_plan_instance.go:299 +0xb40
        github.com/hashicorp/terraform/internal/terraform.(*NodePlannableResourceInstance).Execute(0x140009b3708?, {0x106507580?, 0x140008d2700?}, 0x98?)
        	github.com/hashicorp/terraform/internal/terraform/node_resource_plan_instance.go:77 +0x84
        github.com/hashicorp/terraform/internal/terraform.(*ContextGraphWalker).Execute(0x14000b02000, {0x106507580, 0x140008d2700}, {0x12f404398, 0x14000902cc0})
        	github.com/hashicorp/terraform/internal/terraform/graph_walk_context.go:161 +0xa0
        github.com/hashicorp/terraform/internal/terraform.(*Graph).walk.func1({0x106466c20, 0x14000902cc0})
        	github.com/hashicorp/terraform/internal/terraform/graph.go:143 +0x5f4
        github.com/hashicorp/terraform/internal/dag.(*Walker).walkVertex(0x14000902de0, {0x106466c20, 0x14000902cc0}, 0x140009d6480)
        	github.com/hashicorp/terraform/internal/dag/walk.go:393 +0x2a8
        created by github.com/hashicorp/terraform/internal/dag.(*Walker).Update in goroutine 90
        	github.com/hashicorp/terraform/internal/dag/walk.go:316 +0xc44
FAIL
FAIL	github.com/hashicorp/terraform-plugin-testing/statecheck	0.812s
```

</details>

---------------

Looking at the [protov5 implementation](https://github.com/hashicorp/terraform/blob/69561ef6f940d7ad3fed1eede00c9ebe3f8663af/internal/plugin/grpc_provider.go#L497-L532), it looks like that may have been refactored and the changes were not brought to the protov6 implementation, so I just matched the two files up via a compare 😆.

It also looks like it might have fixed an eventual bug with `ImportResourceState` in protov6 where the identity data would not be set on the protocol request, but I can't test that ATM 😄 

## Target Release

1.12.x

## CHANGELOG entry

I'm not sure if y'all want a changelog for this, lmk if you do 👍🏻 