### PR TITLE
 write-only attributes: internal providers should set write-only attributes to null

### DIFF
--- a/.changes/v1.11/BUG FIXES-20250402-143931.yaml
+++ b/.changes/v1.11/BUG FIXES-20250402-143931.yaml
@@ -1,0 +1,5 @@
+kind: BUG FIXES
+body: 'write-only attributes: internal providers should set write-only attributes to null'
+time: 2025-04-02T14:39:31.672249+02:00
+custom:
+    Issue: "36824"

--- a/internal/command/test_test.go
+++ b/internal/command/test_test.go
@@ -322,6 +322,18 @@ func TestTest_Runs(t *testing.T) {
 			expectedErr: []string{"Cannot apply non-applyable plan"},
 			code:        1,
 		},
+		"write-only-attributes": {
+			expectedOut: []string{"1 passed, 0 failed."},
+			code:        0,
+		},
+		"write-only-attributes-mocked": {
+			expectedOut: []string{"1 passed, 0 failed."},
+			code:        0,
+		},
+		"write-only-attributes-overridden": {
+			expectedOut: []string{"1 passed, 0 failed."},
+			code:        0,
+		},
 	}
 	for name, tc := range tcs {
 		t.Run(name, func(t *testing.T) {
@@ -1618,6 +1630,7 @@ Terraform will perform the following actions:
       + destroy_fail = (known after apply)
       + id           = "constant_value"
       + value        = "bar"
+      + write_only   = (write-only attribute)
     }
 
 Plan: 1 to add, 0 to change, 0 to destroy.
@@ -1629,6 +1642,7 @@ resource "test_resource" "foo" {
     destroy_fail = false
     id           = "constant_value"
     value        = "bar"
+    write_only   = (write-only attribute)
 }
 
 main.tftest.hcl... tearing down
@@ -1951,6 +1965,7 @@ resource "test_resource" "module_resource" {
     destroy_fail = false
     id           = "df6h8as9"
     value        = "start"
+    write_only   = (write-only attribute)
 }
 
   run "initial_apply"... pass
@@ -1960,6 +1975,7 @@ resource "test_resource" "resource" {
     destroy_fail = false
     id           = "598318e0"
     value        = "start"
+    write_only   = (write-only attribute)
 }
 
   run "plan_second_example"... pass
@@ -1975,6 +1991,7 @@ Terraform will perform the following actions:
       + destroy_fail = (known after apply)
       + id           = "b6a1d8cb"
       + value        = "start"
+      + write_only   = (write-only attribute)
     }
 
 Plan: 1 to add, 0 to change, 0 to destroy.
@@ -1991,7 +2008,7 @@ Terraform will perform the following actions:
   ~ resource "test_resource" "resource" {
         id           = "598318e0"
       ~ value        = "start" -> "update"
-        # (1 unchanged attribute hidden)
+        # (2 unchanged attributes hidden)
     }
 
 Plan: 0 to add, 1 to change, 0 to destroy.
@@ -2008,7 +2025,7 @@ Terraform will perform the following actions:
   ~ resource "test_resource" "module_resource" {
         id           = "df6h8as9"
       ~ value        = "start" -> "update"
-        # (1 unchanged attribute hidden)
+        # (2 unchanged attributes hidden)
     }
 
 Plan: 0 to add, 1 to change, 0 to destroy.
@@ -2021,8 +2038,8 @@ Success! 5 passed, 0 failed.
 
 	actual := output.All()
 
-	if !strings.Contains(actual, expected) {
-		t.Errorf("output didn't match expected:\nexpected:\n%s\nactual:\n%s", expected, actual)
+	if diff := cmp.Diff(expected, actual); diff != "" {
+		t.Errorf("output didn't match expected:\nexpected:\n%s\nactual:\n%s\ndiff:\n%s", expected, actual, diff)
 	}
 
 	if provider.ResourceCount() > 0 {
@@ -2831,6 +2848,7 @@ resource "test_resource" "resource" {
     destroy_fail = false
     id           = "9ddca5a9"
     value        = (sensitive value)
+    write_only   = (write-only attribute)
 }
 
 
@@ -2845,6 +2863,7 @@ resource "test_resource" "resource" {
     destroy_fail = false
     id           = "9ddca5a9"
     value        = (sensitive value)
+    write_only   = (write-only attribute)
 }
 
 

--- a/internal/command/testdata/test/write-only-attributes-mocked/main.tf
+++ b/internal/command/testdata/test/write-only-attributes-mocked/main.tf
@@ -1,0 +1,14 @@
+
+variable "input" {
+  type = string
+}
+
+data "test_data_source" "datasource" {
+  id = "resource"
+  write_only = var.input
+}
+
+resource "test_resource" "resource" {
+  value = data.test_data_source.datasource.value
+  write_only = var.input
+}

--- a/internal/command/testdata/test/write-only-attributes-mocked/main.tftest.hcl
+++ b/internal/command/testdata/test/write-only-attributes-mocked/main.tftest.hcl
@@ -1,0 +1,36 @@
+
+mock_provider "test" {
+  mock_resource "test_resource" {
+    defaults = {
+      id = "resource"
+    }
+  }
+
+  mock_data "test_data_source" {
+    defaults = {
+      value = "hello"
+    }
+  }
+}
+
+run "test" {
+  variables {
+    input = "input"
+  }
+
+  assert {
+    condition = data.test_data_source.datasource.value == "hello"
+    error_message = "wrong value"
+  }
+
+  assert {
+    condition = test_resource.resource.value == "hello"
+    error_message = "wrong value"
+  }
+
+  assert {
+    condition = test_resource.resource.id == "resource"
+    error_message = "wrong value"
+  }
+
+}

--- a/internal/command/testdata/test/write-only-attributes-overridden/main.tf
+++ b/internal/command/testdata/test/write-only-attributes-overridden/main.tf
@@ -1,0 +1,14 @@
+
+variable "input" {
+  type = string
+}
+
+data "test_data_source" "datasource" {
+  id = "resource"
+  write_only = var.input
+}
+
+resource "test_resource" "resource" {
+  value = data.test_data_source.datasource.value
+  write_only = var.input
+}

--- a/internal/command/testdata/test/write-only-attributes-overridden/main.tftest.hcl
+++ b/internal/command/testdata/test/write-only-attributes-overridden/main.tftest.hcl
@@ -1,0 +1,38 @@
+
+provider "test" {}
+
+override_resource {
+  target = test_resource.resource
+  values = {
+    id = "resource"
+  }
+}
+
+override_data {
+  target = data.test_data_source.datasource
+  values = {
+    value = "hello"
+  }
+}
+
+run "test" {
+  variables {
+    input = "input"
+  }
+
+  assert {
+    condition = data.test_data_source.datasource.value == "hello"
+    error_message = "wrong value"
+  }
+
+  assert {
+    condition = test_resource.resource.value == "hello"
+    error_message = "wrong value"
+  }
+
+  assert {
+    condition = test_resource.resource.id == "resource"
+    error_message = "wrong value"
+  }
+
+}

--- a/internal/command/testdata/test/write-only-attributes/main.tf
+++ b/internal/command/testdata/test/write-only-attributes/main.tf
@@ -1,0 +1,9 @@
+
+variable "input" {
+  type = string
+}
+
+resource "test_resource" "resource" {
+  id = "resource"
+  write_only = var.input
+}

--- a/internal/command/testdata/test/write-only-attributes/main.tftest.hcl
+++ b/internal/command/testdata/test/write-only-attributes/main.tftest.hcl
@@ -1,0 +1,8 @@
+
+provider "test" {}
+
+run "test" {
+  variables {
+    input = "input"
+  }
+}

--- a/internal/command/testing/test_provider.go
+++ b/internal/command/testing/test_provider.go
@@ -39,6 +39,7 @@ var (
 						"destroy_fail":         {Type: cty.Bool, Optional: true, Computed: true},
 						"create_wait_seconds":  {Type: cty.Number, Optional: true},
 						"destroy_wait_seconds": {Type: cty.Number, Optional: true},
+						"write_only":           {Type: cty.String, Optional: true, WriteOnly: true},
 					},
 				},
 			},
@@ -47,8 +48,9 @@ var (
 			"test_data_source": {
 				Body: &configschema.Block{
 					Attributes: map[string]*configschema.Attribute{
-						"id":    {Type: cty.String, Required: true},
-						"value": {Type: cty.String, Computed: true},
+						"id":         {Type: cty.String, Required: true},
+						"value":      {Type: cty.String, Computed: true},
+						"write_only": {Type: cty.String, Optional: true, WriteOnly: true},
 
 						// We never actually reference these values from a data
 						// source, but we have tests that use the same cty.Value
@@ -233,9 +235,15 @@ func (provider *TestProvider) PlanResourceChange(request providers.PlanResourceC
 		resource = cty.ObjectVal(vals)
 	}
 
-	if destryFail := resource.GetAttr("destroy_fail"); !destryFail.IsKnown() || destryFail.IsNull() {
+	if destroyFail := resource.GetAttr("destroy_fail"); !destroyFail.IsKnown() || destroyFail.IsNull() {
 		vals := resource.AsValueMap()
 		vals["destroy_fail"] = cty.UnknownVal(cty.Bool)
+		resource = cty.ObjectVal(vals)
+	}
+
+	if writeOnly := resource.GetAttr("write_only"); !writeOnly.IsNull() {
+		vals := resource.AsValueMap()
+		vals["write_only"] = cty.NullVal(cty.String)
 		resource = cty.ObjectVal(vals)
 	}
 
@@ -333,6 +341,12 @@ func (provider *TestProvider) ReadDataSource(request providers.ReadDataSourceReq
 	resource := provider.Store.Get(provider.GetDataKey(id))
 	if resource == cty.NilVal {
 		diags = diags.Append(tfdiags.Sourceless(tfdiags.Error, "not found", fmt.Sprintf("%s does not exist", id)))
+	}
+
+	if writeOnly := resource.GetAttr("write_only"); !writeOnly.IsNull() {
+		vals := resource.AsValueMap()
+		vals["write_only"] = cty.NullVal(cty.String)
+		resource = cty.ObjectVal(vals)
 	}
 
 	return providers.ReadDataSourceResponse{

--- a/internal/lang/ephemeral/strip.go
+++ b/internal/lang/ephemeral/strip.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
 package ephemeral
 
 import (

--- a/internal/lang/ephemeral/strip.go
+++ b/internal/lang/ephemeral/strip.go
@@ -1,0 +1,42 @@
+package ephemeral
+
+import (
+	"github.com/zclconf/go-cty/cty"
+
+	"github.com/hashicorp/terraform/internal/configs/configschema"
+)
+
+// StripWriteOnlyAttributes converts all the write-only attributes in value to
+// null values.
+func StripWriteOnlyAttributes(value cty.Value, schema *configschema.Block) cty.Value {
+	// writeOnlyTransformer never returns errors, so we don't need to detect
+	// them here.
+	updated, _ := cty.TransformWithTransformer(value, &writeOnlyTransformer{
+		schema: schema,
+	})
+	return updated
+}
+
+var _ cty.Transformer = (*writeOnlyTransformer)(nil)
+
+type writeOnlyTransformer struct {
+	schema *configschema.Block
+}
+
+func (w *writeOnlyTransformer) Enter(path cty.Path, value cty.Value) (cty.Value, error) {
+	attr := w.schema.AttributeByPath(path)
+	if attr == nil {
+		return value, nil
+	}
+
+	if attr.WriteOnly {
+		value, marks := value.Unmark()
+		return cty.NullVal(value.Type()).WithMarks(marks), nil
+	}
+
+	return value, nil
+}
+
+func (w *writeOnlyTransformer) Exit(_ cty.Path, value cty.Value) (cty.Value, error) {
+	return value, nil // no changes
+}

--- a/internal/lang/ephemeral/strip_test.go
+++ b/internal/lang/ephemeral/strip_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
 package ephemeral
 
 import (

--- a/internal/lang/ephemeral/strip_test.go
+++ b/internal/lang/ephemeral/strip_test.go
@@ -1,0 +1,190 @@
+package ephemeral
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/zclconf/go-cty-debug/ctydebug"
+	"github.com/zclconf/go-cty/cty"
+
+	"github.com/hashicorp/terraform/internal/configs/configschema"
+	"github.com/hashicorp/terraform/internal/lang/marks"
+)
+
+func TestStripWriteOnlyAttributes(t *testing.T) {
+	tcs := map[string]struct {
+		val    cty.Value
+		schema *configschema.Block
+		want   cty.Value
+	}{
+		"primitive": {
+			val: cty.ObjectVal(map[string]cty.Value{
+				"value": cty.StringVal("value"),
+			}),
+			schema: &configschema.Block{
+				Attributes: map[string]*configschema.Attribute{
+					"value": {
+						Type:      cty.String,
+						WriteOnly: true,
+					},
+				},
+			},
+			want: cty.ObjectVal(map[string]cty.Value{
+				"value": cty.NullVal(cty.String),
+			}),
+		},
+		"complex": {
+			val: cty.ObjectVal(map[string]cty.Value{
+				"value": cty.ObjectVal(map[string]cty.Value{
+					"value": cty.StringVal("value"),
+				}),
+			}),
+			schema: &configschema.Block{
+				Attributes: map[string]*configschema.Attribute{
+					"value": {
+						NestedType: &configschema.Object{
+							Attributes: map[string]*configschema.Attribute{
+								"value": {
+									Type: cty.String,
+								},
+							},
+							Nesting: configschema.NestingSingle,
+						},
+						WriteOnly: true,
+					},
+				},
+			},
+			want: cty.ObjectVal(map[string]cty.Value{
+				"value": cty.NullVal(cty.Object(map[string]cty.Type{
+					"value": cty.String,
+				})),
+			}),
+		},
+		"nested in object": {
+			val: cty.ObjectVal(map[string]cty.Value{
+				"value": cty.ObjectVal(map[string]cty.Value{
+					"value": cty.StringVal("value"),
+				}),
+			}),
+			schema: &configschema.Block{
+				Attributes: map[string]*configschema.Attribute{
+					"value": {
+						NestedType: &configschema.Object{
+							Attributes: map[string]*configschema.Attribute{
+								"value": {
+									Type:      cty.String,
+									WriteOnly: true,
+								},
+							},
+							Nesting: configschema.NestingSingle,
+						},
+					},
+				},
+			},
+			want: cty.ObjectVal(map[string]cty.Value{
+				"value": cty.ObjectVal(map[string]cty.Value{
+					"value": cty.NullVal(cty.String),
+				}),
+			}),
+		},
+		"nested in list": {
+			val: cty.ObjectVal(map[string]cty.Value{
+				"value": cty.ListVal([]cty.Value{
+					cty.ObjectVal(map[string]cty.Value{
+						"value": cty.StringVal("value"),
+					}),
+					cty.ObjectVal(map[string]cty.Value{
+						"value": cty.StringVal("value"),
+					}),
+				}),
+			}),
+			schema: &configschema.Block{
+				Attributes: map[string]*configschema.Attribute{
+					"value": {
+						NestedType: &configschema.Object{
+							Attributes: map[string]*configschema.Attribute{
+								"value": {
+									Type:      cty.String,
+									WriteOnly: true,
+								},
+							},
+							Nesting: configschema.NestingList,
+						},
+					},
+				},
+			},
+			want: cty.ObjectVal(map[string]cty.Value{
+				"value": cty.ListVal([]cty.Value{
+					cty.ObjectVal(map[string]cty.Value{
+						"value": cty.NullVal(cty.String),
+					}),
+					cty.ObjectVal(map[string]cty.Value{
+						"value": cty.NullVal(cty.String),
+					}),
+				}),
+			}),
+		},
+		"nested in map": {
+			val: cty.ObjectVal(map[string]cty.Value{
+				"value": cty.MapVal(map[string]cty.Value{
+					"one": cty.ObjectVal(map[string]cty.Value{
+						"value": cty.StringVal("value"),
+					}),
+					"two": cty.ObjectVal(map[string]cty.Value{
+						"value": cty.StringVal("value"),
+					}),
+				}),
+			}),
+			schema: &configschema.Block{
+				Attributes: map[string]*configschema.Attribute{
+					"value": {
+						NestedType: &configschema.Object{
+							Attributes: map[string]*configschema.Attribute{
+								"value": {
+									Type:      cty.String,
+									WriteOnly: true,
+								},
+							},
+							Nesting: configschema.NestingMap,
+						},
+					},
+				},
+			},
+			want: cty.ObjectVal(map[string]cty.Value{
+				"value": cty.MapVal(map[string]cty.Value{
+					"one": cty.ObjectVal(map[string]cty.Value{
+						"value": cty.NullVal(cty.String),
+					}),
+					"two": cty.ObjectVal(map[string]cty.Value{
+						"value": cty.NullVal(cty.String),
+					}),
+				}),
+			}),
+		},
+		"preserves marks": {
+			val: cty.ObjectVal(map[string]cty.Value{
+				"value": cty.StringVal("value"),
+			}).Mark(marks.Sensitive),
+			schema: &configschema.Block{
+				Attributes: map[string]*configschema.Attribute{
+					"value": {
+						Type:      cty.String,
+						WriteOnly: true,
+					},
+				},
+			},
+			want: cty.ObjectVal(map[string]cty.Value{
+				"value": cty.NullVal(cty.String),
+			}).Mark(marks.Sensitive),
+		},
+	}
+
+	for name, tc := range tcs {
+		t.Run(name, func(t *testing.T) {
+			got := StripWriteOnlyAttributes(tc.val, tc.schema)
+			if diff := cmp.Diff(got, tc.want, ctydebug.CmpOptions); len(diff) > 0 {
+				t.Errorf("got diff:\n%s", diff)
+			}
+		})
+	}
+}

--- a/internal/lang/ephemeral/validate.go
+++ b/internal/lang/ephemeral/validate.go
@@ -6,15 +6,16 @@ package ephemeral
 import (
 	"fmt"
 
+	"github.com/zclconf/go-cty/cty"
+
 	"github.com/hashicorp/terraform/internal/configs/configschema"
 	"github.com/hashicorp/terraform/internal/tfdiags"
-	"github.com/zclconf/go-cty/cty"
 )
 
 // ValidateWriteOnlyAttributes identifies all instances of write-only paths that contain non-null values
 // and returns a diagnostic for each instance
 func ValidateWriteOnlyAttributes(summary string, detail func(cty.Path) string, newVal cty.Value, schema *configschema.Block) (diags tfdiags.Diagnostics) {
-	writeOnlyPaths, err := nonNullWriteOnlyPaths(newVal, schema, nil)
+	writeOnlyPaths, err := nonNullWriteOnlyPaths(newVal, schema)
 	if err != nil {
 		return diags.Append(tfdiags.Sourceless(
 			tfdiags.Error,
@@ -36,7 +37,7 @@ func ValidateWriteOnlyAttributes(summary string, detail func(cty.Path) string, n
 
 // nonNullWriteOnlyPaths returns a list of paths to attributes that are write-only
 // and non-null in the given value.
-func nonNullWriteOnlyPaths(val cty.Value, schema *configschema.Block, p cty.Path) ([]cty.Path, error) {
+func nonNullWriteOnlyPaths(val cty.Value, schema *configschema.Block) ([]cty.Path, error) {
 	if schema == nil {
 		panic("nonNullWriteOnlyPaths called wih nil schema")
 	}

--- a/internal/lang/ephemeral/validate_test.go
+++ b/internal/lang/ephemeral/validate_test.go
@@ -6,8 +6,9 @@ package ephemeral
 import (
 	"testing"
 
-	"github.com/hashicorp/terraform/internal/configs/configschema"
 	"github.com/zclconf/go-cty/cty"
+
+	"github.com/hashicorp/terraform/internal/configs/configschema"
 )
 
 func TestNonNullWriteOnlyPaths(t *testing.T) {
@@ -145,7 +146,7 @@ func TestNonNullWriteOnlyPaths(t *testing.T) {
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
-			paths, err := nonNullWriteOnlyPaths(tc.val, tc.schema, nil)
+			paths, err := nonNullWriteOnlyPaths(tc.val, tc.schema)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/internal/providers/mock.go
+++ b/internal/providers/mock.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/hashicorp/terraform/internal/configs"
 	"github.com/hashicorp/terraform/internal/configs/hcl2shim"
+	"github.com/hashicorp/terraform/internal/lang/ephemeral"
 	"github.com/hashicorp/terraform/internal/moduletest/mocking"
 	"github.com/hashicorp/terraform/internal/tfdiags"
 )
@@ -138,7 +139,7 @@ func (m *Mock) UpgradeResourceState(request UpgradeResourceStateRequest) (respon
 		response.Diagnostics = response.Diagnostics.Append(err)
 		return response
 	}
-	response.UpgradedState = value
+	response.UpgradedState = ephemeral.StripWriteOnlyAttributes(value, resource.Body)
 	return response
 }
 
@@ -207,26 +208,25 @@ func (m *Mock) PlanResourceChange(request PlanResourceChangeRequest) PlanResourc
 		}
 	}
 
+	var response PlanResourceChangeResponse
+	schema := m.GetProviderSchema()
+	response.Diagnostics = response.Diagnostics.Append(schema.Diagnostics)
+	if schema.Diagnostics.HasErrors() {
+		// We couldn't retrieve the schema for some reason, so the mock
+		// provider can't really function.
+		return response
+	}
+
+	resource, exists := schema.ResourceTypes[request.TypeName]
+	if !exists {
+		// This means something has gone wrong much earlier, we should have
+		// failed a validation somewhere if a resource type doesn't exist.
+		panic(fmt.Errorf("failed to retrieve schema for resource %s", request.TypeName))
+	}
+
 	if request.PriorState.IsNull() {
 		// Then we are creating this resource - we need to populate the computed
 		// null fields with unknowns so Terraform will render them properly.
-
-		var response PlanResourceChangeResponse
-
-		schema := m.GetProviderSchema()
-		response.Diagnostics = response.Diagnostics.Append(schema.Diagnostics)
-		if schema.Diagnostics.HasErrors() {
-			// We couldn't retrieve the schema for some reason, so the mock
-			// provider can't really function.
-			return response
-		}
-
-		resource, exists := schema.ResourceTypes[request.TypeName]
-		if !exists {
-			// This means something has gone wrong much earlier, we should have
-			// failed a validation somewhere if a resource type doesn't exist.
-			panic(fmt.Errorf("failed to retrieve schema for resource %s", request.TypeName))
-		}
 
 		replacement := &mocking.MockedData{
 			Value:             cty.NilVal, // If we have no data then we use cty.NilVal.
@@ -241,17 +241,16 @@ func (m *Mock) PlanResourceChange(request PlanResourceChangeRequest) PlanResourc
 
 		value, diags := mocking.PlanComputedValuesForResource(request.ProposedNewState, replacement, resource.Body)
 		response.Diagnostics = response.Diagnostics.Append(diags)
-		response.PlannedState = value
+		response.PlannedState = ephemeral.StripWriteOnlyAttributes(value, resource.Body)
 		response.PlannedPrivate = []byte("create")
 		return response
 	}
 
 	// Otherwise, we're just doing a simple update and we don't need to populate
 	// any values for that.
-	return PlanResourceChangeResponse{
-		PlannedState:   request.ProposedNewState,
-		PlannedPrivate: []byte("update"),
-	}
+	response.PlannedState = ephemeral.StripWriteOnlyAttributes(request.ProposedNewState, resource.Body)
+	response.PlannedPrivate = []byte("update")
+	return response
 }
 
 func (m *Mock) ApplyResourceChange(request ApplyResourceChangeRequest) ApplyResourceChangeResponse {
@@ -344,7 +343,7 @@ func (m *Mock) ReadDataSource(request ReadDataSourceRequest) ReadDataSourceRespo
 
 	value, diags := mocking.ComputedValuesForDataSource(request.Config, mockedData, datasource.Body)
 	response.Diagnostics = response.Diagnostics.Append(diags)
-	response.State = value
+	response.State = ephemeral.StripWriteOnlyAttributes(value, datasource.Body)
 	return response
 }
 

--- a/internal/stacks/stackruntime/internal/stackeval/stubs/unknown.go
+++ b/internal/stacks/stackruntime/internal/stackeval/stubs/unknown.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/zclconf/go-cty/cty"
 
+	"github.com/hashicorp/terraform/internal/lang/ephemeral"
 	"github.com/hashicorp/terraform/internal/moduletest/mocking"
 	"github.com/hashicorp/terraform/internal/providers"
 	"github.com/hashicorp/terraform/internal/tfdiags"
@@ -134,7 +135,7 @@ func (u *unknownProvider) PlanResourceChange(request providers.PlanResourceChang
 		}
 
 		return providers.PlanResourceChangeResponse{
-			PlannedState: val,
+			PlannedState: ephemeral.StripWriteOnlyAttributes(val, schema.Body),
 			Deferred: &providers.Deferred{
 				Reason: providers.DeferredReasonProviderConfigUnknown,
 			},
@@ -232,7 +233,7 @@ func (u *unknownProvider) ReadDataSource(request providers.ReadDataSourceRequest
 		}
 
 		return providers.ReadDataSourceResponse{
-			State: val,
+			State: ephemeral.StripWriteOnlyAttributes(val, schema.Body),
 			Deferred: &providers.Deferred{
 				Reason: providers.DeferredReasonProviderConfigUnknown,
 			},

--- a/internal/stacks/stackruntime/testdata/mainbundle/test/with-write-only-attribute/with-write-only-attribute.tf
+++ b/internal/stacks/stackruntime/testdata/mainbundle/test/with-write-only-attribute/with-write-only-attribute.tf
@@ -1,0 +1,32 @@
+terraform {
+  required_providers {
+    testing = {
+      source  = "hashicorp/testing"
+      version = "0.1.0"
+    }
+  }
+}
+
+variable "datasource_id" {
+  type = string
+}
+
+variable "resource_id" {
+  type = string
+}
+
+variable "write_only_input" {
+  type = string
+  sensitive = true
+}
+
+data "testing_write_only_data_source" "data" {
+  id = var.datasource_id
+  write_only = var.write_only_input
+}
+
+resource "testing_write_only_resource" "data" {
+  id    = var.resource_id
+  value = data.testing_write_only_data_source.data.value
+  write_only = var.write_only_input
+}

--- a/internal/stacks/stackruntime/testdata/mainbundle/test/with-write-only-attribute/with-write-only-attribute.tfstack.hcl
+++ b/internal/stacks/stackruntime/testdata/mainbundle/test/with-write-only-attribute/with-write-only-attribute.tfstack.hcl
@@ -1,0 +1,28 @@
+required_providers {
+  testing = {
+    source  = "hashicorp/testing"
+    version = "0.1.0"
+  }
+}
+
+variable "providers" {
+  type = set(string)
+}
+
+provider "testing" "main" {
+  for_each = var.providers
+}
+
+component "main" {
+  source = "./"
+
+  providers = {
+    testing = provider.testing.main["single"]
+  }
+
+  inputs = {
+    datasource_id = "datasource"
+    resource_id = "resource"
+    write_only_input = "secret"
+  }
+}

--- a/internal/stacks/stackruntime/testing/provider.go
+++ b/internal/stacks/stackruntime/testing/provider.go
@@ -59,11 +59,31 @@ var (
 		},
 	}
 
+	WriteOnlyResourceSchema = providers.Schema{
+		Body: &configschema.Block{
+			Attributes: map[string]*configschema.Attribute{
+				"id":         {Type: cty.String, Optional: true, Computed: true},
+				"value":      {Type: cty.String, Optional: true},
+				"write_only": {Type: cty.String, WriteOnly: true, Optional: true},
+			},
+		},
+	}
+
 	TestingDataSourceSchema = providers.Schema{
 		Body: &configschema.Block{
 			Attributes: map[string]*configschema.Attribute{
 				"id":    {Type: cty.String, Required: true},
 				"value": {Type: cty.String, Computed: true},
+			},
+		},
+	}
+
+	WriteOnlyDataSourceSchema = providers.Schema{
+		Body: &configschema.Block{
+			Attributes: map[string]*configschema.Attribute{
+				"id":         {Type: cty.String, Required: true},
+				"value":      {Type: cty.String, Computed: true},
+				"write_only": {Type: cty.String, WriteOnly: true, Optional: true},
 			},
 		},
 	}
@@ -167,10 +187,16 @@ func NewProviderWithData(t *testing.T, store *ResourceStore) *MockProvider {
 						Body:     TestingResourceSchema.Body,
 						Identity: TestingResourceWithIdentitySchema.Identity,
 					},
+					"testing_write_only_resource": {
+						Body: WriteOnlyResourceSchema.Body,
+					},
 				},
 				DataSources: map[string]providers.Schema{
 					"testing_data_source": {
 						Body: TestingDataSourceSchema.Body,
+					},
+					"testing_write_only_data_source": {
+						Body: WriteOnlyDataSourceSchema.Body,
 					},
 				},
 				Functions: map[string]providers.FunctionDecl{

--- a/internal/terraform/node_resource_abstract_instance.go
+++ b/internal/terraform/node_resource_abstract_instance.go
@@ -943,14 +943,14 @@ func (n *NodeAbstractResourceInstance) plan(
 				ComputedAsUnknown: !n.override.UseForPlan,
 			}, schema.Body)
 			resp = providers.PlanResourceChangeResponse{
-				PlannedState: override,
+				PlannedState: ephemeral.StripWriteOnlyAttributes(override, schema.Body),
 				Diagnostics:  overrideDiags,
 			}
 		} else {
 			// This is an update operation, and we don't actually have any
 			// computed values that need to be applied.
 			resp = providers.PlanResourceChangeResponse{
-				PlannedState: proposedNewVal,
+				PlannedState: ephemeral.StripWriteOnlyAttributes(proposedNewVal, schema.Body),
 			}
 		}
 	} else {
@@ -1156,7 +1156,7 @@ func (n *NodeAbstractResourceInstance) plan(
 				ComputedAsUnknown: !n.override.UseForPlan,
 			}, schema.Body)
 			resp = providers.PlanResourceChangeResponse{
-				PlannedState: override,
+				PlannedState: ephemeral.StripWriteOnlyAttributes(override, schema.Body),
 				Diagnostics:  overrideDiags,
 			}
 		} else {
@@ -1641,7 +1641,7 @@ func (n *NodeAbstractResourceInstance) readDataSource(ctx EvalContext, configVal
 			ComputedAsUnknown: false,
 		}, schema.Body)
 		resp = providers.ReadDataSourceResponse{
-			State:       override,
+			State:       ephemeral.StripWriteOnlyAttributes(override, schema.Body),
 			Diagnostics: overrideDiags,
 		}
 	} else {

--- a/internal/terraform/node_resource_plan_instance.go
+++ b/internal/terraform/node_resource_plan_instance.go
@@ -644,7 +644,7 @@ func (n *NodePlannableResourceInstance) importState(ctx EvalContext, addr addrs.
 			ImportedResources: []providers.ImportedResource{
 				{
 					TypeName: addr.Resource.Resource.Type,
-					State:    override,
+					State:    ephemeral.StripWriteOnlyAttributes(override, schema.Body),
 				},
 			},
 			Diagnostics: overrideDiags.InConfigBody(n.Config.Config, absAddr.String()),


### PR DESCRIPTION
We have several internal providers that wrap external providers and override functionality. These providers must handle setting write-only attributes to null automatically as Terraform expects this.

The mock provider in the testing framework, the unknown provider in stacks, and the override_resource functionality in the testing framework are all fixed in this PR.

Fixes #36819 

Target release: v1.11.4