### PR TITLE
test: Fix issue with interleaved stderr and stdout in `TestPlan_WithPolicySetupFailure`

### DIFF
--- a/internal/command/plan_policy_test.go
+++ b/internal/command/plan_policy_test.go
@@ -824,12 +824,7 @@ func TestPlan_WithPolicySetupFailure(t *testing.T) {
 
 	// we still display the policy output
 	// and the plan still succeeds
-	expectedOut := `
-Error: Failed to connect to policy engine
-
-Failed to connect to policy engine: failed to connect to plugin: exec:
-"tfpolicy-plugin": executable file not found in $PATH.
-data.test_data_source.a: Reading...
+	expectedStdOut := `data.test_data_source.a: Reading...
 data.test_data_source.a: Read complete after 0s [id=zzzzz]
 
 Terraform used the selected providers to generate the following execution
@@ -856,8 +851,19 @@ Note: You didn't use the -out option to save this plan, so Terraform can't
 guarantee to take exactly these actions if you run "terraform apply" now.
 `
 
-	if diff := cmp.Diff(expectedOut, output.All()); diff != "" {
-		t.Fatalf("unexpected output:\n%s", diff)
+	if diff := cmp.Diff(expectedStdOut, output.Stdout()); diff != "" {
+		t.Fatalf("unexpected stdout output:\n%s", diff)
+	}
+
+	expectedStdErr := `
+Error: Failed to connect to policy engine
+
+Failed to connect to policy engine: failed to connect to plugin: exec:
+"tfpolicy-plugin": executable file not found in $PATH.
+`
+
+	if diff := cmp.Diff(expectedStdErr, output.Stderr()); diff != "" {
+		t.Fatalf("unexpected stderr output:\n%s", diff)
 	}
 }
 


### PR DESCRIPTION
Addressing a test failure [seen here](https://github.com/hashicorp/terraform/actions/runs/27379234840/job/80911371138?pr=38714):

```
--- FAIL: TestPlan_WithPolicySetupFailure (0.02s)
    plan_policy_test.go:860: unexpected output:
          (
          	"""
        + 	data.test_data_source.a: Reading...
        + 	data.test_data_source.a: Read complete after 0s [id=zzzzz]
          	
          	Error: Failed to connect to policy engine
          	
          	Failed to connect to policy engine: failed to connect to plugin: exec:
          	"tfpolicy-plugin": executable file not found in $PATH.
        - 	data.test_data_source.a: Reading...
        - 	data.test_data_source.a: Read complete after 0s [id=zzzzz]
          	
          	Terraform used the selected providers to generate the following execution
          	... // 22 identical lines
          	"""
          )
{"@level":"info","@message":"Terraform 1.16.0-dev","@module":"terraform.ui","@timestamp":"2026-06-11T21:44:04.757846Z","terraform":"1.16.0-dev","type":"version","ui":"1.3"}
{"@level":"error","@message":"Error: Failed to connect to policy engine","@module":"terraform.ui","@policy":"true","@timestamp":"2026-06-11T21:44:04.758352Z","policy_diagnostic":{"severity":"error","summary":"Failed to connect to policy engine","detail":"Failed to connect to policy engine: failed to connect to plugin: exec: \"tfpolicy-plugin\": executable file not found in $PATH."},"policy_metadata":{},"result":"SetupErrorResult","type":"policy_diagnostic"}
{"@level":"info","@message":"data.test_data_source.a: Refreshing...","@module":"terraform.ui","@timestamp":"2026-06-11T21:44:04.763350Z","hook":{"resource":{"addr":"data.test_data_source.a","module":"","resource":"data.test_data_source.a","implied_provider":"test","resource_type":"test_data_source","resource_name":"a","resource_key":null},"action":"read"},"type":"apply_start"}
{"@level":"info","@message":"data.test_data_source.a: Refresh complete after 0s [id=zzzzz]","@module":"terraform.ui","@timestamp":"2026-06-11T21:44:04.765650Z","hook":{"resource":{"addr":"data.test_data_source.a","module":"","resource":"data.test_data_source.a","implied_provider":"test","resource_type":"test_data_source","resource_name":"a","resource_key":null},"action":"read","id_key":"id","id_value":"zzzzz","elapsed_seconds":0},"type":"apply_complete"}
{"@level":"info","@message":"test_instance.foo: Plan to create","@module":"terraform.ui","@timestamp":"2026-06-11T21:44:04.769343Z","change":{"resource":{"addr":"test_instance.foo","module":"","resource":"test_instance.foo","implied_provider":"test","resource_type":"test_instance","resource_name":"foo","resource_key":null},"action":"create"},"type":"planned_change"}
{"@level":"info","@message":"Plan: 1 to add, 0 to change, 0 to destroy.","@module":"terraform.ui","@timestamp":"2026-06-11T21:44:04.769378Z","changes":{"add":1,"change":0,"import":0,"remove":0,"action_invocation":0,"operation":"plan"},"type":"change_summary"}

FAIL
```

This error occurs due to the `(TestOutput) All()` method interleaving stdout and stderr. This is a problem specific to TestOutput and doesn't reflect how output is shown to end users.

https://github.com/hashicorp/terraform/blob/c2e70631116df3ac11a44a68dc6e5c5d1f5b4f5a/internal/terminal/testing.go#L160-L168

<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.16.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
