### PR TITLE
reduce instance change lookups in GetResource

### DIFF
--- a/.changes/v1.13/ENHANCEMENTS-20250522-093102.yaml
+++ b/.changes/v1.13/ENHANCEMENTS-20250522-093102.yaml
@@ -1,0 +1,5 @@
+kind: ENHANCEMENTS
+body: Performance fix for evaluating high cardinality resources
+time: 2025-05-22T09:31:02.761383-04:00
+custom:
+    Issue: "26355"


### PR DESCRIPTION
Expanded resources always require fetching all instances for evaluation, but the changes data structure requires iterating over all instances for each call to GetResourceInstanceChange, so it turns out to be an n^2 operation. This wasn't very visible in most configs with relatively few numbers of instances, but when you have a resource with a large number of instances referencing another resource with a large number of instances (e.g. the second resource uses the first as the for_each argument), you end up with (n^2)^2 lookups. Because the instance changes are in a global structure, this single point of lock contention would hold up the entire plan.

I'm going to call #26355 closed on this one. It was the last major bottleneck, and gets the performance more inline with individual instance performance. Other fixes will have to be more at the language level, so would be out of scope for instance evaluation specifically.

Closes #26355.


- [x] This change is user-facing and I added a changelog entry.
- [ ] This change is not user-facing.
