### PR TITLE
fix: Avoid crash on test failure in BinaryOpExpr in function call

### DIFF
--- a/.changes/v1.12/BUG FIXES-20250516-114251.yaml
+++ b/.changes/v1.12/BUG FIXES-20250516-114251.yaml
@@ -1,0 +1,5 @@
+kind: BUG FIXES
+body: Avoid crash on test failure in comparison in function call
+time: 2025-05-16T11:42:51.289379+01:00
+custom:
+    Issue: "37071"

--- a/internal/command/views/json/diagnostic.go
+++ b/internal/command/views/json/diagnostic.go
@@ -446,7 +446,9 @@ func NewDiagnostic(diag tfdiags.Diagnostic, sources map[string][]byte) *Diagnost
 					// If the test assertion is a binary expression, we'll include the human-readable
 					// formatted LHS and RHS values in the diagnostic snippet.
 					diagnostic.Snippet.TestAssertionExpr = formatRunBinaryDiag(ctx, fromExpr.Expression)
-					diagnostic.Snippet.TestAssertionExpr.ShowVerbose = testDiag.IsTestVerboseMode()
+					if diagnostic.Snippet.TestAssertionExpr != nil {
+						diagnostic.Snippet.TestAssertionExpr.ShowVerbose = testDiag.IsTestVerboseMode()
+					}
 				}
 
 			}


### PR DESCRIPTION
Fixes #37059

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.12.x

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [x] This change is user-facing and I added a changelog entry.
- [ ] This change is not user-facing.
