### PR TITLE
init: Simplify JSON output to remove unused JSON log content

### DIFF
--- a/internal/command/init.go
+++ b/internal/command/init.go
@@ -486,12 +486,12 @@ func (c *InitCommand) getProvidersFromPSSConfig(ctx context.Context, rootModEarl
 		BuiltInProviderFailure:   builtInProviderFailureCallback(&diags),
 		QueryPackagesBegin: func(provider addrs.Provider, versionConstraints getproviders.VersionConstraints, locked bool) {
 			if locked {
-				view.LogInitMessage(views.ReusingPreviousVersionInfo, provider.ForDisplay())
+				view.Output(views.ReusingPreviousVersionInfo, provider.ForDisplay())
 			} else {
 				if len(versionConstraints) > 0 {
-					view.LogInitMessage(views.FindingMatchingVersionMessage, provider.ForDisplay(), getproviders.VersionConstraintsString(versionConstraints))
+					view.Output(views.FindingMatchingVersionMessage, provider.ForDisplay(), getproviders.VersionConstraintsString(versionConstraints))
 				} else {
-					view.LogInitMessage(views.FindingLatestVersionMessage, provider.ForDisplay())
+					view.Output(views.FindingLatestVersionMessage, provider.ForDisplay())
 				}
 			}
 		},
@@ -677,12 +677,12 @@ func (c *InitCommand) getProviders(ctx context.Context, config *configs.Config, 
 		BuiltInProviderFailure:   builtInProviderFailureCallback(&diags),
 		QueryPackagesBegin: func(provider addrs.Provider, versionConstraints getproviders.VersionConstraints, locked bool) {
 			if locked {
-				view.LogInitMessage(views.ReusingPreviousVersionInfo, provider.ForDisplay())
+				view.Output(views.ReusingPreviousVersionInfo, provider.ForDisplay())
 			} else {
 				if len(versionConstraints) > 0 {
-					view.LogInitMessage(views.FindingMatchingVersionMessage, provider.ForDisplay(), getproviders.VersionConstraintsString(versionConstraints))
+					view.Output(views.FindingMatchingVersionMessage, provider.ForDisplay(), getproviders.VersionConstraintsString(versionConstraints))
 				} else {
-					view.LogInitMessage(views.FindingLatestVersionMessage, provider.ForDisplay())
+					view.Output(views.FindingLatestVersionMessage, provider.ForDisplay())
 				}
 			}
 		},
@@ -1037,14 +1037,14 @@ func (c *InitCommand) Synopsis() string {
 // Returns a reused callback function for the ProviderAlreadyInstalled event in a providercache.InstallerEvents struct.
 func providerAlreadyInstalledCallback(view views.Init) func(provider addrs.Provider, selectedVersion getproviders.Version) {
 	return func(provider addrs.Provider, selectedVersion getproviders.Version) {
-		view.LogInitMessage(views.ProviderAlreadyInstalledMessage, provider.ForDisplay(), selectedVersion)
+		view.Output(views.ProviderAlreadyInstalledMessage, provider.ForDisplay(), selectedVersion)
 	}
 }
 
 // Returns a reused callback function for the BuiltInProviderAvailable event in a providercache.InstallerEvents struct.
 func builtInProviderAvailableCallback(view views.Init) func(provider addrs.Provider) {
 	return func(provider addrs.Provider) {
-		view.LogInitMessage(views.BuiltInProviderAvailableMessage, provider.ForDisplay())
+		view.Output(views.BuiltInProviderAvailableMessage, provider.ForDisplay())
 	}
 }
 
@@ -1062,14 +1062,14 @@ func builtInProviderFailureCallback(diags *tfdiags.Diagnostics) func(provider ad
 // Returns a reused callback function for the LinkFromCacheBegin event in a providercache.InstallerEvents struct.
 func linkFromCacheBeginCallback(view views.Init) func(provider addrs.Provider, version getproviders.Version, cacheRoot string) {
 	return func(provider addrs.Provider, version getproviders.Version, cacheRoot string) {
-		view.LogInitMessage(views.UsingProviderFromCacheDirInfo, provider.ForDisplay(), version)
+		view.Output(views.UsingProviderFromCacheDirInfo, provider.ForDisplay(), version)
 	}
 }
 
 // Returns a reused callback function for the FetchPackageBegin event in a providercache.InstallerEvents struct.
 func fetchPackageBeginCallback(view views.Init) func(provider addrs.Provider, version getproviders.Version, location getproviders.PackageLocation) {
 	return func(provider addrs.Provider, version getproviders.Version, location getproviders.PackageLocation) {
-		view.LogInitMessage(views.InstallingProviderMessage, provider.ForDisplay(), version)
+		view.Output(views.InstallingProviderMessage, provider.ForDisplay(), version)
 	}
 }
 
@@ -1318,7 +1318,7 @@ func fetchPackageSuccessCallback(view views.Init) func(provider addrs.Provider, 
 			keyID = view.PrepareMessage(views.KeyID, keyID)
 		}
 
-		view.LogInitMessage(views.InstalledProviderVersionInfo, provider.ForDisplay(), version, authResult, keyID)
+		view.Output(views.InstalledProviderVersionInfo, provider.ForDisplay(), version, authResult, keyID)
 	}
 }
 
@@ -1372,7 +1372,7 @@ func providersFetchedCallback(view views.Init) func(authResults map[addrs.Provid
 			}
 		}
 		if thirdPartySigned {
-			view.LogInitMessage(views.PartnerAndCommunityProvidersMessage)
+			view.Output(views.PartnerAndCommunityProvidersMessage)
 		}
 	}
 }

--- a/internal/command/init_policy_test.go
+++ b/internal/command/init_policy_test.go
@@ -22,7 +22,6 @@ import (
 )
 
 func TestInit_WithModulePolicy(t *testing.T) {
-
 	cases := []struct {
 		name     string
 		policy   *policy.EvaluationResponse
@@ -70,7 +69,6 @@ func TestInit_WithModulePolicy(t *testing.T) {
 		policyClient := policy.NewTestMockClient(t)
 
 		t.Run(tc.name, func(t *testing.T) {
-
 			policyClient.EvaluateModuleResponse = tc.policy
 			overrides.PolicyClient = policyClient
 
@@ -279,8 +277,8 @@ func TestInit_WithPolicySetupFailureJSON(t *testing.T) {
 		t.Fatalf("got exit status %d; want 1\nstderr:\n%s\n\nstdout:\n%s", code, output.Stderr(), output.Stdout())
 	}
 
-	expected := `{"@level":"info","@message":"Terraform 1.15.0-dev","@module":"terraform.ui","terraform":"1.15.0-dev","type":"version","ui":"1.3"}
-{"@level":"info","@message":"Initializing the backend...","@module":"terraform.ui","message_code":"initializing_backend_message","type":"init_output"}
+	expected := `{"@level":"info","@message":"Terraform 1.15.0-dev","@module":"terraform.ui","terraform":"1.15.0-dev","type":"version","ui":"2.0"}
+{"@level":"info","@message":"Initializing the backend...","@module":"terraform.ui","type":"log"}
 {"@level":"error","@message":"Error: Failed to connect to policy engine","@module":"terraform.ui","@policy":"true","policy_diagnostic":{"severity":"error","summary":"Failed to connect to policy engine","detail":"Failed to connect to policy engine: failed to connect to plugin: exec: \"tfpolicy-plugin\": executable file not found in $PATH."},"policy_metadata":{},"result":"SetupErrorResult","type":"policy_diagnostic"}`
 	checkGoldenReferenceStr(t, output, expected)
 }
@@ -502,8 +500,8 @@ func TestInit_WithModulePolicyJSON(t *testing.T) {
 	}
 
 	expected := `{"@level":"info","@message":"Terraform 1.15.0-dev","@module":"terraform.ui","terraform":"1.15.0-dev","type":"version","ui":"1.3"}
-{"@level":"info","@message":"Initializing the backend...","@module":"terraform.ui","message_code":"initializing_backend_message","type":"init_output"}
-{"@level":"info","@message":"Initializing modules...","@module":"terraform.ui","message_code":"initializing_modules_message","type":"init_output"}
+{"@level":"info","@message":"Initializing the backend...","@module":"terraform.ui","type":"log"}
+{"@level":"info","@message":"Initializing modules...","@module":"terraform.ui","type":"log"}
 {"@level":"error","@message":"Error: module policy denied","@module":"terraform.ui","@policy":"true","policy_diagnostic":{"severity":"error","summary":"module policy denied","detail":"","range":{"filename":"main.tf","start":{"line":6,"column":1,"byte":60},"end":{"line":6,"column":17,"byte":76}},"snippet":{"context":null,"code":"module \"example\" {","start_line":6,"highlight_start_offset":0,"highlight_end_offset":16,"values":[]}},"policy_metadata":{"policy_set_path":"policy_file.tfpolicy.hcl","policy_name":"module_policy.example","file_name":"policy_set.policy.hcl","enforcement_level":"mandatory"},"result":"DenyResult","target_address":"module.example","type":"policy_diagnostic"}
 {"@level":"info","@message":"Policy Result","@module":"terraform.ui","@policy":"true","target_address":"module.example","policy_address":"module_policy.example","policy_metadata":{"policy_set_path":"policy_file.tfpolicy.hcl","policy_name":"module_policy.example","file_name":"policy_set.policy.hcl","enforcement_level":"mandatory"},"result":"DenyResult","type":"policy_result"}
 {"@level":"error","@message":"Error: Policy evaluation failed","@module":"terraform.ui","diagnostic":{"severity":"error","summary":"Policy evaluation failed","detail":"Module download blocked due to policy violations. Please review other diagnostics for details."},"type":"diagnostic"}`

--- a/internal/command/testdata/init-get/output.jsonlog
+++ b/internal/command/testdata/init-get/output.jsonlog
@@ -1,7 +1,7 @@
 {"@level":"info","@message":"Terraform 1.9.0-dev","@module":"terraform.ui","terraform":"1.9.0-dev","type":"version","ui":"1.2"}
-{"@level":"info","@message":"Initializing the backend...","@module":"terraform.ui","message_code": "initializing_backend_message","type":"init_output"}
-{"@level":"info","@message":"Initializing modules...","@module":"terraform.ui","message_code": "initializing_modules_message","type":"init_output"}
+{"@level":"info","@message":"Initializing the backend...","@module":"terraform.ui","type":"log"}
+{"@level":"info","@message":"Initializing modules...","@module":"terraform.ui","type":"log"}
 {"@level":"info","@message":"- foo in foo","@module":"terraform.ui","type":"log"}
-{"@level":"info","@message":"Initializing provider plugins...","@module":"terraform.ui","message_code": "initializing_provider_plugin_message","type":"init_output"}
-{"@level":"info","@message":"Terraform has been successfully initialized!","@module":"terraform.ui","message_code": "output_init_success_message","type":"init_output"}
-{"@level":"info","@message":"You may now begin working with Terraform. Try running \"terraform plan\" to see\nany changes that are required for your infrastructure. All Terraform commands\nshould now work.\n\nIf you ever set or change modules or backend configuration for Terraform,\nrerun this command to reinitialize your working directory. If you forget, other\ncommands will detect it and remind you to do so if necessary.","@module":"terraform.ui","message_code": "output_init_success_cli_message","type":"init_output"}
+{"@level":"info","@message":"Initializing provider plugins...","@module":"terraform.ui","type":"log"}
+{"@level":"info","@message":"Terraform has been successfully initialized!","@module":"terraform.ui","type":"log"}
+{"@level":"info","@message":"You may now begin working with Terraform. Try running \"terraform plan\" to see\nany changes that are required for your infrastructure. All Terraform commands\nshould now work.\n\nIf you ever set or change modules or backend configuration for Terraform,\nrerun this command to reinitialize your working directory. If you forget, other\ncommands will detect it and remind you to do so if necessary.","@module":"terraform.ui","type":"log"}

--- a/internal/command/views/init.go
+++ b/internal/command/views/init.go
@@ -106,21 +106,7 @@ func (v *InitJSON) Output(messageCode InitMessageCode, params ...any) {
 		return
 	}
 
-	// Logged data includes by default:
-	// @level as "info"
-	// @module as "terraform.ui" (See NewJSONView)
-	// @timestamp formatted in the default way
-	//
-	// In the method below we:
-	// * Set @message as the first argument value
-	// * Annotate with extra data:
-	//     "type":"init_output"
-	//     "message_code":"<value>"
-	v.view.log.Info(
-		preppedMessage,
-		"type", "init_output",
-		"message_code", string(messageCode),
-	)
+	v.view.Log(preppedMessage)
 }
 
 func (v *InitJSON) LogInitMessage(messageCode InitMessageCode, params ...any) {

--- a/internal/command/views/init.go
+++ b/internal/command/views/init.go
@@ -18,7 +18,6 @@ type Init interface {
 	Diagnostics(diags tfdiags.Diagnostics)
 	PolicyResults(results *plans.PolicyResults, setupDiags policy.Diagnostics)
 	Output(messageCode InitMessageCode, params ...any)
-	LogInitMessage(messageCode InitMessageCode, params ...any)
 	Log(message string, params ...any)
 	PrepareMessage(messageCode InitMessageCode, params ...any) string
 }
@@ -56,10 +55,6 @@ func (v *InitHuman) PolicyResults(results *plans.PolicyResults, setupDiags polic
 }
 
 func (v *InitHuman) Output(messageCode InitMessageCode, params ...any) {
-	v.view.streams.Println(v.PrepareMessage(messageCode, params...))
-}
-
-func (v *InitHuman) LogInitMessage(messageCode InitMessageCode, params ...any) {
 	v.view.streams.Println(v.PrepareMessage(messageCode, params...))
 }
 
@@ -101,15 +96,6 @@ func (v *InitJSON) PolicyResults(results *plans.PolicyResults, setupDiags policy
 
 func (v *InitJSON) Output(messageCode InitMessageCode, params ...any) {
 	// don't add empty messages to json output
-	preppedMessage := v.PrepareMessage(messageCode, params...)
-	if preppedMessage == "" {
-		return
-	}
-
-	v.view.Log(preppedMessage)
-}
-
-func (v *InitJSON) LogInitMessage(messageCode InitMessageCode, params ...any) {
 	preppedMessage := v.PrepareMessage(messageCode, params...)
 	if preppedMessage == "" {
 		return

--- a/internal/command/views/init_test.go
+++ b/internal/command/views/init_test.go
@@ -386,7 +386,7 @@ func TestNewInit_jsonViewLog(t *testing.T) {
 		t.Fatalf("unexpected return type %t", newInit)
 	}
 
-	newInit.LogInitMessage(InitializingProviderPluginMessage)
+	newInit.Output(InitializingProviderPluginMessage)
 
 	version := tfversion.String()
 	want := []map[string]interface{}{

--- a/internal/command/views/init_test.go
+++ b/internal/command/views/init_test.go
@@ -297,11 +297,10 @@ func TestNewInit_jsonViewOutput(t *testing.T) {
 				"ui":        JSON_UI_VERSION,
 			},
 			{
-				"@level":       "info",
-				"@message":     "Initializing provider plugins...",
-				"message_code": "initializing_provider_plugin_message",
-				"@module":      "terraform.ui",
-				"type":         "log",
+				"@level":   "info",
+				"@message": "Initializing provider plugins...",
+				"@module":  "terraform.ui",
+				"type":     "log",
 			},
 		}
 
@@ -331,11 +330,10 @@ func TestNewInit_jsonViewOutput(t *testing.T) {
 				"ui":        JSON_UI_VERSION,
 			},
 			{
-				"@level":       "info",
-				"@message":     fmt.Sprintf("%s: Finding latest version...", packageName),
-				"@module":      "terraform.ui",
-				"message_code": "finding_latest_version_message",
-				"type":         "log",
+				"@level":   "info",
+				"@message": fmt.Sprintf("%s: Finding latest version...", packageName),
+				"@module":  "terraform.ui",
+				"type":     "log",
 			},
 		}
 
@@ -351,7 +349,7 @@ func TestNewInit_jsonViewOutput(t *testing.T) {
 			t.Fatalf("unexpected return type %t", newInit)
 		}
 
-		var packageName, packageVersion = "hashicorp/aws", "3.0.0"
+		packageName, packageVersion := "hashicorp/aws", "3.0.0"
 		newInit.Output(ProviderAlreadyInstalledMessage, packageName, packageVersion)
 
 		version := tfversion.String()
@@ -365,11 +363,10 @@ func TestNewInit_jsonViewOutput(t *testing.T) {
 				"ui":        JSON_UI_VERSION,
 			},
 			{
-				"@level":       "info",
-				"@message":     fmt.Sprintf("%s v%s: Using previously-installed provider version", packageName, packageVersion),
-				"@module":      "terraform.ui",
-				"message_code": "provider_already_installed_message",
-				"type":         "log",
+				"@level":   "info",
+				"@message": fmt.Sprintf("%s v%s: Using previously-installed provider version", packageName, packageVersion),
+				"@module":  "terraform.ui",
+				"type":     "log",
 			},
 		}
 
@@ -472,7 +469,7 @@ func TestNewInit_humanViewOutput(t *testing.T) {
 			t.Fatalf("unexpected return type %t", newInit)
 		}
 
-		var packageName, packageVersion = "hashicorp/aws", "3.0.0"
+		packageName, packageVersion := "hashicorp/aws", "3.0.0"
 		newInit.Output(ProviderAlreadyInstalledMessage, packageName, packageVersion)
 
 		actual := done(t).All()

--- a/internal/command/views/init_test.go
+++ b/internal/command/views/init_test.go
@@ -301,7 +301,7 @@ func TestNewInit_jsonViewOutput(t *testing.T) {
 				"@message":     "Initializing provider plugins...",
 				"message_code": "initializing_provider_plugin_message",
 				"@module":      "terraform.ui",
-				"type":         "init_output",
+				"type":         "log",
 			},
 		}
 
@@ -335,7 +335,7 @@ func TestNewInit_jsonViewOutput(t *testing.T) {
 				"@message":     fmt.Sprintf("%s: Finding latest version...", packageName),
 				"@module":      "terraform.ui",
 				"message_code": "finding_latest_version_message",
-				"type":         "init_output",
+				"type":         "log",
 			},
 		}
 
@@ -369,7 +369,7 @@ func TestNewInit_jsonViewOutput(t *testing.T) {
 				"@message":     fmt.Sprintf("%s v%s: Using previously-installed provider version", packageName, packageVersion),
 				"@module":      "terraform.ui",
 				"message_code": "provider_already_installed_message",
-				"type":         "init_output",
+				"type":         "log",
 			},
 		}
 

--- a/internal/command/views/json_view.go
+++ b/internal/command/views/json_view.go
@@ -20,7 +20,7 @@ import (
 // This version describes the schema of JSON UI messages. This version must be
 // updated after making any changes to this view, the jsonHook, or any of the
 // command/views/json package.
-const JSON_UI_VERSION = "1.3"
+const JSON_UI_VERSION = "2.0"
 
 func NewJSONView(view *View) *JSONView {
 	log := hclog.New(&hclog.LoggerOptions{


### PR DESCRIPTION
References: https://github.com/hashicorp/terraform/pull/34886

This PR removes the `LogInitMessage` method from the `init` command's View implementation. Instead, all messages logged via that route will now be logged via the `Output` method. Logs produced through these two methods have different structures (see below), so this PR also includes breaking changes to JSON output from the init command. However, we have a version number that we are meant to increment based on non-breaking or breaking changes to JSON output, so I believe this PR doesn't qualify as a breaking change if:
* we increment the ui version number as documented
* systems consuming this JSON output are using that number as documented.

I have confirmed with the Core Cloud team that the changes will not impact HCP Terraform, but if this PR is reviewed I will pull that team in as a reviewer for more visibilty.

# Background

For human/natural language output the `LogInitMessage` and `Output` methods in the `init` command's `InitHuman` view are exactly the same:

https://github.com/hashicorp/terraform/blob/02d9de8bbbe3e9dd1ba902262f2b37a10cb92b33/internal/command/views/init.go#L58-L64

For JSON/machine-readable output these two methods are implemented to produce slightly different JSON objects:

**LogInitMessage**: The JSON view's `LogInitMessage` method uses the Log method in the wrapped JSONView: 

https://github.com/hashicorp/terraform/blob/02d9de8bbbe3e9dd1ba902262f2b37a10cb92b33/internal/command/views/init.go#L126-L133

This uses the default [logger](https://github.com/hashicorp/terraform/blob/02d9de8bbbe3e9dd1ba902262f2b37a10cb92b33/internal/command/views/json_view.go#L26) used in all commands' JSON views, so the log's format is default and minimal, with a message and log type set to `log`. Here's a real example:

```json
{
    "@level":"info",
    "@message":"hashicorp/random: Reusing previous version from the dependency lock file",
    "@module":"terraform.ui",
    "@timestamp":"2025-08-11T15:09:16.874024+02:00",
    "type":"log"
}
```

**Output**: The JSON view's `Output` method doesn't use the Log method, and it defines its own 'shape' by adding the custom field `message_code` and setting `type` to `init_output` :

https://github.com/hashicorp/terraform/blob/02d9de8bbbe3e9dd1ba902262f2b37a10cb92b33/internal/command/views/init.go#L102-L124 

Here's an example of a log produced via `Output` [from our docs](https://developer.hashicorp.com/terraform/internals/machine-readable-ui#example-output). If you navigate there you'll see an `init` command produces a mixture of both log types due to use of `LogInitMessage` or `Output` in different parts of the command:

```json
{
    "@level":"info",
    "@message":"Initializing provider plugins...",
    "@module":"terraform.ui",
    "@timestamp":"2025-08-11T13:09:15Z",
    "message_code":"initializing_provider_plugin_message",
    "type":"init_output"
}
```

# Why this PR

[I asked the Core Cloud team](https://ibm-hashicorp.slack.com/archives/C09KXBVANR4/p1781545435762999) about how and where the `message_code` and `type` fields are used, and the answer was that they were not used.

By removing this init-specific constraint it'll give us freedom to make some of the code that's currently specific to init be reusable between multiple commands. This will also enable provider-download logic that's currently tightly coupled to the init command's View implementation to be updated to be reused across commands that download providers (namely `init` and a new `state migrate` command).


# This PR's changes

The following changes will happen to the `init` command's output, given this example output that's in our documentation:


```diff
{
    "@level": "info",
    "@message": "Terraform 1.9.0",
    "@module": "terraform.ui",
    "@timestamp": "2025-08-11T15:09:15.919212+02:00",
    "terraform": "1.9.0",
    "type": "version",
    "ui": "1.2"
}
{
    "@level": "info",
    "@message": "Initializing the backend...",
    "@module": "terraform.ui",
    "@timestamp": "2025-08-11T13:09:15Z",
-    "message_code": "initializing_backend_message",
-    "type": "init_output"
+    "type": "log"
}
{
    "@level": "info",
    "@message": "Initializing provider plugins...",
    "@module": "terraform.ui",
    "@timestamp": "2025-08-11T13:09:15Z",
-    "message_code": "initializing_provider_plugin_message",
-    "type": "init_output"
+    "type": "log"
}
{
    "@level": "info",
    "@message": "Finding matching versions for provider: hashicorp/aws, version_constraint: \"~\u003e 6.8\"",
    "@module": "terraform.ui",
    "@timestamp": "2025-08-11T15:09:15.921436+02:00",
    "type": "log"
}
{
    "@level": "info",
    "@message": "hashicorp/random: Reusing previous version from the dependency lock file",
    "@module": "terraform.ui",
    "@timestamp": "2025-08-11T15:09:16.874024+02:00",
    "type": "log"
}
{
    "@level": "info",
    "@message": "Installing provider version: hashicorp/aws v6.8.0...",
    "@module": "terraform.ui",
    "@timestamp": "2025-08-11T15:09:18.827459+02:00",
    "type": "log"
}
{
    "@level": "info",
    "@message": "Installed provider version: hashicorp/aws v6.8.0 (signed by HashiCorp)",
    "@module": "terraform.ui",
    "@timestamp": "2025-08-11T15:09:35.414989+02:00",
    "type": "log"
}
{
    "@level": "info",
    "@message": "Installing provider version: hashicorp/random v3.7.2...",
    "@module": "terraform.ui",
    "@timestamp": "2025-08-11T15:09:36.363085+02:00",
    "type": "log"
}
{
    "@level": "info",
    "@message": "Installed provider version: hashicorp/random v3.7.2 (signed by HashiCorp)",
    "@module": "terraform.ui",
    "@timestamp": "2025-08-11T15:09:42.258989+02:00",
    "type": "log"
}
{
    "@level": "info",
    "@message": "Terraform has made some changes to the provider dependency selections recorded\nin the .terraform.lock.hcl file. Review those changes and commit them to your\nversion control system if they represent changes you intended to make.",
    "@module": "terraform.ui",
    "@timestamp": "2025-08-11T13:09:42Z",
-    "message_code": "dependencies_lock_changes_info",
-    "type": "init_output"
+    "type": "log"
}
{
    "@level": "info",
    "@message": "Terraform has been successfully initialized!",
    "@module": "terraform.ui",
    "@timestamp": "2025-08-11T13:09:42Z",
-    "message_code": "output_init_success_message",
-    "type": "init_output"
+    "type": "log"
}
{
    "@level": "info",
    "@message": "You may now begin working with Terraform. Try running \"terraform plan\" to see\nany changes that are required for your infrastructure. All Terraform commands\nshould now work.\n\nIf you ever set or change modules or backend configuration for Terraform,\nrerun this command to reinitialize your working directory. If you forget, other\ncommands will detect it and remind you to do so if necessary.",
    "@module": "terraform.ui",
    "@timestamp": "2025-08-11T13:09:42Z",
-    "message_code": "output_init_success_cli_message",
-    "type": "init_output"
+    "type": "log"
}
```



## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.16.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [x] This change is user-facing and I added a changelog entry.
- [ ] This change is not user-facing.
