### PR TITLE
Sarah's updates to radek/pss-read-write

### DIFF
--- a/internal/plugin6/grpc_provider.go
+++ b/internal/plugin6/grpc_provider.go
@@ -1548,6 +1548,8 @@ func (p *GRPCProvider) ReadStateBytes(r providers.ReadStateBytesRequest) (resp p
 	}
 
 	if buf.Len() != expectedTotalLength {
+		logger.Trace("GRPCProvider.v6: ReadStateBytes: received %d bytes but expected the total bytes to be %d.", buf.Len(), expectedTotalLength)
+
 		err = fmt.Errorf("expected state file of total %d bytes, received %d bytes",
 			expectedTotalLength, buf.Len())
 		resp.Diagnostics = resp.Diagnostics.Append(err)

--- a/internal/plugin6/grpc_provider.go
+++ b/internal/plugin6/grpc_provider.go
@@ -1515,11 +1515,8 @@ func (p *GRPCProvider) ReadStateBytes(r providers.ReadStateBytesRequest) (resp p
 	for {
 		chunk, err := client.Recv()
 		if err == io.EOF {
-			// End of stream, we're done
-			if chunk != nil {
-				// TODO: The EOF error could be just returned alongside the last chunk?
-				resp.Diagnostics = resp.Diagnostics.Append(convert.ProtoToDiagnostics(chunk.Diagnostics))
-			}
+			// No chunk is returned alongside an EOF.
+			// And as EOF is a sentinel error it isn't wrapped as a diagnostic.
 			break
 		}
 		if err != nil {

--- a/internal/plugin6/grpc_provider.go
+++ b/internal/plugin6/grpc_provider.go
@@ -1553,6 +1553,16 @@ func (p *GRPCProvider) ReadStateBytes(r providers.ReadStateBytesRequest) (resp p
 		resp.Diagnostics = resp.Diagnostics.Append(err)
 		return resp
 	}
+
+	// We're done, so close the stream
+	logger.Trace("GRPCProvider.v6: ReadStateBytes: received all chunks, total bytes: ", buf.Len())
+	err = client.CloseSend()
+	if err != nil {
+		resp.Diagnostics = resp.Diagnostics.Append(grpcErr(err))
+		return resp
+	}
+
+	// Add the state data in the response once we know there are no errors
 	resp.Bytes = buf.Bytes()
 
 	return resp

--- a/internal/plugin6/grpc_provider.go
+++ b/internal/plugin6/grpc_provider.go
@@ -1542,7 +1542,11 @@ func (p *GRPCProvider) ReadStateBytes(r providers.ReadStateBytesRequest) (resp p
 		logger.Trace("GRPCProvider.v6: ReadStateBytes: read bytes of a chunk", n)
 	}
 
-	logger.Trace("GRPCProvider.v6: ReadStateBytes: received all chunks", buf.Len())
+	if resp.Diagnostics.HasErrors() {
+		logger.Trace("GRPCProvider.v6: ReadStateBytes: experienced an error when receiving state data from the provider", resp.Diagnostics.Err())
+		return resp
+	}
+
 	if buf.Len() != expectedTotalLength {
 		err = fmt.Errorf("expected state file of total %d bytes, received %d bytes",
 			expectedTotalLength, buf.Len())

--- a/internal/plugin6/grpc_provider_test.go
+++ b/internal/plugin6/grpc_provider_test.go
@@ -3707,7 +3707,7 @@ func TestGRPCProvider_ReadStateBytes(t *testing.T) {
 		// Define what will be returned by each call to Recv
 		mockReadBytesClient.EXPECT().Recv().Return(&proto.ReadStateBytes_Response{
 			Diagnostics: []*proto.Diagnostic{
-				&proto.Diagnostic{
+				{
 					Severity: proto.Diagnostic_ERROR,
 					Summary:  "Error from test",
 					Detail:   "This error is forced by the test case",


### PR DESCRIPTION
This PR moves some fixes to the radek/pss-read-write branch out of https://github.com/hashicorp/terraform/pull/37323

I tested the process of initialising a working directory end to end using the `pss` provider and our changes to the terraform-plugin-go repo, and in the process made these changes to the Core-side of `ReadStateBytes`.

The main changes in this PR are:
* Being clear that the io.EOF sentinel error is not expected to be accompanied with _any_ chunk information, i.e. no bytes and no diagnostics.
* Adding a call to CloseSend to close the stream, if reading the state didn't encounter any grpc errors or custom error diagnostics from the provider.



## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

N/A

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
