### PR TITLE
test fix: sort DeferredActionInvocations before making assertions

### DIFF
--- a/internal/terraform/context_plan_actions_test.go
+++ b/internal/terraform/context_plan_actions_test.go
@@ -1665,10 +1665,16 @@ resource "test_object" "a" {
 				if len(p.DeferredActionInvocations) != 2 {
 					t.Fatalf("expected 2 deferred actions in plan, got %d", len(p.DeferredActionInvocations))
 				}
+
+				sort.Slice(p.DeferredActionInvocations, func(i, j int) bool {
+					return p.DeferredActionInvocations[i].ActionInvocationInstanceSrc.Addr.String() < p.DeferredActionInvocations[j].ActionInvocationInstanceSrc.Addr.String()
+				})
+
 				firstDeferredActionInvocation := p.DeferredActionInvocations[0]
 				if firstDeferredActionInvocation.DeferredReason != providers.DeferredReasonDeferredPrereq {
 					t.Fatalf("expected deferred action to be deferred due to deferred prereq, but got %s", firstDeferredActionInvocation.DeferredReason)
 				}
+
 				if firstDeferredActionInvocation.ActionInvocationInstanceSrc.ActionTrigger.(*plans.LifecycleActionTrigger).TriggeringResourceAddr.String() != "test_object.a" {
 					t.Fatalf("expected deferred action to be triggered by test_object.a, but got %s", firstDeferredActionInvocation.ActionInvocationInstanceSrc.ActionTrigger.(*plans.LifecycleActionTrigger).TriggeringResourceAddr.String())
 				}


### PR DESCRIPTION
Addressing some flapping behavior in a test - the DeferredActionInvocations aren't in any specific order, so this sorts them first for consistent testing.

<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Fixes #

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.14.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [ ] This change is not user-facing.
