### PR TITLE
`stacks` subcommand: Ignore cmd arg parsing errors

### DIFF
--- a/internal/command/stacks.go
+++ b/internal/command/stacks.go
@@ -83,10 +83,7 @@ func (c *StacksCommand) realRun(args []string, stdout, stderr io.Writer) int {
 	cmdFlags := c.Meta.defaultFlagSet("stacks")
 	cmdFlags.StringVar(&pluginCacheDirOverride, "plugin-cache-dir", "", "plugin cache directory")
 	cmdFlags.Usage = func() { c.Ui.Error(c.Help()) }
-	if err := cmdFlags.Parse(args); err != nil {
-		c.Ui.Error(fmt.Sprintf("Error parsing command-line flags: %s\n", err.Error()))
-		return 1
-	}
+	cmdFlags.Parse(args)
 
 	if pluginCacheDirOverride != "" {
 		err := c.storeStacksPluginPath(path.Join(pluginCacheDirOverride, StacksPluginDataDir))


### PR DESCRIPTION
## Description

We'll want to ignore cmd argument parsing errors here, otherwise global arguments passed-to/handled-in the stacks cli plugin will cause a failure here.

## Target Release

1.13.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
