### PR TITLE
chore: typo sweep (seperate, recieve, occured)

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -312,7 +312,7 @@ We value open communication about the tools and methods used to build Terraform.
 
 ### Accountability
 
-Understanding that AI usage can range along a spectrum from AI assistance to AI led approaches we strongly prefer an approach that leaves the contributor in the drivers seat. AI is a tool, not a seperate contributor. The responsibility for changes submitted lies entirely with you, the human opening the PR.
+Understanding that AI usage can range along a spectrum from AI assistance to AI led approaches we strongly prefer an approach that leaves the contributor in the drivers seat. AI is a tool, not a separate contributor. The responsibility for changes submitted lies entirely with you, the human opening the PR.
 
 * **Human ownership**: All PRs must be submitted by a real, human-owned account. We do not accept submissions from bot accounts used for code generation.
 * **Human review**: We proceed with the assumption that every line of code has been reviewed by you. You must ensure that the code meets our quality standards, that edge cases are handled, and that appropriate tests are written and passing.

--- a/internal/lang/funcs/crypto.go
+++ b/internal/lang/funcs/crypto.go
@@ -126,7 +126,7 @@ var BcryptFunc = function.New(&function.Spec{
 		input := args[0].AsString()
 		out, err := bcrypt.GenerateFromPassword([]byte(input), defaultCost)
 		if err != nil {
-			return cty.UnknownVal(cty.String), fmt.Errorf("error occured generating password %s", err.Error())
+			return cty.UnknownVal(cty.String), fmt.Errorf("error occurred generating password %s", err.Error())
 		}
 
 		return cty.StringVal(string(out)), nil

--- a/internal/states/statefile/version4.go
+++ b/internal/states/statefile/version4.go
@@ -339,7 +339,7 @@ func writeStateV4(file *File, w io.Writer) tfdiags.Diagnostics {
 			diags = diags.Append(tfdiags.Sourceless(
 				tfdiags.Error,
 				"Failed to serialize output value in state",
-				fmt.Sprintf("An error occured while serializing output value %q: %s.", name, err),
+				fmt.Sprintf("An error occurred while serializing output value %q: %s.", name, err),
 			))
 			continue
 		}
@@ -349,7 +349,7 @@ func writeStateV4(file *File, w io.Writer) tfdiags.Diagnostics {
 			diags = diags.Append(tfdiags.Sourceless(
 				tfdiags.Error,
 				"Failed to serialize output value in state",
-				fmt.Sprintf("An error occured while serializing the type of output value %q: %s.", name, err),
+				fmt.Sprintf("An error occurred while serializing the type of output value %q: %s.", name, err),
 			))
 			continue
 		}
@@ -422,7 +422,7 @@ func writeStateV4(file *File, w io.Writer) tfdiags.Diagnostics {
 		diags = diags.Append(tfdiags.Sourceless(
 			tfdiags.Error,
 			"Failed to serialize state",
-			fmt.Sprintf("An error occured while serializing the state to save it. This is a bug in Terraform and should be reported: %s.", err),
+			fmt.Sprintf("An error occurred while serializing the state to save it. This is a bug in Terraform and should be reported: %s.", err),
 		))
 		return diags
 	}
@@ -433,7 +433,7 @@ func writeStateV4(file *File, w io.Writer) tfdiags.Diagnostics {
 		diags = diags.Append(tfdiags.Sourceless(
 			tfdiags.Error,
 			"Failed to write state",
-			fmt.Sprintf("An error occured while writing the serialized state: %s.", err),
+			fmt.Sprintf("An error occurred while writing the serialized state: %s.", err),
 		))
 		return diags
 	}

--- a/internal/terraform/eval_context_builtin.go
+++ b/internal/terraform/eval_context_builtin.go
@@ -64,7 +64,7 @@ type BuiltinEvalContext struct {
 	// ExternalProviderConfigs are pre-configured provider instances passed
 	// in by the caller, for situations like Stack components where the
 	// root module isn't designed to be planned and applied in isolation and
-	// instead expects to recieve certain provider configurations from the
+	// instead expects to receive certain provider configurations from the
 	// stack configuration.
 	ExternalProviderConfigs map[addrs.RootProviderConfig]providers.Interface
 


### PR DESCRIPTION
Small sweep of prose/comment typos — no functional change:

- `.github/CONTRIBUTING.md:315` — AI is a tool, not a `seperate` -> `separate` contributor
- `internal/lang/funcs/crypto.go:129` — bcrypt error string `error occured` -> `error occurred`
- `internal/terraform/eval_context_builtin.go:67` — `ExternalProviderConfigs` doc comment `recieve` -> `receive`
- `internal/states/statefile/version4.go:342/352/425/436` — four diagnostic summaries `An error occured` -> `An error occurred`

Terraform test values named `nonexistant` in `evaluate_valid_test.go` / `context_validate_test.go` were intentionally left alone — they are test fixtures naming a never-declared resource; changing them would churn the test corpus without fixing anything user-visible.