### PR TITLE
PSS: Add provider download features to `state migrate`

### DIFF
--- a/internal/command/init.go
+++ b/internal/command/init.go
@@ -45,6 +45,8 @@ import (
 type InitCommand struct {
 	Meta
 
+	// incompleteProviders is necessary here to coordinate separate
+	// provider installation and lock file update processes.
 	incompleteProviders []string
 }
 

--- a/internal/command/meta_dependencies.go
+++ b/internal/command/meta_dependencies.go
@@ -20,15 +20,6 @@ import (
 //
 // We always expect to find this file in the current working directory
 // because that should also be the root module directory.
-//
-// Some commands have legacy command line arguments that make the root module
-// directory something other than the root module directory; when using those,
-// the lock file will be written in the "wrong" place (the current working
-// directory instead of the root module directory) but we do that intentionally
-// to match where the ".terraform" directory would also be written in that
-// case. Eventually we will phase out those legacy arguments in favor of the
-// global -chdir=... option, which _does_ preserve the intended invariant
-// that the root module directory is always the current working directory.
 const dependencyLockFilename = depsfile.LockFilePath // .terraform.lock.hcl
 
 // lockedDependencies reads the dependency lock information from the default lock file location

--- a/internal/command/meta_dependencies.go
+++ b/internal/command/meta_dependencies.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform/internal/tfdiags"
 )
 
-// dependenclyLockFilename is the filename of the dependency lock file.
+// dependencyLockFilename is the filename of the dependency lock file.
 //
 // This file should live in the same directory as the .tf files for the
 // root module of the configuration, alongside the .terraform directory
@@ -29,10 +29,16 @@ import (
 // case. Eventually we will phase out those legacy arguments in favor of the
 // global -chdir=... option, which _does_ preserve the intended invariant
 // that the root module directory is always the current working directory.
-const dependencyLockFilename = ".terraform.lock.hcl"
+const dependencyLockFilename = depsfile.LockFilePath // .terraform.lock.hcl
 
-// lockedDependencies reads the dependency lock information from the lock file
+// lockedDependencies reads the dependency lock information from the default lock file location
 // in the current working directory.
+// Wraps the readLockedDependenciesFromPath method; see that method for details.
+func (m *Meta) lockedDependencies() (*depsfile.Locks, tfdiags.Diagnostics) {
+	return m.readLockedDependenciesFromPath(dependencyLockFilename)
+}
+
+// readLockedDependenciesFromPath reads the dependency lock information from the lock file at the given path.
 //
 // If the lock file doesn't exist at the time of the call, lockedDependencies
 // indicates success and returns an empty Locks object. If the file does
@@ -43,19 +49,19 @@ const dependencyLockFilename = ".terraform.lock.hcl"
 // The result is a snapshot of the locked dependencies at the time of the call
 // and does not update as a result of calling replaceLockedDependencies
 // or any other modification method.
-func (m *Meta) lockedDependencies() (*depsfile.Locks, tfdiags.Diagnostics) {
+func (m *Meta) readLockedDependenciesFromPath(filename string) (*depsfile.Locks, tfdiags.Diagnostics) {
 	// We check that the file exists first, because the underlying HCL
 	// parser doesn't distinguish that error from other error types
 	// in a machine-readable way but we want to treat that as a success
 	// with no locks. There is in theory a race condition here in that
 	// the file could be created or removed in the meantime, but we're not
 	// promising to support two concurrent dependency installation processes.
-	_, err := os.Stat(dependencyLockFilename)
+	_, err := os.Stat(filename)
 	if os.IsNotExist(err) {
 		return m.annotateDependencyLocksWithOverrides(depsfile.NewLocks()), nil
 	}
 
-	ret, diags := depsfile.LoadLocksFromFile(dependencyLockFilename)
+	ret, diags := depsfile.LoadLocksFromFile(filename)
 	return m.annotateDependencyLocksWithOverrides(ret), diags
 }
 

--- a/internal/command/state_migrate.go
+++ b/internal/command/state_migrate.go
@@ -4,12 +4,20 @@
 package command
 
 import (
+	"context"
 	"fmt"
+	"sort"
 	"strings"
 
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/command/arguments"
 	"github.com/hashicorp/terraform/internal/command/views"
+	"github.com/hashicorp/terraform/internal/configs"
 	"github.com/hashicorp/terraform/internal/depsfile"
+	"github.com/hashicorp/terraform/internal/getproviders"
+	"github.com/hashicorp/terraform/internal/getproviders/providerreqs"
+	"github.com/hashicorp/terraform/internal/providercache"
 	"github.com/hashicorp/terraform/internal/tfdiags"
 )
 
@@ -17,6 +25,10 @@ import (
 // the state file from one location to another
 type StateMigrateCommand struct {
 	Meta
+
+	// incompleteProviders is necessary here to coordinate separate
+	// provider installation and lock file update processes.
+	incompleteProviders []string
 }
 
 func (c *StateMigrateCommand) Run(rawArgs []string) int {
@@ -33,7 +45,13 @@ func (c *StateMigrateCommand) Run(rawArgs []string) int {
 		return 1
 	}
 
+	// FIXME: the -input flag value is needed but there is no clear path to pass
+	// this value down, so we continue to mutate the Meta object state for now.
 	c.Meta.input = args.InputEnabled
+
+	// Command can be aborted by interruption signals
+	ctx, done := c.InterruptibleContext(c.CommandContext())
+	defer done()
 
 	// return validation errors early if there are any
 	if diags.HasErrors() {
@@ -82,26 +100,34 @@ func (c *StateMigrateCommand) Run(rawArgs []string) int {
 		source = fmt.Sprintf("state store %q (%s)", smi.StateStore.Type,
 			smi.StateStore.ProviderAddr.ForDisplay())
 
-		srcLocks, srcLockDiags := depsfile.LoadLocksFromFile(args.SourceLockFilePath)
+		// Load any pre-existing source provider lock file.
+		srcLocks, srcLockDiags := c.readLockedDependenciesFromPath(args.SourceLockFilePath)
+		diags = diags.Append(srcLockDiags)
 		if srcLockDiags.HasErrors() {
-			diags = diags.Append(srcLockDiags)
 			stateMigrate.Diagnostics(diags)
 			return 1
-		} else {
-			diags = diags.Append(srcLockDiags)
+		}
 
-			srcB, _, _, srcDiags := c.Meta.stateStoreInitFromConfig(smi.StateStore, srcLocks)
-			diags = diags.Append(srcDiags)
-			if !diags.HasErrors() {
-				migrateOpts.SourceType = smi.StateStore.Type
-				migrateOpts.Source = srcB
-			}
+		upgrade := false // The first provider download step will never be an upgrade. Either it's constrained by a preexisting lock or there is no lock.
+		_, sourceLock, srcProviderDiags := c.getSingleProvider(ctx, smi.StateStore.Type, smi.StateStoreProvider.Requirement, srcLocks, upgrade, MigrationSource, stateMigrate)
+		diags = diags.Append(srcProviderDiags)
+		if srcProviderDiags.HasErrors() {
+			stateMigrate.Diagnostics(diags)
+			return 1
+		}
+
+		srcB, _, _, srcDiags := c.Meta.stateStoreInitFromConfig(smi.StateStore, sourceLock)
+		diags = diags.Append(srcDiags)
+		if !diags.HasErrors() {
+			migrateOpts.SourceType = smi.StateStore.Type
+			migrateOpts.Source = srcB
 		}
 	}
 
 	// Load the destination backend
 	rootMod := cfg.Module
 	var destination string
+	var destinationLock *depsfile.Locks // This should only contain a single lock, if non nil. Used to update the dependency lock file on disk.
 	if rootMod.Backend != nil {
 		destination = fmt.Sprintf("backend %q", rootMod.Backend.Type)
 
@@ -115,20 +141,42 @@ func (c *StateMigrateCommand) Run(rawArgs []string) int {
 		destination = fmt.Sprintf("state store %q (%s)", rootMod.StateStore.Type,
 			rootMod.StateStore.ProviderAddr.ForDisplay())
 
-		dstLocks, dstLockDiags := depsfile.LoadLocksFromFile(args.DestinationLockFilePath)
-		if dstLockDiags.HasErrors() {
-			diags = diags.Append(dstLockDiags)
+		// Get single required_providers entry for state store provider.
+		dstReq, dstReqDiags := c.getDestinationStateStoreProviderRequirements(rootMod.StateStore.ProviderAddr, rootMod.ProviderRequirements)
+		diags = diags.Append(dstReqDiags)
+		if dstReqDiags.HasErrors() {
 			stateMigrate.Diagnostics(diags)
 			return 1
-		} else {
-			diags = diags.Append(dstLockDiags)
+		}
 
-			dstB, _, _, dstDiags := c.Meta.stateStoreInitFromConfig(rootMod.StateStore, dstLocks)
-			diags = diags.Append(dstDiags)
-			if !diags.HasErrors() {
-				migrateOpts.DestinationType = rootMod.StateStore.Type
-				migrateOpts.Destination = dstB
-			}
+		// Load any pre-existing destination provider lock file.
+		dstLocks, dstLockDiags := c.readLockedDependenciesFromPath(args.DestinationLockFilePath)
+		diags = diags.Append(dstLockDiags)
+		if dstLockDiags.HasErrors() {
+			stateMigrate.Diagnostics(diags)
+			return 1
+		}
+
+		// Perform download of the destination provider.
+		// This may be controlled by a pre-existing lock from above or not, therefore the returned
+		// lock for the destination state store may not already be in the lock file.
+		//
+		// We only pass in a single required provider, so we expect a single lock to be
+		// returned. This will be added the dependency lock file after a successful migration.
+		upgrade := false // TODO - control this by -upgrade flag
+		var dstProviderDiags tfdiags.Diagnostics
+		_, destinationLock, dstProviderDiags = c.getSingleProvider(ctx, rootMod.StateStore.Type, dstReq, dstLocks, upgrade, MigrationDestination, stateMigrate)
+		diags = diags.Append(dstProviderDiags)
+		if dstProviderDiags.HasErrors() {
+			stateMigrate.Diagnostics(diags)
+			return 1
+		}
+
+		dstB, _, _, dstDiags := c.Meta.stateStoreInitFromConfig(rootMod.StateStore, destinationLock)
+		diags = diags.Append(dstDiags)
+		if !diags.HasErrors() {
+			migrateOpts.DestinationType = rootMod.StateStore.Type
+			migrateOpts.Destination = dstB
 		}
 	} else {
 		diags = diags.Append(tfdiags.Sourceless(
@@ -152,6 +200,27 @@ func (c *StateMigrateCommand) Run(rawArgs []string) int {
 		diags = diags.Append(fmt.Errorf("migration failed: %w", err))
 		stateMigrate.Diagnostics(diags)
 		return 1
+	}
+
+	// After a successful migration to a state store, we must make sure the dependency lock file contains the
+	// details of the destination state store provider.
+	if rootMod.StateStore != nil {
+		originalLocks, originalLockDiags := c.lockedDependencies()
+		diags = diags.Append(originalLockDiags)
+		if originalLockDiags.HasErrors() {
+			stateMigrate.Diagnostics(diags)
+			return 1
+		}
+		output, depLockFileDiags := c.saveDependencyLockFile(originalLocks, destinationLock, stateMigrate)
+		diags = diags.Append(depLockFileDiags)
+		if depLockFileDiags.HasErrors() {
+			stateMigrate.Diagnostics(diags)
+			return 1
+		}
+
+		if output {
+			stateMigrate.LogInitMessage(views.EmptyMessage)
+		}
 	}
 
 	stateMigrate.Diagnostics(diags)
@@ -188,4 +257,179 @@ Options:
 
 func (c *StateMigrateCommand) Synopsis() string {
 	return "Migrate the state from one location to another"
+}
+
+const (
+	MigrationSource      = "source"
+	MigrationDestination = "destination"
+)
+
+func (c *StateMigrateCommand) getDestinationStateStoreProviderRequirements(provider addrs.Provider, configReqs *configs.RequiredProviders) (providerreqs.Requirements, tfdiags.Diagnostics) {
+	var diags tfdiags.Diagnostics
+	req := make(providerreqs.Requirements, 1)
+
+	if configReqs == nil {
+		panic(fmt.Sprintf("expected one provider requirement for the destination state store provider %q, but received empty data about required providers.", provider))
+	}
+
+	for _, providerReq := range configReqs.RequiredProviders {
+		if providerReq.Type.Equals(provider) {
+			con, err := providerreqs.ParseVersionConstraints(providerReq.Requirement.Required.String())
+			if err != nil {
+				diags = diags.Append(&hcl.Diagnostic{
+					Severity: hcl.DiagError,
+					Summary:  "Invalid version constraint syntax for state store provider",
+					// The errors returned by ParseVersionConstraint already include
+					// the section of input that was incorrect, so we don't need to
+					// include that here.
+					Detail:  fmt.Sprintf("Incorrect version constraint syntax: %s.", err.Error()),
+					Subject: providerReq.Requirement.DeclRange.Ptr(),
+				})
+			}
+			req[providerReq.Type] = con
+		}
+	}
+	if len(req) != 1 {
+		panic(fmt.Sprintf("expected exactly one provider requirement for the destination state store provider %q, got %d", provider, len(req)))
+	}
+
+	return req, diags
+}
+
+// saveDependencyLockFile overwrites the contents of the dependency lock file.
+// The calling code is expected to provide:
+// 1. the previous locks (if any)
+// 2. the lock for the destination state store provider (if any)
+func (c *StateMigrateCommand) saveDependencyLockFile(previousLocks, locksWithDstProvider *depsfile.Locks, view views.StateMigrate) (output bool, diags tfdiags.Diagnostics) {
+	// Get the combination of locks from both potential provider download steps.
+	newLocks := c.mergeLockedDependencies(previousLocks, locksWithDstProvider)
+
+	// If the provider dependencies have changed since the last run then we'll
+	// say a little about that in case the reader wasn't expecting a change.
+	if !newLocks.Equal(previousLocks) {
+		// Jump in here and add a warning if any of the providers are incomplete.
+		if len(c.incompleteProviders) > 0 {
+			// We don't really care about the order here, we just want the
+			// output to be deterministic.
+			sort.Slice(c.incompleteProviders, func(i, j int) bool {
+				return c.incompleteProviders[i] < c.incompleteProviders[j]
+			})
+			diags = diags.Append(tfdiags.Sourceless(
+				tfdiags.Warning,
+				incompleteLockFileInformationHeader,
+				fmt.Sprintf(
+					incompleteLockFileInformationBody,
+					strings.Join(c.incompleteProviders, "\n  - "),
+					getproviders.CurrentPlatform.String())))
+		}
+		if previousLocks.Empty() {
+			// A change from empty to non-empty is special because it suggests
+			// we're running "terraform init" for the first time against a
+			// new configuration. In that case we'll take the opportunity to
+			// say a little about what the dependency lock file is, for new
+			// users or those who are upgrading from a previous Terraform
+			// version that didn't have dependency lock files.
+			view.LogInitMessage(views.LockInfo)
+			output = true
+		} else {
+			view.LogInitMessage(views.DependenciesLockChangesInfo)
+			output = true
+		}
+		lockFileDiags := c.replaceLockedDependencies(newLocks)
+		diags = diags.Append(lockFileDiags)
+	}
+	return output, diags
+}
+
+// getSingleProvider is used to download the source and/or destination state store providers during a state migration.
+// Download of the up to 2 providers is kept separate due to:
+// - Potential for downloading different versions of the same provider
+// - Need to keep the locks separate for source and destination providers; destination providers are added to the dependency lock file.
+func (c *StateMigrateCommand) getSingleProvider(ctx context.Context, storeName string, reqs providerreqs.Requirements, locks *depsfile.Locks, upgrade bool, location string, view views.StateMigrate) (output bool, resultingLock *depsfile.Locks, diags tfdiags.Diagnostics) {
+	ctx, span := tracer.Start(ctx, "install state migration "+location+" provider")
+	defer span.End()
+
+	// We expect to download only one provider
+	if len(reqs) != 1 {
+		panic(fmt.Sprintf("expected exactly one provider requirement for the destination state store provider, got %d", len(reqs)))
+	}
+
+	// Check for legacy provider addresses.
+	for providerAddr := range reqs {
+		if providerAddr.IsLegacy() {
+			diags = diags.Append(tfdiags.Sourceless(
+				tfdiags.Error,
+				"Invalid legacy provider address",
+				fmt.Sprintf(
+					"This configuration or its associated state refers to the unqualified provider %q.\n\nYou must complete the Terraform 0.13 upgrade process before upgrading to later versions.",
+					providerAddr.Type,
+				),
+			))
+		}
+	}
+	if diags.HasErrors() {
+		return false, nil, diags
+	}
+
+	// Use a source that looks for providers in all of the standard locations,
+	// possibly customized by the user in CLI config.
+	inst := c.providerInstaller()
+
+	// Because we're currently just streaming a series of events sequentially
+	// into the terminal, we're showing only a subset of the events to keep
+	// things relatively concise. Later it'd be nice to have a progress UI
+	// where statuses update in-place, but we can't do that as long as we
+	// are shimming our vt100 output to the legacy console API on Windows.
+	evts := &providercache.InstallerEvents{
+		PendingProviders: func(reqs map[addrs.Provider]getproviders.VersionConstraints) {
+			view.LogInitMessage(views.InitializingStateStoreProviderPluginMessage, storeName)
+		},
+		ProviderAlreadyInstalled: providerAlreadyInstalledCallback(view),
+		BuiltInProviderAvailable: builtInProviderAvailableCallback(view),
+		BuiltInProviderFailure:   builtInProviderFailureCallback(&diags),
+		QueryPackagesBegin: func(provider addrs.Provider, versionConstraints getproviders.VersionConstraints, locked bool) {
+			if locked {
+				view.LogInitMessage(views.ReusingPreviousVersionInfo, provider.ForDisplay())
+			} else {
+				if len(versionConstraints) > 0 {
+					view.LogInitMessage(views.FindingMatchingVersionMessage, provider.ForDisplay(), getproviders.VersionConstraintsString(versionConstraints))
+				} else {
+					view.LogInitMessage(views.FindingLatestVersionMessage, provider.ForDisplay())
+				}
+			}
+		},
+		LinkFromCacheBegin:   linkFromCacheBeginCallback(view),
+		FetchPackageBegin:    fetchPackageBeginCallback(view),
+		QueryPackagesFailure: queryPackagesFailureCallback(&diags, ctx, inst.ProviderSource(), reqs, nil),
+		QueryPackagesWarning: queryPackagesWarningCallback(&diags),
+		LinkFromCacheFailure: linkFromCacheFailureCallback(&diags),
+		FetchPackageFailure:  fetchPackageFailureCallback(&diags, reqs),
+		FetchPackageSuccess:  fetchPackageSuccessCallback(view),
+		ProvidersLockUpdated: providersLockUpdatedCallback(&c.incompleteProviders),
+		ProvidersFetched:     providersFetchedCallback(view),
+	}
+	ctx = evts.OnContext(ctx)
+
+	mode := providercache.InstallNewProvidersOnly
+	if upgrade {
+		mode = providercache.InstallUpgrades
+	}
+
+	newLocks, err := inst.EnsureProviderVersions(ctx, locks, reqs, mode)
+	if ctx.Err() == context.Canceled {
+		diags = diags.Append(fmt.Errorf("Provider installation was canceled by an interrupt signal."))
+		return true, nil, diags
+	}
+	if err != nil {
+		// The errors captured in "err" should be redundant with what we
+		// received via the InstallerEvents callbacks above, so we'll
+		// just return those as long as we have some.
+		if !diags.HasErrors() {
+			diags = diags.Append(err)
+		}
+
+		return true, nil, diags
+	}
+
+	return true, newLocks, diags
 }

--- a/internal/command/state_migrate.go
+++ b/internal/command/state_migrate.go
@@ -87,6 +87,7 @@ func (c *StateMigrateCommand) Run(rawArgs []string) int {
 
 	// Load the source backend
 	var source string
+	var sourceLock *depsfile.Locks // This should only contain a single lock, if non nil. Used to avoid re-download if destination provider is the same.
 	if smi.Backend != nil {
 		source = fmt.Sprintf("backend %q", smi.Backend.Type)
 
@@ -109,7 +110,8 @@ func (c *StateMigrateCommand) Run(rawArgs []string) int {
 		}
 
 		upgrade := false // The first provider download step will never be an upgrade. Either it's constrained by a preexisting lock or there is no lock.
-		_, sourceLock, srcProviderDiags := c.getSingleProvider(ctx, smi.StateStore.Type, smi.StateStoreProvider.Requirement, srcLocks, upgrade, MigrationSource, stateMigrate)
+		var srcProviderDiags tfdiags.Diagnostics
+		_, sourceLock, srcProviderDiags = c.getSingleProvider(ctx, smi.StateStore.Type, smi.StateStoreProvider.Requirement, srcLocks, upgrade, MigrationSource, stateMigrate)
 		diags = diags.Append(srcProviderDiags)
 		if srcProviderDiags.HasErrors() {
 			stateMigrate.Diagnostics(diags)
@@ -157,6 +159,19 @@ func (c *StateMigrateCommand) Run(rawArgs []string) int {
 			return 1
 		}
 
+		// The source provider download step may have introduced a new lock that can be re-used here.
+		// Else, this download step could re-download the same provider if the migration is between stores
+		// in the same provider.
+		//
+		// TODO: Make this conditional based on whether we're doing an upgrade or not?
+		//       Or is use of upgrade flag in second download sufficient?
+		var mergedLocks *depsfile.Locks
+		if sourceLock != nil {
+			mergedLocks = c.mergeLockedDependencies(dstLocks, sourceLock)
+		} else {
+			mergedLocks = dstLocks
+		}
+
 		// Perform download of the destination provider.
 		// This may be controlled by a pre-existing lock from above or not, therefore the returned
 		// lock for the destination state store may not already be in the lock file.
@@ -165,7 +180,7 @@ func (c *StateMigrateCommand) Run(rawArgs []string) int {
 		// returned. This will be added the dependency lock file after a successful migration.
 		upgrade := false // TODO - control this by -upgrade flag
 		var dstProviderDiags tfdiags.Diagnostics
-		_, destinationLock, dstProviderDiags = c.getSingleProvider(ctx, rootMod.StateStore.Type, dstReq, dstLocks, upgrade, MigrationDestination, stateMigrate)
+		_, destinationLock, dstProviderDiags = c.getSingleProvider(ctx, rootMod.StateStore.Type, dstReq, mergedLocks, upgrade, MigrationDestination, stateMigrate)
 		diags = diags.Append(dstProviderDiags)
 		if dstProviderDiags.HasErrors() {
 			stateMigrate.Diagnostics(diags)

--- a/internal/command/state_migrate_test.go
+++ b/internal/command/state_migrate_test.go
@@ -10,7 +10,9 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/cli"
+	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/command/workdir"
 	"github.com/hashicorp/terraform/internal/configs/configschema"
 	"github.com/hashicorp/terraform/internal/providers"
@@ -307,7 +309,361 @@ func TestStateMigrate_fromStateStoreToStateStore_inSingleProvider(t *testing.T) 
 	})
 }
 
-// Test migration from a state store to a backend, where the state store provider is already in the dependency lock file.
+// Test migration between two state stores in different providers.
+// Different cases describe whether the source provider is already in the dependency lock file or not.
+func TestStateMigrate_fromStateStoreToStateStore_inDifferentProviders(t *testing.T) {
+	t.Run("source provider already in the dependency lock file, destination is not", func(t *testing.T) {
+		wd := tempWorkingDirFixture(t, "state-store-changed/provider-used")
+		t.Chdir(wd.RootModuleDir())
+
+		b, err := os.ReadFile("source-pss.tfstate")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// hashicorp/test
+		sourcePssSchema := map[string]providers.Schema{
+			"test_src": {
+				Body: &configschema.Block{
+					Attributes: map[string]*configschema.Attribute{},
+				},
+			},
+		}
+		sourceProvider := mockPluggableStateStorageProvider(sourcePssSchema)
+		sourceProvider.MockStates = testing_provider.MockStateBytes{
+			"test_src": map[string][]byte{"default": []byte(b)},
+		}
+		// hashicorp/test2
+		destinationPssSchema := map[string]providers.Schema{
+			"test2_store": {
+				Body: &configschema.Block{
+					Attributes: map[string]*configschema.Attribute{},
+				},
+			},
+		}
+		destinationProvider := mockPluggableStateStorageProvider(destinationPssSchema)
+		destinationProvider.MockStates = testing_provider.MockStateBytes{
+			"test2_store": map[string][]byte{}, // No existing state in the destination
+		}
+		providerSource := newMockProviderSource(t, map[string][]string{
+			"hashicorp/test":  {"1.2.3"},
+			"hashicorp/test2": {"3.2.1"},
+		})
+
+		ui := cli.NewMockUi()
+		view, done := testView(t)
+		c := &StateMigrateCommand{
+			Meta: Meta{
+				Ui:                        ui,
+				View:                      view,
+				WorkingDir:                wd,
+				AllowExperimentalFeatures: true,
+				testingOverrides: &testingOverrides{
+					Providers: map[addrs.Provider]providers.Factory{
+						addrs.NewDefaultProvider("test"):  providers.FactoryFixed(sourceProvider),
+						addrs.NewDefaultProvider("test2"): providers.FactoryFixed(destinationProvider),
+					},
+				},
+				ProviderSource: providerSource,
+			},
+		}
+
+		_ = testInputMap(t, map[string]string{
+			"backend-migrate-copy-to-empty": "yes",
+		})
+
+		args := []string{"-no-color"}
+		code := c.Run(args)
+		out := done(t)
+		if code != 0 {
+			t.Fatalf("unexpected exit: %d\nstderr: %q", code, out.Stderr())
+		}
+
+		expectedMsg := []string{
+			"Initializing provider plugin for state store \"test_src\"...\n- Reusing previous version of hashicorp/test from the dependency lock file",
+			"Initializing provider plugin for state store \"test2_store\"...\n- Finding latest version of hashicorp/test2...\n- Installing hashicorp/test2 v3.2.1...\n- Installed hashicorp/test2 v3.2.1 (verified checksum)",
+			`Migrating state from state store "test_src" (hashicorp/test) to state store "test2_store" (hashicorp/test2)...`,
+		}
+		for _, expectedMsg := range expectedMsg {
+			if !strings.Contains(out.Stdout(), expectedMsg) {
+				t.Fatalf("expected output %q, got %q", expectedMsg, out.Stdout())
+			}
+		}
+
+		// Assert the state is migrated successfully to the destination state store by inspecting the mock.
+		b, err = destinationProvider.MockStates.Read("test2_store", "default")
+		if err != nil {
+			t.Fatalf("unable to find migrated state in mock provider: %s", err)
+		}
+		s, err := statefile.Read(bytes.NewBuffer(b))
+		if err != nil {
+			t.Fatal(err)
+		}
+		_, ok := s.State.RootOutputValues["test"]
+		if !ok {
+			t.Fatalf("unable to find test output in migrated state")
+		}
+
+		// Assert the destination provider is added to the dependency lock file
+		// Also, no providers have been removed from the file.
+		lockFilePath := filepath.Join(wd.RootModuleDir(), dependencyLockFilename)
+		lockFileBytes, err := os.ReadFile(lockFilePath)
+		if err != nil {
+			t.Fatalf("unable to read dependency lock file: %s", err)
+		}
+		expectedContents := `# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/test" {
+  version = "1.2.3"
+}
+
+provider "registry.terraform.io/hashicorp/test2" {
+  version = "3.2.1"
+  hashes = [
+    "h1:gv1gFnIZulslzchnaoyMJ5KoPvoRgVvSGb3tVS803iw=",
+  ]
+}
+`
+		if diff := cmp.Diff(expectedContents, string(lockFileBytes)); diff != "" {
+			t.Fatalf("unexpected dependency lock file contents, diff:\n%s", diff)
+		}
+	})
+	t.Run("destination provider already in the dependency lock file, source is not", func(t *testing.T) {
+		wd := tempWorkingDirFixture(t, "state-store-changed/provider-used")
+		t.Chdir(wd.RootModuleDir())
+
+		// Replace dep lock file in fixtures so that the destination provider is already in the dep lock file, but the source provider is not.
+		lockFileContents := `# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/test2" {
+  version = "3.2.1"
+}`
+		if err := os.WriteFile(filepath.Join(wd.RootModuleDir(), dependencyLockFilename), []byte(lockFileContents), 0644); err != nil {
+			t.Fatalf("unable to overwrite dependency lock file as part of test setup: %s", err)
+		}
+
+		b, err := os.ReadFile("source-pss.tfstate")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// hashicorp/test
+		sourcePssSchema := map[string]providers.Schema{
+			"test_src": {
+				Body: &configschema.Block{
+					Attributes: map[string]*configschema.Attribute{},
+				},
+			},
+		}
+		sourceProvider := mockPluggableStateStorageProvider(sourcePssSchema)
+		sourceProvider.MockStates = testing_provider.MockStateBytes{
+			"test_src": map[string][]byte{"default": []byte(b)},
+		}
+		// hashicorp/test2
+		destinationPssSchema := map[string]providers.Schema{
+			"test2_store": {
+				Body: &configschema.Block{
+					Attributes: map[string]*configschema.Attribute{},
+				},
+			},
+		}
+		destinationProvider := mockPluggableStateStorageProvider(destinationPssSchema)
+		destinationProvider.MockStates = testing_provider.MockStateBytes{
+			"test2_store": map[string][]byte{}, // No existing state in the destination
+		}
+		providerSource := newMockProviderSource(t, map[string][]string{
+			"hashicorp/test":  {"1.2.3"},
+			"hashicorp/test2": {"3.2.1"},
+		})
+
+		ui := cli.NewMockUi()
+		view, done := testView(t)
+		c := &StateMigrateCommand{
+			Meta: Meta{
+				Ui:                        ui,
+				View:                      view,
+				WorkingDir:                wd,
+				AllowExperimentalFeatures: true,
+				testingOverrides: &testingOverrides{
+					Providers: map[addrs.Provider]providers.Factory{
+						addrs.NewDefaultProvider("test"):  providers.FactoryFixed(sourceProvider),
+						addrs.NewDefaultProvider("test2"): providers.FactoryFixed(destinationProvider),
+					},
+				},
+				ProviderSource: providerSource,
+			},
+		}
+
+		_ = testInputMap(t, map[string]string{
+			"backend-migrate-copy-to-empty": "yes",
+		})
+
+		args := []string{"-no-color"}
+		code := c.Run(args)
+		out := done(t)
+		if code != 0 {
+			t.Fatalf("unexpected exit: %d\nstderr: %q", code, out.Stderr())
+		}
+
+		expectedMsg := []string{
+			"Initializing provider plugin for state store \"test_src\"...\n- Finding hashicorp/test versions matching \"1.2.3\"...\n- Installing hashicorp/test v1.2.3...\n- Installed hashicorp/test v1.2.3 (verified checksum)",
+			"Initializing provider plugin for state store \"test2_store\"...\n- Reusing previous version of hashicorp/test2 from the dependency lock file",
+			`Migrating state from state store "test_src" (hashicorp/test) to state store "test2_store" (hashicorp/test2)...`,
+		}
+		for _, expectedMsg := range expectedMsg {
+			if !strings.Contains(out.Stdout(), expectedMsg) {
+				t.Fatalf("expected output %q, got %q", expectedMsg, out.Stdout())
+			}
+		}
+
+		// Assert the state is migrated successfully to the destination state store by inspecting the mock.
+		b, err = destinationProvider.MockStates.Read("test2_store", "default")
+		if err != nil {
+			t.Fatalf("unable to find migrated state in mock provider: %s", err)
+		}
+		s, err := statefile.Read(bytes.NewBuffer(b))
+		if err != nil {
+			t.Fatal(err)
+		}
+		_, ok := s.State.RootOutputValues["test"]
+		if !ok {
+			t.Fatalf("unable to find test output in migrated state")
+		}
+
+		// Assert the dependency lock file is unchanged, as it was already in the lock file.
+		lockFilePath := filepath.Join(wd.RootModuleDir(), dependencyLockFilename)
+		lockFileBytes, err := os.ReadFile(lockFilePath)
+		if err != nil {
+			t.Fatalf("unable to read dependency lock file: %s", err)
+		}
+
+		if diff := cmp.Diff(lockFileContents, string(lockFileBytes)); diff != "" {
+			t.Fatalf("unexpected dependency lock file contents, diff:\n%s", diff)
+		}
+	})
+	t.Run("no existing dependency lock file: only destination provider saved to the dependency lock file", func(t *testing.T) {
+		wd := tempWorkingDirFixture(t, "state-store-changed/provider-used")
+		t.Chdir(wd.RootModuleDir())
+
+		// Remove lock file, so source provider isn't in the dep lock file for this test scenario
+		if err := os.Remove(filepath.Join(wd.RootModuleDir(), dependencyLockFilename)); err != nil {
+			t.Fatalf("error while deleting lock file during test setup: %s", err)
+		}
+
+		b, err := os.ReadFile("source-pss.tfstate")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// hashicorp/test
+		sourcePssSchema := map[string]providers.Schema{
+			"test_src": {
+				Body: &configschema.Block{
+					Attributes: map[string]*configschema.Attribute{},
+				},
+			},
+		}
+		sourceProvider := mockPluggableStateStorageProvider(sourcePssSchema)
+		sourceProvider.MockStates = testing_provider.MockStateBytes{
+			"test_src": map[string][]byte{"default": []byte(b)},
+		}
+		// hashicorp/test2
+		destinationPssSchema := map[string]providers.Schema{
+			"test2_store": {
+				Body: &configschema.Block{
+					Attributes: map[string]*configschema.Attribute{},
+				},
+			},
+		}
+		destinationProvider := mockPluggableStateStorageProvider(destinationPssSchema)
+		destinationProvider.MockStates = testing_provider.MockStateBytes{
+			"test2_store": map[string][]byte{}, // No existing state in the destination
+		}
+		providerSource := newMockProviderSource(t, map[string][]string{
+			"hashicorp/test":  {"1.2.3"},
+			"hashicorp/test2": {"3.2.1"},
+		})
+
+		ui := cli.NewMockUi()
+		view, done := testView(t)
+		c := &StateMigrateCommand{
+			Meta: Meta{
+				Ui:                        ui,
+				View:                      view,
+				WorkingDir:                wd,
+				AllowExperimentalFeatures: true,
+				testingOverrides: &testingOverrides{
+					Providers: map[addrs.Provider]providers.Factory{
+						addrs.NewDefaultProvider("test"):  providers.FactoryFixed(sourceProvider),
+						addrs.NewDefaultProvider("test2"): providers.FactoryFixed(destinationProvider),
+					},
+				},
+				ProviderSource: providerSource,
+			},
+		}
+
+		_ = testInputMap(t, map[string]string{
+			"backend-migrate-copy-to-empty": "yes",
+		})
+
+		args := []string{"-no-color"}
+		code := c.Run(args)
+		out := done(t)
+		if code != 0 {
+			t.Fatalf("unexpected exit: %d\nstderr: %q", code, out.Stderr())
+		}
+
+		expectedMsg := []string{
+			"Initializing provider plugin for state store \"test_src\"...\n- Finding hashicorp/test versions matching \"1.2.3\"...\n- Installing hashicorp/test v1.2.3...\n- Installed hashicorp/test v1.2.3 (verified checksum)",
+			"Initializing provider plugin for state store \"test2_store\"...\n- Finding latest version of hashicorp/test2...\n- Installing hashicorp/test2 v3.2.1...\n- Installed hashicorp/test2 v3.2.1 (verified checksum)",
+			`Migrating state from state store "test_src" (hashicorp/test) to state store "test2_store" (hashicorp/test2)...`,
+		}
+		for _, expectedMsg := range expectedMsg {
+			if !strings.Contains(out.Stdout(), expectedMsg) {
+				t.Fatalf("expected output %q, got %q", expectedMsg, out.Stdout())
+			}
+		}
+
+		// Assert the state is migrated successfully to the destination state store by inspecting the mock.
+		b, err = destinationProvider.MockStates.Read("test2_store", "default")
+		if err != nil {
+			t.Fatalf("unable to find migrated state in mock provider: %s", err)
+		}
+		s, err := statefile.Read(bytes.NewBuffer(b))
+		if err != nil {
+			t.Fatal(err)
+		}
+		_, ok := s.State.RootOutputValues["test"]
+		if !ok {
+			t.Fatalf("unable to find test output in migrated state")
+		}
+
+		// Assert the provider is added to the dependency lock file
+		lockFilePath := filepath.Join(wd.RootModuleDir(), dependencyLockFilename)
+		lockFileBytes, err := os.ReadFile(lockFilePath)
+		if err != nil {
+			t.Fatalf("unable to read dependency lock file: %s", err)
+		}
+
+		// The source provider is not added here, as it's not used post-migration.
+		expectedContents := `# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/test2" {
+  version = "3.2.1"
+  hashes = [
+    "h1:gv1gFnIZulslzchnaoyMJ5KoPvoRgVvSGb3tVS803iw=",
+  ]
+}
+`
+		if diff := cmp.Diff(expectedContents, string(lockFileBytes)); diff != "" {
+			t.Fatalf("unexpected dependency lock file contents, diff:\n%s", diff)
+		}
+	})
+}
+
 func TestStateMigrate_fromStateStoreToBackend(t *testing.T) {
 	wd := tempWorkingDirFixture(t, "state-migrate-state-store-to-backend")
 	t.Chdir(wd.RootModuleDir())

--- a/internal/command/state_migrate_test.go
+++ b/internal/command/state_migrate_test.go
@@ -130,82 +130,181 @@ func TestStateMigrate_fromBackendToStateStore(t *testing.T) {
 // Testing migration between two state stores in a single provider.
 // Different cases describe whether the source provider is already in the dependency lock file or not.
 func TestStateMigrate_fromStateStoreToStateStore_inSingleProvider(t *testing.T) {
-	wd := tempWorkingDirFixture(t, "state-migrate-state-store-to-state-store")
-	t.Chdir(wd.RootModuleDir())
+	t.Run("provider is already in the dependency lock file", func(t *testing.T) {
+		wd := tempWorkingDirFixture(t, "state-migrate-state-store-to-state-store")
+		t.Chdir(wd.RootModuleDir())
 
-	b, err := os.ReadFile("source-pss.tfstate")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	pssSchemas := map[string]providers.Schema{
-		"test_src": {
-			Body: &configschema.Block{
-				Attributes: map[string]*configschema.Attribute{},
-			},
-		},
-		"test_dst": {
-			Body: &configschema.Block{
-				Attributes: map[string]*configschema.Attribute{},
-			},
-		},
-	}
-	p := mockPluggableStateStorageProvider(pssSchemas)
-	p.MockStates = testing_provider.MockStateBytes{
-		"test_src": map[string][]byte{"default": []byte(b)},
-		"test_dst": map[string][]byte{},
-	}
-	providerSource := newMockProviderSource(t, map[string][]string{
-		"hashicorp/test": {"1.2.3"},
-	})
-
-	ui := cli.NewMockUi()
-	view, done := testView(t)
-	c := &StateMigrateCommand{
-		Meta: Meta{
-			Ui:                        ui,
-			View:                      view,
-			WorkingDir:                wd,
-			AllowExperimentalFeatures: true,
-			testingOverrides:          metaOverridesForProvider(p),
-			ProviderSource:            providerSource,
-		},
-	}
-
-	_ = testInputMap(t, map[string]string{
-		"backend-migrate-copy-to-empty": "yes",
-	})
-
-	args := []string{"-no-color"}
-	code := c.Run(args)
-	out := done(t)
-	if code != 0 {
-		t.Fatalf("unexpected exit: %d\nstderr: %q", code, out.Stderr())
-	}
-
-	expectedMsg := []string{
-		`Migrating state from state store "test_src" (hashicorp/test) to state store "test_dst" (hashicorp/test)...`,
-		"Initializing provider plugin for state store \"test_src\"...\n- Reusing previous version of hashicorp/test from the dependency lock file",
-		"Initializing provider plugin for state store \"test_dst\"...\n- Reusing previous version of hashicorp/test from the dependency lock file",
-	}
-	for _, expectedMsg := range expectedMsg {
-		if !strings.Contains(out.Stdout(), expectedMsg) {
-			t.Fatalf("expected output %q, got %q", expectedMsg, out.Stdout())
+		b, err := os.ReadFile("source-pss.tfstate")
+		if err != nil {
+			t.Fatal(err)
 		}
-	}
 
-	b, err = p.MockStates.Read("test_dst", "default")
-	if err != nil {
-		t.Fatalf("unable to find migrated state in mock provider: %s", err)
-	}
-	s, err := statefile.Read(bytes.NewBuffer(b))
-	if err != nil {
-		t.Fatal(err)
-	}
-	_, ok := s.State.RootOutputValues["test"]
-	if !ok {
-		t.Fatalf("unable to find test output in migrated state")
-	}
+		pssSchemas := map[string]providers.Schema{
+			"test_src": {
+				Body: &configschema.Block{
+					Attributes: map[string]*configschema.Attribute{},
+				},
+			},
+			"test_dst": {
+				Body: &configschema.Block{
+					Attributes: map[string]*configschema.Attribute{},
+				},
+			},
+		}
+		p := mockPluggableStateStorageProvider(pssSchemas)
+		p.MockStates = testing_provider.MockStateBytes{
+			"test_src": map[string][]byte{"default": []byte(b)},
+			"test_dst": map[string][]byte{},
+		}
+		providerSource := newMockProviderSource(t, map[string][]string{
+			"hashicorp/test": {"1.2.3"},
+		})
+
+		ui := cli.NewMockUi()
+		view, done := testView(t)
+		c := &StateMigrateCommand{
+			Meta: Meta{
+				Ui:                        ui,
+				View:                      view,
+				WorkingDir:                wd,
+				AllowExperimentalFeatures: true,
+				testingOverrides:          metaOverridesForProvider(p),
+				ProviderSource:            providerSource,
+			},
+		}
+
+		_ = testInputMap(t, map[string]string{
+			"backend-migrate-copy-to-empty": "yes",
+		})
+
+		args := []string{"-no-color"}
+		code := c.Run(args)
+		out := done(t)
+		if code != 0 {
+			t.Fatalf("unexpected exit: %d\nstderr: %q", code, out.Stderr())
+		}
+
+		expectedMsg := []string{
+			`Migrating state from state store "test_src" (hashicorp/test) to state store "test_dst" (hashicorp/test)...`,
+			"Initializing provider plugin for state store \"test_src\"...\n- Reusing previous version of hashicorp/test from the dependency lock file",
+			"Initializing provider plugin for state store \"test_dst\"...\n- Reusing previous version of hashicorp/test from the dependency lock file",
+		}
+		for _, expectedMsg := range expectedMsg {
+			if !strings.Contains(out.Stdout(), expectedMsg) {
+				t.Fatalf("expected output %q, got %q", expectedMsg, out.Stdout())
+			}
+		}
+
+		b, err = p.MockStates.Read("test_dst", "default")
+		if err != nil {
+			t.Fatalf("unable to find migrated state in mock provider: %s", err)
+		}
+		s, err := statefile.Read(bytes.NewBuffer(b))
+		if err != nil {
+			t.Fatal(err)
+		}
+		_, ok := s.State.RootOutputValues["test"]
+		if !ok {
+			t.Fatalf("unable to find test output in migrated state")
+		}
+	})
+
+	t.Run("no existing dependency lock file: provider is downloaded and added to the dependency lock file", func(t *testing.T) {
+		wd := tempWorkingDirFixture(t, "state-migrate-state-store-to-state-store")
+		t.Chdir(wd.RootModuleDir())
+
+		// In this scenario, there is no provider in the dep lock file
+		// Achieve this by truncating the dep lock file from the copied fixtures
+		if err := os.Truncate(filepath.Join(wd.RootModuleDir(), dependencyLockFilename), 0); err != nil {
+			t.Fatalf("error while truncating lock file during test setup: %s", err)
+		}
+
+		b, err := os.ReadFile("source-pss.tfstate")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		pssSchemas := map[string]providers.Schema{
+			"test_src": {
+				Body: &configschema.Block{
+					Attributes: map[string]*configschema.Attribute{},
+				},
+			},
+			"test_dst": {
+				Body: &configschema.Block{
+					Attributes: map[string]*configschema.Attribute{},
+				},
+			},
+		}
+		p := mockPluggableStateStorageProvider(pssSchemas)
+		p.MockStates = testing_provider.MockStateBytes{
+			"test_src": map[string][]byte{"default": []byte(b)},
+			"test_dst": map[string][]byte{},
+		}
+		providerSource := newMockProviderSource(t, map[string][]string{
+			"hashicorp/test": {"1.2.3"},
+		})
+
+		ui := cli.NewMockUi()
+		view, done := testView(t)
+		c := &StateMigrateCommand{
+			Meta: Meta{
+				Ui:                        ui,
+				View:                      view,
+				WorkingDir:                wd,
+				AllowExperimentalFeatures: true,
+				testingOverrides:          metaOverridesForProvider(p),
+				ProviderSource:            providerSource,
+			},
+		}
+
+		_ = testInputMap(t, map[string]string{
+			"backend-migrate-copy-to-empty": "yes",
+		})
+
+		args := []string{"-no-color"}
+		code := c.Run(args)
+		out := done(t)
+		if code != 0 {
+			t.Fatalf("unexpected exit: %d\nstderr: %q", code, out.Stderr())
+		}
+
+		expectedMsg := []string{
+			`Migrating state from state store "test_src" (hashicorp/test) to state store "test_dst" (hashicorp/test)...`,
+			"Initializing provider plugin for state store \"test_src\"...\n- Finding hashicorp/test versions matching \"1.2.3\"...\n- Installing hashicorp/test v1.2.3...\n- Installed hashicorp/test v1.2.3 (verified checksum)",
+			"Initializing provider plugin for state store \"test_dst\"...\n- Reusing previous version of hashicorp/test from the dependency lock file\n- Using previously-installed hashicorp/test v1.2.3",
+		}
+		for _, expectedMsg := range expectedMsg {
+			if !strings.Contains(out.Stdout(), expectedMsg) {
+				t.Fatalf("expected output %q, got %q", expectedMsg, out.Stdout())
+			}
+		}
+
+		// Assert the state is migrated successfully to the
+		// destination state store by inspecting the mock.
+		b, err = p.MockStates.Read("test_dst", "default")
+		if err != nil {
+			t.Fatalf("unable to find migrated state in mock provider: %s", err)
+		}
+		s, err := statefile.Read(bytes.NewBuffer(b))
+		if err != nil {
+			t.Fatal(err)
+		}
+		_, ok := s.State.RootOutputValues["test"]
+		if !ok {
+			t.Fatalf("unable to find test output in migrated state")
+		}
+
+		// Assert the provider is added to the dependency lock file
+		lockFilePath := filepath.Join(wd.RootModuleDir(), dependencyLockFilename)
+		lockFileBytes, err := os.ReadFile(lockFilePath)
+		if err != nil {
+			t.Fatalf("unable to read dependency lock file: %s", err)
+		}
+		if !strings.Contains(string(lockFileBytes), "hashicorp/test") {
+			t.Fatalf("expected provider hashicorp/test to be added to the dependency lock file, got: %s", string(lockFileBytes))
+		}
+	})
 }
 
 // Test migration from a state store to a backend, where the state store provider is already in the dependency lock file.

--- a/internal/command/state_migrate_test.go
+++ b/internal/command/state_migrate_test.go
@@ -76,7 +76,7 @@ func TestStateMigrate_fromBackendToStateStore(t *testing.T) {
 	p := mockPluggableStateStorageProvider(mockSingleStateStoreSchema("test_store"))
 	p.MockStates = testing_provider.NewMockStateBytesWithStateIds("test_store", []string{"default"})
 	providerSource := newMockProviderSource(t, map[string][]string{
-		"hashicorp/test": {"1.0.0"},
+		"hashicorp/test": {"1.2.3"},
 	})
 
 	ui := cli.NewMockUi()
@@ -103,9 +103,14 @@ func TestStateMigrate_fromBackendToStateStore(t *testing.T) {
 		t.Fatalf("unexpected exit: %d\nstderr: %q", code, out.Stderr())
 	}
 
-	expectedMsg := `Migrating state from backend "local" to state store "test_store" (hashicorp/test)...`
-	if !strings.Contains(out.Stdout(), expectedMsg) {
-		t.Fatalf("expected output %q, got %q", expectedMsg, out.Stdout())
+	expectedMsg := []string{
+		"Initializing provider plugin for state store \"test_store\"...\n- Reusing previous version of hashicorp/test from the dependency lock file",
+		`Migrating state from backend "local" to state store "test_store" (hashicorp/test)...`,
+	}
+	for _, expectedMsg := range expectedMsg {
+		if !strings.Contains(out.Stdout(), expectedMsg) {
+			t.Fatalf("expected output %q, got %q", expectedMsg, out.Stdout())
+		}
 	}
 
 	b, err := p.MockStates.Read("test_store", "default")
@@ -122,7 +127,9 @@ func TestStateMigrate_fromBackendToStateStore(t *testing.T) {
 	}
 }
 
-func TestStateMigrate_fromStateStoreToStateStore(t *testing.T) {
+// Testing migration between two state stores in a single provider.
+// Different cases describe whether the source provider is already in the dependency lock file or not.
+func TestStateMigrate_fromStateStoreToStateStore_inSingleProvider(t *testing.T) {
 	wd := tempWorkingDirFixture(t, "state-migrate-state-store-to-state-store")
 	t.Chdir(wd.RootModuleDir())
 
@@ -149,7 +156,7 @@ func TestStateMigrate_fromStateStoreToStateStore(t *testing.T) {
 		"test_dst": map[string][]byte{},
 	}
 	providerSource := newMockProviderSource(t, map[string][]string{
-		"hashicorp/test": {"1.0.0"},
+		"hashicorp/test": {"1.2.3"},
 	})
 
 	ui := cli.NewMockUi()
@@ -176,9 +183,15 @@ func TestStateMigrate_fromStateStoreToStateStore(t *testing.T) {
 		t.Fatalf("unexpected exit: %d\nstderr: %q", code, out.Stderr())
 	}
 
-	expectedMsg := `Migrating state from state store "test_src" (hashicorp/test) to state store "test_dst" (hashicorp/test)...`
-	if !strings.Contains(out.Stdout(), expectedMsg) {
-		t.Fatalf("expected output %q, got %q", expectedMsg, out.Stdout())
+	expectedMsg := []string{
+		`Migrating state from state store "test_src" (hashicorp/test) to state store "test_dst" (hashicorp/test)...`,
+		"Initializing provider plugin for state store \"test_src\"...\n- Reusing previous version of hashicorp/test from the dependency lock file",
+		"Initializing provider plugin for state store \"test_dst\"...\n- Reusing previous version of hashicorp/test from the dependency lock file",
+	}
+	for _, expectedMsg := range expectedMsg {
+		if !strings.Contains(out.Stdout(), expectedMsg) {
+			t.Fatalf("expected output %q, got %q", expectedMsg, out.Stdout())
+		}
 	}
 
 	b, err = p.MockStates.Read("test_dst", "default")
@@ -195,6 +208,7 @@ func TestStateMigrate_fromStateStoreToStateStore(t *testing.T) {
 	}
 }
 
+// Test migration from a state store to a backend, where the state store provider is already in the dependency lock file.
 func TestStateMigrate_fromStateStoreToBackend(t *testing.T) {
 	wd := tempWorkingDirFixture(t, "state-migrate-state-store-to-backend")
 	t.Chdir(wd.RootModuleDir())
@@ -211,7 +225,7 @@ func TestStateMigrate_fromStateStoreToBackend(t *testing.T) {
 	)
 
 	providerSource := newMockProviderSource(t, map[string][]string{
-		"hashicorp/test": {"1.0.0"},
+		"hashicorp/test": {"1.2.3"},
 	})
 
 	ui := cli.NewMockUi()
@@ -238,9 +252,14 @@ func TestStateMigrate_fromStateStoreToBackend(t *testing.T) {
 		t.Fatalf("unexpected exit: %d\nstderr: %q", code, out.Stderr())
 	}
 
-	expectedMsg := `Migrating state from state store "test_store" (hashicorp/test) to backend "local"...`
-	if !strings.Contains(out.Stdout(), expectedMsg) {
-		t.Fatalf("expected output %q, got %q", expectedMsg, out.Stdout())
+	expectedMsg := []string{
+		"Initializing provider plugin for state store \"test_store\"...\n- Reusing previous version of hashicorp/test from the dependency lock file",
+		`Migrating state from state store "test_store" (hashicorp/test) to backend "local"...`,
+	}
+	for _, expectedMsg := range expectedMsg {
+		if !strings.Contains(out.Stdout(), expectedMsg) {
+			t.Fatalf("expected output %q, got %q", expectedMsg, out.Stdout())
+		}
 	}
 
 	f, err := os.Open("destination-backend.tfstate")
@@ -267,6 +286,10 @@ func TestStateMigrate_missingModuleFiles(t *testing.T) {
 	wd := tempWorkingDirFixture(t, "state-migrate-missing-mod-files")
 	t.Chdir(wd.RootModuleDir())
 
+	providerSource := newMockProviderSource(t, map[string][]string{
+		"hashicorp/test": {"1.2.3"},
+	})
+
 	ui := cli.NewMockUi()
 	view, done := testView(t)
 	c := &StateMigrateCommand{
@@ -275,6 +298,7 @@ func TestStateMigrate_missingModuleFiles(t *testing.T) {
 			View:                      view,
 			WorkingDir:                wd,
 			AllowExperimentalFeatures: true,
+			ProviderSource:            providerSource,
 		},
 	}
 
@@ -298,6 +322,10 @@ func TestStateMigrate_emptyModuleFiles(t *testing.T) {
 	wd := tempWorkingDirFixture(t, "state-migrate-empty-mod-files")
 	t.Chdir(wd.RootModuleDir())
 
+	providerSource := newMockProviderSource(t, map[string][]string{
+		"hashicorp/test": {"1.2.3"},
+	})
+
 	ui := cli.NewMockUi()
 	view, done := testView(t)
 	c := &StateMigrateCommand{
@@ -306,6 +334,7 @@ func TestStateMigrate_emptyModuleFiles(t *testing.T) {
 			View:                      view,
 			WorkingDir:                wd,
 			AllowExperimentalFeatures: true,
+			ProviderSource:            providerSource,
 		},
 	}
 

--- a/internal/command/testdata/state-store-changed/provider-used/.terraform/terraform.tfstate
+++ b/internal/command/testdata/state-store-changed/provider-used/.terraform/terraform.tfstate
@@ -4,9 +4,7 @@
     "lineage": "666f9301-7e65-4b19-ae23-71184bb19b03",
     "state_store": {
         "type": "test_store",
-        "config": {
-            "value": "foobar"
-        },
+        "config": {},
         "provider": {
             "version": "1.2.3",
             "source": "registry.terraform.io/hashicorp/test",

--- a/internal/command/testdata/state-store-changed/provider-used/main.tf
+++ b/internal/command/testdata/state-store-changed/provider-used/main.tf
@@ -11,6 +11,5 @@ terraform {
       region = "foobar"
     }
 
-    value = "foobar"
   }
 }

--- a/internal/command/testdata/state-store-changed/provider-used/pss.tfmigrate.hcl
+++ b/internal/command/testdata/state-store-changed/provider-used/pss.tfmigrate.hcl
@@ -1,0 +1,12 @@
+state_store_provider {
+  test = {
+    source = "hashicorp/test"
+    version = "1.2.3"
+  }
+}
+
+from {
+  state_store "test_src" {
+    provider "test" {}
+  }
+}

--- a/internal/command/testdata/state-store-changed/provider-used/source-pss.tfstate
+++ b/internal/command/testdata/state-store-changed/provider-used/source-pss.tfstate
@@ -1,0 +1,14 @@
+{
+    "version": 4,
+    "terraform_version": "1.16.0",
+    "serial": 1,
+    "lineage": "8595356e-c764-dea1-8dae-156b936ec6e2",
+    "outputs": {
+        "test": {
+            "value": "test",
+            "type": "string"
+        }
+    },
+    "resources": [],
+    "check_results": null
+}

--- a/internal/command/views/state_migrate.go
+++ b/internal/command/views/state_migrate.go
@@ -5,6 +5,7 @@ package views
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/hashicorp/terraform/internal/command/arguments"
 	"github.com/hashicorp/terraform/internal/tfdiags"
@@ -13,6 +14,8 @@ import (
 type StateMigrate interface {
 	Log(message string, params ...any)
 	Diagnostics(diags tfdiags.Diagnostics)
+
+	ProviderInstaller
 }
 
 func NewStateMigrate(viewType arguments.ViewType, view *View) StateMigrate {
@@ -24,6 +27,11 @@ func NewStateMigrate(viewType arguments.ViewType, view *View) StateMigrate {
 	}
 }
 
+var (
+	_ StateMigrate      = (*StateMigrateHuman)(nil)
+	_ ProviderInstaller = (*StateMigrateHuman)(nil)
+)
+
 type StateMigrateHuman struct {
 	view *View
 }
@@ -34,4 +42,38 @@ func (s *StateMigrateHuman) Diagnostics(diags tfdiags.Diagnostics) {
 
 func (s *StateMigrateHuman) Log(message string, params ...any) {
 	s.view.streams.Println(fmt.Sprintf(message, params...))
+}
+
+// Implements ProviderInstaller interface.
+func (s *StateMigrateHuman) LogInitMessage(code InitMessageCode, params ...any) {
+	msg, ok := MessageRegistry[code]
+	if !ok {
+		panic("missing message for InstallingProviderMessage init message code")
+	}
+	s.Log(msg.HumanValue, params...)
+}
+
+// Implements ProviderInstaller interface.
+func (s *StateMigrateHuman) Output(code InitMessageCode, params ...any) {
+	msg, ok := MessageRegistry[code]
+	if !ok {
+		panic("missing message for InstallingProviderMessage init message code")
+	}
+	s.Log(msg.HumanValue, params...)
+}
+
+// Implements ProviderInstaller interface.
+func (s *StateMigrateHuman) PrepareMessage(code InitMessageCode, params ...any) string {
+	message, ok := MessageRegistry[code]
+	if !ok {
+		// display the message code as fallback if not found in the message registry
+		return string(code)
+	}
+
+	if message.HumanValue == "" {
+		// no need to apply colorization if the message is empty
+		return message.HumanValue
+	}
+
+	return s.view.colorize.Color(strings.TrimSpace(fmt.Sprintf(message.HumanValue, params...)))
 }


### PR DESCRIPTION
This PR updates `state migrate` to be able to download providers and, depending on the situation, update the dependency lock file.

If a state migration involves 1 or more state stores then the provider implementing those stores may need to be downloaded. There are situations where 0, 1, or 2 providers may need to be downloaded:
- **0** : The 1 or 2 providers used for source and destination state stores are in the dep lock file already.
- **1** : Either the provider used for both source and destination isn't downloaded (or there's no dep lock file), or one of the source or destination providers isn't present.
- **2**: Neither of the source and destination state stores' providers are present in the dependency lock file.

The provider used for the destination state store **must** be in the dep lock file after a successful migration. If the migration fails then the lock file will be untouched, but if it succeeds then the destination provider will either be added to or upgraded in the dependency lock file. Note: upgrade is not yet implemented, and will be a separate PR.

The process of updating the dependency lock file will never remove a provider. If the provider used for the source state store is present in the lock file but isn't present in the configuration (i.e. it was removed from required_providers when the config was changed to describe the new location for storing state) then its removal from the lock file will happen in a subsequent init command. This is because the `state migrate` command does not load the full configuration, only the root module, so it doesn't know about the configuration's full provider requirements. And that's not considering the state's provider requirements. Basically, `state migrate` does not manage the complete dependency lock file, but instead manages a single entry inside it.

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.16.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
