### PR TITLE
Show info when resources are left due to skip cleanup

### DIFF
--- a/.changes/v1.16/ENHANCEMENTS-20260427-112604.yaml
+++ b/.changes/v1.16/ENHANCEMENTS-20260427-112604.yaml
@@ -1,0 +1,5 @@
+kind: ENHANCEMENTS
+body: Show info when resources are left behind due to skip_cleanup
+time: 2026-04-27T11:26:04.782451-04:00
+custom:
+    Issue: "38449"

--- a/internal/command/test_test.go
+++ b/internal/command/test_test.go
@@ -813,6 +813,10 @@ func TestTest_Cleanup(t *testing.T) {
   run "test_three"... pass
   run "test_four"... pass
 main.tftest.hcl... tearing down
+
+Terraform left the following resources in state after executing
+main.tftest.hcl/test_two because the skip_cleanup attribute was set:
+  - test_resource.resource
 main.tftest.hcl... fail
 
 Failure! 4 passed, 0 failed.
@@ -948,6 +952,10 @@ Success!
 
 		expectedCleanup := `main.tftest.hcl... in progress
 main.tftest.hcl... tearing down
+
+Terraform left the following resources in state after executing
+main.tftest.hcl/test_two because the skip_cleanup attribute was set:
+  - test_resource.resource
 main.tftest.hcl... pass
 
 Success!
@@ -3273,9 +3281,10 @@ main.tftest.hcl... in progress
   run "test_four"... pass
   run "test_five"... pass
 main.tftest.hcl... tearing down
+
 Terraform left the following resources in state after executing
 main.tftest.hcl/test_three because the skip_cleanup attribute was set:
-	- test_resource.resource
+  - test_resource.resource
 main.tftest.hcl... pass
 
 Success! 5 passed, 0 failed.
@@ -3365,6 +3374,10 @@ func TestTest_SkipCleanupWithRunDependencies(t *testing.T) {
   run "test_two"... pass
   run "test_three"... pass
 main.tftest.hcl... tearing down
+
+Terraform left the following resources in state after executing
+main.tftest.hcl/test_two because the skip_cleanup attribute was set:
+  - test_resource.resource
 main.tftest.hcl... pass
 
 Success! 3 passed, 0 failed.
@@ -3546,7 +3559,7 @@ func TestTest_SkipCleanup_JSON(t *testing.T) {
 			`{"@level":"info","@message":"  \"test_five\"... pass","@module":"terraform.ui","@testfile":"main.tftest.hcl","@testrun":"test_five","test_run":{"path":"main.tftest.hcl","progress":"complete","run":"test_five","status":"pass"},"type":"test_run"}`,
 			`{"@level":"info","@message":"main.tftest.hcl... tearing down","@module":"terraform.ui","@testfile":"main.tftest.hcl","test_file":{"path":"main.tftest.hcl","progress":"teardown"},"type":"test_file"}`,
 			`{"@level":"info","@message":"  \"test_three\"... tearing down","@module":"terraform.ui","@testfile":"main.tftest.hcl","@testrun":"test_three","test_run":{"path":"main.tftest.hcl","progress":"teardown","run":"test_three"},"type":"test_run"}`,
-				`{"@level":"info","@message":"Terraform left some resources in state after executing main.tftest.hcl/test_three because the skip_cleanup attribute was set.","@module":"terraform.ui","@testfile":"main.tftest.hcl","@testrun":"test_three","test_cleanup_skipped":{"resources":[{"instance":"test_resource.resource"}]},"type":"test_cleanup_skipped"}`,
+			`{"@level":"info","@message":"Terraform left some resources in state after executing main.tftest.hcl/test_three because the skip_cleanup attribute was set.","@module":"terraform.ui","@testfile":"main.tftest.hcl","@testrun":"test_three","test_cleanup":{"skipped_resources":[{"instance":"test_resource.resource"}]},"type":"test_cleanup"}`,
 			`{"@level":"info","@message":"main.tftest.hcl... pass","@module":"terraform.ui","@testfile":"main.tftest.hcl","test_file":{"path":"main.tftest.hcl","progress":"complete","status":"pass"},"type":"test_file"}`,
 			`{"@level":"info","@message":"Success! 5 passed, 0 failed.","@module":"terraform.ui","test_summary":{"errored":0,"failed":0,"passed":5,"skipped":0,"status":"pass"},"type":"test_summary"}`,
 		}
@@ -3627,6 +3640,10 @@ func TestTest_SkipCleanup_FileLevelFlag(t *testing.T) {
   run "test_four"... pass
   run "test_five"... pass
 main.tftest.hcl... tearing down
+
+Terraform left the following resources in state after executing
+main.tftest.hcl/test_four because the skip_cleanup attribute was set:
+  - test_resource.resource
 main.tftest.hcl... pass
 
 Success! 5 passed, 0 failed.

--- a/internal/command/test_test.go
+++ b/internal/command/test_test.go
@@ -3273,6 +3273,9 @@ main.tftest.hcl... in progress
   run "test_four"... pass
   run "test_five"... pass
 main.tftest.hcl... tearing down
+Terraform left the following resources in state after executing
+main.tftest.hcl/test_three because the skip_cleanup attribute was set:
+	- test_resource.resource
 main.tftest.hcl... pass
 
 Success! 5 passed, 0 failed.
@@ -3543,6 +3546,7 @@ func TestTest_SkipCleanup_JSON(t *testing.T) {
 			`{"@level":"info","@message":"  \"test_five\"... pass","@module":"terraform.ui","@testfile":"main.tftest.hcl","@testrun":"test_five","test_run":{"path":"main.tftest.hcl","progress":"complete","run":"test_five","status":"pass"},"type":"test_run"}`,
 			`{"@level":"info","@message":"main.tftest.hcl... tearing down","@module":"terraform.ui","@testfile":"main.tftest.hcl","test_file":{"path":"main.tftest.hcl","progress":"teardown"},"type":"test_file"}`,
 			`{"@level":"info","@message":"  \"test_three\"... tearing down","@module":"terraform.ui","@testfile":"main.tftest.hcl","@testrun":"test_three","test_run":{"path":"main.tftest.hcl","progress":"teardown","run":"test_three"},"type":"test_run"}`,
+				`{"@level":"info","@message":"Terraform left some resources in state after executing main.tftest.hcl/test_three because the skip_cleanup attribute was set.","@module":"terraform.ui","@testfile":"main.tftest.hcl","@testrun":"test_three","test_cleanup_skipped":{"resources":[{"instance":"test_resource.resource"}]},"type":"test_cleanup_skipped"}`,
 			`{"@level":"info","@message":"main.tftest.hcl... pass","@module":"terraform.ui","@testfile":"main.tftest.hcl","test_file":{"path":"main.tftest.hcl","progress":"complete","status":"pass"},"type":"test_file"}`,
 			`{"@level":"info","@message":"Success! 5 passed, 0 failed.","@module":"terraform.ui","test_summary":{"errored":0,"failed":0,"passed":5,"skipped":0,"status":"pass"},"type":"test_summary"}`,
 		}

--- a/internal/command/views/json/test.go
+++ b/internal/command/views/json/test.go
@@ -41,6 +41,10 @@ type TestFileCleanup struct {
 	FailedResources []TestFailedResource `json:"failed_resources"`
 }
 
+type TestFileCleanupSkipped struct {
+	SkippedResources []TestFailedResource `json:"skipped_resources"`
+}
+
 type TestFailedResource struct {
 	Instance   string `json:"instance"`
 	DeposedKey string `json:"deposed_key,omitempty"`

--- a/internal/command/views/test.go
+++ b/internal/command/views/test.go
@@ -281,16 +281,27 @@ func (t *TestHuman) DestroySummary(diags tfdiags.Diagnostics, run *moduletest.Ru
 	t.Diagnostics(run, file, diags)
 
 	skipCleanup := run != nil && run.Config.SkipCleanup
-	if state.HasManagedResourceInstanceObjects() && !skipCleanup {
-		// FIXME: This message says "resources" but this is actually a list
-		// of resource instance objects.
-		t.view.streams.Eprint(format.WordWrap(fmt.Sprintf("\nTerraform left the following resources in state after executing %s, and they need to be cleaned up manually:\n", identifier), t.view.errorColumns()))
-		for _, resource := range addrs.SetSortedNatural(state.AllManagedResourceInstanceObjectAddrs()) {
-			if resource.DeposedKey != states.NotDeposed {
-				t.view.streams.Eprintf("  - %s (%s)\n", resource.ResourceInstance, resource.DeposedKey)
-				continue
+	if state.HasManagedResourceInstanceObjects() {
+		if skipCleanup {
+			t.view.streams.Print(format.WordWrap(fmt.Sprintf("\nTerraform left the following resources in state after executing %s because the skip_cleanup attribute was set:\n", identifier), t.view.outputColumns()))
+			for _, resource := range addrs.SetSortedNatural(state.AllManagedResourceInstanceObjectAddrs()) {
+				if resource.DeposedKey != states.NotDeposed {
+					t.view.streams.Printf("  - %s (%s)\n", resource.ResourceInstance, resource.DeposedKey)
+					continue
+				}
+				t.view.streams.Printf("  - %s\n", resource.ResourceInstance)
 			}
-			t.view.streams.Eprintf("  - %s\n", resource.ResourceInstance)
+		} else {
+			// FIXME: This message says "resources" but this is actually a list
+			// of resource instance objects.
+			t.view.streams.Eprint(format.WordWrap(fmt.Sprintf("\nTerraform left the following resources in state after executing %s, and they need to be cleaned up manually:\n", identifier), t.view.errorColumns()))
+			for _, resource := range addrs.SetSortedNatural(state.AllManagedResourceInstanceObjectAddrs()) {
+				if resource.DeposedKey != states.NotDeposed {
+					t.view.streams.Eprintf("  - %s (%s)\n", resource.ResourceInstance, resource.DeposedKey)
+					continue
+				}
+				t.view.streams.Eprintf("  - %s\n", resource.ResourceInstance)
+			}
 		}
 	}
 }
@@ -612,30 +623,54 @@ func (t *TestJSON) Run(run *moduletest.Run, file *moduletest.File, progress modu
 
 func (t *TestJSON) DestroySummary(diags tfdiags.Diagnostics, run *moduletest.Run, file *moduletest.File, state *states.State) {
 	skipCleanup := run != nil && run.Config.SkipCleanup
-	if state.HasManagedResourceInstanceObjects() && !skipCleanup {
-		cleanup := json.TestFileCleanup{}
-		for _, resource := range addrs.SetSortedNatural(state.AllManagedResourceInstanceObjectAddrs()) {
-			cleanup.FailedResources = append(cleanup.FailedResources, json.TestFailedResource{
-				Instance:   resource.ResourceInstance.String(),
-				DeposedKey: resource.DeposedKey.String(),
-			})
-		}
+	if state.HasManagedResourceInstanceObjects() {
+		if skipCleanup {
+			cleanup := json.TestFileCleanupSkipped{}
+			for _, resource := range addrs.SetSortedNatural(state.AllManagedResourceInstanceObjectAddrs()) {
+				cleanup.SkippedResources = append(cleanup.SkippedResources, json.TestFailedResource{
+					Instance:   resource.ResourceInstance.String(),
+					DeposedKey: resource.DeposedKey.String(),
+				})
+			}
 
-		if run != nil {
-			t.view.log.Error(
-				fmt.Sprintf("Terraform left some resources in state after executing %s/%s, they need to be cleaned up manually.", file.Name, run.Name),
-				"type", json.MessageTestCleanup,
-				json.MessageTestCleanup, cleanup,
-				"@testfile", file.Name,
-				"@testrun", run.Name)
+			if run != nil {
+				t.view.log.Info(
+					fmt.Sprintf("Terraform left some resources in state after executing %s/%s because the skip_cleanup attribute was set.", file.Name, run.Name),
+					"type", json.MessageTestCleanup,
+					json.MessageTestCleanup, cleanup,
+					"@testfile", file.Name,
+					"@testrun", run.Name)
+			} else {
+				t.view.log.Info(
+					fmt.Sprintf("Terraform left some resources in state after executing %s because the skip_cleanup attribute was set.", file.Name),
+					"type", json.MessageTestCleanup,
+					json.MessageTestCleanup, cleanup,
+					"@testfile", file.Name)
+			}
 		} else {
-			t.view.log.Error(
-				fmt.Sprintf("Terraform left some resources in state after executing %s, they need to be cleaned up manually.", file.Name),
-				"type", json.MessageTestCleanup,
-				json.MessageTestCleanup, cleanup,
-				"@testfile", file.Name)
-		}
+			cleanup := json.TestFileCleanup{}
+			for _, resource := range addrs.SetSortedNatural(state.AllManagedResourceInstanceObjectAddrs()) {
+				cleanup.FailedResources = append(cleanup.FailedResources, json.TestFailedResource{
+					Instance:   resource.ResourceInstance.String(),
+					DeposedKey: resource.DeposedKey.String(),
+				})
+			}
 
+			if run != nil {
+				t.view.log.Error(
+					fmt.Sprintf("Terraform left some resources in state after executing %s/%s, they need to be cleaned up manually.", file.Name, run.Name),
+					"type", json.MessageTestCleanup,
+					json.MessageTestCleanup, cleanup,
+					"@testfile", file.Name,
+					"@testrun", run.Name)
+			} else {
+				t.view.log.Error(
+					fmt.Sprintf("Terraform left some resources in state after executing %s, they need to be cleaned up manually.", file.Name),
+					"type", json.MessageTestCleanup,
+					json.MessageTestCleanup, cleanup,
+					"@testfile", file.Name)
+			}
+		}
 	}
 
 	t.Diagnostics(run, file, diags)

--- a/internal/command/views/test_test.go
+++ b/internal/command/views/test_test.go
@@ -833,6 +833,30 @@ Error: first error
 this time it is very bad
 `,
 		},
+		"state_with_skip_cleanup": {
+			run:  &moduletest.Run{Name: "run_block", Config: &configs.TestRun{SkipCleanup: true}},
+			file: &moduletest.File{Name: "main.tftest.hcl"},
+			state: states.BuildState(func(state *states.SyncState) {
+				state.SetResourceInstanceCurrent(
+					addrs.Resource{
+						Mode: addrs.ManagedResourceMode,
+						Type: "test",
+						Name: "foo",
+					}.Instance(addrs.NoKey).Absolute(addrs.RootModuleInstance),
+					&states.ResourceInstanceObjectSrc{
+						Status: states.ObjectReady,
+					},
+					addrs.AbsProviderConfig{
+						Module:   addrs.RootModule,
+						Provider: addrs.NewDefaultProvider("test"),
+					})
+			}),
+			stdout: `
+Terraform left the following resources in state after executing
+main.tftest.hcl/run_block because the skip_cleanup attribute was set:
+  - test.foo
+`,
+		},
 		"state_only_warnings": {
 			diags: tfdiags.Diagnostics{
 				tfdiags.Sourceless(tfdiags.Warning, "first warning", "some thing not very bad happened"),
@@ -1979,6 +2003,42 @@ func TestTestJSON_DestroySummary(t *testing.T) {
 						},
 					},
 					"type": "test_cleanup",
+				},
+			},
+		},
+		"state_from_run_skip_cleanup": {
+			file: &moduletest.File{Name: "main.tftest.hcl"},
+			run:  &moduletest.Run{Name: "run_block", Config: &configs.TestRun{SkipCleanup: true}},
+			state: states.BuildState(func(state *states.SyncState) {
+				state.SetResourceInstanceCurrent(
+					addrs.Resource{
+						Mode: addrs.ManagedResourceMode,
+						Type: "test",
+						Name: "foo",
+					}.Instance(addrs.NoKey).Absolute(addrs.RootModuleInstance),
+					&states.ResourceInstanceObjectSrc{
+						Status: states.ObjectReady,
+					},
+					addrs.AbsProviderConfig{
+						Module:   addrs.RootModule,
+						Provider: addrs.NewDefaultProvider("test"),
+					})
+			}),
+			want: []map[string]interface{}{
+				{
+					"@level":    "info",
+					"@message":  "Terraform left some resources in state after executing main.tftest.hcl/run_block because the skip_cleanup attribute was set.",
+					"@module":   "terraform.ui",
+					"@testfile": "main.tftest.hcl",
+					"@testrun":  "run_block",
+					"test_cleanup_skipped": map[string]interface{}{
+						"resources": []interface{}{
+							map[string]interface{}{
+								"instance": "test.foo",
+							},
+						},
+					},
+					"type": "test_cleanup_skipped",
 				},
 			},
 		},

--- a/internal/command/views/test_test.go
+++ b/internal/command/views/test_test.go
@@ -2031,14 +2031,14 @@ func TestTestJSON_DestroySummary(t *testing.T) {
 					"@module":   "terraform.ui",
 					"@testfile": "main.tftest.hcl",
 					"@testrun":  "run_block",
-					"test_cleanup_skipped": map[string]interface{}{
-						"resources": []interface{}{
+					"test_cleanup": map[string]interface{}{
+						"skipped_resources": []interface{}{
 							map[string]interface{}{
 								"instance": "test.foo",
 							},
 						},
 					},
-					"type": "test_cleanup_skipped",
+					"type": "test_cleanup",
 				},
 			},
 		},


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Fixes #
When resources are left behind due to skip_cleanup attribute, terraform now logs an info message.

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.16.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [x] This change is user-facing and I added a changelog entry.
- [ ] This change is not user-facing.
