### PR TITLE
Add support for module locks [Fixes #31301]

### DIFF
--- a/.changes/v1.14/ENHANCEMENTS-20250803-080008.yaml
+++ b/.changes/v1.14/ENHANCEMENTS-20250803-080008.yaml
@@ -1,0 +1,12 @@
+kind: FEATURES
+body: |
+  Module dependency locking is now supported in .terraform.lock.hcl files alongside provider dependency locks.
+  
+  Modules are now validated with hash checks to ensure reproducible builds and detect module tampering. 
+  Multiple hashes are supported to handle registry inconsistencies, following the same pattern as providers.
+  
+  Hash validation prevents lock file updates when module content doesn't match expected hashes, unless 
+  using the -upgrade flag to explicitly allow new hashes to be accumulated.
+time: 2025-08-03T08:00:08.857939-05:00
+custom:
+    Issue: "31301"

--- a/internal/addrs/module_source_test.go
+++ b/internal/addrs/module_source_test.go
@@ -1,0 +1,289 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package addrs
+
+import (
+	"testing"
+)
+
+func TestModuleSourceRemote_VersionHint(t *testing.T) {
+	tests := []struct {
+		name     string
+		source   string
+		expected string
+	}{
+		// Git URLs with version parameters
+		{
+			name:     "git URL with ref parameter",
+			source:   "git::https://example.com/repo.git?ref=v1.2.3",
+			expected: "v1.2.3",
+		},
+		{
+			name:     "git URL with tag parameter (not supported)",
+			source:   "git::https://example.com/repo.git?tag=v2.0.0",
+			expected: "",
+		},
+		{
+			name:     "git URL with branch parameter (not supported)",
+			source:   "git::https://example.com/repo.git?branch=main",
+			expected: "",
+		},
+		{
+			name:     "git URL with commit parameter (not supported)",
+			source:   "git::https://example.com/repo.git?commit=abc123def456",
+			expected: "",
+		},
+		{
+			name:     "GitHub shorthand with ref",
+			source:   "github.com/hashicorp/terraform-aws-vpc?ref=v3.0.0",
+			expected: "v3.0.0",
+		},
+		{
+			name:     "BitBucket shorthand with ref",
+			source:   "bitbucket.org/hashicorp/terraform-consul?ref=v0.1.0",
+			expected: "v0.1.0",
+		},
+		{
+			name:     "SSH git URL with ref",
+			source:   "git@github.com:hashicorp/terraform.git?ref=v1.0.0",
+			expected: "v1.0.0",
+		},
+		{
+			name:     "URL ending in .git with ref",
+			source:   "https://gitlab.com/example/repo.git?ref=feature-branch",
+			expected: "feature-branch",
+		},
+		{
+			name:     "Multiple parameters - ref takes precedence",
+			source:   "git::https://example.com/repo.git?depth=1&ref=v1.0.0&other=value",
+			expected: "v1.0.0",
+		},
+		{
+			name:     "only ref parameter is recognized when multiple version params present",
+			source:   "git::https://example.com/repo.git?branch=main&tag=v1.0.0&commit=abc123&ref=v2.0.0",
+			expected: "v2.0.0",
+		},
+		{
+			name:     "non-ref version parameters are ignored",
+			source:   "git::https://example.com/repo.git?branch=main&commit=abc123",
+			expected: "",
+		},
+
+		// Non-git URLs should return empty
+		{
+			name:     "HTTP archive URL",
+			source:   "https://example.com/module.zip?version=1.0.0",
+			expected: "",
+		},
+		{
+			name:     "S3 URL",
+			source:   "s3::https://s3.amazonaws.com/bucket/module.zip?version=1.0.0",
+			expected: "",
+		},
+		{
+			name:     "GCS URL",
+			source:   "gcs::https://storage.googleapis.com/bucket/module.zip?version=1.0.0",
+			expected: "",
+		},
+
+		// Git URLs without version parameters
+		{
+			name:     "git URL without parameters",
+			source:   "git::https://example.com/repo.git",
+			expected: "",
+		},
+		{
+			name:     "git URL with non-version parameters only",
+			source:   "git::https://example.com/repo.git?depth=1&sshkey=mykey",
+			expected: "",
+		},
+		{
+			name:     "GitHub shorthand without parameters",
+			source:   "github.com/hashicorp/terraform-aws-vpc",
+			expected: "",
+		},
+
+		// Edge cases
+		{
+			name:     "invalid URL",
+			source:   "not-a-valid-url",
+			expected: "",
+		},
+		{
+			name:     "empty source",
+			source:   "",
+			expected: "",
+		},
+
+		// Additional edge cases
+		{
+			name:     "git URL with multiple query parameters",
+			source:   "git::https://example.com/repo.git?depth=1&ref=v1.0.0&sshkey=mykey",
+			expected: "v1.0.0",
+		},
+		{
+			name:     "git URL with fragment and query",
+			source:   "git::https://example.com/repo.git?ref=v2.0.0#somefragment",
+			expected: "v2.0.0", // Fragment should be excluded from version hint
+		},
+		{
+			name:     "case sensitivity - uppercase REF",
+			source:   "git::https://example.com/repo.git?REF=v1.0.0",
+			expected: "", // Should not match due to case sensitivity
+		},
+		{
+			name:     "malformed git URL with version parameters",
+			source:   "git::not-a-valid-url?ref=v1.0.0",
+			expected: "v1.0.0", // Should still extract parameter even from malformed URL
+		},
+		{
+			name:     "git URL with empty ref parameter value",
+			source:   "git::https://example.com/repo.git?ref=&tag=v1.0.0",
+			expected: "", // Empty ref returns empty, tag parameter is ignored
+		},
+		{
+			name:     "git URL with URL-encoded version",
+			source:   "git::https://example.com/repo.git?ref=v1.0.0%2Bbuild",
+			expected: "v1.0.0+build", // Should be URL decoded
+		},
+		{
+			name:     "SSH git URL with complex parameters",
+			source:   "git@github.com:owner/repo.git?ref=feature/new-feature&depth=1",
+			expected: "feature/new-feature",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			source := ModuleSourceRemote{
+				Package: ModulePackage(tt.source),
+			}
+			got := source.VersionHint()
+			if got != tt.expected {
+				t.Errorf("VersionHint() = %q, expected %q", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestModuleSourceRemote_isGitURL(t *testing.T) {
+	tests := []struct {
+		name     string
+		source   string
+		expected bool
+	}{
+		// Git URLs - should return true
+		{
+			name:     "explicit git:: prefix",
+			source:   "git::https://example.com/repo.git",
+			expected: true,
+		},
+		{
+			name:     "GitHub shorthand",
+			source:   "github.com/hashicorp/terraform",
+			expected: true,
+		},
+		{
+			name:     "BitBucket shorthand",
+			source:   "bitbucket.org/hashicorp/terraform",
+			expected: true,
+		},
+		{
+			name:     "SSH git URL",
+			source:   "git@github.com:hashicorp/terraform.git",
+			expected: true,
+		},
+		{
+			name:     "HTTPS URL ending in .git",
+			source:   "https://gitlab.com/example/repo.git",
+			expected: true,
+		},
+		{
+			name:     "HTTP URL ending in .git",
+			source:   "http://example.com/repo.git",
+			expected: true,
+		},
+
+		// Non-git URLs - should return false
+		{
+			name:     "HTTPS archive",
+			source:   "https://example.com/module.zip",
+			expected: false,
+		},
+		{
+			name:     "S3 URL",
+			source:   "s3::https://s3.amazonaws.com/bucket/module.zip",
+			expected: false,
+		},
+		{
+			name:     "GCS URL",
+			source:   "gcs::https://storage.googleapis.com/bucket/module.zip",
+			expected: false,
+		},
+		{
+			name:     "file:// URL",
+			source:   "file:///path/to/module",
+			expected: false,
+		},
+		{
+			name:     "URL containing .git but not ending with it",
+			source:   "https://example.com/.git/module.zip",
+			expected: false,
+		},
+		{
+			name:     "invalid URL",
+			source:   "not-a-url",
+			expected: false,
+		},
+		{
+			name:     "empty source",
+			source:   "",
+			expected: false,
+		},
+
+		// Additional edge cases for isGitURL
+		{
+			name:     "GitHub with subdirectory",
+			source:   "github.com/hashicorp/terraform//modules/vpc",
+			expected: true,
+		},
+		{
+			name:     "git URL with .git in middle of path",
+			source:   "https://example.com/.git-something/repo",
+			expected: false,
+		},
+		{
+			name:     "SSH with non-standard port",
+			source:   "git@example.com:2222/repo.git",
+			expected: true,
+		},
+		{
+			name:     "git URL with query parameters",
+			source:   "git::https://example.com/repo.git?ref=main",
+			expected: true,
+		},
+		{
+			name:     "URL ending with .git.zip (not git)",
+			source:   "https://example.com/archive.git.zip",
+			expected: false,
+		},
+		{
+			name:     "BitBucket with subdirectory",
+			source:   "bitbucket.org/owner/repo//modules/test",
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			source := ModuleSourceRemote{
+				Package: ModulePackage(tt.source),
+			}
+			got := source.isGitURL()
+			if got != tt.expected {
+				t.Errorf("isGitURL() = %v, expected %v", got, tt.expected)
+			}
+		})
+	}
+}

--- a/internal/checks/state_test.go
+++ b/internal/checks/state_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/configs/configload"
+	"github.com/hashicorp/terraform/internal/depsfile"
 	"github.com/hashicorp/terraform/internal/initwd"
 )
 
@@ -19,7 +20,7 @@ func TestChecksHappyPath(t *testing.T) {
 	loader, close := configload.NewLoaderForTests(t)
 	defer close()
 	inst := initwd.NewModuleInstaller(loader.ModulesDir(), loader, nil)
-	_, instDiags := inst.InstallModules(context.Background(), fixtureDir, "tests", true, false, initwd.ModuleInstallHooksImpl{})
+	_, _, instDiags := inst.InstallModules(context.Background(), fixtureDir, "tests", true, false, initwd.ModuleInstallHooksImpl{}, depsfile.NewLocks())
 	if instDiags.HasErrors() {
 		t.Fatal(instDiags.Err())
 	}

--- a/internal/command/command_test.go
+++ b/internal/command/command_test.go
@@ -159,7 +159,7 @@ func testModuleWithSnapshot(t *testing.T, name string) (*configs.Config, *config
 	// sources only this ultimately just records all of the module paths
 	// in a JSON file so that we can load them below.
 	inst := initwd.NewModuleInstaller(loader.ModulesDir(), loader, registry.NewClient(nil, nil))
-	_, instDiags := inst.InstallModules(context.Background(), dir, "tests", true, false, initwd.ModuleInstallHooksImpl{})
+	_, _, instDiags := inst.InstallModules(context.Background(), dir, "tests", true, false, initwd.ModuleInstallHooksImpl{}, depsfile.NewLocks())
 	if instDiags.HasErrors() {
 		t.Fatal(instDiags.Err())
 	}

--- a/internal/command/get.go
+++ b/internal/command/get.go
@@ -90,5 +90,6 @@ func getModules(ctx context.Context, m *Meta, path string, testsDir string, upgr
 		Ui:             m.Ui,
 		ShowLocalPaths: true,
 	}
-	return m.installModules(ctx, path, testsDir, upgrade, true, hooks)
+	abort, _, diags = m.installModules(ctx, path, testsDir, upgrade, true, hooks)
+	return abort, diags
 }

--- a/internal/command/graph_test.go
+++ b/internal/command/graph_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/configs/configload"
 	"github.com/hashicorp/terraform/internal/configs/configschema"
+	"github.com/hashicorp/terraform/internal/depsfile"
 	"github.com/hashicorp/terraform/internal/initwd"
 	"github.com/hashicorp/terraform/internal/plans"
 	"github.com/hashicorp/terraform/internal/providers"
@@ -225,7 +226,7 @@ func TestGraph_resourcesOnly(t *testing.T) {
 		t.Fatal(err)
 	}
 	inst := initwd.NewModuleInstaller(".terraform/modules", loader, registry.NewClient(nil, nil))
-	_, instDiags := inst.InstallModules(context.Background(), ".", "tests", true, false, initwd.ModuleInstallHooksImpl{})
+	_, _, instDiags := inst.InstallModules(context.Background(), ".", "tests", true, false, initwd.ModuleInstallHooksImpl{}, depsfile.NewLocks())
 	if instDiags.HasErrors() {
 		t.Fatal(instDiags.Err())
 	}

--- a/internal/command/init_run.go
+++ b/internal/command/init_run.go
@@ -192,7 +192,7 @@ func (c *InitCommand) run(initArgs *arguments.Init, view views.Init) int {
 	}
 
 	if initArgs.Get {
-		modsOutput, modsAbort, modsDiags := c.getModules(ctx, path, initArgs.TestsDirectory, rootModEarly, initArgs.Upgrade, view)
+		modsOutput, modsAbort, modsDiags := c.getModules(ctx, path, initArgs.TestsDirectory, rootModEarly, initArgs.Upgrade, initArgs.Lockfile, view)
 		diags = diags.Append(modsDiags)
 		if modsAbort || modsDiags.HasErrors() {
 			view.Diagnostics(diags)

--- a/internal/command/meta_config.go
+++ b/internal/command/meta_config.go
@@ -20,6 +20,7 @@ import (
 	"github.com/hashicorp/terraform/internal/configs"
 	"github.com/hashicorp/terraform/internal/configs/configload"
 	"github.com/hashicorp/terraform/internal/configs/configschema"
+	"github.com/hashicorp/terraform/internal/depsfile"
 	"github.com/hashicorp/terraform/internal/initwd"
 	"github.com/hashicorp/terraform/internal/registry"
 	"github.com/hashicorp/terraform/internal/terraform"
@@ -183,7 +184,7 @@ func (m *Meta) loadHCLFile(filename string) (hcl.Body, tfdiags.Diagnostics) {
 // can then be relayed to the end-user. The uiModuleInstallHooks type in
 // this package has a reasonable implementation for displaying notifications
 // via a provided cli.Ui.
-func (m *Meta) installModules(ctx context.Context, rootDir, testsDir string, upgrade, installErrsOnly bool, hooks initwd.ModuleInstallHooks) (abort bool, diags tfdiags.Diagnostics) {
+func (m *Meta) installModules(ctx context.Context, rootDir, testsDir string, upgrade, installErrsOnly bool, hooks initwd.ModuleInstallHooks) (abort bool, updatedLocks *depsfile.Locks, diags tfdiags.Diagnostics) {
 	ctx, span := tracer.Start(ctx, "install modules")
 	defer span.End()
 
@@ -192,27 +193,34 @@ func (m *Meta) installModules(ctx context.Context, rootDir, testsDir string, upg
 	err := os.MkdirAll(m.modulesDir(), os.ModePerm)
 	if err != nil {
 		diags = diags.Append(fmt.Errorf("failed to create local modules directory: %s", err))
-		return true, diags
+		return true, nil, diags
 	}
 
 	loader, err := m.initConfigLoader()
 	if err != nil {
 		diags = diags.Append(err)
-		return true, diags
+		return true, nil, diags
 	}
 
 	inst := initwd.NewModuleInstaller(m.modulesDir(), loader, m.registryClient())
 
-	_, moreDiags := inst.InstallModules(ctx, rootDir, testsDir, upgrade, installErrsOnly, hooks)
+	// Load existing locks for hash validation
+	locks, lockDiags := m.lockedDependencies()
+	diags = diags.Append(lockDiags)
+	if lockDiags.HasErrors() {
+		return true, nil, diags
+	}
+
+	_, updatedLocks, moreDiags := inst.InstallModules(ctx, rootDir, testsDir, upgrade, installErrsOnly, hooks, locks)
 	diags = diags.Append(moreDiags)
 
 	if ctx.Err() == context.Canceled {
 		m.showDiagnostics(diags)
 		diags = diags.Append(fmt.Errorf("Module installation was canceled by an interrupt signal."))
-		return true, diags
+		return true, nil, diags
 	}
 
-	return false, diags
+	return false, updatedLocks, diags
 }
 
 // initDirFromModule initializes the given directory (which should be

--- a/internal/command/test_test.go
+++ b/internal/command/test_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/hashicorp/terraform/internal/command/views"
 	"github.com/hashicorp/terraform/internal/configs"
 	"github.com/hashicorp/terraform/internal/configs/configload"
+	"github.com/hashicorp/terraform/internal/depsfile"
 	"github.com/hashicorp/terraform/internal/initwd"
 	"github.com/hashicorp/terraform/internal/providers"
 	"github.com/hashicorp/terraform/internal/registry"
@@ -3945,7 +3946,7 @@ func testModuleInline(t *testing.T, sources map[string]string) (*configs.Config,
 	// sources only this ultimately just records all of the module paths
 	// in a JSON file so that we can load them below.
 	inst := initwd.NewModuleInstaller(loader.ModulesDir(), loader, registry.NewClient(nil, nil))
-	_, instDiags := inst.InstallModules(context.Background(), cfgPath, "tests", true, false, initwd.ModuleInstallHooksImpl{})
+	_, _, instDiags := inst.InstallModules(context.Background(), cfgPath, "tests", true, false, initwd.ModuleInstallHooksImpl{}, depsfile.NewLocks())
 	if instDiags.HasErrors() {
 		t.Fatal(instDiags.Err())
 	}

--- a/internal/command/testdata/init-module-lock-file-upgrade/child/main.tf
+++ b/internal/command/testdata/init-module-lock-file-upgrade/child/main.tf
@@ -1,0 +1,1 @@
+# Child module for upgrade test

--- a/internal/command/testdata/init-module-lock-file-upgrade/main.tf
+++ b/internal/command/testdata/init-module-lock-file-upgrade/main.tf
@@ -1,0 +1,3 @@
+module "test" {
+  source = "./child"
+}

--- a/internal/command/testdata/init-module-lock-file/child/main.tf
+++ b/internal/command/testdata/init-module-lock-file/child/main.tf
@@ -1,0 +1,1 @@
+# Empty child module

--- a/internal/command/testdata/init-module-lock-file/main.tf
+++ b/internal/command/testdata/init-module-lock-file/main.tf
@@ -1,0 +1,3 @@
+module "test" {
+  source = "./child"
+}

--- a/internal/depsfile/locks_test.go
+++ b/internal/depsfile/locks_test.go
@@ -311,3 +311,268 @@ func TestProviderLockContainsAll(t *testing.T) {
 		}
 	})
 }
+
+func TestModuleLocks(t *testing.T) {
+	moduleCall1 := addrs.ModuleCall{Name: "example"}.Absolute(addrs.RootModuleInstance)
+	moduleCall2 := addrs.ModuleCall{Name: "other"}.Absolute(addrs.RootModuleInstance)
+	hash1 := providerreqs.HashScheme("h1").New("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+	hash2 := providerreqs.HashScheme("h1").New("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb")
+	hash3 := providerreqs.HashScheme("h1").New("ccccccccccccccccccccccccccccccccccccccccccc")
+
+	equalBothWays := func(t *testing.T, a, b *Locks) {
+		t.Helper()
+		if !a.Equal(b) {
+			t.Errorf("a should be equal to b")
+		}
+		if !b.Equal(a) {
+			t.Errorf("b should be equal to a")
+		}
+	}
+	nonEqualBothWays := func(t *testing.T, a, b *Locks) {
+		t.Helper()
+		if a.Equal(b) {
+			t.Errorf("a should not be equal to b")
+		}
+		if b.Equal(a) {
+			t.Errorf("b should not be equal to a")
+		}
+	}
+
+	t.Run("both empty", func(t *testing.T) {
+		a := NewLocks()
+		b := NewLocks()
+		equalBothWays(t, a, b)
+	})
+
+	t.Run("an extra module lock", func(t *testing.T) {
+		a := NewLocks()
+		b := NewLocks()
+		b.SetModule(moduleCall1, "./modules/example", "", []providerreqs.Hash{hash1})
+		nonEqualBothWays(t, a, b)
+	})
+
+	t.Run("both have same module with same hashes", func(t *testing.T) {
+		a := NewLocks()
+		b := NewLocks()
+		hashes := []providerreqs.Hash{hash1, hash2, hash3}
+		a.SetModule(moduleCall1, "./modules/example", "", hashes)
+		b.SetModule(moduleCall1, "./modules/example", "", hashes)
+		equalBothWays(t, a, b)
+	})
+
+	t.Run("both have same module with different hashes", func(t *testing.T) {
+		a := NewLocks()
+		b := NewLocks()
+		hashesA := []providerreqs.Hash{hash1, hash2}
+		hashesB := []providerreqs.Hash{hash1, hash3}
+		a.SetModule(moduleCall1, "./modules/example", "", hashesA)
+		b.SetModule(moduleCall1, "./modules/example", "", hashesB)
+		nonEqualBothWays(t, a, b)
+	})
+
+	t.Run("both have same module with different sources", func(t *testing.T) {
+		a := NewLocks()
+		b := NewLocks()
+		hashes := []providerreqs.Hash{hash1}
+		a.SetModule(moduleCall1, "./modules/example", "", hashes)
+		b.SetModule(moduleCall1, "./modules/other", "", hashes)
+		nonEqualBothWays(t, a, b)
+	})
+
+	t.Run("different modules", func(t *testing.T) {
+		a := NewLocks()
+		b := NewLocks()
+		hashes := []providerreqs.Hash{hash1}
+		a.SetModule(moduleCall1, "./modules/example", "", hashes)
+		b.SetModule(moduleCall2, "./modules/example", "", hashes)
+		nonEqualBothWays(t, a, b)
+	})
+}
+
+func TestModuleLockSetRemove(t *testing.T) {
+	moduleCall1 := addrs.ModuleCall{Name: "example"}.Absolute(addrs.RootModuleInstance)
+	moduleCall2 := addrs.ModuleCall{Name: "other"}.Absolute(addrs.RootModuleInstance)
+	hash := providerreqs.HashScheme("h1").New("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+
+	locks := NewLocks()
+	if got, want := len(locks.AllModules()), 0; got != want {
+		t.Fatalf("fresh locks object already has modules")
+	}
+
+	locks.SetModule(moduleCall1, "./modules/example", "", []providerreqs.Hash{hash})
+	{
+		got := locks.AllModules()
+		want := map[string]*ModuleLock{
+			moduleCall1.String(): {
+				addr:   moduleCall1,
+				source: "./modules/example",
+				hashes: []providerreqs.Hash{hash},
+			},
+		}
+		if diff := cmp.Diff(want, got, ModuleLockComparer); diff != "" {
+			t.Fatalf("wrong modules after SetModule example\n%s", diff)
+		}
+	}
+
+	locks.SetModule(moduleCall2, "./modules/other", "", []providerreqs.Hash{hash})
+	{
+		got := locks.AllModules()
+		want := map[string]*ModuleLock{
+			moduleCall1.String(): {
+				addr:   moduleCall1,
+				source: "./modules/example",
+				hashes: []providerreqs.Hash{hash},
+			},
+			moduleCall2.String(): {
+				addr:   moduleCall2,
+				source: "./modules/other",
+				hashes: []providerreqs.Hash{hash},
+			},
+		}
+		if diff := cmp.Diff(want, got, ModuleLockComparer); diff != "" {
+			t.Fatalf("wrong modules after SetModule other\n%s", diff)
+		}
+	}
+
+	locks.RemoveModule(moduleCall1)
+	{
+		got := locks.AllModules()
+		want := map[string]*ModuleLock{
+			moduleCall2.String(): {
+				addr:   moduleCall2,
+				source: "./modules/other",
+				hashes: []providerreqs.Hash{hash},
+			},
+		}
+		if diff := cmp.Diff(want, got, ModuleLockComparer); diff != "" {
+			t.Fatalf("wrong modules after RemoveModule example\n%s", diff)
+		}
+	}
+
+	locks.RemoveModule(moduleCall2)
+	{
+		got := locks.AllModules()
+		want := map[string]*ModuleLock{}
+		if diff := cmp.Diff(want, got, ModuleLockComparer); diff != "" {
+			t.Fatalf("wrong modules after RemoveModule other\n%s", diff)
+		}
+	}
+}
+
+func TestModuleLockPreferredHashes(t *testing.T) {
+	moduleCall := addrs.ModuleCall{Name: "example"}.Absolute(addrs.RootModuleInstance)
+	hash1 := providerreqs.HashScheme("h1").New("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+	hash2 := providerreqs.HashScheme("h1").New("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb")
+	hashes := []providerreqs.Hash{hash1, hash2}
+
+	lock := &ModuleLock{
+		addr:   moduleCall,
+		source: "./modules/example",
+		hashes: hashes,
+	}
+
+	got := lock.PreferredHashes()
+	if diff := cmp.Diff(hashes, got); diff != "" {
+		t.Errorf("wrong preferred hashes\n%s", diff)
+	}
+}
+
+func TestModuleLockAbsModuleCallPreventsCollisions(t *testing.T) {
+	locks := NewLocks()
+
+	// Create module structure where multiple modules call child modules with the same name:
+	// - module.database (root calls database)
+	// - module.parent1.database (parent1 calls database)
+	// - module.parent2.database (parent2 calls database)
+
+	// Root-level database call
+	rootDatabaseCall := addrs.ModuleCall{Name: "database"}.Absolute(addrs.RootModuleInstance)
+
+	// Nested database calls
+	parent1Instance := addrs.RootModuleInstance.Child("parent1", addrs.NoKey)
+	parent2Instance := addrs.RootModuleInstance.Child("parent2", addrs.NoKey)
+
+	parent1DatabaseCall := addrs.ModuleCall{Name: "database"}.Absolute(parent1Instance)
+	parent2DatabaseCall := addrs.ModuleCall{Name: "database"}.Absolute(parent2Instance)
+
+	hash1 := providerreqs.HashScheme("h1").New("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+	hash2 := providerreqs.HashScheme("h1").New("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb")
+	hash3 := providerreqs.HashScheme("h1").New("ccccccccccccccccccccccccccccccccccccccccccc")
+
+	// Set locks for all three database modules with different sources and hashes
+	locks.SetModule(rootDatabaseCall, "./modules/shared-db", "1.0.0", []providerreqs.Hash{hash1})
+	locks.SetModule(parent1DatabaseCall, "./modules/postgres", "2.0.0", []providerreqs.Hash{hash2})
+	locks.SetModule(parent2DatabaseCall, "./modules/mysql", "3.0.0", []providerreqs.Hash{hash3})
+
+	// Verify all three locks exist and are different
+	rootLock := locks.Module(rootDatabaseCall)
+	parent1Lock := locks.Module(parent1DatabaseCall)
+	parent2Lock := locks.Module(parent2DatabaseCall)
+
+	if rootLock == nil {
+		t.Fatal("Expected rootLock to exist for module.database")
+	}
+	if parent1Lock == nil {
+		t.Fatal("Expected parent1Lock to exist for module.parent1.database")
+	}
+	if parent2Lock == nil {
+		t.Fatal("Expected parent2Lock to exist for module.parent2.database")
+	}
+
+	// Verify they have different sources (proving no collision)
+	if got, want := rootLock.Source(), "./modules/shared-db"; got != want {
+		t.Errorf("rootLock source: got %s, want %s", got, want)
+	}
+	if got, want := parent1Lock.Source(), "./modules/postgres"; got != want {
+		t.Errorf("parent1Lock source: got %s, want %s", got, want)
+	}
+	if got, want := parent2Lock.Source(), "./modules/mysql"; got != want {
+		t.Errorf("parent2Lock source: got %s, want %s", got, want)
+	}
+
+	// Verify they have different versions
+	if got, want := rootLock.Version(), "1.0.0"; got != want {
+		t.Errorf("rootLock version: got %s, want %s", got, want)
+	}
+	if got, want := parent1Lock.Version(), "2.0.0"; got != want {
+		t.Errorf("parent1Lock version: got %s, want %s", got, want)
+	}
+	if got, want := parent2Lock.Version(), "3.0.0"; got != want {
+		t.Errorf("parent2Lock version: got %s, want %s", got, want)
+	}
+
+	// Verify the string representations are different (proving AbsModuleCall uniqueness)
+	rootKey := rootDatabaseCall.String()
+	parent1Key := parent1DatabaseCall.String()
+	parent2Key := parent2DatabaseCall.String()
+
+	expectedRootKey := "module.database"
+	expectedParent1Key := "module.parent1.module.database"
+	expectedParent2Key := "module.parent2.module.database"
+
+	if got, want := rootKey, expectedRootKey; got != want {
+		t.Errorf("rootDatabaseCall string: got %s, want %s", got, want)
+	}
+	if got, want := parent1Key, expectedParent1Key; got != want {
+		t.Errorf("parent1DatabaseCall string: got %s, want %s", got, want)
+	}
+	if got, want := parent2Key, expectedParent2Key; got != want {
+		t.Errorf("parent2DatabaseCall string: got %s, want %s", got, want)
+	}
+
+	// Verify all three keys are unique
+	keys := []string{rootKey, parent1Key, parent2Key}
+	for i, key1 := range keys {
+		for j, key2 := range keys {
+			if i != j && key1 == key2 {
+				t.Errorf("Keys should be unique but found duplicate: %s", key1)
+			}
+		}
+	}
+
+	// Verify that we have exactly 3 module locks total
+	allModules := locks.AllModules()
+	if got, want := len(allModules), 3; got != want {
+		t.Errorf("Total module locks: got %d, want %d", got, want)
+	}
+}

--- a/internal/depsfile/testdata/locks-files/mixed-provider-module-locks.hcl
+++ b/internal/depsfile/testdata/locks-files/mixed-provider-module-locks.hcl
@@ -1,0 +1,26 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "3.74.0"
+  constraints = ">= 3.29.0"
+  hashes = [
+    "h1:test-provider-hash-1",
+    "h1:test-provider-hash-2",
+  ]
+}
+
+module "module.local_example" {
+  source = "./modules/local-example"
+  hashes = [
+    "h1:test-module-hash-1",
+    "h1:test-module-hash-2",
+  ]
+}
+
+module "module.registry_example" {
+  source = "registry.terraform.io/terraform-aws-modules/vpc/aws"
+  hashes = [
+    "h1:test-module-hash-3",
+  ]
+}

--- a/internal/depsfile/testing.go
+++ b/internal/depsfile/testing.go
@@ -15,6 +15,14 @@ import (
 // of the ProviderLock type.
 var ProviderLockComparer cmp.Option
 
+// ModuleLockComparer is an option for github.com/google/go-cmp/cmp that
+// specifies how to compare values of type depsfile.ModuleLock.
+//
+// Use this, rather than crafting comparison options yourself, in case the
+// comparison strategy needs to change in future due to implementation details
+// of the ModuleLock type.
+var ModuleLockComparer cmp.Option
+
 func init() {
 	// For now, direct comparison of the unexported fields is good enough
 	// because we store everything in a normalized form. If that changes
@@ -22,4 +30,5 @@ func init() {
 	// type with exported fields, so we can retain the ability for cmp to
 	// still report differences deeply.
 	ProviderLockComparer = cmp.AllowUnexported(ProviderLock{})
+	ModuleLockComparer = cmp.AllowUnexported(ModuleLock{})
 }

--- a/internal/initwd/from_module.go
+++ b/internal/initwd/from_module.go
@@ -17,6 +17,7 @@ import (
 	"github.com/hashicorp/terraform/internal/configs"
 	"github.com/hashicorp/terraform/internal/configs/configload"
 	"github.com/hashicorp/terraform/internal/copy"
+	"github.com/hashicorp/terraform/internal/depsfile"
 	"github.com/hashicorp/terraform/internal/getmodules"
 	"github.com/hashicorp/terraform/internal/getmodules/moduleaddrs"
 
@@ -166,8 +167,9 @@ func DirFromModule(ctx context.Context, loader *configload.Loader, rootDir, modu
 	}
 	fetcher := getmodules.NewPackageFetcher()
 
-	walker := inst.moduleInstallWalker(ctx, instManifest, true, wrapHooks, fetcher)
-	_, cDiags := inst.installDescendantModules(fakeRootModule, instManifest, walker, true)
+	locks := depsfile.NewLocks()
+	walker := inst.moduleInstallWalker(ctx, instManifest, true, wrapHooks, fetcher, locks)
+	_, _, cDiags := inst.installDescendantModules(fakeRootModule, instManifest, walker, true, locks)
 	if cDiags.HasErrors() {
 		return diags.Append(cDiags)
 	}

--- a/internal/initwd/module_hash.go
+++ b/internal/initwd/module_hash.go
@@ -1,0 +1,150 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package initwd
+
+import (
+	"crypto/sha256"
+	"encoding/base64"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+)
+
+// includedExtensions contains file extensions that should be included in module hashing.
+// Only files that affect Terraform behavior are included.
+var includedExtensions = []string{
+	".tf",          // Terraform configuration files
+	".tf.json",     // JSON-based Terraform configuration
+	".tfvars",      // Terraform variable files
+	".tfvars.json", // JSON-based variable files
+	".tftest.hcl",  // Terraform test files
+	".tftest.json", // JSON-based test files
+	".sh",          // Shell scripts (often used in provisioners)
+	".py",          // Python scripts (often used in provisioners)
+	".ps1",         // PowerShell scripts (often used in provisioners)
+}
+
+// includedFiles contains specific filenames that should always be included if present
+var includedFiles = []string{
+	"README.md", // Documentation is important for module users
+	"README.txt",
+	"README",
+	"LICENSE", // License information
+	"LICENSE.md",
+	"LICENSE.txt",
+	"CHANGELOG.md", // Version history
+	"CHANGELOG.txt",
+	"CHANGELOG",
+}
+
+// shouldIncludePath checks if a given path should be included in hashing
+// based on explicit inclusion rules
+func shouldIncludePath(relPath string) bool {
+	// Normalize path separators
+	normalized := filepath.ToSlash(relPath)
+
+	// Skip hidden directories (except .terraform which we'd skip anyway)
+	parts := strings.Split(normalized, "/")
+	for _, part := range parts {
+		if strings.HasPrefix(part, ".") {
+			return false
+		}
+	}
+
+	// Check if it's a file we always include
+	baseName := filepath.Base(relPath)
+	for _, included := range includedFiles {
+		if strings.EqualFold(baseName, included) {
+			return true
+		}
+	}
+
+	// Check file extensions
+	ext := strings.ToLower(filepath.Ext(relPath))
+	for _, includedExt := range includedExtensions {
+		if ext == includedExt {
+			return true
+		}
+	}
+
+	// Don't include anything else
+	return false
+}
+
+// hashModuleContent computes a content-based hash of a module directory,
+// including only files that affect Terraform's behavior. This ensures
+// consistent hashes across different download methods while maintaining
+// security by only validating files that actually matter.
+func hashModuleContent(dir string) (string, error) {
+	// Collect all files that should be included in the hash
+	var files []string
+
+	err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		// Skip directories
+		if info.IsDir() {
+			return nil
+		}
+
+		// Get relative path from module root
+		relPath, err := filepath.Rel(dir, path)
+		if err != nil {
+			return err
+		}
+
+		// Check if this file should be included
+		if shouldIncludePath(relPath) {
+			// Convert to forward slashes for consistent hashing
+			files = append(files, filepath.ToSlash(relPath))
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		return "", fmt.Errorf("failed to walk directory: %w", err)
+	}
+
+	// If no relevant files found, that's an error
+	if len(files) == 0 {
+		return "", fmt.Errorf("no Terraform configuration files found in module directory")
+	}
+
+	// Sort files for deterministic output
+	slices.Sort(files)
+
+	// Hash each file's contents
+	h := sha256.New()
+	for _, file := range files {
+		if strings.Contains(file, "\n") {
+			return "", fmt.Errorf("filenames with newlines are not supported")
+		}
+
+		fullPath := filepath.Join(dir, filepath.FromSlash(file))
+		f, err := os.Open(fullPath)
+		if err != nil {
+			return "", fmt.Errorf("failed to open %s: %w", file, err)
+		}
+
+		// Hash the file contents
+		hf := sha256.New()
+		_, err = io.Copy(hf, f)
+		f.Close()
+		if err != nil {
+			return "", fmt.Errorf("failed to hash %s: %w", file, err)
+		}
+
+		// Add to summary: "hash  filename\n" (matching dirhash format)
+		fmt.Fprintf(h, "%x  %s\n", hf.Sum(nil), file)
+	}
+
+	// Return in the same h1: format as dirhash for compatibility
+	return "h1:" + base64.StdEncoding.EncodeToString(h.Sum(nil)), nil
+}

--- a/internal/initwd/module_install_test.go
+++ b/internal/initwd/module_install_test.go
@@ -46,7 +46,7 @@ func TestModuleInstaller(t *testing.T) {
 	loader, close := configload.NewLoaderForTests(t)
 	defer close()
 	inst := NewModuleInstaller(modulesDir, loader, nil)
-	_, diags := inst.InstallModules(context.Background(), ".", "tests", false, false, hooks)
+	_, _, diags := inst.InstallModules(context.Background(), ".", "tests", false, false, hooks, nil)
 	tfdiags.AssertNoDiagnostics(t, diags)
 
 	wantCalls := []testInstallHookCall{
@@ -110,7 +110,7 @@ func TestModuleInstaller_error(t *testing.T) {
 	loader, close := configload.NewLoaderForTests(t)
 	defer close()
 	inst := NewModuleInstaller(modulesDir, loader, nil)
-	_, diags := inst.InstallModules(context.Background(), ".", "tests", false, false, hooks)
+	_, _, diags := inst.InstallModules(context.Background(), ".", "tests", false, false, hooks, nil)
 
 	if !diags.HasErrors() {
 		t.Fatal("expected error")
@@ -131,7 +131,7 @@ func TestModuleInstaller_emptyModuleName(t *testing.T) {
 	loader, close := configload.NewLoaderForTests(t)
 	defer close()
 	inst := NewModuleInstaller(modulesDir, loader, nil)
-	_, diags := inst.InstallModules(context.Background(), ".", "tests", false, false, hooks)
+	_, _, diags := inst.InstallModules(context.Background(), ".", "tests", false, false, hooks, nil)
 
 	if !diags.HasErrors() {
 		t.Fatal("expected error")
@@ -152,7 +152,7 @@ func TestModuleInstaller_invalidModuleName(t *testing.T) {
 	loader, close := configload.NewLoaderForTests(t)
 	defer close()
 	inst := NewModuleInstaller(modulesDir, loader, registry.NewClient(nil, nil))
-	_, diags := inst.InstallModules(context.Background(), dir, "tests", false, false, hooks)
+	_, _, diags := inst.InstallModules(context.Background(), dir, "tests", false, false, hooks, nil)
 
 	if !diags.HasErrors() {
 		t.Fatal("expected error")
@@ -190,7 +190,7 @@ func TestModuleInstaller_packageEscapeError(t *testing.T) {
 	loader, close := configload.NewLoaderForTests(t)
 	defer close()
 	inst := NewModuleInstaller(modulesDir, loader, nil)
-	_, diags := inst.InstallModules(context.Background(), ".", "tests", false, false, hooks)
+	_, _, diags := inst.InstallModules(context.Background(), ".", "tests", false, false, hooks, nil)
 
 	if !diags.HasErrors() {
 		t.Fatal("expected error")
@@ -228,7 +228,7 @@ func TestModuleInstaller_explicitPackageBoundary(t *testing.T) {
 	loader, close := configload.NewLoaderForTests(t)
 	defer close()
 	inst := NewModuleInstaller(modulesDir, loader, nil)
-	_, diags := inst.InstallModules(context.Background(), ".", "tests", false, false, hooks)
+	_, _, diags := inst.InstallModules(context.Background(), ".", "tests", false, false, hooks, nil)
 
 	if diags.HasErrors() {
 		t.Fatalf("unexpected errors\n%s", diags.Err().Error())
@@ -251,7 +251,7 @@ func TestModuleInstaller_ExactMatchPrerelease(t *testing.T) {
 	loader, close := configload.NewLoaderForTests(t)
 	defer close()
 	inst := NewModuleInstaller(modulesDir, loader, registry.NewClient(nil, nil))
-	cfg, diags := inst.InstallModules(context.Background(), ".", "tests", false, false, hooks)
+	cfg, _, diags := inst.InstallModules(context.Background(), ".", "tests", false, false, hooks, nil)
 
 	if diags.HasErrors() {
 		t.Fatalf("found unexpected errors: %s", diags.Err())
@@ -278,7 +278,7 @@ func TestModuleInstaller_PartialMatchPrerelease(t *testing.T) {
 	loader, close := configload.NewLoaderForTests(t)
 	defer close()
 	inst := NewModuleInstaller(modulesDir, loader, registry.NewClient(nil, nil))
-	cfg, diags := inst.InstallModules(context.Background(), ".", "tests", false, false, hooks)
+	cfg, _, diags := inst.InstallModules(context.Background(), ".", "tests", false, false, hooks, nil)
 
 	if diags.HasErrors() {
 		t.Fatalf("found unexpected errors: %s", diags.Err())
@@ -301,7 +301,7 @@ func TestModuleInstaller_invalid_version_constraint_error(t *testing.T) {
 	loader, close := configload.NewLoaderForTests(t)
 	defer close()
 	inst := NewModuleInstaller(modulesDir, loader, nil)
-	_, diags := inst.InstallModules(context.Background(), ".", "tests", false, false, hooks)
+	_, _, diags := inst.InstallModules(context.Background(), ".", "tests", false, false, hooks, nil)
 
 	if !diags.HasErrors() {
 		t.Fatal("expected error")
@@ -327,7 +327,7 @@ func TestModuleInstaller_invalidVersionConstraintGetter(t *testing.T) {
 	loader, close := configload.NewLoaderForTests(t)
 	defer close()
 	inst := NewModuleInstaller(modulesDir, loader, nil)
-	_, diags := inst.InstallModules(context.Background(), ".", "tests", false, false, hooks)
+	_, _, diags := inst.InstallModules(context.Background(), ".", "tests", false, false, hooks, nil)
 
 	if !diags.HasErrors() {
 		t.Fatal("expected error")
@@ -353,7 +353,7 @@ func TestModuleInstaller_invalidVersionConstraintLocal(t *testing.T) {
 	loader, close := configload.NewLoaderForTests(t)
 	defer close()
 	inst := NewModuleInstaller(modulesDir, loader, nil)
-	_, diags := inst.InstallModules(context.Background(), ".", "tests", false, false, hooks)
+	_, _, diags := inst.InstallModules(context.Background(), ".", "tests", false, false, hooks, nil)
 
 	if !diags.HasErrors() {
 		t.Fatal("expected error")
@@ -379,7 +379,7 @@ func TestModuleInstaller_symlink(t *testing.T) {
 	loader, close := configload.NewLoaderForTests(t)
 	defer close()
 	inst := NewModuleInstaller(modulesDir, loader, nil)
-	_, diags := inst.InstallModules(context.Background(), ".", "tests", false, false, hooks)
+	_, _, diags := inst.InstallModules(context.Background(), ".", "tests", false, false, hooks, nil)
 	tfdiags.AssertNoDiagnostics(t, diags)
 
 	wantCalls := []testInstallHookCall{
@@ -455,7 +455,7 @@ func TestLoaderInstallModules_invalidRegistry(t *testing.T) {
 	loader, close := configload.NewLoaderForTests(t)
 	defer close()
 	inst := NewModuleInstaller(modulesDir, loader, registry.NewClient(nil, nil))
-	_, diags := inst.InstallModules(context.Background(), dir, "tests", false, false, hooks)
+	_, _, diags := inst.InstallModules(context.Background(), dir, "tests", false, false, hooks, nil)
 
 	if !diags.HasErrors() {
 		t.Fatal("expected error")
@@ -494,7 +494,7 @@ func TestLoaderInstallModules_registry(t *testing.T) {
 	loader, close := configload.NewLoaderForTests(t)
 	defer close()
 	inst := NewModuleInstaller(modulesDir, loader, registry.NewClient(nil, nil))
-	_, diags := inst.InstallModules(context.Background(), dir, "tests", false, false, hooks)
+	_, _, diags := inst.InstallModules(context.Background(), dir, "tests", false, false, hooks, nil)
 	tfdiags.AssertNoDiagnostics(t, diags)
 
 	v := version.Must(version.NewVersion("0.0.1"))
@@ -657,7 +657,7 @@ func TestLoaderInstallModules_goGetter(t *testing.T) {
 	loader, close := configload.NewLoaderForTests(t)
 	defer close()
 	inst := NewModuleInstaller(modulesDir, loader, registry.NewClient(nil, nil))
-	_, diags := inst.InstallModules(context.Background(), dir, "tests", false, false, hooks)
+	_, _, diags := inst.InstallModules(context.Background(), dir, "tests", false, false, hooks, nil)
 	tfdiags.AssertNoDiagnostics(t, diags)
 
 	wantCalls := []testInstallHookCall{
@@ -775,7 +775,7 @@ func TestModuleInstaller_fromTests(t *testing.T) {
 	loader, close := configload.NewLoaderForTests(t)
 	defer close()
 	inst := NewModuleInstaller(modulesDir, loader, nil)
-	_, diags := inst.InstallModules(context.Background(), ".", "tests", false, false, hooks)
+	_, _, diags := inst.InstallModules(context.Background(), ".", "tests", false, false, hooks, nil)
 	tfdiags.AssertNoDiagnostics(t, diags)
 
 	wantCalls := []testInstallHookCall{
@@ -832,7 +832,7 @@ func TestLoadInstallModules_registryFromTest(t *testing.T) {
 	loader, close := configload.NewLoaderForTests(t)
 	defer close()
 	inst := NewModuleInstaller(modulesDir, loader, registry.NewClient(nil, nil))
-	_, diags := inst.InstallModules(context.Background(), dir, "tests", false, false, hooks)
+	_, _, diags := inst.InstallModules(context.Background(), dir, "tests", false, false, hooks, nil)
 	tfdiags.AssertNoDiagnostics(t, diags)
 
 	v := version.Must(version.NewVersion("0.0.1"))
@@ -1023,4 +1023,78 @@ func assertResultDeepEqual(t *testing.T, got, want interface{}) bool {
 		return true
 	}
 	return false
+}
+
+func TestModuleInstaller_moduleLockCleanup(t *testing.T) {
+	// This test verifies that module locks are properly cleaned up
+	// when modules are removed from the configuration
+	
+	// We need to use registry modules since local modules don't create locks
+	if os.Getenv("TF_ACC") == "" {
+		t.Skip("this test accesses registry.terraform.io; set TF_ACC=1 to run it")
+	}
+	
+	fixtureDir := filepath.Clean("testdata/registry-modules")
+	dir, done := tempChdir(t, fixtureDir)
+
+	defer done()
+
+	hooks := &testInstallHooks{}
+	modulesDir := filepath.Join(dir, ".terraform/modules")
+	loader, close := configload.NewLoaderForTests(t)
+
+	defer close()
+	
+	// Configure registry client
+	regDisco := registry.NewClient(nil, nil)
+	inst := NewModuleInstaller(modulesDir, loader, regDisco)
+
+	// First install with modules
+	_, locks, diags := inst.InstallModules(t.Context(), ".", "tests", false, false, hooks, nil)
+	tfdiags.AssertNoDiagnostics(t, diags)
+
+	// Verify we have module locks (registry modules create locks)
+	initialModuleCount := len(locks.AllModules())
+	if initialModuleCount != 3 {
+		t.Fatalf("expected 3 module locks, got %d", initialModuleCount)
+	}
+
+	// Create a modified configuration with fewer modules
+	tempDir := t.TempDir()
+	
+	// Write a configuration with only one module instead of three
+	modifiedConfig := `
+module "acctest_root" {
+  source  = "hashicorp/module-installer-acctest/aws"
+  version = "0.0.1"
+}
+`
+	err := os.WriteFile(filepath.Join(tempDir, "root.tf"), []byte(modifiedConfig), 0644)
+	if err != nil {
+		t.Fatalf("failed to write modified root.tf: %s", err)
+	}
+
+	// Create a new installer for the temp directory
+	t.Chdir(tempDir)
+	tempModulesDir := filepath.Join(tempDir, ".terraform/modules")
+	
+	// Create a fresh loader for the new directory to avoid caching issues
+	loader2, close2 := configload.NewLoaderForTests(t)
+	defer close2()
+
+	inst2 := NewModuleInstaller(tempModulesDir, loader2, regDisco)
+	
+	// Install again with the modified configuration
+	// The cleanup code should remove locks for modules no longer in config
+	_, locks2, diags := inst2.InstallModules(t.Context(), ".", "tests", false, false, hooks, locks)
+	tfdiags.AssertNoDiagnostics(t, diags)
+
+	// Verify that we have fewer module locks now (should be 1 instead of 3)
+	finalModuleCount := len(locks2.AllModules())
+	if finalModuleCount != 1 {
+		t.Errorf("expected 1 module lock after removing modules from config, got %d", finalModuleCount)
+		for _, lock := range locks2.AllModules() {
+			t.Logf("  - %s", lock.ModuleCall())
+		}
+	}
 }

--- a/internal/initwd/testing.go
+++ b/internal/initwd/testing.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/hashicorp/terraform/internal/configs"
 	"github.com/hashicorp/terraform/internal/configs/configload"
+	"github.com/hashicorp/terraform/internal/depsfile"
 	"github.com/hashicorp/terraform/internal/registry"
 	"github.com/hashicorp/terraform/internal/tfdiags"
 )
@@ -39,7 +40,7 @@ func LoadConfigForTests(t *testing.T, rootDir string, testsDir string) (*configs
 	loader, cleanup := configload.NewLoaderForTests(t)
 	inst := NewModuleInstaller(loader.ModulesDir(), loader, registry.NewClient(nil, nil))
 
-	_, moreDiags := inst.InstallModules(context.Background(), rootDir, testsDir, true, false, ModuleInstallHooksImpl{})
+	_, _, moreDiags := inst.InstallModules(context.Background(), rootDir, testsDir, true, false, ModuleInstallHooksImpl{}, depsfile.NewLocks())
 	diags = diags.Append(moreDiags)
 	if diags.HasErrors() {
 		cleanup()

--- a/internal/lang/globalref/analyzer_test.go
+++ b/internal/lang/globalref/analyzer_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/configs/configload"
 	"github.com/hashicorp/terraform/internal/configs/configschema"
+	"github.com/hashicorp/terraform/internal/depsfile"
 	"github.com/hashicorp/terraform/internal/initwd"
 	"github.com/hashicorp/terraform/internal/providers"
 	"github.com/hashicorp/terraform/internal/registry"
@@ -25,7 +26,7 @@ func testAnalyzer(t *testing.T, fixtureName string) *Analyzer {
 	defer cleanup()
 
 	inst := initwd.NewModuleInstaller(loader.ModulesDir(), loader, registry.NewClient(nil, nil))
-	_, instDiags := inst.InstallModules(context.Background(), configDir, "tests", true, false, initwd.ModuleInstallHooksImpl{})
+	_, _, instDiags := inst.InstallModules(context.Background(), configDir, "tests", true, false, initwd.ModuleInstallHooksImpl{}, depsfile.NewLocks())
 	if instDiags.HasErrors() {
 		t.Fatalf("unexpected module installation errors: %s", instDiags.Err().Error())
 	}

--- a/internal/moduletest/graph/eval_context_test.go
+++ b/internal/moduletest/graph/eval_context_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/hashicorp/terraform/internal/configs"
 	"github.com/hashicorp/terraform/internal/configs/configload"
 	"github.com/hashicorp/terraform/internal/configs/configschema"
+	"github.com/hashicorp/terraform/internal/depsfile"
 	"github.com/hashicorp/terraform/internal/initwd"
 	"github.com/hashicorp/terraform/internal/moduletest"
 	"github.com/hashicorp/terraform/internal/plans"
@@ -836,7 +837,7 @@ func testModuleInline(t *testing.T, sources map[string]string) *configs.Config {
 	// sources only this ultimately just records all of the module paths
 	// in a JSON file so that we can load them below.
 	inst := initwd.NewModuleInstaller(loader.ModulesDir(), loader, registry.NewClient(nil, nil))
-	_, instDiags := inst.InstallModules(context.Background(), cfgPath, "tests", true, false, initwd.ModuleInstallHooksImpl{})
+	_, _, instDiags := inst.InstallModules(context.Background(), cfgPath, "tests", true, false, initwd.ModuleInstallHooksImpl{}, depsfile.NewLocks())
 	if instDiags.HasErrors() {
 		t.Fatal(instDiags.Err())
 	}

--- a/internal/refactoring/move_validate_test.go
+++ b/internal/refactoring/move_validate_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/configs"
 	"github.com/hashicorp/terraform/internal/configs/configload"
+	"github.com/hashicorp/terraform/internal/depsfile"
 	"github.com/hashicorp/terraform/internal/initwd"
 	"github.com/hashicorp/terraform/internal/instances"
 	"github.com/hashicorp/terraform/internal/registry"
@@ -520,7 +521,7 @@ func loadRefactoringFixture(t *testing.T, dir string) (*configs.Config, instance
 	defer cleanup()
 
 	inst := initwd.NewModuleInstaller(loader.ModulesDir(), loader, registry.NewClient(nil, nil))
-	_, instDiags := inst.InstallModules(context.Background(), dir, "tests", true, false, initwd.ModuleInstallHooksImpl{})
+	_, _, instDiags := inst.InstallModules(context.Background(), dir, "tests", true, false, initwd.ModuleInstallHooksImpl{}, depsfile.NewLocks())
 	if instDiags.HasErrors() {
 		t.Fatal(instDiags.Err())
 	}

--- a/internal/terraform/terraform_test.go
+++ b/internal/terraform/terraform_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/configs"
 	"github.com/hashicorp/terraform/internal/configs/configload"
+	"github.com/hashicorp/terraform/internal/depsfile"
 	"github.com/hashicorp/terraform/internal/initwd"
 	"github.com/hashicorp/terraform/internal/plans"
 	"github.com/hashicorp/terraform/internal/providers"
@@ -68,7 +69,7 @@ func testModuleWithSnapshot(t *testing.T, name string) (*configs.Config, *config
 	// sources only this ultimately just records all of the module paths
 	// in a JSON file so that we can load them below.
 	inst := initwd.NewModuleInstaller(loader.ModulesDir(), loader, registry.NewClient(nil, nil))
-	_, instDiags := inst.InstallModules(context.Background(), dir, "tests", true, false, initwd.ModuleInstallHooksImpl{})
+	_, _, instDiags := inst.InstallModules(context.Background(), dir, "tests", true, false, initwd.ModuleInstallHooksImpl{}, depsfile.NewLocks())
 	if instDiags.HasErrors() {
 		t.Fatal(instDiags.Err())
 	}
@@ -128,7 +129,7 @@ func testModuleInline(t testing.TB, sources map[string]string) *configs.Config {
 	// sources only this ultimately just records all of the module paths
 	// in a JSON file so that we can load them below.
 	inst := initwd.NewModuleInstaller(loader.ModulesDir(), loader, registry.NewClient(nil, nil))
-	_, instDiags := inst.InstallModules(context.Background(), cfgPath, "tests", true, false, initwd.ModuleInstallHooksImpl{})
+	_, _, instDiags := inst.InstallModules(context.Background(), cfgPath, "tests", true, false, initwd.ModuleInstallHooksImpl{}, depsfile.NewLocks())
 	if instDiags.HasErrors() {
 		t.Fatal(instDiags.Err())
 	}


### PR DESCRIPTION
This PR implements module dependency locking in Terraform, adding cryptographic hash verification for modules to prevent supply chain attacks.
  Module locks are now stored alongside provider locks in `.terraform.lock.hcl`.

  As described in #31301, Terraform lacks integrity verification for modules. If a module registry or git repository is
  compromised, malicious code could be served for a previously-trusted module version, potentially compromising infrastructure.

  This implementation adds:
  - Hash-based verification using `dirhash.Hash1` algorithm
  - Module locks stored in `.terraform.lock.hcl` alongside provider locks
  - Version tracking for Git modules (ref/tag/branch/commit) and registry modules
  - Validation on subsequent `terraform init` runs

  The change is fully backwards compatible - existing configurations work without modification, and lock entries are added automatically on the
  next `terraform init`.

  Fixes #31301

  ## Target Release

  1.14.x

  ## Rollback Plan

  - [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

  ## Changes to Security Controls

  This PR enhances security controls by adding cryptographic hash verification for modules. This prevents module tampering and ensures the
  integrity of module content across different environments. No existing security controls are removed or weakened.

  ## CHANGELOG entry

  - [x] This change is user-facing and I added a changelog entry.
  - [ ] This change is not user-facing.
