### PR TITLE
🤖🤖🤖 Close `WriteSnapshotToDir` snapshot file handles

### DIFF
--- a/.changes/v1.16/BUG FIXES-20260506-195131.yaml
+++ b/.changes/v1.16/BUG FIXES-20260506-195131.yaml
@@ -1,0 +1,5 @@
+kind: BUG FIXES
+body: WriteSnapshotToDir now closes modules.json after writes to avoid file descriptor leaks
+time: 2026-05-06T19:51:31-05:00
+custom:
+    Issue: "38302"

--- a/internal/modsdir/manifest.go
+++ b/internal/modsdir/manifest.go
@@ -135,6 +135,7 @@ func ReadManifestSnapshotForDir(dir string) (Manifest, error) {
 		}
 		return nil, err
 	}
+	defer r.Close()
 	return ReadManifestSnapshot(r)
 }
 
@@ -172,12 +173,19 @@ func (m Manifest) WriteSnapshot(w io.Writer) error {
 	return err
 }
 
-func (m Manifest) WriteSnapshotToDir(dir string) error {
+func (m Manifest) WriteSnapshotToDir(dir string) (retErr error) {
 	fn := filepath.Join(dir, ManifestSnapshotFilename)
 	log.Printf("[TRACE] modsdir: writing modules manifest to %s", fn)
 	w, err := os.Create(fn)
 	if err != nil {
 		return err
 	}
-	return m.WriteSnapshot(w)
+	defer func() {
+		if closeErr := w.Close(); closeErr != nil && retErr == nil {
+			retErr = closeErr
+		}
+	}()
+
+	retErr = m.WriteSnapshot(w)
+	return retErr
 }

--- a/internal/modsdir/manifest_test.go
+++ b/internal/modsdir/manifest_test.go
@@ -1,0 +1,77 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package modsdir
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func TestManifestWriteSnapshotToDirReleasesFileHandleWindows(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("windows-specific file handle behavior check")
+	}
+
+	dir := t.TempDir()
+	manifest := Manifest{
+		"": {
+			Key: "root",
+			Dir: dir,
+		},
+	}
+
+	if err := manifest.WriteSnapshotToDir(dir); err != nil {
+		t.Fatalf("failed to write manifest snapshot: %s", err)
+	}
+
+	snapshotPath := filepath.Join(dir, ManifestSnapshotFilename)
+	if err := os.Remove(snapshotPath); err != nil {
+		t.Fatalf("failed to remove snapshot file; file may still be open: %s", err)
+	}
+}
+
+func TestManifestWriteSnapshotToDirDoesNotLeakFileDescriptors(t *testing.T) {
+	if _, err := os.Stat("/proc/self/fd"); err != nil {
+		t.Skip("/proc/self/fd not available")
+	}
+
+	dir := t.TempDir()
+	manifest := Manifest{
+		"": {
+			Key: "root",
+			Dir: dir,
+		},
+	}
+
+	startFDCount, err := countOpenFDs()
+	if err != nil {
+		t.Fatalf("failed to read starting fd count: %s", err)
+	}
+
+	for i := 0; i < 256; i++ {
+		if err := manifest.WriteSnapshotToDir(dir); err != nil {
+			t.Fatalf("failed to write manifest snapshot at iteration %d: %s", i, err)
+		}
+	}
+
+	endFDCount, err := countOpenFDs()
+	if err != nil {
+		t.Fatalf("failed to read ending fd count: %s", err)
+	}
+
+	const toleratedDrift = 32
+	if leaked := endFDCount - startFDCount; leaked > toleratedDrift {
+		t.Fatalf("likely leaked file descriptors; started with %d and ended with %d", startFDCount, endFDCount)
+	}
+}
+
+func countOpenFDs() (int, error) {
+	entries, err := os.ReadDir("/proc/self/fd")
+	if err != nil {
+		return 0, err
+	}
+	return len(entries), nil
+}


### PR DESCRIPTION
Fixes #38302.

This closes the `modules.json` snapshot file on all `WriteSnapshotToDir` return paths and returns close errors after a successful encode when appropriate.

The regression tests cover repeated writes and file-handle release behavior in `internal/modsdir`.

AI usage disclosure: AI assistance was used to inspect the affected code path and draft the initial patch/tests. I reviewed the change, kept the scope to `internal/modsdir`, and tested it locally.

Tested:

- `go test ./internal/modsdir` in a Go 1.25.8 Docker container