### PR TITLE
Replace sc with Set-Content

### DIFF
--- a/website/docs/cli/commands/state/pull.mdx
+++ b/website/docs/cli/commands/state/pull.mdx
@@ -24,4 +24,4 @@ You cannot use this command to inspect the Terraform version of
 the remote state, as it will always be converted to the current Terraform
 version before output.
 
--> **Note:** Terraform state files must be in UTF-8 format without a byte order mark (BOM). For PowerShell on Windows, use `Set-Content` to automatically encode files in UTF-8 format. For example, run `terraform state pull | sc terraform.tfstate`.
+-> **Note:** Terraform state files must be in UTF-8 format without a byte order mark (BOM). For PowerShell on Windows, use `Set-Content` to automatically encode files in UTF-8 format. For example, run `terraform state pull | Set-Content terraform.tfstate`.

--- a/website/docs/cli/commands/state/push.mdx
+++ b/website/docs/cli/commands/state/push.mdx
@@ -18,7 +18,7 @@ If PATH is "-" then the state data to push is read from stdin. This data
 is loaded completely into memory and verified prior to being written to
 the destination state.
 
--> **Note:** Terraform state files must be in UTF-8 format without a byte order mark (BOM). For PowerShell on Windows, use `Set-Content` to automatically encode files in UTF-8 format. For example, run `terraform state push | sc terraform.tfstate`.
+-> **Note:** Terraform state files must be in UTF-8 format without a byte order mark (BOM). For PowerShell on Windows, use `Set-Content` to automatically encode files in UTF-8 format. For example, run `terraform state push | Set-Content terraform.tfstate`.
 
 Terraform will perform a number of safety checks to prevent you from
 making changes that appear to be unsafe:


### PR DESCRIPTION
To avoid conflicts with sc.exe ([service control manager](https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/sc-create)), full `Set-Content` command should be used instead of short alias `sc`.