### PR TITLE
Add missing JUnit XML flag to test command help string

### DIFF
--- a/internal/command/test.go
+++ b/internal/command/test.go
@@ -57,6 +57,11 @@ Options:
   -json                 If specified, machine readable output will be printed in
                         JSON format
 
+  -junit-xml=path       Saves a test report in JUnit XML format to the specified
+                        file. This is currently incompatible with remote test
+                        execution using the the -cloud-run option. The file path
+                        must be relative or absolute.
+
   -no-color             If specified, output won't contain any color.
 
   -parallelism=n        Limit the number of concurrent operations within the 


### PR DESCRIPTION
The `terraform test` command supports outputting a JUnit XML file with the `-junit-xml=path` flag. This flag was not documented in the command help string.

<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.12.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

No.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
