### PR TITLE
refactoring GraphNodeProviderConsumer

### DIFF
--- a/internal/terraform/node_action_abstract.go
+++ b/internal/terraform/node_action_abstract.go
@@ -86,26 +86,28 @@ func (n *NodeAbstractAction) AttachActionSchema(schema *providers.ActionSchema) 
 	n.Schema = schema
 }
 
-func (n *NodeAbstractAction) ProvidedBy() (addrs.ProviderConfig, bool) {
+func (n *NodeAbstractAction) Provider() ProviderRef {
 	// If the resolvedProvider is set, use that
 	if n.ResolvedProvider.Provider.Type != "" {
-		return n.ResolvedProvider, true
+		ref := ProviderRef{
+			addr:     n.ResolvedProvider,
+			resolved: true,
+		}
+		return ref
 	}
 
-	// otherwise refer back to the config
-	relAddr := n.Config.ProviderConfigAddr()
-	return addrs.LocalProviderConfig{
-		LocalName: relAddr.LocalName,
-		Alias:     relAddr.Alias,
-	}, false
-}
-
-func (n *NodeAbstractAction) Provider() addrs.Provider {
+	var addr addrs.AbsProviderConfig
 	if n.Config.Provider.Type != "" {
-		return n.Config.Provider
+		addr.Provider = n.Config.Provider
+	} else {
+		addr.Provider = addrs.ImpliedProviderForUnqualifiedType(n.Addr.Action.ImpliedProvider())
 	}
 
-	return addrs.ImpliedProviderForUnqualifiedType(n.Addr.Action.ImpliedProvider())
+	addr.Alias = n.Config.ProviderConfigAddr().Alias
+	addr.Module = n.ModulePath()
+	return ProviderRef{
+		addr: addr,
+	}
 }
 
 func (n *NodeAbstractAction) SetProvider(p addrs.AbsProviderConfig) {

--- a/internal/terraform/node_action_invoke.go
+++ b/internal/terraform/node_action_invoke.go
@@ -29,22 +29,22 @@ type nodeActionInvokeExpand struct {
 	resolvedProvider addrs.AbsProviderConfig // set during the graph walk
 }
 
-func (n *nodeActionInvokeExpand) ProvidedBy() (addr addrs.ProviderConfig, exact bool) {
+func (n *nodeActionInvokeExpand) Provider() ProviderRef {
 	// Once the provider is fully resolved, we can return the known value.
 	if n.resolvedProvider.Provider.Type != "" {
-		return n.resolvedProvider, true
+		return ProviderRef{
+			addr:     n.resolvedProvider,
+			resolved: true,
+		}
 	}
 
-	// Since we always have a config, we can use it
-	relAddr := n.Config.ProviderConfigAddr()
-	return addrs.LocalProviderConfig{
-		LocalName: relAddr.LocalName,
-		Alias:     relAddr.Alias,
-	}, false
-}
+	addr := addrs.AbsProviderConfig{
+		Provider: n.Config.Provider,
+		Alias:    n.Config.ProviderConfigAddr().Alias,
+		Module:   n.ModulePath(),
+	}
 
-func (n *nodeActionInvokeExpand) Provider() (provider addrs.Provider) {
-	return n.Config.Provider
+	return ProviderRef{addr: addr}
 }
 
 func (n *nodeActionInvokeExpand) SetProvider(p addrs.AbsProviderConfig) {

--- a/internal/terraform/node_action_trigger_abstract.go
+++ b/internal/terraform/node_action_trigger_abstract.go
@@ -79,21 +79,21 @@ func (n *nodeAbstractActionTrigger) References() []*addrs.Reference {
 	return refs
 }
 
-func (n *nodeAbstractActionTrigger) ProvidedBy() (addr addrs.ProviderConfig, exact bool) {
+func (n *nodeAbstractActionTrigger) Provider() ProviderRef {
 	if n.resolvedProvider.Provider.Type != "" {
-		return n.resolvedProvider, true
+		return ProviderRef{
+			addr:     n.resolvedProvider,
+			resolved: true,
+		}
 	}
 
-	// Since we always have a config, we can use it
-	relAddr := n.Config.ProviderConfigAddr()
-	return addrs.LocalProviderConfig{
-		LocalName: relAddr.LocalName,
-		Alias:     relAddr.Alias,
-	}, false
-}
-
-func (n *nodeAbstractActionTrigger) Provider() (provider addrs.Provider) {
-	return n.Config.Provider
+	return ProviderRef{
+		addr: addrs.AbsProviderConfig{
+			Provider: n.Config.Provider,
+			Module:   n.ModulePath(),
+			Alias:    n.Config.ProviderConfigAddr().Alias,
+		},
+	}
 }
 
 func (n *nodeAbstractActionTrigger) SetProvider(config addrs.AbsProviderConfig) {

--- a/internal/terraform/node_action_trigger_instance_apply.go
+++ b/internal/terraform/node_action_trigger_instance_apply.go
@@ -200,13 +200,11 @@ func (n *nodeActionTriggerApplyInstance) Execute(ctx EvalContext, wo walkOperati
 	return diags
 }
 
-func (n *nodeActionTriggerApplyInstance) ProvidedBy() (addr addrs.ProviderConfig, exact bool) {
-	return n.ActionInvocation.ProviderAddr, true
-
-}
-
-func (n *nodeActionTriggerApplyInstance) Provider() (provider addrs.Provider) {
-	return n.ActionInvocation.ProviderAddr.Provider
+func (n *nodeActionTriggerApplyInstance) Provider() ProviderRef {
+	return ProviderRef{
+		addr:     n.ActionInvocation.ProviderAddr,
+		resolved: true,
+	}
 }
 
 func (n *nodeActionTriggerApplyInstance) SetProvider(config addrs.AbsProviderConfig) {

--- a/internal/terraform/node_resource_abstract.go
+++ b/internal/terraform/node_resource_abstract.go
@@ -293,27 +293,36 @@ func (n *NodeAbstractResource) SetProvider(p addrs.AbsProviderConfig) {
 }
 
 // GraphNodeProviderConsumer
-func (n *NodeAbstractResource) ProvidedBy() (addrs.ProviderConfig, bool) {
+func (n *NodeAbstractResource) Provider() ProviderRef {
 	// Once the provider is fully resolved, we can return the known value.
 	if n.ResolvedProvider.Provider.Type != "" {
-		return n.ResolvedProvider, true
+		return ProviderRef{
+			addr:     n.ResolvedProvider,
+			resolved: true,
+		}
 	}
 
 	// If we have a config we prefer that above all else
 	if n.Config != nil {
-		relAddr := n.Config.ProviderConfigAddr()
-		return addrs.LocalProviderConfig{
-			LocalName: relAddr.LocalName,
-			Alias:     relAddr.Alias,
-		}, false
+		return ProviderRef{
+			addr: addrs.AbsProviderConfig{
+				Provider: n.Config.Provider,
+				Alias:    n.Config.ProviderConfigAddr().Alias,
+				Module:   n.ModulePath(),
+			},
+		}
 	}
 
 	// See if we have a valid provider config from the state.
 	if n.storedProviderConfig.Provider.Type != "" {
-		// An address from the state must match exactly, since we must ensure
-		// we refresh/destroy a resource with the same provider configuration
-		// that created it.
-		return n.storedProviderConfig, true
+		// An address from the state must match exactly, since we must ensure we
+		// refresh/destroy a resource with the same provider configuration that
+		// created it. Since we have no config, and no ResolvedProvider, the
+		// provider from the state counts as it being fully resolved.
+		return ProviderRef{
+			addr:     n.storedProviderConfig,
+			resolved: true,
+		}
 	}
 
 	// We might have an import target that is providing a specific provider,
@@ -324,39 +333,26 @@ func (n *NodeAbstractResource) ProvidedBy() (addrs.ProviderConfig, bool) {
 		// of them should be. They should also all have the same provider, so it
 		// shouldn't matter which we check here, as they'll all give the same.
 		if n.importTargets[0].Config != nil && n.importTargets[0].Config.ProviderConfigRef != nil {
-			return addrs.LocalProviderConfig{
-				LocalName: n.importTargets[0].Config.ProviderConfigRef.Name,
-				Alias:     n.importTargets[0].Config.ProviderConfigRef.Alias,
-			}, false
+			ref := ProviderRef{
+				addr: addrs.AbsProviderConfig{
+					Provider: n.importTargets[0].Config.Provider,
+					Alias:    n.importTargets[0].Config.ProviderConfigRef.Alias,
+					Module:   n.ModulePath(),
+				},
+			}
+
+			ref.addr.Alias = n.importTargets[0].Config.ProviderConfigRef.Alias
+			return ref
 		}
 	}
 
 	// No provider configuration found; return a default address
-	return addrs.AbsProviderConfig{
-		Provider: n.Provider(),
-		Module:   n.ModulePath(),
-	}, false
-}
-
-// GraphNodeProviderConsumer
-func (n *NodeAbstractResource) Provider() addrs.Provider {
-	if n.Config != nil {
-		return n.Config.Provider
+	return ProviderRef{
+		addr: addrs.AbsProviderConfig{
+			Provider: addrs.ImpliedProviderForUnqualifiedType(n.Addr.Resource.ImpliedProvider()),
+			Module:   n.ModulePath(),
+		},
 	}
-	if n.storedProviderConfig.Provider.Type != "" {
-		return n.storedProviderConfig.Provider
-	}
-
-	if len(n.importTargets) > 0 {
-		// The import targets should either all be defined via config or none
-		// of them should be. They should also all have the same provider, so it
-		// shouldn't matter which we check here, as they'll all give the same.
-		if n.importTargets[0].Config != nil {
-			return n.importTargets[0].Config.Provider
-		}
-	}
-
-	return addrs.ImpliedProviderForUnqualifiedType(n.Addr.Resource.ImpliedProvider())
 }
 
 // GraphNodeProvisionerConsumer

--- a/internal/terraform/node_resource_abstract_instance_test.go
+++ b/internal/terraform/node_resource_abstract_instance_test.go
@@ -141,8 +141,8 @@ func TestNodeAbstractResourceInstanceProvider(t *testing.T) {
 				},
 			}
 			got := node.Provider()
-			if got != test.Want {
-				t.Errorf("wrong result\naddr:  %s\nconfig: %#v\ngot:   %s\nwant:  %s", test.Addr, test.Config, got, test.Want)
+			if got.FQN() != test.Want {
+				t.Errorf("wrong result\naddr:  %s\nconfig: %#v\ngot:   %s\nwant:  %s", test.Addr, test.Config, got.FQN(), test.Want)
 			}
 		})
 	}

--- a/internal/terraform/node_resource_abstract_test.go
+++ b/internal/terraform/node_resource_abstract_test.go
@@ -108,8 +108,8 @@ func TestNodeAbstractResourceProvider(t *testing.T) {
 				Config: test.Config,
 			}
 			got := node.Provider()
-			if got != test.Want {
-				t.Errorf("wrong result\naddr:  %s\nconfig: %#v\ngot:   %s\nwant:  %s", test.Addr, test.Config, got, test.Want)
+			if got.FQN() != test.Want {
+				t.Errorf("wrong result\naddr:  %s\nconfig: %#v\ngot:   %s\nwant:  %s", test.Addr, test.Config, got.FQN(), test.Want)
 			}
 		})
 	}
@@ -140,21 +140,6 @@ func TestNodeAbstractResourceSetProvider(t *testing.T) {
 		},
 	}
 
-	p, exact := node.ProvidedBy()
-	if exact {
-		t.Fatalf("no exact provider should be found from this confniguration, got %q\n", p)
-	}
-
-	// the implied non-exact provider should be "terraform"
-	lpc, ok := p.(addrs.LocalProviderConfig)
-	if !ok {
-		t.Fatalf("expected LocalProviderConfig, got %#v\n", p)
-	}
-
-	if lpc.LocalName != "terraform" {
-		t.Fatalf("expected non-exact provider of 'terraform', got %q", lpc.LocalName)
-	}
-
 	// now set a resolved provider for the resource
 	resolved := addrs.AbsProviderConfig{
 		Provider: addrs.Provider{
@@ -167,14 +152,9 @@ func TestNodeAbstractResourceSetProvider(t *testing.T) {
 	}
 
 	node.SetProvider(resolved)
-	p, exact = node.ProvidedBy()
-	if !exact {
-		t.Fatalf("exact provider should be found, got %q\n", p)
-	}
-
-	apc, ok := p.(addrs.AbsProviderConfig)
-	if !ok {
-		t.Fatalf("expected AbsProviderConfig, got %#v\n", p)
+	apc := node.Provider()
+	if !apc.Resolved() {
+		t.Fatalf("exact provider should be found, got %q\n", apc)
 	}
 
 	if apc.String() != resolved.String() {

--- a/internal/terraform/node_resource_destroy.go
+++ b/internal/terraform/node_resource_destroy.go
@@ -39,12 +39,14 @@ func (n *NodeDestroyResourceInstance) Name() string {
 	return n.ResourceInstanceAddr().String() + " (destroy)"
 }
 
-func (n *NodeDestroyResourceInstance) ProvidedBy() (addr addrs.ProviderConfig, exact bool) {
+func (n *NodeDestroyResourceInstance) Provider() ProviderRef {
 	if n.Addr.Resource.Resource.Mode == addrs.DataResourceMode {
 		// indicate that this node does not require a configured provider
-		return nil, true
+		p := n.NodeAbstractResourceInstance.Provider()
+		p.NoProvider = true
+		return p
 	}
-	return n.NodeAbstractResourceInstance.ProvidedBy()
+	return n.NodeAbstractResourceInstance.Provider()
 }
 
 // GraphNodeDestroyer

--- a/internal/terraform/node_resource_ephemeral.go
+++ b/internal/terraform/node_resource_ephemeral.go
@@ -237,11 +237,7 @@ func (n *nodeEphemeralResourceClose) Execute(ctx EvalContext, op walkOperation) 
 	return resources.CloseInstances(ctx.StopCtx(), n.addr)
 }
 
-func (n *nodeEphemeralResourceClose) ProvidedBy() (addrs.ProviderConfig, bool) {
-	return n.resourceNode.ProvidedBy()
-}
-
-func (n *nodeEphemeralResourceClose) Provider() addrs.Provider {
+func (n *nodeEphemeralResourceClose) Provider() ProviderRef {
 	return n.resourceNode.Provider()
 }
 

--- a/internal/terraform/node_resource_forget.go
+++ b/internal/terraform/node_resource_forget.go
@@ -38,12 +38,14 @@ func (n *NodeForgetResourceInstance) Name() string {
 	return n.ResourceInstanceAddr().String() + " (forget)"
 }
 
-func (n *NodeForgetResourceInstance) ProvidedBy() (addr addrs.ProviderConfig, exact bool) {
+func (n *NodeForgetResourceInstance) Provider() ProviderRef {
 	if n.Addr.Resource.Resource.Mode == addrs.DataResourceMode {
 		// Indicate that this node does not require a configured provider
-		return nil, true
+		p := n.NodeAbstractResourceInstance.Provider()
+		p.NoProvider = true
+		return p
 	}
-	return n.NodeAbstractResourceInstance.ProvidedBy()
+	return n.NodeAbstractResourceInstance.Provider()
 }
 
 // GraphNodeExecutable

--- a/internal/terraform/node_resource_import.go
+++ b/internal/terraform/node_resource_import.go
@@ -36,23 +36,13 @@ func (n *graphNodeImportState) Name() string {
 }
 
 // GraphNodeProviderConsumer
-func (n *graphNodeImportState) ProvidedBy() (addrs.ProviderConfig, bool) {
+func (n *graphNodeImportState) Provider() ProviderRef {
 	// We assume that n.ProviderAddr has been properly populated here.
 	// It's the responsibility of the code creating a graphNodeImportState
 	// to populate this, possibly by calling DefaultProviderConfig() on the
 	// resource address to infer an implied provider from the resource type
 	// name.
-	return n.ProviderAddr, false
-}
-
-// GraphNodeProviderConsumer
-func (n *graphNodeImportState) Provider() addrs.Provider {
-	// We assume that n.ProviderAddr has been properly populated here.
-	// It's the responsibility of the code creating a graphNodeImportState
-	// to populate this, possibly by calling DefaultProviderConfig() on the
-	// resource address to infer an implied provider from the resource type
-	// name.
-	return n.ProviderAddr.Provider
+	return ProviderRef{addr: n.ProviderAddr}
 }
 
 // GraphNodeProviderConsumer

--- a/internal/terraform/node_resource_plan_orphan.go
+++ b/internal/terraform/node_resource_plan_orphan.go
@@ -66,12 +66,14 @@ func (n *NodePlannableResourceInstanceOrphan) Execute(ctx EvalContext, op walkOp
 	}
 }
 
-func (n *NodePlannableResourceInstanceOrphan) ProvidedBy() (addr addrs.ProviderConfig, exact bool) {
+func (n *NodePlannableResourceInstanceOrphan) Provider() ProviderRef {
 	if n.Addr.Resource.Resource.Mode == addrs.DataResourceMode {
 		// indicate that this node does not require a configured provider
-		return nil, true
+		p := n.NodeAbstractResourceInstance.Provider()
+		p.NoProvider = true
+		return p
 	}
-	return n.NodeAbstractResourceInstance.ProvidedBy()
+	return n.NodeAbstractResourceInstance.Provider()
 }
 
 func (n *NodePlannableResourceInstanceOrphan) dataResourceExecute(ctx EvalContext) tfdiags.Diagnostics {

--- a/internal/terraform/transform_attach_schema.go
+++ b/internal/terraform/transform_attach_schema.go
@@ -73,7 +73,7 @@ func (t *AttachSchemaTransformer) Transform(g *Graph) error {
 			addr := tv.ResourceAddr()
 			mode := addr.Resource.Mode
 			typeName := addr.Resource.Type
-			providerFqn := tv.Provider()
+			providerFqn := tv.Provider().FQN()
 
 			schema, err := t.Plugins.ResourceTypeSchema(providerFqn, mode, typeName)
 			if err != nil {
@@ -119,7 +119,7 @@ func (t *AttachSchemaTransformer) Transform(g *Graph) error {
 
 		if tv, ok := v.(GraphNodeAttachActionSchema); ok {
 			addr := tv.ActionAddr()
-			providerFqn := tv.Provider()
+			providerFqn := tv.Provider().FQN()
 			schema, err := t.Plugins.ActionTypeSchema(providerFqn, addr.Action.Type)
 			if err != nil {
 				return fmt.Errorf("failed to read schema for %s in %s: %s", addr, providerFqn, err)

--- a/internal/terraform/transform_config.go
+++ b/internal/terraform/transform_config.go
@@ -37,10 +37,6 @@ type ConfigTransformer struct {
 	// Module is the module to add resources from.
 	Config *configs.Config
 
-	// Mode will only add resources that match the given mode
-	ModeFilter bool
-	Mode       addrs.ResourceMode
-
 	// some actions are skipped during the destroy process
 	destroy bool
 
@@ -158,11 +154,6 @@ func (t *ConfigTransformer) transformSingle(g *Graph, config *configs.Config) er
 
 	for _, r := range allResources {
 		relAddr := r.Addr()
-
-		if t.ModeFilter && relAddr.Mode != t.Mode {
-			// Skip non-matching modes
-			continue
-		}
 
 		// Verify that any actions referenced in the resource's ActionTriggers exist in this module
 		var diags tfdiags.Diagnostics

--- a/internal/terraform/transform_config_test.go
+++ b/internal/terraform/transform_config_test.go
@@ -36,26 +36,6 @@ func TestConfigTransformer(t *testing.T) {
 	}
 }
 
-func TestConfigTransformer_mode(t *testing.T) {
-	g := Graph{Path: addrs.RootModuleInstance}
-	tf := &ConfigTransformer{
-		Config:     testModule(t, "transform-config-mode-data"),
-		ModeFilter: true,
-		Mode:       addrs.DataResourceMode,
-	}
-	if err := tf.Transform(&g); err != nil {
-		t.Fatalf("err: %s", err)
-	}
-
-	actual := strings.TrimSpace(g.String())
-	expected := strings.TrimSpace(`
-data.aws_ami.foo
-`)
-	if actual != expected {
-		t.Fatalf("bad:\n\n%s", actual)
-	}
-}
-
 func TestConfigTransformer_nonUnique(t *testing.T) {
 	g := Graph{Path: addrs.RootModuleInstance}
 	g.Add(NewNodeAbstractResource(

--- a/internal/terraform/transform_destroy_edge.go
+++ b/internal/terraform/transform_destroy_edge.go
@@ -99,19 +99,7 @@ func (t *DestroyEdgeTransformer) tryInterProviderDestroyEdge(g *Graph, from, to 
 	// description of the provider being used to help determine if 2 nodes are
 	// from the same provider instance.
 	getComparableProvider := func(pc GraphNodeProviderConsumer) string {
-		ps := pc.Provider().String()
-
-		// we don't care about `exact` here, since we're only looking for any
-		// clue that the providers may differ.
-		p, _ := pc.ProvidedBy()
-		switch p := p.(type) {
-		case addrs.AbsProviderConfig:
-			ps = p.String()
-		case addrs.LocalProviderConfig:
-			ps = p.String()
-		}
-
-		return ps
+		return pc.Provider().String()
 	}
 
 	pc, ok := from.(GraphNodeProviderConsumer)

--- a/internal/terraform/transform_provider.go
+++ b/internal/terraform/transform_provider.go
@@ -62,30 +62,69 @@ type GraphNodeCloseProvider interface {
 	CloseProviderAddr() addrs.AbsProviderConfig
 }
 
-// GraphNodeProviderConsumer is an interface that nodes that require
-// a provider must implement. ProvidedBy must return the address of the provider
-// to use, which will be resolved to a configuration either in the same module
-// or in an ancestor module, with the resulting absolute address passed to
-// SetProvider.
+// GraphNodeProviderConsumer is an interface that nodes that require a provider
+// must implement. ProviderRef must contain the address of the provider to use,
+// which will be resolved to a configuration either in the same module or in an
+// ancestor module, with the resulting absolute address passed to SetProvider.
 type GraphNodeProviderConsumer interface {
 	GraphNodeModulePath
-	// ProvidedBy returns the address of the provider configuration the node
-	// refers to, if available. The following value types may be returned:
-	//
-	//   nil + exact true: the node does not require a provider
-	// * addrs.LocalProviderConfig: the provider was set in the resource config
-	// * addrs.AbsProviderConfig + exact true: the provider configuration was
-	//   taken from the instance state.
-	// * addrs.AbsProviderConfig + exact false: no config or state; the returned
-	//   value is a default provider configuration address for the resource's
-	//   Provider
-	ProvidedBy() (addr addrs.ProviderConfig, exact bool)
-
-	// Provider() returns the Provider FQN for the node.
-	Provider() (provider addrs.Provider)
+	// Provider returns the provider requested by this resource.
+	Provider() (provider ProviderRef)
 
 	// Set the resolved provider address for this resource.
 	SetProvider(addrs.AbsProviderConfig)
+}
+
+// ProviderRef stores the current known provider status for a resource
+type ProviderRef struct {
+	// addr indicates the currently known addr for this resource's provider.
+	addr addrs.AbsProviderConfig
+
+	// If resolved is true, then we are certain that the provider represents the
+	// actual provider configuration address.
+	resolved bool
+
+	// NoProvider indicates that this this resource does not need to be
+	// connected to a running provider instance.
+	NoProvider bool
+}
+
+// Return the AbsProviderConfig requested by the resource.
+//
+// If Resolved() is not true, the returned address is assumed to be in the same
+// module as the resource. This is so that the resolution algorithm can start in
+// the resource's module to look for legacy style configuration blocks within
+// modules, as it walks up towards the root.
+func (r ProviderRef) AbsProviderConfig() addrs.AbsProviderConfig {
+	return r.addr
+}
+
+// FQN is the filly qualified name for this provider type.
+func (r ProviderRef) FQN() addrs.Provider {
+	return r.addr.Provider
+}
+
+// Resolved indicated that we know the request knows the exact address of the
+// needed provider, and we cannot transfer it to an automatically inherited
+// provider config.
+func (r ProviderRef) Resolved() bool {
+	return r.resolved
+}
+
+// If Required returns false, no provider instance is needed for this resource
+// to execute, and only FQN() is known to be fully resolved.
+func (r ProviderRef) Required() bool {
+	return !r.NoProvider
+}
+
+// As string representation of the AbsProviderConfig
+func (r ProviderRef) String() string {
+	return r.addr.String()
+}
+
+// Returns the FQN string from the provider type.
+func (r ProviderRef) ForDisplay() string {
+	return r.addr.Provider.ForDisplay()
 }
 
 // ProviderTransformer is a GraphTransformer that maps resources to providers
@@ -108,62 +147,23 @@ func (t *ProviderTransformer) Transform(g *Graph) error {
 	// the next step.
 	// Our "requested" map is from graph vertices to string representations of
 	// provider config addresses (for deduping) to requests.
-	type ProviderRequest struct {
-		Addr  addrs.AbsProviderConfig
-		Exact bool // If true, inheritance from parent modules is not attempted
-	}
-	requested := map[dag.Vertex]map[string]ProviderRequest{}
+
+	requested := map[dag.Vertex]map[string]ProviderRef{}
 	needConfigured := map[string]addrs.AbsProviderConfig{}
 	for _, v := range g.Vertices() {
 		// Does the vertex _directly_ use a provider?
 		if pv, ok := v.(GraphNodeProviderConsumer); ok {
-			providerAddr, exact := pv.ProvidedBy()
-			if providerAddr == nil && exact {
+			absPc := pv.Provider()
+			if absPc.NoProvider {
 				// no provider is required
 				continue
 			}
 
-			requested[v] = make(map[string]ProviderRequest)
-
-			var absPc addrs.AbsProviderConfig
-
-			switch p := providerAddr.(type) {
-			case addrs.AbsProviderConfig:
-				// ProvidedBy() returns an AbsProviderConfig when the provider
-				// configuration is set in state, so we do not need to verify
-				// the FQN matches.
-				absPc = p
-
-				if exact {
-					log.Printf("[TRACE] ProviderTransformer: %s is provided by %s exactly", dag.VertexName(v), absPc)
-				}
-
-			case addrs.LocalProviderConfig:
-				// ProvidedBy() return a LocalProviderConfig when the resource
-				// contains a `provider` attribute
-				absPc.Provider = pv.Provider()
-				modPath := pv.ModulePath()
-				if t.Config == nil {
-					absPc.Module = modPath
-					absPc.Alias = p.Alias
-					break
-				}
-
-				absPc.Module = modPath
-				absPc.Alias = p.Alias
-
-			default:
-				// This should never happen; the case statements are meant to be exhaustive
-				panic(fmt.Sprintf("%s: provider for %s couldn't be determined", dag.VertexName(v), absPc))
-			}
-
-			requested[v][absPc.String()] = ProviderRequest{
-				Addr:  absPc,
-				Exact: exact,
-			}
+			requested[v] = make(map[string]ProviderRef)
+			requested[v][absPc.String()] = absPc
 
 			// Direct references need the provider configured as well as initialized
-			needConfigured[absPc.String()] = absPc
+			needConfigured[absPc.String()] = absPc.AbsProviderConfig()
 		}
 	}
 
@@ -173,7 +173,7 @@ func (t *ProviderTransformer) Transform(g *Graph) error {
 	m := providerVertexMap(g)
 	for v, reqs := range requested {
 		for key, req := range reqs {
-			p := req.Addr
+			p := req.AbsProviderConfig()
 			target := m[key]
 
 			_, ok := v.(GraphNodeModulePath)
@@ -189,7 +189,7 @@ func (t *ProviderTransformer) Transform(g *Graph) error {
 
 			// if we don't have a provider at this level, walk up the path looking for one,
 			// unless we were told to be exact.
-			if target == nil && !req.Exact {
+			if target == nil && !req.Resolved() {
 				for pp, ok := p.Inherited(); ok; pp, ok = pp.Inherited() {
 					key := pp.String()
 					target = m[key]
@@ -295,20 +295,15 @@ func (t *CloseProviderTransformer) Transform(g *Graph) error {
 			continue
 		}
 
-		p, exact := pc.ProvidedBy()
-		if p == nil && exact {
+		providerRef := pc.Provider()
+		if providerRef.NoProvider {
 			// this node does not require a provider
 			continue
 		}
 
-		provider, ok := p.(addrs.AbsProviderConfig)
+		closer, ok := cpm[providerRef.String()]
 		if !ok {
-			return fmt.Errorf("%s failed to return a provider reference", dag.VertexName(pc))
-		}
-
-		closer, ok := cpm[provider.String()]
-		if !ok {
-			return fmt.Errorf("no graphNodeCloseProvider for %s", provider)
+			return fmt.Errorf("no graphNodeCloseProvider for %s", providerRef)
 		}
 		g.Connect(dag.BasicEdge(closer, v))
 	}
@@ -356,7 +351,7 @@ func (t *MissingProviderTransformer) Transform(g *Graph) error {
 
 		// For our work here we actually care only about the provider type and
 		// we plan to place all default providers in the root module.
-		providerFqn := pv.Provider()
+		providerFqn := pv.Provider().FQN()
 
 		// We're going to create an implicit _default_ configuration for the
 		// referenced provider type in the _root_ module, ignoring all other


### PR DESCRIPTION
The overlapping `Provider` and `ProvidedBy` method from the `GraphNodeProviderConsumer` interface were both confusing, and impeding work around provider extensions.

Previously the `Provider` method was intended to only indicate the provider "type", which is related to, but not the same as the provider configuration being referenced by the resource. The `ProvidedBy` method was also used to obtain the provider type, along with the provider config being referenced, whether the current record was retrieved from config, or set later, and if it was fully resolved to a specific provider address. To top it off, the `ProviderConfig` interface was overloaded to indicate that a `nil` value meant that no provider was needed, and the type needed to be retrieved by the other `Provider` method.

We can combine all these behaviors into a single `Provider` method by returning all the type and resolution information at once. The new `ProviderRef` struct contains the most accurate address known by the provider, whether it has been resolved to a specific provider configuration, and whether a provider is required at all for execution.

The `addrs.ProviderConfig` interface and `addrs.LocalProviderConfig` type have been removed from core , but still remain for lower-level configuration related functionality. They may be redundant in that role too, but these types have been incorporated into the stacks and testing packages, and it's not clear yet if they still serve a useful purpose there.