### PR TITLE
Address comments in policy evaluation wiring PR

### DIFF
--- a/internal/states/sync.go
+++ b/internal/states/sync.go
@@ -144,10 +144,10 @@ func (s *SyncState) ResourceInstance(addr addrs.AbsResourceInstance) *ResourceIn
 
 func (s *SyncState) ResourceInstancesByConfig(addr addrs.ConfigResource) []*ResourceInstance {
 	s.lock.RLock()
+	defer s.lock.RUnlock()
 	addrs := s.state.allResourceInstanceObjectAddrs(func(objAddr addrs.AbsResourceInstanceObject) bool {
 		return objAddr.ResourceInstance.ConfigResource().Equal(addr)
 	})
-	s.lock.RUnlock()
 	ret := make([]*ResourceInstance, 0, len(addrs))
 	for _, addr := range addrs {
 		ret = append(ret, s.state.ResourceInstance(addr.ResourceInstance).DeepCopy())

--- a/internal/terraform/context_plan_policy_test.go
+++ b/internal/terraform/context_plan_policy_test.go
@@ -995,6 +995,101 @@ func TestContext2Plan_PolicyEvaluation(t *testing.T) {
 				tfdiags.AssertNoDiagnostics(t, d.diags)
 			},
 		},
+		{
+			name:        "normal plan: removed child module config still evaluates policy with nil resource config",
+			expectCalls: 1,
+			mainConfig: `
+						terraform {
+							required_providers {
+								test = {
+									source = "hashicorp/test"
+									version = "1.0.0"
+								}
+							}
+						}
+						`,
+			childConfig: "",
+			policyConfig: `
+						resource_policy "test_resource" "allow_destroy" {
+							enforce {
+								condition = true
+							}
+						}
+						`,
+			planMode: plans.NormalMode,
+			state: states.BuildState(func(ss *states.SyncState) {
+				ss.SetResourceInstanceCurrent(
+					mustResourceInstanceAddr("module.child.test_resource.test"),
+					&states.ResourceInstanceObjectSrc{
+						Status:    states.ObjectReady,
+						AttrsJSON: []byte(`{"id":"bar","type":"test_resource","sensitive_value":"secret"}`),
+					},
+					mustProviderConfig(`provider["registry.terraform.io/hashicorp/test"]`),
+				)
+			}),
+			prepareExpectations: func(t *testing.T, data *data) {
+				data.policy.EvaluateFn = func(ctx context.Context, req policy.EvaluationRequest[*proto.PolicyEvaluateResourceRequest_ResourceMetadata]) policy.EvaluationResponse {
+					data.policyEvalCalls++
+					if req.Target != "test_resource" {
+						t.Fatalf("Expected target test_resource, got %q", req.Target)
+					}
+					if diff := cmp.Diff(req.Meta, &proto.PolicyEvaluateResourceRequest_ResourceMetadata{
+						ProviderType: "test",
+						Operation:    proto.Operation_DELETE,
+					}, protocmp.Transform()); diff != "" {
+						t.Errorf("Invalid resource metadata: %s", diff)
+					}
+					if !req.Attrs.IsNull() {
+						t.Errorf("Expected null attrs for destroy evaluation")
+					}
+					if req.PriorAttrs.IsNull() {
+						t.Errorf("Expected non-null PriorAttrs for destroy evaluation")
+						return policy.EvaluationResponse{}
+					}
+
+					return policy.EvaluationResponse{
+						Overall: policy.AllowResult,
+						Enforcements: []policy.EnforcementResult{{
+							Result:  policy.AllowResult,
+							Message: "allowed",
+						}},
+					}
+				}
+			},
+			assertPolicyResults: func(t *testing.T, d *data) {
+				if !d.policy.EvaluateCalled {
+					t.Error("Expected policyClient.Evaluate to be called for destroy plan")
+				}
+				tfdiags.AssertNoDiagnostics(t, d.diags)
+
+				var gotResults int
+				for addr, result := range d.plan.PolicyResults.Iter() {
+					gotResults++
+					if addr != "module.child.test_resource.test" {
+						t.Fatalf("Expected policy result for module.child.test_resource.test, got %q", addr)
+					}
+					if result.ConfigDeclRange.Filename != "" {
+						t.Fatalf("Expected empty config declaration range for removed config, got %#v", result.ConfigDeclRange)
+					}
+					if len(result.EvaluationResponse.Enforcements) != 1 {
+						t.Fatalf("Expected 1 enforcement result, got %d", len(result.EvaluationResponse.Enforcements))
+					}
+				}
+				if gotResults != 1 {
+					t.Fatalf("Expected 1 stored policy result, got %d", gotResults)
+				}
+
+				for _, rc := range d.plan.Changes.Resources {
+					if rc.Addr.String() == "module.child.test_resource.test" {
+						if rc.Action != plans.Delete {
+							t.Errorf("Expected delete action for module.child.test_resource.test, got %s", rc.Action)
+						}
+						return
+					}
+				}
+				t.Error("Expected module.child.test_resource.test in plan changes")
+			},
+		},
 	}
 
 	for _, tc := range cases {
@@ -1161,6 +1256,89 @@ func TestContext2Plan_PolicyEvaluation_NoResourceRunsAfterPolicy(t *testing.T) {
 		policyDiags = policyDiags.Append(result.EvaluationResponse.Diagnostics.AsTerraformDiags())
 	}
 	tfdiags.AssertNoDiagnostics(t, policyDiags)
+}
+
+func TestContext2Plan_PolicyEvaluation_ManagedResourcesOnly(t *testing.T) {
+	// This tests that only managed resources are sent for policy evaluation.
+	mainConfig := `
+		terraform {
+			required_providers {
+				test = {
+					source = "hashicorp/test"
+					version = "1.0.0"
+				}
+			}
+		}
+
+		data "test_data_source" "lookup" {
+			foo = "from-data"
+		}
+
+		resource "test_resource" "test" {
+			sensitive_value = data.test_data_source.lookup.foo
+		}
+	`
+
+	mod := testModuleInline(t, map[string]string{
+		"main.tf":           mainConfig,
+		"main.tfpolicy.hcl": "",
+	})
+
+	var policyEvalCalls int
+	policyClient := policy.NewTestMockClient(t)
+	policyClient.EvaluateFn = func(ctx context.Context, req policy.EvaluationRequest[*proto.PolicyEvaluateResourceRequest_ResourceMetadata]) policy.EvaluationResponse {
+		policyEvalCalls++
+		if req.Target != "test_resource" {
+			t.Fatalf("expected policy evaluation only for managed resource test_resource, got %q", req.Target)
+		}
+
+		if diff := cmp.Diff(req.Meta, &proto.PolicyEvaluateResourceRequest_ResourceMetadata{
+			ProviderType: "test",
+			Operation:    proto.Operation_CREATE,
+		}, protocmp.Transform()); diff != "" {
+			t.Errorf("Invalid resource metadata: %s", diff)
+		}
+
+		if req.Attrs.IsNull() {
+			t.Fatal("expected non-null attrs for managed resource policy evaluation")
+		}
+		if got := req.Attrs.GetAttr("sensitive_value").AsString(); got != "from-data" {
+			t.Fatalf("expected managed resource attrs to include sensitive_value=from-data, got %q", got)
+		}
+
+		return policy.EvaluationResponse{
+			Overall: policy.AllowResult,
+			Enforcements: []policy.EnforcementResult{{
+				Result:  policy.AllowResult,
+				Message: "allowed",
+			}},
+		}
+	}
+
+	provider := testProvider("test")
+	provider.ReadDataSourceFn = func(req providers.ReadDataSourceRequest) (resp providers.ReadDataSourceResponse) {
+		resp.State = req.Config
+		return resp
+	}
+
+	ctx, diags := NewContext(&ContextOpts{
+		Providers: map[addrs.Provider]providers.Factory{
+			addrs.NewDefaultProvider("test"): testProviderFuncFixed(provider),
+		},
+		Parallelism: 1,
+	})
+	tfdiags.AssertNoDiagnostics(t, diags)
+
+	_, diags = ctx.Plan(mod, states.NewState(), &PlanOpts{
+		Mode:         plans.NormalMode,
+		SetVariables: testInputValuesUnset(mod.Module.Variables),
+		PolicyClient: policyClient,
+	})
+	tfdiags.AssertNoDiagnostics(t, diags)
+
+	if policyEvalCalls != 1 {
+		t.Fatalf("expected exactly 1 policy evaluation call for managed resources, got %d", policyEvalCalls)
+	}
 }
 
 func TestContext2Plan_PolicyEvaluation_ImportBlock(t *testing.T) {

--- a/internal/terraform/node_policy_resource.go
+++ b/internal/terraform/node_policy_resource.go
@@ -7,6 +7,7 @@ import (
 	"log"
 
 	"github.com/hashicorp/terraform/internal/addrs"
+	"github.com/hashicorp/terraform/internal/configs"
 	"github.com/hashicorp/terraform/internal/plans"
 	"github.com/hashicorp/terraform/internal/policy/callback"
 	"github.com/hashicorp/terraform/internal/policy/proto"
@@ -50,9 +51,6 @@ func (n *nodeResourcePolicy) Execute(ctx EvalContext, operation walkOperation) t
 	}
 
 	modCfg := config.DescendantForInstance(n.ResourceAddr.Module)
-	if modCfg == nil {
-		return nil
-	}
 
 	attrs, _ := n.After.UnmarkDeep()
 	priorAttrs, _ := n.Before.UnmarkDeep()
@@ -69,6 +67,7 @@ func (n *nodeResourcePolicy) Execute(ctx EvalContext, operation walkOperation) t
 		plans.CreateThenForget:
 		policyOperation = proto.Operation_UPDATE
 	default:
+		log.Printf("[DEBUG] Unsupported plan action %q, skipping policy evaluation", action)
 		return nil
 	}
 
@@ -82,10 +81,20 @@ func (n *nodeResourcePolicy) Execute(ctx EvalContext, operation walkOperation) t
 		resolved: true,
 	}
 
-	metaVal, metaDiags := providerRef.getProviderMeta(ctx, n.ResourceAddr.Resource, modCfg.Module.ProviderMetas)
-	diags = diags.Append(metaDiags)
-	if diags.HasErrors() {
-		return diags
+	// the module config may be nil if the module call has been removed from the configuration
+	// in this case, we are fine with a nil resource config, as that would only mean
+	// that we do not have the terraform config's source information in the diagnostics
+	// and neither do we have provider meta information to include in the policy request.
+	var resourceConfig *configs.Resource
+	var metaVal cty.Value
+	if modCfg != nil {
+		resourceConfig = modCfg.Module.ResourceByAddr(n.ResourceAddr.Resource.Resource)
+		var metaDiags tfdiags.Diagnostics
+		metaVal, metaDiags = providerRef.getProviderMeta(ctx, n.ResourceAddr.Resource, modCfg.Module.ProviderMetas)
+		diags = diags.Append(metaDiags)
+		if diags.HasErrors() {
+			return diags
+		}
 	}
 
 	callbacks := callback.Functions{
@@ -93,9 +102,8 @@ func (n *nodeResourcePolicy) Execute(ctx EvalContext, operation walkOperation) t
 		GetDataSource: getDataSourceForPolicyCallback(ctx, provider, schema, metaVal),
 	}
 
-	rscConfig := modCfg.Module.ResourceByAddr(n.ResourceAddr.Resource.Resource)
-	result := evaluatePolicies(ctx, operation, n.ResourceAddr, rscConfig, client, attrs, priorAttrs, meta, callbacks)
-	ctx.PolicyResults().AddResource(n.ResourceAddr, result, rscConfig)
+	result := evaluatePolicies(ctx, operation, n.ResourceAddr, resourceConfig, client, attrs, priorAttrs, meta, callbacks)
+	ctx.PolicyResults().AddResource(n.ResourceAddr, result, resourceConfig)
 	return diags
 }
 

--- a/internal/terraform/node_resource_abstract_instance.go
+++ b/internal/terraform/node_resource_abstract_instance.go
@@ -588,7 +588,9 @@ func (n *NodeAbstractResourceInstance) writeChange(ctx EvalContext, change *plan
 		// they are just used internally by Terraform to refresh resources before
 		// they are destroyed (See comments in https://github.com/hashicorp/terraform/blob/d4ca814cbea037dcf2a59d083f8a540bf5d38d3a/internal/terraform/context_plan.go#L46-L53).
 		if policyGraph := ctx.PolicyGraph(); policyGraph != nil && !n.preDestroyRefresh {
-			policyGraph.Add(policyNodeFromChange(change))
+			if n.Addr.Resource.Resource.Mode == addrs.ManagedResourceMode {
+				policyGraph.Add(policyNodeFromChange(change))
+			}
 		}
 		log.Printf("[TRACE] writeChange: recorded %s change for %s", change.Action, n.Addr)
 	} else {


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

This addresses comments raised post-merge in https://github.com/hashicorp/terraform/pull/38516.

The changes made
- Policies should still be evaluated when a child module configuration is removed
- Fixes a mutex bug
- Skips creating policy nodes for non-managed-resources.



## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.16.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [ ] This change is not user-facing.
