### PR TITLE
Refactor code to use backend config state's `SetConfig` method, protect against nil receiver

### DIFF
--- a/internal/command/workdir/backend_config_state.go
+++ b/internal/command/workdir/backend_config_state.go
@@ -5,6 +5,7 @@ package workdir
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 
 	"github.com/zclconf/go-cty/cty"
@@ -51,6 +52,9 @@ func (s *BackendConfigState) Config(schema *configschema.Block) (cty.Value, erro
 // An error is returned if the given value does not conform to the implied
 // type of the schema.
 func (s *BackendConfigState) SetConfig(val cty.Value, schema *configschema.Block) error {
+	if s == nil {
+		return errors.New("SetConfig called on nil BackendConfigState receiver")
+	}
 	ty := schema.ImpliedType()
 	buf, err := ctyjson.Marshal(val, ty)
 	if err != nil {

--- a/internal/command/workdir/statestore_config_state.go
+++ b/internal/command/workdir/statestore_config_state.go
@@ -5,6 +5,7 @@ package workdir
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 
 	version "github.com/hashicorp/go-version"
@@ -85,6 +86,9 @@ func (s *StateStoreConfigState) Config(schema *configschema.Block) (cty.Value, e
 // An error is returned if the given value does not conform to the implied
 // type of the schema.
 func (s *StateStoreConfigState) SetConfig(val cty.Value, schema *configschema.Block) error {
+	if s == nil {
+		return errors.New("SetConfig called on nil StateStoreConfigState receiver")
+	}
 	ty := schema.ImpliedType()
 	buf, err := ctyjson.Marshal(val, ty)
 	if err != nil {


### PR DESCRIPTION
For context, the `SetConfig` method on `BackendConfigState` is only used in the context of tests currently. Whenever a BackendConfigState is assembled the config is set directly by assigning a value to ConfigRaw:

https://github.com/hashicorp/terraform/blob/a9b67a6cdc9502949d38670a3b1187799cf2a70d/internal/command/meta_backend.go#L1055-L1064

That `configJSON` value is constructed in the code immediately preceding the above snippet:

https://github.com/hashicorp/terraform/blob/a9b67a6cdc9502949d38670a3b1187799cf2a70d/internal/command/meta_backend.go#L1049-L1053

This PR refactors that code to instead use [the SetConfig method](https://github.com/hashicorp/terraform/blob/9fb6d02cb3e6c65705f77721b87df41b2795f80f/internal/command/workdir/backend_config_state.go#L54). This method includes the logic for marshalling cty data to JSON, so replaces the equivalent code above that gets the implied type of a schema and marshals the cty value to json. 

Also, this PR adds a nil receiver check to the method.

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.13.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
