### PR TITLE
remove unused interface

### DIFF
--- a/internal/terraform/instance_expanders.go
+++ b/internal/terraform/instance_expanders.go
@@ -8,12 +8,6 @@ import (
 	"github.com/hashicorp/terraform/internal/instances"
 )
 
-// graphNodeExpandsInstances is implemented by nodes that causes instances to
-// be registered in the instances.Expander.
-type graphNodeExpandsInstances interface {
-	expandsInstances()
-}
-
 // forEachModuleInstance is a helper to deal with the common need of doing
 // some action for every dynamic module instance associated with a static
 // module path.

--- a/internal/terraform/node_check.go
+++ b/internal/terraform/node_check.go
@@ -58,7 +58,6 @@ var (
 	_ GraphNodeModulePath        = (*nodeExpandCheck)(nil)
 	_ GraphNodeDynamicExpandable = (*nodeExpandCheck)(nil)
 	_ GraphNodeReferencer        = (*nodeExpandCheck)(nil)
-	_ graphNodeExpandsInstances  = (*nodeExpandCheck)(nil)
 )
 
 // nodeExpandCheck creates child nodes that actually execute the assertions for
@@ -75,8 +74,6 @@ type nodeExpandCheck struct {
 
 	makeInstance func(addrs.AbsCheck, *configs.Check) dag.Vertex
 }
-
-func (n *nodeExpandCheck) expandsInstances() {}
 
 func (n *nodeExpandCheck) ModulePath() addrs.Module {
 	return n.addr.Module

--- a/internal/terraform/node_local.go
+++ b/internal/terraform/node_local.go
@@ -30,10 +30,7 @@ var (
 	_ GraphNodeReferencer        = (*nodeExpandLocal)(nil)
 	_ GraphNodeDynamicExpandable = (*nodeExpandLocal)(nil)
 	_ graphNodeTemporaryValue    = (*nodeExpandLocal)(nil)
-	_ graphNodeExpandsInstances  = (*nodeExpandLocal)(nil)
 )
-
-func (n *nodeExpandLocal) expandsInstances() {}
 
 // graphNodeTemporaryValue
 func (n *nodeExpandLocal) temporaryValue() bool {

--- a/internal/terraform/node_module_expand.go
+++ b/internal/terraform/node_module_expand.go
@@ -29,10 +29,7 @@ var (
 	_ GraphNodeReferenceable    = (*nodeExpandModule)(nil)
 	_ GraphNodeReferencer       = (*nodeExpandModule)(nil)
 	_ GraphNodeReferenceOutside = (*nodeExpandModule)(nil)
-	_ graphNodeExpandsInstances = (*nodeExpandModule)(nil)
 )
-
-func (n *nodeExpandModule) expandsInstances() {}
 
 func (n *nodeExpandModule) Name() string {
 	return n.Addr.String() + " (expand)"

--- a/internal/terraform/node_module_variable.go
+++ b/internal/terraform/node_module_variable.go
@@ -41,10 +41,7 @@ var (
 	_ GraphNodeReferenceable     = (*nodeExpandModuleVariable)(nil)
 	_ GraphNodeReferencer        = (*nodeExpandModuleVariable)(nil)
 	_ graphNodeTemporaryValue    = (*nodeExpandModuleVariable)(nil)
-	_ graphNodeExpandsInstances  = (*nodeExpandModuleVariable)(nil)
 )
-
-func (n *nodeExpandModuleVariable) expandsInstances() {}
 
 func (n *nodeExpandModuleVariable) temporaryValue() bool {
 	return true

--- a/internal/terraform/node_output.go
+++ b/internal/terraform/node_output.go
@@ -55,10 +55,7 @@ var (
 	_ GraphNodeDynamicExpandable  = (*nodeExpandOutput)(nil)
 	_ graphNodeTemporaryValue     = (*nodeExpandOutput)(nil)
 	_ GraphNodeAttachDependencies = (*nodeExpandOutput)(nil)
-	_ graphNodeExpandsInstances   = (*nodeExpandOutput)(nil)
 )
-
-func (n *nodeExpandOutput) expandsInstances() {}
 
 func (n *nodeExpandOutput) temporaryValue() bool {
 	// non root outputs are temporary

--- a/internal/terraform/node_resource_apply.go
+++ b/internal/terraform/node_resource_apply.go
@@ -24,13 +24,9 @@ var (
 	_ GraphNodeReferencer           = (*nodeExpandApplyableResource)(nil)
 	_ GraphNodeConfigResource       = (*nodeExpandApplyableResource)(nil)
 	_ GraphNodeAttachResourceConfig = (*nodeExpandApplyableResource)(nil)
-	_ graphNodeExpandsInstances     = (*nodeExpandApplyableResource)(nil)
 	_ GraphNodeTargetable           = (*nodeExpandApplyableResource)(nil)
 	_ GraphNodeDynamicExpandable    = (*nodeExpandApplyableResource)(nil)
 )
-
-func (n *nodeExpandApplyableResource) expandsInstances() {
-}
 
 func (n *nodeExpandApplyableResource) References() []*addrs.Reference {
 	refs := n.NodeAbstractResource.References()

--- a/internal/terraform/node_resource_plan.go
+++ b/internal/terraform/node_resource_plan.go
@@ -61,14 +61,10 @@ var (
 	_ GraphNodeAttachResourceConfig = (*nodeExpandPlannableResource)(nil)
 	_ GraphNodeAttachDependencies   = (*nodeExpandPlannableResource)(nil)
 	_ GraphNodeTargetable           = (*nodeExpandPlannableResource)(nil)
-	_ graphNodeExpandsInstances     = (*nodeExpandPlannableResource)(nil)
 )
 
 func (n *nodeExpandPlannableResource) Name() string {
 	return n.NodeAbstractResource.Name() + " (expand)"
-}
-
-func (n *nodeExpandPlannableResource) expandsInstances() {
 }
 
 // GraphNodeAttachDependencies


### PR DESCRIPTION
Forgot to remove `graphNodeTemporaryValue` when the `pruneUnusedNodesTransformer` was simplified to no longer make use of it.
