### PR TITLE
Make diagnostic errors from config parsing more explicit that file paths are relative to the root directory.

### DIFF
--- a/internal/command/testdata/validate-invalid/duplicate_import_targets/output.json
+++ b/internal/command/testdata/validate-invalid/duplicate_import_targets/output.json
@@ -7,7 +7,7 @@
     {
       "severity": "error",
       "summary": "Duplicate import configuration for \"aws_instance.web\"",
-      "detail": "An import block for the resource \"aws_instance.web\" was already declared at testdata/validate-invalid/duplicate_import_targets/main.tf:4,1-7. A resource can have only one import block.",
+      "detail": "An import block for the resource \"aws_instance.web\" was already declared at ./testdata/validate-invalid/duplicate_import_targets/main.tf:4,1-7. A resource can have only one import block.",
       "range": {
         "filename": "testdata/validate-invalid/duplicate_import_targets/main.tf",
         "start": {

--- a/internal/command/testdata/validate-invalid/multiple_modules/output.json
+++ b/internal/command/testdata/validate-invalid/multiple_modules/output.json
@@ -7,7 +7,7 @@
     {
       "severity": "error",
       "summary": "Duplicate module call",
-      "detail": "A module call named \"multi_module\" was already defined at testdata/validate-invalid/multiple_modules/main.tf:1,1-22. Module calls must have unique names within a module.",
+      "detail": "A module call named \"multi_module\" was already defined at ./testdata/validate-invalid/multiple_modules/main.tf:1,1-22. Module calls must have unique names within a module.",
       "range": {
         "filename": "testdata/validate-invalid/multiple_modules/main.tf",
         "start": {

--- a/internal/command/testdata/validate-invalid/multiple_resources/output.json
+++ b/internal/command/testdata/validate-invalid/multiple_resources/output.json
@@ -7,7 +7,7 @@
     {
       "severity": "error",
       "summary": "Duplicate resource \"aws_instance\" configuration",
-      "detail": "A aws_instance resource named \"web\" was already declared at testdata/validate-invalid/multiple_resources/main.tf:1,1-30. Resource names must be unique per type in each module.",
+      "detail": "A aws_instance resource named \"web\" was already declared at ./testdata/validate-invalid/multiple_resources/main.tf:1,1-30. Resource names must be unique per type in each module.",
       "range": {
         "filename": "testdata/validate-invalid/multiple_resources/main.tf",
         "start": {

--- a/internal/command/views/json/diagnostic.go
+++ b/internal/command/views/json/diagnostic.go
@@ -199,7 +199,7 @@ func NewDiagnostic(diag tfdiags.Diagnostic, sources map[string][]byte) *Diagnost
 		}
 
 		diagnostic.Range = &DiagnosticRange{
-			Filename: highlightRange.Filename,
+			Filename: fmt.Sprintf("./%s", highlightRange.Filename),
 			Start: Pos{
 				Line:   highlightRange.Start.Line,
 				Column: highlightRange.Start.Column,

--- a/internal/configs/module.go
+++ b/internal/configs/module.go
@@ -283,7 +283,7 @@ func (m *Module) appendFile(file *File) hcl.Diagnostics {
 			diags = append(diags, &hcl.Diagnostic{
 				Severity: hcl.DiagError,
 				Summary:  "Duplicate provider_meta block",
-				Detail:   fmt.Sprintf("A provider_meta block for provider %q was already declared at %s. Providers may only have one provider_meta block per module.", existing.Provider, existing.DeclRange),
+				Detail:   fmt.Sprintf("A provider_meta block for provider %q was already declared at ./%s. Providers may only have one provider_meta block per module.", existing.Provider, existing.DeclRange),
 				Subject:  &pm.DeclRange,
 			})
 		}
@@ -295,7 +295,7 @@ func (m *Module) appendFile(file *File) hcl.Diagnostics {
 			diags = append(diags, &hcl.Diagnostic{
 				Severity: hcl.DiagError,
 				Summary:  "Duplicate variable declaration",
-				Detail:   fmt.Sprintf("A variable named %q was already declared at %s. Variable names must be unique within a module.", existing.Name, existing.DeclRange),
+				Detail:   fmt.Sprintf("A variable named %q was already declared at ./%s. Variable names must be unique within a module.", existing.Name, existing.DeclRange),
 				Subject:  &v.DeclRange,
 			})
 		}
@@ -307,7 +307,7 @@ func (m *Module) appendFile(file *File) hcl.Diagnostics {
 			diags = append(diags, &hcl.Diagnostic{
 				Severity: hcl.DiagError,
 				Summary:  "Duplicate local value definition",
-				Detail:   fmt.Sprintf("A local value named %q was already defined at %s. Local value names must be unique within a module.", existing.Name, existing.DeclRange),
+				Detail:   fmt.Sprintf("A local value named %q was already defined at ./%s. Local value names must be unique within a module.", existing.Name, existing.DeclRange),
 				Subject:  &l.DeclRange,
 			})
 		}
@@ -319,7 +319,7 @@ func (m *Module) appendFile(file *File) hcl.Diagnostics {
 			diags = append(diags, &hcl.Diagnostic{
 				Severity: hcl.DiagError,
 				Summary:  "Duplicate output definition",
-				Detail:   fmt.Sprintf("An output named %q was already defined at %s. Output names must be unique within a module.", existing.Name, existing.DeclRange),
+				Detail:   fmt.Sprintf("An output named %q was already defined at ./%s. Output names must be unique within a module.", existing.Name, existing.DeclRange),
 				Subject:  &o.DeclRange,
 			})
 		}
@@ -331,7 +331,7 @@ func (m *Module) appendFile(file *File) hcl.Diagnostics {
 			diags = append(diags, &hcl.Diagnostic{
 				Severity: hcl.DiagError,
 				Summary:  "Duplicate module call",
-				Detail:   fmt.Sprintf("A module call named %q was already defined at %s. Module calls must have unique names within a module.", existing.Name, existing.DeclRange),
+				Detail:   fmt.Sprintf("A module call named %q was already defined at ./%s. Module calls must have unique names within a module.", existing.Name, existing.DeclRange),
 				Subject:  &mc.DeclRange,
 			})
 		}
@@ -344,7 +344,7 @@ func (m *Module) appendFile(file *File) hcl.Diagnostics {
 			diags = append(diags, &hcl.Diagnostic{
 				Severity: hcl.DiagError,
 				Summary:  fmt.Sprintf("Duplicate resource %q configuration", existing.Type),
-				Detail:   fmt.Sprintf("A %s resource named %q was already declared at %s. Resource names must be unique per type in each module.", existing.Type, existing.Name, existing.DeclRange),
+				Detail:   fmt.Sprintf("A %s resource named %q was already declared at ./%s. Resource names must be unique per type in each module.", existing.Type, existing.Name, existing.DeclRange),
 				Subject:  &r.DeclRange,
 			})
 			continue
@@ -376,7 +376,7 @@ func (m *Module) appendFile(file *File) hcl.Diagnostics {
 			diags = append(diags, &hcl.Diagnostic{
 				Severity: hcl.DiagError,
 				Summary:  fmt.Sprintf("Duplicate data %q configuration", existing.Type),
-				Detail:   fmt.Sprintf("A %s data resource named %q was already declared at %s. Resource names must be unique per type in each module.", existing.Type, existing.Name, existing.DeclRange),
+				Detail:   fmt.Sprintf("A %s data resource named %q was already declared at ./%s. Resource names must be unique per type in each module.", existing.Type, existing.Name, existing.DeclRange),
 				Subject:  &r.DeclRange,
 			})
 			continue
@@ -390,7 +390,7 @@ func (m *Module) appendFile(file *File) hcl.Diagnostics {
 			diags = append(diags, &hcl.Diagnostic{
 				Severity: hcl.DiagError,
 				Summary:  fmt.Sprintf("Duplicate ephemeral %q configuration", existing.Type),
-				Detail:   fmt.Sprintf("A %s ephemeral resource named %q was already declared at %s. Resource names must be unique per type in each module.", existing.Type, existing.Name, existing.DeclRange),
+				Detail:   fmt.Sprintf("A %s ephemeral resource named %q was already declared at ./%s. Resource names must be unique per type in each module.", existing.Type, existing.Name, existing.DeclRange),
 				Subject:  &r.DeclRange,
 			})
 			continue
@@ -420,7 +420,7 @@ func (m *Module) appendFile(file *File) hcl.Diagnostics {
 				diags = append(diags, &hcl.Diagnostic{
 					Severity: hcl.DiagError,
 					Summary:  fmt.Sprintf("Duplicate data %q configuration", existing.Type),
-					Detail:   fmt.Sprintf("A %s data resource named %q was already declared at %s. Resource names must be unique per type in each module, including within check blocks.", existing.Type, existing.Name, existing.DeclRange),
+					Detail:   fmt.Sprintf("A %s data resource named %q was already declared at ./%s. Resource names must be unique per type in each module, including within check blocks.", existing.Type, existing.Name, existing.DeclRange),
 					Subject:  &c.DataResource.DeclRange,
 				})
 				continue
@@ -432,7 +432,7 @@ func (m *Module) appendFile(file *File) hcl.Diagnostics {
 			diags = append(diags, &hcl.Diagnostic{
 				Severity: hcl.DiagError,
 				Summary:  fmt.Sprintf("Duplicate check %q configuration", existing.Name),
-				Detail:   fmt.Sprintf("A check block named %q was already declared at %s. Check blocks must be unique within each module.", existing.Name, existing.DeclRange),
+				Detail:   fmt.Sprintf("A check block named %q was already declared at ./%s. Check blocks must be unique within each module.", existing.Name, existing.DeclRange),
 				Subject:  &c.DeclRange,
 			})
 			continue
@@ -475,7 +475,7 @@ func (m *Module) appendFile(file *File) hcl.Diagnostics {
 				diags = append(diags, &hcl.Diagnostic{
 					Severity: hcl.DiagError,
 					Summary:  fmt.Sprintf("Duplicate import configuration for %q", i.ToResource),
-					Detail:   fmt.Sprintf("An import block for the resource %q was already declared at %s. A resource can have only one import block.", i.ToResource, mi.DeclRange),
+					Detail:   fmt.Sprintf("An import block for the resource %q was already declared at ./%s. A resource can have only one import block.", i.ToResource, mi.DeclRange),
 					Subject:  i.To.Range().Ptr(),
 				})
 			}
@@ -504,7 +504,7 @@ func (m *Module) appendFile(file *File) hcl.Diagnostics {
 			diags = append(diags, &hcl.Diagnostic{
 				Severity: hcl.DiagError,
 				Summary:  fmt.Sprintf("Duplicate action %q configuration", existing.Type),
-				Detail:   fmt.Sprintf("An action named %q was already declared at %s. Resource names must be unique per type in each module.", existing.Name, existing.DeclRange),
+				Detail:   fmt.Sprintf("An action named %q was already declared at ./%s. Resource names must be unique per type in each module.", existing.Name, existing.DeclRange),
 				Subject:  &a.DeclRange,
 			})
 			continue
@@ -561,7 +561,7 @@ func (m *Module) appendQueryFile(file *QueryFile) hcl.Diagnostics {
 			diags = append(diags, &hcl.Diagnostic{
 				Severity: hcl.DiagError,
 				Summary:  "Duplicate variable declaration",
-				Detail:   fmt.Sprintf("A variable named %q was already declared at %s. Variable names must be unique within a module.", existing.Name, existing.DeclRange),
+				Detail:   fmt.Sprintf("A variable named %q was already declared at ./%s. Variable names must be unique within a module.", existing.Name, existing.DeclRange),
 				Subject:  &v.DeclRange,
 			})
 		}
@@ -573,7 +573,7 @@ func (m *Module) appendQueryFile(file *QueryFile) hcl.Diagnostics {
 			diags = append(diags, &hcl.Diagnostic{
 				Severity: hcl.DiagError,
 				Summary:  "Duplicate local value definition",
-				Detail:   fmt.Sprintf("A local value named %q was already defined at %s. Local value names must be unique within a module.", existing.Name, existing.DeclRange),
+				Detail:   fmt.Sprintf("A local value named %q was already defined at ./%s. Local value names must be unique within a module.", existing.Name, existing.DeclRange),
 				Subject:  &l.DeclRange,
 			})
 		}
@@ -586,7 +586,7 @@ func (m *Module) appendQueryFile(file *QueryFile) hcl.Diagnostics {
 			diags = append(diags, &hcl.Diagnostic{
 				Severity: hcl.DiagError,
 				Summary:  fmt.Sprintf("Duplicate list %q configuration", existing.Type),
-				Detail:   fmt.Sprintf("A %s list named %q was already declared at %s. List names must be unique per type in each module.", existing.Type, existing.Name, existing.DeclRange),
+				Detail:   fmt.Sprintf("A %s list named %q was already declared at ./%s. List names must be unique per type in each module.", existing.Type, existing.Name, existing.DeclRange),
 				Subject:  &ql.DeclRange,
 			})
 			continue

--- a/internal/stacks/stackconfig/declarations.go
+++ b/internal/stacks/stackconfig/declarations.go
@@ -81,7 +81,7 @@ func (d *Declarations) addComponent(decl *Component) tfdiags.Diagnostics {
 			Severity: hcl.DiagError,
 			Summary:  "Duplicate component declaration",
 			Detail: fmt.Sprintf(
-				"An component named %q was already declared at %s.",
+				"An component named %q was already declared at ./%s.",
 				name, existing.DeclRange.ToHCL(),
 			),
 			Subject: decl.DeclRange.ToHCL().Ptr(),
@@ -134,7 +134,7 @@ func (d *Declarations) addEmbeddedStack(decl *EmbeddedStack) tfdiags.Diagnostics
 			Severity: hcl.DiagError,
 			Summary:  "Duplicate embedded stack call",
 			Detail: fmt.Sprintf(
-				"An embedded stack call named %q was already declared at %s.",
+				"An embedded stack call named %q was already declared at ./%s.",
 				name, existing.DeclRange.ToHCL(),
 			),
 			Subject: decl.DeclRange.ToHCL().Ptr(),
@@ -180,7 +180,7 @@ func (d *Declarations) addInputVariable(decl *InputVariable) tfdiags.Diagnostics
 			Severity: hcl.DiagError,
 			Summary:  "Duplicate input variable declaration",
 			Detail: fmt.Sprintf(
-				"An input variable named %q was already declared at %s.",
+				"An input variable named %q was already declared at ./%s.",
 				name, existing.DeclRange.ToHCL(),
 			),
 			Subject: decl.DeclRange.ToHCL().Ptr(),
@@ -204,7 +204,7 @@ func (d *Declarations) addLocalValue(decl *LocalValue) tfdiags.Diagnostics {
 			Severity: hcl.DiagError,
 			Summary:  "Duplicate local value declaration",
 			Detail: fmt.Sprintf(
-				"A local value named %q was already declared at %s.",
+				"A local value named %q was already declared at ./%s.",
 				name, existing.DeclRange.ToHCL(),
 			),
 			Subject: decl.DeclRange.ToHCL().Ptr(),
@@ -228,7 +228,7 @@ func (d *Declarations) addOutputValue(decl *OutputValue) tfdiags.Diagnostics {
 			Severity: hcl.DiagError,
 			Summary:  "Duplicate output value declaration",
 			Detail: fmt.Sprintf(
-				"An output value named %q was already declared at %s.",
+				"An output value named %q was already declared at ./%s.",
 				name, existing.DeclRange.ToHCL(),
 			),
 			Subject: decl.DeclRange.ToHCL().Ptr(),
@@ -273,7 +273,7 @@ func (d *Declarations) addProviderConfig(decl *ProviderConfig) tfdiags.Diagnosti
 			Severity: hcl.DiagError,
 			Summary:  "Duplicate provider configuration",
 			Detail: fmt.Sprintf(
-				"An configuration named %q for provider %q was already declared at %s.",
+				"An configuration named %q for provider %q was already declared at ./%s.",
 				addr.LocalName, addr.Alias, existing.DeclRange.ToHCL(),
 			),
 			Subject: decl.DeclRange.ToHCL().Ptr(),

--- a/internal/stacks/stackconfig/provider_requirements.go
+++ b/internal/stacks/stackconfig/provider_requirements.go
@@ -55,7 +55,7 @@ func decodeProviderRequirementsBlock(block *hcl.Block) (*ProviderRequirements, t
 			diags = diags.Append(&hcl.Diagnostic{
 				Severity: hcl.DiagError,
 				Summary:  "Duplicate provider local name",
-				Detail:   fmt.Sprintf("A provider requirement with local name %q was already declared at %s.", name, existing.DeclRange.StartString()),
+				Detail:   fmt.Sprintf("A provider requirement with local name %q was already declared at ./%s.", name, existing.DeclRange.StartString()),
 				Subject:  attr.NameRange.Ptr(),
 			})
 			continue
@@ -82,7 +82,7 @@ func decodeProviderRequirementsBlock(block *hcl.Block) (*ProviderRequirements, t
 				diags = diags.Append(&hcl.Diagnostic{
 					Severity: hcl.DiagError,
 					Summary:  "Duplicate attribute",
-					Detail:   fmt.Sprintf("The attribute %q was already defined at %s.", name, existing.Key.Range()),
+					Detail:   fmt.Sprintf("The attribute %q was already defined at ./%s.", name, existing.Key.Range()),
 					Subject:  pair.Key.Range().Ptr(),
 				})
 				continue


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Don't want to link it yet, but: issue 36835

Currently diagnostic errors that alert users about duplicate outputs, locals, variables, etc., include the path to the file where the duplication has been detected. This is a path relative to the root module, but there isn't the typical `.` present to indicate that the path is relative.

This PR makes diagnostics include `./` at the start of paths in diagnostic Details for parsing errors such as duplicated locals. It also changes **all diagnostics** to include `./` at the start of the file path in the source shown for the diagnostic.

Examples:

Duplicated local variables and outputs in a child module:

Before:
<img width="1036" alt="Screenshot 2025-05-16 at 13 48 34" src="https://github.com/user-attachments/assets/813acaa9-4374-4610-9e6b-940eca0d16a7" />


After:
<img width="1064" alt="Screenshot 2025-05-16 at 13 49 09" src="https://github.com/user-attachments/assets/0ac3f459-1caf-404f-aba9-9d6c8ca6e96f" />


Duplicated local and output in files in the root module:

<img width="914" alt="Screenshot 2025-05-16 at 13 19 21" src="https://github.com/user-attachments/assets/65174487-365c-4c50-a2db-3a6abe5d86fb" />

Example of impact on other diagnostics:

<img width="427" alt="Screenshot 2025-05-16 at 13 50 52" src="https://github.com/user-attachments/assets/7ec0e008-9cb5-40e3-bca8-769f4b4673db" />



## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.13.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

**N/A**

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [ ] This change is not user-facing.
