### PR TITLE
Fix lost renewal diagnostics for ephemeral resources

### DIFF
--- a/.changes/v1.16/BUG FIXES-20260511-064322-3.yaml
+++ b/.changes/v1.16/BUG FIXES-20260511-064322-3.yaml
@@ -1,0 +1,5 @@
+kind: BUG FIXES
+body: Fix lost renewal diagnostics for ephemeral resources where Append return value was discarded
+time: 2026-05-11T06:27:00.000000Z
+custom:
+    Issue: "38544"

--- a/internal/resources/ephemeral/ephemeral_resources.go
+++ b/internal/resources/ephemeral/ephemeral_resources.go
@@ -246,7 +246,7 @@ func (r *resourceInstanceInternal) handleRenewal(ctx context.Context, wg *sync.W
 			// It's time to renew
 			r.renewMu.Lock()
 			anotherRenew, diags := r.impl.Renew(ctx, *nextRenew)
-			r.renewDiags.Append(diags)
+			r.renewDiags = r.renewDiags.Append(diags)
 			if diags.HasErrors() {
 				// If renewal fails then we'll stop trying to renew.
 				r.renewCancel = noopCancel


### PR DESCRIPTION
`tfdiags.Diagnostics.Append()` returns a new slice; it does not modify
the receiver. In `handleRenewal`, the return value was discarded:

```go
r.renewDiags.Append(diags)  // return value lost
```

This silently dropped all renewal error diagnostics, causing two
downstream effects:

- `InstanceValue` (line 105) incorrectly reported the resource as
  live after a failed renewal, because `renewDiags.HasErrors()`
  was always false
- `close` (line 225) lost all renewal diagnostics when surfacing
  errors to the caller

The correct pattern is used on line 270 of the same file:
```go
r.renewDiags = r.renewDiags.Append(ctx.Err())
```

The bug was introduced in 0e80c0b791 (2024-09-16, initial ephemeral
resources implementation) and has been present since.

## Target Release

1.16.x

## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

No changes to security controls.

## CHANGELOG entry

- [x] This change is not user-facing.