### PR TITLE
chore: Update changelog validation to use the PR branch

### DIFF
--- a/.changes/v1.16/NOTES-20260515-094319.yaml
+++ b/.changes/v1.16/NOTES-20260515-094319.yaml
@@ -1,0 +1,3 @@
+(╯°□°)╯︵ ┻━┻
+This is just a malformed changelog
+┬─┬ノ( º _ ºノ)

--- a/.changes/v1.16/NOTES-20260515-094319.yaml
+++ b/.changes/v1.16/NOTES-20260515-094319.yaml
@@ -1,3 +1,0 @@
-(╯°□°)╯︵ ┻━┻
-This is just a malformed changelog
-┬─┬ノ( º _ ºノ)

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -25,6 +25,27 @@ permissions:
     pull-requests: write
 
 jobs:
+    # Validate the changelog in the pull request branch
+    validate-changelog-entry:
+        if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip-changelog-check') }}
+        name: "Check Changelog Entry"
+        runs-on: ubuntu-latest
+
+        steps:
+            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+              with:
+                  sparse-checkout: |
+                      .changie.yaml
+                      .changes/
+                  sparse-checkout-cone-mode: false
+
+            - name: Validate changie fragment is valid
+              uses: miniscruff/changie-action@11bcad388e7973948cbcecb10863baf024d5f607 # v3.0.0
+              with:
+                  version: latest
+                  args: merge -u "." --dry-run
+
+    # Check target branch of the PR to determine if a changelog is needed and what version folder it should exist in
     check-changelog-entry:
         if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip-changelog-check') }}
         name: "Check Changelog Entry"
@@ -51,8 +72,6 @@ jobs:
               with:
                   sparse-checkout: |
                       version/VERSION
-                      .changie.yaml
-                      .changes/
                   sparse-checkout-cone-mode: false
                   ref: ${{ github.base_ref }} # Base ref refers to the target branch of this PR
 
@@ -187,9 +206,3 @@ jobs:
 
                       // Nothing to complain about, so delete any existing comment
                       await createOrUpdateChangelogComment("", true);
-
-            - name: Validate changie fragment is valid
-              uses: miniscruff/changie-action@11bcad388e7973948cbcecb10863baf024d5f607 # v3.0.0
-              with:
-                  version: latest
-                  args: merge -u "." --dry-run


### PR DESCRIPTION
Currently, our changelog validation happens in a step right after we check if a changelog is needed. The check for "if the changelog is needed", is using the target branch (`main`, `v1.15`, etc.), which means that the changelog introduced in the PR isn't considered 😔. Here is an example:
- https://github.com/hashicorp/terraform/pull/38598/changes/dffea3b22e653a69178fb7586c6110444b14037c
- https://github.com/hashicorp/terraform/actions/runs/25921377487/job/76191008132
  - If you open the validate step you can see that the changelog output is from the target branch

I think you could fix this in multiple ways, but I opted to just move the changelog validation into it's own job with it's own checkout of the PR branch 👍🏻 (note, we can't actually test this without merging to `main`, since `pull_request_target` will only source the workflow from the target branch 🙃 )

## Target Release

1.16.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
