### PR TITLE
Action diagnostics handling improvements

### DIFF
--- a/internal/command/graph_test.go
+++ b/internal/command/graph_test.go
@@ -70,8 +70,8 @@ func TestGraph_cyclic(t *testing.T) {
 		{
 			name: "plan",
 			args: []string{"-type=plan"},
-			errors: []string{`Error: Cycle: test_instance.`,
-				`Error: Cycle: local.`},
+			errors: []string{"Error: Cycle:\n  test_instance.",
+				"Error: Cycle:\n  local."},
 		},
 		{
 			name: "plan with -draw-cycles option",
@@ -102,8 +102,8 @@ func TestGraph_cyclic(t *testing.T) {
 			// The cyclic errors do not maintain a consistent order, so we can't
 			// predict the exact output. We'll just check that the error messages
 			// are present for the things we know are cyclic.
-			errors: []string{`Error: Cycle: test_instance.`,
-				`Error: Cycle: local.`},
+			errors: []string{"Error: Cycle:\n  test_instance.",
+				"Error: Cycle:\n  local."},
 		},
 		{
 			name: "apply with -draw-cycles option",

--- a/internal/dag/dag.go
+++ b/internal/dag/dag.go
@@ -6,6 +6,7 @@ package dag
 import (
 	"errors"
 	"fmt"
+	"slices"
 	"sort"
 	"strings"
 
@@ -241,8 +242,33 @@ func (g *AcyclicGraph) Validate() error {
 				cycleStr[j] = VertexName(vertex)
 			}
 
+			// Reverse the cycle string so readers can interpret it
+			// left-to-right or top-to-bottom.
+			slices.Reverse(cycleStr)
+
+			// Since the cycle can start anywhere, pick an arbitrary first node
+			// for consistency. We're going to start with the shortest name, then
+			// compare lexically.
+			first := 0
+			for i := 1; i < len(cycleStr); i++ {
+				if len(cycleStr[i]) < len(cycleStr[first]) {
+					first = i
+					continue
+				}
+
+				if len(cycleStr[i]) == len(cycleStr[first]) && cycleStr[i] < cycleStr[first] {
+					first = i
+				}
+			}
+
+			// pivot the slice around our new first index
+			if first > 0 {
+				cycleStr = append(cycleStr[first:], cycleStr[:first]...)
+			}
+
 			err = errors.Join(err, fmt.Errorf(
-				"Cycle: %s", strings.Join(cycleStr, ", ")))
+				"Cycle:\n  %s", strings.Join(cycleStr, "\n  "),
+			))
 		}
 	}
 

--- a/internal/plugin/convert/diagnostics.go
+++ b/internal/plugin/convert/diagnostics.go
@@ -54,6 +54,16 @@ func AppendProtoDiag(diags []*proto.Diagnostic, d interface{}) []*proto.Diagnost
 
 // ProtoToDiagnostics converts a list of proto.Diagnostics to a tf.Diagnostics.
 func ProtoToDiagnostics(ds []*proto.Diagnostic) tfdiags.Diagnostics {
+	return protoToDiagnostics(ds, nil)
+}
+
+// ProtoToDiagnosticsWithPrefix is used when a particular diagnostic will
+// universally be contained within an outer object in Terraform configuration.
+func ProtoToDiagnosticsWithPrefix(ds []*proto.Diagnostic, prefix cty.Path) tfdiags.Diagnostics {
+	return protoToDiagnostics(ds, prefix)
+}
+
+func protoToDiagnostics(ds []*proto.Diagnostic, prefix cty.Path) tfdiags.Diagnostics {
 	var diags tfdiags.Diagnostics
 	for _, d := range ds {
 		var severity tfdiags.Severity
@@ -69,7 +79,7 @@ func ProtoToDiagnostics(ds []*proto.Diagnostic) tfdiags.Diagnostics {
 
 		// if there's an attribute path, we need to create a AttributeValue diagnostic
 		if d.Attribute != nil && len(d.Attribute.Steps) > 0 {
-			path := AttributePathToPath(d.Attribute)
+			path := AttributePathToPath(d.Attribute, prefix)
 			newDiag = tfdiags.AttributeValue(severity, d.Summary, d.Detail, path)
 		} else {
 			newDiag = tfdiags.WholeContainingBody(severity, d.Summary, d.Detail)
@@ -82,8 +92,7 @@ func ProtoToDiagnostics(ds []*proto.Diagnostic) tfdiags.Diagnostics {
 }
 
 // AttributePathToPath takes the proto encoded path and converts it to a cty.Path
-func AttributePathToPath(ap *proto.AttributePath) cty.Path {
-	var p cty.Path
+func AttributePathToPath(ap *proto.AttributePath, p cty.Path) cty.Path {
 	for _, step := range ap.Steps {
 		switch selector := step.Selector.(type) {
 		case *proto.AttributePath_Step_AttributeName:

--- a/internal/plugin/grpc_provider.go
+++ b/internal/plugin/grpc_provider.go
@@ -29,6 +29,10 @@ import (
 
 var logger = logging.HCLogger()
 
+// Some blocks contain a fixed config block to hold the object configuration,
+// and their diagnostics will always be returned relative to this path.
+var configBlockPath = cty.GetAttrPath("config")
+
 // GRPCProviderPlugin implements plugin.GRPCPlugin for the go-plugin package.
 type GRPCProviderPlugin struct {
 	plugin.Plugin
@@ -715,7 +719,7 @@ func (p *GRPCProvider) PlanResourceChange(r providers.PlanResourceChangeRequest)
 	resp.PlannedState = state
 
 	for _, p := range protoResp.RequiresReplace {
-		resp.RequiresReplace = append(resp.RequiresReplace, convert.AttributePathToPath(p))
+		resp.RequiresReplace = append(resp.RequiresReplace, convert.AttributePathToPath(p, nil))
 	}
 
 	resp.PlannedPrivate = protoResp.PlannedPrivate
@@ -1383,7 +1387,7 @@ func (p *GRPCProvider) ListResource(r providers.ListResourceRequest) providers.L
 			break
 		}
 
-		resp.Diagnostics = resp.Diagnostics.Append(convert.ProtoToDiagnostics(event.Diagnostic))
+		resp.Diagnostics = resp.Diagnostics.Append(convert.ProtoToDiagnosticsWithPrefix(event.Diagnostic, configBlockPath))
 		if resp.Diagnostics.HasErrors() {
 			// If we have errors, we stop processing and return early
 			break
@@ -1531,7 +1535,7 @@ func (p *GRPCProvider) PlanAction(r providers.PlanActionRequest) (resp providers
 		resp.Deferred = convert.ProtoToDeferred(protoResp.Deferred)
 	}
 
-	resp.Diagnostics = resp.Diagnostics.Append(convert.ProtoToDiagnostics(protoResp.Diagnostics))
+	resp.Diagnostics = resp.Diagnostics.Append(convert.ProtoToDiagnosticsWithPrefix(protoResp.Diagnostics, configBlockPath))
 	return resp
 }
 
@@ -1596,7 +1600,7 @@ func (p *GRPCProvider) InvokeAction(r providers.InvokeActionRequest) (resp provi
 				}
 
 			case *proto.InvokeAction_Event_Completed_:
-				diags := convert.ProtoToDiagnostics(ev.Completed.Diagnostics)
+				diags := convert.ProtoToDiagnosticsWithPrefix(ev.Completed.Diagnostics, configBlockPath)
 
 				if !yield(providers.InvokeActionEvent_Completed{
 					Diagnostics: diags,
@@ -1645,7 +1649,7 @@ func (p *GRPCProvider) ValidateActionConfig(r providers.ValidateActionConfigRequ
 		return resp
 	}
 
-	resp.Diagnostics = resp.Diagnostics.Append(convert.ProtoToDiagnostics(protoResp.Diagnostics))
+	resp.Diagnostics = resp.Diagnostics.Append(convert.ProtoToDiagnosticsWithPrefix(protoResp.Diagnostics, configBlockPath))
 	return resp
 }
 

--- a/internal/plugin6/convert/diagnostics.go
+++ b/internal/plugin6/convert/diagnostics.go
@@ -77,6 +77,16 @@ func DiagnosticToProto(diag tfdiags.Diagnostic) *proto.Diagnostic {
 
 // ProtoToDiagnostics converts a list of proto.Diagnostics to a tf.Diagnostics.
 func ProtoToDiagnostics(ds []*proto.Diagnostic) tfdiags.Diagnostics {
+	return protoToDiagnostics(ds, nil)
+}
+
+// ProtoToDiagnosticsWithPrefix is used when a particular diagnostic will
+// universally be contained within an outer object in Terraform configuration.
+func ProtoToDiagnosticsWithPrefix(ds []*proto.Diagnostic, prefix cty.Path) tfdiags.Diagnostics {
+	return protoToDiagnostics(ds, prefix)
+}
+
+func protoToDiagnostics(ds []*proto.Diagnostic, prefix cty.Path) tfdiags.Diagnostics {
 	var diags tfdiags.Diagnostics
 	for _, d := range ds {
 		var severity tfdiags.Severity
@@ -92,7 +102,7 @@ func ProtoToDiagnostics(ds []*proto.Diagnostic) tfdiags.Diagnostics {
 
 		// if there's an attribute path, we need to create a AttributeValue diagnostic
 		if d.Attribute != nil {
-			path := AttributePathToPath(d.Attribute)
+			path := AttributePathToPath(d.Attribute, prefix)
 			newDiag = tfdiags.AttributeValue(severity, d.Summary, d.Detail, path)
 		} else {
 			newDiag = tfdiags.WholeContainingBody(severity, d.Summary, d.Detail)
@@ -105,8 +115,7 @@ func ProtoToDiagnostics(ds []*proto.Diagnostic) tfdiags.Diagnostics {
 }
 
 // AttributePathToPath takes the proto encoded path and converts it to a cty.Path
-func AttributePathToPath(ap *proto.AttributePath) cty.Path {
-	var p cty.Path
+func AttributePathToPath(ap *proto.AttributePath, p cty.Path) cty.Path {
 	for _, step := range ap.Steps {
 		switch selector := step.Selector.(type) {
 		case *proto.AttributePath_Step_AttributeName:

--- a/internal/plugin6/grpc_provider.go
+++ b/internal/plugin6/grpc_provider.go
@@ -54,6 +54,10 @@ func (p *GRPCProviderPlugin) GRPCServer(broker *plugin.GRPCBroker, s *grpc.Serve
 // See https://github.com/hashicorp/terraform-plugin-go/blob/a361c9bf/tfprotov6/tf6server/server.go#L88
 const grpcMaxMessageSize = 256 << 20
 
+// Some blocks contain a fixed config block to hold the object configuration,
+// and their diagnostics will always be returned relative to this path.
+var configBlockPath = cty.GetAttrPath("config")
+
 // GRPCProvider handles the client, or core side of the plugin rpc connection.
 // The GRPCProvider methods are mostly a translation layer between the
 // terraform providers types and the grpc proto types, directly converting
@@ -721,7 +725,7 @@ func (p *GRPCProvider) PlanResourceChange(r providers.PlanResourceChangeRequest)
 	resp.PlannedState = state
 
 	for _, p := range protoResp.RequiresReplace {
-		resp.RequiresReplace = append(resp.RequiresReplace, convert.AttributePathToPath(p))
+		resp.RequiresReplace = append(resp.RequiresReplace, convert.AttributePathToPath(p, nil))
 	}
 
 	resp.PlannedPrivate = protoResp.PlannedPrivate
@@ -1391,7 +1395,7 @@ func (p *GRPCProvider) ListResource(r providers.ListResourceRequest) providers.L
 			break
 		}
 
-		resp.Diagnostics = resp.Diagnostics.Append(convert.ProtoToDiagnostics(event.Diagnostic))
+		resp.Diagnostics = resp.Diagnostics.Append(convert.ProtoToDiagnosticsWithPrefix(event.Diagnostic, configBlockPath))
 		if resp.Diagnostics.HasErrors() {
 			// If we have errors, we stop processing and return early
 			break
@@ -1954,7 +1958,7 @@ func (p *GRPCProvider) PlanAction(r providers.PlanActionRequest) (resp providers
 		resp.Deferred = convert.ProtoToDeferred(protoResp.Deferred)
 	}
 
-	resp.Diagnostics = resp.Diagnostics.Append(convert.ProtoToDiagnostics(protoResp.Diagnostics))
+	resp.Diagnostics = resp.Diagnostics.Append(convert.ProtoToDiagnosticsWithPrefix(protoResp.Diagnostics, configBlockPath))
 	return resp
 }
 
@@ -2019,7 +2023,7 @@ func (p *GRPCProvider) InvokeAction(r providers.InvokeActionRequest) (resp provi
 				}
 
 			case *proto6.InvokeAction_Event_Completed_:
-				diags := convert.ProtoToDiagnostics(ev.Completed.Diagnostics)
+				diags := convert.ProtoToDiagnosticsWithPrefix(ev.Completed.Diagnostics, configBlockPath)
 				if !yield(providers.InvokeActionEvent_Completed{
 					Diagnostics: diags,
 				}) {
@@ -2066,7 +2070,7 @@ func (p *GRPCProvider) ValidateActionConfig(r providers.ValidateActionConfigRequ
 		resp.Diagnostics = resp.Diagnostics.Append(grpcErr(err))
 		return resp
 	}
-	resp.Diagnostics = resp.Diagnostics.Append(convert.ProtoToDiagnostics(protoResp.Diagnostics))
+	resp.Diagnostics = resp.Diagnostics.Append(convert.ProtoToDiagnosticsWithPrefix(protoResp.Diagnostics, configBlockPath))
 	return resp
 }
 

--- a/internal/terraform/action_trigger_instance_apply.go
+++ b/internal/terraform/action_trigger_instance_apply.go
@@ -33,6 +33,11 @@ var (
 func (n *actionTriggerApplyInstance) Invoke(ctx EvalContext, caller addrs.Referenceable, callerVal cty.Value, fromPlan bool) tfdiags.Diagnostics {
 	var diags tfdiags.Diagnostics
 
+	diagsWith := n.ActionInvocation.Addr.String()
+	if caller != nil {
+		diagsWith = fmt.Sprintf("%s, called from %s", diagsWith, caller)
+	}
+
 	provider, actionProviderSchema, err := getProvider(ctx, n.ActionInvocation.ProviderAddr)
 	if err != nil {
 		diags = diags.Append(&hcl.Diagnostic{
@@ -116,15 +121,8 @@ func (n *actionTriggerApplyInstance) Invoke(ctx EvalContext, caller addrs.Refere
 		ClientCapabilities: ctx.ClientCapabilities(),
 	})
 
-	if resp.Diagnostics != nil {
-		if n.actionNode.Config.Config != nil {
-			diags = diags.Append(resp.Diagnostics.InConfigBody(n.actionNode.Config.Config, caller.String()))
-		} else {
-			diags = diags.Append(resp.Diagnostics.InConfigBody(n.actionNode.Config.Body, caller.String()))
-		}
-	}
-
-	if resp.Diagnostics.HasErrors() {
+	diags = diags.Append(resp.Diagnostics.InConfigBody(n.actionNode.Config.Body, diagsWith))
+	if diags.HasErrors() {
 		diags = diags.Append(ctx.Hook(func(h Hook) (HookAction, error) {
 			return h.CompleteAction(hookIdentity, resp.Diagnostics.Err())
 		}))
@@ -143,13 +141,7 @@ func (n *actionTriggerApplyInstance) Invoke(ctx EvalContext, caller addrs.Refere
 				}
 			case providers.InvokeActionEvent_Completed:
 				// Enhance the diagnostics
-				if ev.Diagnostics != nil {
-					if n.actionNode.Config.Config != nil {
-						diags = diags.Append(ev.Diagnostics.InConfigBody(n.actionNode.Config.Config, caller.String()))
-					} else {
-						diags = diags.Append(ev.Diagnostics.InConfigBody(n.actionNode.Config.Body, caller.String()))
-					}
-				}
+				diags = diags.Append(ev.Diagnostics.InConfigBody(n.actionNode.Config.Body, diagsWith))
 
 				diags = diags.Append(ctx.Hook(func(h Hook) (HookAction, error) {
 					return h.CompleteAction(hookIdentity, ev.Diagnostics.Err())
@@ -157,6 +149,7 @@ func (n *actionTriggerApplyInstance) Invoke(ctx EvalContext, caller addrs.Refere
 				if diags.HasErrors() {
 					return diags
 				}
+
 			default:
 				panic(fmt.Sprintf("unexpected action event type %T", ev))
 			}

--- a/internal/terraform/context_apply_action_test.go
+++ b/internal/terraform/context_apply_action_test.go
@@ -321,7 +321,11 @@ resource "test_object" "a" {
 		"before_create failing when calling invoke": {
 			module: map[string]string{
 				"main.tf": `
-action "action_example" "hello" {}
+action "action_example" "hello" {
+  config {
+    attr = "failure"
+  }
+}
 resource "test_object" "a" {
   lifecycle {
     action_trigger {
@@ -335,10 +339,10 @@ resource "test_object" "a" {
 			expectInvokeActionCalled: true,
 			callingInvokeReturnsDiagnostics: func(providers.InvokeActionRequest) tfdiags.Diagnostics {
 				return tfdiags.Diagnostics{
-					tfdiags.Sourceless(
-						tfdiags.Error,
+					tfdiags.AttributeValue(tfdiags.Error,
 						"test case for failing",
 						"this simulates a provider failing before the action is invoked",
+						cty.GetAttrPath("config").GetAttr("attr"),
 					),
 				}
 			},
@@ -348,6 +352,11 @@ resource "test_object" "a" {
 						Severity: hcl.DiagError,
 						Summary:  "test case for failing",
 						Detail:   "this simulates a provider failing before the action is invoked",
+						Subject: &hcl.Range{
+							Filename: filepath.Join(m.Module.SourceDir, "main.tf"),
+							Start:    hcl.Pos{Line: 4, Column: 12, Byte: 57},
+							End:      hcl.Pos{Line: 4, Column: 21, Byte: 66},
+						},
 					},
 				)
 			},

--- a/internal/terraform/context_plan_query_test.go
+++ b/internal/terraform/context_plan_query_test.go
@@ -466,8 +466,8 @@ func TestContext2Plan_queryList(t *testing.T) {
 				`,
 			assertValidateDiags: func(t *testing.T, diags tfdiags.Diagnostics) {
 				tfdiags.AssertDiagnosticCount(t, diags, 1)
-				if !strings.Contains(diags[0].Description().Summary, "Cycle: list.test_resource") {
-					t.Errorf("Expected error message to contain 'Cycle: list.test_resource', got %q", diags[0].Description().Summary)
+				if !strings.Contains(diags[0].Description().Summary, "Cycle:\n  list.test_resource") {
+					t.Errorf("Expected error message to contain 'Cycle:\\n  list.test_resource', got: %q", diags[0].Description().Summary)
 				}
 				if diags[0].Severity() != tfdiags.Error {
 					t.Errorf("Expected error severity to be Error, got %s", diags[0].Severity())

--- a/internal/terraform/context_validate_test.go
+++ b/internal/terraform/context_validate_test.go
@@ -4108,7 +4108,7 @@ func TestContext2Validate_queryList(t *testing.T) {
 				`,
 			diagCount: 1,
 			expectedErrMsg: []string{
-				"Cycle: list.test_resource",
+				"Cycle:\n  list.test_resource",
 			},
 		},
 		{

--- a/internal/terraform/node_action.go
+++ b/internal/terraform/node_action.go
@@ -137,6 +137,11 @@ func (n *NodeActionConfig) recordActionExpansion(ctx EvalContext) tfdiags.Diagno
 func (n *NodeActionConfig) Validate(ctx EvalContext, caller addrs.Referenceable, callerVal cty.Value) tfdiags.Diagnostics {
 	var diags tfdiags.Diagnostics
 
+	diagsWith := n.Addr.String()
+	if caller != nil {
+		diagsWith = fmt.Sprintf("%s, called from %s", diagsWith, caller)
+	}
+
 	provider, _, err := getProvider(ctx, n.ResolvedProvider)
 	diags = diags.Append(err)
 	if diags.HasErrors() {
@@ -171,7 +176,9 @@ func (n *NodeActionConfig) Validate(ctx EvalContext, caller addrs.Referenceable,
 	}
 
 	config := n.Config.Config
-	if n.Config.Config == nil {
+	if config == nil {
+		// We continue here with an empty body, because we also need to validate
+		// for any missing required attributes.
 		config = hcl.EmptyBody()
 	}
 
@@ -181,21 +188,20 @@ func (n *NodeActionConfig) Validate(ctx EvalContext, caller addrs.Referenceable,
 		// If there was no config block at all, we'll add a Context range to the returned diagnostic
 		if n.Config.Config == nil {
 			for _, diag := range valDiags.ToHCL() {
-				diag.Context = &n.Config.DeclRange
+				diag.Context = n.Config.DeclRange.Ptr()
 				diags = diags.Append(diag)
 			}
-			return diags
 		} else {
 			diags = diags.Append(valDiags)
-			return diags
 		}
+		return diags
 	}
 	var deprecationDiags tfdiags.Diagnostics
 	configVal, deprecationDiags = ctx.Deprecations().ValidateAndUnmarkConfig(configVal, n.Schema.ConfigSchema, n.ModulePath())
-	diags = diags.Append(deprecationDiags.InConfigBody(n.Config.Config, n.Addr.String()))
+	diags = diags.Append(deprecationDiags.InConfigBody(config, diagsWith))
 
 	valDiags = validateResourceForbiddenEphemeralValues(ctx, configVal, n.Schema.ConfigSchema)
-	diags = diags.Append(valDiags.InConfigBody(config, n.Addr.String()))
+	diags = diags.Append(valDiags.InConfigBody(config, diagsWith))
 
 	if diags.HasErrors() {
 		return diags
@@ -211,7 +217,7 @@ func (n *NodeActionConfig) Validate(ctx EvalContext, caller addrs.Referenceable,
 
 	resp := provider.ValidateActionConfig(req)
 	if resp.Diagnostics != nil {
-		diags = diags.Append(resp.Diagnostics.InConfigBody(n.Config.Config, caller.String()))
+		diags = diags.Append(resp.Diagnostics.InConfigBody(n.Config.Body, diagsWith))
 	}
 
 	return diags
@@ -447,13 +453,19 @@ func (n *NodeActionConfig) EvalInstance(ctx EvalContext, inst addrs.AbsActionIns
 func (n *NodeActionConfig) evalInstance(ctx EvalContext, repData instances.RepetitionData, callRange *hcl.Range, caller addrs.Referenceable, callerVal cty.Value) (cty.Value, tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
 
+	diagsWith := n.Addr.String()
+	if caller != nil {
+		diagsWith = fmt.Sprintf("%s, called from %s", diagsWith, caller)
+	}
+
 	// This should have been caught already
 	if n.Schema == nil {
 		panic("action eval called without a schema")
 	}
 
+	config := n.Config.Config
 	configVal := cty.NullVal(n.Schema.ConfigSchema.ImpliedType())
-	if n.Config.Config == nil {
+	if config == nil {
 		return configVal, nil
 	}
 
@@ -461,14 +473,14 @@ func (n *NodeActionConfig) evalInstance(ctx EvalContext, repData instances.Repet
 	// mechanisms because the instance must be in state already.
 	var evalDiags tfdiags.Diagnostics
 	if callerVal == cty.NilVal {
-		configVal, _, evalDiags = ctx.EvaluateBlock(n.Config.Config, n.Schema.ConfigSchema, caller, repData)
+		configVal, _, evalDiags = ctx.EvaluateBlock(config, n.Schema.ConfigSchema, caller, repData)
 		diags = diags.Append(evalDiags)
 		if diags.HasErrors() {
 			return configVal, diags
 		}
 	} else {
 		scope := ctx.EvaluationScope(caller, nil, repData)
-		configVal, evalDiags = scope.EvalActionBlock(n.Config.Config, n.Schema.ConfigSchema, callerVal)
+		configVal, evalDiags = scope.EvalActionBlock(config, n.Schema.ConfigSchema, callerVal)
 		diags = diags.Append(evalDiags)
 		if diags.HasErrors() {
 			return configVal, diags
@@ -476,11 +488,11 @@ func (n *NodeActionConfig) evalInstance(ctx EvalContext, repData instances.Repet
 	}
 
 	valDiags := validateResourceForbiddenEphemeralValues(ctx, configVal, n.Schema.ConfigSchema)
-	diags = diags.Append(valDiags.InConfigBody(n.Config.Config, n.Addr.String()))
+	diags = diags.Append(valDiags.InConfigBody(config, diagsWith))
 
 	var deprecationDiags tfdiags.Diagnostics
 	configVal, deprecationDiags = ctx.Deprecations().ValidateAndUnmarkConfig(configVal, n.Schema.ConfigSchema, n.ModulePath())
-	diags = diags.Append(deprecationDiags.InConfigBody(n.Config.Config, n.Addr.String()))
+	diags = diags.Append(deprecationDiags.InConfigBody(config, diagsWith))
 
 	return configVal, diags
 }

--- a/internal/terraform/node_resource_abstract_instance.go
+++ b/internal/terraform/node_resource_abstract_instance.go
@@ -3198,6 +3198,7 @@ func (n *NodeAbstractResourceInstance) planActionTriggers(ctx EvalContext, resRe
 // Plan the individual action invocation.
 // This function uses named result parameters.
 func (n *NodeAbstractResourceInstance) planActionTrigger(ctx EvalContext, resRepData instances.RepetitionData, actionRef actionRef, event configs.ActionTriggerEvent, change *plans.ResourceInstanceChange) (ai *plans.ActionInvocationInstance, deferred bool, diags tfdiags.Diagnostics) {
+	diagsWith := fmt.Sprintf("%s, called from %s", n.Addr, actionRef.actionNode.Addr)
 
 	actionInst, evalActionDiags := evaluateActionExpression(actionRef.configRef.Expr, resRepData)
 	diags = append(diags, evalActionDiags...)
@@ -3280,12 +3281,7 @@ func (n *NodeAbstractResourceInstance) planActionTrigger(ctx EvalContext, resRep
 	})
 
 	// Associate any provider produced diagnostics with the action config block.
-	if actionRef.actionNode.Config.Config != nil {
-		resp.Diagnostics = resp.Diagnostics.InConfigBody(actionRef.actionNode.Config.Config, n.Addr.String())
-	} else {
-		// if there was no action config block, use the entire action block for reference
-		resp.Diagnostics = resp.Diagnostics.InConfigBody(actionRef.actionNode.Config.Body, n.Addr.String())
-	}
+	resp.Diagnostics = resp.Diagnostics.InConfigBody(actionRef.actionNode.Config.Body, diagsWith)
 
 	diags = diags.Append(resp.Diagnostics)
 
@@ -3345,10 +3341,8 @@ func (n *NodeAbstractResourceInstance) invokeDestroyActions(ctx EvalContext, for
 
 // invokeActions invokes any actions triggered for the listed events. Condition
 // expressions are reevaluated here when they exist, and failing conditions are
-// skipped. If the taint return parameter is true, then the resource is also
+// skipped. If the taint return parameter is true, then the resource will be
 // tainted in state.
-//
-// FIXME: don't invoke actions on an already tainted resource?
 func (n *NodeAbstractResourceInstance) invokeActions(ctx EvalContext, repData instances.RepetitionData, forEvents []configs.ActionTriggerEvent, callerVal cty.Value) (taint bool, diags tfdiags.Diagnostics) {
 	for _, trigger := range n.actionApplyTriggers {
 		event := trigger.ActionInvocation.ActionTrigger.TriggerEvent()
@@ -3377,7 +3371,7 @@ func (n *NodeAbstractResourceInstance) invokeActions(ctx EvalContext, repData in
 				return false, diags.Append(invokeDiags)
 			case configs.ActionOnFailureTaint:
 				// We can only taint a newly created resource, because that's
-				// the only action which an be re-done from scratch. Recording
+				// the only action which can be re-done from scratch. Recording
 				// other action events which need to be reinvoked will require
 				// new data to be saved in the state.
 				return event == configs.AfterCreate, diags.Append(invokeDiags)


### PR DESCRIPTION
Because `actions` (and also `list`) blocks contain the object configuration in a nested `config` block, we need to be careful when trying to associate diagnostic to configuration so any attribute paths align correctly. The first step here is to create a new helper for the grpc provider implementations, `ProtoToDiagnosticsWithPrefix`. The paths the provider returns for attribute errors will only be relative to their config, so callers need to prepend the `config` path in order to correctly locate the configuration source. This allows us to always annotate based on the entire surrounding block, and not have non-attribute errors pointing only at nameless `config {` entries.

We can also build a better "with" string to give more context to the diagnostics, including both the action location and any caller address. These two improvements combined give us a diagnostic output like so:

```
│ Error: Invalid Bufo Name
│
│   with action.bufo_print.bufo, called from terraform_data.bufo,
│   on main.tf line 30, in action "bufo_print" "bufo":
│   30:     name = "nope"
```

Another change not directly related to actions, but something even more likely to come up now that we have them, is the format of graph cycles errors. We don't attempt to change them structurally, but we can format them in an easier to read manner. Since cycles are often long, parsing a single line is difficult, and the traversal order is opposite from how one would read through them in configuration. This change reverses the order, prints them on individual lines for visual separation, and picks a consistent starting node. This changes the cycle rendering from
```
│ Error: Cycle: module.test.output.out (expand), local.b (expand), terraform_data.b, terraform_data.a, local.a (expand), module.test.var.in (expand)
```
to a marginally better:
```
│ Error: Cycle:
│   local.a (expand)
│   terraform_data.a
│   terraform_data.b
│   local.b (expand)
│   module.test.output.out (expand)
│   module.test.var.in (expand)
```