### PR TITLE
Replace custom `testCwd` function with standard `testing` library

### DIFF
--- a/internal/command/apply_test.go
+++ b/internal/command/apply_test.go
@@ -782,7 +782,8 @@ func TestApply_plan_remoteState(t *testing.T) {
 	// Disable test mode so input would be asked
 	test = false
 	defer func() { test = true }()
-	tmp := testCwd(t)
+	tmp := t.TempDir()
+	t.Chdir(tmp)
 	remoteStatePath := filepath.Join(tmp, DefaultDataDir, DefaultStateFilename)
 	if err := os.MkdirAll(filepath.Dir(remoteStatePath), 0755); err != nil {
 		t.Fatalf("err: %s", err)

--- a/internal/command/command_test.go
+++ b/internal/command/command_test.go
@@ -641,32 +641,6 @@ func testChdir(t *testing.T, new string) func() {
 	}
 }
 
-// testCwd is used to change the current working directory into a temporary
-// directory. The cleanup is performed automatically after the test and all its
-// subtests complete.
-func testCwd(t *testing.T) string {
-	t.Helper()
-
-	tmp := t.TempDir()
-
-	cwd, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-
-	if err := os.Chdir(tmp); err != nil {
-		t.Fatalf("err: %v", err)
-	}
-
-	t.Cleanup(func() {
-		if err := os.Chdir(cwd); err != nil {
-			t.Fatalf("err: %v", err)
-		}
-	})
-
-	return tmp
-}
-
 // testStdinPipe changes os.Stdin to be a pipe that sends the data from
 // the reader before closing the pipe.
 //

--- a/internal/command/command_test.go
+++ b/internal/command/command_test.go
@@ -463,7 +463,14 @@ func testStateFile(t *testing.T, s *states.State) string {
 }
 
 // testStateFileDefault writes the state out to the default statefile
-// in the cwd. Use `testCwd` to change into a temp cwd.
+// in the cwd.
+//
+// Before calling this, use:
+//
+//	tmp := t.TempDir()
+//	t.Chdir(tmp)
+//
+// to change into a temp working directory
 func testStateFileDefault(t *testing.T, s *states.State) {
 	t.Helper()
 
@@ -479,7 +486,14 @@ func testStateFileDefault(t *testing.T, s *states.State) {
 }
 
 // testStateFileWorkspaceDefault writes the state out to the default statefile
-// for the given workspace in the cwd. Use `testCwd` to change into a temp cwd.
+// for the given workspace in the cwd.
+//
+// Before calling this, use:
+//
+//	tmp := t.TempDir()
+//	t.Chdir(tmp)
+//
+// to change into a temp working directory
 func testStateFileWorkspaceDefault(t *testing.T, workspace string, s *states.State) string {
 	t.Helper()
 
@@ -504,7 +518,14 @@ func testStateFileWorkspaceDefault(t *testing.T, workspace string, s *states.Sta
 }
 
 // testStateFileRemote writes the state out to the remote statefile
-// in the cwd. Use `testCwd` to change into a temp cwd.
+// in the cwd.
+//
+// Before calling this, use:
+//
+//	tmp := t.TempDir()
+//	t.Chdir(tmp)
+//
+// to change into a temp working directory
 func testStateFileRemote(t *testing.T, s *workdir.BackendStateFile) string {
 	t.Helper()
 

--- a/internal/command/console_test.go
+++ b/internal/command/console_test.go
@@ -24,7 +24,8 @@ import (
 // This file still contains some tests using the stdin-based input.
 
 func TestConsole_basic(t *testing.T) {
-	testCwd(t)
+	tmp := t.TempDir()
+	t.Chdir(tmp)
 
 	p := testProvider()
 	ui := cli.NewMockUi()

--- a/internal/command/graph_test.go
+++ b/internal/command/graph_test.go
@@ -292,7 +292,8 @@ digraph G {
 }
 
 func TestGraph_applyPhaseSavedPlan(t *testing.T) {
-	testCwd(t)
+	tmp := t.TempDir()
+	t.Chdir(tmp)
 
 	emptyObj, err := plans.NewDynamicValue(cty.EmptyObjectVal, cty.EmptyObject)
 	if err != nil {

--- a/internal/command/plan_test.go
+++ b/internal/command/plan_test.go
@@ -85,7 +85,8 @@ func TestPlan_lockedState(t *testing.T) {
 }
 
 func TestPlan_plan(t *testing.T) {
-	testCwd(t)
+	tmp := t.TempDir()
+	t.Chdir(tmp)
 
 	planPath := testPlanFileNoop(t)
 

--- a/internal/command/show_test.go
+++ b/internal/command/show_test.go
@@ -73,7 +73,8 @@ func TestShow_noArgsNoState(t *testing.T) {
 
 func TestShow_noArgsWithState(t *testing.T) {
 	// Get a temp cwd
-	testCwd(t)
+	tmp := t.TempDir()
+	t.Chdir(tmp)
 	// Create the default state
 	testStateFileDefault(t, testState())
 

--- a/internal/command/state_identities_test.go
+++ b/internal/command/state_identities_test.go
@@ -285,7 +285,8 @@ func TestStateIdentities_backendOverrideState(t *testing.T) {
 }
 
 func TestStateIdentities_noState(t *testing.T) {
-	testCwd(t)
+	tmp := t.TempDir()
+	t.Chdir(tmp)
 
 	p := testProvider()
 	ui := cli.NewMockUi()

--- a/internal/command/state_list_test.go
+++ b/internal/command/state_list_test.go
@@ -183,7 +183,8 @@ func TestStateList_backendOverrideState(t *testing.T) {
 }
 
 func TestStateList_noState(t *testing.T) {
-	testCwd(t)
+	tmp := t.TempDir()
+	t.Chdir(tmp)
 
 	p := testProvider()
 	ui := cli.NewMockUi()

--- a/internal/command/state_mv_test.go
+++ b/internal/command/state_mv_test.go
@@ -1137,7 +1137,8 @@ func TestStateMv_stateOutExisting(t *testing.T) {
 }
 
 func TestStateMv_noState(t *testing.T) {
-	testCwd(t)
+	tmp := t.TempDir()
+	t.Chdir(tmp)
 
 	p := testProvider()
 	ui := new(cli.MockUi)

--- a/internal/command/state_pull_test.go
+++ b/internal/command/state_pull_test.go
@@ -44,7 +44,8 @@ func TestStatePull(t *testing.T) {
 }
 
 func TestStatePull_noState(t *testing.T) {
-	testCwd(t)
+	tmp := t.TempDir()
+	t.Chdir(tmp)
 
 	p := testProvider()
 	ui := cli.NewMockUi()

--- a/internal/command/state_rm_test.go
+++ b/internal/command/state_rm_test.go
@@ -357,7 +357,8 @@ func TestStateRm_backupExplicit(t *testing.T) {
 }
 
 func TestStateRm_noState(t *testing.T) {
-	testCwd(t)
+	tmp := t.TempDir()
+	t.Chdir(tmp)
 
 	p := testProvider()
 	ui := new(cli.MockUi)

--- a/internal/command/state_show_test.go
+++ b/internal/command/state_show_test.go
@@ -154,7 +154,8 @@ func TestStateShow_multi(t *testing.T) {
 }
 
 func TestStateShow_noState(t *testing.T) {
-	testCwd(t)
+	tmp := t.TempDir()
+	t.Chdir(tmp)
 
 	p := testProvider()
 	streams, done := terminal.StreamsForTesting(t)

--- a/internal/command/state_test.go
+++ b/internal/command/state_test.go
@@ -28,7 +28,8 @@ func testStateBackups(t *testing.T, dir string) []string {
 }
 
 func TestStateDefaultBackupExtension(t *testing.T) {
-	testCwd(t)
+	tmp := t.TempDir()
+	t.Chdir(tmp)
 
 	s, err := (&StateMeta{}).State()
 	if err != nil {

--- a/internal/command/taint_test.go
+++ b/internal/command/taint_test.go
@@ -105,7 +105,8 @@ func TestTaint_lockedState(t *testing.T) {
 
 func TestTaint_backup(t *testing.T) {
 	// Get a temp cwd
-	testCwd(t)
+	tmp := t.TempDir()
+	t.Chdir(tmp)
 
 	// Write the temp state
 	state := states.BuildState(func(s *states.SyncState) {
@@ -149,7 +150,8 @@ func TestTaint_backup(t *testing.T) {
 
 func TestTaint_backupDisable(t *testing.T) {
 	// Get a temp cwd
-	testCwd(t)
+	tmp := t.TempDir()
+	t.Chdir(tmp)
 
 	// Write the temp state
 	state := states.BuildState(func(s *states.SyncState) {
@@ -216,7 +218,8 @@ func TestTaint_badState(t *testing.T) {
 
 func TestTaint_defaultState(t *testing.T) {
 	// Get a temp cwd
-	testCwd(t)
+	tmp := t.TempDir()
+	t.Chdir(tmp)
 
 	// Write the temp state
 	state := states.BuildState(func(s *states.SyncState) {
@@ -259,7 +262,8 @@ func TestTaint_defaultState(t *testing.T) {
 
 func TestTaint_defaultWorkspaceState(t *testing.T) {
 	// Get a temp cwd
-	testCwd(t)
+	tmp := t.TempDir()
+	t.Chdir(tmp)
 
 	state := states.BuildState(func(s *states.SyncState) {
 		s.SetResourceInstanceCurrent(
@@ -391,7 +395,8 @@ because -allow-missing was set.
 
 func TestTaint_stateOut(t *testing.T) {
 	// Get a temp cwd
-	testCwd(t)
+	tmp := t.TempDir()
+	t.Chdir(tmp)
 
 	// Write the temp state
 	state := states.BuildState(func(s *states.SyncState) {

--- a/internal/command/untaint_test.go
+++ b/internal/command/untaint_test.go
@@ -109,7 +109,8 @@ func TestUntaint_lockedState(t *testing.T) {
 
 func TestUntaint_backup(t *testing.T) {
 	// Get a temp cwd
-	testCwd(t)
+	tmp := t.TempDir()
+	t.Chdir(tmp)
 
 	// Write the temp state
 	state := states.BuildState(func(s *states.SyncState) {
@@ -164,7 +165,8 @@ test_instance.foo:
 
 func TestUntaint_backupDisable(t *testing.T) {
 	// Get a temp cwd
-	testCwd(t)
+	tmp := t.TempDir()
+	t.Chdir(tmp)
 
 	// Write the temp state
 	state := states.BuildState(func(s *states.SyncState) {
@@ -235,7 +237,8 @@ func TestUntaint_badState(t *testing.T) {
 
 func TestUntaint_defaultState(t *testing.T) {
 	// Get a temp cwd
-	testCwd(t)
+	tmp := t.TempDir()
+	t.Chdir(tmp)
 
 	// Write the temp state
 	state := states.BuildState(func(s *states.SyncState) {
@@ -282,7 +285,8 @@ test_instance.foo:
 
 func TestUntaint_defaultWorkspaceState(t *testing.T) {
 	// Get a temp cwd
-	testCwd(t)
+	tmp := t.TempDir()
+	t.Chdir(tmp)
 
 	// Write the temp state
 	state := states.BuildState(func(s *states.SyncState) {
@@ -419,7 +423,8 @@ because -allow-missing was set.
 
 func TestUntaint_stateOut(t *testing.T) {
 	// Get a temp cwd
-	testCwd(t)
+	tmp := t.TempDir()
+	t.Chdir(tmp)
 
 	// Write the temp state
 	state := states.BuildState(func(s *states.SyncState) {


### PR DESCRIPTION
Replaces old custom code:

```go
func testCwd(t *testing.T) string {
	t.Helper()

	tmp := t.TempDir()

	cwd, err := os.Getwd()
	if err != nil {
		t.Fatalf("err: %v", err)
	}

	if err := os.Chdir(tmp); err != nil {
		t.Fatalf("err: %v", err)
	}

	t.Cleanup(func() {
		if err := os.Chdir(cwd); err != nil {
			t.Fatalf("err: %v", err)
		}
	})

	return tmp
}
```

with the standard library:

```go
	tmp := t.TempDir()
	t.Chdir(tmp)
```

We don't need a function to make a temp dir and temporarily change directory into it - this is 2 lines with the testing library.

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.14.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
