### PR TITLE
stacks: close providers when getting the provider schema

### DIFF
--- a/internal/rpcapi/dependencies_provider_schema.go
+++ b/internal/rpcapi/dependencies_provider_schema.go
@@ -62,6 +62,9 @@ func loadProviderSchema(providerAddr addrs.Provider, version getproviders.Versio
 	}
 
 	resp := provider.GetProviderSchema()
+	if err := provider.Close(); err != nil {
+		return providers.GetProviderSchemaResponse{}, fmt.Errorf("failed to close provider plugin: %w", err)
+	}
 	return resp, nil
 }
 


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Fixes [TF-35865](https://hashicorp.atlassian.net/browse/TF-35865). Thanks to the missing provider close on the `GetProviderSchemas` call we are introducing a file descriptor leak.

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.16.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.

[TF-35865]: https://hashicorp.atlassian.net/browse/TF-35865?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ