### PR TITLE
add Mermaid graph format to terraform graph command

### DIFF
--- a/.changes/v1.16/ENHANCEMENTS-20260618-120930.yaml
+++ b/.changes/v1.16/ENHANCEMENTS-20260618-120930.yaml
@@ -1,0 +1,6 @@
+kind: ENHANCEMENTS
+body: The 'terraform graph' command now accepts a -format flag, and can output graphs
+  in Mermaid format
+time: 2026-06-18T12:09:30.518397+01:00
+custom:
+  Issue: "38719"

--- a/internal/command/arguments/graph.go
+++ b/internal/command/arguments/graph.go
@@ -25,6 +25,9 @@ type Graph struct {
 	// Plan is the path to a saved plan file to render as a graph.
 	Plan string
 
+	// Format is the output format to emit (dot or mermaid).
+	Format string
+
 	// Vars are the variable-related flags (-var, -var-file).
 	Vars *Vars
 }
@@ -42,6 +45,7 @@ func ParseGraph(args []string) (*Graph, tfdiags.Diagnostics) {
 	cmdFlags := extendedFlagSet("graph", nil, nil, graph.Vars)
 	cmdFlags.BoolVar(&graph.DrawCycles, "draw-cycles", false, "draw-cycles")
 	cmdFlags.StringVar(&graph.GraphType, "type", "", "type")
+	cmdFlags.StringVar(&graph.Format, "format", "dot", "format")
 	cmdFlags.IntVar(&graph.ModuleDepth, "module-depth", -1, "module-depth")
 	cmdFlags.BoolVar(&graph.Verbose, "verbose", false, "verbose")
 	cmdFlags.StringVar(&graph.Plan, "plan", "", "plan")

--- a/internal/command/arguments/graph_test.go
+++ b/internal/command/arguments/graph_test.go
@@ -19,6 +19,7 @@ func TestParseGraph_valid(t *testing.T) {
 		"defaults": {
 			nil,
 			&Graph{
+				Format:      "dot",
 				ModuleDepth: -1,
 				Vars:        &Vars{},
 			},
@@ -26,6 +27,7 @@ func TestParseGraph_valid(t *testing.T) {
 		"plan type": {
 			[]string{"-type=plan"},
 			&Graph{
+				Format:      "dot",
 				GraphType:   "plan",
 				ModuleDepth: -1,
 				Vars:        &Vars{},
@@ -34,6 +36,7 @@ func TestParseGraph_valid(t *testing.T) {
 		"apply type": {
 			[]string{"-type=apply"},
 			&Graph{
+				Format:      "dot",
 				GraphType:   "apply",
 				ModuleDepth: -1,
 				Vars:        &Vars{},
@@ -43,6 +46,7 @@ func TestParseGraph_valid(t *testing.T) {
 			[]string{"-draw-cycles", "-type=plan"},
 			&Graph{
 				DrawCycles:  true,
+				Format:      "dot",
 				GraphType:   "plan",
 				ModuleDepth: -1,
 				Vars:        &Vars{},
@@ -51,6 +55,7 @@ func TestParseGraph_valid(t *testing.T) {
 		"plan file": {
 			[]string{"-plan=tfplan"},
 			&Graph{
+				Format:      "dot",
 				Plan:        "tfplan",
 				ModuleDepth: -1,
 				Vars:        &Vars{},
@@ -59,6 +64,7 @@ func TestParseGraph_valid(t *testing.T) {
 		"verbose": {
 			[]string{"-verbose"},
 			&Graph{
+				Format:      "dot",
 				Verbose:     true,
 				ModuleDepth: -1,
 				Vars:        &Vars{},
@@ -67,6 +73,7 @@ func TestParseGraph_valid(t *testing.T) {
 		"module-depth": {
 			[]string{"-module-depth=2"},
 			&Graph{
+				Format:      "dot",
 				ModuleDepth: 2,
 				Vars:        &Vars{},
 			},
@@ -74,6 +81,7 @@ func TestParseGraph_valid(t *testing.T) {
 		"all flags": {
 			[]string{"-draw-cycles", "-type=plan-destroy", "-plan=tfplan", "-verbose", "-module-depth=3"},
 			&Graph{
+				Format:      "dot",
 				DrawCycles:  true,
 				GraphType:   "plan-destroy",
 				Plan:        "tfplan",
@@ -108,6 +116,7 @@ func TestParseGraph_invalid(t *testing.T) {
 		"unknown flag": {
 			[]string{"-wat"},
 			&Graph{
+				Format:      "dot",
 				ModuleDepth: -1,
 				Vars:        &Vars{},
 			},
@@ -122,6 +131,7 @@ func TestParseGraph_invalid(t *testing.T) {
 		"positional argument": {
 			[]string{"extra"},
 			&Graph{
+				Format:      "dot",
 				ModuleDepth: -1,
 				Vars:        &Vars{},
 			},
@@ -136,6 +146,7 @@ func TestParseGraph_invalid(t *testing.T) {
 		"too many positional arguments": {
 			[]string{"bad", "bad"},
 			&Graph{
+				Format:      "dot",
 				ModuleDepth: -1,
 				Vars:        &Vars{},
 			},

--- a/internal/command/graph.go
+++ b/internal/command/graph.go
@@ -120,7 +120,17 @@ func (c *GraphCommand) Run(rawArgs []string) int {
 			}
 
 			g := fullG.ResourceGraph()
-			return c.resourceOnlyGraph(g)
+
+			switch args.Format {
+			case "mermaid":
+				return c.resourceOnlyGraphMermaid(g)
+			case "", "dot":
+				return c.resourceOnlyGraph(g)
+			default:
+				c.Ui.Error(fmt.Sprintf("Unsupported graph format: %s", args.Format))
+				return 1
+			}
+
 		} else {
 			args.GraphType = "apply"
 		}
@@ -174,11 +184,23 @@ func (c *GraphCommand) Run(rawArgs []string) int {
 		return 1
 	}
 
-	graphStr, err := terraform.GraphDot(g, &dag.DotOpts{
+	var graphStr string
+
+	opts := &dag.DotOpts{
 		DrawCycles: args.DrawCycles,
 		MaxDepth:   args.ModuleDepth,
 		Verbose:    args.Verbose,
-	})
+	}
+
+	switch args.Format {
+	case "mermaid":
+		graphStr, err = terraform.GraphMermaid(g, opts)
+	case "", "dot":
+		graphStr, err = terraform.GraphDot(g, opts)
+	default:
+		c.Ui.Error(fmt.Sprintf("Unsupported graph format: %s", args.Format))
+		return 1
+	}
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf("Error converting graph: %s", err))
 		return 1
@@ -187,7 +209,7 @@ func (c *GraphCommand) Run(rawArgs []string) int {
 	if diags.HasErrors() {
 		// For this command we only show diagnostics if there are errors,
 		// because printing out naked warnings could upset a naive program
-		// consuming our dot output.
+		// consuming our graph output.
 		c.showDiagnostics(diags)
 		return 1
 	}
@@ -289,6 +311,81 @@ func (c *GraphCommand) resourceOnlyGraph(graph addrs.DirectedGraph[addrs.ConfigR
 	return 0
 }
 
+func (c *GraphCommand) resourceOnlyGraphMermaid(graph addrs.DirectedGraph[addrs.ConfigResource]) int {
+	out := c.Streams.Stdout.File
+
+	// use left-to-right layout by default
+	fmt.Fprintln(out, "flowchart LR")
+
+	// collect and sort addresses similar to resourceOnlyGraph for deterministic output
+	allAddrs := graph.AllNodes()
+	if len(allAddrs) == 0 {
+		fmt.Fprintln(out, "  %% This configuration does not contain any resources.")
+		fmt.Fprintln(out, "  %% For a more detailed graph, try: terraform graph -type=plan")
+		return 0
+	}
+
+	addrsOrder := make([]addrs.ConfigResource, 0, len(allAddrs))
+	for _, addr := range allAddrs {
+		addrsOrder = append(addrsOrder, addr)
+	}
+	sort.Slice(addrsOrder, func(i, j int) bool {
+		iAddr, jAddr := addrsOrder[i], addrsOrder[j]
+		iModStr, jModStr := iAddr.Module.String(), jAddr.Module.String()
+		switch {
+		case iModStr != jModStr:
+			return iModStr < jModStr
+		default:
+			iRes, jRes := iAddr.Resource, jAddr.Resource
+			switch {
+			case iRes.Mode != jRes.Mode:
+				return iRes.Mode == addrs.DataResourceMode
+			case iRes.Type != jRes.Type:
+				return iRes.Type < jRes.Type
+			default:
+				return iRes.Name < jRes.Name
+			}
+		}
+	})
+
+	currentMod := addrs.RootModule
+	for _, addr := range addrsOrder {
+		if !addr.Module.Equal(currentMod) {
+			if !currentMod.IsRoot() {
+				fmt.Fprintln(out, "  end")
+			}
+			currentMod = addr.Module
+
+			fmt.Fprintf(out, "  subgraph %s\n", currentMod.String())
+		}
+		id := addr.String()
+		label := addr.Resource.String()
+		if currentMod.IsRoot() {
+			fmt.Fprintf(out, "  %s[%s]\n", id, dag.MermaidEscapeLabel(label))
+		} else {
+			fmt.Fprintf(out, "    %s[%s]\n", id, dag.MermaidEscapeLabel(label))
+		}
+	}
+	if !currentMod.IsRoot() {
+		fmt.Fprintln(out, "  end")
+	}
+
+	// emit edges
+	for _, sourceAddr := range addrsOrder {
+		deps := graph.DirectDependenciesOf(sourceAddr)
+		srcID := sourceAddr.String()
+		for _, targetAddr := range addrsOrder {
+			if !deps.Has(targetAddr) {
+				continue
+			}
+			tgtID := targetAddr.String()
+			fmt.Fprintf(out, "  %s --> %s\n", srcID, tgtID)
+		}
+	}
+
+	return 0
+}
+
 func (c *GraphCommand) Help() string {
 	helpText := `
 Usage: terraform [global options] graph [options]
@@ -334,6 +431,9 @@ Options:
                       to the default files terraform.tfvars and *.auto.tfvars.
                       Use this option more than once to include more than one
                       variables file.
+
+  -format=FORMAT      Output format for the graph. Supported values are
+                      dot (default) and mermaid.
 `
 	return strings.TrimSpace(helpText)
 }

--- a/internal/command/graph_mermaid_test.go
+++ b/internal/command/graph_mermaid_test.go
@@ -4,10 +4,21 @@
 package command
 
 import (
+	"context"
+	"os"
 	"strings"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/cli"
+	"github.com/zclconf/go-cty/cty"
+
+	"github.com/hashicorp/terraform/internal/addrs"
+	"github.com/hashicorp/terraform/internal/configs/configload"
+	"github.com/hashicorp/terraform/internal/configs/configschema"
+	"github.com/hashicorp/terraform/internal/initwd"
+	"github.com/hashicorp/terraform/internal/providers"
+	"github.com/hashicorp/terraform/internal/registry"
 	"github.com/hashicorp/terraform/internal/terminal"
 )
 
@@ -34,5 +45,84 @@ func TestGraph_planPhase_mermaid(t *testing.T) {
 	output := closeStreams(t)
 	if !strings.Contains(output.Stdout(), "flowchart") && !strings.Contains(output.Stdout(), "-->") {
 		t.Fatalf("doesn't look like mermaid graph:\n%s\n\nstderr:\n%s", output.Stdout(), output.Stderr())
+	}
+}
+
+// TestGraph_resourcesOnly_mermaid is a golden-fixture test for the default
+// (resources-only) graph rendered as Mermaid flowchart syntax.  It uses the
+// same "graph-interesting" fixture as TestGraph_resourcesOnly so the two
+// tests document equivalent output for the dot and mermaid formats.
+func TestGraph_resourcesOnly_mermaid(t *testing.T) {
+	wd := tempWorkingDirFixture(t, "graph-interesting")
+	t.Chdir(wd.RootModuleDir())
+
+	loader, cleanupLoader := configload.NewLoaderForTests(t)
+	t.Cleanup(cleanupLoader)
+	err := os.MkdirAll(".terraform/modules", 0700)
+	if err != nil {
+		t.Fatal(err)
+	}
+	inst := initwd.NewModuleInstaller(".terraform/modules", loader, registry.NewClient(nil, nil), nil)
+	_, instDiags := inst.InstallModules(context.Background(), ".", "tests", true, false)
+	if instDiags.HasErrors() {
+		t.Fatal(instDiags.Err())
+	}
+
+	p := testProvider()
+	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
+		ResourceTypes: map[string]providers.Schema{
+			"foo": {
+				Body: &configschema.Block{
+					Attributes: map[string]*configschema.Attribute{
+						"arg": {
+							Type:     cty.String,
+							Optional: true,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	ui := cli.NewMockUi()
+	streams, closeStreams := terminal.StreamsForTesting(t)
+	c := &GraphCommand{
+		Meta: Meta{
+			testingOverrides: &testingOverrides{
+				Providers: map[addrs.Provider]providers.Factory{
+					addrs.NewDefaultProvider("foo"): providers.FactoryFixed(p),
+				},
+			},
+			Ui:      ui,
+			Streams: streams,
+		},
+	}
+
+	args := []string{"-format=mermaid"}
+	if code := c.Run(args); code != 0 {
+		output := closeStreams(t)
+		t.Fatalf("unexpected error: \n%s", output.Stderr())
+	}
+
+	output := closeStreams(t)
+	gotGraph := strings.TrimSpace(output.Stdout())
+	// Golden fixture: the resources-only Mermaid graph for the graph-interesting
+	// configuration.  Node IDs are the full config addresses; labels are the
+	// resource-local addresses (type.name).  module.child resources are wrapped
+	// in a Mermaid subgraph block.
+	wantGraph := strings.TrimSpace(`
+flowchart LR
+  foo.bar["foo.bar"]
+  foo.baz["foo.baz"]
+  foo.boop["foo.boop"]
+  subgraph module.child
+    module.child.foo.bleep["foo.bleep"]
+  end
+  foo.baz --> foo.bar
+  foo.boop --> module.child.foo.bleep
+  module.child.foo.bleep --> foo.bar
+`)
+	if diff := cmp.Diff(wantGraph, gotGraph); diff != "" {
+		t.Fatalf("wrong mermaid graph output\n%s", diff)
 	}
 }

--- a/internal/command/graph_mermaid_test.go
+++ b/internal/command/graph_mermaid_test.go
@@ -1,0 +1,38 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package command
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/cli"
+	"github.com/hashicorp/terraform/internal/terminal"
+)
+
+func TestGraph_planPhase_mermaid(t *testing.T) {
+	td := t.TempDir()
+	testCopyDir(t, testFixturePath("graph"), td)
+	t.Chdir(td)
+
+	ui := new(cli.MockUi)
+	streams, closeStreams := terminal.StreamsForTesting(t)
+	c := &GraphCommand{
+		Meta: Meta{
+			testingOverrides: metaOverridesForProvider(applyFixtureProvider()),
+			Ui:               ui,
+			Streams:          streams,
+		},
+	}
+
+	args := []string{"-type=plan", "-format=mermaid"}
+	if code := c.Run(args); code != 0 {
+		t.Fatalf("bad: \n%s", ui.ErrorWriter.String())
+	}
+
+	output := closeStreams(t)
+	if !strings.Contains(output.Stdout(), "flowchart") && !strings.Contains(output.Stdout(), "-->") {
+		t.Fatalf("doesn't look like mermaid graph:\n%s\n\nstderr:\n%s", output.Stdout(), output.Stderr())
+	}
+}

--- a/internal/dag/graph.go
+++ b/internal/dag/graph.go
@@ -367,6 +367,11 @@ func (g *Graph) Dot(opts *DotOpts) []byte {
 	return newMarshalGraph("", g).Dot(opts)
 }
 
+// Mermaid returns a Mermaid flowchart formatted representation of the Graph.
+func (g *Graph) Mermaid(opts *DotOpts) []byte {
+	return newMarshalGraph("", g).Mermaid(opts)
+}
+
 // VertexName returns the name of a vertex.
 func VertexName(raw Vertex) string {
 	switch v := raw.(type) {

--- a/internal/dag/mermaid.go
+++ b/internal/dag/mermaid.go
@@ -1,0 +1,161 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package dag
+
+import (
+	"bytes"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+func MermaidEscapeLabel(s string) string {
+	// Escape brackets and newlines for Mermaid labels
+	s = strings.ReplaceAll(s, "\n", " ")
+	s = strings.ReplaceAll(s, "\"", "&quot;")
+	return fmt.Sprintf("\"%s\"", s)
+}
+
+// Mermaid produces a Mermaid flowchart representation of the graph.
+// This is a minimal renderer that mirrors the DOT output semantics for
+// nodes and edges
+func (g *marshalGraph) Mermaid(opts *DotOpts) []byte {
+	if opts == nil {
+		opts = &DotOpts{
+			DrawCycles: true,
+			MaxDepth:   -1,
+			Verbose:    true,
+		}
+	}
+
+	var b bytes.Buffer
+
+	// use left-to-right layout by default
+	b.WriteString("flowchart LR\n")
+
+	// Write nodes grouped into subgraphs (if present) to mirror DOT's clustering
+	// behaviour.
+	// Start with the top-level graph
+	g.writeNodes(&b, opts)
+
+	// detect cycle edges
+	cycleEdges := map[string]bool{}
+	if opts.DrawCycles {
+		for _, c := range g.Cycles {
+			if len(c) < 2 {
+				continue
+			}
+			for i, j := 0, 1; i < len(c); i, j = i+1, j+1 {
+				if j >= len(c) {
+					j = 0
+				}
+				src := c[i]
+				tgt := c[j]
+				key := src.ID + "->" + tgt.ID
+				cycleEdges[key] = true
+			}
+		}
+	}
+
+	// emit edges in deterministic order
+	edgeKeys := make([]string, 0, len(g.Edges))
+	edgeMap := make(map[string]*marshalEdge)
+	for _, e := range g.Edges {
+		key := e.Source + "->" + e.Target
+		edgeKeys = append(edgeKeys, key)
+		edgeMap[key] = e
+	}
+	sort.Strings(edgeKeys)
+
+	for _, key := range edgeKeys {
+		e := edgeMap[key]
+		src := g.vertexByID(e.Source)
+		tgt := g.vertexByID(e.Target)
+		if src == nil || tgt == nil {
+			continue
+		}
+
+		b.WriteString(src.ID)
+		b.WriteString(" --> ")
+		b.WriteString(tgt.ID)
+		if cycleEdges[key] {
+			// mark with a CSS class we define below
+			b.WriteString(":::cycle")
+		}
+		b.WriteString("\n")
+	}
+
+	// define cycle class if needed
+	if len(cycleEdges) > 0 {
+		b.WriteString("classDef cycle stroke:#ff0000,stroke-width:2px;\n")
+	}
+
+	return b.Bytes()
+}
+
+func (mg *marshalGraph) writeNodes(b *bytes.Buffer, opts *DotOpts) {
+	// if this is a named subgraph, emit a Mermaid subgraph block.
+	if strings.TrimSpace(mg.Name) != "" {
+		b.WriteString("subgraph ")
+		b.WriteString(mg.Name)
+		b.WriteString("\n")
+	}
+
+	// collect and sort vertices for deterministic output
+	ids := make([]string, 0, len(mg.Vertices))
+	for _, v := range mg.Vertices {
+		ids = append(ids, v.ID)
+	}
+	sort.Strings(ids)
+
+	for _, id := range ids {
+		v := mg.vertexByID(id)
+		if v == nil {
+			continue
+		}
+
+		label := v.Name
+
+		// obtain DOT-style node info if available and merge attributes
+		attrs := map[string]string{}
+		for k, vv := range v.Attrs {
+			attrs[k] = vv
+		}
+
+		// label preference: attrs.label then name
+		if l, ok := attrs["label"]; ok && strings.TrimSpace(l) != "" {
+			label = l
+		}
+
+		// choose Mermaid node shape syntax based on DOT 'shape' attribute
+		shape := strings.ToLower(attrs["shape"]) // may be empty
+
+		var nodeDef string
+		switch shape {
+		case "diamond":
+			nodeDef = fmt.Sprintf("%s{%s}", v.ID, MermaidEscapeLabel(label))
+		case "box", "rectangle", "rect":
+			nodeDef = fmt.Sprintf("%s[%s]", v.ID, MermaidEscapeLabel(label))
+		case "ellipse", "oval":
+			nodeDef = fmt.Sprintf("%s(%s)", v.ID, MermaidEscapeLabel(label))
+		case "circle":
+			nodeDef = fmt.Sprintf("%s((%s))", v.ID, MermaidEscapeLabel(label))
+		default:
+			// default to rectangle
+			nodeDef = fmt.Sprintf("%s[%s]", v.ID, MermaidEscapeLabel(label))
+		}
+
+		b.WriteString(nodeDef)
+		b.WriteString("\n")
+	}
+
+	// recurse into subgraphs
+	for _, sg := range mg.Subgraphs {
+		sg.writeNodes(b, opts)
+	}
+
+	if strings.TrimSpace(mg.Name) != "" {
+		b.WriteString("end\n")
+	}
+}

--- a/internal/dag/mermaid_test.go
+++ b/internal/dag/mermaid_test.go
@@ -1,0 +1,43 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package dag
+
+import (
+	"strings"
+	"testing"
+)
+
+type testVertex struct{ n string }
+
+func (t *testVertex) Name() string { return t.n }
+
+func (t *testVertex) DotNode(title string, opts *DotOpts) *DotNode {
+	return &DotNode{Name: title, Attrs: map[string]string{"label": t.n}}
+}
+
+func TestMermaidBasic(t *testing.T) {
+	g := &Graph{}
+
+	a := &testVertex{n: "a"}
+	b := &testVertex{n: "b"}
+	c := &testVertex{n: "c"}
+
+	g.Add(a)
+	g.Add(b)
+	g.Add(c)
+
+	g.Connect(BasicEdge(a, b))
+	g.Connect(BasicEdge(b, c))
+
+	mg := newMarshalGraph("root", g)
+	out := string(mg.Mermaid(&DotOpts{DrawCycles: true, MaxDepth: -1, Verbose: true}))
+
+	if !strings.Contains(out, "a") || !strings.Contains(out, "b") || !strings.Contains(out, "c") {
+		t.Fatalf("expected nodes a, b, c in output, got: %s", out)
+	}
+
+	if !strings.Contains(out, "-->") {
+		t.Fatalf("expected edges in mermaid output, got: %s", out)
+	}
+}

--- a/internal/terraform/graph_dot.go
+++ b/internal/terraform/graph_dot.go
@@ -10,3 +10,9 @@ import "github.com/hashicorp/terraform/internal/dag"
 func GraphDot(g *Graph, opts *dag.DotOpts) (string, error) {
 	return string(g.Dot(opts)), nil
 }
+
+// GraphMermaid returns the Mermaid flowchart formatting for the given
+// Terraform graph.
+func GraphMermaid(g *Graph, opts *dag.DotOpts) (string, error) {
+	return string(g.Mermaid(opts)), nil
+}


### PR DESCRIPTION
closes #30519 

Adds a new optional `-format=mermaid` flag to the `terraform graph` command, which produces a Mermaid flowchart-type diagram for both resource-only and plan graphs. Without this flag, the DOT format is still produced by default.

GitHub renders Mermaid diagrams embedded in GitHub markdown, such as the text of this PR: see Demo below.

## Implementation

Couple of decisions made here.

There are two codepaths for `terraform graph`: one renders the default resource-only (config) graph, and the other renders all other graph types (plan, plan-refresh-only, plan-destroy, apply). I haven't changed this, so there are now two places where Mermaid graphs are drawn.

Since the Mermaid implementation does not need to maintain compatibility with (very) old versions of the DOT graph, I haven't reimplemented the `GraphNodeDotter` interface.

## Demo

### Resource-only graph

#### DOT format: `terraform graph | dot -Tpng >graph.png`

<img width="2376" height="875" alt="graph2" src="https://github.com/user-attachments/assets/a34ccff4-6a24-49f9-8f6c-8f3e5e751453" />

#### Mermaid format: `terraform graph -format=mermaid`

```mermaid
flowchart LR
  data.aws_availability_zones.available["data.aws_availability_zones.available"]
  data.aws_caller_identity.current["data.aws_caller_identity.current"]
  null_resource.foo["null_resource.foo"]
  subgraph module.dynamodb_table
    module.dynamodb_table.aws_appautoscaling_policy.dynamodb_table_read_policy["aws_appautoscaling_policy.dynamodb_table_read_policy"]
    module.dynamodb_table.aws_appautoscaling_policy.dynamodb_table_write_policy["aws_appautoscaling_policy.dynamodb_table_write_policy"]
    module.dynamodb_table.aws_appautoscaling_target.dynamodb_table_read_target["aws_appautoscaling_target.dynamodb_table_read_target"]
    module.dynamodb_table.aws_appautoscaling_target.dynamodb_table_write_target["aws_appautoscaling_target.dynamodb_table_write_target"]
    module.dynamodb_table.aws_dynamodb_table.my_table["aws_dynamodb_table.my_table"]
  end
  subgraph module.ec2_instance
    module.ec2_instance.data.aws_ami.amazon_linux_2["data.aws_ami.amazon_linux_2"]
    module.ec2_instance.aws_instance.this["aws_instance.this"]
  end
  subgraph module.lambda_execution_role
    module.lambda_execution_role.aws_iam_policy.policy["aws_iam_policy.policy"]
    module.lambda_execution_role.aws_iam_role.role["aws_iam_role.role"]
    module.lambda_execution_role.aws_iam_role_policy.inline_policy["aws_iam_role_policy.inline_policy"]
    module.lambda_execution_role.aws_iam_role_policy_attachment.policy_attachment["aws_iam_role_policy_attachment.policy_attachment"]
  end
  subgraph module.network_firewall
    module.network_firewall.aws_networkfirewall_firewall.firewall["aws_networkfirewall_firewall.firewall"]
    module.network_firewall.aws_networkfirewall_firewall_policy.policy["aws_networkfirewall_firewall_policy.policy"]
    module.network_firewall.aws_networkfirewall_logging_configuration.logging["aws_networkfirewall_logging_configuration.logging"]
    module.network_firewall.aws_networkfirewall_rule_group.rule_groups["aws_networkfirewall_rule_group.rule_groups"]
  end
  subgraph module.secure_bucket
    module.secure_bucket.aws_s3_bucket.secure_bucket["aws_s3_bucket.secure_bucket"]
    module.secure_bucket.aws_s3_bucket_logging.bucket_logging["aws_s3_bucket_logging.bucket_logging"]
    module.secure_bucket.aws_s3_bucket_policy.bucket_policy["aws_s3_bucket_policy.bucket_policy"]
    module.secure_bucket.aws_s3_bucket_public_access_block.secure_bucket_access_block["aws_s3_bucket_public_access_block.secure_bucket_access_block"]
    module.secure_bucket.aws_s3_bucket_server_side_encryption_configuration.bucket_encryption["aws_s3_bucket_server_side_encryption_configuration.bucket_encryption"]
    module.secure_bucket.aws_s3_bucket_versioning.bucket_versioning["aws_s3_bucket_versioning.bucket_versioning"]
  end
  module.ec2_instance.aws_instance.this --> module.ec2_instance.data.aws_ami.amazon_linux_2
  module.lambda_execution_role.aws_iam_policy.policy --> data.aws_caller_identity.current
  module.lambda_execution_role.aws_iam_policy.policy --> module.secure_bucket.aws_s3_bucket.secure_bucket
  module.lambda_execution_role.aws_iam_role_policy.inline_policy --> module.lambda_execution_role.aws_iam_role.role
  module.lambda_execution_role.aws_iam_role_policy_attachment.policy_attachment --> module.lambda_execution_role.aws_iam_policy.policy
  module.lambda_execution_role.aws_iam_role_policy_attachment.policy_attachment --> module.lambda_execution_role.aws_iam_role.role
  module.network_firewall.aws_networkfirewall_firewall.firewall --> module.network_firewall.aws_networkfirewall_firewall_policy.policy
  module.network_firewall.aws_networkfirewall_firewall_policy.policy --> module.network_firewall.aws_networkfirewall_rule_group.rule_groups
  module.network_firewall.aws_networkfirewall_logging_configuration.logging --> module.network_firewall.aws_networkfirewall_firewall.firewall
  module.network_firewall.aws_networkfirewall_logging_configuration.logging --> module.secure_bucket.aws_s3_bucket.secure_bucket
  module.secure_bucket.aws_s3_bucket_logging.bucket_logging --> module.secure_bucket.aws_s3_bucket.secure_bucket
  module.secure_bucket.aws_s3_bucket_policy.bucket_policy --> module.secure_bucket.aws_s3_bucket.secure_bucket
  module.secure_bucket.aws_s3_bucket_public_access_block.secure_bucket_access_block --> module.secure_bucket.aws_s3_bucket.secure_bucket
  module.secure_bucket.aws_s3_bucket_server_side_encryption_configuration.bucket_encryption --> module.secure_bucket.aws_s3_bucket.secure_bucket
  module.secure_bucket.aws_s3_bucket_versioning.bucket_versioning --> module.secure_bucket.aws_s3_bucket.secure_bucket
```

### Plan graph

#### DOT format: `terraform graph -type=plan | dot -Tpng >graph-plan.png`

<img width="19132" height="923" alt="graph-plan" src="https://github.com/user-attachments/assets/6512f62b-bd81-4254-baf7-56fc30464bf6" />

#### Mermaid format: `terraform graph -type=plan -format=mermaid`

```mermaid
flowchart LR
88535518423896["provider[\&quot;registry.terraform.io/hashicorp/aws\&quot;]"]
88535518423920["provider[\&quot;registry.terraform.io/hashicorp/null\&quot;]"]
88535526901728["provider[\&quot;registry.terraform.io/hashicorp/aws\&quot;] (close)"]
88535526901824["provider[\&quot;registry.terraform.io/hashicorp/null\&quot;] (close)"]
88535528038976["module.ec2_instance (close)"]
88535528039648["module.secure_bucket (close)"]
88535528040512["module.network_firewall (close)"]
88535528041208["module.lambda_execution_role (close)"]
88535528041928["module.dynamodb_table (close)"]
88535531486560["null_resource.foo (expand)"]
88535531486640["data.aws_availability_zones.available (expand)"]
88535531486720["data.aws_caller_identity.current (expand)"]
88535531486800["module.secure_bucket.aws_s3_bucket_public_access_block.secure_bucket_access_block (expand)"]
88535531486880["module.secure_bucket.aws_s3_bucket_server_side_encryption_configuration.bucket_encryption (expand)"]
88535532292832["module.lambda_execution_role.output.role_id (expand)"]
88535532292928["module.lambda_execution_role.output.role_arn (expand)"]
88535532293024["module.lambda_execution_role.output.role_name (expand)"]
88535532293120["module.lambda_execution_role.output.policy_id (expand)"]
88535532293216["module.lambda_execution_role.output.policy_arn (expand)"]
88535532293312["module.ec2_instance.output.instance_id (expand)"]
88535532293408["module.ec2_instance.output.instance_arn (expand)"]
88535532293504["module.ec2_instance.output.instance_public_ip (expand)"]
88535532293600["module.ec2_instance.output.instance_private_ip (expand)"]
88535532293696["module.ec2_instance.output.ami_id (expand)"]
88535532293792["module.secure_bucket.output.bucket_versioning_enabled (expand)"]
88535532293888["module.secure_bucket.output.bucket_public_access_blocked (expand)"]
88535532293984["module.secure_bucket.output.bucket_id (expand)"]
88535532294080["module.secure_bucket.output.bucket_arn (expand)"]
88535532294176["module.secure_bucket.output.bucket_domain_name (expand)"]
88535532294272["module.secure_bucket.output.bucket_encryption_algorithm (expand)"]
88535532294368["module.secure_bucket.output.bucket_encryption_enabled (expand)"]
88535532294464["module.network_firewall.output.firewall_id (expand)"]
88535532294560["module.network_firewall.output.firewall_arn (expand)"]
88535532294656["module.network_firewall.output.policy_arn (expand)"]
88535532294752["module.network_firewall.output.rule_group_arns (expand)"]
88535532294848["output.secure_bucket_encryption_enabled (expand)"]
88535532294944["output.lambda_policy_arn (expand)"]
88535532295040["output.network_firewall_arn (expand)"]
88535532295136["output.secure_bucket_name (expand)"]
88535532295232["output.secure_bucket_encryption_algorithm (expand)"]
88535532295328["output.secure_bucket_versioning_enabled (expand)"]
88535532295424["output.secure_bucket_public_access_blocked (expand)"]
88535532295520["output.lambda_role_arn (expand)"]
88535532295616["output.network_firewall_name (expand)"]
88535532295712["output.secure_bucket_arn (expand)"]
88535532328624["var.vpc_id"]
88535532328672["var.firewall_subnet_ids"]
88535532328720["var.environment"]
88535532328768["var.common_tags"]
88535532328816["var.compliance_trail_name"]
88535532328864["var.docdb_engine_version"]
88535532328912["var.cloudtrail_log_group_name"]
88535532328960["var.firewall_name"]
88535532329008["var.firewall_policy_name"]
88535532329056["var.region"]
88535532329104["var.resource_prefix"]
88535532329152["var.s3_encryption_settings"]
88535532329200["var.cloudtrail_bucket_name"]
88535532329248["var.watchdog_trail_name"]
88535532329296["var.docdb_master_password"]
88535532329344["var.dynamo_table_name"]
88535532329392["var.non_compliant_trail_name"]
88535532329440["var.deploy_network_firewall"]
88535532329488["var.network_firewall_rule_groups"]
88535532329536["var.docdb_cluster_identifier"]
88535532329584["var.docdb_master_username"]
88535532363776["module.secure_bucket.aws_s3_bucket_versioning.bucket_versioning (expand)"]
88535532363856["module.secure_bucket.aws_s3_bucket_policy.bucket_policy (expand)"]
88535532363936["module.secure_bucket.aws_s3_bucket_logging.bucket_logging (expand)"]
88535532364016["module.secure_bucket.aws_s3_bucket.secure_bucket (expand)"]
88535532364096["module.network_firewall.aws_networkfirewall_firewall.firewall (expand)"]
88535532364176["module.network_firewall.aws_networkfirewall_firewall_policy.policy (expand)"]
88535532364256["module.network_firewall.aws_networkfirewall_rule_group.rule_groups (expand)"]
88535532364336["module.network_firewall.aws_networkfirewall_logging_configuration.logging (expand)"]
88535532364416["module.lambda_execution_role.aws_iam_role.role (expand)"]
88535532364496["module.lambda_execution_role.aws_iam_policy.policy (expand)"]
88535532364576["module.lambda_execution_role.aws_iam_role_policy_attachment.policy_attachment (expand)"]
88535532364656["module.lambda_execution_role.aws_iam_role_policy.inline_policy (expand)"]
88535532364736["module.dynamodb_table.aws_appautoscaling_target.dynamodb_table_read_target (expand)"]
88535532364816["module.dynamodb_table.aws_appautoscaling_target.dynamodb_table_write_target (expand)"]
88535532364896["module.dynamodb_table.aws_dynamodb_table.my_table (expand)"]
88535532364976["module.dynamodb_table.aws_appautoscaling_policy.dynamodb_table_read_policy (expand)"]
88535532365056["module.dynamodb_table.aws_appautoscaling_policy.dynamodb_table_write_policy (expand)"]
88535532365136["module.ec2_instance.aws_instance.this (expand)"]
88535532365216["module.ec2_instance.data.aws_ami.amazon_linux_2 (expand)"]
88535532365296["module.network_firewall.var.firewall_name (expand)"]
88535532365376["module.network_firewall.var.vpc_id (expand)"]
88535532365456["module.network_firewall.var.subnet_ids (expand)"]
88535532365536["module.network_firewall.var.tags (expand)"]
88535532365616["module.network_firewall.var.rule_groups (expand)"]
88535532365696["module.network_firewall.var.log_bucket_name (expand)"]
88535532365776["module.network_firewall.var.log_prefix (expand)"]
88535532365856["module.network_firewall.var.policy_name (expand)"]
88535532365936["module.network_firewall.var.enable_logging (expand)"]
88535532366016["module.lambda_execution_role.var.role_name (expand)"]
88535532366096["module.lambda_execution_role.var.assume_role_policy (expand)"]
88535532366176["module.lambda_execution_role.var.description (expand)"]
88535532366256["module.lambda_execution_role.var.policy_name (expand)"]
88535532366336["module.lambda_execution_role.var.policy_document (expand)"]
88535532366416["module.lambda_execution_role.var.inline_policy_document (expand)"]
88535532366496["module.lambda_execution_role.var.tags (expand)"]
88535532366576["module.lambda_execution_role.var.policy_description (expand)"]
88535532366656["module.lambda_execution_role.var.inline_policy_name (expand)"]
88535532366736["module.ec2_instance.var.name (expand)"]
88535532366816["module.ec2_instance.var.ami_id (expand)"]
88535532366896["module.ec2_instance.var.use_amazon_linux (expand)"]
88535532366976["module.ec2_instance.var.key_name (expand)"]
88535532367056["module.ec2_instance.var.subnet_id (expand)"]
88535532367136["module.ec2_instance.var.security_group_ids (expand)"]
88535532367216["module.ec2_instance.var.associate_public_ip_address (expand)"]
88535532367296["module.ec2_instance.var.instance_type (expand)"]
88535532367376["module.ec2_instance.var.tags (expand)"]
88535532367456["module.secure_bucket.var.enable_versioning (expand)"]
88535532367536["module.secure_bucket.var.force_destroy (expand)"]
88535532367616["module.secure_bucket.var.logging_target_prefix (expand)"]
88535532367696["module.secure_bucket.var.kms_master_key_id (expand)"]
88535532367776["module.secure_bucket.var.bucket_key_enabled (expand)"]
88535532367856["module.secure_bucket.var.bucket_name (expand)"]
88535532367936["module.secure_bucket.var.tags (expand)"]
88535532368016["module.secure_bucket.var.policy (expand)"]
88535532368096["module.secure_bucket.var.logging_target_bucket (expand)"]
88535532368176["module.secure_bucket.var.sse_algorithm (expand)"]
88535532497680["local.resource_tags (expand)"]
88535550521136["module.ec2_instance (expand)"]
88535550521952["module.secure_bucket (expand)"]
88535550522912["module.network_firewall (expand)"]
88535550523680["module.lambda_execution_role (expand)"]
88535550524496["module.dynamodb_table (expand)"]
88535552541776["root"]
88535518423896 --> 88535532329056
88535526901728 --> 88535531486640
88535526901728 --> 88535531486800
88535526901728 --> 88535531486880
88535526901728 --> 88535532363776
88535526901728 --> 88535532363856
88535526901728 --> 88535532363936
88535526901728 --> 88535532364336
88535526901728 --> 88535532364576
88535526901728 --> 88535532364656
88535526901728 --> 88535532364736
88535526901728 --> 88535532364816
88535526901728 --> 88535532364896
88535526901728 --> 88535532364976
88535526901728 --> 88535532365056
88535526901728 --> 88535532365136
88535526901824 --> 88535531486560
88535528038976 --> 88535532293312
88535528038976 --> 88535532293408
88535528038976 --> 88535532293504
88535528038976 --> 88535532293600
88535528038976 --> 88535532293696
88535528038976 --> 88535532366736
88535528038976 --> 88535532366816
88535528038976 --> 88535532366896
88535528038976 --> 88535532366976
88535528038976 --> 88535532367056
88535528038976 --> 88535532367136
88535528038976 --> 88535532367216
88535528038976 --> 88535532367376
88535528039648 --> 88535531486800
88535528039648 --> 88535531486880
88535528039648 --> 88535532293792
88535528039648 --> 88535532293888
88535528039648 --> 88535532293984
88535528039648 --> 88535532294080
88535528039648 --> 88535532294176
88535528039648 --> 88535532294272
88535528039648 --> 88535532294368
88535528039648 --> 88535532363776
88535528039648 --> 88535532363856
88535528039648 --> 88535532363936
88535528040512 --> 88535532294464
88535528040512 --> 88535532294560
88535528040512 --> 88535532294656
88535528040512 --> 88535532294752
88535528040512 --> 88535532364336
88535528041208 --> 88535532292832
88535528041208 --> 88535532292928
88535528041208 --> 88535532293024
88535528041208 --> 88535532293120
88535528041208 --> 88535532293216
88535528041208 --> 88535532364576
88535528041208 --> 88535532364656
88535528041928 --> 88535532364736
88535528041928 --> 88535532364816
88535528041928 --> 88535532364896
88535528041928 --> 88535532364976
88535528041928 --> 88535532365056
88535531486560 --> 88535518423920
88535531486640 --> 88535518423896
88535531486720 --> 88535518423896
88535531486800 --> 88535532364016
88535531486880 --> 88535532364016
88535531486880 --> 88535532367696
88535531486880 --> 88535532367776
88535531486880 --> 88535532368176
88535532292832 --> 88535532364416
88535532292928 --> 88535532364416
88535532293024 --> 88535532364416
88535532293120 --> 88535532364496
88535532293216 --> 88535532364496
88535532293312 --> 88535532365136
88535532293408 --> 88535532365136
88535532293504 --> 88535532365136
88535532293600 --> 88535532365136
88535532293696 --> 88535532365136
88535532293792 --> 88535532367456
88535532293888 --> 88535550521952
88535532293984 --> 88535532364016
88535532294080 --> 88535532364016
88535532294176 --> 88535532364016
88535532294272 --> 88535532368176
88535532294368 --> 88535550521952
88535532294464 --> 88535532364096
88535532294560 --> 88535532364096
88535532294656 --> 88535532364176
88535532294752 --> 88535532364256
88535532294848 --> 88535532294368
88535532294944 --> 88535532293216
88535532295040 --> 88535532294560
88535532295136 --> 88535532293984
88535532295232 --> 88535532294272
88535532295328 --> 88535532293792
88535532295424 --> 88535532293888
88535532295520 --> 88535532292928
88535532295616 --> 88535532294464
88535532295712 --> 88535532294080
88535532363776 --> 88535532364016
88535532363776 --> 88535532367456
88535532363856 --> 88535532364016
88535532363856 --> 88535532368016
88535532363936 --> 88535532364016
88535532363936 --> 88535532367616
88535532363936 --> 88535532368096
88535532364016 --> 88535518423896
88535532364016 --> 88535532367536
88535532364016 --> 88535532367856
88535532364016 --> 88535532367936
88535532364096 --> 88535532364176
88535532364096 --> 88535532365296
88535532364096 --> 88535532365376
88535532364096 --> 88535532365456
88535532364176 --> 88535532364256
88535532364176 --> 88535532365856
88535532364256 --> 88535518423896
88535532364256 --> 88535532365536
88535532364256 --> 88535532365616
88535532364336 --> 88535532364096
88535532364336 --> 88535532365696
88535532364336 --> 88535532365776
88535532364336 --> 88535532365936
88535532364416 --> 88535518423896
88535532364416 --> 88535532366016
88535532364416 --> 88535532366096
88535532364416 --> 88535532366176
88535532364416 --> 88535532366496
88535532364496 --> 88535532366256
88535532364496 --> 88535532366336
88535532364496 --> 88535532366576
88535532364576 --> 88535532364416
88535532364576 --> 88535532364496
88535532364656 --> 88535532364416
88535532364656 --> 88535532366416
88535532364656 --> 88535532366656
88535532364736 --> 88535518423896
88535532364736 --> 88535550524496
88535532364816 --> 88535518423896
88535532364816 --> 88535550524496
88535532364896 --> 88535518423896
88535532364896 --> 88535550524496
88535532364976 --> 88535518423896
88535532364976 --> 88535550524496
88535532365056 --> 88535518423896
88535532365056 --> 88535550524496
88535532365136 --> 88535532365216
88535532365136 --> 88535532367296
88535532365216 --> 88535518423896
88535532365216 --> 88535550521136
88535532365296 --> 88535532328960
88535532365296 --> 88535550522912
88535532365376 --> 88535532328624
88535532365376 --> 88535550522912
88535532365456 --> 88535532328672
88535532365456 --> 88535550522912
88535532365536 --> 88535532497680
88535532365536 --> 88535550522912
88535532365616 --> 88535532329488
88535532365616 --> 88535550522912
88535532365696 --> 88535532293984
88535532365696 --> 88535550522912
88535532365776 --> 88535550522912
88535532365856 --> 88535532329008
88535532365856 --> 88535550522912
88535532365936 --> 88535550522912
88535532366016 --> 88535532329104
88535532366016 --> 88535550523680
88535532366096 --> 88535550523680
88535532366176 --> 88535550523680
88535532366256 --> 88535532329104
88535532366256 --> 88535550523680
88535532366336 --> 88535531486720
88535532366336 --> 88535532293984
88535532366336 --> 88535550523680
88535532366416 --> 88535550523680
88535532366496 --> 88535532497680
88535532366496 --> 88535550523680
88535532366576 --> 88535550523680
88535532366656 --> 88535550523680
88535532366736 --> 88535550521136
88535532366816 --> 88535550521136
88535532366896 --> 88535550521136
88535532366976 --> 88535550521136
88535532367056 --> 88535550521136
88535532367136 --> 88535550521136
88535532367216 --> 88535550521136
88535532367296 --> 88535550521136
88535532367376 --> 88535550521136
88535532367456 --> 88535532329152
88535532367456 --> 88535550521952
88535532367536 --> 88535550521952
88535532367616 --> 88535550521952
88535532367696 --> 88535532329152
88535532367696 --> 88535550521952
88535532367776 --> 88535532329152
88535532367776 --> 88535550521952
88535532367856 --> 88535532329104
88535532367856 --> 88535550521952
88535532367936 --> 88535532497680
88535532367936 --> 88535550521952
88535532368016 --> 88535550521952
88535532368096 --> 88535532329104
88535532368096 --> 88535550521952
88535532368176 --> 88535532329152
88535532368176 --> 88535550521952
88535532497680 --> 88535532328720
88535532497680 --> 88535532328768
88535550522912 --> 88535532329440
88535552541776 --> 88535526901728
88535552541776 --> 88535526901824
88535552541776 --> 88535528038976
88535552541776 --> 88535528039648
88535552541776 --> 88535528040512
88535552541776 --> 88535528041208
88535552541776 --> 88535528041928
88535552541776 --> 88535532294848
88535552541776 --> 88535532294944
88535552541776 --> 88535532295040
88535552541776 --> 88535532295136
88535552541776 --> 88535532295232
88535552541776 --> 88535532295328
88535552541776 --> 88535532295424
88535552541776 --> 88535532295520
88535552541776 --> 88535532295616
88535552541776 --> 88535532295712
88535552541776 --> 88535532328816
88535552541776 --> 88535532328864
88535552541776 --> 88535532328912
88535552541776 --> 88535532329200
88535552541776 --> 88535532329248
88535552541776 --> 88535532329296
88535552541776 --> 88535532329344
88535552541776 --> 88535532329392
88535552541776 --> 88535532329536
88535552541776 --> 88535532329584
```


## Testing

Test uses the same fixture as the DOT format tests and compares byte-by-byte Mermaid output.