### PR TITLE
Update `backendbase` to use empty strings from configuration, instead of looking for fallback or ENV values

### DIFF
--- a/.changes/v1.15/BUG FIXES-20251105-131122.yaml
+++ b/.changes/v1.15/BUG FIXES-20251105-131122.yaml
@@ -1,0 +1,5 @@
+kind: BUG FIXES
+body: 'backend: Fixed a bug where backends began to ignore empty string values set in the backend configuration.'
+time: 2025-11-05T13:11:22.098037Z
+custom:
+    Issue: "37846"

--- a/internal/backend/backendbase/base_test.go
+++ b/internal/backend/backendbase/base_test.go
@@ -256,11 +256,16 @@ func TestBase_emptyStringsUsed(t *testing.T) {
 		SDKLikeDefaults: SDKLikeDefaults{
 			"foo": {
 				Fallback: "fallback",
+				EnvVars:  []string{"FOO"},
 			},
 		},
 	}
 
-	t.Run("empty string is used", func(t *testing.T) {
+	t.Run("empty string from config is used despite fallback default value and environment variable value set", func(t *testing.T) {
+		// There is a fallback value supplied by the environment
+		envValue := "value from ENV"
+		t.Setenv("FOO", envValue)
+
 		// We pass an explicit empty string as the value of foo
 		val, gotDiags := b.PrepareConfig(cty.ObjectVal(map[string]cty.Value{
 			"foo": cty.StringVal(""),
@@ -275,7 +280,9 @@ func TestBase_emptyStringsUsed(t *testing.T) {
 			}
 			if v.AsString() != "" {
 				// If the empty string from config is ignored, the value here
-				// will be the "fallback" string defined in SDKLikeDefaults above.
+				// will be either thing defined in SDKLikeDefaults above:
+				// 1) the "fallback" string.
+				// 2) the value of FOO environment variable.
 				t.Fatalf("value should be an empty string, but got: %q", v.AsString())
 			}
 		} else {

--- a/internal/backend/backendbase/base_test.go
+++ b/internal/backend/backendbase/base_test.go
@@ -239,3 +239,47 @@ func TestBase_nullCrash(t *testing.T) {
 		}
 	})
 }
+
+func TestBase_emptyStringsUsed(t *testing.T) {
+	// This test ensures that empty strings in config are used and aren't ignored
+	// in favor of SDKLikeDefaults
+
+	b := Base{
+		Schema: &configschema.Block{
+			Attributes: map[string]*configschema.Attribute{
+				"foo": {
+					Type:     cty.String,
+					Required: true,
+				},
+			},
+		},
+		SDKLikeDefaults: SDKLikeDefaults{
+			"foo": {
+				Fallback: "fallback",
+			},
+		},
+	}
+
+	t.Run("empty string is used", func(t *testing.T) {
+		// We pass an explicit empty string as the value of foo
+		val, gotDiags := b.PrepareConfig(cty.ObjectVal(map[string]cty.Value{
+			"foo": cty.StringVal(""),
+		}))
+		if gotDiags.HasErrors() {
+			t.Fatalf("unexpected error diagnostics\n%s", gotDiags.Err())
+		}
+		attrs := val.AsValueMap()
+		if v, ok := attrs["foo"]; ok {
+			if v.IsNull() {
+				t.Fatal("value shouldn't be null")
+			}
+			if v.AsString() != "" {
+				// If the empty string from config is ignored, the value here
+				// will be the "fallback" string defined in SDKLikeDefaults above.
+				t.Fatalf("value should be an empty string, but got: %q", v.AsString())
+			}
+		} else {
+			t.Fatal("cannot find attribute foo")
+		}
+	})
+}

--- a/internal/backend/backendbase/sdklike.go
+++ b/internal/backend/backendbase/sdklike.go
@@ -199,6 +199,11 @@ func (d SDKLikeDefaults) ApplyTo(base cty.Value) (cty.Value, error) {
 			retAttrs[attrName] = givenVal
 			continue
 		}
+		if !givenVal.IsNull() && (givenVal.Type() == cty.String) && (givenVal.AsString() == "") {
+			// Don't use defaults if a string attribute is explicitly set to an empty string in the configuration.
+			retAttrs[attrName] = givenVal
+			continue
+		}
 
 		// The legacy SDK shims convert all values into strings (for flatmap)
 		// and then do their work in terms of that, so we'll follow suit here.

--- a/internal/backend/backendbase/sdklike_test.go
+++ b/internal/backend/backendbase/sdklike_test.go
@@ -264,9 +264,9 @@ func TestSDKLikeApplyEnvDefaults(t *testing.T) {
 			"string_set_fallback":    cty.StringVal("set in config"),
 			"string_set_env":         cty.StringVal("set in config"),
 			"string_fallback_null":   cty.StringVal("boop from fallback"),
-			"string_fallback_empty":  cty.StringVal("boop from fallback"),
+			"string_fallback_empty":  cty.StringVal(""), // config value is used
 			"string_env_null":        cty.StringVal("beep from environment"),
-			"string_env_empty":       cty.StringVal("beep from environment"),
+			"string_env_empty":       cty.StringVal(""), // config value is used
 			"string_env_unsetfirst":  cty.StringVal("beep from environment"),
 			"string_env_unsetsecond": cty.StringVal("beep from environment"),
 			"string_nothing_null":    cty.NullVal(cty.String),


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform/issues/37846

In https://github.com/hashicorp/terraform/pull/37225 (a rebased version of https://github.com/hashicorp/terraform/pull/34990) the azure backend was updated to use the new `backendbase` package  instead of the legacy SDK. This was the last backend migrated over.

Now, the structs representing remote-state backend implementations embed `backendbase.Base` ([example](https://github.com/hashicorp/terraform/blob/9595517730cd8f06d172810a6a5a11d45b6d8927/internal/backend/remote-state/azure/backend.go#L324-L325) in `azure`). If the remote-state backend doesn't implement methods like `PrepareConfig` then the implementation of that method in `backendbase.Base` is used instead.

In the case of the original issue reported about the Azure backend, the `azure` backend doesn't implement `PrepareConfig` itself and instead uses the implementation in `backendbase.Base`. In that method there is logic that didn't accurately mimic how the legacy SDK handled attributes that were explicitly set to an empty string in the configuration:

```hcl
backend "foobar" {
   value = ""
}
```

Instead of using the empty string value like the legacy SDK, the new `backendbase` package looks for any fallback values defined for that attribute in backend's `SDKLikeDefaults` values; default values defined in the schema or names of environment variables to use. The PrepareConfig method returns data about how the backend should be configured, a combo of config, schema defaults, and ENV values, and then Terraform Core then uses that value to configure the backend.

**This PR**
* Updates the `backendbase` package to detect non-null, string attributes that are set to `""` and uses that value, reverting behaviour back to match the legacy SDK.
    * This means the data received by Terraform Core from `PrepareConfig` still includes the empty string, and that'll be used to configure the backend.
* Adds a test that asserts neither fallback default values or ENVs are used when an attribute is set to an empty string.
* Updates existing test.

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.15.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [x] This change is user-facing and I added a changelog entry.
- [ ] This change is not user-facing.
