### PR TITLE
Actions are now deferrable

### DIFF
--- a/internal/addrs/partial_expanded.go
+++ b/internal/addrs/partial_expanded.go
@@ -975,3 +975,12 @@ func (per PartialExpandedAction) PartialExpandedModule() (PartialExpandedModule,
 	}
 	return per.module, true
 }
+
+// MatchesAction returns true if and only if the given action belongs to
+// the recieving partially-expanded action address pattern.
+func (per PartialExpandedAction) MatchesAction(inst AbsAction) bool {
+	if !per.module.MatchesInstance(inst.Module) {
+		return false
+	}
+	return inst.Action.Equal(per.action)
+}

--- a/internal/plans/deferring/deferred.go
+++ b/internal/plans/deferring/deferred.go
@@ -789,6 +789,18 @@ func (d *Deferred) ShouldDeferActionInvocation(ai plans.ActionInvocationInstance
 		}
 	}
 
+	// now check if the action config was deferred
+	configAddr := ai.Addr.ConfigAction()
+	if !d.partialExpandedActionsDeferred.Has(configAddr) {
+		d.partialExpandedActionsDeferred.Put(configAddr, addrs.MakeMap[addrs.PartialExpandedAction, providers.DeferredReason]())
+	}
+
+	for partial := range d.partialExpandedActionsDeferred.Get(configAddr).Iter() {
+		if partial.MatchesAction(ai.Addr.ContainingAction()) {
+			return true, diags
+		}
+	}
+
 	return false, diags
 }
 

--- a/internal/plans/deferring/deferred.go
+++ b/internal/plans/deferring/deferred.go
@@ -5,6 +5,7 @@ package deferring
 
 import (
 	"fmt"
+	"slices"
 	"sync"
 
 	"github.com/hashicorp/hcl/v2"
@@ -88,8 +89,10 @@ type Deferred struct {
 	actionInvocationDeferred []*plans.DeferredActionInvocation
 
 	// actionExpansionDeferred tracks the action expansions that have been
-	// deferred. This can happen because the action expansion is not yet ready to be executed.
-	actionExpansionDeferred addrs.Map[addrs.ConfigAction, addrs.Map[addrs.AbsActionInstance, providers.DeferredReason]]
+	// deferred. This can happen because the action expansion is not yet ready
+	// to be executed, so we only track whole action objects as opposed to
+	// instances.
+	actionExpansionDeferred addrs.Map[addrs.ConfigAction, addrs.Map[addrs.AbsAction, providers.DeferredReason]]
 
 	// partialExpandedResourcesDeferred tracks placeholders that cover an
 	// unbounded set of potential resource instances in situations where we
@@ -163,7 +166,7 @@ func NewDeferred(enabled bool) *Deferred {
 		ephemeralResourceInstancesDeferred:       addrs.MakeMap[addrs.ConfigResource, addrs.Map[addrs.AbsResourceInstance, *plans.DeferredResourceInstanceChange]](),
 		dataSourceInstancesDeferred:              addrs.MakeMap[addrs.ConfigResource, addrs.Map[addrs.AbsResourceInstance, *plans.DeferredResourceInstanceChange]](),
 		actionInvocationDeferred:                 []*plans.DeferredActionInvocation{},
-		actionExpansionDeferred:                  addrs.MakeMap[addrs.ConfigAction, addrs.Map[addrs.AbsActionInstance, providers.DeferredReason]](),
+		actionExpansionDeferred:                  addrs.MakeMap[addrs.ConfigAction, addrs.Map[addrs.AbsAction, providers.DeferredReason]](),
 		partialExpandedResourcesDeferred:         addrs.MakeMap[addrs.ConfigResource, addrs.Map[addrs.PartialExpandedResource, *plans.DeferredResourceInstanceChange]](),
 		partialExpandedDataSourcesDeferred:       addrs.MakeMap[addrs.ConfigResource, addrs.Map[addrs.PartialExpandedResource, *plans.DeferredResourceInstanceChange]](),
 		partialExpandedEphemeralResourceDeferred: addrs.MakeMap[addrs.ConfigResource, addrs.Map[addrs.PartialExpandedResource, *plans.DeferredResourceInstanceChange]](),
@@ -175,6 +178,9 @@ func NewDeferred(enabled bool) *Deferred {
 // GetDeferredChanges returns a slice of all the deferred changes that have
 // been reported to the receiver.
 func (d *Deferred) GetDeferredChanges() []*plans.DeferredResourceInstanceChange {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
 	var changes []*plans.DeferredResourceInstanceChange
 
 	if !d.deferralAllowed {
@@ -206,7 +212,10 @@ func (d *Deferred) GetDeferredChanges() []*plans.DeferredResourceInstanceChange 
 
 // GetDeferredActionInvocations returns a list of all deferred action invocations.
 func (d *Deferred) GetDeferredActionInvocations() []*plans.DeferredActionInvocation {
-	return d.actionInvocationDeferred
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	return slices.Clone(d.actionInvocationDeferred)
 }
 
 // SetExternalDependencyDeferred modifies a freshly-constructed [Deferred]
@@ -240,6 +249,9 @@ func (d *Deferred) DeferralAllowed() bool {
 // as having their own changes deferred without having to duplicate the
 // modules runtime's rules for what counts as a deferral.
 func (d *Deferred) HaveAnyDeferrals() bool {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
 	return d.deferralAllowed &&
 		(d.externalDependencyDeferred ||
 			d.resourceInstancesDeferred.Len() != 0 ||
@@ -692,21 +704,21 @@ func (d *Deferred) ReportModuleExpansionDeferred(addr addrs.PartialExpandedModul
 	d.partialExpandedModulesDeferred.Add(addr)
 }
 
+// Providers cannot defer actions individually, however we record deferred
+// invocations for bookkeeping for now so we know which resources were affected.
 func (d *Deferred) ReportActionInvocationDeferred(ai plans.ActionInvocationInstance, reason providers.DeferredReason) {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 
-	// FIXME: an action can be invoked from multiple triggers, so it could be deferred multiple times
-	//
-	// // Check if the action invocation is already deferred
-	// for _, deferred := range d.actionInvocationDeferred {
-	// 	if deferred.ActionInvocationInstance.Equals(&ai) {
-	// 		// This indicates a bug in the caller, since our graph walk should
-	// 		// ensure that we visit and evaluate each distinct action invocation
-	// 		// only once.
-	// 		panic(fmt.Sprintf("duplicate deferral report for action %s invoked by %s", ai.Addr.String(), ai.ActionTrigger.TriggerEvent().String()))
-	// 	}
-	// }
+	// Check if the action invocation is already deferred
+	for _, deferred := range d.actionInvocationDeferred {
+		if deferred.ActionInvocationInstance.Equals(&ai) {
+			// This indicates a bug in the caller, since our graph walk should
+			// ensure that we visit and evaluate each distinct action invocation
+			// only once.
+			panic(fmt.Sprintf("duplicate deferral report for action %s invoked by %s", ai.Addr.String(), ai.ActionTrigger.TriggerEvent().String()))
+		}
+	}
 
 	d.actionInvocationDeferred = append(d.actionInvocationDeferred, &plans.DeferredActionInvocation{
 		ActionInvocationInstance: &ai,
@@ -714,14 +726,14 @@ func (d *Deferred) ReportActionInvocationDeferred(ai plans.ActionInvocationInsta
 	})
 }
 
-// FIXME: an action in isolation doesn't do anything, so what does it mean for it to be deferred?
-func (d *Deferred) ReportActionDeferred(addr addrs.AbsActionInstance, reason providers.DeferredReason) {
+// Report Action Deferred
+func (d *Deferred) ReportActionDeferred(addr addrs.AbsAction, reason providers.DeferredReason) {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 
-	configAddr := addr.ConfigAction()
+	configAddr := addr.Config()
 	if !d.actionExpansionDeferred.Has(configAddr) {
-		d.actionExpansionDeferred.Put(configAddr, addrs.MakeMap[addrs.AbsActionInstance, providers.DeferredReason]())
+		d.actionExpansionDeferred.Put(configAddr, addrs.MakeMap[addrs.AbsAction, providers.DeferredReason]())
 	}
 
 	configMap := d.actionExpansionDeferred.Get(configAddr)
@@ -765,7 +777,7 @@ func (d *Deferred) ShouldDeferActionInvocation(ai plans.ActionInvocationInstance
 	}
 
 	if c, ok := d.actionExpansionDeferred.GetOk(ai.Addr.ConfigAction()); ok {
-		if c.Has(ai.Addr) {
+		if c.Has(ai.Addr.ContainingAction()) {
 			// Then in this case, the resource wasn't deferred but the action
 			// was and so we will consider this to be an error.
 			diags = diags.Append(&hcl.Diagnostic{

--- a/internal/plans/deferring/deferred.go
+++ b/internal/plans/deferring/deferred.go
@@ -8,7 +8,6 @@ import (
 	"slices"
 	"sync"
 
-	"github.com/hashicorp/hcl/v2"
 	"github.com/zclconf/go-cty/cty"
 
 	"github.com/hashicorp/terraform/internal/addrs"
@@ -746,18 +745,8 @@ func (d *Deferred) ReportActionDeferred(addr addrs.AbsAction, reason providers.D
 }
 
 // ShouldDeferActionInvocation returns true if there is a reason to defer the
-// action invocation instance. We want to defer an action invocation only if
-// the triggering resource was deferred. In addition, we will check if the
-// underlying action was deferred via a reference, and consider it an error if
-// the triggering resource wasn't also deferred.
-//
-// The reason behind the slightly different behaviour here, is that if an
-// action invocation is deferred, then that implies the triggering action
-// should also be deferred.
-//
-// We don't yet have the capability to retroactively defer a resource, so for
-// now actions initiating deferrals themselves is considered an error.
-func (d *Deferred) ShouldDeferActionInvocation(ai plans.ActionInvocationInstance, triggerRange *hcl.Range) (bool, tfdiags.Diagnostics) {
+// action invocation instance.
+func (d *Deferred) ShouldDeferActionInvocation(ai *plans.ActionInvocationInstance) (bool, tfdiags.Diagnostics) {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 
@@ -778,14 +767,7 @@ func (d *Deferred) ShouldDeferActionInvocation(ai plans.ActionInvocationInstance
 
 	if c, ok := d.actionExpansionDeferred.GetOk(ai.Addr.ConfigAction()); ok {
 		if c.Has(ai.Addr.ContainingAction()) {
-			// Then in this case, the resource wasn't deferred but the action
-			// was and so we will consider this to be an error.
-			diags = diags.Append(&hcl.Diagnostic{
-				Severity: hcl.DiagError,
-				Summary:  "Invalid action deferral",
-				Detail:   fmt.Sprintf("The action %s was marked as deferred, but was triggered by a non-deferred resource %s. To work around this, use the -target argument to first apply only the resources that the action block depends on.", ai.Addr, at.TriggeringResourceAddr),
-				Subject:  triggerRange,
-			})
+			return true, diags
 		}
 	}
 
@@ -802,12 +784,6 @@ func (d *Deferred) ShouldDeferActionInvocation(ai plans.ActionInvocationInstance
 	}
 
 	return false, diags
-}
-
-// ShouldDeferAction returns true if the action should be deferred. This is the case if a
-// dependency of the action is deferred.
-func (d *Deferred) ShouldDeferAction(deps []addrs.ConfigResource) bool {
-	return d.DependenciesDeferred(deps)
 }
 
 // UnexpectedProviderDeferralDiagnostic is a diagnostic that indicates that a

--- a/internal/plugin/grpc_provider.go
+++ b/internal/plugin/grpc_provider.go
@@ -1510,12 +1510,22 @@ func (p *GRPCProvider) PlanAction(r providers.PlanActionRequest) (resp providers
 
 	// We only allow deferral from the provider as a whole. The provider must be
 	// able to accept unknown configuration.
-	if protoResp.Deferred != nil && protoResp.Deferred.Reason != proto.Deferred_PROVIDER_CONFIG_UNKNOWN {
-		resp.Diagnostics = resp.Diagnostics.Append(tfdiags.WholeContainingBody(
-			tfdiags.Error,
-			"Invalid deferred reason",
-			fmt.Sprintf("An action can only be deferred due to an unknown provider configuration. Provider %s returned %s.", p.Addr.ForDisplay(), protoResp.Deferred.Reason),
-		))
+	if protoResp.Deferred != nil {
+		if !r.ClientCapabilities.DeferralAllowed {
+			tfdiags.WholeContainingBody(
+				tfdiags.Error,
+				"Invalid deferral",
+				fmt.Sprintf("The provider %s signaled a deferred action, but deferrals are not enabled for this client.", p.Addr.ForDisplay()),
+			)
+		}
+
+		if protoResp.Deferred.Reason != proto.Deferred_PROVIDER_CONFIG_UNKNOWN {
+			resp.Diagnostics = resp.Diagnostics.Append(tfdiags.WholeContainingBody(
+				tfdiags.Error,
+				"Invalid deferred reason",
+				fmt.Sprintf("An action can only be deferred due to an unknown provider configuration. Provider %s returned %s.", p.Addr.ForDisplay(), protoResp.Deferred.Reason),
+			))
+		}
 	}
 
 	resp.Diagnostics = resp.Diagnostics.Append(convert.ProtoToDiagnostics(protoResp.Diagnostics))

--- a/internal/plugin/grpc_provider.go
+++ b/internal/plugin/grpc_provider.go
@@ -1508,10 +1508,6 @@ func (p *GRPCProvider) PlanAction(r providers.PlanActionRequest) (resp providers
 	}
 
 	resp.Diagnostics = resp.Diagnostics.Append(convert.ProtoToDiagnostics(protoResp.Diagnostics))
-	if err != nil {
-		resp.Diagnostics = resp.Diagnostics.Append(grpcErr(err))
-		return resp
-	}
 	if resp.Diagnostics.HasErrors() {
 		return resp
 	}
@@ -1555,6 +1551,7 @@ func (p *GRPCProvider) InvokeAction(r providers.InvokeActionRequest) (resp provi
 	resp.Events = func(yield func(providers.InvokeActionEvent) bool) {
 		logger.Trace("GRPCProvider: InvokeAction: streaming events")
 
+	RECV:
 		for {
 			event, err := protoClient.Recv()
 			if err == io.EOF {
@@ -1572,16 +1569,20 @@ func (p *GRPCProvider) InvokeAction(r providers.InvokeActionRequest) (resp provi
 
 			switch ev := event.Type.(type) {
 			case *proto.InvokeAction_Event_Progress_:
-				yield(providers.InvokeActionEvent_Progress{
+				if !yield(providers.InvokeActionEvent_Progress{
 					Message: ev.Progress.Message,
-				})
+				}) {
+					break RECV
+				}
 
 			case *proto.InvokeAction_Event_Completed_:
 				diags := convert.ProtoToDiagnostics(ev.Completed.Diagnostics)
 
-				yield(providers.InvokeActionEvent_Completed{
+				if !yield(providers.InvokeActionEvent_Completed{
 					Diagnostics: diags,
-				})
+				}) {
+					break RECV
+				}
 
 			default:
 				panic(fmt.Sprintf("unexpected event type %T in InvokeAction response", event.Type))

--- a/internal/plugin/grpc_provider.go
+++ b/internal/plugin/grpc_provider.go
@@ -23,6 +23,7 @@ import (
 	"github.com/hashicorp/terraform/internal/logging"
 	"github.com/hashicorp/terraform/internal/plugin/convert"
 	"github.com/hashicorp/terraform/internal/providers"
+	"github.com/hashicorp/terraform/internal/tfdiags"
 	proto "github.com/hashicorp/terraform/internal/tfplugin5"
 )
 
@@ -1507,11 +1508,17 @@ func (p *GRPCProvider) PlanAction(r providers.PlanActionRequest) (resp providers
 		return resp
 	}
 
-	resp.Diagnostics = resp.Diagnostics.Append(convert.ProtoToDiagnostics(protoResp.Diagnostics))
-	if resp.Diagnostics.HasErrors() {
-		return resp
+	// We only allow deferral from the provider as a whole. The provider must be
+	// able to accept unknown configuration.
+	if protoResp.Deferred != nil && protoResp.Deferred.Reason != proto.Deferred_PROVIDER_CONFIG_UNKNOWN {
+		resp.Diagnostics = resp.Diagnostics.Append(tfdiags.WholeContainingBody(
+			tfdiags.Error,
+			"Invalid deferred reason",
+			fmt.Sprintf("An action can only be deferred due to an unknown provider configuration. Provider %s returned %s.", p.Addr.ForDisplay(), protoResp.Deferred.Reason),
+		))
 	}
 
+	resp.Diagnostics = resp.Diagnostics.Append(convert.ProtoToDiagnostics(protoResp.Diagnostics))
 	return resp
 }
 

--- a/internal/plugin/grpc_provider_test.go
+++ b/internal/plugin/grpc_provider_test.go
@@ -1646,6 +1646,37 @@ func TestGRPCProvider_planAction_invalid_config(t *testing.T) {
 	checkDiagsHasError(t, resp.Diagnostics)
 }
 
+func TestGRPCProvider_planAction_invalid_defer(t *testing.T) {
+	client := mockProviderClient(t)
+
+	client.EXPECT().PlanAction(
+		gomock.Any(),
+		gomock.Any(),
+	).Return(&proto.PlanAction_Response{
+		Deferred: &proto.Deferred{
+			Reason: proto.Deferred_RESOURCE_CONFIG_UNKNOWN,
+		},
+	}, nil)
+
+	p := &GRPCProvider{
+		Addr: addrs.Provider{
+			Type:      "test",
+			Namespace: "hashicorp",
+			Hostname:  "terraform.io",
+		},
+		client: client,
+	}
+
+	resp := p.PlanAction(providers.PlanActionRequest{
+		ActionType: "action",
+		ProposedActionData: cty.ObjectVal(map[string]cty.Value{
+			"attr": cty.StringVal("foo"),
+		}),
+	})
+
+	checkDiagsHasError(t, resp.Diagnostics)
+}
+
 // Mock implementation of the ListResource stream client
 type mockListResourceStreamClient struct {
 	events  []*proto.ListResource_Event

--- a/internal/plugin6/grpc_provider.go
+++ b/internal/plugin6/grpc_provider.go
@@ -25,6 +25,7 @@ import (
 	"github.com/hashicorp/terraform/internal/logging"
 	"github.com/hashicorp/terraform/internal/plugin6/convert"
 	"github.com/hashicorp/terraform/internal/providers"
+	"github.com/hashicorp/terraform/internal/tfdiags"
 	proto6 "github.com/hashicorp/terraform/internal/tfplugin6"
 )
 
@@ -1931,11 +1932,17 @@ func (p *GRPCProvider) PlanAction(r providers.PlanActionRequest) (resp providers
 		return resp
 	}
 
-	resp.Diagnostics = resp.Diagnostics.Append(convert.ProtoToDiagnostics(protoResp.Diagnostics))
-	if resp.Diagnostics.HasErrors() {
-		return resp
+	// We only allow deferral from the provider as a whole. The provider must be
+	// able to accept unknown configuration.
+	if protoResp.Deferred != nil && protoResp.Deferred.Reason != proto6.Deferred_PROVIDER_CONFIG_UNKNOWN {
+		resp.Diagnostics = resp.Diagnostics.Append(tfdiags.WholeContainingBody(
+			tfdiags.Error,
+			"Invalid deferred reason",
+			fmt.Sprintf("An action can only be deferred due to an unknown provider configuration. Provider %s returned %s.", p.Addr.ForDisplay(), protoResp.Deferred.Reason),
+		))
 	}
 
+	resp.Diagnostics = resp.Diagnostics.Append(convert.ProtoToDiagnostics(protoResp.Diagnostics))
 	return resp
 }
 

--- a/internal/plugin6/grpc_provider.go
+++ b/internal/plugin6/grpc_provider.go
@@ -1934,12 +1934,22 @@ func (p *GRPCProvider) PlanAction(r providers.PlanActionRequest) (resp providers
 
 	// We only allow deferral from the provider as a whole. The provider must be
 	// able to accept unknown configuration.
-	if protoResp.Deferred != nil && protoResp.Deferred.Reason != proto6.Deferred_PROVIDER_CONFIG_UNKNOWN {
-		resp.Diagnostics = resp.Diagnostics.Append(tfdiags.WholeContainingBody(
-			tfdiags.Error,
-			"Invalid deferred reason",
-			fmt.Sprintf("An action can only be deferred due to an unknown provider configuration. Provider %s returned %s.", p.Addr.ForDisplay(), protoResp.Deferred.Reason),
-		))
+	if protoResp.Deferred != nil {
+		if !r.ClientCapabilities.DeferralAllowed {
+			tfdiags.WholeContainingBody(
+				tfdiags.Error,
+				"Invalid deferral",
+				fmt.Sprintf("The provider %s signaled a deferred action, but deferrals are not enabled for this client.", p.Addr.ForDisplay()),
+			)
+		}
+
+		if protoResp.Deferred.Reason != proto6.Deferred_PROVIDER_CONFIG_UNKNOWN {
+			resp.Diagnostics = resp.Diagnostics.Append(tfdiags.WholeContainingBody(
+				tfdiags.Error,
+				"Invalid deferred reason",
+				fmt.Sprintf("An action can only be deferred due to an unknown provider configuration. Provider %s returned %s.", p.Addr.ForDisplay(), protoResp.Deferred.Reason),
+			))
+		}
 	}
 
 	resp.Diagnostics = resp.Diagnostics.Append(convert.ProtoToDiagnostics(protoResp.Diagnostics))

--- a/internal/plugin6/grpc_provider.go
+++ b/internal/plugin6/grpc_provider.go
@@ -1932,10 +1932,6 @@ func (p *GRPCProvider) PlanAction(r providers.PlanActionRequest) (resp providers
 	}
 
 	resp.Diagnostics = resp.Diagnostics.Append(convert.ProtoToDiagnostics(protoResp.Diagnostics))
-	if err != nil {
-		resp.Diagnostics = resp.Diagnostics.Append(grpcErr(err))
-		return resp
-	}
 	if resp.Diagnostics.HasErrors() {
 		return resp
 	}
@@ -1979,6 +1975,7 @@ func (p *GRPCProvider) InvokeAction(r providers.InvokeActionRequest) (resp provi
 	resp.Events = func(yield func(providers.InvokeActionEvent) bool) {
 		logger.Trace("GRPCProvider: InvokeAction: streaming events")
 
+	RECV:
 		for {
 			event, err := protoClient.Recv()
 			if err == io.EOF {
@@ -1996,15 +1993,19 @@ func (p *GRPCProvider) InvokeAction(r providers.InvokeActionRequest) (resp provi
 
 			switch ev := event.Type.(type) {
 			case *proto6.InvokeAction_Event_Progress_:
-				yield(providers.InvokeActionEvent_Progress{
+				if !yield(providers.InvokeActionEvent_Progress{
 					Message: ev.Progress.Message,
-				})
+				}) {
+					break RECV
+				}
 
 			case *proto6.InvokeAction_Event_Completed_:
 				diags := convert.ProtoToDiagnostics(ev.Completed.Diagnostics)
-				yield(providers.InvokeActionEvent_Completed{
+				if !yield(providers.InvokeActionEvent_Completed{
 					Diagnostics: diags,
-				})
+				}) {
+					break RECV
+				}
 
 			default:
 				panic(fmt.Sprintf("unexpected event type %T in InvokeAction response", event.Type))

--- a/internal/plugin6/grpc_provider_test.go
+++ b/internal/plugin6/grpc_provider_test.go
@@ -2138,7 +2138,36 @@ func TestGRPCProvider_invokeAction_invalid(t *testing.T) {
 
 	checkDiagsHasError(t, resp.Diagnostics)
 }
+func TestGRPCProvider_planAction_invalid_defer(t *testing.T) {
+	client := mockProviderClient(t)
 
+	client.EXPECT().PlanAction(
+		gomock.Any(),
+		gomock.Any(),
+	).Return(&proto.PlanAction_Response{
+		Deferred: &proto.Deferred{
+			Reason: proto.Deferred_RESOURCE_CONFIG_UNKNOWN,
+		},
+	}, nil)
+
+	p := &GRPCProvider{
+		Addr: addrs.Provider{
+			Type:      "test",
+			Namespace: "hashicorp",
+			Hostname:  "terraform.io",
+		},
+		client: client,
+	}
+
+	resp := p.PlanAction(providers.PlanActionRequest{
+		ActionType: "action",
+		ProposedActionData: cty.ObjectVal(map[string]cty.Value{
+			"attr": cty.StringVal("foo"),
+		}),
+	})
+
+	checkDiagsHasError(t, resp.Diagnostics)
+}
 func TestGRPCProvider_ValidateStateStoreConfig_returns_validation_errors(t *testing.T) {
 	storeName := "mock_store" // mockProviderClient returns a mock that has this state store in its schemas
 

--- a/internal/stacks/stackruntime/plan_test.go
+++ b/internal/stacks/stackruntime/plan_test.go
@@ -6454,7 +6454,7 @@ func TestPlanWithActionInvocationHooks(t *testing.T) {
 		},
 		PendingComponentInstancePlan: collections.NewSet(webComponentInstance),
 		BeginComponentInstancePlan:   collections.NewSet(webComponentInstance),
-		EndComponentInstancePlan:     collections.NewSet(webComponentInstance),
+		DeferComponentInstancePlan:   collections.NewSet(webComponentInstance),
 		ReportResourceInstanceStatus: []*hooks.ResourceInstanceStatusHookData{
 			{
 				Addr:         testResourceObject,

--- a/internal/terraform/action_trigger_instance_apply.go
+++ b/internal/terraform/action_trigger_instance_apply.go
@@ -55,7 +55,7 @@ func (n *actionTriggerApplyInstance) invoke(ctx EvalContext, caller addrs.Refere
 	}
 
 	// FIXME: missing action trigger reference for diags
-	configValue, actionDiags := n.actionNode.EvalInstance(ctx, n.ActionInvocation.Addr.Action.Key, nil, caller)
+	configValue, actionDiags := n.actionNode.EvalInstance(ctx, n.ActionInvocation.Addr, nil, caller)
 	diags = diags.Append(actionDiags)
 	if diags.HasErrors() {
 		return diags

--- a/internal/terraform/context_plan_actions_test.go
+++ b/internal/terraform/context_plan_actions_test.go
@@ -2019,22 +2019,13 @@ resource "test_object" "a" {
 				expectPlanActionCalled: true,
 				planOpts: &PlanOpts{
 					Mode:            plans.NormalMode,
-					DeferralAllowed: true, // actions should ignore this setting
+					DeferralAllowed: true,
 				},
 				planActionFn: func(*testing.T, providers.PlanActionRequest) providers.PlanActionResponse {
 					return providers.PlanActionResponse{
 						Deferred: &providers.Deferred{
-							Reason: providers.DeferredReasonAbsentPrereq,
+							Reason: providers.DeferredReasonProviderConfigUnknown,
 						},
-					}
-				},
-				expectPlanDiagnostics: func(m *configs.Config) tfdiags.Diagnostics {
-					return tfdiags.Diagnostics{
-						tfdiags.Sourceless(
-							tfdiags.Error,
-							"Provider deferred changes when Terraform did not allow deferrals",
-							`The provider signaled a deferred action for "action.test_action.hello", but in this context deferrals are disabled. This is a bug in the provider, please file an issue with the provider developers.`,
-						),
 					}
 				},
 			},
@@ -2073,21 +2064,23 @@ resource "test_object" "a" {
 					}
 					return providers.PlanActionResponse{
 						Deferred: &providers.Deferred{
-							Reason: providers.DeferredReasonAbsentPrereq,
+							Reason: providers.DeferredReasonProviderConfigUnknown,
 						},
 					}
 				},
-				expectPlanDiagnostics: func(m *configs.Config) tfdiags.Diagnostics {
-					// for now, it's just an error for any deferrals but when
-					// this gets implemented we should check that all the
-					// actions are deferred even though only one of them
-					// was actually marked as deferred.
-					return tfdiags.Diagnostics{
-						tfdiags.Sourceless(
-							tfdiags.Error,
-							"Provider deferred changes when Terraform did not allow deferrals",
-							`The provider signaled a deferred action for "action.test_action.hello", but in this context deferrals are disabled. This is a bug in the provider, please file an issue with the provider developers.`,
-						),
+				assertPlan: func(t *testing.T, p *plans.Plan) {
+					// both actions should be reported as deferred
+					if len(p.DeferredActionInvocations) != 2 {
+						t.Fatalf("expected 2 deferred action invocations, got %d", len(p.DeferredActionInvocations))
+					}
+					if len(p.Changes.ActionInvocations) > 0 {
+						t.Fatalf("expected no action invocation, got %d", len(p.Changes.ActionInvocations))
+					}
+					if len(p.DeferredResources) != 1 {
+						t.Fatalf("expected 1 deferred resource, got %d", len(p.DeferredResources))
+					}
+					if len(p.Changes.Resources) > 0 {
+						t.Fatalf("expected no planned resources, got %d\n", len(p.Changes.Resources))
 					}
 				},
 			},
@@ -2132,19 +2125,6 @@ resource "test_object" "a" {
 						Deferred: &providers.Deferred{
 							Reason: providers.DeferredReasonAbsentPrereq,
 						},
-					}
-				},
-				expectPlanDiagnostics: func(m *configs.Config) tfdiags.Diagnostics {
-					// for now, it's just an error for any deferrals but when
-					// this gets implemented we should check that all the
-					// actions are deferred even though only one of them
-					// was actually marked as deferred.
-					return tfdiags.Diagnostics{
-						tfdiags.Sourceless(
-							tfdiags.Error,
-							"Provider deferred changes when Terraform did not allow deferrals",
-							`The provider signaled a deferred action for "action.test_action.hello", but in this context deferrals are disabled. This is a bug in the provider, please file an issue with the provider developers.`,
-						),
 					}
 				},
 			},
@@ -2237,7 +2217,6 @@ resource "test_object" "a" {
 				},
 			},
 
-			// FIXME: this is checking for non-defer errors while deferrals are allowed
 			"action expansion with unknown instances": {
 				module: map[string]string{
 					"main.tf": `
@@ -2268,17 +2247,9 @@ resource "test_object" "a" {
 						},
 					},
 				},
-				assertPlanDiagnostics: func(t *testing.T, diagnostics tfdiags.Diagnostics) {
-					if len(diagnostics) != 1 {
-						t.Fatal("wrong number of diagnostics")
-					}
-
-					if diagnostics[0].Severity() != tfdiags.Error {
-						t.Error("expected error severity")
-					}
-
-					if diagnostics[0].Description().Summary != "Invalid for_each argument" {
-						t.Errorf("expected for_each argument to be source of error but was %s", diagnostics[0].Description().Summary)
+				assertPlan: func(t *testing.T, plan *plans.Plan) {
+					if len(plan.DeferredResources) != 1 {
+						t.Fatal("expected resource to be deferred, because action was deferred")
 					}
 				},
 			},
@@ -2313,8 +2284,6 @@ resource "other_object" "a" {
 }
 `,
 				},
-				// FIXME: how can we defer it due to expansion and call it at the same time?
-				// expectPlanActionCalled: true,
 				planOpts: &PlanOpts{
 					Mode:            plans.NormalMode,
 					DeferralAllowed: true,
@@ -2371,8 +2340,7 @@ resource "other_object" "a" {
 }
 `,
 				},
-				// FIXME: how can we defer it due to expansion and call it at the same time?
-				// expectPlanActionCalled: true,
+				expectPlanActionCalled: false,
 				planOpts: &PlanOpts{
 					Mode:            plans.NormalMode,
 					DeferralAllowed: true,
@@ -2391,25 +2359,6 @@ resource "other_object" "a" {
 					if len(p.Changes.ActionInvocations) != 0 {
 						t.Fatalf("expected 0 planned action invocations, got %d", len(p.Changes.ActionInvocations))
 					}
-
-					// FIXME: This might be fixable by registering deferred
-					// actions from the partially expanded resource. We just
-					// need to allow multiple registrations of action deferrals.
-					//
-					// if len(p.DeferredActionInvocations) != 1 {
-					//  t.Fatalf("expected 1 deferred partial action invocations, got %d", len(p.DeferredActionInvocations))
-					// }
-
-					// ac, err := p.DeferredActionInvocations[0].Decode(&testActionSchema)
-					// if err != nil {
-					// 	t.Fatalf("error decoding action invocation: %s", err)
-					// }
-					// if ac.DeferredReason != providers.DeferredReasonInstanceCountUnknown {
-					// 	t.Fatalf("expected deferred reason to be DeferredReasonInstanceCountUnknown, got %s", ac.DeferredReason)
-					// }
-					// if !ac.ActionInvocationInstance.ConfigValue.IsNull() {
-					// 	t.Fatalf("expected config value to be null")
-					// }
 				},
 			},
 

--- a/internal/terraform/context_plan_actions_test.go
+++ b/internal/terraform/context_plan_actions_test.go
@@ -1019,7 +1019,7 @@ resource "test_object" "a" {
 					return diags.Append(&hcl.Diagnostic{
 						Severity: hcl.DiagError,
 						Summary:  "Reference to non-existent action instance",
-						Detail:   "The given key 2 does not identify an instance of action.test_action.hello",
+						Detail:   "The given key [2] does not identify an instance of action.test_action.hello",
 						Subject: &hcl.Range{
 							Filename: filepath.Join(m.Module.SourceDir, "main.tf"),
 							Start:    hcl.Pos{Line: 13, Column: 18, Byte: 208},
@@ -2236,6 +2236,8 @@ resource "test_object" "a" {
 					}
 				},
 			},
+
+			// FIXME: this is checking for non-defer errors while deferrals are allowed
 			"action expansion with unknown instances": {
 				module: map[string]string{
 					"main.tf": `

--- a/internal/terraform/node_action.go
+++ b/internal/terraform/node_action.go
@@ -56,6 +56,68 @@ func (n NodeActionConfig) Name() string {
 	return n.Addr.String()
 }
 
+func (n *NodeActionConfig) Execute(ctx EvalContext, op walkOperation) tfdiags.Diagnostics {
+	// Validation happens without expansion, and Validate will be called from
+	// either a validateable node or a triggering node.
+	if op == walkValidate {
+		return nil
+	}
+
+	// Action configuration is always evaluated from the context of the
+	// triggering node, so all this node needs to do for Execute is record the
+	// instance expansion. This also makes sure we determine whether we need
+	// to be deferred due to unknown expansion before we get to the resources
+	// triggering the action.
+	return n.recordActionExpansion(ctx)
+}
+
+func (n *NodeActionConfig) recordActionExpansion(ctx EvalContext) tfdiags.Diagnostics {
+	var diags tfdiags.Diagnostics
+
+	// FIXME: this is hard-coded to false for now to match existing behavior,
+	// but actions will need to conform to the same deferral system as all other
+	// objects.
+	// deferralAllowed := ctx.Deferrals().DeferralAllowed()
+	deferralAllowed := false
+
+	expander := ctx.InstanceExpander()
+	for _, module := range expander.ExpandModule(n.Addr.Module, false) {
+		moduleCtx := evalContextForModuleInstance(ctx, module)
+
+		switch {
+		case n.Config.Count != nil:
+			count, countDiags := evaluateCountExpression(n.Config.Count, moduleCtx, deferralAllowed)
+			diags = diags.Append(countDiags)
+			if diags.HasErrors() {
+				return diags
+			}
+			if count >= 0 {
+				expander.SetActionCount(module, n.Addr.Action, count)
+
+			} else {
+				expander.SetActionCountUnknown(module, n.Addr.Action)
+			}
+
+		case n.Config.ForEach != nil:
+			forEach, known, forEachDiags := evaluateForEachExpression(n.Config.ForEach, moduleCtx, deferralAllowed)
+			diags = diags.Append(forEachDiags)
+			if forEachDiags.HasErrors() {
+				return diags
+			}
+			if known {
+				expander.SetActionForEach(module, n.Addr.Action, forEach)
+			} else {
+				expander.SetActionForEachUnknown(module, n.Addr.Action)
+			}
+
+		default:
+			expander.SetActionSingle(module, n.Addr.Action)
+		}
+	}
+
+	return diags
+}
+
 // Validate validates the action config, with an optional caller address if the
 // action is invoked from a resource action trigger.
 func (n *NodeActionConfig) Validate(ctx EvalContext, caller addrs.Referenceable) tfdiags.Diagnostics {
@@ -225,70 +287,47 @@ func (n *NodeActionConfig) AttachDependencies(deps []addrs.ConfigResource) {
 	n.Dependencies = deps
 }
 
-func (n *NodeActionConfig) repetitionData(ctx EvalContext) ([]instances.RepetitionData, tfdiags.Diagnostics) {
-	var diags tfdiags.Diagnostics
-	var reps []instances.RepetitionData
-
-	switch {
-	case n.Config.Count != nil:
-		count, countDiags := evaluateCountExpression(n.Config.Count, ctx, false)
-		diags = diags.Append(countDiags)
-		if diags.HasErrors() {
-			return nil, diags
-		}
-
-		for i := 0; i < count; i++ {
-			reps = append(reps, instances.RepetitionData{
-				CountIndex: cty.NumberIntVal(int64(i)),
-			})
-		}
-		return reps, diags
-
-	case n.Config.ForEach != nil:
-		forEach, _, forEachDiags := evaluateForEachExpression(n.Config.ForEach, ctx, false)
-		diags = diags.Append(forEachDiags)
-		if forEachDiags.HasErrors() {
-			return reps, diags
-		}
-
-		for key, value := range forEach {
-			reps = append(reps, instances.RepetitionData{
-				EachKey:   cty.StringVal(key),
-				EachValue: value,
-			})
-		}
-		return reps, diags
-
-	default:
-		return []instances.RepetitionData{EvalDataForNoInstanceKey}, diags
-	}
-}
-
 // The invoke command can reference an action block to invoke all instances, so
 // here we return a value representing the entire block if we have an
 // addrs.NoKey This function uses addrs.ActionInstance even though it only needs
 // the key because we need to use use a full instance addr for the resulting map
 // keys anyway.
 func (n *NodeActionConfig) EvalInstances(ctx EvalContext, addr addrs.ActionInstance, callRange *hcl.Range, caller addrs.Referenceable) (addrs.Map[addrs.ActionInstance, cty.Value], tfdiags.Diagnostics) {
+	var diags tfdiags.Diagnostics
 	all := addrs.MakeMap[addrs.ActionInstance, cty.Value]()
 
-	switch key := addr.Key.(type) {
-	case addrs.IntKey, addrs.StringKey:
-		val, diags := n.EvalInstance(ctx, key, callRange, caller)
+	var instances []addrs.AbsActionInstance
+
+	expander := ctx.InstanceExpander()
+	if addr.Key == addrs.NoKey {
+		// this might be a single instance with no key, or all instances, so we
+		// must expand for both cases
+		instances = expander.ExpandAction(n.Addr.Absolute(ctx.Path()))
+	} else {
+		// definitely looking for a single instance because we have an index of
+		// some sort
+		instances = []addrs.AbsActionInstance{addr.Absolute(ctx.Path())}
+	}
+
+	for _, instAddr := range instances {
+		repData := expander.GetActionInstanceRepetitionData(instAddr)
+		val, evalDiags := n.evalInstance(ctx, repData, callRange, caller)
+		diags = diags.Append(evalDiags)
 		if diags.HasErrors() {
 			return all, diags
 		}
-		all.Put(addr, val)
-		return all, diags
-
-	default:
-		return n.eval(ctx, addr.Key, callRange, caller)
+		all.Put(instAddr.Action, val)
 	}
+
+	return all, diags
 }
 
 // EvalInstance returns the value from the expanded action block
-func (n *NodeActionConfig) EvalInstance(ctx EvalContext, key addrs.InstanceKey, callRange *hcl.Range, caller addrs.Referenceable) (cty.Value, tfdiags.Diagnostics) {
+func (n *NodeActionConfig) EvalInstance(ctx EvalContext, inst addrs.AbsActionInstance, callRange *hcl.Range, caller addrs.Referenceable) (cty.Value, tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
+
+	key := inst.Action.Key
+
 	// we first validate the correct type of key is being used for the action
 	switch {
 	case n.Config.Count != nil:
@@ -361,97 +400,36 @@ func (n *NodeActionConfig) EvalInstance(ctx EvalContext, key addrs.InstanceKey, 
 		}
 	}
 
-	vals, diags := n.eval(ctx, key, callRange, caller)
-	if diags.HasErrors() {
+	instAddr := n.Addr.Absolute(ctx.Path()).Instance(key)
+
+	expander := ctx.InstanceExpander()
+	// first we have to make sure the instance is valid because the expander only panics
+	instances := expander.ExpandAction(inst.ContainingAction())
+	found := false
+	for _, instAddr := range instances {
+		if instAddr.Equal(inst) {
+			found = true
+		}
+	}
+	if !found {
+		diags = diags.Append(&hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  "Reference to non-existent action instance",
+			Detail:   fmt.Sprintf("The given key %s does not identify an instance of action.test_action.hello", key),
+			Subject:  callRange,
+		})
 		return cty.DynamicVal, diags
 	}
 
-	val := vals.Get(n.Addr.Action.Instance(key))
-	return val, diags
+	repData := expander.GetActionInstanceRepetitionData(instAddr)
+
+	return n.evalInstance(ctx, repData, callRange, caller)
 }
 
 // Eval one or more instances of the action. This function expects that the key
 // is already validated for the the calling context, and will not produce
 // diagnostics for incorrect key types.
-func (n *NodeActionConfig) eval(ctx EvalContext, key addrs.InstanceKey, callRange *hcl.Range, caller addrs.Referenceable) (addrs.Map[addrs.ActionInstance, cty.Value], tfdiags.Diagnostics) {
-	var diags tfdiags.Diagnostics
-	all := addrs.MakeMap[addrs.ActionInstance, cty.Value]()
-
-	actionInstances, diags := n.repetitionData(ctx)
-	if diags.HasErrors() {
-		return all, diags
-	}
-
-	switch key := key.(type) {
-	case addrs.IntKey:
-		if int(key) >= len(actionInstances) {
-			diags = diags.Append(&hcl.Diagnostic{
-				Severity: hcl.DiagError,
-				Summary:  "Reference to non-existent action instance",
-				Detail:   fmt.Sprintf("The given key %d does not identify an instance of %s", key, n.Addr.Absolute(ctx.Path())),
-				Subject:  callRange,
-			})
-			return all, diags
-		}
-
-		val, evalDiags := n.evalInstance(ctx, actionInstances[int(key)], caller)
-		diags = append(diags, evalDiags...)
-		all.Put(n.Addr.Action.Instance(key), val)
-
-		return all, diags
-
-	case addrs.StringKey:
-		for _, inst := range actionInstances {
-			// find the one instance we're looking for
-			if inst.EachKey.AsString() != string(key) {
-				continue
-			}
-			val, evalDiags := n.evalInstance(ctx, inst, caller)
-			diags = diags.Append(evalDiags)
-			if evalDiags.HasErrors() {
-				return all, diags
-			}
-
-			all.Put(n.Addr.Action.Instance(key), val)
-		}
-
-		if all.Len() == 0 {
-			diags = diags.Append(&hcl.Diagnostic{
-				Severity: hcl.DiagError,
-				Summary:  "Reference to non-existent action instance",
-				Detail:   fmt.Sprintf("The given key %s does not identify an instance of %s", key, n.Addr.Absolute(ctx.Path())),
-				Subject:  callRange,
-			})
-			return all, diags
-		}
-
-		return all, diags
-
-	default:
-		for _, inst := range actionInstances {
-			val, evalDiags := n.evalInstance(ctx, inst, caller)
-			diags = diags.Append(evalDiags)
-			if diags.HasErrors() {
-				return all, diags
-			}
-
-			// we need to generate keys out of any new repetition Data
-			switch {
-			case inst.CountIndex != cty.NilVal:
-				idx, _ := inst.CountIndex.AsBigFloat().Int64()
-				key = addrs.IntKey(int(idx))
-			case inst.EachKey != cty.NilVal:
-				key = addrs.StringKey(inst.EachKey.AsString())
-			}
-
-			all.Put(n.Addr.Action.Instance(key), val)
-		}
-
-		return all, diags
-	}
-}
-
-func (n *NodeActionConfig) evalInstance(ctx EvalContext, repData instances.RepetitionData, caller addrs.Referenceable) (cty.Value, tfdiags.Diagnostics) {
+func (n *NodeActionConfig) evalInstance(ctx EvalContext, repData instances.RepetitionData, callRange *hcl.Range, caller addrs.Referenceable) (cty.Value, tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
 
 	// This should have been caught already

--- a/internal/terraform/node_action.go
+++ b/internal/terraform/node_action.go
@@ -74,11 +74,7 @@ func (n *NodeActionConfig) Execute(ctx EvalContext, op walkOperation) tfdiags.Di
 func (n *NodeActionConfig) recordActionExpansion(ctx EvalContext) tfdiags.Diagnostics {
 	var diags tfdiags.Diagnostics
 
-	// FIXME: this is hard-coded to false for now to match existing behavior,
-	// but actions will need to conform to the same deferral system as all other
-	// objects.
-	// deferralAllowed := ctx.Deferrals().DeferralAllowed()
-	deferralAllowed := false
+	deferralAllowed := ctx.Deferrals().DeferralAllowed()
 
 	expander := ctx.InstanceExpander()
 	for _, module := range expander.ExpandModule(n.Addr.Module, false) {
@@ -96,6 +92,7 @@ func (n *NodeActionConfig) recordActionExpansion(ctx EvalContext) tfdiags.Diagno
 
 			} else {
 				expander.SetActionCountUnknown(module, n.Addr.Action)
+				ctx.Deferrals().ReportActionDeferred(n.Addr.Absolute(ctx.Path()), providers.DeferredReasonInstanceCountUnknown)
 			}
 
 		case n.Config.ForEach != nil:
@@ -108,6 +105,7 @@ func (n *NodeActionConfig) recordActionExpansion(ctx EvalContext) tfdiags.Diagno
 				expander.SetActionForEach(module, n.Addr.Action, forEach)
 			} else {
 				expander.SetActionForEachUnknown(module, n.Addr.Action)
+				ctx.Deferrals().ReportActionDeferred(n.Addr.Absolute(ctx.Path()), providers.DeferredReasonInstanceCountUnknown)
 			}
 
 		default:

--- a/internal/terraform/node_resource_plan_instance.go
+++ b/internal/terraform/node_resource_plan_instance.go
@@ -452,21 +452,6 @@ func (n *NodePlannableResourceInstance) managedResourceExecute(ctx EvalContext) 
 			// context surrounding the change, rather than the change itself, and
 			// so it's helpful to still include the valid-in-isolation change as
 			// part of the plan as additional context in our error output.
-			//
-			// FIXME: it is currently important that we write resource changes to
-			// the plan (n.writeChange) before we write the corresponding state
-			// (n.writeResourceInstanceState).
-			//
-			// This is because the planned resource state will normally have the
-			// status of states.ObjectPlanned, which causes later logic to refer to
-			// the contents of the plan to retrieve the resource data. Because
-			// there is no shared lock between these two data structures, reversing
-			// the order of these writes will cause a brief window of inconsistency
-			// which can lead to a failed safety check.
-			//
-			// Future work should adjust these APIs such that it is impossible to
-			// update these two data structures incorrectly through any objects
-			// reachable via the terraform.EvalContext API.
 			diags = diags.Append(n.writeChange(ctx, change, ""))
 			if diags.HasErrors() {
 				return diags

--- a/internal/terraform/node_resource_plan_instance.go
+++ b/internal/terraform/node_resource_plan_instance.go
@@ -576,21 +576,14 @@ func (n *NodePlannableResourceInstance) managedResourceExecute(ctx EvalContext) 
 func (n *NodePlannableResourceInstance) reportDeferredActionTriggers(ctx EvalContext, reason providers.DeferredReason) {
 	deferrals := ctx.Deferrals()
 
-	// FIXME: if the resource is being deferred, we don't even know what the
-	// event is regardless of what the deferral claims, because an update could
-	// instead result in a create, destroy, or noop events.
-	for _, trigger := range n.actionTriggers {
-		for _, action := range trigger.actionRefs {
+	for blockIdx, trigger := range n.actionTriggers {
+		for listIdx, action := range trigger.actionRefs {
 			deferrals.ReportActionInvocationDeferred(plans.ActionInvocationInstance{
-				// FIXME: actions don't expand with modules, so this address
-				// isn't really representative of the real address.
-				//
-				// FIXME x2: we may or may not be able to expand the referenced
-				// instance depending on the deferral, so how should deferrals
-				// handle that?
 				Addr: action.actionNode.Addr.Absolute(n.Addr.Module).Instance(addrs.NoKey),
 				ActionTrigger: &plans.ResourceActionTrigger{
-					TriggeringResourceAddr: n.Addr,
+					TriggeringResourceAddr:  n.Addr,
+					ActionTriggerBlockIndex: blockIdx,
+					ActionsListIndex:        listIdx,
 				},
 			}, reason)
 		}

--- a/internal/terraform/node_resource_plan_instance.go
+++ b/internal/terraform/node_resource_plan_instance.go
@@ -661,7 +661,7 @@ func (n *NodePlannableResourceInstance) planActionTrigger(ctx EvalContext, resRe
 		panic(fmt.Sprintf("unknown action address type: %T", sub))
 	}
 
-	actionVal, actionDiags := actionRef.actionNode.EvalInstance(ctx, actionInst.Key, actionRef.configRef.Expr.Range().Ptr(), n.Addr.Resource)
+	actionVal, actionDiags := actionRef.actionNode.EvalInstance(ctx, actionInst.Absolute(ctx.Path()), actionRef.configRef.Expr.Range().Ptr(), n.Addr.Resource)
 	diags = diags.Append(actionDiags)
 	if diags.HasErrors() {
 		return diags

--- a/internal/terraform/node_resource_plan_instance.go
+++ b/internal/terraform/node_resource_plan_instance.go
@@ -507,8 +507,9 @@ func (n *NodePlannableResourceInstance) managedResourceExecute(ctx EvalContext) 
 			n.reportDeferredActionTriggers(ctx, providers.DeferredReasonDeferredPrereq)
 		}
 
-		// now that the instance is planned we can plan any triggered actions if we weren't deferred
-		// FIXME: the deferral logic is too confusing. this whole method is too confusing
+		// Now that the instance is planned we can plan any triggered actions.
+		// Note that these may also result in resource deferral, so we can't
+		// count in having a plan yet.
 		diags = diags.Append(n.planActionTriggers(ctx, repData))
 
 	} else {
@@ -599,6 +600,10 @@ func (n *NodePlannableResourceInstance) planActionTriggers(ctx EvalContext, resR
 		return nil
 	}
 
+	// any of the actions might be deferred, so collect action actionInvocations
+	// and record them at the end
+	var actionInvocations []*plans.ActionInvocationInstance
+
 	for _, trigger := range n.actionTriggers {
 		scope := ctx.EvaluationScope(nil, nil, resRepData)
 		if trigger.config.Condition != nil {
@@ -617,31 +622,51 @@ func (n *NodePlannableResourceInstance) planActionTriggers(ctx EvalContext, resR
 
 		for _, event := range actionIsTriggeredByEvent(trigger.config.Events, n.change.Action) {
 			for _, action := range trigger.actionRefs {
-				diags = diags.Append(n.planActionTrigger(ctx, resRepData, action, event))
+				ai, deferred, planDiags := n.planActionTrigger(ctx, resRepData, action, event)
+				diags = diags.Append(planDiags)
 				if diags.HasErrors() {
+					return diags
+				}
+
+				actionInvocations = append(actionInvocations, ai)
+
+				if deferred {
+					log.Printf("[DEBUG] NodePlannableResourceInstance %s is being deferred due to action %s", n.Addr, action.actionNode.Addr)
+
+					// get the change for the deferral reporting mechanism, then
+					// revoke and defer the change we just planned.
+					changes := ctx.Changes()
+					change := changes.GetResourceInstanceChange(n.Addr, addrs.NotDeposed)
+					if change != nil {
+						ctx.Changes().RemoveResourceInstanceChange(n.Addr, addrs.NotDeposed)
+					}
+					ctx.Deferrals().ReportResourceInstanceDeferred(n.Addr, providers.DeferredReasonAbsentPrereq, change)
+
+					// this defers all action triggers at once
+					n.reportDeferredActionTriggers(ctx, providers.DeferredReasonDeferredPrereq)
 					return diags
 				}
 			}
 		}
 	}
 
+	// Now that we planned all action invocations with no deferrals, we can
+	// record them all in the changes.
+	for _, ai := range actionInvocations {
+		ctx.Changes().AppendActionInvocation(ai)
+	}
+
 	return diags
 }
 
-func (n *NodePlannableResourceInstance) planActionTrigger(ctx EvalContext, resRepData instances.RepetitionData, actionRef actionRef, event configs.ActionTriggerEvent) tfdiags.Diagnostics {
-	var diags tfdiags.Diagnostics
-
-	at := &plans.ResourceActionTrigger{
-		TriggeringResourceAddr:  n.Addr,
-		ActionTriggerBlockIndex: actionRef.blockIndex,
-		ActionsListIndex:        actionRef.actionIndex,
-		ActionTriggerEvent:      event,
-	}
+// Plan the individual action invocation.
+// This function uses named result parameters.
+func (n *NodePlannableResourceInstance) planActionTrigger(ctx EvalContext, resRepData instances.RepetitionData, actionRef actionRef, event configs.ActionTriggerEvent) (ai *plans.ActionInvocationInstance, deferred bool, diags tfdiags.Diagnostics) {
 
 	ref, evalActionDiags := evaluateActionExpression(actionRef.configRef.Expr, resRepData)
 	diags = append(diags, evalActionDiags...)
 	if diags.HasErrors() {
-		return diags
+		return
 	}
 
 	var actionInst addrs.ActionInstance
@@ -654,10 +679,33 @@ func (n *NodePlannableResourceInstance) planActionTrigger(ctx EvalContext, resRe
 		panic(fmt.Sprintf("unknown action address type: %T", sub))
 	}
 
+	ai = &plans.ActionInvocationInstance{
+		Addr: actionInst.Absolute(n.Addr.Module),
+		ActionTrigger: &plans.ResourceActionTrigger{
+			TriggeringResourceAddr:  n.Addr,
+			ActionTriggerBlockIndex: actionRef.blockIndex,
+			ActionsListIndex:        actionRef.actionIndex,
+			ActionTriggerEvent:      event,
+		},
+		ProviderAddr: actionRef.actionNode.ResolvedProvider,
+	}
+
+	// check if this action was previously deferred
+	shouldDefer, deferDiags := ctx.Deferrals().ShouldDeferActionInvocation(ai)
+	diags = diags.Append(deferDiags)
+	if diags.HasErrors() {
+		return
+	}
+	if shouldDefer {
+		deferred = true
+		log.Printf("[DEBUG] action instance %s deferred due to config block deferral", actionInst)
+		return
+	}
+
 	actionVal, actionDiags := actionRef.actionNode.EvalInstance(ctx, actionInst.Absolute(ctx.Path()), actionRef.configRef.Expr.Range().Ptr(), n.Addr.Resource)
 	diags = diags.Append(actionDiags)
 	if diags.HasErrors() {
-		return diags
+		return
 	}
 
 	provider, _, err := getProvider(ctx, actionRef.actionNode.ResolvedProvider)
@@ -669,27 +717,16 @@ func (n *NodePlannableResourceInstance) planActionTrigger(ctx EvalContext, resRe
 			Subject:  actionRef.actionNode.Config.DeclRange.Ptr(),
 		})
 
-		return diags
+		return
 	}
 
 	unmarkedConfig, _ := actionVal.UnmarkDeepWithPaths()
 
-	cc := ctx.ClientCapabilities()
-
-	// FIXME: Why are there deferrals in actions? An action must respond to an
-	// event, but deferring an action would remove it from the event and
-	// therefore it wouldn't ever be invoked.
-	cc.DeferralAllowed = false
-
 	resp := provider.PlanAction(providers.PlanActionRequest{
 		ActionType:         actionRef.actionNode.Addr.Action.Type,
 		ProposedActionData: unmarkedConfig,
-		ClientCapabilities: cc,
+		ClientCapabilities: ctx.ClientCapabilities(),
 	})
-	// FIXME: we can allow deferrals for stacks operation, but we're going to
-	// limit the reason to only ProviderConfigUnknown to avoid infinite planning
-	// loops with the calling resource.
-
 	// FIXME: config body is not the entire action config block
 	// Our diagnostics expect to be associated with a config body, but we may not have one due to the structure of actions.
 	// How wo we get the action block, and not the action's config block?
@@ -718,21 +755,21 @@ func (n *NodePlannableResourceInstance) planActionTrigger(ctx EvalContext, resRe
 	}
 
 	if resp.Deferred != nil {
-		diags = diags.Append(deferring.UnexpectedProviderDeferralDiagnostic(actionInst))
+		if !ctx.Deferrals().DeferralAllowed() {
+			diags = diags.Append(deferring.UnexpectedProviderDeferralDiagnostic(actionInst))
+			return
+		}
+		log.Printf("[DEBUG] action instance %s deferred by provider", actionInst)
+		deferred = true
+		return
 	}
+
 	if resp.Diagnostics.HasErrors() {
-		return diags
+		return
 	}
 
-	ai := &plans.ActionInvocationInstance{
-		Addr:          actionInst.Absolute(n.Addr.Module),
-		ActionTrigger: at,
-		ConfigValue:   ephemeral.RemoveEphemeralValues(actionVal),
-		ProviderAddr:  actionRef.actionNode.ResolvedProvider,
-	}
-
-	ctx.Changes().AppendActionInvocation(ai)
-	return diags
+	ai.ConfigValue = ephemeral.RemoveEphemeralValues(actionVal)
+	return
 }
 
 // replaceTriggered checks if this instance needs to be replace due to a change


### PR DESCRIPTION
Action can now be deferred. While there is little case for direct deferrals of actions, it needs to be supported to work within stacks components where deferrals are always possible.

The act of providers deferring actions is constrained only to provider configurations being unknown for now, and validated at the protocol level. This latest update actually makes individual deferral of actions a possibility, but we can assess expanding the acceptable reasons later. 

Each action config's expansion is now recorded earlier from within the action config node, so that later callers can determine more immediately if the action was deferred. Plus it lets us reincorporate the use of the instances expander to simplify the code after it was temporarily removed. The deferring structure was refactored so instances can be checked for deferral against their config nodes too, whereas previously the logic was backwards for actions as a way to record invocations.

In order to allow deferred actions, they need to be able to defer their resource as well. This means revoking the prior plan for the instance, which while unusual, should not pose any problems because the graph walk prevents any dependencies from accessing that change during the short window where it existed.
