### PR TITLE
Fix 1.14 changelog entry

### DIFF
--- a/.changes/v1.14/BUG FIXES-20250927-184134.yaml
+++ b/.changes/v1.14/BUG FIXES-20250927-184134.yaml
@@ -1,4 +1,4 @@
-kind: BUGFIX
+kind: BUG FIXES
 body: The CLI now summarizes the number of actions invoked during `terraform apply`, matching the plan output.
 time: 2025-09-27T18:41:34.771437+02:00
 custom:


### PR DESCRIPTION
The changie CI workflow [is currently failing](https://github.com/hashicorp/terraform/actions/runs/18277907604/job/52044452921#step:5:14) on the v1.14 branch due to a misformated changelog entry that was introduced in https://github.com/hashicorp/terraform/pull/37692.

This PR fixes the entry. I'm skipping the changelog check on this PR since the workflow checks out the target branch (v1.14) and will fail until this PR is merged.

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.14.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [ ] This change is not user-facing.
