### PR TITLE
fix: avoid sending HEAD request on provider download

### DIFF
--- a/.changes/v1.12/BUG FIXES-20250514-184357.yaml
+++ b/.changes/v1.12/BUG FIXES-20250514-184357.yaml
@@ -1,0 +1,5 @@
+kind: BUG FIXES
+body: avoid sending HEAD request on provider download
+time: 2025-05-14T18:43:57.332193-04:00
+custom:
+    Issue: "36987"

--- a/.changes/v1.12/BUG FIXES-20250514-184357.yaml
+++ b/.changes/v1.12/BUG FIXES-20250514-184357.yaml
@@ -1,5 +1,5 @@
 kind: BUG FIXES
-body: avoid sending HEAD request on provider download
+body: Fix regression during provider installation by reverting back to not sending HEAD requests.
 time: 2025-05-14T18:43:57.332193-04:00
 custom:
-    Issue: "36987"
+    Issue: "36998"

--- a/internal/providercache/package_install.go
+++ b/internal/providercache/package_install.go
@@ -34,6 +34,7 @@ func installFromHTTPURL(ctx context.Context, meta getproviders.PackageMeta, targ
 		Client:                httpclient.New(),
 		Netrc:                 true,
 		XTerraformGetDisabled: true,
+		DoNotCheckHeadFirst:   true,
 	}
 
 	urlObj, err := url.Parse(urlStr)


### PR DESCRIPTION
Avoiding the new HEAD request that happens before GET request to get provider binary.

Fixes #36987

## Target Release

1.11.x
1.12.x
1.13.x

## Draft CHANGELOG entry

### BUG FIXES
- `terraform init` - avoid sending a HEAD request when fetching providers
