### PR TITLE
fix: Append lost warnings in MaybeGetSchemas

### DIFF
--- a/internal/command/meta.go
+++ b/internal/command/meta.go
@@ -861,14 +861,14 @@ func (c *Meta) MaybeGetSchemas(state *states.State, config *configs.Config) (*te
 
 	path, err := os.Getwd()
 	if err != nil {
-		diags.Append(tfdiags.SimpleWarning(failedToLoadSchemasMessage))
+		diags = diags.Append(tfdiags.SimpleWarning(failedToLoadSchemasMessage))
 		return nil, diags
 	}
 
 	if config == nil {
 		config, diags = c.loadConfig(path)
 		if diags.HasErrors() {
-			diags.Append(tfdiags.SimpleWarning(failedToLoadSchemasMessage))
+			diags = diags.Append(tfdiags.SimpleWarning(failedToLoadSchemasMessage))
 			return nil, diags
 		}
 	}


### PR DESCRIPTION
Fixes lost warning diagnostics. This is part of addressing existing cases of abandoned diagnostics before adding PRs check to prevent new occurrences.

This PR is not meant to revisit design decisions made in https://github.com/hashicorp/terraform/pull/31698. The `MaybeGetSchemas` method was written to tolerate missing schema data, hence errors being downgraded to warnings here.


## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.16.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
