### PR TITLE
Check for configuration errors before installing modules

### DIFF
--- a/.changes/v1.15/BUG FIXES-20260520-183443.yaml
+++ b/.changes/v1.15/BUG FIXES-20260520-183443.yaml
@@ -1,0 +1,5 @@
+kind: BUG FIXES
+body: Fix crash on `init` for modules with empty source
+time: 2026-05-20T18:34:43.331672+02:00
+custom:
+    Issue: "38628"

--- a/internal/command/init_test.go
+++ b/internal/command/init_test.go
@@ -6374,6 +6374,36 @@ func TestInit_varValueWithoutConfig(t *testing.T) {
 	}
 }
 
+func TestInit_invalidConfig(t *testing.T) {
+	td := t.TempDir()
+	t.Chdir(td)
+	cfg1 := `module "test" { version = "1" }`
+
+	if err := os.WriteFile(filepath.Join(td, "main.tf"), []byte(cfg1), 0644); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	ui := cli.NewMockUi()
+	view, done := testView(t)
+	initCmd := &InitCommand{
+		Meta: Meta{
+			Ui:   ui,
+			View: view,
+		},
+	}
+
+	code := initCmd.Run([]string{})
+	testOutput := done(t)
+	if code != 1 {
+		t.Fatalf("expected init to fail with code 1, got code %d: \n%s", code, testOutput.All())
+	}
+
+	expectedErr := "Error: Missing required argument"
+	if !strings.Contains(cleanString(testOutput.Stderr()), expectedErr) {
+		t.Fatalf("unexpected error, expected %q, given: %s", expectedErr, testOutput.Stderr())
+	}
+}
+
 // newMockProviderSource is a helper to succinctly construct a mock provider
 // source that contains a set of packages matching the given provider versions
 // that are available for installation (from temporary local files).

--- a/internal/terraform/node_module_install.go
+++ b/internal/terraform/node_module_install.go
@@ -73,6 +73,12 @@ func (n *nodeInstallModule) References() []*addrs.Reference {
 func (n *nodeInstallModule) Execute(ctx EvalContext, walkOp walkOperation) tfdiags.Diagnostics {
 	var diags tfdiags.Diagnostics
 
+	if n.ModuleCall.SourceExpr == nil {
+		// Cannot install a module without a source
+		// Outer diags should already contain a parsing error
+		return diags
+	}
+
 	var version configs.VersionConstraint
 	if n.ModuleCall.VersionExpr != nil {
 		var versionDiags tfdiags.Diagnostics
@@ -139,6 +145,12 @@ func (n *nodeInstallModule) Execute(ctx EvalContext, walkOp walkOperation) tfdia
 func (n *nodeInstallModule) DynamicExpand(ctx EvalContext) (*Graph, tfdiags.Diagnostics) {
 	var g Graph
 	var diags tfdiags.Diagnostics
+
+	if n.Config == nil {
+		// Cannot expand without a config. This can happen when something goes wrong
+		// during module installation/Execute() above.
+		return nil, diags
+	}
 
 	expander := ctx.InstanceExpander()
 	_, call := n.Addr.Call()


### PR DESCRIPTION
This PR makes sure that we raise diagnostics for configuration errors before attempting to install modules. The diagnostic is already present, but we still tried to access the missing source expression in the module install node. We now skip the installation and as a result raise the diag.

Fixes #38627

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.15.5

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [x] This change is user-facing and I added a changelog entry.
- [ ] This change is not user-facing.
