### PR TITLE
fix: prevent nil pointer panics from unchecked type assertions in OSS and Consul backends

### DIFF
--- a/internal/backend/remote-state/consul/client.go
+++ b/internal/backend/remote-state/consul/client.go
@@ -683,11 +683,23 @@ func (c *RemoteClient) chunkedMode() (bool, string, []string, *consulapi.KVPair,
 			// If we find the "current-hash" key we were in chunked mode
 			hash, ok := d["current-hash"]
 			if ok {
-				chunks := make([]string, 0)
-				for _, c := range d["chunks"].([]interface{}) {
-					chunks = append(chunks, c.(string))
+				hashStr, ok := hash.(string)
+				if !ok {
+					return false, "", nil, pair, fmt.Errorf("corrupt chunked state: \"current-hash\" is not a string")
 				}
-				return true, hash.(string), chunks, pair, nil
+				chunks := make([]string, 0)
+				chunksRaw, ok := d["chunks"].([]interface{})
+				if !ok {
+					return false, "", nil, pair, fmt.Errorf("corrupt chunked state: \"chunks\" is missing or not an array")
+				}
+				for _, c := range chunksRaw {
+					cStr, ok := c.(string)
+					if !ok {
+						return false, "", nil, pair, fmt.Errorf("corrupt chunked state: chunk element is not a string")
+					}
+					chunks = append(chunks, cStr)
+				}
+				return true, hashStr, chunks, pair, nil
 			}
 		}
 	}

--- a/internal/backend/remote-state/oss/backend.go
+++ b/internal/backend/remote-state/oss/backend.go
@@ -594,9 +594,17 @@ func getConfigFromProfile(d *schema.ResourceData, ProfileKey string) (interface{
 			if err != nil {
 				return nil, err
 			}
-			for _, v := range config["profiles"].([]interface{}) {
-				if current == v.(map[string]interface{})["name"] {
-					providerConfig = v.(map[string]interface{})
+			profiles, ok := config["profiles"].([]interface{})
+			if !ok {
+				return nil, fmt.Errorf("failed to read aliyun config: \"profiles\" key is missing or not an array")
+			}
+			for _, v := range profiles {
+				vMap, ok := v.(map[string]interface{})
+				if !ok {
+					continue
+				}
+				if current == vMap["name"] {
+					providerConfig = vMap
 				}
 			}
 		}
@@ -681,7 +689,8 @@ func getAuthCredentialByEcsRoleName(ecsRoleName string) (accessKey, secretKey, t
 		err = fmt.Errorf("refresh Ecs sts token err, fail to get Code: %s", err.Error())
 		return
 	}
-	if code.(string) != "Success" {
+	codeStr, ok := code.(string)
+	if !ok || codeStr != "Success" {
 		err = fmt.Errorf("refresh Ecs sts token err, Code is not Success")
 		return
 	}
@@ -706,7 +715,23 @@ func getAuthCredentialByEcsRoleName(ecsRoleName string) (accessKey, secretKey, t
 		return
 	}
 
-	return accessKeyId.(string), accessKeySecret.(string), securityToken.(string), nil
+	accessKeyIdStr, ok := accessKeyId.(string)
+	if !ok {
+		err = fmt.Errorf("refresh Ecs sts token err, AccessKeyId is not a string")
+		return
+	}
+	accessKeySecretStr, ok := accessKeySecret.(string)
+	if !ok {
+		err = fmt.Errorf("refresh Ecs sts token err, AccessKeySecret is not a string")
+		return
+	}
+	securityTokenStr, ok := securityToken.(string)
+	if !ok {
+		err = fmt.Errorf("refresh Ecs sts token err, SecurityToken is not a string")
+		return
+	}
+
+	return accessKeyIdStr, accessKeySecretStr, securityTokenStr, nil
 }
 
 func getHttpProxyUrl(rawUrl string) (*url.URL, error) {


### PR DESCRIPTION
## What this does

Fixes #38619

Three functions in the OSS and Consul backends performed unchecked type assertions on data from external sources (ECS metadata endpoint, Alibaba Cloud config files, Consul KV store). When the external data was missing expected fields, terraform panicked instead of returning a meaningful error.

## Changes

### `backend/oss`: `getAuthCredentialByEcsRoleName` (line 684)

`jmespath.Search("Code", data)` returns `(nil, nil)` when the `"Code"` key is absent. The subsequent `code.(string)` type assertion panics. Fixed by using comma-ok form for all type assertions (`Code`, `AccessKeyId`, `AccessKeySecret`, `SecurityToken`).

### `backend/oss`: `getConfigFromProfile` (line 597)

`config["profiles"].([]interface{})` panics if `"profiles"` key is missing from `~/.aliyun/config.json`. Fixed by checking if the key exists and is an array before iterating, and validating each element is a map.

### `backend/consul`: `chunkedMode` (line 687)

The code checks if `"current-hash"` exists but blindly asserts `d["chunks"].([]interface{})` without checking. Fixed by validating both `"chunks"` existence and element types before access.

All fixes use comma-ok form with descriptive error messages. No behavioral change on valid inputs.
