### PR TITLE
stacks: pass direct action targets through planning

### DIFF
--- a/.changes/v1.16/ENHANCEMENTS-20260616-000000.yaml
+++ b/.changes/v1.16/ENHANCEMENTS-20260616-000000.yaml
@@ -1,0 +1,5 @@
+kind: ENHANCEMENTS
+body: 'stacks: add invoke_action_addrs to plan RPC and thread through runtime for direct action invocation'
+time: 2026-06-16T12:00:00.000000Z
+custom:
+    Issue: "38732"

--- a/internal/rpcapi/stacks.go
+++ b/internal/rpcapi/stacks.go
@@ -357,6 +357,15 @@ func (s *stacksServer) PlanStackChanges(req *stacks.PlanStackChanges_Request, ev
 		return status.Errorf(codes.InvalidArgument, "invalid input values: %s", err)
 	}
 
+	invokeActionAddrs := make([]stackaddrs.AbsActionInvocationInstance, 0, len(req.InvokeActionAddrs))
+	for _, rawAddr := range req.InvokeActionAddrs {
+		addr, diags := stackaddrs.ParseActionInvocationInstanceStr(rawAddr)
+		if diags.HasErrors() {
+			return status.Errorf(codes.InvalidArgument, "invalid invoke action address %q: %s", rawAddr, diags.ErrWithWarnings())
+		}
+		invokeActionAddrs = append(invokeActionAddrs, addr)
+	}
+
 	var providerFactories map[addrs.Provider]providers.Factory
 	if s.providerCacheOverride != nil {
 		// This is only used in tests to side load providers without needing a
@@ -412,6 +421,7 @@ func (s *stacksServer) PlanStackChanges(req *stacks.PlanStackChanges_Request, ev
 		PrevState:          prevState,
 		ProviderFactories:  providerFactories,
 		InputValues:        inputValues,
+		InvokeActionAddrs:  invokeActionAddrs,
 		ExperimentsAllowed: s.experimentsAllowed,
 		DependencyLocks:    *deps,
 

--- a/internal/rpcapi/stacks_test.go
+++ b/internal/rpcapi/stacks_test.go
@@ -488,6 +488,50 @@ func TestStacksPlanStackChanges(t *testing.T) {
 	}
 }
 
+func TestStacksPlanStackChangesWithInvokeActionAddr(t *testing.T) {
+	ctx := context.Background()
+	handles := newHandleTable()
+	stacksServer := newStacksServer(newStopper(), handles, disco.New(), &serviceOpts{})
+
+	fakeSourceBundle := &sourcebundle.Bundle{}
+	bundleHnd := handles.NewSourceBundle(fakeSourceBundle)
+	emptyConfig := &stackconfig.Config{
+		Root: &stackconfig.ConfigNode{
+			Stack: &stackconfig.Stack{
+				SourceAddr: sourceaddrs.MustParseSource("git::https://example.com/foo.git").(sourceaddrs.RemoteSource),
+			},
+		},
+	}
+	configHnd, err := handles.NewStackConfig(emptyConfig, bundleHnd)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	grpcClient, close := grpcClientForTesting(ctx, t, func(srv *grpc.Server) {
+		stacks.RegisterStacksServer(srv, stacksServer)
+	})
+	defer close()
+
+	stacksClient := stacks.NewStacksClient(grpcClient)
+	events, err := stacksClient.PlanStackChanges(ctx, &stacks.PlanStackChanges_Request{
+		PlanMode:          stacks.PlanMode_NORMAL,
+		StackConfigHandle: configHnd.ForProtobuf(),
+		InvokeActionAddrs: []string{"component.web.action.http.notify"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	for {
+		_, err := events.Recv()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("unexpected stream error: %s", err)
+		}
+	}
+}
+
 func TestStackChangeProgressDuringPlanNormal(t *testing.T) {
 	tcs := map[string]struct {
 		source      string

--- a/internal/rpcapi/terraform1/stacks/stacks.pb.go
+++ b/internal/rpcapi/terraform1/stacks/stacks.pb.go
@@ -3666,7 +3666,8 @@ type PlanStackChanges_Request struct {
 	PreviousState         map[string]*anypb.Any              `protobuf:"bytes,3,rep,name=previous_state,json=previousState,proto3" json:"previous_state,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
 	DependencyLocksHandle int64                              `protobuf:"varint,4,opt,name=dependency_locks_handle,json=dependencyLocksHandle,proto3" json:"dependency_locks_handle,omitempty"`
 	ProviderCacheHandle   int64                              `protobuf:"varint,5,opt,name=provider_cache_handle,json=providerCacheHandle,proto3" json:"provider_cache_handle,omitempty"`
-	InputValues           map[string]*DynamicValueWithSource `protobuf:"bytes,6,rep,name=input_values,json=inputValues,proto3" json:"input_values,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"` // TODO: Various other planning options
+	InputValues           map[string]*DynamicValueWithSource `protobuf:"bytes,6,rep,name=input_values,json=inputValues,proto3" json:"input_values,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	InvokeActionAddrs     []string                           `protobuf:"bytes,8,rep,name=invoke_action_addrs,json=invokeActionAddrs,proto3" json:"invoke_action_addrs,omitempty"` // TODO: Various other planning options
 	unknownFields         protoimpl.UnknownFields
 	sizeCache             protoimpl.SizeCache
 }
@@ -3747,6 +3748,13 @@ func (x *PlanStackChanges_Request) GetProviderCacheHandle() int64 {
 func (x *PlanStackChanges_Request) GetInputValues() map[string]*DynamicValueWithSource {
 	if x != nil {
 		return x.InputValues
+	}
+	return nil
+}
+
+func (x *PlanStackChanges_Request) GetInvokeActionAddrs() []string {
+	if x != nil {
+		return x.InvokeActionAddrs
 	}
 	return nil
 }
@@ -7566,8 +7574,8 @@ const file_stacks_proto_rawDesc = "" +
 	"\aRequest\x12!\n" +
 	"\fstate_handle\x18\x01 \x01(\x03R\vstateHandle\x1a\n" +
 	"\n" +
-	"\bResponse\"\x9b\a\n" +
-	"\x10PlanStackChanges\x1a\xa2\x05\n" +
+	"\bResponse\"\xcb\a\n" +
+	"\x10PlanStackChanges\x1a\xd2\x05\n" +
 	"\aRequest\x128\n" +
 	"\tplan_mode\x18\x01 \x01(\x0e2\x1b.terraform1.stacks.PlanModeR\bplanMode\x12.\n" +
 	"\x13stack_config_handle\x18\x02 \x01(\x03R\x11stackConfigHandle\x122\n" +
@@ -7575,7 +7583,8 @@ const file_stacks_proto_rawDesc = "" +
 	"\x0eprevious_state\x18\x03 \x03(\v2>.terraform1.stacks.PlanStackChanges.Request.PreviousStateEntryB\x02\x18\x01R\rpreviousState\x126\n" +
 	"\x17dependency_locks_handle\x18\x04 \x01(\x03R\x15dependencyLocksHandle\x122\n" +
 	"\x15provider_cache_handle\x18\x05 \x01(\x03R\x13providerCacheHandle\x12_\n" +
-	"\finput_values\x18\x06 \x03(\v2<.terraform1.stacks.PlanStackChanges.Request.InputValuesEntryR\vinputValues\x1aV\n" +
+	"\finput_values\x18\x06 \x03(\v2<.terraform1.stacks.PlanStackChanges.Request.InputValuesEntryR\vinputValues\x12.\n" +
+	"\x13invoke_action_addrs\x18\b \x03(\tR\x11invokeActionAddrs\x1aV\n" +
 	"\x12PreviousStateEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12*\n" +
 	"\x05value\x18\x02 \x01(\v2\x14.google.protobuf.AnyR\x05value:\x028\x01\x1ai\n" +

--- a/internal/rpcapi/terraform1/stacks/stacks.proto
+++ b/internal/rpcapi/terraform1/stacks/stacks.proto
@@ -257,6 +257,7 @@ message PlanStackChanges {
     int64 dependency_locks_handle = 4;
     int64 provider_cache_handle = 5;
     map<string, DynamicValueWithSource> input_values = 6;
+    repeated string invoke_action_addrs = 8;
     // TODO: Various other planning options
   }
   message Event {

--- a/internal/stacks/stackruntime/internal/stackeval/component_instance.go
+++ b/internal/stacks/stackruntime/internal/stackeval/component_instance.go
@@ -163,11 +163,19 @@ func (c *ComponentInstance) PlanOpts(ctx context.Context, mode plans.Mode, skipR
 	}
 
 	providerClients := configuredProviderClients(ctx, c.main, known, unknown, PlanPhase)
+	actionTargets := make([]addrs.Targetable, 0)
+	componentAddr := c.addr.String()
+	for _, target := range c.main.PlanningOpts().InvokeActionAddrs {
+		if target.Component.String() == componentAddr {
+			actionTargets = append(actionTargets, target.Item)
+		}
+	}
 
 	plantimestamp := c.main.PlanTimestamp()
 	return &terraform.PlanOpts{
 		Mode:                       mode,
 		SkipRefresh:                skipRefresh,
+		ActionTargets:              actionTargets,
 		SetVariables:               inputValues,
 		ExternalProviders:          providerClients,
 		ExternalDependencyDeferred: c.deferred,

--- a/internal/stacks/stackruntime/internal/stackeval/planning.go
+++ b/internal/stacks/stackruntime/internal/stackeval/planning.go
@@ -25,6 +25,7 @@ type PlanOpts struct {
 	PlanningMode plans.Mode
 
 	InputVariableValues map[stackaddrs.InputVariable]ExternalInputValue
+	InvokeActionAddrs   []stackaddrs.AbsActionInvocationInstance
 
 	ProviderFactories ProviderFactories
 

--- a/internal/stacks/stackruntime/plan.go
+++ b/internal/stacks/stackruntime/plan.go
@@ -49,6 +49,7 @@ func Plan(ctx context.Context, req *PlanRequest, resp *PlanResponse) {
 	main := stackeval.NewForPlanning(req.Config, req.PrevState, stackeval.PlanOpts{
 		PlanningMode:        req.PlanMode,
 		InputVariableValues: req.InputValues,
+		InvokeActionAddrs:   req.InvokeActionAddrs,
 		ProviderFactories:   req.ProviderFactories,
 		DependencyLocks:     req.DependencyLocks,
 
@@ -97,6 +98,7 @@ type PlanRequest struct {
 	PrevState *stackstate.State
 
 	InputValues       map[stackaddrs.InputVariable]ExternalInputValue
+	InvokeActionAddrs []stackaddrs.AbsActionInvocationInstance
 	ProviderFactories map[addrs.Provider]providers.Factory
 	DependencyLocks   depsfile.Locks
 


### PR DESCRIPTION
## Summary
- add `invoke_action_addrs` to the stacks plan RPC and thread it into stack runtime planning
- filter stack-level invoke targets per component and pass them through Terraform plan options as action targets
- cover the new request path with focused stacks RPC tests

## Why
This enables stack plans to request direct action invocation targets explicitly, which is the core plumbing needed for an Atlas-driven prototype.

## Related
https://hashicorp.atlassian.net/browse/TF-38426