### PR TITLE
Append warning in CLI output when query result is empty

### DIFF
--- a/internal/command/query_test.go
+++ b/internal/command/query_test.go
@@ -95,7 +95,7 @@ Warning: list block(s) [list.test_instance.example2] have 0 results.`,
 		},
 	}
 
-	for _, ts := range tests[len(tests)-1:] {
+	for _, ts := range tests {
 		t.Run(ts.name, func(t *testing.T) {
 			td := t.TempDir()
 			testCopyDir(t, testFixturePath(path.Join("query", ts.directory)), td)
@@ -128,11 +128,11 @@ Warning: list block(s) [list.test_instance.example2] have 0 results.`,
 			args := []string{"-no-color"}
 			code = c.Run(args)
 			output = done(t)
-			actual := strings.TrimSpace(output.All())
 			if len(ts.expectedErr) == 0 {
 				if code != 0 {
 					t.Fatalf("bad: %d\n\n%s", code, output.Stderr())
 				}
+				actual := strings.TrimSpace(output.Stdout())
 
 				// Check that we have query output
 				expected := strings.TrimSpace(ts.expectedOut)
@@ -141,6 +141,7 @@ Warning: list block(s) [list.test_instance.example2] have 0 results.`,
 				}
 
 			} else {
+				actual := strings.TrimSpace(output.Stderr())
 				for _, expected := range ts.expectedErr {
 					expected := strings.TrimSpace(expected)
 					if diff := cmp.Diff(expected, actual); diff != "" {

--- a/internal/command/query_test.go
+++ b/internal/command/query_test.go
@@ -5,6 +5,7 @@ package command
 
 import (
 	"path"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -83,9 +84,18 @@ Error: Unsupported block type
 Blocks of type "resource" are not expected here.
 `},
 		},
+		{
+			name:      "empty result",
+			directory: "empty-result",
+			expectedOut: `list.test_instance.example   id=test-instance-1   Test Instance 1
+list.test_instance.example   id=test-instance-2   Test Instance 2
+
+Warning: list block(s) [list.test_instance.example2] have 0 results.`,
+			initCode: 0,
+		},
 	}
 
-	for _, ts := range tests {
+	for _, ts := range tests[len(tests)-1:] {
 		t.Run(ts.name, func(t *testing.T) {
 			td := t.TempDir()
 			testCopyDir(t, testFixturePath(path.Join("query", ts.directory)), td)
@@ -118,19 +128,21 @@ Blocks of type "resource" are not expected here.
 			args := []string{"-no-color"}
 			code = c.Run(args)
 			output = done(t)
-			actual := output.All()
+			actual := strings.TrimSpace(output.All())
 			if len(ts.expectedErr) == 0 {
 				if code != 0 {
 					t.Fatalf("bad: %d\n\n%s", code, output.Stderr())
 				}
 
 				// Check that we have query output
-				if diff := cmp.Diff(ts.expectedOut, actual); diff != "" {
-					t.Errorf("expected query output to contain %q, \ngot: %q, \ndiff: %s", ts.expectedOut, actual, diff)
+				expected := strings.TrimSpace(ts.expectedOut)
+				if diff := cmp.Diff(expected, actual); diff != "" {
+					t.Errorf("expected query output to contain \n%q, \ngot: \n%q, \ndiff: %s", expected, actual, diff)
 				}
 
 			} else {
 				for _, expected := range ts.expectedErr {
+					expected := strings.TrimSpace(expected)
 					if diff := cmp.Diff(expected, actual); diff != "" {
 						t.Errorf("expected error message to contain '%s', \ngot: %s, \ndiff: %s", expected, actual, diff)
 					}
@@ -228,11 +240,12 @@ func queryFixtureProvider() *testing_provider.MockProvider {
 
 		configMap := wholeConfigMap["config"]
 
-		// For empty results test case //TODO: Remove?
-		if ami, ok := wholeConfigMap["ami"]; ok && ami.AsString() == "ami-nonexistent" {
+		// For empty results test case
+		ami, ok := configMap.AsValueMap()["ami"]
+		if ok && ami.AsString() == "ami-nonexistent" {
 			return providers.ListResourceResponse{
 				Result: cty.ObjectVal(map[string]cty.Value{
-					"data":   cty.ListVal([]cty.Value{}),
+					"data":   cty.ListValEmpty(cty.DynamicPseudoType),
 					"config": configMap,
 				}),
 			}

--- a/internal/command/query_test.go
+++ b/internal/command/query_test.go
@@ -90,7 +90,7 @@ Blocks of type "resource" are not expected here.
 			expectedOut: `list.test_instance.example   id=test-instance-1   Test Instance 1
 list.test_instance.example   id=test-instance-2   Test Instance 2
 
-Warning: list block(s) [list.test_instance.example2] have 0 results.`,
+Warning: list block(s) [list.test_instance.example2] returned 0 results.`,
 			initCode: 0,
 		},
 	}

--- a/internal/command/testdata/query/empty-result/main.tf
+++ b/internal/command/testdata/query/empty-result/main.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_providers {
+    test = {
+      source = "hashicorp/test"
+    }
+  }
+}
+
+provider "test" {}
+
+resource "test_instance" "example" {
+  ami = "ami-12345"
+}

--- a/internal/command/testdata/query/empty-result/query.tfquery.hcl
+++ b/internal/command/testdata/query/empty-result/query.tfquery.hcl
@@ -1,0 +1,15 @@
+list "test_instance" "example" {
+  provider = test
+
+  config {
+    ami = "ami-12345"
+  }
+}
+
+list "test_instance" "example2" {
+  provider = test
+
+  config {
+    ami = "ami-nonexistent"
+  }
+}

--- a/internal/command/views/hook_json.go
+++ b/internal/command/views/hook_json.go
@@ -266,6 +266,7 @@ func (h *jsonHook) PostListQuery(id terraform.HookResourceIdentity, results plan
 	h.view.log.Info(
 		fmt.Sprintf("%s: List complete", addr.String()),
 		"type", json.MessageListComplete,
+		"total", data.LengthInt(),
 	)
 	return terraform.HookActionContinue, nil
 }

--- a/internal/command/views/hook_json.go
+++ b/internal/command/views/hook_json.go
@@ -263,6 +263,10 @@ func (h *jsonHook) PostListQuery(id terraform.HookResourceIdentity, results plan
 			json.MessageListResourceFound, result,
 		)
 	}
+	h.view.log.Info(
+		fmt.Sprintf("%s: List complete", addr.String()),
+		"type", json.MessageListComplete,
+	)
 	return terraform.HookActionContinue, nil
 }
 

--- a/internal/command/views/hook_ui.go
+++ b/internal/command/views/hook_ui.go
@@ -534,7 +534,10 @@ func (h *UiHook) PostListQuery(id terraform.HookResourceIdentity, results plans.
 		result.WriteString(fmt.Sprintf("%s   %-*s   %s\n", addr.String(), maxIdentityLen, identity, displayNames[i]))
 	}
 
-	h.println(result.String())
+	resultStr := result.String()
+	if resultStr != "" {
+		h.println(resultStr)
+	}
 
 	return terraform.HookActionContinue, nil
 }

--- a/internal/command/views/hook_ui.go
+++ b/internal/command/views/hook_ui.go
@@ -534,9 +534,8 @@ func (h *UiHook) PostListQuery(id terraform.HookResourceIdentity, results plans.
 		result.WriteString(fmt.Sprintf("%s   %-*s   %s\n", addr.String(), maxIdentityLen, identity, displayNames[i]))
 	}
 
-	resultStr := result.String()
-	if resultStr != "" {
-		h.println(resultStr)
+	if result.Len() > 0 {
+		h.println(result.String())
 	}
 
 	return terraform.HookActionContinue, nil

--- a/internal/command/views/json/message_types.go
+++ b/internal/command/views/json/message_types.go
@@ -50,6 +50,7 @@ const (
 	// List messages
 	MessageListStart         MessageType = "list_start"
 	MessageListResourceFound MessageType = "list_resource_found"
+	MessageListComplete      MessageType = "list_complete"
 
 	// Action messages
 	MessageActionStart    MessageType = "action_start"

--- a/internal/command/views/query_operation.go
+++ b/internal/command/views/query_operation.go
@@ -81,7 +81,8 @@ func (v *QueryOperationHuman) Plan(plan *plans.Plan, schemas *terraform.Schemas)
 	}
 
 	if len(emptyBlocks) > 0 {
-		v.view.streams.Printf("Warning: list block(s) %v have 0 results.", emptyBlocks)
+		v.view.streams.Printf(
+			v.view.colorize.Color("[reset][yellow]Warning: list block(s) %v have 0 results.[reset]\n"), emptyBlocks)
 	}
 }
 

--- a/internal/command/views/query_operation.go
+++ b/internal/command/views/query_operation.go
@@ -5,6 +5,7 @@ package views
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/hashicorp/terraform/internal/command/arguments"
 	"github.com/hashicorp/terraform/internal/command/format"
@@ -81,8 +82,8 @@ func (v *QueryOperationHuman) Plan(plan *plans.Plan, schemas *terraform.Schemas)
 	}
 
 	if len(emptyBlocks) > 0 {
-		v.view.streams.Printf(
-			v.view.colorize.Color("[reset][yellow]Warning: list block(s) %v have 0 results.[reset]\n"), emptyBlocks)
+		msg := fmt.Sprintf(v.view.colorize.Color("[bold][yellow]Warning:[reset][bold] list block(s) [%s] returned 0 results.\n"), strings.Join(emptyBlocks, ", "))
+		v.view.streams.Println(format.WordWrap(msg, v.view.outputColumns()))
 	}
 }
 

--- a/internal/command/views/query_operation.go
+++ b/internal/command/views/query_operation.go
@@ -59,6 +59,30 @@ func (v *QueryOperationHuman) EmergencyDumpState(stateFile *statefile.File) erro
 }
 
 func (v *QueryOperationHuman) Plan(plan *plans.Plan, schemas *terraform.Schemas) {
+	// The hook for individual query blocks do not display any output when the results are empty,
+	// so we will display a grouped warning message here for the empty queries.
+	emptyBlocks := []string{}
+	for _, query := range plan.Changes.Queries {
+		pSchema := schemas.ProviderSchema(query.ProviderAddr.Provider)
+		addr := query.Addr
+		schema := pSchema.ListResourceTypes[addr.Resource.Resource.Type]
+
+		results, err := query.Decode(schema)
+		if err != nil {
+			v.view.streams.Eprintln(err)
+			continue
+		}
+
+		data := results.Results.Value.GetAttr("data")
+		if data.LengthInt() == 0 {
+			emptyBlocks = append(emptyBlocks, addr.String())
+		}
+
+	}
+
+	if len(emptyBlocks) > 0 {
+		v.view.streams.Printf("Warning: list block(s) %v have 0 results.", emptyBlocks)
+	}
 }
 
 func (v *QueryOperationHuman) PlannedChange(change *plans.ResourceInstanceChangeSrc) {


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Fixes #

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.14.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [ ] This change is not user-facing.
