### PR TITLE
chore: add a test for import duplication

### DIFF
--- a/internal/terraform/context_apply_import_test.go
+++ b/internal/terraform/context_apply_import_test.go
@@ -81,7 +81,7 @@ func TestContextApply_import_in_module(t *testing.T) {
 		t.Fatal(err)
 	}
 	if got, want := attrs["id"], "testa"; got != want {
-		t.Fatalf("wrong id for \"first\" got:  %#v\nwant: %#v", got, want)
+		t.Fatalf("wrong id for \"first\" got:  %#v  want: %#v\n", got, want)
 	}
 
 	rs = state.ResourceInstance(mustResourceInstanceAddr("module.child.test_object.bar[\"second\"]"))
@@ -93,7 +93,7 @@ func TestContextApply_import_in_module(t *testing.T) {
 		t.Fatal(err)
 	}
 	if got, want := attrs["id"], "testb"; got != want {
-		t.Fatalf("wrong id for \"second\" got:  %#v\nwant: %#v", got, want)
+		t.Fatalf("wrong id for \"second\" got:  %#v  want: %#v\n", got, want)
 	}
 }
 
@@ -198,5 +198,68 @@ func TestContextApply_import_in_expanded_module(t *testing.T) { // count AND for
 
 	if !p.ImportResourceStateCalled {
 		t.Fatal("resources not imported")
+	}
+}
+
+func TestContextApply_import_duplication(t *testing.T) {
+	// two imports to the same resource - one in root, one in the child mod
+	m := testModule(t, "import-block-duplication")
+
+	p := mockProviderWithResourceTypeSchema("test_object", &configschema.Block{
+		Attributes: map[string]*configschema.Attribute{
+			"id":          {Type: cty.String, Computed: true},
+			"test_string": {Type: cty.String, Optional: true},
+		},
+	})
+	p.ImportResourceStateFn = func(req providers.ImportResourceStateRequest) providers.ImportResourceStateResponse {
+		return providers.ImportResourceStateResponse{
+			ImportedResources: []providers.ImportedResource{{
+				TypeName: "test_object",
+				State: cty.ObjectVal(map[string]cty.Value{
+					"test_string": cty.StringVal("importable"),
+					"id":          cty.StringVal(req.ID),
+				}),
+			}},
+		}
+	}
+	p.ReadResourceFn = func(r providers.ReadResourceRequest) providers.ReadResourceResponse {
+		id := r.PriorState.GetAttr("id")
+		return providers.ReadResourceResponse{
+			NewState: cty.ObjectVal(map[string]cty.Value{
+				"test_string": cty.StringVal("importable"),
+				"id":          id,
+			}),
+		}
+	}
+	ctx := testContext2(t, &ContextOpts{
+		Providers: map[addrs.Provider]providers.Factory{
+			addrs.NewDefaultProvider("test"): testProviderFuncFixed(p),
+		},
+	})
+
+	diags := ctx.Validate(m, nil)
+	tfdiags.AssertNoErrors(t, diags)
+
+	plan, diags := ctx.Plan(m, states.NewState(), &PlanOpts{
+		Mode: plans.NormalMode,
+	})
+	tfdiags.AssertNoErrors(t, diags)
+
+	state, diags := ctx.Apply(plan, m, nil)
+	tfdiags.AssertNoErrors(t, diags)
+
+	rs := state.ResourceInstance(mustResourceInstanceAddr("module.child.test_object.foo"))
+	if rs == nil {
+		t.Fatal("imported resource not found in module")
+	}
+	var attrs map[string]interface{}
+	err := json.Unmarshal(rs.Current.AttrsJSON, &attrs)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// the parent module import takes precedence (confirming the comment in refactoring/import_statement.go)
+	if got, want := attrs["id"], "rootimport"; got != want {
+		t.Fatalf("wrong id! got:  %#v  want: %#v\n", got, want)
 	}
 }

--- a/internal/terraform/testdata/import-block-duplication/main.tf
+++ b/internal/terraform/testdata/import-block-duplication/main.tf
@@ -1,0 +1,8 @@
+module "child" {
+    source = "./mod"
+}
+
+import {
+    to = module.child.test_object.foo
+    id = "rootimport"
+}

--- a/internal/terraform/testdata/import-block-duplication/mod/main.tf
+++ b/internal/terraform/testdata/import-block-duplication/mod/main.tf
@@ -1,0 +1,6 @@
+resource "test_object" "foo" {}
+
+import {
+    to = test_object.foo
+    id = "modimport"
+}


### PR DESCRIPTION
I woke up in a cold sweat about not testing the assertion that imports in parent modules take precedence when there are duplicates. I'm genuinely revlieved this Just Worked

<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Fixes #

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.16.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [ ] This change is not user-facing.
