### PR TITLE
minor refactoring related to destroy actions

### DIFF
--- a/internal/terraform/context_plan_test.go
+++ b/internal/terraform/context_plan_test.go
@@ -5381,8 +5381,7 @@ func TestContext2Plan_selfRefMultiAll(t *testing.T) {
 
 	// The graph is checked for cycles before we can walk it, so we don't
 	// encounter the self-reference check.
-	//wantErrStr := "Self-referential block"
-	wantErrStr := "Cycle"
+	wantErrStr := "Self-referential block"
 	if !strings.Contains(gotErrStr, wantErrStr) {
 		t.Fatalf("missing expected error\ngot: %s\n\nwant: error containing %q", gotErrStr, wantErrStr)
 	}

--- a/internal/terraform/node_action.go
+++ b/internal/terraform/node_action.go
@@ -300,7 +300,7 @@ func (n *NodeActionConfig) SetProvider(p addrs.AbsProviderConfig) {
 // addrs.NoKey This function uses addrs.ActionInstance even though it only needs
 // the key because we need to use use a full instance addr for the resulting map
 // keys anyway.
-func (n *NodeActionConfig) EvalInvokedInstances(ctx EvalContext, addr addrs.ActionInstance, callRange *hcl.Range, caller addrs.Referenceable) (addrs.Map[addrs.ActionInstance, cty.Value], tfdiags.Diagnostics) {
+func (n *NodeActionConfig) EvalInvokedInstances(ctx EvalContext, addr addrs.ActionInstance, caller addrs.Referenceable) (addrs.Map[addrs.ActionInstance, cty.Value], tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
 	all := addrs.MakeMap[addrs.ActionInstance, cty.Value]()
 
@@ -319,7 +319,7 @@ func (n *NodeActionConfig) EvalInvokedInstances(ctx EvalContext, addr addrs.Acti
 
 	for _, instAddr := range instances {
 		repData := expander.GetActionInstanceRepetitionData(instAddr)
-		val, evalDiags := n.evalInstance(ctx, repData, callRange, caller, cty.NilVal)
+		val, evalDiags := n.evalInstance(ctx, repData, caller, cty.NilVal)
 		diags = diags.Append(evalDiags)
 		if diags.HasErrors() {
 			return all, diags
@@ -444,13 +444,13 @@ func (n *NodeActionConfig) EvalInstance(ctx EvalContext, inst addrs.AbsActionIns
 
 	repData := expander.GetActionInstanceRepetitionData(instAddr)
 
-	return n.evalInstance(ctx, repData, callRange, caller, callerVal)
+	return n.evalInstance(ctx, repData, caller, callerVal)
 }
 
 // Eval one or more instances of the action. This function expects that the key
 // is already validated for the the calling context, and will not produce
 // diagnostics for incorrect key types.
-func (n *NodeActionConfig) evalInstance(ctx EvalContext, repData instances.RepetitionData, callRange *hcl.Range, caller addrs.Referenceable, callerVal cty.Value) (cty.Value, tfdiags.Diagnostics) {
+func (n *NodeActionConfig) evalInstance(ctx EvalContext, repData instances.RepetitionData, caller addrs.Referenceable, callerVal cty.Value) (cty.Value, tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
 
 	diagsWith := n.Addr.String()

--- a/internal/terraform/node_action_invoke.go
+++ b/internal/terraform/node_action_invoke.go
@@ -170,7 +170,7 @@ func (n *nodeActionPlanInvoke) planActions(ctx EvalContext) tfdiags.Diagnostics 
 	// We're relying on the given addr derived from the action target to
 	// determine which action instance to evaluate. If the address has no key
 	// and the action is expanded, we will plan all instances.
-	actionVals, actionDiags := n.ActionConfig.EvalInvokedInstances(ctx, n.Addr.Action, nil, n.Caller)
+	actionVals, actionDiags := n.ActionConfig.EvalInvokedInstances(ctx, n.Addr.Action, n.Caller)
 	diags = diags.Append(actionDiags)
 	if diags.HasErrors() {
 		return diags

--- a/internal/terraform/node_resource_abstract_instance.go
+++ b/internal/terraform/node_resource_abstract_instance.go
@@ -21,6 +21,7 @@ import (
 	"github.com/hashicorp/terraform/internal/instances"
 	"github.com/hashicorp/terraform/internal/lang/ephemeral"
 	"github.com/hashicorp/terraform/internal/lang/format"
+	"github.com/hashicorp/terraform/internal/lang/langrefs"
 	"github.com/hashicorp/terraform/internal/lang/marks"
 	"github.com/hashicorp/terraform/internal/moduletest/mocking"
 	"github.com/hashicorp/terraform/internal/plans"
@@ -65,6 +66,8 @@ var (
 	_ GraphNodeConfigResource            = (*NodeAbstractResourceInstance)(nil)
 	_ GraphNodeResourceInstance          = (*NodeAbstractResourceInstance)(nil)
 	_ GraphNodeAttachResourceState       = (*NodeAbstractResourceInstance)(nil)
+	_ GraphNodeActionInvoker             = (*NodeAbstractResourceInstance)(nil)
+	_ GraphNodeActionCaller              = (*NodeAbstractResourceInstance)(nil)
 	_ GraphNodeAttachResourceConfig      = (*NodeAbstractResourceInstance)(nil)
 	_ GraphNodeAttachResourceSchema      = (*NodeAbstractResourceInstance)(nil)
 	_ GraphNodeAttachProvisionerSchema   = (*NodeAbstractResourceInstance)(nil)
@@ -115,6 +118,31 @@ func (n *NodeAbstractResourceInstance) ReferenceableAddrs() []addrs.Referenceabl
 		// would match both aws_instance.foo[0] and aws_instance.foo[1].
 		addr.ContainingResource().Resource,
 	}
+}
+
+// destroyActionReferences are used by destroy nodes to ensure that only actions
+// are connected by references, since a destroy node cannot reference anything
+// else from the config.
+func (n *NodeAbstractResourceInstance) destroyActionReferences() []*addrs.Reference {
+	var refs []*addrs.Reference
+	// Resources are destroyed using their state, but we do need to evaluate any
+	// potential destroy actions.
+	for _, trigger := range n.actionTriggers {
+		// don't bother with non-destroy references
+		if !slices.ContainsFunc(trigger.config.Events, configs.ActionTriggerEvent.IsDestroy) {
+			continue
+		}
+
+		for _, actionRef := range trigger.actionRefs {
+			refs = append(refs, &addrs.Reference{
+				Subject: actionRef.actionNode.Addr.Action,
+			})
+		}
+
+		rs, _ := langrefs.ReferencesInExpr(addrs.ParseRef, trigger.config.Condition)
+		refs = append(refs, rs...)
+	}
+	return refs
 }
 
 func (n *NodeAbstractResourceInstance) ActionCalls() []addrs.ConfigAction {
@@ -3301,19 +3329,6 @@ func (n *NodeAbstractResourceInstance) planActionTrigger(ctx EvalContext, resRep
 
 	ai.ConfigValue = ephemeral.RemoveEphemeralValues(actionVal)
 	return
-}
-
-// pre-check for before actions since being able to evaluate actions requires a
-// slightly different behavior for diff handling, we guard that change by seeing if
-// it's needed at all.
-func (n *NodeAbstractResourceInstance) hasBeforeActions() bool {
-	for _, trigger := range n.actionApplyTriggers {
-		event := trigger.ActionInvocation.ActionTrigger.TriggerEvent()
-		if event.IsBefore() {
-			return true
-		}
-	}
-	return false
 }
 
 // invokeDestroyAction currently cannot reevaluate the action config due to not

--- a/internal/terraform/node_resource_apply.go
+++ b/internal/terraform/node_resource_apply.go
@@ -143,9 +143,6 @@ func (n *nodeExpandApplyableResource) ephemeralResourceInstanceSubgraph(addr add
 		// Targeting
 		&TargetsTransformer{Targets: n.Targets},
 
-		// Connect references so ordering is correct
-		&ReferenceTransformer{},
-
 		// Make sure there is a single root
 		&RootTransformer{},
 	}

--- a/internal/terraform/node_resource_destroy.go
+++ b/internal/terraform/node_resource_destroy.go
@@ -87,6 +87,12 @@ func (n *NodeDestroyResourceInstance) ReferenceableAddrs() []addrs.Referenceable
 	return []addrs.Referenceable{}
 }
 
+func (n *NodeDestroyResourceInstance) References() []*addrs.Reference {
+	// destroyers don't reference, except when we need destroy actions to be
+	// reevaluated.
+	return n.destroyActionReferences()
+}
+
 // GraphNodeExecutable
 func (n *NodeDestroyResourceInstance) Execute(ctx EvalContext, op walkOperation) (diags tfdiags.Diagnostics) {
 	addr := n.ResourceInstanceAddr()
@@ -157,12 +163,10 @@ func (n *NodeDestroyResourceInstance) managedResourceExecute(ctx EvalContext) (d
 		}
 	}
 
-	if n.hasBeforeActions() {
-		log.Printf("[DEBUG] NodeApplyableResourceInstance: invoking before actions for %s", n.Addr)
-		diags = diags.Append(n.invokeDestroyActions(ctx, configs.BeforeDestroy))
-		if diags.HasErrors() {
-			return diags
-		}
+	log.Printf("[DEBUG] NodeApplyableResourceInstance: invoking before actions for %s", n.Addr)
+	diags = diags.Append(n.invokeDestroyActions(ctx, configs.BeforeDestroy))
+	if diags.HasErrors() {
+		return diags
 	}
 
 	// Managed resources need to be destroyed, while data sources

--- a/internal/terraform/node_resource_destroy_deposed.go
+++ b/internal/terraform/node_resource_destroy_deposed.go
@@ -63,14 +63,9 @@ var (
 	_ GraphNodeProviderConsumer              = (*NodePlanDeposedResourceInstanceObject)(nil)
 	_ GraphNodeProvisionerConsumer           = (*NodePlanDeposedResourceInstanceObject)(nil)
 	_ GraphNodeDestroyer                     = (*NodePlanDeposedResourceInstanceObject)(nil)
-	_ GraphNodePlanDestroyer                 = (*NodePlanDeposedResourceInstanceObject)(nil)
 )
 
 func (n *NodePlanDeposedResourceInstanceObject) DestroyAddr() *addrs.AbsResourceInstance {
-	return &n.Addr
-}
-
-func (n *NodePlanDeposedResourceInstanceObject) PlanDestroyAddr() *addrs.AbsResourceInstance {
 	return &n.Addr
 }
 
@@ -91,7 +86,9 @@ func (n *NodePlanDeposedResourceInstanceObject) ReferenceableAddrs() []addrs.Ref
 // GraphNodeReferencer implementation, overriding the one from NodeAbstractResourceInstance
 func (n *NodePlanDeposedResourceInstanceObject) References() []*addrs.Reference {
 	// We don't evaluate configuration for deposed objects, so they effectively
-	// make no references.
+	// make no references. Deposed instances do not invoke actions, since the
+	// fact they are deposed during plan indicated that the instance already
+	// errored out during a create-before-destroy apply.
 	return nil
 }
 
@@ -311,12 +308,10 @@ func (n *NodeDestroyDeposedResourceInstanceObject) Execute(ctx EvalContext, op w
 		return diags
 	}
 
-	if n.hasBeforeActions() {
-		log.Printf("[DEBUG] NodeApplyableResourceInstance: invoking before actions for %s", n.Addr)
-		diags = diags.Append(n.invokeDestroyActions(ctx, configs.BeforeDestroy))
-		if diags.HasErrors() {
-			return diags
-		}
+	log.Printf("[DEBUG] NodeApplyableResourceInstance: invoking before actions for %s", n.Addr)
+	diags = diags.Append(n.invokeDestroyActions(ctx, configs.BeforeDestroy))
+	if diags.HasErrors() {
+		return diags
 	}
 
 	// we pass a nil configuration to apply because we are destroying

--- a/internal/terraform/node_resource_partial_plan.go
+++ b/internal/terraform/node_resource_partial_plan.go
@@ -353,9 +353,6 @@ func (n *nodeExpandPlannableResource) knownModuleSubgraph(ctx EvalContext, addr 
 		// Targeting
 		&TargetsTransformer{Targets: n.Targets},
 
-		// Connect references so ordering is correct
-		&ReferenceTransformer{},
-
 		// Make sure there is a single root
 		&RootTransformer{},
 	}

--- a/internal/terraform/node_resource_plan.go
+++ b/internal/terraform/node_resource_plan.go
@@ -540,9 +540,6 @@ func (n *nodeExpandPlannableResource) resourceInstanceSubgraph(ctx EvalContext, 
 		// Targeting
 		&TargetsTransformer{Targets: n.Targets},
 
-		// Connect references so ordering is correct
-		&ReferenceTransformer{},
-
 		// Make sure there is a single root
 		&RootTransformer{},
 	}

--- a/internal/terraform/node_resource_plan_destroy.go
+++ b/internal/terraform/node_resource_plan_destroy.go
@@ -29,7 +29,6 @@ var (
 	_ GraphNodeReferenceable        = (*NodePlanDestroyableResourceInstance)(nil)
 	_ GraphNodeReferencer           = (*NodePlanDestroyableResourceInstance)(nil)
 	_ GraphNodeDestroyer            = (*NodePlanDestroyableResourceInstance)(nil)
-	_ GraphNodePlanDestroyer        = (*NodePlanDestroyableResourceInstance)(nil)
 	_ GraphNodeConfigResource       = (*NodePlanDestroyableResourceInstance)(nil)
 	_ GraphNodeResourceInstance     = (*NodePlanDestroyableResourceInstance)(nil)
 	_ GraphNodeAttachResourceConfig = (*NodePlanDestroyableResourceInstance)(nil)
@@ -50,15 +49,14 @@ func (n *NodePlanDestroyableResourceInstance) DestroyAddr() *addrs.AbsResourceIn
 	return &addr
 }
 
-func (n *NodePlanDestroyableResourceInstance) PlanDestroyAddr() *addrs.AbsResourceInstance {
-	addr := n.ResourceInstanceAddr()
-	return &addr
-}
-
 func (n *NodePlanDestroyableResourceInstance) ReferenceableAddrs() []addrs.Referenceable {
 	// destroy nodes are not referenceable, so we must override the method from
 	// the abstract layers
 	return nil
+}
+
+func (n *NodePlanDestroyableResourceInstance) References() (refs []*addrs.Reference) {
+	return n.destroyActionReferences()
 }
 
 func (n *NodePlanDestroyableResourceInstance) AttachActionTriggers(triggers []*resourceActionTrigger) {

--- a/internal/terraform/node_resource_plan_orphan.go
+++ b/internal/terraform/node_resource_plan_orphan.go
@@ -46,7 +46,6 @@ var (
 	_ GraphNodeExecutable           = (*NodePlannableResourceInstanceOrphan)(nil)
 	_ GraphNodeProviderConsumer     = (*NodePlannableResourceInstanceOrphan)(nil)
 	_ GraphNodeDestroyer            = (*NodePlannableResourceInstanceOrphan)(nil)
-	_ GraphNodePlanDestroyer        = (*NodePlannableResourceInstanceOrphan)(nil)
 )
 
 func (n *NodePlannableResourceInstanceOrphan) Name() string {
@@ -54,11 +53,6 @@ func (n *NodePlannableResourceInstanceOrphan) Name() string {
 }
 
 func (n *NodePlannableResourceInstanceOrphan) DestroyAddr() *addrs.AbsResourceInstance {
-	addr := n.ResourceInstanceAddr()
-	return &addr
-}
-
-func (n *NodePlannableResourceInstanceOrphan) PlanDestroyAddr() *addrs.AbsResourceInstance {
 	addr := n.ResourceInstanceAddr()
 	return &addr
 }
@@ -92,6 +86,10 @@ func (n *NodePlannableResourceInstanceOrphan) ReferenceableAddrs() []addrs.Refer
 	// destroy nodes are not referenceable, so we must override the method from
 	// the abstract layers
 	return nil
+}
+
+func (n *NodePlannableResourceInstanceOrphan) References() (refs []*addrs.Reference) {
+	return n.destroyActionReferences()
 }
 
 func (n *NodePlannableResourceInstanceOrphan) AttachActionTriggers(triggers []*resourceActionTrigger) {

--- a/internal/terraform/transform_action_diff.go
+++ b/internal/terraform/transform_action_diff.go
@@ -57,15 +57,11 @@ func (t *ActionDiffTransformer) Transform(g *Graph) error {
 
 				if actionTrigger.ActionTriggerEvent.IsDestroy() {
 					// we may have both create and destroy nodes under ths same
-					// address, so match up their types
-					if _, ok := resourceInstance.(GraphNodeDestroyer); ok {
-						invoker.AttachActionApplyTrigger(&actionTriggerApplyInstance{
-							ActionInvocation: ai,
-							actionNode:       actionConfig,
-						})
-						foundNode = true
+					// address, so match make sure the destroy action trigger is
+					// only attached to a destroyer node
+					if _, ok := resourceInstance.(GraphNodeDestroyer); !ok {
+						continue
 					}
-					continue
 				}
 
 				invoker.AttachActionApplyTrigger(&actionTriggerApplyInstance{

--- a/internal/terraform/transform_destroy_edge.go
+++ b/internal/terraform/transform_destroy_edge.go
@@ -19,16 +19,6 @@ type GraphNodeDestroyer interface {
 	DestroyAddr() *addrs.AbsResourceInstance
 }
 
-// GraphNodePlanDestroyer is implemented only by the planning counterpart for
-// the destroy nodes. These are typically created for objects which only exist
-// in state, like orphaned instances or planing a full destroy operation.
-type GraphNodePlanDestroyer interface {
-	// DestroyAddr is the address of the resource that is being
-	// destroyed by this node. If this returns nil, then this node
-	// is not destroying anything.
-	PlanDestroyAddr() *addrs.AbsResourceInstance
-}
-
 // GraphNodeCreator must be implemented by nodes that create OR update resources.
 type GraphNodeCreator interface {
 	// CreateAddr is the address of the resource being created or updated

--- a/internal/terraform/transform_reference.go
+++ b/internal/terraform/transform_reference.go
@@ -111,54 +111,39 @@ type ReferenceTransformer struct{}
 
 func (t *ReferenceTransformer) Transform(g *Graph) error {
 	// Build a reference map so we can efficiently look up the references
-	vs := g.Vertices()
-	m := NewReferenceMap(vs)
+	vertices := g.Vertices()
+	m := NewReferenceMap(vertices)
 
 	// Find the things that reference things and connect them
-	for _, v := range vs {
-		// Only plan-time destroy nodes can be connected via references.
-		_, destroyer := v.(GraphNodeDestroyer)
-		_, planning := v.(GraphNodePlanDestroyer)
-		if destroyer && !planning {
+	for _, v := range vertices {
+		if _, ok := v.(GraphNodeConfigAction); ok {
+			// Because actions were allowed to reference the calling resource in
+			// configuration, we need to deal with the resulting cycles. Skip
+			// action nodes in the first round so that any triggers can be
+			// connected first and cycles can be detected.
 			continue
 		}
 
-		// Because actions were allowed to reference the calling resource in
-		// configuration, we need to deal with the resulting cycles. Skip action
-		// nodes in the first round so that any triggers can be connected first
-		// so cycles can be detected.
-		if _, ok := v.(*NodeActionConfig); ok {
-			continue
-		}
-
-		parents := m.References(v)
-		parentsDbg := make([]string, len(parents))
-		for i, v := range parents {
-			parentsDbg[i] = dag.VertexName(v)
+		referencedNodes := m.References(v)
+		refDbg := make([]string, len(referencedNodes))
+		for i, v := range referencedNodes {
+			refDbg[i] = dag.VertexName(v)
 		}
 		log.Printf(
 			"[DEBUG] ReferenceTransformer: %q references: %v",
-			dag.VertexName(v), parentsDbg)
+			dag.VertexName(v), refDbg)
 
-		for _, parent := range parents {
-			// A destroy plan relies solely on the state, so we only need to
-			// ensure that temporary values are connected to get the evaluation
-			// order correct. Any references to destroy nodes will cause
-			// cycles, because they are connected in reverse order.
-			if _, ok := parent.(GraphNodeDestroyer); ok {
-				continue
-			}
-
-			if !graphNodesAreResourceInstancesInDifferentInstancesOfSameModule(v, parent) {
-				log.Printf("[DEBUG] ReferenceTransformer: %q references: %v", dag.VertexName(v), dag.VertexName(parent))
-				g.Connect(dag.BasicEdge(v, parent))
+		for _, referenced := range referencedNodes {
+			if !graphNodesAreResourceInstancesInDifferentInstancesOfSameModule(v, referenced) {
+				log.Printf("[DEBUG] ReferenceTransformer: %q references: %v", dag.VertexName(v), dag.VertexName(referenced))
+				g.Connect(dag.BasicEdge(v, referenced))
 			}
 		}
 	}
 
 	// now we can go back and connect the action configs to their dependencies
-	for _, v := range vs {
-		actionConfig, ok := v.(*NodeActionConfig)
+	for _, v := range vertices {
+		actionConfig, ok := v.(GraphNodeConfigAction)
 		if !ok {
 			continue
 		}
@@ -174,17 +159,17 @@ func (t *ReferenceTransformer) Transform(g *Graph) error {
 				caller, ok := ref.(GraphNodeActionCaller)
 				if !ok {
 					// this node cannot call any actions
-					return fmt.Errorf("action reference cycle involving %s and %s", actionConfig.Addr, dag.VertexName(ref))
+					return fmt.Errorf("action reference cycle involving %s and %s", actionConfig.ActionAddr(), dag.VertexName(ref))
 				}
 
 				// The reference can call actions, and we'll allow it if it
 				// directly references back to the same action node.
 				for _, actionCall := range caller.ActionCalls() {
-					if actionCall.Equal(actionConfig.Addr) {
+					if actionCall.Equal(actionConfig.ActionAddr()) {
 						continue ACTIONREFS
 					}
 				}
-				return fmt.Errorf("action reference cycle involving %s and %s", actionConfig.Addr, dag.VertexName(ref))
+				return fmt.Errorf("action reference cycle involving %s and %s", actionConfig.ActionAddr(), dag.VertexName(ref))
 			}
 
 			g.Connect(dag.BasicEdge(actionConfig, ref))


### PR DESCRIPTION
Trying to get destroy actions finalized really highlighted the old problems in the reference transformer, so this PR aims to clean them up.

The variety of resource nodes were never very tidy about what references they exposed, even when they were of a type which could not have references. The reference transformer had to work around these in various ways over the years. mostly by singling out destroy nodes, but now some destroy-plan nodes need references for actions.

It turns out that most of the prep work was already done, and only a few method fixes were needed, then the reference transformer could be simplified to using references whenever they were seen.