### PR TITLE
Action and condition eval before apply

### DIFF
--- a/internal/configs/action.go
+++ b/internal/configs/action.go
@@ -66,6 +66,11 @@ const (
 	Invoke
 )
 
+var (
+	BeforeEvents = []ActionTriggerEvent{BeforeCreate, BeforeUpdate, BeforeDestroy}
+	AfterEvents  = []ActionTriggerEvent{AfterCreate, AfterUpdate, AfterDestroy}
+)
+
 // ActionRef represents a reference to a configured Action
 type ActionRef struct {
 	Expr  hcl.Expression
@@ -84,23 +89,8 @@ func decodeActionTriggerBlock(block *hcl.Block) (*ActionTrigger, hcl.Diagnostics
 	diags = append(diags, bodyDiags...)
 
 	var refs []*addrs.Reference
-	var refDiags tfdiags.Diagnostics
 	if attr, exists := content.Attributes["condition"]; exists {
 		a.Condition = attr.Expr
-
-		refs, refDiags = langrefs.ReferencesInExpr(addrs.ParseRef, attr.Expr)
-		diags = append(diags, refDiags.ToHCL()...)
-
-		for _, ref := range refs {
-			if ref.Subject == addrs.Self {
-				diags = diags.Append(&hcl.Diagnostic{
-					Severity: hcl.DiagError,
-					Summary:  "Self reference not allowed",
-					Detail:   `The condition expression cannot reference "self".`,
-					Subject:  attr.Expr.Range().Ptr(),
-				})
-			}
-		}
 	}
 
 	if attr, exists := content.Attributes["events"]; exists {

--- a/internal/configs/action_test.go
+++ b/internal/configs/action_test.go
@@ -243,9 +243,7 @@ func TestDecodeActionTriggerBlock(t *testing.T) {
 					},
 				},
 			},
-			[]string{
-				`MockExprTraversal:0,0-7: Self reference not allowed; The condition expression cannot reference "self".`,
-			},
+			nil,
 		},
 		"error - condition uses count.index and includes before_event": {
 			&hcl.Block{
@@ -268,9 +266,7 @@ func TestDecodeActionTriggerBlock(t *testing.T) {
 					},
 				},
 			},
-			[]string{
-				`:1,1-29: Count reference not allowed; The condition expression cannot reference "count" if the action is run before the resource is applied.`,
-			},
+			nil,
 		},
 		"error - condition uses each.value and includes before_event": {
 			&hcl.Block{
@@ -293,9 +289,7 @@ func TestDecodeActionTriggerBlock(t *testing.T) {
 					},
 				},
 			},
-			[]string{
-				`:1,1-26: Each reference not allowed; The condition expression cannot reference "each" if the action is run before the resource is applied.`,
-			},
+			nil,
 		},
 	}
 

--- a/internal/terraform/action_trigger_instance_apply.go
+++ b/internal/terraform/action_trigger_instance_apply.go
@@ -16,7 +16,6 @@ import (
 
 type actionTriggerApplyInstance struct {
 	ActionInvocation *plans.ActionInvocationInstanceSrc
-	resolvedProvider addrs.AbsProviderConfig
 
 	// actionNode links the trigger to it's action config node.
 	// This is connected by the diff transformer.
@@ -33,11 +32,11 @@ var (
 func (n *actionTriggerApplyInstance) invoke(ctx EvalContext, caller addrs.Referenceable) tfdiags.Diagnostics {
 	var diags tfdiags.Diagnostics
 
-	provider, _, err := getProvider(ctx, n.resolvedProvider)
+	provider, _, err := getProvider(ctx, n.ActionInvocation.ProviderAddr)
 	if err != nil {
 		diags = diags.Append(&hcl.Diagnostic{
 			Severity: hcl.DiagError,
-			Summary:  fmt.Sprintf("Failed to get provider for %s", n.resolvedProvider),
+			Summary:  fmt.Sprintf("Failed to get provider for %s", n.ActionInvocation.ProviderAddr),
 			Detail:   fmt.Sprintf("Failed to get provider: %s", err),
 			Subject:  n.actionNode.Config.DeclRange.Ptr(),
 		})
@@ -65,7 +64,7 @@ func (n *actionTriggerApplyInstance) invoke(ctx EvalContext, caller addrs.Refere
 		return diags.Append(&hcl.Diagnostic{
 			Severity: hcl.DiagError,
 			Summary:  "Action configuration unknown during apply",
-			Detail:   fmt.Sprintf("The action %s was not fully known during apply.\n\nThis is a bug in Terraform, please report it.", n.ActionInvocation.Addr),
+			Detail:   fmt.Sprintf("The action %s was not fully known during apply.", n.ActionInvocation.Addr),
 			// FIXME: maybe turn this into an attribute path diagnostic?
 			Subject: n.actionNode.Config.DeclRange.Ptr(),
 		})
@@ -102,7 +101,7 @@ func (n *actionTriggerApplyInstance) invoke(ctx EvalContext, caller addrs.Refere
 		return diags
 	}
 
-	if resp.Events != nil { // should only occur in misconfigured tests
+	if resp.Events != nil {
 		for event := range resp.Events {
 			switch ev := event.(type) {
 			case providers.InvokeActionEvent_Progress:
@@ -148,7 +147,8 @@ func (n *actionTriggerApplyInstance) Provider() ProviderRef {
 }
 
 func (n *actionTriggerApplyInstance) SetProvider(config addrs.AbsProviderConfig) {
-	n.resolvedProvider = config
+	// keep this method to satisfy GraphNodeProviderConsumer, but we already
+	// have a resolved provider saved in the plan
 }
 
 func (n *actionTriggerApplyInstance) References() []*addrs.Reference {

--- a/internal/terraform/action_trigger_instance_apply.go
+++ b/internal/terraform/action_trigger_instance_apply.go
@@ -64,7 +64,8 @@ func (n *actionTriggerApplyInstance) invoke(ctx EvalContext, caller addrs.Refere
 		return diags.Append(&hcl.Diagnostic{
 			Severity: hcl.DiagError,
 			Summary:  "Action configuration unknown during apply",
-			Detail:   fmt.Sprintf("The action %s was not fully known during apply.", n.ActionInvocation.Addr),
+			Detail: fmt.Sprintf("The action %s was not fully known during apply. "+
+				"This may be caused by using the caller object in conjunction with a before event.", n.ActionInvocation.Addr),
 			// FIXME: maybe turn this into an attribute path diagnostic?
 			Subject: n.actionNode.Config.DeclRange.Ptr(),
 		})

--- a/internal/terraform/context_apply_action_test.go
+++ b/internal/terraform/context_apply_action_test.go
@@ -1612,46 +1612,6 @@ resource "test_object" "a" {
 			},
 			expectInvokeActionCalled: true,
 		},
-		"referencing triggering resource in after_* condition": {
-			module: map[string]string{
-				"main.tf": `
-action "action_example" "hello" {
-  config {
-    attr = "hello"
-  }
-}
-action "action_example" "world" {
-  config {
-    attr = "world"
-  }
-}
-resource "test_object" "a" {
-  test_string = "foo"
-  lifecycle {
-    action_trigger {
-      events = [after_create]
-      condition = test_object.a.test_string == "foo"
-      actions = [action.action_example.hello]
-    }
-    action_trigger {
-      events = [after_update]
-      condition = test_object.a.test_string == "bar"
-      actions = [action.action_example.world]
-    }
-  }
-}
-`,
-			},
-			expectInvokeActionCalled: true,
-			expectInvokeActionCalls: []providers.InvokeActionRequest{
-				{
-					ActionType: "action_example",
-					PlannedActionData: cty.ObjectVal(map[string]cty.Value{
-						"attr": cty.StringVal("hello"),
-					}),
-				},
-			},
-		},
 		"multiple events triggering in same action trigger": {
 			module: map[string]string{
 				"main.tf": `

--- a/internal/terraform/context_apply_action_test.go
+++ b/internal/terraform/context_apply_action_test.go
@@ -571,7 +571,8 @@ resource "test_object" "b" {
 				return tfdiags.Diagnostics{}.Append(&hcl.Diagnostic{
 					Severity: hcl.DiagError,
 					Summary:  "Action configuration unknown during apply",
-					Detail:   "The action action.action_example.hello was not fully known during apply.\n\nThis is a bug in Terraform, please report it.",
+					Detail: "The action action.action_example.hello was not fully known during apply. " +
+						"This may be caused by using the caller object in conjunction with a before event.",
 					Subject: &hcl.Range{
 						Filename: filepath.Join(m.Module.SourceDir, "main.tf"),
 						Start:    hcl.Pos{Line: 5, Column: 1, Byte: 46},
@@ -1493,6 +1494,44 @@ resource "test_object" "a" {
 `,
 			},
 			expectInvokeActionCalled: true,
+		},
+
+		"before_create references caller": {
+			module: map[string]string{
+				"main.tf": `
+action "action_example" "test" {
+  config {
+    attr = caller.test_string
+  }
+}
+resource "test_object" "a" {
+  test_string = "new"
+  lifecycle {
+    action_trigger {
+      events = [before_update]
+      condition = self.test_string == "new"
+      actions = [action.action_example.test]
+    }
+  }
+}
+`,
+			},
+			prevRunState: states.BuildState(func(s *states.SyncState) {
+				s.SetResourceInstanceCurrent(mustResourceInstanceAddr("test_object.a"),
+					&states.ResourceInstanceObjectSrc{
+						Status:    states.ObjectReady,
+						AttrsJSON: []byte(`{"test_string": "old"}`),
+					},
+					mustProviderConfig(`provider["registry.terraform.io/hashicorp/test"]`),
+				)
+			}),
+			expectInvokeActionCalled: true,
+			expectInvokeActionCalls: []providers.InvokeActionRequest{{
+				ActionType: "action_example",
+				PlannedActionData: cty.ObjectVal(map[string]cty.Value{
+					"attr": cty.StringVal("new"),
+				}),
+			}},
 		},
 
 		"simple condition evaluation - false": {

--- a/internal/terraform/context_plan_actions_test.go
+++ b/internal/terraform/context_plan_actions_test.go
@@ -3139,7 +3139,6 @@ resource "test_object" "a" {
   lifecycle {
     action_trigger {
       events = [before_create]
-      condition = self.name == "new"
       actions = [action.test_action.test]
     }
   }

--- a/internal/terraform/context_plan_actions_test.go
+++ b/internal/terraform/context_plan_actions_test.go
@@ -3114,7 +3114,6 @@ resource "test_object" "a" {
 }
 `,
 				},
-				// expectPlanActionCalled: false,
 				expectPlanActionCalled: true,
 				planOpts: &PlanOpts{
 					Mode: plans.NormalMode,
@@ -3125,20 +3124,29 @@ resource "test_object" "a" {
 						},
 					},
 				},
-				// FIXME: conditions can be unknown, but verify how they are planned
-				//
-				// expectPlanDiagnostics: func(m *configs.Config) tfdiags.Diagnostics {
-				// 	return tfdiags.Diagnostics{}.Append(&hcl.Diagnostic{
-				// 		Severity: hcl.DiagError,
-				// 		Summary:  "Condition must be known",
-				// 		Detail:   "The condition expression resulted in an unknown value, but it must be a known boolean value.",
-				// 		Subject: &hcl.Range{
-				// 			Filename: filepath.Join(m.Module.SourceDir, "main.tf"),
-				// 			Start:    hcl.Pos{Line: 10, Column: 19, Byte: 184},
-				// 			End:      hcl.Pos{Line: 10, Column: 36, Byte: 201},
-				// 		},
-				// 	})
-				// },
+			},
+
+			"before_create references caller": {
+				module: map[string]string{
+					"main.tf": `
+action "test_action" "test" {
+  config {
+    attr = caller.name
+  }
+}
+resource "test_object" "a" {
+  name = "new"
+  lifecycle {
+    action_trigger {
+      events = [before_create]
+      condition = self.name == "new"
+      actions = [action.test_action.test]
+    }
+  }
+}
+`,
+				},
+				expectPlanActionCalled: true,
 			},
 
 			"non-boolean condition": {

--- a/internal/terraform/context_plan_actions_test.go
+++ b/internal/terraform/context_plan_actions_test.go
@@ -3182,7 +3182,7 @@ resource "test_object" "a" {
 				},
 			},
 
-			"referencing triggering resource in after_* condition": {
+			"referencing triggering resource address": {
 				module: map[string]string{
 					"main.tf": `
 action "test_action" "hello" {}
@@ -3195,20 +3195,16 @@ resource "test_object" "a" {
       condition = test_object.a.name == "foo"
       actions = [action.test_action.hello]
     }
-    action_trigger {
-      events = [after_update]
-      condition = test_object.a.name == "bar"
-      actions = [action.test_action.world]
-    }
   }
 }
 `,
 				},
-				expectPlanActionCalled: true,
-
-				assertPlan: func(t *testing.T, p *plans.Plan) {
-					if len(p.Changes.ActionInvocations) != 1 {
-						t.Errorf("expected 1 action invocation, got %d", len(p.Changes.ActionInvocations))
+				expectPlanActionCalled: false,
+				assertValidateDiagnostics: func(t *testing.T, diags tfdiags.Diagnostics) {
+					for _, d := range diags {
+						if d.Description().Summary != "Self-referential block" {
+							t.Errorf("expected Self-referential block diagnostic, got %s", d.Description().Summary)
+						}
 					}
 				},
 			},

--- a/internal/terraform/context_validate_test.go
+++ b/internal/terraform/context_validate_test.go
@@ -4379,6 +4379,33 @@ resource "test_instance" "foo" {
 			"Missing required argument: The argument \"host\" is required, but was not set.",
 			false,
 		},
+
+		"self ref in before_create condition": {
+			`
+terraform {
+  required_providers {
+    test = {
+      source = "hashicorp/test"
+      version = "1.0.0"
+    }
+  }
+}
+action "test_other" "foo" {
+  config {}
+}
+resource "test_instance" "foo" {
+  lifecycle {
+    action_trigger {
+      events = [before_create]
+	  condition = self.foo != "oops"
+      actions = [action.test_other.foo]
+    }
+  }
+}
+				`,
+			"Reference to self in before_create condition: Computed attributes from self may not be known before the resource is created.",
+			true,
+		},
 	}
 
 	for name, test := range tests {

--- a/internal/terraform/node_action.go
+++ b/internal/terraform/node_action.go
@@ -121,7 +121,7 @@ func (n *NodeActionConfig) recordActionExpansion(ctx EvalContext) tfdiags.Diagno
 func (n *NodeActionConfig) Validate(ctx EvalContext, caller addrs.Referenceable) tfdiags.Diagnostics {
 	var diags tfdiags.Diagnostics
 
-	provider, providerSchema, err := getProvider(ctx, n.ResolvedProvider)
+	provider, _, err := getProvider(ctx, n.ResolvedProvider)
 	diags = diags.Append(err)
 	if diags.HasErrors() {
 		return diags
@@ -154,23 +154,12 @@ func (n *NodeActionConfig) Validate(ctx EvalContext, caller addrs.Referenceable)
 		diags = diags.Append(forEachDiags)
 	}
 
-	schema := providerSchema.SchemaForActionType(n.Config.Type)
-	if schema.ConfigSchema == nil {
-		diags = diags.Append(&hcl.Diagnostic{
-			Severity: hcl.DiagError,
-			Summary:  "Invalid action type",
-			Detail:   fmt.Sprintf("The provider %s does not support action type %q.", n.Provider().ForDisplay(), n.Config.Type),
-			Subject:  &n.Config.TypeRange,
-		})
-		return diags
-	}
-
 	config := n.Config.Config
 	if n.Config.Config == nil {
 		config = hcl.EmptyBody()
 	}
 
-	configVal, _, valDiags := ctx.EvaluateBlock(config, schema.ConfigSchema, caller, keyData)
+	configVal, _, valDiags := ctx.EvaluateBlock(config, n.Schema.ConfigSchema, caller, keyData)
 	if valDiags.HasErrors() {
 		// If there was no config block at all, we'll add a Context range to the returned diagnostic
 		if n.Config.Config == nil {
@@ -185,10 +174,10 @@ func (n *NodeActionConfig) Validate(ctx EvalContext, caller addrs.Referenceable)
 		}
 	}
 	var deprecationDiags tfdiags.Diagnostics
-	configVal, deprecationDiags = ctx.Deprecations().ValidateAndUnmarkConfig(configVal, schema.ConfigSchema, n.ModulePath())
+	configVal, deprecationDiags = ctx.Deprecations().ValidateAndUnmarkConfig(configVal, n.Schema.ConfigSchema, n.ModulePath())
 	diags = diags.Append(deprecationDiags.InConfigBody(n.Config.Config, n.Addr.String()))
 
-	valDiags = validateResourceForbiddenEphemeralValues(ctx, configVal, schema.ConfigSchema)
+	valDiags = validateResourceForbiddenEphemeralValues(ctx, configVal, n.Schema.ConfigSchema)
 	diags = diags.Append(valDiags.InConfigBody(config, n.Addr.String()))
 
 	if diags.HasErrors() {

--- a/internal/terraform/node_resource_apply_instance.go
+++ b/internal/terraform/node_resource_apply_instance.go
@@ -6,6 +6,7 @@ package terraform
 import (
 	"fmt"
 	"log"
+	"slices"
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/zclconf/go-cty/cty"
@@ -231,7 +232,7 @@ func (n *NodeApplyableResourceInstance) managedResourceExecute(ctx EvalContext) 
 
 	// Make a new diff, in case we've learned new values in the state
 	// during apply which we can now incorporate.
-	diffApply, _, deferred, planDiags := n.plan(ctx, diff, state, false, n.forceReplace, repData)
+	diffApply, instancePlannedState, deferred, planDiags := n.plan(ctx, diff, state, false, n.forceReplace, repData)
 	diags = diags.Append(planDiags)
 	if diags.HasErrors() {
 		return diags
@@ -272,6 +273,32 @@ func (n *NodeApplyableResourceInstance) managedResourceExecute(ctx EvalContext) 
 	// re-write the state, but we do need to re-evaluate postconditions.
 	if diffApply.Action == plans.NoOp {
 		return diags.Append(n.managedResourcePostconditions(ctx, repData))
+	}
+
+	// In order to ensure the action can be evaluated, we need to update the
+	// stored change and state in case it provides some newly known values. We
+	// hedge against any unexpected changes in diff handling for existing
+	// configurations by only updating these when we have actions to evaluate.
+	if n.hasBeforeActions() {
+		changes := ctx.Changes()
+		changes.RemoveResourceInstanceChange(n.Addr, deposedKey)
+		changes.AppendResourceInstanceChange(diffApply)
+
+		// we also have to update the state to reflect the pending changes
+		// again, or else evaluation will return the old state. Since before
+		// actions are the first time we've encountered this eval-before-applied
+		// situation, all instances in the state were previously just left as
+		// ObjectReady.
+		diags = diags.Append(n.writeResourceInstanceState(ctx, instancePlannedState, workingState))
+		if diags.HasErrors() {
+			return diags
+		}
+
+		log.Printf("[DEBUG] NodeApplyableResourceInstance: invoking before actions for %s", n.Addr)
+		diags = diags.Append(n.invokeActions(ctx, repData, configs.BeforeEvents))
+		if diags.HasErrors() {
+			return diags
+		}
 	}
 
 	state, applyDiags := n.apply(ctx, state, diffApply, n.Config, repData, n.CreateBeforeDestroy())
@@ -352,15 +379,47 @@ func (n *NodeApplyableResourceInstance) managedResourceExecute(ctx EvalContext) 
 	// until the user makes the condition succeed.
 	diags = diags.Append(n.managedResourcePostconditions(ctx, repData))
 
-	diags = diags.Append(n.invokeActions(ctx))
+	diags = diags.Append(n.invokeActions(ctx, repData, configs.AfterEvents))
 
 	return diags
 }
 
-func (n *NodeApplyableResourceInstance) invokeActions(ctx EvalContext) tfdiags.Diagnostics {
+// pre-check for before actions since being able to evaluate actions requires a
+// slightly different behavior for diff handling, we guard that change by seeing if
+// it's needed at all.
+func (n *NodeApplyableResourceInstance) hasBeforeActions() bool {
+	for _, trigger := range n.actionTriggers {
+		event := trigger.ActionInvocation.ActionTrigger.TriggerEvent()
+		if slices.Contains(configs.BeforeEvents, event) {
+			return true
+		}
+	}
+	return false
+}
+
+// invokeActions invokes any actions triggered for the listed events. Condition
+// expressions are reevaluated here when they exist, and failing conditions are
+// skipped.
+func (n *NodeApplyableResourceInstance) invokeActions(ctx EvalContext, repData instances.RepetitionData, forEvents []configs.ActionTriggerEvent) tfdiags.Diagnostics {
 	var diags tfdiags.Diagnostics
 
 	for _, trigger := range n.actionTriggers {
+		event := trigger.ActionInvocation.ActionTrigger.TriggerEvent()
+		if !slices.Contains(forEvents, event) {
+			continue
+		}
+
+		condOK, condDiags := n.evalActionCondition(ctx, trigger, repData)
+		diags = diags.Append(condDiags)
+		if diags.HasErrors() {
+			return diags
+		}
+
+		if !condOK {
+			log.Printf("[DEBUG] NodeApplyableResourceInstance: action condition false, skipping %s", trigger.ActionInvocation.Addr)
+			continue
+		}
+
 		diags = diags.Append(trigger.invoke(ctx, n.Addr.Resource))
 		if diags.HasErrors() {
 			break
@@ -368,6 +427,41 @@ func (n *NodeApplyableResourceInstance) invokeActions(ctx EvalContext) tfdiags.D
 	}
 
 	return diags
+}
+
+// We need to lookup any condition expression from the action block before
+// execution, because the condition is part of the resource config, while the
+// action is planned as an ActionInvocation.
+func (n *NodeApplyableResourceInstance) evalActionCondition(ctx EvalContext, trigger *actionTriggerApplyInstance, repData instances.RepetitionData) (bool, tfdiags.Diagnostics) {
+	var diags tfdiags.Diagnostics
+
+	// this can't be an invoked trigger
+	rat := trigger.ActionInvocation.ActionTrigger.(*plans.ResourceActionTrigger)
+	triggerBlock := n.Config.Managed.ActionTriggers[rat.ActionTriggerBlockIndex]
+
+	if triggerBlock.Condition == nil {
+		return true, diags
+	}
+
+	scope := ctx.EvaluationScope(n.Addr.Resource, nil, repData)
+	cond, conditionEvalDiags := scope.EvalExpr(triggerBlock.Condition, cty.Bool)
+	diags = diags.Append(conditionEvalDiags)
+	if diags.HasErrors() {
+		return false, diags
+	}
+
+	if !cond.IsKnown() {
+		// this should not happen, but give the user a good diagnostic to help
+		// reproduce the problem in case it does.
+		return false, diags.Append(&hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  "Unknown condition when invoking action before apply",
+			Detail:   "The action trigger condition must be known before it can be invoked.",
+			Subject:  triggerBlock.Condition.Range().Ptr(),
+		})
+	}
+
+	return cond.True(), diags
 }
 
 func (n *NodeApplyableResourceInstance) ActionProviders() []ProviderRef {

--- a/internal/terraform/node_resource_plan_instance.go
+++ b/internal/terraform/node_resource_plan_instance.go
@@ -605,7 +605,7 @@ func (n *NodePlannableResourceInstance) planActionTriggers(ctx EvalContext, resR
 	var actionInvocations []*plans.ActionInvocationInstance
 
 	for _, trigger := range n.actionTriggers {
-		scope := ctx.EvaluationScope(nil, nil, resRepData)
+		scope := ctx.EvaluationScope(n.Addr.Resource, nil, resRepData)
 		if trigger.config.Condition != nil {
 			cond, conditionEvalDiags := scope.EvalExpr(trigger.config.Condition, cty.Bool)
 			diags = diags.Append(conditionEvalDiags)
@@ -620,15 +620,17 @@ func (n *NodePlannableResourceInstance) planActionTriggers(ctx EvalContext, resR
 			}
 		}
 
-		for _, event := range actionIsTriggeredByEvent(trigger.config.Events, n.change.Action) {
+		// FIXME: this looks strange, because actions can have multiple events,
+		// but we're just repeating the same plan. Refactoring is annoying
+		// though because the event is set within a nested interface inside a
+		// pointer to the ActionInvocationInstance.
+		for _, event := range eventsForPlannedAction(trigger.config.Events, n.change.Action) {
 			for _, action := range trigger.actionRefs {
 				ai, deferred, planDiags := n.planActionTrigger(ctx, resRepData, action, event)
 				diags = diags.Append(planDiags)
 				if diags.HasErrors() {
 					return diags
 				}
-
-				actionInvocations = append(actionInvocations, ai)
 
 				if deferred {
 					log.Printf("[DEBUG] NodePlannableResourceInstance %s is being deferred due to action %s", n.Addr, action.actionNode.Addr)
@@ -646,6 +648,8 @@ func (n *NodePlannableResourceInstance) planActionTriggers(ctx EvalContext, resR
 					n.reportDeferredActionTriggers(ctx, providers.DeferredReasonDeferredPrereq)
 					return diags
 				}
+
+				actionInvocations = append(actionInvocations, ai)
 			}
 		}
 	}
@@ -1307,7 +1311,7 @@ func depsEqual(a, b []addrs.ConfigResource) bool {
 	return true
 }
 
-func actionIsTriggeredByEvent(events []configs.ActionTriggerEvent, action plans.Action) []configs.ActionTriggerEvent {
+func eventsForPlannedAction(events []configs.ActionTriggerEvent, action plans.Action) []configs.ActionTriggerEvent {
 	triggeredEvents := []configs.ActionTriggerEvent{}
 	for _, event := range events {
 		switch event {

--- a/internal/terraform/node_resource_validate.go
+++ b/internal/terraform/node_resource_validate.go
@@ -80,7 +80,29 @@ func (n *NodeValidatableResource) validateActions(ctx EvalContext) tfdiags.Diagn
 	// purposes of validation we don't need to repeat them. Just collect all
 	// known actions and validate them once each.
 	actions := addrs.MakeMap[addrs.ConfigAction, actionRef]()
+
 	for _, trigger := range n.actionTriggers {
+		// Self refs are allowed, but we'll at least prevent before_create from
+		// using them. Technically a resource can plan known computed
+		// attributes, but we'll guard against the common case for now.
+	EVENTS:
+		for _, event := range trigger.config.Events {
+			if event == configs.BeforeCreate {
+				refs, _ := langrefs.ReferencesInExpr(addrs.ParseRef, trigger.config.Condition)
+				for _, ref := range refs {
+					if _, isSelf := ref.Subject.(addrs.SelfType); isSelf {
+						diags = diags.Append(&hcl.Diagnostic{
+							Severity: hcl.DiagError,
+							Summary:  "Reference to self in before_create condition",
+							Detail:   "Computed attributes from self may not be known before the resource is created.",
+							Subject:  trigger.config.Condition.Range().Ptr(),
+						})
+						break EVENTS
+					}
+				}
+			}
+		}
+
 		for _, ref := range trigger.actionRefs {
 			actions.Put(ref.actionNode.Addr, ref)
 		}

--- a/internal/terraform/node_resource_validate.go
+++ b/internal/terraform/node_resource_validate.go
@@ -103,6 +103,9 @@ func (n *NodeValidatableResource) validateActions(ctx EvalContext) tfdiags.Diagn
 			}
 		}
 
+		// check condition for full address self-refs
+		diags = diags.Append(validateMetaSelfRef(n.Addr.Resource, trigger.config.Condition))
+
 		for _, ref := range trigger.actionRefs {
 			actions.Put(ref.actionNode.Addr, ref)
 		}

--- a/internal/terraform/transform_action_diff.go
+++ b/internal/terraform/transform_action_diff.go
@@ -56,7 +56,6 @@ func (t *ActionDiffTransformer) Transform(g *Graph) error {
 						// FIXME: this doesn't deal with deposed or forget instances
 						n.actionTriggers = append(n.actionTriggers, &actionTriggerApplyInstance{
 							ActionInvocation: ai,
-							resolvedProvider: ai.ProviderAddr,
 							actionNode:       actionConfig,
 						})
 						foundNode = true
@@ -68,7 +67,6 @@ func (t *ActionDiffTransformer) Transform(g *Graph) error {
 				if n, ok := atn.(*NodeApplyableResourceInstance); ok {
 					n.actionTriggers = append(n.actionTriggers, &actionTriggerApplyInstance{
 						ActionInvocation: ai,
-						resolvedProvider: ai.ProviderAddr,
 						actionNode:       actionConfig,
 					})
 					foundNode = true


### PR DESCRIPTION
Here we get `before_` events working at apply time, with references to the caller, and make sure evaluation of actions and conditions at that time sees the correctly planned state.

Evaluation of a resource before it was applied is not something ever done previously, and was returning the old state from the normal eval context. In order to make it work we need to both replace the planned change with the final apply change to store any updated object values, as well as update the working state with a version indicating the object has an associated change.