### PR TITLE
fix(init): Amend code related to getProviders and mergeLockedDependencies to reflect new provider download split.

### DIFF
--- a/internal/command/init.go
+++ b/internal/command/init.go
@@ -589,7 +589,7 @@ func (c *InitCommand) getProvidersFromPSSConfig(ctx context.Context, rootModEarl
 // updated dependency lock data. The dependency lock *file* itself isn't updated here.
 //
 // See getProvidersFromPSSConfig which is equivalent for state store providers.
-func (c *InitCommand) getProviders(ctx context.Context, config *configs.Config, state *states.State, upgrade bool, configLocks *depsfile.Locks, pluginDirs []string, view views.Init, installerHook providercache.InstallerHook) (output bool, resultingLocks *depsfile.Locks, diags tfdiags.Diagnostics) {
+func (c *InitCommand) getProviders(ctx context.Context, config *configs.Config, state *states.State, upgrade bool, pssConfigLocks *depsfile.Locks, pluginDirs []string, view views.Init, installerHook providercache.InstallerHook) (output bool, resultingLocks *depsfile.Locks, diags tfdiags.Diagnostics) {
 	ctx, span := tracer.Start(ctx, "install providers")
 	defer span.End()
 
@@ -628,17 +628,17 @@ func (c *InitCommand) getProviders(ctx context.Context, config *configs.Config, 
 		return false, nil, diags
 	}
 
-	// The locks below are used to avoid re-downloading any providers in the
-	// second download step.
-	// We combine any locks from the dependency lock file and locks identified
-	// from the configuration
+	// Create a combination of:
+	// * The 0 or 1 locks from downloading the state store provider earlier in the init command
+	// * Any previous locks from the dependency lock file.
+	// This helps the installer in getProviders re-download locked versions if necessary and avoid re-downloading the state storage provider.
 	var moreDiags tfdiags.Diagnostics
 	previousLocks, moreDiags := c.lockedDependencies()
 	diags = diags.Append(moreDiags)
 	if diags.HasErrors() {
 		return false, nil, diags
 	}
-	inProgressLocks := c.mergeLockedDependencies(configLocks, previousLocks)
+	inProgressLocks := c.mergeLockedDependencies(pssConfigLocks, previousLocks)
 
 	var inst *providercache.Installer
 	if len(pluginDirs) == 0 {

--- a/internal/command/meta_dependencies.go
+++ b/internal/command/meta_dependencies.go
@@ -90,7 +90,7 @@ func (m *Meta) mergeLockedDependencies(baseLocks, additionalLocks *depsfile.Lock
 	for _, lock := range additionalLocks.AllProviders() {
 		match := mergedLocks.Provider(lock.Provider())
 		if match != nil {
-			log.Printf("[TRACE] Ignoring provider %s version %s in appendLockedDependencies; lock file contains %s version %s already",
+			log.Printf("[TRACE] Ignoring provider %s version %s in mergeLockedDependencies; lock file contains %s version %s already",
 				lock.Provider(),
 				lock.Version(),
 				match.Provider(),

--- a/internal/command/meta_dependencies_test.go
+++ b/internal/command/meta_dependencies_test.go
@@ -6,7 +6,6 @@ package command
 import (
 	"testing"
 
-	"github.com/apparentlymart/go-versions/versions"
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/cli"
 	tfaddr "github.com/hashicorp/terraform-registry-address"
@@ -14,78 +13,92 @@ import (
 	"github.com/hashicorp/terraform/internal/getproviders/providerreqs"
 )
 
-// This tests combining locks from config and state. Locks derived from state are always unconstrained, i.e. no version constraint data,
-// so this test
-func Test_mergeLockedDependencies_config_and_state(t *testing.T) {
-
+// This tests combining locks from multiple sources using the mergeLockedDependencies method.
+func Test_mergeLockedDependencies(t *testing.T) {
 	providerA := tfaddr.NewProvider(tfaddr.DefaultProviderRegistryHost, "my-org", "providerA")
 	providerB := tfaddr.NewProvider(tfaddr.DefaultProviderRegistryHost, "my-org", "providerB")
 	v1_0_0 := providerreqs.MustParseVersion("1.0.0")
+	v2_0_0 := providerreqs.MustParseVersion("2.0.0")
 	versionConstraintv1, _ := providerreqs.ParseVersionConstraints("1.0.0")
+	versionConstraintv2, _ := providerreqs.ParseVersionConstraints("2.0.0")
 	hashesProviderA := []providerreqs.Hash{providerreqs.MustParseHash("providerA:this-is-providerA")}
 	hashesProviderB := []providerreqs.Hash{providerreqs.MustParseHash("providerB:this-is-providerB")}
 
-	var versionUnconstrained providerreqs.VersionConstraints = nil
-	noVersion := versions.Version{}
-
 	cases := map[string]struct {
-		configLocks   *depsfile.Locks
-		stateLocks    *depsfile.Locks
-		expectedLocks *depsfile.Locks
+		baseLocks       *depsfile.Locks
+		additionalLocks *depsfile.Locks
+		expectedLocks   *depsfile.Locks
 	}{
 		"no locks when all inputs empty": {
-			configLocks:   depsfile.NewLocks(),
-			stateLocks:    depsfile.NewLocks(),
-			expectedLocks: depsfile.NewLocks(),
+			baseLocks:       depsfile.NewLocks(),
+			additionalLocks: depsfile.NewLocks(),
+			expectedLocks:   depsfile.NewLocks(),
 		},
-		"when provider only described in config, output locks have matching constraints": {
-			configLocks: func() *depsfile.Locks {
+		"when provider only described in base locks": {
+			baseLocks: func() *depsfile.Locks {
 				configLocks := depsfile.NewLocks()
 				configLocks.SetProvider(providerA, v1_0_0, versionConstraintv1, hashesProviderA)
 				return configLocks
 			}(),
-			stateLocks: depsfile.NewLocks(),
+			additionalLocks: depsfile.NewLocks(),
 			expectedLocks: func() *depsfile.Locks {
 				combinedLocks := depsfile.NewLocks()
 				combinedLocks.SetProvider(providerA, v1_0_0, versionConstraintv1, hashesProviderA)
 				return combinedLocks
 			}(),
 		},
-		"when provider only described in state, output locks are unconstrained": {
-			configLocks: depsfile.NewLocks(),
-			stateLocks: func() *depsfile.Locks {
+		"when provider only described in additional locks": {
+			baseLocks: depsfile.NewLocks(),
+			additionalLocks: func() *depsfile.Locks {
 				stateLocks := depsfile.NewLocks()
-				stateLocks.SetProvider(providerA, noVersion, versionUnconstrained, hashesProviderA)
+				stateLocks.SetProvider(providerA, v2_0_0, versionConstraintv2, hashesProviderA)
 				return stateLocks
 			}(),
 			expectedLocks: func() *depsfile.Locks {
 				combinedLocks := depsfile.NewLocks()
-				combinedLocks.SetProvider(providerA, noVersion, versionUnconstrained, hashesProviderA)
+				combinedLocks.SetProvider(providerA, v2_0_0, versionConstraintv2, hashesProviderA)
 				return combinedLocks
 			}(),
 		},
-		"different providers present in state and config are combined, with version constraints kept on config providers": {
-			configLocks: func() *depsfile.Locks {
-				configLocks := depsfile.NewLocks()
-				configLocks.SetProvider(providerA, v1_0_0, versionConstraintv1, hashesProviderA)
-				return configLocks
+		"different non-overlapping providers present in base and additional locks are combined, output locks have matching constraints": {
+			baseLocks: func() *depsfile.Locks {
+				locks := depsfile.NewLocks()
+				locks.SetProvider(providerA, v1_0_0, versionConstraintv1, hashesProviderA)
+				return locks
 			}(),
-			stateLocks: func() *depsfile.Locks {
-				stateLocks := depsfile.NewLocks()
-
-				// Imagine that the state locks contain:
-				// 1) provider for resources in the config
-				stateLocks.SetProvider(providerA, noVersion, versionUnconstrained, hashesProviderA)
-
-				// 2) also, a provider that's deleted from the config and only present in state
-				stateLocks.SetProvider(providerB, noVersion, versionUnconstrained, hashesProviderB)
-
-				return stateLocks
+			additionalLocks: func() *depsfile.Locks {
+				locks := depsfile.NewLocks()
+				locks.SetProvider(providerB, v2_0_0, versionConstraintv2, hashesProviderB)
+				return locks
 			}(),
 			expectedLocks: func() *depsfile.Locks {
 				combinedLocks := depsfile.NewLocks()
-				combinedLocks.SetProvider(providerA, v1_0_0, versionConstraintv1, hashesProviderA)     // version constraint preserved
-				combinedLocks.SetProvider(providerB, noVersion, versionUnconstrained, hashesProviderB) // sourced from state only
+				combinedLocks.SetProvider(providerA, v1_0_0, versionConstraintv1, hashesProviderA)
+				combinedLocks.SetProvider(providerB, v2_0_0, versionConstraintv2, hashesProviderB)
+				return combinedLocks
+			}(),
+		},
+		"when the same provider is present in both base and additional locks, output locks have the version constraints from the base locks": {
+			baseLocks: func() *depsfile.Locks {
+				locks := depsfile.NewLocks()
+				locks.SetProvider(providerA, v1_0_0, versionConstraintv1, hashesProviderA)
+				return locks
+			}(),
+			additionalLocks: func() *depsfile.Locks {
+				locks := depsfile.NewLocks()
+
+				// Overlap with base locks, but different version
+				locks.SetProvider(providerA, v2_0_0, versionConstraintv2, hashesProviderA)
+
+				// Unique to additional locks, should be preserved in output
+				locks.SetProvider(providerB, v2_0_0, versionConstraintv2, hashesProviderB)
+
+				return locks
+			}(),
+			expectedLocks: func() *depsfile.Locks {
+				combinedLocks := depsfile.NewLocks()
+				combinedLocks.SetProvider(providerA, v1_0_0, versionConstraintv1, hashesProviderA) // base locks not overridden by additional locks
+				combinedLocks.SetProvider(providerB, v2_0_0, versionConstraintv2, hashesProviderB)
 				return combinedLocks
 			}(),
 		},
@@ -105,9 +118,8 @@ func Test_mergeLockedDependencies_config_and_state(t *testing.T) {
 				View: view,
 			}
 
-			// Code under test - combine deps from state with prior deps from config
-			// mergedLocks := m.mergeLockedDependencies(tc.configLocks, tc.stateLocks)
-			mergedLocks := m.mergeLockedDependencies(tc.configLocks, tc.stateLocks)
+			// Code under test
+			mergedLocks := m.mergeLockedDependencies(tc.baseLocks, tc.additionalLocks)
 
 			// We cannot use (l *depsfile.Locks) Equal here as it doesn't compare version constraints
 			// Instead, inspect entries directly


### PR DESCRIPTION
Similar to https://github.com/hashicorp/terraform/pull/38731, this PR is making some fixes to remove lingering reminders of how provider download used to be split in two steps of config/state and now the split is 0-1 providers downloaded for state storage/all the rest of the providers.

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.16.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
