### PR TITLE
PSS: safe provider download during init (interactive mode only)

### DIFF
--- a/internal/command/init.go
+++ b/internal/command/init.go
@@ -351,11 +351,24 @@ the backend configuration is present and valid.
 	return diags
 }
 
+// SafeInitAction describes the action that should be taken by Terraform based on whether
+// pluggable state storage is in use, if the provider is going to be downloaded via HTTP or not,
+// and whether Terraform is being run in automation or not.
+type SafeInitAction rune
+
+const (
+	SafeInitActionInvalid        SafeInitAction = 0
+	SafeInitActionProceed        SafeInitAction = 'P'
+	SafeInitActionPromptForInput SafeInitAction = 'I'
+	SafeInitActionExitEarly      SafeInitAction = 'E'
+	SafeInitActionNotRelevant    SafeInitAction = 'N' // For when a state store isn't in use at all!
+)
+
 // getProvidersFromConfig determines what providers are required by the given configuration data.
 // The method downloads any missing providers that aren't already downloaded and then returns
 // dependency lock data based on the configuration.
 // The dependency lock file itself isn't updated here.
-func (c *InitCommand) getProvidersFromConfig(ctx context.Context, config *configs.Config, upgrade bool, pluginDirs []string, flagLockfile string, view views.Init) (output bool, resultingLocks *depsfile.Locks, diags tfdiags.Diagnostics) {
+func (c *InitCommand) getProvidersFromConfig(ctx context.Context, config *configs.Config, upgrade bool, pluginDirs []string, flagLockfile string, view views.Init) (output bool, resultingLocks *depsfile.Locks, safeInitAction SafeInitAction, diags tfdiags.Diagnostics) {
 	ctx, span := tracer.Start(ctx, "install providers from config")
 	defer span.End()
 
@@ -369,7 +382,7 @@ func (c *InitCommand) getProvidersFromConfig(ctx context.Context, config *config
 	reqs, hclDiags := config.ProviderRequirements()
 	diags = diags.Append(hclDiags)
 	if hclDiags.HasErrors() {
-		return false, nil, diags
+		return false, nil, SafeInitActionInvalid, diags
 	}
 
 	reqs = c.removeDevOverrides(reqs)
@@ -387,7 +400,7 @@ func (c *InitCommand) getProvidersFromConfig(ctx context.Context, config *config
 		}
 	}
 	if diags.HasErrors() {
-		return false, nil, diags
+		return false, nil, SafeInitActionInvalid, diags
 	}
 
 	var inst *providercache.Installer
@@ -409,7 +422,310 @@ func (c *InitCommand) getProvidersFromConfig(ctx context.Context, config *config
 		log.Printf("[DEBUG] will search for provider plugins in %s", pluginDirs)
 	}
 
-	evts := c.prepareInstallerEvents(ctx, reqs, &diags, inst, view, views.InitializingProviderPluginFromConfigMessage, views.ReusingPreviousVersionInfo)
+	// Prepare callback functions for the installer.
+	// These allow us to send output to the terminal as events happen, catch
+	// diagnostics, etc.
+	//
+	// One of the things we capture via these callbacks is the location of
+	// providers as we install them. This allows the calling code to determine
+	// what 'safe init' actions need to take place.
+	providerLocations := make(map[addrs.Provider]getproviders.PackageLocation)
+
+	// Because we're currently just streaming a series of events sequentially
+	// into the terminal, we're showing only a subset of the events to keep
+	// things relatively concise. Later it'd be nice to have a progress UI
+	// where statuses update in-place, but we can't do that as long as we
+	// are shimming our vt100 output to the legacy console API on Windows.
+	evts := &providercache.InstallerEvents{
+		PendingProviders: func(reqs map[addrs.Provider]getproviders.VersionConstraints) {
+			view.Output(views.InitializingProviderPluginFromConfigMessage)
+		},
+		ProviderAlreadyInstalled: func(provider addrs.Provider, selectedVersion getproviders.Version) {
+			view.LogInitMessage(views.ProviderAlreadyInstalledMessage, provider.ForDisplay(), selectedVersion)
+		},
+		BuiltInProviderAvailable: func(provider addrs.Provider) {
+			view.LogInitMessage(views.BuiltInProviderAvailableMessage, provider.ForDisplay())
+		},
+		BuiltInProviderFailure: func(provider addrs.Provider, err error) {
+			diags = diags.Append(tfdiags.Sourceless(
+				tfdiags.Error,
+				"Invalid dependency on built-in provider",
+				fmt.Sprintf("Cannot use %s: %s.", provider.ForDisplay(), err),
+			))
+		},
+		QueryPackagesBegin: func(provider addrs.Provider, versionConstraints getproviders.VersionConstraints, locked bool) {
+			if locked {
+				view.LogInitMessage(views.ReusingPreviousVersionInfo, provider.ForDisplay())
+			} else {
+				if len(versionConstraints) > 0 {
+					view.LogInitMessage(views.FindingMatchingVersionMessage, provider.ForDisplay(), getproviders.VersionConstraintsString(versionConstraints))
+				} else {
+					view.LogInitMessage(views.FindingLatestVersionMessage, provider.ForDisplay())
+				}
+			}
+		},
+		LinkFromCacheBegin: func(provider addrs.Provider, version getproviders.Version, cacheRoot string) {
+			view.LogInitMessage(views.UsingProviderFromCacheDirInfo, provider.ForDisplay(), version)
+		},
+		FetchPackageBegin: func(provider addrs.Provider, version getproviders.Version, location getproviders.PackageLocation) {
+			view.LogInitMessage(views.InstallingProviderMessage, provider.ForDisplay(), version)
+
+			// Record the location of this provider.
+			//
+			// FetchPackageBegin is the callback hook at the start of the process of obtaining a provider that isn't yet
+			// in the dependency lock file. Providers that are processed here will not be processed here on the next init,
+			// as then they will be in the lock file. The same provider type would only be processed here again if the
+			// provider version changed via an `init -upgrade` command.
+			providerLocations[provider] = location
+		},
+		QueryPackagesFailure: func(provider addrs.Provider, err error) {
+			switch errorTy := err.(type) {
+			case getproviders.ErrProviderNotFound:
+				sources := errorTy.Sources
+				displaySources := make([]string, len(sources))
+				for i, source := range sources {
+					displaySources[i] = fmt.Sprintf("  - %s", source)
+				}
+				diags = diags.Append(tfdiags.Sourceless(
+					tfdiags.Error,
+					"Failed to query available provider packages",
+					fmt.Sprintf("Could not retrieve the list of available versions for provider %s: %s\n\n%s",
+						provider.ForDisplay(), err, strings.Join(displaySources, "\n"),
+					),
+				))
+			case getproviders.ErrRegistryProviderNotKnown:
+				// We might be able to suggest an alternative provider to use
+				// instead of this one.
+				suggestion := fmt.Sprintf("\n\nAll modules should specify their required_providers so that external consumers will get the correct providers when using a module. To see which modules are currently depending on %s, run the following command:\n    terraform providers", provider.ForDisplay())
+				alternative := getproviders.MissingProviderSuggestion(ctx, provider, inst.ProviderSource(), reqs)
+				if alternative != provider {
+					suggestion = fmt.Sprintf(
+						"\n\nDid you intend to use %s? If so, you must specify that source address in each module which requires that provider. To see which modules are currently depending on %s, run the following command:\n    terraform providers",
+						alternative.ForDisplay(), provider.ForDisplay(),
+					)
+				}
+
+				diags = diags.Append(tfdiags.Sourceless(
+					tfdiags.Error,
+					"Failed to query available provider packages",
+					fmt.Sprintf("Could not retrieve the list of available versions for provider %s: %s%s",
+						provider.ForDisplay(), err, suggestion,
+					),
+				))
+			case getproviders.ErrHostNoProviders:
+				switch {
+				case errorTy.Hostname == svchost.Hostname("github.com") && !errorTy.HasOtherVersion:
+					// If a user copies the URL of a GitHub repository into
+					// the source argument and removes the schema to make it
+					// provider-address-shaped then that's one way we can end up
+					// here. We'll use a specialized error message in anticipation
+					// of that mistake. We only do this if github.com isn't a
+					// provider registry, to allow for the (admittedly currently
+					// rather unlikely) possibility that github.com starts being
+					// a real Terraform provider registry in the future.
+					diags = diags.Append(tfdiags.Sourceless(
+						tfdiags.Error,
+						"Invalid provider registry host",
+						fmt.Sprintf("The given source address %q specifies a GitHub repository rather than a Terraform provider. Refer to the documentation of the provider to find the correct source address to use.",
+							provider.String(),
+						),
+					))
+
+				case errorTy.HasOtherVersion:
+					diags = diags.Append(tfdiags.Sourceless(
+						tfdiags.Error,
+						"Invalid provider registry host",
+						fmt.Sprintf("The host %q given in provider source address %q does not offer a Terraform provider registry that is compatible with this Terraform version, but it may be compatible with a different Terraform version.",
+							errorTy.Hostname, provider.String(),
+						),
+					))
+
+				default:
+					diags = diags.Append(tfdiags.Sourceless(
+						tfdiags.Error,
+						"Invalid provider registry host",
+						fmt.Sprintf("The host %q given in provider source address %q does not offer a Terraform provider registry.",
+							errorTy.Hostname, provider.String(),
+						),
+					))
+				}
+
+			case getproviders.ErrRequestCanceled:
+				// We don't attribute cancellation to any particular operation,
+				// but rather just emit a single general message about it at
+				// the end, by checking ctx.Err().
+
+			default:
+				suggestion := fmt.Sprintf("\n\nTo see which modules are currently depending on %s and what versions are specified, run the following command:\n    terraform providers", provider.ForDisplay())
+				diags = diags.Append(tfdiags.Sourceless(
+					tfdiags.Error,
+					"Failed to query available provider packages",
+					fmt.Sprintf("Could not retrieve the list of available versions for provider %s: %s%s",
+						provider.ForDisplay(), err, suggestion,
+					),
+				))
+			}
+		},
+		QueryPackagesWarning: func(provider addrs.Provider, warnings []string) {
+			displayWarnings := make([]string, len(warnings))
+			for i, warning := range warnings {
+				displayWarnings[i] = fmt.Sprintf("- %s", warning)
+			}
+
+			diags = diags.Append(tfdiags.Sourceless(
+				tfdiags.Warning,
+				"Additional provider information from registry",
+				fmt.Sprintf("The remote registry returned warnings for %s:\n%s",
+					provider.String(),
+					strings.Join(displayWarnings, "\n"),
+				),
+			))
+		},
+		LinkFromCacheFailure: func(provider addrs.Provider, version getproviders.Version, err error) {
+			diags = diags.Append(tfdiags.Sourceless(
+				tfdiags.Error,
+				"Failed to install provider from shared cache",
+				fmt.Sprintf("Error while importing %s v%s from the shared cache directory: %s.", provider.ForDisplay(), version, err),
+			))
+		},
+		FetchPackageFailure: func(provider addrs.Provider, version getproviders.Version, err error) {
+			const summaryIncompatible = "Incompatible provider version"
+			switch err := err.(type) {
+			case getproviders.ErrProtocolNotSupported:
+				closestAvailable := err.Suggestion
+				switch {
+				case closestAvailable == getproviders.UnspecifiedVersion:
+					diags = diags.Append(tfdiags.Sourceless(
+						tfdiags.Error,
+						summaryIncompatible,
+						fmt.Sprintf(errProviderVersionIncompatible, provider.String()),
+					))
+				case version.GreaterThan(closestAvailable):
+					diags = diags.Append(tfdiags.Sourceless(
+						tfdiags.Error,
+						summaryIncompatible,
+						fmt.Sprintf(providerProtocolTooNew, provider.ForDisplay(),
+							version, tfversion.String(), closestAvailable, closestAvailable,
+							getproviders.VersionConstraintsString(reqs[provider]),
+						),
+					))
+				default: // version is less than closestAvailable
+					diags = diags.Append(tfdiags.Sourceless(
+						tfdiags.Error,
+						summaryIncompatible,
+						fmt.Sprintf(providerProtocolTooOld, provider.ForDisplay(),
+							version, tfversion.String(), closestAvailable, closestAvailable,
+							getproviders.VersionConstraintsString(reqs[provider]),
+						),
+					))
+				}
+			case getproviders.ErrPlatformNotSupported:
+				switch {
+				case err.MirrorURL != nil:
+					// If we're installing from a mirror then it may just be
+					// the mirror lacking the package, rather than it being
+					// unavailable from upstream.
+					diags = diags.Append(tfdiags.Sourceless(
+						tfdiags.Error,
+						summaryIncompatible,
+						fmt.Sprintf(
+							"Your chosen provider mirror at %s does not have a %s v%s package available for your current platform, %s.\n\nProvider releases are separate from Terraform CLI releases, so this provider might not support your current platform. Alternatively, the mirror itself might have only a subset of the plugin packages available in the origin registry, at %s.",
+							err.MirrorURL, err.Provider, err.Version, err.Platform,
+							err.Provider.Hostname,
+						),
+					))
+				default:
+					diags = diags.Append(tfdiags.Sourceless(
+						tfdiags.Error,
+						summaryIncompatible,
+						fmt.Sprintf(
+							"Provider %s v%s does not have a package available for your current platform, %s.\n\nProvider releases are separate from Terraform CLI releases, so not all providers are available for all platforms. Other versions of this provider may have different platforms supported.",
+							err.Provider, err.Version, err.Platform,
+						),
+					))
+				}
+
+			case getproviders.ErrRequestCanceled:
+				// We don't attribute cancellation to any particular operation,
+				// but rather just emit a single general message about it at
+				// the end, by checking ctx.Err().
+
+			default:
+				// We can potentially end up in here under cancellation too,
+				// in spite of our getproviders.ErrRequestCanceled case above,
+				// because not all of the outgoing requests we do under the
+				// "fetch package" banner are source metadata requests.
+				// In that case we will emit a redundant error here about
+				// the request being cancelled, but we'll still detect it
+				// as a cancellation after the installer returns and do the
+				// normal cancellation handling.
+
+				diags = diags.Append(tfdiags.Sourceless(
+					tfdiags.Error,
+					"Failed to install provider",
+					fmt.Sprintf("Error while installing %s v%s: %s", provider.ForDisplay(), version, err),
+				))
+			}
+		},
+		FetchPackageSuccess: func(provider addrs.Provider, version getproviders.Version, localDir string, authResult *getproviders.PackageAuthenticationResult) {
+			var keyID string
+			if authResult != nil && authResult.ThirdPartySigned() {
+				keyID = authResult.KeyID
+			}
+			if keyID != "" {
+				keyID = view.PrepareMessage(views.KeyID, keyID)
+			}
+
+			view.LogInitMessage(views.InstalledProviderVersionInfo, provider.ForDisplay(), version, authResult, keyID)
+		},
+		ProvidersLockUpdated: func(provider addrs.Provider, version getproviders.Version, localHashes []getproviders.Hash, signedHashes []getproviders.Hash, priorHashes []getproviders.Hash) {
+			// We're going to use this opportunity to track if we have any
+			// "incomplete" installs of providers. An incomplete install is
+			// when we are only going to write the local hashes into our lock
+			// file which means a `terraform init` command will fail in future
+			// when used on machines of a different architecture.
+			//
+			// We want to print a warning about this.
+
+			if len(signedHashes) > 0 {
+				// If we have any signedHashes hashes then we don't worry - as
+				// we know we retrieved all available hashes for this version
+				// anyway.
+				return
+			}
+
+			// If local hashes and prior hashes are exactly the same then
+			// it means we didn't record any signed hashes previously, and
+			// we know we're not adding any extra in now (because we already
+			// checked the signedHashes), so that's a problem.
+			//
+			// In the actual check here, if we have any priorHashes and those
+			// hashes are not the same as the local hashes then we're going to
+			// accept that this provider has been configured correctly.
+			if len(priorHashes) > 0 && !reflect.DeepEqual(localHashes, priorHashes) {
+				return
+			}
+
+			// Now, either signedHashes is empty, or priorHashes is exactly the
+			// same as our localHashes which means we never retrieved the
+			// signedHashes previously.
+			//
+			// Either way, this is bad. Let's complain/warn.
+			c.incompleteProviders = append(c.incompleteProviders, provider.ForDisplay())
+		},
+		ProvidersFetched: func(authResults map[addrs.Provider]*getproviders.PackageAuthenticationResult) {
+			thirdPartySigned := false
+			for _, authResult := range authResults {
+				if authResult.ThirdPartySigned() {
+					thirdPartySigned = true
+					break
+				}
+			}
+			if thirdPartySigned {
+				view.LogInitMessage(views.PartnerAndCommunityProvidersMessage)
+			}
+		},
+	}
 	ctx = evts.OnContext(ctx)
 
 	mode := providercache.InstallNewProvidersOnly
@@ -417,7 +733,7 @@ func (c *InitCommand) getProvidersFromConfig(ctx context.Context, config *config
 		if flagLockfile == "readonly" {
 			diags = diags.Append(fmt.Errorf("The -upgrade flag conflicts with -lockfile=readonly."))
 			view.Diagnostics(diags)
-			return true, nil, diags
+			return true, nil, SafeInitActionInvalid, diags
 		}
 
 		mode = providercache.InstallUpgrades
@@ -427,7 +743,7 @@ func (c *InitCommand) getProvidersFromConfig(ctx context.Context, config *config
 	previousLocks, moreDiags := c.lockedDependencies()
 	diags = diags.Append(moreDiags)
 	if diags.HasErrors() {
-		return false, nil, diags
+		return false, nil, SafeInitActionInvalid, diags
 	}
 
 	// Determine which required providers are already downloaded, and download any
@@ -436,7 +752,7 @@ func (c *InitCommand) getProvidersFromConfig(ctx context.Context, config *config
 	if ctx.Err() == context.Canceled {
 		diags = diags.Append(fmt.Errorf("Provider installation was canceled by an interrupt signal."))
 		view.Diagnostics(diags)
-		return true, nil, diags
+		return true, nil, SafeInitActionInvalid, diags
 	}
 	if err != nil {
 		// The errors captured in "err" should be redundant with what we
@@ -446,10 +762,40 @@ func (c *InitCommand) getProvidersFromConfig(ctx context.Context, config *config
 			diags = diags.Append(err)
 		}
 
-		return true, nil, diags
+		return true, nil, SafeInitActionInvalid, diags
 	}
 
-	return true, configLocks, diags
+	// Return advice to the calling code about what to do regarding safe init feature related to state storage providers
+	if config.Module.StateStore == nil {
+		// If PSS isn't in use then return a value that isn't the zero value but isn't misleading.
+		safeInitAction = SafeInitActionNotRelevant
+	}
+	if config.Module.StateStore != nil {
+		location, ok := providerLocations[config.Module.StateStore.ProviderAddr]
+		if !ok {
+			// The provider was not processed in the FetchPackageBegin callback, so it was already present.
+			log.Printf("[TRACE] init (getProvidersFromConfig): the state storage provider %s (%q) will not be changed in the dependency lock file after provider installation. Either it was already present and/or there was no available upgrade version that matched version constraints.", config.Module.StateStore.ProviderAddr.Type, config.Module.StateStore.ProviderAddr)
+			safeInitAction = SafeInitActionProceed
+		} else {
+			// The provider was processed in the FetchPackageBegin callback, so either it's being downloaded for the first time, or upgraded.
+			log.Printf("[TRACE] init (getProvidersFromConfig): the state storage provider %s (%q) will be changed in the dependency lock file during provider installation.", config.Module.StateStore.ProviderAddr.Type, config.Module.StateStore.ProviderAddr)
+
+			switch location.(type) {
+			case getproviders.PackageLocalArchive, getproviders.PackageLocalDir:
+				// If the provider is downloaded from a local source we assume it's safe.
+				// We don't require presence of the -safe-init flag, or require input from the user to approve its usage.
+				log.Printf("[TRACE] init (getProvidersFromConfig): the state storage provider %s (%q) is downloaded from a local source, so we consider it safe.", config.Module.StateStore.ProviderAddr.Type, config.Module.StateStore.ProviderAddr)
+				safeInitAction = SafeInitActionProceed
+			case getproviders.PackageHTTPURL:
+				log.Printf("[DEBUG] init (getProvidersFromConfig): the state storage provider %s (%q) is downloaded via HTTP, so we consider it potentially unsafe.", config.Module.StateStore.ProviderAddr.Type, config.Module.StateStore.ProviderAddr)
+				safeInitAction = SafeInitActionPromptForInput
+			default:
+				panic(fmt.Sprintf("init (getProvidersFromConfig): unexpected provider location type for state storage provider %q: %T", config.Module.StateStore.ProviderAddr, location))
+			}
+		}
+	}
+
+	return true, configLocks, safeInitAction, diags
 }
 
 // getProvidersFromState determines what providers are required by the given state data.
@@ -561,7 +907,6 @@ func (c *InitCommand) getProvidersFromState(ctx context.Context, state *states.S
 // The calling code is expected to provide the previous locks (if any) and the two sets of locks determined from
 // configuration and state data.
 func (c *InitCommand) saveDependencyLockFile(previousLocks, configLocks, stateLocks *depsfile.Locks, flagLockfile string, view views.Init) (output bool, diags tfdiags.Diagnostics) {
-
 	// Get the combination of config and state locks
 	newLocks := c.mergeLockedDependencies(configLocks, stateLocks)
 
@@ -631,7 +976,6 @@ func (c *InitCommand) saveDependencyLockFile(previousLocks, configLocks, stateLo
 // when a specific type of event occurs during provider installation.
 // The calling code needs to provide a tfdiags.Diagnostics collection, so that provider installation code returns diags to the calling code using closures
 func (c *InitCommand) prepareInstallerEvents(ctx context.Context, reqs providerreqs.Requirements, diags *tfdiags.Diagnostics, inst *providercache.Installer, view views.Init, initMsg views.InitMessageCode, reuseMsg views.InitMessageCode) *providercache.InstallerEvents {
-
 	// Because we're currently just streaming a series of events sequentially
 	// into the terminal, we're showing only a subset of the events to keep
 	// things relatively concise. Later it'd be nice to have a progress UI
@@ -758,7 +1102,6 @@ func (c *InitCommand) prepareInstallerEvents(ctx context.Context, reqs providerr
 					),
 				))
 			}
-
 		},
 		QueryPackagesWarning: func(provider addrs.Provider, warnings []string) {
 			displayWarnings := make([]string, len(warnings))

--- a/internal/command/init.go
+++ b/internal/command/init.go
@@ -773,7 +773,11 @@ func (c *InitCommand) getProvidersFromConfig(ctx context.Context, config *config
 	if config.Module.StateStore != nil {
 		location, ok := providerLocations[config.Module.StateStore.ProviderAddr]
 		if !ok {
-			// The provider was not processed in the FetchPackageBegin callback, so it was already present.
+			// The provider was not processed in the FetchPackageBegin callback.
+			// A provider that wasn't downloaded during this init could be because:
+			// * It was already present from a previous installation.
+			// * If upgrading, no newer version was available that matched version constraints.
+			// * Or, the provider is unmanaged/reattached and so download was skipped.
 			log.Printf("[TRACE] init (getProvidersFromConfig): the state storage provider %s (%q) will not be changed in the dependency lock file after provider installation. Either it was already present and/or there was no available upgrade version that matched version constraints.", config.Module.StateStore.ProviderAddr.Type, config.Module.StateStore.ProviderAddr)
 			safeInitAction = SafeInitActionProceed
 		} else {

--- a/internal/command/init_run.go
+++ b/internal/command/init_run.go
@@ -403,15 +403,21 @@ func (c *InitCommand) promptStateStorageProviderApproval(stateStorageProvider ad
 	// If we can receive input then we prompt for ok from the user
 	lock := configLocks.Provider(stateStorageProvider)
 
+	var hashList strings.Builder
+	for _, hash := range lock.PreferredHashes() {
+		hashList.WriteString(fmt.Sprintf("- %s\n", hash))
+	}
+
 	v, err := c.UIInput().Input(context.Background(), &terraform.InputOpts{
 		Id: "approve",
 		Query: fmt.Sprintf(`Do you want to use provider %q (%s), version %s, for managing state?
-Hash: %s
+Hashes:
+%s
 `,
 			lock.Provider().Type,
 			lock.Provider(),
 			lock.Version(),
-			lock.PreferredHashes()[0], // TODO - better handle of multiple hashes
+			hashList.String(),
 		),
 		Description: fmt.Sprintf(`Check the dependency lockfile's entry for %q.
 	Only 'yes' will be accepted to confirm.`, lock.Provider()),

--- a/internal/command/init_run.go
+++ b/internal/command/init_run.go
@@ -17,6 +17,7 @@ import (
 	"github.com/hashicorp/terraform/internal/command/views"
 	"github.com/hashicorp/terraform/internal/configs"
 	"github.com/hashicorp/terraform/internal/depsfile"
+	"github.com/hashicorp/terraform/internal/getproviders"
 	"github.com/hashicorp/terraform/internal/states"
 	"github.com/hashicorp/terraform/internal/terraform"
 	"github.com/hashicorp/terraform/internal/tfdiags"
@@ -411,12 +412,14 @@ func (c *InitCommand) promptStateStorageProviderApproval(stateStorageProvider ad
 	v, err := c.UIInput().Input(context.Background(), &terraform.InputOpts{
 		Id: "approve",
 		Query: fmt.Sprintf(`Do you want to use provider %q (%s), version %s, for managing state?
+Platform: %s
 Hashes:
 %s
 `,
 			lock.Provider().Type,
 			lock.Provider(),
 			lock.Version(),
+			getproviders.CurrentPlatform.String(),
 			hashList.String(),
 		),
 		Description: fmt.Sprintf(`Check the dependency lockfile's entry for %q.

--- a/internal/command/init_run.go
+++ b/internal/command/init_run.go
@@ -239,6 +239,7 @@ func (c *InitCommand) run(initArgs *arguments.Init, view views.Init) int {
 					"The provider used for state storage (%s) needs to be installed safely. Please re-run the \"init\" command with the -safe-init flag.",
 					config.Module.StateStore.ProviderAddr.ForDisplay(),
 				),
+				Subject: &config.Module.StateStore.RequiredProviderDeclRange,
 			})
 			view.Diagnostics(diags)
 			return 1

--- a/internal/command/init_run.go
+++ b/internal/command/init_run.go
@@ -234,7 +234,7 @@ func (c *InitCommand) run(initArgs *arguments.Init, view views.Init) int {
 			// If the -safe-init flag isn't present we prompt the user to re-run init so they're opting into the security UX.
 			diags = diags.Append(&hcl.Diagnostic{
 				Severity: hcl.DiagError,
-				Summary:  "State storage providers must be downloaded using -safe-init flag",
+				Summary:  "State store providers must be downloaded using -safe-init flag",
 				Detail:   "The provider used for state storage needs to be installed safely. Please re-run the \"init\" command with the -safe-init flag.",
 			})
 			view.Diagnostics(diags)
@@ -430,7 +430,7 @@ Hashes:
 	}
 	if v != "yes" {
 		return diags.Append(
-			fmt.Errorf("State storage provider %q (%s) was not approved by the user",
+			fmt.Errorf("State store provider %q (%s) was not approved, so init cannot continue.",
 				lock.Provider().Type,
 				lock.Provider(),
 			),

--- a/internal/command/init_run.go
+++ b/internal/command/init_run.go
@@ -422,8 +422,8 @@ Hashes:
 			getproviders.CurrentPlatform.String(),
 			hashList.String(),
 		),
-		Description: fmt.Sprintf(`Check the dependency lockfile's entry for %q.
-	Only 'yes' will be accepted to confirm.`, lock.Provider()),
+		Description: fmt.Sprintf(`Check the details above for provider %q and confirm that you trust the provider.
+	Only 'yes' will be accepted to confirm.`, lock.Provider().Type),
 	})
 	if err != nil {
 		return diags.Append(fmt.Errorf("Failed to approve use of state storage provider: %s", err))

--- a/internal/command/init_run.go
+++ b/internal/command/init_run.go
@@ -235,7 +235,10 @@ func (c *InitCommand) run(initArgs *arguments.Init, view views.Init) int {
 			diags = diags.Append(&hcl.Diagnostic{
 				Severity: hcl.DiagError,
 				Summary:  "State store providers must be downloaded using -safe-init flag",
-				Detail:   "The provider used for state storage needs to be installed safely. Please re-run the \"init\" command with the -safe-init flag.",
+				Detail: fmt.Sprintf(
+					"The provider used for state storage (%s) needs to be installed safely. Please re-run the \"init\" command with the -safe-init flag.",
+					config.Module.StateStore.ProviderAddr.ForDisplay(),
+				),
 			})
 			view.Diagnostics(diags)
 			return 1

--- a/internal/command/init_run.go
+++ b/internal/command/init_run.go
@@ -243,11 +243,11 @@ func (c *InitCommand) run(initArgs *arguments.Init, view views.Init) int {
 
 		diags = diags.Append(c.promptStateStorageProviderApproval(config.Module.StateStore.ProviderAddr, configLocks))
 		if diags.HasErrors() {
-			view.Output(views.UserRejectedStateStoreProviderMessage)
+			view.Output(views.StateStoreProviderRejectedMessage)
 			view.Diagnostics(diags)
 			return 1
 		}
-		view.Output(views.UserApprovedStateStoreProviderMessage)
+		view.Output(views.StateStoreProviderApprovedMessage)
 	default:
 		// Handle SafeInitActionInvalid or unexpected action types
 		panic(fmt.Sprintf("When installing providers described in the config Terraform couldn't determine what 'safe init' action should be taken and returned action type %T. This is a bug in Terraform and should be reported.", safeInitAction))

--- a/internal/command/init_run.go
+++ b/internal/command/init_run.go
@@ -4,16 +4,19 @@
 package command
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"strings"
 
 	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/backend"
 	"github.com/hashicorp/terraform/internal/cloud"
 	"github.com/hashicorp/terraform/internal/command/arguments"
 	"github.com/hashicorp/terraform/internal/command/views"
 	"github.com/hashicorp/terraform/internal/configs"
+	"github.com/hashicorp/terraform/internal/depsfile"
 	"github.com/hashicorp/terraform/internal/states"
 	"github.com/hashicorp/terraform/internal/terraform"
 	"github.com/hashicorp/terraform/internal/tfdiags"
@@ -210,7 +213,7 @@ func (c *InitCommand) run(initArgs *arguments.Init, view views.Init) int {
 	previousLocks, moreDiags := c.lockedDependencies()
 	diags = diags.Append(moreDiags)
 
-	configProvidersOutput, configLocks, configProviderDiags := c.getProvidersFromConfig(ctx, config, initArgs.Upgrade, initArgs.PluginPath, initArgs.Lockfile, view)
+	configProvidersOutput, configLocks, safeInitAction, configProviderDiags := c.getProvidersFromConfig(ctx, config, initArgs.Upgrade, initArgs.PluginPath, initArgs.Lockfile, view)
 	diags = diags.Append(configProviderDiags)
 	if configProviderDiags.HasErrors() {
 		view.Diagnostics(diags)
@@ -218,6 +221,35 @@ func (c *InitCommand) run(initArgs *arguments.Init, view views.Init) int {
 	}
 	if configProvidersOutput {
 		header = true
+	}
+
+	switch safeInitAction {
+	case SafeInitActionNotRelevant:
+		// do nothing; security features aren't relevant.
+	case SafeInitActionProceed:
+		// do nothing; provider is considered safe and there's no need for notifying the user.
+	case SafeInitActionPromptForInput:
+		if !initArgs.SafeInitWithPluggableStateStore {
+			// If the -safe-init flag isn't present we prompt the user to re-run init so they're opting into the security UX.
+			diags = diags.Append(&hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  "State storage providers must be downloaded using -safe-init flag",
+				Detail:   "The provider used for state storage needs to be installed safely. Please re-run the \"init\" command with the -safe-init flag.",
+			})
+			view.Diagnostics(diags)
+			return 1
+		}
+
+		diags = diags.Append(c.promptStateStorageProviderApproval(config.Module.StateStore.ProviderAddr, configLocks))
+		if diags.HasErrors() {
+			view.Output(views.UserRejectedStateStoreProviderMessage)
+			view.Diagnostics(diags)
+			return 1
+		}
+		view.Output(views.UserApprovedStateStoreProviderMessage)
+	default:
+		// Handle SafeInitActionInvalid or unexpected action types
+		panic(fmt.Sprintf("When installing providers described in the config Terraform couldn't determine what 'safe init' action should be taken and returned action type %T. This is a bug in Terraform and should be reported.", safeInitAction))
 	}
 
 	// If we outputted information, then we need to output a newline
@@ -361,4 +393,39 @@ func (c *InitCommand) run(initArgs *arguments.Init, view views.Init) int {
 		view.Output(output)
 	}
 	return 0
+}
+
+// promptStateStorageProviderApproval is used when Terraform is unsure about the safety of the provider downloaded for state storage
+// purposes, and we need to prompt the user to approve or reject using it.
+func (c *InitCommand) promptStateStorageProviderApproval(stateStorageProvider addrs.Provider, configLocks *depsfile.Locks) tfdiags.Diagnostics {
+	var diags tfdiags.Diagnostics
+
+	// If we can receive input then we prompt for ok from the user
+	lock := configLocks.Provider(stateStorageProvider)
+
+	v, err := c.UIInput().Input(context.Background(), &terraform.InputOpts{
+		Id: "approve",
+		Query: fmt.Sprintf(`Do you want to use provider %q (%s), version %s, for managing state?
+Hash: %s
+`,
+			lock.Provider().Type,
+			lock.Provider(),
+			lock.Version(),
+			lock.PreferredHashes()[0], // TODO - better handle of multiple hashes
+		),
+		Description: fmt.Sprintf(`Check the dependency lockfile's entry for %q.
+	Only 'yes' will be accepted to confirm.`, lock.Provider()),
+	})
+	if err != nil {
+		return diags.Append(fmt.Errorf("Failed to approve use of state storage provider: %s", err))
+	}
+	if v != "yes" {
+		return diags.Append(
+			fmt.Errorf("State storage provider %q (%s) was not approved by the user",
+				lock.Provider().Type,
+				lock.Provider(),
+			),
+		)
+	}
+	return diags
 }

--- a/internal/command/init_test.go
+++ b/internal/command/init_test.go
@@ -3499,7 +3499,7 @@ func TestInit_stateStore_newWorkingDir(t *testing.T) {
 		}
 	})
 
-	t.Run("init: -safe-init enables downloading a state storage provider via HTTP", func(t *testing.T) {
+	t.Run("init: with -safe-init users can approve downloading a state store provider via HTTP", func(t *testing.T) {
 		// Create a temporary, uninitialized working directory with configuration including a state store
 		td := t.TempDir()
 		testCopyDir(t, testFixturePath("init-with-state-store"), td)
@@ -3549,6 +3549,7 @@ func TestInit_stateStore_newWorkingDir(t *testing.T) {
 		output := testOutput.All()
 		expectedOutputs := []string{
 			"Initializing the state store...",
+			"The state store provider was approved",
 			"Terraform created an empty state file for the default workspace",
 			"Terraform has been successfully initialized!",
 		}
@@ -3577,7 +3578,83 @@ func TestInit_stateStore_newWorkingDir(t *testing.T) {
 		}
 	})
 
-	t.Run("init: can safely download state storage provider from a local archive without needing to supply the -safe-init flag", func(t *testing.T) {
+	t.Run("init: with -safe-init users can reject downloading a state store provider via HTTP", func(t *testing.T) {
+		// Create a temporary, uninitialized working directory with configuration including a state store
+		td := t.TempDir()
+		testCopyDir(t, testFixturePath("init-with-state-store"), td)
+		t.Chdir(td)
+
+		// Set up mock provider source that mocks out downloading hashicorp/test v1.2.3 via HTTP.
+		// This stops Terraform auto-approving the provider installation.
+		source := newMockProviderSourceUsingTestHttpServer(t, addrs.NewDefaultProvider("test"), getproviders.MustParseVersion("1.2.3"))
+
+		mockProvider := mockPluggableStateStorageProvider()
+		mockProviderAddress := addrs.NewDefaultProvider("test")
+
+		// Allow the test to respond to the pause in provider installation for
+		// checking the state storage provider.
+		inputWriter := testInputMap(t, map[string]string{
+			"approve": "no",
+		})
+
+		ui := new(cli.MockUi)
+		view, done := testView(t)
+		meta := Meta{
+			Ui:                        ui,
+			View:                      view,
+			AllowExperimentalFeatures: true,
+			testingOverrides: &testingOverrides{
+				Providers: map[addrs.Provider]providers.Factory{
+					mockProviderAddress: providers.FactoryFixed(mockProvider),
+				},
+			},
+			ProviderSource: source,
+		}
+		c := &InitCommand{
+			Meta: meta,
+		}
+
+		args := []string{
+			"-enable-pluggable-state-storage-experiment=true",
+			"-safe-init", // In this test the provider is downloaded via HTTP so this flag is necessary.
+		}
+		code := c.Run(args)
+		testOutput := done(t)
+		if code != 1 {
+			t.Fatalf("expected code 1 exit code, got %d, output: \n%s", code, testOutput.All())
+		}
+
+		// Check output via view
+		output := testOutput.All()
+		expectedOutputs := []string{
+			"The state store provider was rejected",
+		}
+		for _, expected := range expectedOutputs {
+			if !strings.Contains(output, expected) {
+				t.Fatalf("expected output to include %q, but got':\n %s", expected, output)
+			}
+		}
+		// Check output when prompting for approval
+		expectedInputPromptMsg := []string{
+			"Do you want to use provider \"test\" (registry.terraform.io/hashicorp/test), version 1.2.3, for managing state?",
+			getproviders.CurrentPlatform.String(),
+			"h1:wlbEC2mChQZ2hhgUhl6SeVLPP7fMqOFUZAQhQ9GIIno=",
+		}
+		for _, expected := range expectedInputPromptMsg {
+			if !strings.Contains(inputWriter.String(), expected) {
+				t.Fatalf("expected the input prompt to include %q, but got':\n %s", expected, inputWriter.String())
+			}
+		}
+
+		// Assert the dependency lock file was not created
+		lockFile := filepath.Join(td, ".terraform.lock.hcl")
+		_, err := os.Stat(lockFile)
+		if !os.IsNotExist(err) {
+			t.Fatal("expected dependency lock file to not exist, but it does")
+		}
+	})
+
+	t.Run("init: can safely download state store provider from a local archive without needing to supply the -safe-init flag", func(t *testing.T) {
 		// Create a temporary, uninitialized working directory with configuration including a state store
 		td := t.TempDir()
 		testCopyDir(t, testFixturePath("init-with-state-store"), td)
@@ -3711,6 +3788,7 @@ func TestInit_stateStore_newWorkingDir(t *testing.T) {
 		output = testOutput.All()
 		expectedOutputs = []string{
 			"Initializing the state store...",
+			"The state store provider was approved",
 			"Terraform created an empty state file for the default workspace",
 			"Terraform has been successfully initialized!",
 		}

--- a/internal/command/init_test.go
+++ b/internal/command/init_test.go
@@ -4752,7 +4752,7 @@ func TestInit_stateStore_providerUpgrade(t *testing.T) {
 		}
 	})
 
-	t.Run("upgrading the provider used for state storage via HTTP", func(t *testing.T) {
+	t.Run("upgrading the provider used for state storage via HTTP requires -safe-init flag", func(t *testing.T) {
 		// Create a temporary working directory with state store configuration
 		// that doesn't match the backend state file
 		td := t.TempDir()
@@ -4771,12 +4771,7 @@ func TestInit_stateStore_providerUpgrade(t *testing.T) {
 		// In this test scenario we perform an upgrade. This causes v9.9.9 to be downloaded.
 		source := newMockProviderSourceUsingTestHttpServer(t, addrs.NewDefaultProvider("test"), getproviders.MustParseVersion("9.9.9"))
 
-		// Allow the test to respond to the pause in provider installation for
-		// checking the state storage provider.
-		_ = testInputMap(t, map[string]string{
-			"approve": "yes",
-		})
-
+		// INIT #1 - fail upgrade due to needing -safe-init flag
 		ui := new(cli.MockUi)
 		view, done := testView(t)
 		meta := Meta{
@@ -4798,28 +4793,46 @@ func TestInit_stateStore_providerUpgrade(t *testing.T) {
 			"-enable-pluggable-state-storage-experiment=true",
 			"-migrate-state=true",
 			"-upgrade",
-			"-safe-init",
+			// -safe-init not present
 		}
 		code := c.Run(args)
 		testOutput := done(t)
-		if code != 0 {
-			t.Fatalf("expected 0 exit code, got %d, output: \n%s", code, testOutput.All())
+		if code != 1 {
+			t.Fatalf("expected 1 exit code, got %d, output: \n%s", code, testOutput.All())
 		}
-
-		// Check output
 		output := testOutput.All()
-		expectedMsg := "Terraform has been successfully initialized!"
+		expectedMsg := "Error: State storage providers must be downloaded using -safe-init flag"
 		if !strings.Contains(output, expectedMsg) {
 			t.Fatalf("expected output to include %q, but got':\n %s", expectedMsg, output)
 		}
-		expectedReason := "State store provider \"test\" (hashicorp/test) version changed from 1.2.3 to 9.9.9"
-		if !strings.Contains(output, expectedReason) {
-			t.Fatalf("expected output to include reason %q, but got':\n %s", expectedReason, output)
-		}
 
-		// check state remains accessible after migration
-		if _, exists := mockProvider.MockStates[backend.DefaultStateName]; !exists {
-			t.Fatal("expected the default workspace to exist after migration, but it is missing")
+		// INIT #2 - successful upgrade due to presence of -safe-init flag
+		//
+		// Allow the test to respond to the pause in provider installation for
+		// checking the state storage provider.
+		_ = testInputMap(t, map[string]string{
+			"approve": "yes",
+		})
+
+		ui = new(cli.MockUi)
+		view, done = testView(t)
+		c.Meta.View = view
+		c.Meta.Ui = ui
+		args = []string{
+			"-enable-pluggable-state-storage-experiment=true",
+			"-migrate-state=true",
+			"-upgrade",
+			"-safe-init",
+		}
+		code = c.Run(args)
+		testOutput = done(t)
+		if code != 0 {
+			t.Fatalf("expected 0 exit code, got %d, output: \n%s", code, testOutput.All())
+		}
+		output = testOutput.All()
+		expectedMsg = "Terraform has been successfully initialized!"
+		if !strings.Contains(output, expectedMsg) {
+			t.Fatalf("expected output to include %q, but got':\n %s", expectedMsg, output)
 		}
 	})
 }

--- a/internal/command/init_test.go
+++ b/internal/command/init_test.go
@@ -3451,7 +3451,7 @@ func TestInit_testsWithModule(t *testing.T) {
 
 // Testing init's behaviors with `state_store` when run in an empty working directory
 func TestInit_stateStore_newWorkingDir(t *testing.T) {
-	t.Run("init: error if -safe-init isn't set when downloading the state storage provider via HTTP", func(t *testing.T) {
+	t.Run("init: error if -safe-init isn't set when downloading the state store provider via HTTP", func(t *testing.T) {
 		// Create a temporary, uninitialized working directory with configuration including a state store
 		td := t.TempDir()
 		testCopyDir(t, testFixturePath("init-with-state-store"), td)
@@ -3490,7 +3490,7 @@ func TestInit_stateStore_newWorkingDir(t *testing.T) {
 		// Check output
 		output := testOutput.All()
 		expectedOutputs := []string{
-			"Error: State storage providers must be downloaded using -safe-init flag",
+			"Error: State store providers must be downloaded using -safe-init flag",
 		}
 		for _, expectedOutput := range expectedOutputs {
 			if !strings.Contains(output, expectedOutput) {
@@ -3760,7 +3760,7 @@ func TestInit_stateStore_newWorkingDir(t *testing.T) {
 		}
 		output := testOutput.All()
 		expectedOutputs := []string{
-			"Error: State storage providers must be downloaded using -safe-init flag",
+			"Error: State store providers must be downloaded using -safe-init flag",
 		}
 		for _, expectedOutput := range expectedOutputs {
 			if !strings.Contains(output, expectedOutput) {
@@ -4880,7 +4880,7 @@ func TestInit_stateStore_providerUpgrade(t *testing.T) {
 			t.Fatalf("expected 1 exit code, got %d, output: \n%s", code, testOutput.All())
 		}
 		output := testOutput.All()
-		expectedMsg := "Error: State storage providers must be downloaded using -safe-init flag"
+		expectedMsg := "Error: State store providers must be downloaded using -safe-init flag"
 		if !strings.Contains(output, expectedMsg) {
 			t.Fatalf("expected output to include %q, but got':\n %s", expectedMsg, output)
 		}

--- a/internal/command/init_test.go
+++ b/internal/command/init_test.go
@@ -4689,7 +4689,7 @@ func TestInit_stateStore_configChanges(t *testing.T) {
 // TODO: Add a test case showing that downgrading provider version is ok as long as the schema version hasn't
 // changed. We should also have a test demonstrating that downgrades when the schema version HAS changed will fail.
 func TestInit_stateStore_providerUpgrade(t *testing.T) {
-	t.Run("handling upgrading the provider used for state storage", func(t *testing.T) {
+	t.Run("upgrading the provider used for state storage from a local archive", func(t *testing.T) {
 		// Create a temporary working directory with state store configuration
 		// that doesn't match the backend state file
 		td := t.TempDir()
@@ -4728,6 +4728,77 @@ func TestInit_stateStore_providerUpgrade(t *testing.T) {
 			"-enable-pluggable-state-storage-experiment=true",
 			"-migrate-state=true",
 			"-upgrade",
+		}
+		code := c.Run(args)
+		testOutput := done(t)
+		if code != 0 {
+			t.Fatalf("expected 0 exit code, got %d, output: \n%s", code, testOutput.All())
+		}
+
+		// Check output
+		output := testOutput.All()
+		expectedMsg := "Terraform has been successfully initialized!"
+		if !strings.Contains(output, expectedMsg) {
+			t.Fatalf("expected output to include %q, but got':\n %s", expectedMsg, output)
+		}
+		expectedReason := "State store provider \"test\" (hashicorp/test) version changed from 1.2.3 to 9.9.9"
+		if !strings.Contains(output, expectedReason) {
+			t.Fatalf("expected output to include reason %q, but got':\n %s", expectedReason, output)
+		}
+
+		// check state remains accessible after migration
+		if _, exists := mockProvider.MockStates[backend.DefaultStateName]; !exists {
+			t.Fatal("expected the default workspace to exist after migration, but it is missing")
+		}
+	})
+
+	t.Run("upgrading the provider used for state storage via HTTP", func(t *testing.T) {
+		// Create a temporary working directory with state store configuration
+		// that doesn't match the backend state file
+		td := t.TempDir()
+		testCopyDir(t, testFixturePath("state-store-changed/provider-upgraded"), td)
+		t.Chdir(td)
+
+		mockProvider := mockPluggableStateStorageProvider()
+		// The previous init implied by this test scenario would have created the default workspace.
+		mockProvider.MockStates = map[string]any{
+			backend.DefaultStateName: []byte(`{"version":4,"terraform_version":"1.15.0","serial":1,"lineage":"91adaece-23b3-7bce-0695-5aea537d2fef","outputs":{"test":{"value":"test","type":"string"}},"resources":[],"check_results":null}`),
+		}
+		mockProviderAddress := addrs.NewDefaultProvider("test")
+
+		// Set up mock provider source that mocks out downloading hashicorp/test v9.9.9 via HTTP.
+		// The test fixtures include a lock file and backend state file that specify v1.2.3 of the hashicorpt/test provider.
+		// In this test scenario we perform an upgrade. This causes v9.9.9 to be downloaded.
+		source := newMockProviderSourceUsingTestHttpServer(t, addrs.NewDefaultProvider("test"), getproviders.MustParseVersion("9.9.9"))
+
+		// Allow the test to respond to the pause in provider installation for
+		// checking the state storage provider.
+		_ = testInputMap(t, map[string]string{
+			"approve": "yes",
+		})
+
+		ui := new(cli.MockUi)
+		view, done := testView(t)
+		meta := Meta{
+			Ui:                        ui,
+			View:                      view,
+			AllowExperimentalFeatures: true,
+			testingOverrides: &testingOverrides{
+				Providers: map[addrs.Provider]providers.Factory{
+					mockProviderAddress: providers.FactoryFixed(mockProvider),
+				},
+			},
+			ProviderSource: source,
+		}
+		c := &InitCommand{
+			Meta: meta,
+		}
+
+		args := []string{
+			"-enable-pluggable-state-storage-experiment=true",
+			"-migrate-state=true",
+			"-upgrade",
+			"-safe-init",
 		}
 		code := c.Run(args)
 		testOutput := done(t)

--- a/internal/command/init_test.go
+++ b/internal/command/init_test.go
@@ -3560,6 +3560,7 @@ func TestInit_stateStore_newWorkingDir(t *testing.T) {
 		// Check output when prompting for approval
 		expectedInputPromptMsg := []string{
 			"Do you want to use provider \"test\" (registry.terraform.io/hashicorp/test), version 1.2.3, for managing state?",
+			getproviders.CurrentPlatform.String(),
 			"h1:wlbEC2mChQZ2hhgUhl6SeVLPP7fMqOFUZAQhQ9GIIno=",
 		}
 		for _, expected := range expectedInputPromptMsg {

--- a/internal/command/init_test.go
+++ b/internal/command/init_test.go
@@ -3491,6 +3491,11 @@ func TestInit_stateStore_newWorkingDir(t *testing.T) {
 		output := testOutput.All()
 		expectedOutputs := []string{
 			"Error: State store providers must be downloaded using -safe-init flag",
+
+			// The required_providers entry is referenced in the error message.
+			// These lines are impacted if the test fixture is altered
+			"on main.tf line 4, in terraform:",
+			"4:     test = {",
 		}
 		for _, expectedOutput := range expectedOutputs {
 			if !strings.Contains(output, expectedOutput) {

--- a/internal/command/init_test.go
+++ b/internal/command/init_test.go
@@ -3514,7 +3514,7 @@ func TestInit_stateStore_newWorkingDir(t *testing.T) {
 
 		// Allow the test to respond to the pause in provider installation for
 		// checking the state storage provider.
-		_ = testInputMap(t, map[string]string{
+		inputWriter := testInputMap(t, map[string]string{
 			"approve": "yes",
 		})
 
@@ -3545,7 +3545,7 @@ func TestInit_stateStore_newWorkingDir(t *testing.T) {
 			t.Fatalf("expected code 0 exit code, got %d, output: \n%s", code, testOutput.All())
 		}
 
-		// Check output
+		// Check output via view
 		output := testOutput.All()
 		expectedOutputs := []string{
 			"Initializing the state store...",
@@ -3555,6 +3555,16 @@ func TestInit_stateStore_newWorkingDir(t *testing.T) {
 		for _, expected := range expectedOutputs {
 			if !strings.Contains(output, expected) {
 				t.Fatalf("expected output to include %q, but got':\n %s", expected, output)
+			}
+		}
+		// Check output when prompting for approval
+		expectedInputPromptMsg := []string{
+			"Do you want to use provider \"test\" (registry.terraform.io/hashicorp/test), version 1.2.3, for managing state?",
+			"h1:wlbEC2mChQZ2hhgUhl6SeVLPP7fMqOFUZAQhQ9GIIno=",
+		}
+		for _, expected := range expectedInputPromptMsg {
+			if !strings.Contains(inputWriter.String(), expected) {
+				t.Fatalf("expected the input prompt to include %q, but got':\n %s", expected, inputWriter.String())
 			}
 		}
 

--- a/internal/command/init_test.go
+++ b/internal/command/init_test.go
@@ -3451,6 +3451,265 @@ func TestInit_testsWithModule(t *testing.T) {
 
 // Testing init's behaviors with `state_store` when run in an empty working directory
 func TestInit_stateStore_newWorkingDir(t *testing.T) {
+	t.Run("init: error if -safe-init isn't set when downloading the state storage provider via HTTP", func(t *testing.T) {
+		// Create a temporary, uninitialized working directory with configuration including a state store
+		td := t.TempDir()
+		testCopyDir(t, testFixturePath("init-with-state-store"), td)
+		t.Chdir(td)
+
+		// Set up mock provider source that mocks out downloading hashicorp/test v1.2.3 via HTTP.
+		// This stops Terraform auto-approving the provider installation.
+		source := newMockProviderSourceUsingTestHttpServer(t, addrs.NewDefaultProvider("test"), getproviders.MustParseVersion("1.2.3"))
+
+		ui := new(cli.MockUi)
+		view, done := testView(t)
+		meta := Meta{
+			Ui:                        ui,
+			View:                      view,
+			AllowExperimentalFeatures: true,
+			// We don't use testOverrides here because that causes providers to come from the local
+			// filesystem, and that makes them automatically trusted.
+			// The purpose of this test is to assert that downloading providers via HTTP, so we use a
+			// provider source that's mimicking the Registry with an http.Server.
+			ProviderSource: source,
+		}
+		c := &InitCommand{
+			Meta: meta,
+		}
+
+		args := []string{
+			"-enable-pluggable-state-storage-experiment=true",
+			// -safe-init is omitted to create the test scenario
+		}
+		code := c.Run(args)
+		testOutput := done(t)
+		if code != 1 {
+			t.Fatalf("expected code 1 exit code, got %d, output: \n%s", code, testOutput.All())
+		}
+
+		// Check output
+		output := testOutput.All()
+		expectedOutputs := []string{
+			"Error: State storage providers must be downloaded using -safe-init flag",
+		}
+		for _, expectedOutput := range expectedOutputs {
+			if !strings.Contains(output, expectedOutput) {
+				t.Fatalf("expected output to include %q, but got':\n %s", expectedOutput, output)
+			}
+		}
+	})
+
+	t.Run("init: -safe-init enables downloading a state storage provider via HTTP", func(t *testing.T) {
+		// Create a temporary, uninitialized working directory with configuration including a state store
+		td := t.TempDir()
+		testCopyDir(t, testFixturePath("init-with-state-store"), td)
+		t.Chdir(td)
+
+		// Set up mock provider source that mocks out downloading hashicorp/test v1.2.3 via HTTP.
+		// This stops Terraform auto-approving the provider installation.
+		source := newMockProviderSourceUsingTestHttpServer(t, addrs.NewDefaultProvider("test"), getproviders.MustParseVersion("1.2.3"))
+
+		mockProvider := mockPluggableStateStorageProvider()
+		mockProviderAddress := addrs.NewDefaultProvider("test")
+
+		// Allow the test to respond to the pause in provider installation for
+		// checking the state storage provider.
+		_ = testInputMap(t, map[string]string{
+			"approve": "yes",
+		})
+
+		ui := new(cli.MockUi)
+		view, done := testView(t)
+		meta := Meta{
+			Ui:                        ui,
+			View:                      view,
+			AllowExperimentalFeatures: true,
+			testingOverrides: &testingOverrides{
+				Providers: map[addrs.Provider]providers.Factory{
+					mockProviderAddress: providers.FactoryFixed(mockProvider),
+				},
+			},
+			ProviderSource: source,
+		}
+		c := &InitCommand{
+			Meta: meta,
+		}
+
+		args := []string{
+			"-enable-pluggable-state-storage-experiment=true",
+			"-safe-init", // In this test the provider is downloaded via HTTP so this flag is necessary.
+		}
+		code := c.Run(args)
+		testOutput := done(t)
+		if code != 0 {
+			t.Fatalf("expected code 0 exit code, got %d, output: \n%s", code, testOutput.All())
+		}
+
+		// Check output
+		output := testOutput.All()
+		expectedOutputs := []string{
+			"Initializing the state store...",
+			"Terraform created an empty state file for the default workspace",
+			"Terraform has been successfully initialized!",
+		}
+		for _, expected := range expectedOutputs {
+			if !strings.Contains(output, expected) {
+				t.Fatalf("expected output to include %q, but got':\n %s", expected, output)
+			}
+		}
+
+		// Assert the dependency lock file was created
+		lockFile := filepath.Join(td, ".terraform.lock.hcl")
+		_, err := os.Stat(lockFile)
+		if os.IsNotExist(err) {
+			t.Fatal("expected dependency lock file to exist, but it doesn't")
+		}
+	})
+
+	t.Run("init: can safely download state storage provider from a local archive without needing to supply the -safe-init flag", func(t *testing.T) {
+		// Create a temporary, uninitialized working directory with configuration including a state store
+		td := t.TempDir()
+		testCopyDir(t, testFixturePath("init-with-state-store"), td)
+		t.Chdir(td)
+
+		// This mock provider source makes Terraform think the provider is coming from a local archive,
+		// so security checks are skipped.
+		source, close := newMockProviderSource(t, map[string][]string{
+			"hashicorp/test": {"1.2.3"},
+		})
+		t.Cleanup(close)
+
+		mockProvider := mockPluggableStateStorageProvider()
+		mockProviderAddress := addrs.NewDefaultProvider("test")
+
+		ui := new(cli.MockUi)
+		view, done := testView(t)
+		meta := Meta{
+			Ui:                        ui,
+			View:                      view,
+			AllowExperimentalFeatures: true,
+			testingOverrides: &testingOverrides{
+				Providers: map[addrs.Provider]providers.Factory{
+					mockProviderAddress: providers.FactoryFixed(mockProvider),
+				},
+			},
+			ProviderSource: source,
+		}
+		c := &InitCommand{
+			Meta: meta,
+		}
+
+		args := []string{
+			"-enable-pluggable-state-storage-experiment=true",
+			// This test doesn't need -safe-init in the flags due to the location of the provider
+		}
+		code := c.Run(args)
+		testOutput := done(t)
+		if code != 0 {
+			t.Fatalf("expected code 0 exit code, got %d, output: \n%s", code, testOutput.All())
+		}
+
+		// Check output
+		output := testOutput.All()
+		expectedOutputs := []string{
+			"Initializing the state store...",
+			"Terraform created an empty state file for the default workspace",
+			"Terraform has been successfully initialized!",
+		}
+		for _, expected := range expectedOutputs {
+			if !strings.Contains(output, expected) {
+				t.Fatalf("expected output to include %q, but got':\n %s", expected, output)
+			}
+		}
+
+		// Assert the dependency lock file was created
+		lockFile := filepath.Join(td, ".terraform.lock.hcl")
+		_, err := os.Stat(lockFile)
+		if os.IsNotExist(err) {
+			t.Fatal("expected dependency lock file to not exist, but it doesn't")
+		}
+	})
+
+	t.Run("init: if user forgets -safe-init flag and retries they're prompted as expected on the second attempt", func(t *testing.T) {
+		// Create a temporary, uninitialized working directory with configuration including a state store
+		td := t.TempDir()
+		testCopyDir(t, testFixturePath("init-with-state-store"), td)
+		t.Chdir(td)
+
+		// Set up mock provider source that mocks out downloading hashicorp/test v1.2.3 via HTTP.
+		// This stops Terraform auto-approving the provider installation.
+		source := newMockProviderSourceUsingTestHttpServer(t, addrs.NewDefaultProvider("test"), getproviders.MustParseVersion("1.2.3"))
+
+		// Set up providers for use in the second init attempt after the user adds the -safe-init flag.
+		mockProvider := mockPluggableStateStorageProvider()
+		mockProviderAddress := addrs.NewDefaultProvider("test")
+
+		ui := new(cli.MockUi)
+		view, done := testView(t)
+		meta := Meta{
+			Ui:                        ui,
+			View:                      view,
+			AllowExperimentalFeatures: true,
+			testingOverrides: &testingOverrides{
+				Providers: map[addrs.Provider]providers.Factory{
+					mockProviderAddress: providers.FactoryFixed(mockProvider),
+				},
+			},
+			ProviderSource: source,
+		}
+		c := &InitCommand{
+			Meta: meta,
+		}
+
+		// Init number 1: forgetting -safe-init flag
+		args := []string{
+			"-enable-pluggable-state-storage-experiment=true",
+		}
+		code := c.Run(args)
+		testOutput := done(t)
+		if code != 1 {
+			t.Fatalf("expected code 1 exit code, got %d, output: \n%s", code, testOutput.All())
+		}
+		output := testOutput.All()
+		expectedOutputs := []string{
+			"Error: State storage providers must be downloaded using -safe-init flag",
+		}
+		for _, expectedOutput := range expectedOutputs {
+			if !strings.Contains(output, expectedOutput) {
+				t.Fatalf("expected output to include %q, but got':\n %s", expectedOutput, output)
+			}
+		}
+
+		// Init number 2: retrying with -safe-init flag and responding to prompts
+		_ = testInputMap(t, map[string]string{
+			"approve": "yes",
+		})
+		args = []string{
+			"-enable-pluggable-state-storage-experiment=true",
+			"-safe-init",
+		}
+		ui = new(cli.MockUi)
+		view, done = testView(t)
+		c.Ui = ui
+		c.View = view
+		code = c.Run(args)
+		testOutput = done(t)
+		if code != 0 {
+			t.Fatalf("expected code 0 exit code, got %d, output: \n%s", code, testOutput.All())
+		}
+		output = testOutput.All()
+		expectedOutputs = []string{
+			"Initializing the state store...",
+			"Terraform created an empty state file for the default workspace",
+			"Terraform has been successfully initialized!",
+		}
+		for _, expected := range expectedOutputs {
+			if !strings.Contains(output, expected) {
+				t.Fatalf("expected output to include %q, but got':\n %s", expected, output)
+			}
+		}
+	})
+
 	t.Run("init: creates a backend state file and creates the default workspace by default", func(t *testing.T) {
 		// Create a temporary, uninitialized working directory with configuration including a state store
 		td := t.TempDir()

--- a/internal/command/views/init.go
+++ b/internal/command/views/init.go
@@ -199,13 +199,13 @@ var MessageRegistry map[InitMessageCode]InitMessage = map[InitMessageCode]InitMe
 		HumanValue: "\n[reset][bold]Initializing the state store...",
 		JSONValue:  "Initializing the state store...",
 	},
-	"user_approved_state_store_provider_message": {
-		HumanValue: "\n[reset][bold]User approved the state storage provider.",
-		JSONValue:  "User approved the state storage provider.",
+	"state_store_provider_approved_message": {
+		HumanValue: "\n[reset][bold]The state store provider was approved.",
+		JSONValue:  "The state store provider was approved.",
 	},
-	"user_rejected_state_store_provider_message": {
-		HumanValue: "\n[reset][bold]User rejected the state storage provider.",
-		JSONValue:  "User rejected the state storage provider.",
+	"state_store_provider_rejected_message": {
+		HumanValue: "\n[reset][bold]The state store provider was rejected.",
+		JSONValue:  "The state store provider was rejected.",
 	},
 	"default_workspace_created_message": {
 		HumanValue: defaultWorkspaceCreatedInfo,
@@ -351,8 +351,8 @@ const (
 	InitializingModulesMessage                  InitMessageCode = "initializing_modules_message"
 	InitializingBackendMessage                  InitMessageCode = "initializing_backend_message"
 	InitializingStateStoreMessage               InitMessageCode = "initializing_state_store_message"
-	UserApprovedStateStoreProviderMessage       InitMessageCode = "user_approved_state_store_provider_message"
-	UserRejectedStateStoreProviderMessage       InitMessageCode = "user_rejected_state_store_provider_message"
+	StateStoreProviderApprovedMessage           InitMessageCode = "state_store_provider_approved_message"
+	StateStoreProviderRejectedMessage           InitMessageCode = "state_store_provider_rejected_message"
 	InitializingProviderPluginFromConfigMessage InitMessageCode = "initializing_provider_plugin_from_config_message"
 	InitializingProviderPluginFromStateMessage  InitMessageCode = "initializing_provider_plugin_from_state_message"
 	ReusingVersionIdentifiedFromConfig          InitMessageCode = "reusing_version_during_state_provider_init"

--- a/internal/command/views/init.go
+++ b/internal/command/views/init.go
@@ -199,6 +199,14 @@ var MessageRegistry map[InitMessageCode]InitMessage = map[InitMessageCode]InitMe
 		HumanValue: "\n[reset][bold]Initializing the state store...",
 		JSONValue:  "Initializing the state store...",
 	},
+	"user_approved_state_store_provider_message": {
+		HumanValue: "\n[reset][bold]User approved the state storage provider.",
+		JSONValue:  "User approved the state storage provider.",
+	},
+	"user_rejected_state_store_provider_message": {
+		HumanValue: "\n[reset][bold]User rejected the state storage provider.",
+		JSONValue:  "User rejected the state storage provider.",
+	},
 	"default_workspace_created_message": {
 		HumanValue: defaultWorkspaceCreatedInfo,
 		JSONValue:  defaultWorkspaceCreatedInfo,
@@ -343,6 +351,8 @@ const (
 	InitializingModulesMessage                  InitMessageCode = "initializing_modules_message"
 	InitializingBackendMessage                  InitMessageCode = "initializing_backend_message"
 	InitializingStateStoreMessage               InitMessageCode = "initializing_state_store_message"
+	UserApprovedStateStoreProviderMessage       InitMessageCode = "user_approved_state_store_provider_message"
+	UserRejectedStateStoreProviderMessage       InitMessageCode = "user_rejected_state_store_provider_message"
 	InitializingProviderPluginFromConfigMessage InitMessageCode = "initializing_provider_plugin_from_config_message"
 	InitializingProviderPluginFromStateMessage  InitMessageCode = "initializing_provider_plugin_from_state_message"
 	ReusingVersionIdentifiedFromConfig          InitMessageCode = "reusing_version_during_state_provider_init"

--- a/internal/configs/config.go
+++ b/internal/configs/config.go
@@ -677,31 +677,35 @@ func (c *Config) resolveProviderTypes() map[string]addrs.Provider {
 	return providers
 }
 
-// resolveStateStoreProviderType gets tfaddr.Provider data for the provider used for pluggable state storage
-// and assigns it to the ProviderAddr field in the config's root module's state store data.
+// resolveStateStoreProviderData gets tfaddr.Provider data for the provider used for state storage,
+// and data about the declaration range for the paired required_providers entry. These values are
+// assigned to the relevant fields in the config's state store representation.
 //
-// See the reused function resolveStateStoreProviderType for details about logic.
+// See the reused function resolveStateStoreProviderData for details about logic.
 // If no match is found, an error diagnostic is returned.
-func (c *Config) resolveStateStoreProviderType() hcl.Diagnostics {
+func (c *Config) resolveStateStoreProviderData() hcl.Diagnostics {
 	var diags hcl.Diagnostics
 
-	providerType, typeDiags := resolveStateStoreProviderType(c.Root.Module.ProviderRequirements.RequiredProviders,
-		*c.Root.Module.StateStore)
+	providerType, reqDeclRange, typeDiags := resolveStateStoreProviderData(
+		c.Root.Module.ProviderRequirements.RequiredProviders,
+		*c.Root.Module.StateStore,
+	)
 
 	if typeDiags.HasErrors() {
 		diags = append(diags, typeDiags...)
 		return diags
 	}
+	diags = append(diags, typeDiags...) // capture any warnings
 
 	c.Root.Module.StateStore.ProviderAddr = providerType
-	return nil
+	c.Root.Module.StateStore.RequiredProviderDeclRange = reqDeclRange
+	return diags
 }
 
 // resolveProviderTypesForTests matches resolveProviderTypes except it uses
 // the information from resolveProviderTypes to resolve the provider types for
 // providers defined within the configs test files.
 func (c *Config) resolveProviderTypesForTests(providers map[string]addrs.Provider) {
-
 	for _, test := range c.Module.Tests {
 
 		// testProviders contains the configuration blocks for all the providers
@@ -780,7 +784,6 @@ func (c *Config) resolveProviderTypesForTests(providers map[string]addrs.Provide
 						}
 					}
 				}
-
 			} else {
 				// This provider is going to load all the providers it can using
 				// simple name matching.
@@ -833,7 +836,6 @@ func (c *Config) resolveProviderTypesForTests(providers map[string]addrs.Provide
 		}
 
 	}
-
 }
 
 // ProviderTypes returns the FQNs of each distinct provider type referenced
@@ -895,7 +897,6 @@ func (c *Config) ResolveAbsProviderAddr(addr addrs.ProviderConfig, inModule addr
 	default:
 		panic(fmt.Sprintf("cannot ResolveAbsProviderAddr(%v, ...)", addr))
 	}
-
 }
 
 // ProviderForConfigAddr returns the FQN for a given addrs.ProviderConfig, first

--- a/internal/configs/config_build.go
+++ b/internal/configs/config_build.go
@@ -59,7 +59,7 @@ func FinalizeConfig(cfg *Config, walker ModuleWalker, loader MockDataLoader) hcl
 		cfg.resolveProviderTypesForTests(providers)
 
 		if cfg.Module != nil && cfg.Module.StateStore != nil {
-			stateProviderDiags := cfg.resolveStateStoreProviderType()
+			stateProviderDiags := cfg.resolveStateStoreProviderData()
 			diags = append(diags, stateProviderDiags...)
 		}
 	}

--- a/internal/configs/module.go
+++ b/internal/configs/module.go
@@ -191,7 +191,7 @@ func NewModule(primaryFiles, overrideFiles []*File) (*Module, hcl.Diagnostics) {
 	mod.gatherProviderLocalNames()
 
 	if mod.StateStore != nil {
-		diags = append(diags, mod.resolveStateStoreProviderType()...)
+		diags = append(diags, mod.resolveStateStoreProviderData()...)
 	}
 
 	return mod, diags
@@ -895,23 +895,26 @@ func (m *Module) gatherProviderLocalNames() {
 	m.ProviderLocalNames = providers
 }
 
-// resolveStateStoreProviderType uses the processed module to get tfaddr.Provider data for the provider
-// used for pluggable state storage, and assigns it to the ProviderAddr field in the module's state store data.
+// resolveStateStoreProviderData gets tfaddr.Provider data for the provider used for state storage,
+// and data about the declaration range for the paired required_providers entry. These values are
+// assigned to the relevant fields in the module's state store representation.
 //
-// See the reused function resolveStateStoreProviderType for details about logic.
+// See the reused function resolveStateStoreProviderData for details about logic.
 // If no match is found, an error diagnostic is returned.
-func (m *Module) resolveStateStoreProviderType() hcl.Diagnostics {
+func (m *Module) resolveStateStoreProviderData() hcl.Diagnostics {
 	var diags hcl.Diagnostics
 
-	providerType, typeDiags := resolveStateStoreProviderType(m.ProviderRequirements.RequiredProviders,
+	providerType, reqDeclRange, typeDiags := resolveStateStoreProviderData(m.ProviderRequirements.RequiredProviders,
 		*m.StateStore)
 
 	if typeDiags.HasErrors() {
 		diags = append(diags, typeDiags...)
 		return diags
 	}
+	diags = append(diags, typeDiags...) // capture any warnings
 
 	m.StateStore.ProviderAddr = providerType
+	m.StateStore.RequiredProviderDeclRange = reqDeclRange
 	return diags
 }
 

--- a/internal/configs/state_store.go
+++ b/internal/configs/state_store.go
@@ -38,8 +38,12 @@ type StateStore struct {
 	// and is used in diagnostics
 	ProviderAddr tfaddr.Provider
 
-	TypeRange hcl.Range
-	DeclRange hcl.Range
+	// hcl.Range data is stored for use in diagnostics.
+	// Different ranges are relevant for different error types,
+	// e.g. unknown store type, invalid configuration, missing required_provider entry.
+	TypeRange                 hcl.Range
+	DeclRange                 hcl.Range
+	RequiredProviderDeclRange hcl.Range
 }
 
 func decodeStateStoreBlock(block *hcl.Block) (*StateStore, hcl.Diagnostics) {
@@ -104,10 +108,11 @@ var StateStorageBlockSchema = &hcl.BodySchema{
 	},
 }
 
-// resolveStateStoreProviderType is used to obtain provider source data from required_providers data.
-// The only exception is the builtin terraform provider, which we return source data for without using required_providers.
+// resolveStateStoreProviderData updates the provided StateStore used to include data from required_providers.
+// The StateStore struct is updated to include the provider address and the decl range of the matching required_providers entry.
+// Special handling is required for the builtin terraform provider, which we don't expect to be in required_providers.
 // This code is reused in code for parsing config and modules.
-func resolveStateStoreProviderType(requiredProviders map[string]*RequiredProvider, stateStore StateStore) (tfaddr.Provider, hcl.Diagnostics) {
+func resolveStateStoreProviderData(requiredProviders map[string]*RequiredProvider, stateStore StateStore) (tfaddr.Provider, hcl.Range, hcl.Diagnostics) {
 	var diags hcl.Diagnostics
 
 	// We intentionally don't look for entries in required_providers under different local names and match them
@@ -118,7 +123,7 @@ func resolveStateStoreProviderType(requiredProviders map[string]*RequiredProvide
 		// We do not expect users to include built in providers in required_providers
 		// So, if we don't find an entry in required_providers under local name 'terraform' we assume
 		// that the builtin provider is intended.
-		return addrs.NewBuiltInProvider("terraform"), nil
+		return addrs.NewBuiltInProvider("terraform"), hcl.Range{}, diags
 	case !foundReqProviderEntry:
 		diags = diags.Append(
 			&hcl.Diagnostic{
@@ -130,12 +135,12 @@ func resolveStateStoreProviderType(requiredProviders map[string]*RequiredProvide
 				Subject: &stateStore.DeclRange,
 			},
 		)
-		return tfaddr.Provider{}, diags
+		return tfaddr.Provider{}, hcl.Range{}, diags
 	default:
 		// We've got a required_providers entry to use
 		// This code path is used for both re-attached providers
-		// providers that are fully managed by Terraform.
-		return addr.Type, nil
+		// and providers that are fully managed by Terraform.
+		return addr.Type, addr.DeclRange, diags
 	}
 }
 


### PR DESCRIPTION
 # Context & what the new security feature does

This PR fixes a security issue identified in the PSS project. Previously users had the opportunity to inspect providers downloaded in `init` before the providers binaries were executed and used during other downstream commands like `plan`/`apply`. With the introduction of PSS we created a scenario where a provider can be downloaded and immediately used without users having an opportunity to vet them.

Now the `init` command will intervene when it sees Terraform is going to download an 'unsafe' provider for pluggable state storage.

What is unsafe? Terraform regards any provider downloaded over HTTP to be unsafe until the user has approved it. Providers that are sourced from the local machine are treated as safe and pre-vetted, as the user has curated that collection of providers themselves and explicitly directed Terraform to use them via CLI configuration ([see use of filesystem_mirror in the docs](https://developer.hashicorp.com/terraform/cli/config/config-file#explicit-installation-method-configuration)).

How does Terraform intervene? If Terraform detects that the state storage provider will be downloaded via HTTP and the user hasn't opted into a 'safe init' process then the CLI will return an error prompting the user to re-run the init command with a flag (`-safe-init`) that opts them into the new security features. The intention of this flag it to ensure users navigate the potential security issue in an engaged way.

When would Terraform intervene? If the provider is downloaded via HTTP then Terraform will intervene when the state storage provider is first installed or upgraded (via `-upgrade` flag).

When would Terraform _not_ intervene? If the state storage provider is being downloaded for the first time or upgraded but the provider is sourced from a non-HTTP source then Terraform will not force the user to supply the `-safe-init` flag.

# This PR

This work was created after doing some prototyping of different approaches in:
* https://github.com/hashicorp/terraform/compare/main...pss/discovery-block-download-via-installer-as-blackbox
    * Stacked on top of that: https://github.com/hashicorp/terraform/compare/main...pss/discovery-block-download-via-installer-as-blackbox-2
* https://github.com/hashicorp/terraform/compare/main...pss/discovery-block-download-via-download-event-callbacks

The approach in this PR is based on the last branch.

This PR implements security features by editing the `getProvidersFromConfig` function, that's only used in the experimental version of `init` in the PSS experiment. This function determines what providers to download (based on preexisting locks, config, and upgrade flag value) and returns new 'config locks' to the init command implementation. The function now also determines what action Terraform should take regarding PSS and the new security features, and returns a value to the calling code instructing it what to do. By implementing this logic inside the `getProvidersFromConfig` function we can access the location metadata for providers that are downloaded within a given `init` command and this location data helps to decide if the user needs to be prompted or not.

**This PR only implements the features for when Terraform is run in an interactive mode. A follow-up PR will handle security features for TF in automation.**

## Related changes

This PR was stacked on top of:

https://github.com/hashicorp/terraform/pull/38206

https://github.com/hashicorp/terraform/pull/38212


## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

N/A

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
