### PR TITLE
Update `backend.Backend`'s `StateMgr` method to return diagnostics instead of primitive errors

### DIFF
--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -91,7 +91,7 @@ type Backend interface {
 	// If the named workspace doesn't exist, or if it has no state, it will
 	// be created either immediately on this call or the first time
 	// PersistState is called, depending on the state manager implementation.
-	StateMgr(workspace string) (statemgr.Full, error)
+	StateMgr(workspace string) (statemgr.Full, tfdiags.Diagnostics)
 
 	// DeleteWorkspace removes the workspace with the given name if it exists.
 	//

--- a/internal/backend/local/backend.go
+++ b/internal/backend/local/backend.go
@@ -257,18 +257,20 @@ func (b *Local) DeleteWorkspace(name string, force bool) tfdiags.Diagnostics {
 	return diags
 }
 
-func (b *Local) StateMgr(name string) (statemgr.Full, error) {
+func (b *Local) StateMgr(name string) (statemgr.Full, tfdiags.Diagnostics) {
+	var diags tfdiags.Diagnostics
+
 	// If we have a backend handling state, delegate to that.
 	if b.Backend != nil {
 		return b.Backend.StateMgr(name)
 	}
 
 	if s, ok := b.states[name]; ok {
-		return s, nil
+		return s, diags
 	}
 
 	if err := b.createState(name); err != nil {
-		return nil, err
+		return nil, diags.Append(err)
 	}
 
 	statePath, stateOutPath, backupPath := b.StatePaths(name)
@@ -283,7 +285,7 @@ func (b *Local) StateMgr(name string) (statemgr.Full, error) {
 		b.states = map[string]statemgr.Full{}
 	}
 	b.states[name] = s
-	return s, nil
+	return s, diags
 }
 
 // Operation implements backendrun.OperationsBackend

--- a/internal/backend/local/backend_apply_test.go
+++ b/internal/backend/local/backend_apply_test.go
@@ -347,7 +347,7 @@ type backendWithFailingState struct {
 	Local
 }
 
-func (b *backendWithFailingState) StateMgr(name string) (statemgr.Full, error) {
+func (b *backendWithFailingState) StateMgr(name string) (statemgr.Full, tfdiags.Diagnostics) {
 	return &failingState{
 		statemgr.NewFilesystem("failing-state.tfstate"),
 	}, nil

--- a/internal/backend/local/backend_local.go
+++ b/internal/backend/local/backend_local.go
@@ -46,9 +46,9 @@ func (b *Local) localRun(op *backendrun.Operation) (*backendrun.LocalRun, *confi
 
 	// Get the latest state.
 	log.Printf("[TRACE] backend/local: requesting state manager for workspace %q", op.Workspace)
-	s, err := b.StateMgr(op.Workspace)
-	if err != nil {
-		diags = diags.Append(fmt.Errorf("error loading state: %w", err))
+	s, sDiags := b.StateMgr(op.Workspace)
+	if sDiags.HasErrors() {
+		diags = diags.Append(fmt.Errorf("error loading state: %w", sDiags.Err()))
 		return nil, nil, nil, diags
 	}
 	log.Printf("[TRACE] backend/local: requesting state lock for workspace %q", op.Workspace)

--- a/internal/backend/local/backend_local_test.go
+++ b/internal/backend/local/backend_local_test.go
@@ -140,9 +140,9 @@ func TestLocalRun_stalePlan(t *testing.T) {
 	}
 
 	// Refresh the state
-	sm, err := b.StateMgr("")
-	if err != nil {
-		t.Fatalf("unexpected error: %s", err)
+	sm, sDiags := b.StateMgr("")
+	if sDiags.HasErrors() {
+		t.Fatalf("unexpected error: %s", sDiags.Err())
 	}
 	if err := sm.RefreshState(); err != nil {
 		t.Fatalf("unexpected error refreshing state: %s", err)
@@ -214,7 +214,7 @@ type backendWithStateStorageThatFailsRefresh struct {
 
 var _ backend.Backend = backendWithStateStorageThatFailsRefresh{}
 
-func (b backendWithStateStorageThatFailsRefresh) StateMgr(workspace string) (statemgr.Full, error) {
+func (b backendWithStateStorageThatFailsRefresh) StateMgr(workspace string) (statemgr.Full, tfdiags.Diagnostics) {
 	return &stateStorageThatFailsRefresh{}, nil
 }
 

--- a/internal/backend/local/backend_test.go
+++ b/internal/backend/local/backend_test.go
@@ -118,7 +118,7 @@ func TestLocal_useOfPathAttribute(t *testing.T) {
 	workspace := backend.DefaultStateName
 	stmgr, sDiags := b.StateMgr(workspace)
 	if sDiags.HasErrors() {
-		t.Fatalf("unexpected error returned from StateMgr: %w", sDiags.Err())
+		t.Fatalf("unexpected error returned from StateMgr: %s", sDiags.Err())
 	}
 	defaultStatePath := fmt.Sprintf("%s/%s", td, path)
 	if _, err := os.Stat(defaultStatePath); !strings.Contains(err.Error(), "no such file or directory") {
@@ -188,7 +188,7 @@ func TestLocal_pathAttributeWrongExtension(t *testing.T) {
 	workspace := backend.DefaultStateName
 	stmgr, sDiags := b.StateMgr(workspace)
 	if sDiags.HasErrors() {
-		t.Fatalf("unexpected error returned from StateMgr: %w", sDiags.Err())
+		t.Fatalf("unexpected error returned from StateMgr: %s", sDiags.Err())
 	}
 	s := states.NewState()
 	s.RootOutputValues = map[string]*states.OutputValue{
@@ -235,7 +235,7 @@ func TestLocal_useOfWorkspaceDirAttribute(t *testing.T) {
 	defaultStatePath := fmt.Sprintf("%s/terraform.tfstate", td)
 	stmgr, sDiags := b.StateMgr(workspace)
 	if sDiags.HasErrors() {
-		t.Fatalf("unexpected error returned from StateMgr: %w", sDiags.Err())
+		t.Fatalf("unexpected error returned from StateMgr: %s", sDiags.Err())
 	}
 	s := states.NewState()
 	s.RootOutputValues = map[string]*states.OutputValue{

--- a/internal/backend/local/testing.go
+++ b/internal/backend/local/testing.go
@@ -126,9 +126,10 @@ func (b *TestLocalSingleState) DeleteWorkspace(string, bool) tfdiags.Diagnostics
 	return tfdiags.Diagnostics{}.Append(backend.ErrWorkspacesNotSupported)
 }
 
-func (b *TestLocalSingleState) StateMgr(name string) (statemgr.Full, error) {
+func (b *TestLocalSingleState) StateMgr(name string) (statemgr.Full, tfdiags.Diagnostics) {
+	var diags tfdiags.Diagnostics
 	if name != backend.DefaultStateName {
-		return nil, backend.ErrWorkspacesNotSupported
+		return nil, diags.Append(backend.ErrWorkspacesNotSupported)
 	}
 
 	return b.Local.StateMgr(name)
@@ -172,9 +173,10 @@ func (b *TestLocalNoDefaultState) DeleteWorkspace(name string, force bool) tfdia
 	return b.Local.DeleteWorkspace(name, force)
 }
 
-func (b *TestLocalNoDefaultState) StateMgr(name string) (statemgr.Full, error) {
+func (b *TestLocalNoDefaultState) StateMgr(name string) (statemgr.Full, tfdiags.Diagnostics) {
+	var diags tfdiags.Diagnostics
 	if name == backend.DefaultStateName {
-		return nil, backend.ErrDefaultWorkspaceNotSupported
+		return nil, diags.Append(backend.ErrDefaultWorkspaceNotSupported)
 	}
 	return b.Local.StateMgr(name)
 }

--- a/internal/backend/pluggable/pluggable.go
+++ b/internal/backend/pluggable/pluggable.go
@@ -133,7 +133,7 @@ func (p *Pluggable) DeleteWorkspace(workspace string, force bool) tfdiags.Diagno
 // state storage provider to interact with state.
 //
 // StateMgr implements backend.Backend
-func (p *Pluggable) StateMgr(workspace string) (statemgr.Full, error) {
+func (p *Pluggable) StateMgr(workspace string) (statemgr.Full, tfdiags.Diagnostics) {
 	// repackages the provider's methods inside a state manager,
 	// to be passed to the calling code that expects a statemgr.Full
 	return remote.NewRemoteGRPC(p.provider, p.typeName, workspace), nil

--- a/internal/backend/remote-state/azure/client_test.go
+++ b/internal/backend/remote-state/azure/client_test.go
@@ -38,9 +38,9 @@ func TestRemoteClientAccessKeyBasic(t *testing.T) {
 		"environment":          m.env.Name,
 	})).(*Backend)
 
-	state, err := b.StateMgr(backend.DefaultStateName)
-	if err != nil {
-		t.Fatal(err)
+	state, sDiags := b.StateMgr(backend.DefaultStateName)
+	if sDiags.HasErrors() {
+		t.Fatal(sDiags.Err())
 	}
 
 	remote.TestClient(t, state.(*remote.State).Client)
@@ -73,9 +73,9 @@ func TestRemoteClientManagedServiceIdentityBasic(t *testing.T) {
 		"environment":          m.env.Name,
 	})).(*Backend)
 
-	state, err := b.StateMgr(backend.DefaultStateName)
-	if err != nil {
-		t.Fatal(err)
+	state, sDiags := b.StateMgr(backend.DefaultStateName)
+	if sDiags.HasErrors() {
+		t.Fatal(sDiags.Err())
 	}
 
 	remote.TestClient(t, state.(*remote.State).Client)
@@ -110,9 +110,9 @@ func TestRemoteClientSasTokenBasic(t *testing.T) {
 		"environment":          m.env.Name,
 	})).(*Backend)
 
-	state, err := b.StateMgr(backend.DefaultStateName)
-	if err != nil {
-		t.Fatal(err)
+	state, sDiags := b.StateMgr(backend.DefaultStateName)
+	if sDiags.HasErrors() {
+		t.Fatal(sDiags.Err())
 	}
 
 	remote.TestClient(t, state.(*remote.State).Client)
@@ -146,9 +146,9 @@ func TestRemoteClientServicePrincipalBasic(t *testing.T) {
 		"environment":          m.env.Name,
 	})).(*Backend)
 
-	state, err := b.StateMgr(backend.DefaultStateName)
-	if err != nil {
-		t.Fatal(err)
+	state, sDiags := b.StateMgr(backend.DefaultStateName)
+	if sDiags.HasErrors() {
+		t.Fatal(sDiags.Err())
 	}
 
 	remote.TestClient(t, state.(*remote.State).Client)
@@ -187,14 +187,14 @@ func TestRemoteClientAccessKeyLocks(t *testing.T) {
 		"environment":          m.env.Name,
 	})).(*Backend)
 
-	s1, err := b1.StateMgr(backend.DefaultStateName)
-	if err != nil {
-		t.Fatal(err)
+	s1, sDiags := b1.StateMgr(backend.DefaultStateName)
+	if sDiags.HasErrors() {
+		t.Fatal(sDiags.Err())
 	}
 
-	s2, err := b2.StateMgr(backend.DefaultStateName)
-	if err != nil {
-		t.Fatal(err)
+	s2, sDiags := b2.StateMgr(backend.DefaultStateName)
+	if sDiags.HasErrors() {
+		t.Fatal(sDiags.Err())
 	}
 
 	remote.TestRemoteLocks(t, s1.(*remote.State).Client, s2.(*remote.State).Client)
@@ -241,14 +241,14 @@ func TestRemoteClientServicePrincipalLocks(t *testing.T) {
 		"environment":          m.env.Name,
 	})).(*Backend)
 
-	s1, err := b1.StateMgr(backend.DefaultStateName)
-	if err != nil {
-		t.Fatal(err)
+	s1, sDiags := b1.StateMgr(backend.DefaultStateName)
+	if sDiags.HasErrors() {
+		t.Fatal(sDiags.Err())
 	}
 
-	s2, err := b2.StateMgr(backend.DefaultStateName)
-	if err != nil {
-		t.Fatal(err)
+	s2, sDiags := b2.StateMgr(backend.DefaultStateName)
+	if sDiags.HasErrors() {
+		t.Fatal(sDiags.Err())
 	}
 
 	remote.TestRemoteLocks(t, s1.(*remote.State).Client, s2.(*remote.State).Client)

--- a/internal/backend/remote-state/consul/backend_state.go
+++ b/internal/backend/remote-state/consul/backend_state.go
@@ -71,7 +71,8 @@ func (b *Backend) DeleteWorkspace(name string, _ bool) tfdiags.Diagnostics {
 	return diags.Append(err)
 }
 
-func (b *Backend) StateMgr(name string) (statemgr.Full, error) {
+func (b *Backend) StateMgr(name string) (statemgr.Full, tfdiags.Diagnostics) {
+	var diags tfdiags.Diagnostics
 	// Determine the path of the data
 	path := b.statePath(name)
 
@@ -104,7 +105,7 @@ func (b *Backend) StateMgr(name string) (statemgr.Full, error) {
 	lockInfo.Operation = "init"
 	lockId, err := stateMgr.Lock(lockInfo)
 	if err != nil {
-		return nil, fmt.Errorf("failed to lock state in Consul: %s", err)
+		return nil, diags.Append(fmt.Errorf("failed to lock state in Consul: %s", err))
 	}
 
 	// Local helper function so we can call it multiple places
@@ -119,27 +120,27 @@ func (b *Backend) StateMgr(name string) (statemgr.Full, error) {
 	// Grab the value
 	if err := stateMgr.RefreshState(); err != nil {
 		err = lockUnlock(err)
-		return nil, err
+		return nil, diags.Append(err)
 	}
 
 	// If we have no state, we have to create an empty state
 	if v := stateMgr.State(); v == nil {
 		if err := stateMgr.WriteState(states.NewState()); err != nil {
 			err = lockUnlock(err)
-			return nil, err
+			return nil, diags.Append(err)
 		}
 		if err := stateMgr.PersistState(nil); err != nil {
 			err = lockUnlock(err)
-			return nil, err
+			return nil, diags.Append(err)
 		}
 	}
 
 	// Unlock, the state should now be initialized
 	if err := lockUnlock(nil); err != nil {
-		return nil, err
+		return nil, diags.Append(err)
 	}
 
-	return stateMgr, nil
+	return stateMgr, diags
 }
 
 func (b *Backend) statePath(name string) string {

--- a/internal/backend/remote-state/consul/client_test.go
+++ b/internal/backend/remote-state/consul/client_test.go
@@ -43,9 +43,9 @@ func TestRemoteClient(t *testing.T) {
 			}))
 
 			// Grab the client
-			state, err := b.StateMgr(backend.DefaultStateName)
-			if err != nil {
-				t.Fatalf("err: %s", err)
+			state, sDiags := b.StateMgr(backend.DefaultStateName)
+			if sDiags.HasErrors() {
+				t.Fatalf("err: %s", sDiags.Err())
 			}
 
 			// Test
@@ -67,9 +67,9 @@ func TestRemoteClient_gzipUpgrade(t *testing.T) {
 	}))
 
 	// Grab the client
-	state, err := b.StateMgr(backend.DefaultStateName)
-	if err != nil {
-		t.Fatalf("err: %s", err)
+	state, sDiags := b.StateMgr(backend.DefaultStateName)
+	if sDiags.HasErrors() {
+		t.Fatalf("err: %s", sDiags.Err())
 	}
 
 	// Test
@@ -83,9 +83,9 @@ func TestRemoteClient_gzipUpgrade(t *testing.T) {
 	}))
 
 	// Grab the client
-	state, err = b.StateMgr(backend.DefaultStateName)
-	if err != nil {
-		t.Fatalf("err: %s", err)
+	state, sDiags = b.StateMgr(backend.DefaultStateName)
+	if sDiags.HasErrors() {
+		t.Fatalf("err: %s", sDiags.Err())
 	}
 
 	// Test
@@ -105,9 +105,9 @@ func TestConsul_largeState(t *testing.T) {
 		"path":    path,
 	}))
 
-	s, err := b.StateMgr(backend.DefaultStateName)
-	if err != nil {
-		t.Fatal(err)
+	s, sDiags := b.StateMgr(backend.DefaultStateName)
+	if sDiags.HasErrors() {
+		t.Fatal(sDiags.Err())
 	}
 
 	c := s.(*remote.State).Client.(*RemoteClient)
@@ -192,9 +192,9 @@ func TestConsul_largeState(t *testing.T) {
 		"gzip":    true,
 	}))
 
-	s, err = b.StateMgr(backend.DefaultStateName)
-	if err != nil {
-		t.Fatal(err)
+	s, sDiags = b.StateMgr(backend.DefaultStateName)
+	if sDiags.HasErrors() {
+		t.Fatalf("err: %s", sDiags.Err())
 	}
 
 	c = s.(*remote.State).Client.(*RemoteClient)
@@ -229,7 +229,7 @@ func TestConsul_largeState(t *testing.T) {
 	)
 
 	// Deleting the state should remove all chunks
-	err = c.Delete()
+	err := c.Delete()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -296,9 +296,9 @@ func TestConsul_destroyLock(t *testing.T) {
 			}))
 
 			// Grab the client
-			s, err := b.StateMgr(backend.DefaultStateName)
-			if err != nil {
-				t.Fatalf("err: %s", err)
+			s, sDiags := b.StateMgr(backend.DefaultStateName)
+			if sDiags.HasErrors() {
+				t.Fatalf("err: %s", sDiags.Err())
 			}
 
 			clientA := s.(*remote.State).Client.(*RemoteClient)
@@ -319,9 +319,9 @@ func TestConsul_destroyLock(t *testing.T) {
 
 			// The release the lock from a second client to test the
 			// `terraform force-unlock <lock_id>` functionnality
-			s, err = b.StateMgr(backend.DefaultStateName)
-			if err != nil {
-				t.Fatalf("err: %s", err)
+			s, sDiags = b.StateMgr(backend.DefaultStateName)
+			if sDiags.HasErrors() {
+				t.Fatalf("err: %s", sDiags.Err())
 			}
 
 			clientB := s.(*remote.State).Client.(*RemoteClient)
@@ -356,20 +356,20 @@ func TestConsul_lostLock(t *testing.T) {
 	path := fmt.Sprintf("tf-unit/%s", time.Now().String())
 
 	// create 2 instances to get 2 remote.Clients
-	sA, err := backend.TestBackendConfig(t, New(), backend.TestWrapConfig(map[string]interface{}{
+	sA, sDiags := backend.TestBackendConfig(t, New(), backend.TestWrapConfig(map[string]interface{}{
 		"address": srv.HTTPAddr,
 		"path":    path,
 	})).StateMgr(backend.DefaultStateName)
-	if err != nil {
-		t.Fatal(err)
+	if sDiags.HasErrors() {
+		t.Fatal(sDiags.Err())
 	}
 
-	sB, err := backend.TestBackendConfig(t, New(), backend.TestWrapConfig(map[string]interface{}{
+	sB, sDiags := backend.TestBackendConfig(t, New(), backend.TestWrapConfig(map[string]interface{}{
 		"address": srv.HTTPAddr,
 		"path":    path + "-not-used",
 	})).StateMgr(backend.DefaultStateName)
-	if err != nil {
-		t.Fatal(err)
+	if sDiags.HasErrors() {
+		t.Fatal(sDiags.Err())
 	}
 
 	info := statemgr.NewLockInfo()
@@ -418,9 +418,9 @@ func TestConsul_lostLockConnection(t *testing.T) {
 		"path":    path,
 	}))
 
-	s, err := b.StateMgr(backend.DefaultStateName)
-	if err != nil {
-		t.Fatal(err)
+	s, sDiags := b.StateMgr(backend.DefaultStateName)
+	if sDiags.HasErrors() {
+		t.Fatal(sDiags.Err())
 	}
 
 	info := statemgr.NewLockInfo()

--- a/internal/backend/remote-state/cos/backend_test.go
+++ b/internal/backend/remote-state/cos/backend_test.go
@@ -149,9 +149,9 @@ func TestRemoteLocks(t *testing.T) {
 	defer teardownBackend(t, be)
 
 	remoteClient := func() (remote.Client, error) {
-		ss, err := be.StateMgr(backend.DefaultStateName)
-		if err != nil {
-			return nil, err
+		ss, sDiags := be.StateMgr(backend.DefaultStateName)
+		if sDiags.HasErrors() {
+			t.Fatal(sDiags.Err())
 		}
 
 		rs, ok := ss.(*remote.State)

--- a/internal/backend/remote-state/gcs/backend_test.go
+++ b/internal/backend/remote-state/gcs/backend_test.go
@@ -203,9 +203,9 @@ func TestAccRemoteLocks(t *testing.T) {
 	defer teardownBackend(t, be, noPrefix)
 
 	remoteClient := func() (remote.Client, error) {
-		ss, err := be.StateMgr(backend.DefaultStateName)
-		if err != nil {
-			return nil, err
+		ss, sDiags := be.StateMgr(backend.DefaultStateName)
+		if sDiags.HasErrors() {
+			t.Fatal(sDiags.Err())
 		}
 
 		rs, ok := ss.(*remote.State)

--- a/internal/backend/remote-state/http/backend.go
+++ b/internal/backend/remote-state/http/backend.go
@@ -306,12 +306,14 @@ func (b *Backend) configureTLS(client *retryablehttp.Client, configVal cty.Value
 	return nil
 }
 
-func (b *Backend) StateMgr(name string) (statemgr.Full, error) {
+func (b *Backend) StateMgr(name string) (statemgr.Full, tfdiags.Diagnostics) {
+	var diags tfdiags.Diagnostics
+
 	if name != backend.DefaultStateName {
-		return nil, backend.ErrWorkspacesNotSupported
+		return nil, diags.Append(backend.ErrWorkspacesNotSupported)
 	}
 
-	return &remote.State{Client: b.client}, nil
+	return &remote.State{Client: b.client}, diags
 }
 
 func (b *Backend) Workspaces() ([]string, tfdiags.Diagnostics) {

--- a/internal/backend/remote-state/http/server_test.go
+++ b/internal/backend/remote-state/http/server_test.go
@@ -277,9 +277,9 @@ func TestMTLSServer_NoCertFails(t *testing.T) {
 	}
 
 	// Now get a state manager and check that it fails to refresh the state
-	sm, err := b.StateMgr(backend.DefaultStateName)
-	if err != nil {
-		t.Fatalf("unexpected error fetching StateMgr with %s: %v", backend.DefaultStateName, err)
+	sm, sDiags := b.StateMgr(backend.DefaultStateName)
+	if sDiags.HasErrors() {
+		t.Fatalf("unexpected error fetching StateMgr with %s: %v", backend.DefaultStateName, sDiags)
 	}
 	err = sm.RefreshState()
 	if nil == err {
@@ -339,9 +339,9 @@ func TestMTLSServer_WithCertPasses(t *testing.T) {
 	}
 
 	// Now get a state manager, fetch the state, and ensure that the "foo" output is not set
-	sm, err := b.StateMgr(backend.DefaultStateName)
-	if err != nil {
-		t.Fatalf("unexpected error fetching StateMgr with %s: %v", backend.DefaultStateName, err)
+	sm, sDiags := b.StateMgr(backend.DefaultStateName)
+	if sDiags.HasErrors() {
+		t.Fatalf("unexpected error fetching StateMgr with %s: %v", backend.DefaultStateName, sDiags)
 	}
 	if err = sm.RefreshState(); err != nil {
 		t.Fatalf("unexpected error calling RefreshState: %v", err)

--- a/internal/backend/remote-state/inmem/backend_test.go
+++ b/internal/backend/remote-state/inmem/backend_test.go
@@ -36,9 +36,9 @@ func TestBackendConfig(t *testing.T) {
 
 	b := backend.TestBackendConfig(t, New(), backend.TestWrapConfig(config)).(*Backend)
 
-	s, err := b.StateMgr(backend.DefaultStateName)
-	if err != nil {
-		t.Fatal(err)
+	s, sDiags := b.StateMgr(backend.DefaultStateName)
+	if sDiags.HasErrors() {
+		t.Fatal(sDiags)
 	}
 
 	c := s.(*remote.State).Client.(*RemoteClient)
@@ -73,9 +73,9 @@ func TestRemoteState(t *testing.T) {
 	workspace := "workspace"
 
 	// create a new workspace in this backend
-	s, err := b.StateMgr(workspace)
-	if err != nil {
-		t.Fatal(err)
+	s, sDiags := b.StateMgr(workspace)
+	if sDiags.HasErrors() {
+		t.Fatal(sDiags)
 	}
 
 	// force overwriting the remote state

--- a/internal/backend/remote-state/inmem/client_test.go
+++ b/internal/backend/remote-state/inmem/client_test.go
@@ -20,9 +20,9 @@ func TestRemoteClient(t *testing.T) {
 	defer Reset()
 	b := backend.TestBackendConfig(t, New(), hcl.EmptyBody())
 
-	s, err := b.StateMgr(backend.DefaultStateName)
-	if err != nil {
-		t.Fatal(err)
+	s, sDiags := b.StateMgr(backend.DefaultStateName)
+	if sDiags.HasErrors() {
+		t.Fatal(sDiags)
 	}
 
 	remote.TestClient(t, s.(*remote.State).Client)

--- a/internal/backend/remote-state/kubernetes/backend_test.go
+++ b/internal/backend/remote-state/kubernetes/backend_test.go
@@ -89,9 +89,9 @@ func TestBackendLocksSoak(t *testing.T) {
 			"secret_suffix": secretSuffix,
 		}))
 
-		s, err := b.StateMgr(backend.DefaultStateName)
-		if err != nil {
-			t.Fatalf("Error creating state manager: %v", err)
+		s, sDiags := b.StateMgr(backend.DefaultStateName)
+		if sDiags.HasErrors() {
+			t.Fatalf("Error creating state manager: %v", sDiags.Err())
 		}
 
 		lockers = append(lockers, s.(statemgr.Locker))

--- a/internal/backend/remote-state/kubernetes/client_test.go
+++ b/internal/backend/remote-state/kubernetes/client_test.go
@@ -27,9 +27,9 @@ func TestRemoteClient(t *testing.T) {
 		"secret_suffix": secretSuffix,
 	}))
 
-	state, err := b.StateMgr(backend.DefaultStateName)
-	if err != nil {
-		t.Fatal(err)
+	state, sDiags := b.StateMgr(backend.DefaultStateName)
+	if sDiags.HasErrors() {
+		t.Fatal(sDiags.Err())
 	}
 
 	remote.TestClient(t, state.(*remote.State).Client)
@@ -68,14 +68,14 @@ func TestLargeState(t *testing.T) {
 		"secret_suffix": secretSuffix,
 	}))
 
-	s, err := b.StateMgr(backend.DefaultStateName)
-	if err != nil {
-		t.Fatal(err)
+	s, sDiags := b.StateMgr(backend.DefaultStateName)
+	if sDiags.HasErrors() {
+		t.Fatal(sDiags.Err())
 	}
 
 	// generate a very large state
 	largeState := generateLargeState(20)
-	err = s.WriteState(largeState)
+	err := s.WriteState(largeState)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -146,9 +146,9 @@ func TestForceUnlock(t *testing.T) {
 	}))
 
 	// first test with default
-	s1, err := b1.StateMgr(backend.DefaultStateName)
-	if err != nil {
-		t.Fatal(err)
+	s1, sDiags := b1.StateMgr(backend.DefaultStateName)
+	if sDiags.HasErrors() {
+		t.Fatal(sDiags.Err())
 	}
 
 	info := statemgr.NewLockInfo()
@@ -161,9 +161,9 @@ func TestForceUnlock(t *testing.T) {
 	}
 
 	// s1 is now locked, get the same state through s2 and unlock it
-	s2, err := b2.StateMgr(backend.DefaultStateName)
-	if err != nil {
-		t.Fatal("failed to get default state to force unlock:", err)
+	s2, sDiags := b2.StateMgr(backend.DefaultStateName)
+	if sDiags.HasErrors() {
+		t.Fatal("failed to get default state to force unlock:", sDiags)
 	}
 
 	if err := s2.Unlock(lockID); err != nil {
@@ -172,9 +172,9 @@ func TestForceUnlock(t *testing.T) {
 
 	// now try the same thing with a named state
 	// first test with default
-	s1, err = b1.StateMgr("test")
-	if err != nil {
-		t.Fatal(err)
+	s1, sDiags = b1.StateMgr("test")
+	if sDiags.HasErrors() {
+		t.Fatal(sDiags)
 	}
 
 	info = statemgr.NewLockInfo()
@@ -187,9 +187,9 @@ func TestForceUnlock(t *testing.T) {
 	}
 
 	// s1 is now locked, get the same state through s2 and unlock it
-	s2, err = b2.StateMgr("test")
-	if err != nil {
-		t.Fatal("failed to get named state to force unlock:", err)
+	s2, sDiags = b2.StateMgr("test")
+	if sDiags.HasErrors() {
+		t.Fatal("failed to get named state to force unlock:", sDiags)
 	}
 
 	if err = s2.Unlock(lockID); err != nil {

--- a/internal/backend/remote-state/oss/client_test.go
+++ b/internal/backend/remote-state/oss/client_test.go
@@ -40,9 +40,9 @@ func TestRemoteClient(t *testing.T) {
 	createOSSBucket(t, b.ossClient, bucketName)
 	defer deleteOSSBucket(t, b.ossClient, bucketName)
 
-	state, err := b.StateMgr(backend.DefaultStateName)
-	if err != nil {
-		t.Fatal(err)
+	state, sDiags := b.StateMgr(backend.DefaultStateName)
+	if sDiags.HasErrors() {
+		t.Fatal(sDiags)
 	}
 
 	remote.TestClient(t, state.(*remote.State).Client)
@@ -163,9 +163,9 @@ func TestRemoteForceUnlock(t *testing.T) {
 	defer deleteTablestoreTable(t, b1.otsClient, tableName)
 
 	// first test with default
-	s1, err := b1.StateMgr(backend.DefaultStateName)
-	if err != nil {
-		t.Fatal(err)
+	s1, sDiags := b1.StateMgr(backend.DefaultStateName)
+	if sDiags.HasErrors() {
+		t.Fatal(sDiags)
 	}
 
 	info := statemgr.NewLockInfo()
@@ -178,9 +178,9 @@ func TestRemoteForceUnlock(t *testing.T) {
 	}
 
 	// s1 is now locked, get the same state through s2 and unlock it
-	s2, err := b2.StateMgr(backend.DefaultStateName)
-	if err != nil {
-		t.Fatal("failed to get default state to force unlock:", err)
+	s2, sDiags := b2.StateMgr(backend.DefaultStateName)
+	if sDiags.HasErrors() {
+		t.Fatal("failed to get default state to force unlock:", sDiags)
 	}
 
 	if err := s2.Unlock(lockID); err != nil {
@@ -189,9 +189,9 @@ func TestRemoteForceUnlock(t *testing.T) {
 
 	// now try the same thing with a named state
 	// first test with default
-	s1, err = b1.StateMgr("test")
-	if err != nil {
-		t.Fatal(err)
+	s1, sDiags = b1.StateMgr("test")
+	if sDiags.HasErrors() {
+		t.Fatal(sDiags)
 	}
 
 	info = statemgr.NewLockInfo()
@@ -204,9 +204,9 @@ func TestRemoteForceUnlock(t *testing.T) {
 	}
 
 	// s1 is now locked, get the same state through s2 and unlock it
-	s2, err = b2.StateMgr("test")
-	if err != nil {
-		t.Fatal("failed to get named state to force unlock:", err)
+	s2, sDiags = b2.StateMgr("test")
+	if sDiags.HasErrors() {
+		t.Fatal("failed to get named state to force unlock:", sDiags)
 	}
 
 	if err = s2.Unlock(lockID); err != nil {
@@ -233,9 +233,9 @@ func TestRemoteClient_clientMD5(t *testing.T) {
 	createTablestoreTable(t, b.otsClient, tableName)
 	defer deleteTablestoreTable(t, b.otsClient, tableName)
 
-	s, err := b.StateMgr(backend.DefaultStateName)
-	if err != nil {
-		t.Fatal(err)
+	s, sDiags := b.StateMgr(backend.DefaultStateName)
+	if sDiags.HasErrors() {
+		t.Fatal(sDiags)
 	}
 	client := s.(*remote.State).Client.(*RemoteClient)
 

--- a/internal/backend/remote-state/pg/backend_test.go
+++ b/internal/backend/remote-state/pg/backend_test.go
@@ -197,14 +197,14 @@ func TestBackendConfig(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			_, err = b.StateMgr(backend.DefaultStateName)
-			if err != nil {
-				t.Fatal(err)
+			_, sDiags := b.StateMgr(backend.DefaultStateName)
+			if sDiags.HasErrors() {
+				t.Fatal(sDiags)
 			}
 
-			s, err := b.StateMgr(backend.DefaultStateName)
-			if err != nil {
-				t.Fatal(err)
+			s, sDiags := b.StateMgr(backend.DefaultStateName)
+			if sDiags.HasErrors() {
+				t.Fatal(sDiags)
 			}
 			c := s.(*remote.State).Client.(*RemoteClient)
 			if c.Name != backend.DefaultStateName {
@@ -338,14 +338,14 @@ func TestBackendConfigSkipOptions(t *testing.T) {
 				}
 			}
 
-			_, err = b.StateMgr(backend.DefaultStateName)
-			if err != nil {
-				t.Fatal(err)
+			_, sDiags := b.StateMgr(backend.DefaultStateName)
+			if sDiags.HasErrors() {
+				t.Fatal(sDiags)
 			}
 
-			s, err := b.StateMgr(backend.DefaultStateName)
-			if err != nil {
-				t.Fatal(err)
+			s, sDiags := b.StateMgr(backend.DefaultStateName)
+			if sDiags.HasErrors() {
+				t.Fatal(sDiags)
 			}
 			c := s.(*remote.State).Client.(*RemoteClient)
 			if c.Name != backend.DefaultStateName {
@@ -445,9 +445,9 @@ func TestBackendConcurrentLock(t *testing.T) {
 		if b == nil {
 			t.Fatal("Backend could not be configured")
 		}
-		stateMgr, err := b.StateMgr(backend.DefaultStateName)
-		if err != nil {
-			t.Fatalf("Failed to get the state manager: %v", err)
+		stateMgr, sDiags := b.StateMgr(backend.DefaultStateName)
+		if sDiags.HasErrors() {
+			t.Fatalf("Failed to get the state manager: %v", sDiags)
 		}
 
 		info := statemgr.NewLockInfo()

--- a/internal/backend/remote-state/pg/client_test.go
+++ b/internal/backend/remote-state/pg/client_test.go
@@ -40,9 +40,9 @@ func TestRemoteClient(t *testing.T) {
 		t.Fatal("Backend could not be configured")
 	}
 
-	s, err := b.StateMgr(backend.DefaultStateName)
-	if err != nil {
-		t.Fatal(err)
+	s, sDiags := b.StateMgr(backend.DefaultStateName)
+	if sDiags.HasErrors() {
+		t.Fatal(sDiags)
 	}
 
 	remote.TestClient(t, s.(*remote.State).Client)
@@ -64,15 +64,15 @@ func TestRemoteLocks(t *testing.T) {
 	})
 
 	b1 := backend.TestBackendConfig(t, New(), config).(*Backend)
-	s1, err := b1.StateMgr(backend.DefaultStateName)
-	if err != nil {
-		t.Fatal(err)
+	s1, sDiags := b1.StateMgr(backend.DefaultStateName)
+	if sDiags.HasErrors() {
+		t.Fatal(sDiags)
 	}
 
 	b2 := backend.TestBackendConfig(t, New(), config).(*Backend)
-	s2, err := b2.StateMgr(backend.DefaultStateName)
-	if err != nil {
-		t.Fatal(err)
+	s2, sDiags := b2.StateMgr(backend.DefaultStateName)
+	if sDiags.HasErrors() {
+		t.Fatal(sDiags)
 	}
 
 	remote.TestRemoteLocks(t, s1.(*remote.State).Client, s2.(*remote.State).Client)

--- a/internal/backend/remote-state/s3/backend_test.go
+++ b/internal/backend/remote-state/s3/backend_test.go
@@ -2989,7 +2989,13 @@ func TestBackendWrongRegion(t *testing.T) {
 	if _, err := b.StateMgr(backend.DefaultStateName); err == nil {
 		t.Fatal("expected error, got none")
 	} else {
-		if regionErr, ok := As[bucketRegionError](err); ok {
+		var comparableErr error
+		if errValue, isDiag := err.(tfdiags.DiagnosticsAsError); isDiag {
+			// To use `As` below we need to extract the error that's wrapped
+			// in a diagnostic.
+			comparableErr = errValue.WrappedErrors()[0]
+		}
+		if regionErr, ok := As[bucketRegionError](comparableErr); ok {
 			if a, e := regionErr.bucketRegion, bucketRegion; a != e {
 				t.Errorf("expected bucket region %q, got %q", e, a)
 			}

--- a/internal/backend/remote-state/s3/backend_test.go
+++ b/internal/backend/remote-state/s3/backend_test.go
@@ -461,13 +461,9 @@ func TestBackendConfig_DynamoDBEndpoint(t *testing.T) {
 				"dynamodb_endpoint": "dynamo.test",
 			},
 			expectedEndpoint: "dynamo.test/",
-			expectedDiags: func(config hcl.Body) tfdiags.Diagnostics {
-				diags := tfdiags.Diagnostics{
-					deprecatedAttrDiag(cty.GetAttrPath("dynamodb_endpoint"), cty.GetAttrPath("endpoints").GetAttr("dynamodb")),
-					legacyIncompleteURLDiag("dynamo.test", cty.GetAttrPath("dynamodb_endpoint")),
-				}
-				// One of the expected diags comes from config, so we need to add context
-				return diags.InConfigBody(config, "")
+			expectedDiags: tfdiags.Diagnostics{
+				deprecatedAttrDiag(cty.GetAttrPath("dynamodb_endpoint"), cty.GetAttrPath("endpoints").GetAttr("dynamodb")),
+				legacyIncompleteURLDiag("dynamo.test", cty.GetAttrPath("dynamodb_endpoint")),
 			},
 		},
 		"config conflict": {

--- a/internal/backend/remote-state/s3/client_test.go
+++ b/internal/backend/remote-state/s3/client_test.go
@@ -48,9 +48,9 @@ func TestRemoteClientBasic(t *testing.T) {
 	createS3Bucket(ctx, t, b.s3Client, bucketName, b.awsConfig.Region)
 	defer deleteS3Bucket(ctx, t, b.s3Client, bucketName, b.awsConfig.Region)
 
-	state, err := b.StateMgr(backend.DefaultStateName)
-	if err != nil {
-		t.Fatal(err)
+	state, sDiags := b.StateMgr(backend.DefaultStateName)
+	if sDiags.HasErrors() {
+		t.Fatal(sDiags)
 	}
 
 	remote.TestClient(t, state.(*remote.State).Client)
@@ -125,9 +125,9 @@ func TestForceUnlock(t *testing.T) {
 	defer deleteDynamoDBTable(ctx, t, b1.dynClient, bucketName)
 
 	// first test with default
-	s1, err := b1.StateMgr(backend.DefaultStateName)
-	if err != nil {
-		t.Fatal(err)
+	s1, sDiags := b1.StateMgr(backend.DefaultStateName)
+	if sDiags.HasErrors() {
+		t.Fatal(sDiags)
 	}
 
 	info := statemgr.NewLockInfo()
@@ -140,9 +140,9 @@ func TestForceUnlock(t *testing.T) {
 	}
 
 	// s1 is now locked, get the same state through s2 and unlock it
-	s2, err := b2.StateMgr(backend.DefaultStateName)
-	if err != nil {
-		t.Fatal("failed to get default state to force unlock:", err)
+	s2, sDiags := b2.StateMgr(backend.DefaultStateName)
+	if sDiags.HasErrors() {
+		t.Fatal("failed to get default state to force unlock:", sDiags)
 	}
 
 	if err := s2.Unlock(lockID); err != nil {
@@ -151,9 +151,9 @@ func TestForceUnlock(t *testing.T) {
 
 	// now try the same thing with a named state
 	// first test with default
-	s1, err = b1.StateMgr("test")
-	if err != nil {
-		t.Fatal(err)
+	s1, sDiags = b1.StateMgr("test")
+	if sDiags.HasErrors() {
+		t.Fatal(sDiags)
 	}
 
 	info = statemgr.NewLockInfo()
@@ -166,9 +166,9 @@ func TestForceUnlock(t *testing.T) {
 	}
 
 	// s1 is now locked, get the same state through s2 and unlock it
-	s2, err = b2.StateMgr("test")
-	if err != nil {
-		t.Fatal("failed to get named state to force unlock:", err)
+	s2, sDiags = b2.StateMgr("test")
+	if sDiags.HasErrors() {
+		t.Fatal("failed to get named state to force unlock:", sDiags)
 	}
 
 	if err = s2.Unlock(lockID); err != nil {
@@ -202,9 +202,9 @@ func TestForceUnlock_withLockfile(t *testing.T) {
 	defer deleteS3Bucket(ctx, t, b1.s3Client, bucketName, b1.awsConfig.Region)
 
 	// first test with default
-	s1, err := b1.StateMgr(backend.DefaultStateName)
-	if err != nil {
-		t.Fatal(err)
+	s1, sDiags := b1.StateMgr(backend.DefaultStateName)
+	if sDiags.HasErrors() {
+		t.Fatal(sDiags)
 	}
 
 	info := statemgr.NewLockInfo()
@@ -217,9 +217,9 @@ func TestForceUnlock_withLockfile(t *testing.T) {
 	}
 
 	// s1 is now locked, get the same state through s2 and unlock it
-	s2, err := b2.StateMgr(backend.DefaultStateName)
-	if err != nil {
-		t.Fatal("failed to get default state to force unlock:", err)
+	s2, sDiags := b2.StateMgr(backend.DefaultStateName)
+	if sDiags.HasErrors() {
+		t.Fatal("failed to get default state to force unlock:", sDiags)
 	}
 
 	if err := s2.Unlock(lockID); err != nil {
@@ -228,9 +228,9 @@ func TestForceUnlock_withLockfile(t *testing.T) {
 
 	// now try the same thing with a named state
 	// first test with default
-	s1, err = b1.StateMgr("test")
-	if err != nil {
-		t.Fatal(err)
+	s1, sDiags = b1.StateMgr("test")
+	if sDiags.HasErrors() {
+		t.Fatal(sDiags)
 	}
 
 	info = statemgr.NewLockInfo()
@@ -243,9 +243,9 @@ func TestForceUnlock_withLockfile(t *testing.T) {
 	}
 
 	// s1 is now locked, get the same state through s2 and unlock it
-	s2, err = b2.StateMgr("test")
-	if err != nil {
-		t.Fatal("failed to get named state to force unlock:", err)
+	s2, sDiags = b2.StateMgr("test")
+	if sDiags.HasErrors() {
+		t.Fatal("failed to get named state to force unlock:", sDiags)
 	}
 
 	if err = s2.Unlock(lockID); err != nil {
@@ -272,9 +272,9 @@ func TestRemoteClient_clientMD5(t *testing.T) {
 	createDynamoDBTable(ctx, t, b.dynClient, bucketName)
 	defer deleteDynamoDBTable(ctx, t, b.dynClient, bucketName)
 
-	s, err := b.StateMgr(backend.DefaultStateName)
-	if err != nil {
-		t.Fatal(err)
+	s, sDiags := b.StateMgr(backend.DefaultStateName)
+	if sDiags.HasErrors() {
+		t.Fatal(sDiags)
 	}
 	client := s.(*remote.State).Client.(*RemoteClient)
 
@@ -322,9 +322,9 @@ func TestRemoteClient_stateChecksum(t *testing.T) {
 	createDynamoDBTable(ctx, t, b1.dynClient, bucketName)
 	defer deleteDynamoDBTable(ctx, t, b1.dynClient, bucketName)
 
-	s1, err := b1.StateMgr(backend.DefaultStateName)
-	if err != nil {
-		t.Fatal(err)
+	s1, sDiags := b1.StateMgr(backend.DefaultStateName)
+	if sDiags.HasErrors() {
+		t.Fatal(sDiags)
 	}
 	client1 := s1.(*remote.State).Client
 
@@ -347,9 +347,9 @@ func TestRemoteClient_stateChecksum(t *testing.T) {
 		"bucket": bucketName,
 		"key":    keyName,
 	})).(*Backend)
-	s2, err := b2.StateMgr(backend.DefaultStateName)
-	if err != nil {
-		t.Fatal(err)
+	s2, sDiags := b2.StateMgr(backend.DefaultStateName)
+	if sDiags.HasErrors() {
+		t.Fatal(sDiags)
 	}
 	client2 := s2.(*remote.State).Client
 
@@ -440,15 +440,15 @@ func TestRemoteClientPutLargeUploadWithObjectLock_Compliance(t *testing.T) {
 	)
 	defer deleteS3Bucket(ctx, t, b.s3Client, bucketName, b.awsConfig.Region)
 
-	s1, err := b.StateMgr(backend.DefaultStateName)
-	if err != nil {
-		t.Fatal(err)
+	s1, sDiags := b.StateMgr(backend.DefaultStateName)
+	if sDiags.HasErrors() {
+		t.Fatal(sDiags)
 	}
 	client := s1.(*remote.State).Client
 
 	var state bytes.Buffer
 	dataW := io.LimitReader(neverEnding('x'), manager.DefaultUploadPartSize*2)
-	_, err = state.ReadFrom(dataW)
+	_, err := state.ReadFrom(dataW)
 	if err != nil {
 		t.Fatalf("writing dummy data: %s", err)
 	}
@@ -480,15 +480,15 @@ func TestRemoteClientLockFileWithObjectLock_Compliance(t *testing.T) {
 	)
 	defer deleteS3Bucket(ctx, t, b.s3Client, bucketName, b.awsConfig.Region)
 
-	s1, err := b.StateMgr(backend.DefaultStateName)
-	if err != nil {
-		t.Fatal(err)
+	s1, sDiags := b.StateMgr(backend.DefaultStateName)
+	if sDiags.HasErrors() {
+		t.Fatal(sDiags)
 	}
 	client := s1.(*remote.State).Client
 
 	var state bytes.Buffer
 	dataW := io.LimitReader(neverEnding('x'), manager.DefaultUploadPartSize)
-	_, err = state.ReadFrom(dataW)
+	_, err := state.ReadFrom(dataW)
 	if err != nil {
 		t.Fatalf("writing dummy data: %s", err)
 	}
@@ -520,15 +520,15 @@ func TestRemoteClientLockFileWithObjectLock_Governance(t *testing.T) {
 	)
 	defer deleteS3Bucket(ctx, t, b.s3Client, bucketName, b.awsConfig.Region)
 
-	s1, err := b.StateMgr(backend.DefaultStateName)
-	if err != nil {
-		t.Fatal(err)
+	s1, sDiags := b.StateMgr(backend.DefaultStateName)
+	if sDiags.HasErrors() {
+		t.Fatal(sDiags)
 	}
 	client := s1.(*remote.State).Client
 
 	var state bytes.Buffer
 	dataW := io.LimitReader(neverEnding('x'), manager.DefaultUploadPartSize)
-	_, err = state.ReadFrom(dataW)
+	_, err := state.ReadFrom(dataW)
 	if err != nil {
 		t.Fatalf("writing dummy data: %s", err)
 	}
@@ -590,9 +590,9 @@ func TestRemoteClientSkipS3Checksum(t *testing.T) {
 			createS3Bucket(ctx, t, b.s3Client, bucketName, b.awsConfig.Region)
 			defer deleteS3Bucket(ctx, t, b.s3Client, bucketName, b.awsConfig.Region)
 
-			state, err := b.StateMgr(backend.DefaultStateName)
-			if err != nil {
-				t.Fatal(err)
+			state, sDiags := b.StateMgr(backend.DefaultStateName)
+			if sDiags.HasErrors() {
+				t.Fatal(sDiags)
 			}
 
 			c := state.(*remote.State).Client
@@ -606,7 +606,7 @@ func TestRemoteClientSkipS3Checksum(t *testing.T) {
 			}
 
 			var checksum string
-			err = client.put(stateBuf.Bytes(), func(opts *s3.Options) {
+			err := client.put(stateBuf.Bytes(), func(opts *s3.Options) {
 				opts.APIOptions = append(opts.APIOptions,
 					addRetrieveChecksumHeaderMiddleware(t, &checksum),
 					addCancelRequestMiddleware(),

--- a/internal/backend/remote-state/s3/testing_test.go
+++ b/internal/backend/remote-state/s3/testing_test.go
@@ -1,0 +1,28 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package s3
+
+import (
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform/internal/tfdiags"
+)
+
+var diagnosticComparer cmp.Option = cmp.Comparer(diagnosticComparerS3)
+
+// diagnosticComparerS3 is a Comparer function for use with cmp.Diff to compare two tfdiags.Diagnostic values
+func diagnosticComparerS3(l, r tfdiags.Diagnostic) bool {
+	if l.Severity() != r.Severity() {
+		return false
+	}
+	if l.Description() != r.Description() {
+		return false
+	}
+
+	lp := tfdiags.GetAttribute(l)
+	rp := tfdiags.GetAttribute(r)
+	if len(lp) != len(rp) {
+		return false
+	}
+	return lp.Equals(rp)
+}

--- a/internal/backend/remote/backend_context.go
+++ b/internal/backend/remote/backend_context.go
@@ -39,9 +39,9 @@ func (b *Remote) LocalRun(op *backendrun.Operation) (*backendrun.LocalRun, state
 
 	// Get the latest state.
 	log.Printf("[TRACE] backend/remote: requesting state manager for workspace %q", remoteWorkspaceName)
-	stateMgr, err := b.StateMgr(op.Workspace)
-	if err != nil {
-		diags = diags.Append(fmt.Errorf("error loading state: %w", err))
+	stateMgr, sDiags := b.StateMgr(op.Workspace)
+	if sDiags.HasErrors() {
+		diags = diags.Append(fmt.Errorf("error loading state: %w", sDiags.Err()))
 		return nil, nil, diags
 	}
 

--- a/internal/backend/remote/backend_state_test.go
+++ b/internal/backend/remote/backend_state_test.go
@@ -30,14 +30,14 @@ func TestRemoteClient_stateLock(t *testing.T) {
 	b, bCleanup := testBackendDefault(t)
 	defer bCleanup()
 
-	s1, err := b.StateMgr(backend.DefaultStateName)
-	if err != nil {
-		t.Fatalf("expected no error, got %v", err)
+	s1, sDiags := b.StateMgr(backend.DefaultStateName)
+	if sDiags.HasErrors() {
+		t.Fatalf("expected no error, got %v", sDiags.Err())
 	}
 
-	s2, err := b.StateMgr(backend.DefaultStateName)
-	if err != nil {
-		t.Fatalf("expected no error, got %v", err)
+	s2, sDiags := b.StateMgr(backend.DefaultStateName)
+	if sDiags.HasErrors() {
+		t.Fatalf("expected no error, got %v", sDiags.Err())
 	}
 
 	remote.TestRemoteLocks(t, s1.(*remote.State).Client, s2.(*remote.State).Client)
@@ -47,12 +47,12 @@ func TestRemoteClient_Unlock_invalidID(t *testing.T) {
 	b, bCleanup := testBackendDefault(t)
 	defer bCleanup()
 
-	s1, err := b.StateMgr(backend.DefaultStateName)
-	if err != nil {
-		t.Fatalf("expected no error, got %v", err)
+	s1, sDiags := b.StateMgr(backend.DefaultStateName)
+	if sDiags.HasErrors() {
+		t.Fatalf("expected no error, got %v", sDiags.Err())
 	}
 
-	err = s1.Unlock("no")
+	err := s1.Unlock("no")
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
@@ -66,9 +66,9 @@ func TestRemoteClient_Unlock(t *testing.T) {
 	b, bCleanup := testBackendDefault(t)
 	defer bCleanup()
 
-	s1, err := b.StateMgr(backend.DefaultStateName)
-	if err != nil {
-		t.Fatalf("expected no error, got %v", err)
+	s1, sDiags := b.StateMgr(backend.DefaultStateName)
+	if sDiags.HasErrors() {
+		t.Fatalf("expected no error, got %v", sDiags.Err())
 	}
 
 	id, err := s1.Lock(&statemgr.LockInfo{

--- a/internal/backend/remote/backend_test.go
+++ b/internal/backend/remote/backend_test.go
@@ -258,12 +258,12 @@ func TestRemote_addAndRemoveWorkspacesDefault(t *testing.T) {
 		t.Fatalf("expected error %v, got %v", backend.ErrWorkspacesNotSupported, diags.Err())
 	}
 
-	if _, err := b.StateMgr(backend.DefaultStateName); err != nil {
-		t.Fatalf("expected no error, got %v", err)
+	if _, sDiags := b.StateMgr(backend.DefaultStateName); sDiags.HasErrors() {
+		t.Fatalf("expected no error, got %v", sDiags.Err())
 	}
 
-	if _, err := b.StateMgr("prod"); err != backend.ErrWorkspacesNotSupported {
-		t.Fatalf("expected error %v, got %v", backend.ErrWorkspacesNotSupported, err)
+	if _, sDiags := b.StateMgr("prod"); sDiags.Err().Error() != backend.ErrWorkspacesNotSupported.Error() {
+		t.Fatalf("expected error %v, got %v", backend.ErrWorkspacesNotSupported, sDiags.Err())
 	}
 
 	if diags := b.DeleteWorkspace(backend.DefaultStateName, true); diags.HasErrors() {
@@ -289,13 +289,13 @@ func TestRemote_addAndRemoveWorkspacesNoDefault(t *testing.T) {
 		t.Fatalf("expected states %#+v, got %#+v", expectedWorkspaces, states)
 	}
 
-	if _, err := b.StateMgr(backend.DefaultStateName); err != backend.ErrDefaultWorkspaceNotSupported {
-		t.Fatalf("expected error %v, got %v", backend.ErrDefaultWorkspaceNotSupported, err)
+	if _, sDiags := b.StateMgr(backend.DefaultStateName); sDiags.Err().Error() != backend.ErrDefaultWorkspaceNotSupported.Error() {
+		t.Fatalf("expected error %v, got %v", backend.ErrDefaultWorkspaceNotSupported, sDiags.Err())
 	}
 
 	expectedA := "test_A"
-	if _, err := b.StateMgr(expectedA); err != nil {
-		t.Fatal(err)
+	if _, sDiags := b.StateMgr(expectedA); sDiags.HasErrors() {
+		t.Fatal(sDiags.Err())
 	}
 
 	states, wDiags = b.Workspaces()
@@ -309,8 +309,8 @@ func TestRemote_addAndRemoveWorkspacesNoDefault(t *testing.T) {
 	}
 
 	expectedB := "test_B"
-	if _, err := b.StateMgr(expectedB); err != nil {
-		t.Fatal(err)
+	if _, sDiags := b.StateMgr(expectedB); sDiags.HasErrors() {
+		t.Fatal(sDiags.Err())
 	}
 
 	states, wDiags = b.Workspaces()
@@ -496,8 +496,8 @@ func TestRemote_StateMgr_versionCheck(t *testing.T) {
 	}
 
 	// This should succeed
-	if _, err := b.StateMgr(backend.DefaultStateName); err != nil {
-		t.Fatalf("expected no error, got %v", err)
+	if _, sDiags := b.StateMgr(backend.DefaultStateName); sDiags.HasErrors() {
+		t.Fatalf("expected no error, got %v", sDiags.Err())
 	}
 
 	// Now change the remote workspace to a different Terraform version
@@ -514,8 +514,8 @@ func TestRemote_StateMgr_versionCheck(t *testing.T) {
 
 	// This should fail
 	want := `Remote workspace Terraform version "0.13.5" does not match local Terraform version "0.14.0"`
-	if _, err := b.StateMgr(backend.DefaultStateName); err.Error() != want {
-		t.Fatalf("wrong error\n got: %v\nwant: %v", err.Error(), want)
+	if _, sDiags := b.StateMgr(backend.DefaultStateName); sDiags.Err().Error() != want {
+		t.Fatalf("wrong error\n got: %v\nwant: %v", sDiags.Err().Error(), want)
 	}
 }
 
@@ -553,8 +553,8 @@ func TestRemote_StateMgr_versionCheckLatest(t *testing.T) {
 	}
 
 	// This should succeed despite not being a string match
-	if _, err := b.StateMgr(backend.DefaultStateName); err != nil {
-		t.Fatalf("expected no error, got %v", err)
+	if _, sDiags := b.StateMgr(backend.DefaultStateName); sDiags.HasErrors() {
+		t.Fatalf("expected no error, got %v", sDiags.Err())
 	}
 }
 

--- a/internal/backend/remote/testing.go
+++ b/internal/backend/remote/testing.go
@@ -112,9 +112,9 @@ func testRemoteClient(t *testing.T) remote.Client {
 	b, bCleanup := testBackendDefault(t)
 	defer bCleanup()
 
-	raw, err := b.StateMgr(backend.DefaultStateName)
-	if err != nil {
-		t.Fatalf("error: %v", err)
+	raw, sDiags := b.StateMgr(backend.DefaultStateName)
+	if sDiags.HasErrors() {
+		t.Fatalf("error: %v", sDiags.Err())
 	}
 
 	return raw.(*remote.State).Client

--- a/internal/backend/testing.go
+++ b/internal/backend/testing.go
@@ -79,11 +79,11 @@ func TestBackendStates(t *testing.T, b Backend) {
 	t.Helper()
 
 	noDefault := false
-	if _, err := b.StateMgr(DefaultStateName); err != nil {
-		if err == ErrDefaultWorkspaceNotSupported {
+	if _, sDiags := b.StateMgr(DefaultStateName); sDiags.HasErrors() {
+		if sDiags.Err().Error() == ErrDefaultWorkspaceNotSupported.Error() {
 			noDefault = true
 		} else {
-			t.Fatalf("error: %v", err)
+			t.Fatalf("error: %v", sDiags.Err())
 		}
 	}
 
@@ -102,9 +102,9 @@ func TestBackendStates(t *testing.T, b Backend) {
 	}
 
 	// Create a couple states
-	foo, err := b.StateMgr("foo")
-	if err != nil {
-		t.Fatalf("error: %s", err)
+	foo, sDiags := b.StateMgr("foo")
+	if sDiags.HasErrors() {
+		t.Fatalf("error: %s", sDiags.Err())
 	}
 	if err := foo.RefreshState(); err != nil {
 		t.Fatalf("bad: %s", err)
@@ -113,9 +113,9 @@ func TestBackendStates(t *testing.T, b Backend) {
 		t.Fatalf("should be empty: %s", v)
 	}
 
-	bar, err := b.StateMgr("bar")
-	if err != nil {
-		t.Fatalf("error: %s", err)
+	bar, sDiags := b.StateMgr("bar")
+	if sDiags.HasErrors() {
+		t.Fatalf("error: %s", sDiags.Err())
 	}
 	if err := bar.RefreshState(); err != nil {
 		t.Fatalf("bad: %s", err)
@@ -177,9 +177,9 @@ func TestBackendStates(t *testing.T, b Backend) {
 		}
 
 		// fetch foo again from the backend
-		foo, err = b.StateMgr("foo")
-		if err != nil {
-			t.Fatal("error re-fetching state:", err)
+		foo, sDiags = b.StateMgr("foo")
+		if sDiags.HasErrors() {
+			t.Fatalf("error re-fetching state: %s", sDiags.Err())
 		}
 		if err := foo.RefreshState(); err != nil {
 			t.Fatal("error refreshing foo:", err)
@@ -190,9 +190,9 @@ func TestBackendStates(t *testing.T, b Backend) {
 		}
 
 		// fetch the bar again from the backend
-		bar, err = b.StateMgr("bar")
-		if err != nil {
-			t.Fatal("error re-fetching state:", err)
+		bar, sDiags = b.StateMgr("bar")
+		if sDiags.HasErrors() {
+			t.Fatalf("error re-fetching state: %s", sDiags.Err())
 		}
 		if err := bar.RefreshState(); err != nil {
 			t.Fatal("error refreshing bar:", err)
@@ -234,9 +234,9 @@ func TestBackendStates(t *testing.T, b Backend) {
 	// Create and delete the foo workspace again.
 	// Make sure that there are no leftover artifacts from a deleted state
 	// preventing re-creation.
-	foo, err = b.StateMgr("foo")
-	if err != nil {
-		t.Fatalf("error: %s", err)
+	foo, sDiags = b.StateMgr("foo")
+	if sDiags.HasErrors() {
+		t.Fatalf("error: %s", sDiags)
 	}
 	if err := foo.RefreshState(); err != nil {
 		t.Fatalf("bad: %s", err)
@@ -307,9 +307,9 @@ func testLocksInWorkspace(t *testing.T, b1, b2 Backend, testForceUnlock bool, wo
 	t.Helper()
 
 	// Get the default state for each
-	b1StateMgr, err := b1.StateMgr(DefaultStateName)
-	if err != nil {
-		t.Fatalf("error: %s", err)
+	b1StateMgr, sDiags := b1.StateMgr(DefaultStateName)
+	if sDiags.HasErrors() {
+		t.Fatalf("error: %s", sDiags)
 	}
 	if err := b1StateMgr.RefreshState(); err != nil {
 		t.Fatalf("bad: %s", err)
@@ -323,9 +323,9 @@ func testLocksInWorkspace(t *testing.T, b1, b2 Backend, testForceUnlock bool, wo
 
 	t.Logf("TestBackend: testing state locking for %T", b1)
 
-	b2StateMgr, err := b2.StateMgr(DefaultStateName)
-	if err != nil {
-		t.Fatalf("error: %s", err)
+	b2StateMgr, sDiags := b2.StateMgr(DefaultStateName)
+	if sDiags.HasErrors() {
+		t.Fatalf("error: %s", sDiags)
 	}
 	if err := b2StateMgr.RefreshState(); err != nil {
 		t.Fatalf("bad: %s", err)
@@ -351,9 +351,9 @@ func testLocksInWorkspace(t *testing.T, b1, b2 Backend, testForceUnlock bool, wo
 	// Make sure we can still get the statemgr.Full from another instance even
 	// when locked.  This should only happen when a state is loaded via the
 	// backend, and as a remote state.
-	_, err = b2.StateMgr(DefaultStateName)
-	if err != nil {
-		t.Errorf("failed to read locked state from another backend instance: %s", err)
+	_, sDiags = b2.StateMgr(DefaultStateName)
+	if sDiags.HasErrors() {
+		t.Errorf("failed to read locked state from another backend instance: %s", sDiags)
 	}
 
 	// If the lock ID is blank, assume locking is disabled

--- a/internal/builtin/providers/terraform/data_source_state.go
+++ b/internal/builtin/providers/terraform/data_source_state.go
@@ -129,12 +129,12 @@ func dataSourceRemoteStateRead(d cty.Value) (cty.Value, tfdiags.Diagnostics) {
 		workspaceName = workspaceVal.AsString()
 	}
 
-	state, err := b.StateMgr(workspaceName)
-	if err != nil {
+	state, sDiags := b.StateMgr(workspaceName)
+	if sDiags.HasErrors() {
 		diags = diags.Append(tfdiags.AttributeValue(
 			tfdiags.Error,
 			"Error loading state error",
-			fmt.Sprintf("error loading the remote state: %s", err),
+			fmt.Sprintf("error loading the remote state: %s", sDiags.Err()),
 			cty.Path(nil).GetAttr("backend"),
 		))
 		return cty.NilVal, diags

--- a/internal/builtin/providers/terraform/data_source_state_test.go
+++ b/internal/builtin/providers/terraform/data_source_state_test.go
@@ -369,8 +369,8 @@ func (b backendFailsConfigure) Configure(config cty.Value) tfdiags.Diagnostics {
 	return diags
 }
 
-func (b backendFailsConfigure) StateMgr(workspace string) (statemgr.Full, error) {
-	return nil, fmt.Errorf("StateMgr not implemented")
+func (b backendFailsConfigure) StateMgr(workspace string) (statemgr.Full, tfdiags.Diagnostics) {
+	return nil, tfdiags.Diagnostics{}.Append(fmt.Errorf("StateMgr not implemented"))
 }
 
 func (b backendFailsConfigure) DeleteWorkspace(name string, _ bool) tfdiags.Diagnostics {

--- a/internal/cloud/backend_context.go
+++ b/internal/cloud/backend_context.go
@@ -38,9 +38,9 @@ func (b *Cloud) LocalRun(op *backendrun.Operation) (*backendrun.LocalRun, statem
 
 	// Get the latest state.
 	log.Printf("[TRACE] cloud: requesting state manager for workspace %q", remoteWorkspaceName)
-	stateMgr, err := b.StateMgr(op.Workspace)
-	if err != nil {
-		diags = diags.Append(fmt.Errorf("error loading state: %w", err))
+	stateMgr, sDiags := b.StateMgr(op.Workspace)
+	if sDiags.HasErrors() {
+		diags = diags.Append(fmt.Errorf("error loading state: %w", sDiags.Err()))
 		return nil, nil, diags
 	}
 

--- a/internal/cloud/state_test.go
+++ b/internal/cloud/state_test.go
@@ -143,13 +143,13 @@ func TestCloudLocks(t *testing.T) {
 	back, bCleanup := testBackendWithName(t)
 	defer bCleanup()
 
-	a, err := back.StateMgr(testBackendSingleWorkspaceName)
-	if err != nil {
-		t.Fatalf("expected no error, got %v", err)
+	a, sDiags := back.StateMgr(testBackendSingleWorkspaceName)
+	if sDiags.HasErrors() {
+		t.Fatalf("expected no error, got %v", sDiags.Err())
 	}
-	b, err := back.StateMgr(testBackendSingleWorkspaceName)
-	if err != nil {
-		t.Fatalf("expected no error, got %v", err)
+	b, sDiags := back.StateMgr(testBackendSingleWorkspaceName)
+	if sDiags.HasErrors() {
+		t.Fatalf("expected no error, got %v", sDiags.Err())
 	}
 
 	lockerA, ok := a.(statemgr.Locker)

--- a/internal/cloud/testing.go
+++ b/internal/cloud/testing.go
@@ -172,9 +172,9 @@ func testCloudState(t *testing.T) *State {
 	b, bCleanup := testBackendWithName(t)
 	defer bCleanup()
 
-	raw, err := b.StateMgr(testBackendSingleWorkspaceName)
-	if err != nil {
-		t.Fatalf("error: %v", err)
+	raw, sDiags := b.StateMgr(testBackendSingleWorkspaceName)
+	if sDiags.HasErrors() {
+		t.Fatalf("error: %v", sDiags.Err())
 	}
 
 	return raw.(*State)

--- a/internal/command/init_run.go
+++ b/internal/command/init_run.go
@@ -192,9 +192,9 @@ func (c *InitCommand) run(initArgs *arguments.Init, view views.Init) int {
 			view.Diagnostics(diags)
 			return 1
 		}
-		sMgr, err := back.StateMgr(workspace)
-		if err != nil {
-			diags = diags.Append(fmt.Errorf("Error loading state: %s", err))
+		sMgr, sDiags := back.StateMgr(workspace)
+		if sDiags.HasErrors() {
+			diags = diags.Append(fmt.Errorf("Error loading state: %s", sDiags.Err()))
 			view.Diagnostics(diags)
 			return 1
 		}

--- a/internal/command/init_run_experiment.go
+++ b/internal/command/init_run_experiment.go
@@ -234,9 +234,9 @@ func (c *InitCommand) runPssInit(initArgs *arguments.Init, view views.Init) int 
 			view.Diagnostics(diags)
 			return 1
 		}
-		sMgr, err := back.StateMgr(workspace)
-		if err != nil {
-			diags = diags.Append(fmt.Errorf("Error loading state: %s", err))
+		sMgr, sDiags := back.StateMgr(workspace)
+		if sDiags.HasErrors() {
+			diags = diags.Append(fmt.Errorf("Error loading state: %s", sDiags.Err()))
 			view.Diagnostics(diags)
 			return 1
 		}

--- a/internal/command/meta_backend_test.go
+++ b/internal/command/meta_backend_test.go
@@ -50,9 +50,9 @@ func TestMetaBackend_emptyDir(t *testing.T) {
 	}
 
 	// Write some state
-	s, err := b.StateMgr(backend.DefaultStateName)
-	if err != nil {
-		t.Fatalf("unexpected error: %s", err)
+	s, sDiags := b.StateMgr(backend.DefaultStateName)
+	if sDiags.HasErrors() {
+		t.Fatalf("unexpected error: %s", sDiags.Err())
 	}
 	s.WriteState(testState())
 	if err := s.PersistState(nil); err != nil {
@@ -119,9 +119,9 @@ func TestMetaBackend_emptyWithDefaultState(t *testing.T) {
 	}
 
 	// Check the state
-	s, err := b.StateMgr(backend.DefaultStateName)
-	if err != nil {
-		t.Fatalf("unexpected error: %s", err)
+	s, sDiags := b.StateMgr(backend.DefaultStateName)
+	if sDiags.HasErrors() {
+		t.Fatalf("unexpected error: %s", sDiags.Err())
 	}
 	if err := s.RefreshState(); err != nil {
 		t.Fatalf("err: %s", err)
@@ -193,9 +193,9 @@ func TestMetaBackend_emptyWithExplicitState(t *testing.T) {
 	}
 
 	// Check the state
-	s, err := b.StateMgr(backend.DefaultStateName)
-	if err != nil {
-		t.Fatalf("unexpected error: %s", err)
+	s, sDiags := b.StateMgr(backend.DefaultStateName)
+	if sDiags.HasErrors() {
+		t.Fatalf("unexpected error: %s", sDiags.Err())
 	}
 	if err := s.RefreshState(); err != nil {
 		t.Fatalf("err: %s", err)
@@ -265,9 +265,9 @@ func TestMetaBackend_configureNewBackend(t *testing.T) {
 	}
 
 	// Check the state
-	s, err := b.StateMgr(backend.DefaultStateName)
-	if err != nil {
-		t.Fatalf("unexpected error: %s", err)
+	s, sDiags := b.StateMgr(backend.DefaultStateName)
+	if sDiags.HasErrors() {
+		t.Fatalf("unexpected error: %s", sDiags.Err())
 	}
 	if err := s.RefreshState(); err != nil {
 		t.Fatalf("unexpected error: %s", err)
@@ -336,9 +336,9 @@ func TestMetaBackend_configureNewBackendWithState(t *testing.T) {
 	}
 
 	// Check the state
-	s, err := b.StateMgr(backend.DefaultStateName)
-	if err != nil {
-		t.Fatalf("unexpected error: %s", err)
+	s, sDiags := b.StateMgr(backend.DefaultStateName)
+	if sDiags.HasErrors() {
+		t.Fatalf("unexpected error: %s", sDiags.Err())
 	}
 	state, err := statemgr.RefreshAndRead(s)
 	if err != nil {
@@ -459,9 +459,9 @@ func TestMetaBackend_configureNewBackendWithStateNoMigrate(t *testing.T) {
 	}
 
 	// Check the state
-	s, err := b.StateMgr(backend.DefaultStateName)
-	if err != nil {
-		t.Fatalf("unexpected error: %s", err)
+	s, sDiags := b.StateMgr(backend.DefaultStateName)
+	if sDiags.HasErrors() {
+		t.Fatalf("unexpected error: %s", sDiags.Err())
 	}
 	if err := s.RefreshState(); err != nil {
 		t.Fatalf("unexpected error: %s", err)
@@ -502,9 +502,9 @@ func TestMetaBackend_configureNewBackendWithStateExisting(t *testing.T) {
 	}
 
 	// Check the state
-	s, err := b.StateMgr(backend.DefaultStateName)
-	if err != nil {
-		t.Fatalf("unexpected error: %s", err)
+	s, sDiags := b.StateMgr(backend.DefaultStateName)
+	if sDiags.HasErrors() {
+		t.Fatalf("unexpected error: %s", sDiags.Err())
 	}
 	if err := s.RefreshState(); err != nil {
 		t.Fatalf("unexpected error: %s", err)
@@ -574,9 +574,9 @@ func TestMetaBackend_configureNewBackendWithStateExistingNoMigrate(t *testing.T)
 	}
 
 	// Check the state
-	s, err := b.StateMgr(backend.DefaultStateName)
-	if err != nil {
-		t.Fatalf("unexpected error: %s", err)
+	s, sDiags := b.StateMgr(backend.DefaultStateName)
+	if sDiags.HasErrors() {
+		t.Fatalf("unexpected error: %s", sDiags.Err())
 	}
 	if err := s.RefreshState(); err != nil {
 		t.Fatalf("unexpected error: %s", err)
@@ -641,9 +641,9 @@ func TestMetaBackend_configuredUnchanged(t *testing.T) {
 	}
 
 	// Check the state
-	s, err := b.StateMgr(backend.DefaultStateName)
-	if err != nil {
-		t.Fatalf("unexpected error: %s", err)
+	s, sDiags := b.StateMgr(backend.DefaultStateName)
+	if sDiags.HasErrors() {
+		t.Fatalf("unexpected error: %s", sDiags.Err())
 	}
 	if err := s.RefreshState(); err != nil {
 		t.Fatalf("unexpected error: %s", err)
@@ -687,9 +687,9 @@ func TestMetaBackend_changeConfiguredBackend(t *testing.T) {
 	}
 
 	// Check the state
-	s, err := b.StateMgr(backend.DefaultStateName)
-	if err != nil {
-		t.Fatalf("unexpected error: %s", err)
+	s, sDiags := b.StateMgr(backend.DefaultStateName)
+	if sDiags.HasErrors() {
+		t.Fatalf("unexpected error: %s", sDiags.Err())
 	}
 	if err := s.RefreshState(); err != nil {
 		t.Fatalf("unexpected error: %s", err)
@@ -773,9 +773,9 @@ func TestMetaBackend_reconfigureBackendChange(t *testing.T) {
 	}
 
 	// Check the state
-	s, err := b.StateMgr(backend.DefaultStateName)
-	if err != nil {
-		t.Fatalf("unexpected error: %s", err)
+	s, sDiags := b.StateMgr(backend.DefaultStateName)
+	if sDiags.HasErrors() {
+		t.Fatalf("unexpected error: %s", sDiags.Err())
 	}
 	if err := s.RefreshState(); err != nil {
 		t.Fatalf("unexpected error: %s", err)
@@ -913,9 +913,9 @@ func TestMetaBackend_configuredBackendChangeCopy(t *testing.T) {
 	}
 
 	// Check the state
-	s, err := b.StateMgr(backend.DefaultStateName)
-	if err != nil {
-		t.Fatalf("unexpected error: %s", err)
+	s, sDiags := b.StateMgr(backend.DefaultStateName)
+	if sDiags.HasErrors() {
+		t.Fatalf("unexpected error: %s", sDiags.Err())
 	}
 	if err := s.RefreshState(); err != nil {
 		t.Fatalf("unexpected error: %s", err)
@@ -966,9 +966,9 @@ func TestMetaBackend_configuredBackendChangeCopy_singleState(t *testing.T) {
 	}
 
 	// Check the state
-	s, err := b.StateMgr(backend.DefaultStateName)
-	if err != nil {
-		t.Fatalf("unexpected error: %s", err)
+	s, sDiags := b.StateMgr(backend.DefaultStateName)
+	if sDiags.HasErrors() {
+		t.Fatalf("unexpected error: %s", sDiags.Err())
 	}
 	if err := s.RefreshState(); err != nil {
 		t.Fatalf("unexpected error: %s", err)
@@ -1020,9 +1020,9 @@ func TestMetaBackend_configuredBackendChangeCopy_multiToSingleDefault(t *testing
 	}
 
 	// Check the state
-	s, err := b.StateMgr(backend.DefaultStateName)
-	if err != nil {
-		t.Fatalf("unexpected error: %s", err)
+	s, sDiags := b.StateMgr(backend.DefaultStateName)
+	if sDiags.HasErrors() {
+		t.Fatalf("unexpected error: %s", sDiags.Err())
 	}
 	if err := s.RefreshState(); err != nil {
 		t.Fatalf("unexpected error: %s", err)
@@ -1074,9 +1074,9 @@ func TestMetaBackend_configuredBackendChangeCopy_multiToSingle(t *testing.T) {
 	}
 
 	// Check the state
-	s, err := b.StateMgr(backend.DefaultStateName)
-	if err != nil {
-		t.Fatalf("unexpected error: %s", err)
+	s, sDiags := b.StateMgr(backend.DefaultStateName)
+	if sDiags.HasErrors() {
+		t.Fatalf("unexpected error: %s", sDiags.Err())
 	}
 	if err := s.RefreshState(); err != nil {
 		t.Fatalf("unexpected error: %s", err)
@@ -1148,9 +1148,9 @@ func TestMetaBackend_configuredBackendChangeCopy_multiToSingleCurrentEnv(t *test
 	}
 
 	// Check the state
-	s, err := b.StateMgr(backend.DefaultStateName)
-	if err != nil {
-		t.Fatalf("unexpected error: %s", err)
+	s, sDiags := b.StateMgr(backend.DefaultStateName)
+	if sDiags.HasErrors() {
+		t.Fatalf("unexpected error: %s", sDiags.Err())
 	}
 	if err := s.RefreshState(); err != nil {
 		t.Fatalf("unexpected error: %s", err)
@@ -1219,9 +1219,9 @@ func TestMetaBackend_configuredBackendChangeCopy_multiToMulti(t *testing.T) {
 
 	{
 		// Check the default state
-		s, err := b.StateMgr(backend.DefaultStateName)
-		if err != nil {
-			t.Fatalf("unexpected error: %s", err)
+		s, sDiags := b.StateMgr(backend.DefaultStateName)
+		if sDiags.HasErrors() {
+			t.Fatalf("unexpected error: %s", sDiags.Err())
 		}
 		if err := s.RefreshState(); err != nil {
 			t.Fatalf("unexpected error: %s", err)
@@ -1237,9 +1237,9 @@ func TestMetaBackend_configuredBackendChangeCopy_multiToMulti(t *testing.T) {
 
 	{
 		// Check the other state
-		s, err := b.StateMgr("env2")
-		if err != nil {
-			t.Fatalf("unexpected error: %s", err)
+		s, sDiags := b.StateMgr("env2")
+		if sDiags.HasErrors() {
+			t.Fatalf("unexpected error: %s", sDiags.Err())
 		}
 		if err := s.RefreshState(); err != nil {
 			t.Fatalf("unexpected error: %s", err)
@@ -1320,9 +1320,9 @@ func TestMetaBackend_configuredBackendChangeCopy_multiToNoDefaultWithDefault(t *
 
 	{
 		// Check the renamed default state
-		s, err := b.StateMgr("env1")
-		if err != nil {
-			t.Fatalf("unexpected error: %s", err)
+		s, sDiags := b.StateMgr("env1")
+		if sDiags.HasErrors() {
+			t.Fatalf("unexpected error: %s", sDiags.Err())
 		}
 		if err := s.RefreshState(); err != nil {
 			t.Fatalf("unexpected error: %s", err)
@@ -1397,9 +1397,9 @@ func TestMetaBackend_configuredBackendChangeCopy_multiToNoDefaultWithoutDefault(
 
 	{
 		// Check the named state
-		s, err := b.StateMgr("env2")
-		if err != nil {
-			t.Fatalf("unexpected error: %s", err)
+		s, sDiags := b.StateMgr("env2")
+		if sDiags.HasErrors() {
+			t.Fatalf("unexpected error: %s", sDiags.Err())
 		}
 		if err := s.RefreshState(); err != nil {
 			t.Fatalf("unexpected error: %s", err)
@@ -1450,9 +1450,9 @@ func TestMetaBackend_configuredBackendUnset(t *testing.T) {
 	}
 
 	// Check the state
-	s, err := b.StateMgr(backend.DefaultStateName)
-	if err != nil {
-		t.Fatalf("unexpected error: %s", err)
+	s, sDiags := b.StateMgr(backend.DefaultStateName)
+	if sDiags.HasErrors() {
+		t.Fatalf("unexpected error: %s", sDiags.Err())
 	}
 	if err := s.RefreshState(); err != nil {
 		t.Fatalf("unexpected error: %s", err)
@@ -1512,9 +1512,9 @@ func TestMetaBackend_configuredBackendUnsetCopy(t *testing.T) {
 	}
 
 	// Check the state
-	s, err := b.StateMgr(backend.DefaultStateName)
-	if err != nil {
-		t.Fatalf("unexpected error: %s", err)
+	s, sDiags := b.StateMgr(backend.DefaultStateName)
+	if sDiags.HasErrors() {
+		t.Fatalf("unexpected error: %s", sDiags.Err())
 	}
 	if err := s.RefreshState(); err != nil {
 		t.Fatalf("unexpected error: %s", err)
@@ -1580,9 +1580,9 @@ func TestMetaBackend_planLocal(t *testing.T) {
 	}
 
 	// Check the state
-	s, err := b.StateMgr(backend.DefaultStateName)
-	if err != nil {
-		t.Fatalf("unexpected error: %s", err)
+	s, sDiags := b.StateMgr(backend.DefaultStateName)
+	if sDiags.HasErrors() {
+		t.Fatalf("unexpected error: %s", sDiags.Err())
 	}
 	if err := s.RefreshState(); err != nil {
 		t.Fatalf("unexpected error: %s", err)
@@ -1681,9 +1681,9 @@ func TestMetaBackend_planLocalStatePath(t *testing.T) {
 	}
 
 	// Check the state
-	s, err := b.StateMgr(backend.DefaultStateName)
-	if err != nil {
-		t.Fatalf("unexpected error: %s", err)
+	s, sDiags := b.StateMgr(backend.DefaultStateName)
+	if sDiags.HasErrors() {
+		t.Fatalf("unexpected error: %s", sDiags.Err())
 	}
 	if err := s.RefreshState(); err != nil {
 		t.Fatalf("unexpected error: %s", err)
@@ -1770,9 +1770,9 @@ func TestMetaBackend_planLocalMatch(t *testing.T) {
 	}
 
 	// Check the state
-	s, err := b.StateMgr(backend.DefaultStateName)
-	if err != nil {
-		t.Fatalf("unexpected error: %s", err)
+	s, sDiags := b.StateMgr(backend.DefaultStateName)
+	if sDiags.HasErrors() {
+		t.Fatalf("unexpected error: %s", sDiags.Err())
 	}
 	if err := s.RefreshState(); err != nil {
 		t.Fatalf("unexpected error: %s", err)

--- a/internal/command/output.go
+++ b/internal/command/output.go
@@ -83,9 +83,9 @@ func (c *OutputCommand) Outputs(statePath string) (map[string]*states.OutputValu
 	}
 
 	// Get the state
-	stateStore, err := b.StateMgr(env)
-	if err != nil {
-		diags = diags.Append(fmt.Errorf("Failed to load state: %s", err))
+	stateStore, sDiags := b.StateMgr(env)
+	if sDiags.HasErrors() {
+		diags = diags.Append(fmt.Errorf("Failed to load state: %s", sDiags.Err()))
 		return nil, diags
 	}
 

--- a/internal/command/providers.go
+++ b/internal/command/providers.go
@@ -99,9 +99,9 @@ func (c *ProvidersCommand) Run(args []string) int {
 		c.Ui.Error(fmt.Sprintf("Error selecting workspace: %s", err))
 		return 1
 	}
-	s, err := b.StateMgr(env)
-	if err != nil {
-		c.Ui.Error(fmt.Sprintf("Failed to load state: %s", err))
+	s, sDiags := b.StateMgr(env)
+	if sDiags.HasErrors() {
+		c.Ui.Error(fmt.Sprintf("Failed to load state: %s", sDiags.Err()))
 		return 1
 	}
 	if err := s.RefreshState(); err != nil {

--- a/internal/command/show.go
+++ b/internal/command/show.go
@@ -338,9 +338,9 @@ func getStateFromPath(path string) (*statefile.File, error) {
 // getStateFromBackend returns the State for the current workspace, if available.
 func getStateFromBackend(b backend.Backend, workspace string) (*statefile.File, error) {
 	// Get the state store for the given workspace
-	stateStore, err := b.StateMgr(workspace)
-	if err != nil {
-		return nil, fmt.Errorf("Failed to load state manager: %w", err)
+	stateStore, sDiags := b.StateMgr(workspace)
+	if sDiags.HasErrors() {
+		return nil, fmt.Errorf("Failed to load state manager: %w", sDiags.Err())
 	}
 
 	// Refresh the state store with the latest state snapshot from persistent storage

--- a/internal/command/state_identities.go
+++ b/internal/command/state_identities.go
@@ -62,9 +62,9 @@ func (c *StateIdentitiesCommand) Run(args []string) int {
 		c.Ui.Error(fmt.Sprintf("Error selecting workspace: %s", err))
 		return 1
 	}
-	stateMgr, err := b.StateMgr(env)
-	if err != nil {
-		c.Ui.Error(fmt.Sprintf(errStateLoadingState, err))
+	stateMgr, sDiags := b.StateMgr(env)
+	if sDiags.HasErrors() {
+		c.Ui.Error(fmt.Sprintf(errStateLoadingState, sDiags.Err()))
 		return 1
 	}
 	if err := stateMgr.RefreshState(); err != nil {

--- a/internal/command/state_list.go
+++ b/internal/command/state_list.go
@@ -52,9 +52,9 @@ func (c *StateListCommand) Run(args []string) int {
 		c.Ui.Error(fmt.Sprintf("Error selecting workspace: %s", err))
 		return 1
 	}
-	stateMgr, err := b.StateMgr(env)
-	if err != nil {
-		c.Ui.Error(fmt.Sprintf(errStateLoadingState, err))
+	stateMgr, sDiags := b.StateMgr(env)
+	if sDiags.HasErrors() {
+		c.Ui.Error(fmt.Sprintf(errStateLoadingState, sDiags.Err()))
 		return 1
 	}
 	if err := stateMgr.RefreshState(); err != nil {

--- a/internal/command/state_meta.go
+++ b/internal/command/state_meta.go
@@ -53,9 +53,9 @@ func (c *StateMeta) State() (statemgr.Full, error) {
 		}
 
 		// Get the state
-		s, err := b.StateMgr(workspace)
-		if err != nil {
-			return nil, err
+		s, sDiags := b.StateMgr(workspace)
+		if sDiags.HasErrors() {
+			return nil, sDiags.Err()
 		}
 
 		// Get a local backend

--- a/internal/command/state_pull.go
+++ b/internal/command/state_pull.go
@@ -48,9 +48,9 @@ func (c *StatePullCommand) Run(args []string) int {
 		c.Ui.Error(fmt.Sprintf("Error selecting workspace: %s", err))
 		return 1
 	}
-	stateMgr, err := b.StateMgr(env)
-	if err != nil {
-		c.Ui.Error(fmt.Sprintf(errStateLoadingState, err))
+	stateMgr, sDiags := b.StateMgr(env)
+	if sDiags.HasErrors() {
+		c.Ui.Error(fmt.Sprintf(errStateLoadingState, sDiags.Err()))
 		return 1
 	}
 	if err := stateMgr.RefreshState(); err != nil {

--- a/internal/command/state_push.go
+++ b/internal/command/state_push.go
@@ -98,9 +98,9 @@ func (c *StatePushCommand) Run(args []string) int {
 	}
 
 	// Get the state manager for the currently-selected workspace
-	stateMgr, err := b.StateMgr(workspace)
-	if err != nil {
-		c.Ui.Error(fmt.Sprintf("Failed to load destination state: %s", err))
+	stateMgr, sDiags := b.StateMgr(workspace)
+	if sDiags.HasErrors() {
+		c.Ui.Error(fmt.Sprintf("Failed to load destination state: %s", sDiags.Err()))
 		return 1
 	}
 

--- a/internal/command/state_push_test.go
+++ b/internal/command/state_push_test.go
@@ -263,9 +263,9 @@ func TestStatePush_forceRemoteState(t *testing.T) {
 
 	// put a dummy state in place, so we have something to force
 	b := backend.TestBackendConfig(t, inmem.New(), nil)
-	sMgr, err := b.StateMgr("test")
-	if err != nil {
-		t.Fatal(err)
+	sMgr, sDiags := b.StateMgr("test")
+	if sDiags.HasErrors() {
+		t.Fatal(sDiags.Err())
 	}
 	if err := sMgr.WriteState(states.NewState()); err != nil {
 		t.Fatal(err)

--- a/internal/command/state_show.go
+++ b/internal/command/state_show.go
@@ -109,9 +109,9 @@ func (c *StateShowCommand) Run(args []string) int {
 		c.Streams.Eprintf("Error selecting workspace: %s\n", err)
 		return 1
 	}
-	stateMgr, err := b.StateMgr(env)
-	if err != nil {
-		c.Streams.Eprintln(fmt.Sprintf(errStateLoadingState, err))
+	stateMgr, sDiags := b.StateMgr(env)
+	if sDiags.HasErrors() {
+		c.Streams.Eprintln(fmt.Sprintf(errStateLoadingState, sDiags.Err()))
 		return 1
 	}
 	if err := stateMgr.RefreshState(); err != nil {

--- a/internal/command/taint.go
+++ b/internal/command/taint.go
@@ -89,9 +89,9 @@ func (c *TaintCommand) Run(args []string) int {
 	}
 
 	// Get the state
-	stateMgr, err := b.StateMgr(workspace)
-	if err != nil {
-		c.Ui.Error(fmt.Sprintf("Failed to load state: %s", err))
+	stateMgr, sDiags := b.StateMgr(workspace)
+	if sDiags.HasErrors() {
+		c.Ui.Error(fmt.Sprintf("Failed to load state: %s", sDiags.Err()))
 		return 1
 	}
 

--- a/internal/command/unlock.go
+++ b/internal/command/unlock.go
@@ -76,9 +76,9 @@ func (c *UnlockCommand) Run(args []string) int {
 		c.Ui.Error(fmt.Sprintf("Error selecting workspace: %s", err))
 		return 1
 	}
-	stateMgr, err := b.StateMgr(env)
-	if err != nil {
-		c.Ui.Error(fmt.Sprintf("Failed to load state: %s", err))
+	stateMgr, sDiags := b.StateMgr(env)
+	if sDiags.HasErrors() {
+		c.Ui.Error(fmt.Sprintf("Failed to load state: %s", sDiags.Err()))
 		return 1
 	}
 

--- a/internal/command/untaint.go
+++ b/internal/command/untaint.go
@@ -79,9 +79,9 @@ func (c *UntaintCommand) Run(args []string) int {
 	}
 
 	// Get the state
-	stateMgr, err := b.StateMgr(workspace)
-	if err != nil {
-		c.Ui.Error(fmt.Sprintf("Failed to load state: %s", err))
+	stateMgr, sDiags := b.StateMgr(workspace)
+	if sDiags.HasErrors() {
+		c.Ui.Error(fmt.Sprintf("Failed to load state: %s", sDiags.Err()))
 		return 1
 	}
 

--- a/internal/command/workspace_command_test.go
+++ b/internal/command/workspace_command_test.go
@@ -319,9 +319,9 @@ func TestWorkspace_createWithState(t *testing.T) {
 	}
 
 	b := backend.TestBackendConfig(t, inmem.New(), nil)
-	sMgr, err := b.StateMgr(workspace)
-	if err != nil {
-		t.Fatal(err)
+	sMgr, sDiags := b.StateMgr(workspace)
+	if sDiags.HasErrors() {
+		t.Fatal(sDiags)
 	}
 
 	newState := sMgr.State()

--- a/internal/command/workspace_delete.go
+++ b/internal/command/workspace_delete.go
@@ -120,9 +120,9 @@ func (c *WorkspaceDeleteCommand) Run(args []string) int {
 	}
 
 	// Check if the workspace's state is empty or not
-	stateMgr, err := b.StateMgr(workspace)
-	if err != nil {
-		c.Ui.Error(err.Error())
+	stateMgr, sDiags := b.StateMgr(workspace)
+	if sDiags.HasErrors() {
+		c.Ui.Error(sDiags.Err().Error())
 		return 1
 	}
 

--- a/internal/command/workspace_new.go
+++ b/internal/command/workspace_new.go
@@ -102,9 +102,9 @@ func (c *WorkspaceNewCommand) Run(args []string) int {
 		}
 	}
 
-	_, err = b.StateMgr(workspace)
-	if err != nil {
-		c.Ui.Error(err.Error())
+	_, sDiags := b.StateMgr(workspace)
+	if sDiags.HasErrors() {
+		c.Ui.Error(sDiags.Err().Error())
 		return 1
 	}
 
@@ -123,9 +123,9 @@ func (c *WorkspaceNewCommand) Run(args []string) int {
 	}
 
 	// load the new Backend state
-	stateMgr, err := b.StateMgr(workspace)
-	if err != nil {
-		c.Ui.Error(err.Error())
+	stateMgr, sDiags := b.StateMgr(workspace)
+	if sDiags.HasErrors() {
+		c.Ui.Error(sDiags.Err().Error())
 		return 1
 	}
 

--- a/internal/command/workspace_select.go
+++ b/internal/command/workspace_select.go
@@ -105,9 +105,9 @@ func (c *WorkspaceSelectCommand) Run(args []string) int {
 
 	if !found {
 		if orCreate {
-			_, err = b.StateMgr(name)
-			if err != nil {
-				c.Ui.Error(err.Error())
+			_, sDiags := b.StateMgr(name)
+			if sDiags.HasErrors() {
+				c.Ui.Error(sDiags.Err().Error())
 				return 1
 			}
 			newState = true

--- a/internal/stacks/stackmigrate/load.go
+++ b/internal/stacks/stackmigrate/load.go
@@ -112,9 +112,9 @@ func (l *Loader) LoadState(configPath string) (*states.State, tfdiags.Diagnostic
 
 	// The backend is initialised and configured, so now we can load the state
 	// from the backend.
-	stateManager, err := backend.StateMgr(workspace)
-	if err != nil {
-		diags = diags.Append(fmt.Errorf("error loading state: %s", err))
+	stateManager, sDiags := backend.StateMgr(workspace)
+	if sDiags.HasErrors() {
+		diags = diags.Append(fmt.Errorf("error loading state: %s", sDiags.Err()))
 		return state, diags
 	}
 

--- a/internal/tfdiags/contextual.go
+++ b/internal/tfdiags/contextual.go
@@ -99,6 +99,9 @@ func GetAttribute(d Diagnostic) cty.Path {
 	return nil
 }
 
+var _ Diagnostic = &attributeDiagnostic{}
+var _ ComparableDiagnostic = &attributeDiagnostic{}
+
 type attributeDiagnostic struct {
 	diagnosticBase
 	attrPath cty.Path
@@ -383,6 +386,9 @@ func WholeContainingBody(severity Severity, summary, detail string) Diagnostic {
 		},
 	}
 }
+
+var _ Diagnostic = &wholeBodyDiagnostic{}
+var _ ComparableDiagnostic = &wholeBodyDiagnostic{}
 
 type wholeBodyDiagnostic struct {
 	diagnosticBase

--- a/internal/tfdiags/diagnostic_base.go
+++ b/internal/tfdiags/diagnostic_base.go
@@ -15,6 +15,10 @@ type diagnosticBase struct {
 	address  string
 }
 
+var _ Diagnostic = &diagnosticBase{}
+
+var _ ComparableDiagnostic = &diagnosticBase{}
+
 func (d diagnosticBase) Severity() Severity {
 	return d.severity
 }
@@ -37,4 +41,25 @@ func (d diagnosticBase) FromExpr() *FromExpr {
 
 func (d diagnosticBase) ExtraInfo() interface{} {
 	return nil
+}
+
+func (d diagnosticBase) Equals(otherDiag ComparableDiagnostic) bool {
+	od, ok := otherDiag.(diagnosticBase)
+	if !ok {
+		return false
+	}
+	if d.severity != od.severity {
+		return false
+	}
+	if d.summary != od.summary {
+		return false
+	}
+	if d.detail != od.detail {
+		return false
+	}
+	if d.address != od.address {
+		return false
+	}
+
+	return true
 }

--- a/internal/tfdiags/diagnostic_base.go
+++ b/internal/tfdiags/diagnostic_base.go
@@ -17,7 +17,10 @@ type diagnosticBase struct {
 
 var _ Diagnostic = &diagnosticBase{}
 
-var _ ComparableDiagnostic = &diagnosticBase{}
+// diagnosticBase doesn't implement ComparableDiagnostic because the lack of source data
+// means separate diagnostics might be falsely identified as equal. This poses a user-facing
+// risk if deduplication of diagnostics removes a diagnostic that's incorrectly been identified
+// as a duplicate via comparison.
 
 func (d diagnosticBase) Severity() Severity {
 	return d.severity
@@ -41,25 +44,4 @@ func (d diagnosticBase) FromExpr() *FromExpr {
 
 func (d diagnosticBase) ExtraInfo() interface{} {
 	return nil
-}
-
-func (d diagnosticBase) Equals(otherDiag ComparableDiagnostic) bool {
-	od, ok := otherDiag.(diagnosticBase)
-	if !ok {
-		return false
-	}
-	if d.severity != od.severity {
-		return false
-	}
-	if d.summary != od.summary {
-		return false
-	}
-	if d.detail != od.detail {
-		return false
-	}
-	if d.address != od.address {
-		return false
-	}
-
-	return true
 }

--- a/internal/tfdiags/hcl.go
+++ b/internal/tfdiags/hcl.go
@@ -13,6 +13,7 @@ type hclDiagnostic struct {
 }
 
 var _ Diagnostic = hclDiagnostic{}
+var _ ComparableDiagnostic = hclDiagnostic{}
 
 func (d hclDiagnostic) Severity() Severity {
 	switch d.diag.Severity {

--- a/internal/tfdiags/rpc_friendly.go
+++ b/internal/tfdiags/rpc_friendly.go
@@ -15,6 +15,9 @@ type rpcFriendlyDiag struct {
 	Context_  *SourceRange
 }
 
+var _ Diagnostic = &rpcFriendlyDiag{}
+var _ ComparableDiagnostic = &rpcFriendlyDiag{}
+
 // rpcFriendlyDiag transforms a given diagnostic so that is more friendly to
 // RPC.
 //


### PR DESCRIPTION
This PR is stacked on https://github.com/hashicorp/terraform/pull/37509

This PR updates the backend.Backend interface's StateMgr method to return diagnostics instead of errors. This will allow backends to return warnings in future, instead of just errors.

I've also updated any calling code that uses any implementations of that method. This includes test code.


## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

N/A

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
