### PR TITLE
Fix bug in DeepCopy of backend state data that causes loss of StateStore data

### DIFF
--- a/internal/command/workdir/backend_state.go
+++ b/internal/command/workdir/backend_state.go
@@ -143,9 +143,10 @@ func (f *BackendStateFile) DeepCopy() *BackendStateFile {
 		return nil
 	}
 	ret := &BackendStateFile{
-		Version:   f.Version,
-		TFVersion: f.TFVersion,
-		Backend:   f.Backend.DeepCopy(),
+		Version:    f.Version,
+		TFVersion:  f.TFVersion,
+		Backend:    f.Backend.DeepCopy(),
+		StateStore: f.StateStore.DeepCopy(),
 	}
 	if f.Remote != nil {
 		// This shouldn't ever be present in an object held by a caller since

--- a/internal/command/workdir/backend_state_test.go
+++ b/internal/command/workdir/backend_state_test.go
@@ -5,6 +5,7 @@ package workdir
 
 import (
 	"encoding/json"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -228,5 +229,48 @@ func TestEncodeBackendStateFile(t *testing.T) {
 			}
 		})
 
+	}
+}
+
+func TestBackendStateFile_DeepCopy(t *testing.T) {
+
+	tests := map[string]struct {
+		file *BackendStateFile
+	}{
+		"Deep copy preserves state_store data": {
+			file: &BackendStateFile{
+				StateStore: &StateStoreConfigState{
+					Type:      "foo_bar",
+					Provider:  getTestProviderState(t, "1.2.3", "A", "B", "C"),
+					ConfigRaw: json.RawMessage([]byte(`{"foo":"bar"}`)),
+					Hash:      123,
+				},
+			},
+		},
+		"Deep copy preserves backend data": {
+			file: &BackendStateFile{
+				Backend: &BackendConfigState{
+					Type:      "foobar",
+					ConfigRaw: json.RawMessage([]byte(`{"foo":"bar"}`)),
+					Hash:      123,
+				},
+			},
+		},
+		"Deep copy preserves version and Terraform version data": {
+			file: &BackendStateFile{
+				Version:   3,
+				TFVersion: "9.9.9",
+			},
+		},
+	}
+
+	for tn, tc := range tests {
+		t.Run(tn, func(t *testing.T) {
+			copy := tc.file.DeepCopy()
+
+			if !reflect.DeepEqual(copy, tc.file) {
+				t.Fatalf("unexpected difference in backend state data:\n got %#v, want %#v", copy, tc.file)
+			}
+		})
 	}
 }


### PR DESCRIPTION
This PR fixes an issue related to https://github.com/hashicorp/terraform/pull/37179. That previous PR did not update the (*BackendStateFile) DeepCopy method to invoke the new (*StateStoreConfigState) DeepCopy method, resulting in the bug fixed here.

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.13.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
