### PR TITLE
initial commit for "terraform show -json-redacted"

### DIFF
--- a/.changes/v1.16/ENHANCEMENTS-20260507-115159.yaml
+++ b/.changes/v1.16/ENHANCEMENTS-20260507-115159.yaml
@@ -1,0 +1,5 @@
+kind: ENHANCEMENTS
+body: '`terraform show`: Added a new `-json-redacted` option that preserves the machine-readable JSON but masking sensitive values.'
+time: 2026-05-07T11:51:59.34567-04:00
+custom:
+    Issue: "38537"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,6 @@ Experiments are only enabled in alpha releases of Terraform CLI. The following f
   - Test authors can now specify `backend` blocks within `run` blocks in Terraform Test files. Run blocks with `backend` blocks will load state from the specified backend instead of starting from empty state on every execution. This allows test authors to keep long-running test infrastructure alive between test operations, saving time during regular test operations.
   - Test authors can now specify `skip_cleanup` attributes within test files and within run blocks. The `skip_cleanup` attribute tells `terraform test` not to clean up state files produced by run blocks with this attribute set to true. The state files for affected run blocks will be written to disk within the `.terraform` directory, where they can then be cleaned up manually using the also experimental `terraform test cleanup` command.
 
-ENHANCEMENTS:
-
-- `terraform show`: Added a new `-json-redacted` option that preserves the machine-readable JSON structure while masking sensitive values for both state and plan output.
-
 ## Previous Releases
 
 For information on prior major and minor releases, refer to their changelogs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ Experiments are only enabled in alpha releases of Terraform CLI. The following f
   - Test authors can now specify `backend` blocks within `run` blocks in Terraform Test files. Run blocks with `backend` blocks will load state from the specified backend instead of starting from empty state on every execution. This allows test authors to keep long-running test infrastructure alive between test operations, saving time during regular test operations.
   - Test authors can now specify `skip_cleanup` attributes within test files and within run blocks. The `skip_cleanup` attribute tells `terraform test` not to clean up state files produced by run blocks with this attribute set to true. The state files for affected run blocks will be written to disk within the `.terraform` directory, where they can then be cleaned up manually using the also experimental `terraform test cleanup` command.
 
+ENHANCEMENTS:
+
+- `terraform show`: Added a new `-json-redacted` option that preserves the machine-readable JSON structure while masking sensitive values for both state and plan output.
+
 ## Previous Releases
 
 For information on prior major and minor releases, refer to their changelogs:

--- a/internal/command/arguments/show.go
+++ b/internal/command/arguments/show.go
@@ -16,6 +16,10 @@ type Show struct {
 	// ViewType specifies which output format to use: human, JSON, or "raw".
 	ViewType ViewType
 
+	// RedactSensitive requests that machine-readable output replace sensitive
+	// values with redacted placeholders.
+	RedactSensitive bool
+
 	Vars *Vars
 }
 
@@ -30,8 +34,10 @@ func ParseShow(args []string) (*Show, tfdiags.Diagnostics) {
 	}
 
 	var jsonOutput bool
+	var jsonRedactedOutput bool
 	cmdFlags := extendedFlagSet("show", nil, nil, show.Vars)
 	cmdFlags.BoolVar(&jsonOutput, "json", false, "json")
+	cmdFlags.BoolVar(&jsonRedactedOutput, "json-redacted", false, "json-redacted")
 
 	if err := cmdFlags.Parse(args); err != nil {
 		diags = diags.Append(tfdiags.Sourceless(
@@ -54,7 +60,18 @@ func ParseShow(args []string) (*Show, tfdiags.Diagnostics) {
 		show.Path = args[0]
 	}
 
+	if jsonOutput && jsonRedactedOutput {
+		diags = diags.Append(tfdiags.Sourceless(
+			tfdiags.Error,
+			"Incompatible command-line flags",
+			"The -json and -json-redacted options cannot be used together.",
+		))
+	}
+
 	switch {
+	case jsonRedactedOutput:
+		show.ViewType = ViewJSON
+		show.RedactSensitive = true
 	case jsonOutput:
 		show.ViewType = ViewJSON
 	default:

--- a/internal/command/arguments/show_test.go
+++ b/internal/command/arguments/show_test.go
@@ -27,17 +27,28 @@ func TestParseShow_valid(t *testing.T) {
 		"json": {
 			[]string{"-json"},
 			&Show{
-				Path:     "",
-				ViewType: ViewJSON,
-				Vars:     &Vars{},
+				Path:            "",
+				ViewType:        ViewJSON,
+				RedactSensitive: false,
+				Vars:            &Vars{},
+			},
+		},
+		"json redacted": {
+			[]string{"-json-redacted"},
+			&Show{
+				Path:            "",
+				ViewType:        ViewJSON,
+				RedactSensitive: true,
+				Vars:            &Vars{},
 			},
 		},
 		"path": {
 			[]string{"-json", "foo"},
 			&Show{
-				Path:     "foo",
-				ViewType: ViewJSON,
-				Vars:     &Vars{},
+				Path:            "foo",
+				ViewType:        ViewJSON,
+				RedactSensitive: false,
+				Vars:            &Vars{},
 			},
 		},
 	}
@@ -66,9 +77,10 @@ func TestParseShow_invalid(t *testing.T) {
 		"unknown flag": {
 			[]string{"-boop"},
 			&Show{
-				Path:     "",
-				ViewType: ViewHuman,
-				Vars:     &Vars{},
+				Path:            "",
+				ViewType:        ViewHuman,
+				RedactSensitive: false,
+				Vars:            &Vars{},
 			},
 			tfdiags.Diagnostics{
 				tfdiags.Sourceless(
@@ -81,15 +93,32 @@ func TestParseShow_invalid(t *testing.T) {
 		"too many arguments": {
 			[]string{"-json", "bar", "baz"},
 			&Show{
-				Path:     "bar",
-				ViewType: ViewJSON,
-				Vars:     &Vars{},
+				Path:            "bar",
+				ViewType:        ViewJSON,
+				RedactSensitive: false,
+				Vars:            &Vars{},
 			},
 			tfdiags.Diagnostics{
 				tfdiags.Sourceless(
 					tfdiags.Error,
 					"Too many command line arguments",
 					"Expected at most one positional argument.",
+				),
+			},
+		},
+		"incompatible flags": {
+			[]string{"-json", "-json-redacted"},
+			&Show{
+				Path:            "",
+				ViewType:        ViewJSON,
+				RedactSensitive: true,
+				Vars:            &Vars{},
+			},
+			tfdiags.Diagnostics{
+				tfdiags.Sourceless(
+					tfdiags.Error,
+					"Incompatible command-line flags",
+					"The -json and -json-redacted options cannot be used together.",
 				),
 			},
 		},

--- a/internal/command/show.go
+++ b/internal/command/show.go
@@ -48,7 +48,8 @@ func (e *errUnusableDataMisc) Unwrap() error {
 // contents of a Terraform plan or state file.
 type ShowCommand struct {
 	Meta
-	viewType arguments.ViewType
+	viewType        arguments.ViewType
+	redactSensitive bool
 }
 
 func (c *ShowCommand) Run(rawArgs []string) int {
@@ -64,9 +65,10 @@ func (c *ShowCommand) Run(rawArgs []string) int {
 		return 1
 	}
 	c.viewType = args.ViewType
+	c.redactSensitive = args.RedactSensitive
 
 	// Set up view
-	view := views.NewShow(args.ViewType, c.View)
+	view := views.NewShow(args.ViewType, args.RedactSensitive, c.View)
 
 	loader, err := c.initConfigLoader()
 	if err != nil {
@@ -112,6 +114,8 @@ Options:
   -no-color           If specified, output won't contain any color.
   -json               If specified, output the Terraform plan or state in
                       a machine-readable form.
+  -json-redacted      If specified, output the Terraform plan or state in
+                      a machine-readable form with sensitive values redacted.
 
 `
 	return strings.TrimSpace(helpText)
@@ -283,6 +287,9 @@ func (c *ShowCommand) getPlanFromPath(path string) (*plans.Plan, *cloudplan.Remo
 	if lp, ok := pf.Local(); ok {
 		plan, stateFile, config, err = getDataFromPlanfileReader(lp, c.Meta.AllowExperimentalFeatures, c.Meta.VariableValues)
 	} else if cp, ok := pf.Cloud(); ok {
+		// Request the unredacted external JSON format whenever we are in JSON
+		// output mode (including -json-redacted, which applies redaction after
+		// fetch). Request the redacted human-display format otherwise.
 		redacted := c.viewType != arguments.ViewJSON
 		jsonPlan, err = c.getDataFromCloudPlan(cp, redacted)
 	}

--- a/internal/command/show_test.go
+++ b/internal/command/show_test.go
@@ -750,6 +750,88 @@ func TestShow_json_output_sensitive(t *testing.T) {
 	}
 }
 
+func TestShow_json_redacted_output_sensitive(t *testing.T) {
+	td := t.TempDir()
+	inputDir := "testdata/show-json-sensitive"
+	testCopyDir(t, inputDir, td)
+	t.Chdir(td)
+
+	providerSource := newMockProviderSource(t, map[string][]string{"test": {"1.2.3"}})
+
+	p := showFixtureSensitiveProvider()
+
+	// init
+	ui := new(cli.MockUi)
+	view, _ := testView(t)
+	ic := &InitCommand{
+		Meta: Meta{
+			testingOverrides: metaOverridesForProvider(p),
+			Ui:               ui,
+			View:             view,
+			ProviderSource:   providerSource,
+		},
+	}
+	if code := ic.Run([]string{}); code != 0 {
+		t.Fatalf("init failed\n%s", ui.ErrorWriter)
+	}
+
+	// plan
+	planView, planDone := testView(t)
+	pc := &PlanCommand{
+		Meta: Meta{
+			testingOverrides: metaOverridesForProvider(p),
+			View:             planView,
+			ProviderSource:   providerSource,
+		},
+	}
+
+	args := []string{
+		"-out=terraform.plan",
+	}
+	code := pc.Run(args)
+	planOutput := planDone(t)
+
+	if code != 0 {
+		t.Fatalf("unexpected exit status %d; want 0\ngot: %s", code, planOutput.Stderr())
+	}
+
+	// show
+	showView, showDone := testView(t)
+	sc := &ShowCommand{
+		Meta: Meta{
+			testingOverrides: metaOverridesForProvider(p),
+			View:             showView,
+			ProviderSource:   providerSource,
+		},
+	}
+
+	args = []string{
+		"-json-redacted",
+		"terraform.plan",
+	}
+	defer os.Remove("terraform.plan")
+	code = sc.Run(args)
+	showOutput := showDone(t)
+
+	if code != 0 {
+		t.Fatalf("unexpected exit status %d; want 0\ngot: %s", code, showOutput.Stderr())
+	}
+
+	got := showOutput.Stdout()
+	if strings.Contains(got, `"password":"secret"`) {
+		t.Fatalf("redacted output unexpectedly contains sensitive resource values: %s", got)
+	}
+	if strings.Contains(got, `"constant_value":"secret"`) {
+		t.Fatalf("redacted output unexpectedly contains sensitive configuration values: %s", got)
+	}
+	if strings.Contains(got, `"value":"bar"`) {
+		t.Fatalf("redacted output unexpectedly contains sensitive variable/output values: %s", got)
+	}
+	if !strings.Contains(got, `"after_sensitive":{"ami":true,"password":true}`) {
+		t.Fatalf("redacted output should retain sensitive masks for callers: %s", got)
+	}
+}
+
 func TestShow_json_output_actions(t *testing.T) {
 	td := t.TempDir()
 	inputDir := "testdata/show-json-actions"

--- a/internal/command/state_show.go
+++ b/internal/command/state_show.go
@@ -41,7 +41,7 @@ func (c *StateShowCommand) Run(args []string) int {
 
 	c.Meta.statePath = parsedArgs.StatePath
 	c.viewType = parsedArgs.ViewType
-	view := views.NewShow(parsedArgs.ViewType, c.View)
+	view := views.NewShow(parsedArgs.ViewType, false, c.View)
 
 	// Check for user-supplied plugin path
 	var err error

--- a/internal/command/views/show.go
+++ b/internal/command/views/show.go
@@ -33,10 +33,10 @@ type Show interface {
 	DisplayResourceInstanceState(jsonformat.State, tfdiags.Diagnostics) int
 }
 
-func NewShow(vt arguments.ViewType, view *View) Show {
+func NewShow(vt arguments.ViewType, redactSensitive bool, view *View) Show {
 	switch vt {
 	case arguments.ViewJSON:
-		return &ShowJSON{view: view}
+		return &ShowJSON{view: view, redactSensitive: redactSensitive}
 	case arguments.ViewHuman:
 		return &ShowHuman{view: view}
 	default:
@@ -146,7 +146,8 @@ func (v *ShowHuman) Diagnostics(diags tfdiags.Diagnostics) {
 }
 
 type ShowJSON struct {
-	view *View
+	view            *View
+	redactSensitive bool
 }
 
 var _ Show = (*ShowJSON)(nil)
@@ -156,16 +157,40 @@ func (v *ShowJSON) Display(config *configs.Config, plan *plans.Plan, planJSON *c
 	// to building one ourselves.
 	if planJSON != nil {
 		if planJSON.Redacted {
-			v.view.streams.Eprintf("Didn't get external JSON plan format")
-			return 1
+			// Redacted cloud plan format: only usable for human display.
+			if !v.redactSensitive {
+				v.view.streams.Eprintf("Didn't get external JSON plan format")
+				return 1
+			}
+			// For -json-redacted with a cloud plan, treat the pre-redacted bytes
+			// as already safe to output (sensitive values were stripped server-side).
+			v.view.streams.Println(string(planJSON.JSONBytes))
+		} else {
+			bytes := planJSON.JSONBytes
+			if v.redactSensitive {
+				var err error
+				bytes, err = redactShowJSONBytes(bytes)
+				if err != nil {
+					v.view.streams.Eprintf("Failed to redact plan json: %s", err)
+					return 1
+				}
+			}
+			v.view.streams.Println(string(bytes))
 		}
-		v.view.streams.Println(string(planJSON.JSONBytes))
 	} else if plan != nil {
 		planJSON, err := jsonplan.Marshal(config, plan, stateFile, schemas)
 
 		if err != nil {
 			v.view.streams.Eprintf("Failed to marshal plan to json: %s", err)
 			return 1
+		}
+
+		if v.redactSensitive {
+			planJSON, err = redactShowJSONBytes(planJSON)
+			if err != nil {
+				v.view.streams.Eprintf("Failed to redact plan json: %s", err)
+				return 1
+			}
 		}
 		v.view.streams.Println(string(planJSON))
 	} else {
@@ -175,6 +200,14 @@ func (v *ShowJSON) Display(config *configs.Config, plan *plans.Plan, planJSON *c
 		if err != nil {
 			v.view.streams.Eprintf("Failed to marshal state to json: %s", err)
 			return 1
+		}
+
+		if v.redactSensitive {
+			jsonState, err = redactShowJSONBytes(jsonState)
+			if err != nil {
+				v.view.streams.Eprintf("Failed to redact state json: %s", err)
+				return 1
+			}
 		}
 		v.view.streams.Println(string(jsonState))
 	}

--- a/internal/command/views/show_json_redaction.go
+++ b/internal/command/views/show_json_redaction.go
@@ -1,0 +1,589 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package views
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+)
+
+type orderedField struct {
+	Key   string
+	Value any
+}
+
+type orderedObject []orderedField
+
+func redactShowJSONBytes(input []byte) ([]byte, error) {
+	if len(input) == 0 {
+		return input, nil
+	}
+
+	rootValue, err := parseOrderedJSON(input)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode json for redaction: %w", err)
+	}
+	root, ok := asObject(rootValue)
+	if !ok {
+		return nil, fmt.Errorf("failed to decode json for redaction: root is not an object")
+	}
+
+	if valuesRaw, ok := getField(root, "values"); ok {
+		if values, ok := asObject(valuesRaw); ok {
+			redactStateValues(values, nil)
+		}
+	}
+
+	sensitiveVars := map[string]struct{}{}
+	sensitiveAttrs := map[string]map[string]struct{}{}
+
+	if plannedValuesRaw, ok := getField(root, "planned_values"); ok {
+		if plannedValues, ok := asObject(plannedValuesRaw); ok {
+			redactStateValues(plannedValues, sensitiveAttrs)
+		}
+	}
+
+	if priorStateRaw, ok := getField(root, "prior_state"); ok {
+		if priorState, ok := asObject(priorStateRaw); ok {
+			if valuesRaw, ok := getField(priorState, "values"); ok {
+				if values, ok := asObject(valuesRaw); ok {
+					redactStateValues(values, nil)
+				}
+			}
+		}
+	}
+
+	if outputChangesRaw, ok := getField(root, "output_changes"); ok {
+		if outputChanges, ok := asObject(outputChangesRaw); ok {
+			for _, oc := range outputChanges {
+				change, ok := asObject(oc.Value)
+				if !ok {
+					continue
+				}
+				setField(change, "before", redactByMask(getFieldOrNil(change, "before"), getFieldOrNil(change, "before_sensitive")))
+				setField(change, "after", redactByMask(getFieldOrNil(change, "after"), getFieldOrNil(change, "after_sensitive")))
+			}
+		}
+	}
+
+	if resourceChangesRaw, ok := getField(root, "resource_changes"); ok {
+		if resourceChanges, ok := asSlice(resourceChangesRaw); ok {
+			for _, rcValue := range resourceChanges {
+				rc, ok := asObject(rcValue)
+				if !ok {
+					continue
+				}
+				configAddr := resourceAddressToConfigAddress(getStringField(rc, "address"))
+				changeRaw, ok := getField(rc, "change")
+				if !ok {
+					continue
+				}
+				change, ok := asObject(changeRaw)
+				if !ok {
+					continue
+				}
+				beforeMask := getFieldOrNil(change, "before_sensitive")
+				afterMask := getFieldOrNil(change, "after_sensitive")
+				setField(change, "before", redactByMask(getFieldOrNil(change, "before"), beforeMask))
+				setField(change, "after", redactByMask(getFieldOrNil(change, "after"), afterMask))
+				collectSensitiveAttrsFromMask(configAddr, beforeMask, sensitiveAttrs)
+				collectSensitiveAttrsFromMask(configAddr, afterMask, sensitiveAttrs)
+			}
+		}
+	}
+
+	if deferredChangesRaw, ok := getField(root, "deferred_changes"); ok {
+		if deferredChanges, ok := asSlice(deferredChangesRaw); ok {
+			for _, dcValue := range deferredChanges {
+				dc, ok := asObject(dcValue)
+				if !ok {
+					continue
+				}
+				rcRaw, ok := getField(dc, "resource_change")
+				if !ok {
+					continue
+				}
+				rc, ok := asObject(rcRaw)
+				if !ok {
+					continue
+				}
+				configAddr := resourceAddressToConfigAddress(getStringField(rc, "address"))
+				changeRaw, ok := getField(rc, "change")
+				if !ok {
+					continue
+				}
+				change, ok := asObject(changeRaw)
+				if !ok {
+					continue
+				}
+				beforeMask := getFieldOrNil(change, "before_sensitive")
+				afterMask := getFieldOrNil(change, "after_sensitive")
+				setField(change, "before", redactByMask(getFieldOrNil(change, "before"), beforeMask))
+				setField(change, "after", redactByMask(getFieldOrNil(change, "after"), afterMask))
+				collectSensitiveAttrsFromMask(configAddr, beforeMask, sensitiveAttrs)
+				collectSensitiveAttrsFromMask(configAddr, afterMask, sensitiveAttrs)
+			}
+		}
+	}
+
+	if actionInvocationsRaw, ok := getField(root, "action_invocations"); ok {
+		if actionInvocations, ok := asSlice(actionInvocationsRaw); ok {
+			for _, aiValue := range actionInvocations {
+				ai, ok := asObject(aiValue)
+				if !ok {
+					continue
+				}
+				setField(ai, "config_values", redactByMask(getFieldOrNil(ai, "config_values"), getFieldOrNil(ai, "config_sensitive")))
+			}
+		}
+	}
+
+	if deferredAIsRaw, ok := getField(root, "deferred_action_invocations"); ok {
+		if deferredAIs, ok := asSlice(deferredAIsRaw); ok {
+			for _, daiValue := range deferredAIs {
+				dai, ok := asObject(daiValue)
+				if !ok {
+					continue
+				}
+				aiRaw, ok := getField(dai, "action_invocation")
+				if !ok {
+					continue
+				}
+				ai, ok := asObject(aiRaw)
+				if !ok {
+					continue
+				}
+				setField(ai, "config_values", redactByMask(getFieldOrNil(ai, "config_values"), getFieldOrNil(ai, "config_sensitive")))
+			}
+		}
+	}
+
+	if configurationRaw, ok := getField(root, "configuration"); ok {
+		if configuration, ok := asObject(configurationRaw); ok {
+			if rootModuleRaw, ok := getField(configuration, "root_module"); ok {
+				if rootModule, ok := asObject(rootModuleRaw); ok {
+					redactConfigurationModule(rootModule, sensitiveVars, sensitiveAttrs)
+				}
+			}
+		}
+	}
+
+	if variablesRaw, ok := getField(root, "variables"); ok {
+		if variables, ok := asObject(variablesRaw); ok {
+			for name := range sensitiveVars {
+				if variableValue, exists := getField(variables, name); exists {
+					if variable, ok := asObject(variableValue); ok {
+						setField(variable, "value", nil)
+					}
+				}
+			}
+		}
+	}
+
+	return marshalOrderedJSON(root)
+}
+
+func redactStateValues(values orderedObject, collect map[string]map[string]struct{}) {
+	if outputsRaw, ok := getField(values, "outputs"); ok {
+		if outputs, ok := asObject(outputsRaw); ok {
+			for _, ov := range outputs {
+				output, ok := asObject(ov.Value)
+				if !ok {
+					continue
+				}
+				sensitiveValue, _ := getField(output, "sensitive")
+				sensitive, _ := sensitiveValue.(bool)
+				if sensitive {
+					setField(output, "value", nil)
+				}
+			}
+		}
+	}
+	if rootModuleRaw, ok := getField(values, "root_module"); ok {
+		if rootModule, ok := asObject(rootModuleRaw); ok {
+			redactStateModule(rootModule, collect)
+		}
+	}
+}
+
+func redactStateModule(module orderedObject, collect map[string]map[string]struct{}) {
+	if resourcesRaw, ok := getField(module, "resources"); ok {
+		if resources, ok := asSlice(resourcesRaw); ok {
+			for _, rv := range resources {
+				r, ok := asObject(rv)
+				if !ok {
+					continue
+				}
+				setField(r, "values", redactByMask(getFieldOrNil(r, "values"), getFieldOrNil(r, "sensitive_values")))
+				if collect != nil {
+					collectSensitiveAttrsFromMask(resourceAddressToConfigAddress(getStringField(r, "address")), getFieldOrNil(r, "sensitive_values"), collect)
+				}
+			}
+		}
+	}
+	if childModulesRaw, ok := getField(module, "child_modules"); ok {
+		if childModules, ok := asSlice(childModulesRaw); ok {
+			for _, cv := range childModules {
+				if child, ok := asObject(cv); ok {
+					redactStateModule(child, collect)
+				}
+			}
+		}
+	}
+}
+
+func collectSensitiveAttrsFromMask(resourceAddr string, mask any, target map[string]map[string]struct{}) {
+	if resourceAddr == "" {
+		return
+	}
+	maskObj, ok := asObject(mask)
+	if !ok {
+		return
+	}
+	for _, attr := range maskObj {
+		if !maskContainsSensitive(attr.Value) {
+			continue
+		}
+		if _, exists := target[resourceAddr]; !exists {
+			target[resourceAddr] = map[string]struct{}{}
+		}
+		target[resourceAddr][attr.Key] = struct{}{}
+	}
+}
+
+func maskContainsSensitive(mask any) bool {
+	switch m := mask.(type) {
+	case bool:
+		return m
+	case orderedObject:
+		for _, child := range m {
+			if maskContainsSensitive(child.Value) {
+				return true
+			}
+		}
+	case []any:
+		for _, child := range m {
+			if maskContainsSensitive(child) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func redactConfigurationModule(module orderedObject, sensitiveVars map[string]struct{}, sensitiveAttrs map[string]map[string]struct{}) {
+	if variablesRaw, ok := getField(module, "variables"); ok {
+		if variables, ok := asObject(variablesRaw); ok {
+			for _, variableField := range variables {
+				variable, ok := asObject(variableField.Value)
+				if !ok {
+					continue
+				}
+				sensitiveValue, _ := getField(variable, "sensitive")
+				sensitive, _ := sensitiveValue.(bool)
+				if sensitive {
+					sensitiveVars[variableField.Key] = struct{}{}
+				}
+				if _, shouldRedact := sensitiveVars[variableField.Key]; shouldRedact {
+					if _, hasDefault := getField(variable, "default"); hasDefault {
+						setField(variable, "default", nil)
+					}
+				}
+			}
+		}
+	}
+
+	if resourcesRaw, ok := getField(module, "resources"); ok {
+		if resources, ok := asSlice(resourcesRaw); ok {
+			for _, resourceValue := range resources {
+				resource, ok := asObject(resourceValue)
+				if !ok {
+					continue
+				}
+				attrs := sensitiveAttrs[getStringField(resource, "address")]
+				if len(attrs) == 0 {
+					continue
+				}
+				expressionsRaw, ok := getField(resource, "expressions")
+				if !ok {
+					continue
+				}
+				expressions, ok := asObject(expressionsRaw)
+				if !ok {
+					continue
+				}
+				for attrName := range attrs {
+					expressionValue, exists := getField(expressions, attrName)
+					if !exists {
+						continue
+					}
+					expression, ok := asObject(expressionValue)
+					if !ok {
+						continue
+					}
+					if _, hasConst := getField(expression, "constant_value"); hasConst {
+						setField(expression, "constant_value", nil)
+					}
+				}
+			}
+		}
+	}
+
+	if moduleCallsRaw, ok := getField(module, "module_calls"); ok {
+		if moduleCalls, ok := asObject(moduleCallsRaw); ok {
+			for _, callValue := range moduleCalls {
+				call, ok := asObject(callValue.Value)
+				if !ok {
+					continue
+				}
+				childRaw, ok := getField(call, "module")
+				if !ok {
+					continue
+				}
+				child, ok := asObject(childRaw)
+				if !ok {
+					continue
+				}
+				redactConfigurationModule(child, sensitiveVars, sensitiveAttrs)
+			}
+		}
+	}
+}
+
+func redactByMask(value any, mask any) any {
+	switch m := mask.(type) {
+	case bool:
+		if m {
+			return nil
+		}
+		return value
+	case orderedObject:
+		valueObj, ok := asObject(value)
+		if !ok {
+			return value
+		}
+		for _, child := range m {
+			if childValue, exists := getField(valueObj, child.Key); exists {
+				setField(valueObj, child.Key, redactByMask(childValue, child.Value))
+			}
+		}
+		return valueObj
+	case []any:
+		valueSlice, ok := asSlice(value)
+		if !ok {
+			return value
+		}
+		for i, childMask := range m {
+			if i < len(valueSlice) {
+				valueSlice[i] = redactByMask(valueSlice[i], childMask)
+			}
+		}
+		return valueSlice
+	default:
+		return value
+	}
+}
+
+func resourceAddressToConfigAddress(address string) string {
+	if !strings.HasSuffix(address, "]") {
+		return address
+	}
+	open := strings.LastIndex(address, "[")
+	if open == -1 {
+		return address
+	}
+	return address[:open]
+}
+
+func parseOrderedJSON(input []byte) (any, error) {
+	dec := json.NewDecoder(bytes.NewReader(input))
+	dec.UseNumber()
+
+	v, err := decodeOrderedJSONValue(dec)
+	if err != nil {
+		return nil, err
+	}
+
+	if _, err := dec.Token(); err != io.EOF {
+		if err == nil {
+			return nil, fmt.Errorf("trailing data after json value")
+		}
+		return nil, err
+	}
+
+	return v, nil
+}
+
+func decodeOrderedJSONValue(dec *json.Decoder) (any, error) {
+	tok, err := dec.Token()
+	if err != nil {
+		return nil, err
+	}
+
+	if delim, ok := tok.(json.Delim); ok {
+		switch delim {
+		case '{':
+			obj := orderedObject{}
+			for dec.More() {
+				keyTok, err := dec.Token()
+				if err != nil {
+					return nil, err
+				}
+				key, ok := keyTok.(string)
+				if !ok {
+					return nil, fmt.Errorf("invalid object key token %T", keyTok)
+				}
+				value, err := decodeOrderedJSONValue(dec)
+				if err != nil {
+					return nil, err
+				}
+				obj = append(obj, orderedField{Key: key, Value: value})
+			}
+			endTok, err := dec.Token()
+			if err != nil {
+				return nil, err
+			}
+			if endDelim, ok := endTok.(json.Delim); !ok || endDelim != '}' {
+				return nil, fmt.Errorf("invalid object terminator %v", endTok)
+			}
+			return obj, nil
+		case '[':
+			arr := []any{}
+			for dec.More() {
+				value, err := decodeOrderedJSONValue(dec)
+				if err != nil {
+					return nil, err
+				}
+				arr = append(arr, value)
+			}
+			endTok, err := dec.Token()
+			if err != nil {
+				return nil, err
+			}
+			if endDelim, ok := endTok.(json.Delim); !ok || endDelim != ']' {
+				return nil, fmt.Errorf("invalid array terminator %v", endTok)
+			}
+			return arr, nil
+		default:
+			return nil, fmt.Errorf("unsupported delimiter %q", delim)
+		}
+	}
+
+	return tok, nil
+}
+
+func marshalOrderedJSON(v any) ([]byte, error) {
+	var buf bytes.Buffer
+	if err := writeOrderedJSONValue(&buf, v); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+func writeOrderedJSONValue(buf *bytes.Buffer, v any) error {
+	switch tv := v.(type) {
+	case nil:
+		buf.WriteString("null")
+	case bool:
+		if tv {
+			buf.WriteString("true")
+		} else {
+			buf.WriteString("false")
+		}
+	case string:
+		b, err := json.Marshal(tv)
+		if err != nil {
+			return err
+		}
+		buf.Write(b)
+	case json.Number:
+		buf.WriteString(tv.String())
+	case float64, float32, int, int32, int64, uint, uint32, uint64:
+		b, err := json.Marshal(tv)
+		if err != nil {
+			return err
+		}
+		buf.Write(b)
+	case orderedObject:
+		buf.WriteByte('{')
+		for i, field := range tv {
+			if i > 0 {
+				buf.WriteByte(',')
+			}
+			keyBytes, err := json.Marshal(field.Key)
+			if err != nil {
+				return err
+			}
+			buf.Write(keyBytes)
+			buf.WriteByte(':')
+			if err := writeOrderedJSONValue(buf, field.Value); err != nil {
+				return err
+			}
+		}
+		buf.WriteByte('}')
+	case []any:
+		buf.WriteByte('[')
+		for i, elem := range tv {
+			if i > 0 {
+				buf.WriteByte(',')
+			}
+			if err := writeOrderedJSONValue(buf, elem); err != nil {
+				return err
+			}
+		}
+		buf.WriteByte(']')
+	default:
+		b, err := json.Marshal(tv)
+		if err != nil {
+			return err
+		}
+		buf.Write(b)
+	}
+	return nil
+}
+
+func getField(obj orderedObject, key string) (any, bool) {
+	for _, field := range obj {
+		if field.Key == key {
+			return field.Value, true
+		}
+	}
+	return nil, false
+}
+
+func getStringField(obj orderedObject, key string) string {
+	v, ok := getField(obj, key)
+	if !ok {
+		return ""
+	}
+	s, _ := v.(string)
+	return s
+}
+
+func getFieldOrNil(obj orderedObject, key string) any {
+	v, _ := getField(obj, key)
+	return v
+}
+
+func setField(obj orderedObject, key string, value any) {
+	for i := range obj {
+		if obj[i].Key == key {
+			obj[i].Value = value
+			return
+		}
+	}
+}
+
+func asObject(v any) (orderedObject, bool) {
+	obj, ok := v.(orderedObject)
+	return obj, ok
+}
+
+func asSlice(v any) ([]any, bool) {
+	s, ok := v.([]any)
+	return s, ok
+}

--- a/internal/command/views/show_test.go
+++ b/internal/command/views/show_test.go
@@ -99,7 +99,7 @@ func TestShowHuman(t *testing.T) {
 			streams, done := terminal.StreamsForTesting(t)
 			view := NewView(streams)
 			view.Configure(&arguments.View{NoColor: true})
-			v := NewShow(arguments.ViewHuman, view)
+			v := NewShow(arguments.ViewHuman, false, view)
 
 			code := v.Display(nil, testCase.plan, testCase.jsonPlan, testCase.stateFile, testCase.schemas)
 			if code != 0 {
@@ -177,7 +177,7 @@ func TestShowJSON(t *testing.T) {
 			streams, done := terminal.StreamsForTesting(t)
 			view := NewView(streams)
 			view.Configure(&arguments.View{NoColor: true})
-			v := NewShow(arguments.ViewJSON, view)
+			v := NewShow(arguments.ViewJSON, false, view)
 
 			schemas := &terraform.Schemas{
 				Providers: map[addrs.Provider]providers.ProviderSchema{


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

This adds a new flag `-json-redacted` to `terraform show`. This mimics the output of `terraform show -json` but redacts sensitive values. Historically, showing those sensitive values made sense when the assumption was that it was being executed in a machine readable context, but this becomes significantly more dangerous when being executed in an agentic context - hence this new flag.

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Fixes #

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.16.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [x] This change is user-facing and I added a changelog entry.
- [ ] This change is not user-facing.
