### PR TITLE
Fix grammar: change "remains" to "remain" to match plural subject

### DIFF
--- a/website/docs/language/stacks/use-cases.mdx
+++ b/website/docs/language/stacks/use-cases.mdx
@@ -12,7 +12,7 @@ Stacks are ideal for the following situations:
 * Repeating infrastructure across different environments, regions, or accounts that require consistent and synchronized deployments.
 * Tightly orchestrating infrastructure changes across different environments. Stacks help you manage your dependencies and ensure Terraform creates resources in the correct order.
 
-Stacks can simplify the complexity of wrangling the infrastructure in these scenarios, ensuring that your configurations remains organized, maintainable, and scalable.
+Stacks can simplify the complexity of wrangling the infrastructure in these scenarios, ensuring that your configurations remain organized, maintainable, and scalable.
 
 ## Manage deployment dependencies
 


### PR DESCRIPTION
Fix grammar: change "remains" to "remain" to match plural subject

Fixes #

## Target Release
v1.13

## CHANGELOG entry
- [x] This change is not user-facing.