### PR TITLE
Set TLS MinVersion to 1.2 for HTTP backend

### DIFF
--- a/.changes/v1.16/BUG FIXES-20260511-064345-5.yaml
+++ b/.changes/v1.16/BUG FIXES-20260511-064345-5.yaml
@@ -1,0 +1,5 @@
+kind: BUG FIXES
+body: 'backend/http: Set TLS MinVersion to 1.2 to prevent protocol downgrade attacks against state data in transit'
+time: 2026-05-11T06:29:00.000000Z
+custom:
+    Issue: "38546"

--- a/internal/backend/remote-state/http/backend.go
+++ b/internal/backend/remote-state/http/backend.go
@@ -281,6 +281,7 @@ func (b *Backend) configureTLS(client *retryablehttp.Client, configVal cty.Value
 
 	// TLS configuration is needed; create an object and configure it
 	var tlsConfig tls.Config
+	tlsConfig.MinVersion = tls.VersionTLS12
 	client.HTTPClient.Transport.(*http.Transport).TLSClientConfig = &tlsConfig
 
 	if skipCertVerification {


### PR DESCRIPTION
Closes #38576

The HTTP backend's `configureTLS` creates a `tls.Config` without setting
`MinVersion`, which defaults to TLS 1.0 and allows protocol downgrade
attacks against state data in transit. Added `tls.VersionTLS12` to match
the pattern already used by the OCI backend
(`internal/backend/remote-state/oci/auth.go:323`).

TLS 1.0 and 1.1 were formally deprecated by
[RFC 8996](https://datatracker.ietf.org/doc/html/rfc8996) in March 2021.

The omission was introduced in #34806 (2024-03-05) during the
`helper/schema` refactoring.

Related: [moby/moby#32056](https://github.com/moby/moby/pull/32056) -
Docker/Moby added TLS minimum version enforcement for the same class of
downgrade risk.

## Target Release

1.16.x

## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Yes. This change enforces TLS 1.2 as the minimum protocol version for
HTTP backend state storage connections, preventing downgrade to
deprecated TLS 1.0/1.1.

## AI Disclosure

This fix was developed with AI assistance (Grok by xAI) in a human-in-the-loop workflow. The author identified the bug, directed the investigation, reviewed all code changes, and verified correctness. AI was used to assist with code analysis and drafting the fix.

## CHANGELOG entry

- [x] This change is not user-facing.