### PR TITLE
Fix diagnostic comparison issues in `s3` backend tests

### DIFF
--- a/internal/tfdiags/contextual.go
+++ b/internal/tfdiags/contextual.go
@@ -99,6 +99,9 @@ func GetAttribute(d Diagnostic) cty.Path {
 	return nil
 }
 
+var _ Diagnostic = &attributeDiagnostic{}
+var _ ComparableDiagnostic = &attributeDiagnostic{}
+
 type attributeDiagnostic struct {
 	diagnosticBase
 	attrPath cty.Path
@@ -383,6 +386,9 @@ func WholeContainingBody(severity Severity, summary, detail string) Diagnostic {
 		},
 	}
 }
+
+var _ Diagnostic = &wholeBodyDiagnostic{}
+var _ ComparableDiagnostic = &wholeBodyDiagnostic{}
 
 type wholeBodyDiagnostic struct {
 	diagnosticBase

--- a/internal/tfdiags/diagnostic_base.go
+++ b/internal/tfdiags/diagnostic_base.go
@@ -15,6 +15,10 @@ type diagnosticBase struct {
 	address  string
 }
 
+var _ Diagnostic = &diagnosticBase{}
+
+var _ ComparableDiagnostic = &diagnosticBase{}
+
 func (d diagnosticBase) Severity() Severity {
 	return d.severity
 }
@@ -37,4 +41,25 @@ func (d diagnosticBase) FromExpr() *FromExpr {
 
 func (d diagnosticBase) ExtraInfo() interface{} {
 	return nil
+}
+
+func (d diagnosticBase) Equals(otherDiag ComparableDiagnostic) bool {
+	od, ok := otherDiag.(diagnosticBase)
+	if !ok {
+		return false
+	}
+	if d.severity != od.severity {
+		return false
+	}
+	if d.summary != od.summary {
+		return false
+	}
+	if d.detail != od.detail {
+		return false
+	}
+	if d.address != od.address {
+		return false
+	}
+
+	return true
 }

--- a/internal/tfdiags/hcl.go
+++ b/internal/tfdiags/hcl.go
@@ -13,6 +13,7 @@ type hclDiagnostic struct {
 }
 
 var _ Diagnostic = hclDiagnostic{}
+var _ ComparableDiagnostic = hclDiagnostic{}
 
 func (d hclDiagnostic) Severity() Severity {
 	switch d.diag.Severity {

--- a/internal/tfdiags/rpc_friendly.go
+++ b/internal/tfdiags/rpc_friendly.go
@@ -15,6 +15,9 @@ type rpcFriendlyDiag struct {
 	Context_  *SourceRange
 }
 
+var _ Diagnostic = &rpcFriendlyDiag{}
+var _ ComparableDiagnostic = &rpcFriendlyDiag{}
+
 // rpcFriendlyDiag transforms a given diagnostic so that is more friendly to
 // RPC.
 //


### PR DESCRIPTION
This PR is stacked on https://github.com/hashicorp/terraform/pull/37508

Once this PR is merged all the S3 tests will be passing.

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

N/A

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
