### PR TITLE
fix: Prevent provider binary being installed into a symlinked directory

### DIFF
--- a/.changes/v1.15/BUG FIXES-20260518-164938.yaml
+++ b/.changes/v1.15/BUG FIXES-20260518-164938.yaml
@@ -1,0 +1,5 @@
+kind: BUG FIXES
+body: 'init: Prevent provider binaries from being installed into symlinked directories'
+time: 2026-05-18T16:49:38.375301+01:00
+custom:
+    Issue: "38611"

--- a/internal/command/e2etest/providers_tamper_test.go
+++ b/internal/command/e2etest/providers_tamper_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/e2e"
 	"github.com/hashicorp/terraform/internal/getproviders"
 )
@@ -271,3 +272,54 @@ terraform {
   }
 }
 `
+
+func TestSymlinkProviderTargetDirectory(t *testing.T) {
+	// This test reaches out to releases.hashicorp.com to download the
+	// null provider, so it can only run if network access is allowed.
+	skipIfCannotAccessNetwork(t)
+
+	fixturePath := filepath.Join("testdata", "provider-tampering-base")
+	tf := e2e.NewBinary(t, terraformBin, fixturePath)
+
+	// Create a directory that will be symlinked to inside the plugin cache directory.
+	//
+	// If the provider is downloaded without protections against symlinks present,
+	// the binary will be downloaded to ./other-dir, not the expected
+	// ./terraform/providers/registry.terraform.io/hashicorp/null/3.1.0/<platform>/ location
+	otherDir := tf.Path("other-dir")
+	err := os.MkdirAll(otherDir, 0755)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	const providerVersion = "3.1.0" // must match the version in the fixture config
+	symlinkPathInCache := tf.Path(
+		".terraform",
+		"providers",
+		addrs.DefaultProviderRegistryHost.String(),
+		"hashicorp",
+		"null",
+		providerVersion,
+		getproviders.CurrentPlatform.String(),
+	)
+
+	err = os.MkdirAll(filepath.Dir(symlinkPathInCache), 0755)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = os.Symlink(otherDir, symlinkPathInCache)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	stdout, stderr, err := tf.Run("init", "-no-color")
+	if err == nil {
+		t.Fatalf("unexpected init success\nstdout:\n%s\nstderr:\n%s", stdout, stderr)
+	}
+	if !strings.Contains(stderr, "Failed to install provider") {
+		t.Fatalf("missing expected error message\nstderr:\n%s", stderr)
+	}
+	if !strings.Contains(stderr, "symlink") {
+		t.Fatalf("missing expected error message\nstderr:\n%s", stderr)
+	}
+}

--- a/internal/providercache/package_install.go
+++ b/internal/providercache/package_install.go
@@ -124,6 +124,15 @@ func installFromLocalArchive(ctx context.Context, meta getproviders.PackageMeta,
 	// match the allowed hashes and so our caller should catch that after
 	// we return if so.
 
+	// We will, however, check that the target directory the provider binary will be
+	// placed isn't a symlink, if it already exists. This could be a security risk that
+	// enables files to be written to unexpected locations.
+	if fi, err := os.Lstat(targetDir); err == nil {
+		if fi.Mode().Type() == os.ModeSymlink {
+			return authResult, fmt.Errorf("cannot install package into target directory %s because it is a symlink.", targetDir)
+		}
+	}
+
 	err := unzip.Decompress(targetDir, filename, true, 0000)
 	if err != nil {
 		return authResult, err


### PR DESCRIPTION
This fix checks that the folder a provider binary will be placed into (via .terraform/providers/) isn't a symlink. This prevents a situation where the installation process could save provider binaries to arbitrary locations if a symlink is placed in the provider cache.

This solution doesn't protect against symlinks placed higher in the path to where a provider binary will be saved to. If a symlink was used at a higher level in the cache path, e.g. .terraform/provider itself was replaced by a symlink, then the installation process will create the layers of installation path `<registry name>/<namespace>/<type>/<version>/<platform>` (and then binary in that final dir) in the symlinked location instead of just the binary in isolation.

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.16.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [x] This change is user-facing and I added a changelog entry.
- [ ] This change is not user-facing.
