### PR TITLE
Fix: Remove erroneous warning about dev overrides in the `providers lock` command

### DIFF
--- a/.changes/v1.16/NOTES-20260526-164738.yaml
+++ b/.changes/v1.16/NOTES-20260526-164738.yaml
@@ -1,5 +1,0 @@
-kind: NOTES
-body: 'providers: The `providers locks` command will now warn users about any dev_overrides in effect, as these will stop provider locks from being downloaded.'
-time: 2026-05-26T16:47:38.947615+01:00
-custom:
-    Issue: "38634"

--- a/internal/command/meta_providers.go
+++ b/internal/command/meta_providers.go
@@ -196,29 +196,6 @@ func (m *Meta) providerDevOverrideInitWarnings() tfdiags.Diagnostics {
 	}
 }
 
-// providerDevOverrideProviderLockWarnings is just like providerDevOverrideInitWarnings
-// except the diagnostic is written with a message specific to the `providers lock` command.
-// Similarly, diags will only be returned if there is 1+ dev_overrides in effect, and no error
-// diags will be returned.
-func (m *Meta) providerDevOverrideProvidersLockWarnings() tfdiags.Diagnostics {
-	if len(m.ProviderDevOverrides) == 0 {
-		return nil
-	}
-	var detailMsg strings.Builder
-	detailMsg.WriteString("The following provider development overrides are set in the CLI configuration:\n")
-	for addr, path := range m.ProviderDevOverrides {
-		detailMsg.WriteString(fmt.Sprintf(" - %s in %s\n", addr.ForDisplay(), path))
-	}
-	detailMsg.WriteString("\nThese provider locks will not be recorded because the provider is overwritten. If this is unintentional please re-run without the development overrides set.")
-	return tfdiags.Diagnostics{
-		tfdiags.Sourceless(
-			tfdiags.Warning,
-			"Provider development overrides are in effect",
-			detailMsg.String(),
-		),
-	}
-}
-
 func (m *Meta) isProviderDevOverride(pAddr addrs.Provider) bool {
 	if len(m.ProviderDevOverrides) == 0 {
 		return false

--- a/internal/command/providers_lock.go
+++ b/internal/command/providers_lock.go
@@ -195,11 +195,6 @@ func (c *ProvidersLockCommand) Run(args []string) int {
 	// merge all of the generated locks together at the end.
 	updatedLocks := map[getproviders.Platform]*depsfile.Locks{}
 	selectedVersions := map[addrs.Provider]getproviders.Version{}
-
-	// Warn users about any development overrides in effect; they will block
-	// locks being obtained for the overridden providers.
-	c.showDiagnostics(c.providerDevOverrideProvidersLockWarnings())
-
 	for _, platform := range platforms {
 		tempDir, err := ioutil.TempDir("", "terraform-providers-lock")
 		if err != nil {


### PR DESCRIPTION
This PR reverts commit 699f9ce1c5da4f19167cd3f4b30ae9b6fd11a10f from https://github.com/hashicorp/terraform/pull/38634

I was too hasty adding this warning (see [thread](https://github.com/hashicorp/terraform/pull/38634#discussion_r3304655490) for context). Yes, `providers lock` uses EnsureProviderVersions just like init, and EnsureProviderVersions will skip over developer overrides. However it will only skip over dev_overrides _that are known by the Installer_.

In `init` the installer is created with this method, which loads info about dev_overrides and unmanaged providers into the installer used. This means that EnsureProviderVersions knows which providers to skip over.

https://github.com/hashicorp/terraform/blob/cf0aae24f4cc8456c4cbcc3d21eac124992a8c68/internal/command/meta_providers.go#L63-L92

In contrast, in `providers lock` we don't create the installer with any knowledge of dev_overrides or unmanaged providers. The installer is only supplied information about a global cache, if present:

https://github.com/hashicorp/terraform/blob/cf0aae24f4cc8456c4cbcc3d21eac124992a8c68/internal/command/providers_lock.go#L258-L265

So, the current behaviour of `providers lock` is that provider installation does not skip dev_overrides or unmanaged providers and obtains locks for all providers. **Therefore warnings about the impact of dev_overrides are incorrect and misleading.**

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.16.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [x] This change is user-facing and I **deleted the changelog entry for the reverted stuff**.
- [ ] This change is not user-facing.
