### PR TITLE
Improve `init --from-module` test coverage

### DIFF
--- a/internal/initwd/from_module.go
+++ b/internal/initwd/from_module.go
@@ -217,9 +217,7 @@ func DirFromModule(ctx context.Context, loader *configload.Loader, rootDir, modu
 			mod, _ := loader.Parser().LoadConfigDir(rootDir) // ignore diagnostics since we're just doing value-add here anyway
 			if mod != nil {
 				for _, mc := range mod.ModuleCalls {
-					// TODO improve this
 					sourceVal, _ := mc.SourceExpr.Value(nil)
-
 					if !sourceVal.IsKnown() {
 						diags = diags.Append(&hcl.Diagnostic{
 							Severity: hcl.DiagError,

--- a/internal/initwd/from_module_test.go
+++ b/internal/initwd/from_module_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	version "github.com/hashicorp/go-version"
+	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/terraform/internal/configs"
 	"github.com/hashicorp/terraform/internal/configs/configload"
 	"github.com/hashicorp/terraform/internal/copy"
@@ -357,4 +358,38 @@ func TestDirFromModule_rel_submodules(t *testing.T) {
 		gotTraces[path] = varDesc
 	})
 	assertResultDeepEqual(t, gotTraces, wantTraces)
+}
+
+func TestDirFromModule_submodulesWithDynamicSources(t *testing.T) {
+	fixtureDir := filepath.Clean("testdata/empty")
+	fromModuleDir, err := filepath.Abs("./testdata/local-module-dynamic-sources")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tmpDir, done := tempChdir(t, fixtureDir)
+	defer done()
+
+	hooks := &testInstallHooks{}
+	dir, err := filepath.EvalSymlinks(tmpDir)
+	if err != nil {
+		t.Error(err)
+	}
+	modInstallDir := filepath.Join(dir, ".terraform/modules")
+
+	loader, cleanup := configload.NewLoaderForTests(t)
+	defer cleanup()
+	diags := DirFromModule(context.Background(), loader, dir, modInstallDir, fromModuleDir, nil, hooks)
+
+	wantDiags := tfdiags.Diagnostics{}.Append(&hcl.Diagnostic{
+		Severity: hcl.DiagError,
+		Summary:  "Unknown module source",
+		Detail:   "Dynamic module sources cannot be used in conjunction with -from-module",
+		Subject: &hcl.Range{
+			Filename: filepath.Join(dir, "main.tf"),
+			Start:    hcl.Pos{Line: 2, Column: 12, Byte: 27},
+			End:      hcl.Pos{Line: 2, Column: 27, Byte: 42},
+		},
+	})
+	tfdiags.AssertDiagnosticsMatch(t, diags, wantDiags)
 }

--- a/internal/initwd/testdata/local-module-dynamic-sources/main.tf
+++ b/internal/initwd/testdata/local-module-dynamic-sources/main.tf
@@ -1,0 +1,8 @@
+module "name" {
+  source = "./${var.path}"
+}
+
+variable "path" {
+  type    = string
+  default = "child"
+}


### PR DESCRIPTION
Clean up an old todo and add a test for the simplified error message that was introduced in c6b61bf731e117438c92e430800c2516ad204060.

<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.16.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
