### PR TITLE
e2e: Make more E2E tests run in parallel

### DIFF
--- a/internal/command/e2etest/pluggable_state_store_test.go
+++ b/internal/command/e2etest/pluggable_state_store_test.go
@@ -110,6 +110,7 @@ func TestPrimary_stateStore_unmanaged_separatePlan(t *testing.T) {
 
 // Tests using `terraform workspace` commands in combination with pluggable state storage.
 func TestPrimary_stateStore_workspaceCmd(t *testing.T) {
+	t.Parallel()
 	if !canRunGoBuild {
 		// We're running in a separate-build-then-run context, so we can't
 		// currently execute this test which depends on being able to build
@@ -212,6 +213,7 @@ func TestPrimary_stateStore_workspaceCmd(t *testing.T) {
 // > `terraform state show`
 // > `terraform state list`
 func TestPrimary_stateStore_stateCmds(t *testing.T) {
+	t.Parallel()
 	if !canRunGoBuild {
 		// We're running in a separate-build-then-run context, so we can't
 		// currently execute this test which depends on being able to build
@@ -285,6 +287,7 @@ resource "terraform_data" "my-data" {
 // > `terraform output`
 // > `terraform output <name>`
 func TestPrimary_stateStore_outputCmd(t *testing.T) {
+	t.Parallel()
 	if !canRunGoBuild {
 		// We're running in a separate-build-then-run context, so we can't
 		// currently execute this test which depends on being able to build
@@ -351,6 +354,7 @@ func TestPrimary_stateStore_outputCmd(t *testing.T) {
 // > `terraform show <path-to-state-file>`
 // > `terraform show <path-to-plan-file>`
 func TestPrimary_stateStore_showCmd(t *testing.T) {
+	t.Parallel()
 	if !canRunGoBuild {
 		// We're running in a separate-build-then-run context, so we can't
 		// currently execute this test which depends on being able to build
@@ -473,6 +477,7 @@ state, without changing any real infrastructure.
 // in the command's outputs. _This_ test is intended to assert that the command is able to read and use
 // state via a state store ok, and is able to detect providers required only by the state.
 func TestPrimary_stateStore_providerCmds(t *testing.T) {
+	t.Parallel()
 	if !canRunGoBuild {
 		// We're running in a separate-build-then-run context, so we can't
 		// currently execute this test which depends on being able to build

--- a/internal/command/e2etest/primary_test.go
+++ b/internal/command/e2etest/primary_test.go
@@ -238,6 +238,7 @@ func TestPrimaryChdirOption(t *testing.T) {
 }
 
 func TestPrimary_stateStore(t *testing.T) {
+	t.Parallel()
 	if !canRunGoBuild {
 		// We're running in a separate-build-then-run context, so we can't
 		// currently execute this test which depends on being able to build
@@ -309,6 +310,7 @@ func TestPrimary_stateStore(t *testing.T) {
 }
 
 func TestPrimary_stateStore_planFile(t *testing.T) {
+	t.Parallel()
 	if !canRunGoBuild {
 		// We're running in a separate-build-then-run context, so we can't
 		// currently execute this test which depends on being able to build
@@ -393,6 +395,7 @@ func TestPrimary_stateStore_swapProviderSupplyMode_betweenInitAndPlanApply(t *te
 	// In contrast, swapping between a managed provider and any of unmanaged/dev_override/builtin WILL trigger a hash mismatch
 	// because the version data will change.
 	t.Run("users are NOT prompted to migrate state if an unmanaged provider used for PSS provider swaps supply mode (e.g. swap from unmanaged to dev_override) between init and plan+apply", func(t *testing.T) {
+		t.Parallel()
 		if !canRunGoBuild {
 			// We're running in a separate-build-then-run context, so we can't
 			// currently execute this test which depends on being able to build
@@ -474,6 +477,7 @@ func TestPrimary_stateStore_swapProviderSupplyMode_betweenInitAndPlanApply(t *te
 	})
 
 	t.Run("users are prompted to migrate state when they use an unmanaged provider (dev_override) for plan and apply, after initializing a project with a managed provider", func(t *testing.T) {
+		t.Parallel()
 		if !canRunGoBuild {
 			// We're running in a separate-build-then-run context, so we can't
 			// currently execute this test which depends on being able to build
@@ -568,6 +572,7 @@ func TestPrimary_stateStore_swapProviderSupplyMode_betweenInitAndPlanApply(t *te
 	})
 
 	t.Run("users are prompted to migrate state when using a managed provider for plan and apply, after initializing a project with an unmanaged provider (dev_override) for PSS", func(t *testing.T) {
+		t.Parallel()
 		if !canRunGoBuild {
 			// We're running in a separate-build-then-run context, so we can't
 			// currently execute this test which depends on being able to build

--- a/internal/command/e2etest/provider_plugin_test.go
+++ b/internal/command/e2etest/provider_plugin_test.go
@@ -201,7 +201,7 @@ func TestProviderInstall_dev_override(t *testing.T) {
 	}
 
 	t.Run("dev_override not installed during init when provider not present in dependency lock file", func(t *testing.T) {
-		terraformBin := e2e.GoBuild("github.com/hashicorp/terraform", "terraform")
+		t.Parallel()
 		tf := e2e.NewBinary(t, terraformBin, fixturePath)
 
 		// There is no lock file present at start
@@ -256,7 +256,7 @@ provider "registry.terraform.io/hashicorp/simple" {
 	})
 
 	t.Run("dev_override providers are still represented in the dependency lock file after init", func(t *testing.T) {
-		terraformBin := e2e.GoBuild("github.com/hashicorp/terraform", "terraform")
+		t.Parallel()
 		tf := e2e.NewBinary(t, terraformBin, fixturePath)
 
 		// Lockfile contains both simple and simple6 providers already
@@ -312,7 +312,7 @@ provider "registry.terraform.io/hashicorp/simple6" {
 	})
 
 	t.Run("dev_override providers are unchanged in the dependency lock file during init -upgrade", func(t *testing.T) {
-		terraformBin := e2e.GoBuild("github.com/hashicorp/terraform", "terraform")
+		t.Parallel()
 		tf := e2e.NewBinary(t, terraformBin, fixturePath)
 
 		// Lockfile contains both simple and simple6 providers already
@@ -472,7 +472,7 @@ func TestProviderInstall_unmanaged(t *testing.T) {
 	reattachConfig, _ := reattachedProviderForTest(t, addrs.NewDefaultProvider("simple6"), 6)
 
 	t.Run("unmanaged provider not installed when provider not present in dependency lock file", func(t *testing.T) {
-		terraformBin := e2e.GoBuild("github.com/hashicorp/terraform", "terraform")
+		t.Parallel()
 		tf := e2e.NewBinary(t, terraformBin, fixturePath)
 
 		// There is no lock file present at start
@@ -526,7 +526,7 @@ provider "registry.terraform.io/hashicorp/simple" {
 	})
 
 	t.Run("unmanaged providers are still represented in the dependency lock file after init", func(t *testing.T) {
-		terraformBin := e2e.GoBuild("github.com/hashicorp/terraform", "terraform")
+		t.Parallel()
 		tf := e2e.NewBinary(t, terraformBin, fixturePath)
 
 		// Lockfile contains both simple and simple6 providers already
@@ -581,7 +581,7 @@ provider "registry.terraform.io/hashicorp/simple6" {
 	})
 
 	t.Run("unmanaged providers are unchanged in the dependency lock file during init -upgrade", func(t *testing.T) {
-		terraformBin := e2e.GoBuild("github.com/hashicorp/terraform", "terraform")
+		t.Parallel()
 		tf := e2e.NewBinary(t, terraformBin, fixturePath)
 
 		// Lockfile contains both simple and simple6 providers already at older version 1.0.0

--- a/internal/command/e2etest/providers_tamper_test.go
+++ b/internal/command/e2etest/providers_tamper_test.go
@@ -274,6 +274,8 @@ terraform {
 `
 
 func TestSymlinkProviderTargetDirectory(t *testing.T) {
+	t.Parallel()
+
 	// This test reaches out to releases.hashicorp.com to download the
 	// null provider, so it can only run if network access is allowed.
 	skipIfCannotAccessNetwork(t)


### PR DESCRIPTION
After looking into https://github.com/hashicorp/terraform/pull/38678 I realised that a bunch of tests didn't change dir or envs so could be made to run in parallel.

This has helped E2E execution time a lot (comparing to that PR, not to main):

Before

> PASS
> ok      [github.com/hashicorp/terraform/internal/command/e2etest](https://github.com/hashicorp/terraform/internal/command/e2etest) 172.190s

After

> PASS
> ok      github.com/hashicorp/terraform/internal/command/e2etest 62.911s


## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.16.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
