### PR TITLE
cli: change 'will not be destroyed' color from red to yellow

### DIFF
--- a/.changes/v1.16/BUG FIXES-20260608-114220.yaml
+++ b/.changes/v1.16/BUG FIXES-20260608-114220.yaml
@@ -1,0 +1,5 @@
+kind: BUG FIXES
+body: 'Change the "will not be destroyed" message color from red to yellow for removed blocks with destroy=false, making it visually distinct from the "will be destroyed" message'
+time: 2026-06-08T11:42:20+00:00
+custom:
+    Issue: "37973"

--- a/internal/command/jsonformat/plan.go
+++ b/internal/command/jsonformat/plan.go
@@ -564,10 +564,10 @@ func resourceChangeComment(resource jsonplan.ResourceChange, action plans.Action
 		buf.WriteString("\n # (destroy = false is set in the configuration)")
 	case plans.Forget:
 		if len(resource.Deposed) > 0 {
-			buf.WriteString(fmt.Sprintf("[bold] # %s[reset] will be removed from Terraform state, but [bold][red]will not be destroyed[reset]", dispAddr))
+			buf.WriteString(fmt.Sprintf("[bold] # %s[reset] will be removed from Terraform state, but [bold][yellow]will not be destroyed[reset]", dispAddr))
 			buf.WriteString("\n[bold] # (left over from a partially-failed replacement of this instance)")
 		} else {
-			buf.WriteString(fmt.Sprintf("[bold] # %s[reset] will no longer be managed by Terraform, but [bold][red]will not be destroyed[reset]", dispAddr))
+			buf.WriteString(fmt.Sprintf("[bold] # %s[reset] will no longer be managed by Terraform, but [bold][yellow]will not be destroyed[reset]", dispAddr))
 		}
 		buf.WriteString("\n # (destroy = false is set in the configuration)")
 	case plans.Delete:


### PR DESCRIPTION
## Problem

When using removed blocks with destroy=false, the 'will not be destroyed' message was rendered in red, which looked identical to the 'will be destroyed' message. This caused confusion as users couldn't visually distinguish between resources that would be destroyed vs. those that wouldn't.

## Fix

Changed the color of 'will not be destroyed' text from [red] to [yellow] for both Forget action types:
- Removed resources (with deposed objects)
- Resources no longer managed by Terraform

## Testing

- Unit tests in internal/command/jsonformat pass
- Verified the color change only affects the 'will not be destroyed' text

## DCO

Signed-off-by: Lohit Kolluri <lohitkolluri@gmail.com>

Fixes #37973