### PR TITLE
refactor: Make `providers schema` and `state show` commands use `(Meta).WorkingDir.RootModuleDir` over `os.Getwd`

### DIFF
--- a/internal/command/meta.go
+++ b/internal/command/meta.go
@@ -845,6 +845,8 @@ func (m *Meta) applyStateArguments(args *arguments.State) {
 func (m *Meta) checkRequiredVersion() tfdiags.Diagnostics {
 	var diags tfdiags.Diagnostics
 
+	// Cannot use m.WorkingDir.RootModuleDir() here because
+	// of path normalization that happens in loadConfig.
 	pwd, err := os.Getwd()
 	if err != nil {
 		diags = diags.Append(fmt.Errorf("Error getting pwd: %s", err))
@@ -879,6 +881,8 @@ func (m *Meta) checkRequiredVersion() tfdiags.Diagnostics {
 func (c *Meta) MaybeGetSchemas(state *states.State, config *configs.Config) (*terraform.Schemas, tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
 
+	// Cannot use m.WorkingDir.RootModuleDir() here because
+	// of path normalization that happens in loadConfig.
 	path, err := os.Getwd()
 	if err != nil {
 		diags = diags.Append(tfdiags.SimpleWarning(failedToLoadSchemasMessage))

--- a/internal/command/providers_schema.go
+++ b/internal/command/providers_schema.go
@@ -5,7 +5,6 @@ package command
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/hashicorp/terraform/internal/backend/backendrun"
 	"github.com/hashicorp/terraform/internal/command/arguments"
@@ -61,12 +60,8 @@ func (c *ProvidersSchemaCommand) Run(args []string) int {
 	// This is a read-only command
 	c.ignoreRemoteVersionConflict(b)
 
-	// we expect that the config dir is the cwd
-	cwd, err := os.Getwd()
-	if err != nil {
-		c.Ui.Error(fmt.Sprintf("Error getting cwd: %s", err))
-		return 1
-	}
+	// Get the config directory
+	cwd := c.WorkingDir.RootModuleDir()
 
 	// Build the operation
 	opReq := c.Operation(b, arguments.ViewJSON)

--- a/internal/command/providers_schema_test.go
+++ b/internal/command/providers_schema_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/hashicorp/terraform/internal/backend"
 	backendInit "github.com/hashicorp/terraform/internal/backend/init"
 	backendCloud "github.com/hashicorp/terraform/internal/cloud"
+	"github.com/hashicorp/terraform/internal/command/workdir"
 
 	"github.com/hashicorp/terraform/internal/configs/configschema"
 	"github.com/hashicorp/terraform/internal/providers"
@@ -108,6 +109,58 @@ func TestProvidersSchema_output(t *testing.T) {
 				t.Fatalf("wrong result:\n %v\n", cmp.Diff(got, want))
 			}
 		})
+	}
+}
+
+// Test that provider schema data can be obtained based on directory data set in the Meta,
+// not by relying on code upstream from the command having changed the working directory.
+// This test mimics a user running `terraform -chdir=<dir> providers schema`
+func TestProvidersSchema_output_withOverriddenWorkingDir(t *testing.T) {
+	fixtureDir := "providers-schema/basic"
+	td := t.TempDir()
+	testCopyDir(t, testFixturePath(fixtureDir), td)
+
+	// We don't call t.Chdir, intentionally.
+
+	p := providersSchemaFixtureProvider()
+	ui := new(cli.MockUi)
+	c := &ProvidersSchemaCommand{
+		Meta: Meta{
+			Ui:               ui,
+			testingOverrides: metaOverridesForProvider(p),
+
+			// Setting WorkingDir mimics what calling code would do
+			// when running a command with -chdir.
+			WorkingDir: workdir.NewDir(td),
+		},
+	}
+
+	args := []string{
+		"-json",
+	}
+	if code := c.Run(args); code != 0 {
+		t.Fatalf("bad: %d\n\n%s", code, ui.ErrorWriter.String())
+	}
+
+	// Assert we got the expected output, despite no changing into that directory.
+	var got, want providerSchemas
+
+	gotString := ui.OutputWriter.String()
+	json.Unmarshal([]byte(gotString), &got)
+
+	wantFile, err := os.Open(filepath.Join(td, "output.json"))
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	defer wantFile.Close()
+	byteValue, err := io.ReadAll(wantFile)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	json.Unmarshal([]byte(byteValue), &want)
+
+	if !cmp.Equal(got, want) {
+		t.Fatalf("wrong result:\n %v\n", cmp.Diff(got, want))
 	}
 }
 

--- a/internal/command/state_show.go
+++ b/internal/command/state_show.go
@@ -6,7 +6,6 @@ package command
 import (
 	"errors"
 	"fmt"
-	"os"
 	"strings"
 
 	"github.com/hashicorp/terraform/internal/addrs"
@@ -75,11 +74,7 @@ func (c *StateShowCommand) Run(args []string) int {
 	}
 
 	// We expect the config dir to always be the cwd
-	cwd, err := os.Getwd()
-	if err != nil {
-		diags = diags.Append(fmt.Sprintf("Error getting cwd: %s\n", err))
-		return view.DisplayResourceInstanceState(jsonformat.State{}, diags)
-	}
+	cwd := c.WorkingDir.RootModuleDir()
 
 	// Build the operation (required to get the schemas)
 	opReq := c.Operation(b, c.viewType)


### PR DESCRIPTION
# Background (chat, bear with me)

After https://github.com/hashicorp/terraform/pull/38679 I was poking around limitations stopping integration tests being made to run in parallel. One limitation is that a bunch of tests rely on using `t.Chdir` to make the Terraform code execute directly in a temp directory containing a copy of test fixtures.

In an ideal world this wouldn't be necessary; we could set [the WorkingDir field](https://github.com/hashicorp/terraform/blob/68a3d31a92728458d35e169704159a44afb32340/internal/command/meta.go#L64) in the `Meta` in our tests to point at a temp dir. When terraform CLI is used directly [this field is set](https://github.com/hashicorp/terraform/blob/68a3d31a92728458d35e169704159a44afb32340/commands.go#L89) to whatever the current dir is, and upstream code [changes the current dir](https://github.com/hashicorp/terraform/blob/68a3d31a92728458d35e169704159a44afb32340/main.go#L234) based on any values supplied via the -chdir flag. So in theory all downstream code could just use the value of the WorkingDir field and not call os.Getwd directly. Unfortunately that's not the state of the codebase currently, and lots of code uses `os.Getwd` and relies on `os.Chdir` having been called in `main.go`.

In some places, i.e. places with access to the `Meta` and its `WorkingDir` field, we can remove that downstream use of `os.Getwd`. There are several other places where we currently cannot do that. For example, the local backend uses the Filesystem state manager and this is influenced by the current directory (e.g. [when reading in state](https://github.com/hashicorp/terraform/blob/68a3d31a92728458d35e169704159a44afb32340/internal/states/statemgr/filesystem.go#L267)).

_Edit: I also found that loadConfig has some path normalization logic that doesn't work when the current dir does not match the WorkingDir path, so I'm steering clear of things impacted by that! I added some comments to areas I found like this._

# This PR

This PR is an example of removing use of `os.Getwd` in places that have access to the `Meta`. This is just a refactor and there is no user-facing impact; when users use the CLI main.go will change the current directory to match any `-chdir` flag path and then the `WorkingDir` field used in this PR's diffs is set using the (new) current directory's path.

Also, I've added some comments to areas where this type of refactoring isn't appropriate, because config parsing happens downstream.

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.16.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
