### PR TITLE
Improve tests in internal/states (ProviderAddrs, HasCurrent, Unlock)

### DIFF
--- a/internal/states/resource_test.go
+++ b/internal/states/resource_test.go
@@ -8,6 +8,26 @@ import (
 )
 
 func TestResourceInstanceDeposeCurrentObject(t *testing.T) {
+	t.Run("nil receiver HasCurrent", func(t *testing.T) {
+		// small helper to catch panics
+		callHasCurrent := func(ri *ResourceInstance) (ret bool, panicked bool) {
+			defer func() {
+				if r := recover(); r != nil {
+					panicked = true
+				}
+			}()
+			return ri.HasCurrent(), false
+		}
+
+		var nilRI *ResourceInstance
+		got, panicked := callHasCurrent(nilRI)
+		if panicked {
+			t.Fatalf("HasCurrent(nil) panicked; want no panic and false")
+		}
+		if got {
+			t.Fatalf("HasCurrent(nil) = true; want false")
+		}
+	})
 	obj := &ResourceInstanceObjectSrc{
 		// Empty for the sake of this test, because we're just going to
 		// compare by pointer below anyway.

--- a/internal/states/resource_test.go
+++ b/internal/states/resource_test.go
@@ -8,24 +8,13 @@ import (
 )
 
 func TestResourceInstanceDeposeCurrentObject(t *testing.T) {
-	t.Run("nil receiver HasCurrent", func(t *testing.T) {
-		// small helper to catch panics
-		callHasCurrent := func(ri *ResourceInstance) (ret bool, panicked bool) {
-			defer func() {
-				if r := recover(); r != nil {
-					panicked = true
-				}
-			}()
-			return ri.HasCurrent(), false
-		}
-
+	t.Run("nil resource", func(t *testing.T) {
 		var nilRI *ResourceInstance
-		got, panicked := callHasCurrent(nilRI)
-		if panicked {
-			t.Fatalf("HasCurrent(nil) panicked; want no panic and false")
-		}
-		if got {
-			t.Fatalf("HasCurrent(nil) = true; want false")
+		dk := nilRI.deposeCurrentObject(NotDeposed)
+		t.Logf("deposedKey (nil receiver) is %q", dk)
+
+		if dk != NotDeposed {
+			t.Fatalf("expected NotDeposed for nil receiver, got %q", dk)
 		}
 	})
 	obj := &ResourceInstanceObjectSrc{

--- a/internal/states/state_test.go
+++ b/internal/states/state_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/go-test/deep"
 	"github.com/google/go-cmp/cmp"
@@ -337,6 +338,18 @@ func TestStateHasResourceInstanceObjects(t *testing.T) {
 				s := ss.Lock()
 				delete(s.Modules[""].Resources["test.foo"].Instances, addrs.NoKey)
 				ss.Unlock()
+				done := make(chan struct{})
+				go func() {
+					ss.Lock()
+					ss.Unlock()
+					close(done)
+				}()
+				select {
+				case <-done:
+					// OK: lock was released
+				case <-time.After(500 * time.Millisecond):
+					t.Fatalf("Unlock did not release SyncState lock (timed out acquiring lock again)")
+				}
 			},
 			false,
 		},
@@ -1007,6 +1020,70 @@ func TestState_MoveModule(t *testing.T) {
 			t.Fatal("nested child module of src wasn't moved")
 		}
 	})
+}
+
+func TestState_ProviderAddrs(t *testing.T) {
+	// 1) nil state
+	var nilState *State
+	if got := nilState.ProviderAddrs(); got != nil {
+		t.Fatalf("nil state: expected nil, got %#v", got)
+	}
+
+	// 2) empty state
+	empty := NewState()
+	if got := empty.ProviderAddrs(); got != nil {
+		t.Fatalf("empty state: expected nil, got %#v", got)
+	}
+
+	// 3) populated state
+	s := NewState()
+
+	rootAWS := addrs.AbsProviderConfig{
+		Module:   addrs.RootModule,
+		Provider: addrs.NewDefaultProvider("aws"),
+	}
+	rootGoogle := addrs.AbsProviderConfig{
+		Module:   addrs.RootModule,
+		Provider: addrs.NewDefaultProvider("google"),
+	}
+	childAWS := addrs.AbsProviderConfig{
+		Module:   addrs.RootModule.Child("child"),
+		Provider: addrs.NewDefaultProvider("aws"),
+	}
+
+	rm := s.RootModule()
+	rm.SetResourceInstanceCurrent(
+		addrs.Resource{Mode: addrs.ManagedResourceMode, Type: "test_thing", Name: "foo"}.Instance(addrs.NoKey),
+		&ResourceInstanceObjectSrc{Status: ObjectReady, SchemaVersion: 1, AttrsJSON: []byte(`{}`)},
+		rootAWS,
+	)
+
+	rm.SetResourceInstanceCurrent(
+		addrs.Resource{Mode: addrs.ManagedResourceMode, Type: "test_thing", Name: "bar"}.Instance(addrs.NoKey),
+		&ResourceInstanceObjectSrc{Status: ObjectReady, SchemaVersion: 1, AttrsJSON: []byte(`{}`)},
+		rootAWS,
+	)
+
+	rm.SetResourceInstanceCurrent(
+		addrs.Resource{Mode: addrs.ManagedResourceMode, Type: "test_thing", Name: "baz"}.Instance(addrs.NoKey),
+		&ResourceInstanceObjectSrc{Status: ObjectReady, SchemaVersion: 1, AttrsJSON: []byte(`{}`)},
+		rootGoogle,
+	)
+
+	childMI := addrs.RootModuleInstance.Child("child", addrs.NoKey)
+	cm := s.EnsureModule(childMI)
+	cm.SetResourceInstanceCurrent(
+		addrs.Resource{Mode: addrs.ManagedResourceMode, Type: "test_thing", Name: "child"}.Instance(addrs.NoKey),
+		&ResourceInstanceObjectSrc{Status: ObjectReady, SchemaVersion: 1, AttrsJSON: []byte(`{}`)},
+		childAWS,
+	)
+
+	got := s.ProviderAddrs()
+	expected := []addrs.AbsProviderConfig{childAWS, rootAWS, rootGoogle}
+
+	if !reflect.DeepEqual(got, expected) {
+		t.Fatalf("unexpected provider addrs\nexpected: %#v\ngot: %#v", expected, got)
+	}
 }
 
 func mustParseModuleInstanceStr(str string) addrs.ModuleInstance {


### PR DESCRIPTION
<!--
This PR improves the tests in the `internal/states` package to cover cases revealed by mutation testing. 

- `state_test.go`: 
Adds a test that executes `ProviderAddrs()` for three scenarios, (1) a `nil` state, (2) an empty state, and (3) a populated state. This function is currently not exercised by tests in this package, allowing a mutant to survive.
Moreover, code is added to an existing test (`TestStateHasResourceInstanceObjects`) to ensure that Unlock() actually invokes the underlying mutex unlock. Without this, a no-op mutant survives.

- `resource_test.go`: Extends the `TestResourceInstanceDeposeCurrentObject` with minimal subtest that calls `HasCurrent(nil)`. This kills the mutant that removes the receiver nil-check.

-->

<!--

GitHub issues fixed by this PR: https://github.com/hashicorp/terraform/issues/37649

-->

Fixes #37649

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.15.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
