### PR TITLE
CODEOWNERS: Set tf-core-cloud as owner of Cloud backend

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -24,8 +24,8 @@
 /internal/backend/remote-state/kubernetes        @hashicorp/terraform-core @hashicorp/tf-eco-hybrid-cloud
 
 # Cloud backend
-/internal/backend/remote    @hashicorp/tf-core-cloud
-/internal/cloud             @hashicorp/tf-core-cloud
+/internal/backend/remote    @hashicorp/terraform-core @hashicorp/tf-core-cloud
+/internal/cloud             @hashicorp/terraform-core @hashicorp/tf-core-cloud
 
 # Provisioners
 builtin/provisioners/file               @hashicorp/terraform-core

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -23,6 +23,10 @@
 /internal/backend/remote-state/s3                @hashicorp/terraform-core @hashicorp/terraform-aws
 /internal/backend/remote-state/kubernetes        @hashicorp/terraform-core @hashicorp/tf-eco-hybrid-cloud
 
+# Cloud backend
+/internal/backend/remote    @hashicorp/tf-core-cloud
+/internal/cloud             @hashicorp/tf-core-cloud
+
 # Provisioners
 builtin/provisioners/file               @hashicorp/terraform-core
 builtin/provisioners/local-exec         @hashicorp/terraform-core


### PR DESCRIPTION
I believe this mostly just reflects existing practice/reality. Please do correct me if I'm wrong.

Context: I came across [a few older PRs](https://github.com/hashicorp/terraform/pulls?q=is%3Aopen+is%3Apr+label%3Abackend%2Fremote) which touched the Cloud backend in one way or another and thought that auto-assignment of reviewers would reduce the chance of such stale PRs in the future and reduce the need for manual triage.
