### PR TITLE
command/init: Only install PSS provider early

### DIFF
--- a/.changes/v1.16/NOTES-20260602-161506.yaml
+++ b/.changes/v1.16/NOTES-20260602-161506.yaml
@@ -1,0 +1,5 @@
+kind: NOTES
+body: 'command/init: Provider installation was changed to enable future enhancements in the area. This effectively reverses the log message changes from v1.15. `initializing_provider_plugin_message` is being re-introduced to replace the short-lived two message types `initializing_provider_plugin_from_config_message` & `initializing_provider_plugin_from_state_message`. The change should not have any significant end-user impact aside from the command output.'
+time: 2026-06-02T16:15:06.066251+01:00
+custom:
+    Issue: "38648"

--- a/internal/command/init.go
+++ b/internal/command/init.go
@@ -164,7 +164,7 @@ func (c *InitCommand) initBackend(ctx context.Context, root *configs.Module, ini
 	defer span.End()
 
 	if root.StateStore != nil {
-		view.Output(views.InitializingStateStoreMessage)
+		view.Output(views.InitializingStateStoreMessage, root.StateStore.Type)
 	} else {
 		view.Output(views.InitializingBackendMessage)
 	}

--- a/internal/command/init.go
+++ b/internal/command/init.go
@@ -359,7 +359,6 @@ const (
 	SafeInitActionInvalid         SafeInitAction = 0
 	SafeInitActionProceed         SafeInitAction = 'P'
 	SafeInitActionRequireApproval SafeInitAction = 'I'
-	SafeInitActionNotRelevant     SafeInitAction = 'N' // For when a state store isn't in use at all!
 )
 
 // getProvidersFromPSSConfig determines what provider is required given state store configuration
@@ -368,10 +367,6 @@ const (
 //
 // Calling code is responsible for validating inputs to this method, e.g. mutually exclusive flags.
 func (c *InitCommand) getProvidersFromPSSConfig(ctx context.Context, config *configs.Config, previousLocks *depsfile.Locks, upgrade bool, pluginDirs []string, flagLockfile string, view views.Init) (output bool, resultingLocks *depsfile.Locks, safeInitAction SafeInitAction, authResult *getproviders.PackageAuthenticationResult, diags tfdiags.Diagnostics) {
-	if config == nil {
-		return false, nil, SafeInitActionNotRelevant, nil, diags
-	}
-
 	ctx, span := tracer.Start(ctx, "install providers for state store")
 	defer span.End()
 
@@ -528,35 +523,30 @@ func (c *InitCommand) getProvidersFromPSSConfig(ctx context.Context, config *con
 	}
 
 	// Return advice to the calling code about what to do regarding safe init feature related to state storage providers
-	if config.Module.StateStore == nil {
-		// If PSS isn't in use then return a value that isn't the zero value but isn't misleading.
-		safeInitAction = SafeInitActionNotRelevant
+	location, ok := providerLocations[config.Module.StateStore.ProviderAddr]
+	if !ok {
+		// The provider was not processed in the FetchPackageBegin callback.
+		// A provider that wasn't downloaded during this init could be because:
+		// * It was already present from a previous installation.
+		// * If upgrading, no newer version was available that matched version constraints.
+		// * Or, the provider is unmanaged/reattached and so download was skipped.
+		log.Printf("[TRACE] init (getProvidersFromPSSConfig): the state storage provider %s (%q) will not be changed in the dependency lock file after provider installation. Either it was already present and/or there was no available upgrade version that matched version constraints.", config.Module.StateStore.ProviderAddr.Type, config.Module.StateStore.ProviderAddr)
+		safeInitAction = SafeInitActionProceed
 	} else {
-		location, ok := providerLocations[config.Module.StateStore.ProviderAddr]
-		if !ok {
-			// The provider was not processed in the FetchPackageBegin callback.
-			// A provider that wasn't downloaded during this init could be because:
-			// * It was already present from a previous installation.
-			// * If upgrading, no newer version was available that matched version constraints.
-			// * Or, the provider is unmanaged/reattached and so download was skipped.
-			log.Printf("[TRACE] init (getProvidersFromPSSConfig): the state storage provider %s (%q) will not be changed in the dependency lock file after provider installation. Either it was already present and/or there was no available upgrade version that matched version constraints.", config.Module.StateStore.ProviderAddr.Type, config.Module.StateStore.ProviderAddr)
-			safeInitAction = SafeInitActionProceed
-		} else {
-			// The provider was processed in the FetchPackageBegin callback, so either it's being downloaded for the first time, or upgraded.
-			log.Printf("[TRACE] init (getProvidersFromConfig): the state storage provider %s (%q) will be changed in the dependency lock file during provider installation.", config.Module.StateStore.ProviderAddr.Type, config.Module.StateStore.ProviderAddr)
+		// The provider was processed in the FetchPackageBegin callback, so either it's being downloaded for the first time, or upgraded.
+		log.Printf("[TRACE] init (getProvidersFromConfig): the state storage provider %s (%q) will be changed in the dependency lock file during provider installation.", config.Module.StateStore.ProviderAddr.Type, config.Module.StateStore.ProviderAddr)
 
-			switch location.(type) {
-			case getproviders.PackageLocalArchive, getproviders.PackageLocalDir:
-				// If the provider is downloaded from a local source we assume it's safe.
-				// We don't require presence of the -safe-init flag, or require input from the user to approve its usage.
-				log.Printf("[TRACE] init (getProvidersFromConfig): the state storage provider %s (%q) is downloaded from a local source, so we consider it safe.", config.Module.StateStore.ProviderAddr.Type, config.Module.StateStore.ProviderAddr)
-				safeInitAction = SafeInitActionProceed
-			case getproviders.PackageHTTPURL:
-				log.Printf("[DEBUG] init (getProvidersFromConfig): the state storage provider %s (%q) is downloaded via HTTP, so we consider it potentially unsafe.", config.Module.StateStore.ProviderAddr.Type, config.Module.StateStore.ProviderAddr)
-				safeInitAction = SafeInitActionRequireApproval
-			default:
-				panic(fmt.Sprintf("init (getProvidersFromConfig): unexpected provider location type for state storage provider %q: %T", config.Module.StateStore.ProviderAddr, location))
-			}
+		switch location.(type) {
+		case getproviders.PackageLocalArchive, getproviders.PackageLocalDir:
+			// If the provider is downloaded from a local source we assume it's safe.
+			// We don't require presence of the -safe-init flag, or require input from the user to approve its usage.
+			log.Printf("[TRACE] init (getProvidersFromConfig): the state storage provider %s (%q) is downloaded from a local source, so we consider it safe.", config.Module.StateStore.ProviderAddr.Type, config.Module.StateStore.ProviderAddr)
+			safeInitAction = SafeInitActionProceed
+		case getproviders.PackageHTTPURL:
+			log.Printf("[DEBUG] init (getProvidersFromConfig): the state storage provider %s (%q) is downloaded via HTTP, so we consider it potentially unsafe.", config.Module.StateStore.ProviderAddr.Type, config.Module.StateStore.ProviderAddr)
+			safeInitAction = SafeInitActionRequireApproval
+		default:
+			panic(fmt.Sprintf("init (getProvidersFromConfig): unexpected provider location type for state storage provider %q: %T", config.Module.StateStore.ProviderAddr, location))
 		}
 	}
 

--- a/internal/command/init.go
+++ b/internal/command/init.go
@@ -362,18 +362,17 @@ const (
 	SafeInitActionNotRelevant     SafeInitAction = 'N' // For when a state store isn't in use at all!
 )
 
-// getProvidersFromConfig determines what providers are required by the given configuration data.
-// The method downloads any missing providers that aren't already downloaded and then returns
-// dependency lock data based on the configuration.
-// The dependency lock file itself isn't updated here.
+// getProvidersFromPSSConfig determines what provider is required given state store configuration
+// and downloads the provider that isn't already downloaded and then returns
+// updated dependency lock data. The dependency lock file itself isn't updated here.
 //
 // Calling code is responsible for validating inputs to this method, e.g. mutually exclusive flags.
-func (c *InitCommand) getProvidersFromConfig(ctx context.Context, config *configs.Config, previousLocks *depsfile.Locks, upgrade bool, pluginDirs []string, flagLockfile string, view views.Init) (output bool, resultingLocks *depsfile.Locks, safeInitAction SafeInitAction, authResult *getproviders.PackageAuthenticationResult, diags tfdiags.Diagnostics) {
+func (c *InitCommand) getProvidersFromPSSConfig(ctx context.Context, config *configs.Config, previousLocks *depsfile.Locks, upgrade bool, pluginDirs []string, flagLockfile string, view views.Init) (output bool, resultingLocks *depsfile.Locks, safeInitAction SafeInitAction, authResult *getproviders.PackageAuthenticationResult, diags tfdiags.Diagnostics) {
 	if config == nil {
 		return false, nil, SafeInitActionNotRelevant, nil, diags
 	}
 
-	ctx, span := tracer.Start(ctx, "install providers from config")
+	ctx, span := tracer.Start(ctx, "install providers for state store")
 	defer span.End()
 
 	// Dev overrides and unmanaged providers change the installation process in "terraform init";
@@ -391,10 +390,18 @@ func (c *InitCommand) getProvidersFromConfig(ctx context.Context, config *config
 	diags = diags.Append(c.providerUnmanagedInitWarnings())
 
 	// Collect the provider dependencies from the configuration.
-	reqs, hclDiags := config.ProviderRequirements()
+	allReqs, hclDiags := config.ProviderRequirements()
 	diags = diags.Append(hclDiags)
 	if hclDiags.HasErrors() {
 		return false, nil, SafeInitActionInvalid, nil, diags
+	}
+
+	// filter out only PSS providers from allReqs
+	reqs := make(providerreqs.Requirements, 1)
+	for providerReq, cons := range allReqs {
+		if providerReq.Equals(config.Module.StateStore.ProviderAddr) {
+			reqs[providerReq] = cons
+		}
 	}
 
 	for providerAddr := range reqs {
@@ -446,14 +453,14 @@ func (c *InitCommand) getProvidersFromConfig(ctx context.Context, config *config
 	var stateStoreProviderAuthResult *getproviders.PackageAuthenticationResult
 	evts := &providercache.InstallerEvents{
 		PendingProviders: func(reqs map[addrs.Provider]getproviders.VersionConstraints) {
-			view.Output(views.InitializingProviderPluginFromConfigMessage) // Message is specific to provider download from config
+			view.Output(views.InitializingStateStoreProviderPluginMessage, config.Module.StateStore.Type)
 		},
 		ProviderAlreadyInstalled: providerAlreadyInstalledCallback(view),
 		BuiltInProviderAvailable: builtInProviderAvailableCallback(view),
 		BuiltInProviderFailure:   builtInProviderFailureCallback(&diags),
 		QueryPackagesBegin: func(provider addrs.Provider, versionConstraints getproviders.VersionConstraints, locked bool) {
 			if locked {
-				view.LogInitMessage(views.ReusingPreviousVersionInfo, provider.ForDisplay()) // Message is specific to provide download from config
+				view.LogInitMessage(views.ReusingVersionIdentifiedFromConfig, provider.ForDisplay()) // Message is specific to provide download from config
 			} else {
 				if len(versionConstraints) > 0 {
 					view.LogInitMessage(views.FindingMatchingVersionMessage, provider.ForDisplay(), getproviders.VersionConstraintsString(versionConstraints))
@@ -532,7 +539,7 @@ func (c *InitCommand) getProvidersFromConfig(ctx context.Context, config *config
 			// * It was already present from a previous installation.
 			// * If upgrading, no newer version was available that matched version constraints.
 			// * Or, the provider is unmanaged/reattached and so download was skipped.
-			log.Printf("[TRACE] init (getProvidersFromConfig): the state storage provider %s (%q) will not be changed in the dependency lock file after provider installation. Either it was already present and/or there was no available upgrade version that matched version constraints.", config.Module.StateStore.ProviderAddr.Type, config.Module.StateStore.ProviderAddr)
+			log.Printf("[TRACE] init (getProvidersFromPSSConfig): the state storage provider %s (%q) will not be changed in the dependency lock file after provider installation. Either it was already present and/or there was no available upgrade version that matched version constraints.", config.Module.StateStore.ProviderAddr.Type, config.Module.StateStore.ProviderAddr)
 			safeInitAction = SafeInitActionProceed
 		} else {
 			// The provider was processed in the FetchPackageBegin callback, so either it's being downloaded for the first time, or upgraded.
@@ -556,34 +563,32 @@ func (c *InitCommand) getProvidersFromConfig(ctx context.Context, config *config
 	return true, configLocks, safeInitAction, stateStoreProviderAuthResult, diags
 }
 
-// getProvidersFromState determines what providers are required by the given state data.
-// The method downloads any missing providers that aren't already downloaded and then returns
-// dependency lock data based on the state.
-// The calling code is assumed to have already called getProvidersFromConfig, which is used to
-// supply the configLocks argument.
-// The dependency lock file itself isn't updated here.
-func (c *InitCommand) getProvidersFromState(ctx context.Context, state *states.State, configReqs providerreqs.Requirements, configLocks *depsfile.Locks, pluginDirs []string, view views.Init) (output bool, resultingLocks *depsfile.Locks, diags tfdiags.Diagnostics) {
-	ctx, span := tracer.Start(ctx, "install providers from state")
+// getProviders determines what providers are required by the config and state
+// and downloads any missing providers that aren't already downloaded and then returns
+// updated dependency lock data. The dependency lock *file* itself isn't updated here.
+//
+// See getProvidersFromPSSConfig which is equivalent for state store providers.
+func (c *InitCommand) getProviders(ctx context.Context, config *configs.Config, state *states.State, upgrade bool, configLocks *depsfile.Locks, pluginDirs []string, view views.Init) (output bool, resultingLocks *depsfile.Locks, diags tfdiags.Diagnostics) {
+	ctx, span := tracer.Start(ctx, "install providers")
 	defer span.End()
 
-	if state == nil {
-		// if there is no state there are no providers to get
-		return false, depsfile.NewLocks(), diags
+	// Dev overrides cause the result of "terraform init" to be irrelevant for
+	// any overridden providers, so we'll warn about it to avoid later
+	// confusion when Terraform ends up using a different provider than the
+	// lock file called for.
+	diags = diags.Append(c.providerDevOverrideInitWarnings())
+	diags = diags.Append(c.providerUnmanagedInitWarnings())
+
+	// First we'll collect all the provider dependencies we can see in the
+	// configuration and the state.
+	reqs, hclDiags := config.ProviderRequirements()
+	diags = diags.Append(hclDiags)
+	if hclDiags.HasErrors() {
+		return false, nil, diags
 	}
-
-	// Get the state's provider requirements
-	reqs := state.ProviderRequirements()
-
-	// Those requirements lack version constraint data. That matters if the configuration is using a
-	// pre-release of a provider, because installer logic will only be able to use a pre-release of a
-	// provider if a version constraint pins to that pre-release.
-	//
-	// So, we use configuration reqs to replace all entries in the state's requirements with entries
-	// from the config requirements, which may contain additional version constraint information.
-	for providerAddr := range reqs {
-		if r, ok := configReqs[providerAddr]; ok {
-			reqs[providerAddr] = r
-		}
+	if state != nil {
+		stateReqs := state.ProviderRequirements()
+		reqs = reqs.Merge(stateReqs)
 	}
 
 	for providerAddr := range reqs {
@@ -640,14 +645,14 @@ func (c *InitCommand) getProvidersFromState(ctx context.Context, state *states.S
 	// are shimming our vt100 output to the legacy console API on Windows.
 	evts := &providercache.InstallerEvents{
 		PendingProviders: func(reqs map[addrs.Provider]getproviders.VersionConstraints) {
-			view.Output(views.InitializingProviderPluginFromStateMessage) // Message is specific to provider download from state
+			view.Output(views.InitializingProviderPluginMessage)
 		},
 		ProviderAlreadyInstalled: providerAlreadyInstalledCallback(view),
 		BuiltInProviderAvailable: builtInProviderAvailableCallback(view),
 		BuiltInProviderFailure:   builtInProviderFailureCallback(&diags),
 		QueryPackagesBegin: func(provider addrs.Provider, versionConstraints getproviders.VersionConstraints, locked bool) {
 			if locked {
-				view.LogInitMessage(views.ReusingVersionIdentifiedFromConfig, provider.ForDisplay()) // Message is specific to provider download from state
+				view.LogInitMessage(views.ReusingPreviousVersionInfo, provider.ForDisplay())
 			} else {
 				if len(versionConstraints) > 0 {
 					view.LogInitMessage(views.FindingMatchingVersionMessage, provider.ForDisplay(), getproviders.VersionConstraintsString(versionConstraints))
@@ -669,6 +674,9 @@ func (c *InitCommand) getProvidersFromState(ctx context.Context, state *states.S
 	ctx = evts.OnContext(ctx)
 
 	mode := providercache.InstallNewProvidersOnly
+	if upgrade {
+		mode = providercache.InstallUpgrades
+	}
 
 	// We don't handle upgrade flags here, i.e. what happens at this point in getProvidersFromConfig:
 	// > We cannot upgrade a provider used only by the state, as there are no version constraints in state.

--- a/internal/command/init.go
+++ b/internal/command/init.go
@@ -455,7 +455,7 @@ func (c *InitCommand) getProvidersFromPSSConfig(ctx context.Context, config *con
 		BuiltInProviderFailure:   builtInProviderFailureCallback(&diags),
 		QueryPackagesBegin: func(provider addrs.Provider, versionConstraints getproviders.VersionConstraints, locked bool) {
 			if locked {
-				view.LogInitMessage(views.ReusingVersionIdentifiedFromConfig, provider.ForDisplay()) // Message is specific to provide download from config
+				view.LogInitMessage(views.ReusingVersionDuringStateProviderInit, provider.ForDisplay()) // Message is specific to provide download from config
 			} else {
 				if len(versionConstraints) > 0 {
 					view.LogInitMessage(views.FindingMatchingVersionMessage, provider.ForDisplay(), getproviders.VersionConstraintsString(versionConstraints))

--- a/internal/command/init.go
+++ b/internal/command/init.go
@@ -455,7 +455,7 @@ func (c *InitCommand) getProvidersFromPSSConfig(ctx context.Context, config *con
 		BuiltInProviderFailure:   builtInProviderFailureCallback(&diags),
 		QueryPackagesBegin: func(provider addrs.Provider, versionConstraints getproviders.VersionConstraints, locked bool) {
 			if locked {
-				view.LogInitMessage(views.ReusingVersionDuringStateProviderInit, provider.ForDisplay()) // Message is specific to provide download from config
+				view.LogInitMessage(views.ReusingPreviousVersionInfo, provider.ForDisplay())
 			} else {
 				if len(versionConstraints) > 0 {
 					view.LogInitMessage(views.FindingMatchingVersionMessage, provider.ForDisplay(), getproviders.VersionConstraintsString(versionConstraints))

--- a/internal/command/init_run.go
+++ b/internal/command/init_run.go
@@ -289,8 +289,6 @@ func (c *InitCommand) run(initArgs *arguments.Init, view views.Init) int {
 
 		// Course of action depends on the safeInitAction returned from getProvidersFromPSSConfig
 		switch safeInitAction {
-		case SafeInitActionNotRelevant:
-			// do nothing; security features aren't relevant.
 		case SafeInitActionProceed:
 			// do nothing; provider is already trusted and there's no need to notify the user.
 		case SafeInitActionRequireApproval:

--- a/internal/command/init_run.go
+++ b/internal/command/init_run.go
@@ -270,14 +270,14 @@ func (c *InitCommand) run(initArgs *arguments.Init, view views.Init) int {
 		)
 	}
 
-	var configLocks *depsfile.Locks
+	var pssLocks *depsfile.Locks
 	if config != nil && config.Module != nil && config.Module.StateStore != nil {
 		var configProvidersOutput bool
 		var safeInitAction SafeInitAction
 		var stateStoreProviderAuthResult *getproviders.PackageAuthenticationResult
 		var configProviderDiags tfdiags.Diagnostics
 
-		configProvidersOutput, configLocks, safeInitAction, stateStoreProviderAuthResult, configProviderDiags = c.getProvidersFromPSSConfig(ctx, config, alteredPreviousLocks, initArgs.Upgrade, initArgs.PluginPath, initArgs.Lockfile, view)
+		configProvidersOutput, pssLocks, safeInitAction, stateStoreProviderAuthResult, configProviderDiags = c.getProvidersFromPSSConfig(ctx, config, alteredPreviousLocks, initArgs.Upgrade, initArgs.PluginPath, initArgs.Lockfile, view)
 		diags = diags.Append(configProviderDiags)
 		if configProviderDiags.HasErrors() {
 			view.Diagnostics(diags)
@@ -294,7 +294,7 @@ func (c *InitCommand) run(initArgs *arguments.Init, view views.Init) int {
 		case SafeInitActionRequireApproval:
 			if c.input {
 				// Prompt the user about trusting the provider used for state storage.
-				diags = diags.Append(c.promptStateStorageProviderApproval(config.Module.StateStore.ProviderAddr, configLocks, stateStoreProviderAuthResult))
+				diags = diags.Append(c.promptStateStorageProviderApproval(config.Module.StateStore.ProviderAddr, pssLocks, stateStoreProviderAuthResult))
 				if diags.HasErrors() {
 					view.Output(views.StateStoreProviderInteractiveRejectedMessage)
 					view.Diagnostics(diags)
@@ -333,7 +333,7 @@ func (c *InitCommand) run(initArgs *arguments.Init, view views.Init) int {
 		config.Module.StateStore.ProviderSupplyMode == getproviders.ManagedByTerraform {
 		pAddr := config.Module.StateStore.ProviderAddr
 		old := alteredPreviousLocks.Provider(pAddr)
-		new := configLocks.Provider(pAddr)
+		new := pssLocks.Provider(pAddr)
 		if old == nil || new == nil {
 			panic(fmt.Sprintf(`Unexpected missing provider lock for %s during init -upgrade: 
 prior lock: %#v
@@ -371,7 +371,7 @@ If you do not intend to upgrade the state store provider, please update your con
 	case initArgs.Cloud && rootModEarly.CloudConfig != nil:
 		back, backendOutput, backDiags = c.initCloud(ctx, rootModEarly, initArgs.BackendConfig, initArgs.ViewType, view)
 	case initArgs.Backend:
-		back, backendOutput, backDiags = c.initBackend(ctx, rootModEarly, initArgs, configLocks, view)
+		back, backendOutput, backDiags = c.initBackend(ctx, rootModEarly, initArgs, pssLocks, view)
 	default:
 		// load the previously-stored backend config
 		back, backDiags = c.Meta.backendFromState(ctx)
@@ -432,7 +432,7 @@ If you do not intend to upgrade the state store provider, please update your con
 		state = sMgr.State()
 	}
 
-	stateProvidersOutput, stateLocks, stateProvidersDiags := c.getProviders(ctx, config, state, initArgs.Upgrade, configLocks, initArgs.PluginPath, view)
+	stateProvidersOutput, stateLocks, stateProvidersDiags := c.getProviders(ctx, config, state, initArgs.Upgrade, pssLocks, initArgs.PluginPath, view)
 	diags = diags.Append(stateProvidersDiags)
 	if stateProvidersDiags.HasErrors() {
 		view.Diagnostics(diags)
@@ -448,7 +448,7 @@ If you do not intend to upgrade the state store provider, please update your con
 	}
 
 	// Now the two steps of provider download have happened, update the dependency lock file if it has changed.
-	lockFileOutput, lockFileDiags := c.saveDependencyLockFile(previousLocks, configLocks, stateLocks, initArgs.Lockfile, view)
+	lockFileOutput, lockFileDiags := c.saveDependencyLockFile(previousLocks, pssLocks, stateLocks, initArgs.Lockfile, view)
 	diags = diags.Append(lockFileDiags)
 	if lockFileDiags.HasErrors() {
 		view.Diagnostics(diags)

--- a/internal/command/init_run.go
+++ b/internal/command/init_run.go
@@ -269,50 +269,59 @@ func (c *InitCommand) run(initArgs *arguments.Init, view views.Init) int {
 			lock.PreferredHashes(),
 		)
 	}
-	configProvidersOutput, configLocks, safeInitAction, stateStoreProviderAuthResult, configProviderDiags := c.getProvidersFromConfig(ctx, config, alteredPreviousLocks, initArgs.Upgrade, initArgs.PluginPath, initArgs.Lockfile, view)
-	diags = diags.Append(configProviderDiags)
-	if configProviderDiags.HasErrors() {
-		view.Diagnostics(diags)
-		return 1
-	}
-	if configProvidersOutput {
-		header = true
-	}
 
-	// Course of action depends on the safeInitAction returned from getProvidersFromConfig
-	switch safeInitAction {
-	case SafeInitActionNotRelevant:
-		// do nothing; security features aren't relevant.
-	case SafeInitActionProceed:
-		// do nothing; provider is already trusted and there's no need to notify the user.
-	case SafeInitActionRequireApproval:
-		if c.input {
-			// Prompt the user about trusting the provider used for state storage.
-			diags = diags.Append(c.promptStateStorageProviderApproval(config.Module.StateStore.ProviderAddr, configLocks, stateStoreProviderAuthResult))
-			if diags.HasErrors() {
-				view.Output(views.StateStoreProviderInteractiveRejectedMessage)
-				view.Diagnostics(diags)
-				return 1
-			}
-			view.Output(views.StateStoreProviderInteractiveApprovedMessage)
-		} else {
-			// Confirm that a lock was used to control download.
-			// Note: we have to wait and do that here because at this point we know the provider was downloaded from a source that requires additional info about trust.
-			if alteredPreviousLocks.Provider(config.Module.StateStore.ProviderAddr) == nil {
-				// No lock was provided for the state store provider either through pre-existing locks or through the -state-provider-lock-file flag.
-				diags = diags.Append(tfdiags.Sourceless(
-					tfdiags.Error,
-					"Missing lock for state store provider",
-					"Terraform is initializing a state store for the first time in a non-interactive mode. In this scenario Terraform needs a pre-existing dependency lock for the state store provider to be present in the working directory's dependency lock file, or present in another file supplied via the -state-provider-lock-file flag. No lock was found for the state store provider. Please re-run the command using the -state-provider-lock-file flag.",
-				))
-				view.Diagnostics(diags)
-				return 1
-			}
-			view.Output(views.StateStoreProviderAutomationApprovedMessage)
+	var configLocks *depsfile.Locks
+	if config != nil && config.Module != nil && config.Module.StateStore != nil {
+		var configProvidersOutput bool
+		var safeInitAction SafeInitAction
+		var stateStoreProviderAuthResult *getproviders.PackageAuthenticationResult
+		var configProviderDiags tfdiags.Diagnostics
+
+		configProvidersOutput, configLocks, safeInitAction, stateStoreProviderAuthResult, configProviderDiags = c.getProvidersFromPSSConfig(ctx, config, alteredPreviousLocks, initArgs.Upgrade, initArgs.PluginPath, initArgs.Lockfile, view)
+		diags = diags.Append(configProviderDiags)
+		if configProviderDiags.HasErrors() {
+			view.Diagnostics(diags)
+			return 1
 		}
-	default:
-		// Handle SafeInitActionInvalid or unexpected action types
-		panic(fmt.Sprintf("When installing providers described in the config Terraform couldn't determine what 'safe init' action should be taken and returned action type %T. This is a bug in Terraform and should be reported.", safeInitAction))
+		if configProvidersOutput {
+			header = true
+		}
+
+		// Course of action depends on the safeInitAction returned from getProvidersFromPSSConfig
+		switch safeInitAction {
+		case SafeInitActionNotRelevant:
+			// do nothing; security features aren't relevant.
+		case SafeInitActionProceed:
+			// do nothing; provider is already trusted and there's no need to notify the user.
+		case SafeInitActionRequireApproval:
+			if c.input {
+				// Prompt the user about trusting the provider used for state storage.
+				diags = diags.Append(c.promptStateStorageProviderApproval(config.Module.StateStore.ProviderAddr, configLocks, stateStoreProviderAuthResult))
+				if diags.HasErrors() {
+					view.Output(views.StateStoreProviderInteractiveRejectedMessage)
+					view.Diagnostics(diags)
+					return 1
+				}
+				view.Output(views.StateStoreProviderInteractiveApprovedMessage)
+			} else {
+				// Confirm that a lock was used to control download.
+				// Note: we have to wait and do that here because at this point we know the provider was downloaded from a source that requires additional info about trust.
+				if alteredPreviousLocks.Provider(config.Module.StateStore.ProviderAddr) == nil {
+					// No lock was provided for the state store provider either through pre-existing locks or through the -state-provider-lock-file flag.
+					diags = diags.Append(tfdiags.Sourceless(
+						tfdiags.Error,
+						"Missing lock for state store provider",
+						"Terraform is initializing a state store for the first time in a non-interactive mode. In this scenario Terraform needs a pre-existing dependency lock for the state store provider to be present in the working directory's dependency lock file, or present in another file supplied via the -state-provider-lock-file flag. No lock was found for the state store provider. Please re-run the command using the -state-provider-lock-file flag.",
+					))
+					view.Diagnostics(diags)
+					return 1
+				}
+				view.Output(views.StateStoreProviderAutomationApprovedMessage)
+			}
+		default:
+			// Handle SafeInitActionInvalid or unexpected action types
+			panic(fmt.Sprintf("When installing providers described in the config Terraform couldn't determine what 'safe init' action should be taken and returned action type %T. This is a bug in Terraform and should be reported.", safeInitAction))
+		}
 	}
 
 	// The init command is not allowed to upgrade the provider used for state storage (unless we're reconfiguring the state store).
@@ -425,15 +434,7 @@ If you do not intend to upgrade the state store provider, please update your con
 		state = sMgr.State()
 	}
 
-	// Now the resource state is loaded, we can download the providers specified in the state but not the configuration.
-	// This is step two of a two-step provider download process
-	configReqs, cReqDiags := config.ProviderRequirements()
-	diags = diags.Append(cReqDiags)
-	if cReqDiags.HasErrors() {
-		view.Diagnostics(diags)
-		return 1
-	}
-	stateProvidersOutput, stateLocks, stateProvidersDiags := c.getProvidersFromState(ctx, state, configReqs, configLocks, initArgs.PluginPath, view)
+	stateProvidersOutput, stateLocks, stateProvidersDiags := c.getProviders(ctx, config, state, initArgs.Upgrade, configLocks, initArgs.PluginPath, view)
 	diags = diags.Append(stateProvidersDiags)
 	if stateProvidersDiags.HasErrors() {
 		view.Diagnostics(diags)

--- a/internal/command/init_test.go
+++ b/internal/command/init_test.go
@@ -4059,7 +4059,7 @@ func TestInit_stateStore_newWorkingDir_basic(t *testing.T) {
 - Installing hashicorp/test v1.2.3...
 - Installed hashicorp/test v1.2.3 (verified checksum)
 
-Initializing the state store...
+Initializing the state store "test_store"...
 
 Initializing provider plugins...
 - Reusing previous version of hashicorp/test from the dependency lock file
@@ -4355,7 +4355,7 @@ func TestInit_stateStore_newWorkingDir_interactiveProviderApproval(t *testing.T)
 		// Check output
 		output := testOutput.All()
 		expectedOutputs := []string{
-			"Initializing the state store...",
+			`Initializing the state store "test_store"...`,
 			"Terraform has been successfully initialized!",
 		}
 		for _, expected := range expectedOutputs {
@@ -4422,7 +4422,7 @@ func TestInit_stateStore_newWorkingDir_interactiveProviderApproval(t *testing.T)
 		// Check output via view
 		output := testOutput.All()
 		expectedOutputs := []string{
-			"Initializing the state store...",
+			`Initializing the state store "test_store"...`,
 			"The state store provider was approved",
 			"Terraform has been successfully initialized!",
 		}
@@ -4504,7 +4504,7 @@ func TestInit_stateStore_newWorkingDir_interactiveProviderApproval(t *testing.T)
 		// Check output via view
 		output := testOutput.All()
 		expectedOutputs := []string{
-			"Initializing the state store...",
+			`Initializing the state store "test_store"...`,
 			"The state store provider was approved",
 			"Terraform has been successfully initialized!",
 		}
@@ -4705,7 +4705,7 @@ func TestInit_stateStore_newWorkingDir_interactiveProviderApproval(t *testing.T)
 		}
 		output = testOutput.All()
 		expectedOutputs = []string{
-			"Initializing the state store...",
+			`Initializing the state store "test_store"...`,
 			"The state store provider was approved",
 			"Terraform has been successfully initialized!",
 		}
@@ -4764,7 +4764,7 @@ func TestInit_stateStore_newWorkingDir_inAutomationProviderApproval(t *testing.T
 		// Check output
 		output := testOutput.All()
 		expectedOutputs := []string{
-			"Initializing the state store...",
+			`Initializing the state store "test_store"...`,
 			"Terraform has been successfully initialized!",
 		}
 		for _, expected := range expectedOutputs {
@@ -4844,7 +4844,7 @@ func TestInit_stateStore_newWorkingDir_inAutomationProviderApproval(t *testing.T
 		// Check output via view
 		output := testOutput.All()
 		expectedOutputs := []string{
-			"Initializing the state store...",
+			`Initializing the state store "test_store"...`,
 			"The state store provider was approved automatically",
 			"Terraform has been successfully initialized!",
 		}
@@ -4930,7 +4930,7 @@ func TestInit_stateStore_newWorkingDir_inAutomationProviderApproval(t *testing.T
 		// Check output via view
 		output := testOutput.All()
 		expectedOutputs := []string{
-			"Initializing the state store...",
+			`Initializing the state store "test_store"...`,
 			"The state store provider was approved automatically",
 			"Terraform has been successfully initialized!",
 		}
@@ -5176,7 +5176,7 @@ func TestInit_stateStore_reconfigureLeadingToMigrationOfLocalState(t *testing.T)
 	// Check output
 	output := testOutput.All()
 	expectedOutputs := []string{
-		"Initializing the state store...",
+		`Initializing the state store "test_store"...`,
 		"Terraform has been successfully initialized!",
 	}
 	for _, expected := range expectedOutputs {
@@ -5277,7 +5277,7 @@ func TestInit_stateStore_configUnchanged(t *testing.T) {
 		// Check output
 		output := testOutput.All()
 		expectedOutputs := []string{
-			"Initializing the state store...",
+			`Initializing the state store "test_store"...`,
 			"Terraform has been successfully initialized!",
 		}
 		for _, expected := range expectedOutputs {
@@ -5348,7 +5348,7 @@ func TestInit_stateStore_configChanges(t *testing.T) {
 		// Check output
 		output := testOutput.All()
 		expectedOutputs := []string{
-			"Initializing the state store...",
+			`Initializing the state store "test_store"...`,
 			"Terraform has been successfully initialized!",
 		}
 		for _, expected := range expectedOutputs {
@@ -5442,7 +5442,7 @@ func TestInit_stateStore_configChanges(t *testing.T) {
 
 		// When -backend=false the backend/state store isn't initialized, so we don't expect this
 		// output if the flag has the expected effect on Terraform.
-		unexpectedOutput := "Initializing the state store..."
+		unexpectedOutput := `Initializing the state store "test_store"...`
 		if strings.Contains(output, unexpectedOutput) {
 			t.Fatalf("output included %q, which is unexpected if -backend=false is behaving correctly':\n %s", unexpectedOutput, output)
 		}

--- a/internal/command/init_test.go
+++ b/internal/command/init_test.go
@@ -124,20 +124,19 @@ func TestInit_only_test_files(t *testing.T) {
 	}
 }
 
-func TestInit_two_step_provider_download(t *testing.T) {
+func TestInit_two_source_provider_download(t *testing.T) {
 	cases := map[string]struct {
 		workDirPath          string
 		flags                []string
 		expectedDownloadMsgs []string
 	}{
 		"providers required by only the state file": {
-			// TODO - should the output indicate that no providers were found in config?
 			workDirPath: "init-provider-download/state-file-only",
 			expectedDownloadMsgs: []string{
 				views.MessageRegistry[views.OutputInitSuccessCLIMessage].JSONValue,
-				`Initializing provider plugins found in the configuration...
-				Initializing the backend...`, // No providers found in the configuration so next output is backend-related
-				`Initializing provider plugins found in the state...
+				`Initializing the backend...
+				Successfully configured the backend "local"!`, // No providers found in the configuration so next output is backend-related
+				`Initializing provider plugins...
 				- Finding latest version of hashicorp/random...
 				- Installing hashicorp/random v9.9.9...`, // The latest version is expected, as state has no version constraints
 			},
@@ -146,89 +145,63 @@ func TestInit_two_step_provider_download(t *testing.T) {
 			workDirPath: "init-provider-download/config-and-state-different-providers",
 			expectedDownloadMsgs: []string{
 				views.MessageRegistry[views.OutputInitSuccessCLIMessage].JSONValue,
-
-				// Config - this provider is affected by a version constraint
-				`Initializing provider plugins found in the configuration...
-				- Finding hashicorp/null versions matching "< 9.0.0"...
-				- Installing hashicorp/null v1.0.0...
+				"Initializing provider plugins...",
+				// Config - null provider is affected by a version constraint
+				`- Finding hashicorp/null versions matching "< 9.0.0"...`,
+				`- Installing hashicorp/null v1.0.0...
 				- Installed hashicorp/null v1.0.0`,
-
-				// State - the latest version of this provider is expected, as state has no version constraints
-				`Initializing provider plugins found in the state...
-				- Finding latest version of hashicorp/random...
-				- Installing hashicorp/random v9.9.9...`,
+				// State - the latest version of random provider is expected, as state has no version constraints
+				`- Finding latest version of hashicorp/random...`,
+				`- Installing hashicorp/random v9.9.9...
+				- Installed hashicorp/random v9.9.9`,
 			},
 		},
 		"does not re-download providers that are present in both config and state": {
 			workDirPath: "init-provider-download/config-and-state-same-providers",
 			expectedDownloadMsgs: []string{
-				// Config
-				`Initializing provider plugins found in the configuration...
+				`Initializing provider plugins...
 				- Finding hashicorp/random versions matching "< 9.0.0"...
 				- Installing hashicorp/random v1.0.0...
 				- Installed hashicorp/random v1.0.0`,
-				// State
-				`Initializing provider plugins found in the state...
-				- Reusing previous version of hashicorp/random
-				- Using previously-installed hashicorp/random v1.0.0`,
 			},
 		},
 		"reuses providers already represented in a dependency lock file": {
 			workDirPath: "init-provider-download/config-state-file-and-lockfile",
 			expectedDownloadMsgs: []string{
-				// Config
-				`Initializing provider plugins found in the configuration...
+				`Initializing provider plugins...
 				- Reusing previous version of hashicorp/random from the dependency lock file
 				- Installing hashicorp/random v1.0.0...
 				- Installed hashicorp/random v1.0.0`,
-				// State
-				`Initializing provider plugins found in the state...
-				- Reusing previous version of hashicorp/random
-				- Using previously-installed hashicorp/random v1.0.0`,
 			},
 		},
 		"using the -upgrade flag causes provider download to ignore the lock file": {
 			workDirPath: "init-provider-download/config-state-file-and-lockfile",
 			flags:       []string{"-upgrade"},
 			expectedDownloadMsgs: []string{
-				// Config - lock file is not mentioned due to the -upgrade flag
-				`Initializing provider plugins found in the configuration...
+				// lock file is not mentioned due to the -upgrade flag
+				`Initializing provider plugins...
 				- Finding hashicorp/random versions matching "< 9.0.0"...
 				- Installing hashicorp/random v1.0.0...
 				- Installed hashicorp/random v1.0.0`,
-				// State - reuses the provider download from the config
-				`Initializing provider plugins found in the state...
-				- Reusing previous version of hashicorp/random
-				- Using previously-installed hashicorp/random v1.0.0`,
 			},
 		},
 		// Same as some tests above, but now the version constraint in config specifies a pre-release
 		"pre-release not re-downloaded if present in both config and state": {
 			workDirPath: "init-provider-download-prerelease/config-and-state-same-providers",
 			expectedDownloadMsgs: []string{
-				// Config
-				`Initializing provider plugins found in the configuration...
+				`Initializing provider plugins...
 				- Finding hashicorp/random versions matching "1.2.3-beta"...
 				- Installing hashicorp/random v1.2.3-beta...
-				- Installed hashicorp/random v1.2.3-beta`,
-				// State
-				`Initializing provider plugins found in the state...
-				- Reusing previous version of hashicorp/random
-				- Using previously-installed hashicorp/random v1.2.3-beta`,
+				- Installed hashicorp/random v1.2.3-beta (verified checksum)`,
 			},
 		},
 		"reuses pre-release provider already represented in a dependency lock file": {
 			workDirPath: "init-provider-download-prerelease/config-state-file-and-lockfile",
 			expectedDownloadMsgs: []string{
-				// Config
-				`Initializing provider plugins found in the configuration...
+				`Initializing provider plugins...
 				- Reusing previous version of hashicorp/random from the dependency lock file
 				- Installing hashicorp/random v1.2.3-beta...
 				- Installed hashicorp/random v1.2.3-beta`,
-				// State
-				`Initializing provider plugins found in the state...
-				- Reusing previous version of hashicorp/random
-				- Using previously-installed hashicorp/random v1.2.3-beta`,
 			},
 		},
 	}
@@ -2935,7 +2908,7 @@ terraform {
 			getproviders.MustParseVersion("1.2.3"),
 			getproviders.MustParseVersionConstraints("> 1.0.0"),
 			[]getproviders.Hash{
-				getproviders.HashScheme1.New("wlbEC2mChQZ2hhgUhl6SeVLPP7fMqOFUZAQhQ9GIIno="),
+				getproviders.HashScheme1.New("z1PjPOAuP6c16GKfaCTIJwj95cZ9PrOiREixVFeLZYA="),
 			},
 		)
 		if err := depsfile.SaveLocksToFile(locks, ".terraform.lock.hcl"); err != nil {
@@ -4081,8 +4054,16 @@ func TestInit_stateStore_newWorkingDir_basic(t *testing.T) {
 		// Check output
 		output := testOutput.All()
 		expectedOutputs := []string{
-			"Initializing the state store...",
-			"Terraform has been successfully initialized!",
+			`Initializing provider plugin for state store "test_store"...
+- Finding latest version of hashicorp/test...
+- Installing hashicorp/test v1.2.3...
+- Installed hashicorp/test v1.2.3 (verified checksum)
+
+Initializing the state store...
+
+Initializing provider plugins...
+- Reusing previous version of hashicorp/test from the dependency lock file
+- Using previously-installed hashicorp/test v1.2.3`,
 		}
 		for _, expected := range expectedOutputs {
 			if !strings.Contains(output, expected) {

--- a/internal/command/init_test.go
+++ b/internal/command/init_test.go
@@ -235,10 +235,10 @@ func TestInit_two_source_provider_download(t *testing.T) {
 				t.Fatalf("bad: \n%s", done(t).All())
 			}
 
-			actual := cleanString(done(t).All())
+			actual := done(t).All()
 			for _, downloadMsg := range tc.expectedDownloadMsgs {
 				if !strings.Contains(cleanString(actual), cleanString(downloadMsg)) {
-					t.Fatalf("expected output to contain %q\n, got %q", cleanString(downloadMsg), cleanString(actual))
+					t.Fatalf("expected output to contain %q\n, got:\n%s", cleanString(downloadMsg), actual)
 				}
 			}
 		})
@@ -4067,7 +4067,7 @@ Initializing provider plugins...
 		}
 		for _, expected := range expectedOutputs {
 			if !strings.Contains(output, expected) {
-				t.Fatalf("expected output to include %q, but got':\n %s", expected, output)
+				t.Fatalf("expected output to include %q, but got:\n%s", expected, output)
 			}
 		}
 

--- a/internal/command/init_test.go
+++ b/internal/command/init_test.go
@@ -219,7 +219,6 @@ func TestInit_two_source_provider_download(t *testing.T) {
 				"hashicorp/random": {"1.0.0", "1.2.3-beta", "9.9.9"},
 				"hashicorp/null":   {"1.0.0", "1.2.3-beta", "9.9.9"},
 			})
-
 			ui := new(cli.MockUi)
 			view, done := testView(t)
 			c := &InitCommand{
@@ -228,6 +227,71 @@ func TestInit_two_source_provider_download(t *testing.T) {
 					Ui:               ui,
 					View:             view,
 					ProviderSource:   providerSource,
+				},
+			}
+
+			if code := c.Run(tc.flags); code != 0 {
+				t.Fatalf("bad: \n%s", done(t).All())
+			}
+
+			actual := done(t).All()
+			for _, downloadMsg := range tc.expectedDownloadMsgs {
+				if !strings.Contains(cleanString(actual), cleanString(downloadMsg)) {
+					t.Fatalf("expected output to contain %q\n, got:\n%s", cleanString(downloadMsg), actual)
+				}
+			}
+		})
+	}
+}
+
+func TestInit_stateStoreProviderDownload(t *testing.T) {
+	cases := map[string]struct {
+		workDirPath          string
+		flags                []string
+		expectedDownloadMsgs []string
+	}{
+		"does not re-download the provider used for PSS in the second provider download step": {
+			workDirPath: "init-provider-download/state-store-config-only",
+			flags:       []string{"-enable-pluggable-state-storage-experiment"},
+			expectedDownloadMsgs: []string{
+				`Initializing provider plugin for state store "test_store"...
+				- Finding latest version of hashicorp/test...
+				- Installing hashicorp/test v1.2.3...
+				- Installed hashicorp/test v1.2.3`,
+				`Initializing the state store "test_store"...`,
+				`Initializing provider plugins...
+				- Reusing previous version of hashicorp/test from the dependency lock file
+				- Using previously-installed hashicorp/test v1.2.3`,
+			},
+		},
+	}
+
+	for tn, tc := range cases {
+		t.Run(tn, func(t *testing.T) {
+			// Create a temporary working directory no tf configuration but has state
+			td := t.TempDir()
+			testCopyDir(t, testFixturePath(tc.workDirPath), td)
+			os.MkdirAll(td, 0755)
+			t.Chdir(td)
+
+			// A provider source containing the random and null providers
+			providerSource := newMockProviderSource(t, map[string][]string{
+				"hashicorp/random": {"1.0.0", "1.2.3-beta", "9.9.9"},
+				"hashicorp/null":   {"1.0.0", "1.2.3-beta", "9.9.9"},
+				"hashicorp/test":   {"1.2.3"},
+			})
+
+			mockProvider := mockPluggableStateStorageProvider()
+
+			ui := new(cli.MockUi)
+			view, done := testView(t)
+			c := &InitCommand{
+				Meta: Meta{
+					testingOverrides:          metaOverridesForProvider(mockProvider),
+					Ui:                        ui,
+					View:                      view,
+					ProviderSource:            providerSource,
+					AllowExperimentalFeatures: true,
 				},
 			}
 

--- a/internal/command/meta_dependencies.go
+++ b/internal/command/meta_dependencies.go
@@ -79,8 +79,12 @@ func (m *Meta) replaceLockedDependencies(new *depsfile.Locks) tfdiags.Diagnostic
 // This method supports downloading providers in 2 steps, and is used during the second download step and
 // while updating the dependency lock file.
 func (m *Meta) mergeLockedDependencies(baseLocks, additionalLocks *depsfile.Locks) *depsfile.Locks {
-
-	mergedLocks := baseLocks.DeepCopy()
+	var mergedLocks *depsfile.Locks
+	if baseLocks != nil {
+		mergedLocks = baseLocks.DeepCopy()
+	} else {
+		mergedLocks = depsfile.NewLocks()
+	}
 
 	// Append locks derived from the state to locks derived from config.
 	for _, lock := range additionalLocks.AllProviders() {

--- a/internal/command/testdata/init-get/output.jsonlog
+++ b/internal/command/testdata/init-get/output.jsonlog
@@ -1,7 +1,7 @@
 {"@level":"info","@message":"Terraform 1.9.0-dev","@module":"terraform.ui","terraform":"1.9.0-dev","type":"version","ui":"1.2"}
 {"@level":"info","@message":"Initializing modules...","@module":"terraform.ui","message_code": "initializing_modules_message","type":"init_output"}
 {"@level":"info","@message":"- foo in foo","@module":"terraform.ui","type":"log"}
-{"@level":"info","@message":"Initializing provider plugins found in the configuration...","@module":"terraform.ui","message_code": "initializing_provider_plugin_from_config_message","type":"init_output"}
 {"@level":"info","@message":"Initializing the backend...","@module":"terraform.ui","message_code": "initializing_backend_message","type":"init_output"}
+{"@level":"info","@message":"Initializing provider plugins...","@module":"terraform.ui","message_code": "initializing_provider_plugin_message","type":"init_output"}
 {"@level":"info","@message":"Terraform has been successfully initialized!","@module":"terraform.ui","message_code": "output_init_success_message","type":"init_output"}
 {"@level":"info","@message":"You may now begin working with Terraform. Try running \"terraform plan\" to see\nany changes that are required for your infrastructure. All Terraform commands\nshould now work.\n\nIf you ever set or change modules or backend configuration for Terraform,\nrerun this command to reinitialize your working directory. If you forget, other\ncommands will detect it and remind you to do so if necessary.","@module":"terraform.ui","message_code": "output_init_success_cli_message","type":"init_output"}

--- a/internal/command/testdata/init-provider-download/state-store-config-only/main.tf
+++ b/internal/command/testdata/init-provider-download/state-store-config-only/main.tf
@@ -1,0 +1,12 @@
+terraform {
+  required_providers {
+    test = {
+      source = "hashicorp/test"
+    }
+  }
+  state_store "test_store" {
+    provider "test" {}
+
+    value = "foobar"
+  }
+}

--- a/internal/command/views/init.go
+++ b/internal/command/views/init.go
@@ -187,14 +187,6 @@ var MessageRegistry map[InitMessageCode]InitMessage = map[InitMessageCode]InitMe
 		HumanValue: "\n[reset][bold]Initializing provider plugins...",
 		JSONValue:  "Initializing provider plugins...",
 	},
-	"initializing_provider_plugin_from_config_message": {
-		HumanValue: "\n[reset][bold]Initializing provider plugins found in the configuration...",
-		JSONValue:  "Initializing provider plugins found in the configuration...",
-	},
-	"initializing_provider_plugin_from_state_message": {
-		HumanValue: "\n[reset][bold]Initializing provider plugins found in the state...",
-		JSONValue:  "Initializing provider plugins found in the state...",
-	},
 	"initializing_state_store_provider_plugin_message": {
 		HumanValue: "\n[reset][bold]Initializing provider plugin for state store %q...",
 		JSONValue:  "Initializing provider plugin for state store %q...",
@@ -359,8 +351,6 @@ const (
 	StateStoreProviderInteractiveApprovedMessage InitMessageCode = "state_store_provider_interactive_approved_message"
 	StateStoreProviderInteractiveRejectedMessage InitMessageCode = "state_store_provider_interactive_rejected_message"
 	StateStoreProviderAutomationApprovedMessage  InitMessageCode = "state_store_provider_automation_approved_message"
-	InitializingProviderPluginFromConfigMessage  InitMessageCode = "initializing_provider_plugin_from_config_message"
-	InitializingProviderPluginFromStateMessage   InitMessageCode = "initializing_provider_plugin_from_state_message"
 	InitializingProviderPluginMessage            InitMessageCode = "initializing_provider_plugin_message"
 	ReusingVersionIdentifiedFromConfig           InitMessageCode = "reusing_version_during_state_provider_init"
 	LockInfo                                     InitMessageCode = "lock_info"

--- a/internal/command/views/init.go
+++ b/internal/command/views/init.go
@@ -200,8 +200,8 @@ var MessageRegistry map[InitMessageCode]InitMessage = map[InitMessageCode]InitMe
 		JSONValue:  "Initializing provider plugin for state store %q...",
 	},
 	"initializing_state_store_message": {
-		HumanValue: "\n[reset][bold]Initializing the state store...",
-		JSONValue:  "Initializing the state store...",
+		HumanValue: "\n[reset][bold]Initializing the state store %q...",
+		JSONValue:  "Initializing the state store %q...",
 	},
 	"state_store_provider_interactive_approved_message": {
 		HumanValue: "\n[reset][bold]The state store provider was approved by the user.",

--- a/internal/command/views/init.go
+++ b/internal/command/views/init.go
@@ -195,6 +195,10 @@ var MessageRegistry map[InitMessageCode]InitMessage = map[InitMessageCode]InitMe
 		HumanValue: "\n[reset][bold]Initializing provider plugins found in the state...",
 		JSONValue:  "Initializing provider plugins found in the state...",
 	},
+	"initializing_state_store_provider_plugin_message": {
+		HumanValue: "\n[reset][bold]Initializing provider plugin for state store %q...",
+		JSONValue:  "Initializing provider plugin for state store %q...",
+	},
 	"initializing_state_store_message": {
 		HumanValue: "\n[reset][bold]Initializing the state store...",
 		JSONValue:  "Initializing the state store...",
@@ -351,11 +355,13 @@ const (
 	InitializingModulesMessage                   InitMessageCode = "initializing_modules_message"
 	InitializingBackendMessage                   InitMessageCode = "initializing_backend_message"
 	InitializingStateStoreMessage                InitMessageCode = "initializing_state_store_message"
+	InitializingStateStoreProviderPluginMessage  InitMessageCode = "initializing_state_store_provider_plugin_message"
 	StateStoreProviderInteractiveApprovedMessage InitMessageCode = "state_store_provider_interactive_approved_message"
 	StateStoreProviderInteractiveRejectedMessage InitMessageCode = "state_store_provider_interactive_rejected_message"
 	StateStoreProviderAutomationApprovedMessage  InitMessageCode = "state_store_provider_automation_approved_message"
 	InitializingProviderPluginFromConfigMessage  InitMessageCode = "initializing_provider_plugin_from_config_message"
 	InitializingProviderPluginFromStateMessage   InitMessageCode = "initializing_provider_plugin_from_state_message"
+	InitializingProviderPluginMessage            InitMessageCode = "initializing_provider_plugin_message"
 	ReusingVersionIdentifiedFromConfig           InitMessageCode = "reusing_version_during_state_provider_init"
 	LockInfo                                     InitMessageCode = "lock_info"
 	DependenciesLockChangesInfo                  InitMessageCode = "dependencies_lock_changes_info"

--- a/internal/command/views/init.go
+++ b/internal/command/views/init.go
@@ -352,7 +352,7 @@ const (
 	StateStoreProviderInteractiveRejectedMessage InitMessageCode = "state_store_provider_interactive_rejected_message"
 	StateStoreProviderAutomationApprovedMessage  InitMessageCode = "state_store_provider_automation_approved_message"
 	InitializingProviderPluginMessage            InitMessageCode = "initializing_provider_plugin_message"
-	ReusingVersionIdentifiedFromConfig           InitMessageCode = "reusing_version_during_state_provider_init"
+	ReusingVersionDuringStateProviderInit        InitMessageCode = "reusing_version_during_state_provider_init"
 	LockInfo                                     InitMessageCode = "lock_info"
 	DependenciesLockChangesInfo                  InitMessageCode = "dependencies_lock_changes_info"
 

--- a/internal/command/views/init.go
+++ b/internal/command/views/init.go
@@ -227,10 +227,6 @@ var MessageRegistry map[InitMessageCode]InitMessage = map[InitMessageCode]InitMe
 		HumanValue: "- Reusing previous version of %s from the dependency lock file",
 		JSONValue:  "%s: Reusing previous version from the dependency lock file",
 	},
-	"reusing_version_during_state_provider_init": {
-		HumanValue: "- Reusing previous version of %s",
-		JSONValue:  "Reusing previous version of %s",
-	},
 	"finding_matching_version_message": {
 		HumanValue: "- Finding %s versions matching %q...",
 		JSONValue:  "Finding matching versions for provider: %s, version_constraint: %q",
@@ -352,7 +348,6 @@ const (
 	StateStoreProviderInteractiveRejectedMessage InitMessageCode = "state_store_provider_interactive_rejected_message"
 	StateStoreProviderAutomationApprovedMessage  InitMessageCode = "state_store_provider_automation_approved_message"
 	InitializingProviderPluginMessage            InitMessageCode = "initializing_provider_plugin_message"
-	ReusingVersionDuringStateProviderInit        InitMessageCode = "reusing_version_during_state_provider_init"
 	LockInfo                                     InitMessageCode = "lock_info"
 	DependenciesLockChangesInfo                  InitMessageCode = "dependencies_lock_changes_info"
 

--- a/internal/command/views/init_test.go
+++ b/internal/command/views/init_test.go
@@ -129,7 +129,7 @@ func TestNewInit_jsonViewOutput(t *testing.T) {
 			t.Fatalf("unexpected return type %t", newInit)
 		}
 
-		newInit.Output(InitializingProviderPluginFromConfigMessage)
+		newInit.Output(InitializingProviderPluginMessage)
 
 		version := tfversion.String()
 		want := []map[string]any{
@@ -143,8 +143,8 @@ func TestNewInit_jsonViewOutput(t *testing.T) {
 			},
 			{
 				"@level":       "info",
-				"@message":     "Initializing provider plugins found in the configuration...",
-				"message_code": "initializing_provider_plugin_from_config_message",
+				"@message":     "Initializing provider plugins...",
+				"message_code": "initializing_provider_plugin_message",
 				"@module":      "terraform.ui",
 				"type":         "init_output",
 			},
@@ -231,7 +231,7 @@ func TestNewInit_jsonViewLog(t *testing.T) {
 		t.Fatalf("unexpected return type %t", newInit)
 	}
 
-	newInit.LogInitMessage(InitializingProviderPluginFromConfigMessage)
+	newInit.LogInitMessage(InitializingProviderPluginMessage)
 
 	version := tfversion.String()
 	want := []map[string]interface{}{
@@ -245,7 +245,7 @@ func TestNewInit_jsonViewLog(t *testing.T) {
 		},
 		{
 			"@level":   "info",
-			"@message": "Initializing provider plugins found in the configuration...",
+			"@message": "Initializing provider plugins...",
 			"@module":  "terraform.ui",
 			"type":     "log",
 		},
@@ -282,10 +282,10 @@ func TestNewInit_humanViewOutput(t *testing.T) {
 			t.Fatalf("unexpected return type %t", newInit)
 		}
 
-		newInit.Output(InitializingProviderPluginFromConfigMessage)
+		newInit.Output(InitializingProviderPluginMessage)
 
 		actual := done(t).All()
-		expected := "Initializing provider plugins found in the configuration..."
+		expected := "Initializing provider plugins..."
 		if !strings.Contains(actual, expected) {
 			t.Fatalf("expected output to contain: %s, but got %s", expected, actual)
 		}


### PR DESCRIPTION
This walks back some of the decisions we made earlier around two-step provider downloading process. However, it should not impact the safety features and it should not have a tangible (functional) impact on the end-user aside from the log output outlined below.

The motivation is to accommodate some needs of the upcoming policy features.

## TL;DR

Previously the two steps were:

1. Download providers based on configuration
2. Download providers based on state

The process remains two steps but the new steps are:

1. Download 0-1 provider if one is needed for PSS (PSS is in use)
2. Download all other providers (configuration + state)

## End-user Facing Changes

Two new log messages are being introduced (and will need to be documented in https://github.com/hashicorp/web-unified-docs/blob/main/content/terraform/v1.15.x/docs/internals/machine-readable-ui.mdx#init-messages

 - `initializing_provider_plugin_message` (re-introduction after removal in 1.14)
 - `initializing_state_store_provider_plugin_message` (net new but PSS specific)

I also updated `initializing_state_store_message` to include the state store type as I thought it might be helpful. I assume this still falls under the experimental feature and as such does not need to be communicated or documented (yet) until PSS goes GA.

Then two existing messages are being removed here as they lose meaning in the context of this PR:

 - `initializing_provider_plugin_from_config_message`
 - `initializing_provider_plugin_from_state_message`

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.16.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [x] This change is user-facing and I added a changelog entry.
- [ ] This change is not user-facing.
