### PR TITLE
Backport: ready list blocks for beta into v1.14

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -276,6 +276,12 @@ func initCommands(
 			}, nil
 		},
 
+		"query": func() (cli.Command, error) {
+			return &command.QueryCommand{
+				Meta: meta,
+			}, nil
+		},
+
 		"refresh": func() (cli.Command, error) {
 			return &command.RefreshCommand{
 				Meta: meta,
@@ -447,12 +453,6 @@ func initCommands(
 	if meta.AllowExperimentalFeatures {
 		Commands["cloud"] = func() (cli.Command, error) {
 			return &command.CloudCommand{
-				Meta: meta,
-			}, nil
-		}
-
-		Commands["query"] = func() (cli.Command, error) {
-			return &command.QueryCommand{
 				Meta: meta,
 			}, nil
 		}

--- a/internal/cloud/backend_query.go
+++ b/internal/cloud/backend_query.go
@@ -20,6 +20,7 @@ import (
 	"github.com/hashicorp/terraform/internal/genconfig"
 	"github.com/hashicorp/terraform/internal/terraform"
 	"github.com/hashicorp/terraform/internal/tfdiags"
+	"github.com/zclconf/go-cty/cty"
 	ctyjson "github.com/zclconf/go-cty/cty/json"
 )
 
@@ -276,7 +277,7 @@ func (b *Cloud) cancelQueryRun(cancelCtx context.Context, op *backendrun.Operati
 // formatIdentity formats the identity map into a string representation.
 // It flattens the map into a string of key=value pairs, separated by commas.
 func formatIdentity(identity map[string]json.RawMessage) string {
-	parts := make([]string, 0, len(identity))
+	ctyObj := make(map[string]cty.Value, len(identity))
 	for key, value := range identity {
 		ty, err := ctyjson.ImpliedType(value)
 		if err != nil {
@@ -286,9 +287,9 @@ func formatIdentity(identity map[string]json.RawMessage) string {
 		if err != nil {
 			continue
 		}
-		parts = append(parts, fmt.Sprintf("%s=%s", key, tfdiags.ValueToString(v)))
+		ctyObj[key] = v
 	}
-	return strings.Join(parts, ",")
+	return tfdiags.ObjectToString(cty.ObjectVal(ctyObj))
 }
 
 const queryDefaultHeader = `

--- a/internal/cloud/backend_query_test.go
+++ b/internal/cloud/backend_query_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/cli"
 	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/backend/backendrun"
@@ -121,8 +122,15 @@ func TestCloud_queryJSONBasic(t *testing.T) {
 	outp := close(t)
 	gotOut := outp.Stdout()
 
-	if !strings.Contains(gotOut, "list.concept_pet.pets   id=complete-gannet,legs=6   This is a complete-gannet") {
-		t.Fatalf("expected query results in output: %s", gotOut)
+	expectedOut := `list.concept_pet.pets   id=large-roughy,legs=2      This is a large-roughy
+list.concept_pet.pets   id=able-werewolf,legs=5     This is a able-werewolf
+list.concept_pet.pets   id=complete-gannet,legs=6   This is a complete-gannet
+list.concept_pet.pets   id=charming-beagle,legs=3   This is a charming-beagle
+list.concept_pet.pets   id=legal-lamprey,legs=2     This is a legal-lamprey
+
+`
+	if diff := cmp.Diff(expectedOut, gotOut); diff != "" {
+		t.Fatalf("expected query results output to be %s, got %s: diff: %s", expectedOut, gotOut, diff)
 	}
 
 	stateMgr, _ := b.StateMgr(testBackendSingleWorkspaceName)

--- a/internal/cloud/testdata/query-json-basic/main.tfquery.hcl
+++ b/internal/cloud/testdata/query-json-basic/main.tfquery.hcl
@@ -1,1 +1,3 @@
-list "concept_pet" "pets" {}
+list "concept_pet" "pets" {
+  provider = concept
+}

--- a/internal/cloud/testdata/query/main.tfquery.hcl
+++ b/internal/cloud/testdata/query/main.tfquery.hcl
@@ -1,1 +1,3 @@
-list "null_resource" "foo" {}
+list "null_resource" "foo" {
+  provider = null
+}

--- a/internal/command/e2etest/providers_schema_test.go
+++ b/internal/command/e2etest/providers_schema_test.go
@@ -134,6 +134,21 @@ func TestProvidersSchema(t *testing.T) {
                     }
                 }
             },
+            "list_resource_schemas": {
+                "simple_resource": {
+                    "version": 0,
+                    "block": {
+                        "attributes": {
+                            "value": {
+                                "type": "string",
+                                "description_kind": "plain",
+                                "optional": true
+                            }
+                        },
+                        "description_kind": "plain"
+                    }
+                }
+            },
             "resource_identity_schemas": {
                 "simple_resource": {
                     "version": 0,
@@ -203,6 +218,21 @@ func TestProvidersSchema(t *testing.T) {
                                 "description_kind": "plain",
                                 "computed": true
                             },
+                            "value": {
+                                "type": "string",
+                                "description_kind": "plain",
+                                "optional": true
+                            }
+                        },
+                        "description_kind": "plain"
+                    }
+                }
+            },
+            "list_resource_schemas": {
+                "simple_resource": {
+                    "version": 0,
+                    "block": {
+                        "attributes": {
                             "value": {
                                 "type": "string",
                                 "description_kind": "plain",

--- a/internal/command/jsonformat/plan_test.go
+++ b/internal/command/jsonformat/plan_test.go
@@ -8071,7 +8071,7 @@ func runTestCases(t *testing.T, testCases map[string]testCase) {
 				return
 			}
 
-			jsonschemas := jsonprovider.MarshalForRenderer(tfschemas, false)
+			jsonschemas := jsonprovider.MarshalForRenderer(tfschemas)
 			change := structured.FromJsonChange(jsonchanges[0].Change, attribute_path.AlwaysMatcher())
 			renderer := Renderer{Colorize: color}
 			diff := diff{
@@ -8421,7 +8421,7 @@ func TestResourceChange_deferredActions(t *testing.T) {
 			}
 
 			renderer := Renderer{Colorize: color}
-			jsonschemas := jsonprovider.MarshalForRenderer(fullSchema, false)
+			jsonschemas := jsonprovider.MarshalForRenderer(fullSchema)
 			diffs := precomputeDiffs(Plan{
 				DeferredChanges: deferredChanges,
 				ProviderSchemas: jsonschemas,
@@ -8714,7 +8714,7 @@ func TestResourceChange_actions(t *testing.T) {
 					},
 				},
 			}
-			jsonschemas := jsonprovider.MarshalForRenderer(fullSchema, false)
+			jsonschemas := jsonprovider.MarshalForRenderer(fullSchema)
 			diffs := precomputeDiffs(Plan{
 				ResourceChanges:   []jsonplan.ResourceChange{defaultResourceChange},
 				ActionInvocations: tc.actionInvocations,

--- a/internal/command/jsonformat/state_test.go
+++ b/internal/command/jsonformat/state_test.go
@@ -86,7 +86,7 @@ func TestState(t *testing.T) {
 				RootModule:            root,
 				RootModuleOutputs:     outputs,
 				ProviderFormatVersion: jsonprovider.FormatVersion,
-				ProviderSchemas:       jsonprovider.MarshalForRenderer(tt.Schemas, false),
+				ProviderSchemas:       jsonprovider.MarshalForRenderer(tt.Schemas),
 			})
 
 			result := done(t).All()

--- a/internal/command/jsonprovider/provider_test.go
+++ b/internal/command/jsonprovider/provider_test.go
@@ -20,25 +20,23 @@ var cmpOpts = cmpopts.IgnoreUnexported(Provider{})
 
 func TestMarshalProvider(t *testing.T) {
 	tests := []struct {
-		Input               providers.ProviderSchema
-		IncludeExperimental bool
-		Want                *Provider
+		Input providers.ProviderSchema
+		Want  *Provider
 	}{
 		{
 			providers.ProviderSchema{},
-			false,
 			&Provider{
 				Provider:                 &Schema{},
 				ResourceSchemas:          map[string]*Schema{},
 				DataSourceSchemas:        map[string]*Schema{},
 				EphemeralResourceSchemas: map[string]*Schema{},
 				ResourceIdentitySchemas:  map[string]*IdentitySchema{},
+				ListResourceSchemas:      map[string]*Schema{},
 				ActionSchemas:            map[string]*ActionSchema{},
 			},
 		},
 		{
 			testProvider(),
-			false,
 			&Provider{
 				Provider: &Schema{
 					Block: &Block{
@@ -212,53 +210,6 @@ func TestMarshalProvider(t *testing.T) {
 						},
 					},
 				},
-				ResourceIdentitySchemas: map[string]*IdentitySchema{},
-				ActionSchemas:           map[string]*ActionSchema{},
-			},
-		},
-		{
-			providers.ProviderSchema{
-				ListResourceTypes: map[string]providers.Schema{
-					"test_list_resource": {
-						Version: 1,
-						Body: &configschema.Block{
-							Attributes: map[string]*configschema.Attribute{
-								"data": {
-									Type:     cty.DynamicPseudoType,
-									Computed: true,
-								},
-							},
-							BlockTypes: map[string]*configschema.NestedBlock{
-								"config": {
-									Block: configschema.Block{
-										Attributes: map[string]*configschema.Attribute{
-											"filter": {Type: cty.String, Optional: true},
-											"items":  {Type: cty.List(cty.String), Required: true},
-										},
-									},
-									Nesting: configschema.NestingSingle,
-								},
-							},
-						},
-					},
-				},
-				Actions: map[string]providers.ActionSchema{
-					"test_action": {
-						ConfigSchema: &configschema.Block{
-							Attributes: map[string]*configschema.Attribute{
-								"opt_attr": {Type: cty.String, Optional: true},
-								"req_attr": {Type: cty.List(cty.String), Required: true},
-							},
-						},
-					},
-				},
-			},
-			true,
-			&Provider{
-				Provider:                 &Schema{},
-				ResourceSchemas:          map[string]*Schema{},
-				DataSourceSchemas:        map[string]*Schema{},
-				EphemeralResourceSchemas: map[string]*Schema{},
 				ListResourceSchemas: map[string]*Schema{
 					"test_list_resource": {
 						Version: 1,
@@ -305,7 +256,7 @@ func TestMarshalProvider(t *testing.T) {
 
 	for i, test := range tests {
 		t.Run(fmt.Sprint(i), func(t *testing.T) {
-			got := marshalProvider(test.Input, test.IncludeExperimental)
+			got := marshalProvider(test.Input)
 			if diff := cmp.Diff(test.Want, got, cmpOpts); diff != "" {
 				t.Fatalf("wrong result:\n %s\n", diff)
 			}
@@ -427,6 +378,16 @@ func testProvider() providers.ProviderSchema {
 							},
 							Nesting: configschema.NestingSingle,
 						},
+					},
+				},
+			},
+		},
+		Actions: map[string]providers.ActionSchema{
+			"test_action": {
+				ConfigSchema: &configschema.Block{
+					Attributes: map[string]*configschema.Attribute{
+						"opt_attr": {Type: cty.String, Optional: true},
+						"req_attr": {Type: cty.List(cty.String), Required: true},
 					},
 				},
 			},

--- a/internal/command/meta.go
+++ b/internal/command/meta.go
@@ -272,6 +272,9 @@ type Meta struct {
 	// Used with commands which write state to allow users to write remote
 	// state even if the remote and local Terraform versions don't match.
 	ignoreRemoteVersion bool
+
+	// set to true if query files should be parsed
+	includeQueryFiles bool
 }
 
 type testingOverrides struct {

--- a/internal/command/meta_config.go
+++ b/internal/command/meta_config.go
@@ -38,7 +38,7 @@ func (m *Meta) normalizePath(path string) string {
 // loadConfig reads a configuration from the given directory, which should
 // contain a root module and have already have any required descendant modules
 // installed.
-func (m *Meta) loadConfig(rootDir string, parserOpts ...configs.Option) (*configs.Config, tfdiags.Diagnostics) {
+func (m *Meta) loadConfig(rootDir string) (*configs.Config, tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
 	rootDir = m.normalizePath(rootDir)
 
@@ -48,7 +48,7 @@ func (m *Meta) loadConfig(rootDir string, parserOpts ...configs.Option) (*config
 		return nil, diags
 	}
 
-	config, hclDiags := loader.LoadConfig(rootDir, parserOpts...)
+	config, hclDiags := loader.LoadConfig(rootDir)
 	diags = diags.Append(hclDiags)
 	return config, diags
 }
@@ -353,8 +353,9 @@ func (m *Meta) registerSynthConfigSource(filename string, src []byte) {
 func (m *Meta) initConfigLoader() (*configload.Loader, error) {
 	if m.configLoader == nil {
 		loader, err := configload.NewLoader(&configload.Config{
-			ModulesDir: m.modulesDir(),
-			Services:   m.Services,
+			ModulesDir:        m.modulesDir(),
+			Services:          m.Services,
+			IncludeQueryFiles: m.includeQueryFiles,
 		})
 		if err != nil {
 			return nil, err

--- a/internal/command/providers_schema.go
+++ b/internal/command/providers_schema.go
@@ -107,7 +107,7 @@ func (c *ProvidersSchemaCommand) Run(args []string) int {
 		return 1
 	}
 
-	jsonSchemas, err := jsonprovider.Marshal(schemas, c.AllowExperimentalFeatures)
+	jsonSchemas, err := jsonprovider.Marshal(schemas)
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf("Failed to marshal provider schemas to json: %s", err))
 		return 1

--- a/internal/command/query.go
+++ b/internal/command/query.go
@@ -75,6 +75,7 @@ func (c *QueryCommand) Run(rawArgs []string) int {
 	// migrated to views.
 	c.Meta.color = !common.NoColor
 	c.Meta.Color = c.Meta.color
+	c.Meta.includeQueryFiles = true
 
 	// Parse and validate flags
 	args, diags := arguments.ParseQuery(rawArgs)

--- a/internal/command/query_test.go
+++ b/internal/command/query_test.go
@@ -79,7 +79,7 @@ configuration file (.tfquery.hcl file) and try again.
 			name:        "invalid query syntax",
 			directory:   "invalid-syntax",
 			expectedOut: "",
-			initCode:    1,
+			initCode:    0,
 			expectedErr: []string{`
 Error: Unsupported block type
 
@@ -171,21 +171,6 @@ The root module input variable "instance_name" is not set, and has no default
 value. Use a -var or -var-file command line argument to provide a value for
 this variable.
 `},
-		},
-		{
-			name:        "error - duplicate variable across .tf and .tfquery files",
-			directory:   "duplicate-variables",
-			expectedOut: "",
-			expectedErr: []string{`
-Error: Duplicate variable declaration
-
-  on query.tfquery.hcl line 2:
-   2: variable "instance_name" {
-
-A variable named "instance_name" was already declared at main.tf:15,1-25.
-Variable names must be unique within a module.
-`},
-			initCode: 1,
 		},
 	}
 

--- a/internal/command/state_show.go
+++ b/internal/command/state_show.go
@@ -155,7 +155,7 @@ func (c *StateShowCommand) Run(args []string) int {
 		ProviderFormatVersion: jsonprovider.FormatVersion,
 		RootModule:            root,
 		RootModuleOutputs:     outputs,
-		ProviderSchemas:       jsonprovider.MarshalForRenderer(schemas, false),
+		ProviderSchemas:       jsonprovider.MarshalForRenderer(schemas),
 	}
 
 	renderer := jsonformat.Renderer{

--- a/internal/command/views/operation.go
+++ b/internal/command/views/operation.go
@@ -110,7 +110,7 @@ func (v *OperationHuman) Plan(plan *plans.Plan, schemas *terraform.Schemas) {
 		OutputChanges:         outputs,
 		ResourceChanges:       changed,
 		ResourceDrift:         drift,
-		ProviderSchemas:       jsonprovider.MarshalForRenderer(schemas, false),
+		ProviderSchemas:       jsonprovider.MarshalForRenderer(schemas),
 		RelevantAttributes:    attrs,
 		ActionInvocations:     actions,
 	}

--- a/internal/command/views/show.go
+++ b/internal/command/views/show.go
@@ -83,7 +83,7 @@ func (v *ShowHuman) Display(config *configs.Config, plan *plans.Plan, planJSON *
 			OutputChanges:         outputs,
 			ResourceChanges:       changed,
 			ResourceDrift:         drift,
-			ProviderSchemas:       jsonprovider.MarshalForRenderer(schemas, false),
+			ProviderSchemas:       jsonprovider.MarshalForRenderer(schemas),
 			RelevantAttributes:    attrs,
 			ActionInvocations:     actions,
 		}
@@ -113,7 +113,7 @@ func (v *ShowHuman) Display(config *configs.Config, plan *plans.Plan, planJSON *
 			ProviderFormatVersion: jsonprovider.FormatVersion,
 			RootModule:            root,
 			RootModuleOutputs:     outputs,
-			ProviderSchemas:       jsonprovider.MarshalForRenderer(schemas, false),
+			ProviderSchemas:       jsonprovider.MarshalForRenderer(schemas),
 		}
 
 		renderer.RenderHumanState(jstate)

--- a/internal/command/views/test.go
+++ b/internal/command/views/test.go
@@ -203,7 +203,7 @@ func (t *TestHuman) Run(run *moduletest.Run, file *moduletest.File, progress mod
 					ProviderFormatVersion: jsonprovider.FormatVersion,
 					RootModule:            root,
 					RootModuleOutputs:     outputs,
-					ProviderSchemas:       jsonprovider.MarshalForRenderer(schemas, false),
+					ProviderSchemas:       jsonprovider.MarshalForRenderer(schemas),
 				}
 
 				t.view.streams.Println() // Separate the state from any previous statements.
@@ -225,7 +225,7 @@ func (t *TestHuman) Run(run *moduletest.Run, file *moduletest.File, progress mod
 					OutputChanges:         outputs,
 					ResourceChanges:       changed,
 					ResourceDrift:         drift,
-					ProviderSchemas:       jsonprovider.MarshalForRenderer(schemas, false),
+					ProviderSchemas:       jsonprovider.MarshalForRenderer(schemas),
 					RelevantAttributes:    attrs,
 					ActionInvocations:     actions,
 				}
@@ -568,7 +568,7 @@ func (t *TestJSON) Run(run *moduletest.Run, file *moduletest.File, progress modu
 					ProviderFormatVersion: jsonprovider.FormatVersion,
 					RootModule:            root,
 					RootModuleOutputs:     outputs,
-					ProviderSchemas:       jsonprovider.MarshalForRenderer(schemas, false),
+					ProviderSchemas:       jsonprovider.MarshalForRenderer(schemas),
 				}
 
 				t.view.log.Info(
@@ -592,7 +592,7 @@ func (t *TestJSON) Run(run *moduletest.Run, file *moduletest.File, progress modu
 					OutputChanges:         outputs,
 					ResourceChanges:       changed,
 					ResourceDrift:         drift,
-					ProviderSchemas:       jsonprovider.MarshalForRenderer(schemas, false),
+					ProviderSchemas:       jsonprovider.MarshalForRenderer(schemas),
 					RelevantAttributes:    attrs,
 					ActionInvocations:     actions,
 				}

--- a/internal/configs/config_build_test.go
+++ b/internal/configs/config_build_test.go
@@ -227,7 +227,12 @@ func TestBuildConfigInvalidModules(t *testing.T) {
 			path := filepath.Join(testDir, name)
 			parser.AllowLanguageExperiments(true)
 
-			mod, diags := parser.LoadConfigDirWithTests(path, "tests")
+			opts := []Option{MatchTestFiles("tests")}
+			if name == "list-in-child-module" {
+				opts = append(opts, MatchQueryFiles())
+			}
+
+			mod, diags := parser.LoadConfigDir(path, opts...)
 			if diags.HasErrors() {
 				// these tests should only trigger errors that are caught in
 				// the config loader.
@@ -265,7 +270,7 @@ func TestBuildConfigInvalidModules(t *testing.T) {
 					// for simplicity, these tests will treat all source
 					// addresses as relative to the root module
 					sourcePath := filepath.Join(path, req.SourceAddr.String())
-					mod, diags := parser.LoadConfigDir(sourcePath)
+					mod, diags := parser.LoadConfigDir(sourcePath, opts...)
 					version, _ := version.NewVersion("1.0.0")
 					return mod, version, diags
 				}),

--- a/internal/configs/configload/loader.go
+++ b/internal/configs/configload/loader.go
@@ -27,6 +27,8 @@ type Loader struct {
 	// modules is used to install and locate descendant modules that are
 	// referenced (directly or indirectly) from the root module.
 	modules moduleMgr
+
+	parserOpts []configs.Option
 }
 
 // Config is used with NewLoader to specify configuration arguments for the
@@ -43,6 +45,10 @@ type Config struct {
 	// not supported, which should be true only in specialized circumstances
 	// such as in tests.
 	Services *disco.Disco
+
+	// IncludeQueryFiles is set to true if query files should be parsed
+	// when running query commands.
+	IncludeQueryFiles bool
 }
 
 // NewLoader creates and returns a loader that reads configuration from the
@@ -65,11 +71,16 @@ func NewLoader(config *Config) (*Loader, error) {
 			Services:   config.Services,
 			Registry:   reg,
 		},
+		parserOpts: make([]configs.Option, 0),
 	}
 
 	err := ret.modules.readModuleManifestSnapshot()
 	if err != nil {
 		return nil, fmt.Errorf("failed to read module manifest: %s", err)
+	}
+
+	if config.IncludeQueryFiles {
+		ret.parserOpts = append(ret.parserOpts, configs.MatchQueryFiles())
 	}
 
 	return ret, nil
@@ -122,7 +133,7 @@ func (l *Loader) Sources() map[string][]byte {
 // least one Terraform configuration file. This is a wrapper around calling
 // the same method name on the loader's parser.
 func (l *Loader) IsConfigDir(path string) bool {
-	return l.parser.IsConfigDir(path)
+	return l.parser.IsConfigDir(path, l.parserOpts...)
 }
 
 // ImportSources writes into the receiver's source code map the given source

--- a/internal/configs/configload/loader_load.go
+++ b/internal/configs/configload/loader_load.go
@@ -22,14 +22,14 @@ import (
 //
 // LoadConfig performs the basic syntax and uniqueness validations that are
 // required to process the individual modules
-func (l *Loader) LoadConfig(rootDir string, parserOpts ...configs.Option) (*configs.Config, hcl.Diagnostics) {
-	return l.loadConfig(l.parser.LoadConfigDir(rootDir, parserOpts...))
+func (l *Loader) LoadConfig(rootDir string) (*configs.Config, hcl.Diagnostics) {
+	return l.loadConfig(l.parser.LoadConfigDir(rootDir, l.parserOpts...))
 }
 
 // LoadConfigWithTests matches LoadConfig, except the configs.Config contains
 // any relevant .tftest.hcl files.
 func (l *Loader) LoadConfigWithTests(rootDir string, testDir string) (*configs.Config, hcl.Diagnostics) {
-	return l.loadConfig(l.parser.LoadConfigDirWithTests(rootDir, testDir))
+	return l.loadConfig(l.parser.LoadConfigDir(rootDir, append(l.parserOpts, configs.MatchTestFiles(testDir))...))
 }
 
 func (l *Loader) loadConfig(rootMod *configs.Module, diags hcl.Diagnostics) (*configs.Config, hcl.Diagnostics) {

--- a/internal/configs/configload/loader_snapshot.go
+++ b/internal/configs/configload/loader_snapshot.go
@@ -24,7 +24,7 @@ import (
 // creates an in-memory snapshot of the configuration files used, which can
 // be later used to create a loader that may read only from this snapshot.
 func (l *Loader) LoadConfigWithSnapshot(rootDir string) (*configs.Config, *Snapshot, hcl.Diagnostics) {
-	rootMod, diags := l.parser.LoadConfigDir(rootDir)
+	rootMod, diags := l.parser.LoadConfigDir(rootDir, l.parserOpts...)
 	if rootMod == nil {
 		return nil, nil, diags
 	}

--- a/internal/configs/configload/testing.go
+++ b/internal/configs/configload/testing.go
@@ -4,9 +4,10 @@
 package configload
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
+
+	"github.com/hashicorp/terraform/internal/configs"
 )
 
 // NewLoaderForTests is a variant of NewLoader that is intended to be more
@@ -20,10 +21,10 @@ import (
 // In the case of any errors, t.Fatal (or similar) will be called to halt
 // execution of the test, so the calling test does not need to handle errors
 // itself.
-func NewLoaderForTests(t testing.TB) (*Loader, func()) {
+func NewLoaderForTests(t testing.TB, parserOpts ...configs.Option) (*Loader, func()) {
 	t.Helper()
 
-	modulesDir, err := ioutil.TempDir("", "tf-configs")
+	modulesDir, err := os.MkdirTemp("", "tf-configs")
 	if err != nil {
 		t.Fatalf("failed to create temporary modules dir: %s", err)
 		return nil, func() {}
@@ -36,6 +37,7 @@ func NewLoaderForTests(t testing.TB) (*Loader, func()) {
 	loader, err := NewLoader(&Config{
 		ModulesDir: modulesDir,
 	})
+	loader.parserOpts = append(loader.parserOpts, parserOpts...)
 	if err != nil {
 		cleanup()
 		t.Fatalf("failed to create config loader: %s", err)

--- a/internal/configs/parser_config_dir.go
+++ b/internal/configs/parser_config_dir.go
@@ -153,8 +153,8 @@ func (p Parser) ConfigDirFiles(dir string, opts ...Option) (primary, override []
 // exists and contains at least one Terraform config file (with a .tf or
 // .tf.json extension.). Note, we explicitely exclude checking for tests here
 // as tests must live alongside actual .tf config files. Same goes for query files.
-func (p *Parser) IsConfigDir(path string) bool {
-	pathSet, _ := p.dirFileSet(path)
+func (p *Parser) IsConfigDir(path string, opts ...Option) bool {
+	pathSet, _ := p.dirFileSet(path, opts...)
 	return (len(pathSet.Primary) + len(pathSet.Override)) > 0
 }
 

--- a/internal/configs/parser_config_dir_test.go
+++ b/internal/configs/parser_config_dir_test.go
@@ -167,27 +167,23 @@ func TestParserLoadConfigDirWithQueries(t *testing.T) {
 		diagnostics      []string
 		listResources    int
 		managedResources int
-		allowExperiments bool
 	}{
 		{
-			name:             "simple",
-			directory:        "testdata/query-files/valid/simple",
-			listResources:    3,
-			allowExperiments: true,
+			name:          "simple",
+			directory:     "testdata/query-files/valid/simple",
+			listResources: 3,
 		},
 		{
 			name:             "mixed",
 			directory:        "testdata/query-files/valid/mixed",
 			listResources:    3,
 			managedResources: 1,
-			allowExperiments: true,
 		},
 		{
 			name:             "loading query lists with no-experiments",
 			directory:        "testdata/query-files/valid/mixed",
 			managedResources: 1,
-			listResources:    0,
-			allowExperiments: false,
+			listResources:    3,
 		},
 		{
 			name:      "no-provider",
@@ -195,7 +191,6 @@ func TestParserLoadConfigDirWithQueries(t *testing.T) {
 			diagnostics: []string{
 				"testdata/query-files/invalid/no-provider/main.tfquery.hcl:1,1-27: Missing \"provider\" attribute; You must specify a provider attribute when defining a list block.",
 			},
-			allowExperiments: true,
 		},
 		{
 			name:      "with-depends-on",
@@ -203,16 +198,14 @@ func TestParserLoadConfigDirWithQueries(t *testing.T) {
 			diagnostics: []string{
 				"testdata/query-files/invalid/with-depends-on/main.tfquery.hcl:23,3-13: Unsupported argument; An argument named \"depends_on\" is not expected here.",
 			},
-			listResources:    2,
-			allowExperiments: true,
+			listResources: 2,
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			parser := NewParser(nil)
-			parser.AllowLanguageExperiments(test.allowExperiments)
-			mod, diags := parser.LoadConfigDir(test.directory)
+			mod, diags := parser.LoadConfigDir(test.directory, MatchQueryFiles())
 			if len(test.diagnostics) > 0 {
 				if !diags.HasErrors() {
 					t.Errorf("expected errors, but found none")

--- a/internal/configs/parser_file_matcher.go
+++ b/internal/configs/parser_file_matcher.go
@@ -64,9 +64,6 @@ func (p *Parser) dirFileSet(dir string, opts ...Option) (ConfigFileSet, hcl.Diag
 		testDirectory: DefaultTestDirectory,
 		fs:            p.fs,
 	}
-	if p.AllowsLanguageExperiments() {
-		cfg.matchers = append(cfg.matchers, &queryFiles{})
-	}
 	for _, opt := range opts {
 		opt(cfg)
 	}
@@ -139,6 +136,13 @@ func MatchTestFiles(dir string) Option {
 	return func(o *parserConfig) {
 		o.testDirectory = dir
 		o.matchers = append(o.matchers, &testFiles{})
+	}
+}
+
+// MatchQueryFiles adds a matcher for Terraform query files (.tfquery.hcl and .tfquery.json)
+func MatchQueryFiles() Option {
+	return func(o *parserConfig) {
+		o.matchers = append(o.matchers, &queryFiles{})
 	}
 }
 

--- a/internal/initwd/testing.go
+++ b/internal/initwd/testing.go
@@ -53,7 +53,7 @@ func LoadConfigForTests(t *testing.T, rootDir string, testsDir string) (*configs
 		t.Fatalf("failed to refresh modules after installation: %s", err)
 	}
 
-	config, hclDiags := loader.LoadConfig(rootDir, configs.MatchTestFiles(testsDir))
+	config, hclDiags := loader.LoadConfigWithTests(rootDir, testsDir)
 	diags = diags.Append(hclDiags)
 	return config, loader, cleanup, diags
 }


### PR DESCRIPTION
This is a manual backport of https://github.com/hashicorp/terraform/pull/37619, since the automatic one failed.

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.14.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [ ] This change is not user-facing.
