### PR TITLE
Include list resource schemas in provider json schemas (TF-25497)

### DIFF
--- a/internal/command/jsonprovider/provider.go
+++ b/internal/command/jsonprovider/provider.go
@@ -27,6 +27,7 @@ type Provider struct {
 	ResourceSchemas          map[string]*Schema                         `json:"resource_schemas,omitempty"`
 	DataSourceSchemas        map[string]*Schema                         `json:"data_source_schemas,omitempty"`
 	EphemeralResourceSchemas map[string]*Schema                         `json:"ephemeral_resource_schemas,omitempty"`
+	ListResourceSchemas      map[string]*Schema                         `json:"list_resource_schemas,omitempty"`
 	Functions                map[string]*jsonfunction.FunctionSignature `json:"functions,omitempty"`
 	ResourceIdentitySchemas  map[string]*IdentitySchema                 `json:"resource_identity_schemas,omitempty"`
 }
@@ -64,6 +65,7 @@ func marshalProvider(tps providers.ProviderSchema) *Provider {
 		ResourceSchemas:          marshalSchemas(tps.ResourceTypes),
 		DataSourceSchemas:        marshalSchemas(tps.DataSources),
 		EphemeralResourceSchemas: marshalSchemas(tps.EphemeralResourceTypes),
+		ListResourceSchemas:      marshalSchemas(tps.ListResourceTypes),
 		Functions:                jsonfunction.MarshalProviderFunctions(tps.Functions),
 		ResourceIdentitySchemas:  marshalIdentitySchemas(tps.ResourceTypes),
 	}

--- a/internal/command/jsonprovider/provider_test.go
+++ b/internal/command/jsonprovider/provider_test.go
@@ -30,6 +30,7 @@ func TestMarshalProvider(t *testing.T) {
 				ResourceSchemas:          map[string]*Schema{},
 				DataSourceSchemas:        map[string]*Schema{},
 				EphemeralResourceSchemas: map[string]*Schema{},
+				ListResourceSchemas:      map[string]*Schema{},
 				ResourceIdentitySchemas:  map[string]*IdentitySchema{},
 			},
 		},
@@ -208,6 +209,26 @@ func TestMarshalProvider(t *testing.T) {
 						},
 					},
 				},
+				ListResourceSchemas: map[string]*Schema{
+					"test_list_resource": {
+						Version: 1,
+						Block: &Block{
+							Attributes: map[string]*Attribute{
+								"filter": {
+									AttributeType:   json.RawMessage(`"string"`),
+									Optional:        true,
+									DescriptionKind: "plain",
+								},
+								"items": {
+									AttributeType:   json.RawMessage(`["list","string"]`),
+									Required:        true,
+									DescriptionKind: "plain",
+								},
+							},
+							DescriptionKind: "plain",
+						},
+					},
+				},
 				ResourceIdentitySchemas: map[string]*IdentitySchema{},
 			},
 		},
@@ -313,6 +334,17 @@ func testProvider() providers.ProviderSchema {
 								},
 							},
 						},
+					},
+				},
+			},
+		},
+		ListResourceTypes: map[string]providers.Schema{
+			"test_list_resource": {
+				Version: 1,
+				Body: &configschema.Block{
+					Attributes: map[string]*configschema.Attribute{
+						"filter": {Type: cty.String, Optional: true},
+						"items":  {Type: cty.List(cty.String), Required: true},
 					},
 				},
 			},


### PR DESCRIPTION
This PR adds the list resource schemas to the `terraform providers schema -json` output. 


## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.13.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
