### PR TITLE
ensure outputs carry sensitive marks forward

### DIFF
--- a/.changes/v1.13/BUG FIXES-20250604-144021.yaml
+++ b/.changes/v1.13/BUG FIXES-20250604-144021.yaml
@@ -1,0 +1,5 @@
+kind: BUG FIXES
+body: Nested module outputs could lose sensitivity, even when marked as such in the configuration
+time: 2025-06-04T14:40:21.12567-04:00
+custom:
+    Issue: "37212"

--- a/internal/terraform/evaluate.go
+++ b/internal/terraform/evaluate.go
@@ -430,7 +430,7 @@ func (d *evaluationStateData) GetModule(addr addrs.ModuleCall, rng tfdiags.Sourc
 		namedVals := d.Evaluator.NamedValues
 		moduleInstAddr := absAddr.Instance(instKey)
 		attrs := make(map[string]cty.Value, len(outputConfigs))
-		for name := range outputConfigs {
+		for name, cfg := range outputConfigs {
 			outputAddr := moduleInstAddr.OutputValue(name)
 
 			// Although we do typically expect the graph dependencies to
@@ -446,6 +446,9 @@ func (d *evaluationStateData) GetModule(addr addrs.ModuleCall, rng tfdiags.Sourc
 				continue
 			}
 			outputVal := namedVals.GetOutputValue(outputAddr)
+			if cfg.Sensitive {
+				outputVal = outputVal.Mark(marks.Sensitive)
+			}
 			attrs[name] = outputVal
 		}
 


### PR DESCRIPTION
Sensitive marks were lost from module outputs during the namedvals rewrite. Ensure output are evaluated with sensitive marks in accordance with their configuration.

Interestingly I found that the old access point of `lang.Data.GetOutput` was not removed long ago when we fixed module evaluation overall to always access the module objects. This method however was recent [re-captured by the moduletest package](https://github.com/hashicorp/terraform/blob/f80762d3d539eeaf4c8894c3edd0d5f33aeefe60/internal/moduletest/graph/eval_context.go#L305). That code can probably be refactored to use `GetModule` and we can remove the `GetOutput` call to ensure uniformity of evaluation.