### PR TITLE
providers/testing: Remove unused `*TypeName` fields

### DIFF
--- a/internal/providers/testing/provider_mock.go
+++ b/internal/providers/testing/provider_mock.go
@@ -41,25 +41,21 @@ type MockProvider struct {
 	ValidateProviderConfigFn       func(providers.ValidateProviderConfigRequest) providers.ValidateProviderConfigResponse
 
 	ValidateResourceConfigCalled   bool
-	ValidateResourceConfigTypeName string
 	ValidateResourceConfigResponse *providers.ValidateResourceConfigResponse
 	ValidateResourceConfigRequest  providers.ValidateResourceConfigRequest
 	ValidateResourceConfigFn       func(providers.ValidateResourceConfigRequest) providers.ValidateResourceConfigResponse
 
 	ValidateDataResourceConfigCalled   bool
-	ValidateDataResourceConfigTypeName string
 	ValidateDataResourceConfigResponse *providers.ValidateDataResourceConfigResponse
 	ValidateDataResourceConfigRequest  providers.ValidateDataResourceConfigRequest
 	ValidateDataResourceConfigFn       func(providers.ValidateDataResourceConfigRequest) providers.ValidateDataResourceConfigResponse
 
 	UpgradeResourceStateCalled   bool
-	UpgradeResourceStateTypeName string
 	UpgradeResourceStateResponse *providers.UpgradeResourceStateResponse
 	UpgradeResourceStateRequest  providers.UpgradeResourceStateRequest
 	UpgradeResourceStateFn       func(providers.UpgradeResourceStateRequest) providers.UpgradeResourceStateResponse
 
 	UpgradeResourceIdentityCalled   bool
-	UpgradeResourceIdentityTypeName string
 	UpgradeResourceIdentityResponse *providers.UpgradeResourceIdentityResponse
 	UpgradeResourceIdentityRequest  providers.UpgradeResourceIdentityRequest
 	UpgradeResourceIdentityFn       func(providers.UpgradeResourceIdentityRequest) providers.UpgradeResourceIdentityResponse


### PR DESCRIPTION
As far as I can tell, all the impacted methods need to basically enable mocking of _all_ type names, so the field doesn't seem relevant and it appears it was never used.

Introduced initially as part of a bigger PR https://github.com/hashicorp/terraform/pull/27805 and then accidentally copy pasted in other PRs for other purposes.

## Target Release

1.12.x

## CHANGELOG entry

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
