### PR TITLE
Fix broken test due to merge conflict

### DIFF
--- a/internal/terraform/context_plan2_test.go
+++ b/internal/terraform/context_plan2_test.go
@@ -6780,9 +6780,8 @@ resource "test_simple_object" "b" {
 }
 `,
 			},
-			expectedAttributes: []string{
-				"test_computed_object.a.object",
-				"test_computed_object.a.object.value",
+			expectedDiags: []string{
+				"Invalid index:The given key does not identify an element in this collection value. An object only supports looking up attributes by name, not by numeric index.",
 			},
 		},
 		"dynamic object reference": {


### PR DESCRIPTION
I merged https://github.com/hashicorp/terraform/pull/37298 and https://github.com/hashicorp/terraform/pull/37290 at the same time. But, https://github.com/hashicorp/terraform/pull/37298 actually improved the static detection of the errors within the configuration and meant one of the tests I wrote now correctly detects an invalid configuration instead of allowing an invalid `try()` function call.

This PR updates the test so it validates the error instead of the incomplete expected attributes.