### PR TITLE
Fix defects where `done` is called before the command's `Run` method is invoked

### DIFF
--- a/internal/command/test_test.go
+++ b/internal/command/test_test.go
@@ -1494,9 +1494,8 @@ func TestTest_ModuleDependencies(t *testing.T) {
 		Meta: meta,
 	}
 
-	output := done(t)
-
 	if code := init.Run(nil); code != 0 {
+		output := done(t)
 		t.Fatalf("expected status code 0 but got %d: %s", code, output.All())
 	}
 
@@ -1510,7 +1509,7 @@ func TestTest_ModuleDependencies(t *testing.T) {
 	}
 
 	code := command.Run(nil)
-	output = done(t)
+	output := done(t)
 
 	printedOutput := false
 
@@ -1935,9 +1934,8 @@ func TestTest_StatePropagation(t *testing.T) {
 		Meta: meta,
 	}
 
-	output := done(t)
-
 	if code := init.Run(nil); code != 0 {
+		output := done(t)
 		t.Fatalf("expected status code 0 but got %d: %s", code, output.All())
 	}
 
@@ -1951,7 +1949,7 @@ func TestTest_StatePropagation(t *testing.T) {
 	}
 
 	code := c.Run([]string{"-verbose", "-no-color"})
-	output = done(t)
+	output := done(t)
 
 	if code != 0 {
 		t.Errorf("expected status code 0 but got %d", code)
@@ -2075,9 +2073,8 @@ func TestTest_OnlyExternalModules(t *testing.T) {
 		Meta: meta,
 	}
 
-	output := done(t)
-
 	if code := init.Run(nil); code != 0 {
+		output := done(t)
 		t.Fatalf("expected status code 0 but got %d: %s", code, output.All())
 	}
 
@@ -2091,7 +2088,7 @@ func TestTest_OnlyExternalModules(t *testing.T) {
 	}
 
 	code := c.Run([]string{"-no-color"})
-	output = done(t)
+	output := done(t)
 
 	if code != 0 {
 		t.Errorf("expected status code 0 but got %d", code)
@@ -2211,9 +2208,8 @@ func TestTest_InvalidWarningsInCleanup(t *testing.T) {
 		Meta: meta,
 	}
 
-	output := done(t)
-
 	if code := init.Run(nil); code != 0 {
+		output := done(t)
 		t.Fatalf("expected status code 0 but got %d: %s", code, output.All())
 	}
 
@@ -2227,7 +2223,7 @@ func TestTest_InvalidWarningsInCleanup(t *testing.T) {
 	}
 
 	code := c.Run([]string{"-no-color"})
-	output = done(t)
+	output := done(t)
 
 	if code != 0 {
 		t.Errorf("expected status code 0 but got %d", code)
@@ -2810,9 +2806,8 @@ func TestTest_SensitiveInputValues(t *testing.T) {
 		Meta: meta,
 	}
 
-	output := done(t)
-
 	if code := init.Run(nil); code != 0 {
+		output := done(t)
 		t.Fatalf("expected status code 0 but got %d: %s", code, output.All())
 	}
 
@@ -2826,7 +2821,7 @@ func TestTest_SensitiveInputValues(t *testing.T) {
 	}
 
 	code := c.Run([]string{"-no-color", "-verbose"})
-	output = done(t)
+	output := done(t)
 
 	if code != 1 {
 		t.Errorf("expected status code 1 but got %d", code)
@@ -3088,9 +3083,8 @@ func TestTest_InvalidOverrides(t *testing.T) {
 		Meta: meta,
 	}
 
-	output := done(t)
-
 	if code := init.Run(nil); code != 0 {
+		output := done(t)
 		t.Fatalf("expected status code 0 but got %d: %s", code, output.All())
 	}
 
@@ -3104,7 +3098,7 @@ func TestTest_InvalidOverrides(t *testing.T) {
 	}
 
 	code := c.Run([]string{"-no-color"})
-	output = done(t)
+	output := done(t)
 
 	if code != 0 {
 		t.Errorf("expected status code 0 but got %d", code)
@@ -3188,9 +3182,8 @@ func TestTest_InvalidConfig(t *testing.T) {
 		Meta: meta,
 	}
 
-	output := done(t)
-
 	if code := init.Run(nil); code != 0 {
+		output := done(t)
 		t.Fatalf("expected status code 0 but got %d: %s", code, output.All())
 	}
 
@@ -3204,7 +3197,7 @@ func TestTest_InvalidConfig(t *testing.T) {
 	}
 
 	code := c.Run([]string{"-no-color"})
-	output = done(t)
+	output := done(t)
 
 	if code != 1 {
 		t.Errorf("expected status code ! but got %d", code)
@@ -3271,9 +3264,8 @@ func TestTest_RunBlocksInProviders(t *testing.T) {
 		Meta: meta,
 	}
 
-	output := done(t)
-
 	if code := init.Run(nil); code != 0 {
+		output := done(t)
 		t.Fatalf("expected status code 0 but got %d: %s", code, output.All())
 	}
 
@@ -3287,7 +3279,7 @@ func TestTest_RunBlocksInProviders(t *testing.T) {
 	}
 
 	code := test.Run([]string{"-no-color"})
-	output = done(t)
+	output := done(t)
 
 	if code != 0 {
 		t.Errorf("expected status code 0 but got %d", code)
@@ -3339,9 +3331,8 @@ func TestTest_RunBlocksInProviders_BadReferences(t *testing.T) {
 		Meta: meta,
 	}
 
-	output := done(t)
-
 	if code := init.Run(nil); code != 0 {
+		output := done(t)
 		t.Fatalf("expected status code 0 but got %d: %s", code, output.All())
 	}
 
@@ -3355,7 +3346,7 @@ func TestTest_RunBlocksInProviders_BadReferences(t *testing.T) {
 	}
 
 	code := test.Run([]string{"-no-color"})
-	output = done(t)
+	output := done(t)
 
 	if code != 1 {
 		t.Errorf("expected status code 1 but got %d", code)

--- a/internal/command/test_test.go
+++ b/internal/command/test_test.go
@@ -1811,9 +1811,8 @@ can remove the provider configuration again.
 				Meta: meta,
 			}
 
-			output := done(t)
-
 			if code := init.Run(nil); code != 0 {
+				output := done(t)
 				t.Fatalf("expected status code 0 but got %d: %s", code, output.All())
 			}
 
@@ -1827,7 +1826,7 @@ can remove the provider configuration again.
 			}
 
 			code := c.Run([]string{"-no-color"})
-			output = done(t)
+			output := done(t)
 
 			if code != 1 {
 				t.Errorf("expected status code 1 but got %d", code)


### PR DESCRIPTION
The `done` method reads data from stderr and stdout and can be used for assertions or logging. Here, the code was previously collecting data from stderr&stdout before the init commands were run.

Looks like this was being propagated through copy-pasting tests to make new ones, and the impact wasn't obvious as the tests were not asserting about the output from the init command.

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.13.x

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
