### PR TITLE
Move `stacksplugin` cache to `.terraform.d`

### DIFF
--- a/internal/command/stacks.go
+++ b/internal/command/stacks.go
@@ -14,6 +14,7 @@ import (
 	"os/exec"
 	"path"
 	"runtime"
+	"slices"
 	"strings"
 
 	"github.com/hashicorp/go-plugin"
@@ -93,6 +94,10 @@ func (c *StacksCommand) realRun(args []string, stdout, stderr io.Writer) int {
 			c.Ui.Error(fmt.Sprintf("Error storing cached stacks plugin path: %s\n", err))
 			return 1
 		}
+		// Remove the cache override arg from the args so it doesn't get passed to the plugin
+		args = slices.DeleteFunc(args, func(arg string) bool {
+			return strings.HasPrefix(arg, "-plugin-cache-dir")
+		})
 	}
 
 	diags := c.initPlugin()

--- a/internal/command/stacks.go
+++ b/internal/command/stacks.go
@@ -76,7 +76,24 @@ var (
 )
 
 func (c *StacksCommand) realRun(args []string, stdout, stderr io.Writer) int {
+	var pluginCacheDirOverride string
+
 	args = c.Meta.process(args)
+	cmdFlags := c.Meta.defaultFlagSet("stacks")
+	cmdFlags.StringVar(&pluginCacheDirOverride, "plugin-cache-dir", "", "plugin cache directory")
+	cmdFlags.Usage = func() { c.Ui.Error(c.Help()) }
+	if err := cmdFlags.Parse(args); err != nil {
+		c.Ui.Error(fmt.Sprintf("Error parsing command-line flags: %s\n", err.Error()))
+		return 1
+	}
+
+	if pluginCacheDirOverride != "" {
+		err := c.storeStacksPluginPath(path.Join(pluginCacheDirOverride, StacksPluginDataDir))
+		if err != nil {
+			c.Ui.Error(fmt.Sprintf("Error storing cached stacks plugin path: %s\n", err))
+			return 1
+		}
+	}
 
 	diags := c.initPlugin()
 	if diags.HasWarnings() || diags.HasErrors() {
@@ -305,19 +322,50 @@ func (c *StacksCommand) initPlugin() tfdiags.Diagnostics {
 }
 
 func (c *StacksCommand) initPackagesCache() (string, error) {
-	packagesPath := path.Join(c.WorkingDir.DataDir(), StacksPluginDataDir)
+	var pluginPath string
+	defaultPluginPath := path.Join(c.CLIConfigDir, StacksPluginDataDir)
+	cacheStorePath := path.Join(c.WorkingDir.DataDir(), ".stackspluginpath")
 
-	if info, err := os.Stat(packagesPath); err != nil || !info.IsDir() {
-		log.Printf("[TRACE] initialized stacksplugin cache directory at %q", packagesPath)
-		err = os.MkdirAll(packagesPath, 0755)
+	if _, err := os.Stat(cacheStorePath); err != nil {
+		if os.IsNotExist(err) {
+			log.Printf("[TRACE] No stacksplugin cache path store at '%s`, using default '%s'", cacheStorePath, defaultPluginPath)
+			// Use the default plugin cache path if the file does not exist
+			pluginPath = defaultPluginPath
+		} else {
+			log.Printf("[TRACE] Failed to check the stacksplugin cache path store at '%s', using default '%s'", cacheStorePath, defaultPluginPath)
+			// Use the default plugin cache path if there was an error checking the file
+			pluginPath = defaultPluginPath
+		}
+	} else {
+		data, err := os.ReadFile(cacheStorePath)
+		if err != nil {
+			return "", fmt.Errorf("failed to read stacks plugin stored path file: %w", err)
+		}
+		pluginPath = string(data)
+	}
+
+	if info, err := os.Stat(pluginPath); err != nil || !info.IsDir() {
+		log.Printf("[TRACE] initialized stacksplugin cache directory at %q", pluginPath)
+		err = os.MkdirAll(pluginPath, 0755)
 		if err != nil {
 			return "", fmt.Errorf("failed to initialize stacksplugin cache directory: %w", err)
 		}
 	} else {
-		log.Printf("[TRACE] stacksplugin cache directory found at %q", packagesPath)
+		log.Printf("[TRACE] stacksplugin cache directory found at %q", pluginPath)
 	}
 
-	return packagesPath, nil
+	return pluginPath, nil
+}
+
+func (c *StacksCommand) storeStacksPluginPath(pluginCachePath string) error {
+	f, err := os.Create(path.Join(c.WorkingDir.DataDir(), ".stackspluginpath"))
+	if err != nil {
+		return fmt.Errorf("failed to create stacks plugin stored path file: %w", err)
+	}
+	defer f.Close()
+	f.WriteString(pluginCachePath)
+
+	return nil
 }
 
 // Run runs the stacks command with the given arguments.

--- a/internal/pluginshared/stacksbinary.go
+++ b/internal/pluginshared/stacksbinary.go
@@ -26,6 +26,8 @@ func NewStacksBinaryManager(ctx context.Context, stacksPluginDataDir, overridePa
 		return nil, fmt.Errorf("could not initialize stacksplugin version manager: %w", err)
 	}
 
+	// read from the data dir to find the cached stacksplugin binary location
+
 	return &StacksBinaryManager{
 		BinaryManager{
 			pluginDataDir: stacksPluginDataDir,


### PR DESCRIPTION
## Description
This PR moves the cached stacksplugin binary location to `.terraform.d` by default, with the option to override this location with the argument `-plugin-cache-dir`.  

If this location is overriden, then the path provided is stored in `.terraform/.stackspluginpath` of the current working directory for future reference by the subcommand. The thought behind this was to be proactive with providing a workaround in the event any user specific issues made the default behavior a problem.

I figure no changelog entry is needed as this change wraps up into the existing entry for the `terraform stacks` subcommand.

## Context
As it stands, when you run `terraform stacks ...` the stacks plugin binary is downloaded to the `.terraform/tfstacks` directory in current working directory. This is a pattern that came from the cloud subcommand that we ran with at the time. This made sense for the cloud plugin as the command needs the context of a cloud block (with a `.terraform` implicitly in the configuration directory) to fully function. 

Though this isn't the case for the stacks plugin– many of it's commands pertain to cloud operations apart from the configuration itself (listing deployment runs, watching the progress of a deployment group, etc.). As such we didn't make this a requirement of the `stacks` command.

A consequence of this is that the stacks command has the potential to litter `.terraform/tfstacks` with the plugin binary outside of stacks configuration directories– and it seems likely considering the nature of many of the commands.

## Testing

Running `terraform stacks` should create `.terraform.d/stacksplugin` with the stacksplugin binary.

Otherwise running `terraform stacks -plugin-cache-dir=...` should create `stacksplugin` at the provided cache location with the stacksplugin binary as well as a '.terraform/.stackspluginpath' in your working directory with the provided cache path override.

## Target Release

1.13.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [ ] This change is not user-facing.
