### PR TITLE
Fix non-user facing bugs where appended diags are not returned in `terraform` provider

### DIFF
--- a/internal/builtin/providers/terraform/provider.go
+++ b/internal/builtin/providers/terraform/provider.go
@@ -103,7 +103,7 @@ func (p *Provider) ValidateDataResourceConfig(req providers.ValidateDataResource
 
 	// This should not happen
 	if req.TypeName != "terraform_remote_state" {
-		res.Diagnostics.Append(fmt.Errorf("Error: unsupported data source %s", req.TypeName))
+		res.Diagnostics = res.Diagnostics.Append(fmt.Errorf("Error: unsupported data source %s", req.TypeName))
 		return res
 	}
 
@@ -128,7 +128,7 @@ func (p *Provider) ReadDataSource(req providers.ReadDataSourceRequest) providers
 
 	// This should not happen
 	if req.TypeName != "terraform_remote_state" {
-		res.Diagnostics.Append(fmt.Errorf("Error: unsupported data source %s", req.TypeName))
+		res.Diagnostics = res.Diagnostics.Append(fmt.Errorf("Error: unsupported data source %s", req.TypeName))
 		return res
 	}
 
@@ -210,28 +210,28 @@ func (p *Provider) ValidateResourceConfig(req providers.ValidateResourceConfigRe
 
 func (p *Provider) ValidateEphemeralResourceConfig(req providers.ValidateEphemeralResourceConfigRequest) providers.ValidateEphemeralResourceConfigResponse {
 	var resp providers.ValidateEphemeralResourceConfigResponse
-	resp.Diagnostics.Append(fmt.Errorf("unsupported ephemeral resource type %q", req.TypeName))
+	resp.Diagnostics = resp.Diagnostics.Append(fmt.Errorf("unsupported ephemeral resource type %q", req.TypeName))
 	return resp
 }
 
 // OpenEphemeralResource implements providers.Interface.
 func (p *Provider) OpenEphemeralResource(req providers.OpenEphemeralResourceRequest) providers.OpenEphemeralResourceResponse {
 	var resp providers.OpenEphemeralResourceResponse
-	resp.Diagnostics.Append(fmt.Errorf("unsupported ephemeral resource type %q", req.TypeName))
+	resp.Diagnostics = resp.Diagnostics.Append(fmt.Errorf("unsupported ephemeral resource type %q", req.TypeName))
 	return resp
 }
 
 // RenewEphemeralResource implements providers.Interface.
 func (p *Provider) RenewEphemeralResource(req providers.RenewEphemeralResourceRequest) providers.RenewEphemeralResourceResponse {
 	var resp providers.RenewEphemeralResourceResponse
-	resp.Diagnostics.Append(fmt.Errorf("unsupported ephemeral resource type %q", req.TypeName))
+	resp.Diagnostics = resp.Diagnostics.Append(fmt.Errorf("unsupported ephemeral resource type %q", req.TypeName))
 	return resp
 }
 
 // CloseEphemeralResource implements providers.Interface.
 func (p *Provider) CloseEphemeralResource(req providers.CloseEphemeralResourceRequest) providers.CloseEphemeralResourceResponse {
 	var resp providers.CloseEphemeralResourceResponse
-	resp.Diagnostics.Append(fmt.Errorf("unsupported ephemeral resource type %q", req.TypeName))
+	resp.Diagnostics = resp.Diagnostics.Append(fmt.Errorf("unsupported ephemeral resource type %q", req.TypeName))
 	return resp
 }
 


### PR DESCRIPTION
These 'bugs' are not user facing, as any invalid managed resource/data resource/ephemeral resource are caught due to that resource type not being present in the provider schema ([for example, here](https://github.com/hashicorp/terraform/blob/87cdcc350e9ba1e764898d9f0ec29644775bbe9b/internal/terraform/node_resource_ephemeral.go#L43-L52)).

However this code is wrong- the Append method doesn't mutate the Diagnostics collection. The returned value always needs to be assigned back to where the collection is stored.

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.13.x

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
