### PR TITLE
Backport: search: Drop identity from state if no identity schema is present

### DIFF
--- a/internal/states/instance_object_src.go
+++ b/internal/states/instance_object_src.go
@@ -117,7 +117,7 @@ func (os *ResourceInstanceObjectSrc) Decode(schema providers.Schema) (*ResourceI
 	var identity cty.Value
 	if os.decodeIdentityCache != cty.NilVal {
 		identity = os.decodeIdentityCache
-	} else if os.IdentityJSON != nil {
+	} else if os.IdentityJSON != nil && schema.Identity != nil {
 		identity, err = ctyjson.Unmarshal(os.IdentityJSON, schema.Identity.ImpliedType())
 		if err != nil {
 			return nil, fmt.Errorf("failed to decode identity: %s. This is most likely a bug in the Provider, providers must not change the identity schema without updating the identity schema version", err.Error())

--- a/internal/states/instance_object_test.go
+++ b/internal/states/instance_object_test.go
@@ -61,22 +61,22 @@ func TestResourceInstanceObject_encode(t *testing.T) {
 
 	// multiple instances may have been assigned the same deps slice
 	objs := []*ResourceInstanceObject{
-		&ResourceInstanceObject{
+		{
 			Value:        value,
 			Status:       ObjectPlanned,
 			Dependencies: depsOne,
 		},
-		&ResourceInstanceObject{
+		{
 			Value:        value,
 			Status:       ObjectPlanned,
 			Dependencies: depsTwo,
 		},
-		&ResourceInstanceObject{
+		{
 			Value:        value,
 			Status:       ObjectPlanned,
 			Dependencies: depsOne,
 		},
-		&ResourceInstanceObject{
+		{
 			Value:        value,
 			Status:       ObjectPlanned,
 			Dependencies: depsOne,
@@ -91,10 +91,7 @@ func TestResourceInstanceObject_encode(t *testing.T) {
 	var mu sync.Mutex
 
 	for _, obj := range objs {
-		obj := obj
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			rios, err := obj.Encode(schema)
 			if err != nil {
 				t.Errorf("unexpected error: %s", err)
@@ -102,7 +99,7 @@ func TestResourceInstanceObject_encode(t *testing.T) {
 			mu.Lock()
 			encoded = append(encoded, rios)
 			mu.Unlock()
-		}()
+		})
 	}
 	wg.Wait()
 


### PR DESCRIPTION
This PR is manual backport of https://github.com/hashicorp/terraform/pull/37709, because the automatic one failed

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.14.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [ ] This change is not user-facing.
