### PR TITLE
Skip flaky test TestUiHookEphemeralOp_progress

### DIFF
--- a/internal/command/views/hook_ui_test.go
+++ b/internal/command/views/hook_ui_test.go
@@ -736,6 +736,11 @@ ephemeral.test_instance.foo: Closing complete after 0s
 }
 
 func TestUiHookEphemeralOp_progress(t *testing.T) {
+
+	// Skipped due to flakiness
+	// See: https://github.com/hashicorp/terraform/issues/37609
+	t.Skip()
+
 	syncTest, streams, done := streamableSyncTest(t)
 	syncTest(t, func(t *testing.T) {
 		view := NewView(streams)


### PR DESCRIPTION
See https://github.com/hashicorp/terraform/issues/37609

We're all pretty used to this test failing, but it could contribute to us overlooking an important test failure before merging a PR.

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

N/A

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
