### PR TITLE
fix: data race in checks.State.ObjectFailureMessages

### DIFF
--- a/.changes/v1.16/BUG FIXES-20260604-213420.yaml
+++ b/.changes/v1.16/BUG FIXES-20260604-213420.yaml
@@ -1,0 +1,5 @@
+kind: BUG FIXES
+body: 'checks: Fix a data race in State.ObjectFailureMessages that could cause a panic or incorrect results when checks are evaluated concurrently'
+time: 2026-06-04T21:34:20+03:00
+custom:
+    Issue: "38684"

--- a/internal/checks/state.go
+++ b/internal/checks/state.go
@@ -258,6 +258,9 @@ func (c *State) ObjectCheckStatus(addr addrs.Checkable) Status {
 // ObjectCheckStatus's result because errors are defined as "stronger"
 // than failures.
 func (c *State) ObjectFailureMessages(addr addrs.Checkable) []string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
 	var ret []string
 
 	configAddr := addr.ConfigCheckable()

--- a/internal/checks/state_test.go
+++ b/internal/checks/state_test.go
@@ -4,6 +4,8 @@
 package checks_test
 
 import (
+	"fmt"
+	"sync"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -210,4 +212,63 @@ func TestChecksHappyPath(t *testing.T) {
 			}
 		}
 	}
+}
+
+// TestStateObjectFailureMessagesConcurrent is a regression test, meaningful
+// only under `go test -race`, for a data race where ObjectFailureMessages
+// read the shared maps without c.mu while the Report* methods wrote them.
+func TestStateObjectFailureMessagesConcurrent(t *testing.T) {
+	const fixtureDir = "testdata/happypath"
+
+	cfg, _, configCleanup := tftesting.MustLoadConfigForTests(t, fixtureDir, "tests")
+	t.Cleanup(configCleanup)
+
+	// null_resource.c declares a postcondition, and State doesn't validate
+	// instance keys against the count, so we can register extra instances to
+	// keep the writers and readers contending.
+	resourceC := addrs.Resource{
+		Mode: addrs.ManagedResourceMode,
+		Type: "null_resource",
+		Name: "c",
+	}.InModule(addrs.RootModule.Child("child"))
+	moduleChildInst := addrs.RootModuleInstance.Child("child", addrs.NoKey)
+
+	state := checks.NewState(cfg)
+
+	const instanceCount = 64
+	objects := make([]addrs.Checkable, instanceCount)
+	objectSet := addrs.MakeSet[addrs.Checkable]()
+	for i := range objects {
+		inst := resourceC.Resource.Absolute(moduleChildInst).Instance(addrs.IntKey(i))
+		objects[i] = inst
+		objectSet.Add(inst)
+	}
+	state.ReportCheckableObjects(resourceC, objectSet)
+
+	var wg sync.WaitGroup
+
+	// Writers: one failure per object, so no check address is reported twice.
+	for i, obj := range objects {
+		wg.Add(1)
+		go func(i int, obj addrs.Checkable) {
+			defer wg.Done()
+			state.ReportCheckFailure(obj, addrs.ResourcePostcondition, 0, fmt.Sprintf("failure %d", i))
+		}(i, obj)
+	}
+
+	// Readers: read every object's failure messages while the writers run.
+	const readers = 8
+	for r := 0; r < readers; r++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for n := 0; n < 100; n++ {
+				for _, obj := range objects {
+					_ = state.ObjectFailureMessages(obj)
+				}
+			}
+		}()
+	}
+
+	wg.Wait()
 }


### PR DESCRIPTION
`State.ObjectFailureMessages` reads the shared `statuses` and `failureMsgs`
maps without taking `c.mu`, but the `Report*` methods write to those same maps
under the lock while Terraform Core walks the graph concurrently. That's a data
race — under `-race` it's flagged as one, and in the worst case it surfaces as a
`concurrent map read and map write` panic or as wrong/missing failure messages.

The fix just holds `c.mu` for the duration of the read, the same way every other
reader on `*State` already does (e.g. `ObjectCheckStatus`). The method doesn't
call back into any other `*State` method, so there's no risk of deadlocking on
the non-reentrant mutex.

I also added a regression test that runs concurrent writers and readers against a
single `State`. It reports a race under `go test -race ./internal/checks/...`
without the lock and passes with it.

Fixes #38578

## Target Release

1.16.x

This has been latent since #31268, so it's also a reasonable backport candidate
if the team wants it in a patch release.

## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

No. This only adds a mutex lock around an existing read — no changes to access
controls, encryption, or logging.

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## CHANGELOG entry

- [x] This change is user-facing and I added a changelog entry.
- [ ] This change is not user-facing.
