### PR TITLE
Prepare empty 1.13 upgrade guide

### DIFF
--- a/website/docs/language/upgrade-guides/index.mdx
+++ b/website/docs/language/upgrade-guides/index.mdx
@@ -1,72 +1,14 @@
 ---
-page_title: Upgrading to Terraform v1.10
-description: Upgrading to Terraform v1.10
+page_title: Upgrading to Terraform v1.13
+description: Upgrading to Terraform v1.13
 ---
 
-# Upgrading to Terraform v1.10
+# Upgrading to Terraform v1.13
 
 -> **Tip:** Use the version selector to view the upgrade guides for older Terraform versions.
 
-Terraform v1.10 is a minor release in the stable Terraform v1.0 series.
+Terraform v1.13 is a minor release in the stable Terraform v1.0 series.
 
-Terraform v1.10 honors the
+Terraform v1.13 honors the
 [Terraform v1.0 Compatibility Promises](https://developer.hashicorp.com/terraform/language/v1-compatibility-promises).
 There are minor changes that may require additional upgrade steps:
-
-- `moved` blocks will now report an error if `from` or `to` points to a resource type conflicting with reserved keywords
-
-See [the full changelog](https://github.com/hashicorp/terraform/blob/v1.10/CHANGELOG.md)
-for more details. If you encounter any problems during upgrading which are not
-covered this guide, please start a new topic in
-[the Terraform community forum](https://discuss.hashicorp.com/c/terraform-core)
-to discuss it.
-
-## Conflicting `moved` block references
-
-Moved blocks now respect reserved keywords such as `local`, `each`, `self` etc. when parsing resource addresses.
-Configurations that reference resources with type names that match top level blocks and
-keywords from moved blocks will need to prepend the reference identifier with `resource.`.
-
-## S3 Backend 
-
-Executing `terraform init -reconfigure` is required after updating to Terraform v1.10. This removes the [deprecated fields](#root-assume-role-attribute-removal) from the internal state file.
-
-### S3 Native State Locking
-
-The S3 backend now supports S3 native state locking as an opt-in, experimental feature.
-An S3 lock can be used alongside a DynamoDB lock, or independently.
-When both locking mechanisms are configured, a lock must be successfully acquired from both locations before subsequent operations will proceed.
-
-To opt-in to S3 native state locking, set `use_lockfile` to `true`.
-
-```terraform
-terraform {
-  backend "s3" {
-    # additional configuration omitted for brevity
-    use_lockfile = true
-  }
-}
-```
-
-With S3 locking enabled, a lock file will be placed in the same location as the state file.
-The lock file will be named identically to the state file, but with a `.tflock` extension.
-**S3 bucket policies and IAM policies attached to the calling principal may need to be adjusted to include permissions for the new lock file.**
-
-In a future minor version of Terraform the experimental label will be removed from the `use_lockfile` attribute and attributes related to DynamoDB based locking will be deprecated.
-
-### Root Assume Role Attribute Removal
-
-Several root level attributes related to IAM role assumption which were previously deprecated have been removed.
-Each removed field has an analogous field inside the [`assume_role` block](https://developer.hashicorp.com/terraform/language/backend/s3#assume-role-configuration) which should be used instead.
-
-
-| Removed | Replacement |
-| --- | --- |
-| `role_arn` | `assume_role.role_arn` |
-| `session_name` | `assume_role.session_name` |
-| `external_id` | `assume_role.external_id` |
-| `assume_role_duration_seconds` | `assume_role.duration` |
-| `assume_role_policy` | `assume_role.policy` |
-| `assume_role_policy_arns` | `assume_role.policy_arn` |
-| `assume_role_tags` | `assume_role.tags` |
-| `assume_role_transitive_tag_keys` | `assume_role.transitive_tag_keys` |


### PR DESCRIPTION
This is just to avoid accidentally publishing irrelevant upgrade guide under 1.13. We can keep the bare minimum content there for now.

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.13.x

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [ ] This change is not user-facing.
