### PR TITLE
allow output values without top-level ephemeral marks

### DIFF
--- a/.changes/v1.12/BUG FIXES-20250604-131240.yaml
+++ b/.changes/v1.12/BUG FIXES-20250604-131240.yaml
@@ -1,0 +1,5 @@
+kind: BUG FIXES
+body: partial ephemeral values were rejected in ephemeral outputs
+time: 2025-06-04T13:12:40.440242-04:00
+custom:
+    Issue: "37210"

--- a/internal/terraform/node_output.go
+++ b/internal/terraform/node_output.go
@@ -493,18 +493,7 @@ If you do intend to export this data, annotate the output value as sensitive by 
 	// "flagWarnOutputErrors", because they relate to features that were added
 	// more recently than the historical change to treat invalid output values
 	// as errors rather than warnings.
-	if n.Config.Ephemeral && !marks.Has(val, marks.Ephemeral) {
-		// An ephemeral output value must always be ephemeral
-		// This is to prevent accidental persistence upstream
-		// from here.
-		diags = diags.Append(&hcl.Diagnostic{
-			Severity: hcl.DiagError,
-			Summary:  "Value not allowed in ephemeral output",
-			Detail:   "This output value is declared as returning an ephemeral value, so it can only be set to an ephemeral value.",
-			Subject:  n.Config.Expr.Range().Ptr(),
-		})
-		return diags
-	} else if !n.Config.Ephemeral && marks.Contains(val, marks.Ephemeral) {
+	if !n.Config.Ephemeral && marks.Contains(val, marks.Ephemeral) {
 		diags = diags.Append(&hcl.Diagnostic{
 			Severity: hcl.DiagError,
 			Summary:  "Ephemeral value not allowed",


### PR DESCRIPTION
There is currently no way to construct an output value which does not come directly from an ephemeral resource or input. Even if the constructed value is entirely composed of ephemeral attributes or elements, because there is no action to manually mark something as ephemeral (other than a variable block), the resulting value itself is not marked as ephemeral, and fails validation.

Instead of strictly checking for an ephemeral mark on the output value, we can accept any value because the result will always be entirely ephemeral anyway. This mirrors the variable block behavior, which can accept any type of value as input, but is evaluated as ephemeral.