### PR TITLE
arguments: validate -lockfile flag value in ParseInit

### DIFF
--- a/.changes/v1.16/BREAKING CHANGES-20260602-033406.yaml
+++ b/.changes/v1.16/BREAKING CHANGES-20260602-033406.yaml
@@ -1,0 +1,5 @@
+kind: BREAKING CHANGES
+body: 'init: The `-lockfile` flag now returns an error for values other than `readonly`.'
+time: 2026-06-02T03:34:06-07:00
+custom:
+    Issue: "38563"

--- a/internal/command/arguments/init.go
+++ b/internal/command/arguments/init.go
@@ -211,6 +211,14 @@ func ParseInit(args []string, experimentsEnabled bool) (*Init, tfdiags.Diagnosti
 		))
 	}
 
+	if init.Lockfile != "" && init.Lockfile != "readonly" {
+		diags = diags.Append(tfdiags.Sourceless(
+			tfdiags.Error,
+			"Invalid -lockfile flag value",
+			fmt.Sprintf("The -lockfile flag only accepts \"readonly\". Got: %q.", init.Lockfile),
+		))
+	}
+
 	if init.Upgrade && init.Lockfile == "readonly" {
 		// This is appended as a Go error because this validation already existed this way
 		// and it's been moved earlier in the process, to the arguments package.

--- a/internal/command/arguments/init_test.go
+++ b/internal/command/arguments/init_test.go
@@ -374,6 +374,11 @@ func TestParseInit_invalid(t *testing.T) {
 			wantErr:      "The -upgrade flag conflicts with -lockfile=readonly.",
 			wantViewType: ViewHuman,
 		},
+		"with invalid -lockfile value": {
+			args:         []string{"-lockfile=foobar"},
+			wantErr:      "Invalid -lockfile flag value",
+			wantViewType: ViewHuman,
+		},
 	}
 
 	for name, tc := range testCases {


### PR DESCRIPTION
## Description

Fixes #38563.

Invalid values for `-lockfile` (anything other than `"readonly"`) were silently ignored after the init command was refactored to use the `arguments` package in #38561. The flag accepted any value but had no effect, which is confusing.

This adds explicit validation in `ParseInit` so users get a clear diagnostic error instead of the flag being a no-op.

### What changed

- `internal/command/arguments/init.go`: validation block that errors on any non-empty, non-`"readonly"` `-lockfile` value
- `internal/command/arguments/init_test.go`: added `"with invalid -lockfile value"` case to `TestParseInit_invalid`

No behavioral change for valid inputs (`-lockfile=readonly` or no flag).

### CLA

I have signed the HashiCorp CLA: https://cla.hashicorp.com/