### PR TITLE
Standalone action invocations

### DIFF
--- a/internal/addrs/action.go
+++ b/internal/addrs/action.go
@@ -165,8 +165,8 @@ func (a AbsAction) Instance(key InstanceKey) AbsActionInstance {
 	}
 }
 
-// Config returns the unexpanded ConfigAction for this AbsAction.
-func (a AbsAction) Config() ConfigAction {
+// ConfigAction returns the unexpanded ConfigAction for this AbsAction.
+func (a AbsAction) ConfigAction() ConfigAction {
 	return ConfigAction{
 		Module: a.Module.Module(),
 		Action: a.Action,
@@ -180,6 +180,8 @@ func (a AbsAction) TargetContains(other Targetable) bool {
 		return a.Equal(to)
 	case AbsActionInstance:
 		return a.Equal(to.ContainingAction())
+	case ConfigAction:
+		return a.ConfigAction().Equal(to)
 	default:
 		return false
 	}
@@ -276,6 +278,8 @@ func (a AbsActionInstance) TargetContains(other Targetable) bool {
 		return to.Equal(a.ContainingAction()) && a.Action.Key == NoKey
 	case AbsActionInstance:
 		return to.Equal(a)
+	case ConfigAction:
+		return a.ConfigAction().Equal(to)
 	default:
 		return false
 	}
@@ -314,6 +318,7 @@ func (a absActionInstanceKey) uniqueKeySigil() {}
 
 // ConfigAction is the address for an action within the configuration.
 type ConfigAction struct {
+	targetable
 	Module Module
 	Action Action
 }
@@ -337,6 +342,11 @@ func (a ConfigAction) Absolute(module ModuleInstance) AbsAction {
 	}
 }
 
+// AddrType implements Targetable
+func (a ConfigAction) AddrType() TargetableAddrType {
+	return ActionAddrType
+}
+
 func (a ConfigAction) String() string {
 	if len(a.Module) == 0 {
 		return a.Action.String()
@@ -346,6 +356,16 @@ func (a ConfigAction) String() string {
 
 func (a ConfigAction) Equal(o ConfigAction) bool {
 	return a.Module.Equal(o.Module) && a.Action.Equal(o.Action)
+}
+
+func (a ConfigAction) TargetContains(other Targetable) bool {
+	switch other := other.(type) {
+	case AbsAction:
+		return other.ConfigAction().Equal(a)
+	case AbsActionInstance:
+		return other.ContainingAction().ConfigAction().Equal(a)
+	}
+	return false
 }
 
 func (a ConfigAction) UniqueKey() UniqueKey {

--- a/internal/addrs/action_test.go
+++ b/internal/addrs/action_test.go
@@ -205,12 +205,12 @@ func TestAbsActionInstanceEqual(t *testing.T) {
 func TestConfigActionEqual(t *testing.T) {
 	actions := []ConfigAction{
 		{
-			RootModule,
-			Action{Type: "foo", Name: "bar"},
+			Module: RootModule,
+			Action: Action{Type: "foo", Name: "bar"},
 		},
 		{
-			Module{"child"},
-			Action{Type: "the", Name: "bloop"},
+			Module: Module{"child"},
+			Action: Action{Type: "the", Name: "bloop"},
 		},
 	}
 	for _, r := range actions {
@@ -228,34 +228,34 @@ func TestConfigActionEqual(t *testing.T) {
 	}{
 		{ // different name
 			ConfigAction{
-				RootModule,
-				Action{Type: "foo", Name: "bar"},
+				Module: RootModule,
+				Action: Action{Type: "foo", Name: "bar"},
 			},
 			ConfigAction{
-				RootModule,
-				Action{Type: "foo", Name: "baz"},
+				Module: RootModule,
+				Action: Action{Type: "foo", Name: "baz"},
 			},
 		},
 		// different type
 		{
 			ConfigAction{
-				RootModule,
-				Action{Type: "foo", Name: "bar"},
+				Module: RootModule,
+				Action: Action{Type: "foo", Name: "bar"},
 			},
 			ConfigAction{
-				RootModule,
-				Action{Type: "baz", Name: "bar"},
+				Module: RootModule,
+				Action: Action{Type: "baz", Name: "bar"},
 			},
 		},
 		// different Module
 		{
 			ConfigAction{
-				RootModule,
-				Action{Type: "foo", Name: "bar"},
+				Module: RootModule,
+				Action: Action{Type: "foo", Name: "bar"},
 			},
 			ConfigAction{
-				Module{"mod"},
-				Action{Type: "foo", Name: "bar"},
+				Module: Module{"mod"},
+				Action: Action{Type: "foo", Name: "bar"},
 			},
 		},
 	}

--- a/internal/addrs/module.go
+++ b/internal/addrs/module.go
@@ -115,6 +115,15 @@ func (m Module) TargetContains(other Targetable) bool {
 	case AbsResourceInstance:
 		return m.TargetContains(to.Module)
 
+	case ConfigAction:
+		return m.TargetContains(to.Module)
+
+	case AbsAction:
+		return m.TargetContains(to.Module)
+
+	case AbsActionInstance:
+		return m.TargetContains(to.Module)
+
 	default:
 		return false
 	}

--- a/internal/plans/action_invocation.go
+++ b/internal/plans/action_invocation.go
@@ -16,7 +16,6 @@ import (
 )
 
 type ActionInvocationInstance struct {
-	// FIXME: deposed instances are lost
 	Addr addrs.AbsActionInstance
 
 	ActionTrigger ActionTrigger
@@ -26,11 +25,10 @@ type ActionInvocationInstance struct {
 	// used to apply it.
 	ProviderAddr addrs.AbsProviderConfig
 
-	// FIXME: this shouldn't be used yet, but will be required for destroy.
-	// FIXME: what do we do about write-only attributes or ephemeral values in
-	// destroy scenarios?
 	// FIXME: sensitive paths are missing
 	ConfigValue cty.Value
+
+	Caller addrs.Referenceable
 }
 
 func (ai *ActionInvocationInstance) Equals(other *ActionInvocationInstance) bool {
@@ -57,8 +55,6 @@ var (
 
 // ResourceActionTrigger contains the action trigger configuration from the resource.
 type ResourceActionTrigger struct {
-	// FIXME: how do we indicate an unknown condition?
-
 	TriggeringResourceAddr addrs.AbsResourceInstance
 	// Information about the trigger
 	// The event that triggered this action invocation.
@@ -144,6 +140,7 @@ func (ai *ActionInvocationInstance) Encode(schema *providers.ActionSchema) (*Act
 		Addr:          ai.Addr,
 		ActionTrigger: ai.ActionTrigger,
 		ProviderAddr:  ai.ProviderAddr,
+		Caller:        ai.Caller,
 	}
 
 	if ai.ConfigValue != cty.NilVal {

--- a/internal/plans/changes_src.go
+++ b/internal/plans/changes_src.go
@@ -570,7 +570,6 @@ func (c *ChangesSrc) AppendActionInvocationInstanceChange(action *ActionInvocati
 }
 
 type ActionInvocationInstanceSrc struct {
-	// FIXME: deposed instances are lost
 	Addr          addrs.AbsActionInstance
 	ActionTrigger ActionTrigger
 
@@ -578,6 +577,8 @@ type ActionInvocationInstanceSrc struct {
 	SensitiveConfigPaths []cty.Path
 
 	ProviderAddr addrs.AbsProviderConfig
+
+	Caller addrs.Referenceable
 }
 
 // Decode unmarshals the raw representation of actions.

--- a/internal/plans/deferring/deferred.go
+++ b/internal/plans/deferring/deferred.go
@@ -730,7 +730,7 @@ func (d *Deferred) ReportActionDeferred(addr addrs.AbsAction, reason providers.D
 	d.mu.Lock()
 	defer d.mu.Unlock()
 
-	configAddr := addr.Config()
+	configAddr := addr.ConfigAction()
 	if !d.actionExpansionDeferred.Has(configAddr) {
 		d.actionExpansionDeferred.Put(configAddr, addrs.MakeMap[addrs.AbsAction, providers.DeferredReason]())
 	}

--- a/internal/plans/planfile/tfplan.go
+++ b/internal/plans/planfile/tfplan.go
@@ -1344,6 +1344,14 @@ func actionInvocationFromTfplan(rawAction *planproto.ActionInvocationInstance) (
 	}
 	ret.Addr = actionAddr
 
+	if rawAction.Caller != "" {
+		callerAddr, diags := addrs.ParseRefStr(rawAction.Caller)
+		if diags.HasErrors() {
+			return nil, fmt.Errorf("invalid action caller address %q: %w", rawAction.Caller, diags.Err())
+		}
+		ret.Caller = callerAddr.Subject
+	}
+
 	switch at := rawAction.ActionTrigger.(type) {
 	case *planproto.ActionInvocationInstance_ResourceActionTrigger:
 		triggeringResourceAddrs, diags := addrs.ParseAbsResourceInstanceStr(at.ResourceActionTrigger.TriggeringResourceAddr)
@@ -1413,6 +1421,10 @@ func actionInvocationToTfPlan(action *plans.ActionInvocationInstanceSrc) (*planp
 	ret := &planproto.ActionInvocationInstance{
 		Addr:     action.Addr.String(),
 		Provider: action.ProviderAddr.String(),
+	}
+
+	if action.Caller != nil {
+		ret.Caller = action.Caller.String()
 	}
 
 	switch at := action.ActionTrigger.(type) {

--- a/internal/plans/planproto/planfile.pb.go
+++ b/internal/plans/planproto/planfile.pb.go
@@ -1751,6 +1751,9 @@ type ActionInvocationInstance struct {
 	//	*ActionInvocationInstance_ResourceActionTrigger
 	//	*ActionInvocationInstance_InvokeActionTrigger
 	ActionTrigger isActionInvocationInstance_ActionTrigger `protobuf_oneof:"action_trigger"`
+	// If the action uses the caller symbol, we record the resource calling the
+	// action for evaluation.
+	Caller        string `protobuf:"bytes,8,opt,name=caller,proto3" json:"caller,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1836,6 +1839,13 @@ func (x *ActionInvocationInstance) GetInvokeActionTrigger() *InvokeActionTrigger
 		}
 	}
 	return nil
+}
+
+func (x *ActionInvocationInstance) GetCaller() string {
+	if x != nil {
+		return x.Caller
+	}
+	return ""
 }
 
 type isActionInvocationInstance_ActionTrigger interface {
@@ -2349,14 +2359,15 @@ const file_planfile_proto_rawDesc = "" +
 	"\aunknown\x18\x02 \x01(\bR\aunknown\x120\n" +
 	"\bidentity\x18\x03 \x01(\v2\x14.tfplan.DynamicValueR\bidentity\":\n" +
 	"\bDeferred\x12.\n" +
-	"\x06reason\x18\x01 \x01(\x0e2\x16.tfplan.DeferredReasonR\x06reason\"\x85\x03\n" +
+	"\x06reason\x18\x01 \x01(\x0e2\x16.tfplan.DeferredReasonR\x06reason\"\x9d\x03\n" +
 	"\x18ActionInvocationInstance\x12\x12\n" +
 	"\x04addr\x18\x01 \x01(\tR\x04addr\x12\x1a\n" +
 	"\bprovider\x18\x02 \x01(\tR\bprovider\x127\n" +
 	"\fconfig_value\x18\x04 \x01(\v2\x14.tfplan.DynamicValueR\vconfigValue\x12B\n" +
 	"\x16sensitive_config_paths\x18\x05 \x03(\v2\f.tfplan.PathR\x14sensitiveConfigPaths\x12W\n" +
 	"\x17resource_action_trigger\x18\x06 \x01(\v2\x1d.tfplan.ResourceActionTriggerH\x00R\x15resourceActionTrigger\x12Q\n" +
-	"\x15invoke_action_trigger\x18\a \x01(\v2\x1b.tfplan.InvokeActionTriggerH\x00R\x13invokeActionTriggerB\x10\n" +
+	"\x15invoke_action_trigger\x18\a \x01(\v2\x1b.tfplan.InvokeActionTriggerH\x00R\x13invokeActionTrigger\x12\x16\n" +
+	"\x06caller\x18\b \x01(\tR\x06callerB\x10\n" +
 	"\x0eaction_trigger\"\xfd\x01\n" +
 	"\x15ResourceActionTrigger\x128\n" +
 	"\x18triggering_resource_addr\x18\x01 \x01(\tR\x16triggeringResourceAddr\x12?\n" +

--- a/internal/plans/planproto/planfile.proto
+++ b/internal/plans/planproto/planfile.proto
@@ -481,6 +481,10 @@ message ActionInvocationInstance {
         ResourceActionTrigger resource_action_trigger = 6;
         InvokeActionTrigger invoke_action_trigger = 7;
     }
+
+    // If the action uses the caller symbol, we record the resource calling the
+    // action for evaluation.
+    string caller = 8;
 }
 
 // ResourceActionTrigger contains details on the conditions that led to the

--- a/internal/terraform/action_trigger_instance_apply.go
+++ b/internal/terraform/action_trigger_instance_apply.go
@@ -53,7 +53,25 @@ func (n *actionTriggerApplyInstance) invoke(ctx EvalContext, caller addrs.Refere
 		return diags
 	}
 
-	// FIXME: missing action trigger reference for diags
+	// TODO: we will need to decode the saved config value for our initial attempt at destroy actions
+	//
+	// actionSchema, ok := actionProviderSchema.Actions[n.ActionInvocation.Addr.Action.Action.Type]
+	// if !ok {
+	// 	// This should have been caught earlier, but we don't want to panic
+	// 	diags = diags.Append(&hcl.Diagnostic{
+	// 		Severity: hcl.DiagError,
+	// 		Summary:  fmt.Sprintf("Action %s not found in provider schema", n.ActionInvocation.Addr),
+	// 		Detail:   fmt.Sprintf("The action %s was not found in the provider schema for %s", n.ActionInvocation.Addr, n.ActionInvocation.ProviderAddr),
+	// 		Subject:  n.actionNode.Config.DeclRange.Ptr(),
+	// 	})
+	// 	return diags
+	// }
+	// inv, err := n.ActionInvocation.Decode(&actionSchema)
+	// if err != nil {
+	// 	return diags.Append(err)
+	// }
+	// configValue := inv.ConfigValue
+
 	configValue, actionDiags := n.actionNode.EvalInstance(ctx, n.ActionInvocation.Addr, nil, caller)
 	diags = diags.Append(actionDiags)
 	if diags.HasErrors() {
@@ -66,7 +84,6 @@ func (n *actionTriggerApplyInstance) invoke(ctx EvalContext, caller addrs.Refere
 			Summary:  "Action configuration unknown during apply",
 			Detail: fmt.Sprintf("The action %s was not fully known during apply. "+
 				"This may be caused by using the caller object in conjunction with a before event.", n.ActionInvocation.Addr),
-			// FIXME: maybe turn this into an attribute path diagnostic?
 			Subject: n.actionNode.Config.DeclRange.Ptr(),
 		})
 	}

--- a/internal/terraform/context_apply_action_test.go
+++ b/internal/terraform/context_apply_action_test.go
@@ -2524,6 +2524,58 @@ func TestContextApply_invoked_actions(t *testing.T) {
 			}),
 		},
 
+		"invoke action with caller": {
+			module: map[string]string{
+				"main.tf": `
+resource "test_object" "a" {
+  count = 2
+  test_string = "hello"
+  lifecycle {
+    action_trigger {
+      events = [before_update]
+	  actions = [action.action_example.one]
+	}
+  }
+}
+
+action "action_example" "one" {
+  config {
+    attr = caller.test_string
+  }
+}
+	`,
+			},
+			planOpts: &PlanOpts{
+				Mode:          plans.RefreshOnlyMode,
+				ActionTargets: []addrs.Targetable{mustActionAddr("action.action_example.one")},
+			},
+			expectInvokeActionCalled: true,
+			expectInvokeActionCalls: []providers.InvokeActionRequest{
+				{
+					ActionType: "action_example",
+					PlannedActionData: cty.ObjectVal(map[string]cty.Value{
+						"attr": cty.StringVal("hello"),
+					}),
+				},
+				{
+					ActionType: "action_example",
+					PlannedActionData: cty.ObjectVal(map[string]cty.Value{
+						"attr": cty.StringVal("hello"),
+					}),
+				},
+			},
+			prevRunState: states.BuildState(func(state *states.SyncState) {
+				state.SetResourceInstanceCurrent(mustResourceInstanceAddr("test_object.a[0]"), &states.ResourceInstanceObjectSrc{
+					AttrsJSON: []byte(`{"test_string":"hello"}`),
+					Status:    states.ObjectReady,
+				}, mustProviderConfig(`provider["registry.terraform.io/hashicorp/test"]`))
+				state.SetResourceInstanceCurrent(mustResourceInstanceAddr("test_object.a[1]"), &states.ResourceInstanceObjectSrc{
+					AttrsJSON: []byte(`{"test_string":"hello"}`),
+					Status:    states.ObjectReady,
+				}, mustProviderConfig(`provider["registry.terraform.io/hashicorp/test"]`))
+			}),
+		},
+
 		"invoke action with reference (drift)": {
 			module: map[string]string{
 				"main.tf": `

--- a/internal/terraform/context_plan_actions_test.go
+++ b/internal/terraform/context_plan_actions_test.go
@@ -2922,6 +2922,77 @@ action "test_action" "one" {
 				},
 			},
 
+			"invoke action with caller": {
+				module: map[string]string{
+					"main.tf": `
+resource "test_object" "a" {
+  count = 2
+  name = "hello"
+  lifecycle {
+    action_trigger {
+      events = [before_update]
+	  actions = [action.test_action.one]
+	}
+  }
+}
+
+action "test_action" "one" {
+  config {
+    attr = caller.name
+  }
+}
+`,
+				},
+				planOpts: &PlanOpts{
+					Mode: plans.RefreshOnlyMode,
+					ActionTargets: []addrs.Targetable{
+						addrs.AbsAction{
+							Action: addrs.Action{
+								Type: "test_action",
+								Name: "one",
+							},
+						},
+					},
+				},
+				expectPlanActionCalled: true,
+				buildState: func(state *states.SyncState) {
+					state.SetResourceInstanceCurrent(mustResourceInstanceAddr("test_object.a[0]"), &states.ResourceInstanceObjectSrc{
+						AttrsJSON: []byte(`{"name":"hello"}`),
+						Status:    states.ObjectReady,
+					}, mustProviderConfig(`provider["registry.terraform.io/hashicorp/test"]`))
+					state.SetResourceInstanceCurrent(mustResourceInstanceAddr("test_object.a[1]"), &states.ResourceInstanceObjectSrc{
+						AttrsJSON: []byte(`{"name":"hello"}`),
+						Status:    states.ObjectReady,
+					}, mustProviderConfig(`provider["registry.terraform.io/hashicorp/test"]`))
+				},
+				assertPlan: func(t *testing.T, plan *plans.Plan) {
+					if len(plan.Changes.ActionInvocations) != 2 {
+						t.Fatalf("expected exactly one invocation, and found %d", len(plan.Changes.ActionInvocations))
+					}
+
+					ais := plan.Changes.ActionInvocations[0]
+					ai, err := ais.Decode(&testActionSchema)
+					if err != nil {
+						t.Fatal(err)
+					}
+
+					if _, ok := ai.ActionTrigger.(*plans.InvokeActionTrigger); !ok {
+						t.Fatalf("expected invoke action trigger type but was %T", ai.ActionTrigger)
+					}
+
+					expected := cty.ObjectVal(map[string]cty.Value{
+						"attr": cty.StringVal("hello"),
+					})
+					if diff := cmp.Diff(ai.ConfigValue, expected, ctydebug.CmpOptions); len(diff) > 0 {
+						t.Fatalf("wrong value in plan: %s", diff)
+					}
+
+					if !ai.Addr.Equal(mustActionInstanceAddr("action.test_action.one")) {
+						t.Fatalf("wrong address in plan: %s", ai.Addr)
+					}
+				},
+			},
+
 			"invoke action with reference (drift)": {
 				module: map[string]string{
 					"main.tf": `

--- a/internal/terraform/graph_builder_plan.go
+++ b/internal/terraform/graph_builder_plan.go
@@ -168,13 +168,6 @@ func (b *PlanGraphBuilder) Steps() []GraphTransformer {
 			generateConfigPathForImportTargets: b.GenerateConfigPath,
 		},
 
-		&ActionInvokePlanTransformer{
-			Config:        b.Config,
-			Operation:     b.Operation,
-			ActionTargets: b.ActionTargets,
-			queryPlanMode: b.queryPlan,
-		},
-
 		// Add dynamic values
 		&RootVariableTransformer{
 			Config:         b.Config,
@@ -254,6 +247,16 @@ func (b *PlanGraphBuilder) Steps() []GraphTransformer {
 		// Must attach schemas before ReferenceTransformer so that we can
 		// analyze the configuration to find references.
 		&AttachSchemaTransformer{Plugins: b.Plugins, Config: b.Config},
+
+		// In order to analyze any use of caller, this must happen after
+		// AttachSchemaTransformer so we can get all references from the action
+		// configs.
+		&ActionInvokePlanTransformer{
+			Config:        b.Config,
+			Operation:     b.Operation,
+			ActionTargets: b.ActionTargets,
+			queryPlanMode: b.queryPlan,
+		},
 
 		// Create expansion nodes for all of the module calls. This must
 		// come after all other transformers that create nodes representing

--- a/internal/terraform/node_action.go
+++ b/internal/terraform/node_action.go
@@ -25,6 +25,16 @@ type GraphNodeConfigAction interface {
 	ActionAddr() addrs.ConfigAction
 }
 
+// GraphNodeActionCaller is na interface satisfied by resource nodes that have
+// action triggers which can be directly invoked.
+type GraphNodeActionCaller interface {
+	GraphNodeConfigResource
+
+	// Action calls returns all action references so they can be connected to
+	// any of the actions which use the caller symbol
+	ActionCalls() []addrs.ConfigAction
+}
+
 // NodeActionConfig represents an action in the configuration. This node is
 // primarily concerned with resolving provider references and receiving the
 // correct schema. All expansion and execution is done from an action trigger.
@@ -53,7 +63,7 @@ var (
 )
 
 func (n NodeActionConfig) Name() string {
-	return n.Addr.String()
+	return n.Addr.String() + " (config)"
 }
 
 func (n *NodeActionConfig) Execute(ctx EvalContext, op walkOperation) tfdiags.Diagnostics {

--- a/internal/terraform/node_action_invoke.go
+++ b/internal/terraform/node_action_invoke.go
@@ -5,6 +5,7 @@ package terraform
 
 import (
 	"fmt"
+	"log"
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/zclconf/go-cty/cty"
@@ -35,6 +36,10 @@ type nodeActionInvokeExpand struct {
 	// addrs for consistency.
 	Addr         addrs.AbsActionInstance
 	ActionConfig *NodeActionConfig
+
+	// Callers is a list of resources which reference an action which uses the
+	// caller symbol.
+	Callers []addrs.ConfigResource
 }
 
 func (n *nodeActionInvokeExpand) ActionProviders() []ProviderRef {
@@ -57,35 +62,76 @@ func (n *nodeActionInvokeExpand) Name() string {
 }
 
 func (n *nodeActionInvokeExpand) References() []*addrs.Reference {
-	return []*addrs.Reference{
+	// Callers are added to references so we can keep the caller nodes in the
+	// graph. The instances must be evaluated from state, but evaluation
+	// currently requires that resources at least be processed before
+	// evaluation.
+	var callers []*addrs.Reference
+	for _, caller := range n.Callers {
+		callers = append(callers, &addrs.Reference{
+			Subject: caller.Resource,
+		})
+	}
+
+	return append([]*addrs.Reference{
 		{
 			Subject: n.Addr.Action,
 		},
 		{
 			Subject: n.Addr.Action.Action,
 		},
-	}
+	}, callers...)
 }
 
 func (n *nodeActionInvokeExpand) DynamicExpand(ctx EvalContext) (*Graph, tfdiags.Diagnostics) {
 	var g Graph
 
-	// the nodeActionInvokeExpand is only here to expand within any targeted
-	// modules, becuase the action expansion and evaluation must happen within
-	// that module instance's scope
 	expander := ctx.InstanceExpander()
+
+	// invoke only operates via the current state, so any callers must be looked
+	// up via the state. The instances expander won't know about them, and there
+	// will be no changes to find.
+	syncState := ctx.State()
+	state := syncState.Lock()
+	defer syncState.Unlock()
 
 	for _, mod := range expander.ExpandModule(n.Module, false) {
 		if !mod.TargetContains(n.Target) {
 			continue
 		}
 
-		g.Add(&nodeActionPlanInvoke{
-			Module:       mod,
-			Addr:         n.Addr,
-			ActionConfig: n.ActionConfig,
-			ProviderAddr: n.ActionConfig.ResolvedProvider,
-		})
+		if len(n.Callers) == 0 {
+			g.Add(&nodeActionPlanInvoke{
+				Module:       mod,
+				Addr:         n.Addr,
+				ActionConfig: n.ActionConfig,
+				ProviderAddr: n.ActionConfig.ResolvedProvider,
+			})
+		} else {
+			for _, caller := range n.Callers {
+				for _, res := range state.Resources(caller) {
+					if !mod.TargetContains(res.Addr) {
+						// resource from the wrong module instance
+						continue
+					}
+
+					for instKey, resInst := range res.Instances {
+						if resInst.Current == nil {
+							continue
+						}
+
+						log.Printf("[TRACE] expanding %s invoke node for caller %s", n.Addr, res.Addr.Resource)
+						g.Add(&nodeActionPlanInvoke{
+							Module:       mod,
+							Addr:         n.Addr,
+							ActionConfig: n.ActionConfig,
+							ProviderAddr: n.ActionConfig.ResolvedProvider,
+							Caller:       res.Addr.Resource.Instance(instKey),
+						})
+					}
+				}
+			}
+		}
 	}
 	addRootNodeToGraph(&g)
 
@@ -102,6 +148,11 @@ type nodeActionPlanInvoke struct {
 	Addr         addrs.AbsActionInstance
 	ActionConfig *NodeActionConfig
 	ProviderAddr addrs.AbsProviderConfig
+	Caller       addrs.Referenceable
+}
+
+func (n *nodeActionPlanInvoke) Name() string {
+	return n.Addr.String()
 }
 
 func (n *nodeActionPlanInvoke) Path() addrs.ModuleInstance {
@@ -110,13 +161,16 @@ func (n *nodeActionPlanInvoke) Path() addrs.ModuleInstance {
 
 func (n *nodeActionPlanInvoke) Execute(ctx EvalContext, _ walkOperation) tfdiags.Diagnostics {
 	// for now each action instance will be invoked serially
-	return n.invokeActions(ctx)
+	return n.planActions(ctx)
 }
 
-func (n *nodeActionPlanInvoke) invokeActions(ctx EvalContext) tfdiags.Diagnostics {
+func (n *nodeActionPlanInvoke) planActions(ctx EvalContext) tfdiags.Diagnostics {
 	var diags tfdiags.Diagnostics
 
-	actionVals, actionDiags := n.ActionConfig.EvalInstances(ctx, n.Addr.Action, nil, nil)
+	// We're relying on the given addr derived from the action target to
+	// determine which action instance to evaluate. If the address has no key
+	// and the action is expanded, we will plan all instances.
+	actionVals, actionDiags := n.ActionConfig.EvalInstances(ctx, n.Addr.Action, nil, n.Caller)
 	diags = diags.Append(actionDiags)
 	if diags.HasErrors() {
 		return diags
@@ -137,6 +191,7 @@ func (n *nodeActionPlanInvoke) planAction(ctx EvalContext, config *configs.Actio
 		ActionTrigger: new(plans.InvokeActionTrigger),
 		ProviderAddr:  n.ProviderAddr,
 		ConfigValue:   ephemeral.RemoveEphemeralValues(configVal),
+		Caller:        n.Caller,
 	}
 
 	provider, _, err := getProvider(ctx, n.ProviderAddr)
@@ -202,5 +257,17 @@ func (n *nodeActionInvokeApplyInstance) Name() string {
 }
 
 func (n *nodeActionInvokeApplyInstance) Execute(ctx EvalContext, op walkOperation) tfdiags.Diagnostics {
-	return n.invoke(ctx, nil)
+	return n.invoke(ctx, n.ActionInvocation.Caller)
+}
+
+func (n *nodeActionInvokeApplyInstance) References() []*addrs.Reference {
+	refs := n.actionTriggerApplyInstance.References()
+
+	// add any caller to ensure the resource expansion nodes remain in the graph
+	if n.actionTriggerApplyInstance.ActionInvocation.Caller != nil {
+		refs = append(refs, &addrs.Reference{
+			Subject: n.actionTriggerApplyInstance.ActionInvocation.Caller,
+		})
+	}
+	return refs
 }

--- a/internal/terraform/node_resource_abstract.go
+++ b/internal/terraform/node_resource_abstract.go
@@ -117,6 +117,7 @@ var (
 	_ dag.GraphNodeDotter                  = (*NodeAbstractResource)(nil)
 	_ GraphNodeDestroyerCBD                = (*NodeAbstractResource)(nil)
 	_ GraphNodeActionProviderConsumer      = (*NodeAbstractResource)(nil)
+	_ GraphNodeActionCaller                = (*NodeAbstractResource)(nil)
 )
 
 // NewNodeAbstractResource creates an abstract resource graph node for
@@ -383,6 +384,17 @@ func (n *NodeAbstractResource) ActionProviders() []ProviderRef {
 		}
 	}
 	return res
+}
+
+func (n *NodeAbstractResource) ActionCalls() []addrs.ConfigAction {
+	var calls []addrs.ConfigAction
+
+	for _, trigger := range n.actionTriggers {
+		for _, actionRef := range trigger.actionRefs {
+			calls = append(calls, actionRef.actionNode.Addr)
+		}
+	}
+	return calls
 }
 
 // GraphNodeProvisionerConsumer

--- a/internal/terraform/transform_action_diff.go
+++ b/internal/terraform/transform_action_diff.go
@@ -76,10 +76,6 @@ func (t *ActionDiffTransformer) Transform(g *Graph) error {
 				return fmt.Errorf("no resource node found for action trigger %s", actionTrigger.TriggeringResourceAddr)
 			}
 		case *plans.InvokeActionTrigger:
-			// FIXME: this may be invoking a resource action even though it was
-			// added from an invoke command, and we need to differentiate those
-			// calls for the new impl
-
 			actionConfig, ok := actionConfigNodes.GetOk(ai.Addr.ConfigAction())
 			if !ok {
 				panic(fmt.Sprintf("FIXME: missing action for invoke: %s", ai.Addr))

--- a/internal/terraform/transform_action_invoke_plan.go
+++ b/internal/terraform/transform_action_invoke_plan.go
@@ -23,6 +23,31 @@ func (t *ActionInvokePlanTransformer) Transform(g *Graph) error {
 		return nil
 	}
 
+	// We could be invoking an action which is triggered from a resource,
+	// requiring us to resolve `caller`. In that case the calling resource
+	// invokes the action rather than a standalone invoke node.
+	//
+	// calledActions maps the action addresses to the callers, so we can lookup
+	// the resource below.
+	calledActions := addrs.MakeMap[addrs.ConfigAction, []GraphNodeActionCaller]()
+	for _, v := range g.Vertices() {
+		caller, ok := v.(GraphNodeActionCaller)
+		if !ok {
+			continue
+		}
+
+		for _, target := range t.ActionTargets {
+			for _, callee := range caller.ActionCalls() {
+				if target.TargetContains(callee) {
+					callers := calledActions.Get(callee)
+					callers = append(callers, caller)
+					// this resource invokes the calling node
+					calledActions.Put(callee, callers)
+				}
+			}
+		}
+	}
+
 	for _, v := range g.Vertices() {
 		actionNode, ok := v.(*NodeActionConfig)
 		if !ok {
@@ -30,35 +55,50 @@ func (t *ActionInvokePlanTransformer) Transform(g *Graph) error {
 		}
 
 		for _, target := range t.ActionTargets {
+			if !target.TargetContains(actionNode.Addr) {
+				continue
+			}
+
+			// These wil be all resources calling an the action if it uses
+			// "caller". We need to record these so standalone invoke nodes know
+			// how to evaluate the configuration. We will also end up creating
+			// separate invoke nodes for every caller.
+			var resourceCallers []addrs.ConfigResource
+
+			// first check if the action is using "caller" at all. If not just
+			// continue with the standalone invoke path below
+			if callers, ok := calledActions.GetOk(actionNode.Addr); ok {
+				for _, ref := range actionNode.References() {
+					if ref.Subject == addrs.Caller {
+						for _, caller := range callers {
+							resourceCallers = append(resourceCallers, caller.ResourceAddr())
+						}
+						break
+					}
+				}
+			}
+
 			// we need to create the invoke node in the correct module scope for each target
-			var targetAddr addrs.ConfigAction
 			var instAddr addrs.AbsActionInstance
 
 			switch target := target.(type) {
 			case addrs.AbsActionInstance:
-				targetAddr = target.ConfigAction()
 				instAddr = target
 			case addrs.AbsAction:
-				targetAddr = target.Config()
 				instAddr = target.Instance(addrs.NoKey)
 			default:
 				panic(fmt.Sprintf("invalid action addr: %#v", target))
 			}
 
-			if !actionNode.Addr.Equal(targetAddr) {
-				continue
-			}
-
 			g.Add(&nodeActionInvokeExpand{
 				Target:       target,
-				Module:       targetAddr.Module,
+				Module:       actionNode.Addr.Module,
 				Addr:         instAddr,
 				ActionConfig: actionNode,
+				Callers:      resourceCallers,
 			})
-
 		}
 	}
 
 	return nil
-
 }


### PR DESCRIPTION
The goal here is to make sure dependencies of invoked actions are correctly handled during plan and apply in anticipation of destroy actions, as well as introduce the ability to invoke actions using the `caller` symbol. 

Calling `-invoke action.action_example.one` on the configuration below, automatically results in the invocation of the action twice, once for each caller. This is a best effort to maintain compatibility with the existing release, but we may choose to add the ability to simultaneously `-target` in order to reduce caller instances as well. For cases where using `invoke` is expected, user may choose to have standalone `action` nodes that aren't called from resources for better control over invocations.
```
resource "test_object" "a" {
  count = 2
  test_string = "hello"
  lifecycle {
    action_trigger {
      events = [before_update]
	  actions = [action.action_example.one]
	}
  }
}
action "action_example" "one" {
  config {
    attr = caller.test_string
  }
}
```

In order to resolve `caller`, we must first preprocess the graph from the invoke transformer and record all actions that are called from resource triggers. If the action uses the `caller` symbol, we can lookup calling resources and record them for later. These will act as references to ensure graph ordering, as well as give us a `caller` address value for evaluation.

Because we've leverages the same mechanism as `self` for evaluation, we don't need to directly evaluate `caller`, so only need storing the address is sufficient. We add that address to the invoke plan artifacts, allowing us to use the same value during apply and skip the extra processing during the action diff transformer. We again then treat the caller as a reference, so the resource nodes are retained by targeting and evaluation can continue to work without modification, as well as passing the `caller` address into evaluation.