### PR TITLE
Fix module installation edge cases

### DIFF
--- a/.changes/v1.15/BUG FIXES-20260610-100345.yaml
+++ b/.changes/v1.15/BUG FIXES-20260610-100345.yaml
@@ -1,0 +1,5 @@
+kind: BUG FIXES
+body: Fix two module installation edge cases with `null` and sensitive/ephemeral module sources
+time: 2026-06-10T10:03:45.715338+02:00
+custom:
+    Issue: "38704"

--- a/internal/terraform/context_init_test.go
+++ b/internal/terraform/context_init_test.go
@@ -58,6 +58,9 @@ func TestInit(t *testing.T) {
 		// mc -> module calls
 		expectDiags           func(m *configs.Module, mc map[string]*configs.Module) tfdiags.Diagnostics
 		expectLoadModuleCalls []*configs.ModuleRequest
+		// Set to true to emulate module installation continuing even in the presence
+		// of parsing errors
+		ignoreParsingErrors bool
 	}{
 		"empty config": {
 			module: map[string]string{"main.tf": ``},
@@ -847,20 +850,174 @@ module "local" {
 				})
 			},
 		},
+
+		"source from const sensitive variable": {
+			module: map[string]string{
+				"main.tf": `
+variable "sourc" {
+  const     = true
+  sensitive = true
+  default   = "./modules/local"
+}
+module "local" {
+  source  = var.sourc
+}
+`,
+			},
+			ignoreParsingErrors: true,
+			expectDiags: func(m *configs.Module, mc map[string]*configs.Module) tfdiags.Diagnostics {
+				return tfdiags.Diagnostics{}.Append(&hcl.Diagnostic{
+					Severity: hcl.DiagError,
+					Summary:  "Unknown module source",
+					Detail:   "The module source cannot be derived from a sensitive or ephemeral value.",
+					Subject: &hcl.Range{
+						Filename: filepath.Join(m.SourceDir, "main.tf"),
+						Start:    hcl.Pos{Line: 8, Column: 13, Byte: 121},
+						End:      hcl.Pos{Line: 8, Column: 22, Byte: 130},
+					},
+				})
+			},
+		},
+
+		"source from const ephemeral variable": {
+			module: map[string]string{
+				"main.tf": `
+variable "sourc" {
+  const     = true
+  ephemeral = true
+  default   = "./modules/local"
+}
+module "local" {
+  source  = var.sourc
+}
+`,
+			},
+			ignoreParsingErrors: true,
+			expectDiags: func(m *configs.Module, mc map[string]*configs.Module) tfdiags.Diagnostics {
+				return tfdiags.Diagnostics{}.Append(&hcl.Diagnostic{
+					Severity: hcl.DiagError,
+					Summary:  "Unknown module source",
+					Detail:   "The module source cannot be derived from a sensitive or ephemeral value.",
+					Subject: &hcl.Range{
+						Filename: filepath.Join(m.SourceDir, "main.tf"),
+						Start:    hcl.Pos{Line: 8, Column: 13, Byte: 121},
+						End:      hcl.Pos{Line: 8, Column: 22, Byte: 130},
+					},
+				})
+			},
+		},
+
+		"source from const deprecated variable": {
+			module: map[string]string{
+				"main.tf": `
+variable "sourc" {
+  deprecated = true
+  const      = true
+  default    = "./modules/local"
+}
+module "local" {
+  source  = var.sourc
+}
+`,
+			},
+			ignoreParsingErrors: true,
+			expectLoadModuleCalls: []*configs.ModuleRequest{{
+				SourceAddr: mustModuleSource(t, "./modules/local"),
+			}},
+		},
+
+		"version from const sensitive variable": {
+			module: map[string]string{
+				"main.tf": `
+variable "ver" {
+  const     = true
+  sensitive = true
+  default   = "1.0.0"
+}
+module "local" {
+  source  = "./modules/local"
+  version = var.ver
+}
+`,
+			},
+			ignoreParsingErrors: true,
+			expectDiags: func(m *configs.Module, mc map[string]*configs.Module) tfdiags.Diagnostics {
+				return tfdiags.Diagnostics{}.Append(&hcl.Diagnostic{
+					Severity: hcl.DiagError,
+					Summary:  "Unknown module version",
+					Detail:   "The module version cannot be derived from a sensitive or ephemeral value.",
+					Subject: &hcl.Range{
+						Filename: filepath.Join(m.SourceDir, "main.tf"),
+						Start:    hcl.Pos{Line: 9, Column: 13, Byte: 139},
+						End:      hcl.Pos{Line: 9, Column: 20, Byte: 146},
+					},
+				})
+			},
+		},
+
+		"version from const ephemeral variable": {
+			module: map[string]string{
+				"main.tf": `
+variable "ver" {
+  const     = true
+  ephemeral = true
+  default   = "1.0.0"
+}
+module "local" {
+  source  = "./modules/local"
+  version = var.ver
+}
+`,
+			},
+			ignoreParsingErrors: true,
+			expectDiags: func(m *configs.Module, mc map[string]*configs.Module) tfdiags.Diagnostics {
+				return tfdiags.Diagnostics{}.Append(&hcl.Diagnostic{
+					Severity: hcl.DiagError,
+					Summary:  "Unknown module version",
+					Detail:   "The module version cannot be derived from a sensitive or ephemeral value.",
+					Subject: &hcl.Range{
+						Filename: filepath.Join(m.SourceDir, "main.tf"),
+						Start:    hcl.Pos{Line: 9, Column: 13, Byte: 139},
+						End:      hcl.Pos{Line: 9, Column: 20, Byte: 146},
+					},
+				})
+			},
+		},
+
+		"version from const deprecated variable": {
+			module: map[string]string{
+				"main.tf": `
+variable "ver" {
+  deprecated = true
+  const      = true
+  default   = "1.0.0"
+}
+module "local" {
+  source  = "terraform-aws-modules/vpc/aws"
+  version = var.ver
+}
+`,
+			},
+			ignoreParsingErrors: true,
+			expectLoadModuleCalls: []*configs.ModuleRequest{{
+				SourceAddr:        mustModuleSource(t, "terraform-aws-modules/vpc/aws"),
+				VersionConstraint: mustVersionContraint(t, "1.0.0"),
+			}},
+		},
 	} {
 		t.Run(name, func(t *testing.T) {
-			m := testRootModuleInline(t, tc.module)
+			m := testRootModuleInline(t, tc.module, tc.ignoreParsingErrors)
 
 			ctx := testContext2(t, &ContextOpts{
 				Parallelism: 1,
 			})
 			moduleWalker := MockModuleWalker{
-				DefaultModule: testRootModuleInline(t, map[string]string{"main.tf": `// empty`}),
+				DefaultModule: testRootModuleInline(t, map[string]string{"main.tf": `// empty`}, false),
 			}
 			mockedModules := make(map[string]*configs.Module)
 			if tc.mockedLoadModuleCalls != nil {
 				for k, v := range tc.mockedLoadModuleCalls {
-					mockedModules[k] = testRootModuleInline(t, v)
+					mockedModules[k] = testRootModuleInline(t, v, false)
 				}
 				moduleWalker.MockModuleCalls(t, mockedModules)
 			}

--- a/internal/terraform/context_init_test.go
+++ b/internal/terraform/context_init_test.go
@@ -821,6 +821,32 @@ module "local" {
 				SourceAddr: mustModuleSource(t, "./modules/local"),
 			}},
 		},
+
+		"source from const variable set to null": {
+			module: map[string]string{
+				"main.tf": `
+variable "sourc" {
+  const   = true
+  default = null
+}
+module "local" {
+  source  = var.sourc
+}
+`,
+			},
+			expectDiags: func(m *configs.Module, mc map[string]*configs.Module) tfdiags.Diagnostics {
+				return tfdiags.Diagnostics{}.Append(&hcl.Diagnostic{
+					Severity: hcl.DiagError,
+					Summary:  "Unsuitable module source",
+					Detail:   `Unsuitable value: null value is not allowed.`,
+					Subject: &hcl.Range{
+						Filename: filepath.Join(m.SourceDir, "main.tf"),
+						Start:    hcl.Pos{Line: 7, Column: 13, Byte: 85},
+						End:      hcl.Pos{Line: 7, Column: 22, Byte: 94},
+					},
+				})
+			},
+		},
 	} {
 		t.Run(name, func(t *testing.T) {
 			m := testRootModuleInline(t, tc.module)

--- a/internal/terraform/node_module_install.go
+++ b/internal/terraform/node_module_install.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform/internal/configs"
 	"github.com/hashicorp/terraform/internal/getmodules/moduleaddrs"
 	"github.com/hashicorp/terraform/internal/lang/langrefs"
+	"github.com/hashicorp/terraform/internal/lang/marks"
 	"github.com/hashicorp/terraform/internal/tfdiags"
 )
 
@@ -224,6 +225,20 @@ func evalSource(sourceExpr hcl.Expression, hasVersion bool, ctx EvalContext) (ad
 		return nil, "", diags
 	}
 
+	if marks.Has(value, marks.Sensitive) || marks.Has(value, marks.Ephemeral) {
+		diags = diags.Append(&hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  "Unknown module source",
+			Detail:   "The module source cannot be derived from a sensitive or ephemeral value.",
+			Subject:  sourceExpr.Range().Ptr(),
+		})
+		return nil, "", diags
+	}
+
+	// Strip any remaining marks (such as deprecation marks, which are allowed)
+	// so that AsString cannot panic.
+	value, _ = value.Unmark()
+
 	rawSource := value.AsString()
 	if hasVersion {
 		addr, err = moduleaddrs.ParseModuleSourceRegistry(rawSource)
@@ -330,6 +345,20 @@ func evalVersionConstraint(versionExpr hcl.Expression, ctx EvalContext) (configs
 		})
 		return ret, diags
 	}
+
+	if marks.Has(value, marks.Sensitive) || marks.Has(value, marks.Ephemeral) {
+		diags = diags.Append(&hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  "Unknown module version",
+			Detail:   "The module version cannot be derived from a sensitive or ephemeral value.",
+			Subject:  versionExpr.Range().Ptr(),
+		})
+		return ret, diags
+	}
+
+	// Strip any remaining marks (such as deprecation marks, which are allowed)
+	// so that AsString cannot panic.
+	value, _ = value.Unmark()
 
 	constraintStr := value.AsString()
 	constraints, err := version.NewConstraint(constraintStr)

--- a/internal/terraform/node_module_install.go
+++ b/internal/terraform/node_module_install.go
@@ -204,6 +204,16 @@ func evalSource(sourceExpr hcl.Expression, hasVersion bool, ctx EvalContext) (ad
 		return nil, "", diags
 	}
 
+	if value.IsNull() {
+		diags = diags.Append(&hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  "Unsuitable module source",
+			Detail:   `Unsuitable value: null value is not allowed.`,
+			Subject:  sourceExpr.Range().Ptr(),
+		})
+		return nil, "", diags
+	}
+
 	if !value.IsWhollyKnown() {
 		diags = diags.Append(&hcl.Diagnostic{
 			Severity: hcl.DiagError,

--- a/internal/terraform/terraform_test.go
+++ b/internal/terraform/terraform_test.go
@@ -194,7 +194,7 @@ func testModuleInlineWithVars(t testing.TB, sources map[string]string, vars Inpu
 	return config
 }
 
-func testRootModuleInline(t testing.TB, sources map[string]string) *configs.Module {
+func testRootModuleInline(t testing.TB, sources map[string]string, ignoreParsingErrors bool) *configs.Module {
 	t.Helper()
 
 	cfgPath, err := filepath.EvalSymlinks(t.TempDir())
@@ -230,7 +230,7 @@ func testRootModuleInline(t testing.TB, sources map[string]string) *configs.Modu
 	loader.AllowLanguageExperiments(true)
 
 	mod, diags := loader.Parser().LoadConfigDir(cfgPath)
-	if diags.HasErrors() {
+	if diags.HasErrors() && !ignoreParsingErrors {
 		t.Fatal(diags.Error())
 	}
 


### PR DESCRIPTION
This PR addresses two edge cases that can occur during module installation.

Terraform now explicitly checks for `null` in module sources and for marks before continuing. While the configuration parser already detects these combinations, during module installation, Terraform continues to attempt to install modules even when parsing errors are present. 

Fixes https://github.com/hashicorp/terraform/issues/38694
Fixes https://github.com/hashicorp/terraform/issues/38695

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.15.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [x] This change is user-facing and I added a changelog entry.
- [ ] This change is not user-facing.
