### PR TITLE
terraform test: include expected diagnostics in verbose mode

### DIFF
--- a/.changes/v1.14/ENHANCEMENTS-20250723-122922.yaml
+++ b/.changes/v1.14/ENHANCEMENTS-20250723-122922.yaml
@@ -1,0 +1,5 @@
+kind: ENHANCEMENTS
+body: 'terraform test: expected diagnostics will be included in test output when running in verbose mode"'
+time: 2025-07-23T12:29:22.244611+02:00
+custom:
+    Issue: "37362"

--- a/internal/command/test_test.go
+++ b/internal/command/test_test.go
@@ -130,6 +130,37 @@ func TestTest_Runs(t *testing.T) {
 			expectedOut: []string{"1 passed, 0 failed."},
 			code:        0,
 		},
+		"expect_failures_outputs": {
+			expectedOut: []string{"1 passed, 0 failed."},
+			code:        0,
+		},
+		"expect_failures_checks_verbose": {
+			override:    "expect_failures_checks",
+			args:        []string{"-verbose"},
+			expectedOut: []string{"1 passed, 0 failed.", "Warning: Check block assertion failed"},
+			code:        0,
+		},
+		"expect_failures_inputs_verbose": {
+			override:    "expect_failures_inputs",
+			args:        []string{"-verbose"},
+			expectedOut: []string{"1 passed, 0 failed."},
+			expectedErr: []string{"Error: Invalid value for variable"},
+			code:        0,
+		},
+		"expect_failures_resources_verbose": {
+			override:    "expect_failures_resources",
+			args:        []string{"-verbose"},
+			expectedOut: []string{"1 passed, 0 failed."},
+			expectedErr: []string{"Error: Resource postcondition failed"},
+			code:        0,
+		},
+		"expect_failures_outputs_verbose": {
+			override:    "expect_failures_outputs",
+			args:        []string{"-verbose"},
+			expectedOut: []string{"1 passed, 0 failed."},
+			expectedErr: []string{"Error: Module output value precondition failed"},
+			code:        0,
+		},
 		"multiple_files": {
 			expectedOut: []string{"2 passed, 0 failed"},
 			code:        0,

--- a/internal/moduletest/graph/apply.go
+++ b/internal/moduletest/graph/apply.go
@@ -63,7 +63,7 @@ func (n *NodeTestRun) testApply(ctx *EvalContext, variables terraform.InputValue
 
 	// Remove expected diagnostics, and add diagnostics in case anything that should have failed didn't.
 	// We'll also update the run status based on the presence of errors or missing expected failures.
-	failOrErr := n.checkForMissingExpectedFailures(run, applyDiags)
+	failOrErr := n.checkForMissingExpectedFailures(ctx, run, applyDiags)
 	if failOrErr {
 		// Even though the apply operation failed, the graph may have done
 		// partial updates and the returned state should reflect this.
@@ -172,11 +172,19 @@ func (n *NodeTestRun) apply(tfCtx *terraform.Context, plan *plans.Plan, progress
 
 // checkForMissingExpectedFailures checks for missing expected failures in the diagnostics.
 // It updates the run status based on the presence of errors or missing expected failures.
-func (n *NodeTestRun) checkForMissingExpectedFailures(run *moduletest.Run, diags tfdiags.Diagnostics) (failOrErr bool) {
+func (n *NodeTestRun) checkForMissingExpectedFailures(ctx *EvalContext, run *moduletest.Run, diags tfdiags.Diagnostics) (failOrErr bool) {
 	// Retrieve and append diagnostics that are either unrelated to expected failures
 	// or report missing expected failures.
 	unexpectedDiags := run.ValidateExpectedFailures(diags)
-	run.Diagnostics = run.Diagnostics.Append(unexpectedDiags)
+
+	if ctx.Verbose() {
+		// in verbose mode, we still add all the original diagnostics for
+		// display even if they are expected.
+		run.Diagnostics = run.Diagnostics.Append(diags)
+	} else {
+		run.Diagnostics = run.Diagnostics.Append(unexpectedDiags)
+	}
+
 	for _, diag := range unexpectedDiags {
 		// // If any diagnostic indicates a missing expected failure, set the run status to fail.
 		if ok := moduletest.DiagnosticFromMissingExpectedFailure(diag); ok {

--- a/internal/moduletest/graph/plan.go
+++ b/internal/moduletest/graph/plan.go
@@ -32,11 +32,19 @@ func (n *NodeTestRun) testPlan(ctx *EvalContext, variables terraform.InputValues
 	tfCtx, _ := terraform.NewContext(n.opts.ContextOpts)
 
 	// execute the terraform plan operation
-	planScope, plan, planDiags := n.plan(ctx, tfCtx, setVariables, providers, mocks, waiter)
+	planScope, plan, originalDiags := n.plan(ctx, tfCtx, setVariables, providers, mocks, waiter)
 	// We exclude the diagnostics that are expected to fail from the plan
 	// diagnostics, and if an expected failure is not found, we add a new error diagnostic.
-	planDiags = run.ValidateExpectedFailures(planDiags)
-	run.Diagnostics = run.Diagnostics.Append(planDiags)
+	planDiags := run.ValidateExpectedFailures(originalDiags)
+
+	if ctx.Verbose() {
+		// in verbose mode, we still add all the original diagnostics for
+		// display.
+		run.Diagnostics = run.Diagnostics.Append(originalDiags)
+	} else {
+		run.Diagnostics = run.Diagnostics.Append(planDiags)
+	}
+
 	if planDiags.HasErrors() {
 		run.Status = moduletest.Error
 		return


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

When executing in verbose display mode, Terraform Test will now include any diagnostics that would normally be excluded due to be expected.

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Fixes #34673 

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.14.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [x] This change is user-facing and I added a changelog entry.
- [ ] This change is not user-facing.
