### PR TITLE
test: Show warning when a `-filter` flag has an invalid value

### DIFF
--- a/.changes/v1.16/BUG FIXES-20260515-201307.yaml
+++ b/.changes/v1.16/BUG FIXES-20260515-201307.yaml
@@ -1,0 +1,5 @@
+kind: BUG FIXES
+body: 'test: Terraform will now raise a warning when a file referenced via `-filter` flag does not exist.'
+time: 2026-05-15T20:13:07.430709+01:00
+custom:
+    Issue: "38603"

--- a/internal/backend/local/test.go
+++ b/internal/backend/local/test.go
@@ -180,7 +180,7 @@ func (runner *TestSuiteRunner) collectTests() (*moduletest.Suite, tfdiags.Diagno
 						// If the filter is invalid, we'll simply skip this
 						// entry and print a warning. But we could still execute
 						// any other tests within the filter.
-						diags.Append(tfdiags.Sourceless(
+						diags = diags.Append(tfdiags.Sourceless(
 							tfdiags.Warning,
 							"Unknown test file",
 							fmt.Sprintf("The specified test file, %s, could not be found.", name)))

--- a/internal/command/test_test.go
+++ b/internal/command/test_test.go
@@ -179,6 +179,15 @@ func TestTest_Runs(t *testing.T) {
 			expectedOut: []string{"1 passed, 0 failed"},
 			code:        0,
 		},
+		"multiple_files_with_invalid_filter": {
+			override: "multiple_files",
+			args:     []string{"-filter=nonexistent.tftest.hcl"},
+			expectedOut: []string{
+				"Success! 0 passed, 0 failed.",
+				"Warning: Unknown test file",
+			},
+			code: 0,
+		},
 		"no_state": {
 			expectedOut: []string{"0 passed, 1 failed"},
 			expectedErr: []string{"No value for required variable"},


### PR DESCRIPTION
The `-filter` [flag](https://developer.hashicorp.com/terraform/cli/commands/test#filter-testfile) in the `test` command is for specifying a subset of test files to run. If the value didn't match a filename it was meant to raise a warning, but that warning was lost.

This PR properly appends that warning and also adds test coverage of that 'unhappy path' scenario.

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.16.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [x] This change is user-facing and I added a changelog entry.
- [ ] This change is not user-facing.
