### PR TITLE
terraform test: stop transforming the config under test with new variables

### DIFF
--- a/internal/moduletest/graph/apply.go
+++ b/internal/moduletest/graph/apply.go
@@ -72,8 +72,6 @@ func (n *NodeTestRun) testApply(ctx *EvalContext, variables terraform.InputValue
 		return
 	}
 
-	n.AddVariablesToConfig(variables)
-
 	if ctx.Verbose() {
 		schemas, diags := tfCtx.Schemas(config, updated)
 

--- a/internal/moduletest/graph/plan.go
+++ b/internal/moduletest/graph/plan.go
@@ -40,8 +40,6 @@ func (n *NodeTestRun) testPlan(ctx *EvalContext, variables terraform.InputValues
 		return
 	}
 
-	n.AddVariablesToConfig(variables)
-
 	if ctx.Verbose() {
 		schemas, diags := tfCtx.Schemas(config, plan.PriorState)
 

--- a/internal/moduletest/graph/variables.go
+++ b/internal/moduletest/graph/variables.go
@@ -7,13 +7,13 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/hcl/v2"
+	"github.com/zclconf/go-cty/cty"
+
 	"github.com/hashicorp/terraform/internal/addrs"
-	"github.com/hashicorp/terraform/internal/configs"
 	"github.com/hashicorp/terraform/internal/lang/langrefs"
 	hcltest "github.com/hashicorp/terraform/internal/moduletest/hcl"
 	"github.com/hashicorp/terraform/internal/terraform"
 	"github.com/hashicorp/terraform/internal/tfdiags"
-	"github.com/zclconf/go-cty/cty"
 )
 
 // GetVariables builds the terraform.InputValues required for the provided run
@@ -202,38 +202,4 @@ func (n *NodeTestRun) FilterVariablesToModule(values terraform.InputValues) (mod
 		moduleVars[name] = value
 	}
 	return moduleVars, testOnlyVars, diags
-}
-
-// AddVariablesToConfig extends the provided config to ensure it has definitions
-// for all specified variables.
-//
-// This function is essentially the opposite of FilterVariablesToConfig which
-// makes the variables match the config rather than the config match the
-// variables.
-func (n *NodeTestRun) AddVariablesToConfig(variables terraform.InputValues) {
-	run := n.run
-	// If we have got variable values from the test file we need to make sure
-	// they have an equivalent entry in the configuration. We're going to do
-	// that dynamically here.
-
-	// First, take a backup of the existing configuration so we can easily
-	// restore it later.
-	currentVars := make(map[string]*configs.Variable)
-	for name, variable := range run.ModuleConfig.Module.Variables {
-		currentVars[name] = variable
-	}
-
-	for name, value := range variables {
-		if _, exists := run.ModuleConfig.Module.Variables[name]; exists {
-			continue
-		}
-
-		run.ModuleConfig.Module.Variables[name] = &configs.Variable{
-			Name:           name,
-			Type:           value.Value.Type(),
-			ConstraintType: value.Value.Type(),
-			DeclRange:      value.SourceRange.ToHCL(),
-		}
-	}
-
 }


### PR DESCRIPTION
We haven't actually needed to do this since we added the extra eval context for the test framework with the "extra vars" logic: https://github.com/hashicorp/terraform/blob/d8d890f3b26cd61ec523a3cdbb58645b972be697/internal/moduletest/graph/eval_context.go#L407

When `terraform test` was launched, we were reusing the existing eval context which required any variables to be registered in the configuration. This is no longer needed as the extra test only variables are handled separately.

No changelog needed as their is no external facing change.