### PR TITLE
Fixes to protobuf compile script

### DIFF
--- a/tools/protobuf-compile/protobuf-compile.go
+++ b/tools/protobuf-compile/protobuf-compile.go
@@ -144,7 +144,7 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	_, err = buildProtocGenGoGrpc(workDir)
+	protocGenGoGrpcExec, err := buildProtocGenGoGrpc(workDir)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -157,7 +157,7 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	protocGenGoGrpcExec, err := filepath.Abs(protocGenGoExec)
+	protocGenGoGrpcExec, err = filepath.Abs(protocGenGoGrpcExec)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/tools/protobuf-compile/protobuf-compile.go
+++ b/tools/protobuf-compile/protobuf-compile.go
@@ -175,7 +175,7 @@ func main() {
 
 		cmd := &exec.Cmd{
 			Path:   cmdLine[0],
-			Args:   cmdLine[1:],
+			Args:   cmdLine,
 			Dir:    step.WorkDir,
 			Env:    os.Environ(),
 			Stdout: os.Stdout,


### PR DESCRIPTION
Context from hashicorp/terraform-plugin-go:
* https://github.com/hashicorp/terraform-plugin-go/pull/566
* https://github.com/hashicorp/terraform-plugin-go/pull/570

It looks like there are some bugs in this script, found by @austinvalle when he debugged some issues after I copied a version of the script into that repo.

This PRs changes are:
* Correct an error that meant `protoc-gen-go-grpc` wasn't actually being used as a plugin
* Changes to the arguments passed to the `exec.Cmd` that generates the code (for each job defined in protocSteps):
    * The docs for exec.Cmd say "Args holds command line arguments, including the command as Args[0]."

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

N/A

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
