### PR TITLE
Manual Backport: Support for module version evaluating to `null`

### DIFF
--- a/.changes/v1.15/ENHANCEMENTS-20260522-175656.yaml
+++ b/.changes/v1.15/ENHANCEMENTS-20260522-175656.yaml
@@ -1,0 +1,5 @@
+kind: ENHANCEMENTS
+body: Support for module version evaluating to `null` (in the context of dynamic module sources)
+time: 2026-05-22T17:56:56.921372+02:00
+custom:
+    Issue: "38632"

--- a/internal/terraform/context_init_test.go
+++ b/internal/terraform/context_init_test.go
@@ -93,7 +93,7 @@ module "example2" {
 				SourceAddr: mustModuleSource(t, "terraform-iaac/cert-manager/kubernetes"),
 			}, {
 				SourceAddr:        mustModuleSource(t, "terraform-aws-modules/vpc/aws"),
-				VersionConstraint: mustVersionContraint(t, "= 6.6.0"),
+				VersionConstraint: mustVersionContraint(t, "6.6.0"),
 			}},
 		},
 
@@ -214,8 +214,7 @@ module "example2" {
 			},
 
 			expectLoadModuleCalls: []*configs.ModuleRequest{{
-				SourceAddr:        mustModuleSource(t, "terraform-iaac/cert-manager/kubernetes"),
-				VersionConstraint: mustVersionContraint(t, ">= 1.2.3"),
+				SourceAddr: mustModuleSource(t, "terraform-iaac/cert-manager/kubernetes"),
 			}},
 		},
 
@@ -759,27 +758,37 @@ variable "name" {
 				t.Fatalf("expected %d LoadModule calls, got %d", len(tc.expectLoadModuleCalls), len(moduleWalker.Calls))
 			}
 
-			// Create a map of expected sources for easier comparison
-			expectedSources := make(map[string]bool)
+			// Create a map of expected sources and version constraints for comparison
+			type expectedCall struct {
+				found             bool
+				versionConstraint string
+			}
+			expectedSources := make(map[string]*expectedCall)
 			foundSources := []string{}
 			for _, expected := range tc.expectLoadModuleCalls {
-				expectedSources[expected.SourceAddr.String()] = false
+				expectedSources[expected.SourceAddr.String()] = &expectedCall{
+					versionConstraint: expected.VersionConstraint.Required.String(),
+				}
 			}
 
-			// Mark sources as found
+			// Mark sources as found and check version constraints
 			for _, call := range moduleWalker.Calls {
 				source := call.SourceAddr.String()
 				foundSources = append(foundSources, source)
-				if _, exists := expectedSources[source]; !exists {
+				if ec, exists := expectedSources[source]; !exists {
 					t.Errorf("unexpected LoadModule call for source %q", source)
 				} else {
-					expectedSources[source] = true
+					ec.found = true
+					gotConstraint := call.VersionConstraint.Required.String()
+					if gotConstraint != ec.versionConstraint {
+						t.Errorf("LoadModule call for source %q: expected version constraint %q, got %q", source, ec.versionConstraint, gotConstraint)
+					}
 				}
 			}
 
 			// Check all expected sources were called
-			for source, found := range expectedSources {
-				if !found {
+			for source, ec := range expectedSources {
+				if !ec.found {
 					t.Errorf("expected LoadModule call for source %q but it was not called. Calls that were made: \n %s", source, strings.Join(foundSources, ", "))
 				}
 			}

--- a/internal/terraform/context_init_test.go
+++ b/internal/terraform/context_init_test.go
@@ -727,6 +727,100 @@ variable "name" {
 				SourceAddr: mustModuleSource(t, "./modules/example"),
 			}},
 		},
+
+		"registry with version and local with null version": {
+			module: map[string]string{
+				"main.tf": `
+module "vpc" {
+  source  = "terraform-aws-modules/vpc/aws"
+  version = "~> 5.0"
+}
+
+module "local" {
+  source  = "./modules/local"
+  version = null
+}
+`,
+			},
+			expectLoadModuleCalls: []*configs.ModuleRequest{{
+				SourceAddr: mustModuleSource(t, "./modules/local"),
+			}, {
+				SourceAddr:        mustModuleSource(t, "terraform-aws-modules/vpc/aws"),
+				VersionConstraint: mustVersionContraint(t, "~> 5.0"),
+			}},
+		},
+
+		"conditional version with mixed sources - null on local": {
+			module: map[string]string{
+				"main.tf": `
+variable "use_local" {
+  type  = bool
+  const = true
+}
+
+locals {
+  source = var.use_local ? "./modules/local" : "terraform-aws-modules/vpc/aws"
+}
+
+module "example" {
+  source  = local.source
+  version = var.use_local ? null : "5.0.0"
+}
+`,
+			},
+			vars: InputValues{
+				"use_local": &InputValue{Value: cty.BoolVal(true), SourceType: ValueFromCLIArg},
+			},
+			expectLoadModuleCalls: []*configs.ModuleRequest{{
+				SourceAddr: mustModuleSource(t, "./modules/local"),
+			}},
+		},
+
+		"conditional version with mixed sources - version on registry": {
+			module: map[string]string{
+				"main.tf": `
+variable "use_local" {
+  type  = bool
+  const = true
+}
+
+locals {
+  source = var.use_local ? "./modules/local" : "terraform-aws-modules/vpc/aws"
+}
+
+module "example" {
+  source  = local.source
+  version = var.use_local ? null : "5.0.0"
+}
+`,
+			},
+			vars: InputValues{
+				"use_local": &InputValue{Value: cty.BoolVal(false), SourceType: ValueFromCLIArg},
+			},
+			expectLoadModuleCalls: []*configs.ModuleRequest{{
+				SourceAddr:        mustModuleSource(t, "terraform-aws-modules/vpc/aws"),
+				VersionConstraint: mustVersionContraint(t, "5.0.0"),
+			}},
+		},
+
+		"version from const variable set to null": {
+			module: map[string]string{
+				"main.tf": `
+variable "ver" {
+  type    = string
+  const   = true
+  default = null
+}
+module "local" {
+  source  = "./modules/local"
+  version = var.ver
+}
+`,
+			},
+			expectLoadModuleCalls: []*configs.ModuleRequest{{
+				SourceAddr: mustModuleSource(t, "./modules/local"),
+			}},
+		},
 	} {
 		t.Run(name, func(t *testing.T) {
 			m := testRootModuleInline(t, tc.module)

--- a/internal/terraform/node_module_install.go
+++ b/internal/terraform/node_module_install.go
@@ -80,6 +80,7 @@ func (n *nodeInstallModule) Execute(ctx EvalContext, walkOp walkOperation) tfdia
 	}
 
 	var version configs.VersionConstraint
+	hasVersion := false
 	if n.ModuleCall.VersionExpr != nil {
 		var versionDiags tfdiags.Diagnostics
 		version, versionDiags = evalVersionConstraint(n.ModuleCall.VersionExpr, ctx)
@@ -87,9 +88,9 @@ func (n *nodeInstallModule) Execute(ctx EvalContext, walkOp walkOperation) tfdia
 		if diags.HasErrors() {
 			return diags
 		}
+		hasVersion = version.Required.Len() > 0
 	}
 
-	hasVersion := n.ModuleCall.VersionExpr != nil
 	source, sourceRaw, sourceDiags := evalSource(n.ModuleCall.SourceExpr, hasVersion, ctx)
 	diags = diags.Append(sourceDiags)
 	if diags.HasErrors() {


### PR DESCRIPTION
Manual backport of https://github.com/hashicorp/terraform/pull/38632 into v1.15

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.15.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [x] This change is user-facing and I added a changelog entry.
- [ ] This change is not user-facing.
