### PR TITLE
Validate list resource schemas

### DIFF
--- a/internal/schemarepo/loadschemas/plugins.go
+++ b/internal/schemarepo/loadschemas/plugins.go
@@ -180,6 +180,12 @@ func (cp *Plugins) ProviderSchema(addr addrs.Provider) (providers.ProviderSchema
 		}
 	}
 
+	for t, r := range resp.ListResourceTypes {
+		if err := r.Body.InternalValidate(); err != nil {
+			return resp, fmt.Errorf("provider %s has invalid schema for list resource type %q, which is a bug in the provider: %q", addr, t, err)
+		}
+	}
+
 	for n, f := range resp.Functions {
 		if !hclsyntax.ValidIdentifier(n) {
 			return resp, fmt.Errorf("provider %s declares function with invalid name %q", addr, n)


### PR DESCRIPTION
This PR runs our `InternalValidate` for list resource schemas

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.13.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
