### PR TITLE
fix: Capture previously-discarded diagnostics in test providers

### DIFF
--- a/internal/builtin/providers/terraform/provider.go
+++ b/internal/builtin/providers/terraform/provider.go
@@ -285,19 +285,19 @@ func (p *Provider) ListResource(req providers.ListResourceRequest) providers.Lis
 
 func (p *Provider) ValidateStateStoreConfig(req providers.ValidateStateStoreConfigRequest) providers.ValidateStateStoreConfigResponse {
 	var resp providers.ValidateStateStoreConfigResponse
-	resp.Diagnostics.Append(fmt.Errorf("unsupported state store type %q", req.TypeName))
+	resp.Diagnostics = resp.Diagnostics.Append(fmt.Errorf("unsupported state store type %q", req.TypeName))
 	return resp
 }
 
 func (p *Provider) ConfigureStateStore(req providers.ConfigureStateStoreRequest) providers.ConfigureStateStoreResponse {
 	var resp providers.ConfigureStateStoreResponse
-	resp.Diagnostics.Append(fmt.Errorf("unsupported state store type %q", req.TypeName))
+	resp.Diagnostics = resp.Diagnostics.Append(fmt.Errorf("unsupported state store type %q", req.TypeName))
 	return resp
 }
 
 func (p *Provider) ReadStateBytes(req providers.ReadStateBytesRequest) providers.ReadStateBytesResponse {
 	var resp providers.ReadStateBytesResponse
-	resp.Diagnostics.Append(fmt.Errorf("unsupported state store type %q", req.TypeName))
+	resp.Diagnostics = resp.Diagnostics.Append(fmt.Errorf("unsupported state store type %q", req.TypeName))
 	return resp
 }
 
@@ -309,25 +309,25 @@ func (p *Provider) WriteStateBytes(req providers.WriteStateBytesRequest) provide
 
 func (p *Provider) LockState(req providers.LockStateRequest) providers.LockStateResponse {
 	var resp providers.LockStateResponse
-	resp.Diagnostics.Append(fmt.Errorf("unsupported state store type %q", req.TypeName))
+	resp.Diagnostics = resp.Diagnostics.Append(fmt.Errorf("unsupported state store type %q", req.TypeName))
 	return resp
 }
 
 func (p *Provider) UnlockState(req providers.UnlockStateRequest) providers.UnlockStateResponse {
 	var resp providers.UnlockStateResponse
-	resp.Diagnostics.Append(fmt.Errorf("unsupported state store type %q", req.TypeName))
+	resp.Diagnostics = resp.Diagnostics.Append(fmt.Errorf("unsupported state store type %q", req.TypeName))
 	return resp
 }
 
 func (p *Provider) GetStates(req providers.GetStatesRequest) providers.GetStatesResponse {
 	var resp providers.GetStatesResponse
-	resp.Diagnostics.Append(fmt.Errorf("unsupported state store type %q", req.TypeName))
+	resp.Diagnostics = resp.Diagnostics.Append(fmt.Errorf("unsupported state store type %q", req.TypeName))
 	return resp
 }
 
 func (p *Provider) DeleteState(req providers.DeleteStateRequest) providers.DeleteStateResponse {
 	var resp providers.DeleteStateResponse
-	resp.Diagnostics.Append(fmt.Errorf("unsupported state store type %q", req.TypeName))
+	resp.Diagnostics = resp.Diagnostics.Append(fmt.Errorf("unsupported state store type %q", req.TypeName))
 	return resp
 }
 

--- a/internal/provider-simple-v6/provider.go
+++ b/internal/provider-simple-v6/provider.go
@@ -364,7 +364,7 @@ func (s simple) ValidateStateStoreConfig(req providers.ValidateStateStoreConfigR
 	}
 
 	var resp providers.ValidateStateStoreConfigResponse
-	resp.Diagnostics.Append(fmt.Errorf("unsupported state store type %q", req.TypeName))
+	resp.Diagnostics = resp.Diagnostics.Append(fmt.Errorf("unsupported state store type %q", req.TypeName))
 	return resp
 }
 
@@ -377,7 +377,7 @@ func (s simple) ConfigureStateStore(req providers.ConfigureStateStoreRequest) pr
 	}
 
 	var resp providers.ConfigureStateStoreResponse
-	resp.Diagnostics.Append(fmt.Errorf("unsupported state store type %q", req.TypeName))
+	resp.Diagnostics = resp.Diagnostics.Append(fmt.Errorf("unsupported state store type %q", req.TypeName))
 	return resp
 }
 
@@ -390,7 +390,7 @@ func (s simple) ReadStateBytes(req providers.ReadStateBytesRequest) providers.Re
 	}
 
 	var resp providers.ReadStateBytesResponse
-	resp.Diagnostics.Append(fmt.Errorf("unsupported state store type %q", req.TypeName))
+	resp.Diagnostics = resp.Diagnostics.Append(fmt.Errorf("unsupported state store type %q", req.TypeName))
 	return resp
 }
 
@@ -403,7 +403,7 @@ func (s simple) WriteStateBytes(req providers.WriteStateBytesRequest) providers.
 	}
 
 	var resp providers.WriteStateBytesResponse
-	resp.Diagnostics.Append(fmt.Errorf("unsupported state store type %q", req.TypeName))
+	resp.Diagnostics = resp.Diagnostics.Append(fmt.Errorf("unsupported state store type %q", req.TypeName))
 	return resp
 }
 
@@ -416,7 +416,7 @@ func (s simple) LockState(req providers.LockStateRequest) providers.LockStateRes
 	}
 
 	var resp providers.LockStateResponse
-	resp.Diagnostics.Append(fmt.Errorf("unsupported state store type %q", req.TypeName))
+	resp.Diagnostics = resp.Diagnostics.Append(fmt.Errorf("unsupported state store type %q", req.TypeName))
 	return resp
 }
 
@@ -429,7 +429,7 @@ func (s simple) UnlockState(req providers.UnlockStateRequest) providers.UnlockSt
 	}
 
 	var resp providers.UnlockStateResponse
-	resp.Diagnostics.Append(fmt.Errorf("unsupported state store type %q", req.TypeName))
+	resp.Diagnostics = resp.Diagnostics.Append(fmt.Errorf("unsupported state store type %q", req.TypeName))
 	return resp
 }
 
@@ -442,7 +442,7 @@ func (s simple) GetStates(req providers.GetStatesRequest) providers.GetStatesRes
 	}
 
 	var resp providers.GetStatesResponse
-	resp.Diagnostics.Append(fmt.Errorf("unsupported state store type %q", req.TypeName))
+	resp.Diagnostics = resp.Diagnostics.Append(fmt.Errorf("unsupported state store type %q", req.TypeName))
 	return resp
 }
 
@@ -455,7 +455,7 @@ func (s simple) DeleteState(req providers.DeleteStateRequest) providers.DeleteSt
 	}
 
 	var resp providers.DeleteStateResponse
-	resp.Diagnostics.Append(fmt.Errorf("unsupported state store type %q", req.TypeName))
+	resp.Diagnostics = resp.Diagnostics.Append(fmt.Errorf("unsupported state store type %q", req.TypeName))
 	return resp
 }
 

--- a/internal/providers/testing/provider_mock.go
+++ b/internal/providers/testing/provider_mock.go
@@ -18,8 +18,10 @@ import (
 	"github.com/hashicorp/terraform/internal/providers"
 )
 
-var _ providers.Interface = (*MockProvider)(nil)
-var _ providers.StateStoreChunkSizeSetter = (*MockProvider)(nil)
+var (
+	_ providers.Interface                 = (*MockProvider)(nil)
+	_ providers.StateStoreChunkSizeSetter = (*MockProvider)(nil)
+)
 
 // MockProvider implements providers.Interface but mocks out all the
 // calls for testing purposes.
@@ -244,7 +246,6 @@ func (p *MockProvider) getResourceIdentitySchemas() providers.GetResourceIdentit
 
 	resp := providers.GetResourceIdentitySchemasResponse{IdentityTypes: make(map[string]providers.IdentitySchema)}
 	if p.GetProviderSchemaResponse != nil {
-
 		for typeName, schema := range p.GetProviderSchemaResponse.ResourceTypes {
 			if schema.Identity != nil {
 				resp.IdentityTypes[typeName] = providers.IdentitySchema{
@@ -253,7 +254,6 @@ func (p *MockProvider) getResourceIdentitySchemas() providers.GetResourceIdentit
 				}
 			}
 		}
-
 	}
 
 	return resp
@@ -495,7 +495,6 @@ func (p *MockProvider) UpgradeResourceState(r providers.UpgradeResourceStateRequ
 		resp.UpgradedState = v
 	case len(r.RawStateJSON) > 0:
 		v, err := ctyjson.Unmarshal(r.RawStateJSON, schemaType)
-
 		if err != nil {
 			resp.Diagnostics = resp.Diagnostics.Append(err)
 			return resp
@@ -534,7 +533,6 @@ func (p *MockProvider) UpgradeResourceIdentity(r providers.UpgradeResourceIdenti
 	identityType := schema.Identity.ImpliedType()
 
 	v, err := ctyjson.Unmarshal(r.RawIdentityJSON, identityType)
-
 	if err != nil {
 		resp.Diagnostics = resp.Diagnostics.Append(err)
 		return resp
@@ -1119,7 +1117,7 @@ func (p *MockProvider) DeleteState(r providers.DeleteStateRequest) (resp provide
 	if _, match := p.MockStates[r.StateId]; match {
 		delete(p.MockStates, r.StateId)
 	} else {
-		resp.Diagnostics.Append(&hcl.Diagnostic{
+		resp.Diagnostics = resp.Diagnostics.Append(&hcl.Diagnostic{
 			Severity: hcl.DiagError,
 			Summary:  "Workspace cannot be deleted",
 			Detail:   fmt.Sprintf("The workspace %q does not exist, so cannot be deleted", r.StateId),


### PR DESCRIPTION
We had a PR recently (https://github.com/hashicorp/terraform/pull/38583) fixing an instance of the problem where appended diagnostics aren't assigned back to the `tfdiags.Disagnostics` variable. I'm planning on adding a PR linting tool that detects that problem on new contributions, as that fix above exposed a race condition that would have been nice to avoid being merged in the first place.

Before adding that, _this PR_ helps reduce some of the background noise from pre-existing examples of this problem in the code base.

This PR focuses on instances that aren't user facing, i.e. are in error paths that would only be encountered in miswritten tests.

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.16.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
