### PR TITLE
policy: resolve plugin entitlement from the backend and CLI config

### DIFF
--- a/.changes/v1.16/ENHANCEMENTS-20260612-140500.yaml
+++ b/.changes/v1.16/ENHANCEMENTS-20260612-140500.yaml
@@ -1,0 +1,5 @@
+kind: ENHANCEMENTS
+body: 'policy: Resolve the policy plugin entitlement (host, token, organization) from the configured cloud/remote backend for init, plan, and apply, instead of the plugin reading credentials itself'
+time: 2026-06-12T14:05:00.000000-04:00
+custom:
+    Issue: "38716"

--- a/internal/backend/local/backend_policy.go
+++ b/internal/backend/local/backend_policy.go
@@ -1,0 +1,22 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package local
+
+import (
+	"github.com/hashicorp/terraform/internal/policy"
+)
+
+// PolicyEntitlement delegates to the wrapped backend, so plan and apply can read
+// the host/token/org from the underlying cloud or remote backend. Returns nil if
+// the wrapped backend can't supply one.
+func (b *Local) PolicyEntitlement() *policy.Entitlement {
+	if b == nil || b.Backend == nil {
+		return nil
+	}
+	provider, ok := b.Backend.(policy.EntitlementProvider)
+	if !ok {
+		return nil
+	}
+	return provider.PolicyEntitlement()
+}

--- a/internal/backend/local/backend_policy_test.go
+++ b/internal/backend/local/backend_policy_test.go
@@ -1,0 +1,77 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package local
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/internal/backend"
+	"github.com/hashicorp/terraform/internal/policy"
+)
+
+// entitlementBackend is a backend.Backend that also implements
+// policy.EntitlementProvider, for testing Local's delegation.
+type entitlementBackend struct {
+	backend.Backend
+	ent *policy.Entitlement
+}
+
+func (b *entitlementBackend) PolicyEntitlement() *policy.Entitlement { return b.ent }
+
+// plainBackend is a backend.Backend that does not implement
+// policy.EntitlementProvider.
+type plainBackend struct {
+	backend.Backend
+}
+
+func TestLocalPolicyEntitlement(t *testing.T) {
+	ent := &policy.Entitlement{Host: "app.terraform.io", Token: "secret", Org: "hashicorp"}
+
+	tests := []struct {
+		name string
+		b    *Local
+		want *policy.Entitlement
+	}{
+		{
+			name: "nil backend",
+			b:    nil,
+			want: nil,
+		},
+		{
+			name: "nil wrapped backend",
+			b:    &Local{},
+			want: nil,
+		},
+		{
+			name: "wrapped backend provides an entitlement",
+			b:    &Local{Backend: &entitlementBackend{ent: ent}},
+			want: ent,
+		},
+		{
+			name: "wrapped backend provides nil entitlement",
+			b:    &Local{Backend: &entitlementBackend{ent: nil}},
+			want: nil,
+		},
+		{
+			name: "wrapped backend is not an EntitlementProvider",
+			b:    &Local{Backend: &plainBackend{}},
+			want: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.b.PolicyEntitlement()
+			if tt.want == nil {
+				if got != nil {
+					t.Fatalf("expected nil entitlement, got %+v", got)
+				}
+				return
+			}
+			if got != tt.want {
+				t.Fatalf("unexpected entitlement: got %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/backend/remote/backend.go
+++ b/internal/backend/remote/backend.go
@@ -68,6 +68,10 @@ type Remote struct {
 	// organization is the organization that contains the target workspaces.
 	organization string
 
+	// resolvedToken is the API token Configure used to authenticate, persisted
+	// so PolicyEntitlement can return it without re-resolving.
+	resolvedToken string
+
 	// workspace is used to map the default workspace to a remote workspace.
 	workspace string
 
@@ -323,6 +327,8 @@ func (b *Remote) Configure(obj cty.Value) tfdiags.Diagnostics {
 		return diags
 	}
 
+	b.resolvedToken = token
+
 	cfg := &tfe.Config{
 		Address:      service.String(),
 		BasePath:     service.Path,
@@ -552,7 +558,7 @@ func (b *Remote) Workspaces() ([]string, tfdiags.Diagnostics) {
 		return nil, diags.Append(backend.ErrWorkspacesNotSupported)
 	}
 	workspaces, err := b.workspaces()
-	diags.Append(err)
+	diags = diags.Append(err)
 
 	return workspaces, diags
 }

--- a/internal/backend/remote/backend_policy.go
+++ b/internal/backend/remote/backend_policy.go
@@ -1,0 +1,22 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package remote
+
+import (
+	"github.com/hashicorp/terraform/internal/policy"
+)
+
+// PolicyEntitlement returns the host/token/org that Configure resolved, used by
+// the policy plugin to verify entitlement. Returns nil if the triple is
+// incomplete, in which case the plugin applies its own fallback.
+func (b *Remote) PolicyEntitlement() *policy.Entitlement {
+	if b == nil || b.hostname == "" || b.organization == "" || b.resolvedToken == "" {
+		return nil
+	}
+	return &policy.Entitlement{
+		Host:  b.hostname,
+		Token: b.resolvedToken,
+		Org:   b.organization,
+	}
+}

--- a/internal/backend/remote/backend_policy_test.go
+++ b/internal/backend/remote/backend_policy_test.go
@@ -1,0 +1,62 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package remote
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/internal/policy"
+)
+
+func TestRemotePolicyEntitlement(t *testing.T) {
+	tests := []struct {
+		name string
+		b    *Remote
+		want *policy.Entitlement
+	}{
+		{
+			name: "nil backend",
+			b:    nil,
+			want: nil,
+		},
+		{
+			name: "complete triple",
+			b:    &Remote{hostname: "app.terraform.io", organization: "hashicorp", resolvedToken: "secret"},
+			want: &policy.Entitlement{Host: "app.terraform.io", Token: "secret", Org: "hashicorp"},
+		},
+		{
+			name: "missing host",
+			b:    &Remote{organization: "hashicorp", resolvedToken: "secret"},
+			want: nil,
+		},
+		{
+			name: "missing organization",
+			b:    &Remote{hostname: "app.terraform.io", resolvedToken: "secret"},
+			want: nil,
+		},
+		{
+			name: "missing token",
+			b:    &Remote{hostname: "app.terraform.io", organization: "hashicorp"},
+			want: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.b.PolicyEntitlement()
+			if tt.want == nil {
+				if got != nil {
+					t.Fatalf("expected nil entitlement, got %+v", got)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatal("expected entitlement, got nil")
+			}
+			if *got != *tt.want {
+				t.Fatalf("unexpected entitlement: got %+v, want %+v", *got, *tt.want)
+			}
+		})
+	}
+}

--- a/internal/cloud/backend_policy.go
+++ b/internal/cloud/backend_policy.go
@@ -1,0 +1,22 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package cloud
+
+import (
+	"github.com/hashicorp/terraform/internal/policy"
+)
+
+// PolicyEntitlement returns the host/token/org that Configure resolved, used by
+// the policy plugin to verify entitlement. Returns nil if the triple is
+// incomplete, in which case the plugin applies its own fallback.
+func (b *Cloud) PolicyEntitlement() *policy.Entitlement {
+	if b == nil || b.Hostname == "" || b.Organization == "" || b.Token == "" {
+		return nil
+	}
+	return &policy.Entitlement{
+		Host:  b.Hostname,
+		Token: b.Token,
+		Org:   b.Organization,
+	}
+}

--- a/internal/cloud/backend_policy_test.go
+++ b/internal/cloud/backend_policy_test.go
@@ -1,0 +1,62 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package cloud
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/internal/policy"
+)
+
+func TestCloudPolicyEntitlement(t *testing.T) {
+	tests := []struct {
+		name string
+		b    *Cloud
+		want *policy.Entitlement
+	}{
+		{
+			name: "nil backend",
+			b:    nil,
+			want: nil,
+		},
+		{
+			name: "complete triple",
+			b:    &Cloud{Hostname: "app.terraform.io", Organization: "hashicorp", Token: "secret"},
+			want: &policy.Entitlement{Host: "app.terraform.io", Token: "secret", Org: "hashicorp"},
+		},
+		{
+			name: "missing host",
+			b:    &Cloud{Organization: "hashicorp", Token: "secret"},
+			want: nil,
+		},
+		{
+			name: "missing organization",
+			b:    &Cloud{Hostname: "app.terraform.io", Token: "secret"},
+			want: nil,
+		},
+		{
+			name: "missing token",
+			b:    &Cloud{Hostname: "app.terraform.io", Organization: "hashicorp"},
+			want: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.b.PolicyEntitlement()
+			if tt.want == nil {
+				if got != nil {
+					t.Fatalf("expected nil entitlement, got %+v", got)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatal("expected entitlement, got nil")
+			}
+			if *got != *tt.want {
+				t.Fatalf("unexpected entitlement: got %+v, want %+v", *got, *tt.want)
+			}
+		})
+	}
+}

--- a/internal/command/apply.go
+++ b/internal/command/apply.go
@@ -105,7 +105,7 @@ func (c *ApplyCommand) Run(rawArgs []string) int {
 	}
 
 	if len(args.PolicyPaths) > 0 {
-		client, policyDiags, stopClient := c.PolicyClient(context.Background(), args.PolicyPaths)
+		client, policyDiags, stopClient := c.PolicyClient(context.Background(), args.PolicyPaths, backendPolicyEntitlement(be))
 		// if there has been any errors when setting up the policy client, we log them but
 		// we still proceed with the operation, as a failure to set up the policy client
 		// should not prevent the apply operation from running

--- a/internal/command/init_policy_test.go
+++ b/internal/command/init_policy_test.go
@@ -229,6 +229,7 @@ func TestInit_WithPolicySetupFailureJSON(t *testing.T) {
 	}
 
 	expected := `{"@level":"info","@message":"Terraform 1.15.0-dev","@module":"terraform.ui","terraform":"1.15.0-dev","type":"version","ui":"1.3"}
+{"@level":"info","@message":"Initializing the backend...","@module":"terraform.ui","message_code":"initializing_backend_message","type":"init_output"}
 {"@level":"error","@message":"Error: Failed to connect to policy engine","@module":"terraform.ui","@policy":"true","policy_diagnostic":{"severity":"error","summary":"Failed to connect to policy engine","detail":"Failed to connect to policy engine: failed to connect to plugin: exec: \"tfpolicy-plugin\": executable file not found in $PATH."},"policy_metadata":{},"result":"SetupErrorResult","type":"policy_diagnostic"}`
 	checkGoldenReferenceStr(t, output, expected)
 }

--- a/internal/command/init_run.go
+++ b/internal/command/init_run.go
@@ -159,21 +159,6 @@ func (c *InitCommand) run(initArgs *arguments.Init, view views.Init) int {
 		return 1
 	}
 
-	var policyClient policy.Client
-	if len(initArgs.PolicyPaths) > 0 {
-		var policyDiags policy.Diagnostics
-		var stopClient func()
-		policyClient, policyDiags, stopClient = c.PolicyClient(ctx, initArgs.PolicyPaths)
-		defer stopClient()
-		view.PolicyResults(nil, policyDiags)
-		// if there has been any errors when setting up the policy client, we log them
-		// and return early, as a failure to set up the policy client should terminate the init operation
-		if policyDiags.HasErrors() {
-			view.Diagnostics(diags)
-			return 1
-		}
-	}
-
 	// If -state-provider-lock-file is set, we'll use that to obtain a new lock used for the state store provider
 	// This will be 'upserted': it may be that the previous locks don't contain the provider being added. potentially due to being empty, or contain a different version.
 	// The lock added will be used in the first step of provider download.
@@ -226,11 +211,6 @@ func (c *InitCommand) run(initArgs *arguments.Init, view views.Init) int {
 	}
 
 	policyResults := plans.NewPolicyResults()
-	providerHook := &providerPolicyHook{
-		client:        policyClient,
-		policyResults: policyResults,
-		rootModule:    rootModEarly,
-	}
 
 	var pssLocks *depsfile.Locks // May end up containing 0 or 1 lock.
 	if rootModEarly.StateStore != nil {
@@ -333,6 +313,32 @@ Please use \"terraform state migrate -upgrade\" to upgrade the state store provi
 		// If we outputted information, then we need to output a newline
 		// so that our success message is nicely spaced out from prior text.
 		view.Output(views.EmptyMessage)
+	}
+
+	// Set up the policy client now that the backend is configured, so the
+	// entitlement can be read from it (as plan and apply do). getModules and
+	// getProviders below consume the client through the provider hook.
+	var policyClient policy.Client
+	if len(initArgs.PolicyPaths) > 0 {
+		var policyDiags policy.Diagnostics
+		var stopClient func()
+		policyClient, policyDiags, stopClient = c.PolicyClient(ctx, initArgs.PolicyPaths, backendPolicyEntitlement(back))
+		defer stopClient()
+		view.PolicyResults(nil, policyDiags)
+		if policyDiags.HasErrors() {
+			// Surface any backend (and early config) diagnostics here too, so a
+			// backend failure isn't swallowed by this early return: backDiags is
+			// only appended after the core-version check below, which we skip.
+			diags = diags.Append(earlyConfDiags)
+			diags = diags.Append(backDiags)
+			view.Diagnostics(diags)
+			return 1
+		}
+	}
+	providerHook := &providerPolicyHook{
+		client:        policyClient,
+		policyResults: policyResults,
+		rootModule:    rootModEarly,
 	}
 
 	var state *states.State

--- a/internal/command/init_run.go
+++ b/internal/command/init_run.go
@@ -326,9 +326,6 @@ Please use \"terraform state migrate -upgrade\" to upgrade the state store provi
 		defer stopClient()
 		view.PolicyResults(nil, policyDiags)
 		if policyDiags.HasErrors() {
-			// Surface any backend (and early config) diagnostics here too, so a
-			// backend failure isn't swallowed by this early return: backDiags is
-			// only appended after the core-version check below, which we skip.
 			diags = diags.Append(earlyConfDiags)
 			diags = diags.Append(backDiags)
 			view.Diagnostics(diags)

--- a/internal/command/meta_policy.go
+++ b/internal/command/meta_policy.go
@@ -13,6 +13,7 @@ import (
 	"github.com/zclconf/go-cty/cty"
 
 	"github.com/hashicorp/terraform/internal/addrs"
+	"github.com/hashicorp/terraform/internal/backend"
 	"github.com/hashicorp/terraform/internal/configs"
 	"github.com/hashicorp/terraform/internal/initwd"
 	"github.com/hashicorp/terraform/internal/plans"
@@ -23,7 +24,7 @@ import (
 	"github.com/hashicorp/terraform/version"
 )
 
-func (c *Meta) PolicyClient(ctx context.Context, policyPaths []string) (policy.Client, policy.Diagnostics, func()) {
+func (c *Meta) PolicyClient(ctx context.Context, policyPaths []string, ent *policy.Entitlement) (policy.Client, policy.Diagnostics, func()) {
 	var client policy.Client
 	closer := func() {
 		if client != nil {
@@ -72,6 +73,7 @@ func (c *Meta) PolicyClient(ctx context.Context, policyPaths []string) (policy.C
 	resp := client.Setup(ctx, policy.SetupRequest{
 		SourceLocations: policyPaths,
 		CallbackService: callbackServiceID,
+		Entitlement:     ent,
 	})
 	diags = append(diags, resp.Diagnostics...)
 
@@ -116,6 +118,17 @@ func (c *Meta) PolicyClient(ctx context.Context, policyPaths []string) (policy.C
 }
 
 var _ initwd.ModuleInstallHook = &policyModuleInstallHook{}
+
+// backendPolicyEntitlement returns the entitlement from the backend if it
+// implements policy.EntitlementProvider, or nil otherwise (e.g. a local
+// backend).
+func backendPolicyEntitlement(be backend.Backend) *policy.Entitlement {
+	provider, ok := be.(policy.EntitlementProvider)
+	if !ok {
+		return nil
+	}
+	return provider.PolicyEntitlement()
+}
 
 // policyModuleInstallHook enables policy evaluation during module installation.
 type policyModuleInstallHook struct {

--- a/internal/command/meta_policy_test.go
+++ b/internal/command/meta_policy_test.go
@@ -1,0 +1,61 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package command
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/internal/backend"
+	"github.com/hashicorp/terraform/internal/policy"
+)
+
+// entitlementBackend is a backend.Backend that also implements
+// policy.EntitlementProvider.
+type entitlementBackend struct {
+	backend.Backend
+	ent *policy.Entitlement
+}
+
+func (b *entitlementBackend) PolicyEntitlement() *policy.Entitlement { return b.ent }
+
+// plainBackend is a backend.Backend that does not implement
+// policy.EntitlementProvider.
+type plainBackend struct {
+	backend.Backend
+}
+
+func TestBackendPolicyEntitlement(t *testing.T) {
+	ent := &policy.Entitlement{Host: "app.terraform.io", Token: "secret", Org: "hashicorp"}
+
+	tests := []struct {
+		name string
+		be   backend.Backend
+		want *policy.Entitlement
+	}{
+		{
+			name: "backend implements EntitlementProvider",
+			be:   &entitlementBackend{ent: ent},
+			want: ent,
+		},
+		{
+			name: "backend provides nil entitlement",
+			be:   &entitlementBackend{ent: nil},
+			want: nil,
+		},
+		{
+			name: "backend does not implement EntitlementProvider",
+			be:   &plainBackend{},
+			want: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := backendPolicyEntitlement(tt.be)
+			if got != tt.want {
+				t.Fatalf("unexpected entitlement: got %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/command/plan.go
+++ b/internal/command/plan.go
@@ -89,7 +89,7 @@ func (c *PlanCommand) Run(rawArgs []string) int {
 	}
 
 	if len(args.PolicyPaths) > 0 {
-		client, policyDiags, stopClient := c.PolicyClient(context.Background(), args.PolicyPaths)
+		client, policyDiags, stopClient := c.PolicyClient(context.Background(), args.PolicyPaths, backendPolicyEntitlement(be))
 		// if there has been any errors when setting up the policy client, we log them but
 		// we still proceed with the operation, as a failure to set up the policy client
 		// should not prevent the plan operation from running

--- a/internal/policy/client.go
+++ b/internal/policy/client.go
@@ -136,11 +136,19 @@ func (c *client) RegisterCallbackService(ctx context.Context) (*callback.Server,
 
 func (c *client) Setup(ctx context.Context, req SetupRequest) SetupResponse {
 	log.Printf("[DEBUG] Setting up Terraform Policy connection")
-	response, err := c.client.Setup(ctx, &proto.PolicySetupRequest{
+	protoReq := &proto.PolicySetupRequest{
 		ClientCapabilities: new(proto.PolicySetupRequest_ClientCapabilities),
 		SourceLocations:    req.SourceLocations,
 		CallbackService:    req.CallbackService,
-	})
+	}
+	if req.Entitlement != nil {
+		protoReq.Entitlement = &proto.PolicySetupRequest_Entitlement{
+			Host:  req.Entitlement.Host,
+			Token: req.Entitlement.Token,
+			Org:   req.Entitlement.Org,
+		}
+	}
+	response, err := c.client.Setup(ctx, protoReq)
 	if err != nil {
 		return SetupResponse{Diagnostics: Diagnostics{
 			NewErrorDiagnostic("Failed to setup Terraform Policy connection",

--- a/internal/policy/client_test.go
+++ b/internal/policy/client_test.go
@@ -21,9 +21,14 @@ import (
 type stubPolicyClient struct {
 	proto.PolicyClient
 
+	setupFn            func(*proto.PolicySetupRequest) (*proto.PolicySetupResponse, error)
 	evaluateResourceFn func(*proto.PolicyEvaluateResourceRequest) (*proto.PolicyEvaluateResourceResponse, error)
 	evaluateProviderFn func(*proto.PolicyEvaluateProviderRequest) (*proto.PolicyEvaluateProviderResponse, error)
 	evaluateModuleFn   func(*proto.PolicyEvaluateModuleRequest) (*proto.PolicyEvaluateModuleResponse, error)
+}
+
+func (s *stubPolicyClient) Setup(ctx context.Context, req *proto.PolicySetupRequest, _ ...grpc.CallOption) (*proto.PolicySetupResponse, error) {
+	return s.setupFn(req)
 }
 
 func (s *stubPolicyClient) EvaluateResource(ctx context.Context, req *proto.PolicyEvaluateResourceRequest, _ ...grpc.CallOption) (*proto.PolicyEvaluateResourceResponse, error) {
@@ -453,6 +458,74 @@ func TestClientEvaluateModule(t *testing.T) {
 			}
 			if gotReq.ModuleSource != "./child" {
 				t.Fatalf("unexpected module source: got %q, want %q", gotReq.ModuleSource, "./child")
+			}
+		})
+	}
+}
+
+func TestClientSetupEntitlement(t *testing.T) {
+	ctx := t.Context()
+
+	tests := []struct {
+		name        string
+		entitlement *Entitlement
+		want        *proto.PolicySetupRequest_Entitlement
+	}{
+		{
+			name:        "nil entitlement is not serialized",
+			entitlement: nil,
+			want:        nil,
+		},
+		{
+			name: "entitlement is mapped onto the proto request",
+			entitlement: &Entitlement{
+				Host:  "app.terraform.io",
+				Token: "secret",
+				Org:   "hashicorp",
+			},
+			want: &proto.PolicySetupRequest_Entitlement{
+				Host:  "app.terraform.io",
+				Token: "secret",
+				Org:   "hashicorp",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var gotReq *proto.PolicySetupRequest
+			c := &client{
+				client: &stubPolicyClient{
+					setupFn: func(req *proto.PolicySetupRequest) (*proto.PolicySetupResponse, error) {
+						gotReq = req
+						return &proto.PolicySetupResponse{}, nil
+					},
+				},
+			}
+
+			resp := c.Setup(ctx, SetupRequest{
+				SourceLocations: []string{"./policies"},
+				Entitlement:     tt.entitlement,
+			})
+			if resp.Diagnostics.HasErrors() {
+				t.Fatalf("unexpected diagnostics: %#v", resp.Diagnostics)
+			}
+			if gotReq == nil {
+				t.Fatal("expected a setup request to be sent")
+			}
+
+			got := gotReq.Entitlement
+			if tt.want == nil {
+				if got != nil {
+					t.Fatalf("expected nil entitlement, got %+v", got)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatal("expected entitlement, got nil")
+			}
+			if got.Host != tt.want.Host || got.Token != tt.want.Token || got.Org != tt.want.Org {
+				t.Fatalf("unexpected entitlement: got %+v, want %+v", got, tt.want)
 			}
 		})
 	}

--- a/internal/policy/policy.go
+++ b/internal/policy/policy.go
@@ -67,6 +67,25 @@ type (
 
 		// CallbackService is the callback service to use for policy evaluation.
 		CallbackService uint32
+
+		// Entitlement, when non-nil, carries the host/token/org the plugin uses
+		// to verify the calling org is entitled to policy enforcement. Nil means
+		// the plugin skips the check.
+		Entitlement *Entitlement
+	}
+
+	// Entitlement is the credential triple the plugin needs to call the
+	// TFC/TFE entitlement-set endpoint during Setup.
+	Entitlement struct {
+		Host  string
+		Token string
+		Org   string
+	}
+
+	// EntitlementProvider is implemented by backends that can supply a policy
+	// entitlement from their configured credentials.
+	EntitlementProvider interface {
+		PolicyEntitlement() *Entitlement
 	}
 
 	PolicyValue struct {

--- a/internal/policy/proto/policy.pb.go
+++ b/internal/policy/proto/policy.pb.go
@@ -35,8 +35,11 @@ type PolicySetupRequest struct {
 	SourceLocations []string `protobuf:"bytes,2,rep,name=source_locations,json=sourceLocations,proto3" json:"source_locations,omitempty"`
 	// callback_service allows Terraform Policy to use the Callback Service API.
 	CallbackService uint32 `protobuf:"varint,3,opt,name=callback_service,json=callbackService,proto3" json:"callback_service,omitempty"`
-	unknownFields   protoimpl.UnknownFields
-	sizeCache       protoimpl.SizeCache
+	// entitlement is optional; when present, the plugin uses it to call the
+	// entitlement-set endpoint and refuses Setup if the org is not entitled.
+	Entitlement   *PolicySetupRequest_Entitlement `protobuf:"bytes,4,opt,name=entitlement,proto3" json:"entitlement,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *PolicySetupRequest) Reset() {
@@ -88,6 +91,13 @@ func (x *PolicySetupRequest) GetCallbackService() uint32 {
 		return x.CallbackService
 	}
 	return 0
+}
+
+func (x *PolicySetupRequest) GetEntitlement() *PolicySetupRequest_Entitlement {
+	if x != nil {
+		return x.Entitlement
+	}
+	return nil
 }
 
 // SetupResponse is the message response for the Setup RPC.
@@ -781,6 +791,69 @@ func (*PolicySetupRequest_ClientCapabilities) Descriptor() ([]byte, []int) {
 	return file_policy_proto_rawDescGZIP(), []int{0, 0}
 }
 
+// Entitlement carries the host, token, and org the plugin uses to verify
+// policy-enforcement entitlement at Setup. The client resolves these itself.
+// If unset or any field is empty, the plugin skips the check.
+type PolicySetupRequest_Entitlement struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Host          string                 `protobuf:"bytes,1,opt,name=host,proto3" json:"host,omitempty"`
+	Token         string                 `protobuf:"bytes,2,opt,name=token,proto3" json:"token,omitempty"`
+	Org           string                 `protobuf:"bytes,3,opt,name=org,proto3" json:"org,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *PolicySetupRequest_Entitlement) Reset() {
+	*x = PolicySetupRequest_Entitlement{}
+	mi := &file_policy_proto_msgTypes[11]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *PolicySetupRequest_Entitlement) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PolicySetupRequest_Entitlement) ProtoMessage() {}
+
+func (x *PolicySetupRequest_Entitlement) ProtoReflect() protoreflect.Message {
+	mi := &file_policy_proto_msgTypes[11]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use PolicySetupRequest_Entitlement.ProtoReflect.Descriptor instead.
+func (*PolicySetupRequest_Entitlement) Descriptor() ([]byte, []int) {
+	return file_policy_proto_rawDescGZIP(), []int{0, 1}
+}
+
+func (x *PolicySetupRequest_Entitlement) GetHost() string {
+	if x != nil {
+		return x.Host
+	}
+	return ""
+}
+
+func (x *PolicySetupRequest_Entitlement) GetToken() string {
+	if x != nil {
+		return x.Token
+	}
+	return ""
+}
+
+func (x *PolicySetupRequest_Entitlement) GetOrg() string {
+	if x != nil {
+		return x.Org
+	}
+	return ""
+}
+
 // A single terraform_configuration block for a Policy file.
 type PolicySetupResponse_TerraformConfiguration struct {
 	state           protoimpl.MessageState `protogen:"open.v1"`
@@ -791,7 +864,7 @@ type PolicySetupResponse_TerraformConfiguration struct {
 
 func (x *PolicySetupResponse_TerraformConfiguration) Reset() {
 	*x = PolicySetupResponse_TerraformConfiguration{}
-	mi := &file_policy_proto_msgTypes[11]
+	mi := &file_policy_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -803,7 +876,7 @@ func (x *PolicySetupResponse_TerraformConfiguration) String() string {
 func (*PolicySetupResponse_TerraformConfiguration) ProtoMessage() {}
 
 func (x *PolicySetupResponse_TerraformConfiguration) ProtoReflect() protoreflect.Message {
-	mi := &file_policy_proto_msgTypes[11]
+	mi := &file_policy_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -837,7 +910,7 @@ type PolicySetupResponse_ServerCapabilities struct {
 
 func (x *PolicySetupResponse_ServerCapabilities) Reset() {
 	*x = PolicySetupResponse_ServerCapabilities{}
-	mi := &file_policy_proto_msgTypes[12]
+	mi := &file_policy_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -849,7 +922,7 @@ func (x *PolicySetupResponse_ServerCapabilities) String() string {
 func (*PolicySetupResponse_ServerCapabilities) ProtoMessage() {}
 
 func (x *PolicySetupResponse_ServerCapabilities) ProtoReflect() protoreflect.Message {
-	mi := &file_policy_proto_msgTypes[12]
+	mi := &file_policy_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -883,7 +956,7 @@ type PolicyEvaluateResourceRequest_ResourceMetadata struct {
 
 func (x *PolicyEvaluateResourceRequest_ResourceMetadata) Reset() {
 	*x = PolicyEvaluateResourceRequest_ResourceMetadata{}
-	mi := &file_policy_proto_msgTypes[14]
+	mi := &file_policy_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -895,7 +968,7 @@ func (x *PolicyEvaluateResourceRequest_ResourceMetadata) String() string {
 func (*PolicyEvaluateResourceRequest_ResourceMetadata) ProtoMessage() {}
 
 func (x *PolicyEvaluateResourceRequest_ResourceMetadata) ProtoReflect() protoreflect.Message {
-	mi := &file_policy_proto_msgTypes[14]
+	mi := &file_policy_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -945,7 +1018,7 @@ type PolicyEvaluateProviderRequest_ProviderMetadata struct {
 
 func (x *PolicyEvaluateProviderRequest_ProviderMetadata) Reset() {
 	*x = PolicyEvaluateProviderRequest_ProviderMetadata{}
-	mi := &file_policy_proto_msgTypes[15]
+	mi := &file_policy_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -957,7 +1030,7 @@ func (x *PolicyEvaluateProviderRequest_ProviderMetadata) String() string {
 func (*PolicyEvaluateProviderRequest_ProviderMetadata) ProtoMessage() {}
 
 func (x *PolicyEvaluateProviderRequest_ProviderMetadata) ProtoReflect() protoreflect.Message {
-	mi := &file_policy_proto_msgTypes[15]
+	mi := &file_policy_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1018,7 +1091,7 @@ type PolicyEvaluateModuleRequest_ModuleMetadata struct {
 
 func (x *PolicyEvaluateModuleRequest_ModuleMetadata) Reset() {
 	*x = PolicyEvaluateModuleRequest_ModuleMetadata{}
-	mi := &file_policy_proto_msgTypes[16]
+	mi := &file_policy_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1030,7 +1103,7 @@ func (x *PolicyEvaluateModuleRequest_ModuleMetadata) String() string {
 func (*PolicyEvaluateModuleRequest_ModuleMetadata) ProtoMessage() {}
 
 func (x *PolicyEvaluateModuleRequest_ModuleMetadata) ProtoReflect() protoreflect.Message {
-	mi := &file_policy_proto_msgTypes[16]
+	mi := &file_policy_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1064,12 +1137,17 @@ var File_policy_proto protoreflect.FileDescriptor
 
 const file_policy_proto_rawDesc = "" +
 	"\n" +
-	"\fpolicy.proto\x12\x05proto\x1a\x11diagnostics.proto\x1a\vtypes.proto\"\xdf\x01\n" +
+	"\fpolicy.proto\x12\x05proto\x1a\x11diagnostics.proto\x1a\vtypes.proto\"\xf3\x02\n" +
 	"\x12PolicySetupRequest\x12]\n" +
 	"\x13client_capabilities\x18\x01 \x01(\v2,.proto.PolicySetupRequest.ClientCapabilitiesR\x12clientCapabilities\x12)\n" +
 	"\x10source_locations\x18\x02 \x03(\tR\x0fsourceLocations\x12)\n" +
-	"\x10callback_service\x18\x03 \x01(\rR\x0fcallbackService\x1a\x14\n" +
-	"\x12ClientCapabilities\"\xe7\x03\n" +
+	"\x10callback_service\x18\x03 \x01(\rR\x0fcallbackService\x12G\n" +
+	"\ventitlement\x18\x04 \x01(\v2%.proto.PolicySetupRequest.EntitlementR\ventitlement\x1a\x14\n" +
+	"\x12ClientCapabilities\x1aI\n" +
+	"\vEntitlement\x12\x12\n" +
+	"\x04host\x18\x01 \x01(\tR\x04host\x12\x14\n" +
+	"\x05token\x18\x02 \x01(\tR\x05token\x12\x10\n" +
+	"\x03org\x18\x03 \x01(\tR\x03org\"\xe7\x03\n" +
 	"\x13PolicySetupResponse\x12^\n" +
 	"\x13server_capabilities\x18\x01 \x01(\v2-.proto.PolicySetupResponse.ServerCapabilitiesR\x12serverCapabilities\x123\n" +
 	"\vdiagnostics\x18\x02 \x03(\v2\x11.proto.DiagnosticR\vdiagnostics\x1aC\n" +
@@ -1154,7 +1232,7 @@ func file_policy_proto_rawDescGZIP() []byte {
 	return file_policy_proto_rawDescData
 }
 
-var file_policy_proto_msgTypes = make([]protoimpl.MessageInfo, 17)
+var file_policy_proto_msgTypes = make([]protoimpl.MessageInfo, 18)
 var file_policy_proto_goTypes = []any{
 	(*PolicySetupRequest)(nil),                         // 0: proto.PolicySetupRequest
 	(*PolicySetupResponse)(nil),                        // 1: proto.PolicySetupResponse
@@ -1167,60 +1245,62 @@ var file_policy_proto_goTypes = []any{
 	(*PolicyEvaluateModuleRequest)(nil),                // 8: proto.PolicyEvaluateModuleRequest
 	(*PolicyEvaluateModuleResponse)(nil),               // 9: proto.PolicyEvaluateModuleResponse
 	(*PolicySetupRequest_ClientCapabilities)(nil),      // 10: proto.PolicySetupRequest.ClientCapabilities
-	(*PolicySetupResponse_TerraformConfiguration)(nil), // 11: proto.PolicySetupResponse.TerraformConfiguration
-	(*PolicySetupResponse_ServerCapabilities)(nil),     // 12: proto.PolicySetupResponse.ServerCapabilities
-	nil, // 13: proto.PolicySetupResponse.ServerCapabilities.ConfigurationsEntry
-	(*PolicyEvaluateResourceRequest_ResourceMetadata)(nil), // 14: proto.PolicyEvaluateResourceRequest.ResourceMetadata
-	(*PolicyEvaluateProviderRequest_ProviderMetadata)(nil), // 15: proto.PolicyEvaluateProviderRequest.ProviderMetadata
-	(*PolicyEvaluateModuleRequest_ModuleMetadata)(nil),     // 16: proto.PolicyEvaluateModuleRequest.ModuleMetadata
-	(*Diagnostic)(nil),         // 17: proto.Diagnostic
-	(*ResourceAttributes)(nil), // 18: proto.ResourceAttributes
-	(EvaluateResult)(0),        // 19: proto.EvaluateResult
-	(*Range)(nil),              // 20: proto.Range
-	(*Snippet)(nil),            // 21: proto.Snippet
-	(Operation)(0),             // 22: proto.Operation
+	(*PolicySetupRequest_Entitlement)(nil),             // 11: proto.PolicySetupRequest.Entitlement
+	(*PolicySetupResponse_TerraformConfiguration)(nil), // 12: proto.PolicySetupResponse.TerraformConfiguration
+	(*PolicySetupResponse_ServerCapabilities)(nil),     // 13: proto.PolicySetupResponse.ServerCapabilities
+	nil, // 14: proto.PolicySetupResponse.ServerCapabilities.ConfigurationsEntry
+	(*PolicyEvaluateResourceRequest_ResourceMetadata)(nil), // 15: proto.PolicyEvaluateResourceRequest.ResourceMetadata
+	(*PolicyEvaluateProviderRequest_ProviderMetadata)(nil), // 16: proto.PolicyEvaluateProviderRequest.ProviderMetadata
+	(*PolicyEvaluateModuleRequest_ModuleMetadata)(nil),     // 17: proto.PolicyEvaluateModuleRequest.ModuleMetadata
+	(*Diagnostic)(nil),         // 18: proto.Diagnostic
+	(*ResourceAttributes)(nil), // 19: proto.ResourceAttributes
+	(EvaluateResult)(0),        // 20: proto.EvaluateResult
+	(*Range)(nil),              // 21: proto.Range
+	(*Snippet)(nil),            // 22: proto.Snippet
+	(Operation)(0),             // 23: proto.Operation
 }
 var file_policy_proto_depIdxs = []int32{
 	10, // 0: proto.PolicySetupRequest.client_capabilities:type_name -> proto.PolicySetupRequest.ClientCapabilities
-	12, // 1: proto.PolicySetupResponse.server_capabilities:type_name -> proto.PolicySetupResponse.ServerCapabilities
-	17, // 2: proto.PolicySetupResponse.diagnostics:type_name -> proto.Diagnostic
-	18, // 3: proto.PolicyEvaluateResourceRequest.attrs:type_name -> proto.ResourceAttributes
-	14, // 4: proto.PolicyEvaluateResourceRequest.metadata:type_name -> proto.PolicyEvaluateResourceRequest.ResourceMetadata
-	18, // 5: proto.PolicyEvaluateResourceRequest.prior_attrs:type_name -> proto.ResourceAttributes
-	19, // 6: proto.PolicyEvaluationDetail.result:type_name -> proto.EvaluateResult
-	20, // 7: proto.PolicyEvaluationDetail.def_range:type_name -> proto.Range
-	4,  // 8: proto.PolicyEvaluationDetail.enforce_results:type_name -> proto.EnforceBlockResult
-	17, // 9: proto.PolicyEvaluationDetail.diagnostics:type_name -> proto.Diagnostic
-	19, // 10: proto.EnforceBlockResult.result:type_name -> proto.EvaluateResult
-	20, // 11: proto.EnforceBlockResult.range:type_name -> proto.Range
-	17, // 12: proto.EnforceBlockResult.diagnostics:type_name -> proto.Diagnostic
-	21, // 13: proto.EnforceBlockResult.snippet:type_name -> proto.Snippet
-	19, // 14: proto.PolicyEvaluateResourceResponse.result:type_name -> proto.EvaluateResult
-	3,  // 15: proto.PolicyEvaluateResourceResponse.policy_details:type_name -> proto.PolicyEvaluationDetail
-	18, // 16: proto.PolicyEvaluateProviderRequest.attrs:type_name -> proto.ResourceAttributes
-	15, // 17: proto.PolicyEvaluateProviderRequest.metadata:type_name -> proto.PolicyEvaluateProviderRequest.ProviderMetadata
-	19, // 18: proto.PolicyEvaluateProviderResponse.result:type_name -> proto.EvaluateResult
-	3,  // 19: proto.PolicyEvaluateProviderResponse.policy_details:type_name -> proto.PolicyEvaluationDetail
-	18, // 20: proto.PolicyEvaluateModuleRequest.attrs:type_name -> proto.ResourceAttributes
-	16, // 21: proto.PolicyEvaluateModuleRequest.metadata:type_name -> proto.PolicyEvaluateModuleRequest.ModuleMetadata
-	19, // 22: proto.PolicyEvaluateModuleResponse.result:type_name -> proto.EvaluateResult
-	3,  // 23: proto.PolicyEvaluateModuleResponse.policy_details:type_name -> proto.PolicyEvaluationDetail
-	13, // 24: proto.PolicySetupResponse.ServerCapabilities.configurations:type_name -> proto.PolicySetupResponse.ServerCapabilities.ConfigurationsEntry
-	11, // 25: proto.PolicySetupResponse.ServerCapabilities.ConfigurationsEntry.value:type_name -> proto.PolicySetupResponse.TerraformConfiguration
-	22, // 26: proto.PolicyEvaluateResourceRequest.ResourceMetadata.operation:type_name -> proto.Operation
-	0,  // 27: proto.Policy.Setup:input_type -> proto.PolicySetupRequest
-	2,  // 28: proto.Policy.EvaluateResource:input_type -> proto.PolicyEvaluateResourceRequest
-	6,  // 29: proto.Policy.EvaluateProvider:input_type -> proto.PolicyEvaluateProviderRequest
-	8,  // 30: proto.Policy.EvaluateModule:input_type -> proto.PolicyEvaluateModuleRequest
-	1,  // 31: proto.Policy.Setup:output_type -> proto.PolicySetupResponse
-	5,  // 32: proto.Policy.EvaluateResource:output_type -> proto.PolicyEvaluateResourceResponse
-	7,  // 33: proto.Policy.EvaluateProvider:output_type -> proto.PolicyEvaluateProviderResponse
-	9,  // 34: proto.Policy.EvaluateModule:output_type -> proto.PolicyEvaluateModuleResponse
-	31, // [31:35] is the sub-list for method output_type
-	27, // [27:31] is the sub-list for method input_type
-	27, // [27:27] is the sub-list for extension type_name
-	27, // [27:27] is the sub-list for extension extendee
-	0,  // [0:27] is the sub-list for field type_name
+	11, // 1: proto.PolicySetupRequest.entitlement:type_name -> proto.PolicySetupRequest.Entitlement
+	13, // 2: proto.PolicySetupResponse.server_capabilities:type_name -> proto.PolicySetupResponse.ServerCapabilities
+	18, // 3: proto.PolicySetupResponse.diagnostics:type_name -> proto.Diagnostic
+	19, // 4: proto.PolicyEvaluateResourceRequest.attrs:type_name -> proto.ResourceAttributes
+	15, // 5: proto.PolicyEvaluateResourceRequest.metadata:type_name -> proto.PolicyEvaluateResourceRequest.ResourceMetadata
+	19, // 6: proto.PolicyEvaluateResourceRequest.prior_attrs:type_name -> proto.ResourceAttributes
+	20, // 7: proto.PolicyEvaluationDetail.result:type_name -> proto.EvaluateResult
+	21, // 8: proto.PolicyEvaluationDetail.def_range:type_name -> proto.Range
+	4,  // 9: proto.PolicyEvaluationDetail.enforce_results:type_name -> proto.EnforceBlockResult
+	18, // 10: proto.PolicyEvaluationDetail.diagnostics:type_name -> proto.Diagnostic
+	20, // 11: proto.EnforceBlockResult.result:type_name -> proto.EvaluateResult
+	21, // 12: proto.EnforceBlockResult.range:type_name -> proto.Range
+	18, // 13: proto.EnforceBlockResult.diagnostics:type_name -> proto.Diagnostic
+	22, // 14: proto.EnforceBlockResult.snippet:type_name -> proto.Snippet
+	20, // 15: proto.PolicyEvaluateResourceResponse.result:type_name -> proto.EvaluateResult
+	3,  // 16: proto.PolicyEvaluateResourceResponse.policy_details:type_name -> proto.PolicyEvaluationDetail
+	19, // 17: proto.PolicyEvaluateProviderRequest.attrs:type_name -> proto.ResourceAttributes
+	16, // 18: proto.PolicyEvaluateProviderRequest.metadata:type_name -> proto.PolicyEvaluateProviderRequest.ProviderMetadata
+	20, // 19: proto.PolicyEvaluateProviderResponse.result:type_name -> proto.EvaluateResult
+	3,  // 20: proto.PolicyEvaluateProviderResponse.policy_details:type_name -> proto.PolicyEvaluationDetail
+	19, // 21: proto.PolicyEvaluateModuleRequest.attrs:type_name -> proto.ResourceAttributes
+	17, // 22: proto.PolicyEvaluateModuleRequest.metadata:type_name -> proto.PolicyEvaluateModuleRequest.ModuleMetadata
+	20, // 23: proto.PolicyEvaluateModuleResponse.result:type_name -> proto.EvaluateResult
+	3,  // 24: proto.PolicyEvaluateModuleResponse.policy_details:type_name -> proto.PolicyEvaluationDetail
+	14, // 25: proto.PolicySetupResponse.ServerCapabilities.configurations:type_name -> proto.PolicySetupResponse.ServerCapabilities.ConfigurationsEntry
+	12, // 26: proto.PolicySetupResponse.ServerCapabilities.ConfigurationsEntry.value:type_name -> proto.PolicySetupResponse.TerraformConfiguration
+	23, // 27: proto.PolicyEvaluateResourceRequest.ResourceMetadata.operation:type_name -> proto.Operation
+	0,  // 28: proto.Policy.Setup:input_type -> proto.PolicySetupRequest
+	2,  // 29: proto.Policy.EvaluateResource:input_type -> proto.PolicyEvaluateResourceRequest
+	6,  // 30: proto.Policy.EvaluateProvider:input_type -> proto.PolicyEvaluateProviderRequest
+	8,  // 31: proto.Policy.EvaluateModule:input_type -> proto.PolicyEvaluateModuleRequest
+	1,  // 32: proto.Policy.Setup:output_type -> proto.PolicySetupResponse
+	5,  // 33: proto.Policy.EvaluateResource:output_type -> proto.PolicyEvaluateResourceResponse
+	7,  // 34: proto.Policy.EvaluateProvider:output_type -> proto.PolicyEvaluateProviderResponse
+	9,  // 35: proto.Policy.EvaluateModule:output_type -> proto.PolicyEvaluateModuleResponse
+	32, // [32:36] is the sub-list for method output_type
+	28, // [28:32] is the sub-list for method input_type
+	28, // [28:28] is the sub-list for extension type_name
+	28, // [28:28] is the sub-list for extension extendee
+	0,  // [0:28] is the sub-list for field type_name
 }
 
 func init() { file_policy_proto_init() }
@@ -1236,7 +1316,7 @@ func file_policy_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_policy_proto_rawDesc), len(file_policy_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   17,
+			NumMessages:   18,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/internal/policy/proto/policy.proto
+++ b/internal/policy/proto/policy.proto
@@ -37,6 +37,15 @@ message PolicySetupRequest {
   // compatibility concerns to worry about.
   message ClientCapabilities {}
 
+  // Entitlement carries the host, token, and org the plugin uses to verify
+  // policy-enforcement entitlement at Setup. The client resolves these itself.
+  // If unset or any field is empty, the plugin skips the check.
+  message Entitlement {
+    string host = 1;
+    string token = 2;
+    string org = 3;
+  }
+
   // client_capabilities should be populated by the client to indicate which
   // behaviours the client is aware of.
   ClientCapabilities client_capabilities = 1;
@@ -47,6 +56,10 @@ message PolicySetupRequest {
   
   // callback_service allows Terraform Policy to use the Callback Service API.
   uint32 callback_service = 3;
+
+  // entitlement is optional; when present, the plugin uses it to call the
+  // entitlement-set endpoint and refuses Setup if the org is not entitled.
+  Entitlement entitlement = 4;
 }
 
 // SetupResponse is the message response for the Setup RPC.


### PR DESCRIPTION
The Terraform policy plugin verifies, at Setup time, that the calling HCP Terraform organization is entitled to policy enforcement. To do that it needs the host, bearer token, and organization of the run.

This change moves that resolution into Terraform core and passes the resolved triple to the plugin on the Setup RPC. The `cloud` and `remote` backends already resolve host/token/org while configuring, so they expose it through a new `policy.EntitlementProvider` interface (the local backend delegates to its wrapped backend).

`init`, `plan`, and `apply` all read the entitlement from the configured backend:

- **plan / apply** read it from the backend right before setting up the policy client.
- **init** now sets up its policy client *after* the backend is initialized, so it can read the entitlement from the same `cloud`/`remote` backend instead of scraping the CLI config.

If the backend cannot supply an entitlement (e.g. a local backend) the triple is nil and the plugin applies its own fallback.

> Note: the pluggable `state_store` path in `init` runs before any backend exists and is out of scope here; it sets up no policy entitlement.

### Proto

Adds an `Entitlement` message to `PolicySetupRequest` (field 4) and regenerates the stubs with the repo's pinned protoc.

Fixes #

## Target Release

1.16.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

This changes how the policy plugin obtains the credentials used to verify policy-enforcement entitlement: the host/token/organization are now resolved by Terraform core from the configured backend and sent to the plugin over the local Setup RPC, instead of the plugin re-reading credentials itself. No new credentials are stored or transmitted externally.

## CHANGELOG entry

- [x] This change is user-facing and I added a changelog entry.
