### PR TITLE
Allow duplicate list names for different types

### DIFF
--- a/internal/configs/parser_config_dir_test.go
+++ b/internal/configs/parser_config_dir_test.go
@@ -175,7 +175,7 @@ func TestParserLoadConfigDirWithQueries(t *testing.T) {
 		{
 			name:             "mixed",
 			directory:        "testdata/query-files/valid/mixed",
-			listResources:    2,
+			listResources:    3,
 			managedResources: 1,
 			allowExperiments: true,
 		},

--- a/internal/configs/query_file.go
+++ b/internal/configs/query_file.go
@@ -39,7 +39,7 @@ func loadQueryFile(body hcl.Body) (*QueryFile, hcl.Diagnostics) {
 	content, contentDiags := body.Content(queryFileSchema)
 	diags = append(diags, contentDiags...)
 
-	listBlockNames := make(map[string]hcl.Range)
+	listBlockTypes := make(map[string]map[string]hcl.Range)
 
 	for _, block := range content.Blocks {
 		switch block.Type {
@@ -50,16 +50,20 @@ func loadQueryFile(body hcl.Body) (*QueryFile, hcl.Diagnostics) {
 				file.ListResources = append(file.ListResources, list)
 			}
 
-			if rng, exists := listBlockNames[list.Name]; exists {
+			if _, exists := listBlockTypes[list.Type]; !exists {
+				listBlockTypes[list.Type] = make(map[string]hcl.Range)
+			}
+			if rng, exists := listBlockTypes[list.Type][list.Name]; exists {
 				diags = append(diags, &hcl.Diagnostic{
 					Severity: hcl.DiagError,
 					Summary:  "Duplicate \"list\" block names",
-					Detail:   fmt.Sprintf("This query file already has a list block named %s defined at %s.", list.Name, rng),
+					Detail:   fmt.Sprintf("This query file already has a list block named %s.%s defined at %s.", list.Type, list.Name, rng),
 					Subject:  block.DefRange.Ptr(),
 				})
 				continue
 			}
-			listBlockNames[list.Name] = list.DeclRange
+
+			listBlockTypes[list.Type][list.Name] = list.DeclRange
 		case "provider":
 			cfg, cfgDiags := decodeProviderBlock(block, false)
 			diags = append(diags, cfgDiags...)

--- a/internal/configs/testdata/query-files/valid/mixed/main.tfquery.hcl
+++ b/internal/configs/testdata/query-files/valid/mixed/main.tfquery.hcl
@@ -16,3 +16,13 @@ list "aws_instance" "test2" {
     }
   }
 }
+
+list "aws_ec2" "test" {
+  provider = aws
+  count = 1
+  config {
+    tags = {
+      Name = join("-", ["test", list.aws_instance.test.data[0]])
+    }
+  }
+}


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

This fixes a bug that prevented the definition of list resources of different types, but same name. e.g `list.foo.test` and `list.bar.test` within a query file.

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.14.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [ ] This change is not user-facing.
