### PR TITLE
Fix non-const variable checks on `init`

### DIFF
--- a/.changes/v1.15/BUG FIXES-20260429-183507.yaml
+++ b/.changes/v1.15/BUG FIXES-20260429-183507.yaml
@@ -1,0 +1,5 @@
+kind: BUG FIXES
+body: Fix non-const variable checks on `init`
+time: 2026-04-29T18:35:07.99622+02:00
+custom:
+    Issue: "38470"

--- a/internal/terraform/context_init_test.go
+++ b/internal/terraform/context_init_test.go
@@ -697,22 +697,35 @@ module "example" {
 		"non-const variable validation does not run during init": {
 			module: map[string]string{
 				"main.tf": `
+variable "some" {
+ type = string
+}
 variable "name" {
   type    = string
   default = "bad"
 
   validation {
-    condition     = var.name != "bad"
+    condition     = var.name != var.some
     error_message = "must not be bad"
   }
 }
 module "example" {
-    source = "./modules/fixed"
+    source = "./modules/example"
+
+    name = var.name
 }
 `,
 			},
+			mockedLoadModuleCalls: map[string]map[string]string{
+				"./modules/example": {
+					"main.tf": `
+variable "name" {
+  type = string
+}
+`},
+			},
 			expectLoadModuleCalls: []*configs.ModuleRequest{{
-				SourceAddr: mustModuleSource(t, "./modules/fixed"),
+				SourceAddr: mustModuleSource(t, "./modules/example"),
 			}},
 		},
 	} {

--- a/internal/terraform/evaluate.go
+++ b/internal/terraform/evaluate.go
@@ -301,7 +301,7 @@ func (d *evaluationStateData) GetInputVariable(addr addrs.InputVariable, rng tfd
 	// that are disabled, etc. Terraform's static validation leans towards
 	// being liberal in what it accepts because the subsequent plan walk has
 	// more information available and so can be more conservative.
-	if d.Operation == walkValidate {
+	if d.Operation == walkValidate || (d.Operation == walkInit && !config.Const) {
 		// We should still capture the statically-configured marks during
 		// the validate walk.
 		ret := cty.UnknownVal(config.Type)


### PR DESCRIPTION
We did filter non-const variable nodes in the init graph builder, but as soon as a module references a variable, we keep the node in the graph. When the node is in the graph, we ran the validation for that variable.

With this PR Terraform now returns unknown values for non-const variables, achieving a similar behavior as during validate.

Fixes https://github.com/hashicorp/terraform/issues/38463

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.15.1

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [x] This change is user-facing and I added a changelog entry.
- [ ] This change is not user-facing.
