### PR TITLE
docs/plugin-protocol: Clarify use of GetMetadata

### DIFF
--- a/docs/plugin-protocol/tfplugin5.proto
+++ b/docs/plugin-protocol/tfplugin5.proto
@@ -309,9 +309,9 @@ service Provider {
 
     // GetMetadata returns upfront information about server capabilities and
     // supported resource types without requiring the server to instantiate all
-    // schema information, which may be memory intensive. This RPC is optional,
-    // where clients may receive an unimplemented RPC error. Clients should
-    // ignore the error and call the GetSchema RPC as a fallback.
+    // schema information, which may be memory intensive.
+    // This method is CURRENTLY UNUSED and it serves mostly for convenience
+    // of code generation inside of terraform-plugin-mux.
     rpc GetMetadata(GetMetadata.Request) returns (GetMetadata.Response);
 
     // GetSchema returns schema information for the provider, data resources,

--- a/docs/plugin-protocol/tfplugin6.proto
+++ b/docs/plugin-protocol/tfplugin6.proto
@@ -328,9 +328,9 @@ service Provider {
 
     // GetMetadata returns upfront information about server capabilities and
     // supported resource types without requiring the server to instantiate all
-    // schema information, which may be memory intensive. This RPC is optional,
-    // where clients may receive an unimplemented RPC error. Clients should
-    // ignore the error and call the GetProviderSchema RPC as a fallback.
+    // schema information, which may be memory intensive.
+    // This method is CURRENTLY UNUSED and it serves mostly for convenience
+    // of code generation inside of terraform-plugin-mux.
     rpc GetMetadata(GetMetadata.Request) returns (GetMetadata.Response);
 
     // GetSchema returns schema information for the provider, data resources,

--- a/internal/tfplugin5/tfplugin5.pb.go
+++ b/internal/tfplugin5/tfplugin5.pb.go
@@ -7554,9 +7554,9 @@ const _ = grpc.SupportPackageIsVersion6
 type ProviderClient interface {
 	// GetMetadata returns upfront information about server capabilities and
 	// supported resource types without requiring the server to instantiate all
-	// schema information, which may be memory intensive. This RPC is optional,
-	// where clients may receive an unimplemented RPC error. Clients should
-	// ignore the error and call the GetSchema RPC as a fallback.
+	// schema information, which may be memory intensive.
+	// This method is CURRENTLY UNUSED and it serves mostly for convenience
+	// of code generation inside of terraform-plugin-mux.
 	GetMetadata(ctx context.Context, in *GetMetadata_Request, opts ...grpc.CallOption) (*GetMetadata_Response, error)
 	// GetSchema returns schema information for the provider, data resources,
 	// and managed resources.
@@ -7847,9 +7847,9 @@ func (c *providerClient) Stop(ctx context.Context, in *Stop_Request, opts ...grp
 type ProviderServer interface {
 	// GetMetadata returns upfront information about server capabilities and
 	// supported resource types without requiring the server to instantiate all
-	// schema information, which may be memory intensive. This RPC is optional,
-	// where clients may receive an unimplemented RPC error. Clients should
-	// ignore the error and call the GetSchema RPC as a fallback.
+	// schema information, which may be memory intensive.
+	// This method is CURRENTLY UNUSED and it serves mostly for convenience
+	// of code generation inside of terraform-plugin-mux.
 	GetMetadata(context.Context, *GetMetadata_Request) (*GetMetadata_Response, error)
 	// GetSchema returns schema information for the provider, data resources,
 	// and managed resources.

--- a/internal/tfplugin6/tfplugin6.pb.go
+++ b/internal/tfplugin6/tfplugin6.pb.go
@@ -7237,9 +7237,9 @@ const _ = grpc.SupportPackageIsVersion6
 type ProviderClient interface {
 	// GetMetadata returns upfront information about server capabilities and
 	// supported resource types without requiring the server to instantiate all
-	// schema information, which may be memory intensive. This RPC is optional,
-	// where clients may receive an unimplemented RPC error. Clients should
-	// ignore the error and call the GetProviderSchema RPC as a fallback.
+	// schema information, which may be memory intensive.
+	// This method is CURRENTLY UNUSED and it serves mostly for convenience
+	// of code generation inside of terraform-plugin-mux.
 	GetMetadata(ctx context.Context, in *GetMetadata_Request, opts ...grpc.CallOption) (*GetMetadata_Response, error)
 	// GetSchema returns schema information for the provider, data resources,
 	// and managed resources.
@@ -7530,9 +7530,9 @@ func (c *providerClient) StopProvider(ctx context.Context, in *StopProvider_Requ
 type ProviderServer interface {
 	// GetMetadata returns upfront information about server capabilities and
 	// supported resource types without requiring the server to instantiate all
-	// schema information, which may be memory intensive. This RPC is optional,
-	// where clients may receive an unimplemented RPC error. Clients should
-	// ignore the error and call the GetProviderSchema RPC as a fallback.
+	// schema information, which may be memory intensive.
+	// This method is CURRENTLY UNUSED and it serves mostly for convenience
+	// of code generation inside of terraform-plugin-mux.
 	GetMetadata(context.Context, *GetMetadata_Request) (*GetMetadata_Response, error)
 	// GetSchema returns schema information for the provider, data resources,
 	// and managed resources.


### PR DESCRIPTION
This is to clarify the current reality of the `GetMetadata` method which isn't really "optional" in the way the original comment suggests.

Core does not implement this at all currently and while terraform-plugin-mux [does technically call that method](https://github.com/hashicorp/terraform-plugin-mux/blob/101e9dfd0787e782fc4d0869931716180da5df09/tf6muxserver/mux_server.go#L225), it only calls (generated) Go code within the provider which uses mux. **There is no known _RPC_ use of this at all today.**

Further/future context: We may re-assess the need for this method in the protocol in the context of a more granular access to provider schemas. Currently, it is far from ideal that schemas are received as one big blob for everything (all resources, all data sources, etc.).

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.13.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
