### PR TITLE
chore: Adjust changelog validation to use head_ref

### DIFF
--- a/.changes/v1.16/NOTES-20260515-102128.yaml
+++ b/.changes/v1.16/NOTES-20260515-102128.yaml
@@ -1,0 +1,3 @@
+(╯°□°)╯︵ ┻━┻
+This is a bad changelog!
+┬─┬ノ( º _ ºノ)

--- a/.changes/v1.16/NOTES-20260515-102128.yaml
+++ b/.changes/v1.16/NOTES-20260515-102128.yaml
@@ -1,3 +1,0 @@
-(╯°□°)╯︵ ┻━┻
-This is a bad changelog!
-┬─┬ノ( º _ ºノ)

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -38,6 +38,7 @@ jobs:
                       .changie.yaml
                       .changes/
                   sparse-checkout-cone-mode: false
+                  ref: ${{ github.head_ref }} # Head ref refers to the branch of this PR
 
             - name: Validate changie fragment is valid
               uses: miniscruff/changie-action@11bcad388e7973948cbcecb10863baf024d5f607 # v3.0.0


### PR DESCRIPTION
Follow up to #38598, the default branch of `pull_request_target` is the target branch, so we need to explicitly call out the head ref (which is the source).

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.16.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
