### PR TITLE
Accept locked prerelease providers without constraints

### DIFF
--- a/.changes/v1.15/BUG FIXES-20260430-171600.yaml
+++ b/.changes/v1.15/BUG FIXES-20260430-171600.yaml
@@ -1,0 +1,4 @@
+kind: BUG FIXES
+body: Allow init to reuse locked provider versions with prerelease or suffixed versions when those providers are also present in state
+custom:
+    Issue: "38496"

--- a/internal/providercache/installer.go
+++ b/internal/providercache/installer.go
@@ -243,6 +243,14 @@ func (i *Installer) EnsureProviderVersions(ctx context.Context, locks *depsfile.
 			// existing selection from the lock file takes priority over
 			// the currently-configured version constraints.
 			if lock := locks.Provider(provider); lock != nil {
+				// An unconstrained requirement can arise from state, which records only
+				// provider addresses and not version constraints. In that case a
+				// previous lock file selection should remain acceptable, including for
+				// pre-release versions that versions.MeetingConstraints would otherwise
+				// exclude from an unconstrained version set.
+				if len(versionConstraints) == 0 {
+					acceptableVersions = versions.All
+				}
 				if !acceptableVersions.Has(lock.Version()) {
 					err := fmt.Errorf(
 						"locked provider %s %s does not match configured version constraint %s; must use terraform init -upgrade to allow selection of new versions",

--- a/internal/providercache/installer_test.go
+++ b/internal/providercache/installer_test.go
@@ -1963,6 +1963,43 @@ func TestEnsureProviderVersions(t *testing.T) {
 				}
 			},
 		},
+		"unconstrained locked prerelease version is accepted": {
+			Source: getproviders.NewMockSource(
+				[]getproviders.PackageMeta{
+					{
+						Provider:       beepProvider,
+						Version:        getproviders.MustParseVersion("1.0.0-beta1"),
+						TargetPlatform: fakePlatform,
+						Location:       beepProviderDir,
+					},
+				},
+				nil,
+			),
+			LockFile: `
+				provider "example.com/foo/beep" {
+					version     = "1.0.0-beta1"
+					hashes = [
+						"h1:2y06Ykj0FRneZfGCTxI9wRTori8iB7ZL5kQ6YyEnh84=",
+					]
+				}
+			`,
+			Mode: InstallNewProvidersOnly,
+			Reqs: getproviders.Requirements{
+				beepProvider: nil,
+			},
+			Check: func(t *testing.T, dir *Dir, locks *depsfile.Locks) {
+				gotLock := locks.Provider(beepProvider)
+				wantLock := depsfile.NewProviderLock(
+					beepProvider,
+					getproviders.MustParseVersion("1.0.0-beta1"),
+					nil,
+					[]getproviders.Hash{beepProviderHash},
+				)
+				if diff := cmp.Diff(wantLock, gotLock, depsfile.ProviderLockComparer); diff != "" {
+					t.Errorf("wrong lock entry\n%s", diff)
+				}
+			},
+		},
 		"locked version is no longer available": {
 			Source: getproviders.NewMockSource(
 				[]getproviders.PackageMeta{


### PR DESCRIPTION
## Summary

Allow Terraform init to reuse a locked provider version for unconstrained provider requirements, including prerelease or suffixed versions such as `6.0.0-beta3` and `4.52.1-shopify`. This should go in the 1.15 release (patch).

## Problem

After provider installation was split into configuration and state phases, providers discovered from state are installed with no version constraints because state records provider addresses but not constraints. For an unconstrained requirement, `versions.MeetingConstraints` does not accept prerelease versions unless they are explicitly requested, so the state provider installation phase can reject a version that was already selected and locked from configuration:

```text
locked provider registry.terraform.io/hashicorp/aws 6.0.0-beta3 does not match configured version constraint ; must use terraform init -upgrade to allow selection of new versions
```

## Solution

- **`internal/providercache/installer.go`** — When a lock file selection exists for an unconstrained requirement in non-upgrade mode, treat the locked version as acceptable before narrowing installation to that locked version. This preserves the existing lock-file-priority behavior while allowing prerelease/suffixed locked versions to be reused.
- **`internal/providercache/installer_test.go`** — Add a regression test for an unconstrained requirement with a locked prerelease provider version.

## Related

Fixes #38496
