### PR TITLE
backend/local: fix typo `succesfull` -> `successful` in comment

### DIFF
--- a/internal/backend/local/backend_plan.go
+++ b/internal/backend/local/backend_plan.go
@@ -95,7 +95,7 @@ func (b *Local) opPlan(
 		op.ReportResult(runningOp, diags)
 		return
 	}
-	// the state was locked during succesfull context creation; unlock the state
+	// the state was locked during successful context creation; unlock the state
 	// when the operation completes
 	defer func() {
 		diags := op.StateLocker.Unlock()


### PR DESCRIPTION
Fix `succesfull` -> `successful` in a comment in `internal/backend/local/backend_plan.go:98`. Comment-only change.