### PR TITLE
PSS: Implement `Get` and `Put` methods on remote grpc state, using Read/WriteStateBytes RPCs

### DIFF
--- a/internal/states/remote/remote_grpc.go
+++ b/internal/states/remote/remote_grpc.go
@@ -79,7 +79,14 @@ func (g *grpcClient) Get() (*Payload, tfdiags.Diagnostics) {
 //
 // Implementation of remote.Client
 func (g *grpcClient) Put(state []byte) tfdiags.Diagnostics {
-	panic("not implemented yet")
+	req := providers.WriteStateBytesRequest{
+		TypeName: g.typeName,
+		StateId:  g.stateId,
+		Bytes:    state,
+	}
+	resp := g.provider.WriteStateBytes(req)
+
+	return resp.Diagnostics
 }
 
 // Delete invokes the DeleteState gRPC method in the plugin protocol

--- a/internal/states/remote/remote_grpc.go
+++ b/internal/states/remote/remote_grpc.go
@@ -54,7 +54,24 @@ type grpcClient struct {
 //
 // Implementation of remote.Client
 func (g *grpcClient) Get() (*Payload, tfdiags.Diagnostics) {
-	panic("not implemented yet")
+	req := providers.ReadStateBytesRequest{
+		TypeName: g.typeName,
+		StateId:  g.stateId,
+	}
+	resp := g.provider.ReadStateBytes(req)
+
+	if len(resp.Bytes) == 0 {
+		// No state to return
+		return nil, resp.Diagnostics
+	}
+
+	// TODO: Remove or replace use of MD5?
+	// The MD5 value here is never used.
+	payload := &Payload{
+		Data: resp.Bytes,
+		MD5:  []byte{}, // empty, as this is unused downstream
+	}
+	return payload, resp.Diagnostics
 }
 
 // Put invokes the WriteStateBytes gRPC method in the plugin protocol

--- a/internal/states/remote/remote_grpc_test.go
+++ b/internal/states/remote/remote_grpc_test.go
@@ -6,14 +6,122 @@ package remote
 import (
 	"testing"
 
+	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/terraform/internal/providers"
 	testing_provider "github.com/hashicorp/terraform/internal/providers/testing"
+	"github.com/hashicorp/terraform/internal/tfdiags"
 )
+
+// Testing grpcClient's Get method, via the state manager made using a grpcClient.
+// The RefreshState method on a state manager calls the Get method of the underlying client.
+func Test_grpcClient_Get(t *testing.T) {
+	typeName := "foo_bar" // state store 'bar' in provider 'foo'
+	stateId := "production"
+	stateString := `{
+    "version": 4,
+    "terraform_version": "0.13.0",
+    "serial": 0,
+    "lineage": "",
+    "outputs": {
+        "foo": {
+            "value": "bar",
+            "type": "string"
+        }
+    }
+}`
+
+	t.Run("state manager made using grpcClient returns expected state", func(t *testing.T) {
+		provider := testing_provider.MockProvider{
+			// Mock a provider and internal state store that
+			// have both been configured
+			ConfigureProviderCalled:   true,
+			ConfigureStateStoreCalled: true,
+
+			// Check values received by the provider from the Get method.
+			ReadStateBytesFn: func(req providers.ReadStateBytesRequest) providers.ReadStateBytesResponse {
+				if req.TypeName != typeName || req.StateId != stateId {
+					t.Fatalf("expected provider ReadStateBytes method to receive TypeName %q and StateId %q, instead got TypeName %q and StateId %q",
+						typeName,
+						stateId,
+						req.TypeName,
+						req.StateId)
+				}
+				return providers.ReadStateBytesResponse{
+					Bytes: []byte(stateString),
+					// no diags
+				}
+			},
+		}
+
+		// This package will be consumed in a statemgr.Full, so we test using NewRemoteGRPC
+		// and invoke the method on that interface that uses Get.
+		c := NewRemoteGRPC(&provider, typeName, stateId)
+
+		err := c.RefreshState() // Calls Get
+		if err != nil {
+			t.Fatalf("unexpected error: %s", err)
+		}
+
+		if !provider.ReadStateBytesCalled {
+			t.Fatal("expected remote grpc state manager's RefreshState method to, via Get, call ReadStateBytes method on underlying provider, but it has not been called")
+		}
+		s := c.State()
+		v, ok := s.RootOutputValues["foo"]
+		if !ok {
+			t.Fatal("state manager doesn't contain the state returned by the mock")
+		}
+		if v.Value.AsString() != "bar" {
+			t.Fatal("state manager doesn't contain the correct output value in the state")
+		}
+	})
+
+	t.Run("state manager made using grpcClient returns expected error from error diagnostic", func(t *testing.T) {
+		var diags tfdiags.Diagnostics
+		diags = diags.Append(&hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  "error forced from test",
+			Detail:   "error forced from test",
+		})
+		provider := testing_provider.MockProvider{
+			// Mock a provider and internal state store that
+			// have both been configured
+			ConfigureProviderCalled:   true,
+			ConfigureStateStoreCalled: true,
+
+			// Force an error diagnostic
+			ReadStateBytesFn: func(req providers.ReadStateBytesRequest) providers.ReadStateBytesResponse {
+				return providers.ReadStateBytesResponse{
+					// we don't expect state to accompany an error, but this test shows that
+					// if an error us present amy state returned is ignored.
+					Bytes:       []byte(stateString),
+					Diagnostics: diags,
+				}
+			},
+		}
+
+		// This package will be consumed in a statemgr.Full, so we test using NewRemoteGRPC
+		// and invoke the method on that interface that uses Get.
+		c := NewRemoteGRPC(&provider, typeName, stateId)
+
+		err := c.RefreshState() // Calls Get
+		if err == nil {
+			t.Fatal("expected an error but got none")
+		}
+
+		if !provider.ReadStateBytesCalled {
+			t.Fatal("expected remote grpc state manager's RefreshState method to, via Get, call ReadStateBytes method on underlying provider, but it has not been called")
+		}
+		s := c.State()
+		if s != nil {
+			t.Fatalf("expected refresh to fail due to error diagnostic, but state has been refreshed: %s", s.String())
+		}
+	})
+}
 
 // Testing grpcClient's Delete method.
 // This method is needed to implement the remote.Client interface, but
 // this is not invoked by the remote state manager (remote.State) that
-// wil contain the client.
+// will contain the client.
 //
 // In future we should remove the need for a Delete method in
 // remote.Client, but for now it is implemented and tested.


### PR DESCRIPTION
This PR allows any backend.Backend that represents a pluggable state store to return a state manager that's capable of reading and writing state via the ReadStateBytes and WriteStateBytes RPCs.

A remaining question is what to do about the MD5 hash returned from the Get method. This is not used downstream at all, so I've decided to leave it empty intentionally. I think calculating an MD5 hash on the Core/client side would be misleading, as readers would assume the value is used.

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

N/A

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
