### PR TITLE
command/format: don't drop diagnostic content with lines over 64KiB 🤖🤖🤖

### DIFF
--- a/.changes/v1.16/BUG FIXES-20260610-164500.yaml
+++ b/.changes/v1.16/BUG FIXES-20260610-164500.yaml
@@ -1,0 +1,5 @@
+kind: BUG FIXES
+body: 'cli: Diagnostics containing lines longer than 64KiB (such as cycle errors in large configurations) are no longer rendered as an empty box with no error text'
+time: 2026-06-10T16:45:00.000000+02:00
+custom:
+    Issue: "38710"

--- a/internal/command/format/diagnostic.go
+++ b/internal/command/format/diagnostic.go
@@ -4,7 +4,6 @@
 package format
 
 import (
-	"bufio"
 	"bytes"
 	"fmt"
 	"iter"
@@ -99,14 +98,25 @@ func DiagnosticFromJSON(diag *viewsjson.Diagnostic, color *colorstring.Colorize,
 
 	// Before we return, we'll finally add the left rule prefixes to each
 	// line so that the overall message is visually delimited from what's
-	// around it. We'll do that by scanning over what we already generated
+	// around it. We'll do that by iterating over what we already generated
 	// and adding the prefix for each line.
+	//
+	// We intentionally don't use bufio.Scanner here because its default
+	// token size limit silently discards lines longer than 64KiB, which
+	// caused diagnostics with very long summaries (e.g. cycle errors in
+	// large configurations, whose summaries are never word-wrapped) to be
+	// rendered as an empty box with no text at all.
 	var ruleBuf strings.Builder
-	sc := bufio.NewScanner(&buf)
+	lines := strings.Split(buf.String(), "\n")
+	if len(lines) > 0 && lines[len(lines)-1] == "" {
+		// Every write into buf above ends with a newline, so we drop the
+		// trailing empty element to avoid emitting a spurious final line.
+		lines = lines[:len(lines)-1]
+	}
 	ruleBuf.WriteString(leftRuleStart)
 	ruleBuf.WriteByte('\n')
-	for sc.Scan() {
-		line := sc.Text()
+	for _, line := range lines {
+		line = strings.TrimSuffix(line, "\r")
 		prefix := leftRuleLine
 		if line == "" {
 			// Don't print the space after the line if there would be nothing

--- a/internal/command/format/diagnostic_test.go
+++ b/internal/command/format/diagnostic_test.go
@@ -4,6 +4,7 @@
 package format
 
 import (
+	"bufio"
 	"bytes"
 	"fmt"
 	"regexp"
@@ -1469,4 +1470,29 @@ func (e diagnosticCausedByTestFailure) DiagnosticCausedByTestFailure() bool {
 
 func (e diagnosticCausedByTestFailure) IsTestVerboseMode() bool {
 	return e.Verbose
+}
+
+func TestDiagnosticFromJSON_longSummary(t *testing.T) {
+	// Regression test: a diagnostic whose rendered body contains a line
+	// longer than bufio.MaxScanTokenSize (64KiB) must not be rendered as
+	// an empty box. Cycle errors produce single-line summaries that can
+	// easily exceed this in large configurations, since the summary is
+	// deliberately never word-wrapped.
+	summary := "Cycle: " + strings.Repeat("module.example.terraform_data.this, ", 2000)
+	if len(summary) <= bufio.MaxScanTokenSize {
+		t.Fatalf("test summary is only %d bytes; must exceed %d to exercise the regression", len(summary), bufio.MaxScanTokenSize)
+	}
+	diag := &viewsjson.Diagnostic{
+		Severity: viewsjson.DiagnosticSeverityError,
+		Summary:  summary,
+	}
+
+	// A zero-value Colorize just passes through all the formatting codes,
+	// which is convenient for asserting on the contents.
+	colorize := &colorstring.Colorize{}
+	got := DiagnosticFromJSON(diag, colorize, 76)
+
+	if !strings.Contains(got, summary) {
+		t.Errorf("rendered diagnostic does not contain its own summary text\ngot (truncated to 200 chars): %.200s", got)
+	}
 }


### PR DESCRIPTION
Terraform renders each diagnostic into a buffer and then re-reads it line-by-line to add the
`│ ` left-rule prefix. The re-read in `DiagnosticFromJSON` used `bufio.Scanner` with its default
64KiB token size limit: when any rendered line exceeds that limit, `Scan()` stops at the first
oversized line and the (unchecked) scanner error is discarded, so the diagnostic is rendered as
an **empty box with no text at all**:

```
╷
╵
```

Diagnostic summaries are deliberately never word-wrapped, so a single summary line can exceed
64KiB in practice. Dependency cycle errors in large configurations do this easily — the summary
lists every fully-qualified node in the cycle. The failure mode is severe: `terraform plan`
exits 1 while printing no error text whatsoever; the message is only recoverable via `-json`.

This PR replaces the scanner with `strings.Split` over the already-materialized buffer, which has
no line-length limit and does not change memory characteristics. Behaviour parity with
`bufio.ScanLines` is preserved (trailing empty element dropped, trailing `\r` trimmed per line).
Output for all existing tests is unchanged; rendering of a >64KiB diagnostic was verified
manually against a 300-resource cycle reproduction (output identical in structure to the
small-cycle case, with the full summary present).

The plain renderer (`DiagnosticPlainFromJSON`) is not affected — it returns the buffer directly.

Includes a regression test (`TestDiagnosticFromJSON_longSummary`) that fails against the previous
implementation with exactly the empty-box output and passes with this change.

**AI usage disclosure** (per the contributing guide): the root-cause investigation, the fix, and
the regression test in this PR were produced with the assistance of an AI agent (Claude), driven
and reviewed by me. I reproduced the bug locally (bisected the cutoff to exactly
`bufio.MaxScanTokenSize`), reviewed every line of the change, and verified red→green test runs
and a manual end-to-end build.

Fixes #38709

## Target Release

1.16.x

(Candidate for backport to 1.14.x/1.15.x — the bug exists at least since 1.11 and silently
suppresses error output, but I'll defer to maintainers on backport labels.)

## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

No.

## CHANGELOG entry

- [x] This change is user-facing and I added a changelog entry. (`.changes/v1.16/BUG FIXES-….yaml` — added after PR creation so it can reference this PR's number.)
