### PR TITLE
Add `DiagnosticComparerRelaxed` and tests

### DIFF
--- a/internal/tfdiags/compare_test.go
+++ b/internal/tfdiags/compare_test.go
@@ -110,3 +110,144 @@ func TestDiagnosticComparer(t *testing.T) {
 		})
 	}
 }
+
+func TestDiagnosticComparerRelaxed(t *testing.T) {
+
+	baseError := hcl.Diagnostic{
+		Severity: hcl.DiagError,
+		Summary:  "error",
+		Detail:   "this is an error",
+		Subject: &hcl.Range{
+			Filename: "foobar.tf",
+			Start: hcl.Pos{
+				Line:   0,
+				Column: 0,
+				Byte:   0,
+			},
+			End: hcl.Pos{
+				Line:   1,
+				Column: 1,
+				Byte:   1,
+			},
+		},
+	}
+
+	cases := map[string]struct {
+		diag1      Diagnostic
+		diag2      Diagnostic
+		expectDiff bool
+	}{
+		// Correctly identifying things that match
+		"reports that identical diagnostics match": {
+			diag1:      hclDiagnostic{&baseError},
+			diag2:      hclDiagnostic{&baseError},
+			expectDiff: false,
+		},
+		// Correctly identifies when things don't match
+		"reports that diagnostics don't match if the concrete type differs": {
+			diag1:      hclDiagnostic{&baseError},
+			diag2:      makeRPCFriendlyDiag(hclDiagnostic{&baseError}),
+			expectDiff: true,
+		},
+		"reports that diagnostics don't match if severity differs": {
+			diag1: hclDiagnostic{&baseError},
+			diag2: func() Diagnostic {
+				d := baseError
+				d.Severity = hcl.DiagWarning
+				return hclDiagnostic{&d}
+			}(),
+			expectDiff: true,
+		},
+		"reports that diagnostics don't match if summary differs": {
+			diag1: hclDiagnostic{&baseError},
+			diag2: func() Diagnostic {
+				d := baseError
+				d.Summary = "altered summary"
+				return hclDiagnostic{&d}
+			}(),
+			expectDiff: true,
+		},
+		"reports that diagnostics don't match if detail differs": {
+			diag1: hclDiagnostic{&baseError},
+			diag2: func() Diagnostic {
+				d := baseError
+				d.Detail = "altered detail"
+				return hclDiagnostic{&d}
+			}(),
+			expectDiff: true,
+		},
+		"reports that diagnostics don't match if attribute path differs": {
+			diag1: func() Diagnostic {
+				return AttributeValue(Error, "summary here", "detail here", cty.Path{cty.GetAttrStep{Name: "foobar1"}})
+			}(),
+			diag2: func() Diagnostic {
+				return AttributeValue(Error, "summary here", "detail here", cty.Path{cty.GetAttrStep{Name: "foobar2"}})
+			}(),
+			expectDiff: true,
+		},
+		"reports that diagnostics don't match if attribute path is missing from one": {
+			diag1: func() Diagnostic {
+				return AttributeValue(Error, "summary here", "detail here", cty.Path{cty.GetAttrStep{Name: "foobar1"}})
+			}(),
+			diag2: func() Diagnostic {
+				return AttributeValue(Error, "summary here", "detail here", cty.Path{})
+			}(),
+			expectDiff: true,
+		},
+		// Scenarios where diagnostics will be considered equivalent, even if they aren't fully the same
+		"reports that diagnostics match even if sources (Subject) are different; ignored in simple comparison": {
+			diag1: hclDiagnostic{&baseError},
+			diag2: func() Diagnostic {
+				d := baseError
+				d.Subject = &hcl.Range{
+					Filename: "foobar.tf",
+					Start: hcl.Pos{
+						Line:   0,
+						Column: 0,
+						Byte:   0,
+					},
+					End: hcl.Pos{
+						Line:   1,
+						Column: 1,
+						Byte:   1,
+					},
+				}
+				return hclDiagnostic{&d}
+			}(),
+		},
+		"reports that diagnostics match even if sources (Context) are different; ignored in simple comparison": {
+			diag1: hclDiagnostic{&baseError},
+			diag2: func() Diagnostic {
+				d := baseError
+				d.Context = &hcl.Range{
+					Filename: "foobar.tf",
+					Start: hcl.Pos{
+						Line:   0,
+						Column: 0,
+						Byte:   0,
+					},
+					End: hcl.Pos{
+						Line:   1,
+						Column: 1,
+						Byte:   1,
+					},
+				}
+				return hclDiagnostic{&d}
+			}(),
+		},
+	}
+
+	for tn, tc := range cases {
+		t.Run(tn, func(t *testing.T) {
+			output := cmp.Diff(tc.diag1, tc.diag2, DiagnosticComparerRelaxed)
+
+			diffFound := output != ""
+			if diffFound && !tc.expectDiff {
+				t.Fatalf("unexpected diff detected:\n%s", output)
+			}
+			if !diffFound && tc.expectDiff {
+				t.Fatal("expected a diff but none was detected")
+			}
+		})
+	}
+}


### PR DESCRIPTION
The diagnostic comparer used in the s3 code base was  copied over to the shared tfdiags package in https://github.com/hashicorp/terraform/pull/36385.

The comparer was then refactored, and the s3 tests were not run during these changes:
* https://github.com/hashicorp/terraform/pull/36579
* https://github.com/hashicorp/terraform/pull/36825

This has resulted in the s3 tests starting to fail, as they've been forced to use a more stringent comparer than they were originally written to use.

This PR is one option - restore a more relaxed version of the comparer that isn't meant to be the default choice.


## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.13.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
