### PR TITLE
fix(terraform): handle action_trigger in data resource lifecycle

### DIFF
--- a/internal/configs/resource.go
+++ b/internal/configs/resource.go
@@ -29,6 +29,7 @@ type Resource struct {
 
 	Preconditions  []*CheckRule
 	Postconditions []*CheckRule
+	ActionTriggers []*ActionTrigger
 
 	DependsOn []hcl.Traversal
 
@@ -684,6 +685,12 @@ func decodeDataBlock(block *hcl.Block, override, nested bool) (*Resource, hcl.Di
 						r.Preconditions = append(r.Preconditions, cr)
 					case "postcondition":
 						r.Postconditions = append(r.Postconditions, cr)
+					}
+				case "action_trigger":
+					at, atDiags := decodeActionTriggerBlock(block)
+					diags = append(diags, atDiags...)
+					if at != nil {
+						r.ActionTriggers = append(r.ActionTriggers, at)
 					}
 				default:
 					// The cases above should be exhaustive for all block types


### PR DESCRIPTION
Terraform validate crashes when a data resource has an action_trigger block in its lifecycle block.

The resourceLifecycleBlockSchema includes action_trigger as a valid block type, but decodeDataBlock only handled precondition and postcondition, causing a panic for action_trigger.

This fix adds the ActionTriggers field to the Resource struct and handles the action_trigger case in the decodeDataBlock switch statement.

Fixes #38402