### PR TITLE
Add and refactor test in the `planfile` package

### DIFF
--- a/internal/plans/planfile/tfplan_test.go
+++ b/internal/plans/planfile/tfplan_test.go
@@ -65,6 +65,38 @@ func TestTFPlanRoundTrip(t *testing.T) {
 	}
 }
 
+func Test_writeTfplan_validation(t *testing.T) {
+
+	cases := map[string]struct {
+		plan            *plans.Plan
+		wantWriteErrMsg string
+	}{
+		"error when missing backend data": {
+			plan: func() *plans.Plan {
+				rawPlan := examplePlanForTest(t)
+				// remove backend from example plan
+				rawPlan.Backend.Type = ""
+				rawPlan.Backend.Config = nil
+				return rawPlan
+			}(),
+			wantWriteErrMsg: "plan does not have a backend configuration",
+		},
+	}
+
+	for tn, tc := range cases {
+		t.Run(tn, func(t *testing.T) {
+			var buf bytes.Buffer
+			err := writeTfplan(tc.plan, &buf)
+			if err == nil {
+				t.Fatal("this test expects an error but got none")
+			}
+			if err.Error() != tc.wantWriteErrMsg {
+				t.Fatalf("unexpected error message: wanted %q, got %q", tc.wantWriteErrMsg, err)
+			}
+		})
+	}
+}
+
 // examplePlanForTest returns a plans.Plan struct pointer that can be used
 // when setting up tests. The returned plan can be mutated depending on the
 // test case.


### PR DESCRIPTION
This PR refactors and adds some tests to code relating to plan files, in anticipation of a future PR that adds new features to plan files. By pulling this work out early I'm trying to make my next PR smaller.

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

N/A

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
