### PR TITLE
fix: resolve data race and dropped diagnostics on ephemeral resource renewal (#38591)

### DIFF
--- a/.changes/v1.16/BUG FIXES-20260514-191617.yaml
+++ b/.changes/v1.16/BUG FIXES-20260514-191617.yaml
@@ -1,0 +1,5 @@
+kind: BUG FIXES
+body: Fixed a bug that meant errors encountered when renewing ephemeral resources were not shown to users
+time: 2026-05-14T19:16:17.909017+02:00
+custom:
+    Issue: "38591"

--- a/internal/resources/ephemeral/ephemeral_resource_test.go
+++ b/internal/resources/ephemeral/ephemeral_resource_test.go
@@ -5,6 +5,7 @@ package ephemeral
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"sync"
 	"testing"
@@ -303,3 +304,106 @@ func (r *testResourceInstance) Close(ctx context.Context) tfdiags.Diagnostics {
 	r.closed = true
 	return nil
 }
+
+// TestResources_renewalErrorSurfaced verifies that diagnostics from a failed
+// renewal are not silently dropped: InstanceValue must report the resource as
+// not live, and CloseInstances must surface the error to the caller.
+func TestResources_renewalErrorSurfaced(t *testing.T) {
+	ctx := context.Background()
+	resources := NewResources()
+
+	addr := addrs.ResourceInstance{
+		Resource: addrs.Resource{
+			Mode: addrs.EphemeralResourceMode,
+			Type: "test",
+			Name: "a",
+		},
+		Key: addrs.NoKey,
+	}.Absolute(addrs.RootModuleInstance)
+
+	renewCalled := make(chan struct{}, 1)
+	resources.RegisterInstance(ctx, addr, ResourceInstanceRegistration{
+		Value:   cty.EmptyObjectVal,
+		Impl:    &testRenewErrInstance{renewCalled: renewCalled},
+		RenewAt: time.Now().Add(10 * time.Millisecond),
+	})
+
+	select {
+	case <-renewCalled:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for Renew to be called")
+	}
+	resources.wg.Wait() // goroutine exits after the first renewal error
+
+	if _, live := resources.InstanceValue(addr); live {
+		t.Fatal("InstanceValue: got live=true after failed renewal, want false")
+	}
+
+	if diags := resources.CloseInstances(ctx, addr.ConfigResource()); !diags.HasErrors() {
+		t.Fatal("CloseInstances: want renewal error to be surfaced, got none")
+	}
+}
+
+// TestResources_renewalConcurrentInstanceValue calls InstanceValue from
+// multiple goroutines while the renewal goroutine is concurrently writing
+// renewDiags. Run with -race to confirm no data race is present.
+func TestResources_renewalConcurrentInstanceValue(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	resources := NewResources()
+
+	addr := addrs.ResourceInstance{
+		Resource: addrs.Resource{
+			Mode: addrs.EphemeralResourceMode,
+			Type: "test",
+			Name: "a",
+		},
+		Key: addrs.NoKey,
+	}.Absolute(addrs.RootModuleInstance)
+
+	resources.RegisterInstance(ctx, addr, ResourceInstanceRegistration{
+		Value:   cty.EmptyObjectVal,
+		Impl:    &testFastRenewInstance{interval: time.Millisecond},
+		RenewAt: time.Now(),
+	})
+
+	var wg sync.WaitGroup
+	for range 10 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for range 100 {
+				resources.InstanceValue(addr)
+			}
+		}()
+	}
+	wg.Wait()
+}
+
+// testRenewErrInstance is a ResourceInstance whose Renew always fails.
+type testRenewErrInstance struct {
+	renewCalled chan struct{}
+}
+
+func (r *testRenewErrInstance) Renew(_ context.Context, _ providers.EphemeralRenew) (*providers.EphemeralRenew, tfdiags.Diagnostics) {
+	select {
+	case r.renewCalled <- struct{}{}:
+	default:
+	}
+	return nil, tfdiags.Diagnostics(nil).Append(fmt.Errorf("renewal failed"))
+}
+
+func (r *testRenewErrInstance) Close(_ context.Context) tfdiags.Diagnostics { return nil }
+
+// testFastRenewInstance is a ResourceInstance that renews successfully at a
+// short fixed interval, used to drive concurrent access in race tests.
+type testFastRenewInstance struct {
+	interval time.Duration
+}
+
+func (r *testFastRenewInstance) Renew(_ context.Context, _ providers.EphemeralRenew) (*providers.EphemeralRenew, tfdiags.Diagnostics) {
+	return &providers.EphemeralRenew{RenewAt: time.Now().Add(r.interval)}, nil
+}
+
+func (r *testFastRenewInstance) Close(_ context.Context) tfdiags.Diagnostics { return nil }

--- a/internal/resources/ephemeral/ephemeral_resources.go
+++ b/internal/resources/ephemeral/ephemeral_resources.go
@@ -102,7 +102,10 @@ func (r *Resources) InstanceValue(addr addrs.AbsResourceInstance) (val cty.Value
 	}
 	// If renewal has failed then we can't assume that the object is still
 	// live, but we can still return the original value regardless.
-	return inst.value, !inst.renewDiags.HasErrors()
+	inst.renewMu.Lock()
+	hasRenewErrors := inst.renewDiags.HasErrors()
+	inst.renewMu.Unlock()
+	return inst.value, !hasRenewErrors
 }
 
 // CloseInstances shuts down any live ephemeral resource instances that are
@@ -246,7 +249,7 @@ func (r *resourceInstanceInternal) handleRenewal(ctx context.Context, wg *sync.W
 			// It's time to renew
 			r.renewMu.Lock()
 			anotherRenew, diags := r.impl.Renew(ctx, *nextRenew)
-			r.renewDiags.Append(diags)
+			r.renewDiags = r.renewDiags.Append(diags)
 			if diags.HasErrors() {
 				// If renewal fails then we'll stop trying to renew.
 				r.renewCancel = noopCancel


### PR DESCRIPTION
## Summary

Fixes #38591. Two related bugs in `internal/resources/ephemeral/ephemeral_resources.go`:

- **Dropped diagnostics:** `handleRenewal` called `r.renewDiags.Append(diags)` without capturing the return value, silently discarding all renewal diagnostics. Fixed to `r.renewDiags = r.renewDiags.Append(diags)`. (Originally identified in PR #38583 by @SebTardif.)

- **Data race:** `InstanceValue` read `inst.renewDiags.HasErrors()` without holding `inst.renewMu`, while `handleRenewal` writes `renewDiags` under that mutex. The two mutexes are independent, so there was no happens-before relationship between the read and the write. Fixed by acquiring `renewMu` around the read in `InstanceValue`.

The struct already had `renewMu sync.Mutex` with the comment _"hold when accessing renewCancel/renewDiags, and while actually renewing"_ — `InstanceValue` was simply missed when that mutex was introduced. All other `renewDiags` accesses (`close` at line 223, `handleRenewal` at lines 247 and 267) were already correctly protected.

## Lock ordering

No new lock ordering is introduced. All existing paths follow `r.mu` (outer) → `inst.renewMu` (inner), and this fix follows the same order.

## Test plan

- [ ] `go test -race ./internal/terraform/... -run TestContext2Apply_ephemeralProviderRef` passes cleanly
- [ ] `go test -race ./internal/resources/ephemeral/...` passes cleanly