### PR TITLE
configs: stop panicking on action_trigger in data/ephemeral lifecycle

### DIFF
--- a/.changes/v1.16/BUG FIXES-20260424-140000.yaml
+++ b/.changes/v1.16/BUG FIXES-20260424-140000.yaml
@@ -1,0 +1,5 @@
+kind: BUG FIXES
+body: '`terraform validate` no longer panics when an `action_trigger` block is placed inside a `data` or `ephemeral` resource''s `lifecycle` block, and instead returns a clear diagnostic explaining that `action_trigger` is only valid for managed resources'
+time: 2026-04-24T14:00:00-05:00
+custom:
+    Issue: "38402"

--- a/internal/configs/parser_config_test.go
+++ b/internal/configs/parser_config_test.go
@@ -99,6 +99,16 @@ func TestParserLoadConfigFileFailureMessages(t *testing.T) {
 			"Invalid data resource lifecycle argument",
 		},
 		{
+			"invalid-files/data-resource-action-trigger.tf",
+			hcl.DiagError,
+			"Invalid data resource lifecycle block",
+		},
+		{
+			"invalid-files/ephemeral-resource-action-trigger.tf",
+			hcl.DiagError,
+			"Invalid ephemeral resource lifecycle block",
+		},
+		{
 			"invalid-files/variable-type-unknown.tf",
 			hcl.DiagError,
 			"Invalid type specification",

--- a/internal/configs/resource.go
+++ b/internal/configs/resource.go
@@ -509,6 +509,13 @@ func decodeEphemeralBlock(block *hcl.Block, override bool) (*Resource, hcl.Diagn
 					case "postcondition":
 						r.Postconditions = append(r.Postconditions, cr)
 					}
+				case "action_trigger":
+					diags = append(diags, &hcl.Diagnostic{
+						Severity: hcl.DiagError,
+						Summary:  "Invalid ephemeral resource lifecycle block",
+						Detail:   `The "action_trigger" block is defined only for managed resources ("resource" blocks), and is not valid for ephemeral resources.`,
+						Subject:  block.DefRange.Ptr(),
+					})
 				default:
 					// The cases above should be exhaustive for all block types
 					// defined in the lifecycle schema, so this shouldn't happen.
@@ -685,6 +692,13 @@ func decodeDataBlock(block *hcl.Block, override, nested bool) (*Resource, hcl.Di
 					case "postcondition":
 						r.Postconditions = append(r.Postconditions, cr)
 					}
+				case "action_trigger":
+					diags = append(diags, &hcl.Diagnostic{
+						Severity: hcl.DiagError,
+						Summary:  "Invalid data resource lifecycle block",
+						Detail:   `The "action_trigger" block is defined only for managed resources ("resource" blocks), and is not valid for data resources.`,
+						Subject:  block.DefRange.Ptr(),
+					})
 				default:
 					// The cases above should be exhaustive for all block types
 					// defined in the lifecycle schema, so this shouldn't happen.

--- a/internal/configs/testdata/invalid-files/data-resource-action-trigger.tf
+++ b/internal/configs/testdata/invalid-files/data-resource-action-trigger.tf
@@ -1,0 +1,9 @@
+data "example" "example" {
+  lifecycle {
+    # action_trigger is only valid for managed resources.
+    action_trigger {
+      events  = [after_create]
+      actions = [action.example.example]
+    }
+  }
+}

--- a/internal/configs/testdata/invalid-files/ephemeral-resource-action-trigger.tf
+++ b/internal/configs/testdata/invalid-files/ephemeral-resource-action-trigger.tf
@@ -1,0 +1,9 @@
+ephemeral "test_resource" "test" {
+  lifecycle {
+    # action_trigger is only valid for managed resources.
+    action_trigger {
+      events  = [after_create]
+      actions = [action.example.example]
+    }
+  }
+}


### PR DESCRIPTION
Fixes #38402

## Target Release

1.16.x

## What's going on

`decodeDataBlock` and `decodeEphemeralBlock` share `resourceLifecycleBlockSchema` with managed resources, but both decoders only explicitly handle `precondition` / `postcondition` sub-blocks. When `action_trigger` was added to the shared schema, the two non-managed decoders weren't updated, so an `action_trigger` block inside a `data` or `ephemeral` resource's `lifecycle` falls through to the `default` case that was marked as "shouldn't happen" — and panics.

Stack trace on the issue lands right on that panic (`internal/configs/resource.go:691`):

```
panic: unexpected lifecycle sub-block type "action_trigger"
  ... github.com/hashicorp/terraform/internal/configs.decodeDataBlock
```

Reported config that triggers it is roughly:

```hcl
data "panos_template" "example" {
  ...
  lifecycle {
    action_trigger {
      actions = [panos_commit.commit]
      events  = [after_create, after_update]
    }
  }
}
```

## The fix

Handle `action_trigger` explicitly in both decoders and emit a proper `hcl.Diagnostic` pointing at the offending block, following the same "only valid for managed resources" pattern that's already used for any invalid lifecycle *attribute* in those two decoders. This matches what a contributor suggested on the issue: it should fail cleanly during parsing rather than crashing.

After the change, the reproducer returns:

```
Error: Invalid data resource lifecycle block

  on main.tf line 7, in data "terraform_remote_state" "example":
   7:     action_trigger {

The "action_trigger" block is defined only for managed resources
("resource" blocks), and is not valid for data resources.
```

Left the `default: panic(...)` arm in place in both decoders — it's still useful as a "next time someone adds a new block type to the shared schema, wire it up here too" tripwire.

## Tests

Added two invalid-file fixtures plus `TestParserLoadConfigFileFailureMessages` entries so we actually assert the new diagnostic summaries:

- `data-resource-action-trigger.tf` → `Invalid data resource lifecycle block`
- `ephemeral-resource-action-trigger.tf` → `Invalid ephemeral resource lifecycle block`

`go build ./...`, `go vet ./internal/configs/...`, and `go test ./internal/configs/ -run "TestParserLoadConfigFile..."` all pass locally. (The unrelated `TestParserLoadConfigDirWithQueries` failures on my Windows box are the pre-existing path-separator issue called out in CONTRIBUTING.md.)

## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

None.

## CHANGELOG entry

- [x] This change is user-facing and I added a changelog entry (`.changes/v1.16/BUG FIXES-20260424-140000.yaml`).
- [ ] This change is not user-facing.

## AI usage

AI assistance was used to draft the diagnostic code, the fixtures, and the test entries; I reviewed and verified the change locally before pushing.

---

Happy to adjust wording, diagnostic text, or scope (e.g. drop the ephemeral half if you'd rather keep the PR narrowly focused on the reported data-block case).