### PR TITLE
refactor: Update `workspace select` and `new` subcommands to use the arguments package for parsing arguments and flags

### DIFF
--- a/internal/command/arguments/workspace.go
+++ b/internal/command/arguments/workspace.go
@@ -3,6 +3,8 @@
 
 package arguments
 
+import "net/url"
+
 // Workspace represents the command-line arguments common between all workspace subcommands.
 //
 // Subcommands that accept additional arguments should have a specific struct that embeds this struct.
@@ -10,3 +12,18 @@ type Workspace struct {
 	// ViewType specifies which output format to use
 	ViewType ViewType
 }
+
+// ValidWorkspaceName returns true is this name is valid to use as a workspace name.
+// Since most named states are accessed via a filesystem path or URL, check if
+// escaping the name would be required.
+func ValidWorkspaceName(name string) bool {
+	if name == "" {
+		return false
+	}
+	return name == url.PathEscape(name)
+}
+
+const EnvInvalidName = `
+The workspace name %q is not allowed. The name must contain only URL safe
+characters, contain no path separators, and not be an empty string.
+`

--- a/internal/command/arguments/workspace_delete.go
+++ b/internal/command/arguments/workspace_delete.go
@@ -62,6 +62,7 @@ func ParseWorkspaceDelete(args []string) (*WorkspaceDelete, tfdiags.Diagnostics)
 			diags = diags.Append(fmt.Errorf("Expected a workspace name as an argument, instead got an empty string: %q\n", args[0]))
 		}
 
+		// Checking for extra arguments here, not with a len != 1 check above, allows the name to be returned
 		args = args[1:]
 		if len(args) != 0 {
 			diags = diags.Append(errors.New("Expected a single argument: NAME."))

--- a/internal/command/arguments/workspace_new.go
+++ b/internal/command/arguments/workspace_new.go
@@ -1,0 +1,70 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package arguments
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/terraform/internal/tfdiags"
+)
+
+// WorkspaceNew represent flags and arguments specific to the `terraform workspace new` command.
+type WorkspaceNew struct {
+	Workspace
+
+	// Flags
+	Lock        bool
+	LockTimeout time.Duration
+	StatePath   string
+
+	// Positional arguments
+	Name string
+}
+
+// ParseWorkspaceNew processes CLI arguments, returning a WorkspaceNew value and errors.
+// If errors are encountered, an WorkspaceNew value is still returned representing
+// the best effort interpretation of the arguments.
+func ParseWorkspaceNew(args []string) (*WorkspaceNew, tfdiags.Diagnostics) {
+	var diags tfdiags.Diagnostics
+
+	var stateLock bool
+	var stateLockTimeout time.Duration
+	var statePath string
+	cmdFlags := defaultFlagSet("workspace new")
+	cmdFlags.BoolVar(&stateLock, "lock", true, "lock state")
+	cmdFlags.DurationVar(&stateLockTimeout, "lock-timeout", 0, "lock timeout")
+	cmdFlags.StringVar(&statePath, "state", "", "terraform state file")
+	if err := cmdFlags.Parse(args); err != nil {
+		diags = diags.Append(tfdiags.Sourceless(
+			tfdiags.Error,
+			"Failed to parse command-line flags",
+			err.Error(),
+		))
+	}
+
+	// `workspace new` takes only one positional argument: workspace name.
+	args = cmdFlags.Args()
+	if len(args) != 1 {
+		diags = diags.Append(errors.New("Expected a single argument: NAME.")) // Recreating pre-existing error from command package
+	}
+
+	// Obtain and validate name argument, but only if there is the expected number of arguments.
+	var name string
+	if len(args) == 1 {
+		name = args[0]
+		if !ValidWorkspaceName(name) {
+			diags = diags.Append(fmt.Errorf(EnvInvalidName, name))
+		}
+	}
+
+	return &WorkspaceNew{
+		Workspace:   Workspace{ViewType: ViewHuman},
+		Name:        name,
+		Lock:        stateLock,
+		LockTimeout: stateLockTimeout,
+		StatePath:   statePath,
+	}, diags
+}

--- a/internal/command/arguments/workspace_new_test.go
+++ b/internal/command/arguments/workspace_new_test.go
@@ -1,0 +1,149 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package arguments
+
+import (
+	"testing"
+	"time"
+
+	"github.com/hashicorp/terraform/internal/tfdiags"
+)
+
+func TestParseWorkspaceNew_valid(t *testing.T) {
+	testCases := map[string]struct {
+		args []string
+		want *WorkspaceNew
+	}{
+		"name specified & default flags": {
+			[]string{"my-new-workspace"},
+			&WorkspaceNew{
+				Workspace: Workspace{
+					ViewType: ViewHuman,
+				},
+				Name:        "my-new-workspace",
+				Lock:        true,
+				LockTimeout: 0,
+				StatePath:   "",
+			},
+		},
+		"locking turned off via -lock": {
+			[]string{"-lock=false", "my-new-workspace"},
+			&WorkspaceNew{
+				Workspace: Workspace{
+					ViewType: ViewHuman,
+				},
+				Name:        "my-new-workspace",
+				Lock:        false,
+				LockTimeout: 0,
+				StatePath:   "",
+			},
+		},
+		"lock timeout specified via -lock-timeout": {
+			[]string{"-lock-timeout=30s", "my-new-workspace"},
+			&WorkspaceNew{
+				Workspace: Workspace{
+					ViewType: ViewHuman,
+				},
+				Name:        "my-new-workspace",
+				Lock:        true,
+				LockTimeout: 30 * time.Second,
+				StatePath:   "",
+			},
+		},
+		"state path specified via -state": {
+			[]string{"-state=path/to/state", "my-new-workspace"},
+			&WorkspaceNew{
+				Workspace: Workspace{
+					ViewType: ViewHuman,
+				},
+				Name:        "my-new-workspace",
+				Lock:        true,
+				LockTimeout: 0,
+				StatePath:   "path/to/state",
+			},
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			got, diags := ParseWorkspaceNew(tc.args)
+			if len(diags) > 0 {
+				t.Fatalf("unexpected diags: %v", diags)
+			}
+			if *got != *tc.want {
+				t.Fatalf("unexpected result\n got: %#v\nwant: %#v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestParseWorkspaceNew_invalid(t *testing.T) {
+	testCases := map[string]struct {
+		args      []string
+		want      *WorkspaceNew
+		wantDiags tfdiags.Diagnostics
+	}{
+		"unknown flag": {
+			[]string{"-boop", "my-new-workspace"},
+			&WorkspaceNew{
+				Workspace: Workspace{
+					ViewType: ViewHuman,
+				},
+				Name: "my-new-workspace",
+				Lock: true,
+			},
+			tfdiags.Diagnostics{
+				tfdiags.Sourceless(
+					tfdiags.Error,
+					"Failed to parse command-line flags",
+					"flag provided but not defined: -boop",
+				),
+			},
+		},
+		"too many arguments": {
+			[]string{"my-new-workspace", "bar"},
+			&WorkspaceNew{
+				Workspace: Workspace{
+					ViewType: ViewHuman,
+				},
+				Name: "", // Isn't set if there are extra arguments supplied
+				Lock: true,
+			},
+			tfdiags.Diagnostics{
+				tfdiags.Sourceless(
+					tfdiags.Error,
+					"Expected a single argument: NAME.",
+					"", // No detail
+				),
+			},
+		},
+		"invalid workspace name": {
+			[]string{"§@!invalid-name!@§"},
+			&WorkspaceNew{
+				Workspace: Workspace{
+					ViewType: ViewHuman,
+				},
+				Name: "§@!invalid-name!@§",
+				Lock: true,
+			},
+			tfdiags.Diagnostics{
+				tfdiags.Sourceless(
+					tfdiags.Error,
+					"\nThe workspace name \"§@!invalid-name!@§\" is not allowed. The name must contain only URL safe\ncharacters, contain no path separators, and not be an empty string.\n",
+					"", // No detail
+				),
+			},
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			got, gotDiags := ParseWorkspaceNew(tc.args)
+			if *got != *tc.want {
+				t.Fatalf("unexpected result\n got: %#v\nwant: %#v", got, tc.want)
+			}
+			tfdiags.AssertDiagnosticsMatch(t, gotDiags, tc.wantDiags)
+		})
+	}
+}

--- a/internal/command/arguments/workspace_select.go
+++ b/internal/command/arguments/workspace_select.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform/internal/tfdiags"
 )
 
-// WorkspaceSelect represent flags and arguments specific to the `terraform workspace new` command.
+// WorkspaceSelect represent flags and arguments specific to the `terraform workspace select` command.
 type WorkspaceSelect struct {
 	Workspace
 

--- a/internal/command/arguments/workspace_select.go
+++ b/internal/command/arguments/workspace_select.go
@@ -1,0 +1,65 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package arguments
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/hashicorp/terraform/internal/tfdiags"
+)
+
+// WorkspaceSelect represent flags and arguments specific to the `terraform workspace new` command.
+type WorkspaceSelect struct {
+	Workspace
+
+	// Flags
+	OrCreate bool
+
+	// Positional arguments
+	Name string
+}
+
+// ParseWorkspaceSelect processes CLI arguments, returning a WorkspaceSelect value and errors.
+// If errors are encountered, an WorkspaceSelect value is still returned representing
+// the best effort interpretation of the arguments.
+func ParseWorkspaceSelect(args []string) (*WorkspaceSelect, tfdiags.Diagnostics) {
+	var diags tfdiags.Diagnostics
+
+	var orCreate bool
+	cmdFlags := defaultFlagSet("workspace select")
+	cmdFlags.BoolVar(&orCreate, "or-create", false, "create workspace if it does not exist")
+	if err := cmdFlags.Parse(args); err != nil {
+		diags = diags.Append(tfdiags.Sourceless(
+			tfdiags.Error,
+			"Failed to parse command-line flags",
+			err.Error(),
+		))
+	}
+
+	// `workspace select` takes only one positional argument: workspace name.
+	args = cmdFlags.Args()
+	var name string
+	if len(args) == 0 {
+		diags = diags.Append(errors.New("Expected a single argument: NAME.")) // Recreating pre-existing error from command package
+	} else {
+		// Obtain and validate name argument.
+		name = args[0]
+		if !ValidWorkspaceName(name) {
+			diags = diags.Append(fmt.Errorf(EnvInvalidName, name))
+		}
+
+		// Checking for extra arguments here, not with a len != 1 check above, allows the name to be returned
+		args = args[1:]
+		if len(args) != 0 {
+			diags = diags.Append(errors.New("Expected a single argument: NAME."))
+		}
+	}
+
+	return &WorkspaceSelect{
+		Workspace: Workspace{ViewType: ViewHuman},
+		OrCreate:  orCreate,
+		Name:      name,
+	}, diags
+}

--- a/internal/command/arguments/workspace_select_test.go
+++ b/internal/command/arguments/workspace_select_test.go
@@ -1,0 +1,132 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package arguments
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/internal/tfdiags"
+)
+
+func TestParseWorkspaceSelect_valid(t *testing.T) {
+	testCases := map[string]struct {
+		args []string
+		want *WorkspaceSelect
+	}{
+		"name specified & default flags": {
+			[]string{"my-new-workspace"},
+			&WorkspaceSelect{
+				Workspace: Workspace{
+					ViewType: ViewHuman,
+				},
+				Name:     "my-new-workspace",
+				OrCreate: false,
+			},
+		},
+		"or-create flag specified": {
+			[]string{"-or-create", "my-new-workspace"},
+			&WorkspaceSelect{
+				Workspace: Workspace{
+					ViewType: ViewHuman,
+				},
+				Name:     "my-new-workspace",
+				OrCreate: true,
+			},
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			got, diags := ParseWorkspaceSelect(tc.args)
+			if len(diags) > 0 {
+				t.Fatalf("unexpected diags: %v", diags)
+			}
+			if *got != *tc.want {
+				t.Fatalf("unexpected result\n got: %#v\nwant: %#v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestParseWorkspaceSelect_invalid(t *testing.T) {
+	testCases := map[string]struct {
+		args      []string
+		want      *WorkspaceSelect
+		wantDiags tfdiags.Diagnostics
+	}{
+		"unknown flag": {
+			[]string{"-boop", "my-new-workspace"},
+			&WorkspaceSelect{
+				Workspace: Workspace{
+					ViewType: ViewHuman,
+				},
+				Name: "my-new-workspace",
+			},
+			tfdiags.Diagnostics{
+				tfdiags.Sourceless(
+					tfdiags.Error,
+					"Failed to parse command-line flags",
+					"flag provided but not defined: -boop",
+				),
+			},
+		},
+		"too many arguments": {
+			[]string{"my-new-workspace", "bar"},
+			&WorkspaceSelect{
+				Workspace: Workspace{
+					ViewType: ViewHuman,
+				},
+				Name: "my-new-workspace",
+			},
+			tfdiags.Diagnostics{
+				tfdiags.Sourceless(
+					tfdiags.Error,
+					"Expected a single argument: NAME.",
+					"", // No detail
+				),
+			},
+		},
+		"missing argument": {
+			[]string{},
+			&WorkspaceSelect{
+				Workspace: Workspace{
+					ViewType: ViewHuman,
+				},
+				Name: "",
+			},
+			tfdiags.Diagnostics{
+				tfdiags.Sourceless(
+					tfdiags.Error,
+					"Expected a single argument: NAME.",
+					"", // No detail
+				),
+			},
+		},
+		"invalid workspace name": {
+			[]string{""}, // empty string
+			&WorkspaceSelect{
+				Workspace: Workspace{
+					ViewType: ViewHuman,
+				},
+			},
+			tfdiags.Diagnostics{
+				tfdiags.Sourceless(
+					tfdiags.Error,
+					"\nThe workspace name \"\" is not allowed. The name must contain only URL safe\ncharacters, contain no path separators, and not be an empty string.\n",
+					"", // No detail
+				),
+			},
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			got, gotDiags := ParseWorkspaceSelect(tc.args)
+			if *got != *tc.want {
+				t.Fatalf("unexpected result\n got: %#v\nwant: %#v", got, tc.want)
+			}
+			tfdiags.AssertDiagnosticsMatch(t, gotDiags, tc.wantDiags)
+		})
+	}
+}

--- a/internal/command/arguments/workspace_test.go
+++ b/internal/command/arguments/workspace_test.go
@@ -1,0 +1,39 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package arguments
+
+import "testing"
+
+func TestValidWorkspaceName(t *testing.T) {
+	cases := map[string]struct {
+		input string
+		valid bool
+	}{
+		"foobar": {
+			input: "foobar",
+			valid: true,
+		},
+		"valid symbols": {
+			input: "-._~@:",
+			valid: true,
+		},
+		"includes space": {
+			input: "two words",
+			valid: false,
+		},
+		"empty string": {
+			input: "",
+			valid: false,
+		},
+	}
+
+	for tn, tc := range cases {
+		t.Run(tn, func(t *testing.T) {
+			valid := ValidWorkspaceName(tc.input)
+			if valid != tc.valid {
+				t.Fatalf("unexpected output when processing input %q. Wanted %v got %v", tc.input, tc.valid, valid)
+			}
+		})
+	}
+}

--- a/internal/command/workspace_command.go
+++ b/internal/command/workspace_command.go
@@ -5,11 +5,11 @@ package command
 
 import (
 	"fmt"
-	"net/url"
 	"strings"
 
 	"github.com/hashicorp/cli"
 	"github.com/hashicorp/terraform/internal/backend"
+	"github.com/hashicorp/terraform/internal/command/arguments"
 	"github.com/hashicorp/terraform/internal/tfdiags"
 )
 
@@ -47,11 +47,12 @@ func (c *WorkspaceCommand) Synopsis() string {
 // validWorkspaceName returns true is this name is valid to use as a workspace name.
 // Since most named states are accessed via a filesystem path or URL, check if
 // escaping the name would be required.
+//
+// This has been moved to the arguments package but also kept here, as the function is used
+// in some places for reasons other than validating command-line arguments.
+// TODO: Decide whether to keep this function or use arguments package to validate ENV values too.
 func validWorkspaceName(name string) bool {
-	if name == "" {
-		return false
-	}
-	return name == url.PathEscape(name)
+	return arguments.ValidWorkspaceName(name)
 }
 
 func envCommandShowWarning(ui cli.Ui, show bool) {
@@ -102,11 +103,6 @@ Workspace %[1]q is your active workspace.
 
 You cannot delete the currently active workspace. Please switch
 to another workspace and try again.
-`
-
-	envInvalidName = `
-The workspace name %q is not allowed. The name must contain only URL safe
-characters, contain no path separators, and not be an empty string.
 `
 
 	envIsOverriddenNote = `

--- a/internal/command/workspace_command_test.go
+++ b/internal/command/workspace_command_test.go
@@ -335,7 +335,7 @@ func TestWorkspace_cannotCreateOrSelectEmptyStringWorkspace(t *testing.T) {
 		View:       view,
 		WorkingDir: workdir.NewDir("."),
 	}
-	if code := newCmd.Run(args); code != 1 {
+	if code := newCmd.Run(args); code == 0 {
 		t.Fatalf("expected failure when trying to create the \"\" workspace.\noutput: %s", ui.OutputWriter)
 	}
 
@@ -352,7 +352,7 @@ func TestWorkspace_cannotCreateOrSelectEmptyStringWorkspace(t *testing.T) {
 			WorkingDir: workdir.NewDir("."),
 		},
 	}
-	if code := selectCmd.Run(args); code != 1 {
+	if code := selectCmd.Run(args); code == 0 {
 		t.Fatalf("expected failure when trying to select the the \"\" workspace.\noutput: %s", ui.OutputWriter)
 	}
 
@@ -1097,7 +1097,7 @@ func TestWorkspace_extraArgError(t *testing.T) {
 	if code := newCmd.Run(args); code != cli.RunResultHelp {
 		t.Fatalf("bad: %d\n\n%s", code, ui.ErrorWriter)
 	}
-	expectedError := "Expected a single argument: NAME.\n\n"
+	expectedError := "\nError: Expected a single argument: NAME.\n\n\n"
 	if ui.ErrorWriter.String() != expectedError {
 		t.Fatalf("expected error to include %s but was missing, got: %s", expectedError, ui.ErrorWriter.String())
 	}

--- a/internal/command/workspace_command_test.go
+++ b/internal/command/workspace_command_test.go
@@ -1074,39 +1074,6 @@ func TestWorkspace_envCommandDeprecationWarnings(t *testing.T) {
 	}
 }
 
-func TestValidWorkspaceName(t *testing.T) {
-	cases := map[string]struct {
-		input string
-		valid bool
-	}{
-		"foobar": {
-			input: "foobar",
-			valid: true,
-		},
-		"valid symbols": {
-			input: "-._~@:",
-			valid: true,
-		},
-		"includes space": {
-			input: "two words",
-			valid: false,
-		},
-		"empty string": {
-			input: "",
-			valid: false,
-		},
-	}
-
-	for tn, tc := range cases {
-		t.Run(tn, func(t *testing.T) {
-			valid := validWorkspaceName(tc.input)
-			if valid != tc.valid {
-				t.Fatalf("unexpected output when processing input %q. Wanted %v got %v", tc.input, tc.valid, valid)
-			}
-		})
-	}
-}
-
 // Test how all workspace subcommands handle unexpected arguments.
 func TestWorkspace_extraArgError(t *testing.T) {
 	newMeta := func() (Meta, *cli.MockUi) {

--- a/internal/command/workspace_command_test.go
+++ b/internal/command/workspace_command_test.go
@@ -1135,7 +1135,7 @@ func TestWorkspace_extraArgError(t *testing.T) {
 	if code := selectCmd.Run(args); code != cli.RunResultHelp {
 		t.Fatalf("bad: %d\n\n%s", code, ui.ErrorWriter)
 	}
-	expectedError = "Expected a single argument: NAME.\n\n"
+	expectedError = "\nError: Expected a single argument: NAME.\n\n\n"
 	if ui.ErrorWriter.String() != expectedError {
 		t.Fatalf("expected error to include %s but was missing, got: %s", expectedError, ui.ErrorWriter.String())
 	}

--- a/internal/command/workspace_new.go
+++ b/internal/command/workspace_new.go
@@ -51,8 +51,8 @@ func (c *WorkspaceNewCommand) Run(args []string) int {
 
 	workspace := args[0]
 
-	if !validWorkspaceName(workspace) {
-		c.Ui.Error(fmt.Sprintf(envInvalidName, workspace))
+	if !arguments.ValidWorkspaceName(workspace) {
+		c.Ui.Error(fmt.Sprintf(arguments.EnvInvalidName, workspace))
 		return 1
 	}
 

--- a/internal/command/workspace_new.go
+++ b/internal/command/workspace_new.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"os"
 	"strings"
-	"time"
 
 	"github.com/hashicorp/cli"
 	"github.com/hashicorp/terraform/internal/backend/local"
@@ -26,35 +25,22 @@ type WorkspaceNewCommand struct {
 	LegacyName bool
 }
 
-func (c *WorkspaceNewCommand) Run(args []string) int {
-	args = c.Meta.process(args)
+func (c *WorkspaceNewCommand) Run(rawArgs []string) int {
+	var diags tfdiags.Diagnostics
+
+	// Process global flags and configure the view/UI.
+	rawArgs = c.Meta.process(rawArgs)
 	envCommandShowWarning(c.Ui, c.LegacyName)
 
-	var stateLock bool
-	var stateLockTimeout time.Duration
-	var statePath string
-	cmdFlags := c.Meta.defaultFlagSet("workspace new")
-	cmdFlags.BoolVar(&stateLock, "lock", true, "lock state")
-	cmdFlags.DurationVar(&stateLockTimeout, "lock-timeout", 0, "lock timeout")
-	cmdFlags.StringVar(&statePath, "state", "", "terraform state file")
-	cmdFlags.Usage = func() { c.Ui.Error(c.Help()) }
-	if err := cmdFlags.Parse(args); err != nil {
-		c.Ui.Error(fmt.Sprintf("Error parsing command-line flags: %s\n", err.Error()))
-		return 1
-	}
-
-	args = cmdFlags.Args()
-	if len(args) != 1 {
-		c.Ui.Error("Expected a single argument: NAME.\n")
+	// Process command-specific arguments.
+	// Currently there are no arguments for this command, so ignore the returned value for now.
+	args, diags := arguments.ParseWorkspaceNew(rawArgs)
+	if diags.HasErrors() {
+		c.showDiagnostics(diags)
 		return cli.RunResultHelp
 	}
 
-	workspace := args[0]
-
-	if !arguments.ValidWorkspaceName(workspace) {
-		c.Ui.Error(fmt.Sprintf(arguments.EnvInvalidName, workspace))
-		return 1
-	}
+	workspace := args.Name
 
 	// You can't ask to create a workspace when you're overriding the
 	// workspace name to be something different.
@@ -63,12 +49,9 @@ func (c *WorkspaceNewCommand) Run(args []string) int {
 		return 1
 	}
 
-	var diags tfdiags.Diagnostics
-
 	// Load the backend
-	view := arguments.ViewHuman
 	configPath := c.WorkingDir.RootModuleDir()
-	b, diags := c.backend(configPath, view)
+	b, diags := c.backend(configPath, args.ViewType)
 	if diags.HasErrors() {
 		c.showDiagnostics(diags)
 		return 1
@@ -132,7 +115,7 @@ func (c *WorkspaceNewCommand) Run(args []string) int {
 	c.Ui.Output(c.Colorize().Color(fmt.Sprintf(
 		strings.TrimSpace(envCreated), workspace)))
 
-	if statePath == "" {
+	if args.StatePath == "" {
 		// if we're not loading a state, then we're done
 		return 0
 	}
@@ -144,8 +127,8 @@ func (c *WorkspaceNewCommand) Run(args []string) int {
 		return 1
 	}
 
-	if stateLock {
-		stateLocker := clistate.NewLocker(c.stateLockTimeout, views.NewStateLocker(arguments.ViewHuman, c.View))
+	if args.Lock {
+		stateLocker := clistate.NewLocker(args.LockTimeout, views.NewStateLocker(arguments.ViewHuman, c.View))
 		if diags := stateLocker.Lock(stateMgr, "workspace-new"); diags.HasErrors() {
 			c.showDiagnostics(diags)
 			return 1
@@ -158,7 +141,7 @@ func (c *WorkspaceNewCommand) Run(args []string) int {
 	}
 
 	// read the existing state file
-	f, err := os.Open(statePath)
+	f, err := os.Open(args.StatePath)
 	if err != nil {
 		c.Ui.Error(err.Error())
 		return 1

--- a/internal/command/workspace_select.go
+++ b/internal/command/workspace_select.go
@@ -55,8 +55,8 @@ func (c *WorkspaceSelectCommand) Run(args []string) int {
 	c.ignoreRemoteVersionConflict(b)
 
 	name := args[0]
-	if !validWorkspaceName(name) {
-		c.Ui.Error(fmt.Sprintf(envInvalidName, name))
+	if !arguments.ValidWorkspaceName(name) {
+		c.Ui.Error(fmt.Sprintf(arguments.EnvInvalidName, name))
 		return 1
 	}
 

--- a/internal/command/workspace_select.go
+++ b/internal/command/workspace_select.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/hashicorp/cli"
 	"github.com/hashicorp/terraform/internal/command/arguments"
+	"github.com/hashicorp/terraform/internal/tfdiags"
 	"github.com/posener/complete"
 )
 
@@ -17,25 +18,22 @@ type WorkspaceSelectCommand struct {
 	LegacyName bool
 }
 
-func (c *WorkspaceSelectCommand) Run(args []string) int {
-	args = c.Meta.process(args)
+func (c *WorkspaceSelectCommand) Run(rawArgs []string) int {
+	var diags tfdiags.Diagnostics
+
+	// Process global flags and configure the view/UI.
+	rawArgs = c.Meta.process(rawArgs)
 	envCommandShowWarning(c.Ui, c.LegacyName)
 
-	var orCreate bool
-	cmdFlags := c.Meta.defaultFlagSet("workspace select")
-	cmdFlags.BoolVar(&orCreate, "or-create", false, "create workspace if it does not exist")
-	cmdFlags.Usage = func() { c.Ui.Error(c.Help()) }
-	if err := cmdFlags.Parse(args); err != nil {
-		c.Ui.Error(fmt.Sprintf("Error parsing command-line flags: %s\n", err.Error()))
-		return 1
-	}
-
-	args = cmdFlags.Args()
-	if len(args) != 1 {
-		c.Ui.Error("Expected a single argument: NAME.\n")
+	// Process command-specific arguments.
+	// Currently there are no arguments for this command, so ignore the returned value for now.
+	args, diags := arguments.ParseWorkspaceSelect(rawArgs)
+	if diags.HasErrors() {
+		c.showDiagnostics(diags)
 		return cli.RunResultHelp
 	}
 
+	// Block selecting a workspace if an environment variable will override the new selection anyway.
 	current, isOverridden := c.WorkspaceOverridden()
 	if isOverridden {
 		c.Ui.Error(envIsOverriddenSelectError)
@@ -43,9 +41,8 @@ func (c *WorkspaceSelectCommand) Run(args []string) int {
 	}
 
 	// Load the backend
-	view := arguments.ViewHuman
 	configPath := c.WorkingDir.RootModuleDir()
-	b, diags := c.backend(configPath, view)
+	b, diags := c.backend(configPath, args.ViewType)
 	if diags.HasErrors() {
 		c.showDiagnostics(diags)
 		return 1
@@ -54,12 +51,6 @@ func (c *WorkspaceSelectCommand) Run(args []string) int {
 	// This command will not write state
 	c.ignoreRemoteVersionConflict(b)
 
-	name := args[0]
-	if !arguments.ValidWorkspaceName(name) {
-		c.Ui.Error(fmt.Sprintf(arguments.EnvInvalidName, name))
-		return 1
-	}
-
 	states, wDiags := b.Workspaces()
 	if wDiags.HasErrors() {
 		c.Ui.Error(wDiags.Err().Error())
@@ -67,6 +58,7 @@ func (c *WorkspaceSelectCommand) Run(args []string) int {
 	}
 	c.showDiagnostics(diags) // output warnings, if any
 
+	name := args.Name
 	if name == current {
 		// already using this workspace
 		return 0
@@ -83,7 +75,7 @@ func (c *WorkspaceSelectCommand) Run(args []string) int {
 	var newState bool
 
 	if !found {
-		if orCreate {
+		if args.OrCreate {
 			_, sDiags := b.StateMgr(name)
 			if sDiags.HasErrors() {
 				c.Ui.Error(sDiags.Err().Error())


### PR DESCRIPTION
Comes after https://github.com/hashicorp/terraform/pull/38429

This PR updates workspace select and workspace delete to use the arguments package for argument parsing.

All validation of arguments has been moved into that package, alongside parsing.

The commands  `workspace select` and `workspace new` both involve checking the validity of a workspace name. I've moved the function used for that from the `command` package and into the `arguments` package, as the function is primarily used to validate user input.

The old `validWorkspaceName` function in the `command` package is also used to validate data supplied via an environment variable. To continue to enable this but prevent logic duplication I've made the original function a wrapper for the new function in `package arguments`.



## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.16.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
