### PR TITLE
Update JUnit output test to tolerate scientific notation

### DIFF
--- a/internal/command/test_test.go
+++ b/internal/command/test_test.go
@@ -3463,7 +3463,7 @@ func TestTest_JUnitOutput(t *testing.T) {
 			}
 
 			// actual output will include timestamps and test duration data, which isn't deterministic; redact it for comparison
-			timeRegexp := regexp.MustCompile(`time=\"[0-9\.]+\"`)
+			timeRegexp := regexp.MustCompile(`time="[^"]+"`)
 			actualOut = timeRegexp.ReplaceAll(actualOut, []byte("time=\"TIME_REDACTED\""))
 			timestampRegexp := regexp.MustCompile(`timestamp="[^"]+"`)
 			actualOut = timestampRegexp.ReplaceAll(actualOut, []byte("timestamp=\"TIMESTAMP_REDACTED\""))


### PR DESCRIPTION
Fixing a test failure that comes from the machine running TestTest_JUnitOutput so fast that the test duration is under a second. The regex currently expects a number with a decimal in it, not scientific notation like "7.1e-05".

It's not valid to force integer values for `time` ([see use of non-integer values here](https://github.com/testmoapp/junitxml?tab=readme-ov-file#complete-junit-xml-example)), so we don't want to convert the `time` value to integers to solve the scientific notation problem.

Instead, this is a case where the test needs to be updated, not the code under test. We use a trivial test for `TestTest_JUnitOutput`, which can take less than a second to run, so triggering the test failure is due to how contrived the test scenario is.


## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

N/A

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
