### PR TITLE
ci: Detect newly-added code in PRs that does not handle returned tfdiags.Diagnostics values.

### DIFF
--- a/tools/defect-detector/analyzer.go
+++ b/tools/defect-detector/analyzer.go
@@ -12,17 +12,18 @@ import (
 	"golang.org/x/tools/go/ast/inspector"
 )
 
-// DiagsAppendAnalyzer reports ignored return values from tfdiags.Diagnostics.Append.
-var DiagsAppendAnalyzer = &analysis.Analyzer{
-	Name: "tfdiagsappendcheck",
-	Doc:  "reports ignored return values from tfdiags.Diagnostics.Append",
+// IgnoredReturnedDiagsAnalyzer reports ignored return values with type tfdiags.Diagnostics.
+// It emits a more specific message for ignored tfdiags.Diagnostics.Append calls.
+var IgnoredReturnedDiagsAnalyzer = &analysis.Analyzer{
+	Name: "ignored_diag_returns",
+	Doc:  "reports ignored tfdiags.Diagnostics return values",
 	Requires: []*analysis.Analyzer{
 		inspect.Analyzer,
 	},
-	Run: run,
+	Run: ignoredDiagReturns,
 }
 
-func run(pass *analysis.Pass) (interface{}, error) {
+func ignoredDiagReturns(pass *analysis.Pass) (interface{}, error) {
 	ins, ok := pass.ResultOf[inspect.Analyzer].(*inspector.Inspector)
 	if !ok {
 		return nil, nil
@@ -36,22 +37,36 @@ func run(pass *analysis.Pass) (interface{}, error) {
 			return
 		}
 
-		sel, ok := call.Fun.(*ast.SelectorExpr)
-		if !ok || sel.Sel == nil || sel.Sel.Name != "Append" {
+		// Report a specialized message for ignored tfdiags.Diagnostics.Append calls.
+		if sel, ok := call.Fun.(*ast.SelectorExpr); ok && sel.Sel != nil && sel.Sel.Name == "Append" {
+			selInfo, ok := pass.TypesInfo.Selections[sel]
+			if ok && selInfo.Kind() == types.MethodVal && isTfdiagsDiagnostics(selInfo.Recv()) {
+				pass.Reportf(sel.Sel.Pos(), "ignored return value from tfdiags.Diagnostics.Append")
+				return
+			}
+		}
+
+		callType := pass.TypesInfo.TypeOf(call)
+		if callType == nil {
 			return
 		}
 
-		selInfo, ok := pass.TypesInfo.Selections[sel]
-		if !ok || selInfo.Kind() != types.MethodVal {
+		diagsReturn := false
+		switch t := callType.(type) {
+		case *types.Tuple:
+			if t.Len() != 1 {
+				return
+			}
+			diagsReturn = isTfdiagsDiagnostics(t.At(0).Type())
+		default:
+			diagsReturn = isTfdiagsDiagnostics(t)
+		}
+
+		if !diagsReturn {
 			return
 		}
 
-		if !isTfdiagsDiagnostics(selInfo.Recv()) {
-			// Ignore calls to other Append methods that aren't tfdiags.Diagnostics.Append.
-			return
-		}
-
-		pass.Reportf(sel.Sel.Pos(), "ignored return value from tfdiags.Diagnostics.Append")
+		pass.Reportf(call.Pos(), "ignored return value with type tfdiags.Diagnostics")
 	})
 
 	return nil, nil

--- a/tools/defect-detector/analyzer_test.go
+++ b/tools/defect-detector/analyzer_test.go
@@ -16,5 +16,5 @@ func TestAnalyzer(t *testing.T) {
 	// Note, assertions are made in comments in the testdata files.
 	// See comments in ./testpkg/testpkg.go
 	// See docs for analysistest.Run for more info: https://pkg.go.dev/golang.org/x/tools/go/analysis/analysistest#Run
-	analysistest.Run(t, testdata, DiagsAppendAnalyzer, "github.com/hashicorp/terraform/tools/tfdiagsappendcheck/testpkg")
+	analysistest.Run(t, testdata, IgnoredReturnedDiagsAnalyzer, "github.com/hashicorp/terraform/tools/testpkg")
 }

--- a/tools/defect-detector/main/main.go
+++ b/tools/defect-detector/main/main.go
@@ -9,5 +9,5 @@ import (
 )
 
 func main() {
-	singlechecker.Main(defectdetector.DiagsAppendAnalyzer)
+	singlechecker.Main(defectdetector.IgnoredReturnedDiagsAnalyzer)
 }

--- a/tools/defect-detector/testdata/src/github.com/hashicorp/terraform/tools/testpkg/diags-append-method-usage.go
+++ b/tools/defect-detector/testdata/src/github.com/hashicorp/terraform/tools/testpkg/diags-append-method-usage.go
@@ -1,14 +1,9 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
 package testpkg
 
 import "github.com/hashicorp/terraform/internal/tfdiags"
-
-type customAppender struct{}
-
-func (customAppender) Append(...interface{}) {}
-
-type withDiagnostics struct {
-	Diagnostics tfdiags.Diagnostics
-}
 
 func goodAssignment() {
 	var diags tfdiags.Diagnostics
@@ -28,7 +23,16 @@ func badField(resp *withDiagnostics) {
 	resp.Diagnostics.Append(tfdiags.Sourceless(tfdiags.Warning, "summary", "detail")) // want "ignored return value from tfdiags.Diagnostics.Append"
 }
 
+// Something else with an Append method should not get flagged like tfdiags.Diagnostics does.
 func ignoreOtherAppendType() {
 	var other customAppender
 	other.Append("not tfdiags")
+}
+
+type customAppender struct{}
+
+func (customAppender) Append(...interface{}) {}
+
+type withDiagnostics struct {
+	Diagnostics tfdiags.Diagnostics
 }

--- a/tools/defect-detector/testdata/src/github.com/hashicorp/terraform/tools/testpkg/ignored-returns.go
+++ b/tools/defect-detector/testdata/src/github.com/hashicorp/terraform/tools/testpkg/ignored-returns.go
@@ -1,0 +1,33 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package testpkg
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform/internal/tfdiags"
+)
+
+func myFunc() tfdiags.Diagnostics {
+	var diags tfdiags.Diagnostics
+	diags = diags.Append(tfdiags.Sourceless(tfdiags.Warning, "summary", "detail"))
+	return diags
+}
+
+func goodHandleReturns() {
+	diags := myFunc()
+	if len(diags) > 0 {
+		fmt.Printf("have diags: %v", diags)
+	}
+}
+
+func goodIgnoreReturns() {
+	_ = myFunc()
+	fmt.Print("explicitly not using diags value here")
+}
+
+func badNotHandleReturns() {
+	myFunc() // want "ignored return value with type tfdiags.Diagnostics"
+	fmt.Print("no diags value handling here")
+}


### PR DESCRIPTION
This is a potential extension of https://github.com/hashicorp/terraform/pull/38606 that I'll seek some feedback for.

In that PR I updated our CI to detect when the return value from the tfdiags.Diagnostics.Append method is not assigned to a value, which is always incorrect.

This PR updates that Go code analyser to detect all times that a returned tfdiags.Diagnostics value is ignored in calling code. This is a more generalised version of the original problem. Whereas ignoring the return value from the tfdiags.Diagnostics.Append method is **always incorrect**, ignoring a tfdiags.Diagnostics return value elsewhere may be correct.

I'd argue that this CI check doesn't block valid usecases, but now requires that code authors explicitly discard the diagnostics returned using `_`:

```go
func doThing() tfdiags.Diagnostics { ... }

doThing() // bad

_ = doThing() // justifiable, given context of the code

thingDiag := doThing() // good, diags are used.
```

Before opening this PR for review I'm going to ask in our team meeting if we're in agreement about the above, because checks implemented in this way should reflect how we all think about how our code should be written.

<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Fixes #

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

N/A

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
