### PR TITLE
command/state-migrate: Implement migration paths

### DIFF
--- a/internal/command/apply_test.go
+++ b/internal/command/apply_test.go
@@ -763,7 +763,7 @@ func TestApply_plan_stateStore(t *testing.T) {
 	planPath := testPlanFile(t, snap, state, plan)
 
 	// Create a mock, to be used as the pluggable state store described in the planfile
-	mock := testStateStoreMockWithChunkNegotiation(t, 1000)
+	mock := testStateStoreMockWithChunkNegotiation(t, testStateStoreMock(t), 1000)
 	view, done := testView(t)
 	c := &ApplyCommand{
 		Meta: Meta{
@@ -820,7 +820,8 @@ output "foobar" {
 		}
 
 		// Mock provider still needs to be supplied via testingOverrides despite the mock HTTP source
-		mockProvider := mockPluggableStateStorageProvider()
+		mockProvider := mockPluggableStateStorageProvider(mockSingleStateStoreSchema("test_store"))
+		mockProvider.MockStates = testing_provider.NewMockStateBytesWithStateIds("test_store", []string{"default"})
 		mockProviderAddress := addrs.NewDefaultProvider("test")
 		source := newMockProviderSource(t, map[string][]string{
 			// The test fixture config has no version constraints, so the latest version will
@@ -936,7 +937,11 @@ output "foobar" {
 		// Terraform validates that builtin providers are called 'terraform' but we can still supply
 		// a mock in place of the actual builtin terraform provider. We just need the address and any
 		// schemas to match the builtin provider.
-		mockProvider := mockPluggableStateStorageProvider()
+		mockProvider := mockPluggableStateStorageProvider(mockSingleStateStoreSchema("test_store"))
+		mockProvider.MockStates = testing_provider.NewMockStateBytesWithTypesAndStateIds(
+			[]string{"test_store", "terraform_store"},
+			[]string{"default"},
+		)
 		schema := mockProvider.GetProviderSchema()
 		schema.StateStores["terraform_store"] = schema.StateStores["test_store"] // rename to match pretending this is a store in the builtin terraform provider.
 		mockProvider.GetProviderSchemaResponse = &schema
@@ -1080,7 +1085,7 @@ func TestApply_plan_stateStore_errorCases(t *testing.T) {
 		planPath := testPlanFile(t, snap, state, plan)
 
 		// Create a mock, to be used as the pluggable state store described in the planfile
-		mock := testStateStoreMockWithChunkNegotiation(t, 1000)
+		mock := testStateStoreMockWithChunkNegotiation(t, testStateStoreMock(t), 1000)
 		view, done := testView(t)
 		c := &ApplyCommand{
 			Meta: Meta{

--- a/internal/command/arguments/state_migrate.go
+++ b/internal/command/arguments/state_migrate.go
@@ -72,23 +72,26 @@ func ParseStateMigrate(args []string) (*StateMigrate, tfdiags.Diagnostics) {
 		}
 
 	}
+	if srcLockFilePath == "" {
+		// setting default here instead of in the flag definition
+		// to make check above free of side effects
+		srcLockFilePath = lockFileName
+	}
 	if dstLockFilePath == "" {
 		// setting default here instead of in the flag definition
 		// to make check above free of side effects
 		dstLockFilePath = lockFileName
 	}
 
-	if srcLockFilePath != "" {
-		srcFilename := filepath.Base(srcLockFilePath)
-		if srcFilename != lockFileName {
-			diags = diags.Append(tfdiags.Sourceless(
-				tfdiags.Error,
-				"Invalid source-provider-lock-file",
-				fmt.Sprintf("Expected lock file name to be %s, got: %s", lockFileName, srcFilename),
-			))
-		} else {
-			migrate.SourceLockFilePath = srcLockFilePath
-		}
+	srcFilename := filepath.Base(srcLockFilePath)
+	if srcFilename != lockFileName {
+		diags = diags.Append(tfdiags.Sourceless(
+			tfdiags.Error,
+			"Invalid source-provider-lock-file",
+			fmt.Sprintf("Expected lock file name to be %s, got: %s", lockFileName, srcFilename),
+		))
+	} else {
+		migrate.SourceLockFilePath = srcLockFilePath
 	}
 
 	dstFilename := filepath.Base(dstLockFilePath)

--- a/internal/command/arguments/state_migrate_test.go
+++ b/internal/command/arguments/state_migrate_test.go
@@ -19,7 +19,7 @@ func TestStateMigrateArgs(t *testing.T) {
 		{
 			rawArgs: []string{""},
 			expectedArgs: &StateMigrate{
-				SourceLockFilePath:      "",
+				SourceLockFilePath:      ".terraform.lock.hcl",
 				DestinationLockFilePath: ".terraform.lock.hcl",
 				Upgrade:                 false,
 				InputEnabled:            true,
@@ -61,7 +61,7 @@ func TestStateMigrateArgs(t *testing.T) {
 		{
 			rawArgs: []string{"-input=false", "-destination-provider-lock-file", "foo"},
 			expectedArgs: &StateMigrate{
-				SourceLockFilePath:      "",
+				SourceLockFilePath:      ".terraform.lock.hcl",
 				DestinationLockFilePath: "",
 				Upgrade:                 false,
 				InputEnabled:            false,

--- a/internal/command/autocomplete_test.go
+++ b/internal/command/autocomplete_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/hashicorp/terraform/internal/command/workdir"
 	"github.com/hashicorp/terraform/internal/providers"
 	pTesting "github.com/hashicorp/terraform/internal/providers/testing"
-	testing_provider "github.com/hashicorp/terraform/internal/providers/testing"
 	"github.com/posener/complete"
 )
 
@@ -91,9 +90,6 @@ func TestMetaCompletePredictWorkspaceName(t *testing.T) {
 
 		// Set up pluggable state store provider mock
 		mockProvider := mockPluggableStateStorageProvider(mockSingleStateStoreSchema("test_store"))
-		mockProvider.MockStates = testing_provider.NewMockStateBytesWithStateIds("test_store", []string{"default"})
-		// No workspaces exist in the mock
-		mockProvider.MockStates = pTesting.NewMockStateBytes("test")
 		mockProviderAddress := addrs.NewDefaultProvider("test")
 		providerSource := newMockProviderSource(t, map[string][]string{
 			"hashicorp/test": {"1.0.0"},

--- a/internal/command/autocomplete_test.go
+++ b/internal/command/autocomplete_test.go
@@ -11,6 +11,8 @@ import (
 	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/command/workdir"
 	"github.com/hashicorp/terraform/internal/providers"
+	pTesting "github.com/hashicorp/terraform/internal/providers/testing"
+	testing_provider "github.com/hashicorp/terraform/internal/providers/testing"
 	"github.com/posener/complete"
 )
 
@@ -42,12 +44,12 @@ func TestMetaCompletePredictWorkspaceName(t *testing.T) {
 		t.Chdir(td)
 
 		// Set up pluggable state store provider mock
-		mockProvider := mockPluggableStateStorageProvider()
+		mockProvider := mockPluggableStateStorageProvider(mockSingleStateStoreSchema("test_store"))
 		// Mock the existence of workspaces
-		mockProvider.MockStates = map[string]interface{}{
-			"default": true,
-			"foobar":  true,
-		}
+		mockProvider.MockStates = pTesting.NewMockStateBytesWithStateIds("test_store", []string{
+			"default",
+			"foobar",
+		})
 		mockProviderAddress := addrs.NewDefaultProvider("test")
 		providerSource := newMockProviderSource(t, map[string][]string{
 			"hashicorp/test": {"1.0.0"},
@@ -88,9 +90,10 @@ func TestMetaCompletePredictWorkspaceName(t *testing.T) {
 		t.Chdir(td)
 
 		// Set up pluggable state store provider mock
-		mockProvider := mockPluggableStateStorageProvider()
+		mockProvider := mockPluggableStateStorageProvider(mockSingleStateStoreSchema("test_store"))
+		mockProvider.MockStates = testing_provider.NewMockStateBytesWithStateIds("test_store", []string{"default"})
 		// No workspaces exist in the mock
-		mockProvider.MockStates = map[string]interface{}{}
+		mockProvider.MockStates = pTesting.NewMockStateBytes("test")
 		mockProviderAddress := addrs.NewDefaultProvider("test")
 		providerSource := newMockProviderSource(t, map[string][]string{
 			"hashicorp/test": {"1.0.0"},

--- a/internal/command/init_test.go
+++ b/internal/command/init_test.go
@@ -8,12 +8,14 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"maps"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"os"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"strings"
 	"testing"
 
@@ -282,7 +284,6 @@ func TestInit_stateStoreProviderDownload(t *testing.T) {
 			})
 
 			mockProvider := mockPluggableStateStorageProvider(mockSingleStateStoreSchema("test_store"))
-			mockProvider.MockStates = testing_provider.NewMockStateBytesWithStateIds("test_store", []string{"default"})
 
 			ui := new(cli.MockUi)
 			view, done := testView(t)
@@ -4088,7 +4089,6 @@ func TestInit_stateStore_newWorkingDir_basic(t *testing.T) {
 		t.Chdir(td)
 
 		mockProvider := mockPluggableStateStorageProvider(mockSingleStateStoreSchema("test_store"))
-		mockProvider.MockStates = testing_provider.NewMockStateBytes("test_store")
 		mockProviderAddress := addrs.NewDefaultProvider("test")
 		providerSource := newMockProviderSource(t, map[string][]string{
 			// The test fixture config has no version constraints, so the latest version will
@@ -4192,7 +4192,6 @@ Initializing provider plugins...
 		t.Setenv(WorkspaceNameEnvVar, customWorkspace)
 
 		mockProvider := mockPluggableStateStorageProvider(mockSingleStateStoreSchema("test_store"))
-		mockProvider.MockStates = testing_provider.NewMockStateBytes("test_store")
 		mockProviderAddress := addrs.NewDefaultProvider("test")
 		providerSource := newMockProviderSource(t, map[string][]string{
 			"hashicorp/test": {"1.0.0"},
@@ -4404,7 +4403,6 @@ func TestInit_stateStore_newWorkingDir_interactiveProviderApproval(t *testing.T)
 		})
 
 		mockProvider := mockPluggableStateStorageProvider(mockSingleStateStoreSchema("test_store"))
-		mockProvider.MockStates = testing_provider.NewMockStateBytesWithStateIds("test_store", []string{"default"})
 		mockProviderAddress := addrs.NewDefaultProvider("test")
 
 		ui := new(cli.MockUi)
@@ -4466,7 +4464,6 @@ func TestInit_stateStore_newWorkingDir_interactiveProviderApproval(t *testing.T)
 		})
 
 		mockProvider := mockPluggableStateStorageProvider(mockSingleStateStoreSchema("test_store"))
-		mockProvider.MockStates = testing_provider.NewMockStateBytesWithStateIds("test_store", []string{"default"})
 		mockProviderAddress := addrs.NewDefaultProvider("test")
 
 		// Allow the test to respond to the pause in provider installation for
@@ -4549,7 +4546,6 @@ func TestInit_stateStore_newWorkingDir_interactiveProviderApproval(t *testing.T)
 		}, returnApprovedHashes)
 
 		mockProvider := mockPluggableStateStorageProvider(mockSingleStateStoreSchema("test_store"))
-		mockProvider.MockStates = testing_provider.NewMockStateBytesWithStateIds("test_store", []string{"default"})
 		mockProviderAddress := addrs.NewDefaultProvider("test")
 
 		// Allow the test to respond to the pause in provider installation for
@@ -4630,7 +4626,6 @@ func TestInit_stateStore_newWorkingDir_interactiveProviderApproval(t *testing.T)
 		})
 
 		mockProvider := mockPluggableStateStorageProvider(mockSingleStateStoreSchema("test_store"))
-		mockProvider.MockStates = testing_provider.NewMockStateBytesWithStateIds("test_store", []string{"default"})
 		mockProviderAddress := addrs.NewDefaultProvider("test")
 
 		// Allow the test to respond to the pause in provider installation for
@@ -4712,7 +4707,6 @@ func TestInit_stateStore_newWorkingDir_interactiveProviderApproval(t *testing.T)
 
 		// Set up providers for use in the second init attempt.
 		mockProvider := mockPluggableStateStorageProvider(mockSingleStateStoreSchema("test_store"))
-		mockProvider.MockStates = testing_provider.NewMockStateBytesWithStateIds("test_store", []string{"default"})
 
 		ui := new(cli.MockUi)
 		view, done := testView(t)
@@ -4818,7 +4812,6 @@ func TestInit_stateStore_versionConstraintChildModule(t *testing.T) {
 	})
 
 	mockProvider := mockPluggableStateStorageProvider(mockSingleStateStoreSchema("test_store"))
-	mockProvider.MockStates = testing_provider.NewMockStateBytesWithStateIds("test_store", []string{"default"})
 	mockProviderAddress := addrs.NewDefaultProvider("test")
 
 	ui := new(cli.MockUi)
@@ -4916,7 +4909,6 @@ func TestInit_stateStore_newWorkingDir_inAutomationProviderApproval(t *testing.T
 		})
 
 		mockProvider := mockPluggableStateStorageProvider(mockSingleStateStoreSchema("test_store"))
-		mockProvider.MockStates = testing_provider.NewMockStateBytesWithStateIds("test_store", []string{"default"})
 		mockProviderAddress := addrs.NewDefaultProvider("test")
 
 		ui := new(cli.MockUi)
@@ -4980,7 +4972,6 @@ func TestInit_stateStore_newWorkingDir_inAutomationProviderApproval(t *testing.T
 			"hashicorp/test": {expectedVersion, "9.9.9"}, // Extra version - expected version is downloaded, not the latest
 		})
 		mockProvider := mockPluggableStateStorageProvider(mockSingleStateStoreSchema("test_store"))
-		mockProvider.MockStates = testing_provider.NewMockStateBytesWithStateIds("test_store", []string{"default"})
 
 		ui := new(cli.MockUi)
 		view, done := testView(t)
@@ -5070,7 +5061,6 @@ func TestInit_stateStore_newWorkingDir_inAutomationProviderApproval(t *testing.T
 			"hashicorp/test": {expectedVersion, "9.9.9"}, // Extra version - expected version is downloaded, not the latest
 		})
 		mockProvider := mockPluggableStateStorageProvider(mockSingleStateStoreSchema("test_store"))
-		mockProvider.MockStates = testing_provider.NewMockStateBytesWithStateIds("test_store", []string{"default"})
 
 		ui := new(cli.MockUi)
 		view, done := testView(t)
@@ -5144,7 +5134,6 @@ func TestInit_stateStore_newWorkingDir_inAutomationProviderApproval(t *testing.T
 			"hashicorp/test": {expectedVersion},
 		})
 		mockProvider := mockPluggableStateStorageProvider(mockSingleStateStoreSchema("test_store"))
-		mockProvider.MockStates = testing_provider.NewMockStateBytesWithStateIds("test_store", []string{"default"})
 
 		ui := new(cli.MockUi)
 		view, done := testView(t)
@@ -5219,7 +5208,6 @@ func TestInit_stateStore_newWorkingDir_inAutomationProviderApproval(t *testing.T
 			"hashicorp/test": {expectedVersion},
 		})
 		mockProvider := mockPluggableStateStorageProvider(mockSingleStateStoreSchema("test_store"))
-		mockProvider.MockStates = testing_provider.NewMockStateBytesWithStateIds("test_store", []string{"default"})
 
 		ui := new(cli.MockUi)
 		view, done := testView(t)
@@ -7736,6 +7724,8 @@ func mockPluggableStateStorageProvider(schemas map[string]providers.Schema) *tes
 			StateStores:       schemas,
 		},
 	}
+	typeNames := slices.Sorted(maps.Keys(schemas))
+	mock.MockStates = testing_provider.NewMockStateBytesWithTypes(typeNames)
 	mock.GetStatesFn = func(req providers.GetStatesRequest) (resp providers.GetStatesResponse) {
 		stateIds, err := mock.MockStates.StateIds(req.TypeName)
 		if err != nil {

--- a/internal/command/init_test.go
+++ b/internal/command/init_test.go
@@ -4,17 +4,16 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log"
-	"maps"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"os"
 	"path/filepath"
 	"regexp"
-	"slices"
 	"strings"
 	"testing"
 
@@ -45,6 +44,7 @@ import (
 	"github.com/hashicorp/terraform/internal/states"
 	"github.com/hashicorp/terraform/internal/states/statefile"
 	"github.com/hashicorp/terraform/internal/states/statemgr"
+	"github.com/hashicorp/terraform/internal/tfdiags"
 )
 
 // cleanString removes newlines, and redundant spaces.
@@ -281,7 +281,8 @@ func TestInit_stateStoreProviderDownload(t *testing.T) {
 				"hashicorp/test":   {"1.2.3"},
 			})
 
-			mockProvider := mockPluggableStateStorageProvider()
+			mockProvider := mockPluggableStateStorageProvider(mockSingleStateStoreSchema("test_store"))
+			mockProvider.MockStates = testing_provider.NewMockStateBytesWithStateIds("test_store", []string{"default"})
 
 			ui := new(cli.MockUi)
 			view, done := testView(t)
@@ -2553,7 +2554,8 @@ terraform {
 		})
 
 		// Mock provider to act as "hashicorp/test"
-		mockProvider := mockPluggableStateStorageProvider()
+		mockProvider := mockPluggableStateStorageProvider(mockSingleStateStoreSchema("test_store"))
+		mockProvider.MockStates = testing_provider.NewMockStateBytesWithStateIds("test_store", []string{"default"})
 
 		ui := new(cli.MockUi)
 		view, done := testView(t)
@@ -2684,7 +2686,8 @@ terraform {
 		})
 
 		// Mock provider to act as "hashicorp/test"
-		mockProvider := mockPluggableStateStorageProvider()
+		mockProvider := mockPluggableStateStorageProvider(mockSingleStateStoreSchema("test_store"))
+		mockProvider.MockStates = testing_provider.NewMockStateBytesWithStateIds("test_store", []string{"default"})
 		mockProviderAddress := addrs.NewDefaultProvider("test")
 		ui := new(cli.MockUi)
 		view, done := testView(t)
@@ -2808,7 +2811,8 @@ terraform {
 		})
 
 		// Mock provider to act as "hashicorp/test"
-		mockProvider := mockPluggableStateStorageProvider()
+		mockProvider := mockPluggableStateStorageProvider(mockSingleStateStoreSchema("test_store"))
+		mockProvider.MockStates = testing_provider.NewMockStateBytesWithStateIds("test_store", []string{"default"})
 
 		ui := new(cli.MockUi)
 		view, done := testView(t)
@@ -2939,7 +2943,8 @@ terraform {
 			"foobar": {"1.2.3", "9.9.9"},
 		})
 		// Mock provider to act as "hashicorp/test"
-		mockProvider := mockPluggableStateStorageProvider()
+		mockProvider := mockPluggableStateStorageProvider(mockSingleStateStoreSchema("test_store"))
+		mockProvider.MockStates = testing_provider.NewMockStateBytesWithStateIds("test_store", []string{"default"})
 
 		ui := new(cli.MockUi)
 		view, done := testView(t)
@@ -4082,7 +4087,8 @@ func TestInit_stateStore_newWorkingDir_basic(t *testing.T) {
 		testCopyDir(t, testFixturePath("init-with-state-store"), td)
 		t.Chdir(td)
 
-		mockProvider := mockPluggableStateStorageProvider()
+		mockProvider := mockPluggableStateStorageProvider(mockSingleStateStoreSchema("test_store"))
+		mockProvider.MockStates = testing_provider.NewMockStateBytes("test_store")
 		mockProviderAddress := addrs.NewDefaultProvider("test")
 		providerSource := newMockProviderSource(t, map[string][]string{
 			// The test fixture config has no version constraints, so the latest version will
@@ -4135,7 +4141,11 @@ Initializing provider plugins...
 		}
 
 		// Assert the default workspace was not created
-		if _, exists := mockProvider.MockStates[backend.DefaultStateName]; exists {
+		exists, err := mockProvider.MockStates.StateIdExists("test_store", backend.DefaultStateName)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if exists {
 			t.Fatal("expected the default workspace to not be created during init, but it exists")
 		}
 
@@ -4181,7 +4191,8 @@ Initializing provider plugins...
 		customWorkspace := "my-custom-workspace"
 		t.Setenv(WorkspaceNameEnvVar, customWorkspace)
 
-		mockProvider := mockPluggableStateStorageProvider()
+		mockProvider := mockPluggableStateStorageProvider(mockSingleStateStoreSchema("test_store"))
+		mockProvider.MockStates = testing_provider.NewMockStateBytes("test_store")
 		mockProviderAddress := addrs.NewDefaultProvider("test")
 		providerSource := newMockProviderSource(t, map[string][]string{
 			"hashicorp/test": {"1.0.0"},
@@ -4224,13 +4235,17 @@ Initializing provider plugins...
 		}
 
 		// Assert no workspaces exist
-		if len(mockProvider.MockStates) != 0 {
-			t.Fatalf("expected no workspaces, but got: %#v", mockProvider.MockStates)
+		stateIds, err := mockProvider.MockStates.StateIds("test_store")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(stateIds) != 0 {
+			t.Fatalf("expected no workspaces, but got: %#v", stateIds)
 		}
 
 		// Assert no backend state file made due to the error
 		statePath := filepath.Join(meta.DataDir(), DefaultStateFilename)
-		_, err := os.Stat(statePath)
+		_, err = os.Stat(statePath)
 		if pathErr, ok := err.(*os.PathError); !ok || !os.IsNotExist(pathErr.Err) {
 			t.Fatalf("expected backend state file to not be created, but it exists")
 		}
@@ -4246,15 +4261,16 @@ Initializing provider plugins...
 		testCopyDir(t, testFixturePath("init-with-state-store"), td)
 		t.Chdir(td)
 
-		mockProvider := mockPluggableStateStorageProvider()
-		mockProvider.GetStatesResponse = &providers.GetStatesResponse{
-			States: []string{
+		mockProvider := mockPluggableStateStorageProvider(mockSingleStateStoreSchema("test_store"))
+		mockProvider.MockStates = testing_provider.NewMockStateBytesWithStateIds(
+			"test_store",
+			[]string{
 				"foobar1",
 				"foobar2",
 				// Force provider to report workspaces exist
 				// But default workspace doesn't exist
 			},
-		}
+		)
 
 		mockProviderAddress := addrs.NewDefaultProvider("test")
 		providerSource := newMockProviderSource(t, map[string][]string{
@@ -4313,15 +4329,16 @@ Initializing provider plugins...
 		testCopyDir(t, testFixturePath("init-with-state-store"), td)
 		t.Chdir(td)
 
-		mockProvider := mockPluggableStateStorageProvider()
-		mockProvider.GetStatesResponse = &providers.GetStatesResponse{
-			States: []string{
+		mockProvider := mockPluggableStateStorageProvider(mockSingleStateStoreSchema("test_store"))
+		mockProvider.MockStates = testing_provider.NewMockStateBytesWithStateIds(
+			"test_store",
+			[]string{
 				"foobar1",
 				"foobar2",
 				// Force provider to report workspaces exist
 				// But default workspace doesn't exist
 			},
-		}
+		)
 
 		mockProviderAddress := addrs.NewDefaultProvider("test")
 		providerSource := newMockProviderSource(t, map[string][]string{
@@ -4386,7 +4403,8 @@ func TestInit_stateStore_newWorkingDir_interactiveProviderApproval(t *testing.T)
 			"hashicorp/test": {"1.2.3"},
 		})
 
-		mockProvider := mockPluggableStateStorageProvider()
+		mockProvider := mockPluggableStateStorageProvider(mockSingleStateStoreSchema("test_store"))
+		mockProvider.MockStates = testing_provider.NewMockStateBytesWithStateIds("test_store", []string{"default"})
 		mockProviderAddress := addrs.NewDefaultProvider("test")
 
 		ui := new(cli.MockUi)
@@ -4447,7 +4465,8 @@ func TestInit_stateStore_newWorkingDir_interactiveProviderApproval(t *testing.T)
 			"hashicorp/test": {"1.2.3"},
 		})
 
-		mockProvider := mockPluggableStateStorageProvider()
+		mockProvider := mockPluggableStateStorageProvider(mockSingleStateStoreSchema("test_store"))
+		mockProvider.MockStates = testing_provider.NewMockStateBytesWithStateIds("test_store", []string{"default"})
 		mockProviderAddress := addrs.NewDefaultProvider("test")
 
 		// Allow the test to respond to the pause in provider installation for
@@ -4529,7 +4548,8 @@ func TestInit_stateStore_newWorkingDir_interactiveProviderApproval(t *testing.T)
 			"hashicorp/test": {"1.2.3"},
 		}, returnApprovedHashes)
 
-		mockProvider := mockPluggableStateStorageProvider()
+		mockProvider := mockPluggableStateStorageProvider(mockSingleStateStoreSchema("test_store"))
+		mockProvider.MockStates = testing_provider.NewMockStateBytesWithStateIds("test_store", []string{"default"})
 		mockProviderAddress := addrs.NewDefaultProvider("test")
 
 		// Allow the test to respond to the pause in provider installation for
@@ -4609,7 +4629,8 @@ func TestInit_stateStore_newWorkingDir_interactiveProviderApproval(t *testing.T)
 			"hashicorp/test": {"1.2.3"},
 		})
 
-		mockProvider := mockPluggableStateStorageProvider()
+		mockProvider := mockPluggableStateStorageProvider(mockSingleStateStoreSchema("test_store"))
+		mockProvider.MockStates = testing_provider.NewMockStateBytesWithStateIds("test_store", []string{"default"})
 		mockProviderAddress := addrs.NewDefaultProvider("test")
 
 		// Allow the test to respond to the pause in provider installation for
@@ -4690,7 +4711,8 @@ func TestInit_stateStore_newWorkingDir_interactiveProviderApproval(t *testing.T)
 		})
 
 		// Set up providers for use in the second init attempt.
-		mockProvider := mockPluggableStateStorageProvider()
+		mockProvider := mockPluggableStateStorageProvider(mockSingleStateStoreSchema("test_store"))
+		mockProvider.MockStates = testing_provider.NewMockStateBytesWithStateIds("test_store", []string{"default"})
 
 		ui := new(cli.MockUi)
 		view, done := testView(t)
@@ -4795,7 +4817,8 @@ func TestInit_stateStore_versionConstraintChildModule(t *testing.T) {
 		},
 	})
 
-	mockProvider := mockPluggableStateStorageProvider()
+	mockProvider := mockPluggableStateStorageProvider(mockSingleStateStoreSchema("test_store"))
+	mockProvider.MockStates = testing_provider.NewMockStateBytesWithStateIds("test_store", []string{"default"})
 	mockProviderAddress := addrs.NewDefaultProvider("test")
 
 	ui := new(cli.MockUi)
@@ -4892,7 +4915,8 @@ func TestInit_stateStore_newWorkingDir_inAutomationProviderApproval(t *testing.T
 			"hashicorp/test": {"1.2.3"},
 		})
 
-		mockProvider := mockPluggableStateStorageProvider()
+		mockProvider := mockPluggableStateStorageProvider(mockSingleStateStoreSchema("test_store"))
+		mockProvider.MockStates = testing_provider.NewMockStateBytesWithStateIds("test_store", []string{"default"})
 		mockProviderAddress := addrs.NewDefaultProvider("test")
 
 		ui := new(cli.MockUi)
@@ -4955,7 +4979,8 @@ func TestInit_stateStore_newWorkingDir_inAutomationProviderApproval(t *testing.T
 		source := newMockProviderSourceUsingTestHttpServer(t, map[string][]string{
 			"hashicorp/test": {expectedVersion, "9.9.9"}, // Extra version - expected version is downloaded, not the latest
 		})
-		mockProvider := mockPluggableStateStorageProvider()
+		mockProvider := mockPluggableStateStorageProvider(mockSingleStateStoreSchema("test_store"))
+		mockProvider.MockStates = testing_provider.NewMockStateBytesWithStateIds("test_store", []string{"default"})
 
 		ui := new(cli.MockUi)
 		view, done := testView(t)
@@ -5044,7 +5069,8 @@ func TestInit_stateStore_newWorkingDir_inAutomationProviderApproval(t *testing.T
 		source := newMockProviderSourceUsingTestHttpServer(t, map[string][]string{
 			"hashicorp/test": {expectedVersion, "9.9.9"}, // Extra version - expected version is downloaded, not the latest
 		})
-		mockProvider := mockPluggableStateStorageProvider()
+		mockProvider := mockPluggableStateStorageProvider(mockSingleStateStoreSchema("test_store"))
+		mockProvider.MockStates = testing_provider.NewMockStateBytesWithStateIds("test_store", []string{"default"})
 
 		ui := new(cli.MockUi)
 		view, done := testView(t)
@@ -5117,7 +5143,8 @@ func TestInit_stateStore_newWorkingDir_inAutomationProviderApproval(t *testing.T
 		source := newMockProviderSourceUsingTestHttpServer(t, map[string][]string{
 			"hashicorp/test": {expectedVersion},
 		})
-		mockProvider := mockPluggableStateStorageProvider()
+		mockProvider := mockPluggableStateStorageProvider(mockSingleStateStoreSchema("test_store"))
+		mockProvider.MockStates = testing_provider.NewMockStateBytesWithStateIds("test_store", []string{"default"})
 
 		ui := new(cli.MockUi)
 		view, done := testView(t)
@@ -5191,7 +5218,8 @@ func TestInit_stateStore_newWorkingDir_inAutomationProviderApproval(t *testing.T
 		source := newMockProviderSourceUsingTestHttpServer(t, map[string][]string{
 			"hashicorp/test": {expectedVersion},
 		})
-		mockProvider := mockPluggableStateStorageProvider()
+		mockProvider := mockPluggableStateStorageProvider(mockSingleStateStoreSchema("test_store"))
+		mockProvider.MockStates = testing_provider.NewMockStateBytesWithStateIds("test_store", []string{"default"})
 
 		ui := new(cli.MockUi)
 		view, done := testView(t)
@@ -5298,7 +5326,8 @@ func TestInit_stateStore_reconfigureLeadingToMigrationOfLocalState(t *testing.T)
 		"hashicorp/test": {"1.2.3"},
 	})
 
-	mockProvider := mockPluggableStateStorageProvider()
+	mockProvider := mockPluggableStateStorageProvider(mockSingleStateStoreSchema("test_store"))
+	mockProvider.MockStates = testing_provider.NewMockStateBytesWithStateIds("test_store", []string{"default"})
 	mockProviderAddress := addrs.NewDefaultProvider("test")
 
 	ui := new(cli.MockUi)
@@ -5382,7 +5411,8 @@ func TestInit_stateStore_configUnchanged(t *testing.T) {
 		testCopyDir(t, testFixturePath("state-store-unchanged"), td)
 		t.Chdir(td)
 
-		mockProvider := mockPluggableStateStorageProvider()
+		mockProvider := mockPluggableStateStorageProvider(mockSingleStateStoreSchema("test_store"))
+		mockProvider.MockStates = testing_provider.NewMockStateBytesWithStateIds("test_store", []string{"default"})
 		// If the working directory was previously initialized successfully then at least
 		// one workspace is guaranteed to exist when a user is re-running init with no config
 		// changes since last init. So this test says `default` exists.
@@ -5468,11 +5498,13 @@ func TestInit_stateStore_configChanges(t *testing.T) {
 		testCopyDir(t, testFixturePath("state-store-changed/store-config"), td)
 		t.Chdir(td)
 
-		mockProvider := mockPluggableStateStorageProvider()
-
+		mockProvider := mockPluggableStateStorageProvider(mockSingleStateStoreSchema("test_store"))
 		// The previous init implied by this test scenario would have created this.
-		mockProvider.GetStatesResponse = &providers.GetStatesResponse{States: []string{"default"}}
-		mockProvider.MockStates = map[string]interface{}{"default": []byte(`{"version": 4,"terraform_version":"1.15.0","serial": 1,"lineage": "","outputs": {},"resources": [],"checks":[]}`)}
+		mockProvider.MockStates = testing_provider.NewMockStateBytesWithSingleState(
+			"test_store",
+			"default",
+			[]byte(`{"version": 4,"terraform_version":"1.15.0","serial": 1,"lineage": "","outputs": {},"resources": [],"checks":[]}`),
+		)
 
 		mockProviderAddress := addrs.NewDefaultProvider("test")
 		providerSource := newMockProviderSource(t, map[string][]string{
@@ -5556,11 +5588,16 @@ func TestInit_stateStore_configChanges(t *testing.T) {
 		testCopyDir(t, testFixturePath("state-store-changed/store-config"), td)
 		t.Chdir(td)
 
-		mockProvider := mockPluggableStateStorageProvider()
+		mockProvider := mockPluggableStateStorageProvider(mockSingleStateStoreSchema("test_store"))
+		mockProvider.MockStates = testing_provider.NewMockStateBytesWithStateIds("test_store", []string{"default"})
 
 		// The previous init implied by this test scenario would have created this.
 		mockProvider.GetStatesResponse = &providers.GetStatesResponse{States: []string{"default"}}
-		mockProvider.MockStates = map[string]interface{}{"default": []byte(`{"version": 4,"terraform_version":"1.15.0","serial": 1,"lineage": "","outputs": {},"resources": [],"checks":[]}`)}
+		mockProvider.MockStates = testing_provider.NewMockStateBytesWithSingleState(
+			"test_store",
+			"default",
+			[]byte(`{"version": 4,"terraform_version":"1.15.0","serial": 1,"lineage": "","outputs": {},"resources": [],"checks":[]}`),
+		)
 
 		mockProviderAddress := addrs.NewDefaultProvider("test")
 		providerSource := newMockProviderSource(t, map[string][]string{
@@ -5616,8 +5653,8 @@ func TestInit_stateStore_configChanges(t *testing.T) {
 		testCopyDir(t, testFixturePath("state-store-changed/store-config"), td)
 		t.Chdir(td)
 
-		mockProvider := mockPluggableStateStorageProvider()
-		mockProvider.GetStatesResponse = &providers.GetStatesResponse{States: []string{"default"}} // The previous init implied by this test scenario would have created the default workspace.
+		mockProvider := mockPluggableStateStorageProvider(mockSingleStateStoreSchema("test_store"))
+		mockProvider.MockStates = testing_provider.NewMockStateBytesWithStateIds("test_store", []string{"default"}) // The previous init implied by this test scenario would have created the default workspace.
 		mockProviderAddress := addrs.NewDefaultProvider("test")
 		providerSource := newMockProviderSource(t, map[string][]string{
 			"hashicorp/test": {"1.2.3"}, // Matches provider version in backend state file fixture
@@ -5701,7 +5738,8 @@ func TestInit_stateStore_backendConfigFlagNoMigrate(t *testing.T) {
 	testCopyDir(t, testFixturePath("init-state-store"), td)
 	t.Chdir(td)
 
-	mockProvider := mockPluggableStateStorageProvider()
+	mockProvider := mockPluggableStateStorageProvider(mockSingleStateStoreSchema("test_store"))
+	mockProvider.MockStates = testing_provider.NewMockStateBytesWithStateIds("test_store", []string{"default"})
 	// Make the state store's value attribute optional in this test.
 	mockProvider.GetProviderSchemaResponse.StateStores["test_store"].Body.Attributes["value"].Required = false
 
@@ -5811,7 +5849,8 @@ func TestInit_stateStore_unset(t *testing.T) {
 	testCopyDir(t, testFixturePath("init-state-store"), td)
 	t.Chdir(td)
 
-	mockProvider := mockPluggableStateStorageProvider()
+	mockProvider := mockPluggableStateStorageProvider(mockSingleStateStoreSchema("test_store"))
+	mockProvider.MockStates = testing_provider.NewMockStateBytesWithStateIds("test_store", []string{"default"})
 	storeName := "test_store"
 	otherStoreName := "test_otherstore"
 	// Make the provider report that it contains a 2nd storage implementation with the above name
@@ -5914,7 +5953,8 @@ func TestInit_stateStore_unset_withoutProviderRequirements(t *testing.T) {
 	testCopyDir(t, testFixturePath("init-state-store"), td)
 	t.Chdir(td)
 
-	mockProvider := mockPluggableStateStorageProvider()
+	mockProvider := mockPluggableStateStorageProvider(mockSingleStateStoreSchema("test_store"))
+	mockProvider.MockStates = testing_provider.NewMockStateBytesWithStateIds("test_store", []string{"default"})
 	mockProviderAddress := addrs.NewDefaultProvider("test")
 	providerSource := newMockProviderSource(t, map[string][]string{
 		"hashicorp/test": {"1.2.3"}, // Matches provider version in backend state file fixture
@@ -6011,7 +6051,8 @@ func TestInit_stateStore_to_backend(t *testing.T) {
 	testCopyDir(t, testFixturePath("init-state-store"), td)
 	t.Chdir(td)
 
-	mockProvider := mockPluggableStateStorageProvider()
+	mockProvider := mockPluggableStateStorageProvider(mockSingleStateStoreSchema("test_store"))
+	mockProvider.MockStates = testing_provider.NewMockStateBytesWithStateIds("test_store", []string{"default"})
 	mockProviderAddress := addrs.NewDefaultProvider("test")
 	providerSource := newMockProviderSource(t, map[string][]string{
 		"hashicorp/test": {"1.2.3"}, // Matches provider version in backend state file fixture
@@ -6252,7 +6293,8 @@ func TestInit_backend_to_stateStore_singleWorkspace(t *testing.T) {
 	}
 	t.Chdir(td)
 
-	mockProvider := mockPluggableStateStorageProvider()
+	mockProvider := mockPluggableStateStorageProvider(mockSingleStateStoreSchema("test_store"))
+	mockProvider.MockStates = testing_provider.NewMockStateBytesWithStateIds("test_store", []string{"default"})
 	mockProviderAddress := addrs.NewDefaultProvider("test")
 	providerSource := newMockProviderSource(t, map[string][]string{
 		"hashicorp/test": {"1.2.3"},
@@ -6431,7 +6473,8 @@ func TestInit_backend_to_stateStore_noState(t *testing.T) {
 	}
 	t.Chdir(td)
 
-	mockProvider := mockPluggableStateStorageProvider()
+	mockProvider := mockPluggableStateStorageProvider(mockSingleStateStoreSchema("test_store"))
+	mockProvider.MockStates = testing_provider.NewMockStateBytesWithStateIds("test_store", []string{"default"})
 	mockProviderAddress := addrs.NewDefaultProvider("test")
 	providerSource := newMockProviderSource(t, map[string][]string{
 		"hashicorp/test": {"1.2.3"},
@@ -6544,7 +6587,8 @@ func TestInit_localBackend_to_stateStore(t *testing.T) {
 	}
 	t.Chdir(td)
 
-	mockProvider := mockPluggableStateStorageProvider()
+	mockProvider := mockPluggableStateStorageProvider(mockSingleStateStoreSchema("test_store"))
+	mockProvider.MockStates = testing_provider.NewMockStateBytesWithStateIds("test_store", []string{"default"})
 	mockProviderAddress := addrs.NewDefaultProvider("test")
 	providerSource := newMockProviderSource(t, map[string][]string{
 		"hashicorp/test": {"1.2.3"},
@@ -6704,7 +6748,8 @@ func TestInit_backend_to_stateStore_multipleWorkspaces(t *testing.T) {
 	}
 	t.Chdir(td)
 
-	mockProvider := mockPluggableStateStorageProvider()
+	mockProvider := mockPluggableStateStorageProvider(mockSingleStateStoreSchema("test_store"))
+	mockProvider.MockStates = testing_provider.NewMockStateBytesWithStateIds("test_store", []string{"default"})
 	mockProviderAddress := addrs.NewDefaultProvider("test")
 	providerSource := newMockProviderSource(t, map[string][]string{
 		"hashicorp/test": {"1.2.3"},
@@ -6943,7 +6988,8 @@ func TestInit_cloud_to_stateStore(t *testing.T) {
 	}
 	t.Chdir(td)
 
-	mockProvider := mockPluggableStateStorageProvider()
+	mockProvider := mockPluggableStateStorageProvider(mockSingleStateStoreSchema("test_store"))
+	mockProvider.MockStates = testing_provider.NewMockStateBytesWithStateIds("test_store", []string{"default"})
 	mockProviderAddress := addrs.NewDefaultProvider("test")
 	providerSource := newMockProviderSource(t, map[string][]string{
 		"hashicorp/test": {"1.2.3"},
@@ -7645,14 +7691,27 @@ func expectedPackageInstallPath(name, version string, exe bool) string {
 	))
 }
 
-// TODO: introduce pssName as argument here to aid testing migrations
-func mockPluggableStateStorageProvider() *testing_provider.MockProvider {
+func mockSingleStateStoreSchema(storeType string) map[string]providers.Schema {
+	return map[string]providers.Schema{
+		storeType: {
+			Body: &configschema.Block{
+				Attributes: map[string]*configschema.Attribute{
+					"value": {
+						Type:     cty.String,
+						Required: true,
+					},
+				},
+			},
+		},
+	}
+}
+
+func mockPluggableStateStorageProvider(schemas map[string]providers.Schema) *testing_provider.MockProvider {
 	// Create a mock provider to use for PSS
 	// Get mock provider factory to be used during init
 	//
 	// This imagines a provider called `test` that contains
 	// a pluggable state store implementation called `store`.
-	pssName := "test_store"
 	mock := testing_provider.MockProvider{
 		GetProviderSchemaResponse: &providers.GetProviderSchemaResponse{
 			Provider: providers.Schema{
@@ -7674,25 +7733,17 @@ func mockPluggableStateStorageProvider() *testing_provider.MockProvider {
 				},
 			},
 			ListResourceTypes: map[string]providers.Schema{},
-			StateStores: map[string]providers.Schema{
-				pssName: {
-					Body: &configschema.Block{
-						Attributes: map[string]*configschema.Attribute{
-							"value": {
-								Type:     cty.String,
-								Required: true,
-							},
-						},
-					},
-				},
-			},
+			StateStores:       schemas,
 		},
 	}
-	mock.GetStatesFn = func(req providers.GetStatesRequest) providers.GetStatesResponse {
-		states := slices.Sorted(maps.Keys(mock.MockStates))
-		return providers.GetStatesResponse{
-			States: states,
+	mock.GetStatesFn = func(req providers.GetStatesRequest) (resp providers.GetStatesResponse) {
+		stateIds, err := mock.MockStates.StateIds(req.TypeName)
+		if err != nil {
+			resp.Diagnostics = resp.Diagnostics.Append(err)
 		}
+		resp.States = stateIds
+
+		return resp
 	}
 	mock.ConfigureStateStoreFn = func(req providers.ConfigureStateStoreRequest) providers.ConfigureStateStoreResponse {
 		return providers.ConfigureStateStoreResponse{
@@ -7701,29 +7752,35 @@ func mockPluggableStateStorageProvider() *testing_provider.MockProvider {
 			},
 		}
 	}
-	mock.WriteStateBytesFn = func(req providers.WriteStateBytesRequest) providers.WriteStateBytesResponse {
+	mock.WriteStateBytesFn = func(req providers.WriteStateBytesRequest) (resp providers.WriteStateBytesResponse) {
 		// Workspaces exist once the artefact representing it is written
-		if _, exist := mock.MockStates[req.StateId]; !exist {
-			// Ensure non-nil map
-			if mock.MockStates == nil {
-				mock.MockStates = make(map[string]interface{})
+		err := mock.MockStates.Write(req.TypeName, req.StateId, req.Bytes)
+		if err != nil {
+			resp.Diagnostics = resp.Diagnostics.Append(err)
+		}
+
+		return resp
+	}
+	mock.ReadStateBytesFn = func(req providers.ReadStateBytesRequest) (resp providers.ReadStateBytesResponse) {
+		b, err := mock.MockStates.Read(req.TypeName, req.StateId)
+		if err != nil {
+			if errors.Is(err, testing_provider.StateNotFoundErr{TypeName: req.TypeName, StateId: req.StateId}) {
+				warn := tfdiags.SimpleWarning(err.Error())
+				resp.Diagnostics = resp.Diagnostics.Append(warn)
+			} else {
+				resp.Diagnostics = resp.Diagnostics.Append(err)
 			}
 		}
-		mock.MockStates[req.StateId] = req.Bytes
+		resp.Bytes = b
 
-		return providers.WriteStateBytesResponse{
-			Diagnostics: nil, // success
-		}
+		return resp
 	}
-	mock.ReadStateBytesFn = func(req providers.ReadStateBytesRequest) providers.ReadStateBytesResponse {
-		state := []byte{}
-		if v, exist := mock.MockStates[req.StateId]; exist {
-			state = v.([]byte) // If this panics, the mock has been set up with a bad MockStates value
+	mock.DeleteStateFn = func(req providers.DeleteStateRequest) (resp providers.DeleteStateResponse) {
+		err := mock.MockStates.Delete(req.TypeName, req.StateId)
+		if err != nil {
+			resp.Diagnostics = resp.Diagnostics.Append(err)
 		}
-		return providers.ReadStateBytesResponse{
-			Bytes:       state,
-			Diagnostics: nil, // success
-		}
+		return resp
 	}
 	return &mock
 }

--- a/internal/command/meta_backend_test.go
+++ b/internal/command/meta_backend_test.go
@@ -1688,7 +1688,7 @@ func TestMetaBackend_planLocal_stateStore(t *testing.T) {
 
 	// Setup the meta, including a mock provider set up to mock PSS
 	m := testMetaBackend(t, nil)
-	mock := testStateStoreMockWithChunkNegotiation(t, 1000)
+	mock := testStateStoreMockWithChunkNegotiation(t, testStateStoreMock(t), 1000)
 	m.testingOverrides = &testingOverrides{
 		Providers: map[addrs.Provider]providers.Factory{
 			addrs.NewDefaultProvider("test"): providers.FactoryFixed(mock),
@@ -3141,7 +3141,7 @@ func TestMetaBackend_prepareBackend(t *testing.T) {
 
 		m := testMetaBackend(t, nil)
 		m.AllowExperimentalFeatures = true
-		mock := testStateStoreMockWithChunkNegotiation(t, 12345) // chunk size needs to be set, value is arbitrary
+		mock := testStateStoreMockWithChunkNegotiation(t, testStateStoreMock(t), 12345) // chunk size needs to be set, value is arbitrary
 		m.testingOverrides = &testingOverrides{
 			Providers: map[addrs.Provider]providers.Factory{
 				addrs.NewDefaultProvider("test"): providers.FactoryFixed(mock),
@@ -3239,9 +3239,8 @@ func testStateStoreMock(t *testing.T) *testing_provider.MockProvider {
 // without this error: `Failed to negotiate acceptable chunk size`
 //
 // This is meant to be a convenience method when a test is definitely not testing anything related to state store configuration.
-func testStateStoreMockWithChunkNegotiation(t *testing.T, chunkSize int64) *testing_provider.MockProvider {
+func testStateStoreMockWithChunkNegotiation(t *testing.T, mock *testing_provider.MockProvider, chunkSize int64) *testing_provider.MockProvider {
 	t.Helper()
-	mock := testStateStoreMock(t)
 	mock.ConfigureStateStoreResponse = &providers.ConfigureStateStoreResponse{
 		Capabilities: providers.StateStoreServerCapabilities{
 			ChunkSize: chunkSize,

--- a/internal/command/output_test.go
+++ b/internal/command/output_test.go
@@ -19,6 +19,7 @@ import (
 	backendInit "github.com/hashicorp/terraform/internal/backend/init"
 	"github.com/hashicorp/terraform/internal/backend/remote-state/inmem"
 	"github.com/hashicorp/terraform/internal/providers"
+	testing_provider "github.com/hashicorp/terraform/internal/providers/testing"
 	"github.com/hashicorp/terraform/internal/states"
 	"github.com/hashicorp/terraform/internal/states/statefile"
 	"github.com/hashicorp/terraform/internal/tfdiags"
@@ -80,10 +81,12 @@ func TestOutput_stateStore(t *testing.T) {
 	}
 
 	// Create a mock that contains a persisted "default" state that uses the bytes from above.
-	mockProvider := mockPluggableStateStorageProvider()
-	mockProvider.MockStates = map[string]interface{}{
-		"default": stateBuf.Bytes(),
-	}
+	mockProvider := mockPluggableStateStorageProvider(mockSingleStateStoreSchema("test_store"))
+	mockProvider.MockStates = testing_provider.NewMockStateBytesWithSingleState(
+		"test_store",
+		"default",
+		stateBuf.Bytes(),
+	)
 	mockProviderAddress := addrs.NewDefaultProvider("test")
 
 	view, done := testView(t)

--- a/internal/command/plan_test.go
+++ b/internal/command/plan_test.go
@@ -581,10 +581,12 @@ func TestPlan_outStateStore(t *testing.T) {
 	// Make a mock provider that:
 	// 1) will return the state defined above.
 	// 2) has a schema for the resource being managed in this test.
-	mock := mockPluggableStateStorageProvider()
-	mock.MockStates = map[string]interface{}{
-		"default": stateBytes,
-	}
+	mock := mockPluggableStateStorageProvider(mockSingleStateStoreSchema("test_store"))
+	mock.MockStates = testing_provider.NewMockStateBytesWithSingleState(
+		"test_store",
+		"default",
+		stateBytes,
+	)
 	mock.GetProviderSchemaResponse.ResourceTypes = map[string]providers.Schema{
 		"test_instance": {
 			Body: &configschema.Block{

--- a/internal/command/providers_schema_test.go
+++ b/internal/command/providers_schema_test.go
@@ -197,10 +197,12 @@ func TestProvidersSchema_output_withStateStore(t *testing.T) {
 	}
 
 	// Create a mock that contains a persisted "default" state that uses the bytes from above.
-	mockProvider := mockPluggableStateStorageProvider()
-	mockProvider.MockStates = map[string]interface{}{
-		"default": stateBuf.Bytes(),
-	}
+	mockProvider := mockPluggableStateStorageProvider(mockSingleStateStoreSchema("test_store"))
+	mockProvider.MockStates = testing_provider.NewMockStateBytesWithSingleState(
+		"test_store",
+		"default",
+		stateBuf.Bytes(),
+	)
 	mockProviderAddressTest := addrs.NewDefaultProvider("test")
 
 	// Mock for the provider in the state

--- a/internal/command/providers_test.go
+++ b/internal/command/providers_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform/internal/backend"
 	backendInit "github.com/hashicorp/terraform/internal/backend/init"
 	"github.com/hashicorp/terraform/internal/providers"
+	testing_provider "github.com/hashicorp/terraform/internal/providers/testing"
 	"github.com/hashicorp/terraform/internal/states"
 	"github.com/hashicorp/terraform/internal/states/statefile"
 )
@@ -242,10 +243,12 @@ func TestProviders_state_withStateStore(t *testing.T) {
 	}
 
 	// Create a mock that contains a persisted "default" state that uses the bytes from above.
-	mockProvider := mockPluggableStateStorageProvider()
-	mockProvider.MockStates = map[string]interface{}{
-		"default": stateBuf.Bytes(),
-	}
+	mockProvider := mockPluggableStateStorageProvider(mockSingleStateStoreSchema("test_store"))
+	mockProvider.MockStates = testing_provider.NewMockStateBytesWithSingleState(
+		"test_store",
+		"default",
+		stateBuf.Bytes(),
+	)
 	mockProviderAddress := addrs.NewDefaultProvider("test")
 
 	ui := new(cli.MockUi)

--- a/internal/command/show_test.go
+++ b/internal/command/show_test.go
@@ -1164,10 +1164,12 @@ func TestShow_stateStore(t *testing.T) {
 	}
 
 	// Create a mock that contains a persisted "default" state that uses the bytes from above.
-	mockProvider := mockPluggableStateStorageProvider()
-	mockProvider.MockStates = map[string]interface{}{
-		"default": stateBuf.Bytes(),
-	}
+	mockProvider := mockPluggableStateStorageProvider(mockSingleStateStoreSchema("test_store"))
+	mockProvider.MockStates = testing_provider.NewMockStateBytesWithSingleState(
+		"test_store",
+		"default",
+		stateBuf.Bytes(),
+	)
 	mockProviderAddress := addrs.NewDefaultProvider("test")
 
 	view, done := testView(t)

--- a/internal/command/state_identities_test.go
+++ b/internal/command/state_identities_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/cli"
 	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/providers"
+	testing_provider "github.com/hashicorp/terraform/internal/providers/testing"
 	"github.com/hashicorp/terraform/internal/states/statefile"
 )
 
@@ -443,10 +444,12 @@ func TestStateIdentities_stateStore(t *testing.T) {
 	stateBytes := stateBuf.Bytes()
 
 	// Create a mock that contains a persisted "default" state that uses the bytes from above.
-	mockProvider := mockPluggableStateStorageProvider()
-	mockProvider.MockStates = map[string]interface{}{
-		"default": stateBytes,
-	}
+	mockProvider := mockPluggableStateStorageProvider(mockSingleStateStoreSchema("test_store"))
+	mockProvider.MockStates = testing_provider.NewMockStateBytesWithSingleState(
+		"test_store",
+		"default",
+		stateBytes,
+	)
 	mockProviderAddress := addrs.NewDefaultProvider("test")
 
 	ui := cli.NewMockUi()

--- a/internal/command/state_list_test.go
+++ b/internal/command/state_list_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/cli"
 	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/providers"
+	testing_provider "github.com/hashicorp/terraform/internal/providers/testing"
 	"github.com/hashicorp/terraform/internal/states"
 	"github.com/hashicorp/terraform/internal/states/statefile"
 )
@@ -198,10 +199,12 @@ func TestStateList_stateStore(t *testing.T) {
 	}
 
 	// Create a mock that contains a persisted "default" state that uses the bytes from above.
-	mockProvider := mockPluggableStateStorageProvider()
-	mockProvider.MockStates = map[string]interface{}{
-		"default": stateBuf.Bytes(),
-	}
+	mockProvider := mockPluggableStateStorageProvider(mockSingleStateStoreSchema("test_store"))
+	mockProvider.MockStates = testing_provider.NewMockStateBytesWithSingleState(
+		"test_store",
+		"default",
+		stateBuf.Bytes(),
+	)
 	mockProviderAddress := addrs.NewDefaultProvider("test")
 
 	ui := cli.NewMockUi()

--- a/internal/command/state_migrate.go
+++ b/internal/command/state_migrate.go
@@ -105,7 +105,7 @@ func (c *StateMigrateCommand) Run(rawArgs []string) int {
 		}
 	} else if smi.StateStore != nil {
 		source = fmt.Sprintf("state store %q (%s)", smi.StateStore.Type,
-			smi.StateStore.ProviderAddr)
+			smi.StateStore.ProviderAddr.ForDisplay())
 
 		srcLocks, srcLockDiags := depsfile.LoadLocksFromFile(args.SourceLockFilePath)
 		if srcLockDiags.HasErrors() {
@@ -138,7 +138,7 @@ func (c *StateMigrateCommand) Run(rawArgs []string) int {
 		}
 	} else if rootMod.StateStore != nil {
 		destination = fmt.Sprintf("state store %q (%s)", rootMod.StateStore.Type,
-			rootMod.StateStore.ProviderAddr)
+			rootMod.StateStore.ProviderAddr.ForDisplay())
 
 		dstLocks, dstLockDiags := depsfile.LoadLocksFromFile(args.DestinationLockFilePath)
 		if dstLockDiags.HasErrors() {

--- a/internal/command/state_migrate.go
+++ b/internal/command/state_migrate.go
@@ -4,13 +4,13 @@
 package command
 
 import (
-	"errors"
 	"fmt"
 	"os"
 	"strings"
 
 	"github.com/hashicorp/terraform/internal/command/arguments"
 	"github.com/hashicorp/terraform/internal/command/views"
+	"github.com/hashicorp/terraform/internal/depsfile"
 	"github.com/hashicorp/terraform/internal/tfdiags"
 )
 
@@ -86,40 +86,104 @@ func (c *StateMigrateCommand) Run(rawArgs []string) int {
 		return 1
 	}
 
+	// TODO: Account for cases where lock entries are missing
+
+	migrateOpts := &backendMigrateOpts{
+		ViewType: args.ViewType,
+	}
+
+	// Load the source backend
 	var source string
 	if smi.Backend != nil {
 		source = fmt.Sprintf("backend %q", smi.Backend.Type)
+
+		srcB, _, srcDiags := c.Meta.backendInitFromConfig(smi.Backend)
+		diags = diags.Append(srcDiags)
+		if !diags.HasErrors() {
+			migrateOpts.SourceType = smi.Backend.Type
+			migrateOpts.Source = srcB
+		}
 	} else if smi.StateStore != nil {
 		source = fmt.Sprintf("state store %q (%s)", smi.StateStore.Type,
 			smi.StateStore.ProviderAddr)
+
+		srcLocks, srcLockDiags := depsfile.LoadLocksFromFile(args.SourceLockFilePath)
+		if srcLockDiags.HasErrors() {
+			diags = diags.Append(srcLockDiags)
+			stateMigrate.Diagnostics(diags)
+			return 1
+		} else {
+			diags = diags.Append(srcLockDiags)
+
+			srcB, _, _, srcDiags := c.Meta.stateStoreInitFromConfig(smi.StateStore, srcLocks)
+			diags = diags.Append(srcDiags)
+			if !diags.HasErrors() {
+				migrateOpts.SourceType = smi.StateStore.Type
+				migrateOpts.Source = srcB
+			}
+		}
 	}
 
+	// Load the destination backend
 	rootMod := cfg.Module
 	var destination string
 	if rootMod.Backend != nil {
 		destination = fmt.Sprintf("backend %q", rootMod.Backend.Type)
+
+		dstB, _, dstDiags := c.Meta.backendInitFromConfig(rootMod.Backend)
+		diags = diags.Append(dstDiags)
+		if !diags.HasErrors() {
+			migrateOpts.DestinationType = rootMod.Backend.Type
+			migrateOpts.Destination = dstB
+		}
 	} else if rootMod.StateStore != nil {
 		destination = fmt.Sprintf("state store %q (%s)", rootMod.StateStore.Type,
 			rootMod.StateStore.ProviderAddr)
+
+		dstLocks, dstLockDiags := depsfile.LoadLocksFromFile(args.DestinationLockFilePath)
+		if dstLockDiags.HasErrors() {
+			diags = diags.Append(dstLockDiags)
+			stateMigrate.Diagnostics(diags)
+			return 1
+		} else {
+			diags = diags.Append(dstLockDiags)
+
+			dstB, _, _, dstDiags := c.Meta.stateStoreInitFromConfig(rootMod.StateStore, dstLocks)
+			diags = diags.Append(dstDiags)
+			if !diags.HasErrors() {
+				migrateOpts.DestinationType = rootMod.StateStore.Type
+				migrateOpts.Destination = dstB
+			}
+		}
 	} else {
 		diags = diags.Append(tfdiags.Sourceless(
 			tfdiags.Error,
 			"Unknown migration destination",
 			"No configuration was provided for where to migrate the state to. Please ensure that a file with a .tf extension is present and contains valid state_store or backend configuration inside the terraform block.",
 		))
+	}
+
+	// present all errors from above together so user can fix them all at once
+	if diags.HasErrors() {
 		stateMigrate.Diagnostics(diags)
 		return 1
 	}
 
 	stateMigrate.Log("Migrating state from %s to %s...", source, destination)
 
-	// TODO: Load the source backend
-	// TODO: Load the destination backend
-	// TODO: Perform the migration from source to destination
+	// Perform the migration from source to destination
+	err := c.Meta.backendMigrateState(migrateOpts)
+	if err != nil {
+		diags = diags.Append(fmt.Errorf("migration failed: %w", err))
+		stateMigrate.Diagnostics(diags)
+		return 1
+	}
 
-	diags = diags.Append(errors.New("Not implemented yet"))
 	stateMigrate.Diagnostics(diags)
-	return 1
+
+	stateMigrate.Log("Finished migrating state from %s to %s...", source, destination)
+
+	return 0
 }
 
 func (c *StateMigrateCommand) Help() string {

--- a/internal/command/state_migrate_test.go
+++ b/internal/command/state_migrate_test.go
@@ -12,6 +12,9 @@ import (
 
 	"github.com/hashicorp/cli"
 	"github.com/hashicorp/terraform/internal/command/workdir"
+	"github.com/hashicorp/terraform/internal/configs/configschema"
+	"github.com/hashicorp/terraform/internal/providers"
+	testing_provider "github.com/hashicorp/terraform/internal/providers/testing"
 	"github.com/hashicorp/terraform/internal/states/statefile"
 )
 
@@ -70,7 +73,8 @@ func TestStateMigrate_fromBackendToStateStore(t *testing.T) {
 	wd := tempWorkingDirFixture(t, "state-migrate-backend-to-state-store")
 	t.Chdir(wd.RootModuleDir())
 
-	p := mockPluggableStateStorageProvider()
+	p := mockPluggableStateStorageProvider(mockSingleStateStoreSchema("test_store"))
+	p.MockStates = testing_provider.NewMockStateBytesWithStateIds("test_store", []string{"default"})
 	providerSource := newMockProviderSource(t, map[string][]string{
 		"hashicorp/test": {"1.0.0"},
 	})
@@ -104,15 +108,15 @@ func TestStateMigrate_fromBackendToStateStore(t *testing.T) {
 		t.Fatalf("expected output %q, got %q", expectedMsg, out.Stdout())
 	}
 
-	b, ok := p.MockStates["default"].([]byte)
-	if !ok {
-		t.Fatalf("unable to find migrated state in mock provider")
+	b, err := p.MockStates.Read("test_store", "default")
+	if err != nil {
+		t.Fatalf("unable to find migrated state in mock provider: %s", err)
 	}
 	s, err := statefile.Read(bytes.NewBuffer(b))
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, ok = s.State.RootOutputValues["test"]
+	_, ok := s.State.RootOutputValues["test"]
 	if !ok {
 		t.Fatalf("unable to find test output in migrated state")
 	}
@@ -122,8 +126,28 @@ func TestStateMigrate_fromStateStoreToStateStore(t *testing.T) {
 	wd := tempWorkingDirFixture(t, "state-migrate-state-store-to-state-store")
 	t.Chdir(wd.RootModuleDir())
 
-	p := mockPluggableStateStorageProvider()
-	// TODO: mock out read method to return state with `test` output
+	b, err := os.ReadFile("source-pss.tfstate")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	pssSchemas := map[string]providers.Schema{
+		"test_src": {
+			Body: &configschema.Block{
+				Attributes: map[string]*configschema.Attribute{},
+			},
+		},
+		"test_dst": {
+			Body: &configschema.Block{
+				Attributes: map[string]*configschema.Attribute{},
+			},
+		},
+	}
+	p := mockPluggableStateStorageProvider(pssSchemas)
+	p.MockStates = testing_provider.MockStateBytes{
+		"test_src": map[string][]byte{"default": []byte(b)},
+		"test_dst": map[string][]byte{},
+	}
 	providerSource := newMockProviderSource(t, map[string][]string{
 		"hashicorp/test": {"1.0.0"},
 	})
@@ -152,20 +176,20 @@ func TestStateMigrate_fromStateStoreToStateStore(t *testing.T) {
 		t.Fatalf("unexpected exit: %d\nstderr: %q", code, out.Stderr())
 	}
 
-	expectedMsg := `Migrating state from state store "test_store" (registry.terraform.io/hashicorp/test) to state store "test_store" (registry.terraform.io/hashicorp/test)...`
+	expectedMsg := `Migrating state from state store "test_src" (registry.terraform.io/hashicorp/test) to state store "test_dst" (registry.terraform.io/hashicorp/test)...`
 	if !strings.Contains(out.Stdout(), expectedMsg) {
 		t.Fatalf("expected output %q, got %q", expectedMsg, out.Stdout())
 	}
 
-	b, ok := p.MockStates["default"].([]byte)
-	if !ok {
-		t.Fatalf("unable to find migrated state in mock provider")
+	b, err = p.MockStates.Read("test_dst", "default")
+	if err != nil {
+		t.Fatalf("unable to find migrated state in mock provider: %s", err)
 	}
 	s, err := statefile.Read(bytes.NewBuffer(b))
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, ok = s.State.RootOutputValues["test"]
+	_, ok := s.State.RootOutputValues["test"]
 	if !ok {
 		t.Fatalf("unable to find test output in migrated state")
 	}
@@ -175,14 +199,16 @@ func TestStateMigrate_fromStateStoreToBackend(t *testing.T) {
 	wd := tempWorkingDirFixture(t, "state-migrate-state-store-to-backend")
 	t.Chdir(wd.RootModuleDir())
 
-	p := mockPluggableStateStorageProvider()
+	p := mockPluggableStateStorageProvider(mockSingleStateStoreSchema("test_store"))
 	b, err := os.ReadFile("source-pss.tfstate")
 	if err != nil {
 		t.Fatal(err)
 	}
-	p.MockStates = map[string]any{
-		"default": b,
-	}
+	p.MockStates = testing_provider.NewMockStateBytesWithSingleState(
+		"test_store",
+		"default",
+		b,
+	)
 
 	providerSource := newMockProviderSource(t, map[string][]string{
 		"hashicorp/test": {"1.0.0"},

--- a/internal/command/state_migrate_test.go
+++ b/internal/command/state_migrate_test.go
@@ -4,12 +4,15 @@
 package command
 
 import (
+	"bytes"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/hashicorp/cli"
 	"github.com/hashicorp/terraform/internal/command/workdir"
+	"github.com/hashicorp/terraform/internal/states/statefile"
 )
 
 func TestStateMigrate_fromBackendToBackend(t *testing.T) {
@@ -27,21 +30,39 @@ func TestStateMigrate_fromBackendToBackend(t *testing.T) {
 		},
 	}
 
+	_ = testInputMap(t, map[string]string{
+		"backend-migrate-copy-to-empty": "yes",
+	})
+
 	args := []string{"-no-color"}
 	code := c.Run(args)
-	if code != 1 {
-		t.Fatalf("expected exit code 1, got %d", code)
-	}
 	out := done(t)
+	if code != 0 {
+		t.Fatalf("expected exit code 1, got %d\nstderr: %q", code, out.Stderr())
+	}
 
-	expectedMsg := `Migrating state from backend "local" to backend "local"...`
+	expectedMsg := `Finished migrating state from backend "local" to backend "local"...`
 	if !strings.Contains(out.Stdout(), expectedMsg) {
 		t.Fatalf("expected output %q, got %q", expectedMsg, out.Stdout())
 	}
 
-	expectedErr := "Not implemented yet"
-	if !strings.Contains(out.Stderr(), expectedErr) {
-		t.Fatalf("expected output %q, got %q", expectedErr, out.Stderr())
+	f, err := os.Open("destination-backend.tfstate")
+	if err != nil {
+		t.Fatalf("failed to read migrated state: %s", err)
+	}
+	t.Cleanup(func() {
+		err := f.Close()
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
+	s, err := statefile.Read(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, ok := s.State.RootOutputValues["test"]
+	if !ok {
+		t.Fatalf("unable to find test output in migrated state")
 	}
 }
 
@@ -49,6 +70,11 @@ func TestStateMigrate_fromBackendToStateStore(t *testing.T) {
 	wd := tempWorkingDirFixture(t, "state-migrate-backend-to-state-store")
 	t.Chdir(wd.RootModuleDir())
 
+	p := mockPluggableStateStorageProvider()
+	providerSource := newMockProviderSource(t, map[string][]string{
+		"hashicorp/test": {"1.0.0"},
+	})
+
 	ui := cli.NewMockUi()
 	view, done := testView(t)
 	c := &StateMigrateCommand{
@@ -57,24 +83,38 @@ func TestStateMigrate_fromBackendToStateStore(t *testing.T) {
 			View:                      view,
 			WorkingDir:                wd,
 			AllowExperimentalFeatures: true,
+			testingOverrides:          metaOverridesForProvider(p),
+			ProviderSource:            providerSource,
 		},
 	}
 
+	_ = testInputMap(t, map[string]string{
+		"backend-migrate-copy-to-empty": "yes",
+	})
+
 	args := []string{"-no-color"}
 	code := c.Run(args)
-	if code != 1 {
-		t.Fatalf("expected exit code 1, got %d", code)
-	}
 	out := done(t)
+	if code != 0 {
+		t.Fatalf("unexpected exit: %d\nstderr: %q", code, out.Stderr())
+	}
 
 	expectedMsg := `Migrating state from backend "local" to state store "test_store" (registry.terraform.io/hashicorp/test)...`
 	if !strings.Contains(out.Stdout(), expectedMsg) {
 		t.Fatalf("expected output %q, got %q", expectedMsg, out.Stdout())
 	}
 
-	expectedErr := "Not implemented yet"
-	if !strings.Contains(out.Stderr(), expectedErr) {
-		t.Fatalf("expected output %q, got %q", expectedErr, out.All())
+	b, ok := p.MockStates["default"].([]byte)
+	if !ok {
+		t.Fatalf("unable to find migrated state in mock provider")
+	}
+	s, err := statefile.Read(bytes.NewBuffer(b))
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, ok = s.State.RootOutputValues["test"]
+	if !ok {
+		t.Fatalf("unable to find test output in migrated state")
 	}
 }
 
@@ -82,6 +122,12 @@ func TestStateMigrate_fromStateStoreToStateStore(t *testing.T) {
 	wd := tempWorkingDirFixture(t, "state-migrate-state-store-to-state-store")
 	t.Chdir(wd.RootModuleDir())
 
+	p := mockPluggableStateStorageProvider()
+	// TODO: mock out read method to return state with `test` output
+	providerSource := newMockProviderSource(t, map[string][]string{
+		"hashicorp/test": {"1.0.0"},
+	})
+
 	ui := cli.NewMockUi()
 	view, done := testView(t)
 	c := &StateMigrateCommand{
@@ -90,24 +136,38 @@ func TestStateMigrate_fromStateStoreToStateStore(t *testing.T) {
 			View:                      view,
 			WorkingDir:                wd,
 			AllowExperimentalFeatures: true,
+			testingOverrides:          metaOverridesForProvider(p),
+			ProviderSource:            providerSource,
 		},
 	}
 
+	_ = testInputMap(t, map[string]string{
+		"backend-migrate-copy-to-empty": "yes",
+	})
+
 	args := []string{"-no-color"}
 	code := c.Run(args)
-	if code != 1 {
-		t.Fatalf("expected exit code 1, got %d", code)
-	}
 	out := done(t)
+	if code != 0 {
+		t.Fatalf("unexpected exit: %d\nstderr: %q", code, out.Stderr())
+	}
 
 	expectedMsg := `Migrating state from state store "test_store" (registry.terraform.io/hashicorp/test) to state store "test_store" (registry.terraform.io/hashicorp/test)...`
 	if !strings.Contains(out.Stdout(), expectedMsg) {
 		t.Fatalf("expected output %q, got %q", expectedMsg, out.Stdout())
 	}
 
-	expectedErr := "Not implemented yet"
-	if !strings.Contains(out.Stderr(), expectedErr) {
-		t.Fatalf("expected output %q, got %q", expectedErr, out.All())
+	b, ok := p.MockStates["default"].([]byte)
+	if !ok {
+		t.Fatalf("unable to find migrated state in mock provider")
+	}
+	s, err := statefile.Read(bytes.NewBuffer(b))
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, ok = s.State.RootOutputValues["test"]
+	if !ok {
+		t.Fatalf("unable to find test output in migrated state")
 	}
 }
 
@@ -115,6 +175,19 @@ func TestStateMigrate_fromStateStoreToBackend(t *testing.T) {
 	wd := tempWorkingDirFixture(t, "state-migrate-state-store-to-backend")
 	t.Chdir(wd.RootModuleDir())
 
+	p := mockPluggableStateStorageProvider()
+	b, err := os.ReadFile("source-pss.tfstate")
+	if err != nil {
+		t.Fatal(err)
+	}
+	p.MockStates = map[string]any{
+		"default": b,
+	}
+
+	providerSource := newMockProviderSource(t, map[string][]string{
+		"hashicorp/test": {"1.0.0"},
+	})
+
 	ui := cli.NewMockUi()
 	view, done := testView(t)
 	c := &StateMigrateCommand{
@@ -123,24 +196,44 @@ func TestStateMigrate_fromStateStoreToBackend(t *testing.T) {
 			View:                      view,
 			WorkingDir:                wd,
 			AllowExperimentalFeatures: true,
+			testingOverrides:          metaOverridesForProvider(p),
+			ProviderSource:            providerSource,
 		},
 	}
 
+	_ = testInputMap(t, map[string]string{
+		"backend-migrate-copy-to-empty": "yes",
+	})
+
 	args := []string{"-no-color"}
 	code := c.Run(args)
-	if code != 1 {
-		t.Fatalf("expected exit code 1, got %d", code)
-	}
 	out := done(t)
+	if code != 0 {
+		t.Fatalf("unexpected exit: %d\nstderr: %q", code, out.Stderr())
+	}
 
 	expectedMsg := `Migrating state from state store "test_store" (registry.terraform.io/hashicorp/test) to backend "local"...`
 	if !strings.Contains(out.Stdout(), expectedMsg) {
 		t.Fatalf("expected output %q, got %q", expectedMsg, out.Stdout())
 	}
 
-	expectedErr := "Not implemented yet"
-	if !strings.Contains(out.Stderr(), expectedErr) {
-		t.Fatalf("expected output %q, got %q", expectedErr, out.All())
+	f, err := os.Open("destination-backend.tfstate")
+	if err != nil {
+		t.Fatalf("failed to read migrated state: %s", err)
+	}
+	t.Cleanup(func() {
+		err := f.Close()
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
+	s, err := statefile.Read(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, ok := s.State.RootOutputValues["test"]
+	if !ok {
+		t.Fatalf("unable to find test output in migrated state")
 	}
 }
 

--- a/internal/command/state_migrate_test.go
+++ b/internal/command/state_migrate_test.go
@@ -103,7 +103,7 @@ func TestStateMigrate_fromBackendToStateStore(t *testing.T) {
 		t.Fatalf("unexpected exit: %d\nstderr: %q", code, out.Stderr())
 	}
 
-	expectedMsg := `Migrating state from backend "local" to state store "test_store" (registry.terraform.io/hashicorp/test)...`
+	expectedMsg := `Migrating state from backend "local" to state store "test_store" (hashicorp/test)...`
 	if !strings.Contains(out.Stdout(), expectedMsg) {
 		t.Fatalf("expected output %q, got %q", expectedMsg, out.Stdout())
 	}
@@ -176,7 +176,7 @@ func TestStateMigrate_fromStateStoreToStateStore(t *testing.T) {
 		t.Fatalf("unexpected exit: %d\nstderr: %q", code, out.Stderr())
 	}
 
-	expectedMsg := `Migrating state from state store "test_src" (registry.terraform.io/hashicorp/test) to state store "test_dst" (registry.terraform.io/hashicorp/test)...`
+	expectedMsg := `Migrating state from state store "test_src" (hashicorp/test) to state store "test_dst" (hashicorp/test)...`
 	if !strings.Contains(out.Stdout(), expectedMsg) {
 		t.Fatalf("expected output %q, got %q", expectedMsg, out.Stdout())
 	}
@@ -238,7 +238,7 @@ func TestStateMigrate_fromStateStoreToBackend(t *testing.T) {
 		t.Fatalf("unexpected exit: %d\nstderr: %q", code, out.Stderr())
 	}
 
-	expectedMsg := `Migrating state from state store "test_store" (registry.terraform.io/hashicorp/test) to backend "local"...`
+	expectedMsg := `Migrating state from state store "test_store" (hashicorp/test) to backend "local"...`
 	if !strings.Contains(out.Stdout(), expectedMsg) {
 		t.Fatalf("expected output %q, got %q", expectedMsg, out.Stdout())
 	}

--- a/internal/command/state_mv_test.go
+++ b/internal/command/state_mv_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/hashicorp/terraform/internal/backend"
 	backendInit "github.com/hashicorp/terraform/internal/backend/init"
 	"github.com/hashicorp/terraform/internal/providers"
+	testing_provider "github.com/hashicorp/terraform/internal/providers/testing"
 	"github.com/hashicorp/terraform/internal/states"
 	"github.com/hashicorp/terraform/internal/states/statefile"
 )
@@ -204,10 +205,12 @@ func TestStateMv_stateStore(t *testing.T) {
 	}
 
 	// Create a mock that contains a persisted "default" state that uses the bytes from above.
-	mockProvider := mockPluggableStateStorageProvider()
-	mockProvider.MockStates = map[string]interface{}{
-		"default": stateBuf.Bytes(),
-	}
+	mockProvider := mockPluggableStateStorageProvider(mockSingleStateStoreSchema("test_store"))
+	mockProvider.MockStates = testing_provider.NewMockStateBytesWithSingleState(
+		"test_store",
+		"default",
+		stateBuf.Bytes(),
+	)
 	mockProviderAddress := addrs.NewDefaultProvider("test")
 
 	// Make the mock assert that the resource has been moved when the new state is persisted

--- a/internal/command/state_pull_test.go
+++ b/internal/command/state_pull_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform/internal/backend"
 	backendInit "github.com/hashicorp/terraform/internal/backend/init"
 	"github.com/hashicorp/terraform/internal/providers"
+	testing_provider "github.com/hashicorp/terraform/internal/providers/testing"
 	"github.com/hashicorp/terraform/internal/states"
 	"github.com/hashicorp/terraform/internal/states/statefile"
 	"github.com/hashicorp/terraform/internal/terminal"
@@ -101,10 +102,12 @@ func TestStatePull_stateStore(t *testing.T) {
 	stateBytes := stateBuf.Bytes()
 
 	// Create a mock that contains a persisted "default" state that uses the bytes from above.
-	mockProvider := mockPluggableStateStorageProvider()
-	mockProvider.MockStates = map[string]any{
-		"default": stateBytes,
-	}
+	mockProvider := mockPluggableStateStorageProvider(mockSingleStateStoreSchema("test_store"))
+	mockProvider.MockStates = testing_provider.NewMockStateBytesWithSingleState(
+		"test_store",
+		"default",
+		stateBytes,
+	)
 	mockProviderAddress := addrs.NewDefaultProvider("test")
 	providerSource := newMockProviderSource(t, map[string][]string{
 		"hashicorp/test": {"1.0.0"},

--- a/internal/command/state_push_test.go
+++ b/internal/command/state_push_test.go
@@ -15,6 +15,7 @@ import (
 	backendInit "github.com/hashicorp/terraform/internal/backend/init"
 	"github.com/hashicorp/terraform/internal/backend/remote-state/inmem"
 	"github.com/hashicorp/terraform/internal/providers"
+	testing_provider "github.com/hashicorp/terraform/internal/providers/testing"
 	"github.com/hashicorp/terraform/internal/states"
 	"github.com/hashicorp/terraform/internal/states/statefile"
 )
@@ -58,7 +59,8 @@ func TestStatePush_stateStore(t *testing.T) {
 	expected := testStateRead(t, "replace.tfstate")
 
 	// Create a mock that doesn't have any internal states.
-	mockProvider := mockPluggableStateStorageProvider()
+	mockProvider := mockPluggableStateStorageProvider(mockSingleStateStoreSchema("test_store"))
+	mockProvider.MockStates = testing_provider.NewMockStateBytesWithStateIds("test_store", []string{"default"})
 	mockProviderAddress := addrs.NewDefaultProvider("test")
 
 	ui := new(cli.MockUi)
@@ -80,7 +82,11 @@ func TestStatePush_stateStore(t *testing.T) {
 	}
 
 	// Access the pushed state from the mock's internal store
-	r := bytes.NewReader(mockProvider.MockStates["default"].([]byte))
+	b, err := mockProvider.MockStates.Read("test_store", "default")
+	if err != nil {
+		t.Fatal(err)
+	}
+	r := bytes.NewReader(b)
 	actual, err := statefile.Read(r)
 	if err != nil {
 		t.Fatal(err)

--- a/internal/command/state_replace_provider_test.go
+++ b/internal/command/state_replace_provider_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/hashicorp/terraform/internal/backend"
 	backendInit "github.com/hashicorp/terraform/internal/backend/init"
 	"github.com/hashicorp/terraform/internal/providers"
+	testing_provider "github.com/hashicorp/terraform/internal/providers/testing"
 	"github.com/hashicorp/terraform/internal/states"
 	"github.com/hashicorp/terraform/internal/states/statefile"
 )
@@ -336,10 +337,12 @@ func TestStateReplaceProvider_stateStore(t *testing.T) {
 	}
 
 	// Create a mock that contains a persisted "default" state that uses the bytes from above.
-	mockProvider := mockPluggableStateStorageProvider()
-	mockProvider.MockStates = map[string]interface{}{
-		"default": stateBuf.Bytes(),
-	}
+	mockProvider := mockPluggableStateStorageProvider(mockSingleStateStoreSchema("test_store"))
+	mockProvider.MockStates = testing_provider.NewMockStateBytesWithSingleState(
+		"test_store",
+		"default",
+		stateBuf.Bytes(),
+	)
 	mockProviderAddress := addrs.NewDefaultProvider("test")
 
 	ui := new(cli.MockUi)

--- a/internal/command/state_rm_test.go
+++ b/internal/command/state_rm_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/hashicorp/terraform/internal/backend"
 	backendInit "github.com/hashicorp/terraform/internal/backend/init"
 	"github.com/hashicorp/terraform/internal/providers"
+	testing_provider "github.com/hashicorp/terraform/internal/providers/testing"
 	"github.com/hashicorp/terraform/internal/states"
 	"github.com/hashicorp/terraform/internal/states/statefile"
 )
@@ -134,10 +135,12 @@ func TestStateRm_stateStore(t *testing.T) {
 	}
 
 	// Create a mock that contains a persisted "default" state that uses the bytes from above.
-	mockProvider := mockPluggableStateStorageProvider()
-	mockProvider.MockStates = map[string]interface{}{
-		"default": stateBuf.Bytes(),
-	}
+	mockProvider := mockPluggableStateStorageProvider(mockSingleStateStoreSchema("test_store"))
+	mockProvider.MockStates = testing_provider.NewMockStateBytesWithSingleState(
+		"test_store",
+		"default",
+		stateBuf.Bytes(),
+	)
 	mockProviderAddress := addrs.NewDefaultProvider("test")
 
 	// Make the mock assert that the removed resource is not present when the new state is persisted

--- a/internal/command/state_show_test.go
+++ b/internal/command/state_show_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/configs/configschema"
 	"github.com/hashicorp/terraform/internal/providers"
+	testing_provider "github.com/hashicorp/terraform/internal/providers/testing"
 	"github.com/hashicorp/terraform/internal/states"
 	"github.com/hashicorp/terraform/internal/states/statefile"
 )
@@ -373,10 +374,12 @@ func TestStateShow_stateStore(t *testing.T) {
 	}
 
 	// Create a mock that contains a persisted "default" state that uses the bytes from above.
-	mockProvider := mockPluggableStateStorageProvider()
-	mockProvider.MockStates = map[string]interface{}{
-		"default": stateBuf.Bytes(),
-	}
+	mockProvider := mockPluggableStateStorageProvider(mockSingleStateStoreSchema("test_store"))
+	mockProvider.MockStates = testing_provider.NewMockStateBytesWithSingleState(
+		"test_store",
+		"default",
+		stateBuf.Bytes(),
+	)
 	mockProviderAddress := addrs.NewDefaultProvider("test")
 
 	ui := cli.NewMockUi()

--- a/internal/command/testdata/state-migrate-backend-to-backend/backend.tfmigrate.hcl
+++ b/internal/command/testdata/state-migrate-backend-to-backend/backend.tfmigrate.hcl
@@ -1,7 +1,5 @@
 from {
   backend "local" {
-    config {
-      path = "source.tfstate"
-    }
+    path = "source-backend.tfstate"
   }
 }

--- a/internal/command/testdata/state-migrate-backend-to-backend/source-backend.tfstate
+++ b/internal/command/testdata/state-migrate-backend-to-backend/source-backend.tfstate
@@ -1,0 +1,14 @@
+{
+  "version": 4,
+  "terraform_version": "1.16.0",
+  "serial": 1,
+  "lineage": "8595356e-c764-dea1-8dae-156b936ec6e2",
+  "outputs": {
+    "test": {
+      "value": "test",
+      "type": "string"
+    }
+  },
+  "resources": [],
+  "check_results": null
+}

--- a/internal/command/testdata/state-migrate-backend-to-state-store/backend.tfmigrate.hcl
+++ b/internal/command/testdata/state-migrate-backend-to-state-store/backend.tfmigrate.hcl
@@ -1,5 +1,5 @@
 from {
   backend "local" {
-    path = "source.tfstate"
+    path = "source-backend.tfstate"
   }
 }

--- a/internal/command/testdata/state-migrate-backend-to-state-store/pss.tf
+++ b/internal/command/testdata/state-migrate-backend-to-state-store/pss.tf
@@ -6,7 +6,7 @@ terraform {
     }
   }
   state_store "test_store" {
-    path = "destination-pss.tfstate"
+    value = "destination-pss.tfstate"
 
     provider "test" {}
   }

--- a/internal/command/testdata/state-migrate-backend-to-state-store/source-backend.tfstate
+++ b/internal/command/testdata/state-migrate-backend-to-state-store/source-backend.tfstate
@@ -1,0 +1,14 @@
+{
+  "version": 4,
+  "terraform_version": "1.16.0",
+  "serial": 1,
+  "lineage": "8595356e-c764-dea1-8dae-156b936ec6e2",
+  "outputs": {
+    "test": {
+      "value": "test",
+      "type": "string"
+    }
+  },
+  "resources": [],
+  "check_results": null
+}

--- a/internal/command/testdata/state-migrate-state-store-to-backend/backend.tf
+++ b/internal/command/testdata/state-migrate-state-store-to-backend/backend.tf
@@ -1,5 +1,5 @@
 terraform {
   backend "local" {
-    path = "destination.tfstate"
+    path = "destination-backend.tfstate"
   }
 }

--- a/internal/command/testdata/state-migrate-state-store-to-backend/pss.tfmigrate.hcl
+++ b/internal/command/testdata/state-migrate-state-store-to-backend/pss.tfmigrate.hcl
@@ -7,7 +7,7 @@ state_store_provider {
 
 from {
   state_store "test_store" {
-    path = "source.tfstate"
+    value = "source-pss.tfstate"
 
     provider "test" {}
   }

--- a/internal/command/testdata/state-migrate-state-store-to-backend/source-pss.tfstate
+++ b/internal/command/testdata/state-migrate-state-store-to-backend/source-pss.tfstate
@@ -1,0 +1,14 @@
+{
+  "version": 4,
+  "terraform_version": "1.16.0",
+  "serial": 1,
+  "lineage": "8595356e-c764-dea1-8dae-156b936ec6e2",
+  "outputs": {
+    "test": {
+      "value": "test",
+      "type": "string"
+    }
+  },
+  "resources": [],
+  "check_results": null
+}

--- a/internal/command/testdata/state-migrate-state-store-to-state-store/pss.tf
+++ b/internal/command/testdata/state-migrate-state-store-to-state-store/pss.tf
@@ -6,7 +6,7 @@ terraform {
     }
   }
   state_store "test_store" {
-    path = "destination.tfstate"
+    value = "destination-pss.tfstate"
 
     provider "test" {}
   }

--- a/internal/command/testdata/state-migrate-state-store-to-state-store/pss.tf
+++ b/internal/command/testdata/state-migrate-state-store-to-state-store/pss.tf
@@ -5,9 +5,7 @@ terraform {
       version = "1.2.3"
     }
   }
-  state_store "test_store" {
-    value = "destination-pss.tfstate"
-
+  state_store "test_dst" {
     provider "test" {}
   }
 }

--- a/internal/command/testdata/state-migrate-state-store-to-state-store/pss.tfmigrate.hcl
+++ b/internal/command/testdata/state-migrate-state-store-to-state-store/pss.tfmigrate.hcl
@@ -7,7 +7,7 @@ state_store_provider {
 
 from {
   state_store "test_store" {
-    path = "source.tfstate"
+    value = "source-pss.tfstate"
 
     provider "test" {}
   }

--- a/internal/command/testdata/state-migrate-state-store-to-state-store/pss.tfmigrate.hcl
+++ b/internal/command/testdata/state-migrate-state-store-to-state-store/pss.tfmigrate.hcl
@@ -6,9 +6,7 @@ state_store_provider {
 }
 
 from {
-  state_store "test_store" {
-    value = "source-pss.tfstate"
-
+  state_store "test_src" {
     provider "test" {}
   }
 }

--- a/internal/command/testdata/state-migrate-state-store-to-state-store/source-pss.tfstate
+++ b/internal/command/testdata/state-migrate-state-store-to-state-store/source-pss.tfstate
@@ -1,0 +1,14 @@
+{
+  "version": 4,
+  "terraform_version": "1.16.0",
+  "serial": 1,
+  "lineage": "8595356e-c764-dea1-8dae-156b936ec6e2",
+  "outputs": {
+    "test": {
+      "value": "test",
+      "type": "string"
+    }
+  },
+  "resources": [],
+  "check_results": null
+}

--- a/internal/command/views/state_migrate.go
+++ b/internal/command/views/state_migrate.go
@@ -33,5 +33,5 @@ func (s *StateMigrateHuman) Diagnostics(diags tfdiags.Diagnostics) {
 }
 
 func (s *StateMigrateHuman) Log(message string, params ...any) {
-	s.view.streams.Print(fmt.Sprintf(message, params...))
+	s.view.streams.Println(fmt.Sprintf(message, params...))
 }

--- a/internal/command/workspace_command_test.go
+++ b/internal/command/workspace_command_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/hashicorp/terraform/internal/command/views"
 	"github.com/hashicorp/terraform/internal/command/workdir"
 	"github.com/hashicorp/terraform/internal/providers"
+	testing_provider "github.com/hashicorp/terraform/internal/providers/testing"
 	"github.com/hashicorp/terraform/internal/states"
 	"github.com/hashicorp/terraform/internal/states/statefile"
 	"github.com/hashicorp/terraform/internal/states/statemgr"
@@ -35,11 +36,16 @@ func TestWorkspace_allCommands_pluggableStateStore(t *testing.T) {
 	testCopyDir(t, testFixturePath("state-store-new"), td)
 	t.Chdir(td)
 
-	mock := testStateStoreMockWithChunkNegotiation(t, 1000)
+	mock := mockPluggableStateStorageProvider(mockSingleStateStoreSchema("test_store"))
+	mock = testStateStoreMockWithChunkNegotiation(t, mock, 1000)
 
 	// Mock that a custom workspace already exists.
 	preExistingState := "pre-existing"
-	mock.MockStates = map[string]interface{}{preExistingState: true}
+	mock.MockStates = testing_provider.NewMockStateBytesWithSingleState(
+		"test_store",
+		preExistingState,
+		[]byte(`{"version":4,"terraform_version":"1.16.0","serial":1,"lineage":"8595356e-c764-dea1-8dae-156b936ec6e2","outputs":{"test":{"value":"test","type":"string"}},"resources":[],"check_results":null}`),
+	)
 
 	// Assumes the mocked provider is hashicorp/test
 	providerSource := newMockProviderSource(t, map[string][]string{
@@ -71,7 +77,11 @@ func TestWorkspace_allCommands_pluggableStateStore(t *testing.T) {
 		t.Fatalf("bad: %d\n\n%s\n%s", code, ui.ErrorWriter, ui.OutputWriter)
 	}
 	// We expect a state to have not been created for the default workspace
-	if _, ok := mock.MockStates["default"]; ok {
+	ok, err := mock.MockStates.StateIdExists("test_store", "default")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ok {
 		t.Fatal("expected the default workspace to not exist, but it did")
 	}
 
@@ -101,7 +111,11 @@ func TestWorkspace_allCommands_pluggableStateStore(t *testing.T) {
 		t.Errorf("unexpected output, expected %q, but got:\n%s", expectedMsg, ui.OutputWriter)
 	}
 	// We expect a state to have been created for the new custom workspace
-	if _, ok := mock.MockStates[newWorkspace]; !ok {
+	ok, err = mock.MockStates.StateIdExists("test_store", newWorkspace)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok {
 		t.Fatalf("expected the %s workspace to exist, but it didn't", newWorkspace)
 	}
 	current, _ = newCmd.Workspace()
@@ -206,7 +220,7 @@ func TestWorkspace_list_noReturnedWorkspaces(t *testing.T) {
 	testCopyDir(t, testFixturePath("state-store-unchanged"), td)
 	t.Chdir(td)
 
-	mock := testStateStoreMockWithChunkNegotiation(t, 1000)
+	mock := testStateStoreMockWithChunkNegotiation(t, testStateStoreMock(t), 1000)
 
 	// Assumes the mocked provider is hashicorp/test
 	providerSource := newMockProviderSource(t, map[string][]string{
@@ -1398,7 +1412,7 @@ func TestWorkspace_list_jsonOutput(t *testing.T) {
 	t.Chdir(td)
 
 	// Using PSS in this test allows easy mocking of pre-existing workspaces
-	mock := testStateStoreMockWithChunkNegotiation(t, 1000)
+	mock := testStateStoreMockWithChunkNegotiation(t, testStateStoreMock(t), 1000)
 	mock.GetStatesResponse = &providers.GetStatesResponse{
 		States:      []string{"default", "dev", "stage", "prod"},
 		Diagnostics: nil,

--- a/internal/providers/testing/provider_mock.go
+++ b/internal/providers/testing/provider_mock.go
@@ -5,11 +5,8 @@ package testing
 
 import (
 	"fmt"
-	"maps"
-	"slices"
 	"sync"
 
-	"github.com/hashicorp/hcl/v2"
 	"github.com/zclconf/go-cty/cty"
 	ctyjson "github.com/zclconf/go-cty/cty/json"
 	"github.com/zclconf/go-cty/cty/msgpack"
@@ -155,12 +152,12 @@ type MockProvider struct {
 	ReadStateBytesCalled   bool
 	ReadStateBytesRequest  providers.ReadStateBytesRequest
 	ReadStateBytesFn       func(providers.ReadStateBytesRequest) providers.ReadStateBytesResponse
-	ReadStateBytesResponse providers.ReadStateBytesResponse
+	ReadStateBytesResponse *providers.ReadStateBytesResponse
 
 	WriteStateBytesCalled   bool
 	WriteStateBytesRequest  providers.WriteStateBytesRequest
 	WriteStateBytesFn       func(providers.WriteStateBytesRequest) providers.WriteStateBytesResponse
-	WriteStateBytesResponse providers.WriteStateBytesResponse
+	WriteStateBytesResponse *providers.WriteStateBytesResponse
 
 	// See providers.StateStoreChunkSizeSetter interface
 	SetStateStoreChunkSizeCalled bool
@@ -176,9 +173,8 @@ type MockProvider struct {
 	UnlockStateRequest  providers.UnlockStateRequest
 	UnlockStateFn       func(providers.UnlockStateRequest) providers.UnlockStateResponse
 
-	// MockStates is an internal field that tracks which workspaces have been created in a test
-	// The map keys are state ids (workspaces) and the value depends on the test.
-	MockStates map[string]interface{}
+	// MockStates is an internal field that tracks state data stored during a test
+	MockStates MockStateBytes
 
 	GetStatesCalled   bool
 	GetStatesResponse *providers.GetStatesResponse
@@ -345,8 +341,11 @@ func (p *MockProvider) ReadStateBytes(r providers.ReadStateBytesRequest) (resp p
 	if p.ReadStateBytesFn != nil {
 		return p.ReadStateBytesFn(r)
 	}
+	if p.ReadStateBytesResponse != nil {
+		return *p.ReadStateBytesResponse
+	}
 
-	return p.ReadStateBytesResponse
+	return resp
 }
 
 func (p *MockProvider) WriteStateBytes(r providers.WriteStateBytesRequest) (resp providers.WriteStateBytesResponse) {
@@ -358,15 +357,11 @@ func (p *MockProvider) WriteStateBytes(r providers.WriteStateBytesRequest) (resp
 	if p.WriteStateBytesFn != nil {
 		return p.WriteStateBytesFn(r)
 	}
-
-	// If we haven't already, record in the mock that
-	// the matching workspace exists
-	if p.MockStates == nil {
-		p.MockStates = make(map[string]interface{})
+	if p.WriteStateBytesResponse != nil {
+		return *p.WriteStateBytesResponse
 	}
-	p.MockStates[r.StateId] = true
 
-	return p.WriteStateBytesResponse
+	return resp
 }
 
 func (p *MockProvider) LockState(r providers.LockStateRequest) (resp providers.LockStateResponse) {
@@ -1086,16 +1081,13 @@ func (p *MockProvider) GetStates(r providers.GetStatesRequest) (resp providers.G
 		return resp
 	}
 
-	if p.GetStatesResponse != nil {
-		return *p.GetStatesResponse
-	}
-
 	if p.GetStatesFn != nil {
 		return p.GetStatesFn(r)
 	}
 
-	// When no custom logic is provided to the mock, return the internal states list
-	resp.States = slices.Sorted(maps.Keys(p.MockStates))
+	if p.GetStatesResponse != nil {
+		return *p.GetStatesResponse
+	}
 
 	return resp
 }
@@ -1114,23 +1106,12 @@ func (p *MockProvider) DeleteState(r providers.DeleteStateRequest) (resp provide
 		resp.Diagnostics = resp.Diagnostics.Append(fmt.Errorf("ConfigureStateStore not called before DeleteState %q", r.TypeName))
 	}
 
-	if p.DeleteStateResponse != nil {
-		return *p.DeleteStateResponse
-	}
-
 	if p.DeleteStateFn != nil {
 		return p.DeleteStateFn(r)
 	}
 
-	// When no custom logic is provided to the mock, delete matching internal state
-	if _, match := p.MockStates[r.StateId]; match {
-		delete(p.MockStates, r.StateId)
-	} else {
-		resp.Diagnostics = resp.Diagnostics.Append(&hcl.Diagnostic{
-			Severity: hcl.DiagError,
-			Summary:  "Workspace cannot be deleted",
-			Detail:   fmt.Sprintf("The workspace %q does not exist, so cannot be deleted", r.StateId),
-		})
+	if p.DeleteStateResponse != nil {
+		return *p.DeleteStateResponse
 	}
 
 	// If the response contains no diagnostics then the deletion is assumed to be successful.

--- a/internal/providers/testing/state_store_mock.go
+++ b/internal/providers/testing/state_store_mock.go
@@ -20,16 +20,18 @@ func NewMultipleMockStateBytes(types []string) MockStateBytes {
 	return m
 }
 
-func NewMockStateBytes(typeName string) MockStateBytes {
-	m := map[string]map[string][]byte{}
-	m[typeName] = map[string][]byte{}
-	return m
-}
-
 func NewMockStateBytesWithSingleState(typeName, stateId string, b []byte) MockStateBytes {
 	m := map[string]map[string][]byte{}
 	m[typeName] = map[string][]byte{
 		stateId: b,
+	}
+	return m
+}
+
+func NewMockStateBytesWithTypes(typeNames []string) MockStateBytes {
+	m := map[string]map[string][]byte{}
+	for _, typeName := range typeNames {
+		m[typeName] = map[string][]byte{}
 	}
 	return m
 }

--- a/internal/providers/testing/state_store_mock.go
+++ b/internal/providers/testing/state_store_mock.go
@@ -1,0 +1,126 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package testing
+
+import (
+	"fmt"
+	"maps"
+	"slices"
+)
+
+type MockStateBytes map[string]map[string][]byte
+
+func NewMultipleMockStateBytes(types []string) MockStateBytes {
+	m := map[string]map[string][]byte{}
+	for _, t := range types {
+		m[t] = map[string][]byte{}
+	}
+	return m
+}
+
+func NewMockStateBytes(typeName string) MockStateBytes {
+	m := map[string]map[string][]byte{}
+	m[typeName] = map[string][]byte{}
+	return m
+}
+
+func NewMockStateBytesWithSingleState(typeName, stateId string, b []byte) MockStateBytes {
+	m := map[string]map[string][]byte{}
+	m[typeName] = map[string][]byte{
+		stateId: b,
+	}
+	return m
+}
+
+func NewMockStateBytesWithStateIds(typeName string, stateIds []string) MockStateBytes {
+	m := map[string]map[string][]byte{}
+	m[typeName] = map[string][]byte{}
+	for _, stateId := range stateIds {
+		m[typeName][stateId] = []byte{}
+	}
+	return m
+}
+
+func NewMockStateBytesWithTypesAndStateIds(typeNames []string, stateIds []string) MockStateBytes {
+	m := map[string]map[string][]byte{}
+	for _, typeName := range typeNames {
+		m[typeName] = map[string][]byte{}
+		for _, stateId := range stateIds {
+			m[typeName][stateId] = []byte{}
+		}
+	}
+	return m
+}
+
+func (msb MockStateBytes) Write(typeName string, stateId string, b []byte) error {
+	_, ok := msb[typeName]
+	if !ok {
+		return fmt.Errorf("state store %q not declared", typeName)
+	}
+
+	msb[typeName][stateId] = b
+	return nil
+}
+
+type StateNotFoundErr struct {
+	TypeName string
+	StateId  string
+}
+
+func (e StateNotFoundErr) Is(target error) bool {
+	return target == e
+}
+
+func (e StateNotFoundErr) Error() string {
+	return fmt.Sprintf("state not found for state ID %q (%q)", e.StateId, e.TypeName)
+}
+
+func (msb MockStateBytes) Read(typeName string, stateId string) ([]byte, error) {
+	_, ok := msb[typeName]
+	if !ok {
+		return nil, fmt.Errorf("state store %q not declared", typeName)
+	}
+	_, ok = msb[typeName][stateId]
+	if !ok {
+		return nil, StateNotFoundErr{
+			TypeName: typeName,
+			StateId:  stateId,
+		}
+	}
+
+	return msb[typeName][stateId], nil
+}
+
+func (msb MockStateBytes) StateIds(typeName string) ([]string, error) {
+	_, ok := msb[typeName]
+	if !ok {
+		return nil, fmt.Errorf("state store %q not declared", typeName)
+	}
+	return slices.Sorted(maps.Keys(msb[typeName])), nil
+}
+
+func (msb MockStateBytes) Delete(typeName, stateId string) error {
+	_, ok := msb[typeName]
+	if !ok {
+		return fmt.Errorf("state store %q not declared", typeName)
+	}
+
+	_, ok = msb[typeName][stateId]
+	if !ok {
+		return fmt.Errorf("state ID %q (%q) does not exist so cannot be deleted", stateId, typeName)
+	}
+
+	delete(msb[typeName], stateId)
+	return nil
+}
+
+func (msb MockStateBytes) StateIdExists(typeName, stateId string) (bool, error) {
+	_, ok := msb[typeName]
+	if !ok {
+		return false, fmt.Errorf("state store %q not declared", typeName)
+	}
+
+	_, ok = msb[typeName][stateId]
+	return ok, nil
+}

--- a/internal/providers/testing/state_store_mock.go
+++ b/internal/providers/testing/state_store_mock.go
@@ -9,6 +9,7 @@ import (
 	"slices"
 )
 
+// MockStateBytes is a map where the keys are state store types, i.e. names of store implementations in the mock provider. The value is a map of workspace name to bytes data.
 type MockStateBytes map[string]map[string][]byte
 
 func NewMultipleMockStateBytes(types []string) MockStateBytes {


### PR DESCRIPTION
This implements various migrations paths and updates tests to confirm they work.

The assumption made here was that the lockfile always already contains the entries for the providers, which is a problem left for a separate PR.

## Notes for Reviewer

Due to the needed refactoring it is best to go commit by commit.

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.16.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
