### PR TITLE
fix (configload): configloader.Parser is now concurrency-safe

### DIFF
--- a/.changes/v1.15/BUG FIXES-20260618-155709.yaml
+++ b/.changes/v1.15/BUG FIXES-20260618-155709.yaml
@@ -1,0 +1,5 @@
+kind: BUG FIXES
+body: Add concurrency safety to configs.Parser and SourceBundleParser
+time: 2026-06-18T15:57:09.519762-04:00
+custom:
+    Issue: "38745"

--- a/internal/configs/configload/loader_race_test.go
+++ b/internal/configs/configload/loader_race_test.go
@@ -1,0 +1,53 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+//go:build race
+
+package configload
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+)
+
+func TestLoaderSourcesConcurrentWithParserWrite(t *testing.T) {
+	loader, cleanup := NewLoaderForTests(t)
+	defer cleanup()
+
+	const iterations = 2000
+
+	start := make(chan struct{})
+	var ready sync.WaitGroup
+	ready.Add(2)
+
+	var workers sync.WaitGroup
+	workers.Add(2)
+
+	go func() {
+		defer workers.Done()
+		ready.Done()
+		<-start
+
+		for i := 0; i < iterations; i++ {
+			_ = loader.Sources()
+		}
+	}()
+
+	go func() {
+		defer workers.Done()
+		ready.Done()
+		<-start
+
+		for i := 0; i < iterations; i++ {
+			loader.Parser().ForceFileSource(
+				fmt.Sprintf("testdata/%04d.tf", i),
+				[]byte("resource \"test\" \"example\" {}\n"),
+			)
+		}
+	}()
+
+	ready.Wait()
+	close(start)
+	workers.Wait()
+}

--- a/internal/configs/parser.go
+++ b/internal/configs/parser.go
@@ -6,6 +6,7 @@ package configs
 import (
 	"fmt"
 	"strings"
+	"sync"
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclparse"
@@ -27,6 +28,9 @@ type Parser struct {
 	// for itself whether to enable it so that tests can cover both the
 	// allowed and not-allowed situations.
 	allowExperiments bool
+
+	// the shared Parser must be concurrency-safe: https://github.com/hashicorp/terraform/issues/38725
+	mu sync.Mutex
 }
 
 // NewParser creates and returns a new Parser that reads files from the given
@@ -40,6 +44,7 @@ func NewParser(fs afero.Fs) *Parser {
 	return &Parser{
 		fs: afero.Afero{Fs: fs},
 		p:  hclparse.NewParser(),
+		mu: sync.Mutex{},
 	}
 }
 
@@ -57,6 +62,9 @@ func NewParser(fs afero.Fs) *Parser {
 // The file will be parsed using the HCL native syntax unless the filename
 // ends with ".json", in which case the HCL JSON syntax will be used.
 func (p *Parser) LoadHCLFile(path string) (hcl.Body, hcl.Diagnostics) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
 	src, err := p.fs.ReadFile(path)
 
 	if err != nil {
@@ -91,6 +99,8 @@ func (p *Parser) LoadHCLFile(path string) (hcl.Body, hcl.Diagnostics) {
 // have been loaded through this parser, with source filenames (as requested
 // when each file was opened) as the keys.
 func (p *Parser) Sources() map[string][]byte {
+	p.mu.Lock()
+	defer p.mu.Unlock()
 	return p.p.Sources()
 }
 
@@ -103,6 +113,9 @@ func (p *Parser) Sources() map[string][]byte {
 func (p *Parser) ForceFileSource(filename string, src []byte) {
 	// We'll make a synthetic hcl.File here just so we can reuse the
 	// existing cache.
+
+	p.mu.Lock()
+	defer p.mu.Unlock()
 	p.p.AddFile(filename, &hcl.File{
 		Body:  hcl.EmptyBody(),
 		Bytes: src,
@@ -119,6 +132,8 @@ func (p *Parser) ForceFileSource(filename string, src []byte) {
 // is responsible for deciding for itself whether and how to call this
 // method.
 func (p *Parser) AllowLanguageExperiments(allowed bool) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
 	p.allowExperiments = allowed
 }
 
@@ -126,5 +141,7 @@ func (p *Parser) AllowLanguageExperiments(allowed bool) {
 // [Parser.AllowLanguageExperiments], or false if that method has not been
 // called on this object.
 func (p *Parser) AllowsLanguageExperiments() bool {
+	p.mu.Lock()
+	defer p.mu.Unlock()
 	return p.allowExperiments
 }

--- a/internal/configs/parser.go
+++ b/internal/configs/parser.go
@@ -29,7 +29,6 @@ type Parser struct {
 	// allowed and not-allowed situations.
 	allowExperiments bool
 
-	// the shared Parser must be concurrency-safe: https://github.com/hashicorp/terraform/issues/38725
 	mu sync.Mutex
 }
 
@@ -44,7 +43,6 @@ func NewParser(fs afero.Fs) *Parser {
 	return &Parser{
 		fs: afero.Afero{Fs: fs},
 		p:  hclparse.NewParser(),
-		mu: sync.Mutex{},
 	}
 }
 
@@ -66,7 +64,6 @@ func (p *Parser) LoadHCLFile(path string) (hcl.Body, hcl.Diagnostics) {
 	defer p.mu.Unlock()
 
 	src, err := p.fs.ReadFile(path)
-
 	if err != nil {
 		return nil, hcl.Diagnostics{
 			{
@@ -111,11 +108,10 @@ func (p *Parser) Sources() map[string][]byte {
 // some other way. Most callers should load configuration via methods of
 // Parser, which will update the sources cache automatically.
 func (p *Parser) ForceFileSource(filename string, src []byte) {
-	// We'll make a synthetic hcl.File here just so we can reuse the
-	// existing cache.
-
 	p.mu.Lock()
 	defer p.mu.Unlock()
+	// We'll make a synthetic hcl.File here just so we can reuse the
+	// existing cache.
 	p.p.AddFile(filename, &hcl.File{
 		Body:  hcl.EmptyBody(),
 		Bytes: src,

--- a/internal/configs/parser_config.go
+++ b/internal/configs/parser_config.go
@@ -43,7 +43,7 @@ func (p *Parser) LoadTestFile(path string) (*TestFile, hcl.Diagnostics) {
 		return nil, diags
 	}
 
-	test, testDiags := loadTestFile(body, p.allowExperiments)
+	test, testDiags := loadTestFile(body, p.AllowsLanguageExperiments())
 	diags = append(diags, testDiags...)
 	return test, diags
 }
@@ -92,7 +92,7 @@ func (p *Parser) loadConfigFile(path string, override bool) (*File, hcl.Diagnost
 		return nil, diags
 	}
 
-	return parseConfigFile(body, diags, override, p.allowExperiments)
+	return parseConfigFile(body, diags, override, p.AllowsLanguageExperiments())
 }
 
 func parseConfigFile(body hcl.Body, diags hcl.Diagnostics, override, allowExperiments bool) (*File, hcl.Diagnostics) {

--- a/internal/configs/parser_config_dir.go
+++ b/internal/configs/parser_config_dir.go
@@ -225,7 +225,7 @@ func (p *Parser) LoadMockDataDir(dir string, useForPlanDefault bool, source hcl.
 //
 // If the given directory does not exist or cannot be read, error diagnostics
 // are returned. If errors are returned, the resulting lists may be incomplete.
-func (p Parser) ConfigDirFiles(dir string, opts ...Option) (primary, override []string, diags hcl.Diagnostics) {
+func (p *Parser) ConfigDirFiles(dir string, opts ...Option) (primary, override []string, diags hcl.Diagnostics) {
 	fSet, diags := p.dirFileSet(dir, opts...)
 	return fSet.Primary, fSet.Override, diags
 }

--- a/internal/configs/parser_config_dir_test.go
+++ b/internal/configs/parser_config_dir_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/hcl/v2"
+
 	"github.com/hashicorp/terraform/internal/addrs"
 )
 
@@ -42,7 +43,7 @@ func TestParserLoadConfigDirSuccess(t *testing.T) {
 				// The PSS project is currently gated as experimental
 				// TODO(SarahFrench/radeksimko) - remove this from the test once
 				// the feature is GA.
-				parser.allowExperiments = true
+				parser.AllowLanguageExperiments(true)
 			}
 
 			path := filepath.Join("testdata/valid-modules", name)

--- a/internal/configs/source_bundle_parser.go
+++ b/internal/configs/source_bundle_parser.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 
 	"github.com/hashicorp/go-slug/sourceaddrs"
 	"github.com/hashicorp/go-slug/sourcebundle"
@@ -29,6 +30,8 @@ type SourceBundleParser struct {
 	// for itself whether to enable it so that tests can cover both the
 	// allowed and not-allowed situations.
 	allowExperiments bool
+
+	mu sync.Mutex
 }
 
 // NewSourceBundleParser creates a new [SourceBundleParser] for the given
@@ -238,12 +241,14 @@ func (p *SourceBundleParser) loadConfigFile(source sourceaddrs.FinalSource, over
 
 	var file *hcl.File
 	var fdiags hcl.Diagnostics
+	p.mu.Lock()
 	switch {
 	case strings.HasSuffix(path, ".json"):
 		file, fdiags = p.p.ParseJSON(src, syntheticFilename)
 	default:
 		file, fdiags = p.p.ParseHCL(src, syntheticFilename)
 	}
+	p.mu.Unlock()
 	diags = append(diags, fdiags...)
 
 	body := hcl.EmptyBody()
@@ -251,7 +256,7 @@ func (p *SourceBundleParser) loadConfigFile(source sourceaddrs.FinalSource, over
 		body = file.Body
 	}
 
-	return parseConfigFile(body, diags, override, p.allowExperiments)
+	return parseConfigFile(body, diags, override, p.AllowsLanguageExperiments())
 }
 
 // AllowLanguageExperiments specifies whether subsequent LoadConfigFile (and
@@ -264,5 +269,13 @@ func (p *SourceBundleParser) loadConfigFile(source sourceaddrs.FinalSource, over
 // is responsible for deciding for itself whether and how to call this
 // method.
 func (p *SourceBundleParser) AllowLanguageExperiments(allowed bool) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
 	p.allowExperiments = allowed
+}
+
+func (p *SourceBundleParser) AllowsLanguageExperiments() bool {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.allowExperiments
 }

--- a/internal/configs/source_bundle_parser.go
+++ b/internal/configs/source_bundle_parser.go
@@ -210,6 +210,9 @@ func (p *SourceBundleParser) loadSources(sources []sourceaddrs.FinalSource, over
 }
 
 func (p *SourceBundleParser) loadConfigFile(source sourceaddrs.FinalSource, override bool) (*File, hcl.Diagnostics) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
 	var diags hcl.Diagnostics
 	path, err := p.sources.LocalPathForSource(source)
 	if err != nil {
@@ -241,14 +244,13 @@ func (p *SourceBundleParser) loadConfigFile(source sourceaddrs.FinalSource, over
 
 	var file *hcl.File
 	var fdiags hcl.Diagnostics
-	p.mu.Lock()
 	switch {
 	case strings.HasSuffix(path, ".json"):
 		file, fdiags = p.p.ParseJSON(src, syntheticFilename)
 	default:
 		file, fdiags = p.p.ParseHCL(src, syntheticFilename)
 	}
-	p.mu.Unlock()
+
 	diags = append(diags, fdiags...)
 
 	body := hcl.EmptyBody()
@@ -256,7 +258,8 @@ func (p *SourceBundleParser) loadConfigFile(source sourceaddrs.FinalSource, over
 		body = file.Body
 	}
 
-	return parseConfigFile(body, diags, override, p.AllowsLanguageExperiments())
+	// We are in a locked method, it's safe to call p.allowExperiments directly
+	return parseConfigFile(body, diags, override, p.allowExperiments)
 }
 
 // AllowLanguageExperiments specifies whether subsequent LoadConfigFile (and

--- a/internal/configs/source_bundle_parser_race_test.go
+++ b/internal/configs/source_bundle_parser_race_test.go
@@ -1,0 +1,92 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+//go:build race
+
+package configs
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/hashicorp/go-slug/sourceaddrs"
+	"github.com/hashicorp/go-slug/sourcebundle"
+)
+
+func TestSourceBundleParserConcurrentLoadConfigDir(t *testing.T) {
+	bundleDir := testSourceBundleDir(t)
+	bundle, err := sourcebundle.OpenDir(bundleDir)
+	if err != nil {
+		t.Fatalf("failed to open source bundle: %s", err)
+	}
+
+	source := sourceaddrs.MustParseSource("git::https://example.com/root.git").(sourceaddrs.FinalSource)
+	parser := NewSourceBundleParser(bundle)
+
+	const (
+		loaders    = 8
+		iterations = 20
+	)
+
+	start := make(chan struct{})
+	var workers sync.WaitGroup
+	workers.Add(loaders)
+
+	for i := 0; i < loaders; i++ {
+		go func() {
+			defer workers.Done()
+			<-start
+
+			for i := 0; i < iterations; i++ {
+				_, diags := parser.LoadConfigDir(source)
+				if diags.HasErrors() {
+					t.Errorf("unexpected diagnostics: %s", diags.Error())
+					return
+				}
+			}
+		}()
+	}
+
+	close(start)
+	workers.Wait()
+}
+
+func testSourceBundleDir(t *testing.T) string {
+	t.Helper()
+
+	dir := t.TempDir()
+	moduleDir := filepath.Join(dir, "root")
+	if err := os.MkdirAll(moduleDir, 0o755); err != nil {
+		t.Fatalf("failed to create module dir: %s", err)
+	}
+
+	manifest := `{
+	  "terraform_source_bundle": 1,
+	  "packages": [
+	    {
+	      "source": "git::https://example.com/root.git",
+	      "local": "root",
+	      "meta": {}
+	    }
+	  ],
+	  "registry": []
+	}`
+	if err := os.WriteFile(filepath.Join(dir, "terraform-sources.json"), []byte(manifest), 0o644); err != nil {
+		t.Fatalf("failed to write bundle manifest: %s", err)
+	}
+
+	resourceBody := strings.Repeat("x", 4096)
+	for i := 0; i < 40; i++ {
+		filename := filepath.Join(moduleDir, fmt.Sprintf("file%02d.tf", i))
+		content := fmt.Sprintf("resource \"terraform_data\" \"example_%02d\" {\n  input = \"%s\"\n}\n", i, resourceBody)
+		if err := os.WriteFile(filename, []byte(content), 0o644); err != nil {
+			t.Fatalf("failed to write test source file: %s", err)
+		}
+	}
+
+	return dir
+}


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform/issues/38725

The test case was LLM-generated. I confirmed that it failed before my fix and succeeded after. I added the mutex all by my self.

The mutex around Sources was all that was needed to fix this specific report, but I added concurrency safety to these methods (including a few updates to make sure we're using the AllowsLanguageExperiments() method instead of grabbing the field directly), and addressed a similar potential race issue in the SourceBundleParser.

<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Fixes #

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.15.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [ ] This change is not user-facing.
