### PR TITLE
Pss/add saved state store method

### DIFF
--- a/internal/command/meta_backend.go
+++ b/internal/command/meta_backend.go
@@ -27,6 +27,7 @@ import (
 	"github.com/hashicorp/terraform/internal/backend/backendrun"
 	backendInit "github.com/hashicorp/terraform/internal/backend/init"
 	backendLocal "github.com/hashicorp/terraform/internal/backend/local"
+	backendPluggable "github.com/hashicorp/terraform/internal/backend/pluggable"
 	"github.com/hashicorp/terraform/internal/cloud"
 	"github.com/hashicorp/terraform/internal/command/arguments"
 	"github.com/hashicorp/terraform/internal/command/clistate"
@@ -39,6 +40,7 @@ import (
 	"github.com/hashicorp/terraform/internal/states/statemgr"
 	"github.com/hashicorp/terraform/internal/terraform"
 	"github.com/hashicorp/terraform/internal/tfdiags"
+	tfversion "github.com/hashicorp/terraform/version"
 )
 
 // BackendOpts are the options used to initialize a backendrun.OperationsBackend.
@@ -1523,6 +1525,140 @@ func (m *Meta) updateSavedBackendHash(cHash int, sMgr *clistate.LocalState) tfdi
 	}
 
 	return diags
+}
+
+// Initializing a saved state store from the backend state file (aka 'cache file', aka 'legacy state file')
+func (m *Meta) savedStateStore(sMgr *clistate.LocalState, providerFactory providers.Factory) (backend.Backend, tfdiags.Diagnostics) {
+	// We're preparing a state_store version of backend.Backend.
+	//
+	// The provider and state store will be configured using the backend state file.
+
+	var diags tfdiags.Diagnostics
+	var b backend.Backend
+
+	s := sMgr.State()
+
+	provider, err := providerFactory()
+	if err != nil {
+		diags = diags.Append(fmt.Errorf("error when obtaining provider instance during state store initialization: %w", err))
+		return nil, diags
+	}
+	// We purposefully don't have a deferred call to the provider's Close method here because the calling code needs a
+	// running provider instance inside the returned backend.Backend instance.
+	// Stopping the provider process is the responsibility of the calling code.
+
+	resp := provider.GetProviderSchema()
+
+	if len(resp.StateStores) == 0 {
+		diags = diags.Append(&hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  "Provider does not support pluggable state storage",
+			Detail: fmt.Sprintf("There are no state stores implemented by provider %s (%q)",
+				s.StateStore.Provider.Source.Type,
+				s.StateStore.Provider.Source),
+		})
+		return nil, diags
+	}
+
+	stateStoreSchema, exists := resp.StateStores[s.StateStore.Type]
+	if !exists {
+		suggestions := slices.Sorted(maps.Keys(resp.StateStores))
+		suggestion := didyoumean.NameSuggestion(s.StateStore.Type, suggestions)
+		if suggestion != "" {
+			suggestion = fmt.Sprintf(" Did you mean %q?", suggestion)
+		}
+		diags = diags.Append(&hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  "State store not implemented by the provider",
+			Detail: fmt.Sprintf("State store %q is not implemented by provider %s (%q)%s",
+				s.StateStore.Type,
+				s.StateStore.Provider.Source.Type,
+				s.StateStore.Provider.Source,
+				suggestion),
+		})
+		return nil, diags
+	}
+
+	// Get the provider config from the backend state file.
+	providerConfigVal, err := s.StateStore.Provider.Config(resp.Provider.Body)
+	if err != nil {
+		diags = diags.Append(
+			&hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  "Error reading provider configuration state",
+				Detail: fmt.Sprintf("Terraform experienced an error reading provider configuration for provider %s (%q) while configuring state store %s",
+					s.StateStore.Provider.Source.Type,
+					s.StateStore.Provider.Source,
+					s.StateStore.Type,
+				),
+			},
+		)
+		return nil, diags
+	}
+
+	// Get the state store config from the backend state file.
+	stateStoreConfigVal, err := s.StateStore.Config(stateStoreSchema.Body)
+	if err != nil {
+		diags = diags.Append(
+			&hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  "Error reading state store configuration state",
+				Detail: fmt.Sprintf("Terraform experienced an error reading state store configuration for state store %s in provider %s (%q)",
+					s.StateStore.Type,
+					s.StateStore.Provider.Source.Type,
+					s.StateStore.Provider.Source,
+				),
+			},
+		)
+		return nil, diags
+	}
+
+	// Validate and configure the provider
+	validateResp := provider.ValidateProviderConfig(providers.ValidateProviderConfigRequest{
+		Config: providerConfigVal,
+	})
+	diags = diags.Append(validateResp.Diagnostics)
+	if diags.HasErrors() {
+		return nil, diags
+	}
+
+	configureResp := provider.ConfigureProvider(providers.ConfigureProviderRequest{
+		TerraformVersion: tfversion.SemVer.String(),
+		Config:           validateResp.PreparedConfig,
+	})
+	diags = diags.Append(configureResp.Diagnostics)
+	if diags.HasErrors() {
+		return nil, diags
+	}
+
+	// Validate store config
+	validateStoreResp := provider.ValidateStateStoreConfig(providers.ValidateStateStoreConfigRequest{
+		TypeName: s.StateStore.Type,
+		Config:   stateStoreConfigVal,
+	})
+	diags = diags.Append(validateStoreResp.Diagnostics)
+	if diags.HasErrors() {
+		return nil, diags
+	}
+
+	// Configure state store
+	cfgStoreResp := provider.ConfigureStateStore(providers.ConfigureStateStoreRequest{
+		TypeName: s.StateStore.Type,
+		Config:   stateStoreConfigVal,
+	})
+	diags = diags.Append(cfgStoreResp.Diagnostics)
+	if diags.HasErrors() {
+		return nil, diags
+	}
+
+	// Now we have a fully configured state store, ready to be used.
+	// To make it usable we need to return it in a backend.Backend interface.
+	b, err = backendPluggable.NewPluggable(provider, s.StateStore.Type)
+	if err != nil {
+		diags = diags.Append(err)
+	}
+
+	return b, diags
 }
 
 //-------------------------------------------------------------------

--- a/internal/command/meta_backend_test.go
+++ b/internal/command/meta_backend_test.go
@@ -2448,7 +2448,7 @@ func testMetaBackend(t *testing.T, args []string) *Meta {
 
 // testStateStoreMock returns a mock provider that has a state store implementation
 // The provider uses the name "test" and the store inside is "test_store".
-func testStateStoreMock(t *testing.T) providers.Interface {
+func testStateStoreMock(t *testing.T) *testing_provider.MockProvider {
 	t.Helper()
 	return &testing_provider.MockProvider{
 		GetProviderSchemaResponse: &providers.GetProviderSchemaResponse{

--- a/internal/command/meta_backend_test.go
+++ b/internal/command/meta_backend_test.go
@@ -2099,32 +2099,7 @@ func TestMetaBackend_configureNewStateStore(t *testing.T) {
 	//
 	// This imagines a provider called foo that contains
 	// a pluggable state store implementation called bar.
-	mock := &testing_provider.MockProvider{
-		GetProviderSchemaResponse: &providers.GetProviderSchemaResponse{
-			Provider: providers.Schema{
-				Body: &configschema.Block{
-					Attributes: map[string]*configschema.Attribute{
-						"region": {Type: cty.String, Optional: true},
-					},
-				},
-			},
-			DataSources:       map[string]providers.Schema{},
-			ResourceTypes:     map[string]providers.Schema{},
-			ListResourceTypes: map[string]providers.Schema{},
-			StateStores: map[string]providers.Schema{
-				"foo_bar": {
-					Body: &configschema.Block{
-						Attributes: map[string]*configschema.Attribute{
-							"bar": {
-								Type:     cty.String,
-								Required: true,
-							},
-						},
-					},
-				},
-			},
-		},
-	}
+	mock := testStateStoreMock(t)
 	factory := func() (providers.Interface, error) {
 		return mock, nil
 	}
@@ -2214,32 +2189,7 @@ func TestMetaBackend_reconfigureStateStoreChange(t *testing.T) {
 	//
 	// This imagines a provider called foo that contains
 	// a pluggable state store implementation called bar.
-	mock := &testing_provider.MockProvider{
-		GetProviderSchemaResponse: &providers.GetProviderSchemaResponse{
-			Provider: providers.Schema{
-				Body: &configschema.Block{
-					Attributes: map[string]*configschema.Attribute{
-						"region": {Type: cty.String, Optional: true},
-					},
-				},
-			},
-			DataSources:       map[string]providers.Schema{},
-			ResourceTypes:     map[string]providers.Schema{},
-			ListResourceTypes: map[string]providers.Schema{},
-			StateStores: map[string]providers.Schema{
-				"foo_bar": {
-					Body: &configschema.Block{
-						Attributes: map[string]*configschema.Attribute{
-							"bar": {
-								Type:     cty.String,
-								Required: true,
-							},
-						},
-					},
-				},
-			},
-		},
-	}
+	mock := testStateStoreMock(t)
 	factory := func() (providers.Interface, error) {
 		return mock, nil
 	}
@@ -2285,32 +2235,7 @@ func TestMetaBackend_changeConfiguredStateStore(t *testing.T) {
 	//
 	// This imagines a provider called foo that contains
 	// a pluggable state store implementation called bar.
-	mock := &testing_provider.MockProvider{
-		GetProviderSchemaResponse: &providers.GetProviderSchemaResponse{
-			Provider: providers.Schema{
-				Body: &configschema.Block{
-					Attributes: map[string]*configschema.Attribute{
-						"region": {Type: cty.String, Optional: true},
-					},
-				},
-			},
-			DataSources:       map[string]providers.Schema{},
-			ResourceTypes:     map[string]providers.Schema{},
-			ListResourceTypes: map[string]providers.Schema{},
-			StateStores: map[string]providers.Schema{
-				"foo_bar": {
-					Body: &configschema.Block{
-						Attributes: map[string]*configschema.Attribute{
-							"bar": {
-								Type:     cty.String,
-								Required: true,
-							},
-						},
-					},
-				},
-			},
-		},
-	}
+	mock := testStateStoreMock(t)
 	factory := func() (providers.Interface, error) {
 		return mock, nil
 	}
@@ -2353,32 +2278,7 @@ func TestMetaBackend_configuredBackendToStateStore(t *testing.T) {
 	//
 	// This imagines a provider called foo that contains
 	// a pluggable state store implementation called bar.
-	mock := &testing_provider.MockProvider{
-		GetProviderSchemaResponse: &providers.GetProviderSchemaResponse{
-			Provider: providers.Schema{
-				Body: &configschema.Block{
-					Attributes: map[string]*configschema.Attribute{
-						"region": {Type: cty.String, Optional: true},
-					},
-				},
-			},
-			DataSources:       map[string]providers.Schema{},
-			ResourceTypes:     map[string]providers.Schema{},
-			ListResourceTypes: map[string]providers.Schema{},
-			StateStores: map[string]providers.Schema{
-				"foo_bar": {
-					Body: &configschema.Block{
-						Attributes: map[string]*configschema.Attribute{
-							"bar": {
-								Type:     cty.String,
-								Required: true,
-							},
-						},
-					},
-				},
-			},
-		},
-	}
+	mock := testStateStoreMock(t)
 	factory := func() (providers.Interface, error) {
 		return mock, nil
 	}
@@ -2475,32 +2375,7 @@ func TestMetaBackend_configureStateStoreVariableUse(t *testing.T) {
 			//
 			// This imagines a provider called foo that contains
 			// a pluggable state store implementation called bar.
-			mock := &testing_provider.MockProvider{
-				GetProviderSchemaResponse: &providers.GetProviderSchemaResponse{
-					Provider: providers.Schema{
-						Body: &configschema.Block{
-							Attributes: map[string]*configschema.Attribute{
-								"region": {Type: cty.String, Optional: true},
-							},
-						},
-					},
-					DataSources:       map[string]providers.Schema{},
-					ResourceTypes:     map[string]providers.Schema{},
-					ListResourceTypes: map[string]providers.Schema{},
-					StateStores: map[string]providers.Schema{
-						"foo_bar": {
-							Body: &configschema.Block{
-								Attributes: map[string]*configschema.Attribute{
-									"bar": {
-										Type:     cty.String,
-										Required: true,
-									},
-								},
-							},
-						},
-					},
-				},
-			}
+			mock := testStateStoreMock(t)
 			factory := func() (providers.Interface, error) {
 				return mock, nil
 			}

--- a/internal/command/meta_backend_test.go
+++ b/internal/command/meta_backend_test.go
@@ -2538,3 +2538,35 @@ func testMetaBackend(t *testing.T, args []string) *Meta {
 
 	return &m
 }
+
+// testStateStoreMock returns a mock provider that has a state store implementation
+// The provider uses the name "test" and the store inside is "test_store".
+func testStateStoreMock(t *testing.T) providers.Interface {
+	t.Helper()
+	return &testing_provider.MockProvider{
+		GetProviderSchemaResponse: &providers.GetProviderSchemaResponse{
+			Provider: providers.Schema{
+				Body: &configschema.Block{
+					Attributes: map[string]*configschema.Attribute{
+						"region": {Type: cty.String, Optional: true},
+					},
+				},
+			},
+			DataSources:       map[string]providers.Schema{},
+			ResourceTypes:     map[string]providers.Schema{},
+			ListResourceTypes: map[string]providers.Schema{},
+			StateStores: map[string]providers.Schema{
+				"test_store": {
+					Body: &configschema.Block{
+						Attributes: map[string]*configschema.Attribute{
+							"value": {
+								Type:     cty.String,
+								Required: true,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}

--- a/internal/command/testdata/backend-to-state-store/main.tf
+++ b/internal/command/testdata/backend-to-state-store/main.tf
@@ -1,12 +1,12 @@
 terraform {
   required_providers {
-    foo = {
-      source = "my-org/foo"
+    test = {
+      source = "hashicorp/test"
     }
   }
-  state_store "foo_bar" {
-    provider "foo" {}
+  state_store "test_store" {
+    provider "test" {}
 
-    bar = "foobar"
+    value = "foobar"
   }
 }

--- a/internal/command/testdata/state-store-changed/.terraform/terraform.tfstate
+++ b/internal/command/testdata/state-store-changed/.terraform/terraform.tfstate
@@ -10,7 +10,9 @@
         "provider": {
             "version": "1.2.3",
             "source": "registry.terraform.io/my-org/foo",
-            "config": {},
+            "config": {
+                "region": "old-value"
+            },
             "hash": 12345
         },
         "hash": 12345

--- a/internal/command/testdata/state-store-changed/.terraform/terraform.tfstate
+++ b/internal/command/testdata/state-store-changed/.terraform/terraform.tfstate
@@ -3,9 +3,9 @@
     "serial": 0,
     "lineage": "666f9301-7e65-4b19-ae23-71184bb19b03",
     "state_store": {
-        "type": "foo_bar",
+        "type": "test_store",
         "config": {
-            "bar": "old-value"
+            "value": "old-value"
         },
         "provider": {
             "version": "1.2.3",

--- a/internal/command/testdata/state-store-changed/main.tf
+++ b/internal/command/testdata/state-store-changed/main.tf
@@ -1,12 +1,12 @@
 terraform {
   required_providers {
-    foo = {
-      source = "my-org/foo"
+    test = {
+      source = "hashicorp/test"
     }
   }
-  state_store "foo_bar" {
-    provider "foo" {}
+  state_store "test_store" {
+    provider "test" {}
 
-    bar = "changed-value" # changed versus backend state file
+    value = "changed-value" # changed versus backend state file
   }
 }

--- a/internal/command/testdata/state-store-changed/main.tf
+++ b/internal/command/testdata/state-store-changed/main.tf
@@ -5,7 +5,9 @@ terraform {
     }
   }
   state_store "test_store" {
-    provider "test" {}
+    provider "test" {
+      region = "changed-value" # changed versus backend state file
+    }
 
     value = "changed-value" # changed versus backend state file
   }

--- a/internal/command/testdata/state-store-new-vars-in-provider/main.tf
+++ b/internal/command/testdata/state-store-new-vars-in-provider/main.tf
@@ -2,15 +2,15 @@ variable "foo" { default = "bar" }
 
 terraform {
   required_providers {
-    foo = {
-      source = "my-org/foo"
+    test = {
+      source = "hashicorp/test"
     }
   }
-  state_store "foo_bar" {
-    provider "foo" {
+  state_store "test_store" {
+    provider "test" {
       region = var.foo
     }
 
-    bar = "hardcoded"
+    value = "hardcoded"
   }
 }

--- a/internal/command/testdata/state-store-new-vars-in-store/main.tf
+++ b/internal/command/testdata/state-store-new-vars-in-store/main.tf
@@ -2,15 +2,15 @@ variable "foo" { default = "bar" }
 
 terraform {
   required_providers {
-    foo = {
-      source = "my-org/foo"
+    test = {
+      source = "hashicorp/test"
     }
   }
-  state_store "foo_bar" {
-    provider "foo" {
+  state_store "test_store" {
+    provider "test" {
       region = "hardcoded"
     }
 
-    bar = var.foo
+    value = var.foo
   }
 }

--- a/internal/command/testdata/state-store-new/main.tf
+++ b/internal/command/testdata/state-store-new/main.tf
@@ -1,12 +1,12 @@
 terraform {
   required_providers {
-    foo = {
-      source = "my-org/foo"
+    test = {
+      source = "hashicorp/test"
     }
   }
-  state_store "foo_bar" {
-    provider "foo" {}
+  state_store "test_store" {
+    provider "test" {}
 
-    bar = "foobar"
+    value = "foobar"
   }
 }

--- a/internal/command/testdata/state-store-reconfigure/.terraform/terraform.tfstate
+++ b/internal/command/testdata/state-store-reconfigure/.terraform/terraform.tfstate
@@ -3,9 +3,9 @@
     "serial": 0,
     "lineage": "666f9301-7e65-4b19-ae23-71184bb19b03",
     "state_store": {
-        "type": "foo_bar",
+        "type": "test_store",
         "config": {
-            "bar": "old-value"
+            "value": "old-value"
         },
         "provider": {
             "version": "1.2.3",

--- a/internal/command/testdata/state-store-reconfigure/main.tf
+++ b/internal/command/testdata/state-store-reconfigure/main.tf
@@ -1,12 +1,12 @@
 terraform {
   required_providers {
-    foo = {
-      source = "my-org/foo"
+    test = {
+      source = "hashicorp/test"
     }
   }
-  state_store "foo_bar" {
-    provider "foo" {}
+  state_store "test_store" {
+    provider "test" {}
 
-    bar = "changed-value" # changed versus backend state file
+    value = "changed-value" # changed versus backend state file
   }
 }

--- a/internal/command/testdata/state-store-to-backend/.terraform/terraform.tfstate
+++ b/internal/command/testdata/state-store-to-backend/.terraform/terraform.tfstate
@@ -3,9 +3,9 @@
     "serial": 0,
     "lineage": "666f9301-7e65-4b19-ae23-71184bb19b03",
     "state_store": {
-        "type": "foo_bar",
+        "type": "test_store",
         "config": {
-            "bar": "foobar"
+            "value": "foobar"
         },
         "provider": {
             "version": "1.2.3",

--- a/internal/command/testdata/state-store-unset/.terraform/terraform.tfstate
+++ b/internal/command/testdata/state-store-unset/.terraform/terraform.tfstate
@@ -3,9 +3,9 @@
     "serial": 0,
     "lineage": "666f9301-7e65-4b19-ae23-71184bb19b03",
     "state_store": {
-        "type": "foo_bar",
+        "type": "test_store",
         "config": {
-            "bar": "foobar"
+            "value": "foobar"
         },
         "provider": {
             "version": "1.2.3",

--- a/internal/configs/testdata/invalid-modules/conflict-cloud-backend-statestore/main.tf
+++ b/internal/configs/testdata/invalid-modules/conflict-cloud-backend-statestore/main.tf
@@ -8,9 +8,14 @@ terraform {
     }
   }
 
-  state_store "foo_bar" {
-    provider "foo" {}
+  required_providers {
+    test = {
+      source = "hashicorp/test"
+    }
+  }
+  state_store "test_store" {
+    provider "test" {}
 
-    custom_attr = "override"
+    value = "override"
   }
 }

--- a/internal/configs/testdata/invalid-modules/conflict-cloud-statestore-separate-files/state-store.tf
+++ b/internal/configs/testdata/invalid-modules/conflict-cloud-statestore-separate-files/state-store.tf
@@ -1,6 +1,11 @@
 terraform {
-  state_store "foo_bar" {
-    provider "foo" {}
+  required_providers {
+    test = {
+      source = "hashicorp/test"
+    }
+  }
+  state_store "test_store" {
+    provider "test" {}
 
     custom_attr = "override"
   }

--- a/internal/configs/testdata/invalid-modules/conflict-cloud-statestore/main.tf
+++ b/internal/configs/testdata/invalid-modules/conflict-cloud-statestore/main.tf
@@ -6,9 +6,14 @@ terraform {
     }
   }
 
-  state_store "foo_bar" {
-    provider "foo" {}
+  required_providers {
+    test = {
+      source = "hashicorp/test"
+    }
+  }
+  state_store "test_store" {
+    provider "test" {}
 
-    custom_attr = "override"
+    value = "override"
   }
 }

--- a/internal/configs/testdata/invalid-modules/conflict-statestore-backend-separate-files/state-store.tf
+++ b/internal/configs/testdata/invalid-modules/conflict-statestore-backend-separate-files/state-store.tf
@@ -1,6 +1,11 @@
 terraform {
-  state_store "foo_bar" {
-    provider "foo" {}
+  required_providers {
+    test = {
+      source = "hashicorp/test"
+    }
+  }
+  state_store "test_store" {
+    provider "test" {}
 
     custom_attr = "override"
   }

--- a/internal/configs/testdata/invalid-modules/conflict-statestore-backend/main.tf
+++ b/internal/configs/testdata/invalid-modules/conflict-statestore-backend/main.tf
@@ -1,9 +1,14 @@
 terraform {
   backend "foo" {}
 
-  state_store "foo_bar" {
-    provider "foo" {}
+  required_providers {
+    test = {
+      source = "hashicorp/test"
+    }
+  }
+  state_store "test_store" {
+    provider "test" {}
 
-    custom_attr = "override"
+    value = "override"
   }
 }

--- a/internal/configs/testdata/invalid-modules/multiple-state-store/a.tf
+++ b/internal/configs/testdata/invalid-modules/multiple-state-store/a.tf
@@ -1,6 +1,11 @@
 terraform {
-  state_store "foo_bar" {
-    provider "foo" {}
+  required_providers {
+    test = {
+      source = "hashicorp/test"
+    }
+  }
+  state_store "test_store" {
+    provider "test" {}
 
     custom_attr = "override"
   }

--- a/internal/configs/testdata/valid-modules/override-state-store-no-base/override.tf
+++ b/internal/configs/testdata/valid-modules/override-state-store-no-base/override.tf
@@ -1,14 +1,14 @@
 terraform {
   required_providers {
-    foo = {
-      source = "my-org/foo"
+    test = {
+      source = "hashicorp/test"
     }
   }
-  state_store "foo_bar" {
-    provider "foo" {}
+  state_store "test_store" {
+    provider "test" {}
 
-    custom_attr = "foobar"
+    value = "foobar"
   }
 }
 
-provider "foo" {}
+provider "test" {}

--- a/internal/configs/testdata/valid-modules/override-state-store/main.tf
+++ b/internal/configs/testdata/valid-modules/override-state-store/main.tf
@@ -1,13 +1,13 @@
 terraform {
   required_providers {
-    foo = {
-      source = "my-org/foo"
+    test = {
+      source = "hashicorp/test"
     }
   }
-  state_store "foo_bar" {
-    provider "foo" {}
+  state_store "test_store" {
+    provider "test" {}
 
-    custom_attr = "foobar"
+    value = "foobar"
   }
 }
 


### PR DESCRIPTION
## Description

_**This PR adds a new `savedStateStore` method that's similar to the existing `savedBackend` method on `Meta`.**_

The `savedBackend` method on Meta returns a backend that's configured using the backend state file's contents and isn't influenced by the current config. This method is used during state migration events in `init` commands, where Terraform needs to have an instance of the old backend, configured the old way, in order to access state to migrate to the new backend's location.

Note:  [There is a variant](https://github.com/hashicorp/terraform/blob/54af16eab9ec914ca3b9e63b44e9f322d157f9fb/internal/command/meta_backend.go#L979-L983) called `backendFromState` that does a similar job but isn't considered in this PR. This variant is specific to users running init commands with `-backend=false` as a flag.

This PR adds a new `savedStateStore` method that's similar to the existing `savedBackend` method on `Meta`. The method uses only backend state file data to configure and return a backend.Backend instance made using a provider that implements pluggable state storage.


## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.14.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [ ] This change is not user-facing.
