### PR TITLE
stacks: skip resource instance hooks during refresh plans

### DIFF
--- a/internal/stacks/stackruntime/helper_hooks_test.go
+++ b/internal/stacks/stackruntime/helper_hooks_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
 package stackruntime
 
 import (

--- a/internal/stacks/stackruntime/helper_hooks_test.go
+++ b/internal/stacks/stackruntime/helper_hooks_test.go
@@ -1,0 +1,400 @@
+package stackruntime
+
+import (
+	"context"
+	"sort"
+	"sync"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/hashicorp/terraform/internal/collections"
+	"github.com/hashicorp/terraform/internal/stacks/stackaddrs"
+	"github.com/hashicorp/terraform/internal/stacks/stackruntime/hooks"
+)
+
+type ExpectedHooks struct {
+	ComponentExpanded                       []*hooks.ComponentInstances
+	RemovedComponentExpanded                []*hooks.RemovedComponentInstances
+	PendingComponentInstancePlan            collections.Set[stackaddrs.AbsComponentInstance]
+	BeginComponentInstancePlan              collections.Set[stackaddrs.AbsComponentInstance]
+	EndComponentInstancePlan                collections.Set[stackaddrs.AbsComponentInstance]
+	ErrorComponentInstancePlan              collections.Set[stackaddrs.AbsComponentInstance]
+	DeferComponentInstancePlan              collections.Set[stackaddrs.AbsComponentInstance]
+	PendingComponentInstanceApply           collections.Set[stackaddrs.AbsComponentInstance]
+	BeginComponentInstanceApply             collections.Set[stackaddrs.AbsComponentInstance]
+	EndComponentInstanceApply               collections.Set[stackaddrs.AbsComponentInstance]
+	ErrorComponentInstanceApply             collections.Set[stackaddrs.AbsComponentInstance]
+	ReportResourceInstanceStatus            []*hooks.ResourceInstanceStatusHookData
+	ReportResourceInstanceProvisionerStatus []*hooks.ResourceInstanceProvisionerHookData
+	ReportResourceInstanceDrift             []*hooks.ResourceInstanceChange
+	ReportResourceInstancePlanned           []*hooks.ResourceInstanceChange
+	ReportResourceInstanceDeferred          []*hooks.DeferredResourceInstanceChange
+	ReportComponentInstancePlanned          []*hooks.ComponentInstanceChange
+	ReportComponentInstanceApplied          []*hooks.ComponentInstanceChange
+}
+
+func (eh *ExpectedHooks) Validate(t *testing.T, expectedHooks *ExpectedHooks) {
+	sort.SliceStable(expectedHooks.ComponentExpanded, func(i, j int) bool {
+		return expectedHooks.ComponentExpanded[i].ComponentAddr.String() < expectedHooks.ComponentExpanded[j].ComponentAddr.String()
+	})
+	sort.SliceStable(expectedHooks.RemovedComponentExpanded, func(i, j int) bool {
+		return expectedHooks.RemovedComponentExpanded[i].Source.String() < expectedHooks.RemovedComponentExpanded[j].Source.String()
+	})
+	sort.SliceStable(expectedHooks.ReportResourceInstanceStatus, func(i, j int) bool {
+		return expectedHooks.ReportResourceInstanceStatus[i].Addr.String() < expectedHooks.ReportResourceInstanceStatus[j].Addr.String()
+	})
+	sort.SliceStable(expectedHooks.ReportResourceInstanceProvisionerStatus, func(i, j int) bool {
+		return expectedHooks.ReportResourceInstanceProvisionerStatus[i].Addr.String() < expectedHooks.ReportResourceInstanceProvisionerStatus[j].Addr.String()
+	})
+	sort.SliceStable(expectedHooks.ReportResourceInstanceDrift, func(i, j int) bool {
+		return expectedHooks.ReportResourceInstanceDrift[i].Addr.String() < expectedHooks.ReportResourceInstanceDrift[j].Addr.String()
+	})
+	sort.SliceStable(expectedHooks.ReportResourceInstancePlanned, func(i, j int) bool {
+		return expectedHooks.ReportResourceInstancePlanned[i].Addr.String() < expectedHooks.ReportResourceInstancePlanned[j].Addr.String()
+	})
+	sort.SliceStable(expectedHooks.ReportResourceInstanceDeferred, func(i, j int) bool {
+		return expectedHooks.ReportResourceInstanceDeferred[i].Change.Addr.String() < expectedHooks.ReportResourceInstanceDeferred[j].Change.Addr.String()
+	})
+	sort.SliceStable(expectedHooks.ReportComponentInstancePlanned, func(i, j int) bool {
+		return expectedHooks.ReportComponentInstancePlanned[i].Addr.String() < expectedHooks.ReportComponentInstancePlanned[j].Addr.String()
+	})
+	sort.SliceStable(expectedHooks.ReportComponentInstanceApplied, func(i, j int) bool {
+		return expectedHooks.ReportComponentInstanceApplied[i].Addr.String() < expectedHooks.ReportComponentInstanceApplied[j].Addr.String()
+	})
+
+	if diff := cmp.Diff(expectedHooks.ComponentExpanded, eh.ComponentExpanded); len(diff) > 0 {
+		t.Errorf("wrong ComponentExpanded hooks: %s", diff)
+	}
+	if diff := cmp.Diff(expectedHooks.RemovedComponentExpanded, eh.RemovedComponentExpanded); len(diff) > 0 {
+		t.Errorf("wrong RemovedComponentExpanded hooks: %s", diff)
+	}
+	if diff := cmp.Diff(expectedHooks.PendingComponentInstancePlan, eh.PendingComponentInstancePlan, collections.CmpOptions); len(diff) > 0 {
+		t.Errorf("wrong PendingComponentInstancePlan hooks: %s", diff)
+	}
+	if diff := cmp.Diff(expectedHooks.BeginComponentInstancePlan, eh.BeginComponentInstancePlan, collections.CmpOptions); len(diff) > 0 {
+		t.Errorf("wrong BeginComponentInstancePlan hooks: %s", diff)
+	}
+	if diff := cmp.Diff(expectedHooks.EndComponentInstancePlan, eh.EndComponentInstancePlan, collections.CmpOptions); len(diff) > 0 {
+		t.Errorf("wrong EndComponentInstancePlan hooks: %s", diff)
+	}
+	if diff := cmp.Diff(expectedHooks.ErrorComponentInstancePlan, eh.ErrorComponentInstancePlan, collections.CmpOptions); len(diff) > 0 {
+		t.Errorf("wrong ErrorComponentInstancePlan hooks: %s", diff)
+	}
+	if diff := cmp.Diff(expectedHooks.DeferComponentInstancePlan, eh.DeferComponentInstancePlan, collections.CmpOptions); len(diff) > 0 {
+		t.Errorf("wrong DeferComponentInstancePlan hooks: %s", diff)
+	}
+	if diff := cmp.Diff(expectedHooks.PendingComponentInstanceApply, eh.PendingComponentInstanceApply, collections.CmpOptions); len(diff) > 0 {
+		t.Errorf("wrong PendingComponentInstanceApply hooks: %s", diff)
+	}
+	if diff := cmp.Diff(expectedHooks.BeginComponentInstanceApply, eh.BeginComponentInstanceApply, collections.CmpOptions); len(diff) > 0 {
+		t.Errorf("wrong BeginComponentInstanceApply hooks: %s", diff)
+	}
+	if diff := cmp.Diff(expectedHooks.EndComponentInstanceApply, eh.EndComponentInstanceApply, collections.CmpOptions); len(diff) > 0 {
+		t.Errorf("wrong EndComponentInstanceApply hooks: %s", diff)
+	}
+	if diff := cmp.Diff(expectedHooks.ErrorComponentInstanceApply, eh.ErrorComponentInstanceApply, collections.CmpOptions); len(diff) > 0 {
+		t.Errorf("wrong ErrorComponentInstanceApply hooks: %s", diff)
+	}
+	if diff := cmp.Diff(expectedHooks.ReportResourceInstanceStatus, eh.ReportResourceInstanceStatus); len(diff) > 0 {
+		t.Errorf("wrong ReportResourceInstanceStatus hooks: %s", diff)
+	}
+	if diff := cmp.Diff(expectedHooks.ReportResourceInstanceProvisionerStatus, eh.ReportResourceInstanceProvisionerStatus); len(diff) > 0 {
+		t.Errorf("wrong ReportResourceInstanceProvisionerStatus hooks: %s", diff)
+	}
+	if diff := cmp.Diff(expectedHooks.ReportResourceInstanceDrift, eh.ReportResourceInstanceDrift); len(diff) > 0 {
+		t.Errorf("wrong ReportResourceInstanceDrift hooks: %s", diff)
+	}
+	if diff := cmp.Diff(expectedHooks.ReportResourceInstancePlanned, eh.ReportResourceInstancePlanned); len(diff) > 0 {
+		t.Errorf("wrong ReportResourceInstancePlanned hooks: %s", diff)
+	}
+	if diff := cmp.Diff(expectedHooks.ReportResourceInstanceDeferred, eh.ReportResourceInstanceDeferred); len(diff) > 0 {
+		t.Errorf("wrong ReportResourceInstanceDeferred hooks: %s", diff)
+	}
+	if diff := cmp.Diff(expectedHooks.ReportComponentInstancePlanned, eh.ReportComponentInstancePlanned); len(diff) > 0 {
+		t.Errorf("wrong ReportComponentInstancePlanned hooks: %s", diff)
+	}
+	if diff := cmp.Diff(expectedHooks.ReportComponentInstanceApplied, eh.ReportComponentInstanceApplied); len(diff) > 0 {
+		t.Errorf("wrong ReportComponentInstanceApplied hooks: %s", diff)
+	}
+}
+
+type CapturedHooks struct {
+	ExpectedHooks
+
+	sync.Mutex
+	Planning bool
+}
+
+func NewCapturedHooks(planning bool) *CapturedHooks {
+	return &CapturedHooks{
+		Planning: planning,
+		ExpectedHooks: ExpectedHooks{
+			PendingComponentInstancePlan:  collections.NewSet[stackaddrs.AbsComponentInstance](),
+			BeginComponentInstancePlan:    collections.NewSet[stackaddrs.AbsComponentInstance](),
+			EndComponentInstancePlan:      collections.NewSet[stackaddrs.AbsComponentInstance](),
+			ErrorComponentInstancePlan:    collections.NewSet[stackaddrs.AbsComponentInstance](),
+			DeferComponentInstancePlan:    collections.NewSet[stackaddrs.AbsComponentInstance](),
+			PendingComponentInstanceApply: collections.NewSet[stackaddrs.AbsComponentInstance](),
+			BeginComponentInstanceApply:   collections.NewSet[stackaddrs.AbsComponentInstance](),
+			EndComponentInstanceApply:     collections.NewSet[stackaddrs.AbsComponentInstance](),
+			ErrorComponentInstanceApply:   collections.NewSet[stackaddrs.AbsComponentInstance](),
+		},
+	}
+}
+
+func (ch *CapturedHooks) ComponentInstancePending(addr stackaddrs.AbsComponentInstance) bool {
+	if ch.Planning {
+		return ch.PendingComponentInstancePlan.Has(addr)
+	}
+	return ch.PendingComponentInstanceApply.Has(addr)
+}
+
+func (ch *CapturedHooks) ComponentInstanceBegun(addr stackaddrs.AbsComponentInstance) bool {
+	if ch.Planning {
+		return ch.BeginComponentInstancePlan.Has(addr)
+	}
+	return ch.BeginComponentInstanceApply.Has(addr)
+}
+
+func (ch *CapturedHooks) ComponentInstanceFinished(addr stackaddrs.AbsComponentInstance) bool {
+	if ch.Planning {
+		return ch.EndComponentInstancePlan.Has(addr) || ch.ErrorComponentInstancePlan.Has(addr) || ch.DeferComponentInstancePlan.Has(addr)
+	}
+	return ch.EndComponentInstanceApply.Has(addr) || ch.ErrorComponentInstanceApply.Has(addr)
+}
+
+func (ch *CapturedHooks) captureHooks() *Hooks {
+	return &Hooks{
+		ComponentExpanded: func(ctx context.Context, instances *hooks.ComponentInstances) {
+			ch.Lock()
+			defer ch.Unlock()
+			ch.ComponentExpanded = append(ch.ComponentExpanded, instances)
+		},
+		RemovedComponentExpanded: func(ctx context.Context, instances *hooks.RemovedComponentInstances) {
+			ch.Lock()
+			defer ch.Unlock()
+			ch.RemovedComponentExpanded = append(ch.RemovedComponentExpanded, instances)
+		},
+		PendingComponentInstancePlan: func(ctx context.Context, instance stackaddrs.AbsComponentInstance) {
+			ch.Lock()
+			defer ch.Unlock()
+			if ch.ComponentInstancePending(instance) {
+				panic("tried to add pending component instance plan twice")
+			}
+			ch.PendingComponentInstancePlan.Add(instance)
+		},
+		BeginComponentInstancePlan: func(ctx context.Context, instance stackaddrs.AbsComponentInstance) any {
+			ch.Lock()
+			defer ch.Unlock()
+
+			if !ch.ComponentInstancePending(instance) {
+				panic("tried to begin component instance plan before ending")
+			}
+
+			if ch.ComponentInstanceBegun(instance) {
+				panic("tried to add begin component instance plan twice")
+			}
+			ch.BeginComponentInstancePlan.Add(instance)
+			return nil
+		},
+		EndComponentInstancePlan: func(ctx context.Context, a any, instance stackaddrs.AbsComponentInstance) any {
+			ch.Lock()
+			defer ch.Unlock()
+
+			if !ch.BeginComponentInstancePlan.Has(instance) {
+				panic("tried to end component instance plan before beginning")
+			}
+
+			if ch.EndComponentInstancePlan.Has(instance) || ch.ErrorComponentInstancePlan.Has(instance) || ch.DeferComponentInstancePlan.Has(instance) {
+				panic("tried to add end component instance plan twice")
+			}
+			ch.EndComponentInstancePlan.Add(instance)
+			return a
+		},
+		ErrorComponentInstancePlan: func(ctx context.Context, a any, instance stackaddrs.AbsComponentInstance) any {
+			ch.Lock()
+			defer ch.Unlock()
+
+			if !ch.ComponentInstanceBegun(instance) {
+				panic("tried to end component instance plan before beginning")
+			}
+
+			if ch.ComponentInstanceFinished(instance) {
+				panic("tried to add end component instance plan twice")
+			}
+			ch.ErrorComponentInstancePlan.Add(instance)
+			return a
+		},
+		DeferComponentInstancePlan: func(ctx context.Context, a any, instance stackaddrs.AbsComponentInstance) any {
+			ch.Lock()
+			defer ch.Unlock()
+
+			if !ch.ComponentInstanceBegun(instance) {
+				panic("tried to end component instance plan before beginning")
+			}
+
+			if ch.ComponentInstanceFinished(instance) {
+				panic("tried to add end component instance plan twice")
+			}
+			ch.DeferComponentInstancePlan.Add(instance)
+			return a
+		},
+		PendingComponentInstanceApply: func(ctx context.Context, instance stackaddrs.AbsComponentInstance) {
+			ch.Lock()
+			defer ch.Unlock()
+
+			if ch.ComponentInstancePending(instance) {
+				panic("tried to add pending component instance apply twice")
+			}
+			ch.PendingComponentInstanceApply.Add(instance)
+		},
+		BeginComponentInstanceApply: func(ctx context.Context, instance stackaddrs.AbsComponentInstance) any {
+			ch.Lock()
+			defer ch.Unlock()
+
+			if !ch.ComponentInstancePending(instance) {
+				panic("tried to begin component before pending")
+			}
+
+			if ch.ComponentInstanceBegun(instance) {
+				panic("tried to add begin component instance apply twice")
+			}
+			ch.BeginComponentInstanceApply.Add(instance)
+			return nil
+		},
+		EndComponentInstanceApply: func(ctx context.Context, a any, instance stackaddrs.AbsComponentInstance) any {
+			ch.Lock()
+			defer ch.Unlock()
+
+			if !ch.ComponentInstanceBegun(instance) {
+				panic("tried to end component before beginning")
+			}
+
+			if ch.ComponentInstanceFinished(instance) {
+				panic("tried to add end component instance apply twice")
+			}
+			ch.EndComponentInstanceApply.Add(instance)
+			return a
+		},
+		ErrorComponentInstanceApply: func(ctx context.Context, a any, instance stackaddrs.AbsComponentInstance) any {
+			ch.Lock()
+			defer ch.Unlock()
+
+			if !ch.ComponentInstanceBegun(instance) {
+				panic("tried to end component before beginning")
+			}
+
+			if ch.ComponentInstanceFinished(instance) {
+				panic("tried to add error component instance apply twice")
+			}
+			ch.ErrorComponentInstanceApply.Add(instance)
+			return a
+		},
+		ReportResourceInstanceStatus: func(ctx context.Context, a any, data *hooks.ResourceInstanceStatusHookData) any {
+			ch.Lock()
+			defer ch.Unlock()
+
+			if !ch.ComponentInstanceBegun(data.Addr.Component) {
+				panic("tried to report resource instance status before component")
+			}
+
+			if ch.ComponentInstanceFinished(data.Addr.Component) {
+				panic("tried to report resource instance status after component")
+			}
+
+			ch.ReportResourceInstanceStatus = append(ch.ReportResourceInstanceStatus, data)
+			return a
+		},
+		ReportResourceInstanceProvisionerStatus: func(ctx context.Context, a any, data *hooks.ResourceInstanceProvisionerHookData) any {
+			ch.Lock()
+			defer ch.Unlock()
+
+			if !ch.ComponentInstanceBegun(data.Addr.Component) {
+				panic("tried to report resource instance provisioner status before component")
+			}
+
+			if ch.ComponentInstanceFinished(data.Addr.Component) {
+				panic("tried to report resource instance provisioner status after component")
+			}
+
+			ch.ReportResourceInstanceProvisionerStatus = append(ch.ReportResourceInstanceProvisionerStatus, data)
+			return a
+		},
+		ReportResourceInstanceDrift: func(ctx context.Context, a any, change *hooks.ResourceInstanceChange) any {
+			ch.Lock()
+			defer ch.Unlock()
+
+			if !ch.ComponentInstanceBegun(change.Addr.Component) {
+				panic("tried to report resource instance drift before component")
+			}
+
+			if ch.ComponentInstanceFinished(change.Addr.Component) {
+				panic("tried to report resource instance drift after component")
+			}
+
+			ch.ReportResourceInstanceDrift = append(ch.ReportResourceInstanceDrift, change)
+			return a
+		},
+		ReportResourceInstancePlanned: func(ctx context.Context, a any, change *hooks.ResourceInstanceChange) any {
+			ch.Lock()
+			defer ch.Unlock()
+
+			if !ch.ComponentInstanceBegun(change.Addr.Component) {
+				panic("tried to report resource instance planned before component")
+			}
+
+			if ch.ComponentInstanceFinished(change.Addr.Component) {
+				panic("tried to report resource instance planned after component")
+			}
+
+			ch.ReportResourceInstancePlanned = append(ch.ReportResourceInstancePlanned, change)
+			return a
+		},
+		ReportResourceInstanceDeferred: func(ctx context.Context, a any, change *hooks.DeferredResourceInstanceChange) any {
+			ch.Lock()
+			defer ch.Unlock()
+
+			if !ch.ComponentInstanceBegun(change.Change.Addr.Component) {
+				panic("tried to report resource instance deferred before component")
+			}
+
+			if ch.ComponentInstanceFinished(change.Change.Addr.Component) {
+				panic("tried to report resource instance deferred after component")
+			}
+
+			ch.ReportResourceInstanceDeferred = append(ch.ReportResourceInstanceDeferred, change)
+			return a
+		},
+		ReportComponentInstancePlanned: func(ctx context.Context, a any, change *hooks.ComponentInstanceChange) any {
+			ch.Lock()
+			defer ch.Unlock()
+
+			if !ch.ComponentInstanceBegun(change.Addr) {
+				panic("tried to report component instance planned before component")
+			}
+
+			if ch.ComponentInstanceFinished(change.Addr) {
+				panic("tried to report component instance planned after component")
+			}
+
+			ch.ReportComponentInstancePlanned = append(ch.ReportComponentInstancePlanned, change)
+			return a
+		},
+		ReportComponentInstanceApplied: func(ctx context.Context, a any, change *hooks.ComponentInstanceChange) any {
+			ch.Lock()
+			defer ch.Unlock()
+
+			if !ch.ComponentInstanceBegun(change.Addr) {
+				panic("tried to report component instance planned before component")
+			}
+
+			if ch.ComponentInstanceFinished(change.Addr) {
+				panic("tried to report component instance planned after component")
+			}
+
+			ch.ReportComponentInstanceApplied = append(ch.ReportComponentInstanceApplied, change)
+			return a
+		},
+	}
+}

--- a/internal/stacks/stackruntime/internal/stackeval/component_instance.go
+++ b/internal/stacks/stackruntime/internal/stackeval/component_instance.go
@@ -218,6 +218,10 @@ func (c *ComponentInstance) CheckModuleTreePlan(ctx context.Context) (*plans.Pla
 				// outputs from this component can read from the refresh result
 				// without causing a cycle.
 
+				h := hooksFromContext(ctx)
+				hookSingle(ctx, h.PendingComponentInstancePlan, c.Addr())
+				seq, planCtx := hookBegin(ctx, h.BeginComponentInstancePlan, h.ContextAttach, c.Addr())
+
 				refresh, moreDiags := c.refresh.Plan(ctx)
 				var filteredDiags tfdiags.Diagnostics
 				for _, diag := range moreDiags {
@@ -231,6 +235,7 @@ func (c *ComponentInstance) CheckModuleTreePlan(ctx context.Context) (*plans.Pla
 				}
 				diags = diags.Append(filteredDiags)
 				if refresh == nil {
+					hookMore(ctx, seq, h.ErrorComponentInstancePlan, c.Addr())
 					return nil, diags
 				}
 
@@ -239,6 +244,7 @@ func (c *ComponentInstance) CheckModuleTreePlan(ctx context.Context) (*plans.Pla
 				opts, moreDiags := c.PlanOpts(ctx, c.mode, true)
 				diags = diags.Append(moreDiags)
 				if opts == nil {
+					hookMore(ctx, seq, h.ErrorComponentInstancePlan, c.Addr())
 					return nil, diags
 				}
 
@@ -268,7 +274,24 @@ func (c *ComponentInstance) CheckModuleTreePlan(ctx context.Context) (*plans.Pla
 					}
 				}
 
-				plan, moreDiags := PlanComponentInstance(ctx, c.main, refresh.PriorState, opts, c)
+				plan, moreDiags := PlanComponentInstance(planCtx, c.main, refresh.PriorState, opts, []terraform.Hook{
+					&componentInstanceTerraformHook{
+						ctx:   ctx,
+						seq:   seq,
+						hooks: hooksFromContext(ctx),
+						addr:  c.Addr(),
+					},
+				}, c)
+				if plan != nil {
+					ReportComponentInstance(ctx, plan, h, seq, c)
+					if plan.Complete {
+						hookMore(ctx, seq, h.EndComponentInstancePlan, c.Addr())
+					} else {
+						hookMore(ctx, seq, h.DeferComponentInstancePlan, c.Addr())
+					}
+				} else {
+					hookMore(ctx, seq, h.ErrorComponentInstancePlan, c.Addr())
+				}
 				return plan, diags.Append(moreDiags)
 			}
 
@@ -311,7 +334,27 @@ func (c *ComponentInstance) CheckModuleTreePlan(ctx context.Context) (*plans.Pla
 				}
 			}
 
-			plan, moreDiags := PlanComponentInstance(ctx, c.main, c.PlanPrevState(), opts, c)
+			h := hooksFromContext(ctx)
+			hookSingle(ctx, h.PendingComponentInstancePlan, c.Addr())
+			seq, ctx := hookBegin(ctx, h.BeginComponentInstancePlan, h.ContextAttach, c.Addr())
+			plan, moreDiags := PlanComponentInstance(ctx, c.main, c.PlanPrevState(), opts, []terraform.Hook{
+				&componentInstanceTerraformHook{
+					ctx:   ctx,
+					seq:   seq,
+					hooks: hooksFromContext(ctx),
+					addr:  c.Addr(),
+				},
+			}, c)
+			if plan != nil {
+				ReportComponentInstance(ctx, plan, h, seq, c)
+				if plan.Complete {
+					hookMore(ctx, seq, h.EndComponentInstancePlan, c.Addr())
+				} else {
+					hookMore(ctx, seq, h.DeferComponentInstancePlan, c.Addr())
+				}
+			} else {
+				hookMore(ctx, seq, h.ErrorComponentInstancePlan, c.Addr())
+			}
 			return plan, diags.Append(moreDiags)
 		},
 	)

--- a/internal/stacks/stackruntime/internal/stackeval/refresh_instance.go
+++ b/internal/stacks/stackruntime/internal/stackeval/refresh_instance.go
@@ -74,7 +74,7 @@ func (r *RefreshInstance) Plan(ctx context.Context) (*plans.Plan, tfdiags.Diagno
 		// compatible with the destroy operation.
 		opts.PreDestroyRefresh = true
 
-		plan, moreDiags := PlanComponentInstance(ctx, r.component.main, r.component.PlanPrevState(), opts, r.component)
+		plan, moreDiags := PlanComponentInstance(ctx, r.component.main, r.component.PlanPrevState(), opts, nil, r.component)
 		return plan, diags.Append(moreDiags)
 	})
 }


### PR DESCRIPTION
During Stacks destroy operations each component does a refresh operation before calling destroy. This was actually causing the number of resources to be double-counted by the stacks progress events as the refresh operation was triggering the pre- and post- diff hooks to be counted by Stacks.

This PR updates the stacks component planning so the hook implementations are taken out of the code shared by the refresh and planning operations, and are instead called directly by the stack graph nodes where they are needed. This ensures the destroy-refresh operation doesn't emit status updates for resources anymore.

I've added a big testing helper function to help test the stacks hooks implementation, and added a test that uses it to expose the problem fixed here. Because most of the tests share the same core testing code, this implementation does also ensure that many additional tests are also validating the hooks process is adding things in the right order even if they're not all directly validating the exact hooks that are being called.