### PR TITLE
Add changelog entries for resource identities

### DIFF
--- a/.changes/v1.12/ENHANCEMENTS-20250417-182036.yaml
+++ b/.changes/v1.12/ENHANCEMENTS-20250417-182036.yaml
@@ -1,0 +1,5 @@
+kind: ENHANCEMENTS
+body: '`import` blocks: Now support importing a resource via a new identity attribute. This is mutually exclusive with the `id` attribute'
+time: 2025-04-17T18:20:36.814657+02:00
+custom:
+    Issue: "36703"

--- a/.changes/v1.12/ENHANCEMENTS-20250417-182215.yaml
+++ b/.changes/v1.12/ENHANCEMENTS-20250417-182215.yaml
@@ -1,0 +1,5 @@
+kind: ENHANCEMENTS
+body: 'core: Resource identities are stored in state alongside the existing resource values'
+time: 2025-04-17T18:22:15.263795+02:00
+custom:
+    Issue: "36464"

--- a/.changes/v1.12/ENHANCEMENTS-20250417-182215.yaml
+++ b/.changes/v1.12/ENHANCEMENTS-20250417-182215.yaml
@@ -1,5 +1,0 @@
-kind: ENHANCEMENTS
-body: 'core: Resource identities are stored in state alongside the existing resource values'
-time: 2025-04-17T18:22:15.263795+02:00
-custom:
-    Issue: "36464"


### PR DESCRIPTION
This PR adds some basic changelog entries for the resource identity work

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.12.x

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [ ] This change is not user-facing.
