### PR TITLE
plugin: return missing identity schema diagnostics in ReadResource

### DIFF
--- a/.changes/v1.16/BUG FIXES-20260604-191707.yaml
+++ b/.changes/v1.16/BUG FIXES-20260604-191707.yaml
@@ -1,0 +1,5 @@
+kind: BUG FIXES
+body: 'plugin: Terraform will now return an error instead of crashing if a provider returns a resource identity for a resource type without an identity schema'
+time: 2026-06-04T19:17:07+02:00
+custom:
+    Issue: "38683"

--- a/internal/plugin/grpc_provider.go
+++ b/internal/plugin/grpc_provider.go
@@ -606,6 +606,7 @@ func (p *GRPCProvider) ReadResource(r providers.ReadResourceRequest) (resp provi
 
 		if resSchema.Identity == nil {
 			resp.Diagnostics = resp.Diagnostics.Append(fmt.Errorf("unknown identity type %q", r.TypeName))
+			return resp
 		}
 
 		resp.Identity, err = decodeDynamicValue(protoResp.NewIdentity.IdentityData, resSchema.Identity.ImpliedType())

--- a/internal/plugin/grpc_provider_test.go
+++ b/internal/plugin/grpc_provider_test.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"strings"
 	"testing"
 	"time"
 
@@ -747,6 +748,59 @@ func TestGRPCProvider_ReadResource(t *testing.T) {
 		"attr": cty.StringVal("bar"),
 	})
 
+	if !cmp.Equal(expected, resp.NewState, typeComparer, valueComparer, equateEmpty) {
+		t.Fatal(cmp.Diff(expected, resp.NewState, typeComparer, valueComparer, equateEmpty))
+	}
+}
+
+func TestGRPCProvider_ReadResource_missingIdentitySchema(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	client := mockproto.NewMockProviderClient(ctrl)
+	client.EXPECT().GetSchema(
+		gomock.Any(),
+		gomock.Any(),
+		gomock.Any(),
+	).Return(providerProtoSchema(), nil)
+	client.EXPECT().GetResourceIdentitySchemas(
+		gomock.Any(),
+		gomock.Any(),
+		gomock.Any(),
+	).Return(&proto.GetResourceIdentitySchemas_Response{
+		IdentitySchemas: map[string]*proto.ResourceIdentitySchema{},
+	}, nil)
+	client.EXPECT().ReadResource(
+		gomock.Any(),
+		gomock.Any(),
+	).Return(&proto.ReadResource_Response{
+		NewState: &proto.DynamicValue{
+			Msgpack: []byte("\x81\xa4attr\xa3bar"),
+		},
+		NewIdentity: &proto.ResourceIdentityData{
+			IdentityData: &proto.DynamicValue{
+				Msgpack: []byte("\x81\xa7id_attr\xa3foo"),
+			},
+		},
+	}, nil)
+
+	p := &GRPCProvider{
+		client: client,
+	}
+
+	resp := p.ReadResource(providers.ReadResourceRequest{
+		TypeName: "resource",
+		PriorState: cty.ObjectVal(map[string]cty.Value{
+			"attr": cty.StringVal("foo"),
+		}),
+	})
+
+	checkDiagsHasError(t, resp.Diagnostics)
+	if got := resp.Diagnostics.Err().Error(); !strings.Contains(got, `unknown identity type "resource"`) {
+		t.Fatalf("expected unknown identity type diagnostic, got %q", got)
+	}
+
+	expected := cty.ObjectVal(map[string]cty.Value{
+		"attr": cty.StringVal("bar"),
+	})
 	if !cmp.Equal(expected, resp.NewState, typeComparer, valueComparer, equateEmpty) {
 		t.Fatal(cmp.Diff(expected, resp.NewState, typeComparer, valueComparer, equateEmpty))
 	}

--- a/internal/plugin6/grpc_provider.go
+++ b/internal/plugin6/grpc_provider.go
@@ -611,6 +611,7 @@ func (p *GRPCProvider) ReadResource(r providers.ReadResourceRequest) (resp provi
 
 		if resSchema.Identity == nil {
 			resp.Diagnostics = resp.Diagnostics.Append(fmt.Errorf("unknown identity type %q", r.TypeName))
+			return resp
 		}
 
 		resp.Identity, err = decodeDynamicValue(protoResp.NewIdentity.IdentityData, resSchema.Identity.ImpliedType())

--- a/internal/plugin6/grpc_provider_test.go
+++ b/internal/plugin6/grpc_provider_test.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"strings"
 	"testing"
 	"time"
 
@@ -754,6 +755,59 @@ func TestGRPCProvider_ReadResource(t *testing.T) {
 		"attr": cty.StringVal("bar"),
 	})
 
+	if !cmp.Equal(expected, resp.NewState, typeComparer, valueComparer, equateEmpty) {
+		t.Fatal(cmp.Diff(expected, resp.NewState, typeComparer, valueComparer, equateEmpty))
+	}
+}
+
+func TestGRPCProvider_ReadResource_missingIdentitySchema(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	client := mockproto.NewMockProviderClient(ctrl)
+	client.EXPECT().GetProviderSchema(
+		gomock.Any(),
+		gomock.Any(),
+		gomock.Any(),
+	).Return(providerProtoSchema(), nil)
+	client.EXPECT().GetResourceIdentitySchemas(
+		gomock.Any(),
+		gomock.Any(),
+		gomock.Any(),
+	).Return(&proto.GetResourceIdentitySchemas_Response{
+		IdentitySchemas: map[string]*proto.ResourceIdentitySchema{},
+	}, nil)
+	client.EXPECT().ReadResource(
+		gomock.Any(),
+		gomock.Any(),
+	).Return(&proto.ReadResource_Response{
+		NewState: &proto.DynamicValue{
+			Msgpack: []byte("\x81\xa4attr\xa3bar"),
+		},
+		NewIdentity: &proto.ResourceIdentityData{
+			IdentityData: &proto.DynamicValue{
+				Msgpack: []byte("\x81\xa7id_attr\xa3foo"),
+			},
+		},
+	}, nil)
+
+	p := &GRPCProvider{
+		client: client,
+	}
+
+	resp := p.ReadResource(providers.ReadResourceRequest{
+		TypeName: "resource",
+		PriorState: cty.ObjectVal(map[string]cty.Value{
+			"attr": cty.StringVal("foo"),
+		}),
+	})
+
+	checkDiagsHasError(t, resp.Diagnostics)
+	if got := resp.Diagnostics.Err().Error(); !strings.Contains(got, `unknown identity type "resource"`) {
+		t.Fatalf("expected unknown identity type diagnostic, got %q", got)
+	}
+
+	expected := cty.ObjectVal(map[string]cty.Value{
+		"attr": cty.StringVal("bar"),
+	})
 	if !cmp.Equal(expected, resp.NewState, typeComparer, valueComparer, equateEmpty) {
 		t.Fatal(cmp.Diff(expected, resp.NewState, typeComparer, valueComparer, equateEmpty))
 	}


### PR DESCRIPTION
## What changed

This updates the gRPC provider `ReadResource` implementations for protocol 5 and protocol 6 to return immediately after appending the missing identity schema diagnostic.

I also added matching regression tests for both implementations.

## Why

If a provider returns `NewIdentity` for a resource type whose schema does not include an identity schema, Terraform currently appends an error diagnostic and then continues into `resSchema.Identity.ImpliedType()`. That can panic instead of returning the diagnostic.

## Testing

- `go test ./internal/plugin -run 'TestGRPCProvider_ReadResource(_missingIdentitySchema)?$'`
- `go test ./internal/plugin6 -run 'TestGRPCProvider_ReadResource(_missingIdentitySchema)?$'`
- `go test ./internal/plugin`
- `go test ./internal/plugin6`
