### PR TITLE
actions: preserve unknown metadata in the json plan

### DIFF
--- a/internal/command/jsonformat/structured/change.go
+++ b/internal/command/jsonformat/structured/change.go
@@ -187,9 +187,9 @@ func FromJsonViewsOutput(output viewsjson.Output) Change {
 
 func FromJsonActionInvocation(actionInvocation jsonplan.ActionInvocation) Change {
 	return Change{
-		Before:          unwrapAttributeValues(actionInvocation.ConfigValues),
-		After:           unwrapAttributeValues(actionInvocation.ConfigValues),
-		Unknown:         false,
+		Before:          unmarshalGeneric(actionInvocation.ConfigValues),
+		After:           unmarshalGeneric(actionInvocation.ConfigValues),
+		Unknown:         unmarshalGeneric(actionInvocation.ConfigUnknown),
 		BeforeSensitive: unmarshalGeneric(actionInvocation.ConfigSensitive),
 		AfterSensitive:  unmarshalGeneric(actionInvocation.ConfigSensitive),
 

--- a/internal/command/jsonplan/action_invocations_test.go
+++ b/internal/command/jsonplan/action_invocations_test.go
@@ -1,0 +1,179 @@
+package jsonplan
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/zclconf/go-cty/cty"
+	"github.com/zclconf/go-cty/cty/msgpack"
+
+	"github.com/hashicorp/terraform/internal/addrs"
+	"github.com/hashicorp/terraform/internal/configs/configschema"
+	"github.com/hashicorp/terraform/internal/plans"
+	"github.com/hashicorp/terraform/internal/providers"
+	"github.com/hashicorp/terraform/internal/terraform"
+)
+
+func TestMarshalActionInvocations(t *testing.T) {
+
+	action := addrs.AbsActionInstance{
+		Module: addrs.RootModuleInstance,
+		Action: addrs.ActionInstance{
+			Action: addrs.Action{
+				Type: "test_action",
+				Name: "test",
+			},
+			Key: addrs.NoKey,
+		},
+	}
+
+	provider := addrs.AbsProviderConfig{
+		Module: addrs.RootModule,
+		Provider: addrs.Provider{
+			Type:      "test",
+			Namespace: "hashicorp",
+			Hostname:  addrs.DefaultProviderRegistryHost,
+		},
+	}
+
+	schemas := &terraform.Schemas{
+		Providers: map[addrs.Provider]providers.ProviderSchema{
+			provider.Provider: {
+				Actions: map[string]providers.ActionSchema{
+					"test_action": {
+						ConfigSchema: &configschema.Block{
+							Attributes: map[string]*configschema.Attribute{
+								"optional": {
+									Type: cty.String,
+								},
+								"sensitive": {
+									Type:      cty.String,
+									Sensitive: true,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	tcs := map[string]struct {
+		input  *plans.ActionInvocationInstanceSrc
+		output ActionInvocation
+	}{
+		"no metadata": {
+			input: &plans.ActionInvocationInstanceSrc{
+				Addr:          action,
+				ActionTrigger: new(plans.InvokeActionTrigger),
+				ConfigValue: mustDynamicValue(t, cty.ObjectVal(map[string]cty.Value{
+					"optional":  cty.StringVal("hello"),
+					"sensitive": cty.StringVal("world"),
+				})),
+				SensitiveConfigPaths: nil,
+				ProviderAddr:         provider,
+			},
+			output: ActionInvocation{
+				Address: "action.test_action.test",
+				Type:    "test_action",
+				Name:    "test",
+				ConfigValues: mustJson(t, map[string]interface{}{
+					"optional":  "hello",
+					"sensitive": "world",
+				}),
+				ConfigSensitive: mustJson(t, map[string]interface{}{
+					"sensitive": true,
+				}),
+				ConfigUnknown:       mustJson(t, map[string]interface{}{}),
+				ProviderName:        "registry.terraform.io/hashicorp/test",
+				InvokeActionTrigger: new(InvokeActionTrigger),
+			},
+		},
+		"unknown value": {
+			input: &plans.ActionInvocationInstanceSrc{
+				Addr:          action,
+				ActionTrigger: new(plans.InvokeActionTrigger),
+				ConfigValue: mustDynamicValue(t, cty.ObjectVal(map[string]cty.Value{
+					"optional":  cty.UnknownVal(cty.String),
+					"sensitive": cty.StringVal("world"),
+				})),
+				SensitiveConfigPaths: nil,
+				ProviderAddr:         provider,
+			},
+			output: ActionInvocation{
+				Address: "action.test_action.test",
+				Type:    "test_action",
+				Name:    "test",
+				ConfigValues: mustJson(t, map[string]interface{}{
+					"sensitive": "world",
+				}),
+				ConfigSensitive: mustJson(t, map[string]interface{}{
+					"sensitive": true,
+				}),
+				ConfigUnknown: mustJson(t, map[string]interface{}{
+					"optional": true,
+				}),
+				ProviderName:        "registry.terraform.io/hashicorp/test",
+				InvokeActionTrigger: new(InvokeActionTrigger),
+			},
+		},
+		"extra sensitive": {
+			input: &plans.ActionInvocationInstanceSrc{
+				Addr:          action,
+				ActionTrigger: new(plans.InvokeActionTrigger),
+				ConfigValue: mustDynamicValue(t, cty.ObjectVal(map[string]cty.Value{
+					"optional":  cty.StringVal("hello"),
+					"sensitive": cty.StringVal("world"),
+				})),
+				SensitiveConfigPaths: []cty.Path{cty.GetAttrPath("optional")},
+				ProviderAddr:         provider,
+			},
+			output: ActionInvocation{
+				Address: "action.test_action.test",
+				Type:    "test_action",
+				Name:    "test",
+				ConfigValues: mustJson(t, map[string]interface{}{
+					"optional":  "hello",
+					"sensitive": "world",
+				}),
+				ConfigSensitive: mustJson(t, map[string]interface{}{
+					"optional":  true,
+					"sensitive": true,
+				}),
+				ConfigUnknown:       mustJson(t, map[string]interface{}{}),
+				ProviderName:        "registry.terraform.io/hashicorp/test",
+				InvokeActionTrigger: new(InvokeActionTrigger),
+			},
+		},
+	}
+
+	for name, tc := range tcs {
+		t.Run(name, func(t *testing.T) {
+			out, err := MarshalActionInvocation(tc.input, schemas)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if diff := cmp.Diff(tc.output, out); len(diff) > 0 {
+				t.Fatal(diff)
+			}
+		})
+	}
+
+}
+
+func mustDynamicValue(t *testing.T, value cty.Value) []byte {
+	out, err := msgpack.Marshal(value, value.Type())
+	if err != nil {
+		t.Fatal(err)
+	}
+	return out
+}
+
+func mustJson(t *testing.T, data interface{}) json.RawMessage {
+	out, err := json.Marshal(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return out
+}

--- a/internal/command/jsonplan/action_invocations_test.go
+++ b/internal/command/jsonplan/action_invocations_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
 package jsonplan
 
 import (


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

This PR updates the JSON plan to include unknown metadata.

Also, tweaks the representation of the config value to match the simple `json.RawMessage` used by other changes. It is true that it must be an object, so will always be a map, but being more specific for this field compared to other fields led to confusion in consumers, and also needed extra complexity in consuming everything later. This isn't needed anymore.

Also (2), I've updated the sensitive metadata so that it also reads from the schema for sensitive metadata. This matches the behaviour for other changes, and is just another check to make sure sensitive metadata is being included where appropriate.

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->


## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.14.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
