### PR TITLE
pluginshared: Cleanup request path in tests

### DIFF
--- a/internal/pluginshared/testing.go
+++ b/internal/pluginshared/testing.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"path/filepath"
 	"testing"
 	"time"
 )
@@ -67,7 +68,8 @@ func (h *testHTTPHandler) Handle(w http.ResponseWriter, r *http.Request) {
 			w.Write([]byte(testManifest))
 		}
 	default:
-		fileToSend, err := os.Open(fmt.Sprintf("testdata/%s", r.URL.Path))
+		path := filepath.Clean(r.URL.Path)
+		fileToSend, err := os.Open(fmt.Sprintf("testdata/%s", path))
 		if err == nil {
 			io.Copy(w, fileToSend)
 			return


### PR DESCRIPTION
Fixes a CodeQL alert https://github.com/hashicorp/terraform/security/code-scanning/939

While listed as "High" in severity, in practice the impact is negligible since the "user-input" in question is in fact hard-coded HTTP client with pre-defined request shapes/URLs and overall the entire codepath is only used in tests.

This is also the reason why I believe this does not need any Changelog mention.

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.13.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
