### PR TITLE
stacks: update removed blocks to allow targeting of embedded stacks

### DIFF
--- a/internal/rpcapi/stacks.go
+++ b/internal/rpcapi/stacks.go
@@ -239,10 +239,10 @@ func stackConfigMetaforProto(cfgNode *stackconfig.ConfigNode, stackAddr stackadd
 	}
 
 	// Currently Components are the only thing that can be removed
-	for name, rc := range cfgNode.Stack.Removed.All() {
+	for name, rc := range cfgNode.Stack.RemovedComponents.All() {
 		var blocks []*stacks.FindStackConfigurationComponents_Removed_Block
 		for _, rc := range rc {
-			relativeAddress := rc.From.ConfigComponent()
+			relativeAddress := rc.From.TargetConfigComponent()
 			cProto := &stacks.FindStackConfigurationComponents_Removed_Block{
 				SourceAddr:    rc.FinalSourceAddr.String(),
 				ComponentAddr: stackaddrs.Config(append(stackAddr, relativeAddress.Stack...), relativeAddress.Item).String(),
@@ -256,7 +256,7 @@ func stackConfigMetaforProto(cfgNode *stackconfig.ConfigNode, stackAddr stackadd
 			}
 			blocks = append(blocks, cProto)
 		}
-		relativeAddress := rc[0].From.ConfigComponent()
+		relativeAddress := rc[0].From.TargetConfigComponent()
 		ret.Removed[name.String()] = &stacks.FindStackConfigurationComponents_Removed{
 			// in order to ensure as much backwards and forwards compatibility
 			// as possible, we're going to set the deprecated single fields

--- a/internal/stacks/stackconfig/declarations.go
+++ b/internal/stacks/stackconfig/declarations.go
@@ -47,20 +47,25 @@ type Declarations struct {
 	// overall tree might have their own provider configurations.
 	ProviderConfigs map[addrs.LocalProviderConfig]*ProviderConfig
 
-	// Removed are the list of components that have been removed from the
-	// configuration.
-	Removed collections.Map[stackaddrs.ConfigComponent, []*Removed]
+	// RemovedComponents is the list of components that have been removed from
+	// the configuration.
+	RemovedComponents collections.Map[stackaddrs.ConfigComponent, []*Removed]
+
+	// RemovedEmbeddedStacks is the list of embedded stacks that have been removed
+	// from the configuration.
+	RemovedEmbeddedStacks collections.Map[stackaddrs.Stack, []*Removed]
 }
 
 func makeDeclarations() Declarations {
 	return Declarations{
-		EmbeddedStacks:  make(map[string]*EmbeddedStack),
-		Components:      make(map[string]*Component),
-		InputVariables:  make(map[string]*InputVariable),
-		LocalValues:     make(map[string]*LocalValue),
-		OutputValues:    make(map[string]*OutputValue),
-		ProviderConfigs: make(map[addrs.LocalProviderConfig]*ProviderConfig),
-		Removed:         collections.NewMap[stackaddrs.ConfigComponent, []*Removed](),
+		EmbeddedStacks:        make(map[string]*EmbeddedStack),
+		Components:            make(map[string]*Component),
+		InputVariables:        make(map[string]*InputVariable),
+		LocalValues:           make(map[string]*LocalValue),
+		OutputValues:          make(map[string]*OutputValue),
+		ProviderConfigs:       make(map[addrs.LocalProviderConfig]*ProviderConfig),
+		RemovedComponents:     collections.NewMap[stackaddrs.ConfigComponent, []*Removed](),
+		RemovedEmbeddedStacks: collections.NewMap[stackaddrs.Stack, []*Removed](),
 	}
 }
 
@@ -84,7 +89,7 @@ func (d *Declarations) addComponent(decl *Component) tfdiags.Diagnostics {
 		return diags
 	}
 
-	if blocks, exists := d.Removed.GetOk(stackaddrs.ConfigComponent{
+	if blocks, exists := d.RemovedComponents.GetOk(stackaddrs.ConfigComponent{
 		Stack: nil,
 		Item: stackaddrs.Component{
 			Name: name,
@@ -135,6 +140,25 @@ func (d *Declarations) addEmbeddedStack(decl *EmbeddedStack) tfdiags.Diagnostics
 			Subject: decl.DeclRange.ToHCL().Ptr(),
 		})
 		return diags
+	}
+
+	if blocks, exists := d.RemovedEmbeddedStacks.GetOk(stackaddrs.Stack{
+		stackaddrs.StackStep{Name: name},
+	}); exists {
+		for _, removed := range blocks {
+			if removed.From.Stack[0].Index == nil {
+				diags = diags.Append(&hcl.Diagnostic{
+					Severity: hcl.DiagError,
+					Summary:  "Stack exists for removed block",
+					Detail: fmt.Sprintf(
+						"A removed block for stack %q was declared without an index, but a stack block with the same name was declared at %s.\n\nA removed block without an index indicates that the stack and all instances were removed from the configuration, and this is not the case.",
+						name, decl.DeclRange.ToHCL(),
+					),
+					Subject: removed.DeclRange.ToHCL().Ptr(),
+				})
+				return diags
+			}
+		}
 	}
 
 	d.EmbeddedStacks[name] = decl
@@ -264,34 +288,60 @@ func (d *Declarations) addRemoved(decl *Removed) tfdiags.Diagnostics {
 	if decl == nil {
 		return diags
 	}
-	addr := decl.From.ConfigComponent()
 
-	if decl.From.Component.Index == nil && len(decl.From.Stack) == 0 {
-		// If the removed block does not have an index, then we shouldn't also
-		// have a component block with the same name. A removed block without
-		// an index indicates that the component and all instances were removed
-		// from the configuration.
-		//
-		// Note that a removed block with an index is allowed to coexist with a
-		// component block with the same name, because it indicates that only
-		// a specific instance was removed and not the whole thing. During the
-		// validate and planning stages we will validate that the clashing
-		// component and removed blocks are not both pointing to the same index.
-		if component, exists := d.Components[decl.From.Component.Name]; exists {
-			diags = diags.Append(&hcl.Diagnostic{
-				Severity: hcl.DiagError,
-				Summary:  "Component exists for removed block",
-				Detail: fmt.Sprintf(
-					"A removed block for component %q was declared without an index, but a component block with the same name was declared at %s.\n\nA removed block without an index indicates that the component and all instances were removed from the configuration, and this is not the case.",
-					decl.From.Component.Name, component.DeclRange.ToHCL(),
-				),
-				Subject: decl.DeclRange.ToHCL().Ptr(),
-			})
-			return diags
+	if decl.From.Component != nil {
+		addr := decl.From.TargetConfigComponent()
+
+		if decl.From.Component.Index == nil && len(decl.From.Stack) == 0 {
+			// If the removed block does not have an index, then we shouldn't also
+			// have a component block with the same name. A removed block without
+			// an index indicates that the component and all instances were removed
+			// from the configuration.
+			//
+			// Note that a removed block with an index is allowed to coexist with a
+			// component block with the same name, because it indicates that only
+			// a specific instance was removed and not the whole thing. During the
+			// validate and planning stages we will validate that the clashing
+			// component and removed blocks are not both pointing to the same index.
+			if component, exists := d.Components[decl.From.Component.Name]; exists {
+				diags = diags.Append(&hcl.Diagnostic{
+					Severity: hcl.DiagError,
+					Summary:  "Component exists for removed block",
+					Detail: fmt.Sprintf(
+						"A removed block for component %q was declared without an index, but a component block with the same name was declared at %s.\n\nA removed block without an index indicates that the component and all instances were removed from the configuration, and this is not the case.",
+						decl.From.Component.Name, component.DeclRange.ToHCL(),
+					),
+					Subject: decl.DeclRange.ToHCL().Ptr(),
+				})
+				return diags
+			}
 		}
+
+		d.RemovedComponents.Put(addr, append(d.RemovedComponents.Get(addr), decl))
+	} else {
+		addr := decl.From.TargetStack()
+
+		if len(decl.From.Stack) == 1 && decl.From.Stack[0].Index == nil {
+			// Same logic as for components, we can just error a bit earlier
+			// here if the user is targeting a stack that definitely exists
+			// in the configuration.
+			if stack, exists := d.EmbeddedStacks[decl.From.Stack[0].Name]; exists {
+				diags = diags.Append(&hcl.Diagnostic{
+					Severity: hcl.DiagError,
+					Summary:  "Stack exists for removed block",
+					Detail: fmt.Sprintf(
+						"A removed block for stack %q was declared without an index, but a stack block with the same name was declared at %s.\n\nA removed block without an index indicates that the stack and all instances were removed from the configuration, and this is not the case.",
+						decl.From.Component.Name, stack.DeclRange.ToHCL(),
+					),
+					Subject: decl.DeclRange.ToHCL().Ptr(),
+				})
+				return diags
+			}
+		}
+
+		d.RemovedEmbeddedStacks.Put(addr, append(d.RemovedEmbeddedStacks.Get(addr), decl))
 	}
 
-	d.Removed.Put(addr, append(d.Removed.Get(addr), decl))
 	return diags
 }
 
@@ -301,6 +351,11 @@ func (d *Declarations) merge(other *Declarations) tfdiags.Diagnostics {
 		diags = diags.Append(
 			d.addEmbeddedStack(decl),
 		)
+	}
+	for _, blocks := range other.RemovedEmbeddedStacks.All() {
+		for _, decl := range blocks {
+			diags = diags.Append(d.addRemoved(decl))
+		}
 	}
 	for _, decl := range other.Components {
 		diags = diags.Append(
@@ -330,7 +385,7 @@ func (d *Declarations) merge(other *Declarations) tfdiags.Diagnostics {
 			d.addProviderConfig(decl),
 		)
 	}
-	for _, blocks := range other.Removed.All() {
+	for _, blocks := range other.RemovedComponents.All() {
 		for _, decl := range blocks {
 			diags = diags.Append(
 				d.addRemoved(decl),

--- a/internal/stacks/stackconfig/embedded_stack.go
+++ b/internal/stacks/stackconfig/embedded_stack.go
@@ -32,6 +32,14 @@ type EmbeddedStack struct {
 	VersionConstraints                       constraints.IntersectionSpec
 	SourceAddrRange, VersionConstraintsRange tfdiags.SourceRange
 
+	// FinalSourceAddr is populated only when a configuration is loaded
+	// through [LoadConfigDir], and in that case contains the finalized
+	// address produced by resolving the SourceAddr field relative to
+	// the address of the file where the component was declared. This
+	// is the address to use if you intend to load the component's
+	// root module from a source bundle.
+	FinalSourceAddr sourceaddrs.FinalSource
+
 	ForEach hcl.Expression
 
 	// Inputs is an expression that should produce a value that can convert

--- a/internal/stacks/stackplan/plan.go
+++ b/internal/stacks/stackplan/plan.go
@@ -107,8 +107,8 @@ func (p *Plan) ComponentInstances(addr stackaddrs.AbsComponent) collections.Set[
 	return ret
 }
 
-func (p *Plan) StackInstances(addr stackaddrs.AbsStackCall) map[stackaddrs.StackInstanceStep]bool {
-	ret := make(map[stackaddrs.StackInstanceStep]bool)
+func (p *Plan) StackInstances(addr stackaddrs.AbsStackCall) collections.Set[stackaddrs.StackInstance] {
+	ret := collections.NewSet[stackaddrs.StackInstance]()
 	for key := range p.Components.All() {
 		if len(key.Stack) == 0 {
 			continue
@@ -123,7 +123,7 @@ func (p *Plan) StackInstances(addr stackaddrs.AbsStackCall) map[stackaddrs.Stack
 		if last.Name != addr.Item.Name {
 			continue
 		}
-		ret[last] = true
+		ret.Add(key.Stack)
 	}
 	return ret
 }

--- a/internal/stacks/stackruntime/internal/stackeval/component.go
+++ b/internal/stacks/stackruntime/internal/stackeval/component.go
@@ -144,7 +144,7 @@ func (c *Component) CheckInstances(ctx context.Context, phase EvalPhase) (map[ad
 			}
 
 			result := instancesMap(forEachVal, func(ik addrs.InstanceKey, rd instances.RepetitionData) *ComponentInstance {
-				return newComponentInstance(c, stackaddrs.AbsComponentToInstance(c.addr, ik), rd, c.stack.deferred)
+				return newComponentInstance(c, stackaddrs.AbsComponentToInstance(c.addr, ik), rd, c.stack.mode, c.stack.deferred)
 			})
 
 			addrs := make([]stackaddrs.AbsComponentInstance, 0, len(result.insts))
@@ -166,7 +166,7 @@ func (c *Component) CheckInstances(ctx context.Context, phase EvalPhase) (map[ad
 
 func (c *Component) UnknownInstance(ctx context.Context, phase EvalPhase) *ComponentInstance {
 	inst, err := c.unknownInstance.For(phase).Do(ctx, c.tracingName()+" unknown instance", func(ctx context.Context) (*ComponentInstance, error) {
-		return newComponentInstance(c, stackaddrs.AbsComponentToInstance(c.addr, addrs.WildcardKey), instances.UnknownForEachRepetitionData(c.ForEachValue(ctx, phase).Type()), true), nil
+		return newComponentInstance(c, stackaddrs.AbsComponentToInstance(c.addr, addrs.WildcardKey), instances.UnknownForEachRepetitionData(c.ForEachValue(ctx, phase).Type()), c.stack.mode, true), nil
 	})
 	if err != nil {
 		// Since we never return an error from the function we pass to Do,

--- a/internal/stacks/stackruntime/internal/stackeval/component_instance.go
+++ b/internal/stacks/stackruntime/internal/stackeval/component_instance.go
@@ -31,6 +31,7 @@ import (
 type ComponentInstance struct {
 	call     *Component
 	addr     stackaddrs.AbsComponentInstance
+	mode     plans.Mode
 	deferred bool
 
 	main    *Main
@@ -47,10 +48,11 @@ var _ Plannable = (*ComponentInstance)(nil)
 var _ ExpressionScope = (*ComponentInstance)(nil)
 var _ ConfigComponentExpressionScope[stackaddrs.AbsComponentInstance] = (*ComponentInstance)(nil)
 
-func newComponentInstance(call *Component, addr stackaddrs.AbsComponentInstance, repetition instances.RepetitionData, deferred bool) *ComponentInstance {
+func newComponentInstance(call *Component, addr stackaddrs.AbsComponentInstance, repetition instances.RepetitionData, mode plans.Mode, deferred bool) *ComponentInstance {
 	component := &ComponentInstance{
 		call:       call,
 		addr:       addr,
+		mode:       mode,
 		deferred:   deferred,
 		main:       call.main,
 		repetition: repetition,
@@ -189,8 +191,7 @@ func (c *ComponentInstance) CheckModuleTreePlan(ctx context.Context) (*plans.Pla
 		func(ctx context.Context) (*plans.Plan, tfdiags.Diagnostics) {
 			var diags tfdiags.Diagnostics
 
-			mode := c.main.PlanningOpts().PlanningMode
-			if mode == plans.DestroyMode {
+			if c.mode == plans.DestroyMode {
 
 				if !c.main.PlanPrevState().HasComponentInstance(c.Addr()) {
 					// If the component instance doesn't exist in the previous
@@ -235,7 +236,7 @@ func (c *ComponentInstance) CheckModuleTreePlan(ctx context.Context) (*plans.Pla
 
 				// For the actual destroy plan, we'll skip the refresh and
 				// simply use the refreshed state from the refresh plan.
-				opts, moreDiags := c.PlanOpts(ctx, plans.DestroyMode, true)
+				opts, moreDiags := c.PlanOpts(ctx, c.mode, true)
 				diags = diags.Append(moreDiags)
 				if opts == nil {
 					return nil, diags
@@ -271,7 +272,7 @@ func (c *ComponentInstance) CheckModuleTreePlan(ctx context.Context) (*plans.Pla
 				return plan, diags.Append(moreDiags)
 			}
 
-			opts, moreDiags := c.PlanOpts(ctx, mode, false)
+			opts, moreDiags := c.PlanOpts(ctx, c.mode, false)
 			diags = diags.Append(moreDiags)
 			if opts == nil {
 				return nil, diags
@@ -502,7 +503,7 @@ func (c *ComponentInstance) ResultValue(ctx context.Context, phase EvalPhase) ct
 	switch phase {
 	case PlanPhase:
 
-		if c.main.PlanningOpts().PlanningMode == plans.DestroyMode {
+		if c.mode == plans.DestroyMode {
 			// If we are running a destroy plan, then we'll return the result
 			// of our refresh operation.
 			return cty.ObjectVal(c.refresh.Result(ctx))
@@ -684,7 +685,7 @@ func (c *ComponentInstance) PlanChanges(ctx context.Context) ([]stackplan.Planne
 		}
 
 		var refreshPlan *plans.Plan
-		if c.main.PlanningOpts().PlanningMode == plans.DestroyMode {
+		if c.mode == plans.DestroyMode {
 			// if we're in destroy mode, then we did a separate refresh plan
 			// so we'll make sure to pass that in as extra information the
 			// FromPlan function can use.

--- a/internal/stacks/stackruntime/internal/stackeval/main.go
+++ b/internal/stacks/stackruntime/internal/stackeval/main.go
@@ -21,6 +21,7 @@ import (
 	"github.com/hashicorp/terraform/internal/collections"
 	"github.com/hashicorp/terraform/internal/depsfile"
 	"github.com/hashicorp/terraform/internal/lang"
+	"github.com/hashicorp/terraform/internal/plans"
 	"github.com/hashicorp/terraform/internal/providers"
 	"github.com/hashicorp/terraform/internal/provisioners"
 	"github.com/hashicorp/terraform/internal/stacks/stackaddrs"
@@ -310,7 +311,13 @@ func (m *Main) MainStack() *Stack {
 	defer m.mu.Unlock()
 
 	if m.mainStack == nil {
-		m.mainStack = newStack(m, stackaddrs.RootStackInstance, nil, config, collections.NewMap[stackaddrs.ConfigComponent, []*RemovedComponent](), false)
+
+		mode := plans.NormalMode
+		if m.Planning() {
+			mode = m.PlanningOpts().PlanningMode
+		}
+
+		m.mainStack = newStack(m, stackaddrs.RootStackInstance, nil, config, collections.NewMap[stackaddrs.ConfigComponent, []*RemovedComponent](), collections.NewMap[stackaddrs.Stack, []*RemovedStackCall](), mode, false)
 	}
 	return m.mainStack
 }

--- a/internal/stacks/stackruntime/internal/stackeval/removed_component.go
+++ b/internal/stacks/stackruntime/internal/stackeval/removed_component.go
@@ -105,7 +105,7 @@ func (r *RemovedComponent) Instances(ctx context.Context, phase EvalPhase) (map[
 				return nil
 			}
 
-			addr, moreDiags := from.AbsComponentInstance(evalContext, r.stack.addr)
+			addr, moreDiags := from.TargetAbsComponentInstance(evalContext, r.stack.addr)
 			diags = diags.Append(moreDiags)
 			if moreDiags.HasErrors() {
 				return nil

--- a/internal/stacks/stackruntime/internal/stackeval/removed_stack_call.go
+++ b/internal/stacks/stackruntime/internal/stackeval/removed_stack_call.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
 package stackeval
 
 import (

--- a/internal/stacks/stackruntime/internal/stackeval/removed_stack_call.go
+++ b/internal/stacks/stackruntime/internal/stackeval/removed_stack_call.go
@@ -1,0 +1,180 @@
+package stackeval
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/zclconf/go-cty/cty"
+
+	"github.com/hashicorp/terraform/internal/addrs"
+	"github.com/hashicorp/terraform/internal/collections"
+	"github.com/hashicorp/terraform/internal/instances"
+	"github.com/hashicorp/terraform/internal/lang"
+	"github.com/hashicorp/terraform/internal/promising"
+	"github.com/hashicorp/terraform/internal/stacks/stackaddrs"
+	"github.com/hashicorp/terraform/internal/stacks/stackplan"
+	"github.com/hashicorp/terraform/internal/stacks/stackstate"
+	"github.com/hashicorp/terraform/internal/tfdiags"
+)
+
+var _ Plannable = (*RemovedStackCall)(nil)
+var _ Applyable = (*RemovedStackCall)(nil)
+
+type RemovedStackCall struct {
+	stack  *Stack
+	target stackaddrs.Stack // relative to stack
+
+	config *RemovedStackCallConfig
+
+	main *Main
+
+	forEachValue perEvalPhase[promising.Once[withDiagnostics[cty.Value]]]
+	instances    perEvalPhase[promising.Once[withDiagnostics[instancesResult[*RemovedStackCallInstance]]]]
+}
+
+func newRemovedStackCall(main *Main, target stackaddrs.Stack, stack *Stack, config *RemovedStackCallConfig) *RemovedStackCall {
+	return &RemovedStackCall{
+		stack:  stack,
+		target: target,
+		config: config,
+		main:   main,
+	}
+}
+
+// GetExternalRemovedBlocks fetches the removed blocks that target the stack
+// instances being created by this stack call.
+func (r *RemovedStackCall) GetExternalRemovedBlocks() (collections.Map[stackaddrs.ConfigComponent, []*RemovedComponent], collections.Map[stackaddrs.Stack, []*RemovedStackCall]) {
+	return r.stack.Removed().ForStackCall(stackaddrs.StackCall{
+		Name: r.target[0].Name,
+	})
+}
+
+func (r *RemovedStackCall) ForEachValue(ctx context.Context, phase EvalPhase) (cty.Value, tfdiags.Diagnostics) {
+	return doOnceWithDiags(ctx, r.tracingName()+" for_each", r.forEachValue.For(phase), func(ctx context.Context) (cty.Value, tfdiags.Diagnostics) {
+		config := r.config.config
+
+		switch {
+		case config.ForEach != nil:
+			result, diags := evaluateForEachExpr(ctx, config.ForEach, phase, r.stack, "removed")
+			if diags.HasErrors() {
+				return cty.DynamicVal, diags
+			}
+
+			return result.Value, diags
+
+		default:
+			return cty.NilVal, nil
+		}
+	})
+}
+
+func (r *RemovedStackCall) InstancesFor(ctx context.Context, stack stackaddrs.StackInstance, phase EvalPhase) (map[addrs.InstanceKey]*RemovedStackCallInstance, bool) {
+	results, unknown, _ := r.Instances(ctx, phase)
+
+	insts := make(map[addrs.InstanceKey]*RemovedStackCallInstance)
+	for key, inst := range results {
+		if stack.Contains(inst.from) {
+			insts[key] = inst
+		}
+	}
+
+	return insts, unknown
+}
+
+func (r *RemovedStackCall) Instances(ctx context.Context, phase EvalPhase) (map[addrs.InstanceKey]*RemovedStackCallInstance, bool, tfdiags.Diagnostics) {
+	result, diags := doOnceWithDiags(ctx, r.tracingName()+" instances", r.instances.For(phase), func(ctx context.Context) (instancesResult[*RemovedStackCallInstance], tfdiags.Diagnostics) {
+		forEachValue, diags := r.ForEachValue(ctx, phase)
+		if diags.HasErrors() {
+			return instancesResult[*RemovedStackCallInstance]{}, diags
+		}
+
+		// First, evaluate the for_each value to get the set of instances the
+		// user has asked to be removed.
+		result := instancesMap(forEachValue, func(ik addrs.InstanceKey, rd instances.RepetitionData) *RemovedStackCallInstance {
+			from := r.config.config.From
+
+			evalContext, moreDiags := evalContextForTraversals(ctx, from.Variables(), phase, &removedStackCallInstanceExpressionScope{r, rd})
+			diags = diags.Append(moreDiags)
+			if moreDiags.HasErrors() {
+				return nil
+			}
+
+			addr, moreDiags := from.TargetStackInstance(evalContext, r.stack.addr)
+			diags = diags.Append(moreDiags)
+			if moreDiags.HasErrors() {
+				return nil
+			}
+
+			return newRemovedStackCallInstance(r, addr, rd, r.stack.deferred)
+		})
+
+		knownInstances := make(map[addrs.InstanceKey]*RemovedStackCallInstance)
+		for key, rsc := range result.insts {
+			if rsc == nil {
+				// if rsc is nil, it means it was invalid above and we should
+				// have attached diags explaining this.
+				continue
+			}
+
+			if stack := r.main.Stack(ctx, rsc.from.Parent(), phase); stack != nil {
+				embeddedCall := stack.EmbeddedStackCall(stackaddrs.StackCall{
+					Name: rsc.from[len(rsc.from)-1].Name,
+				})
+
+				insts, _ := embeddedCall.Instances(ctx, phase)
+				if _, exists := insts[key]; exists {
+					// error, we have an embedded stack call and a removed block
+					// pointing at the same instance
+					diags = diags.Append(&hcl.Diagnostic{
+						Severity: hcl.DiagError,
+						Summary:  "Cannot remove stack instance",
+						Detail:   fmt.Sprintf("The stack instance %s is targeted by an embedded stack block and cannot be removed. The relevant embedded stack is defined at %s.", rsc.from, embeddedCall.config.config.DeclRange.ToHCL()),
+						Subject:  rsc.call.config.config.DeclRange.ToHCL().Ptr(),
+					})
+
+					continue // don't add this to the known instances
+				}
+			}
+			knownInstances[key] = rsc
+		}
+
+		return result, diags
+	})
+	return result.insts, result.unknown, diags
+}
+
+func (r *RemovedStackCall) PlanChanges(ctx context.Context) ([]stackplan.PlannedChange, tfdiags.Diagnostics) {
+	_, _, diags := r.Instances(ctx, PlanPhase)
+	return nil, diags
+}
+
+func (r *RemovedStackCall) CheckApply(ctx context.Context) ([]stackstate.AppliedChange, tfdiags.Diagnostics) {
+	_, _, diags := r.Instances(ctx, ApplyPhase)
+	return nil, diags
+}
+
+func (r *RemovedStackCall) tracingName() string {
+	return fmt.Sprintf("%s -> %s (removed)", r.stack.addr, r.target)
+}
+
+// removedStackCallInstanceExpressionScope is wrapper around the
+// RemovedStackCall expression scope that also includes repetition data for a
+// specific instance of this removed block.
+type removedStackCallInstanceExpressionScope struct {
+	call *RemovedStackCall
+	rd   instances.RepetitionData
+}
+
+func (r *removedStackCallInstanceExpressionScope) ResolveExpressionReference(ctx context.Context, ref stackaddrs.Reference) (Referenceable, tfdiags.Diagnostics) {
+	return r.call.stack.resolveExpressionReference(ctx, ref, nil, r.rd)
+}
+
+func (r *removedStackCallInstanceExpressionScope) PlanTimestamp() time.Time {
+	return r.call.main.PlanTimestamp()
+}
+
+func (r *removedStackCallInstanceExpressionScope) ExternalFunctions(ctx context.Context) (lang.ExternalFuncs, tfdiags.Diagnostics) {
+	return r.call.main.ProviderFunctions(ctx, r.call.stack.config)
+}

--- a/internal/stacks/stackruntime/internal/stackeval/removed_stack_call_config.go
+++ b/internal/stacks/stackruntime/internal/stackeval/removed_stack_call_config.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
 package stackeval
 
 import (

--- a/internal/stacks/stackruntime/internal/stackeval/removed_stack_call_config.go
+++ b/internal/stacks/stackruntime/internal/stackeval/removed_stack_call_config.go
@@ -1,0 +1,126 @@
+package stackeval
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/zclconf/go-cty/cty"
+
+	"github.com/hashicorp/terraform/internal/instances"
+	"github.com/hashicorp/terraform/internal/lang"
+	"github.com/hashicorp/terraform/internal/promising"
+	"github.com/hashicorp/terraform/internal/stacks/stackaddrs"
+	"github.com/hashicorp/terraform/internal/stacks/stackconfig"
+	"github.com/hashicorp/terraform/internal/stacks/stackplan"
+	"github.com/hashicorp/terraform/internal/tfdiags"
+)
+
+var (
+	_ Validatable     = (*RemovedStackCallConfig)(nil)
+	_ Plannable       = (*RemovedStackCallConfig)(nil)
+	_ ExpressionScope = (*RemovedStackCallConfig)(nil)
+)
+
+type RemovedStackCallConfig struct {
+	target stackaddrs.Stack // relative to stack
+	config *stackconfig.Removed
+	stack  *StackConfig
+
+	main *Main
+
+	forEachValue        perEvalPhase[promising.Once[withDiagnostics[cty.Value]]]
+	inputVariableValues perEvalPhase[promising.Once[withDiagnostics[map[stackaddrs.InputVariable]cty.Value]]]
+}
+
+func newRemovedStackCallConfig(main *Main, target stackaddrs.Stack, stack *StackConfig, config *stackconfig.Removed) *RemovedStackCallConfig {
+	return &RemovedStackCallConfig{
+		target: target,
+		config: config,
+		stack:  stack,
+		main:   main,
+	}
+}
+
+func (r *RemovedStackCallConfig) TargetConfig() *StackConfig {
+	current := r.stack
+	for _, step := range r.target {
+		current = current.ChildConfig(step)
+	}
+	return current
+}
+
+func (r *RemovedStackCallConfig) InputVariableValues(ctx context.Context, phase EvalPhase) (map[stackaddrs.InputVariable]cty.Value, tfdiags.Diagnostics) {
+
+	return doOnceWithDiags(ctx, r.tracingName()+" inputs", r.inputVariableValues.For(phase), validateStackCallInputsFn(r.config.Inputs, r.config.DeclRange.ToHCL(), r.TargetConfig(), r, phase))
+}
+
+func (r *RemovedStackCallConfig) ForEachValue(ctx context.Context, phase EvalPhase) (cty.Value, tfdiags.Diagnostics) {
+	return doOnceWithDiags(ctx, r.tracingName()+" for_each", r.forEachValue.For(phase), func(ctx context.Context) (cty.Value, tfdiags.Diagnostics) {
+		if r.config.ForEach == nil {
+			// This stack config isn't even using for_each.
+			return cty.NilVal, nil
+		}
+
+		var diags tfdiags.Diagnostics
+		result, moreDiags := evaluateForEachExpr(ctx, r.config.ForEach, ValidatePhase, r.stack, "stack")
+		diags = diags.Append(moreDiags)
+		return result.Value, diags
+	})
+}
+
+func (r *RemovedStackCallConfig) Validate(ctx context.Context) tfdiags.Diagnostics {
+	var diags tfdiags.Diagnostics
+	_, moreDiags := r.ForEachValue(ctx, ValidatePhase)
+	diags = diags.Append(moreDiags)
+	_, moreDiags = r.InputVariableValues(ctx, ValidatePhase)
+	diags = diags.Append(moreDiags)
+	return diags
+}
+
+func (r *RemovedStackCallConfig) PlanChanges(ctx context.Context) ([]stackplan.PlannedChange, tfdiags.Diagnostics) {
+	var diags tfdiags.Diagnostics
+	_, moreDiags := r.ForEachValue(ctx, PlanPhase)
+	diags = diags.Append(moreDiags)
+	_, moreDiags = r.InputVariableValues(ctx, PlanPhase)
+	diags = diags.Append(moreDiags)
+	return nil, diags
+}
+
+func (r *RemovedStackCallConfig) tracingName() string {
+	return fmt.Sprintf("%s -> %s (removed)", r.stack.addr, r.target)
+}
+
+func (r *RemovedStackCallConfig) ResolveExpressionReference(ctx context.Context, ref stackaddrs.Reference) (Referenceable, tfdiags.Diagnostics) {
+	repetition := instances.RepetitionData{}
+	if r.config.ForEach != nil {
+		// We're producing an approximation across all eventual instances
+		// of this call, so we'll set each.key and each.value to unknown
+		// values.
+		repetition.EachKey = cty.UnknownVal(cty.String).RefineNotNull()
+		repetition.EachValue = cty.DynamicVal
+	}
+	ret, diags := r.stack.resolveExpressionReference(ctx, ref, nil, repetition)
+
+	if _, ok := ret.(*ProviderConfig); ok {
+		// We can't reference other providers from anywhere inside an embedded
+		// stack call - they should define their own providers.
+		diags = diags.Append(&hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  "Invalid reference",
+			Detail:   fmt.Sprintf("The object %s is not in scope at this location.", ref.Target.String()),
+			Subject:  ref.SourceRange.ToHCL().Ptr(),
+		})
+	}
+
+	return ret, diags
+}
+
+func (r *RemovedStackCallConfig) PlanTimestamp() time.Time {
+	return r.main.PlanTimestamp()
+}
+
+func (r *RemovedStackCallConfig) ExternalFunctions(ctx context.Context) (lang.ExternalFuncs, tfdiags.Diagnostics) {
+	return r.main.ProviderFunctions(ctx, r.stack)
+}

--- a/internal/stacks/stackruntime/internal/stackeval/removed_stack_call_instance.go
+++ b/internal/stacks/stackruntime/internal/stackeval/removed_stack_call_instance.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
 package stackeval
 
 import (

--- a/internal/stacks/stackruntime/internal/stackeval/removed_stack_call_instance.go
+++ b/internal/stacks/stackruntime/internal/stackeval/removed_stack_call_instance.go
@@ -1,0 +1,96 @@
+package stackeval
+
+import (
+	"context"
+	"time"
+
+	"github.com/zclconf/go-cty/cty"
+
+	"github.com/hashicorp/terraform/internal/instances"
+	"github.com/hashicorp/terraform/internal/lang"
+	"github.com/hashicorp/terraform/internal/plans"
+	"github.com/hashicorp/terraform/internal/promising"
+	"github.com/hashicorp/terraform/internal/stacks/stackaddrs"
+	"github.com/hashicorp/terraform/internal/stacks/stackplan"
+	"github.com/hashicorp/terraform/internal/stacks/stackstate"
+	"github.com/hashicorp/terraform/internal/tfdiags"
+)
+
+var _ ExpressionScope = (*RemovedStackCallInstance)(nil)
+var _ Plannable = (*RemovedStackCallInstance)(nil)
+var _ Applyable = (*RemovedStackCallInstance)(nil)
+
+type RemovedStackCallInstance struct {
+	call     *RemovedStackCall
+	from     stackaddrs.StackInstance
+	deferred bool
+
+	main *Main
+
+	repetition instances.RepetitionData
+
+	stack               perEvalPhase[promising.Once[*Stack]]
+	inputVariableValues perEvalPhase[promising.Once[withDiagnostics[cty.Value]]]
+}
+
+func newRemovedStackCallInstance(call *RemovedStackCall, from stackaddrs.StackInstance, repetition instances.RepetitionData, deferred bool) *RemovedStackCallInstance {
+	return &RemovedStackCallInstance{
+		call:       call,
+		from:       from,
+		repetition: repetition,
+		deferred:   deferred,
+		main:       call.main,
+	}
+}
+
+func (r *RemovedStackCallInstance) Stack(ctx context.Context, phase EvalPhase) *Stack {
+	stack, err := r.stack.For(phase).Do(ctx, r.from.String()+" create", func(ctx context.Context) (*Stack, error) {
+		components, embeddedStackCalls := r.call.GetExternalRemovedBlocks()
+		return newStack(r.main, r.from, r.call.stack, r.call.config.TargetConfig(), components, embeddedStackCalls, plans.DestroyMode, r.deferred), nil
+	})
+	if err != nil {
+		// we never return an error from within the once call, so this shouldn't
+		// happen
+		return nil
+	}
+	return stack
+}
+
+func (r *RemovedStackCallInstance) InputVariableValues(ctx context.Context, phase EvalPhase) (cty.Value, tfdiags.Diagnostics) {
+	return doOnceWithDiags(ctx, r.tracingName()+" inputs", r.inputVariableValues.For(phase),
+		validateStackCallInstanceInputsFn(r.Stack(ctx, phase), r.call.config.config.Inputs, r.call.config.config.DeclRange.ToHCL().Ptr(), r, phase))
+}
+
+func (r *RemovedStackCallInstance) CheckApply(ctx context.Context) ([]stackstate.AppliedChange, tfdiags.Diagnostics) {
+	var diags tfdiags.Diagnostics
+
+	_, moreDiags := r.InputVariableValues(ctx, ApplyPhase)
+	diags = diags.Append(moreDiags)
+
+	return nil, diags
+}
+
+func (r *RemovedStackCallInstance) PlanChanges(ctx context.Context) ([]stackplan.PlannedChange, tfdiags.Diagnostics) {
+	var diags tfdiags.Diagnostics
+
+	_, moreDiags := r.InputVariableValues(ctx, PlanPhase)
+	diags = diags.Append(moreDiags)
+
+	return nil, diags
+}
+
+func (r *RemovedStackCallInstance) tracingName() string {
+	return r.from.String() + " (removed)"
+}
+
+func (r *RemovedStackCallInstance) ResolveExpressionReference(ctx context.Context, ref stackaddrs.Reference) (Referenceable, tfdiags.Diagnostics) {
+	return r.call.stack.resolveExpressionReference(ctx, ref, nil, r.repetition)
+}
+
+func (r *RemovedStackCallInstance) PlanTimestamp() time.Time {
+	return r.call.stack.main.PlanTimestamp()
+}
+
+func (r *RemovedStackCallInstance) ExternalFunctions(ctx context.Context) (lang.ExternalFuncs, tfdiags.Diagnostics) {
+	return r.call.stack.main.ProviderFunctions(ctx, r.call.stack.config)
+}

--- a/internal/stacks/stackruntime/internal/stackeval/stack_call.go
+++ b/internal/stacks/stackruntime/internal/stackeval/stack_call.go
@@ -47,7 +47,7 @@ func newStackCall(main *Main, addr stackaddrs.AbsStackCall, stack *Stack, config
 
 // GetExternalRemovedBlocks fetches the removed blocks that target the stack
 // instances being created by this stack call.
-func (c *StackCall) GetExternalRemovedBlocks() collections.Map[stackaddrs.ConfigComponent, []*RemovedComponent] {
+func (c *StackCall) GetExternalRemovedBlocks() (collections.Map[stackaddrs.ConfigComponent, []*RemovedComponent], collections.Map[stackaddrs.Stack, []*RemovedStackCall]) {
 	return c.stack.Removed().ForStackCall(c.addr.Item)
 }
 
@@ -150,7 +150,7 @@ func (c *StackCall) CheckInstances(ctx context.Context, phase EvalPhase) (map[ad
 			}
 
 			return instancesMap(forEachVal, func(ik addrs.InstanceKey, rd instances.RepetitionData) *StackCallInstance {
-				return newStackCallInstance(c, ik, rd, c.stack.deferred)
+				return newStackCallInstance(c, ik, rd, c.stack.mode, c.stack.deferred)
 			}), diags
 		},
 	)
@@ -159,7 +159,7 @@ func (c *StackCall) CheckInstances(ctx context.Context, phase EvalPhase) (map[ad
 
 func (c *StackCall) UnknownInstance(ctx context.Context, phase EvalPhase) *StackCallInstance {
 	inst, err := c.unknownInstance.For(phase).Do(ctx, c.tracingName()+" unknown instace", func(ctx context.Context) (*StackCallInstance, error) {
-		return newStackCallInstance(c, addrs.WildcardKey, instances.UnknownForEachRepetitionData(c.ForEachValue(ctx, phase).Type()), true), nil
+		return newStackCallInstance(c, addrs.WildcardKey, instances.UnknownForEachRepetitionData(c.ForEachValue(ctx, phase).Type()), c.stack.mode, true), nil
 	})
 	if err != nil {
 		// Since we never return an error from the function we pass to Do,

--- a/internal/stacks/stackruntime/internal/stackeval/stack_call_instance.go
+++ b/internal/stacks/stackruntime/internal/stackeval/stack_call_instance.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hashicorp/terraform/internal/instances"
 	"github.com/hashicorp/terraform/internal/lang"
 	"github.com/hashicorp/terraform/internal/lang/marks"
+	"github.com/hashicorp/terraform/internal/plans"
 	"github.com/hashicorp/terraform/internal/promising"
 	"github.com/hashicorp/terraform/internal/stacks/stackaddrs"
 	"github.com/hashicorp/terraform/internal/stacks/stackplan"
@@ -34,6 +35,7 @@ type StackCallInstance struct {
 	call     *StackCall
 	key      addrs.InstanceKey
 	deferred bool
+	mode     plans.Mode
 
 	main *Main
 
@@ -46,11 +48,12 @@ type StackCallInstance struct {
 var _ ExpressionScope = (*StackCallInstance)(nil)
 var _ Plannable = (*StackCallInstance)(nil)
 
-func newStackCallInstance(call *StackCall, key addrs.InstanceKey, repetition instances.RepetitionData, deferred bool) *StackCallInstance {
+func newStackCallInstance(call *StackCall, key addrs.InstanceKey, repetition instances.RepetitionData, mode plans.Mode, deferred bool) *StackCallInstance {
 	return &StackCallInstance{
 		call:       call,
 		key:        key,
 		deferred:   deferred,
+		mode:       mode,
 		main:       call.main,
 		repetition: repetition,
 	}
@@ -69,7 +72,8 @@ func (c *StackCallInstance) CalledStackAddr() stackaddrs.StackInstance {
 
 func (c *StackCallInstance) Stack(ctx context.Context, phase EvalPhase) *Stack {
 	stack, err := c.stack.For(phase).Do(ctx, c.tracingName(), func(ctx context.Context) (*Stack, error) {
-		return newStack(c.main, c.CalledStackAddr(), c.call.stack, c.call.config.TargetConfig(), c.call.GetExternalRemovedBlocks(), c.deferred), nil
+		components, embeddedStackCalls := c.call.GetExternalRemovedBlocks()
+		return newStack(c.main, c.CalledStackAddr(), c.call.stack, c.call.config.TargetConfig(), components, embeddedStackCalls, c.mode, c.deferred), nil
 	})
 	if err != nil {
 		// we don't have cycles in here, and we don't return an error so this
@@ -110,109 +114,8 @@ func (c *StackCallInstance) InputVariableValues(ctx context.Context, phase EvalP
 // child stack input variable declaration, as part of preparing the individual
 // attributes of the result for their appearance in downstream expressions.
 func (c *StackCallInstance) CheckInputVariableValues(ctx context.Context, phase EvalPhase) (cty.Value, tfdiags.Diagnostics) {
-	return doOnceWithDiags(ctx, c.tracingName()+" inputs", c.inputVariableValues.For(phase), func(ctx context.Context) (cty.Value, tfdiags.Diagnostics) {
-		var diags tfdiags.Diagnostics
-		calledStack := c.Stack(ctx, phase)
-		wantTy, defs := calledStack.InputsType()
-		decl := c.call.config.config
-
-		v := cty.EmptyObjectVal
-		expr := decl.Inputs
-		rng := decl.DeclRange
-		var hclCtx *hcl.EvalContext
-		if expr != nil {
-			result, moreDiags := EvalExprAndEvalContext(ctx, expr, phase, c)
-			diags = diags.Append(moreDiags)
-			if moreDiags.HasErrors() {
-				return cty.DynamicVal, diags
-			}
-			expr = result.Expression
-			hclCtx = result.EvalContext
-			v = result.Value
-		}
-
-		v = defs.Apply(v)
-		v, err := convert.Convert(v, wantTy)
-		if err != nil {
-			// A conversion failure here could either be caused by an author-provided
-			// expression that's invalid or by the author omitting the argument
-			// altogether when there's at least one required attribute, so we'll
-			// return slightly different messages in each case.
-			if expr != nil {
-				diags = diags.Append(&hcl.Diagnostic{
-					Severity:    hcl.DiagError,
-					Summary:     "Invalid inputs for embedded stack",
-					Detail:      fmt.Sprintf("Invalid input variable definition object: %s.", tfdiags.FormatError(err)),
-					Subject:     rng.ToHCL().Ptr(),
-					Expression:  expr,
-					EvalContext: hclCtx,
-				})
-			} else {
-				diags = diags.Append(&hcl.Diagnostic{
-					Severity: hcl.DiagError,
-					Summary:  "Missing required inputs for embedded stack",
-					Detail:   fmt.Sprintf("Must provide \"inputs\" argument to define the embedded stack's input variables: %s.", tfdiags.FormatError(err)),
-					Subject:  rng.ToHCL().Ptr(),
-				})
-			}
-			return cty.DynamicVal, diags
-		}
-
-		if v.IsKnown() && !v.IsNull() {
-			var markDiags tfdiags.Diagnostics
-			for varAddr, variable := range calledStack.InputVariables() {
-				varVal := v.GetAttr(varAddr.Name)
-				varDecl := variable.config.config
-
-				if !varDecl.Ephemeral {
-					// If the variable isn't declared as being ephemeral then we
-					// cannot allow ephemeral values to be assigned to it.
-					_, markses := varVal.UnmarkDeepWithPaths()
-					ephemeralPaths, _ := marks.PathsWithMark(markses, marks.Ephemeral)
-					for _, path := range ephemeralPaths {
-						if len(path) == 0 {
-							// The entire value is ephemeral, then.
-							markDiags = markDiags.Append(&hcl.Diagnostic{
-								Severity:    hcl.DiagError,
-								Summary:     "Ephemeral value not allowed",
-								Detail:      fmt.Sprintf("The input variable %q does not accept ephemeral values.", varAddr.Name),
-								Subject:     rng.ToHCL().Ptr(),
-								Expression:  expr,
-								EvalContext: hclCtx,
-								Extra:       diagnosticCausedByEphemeral(true),
-							})
-						} else {
-							// Something nested inside is ephemeral, so we'll be
-							// more specific.
-							markDiags = markDiags.Append(&hcl.Diagnostic{
-								Severity: hcl.DiagError,
-								Summary:  "Ephemeral value not allowed",
-								Detail: fmt.Sprintf(
-									"The input variable %q does not accept ephemeral values, so the value for %s is not compatible.",
-									varAddr.Name, tfdiags.FormatCtyPath(path),
-								),
-								Subject:     rng.ToHCL().Ptr(),
-								Expression:  expr,
-								EvalContext: hclCtx,
-								Extra:       diagnosticCausedByEphemeral(true),
-							})
-						}
-					}
-				}
-			}
-			diags = diags.Append(markDiags)
-			if markDiags.HasErrors() {
-				// If we have an ephemeral value in a place where there shouldn't
-				// be one then we'll return an entirely-unknown value to make sure
-				// that downstreams that aren't checking the errors can't leak the
-				// value into somewhere it ought not to be. We'll still preserve
-				// the type constraint so that we can do type checking downstream.
-				return cty.UnknownVal(v.Type()), diags
-			}
-		}
-
-		return v, diags
-	})
+	return doOnceWithDiags(ctx, c.tracingName()+" inputs", c.inputVariableValues.For(phase),
+		validateStackCallInstanceInputsFn(c.Stack(ctx, phase), c.call.config.config.Inputs, c.call.config.config.DeclRange.ToHCL().Ptr(), c, phase))
 }
 
 // ResolveExpressionReference implements ExpressionScope for the arguments
@@ -263,4 +166,106 @@ func (c *StackCallInstance) CheckApply(ctx context.Context) ([]stackstate.Applie
 // tracingName implements Plannable.
 func (c *StackCallInstance) tracingName() string {
 	return fmt.Sprintf("%s call", c.CalledStackAddr())
+}
+
+func validateStackCallInstanceInputsFn(stack *Stack, expr hcl.Expression, rng *hcl.Range, scope ExpressionScope, phase EvalPhase) func(ctx context.Context) (cty.Value, tfdiags.Diagnostics) {
+	return func(ctx context.Context) (cty.Value, tfdiags.Diagnostics) {
+		var diags tfdiags.Diagnostics
+		wantTy, defs := stack.InputsType()
+
+		v := cty.EmptyObjectVal
+		var hclCtx *hcl.EvalContext
+		if expr != nil {
+			result, moreDiags := EvalExprAndEvalContext(ctx, expr, phase, scope)
+			diags = diags.Append(moreDiags)
+			if moreDiags.HasErrors() {
+				return cty.DynamicVal, diags
+			}
+			expr = result.Expression
+			hclCtx = result.EvalContext
+			v = result.Value
+		}
+
+		v = defs.Apply(v)
+		v, err := convert.Convert(v, wantTy)
+		if err != nil {
+			// A conversion failure here could either be caused by an author-provided
+			// expression that's invalid or by the author omitting the argument
+			// altogether when there's at least one required attribute, so we'll
+			// return slightly different messages in each case.
+			if expr != nil {
+				diags = diags.Append(&hcl.Diagnostic{
+					Severity:    hcl.DiagError,
+					Summary:     "Invalid inputs for embedded stack",
+					Detail:      fmt.Sprintf("Invalid input variable definition object: %s.", tfdiags.FormatError(err)),
+					Subject:     rng,
+					Expression:  expr,
+					EvalContext: hclCtx,
+				})
+			} else {
+				diags = diags.Append(&hcl.Diagnostic{
+					Severity: hcl.DiagError,
+					Summary:  "Missing required inputs for embedded stack",
+					Detail:   fmt.Sprintf("Must provide \"inputs\" argument to define the embedded stack's input variables: %s.", tfdiags.FormatError(err)),
+					Subject:  rng,
+				})
+			}
+			return cty.DynamicVal, diags
+		}
+
+		if v.IsKnown() && !v.IsNull() {
+			var markDiags tfdiags.Diagnostics
+			for varAddr, variable := range stack.InputVariables() {
+				varVal := v.GetAttr(varAddr.Name)
+				varDecl := variable.config.config
+
+				if !varDecl.Ephemeral {
+					// If the variable isn't declared as being ephemeral then we
+					// cannot allow ephemeral values to be assigned to it.
+					_, markses := varVal.UnmarkDeepWithPaths()
+					ephemeralPaths, _ := marks.PathsWithMark(markses, marks.Ephemeral)
+					for _, path := range ephemeralPaths {
+						if len(path) == 0 {
+							// The entire value is ephemeral, then.
+							markDiags = markDiags.Append(&hcl.Diagnostic{
+								Severity:    hcl.DiagError,
+								Summary:     "Ephemeral value not allowed",
+								Detail:      fmt.Sprintf("The input variable %q does not accept ephemeral values.", varAddr.Name),
+								Subject:     rng,
+								Expression:  expr,
+								EvalContext: hclCtx,
+								Extra:       diagnosticCausedByEphemeral(true),
+							})
+						} else {
+							// Something nested inside is ephemeral, so we'll be
+							// more specific.
+							markDiags = markDiags.Append(&hcl.Diagnostic{
+								Severity: hcl.DiagError,
+								Summary:  "Ephemeral value not allowed",
+								Detail: fmt.Sprintf(
+									"The input variable %q does not accept ephemeral values, so the value for %s is not compatible.",
+									varAddr.Name, tfdiags.FormatCtyPath(path),
+								),
+								Subject:     rng,
+								Expression:  expr,
+								EvalContext: hclCtx,
+								Extra:       diagnosticCausedByEphemeral(true),
+							})
+						}
+					}
+				}
+			}
+			diags = diags.Append(markDiags)
+			if markDiags.HasErrors() {
+				// If we have an ephemeral value in a place where there shouldn't
+				// be one then we'll return an entirely-unknown value to make sure
+				// that downstreams that aren't checking the errors can't leak the
+				// value into somewhere it ought not to be. We'll still preserve
+				// the type constraint so that we can do type checking downstream.
+				return cty.UnknownVal(v.Type()), diags
+			}
+		}
+
+		return v, diags
+	}
 }

--- a/internal/stacks/stackruntime/internal/stackeval/stack_config.go
+++ b/internal/stacks/stackruntime/internal/stackeval/stack_config.go
@@ -37,15 +37,16 @@ type StackConfig struct {
 
 	// The remaining fields are where we memoize related objects that we've
 	// constructed and returned. Must lock "mu" before interacting with these.
-	mu             sync.Mutex
-	children       map[stackaddrs.StackStep]*StackConfig
-	inputVariables map[stackaddrs.InputVariable]*InputVariableConfig
-	localValues    map[stackaddrs.LocalValue]*LocalValueConfig
-	outputValues   map[stackaddrs.OutputValue]*OutputValueConfig
-	stackCalls     map[stackaddrs.StackCall]*StackCallConfig
-	components     map[stackaddrs.Component]*ComponentConfig
-	removed        collections.Map[stackaddrs.ConfigComponent, []*RemovedComponentConfig]
-	providers      map[stackaddrs.ProviderConfig]*ProviderConfig
+	mu                sync.Mutex
+	children          map[stackaddrs.StackStep]*StackConfig
+	inputVariables    map[stackaddrs.InputVariable]*InputVariableConfig
+	localValues       map[stackaddrs.LocalValue]*LocalValueConfig
+	outputValues      map[stackaddrs.OutputValue]*OutputValueConfig
+	stackCalls        map[stackaddrs.StackCall]*StackCallConfig
+	removedStackCalls collections.Map[stackaddrs.Stack, []*RemovedStackCallConfig]
+	components        map[stackaddrs.Component]*ComponentConfig
+	removedComponents collections.Map[stackaddrs.ConfigComponent, []*RemovedComponentConfig]
+	providers         map[stackaddrs.ProviderConfig]*ProviderConfig
 }
 
 var (
@@ -59,14 +60,15 @@ func newStackConfig(main *Main, addr stackaddrs.Stack, parent *StackConfig, conf
 		config: config,
 		main:   main,
 
-		children:       make(map[stackaddrs.StackStep]*StackConfig, len(config.Children)),
-		inputVariables: make(map[stackaddrs.InputVariable]*InputVariableConfig, len(config.Stack.Declarations.InputVariables)),
-		localValues:    make(map[stackaddrs.LocalValue]*LocalValueConfig, len(config.Stack.Declarations.LocalValues)),
-		outputValues:   make(map[stackaddrs.OutputValue]*OutputValueConfig, len(config.Stack.Declarations.OutputValues)),
-		stackCalls:     make(map[stackaddrs.StackCall]*StackCallConfig, len(config.Stack.Declarations.EmbeddedStacks)),
-		components:     make(map[stackaddrs.Component]*ComponentConfig, len(config.Stack.Declarations.Components)),
-		removed:        collections.NewMap[stackaddrs.ConfigComponent, []*RemovedComponentConfig](),
-		providers:      make(map[stackaddrs.ProviderConfig]*ProviderConfig, len(config.Stack.Declarations.ProviderConfigs)),
+		children:          make(map[stackaddrs.StackStep]*StackConfig, len(config.Children)),
+		inputVariables:    make(map[stackaddrs.InputVariable]*InputVariableConfig, len(config.Stack.Declarations.InputVariables)),
+		localValues:       make(map[stackaddrs.LocalValue]*LocalValueConfig, len(config.Stack.Declarations.LocalValues)),
+		outputValues:      make(map[stackaddrs.OutputValue]*OutputValueConfig, len(config.Stack.Declarations.OutputValues)),
+		stackCalls:        make(map[stackaddrs.StackCall]*StackCallConfig, len(config.Stack.Declarations.EmbeddedStacks)),
+		removedStackCalls: collections.NewMap[stackaddrs.Stack, []*RemovedStackCallConfig](),
+		components:        make(map[stackaddrs.Component]*ComponentConfig, len(config.Stack.Declarations.Components)),
+		removedComponents: collections.NewMap[stackaddrs.ConfigComponent, []*RemovedComponentConfig](),
+		providers:         make(map[stackaddrs.ProviderConfig]*ProviderConfig, len(config.Stack.Declarations.ProviderConfigs)),
 	}
 }
 
@@ -359,6 +361,29 @@ func (s *StackConfig) StackCalls() map[stackaddrs.StackCall]*StackCallConfig {
 	return ret
 }
 
+func (s *StackConfig) RemovedStackCall(addr stackaddrs.Stack) []*RemovedStackCallConfig {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	ret, ok := s.removedStackCalls.GetOk(addr)
+	if !ok {
+		for _, cfg := range s.config.Stack.RemovedEmbeddedStacks.Get(addr) {
+			removed := newRemovedStackCallConfig(s.main, append(s.addr, addr...), s, cfg)
+			ret = append(ret, removed)
+		}
+		s.removedStackCalls.Put(addr, ret)
+	}
+	return ret
+}
+
+func (s *StackConfig) RemovedStackCalls() collections.Map[stackaddrs.Stack, []*RemovedStackCallConfig] {
+	ret := collections.NewMap[stackaddrs.Stack, []*RemovedStackCallConfig]()
+	for addr := range s.config.Stack.RemovedEmbeddedStacks.All() {
+		ret.Put(addr, s.RemovedStackCall(addr))
+	}
+	return ret
+}
+
 // Component returns a [ComponentConfig] representing the component call
 // declared within this stack config that matches the given address, or nil if
 // there is no such declaration.
@@ -400,9 +425,9 @@ func (s *StackConfig) RemovedComponent(addr stackaddrs.ConfigComponent) []*Remov
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	ret, ok := s.removed.GetOk(addr)
+	ret, ok := s.removedComponents.GetOk(addr)
 	if !ok {
-		for _, cfg := range s.config.Stack.Removed.Get(addr) {
+		for _, cfg := range s.config.Stack.RemovedComponents.Get(addr) {
 			cfgAddr := stackaddrs.ConfigComponent{
 				Stack: append(s.addr, addr.Stack...),
 				Item:  addr.Item,
@@ -410,7 +435,7 @@ func (s *StackConfig) RemovedComponent(addr stackaddrs.ConfigComponent) []*Remov
 			removed := newRemovedComponentConfig(s.main, cfgAddr, s, cfg)
 			ret = append(ret, removed)
 		}
-		s.removed.Put(addr, ret)
+		s.removedComponents.Put(addr, ret)
 	}
 	return ret
 }
@@ -419,7 +444,7 @@ func (s *StackConfig) RemovedComponent(addr stackaddrs.ConfigComponent) []*Remov
 // removed calls declared inside this stack configuration.
 func (s *StackConfig) RemovedComponents() collections.Map[stackaddrs.ConfigComponent, []*RemovedComponentConfig] {
 	ret := collections.NewMap[stackaddrs.ConfigComponent, []*RemovedComponentConfig]()
-	for addr := range s.config.Stack.Removed.All() {
+	for addr := range s.config.Stack.RemovedComponents.All() {
 		ret.Put(addr, s.RemovedComponent(addr))
 	}
 	return ret

--- a/internal/stacks/stackruntime/internal/stackeval/walk_dynamic.go
+++ b/internal/stacks/stackruntime/internal/stackeval/walk_dynamic.go
@@ -57,291 +57,24 @@ func walkDynamicObjectsInStack[Output any](
 	// we can explore downstream stacks concurrently with this one. Each
 	// stack call can represent zero or more child stacks that we'll analyze
 	// by recursive calls to this function.
-	for _, call := range stack.EmbeddedStackCalls() {
-		call := call // separate symbol per loop iteration
-
-		visit(ctx, walk, call)
-
-		// We need to perform the whole expansion in an overall async task
-		// because it involves evaluating for_each expressions, and one
-		// stack call's for_each might depend on the results of another.
-		walk.AsyncTask(ctx, func(ctx context.Context) {
-			insts, unknown := call.Instances(ctx, phase)
-
-			if unknown {
-
-				// If unknown, then we should check for any stacks that exist
-				// in the state and "claim" them. Basically, this means this
-				// value was known and created some stack instances previously
-				// then became unknown in the current operation and we want to
-
-				knownInstances := stack.KnownEmbeddedStacks(call.addr.Item, phase)
-				if len(knownInstances) == 0 {
-					// with no known instances, we'll just process the constant
-					// unknown instance. This represents the idea that stacks
-					// could be created once the value becomes unknown.
-					inst := call.UnknownInstance(ctx, phase)
-					visit(ctx, walk, inst)
-
-					childStack := inst.Stack(ctx, phase)
-					walkDynamicObjectsInStack(ctx, walk, childStack, phase, visit)
-					return
-				}
-
-				// otherwise we have known instances in the state, so we'll
-				// create some dynamic instances for them so the user doesn't
-				// worry they have just disappeared.
-
-				for inst := range knownInstances {
-					if inst.Key == addrs.WildcardKey {
-						inst := call.UnknownInstance(ctx, phase)
-						visit(ctx, walk, inst)
-
-						childStack := inst.Stack(ctx, phase)
-						walkDynamicObjectsInStack(ctx, walk, childStack, phase, visit)
-					} else {
-						inst := newStackCallInstance(call, inst.Key, instances.RepetitionData{
-							EachKey:   inst.Key.Value(),
-							EachValue: cty.UnknownVal(cty.DynamicPseudoType),
-						}, true)
-						visit(ctx, walk, inst)
-
-						childStack := inst.Stack(ctx, phase)
-						walkDynamicObjectsInStack(ctx, walk, childStack, phase, visit)
-					}
-				}
-			}
-
-			// Otherwise, process the instances and their child stacks.
-			for _, inst := range insts {
-				visit(ctx, walk, inst)
-
-				childStack := inst.Stack(ctx, phase)
-				walkDynamicObjectsInStack(ctx, walk, childStack, phase, visit)
-			}
-		})
+	for call := range stack.EmbeddedStackCalls() {
+		walkEmbeddedStack(ctx, walk, stack, call, phase, visit)
 	}
-
-	// Next we're going to visit all the components and removed blocks and
-	// execute each of the instances they represent. We might have component
-	// and removed blocks that are target the same component address. This is
-	// expected, but they shouldn't target the same instances.
-	//
-	// TODO: Check for this and don't evaluate problematic instances.
-	//
-	// In addition, we might have component and removed blocks that evaluate
-	// to unknown instances. If this happens, we may have "unclaimed" instances.
-	// This is normally an error, but if we an unknown values then they could
-	// potentially be claimed once the unknown values are known.
-	//
-	// We'll allow both known removed and known component blocks to claim
-	// anything they want. We'll then check for unclaimed instances and assign
-	// them as being deferred but act as if they are part of whichever block
-	// is unknown. If both are unknown, then all unclaimed instances will be
-	// assigned to the component block and the removed block will do nothing.
-
-	// We also need to visit and check all of the other declarations in
-	// the current stack.
-	for _, component := range stack.Components() {
-		component := component // separate symbol per loop iteration
-		visit(ctx, walk, component)
-
-		// We need to perform the instance expansion in an overall async task
-		// because it involves potentially evaluating a for_each expression.
-		// and that might depend on data from elsewhere in the same stack.
-		walk.AsyncTask(ctx, func(ctx context.Context) {
-			insts, unknown := component.Instances(ctx, phase)
-
-			if unknown {
-				// If the instances claimed by this component block are unknown,
-				// then we'll check all the known instances and mark any that
-				// are not claimed by an equivalent removed block as being
-				// deferred until the foreach is known.
-
-				// knownInstances are the instances that already exist either
-				// because they are in the state or the plan.
-				knownInstances := stack.KnownComponentInstances(component.addr.Item, phase)
-				if knownInstances.Len() == 0 {
-					// If we have no known instances, then we'll make up an
-					// unknown instance that will act as if it is being created
-					// by the component block. This ensures the users still see
-					// some feedback about this component even if we're not
-					// doing anything with it this run block.
-					//
-					// If we have instances in state, the users will see
-					// feedback about those instances so we don't need to do
-					// this.
-					unknownInstance := component.UnknownInstance(ctx, phase)
-					visit(ctx, walk, unknownInstance)
-					return
-				}
-
-				claimedInstances := collections.NewSet[stackaddrs.ComponentInstance]()
-				removed := stack.RemovedComponent(component.addr.Item)
-				for _, block := range removed {
-					// In this case we don't care about the unknown. If the
-					// removed instances are unknown, then we'll mark
-					// everything as being part of the component block. So,
-					// even if insts comes back as unknown and hence empty,
-					// we still proceed as normal.
-					insts, _, _ := block.Instances(ctx, phase)
-					for key := range insts {
-						claimedInstances.Add(stackaddrs.ComponentInstance{
-							Component: component.addr.Item,
-							Key:       key,
-						})
-					}
-				}
-
-				for inst := range knownInstances.All() {
-					if claimedInstances.Has(inst) {
-						// Then this instance is claimed by the removed block.
-						continue
-					}
-
-					// This instance is not claimed by the removed block, so
-					// we'll mark it as being deferred until the foreach is
-					// known.
-
-					if inst.Key == addrs.WildcardKey {
-						// If the key we retrieved is a wildcard key, then we'll
-						// recreate a "proper" unknown instance as we'll
-						// recompute a properly typed each value with this
-						// function.
-						inst := component.UnknownInstance(ctx, phase)
-						visit(ctx, walk, inst)
-					} else {
-						// Otherwise, the key is a known key and the instance
-						// actually does exist.
-						inst := newComponentInstance(component, stackaddrs.AbsComponentInstance{
-							Stack: stack.addr,
-							Item:  inst,
-						}, instances.RepetitionData{
-							EachKey:   inst.Key.Value(),
-							EachValue: cty.UnknownVal(cty.DynamicPseudoType),
-						}, true)
-						visit(ctx, walk, inst)
-					}
-				}
-
-				return
-			}
-
-			for _, inst := range insts {
-				visit(ctx, walk, inst)
-			}
-		})
-	}
-	for addr, blocks := range stack.Removed().localComponents {
-
-		// knownInstances are the instances that already exist either
-		// because they are in the state or the plan.
-		knownInstances := stack.KnownComponentInstances(addr, phase)
-		unknownComponentBlock := false
-
-		// keep track of all the instances that we have processed so far.
-		var mutex sync.Mutex
-		componentInstances := collections.NewSet[stackaddrs.ComponentInstance]()
-		claimedInstances := collections.NewSet[stackaddrs.ComponentInstance]()
-
-		for _, removed := range blocks {
-			removed := removed
-			visit(ctx, walk, removed)
-
-			walk.AsyncTask(ctx, func(ctx context.Context) {
-				insts, unknown := removed.InstancesFor(ctx, stack.addr, phase)
-				if unknown {
-					// If the instances claimed by this removed block are unknown,
-					// then we'll check all the known instances and mark any that
-					// are not claimed by an equivalent component block as being
-					// removed by this block but as deferred until the foreach is
-					// known.
-
-					mutex.Lock()
-					if componentInstances.Len() == 0 {
-						// then we'll gather the component instances. we do this
-						// once, enforced by the mutex and the check above.
-						component := stack.Component(removed.target.Item)
-						if component != nil {
-							insts, unknown := component.Instances(ctx, phase)
-							if unknown {
-								// So both the for_each for the removed block and the
-								// component block is unknown. In this case, we should
-								// have gathered everything as being "updated" from the
-								// component and we'll mark nothing as being removed.
-								unknownComponentBlock = true
-								mutex.Unlock()
-								return
-							}
-
-							for key := range insts {
-								componentInstances.Add(stackaddrs.ComponentInstance{
-									Component: removed.target.Item,
-									Key:       key,
-								})
-							}
-						}
-					}
-					mutex.Unlock()
-
-					if unknownComponentBlock {
-						// if both the component block and this block are
-						// unknown, then any instances will have been claimed
-						// by the component block so we do nothing.
-						return
-					}
-
-					for inst := range knownInstances.All() {
-						mutex.Lock()
-						if componentInstances.Has(inst) {
-							// Then this instance is claimed by the component
-							// block.
-							continue
-						}
-						if claimedInstances.Has(inst) {
-							// Then another removed block has processed this
-							// instance, and we don't want another to try
-							// and claim it.
-							continue
-						}
-						claimedInstances.Add(inst)
-						mutex.Unlock()
-
-						// This instance is not claimed by the component block, so
-						// we'll mark it as being removed by the removed block.
-						inst := newRemovedComponentInstance(removed, stackaddrs.AbsComponentInstance{
-							Stack: stack.addr,
-							Item:  inst,
-						}, instances.RepetitionData{
-							EachKey:   inst.Key.Value(),
-							EachValue: cty.UnknownVal(cty.DynamicPseudoType),
-						}, true)
-						visit(ctx, walk, inst)
-					}
-
-					return
-				}
-
-				for _, inst := range insts {
-					mutex.Lock()
-					if claimedInstances.Has(inst.Addr().Item) {
-						// this is an error, but it should have been raised
-						// elsewhere
-						continue
-					}
-					if componentInstances.Has(inst.Addr().Item) {
-						// this is an error, but it should have been raised
-						// elsewhere
-						continue
-					}
-					claimedInstances.Add(inst.Addr().Item)
-					mutex.Unlock()
-
-					visit(ctx, walk, inst)
-				}
-
-			})
+	for call := range stack.Removed().localStackCalls {
+		if stack.EmbeddedStackCall(call) != nil {
+			continue
 		}
+		walkEmbeddedStack(ctx, walk, stack, call, phase, visit)
+	}
+
+	for component := range stack.Components() {
+		walkComponent(ctx, walk, stack, component, phase, visit)
+	}
+	for component := range stack.Removed().localComponents {
+		if stack.Component(component) != nil {
+			continue // then we processed this as part of the component stage
+		}
+		walkComponent(ctx, walk, stack, component, phase, visit)
 	}
 
 	// Now, we'll do the rest of the declarations in the stack. These are
@@ -379,4 +112,330 @@ func walkDynamicObjectsInStack[Output any](
 	// Finally we'll also check the stack itself, to deal with any problems
 	// with the stack as a whole rather than individual declarations inside.
 	visit(ctx, walk, stack)
+}
+
+// walkComponent just encapsulates the behaviour for visiting all the
+// components in a stack. Components are more complicated than the other
+// parts of a stack as they can be claimed by both component and removed blocks
+// and both of these can evaluate to unknown.
+//
+// What we do here is we go through all the blocks within the configuration
+// and visit them and mark the known instances as "claimed". We also want to
+// find any blocks that evaluate to unknown. This block is then used in the
+// final step where we'll search through any instances within the state that
+// haven't been claimed and assign them to an unknown block, if one was found.
+func walkComponent[Output any](
+	ctx context.Context,
+	walk *walkWithOutput[Output],
+	stack *Stack,
+	addr stackaddrs.Component,
+	phase EvalPhase,
+	visit func(ctx context.Context, walk *walkWithOutput[Output], obj DynamicEvaler)) {
+
+	var unknownComponentBlock *Component
+	var unknownRemovedComponentBlock *RemovedComponent
+
+	var wg sync.WaitGroup
+	var mutex sync.Mutex
+
+	claimedInstances := collections.NewSet[stackaddrs.ComponentInstance]()
+
+	component := stack.Component(addr)
+	if component != nil {
+		visit(ctx, walk, component) // first, just visit the component directly
+
+		// then visit the component instances. we must do this in an async task as
+		// we evaulate the for_each valuate within the instances call.
+
+		wg.Add(1)
+		walk.AsyncTask(ctx, func(ctx context.Context) {
+			defer wg.Done()
+
+			insts, unknown := component.Instances(ctx, phase)
+			if unknown {
+				unknownComponentBlock = component
+				return
+			}
+
+			for key, inst := range insts {
+				instAddr := stackaddrs.ComponentInstance{
+					Component: addr,
+					Key:       key,
+				}
+
+				mutex.Lock()
+				if claimedInstances.Has(instAddr) {
+					// this will be picked up as an error elsewhere, but
+					// two blocks have claimed this instance so we'll just
+					// allow whichever got their first to claim it and we'll
+					// just skip it here.
+					mutex.Unlock()
+					continue
+				}
+				claimedInstances.Add(instAddr)
+				mutex.Unlock()
+
+				visit(ctx, walk, inst)
+			}
+		})
+	}
+
+	for _, block := range stack.Removed().localComponents[addr] {
+		visit(ctx, walk, block) // first, just visit the removed block directly
+
+		wg.Add(1)
+		walk.AsyncTask(ctx, func(ctx context.Context) {
+			defer wg.Done()
+
+			insts, unknown := block.InstancesFor(ctx, stack.addr, phase)
+			if unknown {
+				mutex.Lock()
+				// we might have multiple removed blocks that evaluate to
+				// unknown. if so, we'll just pick a random one that actually
+				// gets assigned to handle any unclaimed instances.
+				unknownRemovedComponentBlock = block
+				mutex.Unlock()
+
+				return
+			}
+
+			for _, inst := range insts {
+				mutex.Lock()
+				if claimedInstances.Has(inst.from.Item) {
+					// this will be picked up as an error elsewhere, but
+					// two blocks have claimed this instance so we'll just
+					// allow whichever got their first to claim it and we'll
+					// just skip it here.
+					mutex.Unlock()
+					continue
+				}
+				claimedInstances.Add(inst.from.Item)
+				mutex.Unlock()
+
+				visit(ctx, walk, inst)
+			}
+		})
+	}
+
+	// finally, we're going to look at the instances that are in state and
+	// hopefully assign any unclaimed ones to an unknown block.
+
+	walk.AsyncTask(ctx, func(ctx context.Context) {
+		wg.Wait() // wait for all the other tasks to finish
+
+		// if we have an unknown component block we want to make sure the
+		// output says something about it. This means if we have unclaimed
+		// instances then the component block will claim those, but if no
+		// unclaimed instances exist we'll create a partial unknown component
+		// instance that means the component block will appear in the plan
+		// somewhere. This starts as true if there is no unknown component block
+		// to make us not do anything by default for this case.
+		unknownComponentBlockClaimedSomething := unknownComponentBlock == nil
+
+		knownInstances := stack.KnownComponentInstances(addr, phase)
+		for inst := range knownInstances.All() {
+			if claimedInstances.Has(inst) {
+				// don't need the mutex any more since this will be fully
+				// initialised when all the wait groups are finished.
+				continue
+			}
+
+			// this is unclaimed, so we'll see if
+
+			if unknownComponentBlock != nil {
+				// then we have a component block to claim it so we make an
+				// instance dynamically and off we go
+
+				unknownComponentBlockClaimedSomething = true
+
+				if inst.Key == addrs.WildcardKey {
+					// use the preset unknown instance if the key is actually
+					// the wildcard
+					inst := unknownComponentBlock.UnknownInstance(ctx, phase)
+					visit(ctx, walk, inst)
+
+					continue
+				}
+
+				inst := newComponentInstance(unknownComponentBlock, stackaddrs.AbsComponentInstance{
+					Stack: stack.addr,
+					Item:  inst,
+				}, instances.RepetitionData{
+					EachKey:   inst.Key.Value(),
+					EachValue: cty.UnknownVal(cty.DynamicPseudoType),
+				}, stack.mode, true)
+				visit(ctx, walk, inst)
+
+				continue
+			}
+
+			if unknownRemovedComponentBlock != nil {
+				// then we didn't have an unknown component block, but we do
+				// have an unknown removed component block to claim it
+
+				inst := newRemovedComponentInstance(unknownRemovedComponentBlock, stackaddrs.AbsComponentInstance{
+					Stack: stack.addr,
+					Item:  inst,
+				}, instances.RepetitionData{
+					EachKey:   inst.Key.Value(),
+					EachValue: cty.UnknownVal(cty.DynamicPseudoType),
+				}, true)
+				visit(ctx, walk, inst)
+
+				continue
+			}
+
+			// then nothing claimed it - this is an error. We don't actually
+			// raise this as an error here though (it will be caught elsewhere).
+
+		}
+
+		if !unknownComponentBlockClaimedSomething {
+			// then we want to include the partial unknown component instance
+			inst := unknownComponentBlock.UnknownInstance(ctx, phase)
+			visit(ctx, walk, inst)
+		}
+	})
+}
+
+// walkEmbeddedStack follows the pattern of walkComponent but for embedded
+// stack calls rather than components.
+func walkEmbeddedStack[Output any](
+	ctx context.Context,
+	walk *walkWithOutput[Output],
+	stack *Stack,
+	addr stackaddrs.StackCall,
+	phase EvalPhase,
+	visit func(ctx context.Context, walk *walkWithOutput[Output], obj DynamicEvaler)) {
+
+	var unknownStackCall *StackCall
+	var unknownRemovedStackCall *RemovedStackCall
+
+	var wg sync.WaitGroup
+	var mutex sync.Mutex
+
+	claimedInstances := collections.NewSet[stackaddrs.StackInstance]()
+
+	embeddedStack := stack.EmbeddedStackCall(addr)
+	if embeddedStack != nil {
+		visit(ctx, walk, embeddedStack)
+
+		wg.Add(1)
+		walk.AsyncTask(ctx, func(ctx context.Context) {
+			defer wg.Done()
+
+			insts, unknown := embeddedStack.Instances(ctx, phase)
+			if unknown {
+				unknownStackCall = embeddedStack
+				return
+			}
+
+			for _, inst := range insts {
+				instAddr := inst.CalledStackAddr()
+
+				mutex.Lock()
+				if claimedInstances.Has(instAddr) {
+					mutex.Unlock()
+					continue
+				}
+				claimedInstances.Add(instAddr)
+				mutex.Unlock()
+
+				visit(ctx, walk, inst)
+				childStack := inst.Stack(ctx, phase)
+				walkDynamicObjectsInStack(ctx, walk, childStack, phase, visit)
+			}
+		})
+	}
+
+	for _, block := range stack.Removed().localStackCalls[addr] {
+		visit(ctx, walk, block)
+
+		wg.Add(1)
+		walk.AsyncTask(ctx, func(ctx context.Context) {
+			defer wg.Done()
+
+			insts, unknown := block.InstancesFor(ctx, stack.addr, phase)
+			if unknown {
+				mutex.Lock()
+				unknownRemovedStackCall = block
+				mutex.Unlock()
+
+				return
+			}
+
+			for _, inst := range insts {
+				mutex.Lock()
+				if claimedInstances.Has(inst.from) {
+					mutex.Unlock()
+					continue
+				}
+				claimedInstances.Add(inst.from)
+				mutex.Unlock()
+
+				visit(ctx, walk, inst)
+				childStack := inst.Stack(ctx, phase)
+				walkDynamicObjectsInStack(ctx, walk, childStack, phase, visit)
+			}
+		})
+	}
+
+	walk.AsyncTask(ctx, func(ctx context.Context) {
+		wg.Wait()
+
+		unknownStackCallClaimedSomething := unknownStackCall == nil
+
+		knownStacks := stack.KnownEmbeddedStacks(addr, phase)
+		for inst := range knownStacks.All() {
+			if claimedInstances.Has(inst) {
+				continue
+			}
+
+			if unknownStackCall != nil {
+				unknownStackCallClaimedSomething = true
+
+				if inst[len(inst)-1].Key == addrs.WildcardKey {
+					inst := unknownStackCall.UnknownInstance(ctx, phase)
+					visit(ctx, walk, inst)
+					childStack := inst.Stack(ctx, phase)
+					walkDynamicObjectsInStack(ctx, walk, childStack, phase, visit)
+					continue
+				}
+
+				inst := newStackCallInstance(unknownStackCall, inst[len(inst)-1].Key, instances.RepetitionData{
+					EachKey:   inst[len(inst)-1].Key.Value(),
+					EachValue: cty.UnknownVal(cty.DynamicPseudoType),
+				}, stack.mode, true)
+
+				visit(ctx, walk, inst)
+				childStack := inst.Stack(ctx, phase)
+				walkDynamicObjectsInStack(ctx, walk, childStack, phase, visit)
+
+				continue
+			}
+
+			if unknownRemovedStackCall != nil {
+				inst := newRemovedStackCallInstance(unknownRemovedStackCall, inst, instances.RepetitionData{
+					EachKey:   inst[len(inst)-1].Key.Value(),
+					EachValue: cty.UnknownVal(cty.DynamicPseudoType),
+				}, true)
+
+				visit(ctx, walk, inst)
+				childStack := inst.Stack(ctx, phase)
+				walkDynamicObjectsInStack(ctx, walk, childStack, phase, visit)
+
+				continue
+			}
+		}
+
+		if !unknownStackCallClaimedSomething {
+			// then we want to include the partial unknown component instance
+			inst := unknownStackCall.UnknownInstance(ctx, phase)
+			visit(ctx, walk, inst)
+			childStack := inst.Stack(ctx, phase)
+			walkDynamicObjectsInStack(ctx, walk, childStack, phase, visit)
+		}
+
+	})
+
 }

--- a/internal/stacks/stackruntime/internal/stackeval/walk_static.go
+++ b/internal/stacks/stackruntime/internal/stackeval/walk_static.go
@@ -74,6 +74,12 @@ func walkStaticObjectsInStackConfig[Output any](
 		visit(ctx, walk, obj)
 	}
 
+	for _, objs := range stackConfig.RemovedStackCalls().All() {
+		for _, obj := range objs {
+			visit(ctx, walk, obj)
+		}
+	}
+
 	for _, childCfg := range stackConfig.ChildConfigs() {
 		walkStaticObjectsInStackConfig(ctx, walk, childCfg, visit)
 	}

--- a/internal/stacks/stackruntime/testdata/mainbundle/test/with-single-input/removed-stack-instance-dynamic/removed-stack-instance-dynamic.tfstack.hcl
+++ b/internal/stacks/stackruntime/testdata/mainbundle/test/with-single-input/removed-stack-instance-dynamic/removed-stack-instance-dynamic.tfstack.hcl
@@ -1,0 +1,39 @@
+required_providers {
+  testing = {
+    source  = "hashicorp/testing"
+    version = "0.1.0"
+  }
+}
+
+variable "input" {
+  type = map(string)
+  default = {}
+}
+
+variable "removed" {
+  type = map(string)
+  default = {}
+}
+
+stack "simple" {
+  for_each = var.input
+
+  source = "../valid"
+
+  inputs = {
+    id = each.key
+    input = each.value
+  }
+}
+
+removed {
+  for_each = var.removed
+
+  from = stack.simple[each.key]
+  source = "../valid"
+
+  inputs = {
+    id = each.key
+    input = each.value
+  }
+}

--- a/internal/stacks/stackstate/state.go
+++ b/internal/stacks/stackstate/state.go
@@ -120,8 +120,8 @@ func (s *State) ComponentInstances(addr stackaddrs.AbsComponent) collections.Set
 
 // StackInstances returns the set of known stack instances for the given stack
 // call.
-func (s *State) StackInstances(call stackaddrs.AbsStackCall) map[stackaddrs.StackInstanceStep]bool {
-	ret := make(map[stackaddrs.StackInstanceStep]bool)
+func (s *State) StackInstances(call stackaddrs.AbsStackCall) collections.Set[stackaddrs.StackInstance] {
+	ret := collections.NewSet[stackaddrs.StackInstance]()
 	for key := range s.componentInstances.All() {
 		if len(key.Stack) == 0 {
 			continue
@@ -136,7 +136,7 @@ func (s *State) StackInstances(call stackaddrs.AbsStackCall) map[stackaddrs.Stac
 		if last.Name != call.Item.Name {
 			continue
 		}
-		ret[last] = true
+		ret.Add(key.Stack)
 	}
 	return ret
 }


### PR DESCRIPTION
This PR adds the concept of a `RemovedStackCall` into the stacks runtime. Essentially, a removed block can now target an entire embedded stack and mark everything inside as being removed.

To enable this, `Stack` objects now accept a `plans.Mode` as part of their constructor which the removed stack call sets to be `plans.Destroy` while regular stack calls inherit from their stack. The behaviour of the removed stack call within the stack is otherwise fairly similar.

This PR also refactors the dynamic walk logic to extract the now fairly complicated logic for handling components and embedded stacks into dedicated functions to tidy everything up a bit.