### PR TITLE
Allow successful init when constraint matches at least one valid version

### DIFF
--- a/.changes/v1.13/ENHANCEMENTS-20250520-155148.yaml
+++ b/.changes/v1.13/ENHANCEMENTS-20250520-155148.yaml
@@ -1,0 +1,5 @@
+kind: ENHANCEMENTS
+body: Allow successful init when provider constraint matches at least one valid version
+time: 2025-05-20T15:51:48.961362+02:00
+custom:
+    Issue: "37137"

--- a/internal/getproviders/package_authentication.go
+++ b/internal/getproviders/package_authentication.go
@@ -39,6 +39,13 @@ type PackageAuthenticationResult struct {
 	KeyID  string
 }
 
+func NewPackageAuthenticationResult(result int, keyID string) *PackageAuthenticationResult {
+	return &PackageAuthenticationResult{
+		result: packageAuthenticationResult(result),
+		KeyID:  keyID,
+	}
+}
+
 func (t *PackageAuthenticationResult) String() string {
 	if t == nil {
 		return "unauthenticated"

--- a/internal/getproviders/registry_client.go
+++ b/internal/getproviders/registry_client.go
@@ -376,10 +376,8 @@ func (c *registryClient) findClosestProtocolCompatibleVersion(ctx context.Contex
 	for versionStr := range available {
 		v, err := ParseVersion(versionStr)
 		if err != nil {
-			return UnspecifiedVersion, ErrQueryFailed{
-				Provider: provider,
-				Wrapped:  fmt.Errorf("registry response includes invalid version string %q: %s", versionStr, err),
-			}
+			log.Printf("[ERROR] registry response includes invalid version string %q. skipping: %s", versionStr, err)
+			continue
 		}
 		versionList = append(versionList, v)
 	}

--- a/internal/getproviders/registry_client.go
+++ b/internal/getproviders/registry_client.go
@@ -376,7 +376,7 @@ func (c *registryClient) findClosestProtocolCompatibleVersion(ctx context.Contex
 	for versionStr := range available {
 		v, err := ParseVersion(versionStr)
 		if err != nil {
-			log.Printf("[ERROR] registry response includes invalid version string %q. skipping: %s", versionStr, err)
+			log.Printf("[WARN] registry response includes invalid version string %q. skipping: %s", versionStr, err)
 			continue
 		}
 		versionList = append(versionList, v)

--- a/internal/getproviders/registry_client_test.go
+++ b/internal/getproviders/registry_client_test.go
@@ -216,6 +216,11 @@ func fakeRegistryHandler(resp http.ResponseWriter, req *http.Request) {
 			// so we can test that the client-side code places them in the
 			// correct order (lowest precedence first).
 			resp.Write([]byte(`{"versions":[{"version":"0.1.0","protocols":["1.0"]},{"version":"2.0.0","protocols":["99.0"]},{"version":"1.2.0","protocols":["5.0"]}, {"version":"1.0.0","protocols":["5.0"]}]}`))
+		case "awesomesauce/invalidsemver":
+			resp.Header().Set("Content-Type", "application/json")
+			resp.WriteHeader(200)
+			// This response includes an invalid semver version to test that the client properly ignores it
+			resp.Write([]byte(`{"versions":[{"version":"0.1.0","protocols":["1.0"]},{"version":"not-a-semver","protocols":["5.0"]},{"version":"1.0.0","protocols":["5.0"]}]}`))
 		case "weaksauce/unsupported-protocol":
 			resp.Header().Set("Content-Type", "application/json")
 			resp.WriteHeader(200)

--- a/internal/getproviders/registry_source.go
+++ b/internal/getproviders/registry_source.go
@@ -6,6 +6,7 @@ package getproviders
 import (
 	"context"
 	"fmt"
+	"log"
 
 	svchost "github.com/hashicorp/terraform-svchost"
 	disco "github.com/hashicorp/terraform-svchost/disco"
@@ -68,10 +69,8 @@ func (s *RegistrySource) AvailableVersions(ctx context.Context, provider addrs.P
 	for str := range versionsResponse {
 		v, err := ParseVersion(str)
 		if err != nil {
-			return nil, nil, ErrQueryFailed{
-				Provider: provider,
-				Wrapped:  fmt.Errorf("registry response includes invalid version string %q: %s", str, err),
-			}
+			log.Printf("[ERROR] registry response includes invalid version string %q. skipping: %s", str, err)
+			continue
 		}
 		ret = append(ret, v)
 	}

--- a/internal/getproviders/registry_source.go
+++ b/internal/getproviders/registry_source.go
@@ -69,7 +69,7 @@ func (s *RegistrySource) AvailableVersions(ctx context.Context, provider addrs.P
 	for str := range versionsResponse {
 		v, err := ParseVersion(str)
 		if err != nil {
-			log.Printf("[ERROR] registry response includes invalid version string %q. skipping: %s", str, err)
+			log.Printf("[WARN] registry response includes invalid version string %q. skipping: %s", str, err)
 			continue
 		}
 		ret = append(ret, v)

--- a/internal/getproviders/registry_source_test.go
+++ b/internal/getproviders/registry_source_test.go
@@ -34,6 +34,11 @@ func TestSourceAvailableVersions(t *testing.T) {
 			``,
 		},
 		{
+			"example.com/awesomesauce/invalidsemver",
+			[]string{"0.1.0", "1.0.0"},
+			``, // No error expected as invalid semvers are just logged and skipped
+		},
+		{
 			"example.com/weaksauce/no-versions",
 			nil,
 			``, // having no versions is not an error, it's just odd

--- a/internal/providercache/installer_test_helper.go
+++ b/internal/providercache/installer_test_helper.go
@@ -1,0 +1,186 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package providercache
+
+import (
+	"archive/zip"
+	"bytes"
+	"crypto/sha256"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/ProtonMail/go-crypto/openpgp"
+	"github.com/ProtonMail/go-crypto/openpgp/armor"
+)
+
+type providerPkg struct {
+	zipContent    []byte
+	shaSumContent []byte
+	sigContent    []byte
+	key           *bytes.Buffer
+	keyID         string
+	filePrefix    string // <provider_name>_<version>
+}
+
+// createTestProvider creates a test provider package with required verification files
+func createTestProvider(t *testing.T, providerName, version string) *providerPkg {
+	entity, pub := generateGPGKey(t)
+	dir := t.TempDir()
+	fileName := fmt.Sprintf("%s_%s", providerName, version)
+
+	// Create a zip file for the provider
+	zipFile := filepath.Join(dir, fileName)
+	zipContent := createProviderZip(t, zipFile, fileName)
+
+	// Generate SHA256SUMS file
+	sumFile, sumContent, err := createSHASums(dir, fileName)
+	if err != nil {
+		t.Fatalf("failed to create SHA sums: %s", err)
+	}
+
+	// Sign the SHA256SUMS file
+	sigContent, err := createDetachedSignature(sumFile, entity)
+	if err != nil {
+		t.Fatalf("failed to create signature: %s", err)
+	}
+
+	return &providerPkg{
+		zipContent:    zipContent,
+		shaSumContent: sumContent,
+		sigContent:    sigContent,
+		key:           pub,
+		keyID:         entity.PrimaryKey.KeyIdString(),
+		filePrefix:    fileName,
+	}
+}
+
+func generateGPGKey(t *testing.T) (*openpgp.Entity, *bytes.Buffer) {
+	entity, err := openpgp.NewEntity("Terraform Test", "test", "terraform@example.com", nil)
+	if err != nil {
+		t.Fatalf("failed to create entity: %s", err)
+	}
+
+	// Export the public key in armored format
+	pubBuf := bytes.NewBuffer(nil)
+	w, err := armor.Encode(pubBuf, openpgp.PublicKeyType, nil)
+	if err != nil {
+		t.Fatalf("failed to create armor writer: %s", err)
+	}
+
+	if err := entity.Serialize(w); err != nil {
+		t.Fatalf("failed to serialize key: %s", err)
+	}
+
+	if err := w.Close(); err != nil {
+		t.Fatalf("failed to finalize armor: %s", err)
+	}
+
+	return entity, pubBuf
+}
+
+func createProviderZip(t *testing.T, zipPath, filename string) []byte {
+	zipBuffer := new(bytes.Buffer)
+	zipWriter := zip.NewWriter(zipBuffer)
+
+	// Add file to the archive
+	_, err := zipWriter.Create(fmt.Sprintf("terraform-provider-%s", filename))
+	if err != nil {
+		t.Fatalf("failed to create zip entry: %s", err)
+	}
+
+	if err := zipWriter.Close(); err != nil {
+		t.Fatalf("failed to close zip writer: %s", err)
+	}
+
+	// Write the zip to a file
+	zipContent := zipBuffer.Bytes()
+	if err := os.WriteFile(zipPath+".zip", zipContent, 0666); err != nil {
+		t.Fatalf("failed to write zip file: %s", err)
+	}
+
+	return zipContent
+}
+
+// createDetachedSignature creates a PGP detached signature for the given file
+func createDetachedSignature(filePath string, entity *openpgp.Entity) ([]byte, error) {
+	r, err := os.Open(filePath)
+	if err != nil {
+		return nil, err
+	}
+	defer safeClose(r)
+
+	sigPath := filePath + ".sig"
+	w, err := os.Create(sigPath)
+	if err != nil {
+		return nil, err
+	}
+	defer safeClose(w)
+
+	if err := openpgp.DetachSign(w, entity, r, nil); err != nil {
+		return nil, err
+	}
+
+	// Read the signature back
+	return os.ReadFile(sigPath)
+}
+
+// createSHASums creates SHA256 sums for all files in the directory
+func createSHASums(dir, name string) (string, []byte, error) {
+	var sums []string
+
+	files, err := os.ReadDir(dir)
+	if err != nil {
+		return "", nil, err
+	}
+
+	for _, file := range files {
+		if file.IsDir() {
+			continue
+		}
+
+		filePath := filepath.Join(dir, file.Name())
+		sum, err := calculateFileHash(filePath)
+		if err != nil {
+			return "", nil, err
+		}
+
+		sums = append(sums, fmt.Sprintf("%x  %s", sum, file.Name()))
+	}
+
+	sumContent := []byte(strings.Join(sums, "\n") + "\n")
+	sumPath := filepath.Join(dir, fmt.Sprintf("%s_SHA256SUMS", name))
+
+	if err := os.WriteFile(sumPath, sumContent, 0666); err != nil {
+		return "", nil, err
+	}
+
+	return sumPath, sumContent, nil
+}
+
+// calculateFileHash returns the SHA256 hash of a file
+func calculateFileHash(path string) ([]byte, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer safeClose(f)
+
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return nil, err
+	}
+
+	return h.Sum(nil), nil
+}
+
+// safeClose safely closes a file, logging any errors
+func safeClose(f *os.File) {
+	if err := f.Close(); err != nil {
+		fmt.Printf("failed to close file: %s\n", err)
+	}
+}


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

This makes s slight change to the `init` command, so that any version from the registry that does not conform to terraform's semver constraints is skipped, allowing the command to use other versions if present. If there is no version deemed valid, the command still appropriately gets an error, but the error would likely tell the user that the registry has no very matching the requested constraint.

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.13.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [x] This change is user-facing and I added a changelog entry.
- [ ] This change is not user-facing.
