### PR TITLE
docs: Correct wording in CLI configuration page

### DIFF
--- a/website/docs/cli/config/config-file.mdx
+++ b/website/docs/cli/config/config-file.mdx
@@ -13,7 +13,8 @@ This topic describes how create a configuration file to customize the behavior o
 The CLI configuration file configures per-user settings for CLI behaviors,
 which apply across all Terraform working directories. This is separate from
 [your infrastructure configuration](/terraform/language). 
-You can define custom configurations in file with the `.terraformrc` extention a file named `terraform.rc`.
+You can define custom configurations in file called `.terraformrc` or `terraform.rc`
+depending on the host operating system as explained below.
 
 ## Locations
 


### PR DESCRIPTION
Fixes #36763

## Target Release

1.11.x

## CHANGELOG entry


- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
