### PR TITLE
actions: implement expansion and planning actions

### DIFF
--- a/internal/actions/actions.go
+++ b/internal/actions/actions.go
@@ -56,3 +56,17 @@ func (a *Actions) GetActionInstance(addr addrs.AbsActionInstance) (*ActionData, 
 
 	return &data, true
 }
+
+func (a *Actions) GetActionInstanceKeys(addr addrs.AbsAction) []addrs.AbsActionInstance {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	result := []addrs.AbsActionInstance{}
+	for _, data := range a.actionInstances.Elements() {
+		if data.Key.ContainingAction().Equal(addr) {
+			result = append(result, data.Key)
+		}
+	}
+
+	return result
+}

--- a/internal/actions/actions.go
+++ b/internal/actions/actions.go
@@ -1,0 +1,58 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package actions
+
+import (
+	"sync"
+
+	"github.com/hashicorp/terraform/internal/addrs"
+	"github.com/zclconf/go-cty/cty"
+)
+
+// Actions keeps track of action declarations accessible to the context.
+// It is used to plan and execute actions in the context of a Terraform configuration.
+type Actions struct {
+	// Must hold this lock when accessing all fields after this one.
+	mu sync.Mutex
+
+	actionInstances addrs.Map[addrs.AbsActionInstance, ActionData]
+}
+
+func NewActions() *Actions {
+	return &Actions{
+		actionInstances: addrs.MakeMap[addrs.AbsActionInstance, ActionData](),
+	}
+}
+
+type ActionData struct {
+	ConfigValue  cty.Value
+	ProviderAddr addrs.AbsProviderConfig
+}
+
+func (a *Actions) AddActionInstance(addr addrs.AbsActionInstance, configValue cty.Value, providerAddr addrs.AbsProviderConfig) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	if a.actionInstances.Has(addr) {
+		panic("action instance already exists: " + addr.String())
+	}
+
+	a.actionInstances.Put(addr, ActionData{
+		ConfigValue:  configValue,
+		ProviderAddr: providerAddr,
+	})
+}
+
+func (a *Actions) GetActionInstance(addr addrs.AbsActionInstance) (*ActionData, bool) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	data, ok := a.actionInstances.GetOk(addr)
+
+	if !ok {
+		return nil, false
+	}
+
+	return &data, true
+}

--- a/internal/configs/action.go
+++ b/internal/configs/action.go
@@ -35,7 +35,7 @@ type Action struct {
 type ActionTrigger struct {
 	Condition hcl.Expression
 	Events    []ActionTriggerEvent
-	Actions   []ActionRef
+	Actions   []*addrs.Reference // References to actions
 
 	DeclRange hcl.Range
 }
@@ -57,15 +57,28 @@ const (
 
 // ActionRef represents a reference to a configured Action
 type ActionRef struct {
-	Traversal hcl.Traversal
-	Range     hcl.Range
+	Type string
+	Name string
+	Key  addrs.InstanceKey
+
+	Range hcl.Range
+}
+
+// Addr returns the address of the action reference.
+// Since we don't allow referencing actions across module boundaries,
+// this is always a relative address.
+func (a ActionRef) Addr() addrs.ActionInstance {
+	return addrs.Action{
+		Type: a.Type,
+		Name: a.Name,
+	}.Instance(a.Key)
 }
 
 func decodeActionTriggerBlock(block *hcl.Block) (*ActionTrigger, hcl.Diagnostics) {
 	var diags hcl.Diagnostics
 	a := &ActionTrigger{
 		Events:    []ActionTriggerEvent{},
-		Actions:   []ActionRef{},
+		Actions:   []*addrs.Reference{},
 		Condition: nil,
 	}
 
@@ -113,7 +126,7 @@ func decodeActionTriggerBlock(block *hcl.Block) (*ActionTrigger, hcl.Diagnostics
 	if attr, exists := content.Attributes["actions"]; exists {
 		exprs, ediags := hcl.ExprList(attr.Expr)
 		diags = append(diags, ediags...)
-		actions := []ActionRef{}
+		actions := []*addrs.Reference{}
 		for _, expr := range exprs {
 			traversal, travDiags := hcl.AbsTraversalForExpr(expr)
 			diags = append(diags, travDiags...)
@@ -125,14 +138,21 @@ func decodeActionTriggerBlock(block *hcl.Block) (*ActionTrigger, hcl.Diagnostics
 					Detail:   "action_triggers.actions accepts a list of one or more actions",
 					Subject:  block.DefRange.Ptr(),
 				})
+				continue
 			}
-			if len(traversal) != 0 {
-				actionRef := ActionRef{
-					Traversal: traversal,
-					Range:     expr.Range(),
-				}
-				actions = append(actions, actionRef)
+
+			ref, refDiags := addrs.ParseRef(traversal)
+			if refDiags.HasErrors() {
+				diags = append(diags, &hcl.Diagnostic{
+					Severity: hcl.DiagError,
+					Summary:  "Invalid action reference",
+					Detail:   fmt.Sprintf("The action reference %q is invalid: %s", traversal, refDiags.Err()),
+					Subject:  expr.Range().Ptr(),
+				})
+				continue
 			}
+			actions = append(actions, ref)
+
 		}
 		a.Actions = actions
 	}

--- a/internal/configs/action.go
+++ b/internal/configs/action.go
@@ -106,6 +106,16 @@ func decodeActionTriggerBlock(block *hcl.Block) (*ActionTrigger, hcl.Diagnostics
 					Subject:  expr.Range().Ptr(),
 				})
 			}
+
+			if event == BeforeDestroy || event == AfterDestroy {
+				diags = append(diags, &hcl.Diagnostic{
+					Severity: hcl.DiagError,
+					Summary:  "Invalid destroy event used",
+					Detail:   "The destroy events (before_destroy, after_destroy) are not supported as of right now. They will be supported in a future release.",
+					Subject:  expr.Range().Ptr(),
+				})
+			}
+
 			events = append(events, event)
 		}
 		a.Events = events

--- a/internal/configs/module_merge_test.go
+++ b/internal/configs/module_merge_test.go
@@ -418,5 +418,5 @@ func TestModuleOverride_action_and_trigger(t *testing.T) {
 
 	// verify the resource action trigger event changed
 	at := mod.ManagedResources["test_instance.test"].Managed.ActionTriggers[0]
-	assertResultDeepEqual(t, at.Events, []ActionTriggerEvent{AfterDestroy})
+	assertResultDeepEqual(t, at.Events, []ActionTriggerEvent{BeforeCreate})
 }

--- a/internal/configs/testdata/valid-modules/override-action-and-trigger/main_override.tf
+++ b/internal/configs/testdata/valid-modules/override-action-and-trigger/main_override.tf
@@ -7,7 +7,7 @@ action "test_action" "test" {
 resource "test_instance" "test" {
     lifecycle {
       action_trigger {
-        events = [after_destroy]
+        events = [before_create]
         actions = [action.test_action.dosomething]
       }
     }

--- a/internal/experiments/experiment.go
+++ b/internal/experiments/experiment.go
@@ -25,13 +25,11 @@ const (
 	PreconditionsPostconditions    = Experiment("preconditions_postconditions")
 	EphemeralValues                = Experiment("ephemeral_values")
 	UnknownInstances               = Experiment("unknown_instances")
-	Actions                        = Experiment("actions")
 )
 
 func init() {
 	// Each experiment constant defined above must be registered here as either
 	// a current or a concluded experiment.
-	registerCurrentExperiment(Actions)
 	registerConcludedExperiment(UnknownInstances, "Unknown instances are being rolled into a larger feature for deferring unready resources and modules.")
 	registerConcludedExperiment(VariableValidation, "Custom variable validation can now be used by default, without enabling an experiment.")
 	registerConcludedExperiment(VariableValidationCrossRef, "Input variable validation rules may now refer to other objects in the same module without enabling any experiment.")

--- a/internal/lang/eval.go
+++ b/internal/lang/eval.go
@@ -359,6 +359,8 @@ func (s *Scope) evalContext(refs []*addrs.Reference, selfAddr addrs.Referenceabl
 			rawSubj = addr.Call
 		case addrs.ModuleCallInstanceOutput:
 			rawSubj = addr.Call.Call
+		case addrs.ActionInstance:
+			rawSubj = addr.Action
 		}
 
 		switch subj := rawSubj.(type) {
@@ -435,6 +437,10 @@ func (s *Scope) evalContext(refs []*addrs.Reference, selfAddr addrs.Referenceabl
 			val, valDiags := normalizeRefValue(s.Data.GetRunBlock(subj, rng))
 			diags = diags.Append(valDiags)
 			runBlocks[subj.Name] = val
+
+		// Actions can not be accessed.
+		case addrs.Action:
+			return nil, diags.Append(tfdiags.Sourceless(tfdiags.Error, "Can not access actions", fmt.Sprintf("Actions can not be accessed, they have no state and can only be referenced with a resources lifecycle action_trigger events list. Tried to access %s.", subj.String())))
 
 		default:
 			// Should never happen

--- a/internal/lang/eval.go
+++ b/internal/lang/eval.go
@@ -440,7 +440,12 @@ func (s *Scope) evalContext(refs []*addrs.Reference, selfAddr addrs.Referenceabl
 
 		// Actions can not be accessed.
 		case addrs.Action:
-			return nil, diags.Append(tfdiags.Sourceless(tfdiags.Error, "Can not access actions", fmt.Sprintf("Actions can not be accessed, they have no state and can only be referenced with a resources lifecycle action_trigger events list. Tried to access %s.", subj.String())))
+			return nil, diags.Append(&hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  "Invalid reference",
+				Detail:   "Actions can't be referenced in this context, they can only be referenced from within a resources lifecycle events list.",
+				Subject:  rng.ToHCL().Ptr(),
+			})
 
 		default:
 			// Should never happen

--- a/internal/moduletest/graph/transform_references.go
+++ b/internal/moduletest/graph/transform_references.go
@@ -29,6 +29,7 @@ func (r *ReferenceTransformer) Transform(graph *terraform.Graph) error {
 
 	for referencer := range dag.SelectSeq[GraphNodeReferencer](graph.VerticesSeq()) {
 		for _, reference := range referencer.References() {
+
 			if target, ok := nodes.GetOk(reference.Subject); ok {
 				graph.Connect(dag.BasicEdge(referencer, target))
 			}

--- a/internal/schemarepo/loadschemas/plugins.go
+++ b/internal/schemarepo/loadschemas/plugins.go
@@ -267,6 +267,20 @@ func (cp *Plugins) ProvisionerSchema(typ string) (*configschema.Block, error) {
 	return resp.Provisioner, nil
 }
 
+func (cp *Plugins) ActionTypeSchema(providerAddr addrs.Provider, actionType string) (*providers.ActionSchema, error) {
+	providerSchema, err := cp.ProviderSchema(providerAddr)
+	if err != nil {
+		return nil, err
+	}
+
+	actionSchema, ok := providerSchema.Actions[actionType]
+	if !ok {
+		return nil, fmt.Errorf("provider %s does not have an action schema for %s", providerAddr, actionType)
+	}
+
+	return &actionSchema, nil
+}
+
 // ProviderFunctionDecls is a helper wrapper around ProviderSchema which first
 // reads the schema of the given provider and then returns all of the
 // functions it declares, if any.

--- a/internal/terraform/context_plan_actions_test.go
+++ b/internal/terraform/context_plan_actions_test.go
@@ -34,7 +34,6 @@ func TestContextPlan_actions(t *testing.T) {
 		"unreferenced": {
 			module: map[string]string{
 				"main.tf": `
-terraform { experiments = [actions] }
 action "test_unlinked" "hello" {}
 			`,
 			},
@@ -44,7 +43,6 @@ action "test_unlinked" "hello" {}
 		"invalid config": {
 			module: map[string]string{
 				"main.tf": `
-terraform { experiments = [actions] }
 action "test_unlinked" "hello" {
   config {
     unknown_attr = "value"
@@ -60,8 +58,8 @@ action "test_unlinked" "hello" {
 					Detail:   `An argument named "unknown_attr" is not expected here.`,
 					Subject: &hcl.Range{
 						Filename: filepath.Join(m.Module.SourceDir, "main.tf"),
-						Start:    hcl.Pos{Line: 5, Column: 5, Byte: 87},
-						End:      hcl.Pos{Line: 5, Column: 17, Byte: 99},
+						Start:    hcl.Pos{Line: 4, Column: 5, Byte: 49},
+						End:      hcl.Pos{Line: 4, Column: 17, Byte: 61},
 					},
 				})
 			},
@@ -70,7 +68,6 @@ action "test_unlinked" "hello" {
 		"before_create triggered": {
 			module: map[string]string{
 				"main.tf": `
-terraform { experiments = [actions] }
 action "test_unlinked" "hello" {}
 resource "test_object" "a" {
   lifecycle {
@@ -88,7 +85,6 @@ resource "test_object" "a" {
 		"after_create triggered": {
 			module: map[string]string{
 				"main.tf": `
-terraform { experiments = [actions] }
 action "test_unlinked" "hello" {}
 resource "test_object" "a" {
   lifecycle {
@@ -106,7 +102,6 @@ resource "test_object" "a" {
 		"before_update triggered - on create": {
 			module: map[string]string{
 				"main.tf": `
-terraform { experiments = [actions] }
 action "test_unlinked" "hello" {}
 resource "test_object" "a" {
   lifecycle {
@@ -124,7 +119,6 @@ resource "test_object" "a" {
 		"after_update triggered - on create": {
 			module: map[string]string{
 				"main.tf": `
-terraform { experiments = [actions] }
 action "test_unlinked" "hello" {}
 resource "test_object" "a" {
   lifecycle {
@@ -142,7 +136,6 @@ resource "test_object" "a" {
 		"before_update triggered - on update": {
 			module: map[string]string{
 				"main.tf": `
-terraform { experiments = [actions] }
 action "test_unlinked" "hello" {}
 resource "test_object" "a" {
   lifecycle {
@@ -167,7 +160,6 @@ resource "test_object" "a" {
 		"after_update triggered - on update": {
 			module: map[string]string{
 				"main.tf": `
-terraform { experiments = [actions] }
 action "test_unlinked" "hello" {}
 resource "test_object" "a" {
   lifecycle {
@@ -192,7 +184,6 @@ resource "test_object" "a" {
 		"before_update triggered - on replace": {
 			module: map[string]string{
 				"main.tf": `
-terraform { experiments = [actions] }
 action "test_unlinked" "hello" {}
 resource "test_object" "a" {
   lifecycle {
@@ -218,7 +209,6 @@ resource "test_object" "a" {
 		"after_update triggered - on replace": {
 			module: map[string]string{
 				"main.tf": `
-terraform { experiments = [actions] }
 action "test_unlinked" "hello" {}
 resource "test_object" "a" {
   lifecycle {
@@ -244,7 +234,6 @@ resource "test_object" "a" {
 		"action for_each": {
 			module: map[string]string{
 				"main.tf": `
-terraform { experiments = [actions] }
 action "test_unlinked" "hello" {
   for_each = toset(["a", "b"])
   
@@ -268,7 +257,6 @@ resource "test_object" "a" {
 		"action for_each with auto-expansion": {
 			module: map[string]string{
 				"main.tf": `
-terraform { experiments = [actions] }
 action "test_unlinked" "hello" {
   for_each = toset(["a", "b"])
   
@@ -292,7 +280,6 @@ resource "test_object" "a" {
 		"action count": {
 			module: map[string]string{
 				"main.tf": `
-terraform { experiments = [actions] }
 action "test_unlinked" "hello" {
   count = 2
 
@@ -317,7 +304,6 @@ resource "test_object" "a" {
 		"action count with auto-expansion": {
 			module: map[string]string{
 				"main.tf": `
-terraform { experiments = [actions] }
 action "test_unlinked" "hello" {
   count = 2
 
@@ -342,7 +328,6 @@ resource "test_object" "a" {
 		"action for_each invalid access": {
 			module: map[string]string{
 				"main.tf": `
-terraform { experiments = [actions] }
 action "test_unlinked" "hello" {
   for_each = toset(["a", "b"])
 
@@ -373,7 +358,6 @@ resource "test_object" "a" {
 		"action count invalid access": {
 			module: map[string]string{
 				"main.tf": `
-terraform { experiments = [actions] }
 action "test_unlinked" "hello" {
   count = 2
 
@@ -404,7 +388,6 @@ resource "test_object" "a" {
 		"expanded resource - unexpanded action": {
 			module: map[string]string{
 				"main.tf": `
-terraform { experiments = [actions] }
 action "test_unlinked" "hello" {}
 resource "test_object" "a" {
   count = 2
@@ -424,7 +407,6 @@ resource "test_object" "a" {
 			toBeImplemented: true, // TODO: Not sure why this panics
 			module: map[string]string{
 				"main.tf": `
-terraform { experiments = [actions] }
 action "test_unlinked" "hello" {
   count = 2
 
@@ -450,7 +432,6 @@ resource "test_object" "a" {
 		"transitive dependencies": {
 			module: map[string]string{
 				"main.tf": `
-terraform { experiments = [actions] }
 resource "test_object" "a" {
   name = "a"
 }
@@ -476,7 +457,6 @@ resource "test_object" "b" {
 		"expanded transitive dependencies": {
 			module: map[string]string{
 				"main.tf": `
-terraform { experiments = [actions] }
 resource "test_object" "a" {
   name = "a"
 }
@@ -528,7 +508,6 @@ resource "test_object" "e" {
 		"failing actions cancel next ones": {
 			module: map[string]string{
 				"main.tf": `
-terraform { experiments = [actions] }
 action "test_unlinked" "failure" {}
 resource "test_object" "a" {
   lifecycle {
@@ -563,7 +542,6 @@ resource "test_object" "a" {
 		"actions cant be accessed in resources": {
 			module: map[string]string{
 				"main.tf": `
-terraform { experiments = [actions] }
 action "test_unlinked" "my_action" {
   config {
     attr = "value"
@@ -588,8 +566,8 @@ resource "test_object" "a" {
 						Detail:   "Actions can't be referenced in this context, they can only be referenced from within a resources lifecycle events list.",
 						Subject: &hcl.Range{
 							Filename: filepath.Join(m.Module.SourceDir, "main.tf"),
-							Start:    hcl.Pos{Line: 9, Column: 10, Byte: 150},
-							End:      hcl.Pos{Line: 9, Column: 40, Byte: 180},
+							Start:    hcl.Pos{Line: 8, Column: 10, Byte: 112},
+							End:      hcl.Pos{Line: 8, Column: 40, Byte: 142},
 						},
 					})
 			},
@@ -598,7 +576,6 @@ resource "test_object" "a" {
 		"actions cant be accessed in outputs": {
 			module: map[string]string{
 				"main.tf": `
-terraform { experiments = [actions] }
 action "test_unlinked" "my_action" {
   config {
     attr = "value"
@@ -630,8 +607,8 @@ output "my_output2" {
 						Detail:   "Actions can't be referenced in this context, they can only be referenced from within a resources lifecycle events list.",
 						Subject: &hcl.Range{
 							Filename: filepath.Join(m.Module.SourceDir, "main.tf"),
-							Start:    hcl.Pos{Line: 22, Column: 13, Byte: 375},
-							End:      hcl.Pos{Line: 22, Column: 43, Byte: 405},
+							Start:    hcl.Pos{Line: 21, Column: 13, Byte: 337},
+							End:      hcl.Pos{Line: 21, Column: 43, Byte: 367},
 						},
 					}).Append(
 					&hcl.Diagnostic{
@@ -640,8 +617,8 @@ output "my_output2" {
 						Detail:   "Actions can't be referenced in this context, they can only be referenced from within a resources lifecycle events list.",
 						Subject: &hcl.Range{
 							Filename: filepath.Join(m.Module.SourceDir, "main.tf"),
-							Start:    hcl.Pos{Line: 18, Column: 13, Byte: 302},
-							End:      hcl.Pos{Line: 18, Column: 43, Byte: 332},
+							Start:    hcl.Pos{Line: 17, Column: 13, Byte: 264},
+							End:      hcl.Pos{Line: 17, Column: 43, Byte: 294},
 						},
 					},
 				)

--- a/internal/terraform/context_plan_actions_test.go
+++ b/internal/terraform/context_plan_actions_test.go
@@ -581,7 +581,17 @@ resource "test_object" "a" {
 `,
 			},
 			expectValidateDiagnostics: func(m *configs.Config) tfdiags.Diagnostics {
-				return tfdiags.Diagnostics{tfdiags.Sourceless(tfdiags.Error, "Can not access actions", "Actions can not be accessed, they have no state and can only be referenced with a resources lifecycle action_trigger events list. Tried to access action.test_unlinked.my_action.")}
+				return tfdiags.Diagnostics{}.Append(
+					&hcl.Diagnostic{
+						Severity: hcl.DiagError,
+						Summary:  "Invalid reference",
+						Detail:   "Actions can't be referenced in this context, they can only be referenced from within a resources lifecycle events list.",
+						Subject: &hcl.Range{
+							Filename: filepath.Join(m.Module.SourceDir, "main.tf"),
+							Start:    hcl.Pos{Line: 9, Column: 10, Byte: 150},
+							End:      hcl.Pos{Line: 9, Column: 40, Byte: 180},
+						},
+					})
 			},
 		},
 
@@ -613,7 +623,28 @@ output "my_output2" {
 `,
 			},
 			expectValidateDiagnostics: func(m *configs.Config) tfdiags.Diagnostics {
-				return tfdiags.Diagnostics{tfdiags.Sourceless(tfdiags.Error, "Can not access actions", "Actions can not be accessed, they have no state and can only be referenced with a resources lifecycle action_trigger events list. Tried to access action.test_unlinked.my_action."), tfdiags.Sourceless(tfdiags.Error, "Can not access actions", "Actions can not be accessed, they have no state and can only be referenced with a resources lifecycle action_trigger events list. Tried to access action.test_unlinked.my_action.")}
+				return tfdiags.Diagnostics{}.Append(
+					&hcl.Diagnostic{
+						Severity: hcl.DiagError,
+						Summary:  "Invalid reference",
+						Detail:   "Actions can't be referenced in this context, they can only be referenced from within a resources lifecycle events list.",
+						Subject: &hcl.Range{
+							Filename: filepath.Join(m.Module.SourceDir, "main.tf"),
+							Start:    hcl.Pos{Line: 22, Column: 13, Byte: 375},
+							End:      hcl.Pos{Line: 22, Column: 43, Byte: 405},
+						},
+					}).Append(
+					&hcl.Diagnostic{
+						Severity: hcl.DiagError,
+						Summary:  "Invalid reference",
+						Detail:   "Actions can't be referenced in this context, they can only be referenced from within a resources lifecycle events list.",
+						Subject: &hcl.Range{
+							Filename: filepath.Join(m.Module.SourceDir, "main.tf"),
+							Start:    hcl.Pos{Line: 18, Column: 13, Byte: 302},
+							End:      hcl.Pos{Line: 18, Column: 43, Byte: 332},
+						},
+					},
+				)
 			},
 		},
 	} {

--- a/internal/terraform/context_plan_actions_test.go
+++ b/internal/terraform/context_plan_actions_test.go
@@ -41,30 +41,6 @@ action "test_unlinked" "hello" {}
 			expectPlanActionCalled: false,
 		},
 
-		"invalid attr": {
-			module: map[string]string{
-				"main.tf": `
-terraform { experiments = [actions] }
-action "test_unlinked" "hello" {
-  unknown_attr = "value"
-}
-		`,
-			},
-			expectPlanActionCalled: false,
-			expectValidateDiagnostics: func(m *configs.Config) (diags tfdiags.Diagnostics) {
-				return diags.Append(&hcl.Diagnostic{
-					Severity: hcl.DiagError,
-					Summary:  "Unsupported argument",
-					Detail:   `An argument named "unknown_attr" is not expected here.`,
-					Subject: &hcl.Range{
-						Filename: filepath.Join(m.Module.SourceDir, "main.tf"),
-						Start:    hcl.Pos{Line: 4, Column: 3, Byte: 74},
-						End:      hcl.Pos{Line: 4, Column: 15, Byte: 86},
-					},
-				})
-			},
-		},
-
 		"invalid config": {
 			module: map[string]string{
 				"main.tf": `

--- a/internal/terraform/context_plan_actions_test.go
+++ b/internal/terraform/context_plan_actions_test.go
@@ -1,0 +1,591 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package terraform
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/terraform/internal/addrs"
+	"github.com/hashicorp/terraform/internal/configs"
+	"github.com/hashicorp/terraform/internal/configs/configschema"
+	"github.com/hashicorp/terraform/internal/plans"
+	"github.com/hashicorp/terraform/internal/providers"
+	testing_provider "github.com/hashicorp/terraform/internal/providers/testing"
+	"github.com/hashicorp/terraform/internal/states"
+	"github.com/hashicorp/terraform/internal/tfdiags"
+	"github.com/zclconf/go-cty/cty"
+)
+
+func TestContextPlan_actions(t *testing.T) {
+
+	for name, tc := range map[string]struct {
+		toBeImplemented    bool
+		module             map[string]string
+		buildState         func(*states.SyncState)
+		planActionResponse *providers.PlanActionResponse
+
+		expectPlanActionCalled    bool
+		expectValidateDiagnostics func(m *configs.Config) tfdiags.Diagnostics
+		expectPlanDiagnostics     func(m *configs.Config) tfdiags.Diagnostics
+	}{
+		"unreferenced": {
+			module: map[string]string{
+				"main.tf": `
+terraform { experiments = [actions] }
+action "test_unlinked" "hello" {}
+			`,
+			},
+			expectPlanActionCalled: false,
+		},
+
+		"invalid config": {
+			module: map[string]string{
+				"main.tf": `
+terraform { experiments = [actions] }
+action "test_unlinked" "hello" {
+  unknown_attr = "value"
+}
+		`,
+			},
+			expectPlanActionCalled: false,
+			expectValidateDiagnostics: func(m *configs.Config) (diags tfdiags.Diagnostics) {
+				return diags.Append(&hcl.Diagnostic{
+					Severity: hcl.DiagError,
+					Summary:  "Unsupported argument",
+					Detail:   `An argument named "unknown_attr" is not expected here.`,
+					Subject: &hcl.Range{
+						Filename: filepath.Join(m.Module.SourceDir, "main.tf"),
+						Start:    hcl.Pos{Line: 4, Column: 3, Byte: 74},
+						End:      hcl.Pos{Line: 4, Column: 15, Byte: 86},
+					},
+				})
+			},
+		},
+
+		"before_create triggered": {
+			module: map[string]string{
+				"main.tf": `
+terraform { experiments = [actions] }
+action "test_unlinked" "hello" {}
+resource "test_object" "a" {
+  lifecycle {
+    action_trigger {
+      events = [before_create]
+      actions = [action.test_unlinked.hello]
+    }
+  }
+}
+`,
+			},
+			expectPlanActionCalled: true,
+		},
+
+		"after_create triggered": {
+			module: map[string]string{
+				"main.tf": `
+terraform { experiments = [actions] }
+action "test_unlinked" "hello" {}
+resource "test_object" "a" {
+  lifecycle {
+    action_trigger {
+      events = [after_create]
+      actions = [action.test_unlinked.hello]
+    }
+  }
+}
+`,
+			},
+			expectPlanActionCalled: true,
+		},
+
+		"before_update triggered - on create": {
+			module: map[string]string{
+				"main.tf": `
+terraform { experiments = [actions] }
+action "test_unlinked" "hello" {}
+resource "test_object" "a" {
+  lifecycle {
+    action_trigger {
+      events = [before_update]
+      actions = [action.test_unlinked.hello]
+    }
+  }
+}
+`,
+			},
+			expectPlanActionCalled: false,
+		},
+
+		"after_update triggered - on create": {
+			module: map[string]string{
+				"main.tf": `
+terraform { experiments = [actions] }
+action "test_unlinked" "hello" {}
+resource "test_object" "a" {
+  lifecycle {
+    action_trigger {
+      events = [after_update]
+      actions = [action.test_unlinked.hello]
+    }
+  }
+}
+`,
+			},
+			expectPlanActionCalled: false,
+		},
+
+		"before_update triggered - on update": {
+			module: map[string]string{
+				"main.tf": `
+terraform { experiments = [actions] }
+action "test_unlinked" "hello" {}
+resource "test_object" "a" {
+  lifecycle {
+    action_trigger {
+      events = [before_update]
+      actions = [action.test_unlinked.hello]
+    }
+  }
+}
+`,
+			},
+
+			buildState: func(s *states.SyncState) {
+				addr := mustResourceInstanceAddr("test_object.a")
+				s.SetResourceInstanceCurrent(addr, &states.ResourceInstanceObjectSrc{
+					AttrsJSON: []byte(`{"name":"previous_run"}`),
+				}, mustProviderConfig(`provider["registry.terraform.io/hashicorp/test"]`))
+			},
+			expectPlanActionCalled: true,
+		},
+
+		"after_update triggered - on update": {
+			module: map[string]string{
+				"main.tf": `
+terraform { experiments = [actions] }
+action "test_unlinked" "hello" {}
+resource "test_object" "a" {
+  lifecycle {
+    action_trigger {
+      events = [after_update]
+      actions = [action.test_unlinked.hello]
+    }
+  }
+}
+`,
+			},
+
+			buildState: func(s *states.SyncState) {
+				addr := mustResourceInstanceAddr("test_object.a")
+				s.SetResourceInstanceCurrent(addr, &states.ResourceInstanceObjectSrc{
+					AttrsJSON: []byte(`{"name":"previous_run"}`),
+				}, mustProviderConfig(`provider["registry.terraform.io/hashicorp/test"]`))
+			},
+			expectPlanActionCalled: true,
+		},
+
+		"before_update triggered - on replace": {
+			module: map[string]string{
+				"main.tf": `
+terraform { experiments = [actions] }
+action "test_unlinked" "hello" {}
+resource "test_object" "a" {
+  lifecycle {
+    action_trigger {
+      events = [before_update]
+      actions = [action.test_unlinked.hello]
+    }
+  }
+}
+`,
+			},
+
+			buildState: func(s *states.SyncState) {
+				addr := mustResourceInstanceAddr("test_object.a")
+				s.SetResourceInstanceCurrent(addr, &states.ResourceInstanceObjectSrc{
+					AttrsJSON: []byte(`{"name":"previous_run"}`),
+					Status:    states.ObjectTainted,
+				}, mustProviderConfig(`provider["registry.terraform.io/hashicorp/test"]`))
+			},
+			expectPlanActionCalled: false,
+		},
+
+		"after_update triggered - on replace": {
+			module: map[string]string{
+				"main.tf": `
+terraform { experiments = [actions] }
+action "test_unlinked" "hello" {}
+resource "test_object" "a" {
+  lifecycle {
+    action_trigger {
+      events = [after_update]
+      actions = [action.test_unlinked.hello]
+    }
+  }
+}
+`,
+			},
+
+			buildState: func(s *states.SyncState) {
+				addr := mustResourceInstanceAddr("test_object.a")
+				s.SetResourceInstanceCurrent(addr, &states.ResourceInstanceObjectSrc{
+					AttrsJSON: []byte(`{"name":"previous_run"}`),
+					Status:    states.ObjectTainted,
+				}, mustProviderConfig(`provider["registry.terraform.io/hashicorp/test"]`))
+			},
+			expectPlanActionCalled: false,
+		},
+
+		"action for_each": {
+			module: map[string]string{
+				"main.tf": `
+terraform { experiments = [actions] }
+action "test_unlinked" "hello" {
+  for_each = toset(["a", "b"])
+}
+resource "test_object" "a" {
+  lifecycle {
+    action_trigger {
+      events = [before_create]
+      actions = [action.test_unlinked.hello["a"], action.test_unlinked.hello["b"]]
+    }
+  }
+}
+`,
+			},
+			expectPlanActionCalled: true,
+		},
+
+		"action count": {
+			module: map[string]string{
+				"main.tf": `
+terraform { experiments = [actions] }
+action "test_unlinked" "hello" {
+    count = 2
+}
+resource "test_object" "a" {
+  lifecycle {
+    action_trigger {
+      events = [before_create]
+      actions = [action.test_unlinked.hello[0], action.test_unlinked.hello[1]]
+    }
+  }
+}
+`,
+			},
+			expectPlanActionCalled: true,
+		},
+
+		"action for_each invalid access": {
+			module: map[string]string{
+				"main.tf": `
+terraform { experiments = [actions] }
+action "test_unlinked" "hello" {
+  for_each = toset(["a", "b"])
+}
+resource "test_object" "a" {
+  lifecycle {
+    action_trigger {
+      events = [before_create]
+      actions = [action.test_unlinked.hello["c"]]
+    }
+  }
+}
+`,
+			},
+			expectPlanActionCalled: false,
+			expectPlanDiagnostics: func(m *configs.Config) (diags tfdiags.Diagnostics) {
+				return diags.Append(tfdiags.Sourceless(
+					tfdiags.Error,
+					`action trigger #0 refers to a non-existent action instance action.test_unlinked.hello["c"]`,
+					"Action instance not found in the current context.",
+				))
+			},
+		},
+
+		"action count invalid access": {
+			module: map[string]string{
+				"main.tf": `
+terraform { experiments = [actions] }
+action "test_unlinked" "hello" {
+    count = 2
+}
+resource "test_object" "a" {
+  lifecycle {
+    action_trigger {
+      events = [before_create]
+      actions = [action.test_unlinked.hello[2]]
+    }
+  }
+}
+`,
+			},
+			expectPlanActionCalled: false,
+			expectPlanDiagnostics: func(m *configs.Config) (diags tfdiags.Diagnostics) {
+				return diags.Append(tfdiags.Sourceless(
+					tfdiags.Error,
+					`action trigger #0 refers to a non-existent action instance action.test_unlinked.hello[2]`,
+					"Action instance not found in the current context.",
+				))
+			},
+		},
+
+		"expanded resource - unexpanded action": {
+			module: map[string]string{
+				"main.tf": `
+terraform { experiments = [actions] }
+action "test_unlinked" "hello" {}
+resource "test_object" "a" {
+  count = 2
+  name = "test-${count.index}"
+  lifecycle {
+    action_trigger {
+      events = [before_create]
+      actions = [action.test_unlinked.hello]
+    }
+  }
+}
+`,
+			},
+			expectPlanActionCalled: true,
+		},
+		"expanded resource - expanded action": {
+			toBeImplemented: true, // TODO: Not sure why this panics
+			module: map[string]string{
+				"main.tf": `
+terraform { experiments = [actions] }
+action "test_unlinked" "hello" {
+count = 2
+}
+resource "test_object" "a" {
+  count = 2
+  name = "test-${count.index}"
+  lifecycle {
+    action_trigger {
+      events = [before_create]
+      actions = [action.test_unlinked.hello[count.index]]
+    }
+  }
+}
+`,
+			},
+			expectPlanActionCalled: true,
+		},
+
+		"transitive dependencies": {
+			module: map[string]string{
+				"main.tf": `
+terraform { experiments = [actions] }
+resource "test_object" "a" {
+  name = "a"
+}
+action "test_unlinked" "hello" {
+    attr = test_object.a.name
+}
+resource "test_object" "b" {
+  name = "b"
+  lifecycle {
+    action_trigger {
+      events = [before_create]
+      actions = [action.test_unlinked.hello]
+    }
+  }
+}
+`,
+			},
+			expectPlanActionCalled: true,
+		},
+
+		"expanded transitive dependencies": {
+			module: map[string]string{
+				"main.tf": `
+terraform { experiments = [actions] }
+resource "test_object" "a" {
+  name = "a"
+}
+resource "test_object" "b" {
+  name = "b"
+}
+action "test_unlinked" "hello_a" {
+    attr = test_object.a.name
+}
+action "test_unlinked" "hello_b" {
+    attr = test_object.a.name
+}
+resource "test_object" "c" {
+  name = "c"
+  lifecycle {
+    action_trigger {
+      events = [before_create]
+      actions = [action.test_unlinked.hello_a]
+    }
+  }
+}
+resource "test_object" "d" {
+  name = "d"
+  lifecycle {
+    action_trigger {
+      events = [before_create]
+      actions = [action.test_unlinked.hello_b]
+    }
+  }
+}
+resource "test_object" "e" {
+  name = "e"
+  lifecycle {
+    action_trigger {
+      events = [before_create]
+      actions = [action.test_unlinked.hello_a, action.test_unlinked.hello_b]
+    }
+  }
+}
+`,
+			},
+			expectPlanActionCalled: true,
+		},
+
+		"failing actions cancel next ones": {
+			module: map[string]string{
+				"main.tf": `
+terraform { experiments = [actions] }
+action "test_unlinked" "failure" {}
+resource "test_object" "a" {
+  lifecycle {
+    action_trigger {
+      events = [before_create]
+      actions = [action.test_unlinked.failure, action.test_unlinked.failure]
+    }
+    action_trigger {
+      events = [before_create]
+      actions = [action.test_unlinked.failure]
+    }
+  }
+}
+`,
+			},
+
+			planActionResponse: &providers.PlanActionResponse{
+				Diagnostics: tfdiags.Diagnostics{
+					tfdiags.Sourceless(tfdiags.Error, "Planning failed", "Test case simulates an error while planning"),
+				},
+			},
+
+			expectPlanActionCalled: true,
+			// We only expect a single diagnostic here, the other should not have been called because the first one failed.
+			expectPlanDiagnostics: func(m *configs.Config) tfdiags.Diagnostics {
+				return tfdiags.Diagnostics{
+					tfdiags.Sourceless(tfdiags.Error, "Planning failed", "Test case simulates an error while planning"),
+				}
+			},
+		},
+
+		"actions cant be accessed": {
+			module: map[string]string{
+				"main.tf": `
+terraform { experiments = [actions] }
+action "test_unlinked" "my_action" {
+  attr = "value"
+}
+resource "test_object" "a" {
+  name = action.test_unlinked.my_action.attr
+  lifecycle {
+    action_trigger {
+      events = [before_create]
+      actions = [action.test_unlinked.my_action]
+    }
+  }
+}
+`,
+			},
+			expectValidateDiagnostics: func(m *configs.Config) tfdiags.Diagnostics {
+				return tfdiags.Diagnostics{tfdiags.Sourceless(tfdiags.Error, "Can not access actions", "Actions can not be accessed, they have no state and can only be referenced with a resources lifecycle action_trigger events list. Tried to access action.test_unlinked.my_action.")}
+			},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if tc.toBeImplemented {
+				t.Skip("Test not implemented yet")
+			}
+
+			m := testModuleInline(t, tc.module)
+
+			p := &testing_provider.MockProvider{
+				GetProviderSchemaResponse: &providers.GetProviderSchemaResponse{
+					Actions: map[string]providers.ActionSchema{
+						"test_unlinked": {
+							ConfigSchema: &configschema.Block{
+								Attributes: map[string]*configschema.Attribute{
+									"attr": {
+										Type:     cty.String,
+										Optional: true,
+									},
+								},
+							},
+
+							Unlinked: &providers.UnlinkedAction{},
+						},
+					},
+					ResourceTypes: map[string]providers.Schema{
+						"test_object": {
+							Body: &configschema.Block{
+								Attributes: map[string]*configschema.Attribute{
+									"name": {
+										Type:     cty.String,
+										Optional: true,
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+
+			if tc.planActionResponse != nil {
+				p.PlanActionResponse = *tc.planActionResponse
+			}
+
+			ctx := testContext2(t, &ContextOpts{
+				Providers: map[addrs.Provider]providers.Factory{
+					// The providers never actually going to get called here, we should
+					// catch the error long before anything happens.
+					addrs.NewDefaultProvider("test"): testProviderFuncFixed(p),
+				},
+			})
+
+			diags := ctx.Validate(m, &ValidateOpts{})
+			if tc.expectValidateDiagnostics != nil {
+				tfdiags.AssertDiagnosticsMatch(t, diags, tc.expectValidateDiagnostics(m))
+			} else {
+				tfdiags.AssertNoDiagnostics(t, diags)
+			}
+
+			if diags.HasErrors() {
+				return
+			}
+
+			var prevRunState *states.State
+			if tc.buildState != nil {
+				prevRunState = states.BuildState(tc.buildState)
+			}
+
+			_, diags = ctx.Plan(m, prevRunState, SimplePlanOpts(plans.NormalMode, InputValues{}))
+
+			if tc.expectPlanDiagnostics != nil {
+				tfdiags.AssertDiagnosticsMatch(t, diags, tc.expectPlanDiagnostics(m))
+			} else {
+				tfdiags.AssertNoDiagnostics(t, diags)
+			}
+
+			// TODO: add tc.assertPlan once we have a plan implementation for actions
+
+			if tc.expectPlanActionCalled && !p.PlanActionCalled {
+				t.Errorf("expected plan action to be called, but it was not")
+			} else if !tc.expectPlanActionCalled && p.PlanActionCalled {
+				t.Errorf("expected plan action to not be called, but it was")
+			}
+		})
+	}
+}

--- a/internal/terraform/context_walk.go
+++ b/internal/terraform/context_walk.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"time"
 
+	"github.com/hashicorp/terraform/internal/actions"
 	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/checks"
 	"github.com/hashicorp/terraform/internal/configs"
@@ -199,5 +200,6 @@ func (c *Context) graphWalker(graph *Graph, operation walkOperation, opts *graph
 		PlanTimestamp:           opts.PlanTimeTimestamp,
 		functionResults:         opts.FunctionResults,
 		Forget:                  opts.Forget,
+		Actions:                 actions.NewActions(),
 	}
 }

--- a/internal/terraform/eval_context.go
+++ b/internal/terraform/eval_context.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/hcl/v2"
 	"github.com/zclconf/go-cty/cty"
 
+	"github.com/hashicorp/terraform/internal/actions"
 	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/checks"
 	"github.com/hashicorp/terraform/internal/configs"
@@ -216,6 +217,11 @@ type EvalContext interface {
 	// Forget if set to true will cause the plan to forget all resources. This is
 	// only allowed in the context of a destroy plan.
 	Forget() bool
+
+	// Actions returns the actions object that tracks all of the action
+	// declarations and their instances that are available in this
+	// EvalContext.
+	Actions() *actions.Actions
 }
 
 func evalContextForModuleInstance(baseCtx EvalContext, addr addrs.ModuleInstance) EvalContext {

--- a/internal/terraform/eval_context_builtin.go
+++ b/internal/terraform/eval_context_builtin.go
@@ -13,6 +13,7 @@ import (
 	"github.com/zclconf/go-cty/cty"
 	"github.com/zclconf/go-cty/cty/function"
 
+	"github.com/hashicorp/terraform/internal/actions"
 	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/checks"
 	"github.com/hashicorp/terraform/internal/configs"
@@ -91,6 +92,7 @@ type BuiltinEvalContext struct {
 	InstanceExpanderValue   *instances.Expander
 	MoveResultsValue        refactoring.MoveResults
 	OverrideValues          *mocking.Overrides
+	ActionsValue            *actions.Actions
 }
 
 // BuiltinEvalContext implements EvalContext
@@ -619,4 +621,8 @@ func (ctx *BuiltinEvalContext) ClientCapabilities() providers.ClientCapabilities
 		DeferralAllowed:            ctx.Deferrals().DeferralAllowed(),
 		WriteOnlyAttributesAllowed: true,
 	}
+}
+
+func (ctx *BuiltinEvalContext) Actions() *actions.Actions {
+	return ctx.ActionsValue
 }

--- a/internal/terraform/eval_context_mock.go
+++ b/internal/terraform/eval_context_mock.go
@@ -11,6 +11,7 @@ import (
 	"github.com/zclconf/go-cty/cty"
 	"github.com/zclconf/go-cty/cty/convert"
 
+	"github.com/hashicorp/terraform/internal/actions"
 	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/checks"
 	"github.com/hashicorp/terraform/internal/configs"
@@ -166,6 +167,9 @@ type MockEvalContext struct {
 
 	ForgetCalled bool
 	ForgetValues bool
+
+	ActionsCalled bool
+	ActionsState  *actions.Actions
 }
 
 // MockEvalContext implements EvalContext
@@ -441,4 +445,9 @@ func (ctx *MockEvalContext) ClientCapabilities() providers.ClientCapabilities {
 		DeferralAllowed:            ctx.Deferrals().DeferralAllowed(),
 		WriteOnlyAttributesAllowed: true,
 	}
+}
+
+func (c *MockEvalContext) Actions() *actions.Actions {
+	c.ActionsCalled = true
+	return c.ActionsState
 }

--- a/internal/terraform/graph_walk_context.go
+++ b/internal/terraform/graph_walk_context.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/hashicorp/terraform/internal/actions"
 	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/checks"
 	"github.com/hashicorp/terraform/internal/collections"
@@ -53,7 +54,8 @@ type ContextGraphWalker struct {
 	Overrides               *mocking.Overrides
 	// Forget if set to true will cause the plan to forget all resources. This is
 	// only allowd in the context of a destroy plan.
-	Forget bool
+	Forget  bool
+	Actions *actions.Actions
 
 	// This is an output. Do not set this, nor read it while a graph walk
 	// is in progress.
@@ -141,6 +143,7 @@ func (w *ContextGraphWalker) EvalContext() EvalContext {
 		Evaluator:               evaluator,
 		OverrideValues:          w.Overrides,
 		forget:                  w.Forget,
+		ActionsValue:            w.Actions,
 	}
 
 	return ctx

--- a/internal/terraform/node_action.go
+++ b/internal/terraform/node_action.go
@@ -1,0 +1,272 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package terraform
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform/internal/addrs"
+	"github.com/hashicorp/terraform/internal/configs"
+	"github.com/hashicorp/terraform/internal/dag"
+	"github.com/hashicorp/terraform/internal/experiments"
+	"github.com/hashicorp/terraform/internal/lang/langrefs"
+	"github.com/hashicorp/terraform/internal/providers"
+	"github.com/hashicorp/terraform/internal/tfdiags"
+)
+
+// GraphNodeConfigAction is implemented by any nodes that represent an action.
+// The type of operation cannot be assumed, only that this node represents
+// the given resource.
+type GraphNodeConfigAction interface {
+	ActionAddr() addrs.ConfigAction
+}
+
+// nodeExpandActionDeclaration represents an action config block in a configuration module,
+// which has not yet been expanded.
+type nodeExpandActionDeclaration struct {
+	Addr   addrs.ConfigAction
+	Config configs.Action
+
+	Schema           *providers.ActionSchema
+	ResolvedProvider addrs.AbsProviderConfig
+}
+
+var (
+	_ GraphNodeConfigAction      = (*nodeExpandActionDeclaration)(nil)
+	_ GraphNodeReferenceable     = (*nodeExpandActionDeclaration)(nil)
+	_ GraphNodeReferencer        = (*nodeExpandActionDeclaration)(nil)
+	_ GraphNodeDynamicExpandable = (*nodeExpandActionDeclaration)(nil)
+	_ GraphNodeProviderConsumer  = (*nodeExpandActionDeclaration)(nil)
+)
+
+func (n *nodeExpandActionDeclaration) Name() string {
+	return n.Addr.String() + " (expand)"
+}
+
+func (n *nodeExpandActionDeclaration) ActionAddr() addrs.ConfigAction {
+	return n.Addr
+}
+
+func (n *nodeExpandActionDeclaration) ReferenceableAddrs() []addrs.Referenceable {
+	return []addrs.Referenceable{n.Addr.Action}
+}
+
+// GraphNodeModulePath
+func (n *nodeExpandActionDeclaration) ModulePath() addrs.Module {
+	return n.Addr.Module
+}
+
+// GraphNodeAttachActionSchema impl
+func (n *nodeExpandActionDeclaration) AttachActionSchema(schema *providers.ActionSchema) {
+	n.Schema = schema
+}
+
+func (n *nodeExpandActionDeclaration) DotNode(string, *dag.DotOpts) *dag.DotNode {
+	return &dag.DotNode{
+		Name: n.Name(),
+	}
+}
+
+// GraphNodeReferencer
+func (n *nodeExpandActionDeclaration) References() []*addrs.Reference {
+	var result []*addrs.Reference
+	c := n.Config
+
+	refs, _ := langrefs.ReferencesInExpr(addrs.ParseRef, c.Count)
+	result = append(result, refs...)
+	refs, _ = langrefs.ReferencesInExpr(addrs.ParseRef, c.ForEach)
+	result = append(result, refs...)
+
+	if n.Schema != nil {
+		refs, _ = langrefs.ReferencesInBlock(addrs.ParseRef, c.Config, n.Schema.ConfigSchema)
+		result = append(result, refs...)
+	}
+
+	return result
+}
+
+func (n *nodeExpandActionDeclaration) DynamicExpand(ctx EvalContext) (*Graph, tfdiags.Diagnostics) {
+	var g Graph
+	var diags tfdiags.Diagnostics
+	expander := ctx.InstanceExpander()
+	moduleInstances := expander.ExpandModule(n.Addr.Module, false)
+
+	for _, module := range moduleInstances {
+		absActAddr := n.Addr.Absolute(module)
+
+		// Check if the actions language experiment is enabled for this module.
+		moduleCtx := evalContextForModuleInstance(ctx, module)
+		allowActions := moduleCtx.LanguageExperimentActive(experiments.Actions)
+		if !allowActions {
+			summary := fmt.Sprintf("Actions experiment not enabled for module %s", module)
+			if module.IsRoot() {
+				summary = "Actions experiment not enabled"
+			}
+			return nil, diags.Append(tfdiags.Sourceless(
+				tfdiags.Error,
+				summary,
+				"The actions experiment must be enabled in order to use actions in your configuration. You can enable it by adding a terraform { experiments = [actions] } block to your configuration.",
+			))
+		}
+
+		// The rest of our work here needs to know which module instance it's
+		// working in, so that it can evaluate expressions in the appropriate scope.
+		_, err := n.expandActionInstances(ctx, absActAddr, &g)
+		diags = diags.Append(err)
+	}
+
+	return &g, diags
+}
+
+func (n *nodeExpandActionDeclaration) expandActionInstances(globalCtx EvalContext, actAddr addrs.AbsAction, g *Graph) ([]addrs.AbsActionInstance, tfdiags.Diagnostics) {
+	var diags tfdiags.Diagnostics
+
+	// The rest of our work here needs to know which module instance it's
+	// working in, so that it can evaluate expressions in the appropriate scope.
+	moduleCtx := evalContextForModuleInstance(globalCtx, actAddr.Module)
+
+	// writeResourceState is responsible for informing the expander of what
+	// repetition mode this resource has, which allows expander.ExpandResource
+	// to work below.
+	moreDiags := n.recordActionData(moduleCtx, actAddr)
+	diags = diags.Append(moreDiags)
+	if moreDiags.HasErrors() {
+		return nil, diags
+	}
+
+	// Before we expand our resource into potentially many resource instances,
+	// we'll verify that any mention of this resource in n.forceReplace is
+	// consistent with the repetition mode of the resource. In other words,
+	// we're aiming to catch a situation where naming a particular resource
+	// instance would require an instance key but the given address has none.
+	expander := moduleCtx.InstanceExpander()
+	instanceAddrs := expander.ExpandAction(actAddr)
+
+	// NOTE: The actual interpretation of n.forceReplace to produce replace
+	// actions is in the per-instance function we're about to call, because
+	// we need to evaluate it on a per-instance basis.
+
+	// Our graph builder mechanism expects to always be constructing new
+	// graphs rather than adding to existing ones, so we'll first
+	// construct a subgraph just for this individual modules's instances and
+	// then we'll steal all of its nodes and edges to incorporate into our
+	// main graph which contains all of the resource instances together.
+	instG, instDiags := n.actionInstanceSubgraph(actAddr, instanceAddrs)
+	if instDiags.HasErrors() {
+		diags = diags.Append(instDiags)
+		return nil, diags
+	}
+	g.Subsume(&instG.AcyclicGraph.Graph)
+
+	return instanceAddrs, diags
+}
+
+func (n *nodeExpandActionDeclaration) actionInstanceSubgraph(addr addrs.AbsAction, instanceAddrs []addrs.AbsActionInstance) (*Graph, tfdiags.Diagnostics) {
+	var diags tfdiags.Diagnostics
+
+	// Start creating the steps
+	steps := []GraphTransformer{
+		// Expand the count or for_each (if present)
+		&ActionCountTransformer{
+			Schema:           n.Schema,
+			Config:           n.Config,
+			Addr:             n.Addr,
+			InstanceAddrs:    instanceAddrs,
+			ResolvedProvider: n.ResolvedProvider,
+		},
+
+		// Connect references so ordering is correct
+		&ReferenceTransformer{},
+
+		// Make sure there is a single root
+		&RootTransformer{},
+	}
+
+	// Build the graph
+	b := &BasicGraphBuilder{
+		Steps: steps,
+		Name:  "nodeExpandActionDeclaration",
+	}
+	graph, graphDiags := b.Build(addr.Module)
+	diags = diags.Append(graphDiags)
+
+	return graph, diags
+}
+
+func (n *nodeExpandActionDeclaration) recordActionData(ctx EvalContext, addr addrs.AbsAction) (diags tfdiags.Diagnostics) {
+
+	// We'll record our expansion decision in the shared "expander" object
+	// so that later operations (i.e. DynamicExpand and expression evaluation)
+	// can refer to it. Since this node represents the abstract module, we need
+	// to expand the module here to create all resources.
+	expander := ctx.InstanceExpander()
+
+	// Allowing unknown values in count and for_each is a top-level plan option.
+	//
+	// If this is false then the codepaths that handle unknown values below
+	// become unreachable, because the evaluate functions will reject unknown
+	// values as an error.
+	// allowUnknown := ctx.Deferrals().DeferralAllowed()
+	allowUnknown := false
+
+	switch {
+	case n.Config.Count != nil:
+		count, countDiags := evaluateCountExpression(n.Config.Count, ctx, allowUnknown)
+		diags = diags.Append(countDiags)
+		if countDiags.HasErrors() {
+			return diags
+		}
+
+		if count >= 0 {
+			expander.SetActionCount(addr.Module, n.Addr.Action, count)
+		} else {
+			// -1 represents "unknown"
+			expander.SetActionCountUnknown(addr.Module, n.Addr.Action)
+		}
+
+	case n.Config.ForEach != nil:
+		forEach, known, forEachDiags := evaluateForEachExpression(n.Config.ForEach, ctx, allowUnknown)
+		diags = diags.Append(forEachDiags)
+		if forEachDiags.HasErrors() {
+			return diags
+		}
+
+		// This method takes care of all of the business logic of updating this
+		// while ensuring that any existing instances are preserved, etc.
+		if known {
+			expander.SetActionForEach(addr.Module, n.Addr.Action, forEach)
+		} else {
+			expander.SetActionForEachUnknown(addr.Module, n.Addr.Action)
+		}
+
+	default:
+		expander.SetActionSingle(addr.Module, n.Addr.Action)
+	}
+
+	return diags
+}
+
+// GraphNodeProviderConsumer
+func (n *nodeExpandActionDeclaration) ProvidedBy() (addrs.ProviderConfig, bool) {
+	// Once the provider is fully resolved, we can return the known value.
+	if n.ResolvedProvider.Provider.Type != "" {
+		return n.ResolvedProvider, true
+	}
+
+	return addrs.AbsProviderConfig{
+		Provider: n.Provider(),
+		Module:   addrs.RootModule, // TODO: Deal with modules
+	}, false
+}
+
+// GraphNodeProviderConsumer
+func (n *nodeExpandActionDeclaration) Provider() addrs.Provider {
+	// TODO: Handle provider field
+	return addrs.ImpliedProviderForUnqualifiedType(n.Addr.Action.ImpliedProvider())
+}
+
+// GraphNodeProviderConsumer
+func (n *nodeExpandActionDeclaration) SetProvider(p addrs.AbsProviderConfig) {
+	n.ResolvedProvider = p
+}

--- a/internal/terraform/node_action.go
+++ b/internal/terraform/node_action.go
@@ -4,12 +4,9 @@
 package terraform
 
 import (
-	"fmt"
-
 	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/configs"
 	"github.com/hashicorp/terraform/internal/dag"
-	"github.com/hashicorp/terraform/internal/experiments"
 	"github.com/hashicorp/terraform/internal/lang/langrefs"
 	"github.com/hashicorp/terraform/internal/providers"
 	"github.com/hashicorp/terraform/internal/tfdiags"
@@ -97,18 +94,6 @@ func (n *nodeExpandActionDeclaration) DynamicExpand(ctx EvalContext) (*Graph, tf
 
 		// Check if the actions language experiment is enabled for this module.
 		moduleCtx := evalContextForModuleInstance(ctx, module)
-		allowActions := moduleCtx.LanguageExperimentActive(experiments.Actions)
-		if !allowActions {
-			summary := fmt.Sprintf("Actions experiment not enabled for module %s", module)
-			if module.IsRoot() {
-				summary = "Actions experiment not enabled"
-			}
-			return nil, diags.Append(tfdiags.Sourceless(
-				tfdiags.Error,
-				summary,
-				"The actions experiment must be enabled in order to use actions in your configuration. You can enable it by adding a terraform { experiments = [actions] } block to your configuration.",
-			))
-		}
 
 		// recordActionData is responsible for informing the expander of what
 		// repetition mode this resource has, which allows expander.ExpandResource

--- a/internal/terraform/node_action_instance.go
+++ b/internal/terraform/node_action_instance.go
@@ -91,7 +91,7 @@ func (n *NodeActionDeclarationInstance) Execute(ctx EvalContext, _ walkOperation
 	}
 
 	ctx.Actions().AddActionInstance(n.Addr, configVal, n.ResolvedProvider)
-	return nil
+	return diags
 }
 
 // GraphNodeReferenceable

--- a/internal/terraform/node_action_instance.go
+++ b/internal/terraform/node_action_instance.go
@@ -1,0 +1,116 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package terraform
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform/internal/addrs"
+	"github.com/hashicorp/terraform/internal/configs"
+	"github.com/hashicorp/terraform/internal/dag"
+	"github.com/hashicorp/terraform/internal/lang/langrefs"
+	"github.com/hashicorp/terraform/internal/providers"
+	"github.com/hashicorp/terraform/internal/tfdiags"
+)
+
+// NodeActionDeclarationInstance represents an action in a particular module.
+//
+// Action Declarations don't do anything by themselves, they are just
+// coming into effect when they are triggered. We expand them here so that
+// when they are referenced we can get the configuration for the action directly.
+type NodeActionDeclarationInstance struct {
+	Addr             addrs.AbsActionInstance
+	Config           configs.Action
+	Schema           *providers.ActionSchema
+	ResolvedProvider addrs.AbsProviderConfig
+}
+
+var (
+	_ GraphNodeModuleInstance = (*NodeActionDeclarationInstance)(nil)
+	_ GraphNodeExecutable     = (*NodeActionDeclarationInstance)(nil)
+	_ GraphNodeReferencer     = (*NodeActionDeclarationInstance)(nil)
+	_ GraphNodeReferenceable  = (*NodeActionDeclarationInstance)(nil)
+)
+
+func (n *NodeActionDeclarationInstance) Name() string {
+	return n.Addr.String()
+}
+
+func (n *NodeActionDeclarationInstance) DotNode(string, *dag.DotOpts) *dag.DotNode {
+	return &dag.DotNode{
+		Name: n.Name(),
+	}
+}
+
+func (n *NodeActionDeclarationInstance) Path() addrs.ModuleInstance {
+	return n.Addr.Module
+}
+
+func (n *NodeActionDeclarationInstance) Execute(ctx EvalContext, _ walkOperation) tfdiags.Diagnostics {
+	var diags tfdiags.Diagnostics
+
+	// This should have been caught already
+	if n.Schema == nil {
+		panic("NodeActionDeclarationInstance.Execute called without a schema")
+	}
+
+	_, providerSchema, err := getProvider(ctx, n.ResolvedProvider)
+	if err != nil {
+		diags = diags.Append(tfdiags.Sourceless(
+			tfdiags.Error,
+			"Failed to get provider",
+			fmt.Sprintf("Failed to get provider: %s", err),
+		))
+		return diags
+	}
+
+	schema, ok := providerSchema.Actions[n.Config.Type]
+	if !ok {
+		diags = diags.Append(tfdiags.Sourceless(
+			tfdiags.Error,
+			"Action not found in provider schema",
+			fmt.Sprintf("Action not found: %s", n.Config.Type),
+		))
+		return diags
+	}
+
+	allInsts := ctx.InstanceExpander()
+	keyData := allInsts.GetActionInstanceRepetitionData(n.Addr)
+
+	configVal, _, configDiags := ctx.EvaluateBlock(n.Config.Config, schema.ConfigSchema.DeepCopy(), nil, keyData)
+
+	diags = diags.Append(configDiags)
+	if diags.HasErrors() {
+		return diags
+	}
+
+	ctx.Actions().AddActionInstance(n.Addr, configVal, n.ResolvedProvider)
+	return nil
+}
+
+// GraphNodeReferenceable
+func (n *NodeActionDeclarationInstance) ReferenceableAddrs() []addrs.Referenceable {
+	return []addrs.Referenceable{n.Addr.Action, n.Addr.Action.Action}
+}
+
+// GraphNodeReferencer
+func (n *NodeActionDeclarationInstance) References() []*addrs.Reference {
+	var result []*addrs.Reference
+	c := n.Config
+	countRefs, _ := langrefs.ReferencesInExpr(addrs.ParseRef, c.Count)
+	result = append(result, countRefs...)
+	forEachRefs, _ := langrefs.ReferencesInExpr(addrs.ParseRef, c.ForEach)
+	result = append(result, forEachRefs...)
+
+	if n.Schema != nil {
+		configRefs, _ := langrefs.ReferencesInBlock(addrs.ParseRef, c.Config, n.Schema.ConfigSchema)
+		result = append(result, configRefs...)
+	}
+
+	return result
+}
+
+func (n *NodeActionDeclarationInstance) ModulePath() addrs.Module {
+	return n.Addr.Module.Module()
+}

--- a/internal/terraform/node_resource_abstract.go
+++ b/internal/terraform/node_resource_abstract.go
@@ -215,6 +215,11 @@ func (n *NodeAbstractResource) References() []*addrs.Reference {
 				refs, _ = langrefs.ReferencesInBlock(addrs.ParseRef, p.Config, schema)
 				result = append(result, refs...)
 			}
+
+			// All actions referenced in the action triggeres should be evaluated prior.
+			for _, at := range c.Managed.ActionTriggers {
+				result = append(result, at.Actions...)
+			}
 		}
 
 		if c.List != nil {

--- a/internal/terraform/node_resource_abstract.go
+++ b/internal/terraform/node_resource_abstract.go
@@ -218,7 +218,13 @@ func (n *NodeAbstractResource) References() []*addrs.Reference {
 
 			// All actions referenced in the action triggeres should be evaluated prior.
 			for _, at := range c.Managed.ActionTriggers {
-				result = append(result, at.Actions...)
+				for _, actionRef := range at.Actions {
+					// This should have been caught during validation
+					ref, _ := addrs.ParseRef(actionRef.Traversal)
+					if ref != nil {
+						result = append(result, ref)
+					}
+				}
 			}
 		}
 

--- a/internal/terraform/node_resource_plan_instance.go
+++ b/internal/terraform/node_resource_plan_instance.go
@@ -573,9 +573,15 @@ func (n *NodePlannableResourceInstance) planActionTriggers(ctx EvalContext, chan
 		for j, actionRef := range at.Actions {
 			var actionAddr addrs.ActionInstance
 
-			if a, ok := actionRef.Subject.(addrs.ActionInstance); ok {
+			ref, parseRefDiags := addrs.ParseRef(actionRef.Traversal)
+			diags = diags.Append(parseRefDiags)
+			if parseRefDiags.HasErrors() {
+				return diags
+			}
+
+			if a, ok := ref.Subject.(addrs.ActionInstance); ok {
 				actionAddr = a
-			} else if a, ok := actionRef.Subject.(addrs.Action); ok {
+			} else if a, ok := ref.Subject.(addrs.Action); ok {
 				// Could be a reference to an action without an instance specified
 				// TODO: This is where we should auto-expand, for now we will just default to taking
 				// the action address with no key

--- a/internal/terraform/node_resource_plan_instance.go
+++ b/internal/terraform/node_resource_plan_instance.go
@@ -559,7 +559,6 @@ func (n *NodePlannableResourceInstance) managedResourceExecute(ctx EvalContext) 
 func (n *NodePlannableResourceInstance) planActionTriggers(ctx EvalContext, change *plans.ResourceInstanceChange) tfdiags.Diagnostics {
 	var diags tfdiags.Diagnostics
 
-	// TODO: When is the config nil?
 	if n.Config == nil || n.Config.Managed == nil || n.Config.Managed.ActionTriggers == nil {
 		return diags
 	}

--- a/internal/terraform/transform_action_count.go
+++ b/internal/terraform/transform_action_count.go
@@ -1,0 +1,40 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package terraform
+
+import (
+	"log"
+
+	"github.com/hashicorp/terraform/internal/addrs"
+	"github.com/hashicorp/terraform/internal/configs"
+	"github.com/hashicorp/terraform/internal/providers"
+)
+
+// ActionCountTransformer is a GraphTransformer that expands the count
+// out for a specific action.
+//
+// This assumes that the count is already interpolated.
+type ActionCountTransformer struct {
+	Schema *providers.ActionSchema
+	Config configs.Action
+
+	Addr             addrs.ConfigAction
+	InstanceAddrs    []addrs.AbsActionInstance
+	ResolvedProvider addrs.AbsProviderConfig
+}
+
+func (t *ActionCountTransformer) Transform(g *Graph) error {
+	for _, addr := range t.InstanceAddrs {
+		node := NodeActionDeclarationInstance{
+			Addr:             addr,
+			Config:           t.Config,
+			Schema:           t.Schema,
+			ResolvedProvider: t.ResolvedProvider,
+		}
+
+		log.Printf("[TRACE] ActionCountTransformer: adding %s", addr)
+		g.Add(&node)
+	}
+	return nil
+}

--- a/internal/terraform/transform_config.go
+++ b/internal/terraform/transform_config.go
@@ -129,6 +129,18 @@ func (t *ConfigTransformer) transformSingle(g *Graph, config *configs.Config) er
 		}
 	}
 
+	for _, a := range module.Actions {
+		if a != nil {
+			addr := a.Addr().InModule(path)
+			log.Printf("[TRACE] ConfigTransformer: Adding action %s", addr)
+			node := &nodeExpandActionDeclaration{
+				Addr:   addr,
+				Config: *a,
+			}
+			g.Add(node)
+		}
+	}
+
 	for _, r := range allResources {
 		relAddr := r.Addr()
 
@@ -174,10 +186,7 @@ func (t *ConfigTransformer) transformSingle(g *Graph, config *configs.Config) er
 		}
 
 		abstract := &NodeAbstractResource{
-			Addr: addrs.ConfigResource{
-				Resource: relAddr,
-				Module:   path,
-			},
+			Addr:          configAddr,
 			importTargets: imports,
 		}
 

--- a/internal/terraform/transform_reference.go
+++ b/internal/terraform/transform_reference.go
@@ -315,6 +315,7 @@ func (m ReferenceMap) References(v dag.Vertex) []dag.Vertex {
 	if rn, ok := v.(GraphNodeReferencer); ok {
 		for _, ref := range rn.References() {
 			referenceKeys = append(referenceKeys, m.referenceMapKey(vertexReferencePath(v), ref.Subject))
+
 		}
 	}
 
@@ -579,6 +580,10 @@ func (m ReferenceMap) referenceMapKey(path addrs.Module, addr addrs.Referenceabl
 
 		if mci, ok := addr.(addrs.ModuleCallInstance); ok {
 			return m.mapKey(path, mci.Call)
+		}
+
+		if ai, ok := addr.(addrs.ActionInstance); ok {
+			return m.mapKey(path, ai.ContainingAction())
 		}
 
 		// If nothing matched, then we'll just return the original key


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->
 This implementation is very barebones, but builds the skelleton for all upcoming features in actions. It includes the graph implementation for planning actions including the expansion of actions and dealing with multiple action triggers.

We plan all actions as part of their triggering resource for now.
All action_triggers depend on the triggering resources plan to determine if an action should run or not, therefore we can plan the actions as part of the triggering resource.

This implementation ignores conditions, deferrals, provider arguments and it does not add the actions to the planfile; mostly to enable more people to work on these issues in parallel.


<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Fixes [TF-25936](https://hashicorp.atlassian.net/browse/TF-25936)


## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.14.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.

[TF-25936]: https://hashicorp.atlassian.net/browse/TF-25936?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ