### PR TITLE
stacks migrate: make diagnostics more relevant to operation

### DIFF
--- a/internal/stacks/stackruntime/testdata/mainbundle/test/for-stacks-migrate/single-component/child/child.tf
+++ b/internal/stacks/stackruntime/testdata/mainbundle/test/for-stacks-migrate/single-component/child/child.tf
@@ -1,0 +1,24 @@
+
+terraform {
+  required_providers {
+    testing = {
+      source  = "hashicorp/testing"
+      version = "0.1.0"
+    }
+  }
+}
+
+resource "testing_resource" "one" {
+  id = "one"
+  value = "one"
+}
+
+resource "testing_resource" "two" {
+  id = "two"
+  value = "two"
+}
+
+resource "testing_resource" "three" {
+  id = "three"
+  value = "three"
+}

--- a/internal/stacks/stackruntime/testdata/mainbundle/test/for-stacks-migrate/single-component/child/grandchild/main.tf
+++ b/internal/stacks/stackruntime/testdata/mainbundle/test/for-stacks-migrate/single-component/child/grandchild/main.tf
@@ -1,0 +1,14 @@
+
+terraform {
+  required_providers {
+    testing = {
+      source  = "hashicorp/testing"
+      version = "0.1.0"
+    }
+  }
+}
+
+resource "testing_resource" "one" {
+  id = "one"
+  value = "one"
+}

--- a/internal/stacks/stackruntime/testdata/mainbundle/test/for-stacks-migrate/single-component/single-component.tfcomponent.hcl
+++ b/internal/stacks/stackruntime/testdata/mainbundle/test/for-stacks-migrate/single-component/single-component.tfcomponent.hcl
@@ -1,0 +1,16 @@
+required_providers {
+  testing = {
+    source  = "hashicorp/testing"
+    version = "0.1.0"
+  }
+}
+
+provider "testing" "default" {}
+
+component "single" {
+  source = "./child"
+
+  providers = {
+    testing = provider.testing.default
+  }
+}


### PR DESCRIPTION
Some feedback from the Stacks migrate team is that the diagnostic returned by Terraform were a bit confusing. This PR goes through some of the diagnostics returned when Terraform migrates state and makes the wording more relevant to the actual operation being carried out.

Generally, Terraform was being a bit too specific about it's internal workings such as returning "provider not found" errors when the root cause was the a mapping was trying to point a resource to an address that didn't exist in the stack configuration. The diagnostics now try and relate things back to what the caller is actually trying to do instead of what Terraform is trying to do at the current point in time.