### PR TITLE
meta: Avoid crash when lockfile is missing on PSS migration

### DIFF
--- a/internal/command/init_test.go
+++ b/internal/command/init_test.go
@@ -4367,6 +4367,8 @@ func TestInit_stateStore_configChanges(t *testing.T) {
 			t.Fatal("expected the default workspace to exist after migration, but it is missing")
 		}
 	})
+
+	// TODO: new test with missing provider lockfile
 }
 
 // Testing init's behaviors with `state_store` when the provider used for state storage in a previous init

--- a/internal/command/meta_backend.go
+++ b/internal/command/meta_backend.go
@@ -2596,6 +2596,10 @@ func (m *Meta) stateStoreConfigNeedsMigration(cfg *configs.StateStore, cfgState 
 	}
 
 	pLock := opts.Locks.Provider(cfg.ProviderAddr)
+	if pLock == nil {
+		log.Printf("[TRACE] stateStoreConfigNeedsMigration: no lock for provider (%s), so migration is required", cfg.ProviderAddr)
+		return true
+	}
 	pVersion, err := providerreqs.GoVersionFromVersion(pLock.Version())
 	if err != nil {
 		log.Printf("[TRACE] stateStoreConfigNeedsMigration: unable to determine provider version (%s), so migration is required", err)


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Fixes #

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.16.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [ ] This change is not user-facing.
