### PR TITLE
stacks: removing embedded stacks should ignore stacks not in state

### DIFF
--- a/internal/stacks/stackplan/plan.go
+++ b/internal/stacks/stackplan/plan.go
@@ -163,6 +163,10 @@ func (p *Plan) GetComponent(addr stackaddrs.AbsComponentInstance) *Component {
 	return targetStackInstance.GetComponent(addr.Item)
 }
 
+func (p *Plan) GetStack(addr stackaddrs.StackInstance) *StackInstance {
+	return p.Root.GetDescendentStack(addr)
+}
+
 // RequiredProviderInstances returns a description of all of the provider
 // instance slots that are required to satisfy the resource instances
 // belonging to the given component instance.

--- a/internal/stacks/stackruntime/plan_test.go
+++ b/internal/stacks/stackruntime/plan_test.go
@@ -879,6 +879,42 @@ func TestPlan(t *testing.T) {
 				},
 			},
 		},
+		"removed block targets stack not in configuration or state": {
+			path: filepath.Join("with-single-input", "removed-stack-instance-dynamic"),
+			cycle: TestCycle{
+				planInputs: map[string]cty.Value{
+					"input": cty.MapValEmpty(cty.String),
+					"removed": cty.MapVal(map[string]cty.Value{
+						"component": cty.StringVal("component"),
+					}),
+				},
+				wantPlannedChanges: []stackplan.PlannedChange{
+					&stackplan.PlannedChangeApplyable{
+						Applyable: true,
+					},
+					&stackplan.PlannedChangeHeader{
+						TerraformVersion: version.SemVer,
+					},
+					&stackplan.PlannedChangePlannedTimestamp{
+						PlannedTimestamp: fakePlanTimestamp,
+					},
+					&stackplan.PlannedChangeRootInputValue{
+						Addr:   stackaddrs.InputVariable{Name: "input"},
+						Action: plans.Create,
+						Before: cty.NullVal(cty.DynamicPseudoType),
+						After:  cty.MapValEmpty(cty.String),
+					},
+					&stackplan.PlannedChangeRootInputValue{
+						Addr:   stackaddrs.InputVariable{Name: "removed"},
+						Action: plans.Create,
+						Before: cty.NullVal(cty.DynamicPseudoType),
+						After: cty.MapVal(map[string]cty.Value{
+							"component": cty.StringVal("component"),
+						}),
+					},
+				},
+			},
+		},
 	}
 	for name, tc := range tcs {
 		t.Run(name, func(t *testing.T) {

--- a/internal/stacks/stackstate/state.go
+++ b/internal/stacks/stackstate/state.go
@@ -83,6 +83,11 @@ func (s *State) HasComponentInstance(addr stackaddrs.AbsComponentInstance) bool 
 	return stack.getComponentInstance(addr.Item) != nil
 }
 
+func (s *State) HasStackInstance(addr stackaddrs.StackInstance) bool {
+	stack := s.root.getDescendent(addr)
+	return stack != nil
+}
+
 // AllComponentInstances returns a set of addresses for all of the component
 // instances that are tracked in the state.
 //


### PR DESCRIPTION
This PR updates the removed_stack_call functionality so a removed block that targets a stack that has already been removed from the state does not create a new stack just to claim it is being removed.