### PR TITLE
Update command help text for `state migrate` command

### DIFF
--- a/internal/command/state_migrate.go
+++ b/internal/command/state_migrate.go
@@ -76,7 +76,7 @@ Options:
 
   -destination-provider-lock-file  Path to a provider lock file for the destination provider (requires -input=false).
 
-  -upgrade                         Trigger upgrade of the provider.
+  -upgrade                         Trigger upgrade of the provider used for state storage.
 
   -input=true                      Enable input for interactive prompts (defaults to true, set to false in automation).
 `

--- a/internal/command/state_migrate.go
+++ b/internal/command/state_migrate.go
@@ -73,8 +73,10 @@ Usage: terraform [global options] state migrate [options]
 Options:
 
   -source-provider-lock-file       Path to a provider lock file for the source provider (requires -input=false).
+                                   Defaults to using the working directory's .terraform.lock.hcl file.
 
   -destination-provider-lock-file  Path to a provider lock file for the destination provider (requires -input=false).
+                                   Defaults to using the working directory's .terraform.lock.hcl file.
 
   -upgrade                         Trigger upgrade of the provider used for state storage.
 

--- a/internal/command/state_migrate.go
+++ b/internal/command/state_migrate.go
@@ -72,13 +72,13 @@ Usage: terraform [global options] state migrate [options]
 
 Options:
 
-  -source-provider-lock-file	   Path to a provider lock file for the source provider (requires -input=false).
+  -source-provider-lock-file       Path to a provider lock file for the source provider (requires -input=false).
 
   -destination-provider-lock-file  Path to a provider lock file for the destination provider (requires -input=false).
 
-  -upgrade  					   Trigger upgrade of the provider.
-  
-  -input=true					   Enable input for interactive prompts (defaults to true, set to false in automation).
+  -upgrade                         Trigger upgrade of the provider.
+
+  -input=true                      Enable input for interactive prompts (defaults to true, set to false in automation).
 `
 	return strings.TrimSpace(helpText)
 }


### PR DESCRIPTION
Minor change to the help text.

1. Making the -upgrade flag's description more specific (you can only upgrade a provider used for PSS via this command)
2. Adding default value info to the two `lock-file` flags.

The lock file flags have an equivalent function to the `-state-provider-lock` flag in https://github.com/hashicorp/terraform/pull/38461 and when that flag isn't supplied Terraform will look -optimistically- at the .terraform.lock.hcl file in the working directory for a usable lock,

See this test case in `TestInit_stateStore_newWorkingDir_inAutomationProviderApproval`:
https://github.com/hashicorp/terraform/blob/28789106e107ecb86a405bfa93b56f14fcb0d77b/internal/command/init_test.go#L4763

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.16.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
