### PR TITLE
1.14 backport of actions: when targeting a resource the associated actions should be run

### DIFF
--- a/internal/terraform/context_apply_action_test.go
+++ b/internal/terraform/context_apply_action_test.go
@@ -38,6 +38,7 @@ func TestContextApply_actions(t *testing.T) {
 		expectInvokeActionCalls             []providers.InvokeActionRequest
 		expectInvokeActionCallsAreUnordered bool
 		expectDiagnostics                   func(m *configs.Config) tfdiags.Diagnostics
+		ignoreWarnings                      bool
 	}{
 		"before_create triggered": {
 			module: map[string]string{
@@ -1928,6 +1929,441 @@ resource "test_object" "a" {
 				},
 			},
 		},
+
+		"targeted run": {
+			module: map[string]string{
+				"main.tf": `
+action "action_example" "hello" {
+  config {
+    attr = "hello"
+  }
+}
+action "action_example" "there" {
+  config {
+    attr = "there"
+  }
+}
+resource "test_object" "a" {
+  lifecycle {
+    action_trigger {
+      events  = [before_create]
+      actions = [action.action_example.hello]
+    }
+    action_trigger {
+      events  = [after_create]
+      actions = [action.action_example.there]
+    }
+  }
+}
+action "action_example" "general" {
+  config {
+    attr = "general"
+  }
+}
+action "action_example" "kenobi" {
+  config {
+    attr = "kenobi"
+  }
+}
+resource "test_object" "b" {
+  lifecycle {
+    action_trigger {
+      events  = [before_create, after_update]
+      actions = [action.action_example.general]
+    }
+  }
+}
+`,
+			},
+			ignoreWarnings:           true,
+			expectInvokeActionCalled: true,
+			expectInvokeActionCalls: []providers.InvokeActionRequest{
+				{
+					ActionType: "action_example",
+					PlannedActionData: cty.ObjectVal(map[string]cty.Value{
+						"attr": cty.StringVal("hello"),
+					}),
+				},
+				{
+					ActionType: "action_example",
+					PlannedActionData: cty.ObjectVal(map[string]cty.Value{
+						"attr": cty.StringVal("there"),
+					}),
+				},
+			},
+			planOpts: &PlanOpts{
+				Mode: plans.NormalMode,
+				Targets: []addrs.Targetable{
+					addrs.RootModuleInstance.Resource(addrs.ManagedResourceMode, "test_object", "a"),
+				},
+			},
+		},
+
+		"targeted run with ancestor that has actions": {
+			module: map[string]string{
+				"main.tf": `
+action "action_example" "hello" {
+  config {
+    attr = "hello"
+  }
+}
+action "action_example" "there" {
+  config {
+    attr = "there"
+  }
+}
+resource "test_object" "origin" {
+  name = "origin"
+  lifecycle {
+    action_trigger {
+      events  = [before_create]
+      actions = [action.action_example.hello]
+    }
+  }
+}
+resource "test_object" "a" {
+  name = test_object.origin.name
+  lifecycle {
+    action_trigger {
+      events  = [after_create]
+      actions = [action.action_example.there]
+    }
+  }
+}
+action "action_example" "general" {}
+action "action_example" "kenobi" {}
+resource "test_object" "b" {
+  lifecycle {
+    action_trigger {
+      events  = [before_create, after_update]
+      actions = [action.action_example.general]
+    }
+  }
+}
+`,
+			},
+			ignoreWarnings:           true,
+			expectInvokeActionCalled: true,
+			expectInvokeActionCalls: []providers.InvokeActionRequest{
+				{
+					ActionType: "action_example",
+					PlannedActionData: cty.ObjectVal(map[string]cty.Value{
+						"attr": cty.StringVal("hello"),
+					}),
+				},
+				{
+					ActionType: "action_example",
+					PlannedActionData: cty.ObjectVal(map[string]cty.Value{
+						"attr": cty.StringVal("there"),
+					}),
+				},
+			},
+			planOpts: &PlanOpts{
+				Mode: plans.NormalMode,
+				Targets: []addrs.Targetable{
+					addrs.RootModuleInstance.Resource(addrs.ManagedResourceMode, "test_object", "a"),
+				},
+			},
+		},
+
+		"targeted run with expansion": {
+			module: map[string]string{
+				"main.tf": `
+action "action_example" "hello" {
+  count = 3
+  config {
+    attr = "hello-${count.index}"
+  }
+}
+action "action_example" "there" {
+  count = 3
+  config {
+    attr = "there-${count.index}"
+  }
+}
+resource "test_object" "a" {
+  count = 3
+  lifecycle {
+    action_trigger {
+      events  = [before_create]
+      actions = [action.action_example.hello[count.index]]
+    }
+    action_trigger {
+      events  = [after_create]
+      actions = [action.action_example.there[count.index]]
+    }
+  }
+}
+action "action_example" "general" {}
+action "action_example" "kenobi" {}
+resource "test_object" "b" {
+  lifecycle {
+    action_trigger {
+      events  = [before_create, after_update]
+      actions = [action.action_example.general]
+    }
+  }
+}
+`,
+			},
+			ignoreWarnings:           true,
+			expectInvokeActionCalled: true,
+			expectInvokeActionCalls: []providers.InvokeActionRequest{
+				{
+					// action_example.hello[2] before_create
+					ActionType: "action_example",
+					PlannedActionData: cty.ObjectVal(map[string]cty.Value{
+						"attr": cty.StringVal("hello-2"),
+					}),
+				},
+				{
+					// action_example.there[2] after_create
+					ActionType: "action_example",
+					PlannedActionData: cty.ObjectVal(map[string]cty.Value{
+						"attr": cty.StringVal("there-2"),
+					}),
+				},
+			},
+			planOpts: &PlanOpts{
+				Mode: plans.NormalMode,
+				Targets: []addrs.Targetable{
+					addrs.RootModuleInstance.
+						Resource(addrs.ManagedResourceMode, "test_object", "a").
+						Instance(addrs.IntKey(2)),
+				},
+			},
+		},
+
+		"targeted run with resource reference": {
+			module: map[string]string{
+				"main.tf": `
+resource "test_object" "source" {
+  name = "src"
+}
+action "action_example" "hello" {
+  config {
+    attr = test_object.source.name
+  }
+}
+action "action_example" "there" {
+  config {
+    attr = "there"
+  }
+}
+resource "test_object" "a" {
+  lifecycle {
+    action_trigger {
+      events  = [before_create]
+      actions = [action.action_example.hello]
+    }
+    action_trigger {
+      events  = [after_create]
+      actions = [action.action_example.there]
+    }
+  }
+}
+action "action_example" "general" {}
+action "action_example" "kenobi" {}
+resource "test_object" "b" {
+  lifecycle {
+    action_trigger {
+      events  = [before_create, after_update]
+      actions = [action.action_example.general]
+    }
+  }
+}
+`,
+			},
+			ignoreWarnings:           true,
+			expectInvokeActionCalled: true,
+			expectInvokeActionCalls: []providers.InvokeActionRequest{
+				{
+					// action_example.hello before_create with config (attr = test_object.source.name -> "src")
+					ActionType: "action_example",
+					PlannedActionData: cty.ObjectVal(map[string]cty.Value{
+						"attr": cty.StringVal("src"),
+					}),
+				},
+				{
+					// action_example.there after_create with static config attr = "there"
+					ActionType: "action_example",
+					PlannedActionData: cty.ObjectVal(map[string]cty.Value{
+						"attr": cty.StringVal("there"),
+					}),
+				},
+			},
+			planOpts: &PlanOpts{
+				Mode: plans.NormalMode,
+				Targets: []addrs.Targetable{
+					addrs.RootModuleInstance.Resource(addrs.ManagedResourceMode, "test_object", "a"),
+				},
+			},
+		},
+
+		"targeted run with condition referencing another resource": {
+			module: map[string]string{
+				"main.tf": `
+resource "test_object" "source" {
+  name = "source"
+}
+action "action_example" "hello" {
+  config {
+    attr = test_object.source.name
+  }
+}
+resource "test_object" "a" {
+  lifecycle {
+    action_trigger {
+      events    = [before_create]
+      condition = test_object.source.name == "source"
+      actions   = [action.action_example.hello]
+    }
+  }
+}
+`,
+			},
+			ignoreWarnings:           true,
+			expectInvokeActionCalled: true,
+			expectInvokeActionCalls: []providers.InvokeActionRequest{
+				{
+					// action_example.hello before_create with config (attr = test_object.source.name -> "source")
+					ActionType: "action_example",
+					PlannedActionData: cty.ObjectVal(map[string]cty.Value{
+						"attr": cty.StringVal("source"),
+					}),
+				},
+			},
+			planOpts: &PlanOpts{
+				Mode: plans.NormalMode,
+				Targets: []addrs.Targetable{
+					addrs.RootModuleInstance.Resource(addrs.ManagedResourceMode, "test_object", "a"),
+				},
+			},
+		},
+
+		"targeted run with action referencing another resource that also triggers actions": {
+			module: map[string]string{
+				"main.tf": `
+action "action_example" "hello" {
+  config {
+    attr = "hello"
+  }
+}
+resource "test_object" "source" {
+  name = "source"
+  lifecycle {
+    action_trigger {
+      events  = [before_create]
+      actions = [action.action_example.hello]
+    }
+  }
+}
+action "action_example" "there" {
+  config {
+    attr = test_object.source.name
+  }
+}
+resource "test_object" "a" {
+  lifecycle {
+    action_trigger {
+      events  = [after_create]
+      actions = [action.action_example.there]
+    }
+  }
+}
+resource "test_object" "b" {
+  lifecycle {
+    action_trigger {
+      events  = [before_create]
+      actions = [action.action_example.hello]
+    }
+  }
+}
+`,
+			},
+			ignoreWarnings:           true,
+			expectInvokeActionCalled: true,
+			expectInvokeActionCalls: []providers.InvokeActionRequest{
+				{
+					// action_example.hello before_create with static config attr = "hello"
+					ActionType: "action_example",
+					PlannedActionData: cty.ObjectVal(map[string]cty.Value{
+						"attr": cty.StringVal("hello"),
+					}),
+				},
+				{
+					// action_example.there after_create with config attr = source.name ("source")
+					ActionType: "action_example",
+					PlannedActionData: cty.ObjectVal(map[string]cty.Value{
+						"attr": cty.StringVal("source"),
+					}),
+				},
+			},
+			planOpts: &PlanOpts{
+				Mode: plans.NormalMode,
+				Targets: []addrs.Targetable{
+					addrs.RootModuleInstance.Resource(addrs.ManagedResourceMode, "test_object", "a"),
+				},
+			},
+		},
+
+		"targeted run triggers resources and actions referenced by not-running actions": {
+			module: map[string]string{
+				"main.tf": `
+action "action_example" "hello" {
+  config {
+    attr = "hello"
+  }
+}
+resource "test_object" "source" {
+name = "source"
+lifecycle {
+	action_trigger {
+		events = [before_create]
+		actions = [action.action_example.hello]
+	}
+}
+}
+action "action_example" "there" {
+config {
+	attr = test_object.source.name
+}
+}
+resource "test_object" "a" {
+lifecycle {
+	action_trigger {
+		events = [after_update]
+		actions = [action.action_example.there]
+	}
+}
+}
+resource "test_object" "b" {
+lifecycle {
+	action_trigger {
+		events = [before_update]
+		actions = [action.action_example.hello]
+	}
+}
+}
+		`,
+			},
+			ignoreWarnings:           true,
+			expectInvokeActionCalled: true,
+			expectInvokeActionCalls: []providers.InvokeActionRequest{
+				{
+					ActionType: "action_example",
+					PlannedActionData: cty.ObjectVal(map[string]cty.Value{
+						"attr": cty.StringVal("hello"),
+					}),
+				},
+			},
+			planOpts: &PlanOpts{
+				Mode: plans.NormalMode,
+				Targets: []addrs.Targetable{
+					addrs.RootModuleInstance.Resource(addrs.ManagedResourceMode, "test_object", "a"),
+				},
+			},
+		},
 	} {
 		t.Run(name, func(t *testing.T) {
 			if tc.toBeImplemented {
@@ -2097,7 +2533,11 @@ resource "test_object" "a" {
 			}
 
 			plan, diags := ctx.Plan(m, tc.prevRunState, planOpts)
-			tfdiags.AssertNoDiagnostics(t, diags)
+			if tc.ignoreWarnings {
+				tfdiags.AssertNoErrors(t, diags)
+			} else {
+				tfdiags.AssertNoDiagnostics(t, diags)
+			}
 
 			if !plan.Applyable {
 				t.Fatalf("plan is not applyable but should be")
@@ -2107,7 +2547,11 @@ resource "test_object" "a" {
 			if tc.expectDiagnostics != nil {
 				tfdiags.AssertDiagnosticsMatch(t, diags, tc.expectDiagnostics(m))
 			} else {
-				tfdiags.AssertNoDiagnostics(t, diags)
+				if tc.ignoreWarnings {
+					tfdiags.AssertNoErrors(t, diags)
+				} else {
+					tfdiags.AssertNoDiagnostics(t, diags)
+				}
 			}
 
 			if tc.expectInvokeActionCalled && len(invokeActionCalls) == 0 {
@@ -2115,7 +2559,7 @@ resource "test_object" "a" {
 			}
 
 			if len(tc.expectInvokeActionCalls) > 0 && len(invokeActionCalls) != len(tc.expectInvokeActionCalls) {
-				t.Fatalf("expected %d invoke action calls, got %d", len(tc.expectInvokeActionCalls), len(invokeActionCalls))
+				t.Fatalf("expected %d invoke action calls, got %d (%#v)", len(tc.expectInvokeActionCalls), len(invokeActionCalls), invokeActionCalls)
 			}
 
 			for i, expectedCall := range tc.expectInvokeActionCalls {

--- a/internal/terraform/node_action_trigger_apply.go
+++ b/internal/terraform/node_action_trigger_apply.go
@@ -28,7 +28,7 @@ var (
 )
 
 func (n *nodeActionTriggerApplyExpand) Name() string {
-	return fmt.Sprintf("%s (apply)", n.nodeAbstractActionTriggerExpand.Name())
+	return fmt.Sprintf("%s (apply - %s)", n.nodeAbstractActionTriggerExpand.Name(), n.relativeTiming)
 }
 
 func (n *nodeActionTriggerApplyExpand) DynamicExpand(ctx EvalContext) (*Graph, tfdiags.Diagnostics) {

--- a/internal/terraform/transform_action_diff.go
+++ b/internal/terraform/transform_action_diff.go
@@ -52,7 +52,6 @@ func (t *ActionDiffTransformer) Transform(g *Graph) error {
 			if (beforeMatches || afterMatches) && atn.lifecycleActionTrigger.actionTriggerBlockIndex == lat.ActionTriggerBlockIndex && atn.lifecycleActionTrigger.actionListIndex == lat.ActionsListIndex {
 				atn.actionInvocationInstances = append(atn.actionInvocationInstances, ai)
 			}
-
 		}
 	}
 


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Fixes #

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.15.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
