### PR TITLE
terraform test: add variable definitions to test files

### DIFF
--- a/.changes/v1.13/ENHANCEMENTS-20250602-152211.yaml
+++ b/.changes/v1.13/ENHANCEMENTS-20250602-152211.yaml
@@ -1,0 +1,5 @@
+kind: ENHANCEMENTS
+body: '`terraform test`: Test authors can now specify definitions for external variables that are referenced within test files directly within the test file itself.'
+time: 2025-06-02T15:22:11.453413+02:00
+custom:
+    Issue: "37195"

--- a/.changes/v1.13/UPGRADE NOTES-20250602-152009.yaml
+++ b/.changes/v1.13/UPGRADE NOTES-20250602-152009.yaml
@@ -1,0 +1,5 @@
+kind: UPGRADE NOTES
+body: '`terraform test`: External variables referenced within test files should now be accompanied by a `variable` definition block within the test file. This is optional, but users with complex external variables may see error diagnostics without the additional variable definition.'
+time: 2025-06-02T15:20:09.188388+02:00
+custom:
+    Issue: "37195"

--- a/internal/command/test_test.go
+++ b/internal/command/test_test.go
@@ -334,6 +334,11 @@ func TestTest_Runs(t *testing.T) {
 			expectedOut: []string{"1 passed, 0 failed."},
 			code:        0,
 		},
+		"with-default-variables": {
+			args:        []string{"-var=input_two=universe"},
+			expectedOut: []string{"1 passed, 0 failed."},
+			code:        0,
+		},
 	}
 	for name, tc := range tcs {
 		t.Run(name, func(t *testing.T) {

--- a/internal/command/testdata/test/with-default-variables/main.tf
+++ b/internal/command/testdata/test/with-default-variables/main.tf
@@ -1,0 +1,12 @@
+
+variable "input_one" {
+  type = string
+}
+
+variable "input_two" {
+  type = string
+}
+
+resource "test_resource" "resource" {
+  value = "${var.input_one} - ${var.input_two}"
+}

--- a/internal/command/testdata/test/with-default-variables/main.tftest.hcl
+++ b/internal/command/testdata/test/with-default-variables/main.tftest.hcl
@@ -1,0 +1,17 @@
+
+variable "input_one" {
+  type = string
+  default = "hello"
+}
+
+variable "input_two" {
+  type = string
+  default = "world" // we will override this an external value
+}
+
+run "test" {
+  assert {
+    condition = test_resource.resource.value == "hello - universe"
+    error_message = "bad concatenation"
+  }
+}

--- a/internal/configs/test_file.go
+++ b/internal/configs/test_file.go
@@ -45,6 +45,14 @@ const (
 // A test file is made up of a sequential list of run blocks, each designating
 // a command to execute and a series of validations to check after the command.
 type TestFile struct {
+
+	// VariableDefinitions allows users to specify variables that should be
+	// provided externally (eg. from the command line or external files).
+	//
+	// This conflicts with the Variables block. Variables specified in the
+	// VariableDefinitions cannot also be specified within the Variables block.
+	VariableDefinitions map[string]*Variable
+
 	// Variables defines a set of global variable definitions that should be set
 	// for every run block within the test file.
 	Variables map[string]hcl.Expression
@@ -327,8 +335,9 @@ type TestRunOptions struct {
 func loadTestFile(body hcl.Body) (*TestFile, hcl.Diagnostics) {
 	var diags hcl.Diagnostics
 	tf := &TestFile{
-		Providers: make(map[string]*Provider),
-		Overrides: addrs.MakeMap[addrs.Targetable, *Override](),
+		VariableDefinitions: make(map[string]*Variable),
+		Providers:           make(map[string]*Provider),
+		Overrides:           addrs.MakeMap[addrs.Targetable, *Override](),
 	}
 
 	// we need to retrieve the file config block first, because the run blocks
@@ -370,6 +379,31 @@ func loadTestFile(body hcl.Body) (*TestFile, hcl.Diagnostics) {
 			}
 			runBlockNames[run.Name] = run.DeclRange
 
+		case "variable":
+			variable, variableDiags := decodeVariableBlock(block, false)
+			diags = append(diags, variableDiags...)
+			if !variableDiags.HasErrors() {
+				if existing, exists := tf.VariableDefinitions[variable.Name]; exists {
+					diags = append(diags, &hcl.Diagnostic{
+						Severity: hcl.DiagError,
+						Summary:  "Duplicate \"variable\" block names",
+						Detail:   fmt.Sprintf("This test file already has a variable named %s defined at %s.", variable.Name, existing.DeclRange),
+						Subject:  variable.DeclRange.Ptr(),
+					})
+					continue
+				}
+				tf.VariableDefinitions[variable.Name] = variable
+
+				if existing, exists := tf.Variables[variable.Name]; exists {
+					diags = append(diags, &hcl.Diagnostic{
+						Severity: hcl.DiagError,
+						Summary:  "Duplicate \"variable\" block names",
+						Detail:   fmt.Sprintf("This test file already has a variable named %s defined at %s.", variable.Name, existing.Range()),
+						Subject:  variable.DeclRange.Ptr(),
+					})
+				}
+			}
+
 		case "variables":
 			if tf.Variables != nil {
 				diags = append(diags, &hcl.Diagnostic{
@@ -388,6 +422,15 @@ func loadTestFile(body hcl.Body) (*TestFile, hcl.Diagnostics) {
 			diags = append(diags, varsDiags...)
 			for _, v := range vars {
 				tf.Variables[v.Name] = v.Expr
+
+				if existing, exists := tf.VariableDefinitions[v.Name]; exists {
+					diags = append(diags, &hcl.Diagnostic{
+						Severity: hcl.DiagError,
+						Summary:  "Duplicate \"variable\" block names",
+						Detail:   fmt.Sprintf("This test file already has a variable named %s defined at %s.", v.Name, v.Range),
+						Subject:  existing.DeclRange.Ptr(),
+					})
+				}
 			}
 		case "provider":
 			provider, providerDiags := decodeProviderBlock(block, true)
@@ -886,6 +929,10 @@ var testFileSchema = &hcl.BodySchema{
 		},
 		{
 			Type:       "mock_provider",
+			LabelNames: []string{"name"},
+		},
+		{
+			Type:       "variable",
 			LabelNames: []string{"name"},
 		},
 		{

--- a/internal/moduletest/graph/eval_context.go
+++ b/internal/moduletest/graph/eval_context.go
@@ -42,7 +42,7 @@ type TestFileState struct {
 // within the suite.
 // The struct provides concurrency-safe access to the various maps it contains.
 type EvalContext struct {
-	VariableCaches *hcltest.VariableCaches
+	VariableCache *hcltest.VariableCache
 
 	// runOutputs is a mapping from run addresses to cty object values
 	// representing the collected output values from the module under test.
@@ -84,10 +84,11 @@ type EvalContext struct {
 }
 
 type EvalContextOpts struct {
-	Verbose   bool
-	Render    views.Test
-	CancelCtx context.Context
-	StopCtx   context.Context
+	Verbose       bool
+	Render        views.Test
+	CancelCtx     context.Context
+	StopCtx       context.Context
+	VariableCache *hcltest.VariableCache
 }
 
 // NewEvalContext constructs a new graph evaluation context for use in
@@ -104,7 +105,7 @@ func NewEvalContext(opts EvalContextOpts) *EvalContext {
 		providersLock:   sync.Mutex{},
 		FileStates:      make(map[string]*TestFileState),
 		stateLock:       sync.Mutex{},
-		VariableCaches:  hcltest.NewVariableCaches(),
+		VariableCache:   opts.VariableCache,
 		cancelContext:   cancelCtx,
 		cancelFunc:      cancel,
 		stopContext:     stopCtx,
@@ -324,10 +325,6 @@ func (ec *EvalContext) GetOutputs() map[addrs.Run]cty.Value {
 	outputCopy := make(map[addrs.Run]cty.Value, len(ec.runOutputs))
 	maps.Copy(outputCopy, ec.runOutputs) // don't use clone here, so we can return a non-nil map
 	return outputCopy
-}
-
-func (ec *EvalContext) GetCache(run *moduletest.Run) *hcltest.VariableCache {
-	return ec.VariableCaches.GetCache(run.Name, run.ModuleConfig)
 }
 
 // ProviderExists returns true if the provider exists for the run inside the context.

--- a/internal/moduletest/graph/transform_config.go
+++ b/internal/moduletest/graph/transform_config.go
@@ -88,7 +88,7 @@ func TransformConfigForRun(ctx *EvalContext, run *moduletest.Run, file *modulete
 				AliasRange: ref.InChild.AliasRange,
 				Config: &hcltest.ProviderConfig{
 					Original:            testProvider.Config,
-					VariableCache:       ctx.GetCache(run),
+					VariableCache:       ctx.VariableCache,
 					AvailableRunOutputs: runOutputs,
 				},
 				Mock:      testProvider.Mock,
@@ -114,7 +114,7 @@ func TransformConfigForRun(ctx *EvalContext, run *moduletest.Run, file *modulete
 				AliasRange: provider.AliasRange,
 				Config: &hcltest.ProviderConfig{
 					Original:            provider.Config,
-					VariableCache:       ctx.GetCache(run),
+					VariableCache:       ctx.VariableCache,
 					AvailableRunOutputs: runOutputs,
 				},
 				Mock:      provider.Mock,

--- a/internal/moduletest/graph/variables.go
+++ b/internal/moduletest/graph/variables.go
@@ -150,9 +150,10 @@ func (n *NodeTestRun) GetVariables(ctx *EvalContext, includeWarnings bool) (terr
 			}
 		}
 
-		// Finally, we're going to give these variables a value. They'll be
-		// processed by the Terraform graph and provided a default value later
-		// if they have one.
+		// If all else fails, these variables may have default values set within
+		// the to-be-executed Terraform config. We'll put in placeholder values
+		// if that is the case, otherwise add a diagnostic early to avoid
+		// executing something we know will fail.
 
 		if variable.Required() {
 			diags = diags.Append(&hcl.Diagnostic{

--- a/internal/moduletest/hcl/provider.go
+++ b/internal/moduletest/hcl/provider.go
@@ -81,7 +81,7 @@ func (p *ProviderConfig) transformAttributes(originals hcl.Attributes) (hcl.Attr
 		refs, _ := langrefs.ReferencesInExpr(addrs.ParseRefFromTestingScope, original.Expr)
 		for _, ref := range refs {
 			if addr, ok := ref.Subject.(addrs.InputVariable); ok {
-				value, valueDiags := p.VariableCache.GetFileVariable(addr.Name)
+				value, valueDiags := p.VariableCache.GetVariableValue(addr.Name)
 				diags = append(diags, valueDiags.ToHCL()...)
 				if value != nil {
 					availableVariables[addr.Name] = value.Value
@@ -89,7 +89,7 @@ func (p *ProviderConfig) transformAttributes(originals hcl.Attributes) (hcl.Attr
 				}
 
 				// If the variable wasn't a file variable, it might be a global.
-				value, valueDiags = p.VariableCache.GetGlobalVariable(addr.Name)
+				value, valueDiags = p.VariableCache.GetVariableValue(addr.Name)
 				diags = append(diags, valueDiags.ToHCL()...)
 				if value != nil {
 					availableVariables[addr.Name] = value.Value

--- a/internal/moduletest/hcl/provider_test.go
+++ b/internal/moduletest/hcl/provider_test.go
@@ -184,19 +184,19 @@ func TestProviderConfig(t *testing.T) {
 				outputs[addr] = cty.ObjectVal(attrs)
 			}
 
-			variableCaches := NewVariableCaches(func(vc *VariableCaches) {
-				vc.FileVariables = func() map[string]hcl.Expression {
+			variableCache := &VariableCache{
+				TestFileVariableExpressions: func() map[string]hcl.Expression {
 					variables := make(map[string]hcl.Expression)
 					for name, value := range tc.variables {
 						variables[name] = hcl.StaticExpr(value, hcl.Range{})
 					}
 					return variables
-				}()
-			})
+				}(),
+			}
 
 			config := ProviderConfig{
 				Original:            file.Body,
-				VariableCache:       variableCaches.GetCache("test", nil),
+				VariableCache:       variableCache,
 				AvailableRunOutputs: outputs,
 			}
 

--- a/internal/moduletest/hcl/variable_cache.go
+++ b/internal/moduletest/hcl/variable_cache.go
@@ -4,6 +4,7 @@
 package hcl
 
 import (
+	"fmt"
 	"sync"
 
 	"github.com/hashicorp/hcl/v2"
@@ -17,125 +18,118 @@ import (
 	"github.com/hashicorp/terraform/internal/tfdiags"
 )
 
-// VariableCaches contains a mapping between test run blocks and evaluated
-// variables. This is used to cache the results of evaluating variables so that
-// they are only evaluated once per run.
-//
-// Each run block has its own configuration and therefore its own set of
-// evaluated variables.
-type VariableCaches struct {
-	GlobalVariables map[string]backendrun.UnparsedVariableValue
-	FileVariables   map[string]hcl.Expression
-
-	caches    map[string]*VariableCache
-	cacheLock sync.Mutex
-}
-
-func NewVariableCaches(opts ...func(*VariableCaches)) *VariableCaches {
-	ret := &VariableCaches{
-		GlobalVariables: make(map[string]backendrun.UnparsedVariableValue),
-		FileVariables:   make(map[string]hcl.Expression),
-		caches:          make(map[string]*VariableCache),
-		cacheLock:       sync.Mutex{},
-	}
-
-	for _, opt := range opts {
-		opt(ret)
-	}
-
-	return ret
-}
-
-// VariableCache contains the cache for a single run block. This cache contains
-// the evaluated values for global and file-level variables.
 type VariableCache struct {
-	config *configs.Config
+	mutex sync.Mutex
 
-	globals terraform.InputValues
-	files   terraform.InputValues
+	// ExternalVariableValues contains the raw values provided by the user
+	// via either the CLI, environment variables, or a variable file.
+	ExternalVariableValues map[string]backendrun.UnparsedVariableValue
 
-	values *VariableCaches // back reference so we can access the stored values
+	// TestFileVariableDefinitions contains the definitions for variables
+	// defined within the test file in `variable` blocks.
+	TestFileVariableDefinitions map[string]*configs.Variable
+
+	// TestFileVariableExpressions contains the concrete variable expressions
+	// defined within the test file `variables` block.
+	TestFileVariableExpressions map[string]hcl.Expression
+
+	// fileVariableValues contains the set of available file level
+	fileVariableValues map[string]*terraform.InputValue
 }
 
-// GetCache returns the cache for the named run. If the cache does not exist, it
-// is created and returned.
-func (caches *VariableCaches) GetCache(name string, config *configs.Config) *VariableCache {
-	caches.cacheLock.Lock()
-	defer caches.cacheLock.Unlock()
-	cache, exists := caches.caches[name]
-	if !exists {
-		cache = &VariableCache{
-			config:  config,
-			globals: make(terraform.InputValues),
-			files:   make(terraform.InputValues),
-			values:  caches,
-		}
-		caches.caches[name] = cache
-	}
-	return cache
-}
-
-// GetGlobalVariable returns a value for the named global variable evaluated
-// against the current run.
-//
-// This function caches the result of evaluating the variable so that it is
-// only evaluated once per run.
-//
-// This function will return a valid input value if parsing fails for any reason
-// so the caller can continue processing the configuration. The diagnostics
-// returned will contain the error message that occurred during parsing and as
-// such should be shown to the user.
-func (cache *VariableCache) GetGlobalVariable(name string) (*terraform.InputValue, tfdiags.Diagnostics) {
-	val, exists := cache.globals[name]
-	if exists {
-		return val, nil
-	}
-
-	variable, exists := cache.values.GlobalVariables[name]
+func (cache *VariableCache) EvaluateExternalVariable(name string, config *configs.Variable) (*terraform.InputValue, tfdiags.Diagnostics) {
+	variable, exists := cache.ExternalVariableValues[name]
 	if !exists {
 		return nil, nil
 	}
 
-	// TODO: We should also introduce a way to specify the mode in the test
-	//   file itself. Suggestion, optional variable blocks.
-	parsingMode := configs.VariableParseHCL
+	if config != nil {
 
-	if cfg, exists := cache.config.Module.Variables[name]; exists {
-		parsingMode = cfg.ParsingMode
+		// If we have a configuration, then we'll using the parsing mode from
+		// that.
+
+		value, diags := variable.ParseVariableValue(config.ParsingMode)
+		if diags.HasErrors() {
+			value = &terraform.InputValue{
+				Value: cty.DynamicVal,
+			}
+		}
+		return value, diags
 	}
 
-	value, diags := variable.ParseVariableValue(parsingMode)
+	// For backwards-compatibility reasons we do also have to support trying
+	// to parse the global variables without a configuration. We introduced the
+	// file-level variable definitions later, and users were already using
+	// global variables so we do need to keep supporting this use case.
+
+	// Otherwise, we have no configuration so we're going to try both parsing
+	// modes.
+
+	value, diags := variable.ParseVariableValue(configs.VariableParseHCL)
+	if !diags.HasErrors() {
+		// then good! we can just return these values directly.
+		return value, diags
+	}
+
+	// otherwise, we'll try the other one.
+
+	value, diags = variable.ParseVariableValue(configs.VariableParseLiteral)
 	if diags.HasErrors() {
-		// In this case, the variable exists but we couldn't parse it. We'll
-		// return a usable value so that we don't compound errors later by
-		// claiming a variable doesn't exist when it does. We also return the
-		// diagnostics explaining the error which will be shown to the user.
+
+		// we'll add a warning diagnostic here, just telling the users they
+		// can avoid this by adding a variable definition.
+
+		diags = diags.Append(tfdiags.Sourceless(
+			tfdiags.Warning,
+			"Missing variable definition",
+			fmt.Sprintf("The variable %q could not be parsed. Terraform had no definition block for this variable, this error could be avoided in future by including a definition block for this variable within the Terraform test file.", name)))
+
+		// as usual make sure we still provide something for this value.
+
 		value = &terraform.InputValue{
 			Value: cty.DynamicVal,
 		}
 	}
-
-	cache.globals[name] = value
 	return value, diags
 }
 
-// GetFileVariable returns a value for the named file-level variable evaluated
-// against the current run.
-//
-// This function caches the result of evaluating the variable so that it is
-// only evaluated once per run.
-//
-// This function will return a valid input value if parsing fails for any reason
-// so the caller can continue processing the configuration. The diagnostics
-// returned will contain the error message that occurred during parsing and as
-// such should be shown to the user.
-func (cache *VariableCache) GetFileVariable(name string) (*terraform.InputValue, tfdiags.Diagnostics) {
-	val, exists := cache.files[name]
-	if exists {
-		return val, nil
+func (cache *VariableCache) evaluateVariableDefinition(name string) (*terraform.InputValue, tfdiags.Diagnostics) {
+	definition, exists := cache.TestFileVariableDefinitions[name]
+	if !exists {
+		// no definition for this variable
+		return nil, nil
 	}
 
-	expr, exists := cache.values.FileVariables[name]
+	var diags tfdiags.Diagnostics
+
+	var input *terraform.InputValue
+	if _, exists := cache.ExternalVariableValues[name]; exists {
+		parsed, moreDiags := cache.EvaluateExternalVariable(name, definition)
+		diags = diags.Append(moreDiags)
+		input = parsed
+	} else {
+		input = &terraform.InputValue{
+			Value: cty.NilVal,
+		}
+	}
+
+	value, moreDiags := terraform.PrepareFinalInputVariableValue(addrs.AbsInputVariableInstance{
+		Module: addrs.RootModuleInstance,
+		Variable: addrs.InputVariable{
+			Name: name,
+		},
+	}, input, definition)
+	diags = diags.Append(moreDiags)
+
+	return &terraform.InputValue{
+		Value:       value,
+		SourceType:  terraform.ValueFromConfig,
+		SourceRange: tfdiags.SourceRangeFromHCL(definition.DeclRange),
+	}, diags
+}
+
+func (cache *VariableCache) evaluateFileVariable(name string) (*terraform.InputValue, tfdiags.Diagnostics) {
+	expr, exists := cache.TestFileVariableExpressions[name]
 	if !exists {
 		return nil, nil
 	}
@@ -146,9 +140,12 @@ func (cache *VariableCache) GetFileVariable(name string) (*terraform.InputValue,
 	refs, refDiags := langrefs.ReferencesInExpr(addrs.ParseRefFromTestingScope, expr)
 	for _, ref := range refs {
 		if input, ok := ref.Subject.(addrs.InputVariable); ok {
-			variable, variableDiags := cache.GetGlobalVariable(input.Name)
-			diags = diags.Append(variableDiags)
+			variable, variableDiags := cache.evaluateVariableDefinition(input.Name)
 			if variable != nil {
+				diags = diags.Append(variableDiags)
+				availableVariables[input.Name] = variable.Value
+			} else if variable, variableDiags := cache.EvaluateExternalVariable(input.Name, nil); variable != nil {
+				diags = diags.Append(variableDiags)
 				availableVariables[input.Name] = variable.Value
 			}
 		}
@@ -156,28 +153,17 @@ func (cache *VariableCache) GetFileVariable(name string) (*terraform.InputValue,
 	diags = diags.Append(refDiags)
 
 	if diags.HasErrors() {
-		// There's no point trying to evaluate the variable as we know it will
-		// fail. We'll just return a usable value so that we don't compound
-		// errors later by claiming a variable doesn't exist when it does. We
-		// also return the diagnostics explaining the error which will be shown
-		// to the user.
-		cache.files[name] = &terraform.InputValue{
+		return &terraform.InputValue{
 			Value: cty.DynamicVal,
-		}
-		return cache.files[name], diags
+		}, diags
 	}
 
 	ctx, ctxDiags := EvalContext(TargetFileVariable, map[string]hcl.Expression{name: expr}, availableVariables, nil)
 	diags = diags.Append(ctxDiags)
-
 	if ctxDiags.HasErrors() {
-		// If we couldn't build the context, we won't actually process these
-		// variables. Instead, we'll fill them with an empty value but still
-		// make a note that the user did provide them.
-		cache.files[name] = &terraform.InputValue{
+		return &terraform.InputValue{
 			Value: cty.DynamicVal,
-		}
-		return cache.files[name], diags
+		}, diags
 	}
 
 	value, valueDiags := expr.Value(ctx)
@@ -190,10 +176,50 @@ func (cache *VariableCache) GetFileVariable(name string) (*terraform.InputValue,
 		value = cty.DynamicVal
 	}
 
-	cache.files[name] = &terraform.InputValue{
+	return &terraform.InputValue{
 		Value:       value,
 		SourceType:  terraform.ValueFromConfig,
 		SourceRange: tfdiags.SourceRangeFromHCL(expr.Range()),
+	}, diags
+}
+
+func (cache *VariableCache) GetVariableValue(name string) (*terraform.InputValue, tfdiags.Diagnostics) {
+	cache.mutex.Lock()
+	defer cache.mutex.Unlock()
+
+	if cache.fileVariableValues == nil {
+		cache.fileVariableValues = make(map[string]*terraform.InputValue)
 	}
-	return cache.files[name], diags
+
+	if value, exists := cache.fileVariableValues[name]; exists {
+		return value, nil
+	}
+
+	if value, valueDiags := cache.evaluateFileVariable(name); value != nil {
+		cache.fileVariableValues[name] = value
+		return value, valueDiags
+	}
+
+	if value, valueDiags := cache.evaluateVariableDefinition(name); value != nil {
+		cache.fileVariableValues[name] = value
+		return value, valueDiags
+	}
+
+	if value, valueDiags := cache.EvaluateExternalVariable(name, nil); value != nil {
+		cache.fileVariableValues[name] = value
+		return value, valueDiags
+	}
+
+	return nil, nil
+}
+
+func (cache *VariableCache) HasVariableDefinition(name string) bool {
+	if _, exists := cache.TestFileVariableExpressions[name]; exists {
+		return true
+	}
+
+	if _, exists := cache.TestFileVariableDefinitions[name]; exists {
+		return true
+	}
+	return false
 }

--- a/internal/terraform/eval_variable.go
+++ b/internal/terraform/eval_variable.go
@@ -21,15 +21,15 @@ import (
 	"github.com/hashicorp/terraform/internal/tfdiags"
 )
 
-func prepareFinalInputVariableValue(addr addrs.AbsInputVariableInstance, raw *InputValue, cfg *configs.Variable) (cty.Value, tfdiags.Diagnostics) {
+func PrepareFinalInputVariableValue(addr addrs.AbsInputVariableInstance, raw *InputValue, cfg *configs.Variable) (cty.Value, tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
 
 	convertTy := cfg.ConstraintType
-	log.Printf("[TRACE] prepareFinalInputVariableValue: preparing %s", addr)
+	log.Printf("[TRACE] PrepareFinalInputVariableValue: preparing %s", addr)
 
 	var defaultVal cty.Value
 	if cfg.Default != cty.NilVal {
-		log.Printf("[TRACE] prepareFinalInputVariableValue: %s has a default value", addr)
+		log.Printf("[TRACE] PrepareFinalInputVariableValue: %s has a default value", addr)
 		var err error
 		defaultVal, err = convert.Convert(cfg.Default, convertTy)
 		if err != nil {
@@ -74,14 +74,14 @@ func prepareFinalInputVariableValue(addr addrs.AbsInputVariableInstance, raw *In
 
 	given := raw.Value
 	if given == cty.NilVal { // The variable wasn't set at all (even to null)
-		log.Printf("[TRACE] prepareFinalInputVariableValue: %s has no defined value", addr)
+		log.Printf("[TRACE] PrepareFinalInputVariableValue: %s has no defined value", addr)
 		if cfg.Required() {
 			// NOTE: The CLI layer typically checks for itself whether all of
 			// the required _root_ module variables are set, which would
 			// mask this error with a more specific one that refers to the
 			// CLI features for setting such variables. We can get here for
 			// child module variables, though.
-			log.Printf("[ERROR] prepareFinalInputVariableValue: %s is required but is not set", addr)
+			log.Printf("[ERROR] PrepareFinalInputVariableValue: %s is required but is not set", addr)
 			diags = diags.Append(&hcl.Diagnostic{
 				Severity: hcl.DiagError,
 				Summary:  `Required variable not set`,
@@ -106,7 +106,7 @@ func prepareFinalInputVariableValue(addr addrs.AbsInputVariableInstance, raw *In
 
 	val, err := convert.Convert(given, convertTy)
 	if err != nil {
-		log.Printf("[ERROR] prepareFinalInputVariableValue: %s has unsuitable type\n  got:  %s\n  want: %s", addr, given.Type(), convertTy)
+		log.Printf("[ERROR] PrepareFinalInputVariableValue: %s has unsuitable type\n  got:  %s\n  want: %s", addr, given.Type(), convertTy)
 		var detail string
 		var subject *hcl.Range
 		if nonFileSource != "" {
@@ -157,11 +157,11 @@ func prepareFinalInputVariableValue(addr addrs.AbsInputVariableInstance, raw *In
 	// Nullable variables just appear as null if they were set to null,
 	// regardless of any default value.
 	if val.IsNull() && !cfg.Nullable {
-		log.Printf("[TRACE] prepareFinalInputVariableValue: %s is defined as null", addr)
+		log.Printf("[TRACE] PrepareFinalInputVariableValue: %s is defined as null", addr)
 		if defaultVal != cty.NilVal {
 			val = defaultVal
 		} else {
-			log.Printf("[ERROR] prepareFinalInputVariableValue: %s is non-nullable but set to null, and is required", addr)
+			log.Printf("[ERROR] PrepareFinalInputVariableValue: %s is non-nullable but set to null, and is required", addr)
 			if nonFileSource != "" {
 				diags = diags.Append(&hcl.Diagnostic{
 					Severity: hcl.DiagError,

--- a/internal/terraform/eval_variable_test.go
+++ b/internal/terraform/eval_variable_test.go
@@ -862,7 +862,7 @@ func TestPrepareFinalInputVariableValue(t *testing.T) {
 				SourceType: ValueFromCaller,
 			}
 
-			got, diags := prepareFinalInputVariableValue(
+			got, diags := PrepareFinalInputVariableValue(
 				varAddr, rawVal, varCfg,
 			)
 
@@ -976,7 +976,7 @@ func TestPrepareFinalInputVariableValue(t *testing.T) {
 						SourceRange: test.SourceRange,
 					}
 
-					_, diags := prepareFinalInputVariableValue(
+					_, diags := PrepareFinalInputVariableValue(
 						varAddr, rawVal, varCfg,
 					)
 					if !diags.HasErrors() {
@@ -994,7 +994,7 @@ func TestPrepareFinalInputVariableValue(t *testing.T) {
 						SourceRange: test.SourceRange,
 					}
 
-					_, diags := prepareFinalInputVariableValue(
+					_, diags := PrepareFinalInputVariableValue(
 						varAddr, rawVal, varCfg,
 					)
 					if !diags.HasErrors() {
@@ -1045,7 +1045,7 @@ func TestPrepareFinalInputVariableValue(t *testing.T) {
 						SourceRange: test.SourceRange,
 					}
 
-					_, diags := prepareFinalInputVariableValue(
+					_, diags := PrepareFinalInputVariableValue(
 						varAddr, rawVal, varCfg,
 					)
 					if !diags.HasErrors() {

--- a/internal/terraform/node_module_variable.go
+++ b/internal/terraform/node_module_variable.go
@@ -303,7 +303,7 @@ func (n *nodeModuleVariable) evalModuleVariable(ctx EvalContext, validateOnly bo
 		SourceRange: errSourceRange,
 	}
 
-	finalVal, moreDiags := prepareFinalInputVariableValue(n.Addr, rawVal, n.Config)
+	finalVal, moreDiags := PrepareFinalInputVariableValue(n.Addr, rawVal, n.Config)
 	diags = diags.Append(moreDiags)
 
 	return finalVal, diags.ErrWithWarnings()

--- a/internal/terraform/node_root_variable.go
+++ b/internal/terraform/node_root_variable.go
@@ -100,7 +100,7 @@ func (n *NodeRootVariable) Execute(ctx EvalContext, op walkOperation) tfdiags.Di
 		}
 	}
 
-	finalVal, moreDiags := prepareFinalInputVariableValue(
+	finalVal, moreDiags := PrepareFinalInputVariableValue(
 		addr,
 		givenVal,
 		n.Config,


### PR DESCRIPTION
Currently, `terraform test` attempts to work out the type of any external variables by delaying evaluation until each run block executes so it can use the definitions within the run blocks's module. This means that the values of variables can technically change between run blocks which isn't ideal.

This commit is the first in a chain which will move the evaluation of variables into the terraform test graph. We need to give the users the option of specifying the type for external variables within the file as these variables are now going to be assessed outside of the context of a run block. To do this, we introduce the optional variable blocks that are added by this commit. The optional variable block means that users can specify the intended type of variables that should be provided externally (ie. from the CLI or an external file) and are used within the test file.

The driving change here is to the `VariableCaches` object / file. Previously, we cached variables at the `run` block level. Each run block had it's own cache and definition of variables as they were interpreted based on the config of the current run block. Now, we just evaluate the variables once, so the variable cache has changed from a map of run blocks to caches, just into an individual run block.

