### PR TITLE
test: Add `File` value to initial `TestFileState` structs

### DIFF
--- a/internal/moduletest/graph/transform_state.go
+++ b/internal/moduletest/graph/transform_state.go
@@ -97,6 +97,7 @@ func (t *TestStateTransformer) Transform(g *terraform.Graph) error {
 
 				log.Printf("[TRACE] TestConfigTransformer.Transform: set initial state for state key %q using backend of type %T declared at %s", key, be, bc.Backend.DeclRange)
 				state = &TestFileState{
+					File:  t.File,
 					Run:   nil,
 					State: stmgr.State(),
 					backend: runBackend{
@@ -118,6 +119,7 @@ func (t *TestStateTransformer) Transform(g *terraform.Graph) error {
 				// We set an empty in-memory state for the state key if no backend is used.
 				log.Printf("[TRACE] TestConfigTransformer.Transform: set initial state for state key %q as empty state", key)
 				state = &TestFileState{
+					File:  t.File,
 					Run:   nil,
 					State: states.NewState(),
 				}


### PR DESCRIPTION
When working on another PR (https://github.com/hashicorp/terraform/pull/36848) I sometimes hit nil pointer errors when iterating on my tests, due to `File` not being set. Eventually the tests I wrote didn't need these `File` values to be set for them to pass, so I pulled them out into this separate PR for discussion.