### PR TITLE
Limit backend block validation in the `validate` command to just backend type

### DIFF
--- a/.changes/v1.15/BUG FIXES-20260429-164013.yaml
+++ b/.changes/v1.15/BUG FIXES-20260429-164013.yaml
@@ -1,0 +1,5 @@
+kind: BUG FIXES
+body: 'validate: Removed validation of attributes inside `backend` blocks due to incompatibility with workflows using the `-backend-config` flag.'
+time: 2026-04-29T16:40:13.802731+01:00
+custom:
+    Issue: "38466"

--- a/internal/command/testdata/invalid-backend-configuration/removed-backend-type/main.tf
+++ b/internal/command/testdata/invalid-backend-configuration/removed-backend-type/main.tf
@@ -1,0 +1,3 @@
+terraform {
+  backend "artifactory" {}
+}

--- a/internal/command/validate.go
+++ b/internal/command/validate.go
@@ -5,21 +5,15 @@ package command
 
 import (
 	"fmt"
-	"maps"
 	"path/filepath"
-	"slices"
 	"strings"
 
 	"github.com/hashicorp/hcl/v2"
-	"github.com/hashicorp/hcl/v2/hcldec"
 	"github.com/hashicorp/terraform/internal/addrs"
 	backendInit "github.com/hashicorp/terraform/internal/backend/init"
-	backendPluggable "github.com/hashicorp/terraform/internal/backend/pluggable"
 	"github.com/hashicorp/terraform/internal/command/arguments"
 	"github.com/hashicorp/terraform/internal/command/views"
 	"github.com/hashicorp/terraform/internal/configs"
-	"github.com/hashicorp/terraform/internal/didyoumean"
-	"github.com/hashicorp/terraform/internal/providers"
 	"github.com/hashicorp/terraform/internal/terraform"
 	"github.com/hashicorp/terraform/internal/tfdiags"
 )
@@ -120,11 +114,8 @@ func (c *ValidateCommand) validate(dir string) tfdiags.Diagnostics {
 
 	// Validation of backend block, if present
 	// Backend blocks live outside the Terraform graph so we have to do this separately.
-	switch {
-	case cfg.Module.Backend != nil:
-		diags = diags.Append(c.validateBackend(cfg.Module.Backend))
-	case cfg.Module.StateStore != nil:
-		diags = diags.Append(c.validateStateStore(cfg.Module.StateStore))
+	if cfg.Module.Backend != nil {
+		diags = diags.Append(c.validateBackendTypeSupported(cfg.Module.Backend))
 	}
 
 	// Unless excluded, we'll also do a quick validation of the Terraform test files. These live
@@ -193,11 +184,10 @@ func (c *ValidateCommand) validateTestFiles(cfg *configs.Config) tfdiags.Diagnos
 	return diags
 }
 
-// We validate the backend in an offline manner, so we use PrepareConfig to validate the configuration (and ENVs present),
-// but we never use the Configure method, as that will interact with third-party systems.
-//
-// The code in this method is very similar to the `backendInitFromConfig` method, expect it doesn't configure the backend.
-func (c *ValidateCommand) validateBackend(cfg *configs.Backend) tfdiags.Diagnostics {
+// Validate that the config includes a backend type that exists in the current binary.
+// A name could be mistyped or the config could be using an old backend type that's been
+// removed from the version of Terraform in use.
+func (c *ValidateCommand) validateBackendTypeSupported(cfg *configs.Backend) tfdiags.Diagnostics {
 	var diags tfdiags.Diagnostics
 
 	bf := backendInit.Backend(cfg.Type)
@@ -216,130 +206,6 @@ func (c *ValidateCommand) validateBackend(cfg *configs.Backend) tfdiags.Diagnost
 		return diags
 	}
 
-	b := bf()
-	backendSchema := b.ConfigSchema()
-
-	decSpec := backendSchema.DecoderSpec()
-	configVal, hclDiags := hcldec.Decode(cfg.Config, decSpec, nil)
-	diags = diags.Append(hclDiags)
-	if hclDiags.HasErrors() {
-		return diags
-	}
-
-	_, validateDiags := b.PrepareConfig(configVal)
-	diags = diags.Append(validateDiags)
-	if validateDiags.HasErrors() {
-		return diags
-	}
-
-	return diags
-}
-
-// We validate the state store in an offline manner, so we use:
-// - State store's PrepareConfig method to validate the state_store block.
-// - Provider's ValidateProviderConfig to validate the nested provider block.
-// We don't use the Configure method, as that will interact with third-party systems.
-//
-// The code in this method is very similar to the `stateStoreInitFromConfig` method,
-// expect it doesn't configure the provider or the state store.
-func (c *ValidateCommand) validateStateStore(cfg *configs.StateStore) tfdiags.Diagnostics {
-	var diags tfdiags.Diagnostics
-
-	locks, depsDiags := c.Meta.lockedDependencies()
-	if depsDiags.HasErrors() {
-		// Add some context to the error so it's obvious that it's related to the state store.
-		newDiag := &hcl.Diagnostic{
-			Severity: hcl.DiagError,
-			Summary:  "Unable to validate state store configuration",
-			Detail:   fmt.Sprintf("An unexpected error was encountered when loading the dependency locks file. Make sure the working directory has been initialized and try again. Error: %s", diags.Err()),
-			Subject:  &cfg.DeclRange,
-		}
-		return diags.Append(newDiag)
-	}
-	diags = diags.Append(depsDiags) // Preserve any warnings
-
-	factory, pDiags := c.Meta.StateStoreProviderFactoryFromConfig(cfg, locks)
-	diags = diags.Append(pDiags)
-	if pDiags.HasErrors() {
-		return diags
-	}
-
-	provider, err := factory()
-	if err != nil {
-		diags = diags.Append(fmt.Errorf("Unable to validate state store configuration. Terraform was unable to obtain a provider instance during state store initialization: %w", err))
-		return diags
-	}
-	defer provider.Close()
-
-	resp := provider.GetProviderSchema()
-
-	if len(resp.StateStores) == 0 {
-		diags = diags.Append(&hcl.Diagnostic{
-			Severity: hcl.DiagError,
-			Summary:  "Provider does not support pluggable state storage",
-			Detail: fmt.Sprintf("There are no state stores implemented by provider %s (%q)",
-				cfg.Provider.Name,
-				cfg.ProviderAddr),
-			Subject: &cfg.DeclRange,
-		})
-		return diags
-	}
-
-	schema, exists := resp.StateStores[cfg.Type]
-	if !exists {
-		suggestions := slices.Sorted(maps.Keys(resp.StateStores))
-		suggestion := didyoumean.NameSuggestion(cfg.Type, suggestions)
-		if suggestion != "" {
-			suggestion = fmt.Sprintf(" Did you mean %q?", suggestion)
-		}
-		diags = diags.Append(&hcl.Diagnostic{
-			Severity: hcl.DiagError,
-			Summary:  "State store not implemented by the provider",
-			Detail: fmt.Sprintf("State store %q is not implemented by provider %s (%q)%s",
-				cfg.Type, cfg.Provider.Name,
-				cfg.ProviderAddr, suggestion),
-			Subject: &cfg.DeclRange,
-		})
-		return diags
-	}
-
-	// Handle the nested provider block.
-	pDecSpec := resp.Provider.Body.DecoderSpec()
-	pConfig := cfg.Provider.Config
-	providerConfigVal, pDecDiags := hcldec.Decode(pConfig, pDecSpec, nil)
-	diags = diags.Append(pDecDiags)
-	if pDecDiags.HasErrors() {
-		return diags
-	}
-
-	// Handle the schema for the state store itself, excluding the provider block.
-	ssdecSpec := schema.Body.DecoderSpec()
-	stateStoreConfigVal, ssDecDiags := hcldec.Decode(cfg.Config, ssdecSpec, nil)
-	diags = diags.Append(ssDecDiags)
-	if ssDecDiags.HasErrors() {
-		return diags
-	}
-
-	// Validate the provider config
-	//
-	// NOTE: We don't configure the provider because the validate command is offline-only.
-	validateResp := provider.ValidateProviderConfig(providers.ValidateProviderConfigRequest{
-		Config: providerConfigVal,
-	})
-	diags = diags.Append(validateResp.Diagnostics)
-	if validateResp.Diagnostics.HasErrors() {
-		return diags
-	}
-
-	// Validate the state store config
-	//
-	// NOTE: We don't configure the state store because the validate command is offline-only.
-	p, err := backendPluggable.NewPluggable(provider, cfg.Type)
-	if err != nil {
-		diags = diags.Append(err)
-	}
-	_, validateDiags := p.PrepareConfig(stateStoreConfigVal)
-	diags = diags.Append(validateDiags)
 	return diags
 }
 

--- a/internal/command/validate_test.go
+++ b/internal/command/validate_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/hashicorp/terraform/internal/configs/configschema"
 	"github.com/hashicorp/terraform/internal/providers"
 	"github.com/hashicorp/terraform/internal/terminal"
-	"github.com/hashicorp/terraform/internal/tfdiags"
 )
 
 func setupTest(t *testing.T, fixturepath string, args ...string) (*terminal.TestOutput, int) {
@@ -697,6 +696,8 @@ The first step in the traversal for a list resource must be an attribute
 }
 
 func TestValidate_backendBlocks(t *testing.T) {
+	// This type of error is detected when parsing hcl, and isn't validation
+	// specific to backend blocks.
 	t.Run("invalid when block contains a repeated attribute", func(t *testing.T) {
 		output, code := setupTest(t, "invalid-backend-configuration/repeated-attr")
 		if code != 1 {
@@ -725,333 +726,32 @@ func TestValidate_backendBlocks(t *testing.T) {
 		}
 	})
 
-	t.Run("invalid when there's an unknown attribute present", func(t *testing.T) {
+	// We don't validate using the backend's schema due to potential use of the -backend-config flag.
+	t.Run("unknown attributes are not detected by validate command", func(t *testing.T) {
 		output, code := setupTest(t, "invalid-backend-configuration/unknown-attr")
-		if code != 1 {
-			t.Fatalf("expected an unsuccessful exit code %d\n\n%s", code, output.Stdout())
+		if code != 0 {
+			t.Fatalf("expected a successful exit code %d\n\n%s", code, output.Stderr())
 		}
-		expectedErr := "Error: Unsupported argument"
-		if !strings.Contains(output.Stderr(), expectedErr) {
+		expected := "Success! The configuration is valid."
+		if !strings.Contains(output.Stdout(), expected) {
 			t.Fatalf("unexpected error content: wanted %q, got: %s",
-				expectedErr,
-				output.Stderr(),
+				expected,
+				output.Stdout(),
 			)
 		}
 	})
 
-	t.Run("invalid when a required attribute is unset", func(t *testing.T) {
+	// We don't validate using the backend's schema due to potential use of the -backend-config flag.
+	t.Run("unset required attributes are not detected by validate command", func(t *testing.T) {
 		output, code := setupTest(t, "invalid-backend-configuration/missing-required-attr")
-		if code != 1 {
-			t.Fatalf("expected an unsuccessful exit code %d\n\n%s", code, output.Stdout())
+		if code != 0 {
+			t.Fatalf("expected a successful exit code %d\n\n%s", code, output.Stderr())
 		}
-		expectedErr := "Error: Missing required argument"
-		if !strings.Contains(output.Stderr(), expectedErr) {
+		expected := "Success! The configuration is valid."
+		if !strings.Contains(output.Stdout(), expected) {
 			t.Fatalf("unexpected error content: wanted %q, got: %s",
-				expectedErr,
-				output.Stderr(),
-			)
-		}
-	})
-}
-
-func TestValidate_stateStoreBlocks(t *testing.T) {
-	t.Run("invalid when state_store block contains a repeated attribute", func(t *testing.T) {
-		fixturePath := "invalid-state-store-configuration/repeated-attr-in-store"
-		view, done := testView(t)
-		mock := mockPluggableStateStorageProvider()
-		c := &ValidateCommand{
-			Meta: Meta{
-				testingOverrides:          metaOverridesForProvider(mock),
-				View:                      view,
-				AllowExperimentalFeatures: true,
-			},
-		}
-		args := []string{"-no-color", testFixturePath(fixturePath)}
-		code := c.Run(args)
-		output := done(t)
-
-		if code != 1 {
-			t.Fatalf("unexpected successful exit code %d\n\n%s", code, output.Stdout())
-		}
-		expectedErr := "Error: Attribute redefined"
-		if !strings.Contains(output.Stderr(), expectedErr) {
-			t.Fatalf("unexpected error content: wanted %q, got: %s",
-				expectedErr,
-				output.Stderr(),
-			)
-		}
-	})
-
-	t.Run("invalid when state_store's provider block contains a repeated attribute", func(t *testing.T) {
-		fixturePath := "invalid-state-store-configuration/repeated-attr-in-provider"
-		view, done := testView(t)
-		mock := mockPluggableStateStorageProvider()
-		c := &ValidateCommand{
-			Meta: Meta{
-				testingOverrides:          metaOverridesForProvider(mock),
-				View:                      view,
-				AllowExperimentalFeatures: true,
-			},
-		}
-		args := []string{"-no-color", testFixturePath(fixturePath)}
-		code := c.Run(args)
-		output := done(t)
-
-		if code != 1 {
-			t.Fatalf("unexpected successful exit code %d\n\n%s", code, output.Stdout())
-		}
-		expectedErr := "Error: Attribute redefined"
-		if !strings.Contains(output.Stderr(), expectedErr) {
-			t.Fatalf("unexpected error content: wanted %q, got: %s",
-				expectedErr,
-				output.Stderr(),
-			)
-		}
-	})
-
-	t.Run("invalid when the state store type is unknown in that provider", func(t *testing.T) {
-		fixturePath := "invalid-state-store-configuration/unknown-store-type"
-		view, done := testView(t)
-		mock := mockPluggableStateStorageProvider()
-		c := &ValidateCommand{
-			Meta: Meta{
-				testingOverrides:          metaOverridesForProvider(mock),
-				View:                      view,
-				AllowExperimentalFeatures: true,
-			},
-		}
-		args := []string{"-no-color", testFixturePath(fixturePath)}
-		code := c.Run(args)
-		output := done(t)
-
-		if code != 1 {
-			t.Fatalf("unexpected successful exit code %d\n\n%s", code, output.Stdout())
-		}
-		expectedErr := "Error: State store not implemented by the provider"
-		if !strings.Contains(output.Stderr(), expectedErr) {
-			t.Fatalf("unexpected error content: wanted %q, got: %s",
-				expectedErr,
-				output.Stderr(),
-			)
-		}
-	})
-
-	t.Run("invalid when the state store provider doesn't implement any stores", func(t *testing.T) {
-		fixturePath := "invalid-state-store-configuration/unknown-store-type" // ok to reuse; see mock provider for test setup
-		view, done := testView(t)
-		mock := mockPluggableStateStorageProvider()
-		mock.GetProviderSchemaResponse.StateStores = map[string]providers.Schema{} // override to have no state stores
-		c := &ValidateCommand{
-			Meta: Meta{
-				testingOverrides:          metaOverridesForProvider(mock),
-				View:                      view,
-				AllowExperimentalFeatures: true,
-			},
-		}
-		args := []string{"-no-color", testFixturePath(fixturePath)}
-		code := c.Run(args)
-		output := done(t)
-
-		if code != 1 {
-			t.Fatalf("unexpected successful exit code %d\n\n%s", code, output.Stdout())
-		}
-		expectedErr := "Error: Provider does not support pluggable state storage"
-		if !strings.Contains(output.Stderr(), expectedErr) {
-			t.Fatalf("unexpected error content: wanted %q, got: %s",
-				expectedErr,
-				output.Stderr(),
-			)
-		}
-	})
-
-	t.Run("invalid when there's an unknown attribute present in the states_store block", func(t *testing.T) {
-		fixturePath := "invalid-state-store-configuration/unknown-attr-in-store"
-		view, done := testView(t)
-		mock := mockPluggableStateStorageProvider()
-		c := &ValidateCommand{
-			Meta: Meta{
-				testingOverrides:          metaOverridesForProvider(mock),
-				View:                      view,
-				AllowExperimentalFeatures: true,
-			},
-		}
-		args := []string{"-no-color", testFixturePath(fixturePath)}
-		code := c.Run(args)
-		output := done(t)
-
-		if code != 1 {
-			t.Fatalf("expected an unsuccessful exit code %d\n\n%s", code, output.Stdout())
-		}
-		expectedErr := "Error: Unsupported argument"
-		if !strings.Contains(output.Stderr(), expectedErr) {
-			t.Fatalf("unexpected error content: wanted %q, got: %s",
-				expectedErr,
-				output.Stderr(),
-			)
-		}
-	})
-
-	t.Run("invalid when there's an unknown attribute present in the states_store's provider block", func(t *testing.T) {
-		fixturePath := "invalid-state-store-configuration/unknown-attr-in-provider"
-		view, done := testView(t)
-		mock := mockPluggableStateStorageProvider()
-		c := &ValidateCommand{
-			Meta: Meta{
-				testingOverrides:          metaOverridesForProvider(mock),
-				View:                      view,
-				AllowExperimentalFeatures: true,
-			},
-		}
-		args := []string{"-no-color", testFixturePath(fixturePath)}
-		code := c.Run(args)
-		output := done(t)
-
-		if code != 1 {
-			t.Fatalf("expected an unsuccessful exit code %d\n\n%s", code, output.Stdout())
-		}
-		expectedErr := "Error: Unsupported argument"
-		if !strings.Contains(output.Stderr(), expectedErr) {
-			t.Fatalf("unexpected error content: wanted %q, got: %s",
-				expectedErr,
-				output.Stderr(),
-			)
-		}
-	})
-
-	t.Run("invalid when a required attribute in state_store block is unset", func(t *testing.T) {
-		fixturePath := "invalid-state-store-configuration/missing-required-attr-in-store"
-		view, done := testView(t)
-		mock := mockPluggableStateStorageProvider()
-		c := &ValidateCommand{
-			Meta: Meta{
-				testingOverrides:          metaOverridesForProvider(mock),
-				View:                      view,
-				AllowExperimentalFeatures: true,
-			},
-		}
-		args := []string{"-no-color", testFixturePath(fixturePath)}
-		code := c.Run(args)
-		output := done(t)
-
-		if code != 1 {
-			t.Fatalf("expected an unsuccessful exit code %d\n\n%s", code, output.Stdout())
-		}
-		expectedErr := "Error: Missing required argument"
-		if !strings.Contains(output.Stderr(), expectedErr) {
-			t.Fatalf("unexpected error content: wanted %q, got: %s",
-				expectedErr,
-				output.Stderr(),
-			)
-		}
-	})
-
-	t.Run("invalid when a required attribute in state_store's provider block is unset", func(t *testing.T) {
-		fixturePath := "invalid-state-store-configuration/missing-required-attr-in-provider"
-		view, done := testView(t)
-		mock := mockPluggableStateStorageProvider()
-		// Make the provider's schema require an attribute that isn't set in the test fixture
-		mock.GetProviderSchemaResponse.Provider.Body = &configschema.Block{
-			Attributes: map[string]*configschema.Attribute{
-				"required_attr": {Type: cty.String, Required: true},
-			},
-		}
-		c := &ValidateCommand{
-			Meta: Meta{
-				testingOverrides:          metaOverridesForProvider(mock),
-				View:                      view,
-				AllowExperimentalFeatures: true,
-			},
-		}
-		args := []string{"-no-color", testFixturePath(fixturePath)}
-		code := c.Run(args)
-		output := done(t)
-
-		if code != 1 {
-			t.Fatalf("expected an unsuccessful exit code %d\n\n%s", code, output.Stdout())
-		}
-		expectedErr := "Error: Missing required argument"
-		if !strings.Contains(output.Stderr(), expectedErr) {
-			t.Fatalf("unexpected error content: wanted %q, got: %s",
-				expectedErr,
-				output.Stderr(),
-			)
-		}
-	})
-
-	t.Run("invalid when the state_store's provider's ValidateProviderConfig method returns an error", func(t *testing.T) {
-		fixturePath := "invalid-state-store-configuration/valid-config" // mock provider creates the errors
-		view, done := testView(t)
-		mock := mockPluggableStateStorageProvider()
-		// Make the provider respond as if there's a problem with the provider config.
-		mock.ValidateProviderConfigResponse = &providers.ValidateProviderConfigResponse{
-			Diagnostics: tfdiags.Diagnostics{}.Append(tfdiags.Sourceless(
-				tfdiags.Error,
-				"Error from test",
-				"This test is forcing an error to be returned from the provider's ValidateProviderConfig method.",
-			)),
-		}
-		c := &ValidateCommand{
-			Meta: Meta{
-				testingOverrides:          metaOverridesForProvider(mock),
-				View:                      view,
-				AllowExperimentalFeatures: true,
-			},
-		}
-		args := []string{"-no-color", testFixturePath(fixturePath)}
-		code := c.Run(args)
-		output := done(t)
-
-		if code != 1 {
-			t.Fatalf("expected an unsuccessful exit code %d\n\n%s", code, output.Stdout())
-		}
-		expectedErr := "Error from test"
-		if !strings.Contains(output.Stderr(), expectedErr) {
-			t.Fatalf("unexpected error content: wanted %q, got: %s",
-				expectedErr,
-				output.Stderr(),
-			)
-		}
-	})
-
-	t.Run("invalid when the state_store's provider's ValidateStateStoreConfig method returns an error", func(t *testing.T) {
-		fixturePath := "invalid-state-store-configuration/valid-config" // mock provider creates the errors
-		view, done := testView(t)
-		mock := mockPluggableStateStorageProvider()
-		// Make the provider respond as if there's a problem with the state store config.
-		// The provider's ValidateStateStoreConfig method is called inside the PrepareConfig method of a Pluggable.
-		mock.ValidateStateStoreConfigResponse = &providers.ValidateStateStoreConfigResponse{
-			Diagnostics: tfdiags.Diagnostics{}.Append(tfdiags.Sourceless(
-				tfdiags.Error,
-				"Error from test",
-				"This test is forcing an error to be returned from the provider's ValidateStateStoreConfig method.",
-			)),
-		}
-		// Make mock happy.
-		// This check -that a provider is configured before state store config is validated- is specific to the mock
-		// and isn't performed by user-facing code in Terraform. The mock's behaviour is to highlight abnormal situations/
-		// breaking of assumptions.
-		// Here we know validate doesn't configure the provider before using validation methods, so we can set this flag
-		// to bypass.
-		mock.ConfigureProviderCalled = true
-		c := &ValidateCommand{
-			Meta: Meta{
-				testingOverrides:          metaOverridesForProvider(mock),
-				View:                      view,
-				AllowExperimentalFeatures: true,
-			},
-		}
-		args := []string{"-no-color", testFixturePath(fixturePath)}
-		code := c.Run(args)
-		output := done(t)
-
-		if code != 1 {
-			t.Fatalf("expected an unsuccessful exit code %d\n\n%s", code, output.Stdout())
-		}
-		expectedErr := "Error from test"
-		if !strings.Contains(output.Stderr(), expectedErr) {
-			t.Fatalf("unexpected error content: wanted %q, got: %s",
-				expectedErr,
-				output.Stderr(),
+				expected,
+				output.Stdout(),
 			)
 		}
 	})

--- a/internal/command/validate_test.go
+++ b/internal/command/validate_test.go
@@ -726,6 +726,25 @@ func TestValidate_backendBlocks(t *testing.T) {
 		}
 	})
 
+	t.Run("removed backends cause errors with extra info", func(t *testing.T) {
+		output, code := setupTest(t, "invalid-backend-configuration/removed-backend-type")
+		if code != 1 {
+			t.Fatalf("expected an unsuccessful exit code %d\n\n%s", code, output.Stderr())
+		}
+		expectedErrMsgs := []string{
+			"Error: Unsupported backend type",
+			"The \"artifactory\" backend is not supported in Terraform v1.3 or later.",
+		}
+		for _, msg := range expectedErrMsgs {
+			if !strings.Contains(output.Stderr(), msg) {
+				t.Fatalf("unexpected error content: wanted to include %q, got: %s",
+					msg,
+					output.Stderr(),
+				)
+			}
+		}
+	})
+
 	// We don't validate using the backend's schema due to potential use of the -backend-config flag.
 	t.Run("unknown attributes are not detected by validate command", func(t *testing.T) {
 		output, code := setupTest(t, "invalid-backend-configuration/unknown-attr")


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform/issues/38466

This was an oversight on my part in the original PR 😅 

We're going with a partial revert to address that issue when using partial configuration. I think continuing to include validation of backend type is valid, while re-enabling use of configurations that are expected to be used alongside `-backend-config`.

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.15.1

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [x] This change is user-facing and I added a changelog entry.
- [ ] This change is not user-facing.
