### PR TITLE
commands/state_migrate: Only validate that lockfiles provided by CLI flag exist

### DIFF
--- a/internal/command/arguments/state_migrate.go
+++ b/internal/command/arguments/state_migrate.go
@@ -5,6 +5,7 @@ package arguments
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 
 	"github.com/hashicorp/terraform/internal/tfdiags"
@@ -72,15 +73,35 @@ func ParseStateMigrate(args []string) (*StateMigrate, tfdiags.Diagnostics) {
 		}
 
 	}
+
 	if srcLockFilePath == "" {
 		// setting default here instead of in the flag definition
 		// to make check above free of side effects
 		srcLockFilePath = lockFileName
+	} else {
+		// If a file is supplied via flag, it must exist.
+		if _, err := os.Stat(srcLockFilePath); err != nil {
+			diags = diags.Append(tfdiags.Sourceless(
+				tfdiags.Error,
+				"Unreadable source provider lock file",
+				fmt.Sprintf("%q: %s", srcLockFilePath, err.Error()),
+			))
+		}
 	}
+
 	if dstLockFilePath == "" {
 		// setting default here instead of in the flag definition
 		// to make check above free of side effects
 		dstLockFilePath = lockFileName
+	} else {
+		// If a file is supplied via flag, it must exist.
+		if _, err := os.Stat(dstLockFilePath); err != nil {
+			diags = diags.Append(tfdiags.Sourceless(
+				tfdiags.Error,
+				"Unreadable destination provider lock file",
+				fmt.Sprintf("%q: %s", dstLockFilePath, err.Error()),
+			))
+		}
 	}
 
 	srcFilename := filepath.Base(srcLockFilePath)

--- a/internal/command/arguments/state_migrate.go
+++ b/internal/command/arguments/state_migrate.go
@@ -8,10 +8,11 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/hashicorp/terraform/internal/depsfile"
 	"github.com/hashicorp/terraform/internal/tfdiags"
 )
 
-const lockFileName = ".terraform.lock.hcl"
+const lockFileName = depsfile.LockFilePath // .terraform.lock.hcl
 
 // StateMigrate represents the command-line arguments for the state migrate command.
 type StateMigrate struct {

--- a/internal/command/arguments/state_migrate_test.go
+++ b/internal/command/arguments/state_migrate_test.go
@@ -4,6 +4,8 @@
 package arguments
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -11,6 +13,21 @@ import (
 )
 
 func TestStateMigrateArgs(t *testing.T) {
+	t.Parallel()
+
+	// Create lock files to use in test, as validation will check for the existence of the
+	// file if a path is supplied via CLI flags.
+	td := t.TempDir()
+	userLockFilePath := filepath.Join(td, ".terraform.lock.hcl")
+	if err := os.WriteFile(userLockFilePath, []byte(""), 0644); err != nil {
+		t.Fatalf("failed to create test lock file: %s", err)
+	}
+
+	invalidLockFilePath := filepath.Join(td, "invalid.lock.hcl")
+	if err := os.WriteFile(invalidLockFilePath, []byte(""), 0644); err != nil {
+		t.Fatalf("failed to create test lock file: %s", err)
+	}
+
 	testCases := []struct {
 		rawArgs       []string
 		expectedArgs  *StateMigrate
@@ -28,21 +45,21 @@ func TestStateMigrateArgs(t *testing.T) {
 		},
 		{ // set or override all flags
 			rawArgs: []string{
-				"-source-provider-lock-file", "/some/path/.terraform.lock.hcl",
-				"-destination-provider-lock-file", "/some/other/path/.terraform.lock.hcl",
+				"-source-provider-lock-file", userLockFilePath,
+				"-destination-provider-lock-file", userLockFilePath,
 				"-upgrade",
 				"-input=false",
 			},
 			expectedArgs: &StateMigrate{
-				SourceLockFilePath:      "/some/path/.terraform.lock.hcl",
-				DestinationLockFilePath: "/some/other/path/.terraform.lock.hcl",
+				SourceLockFilePath:      userLockFilePath,
+				DestinationLockFilePath: userLockFilePath,
 				Upgrade:                 true,
 				InputEnabled:            false,
 				ViewType:                ViewHuman,
 			},
 		},
 		{
-			rawArgs: []string{"-input=false", "-source-provider-lock-file", "foo"},
+			rawArgs: []string{"-input=false", "-source-provider-lock-file", invalidLockFilePath},
 			expectedArgs: &StateMigrate{
 				SourceLockFilePath:      "",
 				DestinationLockFilePath: ".terraform.lock.hcl",
@@ -54,12 +71,12 @@ func TestStateMigrateArgs(t *testing.T) {
 				tfdiags.Sourceless(
 					tfdiags.Error,
 					"Invalid source-provider-lock-file",
-					"Expected lock file name to be .terraform.lock.hcl, got: foo",
+					"Expected lock file name to be .terraform.lock.hcl, got: invalid.lock.hcl",
 				),
 			},
 		},
 		{
-			rawArgs: []string{"-input=false", "-destination-provider-lock-file", "foo"},
+			rawArgs: []string{"-input=false", "-destination-provider-lock-file", invalidLockFilePath},
 			expectedArgs: &StateMigrate{
 				SourceLockFilePath:      ".terraform.lock.hcl",
 				DestinationLockFilePath: "",
@@ -71,7 +88,7 @@ func TestStateMigrateArgs(t *testing.T) {
 				tfdiags.Sourceless(
 					tfdiags.Error,
 					"Invalid destination-provider-lock-file",
-					"Expected lock file name to be .terraform.lock.hcl, got: foo",
+					"Expected lock file name to be .terraform.lock.hcl, got: invalid.lock.hcl",
 				),
 			},
 		},

--- a/internal/command/state_migrate.go
+++ b/internal/command/state_migrate.go
@@ -5,7 +5,6 @@ package command
 
 import (
 	"fmt"
-	"os"
 	"strings"
 
 	"github.com/hashicorp/terraform/internal/command/arguments"
@@ -35,30 +34,6 @@ func (c *StateMigrateCommand) Run(rawArgs []string) int {
 	}
 
 	c.Meta.input = args.InputEnabled
-
-	if args.SourceLockFilePath != "" {
-		if _, err := os.Stat(args.SourceLockFilePath); err != nil {
-			diags = diags.Append(tfdiags.Sourceless(
-				tfdiags.Error,
-				"Unreadable source provider lock file",
-				fmt.Sprintf("%q: %s", args.SourceLockFilePath, err.Error()),
-			))
-		}
-	}
-
-	// It is valid for the destination lockfile to be missing
-	// while state exists - e.g. through the use of builtin provider
-	// or outputs and use of a builtin backend
-	// (as opposed to pluggable state store).
-	if args.DestinationLockFilePath != "" {
-		if _, err := os.Stat(args.DestinationLockFilePath); err != nil {
-			diags = diags.Append(tfdiags.Sourceless(
-				tfdiags.Error,
-				"Unreadable destination provider lock file",
-				fmt.Sprintf("%q: %s", args.DestinationLockFilePath, err.Error()),
-			))
-		}
-	}
 
 	// return validation errors early if there are any
 	if diags.HasErrors() {


### PR DESCRIPTION
This PR is part of decomposing another PR I'm working on to add provider download to the `state migrate` command.

During that work I realised that the command cannot handle a scenario where the user has no .terraform.lock.hcl in the working directory. Although it's odd, we need to account for a user who hasn't committed the lock file to version control but has existing state that needs to be migrated.

The change in this PR means that if the CLI flags are supplied the path is validated. If the CLI flag isn't supplied then the value is set to `".terraform.lock.hcl"` instead. That file might also not exist, but that doesn't matter as the command will download 0-2 providers depending on what's needed by the migration.

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.16.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
