### PR TITLE
commands/init: UX improvements when a child module has version constraints for a state store provider that conflict with the root module.

### DIFF
--- a/internal/command/init.go
+++ b/internal/command/init.go
@@ -490,7 +490,7 @@ func (c *InitCommand) getProvidersFromPSSConfig(ctx context.Context, rootModEarl
 			cb := fetchPackageBeginCallback(view)
 			cb(provider, version, location)
 		},
-		QueryPackagesFailure: queryPackagesFailureCallback(&diags, ctx, inst.ProviderSource(), reqs),
+		QueryPackagesFailure: queryPackagesFailureCallback(&diags, ctx, inst.ProviderSource(), reqs, rootModEarly.StateStore),
 		QueryPackagesWarning: queryPackagesWarningCallback(&diags),
 		LinkFromCacheFailure: linkFromCacheFailureCallback(&diags),
 		FetchPackageFailure:  fetchPackageFailureCallback(&diags, reqs),
@@ -645,6 +645,10 @@ func (c *InitCommand) getProviders(ctx context.Context, config *configs.Config, 
 	// things relatively concise. Later it'd be nice to have a progress UI
 	// where statuses update in-place, but we can't do that as long as we
 	// are shimming our vt100 output to the legacy console API on Windows.
+	var stateStore *configs.StateStore
+	if config != nil && config.Module != nil {
+		stateStore = config.Module.StateStore // may be nil, and that's fine
+	}
 	evts := &providercache.InstallerEvents{
 		PendingProviders: func(reqs map[addrs.Provider]getproviders.VersionConstraints) {
 			view.Output(views.InitializingProviderPluginMessage)
@@ -665,7 +669,7 @@ func (c *InitCommand) getProviders(ctx context.Context, config *configs.Config, 
 		},
 		LinkFromCacheBegin:   linkFromCacheBeginCallback(view),
 		FetchPackageBegin:    fetchPackageBeginCallback(view),
-		QueryPackagesFailure: queryPackagesFailureCallback(&diags, ctx, inst.ProviderSource(), reqs),
+		QueryPackagesFailure: queryPackagesFailureCallback(&diags, ctx, inst.ProviderSource(), reqs, stateStore),
 		QueryPackagesWarning: queryPackagesWarningCallback(&diags),
 		LinkFromCacheFailure: linkFromCacheFailureCallback(&diags),
 		FetchPackageFailure:  fetchPackageFailureCallback(&diags, reqs),
@@ -1057,7 +1061,7 @@ func fetchPackageBeginCallback(view views.Init) func(provider addrs.Provider, ve
 }
 
 // Returns a reused callback function for the QueryPackagesFailure event in a providercache.InstallerEvents struct.
-func queryPackagesFailureCallback(diags *tfdiags.Diagnostics, ctx context.Context, source getproviders.Source, reqs getproviders.Requirements) func(provider addrs.Provider, err error) {
+func queryPackagesFailureCallback(diags *tfdiags.Diagnostics, ctx context.Context, source getproviders.Source, reqs getproviders.Requirements, stateStore *configs.StateStore) func(provider addrs.Provider, err error) {
 	return func(provider addrs.Provider, err error) {
 		switch errorTy := err.(type) {
 		case getproviders.ErrProviderNotFound:
@@ -1135,6 +1139,35 @@ func queryPackagesFailureCallback(diags *tfdiags.Diagnostics, ctx context.Contex
 			// but rather just emit a single general message about it at
 			// the end, by checking ctx.Err().
 
+		case getproviders.ErrLockConflictsWithConstraints:
+			if stateStore != nil && stateStore.ProviderAddr.Equals(provider) {
+				// Handles an edge case where the lock obtained by getProvidersFromPSSConfig using the root module
+				// is not compatible with version constraints from child modules. This is a result of needing to download
+				// the provider for the state store separately to other providers defined in the config.
+				//
+				// The root module takes precedence as it defines and controls the state store.
+				suggestion := fmt.Sprintf("\n\nTo see which modules are currently depending on %s and what versions are specified, run the following command:\n    terraform providers", provider.ForDisplay())
+				*diags = diags.Append(tfdiags.Sourceless(
+					tfdiags.Error,
+					"Unable to download the provider used for state storage",
+					fmt.Sprintf("Provider %q (%s) is used to store state, so the root module's version constraints take precedence when downloading the provider. Terraform encountered an error that suggests that version constraint may be conflicting with a version constraint from a child module. If you want to upgrade the provider used for state storage you must use the following command:\n    terraform state migrate -upgrade\n\nError from the installer: %s%s",
+						provider.Type,
+						provider.ForDisplay(),
+						err,
+						suggestion,
+					),
+				))
+			} else {
+				// duplicate of default logic below
+				suggestion := fmt.Sprintf("\n\nTo see which modules are currently depending on %s and what versions are specified, run the following command:\n    terraform providers", provider.ForDisplay())
+				*diags = diags.Append(tfdiags.Sourceless(
+					tfdiags.Error,
+					"Failed to query available provider packages",
+					fmt.Sprintf("Could not retrieve the list of available versions for provider %s: %s%s",
+						provider.ForDisplay(), err, suggestion,
+					),
+				))
+			}
 		default:
 			suggestion := fmt.Sprintf("\n\nTo see which modules are currently depending on %s and what versions are specified, run the following command:\n    terraform providers", provider.ForDisplay())
 			*diags = diags.Append(tfdiags.Sourceless(

--- a/internal/command/init_test.go
+++ b/internal/command/init_test.go
@@ -4852,12 +4852,19 @@ Initializing provider plugins...
 	// Check stderr
 	stderr := testOutput.Stderr()
 	expectedError := `
-Error: Failed to query available provider packages
+Error: Unable to download the provider used for state storage
 
-Could not retrieve the list of available versions for provider
-hashicorp/test: locked provider registry.terraform.io/hashicorp/test 1.0.0
-does not match configured version constraint >= 2.0.0, < 2.0.0; must use
-terraform init -upgrade to allow selection of new versions
+Provider "test" (hashicorp/test) is used to store state, so the root module's
+version constraints take precedence when downloading the provider. Terraform
+encountered an error that suggests that version constraint may be conflicting
+with a version constraint from a child module. If you want to upgrade the
+provider used for state storage you must use the following command:
+    terraform state migrate -upgrade
+
+Error from the installer: locked provider
+registry.terraform.io/hashicorp/test 1.0.0 does not match configured version
+constraint >= 2.0.0, < 2.0.0; must use terraform init -upgrade to allow
+selection of new versions
 
 To see which modules are currently depending on hashicorp/test and what
 versions are specified, run the following command:

--- a/internal/getproviders/errors.go
+++ b/internal/getproviders/errors.go
@@ -10,6 +10,7 @@ import (
 	svchost "github.com/hashicorp/terraform-svchost"
 
 	"github.com/hashicorp/terraform/internal/addrs"
+	"github.com/hashicorp/terraform/internal/getproviders/providerreqs"
 )
 
 // ErrHostNoProviders is an error type used to indicate that a hostname given
@@ -225,6 +226,23 @@ type ErrRequestCanceled struct {
 
 func (err ErrRequestCanceled) Error() string {
 	return "request canceled"
+}
+
+// ErrLockConflictsWithConstraints is an error type when the local lock file contains
+// a provider version that does not satisfy the constraints of the configuration and
+// the installer is not upgrading providers. The locked version of the provider cannot
+// be changed but also cannot be used.
+type ErrLockConflictsWithConstraints struct {
+	Provider                 addrs.Provider
+	LockVersion              providerreqs.Version
+	VersionConstraintsString string
+}
+
+func (err ErrLockConflictsWithConstraints) Error() string {
+	return fmt.Sprintf(
+		"locked provider %s %s does not match configured version constraint %s; must use terraform init -upgrade to allow selection of new versions",
+		err.Provider, err.LockVersion, err.VersionConstraintsString,
+	)
 }
 
 // ErrIsNotExist returns true if and only if the given error is one of the

--- a/internal/providercache/installer.go
+++ b/internal/providercache/installer.go
@@ -263,10 +263,11 @@ func (i *Installer) EnsureProviderVersions(ctx context.Context, locks *depsfile.
 			// the currently-configured version constraints.
 			if lock := locks.Provider(provider); lock != nil {
 				if !acceptableVersions.Has(lock.Version()) {
-					err := fmt.Errorf(
-						"locked provider %s %s does not match configured version constraint %s; must use terraform init -upgrade to allow selection of new versions",
-						provider, lock.Version(), getproviders.VersionConstraintsString(versionConstraints),
-					)
+					err := getproviders.ErrLockConflictsWithConstraints{
+						Provider:                 provider,
+						LockVersion:              lock.Version(),
+						VersionConstraintsString: getproviders.VersionConstraintsString(versionConstraints),
+					}
 					errs[provider] = err
 					// This is a funny case where we're returning an error
 					// before we do any querying at all. To keep the event


### PR DESCRIPTION
An optional follow-up to https://github.com/hashicorp/terraform/pull/38699 to improve UX in the edge case where the state store provider is used in a child module and version constraints conflict with the root module.

This scenario plays out like this:
1.  the init command downloads a state store provider at [this point](https://github.com/hashicorp/terraform/blob/da87dbb60feb8dac3b385abeb2bc943439f76de0/internal/command/init_run.go#L241) in init
2. The [module download process](https://github.com/hashicorp/terraform/blob/da87dbb60feb8dac3b385abeb2bc943439f76de0/internal/command/init_run.go#L342-L358) downloads a module that introduces new version constraints for that provider.
3. That new version constraint data is used, alongside lock data from point 1, when the majority of [providers are downloaded here](https://github.com/hashicorp/terraform/blob/da87dbb60feb8dac3b385abeb2bc943439f76de0/internal/command/init_run.go#L410)
    * This causes a potential conflict - what if the locked version doesn't match the new constraint introduced by the child module?

Given this is a scenario that's specific to users of the PSS feature, we can change the error returned in this scenario if PSS is in use and the provider triggering the error is the state store provider.

This PR implements that new error message and conditional logic to enable showing the old error in all other scenarios (no PSS in use, or PSS in use but the erroring provider isn't used for a store).

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.16.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
