### PR TITLE
PSS: Remove handling of state migrations including PSS from the `init` command

### DIFF
--- a/internal/command/e2etest/primary_test.go
+++ b/internal/command/e2etest/primary_test.go
@@ -624,11 +624,13 @@ func TestPrimary_stateStore_swapProviderSupplyMode_betweenInitAndPlanApply(t *te
 		if err.Error() != "exit status 1" {
 			t.Fatalf("unexpected plan error: %s\nstderr:\n%s", err, stderr)
 		}
-		if !strings.Contains(stdout, "Warning: Provider development overrides are in effect") {
-			t.Fatalf("expected warning about provider development overrides being in effect, but it was missing from output:\n%s", stdout)
+		devOverrideMsg := "Warning: Provider development overrides are in effect"
+		if !strings.Contains(stdout, devOverrideMsg) {
+			t.Fatalf("expected output to include %q, but it was missing from output:\n%s", devOverrideMsg, stdout)
 		}
-		if !strings.Contains(stderr, "Error: State store initialization required, please run \"terraform init\"") {
-			t.Fatalf("expected error about state store initialization, but it was missing from output:\n%s", stderr)
+		initErrorMsg := "Error: State store initialization required, please run \"terraform state migrate\" or \"terraform init -reconfigure\""
+		if !strings.Contains(stderr, initErrorMsg) {
+			t.Fatalf("expected error output to include %q, but it was missing from output:\n%s", initErrorMsg, stderr)
 		}
 	})
 
@@ -951,7 +953,7 @@ func TestPrimary_stateStore_swapProviderSupplyMode_betweenSuccessiveInits(t *tes
 		if err.Error() != "exit status 1" {
 			t.Fatalf("unexpected init error: %s\nstderr:\n%s", err, stderr)
 		}
-		if !strings.Contains(stderr, "Error: State store configuration changed") {
+		if !strings.Contains(stderr, "Error: State store initialization required, please run \"terraform state migrate\" or \"terraform init -reconfigure\"") {
 			t.Fatalf("expected error about state store configuration changing, but got:\n%s", stderr)
 		}
 	})
@@ -1049,7 +1051,7 @@ func TestPrimary_stateStore_swapProviderSupplyMode_betweenSuccessiveInits(t *tes
 		if err.Error() != "exit status 1" {
 			t.Fatalf("unexpected init error: %s\nstderr:\n%s", err, stderr)
 		}
-		if !strings.Contains(stderr, "Error: State store configuration changed") {
+		if !strings.Contains(stderr, "Error: State store initialization required, please run \"terraform state migrate\" or \"terraform init -reconfigure\"") {
 			t.Fatalf("expected error about state store configuration changing, but got:\n%s", stderr)
 		}
 	})

--- a/internal/command/init_test.go
+++ b/internal/command/init_test.go
@@ -5489,9 +5489,15 @@ func TestInit_cloud_to_stateStore(t *testing.T) {
 			t.Fatalf("expected migration from cloud to fail: \n%s", testOutput.Stdout())
 		}
 		log.Printf("[TRACE] %s: second init with state store complete", t.Name())
-		expectedMsg := "Migrating state from HCP Terraform or Terraform Enterprise to another backend is not \nyet implemented."
-		if !strings.Contains(testOutput.Stderr(), expectedMsg) {
-			t.Fatalf("expected error message %q not found: \n%s", expectedMsg, testOutput.Stderr())
+		expectedMsgs := []string{
+			"Error: Backend initialization required, please run \"terraform state migrate\" or \"terraform init -reconfigure\"",
+			"Reason: Migrating from backend \"cloud\" to state store \"test_store\" in provider test (\"registry.terraform.io/hashicorp/test\")",
+		}
+		output := cleanString(testOutput.Stderr())
+		for _, expectedMsg := range expectedMsgs {
+			if !strings.Contains(output, expectedMsg) {
+				t.Fatalf("expected error message %q not found: \n%s", expectedMsg, output)
+			}
 		}
 	}
 }

--- a/internal/command/init_test.go
+++ b/internal/command/init_test.go
@@ -4461,7 +4461,7 @@ func TestInit_stateStore_backendConfigFlagNoMigrate(t *testing.T) {
 	var originalStateStoreConfigHash uint64
 
 	{
-		log.Printf("[TRACE] TestInit_stateStore_unset: beginning first init")
+		log.Printf("[TRACE] TestInit_stateStore_backendConfigFlagNoMigrate: beginning first init")
 
 		ui := cli.NewMockUi()
 		view, done := testView(t)
@@ -4488,7 +4488,7 @@ func TestInit_stateStore_backendConfigFlagNoMigrate(t *testing.T) {
 		if code != 0 {
 			t.Fatalf("bad: \n%s", testOutput.All())
 		}
-		log.Printf("[TRACE] TestInit_stateStore_unset: first init complete")
+		log.Printf("[TRACE] TestInit_stateStore_backendConfigFlagNoMigrate: first init complete")
 		t.Logf("First run output:\n%s", testOutput.Stdout())
 		t.Logf("First run errors:\n%s", testOutput.Stderr())
 
@@ -4501,7 +4501,7 @@ func TestInit_stateStore_backendConfigFlagNoMigrate(t *testing.T) {
 	}
 
 	{
-		log.Printf("[TRACE] TestInit_stateStore_unset: beginning second init with changed config but compensating CLI flags")
+		log.Printf("[TRACE] TestInit_stateStore_backendConfigFlagNoMigrate: beginning second init with changed config but compensating CLI flags")
 
 		// Remove `value` attribute from config
 		cfg := `terraform {
@@ -4539,7 +4539,7 @@ func TestInit_stateStore_backendConfigFlagNoMigrate(t *testing.T) {
 		if code != 0 {
 			t.Fatalf("Terraform either experienced an unexpected error, or suggested a state migration when this test scenario should not include migrations: \n%s", testOutput.All())
 		}
-		log.Printf("[TRACE] TestInit_stateStore_unset: second init complete")
+		log.Printf("[TRACE] TestInit_stateStore_backendConfigFlagNoMigrate: second init complete")
 		t.Logf("Second run output:\n%s", testOutput.Stdout())
 		t.Logf("Second run errors:\n%s", testOutput.Stderr())
 

--- a/internal/command/init_test.go
+++ b/internal/command/init_test.go
@@ -4349,21 +4349,24 @@ func TestInit_stateStore_unset(t *testing.T) {
 		}
 		code := c.Run(args)
 		testOutput := done(t)
-		if code != 0 {
-			t.Fatalf("bad: \n%s", testOutput.All())
+		if code == 0 {
+			t.Fatalf("expected non-zero exit code, got 0: \n%s", testOutput.All())
 		}
 		log.Printf("[TRACE] TestInit_stateStore_unset: second init complete")
-		t.Logf("Second run output:\n%s", testOutput.Stdout())
-		t.Logf("Second run errors:\n%s", testOutput.Stderr())
-
-		s := testDataStateRead(t, filepath.Join(DefaultDataDir, DefaultStateFilename))
-		if !s.StateStore.Empty() {
-			t.Fatal("should not have StateStore config")
+		expectedMsgs := []string{
+			"Error: State store initialization required, please run \"terraform state migrate\" or \"terraform init -reconfigure\"",
+			"Reason: Unsetting the previously set state store \"test_store\"",
 		}
-		if !s.Backend.Empty() {
-			t.Fatalf("expected empty Backend config after unsetting state store, found: %#v", s.Backend)
+		output := cleanString(testOutput.Stderr())
+		for _, expectedMsg := range expectedMsgs {
+			if !strings.Contains(output, expectedMsg) {
+				t.Fatalf("expected error message %q not found: \n%s", expectedMsg, output)
+			}
 		}
 	}
+
+	// TODO: Create a test in state_migrate_test.go where the terraform state migrate command is used for the migration,
+	// and assert that after migration the local state contains the expected state.
 }
 
 func TestInit_stateStore_unset_withoutProviderRequirements(t *testing.T) {
@@ -4373,10 +4376,6 @@ func TestInit_stateStore_unset_withoutProviderRequirements(t *testing.T) {
 	t.Chdir(td)
 
 	mockProvider := mockPluggableStateStorageProvider()
-	storeName := "test_store"
-	otherStoreName := "test_otherstore"
-	// Make the provider report that it contains a 2nd storage implementation with the above name
-	mockProvider.GetProviderSchemaResponse.StateStores[otherStoreName] = mockProvider.GetProviderSchemaResponse.StateStores[storeName]
 	mockProviderAddress := addrs.NewDefaultProvider("test")
 	providerSource, close := newMockProviderSource(t, map[string][]string{
 		"hashicorp/test": {"1.2.3"}, // Matches provider version in backend state file fixture
@@ -4451,19 +4450,19 @@ func TestInit_stateStore_unset_withoutProviderRequirements(t *testing.T) {
 		}
 		code := c.Run(args)
 		testOutput := done(t)
-		if code != 0 {
-			t.Fatalf("bad: \n%s", testOutput.All())
+		if code != 1 {
+			t.Fatalf("expected code 1 exit code, got %d, output: \n%s", code, testOutput.All())
 		}
-		log.Printf("[TRACE] TestInit_stateStore_unset_withoutProviderRequirements: second init complete")
-		t.Logf("Second run output:\n%s", testOutput.Stdout())
-		t.Logf("Second run errors:\n%s", testOutput.Stderr())
 
-		s := testDataStateRead(t, filepath.Join(DefaultDataDir, DefaultStateFilename))
-		if !s.StateStore.Empty() {
-			t.Fatal("should not have StateStore config")
+		expectedErrMsgs := []string{
+			"Error: State store initialization required, please run \"terraform state migrate\" or \"terraform init -reconfigure\"",
+			"Reason: Unsetting the previously set state store \"test_store\"",
 		}
-		if !s.Backend.Empty() {
-			t.Fatalf("expected empty Backend config after unsetting state store, found: %#v", s.Backend)
+		output := cleanString(testOutput.Stderr())
+		for _, expectedErr := range expectedErrMsgs {
+			if !strings.Contains(output, expectedErr) {
+				t.Fatalf("unexpected error, expected %q, given: %q", expectedErr, output)
+			}
 		}
 	}
 }

--- a/internal/command/init_test.go
+++ b/internal/command/init_test.go
@@ -4851,47 +4851,26 @@ func TestInit_backend_to_stateStore_singleWorkspace(t *testing.T) {
 		}
 		code := c.Run(args)
 		testOutput := done(t)
-		if code != 0 {
-			t.Fatalf("bad: \n%s", testOutput.All())
-		}
-		log.Printf("[TRACE] %s: second init with state store complete", t.Name())
-		t.Logf("Second run output:\n%s", testOutput.Stdout())
-		t.Logf("Second run errors:\n%s", testOutput.Stderr())
-
-		s := testDataStateRead(t, filepath.Join(DefaultDataDir, DefaultStateFilename))
-		if s.StateStore.Empty() {
-			t.Fatal("should have StateStore config")
-		}
-		if !s.Backend.Empty() {
-			t.Fatalf("expected backend to be empty")
+		if code != 1 {
+			t.Fatalf("expected code 1 exit code, got %d, output: \n%s", code, testOutput.All())
 		}
 
-		rawData, ok := mockProvider.MockStates[backend.DefaultStateName].([]byte)
-		if !ok {
-			t.Fatalf("expected %q state to exist in %s: %#v",
-				backend.DefaultStateName,
-				mockProviderAddress,
-				mockProvider.MockStates)
+		expectedErrMsgs := []string{
+			"Error: Backend initialization required, please run \"terraform state migrate\" or \"terraform init -reconfigure\"",
+			"Reason: Migrating from backend \"http\" to state store \"test_store\" in provider test (\"registry.terraform.io/hashicorp/test\")",
+			"run \"terraform state migrate\"",
+			"run \"terraform init -reconfigure\"",
 		}
-
-		data, err := statefile.Read(bytes.NewBuffer(rawData))
-		if err != nil {
-			t.Fatal(err)
-		}
-		expectedOutputs := map[string]*states.OutputValue{
-			"test": {
-				Addr: addrs.AbsOutputValue{
-					OutputValue: addrs.OutputValue{
-						Name: "test",
-					},
-				},
-				Value: cty.StringVal("test"),
-			},
-		}
-		if diff := cmp.Diff(expectedOutputs, data.State.RootOutputValues); diff != "" {
-			t.Fatalf("unexpected data: %s", diff)
+		output := cleanString(testOutput.Stderr())
+		for _, expectedErr := range expectedErrMsgs {
+			if !strings.Contains(output, expectedErr) {
+				t.Fatalf("unexpected error, expected %q, given: %q", expectedErr, output)
+			}
 		}
 	}
+
+	// TODO: Create a test in state_migrate_test.go where the terraform state migrate command is used for the migration,
+	// and assert that after migration the state store contains the expected state.
 }
 
 // TestInit_backend_to_stateStore_noState tests that given no state
@@ -4996,27 +4975,25 @@ func TestInit_backend_to_stateStore_noState(t *testing.T) {
 		}
 		code := c.Run(args)
 		testOutput := done(t)
-		if code != 0 {
-			t.Fatalf("second init exited with non-zero code %d:\n%s", code, testOutput.Stderr())
+		if code != 1 {
+			t.Fatalf("expected second init to exit with code 1, got %d:\n%s", code, testOutput.Stderr())
 		}
-		log.Printf("[TRACE] %s: second init with state store complete", t.Name())
-		t.Logf("Second run output:\n%s", testOutput.Stdout())
-		t.Logf("Second run errors:\n%s", testOutput.Stderr())
-
-		s := testDataStateRead(t, filepath.Join(DefaultDataDir, DefaultStateFilename))
-		if s.StateStore.Empty() {
-			t.Fatal("should have StateStore config")
+		expectedErrMsgs := []string{
+			"Error: Backend initialization required, please run \"terraform state migrate\" or \"terraform init -reconfigure\"",
+			"Reason: Migrating from backend \"http\" to state store \"test_store\" in provider test (\"registry.terraform.io/hashicorp/test\")",
+			"run \"terraform state migrate\"",
+			"run \"terraform init -reconfigure\"",
 		}
-		if !s.Backend.Empty() {
-			t.Fatalf("expected backend to be empty")
-		}
-
-		if len(mockProvider.MockStates) != 0 {
-			t.Fatalf("expected no state to exist in %s: %#v",
-				mockProviderAddress,
-				mockProvider.MockStates)
+		output := cleanString(testOutput.Stderr())
+		for _, expectedErr := range expectedErrMsgs {
+			if !strings.Contains(output, expectedErr) {
+				t.Fatalf("unexpected error, expected %q, given: %q", expectedErr, output)
+			}
 		}
 	}
+
+	// TODO: Create a test in state_migrate_test.go where the terraform state migrate command is used for the migration,
+	// and assert that after migration the state store is still empty.
 }
 
 func TestInit_localBackend_to_stateStore(t *testing.T) {
@@ -5159,51 +5136,25 @@ func TestInit_localBackend_to_stateStore(t *testing.T) {
 		}
 		code := c.Run(args)
 		testOutput := done(t)
-		if code != 0 {
-			t.Fatalf("second init exited with non-zero code %d:\n%s", code, testOutput.Stderr())
+		if code != 1 {
+			t.Fatalf("expected second init to exit with code 1, got %d:\n%s", code, testOutput.Stderr())
 		}
-		log.Printf("[TRACE] %s: second init with state store complete", t.Name())
-		t.Logf("Second run output:\n%s", testOutput.Stdout())
-		t.Logf("Second run errors:\n%s", testOutput.Stderr())
-
-		s := testDataStateRead(t, filepath.Join(DefaultDataDir, DefaultStateFilename))
-		if s.StateStore.Empty() {
-			t.Fatal("should have StateStore config")
+		expectedErrMsgs := []string{
+			"Error: Backend initialization required, please run \"terraform state migrate\" or \"terraform init -reconfigure\"",
+			"Reason: Migrating from backend \"local\" to state store \"test_store\" in provider test (\"registry.terraform.io/hashicorp/test\")",
+			"run \"terraform state migrate\"",
+			"run \"terraform init -reconfigure\"",
 		}
-		if !s.Backend.Empty() {
-			t.Fatalf("expected backend to be empty")
-		}
-
-		rawData, ok := mockProvider.MockStates[backend.DefaultStateName].([]byte)
-		if !ok {
-			t.Fatalf("expected %q state to exist in %s: %#v",
-				backend.DefaultStateName,
-				mockProviderAddress,
-				mockProvider.MockStates)
-		}
-
-		data, err := statefile.Read(bytes.NewBuffer(rawData))
-		if err != nil {
-			t.Fatal(err)
-		}
-		expectedOutputs := map[string]*states.OutputValue{
-			"test": {
-				Addr: addrs.AbsOutputValue{
-					OutputValue: addrs.OutputValue{
-						Name: "test",
-					},
-				},
-				Value: cty.StringVal("test"),
-			},
-		}
-		if diff := cmp.Diff(expectedOutputs, data.State.RootOutputValues); diff != "" {
-			t.Fatalf("unexpected data: %s", diff)
-		}
-
-		if f, err := os.Stat(DefaultStateFilename); err == nil && f.Size() > 0 {
-			t.Fatalf("expected state file to have been removed at %q. Has size %d bytes.", DefaultStateFilename, f.Size())
+		output := cleanString(testOutput.Stderr())
+		for _, expectedErr := range expectedErrMsgs {
+			if !strings.Contains(output, expectedErr) {
+				t.Fatalf("unexpected error, expected %q, given: %q", expectedErr, output)
+			}
 		}
 	}
+
+	// TODO: Create a test in state_migrate_test.go where the terraform state migrate command is used for the migration,
+	// and assert that after migration the state store contains the expected state and the local copies are removed.
 }
 
 func TestInit_backend_to_stateStore_multipleWorkspaces(t *testing.T) {
@@ -5391,69 +5342,25 @@ func TestInit_backend_to_stateStore_multipleWorkspaces(t *testing.T) {
 		}
 		code := c.Run(args)
 		testOutput := done(t)
-		if code != 0 {
-			t.Fatalf("second init failed: \n%s", testOutput.All())
+		if code != 1 {
+			t.Fatalf("expected second init to exit with code 1, got %d:\n%s", code, testOutput.Stderr())
 		}
-		log.Printf("[TRACE] %s: second init with state store complete", t.Name())
-		t.Logf("Second init output:\n%s", testOutput.All())
-
-		s := testDataStateRead(t, filepath.Join(DefaultDataDir, DefaultStateFilename))
-		if s.StateStore.Empty() {
-			t.Fatal("should have StateStore config")
+		expectedErrMsgs := []string{
+			"Error: Backend initialization required, please run \"terraform state migrate\" or \"terraform init -reconfigure\"",
+			"Reason: Migrating from backend \"inmem\" to state store \"test_store\" in provider test (\"registry.terraform.io/hashicorp/test\")",
+			"run \"terraform state migrate\"",
+			"run \"terraform init -reconfigure\"",
 		}
-		if !s.Backend.Empty() {
-			t.Fatalf("expected backend to be empty")
-		}
-
-		expectedOutputs := map[string]*states.OutputValue{
-			"test": {
-				Addr: addrs.AbsOutputValue{
-					OutputValue: addrs.OutputValue{
-						Name: "test",
-					},
-				},
-				Value: cty.StringVal("test"),
-			},
-		}
-
-		expectedWorkspaces := []string{"default", "second"}
-		ws := slices.Sorted(maps.Keys(mockProvider.MockStates))
-		if diff := cmp.Diff(expectedWorkspaces, ws); diff != "" {
-			t.Fatalf("unexpected workspaces: %s", diff)
-		}
-
-		// check default workspace first
-		rawData, ok := mockProvider.MockStates[backend.DefaultStateName].([]byte)
-		if !ok {
-			t.Fatalf("expected %q state to exist in %s: %#v",
-				backend.DefaultStateName,
-				mockProviderAddress,
-				mockProvider.MockStates)
-		}
-		stateData, err := statefile.Read(bytes.NewBuffer(rawData))
-		if err != nil {
-			t.Fatal(err)
-		}
-		if diff := cmp.Diff(expectedOutputs, stateData.State.RootOutputValues); diff != "" {
-			t.Fatalf("unexpected data: %s", diff)
-		}
-
-		// check second workspace
-		rawData2, ok := mockProvider.MockStates["second"].([]byte)
-		if !ok {
-			t.Fatalf("expected %q state to exist in %s: %#v",
-				backend.DefaultStateName,
-				mockProviderAddress,
-				mockProvider.MockStates)
-		}
-		stateData2, err := statefile.Read(bytes.NewBuffer(rawData2))
-		if err != nil {
-			t.Fatal(err)
-		}
-		if diff := cmp.Diff(expectedOutputs, stateData2.State.RootOutputValues); diff != "" {
-			t.Fatalf("unexpected data: %s", diff)
+		output := cleanString(testOutput.Stderr())
+		for _, expectedErr := range expectedErrMsgs {
+			if !strings.Contains(output, expectedErr) {
+				t.Fatalf("unexpected error, expected %q, given: %q", expectedErr, output)
+			}
 		}
 	}
+
+	// TODO: Create a test in state_migrate_test.go where the terraform state migrate command is used for the migration,
+	// and assert both workspaces are migrated successfully.
 }
 
 func TestInit_cloud_to_stateStore(t *testing.T) {

--- a/internal/command/init_test.go
+++ b/internal/command/init_test.go
@@ -4057,7 +4057,7 @@ func TestInit_stateStore_configChanges(t *testing.T) {
 		}
 	})
 
-	t.Run("handling changed state store config without -migrate-state flag", func(t *testing.T) {
+	t.Run("an error is returned from init regardless of -migrate-state flag missing or present", func(t *testing.T) {
 		// Create a temporary working directory with state store configuration
 		// that doesn't match the backend state file
 		td := t.TempDir()
@@ -4089,6 +4089,7 @@ func TestInit_stateStore_configChanges(t *testing.T) {
 			Meta: meta,
 		}
 
+		// 1) When flag is missing
 		args := []string{
 			"-enable-pluggable-state-storage-experiment=true",
 			// missing -migrate-state flag
@@ -4100,280 +4101,46 @@ func TestInit_stateStore_configChanges(t *testing.T) {
 		}
 
 		// Check output
-		output := testOutput.All()
-		expectedMsg := "Error: State store configuration changed"
-		if !strings.Contains(output, expectedMsg) {
-			t.Fatalf("expected output to include %q, but got':\n %s", expectedMsg, output)
+		expectedErrMsgs := []string{
+			"Error: State store initialization required, please run \"terraform state migrate\" or \"terraform init -reconfigure\"",
 		}
-	})
-
-	t.Run("handling changed state store config", func(t *testing.T) {
-		// Create a temporary working directory with state store configuration
-		// that doesn't match the backend state file
-		td := t.TempDir()
-		testCopyDir(t, testFixturePath("state-store-changed/store-config"), td)
-		t.Chdir(td)
-
-		mockProvider := mockPluggableStateStorageProvider()
-		// The previous init implied by this test scenario would have created the default workspace.
-		mockProvider.MockStates = map[string]any{
-			backend.DefaultStateName: []byte(`{"version":4,"terraform_version":"1.15.0","serial":1,"lineage":"91adaece-23b3-7bce-0695-5aea537d2fef","outputs":{"test":{"value":"test","type":"string"}},"resources":[],"check_results":null}`),
-		}
-		mockProviderAddress := addrs.NewDefaultProvider("test")
-		providerSource, close := newMockProviderSource(t, map[string][]string{
-			"hashicorp/test": {"1.2.3"}, // Matches provider version in backend state file fixture
-		})
-		defer close()
-
-		ui := new(cli.MockUi)
-		view, done := testView(t)
-		meta := Meta{
-			Ui:                        ui,
-			View:                      view,
-			AllowExperimentalFeatures: true,
-			testingOverrides: &testingOverrides{
-				Providers: map[addrs.Provider]providers.Factory{
-					mockProviderAddress: providers.FactoryFixed(mockProvider),
-				},
-			},
-			ProviderSource: providerSource,
-		}
-		c := &InitCommand{
-			Meta: meta,
+		output := cleanString(testOutput.Stderr())
+		for _, expectedErr := range expectedErrMsgs {
+			if !strings.Contains(output, expectedErr) {
+				t.Fatalf("unexpected error, expected %q, given: %q", expectedErr, output)
+			}
 		}
 
-		args := []string{
+		// 2) When flag is present
+		ui = new(cli.MockUi)
+		view, done = testView(t)
+		meta.Ui = ui
+		meta.View = view
+		c.Meta = meta
+
+		args = []string{
 			"-enable-pluggable-state-storage-experiment=true",
-			"-force-copy",
+			"-migrate-state",
 		}
-		code := c.Run(args)
-		testOutput := done(t)
-		if code != 0 {
-			t.Fatalf("expected 0 exit code, got %d, output: \n%s", code, testOutput.All())
-		}
-
-		// Check output
-		output := testOutput.All()
-		expectedMsg := "Terraform has been successfully initialized!"
-		if !strings.Contains(output, expectedMsg) {
-			t.Fatalf("expected output to include %q, but got':\n %s", expectedMsg, output)
-		}
-		expectedReason := "State store \"test_store\" (hashicorp/test) configuration changed"
-		if !strings.Contains(output, expectedReason) {
-			t.Fatalf("expected output to include reason %q, but got':\n %s", expectedReason, output)
+		code = c.Run(args)
+		testOutput = done(t)
+		if code == 0 {
+			t.Fatalf("expected non-zero exit code, got %d, output: \n%s", code, testOutput.All())
 		}
 
-		// check state remains accessible after migration
-		if _, exists := mockProvider.MockStates[backend.DefaultStateName]; !exists {
-			t.Fatalf("expected the default workspace to exist after migration, but it is missing: %#v", mockProvider.MockStates)
+		// Check output - should be same as before
+		output = cleanString(testOutput.Stderr())
+		for _, expectedErr := range expectedErrMsgs {
+			if !strings.Contains(output, expectedErr) {
+				t.Fatalf("unexpected error, expected %q, given: %q", expectedErr, output)
+			}
 		}
 	})
 
-	t.Run("handling changed state store provider config", func(t *testing.T) {
-		// Create a temporary working directory with state store configuration
-		// that doesn't match the backend state file
-		td := t.TempDir()
-		testCopyDir(t, testFixturePath("state-store-changed/provider-config"), td)
-		t.Chdir(td)
-
-		mockProvider := mockPluggableStateStorageProvider()
-		// The previous init implied by this test scenario would have created the default workspace.
-		mockProvider.MockStates = map[string]any{
-			backend.DefaultStateName: []byte(`{"version":4,"terraform_version":"1.15.0","serial":1,"lineage":"91adaece-23b3-7bce-0695-5aea537d2fef","outputs":{"test":{"value":"test","type":"string"}},"resources":[],"check_results":null}`),
-		}
-		mockProviderAddress := addrs.NewDefaultProvider("test")
-		providerSource, close := newMockProviderSource(t, map[string][]string{
-			"hashicorp/test": {"1.2.3"}, // Matches provider version in backend state file fixture
-		})
-		defer close()
-
-		ui := new(cli.MockUi)
-		view, done := testView(t)
-		meta := Meta{
-			Ui:                        ui,
-			View:                      view,
-			AllowExperimentalFeatures: true,
-			testingOverrides: &testingOverrides{
-				Providers: map[addrs.Provider]providers.Factory{
-					mockProviderAddress: providers.FactoryFixed(mockProvider),
-				},
-			},
-			ProviderSource: providerSource,
-		}
-		c := &InitCommand{
-			Meta: meta,
-		}
-
-		args := []string{
-			"-enable-pluggable-state-storage-experiment=true",
-			"-force-copy",
-		}
-		code := c.Run(args)
-		testOutput := done(t)
-		if code != 0 {
-			t.Fatalf("expected 0 exit code, got %d, output: \n%s", code, testOutput.All())
-		}
-
-		// Check output
-		output := testOutput.All()
-		expectedMsg := "Terraform has been successfully initialized!"
-		if !strings.Contains(output, expectedMsg) {
-			t.Fatalf("expected output to include %q, but got':\n %s", expectedMsg, output)
-		}
-		expectedReason := "State store provider \"test\" (hashicorp/test) configuration changed"
-		if !strings.Contains(output, expectedReason) {
-			t.Fatalf("expected output to include reason %q, but got':\n %s", expectedReason, output)
-		}
-
-		// check state remains accessible after migration
-		if _, exists := mockProvider.MockStates[backend.DefaultStateName]; !exists {
-			t.Fatal("expected the default workspace to exist after migration, but it is missing")
-		}
-	})
-
-	t.Run("handling changed state store type in the same provider", func(t *testing.T) {
-		// Create a temporary working directory with state store configuration
-		// that doesn't match the backend state file
-		td := t.TempDir()
-		testCopyDir(t, testFixturePath("state-store-changed/state-store-type"), td)
-		t.Chdir(td)
-
-		mockProvider := mockPluggableStateStorageProvider()
-		// The previous init implied by this test scenario would have created the default workspace.
-		mockProvider.MockStates = map[string]any{
-			backend.DefaultStateName: []byte(`{"version":4,"terraform_version":"1.15.0","serial":1,"lineage":"91adaece-23b3-7bce-0695-5aea537d2fef","outputs":{"test":{"value":"test","type":"string"}},"resources":[],"check_results":null}`),
-		}
-		storeName := "test_store"
-		otherStoreName := "test_otherstore"
-		// Make the provider report that it contains a 2nd storage implementation with the above name
-		mockProvider.GetProviderSchemaResponse.StateStores[otherStoreName] = mockProvider.GetProviderSchemaResponse.StateStores[storeName]
-		mockProviderAddress := addrs.NewDefaultProvider("test")
-		providerSource, close := newMockProviderSource(t, map[string][]string{
-			"hashicorp/test": {"1.2.3"}, // Matches provider version in backend state file fixture
-		})
-		defer close()
-
-		ui := new(cli.MockUi)
-		view, done := testView(t)
-		meta := Meta{
-			Ui:                        ui,
-			View:                      view,
-			AllowExperimentalFeatures: true,
-			testingOverrides: &testingOverrides{
-				Providers: map[addrs.Provider]providers.Factory{
-					mockProviderAddress: providers.FactoryFixed(mockProvider),
-				},
-			},
-			ProviderSource: providerSource,
-		}
-		c := &InitCommand{
-			Meta: meta,
-		}
-
-		args := []string{
-			"-enable-pluggable-state-storage-experiment=true",
-			"-force-copy",
-		}
-		code := c.Run(args)
-		testOutput := done(t)
-		if code != 0 {
-			t.Fatalf("expected 0 exit code, got %d, output: \n%s", code, testOutput.All())
-		}
-
-		// Check output
-		output := testOutput.All()
-		expectedMsg := "Terraform has been successfully initialized!"
-		if !strings.Contains(output, expectedMsg) {
-			t.Fatalf("expected output to include %q, but got':\n %s", expectedMsg, output)
-		}
-		expectedReason := "State store type changed from \"test_store\" to \"test_otherstore\""
-		if !strings.Contains(output, expectedReason) {
-			t.Fatalf("expected output to include reason %q, but got':\n %s", expectedReason, output)
-		}
-
-		// check state remains accessible after migration
-		if _, exists := mockProvider.MockStates[backend.DefaultStateName]; !exists {
-			t.Fatal("expected the default workspace to exist after migration, but it is missing")
-		}
-	})
-
-	t.Run("handling changing the provider used for state storage", func(t *testing.T) {
-		// Create a temporary working directory with state store configuration
-		// that doesn't match the backend state file
-		td := t.TempDir()
-		testCopyDir(t, testFixturePath("state-store-changed/provider-used"), td)
-		t.Chdir(td)
-
-		mockProvider := mockPluggableStateStorageProvider()
-		// The previous init implied by this test scenario would have created the default workspace.
-		mockProvider.MockStates = map[string]any{
-			backend.DefaultStateName: []byte(`{"version":4,"terraform_version":"1.15.0","serial":1,"lineage":"91adaece-23b3-7bce-0695-5aea537d2fef","outputs":{"test":{"value":"test","type":"string"}},"resources":[],"check_results":null}`),
-		}
-
-		// Make a mock that implies its name is test2 based on returned schemas
-		mockProvider2 := mockPluggableStateStorageProvider()
-		mockProvider2.GetProviderSchemaResponse.StateStores["test2_store"] = mockProvider.GetProviderSchemaResponse.StateStores["test_store"]
-		delete(mockProvider2.GetProviderSchemaResponse.StateStores, "test_store")
-
-		mockProviderAddress := addrs.NewDefaultProvider("test")
-		mockProviderAddress2 := addrs.NewDefaultProvider("test2")
-		providerSource, close := newMockProviderSource(t, map[string][]string{
-			"hashicorp/test":  {"1.2.3"}, // Provider in backend state file fixture
-			"hashicorp/test2": {"1.2.3"}, // Provider now used in config
-		})
-		defer close()
-
-		ui := new(cli.MockUi)
-		view, done := testView(t)
-		meta := Meta{
-			Ui:                        ui,
-			View:                      view,
-			AllowExperimentalFeatures: true,
-			testingOverrides: &testingOverrides{
-				Providers: map[addrs.Provider]providers.Factory{
-					mockProviderAddress:  providers.FactoryFixed(mockProvider),  // test provider
-					mockProviderAddress2: providers.FactoryFixed(mockProvider2), // test2 provider
-				},
-			},
-			ProviderSource: providerSource,
-		}
-		c := &InitCommand{
-			Meta: meta,
-		}
-
-		args := []string{
-			"-enable-pluggable-state-storage-experiment=true",
-			"-force-copy",
-		}
-		code := c.Run(args)
-		testOutput := done(t)
-		if code != 0 {
-			t.Fatalf("expected 0 exit code, got %d, output: \n%s", code, testOutput.All())
-		}
-
-		// Check output
-		output := testOutput.All()
-		expectedMsg := "Terraform has been successfully initialized!"
-		if !strings.Contains(output, expectedMsg) {
-			t.Fatalf("expected output to include %q, but got':\n %s", expectedMsg, output)
-		}
-		expectedReason := "State store provider changed from hashicorp/test to hashicorp/test2"
-		if !strings.Contains(output, expectedReason) {
-			t.Fatalf("expected output to include reason %q, but got':\n %s", expectedReason, output)
-		}
-
-		// check state remains accessible after migration
-		if _, exists := mockProvider.MockStates[backend.DefaultStateName]; !exists {
-			t.Fatal("expected the default workspace to exist after migration, but it is missing")
-		}
-	})
+	// TODO: once state migrate command is implemented, add test cases in state_migrate_test.go matching the tests
+	// removed from this file in the same commit as this TODO.
 }
 
-// Testing init's behaviors with `state_store` when the provider used for state storage in a previous init
-// command is updated.
-//
-// TODO: Add a test case showing that downgrading provider version is ok as long as the schema version hasn't
-// changed. We should also have a test demonstrating that downgrades when the schema version HAS changed will fail.
 func TestInit_stateStore_providerUpgrade(t *testing.T) {
 	t.Run("handling upgrading the provider used for state storage", func(t *testing.T) {
 		// Create a temporary working directory with state store configuration

--- a/internal/command/init_test.go
+++ b/internal/command/init_test.go
@@ -4513,7 +4513,7 @@ func TestInit_stateStore_to_backend(t *testing.T) {
 		t.Logf("First run errors:\n%s", testOutput.Stderr())
 
 		if _, err := os.Stat(filepath.Join(DefaultDataDir, DefaultStateFilename)); err != nil {
-			t.Fatalf("err: %s", err)
+			t.Fatalf("error when checking the backend state file exists: %s", err)
 		}
 	}
 	{
@@ -4570,7 +4570,7 @@ func TestInit_stateStore_to_backend(t *testing.T) {
 			t.Fatalf("expected apply to fail: \n%s", testOutput.All())
 		}
 		log.Printf("[TRACE] TestInit_stateStore_to_backend: apply complete")
-		expectedErr := "Backend initialization required"
+		expectedErr := "State store initialization required"
 		if !strings.Contains(testOutput.Stderr(), expectedErr) {
 			t.Fatalf("unexpected error, expected %q, given: %q", expectedErr, testOutput.Stderr())
 		}
@@ -4578,10 +4578,6 @@ func TestInit_stateStore_to_backend(t *testing.T) {
 		log.Printf("[TRACE] TestInit_stateStore_to_backend: uninitialised apply complete")
 		t.Logf("First run output:\n%s", testOutput.Stdout())
 		t.Logf("First run errors:\n%s", testOutput.Stderr())
-
-		if _, err := os.Stat(filepath.Join(DefaultDataDir, DefaultStateFilename)); err != nil {
-			t.Fatalf("err: %s", err)
-		}
 	}
 	{
 		log.Printf("[TRACE] TestInit_stateStore_to_backend: beginning second init")
@@ -4624,48 +4620,26 @@ func TestInit_stateStore_to_backend(t *testing.T) {
 		}
 		code := c.Run(args)
 		testOutput := done(t)
-		if code != 0 {
-			t.Fatalf("bad: \n%s", testOutput.All())
+		if code != 1 {
+			t.Fatalf("expected code 1 exit code, got %d, output: \n%s", code, testOutput.All())
 		}
 		log.Printf("[TRACE] TestInit_stateStore_to_backend: second init complete")
-		t.Logf("Second run output:\n%s", testOutput.Stdout())
-		t.Logf("Second run errors:\n%s", testOutput.Stderr())
 
-		s := testDataStateRead(t, filepath.Join(DefaultDataDir, DefaultStateFilename))
-		if !s.StateStore.Empty() {
-			t.Fatal("should not have StateStore config")
+		expectedErrMsgs := []string{
+			"Error: State store initialization required, please run \"terraform state migrate\" or \"terraform init -reconfigure\"",
+			// Assert both commands are mentioned
+			"run \"terraform state migrate\"",
+			"run \"terraform init -reconfigure\"",
 		}
-		if s.Backend.Empty() {
-			t.Fatalf("expected backend to not be empty")
-		}
-
-		data, err := statefile.Read(bytes.NewBuffer(testBackend.Data))
-		if err != nil {
-			t.Fatal(err)
-		}
-		expectedOutputs := map[string]*states.OutputValue{
-			"test": {
-				Addr: addrs.AbsOutputValue{
-					OutputValue: addrs.OutputValue{
-						Name: "test",
-					},
-				},
-				Value: cty.StringVal("test"),
-			},
-		}
-		if diff := cmp.Diff(expectedOutputs, data.State.RootOutputValues); diff != "" {
-			t.Fatalf("unexpected data: %s", diff)
-		}
-
-		expectedGetCalls := 6
-		if testBackend.CallCount("GET") != expectedGetCalls {
-			t.Fatalf("expected %d GET calls, got %d", expectedGetCalls, testBackend.CallCount("GET"))
-		}
-		expectedPostCalls := 1
-		if testBackend.CallCount("POST") != expectedPostCalls {
-			t.Fatalf("expected %d POST calls, got %d", expectedPostCalls, testBackend.CallCount("POST"))
+		output := cleanString(testOutput.Stderr())
+		for _, expectedErr := range expectedErrMsgs {
+			if !strings.Contains(output, expectedErr) {
+				t.Fatalf("unexpected error, expected %q, given: %q", expectedErr, output)
+			}
 		}
 	}
+
+	// TODO: Create a test in state_migrate_test.go where the terraform state migrate command is used for the migration.
 }
 
 // Test that users are shown actionable errors if they try to use a state store in a non-init command

--- a/internal/command/init_test.go
+++ b/internal/command/init_test.go
@@ -4142,68 +4142,13 @@ func TestInit_stateStore_configChanges(t *testing.T) {
 }
 
 func TestInit_stateStore_providerUpgrade(t *testing.T) {
-	t.Run("handling upgrading the provider used for state storage", func(t *testing.T) {
-		// Create a temporary working directory with state store configuration
-		// that doesn't match the backend state file
-		td := t.TempDir()
-		testCopyDir(t, testFixturePath("state-store-changed/provider-upgraded"), td)
-		t.Chdir(td)
+	t.Skip("See TODOs below. This test was removed as part of TF-36263")
+	// TODO: Add a test showing that provider updated in init that affect the PSS provider are blocked and users
+	// are prompted to run state migrate or pin the PSS provider version and re-run init -upgrade.
 
-		mockProvider := mockPluggableStateStorageProvider()
-		// The previous init implied by this test scenario would have created the default workspace.
-		mockProvider.MockStates = map[string]any{
-			backend.DefaultStateName: []byte(`{"version":4,"terraform_version":"1.15.0","serial":1,"lineage":"91adaece-23b3-7bce-0695-5aea537d2fef","outputs":{"test":{"value":"test","type":"string"}},"resources":[],"check_results":null}`),
-		}
-		mockProviderAddress := addrs.NewDefaultProvider("test")
-		providerSource, close := newMockProviderSource(t, map[string][]string{
-			"hashicorp/test": {"1.2.3", "9.9.9"}, // 1.2.3 is the version used in the backend state file, 9.9.9 is the version being upgraded to
-		})
-		defer close()
-
-		ui := new(cli.MockUi)
-		view, done := testView(t)
-		meta := Meta{
-			Ui:                        ui,
-			View:                      view,
-			AllowExperimentalFeatures: true,
-			testingOverrides: &testingOverrides{
-				Providers: map[addrs.Provider]providers.Factory{
-					mockProviderAddress: providers.FactoryFixed(mockProvider),
-				},
-			},
-			ProviderSource: providerSource,
-		}
-		c := &InitCommand{
-			Meta: meta,
-		}
-
-		args := []string{
-			"-enable-pluggable-state-storage-experiment=true",
-			"-migrate-state=true",
-			"-upgrade",
-		}
-		code := c.Run(args)
-		testOutput := done(t)
-		if code != 0 {
-			t.Fatalf("expected 0 exit code, got %d, output: \n%s", code, testOutput.All())
-		}
-
-		// Check output
-		output := testOutput.All()
-		expectedMsg := "Terraform has been successfully initialized!"
-		if !strings.Contains(output, expectedMsg) {
-			t.Fatalf("expected output to include %q, but got':\n %s", expectedMsg, output)
-		}
-		expectedReason := "State store provider \"test\" (hashicorp/test) version changed from 1.2.3 to 9.9.9"
-		if !strings.Contains(output, expectedReason) {
-			t.Fatalf("expected output to include reason %q, but got':\n %s", expectedReason, output)
-		}
-
-		// check state remains accessible after migration
-		if _, exists := mockProvider.MockStates[backend.DefaultStateName]; !exists {
-			t.Fatal("expected the default workspace to exist after migration, but it is missing")
-		}
-	})
+	// TODO: once state migrate command is implemented, add test cases in state_migrate_test.go that show:
+	// 1) a migration when the provider version is updated.
+	// 2) a migration when the provider version is updated and the schema has a breaking change.
 }
 
 // Test a scenario where the configuration changes but the -backend-config CLI flags compensate for those changes

--- a/internal/command/meta_backend.go
+++ b/internal/command/meta_backend.go
@@ -1028,7 +1028,8 @@ func (m *Meta) backendFromConfig(opts *BackendOpts) (backend.Backend, tfdiags.Di
 		// 2. terraform init -reconfigure
 
 		diags = diags.Append(errStateStoreInitDiag(&ssInitReason{
-			Reason: fmt.Sprintf("Unsetting the previously set state store %q", s.StateStore.Type),
+			Reason:          fmt.Sprintf("Unsetting the previously set state store %q", s.StateStore.Type),
+			MigrationNeeded: true,
 		}))
 		return nil, diags
 
@@ -1064,8 +1065,9 @@ func (m *Meta) backendFromConfig(opts *BackendOpts) (backend.Backend, tfdiags.Di
 				stateStoreConfig.ProviderAddr,
 			)
 			diags = diags.Append(errStateStoreInitDiag(&ssInitReason{
-				Reason:  reason,
-				Subject: stateStoreConfig.DeclRange.Ptr(),
+				MigrationNeeded: false, // We're initialising a state store for the first time; no migration.
+				Reason:          reason,
+				Subject:         stateStoreConfig.DeclRange.Ptr(),
 			}))
 			return nil, diags
 		}
@@ -1089,8 +1091,9 @@ func (m *Meta) backendFromConfig(opts *BackendOpts) (backend.Backend, tfdiags.Di
 		initReason := fmt.Sprintf("Migrating from state store %q to backend %q",
 			s.StateStore.Type, backendConfig.Type)
 		diags = diags.Append(errStateStoreInitDiag(&ssInitReason{
-			Reason:  initReason,
-			Subject: backendConfig.DeclRange.Ptr(),
+			MigrationNeeded: true,
+			Reason:          initReason,
+			Subject:         backendConfig.DeclRange.Ptr(),
 		}))
 		return nil, diags
 
@@ -1363,7 +1366,8 @@ func (m *Meta) determineStateStoreInitReason(cfgState *workdir.StateStoreConfigS
 		return &ssInitReason{
 			Reason: fmt.Sprintf("State store %q (%s) supply mode changed from %q to %q",
 				cfg.Type, cfg.ProviderAddr.ForDisplay(), cfgState.ProviderSupplyMode, cfg.ProviderSupplyMode),
-			Subject: cfg.DeclRange.Ptr(),
+			Subject:         cfg.DeclRange.Ptr(),
+			MigrationNeeded: true,
 		}, diags
 	}
 
@@ -1371,14 +1375,16 @@ func (m *Meta) determineStateStoreInitReason(cfgState *workdir.StateStoreConfigS
 		return &ssInitReason{
 			Reason: fmt.Sprintf("State store %q (%s) not initialised",
 				cfg.Type, cfg.ProviderAddr.ForDisplay()),
-			Subject: cfg.DeclRange.Ptr(),
+			Subject:         cfg.DeclRange.Ptr(),
+			MigrationNeeded: false,
 		}, diags
 	}
 	if !cfg.ProviderAddr.Equals(*cfgState.Provider.Source) {
 		return &ssInitReason{
 			Reason: fmt.Sprintf("State store provider changed from %s to %s",
 				cfgState.Provider.Source.ForDisplay(), cfg.ProviderAddr.ForDisplay()),
-			Subject: cfg.Provider.DeclRange.Ptr(),
+			Subject:         cfg.Provider.DeclRange.Ptr(),
+			MigrationNeeded: true,
 		}, diags
 	}
 
@@ -1397,6 +1403,7 @@ func (m *Meta) determineStateStoreInitReason(cfgState *workdir.StateStoreConfigS
 			Reason: fmt.Sprintf("State store provider %q (%s) version changed from %s to %s",
 				cfg.Provider.Name, cfg.ProviderAddr.ForDisplay(),
 				cfgState.Provider.Version, lockVersion),
+			MigrationNeeded: true,
 		}, diags
 	}
 
@@ -1404,7 +1411,8 @@ func (m *Meta) determineStateStoreInitReason(cfgState *workdir.StateStoreConfigS
 		return &ssInitReason{
 			Reason: fmt.Sprintf("State store type changed from %q to %q",
 				cfgState.Type, cfg.Type),
-			Subject: cfg.TypeRange.Ptr(),
+			Subject:         cfg.TypeRange.Ptr(),
+			MigrationNeeded: true,
 		}, diags
 	}
 
@@ -1429,7 +1437,8 @@ func (m *Meta) determineStateStoreInitReason(cfgState *workdir.StateStoreConfigS
 		return &ssInitReason{
 			Reason: fmt.Sprintf("State store provider %q (%s) configuration changed",
 				cfg.Provider.Name, cfg.ProviderAddr.ForDisplay()),
-			Subject: cfg.Provider.DeclRange.Ptr(),
+			Subject:         cfg.Provider.DeclRange.Ptr(),
+			MigrationNeeded: true,
 		}, diags
 	}
 
@@ -1449,7 +1458,8 @@ func (m *Meta) determineStateStoreInitReason(cfgState *workdir.StateStoreConfigS
 		return &ssInitReason{
 			Reason: fmt.Sprintf("State store %q (%s) configuration changed",
 				cfg.Type, cfg.ProviderAddr.ForDisplay()),
-			Subject: cfg.DeclRange.Ptr(),
+			Subject:         cfg.DeclRange.Ptr(),
+			MigrationNeeded: true,
 		}, diags
 	}
 

--- a/internal/command/meta_backend.go
+++ b/internal/command/meta_backend.go
@@ -1022,29 +1022,15 @@ func (m *Meta) backendFromConfig(opts *BackendOpts) (backend.Backend, tfdiags.Di
 			s.StateStore.Provider.Source,
 		)
 
-		if !opts.Init {
-			diags = diags.Append(errStateStoreInitDiag(&ssInitReason{
-				Reason: fmt.Sprintf("Unsetting the previously set state store %q", s.StateStore.Type),
-			}))
-			return nil, diags
-		}
+		// Regardless of whether this code is invoked in an init or non-init command,
+		// we advise users to choose between:
+		// 1. terraform state migrate
+		// 2. terraform init -reconfigure
 
-		if !m.migrateState {
-			diags = diags.Append(migrateOrReconfigStateStoreDiag)
-			return nil, diags
-		}
-
-		// Grab a purely local backend to be the destination for migrated state
-		localB, moreDiags := m.Backend(&BackendOpts{ForceLocal: true, Init: true})
-		diags = diags.Append(moreDiags)
-		if moreDiags.HasErrors() {
-			return nil, diags
-		}
-
-		v := views.NewInit(opts.ViewType, m.View)
-		v.Output(views.InitMessageCode("state_store_unset"), s.StateStore.Type)
-
-		return m.stateStore_to_backend(sMgr, "local", localB, nil, opts.ViewType)
+		diags = diags.Append(errStateStoreInitDiag(&ssInitReason{
+			Reason: fmt.Sprintf("Unsetting the previously set state store %q", s.StateStore.Type),
+		}))
+		return nil, diags
 
 	// Configuring a backend for the first time or -reconfigure flag was used
 	case backendConfig != nil && s.Backend.Empty() &&
@@ -1096,29 +1082,17 @@ func (m *Meta) backendFromConfig(opts *BackendOpts) (backend.Backend, tfdiags.Di
 			backendConfig.Type,
 		)
 
-		if !opts.Init {
-			initReason := fmt.Sprintf("Migrating from state store %q to backend %q",
-				s.StateStore.Type, backendConfig.Type)
-			diags = diags.Append(errBackendInitDiag(initReason))
-			return nil, diags
-		}
-
-		b, configVal, moreDiags := m.backendInitFromConfig(backendConfig)
-		diags = diags.Append(moreDiags)
-		if moreDiags.HasErrors() {
-			return nil, diags
-		}
-
-		v := views.NewInit(opts.ViewType, m.View)
-		v.Output(views.InitMessageCode("state_store_migrate_backend"), s.StateStore.Type, backendConfig.Type)
-
-		newBackendCfgState := &workdir.BackendConfigState{
-			Type: backendConfig.Type,
-		}
-		newBackendCfgState.SetConfig(configVal, b.ConfigSchema())
-		newBackendCfgState.Hash = uint64(cHash)
-
-		return m.stateStore_to_backend(sMgr, backendConfig.Type, b, newBackendCfgState, opts.ViewType)
+		// Regardless of whether this code is invoked in an init or non-init command,
+		// we advise users to choose between:
+		// 1. terraform state migrate
+		// 2. terraform init -reconfigure
+		initReason := fmt.Sprintf("Migrating from state store %q to backend %q",
+			s.StateStore.Type, backendConfig.Type)
+		diags = diags.Append(errStateStoreInitDiag(&ssInitReason{
+			Reason:  initReason,
+			Subject: backendConfig.DeclRange.Ptr(),
+		}))
+		return nil, diags
 
 	// Migration from backend to state store
 	case backendConfig == nil && !s.Backend.Empty() &&
@@ -1130,15 +1104,16 @@ func (m *Meta) backendFromConfig(opts *BackendOpts) (backend.Backend, tfdiags.Di
 			stateStoreConfig.ProviderAddr,
 		)
 
-		if !opts.Init {
-			initReason := fmt.Sprintf("Migrating from backend %q to state store %q in provider %s (%q)",
-				s.Backend.Type, stateStoreConfig.Type,
-				stateStoreConfig.Provider.Name, stateStoreConfig.ProviderAddr)
-			diags = diags.Append(errBackendInitDiag(initReason))
-			return nil, diags
-		}
+		// Regardless of whether this code is invoked in an init or non-init command,
+		// we advise users to choose between:
+		// 1. terraform state migrate
+		// 2. terraform init -reconfigure
 
-		return m.backend_to_stateStore(s.Backend, sMgr, stateStoreConfig, cHash, opts)
+		initReason := fmt.Sprintf("Migrating from backend %q to state store %q in provider %s (%q)",
+			s.Backend.Type, stateStoreConfig.Type,
+			stateStoreConfig.Provider.Name, stateStoreConfig.ProviderAddr)
+		diags = diags.Append(errBackendToStateStoreInitDiag(initReason))
+		return nil, diags
 
 	// Potentially changing a backend configuration
 	case backendConfig != nil && !s.Backend.Empty() &&
@@ -1316,20 +1291,12 @@ func (m *Meta) backendFromConfig(opts *BackendOpts) (backend.Backend, tfdiags.Di
 			return nil, diags
 		}
 
-		if !opts.Init {
-			// user ran another cmd that is not init but they are required to initialize
-			diags = diags.Append(errStateStoreInitDiag(initReason))
-			return nil, diags
-		}
-
-		log.Printf("[WARN] state store has changed since last init: %q", initReason.Reason)
-
-		if !m.migrateState {
-			diags = diags.Append(migrateOrReconfigStateStoreDiag)
-			return nil, diags
-		}
-
-		return m.stateStore_changed(stateStoreConfig, cHash, sMgr, opts, initReason)
+		// Regardless of whether this code is invoked in an init or non-init command,
+		// we advise users to choose between:
+		// 1. terraform state migrate
+		// 2. terraform init -reconfigure
+		diags = diags.Append(errStateStoreInitDiag(initReason))
+		return nil, diags
 
 	default:
 		diags = diags.Append(fmt.Errorf(
@@ -2161,169 +2128,6 @@ func (m *Meta) backend(configPath string, viewType arguments.ViewType) (backendr
 	return be, diags
 }
 
-func (m *Meta) backend_to_stateStore(bcs *workdir.BackendConfigState, sMgr *clistate.LocalState, c *configs.StateStore, cHash int, opts *BackendOpts) (backend.Backend, tfdiags.Diagnostics) {
-	var diags tfdiags.Diagnostics
-
-	vt := arguments.ViewJSON
-	// Set default viewtype if none was set as the StateLocker needs to know exactly
-	// what viewType we want to have.
-	if opts == nil || opts.ViewType != vt {
-		vt = arguments.ViewHuman
-	}
-
-	s := sMgr.State()
-
-	cloudMode := cloud.DetectConfigChangeType(bcs, nil, false)
-	diags = diags.Append(m.assertSupportedCloudInitOptions(cloudMode))
-	if diags.HasErrors() {
-		return nil, diags
-	}
-
-	view := views.NewInit(vt, m.View)
-	if cloudMode == cloud.ConfigMigrationOut {
-		view.Output(views.BackendCloudMigrateStateStoreMessage, c.Type)
-	} else {
-		view.Output(views.BackendMigrateStateStoreMessage, bcs.Type, c.Type)
-	}
-
-	// Initialize the configured backend
-	b, moreDiags := m.savedBackend(sMgr)
-	diags = diags.Append(moreDiags)
-	if moreDiags.HasErrors() {
-		return nil, diags
-	}
-
-	// Get the state store as an instance of backend.Backend
-	ssBackend, storeConfigVal, providerConfigVal, moreDiags := m.stateStoreInitFromConfig(c, opts.Locks)
-	diags = diags.Append(moreDiags)
-	if diags.HasErrors() {
-		return nil, diags
-	}
-
-	// Perform the migration
-	err := m.backendMigrateState(&backendMigrateOpts{
-		SourceType:      bcs.Type,
-		DestinationType: c.Type,
-		Source:          b,
-		Destination:     ssBackend,
-		ViewType:        vt,
-	})
-	if err != nil {
-		diags = diags.Append(err)
-		return nil, diags
-	}
-
-	rDiags := m.removeLocalState(bcs.Type, b)
-	if rDiags.HasErrors() {
-		diags = diags.Append(rDiags)
-		return nil, diags
-	}
-
-	if m.stateLock {
-		view := views.NewStateLocker(vt, m.View)
-		stateLocker := clistate.NewLocker(m.stateLockTimeout, view)
-		if err := stateLocker.Lock(sMgr, "init is initializing state_store first time"); err != nil {
-			diags = diags.Append(fmt.Errorf("Error locking state: %s", err))
-			return nil, diags
-		}
-		defer stateLocker.Unlock()
-	}
-
-	// Store the state_store metadata in our saved state location
-	pVersion, vDiags := getStateStorageProviderVersion(c, opts.Locks) // pVersion will remain nil for builtin, dev override, and unmanaged providers.
-	diags = diags.Append(vDiags)
-	if vDiags.HasErrors() {
-		return nil, diags
-	}
-
-	// Update the stored metadata
-	s.Backend = nil
-	s.StateStore = &workdir.StateStoreConfigState{
-		Type: c.Type,
-		Hash: uint64(cHash),
-		Provider: &workdir.ProviderConfigState{
-			Source:  &c.ProviderAddr,
-			Version: pVersion,
-		},
-		ProviderSupplyMode: c.ProviderSupplyMode,
-	}
-	err = s.StateStore.SetConfig(storeConfigVal, ssBackend.ConfigSchema())
-	if err != nil {
-		diags = diags.Append(fmt.Errorf("Failed to set state store configuration: %w", err))
-		return nil, diags
-	}
-
-	err = s.StateStore.Provider.SetConfig(providerConfigVal, ssBackend.ProviderSchema())
-	if err != nil {
-		diags = diags.Append(fmt.Errorf("Failed to set state store provider configuration: %w", err))
-		return nil, diags
-	}
-
-	// Update backend state file
-	if err := sMgr.WriteState(s); err != nil {
-		diags = diags.Append(errBackendWriteSavedDiag(err))
-		return nil, diags
-	}
-	if err := sMgr.PersistState(); err != nil {
-		diags = diags.Append(errBackendWriteSavedDiag(err))
-		return nil, diags
-	}
-
-	return b, diags
-}
-
-func (m *Meta) removeLocalState(backendType string, b backend.Backend) tfdiags.Diagnostics {
-	var diags tfdiags.Diagnostics
-
-	if backendType != "local" {
-		return diags
-	}
-
-	workspaces, wDiags := b.Workspaces()
-	if wDiags.HasErrors() {
-		diags = diags.Append(&errBackendLocalRead{wDiags.Err()})
-		return diags
-	}
-
-	var localStates []statemgr.Full
-	for _, workspace := range workspaces {
-		localState, sDiags := b.StateMgr(workspace)
-		if sDiags.HasErrors() {
-			diags = diags.Append(&errBackendLocalRead{sDiags.Err()})
-			return diags
-		}
-		if err := localState.RefreshState(); err != nil {
-			diags = diags.Append(&errBackendLocalRead{err})
-			return diags
-		}
-
-		// We only care about non-empty states.
-		if localS := localState.State(); !localS.Empty() {
-			log.Printf("[TRACE] Meta.Backend: will need to migrate workspace states because of existing %q workspace", workspace)
-			localStates = append(localStates, localState)
-		} else {
-			log.Printf("[TRACE] Meta.Backend: ignoring local %q workspace because its state is empty", workspace)
-		}
-	}
-
-	if len(localStates) > 0 {
-		log.Printf("[TRACE] Meta.removeLocalState: removing old state snapshots (%d) from old backend", len(localStates))
-		for idx, localState := range localStates {
-			// We always delete the local state, unless that was our new state too.
-			if err := localState.WriteState(nil); err != nil {
-				diags = diags.Append(&errBackendMigrateLocalDelete{err})
-				return diags
-			}
-			if err := localState.PersistState(nil); err != nil {
-				diags = diags.Append(&errBackendMigrateLocalDelete{err})
-				return diags
-			}
-			log.Printf("[DEBUG] Meta.removeLocalState: deleted local state for workspace %q", workspaces[idx])
-		}
-	}
-	return diags
-}
-
 //-------------------------------------------------------------------
 // State Store Config Scenarios
 // The functions below cover handling all the various scenarios that
@@ -2521,52 +2325,6 @@ func (m *Meta) stateStore_C_s(c *configs.StateStore, stateStoreHash int, backend
 	return b, diags
 }
 
-// Migrating a state store to backend (including local).
-func (m *Meta) stateStore_to_backend(ssSMgr *clistate.LocalState, dstBackendType string, dstBackend backend.Backend, newBackendState *workdir.BackendConfigState, viewType arguments.ViewType) (backend.Backend, tfdiags.Diagnostics) {
-	var diags tfdiags.Diagnostics
-
-	s := ssSMgr.State()
-	stateStoreType := s.StateStore.Type
-
-	view := views.NewInit(viewType, m.View)
-	view.Output(views.StateMigrateLocalMessage, stateStoreType)
-
-	// Initialize the configured state store
-	ss, moreDiags := m.savedStateStore(ssSMgr)
-	diags = diags.Append(moreDiags)
-	if moreDiags.HasErrors() {
-		return nil, diags
-	}
-
-	// Perform the migration
-	err := m.backendMigrateState(&backendMigrateOpts{
-		SourceType:      stateStoreType,
-		DestinationType: dstBackendType,
-		Source:          ss,
-		Destination:     dstBackend,
-		ViewType:        viewType,
-	})
-	if err != nil {
-		diags = diags.Append(err)
-		return nil, diags
-	}
-
-	// Remove the stored metadata
-	s.StateStore = nil
-	s.Backend = newBackendState
-	if err := ssSMgr.WriteState(s); err != nil {
-		diags = diags.Append(errStateStoreClearSaved{err})
-		return nil, diags
-	}
-	if err := ssSMgr.PersistState(); err != nil {
-		diags = diags.Append(errStateStoreClearSaved{err})
-		return nil, diags
-	}
-
-	// Return backend
-	return dstBackend, diags
-}
-
 // stateStoreConfigNeedsMigration returns true if migration might be required to
 // move from the configured state store to the given cached state store config.
 //
@@ -2646,107 +2404,6 @@ func (m *Meta) stateStoreConfigNeedsMigration(cfg *configs.StateStore, cfgState 
 	}
 	log.Print("[TRACE] stateStoreConfigNeedsMigration: configuration values have changed, so migration is required")
 	return true
-}
-
-func (m *Meta) stateStore_changed(cfg *configs.StateStore, cfgHash int, sMgr *clistate.LocalState, opts *BackendOpts, initReason *ssInitReason) (backend.Backend, tfdiags.Diagnostics) {
-	var diags tfdiags.Diagnostics
-
-	vt := arguments.ViewJSON
-	// Set default viewtype if none was set as the StateLocker needs to know exactly
-	// what viewType we want to have.
-	if opts == nil || opts.ViewType != vt {
-		vt = arguments.ViewHuman
-	}
-
-	// Get the destination state store
-	dstB, storeConfigVal, providerConfigVal, moreDiags := m.stateStoreInitFromConfig(cfg, opts.Locks)
-	diags = diags.Append(moreDiags)
-	if moreDiags.HasErrors() {
-		return nil, diags
-	}
-
-	// Grab the source state store
-	srcB, srcBDiags := m.savedStateStore(sMgr)
-	diags = diags.Append(srcBDiags)
-	if srcBDiags.HasErrors() {
-		return nil, diags
-	}
-
-	// Get the old state
-	s := sMgr.State()
-
-	view := views.NewInit(vt, m.View)
-	view.Output(views.StateStoreMigrationMessage,
-		s.StateStore.Type, s.StateStore.Provider.Source.ForDisplay(),
-		cfg.Type, cfg.ProviderAddr.ForDisplay(),
-		initReason.Reason)
-
-	// Perform the migration
-	err := m.backendMigrateState(&backendMigrateOpts{
-		SourceType:      s.StateStore.Type,
-		DestinationType: cfg.Type,
-		Source:          srcB,
-		Destination:     dstB,
-		ViewType:        vt,
-	})
-	if err != nil {
-		diags = diags.Append(err)
-		return nil, diags
-	}
-
-	if m.stateLock {
-		view := views.NewStateLocker(vt, m.View)
-		stateLocker := clistate.NewLocker(m.stateLockTimeout, view)
-		if err := stateLocker.Lock(sMgr, "state store from plan"); err != nil {
-			diags = diags.Append(fmt.Errorf("Error locking state: %s", err))
-			return nil, diags
-		}
-		defer stateLocker.Unlock()
-	}
-
-	pVersion, vDiags := getStateStorageProviderVersion(cfg, opts.Locks) // pVersion will remain nil for builtin, dev override, and unmanaged providers.
-	diags = diags.Append(vDiags)
-	if vDiags.HasErrors() {
-		return nil, diags
-	}
-
-	// Update the state to the new configuration
-	s = sMgr.State()
-	if s == nil {
-		s = workdir.NewBackendStateFile()
-	}
-
-	s.StateStore = &workdir.StateStoreConfigState{
-		Type: cfg.Type,
-		Hash: uint64(cfgHash),
-		Provider: &workdir.ProviderConfigState{
-			Source:  &cfg.ProviderAddr,
-			Version: pVersion,
-		},
-		ProviderSupplyMode: cfg.ProviderSupplyMode,
-	}
-	err = s.StateStore.SetConfig(storeConfigVal, dstB.ConfigSchema())
-	if err != nil {
-		diags = diags.Append(fmt.Errorf("Failed to set state store configuration: %w", err))
-		return nil, diags
-	}
-
-	err = s.StateStore.Provider.SetConfig(providerConfigVal, dstB.ProviderSchema())
-	if err != nil {
-		diags = diags.Append(fmt.Errorf("Failed to set state store provider configuration: %w", err))
-		return nil, diags
-	}
-
-	if err := sMgr.WriteState(s); err != nil {
-		diags = diags.Append(errBackendWriteSavedDiag(err))
-		return nil, diags
-	}
-	if err := sMgr.PersistState(); err != nil {
-		diags = diags.Append(errBackendWriteSavedDiag(err))
-		return nil, diags
-	}
-
-	return dstB, diags
 }
 
 // getStateStorageProviderVersion gets the current version of the state store provider that's in use. This is achieved

--- a/internal/command/meta_backend_errors.go
+++ b/internal/command/meta_backend_errors.go
@@ -173,9 +173,9 @@ Terraform configuration you're using is using a custom configuration for
 the Terraform backend.
 
 Changes to backend configurations require reinitialization. This allows
-Terraform to set up the new configuration, copy existing state, etc. Please run
+Terraform to set up the new configuration, copy existing state, etc. Please use
 "terraform state migrate" to migrate existing state to the new state store,
-or run "terraform init -reconfigure" to use the current configuration without
+or use "terraform init -reconfigure" to use the current configuration without
 migrating existing state.
 
 If the change reason above is incorrect, please verify your configuration
@@ -184,7 +184,7 @@ configuration or state have been made.`, initReason)
 
 	return tfdiags.Sourceless(
 		tfdiags.Error,
-		"Backend initialization required, please run \"terraform init\"",
+		"Backend initialization required, please run \"terraform state migrate\" or \"terraform init -reconfigure\"",
 		msg,
 	)
 }

--- a/internal/command/meta_backend_errors.go
+++ b/internal/command/meta_backend_errors.go
@@ -173,9 +173,9 @@ Terraform configuration you're using is using a custom configuration for
 the Terraform backend.
 
 Changes to backend configurations require reinitialization. This allows
-Terraform to set up the new configuration, copy existing state, etc. Please use
+Terraform to set up the new configuration, copy existing state, etc. Please run
 "terraform state migrate" to migrate existing state to the new state store,
-or use "terraform init -reconfigure" to use the current configuration without
+or run "terraform init -reconfigure" to use the current configuration without
 migrating existing state.
 
 If the change reason above is incorrect, please verify your configuration
@@ -327,5 +327,5 @@ var migrateOrReconfigDiag = tfdiags.Sourceless(
 	tfdiags.Error,
 	"Backend configuration changed",
 	"A change in the backend configuration has been detected, which may require migrating existing state.\n\n"+
-		"If you wish to attempt automatic migration of the state, use \"terraform init -migrate-state\".\n"+
-		`If you wish to store the current configuration with no changes to the state, use "terraform init -reconfigure".`)
+		"If you wish to attempt automatic migration of the state, run \"terraform init -migrate-state\".\n"+
+		`If you wish to store the current configuration with no changes to the state, run "terraform init -reconfigure".`)

--- a/internal/command/meta_backend_errors.go
+++ b/internal/command/meta_backend_errors.go
@@ -190,18 +190,21 @@ configuration or state have been made.`, initReason)
 }
 
 type ssInitReason struct {
-	Reason  string
-	Subject *hcl.Range
+	MigrationNeeded bool
+	Reason          string
+	Subject         *hcl.Range
 }
 
 // errStateStoreInitDiag creates a diagnostic to present to users when
 // users attempt to run a non-init command after making a change to their
 // state_store configuration.
 func errStateStoreInitDiag(ir *ssInitReason) tfdiags.Diagnostics {
-	var msg string
-	if ir != nil {
-		msg += fmt.Sprintf("Reason: %s\n\n", ir.Reason)
+	if ir == nil {
+		panic("errStateStoreInitDiag requires a non-nil reason argument")
 	}
+
+	var msg string
+	msg += fmt.Sprintf("Reason: %s\n\n", ir.Reason)
 
 	msg += `A "state store" is an interface that Terraform uses to store state.
 Changes to state store configurations require reinitialization, and a
@@ -219,11 +222,19 @@ configuration or state have been made.`
 
 	var diags tfdiags.Diagnostics
 
-	if ir != nil && ir.Subject != nil {
+	var summary string
+	if ir.MigrationNeeded {
+		summary = "State store initialization required, please run \"terraform state migrate\" or \"terraform init -reconfigure\""
+	} else {
+		// When no migration is needed we're just initializing a state store for the first time.
+		summary = "State store initialization required, please run \"terraform init\""
+	}
+
+	if ir.Subject != nil {
 		diags = diags.Append(&hcl.Diagnostic{
 			Subject:  ir.Subject,
 			Severity: hcl.DiagError,
-			Summary:  "State store initialization required, please run \"terraform init\"",
+			Summary:  summary,
 			Detail:   msg,
 		})
 		return diags
@@ -231,7 +242,7 @@ configuration or state have been made.`
 
 	diags = diags.Append(tfdiags.Sourceless(
 		tfdiags.Error,
-		"State store initialization required, please run \"terraform init\"",
+		summary,
 		msg,
 	))
 

--- a/internal/command/meta_backend_errors.go
+++ b/internal/command/meta_backend_errors.go
@@ -161,6 +161,34 @@ configuration or state have been made.`, initReason)
 	)
 }
 
+// errBackendToStateStoreInitDiag is a variation of errBackendInitDiag specific to when
+// migrating from a backend to a state store. Text needs to resemble the old backend-specific diagnostic,
+// but the recommended actions are different (using new terraform state migrate command).
+func errBackendToStateStoreInitDiag(initReason string) tfdiags.Diagnostic {
+	msg := fmt.Sprintf(`Reason: %s
+
+The "backend" is the interface that Terraform uses to store state,
+perform operations, etc. If this message is showing up, it means that the
+Terraform configuration you're using is using a custom configuration for
+the Terraform backend.
+
+Changes to backend configurations require reinitialization. This allows
+Terraform to set up the new configuration, copy existing state, etc. Please run
+"terraform state migrate" to migrate existing state to the new state store,
+or run "terraform init -reconfigure" to use the current configuration without
+migrating existing state.
+
+If the change reason above is incorrect, please verify your configuration
+hasn't changed and try again. At this point, no changes to your existing
+configuration or state have been made.`, initReason)
+
+	return tfdiags.Sourceless(
+		tfdiags.Error,
+		"Backend initialization required, please run \"terraform init\"",
+		msg,
+	)
+}
+
 type ssInitReason struct {
 	Reason  string
 	Subject *hcl.Range
@@ -175,15 +203,15 @@ func errStateStoreInitDiag(ir *ssInitReason) tfdiags.Diagnostics {
 		msg += fmt.Sprintf("Reason: %s\n\n", ir.Reason)
 	}
 
-	msg += `The "state store" is the interface that Terraform uses to store state when
-performing operations on the local machine. If this message is showing up,
-it means that the Terraform configuration you're using is using a custom
-configuration for state storage in Terraform.
+	msg += `A "state store" is an interface that Terraform uses to store state.
+Changes to state store configurations require reinitialization, and a
+decision whether to migrate any existing state or not.
 
-Changes to state store configurations require reinitialization. This allows
-Terraform to set up the new configuration, copy existing state, etc. Please run
-"terraform init" with either the "-reconfigure" or "-migrate-state" flags to
-use the current configuration.
+If you want to migrate existing state using the current configuration,
+please run "terraform state migrate".
+
+If you don't want to migrate existing state and just reconfigure how state is
+stored using the current configuration, please run "terraform init -reconfigure".
 
 If the change reason above is incorrect, please verify your configuration
 hasn't changed and try again. At this point, no changes to your existing
@@ -290,29 +318,3 @@ var migrateOrReconfigDiag = tfdiags.Sourceless(
 	"A change in the backend configuration has been detected, which may require migrating existing state.\n\n"+
 		"If you wish to attempt automatic migration of the state, use \"terraform init -migrate-state\".\n"+
 		`If you wish to store the current configuration with no changes to the state, use "terraform init -reconfigure".`)
-
-// migrateOrReconfigStateStoreDiag creates a diagnostic to present to users when
-// an init command encounters a mismatch in state store config state and the current config
-// and Terraform needs users to provide additional instructions about how it
-// should proceed.
-var migrateOrReconfigStateStoreDiag = tfdiags.Sourceless(
-	tfdiags.Error,
-	"State store configuration changed",
-	"A change in the state store configuration has been detected, which may require migrating existing state.\n\n"+
-		"If you wish to attempt automatic migration of the state, use \"terraform init -migrate-state\".\n"+
-		`If you wish to store the current configuration with no changes to the state, use "terraform init -reconfigure".`)
-
-// errStateStoreClearSaved is a custom error used to alert users that
-// Terraform failed to empty the state store state file's contents.
-type errStateStoreClearSaved struct {
-	innerError error
-}
-
-func (e *errStateStoreClearSaved) Error() string {
-	return fmt.Sprintf(`Error clearing the state store configuration: %s
-
-Terraform removes the saved state store configuration when you're removing a
-configured state store. This must be done so future Terraform runs know to not
-use the state store configuration. Please look at the error above, resolve it,
-and try again.`, e.innerError)
-}


### PR DESCRIPTION
Closes https://hashicorp.atlassian.net/browse/TF-36263

Following our decision to manage PSS-related state migrations through a new `terraform state migrate` command, this PR removes handling of those migrations from the `init` command.

Previously, the `init` command would handle state migrations in these scenarios if the `-state-migrate` flag was present. If a non-`init` command was executed when there was a change present in the backend/state_store config then the command would prompt a user to run `init` again.

Now, this code will prompt the user to run either `state migrate` or `init -reconfigure`. This prompt will happen for both init and non-init commands when Terraform identifies a diff between config and the backend state file.

Following this PR there are different strands of work that would lead to re-implementing some tests to replace the ones deleted in this PR:
* The init command will error if the PSS provider is changed while upgrading providers
* The new state migrate command will be the way to:
    * upgrade the PSS provider (and then migrate state)
    * handle any config changes to a state store, or a migration to/from PSS

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.16.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
