### PR TITLE
add TF_GRAPH_TRACE to turn off graph trace output

### DIFF
--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -27,6 +27,10 @@ const (
 	envLogProvider = "TF_LOG_PROVIDER"
 	envLogCloud    = "TF_LOG_CLOUD"
 	envLogStacks   = "TF_LOG_STACKS"
+
+	// This variable is defined here for consistency, but it is used by the
+	// graph builder directly to change how much output to generate.
+	envGraphTrace = "TF_GRAPH_TRACE"
 )
 
 var (
@@ -44,6 +48,8 @@ var (
 		panics:   make(map[string][]string),
 		maxLines: 100,
 	}
+
+	GraphTrace = os.Getenv(envGraphTrace) != ""
 )
 
 func init() {

--- a/internal/terraform/graph_builder.go
+++ b/internal/terraform/graph_builder.go
@@ -45,11 +45,14 @@ func (b *BasicGraphBuilder) Build(path addrs.ModuleInstance) (*Graph, tfdiags.Di
 		log.Printf("[TRACE] Executing graph transform %T", step)
 
 		err := step.Transform(g)
-		if thisStepStr := g.StringWithNodeTypes(); thisStepStr != lastStepStr {
-			log.Printf("[TRACE] Completed graph transform %T with new graph:\n%s  ------", step, logging.Indent(thisStepStr))
-			lastStepStr = thisStepStr
-		} else {
-			log.Printf("[TRACE] Completed graph transform %T (no changes)", step)
+
+		if logging.GraphTrace {
+			if thisStepStr := g.StringWithNodeTypes(); thisStepStr != lastStepStr {
+				log.Printf("[TRACE] Completed graph transform %T with new graph:\n%s  ------", step, logging.Indent(thisStepStr))
+				lastStepStr = thisStepStr
+			} else {
+				log.Printf("[TRACE] Completed graph transform %T (no changes)", step)
+			}
 		}
 
 		if err != nil {
@@ -63,6 +66,11 @@ func (b *BasicGraphBuilder) Build(path addrs.ModuleInstance) (*Graph, tfdiags.Di
 				return g, diags
 			}
 		}
+	}
+
+	if !logging.GraphTrace {
+		// print the graph at least once for normal trace logs
+		log.Printf("[TRACE] Completed graph transform:\n%s  ------", g.StringWithNodeTypes())
 	}
 
 	// Return early if the graph validation is skipped


### PR DESCRIPTION
Graph transformations are really only interesting for developers directly working on graph transformers. Otherwise the complete graph can be printed once in the trace log for general debugging purposes. Removing the intermediate graph steps can reduce log output for large configs by many megabytes per run. On top of the volume of output, the graph string generation can cause a noticeable impact on performance with large graphs.

Developers working on terraform can set `TF_GRAPH_TRACE` to see all intermediate graph transformer steps.
