### PR TITLE
refactor: use slices.Equal to simplify code

### DIFF
--- a/internal/addrs/module.go
+++ b/internal/addrs/module.go
@@ -4,6 +4,7 @@
 package addrs
 
 import (
+	"slices"
 	"strings"
 
 	"github.com/hashicorp/hcl/v2"
@@ -58,15 +59,7 @@ func (m Module) String() string {
 }
 
 func (m Module) Equal(other Module) bool {
-	if len(m) != len(other) {
-		return false
-	}
-	for i := range m {
-		if m[i] != other[i] {
-			return false
-		}
-	}
-	return true
+	return slices.Equal(m, other)
 }
 
 type moduleKey string

--- a/internal/addrs/module_instance.go
+++ b/internal/addrs/module_instance.go
@@ -5,6 +5,7 @@ package addrs
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/hashicorp/hcl/v2"
@@ -305,16 +306,7 @@ func (mk moduleInstanceKey) uniqueKeySigil() {}
 // Equal returns true if the receiver and the given other value
 // contains the exact same parts.
 func (m ModuleInstance) Equal(o ModuleInstance) bool {
-	if len(m) != len(o) {
-		return false
-	}
-
-	for i := range m {
-		if m[i] != o[i] {
-			return false
-		}
-	}
-	return true
+	return slices.Equal(m, o)
 }
 
 // Less returns true if the receiver should sort before the given other value


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

In the Go 1.21 standard library, a new function has been introduced that enhances code conciseness and readability. It can be find  [here](https://pkg.go.dev/slices@go1.21.1#Equal).



<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Fixes #

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.14.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [ ] This change is not user-facing.
