### PR TITLE
workspaces: fix an incorrect behaviour on terraform init

### DIFF
--- a/.changes/v1.13/BUG FIXES-20250428-174545.yaml
+++ b/.changes/v1.13/BUG FIXES-20250428-174545.yaml
@@ -1,0 +1,5 @@
+kind: BUG FIXES
+body: 'workspaces: fix an incorrect behaviour on terraform init'
+time: 2025-04-28T17:45:45.070522+02:00
+custom:
+    Issue: "26127"

--- a/internal/command/meta_backend.go
+++ b/internal/command/meta_backend.go
@@ -263,9 +263,9 @@ func (m *Meta) selectWorkspace(b backend.Backend) error {
 		fmt.Fprintf(&list, "%d. %s\n", i+1, w)
 	}
 
-	// If the backend only has a single workspace, select that as the current workspace
-	if len(workspaces) == 1 {
-		log.Printf("[TRACE] Meta.selectWorkspace: automatically selecting the single workspace provided by the backend (%s)", workspaces[0])
+	// If the backend has at least a single workspace, select the first as the current workspace
+	if len(workspaces) >= 1 {
+		log.Printf("[TRACE] Meta.selectWorkspace: automatically selecting the first available workspace provided by the backend (%s)", workspaces[0])
 		return m.SetWorkspace(workspaces[0])
 	}
 


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->
## Description
When running a terraform init, it needs to retrieve an existing state to download providers that may have been removed from code. In the case the state does not exist, it assumes an empty state.

When a `TF_WORKSPACE` is set, the terraform init command have these behaviors:
- if the workspace exists -> takes its state to init
- If the workspace does not exist:
    - if there is no state at all -> assumes an empty state
    - If there is one and only default state -> takes this one as init state

However there is a case where:
- The workspace does not exist
- There is already a default state defined
- One or multiple workspaces already exists

In this case, terraform will prompt the user to choose a state to run an init.
This case happens in my situation in a CI, where i need to automatically create a new workspace, natively using `TF_WORKSPACE` variable.

## Reproduction

Here is the terraform code used to reproduce this behavior:

```terraform
terraform {
  backend "s3" {
    bucket = "lenstra-kevin-tfstates"
    key    = "init-workspace"
    region = "eu-central-1"
  }
}

resource "null_resource" "test" {}
```

*note that the bucket is empty to run the test*

Then here is the behavior encoutered:
```console
➜  init-workspace git:(main) ✗ terraform init                  
Initializing the backend...
Initializing provider plugins...
- Reusing previous version of hashicorp/null from the dependency lock file
- Using previously-installed hashicorp/null v3.2.3

Terraform has been successfully initialized!

You may now begin working with Terraform. Try running "terraform plan" to see
any changes that are required for your infrastructure. All Terraform commands
should now work.

If you ever set or change modules or backend configuration for Terraform,
rerun this command to reinitialize your working directory. If you forget, other
commands will detect it and remind you to do so if necessary.
➜  init-workspace git:(main) ✗ TF_WORKSPACE=foo terraform init
Initializing the backend...
Initializing provider plugins...
- Reusing previous version of hashicorp/null from the dependency lock file
- Using previously-installed hashicorp/null v3.2.3

Terraform has been successfully initialized!

You may now begin working with Terraform. Try running "terraform plan" to see
any changes that are required for your infrastructure. All Terraform commands
should now work.

If you ever set or change modules or backend configuration for Terraform,
rerun this command to reinitialize your working directory. If you forget, other
commands will detect it and remind you to do so if necessary.
➜  init-workspace git:(main) ✗ TF_WORKSPACE=bar terraform init
Initializing the backend...

The currently selected workspace (bar) does not exist.
  This is expected behavior when the selected workspace did not have an
  existing non-empty state. Please enter a number to select a workspace:
  
  1. default
  2. foo

  Enter a value: ^C
╷
│ Error: Failed to select workspace: interrupted
│ 
│ 
╵
```

On third attempt, we cannot init using a third workspace named `bar`.

The reason is the following:
- At first attempt, terraform assumes a default empty workspace
- At second attempt (`TF_WORSPACE=foo`), terraform will use the default workspace as well
- At third attempt (`TF_WORSPACE=bar`), terraform will fallback to user prompt

This behavior only appears using distant backend, i only tested s3 backend for now.

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Fixes #26127 

## Proposal

As the workspace is already explicitly set with the TF_WORKSPACE variable, i propose to generalize second attempt behavior to all terraform init using an unexisting workspace.
This means that it will use the default workspace to init when the workspace does not exist.

I'm reading s3 backend as well to understand if this could be related to a specific s3 backend issue, please let me know if you have any ideas or proposal to unify the behavior.

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.13.x

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [X] This change is user-facing and I added a changelog entry.
- [ ] This change is not user-facing.
