### PR TITLE
PSS: Allow backend or state_store config to be passed via BackendOpts into method for initialising the operations backend for a command

### DIFF
--- a/internal/command/arguments/flags.go
+++ b/internal/command/arguments/flags.go
@@ -56,6 +56,13 @@ func (f FlagNameValueSlice) AllItems() []FlagNameValue {
 	return *f.Items
 }
 
+func (f FlagNameValueSlice) Len() int {
+	if f.Items == nil {
+		return 0
+	}
+	return len(*f.Items)
+}
+
 func (f FlagNameValueSlice) Alias(flagName string) FlagNameValueSlice {
 	return FlagNameValueSlice{
 		FlagName: flagName,

--- a/internal/command/arguments/flags.go
+++ b/internal/command/arguments/flags.go
@@ -56,13 +56,6 @@ func (f FlagNameValueSlice) AllItems() []FlagNameValue {
 	return *f.Items
 }
 
-func (f FlagNameValueSlice) Len() int {
-	if f.Items == nil {
-		return 0
-	}
-	return len(*f.Items)
-}
-
 func (f FlagNameValueSlice) Alias(flagName string) FlagNameValueSlice {
 	return FlagNameValueSlice{
 		FlagName: flagName,

--- a/internal/command/init.go
+++ b/internal/command/init.go
@@ -481,7 +481,7 @@ func (c *InitCommand) initBackend(ctx context.Context, root *configs.Module, ext
 
 		// If overrides supplied by -backend-config CLI flag, process them
 		var configOverride hcl.Body
-		if extraConfig.Items != nil && len(*extraConfig.Items) > 0 {
+		if extraConfig.Len() > 0 {
 			// We need to launch an instance of the provider to get the config of the state store for processing any overrides.
 			provider, err := factory()
 			defer provider.Close() // Stop the child process once we're done with it here.

--- a/internal/command/init.go
+++ b/internal/command/init.go
@@ -481,7 +481,7 @@ func (c *InitCommand) initBackend(ctx context.Context, root *configs.Module, ext
 
 		// If overrides supplied by -backend-config CLI flag, process them
 		var configOverride hcl.Body
-		if extraConfig.Len() > 0 {
+		if !extraConfig.Empty() {
 			// We need to launch an instance of the provider to get the config of the state store for processing any overrides.
 			provider, err := factory()
 			defer provider.Close() // Stop the child process once we're done with it here.

--- a/internal/command/init.go
+++ b/internal/command/init.go
@@ -8,7 +8,9 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"maps"
 	"reflect"
+	"slices"
 	"sort"
 	"strings"
 
@@ -28,6 +30,7 @@ import (
 	"github.com/hashicorp/terraform/internal/command/views"
 	"github.com/hashicorp/terraform/internal/configs"
 	"github.com/hashicorp/terraform/internal/configs/configschema"
+	"github.com/hashicorp/terraform/internal/didyoumean"
 	"github.com/hashicorp/terraform/internal/getproviders"
 	"github.com/hashicorp/terraform/internal/providercache"
 	"github.com/hashicorp/terraform/internal/states"
@@ -424,9 +427,117 @@ func (c *InitCommand) initBackend(ctx context.Context, root *configs.Module, ext
 
 	view.Output(views.InitializingBackendMessage)
 
-	var backendConfig *configs.Backend
-	var backendConfigOverride hcl.Body
-	if root.Backend != nil {
+	var opts *BackendOpts
+	switch {
+	case root.StateStore != nil && root.Backend != nil:
+		// We expect validation during config parsing to prevent mutually exclusive backend and state_store blocks,
+		// but checking here just in case.
+		diags = diags.Append(&hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  "Conflicting backend and state_store configurations present during init",
+			Detail: fmt.Sprintf("When initializing the backend there was configuration data present for both backend %q and state store %q. This is a bug in Terraform and should be reported.",
+				root.Backend.Type,
+				root.StateStore.Type,
+			),
+			Subject: &root.Backend.TypeRange,
+		})
+		return nil, true, diags
+	case root.StateStore != nil:
+		// state_store config present
+		// Access provider factories
+		ctxOpts, err := c.contextOpts()
+		if err != nil {
+			diags = diags.Append(err)
+			return nil, true, diags
+		}
+
+		if root.StateStore.ProviderAddr.IsZero() {
+			// This should not happen; this data is populated when parsing config,
+			// even for builtin providers
+			panic(fmt.Sprintf("unknown provider while beginning to initialize state store %q from provider %q",
+				root.StateStore.Type,
+				root.StateStore.Provider.Name))
+		}
+
+		var exists bool
+		factory, exists := ctxOpts.Providers[root.StateStore.ProviderAddr]
+		if !exists {
+			diags = diags.Append(&hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  "Provider unavailable",
+				Detail: fmt.Sprintf("The provider %s (%q) is required to initialize the %q state store, but the matching provider factory is missing. This is a bug in Terraform and should be reported.",
+					root.StateStore.Provider.Name,
+					root.StateStore.ProviderAddr,
+					root.StateStore.Type,
+				),
+				Subject: &root.Backend.TypeRange,
+			})
+			return nil, true, diags
+		}
+
+		// If overrides supplied by -backend-config CLI flag, process them
+		var configOverride hcl.Body
+		if len(*extraConfig.Items) > 0 {
+
+			// We need to launch an instance of the provider to get the config of the state store for processing any overrides.
+			provider, err := factory()
+			defer provider.Close() // Stop the child process once we're done with it here.
+			if err != nil {
+				diags = diags.Append(fmt.Errorf("error when obtaining provider instance during state store initialization: %w", err))
+				return nil, true, diags
+			}
+
+			resp := provider.GetProviderSchema()
+
+			if len(resp.StateStores) == 0 {
+				diags = diags.Append(&hcl.Diagnostic{
+					Severity: hcl.DiagError,
+					Summary:  "Provider does not support pluggable state storage",
+					Detail: fmt.Sprintf("There are no state stores implemented by provider %s (%q)",
+						root.StateStore.Provider.Name,
+						root.StateStore.ProviderAddr),
+					Subject: &root.StateStore.DeclRange,
+				})
+				return nil, true, diags
+			}
+
+			stateStoreSchema, exists := resp.StateStores[root.StateStore.Type]
+			if !exists {
+				suggestions := slices.Sorted(maps.Keys(resp.StateStores))
+				suggestion := didyoumean.NameSuggestion(root.StateStore.Type, suggestions)
+				if suggestion != "" {
+					suggestion = fmt.Sprintf(" Did you mean %q?", suggestion)
+				}
+				diags = diags.Append(&hcl.Diagnostic{
+					Severity: hcl.DiagError,
+					Summary:  "State store not implemented by the provider",
+					Detail: fmt.Sprintf("State store %q is not implemented by provider %s (%q)%s",
+						root.StateStore.Type, root.StateStore.Provider.Name,
+						root.StateStore.ProviderAddr, suggestion),
+					Subject: &root.StateStore.DeclRange,
+				})
+				return nil, true, diags
+			}
+
+			// Handle any overrides supplied via -backend-config CLI flags
+			var overrideDiags tfdiags.Diagnostics
+			configOverride, overrideDiags = c.backendConfigOverrideBody(extraConfig, stateStoreSchema.Body)
+			diags = diags.Append(overrideDiags)
+			if overrideDiags.HasErrors() {
+				return nil, true, diags
+			}
+		}
+
+		opts = &BackendOpts{
+			StateStoreConfig: root.StateStore,
+			ProviderFactory:  factory,
+			ConfigOverride:   configOverride,
+			Init:             true,
+			ViewType:         viewType,
+		}
+
+	case root.Backend != nil:
+		// backend config present
 		backendType := root.Backend.Type
 		if backendType == "cloud" {
 			diags = diags.Append(&hcl.Diagnostic{
@@ -456,15 +567,24 @@ func (c *InitCommand) initBackend(ctx context.Context, root *configs.Module, ext
 
 		b := bf()
 		backendSchema := b.ConfigSchema()
-		backendConfig = root.Backend
+		backendConfig := root.Backend
 
-		var overrideDiags tfdiags.Diagnostics
-		backendConfigOverride, overrideDiags = c.backendConfigOverrideBody(extraConfig, backendSchema)
+		backendConfigOverride, overrideDiags := c.backendConfigOverrideBody(extraConfig, backendSchema)
 		diags = diags.Append(overrideDiags)
 		if overrideDiags.HasErrors() {
 			return nil, true, diags
 		}
-	} else {
+
+		opts = &BackendOpts{
+			BackendConfig:  backendConfig,
+			ConfigOverride: backendConfigOverride,
+			Init:           true,
+			ViewType:       viewType,
+		}
+
+	default:
+		// No config; defaults to local state storage
+
 		// If the user supplied a -backend-config on the CLI but no backend
 		// block was found in the configuration, it's likely - but not
 		// necessarily - a mistake. Return a warning.
@@ -486,14 +606,13 @@ However, if you intended to override a defined backend, please verify that
 the backend configuration is present and valid.
 `,
 			))
-		}
-	}
 
-	opts := &BackendOpts{
-		BackendConfig:  backendConfig,
-		ConfigOverride: backendConfigOverride,
-		Init:           true,
-		ViewType:       viewType,
+		}
+
+		opts = &BackendOpts{
+			Init:     true,
+			ViewType: viewType,
+		}
 	}
 
 	back, backDiags := c.Backend(opts)

--- a/internal/command/init.go
+++ b/internal/command/init.go
@@ -425,7 +425,11 @@ func (c *InitCommand) initBackend(ctx context.Context, root *configs.Module, ext
 	_ = ctx // prevent staticcheck from complaining to avoid a maintenence hazard of having the wrong ctx in scope here
 	defer span.End()
 
-	view.Output(views.InitializingBackendMessage)
+	if root.StateStore != nil {
+		view.Output(views.InitializingStateStoreMessage)
+	} else {
+		view.Output(views.InitializingBackendMessage)
+	}
 
 	var opts *BackendOpts
 	switch {

--- a/internal/command/init.go
+++ b/internal/command/init.go
@@ -393,7 +393,7 @@ func (c *InitCommand) getModules(ctx context.Context, path, testsDir string, ear
 
 func (c *InitCommand) initCloud(ctx context.Context, root *configs.Module, extraConfig arguments.FlagNameValueSlice, viewType arguments.ViewType, view views.Init) (be backend.Backend, output bool, diags tfdiags.Diagnostics) {
 	ctx, span := tracer.Start(ctx, "initialize HCP Terraform")
-	_ = ctx // prevent staticcheck from complaining to avoid a maintenence hazard of having the wrong ctx in scope here
+	_ = ctx // prevent staticcheck from complaining to avoid a maintenance hazard of having the wrong ctx in scope here
 	defer span.End()
 
 	view.Output(views.InitializingTerraformCloudMessage)
@@ -422,7 +422,7 @@ func (c *InitCommand) initCloud(ctx context.Context, root *configs.Module, extra
 
 func (c *InitCommand) initBackend(ctx context.Context, root *configs.Module, extraConfig arguments.FlagNameValueSlice, viewType arguments.ViewType, view views.Init) (be backend.Backend, output bool, diags tfdiags.Diagnostics) {
 	ctx, span := tracer.Start(ctx, "initialize backend")
-	_ = ctx // prevent staticcheck from complaining to avoid a maintenence hazard of having the wrong ctx in scope here
+	_ = ctx // prevent staticcheck from complaining to avoid a maintenance hazard of having the wrong ctx in scope here
 	defer span.End()
 
 	if root.StateStore != nil {
@@ -1018,7 +1018,7 @@ func (c *InitCommand) getProviders(ctx context.Context, config *configs.Config, 
 	if !newLocks.Equal(previousLocks) {
 		// if readonly mode
 		if flagLockfile == "readonly" {
-			// check if required provider dependences change
+			// check if required provider dependencies change
 			if !newLocks.EqualProviderAddress(previousLocks) {
 				diags = diags.Append(tfdiags.Sourceless(
 					tfdiags.Error,
@@ -1236,7 +1236,7 @@ Options:
                           itself.
 
   -force-copy             Suppress prompts about copying state data when
-                          initializating a new state backend. This is
+                          initializing a new state backend. This is
                           equivalent to providing a "yes" to all confirmation
                           prompts.
 

--- a/internal/command/init.go
+++ b/internal/command/init.go
@@ -481,8 +481,7 @@ func (c *InitCommand) initBackend(ctx context.Context, root *configs.Module, ext
 
 		// If overrides supplied by -backend-config CLI flag, process them
 		var configOverride hcl.Body
-		if len(*extraConfig.Items) > 0 {
-
+		if extraConfig.Items != nil && len(*extraConfig.Items) > 0 {
 			// We need to launch an instance of the provider to get the config of the state store for processing any overrides.
 			provider, err := factory()
 			defer provider.Close() // Stop the child process once we're done with it here.

--- a/internal/command/views/init.go
+++ b/internal/command/views/init.go
@@ -186,6 +186,10 @@ var MessageRegistry map[InitMessageCode]InitMessage = map[InitMessageCode]InitMe
 		HumanValue: "\n[reset][bold]Initializing provider plugins...",
 		JSONValue:  "Initializing provider plugins...",
 	},
+	"initializing_state_store_message": {
+		HumanValue: "\n[reset][bold]Initializing the state store...",
+		JSONValue:  "Initializing the state store...",
+	},
 	"dependencies_lock_changes_info": {
 		HumanValue: dependenciesLockChangesInfo,
 		JSONValue:  dependenciesLockChangesInfo,
@@ -258,6 +262,7 @@ const (
 	InitializingTerraformCloudMessage   InitMessageCode = "initializing_terraform_cloud_message"
 	InitializingModulesMessage          InitMessageCode = "initializing_modules_message"
 	InitializingBackendMessage          InitMessageCode = "initializing_backend_message"
+	InitializingStateStoreMessage       InitMessageCode = "initializing_state_store_message"
 	InitializingProviderPluginMessage   InitMessageCode = "initializing_provider_plugin_message"
 	LockInfo                            InitMessageCode = "lock_info"
 	DependenciesLockChangesInfo         InitMessageCode = "dependencies_lock_changes_info"


### PR DESCRIPTION
Context: https://github.com/hashicorp/terraform/pull/37321#issuecomment-3069989127
(I figured that the commit in this PR made sense to introduce into main on its own, separate to implementing further logic for PSS in the init command.)

This PR connects the code that can parse `state_store` configuration with new logic introduced in https://github.com/hashicorp/terraform/pull/37321 that allows Terraform to create an operations backend that uses PSS. Prior to this PR the logic in that PR couldn't be invoked, as BackendOpts.StateStoreConfig and BackendOpts.ProviderFactory are never set based on what's in the config.

Now the logic prepares different  `BackendOpts` depending on the situation:
* If PSS is in use: include `state_store` config and the provider factory needed for PSS in the BackendOpts value.
* If a configured backend is in use: pass through `backend` config in the BackendOpts value.
* If there's no config: pass through a minimal BackendOpts, as there is no config to pass through or other related fields.

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.14.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
