### PR TITLE
ci: declare permissions on issue-comment-created and lock

### DIFF
--- a/.github/workflows/issue-comment-created.yml
+++ b/.github/workflows/issue-comment-created.yml
@@ -4,6 +4,10 @@ on:
   issue_comment:
     types: [created]
 
+permissions:
+  issues: write           # action-remove-labels removes 'stale'/'waiting-reply'
+  pull-requests: write    # same removal on PR comments
+
 jobs:
   issue_comment_triage:
     runs-on: ubuntu-latest

--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -4,6 +4,10 @@ on:
   schedule:
     - cron: '50 1 * * *'
 
+permissions:
+  issues: write
+  pull-requests: write
+
 jobs:
   lock:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Pins the default `GITHUB_TOKEN` for the two issue/PR triage workflows still inheriting org defaults:

- **issue-comment-created.yml** — `issues: write` + `pull-requests: write`. `actions-ecosystem/action-remove-labels` removes the `stale` and `waiting-reply` labels from either an issue or a PR comment depending on context.
- **lock.yml** — `issues: write` + `pull-requests: write`. `dessant/lock-threads@v6` locks closed issues and PRs that have been inactive for 30 days and posts a comment on each.

Neither workflow checks out source or uses the token for git operations, so `contents` isn't included. YAML validated locally.