### PR TITLE
fix: Remove unused returned diagnostics from `(p *Pluggable) Close` method

### DIFF
--- a/internal/backend/pluggable/pluggable.go
+++ b/internal/backend/pluggable/pluggable.go
@@ -190,7 +190,6 @@ func (p *Pluggable) StateMgr(workspace string) (statemgr.Full, tfdiags.Diagnosti
 // We don't call the Close method every time a pluggable state store is used, as in majority of
 // cases Terraform will the ability to manage state throughout the entire operation. In those
 // cases the operation ending is sufficient and appropriate for stopping the child process.
-func (p *Pluggable) Close() tfdiags.Diagnostics {
-	var diags tfdiags.Diagnostics
-	return diags.Append(p.provider.Close())
+func (p *Pluggable) Close() {
+	_ = p.provider.Close()
 }


### PR DESCRIPTION
Follow up to https://github.com/hashicorp/terraform/pull/38573, addressing this piece of feedback: https://github.com/hashicorp/terraform/pull/38573#discussion_r3241290205

>If it's not in use, I'd appreciate you removing the return value - we can always add it back in if a use case appears, but if it's not used, let's drop it. However I'll approve this as-is, so if you want to change it later that's fine too.

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.16.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
