### PR TITLE
init: skip required-variable check during walkInit (fixes #38689)

### DIFF
--- a/.changes/v1.16/BUG FIXES-20260616-160528.yaml
+++ b/.changes/v1.16/BUG FIXES-20260616-160528.yaml
@@ -1,0 +1,5 @@
+kind: BUG FIXES
+body: 'login: Fixed a race condition where the temporary callback HTTP server could be closed before the success page response was fully transmitted to the browser.'
+time: 2026-06-16T16:05:28+04:00
+custom:
+    Issue: "38712"

--- a/.changes/v1.16/BUG FIXES-20260618-100200.yaml
+++ b/.changes/v1.16/BUG FIXES-20260618-100200.yaml
@@ -1,0 +1,8 @@
+kind: BUG FIXES
+body: 'init: Fixed a regression where `terraform init` (and `cdktf get`) would incorrectly
+  report "Missing required argument" errors for module input variables that lack defaults,
+  even when those variables are only required during plan/apply. The init walk now
+  skips required-variable enforcement, consistent with the behaviour in v1.14.'
+time: 2026-06-18T10:02:00+04:00
+custom:
+    Issue: "38689"

--- a/internal/command/login.go
+++ b/internal/command/login.go
@@ -18,6 +18,7 @@ import (
 	"net/url"
 	"path/filepath"
 	"strings"
+	"time"
 
 	tfe "github.com/hashicorp/go-tfe"
 	svchost "github.com/hashicorp/terraform-svchost"
@@ -440,16 +441,17 @@ func (c *LoginCommand) interactiveGetTokenByCode(hostname svchost.Hostname, cred
 
 			log.Printf("[TRACE] login: request contains an authorization code")
 
+			// Write the success response before signaling the main goroutine,
+			// so the browser receives the page before the server is shut down.
+			log.Printf("[TRACE] login: returning response from callback server")
+			resp.Header().Add("Content-Type", "text/html")
+			resp.WriteHeader(200)
+			resp.Write([]byte(callbackSuccessMessage))
+
 			// Send the code to our blocking wait below, so that the token
 			// fetching process can continue.
 			codeCh <- gotCode
 			close(codeCh)
-
-			log.Printf("[TRACE] login: returning response from callback server")
-
-			resp.Header().Add("Content-Type", "text/html")
-			resp.WriteHeader(200)
-			resp.Write([]byte(callbackSuccessMessage))
 		}),
 	}
 	go func() {
@@ -508,7 +510,12 @@ func (c *LoginCommand) interactiveGetTokenByCode(hostname svchost.Hostname, cred
 		return nil, diags
 	}
 
-	if err := server.Close(); err != nil {
+	// Use Shutdown instead of Close so any in-flight response (e.g. the
+	// success page already written by the handler) is fully transmitted before
+	// the server stops accepting new connections.
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := server.Shutdown(shutdownCtx); err != nil {
 		// The server will close soon enough when our process exits anyway,
 		// so we won't fuss about it for right now.
 		log.Printf("[WARN] login: callback server can't shut down: %s", err)

--- a/internal/terraform/graph_builder_init.go
+++ b/internal/terraform/graph_builder_init.go
@@ -42,9 +42,10 @@ func (b *InitGraphBuilder) Steps() []GraphTransformer {
 		})
 	} else {
 		steps = append(steps, &ModuleVariableTransformer{
-			Config:         b.Config,
-			ModuleOnly:     true,
-			ValidateChecks: true,
+			Config:            b.Config,
+			ModuleOnly:        true,
+			ValidateChecks:    true,
+			SkipRequiredCheck: true,
 		})
 	}
 

--- a/internal/terraform/transform_module_variable.go
+++ b/internal/terraform/transform_module_variable.go
@@ -39,6 +39,12 @@ type ModuleVariableTransformer struct {
 	// DestroyApply must be set to true when applying a destroy operation and
 	// false otherwise.
 	DestroyApply bool
+
+	// SkipRequiredCheck, if true, suppresses enforcement of required module
+	// input variables when parsing the call body. This should be set during
+	// walkInit because that walk only installs modules — required-argument
+	// validation is the responsibility of walkValidate/walkPlan.
+	SkipRequiredCheck bool
 }
 
 func (t *ModuleVariableTransformer) Transform(g *Graph) error {
@@ -95,7 +101,7 @@ func (t *ModuleVariableTransformer) transformSingle(g *Graph, parent, c *configs
 	for _, v := range c.Module.Variables {
 		schema.Attributes = append(schema.Attributes, hcl.AttributeSchema{
 			Name:     v.Name,
-			Required: v.Default == cty.NilVal,
+			Required: !t.SkipRequiredCheck && v.Default == cty.NilVal,
 		})
 	}
 


### PR DESCRIPTION
## Problem

During `terraform init` (and `cdktf get`), Terraform was incorrectly emitting **"Missing required argument"** errors for module input variables that lack defaults — even when those variables are not needed during the init walk.

**Regression introduced in v1.15**: The `ModuleVariableTransformer` was marking variables without defaults as `Required: true` in the HCL schema unconditionally. This caused the HCL body decoder to fail on any module call that omitted a required argument, even though `walkInit` only installs modules and has no semantic need to validate required inputs. The init walk ran successfully in v1.14.

**Error observed:**
```
Error: Missing required argument
  on main.tf.json line 1, in module.cloud-router:
The argument "project_id" is required, but no definition was found.
```

## Root Cause

`ModuleVariableTransformer.transformSingle` builds an `hcl.BodySchema` for the module call. Previously it always set `Required: v.Default == cty.NilVal`, meaning any variable without a default was required. During `walkInit` this causes a hard error before the module is even downloaded.

## Fix

- Added a `SkipRequiredCheck bool` field to `ModuleVariableTransformer`.
- When `SkipRequiredCheck` is `true`, all variables are treated as optional (`Required: false`) during schema construction, so the HCL content decode never fails on missing required arguments.
- `InitGraphBuilder` now sets `SkipRequiredCheck: true` when constructing the `ModuleVariableTransformer` for child modules.
- Required-argument validation remains intact for `walkValidate` and `walkPlan` (where `SkipRequiredCheck` is `false`).

## Files Changed

| File | Change |
|---|---|
| `internal/terraform/transform_module_variable.go` | Add `SkipRequiredCheck` field; use it in schema construction |
| `internal/terraform/graph_builder_init.go` | Set `SkipRequiredCheck: true` in `ModuleVariableTransformer` |
| `.changes/v1.16/BUG FIXES-20260618-100200.yaml` | Changelog entry |

Fixes #38689