### PR TITLE
PSS : Implement Lock and Unlock methods on remote grpc client

### DIFF
--- a/internal/states/remote/remote_grpc.go
+++ b/internal/states/remote/remote_grpc.go
@@ -110,8 +110,14 @@ func (g *grpcClient) Delete() tfdiags.Diagnostics {
 // to lock a named state in the remote location.
 //
 // Implementation of remote.Client
-func (g *grpcClient) Lock(*statemgr.LockInfo) (string, error) {
-	panic("not implemented yet")
+func (g *grpcClient) Lock(lock *statemgr.LockInfo) (string, error) {
+	req := providers.LockStateRequest{
+		TypeName:  g.typeName,
+		StateId:   g.stateId,
+		Operation: lock.Operation,
+	}
+	resp := g.provider.LockState(req)
+	return resp.LockId, resp.Diagnostics.Err()
 }
 
 // Unlock invokes the UnlockState gRPC method in the plugin protocol
@@ -119,5 +125,11 @@ func (g *grpcClient) Lock(*statemgr.LockInfo) (string, error) {
 //
 // Implementation of remote.Client
 func (g *grpcClient) Unlock(id string) error {
-	panic("not implemented yet")
+	req := providers.UnlockStateRequest{
+		TypeName: g.typeName,
+		StateId:  g.stateId,
+		LockId:   id,
+	}
+	resp := g.provider.UnlockState(req)
+	return resp.Diagnostics.Err()
 }


### PR DESCRIPTION
Follows https://github.com/hashicorp/terraform/pull/37711

This PR connects the relevant structs to the new provider protocol RPCs.

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

N/A

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
