### PR TITLE
Update `remote.Client` interface's methods to return diagnostics instead of primitive errors

### DIFF
--- a/internal/backend/remote-state/azure/client_test.go
+++ b/internal/backend/remote-state/azure/client_test.go
@@ -306,9 +306,9 @@ func TestPutMaintainsMetaData(t *testing.T) {
 	}
 
 	bytes := []byte(randString(20))
-	err = remoteClient.Put(bytes)
-	if err != nil {
-		t.Fatalf("Error putting data: %+v", err)
+	diags := remoteClient.Put(bytes)
+	if diags.HasErrors() {
+		t.Fatalf("Error putting data: %+v", diags.Err())
 	}
 
 	// Verify it still exists

--- a/internal/backend/remote-state/consul/client_test.go
+++ b/internal/backend/remote-state/consul/client_test.go
@@ -135,14 +135,14 @@ func TestConsul_largeState(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		err = c.Put(payload)
-		if err != nil {
-			t.Fatal("could not put payload", err)
+		diags := c.Put(payload)
+		if diags.HasErrors() {
+			t.Fatal("could not put payload", diags.Err())
 		}
 
-		remote, err := c.Get()
-		if err != nil {
-			t.Fatal(err)
+		remote, diags := c.Get()
+		if diags.HasErrors() {
+			t.Fatal(diags.Err())
 		}
 
 		if !bytes.Equal(payload, remote.Data) {
@@ -229,9 +229,9 @@ func TestConsul_largeState(t *testing.T) {
 	)
 
 	// Deleting the state should remove all chunks
-	err := c.Delete()
-	if err != nil {
-		t.Fatal(err)
+	dDiags := c.Delete()
+	if dDiags.HasErrors() {
+		t.Fatal(dDiags.Err())
 	}
 	testPaths(t, []string{})
 }

--- a/internal/backend/remote-state/cos/client.go
+++ b/internal/backend/remote-state/cos/client.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/hashicorp/terraform/internal/states/remote"
 	"github.com/hashicorp/terraform/internal/states/statemgr"
+	"github.com/hashicorp/terraform/internal/tfdiags"
 )
 
 const (
@@ -41,16 +42,17 @@ type remoteClient struct {
 }
 
 // Get returns remote state file
-func (c *remoteClient) Get() (*remote.Payload, error) {
+func (c *remoteClient) Get() (*remote.Payload, tfdiags.Diagnostics) {
 	log.Printf("[DEBUG] get remote state file %s", c.stateFile)
+	var diags tfdiags.Diagnostics
 
 	exists, data, checksum, err := c.getObject(c.stateFile)
 	if err != nil {
-		return nil, err
+		return nil, diags.Append(err)
 	}
 
 	if !exists {
-		return nil, nil
+		return nil, diags
 	}
 
 	payload := &remote.Payload{
@@ -58,21 +60,23 @@ func (c *remoteClient) Get() (*remote.Payload, error) {
 		MD5:  []byte(checksum),
 	}
 
-	return payload, nil
+	return payload, diags
 }
 
 // Put put state file to remote
-func (c *remoteClient) Put(data []byte) error {
+func (c *remoteClient) Put(data []byte) tfdiags.Diagnostics {
 	log.Printf("[DEBUG] put remote state file %s", c.stateFile)
+	var diags tfdiags.Diagnostics
 
-	return c.putObject(c.stateFile, data)
+	return diags.Append(c.putObject(c.stateFile, data))
 }
 
 // Delete delete remote state file
-func (c *remoteClient) Delete() error {
+func (c *remoteClient) Delete() tfdiags.Diagnostics {
 	log.Printf("[DEBUG] delete remote state file %s", c.stateFile)
+	var diags tfdiags.Diagnostics
 
-	return c.deleteObject(c.stateFile)
+	return diags.Append(c.deleteObject(c.stateFile))
 }
 
 // Lock lock remote state file for writing

--- a/internal/backend/remote-state/inmem/client.go
+++ b/internal/backend/remote-state/inmem/client.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform/internal/states/remote"
 	"github.com/hashicorp/terraform/internal/states/statemgr"
+	"github.com/hashicorp/terraform/internal/tfdiags"
 )
 
 // RemoteClient is a remote client that stores data in memory for testing.
@@ -17,7 +18,9 @@ type RemoteClient struct {
 	Name string
 }
 
-func (c *RemoteClient) Get() (*remote.Payload, error) {
+func (c *RemoteClient) Get() (*remote.Payload, tfdiags.Diagnostics) {
+	var diags tfdiags.Diagnostics
+
 	if c.Data == nil {
 		return nil, nil
 	}
@@ -25,21 +28,23 @@ func (c *RemoteClient) Get() (*remote.Payload, error) {
 	return &remote.Payload{
 		Data: c.Data,
 		MD5:  c.MD5,
-	}, nil
+	}, diags
 }
 
-func (c *RemoteClient) Put(data []byte) error {
+func (c *RemoteClient) Put(data []byte) tfdiags.Diagnostics {
+	var diags tfdiags.Diagnostics
 	md5 := md5.Sum(data)
 
 	c.Data = data
 	c.MD5 = md5[:]
-	return nil
+	return diags
 }
 
-func (c *RemoteClient) Delete() error {
+func (c *RemoteClient) Delete() tfdiags.Diagnostics {
+	var diags tfdiags.Diagnostics
 	c.Data = nil
 	c.MD5 = nil
-	return nil
+	return diags
 }
 
 func (c *RemoteClient) Lock(info *statemgr.LockInfo) (string, error) {

--- a/internal/backend/remote-state/oss/client_test.go
+++ b/internal/backend/remote-state/oss/client_test.go
@@ -315,23 +315,23 @@ func TestRemoteClient_stateChecksum(t *testing.T) {
 	client2 := s2.(*remote.State).Client
 
 	// write the new state through client2 so that there is no checksum yet
-	if err := client2.Put(newState.Bytes()); err != nil {
-		t.Fatal(err)
+	if diags := client2.Put(newState.Bytes()); diags.HasErrors() {
+		t.Fatal(diags.Err())
 	}
 
 	// verify that we can pull a state without a checksum
-	if _, err := client1.Get(); err != nil {
-		t.Fatal(err)
+	if _, diags := client1.Get(); diags.HasErrors() {
+		t.Fatal(diags.Err())
 	}
 
 	// write the new state back with its checksum
-	if err := client1.Put(newState.Bytes()); err != nil {
-		t.Fatal(err)
+	if diags := client1.Put(newState.Bytes()); diags.HasErrors() {
+		t.Fatal(diags.Err())
 	}
 
 	// put an empty state in place to check for panics during get
-	if err := client2.Put([]byte{}); err != nil {
-		t.Fatal(err)
+	if diags := client2.Put([]byte{}); diags.HasErrors() {
+		t.Fatal(diags.Err())
 	}
 
 	// remove the timeouts so we can fail immediately
@@ -346,25 +346,25 @@ func TestRemoteClient_stateChecksum(t *testing.T) {
 
 	// fetching an empty state through client1 should now error out due to a
 	// mismatched checksum.
-	if _, err := client1.Get(); !strings.HasPrefix(err.Error(), errBadChecksumFmt[:80]) {
+	if _, diags := client1.Get(); !strings.HasPrefix(diags.Err().Error(), errBadChecksumFmt[:80]) {
 		t.Fatalf("expected state checksum error: got %s", err)
 	}
 
 	// put the old state in place of the new, without updating the checksum
-	if err := client2.Put(oldState.Bytes()); err != nil {
-		t.Fatal(err)
+	if diags := client2.Put(oldState.Bytes()); diags.HasErrors() {
+		t.Fatal(diags.Err())
 	}
 
 	// fetching the wrong state through client1 should now error out due to a
 	// mismatched checksum.
-	if _, err := client1.Get(); !strings.HasPrefix(err.Error(), errBadChecksumFmt[:80]) {
+	if _, diags := client1.Get(); !strings.HasPrefix(diags.Err().Error(), errBadChecksumFmt[:80]) {
 		t.Fatalf("expected state checksum error: got %s", err)
 	}
 
 	// update the state with the correct one after we Get again
 	testChecksumHook = func() {
-		if err := client2.Put(newState.Bytes()); err != nil {
-			t.Fatal(err)
+		if diags := client2.Put(newState.Bytes()); diags.HasErrors() {
+			t.Fatal(diags.Err())
 		}
 		testChecksumHook = nil
 	}
@@ -374,7 +374,7 @@ func TestRemoteClient_stateChecksum(t *testing.T) {
 	// this final Get will fail to fail the checksum verification, the above
 	// callback will update the state with the correct version, and Get should
 	// retry automatically.
-	if _, err := client1.Get(); err != nil {
-		t.Fatal(err)
+	if _, diags := client1.Get(); diags.HasErrors() {
+		t.Fatal(diags.Err())
 	}
 }

--- a/internal/backend/remote-state/s3/backend_test.go
+++ b/internal/backend/remote-state/s3/backend_test.go
@@ -2735,8 +2735,8 @@ func TestBackendExtraPaths(t *testing.T) {
 	}
 
 	// remove the state with extra subkey
-	if err := client.Delete(); err != nil {
-		t.Fatal(err)
+	if diags := client.Delete(); diags.HasErrors() {
+		t.Fatal(diags.Err())
 	}
 
 	// delete the real workspace

--- a/internal/backend/remote-state/s3/client_test.go
+++ b/internal/backend/remote-state/s3/client_test.go
@@ -354,23 +354,23 @@ func TestRemoteClient_stateChecksum(t *testing.T) {
 	client2 := s2.(*remote.State).Client
 
 	// write the new state through client2 so that there is no checksum yet
-	if err := client2.Put(newState.Bytes()); err != nil {
-		t.Fatal(err)
+	if diags := client2.Put(newState.Bytes()); diags.HasErrors() {
+		t.Fatal(diags.Err())
 	}
 
 	// verify that we can pull a state without a checksum
-	if _, err := client1.Get(); err != nil {
-		t.Fatal(err)
+	if _, diags := client1.Get(); diags.HasErrors() {
+		t.Fatal(diags.Err())
 	}
 
 	// write the new state back with its checksum
-	if err := client1.Put(newState.Bytes()); err != nil {
-		t.Fatal(err)
+	if diags := client1.Put(newState.Bytes()); diags.HasErrors() {
+		t.Fatal(diags.Err())
 	}
 
 	// put an empty state in place to check for panics during get
-	if err := client2.Put([]byte{}); err != nil {
-		t.Fatal(err)
+	if diags := client2.Put([]byte{}); diags.HasErrors() {
+		t.Fatal(diags.Err())
 	}
 
 	// remove the timeouts so we can fail immediately
@@ -385,27 +385,27 @@ func TestRemoteClient_stateChecksum(t *testing.T) {
 
 	// fetching an empty state through client1 should now error out due to a
 	// mismatched checksum.
-	if _, err := client1.Get(); !IsA[badChecksumError](err) {
-		t.Fatalf("expected state checksum error: got %s", err)
-	} else if bse, ok := As[badChecksumError](err); ok && len(bse.digest) != 0 {
+	if _, diags := client1.Get(); !IsA[badChecksumError](diags.Err()) {
+		t.Fatalf("expected state checksum error: got %s", diags.Err())
+	} else if bse, ok := As[badChecksumError](diags.Err()); ok && len(bse.digest) != 0 {
 		t.Fatalf("expected empty checksum, got %x", bse.digest)
 	}
 
 	// put the old state in place of the new, without updating the checksum
-	if err := client2.Put(oldState.Bytes()); err != nil {
-		t.Fatal(err)
+	if diags := client2.Put(oldState.Bytes()); diags.HasErrors() {
+		t.Fatal(diags.Err())
 	}
 
 	// fetching the wrong state through client1 should now error out due to a
 	// mismatched checksum.
-	if _, err := client1.Get(); !IsA[badChecksumError](err) {
-		t.Fatalf("expected state checksum error: got %s", err)
+	if _, diags := client1.Get(); !IsA[badChecksumError](diags.Err()) {
+		t.Fatalf("expected state checksum error: got %s", diags.Err())
 	}
 
 	// update the state with the correct one after we Get again
 	testChecksumHook = func() {
-		if err := client2.Put(newState.Bytes()); err != nil {
-			t.Fatal(err)
+		if diags := client2.Put(newState.Bytes()); diags.HasErrors() {
+			t.Fatal(diags.Err())
 		}
 		testChecksumHook = nil
 	}
@@ -415,8 +415,8 @@ func TestRemoteClient_stateChecksum(t *testing.T) {
 	// this final Get will fail to fail the checksum verification, the above
 	// callback will update the state with the correct version, and Get should
 	// retry automatically.
-	if _, err := client1.Get(); err != nil {
-		t.Fatal(err)
+	if _, diags := client1.Get(); diags.HasErrors() {
+		t.Fatal(diags.Err())
 	}
 }
 
@@ -440,9 +440,9 @@ func TestRemoteClientPutLargeUploadWithObjectLock_Compliance(t *testing.T) {
 	)
 	defer deleteS3Bucket(ctx, t, b.s3Client, bucketName, b.awsConfig.Region)
 
-	s1, sDiags := b.StateMgr(backend.DefaultStateName)
-	if sDiags.HasErrors() {
-		t.Fatal(sDiags)
+	s1, diags := b.StateMgr(backend.DefaultStateName)
+	if diags.HasErrors() {
+		t.Fatal(diags)
 	}
 	client := s1.(*remote.State).Client
 
@@ -453,9 +453,9 @@ func TestRemoteClientPutLargeUploadWithObjectLock_Compliance(t *testing.T) {
 		t.Fatalf("writing dummy data: %s", err)
 	}
 
-	err = client.Put(state.Bytes())
-	if err != nil {
-		t.Fatalf("putting data: %s", err)
+	diags = client.Put(state.Bytes())
+	if diags.HasErrors() {
+		t.Fatalf("putting data: %s", diags.Err())
 	}
 }
 
@@ -480,9 +480,9 @@ func TestRemoteClientLockFileWithObjectLock_Compliance(t *testing.T) {
 	)
 	defer deleteS3Bucket(ctx, t, b.s3Client, bucketName, b.awsConfig.Region)
 
-	s1, sDiags := b.StateMgr(backend.DefaultStateName)
-	if sDiags.HasErrors() {
-		t.Fatal(sDiags)
+	s1, diags := b.StateMgr(backend.DefaultStateName)
+	if diags.HasErrors() {
+		t.Fatal(diags)
 	}
 	client := s1.(*remote.State).Client
 
@@ -493,9 +493,9 @@ func TestRemoteClientLockFileWithObjectLock_Compliance(t *testing.T) {
 		t.Fatalf("writing dummy data: %s", err)
 	}
 
-	err = client.Put(state.Bytes())
-	if err != nil {
-		t.Fatalf("putting data: %s", err)
+	diags = client.Put(state.Bytes())
+	if diags.HasErrors() {
+		t.Fatalf("putting data: %s", diags.Err())
 	}
 }
 
@@ -520,9 +520,9 @@ func TestRemoteClientLockFileWithObjectLock_Governance(t *testing.T) {
 	)
 	defer deleteS3Bucket(ctx, t, b.s3Client, bucketName, b.awsConfig.Region)
 
-	s1, sDiags := b.StateMgr(backend.DefaultStateName)
-	if sDiags.HasErrors() {
-		t.Fatal(sDiags)
+	s1, diags := b.StateMgr(backend.DefaultStateName)
+	if diags.HasErrors() {
+		t.Fatal(diags)
 	}
 	client := s1.(*remote.State).Client
 
@@ -533,9 +533,9 @@ func TestRemoteClientLockFileWithObjectLock_Governance(t *testing.T) {
 		t.Fatalf("writing dummy data: %s", err)
 	}
 
-	err = client.Put(state.Bytes())
-	if err != nil {
-		t.Fatalf("putting data: %s", err)
+	diags = client.Put(state.Bytes())
+	if diags.HasErrors() {
+		t.Fatalf("putting data: %s", diags.Err())
 	}
 }
 

--- a/internal/backend/remote/backend_state_test.go
+++ b/internal/backend/remote/backend_state_test.go
@@ -100,7 +100,7 @@ func TestRemoteClient_Put_withRunID(t *testing.T) {
 
 	// Store the new state to verify (this will be done
 	// by the mock that is used) that the run ID is set.
-	if err := client.Put(buf.Bytes()); err != nil {
-		t.Fatalf("expected no error, got %v", err)
+	if diags := client.Put(buf.Bytes()); diags.HasErrors() {
+		t.Fatalf("expected no error, got %v", diags.Err())
 	}
 }

--- a/internal/states/remote/remote.go
+++ b/internal/states/remote/remote.go
@@ -5,15 +5,16 @@ package remote
 
 import (
 	"github.com/hashicorp/terraform/internal/states/statemgr"
+	"github.com/hashicorp/terraform/internal/tfdiags"
 )
 
 // Client is the interface that must be implemented for a remote state
 // driver. It supports dumb put/get/delete, and the higher level structs
 // handle persisting the state properly here.
 type Client interface {
-	Get() (*Payload, error)
-	Put([]byte) error
-	Delete() error
+	Get() (*Payload, tfdiags.Diagnostics)
+	Put([]byte) tfdiags.Diagnostics
+	Delete() tfdiags.Diagnostics
 }
 
 // ClientForcePusher is an optional interface that allows a remote

--- a/internal/states/remote/remote_grpc.go
+++ b/internal/states/remote/remote_grpc.go
@@ -6,6 +6,7 @@ package remote
 import (
 	"github.com/hashicorp/terraform/internal/providers"
 	"github.com/hashicorp/terraform/internal/states/statemgr"
+	"github.com/hashicorp/terraform/internal/tfdiags"
 )
 
 // NewRemoteGRPC returns a remote state manager (remote.State) containing
@@ -52,7 +53,7 @@ type grpcClient struct {
 // and returns a copy of the downloaded state data.
 //
 // Implementation of remote.Client
-func (g *grpcClient) Get() (*Payload, error) {
+func (g *grpcClient) Get() (*Payload, tfdiags.Diagnostics) {
 	panic("not implemented yet")
 }
 
@@ -60,7 +61,7 @@ func (g *grpcClient) Get() (*Payload, error) {
 // and to transfer state data to the remote location.
 //
 // Implementation of remote.Client
-func (g *grpcClient) Put(state []byte) error {
+func (g *grpcClient) Put(state []byte) tfdiags.Diagnostics {
 	panic("not implemented yet")
 }
 
@@ -72,13 +73,13 @@ func (g *grpcClient) Put(state []byte) error {
 // interface's DeleteWorkspace method.
 //
 // Implementation of remote.Client
-func (g *grpcClient) Delete() error {
+func (g *grpcClient) Delete() tfdiags.Diagnostics {
 	req := providers.DeleteStateRequest{
 		TypeName: g.typeName,
 		StateId:  g.stateId,
 	}
 	resp := g.provider.DeleteState(req)
-	return resp.Diagnostics.Err()
+	return resp.Diagnostics
 }
 
 // Lock invokes the LockState gRPC method in the plugin protocol

--- a/internal/states/remote/remote_grpc_test.go
+++ b/internal/states/remote/remote_grpc_test.go
@@ -50,9 +50,9 @@ func Test_grpcClient_Delete(t *testing.T) {
 		stateId:  stateId,
 	}
 
-	err := c.Delete()
-	if err != nil {
-		t.Fatalf("unexpected error: %s", err)
+	diags := c.Delete()
+	if diags.HasErrors() {
+		t.Fatalf("unexpected error: %s", diags.Err())
 	}
 
 	if !provider.DeleteStateCalled {

--- a/internal/states/remote/state.go
+++ b/internal/states/remote/state.go
@@ -135,9 +135,9 @@ func (s *State) RefreshState() error {
 // that we can make internal calls to it from methods that are already holding
 // the s.mu lock.
 func (s *State) refreshState() error {
-	payload, err := s.Client.Get()
-	if err != nil {
-		return err
+	payload, diags := s.Client.Get()
+	if diags.HasErrors() {
+		return diags.Err()
 	}
 
 	// no remote state is OK
@@ -210,9 +210,9 @@ func (s *State) PersistState(schemas *schemarepo.Schemas) error {
 		return err
 	}
 
-	err = s.Client.Put(buf.Bytes())
-	if err != nil {
-		return err
+	diags := s.Client.Put(buf.Bytes())
+	if diags.HasErrors() {
+		return diags.Err()
 	}
 
 	// After we've successfully persisted, what we just wrote is our new

--- a/internal/states/remote/testing.go
+++ b/internal/states/remote/testing.go
@@ -26,9 +26,9 @@ func TestClient(t *testing.T, c Client) {
 		t.Fatalf("put: %s", err)
 	}
 
-	p, err := c.Get()
-	if err != nil {
-		t.Fatalf("get: %s", err)
+	p, diags := c.Get()
+	if diags.HasErrors() {
+		t.Fatalf("get: %s", diags.Err())
 	}
 	if !bytes.Equal(p.Data, data) {
 		t.Fatalf("expected full state %q\n\ngot: %q", string(p.Data), string(data))
@@ -38,9 +38,9 @@ func TestClient(t *testing.T, c Client) {
 		t.Fatalf("delete: %s", err)
 	}
 
-	p, err = c.Get()
-	if err != nil {
-		t.Fatalf("get: %s", err)
+	p, diags = c.Get()
+	if diags.HasErrors() {
+		t.Fatalf("get: %s", diags.Err())
 	}
 	if p != nil {
 		t.Fatalf("expected empty state, got: %q", string(p.Data))


### PR DESCRIPTION
This PR is stacked on https://github.com/hashicorp/terraform/pull/37496

This PR updates the interfaces that are used for reading and saving state to/from remote locations. The changed code is used in all backends in the `remote-state` folder.

By making these interfaces return diagnostics we allow backends to return warnings to users, instead of just errors.

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

N/A

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
