### PR TITLE
Pss/safe provider download during init in automation

### DIFF
--- a/internal/command/init.go
+++ b/internal/command/init.go
@@ -792,7 +792,11 @@ func (c *InitCommand) getProvidersFromConfig(ctx context.Context, config *config
 				safeInitAction = SafeInitActionProceed
 			case getproviders.PackageHTTPURL:
 				log.Printf("[DEBUG] init (getProvidersFromConfig): the state storage provider %s (%q) is downloaded via HTTP, so we consider it potentially unsafe.", config.Module.StateStore.ProviderAddr.Type, config.Module.StateStore.ProviderAddr)
-				safeInitAction = SafeInitActionPromptForInput
+				if c.input {
+					safeInitAction = SafeInitActionPromptForInput
+				} else {
+					safeInitAction = SafeInitActionExitEarly
+				}
 			default:
 				panic(fmt.Sprintf("init (getProvidersFromConfig): unexpected provider location type for state storage provider %q: %T", config.Module.StateStore.ProviderAddr, location))
 			}

--- a/internal/command/init_run.go
+++ b/internal/command/init_run.go
@@ -252,6 +252,41 @@ func (c *InitCommand) run(initArgs *arguments.Init, view views.Init) int {
 			return 1
 		}
 		view.Output(views.StateStoreProviderApprovedMessage)
+	case SafeInitActionExitEarly:
+		if !initArgs.SafeInitWithPluggableStateStore {
+			// If the -safe-init flag isn't present we prompt the user to re-run init so they're opting into the security UX.
+			diags = diags.Append(&hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  "State storage providers must be downloaded using -safe-init flag",
+				Detail:   "The provider used for state storage needs to be installed safely. Please re-run the \"init\" command with the -safe-init flag.",
+			})
+			view.Diagnostics(diags)
+			return 1
+		}
+
+		// If we're in automation we need to write the config-derived providers to lock file
+		lockFileOutput, lockFileDiags := c.saveDependencyLockFile(previousLocks, configLocks, nil, initArgs.Lockfile, view)
+		diags = diags.Append(lockFileDiags)
+		if lockFileDiags.HasErrors() {
+			view.Diagnostics(diags)
+			return 1
+		}
+		if lockFileOutput {
+			// If we outputted information, then we need to output a newline
+			// so that our success message is nicely spaced out from prior text.
+			view.Output(views.EmptyMessage)
+		}
+
+		// ... and prompt the user to look at the values.
+		lock := configLocks.Provider(config.Module.StateStore.ProviderAddr)
+
+		view.Diagnostics(diags) // display any warnings
+		view.Output(views.ExitEarlyForStateStoreProviderConfirmationMessage,
+			lock.Provider().Type,
+			lock.Provider(),
+			lock.Version(),
+		)
+		return 0
 	default:
 		// Handle SafeInitActionInvalid or unexpected action types
 		panic(fmt.Sprintf("When installing providers described in the config Terraform couldn't determine what 'safe init' action should be taken and returned action type %T. This is a bug in Terraform and should be reported.", safeInitAction))

--- a/internal/command/init_test.go
+++ b/internal/command/init_test.go
@@ -3504,6 +3504,55 @@ func TestInit_stateStore_newWorkingDir(t *testing.T) {
 		}
 	})
 
+	t.Run("init: in automation, error if -safe-init isn't set when downloading the state store provider via HTTP", func(t *testing.T) {
+		// Create a temporary, uninitialized working directory with configuration including a state store
+		td := t.TempDir()
+		testCopyDir(t, testFixturePath("init-with-state-store"), td)
+		t.Chdir(td)
+
+		// Set up mock provider source that mocks out downloading hashicorp/test v1.2.3 via HTTP.
+		// This stops Terraform auto-approving the provider installation.
+		source := newMockProviderSourceUsingTestHttpServer(t, addrs.NewDefaultProvider("test"), getproviders.MustParseVersion("1.2.3"))
+
+		ui := new(cli.MockUi)
+		view, done := testView(t)
+		meta := Meta{
+			Ui:                        ui,
+			View:                      view,
+			AllowExperimentalFeatures: true,
+			// We don't use testOverrides here because that causes providers to come from the local
+			// filesystem, and that makes them automatically trusted.
+			// The purpose of this test is to assert that downloading providers via HTTP, so we use a
+			// provider source that's mimicking the Registry with an http.Server.
+			ProviderSource: source,
+		}
+		c := &InitCommand{
+			Meta: meta,
+		}
+
+		args := []string{
+			"-enable-pluggable-state-storage-experiment=true",
+			"-input=false",
+			// -safe-init is omitted to create the test scenario
+		}
+		code := c.Run(args)
+		testOutput := done(t)
+		if code != 1 {
+			t.Fatalf("expected code 1 exit code, got %d, output: \n%s", code, testOutput.All())
+		}
+
+		// Check output
+		output := testOutput.All()
+		expectedOutputs := []string{
+			"Error: State storage providers must be downloaded using -safe-init flag",
+		}
+		for _, expectedOutput := range expectedOutputs {
+			if !strings.Contains(output, expectedOutput) {
+				t.Fatalf("expected output to include %q, but got':\n %s", expectedOutput, output)
+			}
+		}
+	})
+
 	t.Run("init: with -safe-init users can approve downloading a state store provider via HTTP", func(t *testing.T) {
 		// Create a temporary, uninitialized working directory with configuration including a state store
 		td := t.TempDir()
@@ -3656,6 +3705,124 @@ func TestInit_stateStore_newWorkingDir(t *testing.T) {
 		_, err := os.Stat(lockFile)
 		if !os.IsNotExist(err) {
 			t.Fatal("expected dependency lock file to not exist, but it does")
+		}
+	})
+
+	// This test reflects that, in automation, we expect the init process to require 2 separate init commands
+	t.Run("init: in automation, -safe-init enables downloading a state storage provider via HTTP", func(t *testing.T) {
+		// Create a temporary, uninitialized working directory with configuration including a state store
+		td := t.TempDir()
+		testCopyDir(t, testFixturePath("init-with-state-store"), td)
+		t.Chdir(td)
+
+		mockProvider := mockPluggableStateStorageProvider()
+		mockProviderAddress := addrs.NewDefaultProvider("test")
+
+		// Set up mock provider source that mocks out downloading hashicorp/test v1.2.3 via HTTP.
+		// This stops Terraform auto-approving the provider installation.
+		source := newMockProviderSourceUsingTestHttpServer(t, mockProviderAddress, getproviders.MustParseVersion("1.2.3"))
+
+		ui := new(cli.MockUi)
+		view, done := testView(t)
+		meta := Meta{
+			Ui:                        ui,
+			View:                      view,
+			AllowExperimentalFeatures: true,
+			testingOverrides: &testingOverrides{
+				Providers: map[addrs.Provider]providers.Factory{
+					mockProviderAddress: providers.FactoryFixed(mockProvider),
+				},
+			},
+			ProviderSource: source,
+		}
+		c := &InitCommand{
+			Meta: meta,
+		}
+
+		args := []string{
+			"-enable-pluggable-state-storage-experiment=true",
+			"-safe-init",
+			"-input=false", // in automation
+		}
+		code := c.Run(args)
+		testOutput := done(t)
+		if code != 0 {
+			t.Fatalf("expected code 0 exit code, got %d, output: \n%s", code, testOutput.All())
+		}
+
+		// Check output
+		output := cleanString(testOutput.All())
+		expectedOutputs := []string{
+			"Installed hashicorp/test v1.2.3 (verified checksum)",
+			"Terraform has created a lock file .terraform.lock.hcl",
+			"Terraform has exited early to allow you to confirm the provider used for state storage: provider \"test\" (registry.terraform.io/hashicorp/test), version 1.2.3.",
+			`To accept the provider run "terraform init" again`,
+			`To reject the provider update your configuration and run "terraform init" again`,
+		}
+		for _, expected := range expectedOutputs {
+			if !strings.Contains(output, expected) {
+				t.Fatalf("expected output to include \"%s\", but got':\n %s", expected, output)
+			}
+		}
+		unexpectedOutput := "Initializing the state store..."
+		if strings.Contains(output, unexpectedOutput) {
+			t.Fatalf("didn't expect the state store to be initialized at the same time as downloading the state storage provider, but it was:\n %s", output)
+		}
+
+		// Assert the dependency lock file was created
+		lockFile := filepath.Join(td, ".terraform.lock.hcl")
+		_, err := os.Stat(lockFile)
+		if os.IsNotExist(err) {
+			t.Fatal("expected dependency lock file to exist, but it doesn't")
+		}
+
+		// Assert the default workspace and backend states haven't been created yet
+		if _, exists := mockProvider.MockStates[backend.DefaultStateName]; exists {
+			t.Fatal("expected the default workspace to not be created yet, but it is present")
+		}
+		statePath := filepath.Join(meta.DataDir(), DefaultStateFilename)
+		_, err = os.Stat(statePath)
+		if !os.IsNotExist(err) {
+			t.Fatal("expected backend state file to not exist, but it does")
+		}
+
+		// Second init is required to fully initialize the working directory
+		ui = new(cli.MockUi)
+		view, done = testView(t)
+		c.Meta.Ui = ui
+		c.Meta.View = view
+
+		args = []string{
+			"-enable-pluggable-state-storage-experiment=true",
+			// -safe-init not needed in second init
+			"-input=false", // in automation
+		}
+		code = c.Run(args)
+		testOutput = done(t)
+		if code != 0 {
+			t.Fatalf("expected code 0 exit code, got %d, output: \n%s", code, testOutput.All())
+		}
+
+		// Check output
+		output = cleanString(testOutput.All())
+		expectedOutputs = []string{
+			"Reusing previous version of hashicorp/test from the dependency lock file",
+			"Initializing the state store...",
+			"Terraform has been successfully initialized!",
+		}
+		for _, expected := range expectedOutputs {
+			if !strings.Contains(output, expected) {
+				t.Fatalf("expected output to include %q, but got':\n %s", expected, output)
+			}
+		}
+
+		// Assert the default workspace and backend states have now been created
+		if _, exists := mockProvider.MockStates[backend.DefaultStateName]; !exists {
+			t.Fatal("expected the default workspace to created, but it is missing")
+		}
+		_, err = os.Stat(statePath)
+		if os.IsNotExist(err) {
+			t.Fatal("expected backend state file to exist, but it is missing")
 		}
 	})
 

--- a/internal/command/meta_dependencies.go
+++ b/internal/command/meta_dependencies.go
@@ -79,10 +79,20 @@ func (m *Meta) replaceLockedDependencies(new *depsfile.Locks) tfdiags.Diagnostic
 // This method supports downloading providers in 2 steps, and is used during the second download step and
 // while updating the dependency lock file.
 func (m *Meta) mergeLockedDependencies(baseLocks, additionalLocks *depsfile.Locks) *depsfile.Locks {
+	if baseLocks == nil && additionalLocks == nil {
+		return depsfile.NewLocks() // empty locks
+	}
+	if additionalLocks == nil {
+		return baseLocks
+	}
+	if baseLocks == nil {
+		return additionalLocks
+	}
 
-	mergedLocks := baseLocks.DeepCopy()
+	// Here we know that there are two sets of locks to combine and return
 
 	// Append locks derived from the state to locks derived from config.
+	mergedLocks := baseLocks.DeepCopy()
 	for _, lock := range additionalLocks.AllProviders() {
 		match := mergedLocks.Provider(lock.Provider())
 		if match != nil {

--- a/internal/command/meta_dependencies_test.go
+++ b/internal/command/meta_dependencies_test.go
@@ -17,7 +17,6 @@ import (
 // This tests combining locks from config and state. Locks derived from state are always unconstrained, i.e. no version constraint data,
 // so this test
 func Test_mergeLockedDependencies_config_and_state(t *testing.T) {
-
 	providerA := tfaddr.NewProvider(tfaddr.DefaultProviderRegistryHost, "my-org", "providerA")
 	providerB := tfaddr.NewProvider(tfaddr.DefaultProviderRegistryHost, "my-org", "providerB")
 	v1_0_0 := providerreqs.MustParseVersion("1.0.0")
@@ -36,6 +35,37 @@ func Test_mergeLockedDependencies_config_and_state(t *testing.T) {
 		"no locks when all inputs empty": {
 			configLocks:   depsfile.NewLocks(),
 			stateLocks:    depsfile.NewLocks(),
+			expectedLocks: depsfile.NewLocks(),
+		},
+		"nil config locks": {
+			configLocks: nil,
+			stateLocks: func() *depsfile.Locks {
+				configLocks := depsfile.NewLocks()
+				configLocks.SetProvider(providerA, v1_0_0, versionConstraintv1, hashesProviderA)
+				return configLocks
+			}(),
+			expectedLocks: func() *depsfile.Locks {
+				combinedLocks := depsfile.NewLocks()
+				combinedLocks.SetProvider(providerA, v1_0_0, versionConstraintv1, hashesProviderA)
+				return combinedLocks
+			}(),
+		},
+		"nil state locks": {
+			configLocks: func() *depsfile.Locks {
+				configLocks := depsfile.NewLocks()
+				configLocks.SetProvider(providerA, v1_0_0, versionConstraintv1, hashesProviderA)
+				return configLocks
+			}(),
+			stateLocks: nil,
+			expectedLocks: func() *depsfile.Locks {
+				combinedLocks := depsfile.NewLocks()
+				combinedLocks.SetProvider(providerA, v1_0_0, versionConstraintv1, hashesProviderA)
+				return combinedLocks
+			}(),
+		},
+		"all nil locks": {
+			configLocks:   nil,
+			stateLocks:    nil,
 			expectedLocks: depsfile.NewLocks(),
 		},
 		"when provider only described in config, output locks have matching constraints": {

--- a/internal/command/views/init.go
+++ b/internal/command/views/init.go
@@ -207,6 +207,10 @@ var MessageRegistry map[InitMessageCode]InitMessage = map[InitMessageCode]InitMe
 		HumanValue: "\n[reset][bold]The state store provider was rejected.",
 		JSONValue:  "The state store provider was rejected.",
 	},
+	"exit_early_for_state_store_provider_confirmation_message": {
+		HumanValue: earlyExitAfterStateStorageProviderInstallHuman,
+		JSONValue:  earlyExitAfterStateStorageProviderInstallJSON,
+	},
 	"default_workspace_created_message": {
 		HumanValue: defaultWorkspaceCreatedInfo,
 		JSONValue:  defaultWorkspaceCreatedInfo,
@@ -339,26 +343,27 @@ const (
 	// Following message codes are used and documented EXTERNALLY
 	// Keep docs/internals/machine-readable-ui.mdx up to date with
 	// this list when making changes here.
-	CopyingConfigurationMessage                 InitMessageCode = "copying_configuration_message"
-	EmptyMessage                                InitMessageCode = "empty_message"
-	OutputInitEmptyMessage                      InitMessageCode = "output_init_empty_message"
-	OutputInitSuccessMessage                    InitMessageCode = "output_init_success_message"
-	OutputInitSuccessCloudMessage               InitMessageCode = "output_init_success_cloud_message"
-	OutputInitSuccessCLIMessage                 InitMessageCode = "output_init_success_cli_message"
-	OutputInitSuccessCLICloudMessage            InitMessageCode = "output_init_success_cli_cloud_message"
-	UpgradingModulesMessage                     InitMessageCode = "upgrading_modules_message"
-	InitializingTerraformCloudMessage           InitMessageCode = "initializing_terraform_cloud_message"
-	InitializingModulesMessage                  InitMessageCode = "initializing_modules_message"
-	InitializingBackendMessage                  InitMessageCode = "initializing_backend_message"
-	InitializingStateStoreMessage               InitMessageCode = "initializing_state_store_message"
-	StateStoreProviderApprovedMessage           InitMessageCode = "state_store_provider_approved_message"
-	StateStoreProviderRejectedMessage           InitMessageCode = "state_store_provider_rejected_message"
-	InitializingProviderPluginFromConfigMessage InitMessageCode = "initializing_provider_plugin_from_config_message"
-	InitializingProviderPluginFromStateMessage  InitMessageCode = "initializing_provider_plugin_from_state_message"
-	ReusingVersionIdentifiedFromConfig          InitMessageCode = "reusing_version_during_state_provider_init"
-	DefaultWorkspaceCreatedMessage              InitMessageCode = "default_workspace_created_message"
-	LockInfo                                    InitMessageCode = "lock_info"
-	DependenciesLockChangesInfo                 InitMessageCode = "dependencies_lock_changes_info"
+	CopyingConfigurationMessage                       InitMessageCode = "copying_configuration_message"
+	EmptyMessage                                      InitMessageCode = "empty_message"
+	OutputInitEmptyMessage                            InitMessageCode = "output_init_empty_message"
+	OutputInitSuccessMessage                          InitMessageCode = "output_init_success_message"
+	OutputInitSuccessCloudMessage                     InitMessageCode = "output_init_success_cloud_message"
+	OutputInitSuccessCLIMessage                       InitMessageCode = "output_init_success_cli_message"
+	OutputInitSuccessCLICloudMessage                  InitMessageCode = "output_init_success_cli_cloud_message"
+	UpgradingModulesMessage                           InitMessageCode = "upgrading_modules_message"
+	InitializingTerraformCloudMessage                 InitMessageCode = "initializing_terraform_cloud_message"
+	InitializingModulesMessage                        InitMessageCode = "initializing_modules_message"
+	InitializingBackendMessage                        InitMessageCode = "initializing_backend_message"
+	InitializingStateStoreMessage                     InitMessageCode = "initializing_state_store_message"
+	ExitEarlyForStateStoreProviderConfirmationMessage InitMessageCode = "exit_early_for_state_store_provider_confirmation_message"
+	StateStoreProviderApprovedMessage                 InitMessageCode = "state_store_provider_approved_message"
+	StateStoreProviderRejectedMessage                 InitMessageCode = "state_store_provider_rejected_message"
+	InitializingProviderPluginFromConfigMessage       InitMessageCode = "initializing_provider_plugin_from_config_message"
+	InitializingProviderPluginFromStateMessage        InitMessageCode = "initializing_provider_plugin_from_state_message"
+	ReusingVersionIdentifiedFromConfig                InitMessageCode = "reusing_version_during_state_provider_init"
+	DefaultWorkspaceCreatedMessage                    InitMessageCode = "default_workspace_created_message"
+	LockInfo                                          InitMessageCode = "lock_info"
+	DependenciesLockChangesInfo                       InitMessageCode = "dependencies_lock_changes_info"
 
 	//// Message codes below are ONLY used INTERNALLY (for now)
 
@@ -505,6 +510,20 @@ version control system if they represent changes you intended to make.`
 const partnerAndCommunityProvidersInfo = "\nPartner and community providers are signed by their developers.\n" +
 	"If you'd like to know more about provider signing, you can read about it here:\n" +
 	"https://developer.hashicorp.com/terraform/cli/plugins/signing"
+
+const earlyExitAfterStateStorageProviderInstallHuman = `
+[reset][bold]Terraform has exited early to allow you to confirm the provider used for state storage: provider %q (%s), version %s.
+[reset]Inspect the provider's details above in the dependency lockfile to confirm it's the provider you intend to use for managing state.
+To accept the provider run  "terraform init" again.
+To reject the provider update your configuration and run "terraform init" again.
+`
+
+const earlyExitAfterStateStorageProviderInstallJSON = `
+Terraform has exited early to allow you to confirm the provider used for state storage: provider %q (%s), version %s.
+Inspect the provider's details above in the dependency lockfile to confirm it's the provider you intend to use for managing state.
+To accept the provider run  "terraform init" again.
+To reject the provider update your configuration and run "terraform init" again.
+`
 
 const errInitConfigError = `
 [reset]Terraform encountered problems during initialisation, including problems


### PR DESCRIPTION
## Context

See previous PR for background: https://github.com/hashicorp/terraform/pull/38205

## Terraform run in automation

This is broadly the same for Terraform when run in automation, but of course Terraform cannot prompt for input in automation. Therefore instead of prompting Terraform will save the config locks to the dependency lock file and exit early, at which point a user should review the dependency lock file and make a judgement about the provider. Accepting the provider requires running `init` again, rejecting requires making necessary edits to config (changing the provider `source` value, adjusting version constraints etc) and running `init` with the `-safe-init` flag again.


## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

N/A

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [ ] This change is not user-facing.
