### PR TITLE
command/webbrowser: fix 'recieved' typo in mock comment

### DIFF
--- a/internal/command/webbrowser/mock.go
+++ b/internal/command/webbrowser/mock.go
@@ -61,7 +61,7 @@ type MockLauncher struct {
 	// would naturally complete.
 	Context context.Context
 
-	// Responses is a log of all of the responses recieved from the launcher's
+	// Responses is a log of all of the responses received from the launcher's
 	// requests, in the order requested.
 	Responses []*http.Response
 


### PR DESCRIPTION
Fix a typo in the doc comment for the webbrowser mock `Responses` field: `recieved` -> `received`.