### PR TITLE
Handle stacks plugin interrupts

### DIFF
--- a/internal/command/stacks.go
+++ b/internal/command/stacks.go
@@ -94,8 +94,9 @@ func (c *StacksCommand) realRun(args []string, stdout, stderr io.Writer) int {
 		VersionedPlugins: map[int]plugin.PluginSet{
 			1: {
 				"stacks": &stacksplugin1.GRPCStacksPlugin{
-					Metadata: c.pluginConfig.ToMetadata(),
-					Services: c.Meta.Services,
+					Metadata:   c.pluginConfig.ToMetadata(),
+					Services:   c.Meta.Services,
+					ShutdownCh: c.Meta.ShutdownCh,
 				},
 			},
 		},

--- a/internal/rpcapi/stacks_grpc_client.go
+++ b/internal/rpcapi/stacks_grpc_client.go
@@ -108,6 +108,7 @@ func (c GRPCStacksClient) executeWithBrokers(brokerIDs brokerIDs, args []string,
 	// Monitor for interrupt and cancel the context if received
 	go func() {
 		sig := <-c.ShutdownCh
+		fmt.Print("\n\nOperation Interrupted, any remote operations started will continue\n\n")
 		log.Printf("[INFO] Received signal: %s, cancelling operation", sig)
 		cancel()
 	}()

--- a/internal/rpcapi/stacks_grpc_client.go
+++ b/internal/rpcapi/stacks_grpc_client.go
@@ -24,10 +24,11 @@ import (
 
 // GRPCStacksClient is the client interface for interacting with terraform-stacksplugin
 type GRPCStacksClient struct {
-	Client   stacksproto1.CommandServiceClient
-	Broker   *plugin.GRPCBroker
-	Services *disco.Disco
-	Context  context.Context
+	Client     stacksproto1.CommandServiceClient
+	Broker     *plugin.GRPCBroker
+	Services   *disco.Disco
+	Context    context.Context
+	ShutdownCh <-chan struct{}
 }
 
 // Proof that GRPCStacksClient fulfills the go-plugin interface
@@ -102,7 +103,16 @@ func (c GRPCStacksClient) registerBrokers(stdout, stderr io.Writer) brokerIDs {
 // Execute sends the client Execute request and waits for the plugin to return
 // an exit code response before returning
 func (c GRPCStacksClient) executeWithBrokers(brokerIDs brokerIDs, args []string, stdout, stderr io.Writer) int {
-	client, err := c.Client.Execute(c.Context, &stacksproto1.CommandRequest{
+	ctx, cancel := context.WithCancel(c.Context)
+
+	// Monitor for interrupt and cancel the context if received
+	go func() {
+		sig := <-c.ShutdownCh
+		log.Printf("[INFO] Received signal: %s, cancelling operation", sig)
+		cancel()
+	}()
+
+	client, err := c.Client.Execute(ctx, &stacksproto1.CommandRequest{
 		DependenciesServer: brokerIDs.dependenciesBrokerID,
 		PackagesServer:     brokerIDs.packagesBrokerID,
 		StacksServer:       brokerIDs.stacksBrokerID,

--- a/internal/stacksplugin/stacksplugin1/stacks_grpc_plugin.go
+++ b/internal/stacksplugin/stacksplugin1/stacks_grpc_plugin.go
@@ -21,9 +21,10 @@ import (
 // implementation exists in this package.
 type GRPCStacksPlugin struct {
 	plugin.GRPCPlugin
-	Metadata metadata.MD
-	Impl     pluginshared.CustomPluginClient
-	Services *disco.Disco
+	Metadata   metadata.MD
+	Impl       pluginshared.CustomPluginClient
+	Services   *disco.Disco
+	ShutdownCh <-chan struct{}
 }
 
 // Server always returns an error; we're only implementing the GRPCPlugin
@@ -42,10 +43,11 @@ func (p *GRPCStacksPlugin) Client(*plugin.MuxBroker, *rpc.Client) (interface{}, 
 func (p *GRPCStacksPlugin) GRPCClient(ctx context.Context, broker *plugin.GRPCBroker, c *grpc.ClientConn) (interface{}, error) {
 	ctx = metadata.NewOutgoingContext(ctx, p.Metadata)
 	return &rpcapi.GRPCStacksClient{
-		Client:   stacksproto1.NewCommandServiceClient(c),
-		Broker:   broker,
-		Services: p.Services,
-		Context:  ctx,
+		Client:     stacksproto1.NewCommandServiceClient(c),
+		Broker:     broker,
+		Services:   p.Services,
+		Context:    ctx,
+		ShutdownCh: p.ShutdownCh,
 	}, nil
 }
 


### PR DESCRIPTION
Fixes #

This PR provides the ability for command interrupts to be propagated to the Stacks Plugin

This functional goes along with [this Stacks Plugin PR](https://github.com/hashicorp/terraform-stacks-cli/pull/186), and should be used for smoke testing.

## Target Release

1.13.x

## CHANGELOG entry

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
