### PR TITLE
Fix misspelling: occured -> occurred

### DIFF
--- a/.changes/v1.16/BUG FIXES-20260618-175608.yaml
+++ b/.changes/v1.16/BUG FIXES-20260618-175608.yaml
@@ -1,0 +1,5 @@
+kind: BUG FIXES
+body: 'Fixed the misspelling "occured" to "occurred" in the bcrypt() error message and the state-serialization diagnostics'
+time: 2026-06-18T17:56:08-00:00
+custom:
+    Issue: "38741"

--- a/internal/lang/funcs/crypto.go
+++ b/internal/lang/funcs/crypto.go
@@ -126,7 +126,7 @@ var BcryptFunc = function.New(&function.Spec{
 		input := args[0].AsString()
 		out, err := bcrypt.GenerateFromPassword([]byte(input), defaultCost)
 		if err != nil {
-			return cty.UnknownVal(cty.String), fmt.Errorf("error occured generating password %s", err.Error())
+			return cty.UnknownVal(cty.String), fmt.Errorf("error occurred generating password %s", err.Error())
 		}
 
 		return cty.StringVal(string(out)), nil

--- a/internal/stacks/stackruntime/internal/stackeval/applying.go
+++ b/internal/stacks/stackruntime/internal/stackeval/applying.go
@@ -61,7 +61,7 @@ type ApplyOpts struct {
 type Applyable interface {
 	// CheckApply checks the receiver's apply-time result and returns zero
 	// or more applied change descriptions and zero or more diagnostics
-	// describing any problems that occured for this specific object during
+	// describing any problems that occurred for this specific object during
 	// the apply phase.
 	//
 	// CheckApply must not report any diagnostics raised indirectly by

--- a/internal/states/state.go
+++ b/internal/states/state.go
@@ -519,7 +519,7 @@ func (s *State) MoveAbsResourceInstance(src, dst addrs.AbsResourceInstance) {
 // MaybeMoveAbsResourceInstance moves the given src AbsResourceInstance's
 // current state to the new dst address. This function will succeed if both the
 // src address does not exist in state and the dst address does; the return
-// value indicates whether or not the move occured. This function will panic if
+// value indicates whether or not the move occurred. This function will panic if
 // either the src does not exist or the dst does exist (but not both).
 func (s *State) MaybeMoveAbsResourceInstance(src, dst addrs.AbsResourceInstance) bool {
 	// get the src and dst resource instances from state
@@ -578,7 +578,7 @@ func (s *State) MoveModuleInstance(src, dst addrs.ModuleInstance) {
 // MaybeMoveModuleInstance moves the given src ModuleInstance's current state to
 // the new dst address. This function will succeed if both the src address does
 // not exist in state and the dst address does; the return value indicates
-// whether or not the move occured. This function will panic if either the src
+// whether or not the move occurred. This function will panic if either the src
 // does not exist or the dst does exist (but not both).
 func (s *State) MaybeMoveModuleInstance(src, dst addrs.ModuleInstance) bool {
 	if src.IsRoot() || dst.IsRoot() {

--- a/internal/states/statefile/version4.go
+++ b/internal/states/statefile/version4.go
@@ -339,7 +339,7 @@ func writeStateV4(file *File, w io.Writer) tfdiags.Diagnostics {
 			diags = diags.Append(tfdiags.Sourceless(
 				tfdiags.Error,
 				"Failed to serialize output value in state",
-				fmt.Sprintf("An error occured while serializing output value %q: %s.", name, err),
+				fmt.Sprintf("An error occurred while serializing output value %q: %s.", name, err),
 			))
 			continue
 		}
@@ -349,7 +349,7 @@ func writeStateV4(file *File, w io.Writer) tfdiags.Diagnostics {
 			diags = diags.Append(tfdiags.Sourceless(
 				tfdiags.Error,
 				"Failed to serialize output value in state",
-				fmt.Sprintf("An error occured while serializing the type of output value %q: %s.", name, err),
+				fmt.Sprintf("An error occurred while serializing the type of output value %q: %s.", name, err),
 			))
 			continue
 		}
@@ -422,7 +422,7 @@ func writeStateV4(file *File, w io.Writer) tfdiags.Diagnostics {
 		diags = diags.Append(tfdiags.Sourceless(
 			tfdiags.Error,
 			"Failed to serialize state",
-			fmt.Sprintf("An error occured while serializing the state to save it. This is a bug in Terraform and should be reported: %s.", err),
+			fmt.Sprintf("An error occurred while serializing the state to save it. This is a bug in Terraform and should be reported: %s.", err),
 		))
 		return diags
 	}
@@ -433,7 +433,7 @@ func writeStateV4(file *File, w io.Writer) tfdiags.Diagnostics {
 		diags = diags.Append(tfdiags.Sourceless(
 			tfdiags.Error,
 			"Failed to write state",
-			fmt.Sprintf("An error occured while writing the serialized state: %s.", err),
+			fmt.Sprintf("An error occurred while writing the serialized state: %s.", err),
 		))
 		return diags
 	}


### PR DESCRIPTION
Corrects the recurring misspelling "occured" to "occurred" across internal packages, including the user-facing `bcrypt()` error message (internal/lang/funcs/crypto.go) and the state-serialization diagnostics (internal/states/statefile/version4.go), plus a couple of code comments.
