### PR TITLE
Move stacks cmd outside of `AllowExperimentalFeatures` block

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -436,6 +436,12 @@ func initCommands(
 				},
 			}, nil
 		},
+
+		"stacks": func() (cli.Command, error) {
+			return &command.StacksCommand{
+				Meta: meta,
+			}, nil
+		},
 	}
 
 	if meta.AllowExperimentalFeatures {
@@ -447,12 +453,6 @@ func initCommands(
 
 		Commands["query"] = func() (cli.Command, error) {
 			return &command.QueryCommand{
-				Meta: meta,
-			}, nil
-		}
-
-		Commands["stacks"] = func() (cli.Command, error) {
-			return &command.StacksCommand{
 				Meta: meta,
 			}, nil
 		}


### PR DESCRIPTION
## Description

Makes the stacks cmd available outside of alpha releases.

## Target Release

1.13.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [ ] This change is not user-facing.
