### PR TITLE
Explicitly return a partial status for callbacks with incomplete result

### DIFF
--- a/internal/policy/callback/callback.go
+++ b/internal/policy/callback/callback.go
@@ -11,7 +11,7 @@ import (
 )
 
 type Functions struct {
-	GetResources  func(resource string, attrs cty.Value) ([]cty.Value, error)
+	GetResources  func(resource string, attrs cty.Value) ([]cty.Value, bool, error)
 	GetDataSource func(datasource string, attrs cty.Value) (cty.Value, error)
 }
 

--- a/internal/policy/callback/server.go
+++ b/internal/policy/callback/server.go
@@ -34,7 +34,7 @@ func (s *Server) GetResources(_ context.Context, request *proto.GetResourcesRequ
 	if !ok {
 		return nil, fmt.Errorf("no callback registered for ID %d (request type: %s)", request.EvaluationRequestId, request.Type)
 	}
-	resources, err := functions.GetResources(request.Type, attrs)
+	resources, unknown, err := functions.GetResources(request.Type, attrs)
 	if err != nil {
 		return nil, err
 	}
@@ -50,6 +50,7 @@ func (s *Server) GetResources(_ context.Context, request *proto.GetResourcesRequ
 
 	return &proto.GetResourcesResponse{
 		Results: results,
+		Unknown: unknown,
 	}, nil
 }
 

--- a/internal/policy/callback/server.go
+++ b/internal/policy/callback/server.go
@@ -34,7 +34,7 @@ func (s *Server) GetResources(_ context.Context, request *proto.GetResourcesRequ
 	if !ok {
 		return nil, fmt.Errorf("no callback registered for ID %d (request type: %s)", request.EvaluationRequestId, request.Type)
 	}
-	resources, unknown, err := functions.GetResources(request.Type, attrs)
+	resources, isPartialResult, err := functions.GetResources(request.Type, attrs)
 	if err != nil {
 		return nil, err
 	}
@@ -50,7 +50,7 @@ func (s *Server) GetResources(_ context.Context, request *proto.GetResourcesRequ
 
 	return &proto.GetResourcesResponse{
 		Results: results,
-		Unknown: unknown,
+		Partial: isPartialResult,
 	}, nil
 }
 

--- a/internal/policy/proto/callback.pb.go
+++ b/internal/policy/proto/callback.pb.go
@@ -89,9 +89,9 @@ func (x *GetResourcesRequest) GetEvaluationRequestId() uint32 {
 type GetResourcesResponse struct {
 	state   protoimpl.MessageState `protogen:"open.v1"`
 	Results [][]byte               `protobuf:"bytes,1,rep,name=results,proto3" json:"results,omitempty"`
-	// unknown means that the request encountered unknown objects during evaluation,
+	// partial means that the request encountered unknown objects during evaluation,
 	// and the results may be incomplete.
-	Unknown       bool `protobuf:"varint,2,opt,name=unknown,proto3" json:"unknown,omitempty"`
+	Partial       bool `protobuf:"varint,2,opt,name=partial,proto3" json:"partial,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -133,9 +133,9 @@ func (x *GetResourcesResponse) GetResults() [][]byte {
 	return nil
 }
 
-func (x *GetResourcesResponse) GetUnknown() bool {
+func (x *GetResourcesResponse) GetPartial() bool {
 	if x != nil {
-		return x.Unknown
+		return x.Partial
 	}
 	return false
 }
@@ -205,9 +205,9 @@ func (x *GetDataSourceRequest) GetEvaluationRequestId() uint32 {
 type GetDataSourceResponse struct {
 	state  protoimpl.MessageState `protogen:"open.v1"`
 	Result []byte                 `protobuf:"bytes,1,opt,name=result,proto3" json:"result,omitempty"`
-	// unknown means that the request encountered unknown objects during evaluation,
+	// partial means that the request encountered unknown objects during evaluation,
 	// and the results may be incomplete.
-	Unknown       bool `protobuf:"varint,2,opt,name=unknown,proto3" json:"unknown,omitempty"`
+	Partial       bool `protobuf:"varint,2,opt,name=partial,proto3" json:"partial,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -249,9 +249,9 @@ func (x *GetDataSourceResponse) GetResult() []byte {
 	return nil
 }
 
-func (x *GetDataSourceResponse) GetUnknown() bool {
+func (x *GetDataSourceResponse) GetPartial() bool {
 	if x != nil {
-		return x.Unknown
+		return x.Partial
 	}
 	return false
 }
@@ -269,14 +269,14 @@ const file_callback_proto_rawDesc = "" +
 	"\x15evaluation_request_id\x18\x03 \x01(\rR\x13evaluationRequestId\"J\n" +
 	"\x14GetResourcesResponse\x12\x18\n" +
 	"\aresults\x18\x01 \x03(\fR\aresults\x12\x18\n" +
-	"\aunknown\x18\x02 \x01(\bR\aunknown\"v\n" +
+	"\apartial\x18\x02 \x01(\bR\apartial\"v\n" +
 	"\x14GetDataSourceRequest\x12\x12\n" +
 	"\x04type\x18\x01 \x01(\tR\x04type\x12\x16\n" +
 	"\x06config\x18\x02 \x01(\fR\x06config\x122\n" +
 	"\x15evaluation_request_id\x18\x03 \x01(\rR\x13evaluationRequestId\"I\n" +
 	"\x15GetDataSourceResponse\x12\x16\n" +
 	"\x06result\x18\x01 \x01(\fR\x06result\x12\x18\n" +
-	"\aunknown\x18\x02 \x01(\bR\aunknown2\xa6\x01\n" +
+	"\apartial\x18\x02 \x01(\bR\apartial2\xa6\x01\n" +
 	"\x0fCallbackService\x12G\n" +
 	"\fGetResources\x12\x1a.proto.GetResourcesRequest\x1a\x1b.proto.GetResourcesResponse\x12J\n" +
 	"\rGetDataSource\x12\x1b.proto.GetDataSourceRequest\x1a\x1c.proto.GetDataSourceResponseB4Z2github.com/hashicorp/terraform-policy-plugin/protob\x06proto3"

--- a/internal/policy/proto/callback.pb.go
+++ b/internal/policy/proto/callback.pb.go
@@ -87,8 +87,11 @@ func (x *GetResourcesRequest) GetEvaluationRequestId() uint32 {
 }
 
 type GetResourcesResponse struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Results       [][]byte               `protobuf:"bytes,1,rep,name=results,proto3" json:"results,omitempty"`
+	state   protoimpl.MessageState `protogen:"open.v1"`
+	Results [][]byte               `protobuf:"bytes,1,rep,name=results,proto3" json:"results,omitempty"`
+	// unknown means that the request encountered unknown objects during evaluation,
+	// and the results may be incomplete.
+	Unknown       bool `protobuf:"varint,2,opt,name=unknown,proto3" json:"unknown,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -128,6 +131,13 @@ func (x *GetResourcesResponse) GetResults() [][]byte {
 		return x.Results
 	}
 	return nil
+}
+
+func (x *GetResourcesResponse) GetUnknown() bool {
+	if x != nil {
+		return x.Unknown
+	}
+	return false
 }
 
 type GetDataSourceRequest struct {
@@ -193,8 +203,11 @@ func (x *GetDataSourceRequest) GetEvaluationRequestId() uint32 {
 }
 
 type GetDataSourceResponse struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Result        []byte                 `protobuf:"bytes,1,opt,name=result,proto3" json:"result,omitempty"`
+	state  protoimpl.MessageState `protogen:"open.v1"`
+	Result []byte                 `protobuf:"bytes,1,opt,name=result,proto3" json:"result,omitempty"`
+	// unknown means that the request encountered unknown objects during evaluation,
+	// and the results may be incomplete.
+	Unknown       bool `protobuf:"varint,2,opt,name=unknown,proto3" json:"unknown,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -236,6 +249,13 @@ func (x *GetDataSourceResponse) GetResult() []byte {
 	return nil
 }
 
+func (x *GetDataSourceResponse) GetUnknown() bool {
+	if x != nil {
+		return x.Unknown
+	}
+	return false
+}
+
 var File_callback_proto protoreflect.FileDescriptor
 
 const file_callback_proto_rawDesc = "" +
@@ -246,15 +266,17 @@ const file_callback_proto_rawDesc = "" +
 	"\n" +
 	"attributes\x18\x02 \x01(\fR\n" +
 	"attributes\x122\n" +
-	"\x15evaluation_request_id\x18\x03 \x01(\rR\x13evaluationRequestId\"0\n" +
+	"\x15evaluation_request_id\x18\x03 \x01(\rR\x13evaluationRequestId\"J\n" +
 	"\x14GetResourcesResponse\x12\x18\n" +
-	"\aresults\x18\x01 \x03(\fR\aresults\"v\n" +
+	"\aresults\x18\x01 \x03(\fR\aresults\x12\x18\n" +
+	"\aunknown\x18\x02 \x01(\bR\aunknown\"v\n" +
 	"\x14GetDataSourceRequest\x12\x12\n" +
 	"\x04type\x18\x01 \x01(\tR\x04type\x12\x16\n" +
 	"\x06config\x18\x02 \x01(\fR\x06config\x122\n" +
-	"\x15evaluation_request_id\x18\x03 \x01(\rR\x13evaluationRequestId\"/\n" +
+	"\x15evaluation_request_id\x18\x03 \x01(\rR\x13evaluationRequestId\"I\n" +
 	"\x15GetDataSourceResponse\x12\x16\n" +
-	"\x06result\x18\x01 \x01(\fR\x06result2\xa6\x01\n" +
+	"\x06result\x18\x01 \x01(\fR\x06result\x12\x18\n" +
+	"\aunknown\x18\x02 \x01(\bR\aunknown2\xa6\x01\n" +
 	"\x0fCallbackService\x12G\n" +
 	"\fGetResources\x12\x1a.proto.GetResourcesRequest\x1a\x1b.proto.GetResourcesResponse\x12J\n" +
 	"\rGetDataSource\x12\x1b.proto.GetDataSourceRequest\x1a\x1c.proto.GetDataSourceResponseB4Z2github.com/hashicorp/terraform-policy-plugin/protob\x06proto3"

--- a/internal/policy/proto/callback.pb.go
+++ b/internal/policy/proto/callback.pb.go
@@ -205,9 +205,8 @@ func (x *GetDataSourceRequest) GetEvaluationRequestId() uint32 {
 type GetDataSourceResponse struct {
 	state  protoimpl.MessageState `protogen:"open.v1"`
 	Result []byte                 `protobuf:"bytes,1,opt,name=result,proto3" json:"result,omitempty"`
-	// partial means that the request encountered unknown objects during evaluation,
-	// and the results may be incomplete.
-	Partial       bool `protobuf:"varint,2,opt,name=partial,proto3" json:"partial,omitempty"`
+	// deferred indicates that the data source read was deferred during evaluation.
+	Deferred      bool `protobuf:"varint,2,opt,name=deferred,proto3" json:"deferred,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -249,9 +248,9 @@ func (x *GetDataSourceResponse) GetResult() []byte {
 	return nil
 }
 
-func (x *GetDataSourceResponse) GetPartial() bool {
+func (x *GetDataSourceResponse) GetDeferred() bool {
 	if x != nil {
-		return x.Partial
+		return x.Deferred
 	}
 	return false
 }
@@ -273,10 +272,10 @@ const file_callback_proto_rawDesc = "" +
 	"\x14GetDataSourceRequest\x12\x12\n" +
 	"\x04type\x18\x01 \x01(\tR\x04type\x12\x16\n" +
 	"\x06config\x18\x02 \x01(\fR\x06config\x122\n" +
-	"\x15evaluation_request_id\x18\x03 \x01(\rR\x13evaluationRequestId\"I\n" +
+	"\x15evaluation_request_id\x18\x03 \x01(\rR\x13evaluationRequestId\"K\n" +
 	"\x15GetDataSourceResponse\x12\x16\n" +
-	"\x06result\x18\x01 \x01(\fR\x06result\x12\x18\n" +
-	"\apartial\x18\x02 \x01(\bR\apartial2\xa6\x01\n" +
+	"\x06result\x18\x01 \x01(\fR\x06result\x12\x1a\n" +
+	"\bdeferred\x18\x02 \x01(\bR\bdeferred2\xa6\x01\n" +
 	"\x0fCallbackService\x12G\n" +
 	"\fGetResources\x12\x1a.proto.GetResourcesRequest\x1a\x1b.proto.GetResourcesResponse\x12J\n" +
 	"\rGetDataSource\x12\x1b.proto.GetDataSourceRequest\x1a\x1c.proto.GetDataSourceResponseB4Z2github.com/hashicorp/terraform-policy-plugin/protob\x06proto3"

--- a/internal/policy/proto/callback.proto
+++ b/internal/policy/proto/callback.proto
@@ -18,10 +18,15 @@ message GetResourcesRequest {
   // evaluation_request_id is the ID of the policy evaluation request that is
   // making this callback request.
   uint32 evaluation_request_id = 3;
+
+ 
 }
 
 message GetResourcesResponse {
   repeated bytes results = 1;
+  // unknown means that the request encountered unknown objects during evaluation,
+  // and the results may be incomplete.
+  bool unknown = 2;
 }
 
 message GetDataSourceRequest {
@@ -34,4 +39,7 @@ message GetDataSourceRequest {
 
 message GetDataSourceResponse {
   bytes result = 1;
+  // unknown means that the request encountered unknown objects during evaluation,
+  // and the results may be incomplete.
+  bool unknown = 2;
 }

--- a/internal/policy/proto/callback.proto
+++ b/internal/policy/proto/callback.proto
@@ -39,7 +39,6 @@ message GetDataSourceRequest {
 
 message GetDataSourceResponse {
   bytes result = 1;
-  // partial means that the request encountered unknown objects during evaluation,
-  // and the results may be incomplete.
-  bool partial = 2;
+  // deferred indicates that the data source read was deferred during evaluation.
+  bool deferred = 2;
 }

--- a/internal/policy/proto/callback.proto
+++ b/internal/policy/proto/callback.proto
@@ -24,9 +24,9 @@ message GetResourcesRequest {
 
 message GetResourcesResponse {
   repeated bytes results = 1;
-  // unknown means that the request encountered unknown objects during evaluation,
+  // partial means that the request encountered unknown objects during evaluation,
   // and the results may be incomplete.
-  bool unknown = 2;
+  bool partial = 2;
 }
 
 message GetDataSourceRequest {
@@ -39,7 +39,7 @@ message GetDataSourceRequest {
 
 message GetDataSourceResponse {
   bytes result = 1;
-  // unknown means that the request encountered unknown objects during evaluation,
+  // partial means that the request encountered unknown objects during evaluation,
   // and the results may be incomplete.
-  bool unknown = 2;
+  bool partial = 2;
 }

--- a/internal/terraform/context_plan_policy_test.go
+++ b/internal/terraform/context_plan_policy_test.go
@@ -1671,6 +1671,12 @@ func TestContext2Plan_PolicyCallback(t *testing.T) {
 			ami = "booper"
 			depends_on = [test_instance.baz]
 		}
+
+		resource "test_instance" "unknowner" {
+			ami = "unknown"
+			compute = uuid()
+			depends_on = [test_instance.baz]
+		}
 	`
 
 	policyConfig := `
@@ -1700,7 +1706,8 @@ func TestContext2Plan_PolicyCallback(t *testing.T) {
 		matchAllResults  []cty.Value
 		filteredResults  []cty.Value
 		noMatchCount     int
-		unknownTypeCount int
+		nonExistentCount int
+		foundUnknown     bool
 	}
 
 	var mu sync.Mutex
@@ -1715,7 +1722,7 @@ func TestContext2Plan_PolicyCallback(t *testing.T) {
 		}
 
 		// 1. Match all test_instance resources with null attrs (no filter).
-		all, err := req.Callbacks.GetResources("test_instance", cty.NullVal(cty.DynamicPseudoType))
+		all, _, err := req.Callbacks.GetResources("test_instance", cty.NullVal(cty.DynamicPseudoType))
 		if err != nil {
 			t.Errorf("GetResources(test_instance, null): %v", err)
 		} else {
@@ -1723,7 +1730,7 @@ func TestContext2Plan_PolicyCallback(t *testing.T) {
 		}
 
 		// 2. Match resources with ami="bar" filter.
-		filtered, err := req.Callbacks.GetResources("test_instance", cty.ObjectVal(map[string]cty.Value{
+		filtered, _, err := req.Callbacks.GetResources("test_instance", cty.ObjectVal(map[string]cty.Value{
 			"ami": cty.StringVal("bar"),
 		}))
 		if err != nil {
@@ -1733,7 +1740,7 @@ func TestContext2Plan_PolicyCallback(t *testing.T) {
 		}
 
 		// 3. Match with an attribute filter that will never match any planned resource.
-		noMatch, err := req.Callbacks.GetResources("test_instance", cty.ObjectVal(map[string]cty.Value{
+		noMatch, _, err := req.Callbacks.GetResources("test_instance", cty.ObjectVal(map[string]cty.Value{
 			"ami": cty.StringVal("nonexistent"),
 		}))
 		if err != nil {
@@ -1743,11 +1750,21 @@ func TestContext2Plan_PolicyCallback(t *testing.T) {
 		}
 
 		// 4. Query for a resource type that doesn't exist in the config.
-		unknown, err := req.Callbacks.GetResources("nonexistent_resource", cty.NullVal(cty.DynamicPseudoType))
+		nonExistentMatch, _, err := req.Callbacks.GetResources("nonexistent_resource", cty.NullVal(cty.DynamicPseudoType))
 		if err != nil {
 			t.Errorf("GetResources(nonexistent_resource): %v", err)
 		} else {
-			cr.unknownTypeCount = len(unknown)
+			cr.nonExistentCount = len(nonExistentMatch)
+		}
+
+		// 5. Query for a resource type where the filtered attribute is unknown.
+		_, unknown, err := req.Callbacks.GetResources("test_instance", cty.ObjectVal(map[string]cty.Value{
+			"compute": cty.StringVal("foo"),
+		}))
+		if err != nil {
+			t.Errorf("Error when filtering by unknown attribute: %v", err)
+		} else {
+			cr.foundUnknown = unknown
 		}
 
 		// Key by the ami attribute of the resource being evaluated.
@@ -1779,13 +1796,13 @@ func TestContext2Plan_PolicyCallback(t *testing.T) {
 	}
 	tfdiags.AssertNoDiagnostics(t, policyDiags)
 
-	// We expect exactly 3 evaluations (one per test_instance resource).
-	if len(results) != 3 {
-		t.Fatalf("expected 3 policy evaluations, got %d", len(results))
+	// We expect exactly 4 evaluations (one per test_instance resource).
+	if len(results) != 4 {
+		t.Fatalf("expected 4 policy evaluations, got %d", len(results))
 	}
 
 	for ami, cr := range results {
-		expectedTotal := 3
+		expectedTotal := 4
 		filteredCount := 1
 		if len(cr.matchAllResults) != expectedTotal {
 			t.Errorf("evaluation[%s]: expected %d result for matchAll, got %d", ami, expectedTotal, len(cr.matchAllResults))
@@ -1797,8 +1814,13 @@ func TestContext2Plan_PolicyCallback(t *testing.T) {
 		}
 
 		// Querying for a non-existent resource type should always return 0.
-		if cr.unknownTypeCount != 0 {
-			t.Errorf("evaluation[%s]: expected 0 results for nonexistent_resource, got %d", ami, cr.unknownTypeCount)
+		if cr.nonExistentCount != 0 {
+			t.Errorf("evaluation[%s]: expected 0 results for nonexistent_resource, got %d", ami, cr.nonExistentCount)
+		}
+
+		// Querying for a resource type where the filtered attribute is unknown should always return 0.
+		if !cr.foundUnknown {
+			t.Errorf("evaluation[%s]: expected unknown type filter to return at least one result", ami)
 		}
 
 		// The filtered result should only match one resource "bar", except when evaluating "bar" itself.

--- a/internal/terraform/context_plan_policy_test.go
+++ b/internal/terraform/context_plan_policy_test.go
@@ -1667,14 +1667,10 @@ func TestContext2Plan_PolicyCallback(t *testing.T) {
 			depends_on = [test_instance.foo]
 		}
 
-		resource "test_instance" "boop" {
-			ami = "booper"
-			depends_on = [test_instance.baz]
-		}
-
-		resource "test_instance" "unknowner" {
-			ami = "unknown"
-			compute = uuid()
+		resource "test_instance" "mixed" {
+			count = 2
+			ami = count.index == 0 ? "unknown" : "booper"
+			compute = count.index == 0 ? uuid() : "known"
 			depends_on = [test_instance.baz]
 		}
 	`
@@ -1818,9 +1814,10 @@ func TestContext2Plan_PolicyCallback(t *testing.T) {
 			t.Errorf("evaluation[%s]: expected 0 results for nonexistent_resource, got %d", ami, cr.nonExistentCount)
 		}
 
-		// Querying for a resource type where the filtered attribute is unknown should always return 0.
+		// Querying for a resource type where one candidate has an unknown filtered attribute
+		// should report the callback result as incomplete, even if later candidates are definite non-matches.
 		if !cr.foundUnknown {
-			t.Errorf("evaluation[%s]: expected unknown type filter to return at least one result", ami)
+			t.Errorf("evaluation[%s]: expected compute filter to report unknown=true when any candidate has an unknown value", ami)
 		}
 
 		// The filtered result should only match one resource "bar", except when evaluating "bar" itself.

--- a/internal/terraform/policy.go
+++ b/internal/terraform/policy.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/configs"
+	"github.com/hashicorp/terraform/internal/configs/configschema"
 	"github.com/hashicorp/terraform/internal/plans"
 	"github.com/hashicorp/terraform/internal/policy"
 	"github.com/hashicorp/terraform/internal/policy/callback"
@@ -51,7 +52,7 @@ func getResourcesForPolicyCallback(ctx EvalContext, walkOperation walkOperation,
 		if !attrs.IsNull() {
 			filterMap = attrs.AsValueMap()
 		}
-		var unknown bool
+		var accUnknown bool
 		config.DeepEach(func(c *configs.Config) {
 			state := ctx.State()
 			for _, resource := range c.Module.ManagedResources {
@@ -90,44 +91,21 @@ func getResourcesForPolicyCallback(ctx EvalContext, walkOperation walkOperation,
 				}
 
 				for resource := range resourcesSeq {
-					if attrs.IsNull() {
-						// then match everything
-						found = append(found, resource)
-						continue
-					}
-
-					matched := true
-					for name, attr := range filterMap {
-						if schema.Body == nil || schema.Body.Attributes[name] == nil {
-							matched = false
-							break
-						}
-
-						equals := attr.Equals(resource.GetAttr(name))
-						if !equals.IsKnown() {
-							// The filtered attribute for matching is unknown for this resource instance,
-							// so we can't determine whether it matches. We'll mark the callback result as incomplete.
-							// We still continue to the next resource instance, so that we return all known objects as well.
-							unknown = true
-							matched = false
-							continue
-						}
-
-						if equals.False() {
-							matched = false
-							break
-						}
-					}
-
+					matched, unknown := resourceMatchesFilter(addr, schema.Body, filterMap, resource)
 					if matched {
 						resource, _ = resource.UnmarkDeep()
 						found = append(found, resource)
 					}
 
+					// The filtered attribute for matching is unknown for this resource instance,
+					// so we can't determine whether it matches. We'll mark the whole callback result as incomplete.
+					// We still continue to the next resource instance, so that we return all known objects as well.
+					accUnknown = accUnknown || unknown
+
 				}
 			}
 		})
-		return found, unknown, nil
+		return found, accUnknown, nil
 	}
 }
 
@@ -160,4 +138,51 @@ func getDataSourceForPolicyCallback(ctx EvalContext, provider providers.Interfac
 		}
 		return cty.NilVal, fmt.Errorf("no data source found for %s", target)
 	}
+}
+
+// resourceMatchesFilter returns whether the given resource matches the given filter attributes and/or if the filter attributes are unknown for the resource.
+func resourceMatchesFilter(addr addrs.ConfigResource, schema *configschema.Block, filterAttrs map[string]cty.Value, resource cty.Value) (matches, unknown bool) {
+	if resource.IsNull() {
+		// if the resource is null, then it doesn't match anything
+		return false, false
+	}
+	if len(filterAttrs) == 0 {
+		// if the filter is null, then match everything
+		return true, false
+	}
+
+	sawUnknown := false
+
+	for name, attr := range filterAttrs {
+		if !resource.Type().HasAttribute(name) {
+			log.Printf("[DEBUG] attribute %q not found in resource %q", name, addr.String())
+			return false, false
+		}
+
+		if schema == nil || schema.Attributes[name] == nil {
+			return false, false
+		}
+
+		equals := attr.Equals(resource.GetAttr(name))
+		if !equals.IsKnown() {
+			// A filtered attribute for matching is unknown for this resource instance.
+			// We can't determine whether it matches. We track that we saw an unknown attribute, but continue to check other attributes.
+			// This lets false matches take precedence over the unknown result, since we can still determine that the resource does not match.
+			sawUnknown = true
+			continue
+		}
+
+		if equals.False() {
+			log.Printf("[DEBUG] attribute %q does not match in resource %q", name, addr.String())
+			// an attribute mismatch means we can't match this resource
+			return false, false
+		}
+	}
+
+	// We saw an unknown attribute, and no other attributes mismatched, so we can't determine whether the resource matches.
+	if sawUnknown {
+		return false, true
+	}
+
+	return true, false
 }

--- a/internal/terraform/policy.go
+++ b/internal/terraform/policy.go
@@ -160,14 +160,10 @@ func resourceMatchesFilter(addr addrs.ConfigResource, schema *configschema.Block
 			return false, false
 		}
 
-		if schema == nil || schema.Attributes[name] == nil {
-			return false, false
-		}
-
 		equals := attr.Equals(resource.GetAttr(name))
 		if !equals.IsKnown() {
-			// A filtered attribute for matching is unknown for this resource instance.
-			// We can't determine whether it matches. We track that we saw an unknown attribute, but continue to check other attributes.
+			// If the filtered attribute for matching is unknown for this resource instance, we
+			// can't determine whether it matches, so we track that we saw an unknown attribute and continue to check other attributes.
 			// This lets false matches take precedence over the unknown result, since we can still determine that the resource does not match.
 			sawUnknown = true
 			continue

--- a/internal/terraform/policy.go
+++ b/internal/terraform/policy.go
@@ -95,10 +95,11 @@ func getResourcesForPolicyCallback(ctx EvalContext, walkOperation walkOperation,
 					if matched {
 						resource, _ = resource.UnmarkDeep()
 						found = append(found, resource)
+						continue
 					}
 
-					// The filtered attribute for matching is unknown for this resource instance,
-					// so we can't determine whether it matches. We'll mark the whole callback result as incomplete.
+					// If the filtered attribute for matching is unknown for this resource instance,
+					// we can't determine whether it matches, so we'll mark the whole callback result as incomplete.
 					// We still continue to the next resource instance, so that we return all known objects as well.
 					isPartialResult = isPartialResult || unknown
 
@@ -153,9 +154,9 @@ func resourceMatchesFilter(addr addrs.ConfigResource, schema *configschema.Block
 
 	sawUnknown := false
 
+	attrTypes := resource.Type().AttributeTypes()
 	for name, attr := range filterAttrs {
-		if !resource.Type().HasAttribute(name) {
-			log.Printf("[DEBUG] attribute %q not found in resource %q", name, addr.String())
+		if _, ok := attrTypes[name]; !ok {
 			return false, false
 		}
 

--- a/internal/terraform/policy.go
+++ b/internal/terraform/policy.go
@@ -52,7 +52,7 @@ func getResourcesForPolicyCallback(ctx EvalContext, walkOperation walkOperation,
 		if !attrs.IsNull() {
 			filterMap = attrs.AsValueMap()
 		}
-		var accUnknown bool
+		var isPartialResult bool
 		config.DeepEach(func(c *configs.Config) {
 			state := ctx.State()
 			for _, resource := range c.Module.ManagedResources {
@@ -100,12 +100,12 @@ func getResourcesForPolicyCallback(ctx EvalContext, walkOperation walkOperation,
 					// The filtered attribute for matching is unknown for this resource instance,
 					// so we can't determine whether it matches. We'll mark the whole callback result as incomplete.
 					// We still continue to the next resource instance, so that we return all known objects as well.
-					accUnknown = accUnknown || unknown
+					isPartialResult = isPartialResult || unknown
 
 				}
 			}
 		})
-		return found, accUnknown, nil
+		return found, isPartialResult, nil
 	}
 }
 

--- a/internal/terraform/policy.go
+++ b/internal/terraform/policy.go
@@ -44,13 +44,14 @@ func evaluatePolicies(ctx EvalContext, target addrs.AbsResourceInstance, config 
 	return result
 }
 
-func getResourcesForPolicyCallback(ctx EvalContext, walkOperation walkOperation, provider providers.Interface, schema providers.GetProviderSchemaResponse, config *configs.Config) func(target string, attrs cty.Value) ([]cty.Value, error) {
-	return func(target string, attrs cty.Value) ([]cty.Value, error) {
+func getResourcesForPolicyCallback(ctx EvalContext, walkOperation walkOperation, provider providers.Interface, schema providers.GetProviderSchemaResponse, config *configs.Config) func(target string, attrs cty.Value) ([]cty.Value, bool, error) {
+	return func(target string, attrs cty.Value) ([]cty.Value, bool, error) {
 		var found []cty.Value
 		var filterMap map[string]cty.Value
 		if !attrs.IsNull() {
 			filterMap = attrs.AsValueMap()
 		}
+		var unknown bool
 		config.DeepEach(func(c *configs.Config) {
 			state := ctx.State()
 			for _, resource := range c.Module.ManagedResources {
@@ -104,8 +105,11 @@ func getResourcesForPolicyCallback(ctx EvalContext, walkOperation walkOperation,
 
 						equals := attr.Equals(resource.GetAttr(name))
 						if !equals.IsKnown() {
-							// We'll treat unknown values as matches, and they
-							// can be handled on the Terraform Policy side.
+							// The filtered attribute for matching is unknown for this resource instance,
+							// so we can't determine whether it matches. We'll mark the callback result as incomplete.
+							// We still continue to the next resource instance, so that we return all known objects as well.
+							unknown = true
+							matched = false
 							continue
 						}
 
@@ -123,7 +127,7 @@ func getResourcesForPolicyCallback(ctx EvalContext, walkOperation walkOperation,
 				}
 			}
 		})
-		return found, nil
+		return found, unknown, nil
 	}
 }
 

--- a/internal/terraform/policy_test.go
+++ b/internal/terraform/policy_test.go
@@ -4,9 +4,7 @@
 package terraform
 
 import (
-	"fmt"
 	"sort"
-	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -94,11 +92,10 @@ resource "test_resource" "b" {
 	callback := getResourcesForPolicyCallback(ctx, walkApply, nil, providerSchema, config)
 
 	tests := []struct {
-		name          string
-		filter        cty.Value
-		wantNames     []string
-		wantUnknown   bool
-		wantPanicText string
+		name        string
+		filter      cty.Value
+		wantNames   []string
+		wantUnknown bool
 	}{
 		{
 			name:        "null filter returns all matching resources",
@@ -132,29 +129,9 @@ resource "test_resource" "b" {
 				got        []cty.Value
 				gotUnknown bool
 				gotErr     error
-				panicValue any
 			)
 
-			func() {
-				defer func() {
-					panicValue = recover()
-				}()
-				got, gotUnknown, gotErr = callback("test_resource", tt.filter)
-			}()
-
-			if tt.wantPanicText != "" {
-				if panicValue == nil {
-					t.Fatalf("expected panic containing %q, but callback returned normally", tt.wantPanicText)
-				}
-				if got := fmt.Sprint(panicValue); !strings.Contains(got, tt.wantPanicText) {
-					t.Fatalf("wrong panic\ngot:  %q\nwant substring: %q", got, tt.wantPanicText)
-				}
-				return
-			}
-
-			if panicValue != nil {
-				t.Fatalf("unexpected panic: %v", panicValue)
-			}
+			got, gotUnknown, gotErr = callback("test_resource", tt.filter)
 			if gotErr != nil {
 				t.Fatalf("unexpected error: %v", gotErr)
 			}

--- a/internal/terraform/policy_test.go
+++ b/internal/terraform/policy_test.go
@@ -1,0 +1,178 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package terraform
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform/internal/configs/configschema"
+	"github.com/hashicorp/terraform/internal/plans"
+	"github.com/hashicorp/terraform/internal/states"
+	"github.com/zclconf/go-cty/cty"
+)
+
+func TestGetResourcesForPolicyCallback(t *testing.T) {
+	providerSchema := *getProviderSchemaResponseFromProviderSchema(&providerSchema{
+		ResourceTypes: map[string]*configschema.Block{
+			"test_resource": {
+				Attributes: map[string]*configschema.Attribute{
+					"id": {
+						Type:     cty.String,
+						Computed: true,
+					},
+					"name": {
+						Type:     cty.String,
+						Optional: true,
+					},
+				},
+				BlockTypes: map[string]*configschema.NestedBlock{
+					"child": {
+						Nesting: configschema.NestingSingle,
+						Block: configschema.Block{
+							Attributes: map[string]*configschema.Attribute{
+								"value": {
+									Type:     cty.String,
+									Optional: true,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	})
+
+	config := testModuleInline(t, map[string]string{
+		"main.tf": `
+resource "test_resource" "a" {
+  name = "alpha"
+
+  child {
+    value = "one"
+  }
+}
+
+resource "test_resource" "b" {
+  name = "beta"
+
+  child {
+    value = "two"
+  }
+}
+`,
+	})
+
+	state := states.NewState().SyncWrapper()
+	state.SetResourceInstanceCurrent(
+		mustResourceInstanceAddr("test_resource.a"),
+		&states.ResourceInstanceObjectSrc{
+			Status:    states.ObjectReady,
+			AttrsJSON: []byte(`{"id":"a","name":"alpha","child":{"value":"one"}}`),
+		},
+		mustProviderConfig(`provider["registry.terraform.io/hashicorp/test"]`),
+	)
+	state.SetResourceInstanceCurrent(
+		mustResourceInstanceAddr("test_resource.b"),
+		&states.ResourceInstanceObjectSrc{
+			Status:    states.ObjectReady,
+			AttrsJSON: []byte(`{"id":"b","name":"beta","child":{"value":"two"}}`),
+		},
+		mustProviderConfig(`provider["registry.terraform.io/hashicorp/test"]`),
+	)
+	state.Close()
+
+	ctx := &MockEvalContext{
+		StateState:     state,
+		ChangesChanges: plans.NewChanges().SyncWrapper(),
+	}
+
+	callback := getResourcesForPolicyCallback(ctx, walkApply, nil, providerSchema, config)
+
+	tests := []struct {
+		name          string
+		filter        cty.Value
+		wantNames     []string
+		wantUnknown   bool
+		wantPanicText string
+	}{
+		{
+			name:        "null filter returns all matching resources",
+			filter:      cty.NullVal(cty.DynamicPseudoType),
+			wantNames:   []string{"alpha", "beta"},
+			wantUnknown: false,
+		},
+		{
+			name: "scalar attribute filter matches a subset",
+			filter: cty.ObjectVal(map[string]cty.Value{
+				"name": cty.StringVal("alpha"),
+			}),
+			wantNames:   []string{"alpha"},
+			wantUnknown: false,
+		},
+		{
+			name: "nested block filter filter matches a subset",
+			filter: cty.ObjectVal(map[string]cty.Value{
+				"child": cty.ObjectVal(map[string]cty.Value{
+					"value": cty.StringVal("one"),
+				}),
+			}),
+			wantNames:   []string{"alpha"},
+			wantUnknown: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var (
+				got        []cty.Value
+				gotUnknown bool
+				gotErr     error
+				panicValue any
+			)
+
+			func() {
+				defer func() {
+					panicValue = recover()
+				}()
+				got, gotUnknown, gotErr = callback("test_resource", tt.filter)
+			}()
+
+			if tt.wantPanicText != "" {
+				if panicValue == nil {
+					t.Fatalf("expected panic containing %q, but callback returned normally", tt.wantPanicText)
+				}
+				if got := fmt.Sprint(panicValue); !strings.Contains(got, tt.wantPanicText) {
+					t.Fatalf("wrong panic\ngot:  %q\nwant substring: %q", got, tt.wantPanicText)
+				}
+				return
+			}
+
+			if panicValue != nil {
+				t.Fatalf("unexpected panic: %v", panicValue)
+			}
+			if gotErr != nil {
+				t.Fatalf("unexpected error: %v", gotErr)
+			}
+			if gotUnknown != tt.wantUnknown {
+				t.Fatalf("wrong unknown result\ngot:  %t\nwant: %t", gotUnknown, tt.wantUnknown)
+			}
+
+			gotNames := make([]string, 0, len(got))
+			for _, resource := range got {
+				gotNames = append(gotNames, resource.GetAttr("name").AsString())
+			}
+			sort.Strings(gotNames)
+
+			wantNames := append([]string{}, tt.wantNames...)
+			sort.Strings(wantNames)
+			if diff := cmp.Diff(wantNames, gotNames); diff != "" {
+				t.Fatalf("wrong matched resources (-want +got):\n%s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

This PR makes policy resource callbacks explicitly report when filtered results are incomplete due to unknown values.

Previously, `GetResources` treated unknown attribute comparisons as matches. That made callback results look complete even when Terraform could not determine whether some candidate resources actually matched the filter yet. Instead, the callback now returns the known matches and marks the response as partial.

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.16.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [ ] This change is not user-facing.
