### PR TITLE
Fix flaky ordering test

### DIFF
--- a/internal/command/test_test.go
+++ b/internal/command/test_test.go
@@ -1343,30 +1343,41 @@ func TestTest_Parallel(t *testing.T) {
 	// Split the log into lines
 	lines := strings.Split(output, "\n")
 
-	// Find the positions of "test_d", "test_c", "test_setup" in the log output
-	var testDIndex, testCIndex, testSetupIndex int
+	// Find first positions in the log output
+	testSetupIndex, testBIndex, testCIndex, testDIndex := -1, -1, -1, -1
 	for i, line := range lines {
-		if strings.Contains(line, "run \"setup\"") {
-			testSetupIndex = i
-		} else if strings.Contains(line, "run \"test_d\"") {
-			testDIndex = i
-		} else if strings.Contains(line, "run \"test_c\"") {
-			testCIndex = i
+		switch {
+		case strings.Contains(line, `run "setup"`):
+			if testSetupIndex == -1 {
+				testSetupIndex = i
+			}
+		case strings.Contains(line, `run "test_b"`):
+			if testBIndex == -1 {
+				testBIndex = i
+			}
+		case strings.Contains(line, `run "test_c"`):
+			if testCIndex == -1 {
+				testCIndex = i
+			}
+		case strings.Contains(line, `run "test_d"`):
+			if testDIndex == -1 {
+				testDIndex = i
+			}
 		}
 	}
-	if testDIndex == 0 || testCIndex == 0 || testSetupIndex == 0 {
-		t.Fatalf("test_d, test_c, or test_setup not found in the log output")
-	}
 
-	// Ensure "test_d" appears before "test_c", because test_d has no dependencies,
-	// and would therefore run in parallel to much earlier tests which test_c depends on.
-	if testDIndex > testCIndex {
-		t.Errorf("test_d appears after test_c in the log output")
+	if testSetupIndex == -1 || testBIndex == -1 || testCIndex == -1 || testDIndex == -1 {
+		t.Fatalf("test_setup, test_b, test_c, or test_d not found in the log output")
 	}
 
 	// Ensure "test_d" appears after "test_setup", because they have the same state key
 	if testDIndex < testSetupIndex {
-		t.Errorf("test_d appears before test_setup in the log output")
+		t.Errorf("invalid ordering: test_d appears before test_setup in the log output")
+	}
+
+	// Ensure "test_c" appears after "test_b", because they have the same state key
+	if testCIndex < testBIndex {
+		t.Errorf("invalid ordering: test_c appears before test_b in the log output")
 	}
 }
 


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

This fixes a buggy test around test parallelization. The test originally tried to force order by increasing the latency of the run `test_b`, and then trusting that the delay is enough to ensure that other nodes that run in parallel with it run before it, but that is not a given, and has led to flakiness in a particular assertion. Instead, I am now testing things that are only certain to be guaranteed, regardless of latency.
https://github.com/hashicorp/terraform/blob/791caa3c5a8f1fb35aaafe5a9bf1e7c84eb65e19/internal/command/testdata/test/parallel/parallel.tftest.hcl#L52-L56

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.16.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [ ] This change is not user-facing.
