### PR TITLE
Fix exit code for plan, query, and refresh commands for variable-related errors

### DIFF
--- a/.changes/v1.15/BUG FIXES-20260605-121146.yaml
+++ b/.changes/v1.15/BUG FIXES-20260605-121146.yaml
@@ -1,0 +1,5 @@
+kind: BUG FIXES
+body: Fix exit code for plan, query, and refresh commands for variable-related errors
+time: 2026-06-05T12:11:46.24682+02:00
+custom:
+    Issue: "38685"

--- a/internal/command/plan.go
+++ b/internal/command/plan.go
@@ -97,6 +97,9 @@ func (c *PlanCommand) Run(rawArgs []string) int {
 	// we've accumulated here, since the backend will start fresh with its own
 	// diagnostics.
 	view.Diagnostics(diags)
+	if diags.HasErrors() {
+		return 1
+	}
 	diags = nil
 
 	// Perform the operation

--- a/internal/command/plan_test.go
+++ b/internal/command/plan_test.go
@@ -1325,6 +1325,50 @@ func TestPlan_varFileWithDecls(t *testing.T) {
 	}
 }
 
+// TestPlan_varFileDuplicateAttr is a regression test for a bug where a
+// -var-file containing a duplicated attribute would print an error diagnostic
+// but still exit 0, silently discarding the file and falling back to other
+// variable sources (here, the variable's default value). A malformed var file
+// must cause the plan to fail.
+func TestPlan_varFileDuplicateAttr(t *testing.T) {
+	td := t.TempDir()
+	testCopyDir(t, testFixturePath("plan-duplicate-var-file"), td)
+	t.Chdir(td)
+
+	p := planVarsFixtureProvider()
+	planned := false
+	p.PlanResourceChangeFn = func(req providers.PlanResourceChangeRequest) (resp providers.PlanResourceChangeResponse) {
+		planned = true
+		resp.PlannedState = req.ProposedNewState
+		return
+	}
+
+	view, done := testView(t)
+	c := &PlanCommand{
+		Meta: Meta{
+			testingOverrides: metaOverridesForProvider(p),
+			View:             view,
+		},
+	}
+
+	args := []string{
+		"-var-file", "duplicate.tfvars",
+	}
+	code := c.Run(args)
+	output := done(t)
+	if code == 0 {
+		t.Fatalf("succeeded; want failure with a non-zero exit code\n\n%s", output.Stdout())
+	}
+
+	if got, want := output.Stderr(), "Attribute redefined"; !strings.Contains(got, want) {
+		t.Fatalf("missing expected error message\nwant message containing %q\ngot:\n%s", want, got)
+	}
+
+	if planned {
+		t.Fatal("plan proceeded using the variable's default value; the malformed var file should have aborted the operation")
+	}
+}
+
 func TestPlan_detailedExitcode(t *testing.T) {
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("plan"), td)

--- a/internal/command/query.go
+++ b/internal/command/query.go
@@ -136,6 +136,9 @@ func (c *QueryCommand) Run(rawArgs []string) int {
 	// we've accumulated here, since the backend will start fresh with its own
 	// diagnostics.
 	view.Diagnostics(diags)
+	if diags.HasErrors() {
+		return 1
+	}
 	diags = nil
 
 	// Perform the operation

--- a/internal/command/query_test.go
+++ b/internal/command/query_test.go
@@ -248,6 +248,50 @@ this variable.
 	}
 }
 
+// TestQuery_varFileDuplicateAttr is a regression test for a bug where a
+// -var-file containing a duplicated attribute would print an error diagnostic
+// but still exit 0, silently discarding the file and falling back to other
+// variable sources. A malformed var file must cause the query to fail.
+func TestQuery_varFileDuplicateAttr(t *testing.T) {
+	td := t.TempDir()
+	testCopyDir(t, testFixturePath(path.Join("query", "duplicate-var-file")), td)
+	t.Chdir(td)
+
+	providerSource := newMockProviderSource(t, map[string][]string{
+		"hashicorp/test": {"1.0.0"},
+	})
+
+	p := queryFixtureProvider()
+	view, done := testView(t)
+	meta := Meta{
+		testingOverrides:          metaOverridesForProvider(p),
+		View:                      view,
+		AllowExperimentalFeatures: true,
+		ProviderSource:            providerSource,
+	}
+
+	init := &InitCommand{Meta: meta}
+	initCode := init.Run(nil)
+	initOutput := done(t)
+	if initCode != 0 {
+		t.Fatalf("init failed: %d\n\n%s", initCode, initOutput.All())
+	}
+
+	view, done = testView(t)
+	meta.View = view
+
+	c := &QueryCommand{Meta: meta}
+	code := c.Run([]string{"-no-color", "-var-file=duplicate.tfvars"})
+	output := done(t)
+	if code == 0 {
+		t.Fatalf("succeeded; want failure with a non-zero exit code\n\n%s", output.Stdout())
+	}
+
+	if got, want := output.Stderr(), "Attribute redefined"; !strings.Contains(got, want) {
+		t.Fatalf("missing expected error message\nwant message containing %q\ngot:\n%s", want, got)
+	}
+}
+
 func queryFixtureProvider() *testing_provider.MockProvider {
 	p := testProvider()
 	instanceListSchema := &configschema.Block{

--- a/internal/command/refresh.go
+++ b/internal/command/refresh.go
@@ -93,6 +93,9 @@ func (c *RefreshCommand) Run(rawArgs []string) int {
 	// we've accumulated here, since the backend will start fresh with its own
 	// diagnostics.
 	view.Diagnostics(diags)
+	if diags.HasErrors() {
+		return 1
+	}
 	diags = nil
 
 	// Perform the operation

--- a/internal/command/refresh_test.go
+++ b/internal/command/refresh_test.go
@@ -460,6 +460,48 @@ func TestRefresh_varFile(t *testing.T) {
 	}
 }
 
+// TestRefresh_varFileDuplicateAttr is a regression test for a bug where a
+// -var-file containing a duplicated attribute would print an error diagnostic
+// but still exit 0, silently discarding the file and falling back to other
+// variable sources (here, the variable's default value). A malformed var file
+// must cause the refresh to fail.
+func TestRefresh_varFileDuplicateAttr(t *testing.T) {
+	td := t.TempDir()
+	testCopyDir(t, testFixturePath("refresh-duplicate-var-file"), td)
+	t.Chdir(td)
+
+	state := testState()
+	statePath := testStateFile(t, state)
+
+	p := testProvider()
+	p.GetProviderSchemaResponse = refreshVarFixtureSchema()
+	view, done := testView(t)
+	c := &RefreshCommand{
+		Meta: Meta{
+			testingOverrides: metaOverridesForProvider(p),
+			View:             view,
+		},
+	}
+
+	args := []string{
+		"-var-file", "duplicate.tfvars",
+		"-state", statePath,
+	}
+	code := c.Run(args)
+	output := done(t)
+	if code == 0 {
+		t.Fatalf("succeeded; want failure with a non-zero exit code\n\n%s", output.Stdout())
+	}
+
+	if got, want := output.Stderr(), "Attribute redefined"; !strings.Contains(got, want) {
+		t.Fatalf("missing expected error message\nwant message containing %q\ngot:\n%s", want, got)
+	}
+
+	if p.ConfigureProviderCalled {
+		t.Fatal("refresh proceeded using the variable's default value; the malformed var file should have aborted the operation")
+	}
+}
+
 func TestRefresh_varFileDefault(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()

--- a/internal/command/show.go
+++ b/internal/command/show.go
@@ -80,6 +80,10 @@ func (c *ShowCommand) Run(rawArgs []string) int {
 		loader.Parser().ForceFileSource(filename, src)
 	})
 	diags = diags.Append(varDiags)
+	if varDiags.HasErrors() {
+		view.Diagnostics(diags)
+		return 1
+	}
 
 	// Check for user-supplied plugin path
 	if c.pluginPath, err = c.loadPluginPath(); err != nil {

--- a/internal/command/show_test.go
+++ b/internal/command/show_test.go
@@ -361,6 +361,42 @@ func TestShow_planWithChanges(t *testing.T) {
 	}
 }
 
+// TestShow_planWithVarFileDuplicateAttr checks that a -var-file containing a
+// duplicated attribute causes show to fail, rather than silently swallowing
+// the error and exiting 0.
+func TestShow_planWithVarFileDuplicateAttr(t *testing.T) {
+	planPath := showFixturePlanFile(t, plans.Create)
+
+	varFilePath := testTempFile(t)
+	if err := os.WriteFile(varFilePath, []byte("foo = \"first\"\nfoo = \"second\"\n"), 0644); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	view, done := testView(t)
+	c := &ShowCommand{
+		Meta: Meta{
+			testingOverrides: metaOverridesForProvider(showFixtureProvider()),
+			View:             view,
+		},
+	}
+
+	args := []string{
+		"-no-color",
+		"-var-file", varFilePath,
+		planPath,
+	}
+	code := c.Run(args)
+	output := done(t)
+
+	if code == 0 {
+		t.Fatalf("succeeded; want failure with a non-zero exit code\n\nstdout:\n%s", output.Stdout())
+	}
+
+	if got, want := output.Stderr(), "Attribute redefined"; !strings.Contains(got, want) {
+		t.Fatalf("missing expected error message\nwant message containing %q\ngot:\n%s", want, got)
+	}
+}
+
 func TestShow_planWithForceReplaceChange(t *testing.T) {
 	// The main goal of this test is to see that the "replace by request"
 	// resource instance action reason can round-trip through a plan file and

--- a/internal/command/testdata/plan-duplicate-var-file/duplicate.tfvars
+++ b/internal/command/testdata/plan-duplicate-var-file/duplicate.tfvars
@@ -1,0 +1,2 @@
+foo = "first"
+foo = "second"

--- a/internal/command/testdata/plan-duplicate-var-file/main.tf
+++ b/internal/command/testdata/plan-duplicate-var-file/main.tf
@@ -1,0 +1,7 @@
+variable "foo" {
+    default = "default-value"
+}
+
+resource "test_instance" "foo" {
+    value = var.foo
+}

--- a/internal/command/testdata/query/duplicate-var-file/duplicate.tfvars
+++ b/internal/command/testdata/query/duplicate-var-file/duplicate.tfvars
@@ -1,0 +1,2 @@
+target_ami = "ami-aaa"
+target_ami = "ami-bbb"

--- a/internal/command/testdata/query/duplicate-var-file/main.tf
+++ b/internal/command/testdata/query/duplicate-var-file/main.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_providers {
+    test = {
+      source = "hashicorp/test"
+    }
+  }
+}
+
+provider "test" {}

--- a/internal/command/testdata/query/duplicate-var-file/query.tfquery.hcl
+++ b/internal/command/testdata/query/duplicate-var-file/query.tfquery.hcl
@@ -1,0 +1,12 @@
+variable "target_ami" {
+  description = "The AMI to search for"
+  type        = string
+}
+
+list "test_instance" "example" {
+  provider = test
+
+  config {
+    ami = var.target_ami
+  }
+}

--- a/internal/command/testdata/refresh-duplicate-var-file/duplicate.tfvars
+++ b/internal/command/testdata/refresh-duplicate-var-file/duplicate.tfvars
@@ -1,0 +1,2 @@
+foo = "first"
+foo = "second"

--- a/internal/command/testdata/refresh-duplicate-var-file/main.tf
+++ b/internal/command/testdata/refresh-duplicate-var-file/main.tf
@@ -1,0 +1,9 @@
+variable "foo" {
+    default = "default-value"
+}
+
+provider "test" {
+    value = var.foo
+}
+
+resource "test_instance" "foo" {}


### PR DESCRIPTION
This PR fixes a regression introduced in 1.15. Some commands (plan, query, show, refresh) did not check for errors after variable value collection. A malformed `.tfvars` file would no longer abort `plan`, so a pipeline would proceed with the wrong values without any signal of failure.

Fixes [IPL-9558](https://hashicorp.atlassian.net/browse/IPL-9558)

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.15.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [x] This change is user-facing and I added a changelog entry.
- [ ] This change is not user-facing.


[IPL-9558]: https://hashicorp.atlassian.net/browse/IPL-9558?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ