### PR TITLE
github: Allow changelog check to be skipped on label

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -26,6 +26,7 @@ permissions:
 
 jobs:
     check-changelog-entry:
+        if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip-changelog-check') }}
         name: "Check Changelog Entry"
         runs-on: ubuntu-latest
         concurrency:


### PR DESCRIPTION
This is to allow cleanly merging PRs we raise every new minor version, such as https://github.com/hashicorp/terraform/pull/37312

The existing mechanism along with `no-changelog-needed` works for the common cases of regular functional PRs but not for these PRs where we are intentionally changing Changelog related files and at the same time changing nothing functionally.

This would be unexpected situation under any other circumstance - and should continue to be raised by the checks outside of these PRs.

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.14.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [ ] This change is not user-facing.
