### PR TITLE
test: Update some tests in command package to use t.Parallel

### DIFF
--- a/internal/command/cli_ui_test.go
+++ b/internal/command/cli_ui_test.go
@@ -10,5 +10,6 @@ import (
 )
 
 func TestColorizeUi_impl(t *testing.T) {
+	t.Parallel()
 	var _ cli.Ui = new(ColorizeUi)
 }

--- a/internal/command/flag_kv_test.go
+++ b/internal/command/flag_kv_test.go
@@ -10,10 +10,12 @@ import (
 )
 
 func TestFlagStringKV_impl(t *testing.T) {
+	t.Parallel()
 	var _ flag.Value = new(FlagStringKV)
 }
 
 func TestFlagStringKV(t *testing.T) {
+	t.Parallel()
 	cases := []struct {
 		Input  string
 		Output map[string]string

--- a/internal/command/fmt_test.go
+++ b/internal/command/fmt_test.go
@@ -16,6 +16,7 @@ import (
 )
 
 func TestFmt_MockDataFiles(t *testing.T) {
+	t.Parallel()
 	const inSuffix = "_in.tfmock.hcl"
 	const outSuffix = "_out.tfmock.hcl"
 	const gotSuffix = "_got.tfmock.hcl"
@@ -39,6 +40,7 @@ func TestFmt_MockDataFiles(t *testing.T) {
 		}
 		testName := filename[:len(filename)-len(inSuffix)]
 		t.Run(testName, func(t *testing.T) {
+			t.Parallel()
 			inFile := filepath.Join("testdata", "tfmock-fmt", testName+inSuffix)
 			wantFile := filepath.Join("testdata", "tfmock-fmt", testName+outSuffix)
 			gotFile := filepath.Join(tmpDir, testName+gotSuffix)
@@ -80,6 +82,7 @@ func TestFmt_MockDataFiles(t *testing.T) {
 }
 
 func TestFmt_TestFiles(t *testing.T) {
+	t.Parallel()
 	const inSuffix = "_in.tftest.hcl"
 	const outSuffix = "_out.tftest.hcl"
 	const gotSuffix = "_got.tftest.hcl"
@@ -103,6 +106,7 @@ func TestFmt_TestFiles(t *testing.T) {
 		}
 		testName := filename[:len(filename)-len(inSuffix)]
 		t.Run(testName, func(t *testing.T) {
+			t.Parallel()
 			inFile := filepath.Join("testdata", "tftest-fmt", testName+inSuffix)
 			wantFile := filepath.Join("testdata", "tftest-fmt", testName+outSuffix)
 			gotFile := filepath.Join(tmpDir, testName+gotSuffix)
@@ -144,6 +148,7 @@ func TestFmt_TestFiles(t *testing.T) {
 }
 
 func TestFmt_QueryFiles(t *testing.T) {
+	t.Parallel()
 	const inSuffix = "_in.tfquery.hcl"
 	const outSuffix = "_out.tfquery.hcl"
 	const gotSuffix = "_got.tfquery.hcl"
@@ -167,6 +172,7 @@ func TestFmt_QueryFiles(t *testing.T) {
 		}
 		testName := filename[:len(filename)-len(inSuffix)]
 		t.Run(testName, func(t *testing.T) {
+			t.Parallel()
 			inFile := filepath.Join("testdata", "tfquery-fmt", testName+inSuffix)
 			wantFile := filepath.Join("testdata", "tfquery-fmt", testName+outSuffix)
 			gotFile := filepath.Join(tmpDir, testName+gotSuffix)
@@ -208,6 +214,7 @@ func TestFmt_QueryFiles(t *testing.T) {
 }
 
 func TestFmt(t *testing.T) {
+	t.Parallel()
 	const inSuffix = "_in.tf"
 	const outSuffix = "_out.tf"
 	const gotSuffix = "_got.tf"
@@ -231,6 +238,7 @@ func TestFmt(t *testing.T) {
 		}
 		testName := filename[:len(filename)-len(inSuffix)]
 		t.Run(testName, func(t *testing.T) {
+			t.Parallel()
 			inFile := filepath.Join("testdata", "fmt", testName+inSuffix)
 			wantFile := filepath.Join("testdata", "fmt", testName+outSuffix)
 			gotFile := filepath.Join(tmpDir, testName+gotSuffix)
@@ -272,6 +280,8 @@ func TestFmt(t *testing.T) {
 }
 
 func TestFmt_nonexist(t *testing.T) {
+	t.Parallel()
+
 	tempDir := fmtFixtureWriteDir(t)
 
 	ui := new(cli.MockUi)
@@ -295,6 +305,8 @@ func TestFmt_nonexist(t *testing.T) {
 }
 
 func TestFmt_syntaxError(t *testing.T) {
+	t.Parallel()
+
 	tempDir := testTempDir(t)
 
 	invalidSrc := `
@@ -326,6 +338,8 @@ a = 1 +
 }
 
 func TestFmt_snippetInError(t *testing.T) {
+	t.Parallel()
+
 	tempDir := testTempDir(t)
 
 	backendSrc := `terraform {backend "s3" {}}`
@@ -361,6 +375,8 @@ func TestFmt_snippetInError(t *testing.T) {
 }
 
 func TestFmt_manyArgs(t *testing.T) {
+	t.Parallel()
+
 	tempDir := fmtFixtureWriteDir(t)
 	// Add a second file
 	secondSrc := `locals { x = 1 }`
@@ -430,6 +446,7 @@ func TestFmt_workingDirectory(t *testing.T) {
 }
 
 func TestFmt_directoryArg(t *testing.T) {
+	t.Parallel()
 	tempDir := fmtFixtureWriteDir(t)
 
 	ui := new(cli.MockUi)
@@ -457,6 +474,7 @@ func TestFmt_directoryArg(t *testing.T) {
 }
 
 func TestFmt_fileArg(t *testing.T) {
+	t.Parallel()
 	tempDir := fmtFixtureWriteDir(t)
 
 	ui := new(cli.MockUi)
@@ -484,6 +502,7 @@ func TestFmt_fileArg(t *testing.T) {
 }
 
 func TestFmt_stdinArg(t *testing.T) {
+	t.Parallel()
 	input := new(bytes.Buffer)
 	input.Write(fmtFixture.input)
 
@@ -508,6 +527,7 @@ func TestFmt_stdinArg(t *testing.T) {
 }
 
 func TestFmt_nonDefaultOptions(t *testing.T) {
+	t.Parallel()
 	tempDir := fmtFixtureWriteDir(t)
 
 	ui := new(cli.MockUi)
@@ -535,6 +555,7 @@ func TestFmt_nonDefaultOptions(t *testing.T) {
 }
 
 func TestFmt_check(t *testing.T) {
+	t.Parallel()
 	tempDir := fmtFixtureWriteDir(t)
 
 	ui := new(cli.MockUi)
@@ -563,6 +584,7 @@ func TestFmt_check(t *testing.T) {
 }
 
 func TestFmt_checkStdin(t *testing.T) {
+	t.Parallel()
 	input := new(bytes.Buffer)
 	input.Write(fmtFixture.input)
 

--- a/internal/command/logout_test.go
+++ b/internal/command/logout_test.go
@@ -16,6 +16,7 @@ import (
 )
 
 func TestLogout(t *testing.T) {
+	t.Parallel()
 	workDir := t.TempDir()
 
 	ui := cli.NewMockUi()

--- a/internal/command/metadata_functions_test.go
+++ b/internal/command/metadata_functions_test.go
@@ -11,6 +11,7 @@ import (
 )
 
 func TestMetadataFunctions_error(t *testing.T) {
+	t.Parallel()
 	ui := new(cli.MockUi)
 	c := &MetadataFunctionsCommand{
 		Meta: Meta{
@@ -25,6 +26,7 @@ func TestMetadataFunctions_error(t *testing.T) {
 }
 
 func TestMetadataFunctions_output(t *testing.T) {
+	t.Parallel()
 	ui := new(cli.MockUi)
 	m := Meta{Ui: ui}
 	c := &MetadataFunctionsCommand{Meta: m}

--- a/internal/command/plugins_lock_test.go
+++ b/internal/command/plugins_lock_test.go
@@ -4,14 +4,14 @@
 package command
 
 import (
-	"io/ioutil"
 	"os"
 	"reflect"
 	"testing"
 )
 
 func TestPluginSHA256LockFile_Read(t *testing.T) {
-	f, err := ioutil.TempFile(t.TempDir(), "tf-pluginsha1lockfile-test-")
+	t.Parallel()
+	f, err := os.CreateTemp(t.TempDir(), "tf-pluginsha1lockfile-test-")
 	if err != nil {
 		t.Fatalf("failed to create temporary file: %s", err)
 	}

--- a/internal/command/stacks_test.go
+++ b/internal/command/stacks_test.go
@@ -11,6 +11,7 @@ import (
 )
 
 func TestStacksPluginConfig_ToMetadata(t *testing.T) {
+	t.Parallel()
 	expected := metadata.Pairs(
 		"tfc-address", "https://app.staging.terraform.io",
 		"tfc-base-path", "/api/v2/",

--- a/internal/command/ui_input_test.go
+++ b/internal/command/ui_input_test.go
@@ -16,10 +16,12 @@ import (
 )
 
 func TestUIInput_impl(t *testing.T) {
+	t.Parallel()
 	var _ terraform.UIInput = new(UIInput)
 }
 
 func TestUIInputInput(t *testing.T) {
+	t.Parallel()
 	i := &UIInput{
 		Reader: bytes.NewBufferString("foo\n"),
 		Writer: bytes.NewBuffer(nil),
@@ -36,6 +38,7 @@ func TestUIInputInput(t *testing.T) {
 }
 
 func TestUIInputInput_canceled(t *testing.T) {
+	t.Parallel()
 	r, w := io.Pipe()
 	i := &UIInput{
 		Reader: r,
@@ -86,6 +89,7 @@ func TestUIInputInput_canceled(t *testing.T) {
 }
 
 func TestUIInputInput_spaces(t *testing.T) {
+	t.Parallel()
 	i := &UIInput{
 		Reader: bytes.NewBufferString("foo bar\n"),
 		Writer: bytes.NewBuffer(nil),
@@ -102,6 +106,7 @@ func TestUIInputInput_spaces(t *testing.T) {
 }
 
 func TestUIInputInput_Error(t *testing.T) {
+	t.Parallel()
 	i := &UIInput{
 		Reader: bytes.NewBuffer(nil),
 		Writer: bytes.NewBuffer(nil),

--- a/internal/command/workspace_command_test.go
+++ b/internal/command/workspace_command_test.go
@@ -1100,17 +1100,16 @@ func TestWorkspace_envCommandDeprecationWarnings(t *testing.T) {
 
 // Test how all workspace subcommands handle unexpected arguments.
 func TestWorkspace_extraArgError(t *testing.T) {
+	t.Parallel()
+
+	// No temp directory needed as the tests check argument parsing.
+
 	newMeta := func() (Meta, *cli.MockUi) {
 		ui := new(cli.MockUi)
 		return Meta{
-			Ui:         ui,
-			WorkingDir: workdir.NewDir("."),
+			Ui: ui,
 		}, ui
 	}
-
-	// Create a temporary working directory that is empty
-	td := t.TempDir()
-	t.Chdir(td)
 
 	// New
 	meta, ui := newMeta()


### PR DESCRIPTION
I went looking for places we could use `t.Parallel` in the `command` package's tests (chasing the high of https://github.com/hashicorp/terraform/pull/38679 😭 ) and realised that the tests there often change the current working directory so mostly are incapable of running in parallel.

This PR has a bunch of tests I found that _could_ be made to run in parallel but it has little to no impact on how long the `command` package's test suite runs for.

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.16.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
