### PR TITLE
fix: don't show warnings on terraform output

### DIFF
--- a/.changes/v1.15/BUG FIXES-20260430-121433.yaml
+++ b/.changes/v1.15/BUG FIXES-20260430-121433.yaml
@@ -1,0 +1,5 @@
+kind: BUG FIXES
+body: don't show warnings on terraform output
+time: 2026-04-30T12:14:33.373975+02:00
+custom:
+    Issue: "38486"

--- a/internal/command/meta_backend.go
+++ b/internal/command/meta_backend.go
@@ -231,6 +231,13 @@ func (m *Meta) Backend(opts *BackendOpts) (backendrun.OperationsBackend, tfdiags
 		}
 	}
 
+	// For non-PSS (traditional) backends, suppress non-error diagnostics.
+	// Backend warnings such as deprecation notices were already shown during
+	// "terraform init" and should not resurface on every subsequent command.
+	if !stateStoreInUse {
+		return local, nil
+	}
+
 	return local, diags
 }
 

--- a/internal/command/output_test.go
+++ b/internal/command/output_test.go
@@ -13,9 +13,13 @@ import (
 	"github.com/zclconf/go-cty/cty"
 
 	"github.com/hashicorp/terraform/internal/addrs"
+	"github.com/hashicorp/terraform/internal/backend"
+	backendInit "github.com/hashicorp/terraform/internal/backend/init"
+	"github.com/hashicorp/terraform/internal/backend/remote-state/inmem"
 	"github.com/hashicorp/terraform/internal/providers"
 	"github.com/hashicorp/terraform/internal/states"
 	"github.com/hashicorp/terraform/internal/states/statefile"
+	"github.com/hashicorp/terraform/internal/tfdiags"
 )
 
 func TestOutput(t *testing.T) {
@@ -379,5 +383,84 @@ func TestOutput_stateDefault(t *testing.T) {
 	actual := strings.TrimSpace(output.Stdout())
 	if actual != `"bar"` {
 		t.Fatalf("bad: %#v", actual)
+	}
+}
+
+// deprecatedInmemBackend wraps the inmem backend and injects a deprecation
+// warning from PrepareConfig, simulating a backend with deprecated attributes
+// (like the S3 backend's dynamodb_table).
+type deprecatedInmemBackend struct {
+	backend.Backend
+}
+
+func (b *deprecatedInmemBackend) PrepareConfig(obj cty.Value) (cty.Value, tfdiags.Diagnostics) {
+	newObj, diags := b.Backend.PrepareConfig(obj)
+	diags = diags.Append(tfdiags.SimpleWarning(`The attribute "deprecated_attr" is deprecated.`))
+	return newObj, diags
+}
+
+func TestOutput_backendWarningsSuppressed(t *testing.T) {
+	// Pre-populate the inmem backend with a state containing an output value
+	inmem.Reset()
+	originalState := states.BuildState(func(s *states.SyncState) {
+		s.SetOutputValue(
+			addrs.OutputValue{Name: "foo"}.Absolute(addrs.RootModuleInstance),
+			cty.StringVal("bar"),
+			false,
+		)
+	})
+
+	// Register a backend that wraps inmem with a deprecation warning,
+	// simulating a backend like S3 whose PrepareConfig warns about
+	// deprecated attributes (e.g. dynamodb_table).
+	backendInit.Set("inmem", func() backend.Backend {
+		return &deprecatedInmemBackend{Backend: inmem.New()}
+	})
+	defer backendInit.Set("inmem", inmem.New)
+
+	td := t.TempDir()
+	testCopyDir(t, testFixturePath("output-backend-with-deprecation"), td)
+	t.Chdir(td)
+
+	// Write the state into the inmem backend's default workspace
+	b := inmem.New()
+	b.Configure(cty.ObjectVal(map[string]cty.Value{
+		"lock_id": cty.NullVal(cty.String),
+	}))
+	sMgr, sDiags := b.StateMgr(backend.DefaultStateName)
+	if sDiags.HasErrors() {
+		t.Fatalf("unexpected error: %s", sDiags.Err())
+	}
+	sMgr.WriteState(originalState)
+	if err := sMgr.PersistState(nil); err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	view, done := testView(t)
+	c := &OutputCommand{
+		Meta: Meta{
+			testingOverrides: metaOverridesForProvider(testProvider()),
+			View:             view,
+		},
+	}
+
+	args := []string{"foo"}
+	code := c.Run(args)
+	output := done(t)
+	if code != 0 {
+		t.Fatalf("unexpected exit code %d\nstderr:\n%s", code, output.Stderr())
+	}
+
+	// The key assertion: backend deprecation warnings must not appear in output.
+	// Before the fix, Backend() returned these warnings for non-PSS backends,
+	// causing them to show up on every command (not just init).
+	stderr := output.Stderr()
+	if strings.Contains(stderr, "deprecated") {
+		t.Fatalf("backend deprecation warnings should be suppressed for non-PSS backends, got:\n%s", stderr)
+	}
+
+	actual := strings.TrimSpace(output.Stdout())
+	if actual != `"bar"` {
+		t.Fatalf("expected output \"bar\", got: %#v", actual)
 	}
 }

--- a/internal/command/testdata/output-backend-with-deprecation/.terraform/terraform.tfstate
+++ b/internal/command/testdata/output-backend-with-deprecation/.terraform/terraform.tfstate
@@ -1,0 +1,12 @@
+{
+    "version": 3,
+    "serial": 0,
+    "lineage": "test-output-deprecation",
+    "backend": {
+        "type": "inmem",
+        "config": {
+            "lock_id": null
+        },
+        "hash": 3947750061
+    }
+}

--- a/internal/command/testdata/output-backend-with-deprecation/main.tf
+++ b/internal/command/testdata/output-backend-with-deprecation/main.tf
@@ -1,0 +1,7 @@
+terraform {
+    backend "inmem" {}
+}
+
+output "foo" {
+    value = "bar"
+}


### PR DESCRIPTION
As part of PSS we expose errors and warnings from backends, but during `terraform output` this leads to problems with automated scripting. Prior to 1.15 we just swallowed the warnings during `terraform output`.

<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Fixes #38484
Fixes #38479

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.16.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [ ] This change is not user-facing.