### PR TITLE
🤖🤖🤖 e2e: isolate TestInitProvidersLocalOnly from host plugin dirs (#37501)

### DIFF
--- a/internal/command/e2etest/init_test.go
+++ b/internal/command/e2etest/init_test.go
@@ -166,13 +166,21 @@ func TestInitProvidersLocalOnly(t *testing.T) {
 		t.Fatalf("unexpected error: %s", err)
 	}
 
-	// If you run this test on a workstation with a plugin-cache directory
-	// configured, it will leave a bad directory behind and terraform init will
-	// not work until you remove it.
-	//
-	// To avoid this, we will  "zero out" any existing cli config file by
-	// passing in an empty override file.
-	configFile := emptyConfigFileForTests(t, wantMachineDir)
+	// Pin every host-discoverable provider search location into a
+	// per-test isolated tmpdir. Without this the implicit local
+	// provider source (see implicitProviderSource in
+	// provider_source.go) walks the developer's real $HOME and XDG
+	// data dirs, which can cause unrelated plugins on the host to
+	// participate in the install plan and produce confusing failures.
+	// See GH-37501.
+	isolated := tf.IsolateLocalProviderEnv(t)
+
+	// We still want the explicit CLI-config layer neutralised too:
+	// TF_CLI_CONFIG_FILE bypasses the discovery walk entirely and
+	// points at a single, blank .terraformrc. Combined with
+	// IsolateLocalProviderEnv above this gives the test a fully
+	// hermetic provider-source environment.
+	configFile := emptyConfigFileForTests(t, isolated)
 	tf.AddEnv(fmt.Sprintf("TF_CLI_CONFIG_FILE=%s", configFile))
 
 	stdout, stderr, err := tf.Run("init")

--- a/internal/e2e/e2e.go
+++ b/internal/e2e/e2e.go
@@ -129,6 +129,79 @@ func (b *binary) RemoveEnv(name string) {
 	}
 }
 
+// IsolateLocalProviderEnv configures the binary's environment so that
+// Terraform's "implicit" local provider search (see
+// implicitProviderSource in provider_source.go) cannot reach any
+// directory that exists outside of this test's temporary tree.
+//
+// Without this isolation, the e2e tests that exercise local-only provider
+// installation can be perturbed by host-machine state: a real
+// $HOME/.terraform.d/plugins, an XDG-located plugins directory, or a
+// macOS ~/Library/Application Support/io.terraform/plugins entry on the
+// developer's workstation will be discovered by the test binary and
+// participate in the install plan. Historically that has caused
+// confusing "Failed to query available provider packages" failures and
+// other intermittent breakage; see GH-37501 for context.
+//
+// We isolate by pointing every environment variable consulted by
+// terraform's CLI-config and provider-discovery code paths at a fresh,
+// empty per-test directory:
+//
+//   - HOME (Linux/macOS): controls cliconfig.ConfigDir() (i.e.
+//     ~/.terraformrc and ~/.terraform.d/plugins) and macOS userdirs
+//     (~/Library/Application Support/io.terraform).
+//   - XDG_* (Linux): consulted by go-userdirs to compute the XDG data
+//     and config search paths.
+//   - APPDATA / LOCALAPPDATA (Windows): consulted by go-userdirs for
+//     the Windows known-folder hierarchy.
+//
+// In addition, callers usually combine this with TF_CLI_CONFIG_FILE
+// pointing at a blank .terraformrc to neutralise the explicit CLI
+// configuration mechanism. Tests that previously did that themselves
+// can keep doing so; this method only addresses the implicit
+// discovery layer that TF_CLI_CONFIG_FILE does NOT cover.
+//
+// The returned path is the empty isolated home directory, so callers
+// that want to drop a custom file under it (for example a synthetic
+// .terraformrc) can do so. The directory is registered with t.TempDir
+// machinery so it's automatically cleaned up when the test ends.
+func (b *binary) IsolateLocalProviderEnv(t testing.TB) string {
+	t.Helper()
+	isolated := t.TempDir()
+
+	// HOME is consulted by cliconfig.ConfigDir on Linux/macOS for
+	// ~/.terraformrc and ~/.terraform.d/plugins, and by go-userdirs's
+	// macOS backend for ~/Library/Application Support/io.terraform.
+	b.AddEnv("HOME=" + isolated)
+
+	// go-userdirs's XDG (Linux) backend prefers these env vars over
+	// HOME-derived defaults; if any of them point at a real directory
+	// on the developer's machine the test will inherit those plugin
+	// paths. We pin them to empty strings so the library falls back to
+	// XDG-spec defaults under our isolated $HOME (which we know is
+	// empty), matching the no-XDG-set unit-test scenario in
+	// go-userdirs/userdirs/app_unix_test.go.
+	for _, name := range []string{
+		"XDG_DATA_HOME",
+		"XDG_DATA_DIRS",
+		"XDG_CONFIG_HOME",
+		"XDG_CONFIG_DIRS",
+		"XDG_CACHE_HOME",
+	} {
+		b.AddEnv(name + "=")
+	}
+
+	// Windows known-folder vars consulted by go-userdirs's windows
+	// backend. The test suite is documented as Linux/macOS only (see
+	// CONTRIBUTING.md) but we set these defensively so that anyone
+	// running these tests on Windows in the future gets the same
+	// isolation.
+	b.AddEnv("APPDATA=" + isolated)
+	b.AddEnv("LOCALAPPDATA=" + isolated)
+
+	return isolated
+}
+
 // Cmd returns an exec.Cmd pre-configured to run the generated Terraform
 // binary with the given arguments in the temporary working directory.
 //

--- a/internal/e2e/e2e_test.go
+++ b/internal/e2e/e2e_test.go
@@ -1,0 +1,96 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package e2e
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestIsolateLocalProviderEnv asserts that IsolateLocalProviderEnv
+// installs the specific environment-variable overrides we rely on to
+// neutralise host-machine state during e2e tests. The set is derived
+// from cliconfig.ConfigDir's HOME usage and from go-userdirs's
+// per-platform search paths; if either of those grows a new variable
+// in future, this test pins the contract so callers know to update
+// the helper.
+//
+// We don't shell out here — the goal is just to confirm the helper
+// touches the env table the way Cmd() will later read it. The
+// integration of the helper with TestInitProvidersLocalOnly itself
+// is the load-bearing acceptance test (a hostile HOME with a
+// conflicting plugin in ~/.terraform.d/plugins makes that test fail
+// on origin/main and pass on this branch — see GH-37501).
+func TestIsolateLocalProviderEnv(t *testing.T) {
+	b := &binary{}
+	got := b.IsolateLocalProviderEnv(t)
+	if got == "" {
+		t.Fatalf("IsolateLocalProviderEnv returned empty path")
+	}
+
+	want := []string{
+		"HOME=",
+		"XDG_DATA_HOME=",
+		"XDG_DATA_DIRS=",
+		"XDG_CONFIG_HOME=",
+		"XDG_CONFIG_DIRS=",
+		"XDG_CACHE_HOME=",
+		"APPDATA=",
+		"LOCALAPPDATA=",
+	}
+	for _, prefix := range want {
+		found := false
+		for _, e := range b.env {
+			if strings.HasPrefix(e, prefix) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("expected env entry with prefix %q to be set; have: %v", prefix, b.env)
+		}
+	}
+
+	// HOME, APPDATA, and LOCALAPPDATA must point at the returned
+	// isolated tmpdir so that any code path which derives further
+	// directories from them lands inside the tmpdir rather than at
+	// the real user home.
+	for _, name := range []string{"HOME", "APPDATA", "LOCALAPPDATA"} {
+		want := name + "=" + got
+		found := false
+		for _, e := range b.env {
+			if e == want {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("expected %q in env, got entries: %v", want, b.env)
+		}
+	}
+
+	// XDG_* must be set to empty strings so the unix backend of
+	// go-userdirs falls back to spec defaults under the isolated
+	// HOME (see go-userdirs/userdirs/app_unix_test.go for the same
+	// no-XDG-set scenario).
+	for _, name := range []string{
+		"XDG_DATA_HOME",
+		"XDG_DATA_DIRS",
+		"XDG_CONFIG_HOME",
+		"XDG_CONFIG_DIRS",
+		"XDG_CACHE_HOME",
+	} {
+		want := name + "="
+		found := false
+		for _, e := range b.env {
+			if e == want {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("expected %q (empty) in env, got entries: %v", want, b.env)
+		}
+	}
+}


### PR DESCRIPTION
Fixes #37501

## Target Release

1.16.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

No. This is a test-only change. The new helper only manipulates the environment table that the e2e test harness passes to a child Terraform process; it adds no new code path inside the Terraform binary itself.

## CHANGELOG entry

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.

(Test reliability only — please apply `no-changelog-needed`.)

## Summary

`TestInitProvidersLocalOnly` is documented to be self-contained but in practice can be perturbed by host-machine state: a real `~/.terraform.d/plugins` entry, an XDG-located plugins directory, or a macOS `~/Library/Application Support/io.terraform/plugins` entry on a developer's workstation will be picked up by Terraform's *implicit* local provider source (see `implicitProviderSource` in `provider_source.go`) and participate in the install plan. PR #37461 acknowledged this and added an explanatory log line; the follow-up issue #37501 tracked the long-term fix that was suggested in review:

> "for a long-term solution I'd rather see us do something else, like pass in a custom path to a tmpdir or blank `.terraformrc` file (whatever is actually supported) to override automatic discovery" — @mildwonkey on #37461

This PR implements that: a new `binary.IsolateLocalProviderEnv` helper on the e2e harness pins every host-discoverable env var consulted by `cliconfig.ConfigDir` and `go-userdirs` to a per-test tmpdir. `TestInitProvidersLocalOnly` calls the helper alongside its existing `TF_CLI_CONFIG_FILE` override so its provider-discovery surface is now fully hermetic.

## Why this is needed

The existing `TF_CLI_CONFIG_FILE` override only neutralises **explicit** CLI configuration (the `.terraformrc` discovery walk). The **implicit** discovery layer in `implicitProviderSource` is untouched by `TF_CLI_CONFIG_FILE` — it independently reads:

- `cliconfig.ConfigDir()` → derived from `$HOME` (`~/.terraform.d/plugins`)
- `userdirs.ForApp("Terraform", "HashiCorp", "io.terraform").DataSearchPaths("plugins")` → derived from `$HOME` on macOS, from XDG vars on Linux, from `%APPDATA%`/`%LOCALAPPDATA%` on Windows

Anything found under those paths is added as a `getproviders.MultiSourceSelector` and the corresponding provider is excluded from registry installation, with predictable confusing failures when the host's version is incomplete or differs from what the fixture expects.

The fix scrubs all of those locations in one place, with a comment block in `e2e.go` documenting the contract for future readers and a unit test pinning the env-var set so any future addition (e.g. a new XDG variable consulted by go-userdirs) is caught immediately.

## Changes

- `internal/e2e/e2e.go`: add `(*binary).IsolateLocalProviderEnv(t)` — sets `HOME`, `XDG_*`, `APPDATA`, `LOCALAPPDATA` to point at a fresh `t.TempDir()`. Returns the path so callers can drop synthetic config files into it (which is what the updated test does).
- `internal/e2e/e2e_test.go`: new unit test `TestIsolateLocalProviderEnv` that asserts the helper installs every env entry we rely on. Documents the contract so future maintainers know to update the helper if `cliconfig.ConfigDir` or `go-userdirs` grow new variables.
- `internal/command/e2etest/init_test.go`: `TestInitProvidersLocalOnly` now calls `tf.IsolateLocalProviderEnv(t)` first and writes its blank `.terraformrc` into the returned tmpdir. The misleading "if you run this on a workstation with a plugin-cache directory configured, it will leave a bad directory behind" comment is removed (it's no longer accurate — host plugin-cache state is now fully scoped out).

I deliberately scoped this to `TestInitProvidersLocalOnly` only — the test specifically named in the issue. Other init-related tests in the same file (`TestInitProviders`, `TestInitProvidersInternal`, `TestInitProvidersVendored`, `TestInitProvidersCustomMethod`) use the same `emptyConfigFileForTests` pattern and would benefit from the same isolation; happy to migrate them in a follow-up PR if maintainers prefer.

## Reproduce BEFORE/AFTER yourself (copy-paste)

A reviewer can verify this fix end-to-end by pasting the block below. The only thing that changes between BEFORE and AFTER is the checked-out git ref.

```bash
# --- one-time setup ---
git clone https://github.com/hashicorp/terraform.git /tmp/repro && cd /tmp/repro
git fetch https://github.com/jbbqqf/terraform.git feat/37501-e2e-isolate-local-provider-env
export GOCACHE=$(mktemp -d) TMPDIR=$(mktemp -d)

# Build a hostile $HOME with a plugin that conflicts with the
# fixture's example.com/awesomecorp/happycloud v1.2.0:
HOSTILE=$(mktemp -d)
mkdir -p "$HOSTILE/.terraform.d/plugins/example.com/awesomecorp/happycloud/9.9.9/$(go env GOOS)_$(go env GOARCH)"
echo fake > "$HOSTILE/.terraform.d/plugins/example.com/awesomecorp/happycloud/9.9.9/$(go env GOOS)_$(go env GOARCH)/terraform-provider-happycloud_v9.9.9"
chmod +x "$HOSTILE/.terraform.d/plugins/example.com/awesomecorp/happycloud/9.9.9/$(go env GOOS)_$(go env GOARCH)/terraform-provider-happycloud_v9.9.9"

# --- BEFORE (origin/main) ---
git checkout origin/main
HOME="$HOSTILE" go test -count=1 -run TestInitProvidersLocalOnly -v ./internal/command/e2etest/
# Expected: --- FAIL: TestInitProvidersLocalOnly ; "provider download message is missing"
#           plus a "Warning: Incomplete lock file information for providers" message

# --- AFTER (this PR) ---
git checkout FETCH_HEAD
HOME="$HOSTILE" go test -count=1 -run TestInitProvidersLocalOnly -v ./internal/command/e2etest/
# Expected: --- PASS: TestInitProvidersLocalOnly

# --- AND: helper unit test ---
go test -count=1 -run TestIsolateLocalProviderEnv -v ./internal/e2e/
# Expected: --- PASS: TestIsolateLocalProviderEnv
```

## What I ran locally

```
$ HOME=$(mktemp -d) go test -count=1 -short ./internal/command/e2etest/
ok  	github.com/hashicorp/terraform/internal/command/e2etest	119.328s

$ go test -count=1 -v ./internal/e2e/
--- PASS: TestIsolateLocalProviderEnv (0.00s)
ok  	github.com/hashicorp/terraform/internal/e2e	0.009s

$ HOME=$(mktemp -d) go test -count=1 -run 'TestInitProviders|TestInitProvidersInternal|TestInitProvidersLocalOnly|TestInitProvidersCustomMethod|TestInitProvidersVendored' -v ./internal/command/e2etest/
--- PASS: TestInitProvidersInternal (0.03s)
--- PASS: TestInitProvidersLocalOnly (0.04s)
--- PASS: TestInitProvidersCustomMethod (0.07s)
--- SKIP: TestInitProviders (0.00s)            (network-skipped without TF_ACC)
--- SKIP: TestInitProvidersVendored (0.00s)    (network-skipped without TF_ACC)

$ go vet ./internal/e2e/ ./internal/command/e2etest/
(no output)

$ go build ./...
(no output)
```

## Edge cases tested

| # | Scenario | Input | Expected | Verified by |
|---|----------|-------|----------|-------------|
| 1 | Clean host (no `~/.terraform.d`) | `HOME=$(mktemp -d)` | test passes; install message present | `go test -run TestInitProvidersLocalOnly` |
| 2 | Hostile host with conflicting provider | `HOME=$HOSTILE` (with `~/.terraform.d/plugins/example.com/awesomecorp/happycloud/9.9.9/...`) | test passes; v1.2.0 still installed | reproducer block above (AFTER section) |
| 3 | Same hostile host on `origin/main` | identical | test FAILS — establishes regression baseline | reproducer block above (BEFORE section) |
| 4 | Helper contract pin | constructed `binary{}` | every documented env var present | `TestIsolateLocalProviderEnv` |

## Risk / blast radius

Test-only. The new helper is a method on the e2e test harness; no production code path is affected. The harness is consumed exclusively by tests under `internal/command/e2etest` and `internal/cloud/e2e` (the latter does not call this helper and is unchanged).

## Release note

```release-note
no-changelog-needed
```

---

🤖🤖🤖

*PR drafted with assistance from Claude Code (Anthropic). The change was reviewed manually against `hashicorp/terraform`'s source: `provider_source.go:144-163` for the implicit local provider source, `internal/command/cliconfig/config_unix.go:21-34` for `ConfigDir`/`homeDir`, and the `go-userdirs` library at `userdirs/app_unix.go` and `userdirs/app_darwin.go` to confirm the env-var set. The reproducer block above was used during development; it is the same one a reviewer can paste verbatim. Per the repo's AI Usage policy, the responsibility for this change lies with the human submitter.*
