### PR TITLE
Remove paragraph that logical operators do not short-circuit for 1.12

### DIFF
--- a/website/docs/language/expressions/operators.mdx
+++ b/website/docs/language/expressions/operators.mdx
@@ -105,5 +105,3 @@ The logical operators all expect bool values and produce bool values as results.
 Terraform does not have an operator for the "exclusive OR" operation. If you
 know that both operators are boolean values then exclusive OR is equivalent
 to the `!=` ("not equal") operator.
-
-The logical operators in Terraform do not short-circuit, meaning `var.foo && var.foo.bar` will produce an error message if `var.foo` is `null` because both `var.foo` and `var.foo.bar` are evaluated.


### PR DESCRIPTION
I was reading the changelog for the beta1 of 1.12 and noticed this entry:

> Logical binary operators can now short-circuit

This PR removes the callout in our docs that state that this is not supported

<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Related to #36224

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.12.0
