### PR TITLE
actions: enforce ephemeral into write-only attributes behaviour

### DIFF
--- a/internal/terraform/context_apply_action_test.go
+++ b/internal/terraform/context_apply_action_test.go
@@ -1308,54 +1308,6 @@ resource "test_object" "resource" {
 			}},
 		},
 
-		"ephemeral values": {
-			module: map[string]string{
-				"main.tf": `
-variable "attr" {
-  type = string
-  ephemeral = true
-}
-
-resource "test_object" "resource" {
-  name = "hello"
-  lifecycle {
-    action_trigger {
-      events = [before_create]
-      actions = [action.action_example.hello]
-    }
-  }
-}
-
-action "action_example" "hello" {
-  config {
-    attr = var.attr
-  }
-}
-`,
-			},
-			expectInvokeActionCalled: true,
-			expectInvokeActionCalls: []providers.InvokeActionRequest{
-				{
-					ActionType: "action_example",
-					PlannedActionData: cty.ObjectVal(map[string]cty.Value{
-						"attr": cty.StringVal("wo-apply"),
-					}),
-				},
-			},
-			planOpts: SimplePlanOpts(plans.NormalMode, InputValues{
-				"attr": {
-					Value: cty.StringVal("wo-plan"),
-				},
-			}),
-			applyOpts: &ApplyOpts{
-				SetVariables: InputValues{
-					"attr": {
-						Value: cty.StringVal("wo-apply"),
-					},
-				},
-			},
-		},
-
 		"write-only attributes": {
 			module: map[string]string{
 				"main.tf": `

--- a/internal/terraform/node_action_instance.go
+++ b/internal/terraform/node_action_instance.go
@@ -64,7 +64,14 @@ func (n *NodeActionDeclarationInstance) Execute(ctx EvalContext, _ walkOperation
 		configVal, _, configDiags = ctx.EvaluateBlock(n.Config.Config, n.Schema.ConfigSchema.DeepCopy(), nil, keyData)
 
 		diags = diags.Append(configDiags)
-		if diags.HasErrors() {
+		if configDiags.HasErrors() {
+			return diags
+		}
+
+		valDiags := validateResourceForbiddenEphemeralValues(ctx, configVal, n.Schema.ConfigSchema)
+		diags = diags.Append(valDiags.InConfigBody(n.Config.Config, n.Addr.String()))
+
+		if valDiags.HasErrors() {
 			return diags
 		}
 	}

--- a/internal/terraform/node_action_validate.go
+++ b/internal/terraform/node_action_validate.go
@@ -102,6 +102,9 @@ func (n *NodeValidatableAction) Execute(ctx EvalContext, _ walkOperation) tfdiag
 		}
 	}
 
+	valDiags = validateResourceForbiddenEphemeralValues(ctx, configVal, schema.ConfigSchema)
+	diags = diags.Append(valDiags.InConfigBody(config, n.Addr.String()))
+
 	// Use unmarked value for validate request
 	unmarkedConfigVal, _ := configVal.UnmarkDeep()
 	log.Printf("[TRACE] Validating config for %q", n.Addr)


### PR DESCRIPTION
~This just adds two tests that validate the behaviour of ephemeral inputs into actions, and codifies it so we can make sure we don't accidentally regress this in the future (only deliberately regress).~

Edited. I've changed this PR so that we are actually enforcing the ephemeral into write-only attributes behaviour. This matches the behaviour of resources, and means we won't accidentally leak ephemeral values into the plan file or introduce weird behaviour with ephemeral values changing between plan and apply.