### PR TITLE
actions: remove references to action types, linked resources

### DIFF
--- a/internal/command/jsonformat/plan_test.go
+++ b/internal/command/jsonformat/plan_test.go
@@ -8467,8 +8467,8 @@ func TestResourceChange_actions(t *testing.T) {
 		"before actions": {
 			actionInvocations: []jsonplan.ActionInvocation{
 				{
-					Address:      "action.test_unlinked.hello",
-					Type:         "test_unlinked",
+					Address:      "action.test_action.hello",
+					Type:         "test_action",
 					Name:         "hello",
 					ProviderName: "registry.terraform.io/hashicorp/test",
 					LifecycleActionTrigger: &jsonplan.LifecycleActionTrigger{
@@ -8494,7 +8494,7 @@ func TestResourceChange_actions(t *testing.T) {
     }
 
     # Actions to be invoked before this change in order:
-    action "test_unlinked" "hello" {
+    action "test_action" "hello" {
         config {
             disk = {
                 size = "100"
@@ -8511,8 +8511,8 @@ func TestResourceChange_actions(t *testing.T) {
 		"after actions": {
 			actionInvocations: []jsonplan.ActionInvocation{
 				{
-					Address:      "action.test_unlinked.hello",
-					Type:         "test_unlinked",
+					Address:      "action.test_action.hello",
+					Type:         "test_action",
 					Name:         "hello",
 					ProviderName: "registry.terraform.io/hashicorp/test",
 					LifecycleActionTrigger: &jsonplan.LifecycleActionTrigger{
@@ -8538,7 +8538,7 @@ func TestResourceChange_actions(t *testing.T) {
     }
 
     # Actions to be invoked after this change in order:
-    action "test_unlinked" "hello" {
+    action "test_action" "hello" {
         config {
             disk = {
                 size = "100"
@@ -8555,8 +8555,8 @@ func TestResourceChange_actions(t *testing.T) {
 		"before and after actions": {
 			actionInvocations: []jsonplan.ActionInvocation{
 				{
-					Address:      "action.test_unlinked.hello",
-					Type:         "test_unlinked",
+					Address:      "action.test_action.hello",
+					Type:         "test_action",
 					Name:         "hello",
 					ProviderName: "registry.terraform.io/hashicorp/test",
 					LifecycleActionTrigger: &jsonplan.LifecycleActionTrigger{
@@ -8570,8 +8570,8 @@ func TestResourceChange_actions(t *testing.T) {
 					})),
 				},
 				{
-					Address:      "action.test_unlinked.hello",
-					Type:         "test_unlinked",
+					Address:      "action.test_action.hello",
+					Type:         "test_action",
 					Name:         "hello",
 					ProviderName: "registry.terraform.io/hashicorp/test",
 					LifecycleActionTrigger: &jsonplan.LifecycleActionTrigger{
@@ -8585,8 +8585,8 @@ func TestResourceChange_actions(t *testing.T) {
 					})),
 				},
 				{
-					Address:      "action.test_unlinked.hello",
-					Type:         "test_unlinked",
+					Address:      "action.test_action.hello",
+					Type:         "test_action",
 					Name:         "hello",
 					ProviderName: "registry.terraform.io/hashicorp/test",
 					LifecycleActionTrigger: &jsonplan.LifecycleActionTrigger{
@@ -8600,8 +8600,8 @@ func TestResourceChange_actions(t *testing.T) {
 					})),
 				},
 				{
-					Address:      "action.test_unlinked.hello",
-					Type:         "test_unlinked",
+					Address:      "action.test_action.hello",
+					Type:         "test_action",
 					Name:         "hello",
 					ProviderName: "registry.terraform.io/hashicorp/test",
 					LifecycleActionTrigger: &jsonplan.LifecycleActionTrigger{
@@ -8615,8 +8615,8 @@ func TestResourceChange_actions(t *testing.T) {
 					})),
 				},
 				{
-					Address:      "action.test_unlinked.hello",
-					Type:         "test_unlinked",
+					Address:      "action.test_action.hello",
+					Type:         "test_action",
 					Name:         "hello",
 					ProviderName: "registry.terraform.io/hashicorp/test",
 					LifecycleActionTrigger: &jsonplan.LifecycleActionTrigger{
@@ -8636,17 +8636,17 @@ func TestResourceChange_actions(t *testing.T) {
     }
 
     # Actions to be invoked before this change in order:
-    action "test_unlinked" "hello" {
+    action "test_action" "hello" {
         config {
             id = "first-block-and-action"
         }
     }
-    action "test_unlinked" "hello" {
+    action "test_action" "hello" {
         config {
             id = "first-block-second-action"
         }
     }
-    action "test_unlinked" "hello" {
+    action "test_action" "hello" {
         config {
             id = "fourth-block-first-action"
         }
@@ -8654,12 +8654,12 @@ func TestResourceChange_actions(t *testing.T) {
 
 
     # Actions to be invoked after this change in order:
-    action "test_unlinked" "hello" {
+    action "test_action" "hello" {
         config {
             id = "second-block-first-action"
         }
     }
-    action "test_unlinked" "hello" {
+    action "test_action" "hello" {
         config {
             id = "third-block-first-action"
         }
@@ -8669,8 +8669,8 @@ func TestResourceChange_actions(t *testing.T) {
 		"no config value": {
 			actionInvocations: []jsonplan.ActionInvocation{
 				{
-					Address:      "action.test_unlinked.hello",
-					Type:         "test_unlinked",
+					Address:      "action.test_action.hello",
+					Type:         "test_action",
 					Name:         "hello",
 					ProviderName: "registry.terraform.io/hashicorp/test",
 					LifecycleActionTrigger: &jsonplan.LifecycleActionTrigger{
@@ -8687,7 +8687,7 @@ func TestResourceChange_actions(t *testing.T) {
     }
 
     # Actions to be invoked before this change in order:
-    action "test_unlinked" "hello" {
+    action "test_action" "hello" {
     }
 `,
 		},
@@ -8707,7 +8707,7 @@ func TestResourceChange_actions(t *testing.T) {
 							},
 						},
 						Actions: map[string]providers.ActionSchema{
-							"test_unlinked": {
+							"test_action": {
 								ConfigSchema: blockSchema,
 							},
 						},

--- a/internal/command/jsonprovider/provider_test.go
+++ b/internal/command/jsonprovider/provider_test.go
@@ -243,7 +243,7 @@ func TestMarshalProvider(t *testing.T) {
 					},
 				},
 				Actions: map[string]providers.ActionSchema{
-					"test_unlinked_action": {
+					"test_action": {
 						ConfigSchema: &configschema.Block{
 							Attributes: map[string]*configschema.Attribute{
 								"opt_attr": {Type: cty.String, Optional: true},
@@ -281,7 +281,7 @@ func TestMarshalProvider(t *testing.T) {
 				},
 				ResourceIdentitySchemas: map[string]*IdentitySchema{},
 				ActionSchemas: map[string]*ActionSchema{
-					"test_unlinked_action": {
+					"test_action": {
 						ConfigSchema: &Block{
 							Attributes: map[string]*Attribute{
 								"opt_attr": {

--- a/internal/command/show_test.go
+++ b/internal/command/show_test.go
@@ -1128,7 +1128,7 @@ func showFixtureSchema() *providers.GetProviderSchemaResponse {
 			},
 		},
 		Actions: map[string]providers.ActionSchema{
-			"test_unlinked": {
+			"test_action": {
 				ConfigSchema: &configschema.Block{
 					Attributes: map[string]*configschema.Attribute{
 						"attr": {Type: cty.String, Optional: true},

--- a/internal/command/views/operation_test.go
+++ b/internal/command/views/operation_test.go
@@ -572,7 +572,7 @@ func TestOperationJSON_plan_with_actions(t *testing.T) {
 	beep := addrs.Resource{Mode: addrs.ManagedResourceMode, Type: "test_resource", Name: "beep"}.Instance(addrs.IntKey(0)).Absolute(vpc)
 
 	act1 := &plans.ActionInvocationInstanceSrc{
-		Addr: addrs.Action{Type: "test_unlinked_action", Name: "hello"}.Instance(addrs.NoKey).Absolute(root),
+		Addr: addrs.Action{Type: "test_action", Name: "hello"}.Instance(addrs.NoKey).Absolute(root),
 		ActionTrigger: &plans.LifecycleActionTrigger{
 			TriggeringResourceAddr:  boop,
 			ActionTriggerEvent:      configs.AfterCreate,
@@ -581,7 +581,7 @@ func TestOperationJSON_plan_with_actions(t *testing.T) {
 		},
 	}
 	act2 := &plans.ActionInvocationInstanceSrc{
-		Addr: addrs.Action{Type: "test_unlinked_other_action", Name: "world"}.Instance(addrs.NoKey).Absolute(root),
+		Addr: addrs.Action{Type: "test_other_action", Name: "world"}.Instance(addrs.NoKey).Absolute(root),
 		ActionTrigger: &plans.LifecycleActionTrigger{
 			TriggeringResourceAddr:  boop,
 			ActionTriggerEvent:      configs.AfterCreate,
@@ -590,7 +590,7 @@ func TestOperationJSON_plan_with_actions(t *testing.T) {
 		},
 	}
 	act3 := &plans.ActionInvocationInstanceSrc{
-		Addr: addrs.Action{Type: "test_unlinked_action", Name: "goodbye"}.Instance(addrs.IntKey(0)).Absolute(vpc),
+		Addr: addrs.Action{Type: "test_action", Name: "goodbye"}.Instance(addrs.IntKey(0)).Absolute(vpc),
 		ActionTrigger: &plans.LifecycleActionTrigger{
 			TriggeringResourceAddr:  beep,
 			ActionTriggerEvent:      configs.BeforeUpdate,
@@ -665,18 +665,18 @@ func TestOperationJSON_plan_with_actions(t *testing.T) {
 		// Action invocation 1
 		{
 			"@level":   "info",
-			"@message": "planned action invocation: action.test_unlinked_action.hello",
+			"@message": "planned action invocation: action.test_action.hello",
 			"@module":  "terraform.ui",
 			"type":     "planned_action_invocation",
 			"invocation": map[string]interface{}{
 				"action_addr": map[string]interface{}{
-					"addr":             `action.test_unlinked_action.hello`,
+					"addr":             `action.test_action.hello`,
 					"implied_provider": "test",
 					"module":           "",
-					"action":           `action.test_unlinked_action.hello`,
+					"action":           `action.test_action.hello`,
 					"action_key":       nil,
 					"action_name":      "hello",
-					"action_type":      "test_unlinked_action",
+					"action_type":      "test_action",
 				},
 				"lifecycle_trigger": map[string]interface{}{
 					"action_trigger_block_index": float64(0),
@@ -697,18 +697,18 @@ func TestOperationJSON_plan_with_actions(t *testing.T) {
 		// Action invocation 2
 		{
 			"@level":   "info",
-			"@message": "planned action invocation: action.test_unlinked_other_action.world",
+			"@message": "planned action invocation: action.test_other_action.world",
 			"@module":  "terraform.ui",
 			"type":     "planned_action_invocation",
 			"invocation": map[string]interface{}{
 				"action_addr": map[string]interface{}{
-					"addr":             `action.test_unlinked_other_action.world`,
+					"addr":             `action.test_other_action.world`,
 					"implied_provider": "test",
 					"module":           "",
-					"action":           `action.test_unlinked_other_action.world`,
+					"action":           `action.test_other_action.world`,
 					"action_key":       nil,
 					"action_name":      "world",
-					"action_type":      "test_unlinked_other_action",
+					"action_type":      "test_other_action",
 				},
 				"lifecycle_trigger": map[string]interface{}{
 					"action_trigger_block_index": float64(0),
@@ -729,18 +729,18 @@ func TestOperationJSON_plan_with_actions(t *testing.T) {
 		// Action invocation 3
 		{
 			"@level":   "info",
-			"@message": "planned action invocation: action.test_unlinked_action.goodbye[0]",
+			"@message": "planned action invocation: action.test_action.goodbye[0]",
 			"@module":  "terraform.ui",
 			"type":     "planned_action_invocation",
 			"invocation": map[string]interface{}{
 				"action_addr": map[string]interface{}{
-					"addr":             `module.vpc.action.test_unlinked_action.goodbye[0]`,
+					"addr":             `module.vpc.action.test_action.goodbye[0]`,
 					"implied_provider": "test",
 					"module":           "module.vpc",
-					"action":           `action.test_unlinked_action.goodbye[0]`,
+					"action":           `action.test_action.goodbye[0]`,
 					"action_key":       float64(0),
 					"action_name":      "goodbye",
-					"action_type":      "test_unlinked_action",
+					"action_type":      "test_action",
 				},
 				"lifecycle_trigger": map[string]interface{}{
 					"action_trigger_block_index": float64(1),

--- a/internal/configs/action.go
+++ b/internal/configs/action.go
@@ -15,28 +15,6 @@ import (
 	"github.com/hashicorp/terraform/internal/tfdiags"
 )
 
-// There are many ways of handling plurality in error messages (linked_resource
-// vs linked_resources); this is one of them.
-type diagFn func(*hcl.Range) *hcl.Diagnostic
-
-func invalidLinkedResourceDiag(subj *hcl.Range) *hcl.Diagnostic {
-	return &hcl.Diagnostic{
-		Severity: hcl.DiagError,
-		Summary:  `Invalid linked_resource`,
-		Detail:   `linked_resource must only refer to a managed resource in the current module.`,
-		Subject:  subj,
-	}
-}
-
-func invalidLinkedResourcesDiag(subj *hcl.Range) *hcl.Diagnostic {
-	return &hcl.Diagnostic{
-		Severity: hcl.DiagError,
-		Summary:  `Invalid linked_resources`,
-		Detail:   `linked_resources must only refer to managed resources in the current module.`,
-		Subject:  subj,
-	}
-}
-
 func invalidActionDiag(subj *hcl.Range) *hcl.Diagnostic {
 	return &hcl.Diagnostic{
 		Severity: hcl.DiagError,
@@ -53,9 +31,6 @@ type Action struct {
 	Config  hcl.Body
 	Count   hcl.Expression
 	ForEach hcl.Expression
-	// DependsOn []hcl.Traversal // not yet supported
-
-	LinkedResources []hcl.Expression
 
 	ProviderConfigRef *ProviderConfigRef
 	Provider          addrs.Provider
@@ -228,35 +203,6 @@ func decodeActionBlock(block *hcl.Block) (*Action, hcl.Diagnostics) {
 		}
 	}
 
-	if attr, exists := content.Attributes["linked_resource"]; exists {
-		if a.LinkedResources != nil {
-			diags = append(diags, &hcl.Diagnostic{
-				Severity: hcl.DiagError,
-				Summary:  `Invalid use of "linked_resource"`,
-				Detail:   `"linked_resource" and "linked_resources" are mutually exclusive, only one should be used.`,
-				Subject:  &attr.NameRange,
-			})
-		}
-		lr, lrDiags := decodeLinkedResource(attr.Expr)
-		diags = append(diags, lrDiags...)
-		a.LinkedResources = []hcl.Expression{lr}
-	}
-
-	if attr, exists := content.Attributes["linked_resources"]; exists {
-		if a.LinkedResources != nil {
-			diags = append(diags, &hcl.Diagnostic{
-				Severity: hcl.DiagError,
-				Summary:  `Invalid use of "linked_resources"`,
-				Detail:   `"linked_resource" and "linked_resources" are mutually exclusive, only one should be used.`,
-				Subject:  &attr.NameRange,
-			})
-		}
-
-		lrs, lrDiags := decodeLinkedResources(attr.Expr)
-		diags = append(diags, lrDiags...)
-		a.LinkedResources = lrs
-	}
-
 	for _, block := range content.Blocks {
 		switch block.Type {
 		case "config":
@@ -283,13 +229,6 @@ func decodeActionBlock(block *hcl.Block) (*Action, hcl.Diagnostics) {
 		diags = append(diags, providerDiags...)
 	}
 
-	// depends_on: not yet supported
-	// if attr, exists := content.Attributes["depends_on"]; exists {
-	// 	deps, depsDiags := DecodeDependsOn(attr)
-	// 	diags = append(diags, depsDiags...)
-	// 	a.DependsOn = append(a.DependsOn, deps...)
-	// }
-
 	return a, diags
 }
 
@@ -310,12 +249,6 @@ var commonActionAttributes = []hcl.AttributeSchema{
 	},
 	{
 		Name: "provider",
-	},
-	{
-		Name: "linked_resource",
-	},
-	{
-		Name: "linked_resources",
 	},
 }
 
@@ -459,107 +392,4 @@ func decodeActionTriggerRef(expr hcl.Expression) ([]ActionRef, hcl.Diagnostics) 
 	}
 
 	return actionRefs, diags
-}
-
-// decodeLinkedResources decodes and does basic validation of an Action's
-// LinkedResources.
-func decodeLinkedResources(expr hcl.Expression) ([]hcl.Expression, hcl.Diagnostics) {
-	exprs, diags := hcl.ExprList(expr)
-	if diags.HasErrors() {
-		return nil, diags
-	}
-
-	for i, expr := range exprs {
-		// We are manually parsing config, so we need to handle json configs, in
-		// which case the values will be json strings rather than hcl.
-		var jsDiags hcl.Diagnostics
-		expr, jsDiags = unwrapJSONRefExpr(expr)
-		diags = diags.Extend(jsDiags)
-		if diags.HasErrors() {
-			continue
-		}
-
-		// re-assign the value in case it was modified by unwrapJSONRefExpr
-		exprs[i] = expr
-
-		_, lrDiags := decodeUnwrappedLinkedResource(expr, invalidLinkedResourcesDiag)
-		diags = append(diags, lrDiags...)
-
-	}
-
-	return exprs, diags
-}
-
-func decodeLinkedResource(expr hcl.Expression) (hcl.Expression, hcl.Diagnostics) {
-	// Handle possible json configs
-	expr, diags := unwrapJSONRefExpr(expr)
-	if diags.HasErrors() {
-		return expr, diags
-	}
-
-	return decodeUnwrappedLinkedResource(expr, invalidLinkedResourceDiag)
-}
-
-func decodeUnwrappedLinkedResource(expr hcl.Expression, diagFunc diagFn) (hcl.Expression, hcl.Diagnostics) {
-	var diags hcl.Diagnostics
-
-	refs, refDiags := langrefs.ReferencesInExpr(addrs.ParseRef, expr)
-	for _, diag := range refDiags {
-		severity := hcl.DiagError
-		if diag.Severity() == tfdiags.Warning {
-			severity = hcl.DiagWarning
-		}
-
-		diags = append(diags, &hcl.Diagnostic{
-			Severity: severity,
-			Summary:  diag.Description().Summary,
-			Detail:   diag.Description().Detail,
-			Subject:  expr.Range().Ptr(),
-		})
-	}
-
-	if refDiags.HasErrors() {
-		return expr, diags
-	}
-
-	resourceCount := 0
-	for _, ref := range refs {
-		switch sub := ref.Subject.(type) {
-		case addrs.ResourceInstance:
-			if sub.Resource.Mode == addrs.ManagedResourceMode {
-				diags = append(diags, diagFunc(expr.Range().Ptr()))
-			} else {
-				resourceCount++
-			}
-		case addrs.Resource:
-			if sub.Mode != addrs.ManagedResourceMode {
-				diags = append(diags, diagFunc(expr.Range().Ptr()))
-			} else {
-				resourceCount++
-			}
-		case addrs.ModuleCall, addrs.ModuleCallInstance, addrs.ModuleCallInstanceOutput:
-			diags = append(diags, diagFunc(expr.Range().Ptr()))
-		default:
-			// we've checked what we can without evaluating references!
-		}
-	}
-
-	switch {
-	case resourceCount == 0:
-		diags = append(diags, &hcl.Diagnostic{
-			Severity: hcl.DiagError,
-			Summary:  "Invalid linked_resource expression",
-			Detail:   "Missing resource reference in linked_resource expression.",
-			Subject:  expr.Range().Ptr(),
-		})
-	case resourceCount > 1:
-		diags = append(diags, &hcl.Diagnostic{
-			Severity: hcl.DiagError,
-			Summary:  "Invalid linked_resource expression",
-			Detail:   "Multiple resource references in linked_resource expression.",
-			Subject:  expr.Range().Ptr(),
-		})
-	}
-
-	return expr, diags
 }

--- a/internal/configs/module_merge.go
+++ b/internal/configs/module_merge.go
@@ -304,10 +304,6 @@ func (a *Action) merge(oa *Action, rps map[string]*RequiredProvider) hcl.Diagnos
 		}
 	}
 
-	if oa.LinkedResources != nil {
-		a.LinkedResources = oa.LinkedResources
-	}
-
 	a.Config = MergeBodies(a.Config, oa.Config)
 
 	/* depends_on: not yet supported in Actions

--- a/internal/configs/module_merge.go
+++ b/internal/configs/module_merge.go
@@ -306,18 +306,5 @@ func (a *Action) merge(oa *Action, rps map[string]*RequiredProvider) hcl.Diagnos
 
 	a.Config = MergeBodies(a.Config, oa.Config)
 
-	/* depends_on: not yet supported in Actions
-	// We don't allow depends_on to be overridden because that is likely to
-	// cause confusing misbehavior.
-	if len(oa.DependsOn) != 0 {
-		diags = append(diags, &hcl.Diagnostic{
-			Severity: hcl.DiagError,
-			Summary:  "Unsupported override",
-			Detail:   "The depends_on argument may not be overridden.",
-			Subject:  oa.DependsOn[0].SourceRange().Ptr(), // the first item is the closest range we have
-		})
-	}
-	*/
-
 	return diags
 }

--- a/internal/lang/eval.go
+++ b/internal/lang/eval.go
@@ -443,7 +443,7 @@ func (s *Scope) evalContext(refs []*addrs.Reference, selfAddr addrs.Referenceabl
 			return nil, diags.Append(&hcl.Diagnostic{
 				Severity: hcl.DiagError,
 				Summary:  "Invalid reference",
-				Detail:   "Actions can't be referenced in this context, they can only be referenced from within a resources lifecycle events list.",
+				Detail:   "Actions can not be referenced in this context. They can only be referenced from within a resource's lifecycle actions list.",
 				Subject:  rng.ToHCL().Ptr(),
 			})
 

--- a/internal/plans/changes_src.go
+++ b/internal/plans/changes_src.go
@@ -558,11 +558,11 @@ func (cs *ChangeSrc) Decode(schema *providers.Schema) (*Change, error) {
 	}, nil
 }
 
-// AppendResourceInstanceChange records the given resource instance change in
+// AppendActionInvocationInstanceChange records the given resource instance change in
 // the set of planned resource changes.
 func (c *ChangesSrc) AppendActionInvocationInstanceChange(action *ActionInvocationInstanceSrc) {
 	if c == nil {
-		panic("AppendResourceInstanceChange on nil ChangesSync")
+		panic("AppendActionInvocationInstanceChange on nil ChangesSync")
 	}
 
 	a := action.DeepCopy()
@@ -579,7 +579,7 @@ type ActionInvocationInstanceSrc struct {
 	ProviderAddr addrs.AbsProviderConfig
 }
 
-// Decode unmarshals the raw representation of any linked resources.
+// Decode unmarshals the raw representation of actions.
 func (acs *ActionInvocationInstanceSrc) Decode(schema *providers.ActionSchema) (*ActionInvocationInstance, error) {
 	ty := cty.DynamicPseudoType
 	if schema != nil {

--- a/internal/plans/planfile/tfplan_test.go
+++ b/internal/plans/planfile/tfplan_test.go
@@ -442,7 +442,7 @@ func examplePlanForTest(t *testing.T) *plans.Plan {
 			{
 				DeferredReason: providers.DeferredReasonDeferredPrereq,
 				ActionInvocationInstanceSrc: &plans.ActionInvocationInstanceSrc{
-					Addr: addrs.Action{Type: "test_unlinked", Name: "generic_action"}.Absolute(addrs.RootModuleInstance).Instance(addrs.NoKey),
+					Addr: addrs.Action{Type: "test_action", Name: "example"}.Absolute(addrs.RootModuleInstance).Instance(addrs.NoKey),
 					ActionTrigger: &plans.LifecycleActionTrigger{
 						TriggeringResourceAddr: addrs.Resource{
 							Mode: addrs.ManagedResourceMode,

--- a/internal/plans/planproto/planfile.pb.go
+++ b/internal/plans/planproto/planfile.pb.go
@@ -542,8 +542,7 @@ type Plan struct {
 	// checks, and each of those may have zero or more dynamic objects that
 	// the checks were applied to nested within.
 	CheckResults []*CheckResults `protobuf:"bytes,19,rep,name=check_results,json=checkResults,proto3" json:"check_results,omitempty"`
-	// An unordered set of proposed action invocations. This includes any
-	// embedded ResourceInstanceActionChanges for LinkedResources
+	// An unordered set of proposed action invocations.
 	ActionInvocations []*ActionInvocationInstance `protobuf:"bytes,30,rep,name=action_invocations,json=actionInvocations,proto3" json:"action_invocations,omitempty"`
 	// An unordered set of target addresses to include when applying. If no
 	// target addresses are present, the plan applies to the whole
@@ -1733,9 +1732,8 @@ type ActionInvocationInstance struct {
 	// provider is the address of the provider configuration that this change
 	// was planned with, and thus the configuration that must be used to
 	// apply it.
-	Provider        string                          `protobuf:"bytes,2,opt,name=provider,proto3" json:"provider,omitempty"`
-	LinkedResources []*ResourceInstanceActionChange `protobuf:"bytes,3,rep,name=linked_resources,json=linkedResources,proto3" json:"linked_resources,omitempty"`
-	ConfigValue     *DynamicValue                   `protobuf:"bytes,4,opt,name=config_value,json=configValue,proto3" json:"config_value,omitempty"`
+	Provider    string        `protobuf:"bytes,2,opt,name=provider,proto3" json:"provider,omitempty"`
+	ConfigValue *DynamicValue `protobuf:"bytes,4,opt,name=config_value,json=configValue,proto3" json:"config_value,omitempty"`
 	// An unordered set of paths into config_value which are marked as
 	// sensitive. Values at these paths should be obscured in human-readable
 	// output.
@@ -1791,13 +1789,6 @@ func (x *ActionInvocationInstance) GetProvider() string {
 		return x.Provider
 	}
 	return ""
-}
-
-func (x *ActionInvocationInstance) GetLinkedResources() []*ResourceInstanceActionChange {
-	if x != nil {
-		return x.LinkedResources
-	}
-	return nil
 }
 
 func (x *ActionInvocationInstance) GetConfigValue() *DynamicValue {
@@ -2349,11 +2340,10 @@ const file_planfile_proto_rawDesc = "" +
 	"\aunknown\x18\x02 \x01(\bR\aunknown\x120\n" +
 	"\bidentity\x18\x03 \x01(\v2\x14.tfplan.DynamicValueR\bidentity\":\n" +
 	"\bDeferred\x12.\n" +
-	"\x06reason\x18\x01 \x01(\x0e2\x16.tfplan.DeferredReasonR\x06reason\"\xd9\x03\n" +
+	"\x06reason\x18\x01 \x01(\x0e2\x16.tfplan.DeferredReasonR\x06reason\"\x88\x03\n" +
 	"\x18ActionInvocationInstance\x12\x12\n" +
 	"\x04addr\x18\x01 \x01(\tR\x04addr\x12\x1a\n" +
-	"\bprovider\x18\x02 \x01(\tR\bprovider\x12O\n" +
-	"\x10linked_resources\x18\x03 \x03(\v2$.tfplan.ResourceInstanceActionChangeR\x0flinkedResources\x127\n" +
+	"\bprovider\x18\x02 \x01(\tR\bprovider\x127\n" +
 	"\fconfig_value\x18\x04 \x01(\v2\x14.tfplan.DynamicValueR\vconfigValue\x12B\n" +
 	"\x16sensitive_config_paths\x18\x05 \x03(\v2\f.tfplan.PathR\x14sensitiveConfigPaths\x12Z\n" +
 	"\x18lifecycle_action_trigger\x18\x06 \x01(\v2\x1e.tfplan.LifecycleActionTriggerH\x00R\x16lifecycleActionTrigger\x12Q\n" +
@@ -2507,22 +2497,21 @@ var file_planfile_proto_depIdxs = []int32{
 	29, // 34: tfplan.Path.steps:type_name -> tfplan.Path.Step
 	18, // 35: tfplan.Importing.identity:type_name -> tfplan.DynamicValue
 	3,  // 36: tfplan.Deferred.reason:type_name -> tfplan.DeferredReason
-	25, // 37: tfplan.ActionInvocationInstance.linked_resources:type_name -> tfplan.ResourceInstanceActionChange
-	18, // 38: tfplan.ActionInvocationInstance.config_value:type_name -> tfplan.DynamicValue
-	19, // 39: tfplan.ActionInvocationInstance.sensitive_config_paths:type_name -> tfplan.Path
-	23, // 40: tfplan.ActionInvocationInstance.lifecycle_action_trigger:type_name -> tfplan.LifecycleActionTrigger
-	24, // 41: tfplan.ActionInvocationInstance.invoke_action_trigger:type_name -> tfplan.InvokeActionTrigger
-	4,  // 42: tfplan.LifecycleActionTrigger.trigger_event:type_name -> tfplan.ActionTriggerEvent
-	11, // 43: tfplan.ResourceInstanceActionChange.change:type_name -> tfplan.Change
-	18, // 44: tfplan.Plan.VariablesEntry.value:type_name -> tfplan.DynamicValue
-	19, // 45: tfplan.Plan.resource_attr.attr:type_name -> tfplan.Path
-	5,  // 46: tfplan.CheckResults.ObjectResult.status:type_name -> tfplan.CheckResults.Status
-	18, // 47: tfplan.Path.Step.element_key:type_name -> tfplan.DynamicValue
-	48, // [48:48] is the sub-list for method output_type
-	48, // [48:48] is the sub-list for method input_type
-	48, // [48:48] is the sub-list for extension type_name
-	48, // [48:48] is the sub-list for extension extendee
-	0,  // [0:48] is the sub-list for field type_name
+	18, // 37: tfplan.ActionInvocationInstance.config_value:type_name -> tfplan.DynamicValue
+	19, // 38: tfplan.ActionInvocationInstance.sensitive_config_paths:type_name -> tfplan.Path
+	23, // 39: tfplan.ActionInvocationInstance.lifecycle_action_trigger:type_name -> tfplan.LifecycleActionTrigger
+	24, // 40: tfplan.ActionInvocationInstance.invoke_action_trigger:type_name -> tfplan.InvokeActionTrigger
+	4,  // 41: tfplan.LifecycleActionTrigger.trigger_event:type_name -> tfplan.ActionTriggerEvent
+	11, // 42: tfplan.ResourceInstanceActionChange.change:type_name -> tfplan.Change
+	18, // 43: tfplan.Plan.VariablesEntry.value:type_name -> tfplan.DynamicValue
+	19, // 44: tfplan.Plan.resource_attr.attr:type_name -> tfplan.Path
+	5,  // 45: tfplan.CheckResults.ObjectResult.status:type_name -> tfplan.CheckResults.Status
+	18, // 46: tfplan.Path.Step.element_key:type_name -> tfplan.DynamicValue
+	47, // [47:47] is the sub-list for method output_type
+	47, // [47:47] is the sub-list for method input_type
+	47, // [47:47] is the sub-list for extension type_name
+	47, // [47:47] is the sub-list for extension extendee
+	0,  // [0:47] is the sub-list for field type_name
 }
 
 func init() { file_planfile_proto_init() }

--- a/internal/plans/planproto/planfile.proto
+++ b/internal/plans/planproto/planfile.proto
@@ -99,8 +99,7 @@ message Plan {
     // the checks were applied to nested within.
     repeated CheckResults check_results = 19;
 
-    // An unordered set of proposed action invocations. This includes any
-    // embedded ResourceInstanceActionChanges for LinkedResources
+    // An unordered set of proposed action invocations.
     repeated ActionInvocationInstance action_invocations = 30;
 
     // An unordered set of target addresses to include when applying. If no
@@ -471,7 +470,6 @@ message ActionInvocationInstance {
     // apply it.
     string provider = 2;
 
-    repeated ResourceInstanceActionChange linked_resources = 3;
     DynamicValue config_value = 4;
     // An unordered set of paths into config_value which are marked as
     // sensitive. Values at these paths should be obscured in human-readable

--- a/internal/plugin/grpc_provider_test.go
+++ b/internal/plugin/grpc_provider_test.go
@@ -12,21 +12,21 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/hashicorp/terraform/internal/addrs"
-	"github.com/hashicorp/terraform/internal/configs/configschema"
-	"github.com/hashicorp/terraform/internal/configs/hcl2shim"
-	"github.com/hashicorp/terraform/internal/plans"
-	"github.com/hashicorp/terraform/internal/providers"
-	"github.com/hashicorp/terraform/internal/schemarepo"
-	"github.com/hashicorp/terraform/internal/tfdiags"
 	"github.com/zclconf/go-cty/cty"
 	"go.uber.org/mock/gomock"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
+	"github.com/hashicorp/terraform/internal/addrs"
+	"github.com/hashicorp/terraform/internal/configs/configschema"
+	"github.com/hashicorp/terraform/internal/configs/hcl2shim"
+	"github.com/hashicorp/terraform/internal/plans"
 	"github.com/hashicorp/terraform/internal/plugin/convert"
 	mockproto "github.com/hashicorp/terraform/internal/plugin/mock_proto"
+	"github.com/hashicorp/terraform/internal/providers"
+	"github.com/hashicorp/terraform/internal/schemarepo"
+	"github.com/hashicorp/terraform/internal/tfdiags"
 	proto "github.com/hashicorp/terraform/internal/tfplugin5"
 )
 
@@ -150,7 +150,7 @@ func providerProtoSchema() *proto.GetProviderSchema_Response {
 			},
 		},
 		ActionSchemas: map[string]*proto.ActionSchema{
-			"unlinked": {
+			"action": {
 				Schema: &proto.Schema{
 					Block: &proto.Schema_Block{
 						Version: 1,
@@ -1525,7 +1525,7 @@ func TestGRPCProvider_Encode(t *testing.T) {
 	}
 }
 
-func TestGRPCProvider_planAction_unlinked_valid(t *testing.T) {
+func TestGRPCProvider_planAction_valid(t *testing.T) {
 	client := mockProviderClient(t)
 	p := &GRPCProvider{
 		client: client,
@@ -1537,7 +1537,7 @@ func TestGRPCProvider_planAction_unlinked_valid(t *testing.T) {
 	).Return(&proto.PlanAction_Response{}, nil)
 
 	resp := p.PlanAction(providers.PlanActionRequest{
-		ActionType: "unlinked",
+		ActionType: "action",
 		ProposedActionData: cty.ObjectVal(map[string]cty.Value{
 			"attr": cty.StringVal("foo"),
 		}),
@@ -1546,7 +1546,7 @@ func TestGRPCProvider_planAction_unlinked_valid(t *testing.T) {
 	checkDiags(t, resp.Diagnostics)
 }
 
-func TestGRPCProvider_planAction_unlinked_valid_but_fails(t *testing.T) {
+func TestGRPCProvider_planAction_valid_but_fails(t *testing.T) {
 	client := mockProviderClient(t)
 	p := &GRPCProvider{
 		client: client,
@@ -1566,7 +1566,7 @@ func TestGRPCProvider_planAction_unlinked_valid_but_fails(t *testing.T) {
 	}, nil)
 
 	resp := p.PlanAction(providers.PlanActionRequest{
-		ActionType: "unlinked",
+		ActionType: "action",
 		ProposedActionData: cty.ObjectVal(map[string]cty.Value{
 			"attr": cty.StringVal("foo"),
 		}),
@@ -1575,14 +1575,14 @@ func TestGRPCProvider_planAction_unlinked_valid_but_fails(t *testing.T) {
 	checkDiagsHasError(t, resp.Diagnostics)
 }
 
-func TestGRPCProvider_planAction_unlinked_invalid_config(t *testing.T) {
+func TestGRPCProvider_planAction_invalid_config(t *testing.T) {
 	client := mockProviderClient(t)
 	p := &GRPCProvider{
 		client: client,
 	}
 
 	resp := p.PlanAction(providers.PlanActionRequest{
-		ActionType: "unlinked",
+		ActionType: "action",
 		ProposedActionData: cty.ObjectVal(map[string]cty.Value{
 			"not_the_right_attr": cty.StringVal("foo"),
 		}),

--- a/internal/plugin6/grpc_provider_test.go
+++ b/internal/plugin6/grpc_provider_test.go
@@ -157,7 +157,7 @@ func providerProtoSchema() *proto.GetProviderSchema_Response {
 			},
 		},
 		ActionSchemas: map[string]*proto.ActionSchema{
-			"unlinked": {
+			"action": {
 				Schema: &proto.Schema{
 					Block: &proto.Schema_Block{
 						Version: 1,
@@ -1989,7 +1989,7 @@ func TestGRPCProvider_ListResource_Limit(t *testing.T) {
 	}
 }
 
-func TestGRPCProvider_planAction_unlinked_valid(t *testing.T) {
+func TestGRPCProvider_planAction_valid(t *testing.T) {
 	client := mockProviderClient(t)
 	p := &GRPCProvider{
 		client: client,
@@ -2002,7 +2002,7 @@ func TestGRPCProvider_planAction_unlinked_valid(t *testing.T) {
 	).Return(&proto.PlanAction_Response{}, nil)
 
 	resp := p.PlanAction(providers.PlanActionRequest{
-		ActionType: "unlinked",
+		ActionType: "action",
 		ProposedActionData: cty.ObjectVal(map[string]cty.Value{
 			"attr": cty.StringVal("foo"),
 		}),
@@ -2011,7 +2011,7 @@ func TestGRPCProvider_planAction_unlinked_valid(t *testing.T) {
 	checkDiags(t, resp.Diagnostics)
 }
 
-func TestGRPCProvider_planAction_unlinked_valid_but_fails(t *testing.T) {
+func TestGRPCProvider_planAction_valid_but_fails(t *testing.T) {
 	client := mockProviderClient(t)
 	p := &GRPCProvider{
 		client: client,
@@ -2031,7 +2031,7 @@ func TestGRPCProvider_planAction_unlinked_valid_but_fails(t *testing.T) {
 	}, nil)
 
 	resp := p.PlanAction(providers.PlanActionRequest{
-		ActionType: "unlinked",
+		ActionType: "action",
 		ProposedActionData: cty.ObjectVal(map[string]cty.Value{
 			"attr": cty.StringVal("foo"),
 		}),
@@ -2040,14 +2040,14 @@ func TestGRPCProvider_planAction_unlinked_valid_but_fails(t *testing.T) {
 	checkDiagsHasError(t, resp.Diagnostics)
 }
 
-func TestGRPCProvider_planAction_unlinked_invalid_config(t *testing.T) {
+func TestGRPCProvider_planAction_invalid_config(t *testing.T) {
 	client := mockProviderClient(t)
 	p := &GRPCProvider{
 		client: client,
 	}
 
 	resp := p.PlanAction(providers.PlanActionRequest{
-		ActionType: "unlinked",
+		ActionType: "action",
 		ProposedActionData: cty.ObjectVal(map[string]cty.Value{
 			"not_the_right_attr": cty.StringVal("foo"),
 		}),
@@ -2056,7 +2056,7 @@ func TestGRPCProvider_planAction_unlinked_invalid_config(t *testing.T) {
 	checkDiagsHasError(t, resp.Diagnostics)
 }
 
-func TestGRPCProvider_invokeAction_unlinked_valid(t *testing.T) {
+func TestGRPCProvider_invokeAction_valid(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	client := mockProviderClient(t)
 	p := &GRPCProvider{
@@ -2084,7 +2084,7 @@ func TestGRPCProvider_invokeAction_unlinked_valid(t *testing.T) {
 	).Return(mockInvokeClient, nil)
 
 	resp := p.InvokeAction(providers.InvokeActionRequest{
-		ActionType: "unlinked",
+		ActionType: "action",
 		PlannedActionData: cty.ObjectVal(map[string]cty.Value{
 			"attr": cty.StringVal("foo"),
 		}),
@@ -2102,14 +2102,14 @@ func TestGRPCProvider_invokeAction_unlinked_valid(t *testing.T) {
 	checkDiags(t, resp.Diagnostics)
 }
 
-func TestGRPCProvider_invokeAction_unlinked_invalid(t *testing.T) {
+func TestGRPCProvider_invokeAction_invalid(t *testing.T) {
 	client := mockProviderClient(t)
 	p := &GRPCProvider{
 		client: client,
 	}
 
 	resp := p.InvokeAction(providers.InvokeActionRequest{
-		ActionType: "unlinked",
+		ActionType: "action",
 		PlannedActionData: cty.ObjectVal(map[string]cty.Value{
 			"not-defined": cty.StringVal("foo"),
 		}),
@@ -2117,8 +2117,6 @@ func TestGRPCProvider_invokeAction_unlinked_invalid(t *testing.T) {
 
 	checkDiagsHasError(t, resp.Diagnostics)
 }
-
-// Lifecycle and linked action invoke tests removed after deprecation.
 
 func TestGRPCProvider_ValidateStateStoreConfig_returns_validation_errors(t *testing.T) {
 	storeName := "mock_store" // mockProviderClient returns a mock that has this state store in its schemas

--- a/internal/terraform/context_apply_action_test.go
+++ b/internal/terraform/context_apply_action_test.go
@@ -37,18 +37,17 @@ func TestContextApply_actions(t *testing.T) {
 		expectInvokeActionCalled            bool
 		expectInvokeActionCalls             []providers.InvokeActionRequest
 		expectInvokeActionCallsAreUnordered bool
-
-		expectDiagnostics func(m *configs.Config) tfdiags.Diagnostics
+		expectDiagnostics                   func(m *configs.Config) tfdiags.Diagnostics
 	}{
 		"before_create triggered": {
 			module: map[string]string{
 				"main.tf": `
-action "act_unlinked" "hello" {}
+action "action_example" "hello" {}
 resource "test_object" "a" {
   lifecycle {
     action_trigger {
       events = [before_create]
-      actions = [action.act_unlinked.hello]
+      actions = [action.action_example.hello]
     }
   }
 }
@@ -60,12 +59,12 @@ resource "test_object" "a" {
 		"after_create triggered": {
 			module: map[string]string{
 				"main.tf": `
-action "act_unlinked" "hello" {}
+action "action_example" "hello" {}
 resource "test_object" "a" {
   lifecycle {
     action_trigger {
       events = [after_create]
-      actions = [action.act_unlinked.hello]
+      actions = [action.action_example.hello]
     }
   }
 }
@@ -77,13 +76,13 @@ resource "test_object" "a" {
 		"before_update triggered": {
 			module: map[string]string{
 				"main.tf": `
-action "act_unlinked" "hello" {}
+action "action_example" "hello" {}
 resource "test_object" "a" {
   name = "new name"
   lifecycle {
     action_trigger {
       events = [before_update]
-      actions = [action.act_unlinked.hello]
+      actions = [action.action_example.hello]
     }
   }
 }
@@ -112,13 +111,13 @@ resource "test_object" "a" {
 		"after_update triggered": {
 			module: map[string]string{
 				"main.tf": `
-action "act_unlinked" "hello" {}
+action "action_example" "hello" {}
 resource "test_object" "a" {
   name = "new name"
   lifecycle {
     action_trigger {
       events = [after_update]
-      actions = [action.act_unlinked.hello]
+      actions = [action.action_example.hello]
     }
   }
 }
@@ -147,12 +146,12 @@ resource "test_object" "a" {
 		"before_create failing": {
 			module: map[string]string{
 				"main.tf": `
-action "act_unlinked" "hello" {}
+action "action_example" "hello" {}
 resource "test_object" "a" {
   lifecycle {
     action_trigger {
       events = [before_create]
-      actions = [action.act_unlinked.hello]
+      actions = [action.action_example.hello]
     }
   }
 }
@@ -180,8 +179,8 @@ resource "test_object" "a" {
 					Detail:   "test case for failing: this simulates a provider failing",
 					Subject: &hcl.Range{
 						Filename: filepath.Join(m.Module.SourceDir, "main.tf"),
-						Start:    hcl.Pos{Line: 7, Column: 18, Byte: 146},
-						End:      hcl.Pos{Line: 7, Column: 43, Byte: 171},
+						Start:    hcl.Pos{Line: 7, Column: 18, Byte: 148},
+						End:      hcl.Pos{Line: 7, Column: 45, Byte: 175},
 					},
 				})
 			},
@@ -190,9 +189,9 @@ resource "test_object" "a" {
 		"before_create failing with successfully completed actions": {
 			module: map[string]string{
 				"main.tf": `
-action "act_unlinked" "hello" {}
-action "act_unlinked" "world" {}
-action "act_unlinked" "failure" {
+action "action_example" "hello" {}
+action "action_example" "world" {}
+action "action_example" "failure" {
   config {
     attr = "failure"
   }
@@ -201,7 +200,7 @@ resource "test_object" "a" {
   lifecycle {
     action_trigger {
       events = [before_create]
-      actions = [action.act_unlinked.hello, action.act_unlinked.world, action.act_unlinked.failure]
+      actions = [action.action_example.hello, action.action_example.world, action.action_example.failure]
     }
   }
 }
@@ -236,8 +235,8 @@ resource "test_object" "a" {
 						Detail:   `test case for failing: this simulates a provider failing`,
 						Subject: &hcl.Range{
 							Filename: filepath.Join(m.Module.SourceDir, "main.tf"),
-							Start:    hcl.Pos{Line: 13, Column: 72, Byte: 305},
-							End:      hcl.Pos{Line: 13, Column: 99, Byte: 332},
+							Start:    hcl.Pos{Line: 13, Column: 76, Byte: 315},
+							End:      hcl.Pos{Line: 13, Column: 105, Byte: 344},
 						},
 					},
 				)
@@ -248,12 +247,12 @@ resource "test_object" "a" {
 		"before_create failing when calling invoke": {
 			module: map[string]string{
 				"main.tf": `
-action "act_unlinked" "hello" {}
+action "action_example" "hello" {}
 resource "test_object" "a" {
   lifecycle {
     action_trigger {
       events = [before_create]
-      actions = [action.act_unlinked.hello]
+      actions = [action.action_example.hello]
     }
   }
 }
@@ -277,8 +276,8 @@ resource "test_object" "a" {
 						Detail:   "test case for failing: this simulates a provider failing before the action is invoked",
 						Subject: &hcl.Range{
 							Filename: filepath.Join(m.Module.SourceDir, "main.tf"),
-							Start:    hcl.Pos{Line: 7, Column: 18, Byte: 146},
-							End:      hcl.Pos{Line: 7, Column: 43, Byte: 171},
+							Start:    hcl.Pos{Line: 7, Column: 18, Byte: 148},
+							End:      hcl.Pos{Line: 7, Column: 47, Byte: 175},
 						},
 					},
 				)
@@ -288,18 +287,18 @@ resource "test_object" "a" {
 		"failing an action by action event stops next actions in list": {
 			module: map[string]string{
 				"main.tf": `
-action "act_unlinked" "hello" {}
-action "act_unlinked" "failure" {
+action "action_example" "hello" {}
+action "action_example" "failure" {
   config {
     attr = "failure"
   }
 }
-action "act_unlinked" "goodbye" {}
+action "action_example" "goodbye" {}
 resource "test_object" "a" {
   lifecycle {
     action_trigger {
       events = [before_create]
-      actions = [action.act_unlinked.hello, action.act_unlinked.failure, action.act_unlinked.goodbye]
+      actions = [action.action_example.hello, action.action_example.failure, action.action_example.goodbye]
     }
   }
 }
@@ -328,8 +327,8 @@ resource "test_object" "a" {
 						Detail:   "test case for failing: this simulates a provider failing",
 						Subject: &hcl.Range{
 							Filename: filepath.Join(m.Module.SourceDir, "main.tf"),
-							Start:    hcl.Pos{Line: 13, Column: 45, Byte: 280},
-							End:      hcl.Pos{Line: 13, Column: 72, Byte: 307},
+							Start:    hcl.Pos{Line: 13, Column: 47, Byte: 288},
+							End:      hcl.Pos{Line: 13, Column: 76, Byte: 317},
 						},
 					},
 				)
@@ -337,12 +336,12 @@ resource "test_object" "a" {
 
 			// We expect two calls but not the third one, because the second action fails
 			expectInvokeActionCalls: []providers.InvokeActionRequest{{
-				ActionType: "act_unlinked",
+				ActionType: "action_example",
 				PlannedActionData: cty.NullVal(cty.Object(map[string]cty.Type{
 					"attr": cty.String,
 				})),
 			}, {
-				ActionType: "act_unlinked",
+				ActionType: "action_example",
 				PlannedActionData: cty.ObjectVal(map[string]cty.Value{
 					"attr": cty.StringVal("failure"),
 				}),
@@ -352,18 +351,18 @@ resource "test_object" "a" {
 		"failing an action during invocation stops next actions in list": {
 			module: map[string]string{
 				"main.tf": `
-action "act_unlinked" "hello" {}
-action "act_unlinked" "failure" {
+action "action_example" "hello" {}
+action "action_example" "failure" {
   config {
     attr = "failure"
   }
 }
-action "act_unlinked" "goodbye" {}
+action "action_example" "goodbye" {}
 resource "test_object" "a" {
   lifecycle {
     action_trigger {
       events = [before_create]
-      actions = [action.act_unlinked.hello, action.act_unlinked.failure, action.act_unlinked.goodbye]
+      actions = [action.action_example.hello, action.action_example.failure, action.action_example.goodbye]
     }
   }
 }
@@ -391,8 +390,8 @@ resource "test_object" "a" {
 						Detail:   "test case for failing: this simulates a provider failing",
 						Subject: &hcl.Range{
 							Filename: filepath.Join(m.Module.SourceDir, "main.tf"),
-							Start:    hcl.Pos{Line: 13, Column: 45, Byte: 280},
-							End:      hcl.Pos{Line: 13, Column: 72, Byte: 307},
+							Start:    hcl.Pos{Line: 13, Column: 47, Byte: 288},
+							End:      hcl.Pos{Line: 13, Column: 76, Byte: 317},
 						},
 					},
 				)
@@ -400,12 +399,12 @@ resource "test_object" "a" {
 
 			// We expect two calls but not the third one, because the second action fails
 			expectInvokeActionCalls: []providers.InvokeActionRequest{{
-				ActionType: "act_unlinked",
+				ActionType: "action_example",
 				PlannedActionData: cty.NullVal(cty.Object(map[string]cty.Type{
 					"attr": cty.String,
 				})),
 			}, {
-				ActionType: "act_unlinked",
+				ActionType: "action_example",
 				PlannedActionData: cty.ObjectVal(map[string]cty.Value{
 					"attr": cty.StringVal("failure"),
 				}),
@@ -415,26 +414,26 @@ resource "test_object" "a" {
 		"failing an action stops next action triggers": {
 			module: map[string]string{
 				"main.tf": `
-action "act_unlinked" "hello" {}
-action "act_unlinked" "failure" {
+action "action_example" "hello" {}
+action "action_example" "failure" {
   config {
     attr = "failure"
   }
 }
-action "act_unlinked" "goodbye" {}
+action "action_example" "goodbye" {}
 resource "test_object" "a" {
   lifecycle {
     action_trigger {
       events = [before_create]
-      actions = [action.act_unlinked.hello]
+      actions = [action.action_example.hello]
     }
     action_trigger {
       events = [before_create]
-      actions = [action.act_unlinked.failure]
+      actions = [action.action_example.failure]
     }
     action_trigger {
       events = [before_create]
-      actions = [action.act_unlinked.goodbye]
+      actions = [action.action_example.goodbye]
     }
   }
 }
@@ -462,20 +461,20 @@ resource "test_object" "a" {
 						Detail:   "test case for failing: this simulates a provider failing",
 						Subject: &hcl.Range{
 							Filename: filepath.Join(m.Module.SourceDir, "main.tf"),
-							Start:    hcl.Pos{Line: 17, Column: 18, Byte: 355},
-							End:      hcl.Pos{Line: 17, Column: 45, Byte: 382},
+							Start:    hcl.Pos{Line: 17, Column: 18, Byte: 363},
+							End:      hcl.Pos{Line: 17, Column: 47, Byte: 392},
 						},
 					},
 				)
 			},
 			// We expect two calls but not the third one, because the second action fails
 			expectInvokeActionCalls: []providers.InvokeActionRequest{{
-				ActionType: "act_unlinked",
+				ActionType: "action_example",
 				PlannedActionData: cty.NullVal(cty.Object(map[string]cty.Type{
 					"attr": cty.String,
 				})),
 			}, {
-				ActionType: "act_unlinked",
+				ActionType: "action_example",
 				PlannedActionData: cty.ObjectVal(map[string]cty.Value{
 					"attr": cty.StringVal("failure"),
 				}),
@@ -488,7 +487,7 @@ resource "test_object" "a" {
 resource "test_object" "a" {
   name = "foo"
 }
-action "act_unlinked" "hello" {
+action "action_example" "hello" {
   config {
     attr = resource.test_object.a.name
   }
@@ -497,7 +496,7 @@ resource "test_object" "b" {
   lifecycle {
     action_trigger {
       events = [before_create]
-      actions = [action.act_unlinked.hello]
+      actions = [action.action_example.hello]
     }
   }
 }
@@ -505,7 +504,7 @@ resource "test_object" "b" {
 			},
 			expectInvokeActionCalled: true,
 			expectInvokeActionCalls: []providers.InvokeActionRequest{{
-				ActionType: "act_unlinked",
+				ActionType: "action_example",
 				PlannedActionData: cty.ObjectVal(map[string]cty.Value{
 					"attr": cty.StringVal("foo"),
 				}),
@@ -519,7 +518,7 @@ resource "test_object" "b" {
 variable "unknown_value" {
   type = string
 }
-action "act_unlinked" "hello" {
+action "action_example" "hello" {
   config {
     attr = var.unknown_value
   }
@@ -528,7 +527,7 @@ resource "test_object" "b" {
   lifecycle {
     action_trigger {
       events = [before_create]
-      actions = [action.act_unlinked.hello]
+      actions = [action.action_example.hello]
     }
   }
 }
@@ -545,11 +544,11 @@ resource "test_object" "b" {
 				return tfdiags.Diagnostics{}.Append(&hcl.Diagnostic{
 					Severity: hcl.DiagError,
 					Summary:  "Action configuration unknown during apply",
-					Detail:   "The action action.act_unlinked.hello was not fully known during apply.\n\nThis is a bug in Terraform, please report it.",
+					Detail:   "The action action.action_example.hello was not fully known during apply.\n\nThis is a bug in Terraform, please report it.",
 					Subject: &hcl.Range{
 						Filename: filepath.Join(m.Module.SourceDir, "main.tf"),
-						Start:    hcl.Pos{Line: 14, Column: 18, Byte: 236},
-						End:      hcl.Pos{Line: 14, Column: 43, Byte: 261},
+						Start:    hcl.Pos{Line: 14, Column: 18, Byte: 238},
+						End:      hcl.Pos{Line: 14, Column: 45, Byte: 265},
 					},
 				})
 			},
@@ -562,7 +561,7 @@ variable "secret_value" {
   type = string
   sensitive = true
 }
-action "act_unlinked" "hello" {
+action "action_example" "hello" {
   config {
     attr = var.secret_value
   }
@@ -571,7 +570,7 @@ resource "test_object" "b" {
   lifecycle {
     action_trigger {
       events = [before_create]
-      actions = [action.act_unlinked.hello]
+      actions = [action.action_example.hello]
     }
   }
 }
@@ -585,7 +584,7 @@ resource "test_object" "b" {
 
 			expectInvokeActionCalled: true,
 			expectInvokeActionCalls: []providers.InvokeActionRequest{{
-				ActionType: "act_unlinked",
+				ActionType: "action_example",
 				PlannedActionData: cty.ObjectVal(map[string]cty.Value{
 					"attr": cty.StringVal("psst, I'm secret"),
 				}),
@@ -595,17 +594,17 @@ resource "test_object" "b" {
 		"aliased provider": {
 			module: map[string]string{
 				"main.tf": `
-provider "act" {
+provider "action" {
   alias = "aliased"
 }
-action "act_unlinked" "hello" {
-  provider = act.aliased
+action "action_example" "hello" {
+  provider = action.aliased
 }
 resource "test_object" "a" {
   lifecycle {
     action_trigger {
       events = [before_create]
-      actions = [action.act_unlinked.hello]
+      actions = [action.action_example.hello]
     }
   }
 }
@@ -624,12 +623,12 @@ terraform {
     }
   }
 }
-action "ecosystem_unlinked" "hello" {}
+action "ecosystem" "hello" {}
 resource "test_object" "a" {
   lifecycle {
     action_trigger {
       events = [before_create]
-      actions = [action.ecosystem_unlinked.hello]
+      actions = [action.ecosystem.hello]
     }
   }
 }
@@ -641,7 +640,7 @@ resource "test_object" "a" {
 		"after_create with config cycle": {
 			module: map[string]string{
 				"main.tf": `
-action "act_unlinked" "hello" {
+action "action_example" "hello" {
   config {
     attr = test_object.a.name
   }
@@ -651,7 +650,7 @@ resource "test_object" "a" {
   lifecycle {
     action_trigger {
       events = [after_create]
-      actions = [action.act_unlinked.hello]
+      actions = [action.action_example.hello]
     }
   }
 }
@@ -659,7 +658,7 @@ resource "test_object" "a" {
 			},
 			expectInvokeActionCalled: true,
 			expectInvokeActionCalls: []providers.InvokeActionRequest{{
-				ActionType: "act_unlinked",
+				ActionType: "action_example",
 				PlannedActionData: cty.ObjectVal(map[string]cty.Value{
 					"attr": cty.StringVal("test_object_a"),
 				}),
@@ -674,12 +673,12 @@ module "mod" {
 }
 `,
 				"mod/mod.tf": `
-action "act_unlinked" "hello" {}
+action "action_example" "hello" {}
 resource "test_object" "a" {
   lifecycle {
     action_trigger {
       events = [before_create]
-      actions = [action.act_unlinked.hello]
+      actions = [action.action_example.hello]
     }
   }
 }
@@ -687,7 +686,7 @@ resource "test_object" "a" {
 			},
 			expectInvokeActionCalled: true,
 			expectInvokeActionCalls: []providers.InvokeActionRequest{{
-				ActionType: "act_unlinked",
+				ActionType: "action_example",
 				PlannedActionData: cty.NullVal(cty.Object(map[string]cty.Type{
 					"attr": cty.String,
 				})),
@@ -703,12 +702,12 @@ module "mod" {
 }
 `,
 				"mod/mod.tf": `
-action "act_unlinked" "hello" {}
+action "action_example" "hello" {}
 resource "test_object" "a" {
   lifecycle {
     action_trigger {
       events = [before_create]
-      actions = [action.act_unlinked.hello]
+      actions = [action.action_example.hello]
     }
   }
 }
@@ -716,12 +715,12 @@ resource "test_object" "a" {
 			},
 			expectInvokeActionCalled: true,
 			expectInvokeActionCalls: []providers.InvokeActionRequest{{
-				ActionType: "act_unlinked",
+				ActionType: "action_example",
 				PlannedActionData: cty.NullVal(cty.Object(map[string]cty.Type{
 					"attr": cty.String,
 				})),
 			}, {
-				ActionType: "act_unlinked",
+				ActionType: "action_example",
 				PlannedActionData: cty.NullVal(cty.Object(map[string]cty.Type{
 					"attr": cty.String,
 				})),
@@ -736,17 +735,17 @@ module "mod" {
 }
 `,
 				"mod/mod.tf": `
-provider "act" {
+provider "action" {
     alias = "inthemodule"
 }
-action "act_unlinked" "hello" {
-  provider = act.inthemodule
+action "action_example" "hello" {
+  provider = action.inthemodule
 }
 resource "test_object" "a" {
   lifecycle {
     action_trigger {
       events = [before_create]
-      actions = [action.act_unlinked.hello]
+      actions = [action.action_example.hello]
     }
   }
 }
@@ -754,7 +753,7 @@ resource "test_object" "a" {
 			},
 			expectInvokeActionCalled: true,
 			expectInvokeActionCalls: []providers.InvokeActionRequest{{
-				ActionType: "act_unlinked",
+				ActionType: "action_example",
 				PlannedActionData: cty.NullVal(cty.Object(map[string]cty.Type{
 					"attr": cty.String,
 				})),
@@ -764,7 +763,7 @@ resource "test_object" "a" {
 		"action for_each": {
 			module: map[string]string{
 				"main.tf": `
-action "act_unlinked" "hello" {
+action "action_example" "hello" {
   for_each = toset(["a", "b"])
   
   config {
@@ -775,7 +774,7 @@ resource "test_object" "a" {
   lifecycle {
     action_trigger {
       events = [before_create]
-      actions = [action.act_unlinked.hello["a"], action.act_unlinked.hello["b"]]
+      actions = [action.action_example.hello["a"], action.action_example.hello["b"]]
     }
   }
 }
@@ -783,12 +782,12 @@ resource "test_object" "a" {
 			},
 			expectInvokeActionCalled: true,
 			expectInvokeActionCalls: []providers.InvokeActionRequest{{
-				ActionType: "act_unlinked",
+				ActionType: "action_example",
 				PlannedActionData: cty.ObjectVal(map[string]cty.Value{
 					"attr": cty.StringVal("value-a"),
 				}),
 			}, {
-				ActionType: "act_unlinked",
+				ActionType: "action_example",
 				PlannedActionData: cty.ObjectVal(map[string]cty.Value{
 					"attr": cty.StringVal("value-b"),
 				}),
@@ -798,7 +797,7 @@ resource "test_object" "a" {
 		"action count": {
 			module: map[string]string{
 				"main.tf": `
-action "act_unlinked" "hello" {
+action "action_example" "hello" {
   count = 2
 
   config {
@@ -810,19 +809,19 @@ resource "test_object" "a" {
   lifecycle {
     action_trigger {
       events = [before_create]
-      actions = [action.act_unlinked.hello[0], action.act_unlinked.hello[1]]
+      actions = [action.action_example.hello[0], action.action_example.hello[1]]
     }
   }
 }
 `,
 			},
 			expectInvokeActionCalls: []providers.InvokeActionRequest{{
-				ActionType: "act_unlinked",
+				ActionType: "action_example",
 				PlannedActionData: cty.ObjectVal(map[string]cty.Value{
 					"attr": cty.StringVal("value-0"),
 				}),
 			}, {
-				ActionType: "act_unlinked",
+				ActionType: "action_example",
 				PlannedActionData: cty.ObjectVal(map[string]cty.Value{
 					"attr": cty.StringVal("value-1"),
 				}),
@@ -832,12 +831,12 @@ resource "test_object" "a" {
 		"before_update triggered - on create": {
 			module: map[string]string{
 				"main.tf": `
-action "act_unlinked" "hello" {}
+action "action_example" "hello" {}
 resource "test_object" "a" {
   lifecycle {
     action_trigger {
       events = [before_update]
-      actions = [action.act_unlinked.hello]
+      actions = [action.action_example.hello]
     }
   }
 }
@@ -849,12 +848,12 @@ resource "test_object" "a" {
 		"after_update triggered - on create": {
 			module: map[string]string{
 				"main.tf": `
-action "act_unlinked" "hello" {}
+action "action_example" "hello" {}
 resource "test_object" "a" {
   lifecycle {
     action_trigger {
       events = [after_update]
-      actions = [action.act_unlinked.hello]
+      actions = [action.action_example.hello]
     }
   }
 }
@@ -866,12 +865,12 @@ resource "test_object" "a" {
 		"before_update triggered - on replace": {
 			module: map[string]string{
 				"main.tf": `
-action "act_unlinked" "hello" {}
+action "action_example" "hello" {}
 resource "test_object" "a" {
   lifecycle {
     action_trigger {
       events = [before_update]
-      actions = [action.act_unlinked.hello]
+      actions = [action.action_example.hello]
     }
   }
 }
@@ -901,12 +900,12 @@ resource "test_object" "a" {
 		"after_update triggered - on replace": {
 			module: map[string]string{
 				"main.tf": `
-action "act_unlinked" "hello" {}
+action "action_example" "hello" {}
 resource "test_object" "a" {
   lifecycle {
     action_trigger {
       events = [after_update]
-      actions = [action.act_unlinked.hello]
+      actions = [action.action_example.hello]
     }
   }
 }
@@ -936,14 +935,14 @@ resource "test_object" "a" {
 		"expanded resource - unexpanded action": {
 			module: map[string]string{
 				"main.tf": `
-action "act_unlinked" "hello" {}
+action "action_example" "hello" {}
 resource "test_object" "a" {
   count = 2
   name = "test-${count.index}"
   lifecycle {
     action_trigger {
       events = [before_create]
-      actions = [action.act_unlinked.hello]
+      actions = [action.action_example.hello]
     }
   }
 }
@@ -951,12 +950,12 @@ resource "test_object" "a" {
 			},
 			expectInvokeActionCalled: true,
 			expectInvokeActionCalls: []providers.InvokeActionRequest{{
-				ActionType: "act_unlinked",
+				ActionType: "action_example",
 				PlannedActionData: cty.NullVal(cty.Object(map[string]cty.Type{
 					"attr": cty.String,
 				})),
 			}, {
-				ActionType: "act_unlinked",
+				ActionType: "action_example",
 				PlannedActionData: cty.NullVal(cty.Object(map[string]cty.Type{
 					"attr": cty.String,
 				})),
@@ -969,7 +968,7 @@ resource "test_object" "a" {
 resource "test_object" "a" {
   name = "a"
 }
-action "act_unlinked" "hello" {
+action "action_example" "hello" {
   config {
     attr = test_object.a.name
   }
@@ -979,7 +978,7 @@ resource "test_object" "b" {
   lifecycle {
     action_trigger {
       events = [before_create]
-      actions = [action.act_unlinked.hello]
+      actions = [action.action_example.hello]
     }
   }
 }
@@ -987,7 +986,7 @@ resource "test_object" "b" {
 			},
 			expectInvokeActionCalled: true,
 			expectInvokeActionCalls: []providers.InvokeActionRequest{{
-				ActionType: "act_unlinked",
+				ActionType: "action_example",
 				PlannedActionData: cty.ObjectVal(map[string]cty.Value{
 					"attr": cty.StringVal("a"),
 				}),
@@ -1003,12 +1002,12 @@ resource "test_object" "a" {
 resource "test_object" "b" {
   name = "b"
 }
-action "act_unlinked" "hello_a" {
+action "action_example" "hello_a" {
   config {
     attr = test_object.a.name
   }
 }
-action "act_unlinked" "hello_b" {
+action "action_example" "hello_b" {
   config {
     attr = test_object.a.name
   }
@@ -1018,7 +1017,7 @@ resource "test_object" "c" {
   lifecycle {
     action_trigger {
       events = [before_create]
-      actions = [action.act_unlinked.hello_a]
+      actions = [action.action_example.hello_a]
     }
   }
 }
@@ -1027,7 +1026,7 @@ resource "test_object" "d" {
   lifecycle {
     action_trigger {
       events = [before_create]
-      actions = [action.act_unlinked.hello_b]
+      actions = [action.action_example.hello_b]
     }
   }
 }
@@ -1036,7 +1035,7 @@ resource "test_object" "e" {
   lifecycle {
     action_trigger {
       events = [before_create]
-      actions = [action.act_unlinked.hello_a, action.act_unlinked.hello_b]
+      actions = [action.action_example.hello_a, action.action_example.hello_b]
     }
   }
 }
@@ -1044,22 +1043,22 @@ resource "test_object" "e" {
 			},
 			expectInvokeActionCalled: true,
 			expectInvokeActionCalls: []providers.InvokeActionRequest{{
-				ActionType: "act_unlinked",
+				ActionType: "action_example",
 				PlannedActionData: cty.ObjectVal(map[string]cty.Value{
 					"attr": cty.StringVal("a"),
 				}),
 			}, {
-				ActionType: "act_unlinked",
+				ActionType: "action_example",
 				PlannedActionData: cty.ObjectVal(map[string]cty.Value{
 					"attr": cty.StringVal("a"),
 				}),
 			}, {
-				ActionType: "act_unlinked",
+				ActionType: "action_example",
 				PlannedActionData: cty.ObjectVal(map[string]cty.Value{
 					"attr": cty.StringVal("a"),
 				}),
 			}, {
-				ActionType: "act_unlinked",
+				ActionType: "action_example",
 				PlannedActionData: cty.ObjectVal(map[string]cty.Value{
 					"attr": cty.StringVal("a"),
 				}),
@@ -1069,12 +1068,12 @@ resource "test_object" "e" {
 		"destroy run": {
 			module: map[string]string{
 				"main.tf": `
-action "act_unlinked" "hello" {}
+action "action_example" "hello" {}
 resource "test_object" "a" {
   lifecycle {
     action_trigger {
       events = [before_create, after_update]
-      actions = [action.act_unlinked.hello]
+      actions = [action.action_example.hello]
     }
   }
 }
@@ -1104,13 +1103,13 @@ resource "test_object" "a" {
 		"destroying expanded node": {
 			module: map[string]string{
 				"main.tf": `
-action "act_unlinked" "hello" {}
+action "action_example" "hello" {}
 resource "test_object" "a" {
   count = 2
   lifecycle {
     action_trigger {
       events = [before_create, after_update]
-      actions = [action.act_unlinked.hello]
+      actions = [action.action_example.hello]
     }
   }
 }
@@ -1172,7 +1171,7 @@ resource "test_object" "a" {
 		"action config with after_create dependency to triggering resource": {
 			module: map[string]string{
 				"main.tf": `
-action "act_unlinked" "hello" {
+action "action_example" "hello" {
   config {
     attr = test_object.a.name
   }
@@ -1182,7 +1181,7 @@ resource "test_object" "a" {
   lifecycle {
     action_trigger {
       events = [after_create]
-      actions = [action.act_unlinked.hello]
+      actions = [action.action_example.hello]
     }
   }
 }
@@ -1190,7 +1189,7 @@ resource "test_object" "a" {
 			},
 			expectInvokeActionCalled: true,
 			expectInvokeActionCalls: []providers.InvokeActionRequest{{
-				ActionType: "act_unlinked",
+				ActionType: "action_example",
 				PlannedActionData: cty.ObjectVal(map[string]cty.Value{
 					"attr": cty.StringVal("test_name"),
 				}),
@@ -1205,13 +1204,13 @@ module "action_mod" {
 }
 `,
 				"action_mod/main.tf": `
-action "act_unlinked" "hello" {}
+action "action_example" "hello" {}
 resource "test_object" "trigger" {
   name = "trigger_resource"
   lifecycle {
     action_trigger {
       events = [before_create]
-      actions = [action.act_unlinked.hello]
+      actions = [action.action_example.hello]
     }
   }
 }
@@ -1219,7 +1218,7 @@ resource "test_object" "trigger" {
 			},
 			expectInvokeActionCalled: true,
 			expectInvokeActionCalls: []providers.InvokeActionRequest{{
-				ActionType: "act_unlinked",
+				ActionType: "action_example",
 				PlannedActionData: cty.NullVal(cty.Object(map[string]cty.Type{
 					"attr": cty.String,
 				})),
@@ -1239,7 +1238,7 @@ module "child" {
 }
 `,
 				"parent/child/main.tf": `
-action "act_unlinked" "nested_action" {
+action "action_example" "nested_action" {
   config {
     attr = "nested_value"
   }
@@ -1249,7 +1248,7 @@ resource "test_object" "nested_resource" {
   lifecycle {
     action_trigger {
       events = [before_create]
-      actions = [action.act_unlinked.nested_action]
+      actions = [action.action_example.nested_action]
     }
   }
 }
@@ -1257,7 +1256,7 @@ resource "test_object" "nested_resource" {
 			},
 			expectInvokeActionCalled: true,
 			expectInvokeActionCalls: []providers.InvokeActionRequest{{
-				ActionType: "act_unlinked",
+				ActionType: "action_example",
 				PlannedActionData: cty.ObjectVal(map[string]cty.Value{
 					"attr": cty.StringVal("nested_value"),
 				}),
@@ -1278,7 +1277,7 @@ variable "instance_name" {
   type = string
 }
 
-action "act_unlinked" "hello" {
+action "action_example" "hello" {
   config {
     attr = "instance-${var.instance_name}"
   }
@@ -1288,7 +1287,7 @@ resource "test_object" "resource" {
   lifecycle {
     action_trigger {
       events = [before_create]
-      actions = [action.act_unlinked.hello]
+      actions = [action.action_example.hello]
     }
   }
 }
@@ -1297,12 +1296,12 @@ resource "test_object" "resource" {
 			expectInvokeActionCalled:            true,
 			expectInvokeActionCallsAreUnordered: true, // The order depends on the order of the modules
 			expectInvokeActionCalls: []providers.InvokeActionRequest{{
-				ActionType: "act_unlinked",
+				ActionType: "action_example",
 				PlannedActionData: cty.ObjectVal(map[string]cty.Value{
 					"attr": cty.StringVal("instance-a"),
 				}),
 			}, {
-				ActionType: "act_unlinked",
+				ActionType: "action_example",
 				PlannedActionData: cty.ObjectVal(map[string]cty.Value{
 					"attr": cty.StringVal("instance-b"),
 				}),
@@ -1322,12 +1321,12 @@ resource "test_object" "resource" {
   lifecycle {
     action_trigger {
       events = [before_create]
-      actions = [action.act_unlinked_wo.hello]
+      actions = [action.action_example_wo.hello]
     }
   }
 }
 
-action "act_unlinked_wo" "hello" {
+action "action_example_wo" "hello" {
   config {
     attr = var.attr
   }
@@ -1337,7 +1336,7 @@ action "act_unlinked_wo" "hello" {
 			expectInvokeActionCalled: true,
 			expectInvokeActionCalls: []providers.InvokeActionRequest{
 				{
-					ActionType: "act_unlinked_wo",
+					ActionType: "action_example_wo",
 					PlannedActionData: cty.ObjectVal(map[string]cty.Value{
 						"attr": cty.StringVal("wo-apply"),
 					}),
@@ -1359,12 +1358,12 @@ action "act_unlinked_wo" "hello" {
 		"simple action invoke": {
 			module: map[string]string{
 				"main.tf": `
-action "act_unlinked" "one" {
+action "action_example" "one" {
   config {
     attr = "one"
   }
 }
-action "act_unlinked" "two" {
+action "action_example" "two" {
   config {
     attr = "two"
   }
@@ -1374,7 +1373,7 @@ action "act_unlinked" "two" {
 			expectInvokeActionCalled: true,
 			expectInvokeActionCalls: []providers.InvokeActionRequest{
 				{
-					ActionType: "act_unlinked",
+					ActionType: "action_example",
 					PlannedActionData: cty.ObjectVal(map[string]cty.Value{
 						"attr": cty.StringVal("one"),
 					}),
@@ -1386,7 +1385,7 @@ action "act_unlinked" "two" {
 					addrs.AbsActionInstance{
 						Action: addrs.ActionInstance{
 							Action: addrs.Action{
-								Type: "act_unlinked",
+								Type: "action_example",
 								Name: "one",
 							},
 							Key: addrs.NoKey,
@@ -1399,14 +1398,14 @@ action "act_unlinked" "two" {
 		"action invoke with count (all)": {
 			module: map[string]string{
 				"main.tf": `
-action "act_unlinked" "one" {
+action "action_example" "one" {
   count = 2
 
   config {
     attr = "${count.index}"
   }
 }
-action "act_unlinked" "two" {
+action "action_example" "two" {
   count = 2
 
   config {
@@ -1420,7 +1419,7 @@ action "act_unlinked" "two" {
 				ActionTargets: []addrs.Targetable{
 					addrs.AbsAction{
 						Action: addrs.Action{
-							Type: "act_unlinked",
+							Type: "action_example",
 							Name: "one",
 						},
 					},
@@ -1429,13 +1428,13 @@ action "act_unlinked" "two" {
 			expectInvokeActionCalled: true,
 			expectInvokeActionCalls: []providers.InvokeActionRequest{
 				{
-					ActionType: "act_unlinked",
+					ActionType: "action_example",
 					PlannedActionData: cty.ObjectVal(map[string]cty.Value{
 						"attr": cty.StringVal("0"),
 					}),
 				},
 				{
-					ActionType: "act_unlinked",
+					ActionType: "action_example",
 					PlannedActionData: cty.ObjectVal(map[string]cty.Value{
 						"attr": cty.StringVal("1"),
 					}),
@@ -1447,14 +1446,14 @@ action "act_unlinked" "two" {
 		"action invoke with count (instance)": {
 			module: map[string]string{
 				"main.tf": `
-action "act_unlinked" "one" {
+action "action_example" "one" {
   count = 2
 
   config {
     attr = "${count.index}"
   }
 }
-action "act_unlinked" "two" {
+action "action_example" "two" {
   count = 2
 
   config {
@@ -1469,7 +1468,7 @@ action "act_unlinked" "two" {
 					addrs.AbsActionInstance{
 						Action: addrs.ActionInstance{
 							Action: addrs.Action{
-								Type: "act_unlinked",
+								Type: "action_example",
 								Name: "one",
 							},
 							Key: addrs.IntKey(0),
@@ -1480,7 +1479,7 @@ action "act_unlinked" "two" {
 			expectInvokeActionCalled: true,
 			expectInvokeActionCalls: []providers.InvokeActionRequest{
 				{
-					ActionType: "act_unlinked",
+					ActionType: "action_example",
 					PlannedActionData: cty.ObjectVal(map[string]cty.Value{
 						"attr": cty.StringVal("0"),
 					}),
@@ -1495,7 +1494,7 @@ resource "test_object" "a" {
   name = "hello"
 }
 
-action "act_unlinked" "one" {
+action "action_example" "one" {
   config {
     attr = test_object.a.name
   }
@@ -1507,7 +1506,7 @@ action "act_unlinked" "one" {
 				ActionTargets: []addrs.Targetable{
 					addrs.AbsAction{
 						Action: addrs.Action{
-							Type: "act_unlinked",
+							Type: "action_example",
 							Name: "one",
 						},
 					},
@@ -1516,7 +1515,7 @@ action "act_unlinked" "one" {
 			expectInvokeActionCalled: true,
 			expectInvokeActionCalls: []providers.InvokeActionRequest{
 				{
-					ActionType: "act_unlinked",
+					ActionType: "action_example",
 					PlannedActionData: cty.ObjectVal(map[string]cty.Value{
 						"attr": cty.StringVal("hello"),
 					}),
@@ -1537,7 +1536,7 @@ resource "test_object" "a" {
   name = "hello"
 }
 
-action "act_unlinked" "one" {
+action "action_example" "one" {
   config {
     attr = test_object.a.name
   }
@@ -1549,7 +1548,7 @@ action "act_unlinked" "one" {
 				ActionTargets: []addrs.Targetable{
 					addrs.AbsAction{
 						Action: addrs.Action{
-							Type: "act_unlinked",
+							Type: "action_example",
 							Name: "one",
 						},
 					},
@@ -1558,7 +1557,7 @@ action "act_unlinked" "one" {
 			expectInvokeActionCalled: true,
 			expectInvokeActionCalls: []providers.InvokeActionRequest{
 				{
-					ActionType: "act_unlinked",
+					ActionType: "action_example",
 					PlannedActionData: cty.ObjectVal(map[string]cty.Value{
 						"attr": cty.StringVal("drifted value"),
 					}),
@@ -1586,7 +1585,7 @@ resource "test_object" "a" {
   name = "hello"
 }
 
-action "act_unlinked" "one" {
+action "action_example" "one" {
   config {
     attr = test_object.a.name
   }
@@ -1599,7 +1598,7 @@ action "act_unlinked" "one" {
 				ActionTargets: []addrs.Targetable{
 					addrs.AbsAction{
 						Action: addrs.Action{
-							Type: "act_unlinked",
+							Type: "action_example",
 							Name: "one",
 						},
 					},
@@ -1608,7 +1607,7 @@ action "act_unlinked" "one" {
 			expectInvokeActionCalled: true,
 			expectInvokeActionCalls: []providers.InvokeActionRequest{
 				{
-					ActionType: "act_unlinked",
+					ActionType: "action_example",
 					PlannedActionData: cty.ObjectVal(map[string]cty.Value{
 						"attr": cty.StringVal("hello"),
 					}),
@@ -1632,7 +1631,7 @@ action "act_unlinked" "one" {
 		"nested action config single + list blocks applies": {
 			module: map[string]string{
 				"main.tf": `
-action "act_nested" "with_blocks" {
+action "action_nested" "with_blocks" {
   config {
     top_attr = "top"
     settings {
@@ -1647,7 +1646,7 @@ resource "test_object" "a" {
   lifecycle {
     action_trigger {
       events  = [before_create]
-      actions = [action.act_nested.with_blocks]
+      actions = [action.action_nested.with_blocks]
     }
   }
 }
@@ -1656,7 +1655,7 @@ resource "test_object" "a" {
 			expectInvokeActionCalled: true,
 			expectInvokeActionCalls: []providers.InvokeActionRequest{
 				{
-					ActionType: "act_nested",
+					ActionType: "action_nested",
 					PlannedActionData: cty.ObjectVal(map[string]cty.Value{
 						"top_attr": cty.StringVal("top"),
 						"settings": cty.ObjectVal(map[string]cty.Value{
@@ -1676,7 +1675,7 @@ resource "test_object" "a" {
 		"nested action config top-level list blocks applies": {
 			module: map[string]string{
 				"main.tf": `
-action "act_nested" "with_list" {
+action "action_nested" "with_list" {
   config {
     settings_list { id = "one" }
     settings_list { id = "two" }
@@ -1686,7 +1685,7 @@ resource "test_object" "a" {
   lifecycle {
     action_trigger {
       events  = [after_create]
-      actions = [action.act_nested.with_list]
+      actions = [action.action_nested.with_list]
     }
   }
 }
@@ -1695,7 +1694,7 @@ resource "test_object" "a" {
 			expectInvokeActionCalled: true,
 			expectInvokeActionCalls: []providers.InvokeActionRequest{
 				{
-					ActionType: "act_nested",
+					ActionType: "action_nested",
 					PlannedActionData: cty.ObjectVal(map[string]cty.Value{
 						"top_attr": cty.NullVal(cty.String),
 						"settings": cty.NullVal(cty.Object(map[string]cty.Type{
@@ -1715,7 +1714,7 @@ resource "test_object" "a" {
 		"conditions": {
 			module: map[string]string{
 				"main.tf": `
-action "act_unlinked" "hello" {
+action "action_example" "hello" {
 count = 3
 config {
   attr = "value-${count.index}"
@@ -1730,13 +1729,13 @@ lifecycle {
   action_trigger {
     events = [before_create]
     condition = test_object.foo.name == "bar"
-    actions = [action.act_unlinked.hello[0]]
+    actions = [action.action_example.hello[0]]
   }
   
   action_trigger {
     events = [before_create]
     condition = test_object.foo.name == "foo"
-    actions = [action.act_unlinked.hello[1], action.act_unlinked.hello[2]]
+    actions = [action.action_example.hello[1], action.action_example.hello[2]]
   }
   }
 }
@@ -1744,12 +1743,12 @@ lifecycle {
 			},
 			expectInvokeActionCalled: true,
 			expectInvokeActionCalls: []providers.InvokeActionRequest{{
-				ActionType: "act_unlinked",
+				ActionType: "action_example",
 				PlannedActionData: cty.ObjectVal(map[string]cty.Value{
 					"attr": cty.StringVal("value-1"),
 				}),
 			}, {
-				ActionType: "act_unlinked",
+				ActionType: "action_example",
 				PlannedActionData: cty.ObjectVal(map[string]cty.Value{
 					"attr": cty.StringVal("value-2"),
 				}),
@@ -1759,14 +1758,14 @@ lifecycle {
 		"simple condition evaluation - true": {
 			module: map[string]string{
 				"main.tf": `
-action "act_unlinked" "hello" {}
+action "action_example" "hello" {}
 resource "test_object" "a" {
   name = "foo"
   lifecycle {
     action_trigger {
       events = [after_create]
       condition = "foo" == "foo"
-      actions = [action.act_unlinked.hello]
+      actions = [action.action_example.hello]
     }
   }
 }
@@ -1778,14 +1777,14 @@ resource "test_object" "a" {
 		"simple condition evaluation - false": {
 			module: map[string]string{
 				"main.tf": `
-action "act_unlinked" "hello" {}
+action "action_example" "hello" {}
 resource "test_object" "a" {
   name = "foo"
   lifecycle {
     action_trigger {
       events = [after_create]
       condition = "foo" == "bar"
-      actions = [action.act_unlinked.hello]
+      actions = [action.action_example.hello]
     }
   }
 }
@@ -1797,7 +1796,7 @@ resource "test_object" "a" {
 		"using count.index in after_create condition": {
 			module: map[string]string{
 				"main.tf": `
-action "act_unlinked" "hello" {}
+action "action_example" "hello" {}
 resource "test_object" "a" {
   count = 3
   name = "item-${count.index}"
@@ -1805,7 +1804,7 @@ resource "test_object" "a" {
     action_trigger {
       events = [after_create]
       condition = count.index == 1
-      actions = [action.act_unlinked.hello]
+      actions = [action.action_example.hello]
     }
   }
 }
@@ -1817,7 +1816,7 @@ resource "test_object" "a" {
 		"using each.key in after_create condition": {
 			module: map[string]string{
 				"main.tf": `
-action "act_unlinked" "hello" {}
+action "action_example" "hello" {}
 resource "test_object" "a" {
   for_each = toset(["foo", "bar"])
   name = each.key
@@ -1825,7 +1824,7 @@ resource "test_object" "a" {
     action_trigger {
       events = [after_create]
       condition = each.key == "foo"
-      actions = [action.act_unlinked.hello]
+      actions = [action.action_example.hello]
     }
   }
 }
@@ -1837,7 +1836,7 @@ resource "test_object" "a" {
 		"using each.value in after_create condition": {
 			module: map[string]string{
 				"main.tf": `
-action "act_unlinked" "hello" {}
+action "action_example" "hello" {}
 resource "test_object" "a" {
   for_each = {"foo" = "value1", "bar" = "value2"}
   name = each.value
@@ -1845,7 +1844,7 @@ resource "test_object" "a" {
     action_trigger {
       events = [after_create]
       condition = each.value == "value1"
-      actions = [action.act_unlinked.hello]
+      actions = [action.action_example.hello]
     }
   }
 }
@@ -1856,7 +1855,7 @@ resource "test_object" "a" {
 		"multiple events triggering in same action trigger": {
 			module: map[string]string{
 				"main.tf": `
-action "act_unlinked" "hello" {}
+action "action_example" "hello" {}
 resource "test_object" "a" {
   lifecycle {
     action_trigger {
@@ -1865,7 +1864,7 @@ resource "test_object" "a" {
         after_create, // should trigger
         before_update // should be ignored
       ]
-      actions = [action.act_unlinked.hello]
+      actions = [action.action_example.hello]
     }
   }
 }
@@ -1874,13 +1873,13 @@ resource "test_object" "a" {
 			expectInvokeActionCalled: true,
 			expectInvokeActionCalls: []providers.InvokeActionRequest{
 				{
-					ActionType: "act_unlinked",
+					ActionType: "action_example",
 					PlannedActionData: cty.NullVal(cty.Object(map[string]cty.Type{
 						"attr": cty.String,
 					})),
 				},
 				{
-					ActionType: "act_unlinked",
+					ActionType: "action_example",
 					PlannedActionData: cty.NullVal(cty.Object(map[string]cty.Type{
 						"attr": cty.String,
 					})),
@@ -1891,23 +1890,23 @@ resource "test_object" "a" {
 		"multiple events triggering in multiple action trigger": {
 			module: map[string]string{
 				"main.tf": `
-action "act_unlinked" "hello" {}
+action "action_example" "hello" {}
 resource "test_object" "a" {
   lifecycle {
     // should trigger
     action_trigger {
       events = [before_create]
-      actions = [action.act_unlinked.hello]
+      actions = [action.action_example.hello]
     }
     // should trigger
     action_trigger {
       events = [after_create]
-      actions = [action.act_unlinked.hello]
+      actions = [action.action_example.hello]
     }
     // should be ignored
     action_trigger {
       events = [before_update]
-      actions = [action.act_unlinked.hello]
+      actions = [action.action_example.hello]
     }
   }
 }
@@ -1916,13 +1915,13 @@ resource "test_object" "a" {
 			expectInvokeActionCalled: true,
 			expectInvokeActionCalls: []providers.InvokeActionRequest{
 				{
-					ActionType: "act_unlinked",
+					ActionType: "action_example",
 					PlannedActionData: cty.NullVal(cty.Object(map[string]cty.Type{
 						"attr": cty.String,
 					})),
 				},
 				{
-					ActionType: "act_unlinked",
+					ActionType: "action_example",
 					PlannedActionData: cty.NullVal(cty.Object(map[string]cty.Type{
 						"attr": cty.String,
 					})),
@@ -1994,7 +1993,7 @@ resource "test_object" "a" {
 			actionProvider := &testing_provider.MockProvider{
 				GetProviderSchemaResponse: &providers.GetProviderSchemaResponse{
 					Actions: map[string]providers.ActionSchema{
-						"act_unlinked": {
+						"action_example": {
 							ConfigSchema: &configschema.Block{
 								Attributes: map[string]*configschema.Attribute{
 									"attr": {
@@ -2004,7 +2003,7 @@ resource "test_object" "a" {
 								},
 							},
 						},
-						"act_unlinked_wo": {
+						"action_example_wo": {
 							ConfigSchema: &configschema.Block{
 								Attributes: map[string]*configschema.Attribute{
 									"attr": {
@@ -2016,7 +2015,7 @@ resource "test_object" "a" {
 							},
 						},
 						// Added nested action schema with nested blocks
-						"act_nested": {
+						"action_nested": {
 							ConfigSchema: &configschema.Block{
 								Attributes: map[string]*configschema.Attribute{
 									"top_attr": {Type: cty.String, Optional: true},
@@ -2060,7 +2059,7 @@ resource "test_object" "a" {
 			ecosystem := &testing_provider.MockProvider{
 				GetProviderSchemaResponse: &providers.GetProviderSchemaResponse{
 					Actions: map[string]providers.ActionSchema{
-						"ecosystem_unlinked": {
+						"ecosystem": {
 							ConfigSchema: &configschema.Block{
 								Attributes: map[string]*configschema.Attribute{
 									"attr": {
@@ -2078,8 +2077,8 @@ resource "test_object" "a" {
 
 			ctx := testContext2(t, &ContextOpts{
 				Providers: map[addrs.Provider]providers.Factory{
-					addrs.NewDefaultProvider("test"): testProviderFuncFixed(testProvider),
-					addrs.NewDefaultProvider("act"):  testProviderFuncFixed(actionProvider),
+					addrs.NewDefaultProvider("test"):   testProviderFuncFixed(testProvider),
+					addrs.NewDefaultProvider("action"): testProviderFuncFixed(actionProvider),
 					{
 						Type:      "ecosystem",
 						Namespace: "danielmschmidt",

--- a/internal/terraform/resource_provider_mock_test.go
+++ b/internal/terraform/resource_provider_mock_test.go
@@ -53,7 +53,7 @@ func mockProviderWithResourceTypeSchema(name string, schema *configschema.Block)
 
 // simpleMockProvider returns a MockProvider that is pre-configured with schema
 // for its own config, a resource type called "test_object", a data source also
-// called "test_object", and an unlinked (generic) action called "test_action".
+// called "test_object", and an action called "test_action".
 //
 // All four schemas have the same content as returned by function
 // simpleTestSchema.


### PR DESCRIPTION
This PR removes remaining references to action types and linked_resources. Most of the changes are either minor test naming changes, or removing code that was only partially implemented (or implemented but gated and not working - anything referring to linked_resources, for example). I also tweaked a diagnostic with some grammatical issues and fixed some comments while I was in the area.

The impactful proto changes are in a single commit:  
[actions: remove references to linked_resources or action types from the plan proto](https://github.com/hashicorp/terraform/pull/37616/commits/02db4de5ce75b36ab36830f93119b27984d4a932)



<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Fixes #

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.14.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [ ] This change is not user-facing.
