### PR TITLE
Fix JSON format ignored in some logging subsystems

### DIFF
--- a/.changes/v1.14/BUG FIXES-20250814-120000.yaml
+++ b/.changes/v1.14/BUG FIXES-20250814-120000.yaml
@@ -1,0 +1,5 @@
+kind: BUG FIXES
+body: 'logging: Fixed JSON format being ignored in some logging subsystems when TF_LOG_* environment variables are set to "JSON"'
+time: 2025-08-14T12:00:00.000000+00:00
+custom:
+    Issue: "37433"

--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -204,10 +204,24 @@ func globalLogLevel() (hclog.Level, bool) {
 	if envLevel == "" {
 		envLevel = strings.ToUpper(os.Getenv(envLogCore))
 	}
-	if envLevel == "JSON" {
-		json = true
-	}
+
+	// Check if JSON formatting is requested by any subsystem
+	json = isJSONFormatRequested()
+
 	return parseLogLevel(envLevel), json
+}
+
+// isJSONFormatRequested checks if any logging subsystem has requested JSON formatting
+func isJSONFormatRequested() bool {
+	logEnvVars := []string{envLog, envLogCore, envLogProvider, envLogCloud, envLogStacks}
+
+	for _, envVar := range logEnvVars {
+		if strings.ToUpper(os.Getenv(envVar)) == "JSON" {
+			return true
+		}
+	}
+
+	return false
 }
 
 func parseLogLevel(envLevel string) hclog.Level {


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Fixes https://github.com/hashicorp/terraform/issues/37433

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.14.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

This actually fixes what is described in the docs https://developer.hashicorp.com/terraform/internals/debugging

- [ ] This change is user-facing and I added a changelog entry.
- [ ] This change is not user-facing.
