### PR TITLE
Add planned actions to planfile

### DIFF
--- a/internal/plans/action_invocation.go
+++ b/internal/plans/action_invocation.go
@@ -5,7 +5,6 @@ package plans
 
 import (
 	"github.com/hashicorp/terraform/internal/addrs"
-	"github.com/hashicorp/terraform/internal/providers"
 )
 
 type ActionInvocationInstance struct {
@@ -20,7 +19,7 @@ type ActionInvocationInstance struct {
 // Encode produces a variant of the receiver that has its change values
 // serialized so it can be written to a plan file. Pass the implied type of the
 // corresponding resource type schema for correct operation.
-func (ai *ActionInvocationInstance) Encode(schema providers.Schema) (*ActionInvocationInstanceSrc, error) {
+func (ai *ActionInvocationInstance) Encode() (*ActionInvocationInstanceSrc, error) {
 	return &ActionInvocationInstanceSrc{
 		Addr:         ai.Addr,
 		ProviderAddr: ai.ProviderAddr,

--- a/internal/plans/changes.go
+++ b/internal/plans/changes.go
@@ -98,6 +98,14 @@ func (c *Changes) Encode(schemas *schemarepo.Schemas) (*ChangesSrc, error) {
 		changesSrc.Queries = append(changesSrc.Queries, rcs)
 	}
 
+	for _, ai := range c.ActionInvocations {
+		a, err := ai.Encode()
+		if err != nil {
+			return changesSrc, fmt.Errorf("Changes.Encode: %w", err)
+		}
+		changesSrc.ActionInvocations = append(changesSrc.ActionInvocations, a)
+	}
+
 	for _, ocs := range c.Outputs {
 		oc, err := ocs.Encode()
 		if err != nil {

--- a/internal/plans/changes_src.go
+++ b/internal/plans/changes_src.go
@@ -29,7 +29,7 @@ type ChangesSrc struct {
 
 	// ActionInvocations tracks planned action invocations, which may have
 	// embedded resource instance changes.
-	Actions []*ActionInvocationInstanceSrc
+	ActionInvocations []*ActionInvocationInstanceSrc
 
 	// Outputs tracks planned changes output values.
 	//
@@ -159,7 +159,7 @@ func (c *ChangesSrc) Decode(schemas *schemarepo.Schemas) (*Changes, error) {
 		changes.Queries = append(changes.Queries, query)
 	}
 
-	for _, ais := range c.Actions {
+	for _, ais := range c.ActionInvocations {
 		p, ok := schemas.Providers[ais.ProviderAddr.Provider]
 		if !ok {
 			return nil, fmt.Errorf("ChangesSrc.Decode: missing provider %s for action %s", ais.ProviderAddr, ais.Addr)
@@ -557,7 +557,7 @@ func (c *ChangesSrc) AppendActionInvocationInstanceChange(action *ActionInvocati
 	}
 
 	a := action.DeepCopy()
-	c.Actions = append(c.Actions, a)
+	c.ActionInvocations = append(c.ActionInvocations, a)
 }
 
 type ActionInvocationInstanceSrc struct {

--- a/internal/terraform/node_resource_plan_instance.go
+++ b/internal/terraform/node_resource_plan_instance.go
@@ -639,6 +639,11 @@ func (n *NodePlannableResourceInstance) planActionTriggers(ctx EvalContext, chan
 				if diags.HasErrors() {
 					return diags
 				}
+
+				ctx.Changes().AppendActionInvocation(&plans.ActionInvocationInstance{
+					Addr:         absActionAddr,
+					ProviderAddr: actionInstance.ProviderAddr,
+				})
 			}
 		}
 	}


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->



Small PR to integrate the work of https://github.com/hashicorp/terraform/pull/37320 and https://github.com/hashicorp/terraform/pull/37316


<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Closes [TF-27456](https://hashicorp.atlassian.net/browse/TF-27456)

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.14.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.

[TF-27456]: https://hashicorp.atlassian.net/browse/TF-27456?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ