### PR TITLE
feat: add tag options for s3 backend objects

### DIFF
--- a/.changes/v1.15/NEW FEATURES-20251224-132008.yaml
+++ b/.changes/v1.15/NEW FEATURES-20251224-132008.yaml
@@ -1,0 +1,5 @@
+kind: NEW FEATURES
+body: Add s3 backend options `state_tags` and `lock_tags`
+time: 2025-12-24T13:20:08.187193113+01:00
+custom:
+    Issue: "38030"

--- a/internal/backend/remote-state/s3/backend_state.go
+++ b/internal/backend/remote-state/s3/backend_state.go
@@ -166,6 +166,8 @@ func (b *Backend) remoteClient(name string) (*RemoteClient, error) {
 		serverSideEncryption:  b.serverSideEncryption,
 		customerEncryptionKey: b.customerEncryptionKey,
 		acl:                   b.acl,
+		stateTags: 						 b.stateTags,
+		lockTags:  						 b.lockTags,
 		kmsKeyID:              b.kmsKeyID,
 		ddbTable:              b.ddbTable,
 		skipS3Checksum:        b.skipS3Checksum,


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->
Fixes #30054 #36445 
replaces stale PR #30121

configuration is compatible with opentofu and i took actually most part of it https://github.com/opentofu/opentofu/pull/3038

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.15.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [ ] This change is not user-facing.
