### PR TITLE
Remove outdated value source comment

### DIFF
--- a/internal/cloud/backend_context.go
+++ b/internal/cloud/backend_context.go
@@ -296,13 +296,7 @@ func (v *remoteStoredVariableValue) ParseVariableValue(mode configs.VariablePars
 	}
 
 	return &terraform.InputValue{
-		Value: val,
-
-		// We mark these as "from input" with the rationale that entering
-		// variable values into the HCP Terraform or Enterprise UI is,
-		// roughly speaking, a similar idea to entering variable values at
-		// the interactive CLI prompts. It's not a perfect correspondance,
-		// but it's closer than the other options.
+		Value:      val,
 		SourceType: terraform.ValueFromCloud,
 	}, diags
 }


### PR DESCRIPTION
This is a quick follow-up to https://github.com/hashicorp/terraform/pull/38490, to remove the outdated comment.

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.15.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
