### PR TITLE
do not merge: Show that planning for one workspace, switching, and then applying the plan in the wrong workspace doesn't fail

### DIFF
--- a/internal/command/e2etest/primary_test.go
+++ b/internal/command/e2etest/primary_test.go
@@ -149,6 +149,135 @@ func TestPrimarySeparatePlan(t *testing.T) {
 
 }
 
+func TestPrimarySeparatePlan_incorrectWorkspace(t *testing.T) {
+	t.Parallel()
+
+	// This test reaches out to releases.hashicorp.com to download the
+	// template and null providers, so it can only run if network access is
+	// allowed.
+	skipIfCannotAccessNetwork(t)
+
+	fixturePath := filepath.Join("testdata", "full-workflow")
+	tf := e2e.NewBinary(t, terraformBin, fixturePath)
+
+	//// INIT
+	stdout, stderr, err := tf.Run("init")
+	if err != nil {
+		t.Fatalf("unexpected init error: %s\nstderr:\n%s", err, stderr)
+	}
+
+	// Make sure we actually downloaded the plugins, rather than picking up
+	// copies that might be already installed globally on the system.
+	if !strings.Contains(stdout, "Installing hashicorp/null v") {
+		t.Errorf("null provider download message is missing from init output:\n%s", stdout)
+		t.Logf("(this can happen if you have a copy of the plugin in one of the global plugin search dirs)")
+	}
+
+	//// PLAN
+	stdout, stderr, err = tf.Run("plan", "-out=tfplan")
+	if err != nil {
+		t.Fatalf("unexpected plan error: %s\nstderr:\n%s", err, stderr)
+	}
+
+	if !strings.Contains(stdout, "1 to add, 0 to change, 0 to destroy") {
+		t.Errorf("incorrect plan tally; want 1 to add:\n%s", stdout)
+	}
+
+	if !strings.Contains(stdout, "Saved the plan to: tfplan") {
+		t.Errorf("missing \"Saved the plan to...\" message in plan output\n%s", stdout)
+	}
+	if !strings.Contains(stdout, "terraform apply \"tfplan\"") {
+		t.Errorf("missing next-step instruction in plan output\n%s", stdout)
+	}
+
+	plan, err := tf.Plan("tfplan")
+	if err != nil {
+		t.Fatalf("failed to read plan file: %s", err)
+	}
+
+	if plan.Backend.Workspace != "default" {
+		t.Fatalf("expected plan to contain Workspace %q, got %q", "default", plan.Backend.Workspace)
+	}
+
+	// Create and select a workspace that doesn't match the plan made above
+	newWorkspace := "foobar"
+	stdout, stderr, err = tf.Run("workspace", "new", newWorkspace, "-no-color")
+	if err != nil {
+		t.Fatalf("unexpected error: %s\nstderr:\n%s", err, stderr)
+	}
+	expectedMsg := fmt.Sprintf("Created and switched to workspace %q!", newWorkspace)
+	if !strings.Contains(stdout, expectedMsg) {
+		t.Errorf("unexpected output, expected %q, but got:\n%s", expectedMsg, stdout)
+	}
+
+	//// APPLY
+	stdout, stderr, err = tf.Run("apply", "tfplan")
+	if err != nil {
+		t.Fatalf("unexpected apply error: %s\nstderr:\n%s", err, stderr)
+	}
+
+	if !strings.Contains(stdout, "Resources: 1 added, 0 changed, 0 destroyed") {
+		t.Errorf("incorrect apply tally; want 1 added:\n%s", stdout)
+	}
+
+	// Read the state saved for the custom workspace 'foobar'
+	filename := fmt.Sprintf("%s/terraform.tfstate.d/%s/terraform.tfstate", tf.WorkDir(), newWorkspace)
+	f, err := os.OpenFile(filename, os.O_RDWR, 0666)
+	if err != nil {
+		t.Fatalf("Error opening file at %s: %s", filename, err)
+	}
+	defer f.Close()
+
+	stateFile, err := statefile.Read(f)
+	if err != nil {
+		t.Fatalf("Error reading statefile: %s", err)
+	}
+	state := stateFile.State
+
+	stateResources := state.RootModule().Resources
+	var gotResources []string
+	for n := range stateResources {
+		gotResources = append(gotResources, n)
+	}
+	sort.Strings(gotResources)
+
+	wantResources := []string{
+		"null_resource.test",
+	}
+
+	if !reflect.DeepEqual(gotResources, wantResources) {
+		t.Errorf("wrong resources in state\ngot: %#v\nwant: %#v", gotResources, wantResources)
+	}
+
+	//// DESTROY
+	stdout, stderr, err = tf.Run("destroy", "-auto-approve")
+	if err != nil {
+		t.Fatalf("unexpected destroy error: %s\nstderr:\n%s", err, stderr)
+	}
+
+	if !strings.Contains(stdout, "Resources: 1 destroyed") {
+		t.Errorf("incorrect destroy tally; want 1 destroyed:\n%s", stdout)
+	}
+
+	f, err = os.OpenFile(filename, os.O_RDWR, 0666)
+	if err != nil {
+		t.Fatalf("Error opening file at %s: %s", filename, err)
+	}
+	defer f.Close()
+
+	stateFile, err = statefile.Read(f)
+	if err != nil {
+		t.Fatalf("Error reading statefile: %s", err)
+	}
+	state = stateFile.State
+
+	stateResources = state.RootModule().Resources
+	if len(stateResources) != 0 {
+		t.Errorf("wrong resources in state after destroy; want none, but still have:%s", spew.Sdump(stateResources))
+	}
+
+}
+
 func TestPrimaryChdirOption(t *testing.T) {
 	t.Parallel()
 

--- a/internal/command/e2etest/testdata/full-workflow/main.tf
+++ b/internal/command/e2etest/testdata/full-workflow/main.tf
@@ -1,0 +1,14 @@
+
+variable "name" {
+  default = "world"
+}
+
+resource "null_resource" "test" {
+  triggers = {
+    greeting = "Hello ${var.name}"
+  }
+}
+
+output "greeting" {
+  value = null_resource.test.triggers["greeting"]
+}

--- a/internal/command/meta_backend_errors.go
+++ b/internal/command/meta_backend_errors.go
@@ -9,6 +9,27 @@ import (
 	"github.com/hashicorp/terraform/internal/tfdiags"
 )
 
+// errWrongWorkspaceForPlan is a custom error used to alert users that the plan file they are applying
+// describes a workspace that doesn't match the currently selected workspace.
+type errWrongWorkspaceForPlan struct {
+	plannedWorkspace string
+	currentWorkspace string
+}
+
+func (e *errWrongWorkspaceForPlan) Error() string {
+	return fmt.Sprintf(`The plan file describes changes to the %q workspace, but the %q workspace is currently selected in the working directory.
+
+Applying this plan with the incorrect workspace selected could result in state being stored in an unexpected location, or a downstream error
+when Terraform attempts apply a plan using the other workspace's state.
+
+If you'd like to continue to use the plan file, you must run "terraform workspace select %s" to select the correct workspace.
+In future make sure the selected workspace is not changed between creating and applying a plan file.`,
+		e.plannedWorkspace,
+		e.currentWorkspace,
+		e.plannedWorkspace,
+	)
+}
+
 // errBackendLocalRead is a custom error used to alert users that state
 // files on their local filesystem were not erased successfully after
 // migrating that state to a remote-state backend.

--- a/internal/command/meta_backend_test.go
+++ b/internal/command/meta_backend_test.go
@@ -1837,6 +1837,52 @@ func TestMetaBackend_planLocalMatch(t *testing.T) {
 	}
 }
 
+// A plan that contains a workspace that isn't the currently selected workspace
+func TestMetaBackend_planLocal_mismatchedWorkspace(t *testing.T) {
+	// Create a temporary working directory that is empty
+	td := t.TempDir()
+	testCopyDir(t, testFixturePath("backend-plan-local"), td)
+	t.Chdir(td)
+
+	backendConfigBlock := cty.ObjectVal(map[string]cty.Value{
+		"path":          cty.NullVal(cty.String),
+		"workspace_dir": cty.NullVal(cty.String),
+	})
+	backendConfigRaw, err := plans.NewDynamicValue(backendConfigBlock, backendConfigBlock.Type())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defaultWorkspace := "default"
+	backendConfig := plans.Backend{
+		Type:      "local",
+		Config:    backendConfigRaw,
+		Workspace: defaultWorkspace,
+	}
+
+	// Setup the meta
+	m := testMetaBackend(t, nil)
+	selectedWorkspace := "foobar"
+	err = m.SetWorkspace(selectedWorkspace)
+	if err != nil {
+		t.Fatalf("error in test setup: %s", err)
+	}
+
+	// Get the backend
+	_, diags := m.BackendForLocalPlan(backendConfig)
+	if !diags.HasErrors() {
+		t.Fatalf("expected an error but got none: %s", diags.ErrWithWarnings())
+	}
+	expectedMsg := fmt.Sprintf("The plan file describes changes to the %q workspace, but the %q workspace is currently selected in the working directory",
+		defaultWorkspace,
+		selectedWorkspace,
+	)
+	if !strings.Contains(diags.Err().Error(), expectedMsg) {
+		t.Fatalf("expected error to include %q, but got:\n%s",
+			expectedMsg,
+			diags.Err())
+	}
+}
+
 // init a backend using -backend-config options multiple times
 func TestMetaBackend_configureBackendWithExtra(t *testing.T) {
 	// Create a temporary working directory that is empty


### PR DESCRIPTION
## Context

This:

https://github.com/hashicorp/terraform/blob/64015ca6d266d259823c9e172fa911650a0d15ec/internal/command/meta_backend.go#L330-L332

Currently isn't the case.

## Bug description

Assume that a plan was raised against workspace A and a user tries to apply it against workspace B.

The actual behaviour varies depending on the type of plan and what state already exists for workspace B.

1. If the plan is create-only, starting from a position of empty state, and workspace B has no state yet then the apply will complete successfully
2. If the plan is create-only, starting from a position of empty state, and workspace B has a prior state then the apply will fail with error `Saved plan is stale`.
3. If the plan is changing existing resources, i.e. planned using prior state in workspace A, and workspace B has no prior state then the apply will fail with a `different state lineage` error.

In case 2 & 3 the apply stops before making any changes to state, however the error messages don't clearly point out that mismatched workspaces are the underlying cause.

In case 1 users will find that the new state file is persisted in a different location than they expected. The output from the apply command doesn't say which workspace the apply affected, so the user might not notice the issue immediately.

**In this PR:**
* Case 1 is illustrated with `TestPrimarySeparatePlan_incorrectWorkspace_noPriorState`
* Case 2 is illustrated with `TestPrimarySeparatePlan_incorrectWorkspace_withPriorState`
* Case 3 is illustrated with `TestPrimarySeparatePlan_incorrectWorkspace_planChangingExistingResources_noPriorState`



## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

N/A

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [ ] This change is not user-facing.
