### PR TITLE
tf query: disable depends_on for list blocks

### DIFF
--- a/internal/configs/parser_config_dir_test.go
+++ b/internal/configs/parser_config_dir_test.go
@@ -197,6 +197,15 @@ func TestParserLoadConfigDirWithQueries(t *testing.T) {
 			},
 			allowExperiments: true,
 		},
+		{
+			name:      "with-depends-on",
+			directory: "testdata/query-files/invalid/with-depends-on",
+			diagnostics: []string{
+				"testdata/query-files/invalid/with-depends-on/main.tfquery.hcl:23,3-13: Unsupported argument; An argument named \"depends_on\" is not expected here.",
+			},
+			listResources:    2,
+			allowExperiments: true,
+		},
 	}
 
 	for _, test := range tests {

--- a/internal/configs/query_file.go
+++ b/internal/configs/query_file.go
@@ -5,6 +5,7 @@ package configs
 
 import (
 	"fmt"
+	"slices"
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
@@ -193,8 +194,8 @@ func decodeQueryListBlock(block *hcl.Block) (*Resource, hcl.Diagnostics) {
 
 // QueryListResourceBlockSchema is the schema for a list resource type within
 // a terraform query file.
-var QueryListResourceBlockSchema = &hcl.BodySchema{
-	Attributes: append(
+var QueryListResourceBlockSchema = func() *hcl.BodySchema {
+	attrs := append(
 		commonResourceAttributes,
 		hcl.AttributeSchema{
 			Name: "include_resource",
@@ -202,8 +203,12 @@ var QueryListResourceBlockSchema = &hcl.BodySchema{
 		hcl.AttributeSchema{
 			Name: "limit",
 		},
-	),
-}
+	)
+	attrs = slices.DeleteFunc(attrs, func(e hcl.AttributeSchema) bool {
+		return e.Name == "depends_on"
+	})
+	return &hcl.BodySchema{Attributes: attrs}
+}()
 
 // queryFileSchema is the schema for a terraform query file. It defines the
 // expected structure of the file, including the types of supported blocks and their

--- a/internal/configs/query_file.go
+++ b/internal/configs/query_file.go
@@ -5,7 +5,6 @@ package configs
 
 import (
 	"fmt"
-	"slices"
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
@@ -194,21 +193,25 @@ func decodeQueryListBlock(block *hcl.Block) (*Resource, hcl.Diagnostics) {
 
 // QueryListResourceBlockSchema is the schema for a list resource type within
 // a terraform query file.
-var QueryListResourceBlockSchema = func() *hcl.BodySchema {
-	attrs := append(
-		commonResourceAttributes,
-		hcl.AttributeSchema{
+var QueryListResourceBlockSchema = &hcl.BodySchema{
+	Attributes: []hcl.AttributeSchema{
+		{
+			Name: "count",
+		},
+		{
+			Name: "for_each",
+		},
+		{
+			Name: "provider",
+		},
+		{
 			Name: "include_resource",
 		},
-		hcl.AttributeSchema{
+		{
 			Name: "limit",
 		},
-	)
-	attrs = slices.DeleteFunc(attrs, func(e hcl.AttributeSchema) bool {
-		return e.Name == "depends_on"
-	})
-	return &hcl.BodySchema{Attributes: attrs}
-}()
+	},
+}
 
 // queryFileSchema is the schema for a terraform query file. It defines the
 // expected structure of the file, including the types of supported blocks and their

--- a/internal/configs/testdata/query-files/invalid/with-depends-on/main.tfquery.hcl
+++ b/internal/configs/testdata/query-files/invalid/with-depends-on/main.tfquery.hcl
@@ -1,0 +1,24 @@
+list "aws_instance" "test" {
+  provider = aws
+  count = 1
+  include_resource = true
+  limit = 5
+  config {
+    tags = {
+      Name = "test"
+    }
+  }
+}
+list "aws_instance" "test2" {
+  provider = aws
+  count = 1
+  config {
+    tags = {
+      Name = join("-", ["test2", list.aws_instance.test.data[0]])
+    }
+  }
+}
+list "aws_instance" "test3" {
+  provider = aws
+  depends_on = [list.aws_instance.test2]
+}


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

This disables the `depends_on` attribute for list blocks. Before this change, the attribute was accepted, but nothing was being done with it.

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.14.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [ ] This change is not user-facing.
