### PR TITLE
Implement `caller` in action blocks

### DIFF
--- a/internal/addrs/parse_ref.go
+++ b/internal/addrs/parse_ref.go
@@ -374,6 +374,13 @@ func parseRef(traversal hcl.Traversal) (*Reference, tfdiags.Diagnostics) {
 			Remaining:   traversal[1:],
 		}, diags
 
+	case "caller":
+		return &Reference{
+			Subject:     Caller,
+			SourceRange: tfdiags.SourceRangeFromHCL(rootRange),
+			Remaining:   traversal[1:],
+		}, diags
+
 	case "terraform":
 		name, rng, remain, diags := parseSingleAttrRef(traversal)
 		return &Reference{

--- a/internal/addrs/self.go
+++ b/internal/addrs/self.go
@@ -5,19 +5,31 @@ package addrs
 
 // Self is the address of the special object "self" that behaves as an alias
 // for a containing object currently in scope.
-const Self selfT = 0
+const Self SelfType = 0
 
-type selfT int
+// Caller is a pseudo-alias for self, representing the object triggering an
+// action. An action is called from within a resource, but we use "caller"
+// because the configuration is written outside of the resource context.
+const Caller SelfType = 1
 
-func (s selfT) referenceableSigil() {
+type SelfType int
+
+func (s SelfType) referenceableSigil() {
 }
 
-func (s selfT) String() string {
-	return "self"
+func (s SelfType) String() string {
+	switch s {
+	case 0:
+		return "self"
+	case 1:
+		return "caller"
+	default:
+		panic("invalid self type")
+	}
 }
 
-func (s selfT) UniqueKey() UniqueKey {
-	return Self // Self is its own UniqueKey
+func (s SelfType) UniqueKey() UniqueKey {
+	return s
 }
 
-func (s selfT) uniqueKeySigil() {}
+func (s SelfType) uniqueKeySigil() {}

--- a/internal/lang/eval.go
+++ b/internal/lang/eval.go
@@ -302,18 +302,9 @@ func (s *Scope) evalContext(refs []*addrs.Reference, selfAddr addrs.Referenceabl
 		rng := ref.SourceRange
 
 		rawSubj := ref.Subject
-		if rawSubj == addrs.Self {
+		if _, ok := rawSubj.(addrs.SelfType); ok {
 			if selfAddr == nil {
-				diags = diags.Append(&hcl.Diagnostic{
-					Severity: hcl.DiagError,
-					Summary:  `Invalid "self" reference`,
-					// This detail message mentions some current practice that
-					// this codepath doesn't really "know about". If the "self"
-					// object starts being supported in more contexts later then
-					// we'll need to adjust this message.
-					Detail:  `The "self" object is not available in this context. This object can be used only in resource provisioner, connection, and postcondition blocks.`,
-					Subject: ref.SourceRange.ToHCL().Ptr(),
-				})
+				diags = diags.Append(SelfContextDiagnostics(ref))
 				continue
 			}
 
@@ -488,6 +479,7 @@ func (s *Scope) evalContext(refs []*addrs.Reference, selfAddr addrs.Referenceabl
 
 	if self != cty.NilVal {
 		vals["self"] = self
+		vals["caller"] = self
 	}
 
 	if len(listResources) > 0 {
@@ -614,4 +606,30 @@ func CheckForUnknownFunctionDiags(diags hcl.Diagnostics, ignoreUnknownProviderFu
 	}
 
 	return filteredDiags
+}
+
+// SelfContextDiagnostics produces a diagnostic message for incorrect usage of
+// the self object with the correct context for "self" vs "caller"
+func SelfContextDiagnostics(ref *addrs.Reference) *hcl.Diagnostic {
+	switch sub := ref.Subject.(type) {
+	case addrs.SelfType:
+		summary := fmt.Sprintf("Invalid %q reference", sub)
+		detail := fmt.Sprintf("The %q object is not available in this context. ", sub)
+		switch {
+		case sub == addrs.Self:
+			detail += "This object can be used only in resource provisioner, connection, and postcondition blocks."
+		case sub == addrs.Caller:
+			detail += "This object can be used only in action blocks triggered from a resource instance."
+		}
+
+		return &hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  summary,
+			Detail:   detail,
+			Subject:  ref.SourceRange.ToHCL().Ptr(),
+		}
+
+	default:
+		panic(fmt.Sprintf("reference %T is not a self type", ref))
+	}
 }

--- a/internal/lang/eval_test.go
+++ b/internal/lang/eval_test.go
@@ -366,14 +366,31 @@ func TestScopeEvalContext(t *testing.T) {
 				}),
 			},
 		},
+
+		// self is populated as both self and caller
 		{
 			Expr: `self.baz`,
 			Want: map[string]cty.Value{
 				"self": cty.ObjectVal(map[string]cty.Value{
 					"attr": cty.StringVal("multi1"),
 				}),
+				"caller": cty.ObjectVal(map[string]cty.Value{
+					"attr": cty.StringVal("multi1"),
+				}),
 			},
 		},
+		{
+			Expr: `caller.baz`,
+			Want: map[string]cty.Value{
+				"self": cty.ObjectVal(map[string]cty.Value{
+					"attr": cty.StringVal("multi1"),
+				}),
+				"caller": cty.ObjectVal(map[string]cty.Value{
+					"attr": cty.StringVal("multi1"),
+				}),
+			},
+		},
+
 		{
 			Expr: `terraform.workspace`,
 			Want: map[string]cty.Value{

--- a/internal/terraform/action_trigger_instance_apply.go
+++ b/internal/terraform/action_trigger_instance_apply.go
@@ -30,7 +30,7 @@ var (
 	_ GraphNodeProviderConsumer = (*actionTriggerApplyInstance)(nil)
 )
 
-func (n *actionTriggerApplyInstance) invoke(ctx EvalContext, wo walkOperation) tfdiags.Diagnostics {
+func (n *actionTriggerApplyInstance) invoke(ctx EvalContext, caller addrs.Referenceable) tfdiags.Diagnostics {
 	var diags tfdiags.Diagnostics
 
 	provider, _, err := getProvider(ctx, n.resolvedProvider)
@@ -55,7 +55,7 @@ func (n *actionTriggerApplyInstance) invoke(ctx EvalContext, wo walkOperation) t
 	}
 
 	// FIXME: missing action trigger reference for diags
-	configValue, actionDiags := n.actionNode.EvalInstance(ctx, n.ActionInvocation.Addr.Action.Key, nil)
+	configValue, actionDiags := n.actionNode.EvalInstance(ctx, n.ActionInvocation.Addr.Action.Key, nil, caller)
 	diags = diags.Append(actionDiags)
 	if diags.HasErrors() {
 		return diags

--- a/internal/terraform/context_plan_actions_test.go
+++ b/internal/terraform/context_plan_actions_test.go
@@ -1309,7 +1309,7 @@ resource "test_object" "a" {
 				},
 			},
 
-			"action config refers to before triggering resource leads to validation error": {
+			"action config refers to triggering resource": {
 				module: map[string]string{
 					"main.tf": `
 action "test_action" "hello" {
@@ -1328,7 +1328,57 @@ resource "test_object" "a" {
 }
 `,
 				},
-				expectPlanActionCalled: true, // The cycle only appears in the apply graph
+				expectPlanActionCalled: true,
+			},
+
+			"caller can be used for triggering resource": {
+				module: map[string]string{
+					"main.tf": `
+action "test_action" "hello" {
+  config {
+    attr = caller.name
+  }
+}
+resource "test_object" "a" {
+  name = "test_name"
+  lifecycle {
+    action_trigger {
+      events = [after_create]
+      actions = [action.test_action.hello]
+    }
+  }
+}
+`,
+				},
+				expectPlanActionCalled: true,
+			},
+
+			"caller is invalid for standalone action": {
+				module: map[string]string{
+					"main.tf": `
+action "test_action" "hello" {
+  config {
+    attr = caller.name
+  }
+}
+resource "test_object" "a" {
+  name = "test_name"
+}
+`,
+				},
+				assertValidateDiagnostics: func(t *testing.T, diags tfdiags.Diagnostics) {
+					if len(diags) != 1 {
+						t.Fatalf("expected exactly 1 diagnostic but had %d", len(diags))
+					}
+
+					if diags[0].Severity() != tfdiags.Error {
+						t.Error("expected error diagnostic")
+					}
+
+					if diags[0].Description().Summary != `Invalid "caller" reference` {
+						t.Errorf("expected diagnostics about invalid caller, got %s", diags[0].Description().Summary)
+					}
+				},
 			},
 
 			"secret values": {

--- a/internal/terraform/evaluate_valid.go
+++ b/internal/terraform/evaluate_valid.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/configs"
 	"github.com/hashicorp/terraform/internal/didyoumean"
+	"github.com/hashicorp/terraform/internal/lang"
 	"github.com/hashicorp/terraform/internal/tfdiags"
 )
 
@@ -52,21 +53,10 @@ func (e *Evaluator) StaticValidateReference(ref *addrs.Reference, modAddr addrs.
 }
 
 func (e *Evaluator) staticValidateReference(ref *addrs.Reference, modCfg *configs.Config, self addrs.Referenceable, source addrs.Referenceable) tfdiags.Diagnostics {
-	if ref.Subject == addrs.Self {
-		// The "self" address is a special alias for the address given as
-		// our self parameter here, if present.
+	if _, ok := ref.Subject.(addrs.SelfType); ok {
 		if self == nil {
 			var diags tfdiags.Diagnostics
-			diags = diags.Append(&hcl.Diagnostic{
-				Severity: hcl.DiagError,
-				Summary:  `Invalid "self" reference`,
-				// This detail message mentions some current practice that
-				// this codepath doesn't really "know about". If the "self"
-				// object starts being supported in more contexts later then
-				// we'll need to adjust this message.
-				Detail:  `The "self" object is not available in this context. This object can be used only in resource provisioner, connection, and postcondition blocks.`,
-				Subject: ref.SourceRange.ToHCL().Ptr(),
-			})
+			diags = diags.Append(lang.SelfContextDiagnostics(ref))
 			return diags
 		}
 

--- a/internal/terraform/graph_builder_plan.go
+++ b/internal/terraform/graph_builder_plan.go
@@ -80,9 +80,6 @@ type PlanGraphBuilder struct {
 	ConcreteResourceOrphan          ConcreteResourceInstanceNodeFunc
 	ConcreteResourceInstanceDeposed ConcreteResourceInstanceDeposedNodeFunc
 	ConcreteModule                  ConcreteModuleNodeFunc
-	// ConcreteAction is only used by the ConfigTransformer during the Validate
-	// Graph walk; otherwise we fall back to the DefaultConcreteActionFunc.
-	ConcreteAction ConcreteActionNodeFunc
 
 	// Plan Operation this graph will be used for.
 	Operation walkOperation
@@ -162,9 +159,9 @@ func (b *PlanGraphBuilder) Steps() []GraphTransformer {
 	steps := []GraphTransformer{
 		// Creates all the resources represented in the config
 		&ConfigTransformer{
-			Concrete: b.ConcreteResource,
-			Config:   b.Config,
-			destroy:  b.Operation == walkDestroy || b.Operation == walkPlanDestroy,
+			Concrete:  b.ConcreteResource,
+			Config:    b.Config,
+			Operation: b.Operation,
 
 			importTargets: b.ImportTargets,
 
@@ -385,12 +382,6 @@ func (b *PlanGraphBuilder) initValidate() {
 	b.ConcreteModule = func(n *nodeExpandModule) dag.Vertex {
 		return &nodeValidateModule{
 			nodeExpandModule: *n,
-		}
-	}
-
-	b.ConcreteAction = func(a *NodeActionConfig) dag.Vertex {
-		return &NodeValidatableAction{
-			NodeActionConfig: a,
 		}
 	}
 }

--- a/internal/terraform/node_action.go
+++ b/internal/terraform/node_action.go
@@ -56,16 +56,9 @@ func (n NodeActionConfig) Name() string {
 	return n.Addr.String()
 }
 
-// The action config does not expand or execute itself during plan or apply, but
-// for Validate it does verify valid configuration.
-func (n *NodeActionConfig) Execute(ctx EvalContext, op walkOperation) tfdiags.Diagnostics {
-	if op != walkValidate {
-		return nil
-	}
-	return n.validate(ctx)
-}
-
-func (n *NodeActionConfig) validate(ctx EvalContext) tfdiags.Diagnostics {
+// Validate validates the action config, with an optional caller address if the
+// action is invoked from a resource action trigger.
+func (n *NodeActionConfig) Validate(ctx EvalContext, caller addrs.Referenceable) tfdiags.Diagnostics {
 	var diags tfdiags.Diagnostics
 
 	provider, providerSchema, err := getProvider(ctx, n.ResolvedProvider)
@@ -117,7 +110,7 @@ func (n *NodeActionConfig) validate(ctx EvalContext) tfdiags.Diagnostics {
 		config = hcl.EmptyBody()
 	}
 
-	configVal, _, valDiags := ctx.EvaluateBlock(config, schema.ConfigSchema, nil, keyData)
+	configVal, _, valDiags := ctx.EvaluateBlock(config, schema.ConfigSchema, caller, keyData)
 	if valDiags.HasErrors() {
 		// If there was no config block at all, we'll add a Context range to the returned diagnostic
 		if n.Config.Config == nil {
@@ -276,12 +269,12 @@ func (n *NodeActionConfig) repetitionData(ctx EvalContext) ([]instances.Repetiti
 // addrs.NoKey This function uses addrs.ActionInstance even though it only needs
 // the key because we need to use use a full instance addr for the resulting map
 // keys anyway.
-func (n *NodeActionConfig) EvalInstances(ctx EvalContext, addr addrs.ActionInstance, callRange *hcl.Range) (addrs.Map[addrs.ActionInstance, cty.Value], tfdiags.Diagnostics) {
+func (n *NodeActionConfig) EvalInstances(ctx EvalContext, addr addrs.ActionInstance, callRange *hcl.Range, caller addrs.Referenceable) (addrs.Map[addrs.ActionInstance, cty.Value], tfdiags.Diagnostics) {
 	all := addrs.MakeMap[addrs.ActionInstance, cty.Value]()
 
 	switch key := addr.Key.(type) {
 	case addrs.IntKey, addrs.StringKey:
-		val, diags := n.EvalInstance(ctx, key, callRange)
+		val, diags := n.EvalInstance(ctx, key, callRange, caller)
 		if diags.HasErrors() {
 			return all, diags
 		}
@@ -289,12 +282,12 @@ func (n *NodeActionConfig) EvalInstances(ctx EvalContext, addr addrs.ActionInsta
 		return all, diags
 
 	default:
-		return n.eval(ctx, addr.Key, callRange)
+		return n.eval(ctx, addr.Key, callRange, caller)
 	}
 }
 
 // EvalInstance returns the value from the expanded action block
-func (n *NodeActionConfig) EvalInstance(ctx EvalContext, key addrs.InstanceKey, callRange *hcl.Range) (cty.Value, tfdiags.Diagnostics) {
+func (n *NodeActionConfig) EvalInstance(ctx EvalContext, key addrs.InstanceKey, callRange *hcl.Range, caller addrs.Referenceable) (cty.Value, tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
 	// we first validate the correct type of key is being used for the action
 	switch {
@@ -368,7 +361,7 @@ func (n *NodeActionConfig) EvalInstance(ctx EvalContext, key addrs.InstanceKey, 
 		}
 	}
 
-	vals, diags := n.eval(ctx, key, callRange)
+	vals, diags := n.eval(ctx, key, callRange, caller)
 	if diags.HasErrors() {
 		return cty.DynamicVal, diags
 	}
@@ -380,7 +373,7 @@ func (n *NodeActionConfig) EvalInstance(ctx EvalContext, key addrs.InstanceKey, 
 // Eval one or more instances of the action. This function expects that the key
 // is already validated for the the calling context, and will not produce
 // diagnostics for incorrect key types.
-func (n *NodeActionConfig) eval(ctx EvalContext, key addrs.InstanceKey, callRange *hcl.Range) (addrs.Map[addrs.ActionInstance, cty.Value], tfdiags.Diagnostics) {
+func (n *NodeActionConfig) eval(ctx EvalContext, key addrs.InstanceKey, callRange *hcl.Range, caller addrs.Referenceable) (addrs.Map[addrs.ActionInstance, cty.Value], tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
 	all := addrs.MakeMap[addrs.ActionInstance, cty.Value]()
 
@@ -401,7 +394,7 @@ func (n *NodeActionConfig) eval(ctx EvalContext, key addrs.InstanceKey, callRang
 			return all, diags
 		}
 
-		val, evalDiags := n.evalInstance(ctx, actionInstances[int(key)])
+		val, evalDiags := n.evalInstance(ctx, actionInstances[int(key)], caller)
 		diags = append(diags, evalDiags...)
 		all.Put(n.Addr.Action.Instance(key), val)
 
@@ -413,7 +406,7 @@ func (n *NodeActionConfig) eval(ctx EvalContext, key addrs.InstanceKey, callRang
 			if inst.EachKey.AsString() != string(key) {
 				continue
 			}
-			val, evalDiags := n.evalInstance(ctx, inst)
+			val, evalDiags := n.evalInstance(ctx, inst, caller)
 			diags = diags.Append(evalDiags)
 			if evalDiags.HasErrors() {
 				return all, diags
@@ -436,7 +429,7 @@ func (n *NodeActionConfig) eval(ctx EvalContext, key addrs.InstanceKey, callRang
 
 	default:
 		for _, inst := range actionInstances {
-			val, evalDiags := n.evalInstance(ctx, inst)
+			val, evalDiags := n.evalInstance(ctx, inst, caller)
 			diags = diags.Append(evalDiags)
 			if diags.HasErrors() {
 				return all, diags
@@ -458,7 +451,7 @@ func (n *NodeActionConfig) eval(ctx EvalContext, key addrs.InstanceKey, callRang
 	}
 }
 
-func (n *NodeActionConfig) evalInstance(ctx EvalContext, repData instances.RepetitionData) (cty.Value, tfdiags.Diagnostics) {
+func (n *NodeActionConfig) evalInstance(ctx EvalContext, repData instances.RepetitionData, caller addrs.Referenceable) (cty.Value, tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
 
 	// This should have been caught already
@@ -469,7 +462,7 @@ func (n *NodeActionConfig) evalInstance(ctx EvalContext, repData instances.Repet
 	configVal := cty.NullVal(n.Schema.ConfigSchema.ImpliedType())
 	if n.Config.Config != nil {
 		var configDiags tfdiags.Diagnostics
-		configVal, _, configDiags = ctx.EvaluateBlock(n.Config.Config, n.Schema.ConfigSchema.DeepCopy(), nil, repData)
+		configVal, _, configDiags = ctx.EvaluateBlock(n.Config.Config, n.Schema.ConfigSchema.DeepCopy(), caller, repData)
 		diags = diags.Append(configDiags)
 		if configDiags.HasErrors() {
 			return configVal, diags

--- a/internal/terraform/node_action_invoke.go
+++ b/internal/terraform/node_action_invoke.go
@@ -116,7 +116,7 @@ func (n *nodeActionPlanInvoke) Execute(ctx EvalContext, _ walkOperation) tfdiags
 func (n *nodeActionPlanInvoke) invokeActions(ctx EvalContext) tfdiags.Diagnostics {
 	var diags tfdiags.Diagnostics
 
-	actionVals, actionDiags := n.ActionConfig.EvalInstances(ctx, n.Addr.Action, nil)
+	actionVals, actionDiags := n.ActionConfig.EvalInstances(ctx, n.Addr.Action, nil, nil)
 	diags = diags.Append(actionDiags)
 	if diags.HasErrors() {
 		return diags
@@ -202,5 +202,5 @@ func (n *nodeActionInvokeApplyInstance) Name() string {
 }
 
 func (n *nodeActionInvokeApplyInstance) Execute(ctx EvalContext, op walkOperation) tfdiags.Diagnostics {
-	return n.invoke(ctx, op)
+	return n.invoke(ctx, nil)
 }

--- a/internal/terraform/node_action_validate.go
+++ b/internal/terraform/node_action_validate.go
@@ -4,14 +4,7 @@
 package terraform
 
 import (
-	"fmt"
-	"log"
-
-	"github.com/hashicorp/hcl/v2"
-	"github.com/zclconf/go-cty/cty"
-
 	"github.com/hashicorp/terraform/internal/addrs"
-	"github.com/hashicorp/terraform/internal/providers"
 	"github.com/hashicorp/terraform/internal/tfdiags"
 )
 
@@ -36,92 +29,5 @@ func (n *NodeValidatableAction) Path() addrs.ModuleInstance {
 }
 
 func (n *NodeValidatableAction) Execute(ctx EvalContext, _ walkOperation) tfdiags.Diagnostics {
-	var diags tfdiags.Diagnostics
-
-	provider, providerSchema, err := getProvider(ctx, n.ResolvedProvider)
-	diags = diags.Append(err)
-	if diags.HasErrors() {
-		return diags
-	}
-
-	keyData := EvalDataForNoInstanceKey
-
-	switch {
-	case n.Config.Count != nil:
-		// If the config block has count, we'll evaluate with an unknown
-		// number as count.index so we can still type check even though
-		// we won't expand count until the plan phase.
-		keyData = InstanceKeyEvalData{
-			CountIndex: cty.UnknownVal(cty.Number),
-		}
-
-		// Basic type-checking of the count argument. More complete validation
-		// of this will happen when we DynamicExpand during the plan walk.
-		_, countDiags := evaluateCountExpressionValue(n.Config.Count, ctx)
-		diags = diags.Append(countDiags)
-
-	case n.Config.ForEach != nil:
-		keyData = InstanceKeyEvalData{
-			EachKey:   cty.UnknownVal(cty.String),
-			EachValue: cty.UnknownVal(cty.DynamicPseudoType),
-		}
-
-		// Evaluate the for_each expression here so we can expose the diagnostics
-		forEachDiags := newForEachEvaluator(n.Config.ForEach, ctx, false).ValidateActionValue()
-		diags = diags.Append(forEachDiags)
-	}
-
-	schema := providerSchema.SchemaForActionType(n.Config.Type)
-	if schema.ConfigSchema == nil {
-		diags = diags.Append(&hcl.Diagnostic{
-			Severity: hcl.DiagError,
-			Summary:  "Invalid action type",
-			Detail:   fmt.Sprintf("The provider %s does not support action type %q.", n.Provider().ForDisplay(), n.Config.Type),
-			Subject:  &n.Config.TypeRange,
-		})
-		return diags
-	}
-
-	config := n.Config.Config
-	if n.Config.Config == nil {
-		config = hcl.EmptyBody()
-	}
-
-	configVal, _, valDiags := ctx.EvaluateBlock(config, schema.ConfigSchema, nil, keyData)
-	if valDiags.HasErrors() {
-		// If there was no config block at all, we'll add a Context range to the returned diagnostic
-		if n.Config.Config == nil {
-			for _, diag := range valDiags.ToHCL() {
-				diag.Context = &n.Config.DeclRange
-				diags = diags.Append(diag)
-			}
-			return diags
-		} else {
-			diags = diags.Append(valDiags)
-			return diags
-		}
-	}
-	var deprecationDiags tfdiags.Diagnostics
-	configVal, deprecationDiags = ctx.Deprecations().ValidateAndUnmarkConfig(configVal, schema.ConfigSchema, n.ModulePath())
-	diags = diags.Append(deprecationDiags.InConfigBody(n.Config.Config, n.Addr.String()))
-
-	valDiags = validateResourceForbiddenEphemeralValues(ctx, configVal, schema.ConfigSchema)
-	diags = diags.Append(valDiags.InConfigBody(config, n.Addr.String()))
-
-	if diags.HasErrors() {
-		return diags
-	}
-
-	// Use unmarked value for validate request
-	unmarkedConfigVal, _ := configVal.UnmarkDeep()
-	log.Printf("[TRACE] Validating config for %q", n.Addr)
-	req := providers.ValidateActionConfigRequest{
-		TypeName: n.Config.Type,
-		Config:   unmarkedConfigVal,
-	}
-
-	resp := provider.ValidateActionConfig(req)
-	diags = diags.Append(resp.Diagnostics.InConfigBody(n.Config.Config, n.Addr.String()))
-
-	return diags
+	return n.Validate(ctx, nil)
 }

--- a/internal/terraform/node_resource_abstract.go
+++ b/internal/terraform/node_resource_abstract.go
@@ -94,7 +94,7 @@ type NodeAbstractResource struct {
 	overridePreventDestroy bool
 
 	// actionTriggers records all triggers and their referenced actions. The
-	// Action nodes are referenced directly from the referencing trigger, so
+	// We hold a pointer to the action nodes from the referencing trigger, so
 	// that the action nodes can be resolved to the correct provider in the
 	// graph, while allowing the triggering node to also connect to the same
 	// provider.

--- a/internal/terraform/node_resource_apply_instance.go
+++ b/internal/terraform/node_resource_apply_instance.go
@@ -408,7 +408,7 @@ func (n *NodeApplyableResourceInstance) invokeActions(ctx EvalContext) tfdiags.D
 	var diags tfdiags.Diagnostics
 
 	for _, trigger := range n.actionTriggers {
-		diags = diags.Append(trigger.invoke(ctx, walkApply))
+		diags = diags.Append(trigger.invoke(ctx, n.Addr.Resource))
 		if diags.HasErrors() {
 			break
 		}

--- a/internal/terraform/node_resource_plan_instance.go
+++ b/internal/terraform/node_resource_plan_instance.go
@@ -676,7 +676,7 @@ func (n *NodePlannableResourceInstance) planActionTrigger(ctx EvalContext, resRe
 		panic(fmt.Sprintf("unknown action address type: %T", sub))
 	}
 
-	actionVal, actionDiags := actionRef.actionNode.EvalInstance(ctx, actionInst.Key, actionRef.configRef.Expr.Range().Ptr())
+	actionVal, actionDiags := actionRef.actionNode.EvalInstance(ctx, actionInst.Key, actionRef.configRef.Expr.Range().Ptr(), n.Addr.Resource)
 	diags = diags.Append(actionDiags)
 	if diags.HasErrors() {
 		return diags
@@ -708,6 +708,9 @@ func (n *NodePlannableResourceInstance) planActionTrigger(ctx EvalContext, resRe
 		ProposedActionData: unmarkedConfig,
 		ClientCapabilities: cc,
 	})
+	// FIXME: we can allow deferrals for stacks operation, but we're going to
+	// limit the reason to only ProviderConfigUnknown to avoid infinite planning
+	// loops with the calling resource.
 
 	// FIXME: config body is not the entire action config block
 	// Our diagnostics expect to be associated with a config body, but we may not have one due to the structure of actions.

--- a/internal/terraform/node_resource_validate.go
+++ b/internal/terraform/node_resource_validate.go
@@ -67,6 +67,29 @@ func (n *NodeValidatableResource) Execute(ctx EvalContext, op walkOperation) (di
 				return diags
 			}
 		}
+		diags = diags.Append(n.validateActions(ctx))
+	}
+
+	return diags
+}
+
+func (n *NodeValidatableResource) validateActions(ctx EvalContext) tfdiags.Diagnostics {
+	var diags tfdiags.Diagnostics
+
+	// There may be many triggers and many actions within a trigger, but for the
+	// purposes of validation we don't need to repeat them. Just collect all
+	// known actions and validate them once each.
+	actions := addrs.MakeMap[addrs.ConfigAction, actionRef]()
+	for _, trigger := range n.actionTriggers {
+		for _, ref := range trigger.actionRefs {
+			actions.Put(ref.actionNode.Addr, ref)
+		}
+	}
+
+	_, self := n.stubRepetitionData()
+
+	for _, ref := range actions.Iter() {
+		diags = diags.Append(ref.actionNode.Validate(ctx, self))
 	}
 
 	return diags
@@ -140,7 +163,7 @@ func (n *NodeValidatableResource) validateProvisioner(ctx EvalContext, p *config
 }
 
 func (n *NodeValidatableResource) evaluateBlock(ctx EvalContext, body hcl.Body, schema *configschema.Block) (cty.Value, hcl.Body, tfdiags.Diagnostics) {
-	keyData, selfAddr := n.stubRepetitionData(n.Config.Count != nil, n.Config.ForEach != nil)
+	keyData, selfAddr := n.stubRepetitionData()
 
 	val, hclBody, diags := ctx.EvaluateBlock(body, schema, selfAddr, keyData)
 
@@ -587,7 +610,7 @@ func (n *NodeValidatableResource) evaluateExpr(ctx EvalContext, expr hcl.Express
 	return result, diags
 }
 
-func (n *NodeValidatableResource) stubRepetitionData(hasCount, hasForEach bool) (instances.RepetitionData, addrs.Referenceable) {
+func (n *NodeValidatableResource) stubRepetitionData() (instances.RepetitionData, addrs.Referenceable) {
 	keyData := EvalDataForNoInstanceKey
 	selfAddr := n.ResourceAddr().Resource.Instance(addrs.NoKey)
 
@@ -624,7 +647,7 @@ func (n *NodeValidatableResource) stubRepetitionData(hasCount, hasForEach bool) 
 func (n *NodeValidatableResource) validateCheckRules(ctx EvalContext, config *configs.Resource) tfdiags.Diagnostics {
 	var diags tfdiags.Diagnostics
 
-	keyData, selfAddr := n.stubRepetitionData(n.Config.Count != nil, n.Config.ForEach != nil)
+	keyData, selfAddr := n.stubRepetitionData()
 
 	for _, cr := range config.Preconditions {
 		_, conditionDiags := n.evaluateExpr(ctx, cr.Condition, cty.Bool, nil, keyData)

--- a/internal/terraform/transform_config.go
+++ b/internal/terraform/transform_config.go
@@ -6,8 +6,6 @@ package terraform
 import (
 	"fmt"
 	"log"
-	"maps"
-	"slices"
 
 	"github.com/hashicorp/hcl/v2"
 
@@ -31,14 +29,12 @@ import (
 // resources including module resources, rather than creating module nodes that
 // are then "flattened".
 type ConfigTransformer struct {
-	Concrete       ConcreteResourceNodeFunc
-	ConcreteAction ConcreteActionNodeFunc
+	Concrete ConcreteResourceNodeFunc
 
 	// Module is the module to add resources from.
 	Config *configs.Config
 
-	// some actions are skipped during the destroy process
-	destroy bool
+	Operation walkOperation
 
 	// importTargets specifies a slice of addresses that will have state
 	// imported for them.
@@ -94,8 +90,10 @@ func (t *ConfigTransformer) transformSingle(g *Graph, config *configs.Config) er
 	module := config.Module
 	log.Printf("[TRACE] ConfigTransformer: Starting for path: %v", path)
 
+	destroy := t.Operation == walkDestroy || t.Operation == walkPlanDestroy
+
 	var allResources []*configs.Resource
-	if !t.destroy {
+	if !destroy {
 		for _, r := range module.ManagedResources {
 			allResources = append(allResources, r)
 		}
@@ -132,7 +130,13 @@ func (t *ConfigTransformer) transformSingle(g *Graph, config *configs.Config) er
 	// collect all the Action Declarations (configs.Actions) in this module so
 	// we can validate that actions referenced in a resource's ActionTriggers
 	// exist in this module.
-	allConfigActions := make(map[string]*NodeActionConfig)
+	allConfigActions := addrs.MakeMap[addrs.ConfigAction, *NodeActionConfig]()
+
+	// because action blocks are usable in multiple ways we also need to track
+	// which ones have not been "used" within the configuration, so that they
+	// can be validated as standalone blocks with no caller.
+	referencedActionConfigs := addrs.MakeSet[addrs.ConfigAction]()
+
 	for _, a := range module.Actions {
 		if a != nil {
 			addr := a.Addr().InModule(path)
@@ -143,7 +147,7 @@ func (t *ConfigTransformer) transformSingle(g *Graph, config *configs.Config) er
 			}
 
 			g.Add(abstract)
-			allConfigActions[addr.String()] = abstract
+			allConfigActions.Put(addr, abstract)
 		}
 	}
 
@@ -184,9 +188,13 @@ func (t *ConfigTransformer) transformSingle(g *Graph, config *configs.Config) er
 					}
 
 					// Verify that any actions referenced in the resource's ActionTriggers exist in this module
-					actionNode, ok := allConfigActions[configAction.String()]
+					actionNode, ok := allConfigActions.GetOk(configAction)
 					if !ok {
-						suggestion := didyoumean.NameSuggestion(configAction.String(), slices.Collect(maps.Keys(allConfigActions)))
+						var keys []string
+						for k := range allConfigActions.Iter() {
+							keys = append(keys, k.String())
+						}
+						suggestion := didyoumean.NameSuggestion(configAction.String(), keys)
 						if suggestion != "" {
 							suggestion = fmt.Sprintf(" Did you mean %q?", suggestion)
 						}
@@ -200,6 +208,7 @@ func (t *ConfigTransformer) transformSingle(g *Graph, config *configs.Config) er
 						})
 						continue
 					}
+					referencedActionConfigs.Add(configAction)
 					resActTrig.actionRefs = append(resActTrig.actionRefs, actionRef{
 						configRef:   action,
 						actionNode:  actionNode,
@@ -210,6 +219,7 @@ func (t *ConfigTransformer) transformSingle(g *Graph, config *configs.Config) er
 				abstract.actionTriggers = append(abstract.actionTriggers, resActTrig)
 			}
 		}
+
 		if diags.HasErrors() {
 			return diags.Err()
 		}
@@ -258,6 +268,17 @@ func (t *ConfigTransformer) transformSingle(g *Graph, config *configs.Config) er
 		g.Add(node)
 	}
 
+	// convert unused action config nodes into validation nodes
+	if t.Operation == walkValidate {
+		for addr, node := range allConfigActions.Iter() {
+			if !referencedActionConfigs.Has(addr) {
+				g.Remove(node)
+				log.Printf("[DEBUG] replacing unused ActionConfig %s with standalone validation node", addr)
+				g.Add(&NodeValidatableAction{node})
+			}
+		}
+	}
+
 	// If any import targets were not claimed by resources we may be
 	// generating configuration. Add them to the graph for validation.
 	for _, i := range importTargets {
@@ -285,9 +306,11 @@ func (t *ConfigTransformer) transformSingle(g *Graph, config *configs.Config) er
 // validateImportTargets ensures that the import target module exists in the
 // configuration. Individual resources will be check by the validation node.
 func (t *ConfigTransformer) validateImportTargets() error {
-	if t.destroy {
+	// there are no imports during destroy
+	if t.Operation == walkDestroy || t.Operation == walkPlanDestroy {
 		return nil
 	}
+
 	var diags tfdiags.Diagnostics
 
 	for _, i := range t.importTargets {


### PR DESCRIPTION
Because actions are written outside of resources, but are effectively evaluated like provisioners, we create a "caller" object which is a pseudo-alias for "self". The word "self" would be confusing since it typically refers to the surrounding object, but there is no surrounding object in this context. The term "caller" makes it more clear that there is a special object coming from outside of the context of the action config block.

Since actions often need to make use of the triggering resource's state, but the syntax causes reference cycles which can't be fully resolved, we can simplify the configuration using the `caller` object instead.

```
resource "terraform_data" "test" {
  input = "test"
  lifecycle {
    action_trigger {
      events = [after_create]
      actions = [action.test_action.hello]
    }
  }
}

action "test_action" "hello {
  config {
    input = caller.output
  }
}
```

We need to thread "caller" through all action evaluation. We do this by using the same mechanism as "self", since this is effectively just "self at a distance". That means we can leverage all the same mechanisms built around "self" and only need to change some diagnostic output to match the context.

In order to validate action blocks however, it now means there needs to be a `caller` supplied in the `self` argument, so we can't validate them before we get to the triggering resource like we were doing. We have to manually validate actions from the triggering nodes now, and only insert a `NodeValidateAction` for standalone actions that are not referenced otherwise.