### PR TITLE
e2e: Reuse a single experimental build of Terraform in tests for experimental features

### DIFF
--- a/internal/command/e2etest/init_test.go
+++ b/internal/command/e2etest/init_test.go
@@ -471,10 +471,8 @@ func TestInitStateStoreUsingUnmanagedProvider(t *testing.T) {
 		}
 	}
 
-	t.Setenv(e2e.TestExperimentFlag, "true")
-	terraformBin := e2e.GoBuild("github.com/hashicorp/terraform", "terraform")
 	fixturePath := filepath.Join("testdata", "initialized-directory-with-state-store-unmanaged")
-	tf := e2e.NewBinary(t, terraformBin, fixturePath)
+	tf := e2e.NewBinary(t, experimentalTerraformBin, fixturePath)
 
 	// Assert the existing lockfile describes the older version of the provider.
 	lockFile := tf.Path(".terraform.lock.hcl")

--- a/internal/command/e2etest/main_test.go
+++ b/internal/command/e2etest/main_test.go
@@ -12,7 +12,13 @@ import (
 	"github.com/hashicorp/terraform/internal/e2e"
 )
 
-var terraformBin string
+var (
+	// Path to a build of Terraform reused in multiple E2E tests. Experiments are disabled.
+	terraformBin string
+
+	// Path to a build of Terraform reused in multiple E2E tests. Experiments are enabled.
+	experimentalTerraformBin string
+)
 
 // canRunGoBuild is a short-term compromise to account for the fact that we
 // have a small number of tests that work by building helper programs using
@@ -48,10 +54,15 @@ func setup() func() {
 		return func() {}
 	}
 
+	// Make a non-experimental TF executable available for use in tests
 	tmpFilename := e2e.GoBuild("github.com/hashicorp/terraform", "terraform")
-
-	// Make the executable available for use in tests
 	terraformBin = tmpFilename
+
+	// Make an experimental TF executable available for use in tests
+	os.Setenv(e2e.TestExperimentFlag, "true")
+	defer os.Unsetenv(e2e.TestExperimentFlag)
+	tmpExperimentalFilename := e2e.GoBuild("github.com/hashicorp/terraform", "terraform")
+	experimentalTerraformBin = tmpExperimentalFilename
 
 	// Tests running in the ad-hoc testing mode are allowed to use "go build"
 	// and similar to produce other test executables.
@@ -60,6 +71,7 @@ func setup() func() {
 
 	return func() {
 		os.Remove(tmpFilename)
+		os.Remove(tmpExperimentalFilename)
 	}
 }
 

--- a/internal/command/e2etest/pluggable_state_store_test.go
+++ b/internal/command/e2etest/pluggable_state_store_test.go
@@ -38,9 +38,7 @@ func TestPrimary_stateStore_unmanaged_separatePlan(t *testing.T) {
 
 	fixturePath := filepath.Join("testdata", "full-workflow-with-state-store-fs")
 
-	t.Setenv(e2e.TestExperimentFlag, "true")
-	terraformBin := e2e.GoBuild("github.com/hashicorp/terraform", "terraform")
-	tf := e2e.NewBinary(t, terraformBin, fixturePath)
+	tf := e2e.NewBinary(t, experimentalTerraformBin, fixturePath)
 
 	reattachStr, provider := reattachedProviderForTest(t, addrs.NewDefaultProvider("simple6"), 6)
 	tf.AddEnv("TF_REATTACH_PROVIDERS=" + string(reattachStr))
@@ -121,11 +119,8 @@ func TestPrimary_stateStore_workspaceCmd(t *testing.T) {
 		t.Skip("can't run without building a new provider executable")
 	}
 
-	t.Setenv(e2e.TestExperimentFlag, "true")
-	terraformBin := e2e.GoBuild("github.com/hashicorp/terraform", "terraform")
-
 	fixturePath := filepath.Join("testdata", "full-workflow-with-state-store-fs")
-	tf := e2e.NewBinary(t, terraformBin, fixturePath)
+	tf := e2e.NewBinary(t, experimentalTerraformBin, fixturePath)
 	workspaceDirName := "states" // See workspace_dir value in the configuration
 
 	// In order to test integration with PSS we need a provider plugin implementing a state store.
@@ -226,11 +221,8 @@ func TestPrimary_stateStore_stateCmds(t *testing.T) {
 		t.Skip("can't run without building a new provider executable")
 	}
 
-	t.Setenv(e2e.TestExperimentFlag, "true")
-	tfBin := e2e.GoBuild("github.com/hashicorp/terraform", "terraform")
-
 	fixturePath := filepath.Join("testdata", "initialized-directory-with-state-store-fs")
-	tf := e2e.NewBinary(t, tfBin, fixturePath)
+	tf := e2e.NewBinary(t, experimentalTerraformBin, fixturePath)
 
 	workspaceDirName := "states" // see test fixture value for workspace_dir
 
@@ -302,11 +294,8 @@ func TestPrimary_stateStore_outputCmd(t *testing.T) {
 		t.Skip("can't run without building a new provider executable")
 	}
 
-	t.Setenv(e2e.TestExperimentFlag, "true")
-	tfBin := e2e.GoBuild("github.com/hashicorp/terraform", "terraform")
-
 	fixturePath := filepath.Join("testdata", "initialized-directory-with-state-store-fs")
-	tf := e2e.NewBinary(t, tfBin, fixturePath)
+	tf := e2e.NewBinary(t, experimentalTerraformBin, fixturePath)
 
 	workspaceDirName := "states" // see test fixture value for workspace_dir
 
@@ -371,11 +360,8 @@ func TestPrimary_stateStore_showCmd(t *testing.T) {
 		t.Skip("can't run without building a new provider executable")
 	}
 
-	t.Setenv(e2e.TestExperimentFlag, "true")
-	tfBin := e2e.GoBuild("github.com/hashicorp/terraform", "terraform")
-
 	fixturePath := filepath.Join("testdata", "initialized-directory-with-state-store-fs")
-	tf := e2e.NewBinary(t, tfBin, fixturePath)
+	tf := e2e.NewBinary(t, experimentalTerraformBin, fixturePath)
 
 	workspaceDirName := "states" // see test fixture value for workspace_dir
 
@@ -496,10 +482,8 @@ func TestPrimary_stateStore_providerCmds(t *testing.T) {
 		t.Skip("can't run without building a new provider executable")
 	}
 
-	t.Setenv(e2e.TestExperimentFlag, "true")
-	terraformBin := e2e.GoBuild("github.com/hashicorp/terraform", "terraform")
 	fixturePath := filepath.Join("testdata", "full-workflow-with-state-store-fs")
-	tf := e2e.NewBinary(t, terraformBin, fixturePath)
+	tf := e2e.NewBinary(t, experimentalTerraformBin, fixturePath)
 	workspaceDirName := "states" // See workspace_dir value in the configuration
 
 	// Add a state file describing a resource from the simple (v5) provider, so

--- a/internal/command/e2etest/primary_test.go
+++ b/internal/command/e2etest/primary_test.go
@@ -247,11 +247,8 @@ func TestPrimary_stateStore(t *testing.T) {
 		t.Skip("can't run without building a new provider executable")
 	}
 
-	t.Setenv(e2e.TestExperimentFlag, "true")
-	terraformBin := e2e.GoBuild("github.com/hashicorp/terraform", "terraform")
-
 	fixturePath := filepath.Join("testdata", "full-workflow-with-state-store-fs")
-	tf := e2e.NewBinary(t, terraformBin, fixturePath)
+	tf := e2e.NewBinary(t, experimentalTerraformBin, fixturePath)
 	workspaceDirName := "states" // See workspace_dir value in the configuration
 
 	// In order to test integration with PSS we need a provider plugin implementing a state store.
@@ -321,11 +318,8 @@ func TestPrimary_stateStore_planFile(t *testing.T) {
 		t.Skip("can't run without building a new provider executable")
 	}
 
-	t.Setenv(e2e.TestExperimentFlag, "true")
-	terraformBin := e2e.GoBuild("github.com/hashicorp/terraform", "terraform")
-
 	fixturePath := filepath.Join("testdata", "full-workflow-with-state-store-fs")
-	tf := e2e.NewBinary(t, terraformBin, fixturePath)
+	tf := e2e.NewBinary(t, experimentalTerraformBin, fixturePath)
 
 	// In order to test integration with PSS we need a provider plugin implementing a state store.
 	// Here will build the simple6 (built with protocol v6) provider, which implements PSS.
@@ -410,9 +404,7 @@ func TestPrimary_stateStore_swapProviderSupplyMode_betweenInitAndPlanApply(t *te
 
 		fixturePath := filepath.Join("testdata", "full-workflow-with-state-store-fs")
 
-		t.Setenv(e2e.TestExperimentFlag, "true")
-		terraformBin := e2e.GoBuild("github.com/hashicorp/terraform", "terraform")
-		tf := e2e.NewBinary(t, terraformBin, fixturePath)
+		tf := e2e.NewBinary(t, experimentalTerraformBin, fixturePath)
 
 		reattachStr, _ := reattachedProviderForTest(t, addrs.NewDefaultProvider("simple6"), 6)
 		tf.AddEnv("TF_REATTACH_PROVIDERS=" + string(reattachStr))
@@ -493,9 +485,7 @@ func TestPrimary_stateStore_swapProviderSupplyMode_betweenInitAndPlanApply(t *te
 
 		fixturePath := filepath.Join("testdata", "full-workflow-with-state-store-fs")
 
-		t.Setenv(e2e.TestExperimentFlag, "true")
-		terraformBin := e2e.GoBuild("github.com/hashicorp/terraform", "terraform")
-		tf := e2e.NewBinary(t, terraformBin, fixturePath)
+		tf := e2e.NewBinary(t, experimentalTerraformBin, fixturePath)
 
 		// Build provider binaries that will be used via a filesystem mirror/-plugin-dir flag.
 		simple6Provider := filepath.Join(tf.WorkDir(), "terraform-provider-simple6")
@@ -589,9 +579,7 @@ func TestPrimary_stateStore_swapProviderSupplyMode_betweenInitAndPlanApply(t *te
 
 		fixturePath := filepath.Join("testdata", "full-workflow-with-state-store-fs")
 
-		t.Setenv(e2e.TestExperimentFlag, "true")
-		terraformBin := e2e.GoBuild("github.com/hashicorp/terraform", "terraform")
-		tf := e2e.NewBinary(t, terraformBin, fixturePath)
+		tf := e2e.NewBinary(t, experimentalTerraformBin, fixturePath)
 
 		// Build a new provider binary and direct Terraform to use it via CLI configuration file.
 		simple6Provider := filepath.Join(tf.WorkDir(), "terraform-provider-simple6")
@@ -697,9 +685,7 @@ func TestPrimary_stateStore_swapProviderSupplyMode_betweenSuccessiveInits(t *tes
 
 		fixturePath := filepath.Join("testdata", "full-workflow-with-state-store-fs")
 
-		t.Setenv(e2e.TestExperimentFlag, "true")
-		terraformBin := e2e.GoBuild("github.com/hashicorp/terraform", "terraform")
-		tf := e2e.NewBinary(t, terraformBin, fixturePath)
+		tf := e2e.NewBinary(t, experimentalTerraformBin, fixturePath)
 
 		reattachStr, _ := reattachedProviderForTest(t, addrs.NewDefaultProvider("simple6"), 6)
 		tf.AddEnv("TF_REATTACH_PROVIDERS=" + string(reattachStr))
@@ -774,9 +760,7 @@ func TestPrimary_stateStore_swapProviderSupplyMode_betweenSuccessiveInits(t *tes
 
 		fixturePath := filepath.Join("testdata", "full-workflow-with-state-store-fs")
 
-		t.Setenv(e2e.TestExperimentFlag, "true")
-		terraformBin := e2e.GoBuild("github.com/hashicorp/terraform", "terraform")
-		tf := e2e.NewBinary(t, terraformBin, fixturePath)
+		tf := e2e.NewBinary(t, experimentalTerraformBin, fixturePath)
 
 		// Build provider binaries that will be used via a filesystem mirror/-plugin-dir flag.
 		simple6Provider := filepath.Join(tf.WorkDir(), "terraform-provider-simple6")
@@ -864,9 +848,7 @@ func TestPrimary_stateStore_swapProviderSupplyMode_betweenSuccessiveInits(t *tes
 
 		fixturePath := filepath.Join("testdata", "full-workflow-with-state-store-fs")
 
-		t.Setenv(e2e.TestExperimentFlag, "true")
-		terraformBin := e2e.GoBuild("github.com/hashicorp/terraform", "terraform")
-		tf := e2e.NewBinary(t, terraformBin, fixturePath)
+		tf := e2e.NewBinary(t, experimentalTerraformBin, fixturePath)
 
 		// Build a new provider binary and direct Terraform to use it via CLI configuration file.
 		simple6Provider := filepath.Join(tf.WorkDir(), "terraform-provider-simple6")

--- a/internal/command/e2etest/terraform_query_test.go
+++ b/internal/command/e2etest/terraform_query_test.go
@@ -54,7 +54,7 @@ func TestUnmanagedQuery(t *testing.T) {
 			t.Parallel()
 
 			fixturePath := filepath.Join("testdata", "query-provider")
-			tf := e2e.NewBinary(t, experimentalTerraformBin, fixturePath)
+			tf := e2e.NewBinary(t, terraformBin, fixturePath)
 
 			reattachCh := make(chan *plugin.ReattachConfig)
 			closeCh := make(chan struct{})

--- a/internal/command/e2etest/terraform_query_test.go
+++ b/internal/command/e2etest/terraform_query_test.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"encoding/json"
 	"io"
-	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -53,11 +52,9 @@ func TestUnmanagedQuery(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			os.Setenv(e2e.TestExperimentFlag, "true")
-			terraformBin := e2e.GoBuild("github.com/hashicorp/terraform", "terraform")
 
 			fixturePath := filepath.Join("testdata", "query-provider")
-			tf := e2e.NewBinary(t, terraformBin, fixturePath)
+			tf := e2e.NewBinary(t, experimentalTerraformBin, fixturePath)
 
 			reattachCh := make(chan *plugin.ReattachConfig)
 			closeCh := make(chan struct{})


### PR DESCRIPTION
In the e2etest package tests reuse a single build of Terraform accessible via this global scope var:

https://github.com/hashicorp/terraform/blob/624c2f1b3845863fb71e4927902ea6244126c34f/internal/command/e2etest/main_test.go#L15

A [setup function runs once before any tests run](https://github.com/hashicorp/terraform/blob/624c2f1b3845863fb71e4927902ea6244126c34f/internal/command/e2etest/main_test.go#L29-L34), makes a Terraform binary, and enables tests to reuse that binary like this:

https://github.com/hashicorp/terraform/blob/624c2f1b3845863fb71e4927902ea6244126c34f/internal/command/e2etest/primary_test.go#L41-L42


This PR updates that process to also build a binary with experiments enabled, which can be reused in tests that cover experimental features.

This has reduced the time to execute the E2E tests:

Before

> PASS
> ok      [github.com/hashicorp/terraform/internal/command/e2etest](http://github.com/hashicorp/terraform/internal/command/e2etest) 398.746s
> 

After

> PASS
> ok      [github.com/hashicorp/terraform/internal/command/e2etest](http://github.com/hashicorp/terraform/internal/command/e2etest) 172.190s

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.16.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
