### PR TITLE
Update calls to StateMgr method to use diagnostics more conventionally

### DIFF
--- a/internal/backend/local/backend.go
+++ b/internal/backend/local/backend.go
@@ -459,8 +459,8 @@ func (b *Local) StatePaths(name string) (stateIn, stateOut, backupOut string) {
 // in the same files as the "new" state snapshots.
 func (b *Local) PathsConflictWith(other *Local) bool {
 	otherPaths := map[string]struct{}{}
-	otherWorkspaces, err := other.Workspaces()
-	if err != nil {
+	otherWorkspaces, diags := other.Workspaces()
+	if diags.HasErrors() {
 		// If we can't enumerate the workspaces then we'll conservatively
 		// assume that paths _do_ overlap, since we can't be certain.
 		return true
@@ -470,8 +470,8 @@ func (b *Local) PathsConflictWith(other *Local) bool {
 		otherPaths[p] = struct{}{}
 	}
 
-	ourWorkspaces, err := other.Workspaces()
-	if err != nil {
+	ourWorkspaces, diags := other.Workspaces()
+	if diags.HasErrors() {
 		// If we can't enumerate the workspaces then we'll conservatively
 		// assume that paths _do_ overlap, since we can't be certain.
 		return true

--- a/internal/backend/local/testing.go
+++ b/internal/backend/local/testing.go
@@ -151,9 +151,10 @@ func TestNewLocalNoDefault() backend.Backend {
 
 func (b *TestLocalNoDefaultState) Workspaces() ([]string, tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
-	workspaces, err := b.Local.Workspaces()
-	if err != nil {
-		return nil, diags.Append(err)
+	workspaces, wDiags := b.Local.Workspaces()
+	diags = diags.Append(wDiags)
+	if wDiags.HasErrors() {
+		return nil, diags
 	}
 
 	filtered := workspaces[:0]

--- a/internal/backend/remote-state/cos/backend_test.go
+++ b/internal/backend/remote-state/cos/backend_test.go
@@ -63,9 +63,9 @@ func TestRemoteClient(t *testing.T) {
 	be := setupBackend(t, bucket, defaultPrefix, defaultKey, false)
 	defer teardownBackend(t, be)
 
-	ss, err := be.StateMgr(backend.DefaultStateName)
-	if err != nil {
-		t.Fatalf("unexpected error: %s", err)
+	ss, sDiags := be.StateMgr(backend.DefaultStateName)
+	if sDiags.HasErrors() {
+		t.Fatalf("unexpected error: %s", sDiags.Err())
 	}
 
 	rs, ok := ss.(*remote.State)
@@ -85,9 +85,9 @@ func TestRemoteClientWithPrefix(t *testing.T) {
 	be := setupBackend(t, bucket, prefix, defaultKey, false)
 	defer teardownBackend(t, be)
 
-	ss, err := be.StateMgr(backend.DefaultStateName)
-	if err != nil {
-		t.Fatalf("unexpected error: %s", err)
+	ss, sDiags := be.StateMgr(backend.DefaultStateName)
+	if sDiags.HasErrors() {
+		t.Fatalf("unexpected error: %s", sDiags.Err())
 	}
 
 	rs, ok := ss.(*remote.State)
@@ -106,9 +106,9 @@ func TestRemoteClientWithEncryption(t *testing.T) {
 	be := setupBackend(t, bucket, defaultPrefix, defaultKey, true)
 	defer teardownBackend(t, be)
 
-	ss, err := be.StateMgr(backend.DefaultStateName)
-	if err != nil {
-		t.Fatalf("unexpected error: %s", err)
+	ss, sDiags := be.StateMgr(backend.DefaultStateName)
+	if sDiags.HasErrors() {
+		t.Fatalf("unexpected error: %s", sDiags.Err())
 	}
 
 	rs, ok := ss.(*remote.State)
@@ -127,9 +127,9 @@ func TestRemoteClientWithEndpoint(t *testing.T) {
 	be := setupBackendWithEndpoint(t, bucket, defaultPrefix, defaultKey, false)
 	defer teardownBackend(t, be)
 
-	ss, err := be.StateMgr(backend.DefaultStateName)
-	if err != nil {
-		t.Fatalf("unexpected error: %s", err)
+	ss, sDiags := be.StateMgr(backend.DefaultStateName)
+	if sDiags.HasErrors() {
+		t.Fatalf("unexpected error: %s", sDiags.Err())
 	}
 
 	rs, ok := ss.(*remote.State)

--- a/internal/backend/remote-state/gcs/backend_test.go
+++ b/internal/backend/remote-state/gcs/backend_test.go
@@ -151,9 +151,9 @@ func TestAccRemoteClient(t *testing.T) {
 	be := setupBackend(t, config)
 	defer teardownBackend(t, be, noPrefix)
 
-	ss, err := be.StateMgr(backend.DefaultStateName)
-	if err != nil {
-		t.Fatalf("be.StateMgr(%q) = %v", backend.DefaultStateName, err)
+	ss, sDiags := be.StateMgr(backend.DefaultStateName)
+	if sDiags.HasErrors() {
+		t.Fatalf("be.StateMgr(%q) = %v", backend.DefaultStateName, sDiags.Err())
 	}
 
 	rs, ok := ss.(*remote.State)
@@ -177,9 +177,9 @@ func TestAccRemoteClientWithEncryption(t *testing.T) {
 	be := setupBackend(t, config)
 	defer teardownBackend(t, be, noPrefix)
 
-	ss, err := be.StateMgr(backend.DefaultStateName)
-	if err != nil {
-		t.Fatalf("be.StateMgr(%q) = %v", backend.DefaultStateName, err)
+	ss, sDiags := be.StateMgr(backend.DefaultStateName)
+	if sDiags.HasErrors() {
+		t.Fatalf("be.StateMgr(%q) = %v", backend.DefaultStateName, sDiags.Err())
 	}
 
 	rs, ok := ss.(*remote.State)

--- a/internal/backend/remote-state/kubernetes/client_test.go
+++ b/internal/backend/remote-state/kubernetes/client_test.go
@@ -47,14 +47,14 @@ func TestRemoteClientLocks(t *testing.T) {
 		"secret_suffix": secretSuffix,
 	}))
 
-	s1, err := b1.StateMgr(backend.DefaultStateName)
-	if err != nil {
-		t.Fatal(err)
+	s1, sDiags := b1.StateMgr(backend.DefaultStateName)
+	if sDiags.HasErrors() {
+		t.Fatal(sDiags.Err())
 	}
 
-	s2, err := b2.StateMgr(backend.DefaultStateName)
-	if err != nil {
-		t.Fatal(err)
+	s2, sDiags := b2.StateMgr(backend.DefaultStateName)
+	if sDiags.HasErrors() {
+		t.Fatal(sDiags.Err())
 	}
 
 	remote.TestRemoteLocks(t, s1.(*remote.State).Client, s2.(*remote.State).Client)

--- a/internal/backend/remote-state/oss/client_test.go
+++ b/internal/backend/remote-state/oss/client_test.go
@@ -75,14 +75,14 @@ func TestRemoteClientLocks(t *testing.T) {
 	createTablestoreTable(t, b1.otsClient, tableName)
 	defer deleteTablestoreTable(t, b1.otsClient, tableName)
 
-	s1, err := b1.StateMgr(backend.DefaultStateName)
-	if err != nil {
-		t.Fatal(err)
+	s1, sDiags := b1.StateMgr(backend.DefaultStateName)
+	if sDiags.HasErrors() {
+		t.Fatal(sDiags.Err())
 	}
 
-	s2, err := b2.StateMgr(backend.DefaultStateName)
-	if err != nil {
-		t.Fatal(err)
+	s2, sDiags := b2.StateMgr(backend.DefaultStateName)
+	if sDiags.HasErrors() {
+		t.Fatal(sDiags.Err())
 	}
 
 	remote.TestRemoteLocks(t, s1.(*remote.State).Client, s2.(*remote.State).Client)
@@ -116,18 +116,18 @@ func TestRemoteClientLocks_multipleStates(t *testing.T) {
 	createTablestoreTable(t, b1.otsClient, tableName)
 	defer deleteTablestoreTable(t, b1.otsClient, tableName)
 
-	s1, err := b1.StateMgr("s1")
-	if err != nil {
-		t.Fatal(err)
+	s1, sDiags := b1.StateMgr("s1")
+	if sDiags.HasErrors() {
+		t.Fatal(sDiags)
 	}
 	if _, err := s1.Lock(statemgr.NewLockInfo()); err != nil {
 		t.Fatal("failed to get lock for s1:", err)
 	}
 
 	// s1 is now locked, s2 should not be locked as it's a different state file
-	s2, err := b2.StateMgr("s2")
-	if err != nil {
-		t.Fatal(err)
+	s2, sDiags := b2.StateMgr("s2")
+	if sDiags.HasErrors() {
+		t.Fatal(sDiags)
 	}
 	if _, err := s2.Lock(statemgr.NewLockInfo()); err != nil {
 		t.Fatal("failed to get lock for s2:", err)
@@ -283,9 +283,9 @@ func TestRemoteClient_stateChecksum(t *testing.T) {
 	createTablestoreTable(t, b1.otsClient, tableName)
 	defer deleteTablestoreTable(t, b1.otsClient, tableName)
 
-	s1, err := b1.StateMgr(backend.DefaultStateName)
-	if err != nil {
-		t.Fatal(err)
+	s1, sDiags := b1.StateMgr(backend.DefaultStateName)
+	if sDiags.HasErrors() {
+		t.Fatal(sDiags.Err())
 	}
 	client1 := s1.(*remote.State).Client
 
@@ -308,9 +308,9 @@ func TestRemoteClient_stateChecksum(t *testing.T) {
 		"bucket": bucketName,
 		"prefix": path,
 	})).(*Backend)
-	s2, err := b2.StateMgr(backend.DefaultStateName)
-	if err != nil {
-		t.Fatal(err)
+	s2, sDiags := b2.StateMgr(backend.DefaultStateName)
+	if sDiags.HasErrors() {
+		t.Fatal(sDiags.Err())
 	}
 	client2 := s2.(*remote.State).Client
 

--- a/internal/backend/remote-state/oss/client_test.go
+++ b/internal/backend/remote-state/oss/client_test.go
@@ -347,7 +347,7 @@ func TestRemoteClient_stateChecksum(t *testing.T) {
 	// fetching an empty state through client1 should now error out due to a
 	// mismatched checksum.
 	if _, diags := client1.Get(); !strings.HasPrefix(diags.Err().Error(), errBadChecksumFmt[:80]) {
-		t.Fatalf("expected state checksum error: got %s", err)
+		t.Fatalf("expected state checksum error: got %s", diags.Err())
 	}
 
 	// put the old state in place of the new, without updating the checksum
@@ -358,7 +358,7 @@ func TestRemoteClient_stateChecksum(t *testing.T) {
 	// fetching the wrong state through client1 should now error out due to a
 	// mismatched checksum.
 	if _, diags := client1.Get(); !strings.HasPrefix(diags.Err().Error(), errBadChecksumFmt[:80]) {
-		t.Fatalf("expected state checksum error: got %s", err)
+		t.Fatalf("expected state checksum error: got %s", diags.Err())
 	}
 
 	// update the state with the correct one after we Get again

--- a/internal/backend/remote-state/s3/client_test.go
+++ b/internal/backend/remote-state/s3/client_test.go
@@ -84,14 +84,14 @@ func TestRemoteClientLocks(t *testing.T) {
 	createDynamoDBTable(ctx, t, b1.dynClient, bucketName)
 	defer deleteDynamoDBTable(ctx, t, b1.dynClient, bucketName)
 
-	s1, err := b1.StateMgr(backend.DefaultStateName)
-	if err != nil {
-		t.Fatal(err)
+	s1, sDiags := b1.StateMgr(backend.DefaultStateName)
+	if sDiags.HasErrors() {
+		t.Fatal(sDiags.Err())
 	}
 
-	s2, err := b2.StateMgr(backend.DefaultStateName)
-	if err != nil {
-		t.Fatal(err)
+	s2, sDiags := b2.StateMgr(backend.DefaultStateName)
+	if sDiags.HasErrors() {
+		t.Fatal(sDiags.Err())
 	}
 
 	remote.TestRemoteLocks(t, s1.(*remote.State).Client, s2.(*remote.State).Client)

--- a/internal/command/meta_backend.go
+++ b/internal/command/meta_backend.go
@@ -1178,9 +1178,9 @@ func (m *Meta) backend_C_r_s(c *configs.Backend, cHash int, sMgr *clistate.Local
 
 	var localStates []statemgr.Full
 	for _, workspace := range workspaces {
-		localState, err := localB.StateMgr(workspace)
-		if err != nil {
-			diags = diags.Append(fmt.Errorf(errBackendLocalRead, err))
+		localState, sDiags := localB.StateMgr(workspace)
+		if sDiags.HasErrors() {
+			diags = diags.Append(fmt.Errorf(errBackendLocalRead, sDiags.Err()))
 			return nil, diags
 		}
 		if err := localState.RefreshState(); err != nil {

--- a/internal/command/meta_backend_migrate.go
+++ b/internal/command/meta_backend_migrate.go
@@ -696,10 +696,10 @@ func (m *Meta) backendMigrateState_S_TFC(opts *backendMigrateOpts, sourceWorkspa
 		if sourceWorkspaces[i] == backend.DefaultStateName {
 			// For the default workspace we want to look to see if there is any state
 			// before we ask for a workspace name to migrate the default workspace into.
-			sourceState, err := opts.Source.StateMgr(backend.DefaultStateName)
-			if err != nil {
+			sourceState, sDiags := opts.Source.StateMgr(backend.DefaultStateName)
+			if sDiags.HasErrors() {
 				return fmt.Errorf(strings.TrimSpace(
-					errMigrateSingleLoadDefault), opts.SourceType, err)
+					errMigrateSingleLoadDefault), opts.SourceType, sDiags.Err())
 			}
 			// RefreshState is what actually pulls the state to be evaluated.
 			if err := sourceState.RefreshState(); err != nil {

--- a/internal/moduletest/graph/eval_context.go
+++ b/internal/moduletest/graph/eval_context.go
@@ -631,9 +631,9 @@ func (ec *EvalContext) LoadState(run *configs.TestRun) (*states.State, error) {
 		// Then we'll load the state from the backend instead of just using
 		// whatever was in the state.
 
-		stmgr, diags := current.Backend.StateMgr(backend.DefaultStateName)
-		if diags.HasErrors() {
-			return nil, diags.Err()
+		stmgr, sDiags := current.Backend.StateMgr(backend.DefaultStateName)
+		if sDiags.HasErrors() {
+			return nil, sDiags.Err()
 		}
 
 		if err := stmgr.RefreshState(); err != nil {

--- a/internal/moduletest/graph/eval_context.go
+++ b/internal/moduletest/graph/eval_context.go
@@ -631,9 +631,9 @@ func (ec *EvalContext) LoadState(run *configs.TestRun) (*states.State, error) {
 		// Then we'll load the state from the backend instead of just using
 		// whatever was in the state.
 
-		stmgr, err := current.Backend.StateMgr(backend.DefaultStateName)
-		if err != nil {
-			return nil, err.Err()
+		stmgr, diags := current.Backend.StateMgr(backend.DefaultStateName)
+		if diags.HasErrors() {
+			return nil, diags.Err()
 		}
 
 		if err := stmgr.RefreshState(); err != nil {

--- a/internal/moduletest/states/manifest.go
+++ b/internal/moduletest/states/manifest.go
@@ -291,12 +291,12 @@ func (manifest *TestManifest) SaveStates(file *moduletest.File, states map[strin
 					// If we have a backend, regardless of the reason, then
 					// we'll save the state to the backend.
 
-					stmgr, err := state.Backend.StateMgr(backend.DefaultStateName)
-					if err != nil {
+					stmgr, sDiags := state.Backend.StateMgr(backend.DefaultStateName)
+					if sDiags.HasErrors() {
 						diags = diags.Append(&hcl.Diagnostic{
 							Severity: hcl.DiagError,
 							Summary:  "Failed to write state",
-							Detail:   fmt.Sprintf("Failed to write state file for key %s: %s.", key, err),
+							Detail:   fmt.Sprintf("Failed to write state file for key %s: %s.", key, sDiags.Err()),
 						})
 						continue
 					}
@@ -365,12 +365,12 @@ func (manifest *TestManifest) SaveStates(file *moduletest.File, states map[strin
 
 			if state.Backend != nil {
 
-				stmgr, err := state.Backend.StateMgr(backend.DefaultStateName)
-				if err != nil {
+				stmgr, sDiags := state.Backend.StateMgr(backend.DefaultStateName)
+				if sDiags.HasErrors() {
 					diags = diags.Append(&hcl.Diagnostic{
 						Severity: hcl.DiagError,
 						Summary:  "Failed to write state",
-						Detail:   fmt.Sprintf("Failed to write state file for key %s: %s.", key, err),
+						Detail:   fmt.Sprintf("Failed to write state file for key %s: %s.", key, sDiags.Err()),
 					})
 					continue
 				}
@@ -415,12 +415,12 @@ func (manifest *TestManifest) SaveStates(file *moduletest.File, states map[strin
 		for key, state := range states {
 			if state.Backend != nil {
 
-				stmgr, err := state.Backend.StateMgr(backend.DefaultStateName)
-				if err != nil {
+				stmgr, sDiags := state.Backend.StateMgr(backend.DefaultStateName)
+				if sDiags.HasErrors() {
 					diags = diags.Append(&hcl.Diagnostic{
 						Severity: hcl.DiagError,
 						Summary:  "Failed to write state",
-						Detail:   fmt.Sprintf("Failed to write state file for key %s: %s.", key, err),
+						Detail:   fmt.Sprintf("Failed to write state file for key %s: %s.", key, sDiags.Err()),
 					})
 					continue
 				}


### PR DESCRIPTION
Follow up to https://github.com/hashicorp/terraform/pull/37589. In that case, the interface defining the StateMgr method was updated to return diagnostics instead of errors, and something went wrong when that change was pulled into a long-lived feature branch.

This PR changes that code _and_ other examples of calling code to handle diagnostics more conventionally:
* Instead of checking for non-`nil` values, inspect for errors
* Retrieve an `error` representation of the diagnostics where calling code previously used errors to make test failure messages or return errors to users.

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

N/A

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
