### PR TITLE
policy: Fix provider policy evaluation to pass sensitive paths that are marked on the value

### DIFF
--- a/internal/command/meta_policy.go
+++ b/internal/command/meta_policy.go
@@ -138,7 +138,7 @@ func (h *policyModuleInstallHook) ModuleSourceResolved(ctx context.Context, req 
 	result := h.client.EvaluateModule(ctx, policy.EvaluationRequest[*proto.PolicyEvaluateModuleRequest_ModuleMetadata]{
 		// Configuration attributes may not be available during init, so we will send an unknown
 		// dynamic value to the policy client.
-		Attrs:  policy.PolicyValue{Raw: cty.DynamicVal},
+		Attrs:  policy.CtyToPolicyValue(cty.DynamicVal),
 		Target: req.SourceAddr.String(),
 		Meta: &proto.PolicyEvaluateModuleRequest_ModuleMetadata{
 			Address: moduleAddr,
@@ -201,7 +201,7 @@ func (p *providerPolicyHook) ProviderVersionSelected(ctx context.Context, provid
 
 		// Configuration attributes may not be available during init, so we will send an unknown
 		// dynamic value to the policy client.
-		Attrs: policy.PolicyValue{Raw: cty.DynamicVal},
+		Attrs: policy.CtyToPolicyValue(cty.DynamicVal),
 		Meta: &proto.PolicyEvaluateProviderRequest_ProviderMetadata{
 			Name:      provider.Type,
 			Namespace: provider.Namespace,

--- a/internal/terraform/context_apply_policy_test.go
+++ b/internal/terraform/context_apply_policy_test.go
@@ -34,6 +34,10 @@ func TestContext2Apply_PolicyEvaluation_Full(t *testing.T) {
 			}
 		}
 
+		provider "test" {
+			value = sensitive("foo")
+		}
+
 		variable "input" {
 			type = string
 			default = "foo"
@@ -86,6 +90,11 @@ func TestContext2Apply_PolicyEvaluation_Full(t *testing.T) {
 	providerAddr := addrs.NewDefaultProvider("test")
 	provider := testProvider("test")
 	provider.GetProviderSchemaResponse = getProviderSchemaResponseFromProviderSchema(&providerSchema{
+		Provider: &configschema.Block{
+			Attributes: map[string]*configschema.Attribute{
+				"value": {Type: cty.String, Optional: true},
+			},
+		},
 		ResourceTypes: map[string]*configschema.Block{
 			"test_resource": {
 				Attributes: map[string]*configschema.Attribute{
@@ -119,6 +128,9 @@ func TestContext2Apply_PolicyEvaluation_Full(t *testing.T) {
 
 	// The expected values to be sent for policy evaluation.
 	expectedPlan := map[string]cty.Value{
+		"test": cty.ObjectVal(map[string]cty.Value{
+			"value": cty.StringVal("foo"),
+		}),
 		"test_resource": cty.ObjectVal(map[string]cty.Value{
 			"value":           cty.NullVal(cty.String),
 			"sensitive_value": cty.StringVal("foo"),
@@ -156,6 +168,32 @@ func TestContext2Apply_PolicyEvaluation_Full(t *testing.T) {
 		}
 		return policy.EvaluationResponse{Overall: policy.AllowResult}
 	}
+
+	planPolicyClient.EvaluateProviderFn = func(ctx context.Context, req policy.EvaluationRequest[*proto.PolicyEvaluateProviderRequest_ProviderMetadata]) policy.EvaluationResponse {
+		var actualVal cty.Value
+		attrs := req.Attrs
+		target := req.Target
+		if !attrs.Raw.IsNull() {
+			mp := attrs.Raw.AsValueMap()
+			actualVal = cty.ObjectVal(map[string]cty.Value{
+				"value": mp["value"],
+			})
+		}
+		actualPlan[target] = actualVal
+
+		if actualVal.Type().HasAttribute("value") {
+			if !actualVal.GetAttr("value").IsNull() && len(attrs.RedactedPaths) == 0 {
+				t.Errorf("Expected redacted paths for sensitive attributes to be included in the request")
+			}
+
+			for _, path := range attrs.RedactedPaths {
+				if !path.Equals(cty.Path{cty.GetAttrStep{Name: "value"}}) {
+					t.Errorf("Unexpected redacted path: %s", path)
+				}
+			}
+		}
+		return policy.EvaluationResponse{Overall: policy.AllowResult}
+	}
 	t.Cleanup(func() {
 		if diff := cmp.Diff(actualPlan, expectedPlan, cmp.Comparer(cty.Value.RawEquals)); diff != "" {
 			t.Errorf("Unexpected diff (-got +want):\n%s", diff)
@@ -182,6 +220,9 @@ func TestContext2Apply_PolicyEvaluation_Full(t *testing.T) {
 
 	// The expected values to be sent for policy evaluation.
 	expectedApply := map[string]cty.Value{
+		"test": cty.ObjectVal(map[string]cty.Value{
+			"value": cty.StringVal("foo"),
+		}),
 		"test_resource": cty.ObjectVal(map[string]cty.Value{
 			"value":           cty.NullVal(cty.String),
 			"sensitive_value": cty.StringVal("foo"),
@@ -219,6 +260,33 @@ func TestContext2Apply_PolicyEvaluation_Full(t *testing.T) {
 		}
 
 		// this return does not actually do anything
+		return policy.EvaluationResponse{Overall: policy.AllowResult}
+	}
+
+	applyPolicyClient.EvaluateProviderFn = func(ctx context.Context, req policy.EvaluationRequest[*proto.PolicyEvaluateProviderRequest_ProviderMetadata]) policy.EvaluationResponse {
+		var actual cty.Value
+		attrs := req.Attrs
+		target := req.Target
+		if !attrs.Raw.IsNull() {
+			mp := attrs.Raw.AsValueMap()
+			actual = cty.ObjectVal(map[string]cty.Value{
+				"value": mp["value"],
+			})
+		}
+		actualApply[target] = actual
+
+		if actual.Type().HasAttribute("value") {
+			if !actual.GetAttr("value").IsNull() && len(attrs.RedactedPaths) == 0 {
+				t.Errorf("Expected redacted paths for sensitive attributes to be included in the request")
+			}
+
+			for _, path := range attrs.RedactedPaths {
+				if !path.Equals(cty.Path{cty.GetAttrStep{Name: "value"}}) {
+					t.Errorf("Unexpected redacted path: %s", path)
+				}
+			}
+		}
+
 		return policy.EvaluationResponse{Overall: policy.AllowResult}
 	}
 

--- a/internal/terraform/context_apply_policy_test.go
+++ b/internal/terraform/context_apply_policy_test.go
@@ -187,7 +187,7 @@ func TestContext2Apply_PolicyEvaluation_Full(t *testing.T) {
 			}
 
 			for _, path := range attrs.RedactedPaths {
-				if !path.Equals(cty.Path{cty.GetAttrStep{Name: "value"}}) {
+				if !path.Equals(cty.GetAttrPath("value")) {
 					t.Errorf("Unexpected redacted path: %s", path)
 				}
 			}
@@ -281,7 +281,7 @@ func TestContext2Apply_PolicyEvaluation_Full(t *testing.T) {
 			}
 
 			for _, path := range attrs.RedactedPaths {
-				if !path.Equals(cty.Path{cty.GetAttrStep{Name: "value"}}) {
+				if !path.Equals(cty.GetAttrPath("value")) {
 					t.Errorf("Unexpected redacted path: %s", path)
 				}
 			}

--- a/internal/terraform/node_module_expand.go
+++ b/internal/terraform/node_module_expand.go
@@ -358,7 +358,7 @@ func (n *nodeExpandModule) EvalPolicy(ctx EvalContext, op walkOperation) tfdiags
 	// In the above example, the reference to `module.child.output` is deferred until the resource
 	// `test_instance.test2` is evaluated, and any attempt to evaluate it here would result in a cyclic dependency error.
 	result := ctx.PolicyClient().EvaluateModule(ctx.StopCtx(), policy.EvaluationRequest[*proto.PolicyEvaluateModuleRequest_ModuleMetadata]{
-		Attrs:  policy.PolicyValue{Raw: cty.DynamicVal},
+		Attrs:  policy.CtyToPolicyValue(cty.DynamicVal),
 		Target: source,
 		Meta: &proto.PolicyEvaluateModuleRequest_ModuleMetadata{
 			Address: n.Addr.String(),

--- a/internal/terraform/node_provider.go
+++ b/internal/terraform/node_provider.go
@@ -11,7 +11,6 @@ import (
 	"github.com/zclconf/go-cty/cty"
 
 	"github.com/hashicorp/terraform/internal/configs/configschema"
-	"github.com/hashicorp/terraform/internal/lang/marks"
 	"github.com/hashicorp/terraform/internal/policy"
 	"github.com/hashicorp/terraform/internal/policy/proto"
 	"github.com/hashicorp/terraform/internal/providers"
@@ -206,7 +205,11 @@ func (n *NodeApplyableProvider) ConfigureProvider(ctx EvalContext, provider prov
 	}
 
 	// Post-provider config policy evaluation
-	policyDiags := n.EvalPolicy(ctx, unmarkedConfigVal)
+	//
+	// We use the marked "configVal" so that we can send sensitive paths to the
+	// policy plugin. Provider schemas don't have a defined usage/behavior for
+	// the "Sensitive" field, so we don't add sensitive paths from the schema to this value.
+	policyDiags := n.EvalPolicy(ctx, configVal)
 	diags = diags.Append(policyDiags)
 	if policyDiags.HasErrors() {
 		return diags
@@ -226,15 +229,9 @@ func (n *NodeApplyableProvider) EvalPolicy(ctx EvalContext, attrs cty.Value) tfd
 		return nil
 	}
 
-	_, pvms := attrs.UnmarkDeepWithPaths()
-	sensitivePaths, _ := marks.PathsWithMark(pvms, marks.Sensitive)
-
 	result := ctx.PolicyClient().EvaluateProvider(ctx.StopCtx(), policy.EvaluationRequest[*proto.PolicyEvaluateProviderRequest_ProviderMetadata]{
 		Target: n.Addr.Provider.Type,
-		Attrs: policy.PolicyValue{
-			Raw:           attrs,
-			RedactedPaths: sensitivePaths,
-		},
+		Attrs:  policy.CtyToPolicyValue(attrs),
 		Meta: &proto.PolicyEvaluateProviderRequest_ProviderMetadata{
 			Name:      n.Addr.Provider.Type,
 			Alias:     n.Addr.Alias,


### PR DESCRIPTION
This PR adjust the logic for evaluating provider policies to ensure they pass any sensitive marked value path to the policy plugin. This doesn't add any sensitive marks from the provider schema as that's undefined behavior in Terraform (as there was never a usage for sensitive provider attributes).

Test failure prior to making the change:
```bash
--- FAIL: TestContext2Apply_PolicyEvaluation_Full (0.01s)

context_apply_policy_test.go:198: Expected redacted paths for sensitive attributes to be included in the request
context_apply_policy_test.go:294: Expected redacted paths for sensitive attributes to be included in the request
```

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.16.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
