### PR TITLE
terraform test: check specific dependencies before skipping run blocks

### DIFF
--- a/internal/command/test_test.go
+++ b/internal/command/test_test.go
@@ -339,6 +339,11 @@ func TestTest_Runs(t *testing.T) {
 			expectedOut: []string{"1 passed, 0 failed."},
 			code:        0,
 		},
+		"parallel-errors": {
+			expectedOut: []string{"1 passed, 1 failed, 1 skipped."},
+			expectedErr: []string{"Invalid condition run"},
+			code:        1,
+		},
 	}
 	for name, tc := range tcs {
 		t.Run(name, func(t *testing.T) {

--- a/internal/command/testdata/test/parallel-errors/main.tf
+++ b/internal/command/testdata/test/parallel-errors/main.tf
@@ -1,0 +1,11 @@
+variable "input" {
+  type = string
+}
+
+resource "test_resource" "foo" {
+  value = var.input
+}
+
+output "value" {
+  value = test_resource.foo.value
+}

--- a/internal/command/testdata/test/parallel-errors/main.tftest.hcl
+++ b/internal/command/testdata/test/parallel-errors/main.tftest.hcl
@@ -1,0 +1,32 @@
+test {
+  parallel = true
+}
+
+run "one" {
+  state_key = "one"
+
+  variables {
+    input = "one"
+  }
+
+  assert {
+    condition = output.value
+    error_message = "something"
+  }
+}
+
+run "two" {
+  state_key = "two"
+
+  variables {
+    input = run.one.value
+  }
+}
+
+run "three" {
+  state_key = "three"
+
+  variables {
+    input = "three"
+  }
+}

--- a/internal/moduletest/graph/apply.go
+++ b/internal/moduletest/graph/apply.go
@@ -104,10 +104,7 @@ func (n *NodeTestRun) testApply(ctx *EvalContext, variables terraform.InputValue
 	newStatus, outputVals, moreDiags := ctx.EvaluateRun(run, applyScope, testOnlyVariables)
 	run.Status = newStatus
 	run.Diagnostics = run.Diagnostics.Append(moreDiags)
-
-	// Now we've successfully validated this run block, lets add it into
-	// our prior run outputs so future run blocks can access it.
-	ctx.SetOutput(run, outputVals)
+	run.Outputs = outputVals
 
 	// Only update the most recent run and state if the state was
 	// actually updated by this change. We want to use the run that

--- a/internal/moduletest/graph/apply.go
+++ b/internal/moduletest/graph/apply.go
@@ -104,7 +104,15 @@ func (n *NodeTestRun) testApply(ctx *EvalContext, variables terraform.InputValue
 	newStatus, outputVals, moreDiags := ctx.EvaluateRun(run, applyScope, testOnlyVariables)
 	run.Status = newStatus
 	run.Diagnostics = run.Diagnostics.Append(moreDiags)
+
+	// TODO(liamcervante): Temporarily lock the eval context here, while we
+	// still support dynamic provider evaluations. We won't need to lock this
+	// anymore once we don't have to keep all run blocks in the context all the
+	// time.
+
+	ctx.outputsLock.Lock()
 	run.Outputs = outputVals
+	ctx.outputsLock.Unlock()
 
 	// Only update the most recent run and state if the state was
 	// actually updated by this change. We want to use the run that

--- a/internal/moduletest/graph/eval_context.go
+++ b/internal/moduletest/graph/eval_context.go
@@ -384,7 +384,7 @@ func (ec *EvalContext) GetFileState(key string) *TestFileState {
 
 // ReferencesCompleted returns true if all the listed references were actually
 // executed successfully. This allows nodes in the graph to decide if they
-// should execute or not based on the
+// should execute or not based on the status of their references.
 //
 // TODO(liamcervante): Expand this with providers and variables once we've added
 // them to the graph.

--- a/internal/moduletest/graph/eval_context_test.go
+++ b/internal/moduletest/graph/eval_context_test.go
@@ -730,16 +730,21 @@ func TestEvalContext_Evaluate(t *testing.T) {
 				ModuleConfig: config,
 			}
 
-			priorOutputs := make(map[addrs.Run]cty.Value, len(test.priorOutputs))
-			for name, val := range test.priorOutputs {
-				priorOutputs[addrs.Run{Name: name}] = val
-			}
-
 			testCtx := NewEvalContext(EvalContextOpts{
 				CancelCtx: context.Background(),
 				StopCtx:   context.Background(),
 			})
-			testCtx.runOutputs = priorOutputs
+			testCtx.runBlocks = make(map[addrs.Run]*moduletest.Run)
+			for ix, block := range file.Runs[:len(file.Runs)-1] {
+
+				// all prior run blocks we just mark as having passed, and with
+				// the output data specified by the test
+
+				run := moduletest.NewRun(block, config, ix)
+				run.Status = moduletest.Pass
+				run.Outputs = test.priorOutputs[run.Name]
+				testCtx.runBlocks[run.Addr()] = run
+			}
 			gotStatus, gotOutputs, diags := testCtx.EvaluateRun(run, planScope, test.testOnlyVars)
 
 			if got, want := gotStatus, test.expectedStatus; got != want {

--- a/internal/moduletest/graph/plan.go
+++ b/internal/moduletest/graph/plan.go
@@ -72,7 +72,15 @@ func (n *NodeTestRun) testPlan(ctx *EvalContext, variables terraform.InputValues
 	newStatus, outputVals, moreDiags := ctx.EvaluateRun(run, planScope, testOnlyVariables)
 	run.Status = newStatus
 	run.Diagnostics = run.Diagnostics.Append(moreDiags)
+
+	// TODO(liamcervante): Temporarily lock the eval context here, while we
+	// still support dynamic provider evaluations. We won't need to lock this
+	// anymore once we don't have to keep all run blocks in the context all the
+	// time.
+
+	ctx.outputsLock.Lock()
 	run.Outputs = outputVals
+	ctx.outputsLock.Unlock()
 }
 
 func (n *NodeTestRun) plan(ctx *EvalContext, tfCtx *terraform.Context, variables terraform.InputValues, waiter *operationWaiter) (*lang.Scope, *plans.Plan, tfdiags.Diagnostics) {

--- a/internal/moduletest/graph/plan.go
+++ b/internal/moduletest/graph/plan.go
@@ -72,10 +72,7 @@ func (n *NodeTestRun) testPlan(ctx *EvalContext, variables terraform.InputValues
 	newStatus, outputVals, moreDiags := ctx.EvaluateRun(run, planScope, testOnlyVariables)
 	run.Status = newStatus
 	run.Diagnostics = run.Diagnostics.Append(moreDiags)
-
-	// Now we've successfully validated this run block, lets add it into
-	// our prior run outputs so future run blocks can access it.
-	ctx.SetOutput(run, outputVals)
+	run.Outputs = outputVals
 }
 
 func (n *NodeTestRun) plan(ctx *EvalContext, tfCtx *terraform.Context, variables terraform.InputValues, waiter *operationWaiter) (*lang.Scope, *plans.Plan, tfdiags.Diagnostics) {

--- a/internal/moduletest/graph/transform_context.go
+++ b/internal/moduletest/graph/transform_context.go
@@ -4,8 +4,6 @@
 package graph
 
 import (
-	"github.com/zclconf/go-cty/cty"
-
 	"github.com/hashicorp/terraform/internal/dag"
 	"github.com/hashicorp/terraform/internal/moduletest"
 	"github.com/hashicorp/terraform/internal/states"
@@ -31,7 +29,7 @@ func (e *EvalContextTransformer) Transform(graph *terraform.Graph) error {
 				// TODO(liamcervante): Once providers are embedded in the graph
 				// we don't need to track run blocks in this way anymore.
 
-				ctx.SetOutput(run, cty.NilVal)
+				ctx.AddRunBlock(run)
 
 				// We also want to set an empty state file for every state key
 				// we're going to be executing within the graph.


### PR DESCRIPTION
When we first launched the test command, every run block executed in order so one run block erroring meant all others should be skipped. We can now execute run blocks in parallel, which means that sometimes one run block erroring doesn't mean that all others should be skipped. Only those that rely on an errored block should be skipped.

This PR updates the logic for skipping run blocks on failures so they check prior nodes in the graph rather than the overall status of the test file. This will be helpful later when we add variable and providers to the graph as well.

We now track outputs directly in the `moduletest.Run` struct alongside the status instead of separately in the evaluation context. This means we can access the outputs and the status together when deciding on references and prior executions, giving us the ability to selectively decide on a nodes execution based on the status of prior run blocks.