### PR TITLE
Bump backport assistant to 0.5.8

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -17,7 +17,7 @@ jobs:
   backport:
     if: github.event.pull_request
     runs-on: ubuntu-latest
-    container: hashicorpdev/backport-assistant:0.4.7@sha256:36f9d4fba82b9454f1f62bf76c8078fafe3ab0be71356cb96af6d56ac4482cd8
+    container: hashicorpdev/backport-assistant:0.5.8@sha256:b18bc289f405beb58aa22a1b4b3bdac42394fad602541ed94a0f9c5e3f66f954
     steps:
       - name: Run Backport Assistant
         run: |


### PR DESCRIPTION
This PR renames the backport workflow file from `main` to a more specific name and bumps the backport assistants version, which hasn't been updated in over a year

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.14.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
