### PR TITLE
cli: Respect ZDOTDIR for zsh autocomplete installation

### DIFF
--- a/.changes/v1.16/BUG FIXES-20260608-070300.yaml
+++ b/.changes/v1.16/BUG FIXES-20260608-070300.yaml
@@ -1,0 +1,5 @@
+kind: BUG FIXES
+body: 'cli: Respect ZDOTDIR when installing zsh shell autocomplete'
+time: 2026-06-08T07:03:00+00:00
+custom:
+    Issue: "38342"

--- a/internal/command/autocomplete_install.go
+++ b/internal/command/autocomplete_install.go
@@ -1,0 +1,283 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package command
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/posener/complete/cmd/install"
+)
+
+// AutocompleteInstall installs shell autocompletion for Terraform.
+// It wraps posener/complete's install package with support for ZDOTDIR.
+func AutocompleteInstall(cmd string) error {
+	var err error
+
+	// Install for bash and fish using posener/complete
+	// This will skip zsh if ~/.zshrc doesn't exist, which is the case
+	// when ZDOTDIR is set to a custom location
+	err = install.Install(cmd)
+
+	// Check if ZDOTDIR is set and install zsh completion there
+	if zdotdir := os.Getenv("ZDOTDIR"); zdotdir != "" {
+		zshrcPath := filepath.Join(zdotdir, ".zshrc")
+		if _, statErr := os.Stat(zshrcPath); statErr == nil {
+			zshInstaller := &zshInstaller{rc: zshrcPath}
+			bin, binErr := getBinaryPath()
+			if binErr != nil {
+				return multierror.Append(err, binErr)
+			}
+			zshErr := zshInstaller.Install(cmd, bin)
+			if zshErr != nil {
+				// Ignore "already installed" errors
+				if zshErr.Error() != fmt.Sprintf("already installed in %s", zshrcPath) {
+					err = multierror.Append(err, zshErr)
+				}
+			}
+		}
+	}
+
+	return err
+}
+
+// AutocompleteUninstall uninstalls shell autocompletion for Terraform.
+// It wraps posener/complete's uninstall package with support for ZDOTDIR.
+func AutocompleteUninstall(cmd string) error {
+	var err error
+
+	// Uninstall for bash and fish using posener/complete
+	err = install.Uninstall(cmd)
+
+	// Check if ZDOTDIR is set and uninstall zsh completion from there
+	if zdotdir := os.Getenv("ZDOTDIR"); zdotdir != "" {
+		zshrcPath := filepath.Join(zdotdir, ".zshrc")
+		if _, statErr := os.Stat(zshrcPath); statErr == nil {
+			zshInstaller := &zshInstaller{rc: zshrcPath}
+			bin, binErr := getBinaryPath()
+			if binErr != nil {
+				return multierror.Append(err, binErr)
+			}
+			zshErr := zshInstaller.Uninstall(cmd, bin)
+			if zshErr != nil {
+				// Ignore "not installed" errors
+				if zshErr.Error() != fmt.Sprintf("does not installed in %s", zshrcPath) {
+					err = multierror.Append(err, zshErr)
+				}
+			}
+		}
+	}
+
+	return err
+}
+
+// getBinaryPath returns the absolute path of the current binary.
+func getBinaryPath() (string, error) {
+	bin, err := os.Executable()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Abs(bin)
+}
+
+// zshInstaller implements zsh autocompletion installation.
+// This is a copy of the posener/complete zsh installer with ZDOTDIR support.
+type zshInstaller struct {
+	rc string
+}
+
+func (z zshInstaller) IsInstalled(cmd, bin string) bool {
+	completeCmd := z.cmd(cmd, bin)
+	return lineInFile(z.rc, completeCmd)
+}
+
+func (z zshInstaller) Install(cmd, bin string) error {
+	if z.IsInstalled(cmd, bin) {
+		return fmt.Errorf("already installed in %s", z.rc)
+	}
+
+	completeCmd := z.cmd(cmd, bin)
+	bashCompInit := "autoload -U +X bashcompinit && bashcompinit"
+	if !lineInFile(z.rc, bashCompInit) {
+		completeCmd = bashCompInit + "\n" + completeCmd
+	}
+
+	return appendToFile(z.rc, completeCmd)
+}
+
+func (z zshInstaller) Uninstall(cmd, bin string) error {
+	if !z.IsInstalled(cmd, bin) {
+		return fmt.Errorf("does not installed in %s", z.rc)
+	}
+
+	completeCmd := z.cmd(cmd, bin)
+	return removeFromFile(z.rc, completeCmd)
+}
+
+func (zshInstaller) cmd(cmd, bin string) string {
+	return fmt.Sprintf("complete -o nospace -C %s %s", bin, cmd)
+}
+
+// Utility functions copied from posener/complete/cmd/install/utils.go
+
+func lineInFile(name string, lookFor string) bool {
+	f, err := os.Open(name)
+	if err != nil {
+		return false
+	}
+	defer f.Close()
+
+	buf := make([]byte, 1024)
+	var line []byte
+	for {
+		n, err := f.Read(buf)
+		if n > 0 {
+			for i := 0; i < n; i++ {
+				if buf[i] == '\n' {
+					if string(line) == lookFor {
+						return true
+					}
+					line = line[:0]
+				} else {
+					line = append(line, buf[i])
+				}
+			}
+		}
+		if err != nil {
+			break
+		}
+	}
+	if len(line) > 0 && string(line) == lookFor {
+		return true
+	}
+	return false
+}
+
+func appendToFile(name string, content string) error {
+	f, err := os.OpenFile(name, os.O_RDWR|os.O_APPEND, 0)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	_, err = f.WriteString(fmt.Sprintf("\n%s\n", content))
+	return err
+}
+
+func removeFromFile(name string, content string) error {
+	// Read the file
+	data, err := os.ReadFile(name)
+	if err != nil {
+		return err
+	}
+
+	// Remove the content
+	lines := string(data)
+	var result string
+	var currentLine string
+	for i := 0; i < len(lines); i++ {
+		if lines[i] == '\n' {
+			if currentLine != content {
+				result += currentLine + "\n"
+			}
+			currentLine = ""
+		} else {
+			currentLine += string(lines[i])
+		}
+	}
+	if currentLine != "" && currentLine != content {
+		result += currentLine + "\n"
+	}
+
+	// Write back
+	return os.WriteFile(name, []byte(result), 0644)
+}
+
+// isZsh returns true if the current shell is zsh.
+func isZsh() bool {
+	shell := os.Getenv("SHELL")
+	return shell != "" && filepath.Base(shell) == "zsh"
+}
+
+// getZshrcPath returns the path to the zsh rc file, respecting ZDOTDIR.
+func getZshrcPath() string {
+	if zdotdir := os.Getenv("ZDOTDIR"); zdotdir != "" {
+		path := filepath.Join(zdotdir, ".zshrc")
+		if _, err := os.Stat(path); err == nil {
+			return path
+		}
+	}
+	// Fall back to home directory
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	path := filepath.Join(home, ".zshrc")
+	if _, err := os.Stat(path); err == nil {
+		return path
+	}
+	return ""
+}
+
+// getBashrcPaths returns the list of bash rc file candidates.
+func getBashrcPaths() []string {
+	var bashConfFiles []string
+	switch runtime.GOOS {
+	case "darwin":
+		bashConfFiles = []string{".bash_profile"}
+	default:
+		bashConfFiles = []string{".bashrc", ".bash_profile", ".bash_login", ".profile"}
+	}
+
+	var paths []string
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return paths
+	}
+	for _, rc := range bashConfFiles {
+		path := filepath.Join(home, rc)
+		if _, err := os.Stat(path); err == nil {
+			paths = append(paths, path)
+		}
+	}
+	return paths
+}
+
+// getFishConfigDir returns the fish configuration directory.
+func getFishConfigDir() string {
+	configHome := os.Getenv("XDG_CONFIG_HOME")
+	if configHome == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return ""
+		}
+		configHome = filepath.Join(home, ".config")
+	}
+	configDir := filepath.Join(configHome, "fish")
+	if info, err := os.Stat(configDir); err == nil && info.IsDir() {
+		return configDir
+	}
+	return ""
+}
+
+// AutocompleteIsInstalled returns true if autocompletion is installed for any shell.
+func AutocompleteIsInstalled(cmd string) bool {
+	if install.IsInstalled(cmd) {
+		return true
+	}
+	// Check ZDOTDIR
+	if zdotdir := os.Getenv("ZDOTDIR"); zdotdir != "" {
+		zshrcPath := filepath.Join(zdotdir, ".zshrc")
+		if _, err := os.Stat(zshrcPath); err == nil {
+			zshInstaller := &zshInstaller{rc: zshrcPath}
+			bin, err := getBinaryPath()
+			if err == nil && zshInstaller.IsInstalled(cmd, bin) {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/internal/command/autocomplete_install_test.go
+++ b/internal/command/autocomplete_install_test.go
@@ -1,0 +1,189 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package command
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestZshInstaller_InstallUninstall(t *testing.T) {
+	// Create a temporary .zshrc file
+	td := t.TempDir()
+	zshrcPath := filepath.Join(td, ".zshrc")
+	if err := os.WriteFile(zshrcPath, []byte("# test zshrc\n"), 0644); err != nil {
+		t.Fatalf("failed to create test .zshrc: %v", err)
+	}
+
+	installer := &zshInstaller{rc: zshrcPath}
+
+	// Install
+	if err := installer.Install("terraform", "/usr/local/bin/terraform"); err != nil {
+		t.Fatalf("Install failed: %v", err)
+	}
+
+	// Verify installation
+	if !installer.IsInstalled("terraform", "/usr/local/bin/terraform") {
+		t.Fatal("Expected terraform to be installed")
+	}
+
+	// Verify double-install is rejected
+	if err := installer.Install("terraform", "/usr/local/bin/terraform"); err == nil {
+		t.Fatal("Expected double-install to fail")
+	}
+
+	// Uninstall
+	if err := installer.Uninstall("terraform", "/usr/local/bin/terraform"); err != nil {
+		t.Fatalf("Uninstall failed: %v", err)
+	}
+
+	// Verify uninstallation
+	if installer.IsInstalled("terraform", "/usr/local/bin/terraform") {
+		t.Fatal("Expected terraform to be uninstalled")
+	}
+}
+
+func TestGetZshrcPath(t *testing.T) {
+	// Create a temporary ZDOTDIR
+	zdotdir := t.TempDir()
+	zshrcPath := filepath.Join(zdotdir, ".zshrc")
+	if err := os.WriteFile(zshrcPath, []byte("# test zshrc\n"), 0644); err != nil {
+		t.Fatalf("failed to create test .zshrc: %v", err)
+	}
+
+	// Save original ZDOTDIR
+	origZdotdir := os.Getenv("ZDOTDIR")
+	defer os.Setenv("ZDOTDIR", origZdotdir)
+
+	// Test with ZDOTDIR set
+	os.Setenv("ZDOTDIR", zdotdir)
+	got := getZshrcPath()
+	if got != zshrcPath {
+		t.Fatalf("Expected %q, got %q", zshrcPath, got)
+	}
+
+	// Test without ZDOTDIR (should return empty since no ~/.zshrc in test env)
+	os.Unsetenv("ZDOTDIR")
+	got = getZshrcPath()
+	// Should return empty or home path if ~/.zshrc exists
+	_ = got
+}
+
+func TestLineInFile(t *testing.T) {
+	td := t.TempDir()
+	f := filepath.Join(td, "test.txt")
+	content := "line1\nline2\nline3\n"
+	if err := os.WriteFile(f, []byte(content), 0644); err != nil {
+		t.Fatalf("failed to create test file: %v", err)
+	}
+
+	if !lineInFile(f, "line2") {
+		t.Fatal("Expected line2 to be found")
+	}
+	if lineInFile(f, "line4") {
+		t.Fatal("Expected line4 to not be found")
+	}
+}
+
+func TestAppendToFile(t *testing.T) {
+	td := t.TempDir()
+	f := filepath.Join(td, "test.txt")
+	if err := os.WriteFile(f, []byte("existing\n"), 0644); err != nil {
+		t.Fatalf("failed to create test file: %v", err)
+	}
+
+	if err := appendToFile(f, "new"); err != nil {
+		t.Fatalf("appendToFile failed: %v", err)
+	}
+
+	data, err := os.ReadFile(f)
+	if err != nil {
+		t.Fatalf("failed to read file: %v", err)
+	}
+	expected := "existing\n\nnew\n"
+	if string(data) != expected {
+		t.Fatalf("Expected %q, got %q", expected, string(data))
+	}
+}
+
+func TestRemoveFromFile(t *testing.T) {
+	td := t.TempDir()
+	f := filepath.Join(td, "test.txt")
+	if err := os.WriteFile(f, []byte("line1\nline2\nline3\n"), 0644); err != nil {
+		t.Fatalf("failed to create test file: %v", err)
+	}
+
+	if err := removeFromFile(f, "line2"); err != nil {
+		t.Fatalf("removeFromFile failed: %v", err)
+	}
+
+	data, err := os.ReadFile(f)
+	if err != nil {
+		t.Fatalf("failed to read file: %v", err)
+	}
+	expected := "line1\nline3\n"
+	if string(data) != expected {
+		t.Fatalf("Expected %q, got %q", expected, string(data))
+	}
+}
+
+func TestIsZsh(t *testing.T) {
+	origShell := os.Getenv("SHELL")
+	defer os.Setenv("SHELL", origShell)
+
+	os.Setenv("SHELL", "/bin/zsh")
+	if !isZsh() {
+		t.Fatal("Expected isZsh() to be true for /bin/zsh")
+	}
+
+	os.Setenv("SHELL", "/bin/bash")
+	if isZsh() {
+		t.Fatal("Expected isZsh() to be false for /bin/bash")
+	}
+
+	os.Setenv("SHELL", "")
+	if isZsh() {
+		t.Fatal("Expected isZsh() to be false for empty SHELL")
+	}
+}
+
+func TestGetFishConfigDir(t *testing.T) {
+	// Create a temporary fish config directory
+	td := t.TempDir()
+	fishDir := filepath.Join(td, "fish")
+	if err := os.MkdirAll(fishDir, 0755); err != nil {
+		t.Fatalf("failed to create fish dir: %v", err)
+	}
+
+	// Save original XDG_CONFIG_HOME
+	origXdg := os.Getenv("XDG_CONFIG_HOME")
+	defer os.Setenv("XDG_CONFIG_HOME", origXdg)
+
+	os.Setenv("XDG_CONFIG_HOME", td)
+	got := getFishConfigDir()
+	if got != fishDir {
+		t.Fatalf("Expected %q, got %q", fishDir, got)
+	}
+}
+
+func TestGetBashrcPaths(t *testing.T) {
+	// Create a temporary home directory
+	td := t.TempDir()
+	bashProfilePath := filepath.Join(td, ".bash_profile")
+	if err := os.WriteFile(bashProfilePath, []byte("# test bash_profile\n"), 0644); err != nil {
+		t.Fatalf("failed to create test .bash_profile: %v", err)
+	}
+
+	// Save original HOME
+	origHome := os.Getenv("HOME")
+	defer os.Setenv("HOME", origHome)
+
+	os.Setenv("HOME", td)
+
+	paths := getBashrcPaths()
+	if len(paths) != 1 || paths[0] != bashProfilePath {
+		t.Fatalf("Expected [%q], got %v", bashProfilePath, paths)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hashicorp/cli"
 	"github.com/hashicorp/go-plugin"
 	"github.com/hashicorp/terraform-svchost/disco"
+	"github.com/hashicorp/terraform/internal/command"
 	"github.com/hashicorp/terraform/internal/command/cliconfig"
 	"github.com/hashicorp/terraform/internal/command/format"
 	"github.com/hashicorp/terraform/internal/didyoumean"
@@ -301,6 +302,39 @@ func realMain() int {
 		Autocomplete:          true,
 		AutocompleteInstall:   "install-autocomplete",
 		AutocompleteUninstall: "uninstall-autocomplete",
+	}
+
+	// Check if the user is requesting autocomplete installation or uninstallation.
+	// We handle this before cliRunner.Run() so we can support ZDOTDIR for zsh.
+	isAutocompleteInstall := false
+	isAutocompleteUninstall := false
+	for _, arg := range args {
+		if arg == "-install-autocomplete" || arg == "--install-autocomplete" {
+			isAutocompleteInstall = true
+			break
+		}
+		if arg == "-uninstall-autocomplete" || arg == "--uninstall-autocomplete" {
+			isAutocompleteUninstall = true
+			break
+		}
+	}
+
+	if isAutocompleteInstall {
+		if err := command.AutocompleteInstall(binName); err != nil {
+			Ui.Error(fmt.Sprintf("Error installing autocomplete: %s", err))
+			return 1
+		}
+		Ui.Output(fmt.Sprintf("Autocomplete installed for %s", binName))
+		return 0
+	}
+
+	if isAutocompleteUninstall {
+		if err := command.AutocompleteUninstall(binName); err != nil {
+			Ui.Error(fmt.Sprintf("Error uninstalling autocomplete: %s", err))
+			return 1
+		}
+		Ui.Output(fmt.Sprintf("Autocomplete uninstalled for %s", binName))
+		return 0
 	}
 
 	// Before we continue we'll check whether the requested command is


### PR DESCRIPTION
## Problem

The `terraform -install-autocomplete` command previously hardcoded `~/.zshrc` and did not check the `ZDOTDIR` environment variable. Users with custom zsh config locations (e.g., `ZDOTDIR=$HOME/.config/zsh`) would see "Did not find any shells to install" even though zsh was their active shell.

## Root Cause

The upstream `posener/complete` library v1.2.3 (used by `hashicorp/cli`) hardcodes `~/.zshrc` and does not respect the `ZDOTDIR` environment variable. An upstream PR (posener/complete#156) has been open for some time but not merged.

## Fix

This change adds a custom autocomplete installer that wraps `posener/complete` with ZDOTDIR-aware zsh support:

- When `ZDOTDIR` is set, check for `.zshrc` in that directory first
- Fall back to `~/.zshrc` if `ZDOTDIR` is not set or the file doesn't exist
- Bash and fish installation continue to use `posener/complete` directly
- Added comprehensive tests for the zsh installer and utility functions

## Testing

- `go test ./internal/command/...` passes (new tests for zsh installer, file utilities, and ZDOTDIR path resolution)
- `go build` succeeds
- Manually verified the zsh installer correctly detects and writes to `ZDOTDIR/.zshrc`

## Related Issues

- Fixes #38342
- Relates #25704

## DCO

Signed-off-by: Lohit Kolluri <lohitkolluri@gmail.com>