### PR TITLE
actions: ensure config is known during apply

### DIFF
--- a/internal/terraform/context_apply_action_test.go
+++ b/internal/terraform/context_apply_action_test.go
@@ -540,13 +540,19 @@ resource "test_object" "b" {
 				},
 			}),
 
-			expectInvokeActionCalled: true,
-			expectInvokeActionCalls: []providers.InvokeActionRequest{{
-				ActionType: "act_unlinked",
-				PlannedActionData: cty.ObjectVal(map[string]cty.Value{
-					"attr": cty.UnknownVal(cty.String),
-				}),
-			}},
+			expectInvokeActionCalled: false,
+			expectDiagnostics: func(m *configs.Config) tfdiags.Diagnostics {
+				return tfdiags.Diagnostics{}.Append(&hcl.Diagnostic{
+					Severity: hcl.DiagError,
+					Summary:  "Action configuration unknown during apply",
+					Detail:   "The action action.act_unlinked.hello was not fully known during apply.\n\nThis is a bug in Terraform, please report it.",
+					Subject: &hcl.Range{
+						Filename: filepath.Join(m.Module.SourceDir, "main.tf"),
+						Start:    hcl.Pos{Line: 14, Column: 18, Byte: 236},
+						End:      hcl.Pos{Line: 14, Column: 43, Byte: 261},
+					},
+				})
+			},
 		},
 
 		"action with secrets in configuration": {

--- a/internal/terraform/node_action_trigger_apply.go
+++ b/internal/terraform/node_action_trigger_apply.go
@@ -120,6 +120,15 @@ func (n *nodeActionTriggerApply) Execute(ctx EvalContext, wo walkOperation) tfdi
 		})
 	}
 
+	if !configValue.IsWhollyKnown() {
+		return diags.Append(&hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  "Action configuration unknown during apply",
+			Detail:   fmt.Sprintf("The action %s was not fully known during apply.\n\nThis is a bug in Terraform, please report it.", ai.Addr.Action.String()),
+			Subject:  n.ActionTriggerRange,
+		})
+	}
+
 	hookIdentity := HookActionIdentity{
 		Addr:          ai.Addr,
 		ActionTrigger: ai.ActionTrigger,


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Fixes #

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.14.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.