### PR TITLE
docs/cidrnetmask: Address confusing note about IPv6

### DIFF
--- a/website/docs/language/functions/cidrnetmask.mdx
+++ b/website/docs/language/functions/cidrnetmask.mdx
@@ -20,8 +20,8 @@ cidrnetmask(prefix)
 The result is a subnet address formatted in the conventional dotted-decimal
 IPv4 address syntax, as expected by some software.
 
-CIDR notation is the only valid notation for IPv6 addresses, so `cidrnetmask`
-produces an error if given an IPv6 address.
+The `cidrnetmask` function only accepts IPv4 addresses in CIDR notation.
+If you use an IPv6 address, `cidrnetmask` returns an error. 
 
 -> **Note:** As a historical accident, this function interprets IPv4 address
 octets that have leading zeros as decimal numbers, which is contrary to some


### PR DESCRIPTION
This is to pull changes out of https://github.com/hashicorp/terraform/pull/33107 with suggested corrections and also fixed indentation.

Closes #33107 

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.13.x

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [ ] This change is not user-facing.
