### PR TITLE
github: Make permissions explicit in remaining workflows

### DIFF
--- a/.github/workflows/build-terraform-cli.yml
+++ b/.github/workflows/build-terraform-cli.yml
@@ -32,6 +32,10 @@ on:
         type: string
         required: true
 
+permissions:
+  contents: read
+  statuses: write
+
 jobs:
   build:
     runs-on: ${{ inputs.runson }}

--- a/.github/workflows/issue-comment-created.yml
+++ b/.github/workflows/issue-comment-created.yml
@@ -4,6 +4,10 @@ on:
   issue_comment:
     types: [created]
 
+permissions:
+  issues: write
+  pull-requests: write
+
 jobs:
   issue_comment_triage:
     runs-on: ubuntu-latest

--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -4,6 +4,10 @@ on:
   schedule:
     - cron: '50 1 * * *'
 
+permissions:
+  issues: write
+  pull-requests: write
+
 jobs:
   lock:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This is to follow-up on https://github.com/hashicorp/terraform/pull/38723 

It adds explicit `permissions` to workflows which are missing them. I did my best to balance out the assumed runtime needs and excessive permissions - we can always tune later if something breaks.

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.16.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
