### PR TITLE
Allow list resource RPC events with only warnings

### DIFF
--- a/internal/plugin/grpc_provider_test.go
+++ b/internal/plugin/grpc_provider_test.go
@@ -2737,39 +2737,6 @@ func TestGRPCProvider_ListResource_Error(t *testing.T) {
 }
 
 func TestGRPCProvider_ListResource_Diagnostics(t *testing.T) {
-	client := mockProviderClient(t)
-	p := &GRPCProvider{
-		client: client,
-		ctx:    context.Background(),
-	}
-
-	// Create a mock stream client that will return a resource event with diagnostics
-	mockStream := &mockListResourceStreamClient{
-		events: []*proto.ListResource_Event{
-			{
-				DisplayName: "Test Resource With Warning",
-				Identity: &proto.ResourceIdentityData{
-					IdentityData: &proto.DynamicValue{
-						Msgpack: []byte("\x81\xa7id_attr\xa4id-1"),
-					},
-				},
-				Diagnostic: []*proto.Diagnostic{
-					{
-						Severity: proto.Diagnostic_WARNING,
-						Summary:  "Test warning",
-						Detail:   "This is a test warning",
-					},
-				},
-			},
-		},
-	}
-
-	client.EXPECT().ListResource(
-		gomock.Any(),
-		gomock.Any(),
-	).Return(mockStream, nil)
-
-	// Create the request
 	configVal := cty.ObjectVal(map[string]cty.Value{
 		"config": cty.ObjectVal(map[string]cty.Value{
 			"filter_attr": cty.StringVal("filter-value"),
@@ -2781,16 +2748,212 @@ func TestGRPCProvider_ListResource_Diagnostics(t *testing.T) {
 		Limit:    100,
 	}
 
-	resp := p.ListResource(request)
-	checkDiags(t, resp.Diagnostics)
-
-	data := resp.Result.AsValueMap()
-	if _, ok := data["data"]; !ok {
-		t.Fatal("Expected 'data' key in result")
+	testCases := []struct {
+		name          string
+		events        []*proto.ListResource_Event
+		expectedCount int
+		expectedDiags int
+		expectedWarns int // subset of expectedDiags
+	}{
+		{
+			"no events",
+			[]*proto.ListResource_Event{},
+			0,
+			0,
+			0,
+		},
+		{
+			"single event no diagnostics",
+			[]*proto.ListResource_Event{
+				{
+					DisplayName: "Test Resource",
+					Identity: &proto.ResourceIdentityData{
+						IdentityData: &proto.DynamicValue{
+							Msgpack: []byte("\x81\xa7id_attr\xa4id-1"),
+						},
+					},
+				},
+			},
+			1,
+			0,
+			0,
+		},
+		{
+			"event with warning",
+			[]*proto.ListResource_Event{
+				{
+					DisplayName: "Test Resource",
+					Identity: &proto.ResourceIdentityData{
+						IdentityData: &proto.DynamicValue{
+							Msgpack: []byte("\x81\xa7id_attr\xa4id-1"),
+						},
+					},
+					Diagnostic: []*proto.Diagnostic{
+						{
+							Severity: proto.Diagnostic_WARNING,
+							Summary:  "Test warning",
+							Detail:   "Warning detail",
+						},
+					},
+				},
+			},
+			1,
+			1,
+			1,
+		},
+		{
+			"only a warning",
+			[]*proto.ListResource_Event{
+				{
+					Diagnostic: []*proto.Diagnostic{
+						{
+							Severity: proto.Diagnostic_WARNING,
+							Summary:  "Test warning",
+							Detail:   "Warning detail",
+						},
+					},
+				},
+			},
+			0,
+			1,
+			1,
+		},
+		{
+			"only an error",
+			[]*proto.ListResource_Event{
+				{
+					Diagnostic: []*proto.Diagnostic{
+						{
+							Severity: proto.Diagnostic_ERROR,
+							Summary:  "Test error",
+							Detail:   "Error detail",
+						},
+					},
+				},
+			},
+			0,
+			1,
+			0,
+		},
+		{
+			"event with error",
+			[]*proto.ListResource_Event{
+				{
+					DisplayName: "Test Resource",
+					Identity: &proto.ResourceIdentityData{
+						IdentityData: &proto.DynamicValue{
+							Msgpack: []byte("\x81\xa7id_attr\xa4id-1"),
+						},
+					},
+					Diagnostic: []*proto.Diagnostic{
+						{
+							Severity: proto.Diagnostic_ERROR,
+							Summary:  "Test error",
+							Detail:   "Error detail",
+						},
+					},
+				},
+			},
+			0,
+			1,
+			0,
+		},
+		{
+			"multiple events mixed diagnostics",
+			[]*proto.ListResource_Event{
+				{
+					DisplayName: "Resource 1",
+					Identity: &proto.ResourceIdentityData{
+						IdentityData: &proto.DynamicValue{
+							Msgpack: []byte("\x81\xa7id_attr\xa4id-1"),
+						},
+					},
+					Diagnostic: []*proto.Diagnostic{
+						{
+							Severity: proto.Diagnostic_WARNING,
+							Summary:  "Warning 1",
+							Detail:   "Warning detail 1",
+						},
+					},
+				},
+				{
+					DisplayName: "Resource 2",
+					Identity: &proto.ResourceIdentityData{
+						IdentityData: &proto.DynamicValue{
+							Msgpack: []byte("\x81\xa7id_attr\xa4id-2"),
+						},
+					},
+				},
+				{
+					DisplayName: "Resource 3",
+					Identity: &proto.ResourceIdentityData{
+						IdentityData: &proto.DynamicValue{
+							Msgpack: []byte("\x81\xa7id_attr\xa4id-3"),
+						},
+					},
+					Diagnostic: []*proto.Diagnostic{
+						{
+							Severity: proto.Diagnostic_ERROR,
+							Summary:  "Error 1",
+							Detail:   "Error detail 1",
+						},
+						{
+							Severity: proto.Diagnostic_WARNING,
+							Summary:  "Warning 2",
+							Detail:   "Warning detail 2",
+						},
+					},
+				},
+				{ // This event will never be reached
+					DisplayName: "Resource 4",
+					Identity: &proto.ResourceIdentityData{
+						IdentityData: &proto.DynamicValue{
+							Msgpack: []byte("\x81\xa7id_attr\xa4id-4"),
+						},
+					},
+				},
+			},
+			2,
+			3,
+			2,
+		},
 	}
 
-	if !resp.Diagnostics.HasWarnings() {
-		t.Fatal("Expected warning diagnostics, but got none")
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			client := mockProviderClient(t)
+			p := &GRPCProvider{
+				client: client,
+				ctx:    context.Background(),
+			}
+
+			mockStream := &mockListResourceStreamClient{
+				events: tc.events,
+			}
+
+			client.EXPECT().ListResource(
+				gomock.Any(),
+				gomock.Any(),
+			).Return(mockStream, nil)
+
+			resp := p.ListResource(request)
+
+			result := resp.Result.AsValueMap()
+			nResults := result["data"].LengthInt()
+			if nResults != tc.expectedCount {
+				t.Fatalf("Expected %d results, got %d", tc.expectedCount, nResults)
+			}
+
+			nDiagnostics := len(resp.Diagnostics)
+			if nDiagnostics != tc.expectedDiags {
+				t.Fatalf("Expected %d diagnostics, got %d", tc.expectedDiags, nDiagnostics)
+			}
+
+			nWarnings := len(resp.Diagnostics.Warnings())
+			if nWarnings != tc.expectedWarns {
+				t.Fatalf("Expected %d warnings, got %d", tc.expectedWarns, nWarnings)
+			}
+		})
 	}
 }
 

--- a/internal/plugin6/grpc_provider.go
+++ b/internal/plugin6/grpc_provider.go
@@ -1345,12 +1345,23 @@ func (p *GRPCProvider) ListResource(r providers.ListResourceRequest) providers.L
 			break
 		}
 
+		resp.Diagnostics = resp.Diagnostics.Append(convert.ProtoToDiagnostics(event.Diagnostic))
+		if resp.Diagnostics.HasErrors() {
+			// If we have errors, we stop processing and return early
+			break
+		}
+
+		if resp.Diagnostics.HasWarnings() &&
+			(event.Identity == nil || event.Identity.IdentityData == nil) {
+			// If we have warnings but no identity data, we continue with the next event
+			continue
+		}
+
 		obj := map[string]cty.Value{
 			"display_name": cty.StringVal(event.DisplayName),
 			"state":        cty.NullVal(resourceSchema.Body.ImpliedType()),
 			"identity":     cty.NullVal(resourceSchema.Identity.ImpliedType()),
 		}
-		resp.Diagnostics = resp.Diagnostics.Append(convert.ProtoToDiagnostics(event.Diagnostic))
 
 		// Handle identity data - it must be present
 		if event.Identity == nil || event.Identity.IdentityData == nil {
@@ -1376,11 +1387,11 @@ func (p *GRPCProvider) ListResource(r providers.ListResourceRequest) providers.L
 		}
 
 		if resp.Diagnostics.HasErrors() {
+			// If validation errors occurred, we stop processing and return early
 			break
 		}
 
 		results = append(results, cty.ObjectVal(obj))
-
 	}
 
 	// The provider result of a list resource is always a list, but


### PR DESCRIPTION
This PR updates the logic for processing list events. Terraform now allows error and warning diagnostics for list events where all other fields are set to null. It is still possible to have a warning alongside a valid result. Terraform stops processing events and returns early whenever it encounters an error.


## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.14.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
