### PR TITLE
.github/workflows: Update changelog check to use base_ref for checkout

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -54,7 +54,7 @@ jobs:
                       .changie.yaml
                       .changes/
                   sparse-checkout-cone-mode: false
-                  ref: ${{ github.ref }} # Ref refers to the target branch of this PR
+                  ref: ${{ github.base_ref }} # Base ref refers to the target branch of this PR
 
             - name: "Check for changelog entry"
               uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Currently our CI for checking if a changelog is needed always uses the `main` branch (via `github.ref`) rather than the target branch. So for backport PRs that target a different branch, it will use `main` to figure out which version the change will affect.

For example, a backport PR targeting the `v1.15` branch:
- https://github.com/hashicorp/terraform/pull/38452
- https://github.com/hashicorp/terraform/actions/runs/25116609421/job/73605336593?pr=38452
```bash
Error: Currently this PR would target a v1.16 release. Please add a changelog entry for in the .changes/v1.16 folder
```

I think this might have changed recently in GitHub for security reasons ™️ when `github.ref` will always be the default branch for `pull_request_target` events.
- https://github.blog/changelog/2025-11-07-actions-pull_request_target-and-environment-branch-protections-changes/#what-is-changing

The workaround is easy for now, since you can just add our skip changelog label.

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.15.1

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
