### PR TITLE
stacks: include existing components when deferring nested stacks

### DIFF
--- a/internal/stacks/stackaddrs/in_stack.go
+++ b/internal/stacks/stackaddrs/in_stack.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
+
 	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/collections"
 	"github.com/hashicorp/terraform/internal/tfdiags"
@@ -182,8 +183,8 @@ Steps:
 		}
 		traversal = traversal[2:] // consume the first two steps that we already dealt with
 		if len(traversal) > 0 {
-			idxStep, ok := traversal[0].(hcl.TraverseIndex)
-			if ok {
+			switch idxStep := traversal[0].(type) {
+			case hcl.TraverseIndex:
 				var err error
 				addrStep.Key, err = addrs.ParseInstanceKey(idxStep.Key)
 				if err != nil {
@@ -196,6 +197,9 @@ Steps:
 					return nil, nil, diags
 				}
 				traversal = traversal[1:] // consume the step we just dealt with
+			case hcl.TraverseSplat:
+				addrStep.Key = addrs.WildcardKey
+				traversal = traversal[1:]
 			}
 		}
 		stackInst = append(stackInst, addrStep)

--- a/internal/stacks/stackplan/plan.go
+++ b/internal/stacks/stackplan/plan.go
@@ -107,6 +107,27 @@ func (p *Plan) ComponentInstances(addr stackaddrs.AbsComponent) collections.Set[
 	return ret
 }
 
+func (p *Plan) StackInstances(addr stackaddrs.AbsStackCall) map[stackaddrs.StackInstanceStep]bool {
+	ret := make(map[stackaddrs.StackInstanceStep]bool)
+	for key := range p.Components.All() {
+		if len(key.Stack) == 0 {
+			continue
+		}
+
+		last := key.Stack[len(key.Stack)-1]
+		path := key.Stack[:len(key.Stack)-1]
+
+		if path.String() != addr.Stack.String() {
+			continue
+		}
+		if last.Name != addr.Item.Name {
+			continue
+		}
+		ret[last] = true
+	}
+	return ret
+}
+
 // RequiredProviderInstances returns a description of all of the provider
 // instance slots that are required to satisfy the resource instances
 // belonging to the given component instance.

--- a/internal/stacks/stackruntime/internal/stackeval/component.go
+++ b/internal/stacks/stackruntime/internal/stackeval/component.go
@@ -144,7 +144,7 @@ func (c *Component) CheckInstances(ctx context.Context, phase EvalPhase) (map[ad
 			}
 
 			result := instancesMap(forEachVal, func(ik addrs.InstanceKey, rd instances.RepetitionData) *ComponentInstance {
-				return newComponentInstance(c, stackaddrs.AbsComponentToInstance(c.addr, ik), rd, false)
+				return newComponentInstance(c, stackaddrs.AbsComponentToInstance(c.addr, ik), rd, c.stack.deferred)
 			})
 
 			addrs := make([]stackaddrs.AbsComponentInstance, 0, len(result.insts))

--- a/internal/stacks/stackruntime/internal/stackeval/main.go
+++ b/internal/stacks/stackruntime/internal/stackeval/main.go
@@ -310,7 +310,7 @@ func (m *Main) MainStack() *Stack {
 	defer m.mu.Unlock()
 
 	if m.mainStack == nil {
-		m.mainStack = newStack(m, stackaddrs.RootStackInstance, nil, config, collections.NewMap[stackaddrs.ConfigComponent, []*RemovedComponent]())
+		m.mainStack = newStack(m, stackaddrs.RootStackInstance, nil, config, collections.NewMap[stackaddrs.ConfigComponent, []*RemovedComponent](), false)
 	}
 	return m.mainStack
 }

--- a/internal/stacks/stackruntime/internal/stackeval/removed_component.go
+++ b/internal/stacks/stackruntime/internal/stackeval/removed_component.go
@@ -111,7 +111,7 @@ func (r *RemovedComponent) Instances(ctx context.Context, phase EvalPhase) (map[
 				return nil
 			}
 
-			return newRemovedComponentInstance(r, addr, rd, false)
+			return newRemovedComponentInstance(r, addr, rd, r.stack.deferred)
 		})
 
 		// Now, filter out any instances that are not known to the previous

--- a/internal/stacks/stackruntime/internal/stackeval/stack_call.go
+++ b/internal/stacks/stackruntime/internal/stackeval/stack_call.go
@@ -150,7 +150,7 @@ func (c *StackCall) CheckInstances(ctx context.Context, phase EvalPhase) (map[ad
 			}
 
 			return instancesMap(forEachVal, func(ik addrs.InstanceKey, rd instances.RepetitionData) *StackCallInstance {
-				return newStackCallInstance(c, ik, rd)
+				return newStackCallInstance(c, ik, rd, c.stack.deferred)
 			}), diags
 		},
 	)
@@ -159,7 +159,7 @@ func (c *StackCall) CheckInstances(ctx context.Context, phase EvalPhase) (map[ad
 
 func (c *StackCall) UnknownInstance(ctx context.Context, phase EvalPhase) *StackCallInstance {
 	inst, err := c.unknownInstance.For(phase).Do(ctx, c.tracingName()+" unknown instace", func(ctx context.Context) (*StackCallInstance, error) {
-		return newStackCallInstance(c, addrs.WildcardKey, instances.UnknownForEachRepetitionData(c.ForEachValue(ctx, phase).Type())), nil
+		return newStackCallInstance(c, addrs.WildcardKey, instances.UnknownForEachRepetitionData(c.ForEachValue(ctx, phase).Type()), true), nil
 	})
 	if err != nil {
 		// Since we never return an error from the function we pass to Do,

--- a/internal/stacks/stackruntime/internal/stackeval/walk_dynamic.go
+++ b/internal/stacks/stackruntime/internal/stackeval/walk_dynamic.go
@@ -70,12 +70,39 @@ func walkDynamicObjectsInStack[Output any](
 
 			// If unknown, then process the unknown instance and skip the rest.
 			if unknown {
-				inst := call.UnknownInstance(ctx, phase)
-				visit(ctx, walk, inst)
+				knownInstances := stack.KnownEmbeddedStacks(call.addr.Item, phase)
+				if len(knownInstances) == 0 {
+					// with no known instances, we'll just process the constant
+					// unknown instance
+					inst := call.UnknownInstance(ctx, phase)
+					visit(ctx, walk, inst)
 
-				childStack := inst.Stack(ctx, phase)
-				walkDynamicObjectsInStack(ctx, walk, childStack, phase, visit)
-				return
+					childStack := inst.Stack(ctx, phase)
+					walkDynamicObjectsInStack(ctx, walk, childStack, phase, visit)
+					return
+				}
+
+				// otherwise we have instances, so we'll process those with
+				// dedicated instances
+
+				for inst := range knownInstances {
+					if inst.Key == addrs.WildcardKey {
+						inst := call.UnknownInstance(ctx, phase)
+						visit(ctx, walk, inst)
+
+						childStack := inst.Stack(ctx, phase)
+						walkDynamicObjectsInStack(ctx, walk, childStack, phase, visit)
+					} else {
+						inst := newStackCallInstance(call, inst.Key, instances.RepetitionData{
+							EachKey:   inst.Key.Value(),
+							EachValue: cty.UnknownVal(cty.DynamicPseudoType),
+						}, true)
+						visit(ctx, walk, inst)
+
+						childStack := inst.Stack(ctx, phase)
+						walkDynamicObjectsInStack(ctx, walk, childStack, phase, visit)
+					}
+				}
 			}
 
 			// Otherwise, process the instances and their child stacks.

--- a/internal/stacks/stackruntime/testdata/mainbundle/test/with-single-input/deferred-embedded-stack-for-each/deferred-embedded-stack-for-each.tfstack.hcl
+++ b/internal/stacks/stackruntime/testdata/mainbundle/test/with-single-input/deferred-embedded-stack-for-each/deferred-embedded-stack-for-each.tfstack.hcl
@@ -6,7 +6,7 @@ required_providers {
 }
 
 variable "stacks" {
-  type = set(string)
+  type = map(string)
 }
 
 provider "testing" "default" {}
@@ -16,6 +16,7 @@ stack "a" {
   for_each = var.stacks
 
   inputs = {
+    id = each.key
     input = each.value
   }
 }

--- a/internal/stacks/stackstate/state.go
+++ b/internal/stacks/stackstate/state.go
@@ -118,6 +118,29 @@ func (s *State) ComponentInstances(addr stackaddrs.AbsComponent) collections.Set
 	return ret
 }
 
+// StackInstances returns the set of known stack instances for the given stack
+// call.
+func (s *State) StackInstances(call stackaddrs.AbsStackCall) map[stackaddrs.StackInstanceStep]bool {
+	ret := make(map[stackaddrs.StackInstanceStep]bool)
+	for key := range s.componentInstances.All() {
+		if len(key.Stack) == 0 {
+			continue
+		}
+
+		last := key.Stack[len(key.Stack)-1]
+		path := key.Stack[:len(key.Stack)-1]
+
+		if path.String() != call.Stack.String() {
+			continue
+		}
+		if last.Name != call.Item.Name {
+			continue
+		}
+		ret[last] = true
+	}
+	return ret
+}
+
 func (s *State) componentInstanceState(addr stackaddrs.AbsComponentInstance) *componentInstanceState {
 	return s.componentInstances.Get(addr)
 }


### PR DESCRIPTION
Currently, components in nested stacks are just ignored during the plan when the nested stack call is deferred.

This PR updates the stacks runtime so a deferred stack call still triggers deferred updates of any components in the nested stack that already exist.