### PR TITLE
feat: Add warnings to the `init` command if unmanaged providers will influence provider installation

### DIFF
--- a/.changes/v1.16/BUG FIXES-20260528-171432.yaml
+++ b/.changes/v1.16/BUG FIXES-20260528-171432.yaml
@@ -1,0 +1,5 @@
+kind: BUG FIXES
+body: 'init: Add warnings when unmanaged providers are in use and will impact provider installation processes.'
+time: 2026-05-28T17:14:32.881514+01:00
+custom:
+    Issue: "38656"

--- a/internal/command/e2etest/provider_plugin_test.go
+++ b/internal/command/e2etest/provider_plugin_test.go
@@ -218,9 +218,16 @@ func TestProviderInstall_dev_override(t *testing.T) {
 		tf.AddEnv("TF_CLI_CONFIG_FILE=" + cliConfigFilePath)
 
 		// The init process should succeed.
-		stdout, stderr, err := tf.Run("init", fmt.Sprintf("-plugin-dir=%s", absolutePathToCache))
+		stdout, stderr, err := tf.Run(
+			"init",
+			"-no-color",
+			fmt.Sprintf("-plugin-dir=%s", absolutePathToCache),
+		)
 		if err != nil {
 			t.Fatalf("unexpected error: %s\nstdout: %s\nstderr: %s", err, stdout, stderr)
+		}
+		if got, want := stdout, "Warning: Provider development overrides are in effect"; !strings.Contains(got, want) {
+			t.Fatalf("stdout doesn't include the warning about overridden providers\nwant: %s\n%s", want, got)
 		}
 
 		// Lockfile is created
@@ -281,9 +288,16 @@ provider "registry.terraform.io/hashicorp/simple6" {
 		tf.AddEnv("TF_CLI_CONFIG_FILE=" + cliConfigFilePath)
 
 		// The init process should succeed.
-		stdout, stderr, err := tf.Run("init", fmt.Sprintf("-plugin-dir=%s", absolutePathToCache))
+		stdout, stderr, err := tf.Run(
+			"init",
+			"-no-color",
+			fmt.Sprintf("-plugin-dir=%s", absolutePathToCache),
+		)
 		if err != nil {
 			t.Fatalf("unexpected error: %s\nstdout: %s\nstderr: %s", err, stdout, stderr)
+		}
+		if got, want := stdout, "Warning: Provider development overrides are in effect"; !strings.Contains(got, want) {
+			t.Fatalf("stdout doesn't include the warning about overridden providers\nwant: %s\n%s", want, got)
 		}
 
 		// Lockfile is unchanged despite use of a dev_override simple6 provider
@@ -330,9 +344,17 @@ provider "registry.terraform.io/hashicorp/simple6" {
 		tf.AddEnv("TF_CLI_CONFIG_FILE=" + cliConfigFilePath)
 
 		// The init -upgrade process should succeed.
-		stdout, stderr, err := tf.Run("init", "-upgrade", fmt.Sprintf("-plugin-dir=%s", absolutePathToCache))
+		stdout, stderr, err := tf.Run(
+			"init",
+			"-no-color",
+			"-upgrade",
+			fmt.Sprintf("-plugin-dir=%s", absolutePathToCache),
+		)
 		if err != nil {
 			t.Fatalf("unexpected error: %s\nstdout: %s\nstderr: %s", err, stdout, stderr)
+		}
+		if got, want := stdout, "Warning: Provider development overrides are in effect"; !strings.Contains(got, want) {
+			t.Fatalf("stdout doesn't include the warning about overridden providers\nwant: %s\n%s", want, got)
 		}
 
 		// Lockfile shows evidence of upgrade process
@@ -467,9 +489,15 @@ func TestProviderInstall_unmanaged(t *testing.T) {
 		tf.AddEnv("TF_REATTACH_PROVIDERS=" + reattachConfig)
 
 		// The init process should succeed.
-		stdout, stderr, err := tf.Run("init", fmt.Sprintf("-plugin-dir=%s", absolutePathToCache))
+		stdout, stderr, err := tf.Run(
+			"init",
+			"-no-color",
+			fmt.Sprintf("-plugin-dir=%s", absolutePathToCache))
 		if err != nil {
 			t.Fatalf("unexpected error: %s\nstdout: %s\nstderr: %s", err, stdout, stderr)
+		}
+		if got, want := stdout, "Warning: Unmanaged providers are in effect"; !strings.Contains(got, want) {
+			t.Fatalf("stdout doesn't include the warning about unmanaged providers\nwant: %s\n%s", want, got)
 		}
 
 		// Lock file should have been created
@@ -530,9 +558,15 @@ provider "registry.terraform.io/hashicorp/simple6" {
 		tf.AddEnv("TF_REATTACH_PROVIDERS=" + reattachConfig)
 
 		// The init process should succeed.
-		stdout, stderr, err := tf.Run("init", fmt.Sprintf("-plugin-dir=%s", absolutePathToCache))
+		stdout, stderr, err := tf.Run(
+			"init",
+			"-no-color",
+			fmt.Sprintf("-plugin-dir=%s", absolutePathToCache))
 		if err != nil {
 			t.Fatalf("unexpected error: %s\nstdout: %s\nstderr: %s", err, stdout, stderr)
+		}
+		if got, want := stdout, "Warning: Unmanaged providers are in effect"; !strings.Contains(got, want) {
+			t.Fatalf("stdout doesn't include the warning about unmanaged providers\nwant: %s\n%s", want, got)
 		}
 
 		// Lockfile is unchanged despite use of an unmanaged simple6 provider
@@ -579,9 +613,16 @@ provider "registry.terraform.io/hashicorp/simple6" {
 		tf.AddEnv("TF_REATTACH_PROVIDERS=" + reattachConfig)
 
 		// The init -upgrade process should succeed.
-		stdout, stderr, err := tf.Run("init", "-upgrade", fmt.Sprintf("-plugin-dir=%s", absolutePathToCache))
+		stdout, stderr, err := tf.Run(
+			"init",
+			"-upgrade",
+			"-no-color",
+			fmt.Sprintf("-plugin-dir=%s", absolutePathToCache))
 		if err != nil {
 			t.Fatalf("unexpected error: %s\nstdout: %s\nstderr: %s", err, stdout, stderr)
+		}
+		if got, want := stdout, "Warning: Unmanaged providers are in effect"; !strings.Contains(got, want) {
+			t.Fatalf("stdout doesn't include the warning about unmanaged providers\nwant: %s\n%s", want, got)
 		}
 
 		// Lockfile shows evidence of upgrade process

--- a/internal/command/init.go
+++ b/internal/command/init.go
@@ -376,13 +376,19 @@ func (c *InitCommand) getProvidersFromConfig(ctx context.Context, config *config
 	ctx, span := tracer.Start(ctx, "install providers from config")
 	defer span.End()
 
-	// Dev overrides cause the result of "terraform init" to be irrelevant for
-	// any overridden providers, so we'll warn about it to avoid later
-	// confusion when Terraform ends up using a different provider than the
-	// lock file called for.
+	// Dev overrides and unmanaged providers change the installation process in "terraform init";
+	// overridden and unmanaged providers are skipped during installation.
+	// This means that impacted providers won't be downloaded from external sources nor added
+	// to the dependency lock file if they aren't already recorded there. Similarly, any attempt
+	// to upgrade providers will not affect providers impacted by overrides or unmanaged providers.
 	//
-	// This warning is only added here to avoid duplication; not raised in getProvidersFromState.
+	// So, we'll warn users about it to avoid later confusion when Terraform ends up using
+	// a different provider than the lock file called for, or doesn't make expected changes
+	// to the lock file.
+	//
+	// This warning is only shown once, here, to avoid duplication; not raised in getProvidersFromState.
 	diags = diags.Append(c.providerDevOverrideInitWarnings())
+	diags = diags.Append(c.providerUnmanagedInitWarnings())
 
 	// Collect the provider dependencies from the configuration.
 	reqs, hclDiags := config.ProviderRequirements()

--- a/internal/command/meta_providers.go
+++ b/internal/command/meta_providers.go
@@ -10,6 +10,7 @@ import (
 	"log"
 	"os"
 	"os/exec"
+	"sort"
 	"strings"
 
 	"github.com/hashicorp/go-plugin"
@@ -191,6 +192,37 @@ func (m *Meta) providerDevOverrideInitWarnings() tfdiags.Diagnostics {
 		tfdiags.Sourceless(
 			tfdiags.Warning,
 			"Provider development overrides are in effect",
+			detailMsg.String(),
+		),
+	}
+}
+
+// providerUnmanagedInitWarnings returns diagnostics containing at least one
+// warning if and only if there is at least one unmanaged provider in effect
+// via TF_REATTACH_PROVIDERS.
+func (m *Meta) providerUnmanagedInitWarnings() tfdiags.Diagnostics {
+	if len(m.UnmanagedProviders) == 0 {
+		return nil
+	}
+
+	var detailMsg strings.Builder
+	detailMsg.WriteString("The following unmanaged providers are set via the TF_REATTACH_PROVIDERS environment variable:\n")
+
+	providerAddresses := make([]string, 0, len(m.UnmanagedProviders))
+	for providerAddr := range m.UnmanagedProviders {
+		providerAddresses = append(providerAddresses, providerAddr.ForDisplay())
+	}
+	sort.Strings(providerAddresses) // Enable deterministic ordering.
+
+	for _, providerAddr := range providerAddresses {
+		detailMsg.WriteString(fmt.Sprintf(" - %s\n", providerAddr))
+	}
+	detailMsg.WriteString("\nThese providers will not be installed as part of init, nor init -upgrade. Their entries in the dependency lock file will be left unchanged, if present. If this is unintentional please re-run without TF_REATTACH_PROVIDERS set.")
+
+	return tfdiags.Diagnostics{
+		tfdiags.Sourceless(
+			tfdiags.Warning,
+			"Unmanaged providers are in effect",
 			detailMsg.String(),
 		),
 	}

--- a/internal/command/meta_providers_test.go
+++ b/internal/command/meta_providers_test.go
@@ -17,6 +17,48 @@ import (
 	"github.com/hashicorp/terraform/internal/providercache"
 )
 
+func TestProviderUnmanagedWarnings(t *testing.T) {
+	t.Run("no warnings with no unmanaged providers", func(t *testing.T) {
+		meta := Meta{}
+
+		diags := meta.providerUnmanagedInitWarnings()
+		if diags != nil {
+			t.Fatalf("expected no diagnostics, got %#v", diags)
+		}
+	})
+
+	t.Run("warnings with unmanaged providers present", func(t *testing.T) {
+		providerA := addrs.NewDefaultProvider("provider-a")
+		providerB := addrs.NewDefaultProvider("provider-b")
+		meta := Meta{
+			UnmanagedProviders: map[addrs.Provider]*plugin.ReattachConfig{
+				providerB: {},
+				providerA: {},
+			},
+		}
+
+		diags := meta.providerUnmanagedInitWarnings()
+		if diags == nil {
+			t.Fatal("expected diagnostics, got nil")
+		}
+		if diags.HasErrors() {
+			t.Fatalf("expected only warning diagnostics, got errors: %s", diags.ErrWithWarnings())
+		}
+
+		got := diags.ErrWithWarnings().Error()
+		// Output is deterministic so assert exact contents
+		want := `Unmanaged providers are in effect: The following unmanaged providers are set via the TF_REATTACH_PROVIDERS environment variable:
+ - hashicorp/provider-a
+ - hashicorp/provider-b
+
+These providers will not be installed as part of init, nor init -upgrade. Their entries in the dependency lock file will be left unchanged, if present. If this is unintentional please re-run without TF_REATTACH_PROVIDERS set.`
+
+		if diff := cmp.Diff(want, got); diff != "" {
+			t.Errorf("unexpected difference in warning message: %s", diff)
+		}
+	})
+}
+
 // Test the impacts of dev_overrides and reattached/unmanaged providers on the provider installation process.
 // The locks returned from EnsureProviderVersions are what's saved to the dependency lock file, so we are interested
 // in how the pre-existing locks and how providers are overidden impacts the locks returned from that installation process.


### PR DESCRIPTION
Reference: https://github.com/hashicorp/terraform/pull/26605
Reference: https://github.com/hashicorp/terraform/pull/27514
Reference: https://github.com/hashicorp/terraform/pull/37884

When developer overrides warnings were first added in https://github.com/hashicorp/terraform/pull/26605 we warned users about the potential impacts of dev_overrides on resource state. If users performed apply using a dev override in a project that wasn't for testing purposes their state could become incompatible with published providers and require manual edits to state to reverse the effects. Not good.

Warnings were added to `init`, `apply`, and eventually to `plan`.

Later, in https://github.com/hashicorp/terraform/pull/27514, the warning in `init` was made more specific than warnings in plan/apply and just instructed users to not run init when overrides are used. This was based on the assumption that the provider would not be used during init in any way. This also was intended as a way for users to avoid confusing errors when their config includes an unpublished provider in `required_providers`, supply that provider via overrides, and then experience installation errors during `init`.

Recently, in https://github.com/hashicorp/terraform/pull/37884, dev_overrides were made more compatible with `init`, avoiding the unpublished provider installation errors from happening. Therefore the old guidance of 'don't run init when using dev_overrides' became outdated. At that time the dev_override warning was updated to stop instructing users to not perform init while a dev_override is present, and instead the warning tells users about the overrides' potential effects on provider download.

Given that latest change, this PR adds a warning to `init` highlighting the same effects of unmanaged providers on the provider download process. Unmanaged providers have the same impact as overridden providers.

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.16.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [x] This change is user-facing and I added a changelog entry.
- [ ] This change is not user-facing.
