### PR TITLE
Make `workspace delete` command reject empty string arguments

### DIFF
--- a/.changes/v1.13/BUG FIXES-20250626-140248.yaml
+++ b/.changes/v1.13/BUG FIXES-20250626-140248.yaml
@@ -1,0 +1,5 @@
+kind: BUG FIXES
+body: 'workspace: Updated the `workspace delete` command to reject `""` as an invalid workspace name'
+time: 2025-06-26T14:02:48.899952+01:00
+custom:
+    Issue: "37275"

--- a/internal/command/workspace_delete.go
+++ b/internal/command/workspace_delete.go
@@ -44,6 +44,11 @@ func (c *WorkspaceDeleteCommand) Run(args []string) int {
 		c.Ui.Error("Expected a single argument: NAME.\n")
 		return cli.RunResultHelp
 	}
+	if args[0] == "" {
+		// Disallowing empty string identifiers more explicitly, versus "Workspace "" doesn't exist."
+		c.Ui.Error(fmt.Sprintf("Expected a workspace name as an argument, instead got an empty string: %q\n", args[0]))
+		return cli.RunResultHelp
+	}
 
 	configPath, err := ModulePath(args[1:])
 	if err != nil {


### PR DESCRIPTION
This follows https://github.com/hashicorp/terraform/pull/37267, which makes Terraform stop users from creating or switching to workspaces called `""`.

That PR didn't touch the `workspace delete` command, as that command doesn't check the workspace name for validity. This is on purpose; we want to allow users to delete invalid workspaces if they exist.

Currently most if not all backend implementations block deletion of `""` workspaces, as it's conflated with the default workspace. For example: [s3 backend](https://github.com/hashicorp/terraform/blob/a9b67a6cdc9502949d38670a3b1187799cf2a70d/internal/backend/remote-state/s3/backend_state.go#L137-L139), [kubernetes backend](https://github.com/hashicorp/terraform/blob/a9b67a6cdc9502949d38670a3b1187799cf2a70d/internal/backend/remote-state/kubernetes/backend_state.go#L68-L70).

Other backends, e.g. local, don't block the deletion of `""` workspace per se, but they are unsuccessful with `Workspace "" doesn't exist.` errors.

To remove risk around whether a backend in future could allow `terraform workspace delete ""` to remove the `default` workspace, I think we should block that argument value in the delete command.

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.13.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [x] This change is user-facing and I added a changelog entry.
- [ ] This change is not user-facing.
