### PR TITLE
Add machine-readable JSON output to the `workspace list` command

### DIFF
--- a/.changes/v1.16/NEW FEATURES-20260417-110628.yaml
+++ b/.changes/v1.16/NEW FEATURES-20260417-110628.yaml
@@ -1,5 +1,5 @@
 kind: NEW FEATURES
-body: 'workspace: The `workspace list` command can now produce machine-readable output when supplied with the -json flag'
+body: 'workspace: The `workspace list` command can now produce machine-readable output when supplied with the `-json` flag'
 time: 2026-04-17T11:06:28.651099+01:00
 custom:
     Issue: "38397"

--- a/.changes/v1.16/NEW FEATURES-20260417-110628.yaml
+++ b/.changes/v1.16/NEW FEATURES-20260417-110628.yaml
@@ -1,0 +1,5 @@
+kind: NEW FEATURES
+body: 'workspace: The `workspace list` command can now produce machine-readable output when supplied with the -json flag'
+time: 2026-04-17T11:06:28.651099+01:00
+custom:
+    Issue: "38397"

--- a/internal/command/arguments/workspace.go
+++ b/internal/command/arguments/workspace.go
@@ -27,7 +27,10 @@ type WorkspaceList struct {
 func ParseWorkspaceList(args []string) (*WorkspaceList, tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
 
+	var jsonOutput bool
 	cmdFlags := defaultFlagSet("workspace list")
+	cmdFlags.BoolVar(&jsonOutput, "json", false, "produce JSON output")
+
 	if err := cmdFlags.Parse(args); err != nil {
 		diags = diags.Append(tfdiags.Sourceless(
 			tfdiags.Error,
@@ -43,5 +46,10 @@ func ParseWorkspaceList(args []string) (*WorkspaceList, tfdiags.Diagnostics) {
 		diags = diags.Append(errors.New("Too many command line arguments. Did you mean to use -chdir?"))
 	}
 
-	return &WorkspaceList{Workspace: Workspace{ViewType: ViewHuman}}, diags
+	switch {
+	case jsonOutput:
+		return &WorkspaceList{Workspace: Workspace{ViewType: ViewJSON}}, diags
+	default:
+		return &WorkspaceList{Workspace: Workspace{ViewType: ViewHuman}}, diags
+	}
 }

--- a/internal/command/arguments/workspace_test.go
+++ b/internal/command/arguments/workspace_test.go
@@ -22,6 +22,14 @@ func TestParseWorkspaceList_valid(t *testing.T) {
 				},
 			},
 		},
+		"json": {
+			[]string{"-json"},
+			&WorkspaceList{
+				Workspace: Workspace{
+					ViewType: ViewJSON,
+				},
+			},
+		},
 	}
 
 	for name, tc := range testCases {
@@ -59,10 +67,10 @@ func TestParseWorkspaceList_invalid(t *testing.T) {
 			},
 		},
 		"too many arguments": {
-			[]string{"bar", "baz"},
+			[]string{"-json", "bar", "baz"},
 			&WorkspaceList{
 				Workspace: Workspace{
-					ViewType: ViewHuman,
+					ViewType: ViewJSON, // -json flag parsed correctly
 				},
 			},
 			tfdiags.Diagnostics{

--- a/internal/command/views/workspace.go
+++ b/internal/command/views/workspace.go
@@ -42,13 +42,14 @@ type WorkspaceListJSON struct {
 var _ WorkspaceList = (*WorkspaceListJSON)(nil)
 
 type WorkspaceListOutput struct {
-	Workspaces  []WorkspaceOutput       `json:"workspaces"`
-	Diagnostics []*viewsjson.Diagnostic `json:"diagnostics"`
+	FormatVersion string                  `json:"format_version"`
+	Workspaces    []WorkspaceOutput       `json:"workspaces"`
+	Diagnostics   []*viewsjson.Diagnostic `json:"diagnostics"`
 }
 
 type WorkspaceOutput struct {
 	Name      string `json:"name"`
-	IsCurrent bool   `json:"is_current"`
+	IsCurrent bool   `json:"is_current,omitempty"`
 }
 
 // List is used to log the list of present workspaces and indicate which is currently selected
@@ -56,7 +57,14 @@ type WorkspaceOutput struct {
 // If `workspace list` errors must return early with error diagnostics then the list will be empty and accompanied by errors.
 // If the command succeeds then the list will be populated and the diagnostics list will be either empty or contain warnings.
 func (v *WorkspaceListJSON) List(current string, list []string, diags tfdiags.Diagnostics) {
-	output := WorkspaceListOutput{}
+	// FormatVersion represents the version of the json format and will be
+	// incremented for any change to this format that requires changes to a
+	// consuming parser.
+	const FormatVersion = "1.0"
+
+	output := WorkspaceListOutput{
+		FormatVersion: FormatVersion,
+	}
 
 	for _, item := range list {
 		workspace := WorkspaceOutput{
@@ -67,8 +75,9 @@ func (v *WorkspaceListJSON) List(current string, list []string, diags tfdiags.Di
 	}
 
 	if output.Workspaces == nil {
-		// Make sure this always appears as an array in our output, since
-		// this is easier to consume for dynamically-typed languages.
+		// Make sure this always appears as an array in our output
+		// Zero workspaces being returned is a valid outcome. In that scenario a warning diagnostic is included,
+		// and that'll be easier to understand next to an empty workspace list.
 		output.Workspaces = []WorkspaceOutput{}
 	}
 

--- a/internal/command/views/workspace.go
+++ b/internal/command/views/workspace.go
@@ -4,10 +4,90 @@
 package views
 
 import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/hashicorp/terraform/internal/command/arguments"
+	viewsjson "github.com/hashicorp/terraform/internal/command/views/json"
 	"github.com/hashicorp/terraform/internal/tfdiags"
 )
 
 // The WorkspaceList view is used for the `workspace list` subcommand.
 type WorkspaceList interface {
 	List(selected string, list []string, diags tfdiags.Diagnostics)
+}
+
+func NewWorkspaceList(viewType arguments.ViewType, view *View) WorkspaceList {
+	switch viewType {
+	case arguments.ViewHuman:
+		// TODO: Implement human-readable output for workspace list command using the views package, and remove the use of cli.Ui. This is a breaking change.
+		panic("human-readable output for workspace list command is not supported via the views package.")
+	case arguments.ViewJSON:
+		return &WorkspaceListJSON{
+			view: view,
+		}
+	default:
+		panic(fmt.Sprintf("unsupported view type: %s", viewType))
+	}
+}
+
+// The WorkspaceListJSON implementation renders machine-readable logs, suitable for
+// integrating with other software.
+//
+// This JSON output is a 'static log'; the command should produce a single JSON object containing all the available information.
+type WorkspaceListJSON struct {
+	view *View
+}
+
+var _ WorkspaceList = (*WorkspaceListJSON)(nil)
+
+type WorkspaceListOutput struct {
+	Workspaces  []WorkspaceOutput       `json:"workspaces"`
+	Diagnostics []*viewsjson.Diagnostic `json:"diagnostics"`
+}
+
+type WorkspaceOutput struct {
+	Name      string `json:"name"`
+	IsCurrent bool   `json:"is_current"`
+}
+
+// List is used to log the list of present workspaces and indicate which is currently selected
+//
+// If `workspace list` errors must return early with error diagnostics then the list will be empty and accompanied by errors.
+// If the command succeeds then the list will be populated and the diagnostics list will be either empty or contain warnings.
+func (v *WorkspaceListJSON) List(current string, list []string, diags tfdiags.Diagnostics) {
+	output := WorkspaceListOutput{}
+
+	for _, item := range list {
+		workspace := WorkspaceOutput{
+			Name:      item,
+			IsCurrent: item == current,
+		}
+		output.Workspaces = append(output.Workspaces, workspace)
+	}
+
+	if output.Workspaces == nil {
+		// Make sure this always appears as an array in our output, since
+		// this is easier to consume for dynamically-typed languages.
+		output.Workspaces = []WorkspaceOutput{}
+	}
+
+	configSources := v.view.configSources()
+	for _, diag := range diags {
+		output.Diagnostics = append(output.Diagnostics, viewsjson.NewDiagnostic(diag, configSources))
+	}
+
+	if output.Diagnostics == nil {
+		// Make sure this always appears as an array in our output, since
+		// this is easier to consume for dynamically-typed languages.
+		output.Diagnostics = []*viewsjson.Diagnostic{}
+	}
+
+	jsonOutput, err := json.MarshalIndent(output, "", "  ")
+	if err != nil {
+		// Should never happen because we fully-control the input here
+		panic(fmt.Sprintf("failed to marshal workspace list json output: %v", err))
+	}
+
+	v.view.streams.Println(string(jsonOutput))
 }

--- a/internal/command/workspace_command_test.go
+++ b/internal/command/workspace_command_test.go
@@ -1442,22 +1442,20 @@ func TestWorkspace_list_jsonOutput(t *testing.T) {
 	}
 	output := done(t)
 	expectedStdOut := `{
+  "format_version": "1.0",
   "workspaces": [
     {
       "name": "default",
       "is_current": true
     },
     {
-      "name": "dev",
-      "is_current": false
+      "name": "dev"
     },
     {
-      "name": "stage",
-      "is_current": false
+      "name": "stage"
     },
     {
-      "name": "prod",
-      "is_current": false
+      "name": "prod"
     }
   ],
   "diagnostics": []
@@ -1497,22 +1495,20 @@ func TestWorkspace_list_jsonOutput(t *testing.T) {
 	}
 	output = done(t)
 	expectedStdOut = `{
+  "format_version": "1.0",
   "workspaces": [
     {
       "name": "default",
       "is_current": true
     },
     {
-      "name": "dev",
-      "is_current": false
+      "name": "dev"
     },
     {
-      "name": "stage",
-      "is_current": false
+      "name": "stage"
     },
     {
-      "name": "prod",
-      "is_current": false
+      "name": "prod"
     }
   ],
   "diagnostics": [
@@ -1558,6 +1554,7 @@ func TestWorkspace_list_jsonOutput(t *testing.T) {
 	}
 	output = done(t)
 	expectedStdOut = `{
+  "format_version": "1.0",
   "workspaces": [],
   "diagnostics": [
     {

--- a/internal/command/workspace_command_test.go
+++ b/internal/command/workspace_command_test.go
@@ -10,7 +10,9 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/cli"
+	"github.com/hashicorp/hcl/v2"
 
 	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/backend"
@@ -24,6 +26,7 @@ import (
 	"github.com/hashicorp/terraform/internal/states/statefile"
 	"github.com/hashicorp/terraform/internal/states/statemgr"
 	"github.com/hashicorp/terraform/internal/terminal"
+	"github.com/hashicorp/terraform/internal/tfdiags"
 )
 
 func TestWorkspace_allCommands_pluggableStateStore(t *testing.T) {
@@ -1397,5 +1400,181 @@ func TestWorkspace_humanOutput(t *testing.T) {
 	expectedOutput = "Workspace \"foobar\" doesn't exist.\n\nYou can create this workspace with the \"new\" subcommand \nor include the \"-or-create\" flag with the \"select\" subcommand.\n"
 	if actual != expectedOutput {
 		t.Fatalf("want: %s\ngot: %s", expectedOutput, actual)
+	}
+}
+
+func TestWorkspace_list_jsonOutput(t *testing.T) {
+	// Create a temporary working directory with pluggable state storage in the config
+	td := t.TempDir()
+	testCopyDir(t, testFixturePath("state-store-unchanged"), td)
+	t.Chdir(td)
+
+	// Using PSS in this test allows easy mocking of pre-existing workspaces
+	mock := testStateStoreMockWithChunkNegotiation(t, 1000)
+	mock.GetStatesResponse = &providers.GetStatesResponse{
+		States:      []string{"default", "dev", "stage", "prod"},
+		Diagnostics: nil,
+	}
+
+	ui := new(cli.MockUi)
+	view, done := testView(t)
+	meta := Meta{
+		AllowExperimentalFeatures: true,
+		Ui:                        ui,
+		View:                      view,
+		testingOverrides: &testingOverrides{
+			Providers: map[addrs.Provider]providers.Factory{
+				addrs.NewDefaultProvider("test"): providers.FactoryFixed(mock),
+			},
+		},
+		WorkingDir: workdir.NewDir("."),
+	}
+
+	// All commands run in this test should receive the -json flag
+	args := []string{"-json"}
+
+	// Step 1 - test list output with no diagnostics
+	listCmd := &WorkspaceListCommand{
+		Meta: meta,
+	}
+	if code := listCmd.Run(args); code != 0 {
+		t.Fatalf("bad: %d\n\nstderr: %s\n\nstdout: %s", code, done(t).Stderr(), done(t).Stdout())
+	}
+	output := done(t)
+	expectedStdOut := `{
+  "workspaces": [
+    {
+      "name": "default",
+      "is_current": true
+    },
+    {
+      "name": "dev",
+      "is_current": false
+    },
+    {
+      "name": "stage",
+      "is_current": false
+    },
+    {
+      "name": "prod",
+      "is_current": false
+    }
+  ],
+  "diagnostics": []
+}
+`
+	if output.Stdout() != expectedStdOut {
+		diff := cmp.Diff(expectedStdOut, output.Stdout())
+		t.Fatalf("want: %s\ngot: %s\n diff: %s",
+			expectedStdOut,
+			output.Stdout(),
+			diff,
+		)
+	}
+	if output.Stderr() != "" {
+		t.Fatalf("expected stderr to be empty, but got: %s", output.Stderr())
+	}
+
+	// Step 2 - test list output with a warning diagnostics
+	var diags tfdiags.Diagnostics
+	diags = diags.Append(&hcl.Diagnostic{
+		Severity: hcl.DiagWarning,
+		Summary:  "Warning from test",
+		Detail:   "This is a warning from the mocked state store.",
+	})
+	mock.GetStatesResponse = &providers.GetStatesResponse{
+		States:      []string{"default", "dev", "stage", "prod"},
+		Diagnostics: diags,
+	}
+
+	view, done = testView(t)
+	meta.View = view
+	listCmd = &WorkspaceListCommand{
+		Meta: meta,
+	}
+	if code := listCmd.Run(args); code != 0 {
+		t.Fatalf("bad: %d\n\nstderr: %s\n\nstdout: %s", code, done(t).Stderr(), done(t).Stdout())
+	}
+	output = done(t)
+	expectedStdOut = `{
+  "workspaces": [
+    {
+      "name": "default",
+      "is_current": true
+    },
+    {
+      "name": "dev",
+      "is_current": false
+    },
+    {
+      "name": "stage",
+      "is_current": false
+    },
+    {
+      "name": "prod",
+      "is_current": false
+    }
+  ],
+  "diagnostics": [
+    {
+      "severity": "warning",
+      "summary": "Warning from test",
+      "detail": "This is a warning from the mocked state store."
+    }
+  ]
+}
+`
+	if output.Stdout() != expectedStdOut {
+		diff := cmp.Diff(expectedStdOut, output.Stdout())
+		t.Fatalf("want: %s\ngot: %s\n diff: %s",
+			expectedStdOut,
+			output.Stdout(),
+			diff,
+		)
+	}
+	if output.Stderr() != "" {
+		t.Fatalf("expected stderr to be empty, but got: %s", output.Stderr())
+	}
+
+	// Step 3 - test that error diagnostics are shown in isolation (no additional output even if present)
+	diags = tfdiags.Diagnostics{} // empty
+	diags = diags.Append(&hcl.Diagnostic{
+		Severity: hcl.DiagError,
+		Summary:  "Error from test",
+		Detail:   "This is a error from the mocked state store.",
+	})
+	mock.GetStatesResponse = &providers.GetStatesResponse{
+		States:      []string{"default", "dev", "stage", "prod"},
+		Diagnostics: diags,
+	}
+
+	view, done = testView(t)
+	meta.View = view
+	listCmd = &WorkspaceListCommand{
+		Meta: meta,
+	}
+	if code := listCmd.Run(args); code != 1 {
+		t.Fatalf("expected a failure with code 1, but got: %d\n\n%s", code, done(t).All())
+	}
+	output = done(t)
+	expectedStdOut = `{
+  "workspaces": [],
+  "diagnostics": [
+    {
+      "severity": "error",
+      "summary": "Error from test",
+      "detail": "This is a error from the mocked state store."
+    }
+  ]
+}
+`
+	if output.Stdout() != expectedStdOut {
+		t.Fatalf("want: %s\ngot: %s",
+			expectedStdOut,
+			output.Stdout(),
+		)
+	}
+	if output.Stderr() != "" {
+		t.Fatalf("expected stderr to be empty, but got: %s", output.Stderr())
 	}
 }

--- a/internal/command/workspace_list.go
+++ b/internal/command/workspace_list.go
@@ -103,6 +103,10 @@ Usage: terraform [global options] workspace list
 
   List Terraform workspaces.
 
+Options:
+
+  -json            If specified, machine readable output will be
+                   printed in JSON format.
 `
 	return strings.TrimSpace(helpText)
 }

--- a/internal/command/workspace_list.go
+++ b/internal/command/workspace_list.go
@@ -150,7 +150,7 @@ func (v *workspaceListHuman) List(selected string, list []string, diags tfdiags.
 func newWorkspaceList(vt arguments.ViewType, view *views.View, ui cli.Ui, meta *Meta) views.WorkspaceList {
 	switch vt {
 	case arguments.ViewJSON:
-		panic("JSON output is not supported for workspace list command")
+		return views.NewWorkspaceList(vt, view)
 	case arguments.ViewHuman:
 		return &workspaceListHuman{
 			ui:   ui,


### PR DESCRIPTION
Follows https://github.com/hashicorp/terraform/pull/38392

This PR adds JSON output to the workspace list command. The new JSON output is a static log; the command will produce only one log, and its structure is the same regardless of outcome. This makes the JSON easier to consume.

I'm hoping for feedback to mainly look at the design of the JSON object. Here are choices I've made:
* "current" not "selected" when identifying the workspace that's in use - matches [phrasing in the docs](https://developer.hashicorp.com/terraform/cli/commands/workspace/list)
* boolean per workspace in the list, instead of a top-level "current_workspace" field
    *  My rationale was that having workspaces in a list of objects (vs a list of strings) was more extensible in future. Given that choice, it made sense for the first field besides the name to be is_current.


In the happy path, including a warning, output looks like:

```json
{
  "format_version": "1.0",
  "workspaces": [
    {
      "name": "default",
      "is_current": true
    },
    {
      "name": "dev",
      "is_current": false
    },
    {
      "name": "stage",
      "is_current": false
    },
    {
      "name": "prod",
      "is_current": false
    }
  ],
  "diagnostics": [
    {
      "severity": "warning",
      "summary": "Warning!",
      "detail": "Consider yourself warned."
    }
  ]
}
```

In the unhappy path output looks like:

```json
{
  "format_version": "1.0",
  "workspaces": [],
  "diagnostics": [
    {
      "severity": "error",
      "summary": "Error",
      "detail": "This is an error."
    }
  ]
}
```

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.16.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [ ] This change is not user-facing.
