### PR TITLE
Add validation to enforce skip_cleanup=false cannot be used with backends

### DIFF
--- a/internal/command/testdata/test/backend-with-skip-cleanup/false/main.tf
+++ b/internal/command/testdata/test/backend-with-skip-cleanup/false/main.tf
@@ -1,0 +1,4 @@
+resource "test_resource" "a" {
+  id    = "12345"
+  value = "foobar"
+}

--- a/internal/command/testdata/test/backend-with-skip-cleanup/false/main.tftest.hcl
+++ b/internal/command/testdata/test/backend-with-skip-cleanup/false/main.tftest.hcl
@@ -1,0 +1,4 @@
+run "test" {
+  backend "local" {}
+  skip_cleanup = false
+}

--- a/internal/command/testdata/test/backend-with-skip-cleanup/true/main.tf
+++ b/internal/command/testdata/test/backend-with-skip-cleanup/true/main.tf
@@ -1,0 +1,4 @@
+resource "test_resource" "a" {
+  id    = "12345"
+  value = "foobar"
+}

--- a/internal/command/testdata/test/backend-with-skip-cleanup/true/main.tftest.hcl
+++ b/internal/command/testdata/test/backend-with-skip-cleanup/true/main.tftest.hcl
@@ -1,0 +1,4 @@
+run "test" {
+  backend "local" {}
+  skip_cleanup = true
+}

--- a/internal/configs/test_file.go
+++ b/internal/configs/test_file.go
@@ -841,6 +841,16 @@ func decodeTestRunBlock(block *hcl.Block, file *TestFile) (*TestRun, hcl.Diagnos
 		r.SkipCleanupSet = true
 	}
 
+	if r.SkipCleanupSet && !r.SkipCleanup && r.Backend != nil {
+		// Stop user attempting to clean up long-lived resources
+		diags = append(diags, &hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  "Cannot use `skip_cleanup=false` in a run block that contains a backend block",
+			Detail:   "Backend blocks are used in tests to allow reuse of long-lived resources. Due to this, cleanup behavior is implicitly skipped and backend blocks are incompatible with setting `skip_cleanup=false`",
+			Subject:  backendRange.Ptr(),
+		})
+	}
+
 	return &r, diags
 }
 


### PR DESCRIPTION
(Work split out of https://github.com/hashicorp/terraform/pull/36848)

This PR:

* Adds validation to stop users setting `skip_cleanup=false` in a run block with a `backend` block
    * This is because using a backend block implies  `skip_cleanup=true`
    * _We could pivot to making `backend` and `skip_cleanup` mutually exclusive?_
* Adds tests for that validation, and also to show it's ok to set `skip_cleanup=true` in a run block with a `backend` block