### PR TITLE
Fix S3 backend test affected by making the Workspaces method return errors via diagnostics

### DIFF
--- a/internal/backend/remote-state/s3/backend_test.go
+++ b/internal/backend/remote-state/s3/backend_test.go
@@ -2989,7 +2989,13 @@ func TestBackendWrongRegion(t *testing.T) {
 	if _, err := b.StateMgr(backend.DefaultStateName); err == nil {
 		t.Fatal("expected error, got none")
 	} else {
-		if regionErr, ok := As[bucketRegionError](err); ok {
+		var comparableErr error
+		if errValue, isDiag := err.(tfdiags.DiagnosticsAsError); isDiag {
+			// To use `As` below we need to extract the error that's wrapped
+			// in a diagnostic.
+			comparableErr = errValue.WrappedErrors()[0]
+		}
+		if regionErr, ok := As[bucketRegionError](comparableErr); ok {
 			if a, e := regionErr.bucketRegion, bucketRegion; a != e {
 				t.Errorf("expected bucket region %q, got %q", e, a)
 			}


### PR DESCRIPTION
Fixes an issue with how a test is constructed following https://github.com/hashicorp/terraform/pull/37430

After that PR, the returned `error` is now the result of calling `[tfdiags.Diagnostics].Err()` to get an error representation of a diagnostic. This meant the types had changed and interfered with the error comparison code in the test.

At the time I made changes in the Workspaces method this issue was lost amongst the diags comparison issues that are affecting the S3 backends' tests. I'm currently addressing those in a [separate PR](https://github.com/hashicorp/terraform/pull/37509).

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

N/A

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
