### PR TITLE
Validate non-existent module output references in depends_on

### DIFF
--- a/.changes/v1.16/BUG FIXES-20260510-204700.yaml
+++ b/.changes/v1.16/BUG FIXES-20260510-204700.yaml
@@ -1,0 +1,5 @@
+kind: BUG FIXES
+body: validate: non-existent module output references in depends_on now produce an error instead of silently resolving to the entire module
+time: 2026-05-10T20:47:00.000000+00:00
+custom:
+    Issue: "38396"

--- a/internal/terraform/context_validate_test.go
+++ b/internal/terraform/context_validate_test.go
@@ -1803,6 +1803,53 @@ output "out" {
 	}
 }
 
+func TestContext2Validate_invalidModuleOutputInDependsOn(t *testing.T) {
+	// This test verifies that referencing a non-existent module output in depends_on
+	// produces a proper error instead of silently falling back to the whole module.
+	m := testModuleInline(t, map[string]string{
+		"main.tf": `
+module "mod1" {
+  source = "./mod"
+}
+
+resource "test_instance" "example" {
+  # Intentionally referencing a non-existent output of mod1
+  depends_on = [module.mod1.nonexistent_output]
+}
+`,
+		"mod/main.tf": `
+output "real_output" {
+  value = "hello"
+}
+`,
+	})
+
+	p := testProvider("test")
+	ctx := testContext2(t, &ContextOpts{
+		Providers: map[addrs.Provider]providers.Factory{
+			addrs.NewDefaultProvider("test"): testProviderFuncFixed(p),
+		},
+	})
+
+	diags := ctx.Validate(m, nil)
+	if !diags.HasErrors() {
+		t.Fatal("succeeded; want errors")
+	}
+
+	// Should get an error about the undeclared module output
+	found := false
+	for _, d := range diags {
+		des := d.Description().Summary
+		if strings.Contains(des, "Reference to undeclared module output") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected error about undeclared module output, got: %s", diags.Err())
+	}
+}
+
 func TestContext2Validate_rpcDiagnostics(t *testing.T) {
 	// validate module and output depends_on
 	m := testModuleInline(t, map[string]string{

--- a/internal/terraform/evaluate_valid.go
+++ b/internal/terraform/evaluate_valid.go
@@ -419,6 +419,32 @@ func staticValidateModuleCallReference(modCfg *configs.Config, addr addrs.Module
 		return diags
 	}
 
+	// If there are remaining traversal steps (which for ModuleCallInstanceOutput
+	// represents the output name being referenced), check that the output exists.
+	if len(remain) > 0 {
+		if firstStep, ok := remain[0].(hcl.TraverseAttr); ok {
+			outputName := firstStep.Name
+			if _, outputExists := modCfg.Module.Outputs[outputName]; !outputExists {
+				var suggestions []string
+				for name := range modCfg.Module.Outputs {
+					suggestions = append(suggestions, name)
+				}
+				sort.Strings(suggestions)
+				suggestion := didyoumean.NameSuggestion(outputName, suggestions)
+				if suggestion != "" {
+					suggestion = fmt.Sprintf(" Did you mean %q?", suggestion)
+				}
+
+				diags = diags.Append(&hcl.Diagnostic{
+					Severity: hcl.DiagError,
+					Summary:  `Reference to undeclared module output`,
+					Detail:   fmt.Sprintf(`No output named %q is declared in module %q.%s`, outputName, addr.Name, suggestion),
+					Subject:  rng.ToHCL().Ptr(),
+				})
+			}
+		}
+	}
+
 	return diags
 }
 


### PR DESCRIPTION
**Fixes #38396**

When a non-existent module output is referenced in `depends_on` (e.g. `module.mod1.nonexistent_output`), Terraform currently silently resolves the reference to the entire module rather than erroring.

**Root Cause:** `staticValidateModuleCallReference()` only checked if the module call existed, not whether the referenced output existed.

**Fix:** Added output existence validation that returns a clear diagnostic error when a referenced output is not declared in the module.

**Files Changed:**
- `internal/terraform/evaluate_valid.go` — added output existence check (+26 lines)
- `internal/terraform/context_validate_test.go` — added regression test (+47 lines)

**Example:** Before this fix, `module.mod1.doesnotexist` in `depends_on` would silently work. After this fix, it produces:
```
Reference to undeclared module output
No output named "doesnotexist" is declared in module "mod1"
```