### PR TITLE
Fix data race in checks.State.ObjectFailureMessages

### DIFF
--- a/.changes/v1.16/BUG FIXES-20260511-064331-4.yaml
+++ b/.changes/v1.16/BUG FIXES-20260511-064331-4.yaml
@@ -1,0 +1,5 @@
+kind: BUG FIXES
+body: Fix data race in checks.State.ObjectFailureMessages by acquiring mutex before reading shared state
+time: 2026-05-11T06:28:00.000000Z
+custom:
+    Issue: "38545"

--- a/internal/checks/state.go
+++ b/internal/checks/state.go
@@ -258,6 +258,9 @@ func (c *State) ObjectCheckStatus(addr addrs.Checkable) Status {
 // ObjectCheckStatus's result because errors are defined as "stronger"
 // than failures.
 func (c *State) ObjectFailureMessages(addr addrs.Checkable) []string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
 	var ret []string
 
 	configAddr := addr.ConfigCheckable()


### PR DESCRIPTION
`ObjectFailureMessages` reads `c.statuses` and `c.failureMsgs` without
acquiring `c.mu`, while `ReportCheckResult` and `ReportCheckFailure`
write to these fields under the lock from graph walk goroutines. Every
other public method on `*State` acquires `c.mu.Lock()` /
`defer c.mu.Unlock()`.

Added the missing lock acquisition to match the pattern used by all
sibling methods. No deadlock risk: `ObjectFailureMessages` does not call
back into any `*State` method, and its sole caller (`NewCheckResults`)
acquires and releases the lock independently for each method call.

The bug was introduced in #31268 (2022-06-16) and has been present for
nearly 3 years.

Related race condition fixes in this repo:
- #37759 - fix race condition in tests and capture errors from hooks
- #37549 - fix race condition in deferred action test case

## Target Release

1.16.x

## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

No changes to security controls.

## CHANGELOG entry

- [x] This change is not user-facing.