### PR TITLE
Fix `fmt` for `.tfquery.hcl` files

### DIFF
--- a/.changes/v1.15/BUG FIXES-20260417-124134.yaml
+++ b/.changes/v1.15/BUG FIXES-20260417-124134.yaml
@@ -1,0 +1,5 @@
+kind: BUG FIXES
+body: Enable formatting of `.tfquery.hcl` files by `terraform fmt`
+time: 2026-04-17T12:41:34.311508+02:00
+custom:
+    Issue: "38398"

--- a/internal/command/fmt.go
+++ b/internal/command/fmt.go
@@ -32,6 +32,7 @@ var (
 		".tfvars",
 		".tftest.hcl",
 		".tfmock.hcl",
+		".tfquery.hcl",
 	}
 )
 
@@ -50,10 +51,6 @@ type FmtCommand struct {
 func (c *FmtCommand) Run(args []string) int {
 	if c.input == nil {
 		c.input = os.Stdin
-	}
-
-	if c.Meta.AllowExperimentalFeatures {
-		fmtSupportedExts = append(fmtSupportedExts, ".tfquery.hcl")
 	}
 
 	args = c.Meta.process(args)

--- a/internal/command/fmt_test.go
+++ b/internal/command/fmt_test.go
@@ -186,9 +186,8 @@ func TestFmt_QueryFiles(t *testing.T) {
 			ui := cli.NewMockUi()
 			c := &FmtCommand{
 				Meta: Meta{
-					testingOverrides:          metaOverridesForProvider(testProvider()),
-					Ui:                        ui,
-					AllowExperimentalFeatures: true,
+					testingOverrides: metaOverridesForProvider(testProvider()),
+					Ui:               ui,
 				},
 			}
 			args := []string{gotFile}


### PR DESCRIPTION
While looking at commands in a different context, I noticed that formatting support for query files was still gated behind an experimental flag. This PR removes the flag and enables query file formatting by default.

<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Fixes #

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.15.1

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [x] This change is user-facing and I added a changelog entry.
- [ ] This change is not user-facing.
