### PR TITLE
update cidr in variable networks 

### DIFF
--- a/.changes/v1.13/update-cidrblock.yaml
+++ b/.changes/v1.13/update-cidrblock.yaml
@@ -1,0 +1,4 @@
+---
+changes:
+  - description: "update cidrblock in website/docs/language/functions/flatten.mdx."
+    type: bugfix

--- a/.changes/v1.13/update-cidrblock.yaml
+++ b/.changes/v1.13/update-cidrblock.yaml
@@ -1,4 +1,0 @@
----
-changes:
-  - description: "update cidrblock in website/docs/language/functions/flatten.mdx."
-    type: bugfix


### PR DESCRIPTION
<!--
i face the following error when run terraform plan:

│ Error: expected cidr_block to contain a valid network Value, expected 10.1.0.0/16, got 10.1.2.0/16
│ 
│   with aws_vpc.example["dmz"],
│   on main.tf line 47, in resource "aws_vpc" "example":
│   47:   cidr_block = each.value.cidr_block
│ 
╵
╷
│ Error: expected cidr_block to contain a valid network Value, expected 10.1.0.0/16, got 10.1.1.0/16
│ 
│   with aws_vpc.example["public"],
│   on main.tf line 47, in resource "aws_vpc" "example":
│   47:   cidr_block = each.value.cidr_block

-->

<!--
n/a

-->

Fixes #

## Target Release

<!--
n/a

-->

1.13.x

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [x] This change is user-facing and I added a changelog entry. not sure how to do that. 
- [ ] This change is not user-facing.
