### PR TITLE
Special handling for empty module expansion

### DIFF
--- a/.changes/v1.15/BUG FIXES-20260430-103820.yaml
+++ b/.changes/v1.15/BUG FIXES-20260430-103820.yaml
@@ -1,0 +1,5 @@
+kind: BUG FIXES
+body: Fix panic for types modules with no expanded instances
+time: 2026-04-30T10:38:20.648469-04:00
+custom:
+    Issue: "38491"

--- a/internal/terraform/evaluate.go
+++ b/internal/terraform/evaluate.go
@@ -437,23 +437,25 @@ func (d *evaluationStateData) GetModule(addr addrs.ModuleCall, rng tfdiags.Sourc
 		noDynamicTypes = noDynamicTypes && !out.ConstraintType.HasDynamicTypes()
 	}
 
-	if d.Operation == walkValidate && typeDefined {
-		atys := make(map[string]cty.Type, len(outputConfigs))
-		as := make(map[string]cty.Value, len(outputConfigs))
-		for name, c := range outputConfigs {
-			// atys is used to create the module object type for expanded modules
-			atys[name] = c.ConstraintType
-			// the unknown val can be used when we return a single module
-			// instance with unknown outputs
-			val := cty.UnknownVal(c.ConstraintType)
+	// build up the type of the configured module output object
+	atys := make(map[string]cty.Type, len(outputConfigs))
+	// and create a single unknown instance value for validation
+	as := make(map[string]cty.Value, len(outputConfigs))
+	for name, c := range outputConfigs {
+		// atys is used to create the module object type for expanded modules
+		atys[name] = c.ConstraintType
 
-			if c.DeprecatedSet {
-				val = val.Mark(marks.NewDeprecation(c.Deprecated, absAddr.Output(name).ConfigOutputValue().ForDisplay()))
-			}
-			as[name] = val
+		// the unknown val can be used when we return a single module
+		// instance with unknown outputs
+		val := cty.UnknownVal(c.ConstraintType)
+		if c.DeprecatedSet {
+			val = val.Mark(marks.NewDeprecation(c.Deprecated, absAddr.Output(name).ConfigOutputValue().ForDisplay()))
 		}
-		instTy := cty.Object(atys)
+		as[name] = val
+	}
+	instTy := cty.Object(atys)
 
+	if d.Operation == walkValidate && typeDefined {
 		switch {
 		case callConfig.Count != nil && noDynamicTypes:
 			return cty.UnknownVal(cty.List(instTy)), diags
@@ -579,9 +581,12 @@ func (d *evaluationStateData) GetModule(addr addrs.ModuleCall, rng tfdiags.Sourc
 			elems = append(elems, instVal)
 			diags = diags.Append(moreDiags)
 		}
-		if noDynamicTypes {
+		switch {
+		case noDynamicTypes && len(elems) == 0:
+			return cty.ListValEmpty(instTy), diags
+		case noDynamicTypes:
 			return cty.ListVal(elems), diags
-		} else {
+		default:
 			return cty.TupleVal(elems), diags
 		}
 
@@ -592,9 +597,13 @@ func (d *evaluationStateData) GetModule(addr addrs.ModuleCall, rng tfdiags.Sourc
 			attrs[string(instKey.(addrs.StringKey))] = instVal
 			diags = diags.Append(moreDiags)
 		}
-		if noDynamicTypes {
+
+		switch {
+		case noDynamicTypes && len(attrs) == 0:
+			return cty.MapValEmpty(instTy), diags
+		case noDynamicTypes:
 			return cty.MapVal(attrs), diags
-		} else {
+		default:
 			return cty.ObjectVal(attrs), diags
 		}
 

--- a/internal/terraform/evaluate_test.go
+++ b/internal/terraform/evaluate_test.go
@@ -612,6 +612,14 @@ func TestEvaluatorGetModule_validateTypedOutputs(t *testing.T) {
 				"out": cty.String,
 			}))),
 		},
+		"empty_count": {
+			configureModuleCall: func(call *configs.ModuleCall) {
+				call.Count = hcltest.MockExprLiteral(cty.NumberIntVal(0))
+			},
+			want: cty.UnknownVal(cty.List(cty.Object(map[string]cty.Type{
+				"out": cty.String,
+			}))),
+		},
 		"for_each": {
 			configureModuleCall: func(call *configs.ModuleCall) {
 				call.ForEach = hcltest.MockExprLiteral(cty.MapVal(map[string]cty.Value{
@@ -729,6 +737,15 @@ func TestEvaluatorGetModule_planTypedOutputs(t *testing.T) {
 				cty.ObjectVal(map[string]cty.Value{"out": cty.StringVal("second").Mark(marks.Sensitive)}),
 			}),
 		},
+		"empty_count": {
+			setupInstances: func(expander *instances.Expander) {
+				expander.SetModuleCount(addrs.RootModuleInstance, addrs.ModuleCall{Name: "mod"}, 0)
+			},
+			setupOutputs: func(namedValues *namedvals.State) {
+				// explicitly setting no values
+			},
+			want: cty.ListValEmpty(cty.Object(map[string]cty.Type{"out": cty.String})),
+		},
 		"for_each": {
 			setupInstances: func(expander *instances.Expander) {
 				expander.SetModuleForEach(addrs.RootModuleInstance, addrs.ModuleCall{Name: "mod"}, map[string]cty.Value{
@@ -754,6 +771,15 @@ func TestEvaluatorGetModule_planTypedOutputs(t *testing.T) {
 				"a": cty.ObjectVal(map[string]cty.Value{"out": cty.StringVal("first").Mark(marks.Sensitive)}),
 				"b": cty.ObjectVal(map[string]cty.Value{"out": cty.StringVal("second").Mark(marks.Sensitive)}),
 			}),
+		},
+		"empty_for_each": {
+			setupInstances: func(expander *instances.Expander) {
+				expander.SetModuleForEach(addrs.RootModuleInstance, addrs.ModuleCall{Name: "mod"}, map[string]cty.Value{})
+			},
+			setupOutputs: func(namedValues *namedvals.State) {
+				// no values for empty for_each
+			},
+			want: cty.MapValEmpty(cty.Object(map[string]cty.Type{"out": cty.String})),
 		},
 	}
 


### PR DESCRIPTION
The cty library requires special handling for empty lists and maps to be able to define the element types, so we need a separate branch to generate expansion values when expansion results in 0 instances.

Fixes: #38492