### PR TITLE
Make `validate -json` command produce JSON output when argument parsing raises an error

### DIFF
--- a/internal/command/validate.go
+++ b/internal/command/validate.go
@@ -38,14 +38,17 @@ func (c *ValidateCommand) Run(rawArgs []string) int {
 
 	// Parse and validate flags
 	args, diags := arguments.ParseValidate(rawArgs)
-	if diags.HasErrors() {
-		c.View.Diagnostics(diags)
-		c.View.HelpPrompt("validate")
-		return 1
-	}
 
 	c.ParsedArgs = args
 	view := views.NewValidate(args.ViewType, c.View)
+
+	// Now the view is ready, process any diagnostics from argument parsing
+	if diags.HasErrors() {
+		if args.ViewType == arguments.ViewHuman {
+			defer c.View.HelpPrompt("validate")
+		}
+		return view.Results(diags)
+	}
 
 	// If the query flag is set, include query files in the validation.
 	c.includeQueryFiles = c.ParsedArgs.Query

--- a/internal/command/validate_test.go
+++ b/internal/command/validate_test.go
@@ -578,19 +578,21 @@ func TestValidate_json(t *testing.T) {
 }
 
 func TestValidate_ensure_json_diags(t *testing.T) {
-	output, code := setupTest(t, "validate-invalid", "-json", "-var", "foo")
+	t.Run("-var error diags are rendered using the correct view ", func(t *testing.T) {
+		output, code := setupTest(t, "validate-invalid", "-json", "-var", "foo")
 
-	if code != 1 {
-		t.Fatalf("Should have failed: %d\n\n%s", code, output.Stderr())
-	}
+		if code != 1 {
+			t.Fatalf("Should have failed: %d\n\n%s", code, output.Stderr())
+		}
 
-	gotString := output.Stdout()
+		gotString := output.Stdout()
 
-	var got map[string]any
-	err := json.Unmarshal([]byte(gotString), &got)
-	if err != nil {
-		t.Fatalf("Test did not produce valid JSON: %s", err)
-	}
+		var got map[string]any
+		err := json.Unmarshal([]byte(gotString), &got)
+		if err != nil {
+			t.Fatalf("Test did not produce valid JSON: %s", err)
+		}
+	})
 }
 
 func TestValidateWithInvalidListResource(t *testing.T) {

--- a/internal/command/validate_test.go
+++ b/internal/command/validate_test.go
@@ -584,6 +584,28 @@ func TestValidate_ensure_json_diags(t *testing.T) {
 		if code != 1 {
 			t.Fatalf("Should have failed: %d\n\n%s", code, output.Stderr())
 		}
+		if output.Stderr() != "" {
+			t.Fatalf("Expected output, all json output should go to stdout, got stderr: %s", output.Stderr())
+		}
+
+		gotString := output.Stdout()
+
+		var got map[string]any
+		err := json.Unmarshal([]byte(gotString), &got)
+		if err != nil {
+			t.Fatalf("Test did not produce valid JSON: %s", err)
+		}
+	})
+
+	t.Run("Flag/argument parsing error diags are rendered using the correct view ", func(t *testing.T) {
+		output, code := setupTest(t, "validate-invalid", "-json", "-foobar")
+
+		if code != 1 {
+			t.Fatalf("Should have failed: %d\n\n%s", code, output.Stderr())
+		}
+		if output.Stderr() != "" {
+			t.Fatalf("Expected output, all json output should go to stdout, got stderr: %s", output.Stderr())
+		}
 
 		gotString := output.Stdout()
 


### PR DESCRIPTION
The parser methods in the `arguments` package are meant to produce [a 'best effort' interpretation of the flags and arguments](https://github.com/hashicorp/terraform/blob/d6278dff8c5eb02e3df2ce76b4b1ede175f10b1f/internal/command/arguments/validate.go#L35-L36) that a command has received. Because of this it's reasonable to expect Terraform to be able to report argument parsing errors in either human or machine-readable formats. The command just needs to delay handling the diagnostics until after the view is set up.

This raises some questions:
1. How do we handle calls to c.View.HelpPrompt, which is arguably a human-only feature of a command?
2. Should we remove c.View.HelpPrompt from the codebase?
    3.  Or, add it everywhere?

~My opinion is we can remove it; it is only used in 5 commands currently, and what it does is append this to the output using a string argument~ realised that it's actually used in 10 commands, but still inconsistent!


If we keep it, we could make it only shown when human readable output is selected - this is shown in this PR.

```
% terraform validate -json -foobar
{
  "format_version": "1.0",
  "valid": false,
  "error_count": 1,
  "warning_count": 0,
  "diagnostics": [
    {
      "severity": "error",
      "summary": "Failed to parse command-line flags",
      "detail": "flag provided but not defined: -foobar"
    }
  ]
}
```

```
% terraform validate -foobar      
╷
│ Error: Failed to parse command-line flags
│ 
│ flag provided but not defined: -foobar
╵

For more help on using this command, run:
  terraform validate -help
```

# Conclusion

Merging as-is because it avoids breaking changes to human output

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.16.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [x] This change is user-facing and I added a changelog entry.
- [ ] This change is not user-facing.
