### PR TITLE
Continued destroy action development

### DIFF
--- a/internal/lang/eval.go
+++ b/internal/lang/eval.go
@@ -89,10 +89,12 @@ func (s *Scope) EvalActionBlock(body hcl.Body, schema *configschema.Block, calle
 	spec := schema.DecoderSpec()
 
 	refs, diags := langrefs.ReferencesInBlock(s.ParseRef, body, schema)
+	if diags.HasErrors() {
+		return cty.DynamicVal, diags
+	}
 
-	ctx, ctxDiags := s.EvalContext(refs)
+	ctx, ctxDiags := s.EvalContextForExplicitSelf(refs)
 	diags = diags.Append(ctxDiags)
-
 	if diags.HasErrors() {
 		// We'll stop early if we found problems in the references, because
 		// it's likely evaluation will produce redundant copies of the same errors.
@@ -100,6 +102,7 @@ func (s *Scope) EvalActionBlock(body hcl.Body, schema *configschema.Block, calle
 	}
 
 	ctx.Variables["caller"] = caller
+	ctx.Variables["self"] = caller
 
 	val, evalDiags := hcldec.Decode(body, spec, ctx)
 	diags = diags.Append(CheckForUnknownFunctionDiags(evalDiags, s.IgnoreUnknownProviderFunctions))
@@ -243,7 +246,7 @@ func (s *Scope) EvalReference(ref *addrs.Reference, wantType cty.Type) (cty.Valu
 	// We cheat a bit here and just build an EvalContext for our requested
 	// reference with the "self" address overridden, and then pull the "self"
 	// result out of it to return.
-	ctx, ctxDiags := s.evalContext([]*addrs.Reference{ref}, ref.Subject)
+	ctx, ctxDiags := s.evalContext([]*addrs.Reference{ref}, ref.Subject, false)
 	diags = diags.Append(ctxDiags)
 	val := ctx.Variables["self"]
 	if val == cty.NilVal {
@@ -272,10 +275,14 @@ func (s *Scope) EvalReference(ref *addrs.Reference, wantType cty.Type) (cty.Valu
 // this type offers, but this is here for less common situations where the
 // caller will handle the evaluation calls itself.
 func (s *Scope) EvalContext(refs []*addrs.Reference) (*hcl.EvalContext, tfdiags.Diagnostics) {
-	return s.evalContext(refs, s.SelfAddr)
+	return s.evalContext(refs, s.SelfAddr, false)
 }
 
-func (s *Scope) evalContext(refs []*addrs.Reference, selfAddr addrs.Referenceable) (*hcl.EvalContext, tfdiags.Diagnostics) {
+func (s *Scope) EvalContextForExplicitSelf(refs []*addrs.Reference) (*hcl.EvalContext, tfdiags.Diagnostics) {
+	return s.evalContext(refs, s.SelfAddr, true)
+}
+
+func (s *Scope) evalContext(refs []*addrs.Reference, selfAddr addrs.Referenceable, explicitSelf bool) (*hcl.EvalContext, tfdiags.Diagnostics) {
 	if s == nil {
 		panic("attempt to construct EvalContext for nil Scope")
 	}
@@ -331,6 +338,14 @@ func (s *Scope) evalContext(refs []*addrs.Reference, selfAddr addrs.Referenceabl
 
 		rawSubj := ref.Subject
 		if _, ok := rawSubj.(addrs.SelfType); ok {
+			if explicitSelf {
+				// A self value will be passed in explicitly as an evaluation
+				// variable, so we should not try to construct one here.
+				// Planning an orphaned instance or removed resource might fail
+				// here even though self/caller is still valid.
+				continue
+			}
+
 			if selfAddr == nil {
 				diags = diags.Append(SelfContextDiagnostics(ref))
 				continue
@@ -345,7 +360,6 @@ func (s *Scope) evalContext(refs []*addrs.Reference, selfAddr addrs.Referenceabl
 			subj := selfAddr.(addrs.ResourceInstance)
 
 			val, valDiags := normalizeRefValue(s.Data.GetResource(subj.ContainingResource(), rng))
-
 			diags = diags.Append(valDiags)
 
 			// Self is an exception in that it must always resolve to a

--- a/internal/terraform/context_apply_action_test.go
+++ b/internal/terraform/context_apply_action_test.go
@@ -1162,6 +1162,41 @@ resource "test_object" "a" {
 			}),
 		},
 
+		"after destroy": {
+			module: map[string]string{
+				"main.tf": `
+action "action_example" "bye" {
+  config {
+    attr = caller.test_string
+  }
+}
+resource "test_object" "a" {
+  lifecycle {
+    action_trigger {
+      events = [after_destroy]
+      actions = [action.action_example.bye]
+    }
+  }
+}
+`,
+			},
+			expectInvokeActionCalled: true,
+			prevRunState: states.BuildState(func(s *states.SyncState) {
+				s.SetResourceInstanceCurrent(mustResourceInstanceAddr("test_object.a"),
+					&states.ResourceInstanceObjectSrc{
+						Status:    states.ObjectReady,
+						AttrsJSON: []byte(`{"test_string":"bye"}`),
+					},
+					mustProviderConfig(`provider["registry.terraform.io/hashicorp/test"]`),
+				)
+			}),
+			planOpts: &PlanOpts{
+				Mode: plans.DestroyMode,
+				// skip refresh just makes this easier to troubleshoot be removing ane extra walk
+				SkipRefresh: true,
+			},
+		},
+
 		"action config with after_create dependency to triggering resource": {
 			module: map[string]string{
 				"main.tf": `

--- a/internal/terraform/context_apply_action_test.go
+++ b/internal/terraform/context_apply_action_test.go
@@ -1192,7 +1192,7 @@ resource "test_object" "a" {
 			}),
 			planOpts: &PlanOpts{
 				Mode: plans.DestroyMode,
-				// skip refresh just makes this easier to troubleshoot be removing ane extra walk
+				// skip refresh just makes this easier to troubleshoot be removing an extra walk
 				SkipRefresh: true,
 			},
 		},

--- a/internal/terraform/context_plan2_test.go
+++ b/internal/terraform/context_plan2_test.go
@@ -6559,8 +6559,7 @@ resource "test_object" "a" {
 		Mode: plans.DestroyMode,
 		SetVariables: InputValues{
 			"input": {
-				Value:       cty.StringVal("foo"),
-				SourceType:  ValueFromCLIArg,
+				Value:       cty.UnknownVal(cty.String),
 				SourceRange: tfdiags.SourceRange{},
 			},
 		},

--- a/internal/terraform/graph_builder_plan.go
+++ b/internal/terraform/graph_builder_plan.go
@@ -77,7 +77,7 @@ type PlanGraphBuilder struct {
 
 	ConcreteProvider                ConcreteProviderNodeFunc
 	ConcreteResource                ConcreteResourceNodeFunc
-	ConcreteResourceInstance        ConcreteResourceInstanceNodeFunc
+	ConcreteDestroyResourceInstance ConcreteResourceInstanceNodeFunc
 	ConcreteResourceOrphan          ConcreteResourceInstanceNodeFunc
 	ConcreteResourceInstanceDeposed ConcreteResourceInstanceDeposedNodeFunc
 	ConcreteModule                  ConcreteModuleNodeFunc
@@ -223,7 +223,7 @@ func (b *PlanGraphBuilder) Steps() []GraphTransformer {
 		// ConfigTransformer created nodes that will do that during
 		// DynamicExpand.)
 		&StateTransformer{
-			ConcreteCurrent: b.ConcreteResourceInstance,
+			ConcreteCurrent: b.ConcreteDestroyResourceInstance,
 			ConcreteDeposed: b.ConcreteResourceInstanceDeposed,
 			State:           b.State,
 		},
@@ -373,7 +373,7 @@ func (b *PlanGraphBuilder) initPlan() {
 func (b *PlanGraphBuilder) initDestroy() {
 	b.initPlan()
 
-	b.ConcreteResourceInstance = func(a *NodeAbstractResourceInstance) dag.Vertex {
+	b.ConcreteDestroyResourceInstance = func(a *NodeAbstractResourceInstance) dag.Vertex {
 		a.overridePreventDestroy = b.overridePreventDestroy
 		return &NodePlanDestroyableResourceInstance{
 			NodeAbstractResourceInstance: a,

--- a/internal/terraform/node_action.go
+++ b/internal/terraform/node_action.go
@@ -36,12 +36,11 @@ type GraphNodeActionCaller interface {
 }
 
 // GraphNodeActionInvoker attaches planned action invocations to a node which
-// needs to call the action. This is required for nodes not created by the
-// config transformer.
+// needs to call the action.
 type GraphNodeActionInvoker interface {
 	GraphNodeActionCaller
 
-	AttachActionApplyTrigger([]*actionTriggerApplyInstance)
+	AttachActionApplyTrigger(*actionTriggerApplyInstance)
 }
 
 // NodeActionConfig represents an action in the configuration. This node is

--- a/internal/terraform/node_action.go
+++ b/internal/terraform/node_action.go
@@ -36,9 +36,10 @@ type GraphNodeActionCaller interface {
 }
 
 // GraphNodeActionInvoker attaches planned action invocations to a node which
-// needs to call the action.
+// needs to call the action. This is required for nodes not created by the
+// config transformer.
 type GraphNodeActionInvoker interface {
-	GraphNodeConfigResource
+	GraphNodeActionCaller
 
 	AttachActionApplyTrigger([]*actionTriggerApplyInstance)
 }

--- a/internal/terraform/node_action.go
+++ b/internal/terraform/node_action.go
@@ -35,6 +35,14 @@ type GraphNodeActionCaller interface {
 	ActionCalls() []addrs.ConfigAction
 }
 
+// GraphNodeActionInvoker attaches planned action invocations to a node which
+// needs to call the action.
+type GraphNodeActionInvoker interface {
+	GraphNodeConfigResource
+
+	AttachActionApplyTrigger([]*actionTriggerApplyInstance)
+}
+
 // NodeActionConfig represents an action in the configuration. This node is
 // primarily concerned with resolving provider references and receiving the
 // correct schema. All expansion and execution is done from an action trigger.
@@ -50,7 +58,6 @@ type NodeActionConfig struct {
 	// The address of the provider this action will use
 	ResolvedProvider addrs.AbsProviderConfig
 	Schema           *providers.ActionSchema
-	Dependencies     []addrs.ConfigResource
 }
 
 var (
@@ -59,7 +66,6 @@ var (
 	_ GraphNodeConfigAction       = (*NodeActionConfig)(nil)
 	_ GraphNodeAttachActionSchema = (*NodeActionConfig)(nil)
 	_ GraphNodeProviderConsumer   = (*NodeActionConfig)(nil)
-	_ GraphNodeAttachDependencies = (*NodeActionConfig)(nil)
 )
 
 func (n NodeActionConfig) Name() string {
@@ -281,10 +287,6 @@ func (n *NodeActionConfig) Provider() ProviderRef {
 
 func (n *NodeActionConfig) SetProvider(p addrs.AbsProviderConfig) {
 	n.ResolvedProvider = p
-}
-
-func (n *NodeActionConfig) AttachDependencies(deps []addrs.ConfigResource) {
-	n.Dependencies = deps
 }
 
 // The invoke command can reference an action block to invoke all instances, so

--- a/internal/terraform/node_resource_abstract.go
+++ b/internal/terraform/node_resource_abstract.go
@@ -99,6 +99,10 @@ type NodeAbstractResource struct {
 	// graph, while allowing the triggering node to also connect to the same
 	// provider.
 	actionTriggers []*resourceActionTrigger
+
+	// If we have already planned the changes, then we have actionApplyTriggers
+	// instead of actionTriggers
+	actionApplyTriggers []*actionTriggerApplyInstance
 }
 
 var (
@@ -164,9 +168,7 @@ func (n *NodeAbstractResource) ModifyCreateBeforeDestroy(v bool) error {
 func (n *NodeAbstractResource) References() []*addrs.Reference {
 	var result []*addrs.Reference
 
-	c := n.Config
-
-	if c == nil {
+	if n.Config == nil {
 		// you can't have references without configuration
 		return nil
 	}
@@ -179,29 +181,29 @@ func (n *NodeAbstractResource) References() []*addrs.Reference {
 		log.Printf("[WARN] no schema is attached to %s, so config references cannot be detected", n.Name())
 	}
 
-	refs, _ := langrefs.ReferencesInExpr(addrs.ParseRef, c.Count)
+	refs, _ := langrefs.ReferencesInExpr(addrs.ParseRef, n.Config.Count)
 	result = append(result, refs...)
-	refs, _ = langrefs.ReferencesInExpr(addrs.ParseRef, c.ForEach)
+	refs, _ = langrefs.ReferencesInExpr(addrs.ParseRef, n.Config.ForEach)
 	result = append(result, refs...)
 
-	for _, expr := range c.TriggersReplacement {
+	for _, expr := range n.Config.TriggersReplacement {
 		refs, _ = langrefs.ReferencesInExpr(addrs.ParseRef, expr)
 		result = append(result, refs...)
 	}
 
 	// ReferencesInBlock() requires a schema
 	if n.Schema != nil {
-		refs, _ = langrefs.ReferencesInBlock(addrs.ParseRef, c.Config, n.Schema.Body)
+		refs, _ = langrefs.ReferencesInBlock(addrs.ParseRef, n.Config.Config, n.Schema.Body)
 		result = append(result, refs...)
 	}
 
-	if c.Managed != nil {
-		if c.Managed.Connection != nil {
-			refs, _ = langrefs.ReferencesInBlock(addrs.ParseRef, c.Managed.Connection.Config, connectionBlockSupersetSchema)
+	if n.Config.Managed != nil {
+		if n.Config.Managed.Connection != nil {
+			refs, _ = langrefs.ReferencesInBlock(addrs.ParseRef, n.Config.Managed.Connection.Config, connectionBlockSupersetSchema)
 			result = append(result, refs...)
 		}
 
-		for _, p := range c.Managed.Provisioners {
+		for _, p := range n.Config.Managed.Provisioners {
 			if p.When != configs.ProvisionerWhenCreate {
 				continue
 			}
@@ -219,24 +221,24 @@ func (n *NodeAbstractResource) References() []*addrs.Reference {
 		}
 	}
 
-	if c.List != nil {
-		if c.List.IncludeResource != nil {
-			refs, _ := langrefs.ReferencesInExpr(addrs.ParseRef, c.List.IncludeResource)
+	if n.Config.List != nil {
+		if n.Config.List.IncludeResource != nil {
+			refs, _ := langrefs.ReferencesInExpr(addrs.ParseRef, n.Config.List.IncludeResource)
 			result = append(result, refs...)
 		}
-		if c.List.Limit != nil {
-			refs, _ := langrefs.ReferencesInExpr(addrs.ParseRef, c.List.Limit)
+		if n.Config.List.Limit != nil {
+			refs, _ := langrefs.ReferencesInExpr(addrs.ParseRef, n.Config.List.Limit)
 			result = append(result, refs...)
 		}
 	}
 
-	for _, check := range c.Preconditions {
+	for _, check := range n.Config.Preconditions {
 		refs, _ := langrefs.ReferencesInExpr(addrs.ParseRef, check.Condition)
 		result = append(result, refs...)
 		refs, _ = langrefs.ReferencesInExpr(addrs.ParseRef, check.ErrorMessage)
 		result = append(result, refs...)
 	}
-	for _, check := range c.Postconditions {
+	for _, check := range n.Config.Postconditions {
 		refs, _ := langrefs.ReferencesInExpr(addrs.ParseRef, check.Condition)
 		result = append(result, refs...)
 		refs, _ = langrefs.ReferencesInExpr(addrs.ParseRef, check.ErrorMessage)
@@ -262,6 +264,10 @@ func (n *NodeAbstractResource) References() []*addrs.Reference {
 
 		refs, _ := langrefs.ReferencesInExpr(addrs.ParseRef, trigger.config.Condition)
 		result = append(result, refs...)
+	}
+
+	for _, trigger := range n.actionApplyTriggers {
+		refs = append(refs, trigger.References()...)
 	}
 
 	return result
@@ -377,7 +383,13 @@ func (n *NodeAbstractResource) ActionProviders() []ProviderRef {
 	// don't need all the dance around config vs state like in the main
 	// resource, and can just return the connected provider.
 
+	// we check both possible sources of actions depending on whether we are
+	// planning or applying
 	var res []ProviderRef
+	for _, trigger := range n.actionApplyTriggers {
+		res = append(res, ProviderRef{Addr: trigger.ActionInvocation.ProviderAddr, Resolved: true})
+	}
+
 	for _, trigger := range n.actionTriggers {
 		for _, actionRef := range trigger.actionRefs {
 			res = append(res, actionRef.actionNode.Provider())

--- a/internal/terraform/node_resource_abstract.go
+++ b/internal/terraform/node_resource_abstract.go
@@ -93,7 +93,7 @@ type NodeAbstractResource struct {
 	// in the configuration.
 	overridePreventDestroy bool
 
-	// actionTriggers records all triggers and their referenced actions. The
+	// actionTriggers records all triggers and their referenced actions.
 	// We hold a pointer to the action nodes from the referencing trigger, so
 	// that the action nodes can be resolved to the correct provider in the
 	// graph, while allowing the triggering node to also connect to the same
@@ -687,7 +687,14 @@ type resourceActionTrigger struct {
 // during evaluation.
 type actionRef struct {
 	configRef   configs.ActionRef
-	actionNode  *NodeActionConfig
 	blockIndex  int
 	actionIndex int
+
+	// Here we store a reference to the actual NodeActionConfig. While it's
+	// evaluated as if it were embedded within the caller, the action node is
+	// also its own entity in the graph for two reasons: - Provider resolution
+	// can happen via the standard methods - The action has its own expansion,
+	// which must be evaluated before the callers, and multiple callers may
+	// reference the same action node.
+	actionNode *NodeActionConfig
 }

--- a/internal/terraform/node_resource_abstract_instance.go
+++ b/internal/terraform/node_resource_abstract_instance.go
@@ -130,6 +130,10 @@ func (n *NodeAbstractResourceInstance) ActionCalls() []addrs.ConfigAction {
 	return calls
 }
 
+func (n *NodeAbstractResourceInstance) AttachActionApplyTrigger(trigger *actionTriggerApplyInstance) {
+	n.actionApplyTriggers = append(n.actionApplyTriggers, trigger)
+}
+
 // StateDependencies returns the dependencies which will be saved in the state
 // for managed resources, or the most current dependencies for data resources.
 func (n *NodeAbstractResourceInstance) StateDependencies() []addrs.ConfigResource {

--- a/internal/terraform/node_resource_abstract_instance.go
+++ b/internal/terraform/node_resource_abstract_instance.go
@@ -54,8 +54,6 @@ type NodeAbstractResourceInstance struct {
 
 	// override is set by the graph itself, just before this node executes.
 	override *configs.Override
-
-	actionApplyTriggers []*actionTriggerApplyInstance
 }
 
 var (
@@ -119,25 +117,17 @@ func (n *NodeAbstractResourceInstance) ReferenceableAddrs() []addrs.Referenceabl
 	}
 }
 
-// GraphNodeReferencer
-func (n *NodeAbstractResourceInstance) References() []*addrs.Reference {
-	// If we have a configuration attached then we'll delegate to our
-	// embedded abstract resource, which knows how to extract dependencies
-	// from configuration. If there is no config, then the dependencies will
-	// be connected during destroy from those stored in the state.
-	if n.Config != nil {
-		if n.Schema == nil {
-			// We'll produce a log message about this out here so that
-			// we can include the full instance address, since the equivalent
-			// message in NodeAbstractResource.References cannot see it.
-			log.Printf("[WARN] no schema is attached to %s, so config references cannot be detected", n.Name())
-			return nil
-		}
-		return n.NodeAbstractResource.References()
+func (n *NodeAbstractResourceInstance) ActionCalls() []addrs.ConfigAction {
+	// if we're still planning, just delegate to the lower level resource
+	if n.actionApplyTriggers == nil {
+		return n.NodeAbstractResource.ActionCalls()
 	}
 
-	// If we have neither config nor state then we have no references.
-	return nil
+	var calls []addrs.ConfigAction
+	for _, trigger := range n.actionApplyTriggers {
+		calls = append(calls, trigger.ActionInvocation.Addr.ConfigAction())
+	}
+	return calls
 }
 
 // StateDependencies returns the dependencies which will be saved in the state
@@ -3114,6 +3104,216 @@ func getRequiredReplaces(priorVal, plannedNewVal cty.Value, writeOnly []cty.Path
 	return reqRep, diags
 }
 
+func (n *NodeAbstractResourceInstance) reportDeferredActionTriggers(ctx EvalContext, reason providers.DeferredReason) {
+	deferrals := ctx.Deferrals()
+
+	for blockIdx, trigger := range n.actionTriggers {
+		for listIdx, action := range trigger.actionRefs {
+			deferrals.ReportActionInvocationDeferred(plans.ActionInvocationInstance{
+				Addr: action.actionNode.Addr.Absolute(n.Addr.Module).Instance(addrs.NoKey),
+				ActionTrigger: &plans.ResourceActionTrigger{
+					TriggeringResourceAddr:  n.Addr,
+					ActionTriggerBlockIndex: blockIdx,
+					ActionsListIndex:        listIdx,
+				},
+			}, reason)
+		}
+	}
+}
+
+func (n *NodeAbstractResourceInstance) planActionTriggers(ctx EvalContext, resRepData instances.RepetitionData, change *plans.ResourceInstanceChange) tfdiags.Diagnostics {
+	var diags tfdiags.Diagnostics
+
+	// check if our containing resource was deferred
+	_, deferred := ctx.Deferrals().GetDeferredResourceInstanceValue(n.Addr)
+	if deferred {
+		return nil
+	}
+
+	// any of the actions might be deferred, so collect action actionInvocations
+	// and record them at the end
+	var actionInvocations []*plans.ActionInvocationInstance
+
+	for _, trigger := range n.actionTriggers {
+		scope := ctx.EvaluationScope(n.Addr.Resource, nil, resRepData)
+		cond := cty.True
+		if trigger.config.Condition != nil {
+			var conditionEvalDiags tfdiags.Diagnostics
+			cond, conditionEvalDiags = scope.EvalExpr(trigger.config.Condition, cty.Bool)
+			diags = diags.Append(conditionEvalDiags)
+			if diags.HasErrors() {
+				continue
+			}
+
+			if cond.IsKnown() && cond.False() {
+				// if we know the condition is going to be false, there's no need to
+				// even plan the action.
+				continue
+			}
+		}
+
+		// FIXME: this looks strange, because actions can have multiple events,
+		// but we're just repeating the same plan. Refactoring is annoying
+		// though because the event is set within a nested interface inside a
+		// pointer to the ActionInvocationInstance.
+		for _, event := range eventsForPlannedAction(trigger.config.Events, change.Action) {
+			if event.IsDestroy() && !cond.IsKnown() {
+				diags = diags.Append(&hcl.Diagnostic{
+					Severity: hcl.DiagError,
+					Summary:  "Unknown action trigger condition",
+					Detail:   "Condition expression must be known to plan a destroy action.",
+					Subject:  trigger.config.Condition.Range().Ptr(),
+				})
+				return diags
+			}
+
+			for _, action := range trigger.actionRefs {
+				ai, deferred, planDiags := n.planActionTrigger(ctx, resRepData, action, event, change)
+				diags = diags.Append(planDiags)
+				if diags.HasErrors() {
+					return diags
+				}
+
+				if deferred {
+					log.Printf("[DEBUG] NodePlannableResourceInstance %s is being deferred due to action %s", n.Addr, action.actionNode.Addr)
+					ctx.Changes().RemoveResourceInstanceChange(n.Addr, addrs.NotDeposed)
+					ctx.Deferrals().ReportResourceInstanceDeferred(n.Addr, providers.DeferredReasonAbsentPrereq, change)
+					// this defers all action triggers at once
+					n.reportDeferredActionTriggers(ctx, providers.DeferredReasonDeferredPrereq)
+					return diags
+				}
+
+				actionInvocations = append(actionInvocations, ai)
+			}
+		}
+	}
+
+	// Now that we planned all action invocations with no deferrals, we can
+	// record them all in the changes.
+	for _, ai := range actionInvocations {
+		ctx.Changes().AppendActionInvocation(ai)
+	}
+
+	return diags
+}
+
+// Plan the individual action invocation.
+// This function uses named result parameters.
+func (n *NodeAbstractResourceInstance) planActionTrigger(ctx EvalContext, resRepData instances.RepetitionData, actionRef actionRef, event configs.ActionTriggerEvent, change *plans.ResourceInstanceChange) (ai *plans.ActionInvocationInstance, deferred bool, diags tfdiags.Diagnostics) {
+
+	actionInst, evalActionDiags := evaluateActionExpression(actionRef.configRef.Expr, resRepData)
+	diags = append(diags, evalActionDiags...)
+	if diags.HasErrors() {
+		return
+	}
+
+	ai = &plans.ActionInvocationInstance{
+		Addr: actionInst.Absolute(n.Addr.Module),
+		ActionTrigger: &plans.ResourceActionTrigger{
+			TriggeringResourceAddr:  n.Addr,
+			ActionTriggerBlockIndex: actionRef.blockIndex,
+			ActionsListIndex:        actionRef.actionIndex,
+			ActionTriggerEvent:      event,
+		},
+		ProviderAddr: actionRef.actionNode.ResolvedProvider,
+	}
+
+	// check if this action was previously deferred
+	shouldDefer, deferDiags := ctx.Deferrals().ShouldDeferActionInvocation(ai)
+	diags = diags.Append(deferDiags)
+	if diags.HasErrors() {
+		return
+	}
+	if shouldDefer {
+		deferred = true
+		log.Printf("[DEBUG] action instance %s deferred due to config block deferral", actionInst)
+		return
+	}
+
+	callerVal := change.After
+	// If the resource is being destroyed, we want the before val. This works
+	// for replacement (this node doesn't handle full destroys), because the
+	// caller is associated with the existing resource instance rather than the
+	if event == configs.BeforeDestroy || event == configs.AfterDestroy {
+		callerVal = change.Before
+	}
+
+	actionVal, actionDiags := actionRef.actionNode.EvalInstance(ctx, actionInst.Absolute(ctx.Path()), actionRef.configRef.Expr.Range().Ptr(), n.Addr.Resource, callerVal)
+	diags = diags.Append(actionDiags)
+	if diags.HasErrors() {
+		return
+	}
+
+	if event.IsDestroy() {
+		if !actionVal.IsWhollyKnown() {
+			diags = diags.Append(&hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  "Unknown action config",
+				Detail:   "Action configuration must be known to plan a destroy action.",
+				Subject:  actionRef.actionNode.Config.DeclRange.Ptr(),
+			})
+			return
+		}
+
+		if len(ephemeral.EphemeralValuePaths(actionVal)) > 0 {
+			diags = diags.Append(&hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  "Action config contains ephemeral values",
+				Detail:   "A destroy action configuration must be fully planned, and cannot contain ephemeral values.",
+				Subject:  actionRef.actionNode.Config.DeclRange.Ptr(),
+			})
+			return
+		}
+	}
+
+	provider, _, err := getProvider(ctx, actionRef.actionNode.ResolvedProvider)
+	if err != nil {
+		diags = diags.Append(&hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  "Failed to get provider",
+			Detail:   fmt.Sprintf("Failed to get provider: %s", err),
+			Subject:  actionRef.actionNode.Config.DeclRange.Ptr(),
+		})
+
+		return
+	}
+
+	unmarkedConfig, _ := actionVal.UnmarkDeepWithPaths()
+
+	resp := provider.PlanAction(providers.PlanActionRequest{
+		ActionType:         actionRef.actionNode.Addr.Action.Type,
+		ProposedActionData: unmarkedConfig,
+		ClientCapabilities: ctx.ClientCapabilities(),
+	})
+
+	// Associate any provider produced diagnostics with the action config block.
+	if actionRef.actionNode.Config.Config != nil {
+		resp.Diagnostics = resp.Diagnostics.InConfigBody(actionRef.actionNode.Config.Config, n.Addr.String())
+	} else {
+		// if there was no action config block, use the entire action block for reference
+		resp.Diagnostics = resp.Diagnostics.InConfigBody(actionRef.actionNode.Config.Body, n.Addr.String())
+	}
+
+	diags = diags.Append(resp.Diagnostics)
+
+	if resp.Deferred != nil {
+		if !ctx.Deferrals().DeferralAllowed() {
+			diags = diags.Append(deferring.UnexpectedProviderDeferralDiagnostic(actionInst))
+			return
+		}
+		log.Printf("[DEBUG] action instance %s deferred by provider", actionInst)
+		deferred = true
+		return
+	}
+
+	if resp.Diagnostics.HasErrors() {
+		return
+	}
+
+	ai.ConfigValue = ephemeral.RemoveEphemeralValues(actionVal)
+	return
+}
+
 // pre-check for before actions since being able to evaluate actions requires a
 // slightly different behavior for diff handling, we guard that change by seeing if
 // it's needed at all.
@@ -3140,7 +3340,7 @@ func (n *NodeAbstractResourceInstance) invokeDestroyActions(ctx EvalContext, for
 			continue
 		}
 
-		log.Printf("[DEBUG] NodeAbstractesourceInstance: invoking destroy action %s", trigger.ActionInvocation.Addr)
+		log.Printf("[DEBUG] NodeAbstractResourceInstance: invoking destroy action %s", trigger.ActionInvocation.Addr)
 		diags = diags.Append(trigger.Invoke(ctx, n.Addr.Resource, cty.DynamicVal, true))
 		if diags.HasErrors() {
 			break
@@ -3168,7 +3368,7 @@ func (n *NodeAbstractResourceInstance) invokeActions(ctx EvalContext, repData in
 		}
 
 		if !condOK {
-			log.Printf("[DEBUG] NodeAbstractesourceInstance: action condition false, skipping %s", trigger.ActionInvocation.Addr)
+			log.Printf("[DEBUG] NodeAbstractResourceInstance: action condition false, skipping %s", trigger.ActionInvocation.Addr)
 			continue
 		}
 
@@ -3214,12 +3414,4 @@ func (n *NodeAbstractResourceInstance) evalActionCondition(ctx EvalContext, trig
 	}
 
 	return cond.True(), diags
-}
-
-func (n *NodeAbstractResourceInstance) ActionProviders() []ProviderRef {
-	var refs []ProviderRef
-	for _, trigger := range n.actionApplyTriggers {
-		refs = append(refs, ProviderRef{Addr: trigger.ActionInvocation.ProviderAddr, Resolved: true})
-	}
-	return refs
 }

--- a/internal/terraform/node_resource_apply_instance.go
+++ b/internal/terraform/node_resource_apply_instance.go
@@ -144,7 +144,7 @@ func (n *NodeApplyableResourceInstance) dataResourceExecute(ctx EvalContext) (di
 		}
 	}
 
-	diags = diags.Append(n.writeChange(ctx, nil, ""))
+	diags = diags.Append(n.writeChange(ctx, nil, states.NotDeposed))
 
 	diags = diags.Append(updateStateHook(ctx))
 
@@ -298,7 +298,7 @@ func (n *NodeApplyableResourceInstance) managedResourceExecute(ctx EvalContext) 
 
 	// We clear the change out here so that future nodes don't see a change
 	// that is already complete.
-	err = n.writeChange(ctx, nil, "")
+	err = n.writeChange(ctx, nil, states.NotDeposed)
 	if err != nil {
 		return diags.Append(err)
 	}

--- a/internal/terraform/node_resource_destroy.go
+++ b/internal/terraform/node_resource_destroy.go
@@ -34,6 +34,7 @@ var (
 	_ GraphNodeExecutable          = (*NodeDestroyResourceInstance)(nil)
 	_ GraphNodeProviderConsumer    = (*NodeDestroyResourceInstance)(nil)
 	_ GraphNodeProvisionerConsumer = (*NodeDestroyResourceInstance)(nil)
+	_ GraphNodeActionCaller        = (*NodeDestroyResourceInstance)(nil)
 )
 
 func (n *NodeDestroyResourceInstance) Name() string {
@@ -84,31 +85,6 @@ func (n *NodeDestroyResourceInstance) ModifyCreateBeforeDestroy(v bool) error {
 func (n *NodeDestroyResourceInstance) ReferenceableAddrs() []addrs.Referenceable {
 	// a destroy node is not referenceable
 	return []addrs.Referenceable{}
-}
-
-// GraphNodeReferencer, overriding NodeAbstractResource
-func (n *NodeDestroyResourceInstance) References() []*addrs.Reference {
-	// If we have a config, then we need to include destroy-time dependencies
-	if c := n.Config; c != nil && c.Managed != nil {
-		var result []*addrs.Reference
-
-		// We include conn info and config for destroy time provisioners
-		// as dependencies that we have.
-		for _, p := range c.Managed.Provisioners {
-			schema := n.ProvisionerSchemas[p.Type]
-
-			if p.When == configs.ProvisionerWhenDestroy {
-				if p.Connection != nil {
-					result = append(result, ReferencesFromConfig(p.Connection.Config, connectionBlockSupersetSchema)...)
-				}
-				result = append(result, ReferencesFromConfig(p.Config, schema)...)
-			}
-		}
-
-		return result
-	}
-
-	return nil
 }
 
 // GraphNodeExecutable

--- a/internal/terraform/node_resource_destroy_deposed.go
+++ b/internal/terraform/node_resource_destroy_deposed.go
@@ -249,13 +249,6 @@ func (n *NodeDestroyDeposedResourceInstanceObject) ReferenceableAddrs() []addrs.
 	return nil
 }
 
-// GraphNodeReferencer implementation, overriding the one from NodeAbstractResourceInstance
-func (n *NodeDestroyDeposedResourceInstanceObject) References() []*addrs.Reference {
-	// We don't evaluate configuration for deposed objects, so they effectively
-	// make no references.
-	return nil
-}
-
 // GraphNodeDestroyer
 func (n *NodeDestroyDeposedResourceInstanceObject) DestroyAddr() *addrs.AbsResourceInstance {
 	addr := n.ResourceInstanceAddr()

--- a/internal/terraform/node_resource_destroy_deposed.go
+++ b/internal/terraform/node_resource_destroy_deposed.go
@@ -63,9 +63,14 @@ var (
 	_ GraphNodeProviderConsumer              = (*NodePlanDeposedResourceInstanceObject)(nil)
 	_ GraphNodeProvisionerConsumer           = (*NodePlanDeposedResourceInstanceObject)(nil)
 	_ GraphNodeDestroyer                     = (*NodePlanDeposedResourceInstanceObject)(nil)
+	_ GraphNodePlanDestroyer                 = (*NodePlanDeposedResourceInstanceObject)(nil)
 )
 
 func (n *NodePlanDeposedResourceInstanceObject) DestroyAddr() *addrs.AbsResourceInstance {
+	return &n.Addr
+}
+
+func (n *NodePlanDeposedResourceInstanceObject) PlanDestroyAddr() *addrs.AbsResourceInstance {
 	return &n.Addr
 }
 

--- a/internal/terraform/node_resource_plan.go
+++ b/internal/terraform/node_resource_plan.go
@@ -643,6 +643,7 @@ func (n *nodeExpandPlannableResource) concreteResourceOrphan(a *NodeAbstractReso
 	a.Schema = n.Schema
 	a.ProvisionerSchemas = n.ProvisionerSchemas
 	a.ProviderMetas = n.ProviderMetas
+	a.actionTriggers = n.actionTriggers
 
 	return &NodePlannableResourceInstanceOrphan{
 		NodeAbstractResourceInstance: a,

--- a/internal/terraform/node_resource_plan_destroy.go
+++ b/internal/terraform/node_resource_plan_destroy.go
@@ -29,6 +29,7 @@ var (
 	_ GraphNodeReferenceable        = (*NodePlanDestroyableResourceInstance)(nil)
 	_ GraphNodeReferencer           = (*NodePlanDestroyableResourceInstance)(nil)
 	_ GraphNodeDestroyer            = (*NodePlanDestroyableResourceInstance)(nil)
+	_ GraphNodePlanDestroyer        = (*NodePlanDestroyableResourceInstance)(nil)
 	_ GraphNodeConfigResource       = (*NodePlanDestroyableResourceInstance)(nil)
 	_ GraphNodeResourceInstance     = (*NodePlanDestroyableResourceInstance)(nil)
 	_ GraphNodeAttachResourceConfig = (*NodePlanDestroyableResourceInstance)(nil)
@@ -36,6 +37,7 @@ var (
 	_ GraphNodeExecutable           = (*NodePlanDestroyableResourceInstance)(nil)
 	_ GraphNodeProviderConsumer     = (*NodePlanDestroyableResourceInstance)(nil)
 	_ GraphNodeActionCaller         = (*NodePlanDestroyableResourceInstance)(nil)
+	_ GraphNodeAttachActionTriggers = (*NodePlanDestroyableResourceInstance)(nil)
 )
 
 func (n *NodePlanDestroyableResourceInstance) Name() string {
@@ -46,6 +48,21 @@ func (n *NodePlanDestroyableResourceInstance) Name() string {
 func (n *NodePlanDestroyableResourceInstance) DestroyAddr() *addrs.AbsResourceInstance {
 	addr := n.ResourceInstanceAddr()
 	return &addr
+}
+
+func (n *NodePlanDestroyableResourceInstance) PlanDestroyAddr() *addrs.AbsResourceInstance {
+	addr := n.ResourceInstanceAddr()
+	return &addr
+}
+
+func (n *NodePlanDestroyableResourceInstance) ReferenceableAddrs() []addrs.Referenceable {
+	// destroy nodes are not referenceable, so we must override the method from
+	// the abstract layers
+	return nil
+}
+
+func (n *NodePlanDestroyableResourceInstance) AttachActionTriggers(triggers []*resourceActionTrigger) {
+	n.actionTriggers = triggers
 }
 
 // GraphNodeEvalable

--- a/internal/terraform/node_resource_plan_destroy.go
+++ b/internal/terraform/node_resource_plan_destroy.go
@@ -35,6 +35,7 @@ var (
 	_ GraphNodeAttachResourceState  = (*NodePlanDestroyableResourceInstance)(nil)
 	_ GraphNodeExecutable           = (*NodePlanDestroyableResourceInstance)(nil)
 	_ GraphNodeProviderConsumer     = (*NodePlanDestroyableResourceInstance)(nil)
+	_ GraphNodeActionCaller         = (*NodePlanDestroyableResourceInstance)(nil)
 )
 
 func (n *NodePlanDestroyableResourceInstance) Name() string {
@@ -107,6 +108,7 @@ func (n *NodePlanDestroyableResourceInstance) managedResourceExecute(ctx EvalCon
 		return diags
 	} else if ctx.Deferrals().ShouldDeferResourceInstanceChanges(n.Addr, n.Dependencies) {
 		ctx.Deferrals().ReportResourceInstanceDeferred(n.Addr, providers.DeferredReasonDeferredPrereq, change)
+		n.reportDeferredActionTriggers(ctx, providers.DeferredReasonDeferredPrereq)
 		return diags
 	}
 
@@ -115,12 +117,14 @@ func (n *NodePlanDestroyableResourceInstance) managedResourceExecute(ctx EvalCon
 	// context surrounding the change, rather than the change itself, and
 	// so it's helpful to still include the valid-in-isolation change as
 	// part of the plan as additional context in our error output.
-	diags = diags.Append(n.writeChange(ctx, change, ""))
+	diags = diags.Append(n.writeChange(ctx, change, states.NotDeposed))
 
 	diags = diags.Append(n.checkPreventDestroy(change))
 	if diags.HasErrors() {
 		return diags
 	}
+
+	diags = diags.Append(n.planActionTriggers(ctx, EvalDataForInstanceKey(n.ResourceInstanceAddr().Resource.Key, nil), change))
 
 	return diags
 }
@@ -141,5 +145,5 @@ func (n *NodePlanDestroyableResourceInstance) dataResourceExecute(ctx EvalContex
 		},
 		ProviderAddr: n.ResolvedProvider,
 	}
-	return diags.Append(n.writeChange(ctx, change, ""))
+	return diags.Append(n.writeChange(ctx, change, states.NotDeposed))
 }

--- a/internal/terraform/node_resource_plan_instance.go
+++ b/internal/terraform/node_resource_plan_instance.go
@@ -51,9 +51,6 @@ type NodePlannableResourceInstance struct {
 	// importTarget, if populated, contains the information necessary to plan
 	// an import of this resource.
 	importTarget importTarget
-
-	// We store a copy of the instance change for use by actions.
-	change *plans.ResourceInstanceChange
 }
 
 type importTarget struct {
@@ -144,7 +141,7 @@ func (n *NodePlannableResourceInstance) dataResourceExecute(ctx EvalContext) (di
 			return diags
 		}
 
-		diags = diags.Append(n.writeChange(ctx, change, ""))
+		diags = diags.Append(n.writeChange(ctx, change, states.NotDeposed))
 
 		// Post-conditions might block further progress. We intentionally do this
 		// _after_ writing the state/diff because we want to check against
@@ -406,14 +403,11 @@ func (n *NodePlannableResourceInstance) managedResourceExecute(ctx EvalContext) 
 						GeneratedConfig: n.generatedConfigHCL,
 					},
 				}
-				diags = diags.Append(n.writeChange(ctx, change, ""))
+				diags = diags.Append(n.writeChange(ctx, change, states.NotDeposed))
 			}
 
 			return diags
 		}
-
-		// keep this around for actions evaluation
-		n.change = change
 
 		if deferred == nil && planDeferred != nil {
 			deferred = planDeferred
@@ -452,7 +446,7 @@ func (n *NodePlannableResourceInstance) managedResourceExecute(ctx EvalContext) 
 			// context surrounding the change, rather than the change itself, and
 			// so it's helpful to still include the valid-in-isolation change as
 			// part of the plan as additional context in our error output.
-			diags = diags.Append(n.writeChange(ctx, change, ""))
+			diags = diags.Append(n.writeChange(ctx, change, states.NotDeposed))
 			if diags.HasErrors() {
 				return diags
 			}
@@ -510,7 +504,7 @@ func (n *NodePlannableResourceInstance) managedResourceExecute(ctx EvalContext) 
 		// Now that the instance is planned we can plan any triggered actions.
 		// Note that these may also result in resource deferral, so we can't
 		// count in having a plan yet.
-		diags = diags.Append(n.planActionTriggers(ctx, repData))
+		diags = diags.Append(n.planActionTriggers(ctx, repData, change))
 
 	} else {
 		// In refresh-only mode we need to evaluate the for-each expression in
@@ -572,224 +566,6 @@ func (n *NodePlannableResourceInstance) managedResourceExecute(ctx EvalContext) 
 	}
 
 	return diags
-}
-
-func (n *NodePlannableResourceInstance) reportDeferredActionTriggers(ctx EvalContext, reason providers.DeferredReason) {
-	deferrals := ctx.Deferrals()
-
-	for blockIdx, trigger := range n.actionTriggers {
-		for listIdx, action := range trigger.actionRefs {
-			deferrals.ReportActionInvocationDeferred(plans.ActionInvocationInstance{
-				Addr: action.actionNode.Addr.Absolute(n.Addr.Module).Instance(addrs.NoKey),
-				ActionTrigger: &plans.ResourceActionTrigger{
-					TriggeringResourceAddr:  n.Addr,
-					ActionTriggerBlockIndex: blockIdx,
-					ActionsListIndex:        listIdx,
-				},
-			}, reason)
-		}
-	}
-}
-
-func (n *NodePlannableResourceInstance) planActionTriggers(ctx EvalContext, resRepData instances.RepetitionData) tfdiags.Diagnostics {
-	var diags tfdiags.Diagnostics
-
-	// check if our containing resource was deferred
-	_, deferred := ctx.Deferrals().GetDeferredResourceInstanceValue(n.Addr)
-	if deferred {
-		return nil
-	}
-
-	// any of the actions might be deferred, so collect action actionInvocations
-	// and record them at the end
-	var actionInvocations []*plans.ActionInvocationInstance
-
-	for _, trigger := range n.actionTriggers {
-		scope := ctx.EvaluationScope(n.Addr.Resource, nil, resRepData)
-		cond := cty.True
-		if trigger.config.Condition != nil {
-			var conditionEvalDiags tfdiags.Diagnostics
-			cond, conditionEvalDiags = scope.EvalExpr(trigger.config.Condition, cty.Bool)
-			diags = diags.Append(conditionEvalDiags)
-			if diags.HasErrors() {
-				continue
-			}
-
-			if cond.IsKnown() && cond.False() {
-				// if we know the condition is going to be false, there's no need to
-				// even plan the action.
-				continue
-			}
-		}
-
-		// FIXME: this looks strange, because actions can have multiple events,
-		// but we're just repeating the same plan. Refactoring is annoying
-		// though because the event is set within a nested interface inside a
-		// pointer to the ActionInvocationInstance.
-		for _, event := range eventsForPlannedAction(trigger.config.Events, n.change.Action) {
-			if event.IsDestroy() && !cond.IsKnown() {
-				diags = diags.Append(&hcl.Diagnostic{
-					Severity: hcl.DiagError,
-					Summary:  "Unknown action trigger condition",
-					Detail:   "Condition expression must be known to plan a destroy action.",
-					Subject:  trigger.config.Condition.Range().Ptr(),
-				})
-				return diags
-			}
-
-			for _, action := range trigger.actionRefs {
-				ai, deferred, planDiags := n.planActionTrigger(ctx, resRepData, action, event)
-				diags = diags.Append(planDiags)
-				if diags.HasErrors() {
-					return diags
-				}
-
-				if deferred {
-					log.Printf("[DEBUG] NodePlannableResourceInstance %s is being deferred due to action %s", n.Addr, action.actionNode.Addr)
-
-					// get the change for the deferral reporting mechanism, then
-					// revoke and defer the change we just planned.
-					changes := ctx.Changes()
-					change := changes.GetResourceInstanceChange(n.Addr, addrs.NotDeposed)
-					if change != nil {
-						ctx.Changes().RemoveResourceInstanceChange(n.Addr, addrs.NotDeposed)
-					}
-					ctx.Deferrals().ReportResourceInstanceDeferred(n.Addr, providers.DeferredReasonAbsentPrereq, change)
-
-					// this defers all action triggers at once
-					n.reportDeferredActionTriggers(ctx, providers.DeferredReasonDeferredPrereq)
-					return diags
-				}
-
-				actionInvocations = append(actionInvocations, ai)
-			}
-		}
-	}
-
-	// Now that we planned all action invocations with no deferrals, we can
-	// record them all in the changes.
-	for _, ai := range actionInvocations {
-		ctx.Changes().AppendActionInvocation(ai)
-	}
-
-	return diags
-}
-
-// Plan the individual action invocation.
-// This function uses named result parameters.
-func (n *NodePlannableResourceInstance) planActionTrigger(ctx EvalContext, resRepData instances.RepetitionData, actionRef actionRef, event configs.ActionTriggerEvent) (ai *plans.ActionInvocationInstance, deferred bool, diags tfdiags.Diagnostics) {
-
-	actionInst, evalActionDiags := evaluateActionExpression(actionRef.configRef.Expr, resRepData)
-	diags = append(diags, evalActionDiags...)
-	if diags.HasErrors() {
-		return
-	}
-
-	ai = &plans.ActionInvocationInstance{
-		Addr: actionInst.Absolute(n.Addr.Module),
-		ActionTrigger: &plans.ResourceActionTrigger{
-			TriggeringResourceAddr:  n.Addr,
-			ActionTriggerBlockIndex: actionRef.blockIndex,
-			ActionsListIndex:        actionRef.actionIndex,
-			ActionTriggerEvent:      event,
-		},
-		ProviderAddr: actionRef.actionNode.ResolvedProvider,
-	}
-
-	// check if this action was previously deferred
-	shouldDefer, deferDiags := ctx.Deferrals().ShouldDeferActionInvocation(ai)
-	diags = diags.Append(deferDiags)
-	if diags.HasErrors() {
-		return
-	}
-	if shouldDefer {
-		deferred = true
-		log.Printf("[DEBUG] action instance %s deferred due to config block deferral", actionInst)
-		return
-	}
-
-	callerVal := n.change.After
-	// If the resource is being destroyed, we want the before val. This works
-	// for replacement (this node doesn't handle full destroys), because the
-	// caller is associated with the existing resource instance rather than the
-	if event == configs.BeforeDestroy || event == configs.AfterDestroy {
-		callerVal = n.change.Before
-	}
-
-	actionVal, actionDiags := actionRef.actionNode.EvalInstance(ctx, actionInst.Absolute(ctx.Path()), actionRef.configRef.Expr.Range().Ptr(), n.Addr.Resource, callerVal)
-	diags = diags.Append(actionDiags)
-	if diags.HasErrors() {
-		return
-	}
-
-	if event.IsDestroy() {
-		if !actionVal.IsWhollyKnown() {
-			diags = diags.Append(&hcl.Diagnostic{
-				Severity: hcl.DiagError,
-				Summary:  "Unknown action config",
-				Detail:   "Action configuration must be known to plan a destroy action.",
-				Subject:  actionRef.actionNode.Config.DeclRange.Ptr(),
-			})
-			return
-		}
-
-		if len(ephemeral.EphemeralValuePaths(actionVal)) > 0 {
-			diags = diags.Append(&hcl.Diagnostic{
-				Severity: hcl.DiagError,
-				Summary:  "Action config contains ephemeral values",
-				Detail:   "A destroy action configuration must be fully planned, and cannot contain ephemeral values.",
-				Subject:  actionRef.actionNode.Config.DeclRange.Ptr(),
-			})
-			return
-		}
-	}
-
-	provider, _, err := getProvider(ctx, actionRef.actionNode.ResolvedProvider)
-	if err != nil {
-		diags = diags.Append(&hcl.Diagnostic{
-			Severity: hcl.DiagError,
-			Summary:  "Failed to get provider",
-			Detail:   fmt.Sprintf("Failed to get provider: %s", err),
-			Subject:  actionRef.actionNode.Config.DeclRange.Ptr(),
-		})
-
-		return
-	}
-
-	unmarkedConfig, _ := actionVal.UnmarkDeepWithPaths()
-
-	resp := provider.PlanAction(providers.PlanActionRequest{
-		ActionType:         actionRef.actionNode.Addr.Action.Type,
-		ProposedActionData: unmarkedConfig,
-		ClientCapabilities: ctx.ClientCapabilities(),
-	})
-
-	// Associate any provider produced diagnostics with the action config block.
-	if actionRef.actionNode.Config.Config != nil {
-		resp.Diagnostics = resp.Diagnostics.InConfigBody(actionRef.actionNode.Config.Config, n.Addr.String())
-	} else {
-		// if there was no action config block, use the entire action block for reference
-		resp.Diagnostics = resp.Diagnostics.InConfigBody(actionRef.actionNode.Config.Body, n.Addr.String())
-	}
-
-	diags = diags.Append(resp.Diagnostics)
-
-	if resp.Deferred != nil {
-		if !ctx.Deferrals().DeferralAllowed() {
-			diags = diags.Append(deferring.UnexpectedProviderDeferralDiagnostic(actionInst))
-			return
-		}
-		log.Printf("[DEBUG] action instance %s deferred by provider", actionInst)
-		deferred = true
-		return
-	}
-
-	if resp.Diagnostics.HasErrors() {
-		return
-	}
-
-	ai.ConfigValue = ephemeral.RemoveEphemeralValues(actionVal)
-	return
 }
 
 // replaceTriggered checks if this instance needs to be replace due to a change

--- a/internal/terraform/node_resource_plan_orphan.go
+++ b/internal/terraform/node_resource_plan_orphan.go
@@ -174,6 +174,7 @@ func (n *NodePlannableResourceInstanceOrphan) managedResourceExecute(ctx EvalCon
 		return diags
 	} else if shouldDefer {
 		ctx.Deferrals().ReportResourceInstanceDeferred(n.Addr, providers.DeferredReasonDeferredPrereq, change)
+		n.reportDeferredActionTriggers(ctx, providers.DeferredReasonDeferredPrereq)
 		return diags
 	}
 
@@ -190,7 +191,7 @@ func (n *NodePlannableResourceInstanceOrphan) managedResourceExecute(ctx EvalCon
 	// context surrounding the change, rather than the change itself, and
 	// so it's helpful to still include the valid-in-isolation change as
 	// part of the plan as additional context in our error output.
-	diags = diags.Append(n.writeChange(ctx, change, ""))
+	diags = diags.Append(n.writeChange(ctx, change, states.NotDeposed))
 	if diags.HasErrors() {
 		return diags
 	}
@@ -202,7 +203,9 @@ func (n *NodePlannableResourceInstanceOrphan) managedResourceExecute(ctx EvalCon
 		}
 	}
 
-	return diags.Append(n.writeResourceInstanceState(ctx, nil, workingState))
+	diags = diags.Append(n.writeResourceInstanceState(ctx, nil, workingState))
+	diags = diags.Append(n.planActionTriggers(ctx, EvalDataForInstanceKey(n.ResourceInstanceAddr().Resource.Key, nil), change))
+	return diags
 }
 
 func (n *NodePlannableResourceInstanceOrphan) deleteActionReason(ctx EvalContext) plans.ResourceInstanceChangeActionReason {

--- a/internal/terraform/node_resource_plan_orphan.go
+++ b/internal/terraform/node_resource_plan_orphan.go
@@ -45,10 +45,22 @@ var (
 	_ GraphNodeAttachResourceState  = (*NodePlannableResourceInstanceOrphan)(nil)
 	_ GraphNodeExecutable           = (*NodePlannableResourceInstanceOrphan)(nil)
 	_ GraphNodeProviderConsumer     = (*NodePlannableResourceInstanceOrphan)(nil)
+	_ GraphNodeDestroyer            = (*NodePlannableResourceInstanceOrphan)(nil)
+	_ GraphNodePlanDestroyer        = (*NodePlannableResourceInstanceOrphan)(nil)
 )
 
 func (n *NodePlannableResourceInstanceOrphan) Name() string {
 	return n.ResourceInstanceAddr().String() + " (orphan)"
+}
+
+func (n *NodePlannableResourceInstanceOrphan) DestroyAddr() *addrs.AbsResourceInstance {
+	addr := n.ResourceInstanceAddr()
+	return &addr
+}
+
+func (n *NodePlannableResourceInstanceOrphan) PlanDestroyAddr() *addrs.AbsResourceInstance {
+	addr := n.ResourceInstanceAddr()
+	return &addr
 }
 
 // GraphNodeExecutable
@@ -74,6 +86,16 @@ func (n *NodePlannableResourceInstanceOrphan) Provider() ProviderRef {
 		return p
 	}
 	return n.NodeAbstractResourceInstance.Provider()
+}
+
+func (n *NodePlannableResourceInstanceOrphan) ReferenceableAddrs() []addrs.Referenceable {
+	// destroy nodes are not referenceable, so we must override the method from
+	// the abstract layers
+	return nil
+}
+
+func (n *NodePlannableResourceInstanceOrphan) AttachActionTriggers(triggers []*resourceActionTrigger) {
+	n.actionTriggers = triggers
 }
 
 func (n *NodePlannableResourceInstanceOrphan) dataResourceExecute(ctx EvalContext) tfdiags.Diagnostics {

--- a/internal/terraform/transform_action_diff.go
+++ b/internal/terraform/transform_action_diff.go
@@ -36,41 +36,43 @@ func (t *ActionDiffTransformer) Transform(g *Graph) error {
 	for _, ai := range t.Changes.ActionInvocations {
 		switch actionTrigger := ai.ActionTrigger.(type) {
 		case *plans.ResourceActionTrigger:
-			atns, ok := resourceInstanceNodes.GetOk(actionTrigger.TriggeringResourceAddr)
+			resourceInstances, ok := resourceInstanceNodes.GetOk(actionTrigger.TriggeringResourceAddr)
 			if !ok {
 				return fmt.Errorf("no resource node found for action trigger %s", actionTrigger.TriggeringResourceAddr)
 			}
-
-			foundNode := false
 
 			actionConfig, ok := actionConfigNodes.GetOk(ai.Addr.ConfigAction())
 			if !ok {
 				return fmt.Errorf("no action config node found for action trigger %s", actionTrigger.TriggeringResourceAddr)
 			}
 
+			foundNode := false
+
 			// Add the action triggers to their instance nodes.
-			for _, atn := range atns {
+			for _, resourceInstance := range resourceInstances {
+				invoker, ok := resourceInstance.(GraphNodeActionInvoker)
+				if !ok {
+					return fmt.Errorf("node %s type %T is not a GraphNodeActionInvoker", resourceInstance.ResourceInstanceAddr(), resourceInstance)
+				}
+
 				if actionTrigger.ActionTriggerEvent.IsDestroy() {
-					// FIXME: hard-coded types!
-					if n, ok := atn.(*NodeDestroyResourceInstance); ok {
-						fmt.Printf("FOUND DEST INST")
-						n.actionApplyTriggers = append(n.actionApplyTriggers, &actionTriggerApplyInstance{
+					// we may have both create and destroy nodes under ths same
+					// address, so match up their types
+					if _, ok := resourceInstance.(GraphNodeDestroyer); ok {
+						invoker.AttachActionApplyTrigger(&actionTriggerApplyInstance{
 							ActionInvocation: ai,
 							actionNode:       actionConfig,
 						})
-						foundNode = true
-
 					}
+					foundNode = true
 					continue
 				}
 
-				if n, ok := atn.(*NodeApplyableResourceInstance); ok {
-					n.actionApplyTriggers = append(n.actionApplyTriggers, &actionTriggerApplyInstance{
-						ActionInvocation: ai,
-						actionNode:       actionConfig,
-					})
-					foundNode = true
-				}
+				invoker.AttachActionApplyTrigger(&actionTriggerApplyInstance{
+					ActionInvocation: ai,
+					actionNode:       actionConfig,
+				})
+				foundNode = true
 			}
 			if !foundNode {
 				return fmt.Errorf("no resource node found for action trigger %s", actionTrigger.TriggeringResourceAddr)

--- a/internal/terraform/transform_action_diff.go
+++ b/internal/terraform/transform_action_diff.go
@@ -51,7 +51,9 @@ func (t *ActionDiffTransformer) Transform(g *Graph) error {
 			// Add the action triggers to their instance nodes.
 			for _, atn := range atns {
 				if actionTrigger.ActionTriggerEvent.IsDestroy() {
+					// FIXME: hard-coded types!
 					if n, ok := atn.(*NodeDestroyResourceInstance); ok {
+						fmt.Printf("FOUND DEST INST")
 						n.actionApplyTriggers = append(n.actionApplyTriggers, &actionTriggerApplyInstance{
 							ActionInvocation: ai,
 							actionNode:       actionConfig,

--- a/internal/terraform/transform_action_diff.go
+++ b/internal/terraform/transform_action_diff.go
@@ -41,7 +41,6 @@ func (t *ActionDiffTransformer) Transform(g *Graph) error {
 				return fmt.Errorf("no resource node found for action trigger %s", actionTrigger.TriggeringResourceAddr)
 			}
 
-			destroy := actionTrigger.ActionTriggerEvent == configs.BeforeDestroy || actionTrigger.ActionTriggerEvent == configs.AfterDestroy
 			foundNode := false
 
 			actionConfig, ok := actionConfigNodes.GetOk(ai.Addr.ConfigAction())
@@ -51,7 +50,7 @@ func (t *ActionDiffTransformer) Transform(g *Graph) error {
 
 			// Add the action triggers to their instance nodes.
 			for _, atn := range atns {
-				if destroy {
+				if actionTrigger.ActionTriggerEvent.IsDestroy() {
 					if n, ok := atn.(*NodeDestroyResourceInstance); ok {
 						n.actionApplyTriggers = append(n.actionApplyTriggers, &actionTriggerApplyInstance{
 							ActionInvocation: ai,

--- a/internal/terraform/transform_action_diff.go
+++ b/internal/terraform/transform_action_diff.go
@@ -63,8 +63,8 @@ func (t *ActionDiffTransformer) Transform(g *Graph) error {
 							ActionInvocation: ai,
 							actionNode:       actionConfig,
 						})
+						foundNode = true
 					}
-					foundNode = true
 					continue
 				}
 

--- a/internal/terraform/transform_attach_config_resource.go
+++ b/internal/terraform/transform_attach_config_resource.go
@@ -23,6 +23,14 @@ type GraphNodeAttachResourceConfig interface {
 	AttachResourceConfig(*configs.Resource, *configs.Removed)
 }
 
+// GraphNodeAttachActionTriggers is used by the AttachResourceConfigTransformer to
+// attach configuration to action callers.
+type GraphNodeAttachActionTriggers interface {
+	GraphNodeAttachResourceConfig
+
+	AttachActionTriggers([]*resourceActionTrigger)
+}
+
 // AttachResourceConfigTransformer goes through the graph and attaches
 // resource configuration structures to nodes that implement
 // GraphNodeAttachResourceConfig.
@@ -51,9 +59,18 @@ func (t *AttachResourceConfigTransformer) Transform(g *Graph) error {
 		}
 	})
 
+	// action nodes must be embedded along with the configured action refs, so
+	// first find any action nodes that have already been inserted
+	actionConfigNodes := addrs.MakeMap[addrs.ConfigAction, *NodeActionConfig]()
+	for _, v := range g.Vertices() {
+		switch v := v.(type) {
+		case *NodeActionConfig:
+			actionConfigNodes.Put(v.ActionAddr(), v)
+		}
+	}
+
 	// Go through and find GraphNodeAttachResource
 	for _, v := range g.Vertices() {
-		// Only care about GraphNodeAttachResourceConfig implementations
 		arn, ok := v.(GraphNodeAttachResourceConfig)
 		if !ok {
 			continue
@@ -86,6 +103,15 @@ func (t *AttachResourceConfigTransformer) Transform(g *Graph) error {
 				} else {
 					log.Printf("[TRACE] AttachResourceConfigTransformer: no provider meta configs available to attach to %s", dag.VertexName(v))
 				}
+			}
+
+			if aat, ok := v.(GraphNodeAttachActionTriggers); ok {
+				triggers, triggerDiags := buildActionTriggers(r, addr.Module, actionConfigNodes)
+				if triggerDiags.HasErrors() {
+					return triggerDiags.ErrWithWarnings()
+				}
+
+				aat.AttachActionTriggers(triggers)
 			}
 		}
 	}

--- a/internal/terraform/transform_config.go
+++ b/internal/terraform/transform_config.go
@@ -354,8 +354,6 @@ func buildActionTriggers(resource *configs.Resource, path addrs.Module, allConfi
 				continue
 			}
 
-			// referencedActionConfigs.Add(configAction)
-
 			resActTrig.actionRefs = append(resActTrig.actionRefs, actionRef{
 				configRef:   action,
 				actionNode:  actionNode,

--- a/internal/terraform/transform_config.go
+++ b/internal/terraform/transform_config.go
@@ -162,6 +162,14 @@ func (t *ConfigTransformer) transformSingle(g *Graph, config *configs.Config) er
 		}
 		var diags tfdiags.Diagnostics
 
+		// FIXME: we need to attach the config to planned instances (destroy
+		// nodes, and orphan nodes). try and do this in
+		// AttachResourceConfigTransformer.
+		//
+		// Make sure orphaned instances get their configs during expansion
+		// somehow too.
+		//
+		//
 		if r.Managed != nil && r.Managed.ActionTriggers != nil {
 			for blockIdx, at := range r.Managed.ActionTriggers {
 				resActTrig := &resourceActionTrigger{
@@ -190,6 +198,7 @@ func (t *ConfigTransformer) transformSingle(g *Graph, config *configs.Config) er
 					}
 
 					// Verify that any actions referenced in the resource's ActionTriggers exist in this module
+					// FIXME: can this be checked during config loading?
 					actionNode, ok := allConfigActions.GetOk(configAction)
 					if !ok {
 						var keys []string
@@ -270,7 +279,9 @@ func (t *ConfigTransformer) transformSingle(g *Graph, config *configs.Config) er
 		g.Add(node)
 	}
 
-	// convert unused action config nodes into validation nodes
+	// Convert unused action config nodes into validation nodes. Any triggered
+	// actions will be validated from the caller so we can actually validate the
+	// use of "caller".
 	if t.Operation == walkValidate {
 		for addr, node := range allConfigActions.Iter() {
 			if !referencedActionConfigs.Has(addr) {

--- a/internal/terraform/transform_config.go
+++ b/internal/terraform/transform_config.go
@@ -162,77 +162,22 @@ func (t *ConfigTransformer) transformSingle(g *Graph, config *configs.Config) er
 		}
 		var diags tfdiags.Diagnostics
 
-		// FIXME: we need to attach the config to planned instances (destroy
-		// nodes, and orphan nodes). try and do this in
-		// AttachResourceConfigTransformer.
-		//
-		// Make sure orphaned instances get their configs during expansion
-		// somehow too.
-		//
-		//
-		if r.Managed != nil && r.Managed.ActionTriggers != nil {
-			for blockIdx, at := range r.Managed.ActionTriggers {
-				resActTrig := &resourceActionTrigger{
-					config: at,
-				}
-				for actionIdx, action := range at.Actions {
-					refs, parseRefDiags := langrefs.ReferencesInExpr(addrs.ParseRef, action.Expr)
-					if parseRefDiags != nil {
-						return parseRefDiags.Err()
-					}
-
-					var configAction addrs.ConfigAction
-
-					for _, ref := range refs {
-						switch a := ref.Subject.(type) {
-						case addrs.Action:
-							configAction = a.InModule(config.Path)
-						case addrs.ActionInstance:
-							configAction = a.Action.InModule(config.Path)
-						case addrs.CountAttr, addrs.ForEachAttr:
-							// nothing to do, these will get evaluated later
-						default:
-							// This should have been caught during config loading
-							panic(fmt.Sprintf("unexpected action address %T", a))
-						}
-					}
-
-					// Verify that any actions referenced in the resource's ActionTriggers exist in this module
-					// FIXME: can this be checked during config loading?
-					actionNode, ok := allConfigActions.GetOk(configAction)
-					if !ok {
-						var keys []string
-						for k := range allConfigActions.Iter() {
-							keys = append(keys, k.String())
-						}
-						suggestion := didyoumean.NameSuggestion(configAction.String(), keys)
-						if suggestion != "" {
-							suggestion = fmt.Sprintf(" Did you mean %q?", suggestion)
-						}
-
-						diags = diags.Append(&hcl.Diagnostic{
-							Severity: hcl.DiagError,
-							Summary:  "action_trigger actions references non-existent action",
-							Detail:   fmt.Sprintf("The lifecycle action_trigger actions list contains a reference to the action %q that does not exist in the configuration of this module.%s", configAction.String(), suggestion),
-							Subject:  action.Expr.Range().Ptr(),
-							Context:  r.DeclRange.Ptr(),
-						})
-						continue
-					}
-					referencedActionConfigs.Add(configAction)
-					resActTrig.actionRefs = append(resActTrig.actionRefs, actionRef{
-						configRef:   action,
-						actionNode:  actionNode,
-						blockIndex:  blockIdx,
-						actionIndex: actionIdx,
-					})
-				}
-				abstract.actionTriggers = append(abstract.actionTriggers, resActTrig)
-			}
-		}
-
+		// Build the action triggers for the configured resource nodes,
+		// connecting them to the respective ConfigAction nodes.
+		triggers, triggerDiags := buildActionTriggers(r, config.Path, allConfigActions)
+		diags = diags.Append(triggerDiags)
 		if diags.HasErrors() {
 			return diags.Err()
+		}
+
+		abstract.actionTriggers = triggers
+
+		// now record all the action nodes which were used by resources, so that
+		// they are not validated on their own since they may container "caller"
+		for _, trigger := range triggers {
+			for _, actionRef := range trigger.actionRefs {
+				referencedActionConfigs.Add(actionRef.actionNode.Addr)
+			}
 		}
 
 		// If any of the import targets can apply to this node's instances,
@@ -347,4 +292,78 @@ func (t *ConfigTransformer) validateImportTargets() error {
 	}
 
 	return diags.Err()
+}
+
+// buildActionTriggers constructs the list of action refs along with their
+// associated action nodes for a managed resource.
+func buildActionTriggers(resource *configs.Resource, path addrs.Module, allConfigActions addrs.Map[addrs.ConfigAction, *NodeActionConfig]) ([]*resourceActionTrigger, tfdiags.Diagnostics) {
+	var diags tfdiags.Diagnostics
+	var actionTriggers []*resourceActionTrigger
+
+	if resource.Managed == nil {
+		return nil, nil
+	}
+
+	for blockIdx, at := range resource.Managed.ActionTriggers {
+		resActTrig := &resourceActionTrigger{
+			config: at,
+		}
+		for actionIdx, action := range at.Actions {
+			refs, parseRefDiags := langrefs.ReferencesInExpr(addrs.ParseRef, action.Expr)
+			diags = diags.Append(parseRefDiags)
+			if diags.HasErrors() {
+				return nil, diags
+			}
+
+			var configAction addrs.ConfigAction
+
+			for _, ref := range refs {
+				switch a := ref.Subject.(type) {
+				case addrs.Action:
+					configAction = a.InModule(path)
+				case addrs.ActionInstance:
+					configAction = a.Action.InModule(path)
+				case addrs.CountAttr, addrs.ForEachAttr:
+					// nothing to do, these will get evaluated later
+				default:
+					// This should have been caught during config loading
+					panic(fmt.Sprintf("unexpected action address %T", a))
+				}
+			}
+
+			// Verify that any actions referenced in the resource's ActionTriggers exist in this module
+			// FIXME: can this be checked during config loading?
+			actionNode, ok := allConfigActions.GetOk(configAction)
+			if !ok {
+				var keys []string
+				for k := range allConfigActions.Iter() {
+					keys = append(keys, k.String())
+				}
+				suggestion := didyoumean.NameSuggestion(configAction.String(), keys)
+				if suggestion != "" {
+					suggestion = fmt.Sprintf(" Did you mean %q?", suggestion)
+				}
+
+				diags = diags.Append(&hcl.Diagnostic{
+					Severity: hcl.DiagError,
+					Summary:  "action_trigger actions references non-existent action",
+					Detail:   fmt.Sprintf("The lifecycle action_trigger actions list contains a reference to the action %q that does not exist in the configuration of this module.%s", configAction.String(), suggestion),
+					Subject:  action.Expr.Range().Ptr(),
+					Context:  resource.DeclRange.Ptr(),
+				})
+				continue
+			}
+
+			// referencedActionConfigs.Add(configAction)
+
+			resActTrig.actionRefs = append(resActTrig.actionRefs, actionRef{
+				configRef:   action,
+				actionNode:  actionNode,
+				blockIndex:  blockIdx,
+				actionIndex: actionIdx,
+			})
+		}
+		actionTriggers = append(actionTriggers, resActTrig)
+	}
+	return actionTriggers, diags
 }

--- a/internal/terraform/transform_destroy_edge.go
+++ b/internal/terraform/transform_destroy_edge.go
@@ -13,12 +13,20 @@ import (
 
 // GraphNodeDestroyer must be implemented by nodes that destroy resources.
 type GraphNodeDestroyer interface {
-	dag.Vertex
-
 	// DestroyAddr is the address of the resource that is being
 	// destroyed by this node. If this returns nil, then this node
 	// is not destroying anything.
 	DestroyAddr() *addrs.AbsResourceInstance
+}
+
+// GraphNodePlanDestroyer is implemented only by the planning counterpart for
+// the destroy nodes. These are typically created for objects which only exist
+// in state, like orphaned instances or planing a full destroy operation.
+type GraphNodePlanDestroyer interface {
+	// DestroyAddr is the address of the resource that is being
+	// destroyed by this node. If this returns nil, then this node
+	// is not destroying anything.
+	PlanDestroyAddr() *addrs.AbsResourceInstance
 }
 
 // GraphNodeCreator must be implemented by nodes that create OR update resources.

--- a/internal/terraform/transform_reference.go
+++ b/internal/terraform/transform_reference.go
@@ -116,9 +116,10 @@ func (t *ReferenceTransformer) Transform(g *Graph) error {
 
 	// Find the things that reference things and connect them
 	for _, v := range vs {
-		if _, ok := v.(GraphNodeDestroyer); ok {
-			// destroy nodes references are not connected, since they can only
-			// use their own state.
+		// Only plan-time destroy nodes can be connected via references.
+		_, destroyer := v.(GraphNodeDestroyer)
+		_, planning := v.(GraphNodePlanDestroyer)
+		if destroyer && !planning {
 			continue
 		}
 
@@ -166,42 +167,28 @@ func (t *ReferenceTransformer) Transform(g *Graph) error {
 			continue
 		}
 
+	ACTIONREFS:
 		for _, ref := range m.References(actionConfig) {
 			if g.Ancestors(ref).Include(actionConfig) {
-				// We know we have a cycle, now we need to check if it's allowed
-				// for use in legacy action config.
-				resource, isConfigResource := ref.(GraphNodeConfigResource)
-				_, isResourceInstance := ref.(GraphNodeResourceInstance)
-				if !isConfigResource {
+				// this reference creates a cycle, because the action is already
+				// an ancestor of the reference. We need to allow these for the
+				// back-references to calling resources, but only direct
+				// references are allowed.
+
+				caller, ok := ref.(GraphNodeActionCaller)
+				if !ok {
+					// this node cannot call any actions
 					return actionCycleError(ref, actionConfig)
 				}
 
-				if isResourceInstance {
-					// we are really only concerned with finding cycles
-					// originating from the config resource nodes which hold the
-					// references to the action. Instances complicate that
-					// because they rely on references to the config node for
-					// general ordering.
-					continue
-				}
-
-				// The reference is a resource node, and we'll allow it if it
-				// directly references back to the same action node. Only direct
-				// references are allowed here, and more complex cycles will
-				// still error out later during graph validation.
-				for _, backRef := range m.References(resource) {
-					backAction, ok := backRef.(*NodeActionConfig)
-					if !ok {
-						continue
-					}
-
-					if !backAction.Addr.Equal(actionConfig.Addr) {
-						return actionCycleError(ref, actionConfig)
+				// The reference can call actions, and we'll allow it if it
+				// directly references back to the same action node.
+				for _, actionCall := range caller.ActionCalls() {
+					if actionCall.Equal(actionConfig.Addr) {
+						continue ACTIONREFS
 					}
 				}
-
-				log.Printf("[WARN] ReferenceTransformer: skipping %s => %s due to reference cycle", dag.VertexName(actionConfig), dag.VertexName(ref))
-				continue
+				return actionCycleError(ref, actionConfig)
 			}
 
 			g.Connect(dag.BasicEdge(actionConfig, ref))

--- a/internal/terraform/transform_reference.go
+++ b/internal/terraform/transform_reference.go
@@ -156,10 +156,6 @@ func (t *ReferenceTransformer) Transform(g *Graph) error {
 		}
 	}
 
-	actionCycleError := func(ref, action dag.Vertex) error {
-		return fmt.Errorf("action reference cycle involving %s and %s", dag.VertexName(action), dag.VertexName(ref))
-	}
-
 	// now we can go back and connect the action configs to their dependencies
 	for _, v := range vs {
 		actionConfig, ok := v.(*NodeActionConfig)
@@ -178,7 +174,7 @@ func (t *ReferenceTransformer) Transform(g *Graph) error {
 				caller, ok := ref.(GraphNodeActionCaller)
 				if !ok {
 					// this node cannot call any actions
-					return actionCycleError(ref, actionConfig)
+					return fmt.Errorf("action reference cycle involving %s and %s", actionConfig.Addr, dag.VertexName(ref))
 				}
 
 				// The reference can call actions, and we'll allow it if it
@@ -188,7 +184,7 @@ func (t *ReferenceTransformer) Transform(g *Graph) error {
 						continue ACTIONREFS
 					}
 				}
-				return actionCycleError(ref, actionConfig)
+				return fmt.Errorf("action reference cycle involving %s and %s", actionConfig.Addr, dag.VertexName(ref))
 			}
 
 			g.Connect(dag.BasicEdge(actionConfig, ref))


### PR DESCRIPTION
Continue with the refactoring such that destroy plan nodes can access action configuration and plan accordingly.

It turns out self/caller never worked correctly for removed or orphaned resources. Building the eval context requires looking up the true self value, and if we can't evaluate self correctly it will either return the wrong instance value or fail on an indexing operation.

Actions were up until now connected within the config transformer, but that only handles normal resources and actions from configuration. Destroy nodes are added to the graph later from state, and we need to somehow connect those to their respective action nodes.

Introduce a new GraphNodeAttachActionTriggers to attach the action refs to these plan-destroy nodes in the same sweep that takes care of attach the regular resource configs.

Destroy nodes unfortunately now need to reference things, which throws off some of our graph invariants. We should be able to do this with plan graphs, since those are about evaluation order and don't contain resource replacement subgraphs. Allowing references from destroy plan nodes also showed that we were accidentally referencing destroy nodes too (by creating cycles), so hopefully fixing that does not uncover something else depending on those bad references.