### PR TITLE
Add code comment to make in-progress migration from Ui to View more obvious

### DIFF
--- a/internal/command/meta.go
+++ b/internal/command/meta.go
@@ -72,11 +72,18 @@ type Meta struct {
 	// do some default behavior instead if so, rather than panicking.
 	Streams *terminal.Streams
 
-	View *views.View
+	// View is the newer abstraction used for output from Terraform operations.
+	// View allows output to be rendered differently, depending on CLI settings.
+	// Currently the only non-default option is machine-readable output using  the`-json` flag.
+	// We are slowly migrating Terraform operations away from using `cli.Ui` and towards
+	// using `views.View`, and so far only the commands with machine-readable output features are
+	// migrated.
+	// For more information see: https://github.com/hashicorp/terraform/issues/37439
+	View *views.View // View for output
 
 	Color            bool     // True if output should be colored
 	GlobalPluginDirs []string // Additional paths to search for plugins
-	Ui               cli.Ui   // Ui for output
+	Ui               cli.Ui   // Ui for output. See View above.
 
 	// Services provides access to remote endpoint information for
 	// "terraform-native' services running at a specific user-facing hostname.


### PR DESCRIPTION
Related to: https://github.com/hashicorp/terraform/issues/37439

I received some feedback that it'd be good to update the code with a comment to highlight the migration that has been started but not finished. This will help people understand why both are present in the `Meta` and aids discovery of the linked GH issue.


## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

N/A

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
