### PR TITLE
PSS: Validate the backend or state store configurations described by plan files

### DIFF
--- a/internal/backend/local/backend_local_test.go
+++ b/internal/backend/local/backend_local_test.go
@@ -161,8 +161,9 @@ func TestLocalRun_stalePlan(t *testing.T) {
 		UIMode:  plans.NormalMode,
 		Changes: plans.NewChangesSrc(),
 		Backend: &plans.Backend{
-			Type:   "local",
-			Config: backendConfigRaw,
+			Type:      "local",
+			Config:    backendConfigRaw,
+			Workspace: "default",
 		},
 		PrevRunState: states.NewState(),
 		PriorState:   states.NewState(),

--- a/internal/backend/local/backend_plan_test.go
+++ b/internal/backend/local/backend_plan_test.go
@@ -207,8 +207,9 @@ func TestLocal_planOutputsChanged(t *testing.T) {
 	}
 	op.PlanOutBackend = &plans.Backend{
 		// Just a placeholder so that we can generate a valid plan file.
-		Type:   "local",
-		Config: cfgRaw,
+		Type:      "local",
+		Config:    cfgRaw,
+		Workspace: "default",
 	}
 	run, err := b.Operation(context.Background(), op)
 	if err != nil {
@@ -263,8 +264,9 @@ func TestLocal_planModuleOutputsChanged(t *testing.T) {
 		t.Fatal(err)
 	}
 	op.PlanOutBackend = &plans.Backend{
-		Type:   "local",
-		Config: cfgRaw,
+		Type:      "local",
+		Config:    cfgRaw,
+		Workspace: "default",
 	}
 	run, err := b.Operation(context.Background(), op)
 	if err != nil {
@@ -305,8 +307,9 @@ func TestLocal_planTainted(t *testing.T) {
 	}
 	op.PlanOutBackend = &plans.Backend{
 		// Just a placeholder so that we can generate a valid plan file.
-		Type:   "local",
-		Config: cfgRaw,
+		Type:      "local",
+		Config:    cfgRaw,
+		Workspace: "default",
 	}
 	run, err := b.Operation(context.Background(), op)
 	if err != nil {
@@ -384,8 +387,9 @@ func TestLocal_planDeposedOnly(t *testing.T) {
 	}
 	op.PlanOutBackend = &plans.Backend{
 		// Just a placeholder so that we can generate a valid plan file.
-		Type:   "local",
-		Config: cfgRaw,
+		Type:      "local",
+		Config:    cfgRaw,
+		Workspace: "default",
 	}
 	run, err := b.Operation(context.Background(), op)
 	if err != nil {
@@ -475,8 +479,9 @@ func TestLocal_planTainted_createBeforeDestroy(t *testing.T) {
 	}
 	op.PlanOutBackend = &plans.Backend{
 		// Just a placeholder so that we can generate a valid plan file.
-		Type:   "local",
-		Config: cfgRaw,
+		Type:      "local",
+		Config:    cfgRaw,
+		Workspace: "default",
 	}
 	run, err := b.Operation(context.Background(), op)
 	if err != nil {
@@ -566,8 +571,9 @@ func TestLocal_planDestroy(t *testing.T) {
 	}
 	op.PlanOutBackend = &plans.Backend{
 		// Just a placeholder so that we can generate a valid plan file.
-		Type:   "local",
-		Config: cfgRaw,
+		Type:      "local",
+		Config:    cfgRaw,
+		Workspace: "default",
 	}
 
 	run, err := b.Operation(context.Background(), op)
@@ -618,8 +624,9 @@ func TestLocal_planDestroy_withDataSources(t *testing.T) {
 	}
 	op.PlanOutBackend = &plans.Backend{
 		// Just a placeholder so that we can generate a valid plan file.
-		Type:   "local",
-		Config: cfgRaw,
+		Type:      "local",
+		Config:    cfgRaw,
+		Workspace: "default",
 	}
 
 	run, err := b.Operation(context.Background(), op)
@@ -690,8 +697,9 @@ func TestLocal_planOutPathNoChange(t *testing.T) {
 	}
 	op.PlanOutBackend = &plans.Backend{
 		// Just a placeholder so that we can generate a valid plan file.
-		Type:   "local",
-		Config: cfgRaw,
+		Type:      "local",
+		Config:    cfgRaw,
+		Workspace: "default",
 	}
 	op.PlanRefresh = true
 

--- a/internal/command/apply_test.go
+++ b/internal/command/apply_test.go
@@ -1087,8 +1087,9 @@ func TestApply_plan_remoteState(t *testing.T) {
 	}
 	planPath := testPlanFile(t, snap, state, &plans.Plan{
 		Backend: &plans.Backend{
-			Type:   "http",
-			Config: backendConfigRaw,
+			Type:      "http",
+			Config:    backendConfigRaw,
+			Workspace: "default",
 		},
 		Changes: plans.NewChangesSrc(),
 	})

--- a/internal/command/command_test.go
+++ b/internal/command/command_test.go
@@ -192,8 +192,9 @@ func testPlan(t *testing.T) *plans.Plan {
 			// This is just a placeholder so that the plan file can be written
 			// out. Caller may wish to override it to something more "real"
 			// where the plan will actually be subsequently applied.
-			Type:   "local",
-			Config: backendConfigRaw,
+			Type:      "local",
+			Config:    backendConfigRaw,
+			Workspace: "default",
 		},
 		Changes: plans.NewChangesSrc(),
 

--- a/internal/command/graph_test.go
+++ b/internal/command/graph_test.go
@@ -329,8 +329,9 @@ func TestGraph_applyPhaseSavedPlan(t *testing.T) {
 		// Doesn't actually matter since we aren't going to activate the backend
 		// for this command anyway, but we need something here for the plan
 		// file writer to succeed.
-		Type:   "placeholder",
-		Config: emptyObj,
+		Type:      "placeholder",
+		Config:    emptyObj,
+		Workspace: "default",
 	}
 	_, configSnap := testModuleWithSnapshot(t, "graph")
 

--- a/internal/plans/plan.go
+++ b/internal/plans/plan.go
@@ -258,6 +258,8 @@ func NewBackend(typeName string, config cty.Value, configSchema *configschema.Bl
 	}, nil
 }
 
+// Validate checks expected data is present, and does not attempt to validate the
+// backend configuration data against the backend schema.
 func (b *Backend) Validate() error {
 	if b == nil {
 		return errors.New("plan contains a nil Backend")
@@ -295,6 +297,8 @@ type StateStore struct {
 	Workspace string
 }
 
+// Validate checks expected data is present, and does not attempt to validate the
+// state_store configuration data against the store's schema.
 func (s *StateStore) Validate() error {
 	if s == nil {
 		return errors.New("plan contains a nil StateStore")

--- a/internal/plans/plan_test.go
+++ b/internal/plans/plan_test.go
@@ -7,9 +7,11 @@ import (
 	"testing"
 
 	"github.com/go-test/deep"
-
-	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/zclconf/go-cty/cty"
+
+	version "github.com/hashicorp/go-version"
+	"github.com/hashicorp/terraform/internal/addrs"
+	"github.com/hashicorp/terraform/internal/configs/configschema"
 )
 
 func TestProviderAddrs(t *testing.T) {
@@ -103,6 +105,188 @@ func TestProviderAddrs(t *testing.T) {
 	for _, problem := range deep.Equal(got, want) {
 		t.Error(problem)
 	}
+}
+
+func TestBackend_Validate(t *testing.T) {
+
+	typeName := "foobar"
+	workspace := "default"
+	config := cty.ObjectVal(map[string]cty.Value{
+		"bool": cty.BoolVal(true),
+	})
+	schema := &configschema.Block{
+		Attributes: map[string]*configschema.Attribute{
+			"bool": {
+				Type: cty.Bool,
+			},
+		},
+	}
+
+	// Not-empty cases
+	t.Run("backend is not valid if all values are set", func(t *testing.T) {
+		b, err := NewBackend(typeName, config, schema, workspace)
+		if err != nil {
+			t.Fatalf("unexpected error: %s", err)
+		}
+		if err := b.Validate(); err != nil {
+			t.Fatalf("expected the Backend to be valid, given all input values were provided: %s", err)
+		}
+	})
+	t.Run("backend is not empty if the schema contains no attributes or blocks", func(t *testing.T) {
+		emptyConfig := cty.ObjectVal(map[string]cty.Value{})
+		emptySchema := &configschema.Block{
+			Attributes: map[string]*configschema.Attribute{
+				// No attributes
+			},
+		}
+		b, err := NewBackend(typeName, emptyConfig, emptySchema, workspace)
+		if err != nil {
+			t.Fatalf("unexpected error: %s", err)
+		}
+		if err := b.Validate(); err != nil {
+			t.Fatalf("expected the Backend to be valid, as empty schemas should be tolerated: %s", err)
+		}
+	})
+
+	// Empty cases
+	t.Run("backend is empty if type name is missing", func(t *testing.T) {
+		b, err := NewBackend("", config, schema, workspace)
+		if err != nil {
+			t.Fatalf("unexpected error: %s", err)
+		}
+		if err := b.Validate(); err == nil {
+			t.Fatalf("expected the Backend to be invalid, given the type being unset: %#v", b)
+		}
+	})
+	t.Run("backend is empty if workspace name is missing", func(t *testing.T) {
+		b, err := NewBackend(typeName, config, schema, "")
+		if err != nil {
+			t.Fatalf("unexpected error: %s", err)
+		}
+		if err := b.Validate(); err == nil {
+			t.Fatalf("expected the Backend to be invalid, given the type being unset: %#v", b)
+		}
+	})
+}
+
+func TestStateStore_Validate(t *testing.T) {
+	typeName := "test_store"
+	providerVersion := version.Must(version.NewSemver("1.2.3"))
+	source := addrs.MustParseProviderSourceString("hashicorp/test")
+	workspace := "default"
+	config := cty.ObjectVal(map[string]cty.Value{
+		"bool": cty.BoolVal(true),
+	})
+	schema := &configschema.Block{
+		Attributes: map[string]*configschema.Attribute{
+			"bool": {
+				Type: cty.Bool,
+			},
+		},
+	}
+
+	// Not-empty cases
+	t.Run("state store is not empty if all values are set", func(t *testing.T) {
+		s, err := NewStateStore(typeName, providerVersion, &source, config, schema, config, schema, workspace)
+		if err != nil {
+			t.Fatalf("unexpected error: %s", err)
+		}
+		if err := s.Validate(); err != nil {
+			t.Fatalf("expected the StateStore to be valid, given all input values were provided: %s", err)
+		}
+	})
+	t.Run("state store is not empty if the state store config is present but contains all null values", func(t *testing.T) {
+		nullConfig := cty.ObjectVal(map[string]cty.Value{
+			"bool": cty.NullVal(cty.Bool),
+		})
+		s, err := NewStateStore(typeName, providerVersion, &source, nullConfig, schema, config, schema, workspace)
+		if err != nil {
+			t.Fatalf("unexpected error: %s", err)
+		}
+		if err := s.Validate(); err != nil {
+			t.Fatalf("expected the StateStore to be valid, despite the state store config containing only null values: %s", err)
+		}
+	})
+	t.Run("state store is not empty if the provider config is present but contains all null values", func(t *testing.T) {
+		nullConfig := cty.ObjectVal(map[string]cty.Value{
+			"bool": cty.NullVal(cty.Bool),
+		})
+		s, err := NewStateStore(typeName, providerVersion, &source, nullConfig, schema, config, schema, workspace)
+		if err != nil {
+			t.Fatalf("unexpected error: %s", err)
+		}
+		if err := s.Validate(); err != nil {
+			t.Fatalf("expected the StateStore to be valid, despite the provider config containing only null values:  %s", err)
+		}
+	})
+	t.Run("state store is not incorrectly identified as empty if the state store's schema contains no attributes or blocks", func(t *testing.T) {
+		emptyConfig := cty.ObjectVal(map[string]cty.Value{})
+		emptySchema := &configschema.Block{
+			Attributes: map[string]*configschema.Attribute{
+				// No attributes
+			},
+		}
+		s, err := NewStateStore(typeName, providerVersion, &source, emptyConfig, emptySchema, config, schema, workspace)
+		if err != nil {
+			t.Fatalf("unexpected error: %s", err)
+		}
+		if err := s.Validate(); err != nil {
+			t.Fatalf("expected the StateStore to be valid, as empty schemas should be tolerated: %s", err)
+		}
+	})
+	t.Run("state store is not incorrectly identified as empty if the provider's schema contains no attributes or blocks", func(t *testing.T) {
+		emptyConfig := cty.ObjectVal(map[string]cty.Value{})
+		emptySchema := &configschema.Block{
+			Attributes: map[string]*configschema.Attribute{
+				// No attributes
+			},
+		}
+		s, err := NewStateStore(typeName, providerVersion, &source, config, schema, emptyConfig, emptySchema, workspace)
+		if err != nil {
+			t.Fatalf("unexpected error: %s", err)
+		}
+		if err := s.Validate(); err != nil {
+			t.Fatalf("expected the StateStore to be valid, as empty schemas should be tolerated: %s", err)
+		}
+	})
+
+	// Empty cases
+	t.Run("state store is empty if the type is missing", func(t *testing.T) {
+		s, err := NewStateStore("", providerVersion, &source, config, schema, config, schema, workspace)
+		if err != nil {
+			t.Fatalf("unexpected error: %s", err)
+		}
+		if err := s.Validate(); err == nil {
+			t.Fatalf("expected the StateStore to be invalid,  given the type name is missing: %s", err)
+		}
+	})
+	t.Run("state store is empty if the provider version is missing", func(t *testing.T) {
+		s, err := NewStateStore(typeName, nil, &source, config, schema, config, schema, workspace)
+		if err != nil {
+			t.Fatalf("unexpected error: %s", err)
+		}
+		if err := s.Validate(); err == nil {
+			t.Fatalf("expected the StateStore to be invalid, given the version is missing: %s", err)
+		}
+	})
+	t.Run("state store is empty if the provider source is missing", func(t *testing.T) {
+		s, err := NewStateStore(typeName, providerVersion, nil, config, schema, config, schema, workspace)
+		if err != nil {
+			t.Fatalf("unexpected error: %s", err)
+		}
+		if err := s.Validate(); err == nil {
+			t.Fatalf("expected the StateStore to be invalid, given the version is missing: %s", err)
+		}
+	})
+	t.Run("state store is empty if the workspace name is missing", func(t *testing.T) {
+		s, err := NewStateStore(typeName, providerVersion, &source, cty.NilVal, schema, config, schema, "")
+		if err != nil {
+			t.Fatalf("unexpected error: %s", err)
+		}
+		if err := s.Validate(); err == nil {
+			t.Fatalf("expected the StateStore to be invalid, given the workspace name is missing: %s", err)
+		}
+	})
 }
 
 // Module outputs should not effect the result of Empty


### PR DESCRIPTION
This PR adds validation to stop Terraform writing or using a planfile that has incomplete descriptions of the backend or state store configuration.

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

N/A

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
