### PR TITLE
moduletest: return backend Configure diagnostics

### DIFF
--- a/.changes/v1.16/BUG FIXES-20260604-191218.yaml
+++ b/.changes/v1.16/BUG FIXES-20260604-191218.yaml
@@ -1,0 +1,5 @@
+kind: BUG FIXES
+body: 'test: Terraform will now report backend configuration failures from run block backends during terraform test'
+time: 2026-06-04T19:12:18+02:00
+custom:
+    Issue: "38682"

--- a/internal/moduletest/states/manifest.go
+++ b/internal/moduletest/states/manifest.go
@@ -550,7 +550,7 @@ func getBackendInstance(stateKey string, config *configs.Backend, f backend.Init
 
 	configureDiags := b.Configure(newVal)
 	configureDiags = configureDiags.InConfigBody(config.Config, "")
-	if validateDiags.HasErrors() {
+	if configureDiags.HasErrors() {
 		return nil, configureDiags.Err()
 	}
 

--- a/internal/moduletest/states/manifest_test.go
+++ b/internal/moduletest/states/manifest_test.go
@@ -1,0 +1,67 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package states
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/terraform/internal/backend"
+	"github.com/hashicorp/terraform/internal/configs"
+	"github.com/hashicorp/terraform/internal/configs/configschema"
+	"github.com/hashicorp/terraform/internal/states/statemgr"
+	"github.com/hashicorp/terraform/internal/tfdiags"
+	"github.com/zclconf/go-cty/cty"
+)
+
+func TestGetBackendInstanceReturnsConfigureDiagnostics(t *testing.T) {
+	t.Parallel()
+
+	const wantErr = "configure failed"
+
+	_, err := getBackendInstance("test", &configs.Backend{
+		Config: hcl.EmptyBody(),
+	}, func() backend.Backend {
+		return &backendWithConfigureError{
+			configureDiags: tfdiags.Diagnostics{}.Append(
+				tfdiags.Sourceless(tfdiags.Error, "Configure failed", wantErr),
+			),
+		}
+	})
+	if err == nil {
+		t.Fatal("expected configure error, got nil")
+	}
+	if !strings.Contains(err.Error(), wantErr) {
+		t.Fatalf("expected error containing %q, got %q", wantErr, err)
+	}
+}
+
+type backendWithConfigureError struct {
+	configureDiags tfdiags.Diagnostics
+}
+
+func (b *backendWithConfigureError) ConfigSchema() *configschema.Block {
+	return &configschema.Block{}
+}
+
+func (b *backendWithConfigureError) PrepareConfig(config cty.Value) (cty.Value, tfdiags.Diagnostics) {
+	return config, nil
+}
+
+func (b *backendWithConfigureError) Configure(cty.Value) tfdiags.Diagnostics {
+	return b.configureDiags
+}
+
+func (b *backendWithConfigureError) StateMgr(string) (statemgr.Full, tfdiags.Diagnostics) {
+	return nil, nil
+}
+
+func (b *backendWithConfigureError) DeleteWorkspace(string, bool) tfdiags.Diagnostics {
+	return nil
+}
+
+func (b *backendWithConfigureError) Workspaces() ([]string, tfdiags.Diagnostics) {
+	return nil, nil
+}


### PR DESCRIPTION
## What changed

This fixes the diagnostics check after `getBackendInstance` calls `Configure` for a run block backend.

The code was checking `validateDiags` twice, which meant a backend that passed `PrepareConfig` but returned errors from `Configure` could still be treated as successfully configured.

I also added a regression test that exercises that path with a backend stub whose `Configure` call returns an error.

## Impact

`terraform test` now surfaces backend configuration failures from run block `backend` definitions instead of silently continuing with a backend that failed to configure.

## Testing

- `go test ./internal/moduletest/states`
- `go test ./internal/moduletest/...`
