### PR TITLE
command: Implement skeleton for `state migrate`

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -462,6 +462,12 @@ func initCommands(
 				Meta: meta,
 			}, nil
 		}
+
+		Commands["state migrate"] = func() (cli.Command, error) {
+			return &command.StateMigrateCommand{
+				Meta: meta,
+			}, nil
+		}
 	}
 
 	PrimaryCommands = []string{

--- a/internal/command/arguments/state_migrate.go
+++ b/internal/command/arguments/state_migrate.go
@@ -1,0 +1,78 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package arguments
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/hashicorp/terraform/internal/tfdiags"
+)
+
+const lockFileName = ".terraform.lock.hcl"
+
+// StateMigrate represents the command-line arguments for the state migrate command.
+type StateMigrate struct {
+	SourceLockFilePath      string
+	DestinationLockFilePath string
+	Upgrade                 bool
+	InputEnabled            bool
+
+	ViewType ViewType
+}
+
+// ParseStateMigrate processes CLI arguments, returning a StateMigrate value and
+// diagnostics. If errors are encountered, a StateMigrate value is still returned
+// representing the best effort interpretation of the arguments.
+func ParseStateMigrate(args []string) (*StateMigrate, tfdiags.Diagnostics) {
+	var diags tfdiags.Diagnostics
+	migrate := &StateMigrate{
+		ViewType: ViewHuman,
+	}
+
+	var srcLockFilePath, dstLockFilePath string
+	var upgrade, inputEnabled bool
+	cmdFlags := defaultFlagSet("state migrate")
+	cmdFlags.StringVar(&srcLockFilePath, "source-provider-lock-file", "", "Path to a provider lock file for the source provider.")
+	cmdFlags.StringVar(&dstLockFilePath, "destination-provider-lock-file", lockFileName, "Path to a provider lock file for the destination provider.")
+	cmdFlags.BoolVar(&upgrade, "upgrade", false, "Trigger upgrade of the provider.")
+	cmdFlags.BoolVar(&inputEnabled, "input", true, "Enable input for interactive prompts.")
+
+	if err := cmdFlags.Parse(args); err != nil {
+		diags = diags.Append(tfdiags.Sourceless(
+			tfdiags.Error,
+			"Failed to parse command-line flags",
+			err.Error(),
+		))
+	}
+
+	if srcLockFilePath != "" {
+		srcFilename := filepath.Base(srcLockFilePath)
+		if srcFilename != lockFileName {
+			diags = diags.Append(tfdiags.Sourceless(
+				tfdiags.Error,
+				"Invalid source-provider-lock-file",
+				fmt.Sprintf("Expected lock file name to be %s, got: %s", lockFileName, srcFilename),
+			))
+		} else {
+			migrate.SourceLockFilePath = srcLockFilePath
+		}
+	}
+
+	dstFilename := filepath.Base(dstLockFilePath)
+	if dstFilename != lockFileName {
+		diags = diags.Append(tfdiags.Sourceless(
+			tfdiags.Error,
+			"Invalid destination-provider-lock-file",
+			fmt.Sprintf("Expected lock file name to be %s, got: %s", lockFileName, dstFilename),
+		))
+	} else {
+		migrate.DestinationLockFilePath = dstLockFilePath
+	}
+
+	migrate.Upgrade = upgrade
+	migrate.InputEnabled = inputEnabled
+
+	return migrate, diags
+}

--- a/internal/command/arguments/state_migrate.go
+++ b/internal/command/arguments/state_migrate.go
@@ -35,7 +35,7 @@ func ParseStateMigrate(args []string) (*StateMigrate, tfdiags.Diagnostics) {
 	var upgrade, inputEnabled bool
 	cmdFlags := defaultFlagSet("state migrate")
 	cmdFlags.StringVar(&srcLockFilePath, "source-provider-lock-file", "", "Path to a provider lock file for the source provider.")
-	cmdFlags.StringVar(&dstLockFilePath, "destination-provider-lock-file", lockFileName, "Path to a provider lock file for the destination provider.")
+	cmdFlags.StringVar(&dstLockFilePath, "destination-provider-lock-file", "", "Path to a provider lock file for the destination provider.")
 	cmdFlags.BoolVar(&upgrade, "upgrade", false, "Trigger upgrade of the provider.")
 	cmdFlags.BoolVar(&inputEnabled, "input", true, "Enable input for interactive prompts.")
 
@@ -45,6 +45,37 @@ func ParseStateMigrate(args []string) (*StateMigrate, tfdiags.Diagnostics) {
 			"Failed to parse command-line flags",
 			err.Error(),
 		))
+		return migrate, diags
+	}
+
+	migrate.Upgrade = upgrade
+	migrate.InputEnabled = inputEnabled
+
+	if inputEnabled {
+		// lock file paths are only to be used in automation
+		if srcLockFilePath != "" {
+			diags = diags.Append(tfdiags.Sourceless(
+				tfdiags.Error,
+				"Conflicting command-line flags provided",
+				"-source-provider-lock-file cannot be used outside of automation (with -input=true)",
+			))
+		}
+		if dstLockFilePath != "" {
+			diags = diags.Append(tfdiags.Sourceless(
+				tfdiags.Error,
+				"Conflicting command-line flags provided",
+				"-destination-provider-lock-file cannot be used outside of automation (with -input=true)",
+			))
+		}
+		if len(diags) > 0 {
+			return migrate, diags
+		}
+
+	}
+	if dstLockFilePath == "" {
+		// setting default here instead of in the flag definition
+		// to make check above free of side effects
+		dstLockFilePath = lockFileName
 	}
 
 	if srcLockFilePath != "" {
@@ -70,9 +101,6 @@ func ParseStateMigrate(args []string) (*StateMigrate, tfdiags.Diagnostics) {
 	} else {
 		migrate.DestinationLockFilePath = dstLockFilePath
 	}
-
-	migrate.Upgrade = upgrade
-	migrate.InputEnabled = inputEnabled
 
 	return migrate, diags
 }

--- a/internal/command/arguments/state_migrate_test.go
+++ b/internal/command/arguments/state_migrate_test.go
@@ -1,0 +1,87 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package arguments
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform/internal/tfdiags"
+)
+
+func TestStateMigrateArgs(t *testing.T) {
+	testCases := []struct {
+		rawArgs       []string
+		expectedArgs  *StateMigrate
+		expectedDiags tfdiags.Diagnostics
+	}{
+		{
+			rawArgs: []string{""},
+			expectedArgs: &StateMigrate{
+				SourceLockFilePath:      "",
+				DestinationLockFilePath: ".terraform.lock.hcl",
+				Upgrade:                 false,
+				InputEnabled:            true,
+				ViewType:                ViewHuman,
+			},
+		},
+		{ // set or override all flags
+			rawArgs: []string{
+				"-source-provider-lock-file", "/some/path/.terraform.lock.hcl",
+				"-destination-provider-lock-file", "/some/other/path/.terraform.lock.hcl",
+				"-upgrade",
+				"-input=false",
+			},
+			expectedArgs: &StateMigrate{
+				SourceLockFilePath:      "/some/path/.terraform.lock.hcl",
+				DestinationLockFilePath: "/some/other/path/.terraform.lock.hcl",
+				Upgrade:                 true,
+				InputEnabled:            false,
+				ViewType:                ViewHuman,
+			},
+		},
+		{
+			rawArgs: []string{"-source-provider-lock-file", "foo"},
+			expectedArgs: &StateMigrate{
+				SourceLockFilePath:      "",
+				DestinationLockFilePath: ".terraform.lock.hcl",
+				Upgrade:                 false,
+				InputEnabled:            true,
+				ViewType:                ViewHuman,
+			},
+			expectedDiags: tfdiags.Diagnostics{
+				tfdiags.Sourceless(
+					tfdiags.Error,
+					"Invalid source-provider-lock-file",
+					"Expected lock file name to be .terraform.lock.hcl, got: foo",
+				),
+			},
+		},
+		{
+			rawArgs: []string{"-destination-provider-lock-file", "foo"},
+			expectedArgs: &StateMigrate{
+				SourceLockFilePath:      "",
+				DestinationLockFilePath: "",
+				Upgrade:                 false,
+				InputEnabled:            true,
+				ViewType:                ViewHuman,
+			},
+			expectedDiags: tfdiags.Diagnostics{
+				tfdiags.Sourceless(
+					tfdiags.Error,
+					"Invalid destination-provider-lock-file",
+					"Expected lock file name to be .terraform.lock.hcl, got: foo",
+				),
+			},
+		},
+	}
+
+	for i, tc := range testCases {
+		args, diags := ParseStateMigrate(tc.rawArgs)
+		tfdiags.AssertDiagnosticsMatch(t, diags, tc.expectedDiags)
+		if diff := cmp.Diff(tc.expectedArgs, args); diff != "" {
+			t.Fatalf("%d: supplied: %q, got unexpected arguments:\n%s", i, tc.rawArgs, diff)
+		}
+	}
+}

--- a/internal/command/arguments/state_migrate_test.go
+++ b/internal/command/arguments/state_migrate_test.go
@@ -42,12 +42,12 @@ func TestStateMigrateArgs(t *testing.T) {
 			},
 		},
 		{
-			rawArgs: []string{"-source-provider-lock-file", "foo"},
+			rawArgs: []string{"-input=false", "-source-provider-lock-file", "foo"},
 			expectedArgs: &StateMigrate{
 				SourceLockFilePath:      "",
 				DestinationLockFilePath: ".terraform.lock.hcl",
 				Upgrade:                 false,
-				InputEnabled:            true,
+				InputEnabled:            false,
 				ViewType:                ViewHuman,
 			},
 			expectedDiags: tfdiags.Diagnostics{
@@ -59,7 +59,27 @@ func TestStateMigrateArgs(t *testing.T) {
 			},
 		},
 		{
-			rawArgs: []string{"-destination-provider-lock-file", "foo"},
+			rawArgs: []string{"-input=false", "-destination-provider-lock-file", "foo"},
+			expectedArgs: &StateMigrate{
+				SourceLockFilePath:      "",
+				DestinationLockFilePath: "",
+				Upgrade:                 false,
+				InputEnabled:            false,
+				ViewType:                ViewHuman,
+			},
+			expectedDiags: tfdiags.Diagnostics{
+				tfdiags.Sourceless(
+					tfdiags.Error,
+					"Invalid destination-provider-lock-file",
+					"Expected lock file name to be .terraform.lock.hcl, got: foo",
+				),
+			},
+		},
+		{ // set lock file paths outside of automation
+			rawArgs: []string{
+				"-source-provider-lock-file", "/src/.terraform.lock.hcl",
+				"-destination-provider-lock-file", "/dst/.terraform.lock.hcl",
+			},
 			expectedArgs: &StateMigrate{
 				SourceLockFilePath:      "",
 				DestinationLockFilePath: "",
@@ -70,8 +90,13 @@ func TestStateMigrateArgs(t *testing.T) {
 			expectedDiags: tfdiags.Diagnostics{
 				tfdiags.Sourceless(
 					tfdiags.Error,
-					"Invalid destination-provider-lock-file",
-					"Expected lock file name to be .terraform.lock.hcl, got: foo",
+					"Conflicting command-line flags provided",
+					"-source-provider-lock-file cannot be used outside of automation (with -input=true)",
+				),
+				tfdiags.Sourceless(
+					tfdiags.Error,
+					"Conflicting command-line flags provided",
+					"-destination-provider-lock-file cannot be used outside of automation (with -input=true)",
 				),
 			},
 		},

--- a/internal/command/state_migrate.go
+++ b/internal/command/state_migrate.go
@@ -1,0 +1,88 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package command
+
+import (
+	"errors"
+	"os"
+	"strings"
+
+	"github.com/hashicorp/terraform/internal/command/arguments"
+	"github.com/hashicorp/terraform/internal/command/views"
+	"github.com/hashicorp/terraform/internal/tfdiags"
+)
+
+// StateMigrateCommand is a Command implementation that migrates
+// the state file from one location to another
+type StateMigrateCommand struct {
+	Meta
+}
+
+func (c *StateMigrateCommand) Run(rawArgs []string) int {
+	// Parse and apply global view arguments
+	common, rawArgs := arguments.ParseView(rawArgs)
+	c.Meta.View.Configure(common)
+
+	args, diags := arguments.ParseStateMigrate(rawArgs)
+
+	stateMigrate := views.NewStateMigrate(args.ViewType, c.View)
+
+	if diags.HasErrors() {
+		stateMigrate.Diagnostics(diags)
+		return 1
+	}
+
+	c.Meta.input = args.InputEnabled
+
+	if _, err := os.Stat(args.SourceLockFilePath); err != nil {
+		diags = diags.Append(tfdiags.Sourceless(
+			tfdiags.Error,
+			"Unreadable source provider lock file",
+			err.Error(),
+		))
+	}
+
+	// TODO: Is there a reason to do migration without a lock file?
+	if _, err := os.Stat(args.DestinationLockFilePath); err != nil {
+		diags = diags.Append(tfdiags.Sourceless(
+			tfdiags.Error,
+			"Unreadable destination provider lock file",
+			err.Error(),
+		))
+	}
+
+	// TODO: implement
+	// stateMigrate.Log("migrating from %s to %s", "source", "destination")
+
+	diags = diags.Append(errors.New("Not implemented yet"))
+	stateMigrate.Diagnostics(diags)
+	return 1
+}
+
+func (c *StateMigrateCommand) Help() string {
+	helpText := `
+Usage: terraform [global options] state migrate [options]
+
+  Migrate state from source declared in the migration configuration (*.tfmigrate.hcl)
+  to the destination declared in the root module (*.tf).
+
+  An error will be returned if the migration fails, e.g. if the state
+  is inaccessible or the migration configuration is invalid.
+
+Options:
+
+  -source-provider-lock-file	   Path to a provider lock file for the source provider.
+
+  -destination-provider-lock-file  Path to a provider lock file for the destination provider.
+
+  -upgrade  					   Trigger upgrade of the provider.
+  
+  -input=true					   Enable input for interactive prompts.
+`
+	return strings.TrimSpace(helpText)
+}
+
+func (c *StateMigrateCommand) Synopsis() string {
+	return "Migrate the state from one location to another"
+}

--- a/internal/command/state_migrate.go
+++ b/internal/command/state_migrate.go
@@ -72,13 +72,13 @@ Usage: terraform [global options] state migrate [options]
 
 Options:
 
-  -source-provider-lock-file	   Path to a provider lock file for the source provider.
+  -source-provider-lock-file	   Path to a provider lock file for the source provider (requires -input=false).
 
-  -destination-provider-lock-file  Path to a provider lock file for the destination provider.
+  -destination-provider-lock-file  Path to a provider lock file for the destination provider (requires -input=false).
 
   -upgrade  					   Trigger upgrade of the provider.
   
-  -input=true					   Enable input for interactive prompts.
+  -input=true					   Enable input for interactive prompts (defaults to true, set to false in automation).
 `
 	return strings.TrimSpace(helpText)
 }

--- a/internal/command/state_migrate_test.go
+++ b/internal/command/state_migrate_test.go
@@ -1,0 +1,77 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package command
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/cli"
+)
+
+func TestStateMigrate_basic(t *testing.T) {
+	ui := cli.NewMockUi()
+	view, done := testView(t)
+	c := &StateMigrateCommand{
+		Meta: Meta{
+			Ui:   ui,
+			View: view,
+		},
+	}
+
+	tmpDir := t.TempDir()
+	_, err := os.Create(filepath.Join(tmpDir, ".terraform.lock.hcl"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(tmpDir)
+
+	args := []string{}
+	code := c.Run(args)
+	if code != 1 {
+		t.Fatalf("expected exit code 1, got %d", code)
+	}
+	out := done(t)
+
+	expectedMsg := "Not implemented yet"
+	if !strings.Contains(out.Stderr(), expectedMsg) {
+		t.Fatalf("expected output %q, got %q", expectedMsg, out.All())
+	}
+}
+
+func TestStateMigrate_nonExistentLockFiles(t *testing.T) {
+	ui := cli.NewMockUi()
+	view, done := testView(t)
+	c := &StateMigrateCommand{
+		Meta: Meta{
+			Ui:   ui,
+			View: view,
+		},
+	}
+
+	// use temporary directory to ensure the lock files certainly do not exist
+	tmpDir := t.TempDir()
+
+	args := []string{
+		"-source-provider-lock-file", filepath.Join(tmpDir, ".terraform.lock.hcl"),
+		"-destination-provider-lock-file", filepath.Join(tmpDir, ".terraform.lock.hcl"),
+	}
+	code := c.Run(args)
+	if code != 1 {
+		t.Fatalf("expected exit code 1, got %d", code)
+	}
+	out := done(t)
+
+	expectedMsg := "Unreadable source provider lock file"
+	if !strings.Contains(out.Stderr(), expectedMsg) {
+		t.Fatalf("expected output %q, got %q", expectedMsg, out.All())
+	}
+
+	expectedMsg = "Unreadable destination provider lock file"
+	if !strings.Contains(out.Stderr(), expectedMsg) {
+		t.Fatalf("expected output %q, got %q", expectedMsg, out.All())
+	}
+}

--- a/internal/command/state_migrate_test.go
+++ b/internal/command/state_migrate_test.go
@@ -56,6 +56,7 @@ func TestStateMigrate_nonExistentLockFiles(t *testing.T) {
 	tmpDir := t.TempDir()
 
 	args := []string{
+		"-input=false",
 		"-source-provider-lock-file", filepath.Join(tmpDir, ".terraform.lock.hcl"),
 		"-destination-provider-lock-file", filepath.Join(tmpDir, ".terraform.lock.hcl"),
 	}

--- a/internal/command/views/state_migrate.go
+++ b/internal/command/views/state_migrate.go
@@ -1,0 +1,37 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package views
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform/internal/command/arguments"
+	"github.com/hashicorp/terraform/internal/tfdiags"
+)
+
+type StateMigrate interface {
+	Log(message string, params ...any)
+	Diagnostics(diags tfdiags.Diagnostics)
+}
+
+func NewStateMigrate(viewType arguments.ViewType, view *View) StateMigrate {
+	switch viewType {
+	case arguments.ViewHuman:
+		return &StateMigrateHuman{view: view}
+	default:
+		panic(fmt.Sprintf("unsupported view type: %s", viewType))
+	}
+}
+
+type StateMigrateHuman struct {
+	view *View
+}
+
+func (s *StateMigrateHuman) Diagnostics(diags tfdiags.Diagnostics) {
+	s.view.Diagnostics(diags)
+}
+
+func (s *StateMigrateHuman) Log(message string, params ...any) {
+	s.view.streams.Print(fmt.Sprintf(message, params...))
+}


### PR DESCRIPTION
The new command is currently only gated as "experimental", i.e. behind a pre-release. I think this is reasonable considering it's a net new command so unlikely to conflict with existing stuff.

I suppose a random user _could_ stumble upon it and try to use it somehow but when we start filling in the implementation I assume that would stop such a user very quickly if neither of the source or destination is pluggable state store, which itself cannot exist without `init -enable-pluggable-state-storage-experiment`.

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.16.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
