### PR TITLE
Fix resource leaks in provisioners and commands

### DIFF
--- a/.changes/v1.16/BUG FIXES-20260511-064306-1.yaml
+++ b/.changes/v1.16/BUG FIXES-20260511-064306-1.yaml
@@ -1,5 +1,0 @@
-kind: BUG FIXES
-body: Fix resource leaks in provisioners and commands where file handles, HTTP response bodies, or pipe file descriptors were not properly closed
-time: 2026-05-11T06:25:00.000000Z
-custom:
-    Issue: "38541"

--- a/.changes/v1.16/BUG FIXES-20260511-064306-1.yaml
+++ b/.changes/v1.16/BUG FIXES-20260511-064306-1.yaml
@@ -1,0 +1,5 @@
+kind: BUG FIXES
+body: Fix resource leaks in provisioners and commands where file handles, HTTP response bodies, or pipe file descriptors were not properly closed
+time: 2026-05-11T06:25:00.000000Z
+custom:
+    Issue: "38541"

--- a/internal/builtin/provisioners/file/resource_provisioner.go
+++ b/internal/builtin/provisioners/file/resource_provisioner.go
@@ -138,9 +138,11 @@ func getSrc(v cty.Value) (string, bool, error) {
 		}
 
 		if _, err = file.WriteString(content.AsString()); err != nil {
+			file.Close()
 			return "", true, err
 		}
 
+		file.Close()
 		return file.Name(), true, nil
 
 	case !src.IsNull():

--- a/internal/builtin/provisioners/local-exec/resource_provisioner.go
+++ b/internal/builtin/provisioners/local-exec/resource_provisioner.go
@@ -194,6 +194,8 @@ func (p *provisioner) ProvisionResource(req provisioners.ProvisionResourceReques
 	case <-p.ctx.Done():
 	}
 
+	pr.Close()
+
 	if err != nil {
 		resp.Diagnostics = resp.Diagnostics.Append(tfdiags.WholeContainingBody(
 			tfdiags.Error,

--- a/internal/command/login.go
+++ b/internal/command/login.go
@@ -261,6 +261,7 @@ func (c *LoginCommand) Run(args []string) int {
 			c.outputDefaultTFCLoginSuccess()
 			return 0
 		}
+		defer resp.Body.Close()
 
 		body, err := ioutil.ReadAll(resp.Body)
 		if err != nil {
@@ -268,8 +269,6 @@ func (c *LoginCommand) Run(args []string) int {
 			c.outputDefaultTFCLoginSuccess()
 			return 0
 		}
-
-		defer resp.Body.Close()
 		json.Unmarshal(body, &motd)
 
 		if motd.Errors == nil && motd.Message != "" {

--- a/internal/command/workspace_new.go
+++ b/internal/command/workspace_new.go
@@ -146,6 +146,7 @@ func (c *WorkspaceNewCommand) Run(rawArgs []string) int {
 		c.Ui.Error(err.Error())
 		return 1
 	}
+	defer f.Close()
 
 	stateFile, err := statefile.Read(f)
 	if err != nil {


### PR DESCRIPTION
Closes #38575

Fix four resource leaks where file handles, HTTP response bodies, or pipe
file descriptors were not properly closed on all code paths.

**`internal/command/workspace_new.go`** -- The file opened via `os.Open` for
reading existing state (when using `terraform workspace new -state=FILE`)
was never closed. Added `defer f.Close()`.

**`internal/builtin/provisioners/file/resource_provisioner.go`** -- The
`*os.File` handle from `ioutil.TempFile` in `getSrc()` was never closed.
The caller re-opens the file by path, so the original handle must be closed
to avoid leaking one file descriptor per file-provisioner invocation.
Added explicit `file.Close()` before both return paths.

**`internal/command/login.go`** -- The `defer resp.Body.Close()` was placed
after `ioutil.ReadAll(resp.Body)`, meaning the body leaked if ReadAll
returned an error (early return at line 269). Moved the defer to
immediately after the `resp != nil` check, matching idiomatic Go patterns.

**`internal/builtin/provisioners/local-exec/resource_provisioner.go`** --
`os.Pipe()` creates two file descriptors. The write end (`pw`) was
closed at line 187, but the read end (`pr`) was never closed, leaking
one file descriptor per `local-exec` invocation. Added `pr.Close()`
after the copy goroutine completes.

## Target Release

1.16.x

## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

No changes to security controls.

## AI Disclosure

This fix was developed with AI assistance (Grok by xAI) in a human-in-the-loop workflow. The author identified the bug, directed the investigation, reviewed all code changes, and verified correctness. AI was used to assist with code analysis and drafting the fix.

## CHANGELOG entry

- [x] This change is not user-facing.