### PR TITLE
fix: Remove deprecation marks when formatting output for the `console` command.

### DIFF
--- a/.changes/v1.15/BUG FIXES-20260603-172507.yaml
+++ b/.changes/v1.15/BUG FIXES-20260603-172507.yaml
@@ -1,0 +1,5 @@
+kind: BUG FIXES
+body: 'console: Fixed a panic caused by evaluating an expression involving deprecated values'
+time: 2026-06-03T17:25:07.111161+01:00
+custom:
+    Issue: "38676"

--- a/internal/repl/format.go
+++ b/internal/repl/format.go
@@ -20,11 +20,20 @@ func FormatValue(v cty.Value, indent int) string {
 	if !v.IsKnown() {
 		return "(known after apply)"
 	}
+
+	// Any marks on the value must either be used to return
+	// early or be removed. In future marks may used to cause
+	// values to be annotated, but the mark will still need to be
+	// removed before we can get a string representation of the value.
 	if marks.Has(v, marks.Sensitive) {
 		return "(sensitive value)"
 	}
 	if marks.Has(v, marks.Ephemeral) {
 		return "(ephemeral value)"
+	}
+	if marks.Has(v, marks.Deprecation) {
+		// Mark doesn't impact formatting, so remove to unblock normal formatting below
+		v, _ = v.Unmark()
 	}
 	if v.IsNull() {
 		ty := v.Type()

--- a/internal/repl/format_test.go
+++ b/internal/repl/format_test.go
@@ -181,6 +181,10 @@ EOT_`,
 			cty.StringVal("an ephemeral value").Mark(marks.Ephemeral),
 			"(ephemeral value)",
 		},
+		{
+			cty.StringVal("I'm a deprecated string value").Mark(marks.Deprecation),
+			`"I'm a deprecated string value"`, // We don't render deprecated values differently, but we need to ensure the deprecation mark doesn't interfere with formatting
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform/issues/38671

This PR introduces handling of deprecation marks to resolve the linked issue. Deprecation marks aren't used to change how values are rendered, but they need to be removed before we use the cty library to get string representations of values.

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.15.6 

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [x] This change is user-facing and I added a changelog entry.
- [ ] This change is not user-facing.
