### PR TITLE
UnmarkDeep is not needed here

### DIFF
--- a/internal/terraform/eval_for_each.go
+++ b/internal/terraform/eval_for_each.go
@@ -398,6 +398,6 @@ func (ev *forEachEvaluator) validateResource(forEachVal cty.Value) tfdiags.Diagn
 
 // markSafeLengthInt allows calling LengthInt on marked values safely
 func markSafeLengthInt(val cty.Value) int {
-	v, _ := val.UnmarkDeep()
+	v, _ := val.Unmark()
 	return v.LengthInt()
 }


### PR DESCRIPTION
Calling LengthInt does not require unmarking all nested values. The UnmarkDeep call causes an unnecessary deep copy, and generate lots of garbage every time a for_each collection was evaluated, which is at least once for each instance.

