### PR TITLE
stacks: improve test coverage for removed blocks

### DIFF
--- a/internal/stacks/stackruntime/apply_test.go
+++ b/internal/stacks/stackruntime/apply_test.go
@@ -1119,6 +1119,10 @@ func TestApply(t *testing.T) {
 								"removed": cty.StringVal("removed"),
 							}),
 						},
+						&stackstate.AppliedChangeInputVariable{
+							Addr:  mustStackInputVariable("removed-direct"),
+							Value: cty.SetValEmpty(cty.String),
+						},
 					},
 				},
 			},

--- a/internal/stacks/stackruntime/internal/stackeval/component.go
+++ b/internal/stacks/stackruntime/internal/stackeval/component.go
@@ -6,6 +6,7 @@ package stackeval
 import (
 	"context"
 	"fmt"
+	"sync"
 
 	"github.com/zclconf/go-cty/cty"
 
@@ -27,9 +28,11 @@ type Component struct {
 	stack  *Stack
 	config *ComponentConfig
 
-	forEachValue    perEvalPhase[promising.Once[withDiagnostics[cty.Value]]]
-	instances       perEvalPhase[promising.Once[withDiagnostics[instancesResult[*ComponentInstance]]]]
-	unknownInstance perEvalPhase[promising.Once[*ComponentInstance]]
+	forEachValue perEvalPhase[promising.Once[withDiagnostics[cty.Value]]]
+	instances    perEvalPhase[promising.Once[withDiagnostics[instancesResult[*ComponentInstance]]]]
+
+	unknownInstancesMutex sync.Mutex
+	unknownInstances      map[addrs.InstanceKey]*ComponentInstance
 }
 
 var _ Plannable = (*Component)(nil)
@@ -38,10 +41,11 @@ var _ Referenceable = (*Component)(nil)
 
 func newComponent(main *Main, addr stackaddrs.AbsComponent, stack *Stack, config *ComponentConfig) *Component {
 	return &Component{
-		addr:   addr,
-		main:   main,
-		stack:  stack,
-		config: config,
+		addr:             addr,
+		main:             main,
+		stack:            stack,
+		config:           config,
+		unknownInstances: make(map[addrs.InstanceKey]*ComponentInstance),
 	}
 }
 
@@ -164,15 +168,22 @@ func (c *Component) CheckInstances(ctx context.Context, phase EvalPhase) (map[ad
 	return result.insts, result.unknown, diags
 }
 
-func (c *Component) UnknownInstance(ctx context.Context, phase EvalPhase) *ComponentInstance {
-	inst, err := c.unknownInstance.For(phase).Do(ctx, c.tracingName()+" unknown instance", func(ctx context.Context) (*ComponentInstance, error) {
-		return newComponentInstance(c, stackaddrs.AbsComponentToInstance(c.addr, addrs.WildcardKey), instances.UnknownForEachRepetitionData(c.ForEachValue(ctx, phase).Type()), c.stack.mode, true), nil
-	})
-	if err != nil {
-		// Since we never return an error from the function we pass to Do,
-		// this should never happen.
-		panic(err)
+func (c *Component) UnknownInstance(ctx context.Context, key addrs.InstanceKey, phase EvalPhase) *ComponentInstance {
+	c.unknownInstancesMutex.Lock()
+	defer c.unknownInstancesMutex.Unlock()
+
+	if inst, ok := c.unknownInstances[key]; ok {
+		return inst
 	}
+
+	forEachType := c.ForEachValue(ctx, phase).Type()
+	repetitionData := instances.UnknownForEachRepetitionData(forEachType)
+	if key != addrs.WildcardKey {
+		repetitionData.EachKey = key.Value()
+	}
+
+	inst := newComponentInstance(c, stackaddrs.AbsComponentToInstance(c.addr, key), repetitionData, c.stack.mode, true)
+	c.unknownInstances[key] = inst
 	return inst
 }
 

--- a/internal/stacks/stackruntime/internal/stackeval/input_variable.go
+++ b/internal/stacks/stackruntime/internal/stackeval/input_variable.go
@@ -67,18 +67,20 @@ func (v *InputVariable) DefinedByStackCallInstance(ctx context.Context, phase Ev
 		// actually exist, which is odd but we'll tolerate it.
 		return nil
 	}
+
+	lastStep := declarerAddr[len(declarerAddr)-1]
+	instKey := lastStep.Key
+
 	callInsts, unknown := call.Instances(ctx, phase)
 	if unknown {
 		// Return our static unknown instance for this variable.
-		return call.UnknownInstance(ctx, phase)
+		return call.UnknownInstance(ctx, instKey, phase)
 	}
 	if callInsts == nil {
 		// Could get here if the call's for_each is invalid.
 		return nil
 	}
 
-	lastStep := declarerAddr[len(declarerAddr)-1]
-	instKey := lastStep.Key
 	return callInsts[instKey]
 }
 

--- a/internal/stacks/stackruntime/internal/stackeval/removed.go
+++ b/internal/stacks/stackruntime/internal/stackeval/removed.go
@@ -4,13 +4,19 @@
 package stackeval
 
 import (
+	"context"
 	"sync"
 
 	"github.com/hashicorp/terraform/internal/stacks/stackaddrs"
+	"github.com/hashicorp/terraform/internal/stacks/stackconfig"
 )
 
 // Removed encapsulates the somewhat complicated logic for tracking and
 // managing the removed block instances in a given stack.
+//
+// The Removed block does actually capture the entire tree of removed blocks
+// in a single instance via the children field. Each Stack has a reference to
+// its Removed instance, from which it can access all of its children.
 type Removed struct {
 	sync.Mutex
 
@@ -70,4 +76,79 @@ func (removed *Removed) AddStackCall(addr stackaddrs.ConfigStackCall, stackCalls
 		Stack: addr.Stack[1:],
 		Item:  addr.Item,
 	}, stackCalls)
+}
+
+// validateMissingInstanceAgainstRemovedBlocks matches the function of the same
+// name defined on Stack.
+//
+// This function should only ever be called from inside that function and it
+// performs the same purpose except it exclusively looks for orphaned blocks
+// with the children.
+//
+// This function assumes all the checks made in the equivalent function in Stack
+// have been completed, so again (!!!) it should only be called from within
+// the other function.
+func (removed *Removed) validateMissingInstanceAgainstRemovedBlocks(ctx context.Context, addr stackaddrs.StackInstance, target stackaddrs.AbsComponentInstance, phase EvalPhase) (*stackconfig.Removed, *stackconfig.Component) {
+
+	// we're just jumping directly into checking the children, the removed
+	// stack calls should have already been checked by the function on
+	// Stack.
+
+	if len(target.Stack) == 0 {
+
+		if components, ok := removed.components[target.Item.Component]; ok {
+			for _, component := range components {
+				insts, _ := component.InstancesFor(ctx, addr, phase)
+				for _, inst := range insts {
+					if inst.from.Item.Key == target.Item.Key {
+						// then we have actually found it! this is a removed
+						// block that targets the target address, but isn't
+						// in any stacks.
+						return inst.call.config.config, nil
+					}
+				}
+			}
+		}
+
+		return nil, nil // we found no potential blocks
+	}
+
+	// otherwise, we'll keep looking!
+
+	// first, we'll check to see if we have a removed block targeting
+	// the entire stack.
+
+	next := target.Stack[0]
+	rest := stackaddrs.AbsComponentInstance{
+		Stack: target.Stack[1:],
+		Item:  target.Item,
+	}
+
+	if calls, ok := removed.stackCalls[stackaddrs.StackCall{Name: next.Name}]; ok {
+		for _, call := range calls {
+			insts, _ := call.InstancesFor(ctx, append(addr, next), phase)
+			for _, inst := range insts {
+				stack := inst.Stack(ctx, phase)
+
+				// now, hand the search back over to the stack to check if
+				// the target instance is actually claimed by this removed
+				// stack.
+				removed, component := stack.validateMissingInstanceAgainstRemovedBlocks(ctx, rest, phase)
+				if removed != nil || component != nil {
+					// if we found any match, then return this removed block
+					// as the original source
+					return call.config.config, nil
+				}
+			}
+		}
+
+	}
+
+	// finally, we'll keep going through the children of the next one.
+
+	if child, ok := removed.children[next.Name]; ok {
+		return child.validateMissingInstanceAgainstRemovedBlocks(ctx, append(addr, next), rest, phase)
+	}
+
+	return nil, nil
 }

--- a/internal/stacks/stackruntime/internal/stackeval/removed_component.go
+++ b/internal/stacks/stackruntime/internal/stackeval/removed_component.go
@@ -6,12 +6,14 @@ package stackeval
 import (
 	"context"
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/zclconf/go-cty/cty"
 
 	"github.com/hashicorp/terraform/internal/addrs"
+	"github.com/hashicorp/terraform/internal/collections"
 	"github.com/hashicorp/terraform/internal/instances"
 	"github.com/hashicorp/terraform/internal/lang"
 	"github.com/hashicorp/terraform/internal/promising"
@@ -34,17 +36,20 @@ type RemovedComponent struct {
 	stack  *Stack
 	main   *Main
 
-	forEachValue    perEvalPhase[promising.Once[withDiagnostics[cty.Value]]]
-	instances       perEvalPhase[promising.Once[withDiagnostics[instancesResult[*RemovedComponentInstance]]]]
-	unknownInstance perEvalPhase[promising.Once[*RemovedComponentInstance]]
+	forEachValue perEvalPhase[promising.Once[withDiagnostics[cty.Value]]]
+	instances    perEvalPhase[promising.Once[withDiagnostics[instancesResult[*RemovedComponentInstance]]]]
+
+	unknownInstancesMutex sync.Mutex
+	unknownInstances      collections.Map[stackaddrs.AbsComponentInstance, *RemovedComponentInstance]
 }
 
 func newRemovedComponent(main *Main, target stackaddrs.ConfigComponent, stack *Stack, config *RemovedComponentConfig) *RemovedComponent {
 	return &RemovedComponent{
-		target: target,
-		main:   main,
-		config: config,
-		stack:  stack,
+		target:           target,
+		main:             main,
+		config:           config,
+		stack:            stack,
+		unknownInstances: collections.NewMap[stackaddrs.AbsComponentInstance, *RemovedComponentInstance](),
 	}
 }
 
@@ -187,6 +192,22 @@ func (r *RemovedComponent) Instances(ctx context.Context, phase EvalPhase) (map[
 		return result, diags
 	})
 	return result.insts, result.unknown, diags
+}
+
+func (r *RemovedComponent) UnknownInstance(ctx context.Context, from stackaddrs.AbsComponentInstance, phase EvalPhase) *RemovedComponentInstance {
+	r.unknownInstancesMutex.Lock()
+	defer r.unknownInstancesMutex.Unlock()
+
+	if inst, ok := r.unknownInstances.GetOk(from); ok {
+		return inst
+	}
+
+	forEachType, _ := r.ForEachValue(ctx, phase)
+	repetitionData := instances.UnknownForEachRepetitionData(forEachType.Type())
+
+	inst := newRemovedComponentInstance(r, from, repetitionData, true)
+	r.unknownInstances.Put(from, inst)
+	return inst
 }
 
 func (r *RemovedComponent) PlanIsComplete(ctx context.Context, stack stackaddrs.StackInstance) bool {

--- a/internal/stacks/stackruntime/internal/stackeval/stack_config.go
+++ b/internal/stacks/stackruntime/internal/stackeval/stack_config.go
@@ -354,7 +354,7 @@ func (s *StackConfig) StackCalls() map[stackaddrs.StackCall]*StackCallConfig {
 		return nil
 	}
 	ret := make(map[stackaddrs.StackCall]*StackCallConfig, len(s.config.Children))
-	for n := range s.config.Children {
+	for n := range s.config.Stack.EmbeddedStacks {
 		stepAddr := stackaddrs.StackCall{Name: n}
 		ret[stepAddr] = s.StackCall(stepAddr)
 	}

--- a/internal/stacks/stackruntime/plan_test.go
+++ b/internal/stacks/stackruntime/plan_test.go
@@ -596,7 +596,7 @@ func TestPlan(t *testing.T) {
 						PlanComplete:  false,
 						Action:        plans.Update,
 						PlannedInputValues: map[string]plans.DynamicValue{
-							"id":    mustPlanDynamicValueDynamicType(cty.UnknownVal(cty.String)),
+							"id":    mustPlanDynamicValueDynamicType(cty.StringVal("deferred")),
 							"input": mustPlanDynamicValueDynamicType(cty.UnknownVal(cty.String)),
 						},
 						PlannedOutputValues: map[string]cty.Value{},
@@ -644,18 +644,14 @@ func TestPlan(t *testing.T) {
 									Module:   addrs.RootModule,
 									Provider: addrs.MustParseProviderSourceString("hashicorp/testing"),
 								},
-								ActionReason: plans.ResourceInstanceReplaceBecauseCannotUpdate,
-								RequiredReplace: cty.NewPathSet(
-									cty.GetAttrPath("id"),
-								),
 								ChangeSrc: plans.ChangeSrc{
-									Action: plans.DeleteThenCreate,
+									Action: plans.Update,
 									Before: mustPlanDynamicValueSchema(cty.ObjectVal(map[string]cty.Value{
 										"id":    cty.StringVal("deferred"),
 										"value": cty.StringVal("deferred"),
 									}), stacks_testing_provider.TestingResourceSchema.Body),
 									After: mustPlanDynamicValueSchema(cty.ObjectVal(map[string]cty.Value{
-										"id":    cty.UnknownVal(cty.String),
+										"id":    cty.StringVal("deferred"),
 										"value": cty.UnknownVal(cty.String),
 									}), stacks_testing_provider.TestingResourceSchema.Body),
 									AfterSensitivePaths: nil,
@@ -911,6 +907,512 @@ func TestPlan(t *testing.T) {
 						After: cty.MapVal(map[string]cty.Value{
 							"component": cty.StringVal("component"),
 						}),
+					},
+					&stackplan.PlannedChangeRootInputValue{
+						Addr:   stackaddrs.InputVariable{Name: "removed-direct"},
+						Action: plans.Create,
+						Before: cty.NullVal(cty.DynamicPseudoType),
+						After:  cty.SetValEmpty(cty.String),
+					},
+				},
+			},
+		},
+		"embedded stack in state but not in configuration": {
+			path: filepath.Join("with-single-input", "valid"),
+			state: stackstate.NewStateBuilder().
+				AddComponentInstance(stackstate.NewComponentInstanceBuilder(mustAbsComponentInstance("stack.child.component.self"))).
+				AddResourceInstance(stackstate.NewResourceInstanceBuilder().
+					SetAddr(mustAbsResourceInstanceObject("stack.child.component.self.testing_resource.data")).
+					SetProviderAddr(mustDefaultRootProvider("testing")).
+					SetResourceInstanceObjectSrc(states.ResourceInstanceObjectSrc{
+						Status: states.ObjectReady,
+						AttrsJSON: mustMarshalJSONAttrs(map[string]any{
+							"id":    "leftover",
+							"value": "leftover",
+						}),
+					})).
+				Build(),
+			store: stacks_testing_provider.NewResourceStoreBuilder().
+				AddResource("leftover", cty.ObjectVal(map[string]cty.Value{
+					"id":    cty.StringVal("leftover"),
+					"value": cty.StringVal("leftover"),
+				})).
+				Build(),
+			cycle: TestCycle{
+				planInputs: map[string]cty.Value{
+					"input": cty.StringVal("input"),
+				},
+				wantPlannedDiags: initDiags(func(diags tfdiags.Diagnostics) tfdiags.Diagnostics {
+					return diags.Append(&hcl.Diagnostic{
+						Severity: hcl.DiagError,
+						Summary:  "Unclaimed component instance",
+						Detail:   "The component instance stack.child.component.self is not claimed by any component or removed block in the configuration. Make sure it is instantiated by a component block, or targeted for removal by a removed block.",
+					})
+				}),
+			},
+		},
+		"removed and stack block target the same stack": {
+			path: filepath.Join("with-single-input", "removed-stack-instance-dynamic"),
+			cycle: TestCycle{
+				planInputs: map[string]cty.Value{
+					"input": cty.MapVal(map[string]cty.Value{
+						"component": cty.StringVal("component"),
+					}),
+					"removed": cty.MapVal(map[string]cty.Value{
+						"component": cty.StringVal("component"),
+					}),
+				},
+				wantPlannedDiags: initDiags(func(diags tfdiags.Diagnostics) tfdiags.Diagnostics {
+					return diags.Append(&hcl.Diagnostic{
+						Severity: hcl.DiagError,
+						Summary:  "Cannot remove stack instance",
+						Detail:   "The stack instance stack.simple[\"component\"] is targeted by an embedded stack block and cannot be removed. The relevant embedded stack is defined at git::https://example.com/test.git//with-single-input/removed-stack-instance-dynamic/removed-stack-instance-dynamic.tfstack.hcl:25,1-15.",
+						Subject: &hcl.Range{
+							Filename: "git::https://example.com/test.git//with-single-input/removed-stack-instance-dynamic/removed-stack-instance-dynamic.tfstack.hcl",
+							Start:    hcl.Pos{Line: 36, Column: 1, Byte: 441},
+							End:      hcl.Pos{Line: 36, Column: 8, Byte: 448},
+						},
+					})
+				}),
+			},
+		},
+		"removed targets stack block in embedded stack that exists": {
+			path: filepath.Join("with-single-input", "removed-stack-from-embedded-stack"),
+			cycle: TestCycle{
+				planInputs: map[string]cty.Value{
+					"input": cty.MapVal(map[string]cty.Value{
+						"component": cty.MapVal(map[string]cty.Value{
+							"component": cty.StringVal("component"),
+						}),
+					}),
+					"removed": cty.MapVal(map[string]cty.Value{
+						"component": cty.MapVal(map[string]cty.Value{
+							"id":    cty.StringVal("component"),
+							"input": cty.StringVal("component"),
+						}),
+					}),
+				},
+				wantPlannedDiags: initDiags(func(diags tfdiags.Diagnostics) tfdiags.Diagnostics {
+					return diags.Append(&hcl.Diagnostic{
+						Severity: hcl.DiagError,
+						Summary:  "Cannot remove stack instance",
+						Detail:   "The stack instance stack.embedded[\"component\"].stack.simple[\"component\"] is targeted by an embedded stack block and cannot be removed. The relevant embedded stack is defined at git::https://example.com/test.git//with-single-input/removed-stack-instance-dynamic/removed-stack-instance-dynamic.tfstack.hcl:25,1-15.",
+						Subject: &hcl.Range{
+							Filename: "git::https://example.com/test.git//with-single-input/removed-stack-from-embedded-stack/removed-stack-from-embedded-stack.tfstack.hcl",
+							Start:    hcl.Pos{Line: 28, Column: 1, Byte: 360},
+							End:      hcl.Pos{Line: 28, Column: 8, Byte: 367},
+						},
+					})
+				}),
+			},
+		},
+		"removed block targets component inside removed stack": {
+			path: filepath.Join("with-single-input", "removed-stack-instance-dynamic"),
+			state: stackstate.NewStateBuilder().
+				AddComponentInstance(stackstate.NewComponentInstanceBuilder(mustAbsComponentInstance("stack.simple[\"component\"].component.self")).
+					AddInputVariable("id", cty.StringVal("component")).
+					AddInputVariable("input", cty.StringVal("component"))).
+				AddResourceInstance(stackstate.NewResourceInstanceBuilder().
+					SetAddr(mustAbsResourceInstanceObject("stack.simple[\"component\"].component.self.testing_resource.data")).
+					SetProviderAddr(mustDefaultRootProvider("testing")).
+					SetResourceInstanceObjectSrc(states.ResourceInstanceObjectSrc{
+						Status: states.ObjectReady,
+						AttrsJSON: mustMarshalJSONAttrs(map[string]any{
+							"id":    "component",
+							"value": "component",
+						}),
+					})).
+				Build(),
+			store: stacks_testing_provider.NewResourceStoreBuilder().
+				AddResource("component", cty.ObjectVal(map[string]cty.Value{
+					"id":    cty.StringVal("component"),
+					"value": cty.StringVal("component"),
+				})).
+				Build(),
+			cycle: TestCycle{
+				planInputs: map[string]cty.Value{
+					"removed": cty.MapVal(map[string]cty.Value{
+						"component": cty.StringVal("component"),
+					}),
+					"removed-direct": cty.SetVal([]cty.Value{
+						cty.StringVal("component"),
+					}),
+				},
+				wantPlannedDiags: initDiags(func(diags tfdiags.Diagnostics) tfdiags.Diagnostics {
+					return diags.Append(&hcl.Diagnostic{
+						Severity: hcl.DiagError,
+						Summary:  "Cannot remove component instance",
+						Detail:   "The component instance stack.simple[\"component\"].component.self is targeted by a component block and cannot be removed. The relevant component is defined at git::https://example.com/test.git//with-single-input/valid/valid.tfstack.hcl:19,1-17.",
+						Subject: &hcl.Range{
+							Filename: "git::https://example.com/test.git//with-single-input/removed-stack-instance-dynamic/removed-stack-instance-dynamic.tfstack.hcl",
+							Start:    hcl.Pos{Line: 51, Column: 1, Byte: 708},
+							End:      hcl.Pos{Line: 51, Column: 8, Byte: 715},
+						},
+					})
+				}),
+			},
+		},
+		"removed block targets orphaned component": {
+			path: filepath.Join("with-single-input", "removed-component-from-stack-dynamic"),
+			state: stackstate.NewStateBuilder().
+				AddComponentInstance(stackstate.NewComponentInstanceBuilder(mustAbsComponentInstance("stack.simple[\"component\"].component.self")).
+					AddInputVariable("id", cty.StringVal("component")).
+					AddInputVariable("input", cty.StringVal("component"))).
+				AddResourceInstance(stackstate.NewResourceInstanceBuilder().
+					SetAddr(mustAbsResourceInstanceObject("stack.simple[\"component\"].component.self.testing_resource.data")).
+					SetProviderAddr(mustDefaultRootProvider("testing")).
+					SetResourceInstanceObjectSrc(states.ResourceInstanceObjectSrc{
+						Status: states.ObjectReady,
+						AttrsJSON: mustMarshalJSONAttrs(map[string]any{
+							"id":    "component",
+							"value": "component",
+						}),
+					})).
+				Build(),
+			store: stacks_testing_provider.NewResourceStoreBuilder().
+				AddResource("component", cty.ObjectVal(map[string]cty.Value{
+					"id":    cty.StringVal("component"),
+					"value": cty.StringVal("component"),
+				})).
+				Build(),
+			cycle: TestCycle{
+				planInputs: map[string]cty.Value{
+					"simple_input": cty.MapValEmpty(cty.String),
+					"simple_removed": cty.SetVal([]cty.Value{
+						cty.StringVal("component"),
+					}),
+				},
+				wantPlannedDiags: initDiags(func(diags tfdiags.Diagnostics) tfdiags.Diagnostics {
+					return diags.Append(&hcl.Diagnostic{
+						Severity: hcl.DiagError,
+						Summary:  "Invalid removed block",
+						Detail:   "The component instance stack.simple[\"component\"].component.self could not be removed. The linked removed block was not executed because the `from` attribute of the removed block targets a component or embedded stack within an orphaned embedded stack.\n\nIn order to remove an entire stack, update your removed block to target the entire removed stack itself instead of the specific elements within it.",
+						Subject: &hcl.Range{
+							Filename: "git::https://example.com/test.git//with-single-input/removed-component-from-stack-dynamic/removed-component-from-stack-dynamic.tfstack.hcl",
+							Start:    hcl.Pos{Line: 60, Column: 1, Byte: 811},
+							End:      hcl.Pos{Line: 60, Column: 8, Byte: 818},
+						},
+					})
+				}),
+				wantPlannedChanges: []stackplan.PlannedChange{
+					&stackplan.PlannedChangeApplyable{
+						Applyable: false,
+					},
+					&stackplan.PlannedChangeHeader{
+						TerraformVersion: version.SemVer,
+					},
+					&stackplan.PlannedChangePlannedTimestamp{
+						PlannedTimestamp: fakePlanTimestamp,
+					},
+					&stackplan.PlannedChangeRootInputValue{
+						Addr:   stackaddrs.InputVariable{Name: "for_each_input"},
+						Action: plans.Create,
+						Before: cty.NullVal(cty.DynamicPseudoType),
+						After:  cty.MapValEmpty(cty.String),
+					},
+					&stackplan.PlannedChangeRootInputValue{
+						Addr:   stackaddrs.InputVariable{Name: "for_each_removed"},
+						Action: plans.Create,
+						Before: cty.NullVal(cty.DynamicPseudoType),
+						After:  cty.SetValEmpty(cty.String),
+					},
+					&stackplan.PlannedChangeRootInputValue{
+						Addr:   stackaddrs.InputVariable{Name: "simple_input"},
+						Action: plans.Create,
+						Before: cty.NullVal(cty.DynamicPseudoType),
+						After:  cty.MapValEmpty(cty.String),
+					},
+					&stackplan.PlannedChangeRootInputValue{
+						Addr:   stackaddrs.InputVariable{Name: "simple_removed"},
+						Action: plans.Create,
+						Before: cty.NullVal(cty.DynamicPseudoType),
+						After: cty.SetVal([]cty.Value{
+							cty.StringVal("component"),
+						}),
+					},
+				},
+			},
+		},
+		"removed block targets orphaned stack": {
+			path: filepath.Join("with-single-input", "removed-stack-from-embedded-stack"),
+			state: stackstate.NewStateBuilder().
+				AddComponentInstance(stackstate.NewComponentInstanceBuilder(mustAbsComponentInstance("stack.embedded[\"component\"].stack.simple[\"component\"].component.self")).
+					AddInputVariable("id", cty.StringVal("component")).
+					AddInputVariable("input", cty.StringVal("component"))).
+				AddResourceInstance(stackstate.NewResourceInstanceBuilder().
+					SetAddr(mustAbsResourceInstanceObject("stack.embedded[\"component\"].stack.simple[\"component\"].component.self.testing_resource.data")).
+					SetProviderAddr(mustDefaultRootProvider("testing")).
+					SetResourceInstanceObjectSrc(states.ResourceInstanceObjectSrc{
+						Status: states.ObjectReady,
+						AttrsJSON: mustMarshalJSONAttrs(map[string]any{
+							"id":    "component",
+							"value": "component",
+						}),
+					})).
+				Build(),
+			store: stacks_testing_provider.NewResourceStoreBuilder().
+				AddResource("component", cty.ObjectVal(map[string]cty.Value{
+					"id":    cty.StringVal("component"),
+					"value": cty.StringVal("component"),
+				})).
+				Build(),
+			cycle: TestCycle{
+				planInputs: map[string]cty.Value{
+					"input": cty.MapValEmpty(cty.Map(cty.String)),
+					"removed": cty.MapVal(map[string]cty.Value{
+						"component": cty.MapVal(map[string]cty.Value{
+							"id":    cty.StringVal("component"),
+							"input": cty.StringVal("component"),
+						}),
+					}),
+				},
+				wantPlannedDiags: initDiags(func(diags tfdiags.Diagnostics) tfdiags.Diagnostics {
+					return diags.Append(&hcl.Diagnostic{
+						Severity: hcl.DiagError,
+						Summary:  "Invalid removed block",
+						Detail:   "The component instance stack.embedded[\"component\"].stack.simple[\"component\"].component.self could not be removed. The linked removed block was not executed because the `from` attribute of the removed block targets a component or embedded stack within an orphaned embedded stack.\n\nIn order to remove an entire stack, update your removed block to target the entire removed stack itself instead of the specific elements within it.",
+						Subject: &hcl.Range{
+							Filename: "git::https://example.com/test.git//with-single-input/removed-stack-from-embedded-stack/removed-stack-from-embedded-stack.tfstack.hcl",
+							Start:    hcl.Pos{Line: 28, Column: 1, Byte: 360},
+							End:      hcl.Pos{Line: 28, Column: 8, Byte: 367},
+						},
+					})
+				}),
+			},
+		},
+		"removed block targets orphaned component without config definition": {
+			path: filepath.Join("with-single-input", "orphaned-component"),
+			state: stackstate.NewStateBuilder().
+				AddComponentInstance(stackstate.NewComponentInstanceBuilder(mustAbsComponentInstance("stack.embedded.component.self")).
+					AddInputVariable("id", cty.StringVal("component")).
+					AddInputVariable("input", cty.StringVal("component"))).
+				AddResourceInstance(stackstate.NewResourceInstanceBuilder().
+					SetAddr(mustAbsResourceInstanceObject("stack.embedded.component.self.testing_resource.data")).
+					SetProviderAddr(mustDefaultRootProvider("testing")).
+					SetResourceInstanceObjectSrc(states.ResourceInstanceObjectSrc{
+						Status: states.ObjectReady,
+						AttrsJSON: mustMarshalJSONAttrs(map[string]any{
+							"id":    "component",
+							"value": "component",
+						}),
+					})).
+				Build(),
+			store: stacks_testing_provider.NewResourceStoreBuilder().
+				AddResource("component", cty.ObjectVal(map[string]cty.Value{
+					"id":    cty.StringVal("component"),
+					"value": cty.StringVal("component"),
+				})).
+				Build(),
+			cycle: TestCycle{
+				wantPlannedDiags: initDiags(func(diags tfdiags.Diagnostics) tfdiags.Diagnostics {
+					return diags.Append(&hcl.Diagnostic{
+						Severity: hcl.DiagError,
+						Summary:  "Invalid removed block",
+						Detail:   "The component instance stack.embedded.component.self could not be removed. The linked removed block was not executed because the `from` attribute of the removed block targets a component or embedded stack within an orphaned embedded stack.\n\nIn order to remove an entire stack, update your removed block to target the entire removed stack itself instead of the specific elements within it.",
+						Subject: &hcl.Range{
+							Filename: "git::https://example.com/test.git//with-single-input/orphaned-component/orphaned-component.tfstack.hcl",
+							Start:    hcl.Pos{Line: 10, Column: 1, Byte: 131},
+							End:      hcl.Pos{Line: 10, Column: 8, Byte: 138},
+						},
+					})
+				}),
+			},
+		},
+		"unknown embedded stack with internal component targeted by concrete removed block": {
+			path: filepath.Join("with-single-input", "removed-stack-instance-dynamic"),
+			state: stackstate.NewStateBuilder().
+				AddComponentInstance(stackstate.NewComponentInstanceBuilder(mustAbsComponentInstance("stack.simple[\"component\"].component.self")).
+					AddInputVariable("id", cty.StringVal("component")).
+					AddInputVariable("input", cty.StringVal("component"))).
+				AddResourceInstance(stackstate.NewResourceInstanceBuilder().
+					SetAddr(mustAbsResourceInstanceObject("stack.simple[\"component\"].component.self.testing_resource.data")).
+					SetProviderAddr(mustDefaultRootProvider("testing")).
+					SetResourceInstanceObjectSrc(states.ResourceInstanceObjectSrc{
+						Status: states.ObjectReady,
+						AttrsJSON: mustMarshalJSONAttrs(map[string]any{
+							"id":    "component",
+							"value": "component",
+						}),
+					})).
+				Build(),
+			store: stacks_testing_provider.NewResourceStoreBuilder().
+				AddResource("component", cty.ObjectVal(map[string]cty.Value{
+					"id":    cty.StringVal("component"),
+					"value": cty.StringVal("component"),
+				})).
+				Build(),
+			cycle: TestCycle{
+				planInputs: map[string]cty.Value{
+					"removed": cty.UnknownVal(cty.Map(cty.String)),
+				},
+				wantPlannedChanges: []stackplan.PlannedChange{
+					&stackplan.PlannedChangeApplyable{
+						Applyable: true,
+					},
+					&stackplan.PlannedChangeHeader{
+						TerraformVersion: version.SemVer,
+					},
+					&stackplan.PlannedChangePlannedTimestamp{
+						PlannedTimestamp: fakePlanTimestamp,
+					},
+					&stackplan.PlannedChangeComponentInstance{
+						Addr:   mustAbsComponentInstance("stack.simple[\"component\"].component.self"),
+						Action: plans.Delete,
+						Mode:   plans.DestroyMode,
+						PlannedInputValues: map[string]plans.DynamicValue{
+							"id":    mustPlanDynamicValueDynamicType(cty.UnknownVal(cty.String)),
+							"input": mustPlanDynamicValueDynamicType(cty.UnknownVal(cty.String)),
+						},
+						PlannedInputValueMarks: map[string][]cty.PathValueMarks{
+							"id":    nil,
+							"input": nil,
+						},
+						PlannedOutputValues: make(map[string]cty.Value),
+						PlannedCheckResults: &states.CheckResults{},
+						PlanTimestamp:       fakePlanTimestamp,
+					},
+					&stackplan.PlannedChangeDeferredResourceInstancePlanned{
+						ResourceInstancePlanned: stackplan.PlannedChangeResourceInstancePlanned{
+							ResourceInstanceObjectAddr: mustAbsResourceInstanceObject("stack.simple[\"component\"].component.self.testing_resource.data"),
+							ChangeSrc: &plans.ResourceInstanceChangeSrc{
+								Addr:         mustAbsResourceInstance("testing_resource.data"),
+								PrevRunAddr:  mustAbsResourceInstance("testing_resource.data"),
+								ProviderAddr: mustDefaultRootProvider("testing"),
+								ChangeSrc: plans.ChangeSrc{
+									Action: plans.Delete,
+									Before: mustPlanDynamicValue(cty.ObjectVal(map[string]cty.Value{
+										"id":    cty.StringVal("component"),
+										"value": cty.StringVal("component"),
+									})),
+									After: mustPlanDynamicValue(cty.NullVal(cty.Object(map[string]cty.Type{
+										"id":    cty.String,
+										"value": cty.String,
+									}))),
+								},
+							},
+							PriorStateSrc: &states.ResourceInstanceObjectSrc{
+								Status: states.ObjectReady,
+								AttrsJSON: mustMarshalJSONAttrs(map[string]any{
+									"id":    "component",
+									"value": "component",
+								}),
+								Dependencies: make([]addrs.ConfigResource, 0),
+							},
+							ProviderConfigAddr: mustDefaultRootProvider("testing"),
+							Schema:             stacks_testing_provider.TestingResourceSchema,
+						},
+						DeferredReason: providers.DeferredReasonDeferredPrereq,
+					},
+					&stackplan.PlannedChangeRootInputValue{
+						Addr:   stackaddrs.InputVariable{Name: "input"},
+						Action: plans.Create,
+						Before: cty.NullVal(cty.DynamicPseudoType),
+						After:  cty.MapValEmpty(cty.String),
+					},
+					&stackplan.PlannedChangeRootInputValue{
+						Addr:   stackaddrs.InputVariable{Name: "removed"},
+						Action: plans.Create,
+						Before: cty.NullVal(cty.DynamicPseudoType),
+						After:  cty.UnknownVal(cty.Map(cty.String)),
+					},
+					&stackplan.PlannedChangeRootInputValue{
+						Addr:   stackaddrs.InputVariable{Name: "removed-direct"},
+						Action: plans.Create,
+						Before: cty.NullVal(cty.DynamicPseudoType),
+						After:  cty.SetValEmpty(cty.String),
+					},
+				},
+			},
+		},
+		"remove partial stack": {
+			path: filepath.Join("with-single-input", "multiple-components", "removed"),
+			state: stackstate.NewStateBuilder().
+				AddComponentInstance(stackstate.NewComponentInstanceBuilder(mustAbsComponentInstance("stack.multiple.component.one")).
+					AddInputVariable("id", cty.StringVal("one")).
+					AddInputVariable("input", cty.StringVal("one"))).
+				AddResourceInstance(stackstate.NewResourceInstanceBuilder().
+					SetAddr(mustAbsResourceInstanceObject("stack.multiple.component.one.testing_resource.data")).
+					SetProviderAddr(mustDefaultRootProvider("testing")).
+					SetResourceInstanceObjectSrc(states.ResourceInstanceObjectSrc{
+						Status: states.ObjectReady,
+						AttrsJSON: mustMarshalJSONAttrs(map[string]any{
+							"id":    "one",
+							"value": "one",
+						}),
+					})).
+				Build(),
+			store: stacks_testing_provider.NewResourceStoreBuilder().
+				AddResource("one", cty.ObjectVal(map[string]cty.Value{
+					"id":    cty.StringVal("one"),
+					"value": cty.StringVal("one"),
+				})).
+				Build(),
+			cycle: TestCycle{
+				wantPlannedChanges: []stackplan.PlannedChange{
+					&stackplan.PlannedChangeApplyable{
+						Applyable: true,
+					},
+					&stackplan.PlannedChangeHeader{
+						TerraformVersion: version.SemVer,
+					},
+					&stackplan.PlannedChangePlannedTimestamp{
+						PlannedTimestamp: fakePlanTimestamp,
+					},
+					&stackplan.PlannedChangeComponentInstance{
+						Addr:          mustAbsComponentInstance("stack.multiple.component.one"),
+						PlanApplyable: true,
+						PlanComplete:  true,
+						Action:        plans.Delete,
+						Mode:          plans.DestroyMode,
+						PlannedInputValues: map[string]plans.DynamicValue{
+							"id":    mustPlanDynamicValueDynamicType(cty.StringVal("one")),
+							"input": mustPlanDynamicValueDynamicType(cty.StringVal("one")),
+						},
+						PlannedInputValueMarks: map[string][]cty.PathValueMarks{
+							"id":    nil,
+							"input": nil,
+						},
+						PlannedOutputValues: make(map[string]cty.Value),
+						PlannedCheckResults: &states.CheckResults{},
+						PlanTimestamp:       fakePlanTimestamp,
+					},
+					&stackplan.PlannedChangeResourceInstancePlanned{
+						ResourceInstanceObjectAddr: mustAbsResourceInstanceObject("stack.multiple.component.one.testing_resource.data"),
+						ChangeSrc: &plans.ResourceInstanceChangeSrc{
+							Addr:         mustAbsResourceInstance("testing_resource.data"),
+							PrevRunAddr:  mustAbsResourceInstance("testing_resource.data"),
+							ProviderAddr: mustDefaultRootProvider("testing"),
+							ChangeSrc: plans.ChangeSrc{
+								Action: plans.Delete,
+								Before: mustPlanDynamicValue(cty.ObjectVal(map[string]cty.Value{
+									"id":    cty.StringVal("one"),
+									"value": cty.StringVal("one"),
+								})),
+								After: mustPlanDynamicValue(cty.NullVal(cty.Object(map[string]cty.Type{
+									"id":    cty.String,
+									"value": cty.String,
+								}))),
+							},
+						},
+						PriorStateSrc: &states.ResourceInstanceObjectSrc{
+							Status: states.ObjectReady,
+							AttrsJSON: mustMarshalJSONAttrs(map[string]any{
+								"id":    "one",
+								"value": "one",
+							}),
+							Dependencies: make([]addrs.ConfigResource, 0),
+						},
+						ProviderConfigAddr: mustDefaultRootProvider("testing"),
+						Schema:             stacks_testing_provider.TestingResourceSchema,
+					},
+					&stackplan.PlannedChangeComponentInstance{
+						Addr:                mustAbsComponentInstance("stack.multiple.component.two"),
+						PlanApplyable:       true,
+						PlanComplete:        true,
+						Action:              plans.Delete,
+						Mode:                plans.DestroyMode,
+						PlannedOutputValues: make(map[string]cty.Value),
+						PlanTimestamp:       fakePlanTimestamp,
 					},
 				},
 			},

--- a/internal/stacks/stackruntime/testdata/mainbundle/test/with-single-input/multiple-components/multiple-components.tfstack.hcl
+++ b/internal/stacks/stackruntime/testdata/mainbundle/test/with-single-input/multiple-components/multiple-components.tfstack.hcl
@@ -1,0 +1,34 @@
+required_providers {
+  testing = {
+    source  = "hashicorp/testing"
+    version = "0.1.0"
+  }
+}
+
+provider "testing" "default" {}
+
+component "one" {
+  source = "../"
+
+  providers = {
+    testing = provider.testing.default
+  }
+
+  inputs = {
+    id = "one"
+    input = "one"
+  }
+}
+
+component "two" {
+  source = "../"
+
+  providers = {
+    testing = provider.testing.default
+  }
+
+  inputs = {
+    id = "two"
+    input = "two"
+  }
+}

--- a/internal/stacks/stackruntime/testdata/mainbundle/test/with-single-input/multiple-components/removed/removed.tfstack.hcl
+++ b/internal/stacks/stackruntime/testdata/mainbundle/test/with-single-input/multiple-components/removed/removed.tfstack.hcl
@@ -9,7 +9,3 @@ removed {
   from = stack.multiple
   source = "../"
 }
-
-# stack "multiple" {
-#   source = "../"
-# }

--- a/internal/stacks/stackruntime/testdata/mainbundle/test/with-single-input/multiple-components/removed/removed.tfstack.hcl
+++ b/internal/stacks/stackruntime/testdata/mainbundle/test/with-single-input/multiple-components/removed/removed.tfstack.hcl
@@ -1,0 +1,15 @@
+required_providers {
+  testing = {
+    source  = "hashicorp/testing"
+    version = "0.1.0"
+  }
+}
+
+removed {
+  from = stack.multiple
+  source = "../"
+}
+
+# stack "multiple" {
+#   source = "../"
+# }

--- a/internal/stacks/stackruntime/testdata/mainbundle/test/with-single-input/orphaned-component/orphaned-component.tfstack.hcl
+++ b/internal/stacks/stackruntime/testdata/mainbundle/test/with-single-input/orphaned-component/orphaned-component.tfstack.hcl
@@ -1,0 +1,19 @@
+required_providers {
+  testing = {
+    source  = "hashicorp/testing"
+    version = "0.1.0"
+  }
+}
+
+provider "testing" "default" {}
+
+removed {
+  // this is invalid, without a definition of the stack itself we can't remove
+  // components from it directly, instead we should removed the whole stack
+  from = stack.embedded.component.self
+  source = "../"
+
+  providers = {
+    testing = provider.testing.default
+  }
+}

--- a/internal/stacks/stackruntime/testdata/mainbundle/test/with-single-input/removed-stack-from-embedded-stack/removed-stack-from-embedded-stack.tfstack.hcl
+++ b/internal/stacks/stackruntime/testdata/mainbundle/test/with-single-input/removed-stack-from-embedded-stack/removed-stack-from-embedded-stack.tfstack.hcl
@@ -1,0 +1,38 @@
+required_providers {
+  testing = {
+    source  = "hashicorp/testing"
+    version = "0.1.0"
+  }
+}
+
+variable "input" {
+  type = map(map(string))
+  default = {}
+}
+
+variable "removed" {
+  type = map(map(string))
+  default = {}
+}
+
+stack "embedded" {
+  source = "../removed-stack-instance-dynamic"
+
+  for_each = var.input
+
+  inputs = {
+    input = each.value
+  }
+}
+
+removed {
+  for_each = var.removed
+
+  from = stack.embedded[each.key].stack.simple[each.value["id"]]
+  source = "../valid"
+
+  inputs = {
+    id = each.value["id"]
+    input = each.value["input"]
+  }
+}

--- a/internal/stacks/stackruntime/testdata/mainbundle/test/with-single-input/removed-stack-instance-dynamic/removed-stack-instance-dynamic.tfstack.hcl
+++ b/internal/stacks/stackruntime/testdata/mainbundle/test/with-single-input/removed-stack-instance-dynamic/removed-stack-instance-dynamic.tfstack.hcl
@@ -5,6 +5,8 @@ required_providers {
   }
 }
 
+provider "testing" "default" {}
+
 variable "input" {
   type = map(string)
   default = {}
@@ -13,6 +15,11 @@ variable "input" {
 variable "removed" {
   type = map(string)
   default = {}
+}
+
+variable "removed-direct" {
+  type = set(string)
+  default = []
 }
 
 stack "simple" {
@@ -29,11 +36,30 @@ stack "simple" {
 removed {
   for_each = var.removed
 
+  // This removed block targets the stack directly, and just tells it to
+  // remove all components in the stack.
+
   from = stack.simple[each.key]
   source = "../valid"
 
   inputs = {
     id = each.key
     input = each.value
+  }
+}
+
+removed {
+  for_each = var.removed-direct
+
+  // This removed block removes the component in the specified stack directly.
+  // This is okay as long as only a single component in the stack is being
+  // removed. If an entire stack is being removed, you should use the other
+  // approach.
+
+  from = stack.simple[each.key].component.self
+  source = "../"
+
+  providers = {
+    testing = provider.testing.default
   }
 }


### PR DESCRIPTION
This PR adds a lot of tests focusing on the removed blocks to expand test coverage. It also fixes a set of bugs found as part of the testing.

1. Updates the configuration loading to place deeply nested removed blocks into the correct part of the config tree.
2. Caches created instances of stacks and components that are created against unknown blocks instead of duplicating them leading to inconsistent results.
3. Improve the error message when a component in state is targeted by an orphaned removed block to return an error detailing what it means for a removed block to be orphaned.