### PR TITLE
refactor: Separate concerns in mock provider sources logic, handle callbacks using `t.Cleanup`

### DIFF
--- a/internal/command/apply_test.go
+++ b/internal/command/apply_test.go
@@ -822,12 +822,11 @@ output "foobar" {
 		// Mock provider still needs to be supplied via testingOverrides despite the mock HTTP source
 		mockProvider := mockPluggableStateStorageProvider()
 		mockProviderAddress := addrs.NewDefaultProvider("test")
-		source, close := newMockProviderSource(t, map[string][]string{
+		source := newMockProviderSource(t, map[string][]string{
 			// The test fixture config has no version constraints, so the latest version will
 			// be used; below is the 'latest' version in the test world.
 			"hashicorp/test": {"1.2.3"},
 		})
-		t.Cleanup(close)
 
 		ui := new(cli.MockUi)
 		view, done := testView(t)
@@ -943,10 +942,9 @@ output "foobar" {
 		mockProvider.GetProviderSchemaResponse = &schema
 		mockProviderAddress := addrs.NewBuiltInProvider("terraform")
 
-		source, close := newMockProviderSource(t, map[string][]string{
+		source := newMockProviderSource(t, map[string][]string{
 			"hashicorp/terraform": {"1.2.3"},
 		})
-		t.Cleanup(close)
 
 		ui := new(cli.MockUi)
 		view, done := testView(t)

--- a/internal/command/autocomplete_test.go
+++ b/internal/command/autocomplete_test.go
@@ -49,10 +49,9 @@ func TestMetaCompletePredictWorkspaceName(t *testing.T) {
 			"foobar":  true,
 		}
 		mockProviderAddress := addrs.NewDefaultProvider("test")
-		providerSource, close := newMockProviderSource(t, map[string][]string{
+		providerSource := newMockProviderSource(t, map[string][]string{
 			"hashicorp/test": {"1.0.0"},
 		})
-		defer close()
 
 		ui := new(cli.MockUi)
 		view, _ := testView(t)
@@ -93,10 +92,9 @@ func TestMetaCompletePredictWorkspaceName(t *testing.T) {
 		// No workspaces exist in the mock
 		mockProvider.MockStates = map[string]interface{}{}
 		mockProviderAddress := addrs.NewDefaultProvider("test")
-		providerSource, close := newMockProviderSource(t, map[string][]string{
+		providerSource := newMockProviderSource(t, map[string][]string{
 			"hashicorp/test": {"1.0.0"},
 		})
-		defer close()
 
 		ui := new(cli.MockUi)
 		view, _ := testView(t)

--- a/internal/command/import_test.go
+++ b/internal/command/import_test.go
@@ -173,10 +173,9 @@ func TestImport_remoteState(t *testing.T) {
 
 	statePath := "imported.tfstate"
 
-	providerSource, close := newMockProviderSource(t, map[string][]string{
-		"test": []string{"1.2.3"},
+	providerSource := newMockProviderSource(t, map[string][]string{
+		"test": {"1.2.3"},
 	})
-	defer close()
 
 	// init our backend
 	ui := cli.NewMockUi()
@@ -285,10 +284,9 @@ func TestImport_initializationErrorShouldUnlock(t *testing.T) {
 
 	statePath := "imported.tfstate"
 
-	providerSource, close := newMockProviderSource(t, map[string][]string{
-		"test": []string{"1.2.3"},
+	providerSource := newMockProviderSource(t, map[string][]string{
+		"test": {"1.2.3"},
 	})
-	defer close()
 
 	// init our backend
 	ui := cli.NewMockUi()
@@ -781,10 +779,9 @@ func TestImportModuleVarFile(t *testing.T) {
 		},
 	}
 
-	providerSource, close := newMockProviderSource(t, map[string][]string{
-		"test": []string{"1.2.3"},
+	providerSource := newMockProviderSource(t, map[string][]string{
+		"test": {"1.2.3"},
 	})
-	defer close()
 
 	// init to install the module
 	ui := new(cli.MockUi)
@@ -855,10 +852,9 @@ func TestImportModuleInputVariableEvaluation(t *testing.T) {
 		},
 	}
 
-	providerSource, close := newMockProviderSource(t, map[string][]string{
+	providerSource := newMockProviderSource(t, map[string][]string{
 		"test": {"1.2.3"},
 	})
-	defer close()
 
 	// init to install the module
 	ui := new(cli.MockUi)

--- a/internal/command/init2_test.go
+++ b/internal/command/init2_test.go
@@ -310,10 +310,9 @@ func TestPlan_dynamicModuleSource(t *testing.T) {
 	t.Chdir(td)
 
 	p := planFixtureProvider()
-	providerSource, close := newMockProviderSource(t, map[string][]string{
+	providerSource := newMockProviderSource(t, map[string][]string{
 		"hashicorp/test": {"1.0.0"},
 	})
-	defer close()
 
 	args := []string{"-var", "module_name=example"}
 
@@ -363,10 +362,9 @@ func TestPlan_dynamicModuleSourceMismatch(t *testing.T) {
 	t.Chdir(td)
 
 	p := planFixtureProvider()
-	providerSource, close := newMockProviderSource(t, map[string][]string{
+	providerSource := newMockProviderSource(t, map[string][]string{
 		"hashicorp/test": {"1.0.0"},
 	})
-	defer close()
 	args := []string{"-var", "module_name=example"}
 
 	initUi := new(cli.MockUi)
@@ -411,10 +409,9 @@ func TestApply_dynamicModuleSource(t *testing.T) {
 	t.Chdir(td)
 
 	p := planFixtureProvider()
-	providerSource, close := newMockProviderSource(t, map[string][]string{
+	providerSource := newMockProviderSource(t, map[string][]string{
 		"hashicorp/test": {"1.0.0"},
 	})
-	defer close()
 	args := []string{"-var", "module_name=example"}
 
 	initUi := new(cli.MockUi)
@@ -463,10 +460,9 @@ func TestApply_dynamicModuleSourceWithDefaultPlanFile(t *testing.T) {
 	t.Chdir(td)
 
 	p := planFixtureProvider()
-	providerSource, close := newMockProviderSource(t, map[string][]string{
+	providerSource := newMockProviderSource(t, map[string][]string{
 		"hashicorp/test": {"1.0.0"},
 	})
-	defer close()
 
 	initUi := new(cli.MockUi)
 	initView, initDone := testView(t)
@@ -539,10 +535,9 @@ func TestPlan_dynamicModuleSourceWithCount(t *testing.T) {
 	t.Chdir(td)
 
 	p := planFixtureProvider()
-	providerSource, close := newMockProviderSource(t, map[string][]string{
+	providerSource := newMockProviderSource(t, map[string][]string{
 		"hashicorp/test": {"1.0.0"},
 	})
-	defer close()
 
 	args := []string{"-var", "module_name=example"}
 
@@ -592,10 +587,9 @@ func TestPlan_dynamicModuleSourceWithForEach(t *testing.T) {
 	t.Chdir(td)
 
 	p := planFixtureProvider()
-	providerSource, close := newMockProviderSource(t, map[string][]string{
+	providerSource := newMockProviderSource(t, map[string][]string{
 		"hashicorp/test": {"1.0.0"},
 	})
-	defer close()
 
 	args := []string{"-var", "module_name=example"}
 

--- a/internal/command/init_test.go
+++ b/internal/command/init_test.go
@@ -6080,14 +6080,12 @@ func newMockProviderSourceUsingTestHttpServer(t *testing.T, availableProviderVer
 	)
 
 	// Get all the metadata for all provider versions defined in the availableProviderVersions map.
+	// This is needed to enable the http server to serve contents of the correct temporary file.
 	var packages []getproviders.PackageMeta
 	for pSource, versions := range availableProviderVersions {
 		addr := addrs.MustParseProviderSourceString(pSource)
 		for _, versionStr := range versions {
-			version, err := getproviders.ParseVersion(versionStr)
-			if err != nil {
-				t.Fatalf("failed to parse %q as a version number for %q: %s", versionStr, addr.ForDisplay(), err)
-			}
+			version := getproviders.MustParseVersion(versionStr)
 			providerMetadata, err := source.PackageMeta(
 				context.Background(),
 				addr,

--- a/internal/command/init_test.go
+++ b/internal/command/init_test.go
@@ -213,11 +213,10 @@ func TestInit_two_step_provider_download(t *testing.T) {
 			t.Chdir(td)
 
 			// A provider source containing the random and null providers
-			providerSource, close := newMockProviderSource(t, map[string][]string{
+			providerSource := newMockProviderSource(t, map[string][]string{
 				"hashicorp/random": {"1.0.0", "9.9.9"},
 				"hashicorp/null":   {"1.0.0", "9.9.9"},
 			})
-			defer close()
 
 			ui := new(cli.MockUi)
 			view, done := testView(t)
@@ -889,10 +888,9 @@ func TestInit_backendReconfigure(t *testing.T) {
 	testCopyDir(t, testFixturePath("init-backend"), td)
 	t.Chdir(td)
 
-	providerSource, close := newMockProviderSource(t, map[string][]string{
+	providerSource := newMockProviderSource(t, map[string][]string{
 		"hashicorp/test": {"1.2.3"},
 	})
-	defer close()
 
 	ui := new(cli.MockUi)
 	view, done := testView(t)
@@ -964,10 +962,9 @@ func TestInit_backendMigrateWhileLocked(t *testing.T) {
 	testCopyDir(t, testFixturePath("init-backend-migrate-while-locked"), td)
 	t.Chdir(td)
 
-	providerSource, close := newMockProviderSource(t, map[string][]string{
+	providerSource := newMockProviderSource(t, map[string][]string{
 		"hashicorp/test": {"1.2.3"},
 	})
-	defer close()
 
 	ui := new(cli.MockUi)
 	view, done := testView(t)
@@ -1780,7 +1777,7 @@ func TestInit_getProvider(t *testing.T) {
 	overrides := metaOverridesForProvider(testProvider())
 	ui := new(cli.MockUi)
 	view, done := testView(t)
-	providerSource, close := newMockProviderSource(t, map[string][]string{
+	providerSource := newMockProviderSource(t, map[string][]string{
 		// looking for an exact version
 		"exact": {"1.2.3"},
 		// config requires >= 2.3.3
@@ -1788,7 +1785,6 @@ func TestInit_getProvider(t *testing.T) {
 		// config specifies
 		"between": {"3.4.5", "2.3.4", "1.2.3"},
 	})
-	defer close()
 	m := Meta{
 		testingOverrides: overrides,
 		Ui:               ui,
@@ -1887,14 +1883,13 @@ func TestInit_getProviderSource(t *testing.T) {
 	overrides := metaOverridesForProvider(testProvider())
 	ui := new(cli.MockUi)
 	view, done := testView(t)
-	providerSource, close := newMockProviderSource(t, map[string][]string{
+	providerSource := newMockProviderSource(t, map[string][]string{
 		// looking for an exact version
 		"acme/alpha": {"1.2.3"},
 		// config doesn't specify versions for other providers
 		"registry.example.com/acme/beta": {"1.0.0"},
 		"gamma":                          {"2.0.0"},
 	})
-	defer close()
 	m := Meta{
 		testingOverrides: overrides,
 		Ui:               ui,
@@ -1937,10 +1932,9 @@ func TestInit_getProviderLegacyFromState(t *testing.T) {
 	overrides := metaOverridesForProvider(testProvider())
 	ui := new(cli.MockUi)
 	view, done := testView(t)
-	providerSource, close := newMockProviderSource(t, map[string][]string{
+	providerSource := newMockProviderSource(t, map[string][]string{
 		"acme/alpha": {"1.2.3"},
 	})
-	defer close()
 	m := Meta{
 		testingOverrides: overrides,
 		Ui:               ui,
@@ -2044,11 +2038,10 @@ func TestInit_getProviderDetectedLegacy(t *testing.T) {
 	// source: the mock source will return ErrRegistryProviderNotKnown for an
 	// unknown provider, and the registry source will allow us to look up the
 	// appropriate namespace if possible.
-	providerSource, psClose := newMockProviderSource(t, map[string][]string{
+	providerSource := newMockProviderSource(t, map[string][]string{
 		"hashicorp/foo":           {"1.2.3"},
 		"terraform-providers/baz": {"2.3.4"}, // this will not be installed
 	})
-	defer psClose()
 	registrySource, rsClose := testRegistrySource(t)
 	defer rsClose()
 	multiSource := getproviders.MultiSource{
@@ -2109,12 +2102,11 @@ func TestInit_providerSource(t *testing.T) {
 	testCopyDir(t, testFixturePath("init-required-providers"), td)
 	t.Chdir(td)
 
-	providerSource, close := newMockProviderSource(t, map[string][]string{
+	providerSource := newMockProviderSource(t, map[string][]string{
 		"test":      {"1.2.3", "1.2.4"},
 		"test-beta": {"1.2.4"},
 		"source":    {"1.2.2", "1.2.3", "1.2.1"},
 	})
-	defer close()
 
 	ui := cli.NewMockUi()
 	view, done := testView(t)
@@ -2305,7 +2297,7 @@ func TestInit_getUpgradePlugins(t *testing.T) {
 		testCopyDir(t, testFixturePath("init-get-providers"), td)
 		t.Chdir(td)
 
-		providerSource, close := newMockProviderSource(t, map[string][]string{
+		providerSource := newMockProviderSource(t, map[string][]string{
 			// looking for an exact version
 			"exact": {"1.2.3"},
 			// config requires >= 2.3.3
@@ -2313,7 +2305,6 @@ func TestInit_getUpgradePlugins(t *testing.T) {
 			// config specifies > 1.0.0 , < 3.0.0
 			"between": {"3.4.5", "2.3.4", "1.2.3"},
 		})
-		t.Cleanup(close)
 
 		ui := new(cli.MockUi)
 		view, done := testView(t)
@@ -2452,11 +2443,10 @@ terraform {
 			t.Fatalf("failed to write main.tf: %s", err)
 		}
 
-		providerSource, close := newMockProviderSource(t, map[string][]string{
+		providerSource := newMockProviderSource(t, map[string][]string{
 			// config requires > 1.0.0
 			"test": {"1.2.3", "9.9.9"},
 		})
-		t.Cleanup(close)
 
 		// Mock provider to act as "hashicorp/test"
 		mockProvider := mockPluggableStateStorageProvider()
@@ -2578,11 +2568,10 @@ terraform {
 			t.Fatalf("failed to write main.tf: %s", err)
 		}
 
-		providerSource, close := newMockProviderSource(t, map[string][]string{
+		providerSource := newMockProviderSource(t, map[string][]string{
 			// config requires > 1.0.0
 			"test": {"1.2.3", "9.9.9"},
 		})
-		t.Cleanup(close)
 
 		// Mock provider to act as "hashicorp/test"
 		mockProvider := mockPluggableStateStorageProvider()
@@ -2710,13 +2699,11 @@ terraform {
 			t.Fatalf("failed to write main.tf: %s", err)
 		}
 
-		providerSource, close := newMockProviderSource(t, map[string][]string{
+		providerSource := newMockProviderSource(t, map[string][]string{
 			// config requires > 1.0.0
 			"test":   {"1.2.3", "9.9.9"},
 			"foobar": {"1.2.3", "9.9.9"},
 		})
-		t.Cleanup(close)
-
 		// Mock provider to act as "hashicorp/test"
 		mockProvider := mockPluggableStateStorageProvider()
 
@@ -2846,7 +2833,7 @@ func TestInit_getProviderMissing(t *testing.T) {
 	testCopyDir(t, testFixturePath("init-get-providers"), td)
 	t.Chdir(td)
 
-	providerSource, close := newMockProviderSource(t, map[string][]string{
+	providerSource := newMockProviderSource(t, map[string][]string{
 		// looking for exact version 1.2.3
 		"exact": {"1.2.4"},
 		// config requires >= 2.3.3
@@ -2854,7 +2841,6 @@ func TestInit_getProviderMissing(t *testing.T) {
 		// config specifies
 		"between": {"3.4.5", "2.3.4", "1.2.3"},
 	})
-	defer close()
 
 	ui := new(cli.MockUi)
 	view, done := testView(t)
@@ -2971,10 +2957,9 @@ func TestInit_providerLockFile(t *testing.T) {
 	defer os.Chmod(td, os.ModePerm)
 	t.Chdir(td)
 
-	providerSource, close := newMockProviderSource(t, map[string][]string{
+	providerSource := newMockProviderSource(t, map[string][]string{
 		"test": {"1.2.3"},
 	})
-	defer close()
 
 	ui := new(cli.MockUi)
 	view, done := testView(t)
@@ -3158,8 +3143,7 @@ provider "registry.terraform.io/hashicorp/test" {
 			testCopyDir(t, testFixturePath(tc.fixture), td)
 			t.Chdir(td)
 
-			providerSource, close := newMockProviderSource(t, tc.providers)
-			defer close()
+			providerSource := newMockProviderSource(t, tc.providers)
 
 			ui := new(cli.MockUi)
 			view, done := testView(t)
@@ -3206,8 +3190,7 @@ func TestInit_pluginDirReset(t *testing.T) {
 	t.Chdir(td)
 
 	// An empty provider source
-	providerSource, close := newMockProviderSource(t, nil)
-	defer close()
+	providerSource := newMockProviderSource(t, nil)
 
 	ui := new(cli.MockUi)
 	view, done := testView(t)
@@ -3276,8 +3259,7 @@ func TestInit_pluginDirProviders(t *testing.T) {
 	t.Chdir(td)
 
 	// An empty provider source
-	providerSource, close := newMockProviderSource(t, nil)
-	defer close()
+	providerSource := newMockProviderSource(t, nil)
 
 	ui := new(cli.MockUi)
 	view, done := testView(t)
@@ -3375,10 +3357,9 @@ func TestInit_pluginDirProvidersDoesNotGet(t *testing.T) {
 	// Our provider source has a suitable package for "between" available,
 	// but we should ignore it because -plugin-dir is set and thus this
 	// source is temporarily overridden during install.
-	providerSource, close := newMockProviderSource(t, map[string][]string{
+	providerSource := newMockProviderSource(t, map[string][]string{
 		"between": {"2.3.4"},
 	})
-	defer close()
 
 	ui := cli.NewMockUi()
 	view, done := testView(t)
@@ -3452,8 +3433,7 @@ func TestInit_pluginDirWithBuiltIn(t *testing.T) {
 	t.Chdir(td)
 
 	// An empty provider source
-	providerSource, close := newMockProviderSource(t, nil)
-	defer close()
+	providerSource := newMockProviderSource(t, nil)
 
 	ui := cli.NewMockUi()
 	view, done := testView(t)
@@ -3492,8 +3472,7 @@ func TestInit_invalidBuiltInProviders(t *testing.T) {
 	t.Chdir(td)
 
 	// An empty provider source
-	providerSource, close := newMockProviderSource(t, nil)
-	defer close()
+	providerSource := newMockProviderSource(t, nil)
 
 	ui := cli.NewMockUi()
 	view, done := testView(t)
@@ -3658,11 +3637,10 @@ func TestInit_testsWithExternalProviders(t *testing.T) {
 	testCopyDir(t, testFixturePath("init-with-tests-external-providers"), td)
 	t.Chdir(td)
 
-	providerSource, close := newMockProviderSource(t, map[string][]string{
+	providerSource := newMockProviderSource(t, map[string][]string{
 		"hashicorp/testing": {"1.0.0"},
 		"testing/configure": {"1.0.0"},
 	})
-	defer close()
 
 	hashicorpTestingProviderAddress := addrs.NewDefaultProvider("testing")
 	hashicorpTestingProvider := new(testing_provider.MockProvider)
@@ -3699,10 +3677,9 @@ func TestInit_tests(t *testing.T) {
 
 	provider := applyFixtureProvider() // We just want the types from this provider.
 
-	providerSource, close := newMockProviderSource(t, map[string][]string{
+	providerSource := newMockProviderSource(t, map[string][]string{
 		"hashicorp/test": {"1.0.0"},
 	})
-	defer close()
 
 	ui := new(cli.MockUi)
 	view, done := testView(t)
@@ -3729,10 +3706,9 @@ func TestInit_testsWithProvider(t *testing.T) {
 
 	provider := applyFixtureProvider() // We just want the types from this provider.
 
-	providerSource, close := newMockProviderSource(t, map[string][]string{
+	providerSource := newMockProviderSource(t, map[string][]string{
 		"hashicorp/test": {"1.0.0"},
 	})
-	defer close()
 
 	ui := new(cli.MockUi)
 	view, done := testView(t)
@@ -3776,10 +3752,9 @@ func TestInit_testsWithOverriddenInvalidRequiredProviders(t *testing.T) {
 
 	provider := applyFixtureProvider() // We just want the types from this provider.
 
-	providerSource, close := newMockProviderSource(t, map[string][]string{
+	providerSource := newMockProviderSource(t, map[string][]string{
 		"hashicorp/test": {"1.0.0"},
 	})
-	defer close()
 
 	ui := new(cli.MockUi)
 	view, done := testView(t)
@@ -3806,10 +3781,9 @@ func TestInit_testsWithInvalidRequiredProviders(t *testing.T) {
 
 	provider := applyFixtureProvider() // We just want the types from this provider.
 
-	providerSource, close := newMockProviderSource(t, map[string][]string{
+	providerSource := newMockProviderSource(t, map[string][]string{
 		"hashicorp/test": {"1.0.0"},
 	})
-	defer close()
 
 	ui := new(cli.MockUi)
 	view, done := testView(t)
@@ -3837,10 +3811,9 @@ func TestInit_testsWithModule(t *testing.T) {
 
 	provider := applyFixtureProvider() // We just want the types from this provider.
 
-	providerSource, close := newMockProviderSource(t, map[string][]string{
+	providerSource := newMockProviderSource(t, map[string][]string{
 		"hashicorp/test": {"1.0.0"},
 	})
-	defer close()
 
 	ui := new(cli.MockUi)
 	view, done := testView(t)
@@ -3932,10 +3905,9 @@ func TestInit_stateStore_newWorkingDir(t *testing.T) {
 
 		mockProvider := mockPluggableStateStorageProvider()
 		mockProviderAddress := addrs.NewDefaultProvider("test")
-		providerSource, close := newMockProviderSource(t, map[string][]string{
+		providerSource := newMockProviderSource(t, map[string][]string{
 			"hashicorp/test": {"1.2.3"},
 		})
-		defer close()
 
 		ui := new(cli.MockUi)
 		view, done := testView(t)
@@ -4022,10 +3994,9 @@ func TestInit_stateStore_newWorkingDir(t *testing.T) {
 
 		mockProvider := mockPluggableStateStorageProvider()
 		mockProviderAddress := addrs.NewDefaultProvider("test")
-		providerSource, close := newMockProviderSource(t, map[string][]string{
+		providerSource := newMockProviderSource(t, map[string][]string{
 			"hashicorp/test": {"1.0.0"},
 		})
-		defer close()
 
 		ui := new(cli.MockUi)
 		view, done := testView(t)
@@ -4097,10 +4068,9 @@ func TestInit_stateStore_newWorkingDir(t *testing.T) {
 		}
 
 		mockProviderAddress := addrs.NewDefaultProvider("test")
-		providerSource, close := newMockProviderSource(t, map[string][]string{
+		providerSource := newMockProviderSource(t, map[string][]string{
 			"hashicorp/test": {"1.0.0"},
 		})
-		defer close()
 
 		ui := new(cli.MockUi)
 		view, done := testView(t)
@@ -4165,10 +4135,9 @@ func TestInit_stateStore_newWorkingDir(t *testing.T) {
 		}
 
 		mockProviderAddress := addrs.NewDefaultProvider("test")
-		providerSource, close := newMockProviderSource(t, map[string][]string{
+		providerSource := newMockProviderSource(t, map[string][]string{
 			"hashicorp/test": {"1.0.0"},
 		})
-		defer close()
 
 		// Allow the test to respond to the prompt to pick an
 		// existing workspace, given the selected one doesn't exist.
@@ -4254,10 +4223,9 @@ func TestInit_stateStore_configUnchanged(t *testing.T) {
 			States: []string{"default"},
 		}
 		mockProviderAddress := addrs.NewDefaultProvider("test")
-		providerSource, close := newMockProviderSource(t, map[string][]string{
+		providerSource := newMockProviderSource(t, map[string][]string{
 			"hashicorp/test": {"1.2.3"}, // Matches provider version in backend state file fixture
 		})
-		defer close()
 
 		ui := new(cli.MockUi)
 		view, done := testView(t)
@@ -4340,10 +4308,9 @@ func TestInit_stateStore_configChanges(t *testing.T) {
 		mockProvider.MockStates = map[string]interface{}{"default": []byte(`{"version": 4,"terraform_version":"1.15.0","serial": 1,"lineage": "","outputs": {},"resources": [],"checks":[]}`)}
 
 		mockProviderAddress := addrs.NewDefaultProvider("test")
-		providerSource, close := newMockProviderSource(t, map[string][]string{
+		providerSource := newMockProviderSource(t, map[string][]string{
 			"hashicorp/test": {"1.2.3"}, // Matches provider version in backend state file fixture
 		})
-		defer close()
 
 		ui := new(cli.MockUi)
 		view, done := testView(t)
@@ -4429,10 +4396,9 @@ func TestInit_stateStore_configChanges(t *testing.T) {
 		mockProvider.MockStates = map[string]interface{}{"default": []byte(`{"version": 4,"terraform_version":"1.15.0","serial": 1,"lineage": "","outputs": {},"resources": [],"checks":[]}`)}
 
 		mockProviderAddress := addrs.NewDefaultProvider("test")
-		providerSource, close := newMockProviderSource(t, map[string][]string{
+		providerSource := newMockProviderSource(t, map[string][]string{
 			"hashicorp/test": {"1.2.3"}, // Matches provider version in backend state file fixture
 		})
-		defer close()
 
 		ui := new(cli.MockUi)
 		view, done := testView(t)
@@ -4486,10 +4452,9 @@ func TestInit_stateStore_configChanges(t *testing.T) {
 		mockProvider := mockPluggableStateStorageProvider()
 		mockProvider.GetStatesResponse = &providers.GetStatesResponse{States: []string{"default"}} // The previous init implied by this test scenario would have created the default workspace.
 		mockProviderAddress := addrs.NewDefaultProvider("test")
-		providerSource, close := newMockProviderSource(t, map[string][]string{
+		providerSource := newMockProviderSource(t, map[string][]string{
 			"hashicorp/test": {"1.2.3"}, // Matches provider version in backend state file fixture
 		})
-		defer close()
 
 		ui := new(cli.MockUi)
 		view, done := testView(t)
@@ -4584,10 +4549,9 @@ func TestInit_stateStore_backendConfigFlagNoMigrate(t *testing.T) {
 	mockProvider.GetProviderSchemaResponse.StateStores["test_store"].Body.Attributes["value"].Required = false
 
 	mockProviderAddress := addrs.NewDefaultProvider("test")
-	providerSource, close := newMockProviderSource(t, map[string][]string{
+	providerSource := newMockProviderSource(t, map[string][]string{
 		"hashicorp/test": {"1.2.3"}, // Matches provider version in backend state file fixture
 	})
-	t.Cleanup(close)
 
 	var originalStateStoreConfigHash uint64
 
@@ -4696,10 +4660,9 @@ func TestInit_stateStore_unset(t *testing.T) {
 	// Make the provider report that it contains a 2nd storage implementation with the above name
 	mockProvider.GetProviderSchemaResponse.StateStores[otherStoreName] = mockProvider.GetProviderSchemaResponse.StateStores[storeName]
 	mockProviderAddress := addrs.NewDefaultProvider("test")
-	providerSource, close := newMockProviderSource(t, map[string][]string{
+	providerSource := newMockProviderSource(t, map[string][]string{
 		"hashicorp/test": {"1.2.3"}, // Matches provider version in backend state file fixture
 	})
-	defer close()
 
 	{
 		log.Printf("[TRACE] TestInit_stateStore_unset: beginning first init")
@@ -4796,10 +4759,9 @@ func TestInit_stateStore_unset_withoutProviderRequirements(t *testing.T) {
 
 	mockProvider := mockPluggableStateStorageProvider()
 	mockProviderAddress := addrs.NewDefaultProvider("test")
-	providerSource, close := newMockProviderSource(t, map[string][]string{
+	providerSource := newMockProviderSource(t, map[string][]string{
 		"hashicorp/test": {"1.2.3"}, // Matches provider version in backend state file fixture
 	})
-	defer close()
 
 	{
 		log.Printf("[TRACE] TestInit_stateStore_unset_withoutProviderRequirements: beginning first init")
@@ -4894,10 +4856,9 @@ func TestInit_stateStore_to_backend(t *testing.T) {
 
 	mockProvider := mockPluggableStateStorageProvider()
 	mockProviderAddress := addrs.NewDefaultProvider("test")
-	providerSource, close := newMockProviderSource(t, map[string][]string{
+	providerSource := newMockProviderSource(t, map[string][]string{
 		"hashicorp/test": {"1.2.3"}, // Matches provider version in backend state file fixture
 	})
-	defer close()
 
 	tOverrides := &testingOverrides{
 		Providers: map[addrs.Provider]providers.Factory{
@@ -5136,10 +5097,9 @@ func TestInit_backend_to_stateStore_singleWorkspace(t *testing.T) {
 
 	mockProvider := mockPluggableStateStorageProvider()
 	mockProviderAddress := addrs.NewDefaultProvider("test")
-	providerSource, close := newMockProviderSource(t, map[string][]string{
+	providerSource := newMockProviderSource(t, map[string][]string{
 		"hashicorp/test": {"1.2.3"},
 	})
-	defer close()
 
 	tOverrides := &testingOverrides{
 		Providers: map[addrs.Provider]providers.Factory{
@@ -5316,10 +5276,9 @@ func TestInit_backend_to_stateStore_noState(t *testing.T) {
 
 	mockProvider := mockPluggableStateStorageProvider()
 	mockProviderAddress := addrs.NewDefaultProvider("test")
-	providerSource, close := newMockProviderSource(t, map[string][]string{
+	providerSource := newMockProviderSource(t, map[string][]string{
 		"hashicorp/test": {"1.2.3"},
 	})
-	defer close()
 
 	tOverrides := &testingOverrides{
 		Providers: map[addrs.Provider]providers.Factory{
@@ -5430,10 +5389,9 @@ func TestInit_localBackend_to_stateStore(t *testing.T) {
 
 	mockProvider := mockPluggableStateStorageProvider()
 	mockProviderAddress := addrs.NewDefaultProvider("test")
-	providerSource, close := newMockProviderSource(t, map[string][]string{
+	providerSource := newMockProviderSource(t, map[string][]string{
 		"hashicorp/test": {"1.2.3"},
 	})
-	defer close()
 
 	tOverrides := &testingOverrides{
 		Providers: map[addrs.Provider]providers.Factory{
@@ -5591,10 +5549,9 @@ func TestInit_backend_to_stateStore_multipleWorkspaces(t *testing.T) {
 
 	mockProvider := mockPluggableStateStorageProvider()
 	mockProviderAddress := addrs.NewDefaultProvider("test")
-	providerSource, close := newMockProviderSource(t, map[string][]string{
+	providerSource := newMockProviderSource(t, map[string][]string{
 		"hashicorp/test": {"1.2.3"},
 	})
-	defer close()
 
 	tOverrides := &testingOverrides{
 		Providers: map[addrs.Provider]providers.Factory{
@@ -5831,10 +5788,9 @@ func TestInit_cloud_to_stateStore(t *testing.T) {
 
 	mockProvider := mockPluggableStateStorageProvider()
 	mockProviderAddress := addrs.NewDefaultProvider("test")
-	providerSource, close := newMockProviderSource(t, map[string][]string{
+	providerSource := newMockProviderSource(t, map[string][]string{
 		"hashicorp/test": {"1.2.3"},
 	})
-	defer close()
 
 	tOverrides := &testingOverrides{
 		Providers: map[addrs.Provider]providers.Factory{
@@ -6001,7 +5957,7 @@ func TestInit_configErrorsImpactingStateStore(t *testing.T) {
 // abort the current test using the given testing.T. Therefore a caller can
 // assume that if this function returns then the result is valid and ready
 // to use.
-func newMockProviderSource(t *testing.T, availableProviderVersions map[string][]string) (source *getproviders.MockSource, close func()) {
+func newMockProviderSource(t *testing.T, availableProviderVersions map[string][]string) *getproviders.MockSource {
 	t.Helper()
 	var packages []getproviders.PackageMeta
 	for source, versions := range availableProviderVersions {
@@ -6019,7 +5975,7 @@ func newMockProviderSource(t *testing.T, availableProviderVersions map[string][]
 		}
 	}
 
-	return getproviders.NewMockSource(packages, nil), func() {} // Return empty func as
+	return getproviders.NewMockSource(packages, nil)
 }
 
 // newMockProviderSourceViaHTTP is similar to newMockProviderSource except that the metadata (PackageMeta) for each provider

--- a/internal/command/init_test.go
+++ b/internal/command/init_test.go
@@ -1983,14 +1983,14 @@ func TestInit_getProviderInvalidPackage(t *testing.T) {
 	// create a provider source which allows installing an invalid package
 	addr := addrs.MustParseProviderSourceString("invalid/package")
 	version := getproviders.MustParseVersion("1.0.0")
-	meta, close, err := getproviders.FakeInstallablePackageMeta(
+	meta, err := getproviders.FakeInstallablePackageMeta(
+		t,
 		addr,
 		version,
 		getproviders.VersionList{getproviders.MustParseVersion("5.0")},
 		getproviders.CurrentPlatform,
 		"terraform-package", // should be "terraform-provider-package"
 	)
-	defer close()
 	if err != nil {
 		t.Fatalf("failed to prepare fake package for %s %s: %s", addr.ForDisplay(), version, err)
 	}
@@ -5984,9 +5984,9 @@ func TestInit_configErrorsImpactingStateStore(t *testing.T) {
 // source that contains a set of packages matching the given provider versions
 // that are available for installation (from temporary local files).
 //
-// The caller must call the returned close callback once the source is no
-// longer needed, at which point it will clean up all of the temporary files
-// and the packages in the source will no longer be available for installation.
+// This function will automatically close the source at the end of the test/subtest
+// using t.Cleanup, so the caller isn't responsible for cleaning up all of the
+// temporary files and packages in the source.
 //
 // Provider addresses must be valid source strings, and passing only the
 // provider name will be interpreted as a "default" provider under
@@ -6004,31 +6004,22 @@ func TestInit_configErrorsImpactingStateStore(t *testing.T) {
 func newMockProviderSource(t *testing.T, availableProviderVersions map[string][]string) (source *getproviders.MockSource, close func()) {
 	t.Helper()
 	var packages []getproviders.PackageMeta
-	var closes []func()
-	close = func() {
-		for _, f := range closes {
-			f()
-		}
-	}
 	for source, versions := range availableProviderVersions {
 		addr := addrs.MustParseProviderSourceString(source)
 		for _, versionStr := range versions {
 			version, err := getproviders.ParseVersion(versionStr)
 			if err != nil {
-				close()
 				t.Fatalf("failed to parse %q as a version number for %q: %s", versionStr, addr.ForDisplay(), err)
 			}
-			meta, close, err := getproviders.FakeInstallablePackageMeta(addr, version, getproviders.VersionList{getproviders.MustParseVersion("5.0")}, getproviders.CurrentPlatform, "")
+			meta, err := getproviders.FakeInstallablePackageMeta(t, addr, version, getproviders.VersionList{getproviders.MustParseVersion("5.0")}, getproviders.CurrentPlatform, "")
 			if err != nil {
-				close()
 				t.Fatalf("failed to prepare fake package for %s %s: %s", addr.ForDisplay(), versionStr, err)
 			}
-			closes = append(closes, close)
 			packages = append(packages, meta)
 		}
 	}
 
-	return getproviders.NewMockSource(packages, nil), close
+	return getproviders.NewMockSource(packages, nil), nil
 }
 
 // newMockProviderSourceViaHTTP is similar to newMockProviderSource except that the metadata (PackageMeta) for each provider
@@ -6044,31 +6035,27 @@ func newMockProviderSource(t *testing.T, availableProviderVersions map[string][]
 func newMockProviderSourceViaHTTP(t *testing.T, availableProviderVersions map[string][]string, address string) (source *getproviders.MockSource) {
 	t.Helper()
 	var packages []getproviders.PackageMeta
-	var closes []func()
-	close := func() {
-		for _, f := range closes {
-			f()
-		}
-	}
 	for source, versions := range availableProviderVersions {
 		addr := addrs.MustParseProviderSourceString(source)
 		for _, versionStr := range versions {
 			version, err := getproviders.ParseVersion(versionStr)
 			if err != nil {
-				close()
 				t.Fatalf("failed to parse %q as a version number for %q: %s", versionStr, addr.ForDisplay(), err)
 			}
-			meta, close, err := getproviders.FakePackageMetaViaHTTP(addr, version, getproviders.VersionList{getproviders.MustParseVersion("5.0")}, getproviders.CurrentPlatform, address, "")
+			meta, err := getproviders.FakePackageMetaViaHTTP(
+				t,
+				addr,
+				version,
+				getproviders.VersionList{getproviders.MustParseVersion("5.0")},
+				getproviders.CurrentPlatform,
+				address)
 			if err != nil {
-				close()
 				t.Fatalf("failed to prepare fake package for %s %s: %s", addr.ForDisplay(), versionStr, err)
 			}
-			closes = append(closes, close)
 			packages = append(packages, meta)
 		}
 	}
 
-	t.Cleanup(close)
 	return getproviders.NewMockSource(packages, nil)
 }
 
@@ -6208,10 +6195,9 @@ func installFakeProviderPackagesElsewhere(t *testing.T, cacheDir *providercache.
 			if err != nil {
 				t.Fatalf("failed to parse %q as a version number for %q: %s", versionStr, name, err)
 			}
-			meta, close, err := getproviders.FakeInstallablePackageMeta(addr, version, getproviders.VersionList{getproviders.MustParseVersion("5.0")}, getproviders.CurrentPlatform, "")
+			meta, err := getproviders.FakeInstallablePackageMeta(t, addr, version, getproviders.VersionList{getproviders.MustParseVersion("5.0")}, getproviders.CurrentPlatform, "")
 			// We're going to install all these fake packages before we return,
 			// so we don't need to preserve them afterwards.
-			defer close()
 			if err != nil {
 				t.Fatalf("failed to prepare fake package for %s %s: %s", name, versionStr, err)
 			}

--- a/internal/command/init_test.go
+++ b/internal/command/init_test.go
@@ -6019,7 +6019,7 @@ func newMockProviderSource(t *testing.T, availableProviderVersions map[string][]
 		}
 	}
 
-	return getproviders.NewMockSource(packages, nil), nil
+	return getproviders.NewMockSource(packages, nil), func() {} // Return empty func as
 }
 
 // newMockProviderSourceViaHTTP is similar to newMockProviderSource except that the metadata (PackageMeta) for each provider

--- a/internal/command/providers_schema_test.go
+++ b/internal/command/providers_schema_test.go
@@ -61,10 +61,9 @@ func TestProvidersSchema_output(t *testing.T) {
 			testCopyDir(t, inputDir, td)
 			t.Chdir(td)
 
-			providerSource, close := newMockProviderSource(t, map[string][]string{
+			providerSource := newMockProviderSource(t, map[string][]string{
 				"test": {"1.2.3"},
 			})
-			defer close()
 
 			p := providersSchemaFixtureProvider()
 			ui := new(cli.MockUi)

--- a/internal/command/providers_test.go
+++ b/internal/command/providers_test.go
@@ -92,12 +92,11 @@ func TestProviders_modules(t *testing.T) {
 	// first run init with mock provider sources to install the module
 	initUi := new(cli.MockUi)
 	view, _ := testView(t)
-	providerSource, close := newMockProviderSource(t, map[string][]string{
+	providerSource := newMockProviderSource(t, map[string][]string{
 		"foo": {"1.0.0"},
 		"bar": {"2.0.0"},
 		"baz": {"1.2.2"},
 	})
-	defer close()
 	m := Meta{
 		testingOverrides: metaOverridesForProvider(testProvider()),
 		Ui:               initUi,

--- a/internal/command/query_test.go
+++ b/internal/command/query_test.go
@@ -181,10 +181,9 @@ this variable.
 			td := t.TempDir()
 			testCopyDir(t, testFixturePath(path.Join("query", ts.directory)), td)
 			t.Chdir(td)
-			providerSource, close := newMockProviderSource(t, map[string][]string{
+			providerSource := newMockProviderSource(t, map[string][]string{
 				"hashicorp/test": {"1.0.0"},
 			})
-			defer close()
 
 			p := queryFixtureProvider()
 			view, done := testView(t)
@@ -758,10 +757,9 @@ func TestQuery_JSON(t *testing.T) {
 			td := t.TempDir()
 			testCopyDir(t, testFixturePath(path.Join("query", ts.directory)), td)
 			t.Chdir(td)
-			providerSource, close := newMockProviderSource(t, map[string][]string{
+			providerSource := newMockProviderSource(t, map[string][]string{
 				"hashicorp/test": {"1.0.0"},
 			})
-			defer close()
 
 			p := queryFixtureProvider()
 			view, done := testView(t)
@@ -875,10 +873,9 @@ func TestQuery_JSON_Raw(t *testing.T) {
 			td := t.TempDir()
 			testCopyDir(t, testFixturePath(path.Join("query", ts.directory)), td)
 			t.Chdir(td)
-			providerSource, close := newMockProviderSource(t, map[string][]string{
+			providerSource := newMockProviderSource(t, map[string][]string{
 				"hashicorp/test": {"1.0.0"},
 			})
-			defer close()
 
 			p := queryFixtureProvider()
 			view, done := testView(t)

--- a/internal/command/show_test.go
+++ b/internal/command/show_test.go
@@ -552,11 +552,10 @@ func TestShow_json_output(t *testing.T) {
 
 			expectError := strings.Contains(entry.Name(), "error")
 
-			providerSource, close := newMockProviderSource(t, map[string][]string{
+			providerSource := newMockProviderSource(t, map[string][]string{
 				"test":            {"1.2.3"},
 				"hashicorp2/test": {"1.2.3"},
 			})
-			defer close()
 
 			p := showFixtureProvider()
 
@@ -665,8 +664,7 @@ func TestShow_json_output_sensitive(t *testing.T) {
 	testCopyDir(t, inputDir, td)
 	t.Chdir(td)
 
-	providerSource, close := newMockProviderSource(t, map[string][]string{"test": {"1.2.3"}})
-	defer close()
+	providerSource := newMockProviderSource(t, map[string][]string{"test": {"1.2.3"}})
 
 	p := showFixtureSensitiveProvider()
 
@@ -758,9 +756,7 @@ func TestShow_json_output_actions(t *testing.T) {
 	testCopyDir(t, inputDir, td)
 	t.Chdir(td)
 
-	providerSource, close := newMockProviderSource(t, map[string][]string{"test": {"1.2.3"}})
-	defer close()
-
+	providerSource := newMockProviderSource(t, map[string][]string{"test": {"1.2.3"}})
 	p := showFixtureProvider()
 
 	// init
@@ -855,8 +851,7 @@ func TestShow_json_output_conditions_refresh_only(t *testing.T) {
 	testCopyDir(t, inputDir, td)
 	t.Chdir(td)
 
-	providerSource, close := newMockProviderSource(t, map[string][]string{"test": {"1.2.3"}})
-	defer close()
+	providerSource := newMockProviderSource(t, map[string][]string{"test": {"1.2.3"}})
 
 	p := showFixtureSensitiveProvider()
 
@@ -964,10 +959,9 @@ func TestShow_json_output_state(t *testing.T) {
 			testCopyDir(t, inputDir, td)
 			t.Chdir(td)
 
-			providerSource, close := newMockProviderSource(t, map[string][]string{
+			providerSource := newMockProviderSource(t, map[string][]string{
 				"test": {"1.2.3"},
 			})
-			defer close()
 
 			p := showFixtureProvider()
 

--- a/internal/command/state_pull_test.go
+++ b/internal/command/state_pull_test.go
@@ -106,10 +106,9 @@ func TestStatePull_stateStore(t *testing.T) {
 		"default": stateBytes,
 	}
 	mockProviderAddress := addrs.NewDefaultProvider("test")
-	providerSource, close := newMockProviderSource(t, map[string][]string{
+	providerSource := newMockProviderSource(t, map[string][]string{
 		"hashicorp/test": {"1.0.0"},
 	})
-	defer close()
 
 	ui := cli.NewMockUi()
 	streams, _ := terminal.StreamsForTesting(t)

--- a/internal/command/test_test.go
+++ b/internal/command/test_test.go
@@ -480,10 +480,9 @@ func TestTest_Runs(t *testing.T) {
 			store := &testing_command.ResourceStore{
 				Data: make(map[string]cty.Value),
 			}
-			providerSource, close := newMockProviderSource(t, map[string][]string{
+			providerSource := newMockProviderSource(t, map[string][]string{
 				"test": {"1.0.0"},
 			})
-			defer close()
 
 			streams, done := terminal.StreamsForTesting(t)
 			view := views.NewView(streams)
@@ -627,10 +626,9 @@ func TestTest_DestroyFail(t *testing.T) {
 	t.Chdir(td)
 
 	provider := testing_command.NewProvider(nil)
-	providerSource, close := newMockProviderSource(t, map[string][]string{
+	providerSource := newMockProviderSource(t, map[string][]string{
 		"test": {"1.0.0"},
 	})
-	defer close()
 
 	view, done := testView(t)
 
@@ -857,10 +855,9 @@ main.tftest.hcl/test_three, and they need to be cleaned up manually:
 
 	t.Run("cleanup all left-over state", func(t *testing.T) {
 		provider := testing_command.NewProvider(nil)
-		providerSource, close := newMockProviderSource(t, map[string][]string{
+		providerSource := newMockProviderSource(t, map[string][]string{
 			"test": {"1.0.0"},
 		})
-		defer close()
 
 		// Run the test command to create the state
 		td := executeTestCmd(provider, providerSource)
@@ -916,10 +913,9 @@ Success!
 
 	t.Run("cleanup failed state only (-repair)", func(t *testing.T) {
 		provider := testing_command.NewProvider(nil)
-		providerSource, close := newMockProviderSource(t, map[string][]string{
+		providerSource := newMockProviderSource(t, map[string][]string{
 			"test": {"1.0.0"},
 		})
-		defer close()
 
 		// Run the test command to create the state
 		td := executeTestCmd(provider, providerSource)
@@ -977,10 +973,9 @@ func TestTest_CleanupActuallyCleansUp(t *testing.T) {
 	t.Chdir(td)
 
 	provider := testing_command.NewProvider(nil)
-	providerSource, close := newMockProviderSource(t, map[string][]string{
+	providerSource := newMockProviderSource(t, map[string][]string{
 		"test": {"1.0.0"},
 	})
-	defer close()
 
 	streams, done := terminal.StreamsForTesting(t)
 	view := views.NewView(streams)
@@ -1066,10 +1061,9 @@ func TestTest_SkipCleanup_ConsecutiveTestsFail(t *testing.T) {
 	t.Chdir(td)
 
 	provider := testing_command.NewProvider(nil)
-	providerSource, close := newMockProviderSource(t, map[string][]string{
+	providerSource := newMockProviderSource(t, map[string][]string{
 		"test": {"1.0.0"},
 	})
-	defer close()
 
 	streams, done := terminal.StreamsForTesting(t)
 	view := views.NewView(streams)
@@ -1146,10 +1140,9 @@ func TestTest_SharedState_Order(t *testing.T) {
 	t.Chdir(td)
 
 	provider := testing_command.NewProvider(nil)
-	providerSource, close := newMockProviderSource(t, map[string][]string{
+	providerSource := newMockProviderSource(t, map[string][]string{
 		"test": {"1.0.0"},
 	})
-	defer close()
 
 	streams, done := terminal.StreamsForTesting(t)
 	view := views.NewView(streams)
@@ -1218,10 +1211,9 @@ func TestTest_Parallel_Divided_Order(t *testing.T) {
 	t.Chdir(td)
 
 	provider := testing_command.NewProvider(nil)
-	providerSource, close := newMockProviderSource(t, map[string][]string{
+	providerSource := newMockProviderSource(t, map[string][]string{
 		"test": {"1.0.0"},
 	})
-	defer close()
 
 	streams, done := terminal.StreamsForTesting(t)
 	view := views.NewView(streams)
@@ -1295,10 +1287,9 @@ func TestTest_Parallel(t *testing.T) {
 	t.Chdir(td)
 
 	provider := testing_command.NewProvider(nil)
-	providerSource, close := newMockProviderSource(t, map[string][]string{
+	providerSource := newMockProviderSource(t, map[string][]string{
 		"test": {"1.0.0"},
 	})
-	defer close()
 
 	streams, done := terminal.StreamsForTesting(t)
 	view := views.NewView(streams)
@@ -1647,10 +1638,9 @@ func TestTest_ParallelTeardown(t *testing.T) {
 			defer closer()
 			t.Chdir(td)
 
-			providerSource, close := newMockProviderSource(t, map[string][]string{
+			providerSource := newMockProviderSource(t, map[string][]string{
 				"test": {"1.0.0"},
 			})
-			defer close()
 
 			streams, done := terminal.StreamsForTesting(t)
 			view := views.NewView(streams)
@@ -1817,10 +1807,9 @@ func TestTest_ProviderAlias(t *testing.T) {
 		Data: make(map[string]cty.Value),
 	}
 
-	providerSource, close := newMockProviderSource(t, map[string][]string{
+	providerSource := newMockProviderSource(t, map[string][]string{
 		"test": {"1.0.0"},
 	})
-	defer close()
 
 	streams, done := terminal.StreamsForTesting(t)
 	view := views.NewView(streams)
@@ -1885,8 +1874,7 @@ func TestTest_ComplexCondition(t *testing.T) {
 
 	provider := testing_command.NewProvider(nil)
 
-	providerSource, close := newMockProviderSource(t, map[string][]string{"test": {"1.0.0"}})
-	defer close()
+	providerSource := newMockProviderSource(t, map[string][]string{"test": {"1.0.0"}})
 
 	streams, done := terminal.StreamsForTesting(t)
 	view := views.NewView(streams)
@@ -2055,8 +2043,7 @@ func TestTest_ComplexConditionVerbose(t *testing.T) {
 
 	provider := testing_command.NewProvider(nil)
 
-	providerSource, close := newMockProviderSource(t, map[string][]string{"test": {"1.0.0"}})
-	defer close()
+	providerSource := newMockProviderSource(t, map[string][]string{"test": {"1.0.0"}})
 
 	streams, done := terminal.StreamsForTesting(t)
 	view := views.NewView(streams)
@@ -2389,11 +2376,10 @@ func TestTest_ModuleDependencies(t *testing.T) {
 	// Let's make the setup provider write into the data for test provider.
 	setup.SetResourcePrefix("data")
 
-	providerSource, close := newMockProviderSource(t, map[string][]string{
+	providerSource := newMockProviderSource(t, map[string][]string{
 		"test":  {"1.0.0"},
 		"setup": {"1.0.0"},
 	})
-	defer close()
 
 	streams, done := terminal.StreamsForTesting(t)
 	view := views.NewView(streams)
@@ -2466,10 +2452,9 @@ func TestTest_DynamicSourceWithVarFlag(t *testing.T) {
 	store := &testing_command.ResourceStore{
 		Data: make(map[string]cty.Value),
 	}
-	providerSource, close := newMockProviderSource(t, map[string][]string{
+	providerSource := newMockProviderSource(t, map[string][]string{
 		"test": {"1.0.0"},
 	})
-	defer close()
 
 	streams, done := terminal.StreamsForTesting(t)
 	view := views.NewView(streams)
@@ -2525,10 +2510,9 @@ func TestTest_DynamicSourceWithLocalValue(t *testing.T) {
 	store := &testing_command.ResourceStore{
 		Data: make(map[string]cty.Value),
 	}
-	providerSource, close := newMockProviderSource(t, map[string][]string{
+	providerSource := newMockProviderSource(t, map[string][]string{
 		"test": {"1.0.0"},
 	})
-	defer close()
 
 	streams, done := terminal.StreamsForTesting(t)
 	view := views.NewView(streams)
@@ -2584,10 +2568,9 @@ func TestTest_DynamicSourceNested(t *testing.T) {
 	store := &testing_command.ResourceStore{
 		Data: make(map[string]cty.Value),
 	}
-	providerSource, close := newMockProviderSource(t, map[string][]string{
+	providerSource := newMockProviderSource(t, map[string][]string{
 		"test": {"1.0.0"},
 	})
-	defer close()
 
 	streams, done := terminal.StreamsForTesting(t)
 	view := views.NewView(streams)
@@ -2657,11 +2640,10 @@ func TestTest_DynamicSourceWithSetupModule(t *testing.T) {
 	// Let's make the setup provider write into the data for test provider.
 	setup.SetResourcePrefix("data")
 
-	providerSource, close := newMockProviderSource(t, map[string][]string{
+	providerSource := newMockProviderSource(t, map[string][]string{
 		"test":  {"1.0.0"},
 		"setup": {"1.0.0"},
 	})
-	defer close()
 
 	streams, done := terminal.StreamsForTesting(t)
 	view := views.NewView(streams)
@@ -2973,10 +2955,9 @@ can remove the provider configuration again.
 
 			provider := testing_command.NewProvider(nil)
 
-			providerSource, close := newMockProviderSource(t, map[string][]string{
+			providerSource := newMockProviderSource(t, map[string][]string{
 				"test": {"1.0.0"},
 			})
-			defer close()
 
 			streams, done := terminal.StreamsForTesting(t)
 			view := views.NewView(streams)
@@ -3040,10 +3021,9 @@ func TestTest_NestedSetupModules(t *testing.T) {
 
 	provider := testing_command.NewProvider(nil)
 
-	providerSource, close := newMockProviderSource(t, map[string][]string{
+	providerSource := newMockProviderSource(t, map[string][]string{
 		"test": {"1.0.0"},
 	})
-	defer close()
 
 	streams, done := terminal.StreamsForTesting(t)
 	view := views.NewView(streams)
@@ -3095,10 +3075,9 @@ func TestTest_StatePropagation(t *testing.T) {
 
 	provider := testing_command.NewProvider(nil)
 
-	providerSource, close := newMockProviderSource(t, map[string][]string{
+	providerSource := newMockProviderSource(t, map[string][]string{
 		"test": {"1.0.0"},
 	})
-	defer close()
 
 	streams, done := terminal.StreamsForTesting(t)
 	view := views.NewView(streams)
@@ -3233,10 +3212,9 @@ func TestTest_SkipCleanup(t *testing.T) {
 	t.Chdir(td)
 
 	provider := testing_command.NewProvider(nil)
-	providerSource, close := newMockProviderSource(t, map[string][]string{
+	providerSource := newMockProviderSource(t, map[string][]string{
 		"test": {"1.0.0"},
 	})
-	defer close()
 
 	streams, done := terminal.StreamsForTesting(t)
 	view := views.NewView(streams)
@@ -3334,10 +3312,9 @@ func TestTest_SkipCleanupWithRunDependencies(t *testing.T) {
 	t.Chdir(td)
 
 	provider := testing_command.NewProvider(nil)
-	providerSource, close := newMockProviderSource(t, map[string][]string{
+	providerSource := newMockProviderSource(t, map[string][]string{
 		"test": {"1.0.0"},
 	})
-	defer close()
 
 	streams, done := terminal.StreamsForTesting(t)
 	view := views.NewView(streams)
@@ -3464,10 +3441,9 @@ func TestTest_SkipCleanup_JSON(t *testing.T) {
 	t.Chdir(td)
 
 	provider := testing_command.NewProvider(nil)
-	providerSource, close := newMockProviderSource(t, map[string][]string{
+	providerSource := newMockProviderSource(t, map[string][]string{
 		"test": {"1.0.0"},
 	})
-	defer close()
 
 	streams, done := terminal.StreamsForTesting(t)
 	view := views.NewView(streams)
@@ -3595,10 +3571,9 @@ func TestTest_SkipCleanup_FileLevelFlag(t *testing.T) {
 	t.Chdir(td)
 
 	provider := testing_command.NewProvider(nil)
-	providerSource, close := newMockProviderSource(t, map[string][]string{
+	providerSource := newMockProviderSource(t, map[string][]string{
 		"test": {"1.0.0"},
 	})
-	defer close()
 
 	streams, done := terminal.StreamsForTesting(t)
 	view := views.NewView(streams)
@@ -3723,10 +3698,9 @@ func TestTest_OnlyExternalModules(t *testing.T) {
 
 	provider := testing_command.NewProvider(nil)
 
-	providerSource, close := newMockProviderSource(t, map[string][]string{
+	providerSource := newMockProviderSource(t, map[string][]string{
 		"test": {"1.0.0"},
 	})
-	defer close()
 
 	streams, done := terminal.StreamsForTesting(t)
 	view := views.NewView(streams)
@@ -3858,10 +3832,9 @@ func TestTest_InvalidWarningsInCleanup(t *testing.T) {
 	t.Chdir(td)
 
 	provider := testing_command.NewProvider(nil)
-	providerSource, close := newMockProviderSource(t, map[string][]string{
+	providerSource := newMockProviderSource(t, map[string][]string{
 		"test": {"1.0.0"},
 	})
-	defer close()
 
 	streams, done := terminal.StreamsForTesting(t)
 	view := views.NewView(streams)
@@ -4447,10 +4420,9 @@ func TestTest_SensitiveInputValues(t *testing.T) {
 
 	provider := testing_command.NewProvider(nil)
 
-	providerSource, close := newMockProviderSource(t, map[string][]string{
+	providerSource := newMockProviderSource(t, map[string][]string{
 		"test": {"1.0.0"},
 	})
-	defer close()
 
 	streams, done := terminal.StreamsForTesting(t)
 	view := views.NewView(streams)
@@ -4722,10 +4694,9 @@ func TestTest_InvalidOverrides(t *testing.T) {
 
 	provider := testing_command.NewProvider(nil)
 
-	providerSource, close := newMockProviderSource(t, map[string][]string{
+	providerSource := newMockProviderSource(t, map[string][]string{
 		"test": {"1.0.0"},
 	})
-	defer close()
 
 	streams, done := terminal.StreamsForTesting(t)
 	view := views.NewView(streams)
@@ -4822,10 +4793,9 @@ func TestTest_InvalidConfig(t *testing.T) {
 
 	provider := testing_command.NewProvider(nil)
 
-	providerSource, close := newMockProviderSource(t, map[string][]string{
+	providerSource := newMockProviderSource(t, map[string][]string{
 		"test": {"1.0.0"},
 	})
-	defer close()
 
 	streams, done := terminal.StreamsForTesting(t)
 	view := views.NewView(streams)
@@ -4966,10 +4936,9 @@ There is no backend type named "foobar".
 
 			provider := testing_command.NewProvider(nil)
 
-			providerSource, close := newMockProviderSource(t, map[string][]string{
+			providerSource := newMockProviderSource(t, map[string][]string{
 				"test": {"1.0.0"},
 			})
-			defer close()
 
 			streams, done := terminal.StreamsForTesting(t)
 			view := views.NewView(streams)
@@ -5046,10 +5015,9 @@ test_resource_id = 12345`
 
 	provider := testing_command.NewProvider(nil)
 
-	providerSource, close := newMockProviderSource(t, map[string][]string{
+	providerSource := newMockProviderSource(t, map[string][]string{
 		"test": {"1.0.0"},
 	})
-	defer close()
 
 	streams, done := terminal.StreamsForTesting(t)
 	view := views.NewView(streams)
@@ -5154,10 +5122,9 @@ test_resource_id = %s`, resourceId, resourceId)
 	}
 	provider := testing_command.NewProvider(resourceStore)
 
-	providerSource, close := newMockProviderSource(t, map[string][]string{
+	providerSource := newMockProviderSource(t, map[string][]string{
 		"test": {"1.0.0"},
 	})
-	defer close()
 
 	streams, done := terminal.StreamsForTesting(t)
 	view := views.NewView(streams)
@@ -5274,10 +5241,9 @@ func TestTest_UseOfBackends_whenStateArtifactsAreMade(t *testing.T) {
 				provider.Provider.ApplyResourceChangeFn = newFunc
 			}
 
-			providerSource, close := newMockProviderSource(t, map[string][]string{
+			providerSource := newMockProviderSource(t, map[string][]string{
 				"test": {"1.0.0"},
 			})
-			defer close()
 
 			streams, done := terminal.StreamsForTesting(t)
 			view := views.NewView(streams)
@@ -5374,10 +5340,9 @@ func TestTest_UseOfBackends_validatesUseOfSkipCleanup(t *testing.T) {
 			t.Chdir(td)
 
 			provider := testing_command.NewProvider(nil)
-			providerSource, close := newMockProviderSource(t, map[string][]string{
+			providerSource := newMockProviderSource(t, map[string][]string{
 				"test": {"1.0.0"},
 			})
-			defer close()
 
 			streams, done := terminal.StreamsForTesting(t)
 			view := views.NewView(streams)
@@ -5435,10 +5400,9 @@ func TestTest_UseOfBackends_failureDuringApply(t *testing.T) {
 		return resp
 	}
 
-	providerSource, close := newMockProviderSource(t, map[string][]string{
+	providerSource := newMockProviderSource(t, map[string][]string{
 		"test": {"1.0.0"},
 	})
-	defer close()
 
 	streams, done := terminal.StreamsForTesting(t)
 	view := views.NewView(streams)
@@ -5518,10 +5482,9 @@ func TestTest_RunBlocksInProviders(t *testing.T) {
 
 	provider := testing_command.NewProvider(nil)
 
-	providerSource, close := newMockProviderSource(t, map[string][]string{
+	providerSource := newMockProviderSource(t, map[string][]string{
 		"test": {"1.0.0"},
 	})
-	defer close()
 
 	streams, done := terminal.StreamsForTesting(t)
 	view := views.NewView(streams)
@@ -5587,10 +5550,9 @@ func TestTest_RunBlocksInProviders_BadReferences(t *testing.T) {
 		Data: make(map[string]cty.Value),
 	}
 
-	providerSource, close := newMockProviderSource(t, map[string][]string{
+	providerSource := newMockProviderSource(t, map[string][]string{
 		"test": {"1.0.0"},
 	})
-	defer close()
 
 	streams, done := terminal.StreamsForTesting(t)
 	view := views.NewView(streams)
@@ -5753,10 +5715,9 @@ func TestTest_ReferencesIntoIncompletePlan(t *testing.T) {
 	t.Chdir(td)
 
 	provider := testing_command.NewProvider(nil)
-	providerSource, close := newMockProviderSource(t, map[string][]string{
+	providerSource := newMockProviderSource(t, map[string][]string{
 		"test": {"1.0.0"},
 	})
-	defer close()
 
 	streams, done := terminal.StreamsForTesting(t)
 	view := views.NewView(streams)
@@ -5823,10 +5784,9 @@ func TestTest_ReferencesIntoTargetedPlan(t *testing.T) {
 	t.Chdir(td)
 
 	provider := testing_command.NewProvider(nil)
-	providerSource, close := newMockProviderSource(t, map[string][]string{
+	providerSource := newMockProviderSource(t, map[string][]string{
 		"test": {"1.0.0"},
 	})
-	defer close()
 
 	streams, done := terminal.StreamsForTesting(t)
 	view := views.NewView(streams)
@@ -5878,10 +5838,9 @@ func TestTest_TeardownOrder(t *testing.T) {
 	t.Chdir(td)
 
 	provider := testing_command.NewProvider(nil)
-	providerSource, close := newMockProviderSource(t, map[string][]string{
+	providerSource := newMockProviderSource(t, map[string][]string{
 		"test": {"1.0.0"},
 	})
-	defer close()
 
 	streams, done := terminal.StreamsForTesting(t)
 	view := views.NewView(streams)

--- a/internal/command/validate_test.go
+++ b/internal/command/validate_test.go
@@ -265,10 +265,9 @@ func TestValidateWithInvalidTestModule(t *testing.T) {
 
 	provider := testing_command.NewProvider(nil)
 
-	providerSource, close := newMockProviderSource(t, map[string][]string{
+	providerSource := newMockProviderSource(t, map[string][]string{
 		"test": {"1.0.0"},
 	})
-	defer close()
 
 	meta := Meta{
 		testingOverrides: metaOverridesForProvider(provider.Provider),
@@ -452,10 +451,9 @@ func TestValidateWithInvalidOverrides(t *testing.T) {
 
 	provider := testing_command.NewProvider(nil)
 
-	providerSource, close := newMockProviderSource(t, map[string][]string{
+	providerSource := newMockProviderSource(t, map[string][]string{
 		"test": {"1.0.0"},
 	})
-	defer close()
 
 	meta := Meta{
 		testingOverrides: metaOverridesForProvider(provider.Provider),
@@ -656,10 +654,9 @@ The first step in the traversal for a list resource must be an attribute
 			ui := new(cli.MockUi)
 
 			provider := queryFixtureProvider()
-			providerSource, close := newMockProviderSource(t, map[string][]string{
+			providerSource := newMockProviderSource(t, map[string][]string{
 				"test": {"1.0.0"},
 			})
-			defer close()
 
 			meta := Meta{
 				testingOverrides: metaOverridesForProvider(provider),

--- a/internal/command/workspace_command_test.go
+++ b/internal/command/workspace_command_test.go
@@ -42,10 +42,9 @@ func TestWorkspace_allCommands_pluggableStateStore(t *testing.T) {
 	mock.MockStates = map[string]interface{}{preExistingState: true}
 
 	// Assumes the mocked provider is hashicorp/test
-	providerSource, close := newMockProviderSource(t, map[string][]string{
+	providerSource := newMockProviderSource(t, map[string][]string{
 		"hashicorp/test": {"1.2.3"},
 	})
-	defer close()
 
 	ui := new(cli.MockUi)
 	view, _ := testView(t)
@@ -210,10 +209,9 @@ func TestWorkspace_list_noReturnedWorkspaces(t *testing.T) {
 	mock := testStateStoreMockWithChunkNegotiation(t, 1000)
 
 	// Assumes the mocked provider is hashicorp/test
-	providerSource, close := newMockProviderSource(t, map[string][]string{
+	providerSource := newMockProviderSource(t, map[string][]string{
 		"hashicorp/test": {"1.2.3"},
 	})
-	defer close()
 
 	ui := new(cli.MockUi)
 	view, _ := testView(t)

--- a/internal/getproviders/mock_source.go
+++ b/internal/getproviders/mock_source.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"testing"
 
 	"github.com/hashicorp/terraform/internal/addrs"
 )
@@ -147,49 +148,14 @@ func FakePackageMeta(provider addrs.Provider, version Version, protocols Version
 // standard terraform-provider-NAME_X.Y.Z format, but can be overridden with
 // the execFilename argument.
 //
-// It's the caller's responsibility to call the close callback returned
-// alongside the result in order to clean up the temporary file. The caller
-// should call the callback even if this function returns an error, because
-// some error conditions leave a partially-created file on disk.
-func FakeInstallablePackageMeta(provider addrs.Provider, version Version, protocols VersionList, target Platform, execFilename string) (PackageMeta, func(), error) {
-	f, err := os.CreateTemp("", "terraform-getproviders-fake-package-")
+// Cleanup functions are handled internally using t.Cleanup.
+func FakeInstallablePackageMeta(t *testing.T, provider addrs.Provider, version Version, protocols VersionList, target Platform, execFilename string) (PackageMeta, error) {
+	t.Helper()
+
+	f, checksum, err := CreateFakeFileWithChecksumForProvider(t, provider, version, target, execFilename)
 	if err != nil {
-		return PackageMeta{}, func() {}, err
+		return PackageMeta{}, err
 	}
-
-	// After this point, all of our return paths should include this as the
-	// close callback.
-	close := func() {
-		f.Close()
-		os.Remove(f.Name())
-	}
-
-	if execFilename == "" {
-		execFilename = fmt.Sprintf("terraform-provider-%s_%s", provider.Type, version.String())
-		if target.OS == "windows" {
-			// For a little more (technically unnecessary) realism...
-			execFilename += ".exe"
-		}
-	}
-
-	zw := zip.NewWriter(f)
-	fw, err := zw.Create(execFilename)
-	if err != nil {
-		return PackageMeta{}, close, fmt.Errorf("failed to add %s to mock zip file: %s", execFilename, err)
-	}
-	fmt.Fprintf(fw, "This is a fake provider package for %s %s, not a real provider.\n", provider, version)
-	err = zw.Close()
-	if err != nil {
-		return PackageMeta{}, close, fmt.Errorf("failed to close the mock zip file: %s", err)
-	}
-
-	// Compute the SHA256 checksum of the generated file, to allow package
-	// authentication code to be exercised.
-	f.Seek(0, io.SeekStart)
-	h := sha256.New()
-	io.Copy(h, f)
-	checksum := [32]byte{}
-	h.Sum(checksum[:0])
 
 	meta := PackageMeta{
 		Provider:         provider,
@@ -208,7 +174,7 @@ func FakeInstallablePackageMeta(provider addrs.Provider, version Version, protoc
 
 		Authentication: NewArchiveChecksumAuthentication(target, checksum),
 	}
-	return meta, close, nil
+	return meta, nil
 }
 
 // This is basically the same as FakePackageMeta, except that we'll use a PackageHTTPURL instead of a PackageLocalArchive when creating metadata for the provider.
@@ -216,45 +182,11 @@ func FakeInstallablePackageMeta(provider addrs.Provider, version Version, protoc
 //
 // The caller is responsible for calling the close callback to clean up the temporary file.
 // The temporary file is only used to calculate checksums and isn't actually used to install the provider in the test.
-func FakePackageMetaViaHTTP(provider addrs.Provider, version Version, protocols VersionList, target Platform, locationBaseUrl string, execFilename string) (PackageMeta, func(), error) {
-	f, err := os.CreateTemp("", "terraform-getproviders-fake-package-")
+func FakePackageMetaViaHTTP(t *testing.T, provider addrs.Provider, version Version, protocols VersionList, target Platform, locationBaseUrl string) (PackageMeta, error) {
+	f, checksum, err := CreateFakeFileWithChecksumForProvider(t, provider, version, target, "")
 	if err != nil {
-		return PackageMeta{}, func() {}, err
+		return PackageMeta{}, err
 	}
-
-	// After this point, all of our return paths should include this as the
-	// close callback.
-	close := func() {
-		f.Close()
-		os.Remove(f.Name())
-	}
-
-	if execFilename == "" {
-		execFilename = fmt.Sprintf("terraform-provider-%s_%s", provider.Type, version.String())
-		if target.OS == "windows" {
-			// For a little more (technically unnecessary) realism...
-			execFilename += ".exe"
-		}
-	}
-
-	zw := zip.NewWriter(f)
-	fw, err := zw.Create(execFilename)
-	if err != nil {
-		return PackageMeta{}, close, fmt.Errorf("failed to add %s to mock zip file: %s", execFilename, err)
-	}
-	fmt.Fprintf(fw, "This is a fake provider package for %s %s, not a real provider.\n", provider, version)
-	err = zw.Close()
-	if err != nil {
-		return PackageMeta{}, close, fmt.Errorf("failed to close the mock zip file: %s", err)
-	}
-
-	// Compute the SHA256 checksum of the generated file, to allow package
-	// authentication code to be exercised.
-	f.Seek(0, io.SeekStart)
-	h := sha256.New()
-	io.Copy(h, f)
-	checksum := [32]byte{}
-	h.Sum(checksum[:0])
 
 	meta := PackageMeta{
 		Provider:         provider,
@@ -281,7 +213,62 @@ func FakePackageMetaViaHTTP(provider addrs.Provider, version Version, protocols 
 
 		Authentication: NewArchiveChecksumAuthentication(target, checksum),
 	}
-	return meta, close, nil
+	return meta, nil
+}
+
+// CreateFakeFileWithChecksumForProvider creates a temporary zip file containing a fake provider executable for a given combo of:
+//   - provider address
+//   - version
+//   - target platform
+//
+// The function returns an os.File pointing to the temp file and a checksum of its contents. These are intended to be used to
+// create mock provider sources.
+//
+// Cleanup functions (closing the file and deleting it) are handled internally using t.Cleanup.
+func CreateFakeFileWithChecksumForProvider(t *testing.T, provider addrs.Provider, version Version, target Platform, execFilename string) (*os.File, [32]byte, error) {
+	t.Helper()
+
+	f, err := os.CreateTemp("", "terraform-getproviders-fake-package-")
+	if err != nil {
+		return nil, [32]byte{}, err
+	}
+
+	// Handle cleanup of the temporary file using t.Cleanup.
+	close := func() {
+		f.Close()
+		os.Remove(f.Name())
+	}
+	t.Cleanup(close)
+
+	if execFilename == "" {
+		execFilename = fmt.Sprintf("terraform-provider-%s_%s", provider.Type, version.String())
+		if target.OS == "windows" {
+			// For a little more (technically unnecessary) realism...
+			execFilename += ".exe"
+		}
+	}
+
+	// Create mock zip file
+	zw := zip.NewWriter(f)
+	fw, err := zw.Create(execFilename)
+	if err != nil {
+		return nil, [32]byte{}, fmt.Errorf("failed to add %s to mock zip file: %s", execFilename, err)
+	}
+	fmt.Fprintf(fw, "This is a fake provider package for %s %s, not a real provider.\n", provider, version)
+	err = zw.Close()
+	if err != nil {
+		return nil, [32]byte{}, fmt.Errorf("failed to close the mock zip file: %s", err)
+	}
+
+	// Compute the SHA256 checksum of the generated file, to allow package
+	// authentication code to be exercised.
+	f.Seek(0, io.SeekStart)
+	h := sha256.New()
+	io.Copy(h, f)
+	checksum := [32]byte{}
+	h.Sum(checksum[:0])
+
+	return f, checksum, nil
 }
 
 func (s *MockSource) ForDisplay(provider addrs.Provider) string {


### PR DESCRIPTION
For a separate PR [I've been working on implementing a test helper that returns an http server that acts as a network mirror](https://github.com/hashicorp/terraform/pull/38395#discussion_r3139487296). For that to work the server needs to be able to serve data from files that 'look like' provider archives and have associated checksums.

That logic already exists but it was inside of `getproviders.FakeInstallablePackageMeta`. That function both created temporary files and returned `PackageMeta` data. I've split the file creation out into a new `CreateFakeFileWithChecksumForProvider` function that in future I will reuse when implementing the mock network mirror.

During this refactoring I realised that there a lot of callbacks returned to calling code for cleanup. I've updated existing helpers and made the new helper use the passed in testing.T argument to handle cleanup internally via `t.Cleanup`. I don't believe there's a special reason why this isn't already used in provider source-related helpers; when these helpers were originally added in March 2020 (https://github.com/hashicorp/terraform/pull/24477) the t.Cleanup function had only just been introduced to Go [the month before](https://go.dev/doc/go1.14#testingpkgtesting) and I imagine hadn't been adopted in the codebase yet.

**Note to reviewer:**

Please go commit-by-commit to understand the diffs! I've split things up.

That final commit dramatically increased the footprint of this PR 😅  - we could avoid this by reverting the last commit and using the approach in https://github.com/hashicorp/terraform/pull/38446/commits/5c6fe51c674538c4c24e73e0932c3c63cb74fbd6 , returning a no-op callback and leaving calling code unchanged. If we chose that approach we'd need to avoid copy-paste of existing tests and instead have new tests ignore the returned no-op callback. In my opinion it's better to rip the bandaid off now.

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.16.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
