### PR TITLE
Fix `validate` not returning JSON for early diagnostics

### DIFF
--- a/.changes/v1.15/BUG FIXES-20260417-181051.yaml
+++ b/.changes/v1.15/BUG FIXES-20260417-181051.yaml
@@ -1,0 +1,5 @@
+kind: BUG FIXES
+body: Fix `validate` not returning JSON for some early diagnostics
+time: 2026-04-17T18:10:51.004741+02:00
+custom:
+    Issue: "38400"

--- a/internal/command/validate.go
+++ b/internal/command/validate.go
@@ -50,28 +50,26 @@ func (c *ValidateCommand) Run(rawArgs []string) int {
 	// If the query flag is set, include query files in the validation.
 	c.includeQueryFiles = c.ParsedArgs.Query
 
+	// After this point, we must only produce JSON output if JSON mode is
+	// enabled, so all errors should be accumulated into diags and we'll
+	// print out a suitable result at the end, depending on the format
+	// selection. All returns from this point on must be tail-calls into
+	// view.Results in order to produce the expected output.
+
 	loader, err := c.initConfigLoader()
 	if err != nil {
 		diags = diags.Append(err)
-		view.Diagnostics(diags)
-		return 1
+		return view.Results(diags)
 	}
 
 	var varDiags tfdiags.Diagnostics
 	c.VariableValues, varDiags = args.Vars.CollectValues(func(filename string, src []byte) {
 		loader.Parser().ForceFileSource(filename, src)
 	})
-	diags = diags.Append(varDiags)
-	if diags.HasErrors() {
-		view.Diagnostics(diags)
-		return 1
+	if varDiags.HasErrors() {
+		diags = diags.Append(varDiags)
+		return view.Results(diags)
 	}
-
-	// After this point, we must only produce JSON output if JSON mode is
-	// enabled, so all errors should be accumulated into diags and we'll
-	// print out a suitable result at the end, depending on the format
-	// selection. All returns from this point on must be tail-calls into
-	// view.Results in order to produce the expected output.
 
 	dir, err := filepath.Abs(args.Path)
 	if err != nil {

--- a/internal/command/validate_test.go
+++ b/internal/command/validate_test.go
@@ -577,6 +577,22 @@ func TestValidate_json(t *testing.T) {
 	}
 }
 
+func TestValidate_ensure_json_diags(t *testing.T) {
+	output, code := setupTest(t, "validate-invalid", "-json", "-var", "foo")
+
+	if code != 1 {
+		t.Fatalf("Should have failed: %d\n\n%s", code, output.Stderr())
+	}
+
+	gotString := output.Stdout()
+
+	var got map[string]any
+	err := json.Unmarshal([]byte(gotString), &got)
+	if err != nil {
+		t.Fatalf("Test did not produce valid JSON: %s", err)
+	}
+}
+
 func TestValidateWithInvalidListResource(t *testing.T) {
 	td := t.TempDir()
 	cases := []struct {


### PR DESCRIPTION
Errors during initializing the config loader and collecting variable values were printed as human readable message even if `-json` was specified. This PR fixes this behavior and turns both errors into JSON.

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.15.1

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [x] This change is user-facing and I added a changelog entry.
- [ ] This change is not user-facing.
