### PR TITLE
Test run Parallelism of 1 should not result in deadlock

### DIFF
--- a/internal/command/arguments/test.go
+++ b/internal/command/arguments/test.go
@@ -22,6 +22,10 @@ type Test struct {
 	// during the plan or apply command within a single test run.
 	OperationParallelism int
 
+	// RunParallelism is the limit Terraform places on parallel test runs. This
+	// is the number of test runs that can be executed in parallel within a file.
+	RunParallelism int
+
 	// TestDirectory allows the user to override the directory that the test
 	// command will use to discover test files, defaults to "tests". Regardless
 	// of the value here, test files within the configuration directory will
@@ -60,6 +64,7 @@ func ParseTest(args []string) (*Test, tfdiags.Diagnostics) {
 	cmdFlags.StringVar(&test.JUnitXMLFile, "junit-xml", "", "junit-xml")
 	cmdFlags.BoolVar(&test.Verbose, "verbose", false, "verbose")
 	cmdFlags.IntVar(&test.OperationParallelism, "parallelism", DefaultParallelism, "parallelism")
+	cmdFlags.IntVar(&test.RunParallelism, "run-parallelism", DefaultParallelism, "run-parallelism")
 
 	// TODO: Finalise the name of this flag.
 	cmdFlags.StringVar(&test.CloudRunSource, "cloud-run", "", "cloud-run")

--- a/internal/command/test.go
+++ b/internal/command/test.go
@@ -227,6 +227,7 @@ func (c *TestCommand) Run(rawArgs []string) int {
 			CancelledCtx:        cancelCtx,
 			Filter:              args.Filter,
 			Verbose:             args.Verbose,
+			Concurrency:         args.RunParallelism,
 		}
 
 		// JUnit output is only compatible with local test execution

--- a/internal/command/test_test.go
+++ b/internal/command/test_test.go
@@ -62,6 +62,11 @@ func TestTest_Runs(t *testing.T) {
 			expectedOut: []string{"1 passed, 0 failed."},
 			code:        0,
 		},
+		"simple_pass_count": {
+			expectedOut: []string{"1 passed, 0 failed."},
+			args:        []string{"-run-parallelism", "1"},
+			code:        0,
+		},
 		"simple_pass_nested_alternate": {
 			args:        []string{"-test-directory", "other"},
 			expectedOut: []string{"1 passed, 0 failed."},

--- a/internal/command/testdata/test/simple_pass_count/main.tf
+++ b/internal/command/testdata/test/simple_pass_count/main.tf
@@ -1,0 +1,4 @@
+resource "test_resource" "foo" {
+  count = 3
+  value = "bar"
+}

--- a/internal/command/testdata/test/simple_pass_count/main.tftest.hcl
+++ b/internal/command/testdata/test/simple_pass_count/main.tftest.hcl
@@ -1,0 +1,6 @@
+run "validate_test_resource" {
+  assert {
+    condition = test_resource.foo[0].value == "bar"
+    error_message = "invalid value"
+  }
+}

--- a/internal/moduletest/graph/transform_state_cleanup.go
+++ b/internal/moduletest/graph/transform_state_cleanup.go
@@ -12,7 +12,14 @@ import (
 	"github.com/hashicorp/terraform/internal/terraform"
 )
 
-var _ GraphNodeExecutable = &TeardownSubgraph{}
+var (
+	_ GraphNodeExecutable = &TeardownSubgraph{}
+	_ Subgrapher          = &TeardownSubgraph{}
+)
+
+type Subgrapher interface {
+	isSubGrapher()
+}
 
 // TeardownSubgraph is a subgraph for cleaning up the state of
 // resources defined in the state files created by the test runs.
@@ -53,6 +60,8 @@ func (b *TeardownSubgraph) Execute(ctx *EvalContext) {
 	diags = Walk(g, ctx)
 	b.opts.File.AppendDiagnostics(diags)
 }
+
+func (b *TeardownSubgraph) isSubGrapher() {}
 
 // TestStateCleanupTransformer is a GraphTransformer that adds a cleanup node
 // for each state that is created by the test runs.


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Fixes #

When #36323 introduced the parallelism flag for limiting plan/apply operations concurrency, we agreed that a new flag would likely be needed for the run parallelism. Until now, the value for run concurrency was not set and we have just been using the default of 10. 

What led me to this is discovering that a parallelism of 1 will result in a deadlock if nodes that create subgraphs also acquire the lock.

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.13.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [ ] This change is not user-facing.
