### PR TITLE
Update and add new tests for module-parsing logic

### DIFF
--- a/internal/configs/module_test.go
+++ b/internal/configs/module_test.go
@@ -495,4 +495,16 @@ func TestModule_conflicting_backend_cloud(t *testing.T) {
 			t.Fatalf("expected error to contain %q\nerror was:\n%s", want, got)
 		}
 	})
+
+	t.Run("it detects when both cloud and backend blocks are present within the same module in separate files", func(t *testing.T) {
+		_, diags := testModuleFromDir("testdata/invalid-modules/conflict-cloud-backend-separate-files")
+		if !diags.HasErrors() {
+			t.Fatal("module should have error diags, but does not")
+		}
+
+		want := `Both a backend and cloud configuration are present`
+		if got := diags.Error(); !strings.Contains(got, want) {
+			t.Fatalf("expected error to contain %q\nerror was:\n%s", want, got)
+		}
+	})
 }

--- a/internal/configs/module_test.go
+++ b/internal/configs/module_test.go
@@ -415,6 +415,35 @@ func TestModule_cloud_overrides_no_base(t *testing.T) {
 		t.Errorf("expected module CloudConfig not to be nil")
 	}
 }
+
+// Test overriding a cloud block with a backend block
+func TestModule_backend_overrides_cloud(t *testing.T) {
+	mod, diags := testModuleFromDir("testdata/valid-modules/override-cloud-with-backend")
+	if diags.HasErrors() {
+		t.Fatal(diags.Error())
+	}
+
+	gotType := mod.Backend.Type
+	wantType := "override"
+
+	if gotType != wantType {
+		t.Errorf("wrong result for backend type: got %#v, want %#v\n", gotType, wantType)
+	}
+
+	attrs, _ := mod.Backend.Config.JustAttributes()
+
+	gotAttr, diags := attrs["path"].Expr.Value(nil)
+	if diags.HasErrors() {
+		t.Fatal(diags.Error())
+	}
+
+	wantAttr := cty.StringVal("value from override")
+
+	if !gotAttr.RawEquals(wantAttr) {
+		t.Errorf("wrong result for backend 'path': got %#v, want %#v\n", gotAttr, wantAttr)
+	}
+}
+
 // An override file containing multiple cloud blocks causes an error
 func TestModule_cloud_duplicate_overrides(t *testing.T) {
 	_, diags := testModuleFromDir("testdata/invalid-modules/override-cloud-duplicates")

--- a/internal/configs/module_test.go
+++ b/internal/configs/module_test.go
@@ -452,3 +452,31 @@ func TestModule_cloud_duplicate_overrides(t *testing.T) {
 		t.Fatalf("expected module error to contain %q\nerror was:\n%s", want, got)
 	}
 }
+
+// At most one backend block per module is permitted.
+func TestModule_backend_multiple(t *testing.T) {
+	// Multiple backends across multiple files
+	_, diags := testModuleFromDir("testdata/invalid-modules/multiple-backends")
+	if !diags.HasErrors() {
+		t.Fatal("module should have error diags, but does not")
+	}
+
+	want := `Duplicate backend configuration`
+	if got := diags.Error(); !strings.Contains(got, want) {
+		t.Fatalf("expected error to contain %q\nerror was:\n%s", want, got)
+	}
+}
+
+// At most one cloud block per module is permitted.
+func TestModule_cloud_multiple(t *testing.T) {
+	// Multiple cloud blocks across multiple files
+	_, diags := testModuleFromDir("testdata/invalid-modules/multiple-cloud")
+	if !diags.HasErrors() {
+		t.Fatal("module should have error diags, but does not")
+	}
+
+	want := `Duplicate HCP Terraform configurations`
+	if got := diags.Error(); !strings.Contains(got, want) {
+		t.Fatalf("expected error to contain %q\nerror was:\n%s", want, got)
+	}
+}

--- a/internal/configs/module_test.go
+++ b/internal/configs/module_test.go
@@ -480,3 +480,19 @@ func TestModule_cloud_multiple(t *testing.T) {
 		t.Fatalf("expected error to contain %q\nerror was:\n%s", want, got)
 	}
 }
+
+// Cannot combine use of backend, cloud blocks.
+func TestModule_conflicting_backend_cloud(t *testing.T) {
+
+	t.Run("it detects when both cloud and backend blocks are in the same terraform block", func(t *testing.T) {
+		_, diags := testModuleFromDir("testdata/invalid-modules/conflict-cloud-backend")
+		if !diags.HasErrors() {
+			t.Fatal("module should have error diags, but does not")
+		}
+
+		want := `Both a backend and cloud configuration are present`
+		if got := diags.Error(); !strings.Contains(got, want) {
+			t.Fatalf("expected error to contain %q\nerror was:\n%s", want, got)
+		}
+	})
+}

--- a/internal/configs/module_test.go
+++ b/internal/configs/module_test.go
@@ -315,7 +315,8 @@ func TestImpliedProviderForUnqualifiedType(t *testing.T) {
 	}
 }
 
-func TestModule_backend_override(t *testing.T) {
+// Test overriding a backend block to another backend block
+func TestModule_backend_overrides_a_backend(t *testing.T) {
 	mod, diags := testModuleFromDir("testdata/valid-modules/override-backend")
 	if diags.HasErrors() {
 		t.Fatal(diags.Error())
@@ -342,9 +343,11 @@ func TestModule_backend_override(t *testing.T) {
 	}
 }
 
+// Test adding a backend block via an override
+//
 // Unlike most other overrides, backend blocks do not require a base configuration in a primary
 // configuration file, as an omitted backend there implies the local backend.
-func TestModule_backend_override_no_base(t *testing.T) {
+func TestModule_backend_overrides_no_base(t *testing.T) {
 	mod, diags := testModuleFromDir("testdata/valid-modules/override-backend-no-base")
 	if diags.HasErrors() {
 		t.Fatal(diags.Error())
@@ -355,7 +358,8 @@ func TestModule_backend_override_no_base(t *testing.T) {
 	}
 }
 
-func TestModule_cloud_override_backend(t *testing.T) {
+// Test overriding a backend block with a cloud block
+func TestModule_cloud_overrides_a_backend(t *testing.T) {
 	mod, diags := testModuleFromDir("testdata/valid-modules/override-backend-with-cloud")
 	if diags.HasErrors() {
 		t.Fatal(diags.Error())
@@ -370,21 +374,8 @@ func TestModule_cloud_override_backend(t *testing.T) {
 	}
 }
 
-// Unlike most other overrides, cloud blocks do not require a base configuration in a primary
-// configuration file, as an omitted backend there implies the local backend and cloud blocks
-// override backends.
-func TestModule_cloud_override_no_base(t *testing.T) {
-	mod, diags := testModuleFromDir("testdata/valid-modules/override-cloud-no-base")
-	if diags.HasErrors() {
-		t.Fatal(diags.Error())
-	}
-
-	if mod.CloudConfig == nil {
-		t.Errorf("expected module CloudConfig not to be nil")
-	}
-}
-
-func TestModule_cloud_override(t *testing.T) {
+// Test overriding a cloud block with a different cloud block.
+func TestModule_cloud_overrides_cloud(t *testing.T) {
 	mod, diags := testModuleFromDir("testdata/valid-modules/override-cloud")
 	if diags.HasErrors() {
 		t.Fatal(diags.Error())
@@ -409,6 +400,22 @@ func TestModule_cloud_override(t *testing.T) {
 	}
 }
 
+// Test adding a cloud block via an override
+//
+// Unlike most other overrides, cloud blocks do not require a base configuration in a primary
+// configuration file, as an omitted backend there implies the local backend and cloud blocks
+// override backends.
+func TestModule_cloud_overrides_no_base(t *testing.T) {
+	mod, diags := testModuleFromDir("testdata/valid-modules/override-cloud-no-base")
+	if diags.HasErrors() {
+		t.Fatal(diags.Error())
+	}
+
+	if mod.CloudConfig == nil {
+		t.Errorf("expected module CloudConfig not to be nil")
+	}
+}
+// An override file containing multiple cloud blocks causes an error
 func TestModule_cloud_duplicate_overrides(t *testing.T) {
 	_, diags := testModuleFromDir("testdata/invalid-modules/override-cloud-duplicates")
 	want := `Duplicate HCP Terraform configurations`

--- a/internal/configs/module_test.go
+++ b/internal/configs/module_test.go
@@ -315,145 +315,150 @@ func TestImpliedProviderForUnqualifiedType(t *testing.T) {
 	}
 }
 
-// Test overriding a backend block with a different backend block
 func TestModule_backend_overrides_a_backend(t *testing.T) {
-	mod, diags := testModuleFromDir("testdata/valid-modules/override-backend")
-	if diags.HasErrors() {
-		t.Fatal(diags.Error())
-	}
+	t.Run("it can override a backend block with a different backend block", func(t *testing.T) {
+		mod, diags := testModuleFromDir("testdata/valid-modules/override-backend")
+		if diags.HasErrors() {
+			t.Fatal(diags.Error())
+		}
 
-	gotType := mod.Backend.Type
-	wantType := "bar"
+		gotType := mod.Backend.Type
+		wantType := "bar"
 
-	if gotType != wantType {
-		t.Errorf("wrong result for backend type: got %#v, want %#v\n", gotType, wantType)
-	}
+		if gotType != wantType {
+			t.Errorf("wrong result for backend type: got %#v, want %#v\n", gotType, wantType)
+		}
 
-	attrs, _ := mod.Backend.Config.JustAttributes()
+		attrs, _ := mod.Backend.Config.JustAttributes()
 
-	gotAttr, diags := attrs["path"].Expr.Value(nil)
-	if diags.HasErrors() {
-		t.Fatal(diags.Error())
-	}
+		gotAttr, diags := attrs["path"].Expr.Value(nil)
+		if diags.HasErrors() {
+			t.Fatal(diags.Error())
+		}
 
-	wantAttr := cty.StringVal("CHANGED/relative/path/to/terraform.tfstate")
+		wantAttr := cty.StringVal("CHANGED/relative/path/to/terraform.tfstate")
 
-	if !gotAttr.RawEquals(wantAttr) {
-		t.Errorf("wrong result for backend 'path': got %#v, want %#v\n", gotAttr, wantAttr)
-	}
+		if !gotAttr.RawEquals(wantAttr) {
+			t.Errorf("wrong result for backend 'path': got %#v, want %#v\n", gotAttr, wantAttr)
+		}
+	})
 }
 
-// Test adding a backend block via an override
-//
 // Unlike most other overrides, backend blocks do not require a base configuration in a primary
 // configuration file, as an omitted backend there implies the local backend.
 func TestModule_backend_overrides_no_base(t *testing.T) {
-	mod, diags := testModuleFromDir("testdata/valid-modules/override-backend-no-base")
-	if diags.HasErrors() {
-		t.Fatal(diags.Error())
-	}
+	t.Run("it can introduce a backend block via overrides when the base config has has no cloud or backend blocks", func(t *testing.T) {
+		mod, diags := testModuleFromDir("testdata/valid-modules/override-backend-no-base")
+		if diags.HasErrors() {
+			t.Fatal(diags.Error())
+		}
 
-	if mod.Backend == nil {
-		t.Errorf("expected module Backend not to be nil")
-	}
+		if mod.Backend == nil {
+			t.Errorf("expected module Backend not to be nil")
+		}
+	})
 }
 
-// Test overriding a backend block with a cloud block
 func TestModule_cloud_overrides_a_backend(t *testing.T) {
-	mod, diags := testModuleFromDir("testdata/valid-modules/override-backend-with-cloud")
-	if diags.HasErrors() {
-		t.Fatal(diags.Error())
-	}
+	t.Run("it can override a backend block with a cloud block", func(t *testing.T) {
+		mod, diags := testModuleFromDir("testdata/valid-modules/override-backend-with-cloud")
+		if diags.HasErrors() {
+			t.Fatal(diags.Error())
+		}
 
-	if mod.Backend != nil {
-		t.Errorf("expected module Backend to be nil")
-	}
+		if mod.Backend != nil {
+			t.Errorf("expected module Backend to be nil")
+		}
 
-	if mod.CloudConfig == nil {
-		t.Errorf("expected module CloudConfig not to be nil")
-	}
+		if mod.CloudConfig == nil {
+			t.Errorf("expected module CloudConfig not to be nil")
+		}
+	})
 }
 
-// Test overriding a cloud block with a different cloud block.
 func TestModule_cloud_overrides_cloud(t *testing.T) {
-	mod, diags := testModuleFromDir("testdata/valid-modules/override-cloud")
-	if diags.HasErrors() {
-		t.Fatal(diags.Error())
-	}
+	t.Run("it can override a cloud block with a different cloud block", func(t *testing.T) {
+		mod, diags := testModuleFromDir("testdata/valid-modules/override-cloud")
+		if diags.HasErrors() {
+			t.Fatal(diags.Error())
+		}
 
-	attrs, _ := mod.CloudConfig.Config.JustAttributes()
+		attrs, _ := mod.CloudConfig.Config.JustAttributes()
 
-	gotAttr, diags := attrs["organization"].Expr.Value(nil)
-	if diags.HasErrors() {
-		t.Fatal(diags.Error())
-	}
+		gotAttr, diags := attrs["organization"].Expr.Value(nil)
+		if diags.HasErrors() {
+			t.Fatal(diags.Error())
+		}
 
-	wantAttr := cty.StringVal("CHANGED")
+		wantAttr := cty.StringVal("CHANGED")
 
-	if !gotAttr.RawEquals(wantAttr) {
-		t.Errorf("wrong result for Cloud 'organization': got %#v, want %#v\n", gotAttr, wantAttr)
-	}
+		if !gotAttr.RawEquals(wantAttr) {
+			t.Errorf("wrong result for Cloud 'organization': got %#v, want %#v\n", gotAttr, wantAttr)
+		}
 
-	// The override should have completely replaced the cloud block in the primary file, no merging
-	if attrs["should_not_be_present_with_override"] != nil {
-		t.Errorf("expected 'should_not_be_present_with_override' attribute to be nil")
-	}
+		// The override should have completely replaced the cloud block in the primary file, no merging
+		if attrs["should_not_be_present_with_override"] != nil {
+			t.Errorf("expected 'should_not_be_present_with_override' attribute to be nil")
+		}
+	})
 }
 
-// Test adding a cloud block via an override
-//
 // Unlike most other overrides, cloud blocks do not require a base configuration in a primary
 // configuration file, as an omitted backend there implies the local backend and cloud blocks
 // override backends.
 func TestModule_cloud_overrides_no_base(t *testing.T) {
-	mod, diags := testModuleFromDir("testdata/valid-modules/override-cloud-no-base")
-	if diags.HasErrors() {
-		t.Fatal(diags.Error())
-	}
+	t.Run("it can introduce a cloud block via overrides when the base config has no cloud or backend blocks", func(t *testing.T) {
 
-	if mod.CloudConfig == nil {
-		t.Errorf("expected module CloudConfig not to be nil")
-	}
+		mod, diags := testModuleFromDir("testdata/valid-modules/override-cloud-no-base")
+		if diags.HasErrors() {
+			t.Fatal(diags.Error())
+		}
+
+		if mod.CloudConfig == nil {
+			t.Errorf("expected module CloudConfig not to be nil")
+		}
+	})
 }
 
-// Test overriding a cloud block with a backend block
 func TestModule_backend_overrides_cloud(t *testing.T) {
-	mod, diags := testModuleFromDir("testdata/valid-modules/override-cloud-with-backend")
-	if diags.HasErrors() {
-		t.Fatal(diags.Error())
-	}
+	t.Run("it can override a cloud block with a backend block", func(t *testing.T) {
+		mod, diags := testModuleFromDir("testdata/valid-modules/override-cloud-with-backend")
+		if diags.HasErrors() {
+			t.Fatal(diags.Error())
+		}
 
-	gotType := mod.Backend.Type
-	wantType := "override"
+		gotType := mod.Backend.Type
+		wantType := "override"
 
-	if gotType != wantType {
-		t.Errorf("wrong result for backend type: got %#v, want %#v\n", gotType, wantType)
-	}
+		if gotType != wantType {
+			t.Errorf("wrong result for backend type: got %#v, want %#v\n", gotType, wantType)
+		}
 
-	attrs, _ := mod.Backend.Config.JustAttributes()
+		attrs, _ := mod.Backend.Config.JustAttributes()
 
-	gotAttr, diags := attrs["path"].Expr.Value(nil)
-	if diags.HasErrors() {
-		t.Fatal(diags.Error())
-	}
+		gotAttr, diags := attrs["path"].Expr.Value(nil)
+		if diags.HasErrors() {
+			t.Fatal(diags.Error())
+		}
 
-	wantAttr := cty.StringVal("value from override")
+		wantAttr := cty.StringVal("value from override")
 
-	if !gotAttr.RawEquals(wantAttr) {
-		t.Errorf("wrong result for backend 'path': got %#v, want %#v\n", gotAttr, wantAttr)
-	}
+		if !gotAttr.RawEquals(wantAttr) {
+			t.Errorf("wrong result for backend 'path': got %#v, want %#v\n", gotAttr, wantAttr)
+		}
+	})
 }
 
-// An override file containing multiple cloud blocks causes an error
 func TestModule_cloud_duplicate_overrides(t *testing.T) {
-	_, diags := testModuleFromDir("testdata/invalid-modules/override-cloud-duplicates")
-	want := `Duplicate HCP Terraform configurations`
-	if got := diags.Error(); !strings.Contains(got, want) {
-		t.Fatalf("expected module error to contain %q\nerror was:\n%s", want, got)
-	}
+	t.Run("it raises an error when a override file contains multiple cloud blocks", func(t *testing.T) {
+		_, diags := testModuleFromDir("testdata/invalid-modules/override-cloud-duplicates")
+		want := `Duplicate HCP Terraform configurations`
+		if got := diags.Error(); !strings.Contains(got, want) {
+			t.Fatalf("expected module error to contain %q\nerror was:\n%s", want, got)
+		}
+	})
 }
 
-// At most one backend block per module is permitted.
 func TestModule_backend_multiple(t *testing.T) {
 	t.Run("it detects when two backend blocks are present within the same module in separate files", func(t *testing.T) {
 		_, diags := testModuleFromDir("testdata/invalid-modules/multiple-backends")
@@ -468,7 +473,6 @@ func TestModule_backend_multiple(t *testing.T) {
 	})
 }
 
-// At most one cloud block per module is permitted.
 func TestModule_cloud_multiple(t *testing.T) {
 	t.Run("it detects when two cloud blocks are present within the same module in separate files", func(t *testing.T) {
 

--- a/internal/configs/module_test.go
+++ b/internal/configs/module_test.go
@@ -315,7 +315,7 @@ func TestImpliedProviderForUnqualifiedType(t *testing.T) {
 	}
 }
 
-// Test overriding a backend block to another backend block
+// Test overriding a backend block with a different backend block
 func TestModule_backend_overrides_a_backend(t *testing.T) {
 	mod, diags := testModuleFromDir("testdata/valid-modules/override-backend")
 	if diags.HasErrors() {
@@ -455,30 +455,33 @@ func TestModule_cloud_duplicate_overrides(t *testing.T) {
 
 // At most one backend block per module is permitted.
 func TestModule_backend_multiple(t *testing.T) {
-	// Multiple backends across multiple files
-	_, diags := testModuleFromDir("testdata/invalid-modules/multiple-backends")
-	if !diags.HasErrors() {
-		t.Fatal("module should have error diags, but does not")
-	}
+	t.Run("it detects when two backend blocks are present within the same module in separate files", func(t *testing.T) {
+		_, diags := testModuleFromDir("testdata/invalid-modules/multiple-backends")
+		if !diags.HasErrors() {
+			t.Fatal("module should have error diags, but does not")
+		}
 
-	want := `Duplicate backend configuration`
-	if got := diags.Error(); !strings.Contains(got, want) {
-		t.Fatalf("expected error to contain %q\nerror was:\n%s", want, got)
-	}
+		want := `Duplicate backend configuration`
+		if got := diags.Error(); !strings.Contains(got, want) {
+			t.Fatalf("expected error to contain %q\nerror was:\n%s", want, got)
+		}
+	})
 }
 
 // At most one cloud block per module is permitted.
 func TestModule_cloud_multiple(t *testing.T) {
-	// Multiple cloud blocks across multiple files
-	_, diags := testModuleFromDir("testdata/invalid-modules/multiple-cloud")
-	if !diags.HasErrors() {
-		t.Fatal("module should have error diags, but does not")
-	}
+	t.Run("it detects when two cloud blocks are present within the same module in separate files", func(t *testing.T) {
 
-	want := `Duplicate HCP Terraform configurations`
-	if got := diags.Error(); !strings.Contains(got, want) {
-		t.Fatalf("expected error to contain %q\nerror was:\n%s", want, got)
-	}
+		_, diags := testModuleFromDir("testdata/invalid-modules/multiple-cloud")
+		if !diags.HasErrors() {
+			t.Fatal("module should have error diags, but does not")
+		}
+
+		want := `Duplicate HCP Terraform configurations`
+		if got := diags.Error(); !strings.Contains(got, want) {
+			t.Fatalf("expected error to contain %q\nerror was:\n%s", want, got)
+		}
+	})
 }
 
 // Cannot combine use of backend, cloud blocks.

--- a/internal/configs/testdata/invalid-modules/conflict-cloud-backend-separate-files/backend.tf
+++ b/internal/configs/testdata/invalid-modules/conflict-cloud-backend-separate-files/backend.tf
@@ -1,0 +1,3 @@
+terraform {
+  backend "foo" {}
+}

--- a/internal/configs/testdata/invalid-modules/conflict-cloud-backend-separate-files/cloud.tf
+++ b/internal/configs/testdata/invalid-modules/conflict-cloud-backend-separate-files/cloud.tf
@@ -1,0 +1,8 @@
+terraform {
+  cloud {
+    organization = "sarahfrench"
+    workspaces {
+      name = "test-cloud-backend"
+    }
+  }
+}

--- a/internal/configs/testdata/invalid-modules/conflict-cloud-backend/main.tf
+++ b/internal/configs/testdata/invalid-modules/conflict-cloud-backend/main.tf
@@ -1,0 +1,10 @@
+terraform {
+  backend "foo" {}
+
+  cloud {
+    organization = "sarahfrench"
+    workspaces {
+      name = "test-cloud-backend"
+    }
+  }
+}

--- a/internal/configs/testdata/invalid-modules/multiple-backends/a.tf
+++ b/internal/configs/testdata/invalid-modules/multiple-backends/a.tf
@@ -1,0 +1,3 @@
+terraform {
+  backend "foo" {}
+}

--- a/internal/configs/testdata/invalid-modules/multiple-backends/b.tf
+++ b/internal/configs/testdata/invalid-modules/multiple-backends/b.tf
@@ -1,0 +1,3 @@
+terraform {
+  backend "bar" {}
+}

--- a/internal/configs/testdata/invalid-modules/multiple-cloud/a.tf
+++ b/internal/configs/testdata/invalid-modules/multiple-cloud/a.tf
@@ -1,0 +1,5 @@
+terraform {
+  cloud {
+    organization = "foo"
+  }
+}

--- a/internal/configs/testdata/invalid-modules/multiple-cloud/b.tf
+++ b/internal/configs/testdata/invalid-modules/multiple-cloud/b.tf
@@ -1,0 +1,5 @@
+terraform {
+  cloud {
+    organization = "bar"
+  }
+}

--- a/internal/configs/testdata/valid-modules/override-cloud-with-backend/main.tf
+++ b/internal/configs/testdata/valid-modules/override-cloud-with-backend/main.tf
@@ -1,0 +1,13 @@
+terraform {
+  cloud {
+    organization = "foo"
+  }
+}
+
+resource "aws_instance" "web" {
+  ami = "ami-1234"
+  security_groups = [
+    "foo",
+    "bar",
+  ]
+}

--- a/internal/configs/testdata/valid-modules/override-cloud-with-backend/override.tf
+++ b/internal/configs/testdata/valid-modules/override-cloud-with-backend/override.tf
@@ -1,0 +1,5 @@
+terraform {
+  backend "override" {
+    path = "value from override"
+  }
+}


### PR DESCRIPTION
This PR adds some missing test coverage in the `configs` package (coverage goes from 76.4%  to 76.6% , lol)
This PR also includes renaming some existing tests, reordering them for consistency in the file, and adding test names.

The new tests are:
* `TestModule_backend_overrides_cloud`  - you can override a cloud block with a backend block in an override file.
* `TestModule_backend_multiple` - validation stops multiple backend blocks being present in a module.
* `TestModule_cloud_multiple`  - validation stops multiple cloud blocks being present in a module.
* `TestModule_conflicting_backend_cloud`  - validation stops a combination of cloud and backend blocks being present in a module.

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

N/A

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
