### PR TITLE
docs: Changie should prompt for PR numbers only.

### DIFF
--- a/.changie.yaml
+++ b/.changie.yaml
@@ -10,8 +10,8 @@ versionFormat: '## {{.Version}} ({{.Time.Format "January 2, 2006"}})'
 kindFormat: "{{.Kind}}:"
 changeFormat: "* {{.Body}} {{- if .Custom.Issue }} ([#{{.Custom.Issue}}](https://github.com/hashicorp/terraform/issues/{{.Custom.Issue}})){{- end}}"
 custom:
-    - key: Issue
-      label: Issue/PR Number
+    - key: Issue # Misleading name, but the key cannot be changed without breaking existing change files. Do not supply an issue number for this field.
+      label: PR Number
       type: int
       minInt: 1
 kinds:

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -157,8 +157,7 @@ This is different if you are backporting your changes to an earlier release vers
 If your change is user-facing you can use `npx changie new` to create a new changelog entry via your terminal. The command is interactive and you will need to:
 1. Select which kind of change you're introducing.
 2. Provide a short description.
-3. Enter the number of the GitHub issue your PR closes.
-    * If there is no issue, use the PR number.
+3. Enter the number of your GitHub PR.
 
 Your description should be written from an end-user's perspective and not describe implementation details. For example, out of these two potential changelog entries, users will find the second one more useful:
 


### PR DESCRIPTION
See this thread: https://github.com/hashicorp/terraform/pull/38659/changes/BASE..3170b3c5ed7c5843dde6d17c4899ff9f7f67ca16#r3335015831

This PR causes changie to prompt specifically for the PR number and not either the Issue or PR Number:

<img width="399" height="60" alt="Screenshot 2026-06-01 at 17 09 56" src="https://github.com/user-attachments/assets/2d0ed3b3-98ec-4310-839f-bcf59b8b35f9" />

Updated contribution guidelines to match


## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.16.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
