### PR TITLE
stacks: ensure consistent sources between removed blocks

### DIFF
--- a/internal/stacks/stackconfig/testdata/basics-bundle/errored-sources/main.tf
+++ b/internal/stacks/stackconfig/testdata/basics-bundle/errored-sources/main.tf
@@ -1,0 +1,17 @@
+variable "name" {
+  type = string
+}
+
+resource "null_resource" "example" {
+  triggers = {
+    name = var.name
+  }
+}
+
+output "greeting" {
+  value = "Hello, ${var.name}!"
+}
+
+output "resource_id" {
+  value = null_resource.example.id
+}

--- a/internal/stacks/stackconfig/testdata/basics-bundle/errored-sources/main.tfstack.hcl
+++ b/internal/stacks/stackconfig/testdata/basics-bundle/errored-sources/main.tfstack.hcl
@@ -1,0 +1,53 @@
+required_providers {
+  null = {
+    source  = "hashicorp/null"
+    version = "3.2.1"
+  }
+}
+
+provider "null" "a" {}
+
+removed {
+  from = stack.a.component.a // bad, stack.a is undefined so this is orphaned
+
+  source = "./"
+
+  providers = {
+    null = provider.null.a
+  }
+}
+
+removed {
+  from = stack.a.stack.b // bad, stack.a is undefined so this is orphaned
+  source = "./subdir"
+}
+
+removed {
+  from = stack.b["a"]
+  source = "./subdir"
+}
+
+removed {
+  from = stack.b["b"]
+  source = "./" // bad, the sources should be the same for stack.b
+}
+
+removed {
+  from = stack.a.component.b["a"]
+
+  source = "./"
+
+  providers = {
+    null = provider.null.a
+  }
+}
+
+removed {
+  from = stack.a.component.b["b"] // bad, the sources should be the same for component.b
+
+  source = "./subdir"
+
+  providers = {
+    null = provider.null.a
+  }
+}

--- a/internal/stacks/stackconfig/testdata/basics-bundle/errored-sources/subdir/main.tfstack.hcl
+++ b/internal/stacks/stackconfig/testdata/basics-bundle/errored-sources/subdir/main.tfstack.hcl
@@ -1,0 +1,20 @@
+required_providers {
+  null = {
+    source  = "hashicorp/null"
+    version = "3.2.1"
+  }
+}
+
+provider "null" "a" {}
+
+component "a" {
+  source = "../"
+
+  inputs = {
+    name = var.name
+  }
+
+  providers = {
+    null = provider.null.a
+  }
+}

--- a/internal/stacks/stackconfig/testdata/basics-bundle/terraform-sources.json
+++ b/internal/stacks/stackconfig/testdata/basics-bundle/terraform-sources.json
@@ -15,6 +15,11 @@
             "source": "git::https://example.com/errored.git",
             "local": "errored",
             "meta": {}
+        },
+        {
+            "source": "git::https://example.com/errored-sources.git",
+            "local": "errored-sources",
+            "meta": {}
         }
     ],
     "registry": [


### PR DESCRIPTION
This PR updates the Stack configuration loading so that it validates the source attributes of component, stack and removed blocks that target the same component or stack are the same.