### PR TITLE
Fix version in resource identity upgrade request

### DIFF
--- a/internal/terraform/upgrade_resource_state.go
+++ b/internal/terraform/upgrade_resource_state.go
@@ -182,7 +182,7 @@ func upgradeResourceIdentity(addr addrs.AbsResourceInstance, provider providers.
 		// to all protobuf target languages so in practice we use int64
 		// on the wire. In future we will change all of our internal
 		// representations to int64 too.
-		Version:         int64(src.SchemaVersion),
+		Version:         int64(src.IdentitySchemaVersion),
 		RawIdentityJSON: src.IdentityJSON,
 	}
 


### PR DESCRIPTION
This PR fixes a typo and now sends the correct identity schema version on upgrade requests.

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.12.x

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [ ] This change is not user-facing.
