### PR TITLE
fix(init): validate -lockfile flag value in ParseInit

### DIFF
--- a/.changes/v1.16/BUG FIXES-20260607-100000.yaml
+++ b/.changes/v1.16/BUG FIXES-20260607-100000.yaml
@@ -1,0 +1,5 @@
+kind: BUG FIXES
+body: "`terraform init` now validates the `-lockfile` flag value and returns a clear error for unrecognized values"
+time: 2026-06-07T10:00:00.000000Z
+custom:
+    Issue: "38563"

--- a/internal/command/arguments/init.go
+++ b/internal/command/arguments/init.go
@@ -211,6 +211,14 @@ func ParseInit(args []string, experimentsEnabled bool) (*Init, tfdiags.Diagnosti
 		))
 	}
 
+	if init.Lockfile != "" && init.Lockfile != "readonly" {
+		diags = diags.Append(tfdiags.Sourceless(
+			tfdiags.Error,
+			"Invalid value for -lockfile flag",
+			fmt.Sprintf("The -lockfile flag only accepts \"readonly\". Got: %q.", init.Lockfile),
+		))
+	}
+
 	if init.Upgrade && init.Lockfile == "readonly" {
 		// This is appended as a Go error because this validation already existed this way
 		// and it's been moved earlier in the process, to the arguments package.

--- a/internal/command/arguments/init_test.go
+++ b/internal/command/arguments/init_test.go
@@ -374,6 +374,11 @@ func TestParseInit_invalid(t *testing.T) {
 			wantErr:      "The -upgrade flag conflicts with -lockfile=readonly.",
 			wantViewType: ViewHuman,
 		},
+		"with invalid -lockfile value": {
+			args:         []string{"-lockfile=foobar"},
+			wantErr:      `The -lockfile flag only accepts "readonly". Got: "foobar".`,
+			wantViewType: ViewHuman,
+		},
 	}
 
 	for name, tc := range testCases {


### PR DESCRIPTION
## Summary

The `-lockfile` flag only acts on `"readonly"`; any other non-empty value was silently accepted and ignored, giving the user no indication their flag had no effect.

This PR adds an error diagnostic when an unrecognised value is supplied, consistent with how other flag values are validated in `ParseInit`.

Closes #38563

## Changes

- `internal/command/arguments/init.go` — add validation block: if `Lockfile` is non-empty and not `"readonly"`, append an error diagnostic
- `internal/command/arguments/init_test.go` — add `"with invalid -lockfile value"` table case to `TestParseInit_invalid`

## Test plan

- [x] `go test ./internal/command/arguments/... -run TestParseInit` passes (all existing cases + new case)
- [x] `terraform init -lockfile=foobar` now exits non-zero with a clear error message