### PR TITLE
refactor: remove readDiff

### DIFF
--- a/internal/terraform/node_resource_abstract_instance.go
+++ b/internal/terraform/node_resource_abstract_instance.go
@@ -161,25 +161,6 @@ func (n *NodeAbstractResourceInstance) SetOverride(override *configs.Override) {
 	n.override = override
 }
 
-// readDiff returns the planned change for a particular resource instance
-// object.
-func (n *NodeAbstractResourceInstance) readDiff(ctx EvalContext, providerSchema providers.ProviderSchema) (*plans.ResourceInstanceChange, error) {
-	changes := ctx.Changes()
-	addr := n.ResourceInstanceAddr()
-
-	schema := providerSchema.SchemaForResourceAddr(addr.Resource.Resource)
-	if schema.Body == nil {
-		// Should be caught during validation, so we don't bother with a pretty error here
-		return nil, fmt.Errorf("provider does not support resource type %q", addr.Resource.Resource.Type)
-	}
-
-	change := changes.GetResourceInstanceChange(addr, addrs.NotDeposed)
-
-	log.Printf("[TRACE] readDiff: Read %s change from plan for %s", change.Action, n.Addr)
-
-	return change, nil
-}
-
 func (n *NodeAbstractResourceInstance) checkPreventDestroy(change *plans.ResourceInstanceChange) tfdiags.Diagnostics {
 	if change == nil || n.Config == nil || n.Config.Managed == nil {
 		return nil

--- a/internal/terraform/node_resource_apply_instance.go
+++ b/internal/terraform/node_resource_apply_instance.go
@@ -112,17 +112,7 @@ func (n *NodeApplyableResourceInstance) ephemeralResourceExecute(ctx EvalContext
 }
 
 func (n *NodeApplyableResourceInstance) dataResourceExecute(ctx EvalContext) (diags tfdiags.Diagnostics) {
-	_, providerSchema, err := getProvider(ctx, n.ResolvedProvider)
-	diags = diags.Append(err)
-	if diags.HasErrors() {
-		return diags
-	}
-
-	change, err := n.readDiff(ctx, providerSchema)
-	diags = diags.Append(err)
-	if diags.HasErrors() {
-		return diags
-	}
+	change := ctx.Changes().GetResourceInstanceChange(n.Addr, addrs.NotDeposed)
 	// Stop early if we don't actually have a diff
 	if change == nil {
 		return diags
@@ -187,11 +177,7 @@ func (n *NodeApplyableResourceInstance) managedResourceExecute(ctx EvalContext) 
 	}
 
 	// Get the saved diff for apply
-	diffApply, err := n.readDiff(ctx, providerSchema)
-	diags = diags.Append(err)
-	if diags.HasErrors() {
-		return diags
-	}
+	diffApply := ctx.Changes().GetResourceInstanceChange(n.Addr, addrs.NotDeposed)
 
 	// We don't want to do any destroys
 	// (these are handled by NodeDestroyResourceInstance instead)
@@ -228,11 +214,7 @@ func (n *NodeApplyableResourceInstance) managedResourceExecute(ctx EvalContext) 
 	}
 
 	// Get the saved diff
-	diff, err := n.readDiff(ctx, providerSchema)
-	diags = diags.Append(err)
-	if diags.HasErrors() {
-		return diags
-	}
+	diff := ctx.Changes().GetResourceInstanceChange(n.Addr, addrs.NotDeposed)
 
 	// Make a new diff, in case we've learned new values in the state
 	// during apply which we can now incorporate.

--- a/internal/terraform/node_resource_destroy.go
+++ b/internal/terraform/node_resource_destroy.go
@@ -138,15 +138,8 @@ func (n *NodeDestroyResourceInstance) managedResourceExecute(ctx EvalContext) (d
 	var changeApply *plans.ResourceInstanceChange
 	var state *states.ResourceInstanceObject
 
-	_, providerSchema, err := getProvider(ctx, n.ResolvedProvider)
-	diags = diags.Append(err)
-	if diags.HasErrors() {
-		return diags
-	}
-
-	changeApply, err = n.readDiff(ctx, providerSchema)
-	diags = diags.Append(err)
-	if changeApply == nil || diags.HasErrors() {
+	changeApply = ctx.Changes().GetResourceInstanceChange(n.Addr, addrs.NotDeposed)
+	if changeApply == nil {
 		return diags
 	}
 
@@ -195,7 +188,7 @@ func (n *NodeDestroyResourceInstance) managedResourceExecute(ctx EvalContext) (d
 	// we don't return immediately here on error, so that the state can be
 	// finalized
 
-	err = n.writeResourceInstanceState(ctx, state, workingState)
+	err := n.writeResourceInstanceState(ctx, state, workingState)
 	if err != nil {
 		return diags.Append(err)
 	}

--- a/internal/terraform/node_resource_forget.go
+++ b/internal/terraform/node_resource_forget.go
@@ -60,15 +60,8 @@ func (n *NodeForgetResourceInstance) Execute(ctx EvalContext, op walkOperation) 
 	var changeApply *plans.ResourceInstanceChange
 	var state *states.ResourceInstanceObject
 
-	_, providerSchema, err := getProvider(ctx, n.ResolvedProvider)
-	diags = diags.Append(err)
-	if diags.HasErrors() {
-		return diags
-	}
-
-	changeApply, err = n.readDiff(ctx, providerSchema)
-	diags = diags.Append(err)
-	if changeApply == nil || diags.HasErrors() {
+	changeApply = ctx.Changes().GetResourceInstanceChange(n.Addr, addrs.NotDeposed)
+	if changeApply == nil {
 		return diags
 	}
 


### PR DESCRIPTION
readDiff is no longer necessary now that we don't need the provider schema to read the change. All calls to readDiff were replaced with a single-line call to ctx.Changes, using the same inputs (`n.Addr, addrs.NotDeposed`) that readDiff used.

This is the PR which preceded this change: https://github.com/hashicorp/terraform/pull/35558/changes
