### PR TITLE
fix: warnings against using `terraform env list` are shown in JSON format when the -json flag is present

### DIFF
--- a/internal/command/workspace_command.go
+++ b/internal/command/workspace_command.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/hashicorp/cli"
+	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/terraform/internal/backend"
 	"github.com/hashicorp/terraform/internal/tfdiags"
 )
@@ -68,6 +69,28 @@ with other concepts.
 The "terraform workspace" commands should be used instead. "terraform env"
 will be removed in a future Terraform version.
 `)
+}
+
+// envCommandWarningDiag returns diagnostic version of the output from envCommandShowWarning.
+// This should be used when the output is being rendered in a machine-readable format.
+func envCommandWarningDiag(show bool) tfdiags.Diagnostics {
+	var diags tfdiags.Diagnostics
+	if !show {
+		return diags // empty
+	}
+
+	diags = diags.Append(&hcl.Diagnostic{
+		Severity: hcl.DiagWarning,
+		Detail:   `Warning: the "terraform env" family of commands is deprecated.`,
+		Summary: `"Workspace" is now the preferred term for what earlier Terraform versions
+called "environment", to reduce ambiguity caused by the latter term colliding
+with other concepts.
+
+The "terraform workspace" commands should be used instead. "terraform env"
+will be removed in a future Terraform version.
+`,
+	})
+	return diags
 }
 
 const (

--- a/internal/command/workspace_command_test.go
+++ b/internal/command/workspace_command_test.go
@@ -965,7 +965,7 @@ func TestWorkspace_selectWithOrCreate(t *testing.T) {
 // Test covers:
 // - `terraform env new`
 // - `terraform env select`
-// - `terraform env list`
+// - `terraform env list` - with and without `-json`
 // - `terraform env delete`
 //
 // Note: there is no `env` equivalent of `terraform workspace show`.
@@ -1048,6 +1048,30 @@ func TestWorkspace_envCommandDeprecationWarnings(t *testing.T) {
 		t.Fatalf("expected the command to return a warning, but it was missing.\nwanted: %s\ngot: %s",
 			expectedWarning,
 			ui.ErrorWriter.String(),
+		)
+	}
+
+	// Assert `terraform env list -json` returns expected deprecation warning
+	ui = new(cli.MockUi)
+	view, done := testView(t)
+	listCmd = &WorkspaceListCommand{
+		Meta: Meta{
+			Ui:         ui,
+			View:       view,
+			WorkingDir: workdir.NewDir("."),
+		},
+		LegacyName: true,
+	}
+	args = []string{"-json"}
+	if code := listCmd.Run(args); code != 0 {
+		t.Fatalf("bad: %d\n\n%s", code, done(t).All())
+	}
+	output := cleanString(done(t).All())
+	expectedWarningJSON := "Warning: the \\\"terraform env\\\" family of commands is deprecated."
+	if !strings.Contains(output, expectedWarningJSON) {
+		t.Fatalf("expected the command to return a warning, but it was missing.\nwanted: %s\ngot: %s",
+			expectedWarningJSON,
+			output,
 		)
 	}
 

--- a/internal/command/workspace_list.go
+++ b/internal/command/workspace_list.go
@@ -44,7 +44,11 @@ func (c *WorkspaceListCommand) Run(rawArgs []string) int {
 	view := newWorkspaceList(args.ViewType, c.View, c.Ui, &c.Meta)
 
 	// Warn against using `terraform env` commands
-	envCommandShowWarning(c.Ui, c.LegacyName)
+	if args.ViewType == arguments.ViewHuman {
+		envCommandShowWarning(c.Ui, c.LegacyName)
+	} else {
+		diags = diags.Append(envCommandWarningDiag(c.LegacyName))
+	}
 
 	// Now the view is ready, process any error diagnostics from parsing arguments.
 	if diags.HasErrors() {
@@ -54,8 +58,9 @@ func (c *WorkspaceListCommand) Run(rawArgs []string) int {
 
 	// Load the backend
 	configPath := c.WorkingDir.RootModuleDir()
-	b, diags := c.backend(configPath, args.ViewType)
-	if diags.HasErrors() {
+	b, bDiags := c.backend(configPath, args.ViewType)
+	diags = diags.Append(bDiags)
+	if bDiags.HasErrors() {
 		view.List("", nil, diags)
 		return 1
 	}


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform/commit/694ed4a33d65b047bcce6453120ec589905b526e, which is due to be released in v1.16.

Previously the `workspace list` command showed this deprecated command alias warning in human-readable output even if a user supplied the `-json` flag. This PR fixes that and updates relevant tests.

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.16.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.

Given the thing this is fixing is unreleased, I don't believe we need an additional change log entry
