### PR TITLE
Illustrative, do not merge: Split list of `init` message codes up by their existing usage.

### DIFF
--- a/internal/command/init_test.go
+++ b/internal/command/init_test.go
@@ -86,7 +86,7 @@ func TestInit_empty(t *testing.T) {
 	if code := c.Run(args); code != 0 {
 		t.Fatalf("bad: \n%s", done(t).All())
 	}
-	exp := views.MessageRegistry[views.OutputInitEmptyMessage].JSONValue
+	exp := views.OutputRegistry[views.OutputInitEmptyMessage].JSONValue
 	actual := cleanString(done(t).All())
 	if !strings.Contains(actual, cleanString(exp)) {
 		t.Fatalf("expected output to be %q\n, got %q", exp, actual)
@@ -117,7 +117,7 @@ func TestInit_only_test_files(t *testing.T) {
 	if code := c.Run(args); code != 0 {
 		t.Fatalf("bad: \n%s", done(t).All())
 	}
-	exp := views.MessageRegistry[views.OutputInitSuccessCLIMessage].JSONValue
+	exp := views.OutputRegistry[views.OutputInitSuccessCLIMessage].JSONValue
 	actual := cleanString(done(t).All())
 	if !strings.Contains(actual, cleanString(exp)) {
 		t.Fatalf("expected output to be %q\n, got %q", exp, actual)
@@ -133,7 +133,7 @@ func TestInit_two_source_provider_download(t *testing.T) {
 		"providers required by only the state file": {
 			workDirPath: "init-provider-download/state-file-only",
 			expectedDownloadMsgs: []string{
-				views.MessageRegistry[views.OutputInitSuccessCLIMessage].JSONValue,
+				views.OutputRegistry[views.OutputInitSuccessCLIMessage].JSONValue,
 				`Initializing the backend...
 				Successfully configured the backend "local"!`, // No providers found in the configuration so next output is backend-related
 				`Initializing provider plugins...
@@ -144,7 +144,7 @@ func TestInit_two_source_provider_download(t *testing.T) {
 		"different providers required by config and state": {
 			workDirPath: "init-provider-download/config-and-state-different-providers",
 			expectedDownloadMsgs: []string{
-				views.MessageRegistry[views.OutputInitSuccessCLIMessage].JSONValue,
+				views.OutputRegistry[views.OutputInitSuccessCLIMessage].JSONValue,
 				"Initializing provider plugins...",
 				// Config - null provider is affected by a version constraint
 				`- Finding hashicorp/null versions matching "< 9.0.0"...`,

--- a/internal/command/views/init.go
+++ b/internal/command/views/init.go
@@ -55,15 +55,21 @@ func (v *InitHuman) PolicyResults(results *plans.PolicyResults, setupDiags polic
 	v.view.PolicyResults(results, setupDiags)
 }
 
+// Creates output using a message code and parameters.
+//
+// Matches the logic of LogInitMessage, but uses a different subset of message codes.
 func (v *InitHuman) Output(messageCode InitMessageCode, params ...any) {
 	v.view.streams.Println(v.PrepareMessage(messageCode, params...))
 }
 
+// Creates output using a message code and parameters.
+//
+// Matches the logic of Output, but uses a different subset of message codes.
 func (v *InitHuman) LogInitMessage(messageCode InitMessageCode, params ...any) {
 	v.view.streams.Println(v.PrepareMessage(messageCode, params...))
 }
 
-// this implements log method for use by interfaces that need to log generic string messages, e.g used for logging in hook_module_install.go
+// Log implements a log method for use by interfaces that need to log generic string messages, e.g used for logging in hook_module_install.go
 func (v *InitHuman) Log(message string, params ...any) {
 	v.view.streams.Println(strings.TrimSpace(fmt.Sprintf(message, params...)))
 }
@@ -99,6 +105,8 @@ func (v *InitJSON) PolicyResults(results *plans.PolicyResults, setupDiags policy
 	v.view.PolicyResults(results, setupDiags)
 }
 
+// Creates output using a message code and parameters.
+// JSON output is logged with "type": "init_output"
 func (v *InitJSON) Output(messageCode InitMessageCode, params ...any) {
 	// don't add empty messages to json output
 	preppedMessage := v.PrepareMessage(messageCode, params...)
@@ -123,6 +131,8 @@ func (v *InitJSON) Output(messageCode InitMessageCode, params ...any) {
 	)
 }
 
+// Creates output using a message code and parameters.
+// JSON output is logged with "type": "log"
 func (v *InitJSON) LogInitMessage(messageCode InitMessageCode, params ...any) {
 	preppedMessage := v.PrepareMessage(messageCode, params...)
 	if preppedMessage == "" {
@@ -132,7 +142,7 @@ func (v *InitJSON) LogInitMessage(messageCode InitMessageCode, params ...any) {
 	v.view.Log(preppedMessage)
 }
 
-// this implements log method for use by services that need to log generic string messages, e.g usage logging in hook_module_install.go
+// Log implements a log method for use by interfaces that need to log generic string messages, e.g used for logging in hook_module_install.go
 func (v *InitJSON) Log(message string, params ...any) {
 	v.view.Log(strings.TrimSpace(fmt.Sprintf(message, params...)))
 }

--- a/internal/command/views/init.go
+++ b/internal/command/views/init.go
@@ -17,10 +17,10 @@ import (
 type Init interface {
 	Diagnostics(diags tfdiags.Diagnostics)
 	PolicyResults(results *plans.PolicyResults, setupDiags policy.Diagnostics)
-	Output(messageCode InitMessageCode, params ...any)
-	LogInitMessage(messageCode InitMessageCode, params ...any)
+	Output(messageCode OutputMessageCode, params ...any)
+	LogInitMessage(initMessageCode InitMessageCode, params ...any)
 	Log(message string, params ...any)
-	PrepareMessage(messageCode InitMessageCode, params ...any) string
+	PrepareMessage(messageCode any, params ...any) string
 }
 
 // NewInit returns Init implementation for the given ViewType.
@@ -56,13 +56,15 @@ func (v *InitHuman) PolicyResults(results *plans.PolicyResults, setupDiags polic
 }
 
 // Creates output using a message code and parameters.
+// Accepts only 'OutputMessageCode' values.
 //
 // Matches the logic of LogInitMessage, but uses a different subset of message codes.
-func (v *InitHuman) Output(messageCode InitMessageCode, params ...any) {
+func (v *InitHuman) Output(messageCode OutputMessageCode, params ...any) {
 	v.view.streams.Println(v.PrepareMessage(messageCode, params...))
 }
 
 // Creates output using a message code and parameters.
+// Accepts only 'InitMessageCode' values.
 //
 // Matches the logic of Output, but uses a different subset of message codes.
 func (v *InitHuman) LogInitMessage(messageCode InitMessageCode, params ...any) {
@@ -74,11 +76,28 @@ func (v *InitHuman) Log(message string, params ...any) {
 	v.view.streams.Println(strings.TrimSpace(fmt.Sprintf(message, params...)))
 }
 
-func (v *InitHuman) PrepareMessage(messageCode InitMessageCode, params ...any) string {
-	message, ok := MessageRegistry[messageCode]
+// PrepareMessage creates output using a message code and parameters.
+// Accepts 'InitMessageCode', 'OutputMessageCode', and 'PreparedMessageCode' values.
+//
+// If the message code doesn't match an entry in any of the used message registries then
+// the method will panic.
+func (v *InitHuman) PrepareMessage(messageCode any, params ...any) string {
+	var message InitMessage
+	var ok bool
+	switch val := messageCode.(type) {
+	case InitMessageCode:
+		message, ok = InitMessageRegistry[val]
+	case OutputMessageCode:
+		message, ok = OutputRegistry[val]
+	case PreparedMessageCode:
+		message, ok = PreparedMessageRegistry[val]
+	default:
+		panic(fmt.Sprintf("unknown message code type %T", messageCode))
+	}
 	if !ok {
-		// display the message code as fallback if not found in the message registry
-		return string(messageCode)
+		// Doesn't match a known message code.
+		// This means there's an error in calling code; panic.
+		panic(fmt.Sprintf("unknown message code %q", messageCode))
 	}
 
 	if message.HumanValue == "" {
@@ -107,7 +126,7 @@ func (v *InitJSON) PolicyResults(results *plans.PolicyResults, setupDiags policy
 
 // Creates output using a message code and parameters.
 // JSON output is logged with "type": "init_output"
-func (v *InitJSON) Output(messageCode InitMessageCode, params ...any) {
+func (v *InitJSON) Output(messageCode OutputMessageCode, params ...any) {
 	// don't add empty messages to json output
 	preppedMessage := v.PrepareMessage(messageCode, params...)
 	if preppedMessage == "" {
@@ -147,11 +166,28 @@ func (v *InitJSON) Log(message string, params ...any) {
 	v.view.Log(strings.TrimSpace(fmt.Sprintf(message, params...)))
 }
 
-func (v *InitJSON) PrepareMessage(messageCode InitMessageCode, params ...any) string {
-	message, ok := MessageRegistry[messageCode]
+// PrepareMessage creates output using a message code and parameters.
+// Accepts 'InitMessageCode', 'OutputMessageCode', and 'PreparedMessageCode' values.
+//
+// If the message code doesn't match an entry in any of the used message registries then
+// the method will panic.
+func (v *InitJSON) PrepareMessage(messageCode any, params ...any) string {
+	var message InitMessage
+	var ok bool
+	switch val := messageCode.(type) {
+	case InitMessageCode:
+		message, ok = InitMessageRegistry[val]
+	case OutputMessageCode:
+		message, ok = OutputRegistry[val]
+	case PreparedMessageCode:
+		message, ok = PreparedMessageRegistry[val]
+	default:
+		panic(fmt.Sprintf("unknown message code type %T", messageCode))
+	}
 	if !ok {
-		// display the message code as fallback if not found in the message registry
-		return string(messageCode)
+		// Doesn't match a known message code.
+		// This means there's an error in calling code; panic.
+		panic(fmt.Sprintf("unknown message code %q", messageCode))
 	}
 
 	return strings.TrimSpace(fmt.Sprintf(message.JSONValue, params...))
@@ -163,7 +199,46 @@ type InitMessage struct {
 	JSONValue  string
 }
 
-var MessageRegistry map[InitMessageCode]InitMessage = map[InitMessageCode]InitMessage{
+// InitMessageRegistry contains all messages that are logged via the LogInitMessage method.
+// When machine-readable output is used, the JSON log includes "type": "log".
+var InitMessageRegistry map[InitMessageCode]InitMessage = map[InitMessageCode]InitMessage{
+	"provider_already_installed_message": {
+		HumanValue: "- Using previously-installed %s v%s",
+		JSONValue:  "%s v%s: Using previously-installed provider version",
+	},
+	"built_in_provider_available_message": {
+		HumanValue: "- %s is built in to Terraform",
+		JSONValue:  "%s is built in to Terraform",
+	},
+	"reusing_previous_version_info": {
+		HumanValue: "- Reusing previous version of %s from the dependency lock file",
+		JSONValue:  "%s: Reusing previous version from the dependency lock file",
+	},
+	"finding_matching_version_message": {
+		HumanValue: "- Finding %s versions matching %q...",
+		JSONValue:  "Finding matching versions for provider: %s, version_constraint: %q",
+	},
+	"finding_latest_version_message": {
+		HumanValue: "- Finding latest version of %s...",
+		JSONValue:  "%s: Finding latest version...",
+	},
+	"using_provider_from_cache_dir_info": {
+		HumanValue: "- Using %s v%s from the shared cache directory",
+		JSONValue:  "%s v%s: Using from the shared cache directory",
+	},
+	"installing_provider_message": {
+		HumanValue: "- Installing %s v%s...",
+		JSONValue:  "Installing provider version: %s v%s...",
+	},
+	"installed_provider_version_info": {
+		HumanValue: "- Installed %s v%s (%s%s)",
+		JSONValue:  "Installed provider version: %s v%s (%s%s)",
+	},
+}
+
+// OutputRegistry contains all messages that are logged via the Output method.
+// When machine-readable output is used, the JSON log includes "type": "init_output".
+var OutputRegistry map[OutputMessageCode]InitMessage = map[OutputMessageCode]InitMessage{
 	"copying_configuration_message": {
 		HumanValue: "[reset][bold]Copying configuration[reset] from %q...",
 		JSONValue:  "Copying configuration from %q...",
@@ -236,49 +311,9 @@ var MessageRegistry map[InitMessageCode]InitMessage = map[InitMessageCode]InitMe
 		HumanValue: previousLockInfoHuman,
 		JSONValue:  previousLockInfoJSON,
 	},
-	"provider_already_installed_message": {
-		HumanValue: "- Using previously-installed %s v%s",
-		JSONValue:  "%s v%s: Using previously-installed provider version",
-	},
-	"built_in_provider_available_message": {
-		HumanValue: "- %s is built in to Terraform",
-		JSONValue:  "%s is built in to Terraform",
-	},
-	"reusing_previous_version_info": {
-		HumanValue: "- Reusing previous version of %s from the dependency lock file",
-		JSONValue:  "%s: Reusing previous version from the dependency lock file",
-	},
-	"finding_matching_version_message": {
-		HumanValue: "- Finding %s versions matching %q...",
-		JSONValue:  "Finding matching versions for provider: %s, version_constraint: %q",
-	},
-	"finding_latest_version_message": {
-		HumanValue: "- Finding latest version of %s...",
-		JSONValue:  "%s: Finding latest version...",
-	},
-	"using_provider_from_cache_dir_info": {
-		HumanValue: "- Using %s v%s from the shared cache directory",
-		JSONValue:  "%s v%s: Using from the shared cache directory",
-	},
-	"installing_provider_message": {
-		HumanValue: "- Installing %s v%s...",
-		JSONValue:  "Installing provider version: %s v%s...",
-	},
-	"key_id": {
-		HumanValue: ", key ID [reset][bold]%s[reset]",
-		JSONValue:  "key_id: %s",
-	},
-	"installed_provider_version_info": {
-		HumanValue: "- Installed %s v%s (%s%s)",
-		JSONValue:  "Installed provider version: %s v%s (%s%s)",
-	},
 	"partner_and_community_providers_message": {
 		HumanValue: partnerAndCommunityProvidersInfo,
 		JSONValue:  partnerAndCommunityProvidersInfo,
-	},
-	"init_config_error": {
-		HumanValue: errInitConfigError,
-		JSONValue:  errInitConfigErrorJSON,
 	},
 	"state_store_unset": {
 		HumanValue: "[reset][green]\n\nSuccessfully unset the state store %q. Terraform will now operate locally.",
@@ -346,6 +381,20 @@ var MessageRegistry map[InitMessageCode]InitMessage = map[InitMessageCode]InitMe
 	},
 }
 
+// PreparedMessageRegistry contains all messages that are prepared via PrepareMessage directly.
+// The resulting message strings are not immediately logged and instead are used to create diagnostics
+// or inputs to other messages.
+var PreparedMessageRegistry map[PreparedMessageCode]InitMessage = map[PreparedMessageCode]InitMessage{
+	"init_config_error": {
+		HumanValue: errInitConfigError,
+		JSONValue:  errInitConfigErrorJSON,
+	},
+	"key_id": {
+		HumanValue: ", key ID [reset][bold]%s[reset]",
+		JSONValue:  "key_id: %s",
+	},
+}
+
 type (
 	// Messages that are logged via the Output method.
 	// Log type: "init_output" in JSON output.
@@ -363,56 +412,56 @@ const (
 	// Following message codes are used and documented EXTERNALLY
 	// Keep docs/internals/machine-readable-ui.mdx up to date with
 	// this list when making changes here.
-	CopyingConfigurationMessage                  InitMessageCode = "copying_configuration_message"
-	EmptyMessage                                 InitMessageCode = "empty_message"
-	OutputInitEmptyMessage                       InitMessageCode = "output_init_empty_message"
-	OutputInitSuccessMessage                     InitMessageCode = "output_init_success_message"
-	OutputInitSuccessCloudMessage                InitMessageCode = "output_init_success_cloud_message"
-	OutputInitSuccessCLIMessage                  InitMessageCode = "output_init_success_cli_message"
-	OutputInitSuccessCLICloudMessage             InitMessageCode = "output_init_success_cli_cloud_message"
-	UpgradingModulesMessage                      InitMessageCode = "upgrading_modules_message"
-	InitializingTerraformCloudMessage            InitMessageCode = "initializing_terraform_cloud_message"
-	InitializingModulesMessage                   InitMessageCode = "initializing_modules_message"
-	InitializingBackendMessage                   InitMessageCode = "initializing_backend_message"
-	InitializingStateStoreMessage                InitMessageCode = "initializing_state_store_message"
-	InitializingStateStoreProviderPluginMessage  InitMessageCode = "initializing_state_store_provider_plugin_message"
-	StateStoreProviderInteractiveApprovedMessage InitMessageCode = "state_store_provider_interactive_approved_message"
-	StateStoreProviderInteractiveRejectedMessage InitMessageCode = "state_store_provider_interactive_rejected_message"
-	StateStoreProviderAutomationApprovedMessage  InitMessageCode = "state_store_provider_automation_approved_message"
-	InitializingProviderPluginMessage            InitMessageCode = "initializing_provider_plugin_message"
-	LockInfo                                     InitMessageCode = "lock_info"
-	DependenciesLockChangesInfo                  InitMessageCode = "dependencies_lock_changes_info"
+	CopyingConfigurationMessage                  OutputMessageCode = "copying_configuration_message"
+	EmptyMessage                                 OutputMessageCode = "empty_message"
+	OutputInitEmptyMessage                       OutputMessageCode = "output_init_empty_message"
+	OutputInitSuccessMessage                     OutputMessageCode = "output_init_success_message"
+	OutputInitSuccessCloudMessage                OutputMessageCode = "output_init_success_cloud_message"
+	OutputInitSuccessCLIMessage                  OutputMessageCode = "output_init_success_cli_message"
+	OutputInitSuccessCLICloudMessage             OutputMessageCode = "output_init_success_cli_cloud_message"
+	UpgradingModulesMessage                      OutputMessageCode = "upgrading_modules_message"
+	InitializingTerraformCloudMessage            OutputMessageCode = "initializing_terraform_cloud_message"
+	InitializingModulesMessage                   OutputMessageCode = "initializing_modules_message"
+	InitializingBackendMessage                   OutputMessageCode = "initializing_backend_message"
+	InitializingStateStoreMessage                OutputMessageCode = "initializing_state_store_message"
+	InitializingStateStoreProviderPluginMessage  OutputMessageCode = "initializing_state_store_provider_plugin_message"
+	StateStoreProviderInteractiveApprovedMessage OutputMessageCode = "state_store_provider_interactive_approved_message"
+	StateStoreProviderInteractiveRejectedMessage OutputMessageCode = "state_store_provider_interactive_rejected_message"
+	StateStoreProviderAutomationApprovedMessage  OutputMessageCode = "state_store_provider_automation_approved_message"
+	InitializingProviderPluginMessage            OutputMessageCode = "initializing_provider_plugin_message"
+	LockInfo                                     OutputMessageCode = "lock_info"
+	DependenciesLockChangesInfo                  OutputMessageCode = "dependencies_lock_changes_info"
 
 	//// Message codes below are ONLY used INTERNALLY (for now)
 
 	// InitConfigError indicates problems encountered during initialisation
-	InitConfigError InitMessageCode = "init_config_error"
+	InitConfigError PreparedMessageCode = "init_config_error"
 	// BackendConfiguredSuccessMessage indicates successful backend configuration
-	BackendConfiguredSuccessMessage InitMessageCode = "backend_configured_success"
+	BackendConfiguredSuccessMessage OutputMessageCode = "backend_configured_success"
 	// BackendConfiguredUnsetMessage indicates successful backend unsetting
-	BackendConfiguredUnsetMessage InitMessageCode = "backend_configured_unset"
+	BackendConfiguredUnsetMessage OutputMessageCode = "backend_configured_unset"
 	// BackendMigrateToCloudMessage indicates migration to HCP Terraform
-	BackendMigrateToCloudMessage InitMessageCode = "backend_migrate_to_cloud"
+	BackendMigrateToCloudMessage OutputMessageCode = "backend_migrate_to_cloud"
 	// BackendMigrateFromCloudMessage indicates migration from HCP Terraform
-	BackendMigrateFromCloudMessage InitMessageCode = "backend_migrate_from_cloud"
+	BackendMigrateFromCloudMessage OutputMessageCode = "backend_migrate_from_cloud"
 	// BackendCloudChangeInPlaceMessage indicates HCP Terraform configuration change
-	BackendCloudChangeInPlaceMessage InitMessageCode = "backend_cloud_change_in_place"
+	BackendCloudChangeInPlaceMessage OutputMessageCode = "backend_cloud_change_in_place"
 	// BackendMigrateTypeChangeMessage indicates backend type change
-	BackendMigrateTypeChangeMessage InitMessageCode = "backend_migrate_type_change"
+	BackendMigrateTypeChangeMessage OutputMessageCode = "backend_migrate_type_change"
 	// BackendReconfigureMessage indicates backend reconfiguration
-	BackendReconfigureMessage InitMessageCode = "backend_reconfigure"
+	BackendReconfigureMessage OutputMessageCode = "backend_reconfigure"
 	// BackendMigrateLocalMessage indicates migration to local backend
-	BackendMigrateLocalMessage InitMessageCode = "backend_migrate_local"
+	BackendMigrateLocalMessage OutputMessageCode = "backend_migrate_local"
 	// BackendCloudMigrateLocalMessage indicates migration from cloud to local
-	BackendCloudMigrateLocalMessage InitMessageCode = "backend_cloud_migrate_local"
+	BackendCloudMigrateLocalMessage OutputMessageCode = "backend_cloud_migrate_local"
 	// BackendCloudMigrateStateStoreMessage indicates migration from cloud to a state store
-	BackendCloudMigrateStateStoreMessage InitMessageCode = "backend_cloud_migrate_state_store"
+	BackendCloudMigrateStateStoreMessage OutputMessageCode = "backend_cloud_migrate_state_store"
 	// BackendMigrateStateStoreMessage indicates migration from a backend to a state store
-	BackendMigrateStateStoreMessage InitMessageCode = "backend_migrate_state_store"
+	BackendMigrateStateStoreMessage OutputMessageCode = "backend_migrate_state_store"
 	// StateMigrateLocalMessage indicates migration from state store to local
-	StateMigrateLocalMessage InitMessageCode = "state_store_migrate_local"
+	StateMigrateLocalMessage OutputMessageCode = "state_store_migrate_local"
 	// StateStoreMigrationMessage indicates migration from state store to state store
-	StateStoreMigrationMessage InitMessageCode = "state_store_migrate_state_store"
+	StateStoreMigrationMessage OutputMessageCode = "state_store_migrate_state_store"
 	// FindingMatchingVersionMessage indicates that Terraform is looking for a provider version that matches the constraint during installation
 	FindingMatchingVersionMessage InitMessageCode = "finding_matching_version_message"
 	// InstalledProviderVersionInfo describes a successfully installed provider along with its version
@@ -424,7 +473,7 @@ const (
 	// ProviderAlreadyInstalledMessage indicates a provider that is already installed during installation
 	ProviderAlreadyInstalledMessage InitMessageCode = "provider_already_installed_message"
 	// KeyID indicates the key ID used to sign of a successfully installed provider
-	KeyID InitMessageCode = "key_id"
+	KeyID PreparedMessageCode = "key_id"
 	// InstallingProviderMessage indicates that a provider is being installed (from a remote location)
 	InstallingProviderMessage InitMessageCode = "installing_provider_message"
 	// FindingLatestVersionMessage indicates that Terraform is looking for the latest version of a provider during installation (no constraint was supplied)

--- a/internal/command/views/init.go
+++ b/internal/command/views/init.go
@@ -346,7 +346,18 @@ var MessageRegistry map[InitMessageCode]InitMessage = map[InitMessageCode]InitMe
 	},
 }
 
-type InitMessageCode string
+type (
+	// Messages that are logged via the Output method.
+	// Log type: "init_output" in JSON output.
+	OutputMessageCode string
+
+	// Messages that are logged via the LogInitMessage method.
+	// Log type: "log" in JSON output.
+	InitMessageCode string
+
+	// These are messages that are prepared and used as a string, not prepared as part of logging a message.
+	PreparedMessageCode string
+)
 
 const (
 	// Following message codes are used and documented EXTERNALLY

--- a/internal/command/views/init_test.go
+++ b/internal/command/views/init_test.go
@@ -275,6 +275,7 @@ func TestNewInit_humanViewPolicyResults_infoWithoutSnippet(t *testing.T) {
 	}
 }
 
+// Test use of params with the Output method.
 func TestNewInit_jsonViewOutput(t *testing.T) {
 	t.Run("no param", func(t *testing.T) {
 		streams, done := terminal.StreamsForTesting(t)
@@ -317,8 +318,8 @@ func TestNewInit_jsonViewOutput(t *testing.T) {
 			t.Fatalf("unexpected return type %t", newInit)
 		}
 
-		packageName := "hashicorp/aws"
-		newInit.Output(FindingLatestVersionMessage, packageName)
+		backend := "s3"
+		newInit.Output(BackendMigrateToCloudMessage, backend)
 
 		version := tfversion.String()
 		want := []map[string]interface{}{
@@ -332,9 +333,9 @@ func TestNewInit_jsonViewOutput(t *testing.T) {
 			},
 			{
 				"@level":       "info",
-				"@message":     fmt.Sprintf("%s: Finding latest version...", packageName),
+				"@message":     fmt.Sprintf("Migrating from backend %q to HCP Terraform.", backend),
 				"@module":      "terraform.ui",
-				"message_code": "finding_latest_version_message",
+				"message_code": "backend_migrate_to_cloud",
 				"type":         "init_output",
 			},
 		}
@@ -351,8 +352,8 @@ func TestNewInit_jsonViewOutput(t *testing.T) {
 			t.Fatalf("unexpected return type %t", newInit)
 		}
 
-		var packageName, packageVersion = "hashicorp/aws", "3.0.0"
-		newInit.Output(ProviderAlreadyInstalledMessage, packageName, packageVersion)
+		backend, stateStore := "s3", "test_store"
+		newInit.Output(BackendMigrateStateStoreMessage, backend, stateStore)
 
 		version := tfversion.String()
 		want := []map[string]interface{}{
@@ -366,9 +367,9 @@ func TestNewInit_jsonViewOutput(t *testing.T) {
 			},
 			{
 				"@level":       "info",
-				"@message":     fmt.Sprintf("%s v%s: Using previously-installed provider version", packageName, packageVersion),
+				"@message":     fmt.Sprintf("Migrating from backend %q to state store %q.", backend, stateStore),
 				"@module":      "terraform.ui",
-				"message_code": "provider_already_installed_message",
+				"message_code": "backend_migrate_state_store",
 				"type":         "init_output",
 			},
 		}
@@ -378,6 +379,80 @@ func TestNewInit_jsonViewOutput(t *testing.T) {
 	})
 }
 
+// Test use of params with the LogInitMessage method.
+func TestNewInit_jsonViewLogInitMessage(t *testing.T) {
+	t.Run("no param", func(t *testing.T) {
+		t.Skip("no zero param messages are used with the LogInitMessage method")
+	})
+
+	t.Run("single param", func(t *testing.T) {
+		streams, done := terminal.StreamsForTesting(t)
+
+		newInit := NewInit(arguments.ViewJSON, NewView(streams).SetRunningInAutomation(true))
+		if _, ok := newInit.(*InitJSON); !ok {
+			t.Fatalf("unexpected return type %t", newInit)
+		}
+
+		packageName := "hashicorp/aws"
+		newInit.LogInitMessage(FindingLatestVersionMessage, packageName)
+
+		version := tfversion.String()
+		want := []map[string]interface{}{
+			{
+				"@level":    "info",
+				"@message":  fmt.Sprintf("Terraform %s", version),
+				"@module":   "terraform.ui",
+				"terraform": version,
+				"type":      "version",
+				"ui":        JSON_UI_VERSION,
+			},
+			{
+				"@level":   "info",
+				"@message": fmt.Sprintf("%s: Finding latest version...", packageName),
+				"@module":  "terraform.ui",
+				"type":     "log",
+			},
+		}
+
+		actual := done(t).Stdout()
+		testJSONViewOutputEqualsFull(t, actual, want)
+	})
+
+	t.Run("variable length params", func(t *testing.T) {
+		streams, done := terminal.StreamsForTesting(t)
+
+		newInit := NewInit(arguments.ViewJSON, NewView(streams).SetRunningInAutomation(true))
+		if _, ok := newInit.(*InitJSON); !ok {
+			t.Fatalf("unexpected return type %t", newInit)
+		}
+
+		packageName, packageVersion := "hashicorp/aws", "3.0.0"
+		newInit.LogInitMessage(ProviderAlreadyInstalledMessage, packageName, packageVersion)
+
+		version := tfversion.String()
+		want := []map[string]interface{}{
+			{
+				"@level":    "info",
+				"@message":  fmt.Sprintf("Terraform %s", version),
+				"@module":   "terraform.ui",
+				"terraform": version,
+				"type":      "version",
+				"ui":        JSON_UI_VERSION,
+			},
+			{
+				"@level":   "info",
+				"@message": fmt.Sprintf("%s v%s: Using previously-installed provider version", packageName, packageVersion),
+				"@module":  "terraform.ui",
+				"type":     "log",
+			},
+		}
+
+		actual := done(t).Stdout()
+		testJSONViewOutputEqualsFull(t, actual, want)
+	})
+}
+
+// Test use of the Log method
 func TestNewInit_jsonViewLog(t *testing.T) {
 	streams, done := terminal.StreamsForTesting(t)
 
@@ -386,7 +461,9 @@ func TestNewInit_jsonViewLog(t *testing.T) {
 		t.Fatalf("unexpected return type %t", newInit)
 	}
 
-	newInit.LogInitMessage(InitializingProviderPluginMessage)
+	msg := `This is testing the generic Log method with a parameter: %s`
+	value := "value"
+	newInit.Log(msg, value)
 
 	version := tfversion.String()
 	want := []map[string]interface{}{
@@ -400,7 +477,7 @@ func TestNewInit_jsonViewLog(t *testing.T) {
 		},
 		{
 			"@level":   "info",
-			"@message": "Initializing provider plugins...",
+			"@message": fmt.Sprintf(msg, value),
 			"@module":  "terraform.ui",
 			"type":     "log",
 		},
@@ -411,7 +488,7 @@ func TestNewInit_jsonViewLog(t *testing.T) {
 }
 
 func TestNewInit_jsonViewPrepareMessage(t *testing.T) {
-	t.Run("existing message code", func(t *testing.T) {
+	t.Run("existing output message code", func(t *testing.T) {
 		streams, _ := terminal.StreamsForTesting(t)
 
 		newInit := NewInit(arguments.ViewJSON, NewView(streams).SetRunningInAutomation(true))
@@ -419,9 +496,64 @@ func TestNewInit_jsonViewPrepareMessage(t *testing.T) {
 			t.Fatalf("unexpected return type %t", newInit)
 		}
 
+		var code any = InitializingModulesMessage
+		switch code := code.(type) {
+		case OutputMessageCode:
+			// expected
+		default:
+			t.Fatalf("test should provide a code with type OutputMessageCode, got %T", code)
+		}
+
 		want := "Initializing modules..."
 
 		actual := newInit.PrepareMessage(InitializingModulesMessage)
+		if !cmp.Equal(want, actual) {
+			t.Errorf("unexpected output: %s", cmp.Diff(want, actual))
+		}
+	})
+
+	t.Run("existing init message code", func(t *testing.T) {
+		streams, _ := terminal.StreamsForTesting(t)
+
+		newInit := NewInit(arguments.ViewJSON, NewView(streams).SetRunningInAutomation(true))
+		if _, ok := newInit.(*InitJSON); !ok {
+			t.Fatalf("unexpected return type %t", newInit)
+		}
+
+		var code any = FindingLatestVersionMessage
+		switch code := code.(type) {
+		case InitMessageCode:
+			// expected
+		default:
+			t.Fatalf("test should provide a code with type InitMessageCode, got %T", code)
+		}
+
+		provider := "hashicorp/aws"
+		want := fmt.Sprintf("%s: Finding latest version...", provider)
+		actual := newInit.PrepareMessage(FindingLatestVersionMessage, provider)
+		if !cmp.Equal(want, actual) {
+			t.Errorf("unexpected output: %s", cmp.Diff(want, actual))
+		}
+	})
+
+	t.Run("existing prepared message code", func(t *testing.T) {
+		streams, _ := terminal.StreamsForTesting(t)
+
+		newInit := NewInit(arguments.ViewJSON, NewView(streams).SetRunningInAutomation(true))
+		if _, ok := newInit.(*InitJSON); !ok {
+			t.Fatalf("unexpected return type %t", newInit)
+		}
+
+		var code any = InitConfigError
+		switch code := code.(type) {
+		case PreparedMessageCode:
+			// expected
+		default:
+			t.Fatalf("test should provide a code with type PreparedMessageCode, got %T", code)
+		}
+
+		want := strings.TrimSpace(errInitConfigErrorJSON) // A trimmed version is returned
+		actual := newInit.PrepareMessage(InitConfigError)
 		if !cmp.Equal(want, actual) {
 			t.Errorf("unexpected output: %s", cmp.Diff(want, actual))
 		}
@@ -455,7 +587,7 @@ func TestNewInit_humanViewOutput(t *testing.T) {
 		}
 
 		packageName := "hashicorp/aws"
-		newInit.Output(FindingLatestVersionMessage, packageName)
+		newInit.LogInitMessage(FindingLatestVersionMessage, packageName)
 
 		actual := done(t).All()
 		expected := "Finding latest version of hashicorp/aws"
@@ -472,8 +604,8 @@ func TestNewInit_humanViewOutput(t *testing.T) {
 			t.Fatalf("unexpected return type %t", newInit)
 		}
 
-		var packageName, packageVersion = "hashicorp/aws", "3.0.0"
-		newInit.Output(ProviderAlreadyInstalledMessage, packageName, packageVersion)
+		packageName, packageVersion := "hashicorp/aws", "3.0.0"
+		newInit.LogInitMessage(ProviderAlreadyInstalledMessage, packageName, packageVersion)
 
 		actual := done(t).All()
 		expected := "- Using previously-installed hashicorp/aws v3.0.0"


### PR DESCRIPTION
This PR isn't necessarily here to be merged. For now I'm intending for it to show that:

* Different subsets of messages are logged via the Output and LogInitMessage methods that are implemented on the `init` command's view implementation.
* That distinction -which message is logged in which way- appears to be important because the JSON view for `init` uses different log types for those methods:
    * Message logged via `Output` => `"type": "init_output"`
    * Message logged via `LogInitMessage` =>  `"type": "log"`

The different handling of different subsets of the messages isn't made clear in the code. This PR highlights this by implementing new custom subtypes; in addition to the existing `InitMessageCode` type, this PR adds:
* `OutputMessageCode` : messages logged only via the Output Method
* `PreparedMessageCode` : messages that are never logged directly.

I've also made the `Output` and `LogInitMessage` methods only accept message codes with the matching custom type.

Hopefully these changes help make how the code current works more explicit and can facilitate conversations around:
* What is the significance of `"type": "init_output"` versus  `"type": "log"` in JSON output from the init command?
* How can we refactor the init view code to enable code reuse without breaking changes

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

N/A

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
