### PR TITLE
refactor: Change `workspace list` to use view.View instead of cli.Ui when rendering human output to the terminal

### DIFF
--- a/internal/command/views/workspace.go
+++ b/internal/command/views/workspace.go
@@ -1,0 +1,54 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package views
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform/internal/command/arguments"
+	"github.com/hashicorp/terraform/internal/tfdiags"
+)
+
+// The Workspace view is used for workspace subcommands.
+type Workspace interface {
+	Diagnostics(diags tfdiags.Diagnostics)
+	Output(message string)
+}
+
+// NewInit returns Init implementation for the given ViewType.
+func NewWorkspace(vt arguments.ViewType, view *View) Workspace {
+	switch vt {
+	case arguments.ViewJSON:
+		panic("machine readable output not implemented for workspace subcommands")
+	case arguments.ViewHuman:
+		return &WorkspaceHuman{
+			view: view,
+		}
+	default:
+		panic(fmt.Sprintf("unknown view type %v", vt))
+	}
+}
+
+// The WorkspaceHuman implementation renders human-readable text logs, suitable for
+// a scrolling terminal.
+type WorkspaceHuman struct {
+	view *View
+}
+
+var _ Workspace = (*WorkspaceHuman)(nil)
+
+// Diagnostics renders a list of diagnostics, including the option for compact warnings.
+func (v *WorkspaceHuman) Diagnostics(diags tfdiags.Diagnostics) {
+	v.view.Diagnostics(diags)
+}
+
+// Output is used to render text in the terminal, such as data returned from a command.
+func (v *WorkspaceHuman) Output(msg string) {
+	v.view.streams.Println(v.prepareMessage(msg))
+}
+
+func (v *WorkspaceHuman) prepareMessage(msg string) string {
+	return v.view.colorize.Color(strings.TrimSpace(msg))
+}

--- a/internal/command/views/workspace.go
+++ b/internal/command/views/workspace.go
@@ -17,7 +17,7 @@ type Workspace interface {
 	Output(message string)
 }
 
-// NewInit returns Init implementation for the given ViewType.
+// NewWorkspace returns the Workspace implementation for the given ViewType.
 func NewWorkspace(vt arguments.ViewType, view *View) Workspace {
 	switch vt {
 	case arguments.ViewJSON:

--- a/internal/command/workspace_command.go
+++ b/internal/command/workspace_command.go
@@ -8,6 +8,9 @@ import (
 	"strings"
 
 	"github.com/hashicorp/cli"
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/terraform/internal/command/views"
+	"github.com/hashicorp/terraform/internal/tfdiags"
 )
 
 // WorkspaceCommand is a Command Implementation that manipulates workspaces,
@@ -65,6 +68,29 @@ with other concepts.
 The "terraform workspace" commands should be used instead. "terraform env"
 will be removed in a future Terraform version.
 `)
+}
+
+// This is a version of `envCommandShowWarning` that uses views.View instead of
+// cli.Ui. We intend to change all `workspace` commands to use views.View, at which
+// point the original version of the method can be removed.
+func envCommandShowWarningWithView(view *views.View, show bool) {
+	if !show {
+		return
+	}
+
+	var diags tfdiags.Diagnostics
+	diags = diags.Append(&hcl.Diagnostic{
+		Severity: hcl.DiagWarning,
+		Detail:   `Warning: the "terraform env" family of commands is deprecated.`,
+		Summary: `"Workspace" is now the preferred term for what earlier Terraform versions
+called "environment", to reduce ambiguity caused by the latter term colliding
+with other concepts.
+
+The "terraform workspace" commands should be used instead. "terraform env"
+will be removed in a future Terraform version.
+`,
+	})
+	view.Diagnostics(diags)
 }
 
 const (


### PR DESCRIPTION
# Background

Part of https://github.com/hashicorp/terraform/issues/37439

This PR changes just the `workspace list` command to use the newer view.View abstraction for rendering output. Please see the issue above for more context.

The `workspace list` command only supports human-readable output, before this PR and after this PR. However the changes in this PR make adding support for machine-readable output reasonably easy. I'm planning to do that in future, separately.

# This PR

This PR introduces structs in the `views` package (`WorkspaceHuman`, etc) to enable rendering diagnostics and text notices to the terminal. Diagnostics can be received from backends/state stores when retrieving the list of workspaces via their `Workspaces` methods or could be raised in the command itself (https://github.com/hashicorp/terraform/pull/38094). The text notices include the list output of the command itself:

```
* default
  dev
  stage
  prod
```

Those structs are then used in the `workspace select` command. E.g. instead of `c.Ui.Error` to log errors, the code uses the generic `view.Diagnostics` method to render diagnostics (both warning or error level).

## Things for the reviewer to note

There is a change in behaviour when rendering warning diagnostics.

When using cli.Ui, **warnings are logged to stderr**:

1. When the tool is used E2E: https://github.com/hashicorp/cli/blob/4383e52914f5677576e148a6d7e1f399c0e91a7c/ui_common.go#L76-L78
2. When we mock the Ui in tests: https://github.com/hashicorp/cli/blob/4383e52914f5677576e148a6d7e1f399c0e91a7c/ui_mock.go#L75-L80

when using view.View's `Diagnostics` method, **warnings are logged to stdout**:
https://github.com/hashicorp/terraform/blob/ac3e32b62bdd35dad7cc3e9ad000119fdb537f65/internal/command/views/view.go#L120-L124

I'm still trying to work out if we consider this a breaking change or not, but I'm leaning towards _not_:
* Workspace commands are not used in the context of HCPTF, so there's no concern of breaking how CLI output is consumed there (Slack me for context on this).
* We _technically_ don't have any guarantees for any human output

The only issue I've found so far is that the parsing of human output in terraform-exec relies on stdout containing only the list of workspaces. I've got a proposed change to fix this in: https://github.com/hashicorp/terraform-exec/pull/562
However the best route forward would be to add machine-readable output support to the `workspace` commands and update terraform-exec to use that instead.

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

N/A

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [x] This change is user-facing and I added a changelog entry.
- [ ] This change is not user-facing.
