### PR TITLE
Add some light guidance to contribution guide about change log entries' content

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -154,7 +154,21 @@ This is different if you are backporting your changes to an earlier release vers
 
 #### Create a change file using `changie`
 
-If your change is user-facing you can use `npx changie new` to create a new changelog entry via your terminal. The command is interactive and you will need to: select which kind of change you're introducing, provide a short description, and enter either the number of the GitHub issue your PR closes or your PR's number.
+If your change is user-facing you can use `npx changie new` to create a new changelog entry via your terminal. The command is interactive and you will need to:
+1. Select which kind of change you're introducing.
+2. Provide a short description.
+3. Enter the number of the GitHub issue your PR closes.
+    * If there is no issue, use the PR number.
+
+Your description should be written from an end-user's perspective and not describe implementation details. For example, out of these two potential changelog entries, users will find the second one more useful:
+
+> Ensured that SourceBundleParser always receives a relative path for the Source Directory
+
+> Fixed an issue where terraform stacks validate was failing to resolve relative paths for modules
+
+If there isn't an impact on the end user then there shouldn't be a changelog entry.
+
+Dependency bumps or other changes, like Go version upgrades, should only be in the changelog if the change impacts the user or fixes a user-facing issue. For example, if a dependency bump resolves a CVE that impacts Terraform and users are exposed to risk there should be a changelog entry. If the dependency bump is moving the code away from a version of a dependency that's linked to a CVE that isn't impacting Terraform then no changelog entry is needed.
 
 Make sure to select the correct kind of change:
 


### PR DESCRIPTION
By unpopular demand, some text about changelog entries.

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.16.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing. N/A
