### PR TITLE
actions: add invoke nodes to the graph

### DIFF
--- a/internal/command/apply.go
+++ b/internal/command/apply.go
@@ -270,7 +270,6 @@ func (c *ApplyCommand) OperationRequest(
 	opReq.PlanFile = planFile
 	opReq.PlanRefresh = args.Refresh
 	opReq.Targets = args.Targets
-	opReq.ActionTargets = args.ActionTargets
 	opReq.ForceReplace = args.ForceReplace
 	opReq.Type = backendrun.OperationTypeApply
 	opReq.View = view.Operation()
@@ -279,6 +278,7 @@ func (c *ApplyCommand) OperationRequest(
 	// EXPERIMENTAL: maybe enable deferred actions
 	if c.AllowExperimentalFeatures {
 		opReq.DeferralAllowed = args.DeferralAllowed
+		opReq.ActionTargets = args.ActionTargets
 	} else if args.DeferralAllowed {
 		// Belated flag parse error, since we don't know about experiments
 		// support at actual parse time.
@@ -286,6 +286,15 @@ func (c *ApplyCommand) OperationRequest(
 			tfdiags.Error,
 			"Failed to parse command-line flags",
 			"The -allow-deferral flag is only valid in experimental builds of Terraform.",
+		))
+		return nil, diags
+	} else if len(args.ActionTargets) > 0 {
+		// Belated flag parse error, since we don't know about experiments
+		// support at actual parse time.
+		diags = diags.Append(tfdiags.Sourceless(
+			tfdiags.Error,
+			"Failed to parse command-line flags",
+			"The -invoke flag is only valid in experimental builds of Terraform.",
 		))
 		return nil, diags
 	}

--- a/internal/command/arguments/extended.go
+++ b/internal/command/arguments/extended.go
@@ -159,7 +159,7 @@ func (o *Operation) Parse() tfdiags.Diagnostics {
 			continue
 		}
 
-		o.Targets = append(o.Targets, target.Subject)
+		o.ActionTargets = append(o.ActionTargets, target.Subject)
 	}
 
 	if len(o.ActionTargets) > 0 && len(o.Targets) > 0 {

--- a/internal/command/plan.go
+++ b/internal/command/plan.go
@@ -161,7 +161,6 @@ func (c *PlanCommand) OperationRequest(
 	opReq.PlanOutPath = planOutPath
 	opReq.GenerateConfigOut = generateConfigOut
 	opReq.Targets = args.Targets
-	opReq.ActionTargets = args.ActionTargets
 	opReq.ForceReplace = args.ForceReplace
 	opReq.Type = backendrun.OperationTypePlan
 	opReq.View = view.Operation()
@@ -169,6 +168,7 @@ func (c *PlanCommand) OperationRequest(
 	// EXPERIMENTAL: maybe enable deferred actions
 	if c.AllowExperimentalFeatures {
 		opReq.DeferralAllowed = args.DeferralAllowed
+		opReq.ActionTargets = args.ActionTargets
 	} else if args.DeferralAllowed {
 		// Belated flag parse error, since we don't know about experiments
 		// support at actual parse time.
@@ -176,6 +176,15 @@ func (c *PlanCommand) OperationRequest(
 			tfdiags.Error,
 			"Failed to parse command-line flags",
 			"The -allow-deferral flag is only valid in experimental builds of Terraform.",
+		))
+		return nil, diags
+	} else if len(args.ActionTargets) > 0 {
+		// Belated flag parse error, since we don't know about experiments
+		// support at actual parse time.
+		diags = diags.Append(tfdiags.Sourceless(
+			tfdiags.Error,
+			"Failed to parse command-line flags",
+			"The -invoke flag is only valid in experimental builds of Terraform.",
 		))
 		return nil, diags
 	}

--- a/internal/command/views/hook_json_test.go
+++ b/internal/command/views/hook_json_test.go
@@ -34,7 +34,7 @@ func testJSONHookResourceID(addr addrs.AbsResourceInstance) terraform.HookResour
 func testJSONHookActionID(actionAddr addrs.AbsActionInstance, triggeringResourceAddr addrs.AbsResourceInstance, actionTriggerIndex int, actionsListIndex int) terraform.HookActionIdentity {
 	return terraform.HookActionIdentity{
 		Addr: actionAddr,
-		ActionTrigger: plans.LifecycleActionTrigger{
+		ActionTrigger: &plans.LifecycleActionTrigger{
 			TriggeringResourceAddr:  triggeringResourceAddr,
 			ActionTriggerBlockIndex: actionTriggerIndex,
 			ActionsListIndex:        actionsListIndex,

--- a/internal/command/views/json/change.go
+++ b/internal/command/views/json/change.go
@@ -64,7 +64,7 @@ func NewPlannedActionInvocation(aiSrc *plans.ActionInvocationInstanceSrc) *Actio
 		Action: newActionAddr(aiSrc.Addr),
 	}
 
-	if at, ok := aiSrc.ActionTrigger.(plans.LifecycleActionTrigger); ok {
+	if at, ok := aiSrc.ActionTrigger.(*plans.LifecycleActionTrigger); ok {
 		ai.LifecycleTrigger = &ActionInvocationLifecycleTrigger{
 			TriggeringResource:      newResourceAddr(at.TriggeringResourceAddr),
 			TriggeringEvent:         at.ActionTriggerEvent.String(),

--- a/internal/command/views/json/hook.go
+++ b/internal/command/views/json/hook.go
@@ -374,7 +374,7 @@ func (h *actionStart) String() string {
 }
 
 func NewActionStart(id terraform.HookActionIdentity) Hook {
-	at, ok := id.ActionTrigger.(plans.LifecycleActionTrigger)
+	at, ok := id.ActionTrigger.(*plans.LifecycleActionTrigger)
 	if !ok {
 		panic("invalid action trigger")
 	}
@@ -408,7 +408,7 @@ func (h *actionProgress) String() string {
 }
 
 func NewActionProgress(id terraform.HookActionIdentity, message string) Hook {
-	at, ok := id.ActionTrigger.(plans.LifecycleActionTrigger)
+	at, ok := id.ActionTrigger.(*plans.LifecycleActionTrigger)
 	if !ok {
 		panic("invalid action trigger")
 	}
@@ -441,7 +441,7 @@ func (h *actionComplete) String() string {
 }
 
 func NewActionComplete(id terraform.HookActionIdentity) Hook {
-	at, ok := id.ActionTrigger.(plans.LifecycleActionTrigger)
+	at, ok := id.ActionTrigger.(*plans.LifecycleActionTrigger)
 	if !ok {
 		panic("invalid action trigger")
 	}
@@ -474,7 +474,7 @@ func (h *actionErrored) String() string {
 }
 
 func NewActionErrored(id terraform.HookActionIdentity, err error) Hook {
-	at, ok := id.ActionTrigger.(plans.LifecycleActionTrigger)
+	at, ok := id.ActionTrigger.(*plans.LifecycleActionTrigger)
 	if !ok {
 		panic("invalid action trigger")
 	}

--- a/internal/command/views/operation_test.go
+++ b/internal/command/views/operation_test.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/zclconf/go-cty/cty"
+
 	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/command/arguments"
 	"github.com/hashicorp/terraform/internal/configs"
@@ -18,7 +20,6 @@ import (
 	"github.com/hashicorp/terraform/internal/states/statefile"
 	"github.com/hashicorp/terraform/internal/terminal"
 	"github.com/hashicorp/terraform/internal/terraform"
-	"github.com/zclconf/go-cty/cty"
 )
 
 func TestOperation_stopping(t *testing.T) {
@@ -572,7 +573,7 @@ func TestOperationJSON_plan_with_actions(t *testing.T) {
 
 	act1 := &plans.ActionInvocationInstanceSrc{
 		Addr: addrs.Action{Type: "test_unlinked_action", Name: "hello"}.Instance(addrs.NoKey).Absolute(root),
-		ActionTrigger: plans.LifecycleActionTrigger{
+		ActionTrigger: &plans.LifecycleActionTrigger{
 			TriggeringResourceAddr:  boop,
 			ActionTriggerEvent:      configs.AfterCreate,
 			ActionTriggerBlockIndex: 0,
@@ -581,7 +582,7 @@ func TestOperationJSON_plan_with_actions(t *testing.T) {
 	}
 	act2 := &plans.ActionInvocationInstanceSrc{
 		Addr: addrs.Action{Type: "test_unlinked_other_action", Name: "world"}.Instance(addrs.NoKey).Absolute(root),
-		ActionTrigger: plans.LifecycleActionTrigger{
+		ActionTrigger: &plans.LifecycleActionTrigger{
 			TriggeringResourceAddr:  boop,
 			ActionTriggerEvent:      configs.AfterCreate,
 			ActionTriggerBlockIndex: 0,
@@ -590,7 +591,7 @@ func TestOperationJSON_plan_with_actions(t *testing.T) {
 	}
 	act3 := &plans.ActionInvocationInstanceSrc{
 		Addr: addrs.Action{Type: "test_unlinked_action", Name: "goodbye"}.Instance(addrs.IntKey(0)).Absolute(vpc),
-		ActionTrigger: plans.LifecycleActionTrigger{
+		ActionTrigger: &plans.LifecycleActionTrigger{
 			TriggeringResourceAddr:  beep,
 			ActionTriggerEvent:      configs.BeforeUpdate,
 			ActionTriggerBlockIndex: 1,

--- a/internal/configs/action.go
+++ b/internal/configs/action.go
@@ -87,6 +87,7 @@ const (
 	AfterUpdate
 	BeforeDestroy
 	AfterDestroy
+	Invoke
 )
 
 // ActionRef represents a reference to a configured Action

--- a/internal/configs/actiontriggerevent_string.go
+++ b/internal/configs/actiontriggerevent_string.go
@@ -15,11 +15,12 @@ func _() {
 	_ = x[AfterUpdate-4]
 	_ = x[BeforeDestroy-5]
 	_ = x[AfterDestroy-6]
+	_ = x[Invoke-7]
 }
 
-const _ActionTriggerEvent_name = "UnknownBeforeCreateAfterCreateBeforeUpdateAfterUpdateBeforeDestroyAfterDestroy"
+const _ActionTriggerEvent_name = "UnknownBeforeCreateAfterCreateBeforeUpdateAfterUpdateBeforeDestroyAfterDestroyInvoke"
 
-var _ActionTriggerEvent_index = [...]uint8{0, 7, 19, 30, 42, 53, 66, 78}
+var _ActionTriggerEvent_index = [...]uint8{0, 7, 19, 30, 42, 53, 66, 78, 84}
 
 func (i ActionTriggerEvent) String() string {
 	if i < 0 || i >= ActionTriggerEvent(len(_ActionTriggerEvent_index)-1) {

--- a/internal/plans/changes_src.go
+++ b/internal/plans/changes_src.go
@@ -612,12 +612,12 @@ func (acs *ActionInvocationInstanceSrc) Less(other *ActionInvocationInstanceSrc)
 	return acs.ActionTrigger.Less(other.ActionTrigger)
 }
 
-func (needle *ActionInvocationInstanceSrc) FilterLaterActionInvocations(actionInvocations []*ActionInvocationInstanceSrc) []*ActionInvocationInstanceSrc {
-	needleLat := needle.ActionTrigger.(LifecycleActionTrigger)
+func (acs *ActionInvocationInstanceSrc) FilterLaterActionInvocations(actionInvocations []*ActionInvocationInstanceSrc) []*ActionInvocationInstanceSrc {
+	needleLat := acs.ActionTrigger.(*LifecycleActionTrigger)
 
 	var laterInvocations []*ActionInvocationInstanceSrc
 	for _, invocation := range actionInvocations {
-		if lat, ok := invocation.ActionTrigger.(LifecycleActionTrigger); ok {
+		if lat, ok := invocation.ActionTrigger.(*LifecycleActionTrigger); ok {
 			if lat.TriggeringResourceAddr.Equal(needleLat.TriggeringResourceAddr) && (lat.ActionTriggerBlockIndex > needleLat.ActionTriggerBlockIndex || lat.ActionTriggerBlockIndex == needleLat.ActionTriggerBlockIndex && lat.ActionsListIndex > needleLat.ActionsListIndex) {
 				laterInvocations = append(laterInvocations, invocation)
 			}

--- a/internal/plans/changes_src.go
+++ b/internal/plans/changes_src.go
@@ -63,6 +63,11 @@ func (c *ChangesSrc) Empty() bool {
 		}
 	}
 
+	if len(c.ActionInvocations) > 0 {
+		// action invocations can be applied
+		return false
+	}
+
 	return true
 }
 

--- a/internal/plans/deferring/deferred.go
+++ b/internal/plans/deferring/deferred.go
@@ -663,12 +663,12 @@ func (d *Deferred) ReportActionInvocationDeferred(ai plans.ActionInvocationInsta
 // a) the resource was deferred
 // or
 // b) a previously run action was deferred
-func (d *Deferred) ShouldDeferActionInvocation(ai plans.ActionInvocationInstance) bool {
+func (d *Deferred) ShouldDeferActionInvocation(trigger plans.ActionTrigger) bool {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 
 	// We only want to defer actions that are lifecycle triggered
-	at, ok := ai.ActionTrigger.(plans.LifecycleActionTrigger)
+	at, ok := trigger.(*plans.LifecycleActionTrigger)
 	if !ok {
 		return false
 	}
@@ -683,7 +683,7 @@ func (d *Deferred) ShouldDeferActionInvocation(ai plans.ActionInvocationInstance
 	// Since all actions plan in order we can just check if an action for this resource instance
 	// has been deferred already
 	for _, deferred := range d.actionInvocationDeferred {
-		deferredAt, deferredOk := deferred.ActionInvocationInstance.ActionTrigger.(plans.LifecycleActionTrigger)
+		deferredAt, deferredOk := deferred.ActionInvocationInstance.ActionTrigger.(*plans.LifecycleActionTrigger)
 		if !deferredOk {
 			continue // We only care about lifecycle triggered actions here
 		}

--- a/internal/plans/plan.go
+++ b/internal/plans/plan.go
@@ -71,6 +71,7 @@ type Plan struct {
 	DeferredResources         []*DeferredResourceInstanceChangeSrc
 	DeferredActionInvocations []*DeferredActionInvocationSrc
 	TargetAddrs               []addrs.Targetable
+	ActionTargetAddrs         []addrs.Targetable // TODO(liamcervante)
 	ForceReplaceAddrs         []addrs.AbsResourceInstance
 
 	Backend    Backend

--- a/internal/plans/plan.go
+++ b/internal/plans/plan.go
@@ -71,7 +71,7 @@ type Plan struct {
 	DeferredResources         []*DeferredResourceInstanceChangeSrc
 	DeferredActionInvocations []*DeferredActionInvocationSrc
 	TargetAddrs               []addrs.Targetable
-	ActionTargetAddrs         []addrs.Targetable // TODO(liamcervante)
+	ActionTargetAddrs         []addrs.Targetable
 	ForceReplaceAddrs         []addrs.AbsResourceInstance
 
 	Backend    Backend

--- a/internal/plans/planfile/tfplan_test.go
+++ b/internal/plans/planfile/tfplan_test.go
@@ -307,7 +307,7 @@ func examplePlanForTest(t *testing.T) *plans.Plan {
 				{
 					Addr:         addrs.Action{Type: "example", Name: "foo"}.Instance(addrs.NoKey).Absolute(addrs.RootModuleInstance),
 					ProviderAddr: provider,
-					ActionTrigger: plans.LifecycleActionTrigger{
+					ActionTrigger: &plans.LifecycleActionTrigger{
 						ActionTriggerEvent:      configs.BeforeCreate,
 						ActionTriggerBlockIndex: 2,
 						ActionsListIndex:        0,
@@ -321,7 +321,7 @@ func examplePlanForTest(t *testing.T) *plans.Plan {
 				{
 					Addr:         addrs.Action{Type: "example", Name: "bar"}.Instance(addrs.NoKey).Absolute(addrs.RootModuleInstance),
 					ProviderAddr: provider,
-					ActionTrigger: plans.LifecycleActionTrigger{
+					ActionTrigger: &plans.LifecycleActionTrigger{
 						ActionTriggerEvent:      configs.BeforeCreate,
 						ActionTriggerBlockIndex: 2,
 						ActionsListIndex:        1,
@@ -338,7 +338,7 @@ func examplePlanForTest(t *testing.T) *plans.Plan {
 				{
 					Addr:         addrs.Action{Type: "example", Name: "baz"}.Instance(addrs.NoKey).Absolute(addrs.RootModuleInstance),
 					ProviderAddr: provider,
-					ActionTrigger: plans.LifecycleActionTrigger{
+					ActionTrigger: &plans.LifecycleActionTrigger{
 						ActionTriggerEvent:      configs.BeforeCreate,
 						ActionTriggerBlockIndex: 2,
 						ActionsListIndex:        1,
@@ -443,7 +443,7 @@ func examplePlanForTest(t *testing.T) *plans.Plan {
 				DeferredReason: providers.DeferredReasonDeferredPrereq,
 				ActionInvocationInstanceSrc: &plans.ActionInvocationInstanceSrc{
 					Addr: addrs.Action{Type: "test_unlinked", Name: "generic_action"}.Absolute(addrs.RootModuleInstance).Instance(addrs.NoKey),
-					ActionTrigger: plans.LifecycleActionTrigger{
+					ActionTrigger: &plans.LifecycleActionTrigger{
 						TriggeringResourceAddr: addrs.Resource{
 							Mode: addrs.ManagedResourceMode,
 							Type: "test_thing",

--- a/internal/plans/planproto/planfile.pb.go
+++ b/internal/plans/planproto/planfile.pb.go
@@ -300,7 +300,7 @@ const (
 	ActionTriggerEvent_AFTER_UPDATE   ActionTriggerEvent = 4
 	ActionTriggerEvent_BEFORE_DESTROY ActionTriggerEvent = 5
 	ActionTriggerEvent_AFTER_DESTROY  ActionTriggerEvent = 6
-	ActionTriggerEvent_CLI            ActionTriggerEvent = 7
+	ActionTriggerEvent_INVOKE         ActionTriggerEvent = 7
 )
 
 // Enum value maps for ActionTriggerEvent.
@@ -313,7 +313,7 @@ var (
 		4: "AFTER_UPDATE",
 		5: "BEFORE_DESTROY",
 		6: "AFTER_DESTROY",
-		7: "CLI",
+		7: "INVOKE",
 	}
 	ActionTriggerEvent_value = map[string]int32{
 		"INVALID_EVENT":  0,
@@ -323,7 +323,7 @@ var (
 		"AFTER_UPDATE":   4,
 		"BEFORE_DESTROY": 5,
 		"AFTER_DESTROY":  6,
-		"CLI":            7,
+		"INVOKE":         7,
 	}
 )
 
@@ -549,6 +549,10 @@ type Plan struct {
 	// target addresses are present, the plan applies to the whole
 	// configuration.
 	TargetAddrs []string `protobuf:"bytes,5,rep,name=target_addrs,json=targetAddrs,proto3" json:"target_addrs,omitempty"`
+	// An unordered set of action addresses that must be invoked when applying.
+	// If no actions are specified then only lifecycle actions should be
+	// executed.
+	ActionTargetAddrs []string `protobuf:"bytes,32,rep,name=action_target_addrs,json=actionTargetAddrs,proto3" json:"action_target_addrs,omitempty"`
 	// An unordered set of force-replace addresses to include when applying.
 	// This must match the set of addresses that was used when creating the
 	// plan, or else applying the plan will fail when it reaches a different
@@ -703,6 +707,13 @@ func (x *Plan) GetActionInvocations() []*ActionInvocationInstance {
 func (x *Plan) GetTargetAddrs() []string {
 	if x != nil {
 		return x.TargetAddrs
+	}
+	return nil
+}
+
+func (x *Plan) GetActionTargetAddrs() []string {
+	if x != nil {
+		return x.ActionTargetAddrs
 	}
 	return nil
 }
@@ -1732,6 +1743,7 @@ type ActionInvocationInstance struct {
 	// Types that are valid to be assigned to ActionTrigger:
 	//
 	//	*ActionInvocationInstance_LifecycleActionTrigger
+	//	*ActionInvocationInstance_InvokeActionTrigger
 	ActionTrigger isActionInvocationInstance_ActionTrigger `protobuf_oneof:"action_trigger"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -1818,6 +1830,15 @@ func (x *ActionInvocationInstance) GetLifecycleActionTrigger() *LifecycleActionT
 	return nil
 }
 
+func (x *ActionInvocationInstance) GetInvokeActionTrigger() *InvokeActionTrigger {
+	if x != nil {
+		if x, ok := x.ActionTrigger.(*ActionInvocationInstance_InvokeActionTrigger); ok {
+			return x.InvokeActionTrigger
+		}
+	}
+	return nil
+}
+
 type isActionInvocationInstance_ActionTrigger interface {
 	isActionInvocationInstance_ActionTrigger()
 }
@@ -1826,7 +1847,13 @@ type ActionInvocationInstance_LifecycleActionTrigger struct {
 	LifecycleActionTrigger *LifecycleActionTrigger `protobuf:"bytes,6,opt,name=lifecycle_action_trigger,json=lifecycleActionTrigger,proto3,oneof"`
 }
 
+type ActionInvocationInstance_InvokeActionTrigger struct {
+	InvokeActionTrigger *InvokeActionTrigger `protobuf:"bytes,7,opt,name=invoke_action_trigger,json=invokeActionTrigger,proto3,oneof"`
+}
+
 func (*ActionInvocationInstance_LifecycleActionTrigger) isActionInvocationInstance_ActionTrigger() {}
+
+func (*ActionInvocationInstance_InvokeActionTrigger) isActionInvocationInstance_ActionTrigger() {}
 
 // LifecycleActionTrigger contains details on the conditions that led to the
 // triggering of an action.
@@ -1898,6 +1925,44 @@ func (x *LifecycleActionTrigger) GetActionsListIndex() int64 {
 	return 0
 }
 
+// InvokeActionTrigger indicates the action was triggered by the invoke command
+// on the CLI.
+type InvokeActionTrigger struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *InvokeActionTrigger) Reset() {
+	*x = InvokeActionTrigger{}
+	mi := &file_planfile_proto_msgTypes[17]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *InvokeActionTrigger) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*InvokeActionTrigger) ProtoMessage() {}
+
+func (x *InvokeActionTrigger) ProtoReflect() protoreflect.Message {
+	mi := &file_planfile_proto_msgTypes[17]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use InvokeActionTrigger.ProtoReflect.Descriptor instead.
+func (*InvokeActionTrigger) Descriptor() ([]byte, []int) {
+	return file_planfile_proto_rawDescGZIP(), []int{17}
+}
+
 type ResourceInstanceActionChange struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// addr is a string representation of the resource instance address that
@@ -1916,7 +1981,7 @@ type ResourceInstanceActionChange struct {
 
 func (x *ResourceInstanceActionChange) Reset() {
 	*x = ResourceInstanceActionChange{}
-	mi := &file_planfile_proto_msgTypes[17]
+	mi := &file_planfile_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1928,7 +1993,7 @@ func (x *ResourceInstanceActionChange) String() string {
 func (*ResourceInstanceActionChange) ProtoMessage() {}
 
 func (x *ResourceInstanceActionChange) ProtoReflect() protoreflect.Message {
-	mi := &file_planfile_proto_msgTypes[17]
+	mi := &file_planfile_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1941,7 +2006,7 @@ func (x *ResourceInstanceActionChange) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ResourceInstanceActionChange.ProtoReflect.Descriptor instead.
 func (*ResourceInstanceActionChange) Descriptor() ([]byte, []int) {
-	return file_planfile_proto_rawDescGZIP(), []int{17}
+	return file_planfile_proto_rawDescGZIP(), []int{18}
 }
 
 func (x *ResourceInstanceActionChange) GetAddr() string {
@@ -1975,7 +2040,7 @@ type PlanResourceAttr struct {
 
 func (x *PlanResourceAttr) Reset() {
 	*x = PlanResourceAttr{}
-	mi := &file_planfile_proto_msgTypes[19]
+	mi := &file_planfile_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1987,7 +2052,7 @@ func (x *PlanResourceAttr) String() string {
 func (*PlanResourceAttr) ProtoMessage() {}
 
 func (x *PlanResourceAttr) ProtoReflect() protoreflect.Message {
-	mi := &file_planfile_proto_msgTypes[19]
+	mi := &file_planfile_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2028,7 +2093,7 @@ type CheckResults_ObjectResult struct {
 
 func (x *CheckResults_ObjectResult) Reset() {
 	*x = CheckResults_ObjectResult{}
-	mi := &file_planfile_proto_msgTypes[20]
+	mi := &file_planfile_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2040,7 +2105,7 @@ func (x *CheckResults_ObjectResult) String() string {
 func (*CheckResults_ObjectResult) ProtoMessage() {}
 
 func (x *CheckResults_ObjectResult) ProtoReflect() protoreflect.Message {
-	mi := &file_planfile_proto_msgTypes[20]
+	mi := &file_planfile_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2090,7 +2155,7 @@ type Path_Step struct {
 
 func (x *Path_Step) Reset() {
 	*x = Path_Step{}
-	mi := &file_planfile_proto_msgTypes[21]
+	mi := &file_planfile_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2102,7 +2167,7 @@ func (x *Path_Step) String() string {
 func (*Path_Step) ProtoMessage() {}
 
 func (x *Path_Step) ProtoReflect() protoreflect.Message {
-	mi := &file_planfile_proto_msgTypes[21]
+	mi := &file_planfile_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2167,7 +2232,7 @@ var File_planfile_proto protoreflect.FileDescriptor
 
 const file_planfile_proto_rawDesc = "" +
 	"\n" +
-	"\x0eplanfile.proto\x12\x06tfplan\"\xcb\n" +
+	"\x0eplanfile.proto\x12\x06tfplan\"\xfb\n" +
 	"\n" +
 	"\x04Plan\x12\x18\n" +
 	"\aversion\x18\x01 \x01(\x04R\aversion\x12%\n" +
@@ -2185,6 +2250,7 @@ const file_planfile_proto_rawDesc = "" +
 	"\rcheck_results\x18\x13 \x03(\v2\x14.tfplan.CheckResultsR\fcheckResults\x12O\n" +
 	"\x12action_invocations\x18\x1e \x03(\v2 .tfplan.ActionInvocationInstanceR\x11actionInvocations\x12!\n" +
 	"\ftarget_addrs\x18\x05 \x03(\tR\vtargetAddrs\x12.\n" +
+	"\x13action_target_addrs\x18  \x03(\tR\x11actionTargetAddrs\x12.\n" +
 	"\x13force_replace_addrs\x18\x10 \x03(\tR\x11forceReplaceAddrs\x12+\n" +
 	"\x11terraform_version\x18\x0e \x01(\tR\x10terraformVersion\x12)\n" +
 	"\abackend\x18\r \x01(\v2\x0f.tfplan.BackendR\abackend\x123\n" +
@@ -2283,20 +2349,22 @@ const file_planfile_proto_rawDesc = "" +
 	"\aunknown\x18\x02 \x01(\bR\aunknown\x120\n" +
 	"\bidentity\x18\x03 \x01(\v2\x14.tfplan.DynamicValueR\bidentity\":\n" +
 	"\bDeferred\x12.\n" +
-	"\x06reason\x18\x01 \x01(\x0e2\x16.tfplan.DeferredReasonR\x06reason\"\x86\x03\n" +
+	"\x06reason\x18\x01 \x01(\x0e2\x16.tfplan.DeferredReasonR\x06reason\"\xd9\x03\n" +
 	"\x18ActionInvocationInstance\x12\x12\n" +
 	"\x04addr\x18\x01 \x01(\tR\x04addr\x12\x1a\n" +
 	"\bprovider\x18\x02 \x01(\tR\bprovider\x12O\n" +
 	"\x10linked_resources\x18\x03 \x03(\v2$.tfplan.ResourceInstanceActionChangeR\x0flinkedResources\x127\n" +
 	"\fconfig_value\x18\x04 \x01(\v2\x14.tfplan.DynamicValueR\vconfigValue\x12B\n" +
 	"\x16sensitive_config_paths\x18\x05 \x03(\v2\f.tfplan.PathR\x14sensitiveConfigPaths\x12Z\n" +
-	"\x18lifecycle_action_trigger\x18\x06 \x01(\v2\x1e.tfplan.LifecycleActionTriggerH\x00R\x16lifecycleActionTriggerB\x10\n" +
+	"\x18lifecycle_action_trigger\x18\x06 \x01(\v2\x1e.tfplan.LifecycleActionTriggerH\x00R\x16lifecycleActionTrigger\x12Q\n" +
+	"\x15invoke_action_trigger\x18\a \x01(\v2\x1b.tfplan.InvokeActionTriggerH\x00R\x13invokeActionTriggerB\x10\n" +
 	"\x0eaction_trigger\"\xfe\x01\n" +
 	"\x16LifecycleActionTrigger\x128\n" +
 	"\x18triggering_resource_addr\x18\x01 \x01(\tR\x16triggeringResourceAddr\x12?\n" +
 	"\rtrigger_event\x18\x02 \x01(\x0e2\x1a.tfplan.ActionTriggerEventR\ftriggerEvent\x12;\n" +
 	"\x1aaction_trigger_block_index\x18\x03 \x01(\x03R\x17actionTriggerBlockIndex\x12,\n" +
-	"\x12actions_list_index\x18\x04 \x01(\x03R\x10actionsListIndex\"{\n" +
+	"\x12actions_list_index\x18\x04 \x01(\x03R\x10actionsListIndex\"\x15\n" +
+	"\x13InvokeActionTrigger\"{\n" +
 	"\x1cResourceInstanceActionChange\x12\x12\n" +
 	"\x04addr\x18\x01 \x01(\tR\x04addr\x12\x1f\n" +
 	"\vdeposed_key\x18\x02 \x01(\tR\n" +
@@ -2343,7 +2411,7 @@ const file_planfile_proto_rawDesc = "" +
 	"\x17RESOURCE_CONFIG_UNKNOWN\x10\x02\x12\x1b\n" +
 	"\x17PROVIDER_CONFIG_UNKNOWN\x10\x03\x12\x11\n" +
 	"\rABSENT_PREREQ\x10\x04\x12\x13\n" +
-	"\x0fDEFERRED_PREREQ\x10\x05*\xa1\x01\n" +
+	"\x0fDEFERRED_PREREQ\x10\x05*\xa4\x01\n" +
 	"\x12ActionTriggerEvent\x12\x11\n" +
 	"\rINVALID_EVENT\x10\x00\x12\x11\n" +
 	"\rBEFORE_CERATE\x10\x01\x12\x10\n" +
@@ -2351,8 +2419,9 @@ const file_planfile_proto_rawDesc = "" +
 	"\rBEFORE_UPDATE\x10\x03\x12\x10\n" +
 	"\fAFTER_UPDATE\x10\x04\x12\x12\n" +
 	"\x0eBEFORE_DESTROY\x10\x05\x12\x11\n" +
-	"\rAFTER_DESTROY\x10\x06\x12\a\n" +
-	"\x03CLI\x10\aB9Z7github.com/hashicorp/terraform/internal/plans/planprotob\x06proto3"
+	"\rAFTER_DESTROY\x10\x06\x12\n" +
+	"\n" +
+	"\x06INVOKE\x10\aB9Z7github.com/hashicorp/terraform/internal/plans/planprotob\x06proto3"
 
 var (
 	file_planfile_proto_rawDescOnce sync.Once
@@ -2367,7 +2436,7 @@ func file_planfile_proto_rawDescGZIP() []byte {
 }
 
 var file_planfile_proto_enumTypes = make([]protoimpl.EnumInfo, 7)
-var file_planfile_proto_msgTypes = make([]protoimpl.MessageInfo, 22)
+var file_planfile_proto_msgTypes = make([]protoimpl.MessageInfo, 23)
 var file_planfile_proto_goTypes = []any{
 	(Mode)(0),                              // 0: tfplan.Mode
 	(Action)(0),                            // 1: tfplan.Action
@@ -2393,15 +2462,16 @@ var file_planfile_proto_goTypes = []any{
 	(*Deferred)(nil),                       // 21: tfplan.Deferred
 	(*ActionInvocationInstance)(nil),       // 22: tfplan.ActionInvocationInstance
 	(*LifecycleActionTrigger)(nil),         // 23: tfplan.LifecycleActionTrigger
-	(*ResourceInstanceActionChange)(nil),   // 24: tfplan.ResourceInstanceActionChange
-	nil,                                    // 25: tfplan.Plan.VariablesEntry
-	(*PlanResourceAttr)(nil),               // 26: tfplan.Plan.resource_attr
-	(*CheckResults_ObjectResult)(nil),      // 27: tfplan.CheckResults.ObjectResult
-	(*Path_Step)(nil),                      // 28: tfplan.Path.Step
+	(*InvokeActionTrigger)(nil),            // 24: tfplan.InvokeActionTrigger
+	(*ResourceInstanceActionChange)(nil),   // 25: tfplan.ResourceInstanceActionChange
+	nil,                                    // 26: tfplan.Plan.VariablesEntry
+	(*PlanResourceAttr)(nil),               // 27: tfplan.Plan.resource_attr
+	(*CheckResults_ObjectResult)(nil),      // 28: tfplan.CheckResults.ObjectResult
+	(*Path_Step)(nil),                      // 29: tfplan.Path.Step
 }
 var file_planfile_proto_depIdxs = []int32{
 	0,  // 0: tfplan.Plan.ui_mode:type_name -> tfplan.Mode
-	25, // 1: tfplan.Plan.variables:type_name -> tfplan.Plan.VariablesEntry
+	26, // 1: tfplan.Plan.variables:type_name -> tfplan.Plan.VariablesEntry
 	12, // 2: tfplan.Plan.resource_changes:type_name -> tfplan.ResourceInstanceChange
 	12, // 3: tfplan.Plan.resource_drift:type_name -> tfplan.ResourceInstanceChange
 	13, // 4: tfplan.Plan.deferred_changes:type_name -> tfplan.DeferredResourceInstanceChange
@@ -2411,7 +2481,7 @@ var file_planfile_proto_depIdxs = []int32{
 	22, // 8: tfplan.Plan.action_invocations:type_name -> tfplan.ActionInvocationInstance
 	8,  // 9: tfplan.Plan.backend:type_name -> tfplan.Backend
 	9,  // 10: tfplan.Plan.state_store:type_name -> tfplan.StateStore
-	26, // 11: tfplan.Plan.relevant_attributes:type_name -> tfplan.Plan.resource_attr
+	27, // 11: tfplan.Plan.relevant_attributes:type_name -> tfplan.Plan.resource_attr
 	17, // 12: tfplan.Plan.function_results:type_name -> tfplan.FunctionCallHash
 	18, // 13: tfplan.Backend.config:type_name -> tfplan.DynamicValue
 	18, // 14: tfplan.StateStore.config:type_name -> tfplan.DynamicValue
@@ -2433,25 +2503,26 @@ var file_planfile_proto_depIdxs = []int32{
 	11, // 30: tfplan.OutputChange.change:type_name -> tfplan.Change
 	6,  // 31: tfplan.CheckResults.kind:type_name -> tfplan.CheckResults.ObjectKind
 	5,  // 32: tfplan.CheckResults.status:type_name -> tfplan.CheckResults.Status
-	27, // 33: tfplan.CheckResults.objects:type_name -> tfplan.CheckResults.ObjectResult
-	28, // 34: tfplan.Path.steps:type_name -> tfplan.Path.Step
+	28, // 33: tfplan.CheckResults.objects:type_name -> tfplan.CheckResults.ObjectResult
+	29, // 34: tfplan.Path.steps:type_name -> tfplan.Path.Step
 	18, // 35: tfplan.Importing.identity:type_name -> tfplan.DynamicValue
 	3,  // 36: tfplan.Deferred.reason:type_name -> tfplan.DeferredReason
-	24, // 37: tfplan.ActionInvocationInstance.linked_resources:type_name -> tfplan.ResourceInstanceActionChange
+	25, // 37: tfplan.ActionInvocationInstance.linked_resources:type_name -> tfplan.ResourceInstanceActionChange
 	18, // 38: tfplan.ActionInvocationInstance.config_value:type_name -> tfplan.DynamicValue
 	19, // 39: tfplan.ActionInvocationInstance.sensitive_config_paths:type_name -> tfplan.Path
 	23, // 40: tfplan.ActionInvocationInstance.lifecycle_action_trigger:type_name -> tfplan.LifecycleActionTrigger
-	4,  // 41: tfplan.LifecycleActionTrigger.trigger_event:type_name -> tfplan.ActionTriggerEvent
-	11, // 42: tfplan.ResourceInstanceActionChange.change:type_name -> tfplan.Change
-	18, // 43: tfplan.Plan.VariablesEntry.value:type_name -> tfplan.DynamicValue
-	19, // 44: tfplan.Plan.resource_attr.attr:type_name -> tfplan.Path
-	5,  // 45: tfplan.CheckResults.ObjectResult.status:type_name -> tfplan.CheckResults.Status
-	18, // 46: tfplan.Path.Step.element_key:type_name -> tfplan.DynamicValue
-	47, // [47:47] is the sub-list for method output_type
-	47, // [47:47] is the sub-list for method input_type
-	47, // [47:47] is the sub-list for extension type_name
-	47, // [47:47] is the sub-list for extension extendee
-	0,  // [0:47] is the sub-list for field type_name
+	24, // 41: tfplan.ActionInvocationInstance.invoke_action_trigger:type_name -> tfplan.InvokeActionTrigger
+	4,  // 42: tfplan.LifecycleActionTrigger.trigger_event:type_name -> tfplan.ActionTriggerEvent
+	11, // 43: tfplan.ResourceInstanceActionChange.change:type_name -> tfplan.Change
+	18, // 44: tfplan.Plan.VariablesEntry.value:type_name -> tfplan.DynamicValue
+	19, // 45: tfplan.Plan.resource_attr.attr:type_name -> tfplan.Path
+	5,  // 46: tfplan.CheckResults.ObjectResult.status:type_name -> tfplan.CheckResults.Status
+	18, // 47: tfplan.Path.Step.element_key:type_name -> tfplan.DynamicValue
+	48, // [48:48] is the sub-list for method output_type
+	48, // [48:48] is the sub-list for method input_type
+	48, // [48:48] is the sub-list for extension type_name
+	48, // [48:48] is the sub-list for extension extendee
+	0,  // [0:48] is the sub-list for field type_name
 }
 
 func init() { file_planfile_proto_init() }
@@ -2461,8 +2532,9 @@ func file_planfile_proto_init() {
 	}
 	file_planfile_proto_msgTypes[15].OneofWrappers = []any{
 		(*ActionInvocationInstance_LifecycleActionTrigger)(nil),
+		(*ActionInvocationInstance_InvokeActionTrigger)(nil),
 	}
-	file_planfile_proto_msgTypes[21].OneofWrappers = []any{
+	file_planfile_proto_msgTypes[22].OneofWrappers = []any{
 		(*Path_Step_AttributeName)(nil),
 		(*Path_Step_ElementKey)(nil),
 	}
@@ -2472,7 +2544,7 @@ func file_planfile_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_planfile_proto_rawDesc), len(file_planfile_proto_rawDesc)),
 			NumEnums:      7,
-			NumMessages:   22,
+			NumMessages:   23,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/internal/plans/planproto/planfile.proto
+++ b/internal/plans/planproto/planfile.proto
@@ -108,6 +108,11 @@ message Plan {
     // configuration.
     repeated string target_addrs = 5;
 
+    // An unordered set of action addresses that must be invoked when applying.
+    // If no actions are specified then only lifecycle actions should be
+    // executed.
+    repeated string action_target_addrs = 32;
+
     // An unordered set of force-replace addresses to include when applying.
     // This must match the set of addresses that was used when creating the
     // plan, or else applying the plan will fail when it reaches a different
@@ -453,7 +458,7 @@ enum ActionTriggerEvent {
     AFTER_UPDATE = 4;
     BEFORE_DESTROY = 5;
     AFTER_DESTROY = 6;
-    CLI = 7;
+    INVOKE = 7;
 }
 
 // ActionInvocationInstance contains a planned action invocation and any embedded ResourceInstanceActionChanges
@@ -475,6 +480,7 @@ message ActionInvocationInstance {
 
     oneof action_trigger {
         LifecycleActionTrigger lifecycle_action_trigger = 6;
+        InvokeActionTrigger invoke_action_trigger = 7;
     }
 }
 
@@ -486,6 +492,10 @@ message LifecycleActionTrigger {
   int64 action_trigger_block_index = 3;
   int64 actions_list_index = 4;
 }
+
+// InvokeActionTrigger indicates the action was triggered by the invoke command
+// on the CLI.
+message InvokeActionTrigger {}
 
 message ResourceInstanceActionChange {
     // addr is a string representation of the resource instance address that

--- a/internal/terraform/context_apply.go
+++ b/internal/terraform/context_apply.go
@@ -366,6 +366,7 @@ func (c *Context) applyGraph(plan *plans.Plan, config *configs.Config, opts *App
 		ExternalProviderConfigs: externalProviderConfigs,
 		Plugins:                 c.plugins,
 		Targets:                 plan.TargetAddrs,
+		ActionTargets:           plan.ActionTargetAddrs,
 		ForceReplace:            plan.ForceReplaceAddrs,
 		Operation:               operation,
 		ExternalReferences:      plan.ExternalReferences,

--- a/internal/terraform/context_apply_action_test.go
+++ b/internal/terraform/context_apply_action_test.go
@@ -1341,6 +1341,45 @@ action "act_unlinked_wo" "hello" {
 				},
 			},
 		},
+		"simple action invoke": {
+			module: map[string]string{
+				"main.tf": `
+action "act_unlinked" "one" {
+  config {
+    attr = "one"
+  }
+}
+action "act_unlinked" "two" {
+  config {
+    attr = "two"
+  }
+}
+`,
+			},
+			expectInvokeActionCalled: true,
+			expectInvokeActionCalls: []providers.InvokeActionRequest{
+				{
+					ActionType: "act_unlinked",
+					PlannedActionData: cty.ObjectVal(map[string]cty.Value{
+						"attr": cty.StringVal("one"),
+					}),
+				},
+			},
+			planOpts: &PlanOpts{
+				Mode: plans.RefreshOnlyMode,
+				ActionTargets: []addrs.Targetable{
+					addrs.AbsActionInstance{
+						Action: addrs.ActionInstance{
+							Action: addrs.Action{
+								Type: "act_unlinked",
+								Name: "one",
+							},
+							Key: addrs.NoKey,
+						},
+					},
+				},
+			},
+		},
 	} {
 		t.Run(name, func(t *testing.T) {
 			if tc.toBeImplemented {

--- a/internal/terraform/context_apply_action_test.go
+++ b/internal/terraform/context_apply_action_test.go
@@ -1598,7 +1598,7 @@ action "act_unlinked" "one" {
 					},
 				},
 			}
-			
+
 			if tc.readResourceFn != nil {
 				testProvider.ReadResourceFn = func(r providers.ReadResourceRequest) providers.ReadResourceResponse {
 					return tc.readResourceFn(t, r)

--- a/internal/terraform/context_apply_action_test.go
+++ b/internal/terraform/context_apply_action_test.go
@@ -28,6 +28,7 @@ func TestContext2Apply_actions(t *testing.T) {
 		mode                            plans.Mode
 		prevRunState                    *states.State
 		events                          func(req providers.InvokeActionRequest) []providers.InvokeActionEvent
+		readResourceFn                  func(*testing.T, providers.ReadResourceRequest) providers.ReadResourceResponse
 		callingInvokeReturnsDiagnostics func(providers.InvokeActionRequest) tfdiags.Diagnostics
 
 		planOpts  *PlanOpts
@@ -1388,6 +1389,189 @@ action "act_unlinked" "two" {
 				},
 			},
 		},
+
+		"action invoke with count (all)": {
+			module: map[string]string{
+				"main.tf": `
+action "act_unlinked" "one" {
+  count = 2
+
+  config {
+    attr = "${count.index}"
+  }
+}
+action "act_unlinked" "two" {
+  count = 2
+
+  config {
+    attr = "two"
+  }
+}
+`,
+			},
+			planOpts: &PlanOpts{
+				Mode: plans.RefreshOnlyMode,
+				ActionTargets: []addrs.Targetable{
+					addrs.AbsAction{
+						Action: addrs.Action{
+							Type: "act_unlinked",
+							Name: "one",
+						},
+					},
+				},
+			},
+			expectInvokeActionCalled: true,
+			expectInvokeActionCalls: []providers.InvokeActionRequest{
+				{
+					ActionType: "act_unlinked",
+					PlannedActionData: cty.ObjectVal(map[string]cty.Value{
+						"attr": cty.StringVal("0"),
+					}),
+				},
+				{
+					ActionType: "act_unlinked",
+					PlannedActionData: cty.ObjectVal(map[string]cty.Value{
+						"attr": cty.StringVal("1"),
+					}),
+				},
+			},
+			expectInvokeActionCallsAreUnordered: true,
+		},
+
+		"action invoke with count (instance)": {
+			module: map[string]string{
+				"main.tf": `
+action "act_unlinked" "one" {
+  count = 2
+
+  config {
+    attr = "${count.index}"
+  }
+}
+action "act_unlinked" "two" {
+  count = 2
+
+  config {
+    attr = "two"
+  }
+}
+`,
+			},
+			planOpts: &PlanOpts{
+				Mode: plans.RefreshOnlyMode,
+				ActionTargets: []addrs.Targetable{
+					addrs.AbsActionInstance{
+						Action: addrs.ActionInstance{
+							Action: addrs.Action{
+								Type: "act_unlinked",
+								Name: "one",
+							},
+							Key: addrs.IntKey(0),
+						},
+					},
+				},
+			},
+			expectInvokeActionCalled: true,
+			expectInvokeActionCalls: []providers.InvokeActionRequest{
+				{
+					ActionType: "act_unlinked",
+					PlannedActionData: cty.ObjectVal(map[string]cty.Value{
+						"attr": cty.StringVal("0"),
+					}),
+				},
+			},
+		},
+
+		"invoke action with reference": {
+			module: map[string]string{
+				"main.tf": `
+resource "test_object" "a" {
+  name = "hello"
+}
+
+action "act_unlinked" "one" {
+  config {
+    attr = test_object.a.name
+  }
+}
+`,
+			},
+			planOpts: &PlanOpts{
+				Mode: plans.RefreshOnlyMode,
+				ActionTargets: []addrs.Targetable{
+					addrs.AbsAction{
+						Action: addrs.Action{
+							Type: "act_unlinked",
+							Name: "one",
+						},
+					},
+				},
+			},
+			expectInvokeActionCalled: true,
+			expectInvokeActionCalls: []providers.InvokeActionRequest{
+				{
+					ActionType: "act_unlinked",
+					PlannedActionData: cty.ObjectVal(map[string]cty.Value{
+						"attr": cty.StringVal("hello"),
+					}),
+				},
+			},
+			prevRunState: states.BuildState(func(state *states.SyncState) {
+				state.SetResourceInstanceCurrent(mustResourceInstanceAddr("test_object.a"), &states.ResourceInstanceObjectSrc{
+					AttrsJSON: []byte(`{"name":"hello"}`),
+					Status:    states.ObjectReady,
+				}, mustProviderConfig(`provider["registry.terraform.io/hashicorp/test"]`))
+			}),
+		},
+
+		"invoke action with reference (drift)": {
+			module: map[string]string{
+				"main.tf": `
+resource "test_object" "a" {
+  name = "hello"
+}
+
+action "act_unlinked" "one" {
+  config {
+    attr = test_object.a.name
+  }
+}
+`,
+			},
+			planOpts: &PlanOpts{
+				Mode: plans.RefreshOnlyMode,
+				ActionTargets: []addrs.Targetable{
+					addrs.AbsAction{
+						Action: addrs.Action{
+							Type: "act_unlinked",
+							Name: "one",
+						},
+					},
+				},
+			},
+			expectInvokeActionCalled: true,
+			expectInvokeActionCalls: []providers.InvokeActionRequest{
+				{
+					ActionType: "act_unlinked",
+					PlannedActionData: cty.ObjectVal(map[string]cty.Value{
+						"attr": cty.StringVal("drifted value"),
+					}),
+				},
+			},
+			readResourceFn: func(t *testing.T, request providers.ReadResourceRequest) providers.ReadResourceResponse {
+				return providers.ReadResourceResponse{
+					NewState: cty.ObjectVal(map[string]cty.Value{
+						"name": cty.StringVal("drifted value"),
+					}),
+				}
+			},
+			prevRunState: states.BuildState(func(state *states.SyncState) {
+				state.SetResourceInstanceCurrent(mustResourceInstanceAddr("test_object.a"), &states.ResourceInstanceObjectSrc{
+					AttrsJSON: []byte(`{"name":"hello"}`),
+					Status:    states.ObjectReady,
+				}, mustProviderConfig(`provider["registry.terraform.io/hashicorp/test"]`))
+			}),
+		},
 	} {
 		t.Run(name, func(t *testing.T) {
 			if tc.toBeImplemented {
@@ -1413,6 +1597,12 @@ action "act_unlinked" "two" {
 						},
 					},
 				},
+			}
+			
+			if tc.readResourceFn != nil {
+				testProvider.ReadResourceFn = func(r providers.ReadResourceRequest) providers.ReadResourceResponse {
+					return tc.readResourceFn(t, r)
+				}
 			}
 
 			invokeActionFn := func(req providers.InvokeActionRequest) providers.InvokeActionResponse {

--- a/internal/terraform/context_plan.go
+++ b/internal/terraform/context_plan.go
@@ -904,7 +904,9 @@ func (c *Context) planWalk(config *configs.Config, prevRunState *states.State, o
 			// In refresh-only mode we explicitly don't expect to propose any
 			// actions, but the plan is applyable if the state was changed
 			// in an interesting way by the refresh step.
-			plan.Applyable = !plan.PriorState.ManagedResourcesEqual(plan.PrevRunState) || !plan.PriorState.RootOutputValuesEqual(plan.PrevRunState)
+			plan.Applyable = !plan.PriorState.ManagedResourcesEqual(plan.PrevRunState) ||
+				!plan.PriorState.RootOutputValuesEqual(plan.PrevRunState) ||
+				len(plan.Changes.ActionInvocations) > 0
 		} else {
 			// For other planning modes a plan is applyable if its "changes"
 			// are not considered empty (by whatever rules the plans package

--- a/internal/terraform/context_plan_actions_test.go
+++ b/internal/terraform/context_plan_actions_test.go
@@ -8,7 +8,9 @@ import (
 	"slices"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/hcl/v2"
+	"github.com/zclconf/go-cty-debug/ctydebug"
 	"github.com/zclconf/go-cty/cty"
 
 	"github.com/hashicorp/terraform/internal/addrs"
@@ -135,7 +137,7 @@ resource "test_object" "a" {
 					t.Fatalf("expected action address to be 'action.test_unlinked.hello', got '%s'", action.Addr)
 				}
 
-				at, ok := action.ActionTrigger.(plans.LifecycleActionTrigger)
+				at, ok := action.ActionTrigger.(*plans.LifecycleActionTrigger)
 				if !ok {
 					t.Fatalf("expected action trigger to be a LifecycleActionTrigger, got %T", action.ActionTrigger)
 				}
@@ -1013,7 +1015,7 @@ resource "other_object" "a" {
 					t.Fatalf("expected action address to be 'module.mod.action.test_unlinked.hello', got '%s'", action.Addr)
 				}
 
-				at, ok := action.ActionTrigger.(plans.LifecycleActionTrigger)
+				at, ok := action.ActionTrigger.(*plans.LifecycleActionTrigger)
 				if !ok {
 					t.Fatalf("expected action trigger to be a LifecycleActionTrigger, got %T", action.ActionTrigger)
 				}
@@ -1067,11 +1069,11 @@ resource "other_object" "a" {
 
 				// We know we are run within two child modules, so we can just sort by the triggering resource address
 				slices.SortFunc(p.Changes.ActionInvocations, func(a, b *plans.ActionInvocationInstanceSrc) int {
-					at, ok := a.ActionTrigger.(plans.LifecycleActionTrigger)
+					at, ok := a.ActionTrigger.(*plans.LifecycleActionTrigger)
 					if !ok {
 						t.Fatalf("expected action trigger to be a LifecycleActionTrigger, got %T", a.ActionTrigger)
 					}
-					bt, ok := b.ActionTrigger.(plans.LifecycleActionTrigger)
+					bt, ok := b.ActionTrigger.(*plans.LifecycleActionTrigger)
 					if !ok {
 						t.Fatalf("expected action trigger to be a LifecycleActionTrigger, got %T", b.ActionTrigger)
 					}
@@ -1087,7 +1089,7 @@ resource "other_object" "a" {
 					t.Fatalf("expected action address to be 'module.mod[0].action.test_unlinked.hello', got '%s'", action.Addr)
 				}
 
-				at := action.ActionTrigger.(plans.LifecycleActionTrigger)
+				at := action.ActionTrigger.(*plans.LifecycleActionTrigger)
 
 				if !at.TriggeringResourceAddr.Equal(mustResourceInstanceAddr("module.mod[0].other_object.a")) {
 					t.Fatalf("expected action to have triggering resource address 'module.mod[0].other_object.a', but it is %s", at.TriggeringResourceAddr)
@@ -1112,7 +1114,7 @@ resource "other_object" "a" {
 					t.Fatalf("expected action address to be 'module.mod[1].action.test_unlinked.hello', got '%s'", action2.Addr)
 				}
 
-				a2t := action2.ActionTrigger.(plans.LifecycleActionTrigger)
+				a2t := action2.ActionTrigger.(*plans.LifecycleActionTrigger)
 
 				if !a2t.TriggeringResourceAddr.Equal(mustResourceInstanceAddr("module.mod[1].other_object.a")) {
 					t.Fatalf("expected action to have triggering resource address 'module.mod[1].other_object.a', but it is %s", a2t.TriggeringResourceAddr)
@@ -1156,7 +1158,7 @@ resource "other_object" "a" {
 					t.Fatalf("expected action address to be 'module.mod.action.test_unlinked.hello', got '%s'", action.Addr)
 				}
 
-				at, ok := action.ActionTrigger.(plans.LifecycleActionTrigger)
+				at, ok := action.ActionTrigger.(*plans.LifecycleActionTrigger)
 				if !ok {
 					t.Fatalf("expected action trigger to be a lifecycle action trigger, got %T", action.ActionTrigger)
 				}
@@ -1205,7 +1207,7 @@ resource "other_object" "a" {
 				if action.Addr.String() != "action.ecosystem_unlinked.hello" {
 					t.Fatalf("expected action address to be 'action.ecosystem_unlinked.hello', got '%s'", action.Addr)
 				}
-				at, ok := action.ActionTrigger.(plans.LifecycleActionTrigger)
+				at, ok := action.ActionTrigger.(*plans.LifecycleActionTrigger)
 				if !ok {
 					t.Fatalf("expected action trigger to be a LifecycleActionTrigger, got %T", action.ActionTrigger)
 				}
@@ -1251,7 +1253,7 @@ resource "other_object" "a" {
 					t.Fatalf("expected action address to be 'action.test_unlinked.hello', got '%s'", action.Addr)
 				}
 
-				at, ok := action.ActionTrigger.(plans.LifecycleActionTrigger)
+				at, ok := action.ActionTrigger.(*plans.LifecycleActionTrigger)
 				if !ok {
 					t.Fatalf("expected action trigger to be a LifecycleActionTrigger, got %T", action.ActionTrigger)
 				}
@@ -1468,8 +1470,8 @@ resource "test_object" "a" {
 				if deferredActionInvocation.DeferredReason != providers.DeferredReasonAbsentPrereq {
 					t.Fatalf("expected deferred action to be deferred due to absent prereq, but got %s", deferredActionInvocation.DeferredReason)
 				}
-				if deferredActionInvocation.ActionInvocationInstanceSrc.ActionTrigger.(plans.LifecycleActionTrigger).TriggeringResourceAddr.String() != "test_object.a" {
-					t.Fatalf("expected deferred action to be triggered by test_object.a, but got %s", deferredActionInvocation.ActionInvocationInstanceSrc.ActionTrigger.(plans.LifecycleActionTrigger).TriggeringResourceAddr.String())
+				if deferredActionInvocation.ActionInvocationInstanceSrc.ActionTrigger.(*plans.LifecycleActionTrigger).TriggeringResourceAddr.String() != "test_object.a" {
+					t.Fatalf("expected deferred action to be triggered by test_object.a, but got %s", deferredActionInvocation.ActionInvocationInstanceSrc.ActionTrigger.(*plans.LifecycleActionTrigger).TriggeringResourceAddr.String())
 				}
 
 				if deferredActionInvocation.ActionInvocationInstanceSrc.Addr.String() != "action.test_unlinked.hello" {
@@ -1529,8 +1531,8 @@ resource "test_object" "a" {
 				if firstDeferredActionInvocation.DeferredReason != providers.DeferredReasonAbsentPrereq {
 					t.Fatalf("expected deferred action to be deferred due to absent prereq, but got %s", firstDeferredActionInvocation.DeferredReason)
 				}
-				if firstDeferredActionInvocation.ActionInvocationInstanceSrc.ActionTrigger.(plans.LifecycleActionTrigger).TriggeringResourceAddr.String() != "test_object.a" {
-					t.Fatalf("expected deferred action to be triggered by test_object.a, but got %s", firstDeferredActionInvocation.ActionInvocationInstanceSrc.ActionTrigger.(plans.LifecycleActionTrigger).TriggeringResourceAddr.String())
+				if firstDeferredActionInvocation.ActionInvocationInstanceSrc.ActionTrigger.(*plans.LifecycleActionTrigger).TriggeringResourceAddr.String() != "test_object.a" {
+					t.Fatalf("expected deferred action to be triggered by test_object.a, but got %s", firstDeferredActionInvocation.ActionInvocationInstanceSrc.ActionTrigger.(*plans.LifecycleActionTrigger).TriggeringResourceAddr.String())
 				}
 
 				if firstDeferredActionInvocation.ActionInvocationInstanceSrc.Addr.String() != "action.test_unlinked.hello" {
@@ -1541,8 +1543,8 @@ resource "test_object" "a" {
 				if secondDeferredActionInvocation.DeferredReason != providers.DeferredReasonDeferredPrereq {
 					t.Fatalf("expected second deferred action to be deferred due to deferred prereq, but got %s", secondDeferredActionInvocation.DeferredReason)
 				}
-				if secondDeferredActionInvocation.ActionInvocationInstanceSrc.ActionTrigger.(plans.LifecycleActionTrigger).TriggeringResourceAddr.String() != "test_object.a" {
-					t.Fatalf("expected second deferred action to be triggered by test_object.a, but got %s", secondDeferredActionInvocation.ActionInvocationInstanceSrc.ActionTrigger.(plans.LifecycleActionTrigger).TriggeringResourceAddr.String())
+				if secondDeferredActionInvocation.ActionInvocationInstanceSrc.ActionTrigger.(*plans.LifecycleActionTrigger).TriggeringResourceAddr.String() != "test_object.a" {
+					t.Fatalf("expected second deferred action to be triggered by test_object.a, but got %s", secondDeferredActionInvocation.ActionInvocationInstanceSrc.ActionTrigger.(*plans.LifecycleActionTrigger).TriggeringResourceAddr.String())
 				}
 
 				if secondDeferredActionInvocation.ActionInvocationInstanceSrc.Addr.String() != "action.ecosystem_unlinked.world" {
@@ -1606,8 +1608,8 @@ resource "test_object" "a" {
 				if firstDeferredActionInvocation.DeferredReason != providers.DeferredReasonAbsentPrereq {
 					t.Fatalf("expected deferred action to be deferred due to absent prereq, but got %s", firstDeferredActionInvocation.DeferredReason)
 				}
-				if firstDeferredActionInvocation.ActionInvocationInstanceSrc.ActionTrigger.(plans.LifecycleActionTrigger).TriggeringResourceAddr.String() != "test_object.a" {
-					t.Fatalf("expected deferred action to be triggered by test_object.a, but got %s", firstDeferredActionInvocation.ActionInvocationInstanceSrc.ActionTrigger.(plans.LifecycleActionTrigger).TriggeringResourceAddr.String())
+				if firstDeferredActionInvocation.ActionInvocationInstanceSrc.ActionTrigger.(*plans.LifecycleActionTrigger).TriggeringResourceAddr.String() != "test_object.a" {
+					t.Fatalf("expected deferred action to be triggered by test_object.a, but got %s", firstDeferredActionInvocation.ActionInvocationInstanceSrc.ActionTrigger.(*plans.LifecycleActionTrigger).TriggeringResourceAddr.String())
 				}
 
 				if firstDeferredActionInvocation.ActionInvocationInstanceSrc.Addr.String() != "action.test_unlinked.hello" {
@@ -1618,8 +1620,8 @@ resource "test_object" "a" {
 				if secondDeferredActionInvocation.DeferredReason != providers.DeferredReasonDeferredPrereq {
 					t.Fatalf("expected second deferred action to be deferred due to deferred prereq, but got %s", secondDeferredActionInvocation.DeferredReason)
 				}
-				if secondDeferredActionInvocation.ActionInvocationInstanceSrc.ActionTrigger.(plans.LifecycleActionTrigger).TriggeringResourceAddr.String() != "test_object.a" {
-					t.Fatalf("expected second deferred action to be triggered by test_object.a, but got %s", secondDeferredActionInvocation.ActionInvocationInstanceSrc.ActionTrigger.(plans.LifecycleActionTrigger).TriggeringResourceAddr.String())
+				if secondDeferredActionInvocation.ActionInvocationInstanceSrc.ActionTrigger.(*plans.LifecycleActionTrigger).TriggeringResourceAddr.String() != "test_object.a" {
+					t.Fatalf("expected second deferred action to be triggered by test_object.a, but got %s", secondDeferredActionInvocation.ActionInvocationInstanceSrc.ActionTrigger.(*plans.LifecycleActionTrigger).TriggeringResourceAddr.String())
 				}
 
 				if secondDeferredActionInvocation.ActionInvocationInstanceSrc.Addr.String() != "action.ecosystem_unlinked.world" {
@@ -1688,8 +1690,8 @@ resource "test_object" "a" {
 				if firstDeferredActionInvocation.DeferredReason != providers.DeferredReasonDeferredPrereq {
 					t.Fatalf("expected deferred action to be deferred due to deferred prereq, but got %s", firstDeferredActionInvocation.DeferredReason)
 				}
-				if firstDeferredActionInvocation.ActionInvocationInstanceSrc.ActionTrigger.(plans.LifecycleActionTrigger).TriggeringResourceAddr.String() != "test_object.a" {
-					t.Fatalf("expected deferred action to be triggered by test_object.a, but got %s", firstDeferredActionInvocation.ActionInvocationInstanceSrc.ActionTrigger.(plans.LifecycleActionTrigger).TriggeringResourceAddr.String())
+				if firstDeferredActionInvocation.ActionInvocationInstanceSrc.ActionTrigger.(*plans.LifecycleActionTrigger).TriggeringResourceAddr.String() != "test_object.a" {
+					t.Fatalf("expected deferred action to be triggered by test_object.a, but got %s", firstDeferredActionInvocation.ActionInvocationInstanceSrc.ActionTrigger.(*plans.LifecycleActionTrigger).TriggeringResourceAddr.String())
 				}
 
 				if firstDeferredActionInvocation.ActionInvocationInstanceSrc.Addr.String() != "action.test_unlinked.hello" {
@@ -1700,8 +1702,8 @@ resource "test_object" "a" {
 				if secondDeferredActionInvocation.DeferredReason != providers.DeferredReasonDeferredPrereq {
 					t.Fatalf("expected second deferred action to be deferred due to deferred prereq, but got %s", secondDeferredActionInvocation.DeferredReason)
 				}
-				if secondDeferredActionInvocation.ActionInvocationInstanceSrc.ActionTrigger.(plans.LifecycleActionTrigger).TriggeringResourceAddr.String() != "test_object.a" {
-					t.Fatalf("expected second deferred action to be triggered by test_object.a, but got %s", secondDeferredActionInvocation.ActionInvocationInstanceSrc.ActionTrigger.(plans.LifecycleActionTrigger).TriggeringResourceAddr.String())
+				if secondDeferredActionInvocation.ActionInvocationInstanceSrc.ActionTrigger.(*plans.LifecycleActionTrigger).TriggeringResourceAddr.String() != "test_object.a" {
+					t.Fatalf("expected second deferred action to be triggered by test_object.a, but got %s", secondDeferredActionInvocation.ActionInvocationInstanceSrc.ActionTrigger.(*plans.LifecycleActionTrigger).TriggeringResourceAddr.String())
 				}
 
 				if secondDeferredActionInvocation.ActionInvocationInstanceSrc.Addr.String() != "action.test_unlinked.hello" {
@@ -1767,6 +1769,64 @@ action "test_unlinked_wo" "hello" {
 
 				if !ai.ConfigValue.GetAttr("attr").IsNull() {
 					t.Fatal("should have converted ephemeral value to null in the plan")
+				}
+			},
+		},
+
+		"simple action invoke": {
+			module: map[string]string{
+				"main.tf": `
+action "test_unlinked" "one" {
+  config {
+    attr = "one"
+  }
+}
+action "test_unlinked" "two" {
+  config {
+    attr = "two"
+  }
+}
+`,
+			},
+			planOpts: &PlanOpts{
+				Mode: plans.RefreshOnlyMode,
+				ActionTargets: []addrs.Targetable{
+					addrs.AbsActionInstance{
+						Action: addrs.ActionInstance{
+							Action: addrs.Action{
+								Type: "test_unlinked",
+								Name: "one",
+							},
+							Key: addrs.NoKey,
+						},
+					},
+				},
+			},
+			expectPlanActionCalled: true,
+			assertPlan: func(t *testing.T, plan *plans.Plan) {
+				if len(plan.Changes.ActionInvocations) != 1 {
+					t.Fatalf("expected exactly one invocation, and found %d", len(plan.Changes.ActionInvocations))
+				}
+
+				ais := plan.Changes.ActionInvocations[0]
+				ai, err := ais.Decode(&unlinkedActionSchema)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				if _, ok := ai.ActionTrigger.(*plans.InvokeActionTrigger); !ok {
+					t.Fatalf("expected invoke action trigger type but was %T", ai.ActionTrigger)
+				}
+
+				expected := cty.ObjectVal(map[string]cty.Value{
+					"attr": cty.StringVal("one"),
+				})
+				if diff := cmp.Diff(ai.ConfigValue, expected, ctydebug.CmpOptions); len(diff) > 0 {
+					t.Fatalf("wrong value in plan: %s", diff)
+				}
+
+				if !ai.Addr.Equal(mustActionInstanceAddr(t, "action.test_unlinked.one")) {
+					t.Fatalf("wrong address in plan: %s", ai.Addr)
 				}
 			},
 		},
@@ -1940,4 +2000,12 @@ action "test_unlinked_wo" "hello" {
 			}
 		})
 	}
+}
+
+func mustActionInstanceAddr(t *testing.T, address string) addrs.AbsActionInstance {
+	action, diags := addrs.ParseAbsActionInstanceStr(address)
+	if len(diags) > 0 {
+		t.Fatalf("invalid action %s", diags.Err())
+	}
+	return action
 }

--- a/internal/terraform/context_plan_actions_test.go
+++ b/internal/terraform/context_plan_actions_test.go
@@ -83,6 +83,9 @@ action "test_unlinked" "hello" {}
 				if len(p.Changes.ActionInvocations) != 0 {
 					t.Fatalf("expected no actions in plan, got %d", len(p.Changes.ActionInvocations))
 				}
+				if p.Applyable {
+					t.Fatalf("should not be able to apply this plan")
+				}
 			},
 		},
 

--- a/internal/terraform/graph_builder_apply.go
+++ b/internal/terraform/graph_builder_apply.go
@@ -56,6 +56,10 @@ type ApplyGraphBuilder struct {
 	// outputs should go into the diff so that this is unnecessary.
 	Targets []addrs.Targetable
 
+	// ActionTargets are actions to target. As with Targets we need to remove
+	// outputs, so when/if we remove Targets we can remove this as well.
+	ActionTargets []addrs.Targetable
+
 	// ForceReplace are the resource instance addresses that the user
 	// requested to force replacement for when creating the plan, if any.
 	// The apply step refers to these as part of verifying that the planned
@@ -233,7 +237,7 @@ func (b *ApplyGraphBuilder) Steps() []GraphTransformer {
 		},
 
 		// Target
-		&TargetsTransformer{Targets: b.Targets},
+		&TargetsTransformer{Targets: b.Targets, ActionTargets: b.ActionTargets},
 
 		// Close any ephemeral resource instances.
 		&ephemeralResourceCloseTransformer{},

--- a/internal/terraform/graph_builder_plan.go
+++ b/internal/terraform/graph_builder_plan.go
@@ -52,6 +52,9 @@ type PlanGraphBuilder struct {
 	// Targets are resources to target
 	Targets []addrs.Targetable
 
+	// ActionTargets are actions that should be triggered.
+	ActionTargets []addrs.Targetable
+
 	// ForceReplace are resource instances where if we would normally have
 	// generated a NoOp or Update action then we'll force generating a replace
 	// action instead. Create and Delete actions are not affected.
@@ -173,6 +176,7 @@ func (b *PlanGraphBuilder) Steps() []GraphTransformer {
 		&ActionPlanTransformer{
 			Config:    b.Config,
 			Operation: b.Operation,
+			Targets:   b.ActionTargets,
 		},
 
 		// Add dynamic values

--- a/internal/terraform/node_action.go
+++ b/internal/terraform/node_action.go
@@ -23,7 +23,7 @@ type GraphNodeConfigAction interface {
 // which has not yet been expanded.
 type nodeExpandActionDeclaration struct {
 	Addr   addrs.ConfigAction
-	Config configs.Action
+	Config *configs.Action
 
 	Schema           *providers.ActionSchema
 	ResolvedProvider addrs.AbsProviderConfig

--- a/internal/terraform/node_action_instance.go
+++ b/internal/terraform/node_action_instance.go
@@ -5,13 +5,14 @@ package terraform
 
 import (
 	"github.com/hashicorp/hcl/v2"
+	"github.com/zclconf/go-cty/cty"
+
 	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/configs"
 	"github.com/hashicorp/terraform/internal/dag"
 	"github.com/hashicorp/terraform/internal/lang/langrefs"
 	"github.com/hashicorp/terraform/internal/providers"
 	"github.com/hashicorp/terraform/internal/tfdiags"
-	"github.com/zclconf/go-cty/cty"
 )
 
 // NodeActionDeclarationInstance represents an action in a particular module.
@@ -21,7 +22,7 @@ import (
 // when they are referenced we can get the configuration for the action directly.
 type NodeActionDeclarationInstance struct {
 	Addr             addrs.AbsActionInstance
-	Config           configs.Action
+	Config           *configs.Action
 	Schema           *providers.ActionSchema
 	ResolvedProvider addrs.AbsProviderConfig
 }

--- a/internal/terraform/node_action_invoke.go
+++ b/internal/terraform/node_action_invoke.go
@@ -1,0 +1,183 @@
+package terraform
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/hcl/v2"
+
+	"github.com/hashicorp/terraform/internal/addrs"
+	"github.com/hashicorp/terraform/internal/configs"
+	"github.com/hashicorp/terraform/internal/lang/ephemeral"
+	"github.com/hashicorp/terraform/internal/plans"
+	"github.com/hashicorp/terraform/internal/providers"
+	"github.com/hashicorp/terraform/internal/tfdiags"
+)
+
+var (
+	_ GraphNodeDynamicExpandable = (*nodeActionInvokeExpand)(nil)
+	_ GraphNodeReferencer        = (*nodeActionInvokeExpand)(nil)
+	_ GraphNodeProviderConsumer  = (*nodeActionInvokeExpand)(nil)
+)
+
+type nodeActionInvokeExpand struct {
+	Target addrs.Targetable
+	Config *configs.Action
+
+	resolvedProvider addrs.AbsProviderConfig // set during the graph walk
+}
+
+func (n *nodeActionInvokeExpand) ProvidedBy() (addr addrs.ProviderConfig, exact bool) {
+	// Once the provider is fully resolved, we can return the known value.
+	if n.resolvedProvider.Provider.Type != "" {
+		return n.resolvedProvider, true
+	}
+
+	// Since we always have a config, we can use it
+	relAddr := n.Config.ProviderConfigAddr()
+	return addrs.LocalProviderConfig{
+		LocalName: relAddr.LocalName,
+		Alias:     relAddr.Alias,
+	}, false
+}
+
+func (n *nodeActionInvokeExpand) Provider() (provider addrs.Provider) {
+	return n.Config.Provider
+}
+
+func (n *nodeActionInvokeExpand) SetProvider(p addrs.AbsProviderConfig) {
+	n.resolvedProvider = p
+}
+
+func (n *nodeActionInvokeExpand) ModulePath() addrs.Module {
+	switch target := n.Target.(type) {
+	case addrs.AbsActionInstance:
+		return target.Module.Module()
+	case addrs.AbsAction:
+		return target.Module.Module()
+	default:
+		panic("unrecognized action type")
+	}
+}
+
+func (n *nodeActionInvokeExpand) References() []*addrs.Reference {
+	switch target := n.Target.(type) {
+	case addrs.AbsActionInstance:
+		return []*addrs.Reference{
+			{
+				Subject: target.Action,
+			},
+			{
+				Subject: target.Action.Action,
+			},
+		}
+	case addrs.AbsAction:
+		return []*addrs.Reference{
+			{
+				Subject: target.Action,
+			},
+		}
+	default:
+		panic("not an action target")
+	}
+}
+
+func (n *nodeActionInvokeExpand) DynamicExpand(context EvalContext) (*Graph, tfdiags.Diagnostics) {
+	var diags tfdiags.Diagnostics
+
+	if n.Config == nil {
+		// This means the user specified an action target that does not exist.
+		return nil, diags.Append(tfdiags.Sourceless(
+			tfdiags.Error,
+			"Invalid action target",
+			fmt.Sprintf("Action %s does not exist within the configuration.", n.Target.String())))
+	}
+
+	var g Graph
+	switch addr := n.Target.(type) {
+	case addrs.AbsActionInstance:
+		if _, ok := context.Actions().GetActionInstance(addr); !ok {
+			return nil, diags.Append(&hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  "Invalid action",
+				Detail:   fmt.Sprintf("Targeted action does not exist after expansion: %s.", addr),
+				Subject:  n.Config.DeclRange.Ptr(),
+			})
+		} else {
+			g.Add(&nodeActionInvokeInstance{
+				Target: addr,
+				Config: n.Config,
+			})
+		}
+
+	case addrs.AbsAction:
+		for _, target := range context.Actions().GetActionInstanceKeys(addr) {
+			g.Add(&nodeActionInvokeInstance{
+				Target: target,
+				Config: n.Config,
+			})
+		}
+	}
+	addRootNodeToGraph(&g)
+	return &g, diags
+}
+
+var (
+	_ GraphNodeExecutable     = (*nodeActionInvokeInstance)(nil)
+	_ GraphNodeModuleInstance = (*nodeActionInvokeInstance)(nil)
+)
+
+type nodeActionInvokeInstance struct {
+	Target addrs.AbsActionInstance
+	Config *configs.Action
+}
+
+func (n *nodeActionInvokeInstance) Path() addrs.ModuleInstance {
+	return n.Target.Module
+}
+
+func (n *nodeActionInvokeInstance) Execute(ctx EvalContext, _ walkOperation) tfdiags.Diagnostics {
+	var diags tfdiags.Diagnostics
+
+	actionInstance, ok := ctx.Actions().GetActionInstance(n.Target)
+	if !ok {
+		// shouldn't happen, we checked these things exist in the expand node
+		panic("tried to trigger non-existent action")
+	}
+
+	ai := plans.ActionInvocationInstance{
+		Addr:          n.Target,
+		ActionTrigger: new(plans.InvokeActionTrigger),
+		ProviderAddr:  actionInstance.ProviderAddr,
+		ConfigValue:   ephemeral.RemoveEphemeralValues(actionInstance.ConfigValue),
+	}
+
+	provider, _, err := getProvider(ctx, actionInstance.ProviderAddr)
+	if err != nil {
+		return diags.Append(&hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  "Failed to get provider",
+			Detail:   fmt.Sprintf("Failed to get provider while triggering action %s: %s.", n.Target, err),
+			Subject:  n.Config.DeclRange.Ptr(),
+		})
+	}
+
+	unmarkedConfig, _ := actionInstance.ConfigValue.UnmarkDeepWithPaths()
+	resp := provider.PlanAction(providers.PlanActionRequest{
+		ActionType:         n.Target.Action.Action.Type,
+		ProposedActionData: unmarkedConfig,
+		ClientCapabilities: ctx.ClientCapabilities(),
+	})
+
+	diags = diags.Append(resp.Diagnostics.InConfigBody(n.Config.Config, n.Target.ContainingAction().String()))
+	if resp.Deferred != nil {
+		return diags.Append(&hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  "Provider deferred an action",
+			Detail:   fmt.Sprintf("The provider for %s ordered the action deferred. This likely means you are executing the action against a configuration that hasn't been completely applied.", n.Target),
+			Subject:  n.Config.DeclRange.Ptr(),
+		})
+	}
+
+	ctx.Changes().AppendActionInvocation(&ai)
+	return diags
+}

--- a/internal/terraform/node_action_invoke.go
+++ b/internal/terraform/node_action_invoke.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
 package terraform
 
 import (

--- a/internal/terraform/node_action_trigger_instance_plan.go
+++ b/internal/terraform/node_action_trigger_instance_plan.go
@@ -38,8 +38,8 @@ func (at *lifecycleActionTriggerInstance) Name() string {
 	return fmt.Sprintf("%s.lifecycle.action_trigger[%d].actions[%d]", at.resourceAddress.String(), at.actionTriggerBlockIndex, at.actionListIndex)
 }
 
-func (at *lifecycleActionTriggerInstance) ActionTrigger(triggeringEvent configs.ActionTriggerEvent) plans.LifecycleActionTrigger {
-	return plans.LifecycleActionTrigger{
+func (at *lifecycleActionTriggerInstance) ActionTrigger(triggeringEvent configs.ActionTriggerEvent) *plans.LifecycleActionTrigger {
+	return &plans.LifecycleActionTrigger{
 		TriggeringResourceAddr:  at.resourceAddress,
 		ActionTriggerBlockIndex: at.actionTriggerBlockIndex,
 		ActionsListIndex:        at.actionListIndex,
@@ -95,7 +95,7 @@ func (n *nodeActionTriggerPlanInstance) Execute(ctx EvalContext, operation walkO
 	}
 
 	// If we already deferred an action invocation on the same resource with an earlier trigger we can defer this one as well
-	if deferrals.DeferralAllowed() && deferrals.ShouldDeferActionInvocation(ai) {
+	if deferrals.DeferralAllowed() && deferrals.ShouldDeferActionInvocation(ai.ActionTrigger) {
 		deferrals.ReportActionInvocationDeferred(ai, providers.DeferredReasonDeferredPrereq)
 		return diags
 	}

--- a/internal/terraform/transform_action_diff.go
+++ b/internal/terraform/transform_action_diff.go
@@ -39,7 +39,7 @@ func (t *ActionDiffTransformer) Transform(g *Graph) error {
 
 		// If the action invocations is triggered within the lifecycle of a resource
 		// we want to add information about the source location to the apply node
-		if at, ok := action.ActionTrigger.(plans.LifecycleActionTrigger); ok {
+		if at, ok := action.ActionTrigger.(*plans.LifecycleActionTrigger); ok {
 			moduleInstance := t.Config.DescendantForInstance(at.TriggeringResourceAddr.Module)
 			if moduleInstance == nil {
 				panic(fmt.Sprintf("Could not find module instance for resource %s in config", at.TriggeringResourceAddr.String()))
@@ -63,7 +63,7 @@ func (t *ActionDiffTransformer) Transform(g *Graph) error {
 		invocationMap[action] = node
 
 		// Add edge to triggering resource
-		if lat, ok := action.ActionTrigger.(plans.LifecycleActionTrigger); ok {
+		if lat, ok := action.ActionTrigger.(*plans.LifecycleActionTrigger); ok {
 			// Add edges for lifecycle action triggers
 			resourceNode, ok := applyNodes.GetOk(lat.TriggeringResourceAddr.ConfigResource())
 			if !ok {
@@ -83,6 +83,12 @@ func (t *ActionDiffTransformer) Transform(g *Graph) error {
 
 	// Find all dependencies between action invocations
 	for _, action := range t.Changes.ActionInvocations {
+		if _, ok := action.ActionTrigger.(*plans.LifecycleActionTrigger); !ok {
+			// only add dependencies between lifecycle actions. invoke actions
+			// all act independently.
+			continue
+		}
+
 		node := invocationMap[action]
 		others := action.FilterLaterActionInvocations(t.Changes.ActionInvocations)
 		for _, other := range others {

--- a/internal/terraform/transform_action_plan.go
+++ b/internal/terraform/transform_action_plan.go
@@ -38,7 +38,7 @@ func (t *ActionPlanTransformer) Transform(g *Graph) error {
 			case addrs.AbsActionInstance:
 				module := t.Config.DescendantForInstance(target.Module)
 				if module != nil {
-					config = module.Module.Actions[target.Action.String()]
+					config = module.Module.Actions[target.Action.Action.String()]
 				}
 			}
 

--- a/internal/terraform/transform_action_plan.go
+++ b/internal/terraform/transform_action_plan.go
@@ -42,6 +42,10 @@ func (t *ActionPlanTransformer) Transform(g *Graph) error {
 				}
 			}
 
+			if config == nil {
+				return fmt.Errorf("action %s does not exist in the configuration", target.String())
+			}
+
 			g.Add(&nodeActionInvokeExpand{
 				Target: target,
 				Config: config,

--- a/internal/terraform/transform_action_plan.go
+++ b/internal/terraform/transform_action_plan.go
@@ -14,6 +14,7 @@ import (
 
 type ActionPlanTransformer struct {
 	Config    *configs.Config
+	Targets   []addrs.Targetable
 	Operation walkOperation
 }
 
@@ -21,6 +22,37 @@ func (t *ActionPlanTransformer) Transform(g *Graph) error {
 	if t.Operation != walkPlan {
 		return nil
 	}
+
+	if len(t.Targets) > 0 {
+		// Then we're invoking and we're just going to include the actions that
+		// have been specifically asked for.
+
+		for _, target := range t.Targets {
+			var config *configs.Action
+			switch target := target.(type) {
+			case addrs.AbsAction:
+				module := t.Config.DescendantForInstance(target.Module)
+				if module != nil {
+					config = module.Module.Actions[target.Action.String()]
+				}
+			case addrs.AbsActionInstance:
+				module := t.Config.DescendantForInstance(target.Module)
+				if module != nil {
+					config = module.Module.Actions[target.Action.String()]
+				}
+			}
+
+			g.Add(&nodeActionInvokeExpand{
+				Target: target,
+				Config: config,
+			})
+		}
+
+		return nil
+	}
+
+	// otherwise, add all the action triggers from the config.
+
 	return t.transform(g, t.Config)
 }
 

--- a/internal/terraform/transform_config.go
+++ b/internal/terraform/transform_config.go
@@ -8,6 +8,7 @@ import (
 	"log"
 
 	"github.com/hashicorp/hcl/v2"
+
 	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/configs"
 	"github.com/hashicorp/terraform/internal/dag"
@@ -135,7 +136,7 @@ func (t *ConfigTransformer) transformSingle(g *Graph, config *configs.Config) er
 			log.Printf("[TRACE] ConfigTransformer: Adding action %s", addr)
 			node := &nodeExpandActionDeclaration{
 				Addr:   addr,
-				Config: *a,
+				Config: a,
 			}
 			g.Add(node)
 		}


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

This PR adds new "invoke" nodes into the plan graph that are added when the `-invoke` flag is used in the CLI.

This PR also makes the `-invoke` flag experimental, as the action config blocks are also experimental.

The approach is to modify the action plan transformer so when it has actions to invoke instead of adding triggers from the configuration, it instead adds nodes based on the targeted actions. The apply operation doesn't actually need any changes, as they already trigger based on the invocations in the plan and both types of triggers (lifecycle and invoked) are put into the plan the same way.

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->


## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.14.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
