### PR TITLE
Skip policy evaluation if plan/apply fails

### DIFF
--- a/internal/terraform/context_apply_policy_test.go
+++ b/internal/terraform/context_apply_policy_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/hashicorp/terraform/internal/policy"
 	"github.com/hashicorp/terraform/internal/policy/proto"
 	"github.com/hashicorp/terraform/internal/providers"
+	testing_provider "github.com/hashicorp/terraform/internal/providers/testing"
 	"github.com/hashicorp/terraform/internal/states"
 	"github.com/hashicorp/terraform/internal/tfdiags"
 	"github.com/zclconf/go-cty/cty"
@@ -503,6 +504,193 @@ func TestContext2Apply_PolicyEvaluationError(t *testing.T) {
 	rs := state.Resource(mustAbsResourceAddr("test_resource.test"))
 	if rs == nil {
 		t.Fatal("expected resource to be in the state")
+	}
+}
+
+func TestContext2Apply_PolicyEvaluation_WriteOnly(t *testing.T) {
+	providerAddr := addrs.NewDefaultProvider("ephem")
+
+	for _, tc := range []struct {
+		name             string
+		applyResourceFn  func(req providers.ApplyResourceChangeRequest) providers.ApplyResourceChangeResponse
+		expectPolicyCall bool
+		assertPolicyReq  func(*testing.T, policy.EvaluationRequest[*proto.PolicyEvaluateResourceRequest_ResourceMetadata])
+		expectDiags      tfdiags.Diagnostics
+	}{
+		{
+			name: "policy receives null write-only attrs",
+			applyResourceFn: func(req providers.ApplyResourceChangeRequest) providers.ApplyResourceChangeResponse {
+				return providers.ApplyResourceChangeResponse{
+					NewState: cty.ObjectVal(map[string]cty.Value{
+						"normal":     req.Config.GetAttr("normal"),
+						"write_only": cty.NullVal(cty.String),
+					}),
+				}
+			},
+			expectPolicyCall: true,
+			assertPolicyReq: func(t *testing.T, req policy.EvaluationRequest[*proto.PolicyEvaluateResourceRequest_ResourceMetadata]) {
+				t.Helper()
+
+				if req.Target != "ephem_write_only" {
+					t.Fatalf("unexpected policy target %q", req.Target)
+				}
+				if diff := cmp.Diff(req.Meta, &proto.PolicyEvaluateResourceRequest_ResourceMetadata{
+					ProviderType: "ephem",
+					Operation:    proto.Operation_UPDATE,
+				}, protocmp.Transform()); diff != "" {
+					t.Fatalf("invalid resource metadata: %s", diff)
+				}
+
+				if req.Attrs.Raw.IsNull() {
+					t.Fatal("expected non-null attrs for policy evaluation")
+				}
+				if req.PriorAttrs.Raw.IsNull() {
+					t.Fatal("expected non-null prior attrs for policy evaluation")
+				}
+
+				if got := req.Attrs.Raw.GetAttr("normal").AsString(); got != "updated" {
+					t.Fatalf("expected attrs.normal to be updated, got %q", got)
+				}
+				if got := req.PriorAttrs.Raw.GetAttr("normal").AsString(); got != "outdated" {
+					t.Fatalf("expected prior_attrs.normal to be outdated, got %q", got)
+				}
+				if got := req.Attrs.Raw.GetAttr("write_only"); !got.IsNull() {
+					t.Fatalf("expected attrs.write_only to be null, got %v", got)
+				}
+				if got := req.PriorAttrs.Raw.GetAttr("write_only"); !got.IsNull() {
+					t.Fatalf("expected prior_attrs.write_only to be null, got %v", got)
+				}
+			},
+		},
+		{
+			name: "provider returning write-only value fails before policy",
+			applyResourceFn: func(req providers.ApplyResourceChangeRequest) providers.ApplyResourceChangeResponse {
+				return providers.ApplyResourceChangeResponse{
+					NewState: cty.ObjectVal(map[string]cty.Value{
+						"normal":     req.Config.GetAttr("normal"),
+						"write_only": cty.StringVal("should not be returned by the provider"),
+					}),
+				}
+			},
+			expectPolicyCall: false,
+			expectDiags: tfdiags.Diagnostics{}.Append(tfdiags.Sourceless(
+				tfdiags.Error,
+				"Provider produced invalid object",
+				`Provider "provider[\"registry.terraform.io/hashicorp/ephem\"]" returned a value for the write-only attribute "ephem_write_only.wo.write_only" after apply. Write-only attributes cannot be read back from the provider. This is a bug in the provider, which should be reported in the provider's own issue tracker.`,
+			)),
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			m := testModuleInline(t, map[string]string{
+				"main.tf": `
+					variable "ephem" {
+						type      = string
+						ephemeral = true
+					}
+
+					resource "ephem_write_only" "wo" {
+						normal     = "updated"
+						write_only = var.ephem
+					}
+				`,
+				"main.tfpolicy.hcl": `
+					resource_policy "ephem_write_only" "policy_name" {
+						enforce {
+							condition = true
+						}
+					}
+				`,
+			})
+
+			provider := &testing_provider.MockProvider{}
+			provider.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
+				ResourceTypes: map[string]providers.Schema{
+					"ephem_write_only": {
+						Body: &configschema.Block{
+							Attributes: map[string]*configschema.Attribute{
+								"normal": {
+									Type:     cty.String,
+									Required: true,
+								},
+								"write_only": {
+									Type:      cty.String,
+									Required:  true,
+									WriteOnly: true,
+								},
+							},
+						},
+					},
+				},
+			}
+			provider.PlanResourceChangeFn = func(req providers.PlanResourceChangeRequest) providers.PlanResourceChangeResponse {
+				return providers.PlanResourceChangeResponse{
+					PlannedState: cty.ObjectVal(map[string]cty.Value{
+						"normal":     req.ProposedNewState.GetAttr("normal"),
+						"write_only": cty.NullVal(cty.String),
+					}),
+				}
+			}
+			provider.ApplyResourceChangeFn = tc.applyResourceFn
+
+			priorState := states.BuildState(func(state *states.SyncState) {
+				state.SetResourceInstanceCurrent(
+					mustResourceInstanceAddr("ephem_write_only.wo"),
+					&states.ResourceInstanceObjectSrc{
+						Status:    states.ObjectReady,
+						AttrsJSON: []byte(`{"normal":"outdated","write_only":null}`),
+					},
+					addrs.AbsProviderConfig{
+						Provider: providerAddr,
+						Module:   addrs.RootModule,
+					},
+				)
+			})
+
+			ctx := testContext2(t, &ContextOpts{
+				Providers: map[addrs.Provider]providers.Factory{
+					providerAddr: testProviderFuncFixed(provider),
+				},
+			})
+
+			plan, diags := ctx.Plan(m, priorState, &PlanOpts{
+				Mode: plans.NormalMode,
+				SetVariables: InputValues{
+					"ephem": {
+						Value:      cty.StringVal("ephemeral-secret"),
+						SourceType: ValueFromCLIArg,
+					},
+				},
+			})
+			tfdiags.AssertNoDiagnostics(t, diags)
+
+			applyPolicyClient := policy.NewTestMockClient(t)
+			applyPolicyClient.EvaluateFn = func(ctx context.Context, req policy.EvaluationRequest[*proto.PolicyEvaluateResourceRequest_ResourceMetadata]) policy.EvaluationResponse {
+				if tc.assertPolicyReq != nil {
+					tc.assertPolicyReq(t, req)
+				}
+				return policy.EvaluationResponse{Overall: policy.AllowResult}
+			}
+
+			_, diags = ctx.Apply(plan, m, &ApplyOpts{
+				SetVariables: InputValues{
+					"ephem": {
+						Value:      cty.StringVal("ephemeral-secret"),
+						SourceType: ValueFromCLIArg,
+					},
+				},
+				PolicyClient: applyPolicyClient,
+			})
+
+			if tc.expectDiags != nil {
+				tfdiags.AssertDiagnosticsMatch(t, diags, tc.expectDiags)
+			} else {
+				tfdiags.AssertNoDiagnostics(t, diags)
+			}
+
+			if applyPolicyClient.EvaluateCalled != tc.expectPolicyCall {
+				t.Fatalf("expected policy evaluation called=%t, got %t", tc.expectPolicyCall, applyPolicyClient.EvaluateCalled)
+			}
+		})
 	}
 }
 

--- a/internal/terraform/context_plan_policy_test.go
+++ b/internal/terraform/context_plan_policy_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/hashicorp/terraform/internal/policy"
 	"github.com/hashicorp/terraform/internal/policy/proto"
 	"github.com/hashicorp/terraform/internal/providers"
+	testing_provider "github.com/hashicorp/terraform/internal/providers/testing"
 	"github.com/hashicorp/terraform/internal/states"
 	"github.com/hashicorp/terraform/internal/tfdiags"
 	"github.com/zclconf/go-cty/cty"
@@ -1290,6 +1291,184 @@ func TestContext2Plan_PolicyEvaluation_RedactedPaths(t *testing.T) {
 
 	assertPathsEqual(t, policyClient.EvaluateRequest.Attrs.RedactedPaths, wantAttrs)
 	assertPathsEqual(t, policyClient.EvaluateRequest.PriorAttrs.RedactedPaths, wantPriorAttrs)
+}
+
+func TestContext2Plan_PolicyEvaluation_WriteOnly(t *testing.T) {
+	providerAddr := addrs.NewDefaultProvider("ephem")
+	provider := &testing_provider.MockProvider{
+		GetProviderSchemaResponse: &providers.GetProviderSchemaResponse{
+			ResourceTypes: map[string]providers.Schema{
+				"ephem_write_only": {
+					Body: &configschema.Block{
+						Attributes: map[string]*configschema.Attribute{
+							"normal": {
+								Type:     cty.String,
+								Required: true,
+							},
+							"write_only": {
+								Type:      cty.String,
+								Required:  true,
+								WriteOnly: true,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	testCases := []struct {
+		name             string
+		planResourceFn   func(req providers.PlanResourceChangeRequest) providers.PlanResourceChangeResponse
+		expectPolicyCall bool
+		assertPolicyReq  func(*testing.T, policy.EvaluationRequest[*proto.PolicyEvaluateResourceRequest_ResourceMetadata])
+		expectDiags      tfdiags.Diagnostics
+	}{
+		{
+			name: "policy receives null write-only attrs",
+			planResourceFn: func(req providers.PlanResourceChangeRequest) providers.PlanResourceChangeResponse {
+				return providers.PlanResourceChangeResponse{
+					PlannedState: cty.ObjectVal(map[string]cty.Value{
+						"normal":     req.ProposedNewState.GetAttr("normal"),
+						"write_only": cty.NullVal(cty.String),
+					}),
+				}
+			},
+			expectPolicyCall: true,
+			assertPolicyReq: func(t *testing.T, req policy.EvaluationRequest[*proto.PolicyEvaluateResourceRequest_ResourceMetadata]) {
+				t.Helper()
+
+				if req.Target != "ephem_write_only" {
+					t.Fatalf("unexpected policy target %q", req.Target)
+				}
+				if diff := cmp.Diff(req.Meta, &proto.PolicyEvaluateResourceRequest_ResourceMetadata{
+					ProviderType: "ephem",
+					Operation:    proto.Operation_UPDATE,
+				}, protocmp.Transform()); diff != "" {
+					t.Fatalf("invalid resource metadata: %s", diff)
+				}
+
+				if req.Attrs.Raw.IsNull() {
+					t.Fatal("expected non-null attrs for policy evaluation")
+				}
+				if req.PriorAttrs.Raw.IsNull() {
+					t.Fatal("expected non-null prior attrs for policy evaluation")
+				}
+
+				if got := req.Attrs.Raw.GetAttr("normal").AsString(); got != "updated" {
+					t.Fatalf("expected attrs.normal to be updated, got %q", got)
+				}
+				if got := req.PriorAttrs.Raw.GetAttr("normal").AsString(); got != "outdated" {
+					t.Fatalf("expected prior_attrs.normal to be outdated, got %q", got)
+				}
+				if got := req.Attrs.Raw.GetAttr("write_only"); !got.IsNull() {
+					t.Fatalf("expected attrs.write_only to be null, got %v", got)
+				}
+				if got := req.PriorAttrs.Raw.GetAttr("write_only"); !got.IsNull() {
+					t.Fatalf("expected prior_attrs.write_only to be null, got %v", got)
+				}
+			},
+		},
+		{
+			name: "provider returning write-only value fails before policy",
+			planResourceFn: func(req providers.PlanResourceChangeRequest) providers.PlanResourceChangeResponse {
+				return providers.PlanResourceChangeResponse{
+					PlannedState: cty.ObjectVal(map[string]cty.Value{
+						"normal":     req.ProposedNewState.GetAttr("normal"),
+						"write_only": cty.StringVal("should not be returned by the provider"),
+					}),
+				}
+			},
+			expectPolicyCall: false,
+			expectDiags: tfdiags.Diagnostics{}.Append(tfdiags.Sourceless(
+				tfdiags.Error,
+				"Provider produced invalid plan",
+				`Provider "provider[\"registry.terraform.io/hashicorp/ephem\"]" returned a value for the write-only attribute "ephem_write_only.wo.write_only" during planning. Write-only attributes cannot be read back from the provider. This is a bug in the provider, which should be reported in the provider's own issue tracker.`,
+			)),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			m := testModuleInline(t, map[string]string{
+				"main.tf": `
+					variable "ephem" {
+						type      = string
+						ephemeral = true
+					}
+
+					resource "ephem_write_only" "wo" {
+						normal     = "updated"
+						write_only = var.ephem
+					}
+				`,
+				"main.tfpolicy.hcl": `
+					resource_policy "ephem_write_only" "policy_name" {
+						enforce {
+							condition = true
+						}
+					}
+				`,
+			})
+
+			provider.PlanResourceChangeFn = tc.planResourceFn
+
+			priorState := states.BuildState(func(state *states.SyncState) {
+				state.SetResourceInstanceCurrent(
+					mustResourceInstanceAddr("ephem_write_only.wo"),
+					&states.ResourceInstanceObjectSrc{
+						Status:    states.ObjectReady,
+						AttrsJSON: []byte(`{"normal":"outdated","write_only":null}`),
+					},
+					addrs.AbsProviderConfig{
+						Provider: providerAddr,
+						Module:   addrs.RootModule,
+					},
+				)
+			})
+
+			policyClient := policy.NewTestMockClient(t)
+			policyClient.EvaluateFn = func(ctx context.Context, req policy.EvaluationRequest[*proto.PolicyEvaluateResourceRequest_ResourceMetadata]) policy.EvaluationResponse {
+				if !tc.expectPolicyCall {
+					t.Fatalf("expected policy evaluation to be skipped, got request for %s", req.Target)
+				}
+				if tc.assertPolicyReq != nil {
+					tc.assertPolicyReq(t, req)
+				}
+				return policy.EvaluationResponse{Overall: policy.AllowResult}
+			}
+
+			ctx := testContext2(t, &ContextOpts{
+				Providers: map[addrs.Provider]providers.Factory{
+					providerAddr: testProviderFuncFixed(provider),
+				},
+			})
+
+			plan, diags := ctx.Plan(m, priorState, &PlanOpts{
+				Mode: plans.NormalMode,
+				SetVariables: InputValues{
+					"ephem": {
+						Value:      cty.StringVal("ephemeral-secret"),
+						SourceType: ValueFromCLIArg,
+					},
+				},
+				PolicyClient: policyClient,
+			})
+
+			if tc.expectDiags != nil {
+				tfdiags.AssertDiagnosticsMatch(t, diags, tc.expectDiags)
+			} else {
+				if plan == nil {
+					t.Fatal("expected non-nil plan")
+				}
+				tfdiags.AssertNoDiagnostics(t, diags)
+			}
+
+			if policyClient.EvaluateCalled != tc.expectPolicyCall {
+				t.Fatalf("expected policy evaluation called=%t, got %t", tc.expectPolicyCall, policyClient.EvaluateCalled)
+			}
+		})
+	}
 }
 
 func TestContext2Plan_PolicyEvaluation_NoResourceRunsAfterPolicy(t *testing.T) {

--- a/internal/terraform/node_resource_apply_instance.go
+++ b/internal/terraform/node_resource_apply_instance.go
@@ -288,18 +288,19 @@ func (n *NodeApplyableResourceInstance) managedResourceExecute(ctx EvalContext) 
 		if err := n.taintInstanceState(ctx, state, diffApply.Action); err != nil {
 			return diags.Append(err)
 		}
-	}
-
-	if policyGraph := ctx.PolicyGraph(); policyGraph != nil {
-		// The resource has been applied, so we add a policy node to send its data
-		// for policy evaluation.
-		policyGraph.Add(&nodeResourcePolicy{
-			ResourceAddr: diffApply.Addr,
-			ProviderAddr: diffApply.ProviderAddr,
-			Before:       diffApply.Before,
-			After:        state.Value,
-			Action:       diffApply.Action,
-		})
+	} else {
+		// We only add a policy node if the apply was successful.
+		if policyGraph := ctx.PolicyGraph(); policyGraph != nil {
+			// The resource has been applied, so we add a policy node to send its data
+			// for policy evaluation.
+			policyGraph.Add(&nodeResourcePolicy{
+				ResourceAddr: diffApply.Addr,
+				ProviderAddr: diffApply.ProviderAddr,
+				Before:       diffApply.Before,
+				After:        state.Value,
+				Action:       diffApply.Action,
+			})
+		}
 	}
 
 	// We clear the change out here so that future nodes don't see a change


### PR DESCRIPTION
- Add tests verifying write-only attributes are not sent for policy evaluation

<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

The PR adds tests verifying write-only attributes are not sent for policy evaluation.

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.16.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [ ] This change is not user-facing.
