### PR TITLE
Make Terraform reject empty strings as invalid workspace names

### DIFF
--- a/internal/command/workspace_command.go
+++ b/internal/command/workspace_command.go
@@ -45,6 +45,9 @@ func (c *WorkspaceCommand) Synopsis() string {
 // Since most named states are accessed via a filesystem path or URL, check if
 // escaping the name would be required.
 func validWorkspaceName(name string) bool {
+	if name == "" {
+		return false
+	}
 	return name == url.PathEscape(name)
 }
 

--- a/internal/command/workspace_command_test.go
+++ b/internal/command/workspace_command_test.go
@@ -494,6 +494,11 @@ func TestValidWorkspaceName(t *testing.T) {
 			input: "two words",
 			valid: false,
 		},
+		"empty string": {
+			input: "",
+			valid: false,
+		},
+	}
 
 	for tn, tc := range cases {
 		t.Run(tn, func(t *testing.T) {

--- a/internal/command/workspace_command_test.go
+++ b/internal/command/workspace_command_test.go
@@ -476,3 +476,31 @@ func TestWorkspace_selectWithOrCreate(t *testing.T) {
 	}
 
 }
+
+func TestValidWorkspaceName(t *testing.T) {
+	cases := map[string]struct {
+		input string
+		valid bool
+	}{
+		"foobar": {
+			input: "foobar",
+			valid: true,
+		},
+		"valid symbols": {
+			input: "-._~@:",
+			valid: true,
+		},
+		"includes space": {
+			input: "two words",
+			valid: false,
+		},
+
+	for tn, tc := range cases {
+		t.Run(tn, func(t *testing.T) {
+			valid := validWorkspaceName(tc.input)
+			if valid != tc.valid {
+				t.Fatalf("unexpected output when processing input %q. Wanted %v got %v", tc.input, tc.valid, valid)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Fixes #

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.13.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [x] This change is user-facing and I added a changelog entry.
- [ ] This change is not user-facing.
