### PR TITLE
actions: allow invoke only on local execution while TFC adds support

### DIFF
--- a/internal/command/plan.go
+++ b/internal/command/plan.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform/internal/backend/backendrun"
+	"github.com/hashicorp/terraform/internal/backend/local"
 	"github.com/hashicorp/terraform/internal/command/arguments"
 	"github.com/hashicorp/terraform/internal/command/views"
 	"github.com/hashicorp/terraform/internal/tfdiags"
@@ -76,6 +77,16 @@ func (c *PlanCommand) Run(rawArgs []string) int {
 	if diags.HasErrors() {
 		view.Diagnostics(diags)
 		return 1
+	}
+
+	if len(args.Operation.ActionTargets) > 0 {
+		if _, ok := be.(*local.Local); !ok {
+			// Temporarily block invoking actions when executing anything other
+			// than locally.
+			// TODO: Remove this when TFC supports remote operation of action
+			//       invoke plans.
+			diags = diags.Append(tfdiags.Sourceless(tfdiags.Error, "Invalid argument", "The -invoke argument can currently only be used when Terraform is executing locally."))
+		}
 	}
 
 	// Build the operation request

--- a/internal/command/plan.go
+++ b/internal/command/plan.go
@@ -86,6 +86,8 @@ func (c *PlanCommand) Run(rawArgs []string) int {
 			// TODO: Remove this when TFC supports remote operation of action
 			//       invoke plans.
 			diags = diags.Append(tfdiags.Sourceless(tfdiags.Error, "Invalid argument", "The -invoke argument can currently only be used when Terraform is executing locally."))
+			view.Diagnostics(diags)
+			return 1
 		}
 	}
 


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

This PR just returns an error early if a user tries to invoke actions with a cloud backend. TFC hasn't been updated yet, and Terraform crashes if this is attempted. With this we just get an error message instead of a crash, and we can remove this once TFC is up to date.

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->


## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.14.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
