### PR TITLE
Add changelog entries for Terraform Search (TF-28525)

### DIFF
--- a/.changes/v1.14/NEW FEATURES-20250829-183404.yaml
+++ b/.changes/v1.14/NEW FEATURES-20250829-183404.yaml
@@ -1,0 +1,3 @@
+kind: NEW FEATURES
+body: "**List Resources**: List resources can be defined in `*.tfquery.hcl` files and allow querying and filterting existing infrastructure."
+time: 2025-08-29T18:34:04.250038+02:00

--- a/.changes/v1.14/NEW FEATURES-20250829-184206.yaml
+++ b/.changes/v1.14/NEW FEATURES-20250829-184206.yaml
@@ -1,0 +1,3 @@
+kind: NEW FEATURES
+body: "A new Terraform command `terraform query`: Executes list operations against existing infrastructure and displays the results. The command can optionally generate configuration for importing results into Terraform."
+time: 2025-08-29T18:42:06.659172+02:00


### PR DESCRIPTION
This PR adds changelog entries for the upcoming Terraform 1.14 beta

Only merge close to the beta release date

## Rendered version

<img width="1976" height="420" alt="CleanShot 2025-08-29 at 18 51 01@2x" src="https://github.com/user-attachments/assets/2e1b74bc-a75f-4c8b-8832-c8bf5fa4344e" />

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.14.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [x] This change is user-facing and I added a changelog entry.
- [ ] This change is not user-facing.
