### PR TITLE
action validation preparation: add NodeAbstractAction

### DIFF
--- a/internal/terraform/node_action.go
+++ b/internal/terraform/node_action.go
@@ -5,7 +5,6 @@ package terraform
 
 import (
 	"github.com/hashicorp/terraform/internal/addrs"
-	"github.com/hashicorp/terraform/internal/configs"
 	"github.com/hashicorp/terraform/internal/dag"
 	"github.com/hashicorp/terraform/internal/lang/langrefs"
 	"github.com/hashicorp/terraform/internal/providers"
@@ -22,11 +21,7 @@ type GraphNodeConfigAction interface {
 // nodeExpandActionDeclaration represents an action config block in a configuration module,
 // which has not yet been expanded.
 type nodeExpandActionDeclaration struct {
-	Addr   addrs.ConfigAction
-	Config configs.Action
-
-	Schema           *providers.ActionSchema
-	ResolvedProvider addrs.AbsProviderConfig
+	*NodeAbstractAction
 }
 
 var (
@@ -193,6 +188,9 @@ func (n *nodeExpandActionDeclaration) ProvidedBy() (addrs.ProviderConfig, bool) 
 
 // GraphNodeProviderConsumer
 func (n *nodeExpandActionDeclaration) Provider() addrs.Provider {
+	if n.ResolvedProvider.Provider.Type != "" {
+		return n.ResolvedProvider.Provider
+	}
 	return n.Config.Provider
 }
 

--- a/internal/terraform/node_action_abstract.go
+++ b/internal/terraform/node_action_abstract.go
@@ -1,0 +1,121 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package terraform
+
+import (
+	"github.com/hashicorp/terraform/internal/addrs"
+	"github.com/hashicorp/terraform/internal/configs"
+	"github.com/hashicorp/terraform/internal/dag"
+	"github.com/hashicorp/terraform/internal/lang/langrefs"
+	"github.com/hashicorp/terraform/internal/providers"
+)
+
+// NodeAbstractAction represents an action that has no associated
+// operations.
+type NodeAbstractAction struct {
+	Addr   addrs.ConfigAction
+	Config configs.Action
+
+	// The fields below will be automatically set using the Attach interfaces if
+	// you're running those transforms, but also can be explicitly set if you
+	// already have that information.
+
+	// The address of the provider this action will use
+	ResolvedProvider addrs.AbsProviderConfig
+	Schema           *providers.ActionSchema
+}
+
+// NewNodeAbstractAction creates an abstract action graph node for
+// the given action config address.
+func NewNodeAbstractAction(addr addrs.ConfigAction, config configs.Action) *NodeAbstractAction {
+	return &NodeAbstractAction{
+		Addr:   addr,
+		Config: config, // we don't have an "attach action config" transformer
+	}
+}
+
+var (
+	_ GraphNodeReferenceable      = (*NodeAbstractAction)(nil)
+	_ GraphNodeReferencer         = (*NodeAbstractAction)(nil)
+	_ GraphNodeConfigAction       = (*NodeAbstractAction)(nil)
+	_ GraphNodeAttachActionSchema = (*NodeAbstractAction)(nil)
+	_ GraphNodeProviderConsumer   = (*NodeAbstractAction)(nil)
+)
+
+func (n NodeAbstractAction) Name() string {
+	return n.Addr.String()
+}
+
+// ConcreteActionNodeFunc is a callback type used to convert an
+// abstract action to a concrete one of some type.
+type ConcreteActionNodeFunc func(*NodeAbstractAction) dag.Vertex
+
+// I'm not sure why my ConcreteActionNodeFUnction kept being nil in tests, but
+// this is much more robust. If it isn't a validate walk, we need
+// nodeExpandActionDeclaration.
+func DefaultConcreteActionNodeFunc(a *NodeAbstractAction) dag.Vertex {
+	return &nodeExpandActionDeclaration{
+		NodeAbstractAction: a,
+	}
+}
+
+// GraphNodeConfigAction
+func (n NodeAbstractAction) ActionAddr() addrs.ConfigAction {
+	return n.Addr
+}
+
+func (n NodeAbstractAction) ModulePath() addrs.Module {
+	return n.Addr.Module
+}
+
+func (n *NodeAbstractAction) ReferenceableAddrs() []addrs.Referenceable {
+	return []addrs.Referenceable{n.Addr.Action}
+}
+
+func (n *NodeAbstractAction) References() []*addrs.Reference {
+	var result []*addrs.Reference
+	c := n.Config
+
+	refs, _ := langrefs.ReferencesInExpr(addrs.ParseRef, c.Count)
+	result = append(result, refs...)
+	refs, _ = langrefs.ReferencesInExpr(addrs.ParseRef, c.ForEach)
+	result = append(result, refs...)
+
+	if n.Schema != nil {
+		refs, _ = langrefs.ReferencesInBlock(addrs.ParseRef, c.Config, n.Schema.ConfigSchema)
+		result = append(result, refs...)
+	}
+
+	return result
+}
+
+func (n *NodeAbstractAction) AttachActionSchema(schema *providers.ActionSchema) {
+	n.Schema = schema
+}
+
+func (n *NodeAbstractAction) ProvidedBy() (addrs.ProviderConfig, bool) {
+	// If the resolvedProvider is set, use that
+	if n.ResolvedProvider.Provider.Type != "" {
+		return n.ResolvedProvider, true
+	}
+
+	// otherwise refer back to the config
+	relAddr := n.Config.ProviderConfigAddr()
+	return addrs.LocalProviderConfig{
+		LocalName: relAddr.LocalName,
+		Alias:     relAddr.Alias,
+	}, false
+}
+
+func (n *NodeAbstractAction) Provider() addrs.Provider {
+	if n.Config.Provider.Type != "" {
+		return n.Config.Provider
+	}
+
+	return addrs.ImpliedProviderForUnqualifiedType(n.Addr.Action.ImpliedProvider())
+}
+
+func (n *NodeAbstractAction) SetProvider(p addrs.AbsProviderConfig) {
+	n.ResolvedProvider = p
+}


### PR DESCRIPTION
I decided to (loosely) follow the NodeResourceAbstract pattern so that, in the next commit, I can configure the validate walk to create a NodeValidatableAction vs the default nodeExpandActionDeclaration. I am putting this in a separate commit for easier review, to show that this did not impact the current implementation.

<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Fixes #

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.14.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [ ] This change is not user-facing.
