### PR TITLE
chore: Remove unused `DefaultWorkspaceCreatedMessage` and `defaultWorkspaceCreatedInfo`

### DIFF
--- a/internal/command/views/init.go
+++ b/internal/command/views/init.go
@@ -199,10 +199,6 @@ var MessageRegistry map[InitMessageCode]InitMessage = map[InitMessageCode]InitMe
 		HumanValue: "\n[reset][bold]Initializing the state store...",
 		JSONValue:  "Initializing the state store...",
 	},
-	"default_workspace_created_message": {
-		HumanValue: defaultWorkspaceCreatedInfo,
-		JSONValue:  defaultWorkspaceCreatedInfo,
-	},
 	"dependencies_lock_changes_info": {
 		HumanValue: dependenciesLockChangesInfo,
 		JSONValue:  dependenciesLockChangesInfo,
@@ -346,7 +342,6 @@ const (
 	InitializingProviderPluginFromConfigMessage InitMessageCode = "initializing_provider_plugin_from_config_message"
 	InitializingProviderPluginFromStateMessage  InitMessageCode = "initializing_provider_plugin_from_state_message"
 	ReusingVersionIdentifiedFromConfig          InitMessageCode = "reusing_version_during_state_provider_init"
-	DefaultWorkspaceCreatedMessage              InitMessageCode = "default_workspace_created_message"
 	LockInfo                                    InitMessageCode = "lock_info"
 	DependenciesLockChangesInfo                 InitMessageCode = "dependencies_lock_changes_info"
 
@@ -479,13 +474,6 @@ Terraform has created a lock file .terraform.lock.hcl to record the provider
 selections it made above. Include this file in your version control repository
 so that Terraform can guarantee to make the same selections by default when
 you run "terraform init" in the future.`
-
-const defaultWorkspaceCreatedInfo = `
-Terraform created an empty state file for the default workspace in your state store
-because it didn't exist. If this was not intended, read the init command's documentation for
-more guidance:
-https://developer.hashicorp.com/terraform/cli/commands/init
-`
 
 const dependenciesLockChangesInfo = `
 Terraform has made some changes to the provider dependency selections recorded


### PR DESCRIPTION
These should have been removed as part of https://github.com/hashicorp/terraform/pull/38281

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.16.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
