### PR TITLE
Support for Pkl language via function `pkleval`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/apparentlymart/go-shquot v0.0.1
 	github.com/apparentlymart/go-userdirs v0.0.0-20200915174352-b0c018a67c13
 	github.com/apparentlymart/go-versions v1.0.2
+	github.com/apple/pkl-go v0.10.0
 	github.com/armon/circbuf v0.0.0-20190214190532-5111143e8da2
 	github.com/bgentry/speakeasy v0.1.0
 	github.com/bmatcuk/doublestar v1.1.5

--- a/go.sum
+++ b/go.sum
@@ -694,6 +694,8 @@ github.com/apparentlymart/go-userdirs v0.0.0-20200915174352-b0c018a67c13 h1:Jtue
 github.com/apparentlymart/go-userdirs v0.0.0-20200915174352-b0c018a67c13/go.mod h1:7kfpUbyCdGJ9fDRCp3fopPQi5+cKNHgTE4ZuNrO71Cw=
 github.com/apparentlymart/go-versions v1.0.2 h1:n5Gg9YvSLK8Zzpy743J7abh2jt7z7ammOQ0oTd/5oA4=
 github.com/apparentlymart/go-versions v1.0.2/go.mod h1:YF5j7IQtrOAOnsGkniupEA5bfCjzd7i14yu0shZavyM=
+github.com/apple/pkl-go v0.10.0 h1:meKk0ZlEYaS9wtJdD2RknmfJvuyiwHXaq/YV27f36qM=
+github.com/apple/pkl-go v0.10.0/go.mod h1:EDQmYVtFBok/eLI+9rT0EoBBXNtMM1THwR+rwBcAH3I=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/circbuf v0.0.0-20190214190532-5111143e8da2 h1:7Ip0wMmLHLRJdrloDxZfhMm0xrLXZS8+COSu2bXmEQs=
 github.com/armon/circbuf v0.0.0-20190214190532-5111143e8da2/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=

--- a/internal/lang/functions.go
+++ b/internal/lang/functions.go
@@ -126,6 +126,7 @@ func (s *Scope) Functions() map[string]function.Function {
 			"one":              funcs.OneFunc,
 			"parseint":         stdlib.ParseIntFunc,
 			"pathexpand":       funcs.PathExpandFunc,
+			"pkleval":          funcs.PklEvalFunc,
 			"pow":              stdlib.PowFunc,
 			"range":            stdlib.RangeFunc,
 			"regex":            stdlib.RegexFunc,

--- a/website/data/language-nav-data.json
+++ b/website/data/language-nav-data.json
@@ -643,6 +643,10 @@
             "href": "/language/functions/jsonencode"
           },
           {
+            "title": "<code>pkleval</code>",
+            "href": "/language/functions/pkleval"
+          },
+          {
             "title": "<code>textdecodebase64</code>",
             "href": "/language/functions/textdecodebase64"
           },
@@ -972,6 +976,7 @@
       },
       { "title": "one", "path": "functions/one", "hidden": true },
       { "title": "parseint", "path": "functions/parseint", "hidden": true },
+      { "title": "pkleval", "path": "functions/pkleval", "hidden": true },
       { "title": "pathexpand", "path": "functions/pathexpand", "hidden": true },
       { "title": "plantimestamp", "path": "functions/plantimestamp", "hidden": true },
       { "title": "pow", "path": "functions/pow", "hidden": true },

--- a/website/docs/language/functions/pkleval.mdx
+++ b/website/docs/language/functions/pkleval.mdx
@@ -1,0 +1,61 @@
+---
+page_title: pkleval - Functions - Configuration Language
+description: The pkleval function evaluates a given value with pkl and returns the resulting json string.
+---
+
+# `pkleval` Function
+
+`pkleval` evaluates a given value to a json string using the
+[Pkl](https://pkl-lang.org/main/current/language-reference/index.html) language syntax.
+
+The output of this function can be used together with
+[`jsondecode`](/terraform/language/functions/jsondecode).
+
+## Examples
+
+```pkl
+# zoo.pkl
+module zoo
+
+class Animal {
+  name: String
+  species: String
+  age: Int
+}
+
+animals {
+  new Animal {
+    name = "Simba"
+    species = "Lion"
+    age = 5
+  }
+  new Animal {
+    name = "Rafiki"
+    species = "Mandrill"
+    age = 10
+  }
+}
+```
+
+```
+> pkleval(file("zoo.pkl"))
+{
+  "animals": [
+    {
+      "name": "Simba",
+      "species": "Lion",
+      "age": 5
+    },
+    {
+      "name": "Rafiki",
+      "species": "Mandrill",
+      "age": 10
+    }
+  ]
+}
+```
+
+## Related Functions
+
+- [`jsondecode`](/terraform/language/functions/jsondecode) can be used to convert
+  pkleval output to Terraform objects/types.


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

This PR adds a new function for parsing/evaluating Pkl files (https://pkl-lang.org/main/current/language-reference/index.html). The function generates JSON files, which can be parsed by the existing function `jsondecode`.



## Example:

```pkl
# Example Pkl file "zoo.pkl"
module zoo

class Animal {
  name: String
  species: String
  age: Int
}

animals {
  new Animal {
    name = "Simba"
    species = "Lion"
    age = 5
  }
  new Animal {
    name = "Rafiki"
    species = "Mandrill"
    age = 10
  }
}
```

```terraform
locals {
  file = file("${path.module}/zoo.pkl")
  zoo  = jsondecode(pkleval(local.file))
}

resource "terraform_data" "zoo" {
  for_each = {
    for animal in local.zoo.animals : animal.name => animal
  }
  input = each.value
}
```

```
Terraform used the selected providers to generate the following execution plan. Resource
actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # terraform_data.zoo["Rafiki"] will be created
  + resource "terraform_data" "zoo" {
      + id     = (known after apply)
      + input  = {
          + age     = 10
          + name    = "Rafiki"
          + species = "Mandrill"
        }
      + output = (known after apply)
    }

  # terraform_data.zoo["Simba"] will be created
  + resource "terraform_data" "zoo" {
      + id     = (known after apply)
      + input  = {
          + age     = 5
          + name    = "Simba"
          + species = "Lion"
        }
      + output = (known after apply)
    }

Plan: 2 to add, 0 to change, 0 to destroy.

──────────────────────────────────────────────────────────────────────────────────────────────

Note: You didn't use the -out option to save this plan, so Terraform can't guarantee to take
exactly these actions if you run "terraform apply" now.
```

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.13.x

## CHANGELOG entry

NEW FEATURES

* Add a new encoding function for evaluating [Pkl](https://pkl-lang.org/main/current/language-reference/index.html) files: `pkleval()`

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [x] This change is user-facing and I added a changelog entry.
- [ ] This change is not user-facing.
