### PR TITLE
chore: Remove unneeded `init` test

### DIFF
--- a/internal/command/init_test.go
+++ b/internal/command/init_test.go
@@ -3944,7 +3944,6 @@ func TestInit_stateStore_newWorkingDir(t *testing.T) {
 
 		args := []string{
 			"-enable-pluggable-state-storage-experiment=true",
-			// This test doesn't need -safe-init in the flags due to the location of the provider
 		}
 		code := c.Run(args)
 		testOutput := done(t)
@@ -4226,7 +4225,7 @@ func TestInit_stateStore_newWorkingDir(t *testing.T) {
 			"hashicorp/test": {"1.2.3"},
 		})
 
-		// Set up providers for use in the second init attempt after the user adds the -safe-init flag.
+		// Set up providers for use in the second init attempt.
 		mockProvider := mockPluggableStateStorageProvider()
 
 		ui := new(cli.MockUi)
@@ -4942,16 +4941,6 @@ func TestInit_stateStore_configChanges(t *testing.T) {
 
 	// TODO: once state migrate command is implemented, add test cases in state_migrate_test.go matching the tests
 	// removed from this file in the same commit as this TODO.
-}
-
-func TestInit_stateStore_providerUpgrade(t *testing.T) {
-	t.Skip("See TODOs below. This test was removed as part of TF-36263")
-	// TODO: Add a test showing that provider updated in init that affect the PSS provider are blocked and users
-	// are prompted to run state migrate or pin the PSS provider version and re-run init -upgrade.
-
-	// TODO: once state migrate command is implemented, add test cases in state_migrate_test.go that show:
-	// 1) a migration when the provider version is updated.
-	// 2) a migration when the provider version is updated and the schema has a breaking change.
 }
 
 // Test a scenario where the configuration changes but the -backend-config CLI flags compensate for those changes


### PR DESCRIPTION
Follow up to https://github.com/hashicorp/terraform/pull/38391

That PR added tests showing that upgrading the provider used for PSS is blocked in init. There are no other upgrade-related user stories related to PSS in init, as upgrading the state storage provider will only be possible through a new `state migrate` command in future.  Therefore these TODOs etc should be removed.

This PR also updates some old code comments that have outdated reference to a `-safe-init` flag that's no longer part of the plan.

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->
N/A
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
