### PR TITLE
fix(apply): Warn users when `apply` is passed plan options -target, -destroy and -refresh-only if they disagree with the saved plan in use.

### DIFF
--- a/.changes/v1.16/BUG FIXES-20260608-115707.yaml
+++ b/.changes/v1.16/BUG FIXES-20260608-115707.yaml
@@ -1,0 +1,5 @@
+kind: BUG FIXES
+body: 'apply: Added warnings that alert users if plan options (-target, -destroy or -refresh-only flags) passed to the apply command disagree with the saved plan file, if one is supplied. Prior to this fix the flags would be silently ignored, which could be misleading.'
+time: 2026-06-08T11:57:07.186819+01:00
+custom:
+    Issue: "38698"

--- a/internal/backend/local/backend_apply.go
+++ b/internal/backend/local/backend_apply.go
@@ -35,7 +35,8 @@ func (b *Local) opApply(
 	stopCtx context.Context,
 	cancelCtx context.Context,
 	op *backendrun.Operation,
-	runningOp *backendrun.RunningOperation) {
+	runningOp *backendrun.RunningOperation,
+) {
 	log.Printf("[INFO] backend/local: starting Apply operation")
 
 	var diags, moreDiags tfdiags.Diagnostics
@@ -371,7 +372,7 @@ func (b *Local) opApply(
 							diags = diags.Append(&hcl.Diagnostic{
 								Severity: hcl.DiagWarning,
 								Summary:  "Ignoring variable when applying a saved plan",
-								Detail: fmt.Sprintf("The variable %s cannot be overriden when applying a saved plan file, "+
+								Detail: fmt.Sprintf("The variable %s cannot be overridden when applying a saved plan file, "+
 									"because a saved plan includes the variable values that were set when it was created. "+
 									"The saved plan specifies %s as the value whereas during apply the value %s was %s. "+
 									"To declare an ephemeral variable which is not saved in the plan file, use ephemeral = true.",
@@ -419,6 +420,48 @@ func (b *Local) opApply(
 			op.ReportResult(runningOp, diags)
 			return
 		}
+	}
+
+	// If the user erroneously included any plan options flags when they supplied a plan file,
+	// we'll return an error if the flag values don't match the plan file.
+	if len(op.Targets) != 0 {
+		// Do target flags all match targets in the plan?
+		for _, target := range op.Targets {
+			found := false
+			for _, planTarget := range plan.TargetAddrs {
+				if target.TargetContains(planTarget) {
+					found = true
+					break
+				}
+			}
+			if !found {
+				diags = diags.Append(tfdiags.Sourceless(
+					tfdiags.Warning,
+					"Can't change resource targeting when applying a saved plan",
+					fmt.Sprintf("The target address %q was supplied using a -target flag but does not match a target in the saved plan file. This flag will be ignored and won't influence the apply operation.", target),
+				))
+			}
+		}
+	}
+	if op.PlanMode != plan.UIMode {
+		if op.PlanMode == plans.DestroyMode {
+			diags = diags.Append(tfdiags.Sourceless(
+				tfdiags.Warning,
+				"Can't change plan mode when applying a saved plan",
+				"The -destroy flag was supplied to the apply command, but the plan file was not created with the -destroy flag. This flag will be ignored and won't influence the apply operation.",
+			))
+		}
+		if op.PlanMode == plans.RefreshOnlyMode {
+			diags = diags.Append(tfdiags.Sourceless(
+				tfdiags.Warning,
+				"Can't change plan mode when applying a saved plan",
+				"The -refresh-only flag was supplied to the apply command, but the plan file was not created with the -refresh-only flag. This flag will be ignored and won't influence the apply operation.",
+			))
+		}
+	}
+	if diags.HasErrors() {
+		op.ReportResult(runningOp, diags)
+		return
 	}
 
 	// Start the apply in a goroutine so that we can be interrupted.

--- a/internal/command/apply_test.go
+++ b/internal/command/apply_test.go
@@ -2081,6 +2081,112 @@ func TestApply_changedVars_applyTime(t *testing.T) {
 	})
 }
 
+// There isn't validation to stop users passing plan options like -target, -destroy and -refresh-only flags
+// to an apply command when a saved plan is used.
+//
+// Adding any validation is a breaking change.
+// For now, we raise warnings when applying a plan file that doesn't match the intent
+// expressed by the plan options passed to the apply command alongside the plan file.
+// See: https://github.com/hashicorp/terraform/issues/38670
+func TestApply_changedPlanOptions_applyTime(t *testing.T) {
+	t.Run("change to -target", func(t *testing.T) {
+		planPath := applyFixturePlanFile(t)
+		statePath := testTempFile(t)
+
+		p := applyFixtureProvider()
+		view, done := testView(t)
+		c := &ApplyCommand{
+			Meta: Meta{
+				testingOverrides: metaOverridesForProvider(p),
+				View:             view,
+			},
+		}
+
+		args := []string{
+			"-no-color",
+			"-target", "test_instance.foo",
+			"-state-out", statePath,
+			planPath,
+		}
+		code := c.Run(args)
+		output := done(t)
+		if code != 0 {
+			t.Fatalf("unexpected exit code %d:\n\n%s", code, output.All())
+		}
+
+		if !strings.Contains(output.Stdout(), `Warning: Can't change resource targeting when applying a saved plan`) {
+			t.Fatalf("missing warning text:\n%s", output.All())
+		}
+		if !strings.Contains(output.Stdout(), `target address "test_instance.foo"`) {
+			t.Fatalf("missing detail from warning:\n%s", output.All())
+		}
+	})
+	t.Run("change to -destroy", func(t *testing.T) {
+		planPath := applyFixturePlanFile(t)
+		statePath := testTempFile(t)
+
+		p := applyFixtureProvider()
+		view, done := testView(t)
+		c := &ApplyCommand{
+			Meta: Meta{
+				testingOverrides: metaOverridesForProvider(p),
+				View:             view,
+			},
+		}
+
+		args := []string{
+			"-no-color",
+			"-destroy",
+			"-state-out", statePath,
+			planPath,
+		}
+		code := c.Run(args)
+		output := done(t)
+		if code != 0 {
+			t.Fatalf("unexpected exit code %d:\n\n%s", code, output.All())
+		}
+
+		if !strings.Contains(output.Stdout(), `Warning: Can't change plan mode when applying a saved plan`) {
+			t.Fatalf("missing warning:\n%s", output.All())
+		}
+		if !strings.Contains(output.Stdout(), `-destroy`) {
+			t.Fatalf("missing flag name from warning:\n%s", output.All())
+		}
+	})
+	t.Run("change to -refresh-only", func(t *testing.T) {
+		planPath := applyFixturePlanFile(t)
+		statePath := testTempFile(t)
+
+		p := applyFixtureProvider()
+		view, done := testView(t)
+		c := &ApplyCommand{
+			Meta: Meta{
+				testingOverrides: metaOverridesForProvider(p),
+				View:             view,
+			},
+		}
+
+		args := []string{
+			"-no-color",
+			"-refresh-only",
+			"-state-out", statePath,
+			planPath,
+		}
+		code := c.Run(args)
+		output := done(t)
+		if code != 0 {
+			t.Fatalf("unexpected exit code %d:\n\n%s", code, output.All())
+		}
+
+		if !strings.Contains(output.Stdout(), `Warning: Can't change plan mode when applying a saved plan`) {
+			t.Fatalf("missing warning text:\n%s", output.All())
+		}
+		if !strings.Contains(output.Stdout(), `-refresh-only`) {
+			t.Fatalf("missing flag name from warning:\n%s", output.All())
+		}
+	})
+}
+
 // we should be able to apply a plan file with no other file dependencies
 func TestApply_planNoModuleFiles(t *testing.T) {
 	// temporary data directory which we can remove between commands


### PR DESCRIPTION
Addresses https://github.com/hashicorp/terraform/issues/38670 in a non-breaking way.

The linked issue shows that when `apply` is given a plan file and 1+ `-target` flags those flags are ignored. This is because the `-target` flag influences planning. If `apply` is supplied with a plan file it never performs planning of its own and the target data is unused.

Similarly, other [plan options](https://developer.hashicorp.com/terraform/cli/commands/apply#plan-options) will be ignored by `apply` if a saved plan is in use:
* -target
* -destroy
* -refresh-only
* -var and -var-file : There are [errors raised](https://github.com/hashicorp/terraform/blob/d038b9e6cd8636e97a6844e45e8a0157a50ef8df/internal/backend/local/backend_apply.go#L382-L394) if these are used alongside a saved plan.

What we cannot do outside a major release:
* We can't add validation to the `apply`-specific logic in the `arguments` package
* We can't raise hard errors even when the plan options contradict the saved plan that's in use at the same time.

What we can do:
* Add warnings.


This PR adds warnings if a user is unknowingly instructing Terraform to perform contradicting actions, so that they know the flags are ignored and the plan is followed as-is.

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.15.6

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [x] This change is user-facing and I added a changelog entry.
- [ ] This change is not user-facing.
