### PR TITLE
Improve line-based list result output

### DIFF
--- a/internal/command/views/hook_ui.go
+++ b/internal/command/views/hook_ui.go
@@ -514,17 +514,28 @@ func (h *UiHook) PreListQuery(id terraform.HookResourceIdentity, input_config ct
 func (h *UiHook) PostListQuery(id terraform.HookResourceIdentity, results plans.QueryResults) (terraform.HookAction, error) {
 	addr := id.Addr
 	data := results.Value.GetAttr("data")
+
+	identities := make([]string, 0, data.LengthInt())
+	displayNames := make([]string, 0, data.LengthInt())
+	maxIdentityLen := 0
 	for it := data.ElementIterator(); it.Next(); {
 		_, value := it.Element()
+		identity := tfdiags.ObjectToString(value.GetAttr("identity"))
+		if len(identity) > maxIdentityLen {
+			maxIdentityLen = len(identity)
+		}
+		identities = append(identities, identity)
 
-		h.println(fmt.Sprintf(
-			"%s\t%s\t%s",
-			addr.String(),
-			// TODO maybe deduplicate common identity attributes?
-			tfdiags.ObjectToString(value.GetAttr("identity")),
-			value.GetAttr("display_name").AsString(),
-		))
+		displayNames = append(displayNames, value.GetAttr("display_name").AsString())
 	}
+
+	result := strings.Builder{}
+	for i, identity := range identities {
+		result.WriteString(fmt.Sprintf("%s   %-*s   %s\n", addr.String(), maxIdentityLen, identity, displayNames[i]))
+	}
+
+	h.println(result.String())
+
 	return terraform.HookActionContinue, nil
 }
 


### PR DESCRIPTION
This PR improves the line-based output of list results. By building the whole result string first, we ensure that the results are always grouped by list block. By adding space padding to the identities, we ensure that the display names start at the same column.

Fixes https://hashicorp.atlassian.net/browse/TF-27425
Fixes https://hashicorp.atlassian.net/browse/TF-27551

## UX
**Before**
<img width="1926" height="730" alt="CleanShot 2025-07-18 at 14 02 31@2x" src="https://github.com/user-attachments/assets/ddeb790a-8af4-423e-b6ee-d18e1e9ca92f" />

**After**
<img width="1812" height="786" alt="CleanShot 2025-07-18 at 14 01 53@2x" src="https://github.com/user-attachments/assets/9082c540-cd7d-4f3d-a181-d0d16602670e" />


## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.14.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [ ] This change is not user-facing.
