### PR TITLE
Action validation and diagnostic cleanup

### DIFF
--- a/internal/addrs/parse_ref.go
+++ b/internal/addrs/parse_ref.go
@@ -652,19 +652,35 @@ func parseActionRef(startRange hcl.Range, traversal hcl.Traversal) (*Reference, 
 	}
 
 	if idxTrav, ok := remain[0].(hcl.TraverseIndex); ok {
-		var err error
-		actionInstAddr.Key, err = ParseInstanceKey(idxTrav.Key)
-		if err != nil {
-			diags = diags.Append(&hcl.Diagnostic{
-				Severity: hcl.DiagError,
-				Summary:  "Invalid index key",
-				Detail:   fmt.Sprintf("Invalid index for resource instance: %s.", err),
-				Subject:  &idxTrav.SrcRange,
-			})
-			return nil, diags
+		if idxTrav.Key.IsKnown() {
+			var err error
+			actionInstAddr.Key, err = ParseInstanceKey(idxTrav.Key)
+			if err != nil {
+				diags = diags.Append(&hcl.Diagnostic{
+					Severity: hcl.DiagError,
+					Summary:  "Invalid index key",
+					Detail:   fmt.Sprintf("Invalid index for action instance: %s.", err),
+					Subject:  &idxTrav.SrcRange,
+				})
+				return nil, diags
+			}
+		} else {
+			// allowing a wildcard key means we can parse and instance refs
+			// during validation even when they use count.index or each.key
+			actionInstAddr.Key = WildcardKey
 		}
+
 		remain = remain[1:]
 		rng = hcl.RangeBetween(rng, idxTrav.SrcRange)
+	}
+
+	if len(remain) > 0 {
+		diags = diags.Append(&hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  "Unexpected attribute in action reference",
+			Detail:   "Actions have no referenceable attributes.",
+			Subject:  remain[0].SourceRange().Ptr(),
+		})
 	}
 
 	return &Reference{

--- a/internal/configs/action.go
+++ b/internal/configs/action.go
@@ -19,7 +19,7 @@ func invalidActionDiag(subj *hcl.Range) *hcl.Diagnostic {
 	return &hcl.Diagnostic{
 		Severity: hcl.DiagError,
 		Summary:  `Invalid action argument inside action_triggers`,
-		Detail:   `action_triggers.actions must only refer to actions in the current module.`,
+		Detail:   `action_triggers.actions must only refer to actions in the current module, count.index, or each.key.`,
 		Subject:  subj,
 	}
 }
@@ -83,6 +83,7 @@ func decodeActionTriggerBlock(block *hcl.Block) (*ActionTrigger, hcl.Diagnostics
 		Events:    []ActionTriggerEvent{},
 		Actions:   []ActionRef{},
 		Condition: nil,
+		DeclRange: block.DefRange,
 	}
 
 	content, bodyDiags := block.Body.Content(actionTriggerSchema)
@@ -346,6 +347,7 @@ func decodeActionTriggerRef(expr hcl.Expression) ([]ActionRef, hcl.Diagnostics) 
 	}
 	actionRefs := make([]ActionRef, len(exprs))
 
+EXPRS:
 	for i, expr := range exprs {
 		// Since we are manually parsing the action_trigger.Actions argument, we
 		// need to specially handle json configs, in which case the values will
@@ -387,6 +389,8 @@ func decodeActionTriggerRef(expr hcl.Expression) ([]ActionRef, hcl.Diagnostics) 
 			switch ref.Subject.(type) {
 			case addrs.Action, addrs.ActionInstance:
 				actionCount++
+			case addrs.CountAttr, addrs.ForEachAttr:
+				// these are OK
 			case addrs.ModuleCall, addrs.ModuleCallInstance, addrs.ModuleCallInstanceOutput:
 				diags = append(diags, &hcl.Diagnostic{
 					Severity: hcl.DiagError,
@@ -394,13 +398,11 @@ func decodeActionTriggerRef(expr hcl.Expression) ([]ActionRef, hcl.Diagnostics) 
 					Detail:   "Actions can only be referenced in the module they are declared in.",
 					Subject:  expr.Range().Ptr(),
 				})
-				continue
-			case addrs.Resource, addrs.ResourceInstance:
+				continue EXPRS
+			default:
 				// definitely not an action
 				diags = append(diags, invalidActionDiag(expr.Range().Ptr()))
-				continue
-			default:
-				// we've checked what we can
+				continue EXPRS
 			}
 		}
 

--- a/internal/configs/action.go
+++ b/internal/configs/action.go
@@ -37,6 +37,7 @@ type Action struct {
 
 	DeclRange hcl.Range
 	TypeRange hcl.Range
+	Body      hcl.Body
 }
 
 // ActionTrigger represents a configured "action_trigger" inside the lifecycle
@@ -197,6 +198,7 @@ func decodeActionBlock(block *hcl.Block) (*Action, hcl.Diagnostics) {
 		Name:      block.Labels[1],
 		DeclRange: block.DefRange,
 		TypeRange: block.LabelRanges[0],
+		Body:      block.Body,
 	}
 
 	if !hclsyntax.ValidIdentifier(a.Type) {

--- a/internal/configs/action_test.go
+++ b/internal/configs/action_test.go
@@ -30,6 +30,7 @@ func TestDecodeActionBlock(t *testing.T) {
 				Type:      "an_action",
 				Name:      "foo",
 				DeclRange: blockRange,
+				Body:      hcl.EmptyBody(),
 			},
 			nil,
 		},
@@ -52,6 +53,12 @@ func TestDecodeActionBlock(t *testing.T) {
 				DeclRange: blockRange,
 				Count:     hcltest.MockExprLiteral(cty.NumberIntVal(2)),
 				ForEach:   hcltest.MockExprLiteral(cty.StringVal("something")),
+				Body: hcltest.MockBody(&hcl.BodyContent{
+					Attributes: hcltest.MockAttrs(map[string]hcl.Expression{
+						"count":    hcltest.MockExprLiteral(cty.NumberIntVal(2)),
+						"for_each": hcltest.MockExprLiteral(cty.StringVal("something")),
+					}),
+				}),
 			},
 			[]string{"MockAttrs:0,0-0: Invalid combination of \"count\" and \"for_each\"; The \"count\" and \"for_each\" meta-arguments are mutually-exclusive, only one should be used."},
 		},
@@ -141,7 +148,6 @@ func TestDecodeActionTriggerBlock(t *testing.T) {
 				},
 			},
 			[]string{
-				"MockExprTraversal:0,0-33: No actions specified; At least one action must be specified for an action_trigger.",
 				"MockExprTraversal:0,0-33: Invalid reference to action outside this module; Actions can only be referenced in the module they are declared in.",
 			},
 		},
@@ -167,8 +173,7 @@ func TestDecodeActionTriggerBlock(t *testing.T) {
 				},
 			},
 			[]string{
-				"MockExprTraversal:0,0-16: No actions specified; At least one action must be specified for an action_trigger.",
-				"MockExprTraversal:0,0-16: Invalid action argument inside action_triggers; action_triggers.actions must only refer to actions in the current module.",
+				"MockExprTraversal:0,0-16: Invalid action argument inside action_triggers; action_triggers.actions must only refer to actions in the current module, count.index, or each.key.",
 			},
 		},
 		"error - invalid event": {

--- a/internal/configs/module_merge_test.go
+++ b/internal/configs/module_merge_test.go
@@ -538,6 +538,7 @@ func TestModuleOverride_action_and_trigger(t *testing.T) {
 			Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
 			End:      hcl.Pos{Line: 1, Column: 21, Byte: 20},
 		},
+		Body: mod.Actions["action.test_action.test"].Body,
 	}
 
 	// We're going to extract and nil out our hcl.Body here because DeepEqual

--- a/internal/terraform/action_trigger_instance_apply.go
+++ b/internal/terraform/action_trigger_instance_apply.go
@@ -93,11 +93,17 @@ func (n *actionTriggerApplyInstance) invoke(ctx EvalContext, caller addrs.Refere
 		ClientCapabilities: ctx.ClientCapabilities(),
 	})
 
-	respDiags := n.AddSubjectToDiagnostics(resp.Diagnostics)
-	diags = diags.Append(respDiags)
-	if respDiags.HasErrors() {
+	if resp.Diagnostics != nil {
+		if n.actionNode.Config.Config != nil {
+			diags = diags.Append(resp.Diagnostics.InConfigBody(n.actionNode.Config.Config, caller.String()))
+		} else {
+			diags = diags.Append(resp.Diagnostics.InConfigBody(n.actionNode.Config.Body, caller.String()))
+		}
+	}
+
+	if resp.Diagnostics.HasErrors() {
 		diags = diags.Append(ctx.Hook(func(h Hook) (HookAction, error) {
-			return h.CompleteAction(hookIdentity, respDiags.Err())
+			return h.CompleteAction(hookIdentity, resp.Diagnostics.Err())
 		}))
 		return diags
 	}
@@ -114,13 +120,17 @@ func (n *actionTriggerApplyInstance) invoke(ctx EvalContext, caller addrs.Refere
 				}
 			case providers.InvokeActionEvent_Completed:
 				// Enhance the diagnostics
-				diags = diags.Append(n.AddSubjectToDiagnostics(ev.Diagnostics))
+				if ev.Diagnostics != nil {
+					if n.actionNode.Config.Config != nil {
+						diags = diags.Append(ev.Diagnostics.InConfigBody(n.actionNode.Config.Config, caller.String()))
+					} else {
+						diags = diags.Append(ev.Diagnostics.InConfigBody(n.actionNode.Config.Body, caller.String()))
+					}
+				}
+
 				diags = diags.Append(ctx.Hook(func(h Hook) (HookAction, error) {
 					return h.CompleteAction(hookIdentity, ev.Diagnostics.Err())
 				}))
-				if ev.Diagnostics.HasErrors() {
-					return diags
-				}
 				if diags.HasErrors() {
 					return diags
 				}
@@ -172,28 +182,4 @@ func (n *actionTriggerApplyInstance) ModulePath() addrs.Module {
 // GraphNodeExecutable
 func (n *actionTriggerApplyInstance) Path() addrs.ModuleInstance {
 	return n.ActionInvocation.Addr.Module
-}
-
-func (n *actionTriggerApplyInstance) AddSubjectToDiagnostics(input tfdiags.Diagnostics) tfdiags.Diagnostics {
-	var diags tfdiags.Diagnostics
-	if len(input) > 0 {
-		severity := hcl.DiagWarning
-		message := "Warning when invoking action"
-		err := input.Warnings().ErrWithWarnings()
-		if input.HasErrors() {
-			severity = hcl.DiagError
-			message = "Error when invoking action"
-			err = input.ErrWithWarnings()
-		}
-
-		diags = diags.Append(&hcl.Diagnostic{
-			Severity: severity,
-			Summary:  message,
-			Detail:   err.Error(),
-
-			// FIXME: this is the action config block, make sure user can associate this with the trigger
-			Subject: n.actionNode.Config.DeclRange.Ptr(),
-		})
-	}
-	return diags
 }

--- a/internal/terraform/context_apply_action_test.go
+++ b/internal/terraform/context_apply_action_test.go
@@ -206,13 +206,8 @@ resource "test_object" "a" {
 			expectDiagnostics: func(m *configs.Config) tfdiags.Diagnostics {
 				return tfdiags.Diagnostics{}.Append(&hcl.Diagnostic{
 					Severity: hcl.DiagError,
-					Summary:  "Error when invoking action",
-					Detail:   "test case for failing: this simulates a provider failing",
-					Subject: &hcl.Range{
-						Filename: filepath.Join(m.Module.SourceDir, "main.tf"),
-						Start:    hcl.Pos{Line: 2, Column: 1, Byte: 1},
-						End:      hcl.Pos{Line: 2, Column: 32, Byte: 32},
-					},
+					Summary:  "test case for failing",
+					Detail:   "this simulates a provider failing",
 				})
 			},
 		},
@@ -261,13 +256,8 @@ resource "test_object" "a" {
 				return tfdiags.Diagnostics{}.Append(
 					&hcl.Diagnostic{
 						Severity: hcl.DiagError,
-						Summary:  "Error when invoking action",
-						Detail:   `test case for failing: this simulates a provider failing`,
-						Subject: &hcl.Range{
-							Filename: filepath.Join(m.Module.SourceDir, "main.tf"),
-							Start:    hcl.Pos{Line: 4, Column: 1, Byte: 71},
-							End:      hcl.Pos{Line: 4, Column: 34, Byte: 104},
-						},
+						Summary:  "test case for failing",
+						Detail:   `this simulates a provider failing`,
 					},
 				)
 
@@ -302,13 +292,8 @@ resource "test_object" "a" {
 				return tfdiags.Diagnostics{}.Append(
 					&hcl.Diagnostic{
 						Severity: hcl.DiagError,
-						Summary:  "Error when invoking action",
-						Detail:   "test case for failing: this simulates a provider failing before the action is invoked",
-						Subject: &hcl.Range{
-							Filename: filepath.Join(m.Module.SourceDir, "main.tf"),
-							Start:    hcl.Pos{Line: 2, Column: 1, Byte: 1},
-							End:      hcl.Pos{Line: 2, Column: 32, Byte: 32},
-						},
+						Summary:  "test case for failing",
+						Detail:   "this simulates a provider failing before the action is invoked",
 					},
 				)
 			},
@@ -353,13 +338,8 @@ resource "test_object" "a" {
 				return tfdiags.Diagnostics{}.Append(
 					&hcl.Diagnostic{
 						Severity: hcl.DiagError,
-						Summary:  "Error when invoking action",
-						Detail:   "test case for failing: this simulates a provider failing",
-						Subject: &hcl.Range{
-							Filename: filepath.Join(m.Module.SourceDir, "main.tf"),
-							Start:    hcl.Pos{Line: 3, Column: 1, Byte: 36},
-							End:      hcl.Pos{Line: 3, Column: 34, Byte: 69},
-						},
+						Summary:  "test case for failing",
+						Detail:   "this simulates a provider failing",
 					},
 				)
 			},
@@ -415,13 +395,8 @@ resource "test_object" "a" {
 				return tfdiags.Diagnostics{}.Append(
 					&hcl.Diagnostic{
 						Severity: hcl.DiagError,
-						Summary:  "Error when invoking action",
-						Detail:   "test case for failing: this simulates a provider failing",
-						Subject: &hcl.Range{
-							Filename: filepath.Join(m.Module.SourceDir, "main.tf"),
-							Start:    hcl.Pos{Line: 3, Column: 1, Byte: 36},
-							End:      hcl.Pos{Line: 3, Column: 34, Byte: 69},
-						},
+						Summary:  "test case for failing",
+						Detail:   "this simulates a provider failing",
 					},
 				)
 			},
@@ -485,13 +460,8 @@ resource "test_object" "a" {
 				return tfdiags.Diagnostics{}.Append(
 					&hcl.Diagnostic{
 						Severity: hcl.DiagError,
-						Summary:  "Error when invoking action",
-						Detail:   "test case for failing: this simulates a provider failing",
-						Subject: &hcl.Range{
-							Filename: filepath.Join(m.Module.SourceDir, "main.tf"),
-							Start:    hcl.Pos{Line: 3, Column: 1, Byte: 36},
-							End:      hcl.Pos{Line: 3, Column: 34, Byte: 69},
-						},
+						Summary:  "test case for failing",
+						Detail:   "this simulates a provider failing",
 					},
 				)
 			},

--- a/internal/terraform/context_plan_actions_test.go
+++ b/internal/terraform/context_plan_actions_test.go
@@ -656,13 +656,8 @@ resource "test_object" "a" {
 					return tfdiags.Diagnostics{}.Append(
 						&hcl.Diagnostic{
 							Severity: hcl.DiagError,
-							Summary:  "Failed to plan action",
-							Detail:   "Planning failed: Test case simulates an error while planning",
-							Subject: &hcl.Range{
-								Filename: filepath.Join(m.Module.SourceDir, "main.tf"),
-								Start:    hcl.Pos{Line: 7, Column: 8, Byte: 147},
-								End:      hcl.Pos{Line: 7, Column: 46, Byte: 173},
-							},
+							Summary:  "Planning failed",
+							Detail:   "Test case simulates an error while planning",
 						},
 					)
 				},
@@ -701,32 +696,32 @@ resource "test_object" "a" {
 					return tfdiags.Diagnostics{}.Append(
 						&hcl.Diagnostic{
 							Severity: hcl.DiagWarning,
-							Summary:  "Warnings when planning action",
-							Detail:   "Warning during planning: Test case simulates a warning while planning",
+							Summary:  "Warning during planning",
+							Detail:   "Test case simulates a warning while planning",
 							Subject: &hcl.Range{
 								Filename: filepath.Join(m.Module.SourceDir, "main.tf"),
-								Start:    hcl.Pos{Line: 7, Column: 8, Byte: 147},
-								End:      hcl.Pos{Line: 7, Column: 46, Byte: 173},
+								Start:    hcl.Pos{Line: 2, Column: 32, Byte: 32},
+								End:      hcl.Pos{Line: 2, Column: 32, Byte: 32},
 							},
 						},
 						&hcl.Diagnostic{
 							Severity: hcl.DiagWarning,
-							Summary:  "Warnings when planning action",
-							Detail:   "Warning during planning: Test case simulates a warning while planning",
+							Summary:  "Warning during planning",
+							Detail:   "Test case simulates a warning while planning",
 							Subject: &hcl.Range{
 								Filename: filepath.Join(m.Module.SourceDir, "main.tf"),
-								Start:    hcl.Pos{Line: 7, Column: 48, Byte: 175},
-								End:      hcl.Pos{Line: 7, Column: 76, Byte: 201},
+								Start:    hcl.Pos{Line: 2, Column: 32, Byte: 32},
+								End:      hcl.Pos{Line: 2, Column: 32, Byte: 32},
 							},
 						},
 						&hcl.Diagnostic{
 							Severity: hcl.DiagWarning,
-							Summary:  "Warnings when planning action",
-							Detail:   "Warning during planning: Test case simulates a warning while planning",
+							Summary:  "Warning during planning",
+							Detail:   "Test case simulates a warning while planning",
 							Subject: &hcl.Range{
 								Filename: filepath.Join(m.Module.SourceDir, "main.tf"),
-								Start:    hcl.Pos{Line: 11, Column: 8, Byte: 278},
-								End:      hcl.Pos{Line: 11, Column: 46, Byte: 304},
+								Start:    hcl.Pos{Line: 2, Column: 32, Byte: 32},
+								End:      hcl.Pos{Line: 2, Column: 32, Byte: 32},
 							},
 						},
 					)

--- a/internal/terraform/context_plan_actions_test.go
+++ b/internal/terraform/context_plan_actions_test.go
@@ -262,7 +262,18 @@ resource "test_object" "a" {
 								Start:    hcl.Pos{Line: 8, Column: 10, Byte: 110},
 								End:      hcl.Pos{Line: 8, Column: 40, Byte: 138},
 							},
-						})
+						},
+						&hcl.Diagnostic{
+							Severity: hcl.DiagError,
+							Summary:  "Unexpected attribute in action reference",
+							Detail:   "Actions have no referenceable attributes.",
+							Subject: &hcl.Range{
+								Filename: filepath.Join(m.Module.SourceDir, "main.tf"),
+								Start:    hcl.Pos{Line: 8, Column: 39, Byte: 138},
+								End:      hcl.Pos{Line: 8, Column: 43, Byte: 143},
+							},
+						},
+					)
 				},
 			},
 
@@ -312,6 +323,16 @@ output "my_output2" {
 								Filename: filepath.Join(m.Module.SourceDir, "main.tf"),
 								Start:    hcl.Pos{Line: 17, Column: 13, Byte: 258},
 								End:      hcl.Pos{Line: 17, Column: 43, Byte: 286},
+							},
+						},
+						&hcl.Diagnostic{
+							Severity: hcl.DiagError,
+							Summary:  "Unexpected attribute in action reference",
+							Detail:   "Actions have no referenceable attributes.",
+							Subject: &hcl.Range{
+								Filename: filepath.Join(m.Module.SourceDir, "main.tf"),
+								Start:    hcl.Pos{Line: 17, Column: 39, Byte: 286},
+								End:      hcl.Pos{Line: 17, Column: 44, Byte: 291},
 							},
 						},
 					)
@@ -728,11 +749,11 @@ resource "test_object" "a" {
 `,
 				},
 				expectPlanActionCalled: false,
-				expectPlanDiagnostics: func(m *configs.Config) tfdiags.Diagnostics {
+				expectValidateDiagnostics: func(m *configs.Config) tfdiags.Diagnostics {
 					return tfdiags.Diagnostics{}.Append(&hcl.Diagnostic{
 						Severity: hcl.DiagError,
-						Summary:  "Invalid action expression",
-						Detail:   "Unexpected expression found in action_triggers.actions.",
+						Summary:  "Invalid instance reference",
+						Detail:   "Only object references with dynamic indexes are allowed in this context.",
 						Subject: &hcl.Range{
 							Filename: filepath.Join(m.Module.SourceDir, "main.tf"),
 							Start:    hcl.Pos{Line: 9, Column: 18, Byte: 159},
@@ -1024,6 +1045,73 @@ resource "test_object" "a" {
 							Filename: filepath.Join(m.Module.SourceDir, "main.tf"),
 							Start:    hcl.Pos{Line: 13, Column: 18, Byte: 208},
 							End:      hcl.Pos{Line: 13, Column: 47, Byte: 235},
+						},
+					})
+				},
+			},
+
+			"action count invalid index": {
+				module: map[string]string{
+					"main.tf": `
+action "test_action" "hello" {
+  config {
+    attr = "value"
+  }
+}
+resource "test_object" "a" {
+  lifecycle {
+    action_trigger {
+      events = [before_create]
+      actions = [action.test_action.hello[2]]
+    }
+  }
+}
+`,
+				},
+				expectPlanActionCalled: false,
+				expectValidateDiagnostics: func(m *configs.Config) (diags tfdiags.Diagnostics) {
+					return diags.Append(&hcl.Diagnostic{
+						Severity: hcl.DiagError,
+						Summary:  "Invalid index",
+						Detail:   "Unexpanded action referenced with instance key 2",
+						Subject: &hcl.Range{
+							Filename: filepath.Join(m.Module.SourceDir, "main.tf"),
+							Start:    hcl.Pos{Line: 11, Column: 18, Byte: 180},
+							End:      hcl.Pos{Line: 13, Column: 45, Byte: 207},
+						},
+					})
+				},
+			},
+
+			"action referenced without index": {
+				module: map[string]string{
+					"main.tf": `
+action "test_action" "hello" {
+  count = 1
+  config {
+    attr = "value"
+  }
+}
+resource "test_object" "a" {
+  lifecycle {
+    action_trigger {
+      events = [before_create]
+      actions = [action.test_action.hello]
+    }
+  }
+}
+`,
+				},
+				expectPlanActionCalled: false,
+				expectValidateDiagnostics: func(m *configs.Config) (diags tfdiags.Diagnostics) {
+					return diags.Append(&hcl.Diagnostic{
+						Severity: hcl.DiagError,
+						Summary:  "Missing index",
+						Detail:   "An action with count must be referenced via an integer key",
+						Subject: &hcl.Range{
+							Filename: filepath.Join(m.Module.SourceDir, "main.tf"),
+							Start:    hcl.Pos{Line: 11, Column: 18, Byte: 192},
+							End:      hcl.Pos{Line: 13, Column: 42, Byte: 216},
 						},
 					})
 				},

--- a/internal/terraform/eval_context_builtin.go
+++ b/internal/terraform/eval_context_builtin.go
@@ -351,7 +351,7 @@ func (ctx *BuiltinEvalContext) EvaluateExpr(expr hcl.Expression, wantType cty.Ty
 func (ctx *BuiltinEvalContext) EvaluateReplaceTriggeredBy(expr hcl.Expression, repData instances.RepetitionData) (*addrs.Reference, bool, tfdiags.Diagnostics) {
 
 	// get the reference to lookup changes in the plan
-	ref, diags := evalReplaceTriggeredByExpr(expr, repData)
+	ref, diags := evalSemiStaticExpr(expr, repData)
 	if diags.HasErrors() {
 		return nil, false, diags
 	}

--- a/internal/terraform/evaluate_action_expression.go
+++ b/internal/terraform/evaluate_action_expression.go
@@ -4,8 +4,9 @@
 package terraform
 
 import (
+	"fmt"
+
 	"github.com/hashicorp/hcl/v2"
-	"github.com/hashicorp/hcl/v2/hclsyntax"
 
 	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/instances"
@@ -15,68 +16,21 @@ import (
 // evaluateActionExpression expands the hcl.Expression from a resource's list
 // action_trigger.actions. Note that if the action uses count or for_each, it's
 // using the resource instances count/for_each.
-func evaluateActionExpression(expr hcl.Expression, repData instances.RepetitionData) (*addrs.Reference, tfdiags.Diagnostics) {
-	var ref *addrs.Reference
-	var diags tfdiags.Diagnostics
-
-	traversal, diags := actionExprToTraversal(expr, repData)
+func evaluateActionExpression(expr hcl.Expression, repData instances.RepetitionData) (addrs.ActionInstance, tfdiags.Diagnostics) {
+	ref, diags := evalSemiStaticExpr(expr, repData)
 	if diags.HasErrors() {
-		return nil, diags
+		return addrs.ActionInstance{}, diags
 	}
 
-	// We now have a static traversal, so we can just turn it into an addrs.Reference.
-	ref, ds := addrs.ParseRef(traversal)
-	diags = diags.Append(ds)
-
-	return ref, diags
-}
-
-// actionExprToTraversal takes an hcl expression limited to the syntax allowed
-// in a resource's lifecycle.action_triggers.actions list, and converts it to a
-// static traversal. The RepetitionData contains the data necessary to evaluate
-// the only allowed variables in the expression, count.index and each.key.
-func actionExprToTraversal(expr hcl.Expression, repData instances.RepetitionData) (hcl.Traversal, tfdiags.Diagnostics) {
-	var trav hcl.Traversal
-	var diags tfdiags.Diagnostics
-
-	switch e := expr.(type) {
-	case *hclsyntax.RelativeTraversalExpr:
-		t, d := actionExprToTraversal(e.Source, repData)
-		diags = diags.Append(d)
-		trav = append(trav, t...)
-		trav = append(trav, e.Traversal...)
-
-	case *hclsyntax.ScopeTraversalExpr:
-		// a static reference, we can just append the traversal
-		trav = append(trav, e.Traversal...)
-
-	case *hclsyntax.IndexExpr:
-		// Get the collection from the index expression
-		t, d := actionExprToTraversal(e.Collection, repData)
-		diags = diags.Append(d)
-		if diags.HasErrors() {
-			return nil, diags
-		}
-		trav = append(trav, t...)
-
-		// The index key is the only place where we could have variables that
-		// reference count and each, so we need to parse those independently.
-		idx, hclDiags := parseKeyExprForStaticTraveral(e.Key, repData)
-		diags = diags.Append(hclDiags)
-
-		trav = append(trav, idx)
-
+	var actionInst addrs.ActionInstance
+	switch sub := ref.Subject.(type) {
+	case addrs.Action:
+		actionInst = sub.Instance(addrs.NoKey)
+	case addrs.ActionInstance:
+		actionInst = sub
 	default:
-		// Something unexpected got through config validation. We're not sure
-		// what it is, but we'll point it out in the diagnostics for the user
-		// to fix.
-		diags = diags.Append(&hcl.Diagnostic{
-			Severity: hcl.DiagError,
-			Summary:  "Invalid action expression",
-			Detail:   "Unexpected expression found in action_triggers.actions.",
-			Subject:  e.Range().Ptr(),
-		})
+		panic(fmt.Sprintf("unknown action address type: %T", sub))
 	}
 
-	return trav, diags
+	return actionInst, diags
 }

--- a/internal/terraform/evaluate_triggers.go
+++ b/internal/terraform/evaluate_triggers.go
@@ -15,11 +15,14 @@ import (
 	"github.com/hashicorp/terraform/internal/tfdiags"
 )
 
-func evalReplaceTriggeredByExpr(expr hcl.Expression, keyData instances.RepetitionData) (*addrs.Reference, tfdiags.Diagnostics) {
+// evalSemiStaticExpr takes a reference expression which might contain instance
+// indexes derived from variable values, and returns an addrs.Reference for the
+// known parts.
+func evalSemiStaticExpr(expr hcl.Expression, keyData instances.RepetitionData) (*addrs.Reference, tfdiags.Diagnostics) {
 	var ref *addrs.Reference
 	var diags tfdiags.Diagnostics
 
-	traversal, diags := triggersExprToTraversal(expr, keyData)
+	traversal, diags := semiStaticExpToTraversal(expr, keyData)
 	if diags.HasErrors() {
 		return nil, diags
 	}
@@ -31,17 +34,17 @@ func evalReplaceTriggeredByExpr(expr hcl.Expression, keyData instances.Repetitio
 	return ref, diags
 }
 
-// trggersExprToTraversal takes an hcl expression limited to the syntax allowed
-// in replace_triggered_by, and converts it to a static traversal. The
-// RepetitionData contains the data necessary to evaluate the only allowed
-// variables in the expression, count.index and each.key.
-func triggersExprToTraversal(expr hcl.Expression, keyData instances.RepetitionData) (hcl.Traversal, tfdiags.Diagnostics) {
+// semiStaticExpToTraversal takes an hcl expression limited to the syntax allowed
+// for static references with dynamic instance keys, and converts it to a static
+// traversal. The RepetitionData contains the data necessary to evaluate the
+// only allowed variables in the expression, count.index and each.key.
+func semiStaticExpToTraversal(expr hcl.Expression, keyData instances.RepetitionData) (hcl.Traversal, tfdiags.Diagnostics) {
 	var trav hcl.Traversal
 	var diags tfdiags.Diagnostics
 
 	switch e := expr.(type) {
 	case *hclsyntax.RelativeTraversalExpr:
-		t, d := triggersExprToTraversal(e.Source, keyData)
+		t, d := semiStaticExpToTraversal(e.Source, keyData)
 		diags = diags.Append(d)
 		trav = append(trav, t...)
 		trav = append(trav, e.Traversal...)
@@ -52,7 +55,7 @@ func triggersExprToTraversal(expr hcl.Expression, keyData instances.RepetitionDa
 
 	case *hclsyntax.IndexExpr:
 		// Get the collection from the index expression
-		t, d := triggersExprToTraversal(e.Collection, keyData)
+		t, d := semiStaticExpToTraversal(e.Collection, keyData)
 		diags = diags.Append(d)
 		if diags.HasErrors() {
 			return nil, diags
@@ -72,8 +75,8 @@ func triggersExprToTraversal(expr hcl.Expression, keyData instances.RepetitionDa
 		// to fix.
 		diags = diags.Append(&hcl.Diagnostic{
 			Severity: hcl.DiagError,
-			Summary:  "Invalid replace_triggered_by expression",
-			Detail:   "Unexpected expression found in replace_triggered_by.",
+			Summary:  "Invalid instance reference",
+			Detail:   "Only object references with dynamic indexes are allowed in this context.",
 			Subject:  e.Range().Ptr(),
 		})
 	}

--- a/internal/terraform/evaluate_triggers_test.go
+++ b/internal/terraform/evaluate_triggers_test.go
@@ -69,7 +69,7 @@ func TestEvalReplaceTriggeredBy(t *testing.T) {
 				t.Fatal(hclDiags)
 			}
 
-			got, diags := evalReplaceTriggeredByExpr(expr, tc.repData)
+			got, diags := evalSemiStaticExpr(expr, tc.repData)
 			if diags.HasErrors() {
 				t.Fatal(diags.Err())
 			}

--- a/internal/terraform/node_action.go
+++ b/internal/terraform/node_action.go
@@ -309,13 +309,12 @@ func (n *NodeActionConfig) EvalInstances(ctx EvalContext, addr addrs.ActionInsta
 	return all, diags
 }
 
-// EvalInstance returns the value from the expanded action block
-func (n *NodeActionConfig) EvalInstance(ctx EvalContext, inst addrs.AbsActionInstance, callRange *hcl.Range, caller addrs.Referenceable) (cty.Value, tfdiags.Diagnostics) {
+// validate the correct type of key is being used for the action block
+func (n *NodeActionConfig) validateInstanceKey(addr addrs.AbsActionInstance, callRange *hcl.Range) tfdiags.Diagnostics {
 	var diags tfdiags.Diagnostics
 
-	key := inst.Action.Key
+	key := addr.Action.Key
 
-	// we first validate the correct type of key is being used for the action
 	switch {
 	case n.Config.Count != nil:
 		switch key := key.(type) {
@@ -329,15 +328,17 @@ func (n *NodeActionConfig) EvalInstance(ctx EvalContext, inst addrs.AbsActionIns
 				Detail:   fmt.Sprintf("Invalid string key %s for action with count", key),
 				Subject:  callRange,
 			})
-			return cty.DynamicVal, diags
 		default:
+			if key == addrs.WildcardKey {
+				return diags
+			}
+
 			diags = diags.Append(&hcl.Diagnostic{
 				Severity: hcl.DiagError,
 				Summary:  "Missing index",
 				Detail:   "An action with count must be referenced via an integer key",
 				Subject:  callRange,
 			})
-			return cty.DynamicVal, diags
 		}
 
 	case n.Config.ForEach != nil:
@@ -349,24 +350,25 @@ func (n *NodeActionConfig) EvalInstance(ctx EvalContext, inst addrs.AbsActionIns
 				Detail:   fmt.Sprintf("Invalid key %d for action with for_each", key),
 				Subject:  callRange,
 			})
-			return cty.DynamicVal, diags
 
 		case addrs.StringKey:
 			// OK
 
 		default:
+			if key == addrs.WildcardKey {
+				return diags
+			}
 			diags = diags.Append(&hcl.Diagnostic{
 				Severity: hcl.DiagError,
 				Summary:  "Missing index",
 				Detail:   "An action with for_each must be referenced via a string key",
 				Subject:  callRange,
 			})
-			return cty.DynamicVal, diags
 		}
 
 	default:
 		switch key := key.(type) {
-		case addrs.IntKey:
+		case addrs.IntKey, addrs.StringKey:
 			diags = diags.Append(&hcl.Diagnostic{
 				Severity: hcl.DiagError,
 				Summary:  "Invalid index",
@@ -374,20 +376,30 @@ func (n *NodeActionConfig) EvalInstance(ctx EvalContext, inst addrs.AbsActionIns
 				Subject:  callRange,
 			})
 
-			return cty.DynamicVal, diags
-
-		case addrs.StringKey:
-			diags = diags.Append(&hcl.Diagnostic{
-				Severity: hcl.DiagError,
-				Summary:  "Invalid index",
-				Detail:   fmt.Sprintf("Unexpanded action referenced with instance key %s", key),
-				Subject:  callRange,
-			})
-			return cty.DynamicVal, diags
+		default:
+			if key == addrs.WildcardKey {
+				diags = diags.Append(&hcl.Diagnostic{
+					Severity: hcl.DiagError,
+					Summary:  "Invalid index",
+					Detail:   fmt.Sprintf("Unexpanded action referenced with instance key %s", key),
+					Subject:  callRange,
+				})
+			}
 		}
 	}
+	return diags
+}
 
-	instAddr := n.Addr.Absolute(ctx.Path()).Instance(key)
+// EvalInstance returns the value from the expanded action block
+func (n *NodeActionConfig) EvalInstance(ctx EvalContext, inst addrs.AbsActionInstance, callRange *hcl.Range, caller addrs.Referenceable) (cty.Value, tfdiags.Diagnostics) {
+	var diags tfdiags.Diagnostics
+
+	diags = diags.Append(n.validateInstanceKey(inst, callRange))
+	if diags.HasErrors() {
+		return cty.DynamicVal, diags
+	}
+
+	instAddr := n.Addr.Absolute(ctx.Path()).Instance(inst.Action.Key)
 
 	expander := ctx.InstanceExpander()
 	// first we have to make sure the instance is valid because the expander only panics
@@ -402,7 +414,7 @@ func (n *NodeActionConfig) EvalInstance(ctx EvalContext, inst addrs.AbsActionIns
 		diags = diags.Append(&hcl.Diagnostic{
 			Severity: hcl.DiagError,
 			Summary:  "Reference to non-existent action instance",
-			Detail:   fmt.Sprintf("The given key %s does not identify an instance of action.test_action.hello", key),
+			Detail:   fmt.Sprintf("The given key %s does not identify an instance of action.test_action.hello", inst.Action.Key),
 			Subject:  callRange,
 		})
 		return cty.DynamicVal, diags

--- a/internal/terraform/node_action.go
+++ b/internal/terraform/node_action.go
@@ -193,7 +193,9 @@ func (n *NodeActionConfig) Validate(ctx EvalContext, caller addrs.Referenceable)
 	}
 
 	resp := provider.ValidateActionConfig(req)
-	diags = diags.Append(resp.Diagnostics.InConfigBody(n.Config.Config, n.Addr.String()))
+	if resp.Diagnostics != nil {
+		diags = diags.Append(resp.Diagnostics.InConfigBody(n.Config.Config, caller.String()))
+	}
 
 	return diags
 }

--- a/internal/terraform/node_resource_abstract.go
+++ b/internal/terraform/node_resource_abstract.go
@@ -662,13 +662,8 @@ type resourceActionTrigger struct {
 // expression itself, so that we can refine it to the individual action instance
 // during evaluation.
 type actionRef struct {
-	configRef  configs.ActionRef
-	actionNode *NodeActionConfig
-
-	// FIXME: are two indexes really needed when we know the overall order? This
-	// mirrors the plan structure for now.
-	// Block and action indexes to record in the plan where the calls
-	// originated.
+	configRef   configs.ActionRef
+	actionNode  *NodeActionConfig
 	blockIndex  int
 	actionIndex int
 }

--- a/internal/terraform/node_resource_plan_instance.go
+++ b/internal/terraform/node_resource_plan_instance.go
@@ -667,20 +667,10 @@ func (n *NodePlannableResourceInstance) planActionTriggers(ctx EvalContext, resR
 // This function uses named result parameters.
 func (n *NodePlannableResourceInstance) planActionTrigger(ctx EvalContext, resRepData instances.RepetitionData, actionRef actionRef, event configs.ActionTriggerEvent) (ai *plans.ActionInvocationInstance, deferred bool, diags tfdiags.Diagnostics) {
 
-	ref, evalActionDiags := evaluateActionExpression(actionRef.configRef.Expr, resRepData)
+	actionInst, evalActionDiags := evaluateActionExpression(actionRef.configRef.Expr, resRepData)
 	diags = append(diags, evalActionDiags...)
 	if diags.HasErrors() {
 		return
-	}
-
-	var actionInst addrs.ActionInstance
-	switch sub := ref.Subject.(type) {
-	case addrs.Action:
-		actionInst = sub.Instance(addrs.NoKey)
-	case addrs.ActionInstance:
-		actionInst = sub
-	default:
-		panic(fmt.Sprintf("unknown action address type: %T", sub))
 	}
 
 	ai = &plans.ActionInvocationInstance{

--- a/internal/terraform/node_resource_plan_instance.go
+++ b/internal/terraform/node_resource_plan_instance.go
@@ -721,32 +721,16 @@ func (n *NodePlannableResourceInstance) planActionTrigger(ctx EvalContext, resRe
 		ProposedActionData: unmarkedConfig,
 		ClientCapabilities: ctx.ClientCapabilities(),
 	})
-	// FIXME: config body is not the entire action config block
-	// Our diagnostics expect to be associated with a config body, but we may not have one due to the structure of actions.
-	// How wo we get the action block, and not the action's config block?
+
+	// Associate any provider produced diagnostics with the action config block.
 	if actionRef.actionNode.Config.Config != nil {
-		resp.Diagnostics = resp.Diagnostics.InConfigBody(actionRef.actionNode.Config.Config, actionRef.actionNode.Addr.String())
+		resp.Diagnostics = resp.Diagnostics.InConfigBody(actionRef.actionNode.Config.Config, n.Addr.String())
+	} else {
+		// if there was no action config block, use the entire action block for reference
+		resp.Diagnostics = resp.Diagnostics.InConfigBody(actionRef.actionNode.Config.Body, n.Addr.String())
 	}
 
-	// FIXME: this diagnostic handling is incorrect, but it matches
-	// the existing implementation for now
-	if len(resp.Diagnostics) > 0 {
-		severity := hcl.DiagWarning
-		message := "Warnings when planning action"
-		err := resp.Diagnostics.Warnings().ErrWithWarnings()
-		if resp.Diagnostics.HasErrors() {
-			severity = hcl.DiagError
-			message = "Failed to plan action"
-			err = resp.Diagnostics.ErrWithWarnings()
-		}
-
-		diags = diags.Append(&hcl.Diagnostic{
-			Severity: severity,
-			Summary:  message,
-			Detail:   err.Error(),
-			Subject:  actionRef.configRef.Range.Ptr(),
-		})
-	}
+	diags = diags.Append(resp.Diagnostics)
 
 	if resp.Deferred != nil {
 		if !ctx.Deferrals().DeferralAllowed() {

--- a/internal/terraform/node_resource_validate.go
+++ b/internal/terraform/node_resource_validate.go
@@ -76,6 +76,9 @@ func (n *NodeValidatableResource) Execute(ctx EvalContext, op walkOperation) (di
 func (n *NodeValidatableResource) validateActions(ctx EvalContext) tfdiags.Diagnostics {
 	var diags tfdiags.Diagnostics
 
+	// check that we have the correct reference type for any action expansion
+	repData, _ := n.stubRepetitionData()
+
 	// There may be many triggers and many actions within a trigger, but for the
 	// purposes of validation we don't need to repeat them. Just collect all
 	// known actions and validate them once each.
@@ -108,6 +111,15 @@ func (n *NodeValidatableResource) validateActions(ctx EvalContext) tfdiags.Diagn
 
 		for _, ref := range trigger.actionRefs {
 			actions.Put(ref.actionNode.Addr, ref)
+
+			actionInst, ds := evaluateActionExpression(ref.configRef.Expr, repData)
+			diags = diags.Append(ds)
+			if diags.HasErrors() {
+				// validateInstanceKey won't work if the value is invalid
+				continue
+			}
+
+			diags = diags.Append(ref.actionNode.validateInstanceKey(actionInst.Absolute(ctx.Path()), ref.configRef.Range.Ptr()))
 		}
 	}
 


### PR DESCRIPTION
Some cleanup around validation and diagnostic for actions.

- Validation: Unify the code shared between parsing action references and replace_triggered_by references. Refine, remove duplicates, and catch some more cases where the indexing is somehow wrong for action instances.

- Diagnostics: the diagnostics returned by provider were being mangled into generic `Error when invoking action` messages, all pointing at the trigger rather than the config. Use the actual diagnostics and annotate them for the action config locations, making sure to highlight the correct attributes when signaled by the provider.

We don't really have an mechanisms for dealing with 2 source locations since the config is effectively split between action and trigger blocks, but we can make use of the `with` clause in the diagnostic to insert the caller address rather than the action block address. It will have to be seen how useful it is, but for now we go from the unattributed 

```
│ Error: Invalid Bufo Name
│
│   with terraform_data.bufo[0],
│   on main.tf line 22, in action "bufo_print" "bufo":
│   22:     name = "nope"
```

We don't have control over the clause preposition, so "with" will have to do for now. That mechanism was created to show the actual module/resource instances and is freeform, so we could theoretically add more plain text there if desired.