### PR TITLE
Allow init success when policy result is unknown

### DIFF
--- a/internal/command/init_policy_test.go
+++ b/internal/command/init_policy_test.go
@@ -22,50 +22,84 @@ import (
 )
 
 func TestInit_WithModulePolicy(t *testing.T) {
-	td := t.TempDir()
-	testCopyDir(t, testFixturePath("dynamic-module-sources/local-source-with-variable"), td)
-	t.Chdir(td)
 
-	ui := new(cli.MockUi)
-	view, done := testView(t)
-
-	overrides := metaOverridesForProvider(testProvider())
-	policyClient := policy.NewTestMockClient(t)
-	overrides.PolicyClient = policyClient
-
-	c := &InitCommand{
-		Meta: Meta{
-			testingOverrides:          overrides,
-			Ui:                        ui,
-			View:                      view,
-			AllowExperimentalFeatures: true,
+	cases := []struct {
+		name     string
+		policy   *policy.EvaluationResponse
+		expected int
+	}{
+		{
+			name: "unknown module policy",
+			// This unknown evaluation should still lead to success of the init operation
+			policy:   &policy.EvaluationResponse{Overall: policy.UnknownResult},
+			expected: 0,
+		},
+		{
+			name:     "success module policy",
+			policy:   &policy.EvaluationResponse{Overall: policy.AllowResult},
+			expected: 0,
 		},
 	}
 
-	code := c.Run([]string{"-policies", td, "-var", "module_name=example"})
-	output := done(t)
-	if code != 0 {
-		t.Fatalf("got exit status %d; want 0\nstderr:\n%s\n\nstdout:\n%s", code, output.Stderr(), output.Stdout())
-	}
+	for _, tc := range cases {
+		td := t.TempDir()
+		testCopyDir(t, testFixturePath("dynamic-module-sources/local-source-with-variable"), td)
+		t.Chdir(td)
 
-	if !policyClient.EvaluateModuleCalled {
-		t.Fatal("expected EvaluateModule to be called")
-	}
+		ui := new(cli.MockUi)
+		view, done := testView(t)
 
-	if got, want := policyClient.EvaluateModuleRequest.Target, "./modules/example"; got != want {
-		t.Fatalf("wrong module policy target\ngot:  %q\nwant: %q", got, want)
-	}
+		overrides := metaOverridesForProvider(testProvider())
+		policyClient := policy.NewTestMockClient(t)
 
-	if policyClient.EvaluateModuleRequest.Meta == nil {
-		t.Fatal("expected module metadata to be set")
-	}
+		t.Run(tc.name, func(t *testing.T) {
 
-	if got, want := policyClient.EvaluateModuleRequest.Meta.Address, "module.example"; got != want {
-		t.Fatalf("wrong module address\ngot:  %q\nwant: %q", got, want)
-	}
+			policyClient.EvaluateModuleResponse = tc.policy
+			overrides.PolicyClient = policyClient
 
-	if got, want := policyClient.EvaluateModuleRequest.Meta.Version, ""; got != want {
-		t.Fatalf("wrong module version\ngot:  %q\nwant: %q", got, want)
+			c := &InitCommand{
+				Meta: Meta{
+					testingOverrides:          overrides,
+					Ui:                        ui,
+					View:                      view,
+					AllowExperimentalFeatures: true,
+				},
+			}
+
+			code := c.Run([]string{"-policies", td, "-var", "module_name=example"})
+			output := done(t)
+			if code != tc.expected {
+				t.Fatalf("got exit status %d; want %d\nstderr:\n%s\n\nstdout:\n%s", code, tc.expected, output.Stderr(), output.Stdout())
+			}
+
+			if !policyClient.EvaluateModuleCalled {
+				t.Fatal("expected EvaluateModule to be called")
+			}
+
+			if got, want := policyClient.EvaluateModuleRequest.Target, "./modules/example"; got != want {
+				t.Fatalf("wrong module policy target\ngot:  %q\nwant: %q", got, want)
+			}
+
+			if !policyClient.EvaluateModuleCalled {
+				t.Fatal("expected EvaluateModule to be called")
+			}
+
+			if got, want := policyClient.EvaluateModuleRequest.Target, "./modules/example"; got != want {
+				t.Fatalf("wrong module policy target\ngot:  %q\nwant: %q", got, want)
+			}
+
+			if policyClient.EvaluateModuleRequest.Meta == nil {
+				t.Fatal("expected module metadata to be set")
+			}
+
+			if got, want := policyClient.EvaluateModuleRequest.Meta.Address, "module.example"; got != want {
+				t.Fatalf("wrong module address\ngot:  %q\nwant: %q", got, want)
+			}
+
+			if got, want := policyClient.EvaluateModuleRequest.Meta.Version, ""; got != want {
+				t.Fatalf("wrong module version\ngot:  %q\nwant: %q", got, want)
+			}
+		})
 	}
 }
 
@@ -521,6 +555,10 @@ func TestInit_WithProviderPolicy(t *testing.T) {
 			}
 		})
 
+		if req.Target == "test" {
+			// This unknown evaluation should still lead to success of the init operation
+			return policy.EvaluationResponse{Overall: policy.UnknownResult}
+		}
 		return policy.EvaluationResponse{Overall: policy.AllowResult}
 	}
 	overrides.PolicyClient = policyClient

--- a/internal/command/init_policy_test.go
+++ b/internal/command/init_policy_test.go
@@ -30,14 +30,31 @@ func TestInit_WithModulePolicy(t *testing.T) {
 	}{
 		{
 			name: "unknown module policy",
-			// This unknown evaluation should still lead to success of the init operation
+			// This unknown evaluation should still lead to success of the init operation.
 			policy:   &policy.EvaluationResponse{Overall: policy.UnknownResult},
+			expected: 0,
+		},
+		{
+			name: "advisory deny module policy",
+			// Advisory policies may return deny without error diagnostics and should
+			// not block init.
+			policy:   &policy.EvaluationResponse{Overall: policy.DenyResult},
 			expected: 0,
 		},
 		{
 			name:     "success module policy",
 			policy:   &policy.EvaluationResponse{Overall: policy.AllowResult},
 			expected: 0,
+		},
+		{
+			name: "errored module policy",
+			policy: &policy.EvaluationResponse{
+				Overall: policy.DenyResult,
+				Diagnostics: policy.Diagnostics{
+					policy.NewErrorDiagnostic("test error", "test error detail", policy.DenyResult),
+				},
+			},
+			expected: 1,
 		},
 	}
 
@@ -556,8 +573,13 @@ func TestInit_WithProviderPolicy(t *testing.T) {
 		})
 
 		if req.Target == "test" {
-			// This unknown evaluation should still lead to success of the init operation
+			// This unknown evaluation should still lead to success of the init operation.
 			return policy.EvaluationResponse{Overall: policy.UnknownResult}
+		}
+		if req.Target == "happycloud" {
+			// Advisory policies may return deny without error diagnostics and should
+			// not block init.
+			return policy.EvaluationResponse{Overall: policy.DenyResult}
 		}
 		return policy.EvaluationResponse{Overall: policy.AllowResult}
 	}

--- a/internal/command/meta_policy.go
+++ b/internal/command/meta_policy.go
@@ -163,11 +163,12 @@ func (h *policyModuleInstallHook) ModuleSourceResolved(ctx context.Context, req 
 	}
 	h.policyResults.AddModule(req.Path, result, moduleCall)
 
-	// return a generic error here that the init command returns to the CLI.
+	// Return a generic error here that the init command returns to the CLI.
 	// The detailed policy diagnostics are included in the policy results
-	// and will be formatted in the CLI output.
-	allowed := result.Overall == policy.AllowResult || result.Overall == policy.UnknownResult
-	if !allowed || result.Diagnostics.HasErrors() {
+	// and will be formatted in the CLI output. Init uses diagnostics as the
+	// blocking signal because advisory policies may return deny without any
+	// error diagnostics.
+	if result.Diagnostics.HasErrors() {
 		return tfdiags.Diagnostics{
 			policy.NewErrorDiagnostic(
 				"Policy evaluation failed",
@@ -217,8 +218,9 @@ func (p *providerPolicyHook) ProviderVersionSelected(ctx context.Context, provid
 
 	p.policyResults.AddProvider(addr, result, providerConfig)
 	log.Println("[DEBUG] init: policy result for provider", provider.String(), version, "overall", result.Overall)
-	allowed := result.Overall == policy.AllowResult || result.Overall == policy.UnknownResult
-	if !allowed || result.Diagnostics.HasErrors() {
+	// Init uses diagnostics as the blocking signal because advisory policies
+	// may return deny without any error diagnostics.
+	if result.Diagnostics.HasErrors() {
 		return fmt.Errorf("Provider download blocked due to policy violations. Please review other diagnostics for details.")
 	}
 

--- a/internal/command/meta_policy.go
+++ b/internal/command/meta_policy.go
@@ -166,7 +166,8 @@ func (h *policyModuleInstallHook) ModuleSourceResolved(ctx context.Context, req 
 	// return a generic error here that the init command returns to the CLI.
 	// The detailed policy diagnostics are included in the policy results
 	// and will be formatted in the CLI output.
-	if result.Overall != policy.AllowResult {
+	allowed := result.Overall == policy.AllowResult || result.Overall == policy.UnknownResult
+	if !allowed || result.Diagnostics.HasErrors() {
 		return tfdiags.Diagnostics{
 			policy.NewErrorDiagnostic(
 				"Policy evaluation failed",
@@ -216,7 +217,8 @@ func (p *providerPolicyHook) ProviderVersionSelected(ctx context.Context, provid
 
 	p.policyResults.AddProvider(addr, result, providerConfig)
 	log.Println("[DEBUG] init: policy result for provider", provider.String(), version, "overall", result.Overall)
-	if result.Overall != policy.AllowResult {
+	allowed := result.Overall == policy.AllowResult || result.Overall == policy.UnknownResult
+	if !allowed || result.Diagnostics.HasErrors() {
 		return fmt.Errorf("Provider download blocked due to policy violations. Please review other diagnostics for details.")
 	}
 


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

The PR updates the init command to Treat `UnknownResult` as non-blocking during policy evaluation.

Previously, init-time policy hooks only supported successful installs when policy evaluation returned `AllowResult`. `UnknownResult` means that the outcome is indeterminate, and in this case, we favor simply allowing the operation to succeed.
Also, denied advisory policies should allow the policy to succeed

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.16.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [ ] This change is not user-facing.
