### PR TITLE
chore: Adjust the title of the validate changelog job

### DIFF
--- a/.changes/v1.16/NOTES-20260515-104542.yaml
+++ b/.changes/v1.16/NOTES-20260515-104542.yaml
@@ -1,0 +1,3 @@
+(╯°□°)╯︵ ┻━┻
+This is a malformed changelog
+┬─┬ノ( º _ ºノ)

--- a/.changes/v1.16/NOTES-20260515-104542.yaml
+++ b/.changes/v1.16/NOTES-20260515-104542.yaml
@@ -1,3 +1,0 @@
-(╯°□°)╯︵ ┻━┻
-This is a malformed changelog
-┬─┬ノ( º _ ºノ)

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -28,7 +28,7 @@ jobs:
     # Validate the changelog in the pull request branch
     validate-changelog-entry:
         if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip-changelog-check') }}
-        name: "Check Changelog Entry"
+        name: "Validate Changelog"
         runs-on: ubuntu-latest
 
         steps:


### PR DESCRIPTION
One final follow-up to #38598 (and a test, see https://github.com/hashicorp/terraform/actions/runs/25924234719/job/76201037830)

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.16.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
