### PR TITLE
backport of write-only attributes: internal providers should set write-only attributes to null

### DIFF
--- a/.changes/v1.11/BUG FIXES-20250402-143931.yaml
+++ b/.changes/v1.11/BUG FIXES-20250402-143931.yaml
@@ -1,0 +1,5 @@
+kind: BUG FIXES
+body: 'write-only attributes: internal providers should set write-only attributes to null'
+time: 2025-04-02T14:39:31.672249+02:00
+custom:
+    Issue: "36824"

--- a/internal/command/test_test.go
+++ b/internal/command/test_test.go
@@ -300,6 +300,18 @@ func TestTest_Runs(t *testing.T) {
 			expectedErr: []string{"Cannot apply non-applyable plan"},
 			code:        1,
 		},
+		"write-only-attributes": {
+			expectedOut: []string{"1 passed, 0 failed."},
+			code:        0,
+		},
+		"write-only-attributes-mocked": {
+			expectedOut: []string{"1 passed, 0 failed."},
+			code:        0,
+		},
+		"write-only-attributes-overridden": {
+			expectedOut: []string{"1 passed, 0 failed."},
+			code:        0,
+		},
 	}
 	for name, tc := range tcs {
 		t.Run(name, func(t *testing.T) {
@@ -786,6 +798,7 @@ Terraform will perform the following actions:
       + destroy_fail = (known after apply)
       + id           = "constant_value"
       + value        = "bar"
+      + write_only   = (write-only attribute)
     }
 
 Plan: 1 to add, 0 to change, 0 to destroy.
@@ -797,6 +810,7 @@ resource "test_resource" "foo" {
     destroy_fail = false
     id           = "constant_value"
     value        = "bar"
+    write_only   = (write-only attribute)
 }
 
 main.tftest.hcl... tearing down
@@ -1102,6 +1116,7 @@ resource "test_resource" "module_resource" {
     destroy_fail = false
     id           = "df6h8as9"
     value        = "start"
+    write_only   = (write-only attribute)
 }
 
   run "initial_apply"... pass
@@ -1111,6 +1126,7 @@ resource "test_resource" "resource" {
     destroy_fail = false
     id           = "598318e0"
     value        = "start"
+    write_only   = (write-only attribute)
 }
 
   run "plan_second_example"... pass
@@ -1126,6 +1142,7 @@ Terraform will perform the following actions:
       + destroy_fail = (known after apply)
       + id           = "b6a1d8cb"
       + value        = "start"
+      + write_only   = (write-only attribute)
     }
 
 Plan: 1 to add, 0 to change, 0 to destroy.
@@ -1142,7 +1159,7 @@ Terraform will perform the following actions:
   ~ resource "test_resource" "resource" {
         id           = "598318e0"
       ~ value        = "start" -> "update"
-        # (1 unchanged attribute hidden)
+        # (2 unchanged attributes hidden)
     }
 
 Plan: 0 to add, 1 to change, 0 to destroy.
@@ -1159,7 +1176,7 @@ Terraform will perform the following actions:
   ~ resource "test_resource" "module_resource" {
         id           = "df6h8as9"
       ~ value        = "start" -> "update"
-        # (1 unchanged attribute hidden)
+        # (2 unchanged attributes hidden)
     }
 
 Plan: 0 to add, 1 to change, 0 to destroy.
@@ -1172,8 +1189,8 @@ Success! 5 passed, 0 failed.
 
 	actual := output.All()
 
-	if !strings.Contains(actual, expected) {
-		t.Errorf("output didn't match expected:\nexpected:\n%s\nactual:\n%s", expected, actual)
+	if diff := cmp.Diff(expected, actual); diff != "" {
+		t.Errorf("output didn't match expected:\nexpected:\n%s\nactual:\n%s\ndiff:\n%s", expected, actual, diff)
 	}
 
 	if provider.ResourceCount() > 0 {
@@ -1923,6 +1940,7 @@ resource "test_resource" "resource" {
     destroy_fail = false
     id           = "9ddca5a9"
     value        = (sensitive value)
+    write_only   = (write-only attribute)
 }
 
 

--- a/internal/command/testdata/test/write-only-attributes-mocked/main.tf
+++ b/internal/command/testdata/test/write-only-attributes-mocked/main.tf
@@ -1,0 +1,14 @@
+
+variable "input" {
+  type = string
+}
+
+data "test_data_source" "datasource" {
+  id = "resource"
+  write_only = var.input
+}
+
+resource "test_resource" "resource" {
+  value = data.test_data_source.datasource.value
+  write_only = var.input
+}

--- a/internal/command/testdata/test/write-only-attributes-mocked/main.tftest.hcl
+++ b/internal/command/testdata/test/write-only-attributes-mocked/main.tftest.hcl
@@ -1,0 +1,36 @@
+
+mock_provider "test" {
+  mock_resource "test_resource" {
+    defaults = {
+      id = "resource"
+    }
+  }
+
+  mock_data "test_data_source" {
+    defaults = {
+      value = "hello"
+    }
+  }
+}
+
+run "test" {
+  variables {
+    input = "input"
+  }
+
+  assert {
+    condition = data.test_data_source.datasource.value == "hello"
+    error_message = "wrong value"
+  }
+
+  assert {
+    condition = test_resource.resource.value == "hello"
+    error_message = "wrong value"
+  }
+
+  assert {
+    condition = test_resource.resource.id == "resource"
+    error_message = "wrong value"
+  }
+
+}

--- a/internal/command/testdata/test/write-only-attributes-overridden/main.tf
+++ b/internal/command/testdata/test/write-only-attributes-overridden/main.tf
@@ -1,0 +1,14 @@
+
+variable "input" {
+  type = string
+}
+
+data "test_data_source" "datasource" {
+  id = "resource"
+  write_only = var.input
+}
+
+resource "test_resource" "resource" {
+  value = data.test_data_source.datasource.value
+  write_only = var.input
+}

--- a/internal/command/testdata/test/write-only-attributes-overridden/main.tftest.hcl
+++ b/internal/command/testdata/test/write-only-attributes-overridden/main.tftest.hcl
@@ -1,0 +1,38 @@
+
+provider "test" {}
+
+override_resource {
+  target = test_resource.resource
+  values = {
+    id = "resource"
+  }
+}
+
+override_data {
+  target = data.test_data_source.datasource
+  values = {
+    value = "hello"
+  }
+}
+
+run "test" {
+  variables {
+    input = "input"
+  }
+
+  assert {
+    condition = data.test_data_source.datasource.value == "hello"
+    error_message = "wrong value"
+  }
+
+  assert {
+    condition = test_resource.resource.value == "hello"
+    error_message = "wrong value"
+  }
+
+  assert {
+    condition = test_resource.resource.id == "resource"
+    error_message = "wrong value"
+  }
+
+}

--- a/internal/command/testdata/test/write-only-attributes/main.tf
+++ b/internal/command/testdata/test/write-only-attributes/main.tf
@@ -1,0 +1,9 @@
+
+variable "input" {
+  type = string
+}
+
+resource "test_resource" "resource" {
+  id = "resource"
+  write_only = var.input
+}

--- a/internal/command/testdata/test/write-only-attributes/main.tftest.hcl
+++ b/internal/command/testdata/test/write-only-attributes/main.tftest.hcl
@@ -1,0 +1,8 @@
+
+provider "test" {}
+
+run "test" {
+  variables {
+    input = "input"
+  }
+}

--- a/internal/lang/ephemeral/strip.go
+++ b/internal/lang/ephemeral/strip.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
 package ephemeral
 
 import (

--- a/internal/lang/ephemeral/strip.go
+++ b/internal/lang/ephemeral/strip.go
@@ -1,0 +1,42 @@
+package ephemeral
+
+import (
+	"github.com/zclconf/go-cty/cty"
+
+	"github.com/hashicorp/terraform/internal/configs/configschema"
+)
+
+// StripWriteOnlyAttributes converts all the write-only attributes in value to
+// null values.
+func StripWriteOnlyAttributes(value cty.Value, schema *configschema.Block) cty.Value {
+	// writeOnlyTransformer never returns errors, so we don't need to detect
+	// them here.
+	updated, _ := cty.TransformWithTransformer(value, &writeOnlyTransformer{
+		schema: schema,
+	})
+	return updated
+}
+
+var _ cty.Transformer = (*writeOnlyTransformer)(nil)
+
+type writeOnlyTransformer struct {
+	schema *configschema.Block
+}
+
+func (w *writeOnlyTransformer) Enter(path cty.Path, value cty.Value) (cty.Value, error) {
+	attr := w.schema.AttributeByPath(path)
+	if attr == nil {
+		return value, nil
+	}
+
+	if attr.WriteOnly {
+		value, marks := value.Unmark()
+		return cty.NullVal(value.Type()).WithMarks(marks), nil
+	}
+
+	return value, nil
+}
+
+func (w *writeOnlyTransformer) Exit(_ cty.Path, value cty.Value) (cty.Value, error) {
+	return value, nil // no changes
+}

--- a/internal/lang/ephemeral/strip_test.go
+++ b/internal/lang/ephemeral/strip_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
 package ephemeral
 
 import (

--- a/internal/lang/ephemeral/strip_test.go
+++ b/internal/lang/ephemeral/strip_test.go
@@ -1,0 +1,190 @@
+package ephemeral
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/zclconf/go-cty-debug/ctydebug"
+	"github.com/zclconf/go-cty/cty"
+
+	"github.com/hashicorp/terraform/internal/configs/configschema"
+	"github.com/hashicorp/terraform/internal/lang/marks"
+)
+
+func TestStripWriteOnlyAttributes(t *testing.T) {
+	tcs := map[string]struct {
+		val    cty.Value
+		schema *configschema.Block
+		want   cty.Value
+	}{
+		"primitive": {
+			val: cty.ObjectVal(map[string]cty.Value{
+				"value": cty.StringVal("value"),
+			}),
+			schema: &configschema.Block{
+				Attributes: map[string]*configschema.Attribute{
+					"value": {
+						Type:      cty.String,
+						WriteOnly: true,
+					},
+				},
+			},
+			want: cty.ObjectVal(map[string]cty.Value{
+				"value": cty.NullVal(cty.String),
+			}),
+		},
+		"complex": {
+			val: cty.ObjectVal(map[string]cty.Value{
+				"value": cty.ObjectVal(map[string]cty.Value{
+					"value": cty.StringVal("value"),
+				}),
+			}),
+			schema: &configschema.Block{
+				Attributes: map[string]*configschema.Attribute{
+					"value": {
+						NestedType: &configschema.Object{
+							Attributes: map[string]*configschema.Attribute{
+								"value": {
+									Type: cty.String,
+								},
+							},
+							Nesting: configschema.NestingSingle,
+						},
+						WriteOnly: true,
+					},
+				},
+			},
+			want: cty.ObjectVal(map[string]cty.Value{
+				"value": cty.NullVal(cty.Object(map[string]cty.Type{
+					"value": cty.String,
+				})),
+			}),
+		},
+		"nested in object": {
+			val: cty.ObjectVal(map[string]cty.Value{
+				"value": cty.ObjectVal(map[string]cty.Value{
+					"value": cty.StringVal("value"),
+				}),
+			}),
+			schema: &configschema.Block{
+				Attributes: map[string]*configschema.Attribute{
+					"value": {
+						NestedType: &configschema.Object{
+							Attributes: map[string]*configschema.Attribute{
+								"value": {
+									Type:      cty.String,
+									WriteOnly: true,
+								},
+							},
+							Nesting: configschema.NestingSingle,
+						},
+					},
+				},
+			},
+			want: cty.ObjectVal(map[string]cty.Value{
+				"value": cty.ObjectVal(map[string]cty.Value{
+					"value": cty.NullVal(cty.String),
+				}),
+			}),
+		},
+		"nested in list": {
+			val: cty.ObjectVal(map[string]cty.Value{
+				"value": cty.ListVal([]cty.Value{
+					cty.ObjectVal(map[string]cty.Value{
+						"value": cty.StringVal("value"),
+					}),
+					cty.ObjectVal(map[string]cty.Value{
+						"value": cty.StringVal("value"),
+					}),
+				}),
+			}),
+			schema: &configschema.Block{
+				Attributes: map[string]*configschema.Attribute{
+					"value": {
+						NestedType: &configschema.Object{
+							Attributes: map[string]*configschema.Attribute{
+								"value": {
+									Type:      cty.String,
+									WriteOnly: true,
+								},
+							},
+							Nesting: configschema.NestingList,
+						},
+					},
+				},
+			},
+			want: cty.ObjectVal(map[string]cty.Value{
+				"value": cty.ListVal([]cty.Value{
+					cty.ObjectVal(map[string]cty.Value{
+						"value": cty.NullVal(cty.String),
+					}),
+					cty.ObjectVal(map[string]cty.Value{
+						"value": cty.NullVal(cty.String),
+					}),
+				}),
+			}),
+		},
+		"nested in map": {
+			val: cty.ObjectVal(map[string]cty.Value{
+				"value": cty.MapVal(map[string]cty.Value{
+					"one": cty.ObjectVal(map[string]cty.Value{
+						"value": cty.StringVal("value"),
+					}),
+					"two": cty.ObjectVal(map[string]cty.Value{
+						"value": cty.StringVal("value"),
+					}),
+				}),
+			}),
+			schema: &configschema.Block{
+				Attributes: map[string]*configschema.Attribute{
+					"value": {
+						NestedType: &configschema.Object{
+							Attributes: map[string]*configschema.Attribute{
+								"value": {
+									Type:      cty.String,
+									WriteOnly: true,
+								},
+							},
+							Nesting: configschema.NestingMap,
+						},
+					},
+				},
+			},
+			want: cty.ObjectVal(map[string]cty.Value{
+				"value": cty.MapVal(map[string]cty.Value{
+					"one": cty.ObjectVal(map[string]cty.Value{
+						"value": cty.NullVal(cty.String),
+					}),
+					"two": cty.ObjectVal(map[string]cty.Value{
+						"value": cty.NullVal(cty.String),
+					}),
+				}),
+			}),
+		},
+		"preserves marks": {
+			val: cty.ObjectVal(map[string]cty.Value{
+				"value": cty.StringVal("value"),
+			}).Mark(marks.Sensitive),
+			schema: &configschema.Block{
+				Attributes: map[string]*configschema.Attribute{
+					"value": {
+						Type:      cty.String,
+						WriteOnly: true,
+					},
+				},
+			},
+			want: cty.ObjectVal(map[string]cty.Value{
+				"value": cty.NullVal(cty.String),
+			}).Mark(marks.Sensitive),
+		},
+	}
+
+	for name, tc := range tcs {
+		t.Run(name, func(t *testing.T) {
+			got := StripWriteOnlyAttributes(tc.val, tc.schema)
+			if diff := cmp.Diff(got, tc.want, ctydebug.CmpOptions); len(diff) > 0 {
+				t.Errorf("got diff:\n%s", diff)
+			}
+		})
+	}
+}

--- a/internal/lang/ephemeral/validate.go
+++ b/internal/lang/ephemeral/validate.go
@@ -6,15 +6,16 @@ package ephemeral
 import (
 	"fmt"
 
+	"github.com/zclconf/go-cty/cty"
+
 	"github.com/hashicorp/terraform/internal/configs/configschema"
 	"github.com/hashicorp/terraform/internal/tfdiags"
-	"github.com/zclconf/go-cty/cty"
 )
 
 // ValidateWriteOnlyAttributes identifies all instances of write-only paths that contain non-null values
 // and returns a diagnostic for each instance
 func ValidateWriteOnlyAttributes(summary string, detail func(cty.Path) string, newVal cty.Value, schema *configschema.Block) (diags tfdiags.Diagnostics) {
-	writeOnlyPaths, err := nonNullWriteOnlyPaths(newVal, schema, nil)
+	writeOnlyPaths, err := nonNullWriteOnlyPaths(newVal, schema)
 	if err != nil {
 		return diags.Append(tfdiags.Sourceless(
 			tfdiags.Error,
@@ -36,7 +37,7 @@ func ValidateWriteOnlyAttributes(summary string, detail func(cty.Path) string, n
 
 // nonNullWriteOnlyPaths returns a list of paths to attributes that are write-only
 // and non-null in the given value.
-func nonNullWriteOnlyPaths(val cty.Value, schema *configschema.Block, p cty.Path) ([]cty.Path, error) {
+func nonNullWriteOnlyPaths(val cty.Value, schema *configschema.Block) ([]cty.Path, error) {
 	if schema == nil {
 		panic("nonNullWriteOnlyPaths called wih nil schema")
 	}

--- a/internal/lang/ephemeral/validate_test.go
+++ b/internal/lang/ephemeral/validate_test.go
@@ -6,8 +6,9 @@ package ephemeral
 import (
 	"testing"
 
-	"github.com/hashicorp/terraform/internal/configs/configschema"
 	"github.com/zclconf/go-cty/cty"
+
+	"github.com/hashicorp/terraform/internal/configs/configschema"
 )
 
 func TestNonNullWriteOnlyPaths(t *testing.T) {
@@ -145,7 +146,7 @@ func TestNonNullWriteOnlyPaths(t *testing.T) {
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
-			paths, err := nonNullWriteOnlyPaths(tc.val, tc.schema, nil)
+			paths, err := nonNullWriteOnlyPaths(tc.val, tc.schema)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/internal/providers/mock.go
+++ b/internal/providers/mock.go
@@ -128,7 +128,7 @@ func (m *Mock) UpgradeResourceState(request UpgradeResourceStateRequest) (respon
 		response.Diagnostics = response.Diagnostics.Append(err)
 		return response
 	}
-	response.UpgradedState = ephemeral.StripWriteOnlyAttributes(value, resource.Body)
+	response.UpgradedState = ephemeral.StripWriteOnlyAttributes(value, resource.Block)
 	return response
 }
 
@@ -195,14 +195,14 @@ func (m *Mock) PlanResourceChange(request PlanResourceChangeRequest) PlanResourc
 
 		value, diags := mocking.PlanComputedValuesForResource(request.ProposedNewState, replacement, resource.Block)
 		response.Diagnostics = response.Diagnostics.Append(diags)
-		response.PlannedState = ephemeral.StripWriteOnlyAttributes(value, resource.Body)
+		response.PlannedState = ephemeral.StripWriteOnlyAttributes(value, resource.Block)
 		response.PlannedPrivate = []byte("create")
 		return response
 	}
 
 	// Otherwise, we're just doing a simple update and we don't need to populate
 	// any values for that.
-	response.PlannedState = ephemeral.StripWriteOnlyAttributes(request.ProposedNewState, resource.Body)
+	response.PlannedState = ephemeral.StripWriteOnlyAttributes(request.ProposedNewState, resource.Block)
 	response.PlannedPrivate = []byte("update")
 	return response
 }
@@ -295,7 +295,7 @@ func (m *Mock) ReadDataSource(request ReadDataSourceRequest) ReadDataSourceRespo
 
 	value, diags := mocking.ComputedValuesForDataSource(request.Config, mockedData, datasource.Block)
 	response.Diagnostics = response.Diagnostics.Append(diags)
-	response.State = ephemeral.StripWriteOnlyAttributes(value, datasource.Body)
+	response.State = ephemeral.StripWriteOnlyAttributes(value, datasource.Block)
 	return response
 }
 

--- a/internal/stacks/stackruntime/internal/stackeval/stubs/unknown.go
+++ b/internal/stacks/stackruntime/internal/stackeval/stubs/unknown.go
@@ -125,7 +125,7 @@ func (u *unknownProvider) PlanResourceChange(request providers.PlanResourceChang
 		}
 
 		return providers.PlanResourceChangeResponse{
-			PlannedState: ephemeral.StripWriteOnlyAttributes(val, schema.Body),
+			PlannedState: ephemeral.StripWriteOnlyAttributes(val, schema.Block),
 			Deferred: &providers.Deferred{
 				Reason: providers.DeferredReasonProviderConfigUnknown,
 			},
@@ -223,7 +223,7 @@ func (u *unknownProvider) ReadDataSource(request providers.ReadDataSourceRequest
 		}
 
 		return providers.ReadDataSourceResponse{
-			State: ephemeral.StripWriteOnlyAttributes(val, schema.Body),
+			State: ephemeral.StripWriteOnlyAttributes(val, schema.Block),
 			Deferred: &providers.Deferred{
 				Reason: providers.DeferredReasonProviderConfigUnknown,
 			},

--- a/internal/stacks/stackruntime/internal/stackeval/stubs/unknown.go
+++ b/internal/stacks/stackruntime/internal/stackeval/stubs/unknown.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/zclconf/go-cty/cty"
 
+	"github.com/hashicorp/terraform/internal/lang/ephemeral"
 	"github.com/hashicorp/terraform/internal/moduletest/mocking"
 	"github.com/hashicorp/terraform/internal/providers"
 	"github.com/hashicorp/terraform/internal/tfdiags"
@@ -124,7 +125,7 @@ func (u *unknownProvider) PlanResourceChange(request providers.PlanResourceChang
 		}
 
 		return providers.PlanResourceChangeResponse{
-			PlannedState: val,
+			PlannedState: ephemeral.StripWriteOnlyAttributes(val, schema.Body),
 			Deferred: &providers.Deferred{
 				Reason: providers.DeferredReasonProviderConfigUnknown,
 			},
@@ -222,7 +223,7 @@ func (u *unknownProvider) ReadDataSource(request providers.ReadDataSourceRequest
 		}
 
 		return providers.ReadDataSourceResponse{
-			State: val,
+			State: ephemeral.StripWriteOnlyAttributes(val, schema.Body),
 			Deferred: &providers.Deferred{
 				Reason: providers.DeferredReasonProviderConfigUnknown,
 			},

--- a/internal/stacks/stackruntime/testdata/mainbundle/test/with-write-only-attribute/with-write-only-attribute.tf
+++ b/internal/stacks/stackruntime/testdata/mainbundle/test/with-write-only-attribute/with-write-only-attribute.tf
@@ -1,0 +1,32 @@
+terraform {
+  required_providers {
+    testing = {
+      source  = "hashicorp/testing"
+      version = "0.1.0"
+    }
+  }
+}
+
+variable "datasource_id" {
+  type = string
+}
+
+variable "resource_id" {
+  type = string
+}
+
+variable "write_only_input" {
+  type = string
+  sensitive = true
+}
+
+data "testing_write_only_data_source" "data" {
+  id = var.datasource_id
+  write_only = var.write_only_input
+}
+
+resource "testing_write_only_resource" "data" {
+  id    = var.resource_id
+  value = data.testing_write_only_data_source.data.value
+  write_only = var.write_only_input
+}

--- a/internal/stacks/stackruntime/testdata/mainbundle/test/with-write-only-attribute/with-write-only-attribute.tfstack.hcl
+++ b/internal/stacks/stackruntime/testdata/mainbundle/test/with-write-only-attribute/with-write-only-attribute.tfstack.hcl
@@ -1,0 +1,28 @@
+required_providers {
+  testing = {
+    source  = "hashicorp/testing"
+    version = "0.1.0"
+  }
+}
+
+variable "providers" {
+  type = set(string)
+}
+
+provider "testing" "main" {
+  for_each = var.providers
+}
+
+component "main" {
+  source = "./"
+
+  providers = {
+    testing = provider.testing.main["single"]
+  }
+
+  inputs = {
+    datasource_id = "datasource"
+    resource_id = "resource"
+    write_only_input = "secret"
+  }
+}

--- a/internal/stacks/stackruntime/testing/provider.go
+++ b/internal/stacks/stackruntime/testing/provider.go
@@ -155,7 +155,7 @@ func NewProviderWithData(t *testing.T, store *ResourceStore) *MockProvider {
 						Block: BlockedResourceSchema,
 					},
 					"testing_write_only_resource": {
-						Body: WriteOnlyResourceSchema.Body,
+						Block: WriteOnlyResourceSchema,
 					},
 				},
 				DataSources: map[string]providers.Schema{
@@ -163,7 +163,7 @@ func NewProviderWithData(t *testing.T, store *ResourceStore) *MockProvider {
 						Block: TestingDataSourceSchema,
 					},
 					"testing_write_only_data_source": {
-						Body: WriteOnlyDataSourceSchema.Body,
+						Block: WriteOnlyDataSourceSchema,
 					},
 				},
 				Functions: map[string]providers.FunctionDecl{

--- a/internal/stacks/stackruntime/testing/provider.go
+++ b/internal/stacks/stackruntime/testing/provider.go
@@ -51,10 +51,26 @@ var (
 		},
 	}
 
+	WriteOnlyResourceSchema = &configschema.Block{
+		Attributes: map[string]*configschema.Attribute{
+			"id":         {Type: cty.String, Optional: true, Computed: true},
+			"value":      {Type: cty.String, Optional: true},
+			"write_only": {Type: cty.String, WriteOnly: true, Optional: true},
+		},
+	}
+
 	TestingDataSourceSchema = &configschema.Block{
 		Attributes: map[string]*configschema.Attribute{
 			"id":    {Type: cty.String, Required: true},
 			"value": {Type: cty.String, Computed: true},
+		},
+	}
+
+	WriteOnlyDataSourceSchema = &configschema.Block{
+		Attributes: map[string]*configschema.Attribute{
+			"id":         {Type: cty.String, Required: true},
+			"value":      {Type: cty.String, Computed: true},
+			"write_only": {Type: cty.String, WriteOnly: true, Optional: true},
 		},
 	}
 )
@@ -138,10 +154,16 @@ func NewProviderWithData(t *testing.T, store *ResourceStore) *MockProvider {
 					"testing_blocked_resource": {
 						Block: BlockedResourceSchema,
 					},
+					"testing_write_only_resource": {
+						Body: WriteOnlyResourceSchema.Body,
+					},
 				},
 				DataSources: map[string]providers.Schema{
 					"testing_data_source": {
 						Block: TestingDataSourceSchema,
+					},
+					"testing_write_only_data_source": {
+						Body: WriteOnlyDataSourceSchema.Body,
 					},
 				},
 				Functions: map[string]providers.FunctionDecl{

--- a/internal/stacks/stackruntime/testing/resource.go
+++ b/internal/stacks/stackruntime/testing/resource.go
@@ -35,6 +35,8 @@ func getResource(name string) resource {
 		return &failedResource{}
 	case "testing_blocked_resource":
 		return &blockedResource{}
+	case "testing_write_only_resource":
+		return &writeOnlyResource{}
 	default:
 		panic("unknown resource: " + name)
 	}
@@ -45,6 +47,7 @@ var (
 	_ resource = (*deferredResource)(nil)
 	_ resource = (*failedResource)(nil)
 	_ resource = (*blockedResource)(nil)
+	_ resource = (*writeOnlyResource)(nil)
 )
 
 // testingResource is a simple resource that can be managed by the mock provider
@@ -316,6 +319,60 @@ func (b *blockedResource) Apply(request providers.ApplyResourceChangeRequest, st
 	return
 }
 
+// writeOnlyResource is the same as testingResource but it includes an extra
+// write-only attribute.
+type writeOnlyResource struct{}
+
+func (w *writeOnlyResource) Read(request providers.ReadResourceRequest, store *ResourceStore) (response providers.ReadResourceResponse) {
+	id := request.PriorState.GetAttr("id").AsString()
+	var exists bool
+	response.NewState, exists = store.Get(id)
+	if !exists {
+		response.NewState = cty.NullVal(WriteOnlyResourceSchema.Body.ImpliedType())
+	}
+	return
+}
+
+func (w *writeOnlyResource) Plan(request providers.PlanResourceChangeRequest, store *ResourceStore) (response providers.PlanResourceChangeResponse) {
+	if request.ProposedNewState.IsNull() {
+		response.PlannedState = request.ProposedNewState
+		return
+	}
+
+	response.PlannedState = setNull(planEnsureId(request.ProposedNewState), "write_only")
+	replace, err := validateId(response.PlannedState, request.PriorState, store)
+	if err != nil {
+		response.Diagnostics = append(response.Diagnostics, tfdiags.Sourceless(tfdiags.Error, "testingResource error", err.Error()))
+		return
+	}
+	if replace {
+		response.RequiresReplace = []cty.Path{cty.GetAttrPath("id")}
+	}
+	return
+}
+
+func (w *writeOnlyResource) Apply(request providers.ApplyResourceChangeRequest, store *ResourceStore) (response providers.ApplyResourceChangeResponse) {
+	if request.PlannedState.IsNull() {
+		store.Delete(request.PriorState.GetAttr("id").AsString())
+		response.NewState = request.PlannedState
+		return
+	}
+
+	value := applyEnsureId(request.PlannedState)
+	replace, err := validateId(value, request.PriorState, store)
+	if err != nil {
+		response.Diagnostics = append(response.Diagnostics, tfdiags.Sourceless(tfdiags.Error, "testingResource error", err.Error()))
+		return
+	}
+	response.NewState = value
+
+	if replace {
+		store.Delete(request.PriorState.GetAttr("id").AsString())
+	}
+	store.Set(response.NewState.GetAttr("id").AsString(), response.NewState)
+	return
+}
+
 func validateId(target cty.Value, prior cty.Value, store *ResourceStore) (bool, error) {
 	if prior.IsNull() {
 		// Then we're creating a resource, we want to make sure we're not
@@ -366,6 +423,15 @@ func setKnown(value cty.Value, attr string, attrValue cty.Value) cty.Value {
 	if v := value.GetAttr(attr); !v.IsKnown() {
 		vals := value.AsValueMap()
 		vals[attr] = attrValue
+		return cty.ObjectVal(vals)
+	}
+	return value
+}
+
+func setNull(value cty.Value, attr string) cty.Value {
+	if v := value.GetAttr(attr); !v.IsKnown() {
+		vals := value.AsValueMap()
+		vals[attr] = cty.NullVal(v.Type())
 		return cty.ObjectVal(vals)
 	}
 	return value

--- a/internal/stacks/stackruntime/testing/resource.go
+++ b/internal/stacks/stackruntime/testing/resource.go
@@ -328,7 +328,7 @@ func (w *writeOnlyResource) Read(request providers.ReadResourceRequest, store *R
 	var exists bool
 	response.NewState, exists = store.Get(id)
 	if !exists {
-		response.NewState = cty.NullVal(WriteOnlyResourceSchema.Body.ImpliedType())
+		response.NewState = cty.NullVal(WriteOnlyResourceSchema.ImpliedType())
 	}
 	return
 }

--- a/internal/terraform/node_resource_abstract_instance.go
+++ b/internal/terraform/node_resource_abstract_instance.go
@@ -920,14 +920,14 @@ func (n *NodeAbstractResourceInstance) plan(
 				ComputedAsUnknown: !n.override.UseForPlan,
 			}, schema)
 			resp = providers.PlanResourceChangeResponse{
-				PlannedState: ephemeral.StripWriteOnlyAttributes(override, schema.Body),
+				PlannedState: ephemeral.StripWriteOnlyAttributes(override, schema),
 				Diagnostics:  overrideDiags,
 			}
 		} else {
 			// This is an update operation, and we don't actually have any
 			// computed values that need to be applied.
 			resp = providers.PlanResourceChangeResponse{
-				PlannedState: ephemeral.StripWriteOnlyAttributes(proposedNewVal, schema.Body),
+				PlannedState: ephemeral.StripWriteOnlyAttributes(proposedNewVal, schema),
 			}
 		}
 	} else {
@@ -1116,7 +1116,7 @@ func (n *NodeAbstractResourceInstance) plan(
 				ComputedAsUnknown: !n.override.UseForPlan,
 			}, schema)
 			resp = providers.PlanResourceChangeResponse{
-				PlannedState: ephemeral.StripWriteOnlyAttributes(override, schema.Body),
+				PlannedState: ephemeral.StripWriteOnlyAttributes(override, schema),
 				Diagnostics:  overrideDiags,
 			}
 		} else {
@@ -1591,7 +1591,7 @@ func (n *NodeAbstractResourceInstance) readDataSource(ctx EvalContext, configVal
 			ComputedAsUnknown: false,
 		}, schema)
 		resp = providers.ReadDataSourceResponse{
-			State:       ephemeral.StripWriteOnlyAttributes(override, schema.Body),
+			State:       ephemeral.StripWriteOnlyAttributes(override, schema),
 			Diagnostics: overrideDiags,
 		}
 	} else {

--- a/internal/terraform/node_resource_abstract_instance.go
+++ b/internal/terraform/node_resource_abstract_instance.go
@@ -920,14 +920,14 @@ func (n *NodeAbstractResourceInstance) plan(
 				ComputedAsUnknown: !n.override.UseForPlan,
 			}, schema)
 			resp = providers.PlanResourceChangeResponse{
-				PlannedState: override,
+				PlannedState: ephemeral.StripWriteOnlyAttributes(override, schema.Body),
 				Diagnostics:  overrideDiags,
 			}
 		} else {
 			// This is an update operation, and we don't actually have any
 			// computed values that need to be applied.
 			resp = providers.PlanResourceChangeResponse{
-				PlannedState: proposedNewVal,
+				PlannedState: ephemeral.StripWriteOnlyAttributes(proposedNewVal, schema.Body),
 			}
 		}
 	} else {
@@ -1116,7 +1116,7 @@ func (n *NodeAbstractResourceInstance) plan(
 				ComputedAsUnknown: !n.override.UseForPlan,
 			}, schema)
 			resp = providers.PlanResourceChangeResponse{
-				PlannedState: override,
+				PlannedState: ephemeral.StripWriteOnlyAttributes(override, schema.Body),
 				Diagnostics:  overrideDiags,
 			}
 		} else {
@@ -1591,7 +1591,7 @@ func (n *NodeAbstractResourceInstance) readDataSource(ctx EvalContext, configVal
 			ComputedAsUnknown: false,
 		}, schema)
 		resp = providers.ReadDataSourceResponse{
-			State:       override,
+			State:       ephemeral.StripWriteOnlyAttributes(override, schema.Body),
 			Diagnostics: overrideDiags,
 		}
 	} else {

--- a/internal/terraform/node_resource_plan_instance.go
+++ b/internal/terraform/node_resource_plan_instance.go
@@ -643,7 +643,7 @@ func (n *NodePlannableResourceInstance) importState(ctx EvalContext, addr addrs.
 			ImportedResources: []providers.ImportedResource{
 				{
 					TypeName: addr.Resource.Resource.Type,
-					State:    ephemeral.StripWriteOnlyAttributes(override, schema.Body),
+					State:    ephemeral.StripWriteOnlyAttributes(override, schema),
 				},
 			},
 			Diagnostics: overrideDiags.InConfigBody(n.Config.Config, absAddr.String()),

--- a/internal/terraform/node_resource_plan_instance.go
+++ b/internal/terraform/node_resource_plan_instance.go
@@ -643,7 +643,7 @@ func (n *NodePlannableResourceInstance) importState(ctx EvalContext, addr addrs.
 			ImportedResources: []providers.ImportedResource{
 				{
 					TypeName: addr.Resource.Resource.Type,
-					State:    override,
+					State:    ephemeral.StripWriteOnlyAttributes(override, schema.Body),
 				},
 			},
 			Diagnostics: overrideDiags.InConfigBody(n.Config.Config, absAddr.String()),


### PR DESCRIPTION
Manual backport of https://github.com/hashicorp/terraform/pull/36824

Automatic backport failed in https://github.com/hashicorp/terraform/pull/36826