### PR TITLE
Update info for debugging why `TestInitProvidersLocalOnly` may fail

### DIFF
--- a/internal/command/e2etest/init_test.go
+++ b/internal/command/e2etest/init_test.go
@@ -168,6 +168,7 @@ func TestInitProvidersLocalOnly(t *testing.T) {
 
 	if stderr != "" {
 		t.Errorf("unexpected stderr output:\n%s", stderr)
+		t.Logf("(a \"Failed to query available provider packages\" error can happen here if you have a .terraformrc CLI configuration file present in your home directory)")
 	}
 
 	if !strings.Contains(stdout, "Terraform has been successfully initialized!") {


### PR DESCRIPTION
I just had to wrestle with this test for a while:

https://github.com/hashicorp/terraform/blob/62b3ba590aa2f0f4c5d412833f5317754f556c0c/internal/command/e2etest/init_test.go#L135C6-L143

The log at the end suggests checking [implied local mirror directories](https://developer.hashicorp.com/terraform/cli/config/config-file#implied-local-mirror-directories) but the test can fail earlier if a CLI configuration file is present on your machine and it causes Terraform to start making network calls.

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

N/A

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
