### PR TITLE
Fix hide check scoped data sources

### DIFF
--- a/.changes/v1.16/BUG FIXES-20260414-120000.yaml
+++ b/.changes/v1.16/BUG FIXES-20260414-120000.yaml
@@ -1,0 +1,5 @@
+kind: BUG FIXES
+body: hide check-scoped data sources from plan output
+time: 2026-04-14T12:00:00.000000-04:00
+custom:
+  Issue: "36536"

--- a/internal/command/jsonformat/plan.go
+++ b/internal/command/jsonformat/plan.go
@@ -395,6 +395,13 @@ func renderHumanDiff(renderer Renderer, diff diff, cause string) (string, bool) 
 		// Skip resource changes that have nothing interesting to say.
 		return "", false
 	}
+		// Skip data sources that are reloaded only for check block verification
+	if diff.change.Mode == jsonstate.DataResourceMode &&
+		diff.change.ActionReason == jsonplan.ResourceInstanceReadBecauseCheckNested &&
+		action == plans.Read {
+		return "", false
+	}
+
 
 	var buf bytes.Buffer
 	buf.WriteString(renderer.Colorize.Color(resourceChangeComment(diff.change, action, cause)))

--- a/internal/command/jsonformat/plan.go
+++ b/internal/command/jsonformat/plan.go
@@ -77,6 +77,11 @@ func (plan Plan) renderHuman(renderer Renderer, mode plans.Mode, opts ...plans.Q
 			// Don't render anything for deleted data sources.
 			continue
 		}
+				// Skip data sources that are reloaded only for check block verification
+		if action == plans.Read && diff.change.Mode == jsonstate.DataResourceMode &&
+			diff.change.ActionReason == jsonplan.ResourceInstanceReadBecauseCheckNested {
+			continue
+		}
 
 		changes = append(changes, diff)
 


### PR DESCRIPTION
Fix hide check scoped data sources

This change skips rendering data sources in the plan output when they are being reloaded solely for check block verification (check blocks). These data sources have no actionable diff - the Action is Read with ActionReason ReadBecauseCheckNested - and showing them with an empty block in the plan output is confusing to users.

The fix adds conditions in both renderHuman and renderHumanDiff (internal/command/jsonformat/plan.go) to skip check-scoped data sources before they are rendered or counted in the plan output.

Fixes hashicorp#36536

## Target Release

1.16.x

## Rollback Plan

[x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

No changes to security controls.

## CHANGELOG entry

[x] This change is user-facing and I added a changelog entry.

[ ] This change is not user-facing.