### PR TITLE
fix: remove extra quoting in import error messages

### DIFF
--- a/.changes/v1.16/BUG FIXES-20260614-224555.yaml
+++ b/.changes/v1.16/BUG FIXES-20260614-224555.yaml
@@ -1,0 +1,5 @@
+kind: BUG FIXES
+body: Remove extra quoting in import error messages for resource addresses
+time: 2026-06-14T22:30:00Z
+custom:
+    Issue: "34124"

--- a/internal/terraform/node_resource_import.go
+++ b/internal/terraform/node_resource_import.go
@@ -261,7 +261,7 @@ func (n *graphNodeImportStateSub) Execute(ctx EvalContext, op walkOperation) (di
 			tfdiags.Error,
 			"Cannot import deferred remote object",
 			fmt.Sprintf(
-				"While attempting to import an existing object to %q, "+
+				"While attempting to import an existing object to %s, "+
 					"the provider deferred reading the resource. "+
 					"This is a bug in the provider since deferrals are not supported when importing through the CLI, please file an issue."+
 					"Please either use an import block for importing this resource "+
@@ -279,7 +279,7 @@ func (n *graphNodeImportStateSub) Execute(ctx EvalContext, op walkOperation) (di
 				tfdiags.Error,
 				"Cannot import non-existent remote object",
 				fmt.Sprintf(
-					"While attempting to import an existing object to %q, "+
+					"While attempting to import an existing object to %s, "+
 						"the provider detected that no object exists with the given id. "+
 						"Only pre-existing objects can be imported; check that the id "+
 						"is correct and that it is associated with the provider's "+

--- a/internal/terraform/node_resource_plan_instance.go
+++ b/internal/terraform/node_resource_plan_instance.go
@@ -847,7 +847,7 @@ func (n *NodePlannableResourceInstance) importState(ctx EvalContext, addr addrs.
 			tfdiags.Error,
 			"Cannot import non-existent remote object",
 			fmt.Sprintf(
-				"While attempting to import an existing object to %q, "+
+				"While attempting to import an existing object to %s, "+
 					"the provider detected that no object exists with the given id. "+
 					"Only pre-existing objects can be imported; check that the id "+
 					"is correct and that it is associated with the provider's "+


### PR DESCRIPTION
## Description
Remove extra quoting from import error messages that occur when Terraform attempts to import non-existent remote objects.

## Problem
Resource instance addresses were being formatted with `%q` (quoted string) instead of `%s` (unquoted), causing misleading error messages like:
```
While attempting to import an existing object to \"aws_instance.example\", ...
```

This is confusing because:
1. Resource addresses aren't written in quotes in configuration
2. When addresses contain quotes (e.g., `resource.name[\"key\"]`), the extra quoting makes parsing harder
3. Users may misinterpret the escaping as a command-line or configuration issue

## Solution
Changed three occurrences of `%q` to `%s` in:
- `internal/terraform/node_resource_import.go` (lines 264, 282)
- `internal/terraform/node_resource_plan_instance.go` (line 850)

## Testing
- All existing import tests pass (20+ test cases)
- Changes are minimal and mechanical (format string only)

Fixes: #34124