### PR TITLE
Replace use of `defer` with `t.Cleanup` in majority of `command` package tests

### DIFF
--- a/internal/command/apply_destroy_test.go
+++ b/internal/command/apply_destroy_test.go
@@ -23,7 +23,7 @@ func TestApply_destroy(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("apply"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	originalState := states.BuildState(func(s *states.SyncState) {
 		s.SetResourceInstanceCurrent(
@@ -127,7 +127,7 @@ func TestApply_destroyApproveNo(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("apply"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	// Create some existing state
 	originalState := states.BuildState(func(s *states.SyncState) {
@@ -195,7 +195,7 @@ func TestApply_destroyApproveYes(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("apply"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	// Create some existing state
 	originalState := states.BuildState(func(s *states.SyncState) {
@@ -266,7 +266,7 @@ func TestApply_destroyLockedState(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("apply"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	originalState := states.BuildState(func(s *states.SyncState) {
 		s.SetResourceInstanceCurrent(
@@ -324,7 +324,7 @@ func TestApply_destroyPlan(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("apply"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	planPath := testPlanFileNoop(t)
 
@@ -356,7 +356,7 @@ func TestApply_destroyPath(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("apply"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	p := applyFixtureProvider()
 
@@ -390,7 +390,7 @@ func TestApply_destroyTargetedDependencies(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("apply-destroy-targeted"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	originalState := states.BuildState(func(s *states.SyncState) {
 		s.SetResourceInstanceCurrent(
@@ -524,7 +524,7 @@ func TestApply_destroyTargeted(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("apply-destroy-targeted"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	originalState := states.BuildState(func(s *states.SyncState) {
 		s.SetResourceInstanceCurrent(

--- a/internal/command/apply_test.go
+++ b/internal/command/apply_test.go
@@ -37,7 +37,7 @@ func TestApply(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("apply"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	statePath := testTempFile(t)
 
@@ -75,7 +75,7 @@ func TestApply_path(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("apply"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	p := applyFixtureProvider()
 
@@ -105,7 +105,7 @@ func TestApply_approveNo(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("apply"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	statePath := testTempFile(t)
 
@@ -148,7 +148,7 @@ func TestApply_approveYes(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("apply"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	statePath := testTempFile(t)
 
@@ -195,7 +195,7 @@ func TestApply_lockedState(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("apply"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	statePath := testTempFile(t)
 
@@ -234,7 +234,7 @@ func TestApply_lockedStateWait(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("apply"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	statePath := testTempFile(t)
 
@@ -278,7 +278,7 @@ func TestApply_parallelism(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("parallelism"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	statePath := testTempFile(t)
 
@@ -376,7 +376,7 @@ func TestApply_configInvalid(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("apply-config-invalid"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	p := testProvider()
 	view, done := testView(t)
@@ -402,7 +402,7 @@ func TestApply_defaultState(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("apply"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	statePath := filepath.Join(td, DefaultStateFilename)
 
@@ -454,7 +454,7 @@ func TestApply_error(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("apply-error"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	statePath := testTempFile(t)
 
@@ -531,7 +531,7 @@ func TestApply_input(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("apply-input"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	// Disable test mode so input would be asked
 	test = false
@@ -581,7 +581,7 @@ func TestApply_inputPartial(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("apply-input-partial"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	// Disable test mode so input would be asked
 	test = false
@@ -627,7 +627,7 @@ func TestApply_noArgs(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("apply"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	statePath := testTempFile(t)
 
@@ -1249,7 +1249,7 @@ foo = "bar"
 		t.Run(name, func(t *testing.T) {
 			td := t.TempDir()
 			testCopyDir(t, testFixturePath("apply-ephemeral-variable"), td)
-			defer testChdir(t, td)()
+			t.Cleanup(testChdir(t, td))
 
 			_, snap := testModuleWithSnapshot(t, "apply-ephemeral-variable")
 			plannedVal := cty.ObjectVal(map[string]cty.Value{
@@ -1423,7 +1423,7 @@ func TestApply_changedVars_applyTime(t *testing.T) {
 		// var files.
 		td := t.TempDir()
 		testCopyDir(t, testFixturePath("apply-vars-auto"), td)
-		defer testChdir(t, td)()
+		t.Cleanup(testChdir(t, td))
 
 		p := planVarsFixtureProvider()
 		view, done := testView(t)
@@ -1469,7 +1469,7 @@ func TestApply_planNoModuleFiles(t *testing.T) {
 	td := testTempDir(t)
 	defer os.RemoveAll(td)
 
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	p := applyFixtureProvider()
 	planPath := applyFixturePlanFile(t)
@@ -1492,7 +1492,7 @@ func TestApply_refresh(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("apply"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	originalState := states.BuildState(func(s *states.SyncState) {
 		s.SetResourceInstanceCurrent(
@@ -1559,7 +1559,7 @@ func TestApply_refreshFalse(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("apply"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	originalState := states.BuildState(func(s *states.SyncState) {
 		s.SetResourceInstanceCurrent(
@@ -1608,7 +1608,7 @@ func TestApply_shutdown(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("apply-shutdown"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	cancelled := make(chan struct{})
 	shutdownCh := make(chan struct{})
@@ -1696,7 +1696,7 @@ func TestApply_state(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("apply"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	originalState := states.BuildState(func(s *states.SyncState) {
 		s.SetResourceInstanceCurrent(
@@ -1790,7 +1790,7 @@ func TestApply_stateNoExist(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("apply"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	p := applyFixtureProvider()
 	view, done := testView(t)
@@ -1815,7 +1815,7 @@ func TestApply_sensitiveOutput(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("apply-sensitive-output"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	p := testProvider()
 	view, done := testView(t)
@@ -1852,7 +1852,7 @@ func TestApply_vars(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("apply-vars"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	statePath := testTempFile(t)
 
@@ -1909,7 +1909,7 @@ func TestApply_varFile(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("apply-vars"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	varFilePath := testTempFile(t)
 	if err := ioutil.WriteFile(varFilePath, []byte(applyVarFile), 0644); err != nil {
@@ -1971,7 +1971,7 @@ func TestApply_varFileDefault(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("apply-vars"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	varFilePath := filepath.Join(td, "terraform.tfvars")
 	if err := os.WriteFile(varFilePath, []byte(applyVarFile), 0644); err != nil {
@@ -2032,7 +2032,7 @@ func TestApply_varFileDefaultJSON(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("apply-vars"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	varFilePath := filepath.Join(td, "terraform.tfvars.json")
 	if err := ioutil.WriteFile(varFilePath, []byte(applyVarFileJSON), 0644); err != nil {
@@ -2093,7 +2093,7 @@ func TestApply_backup(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("apply"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	originalState := states.BuildState(func(s *states.SyncState) {
 		s.SetResourceInstanceCurrent(
@@ -2170,7 +2170,7 @@ func TestApply_disableBackup(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("apply"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	originalState := testState()
 	statePath := testStateFile(t, originalState)
@@ -2249,7 +2249,7 @@ func TestApply_terraformEnv(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("apply-terraform-env"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	statePath := testTempFile(t)
 
@@ -2286,7 +2286,7 @@ func TestApply_terraformEnvNonDefault(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("apply-terraform-env"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	// Create new env
 	{
@@ -2347,7 +2347,7 @@ output = test
 func TestApply_targeted(t *testing.T) {
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("apply-targeted"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	p := testProvider()
 	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
@@ -2402,7 +2402,7 @@ func TestApply_targetFlagsDiags(t *testing.T) {
 		t.Run(target, func(t *testing.T) {
 			td := testTempDir(t)
 			defer os.RemoveAll(td)
-			defer testChdir(t, td)()
+			t.Cleanup(testChdir(t, td))
 
 			view, done := testView(t)
 			c := &ApplyCommand{
@@ -2435,7 +2435,7 @@ func TestApply_targetFlagsDiags(t *testing.T) {
 func TestApply_replace(t *testing.T) {
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("apply-replace"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	originalState := states.BuildState(func(s *states.SyncState) {
 		s.SetResourceInstanceCurrent(
@@ -2522,7 +2522,7 @@ func TestApply_pluginPath(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("apply"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	statePath := testTempFile(t)
 
@@ -2562,7 +2562,7 @@ func TestApply_jsonGoldenReference(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("apply"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	statePath := testTempFile(t)
 
@@ -2603,7 +2603,7 @@ func TestApply_warnings(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("apply"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	p := testProvider()
 	p.GetProviderSchemaResponse = applyFixtureSchema()

--- a/internal/command/autocomplete_test.go
+++ b/internal/command/autocomplete_test.go
@@ -17,7 +17,7 @@ func TestMetaCompletePredictWorkspaceName(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	os.MkdirAll(td, 0755)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	// make sure a vars file doesn't interfere
 	err := ioutil.WriteFile(DefaultVarsFilename, nil, 0644)

--- a/internal/command/command_test.go
+++ b/internal/command/command_test.go
@@ -631,8 +631,13 @@ func testChdir(t *testing.T, new string) func() {
 	}
 
 	return func() {
-		// Re-run the function ignoring the defer result
-		testChdir(t, old)
+		// This code needs to be resilient to the tmp directory having already
+		// been deleted by the cleanup function made by t.TempDir.
+		//
+		// To achieve this, avoid recursion
+		if err := os.Chdir(old); err != nil {
+			t.Fatalf("err: %v", err)
+		}
 	}
 }
 

--- a/internal/command/console_test.go
+++ b/internal/command/console_test.go
@@ -57,7 +57,7 @@ func TestConsole_basic(t *testing.T) {
 func TestConsole_tfvars(t *testing.T) {
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("apply-vars"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	// Write a terraform.tvars
 	varFilePath := filepath.Join(td, "terraform.tfvars")
@@ -115,7 +115,7 @@ func TestConsole_unsetRequiredVars(t *testing.T) {
 	// intentionally not setting here.
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("apply-vars"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	p := testProvider()
 	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
@@ -159,7 +159,7 @@ func TestConsole_unsetRequiredVars(t *testing.T) {
 func TestConsole_variables(t *testing.T) {
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("variables"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	p := testProvider()
 	ui := cli.NewMockUi()
@@ -201,7 +201,7 @@ func TestConsole_variables(t *testing.T) {
 func TestConsole_modules(t *testing.T) {
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("modules"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	p := applyFixtureProvider()
 	ui := cli.NewMockUi()
@@ -243,7 +243,7 @@ func TestConsole_modules(t *testing.T) {
 func TestConsole_modulesPlan(t *testing.T) {
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("apply"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	p := applyFixtureProvider()
 	ui := cli.NewMockUi()

--- a/internal/command/graph_test.go
+++ b/internal/command/graph_test.go
@@ -27,7 +27,7 @@ import (
 func TestGraph_planPhase(t *testing.T) {
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("graph"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	ui := new(cli.MockUi)
 	streams, closeStreams := terminal.StreamsForTesting(t)
@@ -53,7 +53,7 @@ func TestGraph_planPhase(t *testing.T) {
 func TestGraph_cyclic(t *testing.T) {
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("graph-cyclic"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	tests := []struct {
 		name     string
@@ -189,7 +189,7 @@ func TestGraph_multipleArgs(t *testing.T) {
 func TestGraph_noConfig(t *testing.T) {
 	td := t.TempDir()
 	os.MkdirAll(td, 0755)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	streams, closeStreams := terminal.StreamsForTesting(t)
 	defer closeStreams(t)

--- a/internal/command/import_test.go
+++ b/internal/command/import_test.go
@@ -165,7 +165,7 @@ func TestImport_providerConfig(t *testing.T) {
 func TestImport_remoteState(t *testing.T) {
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("import-provider-remote-state"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	statePath := "imported.tfstate"
 
@@ -277,7 +277,7 @@ func TestImport_remoteState(t *testing.T) {
 func TestImport_initializationErrorShouldUnlock(t *testing.T) {
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("import-provider-remote-state"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	statePath := "imported.tfstate"
 
@@ -746,7 +746,7 @@ func TestImport_missingModuleConfig(t *testing.T) {
 func TestImportModuleVarFile(t *testing.T) {
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("import-module-var-file"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	statePath := testTempFile(t)
 
@@ -820,7 +820,7 @@ func TestImportModuleVarFile(t *testing.T) {
 func TestImportModuleInputVariableEvaluation(t *testing.T) {
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("import-module-input-variable"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	statePath := testTempFile(t)
 

--- a/internal/command/init_test.go
+++ b/internal/command/init_test.go
@@ -57,7 +57,7 @@ func TestInit_empty(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	os.MkdirAll(td, 0755)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	ui := new(cli.MockUi)
 	view, done := testView(t)
@@ -84,7 +84,7 @@ func TestInit_only_test_files(t *testing.T) {
 	// Create a temporary working directory that has only test files and no tf configuration
 	td := t.TempDir()
 	os.MkdirAll(td, 0755)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	if _, err := os.Create("main.tftest.hcl"); err != nil {
 		t.Fatalf("err: %s", err)
@@ -115,7 +115,7 @@ func TestInit_multipleArgs(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	os.MkdirAll(td, 0755)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	ui := new(cli.MockUi)
 	view, done := testView(t)
@@ -140,7 +140,7 @@ func TestInit_migrateStateAndJSON(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	os.MkdirAll(td, 0755)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	ui := new(cli.MockUi)
 	view, done := testView(t)
@@ -170,7 +170,7 @@ func TestInit_fromModule_cwdDest(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	os.MkdirAll(td, os.ModePerm)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	ui := new(cli.MockUi)
 	view, done := testView(t)
@@ -249,7 +249,7 @@ func TestInit_get(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("init-get"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	ui := new(cli.MockUi)
 	view, done := testView(t)
@@ -277,7 +277,7 @@ func TestInit_json(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("init-get"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	ui := new(cli.MockUi)
 	view, done := testView(t)
@@ -303,7 +303,7 @@ func TestInit_getUpgradeModules(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("init-get"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	ui := new(cli.MockUi)
 	view, done := testView(t)
@@ -335,7 +335,7 @@ func TestInit_backend(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("init-backend"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	ui := new(cli.MockUi)
 	view, done := testView(t)
@@ -361,7 +361,7 @@ func TestInit_backendUnset(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("init-backend"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	{
 		log.Printf("[TRACE] TestInit_backendUnset: beginning first init")
@@ -431,7 +431,7 @@ func TestInit_backendConfigFile(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("init-backend-config-file"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	t.Run("good-config-file", func(t *testing.T) {
 		ui := new(cli.MockUi)
@@ -567,7 +567,7 @@ func TestInit_backendConfigFilePowershellConfusion(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("init-backend-config-file"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	ui := new(cli.MockUi)
 	view, done := testView(t)
@@ -603,7 +603,7 @@ func TestInit_backendReconfigure(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("init-backend"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	providerSource, close := newMockProviderSource(t, map[string][]string{
 		"hashicorp/test": {"1.2.3"},
@@ -650,7 +650,7 @@ func TestInit_backendConfigFileChange(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("init-backend-config-file-change"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	ui := new(cli.MockUi)
 	view, done := testView(t)
@@ -678,7 +678,7 @@ func TestInit_backendMigrateWhileLocked(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("init-backend-migrate-while-locked"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	providerSource, close := newMockProviderSource(t, map[string][]string{
 		"hashicorp/test": {"1.2.3"},
@@ -731,7 +731,7 @@ func TestInit_backendConfigFileChangeWithExistingState(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("init-backend-config-file-change-migrate-existing"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	ui := new(cli.MockUi)
 	view, _ := testView(t)
@@ -768,7 +768,7 @@ func TestInit_backendConfigKV(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("init-backend-config-kv"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	ui := new(cli.MockUi)
 	view, done := testView(t)
@@ -796,7 +796,7 @@ func TestInit_backendConfigKVReInit(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("init-backend-config-kv"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	ui := new(cli.MockUi)
 	view, done := testView(t)
@@ -859,7 +859,7 @@ func TestInit_backendConfigKVReInitWithConfigDiff(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("init-backend"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	ui := new(cli.MockUi)
 	view, done := testView(t)
@@ -907,7 +907,7 @@ func TestInit_backendCli_no_config_block(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("init"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	ui := new(cli.MockUi)
 	view, done := testView(t)
@@ -933,7 +933,7 @@ func TestInit_backendCli_no_config_block(t *testing.T) {
 func TestInit_backendReinitWithExtra(t *testing.T) {
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("init-backend-empty"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	m := testMetaBackend(t, nil)
 	opts := &BackendOpts{
@@ -990,7 +990,7 @@ func TestInit_backendReinitWithExtra(t *testing.T) {
 func TestInit_backendReinitConfigToExtra(t *testing.T) {
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("init-backend"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	ui := new(cli.MockUi)
 	view, done := testView(t)
@@ -1352,7 +1352,7 @@ prompts.
 func TestInit_inputFalse(t *testing.T) {
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("init-backend"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	ui := new(cli.MockUi)
 	view, done := testView(t)
@@ -1430,7 +1430,7 @@ func TestInit_getProvider(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("init-get-providers"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	overrides := metaOverridesForProvider(testProvider())
 	ui := new(cli.MockUi)
@@ -1537,7 +1537,7 @@ func TestInit_getProviderSource(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("init-get-provider-source"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	overrides := metaOverridesForProvider(testProvider())
 	ui := new(cli.MockUi)
@@ -1587,7 +1587,7 @@ func TestInit_getProviderLegacyFromState(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("init-get-provider-legacy-from-state"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	overrides := metaOverridesForProvider(testProvider())
 	ui := new(cli.MockUi)
@@ -1629,7 +1629,7 @@ func TestInit_getProviderInvalidPackage(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("init-get-provider-invalid-package"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	overrides := metaOverridesForProvider(testProvider())
 	ui := new(cli.MockUi)
@@ -1693,7 +1693,7 @@ func TestInit_getProviderDetectedLegacy(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("init-get-provider-detected-legacy"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	// We need to construct a multisource with a mock source and a registry
 	// source: the mock source will return ErrRegistryProviderNotKnown for an
@@ -1762,7 +1762,7 @@ func TestInit_providerSource(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("init-required-providers"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	providerSource, close := newMockProviderSource(t, map[string][]string{
 		"test":      {"1.2.3", "1.2.4"},
@@ -1873,7 +1873,7 @@ func TestInit_cancelModules(t *testing.T) {
 
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("init-registry-module"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	// Our shutdown channel is pre-closed so init will exit as soon as it
 	// starts a cancelable portion of the process.
@@ -1911,7 +1911,7 @@ func TestInit_cancelProviders(t *testing.T) {
 
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("init-required-providers"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	// Use a provider source implementation which is designed to hang indefinitely,
 	// to avoid a race between the closed shutdown channel and the provider source
@@ -1956,7 +1956,7 @@ func TestInit_getUpgradePlugins(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("init-get-providers"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	providerSource, close := newMockProviderSource(t, map[string][]string{
 		// looking for an exact version
@@ -2081,7 +2081,7 @@ func TestInit_getProviderMissing(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("init-get-providers"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	providerSource, close := newMockProviderSource(t, map[string][]string{
 		// looking for exact version 1.2.3
@@ -2122,7 +2122,7 @@ func TestInit_checkRequiredVersion(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("init-check-required-version"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	ui := cli.NewMockUi()
 	view, done := testView(t)
@@ -2153,7 +2153,7 @@ func TestInit_checkRequiredVersionFirst(t *testing.T) {
 	t.Run("root_module", func(t *testing.T) {
 		td := t.TempDir()
 		testCopyDir(t, testFixturePath("init-check-required-version-first"), td)
-		defer testChdir(t, td)()
+		t.Cleanup(testChdir(t, td))
 
 		ui := cli.NewMockUi()
 		view, done := testView(t)
@@ -2177,7 +2177,7 @@ func TestInit_checkRequiredVersionFirst(t *testing.T) {
 	t.Run("sub_module", func(t *testing.T) {
 		td := t.TempDir()
 		testCopyDir(t, testFixturePath("init-check-required-version-first-module"), td)
-		defer testChdir(t, td)()
+		t.Cleanup(testChdir(t, td))
 
 		ui := cli.NewMockUi()
 		view, done := testView(t)
@@ -2206,7 +2206,7 @@ func TestInit_providerLockFile(t *testing.T) {
 	testCopyDir(t, testFixturePath("init-provider-lock-file"), td)
 	// The temporary directory does not have write permission (dr-xr-xr-x) after the copy
 	defer os.Chmod(td, os.ModePerm)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	providerSource, close := newMockProviderSource(t, map[string][]string{
 		"test": {"1.2.3"},
@@ -2393,7 +2393,7 @@ provider "registry.terraform.io/hashicorp/test" {
 			// Create a temporary working directory that is empty
 			td := t.TempDir()
 			testCopyDir(t, testFixturePath(tc.fixture), td)
-			defer testChdir(t, td)()
+			t.Cleanup(testChdir(t, td))
 
 			providerSource, close := newMockProviderSource(t, tc.providers)
 			defer close()
@@ -2440,7 +2440,7 @@ provider "registry.terraform.io/hashicorp/test" {
 func TestInit_pluginDirReset(t *testing.T) {
 	td := testTempDir(t)
 	defer os.RemoveAll(td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	// An empty provider source
 	providerSource, close := newMockProviderSource(t, nil)
@@ -2510,7 +2510,7 @@ func TestInit_pluginDirReset(t *testing.T) {
 func TestInit_pluginDirProviders(t *testing.T) {
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("init-get-providers"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	// An empty provider source
 	providerSource, close := newMockProviderSource(t, nil)
@@ -2607,7 +2607,7 @@ func TestInit_pluginDirProviders(t *testing.T) {
 func TestInit_pluginDirProvidersDoesNotGet(t *testing.T) {
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("init-get-providers"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	// Our provider source has a suitable package for "between" available,
 	// but we should ignore it because -plugin-dir is set and thus this
@@ -2686,7 +2686,7 @@ func TestInit_pluginDirProvidersDoesNotGet(t *testing.T) {
 func TestInit_pluginDirWithBuiltIn(t *testing.T) {
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("init-internal"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	// An empty provider source
 	providerSource, close := newMockProviderSource(t, nil)
@@ -2726,7 +2726,7 @@ func TestInit_invalidBuiltInProviders(t *testing.T) {
 	//   not exist at all.
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("init-internal-invalid"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	// An empty provider source
 	providerSource, close := newMockProviderSource(t, nil)
@@ -2763,7 +2763,7 @@ func TestInit_invalidBuiltInProviders(t *testing.T) {
 func TestInit_invalidSyntaxNoBackend(t *testing.T) {
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("init-syntax-invalid-no-backend"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	ui := cli.NewMockUi()
 	view, done := testView(t)
@@ -2794,7 +2794,7 @@ func TestInit_invalidSyntaxNoBackend(t *testing.T) {
 func TestInit_invalidSyntaxWithBackend(t *testing.T) {
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("init-syntax-invalid-with-backend"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	ui := cli.NewMockUi()
 	view, done := testView(t)
@@ -2825,7 +2825,7 @@ func TestInit_invalidSyntaxWithBackend(t *testing.T) {
 func TestInit_invalidSyntaxInvalidBackend(t *testing.T) {
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("init-syntax-invalid-backend-invalid"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	ui := cli.NewMockUi()
 	view, done := testView(t)
@@ -2859,7 +2859,7 @@ func TestInit_invalidSyntaxInvalidBackend(t *testing.T) {
 func TestInit_invalidSyntaxBackendAttribute(t *testing.T) {
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("init-syntax-invalid-backend-attribute-invalid"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	ui := cli.NewMockUi()
 	view, done := testView(t)
@@ -2893,7 +2893,7 @@ func TestInit_invalidSyntaxBackendAttribute(t *testing.T) {
 func TestInit_testsWithExternalProviders(t *testing.T) {
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("init-with-tests-external-providers"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	providerSource, close := newMockProviderSource(t, map[string][]string{
 		"hashicorp/testing": {"1.0.0"},
@@ -2932,7 +2932,7 @@ func TestInit_tests(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("init-with-tests"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	provider := applyFixtureProvider() // We just want the types from this provider.
 
@@ -2962,7 +2962,7 @@ func TestInit_testsWithProvider(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("init-with-tests-with-provider"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	provider := applyFixtureProvider() // We just want the types from this provider.
 
@@ -3009,7 +3009,7 @@ versions are specified, run the following command:
 func TestInit_testsWithOverriddenInvalidRequiredProviders(t *testing.T) {
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("init-with-overrides-and-duplicates"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	provider := applyFixtureProvider() // We just want the types from this provider.
 
@@ -3039,7 +3039,7 @@ func TestInit_testsWithOverriddenInvalidRequiredProviders(t *testing.T) {
 func TestInit_testsWithInvalidRequiredProviders(t *testing.T) {
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("init-with-duplicates"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	provider := applyFixtureProvider() // We just want the types from this provider.
 
@@ -3070,7 +3070,7 @@ func TestInit_testsWithModule(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("init-with-tests-with-module"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	provider := applyFixtureProvider() // We just want the types from this provider.
 
@@ -3108,7 +3108,7 @@ func TestInit_stateStoreBlockIsExperimental(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("init-with-state-store"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	ui := new(cli.MockUi)
 	view, done := testView(t)

--- a/internal/command/meta_backend_test.go
+++ b/internal/command/meta_backend_test.go
@@ -37,7 +37,7 @@ func TestMetaBackend_emptyDir(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	os.MkdirAll(td, 0755)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	// Get the backend
 	m := testMetaBackend(t, nil)
@@ -92,7 +92,7 @@ func TestMetaBackend_emptyWithDefaultState(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	os.MkdirAll(td, 0755)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	// Write the legacy state
 	statePath := DefaultStateFilename
@@ -159,7 +159,7 @@ func TestMetaBackend_emptyWithExplicitState(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	os.MkdirAll(td, 0755)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	// Create another directory to store our state
 	stateDir := t.TempDir()
@@ -230,7 +230,7 @@ func TestMetaBackend_configureInterpolation(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("backend-new-interp"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	// Setup the meta
 	m := testMetaBackend(t, nil)
@@ -246,7 +246,7 @@ func TestMetaBackend_configureInterpolation(t *testing.T) {
 func TestMetaBackend_configureNew(t *testing.T) {
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("backend-new"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	// Setup the meta
 	m := testMetaBackend(t, nil)
@@ -310,7 +310,7 @@ func TestMetaBackend_configureNewWithState(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("backend-new-migrate"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	// Ask input
 	defer testInteractiveInput(t, []string{"yes"})()
@@ -387,7 +387,7 @@ func TestMetaBackend_configureNewWithoutCopy(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("backend-new-migrate"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	if err := copy.CopyFile(DefaultStateFilename, "local-state.tfstate"); err != nil {
 		t.Fatal(err)
@@ -437,7 +437,7 @@ func TestMetaBackend_configureNewWithStateNoMigrate(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("backend-new-migrate"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	// Ask input
 	defer testInteractiveInput(t, []string{"no"})()
@@ -481,7 +481,7 @@ func TestMetaBackend_configureNewWithStateExisting(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("backend-new-migrate-existing"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	// Setup the meta
 	m := testMetaBackend(t, nil)
@@ -552,7 +552,7 @@ func TestMetaBackend_configureNewWithStateExistingNoMigrate(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("backend-new-migrate-existing"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	// Ask input
 	defer testInteractiveInput(t, []string{"no"})()
@@ -663,7 +663,7 @@ func TestMetaBackend_configuredChange(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("backend-change"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	// Ask input
 	defer testInteractiveInput(t, []string{"no"})()
@@ -742,7 +742,7 @@ func TestMetaBackend_reconfigureChange(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("backend-change-single-to-single"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	// Register the single-state backend
 	backendInit.Set("local-single", backendLocal.TestNewLocalSingle)
@@ -795,7 +795,7 @@ func TestMetaBackend_initSelectedWorkspaceDoesNotExist(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("init-backend-selected-workspace-doesnt-exist-multi"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	// Setup the meta
 	m := testMetaBackend(t, nil)
@@ -828,7 +828,7 @@ func TestMetaBackend_initSelectedWorkspaceDoesNotExistAutoSelect(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("init-backend-selected-workspace-doesnt-exist-single"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	// Setup the meta
 	m := testMetaBackend(t, nil)
@@ -869,7 +869,7 @@ func TestMetaBackend_initSelectedWorkspaceDoesNotExistInputFalse(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("init-backend-selected-workspace-doesnt-exist-multi"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	// Setup the meta
 	m := testMetaBackend(t, nil)
@@ -889,7 +889,7 @@ func TestMetaBackend_configuredChangeCopy(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("backend-change"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	// Ask input
 	defer testInteractiveInput(t, []string{"yes", "yes"})()
@@ -936,7 +936,7 @@ func TestMetaBackend_configuredChangeCopy_singleState(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("backend-change-single-to-single"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	// Register the single-state backend
 	backendInit.Set("local-single", backendLocal.TestNewLocalSingle)
@@ -990,7 +990,7 @@ func TestMetaBackend_configuredChangeCopy_multiToSingleDefault(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("backend-change-multi-default-to-single"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	// Register the single-state backend
 	backendInit.Set("local-single", backendLocal.TestNewLocalSingle)
@@ -1043,7 +1043,7 @@ func TestMetaBackend_configuredChangeCopy_multiToSingle(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("backend-change-multi-to-single"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	// Register the single-state backend
 	backendInit.Set("local-single", backendLocal.TestNewLocalSingle)
@@ -1112,7 +1112,7 @@ func TestMetaBackend_configuredChangeCopy_multiToSingleCurrentEnv(t *testing.T) 
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("backend-change-multi-to-single"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	// Register the single-state backend
 	backendInit.Set("local-single", backendLocal.TestNewLocalSingle)
@@ -1177,7 +1177,7 @@ func TestMetaBackend_configuredChangeCopy_multiToMulti(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("backend-change-multi-to-multi"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	// Ask input
 	defer testInputMap(t, map[string]string{
@@ -1270,7 +1270,7 @@ func TestMetaBackend_configuredChangeCopy_multiToNoDefaultWithDefault(t *testing
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("backend-change-multi-to-no-default-with-default"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	// Register the single-state backend
 	backendInit.Set("local-no-default", backendLocal.TestNewLocalNoDefault)
@@ -1345,7 +1345,7 @@ func TestMetaBackend_configuredChangeCopy_multiToNoDefaultWithoutDefault(t *test
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("backend-change-multi-to-no-default-without-default"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	// Register the single-state backend
 	backendInit.Set("local-no-default", backendLocal.TestNewLocalNoDefault)
@@ -1417,7 +1417,7 @@ func TestMetaBackend_configuredUnset(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("backend-unset"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	// Ask input
 	defer testInteractiveInput(t, []string{"no"})()
@@ -1479,7 +1479,7 @@ func TestMetaBackend_configuredUnsetCopy(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("backend-unset"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	// Ask input
 	defer testInteractiveInput(t, []string{"yes", "yes"})()
@@ -1536,7 +1536,7 @@ func TestMetaBackend_planLocal(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("backend-plan-local"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	backendConfigBlock := cty.ObjectVal(map[string]cty.Value{
 		"path":          cty.NullVal(cty.String),
@@ -1624,7 +1624,7 @@ func TestMetaBackend_planLocal(t *testing.T) {
 func TestMetaBackend_planLocalStatePath(t *testing.T) {
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("backend-plan-local"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	original := testState()
 	markStateForMatching(original, "hello")
@@ -1726,7 +1726,7 @@ func TestMetaBackend_planLocalMatch(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("backend-plan-local-match"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	backendConfigBlock := cty.ObjectVal(map[string]cty.Value{
 		"path":          cty.NullVal(cty.String),
@@ -1813,7 +1813,7 @@ func TestMetaBackend_configureWithExtra(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("init-backend-empty"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	extras := map[string]cty.Value{"path": cty.StringVal("hello")}
 	m := testMetaBackend(t, nil)
@@ -1864,7 +1864,7 @@ func TestMetaBackend_localDoesNotDeleteLocal(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("init-backend-empty"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	// // create our local state
 	orig := states.NewState()
@@ -1894,7 +1894,7 @@ func TestMetaBackend_configToExtra(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("init-backend"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	// init the backend
 	m := testMetaBackend(t, nil)

--- a/internal/command/meta_test.go
+++ b/internal/command/meta_test.go
@@ -186,7 +186,7 @@ func TestMeta_initStatePaths(t *testing.T) {
 func TestMeta_Env(t *testing.T) {
 	td := t.TempDir()
 	os.MkdirAll(td, 0755)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	m := new(Meta)
 
@@ -315,7 +315,7 @@ func TestMeta_Workspace_override(t *testing.T) {
 func TestMeta_Workspace_invalidSelected(t *testing.T) {
 	td := t.TempDir()
 	os.MkdirAll(td, 0755)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	// this is an invalid workspace name
 	workspace := "test workspace"
@@ -447,7 +447,7 @@ func TestCommand_checkRequiredVersion(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("command-check-required-version"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	ui := cli.NewMockUi()
 	meta := Meta{

--- a/internal/command/plan_test.go
+++ b/internal/command/plan_test.go
@@ -33,7 +33,7 @@ import (
 func TestPlan(t *testing.T) {
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("plan"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	p := planFixtureProvider()
 	view, done := testView(t)
@@ -55,7 +55,7 @@ func TestPlan(t *testing.T) {
 func TestPlan_lockedState(t *testing.T) {
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("plan"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	unlock, err := testLockState(t, testDataDir, filepath.Join(td, DefaultStateFilename))
 	if err != nil {
@@ -109,7 +109,7 @@ func TestPlan_plan(t *testing.T) {
 func TestPlan_destroy(t *testing.T) {
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("plan"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	originalState := states.BuildState(func(s *states.SyncState) {
 		s.SetResourceInstanceCurrent(
@@ -162,7 +162,7 @@ func TestPlan_destroy(t *testing.T) {
 func TestPlan_noState(t *testing.T) {
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("plan"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	p := planFixtureProvider()
 	view, done := testView(t)
@@ -196,7 +196,7 @@ func TestPlan_noState(t *testing.T) {
 func TestPlan_generatedConfigPath(t *testing.T) {
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("plan-import-config-gen"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	genPath := filepath.Join(td, "generated.tf")
 
@@ -237,7 +237,7 @@ func TestPlan_generatedConfigPath(t *testing.T) {
 func TestPlan_outPath(t *testing.T) {
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("plan"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	outPath := filepath.Join(td, "test.plan")
 
@@ -269,7 +269,7 @@ func TestPlan_outPath(t *testing.T) {
 func TestPlan_outPathNoChange(t *testing.T) {
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("plan"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	originalState := states.BuildState(func(s *states.SyncState) {
 		s.SetResourceInstanceCurrent(
@@ -323,7 +323,7 @@ func TestPlan_outPathNoChange(t *testing.T) {
 func TestPlan_outPathWithError(t *testing.T) {
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("plan-fail-condition"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	outPath := filepath.Join(td, "test.plan")
 
@@ -373,7 +373,7 @@ func TestPlan_outBackend(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("plan-out-backend"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	originalState := states.BuildState(func(s *states.SyncState) {
 		s.SetResourceInstanceCurrent(
@@ -473,7 +473,7 @@ func TestPlan_refreshFalse(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("plan-existing-state"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	p := planFixtureProvider()
 	view, done := testView(t)
@@ -502,7 +502,7 @@ func TestPlan_refreshTrue(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("plan-existing-state"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	p := planFixtureProvider()
 	view, done := testView(t)
@@ -537,7 +537,7 @@ func TestPlan_refreshFalseRefreshTrue(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("plan-existing-state"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	p := planFixtureProvider()
 	view, done := testView(t)
@@ -567,7 +567,7 @@ func TestPlan_state(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("plan"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	originalState := testState()
 	statePath := testStateFile(t, originalState)
@@ -609,7 +609,7 @@ func TestPlan_stateDefault(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("plan"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	// Generate state and move it to the default path
 	originalState := testState()
@@ -654,7 +654,7 @@ func TestPlan_validate(t *testing.T) {
 
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("plan-invalid"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	p := testProvider()
 	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
@@ -701,7 +701,7 @@ func TestPlan_vars(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("plan-vars"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	p := planVarsFixtureProvider()
 	view, done := testView(t)
@@ -751,7 +751,7 @@ func TestPlan_varsInvalid(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("plan-vars"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	for _, tc := range testCases {
 		t.Run(strings.Join(tc.args, " "), func(t *testing.T) {
@@ -782,7 +782,7 @@ func TestPlan_varsUnset(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("plan-vars"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	// The plan command will prompt for interactive input of var.foo.
 	// We'll answer "bar" to that prompt, which should then allow this
@@ -818,7 +818,7 @@ func TestPlan_providerArgumentUnset(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("plan"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	// Disable test mode so input would be asked
 	test = false
@@ -897,7 +897,7 @@ func TestPlan_providerArgumentUnset(t *testing.T) {
 func TestPlan_providerConfigMerge(t *testing.T) {
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("plan-provider-input"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	// Disable test mode so input would be asked
 	test = false
@@ -986,7 +986,7 @@ func TestPlan_varFile(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("plan-vars"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	varFilePath := testTempFile(t)
 	if err := ioutil.WriteFile(varFilePath, []byte(planVarFile), 0644); err != nil {
@@ -1027,7 +1027,7 @@ func TestPlan_varFileDefault(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("plan-vars"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	varFilePath := filepath.Join(td, "terraform.tfvars")
 	if err := ioutil.WriteFile(varFilePath, []byte(planVarFile), 0644); err != nil {
@@ -1066,7 +1066,7 @@ func TestPlan_varFileWithDecls(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("plan-vars"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	varFilePath := testTempFile(t)
 	if err := ioutil.WriteFile(varFilePath, []byte(planVarFileWithDecl), 0644); err != nil {
@@ -1100,7 +1100,7 @@ func TestPlan_varFileWithDecls(t *testing.T) {
 func TestPlan_detailedExitcode(t *testing.T) {
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("plan"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	t.Run("return 1", func(t *testing.T) {
 		view, done := testView(t)
@@ -1138,7 +1138,7 @@ func TestPlan_detailedExitcode(t *testing.T) {
 func TestPlan_detailedExitcode_emptyDiff(t *testing.T) {
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("plan-emptydiff"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	p := testProvider()
 	view, done := testView(t)
@@ -1161,7 +1161,7 @@ func TestPlan_shutdown(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("apply-shutdown"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	cancelled := make(chan struct{})
 	shutdownCh := make(chan struct{})
@@ -1230,7 +1230,7 @@ func TestPlan_shutdown(t *testing.T) {
 func TestPlan_init_required(t *testing.T) {
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("plan"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	view, done := testView(t)
 	c := &PlanCommand{
@@ -1256,7 +1256,7 @@ func TestPlan_init_required(t *testing.T) {
 func TestPlan_targeted(t *testing.T) {
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("apply-targeted"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	p := testProvider()
 	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
@@ -1310,7 +1310,7 @@ func TestPlan_targetFlagsDiags(t *testing.T) {
 		t.Run(target, func(t *testing.T) {
 			td := testTempDir(t)
 			defer os.RemoveAll(td)
-			defer testChdir(t, td)()
+			t.Cleanup(testChdir(t, td))
 
 			view, done := testView(t)
 			c := &PlanCommand{
@@ -1342,7 +1342,7 @@ func TestPlan_targetFlagsDiags(t *testing.T) {
 func TestPlan_replace(t *testing.T) {
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("plan-replace"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	originalState := states.BuildState(func(s *states.SyncState) {
 		s.SetResourceInstanceCurrent(
@@ -1415,7 +1415,7 @@ func TestPlan_parallelism(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("parallelism"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	par := 4
 
@@ -1501,7 +1501,7 @@ func TestPlan_parallelism(t *testing.T) {
 func TestPlan_warnings(t *testing.T) {
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("plan"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	t.Run("full warnings", func(t *testing.T) {
 		p := planWarningsFixtureProvider()
@@ -1564,7 +1564,7 @@ func TestPlan_jsonGoldenReference(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("plan"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	p := planFixtureProvider()
 	view, done := testView(t)

--- a/internal/command/plugins_test.go
+++ b/internal/command/plugins_test.go
@@ -12,7 +12,7 @@ import (
 func TestPluginPath(t *testing.T) {
 	td := testTempDir(t)
 	defer os.RemoveAll(td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	pluginPath := []string{"a", "b", "c"}
 

--- a/internal/command/providers_lock_test.go
+++ b/internal/command/providers_lock_test.go
@@ -23,7 +23,7 @@ func TestProvidersLock(t *testing.T) {
 		// create an empty working directory
 		td := t.TempDir()
 		os.MkdirAll(td, 0755)
-		defer testChdir(t, td)()
+		t.Cleanup(testChdir(t, td))
 
 		ui := new(cli.MockUi)
 		c := &ProvidersLockCommand{
@@ -74,7 +74,7 @@ provider "registry.terraform.io/hashicorp/test" {
 func runProviderLockGenericTest(t *testing.T, testDirectory, expected string) {
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath(testDirectory), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	// Our fixture dir has a generic os_arch dir, which we need to customize
 	// to the actual OS/arch where this test is running in order to get the

--- a/internal/command/providers_schema_test.go
+++ b/internal/command/providers_schema_test.go
@@ -50,7 +50,7 @@ func TestProvidersSchema_output(t *testing.T) {
 			td := t.TempDir()
 			inputDir := filepath.Join(fixtureDir, entry.Name())
 			testCopyDir(t, inputDir, td)
-			defer testChdir(t, td)()
+			t.Cleanup(testChdir(t, td))
 
 			providerSource, close := newMockProviderSource(t, map[string][]string{
 				"test": {"1.2.3"},

--- a/internal/command/providers_test.go
+++ b/internal/command/providers_test.go
@@ -80,7 +80,7 @@ func TestProviders_noConfigs(t *testing.T) {
 func TestProviders_modules(t *testing.T) {
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("providers/modules"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	// first run init with mock provider sources to install the module
 	initUi := new(cli.MockUi)

--- a/internal/command/refresh_test.go
+++ b/internal/command/refresh_test.go
@@ -34,7 +34,7 @@ func TestRefresh(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("refresh"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	state := testState()
 	statePath := testStateFile(t, state)
@@ -91,7 +91,7 @@ func TestRefresh_empty(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("refresh-empty"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	p := testProvider()
 	view, done := testView(t)
@@ -125,7 +125,7 @@ func TestRefresh_lockedState(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("refresh"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	state := testState()
 	statePath := testStateFile(t, state)
@@ -234,7 +234,7 @@ func TestRefresh_defaultState(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("refresh"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	originalState := testState()
 
@@ -316,7 +316,7 @@ func TestRefresh_outPath(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("refresh"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	state := testState()
 	statePath := testStateFile(t, state)
@@ -385,7 +385,7 @@ func TestRefresh_var(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("refresh-var"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	state := testState()
 	statePath := testStateFile(t, state)
@@ -422,7 +422,7 @@ func TestRefresh_varFile(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("refresh-var"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	state := testState()
 	statePath := testStateFile(t, state)
@@ -464,7 +464,7 @@ func TestRefresh_varFileDefault(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("refresh-var"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	state := testState()
 	statePath := testStateFile(t, state)
@@ -505,7 +505,7 @@ func TestRefresh_varsUnset(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("refresh-unset-var"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	// Disable test mode so input would be asked
 	test = false
@@ -553,7 +553,7 @@ func TestRefresh_backup(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("refresh"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	state := testState()
 	statePath := testStateFile(t, state)
@@ -638,7 +638,7 @@ func TestRefresh_disableBackup(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("refresh"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	state := testState()
 	statePath := testStateFile(t, state)
@@ -713,7 +713,7 @@ func TestRefresh_displaysOutputs(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("refresh-output"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	state := testState()
 	statePath := testStateFile(t, state)
@@ -760,7 +760,7 @@ func TestRefresh_displaysOutputs(t *testing.T) {
 func TestRefresh_targeted(t *testing.T) {
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("refresh-targeted"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	state := testState()
 	statePath := testStateFile(t, state)
@@ -821,7 +821,7 @@ func TestRefresh_targetFlagsDiags(t *testing.T) {
 		t.Run(target, func(t *testing.T) {
 			td := testTempDir(t)
 			defer os.RemoveAll(td)
-			defer testChdir(t, td)()
+			t.Cleanup(testChdir(t, td))
 
 			view, done := testView(t)
 			c := &RefreshCommand{
@@ -854,7 +854,7 @@ func TestRefresh_warnings(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("apply"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	p := testProvider()
 	p.GetProviderSchemaResponse = refreshFixtureSchema()

--- a/internal/command/show_test.go
+++ b/internal/command/show_test.go
@@ -544,7 +544,7 @@ func TestShow_json_output(t *testing.T) {
 			td := t.TempDir()
 			inputDir := filepath.Join(fixtureDir, entry.Name())
 			testCopyDir(t, inputDir, td)
-			defer testChdir(t, td)()
+			t.Cleanup(testChdir(t, td))
 
 			expectError := strings.Contains(entry.Name(), "error")
 
@@ -659,7 +659,7 @@ func TestShow_json_output_sensitive(t *testing.T) {
 	td := t.TempDir()
 	inputDir := "testdata/show-json-sensitive"
 	testCopyDir(t, inputDir, td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	providerSource, close := newMockProviderSource(t, map[string][]string{"test": {"1.2.3"}})
 	defer close()
@@ -754,7 +754,7 @@ func TestShow_json_output_conditions_refresh_only(t *testing.T) {
 	td := t.TempDir()
 	inputDir := "testdata/show-json/conditions"
 	testCopyDir(t, inputDir, td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	providerSource, close := newMockProviderSource(t, map[string][]string{"test": {"1.2.3"}})
 	defer close()
@@ -863,7 +863,7 @@ func TestShow_json_output_state(t *testing.T) {
 			td := t.TempDir()
 			inputDir := filepath.Join(fixtureDir, entry.Name())
 			testCopyDir(t, inputDir, td)
-			defer testChdir(t, td)()
+			t.Cleanup(testChdir(t, td))
 
 			providerSource, close := newMockProviderSource(t, map[string][]string{
 				"test": {"1.2.3"},
@@ -938,7 +938,7 @@ func TestShow_planWithNonDefaultStateLineage(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("show"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	// Write default state file with a testing lineage ("fake-for-testing")
 	testStateFileDefault(t, testState())
@@ -985,7 +985,7 @@ func TestShow_corruptStatefile(t *testing.T) {
 	td := t.TempDir()
 	inputDir := "testdata/show-corrupt-statefile"
 	testCopyDir(t, inputDir, td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	view, done := testView(t)
 	c := &ShowCommand{

--- a/internal/command/state_identities_test.go
+++ b/internal/command/state_identities_test.go
@@ -193,7 +193,7 @@ func TestStateIdentities_backendDefaultState(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("state-identities-backend-default"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	p := testProvider()
 	ui := cli.NewMockUi()
@@ -243,7 +243,7 @@ func TestStateIdentities_backendOverrideState(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to rename state file: %s", err)
 	}
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	p := testProvider()
 	ui := cli.NewMockUi()
@@ -306,7 +306,7 @@ func TestStateIdentities_modules(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("state-identities-nested-modules"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	p := testProvider()
 	ui := cli.NewMockUi()

--- a/internal/command/state_list_test.go
+++ b/internal/command/state_list_test.go
@@ -101,7 +101,7 @@ func TestStateList_backendDefaultState(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("state-list-backend-default"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	p := testProvider()
 	ui := cli.NewMockUi()
@@ -129,7 +129,7 @@ func TestStateList_backendCustomState(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("state-list-backend-custom"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	p := testProvider()
 	ui := cli.NewMockUi()
@@ -157,7 +157,7 @@ func TestStateList_backendOverrideState(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("state-list-backend-custom"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	p := testProvider()
 	ui := cli.NewMockUi()
@@ -204,7 +204,7 @@ func TestStateList_modules(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("state-list-nested-modules"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	p := testProvider()
 	ui := cli.NewMockUi()

--- a/internal/command/state_mv_test.go
+++ b/internal/command/state_mv_test.go
@@ -175,7 +175,7 @@ func TestStateMv_backupAndBackupOutOptionsWithNonLocalBackend(t *testing.T) {
 	t.Run("backup option specified", func(t *testing.T) {
 		td := t.TempDir()
 		testCopyDir(t, testFixturePath("init-backend-http"), td)
-		defer testChdir(t, td)()
+		t.Cleanup(testChdir(t, td))
 
 		backupPath := filepath.Join(td, "backup")
 
@@ -223,7 +223,7 @@ on a local state file only. You must specify a local state file with the
 	t.Run("backup-out option specified", func(t *testing.T) {
 		td := t.TempDir()
 		testCopyDir(t, testFixturePath("init-backend-http"), td)
-		defer testChdir(t, td)()
+		t.Cleanup(testChdir(t, td))
 
 		backupOutPath := filepath.Join(td, "backup-out")
 
@@ -271,7 +271,7 @@ on a local state file only. You must specify a local state file with the
 	t.Run("backup and backup-out options specified", func(t *testing.T) {
 		td := t.TempDir()
 		testCopyDir(t, testFixturePath("init-backend-http"), td)
-		defer testChdir(t, td)()
+		t.Cleanup(testChdir(t, td))
 
 		backupPath := filepath.Join(td, "backup")
 		backupOutPath := filepath.Join(td, "backup-out")
@@ -321,7 +321,7 @@ on a local state file only. You must specify a local state file with the
 	t.Run("backup option specified with state option", func(t *testing.T) {
 		td := t.TempDir()
 		testCopyDir(t, testFixturePath("init-backend-http"), td)
-		defer testChdir(t, td)()
+		t.Cleanup(testChdir(t, td))
 
 		statePath := testStateFile(t, state)
 		backupPath := filepath.Join(td, "backup")
@@ -361,7 +361,7 @@ on a local state file only. You must specify a local state file with the
 	t.Run("backup-out option specified with state option", func(t *testing.T) {
 		td := t.TempDir()
 		testCopyDir(t, testFixturePath("init-backend-http"), td)
-		defer testChdir(t, td)()
+		t.Cleanup(testChdir(t, td))
 
 		statePath := testStateFile(t, state)
 		backupOutPath := filepath.Join(td, "backup-out")
@@ -852,7 +852,7 @@ match.
 func TestStateMv_explicitWithBackend(t *testing.T) {
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("init-backend"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	backupPath := filepath.Join(td, "backup")
 
@@ -1465,7 +1465,7 @@ func TestStateMv_toNewModule(t *testing.T) {
 func TestStateMv_withinBackend(t *testing.T) {
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("backend-unchanged"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	state := states.BuildState(func(s *states.SyncState) {
 		s.SetResourceInstanceCurrent(
@@ -1544,7 +1544,7 @@ func TestStateMv_withinBackend(t *testing.T) {
 func TestStateMv_fromBackendToLocal(t *testing.T) {
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("backend-unchanged"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	state := states.NewState()
 	state.Module(addrs.RootModuleInstance).SetResourceInstanceCurrent(
@@ -1711,7 +1711,7 @@ func TestStateMv_checkRequiredVersion(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("command-check-required-version"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	state := states.BuildState(func(s *states.SyncState) {
 		s.SetResourceInstanceCurrent(

--- a/internal/command/state_pull_test.go
+++ b/internal/command/state_pull_test.go
@@ -16,7 +16,7 @@ func TestStatePull(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("state-pull-backend"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	expected, err := ioutil.ReadFile("local-state.tfstate")
 	if err != nil {
@@ -70,7 +70,7 @@ func TestStatePull_checkRequiredVersion(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("command-check-required-version"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	p := testProvider()
 	ui := cli.NewMockUi()

--- a/internal/command/state_push_test.go
+++ b/internal/command/state_push_test.go
@@ -18,7 +18,7 @@ func TestStatePush_empty(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("state-push-good"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	expected := testStateRead(t, "replace.tfstate")
 
@@ -48,7 +48,7 @@ func TestStatePush_lockedState(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("state-push-good"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	p := testProvider()
 	ui := new(cli.MockUi)
@@ -80,7 +80,7 @@ func TestStatePush_replaceMatch(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("state-push-replace-match"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	expected := testStateRead(t, "replace.tfstate")
 
@@ -110,7 +110,7 @@ func TestStatePush_replaceMatchStdin(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("state-push-replace-match"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	expected := testStateRead(t, "replace.tfstate")
 
@@ -147,7 +147,7 @@ func TestStatePush_lineageMismatch(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("state-push-bad-lineage"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	expected := testStateRead(t, "local-state.tfstate")
 
@@ -177,7 +177,7 @@ func TestStatePush_serialNewer(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("state-push-serial-newer"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	expected := testStateRead(t, "local-state.tfstate")
 
@@ -207,7 +207,7 @@ func TestStatePush_serialOlder(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("state-push-serial-older"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	expected := testStateRead(t, "replace.tfstate")
 
@@ -236,7 +236,7 @@ func TestStatePush_serialOlder(t *testing.T) {
 func TestStatePush_forceRemoteState(t *testing.T) {
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("inmem-backend"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 	defer inmem.Reset()
 
 	s := states.NewState()
@@ -290,7 +290,7 @@ func TestStatePush_checkRequiredVersion(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("command-check-required-version"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	p := testProvider()
 	ui := cli.NewMockUi()

--- a/internal/command/state_replace_provider_test.go
+++ b/internal/command/state_replace_provider_test.go
@@ -301,7 +301,7 @@ func TestStateReplaceProvider_checkRequiredVersion(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("command-check-required-version"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	state := states.BuildState(func(s *states.SyncState) {
 		s.SetResourceInstanceCurrent(

--- a/internal/command/state_rm_test.go
+++ b/internal/command/state_rm_test.go
@@ -381,7 +381,7 @@ func TestStateRm_noState(t *testing.T) {
 func TestStateRm_needsInit(t *testing.T) {
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("backend-change"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	p := testProvider()
 	ui := new(cli.MockUi)
@@ -409,7 +409,7 @@ func TestStateRm_needsInit(t *testing.T) {
 func TestStateRm_backendState(t *testing.T) {
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("backend-unchanged"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	state := states.BuildState(func(s *states.SyncState) {
 		s.SetResourceInstanceCurrent(
@@ -490,7 +490,7 @@ func TestStateRm_checkRequiredVersion(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("command-check-required-version"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	state := states.BuildState(func(s *states.SyncState) {
 		s.SetResourceInstanceCurrent(

--- a/internal/command/taint_test.go
+++ b/internal/command/taint_test.go
@@ -493,7 +493,7 @@ func TestTaint_checkRequiredVersion(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("command-check-required-version"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	// Write the temp state
 	state := states.BuildState(func(s *states.SyncState) {

--- a/internal/command/test_test.go
+++ b/internal/command/test_test.go
@@ -380,7 +380,7 @@ func TestTest_Runs(t *testing.T) {
 
 			td := t.TempDir()
 			testCopyDir(t, testFixturePath(path.Join("test", file)), td)
-			defer testChdir(t, td)()
+			t.Cleanup(testChdir(t, td))
 
 			store := &testing_command.ResourceStore{
 				Data: make(map[string]cty.Value),
@@ -494,7 +494,7 @@ func TestTest_Runs(t *testing.T) {
 func TestTest_Interrupt(t *testing.T) {
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath(path.Join("test", "with_interrupt")), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	provider := testing_command.NewProvider(nil)
 	view, done := testView(t)
@@ -526,7 +526,7 @@ func TestTest_Interrupt(t *testing.T) {
 func TestTest_DestroyFail(t *testing.T) {
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath(path.Join("test", "destroy_fail")), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	provider := testing_command.NewProvider(nil)
 	providerSource, close := newMockProviderSource(t, map[string][]string{
@@ -625,7 +625,7 @@ main.tftest.hcl/single, and they need to be cleaned up manually:
 func TestTest_SharedState_Order(t *testing.T) {
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath(path.Join("test", "shared_state")), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	provider := testing_command.NewProvider(nil)
 	providerSource, close := newMockProviderSource(t, map[string][]string{
@@ -697,7 +697,7 @@ func TestTest_SharedState_Order(t *testing.T) {
 func TestTest_Parallel_Divided_Order(t *testing.T) {
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath(path.Join("test", "parallel_divided")), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	provider := testing_command.NewProvider(nil)
 	providerSource, close := newMockProviderSource(t, map[string][]string{
@@ -774,7 +774,7 @@ func TestTest_Parallel_Divided_Order(t *testing.T) {
 func TestTest_Parallel(t *testing.T) {
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath(path.Join("test", "parallel")), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	provider := testing_command.NewProvider(nil)
 	providerSource, close := newMockProviderSource(t, map[string][]string{
@@ -1127,7 +1127,7 @@ func TestTest_ParallelTeardown(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			_, td, closer := testModuleInline(t, tt.sources)
 			defer closer()
-			defer testChdir(t, td)()
+			t.Cleanup(testChdir(t, td))
 
 			providerSource, close := newMockProviderSource(t, map[string][]string{
 				"test": {"1.0.0"},
@@ -1212,7 +1212,7 @@ func TestTest_ParallelTeardown(t *testing.T) {
 func TestTest_InterruptSkipsRemaining(t *testing.T) {
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath(path.Join("test", "with_interrupt_and_additional_file")), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	provider := testing_command.NewProvider(nil)
 	view, done := testView(t)
@@ -1244,7 +1244,7 @@ func TestTest_InterruptSkipsRemaining(t *testing.T) {
 func TestTest_DoubleInterrupt(t *testing.T) {
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath(path.Join("test", "with_double_interrupt")), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	provider := testing_command.NewProvider(nil)
 	view, done := testView(t)
@@ -1293,7 +1293,7 @@ test:
 func TestTest_ProviderAlias(t *testing.T) {
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath(path.Join("test", "with_provider_alias")), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	store := &testing_command.ResourceStore{
 		Data: make(map[string]cty.Value),
@@ -1363,7 +1363,7 @@ func TestTest_ProviderAlias(t *testing.T) {
 func TestTest_ComplexCondition(t *testing.T) {
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath(path.Join("test", "complex_condition")), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	provider := testing_command.NewProvider(nil)
 
@@ -1533,7 +1533,7 @@ expected to fail
 func TestTest_ComplexConditionVerbose(t *testing.T) {
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath(path.Join("test", "complex_condition")), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	provider := testing_command.NewProvider(nil)
 
@@ -1852,7 +1852,7 @@ expected to fail
 func TestTest_ModuleDependencies(t *testing.T) {
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath(path.Join("test", "with_setup_module")), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	// Our two providers will share a common set of values to make things
 	// easier.
@@ -1943,7 +1943,7 @@ func TestTest_ModuleDependencies(t *testing.T) {
 func TestTest_CatchesErrorsBeforeDestroy(t *testing.T) {
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath(path.Join("test", "invalid_default_state")), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	provider := testing_command.NewProvider(nil)
 	view, done := testView(t)
@@ -2000,7 +2000,7 @@ variable into a "variables" block within the test file or run block.
 func TestTest_Verbose(t *testing.T) {
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath(path.Join("test", "plan_then_apply")), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	provider := testing_command.NewProvider(nil)
 	view, done := testView(t)
@@ -2190,7 +2190,7 @@ can remove the provider configuration again.
 
 			td := t.TempDir()
 			testCopyDir(t, testFixturePath(path.Join("test", file)), td)
-			defer testChdir(t, td)()
+			t.Cleanup(testChdir(t, td))
 
 			provider := testing_command.NewProvider(nil)
 
@@ -2257,7 +2257,7 @@ can remove the provider configuration again.
 func TestTest_NestedSetupModules(t *testing.T) {
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath(path.Join("test", "with_nested_setup_modules")), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	provider := testing_command.NewProvider(nil)
 
@@ -2312,7 +2312,7 @@ func TestTest_NestedSetupModules(t *testing.T) {
 func TestTest_StatePropagation(t *testing.T) {
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath(path.Join("test", "state_propagation")), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	provider := testing_command.NewProvider(nil)
 
@@ -2451,7 +2451,7 @@ Success! 5 passed, 0 failed.
 func TestTest_OnlyExternalModules(t *testing.T) {
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath(path.Join("test", "only_modules")), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	provider := testing_command.NewProvider(nil)
 
@@ -2520,7 +2520,7 @@ Success! 2 passed, 0 failed.
 func TestTest_PartialUpdates(t *testing.T) {
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath(path.Join("test", "partial_updates")), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	provider := testing_command.NewProvider(nil)
 	view, done := testView(t)
@@ -2587,7 +2587,7 @@ Success! 2 passed, 0 failed.
 func TestTest_InvalidWarningsInCleanup(t *testing.T) {
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath(path.Join("test", "invalid-cleanup-warnings")), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	provider := testing_command.NewProvider(nil)
 	providerSource, close := newMockProviderSource(t, map[string][]string{
@@ -2663,7 +2663,7 @@ Success! 1 passed, 0 failed.
 func TestTest_BadReferences(t *testing.T) {
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath(path.Join("test", "bad-references")), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	provider := testing_command.NewProvider(nil)
 	view, done := testView(t)
@@ -2735,7 +2735,7 @@ The input variable "default" does not exist within this test file.
 func TestTest_UndefinedVariables(t *testing.T) {
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath(path.Join("test", "variables_undefined_in_config")), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	provider := testing_command.NewProvider(nil)
 	view, done := testView(t)
@@ -2788,7 +2788,7 @@ can be declared with a variable "input" {} block.
 func TestTest_VariablesInProviders(t *testing.T) {
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath(path.Join("test", "provider_vars")), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	provider := testing_command.NewProvider(nil)
 	view, done := testView(t)
@@ -2827,7 +2827,7 @@ Success! 1 passed, 0 failed.
 func TestTest_ExpectedFailuresDuringPlanning(t *testing.T) {
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath(path.Join("test", "expected_failures_during_planning")), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	provider := testing_command.NewProvider(nil)
 	view, done := testView(t)
@@ -2946,7 +2946,7 @@ func TestTest_MissingExpectedFailuresDuringApply(t *testing.T) {
 	// This lets subsequent runs continue to execute and the file to be marked as failed.
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath(path.Join("test", "expect_failures_during_apply")), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	provider := testing_command.NewProvider(nil)
 	view, done := testView(t)
@@ -3137,7 +3137,7 @@ operation, and the specified output value is only known after apply.
 		t.Run(name, func(t *testing.T) {
 			td := t.TempDir()
 			testCopyDir(t, testFixturePath(path.Join("test", name)), td)
-			defer testChdir(t, td)()
+			t.Cleanup(testChdir(t, td))
 
 			provider := testing_command.NewProvider(nil)
 			view, done := testView(t)
@@ -3175,7 +3175,7 @@ operation, and the specified output value is only known after apply.
 func TestTest_SensitiveInputValues(t *testing.T) {
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath(path.Join("test", "sensitive_input_values")), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	provider := testing_command.NewProvider(nil)
 
@@ -3321,7 +3321,7 @@ expected to fail
 func TestTest_LongRunningTest(t *testing.T) {
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath(path.Join("test", "long_running")), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	provider := testing_command.NewProvider(nil)
 	view, done := testView(t)
@@ -3363,7 +3363,7 @@ Success! 1 passed, 0 failed.
 func TestTest_LongRunningTestJSON(t *testing.T) {
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath(path.Join("test", "long_running")), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	provider := testing_command.NewProvider(nil)
 	view, done := testView(t)
@@ -3450,7 +3450,7 @@ func TestTest_LongRunningTestJSON(t *testing.T) {
 func TestTest_InvalidOverrides(t *testing.T) {
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath(path.Join("test", "invalid-overrides")), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	provider := testing_command.NewProvider(nil)
 
@@ -3550,7 +3550,7 @@ Success! 2 passed, 0 failed.
 func TestTest_InvalidConfig(t *testing.T) {
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath(path.Join("test", "invalid_config")), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	provider := testing_command.NewProvider(nil)
 
@@ -3631,7 +3631,7 @@ permission denied..
 func TestTest_RunBlocksInProviders(t *testing.T) {
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath(path.Join("test", "provider_runs")), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	provider := testing_command.NewProvider(nil)
 
@@ -3698,7 +3698,7 @@ Success! 2 passed, 0 failed.
 func TestTest_RunBlocksInProviders_BadReferences(t *testing.T) {
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath(path.Join("test", "provider_runs_invalid")), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	store := &testing_command.ResourceStore{
 		Data: make(map[string]cty.Value),
@@ -3816,7 +3816,7 @@ func TestTest_JUnitOutput(t *testing.T) {
 			td := t.TempDir()
 			testPath := path.Join("test", tc.path)
 			testCopyDir(t, testFixturePath(testPath), td)
-			defer testChdir(t, td)()
+			t.Cleanup(testChdir(t, td))
 
 			provider := testing_command.NewProvider(nil)
 			view, done := testView(t)

--- a/internal/command/unlock_test.go
+++ b/internal/command/unlock_test.go
@@ -18,7 +18,7 @@ import (
 func TestUnlock(t *testing.T) {
 	td := t.TempDir()
 	os.MkdirAll(td, 0755)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	// Write the legacy state
 	statePath := DefaultStateFilename
@@ -70,7 +70,7 @@ func TestUnlock_inmemBackend(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("backend-inmem-locked"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 	defer inmem.Reset()
 
 	// init backend

--- a/internal/command/validate_test.go
+++ b/internal/command/validate_test.go
@@ -73,7 +73,7 @@ func TestValidateCommandWithTfvarsFile(t *testing.T) {
 	// requires scanning the current working directory by validate command.
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("validate-valid/with-tfvars-file"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	view, done := testView(t)
 	c := &ValidateCommand{
@@ -260,7 +260,7 @@ func TestValidateWithInvalidTestModule(t *testing.T) {
 
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath(path.Join("test", "invalid-module")), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	streams, done := terminal.StreamsForTesting(t)
 	view := views.NewView(streams)
@@ -317,7 +317,7 @@ func TestValidateWithInvalidOverrides(t *testing.T) {
 
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath(path.Join("test", "invalid-overrides")), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	streams, done := terminal.StreamsForTesting(t)
 	view := views.NewView(streams)

--- a/internal/command/version_test.go
+++ b/internal/command/version_test.go
@@ -20,7 +20,7 @@ func TestVersionCommand_implements(t *testing.T) {
 
 func TestVersion(t *testing.T) {
 	td := t.TempDir()
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	// We'll create a fixed dependency lock file in our working directory
 	// so we can verify that the version command shows the information
@@ -114,7 +114,7 @@ func TestVersion_outdated(t *testing.T) {
 
 func TestVersion_json(t *testing.T) {
 	td := t.TempDir()
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	ui := cli.NewMockUi()
 	meta := Meta{

--- a/internal/command/workspace_command_test.go
+++ b/internal/command/workspace_command_test.go
@@ -25,7 +25,7 @@ func TestWorkspace_createAndChange(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	os.MkdirAll(td, 0755)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	newCmd := &WorkspaceNewCommand{}
 
@@ -66,7 +66,7 @@ func TestWorkspace_cannotCreateOrSelectEmptyStringWorkspace(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	os.MkdirAll(td, 0755)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	newCmd := &WorkspaceNewCommand{}
 
@@ -111,7 +111,7 @@ func TestWorkspace_createAndList(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	os.MkdirAll(td, 0755)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	// make sure a vars file doesn't interfere
 	err := ioutil.WriteFile(
@@ -159,7 +159,7 @@ func TestWorkspace_createAndShow(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	os.MkdirAll(td, 0755)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	// make sure a vars file doesn't interfere
 	err := ioutil.WriteFile(
@@ -227,7 +227,7 @@ func TestWorkspace_createInvalid(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	os.MkdirAll(td, 0755)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	envs := []string{"test_a*", "test_b/foo", "../../../test_c", "好_d"}
 
@@ -264,7 +264,7 @@ func TestWorkspace_createInvalid(t *testing.T) {
 func TestWorkspace_createWithState(t *testing.T) {
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("inmem-backend"), td)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 	defer inmem.Reset()
 
 	// init the backend
@@ -334,7 +334,7 @@ func TestWorkspace_createWithState(t *testing.T) {
 func TestWorkspace_delete(t *testing.T) {
 	td := t.TempDir()
 	os.MkdirAll(td, 0755)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	// create the workspace directories
 	if err := os.MkdirAll(filepath.Join(local.DefaultWorkspaceDir, "test"), 0755); err != nil {
@@ -389,7 +389,7 @@ func TestWorkspace_delete(t *testing.T) {
 func TestWorkspace_deleteInvalid(t *testing.T) {
 	td := t.TempDir()
 	os.MkdirAll(td, 0755)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	// choose an invalid workspace name
 	workspace := "test workspace"
@@ -421,7 +421,7 @@ func TestWorkspace_deleteInvalid(t *testing.T) {
 func TestWorkspace_deleteRejectsEmptyString(t *testing.T) {
 	td := t.TempDir()
 	os.MkdirAll(td, 0755)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	// Empty string identifier for workspace
 	workspace := ""
@@ -450,7 +450,7 @@ func TestWorkspace_deleteRejectsEmptyString(t *testing.T) {
 func TestWorkspace_deleteWithState(t *testing.T) {
 	td := t.TempDir()
 	os.MkdirAll(td, 0755)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	// create the workspace directories
 	if err := os.MkdirAll(filepath.Join(local.DefaultWorkspaceDir, "test"), 0755); err != nil {
@@ -526,7 +526,7 @@ func TestWorkspace_deleteWithState(t *testing.T) {
 func TestWorkspace_cannotDeleteDefaultWorkspace(t *testing.T) {
 	td := t.TempDir()
 	os.MkdirAll(td, 0755)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	// Create an empty default state, i.e. create default workspace.
 	originalStateFile := &statefile.File{
@@ -614,7 +614,7 @@ func TestWorkspace_selectWithOrCreate(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	os.MkdirAll(td, 0755)
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	selectCmd := &WorkspaceSelectCommand{}
 

--- a/internal/stacks/stackmigrate/meta_test.go
+++ b/internal/stacks/stackmigrate/meta_test.go
@@ -58,7 +58,7 @@ func TestMeta_Workspace_override(t *testing.T) {
 // existing workflows with invalid workspace names.
 func TestMeta_Workspace_invalidSelected(t *testing.T) {
 	td := t.TempDir()
-	defer testChdir(t, td)()
+	t.Cleanup(testChdir(t, td))
 
 	// this is an invalid workspace name
 	workspace := "test workspace"


### PR DESCRIPTION
Lots of tests in the command package were created before the standard library included `t.Cleanup`. Instead the tests were written using `defer`.

[This blog post](https://brandur.org/fragments/go-prefer-t-cleanup-with-parallel-subtests) describes the benefits of using t.Cleanup versus defer, but tl;dr is that t.Cleanup behaves as expected in the context of a test that has multiple cases and uses t.Parrallel. In that context `defer`-ed functions can be executed at unexpected times.

By replacing the use of defer I'm hoping to stop this being proliferated by copy-pasting of tests, and this will prevent any possible bugs being introduced in future.



The diffs in this PR are wide-reaching but are all the same change:

```diff
- 	defer testChdir(t, td)()
+ 	t.Cleanup(testChdir(t, td))
```

There are still places that use defer in the code, but I can change that in a separate PR. I wanted to keep this PR easier to review by having only 1 type of diff, even if it is occurring a lot.


## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

N/A

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
