### PR TITLE
relevant attributes: strip out invalid relevant attributes from the plan

### DIFF
--- a/internal/command/jsonformat/structured/attribute_path/matcher.go
+++ b/internal/command/jsonformat/structured/attribute_path/matcher.go
@@ -151,6 +151,10 @@ func (p *PathMatcher) GetChildWithKey(key string) Matcher {
 			continue
 		}
 
+		if _, ok := path[0].(string); !ok {
+			panic("not a string")
+		}
+
 		if path[0].(string) == key {
 			child.Paths = append(child.Paths, path[1:])
 		}

--- a/internal/terraform/context_plan2_test.go
+++ b/internal/terraform/context_plan2_test.go
@@ -6698,6 +6698,163 @@ resource "aws_instance" "foo" {
 	}
 }
 
+func TestContext2Plan_invalidReferencesAreNotRelevant(t *testing.T) {
+	p := &testing_provider.MockProvider{
+		GetProviderSchemaResponse: &providers.GetProviderSchemaResponse{
+			Provider: providers.Schema{
+				Body: new(configschema.Block),
+			},
+			ResourceTypes: map[string]providers.Schema{
+				"test_computed_object": {
+					Body: &configschema.Block{
+						Attributes: map[string]*configschema.Attribute{
+							"key": {
+								Type:     cty.String,
+								Computed: true,
+							},
+							"dynamic": {
+								Type:     cty.DynamicPseudoType,
+								Computed: true,
+							},
+							"object": {
+								NestedType: &configschema.Object{
+									Nesting: configschema.NestingSingle,
+									Attributes: map[string]*configschema.Attribute{
+										"value": {
+											Type:     cty.String,
+											Computed: true,
+										},
+									},
+								},
+								Computed: true,
+							},
+						},
+					},
+				},
+				"test_simple_object": {
+					Body: &configschema.Block{
+						Attributes: map[string]*configschema.Attribute{
+							"value": {
+								Type:     cty.String,
+								Optional: true,
+							},
+						},
+					},
+				},
+			},
+		},
+		PlanResourceChangeFn: func(request providers.PlanResourceChangeRequest) providers.PlanResourceChangeResponse {
+			switch request.TypeName {
+			case "test_computed_object":
+				return providers.PlanResourceChangeResponse{
+					PlannedState: cty.ObjectVal(map[string]cty.Value{
+						"key": cty.UnknownVal(cty.String),
+						"object": cty.UnknownVal(cty.Object(map[string]cty.Type{
+							"value": cty.String,
+						})),
+						"dynamic": cty.DynamicVal,
+					}),
+				}
+			case "test_simple_object":
+				return providers.PlanResourceChangeResponse{
+					PlannedState: request.ProposedNewState,
+				}
+			default:
+				panic(fmt.Sprintf("unknown resource type %q", request.TypeName))
+			}
+		},
+	}
+
+	tcs := map[string]struct {
+		configs            map[string]string
+		expectedAttributes []string
+		expectedDiags      []string
+	}{
+		"invalid object reference": {
+			configs: map[string]string{
+				"main.tf": `
+resource "test_computed_object" "a" {}
+
+resource "test_simple_object" "b" {
+	value = try(test_computed_object.a.object[0].value, test_computed_object.a.object.value)
+}
+`,
+			},
+			expectedAttributes: []string{
+				"test_computed_object.a.object.value",
+			},
+		},
+		"dynamic object reference": {
+			configs: map[string]string{
+				"main.tf": `
+resource "test_computed_object" "a" {}
+
+resource "test_simple_object" "b" {
+	value = try(test_computed_object.a.dynamic[0].value, test_computed_object.a.object.value)
+}
+`,
+			},
+			expectedAttributes: []string{
+				"test_computed_object.a.object.value",
+			},
+		},
+		"unknown object reference": {
+			configs: map[string]string{
+				"main.tf": `
+resource "test_computed_object" "a" {}
+
+resource "test_simple_object" "b" {
+	value = try(test_computed_object.a.object[test_computed_object.a.key].value, test_computed_object.a.object.value)
+}
+`,
+			},
+			expectedAttributes: []string{
+				"test_computed_object.a.key",
+				"test_computed_object.a.object",
+				"test_computed_object.a.object.value",
+			},
+		},
+	}
+	for name, tc := range tcs {
+		t.Run(name, func(t *testing.T) {
+			m := testModuleInline(t, tc.configs)
+			ctx := testContext2(t, &ContextOpts{
+				Providers: map[addrs.Provider]providers.Factory{
+					addrs.NewDefaultProvider("test"): testProviderFuncFixed(p),
+				},
+			})
+
+			plan, diags := ctx.Plan(m, nil, DefaultPlanOpts)
+			if len(diags) != len(tc.expectedDiags) {
+				t.Errorf("should find exactly %d diagnostics, but was %d", len(tc.expectedDiags), len(diags))
+			} else {
+				for ix := range tc.expectedDiags {
+					if diag := fmt.Sprintf("%s:%s", diags[ix].Description().Summary, diags[ix].Description().Detail); diag != tc.expectedDiags[ix] {
+						t.Errorf("unexpected diagnostic diagnostic: %s", diag)
+					}
+				}
+			}
+
+			if len(plan.RelevantAttributes) != len(tc.expectedAttributes) {
+				t.Errorf("should find exactly %d relevant attribute, but was %d", len(tc.expectedAttributes), len(plan.RelevantAttributes))
+			} else {
+
+				var sorted []string
+				for _, attr := range plan.RelevantAttributes {
+					sorted = append(sorted, attr.DebugString())
+				}
+				sort.Strings(sorted)
+
+				for ix := range tc.expectedAttributes {
+					if sorted[ix] != tc.expectedAttributes[ix] {
+						t.Errorf("found wrong relevant attribute at %d: %s", ix, sorted[ix])
+					}
+				}
+			}
+		})
+	}
+}
+
 func TestContext2Plan_orphanUpdateInstance(t *testing.T) {
 	// ean orphaned instance should still reflect the refreshed state in the plan
 	m := testModuleInline(t, map[string]string{


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

Because `try()` and `can()` functions hide invalid references, these invalid references can find their way into the relevant attributes field in the plan. The plan renderer might then crash if it tries to render drift derived from those attributes since the plan renderer assumes everything in the plan is valid. 

This PR updates the plan generation so that it checks relevant attributes before putting them into the plan, and will only include valid references.

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Fixes #37271 

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.13.x

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

I will add a CHANGELOG later if we like this approach.