### PR TITLE
Fix lost renewal diagnostics and data race for ephemeral resources

### DIFF
--- a/.changes/v1.16/BUG FIXES-20260515-120000.yaml
+++ b/.changes/v1.16/BUG FIXES-20260515-120000.yaml
@@ -1,0 +1,5 @@
+kind: BUG FIXES
+body: Fixed a bug that meant errors encountered when renewing ephemeral resources were not shown to users
+time: 2026-05-15T12:00:00.000000Z
+custom:
+    Issue: "38574"

--- a/internal/resources/ephemeral/ephemeral_resource_test.go
+++ b/internal/resources/ephemeral/ephemeral_resource_test.go
@@ -5,6 +5,7 @@ package ephemeral
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"sync"
 	"testing"
@@ -272,6 +273,56 @@ func TestResourcesCancellation(t *testing.T) {
 	}
 }
 
+func TestResourcesRenewFailure(t *testing.T) {
+	resources := NewResources()
+
+	addr := addrs.ResourceInstance{
+		Resource: addrs.Resource{
+			Mode: addrs.EphemeralResourceMode,
+			Type: "test",
+			Name: "a",
+		},
+		Key: addrs.NoKey,
+	}.Absolute(addrs.RootModuleInstance)
+
+	ctx := context.TODO()
+
+	renewErr := make(chan struct{})
+	inst := &testResourceInstance{
+		name:          addr.String(),
+		renewInterval: 10 * time.Millisecond,
+		failAfter:     1,
+		notifyErr:     renewErr,
+	}
+
+	resources.RegisterInstance(ctx, addr, ResourceInstanceRegistration{
+		Value: cty.ObjectVal(map[string]cty.Value{
+			"test": cty.StringVal("ephemeral.test.a"),
+		}),
+		Impl:    inst,
+		RenewAt: time.Now().Add(10 * time.Millisecond),
+	})
+
+	// Wait for the renewal failure to be processed.
+	select {
+	case <-renewErr:
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for renewal failure")
+	}
+
+	// After a failed renewal the instance should no longer be live.
+	_, live := resources.InstanceValue(addr)
+	if live {
+		t.Fatalf("%s should not be live after renewal failure", addr)
+	}
+
+	// Close should surface the renewal error diagnostics.
+	diags := resources.CloseInstances(ctx, addr.ConfigResource())
+	if !diags.HasErrors() {
+		t.Fatal("expected error diagnostics from failed renewal")
+	}
+}
+
 type testResourceInstance struct {
 	sync.Mutex
 	name          string
@@ -279,6 +330,8 @@ type testResourceInstance struct {
 	renewed       int
 	notifyRenew   chan string
 	closed        bool
+	failAfter     int           // if > 0, fail on the Nth renewal
+	notifyErr     chan struct{} // closed after the failing renewal returns
 }
 
 func (r *testResourceInstance) Renew(ctx context.Context, req providers.EphemeralRenew) (*providers.EphemeralRenew, tfdiags.Diagnostics) {
@@ -288,11 +341,22 @@ func (r *testResourceInstance) Renew(ctx context.Context, req providers.Ephemera
 	r.Lock()
 	defer r.Unlock()
 	r.renewed++
-	select {
-	case r.notifyRenew <- r.name:
-	case <-time.After(time.Second):
-		// stop renewing if no-one is listening
-		return nil, nil
+	if r.failAfter > 0 && r.renewed >= r.failAfter {
+		var diags tfdiags.Diagnostics
+		diags = diags.Append(fmt.Errorf("renewal failed"))
+		if r.notifyErr != nil {
+			close(r.notifyErr)
+			r.notifyErr = nil
+		}
+		return nil, diags
+	}
+	if r.notifyRenew != nil {
+		select {
+		case r.notifyRenew <- r.name:
+		case <-time.After(time.Second):
+			// stop renewing if no-one is listening
+			return nil, nil
+		}
 	}
 	return nextRenew, nil
 }

--- a/internal/resources/ephemeral/ephemeral_resources.go
+++ b/internal/resources/ephemeral/ephemeral_resources.go
@@ -102,7 +102,10 @@ func (r *Resources) InstanceValue(addr addrs.AbsResourceInstance) (val cty.Value
 	}
 	// If renewal has failed then we can't assume that the object is still
 	// live, but we can still return the original value regardless.
-	return inst.value, !inst.renewDiags.HasErrors()
+	inst.renewMu.Lock()
+	hasErrors := inst.renewDiags.HasErrors()
+	inst.renewMu.Unlock()
+	return inst.value, !hasErrors
 }
 
 // CloseInstances shuts down any live ephemeral resource instances that are
@@ -246,7 +249,7 @@ func (r *resourceInstanceInternal) handleRenewal(ctx context.Context, wg *sync.W
 			// It's time to renew
 			r.renewMu.Lock()
 			anotherRenew, diags := r.impl.Renew(ctx, *nextRenew)
-			r.renewDiags.Append(diags)
+			r.renewDiags = r.renewDiags.Append(diags)
 			if diags.HasErrors() {
 				// If renewal fails then we'll stop trying to renew.
 				r.renewCancel = noopCancel


### PR DESCRIPTION
Closes #38591

Two bugs in `handleRenewal` for ephemeral resources:

1. `tfdiags.Diagnostics.Append()` returns a new slice; it does not modify the receiver. In `handleRenewal`, the return value was discarded at line 249, silently dropping all renewal error diagnostics. The correct pattern is already used on line 270 of the same file.

2. `InstanceValue` reads `renewDiags` without holding `renewMu`, creating a data race with the renewal goroutine. The struct comment on `renewMu` (line 203) documents that it must be held when accessing `renewDiags`.

Effects of bug #1:
- `InstanceValue` incorrectly reported the resource as live after a failed renewal, because `renewDiags.HasErrors()` was always false
- `close` lost all renewal diagnostics when surfacing errors to the caller
- The error path in `evaluate.go:1124` was unreachable dead code

Both bugs were introduced in #35742 (2024-09-16, initial ephemeral resources implementation).

This is a resubmission of #38583, which was closed due to the data race in bug #2. This PR fixes both issues. (Original issue #38574 was closed by @SarahFrench as a duplicate of #38591.)

## Target Release

1.16.x

## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

No changes to security controls.

## AI Disclosure

This fix was developed with AI assistance (Grok by xAI) in a human-in-the-loop workflow. The author identified the bug, directed the investigation, reviewed all code changes, and verified correctness. AI was used to assist with code analysis and drafting the fix.

## CHANGELOG entry

- [x] This change is user-facing and I added a changelog entry.

## Test plan

- [x] `go test -race ./internal/resources/ephemeral/...` -- all tests pass, no races detected
- [x] New `TestResourcesRenewFailure` verifies renewal failure -> live=false -> diagnostics surfaced on close
- [x] Red-green verified: test fails without fix, passes with fix