### PR TITLE
Relax resource identity validation

### DIFF
--- a/internal/terraform/context_plan_identity_test.go
+++ b/internal/terraform/context_plan_identity_test.go
@@ -446,12 +446,13 @@ func TestContext2Plan_resource_identity_plan(t *testing.T) {
 			},
 		},
 		"create - null planned identity schema": {
+			// We allow null values in identities
 			plannedIdentity: cty.ObjectVal(map[string]cty.Value{
 				"id": cty.NullVal(cty.String),
 			}),
-			expectDiagnostics: tfdiags.Diagnostics{
-				tfdiags.Sourceless(tfdiags.Error, "Provider produced an identity that doesn't match the schema", "Provider \"registry.terraform.io/hashicorp/test\" returned an identity for test_resource.test that doesn't match the identity schema: attributes \"id\" are required and must not be null. \n\nThis is a bug in the provider, which should be reported in the provider's own issue tracker."),
-			},
+			expectedIdentity: cty.ObjectVal(map[string]cty.Value{
+				"id": cty.NullVal(cty.String),
+			}),
 		},
 		"update": {
 			prevRunState: states.BuildState(func(s *states.SyncState) {

--- a/internal/terraform/node_resource_abstract_instance.go
+++ b/internal/terraform/node_resource_abstract_instance.go
@@ -2949,25 +2949,6 @@ func (n *NodeAbstractResourceInstance) validateIdentity(newIdentity cty.Value, i
 		return diags
 	}
 
-	// Check for required attributes
-	names := make([]string, 0, len(identitySchema.Attributes))
-	for name, attrS := range identitySchema.Attributes {
-		if attrS.Required && newIdentity.GetAttr(name).IsNull() {
-			names = append(names, name)
-		}
-	}
-	if len(names) > 0 {
-		diags = diags.Append(tfdiags.Sourceless(
-			tfdiags.Error,
-			"Provider produced an identity that doesn't match the schema",
-			fmt.Sprintf(
-				"Provider %q returned an identity for %s that doesn't match the identity schema: attributes %q are required and must not be null. \n\nThis is a bug in the provider, which should be reported in the provider's own issue tracker.",
-				n.ResolvedProvider.Provider, n.Addr,
-				strings.Join(names, ", "),
-			),
-		))
-	}
-
 	return diags
 }
 


### PR DESCRIPTION
This PR removes two resource identity validations:

1. That an identity hasn't changed. Some resources have mutable identities, and the provider SDK can provide better safeguards and opt-out behaviour than enforcing this for every resource type in Terraform.
2. That an identity can't contain null values. Some identities need some sort of "optional" attribute, so we won't enforce that values must be non-null. This shifts some responsibility to provider authors that a resource identity is still uniquely identifiable even with null values.

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.12.x

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [ ] This change is not user-facing.
