### PR TITLE
docs: Warn about use of heredoc for JSON/YAML

### DIFF
--- a/website/docs/language/expressions/strings.mdx
+++ b/website/docs/language/expressions/strings.mdx
@@ -47,7 +47,26 @@ There are also two special escape sequences that do not use backslashes:
 
 ## Heredoc Strings
 
-Terraform also supports a "heredoc" style of string literal inspired by Unix
+<Highlight>
+
+Don't use "heredoc" strings to generate JSON or YAML. Instead, use
+[the `jsonencode` function](/terraform/language/functions/jsonencode) or
+[the `yamlencode` function](/terraform/language/functions/yamlencode) so that Terraform
+can be responsible for guaranteeing valid JSON or YAML syntax.
+
+<CodeBlockConfig>
+
+```hcl
+example = jsonencode({
+  a = 1
+  b = "hello"
+})
+```
+
+</CodeBlockConfig>
+</Highlight>
+
+Terraform supports a "heredoc" style of string literal inspired by Unix
 shell languages, which allows multi-line strings to be expressed more clearly.
 
 ```hcl
@@ -73,20 +92,6 @@ consists entirely of the identifier given in the introducer.
 In the above example, `EOT` is the identifier selected. Any identifier is
 allowed, but conventionally this identifier is in all-uppercase and begins with
 `EO`, meaning "end of". `EOT` in this case stands for "end of text".
-
-### Generating JSON or YAML
-
-Don't use "heredoc" strings to generate JSON or YAML. Instead, use
-[the `jsonencode` function](/terraform/language/functions/jsonencode) or
-[the `yamlencode` function](/terraform/language/functions/yamlencode) so that Terraform
-can be responsible for guaranteeing valid JSON or YAML syntax.
-
-```hcl
-  example = jsonencode({
-    a = 1
-    b = "hello"
-  })
-```
 
 ### Indented Heredocs
 

--- a/website/docs/language/expressions/strings.mdx
+++ b/website/docs/language/expressions/strings.mdx
@@ -47,25 +47,6 @@ There are also two special escape sequences that do not use backslashes:
 
 ## Heredoc Strings
 
-<Highlight>
-
-Don't use "heredoc" strings to generate JSON or YAML. Instead, use
-[the `jsonencode` function](/terraform/language/functions/jsonencode) or
-[the `yamlencode` function](/terraform/language/functions/yamlencode) so that Terraform
-can be responsible for guaranteeing valid JSON or YAML syntax.
-
-<CodeBlockConfig>
-
-```hcl
-example = jsonencode({
-  a = 1
-  b = "hello"
-})
-```
-
-</CodeBlockConfig>
-</Highlight>
-
 Terraform supports a "heredoc" style of string literal inspired by Unix
 shell languages, which allows multi-line strings to be expressed more clearly.
 
@@ -92,6 +73,25 @@ consists entirely of the identifier given in the introducer.
 In the above example, `EOT` is the identifier selected. Any identifier is
 allowed, but conventionally this identifier is in all-uppercase and begins with
 `EO`, meaning "end of". `EOT` in this case stands for "end of text".
+
+<Highlight>
+
+Don't use "heredoc" strings to generate JSON or YAML. Instead, use
+[the `jsonencode` function](/terraform/language/functions/jsonencode) or
+[the `yamlencode` function](/terraform/language/functions/yamlencode) so that Terraform
+can be responsible for guaranteeing valid JSON or YAML syntax.
+
+<CodeBlockConfig>
+
+```hcl
+example = jsonencode({
+  a = 1
+  b = "hello"
+})
+```
+
+</CodeBlockConfig>
+</Highlight>
 
 ### Indented Heredocs
 


### PR DESCRIPTION
Closes https://github.com/hashicorp/terraform/pull/35029

## Preview

https://terraform-et2f4hct7-hashicorp.vercel.app/terraform/language/expressions/strings#heredoc-strings
<img width="717" alt="Screenshot 2025-05-19 at 11 28 27" src="https://github.com/user-attachments/assets/19d6b6d0-b775-436b-b1c1-17152a499c06" />



## Target Release

1.13.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
