### PR TITLE
Validate identity to match identity schema

### DIFF
--- a/internal/terraform/context_apply2_test.go
+++ b/internal/terraform/context_apply2_test.go
@@ -2224,6 +2224,7 @@ import {
 						Required: true,
 					},
 				},
+				Nesting: configschema.NestingSingle,
 			},
 		},
 	})

--- a/internal/terraform/context_plan_identity_test.go
+++ b/internal/terraform/context_plan_identity_test.go
@@ -445,6 +445,14 @@ func TestContext2Plan_resource_identity_plan(t *testing.T) {
 				tfdiags.Sourceless(tfdiags.Error, "Provider produced an identity that doesn't match the schema", "Provider \"registry.terraform.io/hashicorp/test\" returned an identity for test_resource.test that doesn't match the identity schema: .id: string required, but received bool. \n\nThis is a bug in the provider, which should be reported in the provider's own issue tracker."),
 			},
 		},
+		"create - null planned identity schema": {
+			plannedIdentity: cty.ObjectVal(map[string]cty.Value{
+				"id": cty.NullVal(cty.String),
+			}),
+			expectDiagnostics: tfdiags.Diagnostics{
+				tfdiags.Sourceless(tfdiags.Error, "Provider produced an identity that doesn't match the schema", "Provider \"registry.terraform.io/hashicorp/test\" returned an identity for test_resource.test that doesn't match the identity schema: attributes \"id\" are required and must not be null. \n\nThis is a bug in the provider, which should be reported in the provider's own issue tracker."),
+			},
+		},
 		"update": {
 			prevRunState: states.BuildState(func(s *states.SyncState) {
 				s.SetResourceInstanceCurrent(

--- a/internal/terraform/context_plan_identity_test.go
+++ b/internal/terraform/context_plan_identity_test.go
@@ -437,6 +437,14 @@ func TestContext2Plan_resource_identity_plan(t *testing.T) {
 				"id": cty.StringVal("foo"),
 			}),
 		},
+		"create - invalid planned identity schema": {
+			plannedIdentity: cty.ObjectVal(map[string]cty.Value{
+				"id": cty.BoolVal(false),
+			}),
+			expectDiagnostics: tfdiags.Diagnostics{
+				tfdiags.Sourceless(tfdiags.Error, "Provider produced an identity that doesn't match the schema", "Provider \"registry.terraform.io/hashicorp/test\" returned an identity for test_resource.test that doesn't match the identity schema: .id: string required, but received bool. \n\nThis is a bug in the provider, which should be reported in the provider's own issue tracker."),
+			},
+		},
 		"update": {
 			prevRunState: states.BuildState(func(s *states.SyncState) {
 				s.SetResourceInstanceCurrent(

--- a/internal/terraform/node_resource_abstract_instance.go
+++ b/internal/terraform/node_resource_abstract_instance.go
@@ -2969,6 +2969,26 @@ func (n *NodeAbstractResourceInstance) validateIdentityMatchesSchema(newIdentity
 				),
 			))
 		}
+		return diags
+	}
+
+	// Check for required attributes
+	names := make([]string, 0, len(identitySchema.Attributes))
+	for name, attrS := range identitySchema.Attributes {
+		if attrS.Required && newIdentity.GetAttr(name).IsNull() {
+			names = append(names, name)
+		}
+	}
+	if len(names) > 0 {
+		diags = diags.Append(tfdiags.Sourceless(
+			tfdiags.Error,
+			"Provider produced an identity that doesn't match the schema",
+			fmt.Sprintf(
+				"Provider %q returned an identity for %s that doesn't match the identity schema: attributes %q are required and must not be null. \n\nThis is a bug in the provider, which should be reported in the provider's own issue tracker.",
+				n.ResolvedProvider.Provider, n.Addr,
+				strings.Join(names, ", "),
+			),
+		))
 	}
 
 	return diags

--- a/internal/terraform/node_resource_abstract_instance.go
+++ b/internal/terraform/node_resource_abstract_instance.go
@@ -1115,11 +1115,11 @@ func (n *NodeAbstractResourceInstance) plan(
 			// If the identity is not known we can not validate it did not change
 			if !diags.HasErrors() {
 				diags = diags.Append(n.validateIdentityDidNotChange(currentState, plannedIdentity))
-				diags = diags.Append(n.validateIdentityMatchesSchema(plannedIdentity, schema.Identity))
 			}
 		}
 
 		diags = diags.Append(n.validateIdentity(plannedIdentity))
+		diags = diags.Append(n.validateIdentityMatchesSchema(plannedIdentity, schema.Identity))
 	}
 	if diags.HasErrors() {
 		return nil, nil, deferred, keyData, diags
@@ -2946,7 +2946,7 @@ func (n *NodeAbstractResourceInstance) validateIdentityMatchesSchema(newIdentity
 	currentType := identitySchema.ImpliedType()
 	if errs := newType.TestConformance(currentType); len(errs) > 0 {
 		for _, err := range errs {
-			diags = diags.Append(tfdiags.Sourceless(
+			diags = diags.AppendWithoutDuplicates(tfdiags.Sourceless(
 				tfdiags.Error,
 				"Provider produced an identity that doesn't match the schema",
 				fmt.Sprintf(


### PR DESCRIPTION
This PR adds a new validation that an provider-returned identity conforms to the identity schema.

- [x] Tests
- [x] Check if we need to validate this in other places
- [x] Do we need to check if values aren't null? Is just checking the type conformance enough? 

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.12.x

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [ ] This change is not user-facing.
