### PR TITLE
Fix typo "occured" → "occurred" in state serialization diagnostics

### DIFF
--- a/internal/states/statefile/version4.go
+++ b/internal/states/statefile/version4.go
@@ -339,7 +339,7 @@ func writeStateV4(file *File, w io.Writer) tfdiags.Diagnostics {
 			diags = diags.Append(tfdiags.Sourceless(
 				tfdiags.Error,
 				"Failed to serialize output value in state",
-				fmt.Sprintf("An error occured while serializing output value %q: %s.", name, err),
+				fmt.Sprintf("An error occurred while serializing output value %q: %s.", name, err),
 			))
 			continue
 		}
@@ -349,7 +349,7 @@ func writeStateV4(file *File, w io.Writer) tfdiags.Diagnostics {
 			diags = diags.Append(tfdiags.Sourceless(
 				tfdiags.Error,
 				"Failed to serialize output value in state",
-				fmt.Sprintf("An error occured while serializing the type of output value %q: %s.", name, err),
+				fmt.Sprintf("An error occurred while serializing the type of output value %q: %s.", name, err),
 			))
 			continue
 		}
@@ -422,7 +422,7 @@ func writeStateV4(file *File, w io.Writer) tfdiags.Diagnostics {
 		diags = diags.Append(tfdiags.Sourceless(
 			tfdiags.Error,
 			"Failed to serialize state",
-			fmt.Sprintf("An error occured while serializing the state to save it. This is a bug in Terraform and should be reported: %s.", err),
+			fmt.Sprintf("An error occurred while serializing the state to save it. This is a bug in Terraform and should be reported: %s.", err),
 		))
 		return diags
 	}
@@ -433,7 +433,7 @@ func writeStateV4(file *File, w io.Writer) tfdiags.Diagnostics {
 		diags = diags.Append(tfdiags.Sourceless(
 			tfdiags.Error,
 			"Failed to write state",
-			fmt.Sprintf("An error occured while writing the serialized state: %s.", err),
+			fmt.Sprintf("An error occurred while writing the serialized state: %s.", err),
 		))
 		return diags
 	}


### PR DESCRIPTION

**Repo:** hashicorp/terraform (⭐ 41000)
**Type:** docs
**Files changed:** 1
**Lines:** +4/-4

## What
Corrects a recurring spelling mistake ("occured" → "occurred") in four user-facing diagnostic messages emitted from `internal/states/statefile/version4.go` when Terraform fails to serialize an output value, an output value's type, or the overall state file.

## Why
These error strings are surfaced verbatim to operators when something goes wrong while writing state. The misspelling is visible in CLI output and in any logs/issue reports that include the diagnostic, so cleaning it up is a small polish that improves the perceived quality of error reporting without changing any behavior.

## Testing
Pure string change in user-facing diagnostic detail. No code paths or structured fields are affected, so existing tests continue to pass. Manual verification: `grep -n "occured" internal/states/statefile/version4.go` returns no matches after the patch.

## Risk
Low — comment/string-only change; no logic, types, or APIs altered.
