### PR TITLE
Support tfquery files in `terraform fmt`

### DIFF
--- a/internal/command/fmt_test.go
+++ b/internal/command/fmt_test.go
@@ -6,7 +6,6 @@ package command
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -20,7 +19,7 @@ func TestFmt_MockDataFiles(t *testing.T) {
 	const inSuffix = "_in.tfmock.hcl"
 	const outSuffix = "_out.tfmock.hcl"
 	const gotSuffix = "_got.tfmock.hcl"
-	entries, err := ioutil.ReadDir("testdata/tfmock-fmt")
+	entries, err := os.ReadDir("testdata/tfmock-fmt")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -43,15 +42,15 @@ func TestFmt_MockDataFiles(t *testing.T) {
 			inFile := filepath.Join("testdata", "tfmock-fmt", testName+inSuffix)
 			wantFile := filepath.Join("testdata", "tfmock-fmt", testName+outSuffix)
 			gotFile := filepath.Join(tmpDir, testName+gotSuffix)
-			input, err := ioutil.ReadFile(inFile)
+			input, err := os.ReadFile(inFile)
 			if err != nil {
 				t.Fatal(err)
 			}
-			want, err := ioutil.ReadFile(wantFile)
+			want, err := os.ReadFile(wantFile)
 			if err != nil {
 				t.Fatal(err)
 			}
-			err = ioutil.WriteFile(gotFile, input, 0700)
+			err = os.WriteFile(gotFile, input, 0700)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -68,7 +67,7 @@ func TestFmt_MockDataFiles(t *testing.T) {
 				t.Fatalf("fmt command was unsuccessful:\n%s", ui.ErrorWriter.String())
 			}
 
-			got, err := ioutil.ReadFile(gotFile)
+			got, err := os.ReadFile(gotFile)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -84,7 +83,7 @@ func TestFmt_TestFiles(t *testing.T) {
 	const inSuffix = "_in.tftest.hcl"
 	const outSuffix = "_out.tftest.hcl"
 	const gotSuffix = "_got.tftest.hcl"
-	entries, err := ioutil.ReadDir("testdata/tftest-fmt")
+	entries, err := os.ReadDir("testdata/tftest-fmt")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -107,15 +106,15 @@ func TestFmt_TestFiles(t *testing.T) {
 			inFile := filepath.Join("testdata", "tftest-fmt", testName+inSuffix)
 			wantFile := filepath.Join("testdata", "tftest-fmt", testName+outSuffix)
 			gotFile := filepath.Join(tmpDir, testName+gotSuffix)
-			input, err := ioutil.ReadFile(inFile)
+			input, err := os.ReadFile(inFile)
 			if err != nil {
 				t.Fatal(err)
 			}
-			want, err := ioutil.ReadFile(wantFile)
+			want, err := os.ReadFile(wantFile)
 			if err != nil {
 				t.Fatal(err)
 			}
-			err = ioutil.WriteFile(gotFile, input, 0700)
+			err = os.WriteFile(gotFile, input, 0700)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -132,7 +131,72 @@ func TestFmt_TestFiles(t *testing.T) {
 				t.Fatalf("fmt command was unsuccessful:\n%s", ui.ErrorWriter.String())
 			}
 
-			got, err := ioutil.ReadFile(gotFile)
+			got, err := os.ReadFile(gotFile)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if diff := cmp.Diff(string(want), string(got)); diff != "" {
+				t.Errorf("wrong result\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestFmt_QueryFiles(t *testing.T) {
+	const inSuffix = "_in.tfquery.hcl"
+	const outSuffix = "_out.tfquery.hcl"
+	const gotSuffix = "_got.tfquery.hcl"
+	entries, err := os.ReadDir("testdata/tfquery-fmt")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tmpDir, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, info := range entries {
+		if info.IsDir() {
+			continue
+		}
+		filename := info.Name()
+		if !strings.HasSuffix(filename, inSuffix) {
+			continue
+		}
+		testName := filename[:len(filename)-len(inSuffix)]
+		t.Run(testName, func(t *testing.T) {
+			inFile := filepath.Join("testdata", "tfquery-fmt", testName+inSuffix)
+			wantFile := filepath.Join("testdata", "tfquery-fmt", testName+outSuffix)
+			gotFile := filepath.Join(tmpDir, testName+gotSuffix)
+			input, err := os.ReadFile(inFile)
+			if err != nil {
+				t.Fatal(err)
+			}
+			want, err := os.ReadFile(wantFile)
+			if err != nil {
+				t.Fatal(err)
+			}
+			err = os.WriteFile(gotFile, input, 0700)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			ui := cli.NewMockUi()
+			c := &FmtCommand{
+				Meta: Meta{
+					testingOverrides:          metaOverridesForProvider(testProvider()),
+					Ui:                        ui,
+					AllowExperimentalFeatures: true,
+				},
+			}
+			args := []string{gotFile}
+			if code := c.Run(args); code != 0 {
+				t.Fatalf("fmt command was unsuccessful:\n%s", ui.ErrorWriter.String())
+			}
+
+			got, err := os.ReadFile(gotFile)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -148,7 +212,7 @@ func TestFmt(t *testing.T) {
 	const inSuffix = "_in.tf"
 	const outSuffix = "_out.tf"
 	const gotSuffix = "_got.tf"
-	entries, err := ioutil.ReadDir("testdata/fmt")
+	entries, err := os.ReadDir("testdata/fmt")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -171,15 +235,15 @@ func TestFmt(t *testing.T) {
 			inFile := filepath.Join("testdata", "fmt", testName+inSuffix)
 			wantFile := filepath.Join("testdata", "fmt", testName+outSuffix)
 			gotFile := filepath.Join(tmpDir, testName+gotSuffix)
-			input, err := ioutil.ReadFile(inFile)
+			input, err := os.ReadFile(inFile)
 			if err != nil {
 				t.Fatal(err)
 			}
-			want, err := ioutil.ReadFile(wantFile)
+			want, err := os.ReadFile(wantFile)
 			if err != nil {
 				t.Fatal(err)
 			}
-			err = ioutil.WriteFile(gotFile, input, 0700)
+			err = os.WriteFile(gotFile, input, 0700)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -196,7 +260,7 @@ func TestFmt(t *testing.T) {
 				t.Fatalf("fmt command was unsuccessful:\n%s", ui.ErrorWriter.String())
 			}
 
-			got, err := ioutil.ReadFile(gotFile)
+			got, err := os.ReadFile(gotFile)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -238,7 +302,7 @@ func TestFmt_syntaxError(t *testing.T) {
 a = 1 +
 `
 
-	err := ioutil.WriteFile(filepath.Join(tempDir, "invalid.tf"), []byte(invalidSrc), 0644)
+	err := os.WriteFile(filepath.Join(tempDir, "invalid.tf"), []byte(invalidSrc), 0644)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -267,7 +331,7 @@ func TestFmt_snippetInError(t *testing.T) {
 
 	backendSrc := `terraform {backend "s3" {}}`
 
-	err := ioutil.WriteFile(filepath.Join(tempDir, "backend.tf"), []byte(backendSrc), 0644)
+	err := os.WriteFile(filepath.Join(tempDir, "backend.tf"), []byte(backendSrc), 0644)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -302,7 +366,7 @@ func TestFmt_manyArgs(t *testing.T) {
 	// Add a second file
 	secondSrc := `locals { x = 1 }`
 
-	err := ioutil.WriteFile(filepath.Join(tempDir, "second.tf"), []byte(secondSrc), 0644)
+	err := os.WriteFile(filepath.Join(tempDir, "second.tf"), []byte(secondSrc), 0644)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -539,7 +603,7 @@ var fmtFixture = struct {
 func fmtFixtureWriteDir(t *testing.T) string {
 	dir := testTempDir(t)
 
-	err := ioutil.WriteFile(filepath.Join(dir, fmtFixture.filename), fmtFixture.input, 0644)
+	err := os.WriteFile(filepath.Join(dir, fmtFixture.filename), fmtFixture.input, 0644)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/command/testdata/tfquery-fmt/main_in.tfquery.hcl
+++ b/internal/command/testdata/tfquery-fmt/main_in.tfquery.hcl
@@ -1,0 +1,14 @@
+
+variable "value" {
+  type = string
+default = "value"
+}
+
+list foo_list "some_list_block" {
+  provider=foo
+
+  config {
+  condition = var.value
+      filter = 42
+  }
+}

--- a/internal/command/testdata/tfquery-fmt/main_out.tfquery.hcl
+++ b/internal/command/testdata/tfquery-fmt/main_out.tfquery.hcl
@@ -1,0 +1,14 @@
+
+variable "value" {
+  type    = string
+  default = "value"
+}
+
+list "foo_list" "some_list_block" {
+  provider = foo
+
+  config {
+    condition = var.value
+    filter    = 42
+  }
+}


### PR DESCRIPTION
This PR adds support for formatting `*.tfquery.hcl` files when running `terraform fmt`

Fixes https://hashicorp.atlassian.net/browse/TF-27590

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.14.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [ ] This change is not user-facing.
