### PR TITLE
docs(init): Remove outdated code comment

### DIFF
--- a/internal/command/init.go
+++ b/internal/command/init.go
@@ -703,12 +703,6 @@ func (c *InitCommand) getProviders(ctx context.Context, config *configs.Config, 
 		mode = providercache.InstallUpgrades
 	}
 
-	// We don't handle upgrade flags here, i.e. what happens at this point in getProvidersFromConfig:
-	// > We cannot upgrade a provider used only by the state, as there are no version constraints in state.
-	//    > Given the overlap between providers in the config and state, using the upgrade mode here
-	//      would remove the effects of version constraints from the config.
-	// > Any validation of CLI flag usage is already done in getProvidersFromConfig
-
 	newLocks, err := inst.EnsureProviderVersions(ctx, inProgressLocks, reqs, mode, installerHook)
 	if ctx.Err() == context.Canceled {
 		diags = diags.Append(fmt.Errorf("Provider installation was canceled by an interrupt signal."))


### PR DESCRIPTION
This comment dates from when this method was getProvidersFromState and indeed we couldn't perform upgrades then. Since then, this method has been changed to resemble the older method getProviders which downloads all providers barring the potentially already downloaded state storage provider. See https://github.com/hashicorp/terraform/pull/38648

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.16.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
