### PR TITLE
apply: include sensitive metadata when comparing changed input values

### DIFF
--- a/.changes/v1.14/BUG FIXES-20250910-095424.yaml
+++ b/.changes/v1.14/BUG FIXES-20250910-095424.yaml
@@ -1,0 +1,5 @@
+kind: BUG FIXES
+body: 'apply: hide sensitive inputs when values have changed between plan and apply'
+time: 2025-09-10T09:54:24.889605+02:00
+custom:
+    Issue: "37582"

--- a/internal/command/testdata/apply-sensitive-variable/main.tf
+++ b/internal/command/testdata/apply-sensitive-variable/main.tf
@@ -1,0 +1,9 @@
+variable "shadow" {
+  type = string
+  sensitive = true
+}
+
+output "foo" {
+  value = var.shadow
+  sensitive = true
+}


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

This PR updates the output for when input values have erroneously changed between plan and apply so that sensitive input values are hidden in the error message.

This approach just rechecks the actual configuration for sensitive values, and applies those marks to the rendered outputs. Interestingly, the plan itself does not contain the information from the configuration, even those it does have room for the marks to be added. [This comment](https://github.com/hashicorp/terraform/blob/main/internal/terraform/context_plan.go#L376-L383) suggests that this is deliberate, so I didn't change that behaviour. 

Another approach would be to change that behaviour and add the marks from the config during the plan stage, and then just apply the marks from the plan instead of rechecking the config. I was worried about unintended side effects etc, so I went with just rechecking the config but am happy to go and make the more complete change if anyone feels strongly about it.

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Fixes #37563

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.13.2

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [x] This change is user-facing and I added a changelog entry.
- [ ] This change is not user-facing.
