### PR TITLE
Add test helper to create mock provider that contains a state store

### DIFF
--- a/internal/command/meta_backend_test.go
+++ b/internal/command/meta_backend_test.go
@@ -2099,32 +2099,7 @@ func TestMetaBackend_configureNewStateStore(t *testing.T) {
 	//
 	// This imagines a provider called foo that contains
 	// a pluggable state store implementation called bar.
-	mock := &testing_provider.MockProvider{
-		GetProviderSchemaResponse: &providers.GetProviderSchemaResponse{
-			Provider: providers.Schema{
-				Body: &configschema.Block{
-					Attributes: map[string]*configschema.Attribute{
-						"region": {Type: cty.String, Optional: true},
-					},
-				},
-			},
-			DataSources:       map[string]providers.Schema{},
-			ResourceTypes:     map[string]providers.Schema{},
-			ListResourceTypes: map[string]providers.Schema{},
-			StateStores: map[string]providers.Schema{
-				"foo_bar": {
-					Body: &configschema.Block{
-						Attributes: map[string]*configschema.Attribute{
-							"bar": {
-								Type:     cty.String,
-								Required: true,
-							},
-						},
-					},
-				},
-			},
-		},
-	}
+	mock := testStateStoreMock(t)
 	factory := func() (providers.Interface, error) {
 		return mock, nil
 	}
@@ -2214,32 +2189,7 @@ func TestMetaBackend_reconfigureStateStoreChange(t *testing.T) {
 	//
 	// This imagines a provider called foo that contains
 	// a pluggable state store implementation called bar.
-	mock := &testing_provider.MockProvider{
-		GetProviderSchemaResponse: &providers.GetProviderSchemaResponse{
-			Provider: providers.Schema{
-				Body: &configschema.Block{
-					Attributes: map[string]*configschema.Attribute{
-						"region": {Type: cty.String, Optional: true},
-					},
-				},
-			},
-			DataSources:       map[string]providers.Schema{},
-			ResourceTypes:     map[string]providers.Schema{},
-			ListResourceTypes: map[string]providers.Schema{},
-			StateStores: map[string]providers.Schema{
-				"foo_bar": {
-					Body: &configschema.Block{
-						Attributes: map[string]*configschema.Attribute{
-							"bar": {
-								Type:     cty.String,
-								Required: true,
-							},
-						},
-					},
-				},
-			},
-		},
-	}
+	mock := testStateStoreMock(t)
 	factory := func() (providers.Interface, error) {
 		return mock, nil
 	}
@@ -2285,32 +2235,7 @@ func TestMetaBackend_changeConfiguredStateStore(t *testing.T) {
 	//
 	// This imagines a provider called foo that contains
 	// a pluggable state store implementation called bar.
-	mock := &testing_provider.MockProvider{
-		GetProviderSchemaResponse: &providers.GetProviderSchemaResponse{
-			Provider: providers.Schema{
-				Body: &configschema.Block{
-					Attributes: map[string]*configschema.Attribute{
-						"region": {Type: cty.String, Optional: true},
-					},
-				},
-			},
-			DataSources:       map[string]providers.Schema{},
-			ResourceTypes:     map[string]providers.Schema{},
-			ListResourceTypes: map[string]providers.Schema{},
-			StateStores: map[string]providers.Schema{
-				"foo_bar": {
-					Body: &configschema.Block{
-						Attributes: map[string]*configschema.Attribute{
-							"bar": {
-								Type:     cty.String,
-								Required: true,
-							},
-						},
-					},
-				},
-			},
-		},
-	}
+	mock := testStateStoreMock(t)
 	factory := func() (providers.Interface, error) {
 		return mock, nil
 	}
@@ -2353,32 +2278,7 @@ func TestMetaBackend_configuredBackendToStateStore(t *testing.T) {
 	//
 	// This imagines a provider called foo that contains
 	// a pluggable state store implementation called bar.
-	mock := &testing_provider.MockProvider{
-		GetProviderSchemaResponse: &providers.GetProviderSchemaResponse{
-			Provider: providers.Schema{
-				Body: &configschema.Block{
-					Attributes: map[string]*configschema.Attribute{
-						"region": {Type: cty.String, Optional: true},
-					},
-				},
-			},
-			DataSources:       map[string]providers.Schema{},
-			ResourceTypes:     map[string]providers.Schema{},
-			ListResourceTypes: map[string]providers.Schema{},
-			StateStores: map[string]providers.Schema{
-				"foo_bar": {
-					Body: &configschema.Block{
-						Attributes: map[string]*configschema.Attribute{
-							"bar": {
-								Type:     cty.String,
-								Required: true,
-							},
-						},
-					},
-				},
-			},
-		},
-	}
+	mock := testStateStoreMock(t)
 	factory := func() (providers.Interface, error) {
 		return mock, nil
 	}
@@ -2475,32 +2375,7 @@ func TestMetaBackend_configureStateStoreVariableUse(t *testing.T) {
 			//
 			// This imagines a provider called foo that contains
 			// a pluggable state store implementation called bar.
-			mock := &testing_provider.MockProvider{
-				GetProviderSchemaResponse: &providers.GetProviderSchemaResponse{
-					Provider: providers.Schema{
-						Body: &configschema.Block{
-							Attributes: map[string]*configschema.Attribute{
-								"region": {Type: cty.String, Optional: true},
-							},
-						},
-					},
-					DataSources:       map[string]providers.Schema{},
-					ResourceTypes:     map[string]providers.Schema{},
-					ListResourceTypes: map[string]providers.Schema{},
-					StateStores: map[string]providers.Schema{
-						"foo_bar": {
-							Body: &configschema.Block{
-								Attributes: map[string]*configschema.Attribute{
-									"bar": {
-										Type:     cty.String,
-										Required: true,
-									},
-								},
-							},
-						},
-					},
-				},
-			}
+			mock := testStateStoreMock(t)
 			factory := func() (providers.Interface, error) {
 				return mock, nil
 			}

--- a/internal/command/meta_backend_test.go
+++ b/internal/command/meta_backend_test.go
@@ -2416,7 +2416,7 @@ func testMetaBackend(t *testing.T, args []string) *Meta {
 
 // testStateStoreMock returns a mock provider that has a state store implementation
 // The provider uses the name "test" and the store inside is "test_store".
-func testStateStoreMock(t *testing.T) providers.Interface {
+func testStateStoreMock(t *testing.T) *testing_provider.MockProvider {
 	t.Helper()
 	return &testing_provider.MockProvider{
 		GetProviderSchemaResponse: &providers.GetProviderSchemaResponse{

--- a/internal/command/meta_backend_test.go
+++ b/internal/command/meta_backend_test.go
@@ -2538,3 +2538,35 @@ func testMetaBackend(t *testing.T, args []string) *Meta {
 
 	return &m
 }
+
+// testStateStoreMock returns a mock provider that has a state store implementation
+// The provider uses the name "test" and the store inside is "test_store".
+func testStateStoreMock(t *testing.T) providers.Interface {
+	t.Helper()
+	return &testing_provider.MockProvider{
+		GetProviderSchemaResponse: &providers.GetProviderSchemaResponse{
+			Provider: providers.Schema{
+				Body: &configschema.Block{
+					Attributes: map[string]*configschema.Attribute{
+						"region": {Type: cty.String, Optional: true},
+					},
+				},
+			},
+			DataSources:       map[string]providers.Schema{},
+			ResourceTypes:     map[string]providers.Schema{},
+			ListResourceTypes: map[string]providers.Schema{},
+			StateStores: map[string]providers.Schema{
+				"test_store": {
+					Body: &configschema.Block{
+						Attributes: map[string]*configschema.Attribute{
+							"value": {
+								Type:     cty.String,
+								Required: true,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}

--- a/internal/command/testdata/backend-to-state-store/main.tf
+++ b/internal/command/testdata/backend-to-state-store/main.tf
@@ -1,12 +1,12 @@
 terraform {
   required_providers {
-    foo = {
-      source = "my-org/foo"
+    test = {
+      source = "hashicorp/test"
     }
   }
-  state_store "foo_bar" {
-    provider "foo" {}
+  state_store "test_store" {
+    provider "test" {}
 
-    bar = "foobar"
+    value = "foobar"
   }
 }

--- a/internal/command/testdata/state-store-changed/.terraform/terraform.tfstate
+++ b/internal/command/testdata/state-store-changed/.terraform/terraform.tfstate
@@ -3,9 +3,9 @@
     "serial": 0,
     "lineage": "666f9301-7e65-4b19-ae23-71184bb19b03",
     "state_store": {
-        "type": "foo_bar",
+        "type": "test_store",
         "config": {
-            "bar": "old-value"
+            "value": "old-value"
         },
         "provider": {
             "version": "1.2.3",

--- a/internal/command/testdata/state-store-changed/main.tf
+++ b/internal/command/testdata/state-store-changed/main.tf
@@ -1,12 +1,12 @@
 terraform {
   required_providers {
-    foo = {
-      source = "my-org/foo"
+    test = {
+      source = "hashicorp/test"
     }
   }
-  state_store "foo_bar" {
-    provider "foo" {}
+  state_store "test_store" {
+    provider "test" {}
 
-    bar = "changed-value" # changed versus backend state file
+    value = "changed-value" # changed versus backend state file
   }
 }

--- a/internal/command/testdata/state-store-new-vars-in-provider/main.tf
+++ b/internal/command/testdata/state-store-new-vars-in-provider/main.tf
@@ -2,15 +2,15 @@ variable "foo" { default = "bar" }
 
 terraform {
   required_providers {
-    foo = {
-      source = "my-org/foo"
+    test = {
+      source = "hashicorp/test"
     }
   }
-  state_store "foo_bar" {
-    provider "foo" {
+  state_store "test_store" {
+    provider "test" {
       region = var.foo
     }
 
-    bar = "hardcoded"
+    value = "hardcoded"
   }
 }

--- a/internal/command/testdata/state-store-new-vars-in-store/main.tf
+++ b/internal/command/testdata/state-store-new-vars-in-store/main.tf
@@ -2,15 +2,15 @@ variable "foo" { default = "bar" }
 
 terraform {
   required_providers {
-    foo = {
-      source = "my-org/foo"
+    test = {
+      source = "hashicorp/test"
     }
   }
-  state_store "foo_bar" {
-    provider "foo" {
+  state_store "test_store" {
+    provider "test" {
       region = "hardcoded"
     }
 
-    bar = var.foo
+    value = var.foo
   }
 }

--- a/internal/command/testdata/state-store-new/main.tf
+++ b/internal/command/testdata/state-store-new/main.tf
@@ -1,12 +1,12 @@
 terraform {
   required_providers {
-    foo = {
-      source = "my-org/foo"
+    test = {
+      source = "hashicorp/test"
     }
   }
-  state_store "foo_bar" {
-    provider "foo" {}
+  state_store "test_store" {
+    provider "test" {}
 
-    bar = "foobar"
+    value = "foobar"
   }
 }

--- a/internal/command/testdata/state-store-reconfigure/.terraform/terraform.tfstate
+++ b/internal/command/testdata/state-store-reconfigure/.terraform/terraform.tfstate
@@ -3,9 +3,9 @@
     "serial": 0,
     "lineage": "666f9301-7e65-4b19-ae23-71184bb19b03",
     "state_store": {
-        "type": "foo_bar",
+        "type": "test_store",
         "config": {
-            "bar": "old-value"
+            "value": "old-value"
         },
         "provider": {
             "version": "1.2.3",

--- a/internal/command/testdata/state-store-reconfigure/main.tf
+++ b/internal/command/testdata/state-store-reconfigure/main.tf
@@ -1,12 +1,12 @@
 terraform {
   required_providers {
-    foo = {
-      source = "my-org/foo"
+    test = {
+      source = "hashicorp/test"
     }
   }
-  state_store "foo_bar" {
-    provider "foo" {}
+  state_store "test_store" {
+    provider "test" {}
 
-    bar = "changed-value" # changed versus backend state file
+    value = "changed-value" # changed versus backend state file
   }
 }

--- a/internal/command/testdata/state-store-to-backend/.terraform/terraform.tfstate
+++ b/internal/command/testdata/state-store-to-backend/.terraform/terraform.tfstate
@@ -3,9 +3,9 @@
     "serial": 0,
     "lineage": "666f9301-7e65-4b19-ae23-71184bb19b03",
     "state_store": {
-        "type": "foo_bar",
+        "type": "test_store",
         "config": {
-            "bar": "foobar"
+            "value": "foobar"
         },
         "provider": {
             "version": "1.2.3",

--- a/internal/command/testdata/state-store-unset/.terraform/terraform.tfstate
+++ b/internal/command/testdata/state-store-unset/.terraform/terraform.tfstate
@@ -3,9 +3,9 @@
     "serial": 0,
     "lineage": "666f9301-7e65-4b19-ae23-71184bb19b03",
     "state_store": {
-        "type": "foo_bar",
+        "type": "test_store",
         "config": {
-            "bar": "foobar"
+            "value": "foobar"
         },
         "provider": {
             "version": "1.2.3",

--- a/internal/configs/testdata/invalid-modules/conflict-cloud-backend-statestore/main.tf
+++ b/internal/configs/testdata/invalid-modules/conflict-cloud-backend-statestore/main.tf
@@ -8,9 +8,14 @@ terraform {
     }
   }
 
-  state_store "foo_bar" {
-    provider "foo" {}
+  required_providers {
+    test = {
+      source = "hashicorp/test"
+    }
+  }
+  state_store "test_store" {
+    provider "test" {}
 
-    custom_attr = "override"
+    value = "override"
   }
 }

--- a/internal/configs/testdata/invalid-modules/conflict-cloud-statestore-separate-files/state-store.tf
+++ b/internal/configs/testdata/invalid-modules/conflict-cloud-statestore-separate-files/state-store.tf
@@ -1,6 +1,11 @@
 terraform {
-  state_store "foo_bar" {
-    provider "foo" {}
+  required_providers {
+    test = {
+      source = "hashicorp/test"
+    }
+  }
+  state_store "test_store" {
+    provider "test" {}
 
     custom_attr = "override"
   }

--- a/internal/configs/testdata/invalid-modules/conflict-cloud-statestore/main.tf
+++ b/internal/configs/testdata/invalid-modules/conflict-cloud-statestore/main.tf
@@ -6,9 +6,14 @@ terraform {
     }
   }
 
-  state_store "foo_bar" {
-    provider "foo" {}
+  required_providers {
+    test = {
+      source = "hashicorp/test"
+    }
+  }
+  state_store "test_store" {
+    provider "test" {}
 
-    custom_attr = "override"
+    value = "override"
   }
 }

--- a/internal/configs/testdata/invalid-modules/conflict-statestore-backend-separate-files/state-store.tf
+++ b/internal/configs/testdata/invalid-modules/conflict-statestore-backend-separate-files/state-store.tf
@@ -1,6 +1,11 @@
 terraform {
-  state_store "foo_bar" {
-    provider "foo" {}
+  required_providers {
+    test = {
+      source = "hashicorp/test"
+    }
+  }
+  state_store "test_store" {
+    provider "test" {}
 
     custom_attr = "override"
   }

--- a/internal/configs/testdata/invalid-modules/conflict-statestore-backend/main.tf
+++ b/internal/configs/testdata/invalid-modules/conflict-statestore-backend/main.tf
@@ -1,9 +1,14 @@
 terraform {
   backend "foo" {}
 
-  state_store "foo_bar" {
-    provider "foo" {}
+  required_providers {
+    test = {
+      source = "hashicorp/test"
+    }
+  }
+  state_store "test_store" {
+    provider "test" {}
 
-    custom_attr = "override"
+    value = "override"
   }
 }

--- a/internal/configs/testdata/invalid-modules/multiple-state-store/a.tf
+++ b/internal/configs/testdata/invalid-modules/multiple-state-store/a.tf
@@ -1,6 +1,11 @@
 terraform {
-  state_store "foo_bar" {
-    provider "foo" {}
+  required_providers {
+    test = {
+      source = "hashicorp/test"
+    }
+  }
+  state_store "test_store" {
+    provider "test" {}
 
     custom_attr = "override"
   }

--- a/internal/configs/testdata/valid-modules/override-state-store-no-base/override.tf
+++ b/internal/configs/testdata/valid-modules/override-state-store-no-base/override.tf
@@ -1,14 +1,14 @@
 terraform {
   required_providers {
-    foo = {
-      source = "my-org/foo"
+    test = {
+      source = "hashicorp/test"
     }
   }
-  state_store "foo_bar" {
-    provider "foo" {}
+  state_store "test_store" {
+    provider "test" {}
 
-    custom_attr = "foobar"
+    value = "foobar"
   }
 }
 
-provider "foo" {}
+provider "test" {}

--- a/internal/configs/testdata/valid-modules/override-state-store/main.tf
+++ b/internal/configs/testdata/valid-modules/override-state-store/main.tf
@@ -1,13 +1,13 @@
 terraform {
   required_providers {
-    foo = {
-      source = "my-org/foo"
+    test = {
+      source = "hashicorp/test"
     }
   }
-  state_store "foo_bar" {
-    provider "foo" {}
+  state_store "test_store" {
+    provider "test" {}
 
-    custom_attr = "foobar"
+    value = "foobar"
   }
 }
 


### PR DESCRIPTION
This reduces repetitive code in these tests, but requires the test fixtures to be updated to use the correct provider and state store names

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

N/A

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
