### PR TITLE
Add comments about use of ResourceStores with TestProviders

### DIFF
--- a/internal/command/testing/test_provider.go
+++ b/internal/command/testing/test_provider.go
@@ -105,6 +105,13 @@ type TestProvider struct {
 	Store *ResourceStore
 }
 
+// NewProvider creates a new TestProvider for use in tests.
+//
+// If you provide an empty or nil *ResourceStore argument this is equivalent to the provider
+// not having provisioned any remote objects prior to the test's events.
+//
+// If you provide a *ResourceStore containing values, those cty.Values represent remote objects
+// that the provider has 'already' provisioned and can return information about immediately in a test.
 func NewProvider(store *ResourceStore) *TestProvider {
 	if store == nil {
 		store = &ResourceStore{
@@ -381,6 +388,10 @@ func (provider *TestProvider) CloseEphemeralResource(providers.CloseEphemeralRes
 
 // ResourceStore manages a set of cty.Value resources that can be shared between
 // TestProvider providers.
+//
+// A ResourceStore represents the remote objects that a test provider is managing.
+// For example, when the test provider gets a ReadResource request it will search
+// the store for a resource with a matching ID. See (*TestProvider).ReadResource.
 type ResourceStore struct {
 	mutex sync.RWMutex
 


### PR DESCRIPTION
I was wrestling with a test failing and I didn't realise it was because my test assumed a remote-object already existed and was readable by this test provider. Eventually I realised that using a ResourceStore would solve my problem.

The existing comments didn't call out that those resources represent pre-existing remote objects, so figured I'd add some to help discovery. 

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.13.x

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
