### PR TITLE
refactor: Remove use of ModulePath func from multiple commands, and the codebase

### DIFF
--- a/internal/command/autocomplete.go
+++ b/internal/command/autocomplete.go
@@ -44,10 +44,7 @@ func (m *Meta) completePredictWorkspaceName() complete.Predictor {
 		// directory, since we don't have enough context to know where to
 		// find any config path argument, and it might be _after_ the argument
 		// we're trying to complete here anyway.
-		configPath, err := ModulePath(nil)
-		if err != nil {
-			return nil
-		}
+		configPath := m.WorkingDir.RootModuleDir()
 
 		b, diags := m.backend(configPath, arguments.ViewHuman)
 		if diags.HasErrors() {

--- a/internal/command/autocomplete_test.go
+++ b/internal/command/autocomplete_test.go
@@ -15,14 +15,16 @@ import (
 )
 
 func TestMetaCompletePredictWorkspaceName(t *testing.T) {
-
 	t.Run("test autocompletion using the local backend", func(t *testing.T) {
 		// Create a temporary working directory that is empty
 		td := t.TempDir()
 		t.Chdir(td)
 
 		ui := new(cli.MockUi)
-		meta := &Meta{Ui: ui}
+		meta := &Meta{
+			Ui:         ui,
+			WorkingDir: workdir.NewDir(td),
+		}
 
 		predictor := meta.completePredictWorkspaceName()
 
@@ -55,10 +57,8 @@ func TestMetaCompletePredictWorkspaceName(t *testing.T) {
 
 		ui := new(cli.MockUi)
 		view, _ := testView(t)
-		wd := workdir.NewDir(".")
-		wd.OverrideOriginalWorkingDir(td)
 		meta := Meta{
-			WorkingDir:                wd, // Use the test's temp dir
+			WorkingDir:                workdir.NewDir(td), // Use the test's temp dir
 			Ui:                        ui,
 			View:                      view,
 			AllowExperimentalFeatures: true,
@@ -98,10 +98,8 @@ func TestMetaCompletePredictWorkspaceName(t *testing.T) {
 
 		ui := new(cli.MockUi)
 		view, _ := testView(t)
-		wd := workdir.NewDir(".")
-		wd.OverrideOriginalWorkingDir(td)
 		meta := Meta{
-			WorkingDir:                wd, // Use the test's temp dir
+			WorkingDir:                workdir.NewDir(td), // Use the test's temp dir
 			Ui:                        ui,
 			View:                      view,
 			AllowExperimentalFeatures: true,

--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -4,8 +4,6 @@
 package command
 
 import (
-	"fmt"
-	"os"
 	"runtime"
 )
 
@@ -50,26 +48,3 @@ backend performs all operations locally on your machine. Your configuration
 is configured to use a non-local backend. This backend doesn't support this
 operation.
 `
-
-// ModulePath returns the path to the root module and validates CLI arguments.
-//
-// This centralizes the logic for any commands that previously accepted
-// a module path via CLI arguments. This will error if any extraneous arguments
-// are given and suggest using the -chdir flag instead.
-//
-// If your command accepts more than one arg, then change the slice bounds
-// to pass validation.
-func ModulePath(args []string) (string, error) {
-	// TODO: test
-
-	if len(args) > 0 {
-		return "", fmt.Errorf("Too many command line arguments. Did you mean to use -chdir?")
-	}
-
-	path, err := os.Getwd()
-	if err != nil {
-		return "", fmt.Errorf("Error getting pwd: %s", err)
-	}
-
-	return path, nil
-}

--- a/internal/command/get.go
+++ b/internal/command/get.go
@@ -45,12 +45,7 @@ func (c *GetCommand) Run(args []string) int {
 	ctx, done := c.InterruptibleContext(c.CommandContext())
 	defer done()
 
-	path, err := ModulePath(nil)
-	if err != nil {
-		c.Ui.Error(err.Error())
-		return 1
-	}
-
+	path := c.Meta.WorkingDir.RootModuleDir()
 	diags = diags.Append(c.resolveConstVariables(path, arguments.ViewHuman))
 	if diags.HasErrors() {
 		c.showDiagnostics(diags)

--- a/internal/command/graph.go
+++ b/internal/command/graph.go
@@ -32,13 +32,11 @@ func (c *GraphCommand) Run(rawArgs []string) int {
 		return 1
 	}
 
-	configPath, err := ModulePath(nil)
-	if err != nil {
-		c.Ui.Error(err.Error())
-		return 1
-	}
+	// Get the root module directory
+	configPath := c.Meta.WorkingDir.RootModuleDir()
 
 	// Check for user-supplied plugin path
+	var err error
 	if c.pluginPath, err = c.loadPluginPath(); err != nil {
 		c.Ui.Error(fmt.Sprintf("Error loading plugin path: %s", err))
 		return 1

--- a/internal/command/graph_test.go
+++ b/internal/command/graph_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/backend"
 	backendInit "github.com/hashicorp/terraform/internal/backend/init"
+	"github.com/hashicorp/terraform/internal/command/workdir"
 	"github.com/hashicorp/terraform/internal/configs/configload"
 	"github.com/hashicorp/terraform/internal/configs/configschema"
 	"github.com/hashicorp/terraform/internal/initwd"
@@ -27,9 +28,9 @@ import (
 )
 
 func TestGraph_planPhase(t *testing.T) {
+	t.Parallel() // possible because t.Chdir not needed
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("graph"), td)
-	t.Chdir(td)
 
 	ui := new(cli.MockUi)
 	streams, closeStreams := terminal.StreamsForTesting(t)
@@ -38,6 +39,7 @@ func TestGraph_planPhase(t *testing.T) {
 			testingOverrides: metaOverridesForProvider(applyFixtureProvider()),
 			Ui:               ui,
 			Streams:          streams,
+			WorkingDir:       workdir.NewDir(td),
 		},
 	}
 
@@ -53,9 +55,9 @@ func TestGraph_planPhase(t *testing.T) {
 }
 
 func TestGraph_cyclic(t *testing.T) {
+	t.Parallel() // possible because t.Chdir not needed
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("graph-cyclic"), td)
-	t.Chdir(td)
 
 	tests := []struct {
 		name     string
@@ -70,8 +72,10 @@ func TestGraph_cyclic(t *testing.T) {
 		{
 			name: "plan",
 			args: []string{"-type=plan"},
-			errors: []string{`Error: Cycle: test_instance.`,
-				`Error: Cycle: local.`},
+			errors: []string{
+				`Error: Cycle: test_instance.`,
+				`Error: Cycle: local.`,
+			},
 		},
 		{
 			name: "plan with -draw-cycles option",
@@ -102,8 +106,10 @@ func TestGraph_cyclic(t *testing.T) {
 			// The cyclic errors do not maintain a consistent order, so we can't
 			// predict the exact output. We'll just check that the error messages
 			// are present for the things we know are cyclic.
-			errors: []string{`Error: Cycle: test_instance.`,
-				`Error: Cycle: local.`},
+			errors: []string{
+				`Error: Cycle: test_instance.`,
+				`Error: Cycle: local.`,
+			},
 		},
 		{
 			name: "apply with -draw-cycles option",
@@ -139,6 +145,7 @@ func TestGraph_cyclic(t *testing.T) {
 					testingOverrides: metaOverridesForProvider(applyFixtureProvider()),
 					Ui:               ui,
 					Streams:          streams,
+					WorkingDir:       workdir.NewDir(td),
 				},
 			}
 
@@ -165,7 +172,6 @@ func TestGraph_cyclic(t *testing.T) {
 			if strings.TrimSpace(output.Stdout()) != strings.TrimSpace(tt.expected) {
 				t.Fatalf("expected dot graph to match:\n%s", cmp.Diff(output.Stdout(), tt.expected))
 			}
-
 		})
 	}
 }
@@ -189,9 +195,10 @@ func TestGraph_multipleArgs(t *testing.T) {
 }
 
 func TestGraph_noConfig(t *testing.T) {
+	t.Parallel() // possible because t.Chdir not needed
+
 	td := t.TempDir()
 	os.MkdirAll(td, 0755)
-	t.Chdir(td)
 
 	streams, closeStreams := terminal.StreamsForTesting(t)
 	defer closeStreams(t)
@@ -201,6 +208,7 @@ func TestGraph_noConfig(t *testing.T) {
 			testingOverrides: metaOverridesForProvider(applyFixtureProvider()),
 			Ui:               ui,
 			Streams:          streams,
+			WorkingDir:       workdir.NewDir(td),
 		},
 	}
 
@@ -214,7 +222,8 @@ func TestGraph_noConfig(t *testing.T) {
 
 func TestGraph_resourcesOnly(t *testing.T) {
 	wd := tempWorkingDirFixture(t, "graph-interesting")
-	t.Chdir(wd.RootModuleDir())
+	td := wd.RootModuleDir()
+	t.Chdir(td)
 
 	// The graph-interesting fixture has a child module, so we'll need to
 	// run the module installer just to get the working directory set up
@@ -257,8 +266,9 @@ func TestGraph_resourcesOnly(t *testing.T) {
 					addrs.NewDefaultProvider("foo"): providers.FactoryFixed(p),
 				},
 			},
-			Ui:      ui,
-			Streams: streams,
+			Ui:         ui,
+			Streams:    streams,
+			WorkingDir: workdir.NewDir(td),
 		},
 	}
 
@@ -346,6 +356,7 @@ func TestGraph_applyPhaseSavedPlan(t *testing.T) {
 			testingOverrides: metaOverridesForProvider(applyFixtureProvider()),
 			Ui:               ui,
 			Streams:          streams,
+			WorkingDir:       workdir.NewDir(tmp),
 		},
 	}
 
@@ -365,7 +376,7 @@ func TestGraph_applyPhaseSavedPlan(t *testing.T) {
 func TestGraph_constVariable(t *testing.T) {
 	t.Run("missing value", func(t *testing.T) {
 		wd := tempWorkingDirFixture(t, "dynamic-module-sources/command-with-const-var")
-		t.Chdir(wd.RootModuleDir())
+		// t.Chdir not needed
 
 		ui := cli.NewMockUi()
 		streams, closeStreams := terminal.StreamsForTesting(t)

--- a/internal/command/modules.go
+++ b/internal/command/modules.go
@@ -65,14 +65,8 @@ func (c *ModulesCommand) Run(rawArgs []string) int {
 		return 1
 	}
 
-	rootModPath, err := ModulePath([]string{})
-	if err != nil {
-		diags = diags.Append(err)
-		view.Diagnostics(diags)
-		return 1
-	}
-
 	// Read the root module path so we can then traverse the tree
+	rootModPath := c.Meta.WorkingDir.RootModuleDir()
 	rootModEarly, earlyConfDiags := c.loadSingleModule(rootModPath)
 	if rootModEarly == nil {
 		diags = diags.Append(errors.New("root module not found. Please run terraform init"), earlyConfDiags)

--- a/internal/command/providers.go
+++ b/internal/command/providers.go
@@ -37,11 +37,7 @@ func (c *ProvidersCommand) Run(args []string) int {
 		return 1
 	}
 
-	configPath, err := ModulePath(nil)
-	if err != nil {
-		c.Ui.Error(err.Error())
-		return 1
-	}
+	configPath := c.Meta.WorkingDir.RootModuleDir()
 
 	loader, err := c.initConfigLoader()
 	if err != nil {

--- a/internal/command/providers_test.go
+++ b/internal/command/providers_test.go
@@ -5,7 +5,6 @@ package command
 
 import (
 	"bytes"
-	"os"
 	"strings"
 	"testing"
 
@@ -13,25 +12,22 @@ import (
 	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/backend"
 	backendInit "github.com/hashicorp/terraform/internal/backend/init"
+	"github.com/hashicorp/terraform/internal/command/workdir"
 	"github.com/hashicorp/terraform/internal/providers"
 	"github.com/hashicorp/terraform/internal/states"
 	"github.com/hashicorp/terraform/internal/states/statefile"
 )
 
 func TestProviders(t *testing.T) {
-	cwd, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("err: %s", err)
-	}
-	if err := os.Chdir(testFixturePath("providers/basic")); err != nil {
-		t.Fatalf("err: %s", err)
-	}
-	defer os.Chdir(cwd)
+	td := t.TempDir()
+	testCopyDir(t, testFixturePath("providers/basic"), td)
+	t.Chdir(td)
 
 	ui := new(cli.MockUi)
 	c := &ProvidersCommand{
 		Meta: Meta{
-			Ui: ui,
+			Ui:         ui,
+			WorkingDir: workdir.NewDir(td),
 		},
 	}
 
@@ -55,19 +51,15 @@ func TestProviders(t *testing.T) {
 }
 
 func TestProviders_noConfigs(t *testing.T) {
-	cwd, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("err: %s", err)
-	}
-	if err := os.Chdir(testFixturePath("")); err != nil {
-		t.Fatalf("err: %s", err)
-	}
-	defer os.Chdir(cwd)
+	td := t.TempDir()
+	testCopyDir(t, testFixturePath(""), td)
+	t.Chdir(td)
 
 	ui := new(cli.MockUi)
 	c := &ProvidersCommand{
 		Meta: Meta{
-			Ui: ui,
+			Ui:         ui,
+			WorkingDir: workdir.NewDir(td),
 		},
 	}
 
@@ -102,6 +94,7 @@ func TestProviders_modules(t *testing.T) {
 		Ui:               initUi,
 		View:             view,
 		ProviderSource:   providerSource,
+		WorkingDir:       workdir.NewDir(td),
 	}
 	ic := &InitCommand{
 		Meta: m,
@@ -114,7 +107,8 @@ func TestProviders_modules(t *testing.T) {
 	ui := new(cli.MockUi)
 	c := &ProvidersCommand{
 		Meta: Meta{
-			Ui: ui,
+			Ui:         ui,
+			WorkingDir: workdir.NewDir(td),
 		},
 	}
 
@@ -139,19 +133,15 @@ func TestProviders_modules(t *testing.T) {
 }
 
 func TestProviders_state(t *testing.T) {
-	cwd, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("err: %s", err)
-	}
-	if err := os.Chdir(testFixturePath("providers/state")); err != nil {
-		t.Fatalf("err: %s", err)
-	}
-	defer os.Chdir(cwd)
+	td := t.TempDir()
+	testCopyDir(t, testFixturePath("providers/state"), td)
+	t.Chdir(td)
 
 	ui := new(cli.MockUi)
 	c := &ProvidersCommand{
 		Meta: Meta{
-			Ui: ui,
+			Ui:         ui,
+			WorkingDir: workdir.NewDir(td),
 		},
 	}
 
@@ -176,19 +166,15 @@ func TestProviders_state(t *testing.T) {
 }
 
 func TestProviders_tests(t *testing.T) {
-	cwd, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("err: %s", err)
-	}
-	if err := os.Chdir(testFixturePath("providers/tests")); err != nil {
-		t.Fatalf("err: %s", err)
-	}
-	defer os.Chdir(cwd)
+	td := t.TempDir()
+	testCopyDir(t, testFixturePath("providers/tests"), td)
+	t.Chdir(td)
 
 	ui := new(cli.MockUi)
 	c := &ProvidersCommand{
 		Meta: Meta{
-			Ui: ui,
+			Ui:         ui,
+			WorkingDir: workdir.NewDir(td),
 		},
 	}
 
@@ -258,6 +244,7 @@ func TestProviders_state_withStateStore(t *testing.T) {
 					mockProviderAddress: providers.FactoryFixed(mockProvider),
 				},
 			},
+			WorkingDir: workdir.NewDir(td),
 		},
 	}
 

--- a/internal/command/unlock.go
+++ b/internal/command/unlock.go
@@ -38,17 +38,11 @@ func (c *UnlockCommand) Run(args []string) int {
 		c.Ui.Error("Expected a single argument: LOCK_ID")
 		return cli.RunResultHelp
 	}
-
 	lockID := args[0]
-	args = args[1:]
 
 	// assume everything is initialized. The user can manually init if this is
 	// required.
-	configPath, err := ModulePath(args)
-	if err != nil {
-		c.Ui.Error(err.Error())
-		return 1
-	}
+	configPath := c.Meta.WorkingDir.RootModuleDir()
 
 	var diags tfdiags.Diagnostics
 

--- a/internal/command/unlock_test.go
+++ b/internal/command/unlock_test.go
@@ -42,6 +42,7 @@ func TestUnlock(t *testing.T) {
 			testingOverrides: metaOverridesForProvider(p),
 			Ui:               ui,
 			View:             view,
+			WorkingDir:       workdir.NewDir(td),
 		},
 	}
 
@@ -78,8 +79,9 @@ func TestUnlock_inmemBackend(t *testing.T) {
 	view, _ := testView(t)
 	ci := &InitCommand{
 		Meta: Meta{
-			Ui:   ui,
-			View: view,
+			Ui:         ui,
+			View:       view,
+			WorkingDir: workdir.NewDir(td),
 		},
 	}
 	if code := ci.Run(nil); code != 0 {
@@ -89,8 +91,9 @@ func TestUnlock_inmemBackend(t *testing.T) {
 	ui = new(cli.MockUi)
 	c := &UnlockCommand{
 		Meta: Meta{
-			Ui:   ui,
-			View: view,
+			Ui:         ui,
+			View:       view,
+			WorkingDir: workdir.NewDir(td),
 		},
 	}
 
@@ -107,8 +110,9 @@ func TestUnlock_inmemBackend(t *testing.T) {
 	ui = new(cli.MockUi)
 	c = &UnlockCommand{
 		Meta: Meta{
-			Ui:   ui,
-			View: view,
+			Ui:         ui,
+			View:       view,
+			WorkingDir: workdir.NewDir(td),
 		},
 	}
 
@@ -117,5 +121,4 @@ func TestUnlock_inmemBackend(t *testing.T) {
 	if code := c.Run(args); code != 0 {
 		t.Fatalf("bad: %d\n%s\n%s", code, ui.OutputWriter.String(), ui.ErrorWriter.String())
 	}
-
 }


### PR DESCRIPTION
Stacked PR on top of https://github.com/hashicorp/terraform/pull/38692

This PR removes all use of the ModulePath function from commands and removes the function from the codebase.

See the previous PR for context about this guy:

https://github.com/hashicorp/terraform/blob/78a333060e0ededea5083a5d404906926a31de1a/internal/command/command.go#L62-L75

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.16.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
