### PR TITLE
Add otel tracing to terraform policy

### DIFF
--- a/internal/backend/local/backend_apply.go
+++ b/internal/backend/local/backend_apply.go
@@ -12,6 +12,8 @@ import (
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/zclconf/go-cty/cty"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
 
 	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/backend/backendrun"
@@ -93,6 +95,7 @@ func (b *Local) opApply(
 
 	var plan *plans.Plan
 	combinedPlanApply := false
+	lr.Core.SetTracingContext(stopCtx)
 	// If we weren't given a plan, then we refresh/plan
 	if op.PlanFile == nil {
 		// set the policy client to nil for the plan preceding apply
@@ -445,7 +448,22 @@ func (b *Local) opApply(
 	diags = diags.Append(applyDiags)
 
 	// Print the policy results we found during apply
+	policyResultCount := 0
+	if plan.PolicyResults != nil {
+		policyResultCount = plan.PolicyResults.Len()
+	}
+	var polRenderSpan trace.Span
+	polRenderSpanEnd := func() {}
+	if policyResultCount > 0 {
+		_, polRenderSpan = tracer().Start(stopCtx, "terraform.local.apply.render_policy_results",
+			trace.WithAttributes(
+				attribute.Int("apply.policy_results", policyResultCount),
+			),
+		)
+		polRenderSpanEnd = func() { polRenderSpan.End() }
+	}
 	op.View.PolicyResults(plan.PolicyResults, nil)
+	polRenderSpanEnd()
 
 	// Even on error with an empty state, the state value should not be nil.
 	// Return early here to prevent corrupting any existing state.

--- a/internal/backend/local/backend_apply.go
+++ b/internal/backend/local/backend_apply.go
@@ -60,7 +60,7 @@ func (b *Local) opApply(
 	op.Hooks = append(op.Hooks, stateHook)
 
 	// Get our context
-	lr, _, opState, contextDiags := b.localRun(op)
+	lr, _, opState, contextDiags := b.localRun(stopCtx, op)
 
 	diags = diags.Append(contextDiags)
 	if contextDiags.HasErrors() {
@@ -95,7 +95,6 @@ func (b *Local) opApply(
 
 	var plan *plans.Plan
 	combinedPlanApply := false
-	lr.Core.SetTracingContext(stopCtx)
 	// If we weren't given a plan, then we refresh/plan
 	if op.PlanFile == nil {
 		// set the policy client to nil for the plan preceding apply

--- a/internal/backend/local/backend_local.go
+++ b/internal/backend/local/backend_local.go
@@ -39,11 +39,11 @@ func (b *Local) LocalRun(ctx context.Context, op *backendrun.Operation) (*backen
 
 	op.StateLocker = op.StateLocker.WithContext(ctx)
 
-	lr, _, stateMgr, diags := b.localRun(op)
+	lr, _, stateMgr, diags := b.localRun(ctx, op)
 	return lr, stateMgr, diags
 }
 
-func (b *Local) localRun(op *backendrun.Operation) (*backendrun.LocalRun, *configload.Snapshot, statemgr.Full, tfdiags.Diagnostics) {
+func (b *Local) localRun(ctx context.Context, op *backendrun.Operation) (*backendrun.LocalRun, *configload.Snapshot, statemgr.Full, tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
 
 	// Get the latest state.
@@ -83,6 +83,7 @@ func (b *Local) localRun(op *backendrun.Operation) (*backendrun.LocalRun, *confi
 	}
 	coreOpts.UIInput = op.UIIn
 	coreOpts.Hooks = op.Hooks
+	coreOpts.TracingContext = ctx
 
 	var ctxDiags tfdiags.Diagnostics
 	var configSnap *configload.Snapshot

--- a/internal/backend/local/backend_plan.go
+++ b/internal/backend/local/backend_plan.go
@@ -9,6 +9,9 @@ import (
 	"io"
 	"log"
 
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+
 	"github.com/hashicorp/terraform/internal/backend/backendrun"
 	"github.com/hashicorp/terraform/internal/genconfig"
 	"github.com/hashicorp/terraform/internal/logging"
@@ -118,6 +121,7 @@ func (b *Local) opPlan(
 		defer logging.PanicHandler()
 		defer close(doneCh)
 		log.Printf("[INFO] backend/local: plan calling Plan")
+		lr.Core.SetTracingContext(stopCtx)
 		plan, planDiags = lr.Core.Plan(lr.Config, lr.InputState, lr.PlanOpts)
 	}()
 
@@ -223,7 +227,22 @@ func (b *Local) opPlan(
 	op.View.Plan(plan, schemas)
 
 	// Report all policy results that may have accumulated during the plan
+	policyResultCount := 0
+	if plan.PolicyResults != nil {
+		policyResultCount = plan.PolicyResults.Len()
+	}
+	var polRenderSpan trace.Span
+	polRenderSpanEnd := func() {}
+	if policyResultCount > 0 {
+		_, polRenderSpan = tracer().Start(stopCtx, "terraform.local.plan.render_policy_results",
+			trace.WithAttributes(
+				attribute.Int("plan.policy_results", policyResultCount),
+			),
+		)
+		polRenderSpanEnd = func() { polRenderSpan.End() }
+	}
 	op.View.PolicyResults(plan.PolicyResults, nil)
+	polRenderSpanEnd()
 
 	// If we've accumulated any diagnostics along the way then we'll show them
 	// here just before we show the summary and next steps. This can potentially

--- a/internal/backend/local/backend_plan.go
+++ b/internal/backend/local/backend_plan.go
@@ -92,7 +92,7 @@ func (b *Local) opPlan(
 	}
 
 	// Set up backend and get our context
-	lr, configSnap, opState, ctxDiags := b.localRun(op)
+	lr, configSnap, opState, ctxDiags := b.localRun(stopCtx, op)
 
 	diags = diags.Append(ctxDiags)
 	if ctxDiags.HasErrors() {
@@ -121,7 +121,6 @@ func (b *Local) opPlan(
 		defer logging.PanicHandler()
 		defer close(doneCh)
 		log.Printf("[INFO] backend/local: plan calling Plan")
-		lr.Core.SetTracingContext(stopCtx)
 		plan, planDiags = lr.Core.Plan(lr.Config, lr.InputState, lr.PlanOpts)
 	}()
 

--- a/internal/backend/local/backend_refresh.go
+++ b/internal/backend/local/backend_refresh.go
@@ -48,7 +48,7 @@ func (b *Local) opRefresh(
 	op.PlanRefresh = true
 
 	// Get our context
-	lr, _, opState, contextDiags := b.localRun(op)
+	lr, _, opState, contextDiags := b.localRun(stopCtx, op)
 	diags = diags.Append(contextDiags)
 	if contextDiags.HasErrors() {
 		op.ReportResult(runningOp, diags)
@@ -91,7 +91,6 @@ func (b *Local) opRefresh(
 	go func() {
 		defer logging.PanicHandler()
 		defer close(doneCh)
-		lr.Core.SetTracingContext(stopCtx)
 		newState, refreshDiags = lr.Core.Refresh(lr.Config, lr.InputState, lr.PlanOpts)
 		log.Printf("[INFO] backend/local: refresh calling Refresh")
 	}()

--- a/internal/backend/local/backend_refresh.go
+++ b/internal/backend/local/backend_refresh.go
@@ -91,6 +91,7 @@ func (b *Local) opRefresh(
 	go func() {
 		defer logging.PanicHandler()
 		defer close(doneCh)
+		lr.Core.SetTracingContext(stopCtx)
 		newState, refreshDiags = lr.Core.Refresh(lr.Config, lr.InputState, lr.PlanOpts)
 		log.Printf("[INFO] backend/local: refresh calling Refresh")
 	}()

--- a/internal/backend/local/telemetry.go
+++ b/internal/backend/local/telemetry.go
@@ -1,0 +1,18 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package local
+
+import (
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/trace"
+)
+
+// tracer returns the OpenTelemetry tracer for the local backend.
+//
+// Resolved lazily on every call so the global TracerProvider installed by
+// the CLI's openTelemetryInit (which runs after this package's init) is
+// reflected in the tracer used at runtime.
+func tracer() trace.Tracer {
+	return otel.Tracer("github.com/hashicorp/terraform/internal/backend/local")
+}

--- a/internal/command/apply.go
+++ b/internal/command/apply.go
@@ -4,7 +4,6 @@
 package command
 
 import (
-	"context"
 	"fmt"
 	"strings"
 
@@ -105,7 +104,7 @@ func (c *ApplyCommand) Run(rawArgs []string) int {
 	}
 
 	if len(args.PolicyPaths) > 0 {
-		client, policyDiags, stopClient := c.PolicyClient(context.Background(), args.PolicyPaths, backendPolicyEntitlement(be))
+		client, policyDiags, stopClient := c.PolicyClient(c.CommandContext(), args.PolicyPaths, backendPolicyEntitlement(be))
 		// if there has been any errors when setting up the policy client, we log them but
 		// we still proceed with the operation, as a failure to set up the policy client
 		// should not prevent the apply operation from running

--- a/internal/command/meta.go
+++ b/internal/command/meta.go
@@ -20,8 +20,9 @@ import (
 
 	"github.com/hashicorp/cli"
 	plugin "github.com/hashicorp/go-plugin"
-	"github.com/hashicorp/terraform-svchost/disco"
 	"github.com/mitchellh/colorstring"
+
+	"github.com/hashicorp/terraform-svchost/disco"
 
 	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/backend"
@@ -497,7 +498,7 @@ func (m *Meta) RunOperation(b backendrun.OperationsBackend, opReq *backendrun.Op
 		opReq.ConfigDir = m.normalizePath(opReq.ConfigDir)
 	}
 
-	op, err := b.Operation(context.Background(), opReq)
+	op, err := b.Operation(m.CommandContext(), opReq)
 	if err != nil {
 		return nil, fmt.Errorf("error starting operation: %s", err)
 	}

--- a/internal/command/plan.go
+++ b/internal/command/plan.go
@@ -4,7 +4,6 @@
 package command
 
 import (
-	"context"
 	"fmt"
 	"strings"
 
@@ -89,7 +88,7 @@ func (c *PlanCommand) Run(rawArgs []string) int {
 	}
 
 	if len(args.PolicyPaths) > 0 {
-		client, policyDiags, stopClient := c.PolicyClient(context.Background(), args.PolicyPaths, backendPolicyEntitlement(be))
+		client, policyDiags, stopClient := c.PolicyClient(c.CommandContext(), args.PolicyPaths, backendPolicyEntitlement(be))
 		// if there has been any errors when setting up the policy client, we log them but
 		// we still proceed with the operation, as a failure to set up the policy client
 		// should not prevent the plan operation from running

--- a/internal/policy/callback/callback.go
+++ b/internal/policy/callback/callback.go
@@ -4,6 +4,7 @@
 package callback
 
 import (
+	"context"
 	"sync"
 	"sync/atomic"
 
@@ -11,8 +12,8 @@ import (
 )
 
 type Functions struct {
-	GetResources  func(resource string, attrs cty.Value) ([]cty.Value, bool, error)
-	GetDataSource func(datasource string, attrs cty.Value) (cty.Value, error)
+	GetResources  func(ctx context.Context, resource string, attrs cty.Value) ([]cty.Value, bool, error)
+	GetDataSource func(ctx context.Context, datasource string, attrs cty.Value) (cty.Value, error)
 }
 
 // Registry is an interface for managing callback functions for resources and

--- a/internal/policy/callback/server.go
+++ b/internal/policy/callback/server.go
@@ -9,10 +9,6 @@ import (
 
 	"github.com/zclconf/go-cty/cty"
 	"github.com/zclconf/go-cty/cty/msgpack"
-	"go.opentelemetry.io/otel"
-	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/codes"
-	"go.opentelemetry.io/otel/trace"
 	"google.golang.org/grpc"
 
 	"github.com/hashicorp/terraform/internal/policy/proto"
@@ -22,12 +18,6 @@ var (
 	_ proto.CallbackServiceServer = (*Server)(nil)
 )
 
-// tracer is resolved lazily so the global TracerProvider installed by
-// openTelemetryInit (which runs after package init) is reflected.
-func tracer() trace.Tracer {
-	return otel.Tracer("github.com/hashicorp/terraform/internal/policy/callback")
-}
-
 type Server struct {
 	ID       uint32
 	Registry Registry
@@ -36,32 +26,18 @@ type Server struct {
 }
 
 func (s *Server) GetResources(ctx context.Context, request *proto.GetResourcesRequest) (*proto.GetResourcesResponse, error) {
-	ctx, span := tracer().Start(ctx, "policy.callback.server.get_resources",
-		trace.WithAttributes(
-			attribute.String("policy.callback.resource_type", request.Type),
-			attribute.Int64("policy.evaluation.id", int64(request.EvaluationRequestId)),
-		),
-	)
-	defer span.End()
-
 	attrs, err := msgpack.Unmarshal(request.Attributes, cty.DynamicPseudoType)
 	if err != nil {
 		err = fmt.Errorf("failed to unserialize attributes: %w", err)
-		span.RecordError(err)
-		span.SetStatus(codes.Error, err.Error())
 		return nil, err
 	}
 	functions, ok := s.Registry.Get(request.EvaluationRequestId)
 	if !ok {
 		err := fmt.Errorf("no callback registered for ID %d (request type: %s)", request.EvaluationRequestId, request.Type)
-		span.RecordError(err)
-		span.SetStatus(codes.Error, err.Error())
 		return nil, err
 	}
 	resources, isPartialResult, err := functions.GetResources(ctx, request.Type, attrs)
 	if err != nil {
-		span.RecordError(err)
-		span.SetStatus(codes.Error, err.Error())
 		return nil, err
 	}
 
@@ -70,14 +46,11 @@ func (s *Server) GetResources(ctx context.Context, request *proto.GetResourcesRe
 		result, err := msgpack.Marshal(resource, cty.DynamicPseudoType)
 		if err != nil {
 			err = fmt.Errorf("failed to serialize resource: %w", err)
-			span.RecordError(err)
-			span.SetStatus(codes.Error, err.Error())
 			return nil, err
 		}
 		results = append(results, result)
 	}
 
-	span.SetAttributes(attribute.Int("policy.callback.results.count", len(results)))
 	return &proto.GetResourcesResponse{
 		Results: results,
 		Partial: isPartialResult,
@@ -85,41 +58,26 @@ func (s *Server) GetResources(ctx context.Context, request *proto.GetResourcesRe
 }
 
 func (s *Server) GetDataSource(ctx context.Context, request *proto.GetDataSourceRequest) (*proto.GetDataSourceResponse, error) {
-	ctx, span := tracer().Start(ctx, "policy.callback.server.get_datasource",
-		trace.WithAttributes(
-			attribute.String("policy.callback.datasource_type", request.Type),
-			attribute.Int64("policy.evaluation.id", int64(request.EvaluationRequestId)),
-		),
-	)
-	defer span.End()
-
 	config, err := msgpack.Unmarshal(request.Config, cty.DynamicPseudoType)
 	if err != nil {
 		err = fmt.Errorf("failed to unserialize config: %w", err)
-		span.RecordError(err)
-		span.SetStatus(codes.Error, err.Error())
+
 		return nil, err
 	}
 
 	functions, ok := s.Registry.Get(request.EvaluationRequestId)
 	if !ok {
 		err := fmt.Errorf("no callback registered for ID %d (request type: %s)", request.EvaluationRequestId, request.Type)
-		span.RecordError(err)
-		span.SetStatus(codes.Error, err.Error())
 		return nil, err
 	}
 	datasource, err := functions.GetDataSource(ctx, request.Type, config)
 	if err != nil {
-		span.RecordError(err)
-		span.SetStatus(codes.Error, err.Error())
 		return nil, err
 	}
 
 	result, err := msgpack.Marshal(datasource, cty.DynamicPseudoType)
 	if err != nil {
 		err = fmt.Errorf("failed to serialize datasource: %w", err)
-		span.RecordError(err)
-		span.SetStatus(codes.Error, err.Error())
 		return nil, err
 	}
 

--- a/internal/policy/callback/server.go
+++ b/internal/policy/callback/server.go
@@ -9,6 +9,10 @@ import (
 
 	"github.com/zclconf/go-cty/cty"
 	"github.com/zclconf/go-cty/cty/msgpack"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
 	"google.golang.org/grpc"
 
 	"github.com/hashicorp/terraform/internal/policy/proto"
@@ -18,6 +22,12 @@ var (
 	_ proto.CallbackServiceServer = (*Server)(nil)
 )
 
+// tracer is resolved lazily so the global TracerProvider installed by
+// openTelemetryInit (which runs after package init) is reflected.
+func tracer() trace.Tracer {
+	return otel.Tracer("github.com/hashicorp/terraform/internal/policy/callback")
+}
+
 type Server struct {
 	ID       uint32
 	Registry Registry
@@ -25,17 +35,33 @@ type Server struct {
 	proto.UnimplementedCallbackServiceServer
 }
 
-func (s *Server) GetResources(_ context.Context, request *proto.GetResourcesRequest) (*proto.GetResourcesResponse, error) {
+func (s *Server) GetResources(ctx context.Context, request *proto.GetResourcesRequest) (*proto.GetResourcesResponse, error) {
+	ctx, span := tracer().Start(ctx, "policy.callback.server.get_resources",
+		trace.WithAttributes(
+			attribute.String("policy.callback.resource_type", request.Type),
+			attribute.Int64("policy.evaluation.id", int64(request.EvaluationRequestId)),
+		),
+	)
+	defer span.End()
+
 	attrs, err := msgpack.Unmarshal(request.Attributes, cty.DynamicPseudoType)
 	if err != nil {
-		return nil, fmt.Errorf("failed to unserialize attributes: %w", err)
+		err = fmt.Errorf("failed to unserialize attributes: %w", err)
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+		return nil, err
 	}
 	functions, ok := s.Registry.Get(request.EvaluationRequestId)
 	if !ok {
-		return nil, fmt.Errorf("no callback registered for ID %d (request type: %s)", request.EvaluationRequestId, request.Type)
+		err := fmt.Errorf("no callback registered for ID %d (request type: %s)", request.EvaluationRequestId, request.Type)
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+		return nil, err
 	}
-	resources, isPartialResult, err := functions.GetResources(request.Type, attrs)
+	resources, isPartialResult, err := functions.GetResources(ctx, request.Type, attrs)
 	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
 		return nil, err
 	}
 
@@ -43,35 +69,58 @@ func (s *Server) GetResources(_ context.Context, request *proto.GetResourcesRequ
 	for _, resource := range resources {
 		result, err := msgpack.Marshal(resource, cty.DynamicPseudoType)
 		if err != nil {
-			return nil, fmt.Errorf("failed to serialize resource: %w", err)
+			err = fmt.Errorf("failed to serialize resource: %w", err)
+			span.RecordError(err)
+			span.SetStatus(codes.Error, err.Error())
+			return nil, err
 		}
 		results = append(results, result)
 	}
 
+	span.SetAttributes(attribute.Int("policy.callback.results.count", len(results)))
 	return &proto.GetResourcesResponse{
 		Results: results,
 		Partial: isPartialResult,
 	}, nil
 }
 
-func (s *Server) GetDataSource(_ context.Context, request *proto.GetDataSourceRequest) (*proto.GetDataSourceResponse, error) {
+func (s *Server) GetDataSource(ctx context.Context, request *proto.GetDataSourceRequest) (*proto.GetDataSourceResponse, error) {
+	ctx, span := tracer().Start(ctx, "policy.callback.server.get_datasource",
+		trace.WithAttributes(
+			attribute.String("policy.callback.datasource_type", request.Type),
+			attribute.Int64("policy.evaluation.id", int64(request.EvaluationRequestId)),
+		),
+	)
+	defer span.End()
+
 	config, err := msgpack.Unmarshal(request.Config, cty.DynamicPseudoType)
 	if err != nil {
-		return nil, fmt.Errorf("failed to unserialize config: %w", err)
+		err = fmt.Errorf("failed to unserialize config: %w", err)
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+		return nil, err
 	}
 
 	functions, ok := s.Registry.Get(request.EvaluationRequestId)
 	if !ok {
-		return nil, fmt.Errorf("no callback registered for ID %d (request type: %s)", request.EvaluationRequestId, request.Type)
+		err := fmt.Errorf("no callback registered for ID %d (request type: %s)", request.EvaluationRequestId, request.Type)
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+		return nil, err
 	}
-	datasource, err := functions.GetDataSource(request.Type, config)
+	datasource, err := functions.GetDataSource(ctx, request.Type, config)
 	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
 		return nil, err
 	}
 
 	result, err := msgpack.Marshal(datasource, cty.DynamicPseudoType)
 	if err != nil {
-		return nil, fmt.Errorf("failed to serialize datasource: %w", err)
+		err = fmt.Errorf("failed to serialize datasource: %w", err)
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+		return nil, err
 	}
 
 	return &proto.GetDataSourceResponse{

--- a/internal/policy/client.go
+++ b/internal/policy/client.go
@@ -240,9 +240,7 @@ func (c *client) RegisterCallbackService(ctx context.Context) (*callback.Server,
 }
 
 func (c *client) Setup(ctx context.Context, req SetupRequest) SetupResponse {
-	ctx, span := tracer().Start(ctx, "policy.client.setup",
-		trace.WithAttributes(attribute.Int("policy.source_locations.count", len(req.SourceLocations))),
-	)
+	ctx, span := tracer().Start(ctx, "policy.client.setup")
 	defer span.End()
 
 	log.Printf("[DEBUG] Setting up Terraform Policy connection")

--- a/internal/policy/client.go
+++ b/internal/policy/client.go
@@ -16,6 +16,10 @@ import (
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-plugin"
 	"github.com/zclconf/go-cty/cty"
+	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
 	"google.golang.org/grpc"
 
 	"github.com/hashicorp/terraform/internal/policy/callback"
@@ -112,6 +116,9 @@ func NewPolicyClient(ctx context.Context, policyPluginPath string, policyPaths [
 // Connect creates a connection to tfpolicy-plugin. If policyPluginPath is empty, the command lookup
 // will default to the executable "tfpolicy-plugin" in the $PATH.
 func Connect(ctx context.Context, policyPluginPath string) (Client, error) {
+	ctx, span := tracer().Start(ctx, "policy.client.connect")
+	defer span.End()
+
 	pgm := "tfpolicy-plugin" // by default, just use this if it's in the path
 
 	if policyPluginPath != "" {
@@ -132,6 +139,11 @@ func Connect(ctx context.Context, policyPluginPath string) (Client, error) {
 		AllowedProtocols: []plugin.Protocol{
 			plugin.ProtocolGRPC,
 		},
+		// This propagates the active trace context via gRPC metadata  so the plugin's handler
+		// spans become children of the terraform-side span that invoked them.
+		GRPCDialOptions: []grpc.DialOption{
+			grpc.WithStatsHandler(otelgrpc.NewClientHandler()),
+		},
 		Logger: hclog.New(&hclog.LoggerOptions{
 			Level: func() hclog.Level {
 				level := hclog.LevelFromString(os.Getenv(TerraformPolicyLogLevelEnvVar))
@@ -146,13 +158,19 @@ func Connect(ctx context.Context, policyPluginPath string) (Client, error) {
 	rpc, err := plugin.Client()
 	if err != nil {
 		plugin.Kill()
-		return nil, fmt.Errorf("failed to connect to plugin: %v", err)
+		err = fmt.Errorf("failed to connect to plugin: %v", err)
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+		return nil, err
 	}
 
 	raw, err := rpc.Dispense("policy")
 	if err != nil {
 		plugin.Kill()
-		return nil, fmt.Errorf("failed to dispense plugin: %v", err)
+		err = fmt.Errorf("failed to dispense plugin: %v", err)
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+		return nil, err
 	}
 
 	sc := raw.(*client)
@@ -184,6 +202,11 @@ func (c *client) RegisterCallbackService(ctx context.Context) (*callback.Server,
 
 	// Start the callback service server on the broker.
 	go c.broker.AcceptAndServe(cbServiceID, func(opts []grpc.ServerOption) *grpc.Server {
+		// Install the OpenTelemetry gRPC server stats handler so that the
+		// trace context the plugin client injects into outgoing callback RPC
+		// metadata is extracted and made the parent of the callback handler
+		// spans.
+		opts = append(opts, grpc.StatsHandler(otelgrpc.NewServerHandler()))
 		server := grpc.NewServer(opts...)
 		proto.RegisterCallbackServiceServer(server, c.cbServer)
 		serverCh <- server
@@ -217,6 +240,11 @@ func (c *client) RegisterCallbackService(ctx context.Context) (*callback.Server,
 }
 
 func (c *client) Setup(ctx context.Context, req SetupRequest) SetupResponse {
+	ctx, span := tracer().Start(ctx, "policy.client.setup",
+		trace.WithAttributes(attribute.Int("policy.source_locations.count", len(req.SourceLocations))),
+	)
+	defer span.End()
+
 	log.Printf("[DEBUG] Setting up Terraform Policy connection")
 	protoReq := &proto.PolicySetupRequest{
 		ClientCapabilities: new(proto.PolicySetupRequest_ClientCapabilities),
@@ -247,6 +275,11 @@ func (c *client) Setup(ctx context.Context, req SetupRequest) SetupResponse {
 }
 
 func (c *client) EvaluateResource(ctx context.Context, req EvaluationRequest[*proto.PolicyEvaluateResourceRequest_ResourceMetadata]) EvaluationResponse {
+	ctx, span := tracer().Start(ctx, "policy.client.evaluate_resource",
+		trace.WithAttributes(attribute.String("policy.resource.type", req.Target)),
+	)
+	defer span.End()
+
 	log.Printf("[DEBUG] Evaluating policy for resource %s", req.Target)
 	var diags []*proto.Diagnostic
 
@@ -299,6 +332,11 @@ func (c *client) EvaluateResource(ctx context.Context, req EvaluationRequest[*pr
 }
 
 func (c *client) EvaluateProvider(ctx context.Context, req EvaluationRequest[*proto.PolicyEvaluateProviderRequest_ProviderMetadata]) EvaluationResponse {
+	ctx, span := tracer().Start(ctx, "policy.client.evaluate_provider",
+		trace.WithAttributes(attribute.String("policy.provider.type", req.Target)),
+	)
+	defer span.End()
+
 	log.Printf("[DEBUG] Evaluating policy for provider %s", req.Target)
 	var diags []*proto.Diagnostic
 	req = normalizeRequest(req)
@@ -331,6 +369,11 @@ func (c *client) EvaluateProvider(ctx context.Context, req EvaluationRequest[*pr
 }
 
 func (c *client) EvaluateModule(ctx context.Context, req EvaluationRequest[*proto.PolicyEvaluateModuleRequest_ModuleMetadata]) EvaluationResponse {
+	ctx, span := tracer().Start(ctx, "policy.client.evaluate_module",
+		trace.WithAttributes(attribute.String("policy.module.source", req.Target)),
+	)
+	defer span.End()
+
 	log.Printf("[DEBUG] Evaluating policy for module %s", req.Target)
 	var diags []*proto.Diagnostic
 

--- a/internal/policy/telemetry.go
+++ b/internal/policy/telemetry.go
@@ -1,0 +1,18 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package policy
+
+import (
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/trace"
+)
+
+// tracer returns the OpenTelemetry tracer used by the policy client.
+//
+// Resolved lazily on every call so the global TracerProvider installed by
+// `openTelemetryInit` (in package main, which runs after this package's
+// `init`) is reflected in the tracer used at runtime.
+func tracer() trace.Tracer {
+	return otel.Tracer("github.com/hashicorp/terraform/internal/policy")
+}

--- a/internal/terraform/context.go
+++ b/internal/terraform/context.go
@@ -106,6 +106,9 @@ type Context struct {
 	runCond             *sync.Cond
 	runContext          context.Context
 	runContextCancel    context.CancelFunc
+
+	// tracingCtx is as the parent context for tracing within the graph walk
+	tracingCtx context.Context
 }
 
 // (additional methods on Context can be found in context_*.go files.)
@@ -243,13 +246,25 @@ func (c *Context) acquireRun(phase string) func() {
 	// Build our lock
 	c.runCond = sync.NewCond(&c.l)
 
-	// Create a new run context
-	c.runContext, c.runContextCancel = context.WithCancel(context.Background())
+	// Use tracingCtx as parent context so tracing spans inherit the hierarchy properly
+	parent := c.tracingCtx
+	if parent == nil {
+		parent = context.Background()
+	}
+	c.runContext, c.runContextCancel = context.WithCancel(parent)
 
 	// Reset the stop hook so we're not stopped
 	c.sh.Reset()
 
 	return c.releaseRun
+}
+
+// SetTracingContext records a context.Context that will be used as the parent
+// for all spans created within the graph walk.
+func (c *Context) SetTracingContext(ctx context.Context) {
+	c.l.Lock()
+	defer c.l.Unlock()
+	c.tracingCtx = ctx
 }
 
 func (c *Context) releaseRun() {

--- a/internal/terraform/context.go
+++ b/internal/terraform/context.go
@@ -60,6 +60,8 @@ type ContextOpts struct {
 	// been passed to Terraform Core using this field.
 	PreloadedProviderSchemas map[addrs.Provider]providers.ProviderSchema
 
+	TracingContext context.Context
+
 	UIInput UIInput
 }
 
@@ -165,6 +167,7 @@ func NewContext(opts *ContextOpts) (*Context, tfdiags.Diagnostics) {
 		parallelSem:         NewSemaphore(par),
 		providerInputConfig: make(map[string]map[string]cty.Value),
 		sh:                  sh,
+		tracingCtx:          opts.TracingContext,
 	}, diags
 }
 
@@ -257,14 +260,6 @@ func (c *Context) acquireRun(phase string) func() {
 	c.sh.Reset()
 
 	return c.releaseRun
-}
-
-// SetTracingContext records a context.Context that will be used as the parent
-// for all spans created within the graph walk.
-func (c *Context) SetTracingContext(ctx context.Context) {
-	c.l.Lock()
-	defer c.l.Unlock()
-	c.tracingCtx = ctx
 }
 
 func (c *Context) releaseRun() {

--- a/internal/terraform/context_apply_policy_test.go
+++ b/internal/terraform/context_apply_policy_test.go
@@ -5,6 +5,7 @@ package terraform
 
 import (
 	"context"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -20,6 +21,10 @@ import (
 	"github.com/hashicorp/terraform/internal/states"
 	"github.com/hashicorp/terraform/internal/tfdiags"
 	"github.com/zclconf/go-cty/cty"
+	"go.opentelemetry.io/otel"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	"go.opentelemetry.io/otel/trace"
 	"google.golang.org/protobuf/testing/protocmp"
 )
 
@@ -991,5 +996,312 @@ func TestContext2Apply_PolicyEvaluation_Destroy(t *testing.T) {
 	rs := resultState.Resource(mustAbsResourceAddr("test_resource.test"))
 	if rs != nil {
 		t.Fatal("expected test_resource.test to be removed from state after destroy")
+	}
+}
+
+func TestContext2Apply_PolicyCallback(t *testing.T) {
+	mainConfig := `
+		terraform {
+			required_providers {
+				test = {
+					source = "hashicorp/test"
+					version = "1.0.0"
+				}
+			}
+		}
+
+		resource "test_instance" "foo" {
+			ami = "bar"
+		}
+
+		resource "test_instance" "baz" {
+			ami = "qux"
+			depends_on = [test_instance.foo]
+		}
+
+		resource "test_instance" "boop" {
+			ami = "booper"
+			depends_on = [test_instance.baz]
+		}
+	`
+
+	policyConfig := `
+		resource_policy "test_instance" "policy_name" {
+			enforce {
+				condition = core::getresources("some_resource_type", {})[0].value != null
+			}
+		}
+	`
+
+	mod := testModuleInline(t, map[string]string{
+		"main.tf":           mainConfig,
+		"main.tfpolicy.hcl": policyConfig,
+	})
+
+	providerAddr := addrs.NewDefaultProvider("test")
+	provider := testProvider("test")
+	provider.PlanResourceChangeFn = func(req providers.PlanResourceChangeRequest) providers.PlanResourceChangeResponse {
+		return providers.PlanResourceChangeResponse{
+			PlannedState: req.ProposedNewState,
+		}
+	}
+	// Apply echoes the planned config back as the new state, so the applied
+	// instances carry concrete ami values in state for the callback to read.
+	provider.ApplyResourceChangeFn = func(req providers.ApplyResourceChangeRequest) (resp providers.ApplyResourceChangeResponse) {
+		resp.NewState = req.PlannedState
+		return resp
+	}
+
+	type callbackResult struct {
+		matchAllResults  []cty.Value
+		filteredResults  []cty.Value
+		noMatchCount     int
+		unknownTypeCount int
+	}
+
+	// The plan policy client allows everything; the callback assertions run
+	// during apply only.
+	planPolicyClient := policy.NewTestMockClient(t)
+	planPolicyClient.EvaluateFn = func(ctx context.Context, req policy.EvaluationRequest[*proto.PolicyEvaluateResourceRequest_ResourceMetadata]) policy.EvaluationResponse {
+		return policy.EvaluationResponse{Overall: policy.AllowResult}
+	}
+
+	var mu sync.Mutex
+	results := make(map[string]callbackResult)
+
+	applyPolicyClient := policy.NewTestMockClient(t)
+	applyPolicyClient.EvaluateFn = func(ctx context.Context, req policy.EvaluationRequest[*proto.PolicyEvaluateResourceRequest_ResourceMetadata]) policy.EvaluationResponse {
+		cr := callbackResult{}
+
+		if req.Callbacks.GetResources == nil {
+			t.Errorf("GetResources callback was nil")
+			return policy.EvaluationResponse{Overall: policy.AllowResult}
+		}
+
+		// 1. Match all test_instance resources with null attrs (no filter).
+		all, _, err := req.Callbacks.GetResources(t.Context(), "test_instance", cty.NullVal(cty.DynamicPseudoType))
+		if err != nil {
+			t.Errorf("GetResources(test_instance, null): %v", err)
+		} else {
+			cr.matchAllResults = all
+		}
+
+		// 2. Match resources with ami="bar" filter.
+		filtered, _, err := req.Callbacks.GetResources(t.Context(), "test_instance", cty.ObjectVal(map[string]cty.Value{
+			"ami": cty.StringVal("bar"),
+		}))
+		if err != nil {
+			t.Errorf("GetResources(test_instance, ami=bar): %v", err)
+		} else {
+			cr.filteredResults = filtered
+		}
+
+		// 3. Match with an attribute filter that will never match.
+		noMatch, _, err := req.Callbacks.GetResources(t.Context(), "test_instance", cty.ObjectVal(map[string]cty.Value{
+			"ami": cty.StringVal("nonexistent"),
+		}))
+		if err != nil {
+			t.Errorf("GetResources(test_instance, ami=nonexistent): %v", err)
+		} else {
+			cr.noMatchCount = len(noMatch)
+		}
+
+		// 4. Query for a resource type that doesn't exist in the config.
+		unknown, _, err := req.Callbacks.GetResources(t.Context(), "nonexistent_resource", cty.NullVal(cty.DynamicPseudoType))
+		if err != nil {
+			t.Errorf("GetResources(nonexistent_resource): %v", err)
+		} else {
+			cr.unknownTypeCount = len(unknown)
+		}
+
+		ami := req.Attrs.Raw.GetAttr("ami").AsString()
+		mu.Lock()
+		results[ami] = cr
+		mu.Unlock()
+
+		return policy.EvaluationResponse{Overall: policy.AllowResult}
+	}
+
+	ctx, diags := NewContext(&ContextOpts{
+		Providers: map[addrs.Provider]providers.Factory{
+			providerAddr: testProviderFuncFixed(provider),
+		},
+	})
+	tfdiags.AssertNoDiagnostics(t, diags)
+
+	plan, diags := ctx.Plan(mod, states.NewState(), &PlanOpts{
+		Mode:         plans.NormalMode,
+		SetVariables: testInputValuesUnset(mod.Module.Variables),
+		PolicyClient: planPolicyClient,
+	})
+	tfdiags.AssertNoDiagnostics(t, diags)
+
+	_, diags = ctx.Apply(plan, mod, &ApplyOpts{
+		PolicyClient: applyPolicyClient,
+	})
+	tfdiags.AssertNoDiagnostics(t, diags)
+
+	// We expect exactly 3 evaluations (one per test_instance resource) during
+	// apply.
+	if len(results) != 3 {
+		t.Fatalf("expected 3 policy evaluations during apply, got %d", len(results))
+	}
+
+	for ami, cr := range results {
+		// match-all reads every test_instance from state: all 3 instances.
+		if len(cr.matchAllResults) != 3 {
+			t.Errorf("evaluation[%s]: expected 3 results for matchAll from state, got %d", ami, len(cr.matchAllResults))
+		}
+		// ami="bar" matches exactly the one foo instance.
+		if len(cr.filteredResults) != 1 {
+			t.Errorf("evaluation[%s]: expected 1 result for ami=bar filter, got %d", ami, len(cr.filteredResults))
+		}
+		// ami="nonexistent" matches nothing.
+		if cr.noMatchCount != 0 {
+			t.Errorf("evaluation[%s]: expected 0 results for ami=nonexistent filter, got %d", ami, cr.noMatchCount)
+		}
+		// An unknown resource type returns nothing.
+		if cr.unknownTypeCount != 0 {
+			t.Errorf("evaluation[%s]: expected 0 results for nonexistent_resource, got %d", ami, cr.unknownTypeCount)
+		}
+	}
+}
+
+// TestContext2Apply_PolicySpanParentage verifies the OpenTelemetry wiring that
+// makes per-resource policy spans children of the enclosing "terraform apply"
+// command span.
+func TestContext2Apply_PolicySpanParentage(t *testing.T) {
+	// Collect spans into an in-memory exporter. The tracer provider is a
+	// global, so this test must not run in parallel. We restore the previous
+	// provider (rather than setting nil) so later tests in this package that
+	// emit spans -- e.g. the policy-phase span -- don't hit a nil provider.
+	prevProvider := otel.GetTracerProvider()
+	exp := tracetest.NewInMemoryExporter()
+	provider := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(sdktrace.NewSimpleSpanProcessor(exp)))
+	otel.SetTracerProvider(provider)
+	t.Cleanup(func() {
+		provider.Shutdown(context.Background())
+		otel.SetTracerProvider(prevProvider)
+	})
+
+	mainConfig := `
+		terraform {
+			required_providers {
+				test = {
+					source = "hashicorp/test"
+					version = "1.0.0"
+				}
+			}
+		}
+
+		resource "test_instance" "foo" {
+			ami = "bar"
+		}
+	`
+	policyConfig := `
+		resource_policy "test_instance" "policy_name" {
+			enforce {
+				condition = attrs.ami != ""
+			}
+		}
+	`
+	mod := testModuleInline(t, map[string]string{
+		"main.tf":           mainConfig,
+		"main.tfpolicy.hcl": policyConfig,
+	})
+
+	providerAddr := addrs.NewDefaultProvider("test")
+	prov := testProvider("test")
+	prov.PlanResourceChangeFn = func(req providers.PlanResourceChangeRequest) providers.PlanResourceChangeResponse {
+		return providers.PlanResourceChangeResponse{PlannedState: req.ProposedNewState}
+	}
+	prov.ApplyResourceChangeFn = func(req providers.ApplyResourceChangeRequest) (resp providers.ApplyResourceChangeResponse) {
+		resp.NewState = req.PlannedState
+		return resp
+	}
+
+	// Plan with an allow-all client (no spans needed during plan here).
+	planClient := policy.NewTestMockClient(t)
+	planClient.EvaluateFn = func(ctx context.Context, req policy.EvaluationRequest[*proto.PolicyEvaluateResourceRequest_ResourceMetadata]) policy.EvaluationResponse {
+		return policy.EvaluationResponse{Overall: policy.AllowResult}
+	}
+
+	// The apply client starts a span named like the real client's, using the
+	// context the engine passes in. That context is ctx.StopCtx() (the run
+	// context), which acquireRun parents on the caller context we set below.
+	var evaluateSpanContext trace.SpanContext
+	applyClient := policy.NewTestMockClient(t)
+	applyClient.EvaluateFn = func(ctx context.Context, req policy.EvaluationRequest[*proto.PolicyEvaluateResourceRequest_ResourceMetadata]) policy.EvaluationResponse {
+		_, span := otel.Tracer("test").Start(ctx, "policy.client.evaluate_resource")
+		evaluateSpanContext = span.SpanContext()
+		span.End()
+		return policy.EvaluationResponse{Overall: policy.AllowResult}
+	}
+
+	tfCtx, diags := NewContext(&ContextOpts{
+		Providers: map[addrs.Provider]providers.Factory{
+			providerAddr: testProviderFuncFixed(prov),
+		},
+	})
+	tfdiags.AssertNoDiagnostics(t, diags)
+
+	plan, diags := tfCtx.Plan(mod, states.NewState(), &PlanOpts{
+		Mode:         plans.NormalMode,
+		SetVariables: testInputValuesUnset(mod.Module.Variables),
+		PolicyClient: planClient,
+	})
+	tfdiags.AssertNoDiagnostics(t, diags)
+
+	// Open the command-level span, exactly as command.ApplyCommand does via
+	// Meta.StartCommandSpan, and install it as the caller context so the apply
+	// walk's run context is parented under it.
+	commandCtx, commandSpan := otel.Tracer("test").Start(context.Background(), "terraform apply")
+	commandSpanContext := commandSpan.SpanContext()
+	tfCtx.SetTracingContext(commandCtx)
+
+	_, diags = tfCtx.Apply(plan, mod, &ApplyOpts{
+		PolicyClient: applyClient,
+	})
+	tfdiags.AssertNoDiagnostics(t, diags)
+	commandSpan.End()
+
+	if !evaluateSpanContext.IsValid() {
+		t.Fatal("policy evaluate span was never started during apply")
+	}
+
+	// The evaluate span must belong to the same trace as the command span...
+	if evaluateSpanContext.TraceID() != commandSpanContext.TraceID() {
+		t.Errorf("policy evaluate span is in a different trace than the terraform apply span\n  apply trace:    %s\n  evaluate trace: %s",
+			commandSpanContext.TraceID(), evaluateSpanContext.TraceID())
+	}
+
+	// ...and it must be a descendant of the command span. We find the recorded
+	// evaluate span in the exporter and walk its parent chain up to the command
+	// span.
+	spans := exp.GetSpans()
+	byID := make(map[trace.SpanID]tracetest.SpanStub, len(spans))
+	for _, s := range spans {
+		byID[s.SpanContext.SpanID()] = s
+	}
+
+	cur, ok := byID[evaluateSpanContext.SpanID()]
+	if !ok {
+		t.Fatalf("evaluate span %s was not recorded by the exporter", evaluateSpanContext.SpanID())
+	}
+	foundCommandAncestor := false
+	for {
+		parentID := cur.Parent.SpanID()
+		if parentID == commandSpanContext.SpanID() {
+			foundCommandAncestor = true
+			break
+		}
+		next, ok := byID[parentID]
+		if !ok {
+			break
+		}
+		cur = next
+	}
+	if !foundCommandAncestor {
+		t.Errorf("policy.client.evaluate_resource span is not nested under the terraform apply span")
 	}
 }

--- a/internal/terraform/context_apply_policy_test.go
+++ b/internal/terraform/context_apply_policy_test.go
@@ -1238,10 +1238,14 @@ func TestContext2Apply_PolicySpanParentage(t *testing.T) {
 		return policy.EvaluationResponse{Overall: policy.AllowResult}
 	}
 
+	commandCtx, commandSpan := otel.Tracer("test").Start(context.Background(), "terraform apply")
+	commandSpanContext := commandSpan.SpanContext()
+
 	tfCtx, diags := NewContext(&ContextOpts{
 		Providers: map[addrs.Provider]providers.Factory{
 			providerAddr: testProviderFuncFixed(prov),
 		},
+		TracingContext: commandCtx,
 	})
 	tfdiags.AssertNoDiagnostics(t, diags)
 
@@ -1251,13 +1255,6 @@ func TestContext2Apply_PolicySpanParentage(t *testing.T) {
 		PolicyClient: planClient,
 	})
 	tfdiags.AssertNoDiagnostics(t, diags)
-
-	// Open the command-level span, exactly as command.ApplyCommand does via
-	// Meta.StartCommandSpan, and install it as the caller context so the apply
-	// walk's run context is parented under it.
-	commandCtx, commandSpan := otel.Tracer("test").Start(context.Background(), "terraform apply")
-	commandSpanContext := commandSpan.SpanContext()
-	tfCtx.SetTracingContext(commandCtx)
 
 	_, diags = tfCtx.Apply(plan, mod, &ApplyOpts{
 		PolicyClient: applyClient,

--- a/internal/terraform/context_apply_policy_test.go
+++ b/internal/terraform/context_apply_policy_test.go
@@ -1302,3 +1302,208 @@ func TestContext2Apply_PolicySpanParentage(t *testing.T) {
 		t.Errorf("policy.client.evaluate_resource span is not nested under the terraform apply span")
 	}
 }
+
+// TestContext2Apply_PolicyPhaseSpanOutlivesEvaluations verifies that the
+// policy-phase span ("terraform.policy.evaluate") is ended only after every
+// policy evaluation, and any spans nested below them, has finished. The span is
+// ended by the nodePolicyEvalFinish sentinel node, which must depend on every
+// policy node in the subgraph; otherwise it closes the span while evaluations
+// are still running and child spans outlive their parent.
+//
+// It mutates the global OpenTelemetry TracerProvider, so it must not run in
+// parallel.
+func TestContext2Apply_PolicyPhaseSpanOutlivesEvaluations(t *testing.T) {
+	// Each evaluation sleeps for this long so an out-of-order finish node closes
+	// the phase span observably early.
+	const evalDelay = 100 * time.Millisecond
+
+	// Record spans into an in-memory exporter. Restore the previous (global)
+	// provider rather than setting nil so other tests don't hit a nil provider.
+	prevProvider := otel.GetTracerProvider()
+	exp := tracetest.NewInMemoryExporter()
+	provider := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(sdktrace.NewSimpleSpanProcessor(exp)))
+	otel.SetTracerProvider(provider)
+	t.Cleanup(func() {
+		provider.Shutdown(context.Background())
+		otel.SetTracerProvider(prevProvider)
+	})
+
+	// With the prior state below, this yields one update, one create and one
+	// delete evaluation during apply.
+	mainConfig := `
+		terraform {
+			required_providers {
+				test = {
+					source = "hashicorp/test"
+					version = "1.0.0"
+				}
+			}
+		}
+
+		resource "test_instance" "to_update" {
+			ami = "new"
+		}
+
+		resource "test_instance" "to_create" {
+			ami = "fresh"
+		}
+	`
+	policyConfig := `
+		resource_policy "test_instance" "policy_name" {
+			enforce {
+				condition = true
+			}
+		}
+	`
+	mod := testModuleInline(t, map[string]string{
+		"main.tf":           mainConfig,
+		"main.tfpolicy.hcl": policyConfig,
+	})
+
+	providerAddr := addrs.NewDefaultProvider("test")
+	prov := testProvider("test")
+	prov.PlanResourceChangeFn = func(req providers.PlanResourceChangeRequest) providers.PlanResourceChangeResponse {
+		return providers.PlanResourceChangeResponse{PlannedState: req.ProposedNewState}
+	}
+	prov.ApplyResourceChangeFn = func(req providers.ApplyResourceChangeRequest) (resp providers.ApplyResourceChangeResponse) {
+		resp.NewState = req.PlannedState
+		return resp
+	}
+
+	// Prior state so that to_update is updated and to_delete is destroyed.
+	priorState := states.BuildState(func(ss *states.SyncState) {
+		ss.SetResourceInstanceCurrent(
+			mustResourceInstanceAddr("test_instance.to_update"),
+			&states.ResourceInstanceObjectSrc{
+				Status:    states.ObjectReady,
+				AttrsJSON: []byte(`{"id":"update-id","ami":"old"}`),
+			},
+			mustProviderConfig(`provider["registry.terraform.io/hashicorp/test"]`),
+		)
+		ss.SetResourceInstanceCurrent(
+			mustResourceInstanceAddr("test_instance.to_delete"),
+			&states.ResourceInstanceObjectSrc{
+				Status:    states.ObjectReady,
+				AttrsJSON: []byte(`{"id":"delete-id","ami":"obsolete"}`),
+			},
+			mustProviderConfig(`provider["registry.terraform.io/hashicorp/test"]`),
+		)
+	})
+
+	// Plan uses a plain allow-all client; the span assertions concern apply.
+	planClient := policy.NewTestMockClient(t)
+
+	// The apply client mirrors the real client: per evaluation it starts a
+	// per-resource span under the phase span, invokes a callback to nest a
+	// further span, then does some work.
+	applyClient := policy.NewTestMockClient(t)
+	applyClient.EvaluateFn = func(ctx context.Context, req policy.EvaluationRequest[*proto.PolicyEvaluateResourceRequest_ResourceMetadata]) policy.EvaluationResponse {
+		spanCtx, span := otel.Tracer("test").Start(ctx, "policy.client.evaluate_resource")
+		defer span.End()
+
+		if req.Callbacks.GetResources != nil {
+			req.Callbacks.GetResources(spanCtx, "test_instance", cty.NullVal(cty.DynamicPseudoType))
+		}
+
+		time.Sleep(evalDelay)
+
+		return policy.EvaluationResponse{Overall: policy.AllowResult}
+	}
+
+	tfCtx, diags := NewContext(&ContextOpts{
+		Providers: map[addrs.Provider]providers.Factory{
+			providerAddr: testProviderFuncFixed(prov),
+		},
+	})
+	tfdiags.AssertNoDiagnostics(t, diags)
+
+	plan, diags := tfCtx.Plan(mod, priorState, &PlanOpts{
+		Mode:         plans.NormalMode,
+		SetVariables: testInputValuesUnset(mod.Module.Variables),
+		PolicyClient: planClient,
+	})
+	tfdiags.AssertNoDiagnostics(t, diags)
+
+	// Sanity check that the plan really covers all three evaluation kinds.
+	gotActions := map[string]plans.Action{}
+	for _, rc := range plan.Changes.Resources {
+		gotActions[rc.Addr.String()] = rc.Action
+	}
+	for addr, want := range map[string]plans.Action{
+		"test_instance.to_update": plans.Update,
+		"test_instance.to_create": plans.Create,
+		"test_instance.to_delete": plans.Delete,
+	} {
+		if gotActions[addr] != want {
+			t.Fatalf("expected %s to have action %s, got %s", addr, want, gotActions[addr])
+		}
+	}
+
+	_, diags = tfCtx.Apply(plan, mod, &ApplyOpts{
+		PolicyClient: applyClient,
+	})
+	tfdiags.AssertNoDiagnostics(t, diags)
+
+	spans := exp.GetSpans()
+	byID := make(map[trace.SpanID]tracetest.SpanStub, len(spans))
+	for _, s := range spans {
+		byID[s.SpanContext.SpanID()] = s
+	}
+
+	// isDescendantOf reports whether s is nested (at any depth) under ancestorID.
+	isDescendantOf := func(s tracetest.SpanStub, ancestorID trace.SpanID) bool {
+		parentID := s.Parent.SpanID()
+		for parentID.IsValid() {
+			if parentID == ancestorID {
+				return true
+			}
+			parent, ok := byID[parentID]
+			if !ok {
+				return false
+			}
+			parentID = parent.Parent.SpanID()
+		}
+		return false
+	}
+
+	var phaseSpans []tracetest.SpanStub
+	var evaluateSpans int
+	for _, s := range spans {
+		switch s.Name {
+		case "terraform.policy.evaluate":
+			phaseSpans = append(phaseSpans, s)
+		case "policy.client.evaluate_resource":
+			evaluateSpans++
+		}
+	}
+
+	if len(phaseSpans) == 0 {
+		t.Fatal("no terraform.policy.evaluate phase span was recorded")
+	}
+	if evaluateSpans < 3 {
+		t.Fatalf("expected at least 3 policy.client.evaluate_resource spans (create, update, delete), got %d", evaluateSpans)
+	}
+
+	// Every span nested under a phase span must have finished no later than the
+	// phase span itself.
+	checkedDescendants := 0
+	for _, phase := range phaseSpans {
+		for _, s := range spans {
+			if s.SpanContext.SpanID() == phase.SpanContext.SpanID() {
+				continue
+			}
+			if !isDescendantOf(s, phase.SpanContext.SpanID()) {
+				continue
+			}
+			checkedDescendants++
+			if s.EndTime.After(phase.EndTime) {
+				t.Errorf("span %q finished %s after its ancestor phase span %q; the phase span was closed before policy evaluation completed",
+					s.Name, s.EndTime.Sub(phase.EndTime), phase.Name)
+			}
+		}
+	}
+
+	if checkedDescendants == 0 {
+		t.Fatal("no descendant spans were found under any policy phase span; the test did not exercise nested policy evaluation as intended")
+	}
+}

--- a/internal/terraform/context_plan_policy_test.go
+++ b/internal/terraform/context_plan_policy_test.go
@@ -15,6 +15,9 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/hcl/v2"
+	"github.com/zclconf/go-cty/cty"
+	"google.golang.org/protobuf/testing/protocmp"
+
 	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/configs"
 	"github.com/hashicorp/terraform/internal/configs/configschema"
@@ -26,8 +29,6 @@ import (
 	"github.com/hashicorp/terraform/internal/providers"
 	"github.com/hashicorp/terraform/internal/states"
 	"github.com/hashicorp/terraform/internal/tfdiags"
-	"github.com/zclconf/go-cty/cty"
-	"google.golang.org/protobuf/testing/protocmp"
 )
 
 func TestContext2Plan_PolicyEvaluation(t *testing.T) {
@@ -1718,7 +1719,7 @@ func TestContext2Plan_PolicyCallback(t *testing.T) {
 		}
 
 		// 1. Match all test_instance resources with null attrs (no filter).
-		all, _, err := req.Callbacks.GetResources("test_instance", cty.NullVal(cty.DynamicPseudoType))
+		all, _, err := req.Callbacks.GetResources(t.Context(), "test_instance", cty.NullVal(cty.DynamicPseudoType))
 		if err != nil {
 			t.Errorf("GetResources(test_instance, null): %v", err)
 		} else {
@@ -1726,7 +1727,7 @@ func TestContext2Plan_PolicyCallback(t *testing.T) {
 		}
 
 		// 2. Match resources with ami="bar" filter.
-		filtered, _, err := req.Callbacks.GetResources("test_instance", cty.ObjectVal(map[string]cty.Value{
+		filtered, _, err := req.Callbacks.GetResources(t.Context(), "test_instance", cty.ObjectVal(map[string]cty.Value{
 			"ami": cty.StringVal("bar"),
 		}))
 		if err != nil {
@@ -1736,7 +1737,7 @@ func TestContext2Plan_PolicyCallback(t *testing.T) {
 		}
 
 		// 3. Match with an attribute filter that will never match any planned resource.
-		noMatch, _, err := req.Callbacks.GetResources("test_instance", cty.ObjectVal(map[string]cty.Value{
+		noMatch, _, err := req.Callbacks.GetResources(t.Context(), "test_instance", cty.ObjectVal(map[string]cty.Value{
 			"ami": cty.StringVal("nonexistent"),
 		}))
 		if err != nil {
@@ -1746,7 +1747,7 @@ func TestContext2Plan_PolicyCallback(t *testing.T) {
 		}
 
 		// 4. Query for a resource type that doesn't exist in the config.
-		nonExistentMatch, _, err := req.Callbacks.GetResources("nonexistent_resource", cty.NullVal(cty.DynamicPseudoType))
+		nonExistentMatch, _, err := req.Callbacks.GetResources(t.Context(), "nonexistent_resource", cty.NullVal(cty.DynamicPseudoType))
 		if err != nil {
 			t.Errorf("GetResources(nonexistent_resource): %v", err)
 		} else {
@@ -1754,7 +1755,7 @@ func TestContext2Plan_PolicyCallback(t *testing.T) {
 		}
 
 		// 5. Query for a resource type where the filtered attribute is unknown.
-		_, unknown, err := req.Callbacks.GetResources("test_instance", cty.ObjectVal(map[string]cty.Value{
+		_, unknown, err := req.Callbacks.GetResources(t.Context(), "test_instance", cty.ObjectVal(map[string]cty.Value{
 			"compute": cty.StringVal("foo"),
 		}))
 		if err != nil {

--- a/internal/terraform/graph_policy.go
+++ b/internal/terraform/graph_policy.go
@@ -5,12 +5,18 @@ package terraform
 
 import (
 	"sync"
+
+	"go.opentelemetry.io/otel/trace"
 )
 
 // policySubgraph is a subgraph that stores resource policy nodes.
 type policySubgraph struct {
 	lock  sync.Mutex
 	graph Graph
+
+	// span carries the tracing information. We need the span itself so we can end it
+	// when the policy evaluation is finished
+	span trace.Span
 }
 
 func newPolicySubgraph() *policySubgraph {

--- a/internal/terraform/node_policy_eval.go
+++ b/internal/terraform/node_policy_eval.go
@@ -43,7 +43,7 @@ func (n *nodePolicyEval) DynamicExpand(ctx EvalContext) (*Graph, tfdiags.Diagnos
 	finish := &nodePolicyEvalFinish{span: policyGraph.span}
 	policyGraph.graph.Add(finish)
 	for pn := range policyGraph.graph.VerticesSeq() {
-		if _, ok := pn.(*nodePolicyEval); !ok {
+		if _, ok := pn.(*nodeResourcePolicy); !ok {
 			continue
 		}
 		// finish depends on pn, so pn runs first and finish runs after.

--- a/internal/terraform/node_policy_eval.go
+++ b/internal/terraform/node_policy_eval.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform/internal/dag"
 	"github.com/hashicorp/terraform/internal/tfdiags"
+	"go.opentelemetry.io/otel/trace"
 )
 
 // nodePolicyEval is a node that completes the building of the policy graph,
@@ -34,6 +35,21 @@ func (n *nodePolicyEval) DynamicExpand(ctx EvalContext) (*Graph, tfdiags.Diagnos
 	ctx.Changes().Close()
 	ctx.State().Close()
 
+	_, span := tracer().Start(ctx.StopCtx(), "terraform.policy.evaluate")
+	policyGraph.span = span
+
+	// Add a finish node that depends on every policy node, so it runs last and
+	// ends the phase span once all policy evaluation has completed.
+	finish := &nodePolicyEvalFinish{span: policyGraph.span}
+	policyGraph.graph.Add(finish)
+	for pn := range policyGraph.graph.VerticesSeq() {
+		if _, ok := pn.(*nodePolicyEval); !ok {
+			continue
+		}
+		// finish depends on pn, so pn runs first and finish runs after.
+		policyGraph.graph.Connect(dag.BasicEdge(finish, pn))
+	}
+
 	// ensure the graph has a single root
 	addRootNodeToGraph(&policyGraph.graph)
 	return &policyGraph.graph, nil
@@ -44,5 +60,32 @@ func (n *nodePolicyEval) DynamicExpand(ctx EvalContext) (*Graph, tfdiags.Diagnos
 // evaluated with error diagnostics.
 func (n *nodePolicyEval) AllowUpstreamFailure(dep dag.Vertex) bool {
 	_, ok := dep.(GraphNodeConfigResource)
+	return ok
+}
+
+// nodePolicyEvalFinish is a sentinel node appended to the policy subgraph that
+// runs after every policy node and ends the policy-execution phase span. It
+// must tolerate upstream failures so the span is still closed even if a policy
+// node returned error diagnostics.
+type nodePolicyEvalFinish struct {
+	span trace.Span
+}
+
+var _ GraphNodeExecutable = (*nodePolicyEvalFinish)(nil)
+var _ dag.TolerantVertex = (*nodePolicyEvalFinish)(nil)
+
+func (n *nodePolicyEvalFinish) Name() string {
+	return "(policy evaluation complete)"
+}
+
+func (n *nodePolicyEvalFinish) Execute(ctx EvalContext, op walkOperation) tfdiags.Diagnostics {
+	n.span.End()
+	return nil
+}
+
+// AllowUpstreamFailure tolerates failures from the policy nodes so the phase
+// span is always ended.
+func (n *nodePolicyEvalFinish) AllowUpstreamFailure(dep dag.Vertex) bool {
+	_, ok := dep.(*nodeResourcePolicy)
 	return ok
 }

--- a/internal/terraform/policy.go
+++ b/internal/terraform/policy.go
@@ -10,6 +10,7 @@ import (
 	"log"
 
 	"github.com/zclconf/go-cty/cty"
+	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 
 	"github.com/hashicorp/terraform/internal/addrs"
@@ -55,7 +56,12 @@ func evaluatePolicies(ctx EvalContext, target addrs.AbsResourceInstance, config 
 }
 
 func getResourcesForPolicyCallback(ctx EvalContext, walkOperation walkOperation, provider providers.Interface, schema providers.GetProviderSchemaResponse, config *configs.Config) func(callbackCtx context.Context, target string, attrs cty.Value) ([]cty.Value, bool, error) {
-	return func(_ context.Context, target string, attrs cty.Value) ([]cty.Value, bool, error) {
+	return func(c context.Context, target string, attrs cty.Value) ([]cty.Value, bool, error) {
+		_, span := tracer().Start(c, "policy.callback.getResources", trace.WithAttributes(
+			attribute.String("policy.callback.getResources.type", target),
+		))
+
+		defer span.End()
 		var found []cty.Value
 		var filterMap map[string]cty.Value
 		if !attrs.IsNull() {
@@ -115,12 +121,17 @@ func getResourcesForPolicyCallback(ctx EvalContext, walkOperation walkOperation,
 				}
 			}
 		})
+		span.SetAttributes(attribute.String("policy.callback.getResources.result_count", fmt.Sprintf("%d", len(found))))
 		return found, isPartialResult, nil
 	}
 }
 
 func getDataSourceForPolicyCallback(ctx EvalContext, provider providers.Interface, schema providers.GetProviderSchemaResponse, meta cty.Value) func(callbackCtx context.Context, datasource string, attrs cty.Value) (cty.Value, error) {
-	return func(_ context.Context, target string, attrs cty.Value) (cty.Value, error) {
+	return func(c context.Context, target string, attrs cty.Value) (cty.Value, error) {
+		_, span := tracer().Start(c, "policy.callback.getDataSource", trace.WithAttributes(
+			attribute.String("policy.callback.getDataSource.type", target),
+		))
+		defer span.End()
 		if datasource, ok := schema.DataSources[target]; ok {
 			configVal, err := datasource.Body.CoerceValue(attrs)
 			if err != nil {

--- a/internal/terraform/policy.go
+++ b/internal/terraform/policy.go
@@ -4,11 +4,13 @@
 package terraform
 
 import (
+	"context"
 	"fmt"
 	"iter"
 	"log"
 
 	"github.com/zclconf/go-cty/cty"
+	"go.opentelemetry.io/otel/trace"
 
 	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/configs"
@@ -22,7 +24,14 @@ import (
 )
 
 func evaluatePolicies(ctx EvalContext, target addrs.AbsResourceInstance, config *configs.Resource, attrs, priorAttrs cty.Value, meta *proto.PolicyEvaluateResourceRequest_ResourceMetadata, callbacks callback.Functions) policy.EvaluationResponse {
-	result := ctx.PolicyClient().EvaluateResource(ctx.StopCtx(), policy.EvaluationRequest[*proto.PolicyEvaluateResourceRequest_ResourceMetadata]{
+	// We want a per-resource parent span so we can reason about the evaluation of individual
+	// resources in the trace
+	evalCtx := ctx.StopCtx()
+	if phaseSpan := ctx.PolicyGraph().span; phaseSpan != nil {
+		evalCtx = trace.ContextWithSpan(evalCtx, phaseSpan)
+	}
+
+	result := ctx.PolicyClient().EvaluateResource(evalCtx, policy.EvaluationRequest[*proto.PolicyEvaluateResourceRequest_ResourceMetadata]{
 		Target:     target.Resource.Resource.Type,
 		Attrs:      policy.CtyToPolicyValue(attrs),
 		PriorAttrs: policy.CtyToPolicyValue(priorAttrs),
@@ -45,8 +54,8 @@ func evaluatePolicies(ctx EvalContext, target addrs.AbsResourceInstance, config 
 	return result
 }
 
-func getResourcesForPolicyCallback(ctx EvalContext, walkOperation walkOperation, provider providers.Interface, schema providers.GetProviderSchemaResponse, config *configs.Config) func(target string, attrs cty.Value) ([]cty.Value, bool, error) {
-	return func(target string, attrs cty.Value) ([]cty.Value, bool, error) {
+func getResourcesForPolicyCallback(ctx EvalContext, walkOperation walkOperation, provider providers.Interface, schema providers.GetProviderSchemaResponse, config *configs.Config) func(callbackCtx context.Context, target string, attrs cty.Value) ([]cty.Value, bool, error) {
+	return func(_ context.Context, target string, attrs cty.Value) ([]cty.Value, bool, error) {
 		var found []cty.Value
 		var filterMap map[string]cty.Value
 		if !attrs.IsNull() {
@@ -110,8 +119,8 @@ func getResourcesForPolicyCallback(ctx EvalContext, walkOperation walkOperation,
 	}
 }
 
-func getDataSourceForPolicyCallback(ctx EvalContext, provider providers.Interface, schema providers.GetProviderSchemaResponse, meta cty.Value) func(datasource string, attrs cty.Value) (cty.Value, error) {
-	return func(target string, attrs cty.Value) (cty.Value, error) {
+func getDataSourceForPolicyCallback(ctx EvalContext, provider providers.Interface, schema providers.GetProviderSchemaResponse, meta cty.Value) func(callbackCtx context.Context, datasource string, attrs cty.Value) (cty.Value, error) {
+	return func(_ context.Context, target string, attrs cty.Value) (cty.Value, error) {
 		if datasource, ok := schema.DataSources[target]; ok {
 			configVal, err := datasource.Body.CoerceValue(attrs)
 			if err != nil {

--- a/internal/terraform/policy_test.go
+++ b/internal/terraform/policy_test.go
@@ -131,7 +131,7 @@ resource "test_resource" "b" {
 				gotErr     error
 			)
 
-			got, gotUnknown, gotErr = callback("test_resource", tt.filter)
+			got, gotUnknown, gotErr = callback(t.Context(), "test_resource", tt.filter)
 			if gotErr != nil {
 				t.Fatalf("unexpected error: %v", gotErr)
 			}

--- a/internal/terraform/telemetry.go
+++ b/internal/terraform/telemetry.go
@@ -1,0 +1,18 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package terraform
+
+import (
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/trace"
+)
+
+// tracer returns the OpenTelemetry tracer used by Terraform Core.
+//
+// Resolved lazily on every call so the global TracerProvider installed by
+// the CLI's openTelemetryInit (which runs after this package's init) is
+// reflected in the tracer used at runtime.
+func tracer() trace.Tracer {
+	return otel.Tracer("github.com/hashicorp/terraform/internal/terraform")
+}

--- a/main.go
+++ b/main.go
@@ -81,7 +81,9 @@ func realMain() int {
 	{
 		// At minimum we emit a span covering the entire command execution.
 		_, displayArgs := shquot.POSIXShellSplit(os.Args)
-		ctx, otelSpan = tracer.Start(context.Background(), fmt.Sprintf("terraform %s", displayArgs))
+		// Extract the parent traces from the environment if present.
+		parentCtx := extractParentTraceContext(context.Background())
+		ctx, otelSpan = tracer.Start(parentCtx, fmt.Sprintf("terraform %s", displayArgs))
 		defer otelSpan.End()
 	}
 

--- a/telemetry.go
+++ b/telemetry.go
@@ -6,6 +6,7 @@ package main
 import (
 	"context"
 	"os"
+	"strings"
 
 	"github.com/hashicorp/terraform/version"
 	"go.opentelemetry.io/contrib/exporters/autoexport"
@@ -87,4 +88,31 @@ func openTelemetryInit() error {
 	otel.SetTextMapPropagator(pgtr)
 
 	return nil
+}
+
+// extractParentTraceContext returns a context that carries any trace context
+// propagated to this CLI invocation by a parent process via the standard
+// W3C environment variables TRACEPARENT and TRACESTATE, plus OpenTelemetry
+// BAGGAGE.
+//
+// Extraction uses the globally-installed TextMapPropagator, which is only
+// configured when telemetry export is enabled (see openTelemetryInit). When
+// telemetry is disabled, or when no trace-context variables are present in
+// the environment, the supplied context is returned unchanged so the command
+// simply starts a brand-new root span.
+func extractParentTraceContext(ctx context.Context) context.Context {
+	// The W3C TraceContext/Baggage propagators use lower-case carrier keys
+	// ("traceparent", "tracestate", "baggage"); the corresponding environment
+	// variables are conventionally upper-case.
+	carrier := propagation.MapCarrier{}
+	for _, key := range []string{"traceparent", "tracestate", "baggage"} {
+		if v := os.Getenv(strings.ToUpper(key)); v != "" {
+			carrier[key] = v
+		}
+	}
+	if len(carrier) == 0 {
+		return ctx
+	}
+
+	return otel.GetTextMapPropagator().Extract(ctx, carrier)
 }

--- a/telemetry_test.go
+++ b/telemetry_test.go
@@ -1,0 +1,60 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package main
+
+import (
+	"context"
+	"testing"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/propagation"
+	"go.opentelemetry.io/otel/trace"
+)
+
+func TestExtractParentTraceContext(t *testing.T) {
+	// Install the same propagator that openTelemetryInit configures when
+	// telemetry export is enabled, so extraction has something to work with.
+	otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(
+		propagation.TraceContext{}, propagation.Baggage{},
+	))
+	t.Cleanup(func() { otel.SetTextMapPropagator(nil) })
+
+	const (
+		traceID = "0af7651916cd43dd8448eb211c80319c"
+		spanID  = "b7ad6b7169203331"
+	)
+
+	t.Run("adopts the parent from TRACEPARENT", func(t *testing.T) {
+		t.Setenv("TRACEPARENT", "00-"+traceID+"-"+spanID+"-01")
+
+		ctx := extractParentTraceContext(context.Background())
+
+		sc := trace.SpanContextFromContext(ctx)
+		if !sc.IsValid() {
+			t.Fatal("expected a valid span context, got an invalid one")
+		}
+		if got := sc.TraceID().String(); got != traceID {
+			t.Errorf("trace id = %s, want %s", got, traceID)
+		}
+		if got := sc.SpanID().String(); got != spanID {
+			t.Errorf("span id = %s, want %s", got, spanID)
+		}
+		if !sc.IsRemote() {
+			t.Error("expected the extracted span context to be marked remote")
+		}
+	})
+
+	t.Run("returns the context unchanged when no trace context is present", func(t *testing.T) {
+		// Treat empty values as unset.
+		t.Setenv("TRACEPARENT", "")
+		t.Setenv("TRACESTATE", "")
+		t.Setenv("BAGGAGE", "")
+
+		ctx := extractParentTraceContext(context.Background())
+
+		if trace.SpanContextFromContext(ctx).IsValid() {
+			t.Error("expected no span context when the environment is empty")
+		}
+	})
+}


### PR DESCRIPTION
This PR adds OTEL tracing (that we already have for parts of the codebase) to the policy related codepaths. This will help us gather data on execution performance. This PR has been generated by an LLM but I pre-reviewed it.

<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Fixes #

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.16.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
