### PR TITLE
fix: Avoid warnings in 'terraform output -json' (#38512)

### DIFF
--- a/.changes/v1.16/BUG FIXES-20260504-160000.yaml
+++ b/.changes/v1.16/BUG FIXES-20260504-160000.yaml
@@ -1,0 +1,5 @@
+kind: BUG FIXES
+body: Avoid warnings on stdout in 'terraform output -json' so the result remains parseable JSON
+time: 2026-05-04T16:00:00.000000+00:00
+custom:
+    Issue: "38512"

--- a/internal/command/output_test.go
+++ b/internal/command/output_test.go
@@ -463,3 +463,77 @@ func TestOutputRaw_warningsSuppressed(t *testing.T) {
 		t.Fatalf("expected output \"bar\", got: %#v", actual)
 	}
 }
+
+func TestOutputJSON_warningsSuppressed(t *testing.T) {
+	// Pre-populate the inmem backend with a state containing an output value
+	inmem.Reset()
+	originalState := states.BuildState(func(s *states.SyncState) {
+		s.SetOutputValue(
+			addrs.OutputValue{Name: "foo"}.Absolute(addrs.RootModuleInstance),
+			cty.StringVal("bar"),
+			false,
+		)
+	})
+
+	// Register a backend that wraps inmem with a deprecation warning,
+	// simulating a backend like S3 whose PrepareConfig warns about
+	// deprecated attributes (e.g. dynamodb_table). The same fixture
+	// powering TestOutputRaw_warningsSuppressed also reproduces the
+	// `-json` issue reported in #38512.
+	backendInit.Set("inmem", func() backend.Backend {
+		return &deprecatedInmemBackend{Backend: inmem.New()}
+	})
+	defer backendInit.Set("inmem", inmem.New)
+
+	td := t.TempDir()
+	testCopyDir(t, testFixturePath("output-backend-with-deprecation"), td)
+	t.Chdir(td)
+
+	// Write the state into the inmem backend's default workspace
+	b := inmem.New()
+	b.Configure(cty.ObjectVal(map[string]cty.Value{
+		"lock_id": cty.NullVal(cty.String),
+	}))
+	sMgr, sDiags := b.StateMgr(backend.DefaultStateName)
+	if sDiags.HasErrors() {
+		t.Fatalf("unexpected error: %s", sDiags.Err())
+	}
+	sMgr.WriteState(originalState)
+	if err := sMgr.PersistState(nil); err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	view, done := testView(t)
+	c := &OutputCommand{
+		Meta: Meta{
+			testingOverrides: metaOverridesForProvider(testProvider()),
+			View:             view,
+		},
+	}
+
+	args := []string{"-json", "foo"}
+	code := c.Run(args)
+	output := done(t)
+	if code != 0 {
+		t.Fatalf("unexpected exit code %d\nstderr:\n%s", code, output.Stderr())
+	}
+
+	// The key assertion: warnings must not appear on stdout because the
+	// caller is piping the output to `jq` or similar and any non-JSON
+	// content there breaks that pipeline. They are also not expected on
+	// stderr in this run because there was no error to surface.
+	stdout := output.Stdout()
+	if strings.Contains(stdout, "deprecated") {
+		t.Fatalf("warnings should be suppressed from stdout in -json mode, got:\n%s", stdout)
+	}
+	stderr := output.Stderr()
+	if strings.Contains(stderr, "deprecated") {
+		t.Fatalf("warnings should be suppressed in -json mode, got on stderr:\n%s", stderr)
+	}
+
+	// What remains on stdout must be parseable JSON containing the value.
+	actual := strings.TrimSpace(stdout)
+	if actual != `"bar"` {
+		t.Fatalf(`expected output "\"bar\"", got: %#v`, actual)
+	}
+}

--- a/internal/command/views/output.go
+++ b/internal/command/views/output.go
@@ -258,7 +258,13 @@ func (v *OutputJSON) Output(name string, outputs map[string]*states.OutputValue)
 }
 
 func (v *OutputJSON) Diagnostics(diags tfdiags.Diagnostics) {
-	v.view.Diagnostics(diags)
+	// filter out warnings as these wouldn't be expected in JSON mode
+	// either: pipelines like `terraform output -json | jq` cannot
+	// tolerate non-JSON content on stdout, and warnings typically don't
+	// influence the exit code so the user cannot expect them in stdout.
+	// Mirrors the same suppression added for `-raw` in #38487.
+	errsOnly := diags.ErrorsOnly()
+	v.view.Diagnostics(errsOnly)
 }
 
 // For text and raw output modes, an empty map of outputs is considered a


### PR DESCRIPTION
## Summary

Closes #38512.

The same backend deprecation warnings that #38487 suppressed for `terraform output -raw` also pollute stdout when running `terraform output -json`, breaking `terraform output -json | jq …` pipelines. As the issue reporter noted, the same fix shape applies.

## Change

Apply the `ErrorsOnly()` filter the raw formatter already uses to the JSON formatter:

```go
func (v *OutputJSON) Diagnostics(diags tfdiags.Diagnostics) {
	// filter out warnings as these wouldn't be expected in JSON mode
	// either: pipelines like `terraform output -json | jq` cannot
	// tolerate non-JSON content on stdout, and warnings typically don't
	// influence the exit code so the user cannot expect them in stdout.
	// Mirrors the same suppression added for `-raw` in #38487.
	errsOnly := diags.ErrorsOnly()
	v.view.Diagnostics(errsOnly)
}
```

The `ErrorsOnly()` helper added to `tfdiags/diagnostics.go` in #38487 is reused as-is — no new helper.

## Test

`TestOutputJSON_warningsSuppressed` mirrors `TestOutputRaw_warningsSuppressed` introduced in #38487. It:

- reuses the `output-backend-with-deprecation` fixture
- registers the `deprecatedInmemBackend` that emits a deprecation warning during `PrepareConfig`
- runs `terraform output -json foo`
- asserts exit code 0
- asserts `"deprecated"` does **not** appear on stdout (the parseable-JSON gate that #38512 was reporting)
- asserts `"deprecated"` does not appear on stderr in this case (no error to surface)
- asserts the remaining stdout is the parseable JSON value `\"bar\"`

```
$ go test ./internal/command -run "TestOutput(Raw|JSON)_warningsSuppressed" -v
=== RUN   TestOutputRaw_warningsSuppressed
--- PASS: TestOutputRaw_warningsSuppressed (0.00s)
=== RUN   TestOutputJSON_warningsSuppressed
--- PASS: TestOutputJSON_warningsSuppressed (0.00s)
PASS
```

## Changelog

Added `.changes/v1.16/BUG FIXES-20260504-160000.yaml` per the changie flow:

```yaml
kind: BUG FIXES
body: Avoid warnings on stdout in 'terraform output -json' so the result remains parseable JSON
time: 2026-05-04T16:00:00.000000+00:00
custom:
    Issue: "38512"
```

## Target Release

1.16.x (matches the `target-1.16.x` shape #38487 used; happy to add a backport label if you'd like this on 1.15.x as well, since the same break exists there).

## Rollback Plan

This is a single-method change in `views/output.go`. Reverting the commit restores the prior behavior without any state migration concerns.

## Notes for review

- I deliberately mirrored #38487's exact pattern instead of refactoring the two methods into a shared helper. The two `Diagnostics` impls are now nearly identical and could be hoisted into a `nonHumanDiagnostics` helper, but that would be a wider refactor than this bug fix — happy to do it as a follow-up if you'd prefer.
- The new test asserts JSON validity by string-comparing the trimmed stdout to `"bar"`. If you'd prefer a `json.Unmarshal` round-trip assertion, easy to swap.