### PR TITLE
fix: Filter out `forget` resources in jsonplan `planned_values`

### DIFF
--- a/.changes/v1.15/BUG FIXES-20260601-232542.yaml
+++ b/.changes/v1.15/BUG FIXES-20260601-232542.yaml
@@ -1,0 +1,5 @@
+kind: BUG FIXES
+body: Fixed an issue where resources being removed from state via `removed` block were incorrectly listed under `planned_values` in json representations of the plan file.
+time: 2026-06-01T23:25:42.881637+01:00
+custom:
+    Issue: "38665"

--- a/.changes/v1.16/BUG FIXES-20260601-232542.yaml
+++ b/.changes/v1.16/BUG FIXES-20260601-232542.yaml
@@ -1,0 +1,5 @@
+kind: BUG FIXES
+body: Fixed an issue where resources being removed from state via `removed` block where incorrectly listed under `planned_values` in json plan representation
+time: 2026-06-01T23:25:42.881637+01:00
+custom:
+    Issue: "38665"

--- a/.changes/v1.16/BUG FIXES-20260601-232542.yaml
+++ b/.changes/v1.16/BUG FIXES-20260601-232542.yaml
@@ -1,5 +1,0 @@
-kind: BUG FIXES
-body: Fixed an issue where resources being removed from state via `removed` block where incorrectly listed under `planned_values` in json plan representation
-time: 2026-06-01T23:25:42.881637+01:00
-custom:
-    Issue: "38665"

--- a/internal/command/jsonplan/values.go
+++ b/internal/command/jsonplan/values.go
@@ -103,10 +103,10 @@ func marshalPlannedValues(changes *plans.ChangesSrc, schemas *terraform.Schemas)
 	seenModules := make(map[string]bool)
 
 	for _, resource := range changes.Resources {
-		// If the resource is being deleted, skip over it.
+		// If the resource is being deleted or forgotten (removed from state), skip over it.
 		// Deposed instances are always conceptually a destroy, but if they
 		// were gone during refresh then the change becomes a noop.
-		if resource.Action != plans.Delete && resource.DeposedKey == states.NotDeposed {
+		if resource.Action != plans.Delete && resource.Action != plans.Forget && resource.DeposedKey == states.NotDeposed {
 			containingModule := resource.Addr.Module.String()
 			moduleResourceMap[containingModule] = append(moduleResourceMap[containingModule], resource.Addr)
 
@@ -170,7 +170,7 @@ func marshalPlanResources(changes *plans.ChangesSrc, ris []addrs.AbsResourceInst
 
 	for _, ri := range ris {
 		r := changes.ResourceInstance(ri)
-		if r.Action == plans.Delete {
+		if r.Action == plans.Delete || r.Action == plans.Forget {
 			continue
 		}
 

--- a/internal/command/jsonplan/values_test.go
+++ b/internal/command/jsonplan/values_test.go
@@ -237,6 +237,19 @@ func TestMarshalPlanResources(t *testing.T) {
 			Want: nil,
 			Err:  false,
 		},
+		"forget": {
+			Action: plans.Forget,
+			Before: cty.ObjectVal(map[string]cty.Value{
+				"woozles": cty.StringVal("foo"),
+				"foozles": cty.StringVal("bar"),
+			}),
+			After: cty.NullVal(cty.Object(map[string]cty.Type{
+				"woozles": cty.String,
+				"foozles": cty.String,
+			})),
+			Want: nil,
+			Err:  false,
+		},
 		"update without unknowns": {
 			Action: plans.Update,
 			Before: cty.ObjectVal(map[string]cty.Value{


### PR DESCRIPTION
# Background  

<!--
Describe in detail the changes you are proposing, and the rationale.
See the contributing guide:
https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md
-->

The `planned_values` section of a JSON plan output represents the projected post-apply state of a configuration.
Currently, when a resource is being removed from state via a `removed` block with `lifecycle { destroy = false }` (the "forget" change action), it gets mistakenly included in the `planned_values` section of the plan, with its attributes stripped to null.

Given a "forgotten" resource is being dropped from state, it should not be appearing in the `planned_values`.
Additionally, as the forgotten resource attributes are being stripped to null (untrue, as the resource is not being deleted and still holds real values in the cloud), the current representation of the forgotten resource doesn't properly reflect neither its prior state nor the real post-apply state.

  **Cause:** This was an oversight from when the `removed` block was introduced in v1.7.0 (#34251).
- In `internal/command/jsonplan/values.go`, both `marshalPlannedValues` and `marshalPlanResources` filter out resources with the `Delete` action but not the `Forget` action, so forgotten resources fall through into `planned_values`. 
-  In `internal/terraform/node_resource_abstract_instance.go` the `planForget` function sets `change.After` to null on forgotten resources. This is intended, but results in resources showing up stripped of attributes in `planned_values`.  

This PR fixes this issue by adding a skip for `plans.Forget` action in both `marshalPlannedValues` and `marshalPlanResources` functions, resulting in forgotten resources being omitted from `planned_values` as intended.

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Fixes #38641 

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.16.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

No changes have been made to security controls (access controls, encryption, logging).
This change only affects the JSON serialization of plan output.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [x] This change is user-facing and I added a changelog entry.
- [ ] This change is not user-facing.
