### PR TITLE
Init   upgrade cooldown period for new dependencies

### DIFF
--- a/.changes/v1.16/NEW FEATURES-20260409-120000.yaml
+++ b/.changes/v1.16/NEW FEATURES-20260409-120000.yaml
@@ -1,0 +1,5 @@
+kind: NEW FEATURES
+body: Add minimum version age filtering for provider and module upgrades, with configurable exclusions for trusted sources
+time: 2026-04-09T12:00:00.000000-04:00
+custom:
+    Issue: "38304"

--- a/commands.go
+++ b/commands.go
@@ -102,6 +102,9 @@ func initCommands(
 		PluginCacheDir:      config.PluginCacheDir,
 
 		PluginCacheMayBreakDependencyLockFile: config.PluginCacheMayBreakDependencyLockFile,
+		MinimumVersionAge:                     config.MinimumVersionAge,
+		MinimumVersionAgeExcludeProviders:     config.MinimumVersionAgeExcludeProviders,
+		MinimumVersionAgeExcludeModules:       config.MinimumVersionAgeExcludeModules,
 
 		ShutdownCh:    makeShutdownCh(),
 		CallerContext: ctx,

--- a/internal/command/arguments/init.go
+++ b/internal/command/arguments/init.go
@@ -53,6 +53,14 @@ type Init struct {
 	// Upgrade specifies whether to upgrade modules and plugins as part of their respective installation steps
 	Upgrade bool
 
+	// MinimumVersionAge optionally overrides configured minimum version age
+	// filtering for this init invocation.
+	MinimumVersionAge time.Duration
+
+	// MinimumVersionAgeSet reports whether -minimum-version-age was explicitly
+	// set on the CLI.
+	MinimumVersionAgeSet bool
+
 	// Json specifies whether to output in JSON format
 	Json bool
 
@@ -106,6 +114,7 @@ func ParseInit(args []string, experimentsEnabled bool) (*Init, tfdiags.Diagnosti
 	cmdFlags.BoolVar(&init.Reconfigure, "reconfigure", false, "reconfigure")
 	cmdFlags.BoolVar(&init.MigrateState, "migrate-state", false, "migrate state")
 	cmdFlags.BoolVar(&init.Upgrade, "upgrade", false, "")
+	cmdFlags.DurationVar(&init.MinimumVersionAge, "minimum-version-age", 0, "minimum age required for upgrade candidate versions")
 	cmdFlags.StringVar(&init.Lockfile, "lockfile", "", "Set a dependency lockfile mode")
 	cmdFlags.BoolVar(&init.IgnoreRemoteVersion, "ignore-remote-version", false, "continue even if remote and local Terraform versions are incompatible")
 	cmdFlags.StringVar(&init.TestsDirectory, "test-directory", "tests", "test-directory")
@@ -152,6 +161,15 @@ func ParseInit(args []string, experimentsEnabled bool) (*Init, tfdiags.Diagnosti
 			tfdiags.Error,
 			"Invalid init options",
 			"The -migrate-state and -reconfigure options are mutually-exclusive.",
+		))
+	}
+
+	init.MinimumVersionAgeSet = FlagIsSet(cmdFlags, "minimum-version-age")
+	if init.MinimumVersionAgeSet && init.MinimumVersionAge < 0 {
+		diags = diags.Append(tfdiags.Sourceless(
+			tfdiags.Error,
+			"Invalid init options",
+			"The -minimum-version-age option must not be negative.",
 		))
 	}
 

--- a/internal/command/cliconfig/cliconfig.go
+++ b/internal/command/cliconfig/cliconfig.go
@@ -20,7 +20,9 @@ import (
 	"maps"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/hcl"
 
@@ -30,6 +32,9 @@ import (
 
 const pluginCacheDirEnvVar = "TF_PLUGIN_CACHE_DIR"
 const pluginCacheMayBreakLockFileEnvVar = "TF_PLUGIN_CACHE_MAY_BREAK_DEPENDENCY_LOCK_FILE"
+const minVersionAgeEnvVar = "TF_MINIMUM_VERSION_AGE"
+const minVersionAgeExcludeProvidersEnvVar = "TF_MINIMUM_VERSION_AGE_EXCLUDE_PROVIDERS"
+const minVersionAgeExcludeModulesEnvVar = "TF_MINIMUM_VERSION_AGE_EXCLUDE_MODULES"
 
 // Config is the structure of the configuration for the Terraform CLI.
 //
@@ -56,6 +61,18 @@ type Config struct {
 	// would prefer to have the plugin cache dir's behavior to take priority
 	// over the requirements of the dependency lock file.
 	PluginCacheMayBreakDependencyLockFile bool `hcl:"plugin_cache_may_break_dependency_lock_file"`
+
+	// MinimumVersionAge excludes newly-published versions younger than this
+	// duration when selecting upgrade candidates.
+	MinimumVersionAge time.Duration `hcl:"minimum_version_age"`
+
+	// MinimumVersionAgeExcludeProviders lists provider source addresses that
+	// should bypass minimum_version_age filtering.
+	MinimumVersionAgeExcludeProviders []string `hcl:"minimum_version_age_exclude_providers"`
+
+	// MinimumVersionAgeExcludeModules lists registry module package addresses
+	// that should bypass minimum_version_age filtering.
+	MinimumVersionAgeExcludeModules []string `hcl:"minimum_version_age_exclude_modules"`
 
 	Hosts map[string]*ConfigHost `hcl:"host"`
 
@@ -254,6 +271,32 @@ func envConfig(env map[string]string) *Config {
 		config.PluginCacheMayBreakDependencyLockFile = true
 	}
 
+	if envMinAge := env[minVersionAgeEnvVar]; envMinAge != "" {
+		if seconds, err := strconv.ParseInt(envMinAge, 10, 64); err == nil && seconds >= 0 {
+			config.MinimumVersionAge = time.Duration(seconds) * time.Second
+		} else if duration, err := time.ParseDuration(envMinAge); err == nil && duration >= 0 {
+			config.MinimumVersionAge = duration
+		}
+	}
+
+	if envExcludeProviders := env[minVersionAgeExcludeProvidersEnvVar]; envExcludeProviders != "" {
+		for _, item := range strings.Split(envExcludeProviders, ",") {
+			item = strings.TrimSpace(item)
+			if item != "" {
+				config.MinimumVersionAgeExcludeProviders = append(config.MinimumVersionAgeExcludeProviders, item)
+			}
+		}
+	}
+
+	if envExcludeModules := env[minVersionAgeExcludeModulesEnvVar]; envExcludeModules != "" {
+		for _, item := range strings.Split(envExcludeModules, ",") {
+			item = strings.TrimSpace(item)
+			if item != "" {
+				config.MinimumVersionAgeExcludeModules = append(config.MinimumVersionAgeExcludeModules, item)
+			}
+		}
+	}
+
 	return config
 }
 
@@ -333,6 +376,12 @@ func (c *Config) Validate() tfdiags.Diagnostics {
 		}
 	}
 
+	if c.MinimumVersionAge < 0 {
+		diags = diags.Append(
+			fmt.Errorf("minimum_version_age must not be negative"),
+		)
+	}
+
 	return diags
 }
 
@@ -368,6 +417,25 @@ func (c *Config) Merge(c2 *Config) *Config {
 		// This setting saturates to "on"; once either configuration sets it,
 		// there is no way to override it back to off again.
 		result.PluginCacheMayBreakDependencyLockFile = true
+	}
+
+	result.MinimumVersionAge = c.MinimumVersionAge
+	if result.MinimumVersionAge == 0 {
+		result.MinimumVersionAge = c2.MinimumVersionAge
+	}
+
+	if len(c.MinimumVersionAgeExcludeProviders) > 0 {
+		result.MinimumVersionAgeExcludeProviders = append(result.MinimumVersionAgeExcludeProviders, c.MinimumVersionAgeExcludeProviders...)
+	}
+	if len(c2.MinimumVersionAgeExcludeProviders) > 0 {
+		result.MinimumVersionAgeExcludeProviders = append(result.MinimumVersionAgeExcludeProviders, c2.MinimumVersionAgeExcludeProviders...)
+	}
+
+	if len(c.MinimumVersionAgeExcludeModules) > 0 {
+		result.MinimumVersionAgeExcludeModules = append(result.MinimumVersionAgeExcludeModules, c.MinimumVersionAgeExcludeModules...)
+	}
+	if len(c2.MinimumVersionAgeExcludeModules) > 0 {
+		result.MinimumVersionAgeExcludeModules = append(result.MinimumVersionAgeExcludeModules, c2.MinimumVersionAgeExcludeModules...)
 	}
 
 	if (len(c.Hosts) + len(c2.Hosts)) > 0 {

--- a/internal/command/init_run.go
+++ b/internal/command/init_run.go
@@ -34,6 +34,9 @@ func (c *InitCommand) run(initArgs *arguments.Init, view views.Init) int {
 	c.Meta.input = initArgs.InputEnabled
 	c.Meta.targetFlags = initArgs.TargetFlags
 	c.Meta.compactWarnings = initArgs.CompactWarnings
+	if initArgs.MinimumVersionAgeSet {
+		c.Meta.MinimumVersionAge = initArgs.MinimumVersionAge
+	}
 
 	// Copying the state only happens during backend migration, so setting
 	// -force-copy implies -migrate-state

--- a/internal/command/meta.go
+++ b/internal/command/meta.go
@@ -130,6 +130,18 @@ type Meta struct {
 	// longer any compelling reasons for folks to not lock their dependencies.
 	PluginCacheMayBreakDependencyLockFile bool
 
+	// MinimumVersionAge excludes newly-published provider and module versions
+	// younger than this duration during upgrade selection.
+	MinimumVersionAge time.Duration
+
+	// MinimumVersionAgeExcludeProviders contains provider source addresses that
+	// bypass minimum version age filtering.
+	MinimumVersionAgeExcludeProviders []string
+
+	// MinimumVersionAgeExcludeModules contains registry module package addresses
+	// that bypass minimum version age filtering.
+	MinimumVersionAgeExcludeModules []string
+
 	// ProviderSource allows determining the available versions of a provider
 	// and determines where a distribution package for a particular
 	// provider version can be obtained.

--- a/internal/command/meta_config.go
+++ b/internal/command/meta_config.go
@@ -25,6 +25,7 @@ import (
 	"github.com/hashicorp/terraform/internal/configs"
 	"github.com/hashicorp/terraform/internal/configs/configload"
 	"github.com/hashicorp/terraform/internal/configs/configschema"
+	"github.com/hashicorp/terraform/internal/getmodules/moduleaddrs"
 	"github.com/hashicorp/terraform/internal/initwd"
 	"github.com/hashicorp/terraform/internal/registry"
 	"github.com/hashicorp/terraform/internal/terraform"
@@ -319,7 +320,7 @@ func (m *Meta) installModules(ctx context.Context, rootDir, testsDir string, upg
 	if len(m.MinimumVersionAgeExcludeModules) > 0 {
 		excluded := make(map[addrs.ModuleRegistryPackage]struct{}, len(m.MinimumVersionAgeExcludeModules))
 		for _, raw := range m.MinimumVersionAgeExcludeModules {
-			moduleSource, err := addrs.ParseModuleSource(strings.TrimSpace(raw))
+			moduleSource, err := moduleaddrs.ParseModuleSource(strings.TrimSpace(raw))
 			if err != nil {
 				log.Printf("[WARN] Ignoring invalid minimum_version_age_exclude_modules entry %q: %s", raw, err)
 				continue

--- a/internal/command/meta_config.go
+++ b/internal/command/meta_config.go
@@ -6,9 +6,11 @@ package command
 import (
 	"context"
 	"fmt"
+	"log"
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
@@ -17,6 +19,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 
+	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/backend/backendrun"
 	"github.com/hashicorp/terraform/internal/command/arguments"
 	"github.com/hashicorp/terraform/internal/configs"
@@ -312,6 +315,24 @@ func (m *Meta) installModules(ctx context.Context, rootDir, testsDir string, upg
 		})
 	}
 	inst := initwd.NewModuleInstaller(m.modulesDir(), loader, m.registryClient(), initializer)
+	inst.SetMinimumVersionAge(m.MinimumVersionAge)
+	if len(m.MinimumVersionAgeExcludeModules) > 0 {
+		excluded := make(map[addrs.ModuleRegistryPackage]struct{}, len(m.MinimumVersionAgeExcludeModules))
+		for _, raw := range m.MinimumVersionAgeExcludeModules {
+			moduleSource, err := addrs.ParseModuleSource(strings.TrimSpace(raw))
+			if err != nil {
+				log.Printf("[WARN] Ignoring invalid minimum_version_age_exclude_modules entry %q: %s", raw, err)
+				continue
+			}
+			registrySource, ok := moduleSource.(addrs.ModuleSourceRegistry)
+			if !ok {
+				log.Printf("[WARN] Ignoring non-registry minimum_version_age_exclude_modules entry %q", raw)
+				continue
+			}
+			excluded[registrySource.Package] = struct{}{}
+		}
+		inst.SetMinimumVersionAgeExcludes(excluded)
+	}
 
 	_, moreDiags := inst.InstallModules(ctx, rootDir, testsDir, upgrade, installErrsOnly, hooks)
 	diags = diags.Append(moreDiags)

--- a/internal/command/meta_providers.go
+++ b/internal/command/meta_providers.go
@@ -79,6 +79,19 @@ func (m *Meta) providerInstallerCustomSource(source getproviders.Source) *provid
 		unmanagedProviderTypes[ty] = struct{}{}
 	}
 	inst.SetUnmanagedProviderTypes(unmanagedProviderTypes)
+	inst.SetMinimumVersionAge(m.MinimumVersionAge)
+	if len(m.MinimumVersionAgeExcludeProviders) > 0 {
+		excluded := make(map[addrs.Provider]struct{}, len(m.MinimumVersionAgeExcludeProviders))
+		for _, raw := range m.MinimumVersionAgeExcludeProviders {
+			provider, diags := addrs.ParseProviderSourceString(strings.TrimSpace(raw))
+			if diags.HasErrors() {
+				log.Printf("[WARN] Ignoring invalid minimum_version_age_exclude_providers entry %q", raw)
+				continue
+			}
+			excluded[provider] = struct{}{}
+		}
+		inst.SetMinimumVersionAgeExcludes(excluded)
+	}
 	return inst
 }
 

--- a/internal/getproviders/memoize_source.go
+++ b/internal/getproviders/memoize_source.go
@@ -6,6 +6,7 @@ package getproviders
 import (
 	"context"
 	"sync"
+	"time"
 
 	"github.com/hashicorp/terraform/internal/addrs"
 )
@@ -24,6 +25,7 @@ import (
 type MemoizeSource struct {
 	underlying        Source
 	availableVersions map[addrs.Provider]memoizeAvailableVersionsRet
+	versionTimestamps map[memoizeVersionTimestampCall]memoizeVersionTimestampRet
 	packageMetas      map[memoizePackageMetaCall]memoizePackageMetaRet
 	mu                sync.Mutex
 }
@@ -32,6 +34,16 @@ type memoizeAvailableVersionsRet struct {
 	VersionList VersionList
 	Warnings    Warnings
 	Err         error
+}
+
+type memoizeVersionTimestampCall struct {
+	Provider addrs.Provider
+	Version  Version
+}
+
+type memoizeVersionTimestampRet struct {
+	Timestamp *time.Time
+	Err       error
 }
 
 type memoizePackageMetaCall struct {
@@ -53,6 +65,7 @@ func NewMemoizeSource(underlying Source) *MemoizeSource {
 	return &MemoizeSource{
 		underlying:        underlying,
 		availableVersions: make(map[addrs.Provider]memoizeAvailableVersionsRet),
+		versionTimestamps: make(map[memoizeVersionTimestampCall]memoizeVersionTimestampRet),
 		packageMetas:      make(map[memoizePackageMetaCall]memoizePackageMetaRet),
 	}
 }
@@ -75,6 +88,35 @@ func (s *MemoizeSource) AvailableVersions(ctx context.Context, provider addrs.Pr
 		Warnings:    warnings,
 	}
 	return ret, warnings, err
+}
+
+// VersionTimestamp requests the version timestamp from the underlying source
+// and caches it before returning it, or on subsequent calls returns the result
+// directly from the cache.
+func (s *MemoizeSource) VersionTimestamp(ctx context.Context, provider addrs.Provider, version Version) (*time.Time, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	call := memoizeVersionTimestampCall{
+		Provider: provider,
+		Version:  version,
+	}
+	if existing, exists := s.versionTimestamps[call]; exists {
+		return existing.Timestamp, existing.Err
+	}
+
+	timed, ok := s.underlying.(VersionTimestampSource)
+	if !ok {
+		s.versionTimestamps[call] = memoizeVersionTimestampRet{}
+		return nil, nil
+	}
+
+	ret, err := timed.VersionTimestamp(ctx, provider, version)
+	s.versionTimestamps[call] = memoizeVersionTimestampRet{
+		Timestamp: ret,
+		Err:       err,
+	}
+	return ret, err
 }
 
 // PackageMeta requests package metadata from the underlying source and caches

--- a/internal/getproviders/multi_source.go
+++ b/internal/getproviders/multi_source.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	svchost "github.com/hashicorp/terraform-svchost"
 
@@ -111,6 +112,33 @@ func (s MultiSource) PackageMeta(ctx context.Context, provider addrs.Provider, v
 		Version:  version,
 		Platform: target,
 	}
+}
+
+// VersionTimestamp retrieves the publish timestamp for a provider version from
+// the first matching source that can report timestamps.
+func (s MultiSource) VersionTimestamp(ctx context.Context, provider addrs.Provider, version Version) (*time.Time, error) {
+	for _, selector := range s {
+		if !selector.CanHandleProvider(provider) {
+			continue
+		}
+
+		timed, ok := selector.Source.(VersionTimestampSource)
+		if !ok {
+			continue
+		}
+
+		timestamp, err := timed.VersionTimestamp(ctx, provider, version)
+		switch err.(type) {
+		case nil:
+			return timestamp, nil
+		case ErrProviderNotFound, ErrRegistryProviderNotKnown, ErrPlatformNotSupported:
+			continue
+		default:
+			return nil, err
+		}
+	}
+
+	return nil, nil
 }
 
 // MultiSourceSelector is an element of the source selection configuration on

--- a/internal/getproviders/registry_client.go
+++ b/internal/getproviders/registry_client.go
@@ -96,24 +96,24 @@ func newRegistryClient(baseURL *url.URL, creds svcauth.HostCredentials) *registr
 // 404 Not Found to indicate that the namespace or provider type are not known,
 // ErrUnauthorized if the registry responds with 401 or 403 status codes, or
 // ErrQueryFailed for any other protocol or operational problem.
-func (c *registryClient) ProviderVersions(ctx context.Context, addr addrs.Provider) (map[string][]string, []string, error) {
+func (c *registryClient) ProviderVersions(ctx context.Context, addr addrs.Provider) (map[string][]string, map[string]*time.Time, []string, error) {
 	endpointPath, err := url.Parse(path.Join(addr.Namespace, addr.Type, "versions"))
 	if err != nil {
 		// Should never happen because we're constructing this from
 		// already-validated components.
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 	endpointURL := c.baseURL.ResolveReference(endpointPath)
 	req, err := retryablehttp.NewRequest("GET", endpointURL.String(), nil)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 	req = req.WithContext(ctx)
 	c.addHeadersToRequest(req.Request)
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
-		return nil, nil, c.errQueryFailed(addr, err)
+		return nil, nil, nil, c.errQueryFailed(addr, err)
 	}
 	defer resp.Body.Close()
 
@@ -121,13 +121,13 @@ func (c *registryClient) ProviderVersions(ctx context.Context, addr addrs.Provid
 	case http.StatusOK:
 		// Great!
 	case http.StatusNotFound:
-		return nil, nil, ErrRegistryProviderNotKnown{
+		return nil, nil, nil, ErrRegistryProviderNotKnown{
 			Provider: addr,
 		}
 	case http.StatusUnauthorized, http.StatusForbidden:
-		return nil, nil, c.errUnauthorized(addr.Hostname)
+		return nil, nil, nil, c.errUnauthorized(addr.Hostname)
 	default:
-		return nil, nil, c.errQueryFailed(addr, errors.New(resp.Status))
+		return nil, nil, nil, c.errQueryFailed(addr, errors.New(resp.Status))
 	}
 
 	// We ignore the platforms portion of the response body, because the
@@ -135,8 +135,9 @@ func (c *registryClient) ProviderVersions(ctx context.Context, addr addrs.Provid
 	// versions' metadata.
 	type ResponseBody struct {
 		Versions []struct {
-			Version   string   `json:"version"`
-			Protocols []string `json:"protocols"`
+			Version     string     `json:"version"`
+			Protocols   []string   `json:"protocols"`
+			PublishedAt *time.Time `json:"published_at,omitempty"`
 		} `json:"versions"`
 		Warnings []string `json:"warnings"`
 	}
@@ -144,19 +145,21 @@ func (c *registryClient) ProviderVersions(ctx context.Context, addr addrs.Provid
 
 	dec := json.NewDecoder(resp.Body)
 	if err := dec.Decode(&body); err != nil {
-		return nil, nil, c.errQueryFailed(addr, err)
+		return nil, nil, nil, c.errQueryFailed(addr, err)
 	}
 
 	if len(body.Versions) == 0 {
-		return nil, body.Warnings, nil
+		return nil, nil, body.Warnings, nil
 	}
 
-	ret := make(map[string][]string, len(body.Versions))
+	protocols := make(map[string][]string, len(body.Versions))
+	timestamps := make(map[string]*time.Time, len(body.Versions))
 	for _, v := range body.Versions {
-		ret[v.Version] = v.Protocols
+		protocols[v.Version] = v.Protocols
+		timestamps[v.Version] = v.PublishedAt // nil if not provided by registry
 	}
 
-	return ret, body.Warnings, nil
+	return protocols, timestamps, body.Warnings, nil
 }
 
 // PackageMeta returns metadata about a distribution package for a provider.
@@ -366,7 +369,7 @@ func (c *registryClient) PackageMeta(ctx context.Context, provider addrs.Provide
 // findClosestProtocolCompatibleVersion searches for the provider version with the closest protocol match.
 func (c *registryClient) findClosestProtocolCompatibleVersion(ctx context.Context, provider addrs.Provider, version Version) (Version, error) {
 	var match Version
-	available, _, err := c.ProviderVersions(ctx, provider)
+	available, _, _, err := c.ProviderVersions(ctx, provider)
 	if err != nil {
 		return UnspecifiedVersion, err
 	}

--- a/internal/getproviders/registry_client_test.go
+++ b/internal/getproviders/registry_client_test.go
@@ -352,7 +352,7 @@ func TestProviderVersions(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			gotVersions, _, err := client.ProviderVersions(context.Background(), test.provider)
+			gotVersions, _, _, err := client.ProviderVersions(context.Background(), test.provider)
 
 			if err != nil {
 				if test.wantErr == "" {

--- a/internal/getproviders/registry_source.go
+++ b/internal/getproviders/registry_source.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"time"
 
 	svchost "github.com/hashicorp/terraform-svchost"
 	disco "github.com/hashicorp/terraform-svchost/disco"
@@ -43,7 +44,7 @@ func (s *RegistrySource) AvailableVersions(ctx context.Context, provider addrs.P
 		return nil, nil, err
 	}
 
-	versionsResponse, warnings, err := client.ProviderVersions(ctx, provider)
+	versionsResponse, _, warnings, err := client.ProviderVersions(ctx, provider)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -76,6 +77,22 @@ func (s *RegistrySource) AvailableVersions(ctx context.Context, provider addrs.P
 	}
 	ret.Sort() // lowest precedence first, preserving order when equal precedence
 	return ret, warnings, nil
+}
+
+// VersionTimestamp returns the publish timestamp for a provider version, if
+// the underlying registry reports it.
+func (s *RegistrySource) VersionTimestamp(ctx context.Context, provider addrs.Provider, version Version) (*time.Time, error) {
+	client, err := s.registryClient(provider.Hostname)
+	if err != nil {
+		return nil, err
+	}
+
+	_, timestamps, _, err := client.ProviderVersions(ctx, provider)
+	if err != nil {
+		return nil, err
+	}
+
+	return timestamps[version.String()], nil
 }
 
 // PackageMeta returns metadata about the location and capabilities of

--- a/internal/getproviders/source.go
+++ b/internal/getproviders/source.go
@@ -5,6 +5,7 @@ package getproviders
 
 import (
 	"context"
+	"time"
 
 	"github.com/hashicorp/terraform/internal/addrs"
 )
@@ -15,4 +16,10 @@ type Source interface {
 	AvailableVersions(ctx context.Context, provider addrs.Provider) (VersionList, Warnings, error)
 	PackageMeta(ctx context.Context, provider addrs.Provider, version Version, target Platform) (PackageMeta, error)
 	ForDisplay(provider addrs.Provider) string
+}
+
+// VersionTimestampSource is an optional extension for Source implementations
+// that can report publish timestamps for provider versions.
+type VersionTimestampSource interface {
+	VersionTimestamp(ctx context.Context, provider addrs.Provider, version Version) (*time.Time, error)
 }

--- a/internal/initwd/module_install.go
+++ b/internal/initwd/module_install.go
@@ -12,6 +12,7 @@ import (
 	"path"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/apparentlymart/go-versions/versions"
 	version "github.com/hashicorp/go-version"
@@ -37,6 +38,9 @@ type ModuleInstaller struct {
 	loader  *configload.Loader
 	reg     *registry.Client
 
+	minVersionAge         time.Duration
+	minVersionAgeExcludes map[addrs.ModuleRegistryPackage]struct{}
+
 	// The keys in moduleVersions are resolved and trimmed registry source
 	// addresses and the values are the registry response.
 	registryPackageVersions map[addrs.ModuleRegistryPackage]*response.ModuleVersions
@@ -58,10 +62,53 @@ func NewModuleInstaller(modsDir string, loader *configload.Loader, reg *registry
 		modsDir:                 modsDir,
 		loader:                  loader,
 		reg:                     reg,
+		minVersionAgeExcludes:   make(map[addrs.ModuleRegistryPackage]struct{}),
 		registryPackageVersions: make(map[addrs.ModuleRegistryPackage]*response.ModuleVersions),
 		registryPackageSources:  make(map[moduleVersion]addrs.ModuleSourceRemote),
 		initializer:             initializer,
 	}
+}
+
+func moduleConstraintIsExact(raw string) bool {
+	constraints := strings.Split(raw, ",")
+	if len(constraints) != 1 {
+		return false
+	}
+
+	constraint := strings.TrimSpace(constraints[0])
+	if constraint == "" {
+		return false
+	}
+
+	if strings.HasPrefix(constraint, "=") {
+		constraint = strings.TrimSpace(strings.TrimPrefix(constraint, "="))
+	}
+
+	if constraint == "" {
+		return false
+	}
+
+	operators := []string{"~>", ">=", "<=", "!=", ">", "<"}
+	for _, op := range operators {
+		if strings.Contains(constraint, op) {
+			return false
+		}
+	}
+
+	_, err := version.NewVersion(constraint)
+	return err == nil
+}
+
+// SetMinimumVersionAge configures a minimum publish age required for module
+// versions to be considered during installation.
+func (i *ModuleInstaller) SetMinimumVersionAge(age time.Duration) {
+	i.minVersionAge = age
+}
+
+// SetMinimumVersionAgeExcludes configures module packages that should bypass
+// minimum publish age filtering.
+func (i *ModuleInstaller) SetMinimumVersionAgeExcludes(modules map[addrs.ModuleRegistryPackage]struct{}) {
+	i.minVersionAgeExcludes = modules
 }
 
 // InstallModules analyses the root module in the given directory and installs
@@ -564,6 +611,16 @@ func (i *ModuleInstaller) installRegistryModule(ctx context.Context, req *config
 		}
 
 		if req.VersionConstraint.Required.Check(v) {
+			if i.minVersionAge > 0 {
+				if _, excluded := i.minVersionAgeExcludes[packageAddr]; !excluded {
+					if mv.PublishedAt != nil && !moduleConstraintIsExact(req.VersionConstraint.Required.String()) {
+						minTimestamp := time.Now().Add(-i.minVersionAge)
+						if mv.PublishedAt.After(minTimestamp) {
+							continue
+						}
+					}
+				}
+			}
 			if latestMatch == nil || v.GreaterThan(latestMatch) {
 				latestMatch = v
 			}

--- a/internal/providercache/installer.go
+++ b/internal/providercache/installer.go
@@ -182,6 +182,37 @@ func (i *Installer) SetMinimumVersionAgeExcludes(providers map[addrs.Provider]st
 	i.minVersionAgeExcludes = providers
 }
 
+func providerConstraintIsExact(vc getproviders.VersionConstraints) bool {
+	raw := getproviders.VersionConstraintsString(vc)
+	constraints := strings.Split(raw, ",")
+	if len(constraints) != 1 {
+		return false
+	}
+
+	constraint := strings.TrimSpace(constraints[0])
+	if constraint == "" {
+		return false
+	}
+
+	if strings.HasPrefix(constraint, "=") {
+		constraint = strings.TrimSpace(strings.TrimPrefix(constraint, "="))
+	}
+
+	if constraint == "" {
+		return false
+	}
+
+	operators := []string{"~>", ">=", "<=", "!=", ">", "<"}
+	for _, op := range operators {
+		if strings.Contains(constraint, op) {
+			return false
+		}
+	}
+
+	_, err := getproviders.ParseVersion(constraint)
+	return err == nil
+}
+
 // EnsureProviderVersions compares the given provider requirements with what
 // is already available in the installer's target directory and then takes
 // appropriate installation actions to ensure that suitable packages
@@ -325,31 +356,37 @@ NeedProvider:
 				cb(provider, warnings)
 			}
 		}
-		available.Sort()                                                      // put the versions in increasing order of precedence
+		available.Sort() // put the versions in increasing order of precedence
+		applyMinVersionAge := i.minVersionAge > 0
+		if applyMinVersionAge {
+			if _, excluded := i.minVersionAgeExcludes[provider]; excluded {
+				applyMinVersionAge = false
+			} else if providerConstraintIsExact(reqs[provider]) {
+				applyMinVersionAge = false
+			}
+		}
 		for versionIdx := len(available) - 1; versionIdx >= 0; versionIdx-- { // walk backwards to consider newer versions first
 			candidate := available[versionIdx]
 			if !acceptableVersions.Has(candidate) {
 				continue
 			}
 
-			if i.minVersionAge > 0 {
-				if _, excluded := i.minVersionAgeExcludes[provider]; !excluded {
-					timed, ok := i.source.(getproviders.VersionTimestampSource)
-					if ok {
-						timestamp, err := timed.VersionTimestamp(ctx, provider, candidate)
-						if err != nil {
-							err = fmt.Errorf("failed to query publish timestamp for %s %s: %w", provider, candidate, err)
-							errs[provider] = err
-							if cb := evts.QueryPackagesFailure; cb != nil {
-								cb(provider, err)
-							}
-							continue NeedProvider
+			if applyMinVersionAge {
+				timed, ok := i.source.(getproviders.VersionTimestampSource)
+				if ok {
+					timestamp, err := timed.VersionTimestamp(ctx, provider, candidate)
+					if err != nil {
+						err = fmt.Errorf("failed to query publish timestamp for %s %s: %w", provider, candidate, err)
+						errs[provider] = err
+						if cb := evts.QueryPackagesFailure; cb != nil {
+							cb(provider, err)
 						}
-						if timestamp != nil {
-							minTimestamp := time.Now().Add(-i.minVersionAge)
-							if timestamp.After(minTimestamp) {
-								continue
-							}
+						continue NeedProvider
+					}
+					if timestamp != nil {
+						minTimestamp := time.Now().Add(-i.minVersionAge)
+						if timestamp.After(minTimestamp) {
+							continue
 						}
 					}
 				}

--- a/internal/providercache/installer.go
+++ b/internal/providercache/installer.go
@@ -10,6 +10,7 @@ import (
 	"slices"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/apparentlymart/go-versions/versions"
 
@@ -58,6 +59,14 @@ type Installer struct {
 	// lifecycle for, and therefore does not need to worry about the
 	// installation of.
 	unmanagedProviderTypes map[addrs.Provider]struct{}
+
+	// minVersionAge, when non-zero, excludes provider versions published more
+	// recently than now-minVersionAge during version selection.
+	minVersionAge time.Duration
+
+	// minVersionAgeExcludes identifies providers that should bypass
+	// minVersionAge filtering.
+	minVersionAgeExcludes map[addrs.Provider]struct{}
 }
 
 // NewInstaller constructs and returns a new installer with the given target
@@ -159,6 +168,18 @@ func (i *Installer) SetBuiltInProviderTypes(types []string) {
 // or versioning of these binaries.
 func (i *Installer) SetUnmanagedProviderTypes(types map[addrs.Provider]struct{}) {
 	i.unmanagedProviderTypes = types
+}
+
+// SetMinimumVersionAge configures a minimum publish age required for provider
+// versions to be considered during installation.
+func (i *Installer) SetMinimumVersionAge(age time.Duration) {
+	i.minVersionAge = age
+}
+
+// SetMinimumVersionAgeExcludes configures providers that should bypass the
+// minimum publish age filter.
+func (i *Installer) SetMinimumVersionAgeExcludes(providers map[addrs.Provider]struct{}) {
+	i.minVersionAgeExcludes = providers
 }
 
 // EnsureProviderVersions compares the given provider requirements with what
@@ -304,15 +325,41 @@ NeedProvider:
 				cb(provider, warnings)
 			}
 		}
-		available.Sort()                           // put the versions in increasing order of precedence
-		for i := len(available) - 1; i >= 0; i-- { // walk backwards to consider newer versions first
-			if acceptableVersions.Has(available[i]) {
-				need[provider] = available[i]
-				if cb := evts.QueryPackagesSuccess; cb != nil {
-					cb(provider, available[i])
-				}
-				continue NeedProvider
+		available.Sort()                                                      // put the versions in increasing order of precedence
+		for versionIdx := len(available) - 1; versionIdx >= 0; versionIdx-- { // walk backwards to consider newer versions first
+			candidate := available[versionIdx]
+			if !acceptableVersions.Has(candidate) {
+				continue
 			}
+
+			if i.minVersionAge > 0 {
+				if _, excluded := i.minVersionAgeExcludes[provider]; !excluded {
+					timed, ok := i.source.(getproviders.VersionTimestampSource)
+					if ok {
+						timestamp, err := timed.VersionTimestamp(ctx, provider, candidate)
+						if err != nil {
+							err = fmt.Errorf("failed to query publish timestamp for %s %s: %w", provider, candidate, err)
+							errs[provider] = err
+							if cb := evts.QueryPackagesFailure; cb != nil {
+								cb(provider, err)
+							}
+							continue NeedProvider
+						}
+						if timestamp != nil {
+							minTimestamp := time.Now().Add(-i.minVersionAge)
+							if timestamp.After(minTimestamp) {
+								continue
+							}
+						}
+					}
+				}
+			}
+
+			need[provider] = candidate
+			if cb := evts.QueryPackagesSuccess; cb != nil {
+				cb(provider, candidate)
+			}
+			continue NeedProvider
 		}
 		// If we get here then the source has no packages that meet the given
 		// version constraint, which we model as a query error.

--- a/internal/providercache/installer_test.go
+++ b/internal/providercache/installer_test.go
@@ -14,6 +14,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/apparentlymart/go-versions/versions"
 	"github.com/apparentlymart/go-versions/versions/constraints"
@@ -2599,6 +2600,120 @@ func TestEnsureProviderVersions_protocol_errors(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestEnsureProviderVersions_minimumVersionAge_ExactPinsBypassFilter(t *testing.T) {
+	provider := addrs.MustParseProviderSourceString("registry.terraform.io/hashicorp/test")
+	platform := getproviders.CurrentPlatform
+	protocols := getproviders.VersionList{getproviders.MustParseVersion("5.0")}
+
+	pkgOld, closeOld, err := getproviders.FakeInstallablePackageMeta(provider, getproviders.MustParseVersion("1.2.2"), protocols, platform, "")
+	if err != nil {
+		t.Fatalf("failed to create old provider package: %s", err)
+	}
+	defer closeOld()
+
+	pkgNew, closeNew, err := getproviders.FakeInstallablePackageMeta(provider, getproviders.MustParseVersion("1.2.3"), protocols, platform, "")
+	if err != nil {
+		t.Fatalf("failed to create new provider package: %s", err)
+	}
+	defer closeNew()
+
+	now := time.Now()
+	stampSource := &testTimestampedSource{
+		Source: getproviders.NewMockSource([]getproviders.PackageMeta{pkgOld, pkgNew}, nil),
+		timestamps: map[addrs.Provider]map[getproviders.Version]*time.Time{
+			provider: {
+				pkgOld.Version: ptrTime(now.Add(-48 * time.Hour)),
+				pkgNew.Version: ptrTime(now.Add(-2 * time.Hour)),
+			},
+		},
+	}
+
+	targetDir := NewDir(t.TempDir())
+	inst := NewInstaller(targetDir, stampSource)
+	inst.SetMinimumVersionAge(24 * time.Hour)
+
+	reqs := getproviders.Requirements{provider: getproviders.MustParseVersionConstraints("1.2.3")}
+	newLocks, err := inst.EnsureProviderVersions(context.Background(), depsfile.NewLocks(), reqs, InstallUpgrades)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	got := newLocks.Provider(provider)
+	if got == nil {
+		t.Fatalf("missing lock entry for %s", provider)
+	}
+	if got.Version() != getproviders.MustParseVersion("1.2.3") {
+		t.Fatalf("wrong selected version: got %s, want 1.2.3", got.Version())
+	}
+}
+
+func TestEnsureProviderVersions_minimumVersionAge_RangedConstraintsFilterNewer(t *testing.T) {
+	provider := addrs.MustParseProviderSourceString("registry.terraform.io/hashicorp/test")
+	platform := getproviders.CurrentPlatform
+	protocols := getproviders.VersionList{getproviders.MustParseVersion("5.0")}
+
+	pkgOld, closeOld, err := getproviders.FakeInstallablePackageMeta(provider, getproviders.MustParseVersion("1.2.2"), protocols, platform, "")
+	if err != nil {
+		t.Fatalf("failed to create old provider package: %s", err)
+	}
+	defer closeOld()
+
+	pkgNew, closeNew, err := getproviders.FakeInstallablePackageMeta(provider, getproviders.MustParseVersion("1.2.3"), protocols, platform, "")
+	if err != nil {
+		t.Fatalf("failed to create new provider package: %s", err)
+	}
+	defer closeNew()
+
+	now := time.Now()
+	stampSource := &testTimestampedSource{
+		Source: getproviders.NewMockSource([]getproviders.PackageMeta{pkgOld, pkgNew}, nil),
+		timestamps: map[addrs.Provider]map[getproviders.Version]*time.Time{
+			provider: {
+				pkgOld.Version: ptrTime(now.Add(-48 * time.Hour)),
+				pkgNew.Version: ptrTime(now.Add(-2 * time.Hour)),
+			},
+		},
+	}
+
+	targetDir := NewDir(t.TempDir())
+	inst := NewInstaller(targetDir, stampSource)
+	inst.SetMinimumVersionAge(24 * time.Hour)
+
+	reqs := getproviders.Requirements{provider: getproviders.MustParseVersionConstraints("~> 1.2")}
+	newLocks, err := inst.EnsureProviderVersions(context.Background(), depsfile.NewLocks(), reqs, InstallUpgrades)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	got := newLocks.Provider(provider)
+	if got == nil {
+		t.Fatalf("missing lock entry for %s", provider)
+	}
+	if got.Version() != getproviders.MustParseVersion("1.2.2") {
+		t.Fatalf("wrong selected version: got %s, want 1.2.2", got.Version())
+	}
+}
+
+type testTimestampedSource struct {
+	getproviders.Source
+	timestamps map[addrs.Provider]map[getproviders.Version]*time.Time
+}
+
+var _ getproviders.VersionTimestampSource = (*testTimestampedSource)(nil)
+
+func (s *testTimestampedSource) VersionTimestamp(ctx context.Context, provider addrs.Provider, version getproviders.Version) (*time.Time, error) {
+	if byVersion, ok := s.timestamps[provider]; ok {
+		if timestamp, ok := byVersion[version]; ok {
+			return timestamp, nil
+		}
+	}
+	return nil, nil
+}
+
+func ptrTime(v time.Time) *time.Time {
+	return &v
 }
 
 // testServices starts up a local HTTP server running a fake provider registry

--- a/internal/registry/response/module_versions.go
+++ b/internal/registry/response/module_versions.go
@@ -3,6 +3,8 @@
 
 package response
 
+import "time"
+
 // ModuleVersions is the response format that contains all metadata about module
 // versions needed for terraform CLI to resolve version constraints. See RFC
 // TF-042 for details on this format.
@@ -20,9 +22,10 @@ type ModuleProviderVersions struct {
 // ModuleVersion is the output metadata for a given version needed by CLI to
 // resolve candidate versions to satisfy requirements.
 type ModuleVersion struct {
-	Version    string              `json:"version"`
-	Root       VersionSubmodule    `json:"root"`
-	Submodules []*VersionSubmodule `json:"submodules"`
+	Version     string              `json:"version"`
+	PublishedAt *time.Time          `json:"published_at,omitempty"`
+	Root        VersionSubmodule    `json:"root"`
+	Submodules  []*VersionSubmodule `json:"submodules"`
 }
 
 // VersionSubmodule is the output metadata for a submodule within a given


### PR DESCRIPTION
 #38304 (issue number)

Use Cases
This would match the emerging consensus in the industry that upgrading to very recent releases poses an increasing risk of supply-chain attacks. Having a cooldown / minimum age period would give the community time to detect such attacks. Terraform is a tempting target since it is typically run with high-privilege credentials.

Proposal
Add an option (via the usual CLI / config file / environmental variables) to set a minimum age to consider when evaluating module versions (e.g. “Do not install anything released in the last 7 days”). When running terraform init --upgrade the solver can ignore versions which were published after the cutoff date.

To allow high-priority updates or safe sources, it would be useful to implement an exclude mechanism either by disabling this feature for a single provider or module such as a trusted internal publisher or to define the logic such that it only applies when attempting to upgrade the pinned versions but never prevents a newer version when explicitly pinned in the provider / module version (e.g. version = "1.2.3" does not have the check applied but version = "~> 1.2" would treat yesterday's 1.2.3 as if it was never published and use last week's 1.2.2).

References
https://docs.astral.sh/uv/concepts/resolution/#dependency-cooldowns
https://pnpm.io/settings#minimumreleaseage
https://docs.npmjs.com/cli/v11/commands/npm-update#min-release-age
https://github.com/rust-lang/cargo/issues/15973
https://docs.renovatebot.com/key-concepts/minimum-release-age/

## Target Release
1.16.x

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.16.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

No explicit changes to security controls. This change modifies version selection behavior during provider/module resolution by introducing a minimum release age filter and optional exclusions, but it does not add or alter access controls, encryption, or logging mechanisms.

## CHANGELOG entry

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).


 [ ] This change is user-facing and I added a changelog entry.

