### PR TITLE
Return early during provider installation if there is no config

### DIFF
--- a/.changes/v1.15/BUG FIXES-20260512-125801.yaml
+++ b/.changes/v1.15/BUG FIXES-20260512-125801.yaml
@@ -1,0 +1,5 @@
+kind: BUG FIXES
+body: Fix crash during provider installation when there is no config
+time: 2026-05-12T12:58:01.257167+02:00
+custom:
+    Issue: "38560"

--- a/internal/command/init.go
+++ b/internal/command/init.go
@@ -377,6 +377,10 @@ const (
 // dependency lock data based on the configuration.
 // The dependency lock file itself isn't updated here.
 func (c *InitCommand) getProvidersFromConfig(ctx context.Context, config *configs.Config, upgrade bool, pluginDirs []string, flagLockfile string, view views.Init) (output bool, resultingLocks *depsfile.Locks, safeInitAction SafeInitAction, authResult *getproviders.PackageAuthenticationResult, diags tfdiags.Diagnostics) {
+	if config == nil {
+		return false, nil, SafeInitActionInvalid, nil, diags
+	}
+
 	ctx, span := tracer.Start(ctx, "install providers from config")
 	defer span.End()
 

--- a/internal/command/init.go
+++ b/internal/command/init.go
@@ -378,7 +378,7 @@ const (
 // The dependency lock file itself isn't updated here.
 func (c *InitCommand) getProvidersFromConfig(ctx context.Context, config *configs.Config, upgrade bool, pluginDirs []string, flagLockfile string, view views.Init) (output bool, resultingLocks *depsfile.Locks, safeInitAction SafeInitAction, authResult *getproviders.PackageAuthenticationResult, diags tfdiags.Diagnostics) {
 	if config == nil {
-		return false, nil, SafeInitActionInvalid, nil, diags
+		return false, nil, SafeInitActionNotRelevant, nil, diags
 	}
 
 	ctx, span := tracer.Start(ctx, "install providers from config")

--- a/internal/command/init_test.go
+++ b/internal/command/init_test.go
@@ -6335,7 +6335,7 @@ func TestInit_configErrorsImpactingStateStore(t *testing.T) {
 	code := initCmd.Run(args)
 	testOutput := done(t)
 	if code != 1 {
-		t.Fatalf("expected apply to fail with code 1, got code %d: \n%s", code, testOutput.All())
+		t.Fatalf("expected init to fail with code 1, got code %d: \n%s", code, testOutput.All())
 	}
 	log.Printf("[TRACE] TestInit_configErrorsImpactingStateStore: init complete")
 	t.Logf("init output:\n%s", testOutput.Stdout())
@@ -6352,6 +6352,36 @@ func TestInit_configErrorsImpactingStateStore(t *testing.T) {
 		if !strings.Contains(cleanString(testOutput.Stderr()), e) {
 			t.Fatalf("unexpected error, expected %q, given: %s", e, testOutput.Stderr())
 		}
+	}
+}
+
+func TestInit_varValueWithoutConfig(t *testing.T) {
+	td := t.TempDir()
+	t.Chdir(td)
+	cfg1 := `terraform {}`
+
+	if err := os.WriteFile(filepath.Join(td, "main.tf"), []byte(cfg1), 0644); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	ui := cli.NewMockUi()
+	view, done := testView(t)
+	initCmd := &InitCommand{
+		Meta: Meta{
+			Ui:   ui,
+			View: view,
+		},
+	}
+
+	code := initCmd.Run([]string{"-var", "foo=bar"})
+	testOutput := done(t)
+	if code != 1 {
+		t.Fatalf("expected init to fail with code 1, got code %d: \n%s", code, testOutput.All())
+	}
+
+	expectedErr := "Error: Value for undeclared variable"
+	if !strings.Contains(cleanString(testOutput.Stderr()), expectedErr) {
+		t.Fatalf("unexpected error, expected %q, given: %s", expectedErr, testOutput.Stderr())
 	}
 }
 


### PR DESCRIPTION
Fixes #38558

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.15.3

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [x] This change is user-facing and I added a changelog entry.
- [ ] This change is not user-facing.
