### PR TITLE
Fix experimental gating of PSS feature

### DIFF
--- a/internal/command/experimental_test.go
+++ b/internal/command/experimental_test.go
@@ -1,0 +1,104 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package command
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/cli"
+)
+
+func TestInit_stateStoreBlockIsExperimental(t *testing.T) {
+
+	t.Run("init command", func(t *testing.T) {
+		// Create a temporary working directory with state_store in use
+		td := t.TempDir()
+		testCopyDir(t, testFixturePath("init-with-state-store"), td)
+		t.Chdir(td)
+
+		ui := new(cli.MockUi)
+		view, done := testView(t)
+		c := &InitCommand{
+			Meta: Meta{
+				Ui:                        ui,
+				View:                      view,
+				AllowExperimentalFeatures: false,
+			},
+		}
+
+		args := []string{}
+		code := c.Run(args)
+		testOutput := done(t)
+		if code != 1 {
+			t.Fatalf("unexpected output: \n%s", testOutput.All())
+		}
+
+		// Check output
+		output := testOutput.Stderr()
+		if !strings.Contains(output, `Blocks of type "state_store" are not expected here`) {
+			t.Fatalf("doesn't look like experiment is blocking access': %s", output)
+		}
+	})
+
+	t.Run("non-init command: plan", func(t *testing.T) {
+		// Create a temporary working directory with state_store in use
+		td := t.TempDir()
+		testCopyDir(t, testFixturePath("init-with-state-store"), td)
+		t.Chdir(td)
+
+		ui := new(cli.MockUi)
+		view, done := testView(t)
+		c := &PlanCommand{
+			Meta: Meta{
+				Ui:                        ui,
+				View:                      view,
+				AllowExperimentalFeatures: false,
+			},
+		}
+
+		args := []string{}
+		code := c.Run(args)
+		testOutput := done(t)
+		if code != 1 {
+			t.Fatalf("unexpected output: \n%s", testOutput.All())
+		}
+
+		// Check output
+		output := testOutput.Stderr()
+		if !strings.Contains(output, `Blocks of type "state_store" are not expected here`) {
+			t.Fatalf("doesn't look like experiment is blocking access': %s", output)
+		}
+	})
+
+	t.Run("non-init command: state list", func(t *testing.T) {
+		// Create a temporary working directory with state_store in use
+		td := t.TempDir()
+		testCopyDir(t, testFixturePath("init-with-state-store"), td)
+		t.Chdir(td)
+
+		ui := new(cli.MockUi)
+		view, done := testView(t)
+		c := &StateListCommand{
+			Meta: Meta{
+				Ui:                        ui,
+				View:                      view,
+				AllowExperimentalFeatures: false,
+			},
+		}
+
+		args := []string{}
+		code := c.Run(args)
+		testOutput := done(t)
+		if code != 1 {
+			t.Fatalf("unexpected output: \n%s", testOutput.All())
+		}
+
+		// Check output
+		output := ui.ErrorWriter.String()
+		if !strings.Contains(output, `Blocks of type "state_store" are not expected here`) {
+			t.Fatalf("doesn't look like experiment is blocking access': %s", output)
+		}
+	})
+}

--- a/internal/command/init_test.go
+++ b/internal/command/init_test.go
@@ -3227,36 +3227,6 @@ func TestInit_testsWithModule(t *testing.T) {
 	}
 }
 
-func TestInit_stateStoreBlockIsExperimental(t *testing.T) {
-	// Create a temporary working directory that is empty
-	td := t.TempDir()
-	testCopyDir(t, testFixturePath("init-with-state-store"), td)
-	t.Chdir(td)
-
-	ui := new(cli.MockUi)
-	view, done := testView(t)
-	c := &InitCommand{
-		Meta: Meta{
-			Ui:                        ui,
-			View:                      view,
-			AllowExperimentalFeatures: false,
-		},
-	}
-
-	args := []string{}
-	code := c.Run(args)
-	testOutput := done(t)
-	if code != 1 {
-		t.Fatalf("unexpected output: \n%s", testOutput.All())
-	}
-
-	// Check output
-	output := testOutput.Stderr()
-	if !strings.Contains(output, `Blocks of type "state_store" are not expected here`) {
-		t.Fatalf("doesn't look like experiment is blocking access': %s", output)
-	}
-}
-
 // newMockProviderSource is a helper to succinctly construct a mock provider
 // source that contains a set of packages matching the given provider versions
 // that are available for installation (from temporary local files).


### PR DESCRIPTION
After https://github.com/hashicorp/terraform/pull/37350 PSS was only gated in `init` commands.

This PR ensures that gating is present in all commands, and updates tests to give more confidence about this.

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.14.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
