### PR TITLE
disable tls kyber KEX

### DIFF
--- a/.changes/v1.11/BUG FIXES-20250327-094612.yaml
+++ b/.changes/v1.11/BUG FIXES-20250327-094612.yaml
@@ -1,0 +1,5 @@
+kind: BUG FIXES
+body: disable X25519Kyber768Draft00 in TLS to prevent timouts with some AWS network firewalls
+time: 2025-03-27T09:46:12.506243-04:00
+custom:
+    Issue: "36791"

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,10 @@ go 1.23.3
 
 godebug winsymlink=0
 
+// Disable experimental post-quantum key exchange mechanism X25519Kyber768Draft00
+// This was causing errors with AWS Network Firewall when using go1.23
+godebug tlskyber=0
+
 require (
 	github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2
 	github.com/ProtonMail/go-crypto v1.0.0


### PR DESCRIPTION
Disable kyber globally in core. This primarily affects the S3 backend, since the only reported incompatible system was the AWS firewall, and the AWS provider has chosen to disable this option as well. https://github.com/hashicorp/terraform-provider-aws/pull/41740. 

There could be other incompatible networks out there still however, and since the X25519Kyber768Draft00 was removed in go1.24, we can just disable it for v1.11 and move on.

## Target Release

v1.11
