### PR TITLE
check for data races in more packages

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -82,7 +82,7 @@ jobs:
       # it for select packages.
       - name: "Race detector"
         run: |
-          go test -race ./internal/terraform ./internal/command ./internal/states
+          go test -race ./internal/terraform ./internal/command ./internal/states ./internal/promising ./internal/stacks/...
 
   e2e-tests:
     # This is an intentionally-limited form of our E2E test run which only

--- a/internal/stacks/stackruntime/apply_test.go
+++ b/internal/stacks/stackruntime/apply_test.go
@@ -11,6 +11,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -3750,8 +3751,11 @@ func TestApplyWithStateManipulation(t *testing.T) {
 
 			// Check the counts during the apply for this test.
 			gotCounts := collections.NewMap[stackaddrs.AbsComponentInstance, *hooks.ComponentInstanceChange]()
+			var gotCountsMu sync.Mutex
 			ctx = ContextWithHooks(ctx, &stackeval.Hooks{
 				ReportComponentInstanceApplied: func(ctx context.Context, span any, change *hooks.ComponentInstanceChange) any {
+					gotCountsMu.Lock()
+					defer gotCountsMu.Unlock()
 					gotCounts.Put(change.Addr, change)
 					return span
 				},
@@ -3804,6 +3808,8 @@ func TestApplyWithStateManipulation(t *testing.T) {
 			}
 
 			wantCounts := tc.counts
+			gotCountsMu.Lock()
+			defer gotCountsMu.Unlock()
 			for key, elem := range wantCounts.All() {
 				// First, make sure everything we wanted is present.
 				if !gotCounts.HasKey(key) {

--- a/internal/stacks/stackruntime/plan.go
+++ b/internal/stacks/stackruntime/plan.go
@@ -5,6 +5,7 @@ package stackruntime
 
 import (
 	"context"
+	"sync/atomic"
 	"time"
 
 	"github.com/hashicorp/terraform/internal/addrs"
@@ -39,7 +40,7 @@ func Plan(ctx context.Context, req *PlanRequest, resp *PlanResponse) {
 		close(resp.PlannedChanges) // MUST be the last channel to close
 	}()
 
-	var errored bool
+	var errored atomic.Bool
 
 	planTimestamp := time.Now().UTC()
 	if req.ForcePlanTimestamp != nil {
@@ -62,7 +63,7 @@ func Plan(ctx context.Context, req *PlanRequest, resp *PlanResponse) {
 		AnnounceDiagnostics: func(ctx context.Context, diags tfdiags.Diagnostics) {
 			for _, diag := range diags {
 				if diag.Severity() == tfdiags.Error {
-					errored = true
+					errored.Store(true)
 				}
 				resp.Diagnostics <- diag
 			}
@@ -78,7 +79,7 @@ func Plan(ctx context.Context, req *PlanRequest, resp *PlanResponse) {
 	}
 
 	// An overall stack plan is applyable if it has no error diagnostics.
-	resp.Applyable = !errored
+	resp.Applyable = !errored.Load()
 
 	// Before we return we'll emit one more special planned change just to
 	// remember in the raw plan sequence whether we considered this plan to be

--- a/internal/stacks/stackruntime/plan_test.go
+++ b/internal/stacks/stackruntime/plan_test.go
@@ -20,24 +20,22 @@ import (
 	"github.com/zclconf/go-cty/cty"
 	"github.com/zclconf/go-cty/cty/msgpack"
 
-	"github.com/hashicorp/terraform/internal/checks"
-	"github.com/hashicorp/terraform/internal/depsfile"
-	"github.com/hashicorp/terraform/internal/getproviders/providerreqs"
-	"github.com/hashicorp/terraform/internal/stacks/stackruntime/hooks"
-
 	"github.com/hashicorp/terraform/internal/addrs"
-
 	"github.com/hashicorp/terraform/internal/builtin/providers/terraform"
 	terraformProvider "github.com/hashicorp/terraform/internal/builtin/providers/terraform"
+	"github.com/hashicorp/terraform/internal/checks"
 	"github.com/hashicorp/terraform/internal/collections"
 	"github.com/hashicorp/terraform/internal/configs"
 	"github.com/hashicorp/terraform/internal/configs/configschema"
+	"github.com/hashicorp/terraform/internal/depsfile"
+	"github.com/hashicorp/terraform/internal/getproviders/providerreqs"
 	"github.com/hashicorp/terraform/internal/lang/marks"
 	"github.com/hashicorp/terraform/internal/plans"
 	"github.com/hashicorp/terraform/internal/providers"
 	default_testing_provider "github.com/hashicorp/terraform/internal/providers/testing"
 	"github.com/hashicorp/terraform/internal/stacks/stackaddrs"
 	"github.com/hashicorp/terraform/internal/stacks/stackplan"
+	"github.com/hashicorp/terraform/internal/stacks/stackruntime/hooks"
 	"github.com/hashicorp/terraform/internal/stacks/stackruntime/internal/stackeval"
 	stacks_testing_provider "github.com/hashicorp/terraform/internal/stacks/stackruntime/testing"
 	"github.com/hashicorp/terraform/internal/stacks/stackstate"
@@ -57,10 +55,6 @@ import (
 func TestPlan_valid(t *testing.T) {
 	for name, tc := range validConfigurations {
 		t.Run(name, func(t *testing.T) {
-			if tc.skip {
-				// We've added this test before the implementation was ready.
-				t.SkipNow()
-			}
 			ctx := context.Background()
 
 			lock := depsfile.NewLocks()
@@ -130,10 +124,6 @@ func TestPlan_valid(t *testing.T) {
 func TestPlan_invalid(t *testing.T) {
 	for name, tc := range invalidConfigurations {
 		t.Run(name, func(t *testing.T) {
-			if tc.skip {
-				// We've added this test before the implementation was ready.
-				t.SkipNow()
-			}
 			ctx := context.Background()
 
 			lock := depsfile.NewLocks()
@@ -2466,12 +2456,10 @@ func TestPlanSensitiveOutputAsInput(t *testing.T) {
 					Component: stackaddrs.Component{Name: "self"},
 				},
 			),
-			Action:        plans.Create,
-			PlanApplyable: true,
-			PlanComplete:  true,
-			RequiredComponents: collections.NewSet[stackaddrs.AbsComponent](
-				mustAbsComponent("stack.sensitive.component.self"),
-			),
+			Action:              plans.Create,
+			PlanApplyable:       true,
+			PlanComplete:        true,
+			RequiredComponents:  collections.NewSet(mustAbsComponent("stack.sensitive.component.self")),
 			PlannedCheckResults: &states.CheckResults{},
 			PlannedInputValues: map[string]plans.DynamicValue{
 				"secret": mustPlanDynamicValueDynamicType(cty.StringVal("secret")),
@@ -2778,7 +2766,7 @@ func TestPlanWithSensitivePropagation(t *testing.T) {
 			PlanApplyable: true,
 			PlanComplete:  true,
 			Action:        plans.Create,
-			RequiredComponents: collections.NewSet[stackaddrs.AbsComponent](
+			RequiredComponents: collections.NewSet(
 				stackaddrs.AbsComponent{
 					Stack: stackaddrs.RootStackInstance,
 					Item:  stackaddrs.Component{Name: "sensitive"},
@@ -2941,12 +2929,10 @@ func TestPlanWithSensitivePropagationNested(t *testing.T) {
 					Component: stackaddrs.Component{Name: "self"},
 				},
 			),
-			Action:        plans.Create,
-			PlanApplyable: true,
-			PlanComplete:  true,
-			RequiredComponents: collections.NewSet[stackaddrs.AbsComponent](
-				mustAbsComponent("stack.sensitive.component.self"),
-			),
+			Action:              plans.Create,
+			PlanApplyable:       true,
+			PlanComplete:        true,
+			RequiredComponents:  collections.NewSet(mustAbsComponent("stack.sensitive.component.self")),
 			PlannedCheckResults: &states.CheckResults{},
 			PlannedInputValues: map[string]plans.DynamicValue{
 				"id":    mustPlanDynamicValueDynamicType(cty.NullVal(cty.String)),
@@ -3553,7 +3539,7 @@ func TestPlanWithDeferredComponentForEach(t *testing.T) {
 			PlanApplyable: true,
 			PlanComplete:  false,
 			Action:        plans.Create,
-			RequiredComponents: collections.NewSet[stackaddrs.AbsComponent](
+			RequiredComponents: collections.NewSet(
 				stackaddrs.AbsComponent{
 					Stack: stackaddrs.RootStackInstance,
 					Item: stackaddrs.Component{
@@ -3810,7 +3796,7 @@ func TestPlanWithDeferredComponentReferences(t *testing.T) {
 			},
 			PlannedCheckResults: &states.CheckResults{},
 			PlanTimestamp:       fakePlanTimestamp,
-			RequiredComponents: collections.NewSet[stackaddrs.AbsComponent](
+			RequiredComponents: collections.NewSet(
 				stackaddrs.AbsComponent{
 					Stack: stackaddrs.RootStackInstance,
 					Item: stackaddrs.Component{
@@ -4426,14 +4412,13 @@ func TestPlanWithStateManipulation(t *testing.T) {
 					PlannedTimestamp: fakePlanTimestamp,
 				},
 			},
-			counts: collections.NewMap[stackaddrs.AbsComponentInstance, *hooks.ComponentInstanceChange](
-				collections.MapElem[stackaddrs.AbsComponentInstance, *hooks.ComponentInstanceChange]{
-					K: mustAbsComponentInstance("component.self"),
-					V: &hooks.ComponentInstanceChange{
-						Addr: mustAbsComponentInstance("component.self"),
-						Move: 1,
-					},
-				}),
+			counts: collections.NewMap(collections.MapElem[stackaddrs.AbsComponentInstance, *hooks.ComponentInstanceChange]{
+				K: mustAbsComponentInstance("component.self"),
+				V: &hooks.ComponentInstanceChange{
+					Addr: mustAbsComponentInstance("component.self"),
+					Move: 1,
+				},
+			}),
 		},
 		"cross-type-moved": {
 			state: stackstate.NewStateBuilder().
@@ -4508,14 +4493,13 @@ func TestPlanWithStateManipulation(t *testing.T) {
 					PlannedTimestamp: fakePlanTimestamp,
 				},
 			},
-			counts: collections.NewMap[stackaddrs.AbsComponentInstance, *hooks.ComponentInstanceChange](
-				collections.MapElem[stackaddrs.AbsComponentInstance, *hooks.ComponentInstanceChange]{
-					K: mustAbsComponentInstance("component.self"),
-					V: &hooks.ComponentInstanceChange{
-						Addr: mustAbsComponentInstance("component.self"),
-						Move: 1,
-					},
-				}),
+			counts: collections.NewMap(collections.MapElem[stackaddrs.AbsComponentInstance, *hooks.ComponentInstanceChange]{
+				K: mustAbsComponentInstance("component.self"),
+				V: &hooks.ComponentInstanceChange{
+					Addr: mustAbsComponentInstance("component.self"),
+					Move: 1,
+				},
+			}),
 		},
 		"import": {
 			state: stackstate.NewStateBuilder().Build(), // We start with an empty state for this.
@@ -4599,14 +4583,13 @@ func TestPlanWithStateManipulation(t *testing.T) {
 					RequiredOnApply: false,
 				},
 			},
-			counts: collections.NewMap[stackaddrs.AbsComponentInstance, *hooks.ComponentInstanceChange](
-				collections.MapElem[stackaddrs.AbsComponentInstance, *hooks.ComponentInstanceChange]{
-					K: mustAbsComponentInstance("component.self"),
-					V: &hooks.ComponentInstanceChange{
-						Addr:   mustAbsComponentInstance("component.self"),
-						Import: 1,
-					},
-				}),
+			counts: collections.NewMap(collections.MapElem[stackaddrs.AbsComponentInstance, *hooks.ComponentInstanceChange]{
+				K: mustAbsComponentInstance("component.self"),
+				V: &hooks.ComponentInstanceChange{
+					Addr:   mustAbsComponentInstance("component.self"),
+					Import: 1,
+				},
+			}),
 		},
 		"removed": {
 			state: stackstate.NewStateBuilder().
@@ -4679,14 +4662,13 @@ func TestPlanWithStateManipulation(t *testing.T) {
 					PlannedTimestamp: fakePlanTimestamp,
 				},
 			},
-			counts: collections.NewMap[stackaddrs.AbsComponentInstance, *hooks.ComponentInstanceChange](
-				collections.MapElem[stackaddrs.AbsComponentInstance, *hooks.ComponentInstanceChange]{
-					K: mustAbsComponentInstance("component.self"),
-					V: &hooks.ComponentInstanceChange{
-						Addr:   mustAbsComponentInstance("component.self"),
-						Forget: 1,
-					},
-				}),
+			counts: collections.NewMap(collections.MapElem[stackaddrs.AbsComponentInstance, *hooks.ComponentInstanceChange]{
+				K: mustAbsComponentInstance("component.self"),
+				V: &hooks.ComponentInstanceChange{
+					Addr:   mustAbsComponentInstance("component.self"),
+					Forget: 1,
+				},
+			}),
 			expectedWarnings: []string{"Some objects will no longer be managed by Terraform"},
 		},
 	}
@@ -5060,7 +5042,7 @@ func TestPlan_DependsOnUpdatesRequirements(t *testing.T) {
 			PlanApplyable: true,
 			PlanComplete:  true,
 			Action:        plans.Create,
-			RequiredComponents: collections.NewSet[stackaddrs.AbsComponent](
+			RequiredComponents: collections.NewSet(
 				mustAbsComponent("component.first"),
 				mustAbsComponent("stack.second.component.self"),
 			),
@@ -5108,7 +5090,7 @@ func TestPlan_DependsOnUpdatesRequirements(t *testing.T) {
 			PlanApplyable: true,
 			PlanComplete:  true,
 			Action:        plans.Create,
-			RequiredComponents: collections.NewSet[stackaddrs.AbsComponent](
+			RequiredComponents: collections.NewSet(
 				mustAbsComponent("component.first"),
 				mustAbsComponent("component.empty"),
 			),

--- a/internal/stacks/stackruntime/validate_test.go
+++ b/internal/stacks/stackruntime/validate_test.go
@@ -342,7 +342,7 @@ var (
 // potentially be included in here unless it depends on provider plugins
 // to complete validation, since this test cannot supply provider plugins.
 func TestValidate_valid(t *testing.T) {
-	for name, _ := range validConfigurations {
+	for name := range validConfigurations {
 		t.Run(name, func(t *testing.T) {
 			ctx := context.Background()
 

--- a/internal/stacks/stackruntime/validate_test.go
+++ b/internal/stacks/stackruntime/validate_test.go
@@ -20,10 +20,6 @@ import (
 )
 
 type validateTestInput struct {
-	// skip lets us write tests for behaviour we want to add in the future. Set
-	// this to true for any tests that are not yet implemented.
-	skip bool
-
 	// diags is a function that returns the expected diagnostics for the
 	// test.
 	diags func() tfdiags.Diagnostics
@@ -346,12 +342,8 @@ var (
 // potentially be included in here unless it depends on provider plugins
 // to complete validation, since this test cannot supply provider plugins.
 func TestValidate_valid(t *testing.T) {
-	for name, tc := range validConfigurations {
+	for name, _ := range validConfigurations {
 		t.Run(name, func(t *testing.T) {
-			if tc.skip {
-				// We've added this test before the implementation was ready.
-				t.SkipNow()
-			}
 			ctx := context.Background()
 
 			lock := depsfile.NewLocks()
@@ -399,10 +391,6 @@ func TestValidate_valid(t *testing.T) {
 func TestValidate_invalid(t *testing.T) {
 	for name, tc := range invalidConfigurations {
 		t.Run(name, func(t *testing.T) {
-			if tc.skip {
-				// We've added this test before the implementation was ready.
-				t.SkipNow()
-			}
 			ctx := context.Background()
 
 			lock := depsfile.NewLocks()


### PR DESCRIPTION
The first commit in this PR just adds `stacks` and `promising` to the data race checks, so you can see the failure. (Note that the race tests now take 5 minutes).

(Promising feels like a good package to check, but it's also stable and didn't have a data race, so I'd be happy to remove that).

The next PR addresses the data race. We had multiple async PlanAll calls writing to a single `errored` bool, so I just swapped it with an atomic.Bool. 

The second data race is a test-only issue; the ReportComponentInstanceApplied method was being called async by multiple Apply() calls.