### PR TITLE
skip set elem comparison when already matched

### DIFF
--- a/.changes/v1.13/ENHANCEMENTS-20250627-094638.yaml
+++ b/.changes/v1.13/ENHANCEMENTS-20250627-094638.yaml
@@ -1,0 +1,5 @@
+kind: ENHANCEMENTS
+body: skip redundant comparisons when comparing planned set changes
+time: 2025-06-27T09:46:38.899237-04:00
+custom:
+    Issue: "37280"

--- a/internal/plans/objchange/compatible.go
+++ b/internal/plans/objchange/compatible.go
@@ -366,6 +366,14 @@ func assertSetValuesCompatible(planned, actual cty.Value, path cty.Path, f func(
 	beqs := make([]bool, len(bs))
 	for ai, av := range as {
 		for bi, bv := range bs {
+			if aeqs[ai] && beqs[bi] {
+				// because the best we can do is check that a value correlates
+				// with some other value in the other set, one or both values
+				// might have already been matched. If they have both matched in
+				// some way there's no need run the check again.
+				continue
+			}
+
 			if f(av, bv) {
 				aeqs[ai] = true
 				beqs[bi] = true


### PR DESCRIPTION
If both elements of the set have already been matched, there is no need to compare them again.
Verified the coverage using existing tests, so no need for another duplicate test case.

Closes #32940
