### PR TITLE
Mildwonkey/actions deps tests

### DIFF
--- a/internal/addrs/action.go
+++ b/internal/addrs/action.go
@@ -504,3 +504,79 @@ func ParseAbsActionInstance(traversal hcl.Traversal) (AbsActionInstance, tfdiags
 		return AbsActionInstance{}, diags
 	}
 }
+
+// ParseAbsActionStr is a helper wrapper around ParseAbsAction that takes a
+// string and parses it with the HCL native syntax traversal parser before
+// interpreting it.
+//
+// Error diagnostics are returned if either the parsing fails or the analysis of
+// the traversal fails. There is no way for the caller to distinguish the two
+// kinds of diagnostics programmatically. If error diagnostics are returned the
+// returned address may be incomplete.
+//
+// Since this function has no context about the source of the given string, any
+// returned diagnostics will not have meaningful source location information.
+func ParseAbsActionStr(str string) (AbsAction, tfdiags.Diagnostics) {
+	var diags tfdiags.Diagnostics
+
+	traversal, parseDiags := hclsyntax.ParseTraversalAbs([]byte(str), "", hcl.Pos{Line: 1, Column: 1})
+	diags = diags.Append(parseDiags)
+	if parseDiags.HasErrors() {
+		return AbsAction{}, diags
+	}
+
+	addr, addrDiags := ParseAbsAction(traversal)
+	diags = diags.Append(addrDiags)
+	return addr, diags
+}
+
+// ParseAbsAction attempts to interpret the given traversal as an absolute
+// action address, using the same syntax as expected by ParseTarget.
+//
+// If no error diagnostics are returned, the returned target includes the
+// address that was extracted and the source range it was extracted from.
+//
+// If error diagnostics are returned then the AbsResource value is invalid and
+// must not be used.
+func ParseAbsAction(traversal hcl.Traversal) (AbsAction, tfdiags.Diagnostics) {
+	addr, diags := ParseTargetAction(traversal)
+	if diags.HasErrors() {
+		return AbsAction{}, diags
+	}
+
+	switch tt := addr.Subject.(type) {
+
+	case AbsAction:
+		return tt, diags
+
+	case AbsActionInstance: // Catch likely user error with specialized message
+		// Assume that the last element of the traversal must be the index,
+		// since that's required for a valid resource instance address.
+		indexStep := traversal[len(traversal)-1]
+		diags = diags.Append(&hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  "Invalid address",
+			Detail:   "An action address is required. This instance key identifies a specific action instance, which is not expected here.",
+			Subject:  indexStep.SourceRange().Ptr(),
+		})
+		return AbsAction{}, diags
+
+	case ModuleInstance: // Catch likely user error with specialized message
+		diags = diags.Append(&hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  "Invalid address",
+			Detail:   "An action address is required here. The module path must be followed by an action specification.",
+			Subject:  traversal.SourceRange().Ptr(),
+		})
+		return AbsAction{}, diags
+
+	default: // Generic message for other address types
+		diags = diags.Append(&hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  "Invalid address",
+			Detail:   "An action address is required here.",
+			Subject:  traversal.SourceRange().Ptr(),
+		})
+		return AbsAction{}, diags
+	}
+}

--- a/internal/providers/testing/provider_mock.go
+++ b/internal/providers/testing/provider_mock.go
@@ -227,6 +227,7 @@ func (p *MockProvider) getProviderSchema() providers.GetProviderSchemaResponse {
 		ResourceTypes:     map[string]providers.Schema{},
 		ListResourceTypes: map[string]providers.Schema{},
 		StateStores:       map[string]providers.Schema{},
+		Actions:           map[string]providers.ActionSchema{},
 	}
 }
 

--- a/internal/terraform/context_apply_test.go
+++ b/internal/terraform/context_apply_test.go
@@ -12866,12 +12866,10 @@ resource "test_object" "a" {
 
 func TestContext2Apply_nilResponse(t *testing.T) {
 	// empty config to remove our resource
-	m := testModuleInline(t, map[string]string{
-		"main.tf": `
+	m := testMainModuleInline(t, `
 resource "test_object" "a" {
 }
-`,
-	})
+`)
 
 	p := simpleMockProvider()
 	p.ApplyResourceChangeResponse = &providers.ApplyResourceChangeResponse{}

--- a/internal/terraform/resource_provider_mock_test.go
+++ b/internal/terraform/resource_provider_mock_test.go
@@ -4,6 +4,8 @@
 package terraform
 
 import (
+	"fmt"
+
 	"github.com/hashicorp/terraform/internal/configs/configschema"
 	"github.com/hashicorp/terraform/internal/providers"
 	testing_provider "github.com/hashicorp/terraform/internal/providers/testing"
@@ -80,6 +82,26 @@ func simpleMockProvider() *testing_provider.MockProvider {
 			},
 			Actions: map[string]providers.ActionSchema{
 				"test_action": {ConfigSchema: simpleTestSchema()},
+			},
+		},
+	}
+}
+
+// namedMockProvider is similar to simpleMockProvider, but the names of it's resources begin with the specified name string.
+// It is pre-configured with schema for its own config, a resource type called NAME_object, a data source also
+// called NAME_object, and an action called NAME_action.
+func namedMockProvider(name string) *testing_provider.MockProvider {
+	return &testing_provider.MockProvider{
+		GetProviderSchemaResponse: &providers.GetProviderSchemaResponse{
+			Provider: providers.Schema{Body: simpleTestSchema()},
+			ResourceTypes: map[string]providers.Schema{
+				fmt.Sprintf("%s_object", name): {Body: simpleTestSchema()},
+			},
+			DataSources: map[string]providers.Schema{
+				fmt.Sprintf("%s_object", name): {Body: simpleTestSchema()},
+			},
+			Actions: map[string]providers.ActionSchema{
+				fmt.Sprintf("%s_action", name): {ConfigSchema: simpleTestSchema()},
 			},
 		},
 	}

--- a/internal/terraform/terraform_test.go
+++ b/internal/terraform/terraform_test.go
@@ -20,14 +20,13 @@ import (
 	"github.com/hashicorp/terraform/internal/configs"
 	"github.com/hashicorp/terraform/internal/configs/configload"
 	"github.com/hashicorp/terraform/internal/initwd"
+	_ "github.com/hashicorp/terraform/internal/logging"
 	"github.com/hashicorp/terraform/internal/plans"
 	"github.com/hashicorp/terraform/internal/providers"
 	testing_provider "github.com/hashicorp/terraform/internal/providers/testing"
 	"github.com/hashicorp/terraform/internal/provisioners"
 	"github.com/hashicorp/terraform/internal/registry"
 	"github.com/hashicorp/terraform/internal/states"
-
-	_ "github.com/hashicorp/terraform/internal/logging"
 )
 
 // This is the directory where our test fixtures are.
@@ -85,6 +84,11 @@ func testModuleWithSnapshot(t *testing.T, name string) (*configs.Config, *config
 	}
 
 	return config, snap
+}
+
+// testMainModuleInline is a wrapper for testModuleInline, because many of our tests just need a main.tf
+func testMainModuleInline(t testing.TB, source string, parserOpts ...configs.Option) *configs.Config {
+	return testModuleInline(t, map[string]string{"main.tf": source}, parserOpts...)
 }
 
 // testModuleInline takes a map of path -> config strings and yields a config

--- a/internal/terraform/terraform_test.go
+++ b/internal/terraform/terraform_test.go
@@ -265,6 +265,22 @@ func mustModuleInstance(s string) addrs.ModuleInstance {
 	return p
 }
 
+func mustAbsActionAddr(s string) addrs.AbsAction {
+	addr, diags := addrs.ParseAbsActionStr(s)
+	if diags.HasErrors() {
+		panic(diags.Err())
+	}
+	return addr
+}
+
+func mustAbsActionInstanceAddr(s string) addrs.AbsActionInstance {
+	addr, diags := addrs.ParseAbsActionInstanceStr(s)
+	if diags.HasErrors() {
+		panic(diags.Err())
+	}
+	return addr
+}
+
 // HookRecordApplyOrder is a test hook that records the order of applies
 // by recording the PreApply event.
 type HookRecordApplyOrder struct {


### PR DESCRIPTION
This is 1 test - an apply actions test that verifies that the resource and its deps aren't created if the action fails - and a lot of tiny nitpicky changes, and I'm sorry about that 😅 

The existing tests are pretty great, but I was having a difficult time adding or modifying them. While writing a new test I realized I could simplify the big test a bit using existing test helpers (not every possible helper, but I tried to grab ones that would save multiple lines across multiple tests) or adding new actions-specific ones.

I might care too much about into tests, it's fair.

Highlights:

`testMainModuleInline()`: so I don't need to ever write `map[string]string{"main.tf": module}` again
`namedMockProvider()`: it takes a lot of boilerplate just to make a mock provider with a different name - NO MORE
`ParseAbsAction`, `ParseAbsActionStr`, `mustAbsActionAddr`, `mustAbsActionInstanceAddr` - the basics

<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Fixes #

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.15.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [ ] This change is not user-facing.
