### PR TITLE
query: constrict query files parsing to tf query command only

### DIFF
--- a/internal/command/meta.go
+++ b/internal/command/meta.go
@@ -273,7 +273,7 @@ type Meta struct {
 	// state even if the remote and local Terraform versions don't match.
 	ignoreRemoteVersion bool
 
-	// set when running query commands
+	// set to true if query files should be parsed
 	includeQueryFiles bool
 }
 

--- a/internal/command/meta.go
+++ b/internal/command/meta.go
@@ -272,6 +272,9 @@ type Meta struct {
 	// Used with commands which write state to allow users to write remote
 	// state even if the remote and local Terraform versions don't match.
 	ignoreRemoteVersion bool
+
+	// set when running query commands
+	includeQueryFiles bool
 }
 
 type testingOverrides struct {

--- a/internal/command/meta_config.go
+++ b/internal/command/meta_config.go
@@ -38,7 +38,7 @@ func (m *Meta) normalizePath(path string) string {
 // loadConfig reads a configuration from the given directory, which should
 // contain a root module and have already have any required descendant modules
 // installed.
-func (m *Meta) loadConfig(rootDir string, parserOpts ...configs.Option) (*configs.Config, tfdiags.Diagnostics) {
+func (m *Meta) loadConfig(rootDir string) (*configs.Config, tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
 	rootDir = m.normalizePath(rootDir)
 
@@ -48,7 +48,7 @@ func (m *Meta) loadConfig(rootDir string, parserOpts ...configs.Option) (*config
 		return nil, diags
 	}
 
-	config, hclDiags := loader.LoadConfig(rootDir, parserOpts...)
+	config, hclDiags := loader.LoadConfig(rootDir)
 	diags = diags.Append(hclDiags)
 	return config, diags
 }
@@ -353,8 +353,9 @@ func (m *Meta) registerSynthConfigSource(filename string, src []byte) {
 func (m *Meta) initConfigLoader() (*configload.Loader, error) {
 	if m.configLoader == nil {
 		loader, err := configload.NewLoader(&configload.Config{
-			ModulesDir: m.modulesDir(),
-			Services:   m.Services,
+			ModulesDir:   m.modulesDir(),
+			Services:     m.Services,
+			IncludeQuery: m.includeQueryFiles,
 		})
 		if err != nil {
 			return nil, err

--- a/internal/command/meta_config.go
+++ b/internal/command/meta_config.go
@@ -353,9 +353,9 @@ func (m *Meta) registerSynthConfigSource(filename string, src []byte) {
 func (m *Meta) initConfigLoader() (*configload.Loader, error) {
 	if m.configLoader == nil {
 		loader, err := configload.NewLoader(&configload.Config{
-			ModulesDir:   m.modulesDir(),
-			Services:     m.Services,
-			IncludeQuery: m.includeQueryFiles,
+			ModulesDir:        m.modulesDir(),
+			Services:          m.Services,
+			IncludeQueryFiles: m.includeQueryFiles,
 		})
 		if err != nil {
 			return nil, err

--- a/internal/command/query.go
+++ b/internal/command/query.go
@@ -75,6 +75,7 @@ func (c *QueryCommand) Run(rawArgs []string) int {
 	// migrated to views.
 	c.Meta.color = !common.NoColor
 	c.Meta.Color = c.Meta.color
+	c.Meta.includeQueryFiles = true
 
 	// Parse and validate flags
 	args, diags := arguments.ParseQuery(rawArgs)

--- a/internal/command/query_test.go
+++ b/internal/command/query_test.go
@@ -80,7 +80,7 @@ configuration file (.tfquery.hcl file) and try again.
 			name:        "invalid query syntax",
 			directory:   "invalid-syntax",
 			expectedOut: "",
-			initCode:    1,
+			initCode:    0,
 			expectedErr: []string{`
 Error: Unsupported block type
 
@@ -172,21 +172,6 @@ The root module input variable "instance_name" is not set, and has no default
 value. Use a -var or -var-file command line argument to provide a value for
 this variable.
 `},
-		},
-		{
-			name:        "error - duplicate variable across .tf and .tfquery files",
-			directory:   "duplicate-variables",
-			expectedOut: "",
-			expectedErr: []string{`
-Error: Duplicate variable declaration
-
-  on query.tfquery.hcl line 2:
-   2: variable "instance_name" {
-
-A variable named "instance_name" was already declared at main.tf:15,1-25.
-Variable names must be unique within a module.
-`},
-			initCode: 1,
 		},
 	}
 

--- a/internal/configs/config_build_test.go
+++ b/internal/configs/config_build_test.go
@@ -227,7 +227,12 @@ func TestBuildConfigInvalidModules(t *testing.T) {
 			path := filepath.Join(testDir, name)
 			parser.AllowLanguageExperiments(true)
 
-			mod, diags := parser.LoadConfigDirWithTests(path, "tests")
+			opts := []Option{MatchTestFiles("tests")}
+			if name == "list-in-child-module" {
+				opts = append(opts, MatchQueryFiles())
+			}
+
+			mod, diags := parser.LoadConfigDir(path, opts...)
 			if diags.HasErrors() {
 				// these tests should only trigger errors that are caught in
 				// the config loader.
@@ -265,7 +270,7 @@ func TestBuildConfigInvalidModules(t *testing.T) {
 					// for simplicity, these tests will treat all source
 					// addresses as relative to the root module
 					sourcePath := filepath.Join(path, req.SourceAddr.String())
-					mod, diags := parser.LoadConfigDir(sourcePath)
+					mod, diags := parser.LoadConfigDir(sourcePath, opts...)
 					version, _ := version.NewVersion("1.0.0")
 					return mod, version, diags
 				}),

--- a/internal/configs/configload/loader.go
+++ b/internal/configs/configload/loader.go
@@ -46,7 +46,9 @@ type Config struct {
 	// such as in tests.
 	Services *disco.Disco
 
-	IncludeQuery bool
+	// IncludeQueryFiles is set to true if query files should be parsed
+	// when running query commands.
+	IncludeQueryFiles bool
 }
 
 // NewLoader creates and returns a loader that reads configuration from the
@@ -77,7 +79,7 @@ func NewLoader(config *Config) (*Loader, error) {
 		return nil, fmt.Errorf("failed to read module manifest: %s", err)
 	}
 
-	if config.IncludeQuery {
+	if config.IncludeQueryFiles {
 		ret.parserOpts = append(ret.parserOpts, configs.MatchQueryFiles())
 	}
 

--- a/internal/configs/configload/loader_load.go
+++ b/internal/configs/configload/loader_load.go
@@ -22,8 +22,8 @@ import (
 //
 // LoadConfig performs the basic syntax and uniqueness validations that are
 // required to process the individual modules
-func (l *Loader) LoadConfig(rootDir string, parserOpts ...configs.Option) (*configs.Config, hcl.Diagnostics) {
-	return l.loadConfig(l.parser.LoadConfigDir(rootDir, parserOpts...))
+func (l *Loader) LoadConfig(rootDir string) (*configs.Config, hcl.Diagnostics) {
+	return l.loadConfig(l.parser.LoadConfigDir(rootDir, l.parserOpts...))
 }
 
 // LoadConfigWithTests matches LoadConfig, except the configs.Config contains

--- a/internal/configs/configload/loader_load.go
+++ b/internal/configs/configload/loader_load.go
@@ -29,7 +29,7 @@ func (l *Loader) LoadConfig(rootDir string) (*configs.Config, hcl.Diagnostics) {
 // LoadConfigWithTests matches LoadConfig, except the configs.Config contains
 // any relevant .tftest.hcl files.
 func (l *Loader) LoadConfigWithTests(rootDir string, testDir string) (*configs.Config, hcl.Diagnostics) {
-	return l.loadConfig(l.parser.LoadConfigDirWithTests(rootDir, testDir))
+	return l.loadConfig(l.parser.LoadConfigDir(rootDir, append(l.parserOpts, configs.MatchTestFiles(testDir))...))
 }
 
 func (l *Loader) loadConfig(rootMod *configs.Module, diags hcl.Diagnostics) (*configs.Config, hcl.Diagnostics) {

--- a/internal/configs/configload/loader_snapshot.go
+++ b/internal/configs/configload/loader_snapshot.go
@@ -24,7 +24,7 @@ import (
 // creates an in-memory snapshot of the configuration files used, which can
 // be later used to create a loader that may read only from this snapshot.
 func (l *Loader) LoadConfigWithSnapshot(rootDir string) (*configs.Config, *Snapshot, hcl.Diagnostics) {
-	rootMod, diags := l.parser.LoadConfigDir(rootDir)
+	rootMod, diags := l.parser.LoadConfigDir(rootDir, l.parserOpts...)
 	if rootMod == nil {
 		return nil, nil, diags
 	}

--- a/internal/configs/configload/testing.go
+++ b/internal/configs/configload/testing.go
@@ -4,9 +4,10 @@
 package configload
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
+
+	"github.com/hashicorp/terraform/internal/configs"
 )
 
 // NewLoaderForTests is a variant of NewLoader that is intended to be more
@@ -20,10 +21,10 @@ import (
 // In the case of any errors, t.Fatal (or similar) will be called to halt
 // execution of the test, so the calling test does not need to handle errors
 // itself.
-func NewLoaderForTests(t testing.TB) (*Loader, func()) {
+func NewLoaderForTests(t testing.TB, parserOpts ...configs.Option) (*Loader, func()) {
 	t.Helper()
 
-	modulesDir, err := ioutil.TempDir("", "tf-configs")
+	modulesDir, err := os.MkdirTemp("", "tf-configs")
 	if err != nil {
 		t.Fatalf("failed to create temporary modules dir: %s", err)
 		return nil, func() {}
@@ -36,6 +37,7 @@ func NewLoaderForTests(t testing.TB) (*Loader, func()) {
 	loader, err := NewLoader(&Config{
 		ModulesDir: modulesDir,
 	})
+	loader.parserOpts = append(loader.parserOpts, parserOpts...)
 	if err != nil {
 		cleanup()
 		t.Fatalf("failed to create config loader: %s", err)

--- a/internal/configs/parser_config_dir.go
+++ b/internal/configs/parser_config_dir.go
@@ -153,8 +153,8 @@ func (p Parser) ConfigDirFiles(dir string, opts ...Option) (primary, override []
 // exists and contains at least one Terraform config file (with a .tf or
 // .tf.json extension.). Note, we explicitely exclude checking for tests here
 // as tests must live alongside actual .tf config files. Same goes for query files.
-func (p *Parser) IsConfigDir(path string) bool {
-	pathSet, _ := p.dirFileSet(path)
+func (p *Parser) IsConfigDir(path string, opts ...Option) bool {
+	pathSet, _ := p.dirFileSet(path, opts...)
 	return (len(pathSet.Primary) + len(pathSet.Override)) > 0
 }
 

--- a/internal/configs/parser_config_dir_test.go
+++ b/internal/configs/parser_config_dir_test.go
@@ -205,7 +205,7 @@ func TestParserLoadConfigDirWithQueries(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			parser := NewParser(nil)
-			mod, diags := parser.LoadConfigDir(test.directory)
+			mod, diags := parser.LoadConfigDir(test.directory, MatchQueryFiles())
 			if len(test.diagnostics) > 0 {
 				if !diags.HasErrors() {
 					t.Errorf("expected errors, but found none")

--- a/internal/configs/parser_file_matcher.go
+++ b/internal/configs/parser_file_matcher.go
@@ -59,8 +59,8 @@ func (p *Parser) dirFileSet(dir string, opts ...Option) (ConfigFileSet, hcl.Diag
 
 	// Set up the parser configuration
 	cfg := &parserConfig{
-		// We always match .tf files and .tfquery.hcl files
-		matchers:      []FileMatcher{&moduleFiles{}, &queryFiles{}},
+		// We always match .tf files
+		matchers:      []FileMatcher{&moduleFiles{}},
 		testDirectory: DefaultTestDirectory,
 		fs:            p.fs,
 	}
@@ -136,6 +136,13 @@ func MatchTestFiles(dir string) Option {
 	return func(o *parserConfig) {
 		o.testDirectory = dir
 		o.matchers = append(o.matchers, &testFiles{})
+	}
+}
+
+// MatchQueryFiles adds a matcher for Terraform query files (.tfquery.hcl and .tfquery.json)
+func MatchQueryFiles() Option {
+	return func(o *parserConfig) {
+		o.matchers = append(o.matchers, &queryFiles{})
 	}
 }
 

--- a/internal/initwd/testing.go
+++ b/internal/initwd/testing.go
@@ -53,7 +53,7 @@ func LoadConfigForTests(t *testing.T, rootDir string, testsDir string) (*configs
 		t.Fatalf("failed to refresh modules after installation: %s", err)
 	}
 
-	config, hclDiags := loader.LoadConfig(rootDir, configs.MatchTestFiles(testsDir))
+	config, hclDiags := loader.LoadConfigWithTests(rootDir, testsDir)
 	diags = diags.Append(hclDiags)
 	return config, loader, cleanup, diags
 }

--- a/internal/terraform/terraform_test.go
+++ b/internal/terraform/terraform_test.go
@@ -139,7 +139,7 @@ func testModuleInline(t testing.TB, sources map[string]string) *configs.Config {
 		t.Fatalf("failed to refresh modules after installation: %s", err)
 	}
 
-	config, diags := loader.LoadConfig(cfgPath, configs.MatchTestFiles("tests"))
+	config, diags := loader.LoadConfigWithTests(cfgPath, "tests")
 	if diags.HasErrors() {
 		t.Fatal(diags.Error())
 	}

--- a/internal/terraform/terraform_test.go
+++ b/internal/terraform/terraform_test.go
@@ -97,6 +97,8 @@ func testModuleInline(t testing.TB, sources map[string]string) *configs.Config {
 		t.Fatal(err)
 	}
 
+	var queryOpt configs.Option
+
 	for path, configStr := range sources {
 		dir := filepath.Dir(path)
 		if dir != "." {
@@ -116,9 +118,18 @@ func testModuleInline(t testing.TB, sources map[string]string) *configs.Config {
 		if err != nil {
 			t.Fatalf("Error creating temporary file for config: %s", err)
 		}
+
+		if strings.HasSuffix(path, "tfquery.hcl") || strings.HasSuffix(path, "tfquery.json") {
+			queryOpt = configs.MatchQueryFiles()
+		}
 	}
 
-	loader, cleanup := configload.NewLoaderForTests(t)
+	var parserOpts []configs.Option
+	if queryOpt != nil {
+		parserOpts = append(parserOpts, queryOpt)
+	}
+
+	loader, cleanup := configload.NewLoaderForTests(t, parserOpts...)
 	defer cleanup()
 
 	// We need to be able to exercise experimental features in our integration tests.


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

This constricts the parsing of query files to only commands related to terraform query. This implies that `init` would not parse query files, and we would not catch invalid config until running the `terraform query` command.
I had to edit this many files so that we could configure the loader to optional parse query files.

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.15.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [ ] This change is not user-facing.
