### PR TITLE
command: add -net-mirror flag to `terraform providers mirror`

### DIFF
--- a/internal/command/arguments/providers_mirror.go
+++ b/internal/command/arguments/providers_mirror.go
@@ -8,9 +8,10 @@ import "github.com/hashicorp/terraform/internal/tfdiags"
 // ProvidersMirror represents the command-line arguments for the providers
 // mirror command.
 type ProvidersMirror struct {
-	Platforms FlagStringSlice
-	LockFile  bool
-	OutputDir string
+	Platforms    FlagStringSlice
+	LockFile     bool
+	NetMirrorURL string
+	OutputDir    string
 
 	// Vars are the variable-related flags (-var, -var-file).
 	Vars *Vars
@@ -28,6 +29,7 @@ func ParseProvidersMirror(args []string) (*ProvidersMirror, tfdiags.Diagnostics)
 	cmdFlags := extendedFlagSet("providers mirror", nil, nil, providersMirror.Vars)
 	cmdFlags.Var(&providersMirror.Platforms, "platform", "target platform")
 	cmdFlags.BoolVar(&providersMirror.LockFile, "lock-file", true, "use lock file")
+	cmdFlags.StringVar(&providersMirror.NetMirrorURL, "net-mirror", "", "network mirror base URL")
 
 	if err := cmdFlags.Parse(args); err != nil {
 		diags = diags.Append(tfdiags.Sourceless(

--- a/internal/command/arguments/providers_mirror_test.go
+++ b/internal/command/arguments/providers_mirror_test.go
@@ -37,6 +37,15 @@ func TestParseProvidersMirror_valid(t *testing.T) {
 				Vars:      &Vars{},
 			},
 		},
+		"net-mirror": {
+			[]string{"-net-mirror=https://mirror.example.com/", "./mirror"},
+			&ProvidersMirror{
+				NetMirrorURL: "https://mirror.example.com/",
+				LockFile:     true,
+				OutputDir:    "./mirror",
+				Vars:         &Vars{},
+			},
+		},
 	}
 
 	cmpOpts := cmpopts.IgnoreUnexported(Vars{})

--- a/internal/command/providers_mirror.go
+++ b/internal/command/providers_mirror.go
@@ -114,13 +114,36 @@ func (c *ProvidersMirrorCommand) Run(args []string) int {
 		return 1
 	}
 
-	// Unlike other commands, this command always consults the origin registry
-	// for every provider so that it can be used to update a local mirror
-	// directory without needing to first disable that local mirror
-	// in the CLI configuration.
-	source := getproviders.NewMemoizeSource(
-		getproviders.NewRegistrySource(c.Services),
-	)
+	// Unlike other commands, this command ignores the installation methods
+	// configured in the CLI configuration and instead chooses an installation
+	// method based on CLI options.
+	//
+	// By default it consults the origin registry for every provider so that
+	// it can be used to update a local mirror directory without needing to
+	// first disable that local mirror in the CLI configuration. With
+	// -net-mirror, it consults the given network mirror instead, which is
+	// useful when re-mirroring from an existing internal network mirror.
+	var source getproviders.Source
+	switch {
+	case parsedArgs.NetMirrorURL != "":
+		u, err := url.Parse(parsedArgs.NetMirrorURL)
+		if err != nil || u.Scheme != "https" {
+			diags = diags.Append(tfdiags.Sourceless(
+				tfdiags.Error,
+				"Invalid network mirror URL",
+				"The -net-mirror option requires a valid https: URL as the mirror base URL.",
+			))
+			c.showDiagnostics(diags)
+			return 1
+		}
+		source = getproviders.NewMemoizeSource(
+			getproviders.NewHTTPMirrorSource(u, c.Services.CredentialsSource()),
+		)
+	default:
+		source = getproviders.NewMemoizeSource(
+			getproviders.NewRegistrySource(c.Services),
+		)
+	}
 
 	// Providers from registries always use HTTP, so we don't need the full
 	// generality of go-getter but it's still handy to use the HTTP getter
@@ -393,6 +416,11 @@ Options:
                       By default the mirror command will use the version info
                       in the lock file if the configuration directory has been
                       previously initialized.
+
+  -net-mirror=url     Consult the given network mirror to obtain providers
+                      instead of contacting their origin registries. The URL
+                      must use the https: scheme. This is useful for
+                      re-mirroring from an existing internal network mirror.
 
   -var 'foo=bar'      Set a value for one of the input variables in the root
                       module of the configuration. Use this option more than


### PR DESCRIPTION
🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary

Adds a `-net-mirror=<url>` flag to `terraform providers mirror`, allowing the command to fetch provider packages from a network mirror instead of always contacting the origin registry. This brings parity with `terraform providers lock`, which already supports `-net-mirror` (and `-fs-mirror`).

The new flag is useful for re-mirroring from an existing internal network mirror — for example, populating a fresh filesystem mirror from a corporate mirror without first having to disable that mirror in CLI config or hit the public registry.

Fixes #36006

## Changes

- `internal/command/arguments/providers_mirror.go`: new `NetMirrorURL` field and `-net-mirror` flag.
- `internal/command/providers_mirror.go`: source selection is now a switch — when `-net-mirror=<url>` is set (and validated as `https:`), use `getproviders.NewHTTPMirrorSource` with the CLI's credentials source; otherwise fall back to the existing `NewRegistrySource` behavior. Help text updated.
- `internal/command/arguments/providers_mirror_test.go`: added a `net-mirror` test case.

The download path needed no changes: `HTTPMirrorSource.PackageMeta()` returns `PackageHTTPURL` (resolved to absolute) just like the registry source, and hash-based `PackageHashAuthentication` works through the existing `meta.Authentication.AuthenticatePackage()` call.

## Target Release

1.16.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

No changes to security controls. The new flag enforces `https:`-only URLs (matching the existing `-net-mirror` behavior in `providers lock`), and provider package authentication via the network mirror's hash list is performed by the existing `PackageHashAuthentication` path.

## CHANGELOG entry

- [x] This change is user-facing and I added a changelog entry. *(to follow — happy to add a `npx changie new` ENHANCEMENT entry under `.changes/v1.XX/` once a reviewer confirms the right target version directory)*
- [ ] This change is not user-facing.

## Test plan

- [x] `go test ./internal/command/arguments/... -run TestParseProvidersMirror`
- [x] `go test ./internal/command/ -run TestProvidersMirror`
- [ ] Manual smoke test: serve a previously-generated mirror directory via `python3 -m http.server` behind HTTPS and run `terraform providers mirror -net-mirror=https://.../ ./out`, confirm packages download and JSON indexes are written.

🤖 Generated with [Claude Code](https://claude.com/claude-code)