### PR TITLE
temporarily require manager approval for go.mod changes

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -32,3 +32,6 @@
 builtin/provisioners/file               @hashicorp/terraform-core
 builtin/provisioners/local-exec         @hashicorp/terraform-core
 builtin/provisioners/remote-exec        @hashicorp/terraform-core
+
+# temporary go.mod protection during freeze
+/go.mod      @tommyokeefe


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->
As discussed internally this adds additional protections to ensure we do not make any changes in `go.mod` during the temporary dependency freeze around Hashiconf. 

As written now this uses my github user directly. If anyone feels strongly about avoiding that we could create a new group that I am the only member of and go that route. 

This also references the file directly. If someone has a better / preferred pattern I'm happy to change it as well. 

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->


## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.14.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
