### PR TITLE
stacks: provide stack and config on component creation

### DIFF
--- a/internal/stacks/stackruntime/internal/stackeval/output_value.go
+++ b/internal/stacks/stackruntime/internal/stackeval/output_value.go
@@ -15,7 +15,6 @@ import (
 	"github.com/hashicorp/terraform/internal/plans"
 	"github.com/hashicorp/terraform/internal/promising"
 	"github.com/hashicorp/terraform/internal/stacks/stackaddrs"
-	"github.com/hashicorp/terraform/internal/stacks/stackconfig"
 	"github.com/hashicorp/terraform/internal/stacks/stackconfig/stackconfigtypes"
 	"github.com/hashicorp/terraform/internal/stacks/stackconfig/typeexpr"
 	"github.com/hashicorp/terraform/internal/stacks/stackplan"
@@ -25,7 +24,9 @@ import (
 
 // OutputValue represents an input variable belonging to a [Stack].
 type OutputValue struct {
-	addr stackaddrs.AbsOutputValue
+	addr   stackaddrs.AbsOutputValue
+	stack  *Stack
+	config *OutputValueConfig
 
 	main *Main
 
@@ -34,40 +35,17 @@ type OutputValue struct {
 
 var _ Plannable = (*OutputValue)(nil)
 
-func newOutputValue(main *Main, addr stackaddrs.AbsOutputValue) *OutputValue {
+func newOutputValue(main *Main, addr stackaddrs.AbsOutputValue, stack *Stack, config *OutputValueConfig) *OutputValue {
 	return &OutputValue{
-		addr: addr,
-		main: main,
+		addr:   addr,
+		stack:  stack,
+		config: config,
+		main:   main,
 	}
-}
-
-func (v *OutputValue) Addr() stackaddrs.AbsOutputValue {
-	return v.addr
-}
-
-func (v *OutputValue) Config() *OutputValueConfig {
-	configAddr := stackaddrs.ConfigForAbs(v.Addr())
-	stackConfig := v.main.StackConfig(configAddr.Stack)
-	if stackConfig == nil {
-		return nil
-	}
-	return stackConfig.OutputValue(configAddr.Item)
-}
-
-func (v *OutputValue) Stack(ctx context.Context, phase EvalPhase) *Stack {
-	return v.main.Stack(ctx, v.Addr().Stack, phase)
-}
-
-func (v *OutputValue) Declaration() *stackconfig.OutputValue {
-	cfg := v.Config()
-	if cfg == nil {
-		return nil
-	}
-	return cfg.Declaration()
 }
 
 func (v *OutputValue) ResultType() (cty.Type, *typeexpr.Defaults) {
-	decl := v.Declaration()
+	decl := v.config.config
 	if decl == nil {
 		// If we get here then something odd must be going on, but
 		// we don't have enough context to guess why so we'll just
@@ -82,8 +60,8 @@ func (v *OutputValue) ResultType() (cty.Type, *typeexpr.Defaults) {
 func (v *OutputValue) CheckResultType() (cty.Type, *typeexpr.Defaults, tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
 	ty, defs := v.ResultType()
-	decl := v.Declaration()
-	if v.Addr().Stack.IsRoot() {
+	decl := v.config.config
+	if v.addr.Stack.IsRoot() {
 		// A root output value cannot return provider configuration references,
 		// because root outputs outlive the operation that generated them but
 		// provider instances are live only during a single evaluation.
@@ -117,17 +95,10 @@ func (v *OutputValue) CheckResultValue(ctx context.Context, phase EvalPhase) (ct
 		func(ctx context.Context) (cty.Value, tfdiags.Diagnostics) {
 			var diags tfdiags.Diagnostics
 
-			cfg := v.Config()
+			cfg := v.config
 			ty, defs := v.ResultType()
 
-			stack := v.Stack(ctx, phase)
-			if stack == nil {
-				// If we're in a stack whose expansion isn't known yet then
-				// we'll return an unknown value placeholder so that
-				// downstreams can at least do type-checking.
-				return cfg.markResultValue(cty.UnknownVal(ty)), diags
-			}
-			result, moreDiags := EvalExprAndEvalContext(ctx, v.Declaration().Value, phase, stack)
+			result, moreDiags := EvalExprAndEvalContext(ctx, v.config.config.Value, phase, v.stack)
 			diags = diags.Append(moreDiags)
 			if moreDiags.HasErrors() {
 				return cfg.markResultValue(cty.UnknownVal(ty)), diags
@@ -142,18 +113,18 @@ func (v *OutputValue) CheckResultValue(ctx context.Context, phase EvalPhase) (ct
 				diags = diags.Append(result.Diagnostic(
 					tfdiags.Error,
 					"Invalid output value result",
-					fmt.Sprintf("Unsuitable value for output %q: %s.", v.Addr().Item.Name, tfdiags.FormatError(err)),
+					fmt.Sprintf("Unsuitable value for output %q: %s.", v.addr.Item.Name, tfdiags.FormatError(err)),
 				))
 				return cfg.markResultValue(cty.UnknownVal(ty)), diags
 			}
 
-			if cfg.Declaration().Ephemeral {
+			if cfg.config.Ephemeral {
 				// Verify that ephemeral outputs are not declared on the root stack.
-				if v.Addr().Stack.IsRoot() {
+				if v.addr.Stack.IsRoot() {
 					diags = diags.Append(result.Diagnostic(
 						tfdiags.Error,
 						"Ephemeral output value not allowed on root stack",
-						fmt.Sprintf("Output value %q is marked as ephemeral, this is only allowed in embedded stacks.", v.Addr().Item.Name),
+						fmt.Sprintf("Output value %q is marked as ephemeral, this is only allowed in embedded stacks.", v.addr.Item.Name),
 					))
 				}
 
@@ -162,7 +133,7 @@ func (v *OutputValue) CheckResultValue(ctx context.Context, phase EvalPhase) (ct
 					diags = diags.Append(result.Diagnostic(
 						tfdiags.Error,
 						"Expected ephemeral value",
-						fmt.Sprintf("The output value %q is marked as ephemeral, but the value is not ephemeral.", v.Addr().Item.Name),
+						fmt.Sprintf("The output value %q is marked as ephemeral, but the value is not ephemeral.", v.addr.Item.Name),
 					))
 				}
 
@@ -175,7 +146,7 @@ func (v *OutputValue) CheckResultValue(ctx context.Context, phase EvalPhase) (ct
 						moreDiags = moreDiags.Append(result.Diagnostic(
 							tfdiags.Error,
 							"Ephemeral value not allowed",
-							fmt.Sprintf("The output value %q does not accept ephemeral values.", v.Addr().Item.Name),
+							fmt.Sprintf("The output value %q does not accept ephemeral values.", v.addr.Item.Name),
 						))
 					} else {
 						moreDiags = moreDiags.Append(result.Diagnostic(
@@ -183,7 +154,7 @@ func (v *OutputValue) CheckResultValue(ctx context.Context, phase EvalPhase) (ct
 							"Ephemeral value not allowed",
 							fmt.Sprintf(
 								"The output value %q does not accept ephemeral values, so the value of %s is not compatible.",
-								v.Addr().Item.Name,
+								v.addr.Item.Name,
 								tfdiags.FormatCtyPath(path),
 							),
 						))
@@ -225,11 +196,11 @@ func (v *OutputValue) PlanChanges(ctx context.Context) ([]stackplan.PlannedChang
 	}
 
 	// Only the root stack's outputs are exposed externally.
-	if !v.Addr().Stack.IsRoot() {
+	if !v.addr.Stack.IsRoot() {
 		return nil, diags
 	}
 
-	before := v.main.PlanPrevState().RootOutputValue(v.Addr().Item)
+	before := v.main.PlanPrevState().RootOutputValue(v.addr.Item)
 	if v.main.PlanningOpts().PlanningMode == plans.DestroyMode {
 		if before == cty.NilVal {
 			// If the value didn't exist before and we're in destroy mode,
@@ -241,7 +212,7 @@ func (v *OutputValue) PlanChanges(ctx context.Context) ([]stackplan.PlannedChang
 		ty, _ := v.ResultType()
 		return []stackplan.PlannedChange{
 			&stackplan.PlannedChangeOutputValue{
-				Addr:   v.Addr().Item,
+				Addr:   v.addr.Item,
 				Action: plans.Delete,
 				Before: before,
 				After:  cty.NullVal(ty),
@@ -249,7 +220,7 @@ func (v *OutputValue) PlanChanges(ctx context.Context) ([]stackplan.PlannedChang
 		}, diags
 	}
 
-	decl := v.Declaration()
+	decl := v.config.config
 	after := v.ResultValue(ctx, PlanPhase)
 	if decl.Ephemeral {
 		after = cty.NullVal(after.Type())
@@ -279,7 +250,7 @@ func (v *OutputValue) PlanChanges(ctx context.Context) ([]stackplan.PlannedChang
 
 	return []stackplan.PlannedChange{
 		&stackplan.PlannedChangeOutputValue{
-			Addr:   v.Addr().Item,
+			Addr:   v.addr.Item,
 			Action: action,
 			Before: before,
 			After:  after,
@@ -289,15 +260,15 @@ func (v *OutputValue) PlanChanges(ctx context.Context) ([]stackplan.PlannedChang
 
 // References implements Referrer
 func (v *OutputValue) References(context.Context) []stackaddrs.AbsReference {
-	cfg := v.Declaration()
+	cfg := v.config.config
 	var ret []stackaddrs.Reference
 	ret = append(ret, ReferencesInExpr(cfg.Value)...)
-	return makeReferencesAbsolute(ret, v.Addr().Stack)
+	return makeReferencesAbsolute(ret, v.addr.Stack)
 }
 
 // CheckApply implements Applyable.
 func (v *OutputValue) CheckApply(ctx context.Context) ([]stackstate.AppliedChange, tfdiags.Diagnostics) {
-	if !v.Addr().Stack.IsRoot() {
+	if !v.addr.Stack.IsRoot() {
 		return nil, v.checkValid(ctx, ApplyPhase)
 	}
 
@@ -306,14 +277,14 @@ func (v *OutputValue) CheckApply(ctx context.Context) ([]stackstate.AppliedChang
 		return nil, diags
 	}
 
-	if v.main.PlanBeingApplied().DeletedOutputValues.Has(v.Addr().Item) {
+	if v.main.PlanBeingApplied().DeletedOutputValues.Has(v.addr.Item) {
 		// If the plan being applied has marked this output value for deletion,
 		// we won't handle it here. The stack will take care of removing
 		// everything related to this output value.
 		return nil, diags
 	}
 
-	decl := v.Declaration()
+	decl := v.config.config
 	value := v.ResultValue(ctx, ApplyPhase)
 	if decl.Ephemeral {
 		value = cty.NullVal(value.Type())
@@ -321,12 +292,12 @@ func (v *OutputValue) CheckApply(ctx context.Context) ([]stackstate.AppliedChang
 
 	return []stackstate.AppliedChange{
 		&stackstate.AppliedChangeOutputValue{
-			Addr:  v.Addr().Item,
+			Addr:  v.addr.Item,
 			Value: value,
 		},
 	}, diags
 }
 
 func (v *OutputValue) tracingName() string {
-	return v.Addr().String()
+	return v.addr.String()
 }

--- a/internal/stacks/stackruntime/internal/stackeval/output_value_config.go
+++ b/internal/stacks/stackruntime/internal/stackeval/output_value_config.go
@@ -23,6 +23,7 @@ import (
 type OutputValueConfig struct {
 	addr   stackaddrs.ConfigOutputValue
 	config *stackconfig.OutputValue
+	stack  *StackConfig
 
 	main *Main
 
@@ -31,34 +32,20 @@ type OutputValueConfig struct {
 
 var _ Validatable = (*OutputValueConfig)(nil)
 
-func newOutputValueConfig(main *Main, addr stackaddrs.ConfigOutputValue, config *stackconfig.OutputValue) *OutputValueConfig {
+func newOutputValueConfig(main *Main, addr stackaddrs.ConfigOutputValue, stack *StackConfig, config *stackconfig.OutputValue) *OutputValueConfig {
 	if config == nil {
 		panic("newOutputValueConfig with nil configuration")
 	}
 	return &OutputValueConfig{
 		addr:   addr,
 		config: config,
+		stack:  stack,
 		main:   main,
 	}
 }
 
-func (ov *OutputValueConfig) Addr() stackaddrs.ConfigOutputValue {
-	return ov.addr
-}
-
-func (ov *OutputValueConfig) Declaration() *stackconfig.OutputValue {
-	return ov.config
-}
-
 func (ov *OutputValueConfig) tracingName() string {
-	return ov.Addr().String()
-}
-
-// StackConfig returns the object representing the stack configuration that
-// this output block belongs to.
-func (ov *OutputValueConfig) StackConfig() *StackConfig {
-	stackConfigAddr := ov.Addr().Stack
-	return ov.main.StackConfig(stackConfigAddr)
+	return ov.addr.String()
 }
 
 // Value returns the result value for this output value that should be used
@@ -99,7 +86,7 @@ func (ov *OutputValueConfig) validateValueInner(phase EvalPhase) func(ctx contex
 	return func(ctx context.Context) (cty.Value, tfdiags.Diagnostics) {
 		var diags tfdiags.Diagnostics
 
-		result, moreDiags := EvalExprAndEvalContext(ctx, ov.config.Value, phase, ov.StackConfig())
+		result, moreDiags := EvalExprAndEvalContext(ctx, ov.config.Value, phase, ov.stack)
 		v := result.Value
 		diags = diags.Append(moreDiags)
 		if moreDiags.HasErrors() {

--- a/internal/stacks/stackruntime/internal/stackeval/output_value_test.go
+++ b/internal/stacks/stackruntime/internal/stackeval/output_value_test.go
@@ -330,7 +330,7 @@ func TestOutputValueEphemeralInChildStack(t *testing.T) {
 					Name: "child",
 					Key:  addrs.NoKey,
 				}
-				stack := rootStack.ChildStackChecked(ctx, childStackStep, ValidatePhase)
+				stack := rootStack.ChildStack(ctx, childStackStep, ValidatePhase)
 				output := stack.OutputValues()[outputAddr]
 				if output == nil {
 					t.Fatalf("missing %s", outputAddr)

--- a/internal/stacks/stackruntime/internal/stackeval/provider_config_test.go
+++ b/internal/stacks/stackruntime/internal/stackeval/provider_config_test.go
@@ -58,7 +58,7 @@ func TestProviderConfig_CheckProviderArgs_EmptyConfig(t *testing.T) {
 		if provider == nil {
 			t.Fatal("no provider.foo.bar is available")
 		}
-		return provider.Config()
+		return provider.config
 	}
 
 	subtestInPromisingTask(t, "valid", func(ctx context.Context, t *testing.T) {
@@ -140,7 +140,7 @@ func TestProviderConfig_CheckProviderArgs(t *testing.T) {
 		if provider == nil {
 			t.Fatal("no provider.foo.bar is available")
 		}
-		return provider.Config()
+		return provider.config
 	}
 
 	subtestInPromisingTask(t, "valid", func(ctx context.Context, t *testing.T) {

--- a/internal/stacks/stackruntime/internal/stackeval/provider_expressions.go
+++ b/internal/stacks/stackruntime/internal/stackeval/provider_expressions.go
@@ -29,6 +29,7 @@ type ConfigComponentExpressionScope[Addr any] interface {
 	ExpressionScope
 
 	Addr() Addr
+	StackConfig() *StackConfig
 	ModuleTree(ctx context.Context) *configs.Config
 	DeclRange() *hcl.Range
 }
@@ -219,7 +220,6 @@ func EvalProviderValues(ctx context.Context, main *Main, providers map[addrs.Loc
 	//   store the additional information we need. Once this is fixed we can
 	//   come and tidy this up as well.
 
-	stackConfig := main.StackConfig(scope.Addr().Stack.ConfigAddr())
 	moduleTree := scope.ModuleTree(ctx)
 
 	// We'll search through the declConfigs to find any keys that match the
@@ -262,7 +262,7 @@ func EvalProviderValues(ctx context.Context, main *Main, providers map[addrs.Loc
 			knownProviders[sourceAddr] = inst
 		}
 
-		if _, ok := stackConfig.ProviderLocalName(provider); !ok {
+		if _, ok := scope.StackConfig().ProviderLocalName(provider); !ok {
 			// Even though we have an entry for this provider in the declConfigs
 			// doesn't mean we have an entry for this in our required providers.
 			diags = diags.Append(&hcl.Diagnostic{

--- a/internal/stacks/stackruntime/internal/stackeval/provider_instance_test.go
+++ b/internal/stacks/stackruntime/internal/stackeval/provider_instance_test.go
@@ -168,7 +168,7 @@ func TestProviderInstanceCheckProviderArgs(t *testing.T) {
 		// We'll make sure the configuration really does omit the config
 		// block, in case someone modifies the fixture in future without
 		// realizing we're relying on that invariant here.
-		decl := inst.provider.Declaration()
+		decl := inst.provider.config.config
 		if decl.Config != nil {
 			t.Fatal("test fixture has a config block for the provider; should omit it")
 		}

--- a/internal/stacks/stackruntime/internal/stackeval/stack_call_config.go
+++ b/internal/stacks/stackruntime/internal/stackeval/stack_call_config.go
@@ -26,6 +26,7 @@ import (
 type StackCallConfig struct {
 	addr   stackaddrs.ConfigStackCall
 	config *stackconfig.EmbeddedStack
+	stack  *StackConfig
 
 	main *Main
 
@@ -38,37 +39,23 @@ var _ Validatable = (*StackCallConfig)(nil)
 var _ Referenceable = (*StackCallConfig)(nil)
 var _ ExpressionScope = (*StackCallConfig)(nil)
 
-func newStackCallConfig(main *Main, addr stackaddrs.ConfigStackCall, config *stackconfig.EmbeddedStack) *StackCallConfig {
+func newStackCallConfig(main *Main, addr stackaddrs.ConfigStackCall, stack *StackConfig, config *stackconfig.EmbeddedStack) *StackCallConfig {
 	return &StackCallConfig{
 		addr:   addr,
 		config: config,
+		stack:  stack,
 		main:   main,
 	}
 }
 
-func (s *StackCallConfig) Addr() stackaddrs.ConfigStackCall {
-	return s.addr
-}
-
 func (s *StackCallConfig) tracingName() string {
-	return s.Addr().String()
+	return s.addr.String()
 }
 
-// CallerConfig returns the object representing the stack configuration that this
-// stack call was declared within.
-func (s *StackCallConfig) CallerConfig() *StackConfig {
-	return s.main.mustStackConfig(s.Addr().Stack)
-}
-
-// CalleeConfig returns the object representing the child stack configuration
+// TargetConfig returns the object representing the child stack configuration
 // that this stack call is referring to.
-func (s *StackCallConfig) CalleeConfig() *StackConfig {
-	return s.main.mustStackConfig(s.Addr().Stack.Child(s.addr.Item.Name))
-}
-
-// Declaration returns the [stackconfig.EmbeddedStack] that declared this object.
-func (s *StackCallConfig) Declaration() *stackconfig.EmbeddedStack {
-	return s.config
+func (s *StackCallConfig) TargetConfig() *StackConfig {
+	return s.stack.ChildConfig(stackaddrs.StackStep{Name: s.addr.Item.Name})
 }
 
 // ResultType returns the type of the overall result value for this call.
@@ -78,7 +65,7 @@ func (s *StackCallConfig) Declaration() *stackconfig.EmbeddedStack {
 func (s *StackCallConfig) ResultType() cty.Type {
 	// The result type of each of our instances is an object type constructed
 	// from all of the declared output values in the child stack.
-	calleeStack := s.CalleeConfig()
+	calleeStack := s.TargetConfig()
 	calleeOutputs := calleeStack.OutputValues()
 	atys := make(map[string]cty.Type, len(calleeOutputs))
 	for addr, ov := range calleeOutputs {
@@ -117,7 +104,7 @@ func (s *StackCallConfig) validateForEachValueInner(phase EvalPhase) func(contex
 			return cty.NilVal, diags
 		}
 
-		result, moreDiags := evaluateForEachExpr(ctx, s.config.ForEach, phase, s.CallerConfig(), "stack")
+		result, moreDiags := evaluateForEachExpr(ctx, s.config.ForEach, phase, s.stack, "stack")
 		diags = diags.Append(moreDiags)
 		return result.Value, diags
 	}
@@ -145,7 +132,7 @@ func (s *StackCallConfig) ValidateInputVariableValues(ctx context.Context, phase
 func (s *StackCallConfig) validateInputVariableValuesInner(phase EvalPhase) func(context.Context) (map[stackaddrs.InputVariable]cty.Value, tfdiags.Diagnostics) {
 	return func(ctx context.Context) (map[stackaddrs.InputVariable]cty.Value, tfdiags.Diagnostics) {
 		var diags tfdiags.Diagnostics
-		callee := s.CalleeConfig()
+		callee := s.TargetConfig()
 		vars := callee.InputVariables()
 
 		atys := make(map[string]cty.Type, len(vars))
@@ -294,7 +281,7 @@ func (s *StackCallConfig) ValidateResultValue(ctx context.Context, phase EvalPha
 				// there will be exactly one instance and can assume that
 				// the output value implementation will provide a suitable
 				// approximation of the final value.
-				calleeStack := s.CalleeConfig()
+				calleeStack := s.TargetConfig()
 				calleeOutputs := calleeStack.OutputValues()
 				attrs := make(map[string]cty.Value, len(calleeOutputs))
 				for addr, ov := range calleeOutputs {
@@ -327,9 +314,7 @@ func (s *StackCallConfig) ResolveExpressionReference(ctx context.Context, ref st
 		repetition.EachKey = cty.UnknownVal(cty.String).RefineNotNull()
 		repetition.EachValue = cty.DynamicVal
 	}
-	ret, diags := s.main.
-		mustStackConfig(s.Addr().Stack).
-		resolveExpressionReference(ctx, ref, nil, repetition)
+	ret, diags := s.stack.resolveExpressionReference(ctx, ref, nil, repetition)
 
 	if _, ok := ret.(*ProviderConfig); ok {
 		// We can't reference other providers from anywhere inside an embedded
@@ -347,7 +332,7 @@ func (s *StackCallConfig) ResolveExpressionReference(ctx context.Context, ref st
 
 // ExternalFunctions implements ExpressionScope.
 func (s *StackCallConfig) ExternalFunctions(ctx context.Context) (lang.ExternalFuncs, tfdiags.Diagnostics) {
-	return s.main.ProviderFunctions(ctx, s.main.StackConfig(s.Addr().Stack))
+	return s.main.ProviderFunctions(ctx, s.stack)
 }
 
 // PlanTimestamp implements ExpressionScope, providing the timestamp at which
@@ -364,7 +349,7 @@ func (s *StackCallConfig) checkValid(ctx context.Context, phase EvalPhase) tfdia
 	diags = diags.Append(moreDiags)
 	_, moreDiags = s.ValidateResultValue(ctx, phase)
 	diags = diags.Append(moreDiags)
-	moreDiags = ValidateDependsOn(s.CallerConfig(), s.config.DependsOn)
+	moreDiags = ValidateDependsOn(s.stack, s.config.DependsOn)
 	diags = diags.Append(moreDiags)
 	return diags
 }

--- a/internal/stacks/stackruntime/internal/stackeval/stack_call_instance.go
+++ b/internal/stacks/stackruntime/internal/stackeval/stack_call_instance.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hashicorp/terraform/internal/instances"
 	"github.com/hashicorp/terraform/internal/lang"
 	"github.com/hashicorp/terraform/internal/lang/marks"
+	"github.com/hashicorp/terraform/internal/promising"
 	"github.com/hashicorp/terraform/internal/stacks/stackaddrs"
 	"github.com/hashicorp/terraform/internal/stacks/stackplan"
 	"github.com/hashicorp/terraform/internal/stacks/stackstate"
@@ -36,6 +37,9 @@ type StackCallInstance struct {
 	main *Main
 
 	repetition instances.RepetitionData
+
+	stack               perEvalPhase[promising.Once[*Stack]]
+	inputVariableValues perEvalPhase[promising.Once[withDiagnostics[cty.Value]]]
 }
 
 var _ ExpressionScope = (*StackCallInstance)(nil)
@@ -54,32 +58,23 @@ func (c *StackCallInstance) RepetitionData() instances.RepetitionData {
 	return c.repetition
 }
 
-// CallerStack returns the stack instance that contains the call that this
-// is an instance of.
-func (c *StackCallInstance) CallerStack() *Stack {
-	stackAddr := c.call.Addr().Stack
-	// "Unchecked" is safe because newStackCallInstance is only called
-	// based on the results of evaluating the call's for_each.
-	return c.main.StackUnchecked(stackAddr)
-}
-
-// Call returns the stack call that this is an instance of.
-func (c *StackCallInstance) Call() *StackCall {
-	return c.call
-}
-
 func (c *StackCallInstance) CalledStackAddr() stackaddrs.StackInstance {
-	callAddr := c.call.Addr()
+	callAddr := c.call.addr
 	callerAddr := callAddr.Stack
 	return callerAddr.Child(callAddr.Item.Name, c.key)
 
 }
 
-// CalledStack returns the stack instance that this call is instantiating.
-func (c *StackCallInstance) CalledStack() *Stack {
-	// "Unchecked" is safe because newStackCallInstance is only called
-	// based on the results of evaluating the call's for_each.
-	return c.main.StackUnchecked(c.CalledStackAddr())
+func (c *StackCallInstance) Stack(ctx context.Context, phase EvalPhase) *Stack {
+	stack, err := c.stack.For(phase).Do(ctx, c.tracingName(), func(ctx context.Context) (*Stack, error) {
+		return newStack(c.main, c.CalledStackAddr(), c.call.stack, c.call.config.TargetConfig()), nil
+	})
+	if err != nil {
+		// we don't have cycles in here, and we don't return an error so this
+		// should never happen.
+		panic(err)
+	}
+	return stack
 }
 
 // InputVariableValues returns the [cty.Value] representing the input variable
@@ -113,120 +108,121 @@ func (c *StackCallInstance) InputVariableValues(ctx context.Context, phase EvalP
 // child stack input variable declaration, as part of preparing the individual
 // attributes of the result for their appearance in downstream expressions.
 func (c *StackCallInstance) CheckInputVariableValues(ctx context.Context, phase EvalPhase) (cty.Value, tfdiags.Diagnostics) {
-	var diags tfdiags.Diagnostics
-	calledStack := c.CalledStack()
-	wantTy, defs := calledStack.InputsType()
-	decl := c.call.Declaration()
+	return doOnceWithDiags(ctx, c.tracingName()+" inputs", c.inputVariableValues.For(phase), func(ctx context.Context) (cty.Value, tfdiags.Diagnostics) {
+		var diags tfdiags.Diagnostics
+		calledStack := c.Stack(ctx, phase)
+		wantTy, defs := calledStack.InputsType()
+		decl := c.call.config.config
 
-	v := cty.EmptyObjectVal
-	expr := decl.Inputs
-	rng := decl.DeclRange
-	var hclCtx *hcl.EvalContext
-	if expr != nil {
-		result, moreDiags := EvalExprAndEvalContext(ctx, expr, phase, c)
-		diags = diags.Append(moreDiags)
-		if moreDiags.HasErrors() {
+		v := cty.EmptyObjectVal
+		expr := decl.Inputs
+		rng := decl.DeclRange
+		var hclCtx *hcl.EvalContext
+		if expr != nil {
+			result, moreDiags := EvalExprAndEvalContext(ctx, expr, phase, c)
+			diags = diags.Append(moreDiags)
+			if moreDiags.HasErrors() {
+				return cty.DynamicVal, diags
+			}
+			expr = result.Expression
+			hclCtx = result.EvalContext
+			v = result.Value
+		}
+
+		v = defs.Apply(v)
+		v, err := convert.Convert(v, wantTy)
+		if err != nil {
+			// A conversion failure here could either be caused by an author-provided
+			// expression that's invalid or by the author omitting the argument
+			// altogether when there's at least one required attribute, so we'll
+			// return slightly different messages in each case.
+			if expr != nil {
+				diags = diags.Append(&hcl.Diagnostic{
+					Severity:    hcl.DiagError,
+					Summary:     "Invalid inputs for embedded stack",
+					Detail:      fmt.Sprintf("Invalid input variable definition object: %s.", tfdiags.FormatError(err)),
+					Subject:     rng.ToHCL().Ptr(),
+					Expression:  expr,
+					EvalContext: hclCtx,
+				})
+			} else {
+				diags = diags.Append(&hcl.Diagnostic{
+					Severity: hcl.DiagError,
+					Summary:  "Missing required inputs for embedded stack",
+					Detail:   fmt.Sprintf("Must provide \"inputs\" argument to define the embedded stack's input variables: %s.", tfdiags.FormatError(err)),
+					Subject:  rng.ToHCL().Ptr(),
+				})
+			}
 			return cty.DynamicVal, diags
 		}
-		expr = result.Expression
-		hclCtx = result.EvalContext
-		v = result.Value
-	}
 
-	v = defs.Apply(v)
-	v, err := convert.Convert(v, wantTy)
-	if err != nil {
-		// A conversion failure here could either be caused by an author-provided
-		// expression that's invalid or by the author omitting the argument
-		// altogether when there's at least one required attribute, so we'll
-		// return slightly different messages in each case.
-		if expr != nil {
-			diags = diags.Append(&hcl.Diagnostic{
-				Severity:    hcl.DiagError,
-				Summary:     "Invalid inputs for embedded stack",
-				Detail:      fmt.Sprintf("Invalid input variable definition object: %s.", tfdiags.FormatError(err)),
-				Subject:     rng.ToHCL().Ptr(),
-				Expression:  expr,
-				EvalContext: hclCtx,
-			})
-		} else {
-			diags = diags.Append(&hcl.Diagnostic{
-				Severity: hcl.DiagError,
-				Summary:  "Missing required inputs for embedded stack",
-				Detail:   fmt.Sprintf("Must provide \"inputs\" argument to define the embedded stack's input variables: %s.", tfdiags.FormatError(err)),
-				Subject:  rng.ToHCL().Ptr(),
-			})
-		}
-		return cty.DynamicVal, diags
-	}
+		if v.IsKnown() && !v.IsNull() {
+			var markDiags tfdiags.Diagnostics
+			for varAddr, variable := range calledStack.InputVariables() {
+				varVal := v.GetAttr(varAddr.Name)
+				varDecl := variable.config.config
 
-	if v.IsKnown() && !v.IsNull() {
-		var markDiags tfdiags.Diagnostics
-		for varAddr, variable := range calledStack.InputVariables() {
-			varVal := v.GetAttr(varAddr.Name)
-			varDecl := variable.Declaration()
-
-			if !varDecl.Ephemeral {
-				// If the variable isn't declared as being ephemeral then we
-				// cannot allow ephemeral values to be assigned to it.
-				_, markses := varVal.UnmarkDeepWithPaths()
-				ephemeralPaths, _ := marks.PathsWithMark(markses, marks.Ephemeral)
-				for _, path := range ephemeralPaths {
-					if len(path) == 0 {
-						// The entire value is ephemeral, then.
-						markDiags = markDiags.Append(&hcl.Diagnostic{
-							Severity:    hcl.DiagError,
-							Summary:     "Ephemeral value not allowed",
-							Detail:      fmt.Sprintf("The input variable %q does not accept ephemeral values.", varAddr.Name),
-							Subject:     rng.ToHCL().Ptr(),
-							Expression:  expr,
-							EvalContext: hclCtx,
-							Extra:       diagnosticCausedByEphemeral(true),
-						})
-					} else {
-						// Something nested inside is ephemeral, so we'll be
-						// more specific.
-						markDiags = markDiags.Append(&hcl.Diagnostic{
-							Severity: hcl.DiagError,
-							Summary:  "Ephemeral value not allowed",
-							Detail: fmt.Sprintf(
-								"The input variable %q does not accept ephemeral values, so the value for %s is not compatible.",
-								varAddr.Name, tfdiags.FormatCtyPath(path),
-							),
-							Subject:     rng.ToHCL().Ptr(),
-							Expression:  expr,
-							EvalContext: hclCtx,
-							Extra:       diagnosticCausedByEphemeral(true),
-						})
+				if !varDecl.Ephemeral {
+					// If the variable isn't declared as being ephemeral then we
+					// cannot allow ephemeral values to be assigned to it.
+					_, markses := varVal.UnmarkDeepWithPaths()
+					ephemeralPaths, _ := marks.PathsWithMark(markses, marks.Ephemeral)
+					for _, path := range ephemeralPaths {
+						if len(path) == 0 {
+							// The entire value is ephemeral, then.
+							markDiags = markDiags.Append(&hcl.Diagnostic{
+								Severity:    hcl.DiagError,
+								Summary:     "Ephemeral value not allowed",
+								Detail:      fmt.Sprintf("The input variable %q does not accept ephemeral values.", varAddr.Name),
+								Subject:     rng.ToHCL().Ptr(),
+								Expression:  expr,
+								EvalContext: hclCtx,
+								Extra:       diagnosticCausedByEphemeral(true),
+							})
+						} else {
+							// Something nested inside is ephemeral, so we'll be
+							// more specific.
+							markDiags = markDiags.Append(&hcl.Diagnostic{
+								Severity: hcl.DiagError,
+								Summary:  "Ephemeral value not allowed",
+								Detail: fmt.Sprintf(
+									"The input variable %q does not accept ephemeral values, so the value for %s is not compatible.",
+									varAddr.Name, tfdiags.FormatCtyPath(path),
+								),
+								Subject:     rng.ToHCL().Ptr(),
+								Expression:  expr,
+								EvalContext: hclCtx,
+								Extra:       diagnosticCausedByEphemeral(true),
+							})
+						}
 					}
 				}
 			}
+			diags = diags.Append(markDiags)
+			if markDiags.HasErrors() {
+				// If we have an ephemeral value in a place where there shouldn't
+				// be one then we'll return an entirely-unknown value to make sure
+				// that downstreams that aren't checking the errors can't leak the
+				// value into somewhere it ought not to be. We'll still preserve
+				// the type constraint so that we can do type checking downstream.
+				return cty.UnknownVal(v.Type()), diags
+			}
 		}
-		diags = diags.Append(markDiags)
-		if markDiags.HasErrors() {
-			// If we have an ephemeral value in a place where there shouldn't
-			// be one then we'll return an entirely-unknown value to make sure
-			// that downstreams that aren't checking the errors can't leak the
-			// value into somewhere it ought not to be. We'll still preserve
-			// the type constraint so that we can do type checking downstream.
-			return cty.UnknownVal(v.Type()), diags
-		}
-	}
 
-	return v, diags
+		return v, diags
+	})
 }
 
 // ResolveExpressionReference implements ExpressionScope for the arguments
 // inside an embedded stack call block, evaluated in the context of a
 // particular instance of that call.
 func (c *StackCallInstance) ResolveExpressionReference(ctx context.Context, ref stackaddrs.Reference) (Referenceable, tfdiags.Diagnostics) {
-	stack := c.CallerStack()
-	return stack.resolveExpressionReference(ctx, ref, nil, c.repetition)
+	return c.call.stack.resolveExpressionReference(ctx, ref, nil, c.repetition)
 }
 
 // ExternalFunctions implements ExpressionScope.
 func (c *StackCallInstance) ExternalFunctions(ctx context.Context) (lang.ExternalFuncs, tfdiags.Diagnostics) {
-	return c.main.ProviderFunctions(ctx, c.main.StackConfig(c.call.Addr().Stack.ConfigAddr()))
+	return c.main.ProviderFunctions(ctx, c.call.stack.config)
 }
 
 // PlanTimestamp implements ExpressionScope, providing the timestamp at which

--- a/internal/stacks/stackruntime/internal/stackeval/stack_config.go
+++ b/internal/stacks/stackruntime/internal/stackeval/stack_config.go
@@ -30,6 +30,7 @@ type StackConfig struct {
 	addr stackaddrs.Stack
 
 	config *stackconfig.ConfigNode
+	parent *StackConfig
 
 	main *Main
 
@@ -50,9 +51,10 @@ var (
 	_ ExpressionScope = (*StackConfig)(nil)
 )
 
-func newStackConfig(main *Main, addr stackaddrs.Stack, config *stackconfig.ConfigNode) *StackConfig {
+func newStackConfig(main *Main, addr stackaddrs.Stack, parent *StackConfig, config *stackconfig.ConfigNode) *StackConfig {
 	return &StackConfig{
 		addr:   addr,
+		parent: parent,
 		config: config,
 		main:   main,
 
@@ -67,40 +69,6 @@ func newStackConfig(main *Main, addr stackaddrs.Stack, config *stackconfig.Confi
 	}
 }
 
-func (s *StackConfig) Addr() stackaddrs.Stack {
-	return s.addr
-}
-
-func (s *StackConfig) IsRoot() bool {
-	return s.addr.IsRoot()
-}
-
-// ParentAddr returns the address of the containing stack, or panics if called
-// on the root stack (since it has no parent).
-func (s *StackConfig) ParentAddr() stackaddrs.Stack {
-	return s.addr.Parent()
-}
-
-// ConfigDeclarations returns a pointer to the [stackconfig.Declarations]
-// object describing the configured declarations from this stack config's
-// configuration files.
-func (s *StackConfig) ConfigDeclarations() *stackconfig.Declarations {
-	return &s.config.Stack.Declarations
-}
-
-// ParentConfig returns the [StackConfig] object representing the configuration
-// of the containing stack, or nil if the receiver is the root stack in the
-// tree.
-func (s *StackConfig) ParentConfig() *StackConfig {
-	if s.IsRoot() {
-		return nil
-	}
-	// Each StackConfig is only responsible for looking after its direct
-	// children, so to navigate upwards we need to start back at the
-	// root and work our way through the tree again.
-	return s.main.StackConfig(s.ParentAddr())
-}
-
 // ChildConfig returns a [StackConfig] representing the embedded stack matching
 // the given address step, or nil if there is no such stack.
 func (s *StackConfig) ChildConfig(step stackaddrs.StackStep) *StackConfig {
@@ -113,8 +81,8 @@ func (s *StackConfig) ChildConfig(step stackaddrs.StackStep) *StackConfig {
 		if !ok {
 			return nil
 		}
-		childAddr := s.Addr().Child(step.Name)
-		s.children[step] = newStackConfig(s.main, childAddr, childNode)
+		childAddr := s.addr.Child(step.Name)
+		s.children[step] = newStackConfig(s.main, childAddr, s, childNode)
 		ret = s.children[step]
 	}
 	return ret
@@ -159,8 +127,8 @@ func (s *StackConfig) InputVariable(addr stackaddrs.InputVariable) *InputVariabl
 		if !ok {
 			return nil
 		}
-		cfgAddr := stackaddrs.Config(s.Addr(), addr)
-		ret = newInputVariableConfig(s.main, cfgAddr, cfg)
+		cfgAddr := stackaddrs.Config(s.addr, addr)
+		ret = newInputVariableConfig(s.main, cfgAddr, s, cfg)
 		s.inputVariables[addr] = ret
 	}
 	return ret
@@ -193,8 +161,8 @@ func (s *StackConfig) LocalValue(addr stackaddrs.LocalValue) *LocalValueConfig {
 		if !ok {
 			return nil
 		}
-		cfgAddr := stackaddrs.Config(s.Addr(), addr)
-		ret = newLocalValueConfig(s.main, cfgAddr, cfg)
+		cfgAddr := stackaddrs.Config(s.addr, addr)
+		ret = newLocalValueConfig(s.main, cfgAddr, s, cfg)
 		s.localValues[addr] = ret
 	}
 	return ret
@@ -213,8 +181,8 @@ func (s *StackConfig) OutputValue(addr stackaddrs.OutputValue) *OutputValueConfi
 		if !ok {
 			return nil
 		}
-		cfgAddr := stackaddrs.Config(s.Addr(), addr)
-		ret = newOutputValueConfig(s.main, cfgAddr, cfg)
+		cfgAddr := stackaddrs.Config(s.addr, addr)
+		ret = newOutputValueConfig(s.main, cfgAddr, s, cfg)
 		s.outputValues[addr] = ret
 	}
 	return ret
@@ -293,8 +261,8 @@ func (s *StackConfig) Provider(addr stackaddrs.ProviderConfig) *ProviderConfig {
 		if !ok {
 			return nil
 		}
-		cfgAddr := stackaddrs.Config(s.Addr(), addr)
-		ret = newProviderConfig(s.main, cfgAddr, cfg)
+		cfgAddr := stackaddrs.Config(s.addr, addr)
+		ret = newProviderConfig(s.main, cfgAddr, s, cfg)
 		s.providers[addr] = ret
 	}
 	return ret
@@ -329,8 +297,8 @@ func (s *StackConfig) ProviderByLocalAddr(localAddr stackaddrs.ProviderConfigRef
 		if !ok {
 			return nil
 		}
-		cfgAddr := stackaddrs.Config(s.Addr(), addr)
-		ret = newProviderConfig(s.main, cfgAddr, cfg)
+		cfgAddr := stackaddrs.Config(s.addr, addr)
+		ret = newProviderConfig(s.main, cfgAddr, s, cfg)
 		s.providers[addr] = ret
 	}
 	return ret
@@ -369,8 +337,8 @@ func (s *StackConfig) StackCall(addr stackaddrs.StackCall) *StackCallConfig {
 		if !ok {
 			return nil
 		}
-		cfgAddr := stackaddrs.Config(s.Addr(), addr)
-		ret = newStackCallConfig(s.main, cfgAddr, cfg)
+		cfgAddr := stackaddrs.Config(s.addr, addr)
+		ret = newStackCallConfig(s.main, cfgAddr, s, cfg)
 		s.stackCalls[addr] = ret
 	}
 	return ret
@@ -403,8 +371,8 @@ func (s *StackConfig) Component(addr stackaddrs.Component) *ComponentConfig {
 		if !ok {
 			return nil
 		}
-		cfgAddr := stackaddrs.Config(s.Addr(), addr)
-		ret = newComponentConfig(s.main, cfgAddr, cfg)
+		cfgAddr := stackaddrs.Config(s.addr, addr)
+		ret = newComponentConfig(s.main, cfgAddr, s, cfg)
 		s.components[addr] = ret
 	}
 	return ret
@@ -438,8 +406,8 @@ func (s *StackConfig) Removed(addr stackaddrs.Component) []*RemovedConfig {
 			return nil
 		}
 		for _, cfg := range cfgs {
-			cfgAddr := stackaddrs.Config(s.Addr(), addr)
-			removed := newRemovedConfig(s.main, cfgAddr, cfg)
+			cfgAddr := stackaddrs.Config(s.addr, addr)
+			removed := newRemovedConfig(s.main, cfgAddr, s, cfg)
 			ret = append(ret, removed)
 		}
 		s.removed[addr] = ret

--- a/internal/stacks/stackruntime/internal/stackeval/walk_dynamic.go
+++ b/internal/stacks/stackruntime/internal/stackeval/walk_dynamic.go
@@ -73,7 +73,7 @@ func walkDynamicObjectsInStack[Output any](
 				inst := call.UnknownInstance(ctx, phase)
 				visit(ctx, walk, inst)
 
-				childStack := inst.CalledStack()
+				childStack := inst.Stack(ctx, phase)
 				walkDynamicObjectsInStack(ctx, walk, childStack, phase, visit)
 				return
 			}
@@ -82,7 +82,7 @@ func walkDynamicObjectsInStack[Output any](
 			for _, inst := range insts {
 				visit(ctx, walk, inst)
 
-				childStack := inst.CalledStack()
+				childStack := inst.Stack(ctx, phase)
 				walkDynamicObjectsInStack(ctx, walk, childStack, phase, visit)
 			}
 		})
@@ -126,7 +126,7 @@ func walkDynamicObjectsInStack[Output any](
 
 				// knownInstances are the instances that already exist either
 				// because they are in the state or the plan.
-				knownInstances := stack.KnownComponentInstances(component.Addr().Item, phase)
+				knownInstances := stack.KnownComponentInstances(component.addr.Item, phase)
 				if knownInstances.Len() == 0 {
 					// If we have no known instances, then we'll make up an
 					// unknown instance that will act as if it is being created
@@ -143,7 +143,7 @@ func walkDynamicObjectsInStack[Output any](
 				}
 
 				claimedInstances := collections.NewSet[stackaddrs.ComponentInstance]()
-				removed := stack.Removed(component.Addr().Item)
+				removed := stack.Removed(component.addr.Item)
 				for _, block := range removed {
 					// In this case we don't care about the unknown. If the
 					// removed instances are unknown, then we'll mark
@@ -153,7 +153,7 @@ func walkDynamicObjectsInStack[Output any](
 					insts, _, _ := block.Instances(ctx, phase)
 					for key := range insts {
 						claimedInstances.Add(stackaddrs.ComponentInstance{
-							Component: component.Addr().Item,
+							Component: component.addr.Item,
 							Key:       key,
 						})
 					}
@@ -227,7 +227,7 @@ func walkDynamicObjectsInStack[Output any](
 					if componentInstances.Len() == 0 {
 						// then we'll gather the component instances. we do this
 						// once, enforced by the mutex and the check above.
-						component := stack.Component(removed.Addr().Item)
+						component := stack.Component(removed.addr.Item)
 						if component != nil {
 							insts, unknown := component.Instances(ctx, phase)
 							if unknown {
@@ -242,7 +242,7 @@ func walkDynamicObjectsInStack[Output any](
 
 							for key := range insts {
 								componentInstances.Add(stackaddrs.ComponentInstance{
-									Component: removed.Addr().Item,
+									Component: removed.addr.Item,
 									Key:       key,
 								})
 							}


### PR DESCRIPTION
This PR is a refactoring of the Stacks runtime. No expected behaviour change as a result of these changes.

Previously, nodes in the stacks runtime were created with a single link back to the `main` object. From the main object they could then search for the stack instance the nodes were linked to. However, the nodes are all created from inside the stack they want to link back to. I found this reverse look up very confusing.

After this PR, nodes in the runtime accept both the stack and the configuration they are linked to directly in their constructor. This information is simply always available to them, removing the need for the lookups. I think it is easier to reason about each node and where it lives in the stack with this information made available up front. In addition, we can now create stack instances directly within the embedded stack calls that initialise them, making the tracing of stack instances much easier.