### PR TITLE
terraform test: refactor graph edge calculation

### DIFF
--- a/internal/command/test_test.go
+++ b/internal/command/test_test.go
@@ -357,6 +357,11 @@ func TestTest_Runs(t *testing.T) {
 			expectedErr: []string{"Invalid condition run"},
 			code:        1,
 		},
+		"write-into-default-state": {
+			args:        []string{"-verbose"},
+			expectedOut: []string{"test_resource.two will be destroyed"},
+			code:        0,
+		},
 	}
 	for name, tc := range tcs {
 		t.Run(name, func(t *testing.T) {
@@ -609,10 +614,10 @@ main.tftest.hcl/single, and they need to be cleaned up manually:
 	// It's really important that the above message is printed, so we're testing
 	// for it specifically and making sure it contains all the resources.
 	if diff := cmp.Diff(cleanupErr, err); diff != "" {
-		t.Errorf("expected err to be %s\n\nbut got %s\n\n diff:%s\n", cleanupErr, err, diff)
+		t.Errorf("expected err to be\n%s\n\nbut got\n%s\n\n diff:\n%s\n", cleanupErr, err, diff)
 	}
 	if diff := cmp.Diff(cleanupMessage, output.Stdout()); diff != "" {
-		t.Errorf("expected output to be %s\n\nbut got %s\n\n diff:%s\n", cleanupMessage, output.Stdout(), diff)
+		t.Errorf("expected output to be \n%s\n\nbut got \n%s\n\n diff:\n%s\n", cleanupMessage, output.Stdout(), diff)
 	}
 
 	// This time the test command shouldn't have cleaned up the resource because

--- a/internal/command/testdata/test/write-into-default-state/main.tf
+++ b/internal/command/testdata/test/write-into-default-state/main.tf
@@ -1,0 +1,2 @@
+
+resource "test_resource" "one" {}

--- a/internal/command/testdata/test/write-into-default-state/main.tftest.hcl
+++ b/internal/command/testdata/test/write-into-default-state/main.tftest.hcl
@@ -1,0 +1,11 @@
+
+run "one" {
+  state_key = ""
+  module {
+    source = "./setup"
+  }
+}
+
+run "two" {
+  command = plan
+}

--- a/internal/command/testdata/test/write-into-default-state/setup/main.tf
+++ b/internal/command/testdata/test/write-into-default-state/setup/main.tf
@@ -1,0 +1,4 @@
+
+resource "test_resource" "one" {}
+
+resource "test_resource" "two" {}

--- a/internal/configs/test_file.go
+++ b/internal/configs/test_file.go
@@ -40,6 +40,12 @@ const (
 	RefreshOnlyTestMode TestMode = 'R'
 )
 
+const (
+	// TestMainStateIdentifier is the default state identifier for the main
+	// state of the test file.
+	TestMainStateIdentifier = ""
+)
+
 // TestFile represents a single test file within a `terraform test` execution.
 //
 // A test file is made up of a sequential list of run blocks, each designating
@@ -743,6 +749,10 @@ func decodeTestRunBlock(block *hcl.Block, file *TestFile) (*TestRun, hcl.Diagnos
 	if attr, exists := content.Attributes["state_key"]; exists {
 		rawDiags := gohcl.DecodeExpression(attr.Expr, nil, &r.StateKey)
 		diags = append(diags, rawDiags...)
+	} else if r.Module != nil {
+		r.StateKey = r.Module.Source.String()
+	} else {
+		r.StateKey = TestMainStateIdentifier // redundant, but let's be explicit
 	}
 
 	if attr, exists := content.Attributes["parallel"]; exists {

--- a/internal/moduletest/graph/apply.go
+++ b/internal/moduletest/graph/apply.go
@@ -22,7 +22,7 @@ import (
 func (n *NodeTestRun) testApply(ctx *EvalContext, variables terraform.InputValues, providers map[addrs.RootProviderConfig]providers.Interface, mocks map[addrs.RootProviderConfig]*configs.MockData, waiter *operationWaiter) {
 	file, run := n.File(), n.run
 	config := run.ModuleConfig
-	key := n.run.GetStateKey()
+	key := n.run.Config.StateKey
 
 	// FilterVariablesToModule only returns warnings, so we don't check the
 	// returned diags for errors.

--- a/internal/moduletest/graph/node_test_run.go
+++ b/internal/moduletest/graph/node_test_run.go
@@ -49,6 +49,16 @@ func (n *NodeTestRun) Referenceable() addrs.Referenceable {
 
 func (n *NodeTestRun) References() []*addrs.Reference {
 	references, _ := n.run.GetReferences()
+
+	for _, run := range n.priorRuns {
+		// we'll also draw an implicit reference to all prior runs to make sure
+		// they execute first
+		references = append(references, &addrs.Reference{
+			Subject:     run.Addr(),
+			SourceRange: tfdiags.SourceRangeFromHCL(n.run.Config.DeclRange),
+		})
+	}
+
 	return references
 }
 
@@ -117,10 +127,6 @@ func (n *NodeTestRun) Execute(evalCtx *EvalContext) {
 func (n *NodeTestRun) execute(ctx *EvalContext, waiter *operationWaiter) {
 	file, run := n.File(), n.run
 	ctx.Renderer().Run(run, file, moduletest.Starting, 0)
-	if run.Config.ConfigUnderTest != nil && run.GetStateKey() == moduletest.MainStateIdentifier {
-		// This is bad, and should not happen because the state key is derived from the custom module source.
-		panic(fmt.Sprintf("TestFileRunner: custom module %s has the same key as main state", file.Name))
-	}
 
 	providers, mocks, providerDiags := n.getProviders(ctx)
 	if !ctx.ProvidersCompleted(providers) {

--- a/internal/moduletest/graph/plan.go
+++ b/internal/moduletest/graph/plan.go
@@ -114,7 +114,7 @@ func (n *NodeTestRun) plan(ctx *EvalContext, tfCtx *terraform.Context, variables
 
 	waiter.update(tfCtx, moduletest.Running, nil)
 	log.Printf("[DEBUG] TestFileRunner: starting plan for %s/%s", file.Name, run.Name)
-	state := ctx.GetFileState(run.GetStateKey()).State
+	state := ctx.GetFileState(run.Config.StateKey).State
 	plan, planScope, planDiags := tfCtx.PlanAndEval(config, state, planOpts)
 	log.Printf("[DEBUG] TestFileRunner: completed plan for %s/%s", file.Name, run.Name)
 	diags = diags.Append(planDiags)

--- a/internal/moduletest/graph/transform_context.go
+++ b/internal/moduletest/graph/transform_context.go
@@ -24,7 +24,7 @@ func (e *EvalContextTransformer) Transform(graph *terraform.Graph) error {
 			for _, run := range e.File.Runs {
 				// initialise all the state keys before the graph starts
 				// properly
-				key := run.GetStateKey()
+				key := run.Config.StateKey
 				if state := ctx.GetFileState(key); state == nil {
 					ctx.SetFileState(key, &TestFileState{
 						Run:   nil,

--- a/internal/moduletest/graph/transform_state_cleanup.go
+++ b/internal/moduletest/graph/transform_state_cleanup.go
@@ -36,8 +36,8 @@ func (b *TeardownSubgraph) Execute(ctx *EvalContext) {
 	for runNode := range dag.SelectSeq[*NodeTestRun](b.parent.VerticesSeq()) {
 		refs := b.parent.Ancestors(runNode)
 		for _, ref := range refs {
-			if ref, ok := ref.(*NodeTestRun); ok && ref.run.GetStateKey() != runNode.run.GetStateKey() {
-				runRefMap[runNode.run.Addr()] = append(runRefMap[runNode.run.Addr()], ref.run.GetStateKey())
+			if ref, ok := ref.(*NodeTestRun); ok && ref.run.Config.StateKey != runNode.run.Config.StateKey {
+				runRefMap[runNode.run.Addr()] = append(runRefMap[runNode.run.Addr()], ref.run.Config.StateKey)
 			}
 		}
 	}
@@ -81,7 +81,7 @@ func (t *TestStateCleanupTransformer) Transform(g *terraform.Graph) error {
 	// iterate in reverse order of the run index, so that the last run for each state key
 	// is attached to the cleanup node.
 	for _, run := range slices.Backward(t.opts.File.Runs) {
-		key := run.GetStateKey()
+		key := run.Config.StateKey
 
 		if _, exists := cleanupMap[key]; !exists {
 			node := &NodeStateCleanup{
@@ -109,8 +109,6 @@ func (t *TestStateCleanupTransformer) Transform(g *terraform.Graph) error {
 	for _, node := range arr {
 		t.depthFirstTraverse(g, node, visited, cleanupMap, depStateKeys)
 	}
-
-	ControlParallelism(g, arr)
 	return nil
 }
 
@@ -126,11 +124,7 @@ func (t *TestStateCleanupTransformer) depthFirstTraverse(g *terraform.Graph, nod
 			continue
 		}
 		refNode := cleanupNodes[refStateKey]
-		// leave non-parallel nodes out of this. Their sequential connections
-		// will be handled later.
-		if node.parallel && refNode.parallel {
-			g.Connect(dag.BasicEdge(refNode, node))
-		}
+		g.Connect(dag.BasicEdge(refNode, node))
 		t.depthFirstTraverse(g, refNode, visited, cleanupNodes, depStateKeys)
 	}
 }

--- a/internal/moduletest/graph/transform_test_run.go
+++ b/internal/moduletest/graph/transform_test_run.go
@@ -4,7 +4,6 @@
 package graph
 
 import (
-	"github.com/hashicorp/terraform/internal/dag"
 	"github.com/hashicorp/terraform/internal/moduletest"
 	"github.com/hashicorp/terraform/internal/terraform"
 )
@@ -17,71 +16,23 @@ type TestRunTransformer struct {
 
 func (t *TestRunTransformer) Transform(g *terraform.Graph) error {
 	// Create and add nodes for each run
-	var nodes []*NodeTestRun
 	for _, run := range t.opts.File.Runs {
-		node := &NodeTestRun{run: run, opts: t.opts, priorRuns: make(map[string]*moduletest.Run)}
-		g.Add(node)
-		nodes = append(nodes, node)
+		priorRuns := make(map[string]*moduletest.Run)
+		for ix := run.Index - 1; ix >= 0; ix-- {
+			// If either node isn't parallel, we should draw an edge between
+			// them. Also, if they share the same state key we should also draw
+			// an edge between them regardless of the parallelisation.
+			if target := t.opts.File.Runs[ix]; !run.Config.Parallel || !target.Config.Parallel || run.Config.StateKey == target.Config.StateKey {
+				priorRuns[target.Name] = target
+			}
+		}
+
+		g.Add(&NodeTestRun{
+			run:       run,
+			opts:      t.opts,
+			priorRuns: priorRuns,
+		})
 	}
-
-	// Connect nodes based on dependencies
-	ControlParallelism(g, nodes)
-
-	// Runs with the same state key inherently depend on each other, so we
-	// connect them sequentially.
-	t.connectSameStateRuns(g, nodes)
 
 	return nil
-}
-
-func (t *TestRunTransformer) connectSameStateRuns(g *terraform.Graph, nodes []*NodeTestRun) {
-	stateRuns := make(map[string][]*NodeTestRun)
-	for _, node := range nodes {
-		key := node.run.GetStateKey()
-		stateRuns[key] = append(stateRuns[key], node)
-	}
-	for _, runs := range stateRuns {
-		for i := 1; i < len(runs); i++ {
-			curr, prev := runs[i], runs[i-1]
-			curr.priorRuns[prev.run.Name] = prev.run
-			g.Connect(dag.BasicEdge(curr, prev))
-		}
-	}
-}
-
-// ControlParallelism connects nodes in the graph based on their parallelism
-// settings. If a node opts out of parallelism, it will be connected sequentially
-// to all previous and subsequent nodes that are also part of the parallelism
-// control flow.
-func ControlParallelism[T any](g *terraform.Graph, nodes []T) {
-	for i, node := range nodes {
-		switch node := any(node).(type) {
-		case *NodeTestRun:
-			if node.run.Config.Parallel {
-				continue
-			}
-
-			for j := range i {
-				refNode := any(nodes[j]).(*NodeTestRun)
-				node.priorRuns[refNode.run.Name] = refNode.run
-			}
-		case *NodeStateCleanup:
-			if node.parallel {
-				continue
-			}
-		default:
-			// If the node type does not support parallelism, skip it.
-			continue
-		}
-
-		// Connect to all previous runs
-		for j := range i {
-			g.Connect(dag.BasicEdge(node, nodes[j]))
-		}
-
-		// Connect to all subsequent runs
-		for j := i + 1; j < len(nodes); j++ {
-			g.Connect(dag.BasicEdge(nodes[j], node))
-		}
-	}
 }

--- a/internal/moduletest/graph/wait.go
+++ b/internal/moduletest/graph/wait.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform/internal/command/views"
+	"github.com/hashicorp/terraform/internal/configs"
 	"github.com/hashicorp/terraform/internal/moduletest"
 	"github.com/hashicorp/terraform/internal/plans"
 	"github.com/hashicorp/terraform/internal/states"
@@ -134,7 +135,7 @@ func (w *operationWaiter) updateProgress() {
 func (w *operationWaiter) handleCancelled() bool {
 	log.Printf("[DEBUG] TestFileRunner: test execution cancelled during %s", w.identifier)
 	states := make(map[*moduletest.Run]*states.State)
-	mainKey := moduletest.MainStateIdentifier
+	mainKey := configs.TestMainStateIdentifier
 	states[nil] = w.evalCtx.GetFileState(mainKey).State
 	for key, module := range w.evalCtx.FileStates {
 		if key == mainKey {

--- a/internal/moduletest/run.go
+++ b/internal/moduletest/run.go
@@ -20,10 +20,6 @@ import (
 	"github.com/hashicorp/terraform/internal/tfdiags"
 )
 
-const (
-	MainStateIdentifier = ""
-)
-
 type Run struct {
 	Config *configs.TestRun
 
@@ -189,24 +185,6 @@ func (run *Run) GetReferences() ([]*addrs.Reference, tfdiags.Diagnostics) {
 	}
 
 	return references, diagnostics
-}
-
-// GetStateKey returns the run's state key. If an explicit state key is set in
-// the run's configuration, that key is returned. Otherwise, if the run is using
-// an alternate module under test, the source of that module is returned as the
-// state key. If neither of these conditions are met, an empty string is
-// returned, and this denotes that the run is using the root module under test.
-func (run *Run) GetStateKey() string {
-	if run.Config.StateKey != "" {
-		return run.Config.StateKey
-	}
-
-	// The run has an alternate module under test, so we can use the module's source
-	if run.Config.ConfigUnderTest != nil {
-		return run.Config.Module.Source.String()
-	}
-
-	return MainStateIdentifier
 }
 
 // GetModuleConfigID returns the identifier for the module configuration that


### PR DESCRIPTION
This PR uses the newly introduced `priorRuns` concept to simply connecting edges between runs within the Terraform Test graph. In turn, we can now simply the edges calculation between cleanup nodes as the dependencies (including references and parallelisation information) are now embedded into the graph already, and we can retrieve this from the dependency information instead of recalculating it.