### PR TITLE
actions: improve error messages and reenable error related tests

### DIFF
--- a/internal/terraform/context_plan_actions_test.go
+++ b/internal/terraform/context_plan_actions_test.go
@@ -665,7 +665,6 @@ resource "test_object" "e" {
 		},
 
 		"failing actions cancel next ones": {
-			toBeImplemented: true, // TODO: Look into this
 			module: map[string]string{
 				"main.tf": `
 action "test_unlinked" "failure" {}


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

We disabled a few tests around error handling for actions when we refactored the way actions work in #37444. This PR re-enables them albeit differently: Instead of adding context for how to proceed (undo changes, retry failing / not-yet-run actions) we show the invocation of the action. This gives the user more context. We will wait for user feedback if the next steps would be useful as well even with this context already in place. It is a bit more difficult to add this info in the current system therefore we postpone it for now until the work is more stable.

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Fixes #

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.14.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.