### PR TITLE
Redact private key material from SSH error messages

### DIFF
--- a/.changes/v1.16/BUG FIXES-20260511-064314-2.yaml
+++ b/.changes/v1.16/BUG FIXES-20260511-064314-2.yaml
@@ -1,0 +1,5 @@
+kind: BUG FIXES
+body: 'communicator/ssh: Redact private key and certificate material from error messages to prevent credential exposure in logs'
+time: 2026-05-11T06:26:00.000000Z
+custom:
+    Issue: "38543"

--- a/internal/communicator/ssh/provisioner.go
+++ b/internal/communicator/ssh/provisioner.go
@@ -397,22 +397,22 @@ func buildSSHClientConfig(opts sshClientConfigOpts) (*ssh.ClientConfig, error) {
 func signCertWithPrivateKey(pk string, certificate string) (ssh.AuthMethod, error) {
 	rawPk, err := ssh.ParseRawPrivateKey([]byte(pk))
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse private key %q: %s", pk, err)
+		return nil, fmt.Errorf("failed to parse private key: %s", err)
 	}
 
 	pcert, _, _, _, err := ssh.ParseAuthorizedKey([]byte(certificate))
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse certificate %q: %s", certificate, err)
+		return nil, fmt.Errorf("failed to parse certificate: %s", err)
 	}
 
 	usigner, err := ssh.NewSignerFromKey(rawPk)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create signer from raw private key %q: %s", rawPk, err)
+		return nil, fmt.Errorf("failed to create signer from private key: %s", err)
 	}
 
 	ucertSigner, err := ssh.NewCertSigner(pcert.(*ssh.Certificate), usigner)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create cert signer %q: %s", usigner, err)
+		return nil, fmt.Errorf("failed to create cert signer: %s", err)
 	}
 
 	return ssh.PublicKeys(ucertSigner), nil


### PR DESCRIPTION
`signCertWithPrivateKey()` in the SSH communicator formats private key
content, certificate content, and parsed key structs into error messages
using `%q`. These error strings propagate to terminal output and CI logs
(GitHub Actions, Jenkins, etc.), exposing credential material to anyone
with log access.

This commit removes the sensitive values from the four `fmt.Errorf` calls
in the function. The underlying `golang.org/x/crypto/ssh` error (still
included via `%s`) already describes the failure cause (malformed PEM,
unsupported algorithm, key/cert type mismatch), so no diagnostic
information is lost. The four distinct error prefixes still identify
which step failed.

The sibling function `readPrivateKey()` was already safe (it only formats
`err`, not the key content).

Related redaction work in this repo:
- #30067 - Redact sensitive values from function errors

Similar fix in other projects:
- [moby/moby#33884](https://github.com/moby/moby/pull/33884) - Redact secret data on "secret create"

## Target Release

1.16.x

## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Yes. This change prevents private key material from being exposed in error
messages that appear in terminal output and CI/CD logs.

## CHANGELOG entry

- [x] This change is not user-facing.