### PR TITLE
Minor fixes to init-time policy and policy lifecycle

### DIFF
--- a/internal/command/apply.go
+++ b/internal/command/apply.go
@@ -111,7 +111,9 @@ func (c *ApplyCommand) Run(rawArgs []string) int {
 			opReq.View.PolicyResults(nil, policyDiags)
 		}
 		opReq.PolicyClient = client
-		defer stopClient()
+		if policyDiags.HasErrors() {
+			stopClient()
+		}
 	}
 
 	// Collect variable value and add them to the operation request

--- a/internal/command/apply.go
+++ b/internal/command/apply.go
@@ -106,14 +106,14 @@ func (c *ApplyCommand) Run(rawArgs []string) int {
 
 	if len(args.PolicyPaths) > 0 {
 		client, policyDiags, stopClient := c.PolicyClient(context.Background(), args.PolicyPaths)
-		// if there has been any errors when setting up the policy client, we'll log them
+		// if there has been any errors when setting up the policy client, we log them but
+		// we still proceed with the operation, as a failure to set up the policy client
+		// should not prevent the apply operation from running
 		if opReq.View != nil && policyDiags != nil {
 			opReq.View.PolicyResults(nil, policyDiags)
 		}
 		opReq.PolicyClient = client
-		if policyDiags.HasErrors() {
-			stopClient()
-		}
+		defer stopClient()
 	}
 
 	// Collect variable value and add them to the operation request

--- a/internal/command/apply_policy_test.go
+++ b/internal/command/apply_policy_test.go
@@ -6,6 +6,7 @@ package command
 import (
 	"context"
 	"os"
+	"sync/atomic"
 	"testing"
 
 	"github.com/hashicorp/hcl/v2"
@@ -152,6 +153,59 @@ func TestApply_WithPolicyDiagnosticsJSON(t *testing.T) {
 {"@level":"info","@message":"Apply complete! Resources: 1 added, 0 changed, 0 destroyed.","@module":"terraform.ui","changes":{"add":1,"change":0,"import":0,"remove":0,"action_invocation":0,"operation":"apply"},"type":"change_summary"}
 {"@level":"info","@message":"Outputs: 0","@module":"terraform.ui","outputs":{},"type":"outputs"}`
 	checkGoldenReferenceStr(t, output, expected)
+}
+
+func TestApply_WithPolicyClientStopAfterApply(t *testing.T) {
+	td := t.TempDir()
+	testCopyDir(t, testFixturePath("plan"), td)
+	t.Chdir(td)
+	policyCode := `		resource_policy "resource_type" "policy_name" {
+		  enforce_attrs {
+		    key = attr.value == "foo"
+		  }
+		}
+	`
+	if err := os.WriteFile("policy.hcl", []byte(policyCode), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	p := planFixtureProvider()
+	view, done := testView(t)
+	overrides := metaOverridesForProvider(p)
+	policyClient := policy.NewTestMockClient(t)
+	var stopCalled atomic.Bool
+	var policyEvaluated atomic.Bool
+	policyClient.StopFn = func() {
+		stopCalled.Store(true)
+	}
+	policyClient.EvaluateFn = func(ctx context.Context, req policy.EvaluationRequest[*proto.PolicyEvaluateResourceRequest_ResourceMetadata]) policy.EvaluationResponse {
+		policyEvaluated.Store(true)
+		if stopCalled.Load() {
+			t.Fatal("policy client Stop was called before apply finished")
+		}
+		return policy.EvaluationResponse{Overall: policy.AllowResult}
+	}
+	overrides.PolicyClient = policyClient
+	c := &ApplyCommand{
+		Meta: Meta{
+			testingOverrides:          overrides,
+			View:                      view,
+			AllowExperimentalFeatures: true,
+		},
+	}
+
+	args := []string{"-policies", td}
+	code := c.Run(append(args, "-no-color", "-auto-approve"))
+	output := done(t)
+	if code != 0 {
+		t.Fatalf("bad: %d\n\n%s", code, output.All())
+	}
+	if !policyEvaluated.Load() {
+		t.Fatal("expected policy evaluation to be called during apply")
+	}
+	if !stopCalled.Load() {
+		t.Fatal("expected policy client Stop to be called after apply")
+	}
 }
 
 // This tests that the plan policy diagnostic is superceded by the apply policy evaluation.

--- a/internal/command/init.go
+++ b/internal/command/init.go
@@ -390,7 +390,7 @@ const (
 // updated dependency lock data. The dependency lock file itself isn't updated here.
 //
 // Calling code is responsible for validating inputs to this method, e.g. mutually exclusive flags.
-func (c *InitCommand) getProvidersFromPSSConfig(ctx context.Context, rootModEarly *configs.Module, previousLocks *depsfile.Locks, upgrade bool, pluginDirs []string, flagLockfile string, view views.Init, installerHook *providerPolicyHook) (output bool, resultingLocks *depsfile.Locks, safeInitAction SafeInitAction, authResult *getproviders.PackageAuthenticationResult, diags tfdiags.Diagnostics) {
+func (c *InitCommand) getProvidersFromPSSConfig(ctx context.Context, rootModEarly *configs.Module, previousLocks *depsfile.Locks, upgrade bool, pluginDirs []string, flagLockfile string, view views.Init) (output bool, resultingLocks *depsfile.Locks, safeInitAction SafeInitAction, authResult *getproviders.PackageAuthenticationResult, diags tfdiags.Diagnostics) {
 	ctx, span := tracer.Start(ctx, "install providers for state store")
 	defer span.End()
 
@@ -535,7 +535,7 @@ func (c *InitCommand) getProvidersFromPSSConfig(ctx context.Context, rootModEarl
 
 	// Determine which required providers are already downloaded, and download any
 	// new providers or newer versions of providers
-	configLocks, err := inst.EnsureProviderVersions(ctx, previousLocks, reqs, mode, installerHook)
+	configLocks, err := inst.EnsureProviderVersions(ctx, previousLocks, reqs, mode)
 	if ctx.Err() == context.Canceled {
 		diags = diags.Append(fmt.Errorf("Provider installation was canceled by an interrupt signal."))
 		view.Diagnostics(diags)

--- a/internal/command/init.go
+++ b/internal/command/init.go
@@ -588,7 +588,7 @@ func (c *InitCommand) getProvidersFromPSSConfig(ctx context.Context, rootModEarl
 // updated dependency lock data. The dependency lock *file* itself isn't updated here.
 //
 // See getProvidersFromPSSConfig which is equivalent for state store providers.
-func (c *InitCommand) getProviders(ctx context.Context, config *configs.Config, state *states.State, upgrade bool, configLocks *depsfile.Locks, pluginDirs []string, view views.Init, installerHook *providerPolicyHook) (output bool, resultingLocks *depsfile.Locks, diags tfdiags.Diagnostics) {
+func (c *InitCommand) getProviders(ctx context.Context, config *configs.Config, state *states.State, upgrade bool, configLocks *depsfile.Locks, pluginDirs []string, view views.Init, installerHook providercache.InstallerHook) (output bool, resultingLocks *depsfile.Locks, diags tfdiags.Diagnostics) {
 	ctx, span := tracer.Start(ctx, "install providers")
 	defer span.End()
 

--- a/internal/command/init.go
+++ b/internal/command/init.go
@@ -56,6 +56,18 @@ func (c *InitCommand) Run(args []string) int {
 
 	view := views.NewInit(initArgs.ViewType, c.View)
 
+	loader, err := c.initConfigLoader()
+	if err != nil {
+		diags = diags.Append(err)
+		view.Diagnostics(diags)
+		return 1
+	}
+
+	var varDiags tfdiags.Diagnostics
+	c.VariableValues, varDiags = initArgs.Vars.CollectValues(func(filename string, src []byte) {
+		loader.Parser().ForceFileSource(filename, src)
+	})
+	diags = diags.Append(varDiags)
 	diags = diags.Append(c.Validate(initArgs))
 	if diags.HasErrors() {
 		view.Diagnostics(diags)
@@ -288,17 +300,6 @@ func (c *InitCommand) initBackend(ctx context.Context, root *configs.Module, ini
 }
 
 func (c *InitCommand) Validate(args *arguments.Init) (diags tfdiags.Diagnostics) {
-	loader, err := c.initConfigLoader()
-	if err != nil {
-		diags = diags.Append(err)
-		return diags
-	}
-
-	var varDiags tfdiags.Diagnostics
-	c.VariableValues, varDiags = args.Vars.CollectValues(func(filename string, src []byte) {
-		loader.Parser().ForceFileSource(filename, src)
-	})
-	diags = diags.Append(varDiags)
 
 	diags = diags.Append(validatePolicyPaths(args.PolicyPaths, c.AllowExperimentalFeatures))
 	return diags

--- a/internal/command/init_policy_test.go
+++ b/internal/command/init_policy_test.go
@@ -269,12 +269,21 @@ func TestInit_WithNestedModulePolicyDiagnostics(t *testing.T) {
 	ui := new(cli.MockUi)
 	view, done := testView(t)
 
+	// assert modules are evaluated correctly
+	expected := map[string]policy.EvaluateResult{
+		"./grandchild":    policy.DenyResult,
+		"./modules/child": policy.AllowResult,
+	}
+	actual := map[string]policy.EvaluateResult{}
+
 	overrides := metaOverridesForProvider(testProvider())
 	policyClient := policy.NewTestMockClient(t)
 	policyClient.EvaluateModuleFn = func(ctx context.Context, req policy.EvaluationRequest[*proto.PolicyEvaluateModuleRequest_ModuleMetadata]) policy.EvaluationResponse {
 		if req.Target != "./grandchild" {
+			actual[req.Target] = policy.AllowResult
 			return policy.EvaluationResponse{Overall: policy.AllowResult}
 		}
+		actual[req.Target] = policy.DenyResult
 		return policy.EvaluationResponse{
 			Overall: policy.DenyResult,
 			Diagnostics: policy.Diagnostics{
@@ -315,13 +324,25 @@ func TestInit_WithNestedModulePolicyDiagnostics(t *testing.T) {
 	if !policyClient.EvaluateModuleCalled {
 		t.Fatal("expected EvaluateModule to be called")
 	}
+	if diff := cmp.Diff(expected, actual); diff != "" {
+		t.Fatalf("unexpected module policy evaluation results:\n%s", diff)
+	}
 
 	stderr := output.Stderr()
-	if !strings.Contains(stderr, "on modules/child/main.tf line 12:") {
-		t.Fatalf("expected nested module diagnostic to point at modules/child/main.tf:12, got:\n%s", stderr)
-	}
-	if !strings.Contains(stderr, `12: module "nested" {`) {
-		t.Fatalf("expected nested module snippet in diagnostics, got:\n%s", stderr)
+	expectedStderr := `
+Error: nested module policy denied
+
+  on modules/child/main.tf line 12:
+  12: module "nested" {
+
+
+Error: Policy evaluation failed
+
+Module download blocked due to policy violations. Please review other
+diagnostics for details.
+`
+	if diff := cmp.Diff(expectedStderr, stderr); diff != "" {
+		t.Fatalf("unexpected stderr:\n%s\nexpected:\n%s\n diff:\n%s", stderr, expectedStderr, diff)
 	}
 }
 

--- a/internal/command/init_policy_test.go
+++ b/internal/command/init_policy_test.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"slices"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -64,6 +65,52 @@ func TestInit_WithModulePolicy(t *testing.T) {
 
 	if got, want := policyClient.EvaluateModuleRequest.Meta.Version, ""; got != want {
 		t.Fatalf("wrong module version\ngot:  %q\nwant: %q", got, want)
+	}
+}
+
+func TestInit_WithPolicyClientStopAfterInit(t *testing.T) {
+	td := t.TempDir()
+	testCopyDir(t, testFixturePath("dynamic-module-sources/local-source-with-variable"), td)
+	t.Chdir(td)
+
+	ui := new(cli.MockUi)
+	view, done := testView(t)
+
+	overrides := metaOverridesForProvider(testProvider())
+	policyClient := policy.NewTestMockClient(t)
+	var stopCalled atomic.Bool
+	var policyEvaluated atomic.Bool
+	policyClient.StopFn = func() {
+		stopCalled.Store(true)
+	}
+	policyClient.EvaluateModuleFn = func(ctx context.Context, req policy.EvaluationRequest[*proto.PolicyEvaluateModuleRequest_ModuleMetadata]) policy.EvaluationResponse {
+		policyEvaluated.Store(true)
+		if stopCalled.Load() {
+			t.Fatal("policy client Stop was called before init finished")
+		}
+		return policy.EvaluationResponse{Overall: policy.AllowResult}
+	}
+	overrides.PolicyClient = policyClient
+
+	c := &InitCommand{
+		Meta: Meta{
+			testingOverrides:          overrides,
+			Ui:                        ui,
+			View:                      view,
+			AllowExperimentalFeatures: true,
+		},
+	}
+
+	code := c.Run([]string{"-policies", td, "-var", "module_name=example"})
+	output := done(t)
+	if code != 0 {
+		t.Fatalf("got exit status %d; want 0\nstderr:\n%s\n\nstdout:\n%s", code, output.Stderr(), output.Stdout())
+	}
+	if !policyEvaluated.Load() {
+		t.Fatal("expected module policy evaluation to be called during init")
+	}
+	if !stopCalled.Load() {
+		t.Fatal("expected policy client Stop to be called after init")
 	}
 }
 

--- a/internal/command/init_run.go
+++ b/internal/command/init_run.go
@@ -164,9 +164,9 @@ func (c *InitCommand) run(initArgs *arguments.Init, view views.Init) int {
 		var policyDiags policy.Diagnostics
 		var stopClient func()
 		policyClient, policyDiags, stopClient = c.PolicyClient(ctx, initArgs.PolicyPaths)
-		defer stopClient()
 		view.PolicyResults(nil, policyDiags)
 		if policyDiags.HasErrors() {
+			stopClient()
 			view.Diagnostics(diags)
 			return 1
 		}
@@ -260,7 +260,7 @@ Please use \"terraform state migrate -upgrade\" to upgrade the state store provi
 		}
 
 		// Use alteredPreviousLocks, which may contain an additional lock supplied from the -state-provider-lock-file flag
-		configProvidersOutput, pssLocks, safeInitAction, stateStoreProviderAuthResult, configProviderDiags = c.getProvidersFromPSSConfig(ctx, rootModEarly, alteredPreviousLocks, allowUpgrade, initArgs.PluginPath, initArgs.Lockfile, view, providerHook)
+		configProvidersOutput, pssLocks, safeInitAction, stateStoreProviderAuthResult, configProviderDiags = c.getProvidersFromPSSConfig(ctx, rootModEarly, alteredPreviousLocks, allowUpgrade, initArgs.PluginPath, initArgs.Lockfile, view)
 		diags = diags.Append(configProviderDiags)
 		if configProviderDiags.HasErrors() {
 			view.PolicyResults(policyResults, nil)

--- a/internal/command/init_run.go
+++ b/internal/command/init_run.go
@@ -164,9 +164,11 @@ func (c *InitCommand) run(initArgs *arguments.Init, view views.Init) int {
 		var policyDiags policy.Diagnostics
 		var stopClient func()
 		policyClient, policyDiags, stopClient = c.PolicyClient(ctx, initArgs.PolicyPaths)
+		defer stopClient()
 		view.PolicyResults(nil, policyDiags)
+		// if there has been any errors when setting up the policy client, we log them
+		// and return early, as a failure to set up the policy client should terminate the init operation
 		if policyDiags.HasErrors() {
-			stopClient()
 			view.Diagnostics(diags)
 			return 1
 		}

--- a/internal/command/meta_policy.go
+++ b/internal/command/meta_policy.go
@@ -18,6 +18,7 @@ import (
 	"github.com/hashicorp/terraform/internal/plans"
 	"github.com/hashicorp/terraform/internal/policy"
 	"github.com/hashicorp/terraform/internal/policy/proto"
+	"github.com/hashicorp/terraform/internal/providercache"
 	"github.com/hashicorp/terraform/internal/tfdiags"
 	"github.com/hashicorp/terraform/version"
 )
@@ -114,6 +115,8 @@ func (c *Meta) PolicyClient(ctx context.Context, policyPaths []string) (policy.C
 	return client, diags, closer
 }
 
+var _ initwd.ModuleInstallHook = &policyModuleInstallHook{}
+
 // policyModuleInstallHook enables policy evaluation during module installation.
 type policyModuleInstallHook struct {
 	initwd.ModuleInstallHookImpl
@@ -174,6 +177,8 @@ func (h *policyModuleInstallHook) ModuleSourceResolved(ctx context.Context, req 
 	}
 	return nil
 }
+
+var _ providercache.InstallerHook = &providerPolicyHook{}
 
 // providerPolicyHook enables policy evaluation during provider installation.
 type providerPolicyHook struct {

--- a/internal/command/meta_policy.go
+++ b/internal/command/meta_policy.go
@@ -40,7 +40,8 @@ func (c *Meta) PolicyClient(ctx context.Context, policyPaths []string) (policy.C
 
 	// Use a pre-initialized client for tests if one is available
 	if c.testingOverrides != nil {
-		if client := c.testingOverrides.PolicyClient; client != nil {
+		client = c.testingOverrides.PolicyClient
+		if client != nil {
 			return client, nil, closer
 		}
 	}
@@ -209,7 +210,7 @@ func (p *providerPolicyHook) ProviderVersionSelected(ctx context.Context, provid
 	providerConfig := p.rootModule.ProviderConfigs[provider.Type]
 
 	p.policyResults.AddProvider(addr, result, providerConfig)
-
+	log.Println("[DEBUG] init: policy result for provider", provider.String(), version, "overall", result.Overall)
 	if result.Overall != policy.AllowResult {
 		return fmt.Errorf("Provider download blocked due to policy violations. Please review other diagnostics for details.")
 	}

--- a/internal/command/plan.go
+++ b/internal/command/plan.go
@@ -88,6 +88,18 @@ func (c *PlanCommand) Run(rawArgs []string) int {
 		return 1
 	}
 
+	if len(args.PolicyPaths) > 0 {
+		client, policyDiags, stopClient := c.PolicyClient(context.Background(), args.PolicyPaths)
+		// if there has been any errors when setting up the policy client, we log them but
+		// we still proceed with the operation, as a failure to set up the policy client
+		// should not prevent the plan operation from running
+		if opReq.View != nil && policyDiags != nil {
+			opReq.View.PolicyResults(nil, policyDiags)
+		}
+		opReq.PolicyClient = client
+		defer stopClient()
+	}
+
 	// Collect variable value and add them to the operation request
 	var varDiags tfdiags.Diagnostics
 	opReq.Variables, varDiags = args.Vars.CollectValues(func(filename string, src []byte) {
@@ -178,18 +190,6 @@ func (c *PlanCommand) OperationRequest(be backendrun.OperationsBackend, view vie
 	if err != nil {
 		diags = diags.Append(fmt.Errorf("Failed to initialize config loader: %s", err))
 		return nil, diags
-	}
-
-	if len(policyPaths) > 0 {
-		client, policyDiags, stopClient := c.PolicyClient(context.Background(), policyPaths)
-		// if there has been any errors when setting up the policy client, we'll log them
-		if opReq.View != nil && policyDiags != nil {
-			opReq.View.PolicyResults(nil, policyDiags)
-		}
-		opReq.PolicyClient = client
-		if policyDiags.HasErrors() {
-			stopClient()
-		}
 	}
 
 	return opReq, diags

--- a/internal/command/plan.go
+++ b/internal/command/plan.go
@@ -187,7 +187,9 @@ func (c *PlanCommand) OperationRequest(be backendrun.OperationsBackend, view vie
 			opReq.View.PolicyResults(nil, policyDiags)
 		}
 		opReq.PolicyClient = client
-		defer stopClient()
+		if policyDiags.HasErrors() {
+			stopClient()
+		}
 	}
 
 	return opReq, diags

--- a/internal/command/plan_policy_test.go
+++ b/internal/command/plan_policy_test.go
@@ -816,8 +816,7 @@ func TestPlan_WithPolicyClientStopAfterPlan(t *testing.T) {
 		}
 		return policy.EvaluationResponse{Overall: policy.AllowResult}
 	}
-	overs := overrides
-	overs.PolicyClient = policyClient
+	overrides.PolicyClient = policyClient
 	c := &PlanCommand{
 		Meta: Meta{
 			testingOverrides:          overs,

--- a/internal/command/plan_policy_test.go
+++ b/internal/command/plan_policy_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"sync/atomic"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -783,6 +784,57 @@ func TestPlan_WithPolicySuccessInfoJSON(t *testing.T) {
 	}
 
 	checkGoldenReference(t, output, "plan-policy")
+}
+
+func TestPlan_WithPolicyClientStopAfterPlan(t *testing.T) {
+	td := t.TempDir()
+	testCopyDir(t, testFixturePath("plan"), td)
+	t.Chdir(td)
+	policyCode := `		resource_policy "resource_type" "policy_name" {
+		  enforce_attrs {
+		    key = attr.value == "foo"
+		  }
+		}
+	`
+	if err := os.WriteFile("policy.hcl", []byte(policyCode), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	p := planFixtureProvider()
+	view, done := testView(t)
+	overrides := metaOverridesForProvider(p)
+	policyClient := policy.NewTestMockClient(t)
+	var stopCalled atomic.Bool
+	var policyEvaluated atomic.Bool
+	policyClient.StopFn = func() {
+		stopCalled.Store(true)
+	}
+	policyClient.EvaluateFn = func(ctx context.Context, req policy.EvaluationRequest[*proto.PolicyEvaluateResourceRequest_ResourceMetadata]) policy.EvaluationResponse {
+		policyEvaluated.Store(true)
+		if stopCalled.Load() {
+			t.Fatal("policy client Stop was called before the plan finished")
+		}
+		return policy.EvaluationResponse{Overall: policy.AllowResult}
+	}
+	overs := overrides
+	overs.PolicyClient = policyClient
+	c := &PlanCommand{
+		Meta: Meta{
+			testingOverrides:          overs,
+			View:                      view,
+			AllowExperimentalFeatures: true,
+		},
+	}
+
+	args := []string{"-policies", td}
+	code := c.Run(append(args, "-no-color"))
+	output := done(t)
+	if code != 0 {
+		t.Fatalf("bad: %d\n\n%s", code, output.All())
+	}
+	if !policyEvaluated.Load() {
+		t.Fatal("expected policy evaluation to be called during plan")
+	}
 }
 
 func TestPlan_WithPolicySetupFailure(t *testing.T) {

--- a/internal/command/plan_policy_test.go
+++ b/internal/command/plan_policy_test.go
@@ -835,6 +835,9 @@ func TestPlan_WithPolicyClientStopAfterPlan(t *testing.T) {
 	if !policyEvaluated.Load() {
 		t.Fatal("expected policy evaluation to be called during plan")
 	}
+	if !stopCalled.Load() {
+		t.Fatal("expected policy client Stop to be called after plan")
+	}
 }
 
 func TestPlan_WithPolicySetupFailure(t *testing.T) {

--- a/internal/command/plan_policy_test.go
+++ b/internal/command/plan_policy_test.go
@@ -819,7 +819,7 @@ func TestPlan_WithPolicyClientStopAfterPlan(t *testing.T) {
 	overrides.PolicyClient = policyClient
 	c := &PlanCommand{
 		Meta: Meta{
-			testingOverrides:          overs,
+			testingOverrides:          overrides,
 			View:                      view,
 			AllowExperimentalFeatures: true,
 		},

--- a/internal/policy/client.go
+++ b/internal/policy/client.go
@@ -265,6 +265,7 @@ func (c *client) EvaluateModule(ctx context.Context, req EvaluationRequest[*prot
 }
 
 func (c *client) Stop() {
+	log.Println("[DEBUG] stopping policy client")
 	if c.cbServer != nil {
 		c.cbServer.Stop()
 	}

--- a/internal/policy/mock.go
+++ b/internal/policy/mock.go
@@ -43,6 +43,7 @@ type MockClient struct {
 
 	// Stop method tracking
 	StopCalled bool
+	StopFn     func()
 }
 
 func (p *MockClient) beginWrite() func() {
@@ -117,4 +118,7 @@ func (p *MockClient) EvaluateModule(ctx context.Context, r EvaluationRequest[*pr
 func (p *MockClient) Stop() {
 	defer p.beginWrite()()
 	p.StopCalled = true
+	if p.StopFn != nil {
+		p.StopFn()
+	}
 }


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

This PR tightens a few policy-related behaviors and adds regression coverage around those paths.

## Changes
- Avoid stopping the policy client immediately after setup in `plan`, `apply`, and `init`; only stop it early when policy setup itself fails.
- Remove provider policy hooks from the state-store/PSS provider installation path, since that flow is mutually exclusive with policy evaluation.
- Generalize `getProviders` to accept the installer hook interface directly and add compile-time interface assertions for the 

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.16.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [ ] This change is not user-facing.
