### PR TITLE
Handle `-help` usage in stacks plugin

### DIFF
--- a/.changes/v1.14/ENHANCEMENTS-20250919-115253.yaml
+++ b/.changes/v1.14/ENHANCEMENTS-20250919-115253.yaml
@@ -1,0 +1,5 @@
+kind: ENHANCEMENTS
+body: '`terraform stacks` command support for `-help` flag'
+time: 2025-09-19T11:52:53.923764-04:00
+custom:
+    Issue: "37645"

--- a/internal/command/stacks.go
+++ b/internal/command/stacks.go
@@ -82,7 +82,6 @@ func (c *StacksCommand) realRun(args []string, stdout, stderr io.Writer) int {
 	args = c.Meta.process(args)
 	cmdFlags := c.Meta.defaultFlagSet("stacks")
 	cmdFlags.StringVar(&pluginCacheDirOverride, "plugin-cache-dir", "", "plugin cache directory")
-	cmdFlags.Usage = func() { c.Ui.Error(c.Help()) }
 	cmdFlags.Parse(args)
 
 	if pluginCacheDirOverride != "" {
@@ -379,8 +378,17 @@ func (c *StacksCommand) Run(args []string) int {
 // Help returns help text for the stacks command.
 func (c *StacksCommand) Help() string {
 	helpText := new(bytes.Buffer)
-	if exitCode := c.realRun([]string{}, helpText, io.Discard); exitCode != 0 {
-		return ""
+	errorText := new(bytes.Buffer)
+
+	parsedArgs := []string{}
+	for _, arg := range os.Args[1:] {
+		if arg == "stacks" {
+			continue // skip stacks command name
+		}
+		parsedArgs = append(parsedArgs, arg)
+	}
+	if exitCode := c.realRun(parsedArgs, helpText, errorText); exitCode != 0 {
+		return errorText.String()
 	}
 
 	return helpText.String()


### PR DESCRIPTION
## Description

This PR provide the raw args to the `StacksCommand`'s `Help()` which allows for the more typical `-help` usage rather than strictly requiring the `-usage` flag for command usage information.

We previously ran into trouble with the handling of the `-help` flag in regards to the the stacks CLI plugin. Notably since the cli runner strips the `-help` flag from the args passed to the command's `Run` implementation. At the time we encountered this we opted for a stop gap solution of using the `-usage` flag for help texts. This PR at adds the ability to properly handle the help flag.

## Target Release

1.14.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [x] This change is user-facing and I added a changelog entry.
- [ ] This change is not user-facing.
