### PR TITLE
Ignore key expiration errors on stacks plugin installation

### DIFF
--- a/.changes/v1.13/BUG FIXES-20260420-163016.yaml
+++ b/.changes/v1.13/BUG FIXES-20260420-163016.yaml
@@ -1,0 +1,5 @@
+kind: BUG FIXES
+body: Fix Terraform Stacks plugin installation error
+time: 2026-04-20T16:30:16.77992+02:00
+custom:
+    Issue: "38406"

--- a/.changes/v1.14/BUG FIXES-20260420-163016.yaml
+++ b/.changes/v1.14/BUG FIXES-20260420-163016.yaml
@@ -1,0 +1,5 @@
+kind: BUG FIXES
+body: Fix Terraform Stacks plugin installation error
+time: 2026-04-20T16:30:16.77992+02:00
+custom:
+    Issue: "38406"

--- a/.changes/v1.15/BUG FIXES-20260420-163016.yaml
+++ b/.changes/v1.15/BUG FIXES-20260420-163016.yaml
@@ -1,0 +1,5 @@
+kind: BUG FIXES
+body: Fix Terraform Stacks plugin installation error
+time: 2026-04-20T16:30:16.77992+02:00
+custom:
+    Issue: "38406"

--- a/internal/releaseauth/signature.go
+++ b/internal/releaseauth/signature.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/ProtonMail/go-crypto/openpgp"
+	openpgpErrors "github.com/ProtonMail/go-crypto/openpgp/errors"
 )
 
 // SignatureAuthentication is an archive Authenticator that validates that SHA256SUMS data
@@ -48,7 +49,13 @@ func (a SignatureAuthentication) Authenticate() error {
 		return fmt.Errorf("error creating HashiCorp keyring: %s", err)
 	}
 
-	_, err = openpgp.CheckDetachedSignature(hashicorpKeyring, bytes.NewReader(a.signed), bytes.NewReader(a.signature), nil)
+	entity, err := openpgp.CheckDetachedSignature(hashicorpKeyring, bytes.NewReader(a.signed), bytes.NewReader(a.signature), nil)
+	if err == openpgpErrors.ErrKeyExpired {
+		for id := range entity.Identities {
+			log.Printf("[WARN] expired openpgp key from %s\n", id)
+		}
+		err = nil
+	}
 	if err != nil {
 		log.Printf("[DEBUG] GPG reported an error while verifying detached signature: %s", err)
 		return ErrNotSignedByHashiCorp


### PR DESCRIPTION
This PR aligns the stacks plugin installation checks with the provider installation:

https://github.com/hashicorp/terraform/blob/97265cf46ef95f26f3d47b1449a56c35bb9e2dac/internal/getproviders/package_authentication.go#L466-L477

This fixes the stacks plugin installation error. In the long run we should merge both code paths.

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.14.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [x] This change is user-facing and I added a changelog entry.
- [ ] This change is not user-facing.
