### PR TITLE
Ignore undeclared variable values from the cloud backend

### DIFF
--- a/.changes/v1.15/BUG FIXES-20260430-154241.yaml
+++ b/.changes/v1.15/BUG FIXES-20260430-154241.yaml
@@ -1,0 +1,5 @@
+kind: BUG FIXES
+body: Ignore undeclared variable values from the cloud backend
+time: 2026-04-30T15:42:41.89732+02:00
+custom:
+    Issue: "38490"

--- a/internal/backend/backendrun/unparsed_value.go
+++ b/internal/backend/backendrun/unparsed_value.go
@@ -59,6 +59,11 @@ func ParseUndeclaredVariableValues(vv map[string]arguments.UnparsedVariableValue
 			// variables, because users will often set these globally
 			// when they are used across many (but not necessarily all)
 			// configurations.
+		case terraform.ValueFromCloud:
+			// We allow and ignore undeclared names fetched from the cloud
+			// backend, because users will often set these globally or via
+			// varsets when they are used across many (but not necessarily all)
+			// workspaces.
 		case terraform.ValueFromCLIArg:
 			diags = diags.Append(tfdiags.Sourceless(
 				tfdiags.Error,

--- a/internal/cloud/backend_context.go
+++ b/internal/cloud/backend_context.go
@@ -303,6 +303,6 @@ func (v *remoteStoredVariableValue) ParseVariableValue(mode configs.VariablePars
 		// roughly speaking, a similar idea to entering variable values at
 		// the interactive CLI prompts. It's not a perfect correspondance,
 		// but it's closer than the other options.
-		SourceType: terraform.ValueFromInput,
+		SourceType: terraform.ValueFromCloud,
 	}, diags
 }

--- a/internal/cloud/backend_context_test.go
+++ b/internal/cloud/backend_context_test.go
@@ -279,7 +279,7 @@ func TestRemoteVariablesDoNotOverride(t *testing.T) {
 			terraform.InputValues{
 				varName1: &terraform.InputValue{
 					Value:      cty.StringVal(varValue1),
-					SourceType: terraform.ValueFromInput,
+					SourceType: terraform.ValueFromCloud,
 					SourceRange: tfdiags.SourceRange{
 						Filename: "",
 						Start:    tfdiags.SourcePos{Line: 0, Column: 0, Byte: 0},
@@ -288,7 +288,7 @@ func TestRemoteVariablesDoNotOverride(t *testing.T) {
 				},
 				varName2: &terraform.InputValue{
 					Value:      cty.StringVal(varValue2),
-					SourceType: terraform.ValueFromInput,
+					SourceType: terraform.ValueFromCloud,
 					SourceRange: tfdiags.SourceRange{
 						Filename: "",
 						Start:    tfdiags.SourcePos{Line: 0, Column: 0, Byte: 0},
@@ -297,7 +297,7 @@ func TestRemoteVariablesDoNotOverride(t *testing.T) {
 				},
 				varName3: &terraform.InputValue{
 					Value:      cty.StringVal(varValue3),
-					SourceType: terraform.ValueFromInput,
+					SourceType: terraform.ValueFromCloud,
 					SourceRange: tfdiags.SourceRange{
 						Filename: "",
 						Start:    tfdiags.SourcePos{Line: 0, Column: 0, Byte: 0},
@@ -328,7 +328,7 @@ func TestRemoteVariablesDoNotOverride(t *testing.T) {
 			terraform.InputValues{
 				varName1: &terraform.InputValue{
 					Value:      cty.StringVal(varValue1),
-					SourceType: terraform.ValueFromInput,
+					SourceType: terraform.ValueFromCloud,
 					SourceRange: tfdiags.SourceRange{
 						Filename: "",
 						Start:    tfdiags.SourcePos{Line: 0, Column: 0, Byte: 0},
@@ -337,7 +337,7 @@ func TestRemoteVariablesDoNotOverride(t *testing.T) {
 				},
 				varName2: &terraform.InputValue{
 					Value:      cty.StringVal(varValue2),
-					SourceType: terraform.ValueFromInput,
+					SourceType: terraform.ValueFromCloud,
 					SourceRange: tfdiags.SourceRange{
 						Filename: "",
 						Start:    tfdiags.SourcePos{Line: 0, Column: 0, Byte: 0},
@@ -373,7 +373,7 @@ func TestRemoteVariablesDoNotOverride(t *testing.T) {
 			terraform.InputValues{
 				varName1: &terraform.InputValue{
 					Value:      cty.StringVal(varValue1),
-					SourceType: terraform.ValueFromInput,
+					SourceType: terraform.ValueFromCloud,
 					SourceRange: tfdiags.SourceRange{
 						Filename: "",
 						Start:    tfdiags.SourcePos{Line: 0, Column: 0, Byte: 0},
@@ -382,7 +382,7 @@ func TestRemoteVariablesDoNotOverride(t *testing.T) {
 				},
 				varName2: &terraform.InputValue{
 					Value:      cty.StringVal(varValue2),
-					SourceType: terraform.ValueFromInput,
+					SourceType: terraform.ValueFromCloud,
 					SourceRange: tfdiags.SourceRange{
 						Filename: "",
 						Start:    tfdiags.SourcePos{Line: 0, Column: 0, Byte: 0},

--- a/internal/cloud/backend_context_test.go
+++ b/internal/cloud/backend_context_test.go
@@ -169,7 +169,8 @@ func TestRemoteContextWithVars(t *testing.T) {
 			&tfe.VariableCreateOptions{
 				Category: &catTerraform,
 			},
-			`Value for undeclared variable: A variable named "key" was assigned a value, but the root module does not declare a variable of that name. To use this value, add a "variable" block to the configuration.`,
+			// We don't expect an error for values of undeclared variables
+			``,
 		},
 		"environment variable": {
 			&tfe.VariableCreateOptions{

--- a/internal/terraform/valuesourcetype_string.go
+++ b/internal/terraform/valuesourcetype_string.go
@@ -17,6 +17,7 @@ func _() {
 	_ = x[ValueFromInput-73]
 	_ = x[ValueFromPlan-80]
 	_ = x[ValueFromCaller-83]
+	_ = x[ValueFromCloud-84]
 }
 
 const (
@@ -27,11 +28,12 @@ const (
 	_ValueSourceType_name_4 = "ValueFromInput"
 	_ValueSourceType_name_5 = "ValueFromNamedFile"
 	_ValueSourceType_name_6 = "ValueFromPlan"
-	_ValueSourceType_name_7 = "ValueFromCaller"
+	_ValueSourceType_name_7 = "ValueFromCallerValueFromCloud"
 )
 
 var (
 	_ValueSourceType_index_3 = [...]uint8{0, 15, 32}
+	_ValueSourceType_index_7 = [...]uint8{0, 15, 29}
 )
 
 func (i ValueSourceType) String() string {
@@ -51,8 +53,9 @@ func (i ValueSourceType) String() string {
 		return _ValueSourceType_name_5
 	case i == 80:
 		return _ValueSourceType_name_6
-	case i == 83:
-		return _ValueSourceType_name_7
+	case 83 <= i && i <= 84:
+		i -= 83
+		return _ValueSourceType_name_7[_ValueSourceType_index_7[i]:_ValueSourceType_index_7[i+1]]
 	default:
 		return "ValueSourceType(" + strconv.FormatInt(int64(i), 10) + ")"
 	}

--- a/internal/terraform/variables.go
+++ b/internal/terraform/variables.go
@@ -105,6 +105,10 @@ const (
 	// ValueFromCaller indicates that the value was explicitly overridden by
 	// a caller to Context.SetVariable after the context was constructed.
 	ValueFromCaller ValueSourceType = 'S'
+
+	// ValueFromCloud indicates that the value was retrieved from a remote source,
+	// such as HCP Terraform or Terraform Enterprise.
+	ValueFromCloud ValueSourceType = 'T'
 )
 
 func (v *InputValue) GoString() string {
@@ -153,6 +157,8 @@ func (v ValueSourceType) DiagnosticLabel() string {
 		return "set by an interactive input"
 	case ValueFromPlan:
 		return "set by the plan"
+	case ValueFromCloud:
+		return "set by the cloud backend"
 	default:
 		return "unknown"
 	}


### PR DESCRIPTION
We added variables to all commands that interact with configuration in #38276. For users of the cloud backend, we fetch the variable values from HCP Terraform.

Before the change, the code for fetching variables was using by 5 commands: `console`, `graph`, `providers schema`, `state show`, and `import`. But the first four [stubbed variables by default](https://github.com/hashicorp/terraform/blob/1d517c3ae8970d0ee790a1c82efcc2c293ad4d29/internal/cloud/backend_context.go#L94), so only the `import` command ended up fetching variables from HCP Terraform and raising the `Value for undeclared variable` error.

The error is a result of treating remote variable values like CLI supplied ones:
https://github.com/hashicorp/terraform/blob/e6850a514f818187fd498ea4c055adbd485e978b/internal/cloud/backend_context.go#L298-L307

By reusing the same logic for fetching and parsing variables for many more commands now than just `import`,  we make this behavior much more visible. 

The new value source type will not raise any diagnostics or warnings when running any of the commands that accept variables now. With the tradeoff, that running `import` with the cloud backend will now also not raise these kind of diagnostics anymore. 

Fixes #38475

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.15.1

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [x] This change is user-facing and I added a changelog entry.
- [ ] This change is not user-facing.
