### PR TITLE
terraform test: fix regression when running with no tests (#37475) (alt)

### DIFF
--- a/.changes/v1.14/BUG FIXES-20250821-092253.yaml
+++ b/.changes/v1.14/BUG FIXES-20250821-092253.yaml
@@ -1,0 +1,5 @@
+kind: BUG FIXES
+body: Fix regression that caused `terraform test` with zero tests to return a non-zero exit code.
+time: 2025-08-21T09:22:53.392949+02:00
+custom:
+    Issue: "37478"

--- a/internal/backend/local/test.go
+++ b/internal/backend/local/test.go
@@ -146,6 +146,10 @@ func (runner *TestSuiteRunner) Test() (moduletest.Status, tfdiags.Diagnostics) {
 		}
 	}
 
+	if suite.Status == moduletest.Pending {
+		suite.Status = moduletest.Pass
+	}
+
 	return suite.Status, diags
 }
 


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

Fixes [this change](https://github.com/hashicorp/terraform/pull/37205/commits/809a779fd3be8bbf128077f6d2d73f4f071c6424#diff-3f231f9b0cca0621e8e5f34dc8590184b66a841fa54cafd10a8da2d1bf619e3cL106-R105) in 809a779fd3be8bbf128077f6d2d73f4f071c6424 of #37205 (incorporated into yesterday's [v1.13.0](https://github.com/hashicorp/terraform/releases/tag/v1.13.0) release):

```diff
-	suite.Status = moduletest.Pass
+	suite.Status = moduletest.Pending
```

Which makes `terraform test` with no files return a non-zero exit code.

This alternative implementation keeps `suite.Status = Pending` until the very end, in case there's a reason why it was made to be `moduletest.Pending` in #37205.

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Fixes #37475

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.14.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [x] This change is user-facing and I added a changelog entry.
- [ ] This change is not user-facing.
