### PR TITLE
Fix import with optional identity attributes

### DIFF
--- a/internal/configs/configschema/implied_type.go
+++ b/internal/configs/configschema/implied_type.go
@@ -107,6 +107,14 @@ func (o *Object) ImpliedType() cty.Type {
 	return o.specType().WithoutOptionalAttributesDeep()
 }
 
+// ConfigType returns a cty.Type that can be used to decode a configuration
+// object using the receiving block schema.
+//
+// ConfigType will preserve optional attributes
+func (o *Object) ConfigType() cty.Type {
+	return o.specType()
+}
+
 // specType returns the cty.Type used for decoding a NestedType Attribute using
 // the receiving block schema.
 func (o *Object) specType() cty.Type {

--- a/internal/terraform/context_plan_import_test.go
+++ b/internal/terraform/context_plan_import_test.go
@@ -1961,6 +1961,9 @@ func TestContext2Plan_importIdentityModule(t *testing.T) {
 				State: cty.ObjectVal(map[string]cty.Value{
 					"id": cty.StringVal("foo"),
 				}),
+				Identity: cty.ObjectVal(map[string]cty.Value{
+					"name": cty.StringVal("bar"),
+				}),
 			},
 		},
 	}
@@ -2137,4 +2140,80 @@ import {
 			t.Errorf("expected non-import change, got import change %#v", instPlan.Importing)
 		}
 	})
+}
+
+func TestContext2Plan_importIdentityModuleWithOptional(t *testing.T) {
+	p := testProvider("aws")
+	m := testModule(t, "import-identity-module")
+
+	p.GetProviderSchemaResponse = getProviderSchemaResponseFromProviderSchema(&providerSchema{
+		ResourceTypes: map[string]*configschema.Block{
+			"aws_lb": {
+				Attributes: map[string]*configschema.Attribute{
+					"id": {
+						Type:     cty.String,
+						Computed: true,
+					},
+				},
+			},
+		},
+		IdentityTypes: map[string]*configschema.Object{
+			"aws_lb": {
+				Attributes: map[string]*configschema.Attribute{
+					"name": {
+						Type:     cty.String,
+						Required: true,
+					},
+					"something": {
+						Type:     cty.Number,
+						Optional: true,
+					},
+				},
+				Nesting: configschema.NestingSingle,
+			},
+		},
+	})
+	wantIdentity := cty.ObjectVal(map[string]cty.Value{
+		"name":      cty.StringVal("bar"),
+		"something": cty.NumberIntVal(42),
+	})
+	p.ImportResourceStateResponse = &providers.ImportResourceStateResponse{
+		ImportedResources: []providers.ImportedResource{
+			{
+				TypeName: "aws_lb",
+				State: cty.ObjectVal(map[string]cty.Value{
+					"id": cty.StringVal("foo"),
+				}),
+				Identity: wantIdentity,
+			},
+		},
+	}
+	ctx := testContext2(t, &ContextOpts{
+		Providers: map[addrs.Provider]providers.Factory{
+			addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
+		},
+	})
+
+	diags := ctx.Validate(m, &ValidateOpts{})
+	if diags.HasErrors() {
+		t.Fatalf("unexpected errors\n%s", diags.Err().Error())
+	}
+
+	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	if diags.HasErrors() {
+		t.Fatalf("unexpected errors: %s", diags.Err())
+	}
+
+	addr := mustResourceInstanceAddr("aws_lb.foo")
+	instPlan := plan.Changes.ResourceInstance(addr)
+	if instPlan == nil {
+		t.Fatalf("no plan for %s at all", addr)
+	}
+
+	identityMatches := instPlan.Importing.Identity.Equals(wantIdentity)
+	if !identityMatches.True() {
+		t.Errorf("identity does not match\ngot:  %s\nwant: %s",
+			tfdiags.ObjectToString(instPlan.Importing.Identity),
+			tfdiags.ObjectToString(wantIdentity))
+	}
 }

--- a/internal/terraform/eval_import.go
+++ b/internal/terraform/eval_import.go
@@ -88,7 +88,7 @@ func evaluateImportIdentityExpression(expr hcl.Expression, identity *configschem
 	// that context.
 	ctx = evalContextForModuleInstance(ctx, addrs.RootModuleInstance)
 	scope := ctx.EvaluationScope(nil, nil, keyData)
-	importIdentityVal, evalDiags := scope.EvalExpr(expr, identity.ImpliedType())
+	importIdentityVal, evalDiags := scope.EvalExpr(expr, identity.ConfigType())
 	if evalDiags.HasErrors() {
 		// TODO? Do we need to improve the error message?
 		return cty.NilVal, evalDiags

--- a/internal/terraform/node_resource_plan_instance.go
+++ b/internal/terraform/node_resource_plan_instance.go
@@ -386,7 +386,15 @@ func (n *NodePlannableResourceInstance) managedResourceExecute(ctx EvalContext) 
 		}
 
 		if importing {
-			change.Importing = &plans.Importing{Target: n.importTarget}
+			// There is a subtle difference between the import by identity
+			// and the import by ID. When importing by identity, we need to
+			// make sure to use the complete identity return by the provider
+			// instead of the (potential) incomplete one from the configuration.
+			if n.importTarget.Type().IsObjectType() {
+				change.Importing = &plans.Importing{Target: instanceRefreshState.Identity}
+			} else {
+				change.Importing = &plans.Importing{Target: n.importTarget}
+			}
 		}
 
 		// FIXME: here we udpate the change to reflect the reason for

--- a/internal/tfdiags/object.go
+++ b/internal/tfdiags/object.go
@@ -34,6 +34,11 @@ func ObjectToString(obj cty.Value) string {
 				result += ","
 			}
 
+			if val.IsNull() {
+				result += fmt.Sprintf("%s=<null>", keyStr)
+				continue
+			}
+
 			switch val.Type() {
 			case cty.Bool:
 				result += fmt.Sprintf("%s=%t", keyStr, val.True())

--- a/internal/tfdiags/object_test.go
+++ b/internal/tfdiags/object_test.go
@@ -50,6 +50,14 @@ func Test_ObjectToString(t *testing.T) {
 			}),
 			expected: "list=[a,b,c],string=hello",
 		},
+		{
+			name: "with null value",
+			value: cty.ObjectVal(map[string]cty.Value{
+				"string": cty.StringVal("hello"),
+				"null":   cty.NullVal(cty.String),
+			}),
+			expected: "null=<null>,string=hello",
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
This PR addresses two issues when using optional attributes in an identity. We now correctly use the fully populated identity from the provider instead of the one from config.

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.12.x

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [ ] This change is not user-facing.
