### PR TITLE
Remove unused test fixture "push-backend-new"

### DIFF
--- a/internal/command/testdata/push-backend-new/main.tf
+++ b/internal/command/testdata/push-backend-new/main.tf
@@ -1,5 +1,0 @@
-terraform {
-  backend "inmem" {}
-}
-
-atlas { name = "hello" }


### PR DESCRIPTION
Removes a test fixture that's not referenced in any test. I found this while investigating usage of the `inmem` backend

Also, the `atlas` block suggests it's been outdated for a while!

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.13.x

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
