### PR TITLE
Exclude nested config block from list resource schemas

### DIFF
--- a/internal/command/jsonformat/plan_test.go
+++ b/internal/command/jsonformat/plan_test.go
@@ -8544,7 +8544,7 @@ func TestResourceChange_actions(t *testing.T) {
 					},
 				},
 			}
-			jsonschemas := jsonprovider.MarshalForRenderer(fullSchema, false)
+			jsonschemas := jsonprovider.MarshalForRenderer(fullSchema, true)
 			diffs := precomputeDiffs(Plan{
 				ResourceChanges:   []jsonplan.ResourceChange{defaultResourceChange},
 				ActionInvocations: tc.actionInvocations,

--- a/internal/command/jsonprovider/provider.go
+++ b/internal/command/jsonprovider/provider.go
@@ -72,7 +72,18 @@ func marshalProvider(tps providers.ProviderSchema, includeExperimentalSchemas bo
 	}
 
 	if includeExperimentalSchemas {
-		p.ListResourceSchemas = marshalSchemas(tps.ListResourceTypes)
+		// List resource schemas are nested under a "config" block, so we need to
+		// extract that block to get the actual provider schema for the list resource.
+		// When getting the provider schemas, Terraform adds this extra level to
+		// better match the actual configuration structure.
+		listSchemas := make(map[string]providers.Schema, len(tps.ListResourceTypes))
+		for k, v := range tps.ListResourceTypes {
+			listSchemas[k] = providers.Schema{
+				Body:    &v.Body.BlockTypes["config"].Block,
+				Version: v.Version,
+			}
+		}
+		p.ListResourceSchemas = marshalSchemas(listSchemas)
 	}
 
 	return p

--- a/internal/command/jsonprovider/provider.go
+++ b/internal/command/jsonprovider/provider.go
@@ -68,7 +68,6 @@ func marshalProvider(tps providers.ProviderSchema, includeExperimentalSchemas bo
 		EphemeralResourceSchemas: marshalSchemas(tps.EphemeralResourceTypes),
 		Functions:                jsonfunction.MarshalProviderFunctions(tps.Functions),
 		ResourceIdentitySchemas:  marshalIdentitySchemas(tps.ResourceTypes),
-		ActionSchemas:            marshalActionSchemas(tps.Actions),
 	}
 
 	if includeExperimentalSchemas {
@@ -84,6 +83,8 @@ func marshalProvider(tps providers.ProviderSchema, includeExperimentalSchemas bo
 			}
 		}
 		p.ListResourceSchemas = marshalSchemas(listSchemas)
+
+		p.ActionSchemas = marshalActionSchemas(tps.Actions)
 	}
 
 	return p

--- a/internal/command/jsonprovider/provider_test.go
+++ b/internal/command/jsonprovider/provider_test.go
@@ -33,7 +33,6 @@ func TestMarshalProvider(t *testing.T) {
 				DataSourceSchemas:        map[string]*Schema{},
 				EphemeralResourceSchemas: map[string]*Schema{},
 				ResourceIdentitySchemas:  map[string]*IdentitySchema{},
-				ActionSchemas:            map[string]*ActionSchema{},
 			},
 		},
 		{
@@ -213,7 +212,6 @@ func TestMarshalProvider(t *testing.T) {
 					},
 				},
 				ResourceIdentitySchemas: map[string]*IdentitySchema{},
-				ActionSchemas:           map[string]*ActionSchema{},
 			},
 		},
 		{
@@ -223,8 +221,21 @@ func TestMarshalProvider(t *testing.T) {
 						Version: 1,
 						Body: &configschema.Block{
 							Attributes: map[string]*configschema.Attribute{
-								"filter": {Type: cty.String, Optional: true},
-								"items":  {Type: cty.List(cty.String), Required: true},
+								"data": {
+									Type:     cty.DynamicPseudoType,
+									Computed: true,
+								},
+							},
+							BlockTypes: map[string]*configschema.NestedBlock{
+								"config": {
+									Block: configschema.Block{
+										Attributes: map[string]*configschema.Attribute{
+											"filter": {Type: cty.String, Optional: true},
+											"items":  {Type: cty.List(cty.String), Required: true},
+										},
+									},
+									Nesting: configschema.NestingSingle,
+								},
 							},
 						},
 					},
@@ -483,8 +494,21 @@ func testProvider() providers.ProviderSchema {
 				Version: 1,
 				Body: &configschema.Block{
 					Attributes: map[string]*configschema.Attribute{
-						"filter": {Type: cty.String, Optional: true},
-						"items":  {Type: cty.List(cty.String), Required: true},
+						"data": {
+							Type:     cty.DynamicPseudoType,
+							Computed: true,
+						},
+					},
+					BlockTypes: map[string]*configschema.NestedBlock{
+						"config": {
+							Block: configschema.Block{
+								Attributes: map[string]*configschema.Attribute{
+									"filter": {Type: cty.String, Optional: true},
+									"items":  {Type: cty.List(cty.String), Required: true},
+								},
+							},
+							Nesting: configschema.NestingSingle,
+						},
 					},
 				},
 			},


### PR DESCRIPTION
This PR removes the nested `config` block from the list resource schema JSON output of `terraform providers schema -json`. It makes the schema easier to consume and hides the nested block implementation detail.

It also moves the actions schemas behind the experimental flag.

### UX
**Before**
<img width="1886" height="852" alt="CleanShot 2025-08-26 at 17 45 18@2x" src="https://github.com/user-attachments/assets/df99a736-b38a-4b22-921c-a04a5b5c532a" />

**After**
<img width="1810" height="452" alt="CleanShot 2025-08-26 at 17 44 51@2x" src="https://github.com/user-attachments/assets/336c59eb-d650-44ef-a339-8ea08c67c560" />

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.14.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
