### PR TITLE
chore: Modernise some code in provisioners packages, add some code comments

### DIFF
--- a/internal/builtin/provisioners/file/resource_provisioner.go
+++ b/internal/builtin/provisioners/file/resource_provisioner.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 
 	"github.com/hashicorp/terraform/internal/communicator"
@@ -125,14 +124,18 @@ func (p *provisioner) ProvisionResource(req provisioners.ProvisionResourceReques
 	return resp
 }
 
-// getSrc returns the file to use as source
+// getSrc returns the file to use as source.
+//
+// If the "content" attribute is set, a temporary file with that content will be created and used.
+// This temporary file needs to be deleted by the caller after the copying process is complete.
+// The boolean return value indicates whether the caller needs to do this.
 func getSrc(v cty.Value) (string, bool, error) {
 	content := v.GetAttr("content")
 	src := v.GetAttr("source")
 
 	switch {
 	case !content.IsNull():
-		file, err := ioutil.TempFile("", "tf-file-content")
+		file, err := os.CreateTemp("", "tf-file-content")
 		if err != nil {
 			return "", true, err
 		}

--- a/internal/builtin/provisioners/local-exec/resource_provisioner_test.go
+++ b/internal/builtin/provisioners/local-exec/resource_provisioner_test.go
@@ -5,7 +5,6 @@ package localexec
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
@@ -17,7 +16,9 @@ import (
 )
 
 func TestResourceProvider_Apply(t *testing.T) {
-	defer os.Remove("test_out")
+	td := t.TempDir()
+	t.Chdir(td)
+
 	output := cli.NewMockUi()
 	p := New()
 	schema := p.GetSchema().Provisioner
@@ -38,7 +39,7 @@ func TestResourceProvider_Apply(t *testing.T) {
 	}
 
 	// Check the file
-	raw, err := ioutil.ReadFile("test_out")
+	raw, err := os.ReadFile("test_out")
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -131,10 +132,16 @@ is not really an interpreter`
 	}
 }
 
+// The provisioner can be configured to use a directory other than the current working directory.
 func TestResourceProvider_ApplyCustomWorkingDirectory(t *testing.T) {
+	// Avoid refactoring to using t.TempDir here; t.TempDir creates a symlink to the actual temp directory and there's a mismatch
+	// between the path returned by t.TempDir (symlink) and the path returned by the `pwd` command (actual path).
+	// This occurs on macOS.
+	//
+	// So, continue to create a directory in this test's directory and avoid symlinks.
 	testdir := "working_dir_test"
 	os.Mkdir(testdir, 0755)
-	defer os.Remove(testdir)
+	t.Cleanup(func() { os.Remove(testdir) })
 
 	output := cli.NewMockUi()
 	p := New()
@@ -239,7 +246,6 @@ func TestResourceProvisioner_nullsInOptionals(t *testing.T) {
 		}),
 	} {
 		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
-
 			cfg, err := schema.CoerceValue(cfg)
 			if err != nil {
 				t.Fatal(err)

--- a/internal/builtin/provisioners/remote-exec/resource_provisioner.go
+++ b/internal/builtin/provisioners/remote-exec/resource_provisioner.go
@@ -9,7 +9,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"strings"
@@ -182,7 +181,7 @@ func collectScripts(v cty.Value) ([]io.ReadCloser, error) {
 
 		var r []io.ReadCloser
 		for _, script := range scripts {
-			r = append(r, ioutil.NopCloser(bytes.NewReader([]byte(script))))
+			r = append(r, io.NopCloser(bytes.NewReader([]byte(script))))
 		}
 
 		return r, nil


### PR DESCRIPTION
While reviewing https://github.com/hashicorp/terraform/pull/38585 I dug into the provisioner packages a bit.

While I couldn't identify any easy way to add meaningful test coverage to the `file` provisioner (implementing a mock SSH server that can perform scp would be a disproportionate amount of effort!) I did find some places that could benefit from updating.

Ideally cleanup like this would happen when more meaningful changes are being made to the code, but this PR is coupled to that community PR I've linked.

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.16.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
