### PR TITLE
Fix remote-state backend name in CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -12,7 +12,7 @@
 # cannot be used automatically by GitHub's pull request workflow and would
 # make GitHub consider this file invalid if not commented.
 
-# Remote-state backend                  # Maintainer
+# Remote-state backend                           # Maintainer
 /internal/backend/remote-state/azure             @hashicorp/terraform-core @hashicorp/terraform-azure
 #/internal/backend/remote-state/consul           Unmaintained
 #/internal/backend/remote-state/cos              @likexian
@@ -22,7 +22,7 @@
 #/internal/backend/remote-state/pg               @remilapeyre
 /internal/backend/remote-state/s3                @hashicorp/terraform-core @hashicorp/terraform-aws
 /internal/backend/remote-state/kubernetes        @hashicorp/terraform-core @hashicorp/tf-eco-hybrid-cloud
-#/internal/backend/remote-state/oracle_oci        @ravinitp @pvkrishnachaitanya
+#/internal/backend/remote-state/oci              @ravinitp @pvkrishnachaitanya
 
 # Cloud backend
 /internal/backend/remote    @hashicorp/terraform-core @hashicorp/tf-core-cloud


### PR DESCRIPTION
Fixes the path to the backend - the original value didn't match an existing directory.
But of course this doesn't matter as it's not an active line in the CODEOWNERS file anyway

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

N/A

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
