### PR TITLE
Action back-reference trigger warning

### DIFF
--- a/internal/terraform/context_apply_action_test.go
+++ b/internal/terraform/context_apply_action_test.go
@@ -634,34 +634,6 @@ resource "test_object" "a" {
 			expectInvokeActionCalled: true,
 		},
 
-		"after_create with config cycle": {
-			module: map[string]string{
-				"main.tf": `
-action "action_example" "hello" {
-  config {
-    attr = test_object.a.test_string
-  }
-}
-resource "test_object" "a" {
-  test_string = "test_object_a"
-  lifecycle {
-    action_trigger {
-      events = [after_create]
-      actions = [action.action_example.hello]
-    }
-  }
-}
-`,
-			},
-			expectInvokeActionCalled: true,
-			expectInvokeActionCalls: []providers.InvokeActionRequest{{
-				ActionType: "action_example",
-				PlannedActionData: cty.ObjectVal(map[string]cty.Value{
-					"attr": cty.StringVal("test_object_a"),
-				}),
-			}},
-		},
-
 		"triggered within module": {
 			module: map[string]string{
 				"main.tf": `
@@ -1144,7 +1116,7 @@ resource "test_object" "a" {
 				"main.tf": `
 action "action_example" "hello" {
   config {
-    attr = test_object.a.test_string
+    attr = caller.test_string
   }
 }
 resource "test_object" "a" {

--- a/internal/terraform/context_plan_actions_test.go
+++ b/internal/terraform/context_plan_actions_test.go
@@ -207,6 +207,18 @@ list "test_resource" "test1" {
 					Mode:  plans.NormalMode,
 					Query: true,
 				},
+				expectValidateDiagnostics: func(m *configs.Config) (diags tfdiags.Diagnostics) {
+					return diags.Append(&hcl.Diagnostic{
+						Severity: hcl.DiagWarning,
+						Summary:  "Reference to triggering resource",
+						Detail:   `The triggering resource object can be accessed via the "caller" symbol to avoid unexpected graph cycles.`,
+						Subject: &hcl.Range{
+							Filename: filepath.Join(m.Module.SourceDir, "main.tf"),
+							Start:    hcl.Pos{Line: 4, Column: 11, Byte: 53},
+							End:      hcl.Pos{Line: 4, Column: 33, Byte: 75},
+						},
+					})
+				},
 			},
 			"invalid config": {
 				module: map[string]string{
@@ -1368,6 +1380,18 @@ resource "test_object" "a" {
 `,
 				},
 				expectPlanActionCalled: true,
+				expectValidateDiagnostics: func(m *configs.Config) (diags tfdiags.Diagnostics) {
+					return diags.Append(&hcl.Diagnostic{
+						Severity: hcl.DiagWarning,
+						Summary:  "Reference to triggering resource",
+						Detail:   `The triggering resource object can be accessed via the "caller" symbol to avoid unexpected graph cycles.`,
+						Subject: &hcl.Range{
+							Filename: filepath.Join(m.Module.SourceDir, "main.tf"),
+							Start:    hcl.Pos{Line: 4, Column: 12, Byte: 54},
+							End:      hcl.Pos{Line: 4, Column: 25, Byte: 67},
+						},
+					})
+				},
 				assertPlan: func(t *testing.T, p *plans.Plan) {
 					if len(p.Changes.ActionInvocations) != 1 {
 						t.Fatalf("expected one action in plan, got %d", len(p.Changes.ActionInvocations))
@@ -1412,6 +1436,18 @@ resource "test_object" "a" {
 `,
 				},
 				expectPlanActionCalled: true,
+				expectValidateDiagnostics: func(m *configs.Config) (diags tfdiags.Diagnostics) {
+					return diags.Append(&hcl.Diagnostic{
+						Severity: hcl.DiagWarning,
+						Summary:  "Reference to triggering resource",
+						Detail:   `The triggering resource object can be accessed via the "caller" symbol to avoid unexpected graph cycles.`,
+						Subject: &hcl.Range{
+							Filename: filepath.Join(m.Module.SourceDir, "main.tf"),
+							Start:    hcl.Pos{Line: 4, Column: 12, Byte: 54},
+							End:      hcl.Pos{Line: 4, Column: 25, Byte: 67},
+						},
+					})
+				},
 			},
 
 			"caller can be used for triggering resource": {

--- a/internal/terraform/node_resource_validate.go
+++ b/internal/terraform/node_resource_validate.go
@@ -120,6 +120,20 @@ func (n *NodeValidatableResource) validateActions(ctx EvalContext) tfdiags.Diagn
 			}
 
 			diags = diags.Append(ref.actionNode.validateInstanceKey(actionInst.Absolute(ctx.Path()), ref.configRef.Range.Ptr()))
+
+			// actions initially allowed to use caller data via arbitrary
+			// expressions, but using caller is preferred now to avoid hidden
+			// cycles in the graph
+			for _, actionBlockRef := range ref.actionNode.References() {
+				if resource, ok := actionBlockRef.Subject.(addrs.ResourceInstance); ok && resource.Resource.Equal(n.Addr.Resource) {
+					diags = diags.Append(&hcl.Diagnostic{
+						Severity: hcl.DiagWarning,
+						Summary:  "Reference to triggering resource",
+						Detail:   `The triggering resource object can be accessed via the "caller" symbol to avoid unexpected graph cycles.`,
+						Subject:  actionBlockRef.SourceRange.ToHCL().Ptr(),
+					})
+				}
+			}
 		}
 	}
 


### PR DESCRIPTION
Actions were initially allowed to refer back to the triggering resource via the caller's full address. In order to do that terraform needs to specifically catch the reference and remove the cycle it causes. If this reference is indirected in any way, we lose that ability and the apply will fail with a graph cycle.

We've since introduced the "caller" object, which is a alias for "self" from the triggering resource. Detect when the user has an action config which should be using "caller" instead of a resource address, and present a warning about the old syntax.

```
│ Warning: Reference to triggering resource
│
│   on main.tf line 20, in action "bufo_print" "bufo":
│   20:     name  = "bufo-${terraform_data.bufo.output}"
│
│ The triggering resource object can be accessed via the "caller" symbol to avoid unexpected graph cycles.
```