### PR TITLE
policy: Add provider policy evaluation support to stacks

### DIFF
--- a/internal/command/meta_policy.go
+++ b/internal/command/meta_policy.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/zclconf/go-cty/cty"
 
+	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/backend"
 	"github.com/hashicorp/terraform/internal/configs"
@@ -168,7 +169,11 @@ func (p *providerPolicyHook) ProviderVersionSelected(ctx context.Context, provid
 	addr := addrs.AbsProviderConfig{Provider: provider, Module: addrs.RootModule}
 	providerConfig := p.rootModule.ProviderConfigs[provider.Type]
 
-	p.policyResults.AddProvider(addr, result, providerConfig)
+	var rng hcl.Range
+	if providerConfig != nil {
+		rng = providerConfig.DeclRange
+	}
+	p.policyResults.AddProvider(addr, result, rng)
 	log.Println("[DEBUG] init: policy result for provider", provider.String(), version, "overall", result.Overall)
 	// Init uses diagnostics as the blocking signal because advisory policies
 	// may return deny without any error diagnostics.

--- a/internal/plans/policy.go
+++ b/internal/plans/policy.go
@@ -50,18 +50,14 @@ func (pr *PolicyResults) AddResource(addr addrs.AbsResourceInstance, result poli
 	pr.set.Put(addr, PolicyEvaluation{EvaluationResponse: result, ConfigDeclRange: rng})
 }
 
-func (pr *PolicyResults) AddProvider(addr addrs.AbsProviderConfig, result policy.EvaluationResponse, config *configs.Provider) {
+func (pr *PolicyResults) AddProvider(addr addrs.AbsProviderConfig, result policy.EvaluationResponse, configDeclRange hcl.Range) {
 	// Don't add empty results
 	if result.Empty() {
 		return
 	}
 	pr.mu.Lock()
 	defer pr.mu.Unlock()
-	var rng hcl.Range
-	if config != nil {
-		rng = config.DeclRange
-	}
-	pr.pset.Put(addr, PolicyEvaluation{EvaluationResponse: result, ConfigDeclRange: rng})
+	pr.pset.Put(addr, PolicyEvaluation{EvaluationResponse: result, ConfigDeclRange: configDeclRange})
 }
 
 func (pr *PolicyResults) AddModule(addr addrs.Module, result policy.EvaluationResponse, config *configs.ModuleCall) {

--- a/internal/plans/policy.go
+++ b/internal/plans/policy.go
@@ -55,6 +55,19 @@ func (pr *PolicyResults) AddProvider(addr addrs.AbsProviderConfig, result policy
 	if result.Empty() {
 		return
 	}
+
+	// Annotate the result diagnostics with the local range so that diagnostics can be rendered with both the
+	// policy source and the object being enforced.
+	if !configDeclRange.Empty() {
+		ptr := configDeclRange.Ptr()
+		for idx, diag := range result.Diagnostics {
+			result.Diagnostics[idx] = diag.WithLocalRange(ptr)
+		}
+		for idx := range result.Enforcements {
+			result.Enforcements[idx].LocalRange = ptr
+		}
+	}
+
 	pr.mu.Lock()
 	defer pr.mu.Unlock()
 	pr.pset.Put(addr, PolicyEvaluation{EvaluationResponse: result, ConfigDeclRange: configDeclRange})

--- a/internal/plans/policy_test.go
+++ b/internal/plans/policy_test.go
@@ -27,7 +27,7 @@ func TestPolicyResults(t *testing.T) {
 		allow := policy.EvaluationResponse{Overall: policy.AllowResult}
 
 		pr.AddResource(resourceAddr, allow, resourceConfig)
-		pr.AddProvider(providerAddr, allow, providerConfig)
+		pr.AddProvider(providerAddr, allow, providerConfig.DeclRange)
 		pr.AddModule(moduleAddr, allow, moduleConfig)
 
 		// Empty results should be skipped, so the length should still be 0
@@ -43,7 +43,7 @@ func TestPolicyResults(t *testing.T) {
 		moduleResult := policy.EvaluationResponse{Overall: policy.DenyResult}
 
 		pr.AddResource(resourceAddr, resourceResult, resourceConfig)
-		pr.AddProvider(providerAddr, providerResult, providerConfig)
+		pr.AddProvider(providerAddr, providerResult, providerConfig.DeclRange)
 		pr.AddModule(moduleAddr, moduleResult, moduleConfig)
 
 		if got := pr.Len(); got != 3 {

--- a/internal/rpcapi/convert.go
+++ b/internal/rpcapi/convert.go
@@ -160,7 +160,7 @@ func externalInputValueFromProto(protoVal *stacks.DynamicValueWithSource) (stack
 	}, nil
 }
 
-func componentInstancePolicyEvaluationProto(componentAddr stackaddrs.AbsComponentInstance, policyResults *plans.PolicyResults) *stacks.PolicyEvaluationResponse {
+func componentInstancePolicyEvaluationProto(componentInstanceAddr stackaddrs.AbsComponentInstance, policyResults *plans.PolicyResults) *stacks.ComponentInstancePolicyEvaluation {
 	results := make([]*stacks.PolicyResult, 0)
 	infos := make([]*stacks.PolicyInfo, 0)
 	policyDiags := make([]*stacks.PolicyDiagnostic, 0)
@@ -171,10 +171,32 @@ func componentInstancePolicyEvaluationProto(componentAddr stackaddrs.AbsComponen
 		policyDiags = append(policyDiags, policyDiagsToProto(addr, result.EvaluationResponse.Diagnostics)...)
 	}
 
-	return &stacks.PolicyEvaluationResponse{
+	return &stacks.ComponentInstancePolicyEvaluation{
 		Addr: &stacks.ComponentInstanceInStackAddr{
-			ComponentAddr:         stackaddrs.ConfigComponentForAbsInstance(componentAddr).String(),
-			ComponentInstanceAddr: componentAddr.String(),
+			ComponentAddr:         stackaddrs.ConfigComponentForAbsInstance(componentInstanceAddr).String(),
+			ComponentInstanceAddr: componentInstanceAddr.String(),
+		},
+		Results:     results,
+		Infos:       infos,
+		Diagnostics: policyDiags,
+	}
+}
+
+func providerInstancePolicyEvaluationProto(providerInstanceAddr stackaddrs.AbsProviderConfigInstance, policyResults *plans.PolicyResults) *stacks.ProviderInstancePolicyEvaluation {
+	results := make([]*stacks.PolicyResult, 0)
+	infos := make([]*stacks.PolicyInfo, 0)
+	policyDiags := make([]*stacks.PolicyDiagnostic, 0)
+
+	for addr, result := range policyResults.Iter() {
+		results = append(results, policyResultsToProto(addr, result.EvaluationResponse.Policies)...)
+		infos = append(infos, policyInfosToProto(addr, result.EvaluationResponse.Enforcements)...)
+		policyDiags = append(policyDiags, policyDiagsToProto(addr, result.EvaluationResponse.Diagnostics)...)
+	}
+
+	return &stacks.ProviderInstancePolicyEvaluation{
+		Addr: &stacks.ProviderInstanceInStackAddr{
+			ProviderAddr:         stackaddrs.ConfigProviderConfigForAbsInstance(providerInstanceAddr).String(),
+			ProviderInstanceAddr: providerInstanceAddr.String(),
 		},
 		Results:     results,
 		Infos:       infos,

--- a/internal/rpcapi/convert_test.go
+++ b/internal/rpcapi/convert_test.go
@@ -194,7 +194,7 @@ func TestDiagnosticsToProto(t *testing.T) {
 	}
 }
 
-func TestPolicyEvaluationResponseProto(t *testing.T) {
+func TestComponentInstancePolicyEvaluationProto(t *testing.T) {
 	policyObj := &policy.Policy{
 		Result:           policy.AllowResult,
 		Address:          "policy_name",
@@ -218,14 +218,14 @@ func TestPolicyEvaluationResponseProto(t *testing.T) {
 	testCases := map[string]struct {
 		componentAddr string
 		policyResults func() *plans.PolicyResults
-		want          *stacks.PolicyEvaluationResponse
+		want          *stacks.ComponentInstancePolicyEvaluation
 	}{
 		"no results": {
 			componentAddr: "component.test",
 			policyResults: func() *plans.PolicyResults {
 				return plans.NewPolicyResults()
 			},
-			want: &stacks.PolicyEvaluationResponse{},
+			want: &stacks.ComponentInstancePolicyEvaluation{},
 		},
 		"policy result with diagnostic": {
 			componentAddr: "component.test",
@@ -255,7 +255,7 @@ func TestPolicyEvaluationResponseProto(t *testing.T) {
 				)
 				return results
 			},
-			want: &stacks.PolicyEvaluationResponse{
+			want: &stacks.ComponentInstancePolicyEvaluation{
 				Results: []*stacks.PolicyResult{
 					{
 						TargetAddress: "module.example",
@@ -320,7 +320,7 @@ func TestPolicyEvaluationResponseProto(t *testing.T) {
 				)
 				return results
 			},
-			want: &stacks.PolicyEvaluationResponse{
+			want: &stacks.ComponentInstancePolicyEvaluation{
 				Results: []*stacks.PolicyResult{
 					{
 						TargetAddress: "module.example",
@@ -408,7 +408,7 @@ func TestPolicyEvaluationResponseProto(t *testing.T) {
 				)
 				return results
 			},
-			want: &stacks.PolicyEvaluationResponse{
+			want: &stacks.ComponentInstancePolicyEvaluation{
 				Diagnostics: []*stacks.PolicyDiagnostic{
 					{
 						TargetAddress: "module.example",
@@ -490,7 +490,7 @@ func TestPolicyEvaluationResponseProto(t *testing.T) {
 				)
 				return results
 			},
-			want: &stacks.PolicyEvaluationResponse{
+			want: &stacks.ComponentInstancePolicyEvaluation{
 				Results: []*stacks.PolicyResult{
 					{
 						TargetAddress: "module.example",
@@ -556,7 +556,7 @@ func TestPolicyEvaluationResponseProto(t *testing.T) {
 				)
 				return results
 			},
-			want: &stacks.PolicyEvaluationResponse{
+			want: &stacks.ComponentInstancePolicyEvaluation{
 				Diagnostics: []*stacks.PolicyDiagnostic{
 					{
 						TargetAddress: "test_instance.example",
@@ -633,7 +633,7 @@ func TestPolicyEvaluationResponseProto(t *testing.T) {
 				)
 				return results
 			},
-			want: &stacks.PolicyEvaluationResponse{
+			want: &stacks.ComponentInstancePolicyEvaluation{
 				Diagnostics: []*stacks.PolicyDiagnostic{
 					{
 						TargetAddress: "test_instance.example",
@@ -672,6 +672,287 @@ func TestPolicyEvaluationResponseProto(t *testing.T) {
 			}
 
 			got := componentInstancePolicyEvaluationProto(componentAddr, tc.policyResults())
+
+			if diff := cmp.Diff(want, got, protocmp.Transform()); diff != "" {
+				t.Errorf("wrong result\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestProviderInstancePolicyEvaluationProto(t *testing.T) {
+	policyObj := &policy.Policy{
+		Result:           policy.AllowResult,
+		Address:          "policy_name",
+		PolicySetName:    "some_policy_set",
+		Filename:         "policy_file.tfpolicy.hcl",
+		EnforcementLevel: "mandatory",
+	}
+
+	snippetContext := `provider_policy "example"`
+
+	exprValueBytes, err := msgpack.Marshal(cty.StringVal("bar"), cty.String)
+	if err != nil {
+		t.Fatalf("failed to marshal expression value: %s", err)
+	}
+
+	providerInstanceAddr := stackaddrs.AbsProviderConfigInstance{
+		Stack: stackaddrs.RootStackInstance,
+		Item: stackaddrs.ProviderConfigInstance{
+			ProviderConfig: stackaddrs.ProviderConfig{
+				Provider: addrs.NewDefaultProvider("testing"),
+				Name:     "default",
+			},
+			Key: addrs.NoKey,
+		},
+	}
+
+	testCases := map[string]struct {
+		policyResults func() *plans.PolicyResults
+		want          *stacks.ProviderInstancePolicyEvaluation
+	}{
+		"no results": {
+			policyResults: func() *plans.PolicyResults {
+				return plans.NewPolicyResults()
+			},
+			want: &stacks.ProviderInstancePolicyEvaluation{},
+		},
+		"policy result with diagnostic": {
+			policyResults: func() *plans.PolicyResults {
+				results := plans.NewPolicyResults()
+				results.AddProvider(
+					addrs.AbsProviderConfig{
+						Module:   addrs.RootModule,
+						Provider: addrs.MustParseProviderSourceString("registry.terraform.io/hashicorp/testing"),
+					},
+					policy.EvaluationResponse{
+						Overall: policy.DenyResult,
+						Diagnostics: policy.Diagnostics{
+							policy.NewErrorDiagnostic(
+								"provider policy denied",
+								"provider policy blocked usage",
+								policy.DenyResult,
+							),
+						},
+						Policies: []*policy.Policy{
+							{
+								Address:          "provider_policy.example",
+								Filename:         "policy_file.tfpolicy.hcl",
+								EnforcementLevel: "mandatory",
+								Result:           policy.DenyResult,
+							},
+						},
+					},
+					hcl.Range{},
+				)
+				return results
+			},
+			want: &stacks.ProviderInstancePolicyEvaluation{
+				Results: []*stacks.PolicyResult{
+					{
+						TargetAddress: `provider["registry.terraform.io/hashicorp/testing"]`,
+						PolicyMetadata: &stacks.PolicyMetaData{
+							PolicyName:       "provider_policy.example",
+							FileName:         "policy_file.tfpolicy.hcl",
+							EnforcementLevel: "mandatory",
+						},
+						Result: stacks.EvaluateResult_DENY_EVALUATE_RESULT,
+					},
+				},
+				Diagnostics: []*stacks.PolicyDiagnostic{
+					{
+						TargetAddress: `provider["registry.terraform.io/hashicorp/testing"]`,
+						Result:        stacks.EvaluateResult_DENY_EVALUATE_RESULT,
+						Diagnostic: &terraform1.Diagnostic{
+							Severity: terraform1.Diagnostic_ERROR,
+							Summary:  "provider policy denied",
+							Detail:   "provider policy blocked usage",
+						},
+						PolicyMetadata: &stacks.PolicyMetaData{},
+					},
+				},
+			},
+		},
+		"policy info with snippet and range": {
+			policyResults: func() *plans.PolicyResults {
+				results := plans.NewPolicyResults()
+				results.AddProvider(
+					addrs.AbsProviderConfig{
+						Module:   addrs.RootModule,
+						Provider: addrs.MustParseProviderSourceString("registry.terraform.io/hashicorp/testing"),
+					},
+					policy.EvaluationResponse{
+						Overall:  policy.AllowResult,
+						Policies: []*policy.Policy{policyObj},
+						Enforcements: []policy.EnforcementResult{
+							{
+								Result:     policy.AllowResult,
+								Message:    "provider policy allowed usage",
+								BlockIndex: 1,
+								Policy:     policyObj,
+								Range: &hcl.Range{
+									Filename: "policy_file.tfpolicy.hcl",
+									Start:    hcl.Pos{Line: 3, Column: 5, Byte: 10},
+									End:      hcl.Pos{Line: 4, Column: 10, Byte: 30},
+								},
+								Snippet: &proto.Snippet{
+									Code:                 `key = attr.value == "foo"`,
+									Context:              &snippetContext,
+									StartLine:            3,
+									HighlightStartOffset: 0,
+									HighlightEndOffset:   5,
+								},
+							},
+							{
+								// Enforcements without a message are skipped.
+								Result: policy.AllowResult,
+								Policy: policyObj,
+							},
+						},
+					},
+					hcl.Range{},
+				)
+				return results
+			},
+			want: &stacks.ProviderInstancePolicyEvaluation{
+				Results: []*stacks.PolicyResult{
+					{
+						TargetAddress: `provider["registry.terraform.io/hashicorp/testing"]`,
+						PolicyMetadata: &stacks.PolicyMetaData{
+							PolicyName:       "policy_name",
+							PolicySetName:    "some_policy_set",
+							FileName:         "policy_file.tfpolicy.hcl",
+							EnforcementLevel: "mandatory",
+						},
+						Result: stacks.EvaluateResult_ALLOW_EVALUATE_RESULT,
+					},
+				},
+				Infos: []*stacks.PolicyInfo{
+					{
+						TargetAddress: `provider["registry.terraform.io/hashicorp/testing"]`,
+						Result:        stacks.EvaluateResult_ALLOW_EVALUATE_RESULT,
+						Message:       "provider policy allowed usage",
+						PolicyMetadata: &stacks.PolicyMetaData{
+							PolicyName:       "policy_name",
+							PolicySetName:    "some_policy_set",
+							FileName:         "policy_file.tfpolicy.hcl",
+							EnforcementLevel: "mandatory",
+							EnforceIndex:     1,
+						},
+						PolicySnippet: &stacks.PolicySnippet{
+							Code:                 `key = attr.value == "foo"`,
+							Context:              snippetContext,
+							StartLine:            3,
+							HighlightStartOffset: 0,
+							HighlightEndOffset:   5,
+						},
+						PolicyRange: &terraform1.SourceRange{
+							SourceAddr: "policy_file.tfpolicy.hcl",
+							Start:      &terraform1.SourcePos{Byte: 10, Line: 3, Column: 5},
+							End:        &terraform1.SourcePos{Byte: 30, Line: 4, Column: 10},
+						},
+					},
+				},
+			},
+		},
+		"policy diagnostic with extra data": {
+			policyResults: func() *plans.PolicyResults {
+				results := plans.NewPolicyResults()
+				results.AddProvider(
+					addrs.AbsProviderConfig{
+						Module:   addrs.RootModule,
+						Provider: addrs.MustParseProviderSourceString("registry.terraform.io/hashicorp/testing"),
+					},
+					policy.EvaluationResponse{
+						Overall: policy.DenyResult,
+						Diagnostics: policy.DiagsFromProto([]*proto.Diagnostic{
+							{
+								Severity: proto.Severity_ERROR,
+								Summary:  "policy error",
+								Detail:   "the provider is not allowed",
+								Result: &proto.DiagnosticResult{
+									Result: proto.EvaluateResult_DENY_EVALUATE_RESULT,
+								},
+								Subject: &proto.Range{
+									Filename: "policy_file.tfpolicy.hcl",
+									Start:    &proto.Position{Byte: 10, Line: 2, Column: 3},
+									End:      &proto.Position{Byte: 20, Line: 2, Column: 13},
+								},
+								Snippet: &proto.Snippet{
+									Context:              &snippetContext,
+									Code:                 `key = attr.value == "foo"`,
+									StartLine:            2,
+									HighlightStartOffset: 6,
+									HighlightEndOffset:   11,
+								},
+								ExpressionValues: []*proto.ExpressionValue{
+									{
+										Traversal: &proto.AttributePath{
+											Steps: []*proto.AttributePath_Step{
+												{
+													Selector: &proto.AttributePath_Step_AttributeName{AttributeName: "value"},
+												},
+											},
+										},
+										Value: exprValueBytes,
+									},
+								},
+							},
+						}, policyObj),
+					},
+					hcl.Range{},
+				)
+				return results
+			},
+			want: &stacks.ProviderInstancePolicyEvaluation{
+				Diagnostics: []*stacks.PolicyDiagnostic{
+					{
+						TargetAddress: `provider["registry.terraform.io/hashicorp/testing"]`,
+						Result:        stacks.EvaluateResult_DENY_EVALUATE_RESULT,
+						Diagnostic: &terraform1.Diagnostic{
+							Severity: terraform1.Diagnostic_ERROR,
+							Summary:  "policy error",
+							Detail:   "the provider is not allowed",
+						},
+						PolicyMetadata: &stacks.PolicyMetaData{
+							PolicyName:       "policy_name",
+							PolicySetName:    "some_policy_set",
+							FileName:         "policy_file.tfpolicy.hcl",
+							EnforcementLevel: "mandatory",
+						},
+						PolicySnippet: &stacks.PolicySnippet{
+							Context:              snippetContext,
+							Code:                 `key = attr.value == "foo"`,
+							StartLine:            2,
+							HighlightStartOffset: 6,
+							HighlightEndOffset:   11,
+						},
+						PolicyRange: &terraform1.SourceRange{
+							SourceAddr: "policy_file.tfpolicy.hcl",
+							Start:      &terraform1.SourcePos{Byte: 10, Line: 2, Column: 3},
+							End:        &terraform1.SourcePos{Byte: 20, Line: 2, Column: 13},
+						},
+						ExpressionValues: []*stacks.ExpressionValue{
+							{
+								Traversal: stacks.NewAttributePath(cty.GetAttrPath("value")),
+								Value:     exprValueBytes,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			want := tc.want
+			want.Addr = &stacks.ProviderInstanceInStackAddr{
+				ProviderAddr:         stackaddrs.ConfigProviderConfigForAbsInstance(providerInstanceAddr).String(),
+				ProviderInstanceAddr: providerInstanceAddr.String(),
+			}
+
+			got := providerInstancePolicyEvaluationProto(providerInstanceAddr, tc.policyResults())
 
 			if diff := cmp.Diff(want, got, protocmp.Transform()); diff != "" {
 				t.Errorf("wrong result\n%s", diff)

--- a/internal/rpcapi/stacks.go
+++ b/internal/rpcapi/stacks.go
@@ -1088,6 +1088,18 @@ func stackPlanHooks(evts *syncPlanStackChangesServer, mainStackSource sourceaddr
 		})
 	}
 
+	changeHooks.ReportProviderInstancePolicyResults = func(ctx context.Context, h *hooks.ProviderInstancePolicyResults) {
+		if h.PolicyResults.Len() == 0 {
+			return
+		}
+
+		evts.Send(&stacks.PlanStackChanges_Event{
+			Event: &stacks.PlanStackChanges_Event_ProviderInstancePolicyEvaluation{
+				ProviderInstancePolicyEvaluation: providerInstancePolicyEvaluationProto(h.Addr, h.PolicyResults),
+			},
+		})
+	}
+
 	return changeHooks
 }
 
@@ -1111,6 +1123,18 @@ func stackApplyHooks(evts *syncApplyStackChangesServer, mainStackSource sourcead
 		evts.Send(&stacks.ApplyStackChanges_Event{
 			Event: &stacks.ApplyStackChanges_Event_ComponentInstancePolicyEvaluation{
 				ComponentInstancePolicyEvaluation: componentInstancePolicyEvaluationProto(h.Addr, h.PolicyResults),
+			},
+		})
+	}
+
+	changeHooks.ReportProviderInstancePolicyResults = func(ctx context.Context, h *hooks.ProviderInstancePolicyResults) {
+		if h.PolicyResults.Len() == 0 {
+			return
+		}
+
+		evts.Send(&stacks.ApplyStackChanges_Event{
+			Event: &stacks.ApplyStackChanges_Event_ProviderInstancePolicyEvaluation{
+				ProviderInstancePolicyEvaluation: providerInstancePolicyEvaluationProto(h.Addr, h.PolicyResults),
 			},
 		})
 	}

--- a/internal/rpcapi/stacks_test.go
+++ b/internal/rpcapi/stacks_test.go
@@ -553,45 +553,13 @@ func TestStacksPlanStackChanges_noPolicies(t *testing.T) {
 	}
 
 	// No policy events should be emitted
-	wantEvents := make([]*stacks.PlanStackChanges_Event_ComponentInstancePolicyEvaluation, 0)
-
-	// Collect policy evaluation + diagnostics
-	gotEvents := make([]*stacks.PlanStackChanges_Event_ComponentInstancePolicyEvaluation, 0)
-	var diags []*terraform1.Diagnostic
-	for {
-		event, err := events.Recv()
-		if err == io.EOF {
-			break
-		}
-		if err != nil {
-			t.Fatalf("unexpected error: %s", err)
-		}
-
-		switch evt := event.Event.(type) {
-		case *stacks.PlanStackChanges_Event_ComponentInstancePolicyEvaluation:
-			gotEvents = append(gotEvents, evt)
-		case *stacks.PlanStackChanges_Event_Diagnostic:
-			diags = append(diags, event.GetDiagnostic())
-		default:
-			continue
-		}
-	}
-
-	if len(diags) > 0 {
-		t.Fatalf("unexpected diags: %v", diags)
-	}
-
-	// Order of policy events is not guaranteed
-	slices.SortFunc(gotEvents, func(a, b *stacks.PlanStackChanges_Event_ComponentInstancePolicyEvaluation) int {
-		return strings.Compare(
-			a.ComponentInstancePolicyEvaluation.GetAddr().GetComponentInstanceAddr(),
-			b.ComponentInstancePolicyEvaluation.GetAddr().GetComponentInstanceAddr(),
-		)
-	})
+	wantEvents := make([]aggregatedPolicyEvent, 0)
+	gotEvents := collectPolicyEventsFromPlan(t, events)
 
 	if diff := cmp.Diff(wantEvents, gotEvents, protocmp.Transform(),
 		// Order of policy evaluation data is not guaranteed
-		protocmp.SortRepeatedFields(&stacks.PolicyEvaluationResponse{}, "results", "infos", "diagnostics"),
+		protocmp.SortRepeatedFields(&stacks.ComponentInstancePolicyEvaluation{}, "results", "infos", "diagnostics"),
+		protocmp.SortRepeatedFields(&stacks.ProviderInstancePolicyEvaluation{}, "results", "infos", "diagnostics"),
 	); diff != "" {
 		t.Fatalf("unexpected policy events\n%s", diff)
 	}
@@ -660,53 +628,19 @@ func TestStacksPlanStackChanges_withPolicies(t *testing.T) {
 		t.Fatalf("unexpected error: %s", err)
 	}
 
-	// All components will output the same policy evaluation data from different addresses
-	wantEvents := []*stacks.PlanStackChanges_Event_ComponentInstancePolicyEvaluation{
-		{
-			ComponentInstancePolicyEvaluation: createExpectedPolicyEvaluationResponse(`component.simple_component["comp1"]`),
-		},
-		{
-			ComponentInstancePolicyEvaluation: createExpectedPolicyEvaluationResponse(`component.simple_component["comp2"]`),
-		},
+	wantEvents := []aggregatedPolicyEvent{
+		createExpectedComponentInstancePolicyEvaluation(`component.simple_component["comp1"]`),
+		createExpectedComponentInstancePolicyEvaluation(`component.simple_component["comp2"]`),
+		createExpectedProviderInstancePolicyEvaluation(`provider["registry.terraform.io/hashicorp/testing"].default["comp1"]`),
+		createExpectedProviderInstancePolicyEvaluation(`provider["registry.terraform.io/hashicorp/testing"].default["comp2"]`),
 	}
 
-	// Collect policy evaluation + diagnostics
-	gotEvents := make([]*stacks.PlanStackChanges_Event_ComponentInstancePolicyEvaluation, 0)
-	var diags []*terraform1.Diagnostic
-	for {
-		event, err := events.Recv()
-		if err == io.EOF {
-			break
-		}
-		if err != nil {
-			t.Fatalf("unexpected error: %s", err)
-		}
-
-		switch evt := event.Event.(type) {
-		case *stacks.PlanStackChanges_Event_ComponentInstancePolicyEvaluation:
-			gotEvents = append(gotEvents, evt)
-		case *stacks.PlanStackChanges_Event_Diagnostic:
-			diags = append(diags, event.GetDiagnostic())
-		default:
-			continue
-		}
-	}
-
-	if len(diags) > 0 {
-		t.Fatalf("unexpected diags: %v", diags)
-	}
-
-	// Order of policy events is not guaranteed
-	slices.SortFunc(gotEvents, func(a, b *stacks.PlanStackChanges_Event_ComponentInstancePolicyEvaluation) int {
-		return strings.Compare(
-			a.ComponentInstancePolicyEvaluation.GetAddr().GetComponentInstanceAddr(),
-			b.ComponentInstancePolicyEvaluation.GetAddr().GetComponentInstanceAddr(),
-		)
-	})
+	gotEvents := collectPolicyEventsFromPlan(t, events)
 
 	if diff := cmp.Diff(wantEvents, gotEvents, protocmp.Transform(),
 		// Order of policy evaluation data is not guaranteed
-		protocmp.SortRepeatedFields(&stacks.PolicyEvaluationResponse{}, "results", "infos", "diagnostics"),
+		protocmp.SortRepeatedFields(&stacks.ComponentInstancePolicyEvaluation{}, "results", "infos", "diagnostics"),
+		protocmp.SortRepeatedFields(&stacks.ProviderInstancePolicyEvaluation{}, "results", "infos", "diagnostics"),
 	); diff != "" {
 		t.Fatalf("unexpected policy events\n%s", diff)
 	}
@@ -777,37 +711,13 @@ func TestStacksPlanStackChanges_noPolicyResultsForRefresh(t *testing.T) {
 	}
 
 	// No policy events should be emitted as this plan is in refresh mode
-	wantEvents := make([]*stacks.PlanStackChanges_Event_ComponentInstancePolicyEvaluation, 0)
-
-	// Collect policy evaluation + diagnostics
-	gotEvents := make([]*stacks.PlanStackChanges_Event_ComponentInstancePolicyEvaluation, 0)
-	var diags []*terraform1.Diagnostic
-	for {
-		event, err := events.Recv()
-		if err == io.EOF {
-			break
-		}
-		if err != nil {
-			t.Fatalf("unexpected error: %s", err)
-		}
-
-		switch evt := event.Event.(type) {
-		case *stacks.PlanStackChanges_Event_ComponentInstancePolicyEvaluation:
-			gotEvents = append(gotEvents, evt)
-		case *stacks.PlanStackChanges_Event_Diagnostic:
-			diags = append(diags, event.GetDiagnostic())
-		default:
-			continue
-		}
-	}
-
-	if len(diags) > 0 {
-		t.Fatalf("unexpected diags: %v", diags)
-	}
+	wantEvents := make([]aggregatedPolicyEvent, 0)
+	gotEvents := collectPolicyEventsFromPlan(t, events)
 
 	if diff := cmp.Diff(wantEvents, gotEvents, protocmp.Transform(),
 		// Order of policy evaluation data is not guaranteed
-		protocmp.SortRepeatedFields(&stacks.PolicyEvaluationResponse{}, "results", "infos", "diagnostics"),
+		protocmp.SortRepeatedFields(&stacks.ComponentInstancePolicyEvaluation{}, "results", "infos", "diagnostics"),
+		protocmp.SortRepeatedFields(&stacks.ProviderInstancePolicyEvaluation{}, "results", "infos", "diagnostics"),
 	); diff != "" {
 		t.Fatalf("unexpected policy events\n%s", diff)
 	}
@@ -878,37 +788,13 @@ func TestStacksPlanStackChanges_noPolicyResultsForDestroy(t *testing.T) {
 	}
 
 	// No policy events should be emitted as this plan is in destroy mode
-	wantEvents := make([]*stacks.PlanStackChanges_Event_ComponentInstancePolicyEvaluation, 0)
-
-	// Collect policy evaluation + diagnostics
-	gotEvents := make([]*stacks.PlanStackChanges_Event_ComponentInstancePolicyEvaluation, 0)
-	var diags []*terraform1.Diagnostic
-	for {
-		event, err := events.Recv()
-		if err == io.EOF {
-			break
-		}
-		if err != nil {
-			t.Fatalf("unexpected error: %s", err)
-		}
-
-		switch evt := event.Event.(type) {
-		case *stacks.PlanStackChanges_Event_ComponentInstancePolicyEvaluation:
-			gotEvents = append(gotEvents, evt)
-		case *stacks.PlanStackChanges_Event_Diagnostic:
-			diags = append(diags, event.GetDiagnostic())
-		default:
-			continue
-		}
-	}
-
-	if len(diags) > 0 {
-		t.Fatalf("unexpected diags: %v", diags)
-	}
+	wantEvents := make([]aggregatedPolicyEvent, 0)
+	gotEvents := collectPolicyEventsFromPlan(t, events)
 
 	if diff := cmp.Diff(wantEvents, gotEvents, protocmp.Transform(),
 		// Order of policy evaluation data is not guaranteed
-		protocmp.SortRepeatedFields(&stacks.PolicyEvaluationResponse{}, "results", "infos", "diagnostics"),
+		protocmp.SortRepeatedFields(&stacks.ComponentInstancePolicyEvaluation{}, "results", "infos", "diagnostics"),
+		protocmp.SortRepeatedFields(&stacks.ProviderInstancePolicyEvaluation{}, "results", "infos", "diagnostics"),
 	); diff != "" {
 		t.Fatalf("unexpected policy events\n%s", diff)
 	}
@@ -1022,45 +908,13 @@ func TestStacksApplyStackChanges_noPolicies(t *testing.T) {
 	}
 
 	// No policy events should be emitted
-	wantEvents := make([]*stacks.ApplyStackChanges_Event_ComponentInstancePolicyEvaluation, 0)
-
-	// Collect policy evaluation + diagnostics
-	gotEvents := make([]*stacks.ApplyStackChanges_Event_ComponentInstancePolicyEvaluation, 0)
-	var diags []*terraform1.Diagnostic
-	for {
-		event, err := applyResp.Recv()
-		if err == io.EOF {
-			break
-		}
-		if err != nil {
-			t.Fatalf("unexpected error: %s", err)
-		}
-
-		switch evt := event.Event.(type) {
-		case *stacks.ApplyStackChanges_Event_ComponentInstancePolicyEvaluation:
-			gotEvents = append(gotEvents, evt)
-		case *stacks.ApplyStackChanges_Event_Diagnostic:
-			diags = append(diags, event.GetDiagnostic())
-		default:
-			continue
-		}
-	}
-
-	if len(diags) > 0 {
-		t.Fatalf("unexpected diags: %v", diags)
-	}
-
-	// Order of policy events is not guaranteed
-	slices.SortFunc(gotEvents, func(a, b *stacks.ApplyStackChanges_Event_ComponentInstancePolicyEvaluation) int {
-		return strings.Compare(
-			a.ComponentInstancePolicyEvaluation.GetAddr().GetComponentInstanceAddr(),
-			b.ComponentInstancePolicyEvaluation.GetAddr().GetComponentInstanceAddr(),
-		)
-	})
+	wantEvents := make([]aggregatedPolicyEvent, 0)
+	gotEvents := collectPolicyEventsFromApply(t, applyResp)
 
 	if diff := cmp.Diff(wantEvents, gotEvents, protocmp.Transform(),
 		// Order of policy evaluation data is not guaranteed
-		protocmp.SortRepeatedFields(&stacks.PolicyEvaluationResponse{}, "results", "infos", "diagnostics"),
+		protocmp.SortRepeatedFields(&stacks.ComponentInstancePolicyEvaluation{}, "results", "infos", "diagnostics"),
+		protocmp.SortRepeatedFields(&stacks.ProviderInstancePolicyEvaluation{}, "results", "infos", "diagnostics"),
 	); diff != "" {
 		t.Fatalf("unexpected policy events\n%s", diff)
 	}
@@ -1174,53 +1028,19 @@ func TestStacksApplyStackChanges_withPolicies(t *testing.T) {
 		t.Fatalf("unexpected error: %s", err)
 	}
 
-	// All components will output the same policy evaluation data from different addresses
-	wantEvents := []*stacks.ApplyStackChanges_Event_ComponentInstancePolicyEvaluation{
-		{
-			ComponentInstancePolicyEvaluation: createExpectedPolicyEvaluationResponse(`component.simple_component["comp1"]`),
-		},
-		{
-			ComponentInstancePolicyEvaluation: createExpectedPolicyEvaluationResponse(`component.simple_component["comp2"]`),
-		},
+	wantEvents := []aggregatedPolicyEvent{
+		createExpectedComponentInstancePolicyEvaluation(`component.simple_component["comp1"]`),
+		createExpectedComponentInstancePolicyEvaluation(`component.simple_component["comp2"]`),
+		createExpectedProviderInstancePolicyEvaluation(`provider["registry.terraform.io/hashicorp/testing"].default["comp1"]`),
+		createExpectedProviderInstancePolicyEvaluation(`provider["registry.terraform.io/hashicorp/testing"].default["comp2"]`),
 	}
 
-	// Collect policy evaluation + diagnostics
-	gotEvents := make([]*stacks.ApplyStackChanges_Event_ComponentInstancePolicyEvaluation, 0)
-	var diags []*terraform1.Diagnostic
-	for {
-		event, err := applyResp.Recv()
-		if err == io.EOF {
-			break
-		}
-		if err != nil {
-			t.Fatalf("unexpected error: %s", err)
-		}
-
-		switch evt := event.Event.(type) {
-		case *stacks.ApplyStackChanges_Event_ComponentInstancePolicyEvaluation:
-			gotEvents = append(gotEvents, evt)
-		case *stacks.ApplyStackChanges_Event_Diagnostic:
-			diags = append(diags, event.GetDiagnostic())
-		default:
-			continue
-		}
-	}
-
-	if len(diags) > 0 {
-		t.Fatalf("unexpected diags: %v", diags)
-	}
-
-	// Order of policy events is not guaranteed
-	slices.SortFunc(gotEvents, func(a, b *stacks.ApplyStackChanges_Event_ComponentInstancePolicyEvaluation) int {
-		return strings.Compare(
-			a.ComponentInstancePolicyEvaluation.GetAddr().GetComponentInstanceAddr(),
-			b.ComponentInstancePolicyEvaluation.GetAddr().GetComponentInstanceAddr(),
-		)
-	})
+	gotEvents := collectPolicyEventsFromApply(t, applyResp)
 
 	if diff := cmp.Diff(wantEvents, gotEvents, protocmp.Transform(),
 		// Order of policy evaluation data is not guaranteed
-		protocmp.SortRepeatedFields(&stacks.PolicyEvaluationResponse{}, "results", "infos", "diagnostics"),
+		protocmp.SortRepeatedFields(&stacks.ComponentInstancePolicyEvaluation{}, "results", "infos", "diagnostics"),
+		protocmp.SortRepeatedFields(&stacks.ProviderInstancePolicyEvaluation{}, "results", "infos", "diagnostics"),
 	); diff != "" {
 		t.Fatalf("unexpected policy events\n%s", diff)
 	}
@@ -1335,38 +1155,21 @@ func TestStacksApplyStackChanges_noPolicyResultsForRefresh(t *testing.T) {
 		t.Fatalf("unexpected error: %s", err)
 	}
 
-	// No policy events should be emitted as the plan for this apply was created in refresh mode
-	wantEvents := make([]*stacks.ApplyStackChanges_Event_ComponentInstancePolicyEvaluation, 0)
-
-	// Collect policy evaluation + diagnostics
-	gotEvents := make([]*stacks.ApplyStackChanges_Event_ComponentInstancePolicyEvaluation, 0)
-	var diags []*terraform1.Diagnostic
-	for {
-		event, err := applyResp.Recv()
-		if err == io.EOF {
-			break
-		}
-		if err != nil {
-			t.Fatalf("unexpected error: %s", err)
-		}
-
-		switch evt := event.Event.(type) {
-		case *stacks.ApplyStackChanges_Event_ComponentInstancePolicyEvaluation:
-			gotEvents = append(gotEvents, evt)
-		case *stacks.ApplyStackChanges_Event_Diagnostic:
-			diags = append(diags, event.GetDiagnostic())
-		default:
-			continue
-		}
+	// TODO: This is currently bugged because ApplyStackChanges is using the stackplan Mode field to control running policy evaluation,
+	// but that field is not serialized or deserialized from the plan itself.
+	//
+	// This test may eventually be modified anyways, so we just expect just provider policies to be evaluated for now
+	wantEvents := []aggregatedPolicyEvent{
+		createExpectedProviderInstancePolicyEvaluation(`provider["registry.terraform.io/hashicorp/testing"].default["comp1"]`),
+		createExpectedProviderInstancePolicyEvaluation(`provider["registry.terraform.io/hashicorp/testing"].default["comp2"]`),
 	}
 
-	if len(diags) > 0 {
-		t.Fatalf("unexpected diags: %v", diags)
-	}
+	gotEvents := collectPolicyEventsFromApply(t, applyResp)
 
 	if diff := cmp.Diff(wantEvents, gotEvents, protocmp.Transform(),
 		// Order of policy evaluation data is not guaranteed
-		protocmp.SortRepeatedFields(&stacks.PolicyEvaluationResponse{}, "results", "infos", "diagnostics"),
+		protocmp.SortRepeatedFields(&stacks.ComponentInstancePolicyEvaluation{}, "results", "infos", "diagnostics"),
+		protocmp.SortRepeatedFields(&stacks.ProviderInstancePolicyEvaluation{}, "results", "infos", "diagnostics"),
 	); diff != "" {
 		t.Fatalf("unexpected policy events\n%s", diff)
 	}
@@ -1481,38 +1284,20 @@ func TestStacksApplyStackChanges_noPolicyResultsForDestroy(t *testing.T) {
 		t.Fatalf("unexpected error: %s", err)
 	}
 
-	// No policy events should be emitted as the plan for this apply was created in destroy mode
-	wantEvents := make([]*stacks.ApplyStackChanges_Event_ComponentInstancePolicyEvaluation, 0)
-
-	// Collect policy evaluation + diagnostics
-	gotEvents := make([]*stacks.ApplyStackChanges_Event_ComponentInstancePolicyEvaluation, 0)
-	var diags []*terraform1.Diagnostic
-	for {
-		event, err := applyResp.Recv()
-		if err == io.EOF {
-			break
-		}
-		if err != nil {
-			t.Fatalf("unexpected error: %s", err)
-		}
-
-		switch evt := event.Event.(type) {
-		case *stacks.ApplyStackChanges_Event_ComponentInstancePolicyEvaluation:
-			gotEvents = append(gotEvents, evt)
-		case *stacks.ApplyStackChanges_Event_Diagnostic:
-			diags = append(diags, event.GetDiagnostic())
-		default:
-			continue
-		}
+	// TODO: This is currently bugged because ApplyStackChanges is using the stackplan Mode field to control running policy evaluation,
+	// but that field is not serialized or deserialized from the plan itself.
+	//
+	// This test may eventually be modified anyways, so we just expect just provider policies to be evaluated for now
+	wantEvents := []aggregatedPolicyEvent{
+		createExpectedProviderInstancePolicyEvaluation(`provider["registry.terraform.io/hashicorp/testing"].default["comp1"]`),
+		createExpectedProviderInstancePolicyEvaluation(`provider["registry.terraform.io/hashicorp/testing"].default["comp2"]`),
 	}
-
-	if len(diags) > 0 {
-		t.Fatalf("unexpected diags: %v", diags)
-	}
+	gotEvents := collectPolicyEventsFromApply(t, applyResp)
 
 	if diff := cmp.Diff(wantEvents, gotEvents, protocmp.Transform(),
 		// Order of policy evaluation data is not guaranteed
-		protocmp.SortRepeatedFields(&stacks.PolicyEvaluationResponse{}, "results", "infos", "diagnostics"),
+		protocmp.SortRepeatedFields(&stacks.ComponentInstancePolicyEvaluation{}, "results", "infos", "diagnostics"),
+		protocmp.SortRepeatedFields(&stacks.ProviderInstancePolicyEvaluation{}, "results", "infos", "diagnostics"),
 	); diff != "" {
 		t.Fatalf("unexpected policy events\n%s", diff)
 	}
@@ -3230,15 +3015,43 @@ func policyEvaluationTestClient(t *testing.T) policy.Client {
 	}
 
 	policyClient.EvaluateProviderFn = func(ctx context.Context, req policy.EvaluationRequest[*policyproto.PolicyEvaluateProviderRequest_ProviderMetadata]) policy.EvaluationResponse {
-		// TODO: Update this test to assert provider policy evaluation when we add it to the stacks runtime (follow-up PR)
-		t.Fatal("unexpected call to provider policy evaluation")
-		return policy.EvaluationResponse{}
+		// Assert provider data
+		expectedMeta := &policyproto.PolicyEvaluateProviderRequest_ProviderMetadata{
+			Name:      "testing",
+			Alias:     "default",
+			Namespace: "hashicorp",
+			Source:    "registry.terraform.io/hashicorp/testing",
+			Version:   "0.0.0",
+		}
+		if diff := cmp.Diff(req.Meta, expectedMeta, protocmp.Transform()); diff != "" {
+			t.Fatalf("unexpected provider metadata\n%s", diff)
+		}
+
+		val := req.Attrs.Raw.GetAttr("ignored")
+		if !strings.HasPrefix(val.AsString(), "comp") {
+			t.Fatalf(`unexpected resource data, wanted: attr.ignored to start with "comp", got: %q`, val.AsString())
+		}
+
+		return policy.EvaluationResponse{
+			Overall:  policy.DenyResult,
+			Policies: []*policy.Policy{policyObj(policy.DenyResult)},
+			Diagnostics: policy.DiagsFromProto([]*policyproto.Diagnostic{
+				{
+					Severity: policyproto.Severity_ERROR,
+					Summary:  "Provider policy violation",
+					Detail:   "testing provider violates policy",
+					Result: &policyproto.DiagnosticResult{
+						Result: policyproto.EvaluateResult_DENY_EVALUATE_RESULT,
+					},
+				},
+			}, nil),
+		}
 	}
 
 	return policyClient
 }
 
-func createExpectedPolicyEvaluationResponse(componentInstanceAddr string) *stacks.PolicyEvaluationResponse {
+func createExpectedComponentInstancePolicyEvaluation(componentInstanceAddr string) aggregatedPolicyEvent {
 	expectedPolicyMetadata := &stacks.PolicyMetaData{
 		PolicyName:       "policy_name",
 		PolicySetName:    "some_policy_set",
@@ -3246,83 +3059,223 @@ func createExpectedPolicyEvaluationResponse(componentInstanceAddr string) *stack
 		FileName:         "policy_file.tfpolicy.hcl",
 	}
 
-	return &stacks.PolicyEvaluationResponse{
-		Addr: &stacks.ComponentInstanceInStackAddr{
-			ComponentAddr:         "component.simple_component",
-			ComponentInstanceAddr: componentInstanceAddr,
-		},
-		Results: []*stacks.PolicyResult{
-			{
-				TargetAddress:  "module.child.testing_resource.child_resource",
-				PolicyMetadata: expectedPolicyMetadata,
-				Result:         stacks.EvaluateResult_DENY_EVALUATE_RESULT,
+	return aggregatedPolicyEvent{
+		Addr: componentInstanceAddr,
+		PolicyEvalautionProto: &stacks.ComponentInstancePolicyEvaluation{
+			Addr: &stacks.ComponentInstanceInStackAddr{
+				ComponentAddr:         "component.simple_component",
+				ComponentInstanceAddr: componentInstanceAddr,
 			},
-			{
-				TargetAddress:  "testing_resource.parent_resource",
-				PolicyMetadata: expectedPolicyMetadata,
-				Result:         stacks.EvaluateResult_ALLOW_EVALUATE_RESULT,
-			},
-			{
-				TargetAddress:  "module.child",
-				PolicyMetadata: expectedPolicyMetadata,
-				Result:         stacks.EvaluateResult_DENY_EVALUATE_RESULT,
-			},
-		},
-		Infos: []*stacks.PolicyInfo{
-			{
-				TargetAddress: "testing_resource.parent_resource",
-				PolicyMetadata: &stacks.PolicyMetaData{
-					PolicyName:       "policy_name",
-					PolicySetName:    "some_policy_set",
-					EnforcementLevel: "mandatory",
-					FileName:         "policy_file.tfpolicy.hcl",
-					EnforceIndex:     1,
+			Results: []*stacks.PolicyResult{
+				{
+					TargetAddress:  "module.child.testing_resource.child_resource",
+					PolicyMetadata: expectedPolicyMetadata,
+					Result:         stacks.EvaluateResult_DENY_EVALUATE_RESULT,
 				},
-				Message: "just an advisory message",
-				Result:  stacks.EvaluateResult_ALLOW_EVALUATE_RESULT,
-			},
-		},
-		Diagnostics: []*stacks.PolicyDiagnostic{
-			{
-				TargetAddress:  "module.child.testing_resource.child_resource",
-				PolicyMetadata: &stacks.PolicyMetaData{},
-				Result:         stacks.EvaluateResult_DENY_EVALUATE_RESULT,
-				Diagnostic: &terraform1.Diagnostic{
-					Severity: terraform1.Diagnostic_ERROR,
-					Summary:  "Child module resource violation",
-					Detail:   "module.child.testing_resource.child_resource violates policy",
-					Subject: &terraform1.SourceRange{
-						SourceAddr: "git::https://example.com/multiple-components.git//child/main.tf",
-						Start:      &terraform1.SourcePos{Byte: 161, Line: 14, Column: 1},
-						End:        &terraform1.SourcePos{Byte: 205, Line: 14, Column: 45},
-					},
-					Context: &terraform1.SourceRange{
-						SourceAddr: "git::https://example.com/multiple-components.git//child/main.tf",
-						Start:      &terraform1.SourcePos{Byte: 161, Line: 14, Column: 1},
-						End:        &terraform1.SourcePos{Byte: 205, Line: 14, Column: 45},
-					},
+				{
+					TargetAddress:  "testing_resource.parent_resource",
+					PolicyMetadata: expectedPolicyMetadata,
+					Result:         stacks.EvaluateResult_ALLOW_EVALUATE_RESULT,
+				},
+				{
+					TargetAddress:  "module.child",
+					PolicyMetadata: expectedPolicyMetadata,
+					Result:         stacks.EvaluateResult_DENY_EVALUATE_RESULT,
 				},
 			},
-			{
-				TargetAddress:  "module.child",
-				PolicyMetadata: &stacks.PolicyMetaData{},
-				Result:         stacks.EvaluateResult_DENY_EVALUATE_RESULT,
-				Diagnostic: &terraform1.Diagnostic{
-					Severity: terraform1.Diagnostic_ERROR,
-					Summary:  "Child module policy violation",
-					Detail:   "module.child violates policy",
-					Subject: &terraform1.SourceRange{
-						SourceAddr: "git::https://example.com/multiple-components.git//main.tf",
-						Start:      &terraform1.SourcePos{Byte: 259, Line: 18, Column: 1},
-						End:        &terraform1.SourcePos{Byte: 273, Line: 18, Column: 15},
+			Infos: []*stacks.PolicyInfo{
+				{
+					TargetAddress: "testing_resource.parent_resource",
+					PolicyMetadata: &stacks.PolicyMetaData{
+						PolicyName:       "policy_name",
+						PolicySetName:    "some_policy_set",
+						EnforcementLevel: "mandatory",
+						FileName:         "policy_file.tfpolicy.hcl",
+						EnforceIndex:     1,
 					},
-					Context: &terraform1.SourceRange{
-						SourceAddr: "git::https://example.com/multiple-components.git//main.tf",
-						Start:      &terraform1.SourcePos{Byte: 259, Line: 18, Column: 1},
-						End:        &terraform1.SourcePos{Byte: 273, Line: 18, Column: 15},
+					Message: "just an advisory message",
+					Result:  stacks.EvaluateResult_ALLOW_EVALUATE_RESULT,
+				},
+			},
+			Diagnostics: []*stacks.PolicyDiagnostic{
+				{
+					TargetAddress:  "module.child.testing_resource.child_resource",
+					PolicyMetadata: &stacks.PolicyMetaData{},
+					Result:         stacks.EvaluateResult_DENY_EVALUATE_RESULT,
+					Diagnostic: &terraform1.Diagnostic{
+						Severity: terraform1.Diagnostic_ERROR,
+						Summary:  "Child module resource violation",
+						Detail:   "module.child.testing_resource.child_resource violates policy",
+						Subject: &terraform1.SourceRange{
+							SourceAddr: "git::https://example.com/multiple-components.git//child/main.tf",
+							Start:      &terraform1.SourcePos{Byte: 161, Line: 14, Column: 1},
+							End:        &terraform1.SourcePos{Byte: 205, Line: 14, Column: 45},
+						},
+						Context: &terraform1.SourceRange{
+							SourceAddr: "git::https://example.com/multiple-components.git//child/main.tf",
+							Start:      &terraform1.SourcePos{Byte: 161, Line: 14, Column: 1},
+							End:        &terraform1.SourcePos{Byte: 205, Line: 14, Column: 45},
+						},
+					},
+				},
+				{
+					TargetAddress:  "module.child",
+					PolicyMetadata: &stacks.PolicyMetaData{},
+					Result:         stacks.EvaluateResult_DENY_EVALUATE_RESULT,
+					Diagnostic: &terraform1.Diagnostic{
+						Severity: terraform1.Diagnostic_ERROR,
+						Summary:  "Child module policy violation",
+						Detail:   "module.child violates policy",
+						Subject: &terraform1.SourceRange{
+							SourceAddr: "git::https://example.com/multiple-components.git//main.tf",
+							Start:      &terraform1.SourcePos{Byte: 259, Line: 18, Column: 1},
+							End:        &terraform1.SourcePos{Byte: 273, Line: 18, Column: 15},
+						},
+						Context: &terraform1.SourceRange{
+							SourceAddr: "git::https://example.com/multiple-components.git//main.tf",
+							Start:      &terraform1.SourcePos{Byte: 259, Line: 18, Column: 1},
+							End:        &terraform1.SourcePos{Byte: 273, Line: 18, Column: 15},
+						},
 					},
 				},
 			},
 		},
 	}
+}
+
+func createExpectedProviderInstancePolicyEvaluation(providerInstanceAddr string) aggregatedPolicyEvent {
+	expectedPolicyMetadata := &stacks.PolicyMetaData{
+		PolicyName:       "policy_name",
+		PolicySetName:    "some_policy_set",
+		EnforcementLevel: "mandatory",
+		FileName:         "policy_file.tfpolicy.hcl",
+	}
+
+	providerAddr := `provider["registry.terraform.io/hashicorp/testing"].default`
+	return aggregatedPolicyEvent{
+		Addr: providerInstanceAddr,
+		PolicyEvalautionProto: &stacks.ProviderInstancePolicyEvaluation{
+			Addr: &stacks.ProviderInstanceInStackAddr{
+				ProviderAddr:         providerAddr,
+				ProviderInstanceAddr: providerInstanceAddr,
+			},
+			Results: []*stacks.PolicyResult{
+				{
+					TargetAddress:  providerAddr,
+					PolicyMetadata: expectedPolicyMetadata,
+					Result:         stacks.EvaluateResult_DENY_EVALUATE_RESULT,
+				},
+			},
+			Infos: []*stacks.PolicyInfo{},
+			Diagnostics: []*stacks.PolicyDiagnostic{
+				{
+					TargetAddress:  providerAddr,
+					PolicyMetadata: &stacks.PolicyMetaData{},
+					Result:         stacks.EvaluateResult_DENY_EVALUATE_RESULT,
+					Diagnostic: &terraform1.Diagnostic{
+						Severity: terraform1.Diagnostic_ERROR,
+						Summary:  "Provider policy violation",
+						Detail:   "testing provider violates policy",
+					},
+				},
+			},
+		},
+	}
+}
+
+func collectPolicyEventsFromPlan(t *testing.T, planEvents grpc.ServerStreamingClient[stacks.PlanStackChanges_Event]) []aggregatedPolicyEvent {
+	t.Helper()
+
+	gotEvents := make([]aggregatedPolicyEvent, 0)
+	var diags []*terraform1.Diagnostic
+	for {
+		event, err := planEvents.Recv()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("unexpected error: %s", err)
+		}
+
+		switch evt := event.Event.(type) {
+		case *stacks.PlanStackChanges_Event_ComponentInstancePolicyEvaluation:
+			gotEvents = append(gotEvents, aggregatedPolicyEvent{
+				Addr:                  evt.ComponentInstancePolicyEvaluation.GetAddr().GetComponentInstanceAddr(),
+				PolicyEvalautionProto: evt.ComponentInstancePolicyEvaluation,
+			})
+		case *stacks.PlanStackChanges_Event_ProviderInstancePolicyEvaluation:
+			gotEvents = append(gotEvents, aggregatedPolicyEvent{
+				Addr:                  evt.ProviderInstancePolicyEvaluation.GetAddr().GetProviderInstanceAddr(),
+				PolicyEvalautionProto: evt.ProviderInstancePolicyEvaluation,
+			})
+		case *stacks.PlanStackChanges_Event_Diagnostic:
+			diags = append(diags, event.GetDiagnostic())
+		default:
+			continue
+		}
+	}
+
+	if len(diags) > 0 {
+		t.Fatalf("unexpected diags: %v", diags)
+	}
+
+	// Order of policy events is not guaranteed
+	slices.SortFunc(gotEvents, func(a, b aggregatedPolicyEvent) int {
+		return strings.Compare(
+			a.Addr,
+			b.Addr,
+		)
+	})
+
+	return gotEvents
+}
+
+func collectPolicyEventsFromApply(t *testing.T, applyEvents grpc.ServerStreamingClient[stacks.ApplyStackChanges_Event]) []aggregatedPolicyEvent {
+	gotEvents := make([]aggregatedPolicyEvent, 0)
+	var diags []*terraform1.Diagnostic
+	for {
+		event, err := applyEvents.Recv()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("unexpected error: %s", err)
+		}
+
+		switch evt := event.Event.(type) {
+		case *stacks.ApplyStackChanges_Event_ComponentInstancePolicyEvaluation:
+			gotEvents = append(gotEvents, aggregatedPolicyEvent{
+				Addr:                  evt.ComponentInstancePolicyEvaluation.GetAddr().GetComponentInstanceAddr(),
+				PolicyEvalautionProto: evt.ComponentInstancePolicyEvaluation,
+			})
+		case *stacks.ApplyStackChanges_Event_ProviderInstancePolicyEvaluation:
+			gotEvents = append(gotEvents, aggregatedPolicyEvent{
+				Addr:                  evt.ProviderInstancePolicyEvaluation.GetAddr().GetProviderInstanceAddr(),
+				PolicyEvalautionProto: evt.ProviderInstancePolicyEvaluation,
+			})
+		case *stacks.ApplyStackChanges_Event_Diagnostic:
+			diags = append(diags, event.GetDiagnostic())
+		default:
+			continue
+		}
+	}
+
+	if len(diags) > 0 {
+		t.Fatalf("unexpected diags: %v", diags)
+	}
+
+	// Order of policy events is not guaranteed
+	slices.SortFunc(gotEvents, func(a, b aggregatedPolicyEvent) int {
+		return strings.Compare(
+			a.Addr,
+			b.Addr,
+		)
+	})
+
+	return gotEvents
+}
+
+type aggregatedPolicyEvent struct {
+	Addr                  string
+	PolicyEvalautionProto any
 }

--- a/internal/rpcapi/stacks_test.go
+++ b/internal/rpcapi/stacks_test.go
@@ -3176,6 +3176,16 @@ func createExpectedProviderInstancePolicyEvaluation(providerInstanceAddr string)
 						Severity: terraform1.Diagnostic_ERROR,
 						Summary:  "Provider policy violation",
 						Detail:   "testing provider violates policy",
+						Subject: &terraform1.SourceRange{
+							SourceAddr: "git::https://example.com/multiple-components.git//main.tfcomponent.hcl",
+							Start:      &terraform1.SourcePos{Byte: 98, Line: 8, Column: 1},
+							End:        &terraform1.SourcePos{Byte: 126, Line: 8, Column: 29},
+						},
+						Context: &terraform1.SourceRange{
+							SourceAddr: "git::https://example.com/multiple-components.git//main.tfcomponent.hcl",
+							Start:      &terraform1.SourcePos{Byte: 98, Line: 8, Column: 1},
+							End:        &terraform1.SourcePos{Byte: 126, Line: 8, Column: 29},
+						},
 					},
 				},
 			},

--- a/internal/rpcapi/terraform1/stacks/stacks.pb.go
+++ b/internal/rpcapi/terraform1/stacks/stacks.pb.go
@@ -352,7 +352,7 @@ func (x PlannedChange_ActionTriggerEvent) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use PlannedChange_ActionTriggerEvent.Descriptor instead.
 func (PlannedChange_ActionTriggerEvent) EnumDescriptor() ([]byte, []int) {
-	return file_stacks_proto_rawDescGZIP(), []int{23, 0}
+	return file_stacks_proto_rawDescGZIP(), []int{24, 0}
 }
 
 // Reason describes the reason why a resource instance change was
@@ -412,7 +412,7 @@ func (x Deferred_Reason) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use Deferred_Reason.Descriptor instead.
 func (Deferred_Reason) EnumDescriptor() ([]byte, []int) {
-	return file_stacks_proto_rawDescGZIP(), []int{24, 0}
+	return file_stacks_proto_rawDescGZIP(), []int{25, 0}
 }
 
 // ActionTriggerEvent describes the reason an action was triggered
@@ -477,7 +477,7 @@ func (x StackChangeProgress_ActionTriggerEvent) Number() protoreflect.EnumNumber
 
 // Deprecated: Use StackChangeProgress_ActionTriggerEvent.Descriptor instead.
 func (StackChangeProgress_ActionTriggerEvent) EnumDescriptor() ([]byte, []int) {
-	return file_stacks_proto_rawDescGZIP(), []int{26, 0}
+	return file_stacks_proto_rawDescGZIP(), []int{27, 0}
 }
 
 type StackChangeProgress_ComponentInstanceStatus_Status int32
@@ -541,7 +541,7 @@ func (x StackChangeProgress_ComponentInstanceStatus_Status) Number() protoreflec
 
 // Deprecated: Use StackChangeProgress_ComponentInstanceStatus_Status.Descriptor instead.
 func (StackChangeProgress_ComponentInstanceStatus_Status) EnumDescriptor() ([]byte, []int) {
-	return file_stacks_proto_rawDescGZIP(), []int{26, 0, 0}
+	return file_stacks_proto_rawDescGZIP(), []int{27, 0, 0}
 }
 
 type StackChangeProgress_ResourceInstanceStatus_Status int32
@@ -608,7 +608,7 @@ func (x StackChangeProgress_ResourceInstanceStatus_Status) Number() protoreflect
 
 // Deprecated: Use StackChangeProgress_ResourceInstanceStatus_Status.Descriptor instead.
 func (StackChangeProgress_ResourceInstanceStatus_Status) EnumDescriptor() ([]byte, []int) {
-	return file_stacks_proto_rawDescGZIP(), []int{26, 1, 0}
+	return file_stacks_proto_rawDescGZIP(), []int{27, 1, 0}
 }
 
 type StackChangeProgress_ActionInvocationStatus_Status int32
@@ -663,7 +663,7 @@ func (x StackChangeProgress_ActionInvocationStatus_Status) Number() protoreflect
 
 // Deprecated: Use StackChangeProgress_ActionInvocationStatus_Status.Descriptor instead.
 func (StackChangeProgress_ActionInvocationStatus_Status) EnumDescriptor() ([]byte, []int) {
-	return file_stacks_proto_rawDescGZIP(), []int{26, 5, 0}
+	return file_stacks_proto_rawDescGZIP(), []int{27, 5, 0}
 }
 
 type StackChangeProgress_ProvisionerStatus_Status int32
@@ -715,7 +715,7 @@ func (x StackChangeProgress_ProvisionerStatus_Status) Number() protoreflect.Enum
 
 // Deprecated: Use StackChangeProgress_ProvisionerStatus_Status.Descriptor instead.
 func (StackChangeProgress_ProvisionerStatus_Status) EnumDescriptor() ([]byte, []int) {
-	return file_stacks_proto_rawDescGZIP(), []int{26, 9, 0}
+	return file_stacks_proto_rawDescGZIP(), []int{27, 9, 0}
 }
 
 // OpenTerraformState opens a previously-saved Terraform state, returning a
@@ -1477,6 +1477,61 @@ func (x *AttributePath) GetSteps() []*AttributePath_Step {
 	return nil
 }
 
+// Represents the address of a specific provider instance within a stack.
+type ProviderInstanceInStackAddr struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// The address of the static provider config that this is an instance of.
+	ProviderAddr string `protobuf:"bytes,1,opt,name=provider_addr,json=providerAddr,proto3" json:"provider_addr,omitempty"`
+	// The address of the provider instance config.
+	ProviderInstanceAddr string `protobuf:"bytes,2,opt,name=provider_instance_addr,json=providerInstanceAddr,proto3" json:"provider_instance_addr,omitempty"`
+	unknownFields        protoimpl.UnknownFields
+	sizeCache            protoimpl.SizeCache
+}
+
+func (x *ProviderInstanceInStackAddr) Reset() {
+	*x = ProviderInstanceInStackAddr{}
+	mi := &file_stacks_proto_msgTypes[19]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ProviderInstanceInStackAddr) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ProviderInstanceInStackAddr) ProtoMessage() {}
+
+func (x *ProviderInstanceInStackAddr) ProtoReflect() protoreflect.Message {
+	mi := &file_stacks_proto_msgTypes[19]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ProviderInstanceInStackAddr.ProtoReflect.Descriptor instead.
+func (*ProviderInstanceInStackAddr) Descriptor() ([]byte, []int) {
+	return file_stacks_proto_rawDescGZIP(), []int{19}
+}
+
+func (x *ProviderInstanceInStackAddr) GetProviderAddr() string {
+	if x != nil {
+		return x.ProviderAddr
+	}
+	return ""
+}
+
+func (x *ProviderInstanceInStackAddr) GetProviderInstanceAddr() string {
+	if x != nil {
+		return x.ProviderInstanceAddr
+	}
+	return ""
+}
+
 // Represents the address of a specific component instance within a stack.
 type ComponentInstanceInStackAddr struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
@@ -1493,7 +1548,7 @@ type ComponentInstanceInStackAddr struct {
 
 func (x *ComponentInstanceInStackAddr) Reset() {
 	*x = ComponentInstanceInStackAddr{}
-	mi := &file_stacks_proto_msgTypes[19]
+	mi := &file_stacks_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1505,7 +1560,7 @@ func (x *ComponentInstanceInStackAddr) String() string {
 func (*ComponentInstanceInStackAddr) ProtoMessage() {}
 
 func (x *ComponentInstanceInStackAddr) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[19]
+	mi := &file_stacks_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1518,7 +1573,7 @@ func (x *ComponentInstanceInStackAddr) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ComponentInstanceInStackAddr.ProtoReflect.Descriptor instead.
 func (*ComponentInstanceInStackAddr) Descriptor() ([]byte, []int) {
-	return file_stacks_proto_rawDescGZIP(), []int{19}
+	return file_stacks_proto_rawDescGZIP(), []int{20}
 }
 
 func (x *ComponentInstanceInStackAddr) GetComponentAddr() string {
@@ -1553,7 +1608,7 @@ type ActionInvocationInstanceInStackAddr struct {
 
 func (x *ActionInvocationInstanceInStackAddr) Reset() {
 	*x = ActionInvocationInstanceInStackAddr{}
-	mi := &file_stacks_proto_msgTypes[20]
+	mi := &file_stacks_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1565,7 +1620,7 @@ func (x *ActionInvocationInstanceInStackAddr) String() string {
 func (*ActionInvocationInstanceInStackAddr) ProtoMessage() {}
 
 func (x *ActionInvocationInstanceInStackAddr) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[20]
+	mi := &file_stacks_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1578,7 +1633,7 @@ func (x *ActionInvocationInstanceInStackAddr) ProtoReflect() protoreflect.Messag
 
 // Deprecated: Use ActionInvocationInstanceInStackAddr.ProtoReflect.Descriptor instead.
 func (*ActionInvocationInstanceInStackAddr) Descriptor() ([]byte, []int) {
-	return file_stacks_proto_rawDescGZIP(), []int{20}
+	return file_stacks_proto_rawDescGZIP(), []int{21}
 }
 
 func (x *ActionInvocationInstanceInStackAddr) GetComponentInstanceAddr() string {
@@ -1613,7 +1668,7 @@ type ResourceInstanceInStackAddr struct {
 
 func (x *ResourceInstanceInStackAddr) Reset() {
 	*x = ResourceInstanceInStackAddr{}
-	mi := &file_stacks_proto_msgTypes[21]
+	mi := &file_stacks_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1625,7 +1680,7 @@ func (x *ResourceInstanceInStackAddr) String() string {
 func (*ResourceInstanceInStackAddr) ProtoMessage() {}
 
 func (x *ResourceInstanceInStackAddr) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[21]
+	mi := &file_stacks_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1638,7 +1693,7 @@ func (x *ResourceInstanceInStackAddr) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ResourceInstanceInStackAddr.ProtoReflect.Descriptor instead.
 func (*ResourceInstanceInStackAddr) Descriptor() ([]byte, []int) {
-	return file_stacks_proto_rawDescGZIP(), []int{21}
+	return file_stacks_proto_rawDescGZIP(), []int{22}
 }
 
 func (x *ResourceInstanceInStackAddr) GetComponentInstanceAddr() string {
@@ -1678,7 +1733,7 @@ type ResourceInstanceObjectInStackAddr struct {
 
 func (x *ResourceInstanceObjectInStackAddr) Reset() {
 	*x = ResourceInstanceObjectInStackAddr{}
-	mi := &file_stacks_proto_msgTypes[22]
+	mi := &file_stacks_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1690,7 +1745,7 @@ func (x *ResourceInstanceObjectInStackAddr) String() string {
 func (*ResourceInstanceObjectInStackAddr) ProtoMessage() {}
 
 func (x *ResourceInstanceObjectInStackAddr) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[22]
+	mi := &file_stacks_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1703,7 +1758,7 @@ func (x *ResourceInstanceObjectInStackAddr) ProtoReflect() protoreflect.Message 
 
 // Deprecated: Use ResourceInstanceObjectInStackAddr.ProtoReflect.Descriptor instead.
 func (*ResourceInstanceObjectInStackAddr) Descriptor() ([]byte, []int) {
-	return file_stacks_proto_rawDescGZIP(), []int{22}
+	return file_stacks_proto_rawDescGZIP(), []int{23}
 }
 
 func (x *ResourceInstanceObjectInStackAddr) GetComponentInstanceAddr() string {
@@ -1771,7 +1826,7 @@ type PlannedChange struct {
 
 func (x *PlannedChange) Reset() {
 	*x = PlannedChange{}
-	mi := &file_stacks_proto_msgTypes[23]
+	mi := &file_stacks_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1783,7 +1838,7 @@ func (x *PlannedChange) String() string {
 func (*PlannedChange) ProtoMessage() {}
 
 func (x *PlannedChange) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[23]
+	mi := &file_stacks_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1796,7 +1851,7 @@ func (x *PlannedChange) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PlannedChange.ProtoReflect.Descriptor instead.
 func (*PlannedChange) Descriptor() ([]byte, []int) {
-	return file_stacks_proto_rawDescGZIP(), []int{23}
+	return file_stacks_proto_rawDescGZIP(), []int{24}
 }
 
 func (x *PlannedChange) GetRaw() []*anypb.Any {
@@ -1824,7 +1879,7 @@ type Deferred struct {
 
 func (x *Deferred) Reset() {
 	*x = Deferred{}
-	mi := &file_stacks_proto_msgTypes[24]
+	mi := &file_stacks_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1836,7 +1891,7 @@ func (x *Deferred) String() string {
 func (*Deferred) ProtoMessage() {}
 
 func (x *Deferred) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[24]
+	mi := &file_stacks_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1849,7 +1904,7 @@ func (x *Deferred) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Deferred.ProtoReflect.Descriptor instead.
 func (*Deferred) Descriptor() ([]byte, []int) {
-	return file_stacks_proto_rawDescGZIP(), []int{24}
+	return file_stacks_proto_rawDescGZIP(), []int{25}
 }
 
 func (x *Deferred) GetReason() Deferred_Reason {
@@ -1931,7 +1986,7 @@ type AppliedChange struct {
 
 func (x *AppliedChange) Reset() {
 	*x = AppliedChange{}
-	mi := &file_stacks_proto_msgTypes[25]
+	mi := &file_stacks_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1943,7 +1998,7 @@ func (x *AppliedChange) String() string {
 func (*AppliedChange) ProtoMessage() {}
 
 func (x *AppliedChange) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[25]
+	mi := &file_stacks_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1956,7 +2011,7 @@ func (x *AppliedChange) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AppliedChange.ProtoReflect.Descriptor instead.
 func (*AppliedChange) Descriptor() ([]byte, []int) {
-	return file_stacks_proto_rawDescGZIP(), []int{25}
+	return file_stacks_proto_rawDescGZIP(), []int{26}
 }
 
 func (x *AppliedChange) GetRaw() []*AppliedChange_RawChange {
@@ -2002,7 +2057,7 @@ type StackChangeProgress struct {
 
 func (x *StackChangeProgress) Reset() {
 	*x = StackChangeProgress{}
-	mi := &file_stacks_proto_msgTypes[26]
+	mi := &file_stacks_proto_msgTypes[27]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2014,7 +2069,7 @@ func (x *StackChangeProgress) String() string {
 func (*StackChangeProgress) ProtoMessage() {}
 
 func (x *StackChangeProgress) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[26]
+	mi := &file_stacks_proto_msgTypes[27]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2027,7 +2082,7 @@ func (x *StackChangeProgress) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StackChangeProgress.ProtoReflect.Descriptor instead.
 func (*StackChangeProgress) Descriptor() ([]byte, []int) {
-	return file_stacks_proto_rawDescGZIP(), []int{26}
+	return file_stacks_proto_rawDescGZIP(), []int{27}
 }
 
 func (x *StackChangeProgress) GetEvent() isStackChangeProgress_Event {
@@ -2214,7 +2269,7 @@ type ListResourceIdentities struct {
 
 func (x *ListResourceIdentities) Reset() {
 	*x = ListResourceIdentities{}
-	mi := &file_stacks_proto_msgTypes[27]
+	mi := &file_stacks_proto_msgTypes[28]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2226,7 +2281,7 @@ func (x *ListResourceIdentities) String() string {
 func (*ListResourceIdentities) ProtoMessage() {}
 
 func (x *ListResourceIdentities) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[27]
+	mi := &file_stacks_proto_msgTypes[28]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2239,12 +2294,11 @@ func (x *ListResourceIdentities) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListResourceIdentities.ProtoReflect.Descriptor instead.
 func (*ListResourceIdentities) Descriptor() ([]byte, []int) {
-	return file_stacks_proto_rawDescGZIP(), []int{27}
+	return file_stacks_proto_rawDescGZIP(), []int{28}
 }
 
-type PolicyEvaluationResponse struct {
-	state protoimpl.MessageState `protogen:"open.v1"`
-	// Policies are only evaluated for component instances
+type ComponentInstancePolicyEvaluation struct {
+	state         protoimpl.MessageState        `protogen:"open.v1"`
 	Addr          *ComponentInstanceInStackAddr `protobuf:"bytes,1,opt,name=addr,proto3" json:"addr,omitempty"`
 	Results       []*PolicyResult               `protobuf:"bytes,2,rep,name=results,proto3" json:"results,omitempty"`
 	Infos         []*PolicyInfo                 `protobuf:"bytes,3,rep,name=infos,proto3" json:"infos,omitempty"`
@@ -2253,21 +2307,21 @@ type PolicyEvaluationResponse struct {
 	sizeCache     protoimpl.SizeCache
 }
 
-func (x *PolicyEvaluationResponse) Reset() {
-	*x = PolicyEvaluationResponse{}
-	mi := &file_stacks_proto_msgTypes[28]
+func (x *ComponentInstancePolicyEvaluation) Reset() {
+	*x = ComponentInstancePolicyEvaluation{}
+	mi := &file_stacks_proto_msgTypes[29]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
 
-func (x *PolicyEvaluationResponse) String() string {
+func (x *ComponentInstancePolicyEvaluation) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*PolicyEvaluationResponse) ProtoMessage() {}
+func (*ComponentInstancePolicyEvaluation) ProtoMessage() {}
 
-func (x *PolicyEvaluationResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[28]
+func (x *ComponentInstancePolicyEvaluation) ProtoReflect() protoreflect.Message {
+	mi := &file_stacks_proto_msgTypes[29]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2278,33 +2332,101 @@ func (x *PolicyEvaluationResponse) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use PolicyEvaluationResponse.ProtoReflect.Descriptor instead.
-func (*PolicyEvaluationResponse) Descriptor() ([]byte, []int) {
-	return file_stacks_proto_rawDescGZIP(), []int{28}
+// Deprecated: Use ComponentInstancePolicyEvaluation.ProtoReflect.Descriptor instead.
+func (*ComponentInstancePolicyEvaluation) Descriptor() ([]byte, []int) {
+	return file_stacks_proto_rawDescGZIP(), []int{29}
 }
 
-func (x *PolicyEvaluationResponse) GetAddr() *ComponentInstanceInStackAddr {
+func (x *ComponentInstancePolicyEvaluation) GetAddr() *ComponentInstanceInStackAddr {
 	if x != nil {
 		return x.Addr
 	}
 	return nil
 }
 
-func (x *PolicyEvaluationResponse) GetResults() []*PolicyResult {
+func (x *ComponentInstancePolicyEvaluation) GetResults() []*PolicyResult {
 	if x != nil {
 		return x.Results
 	}
 	return nil
 }
 
-func (x *PolicyEvaluationResponse) GetInfos() []*PolicyInfo {
+func (x *ComponentInstancePolicyEvaluation) GetInfos() []*PolicyInfo {
 	if x != nil {
 		return x.Infos
 	}
 	return nil
 }
 
-func (x *PolicyEvaluationResponse) GetDiagnostics() []*PolicyDiagnostic {
+func (x *ComponentInstancePolicyEvaluation) GetDiagnostics() []*PolicyDiagnostic {
+	if x != nil {
+		return x.Diagnostics
+	}
+	return nil
+}
+
+type ProviderInstancePolicyEvaluation struct {
+	state         protoimpl.MessageState       `protogen:"open.v1"`
+	Addr          *ProviderInstanceInStackAddr `protobuf:"bytes,1,opt,name=addr,proto3" json:"addr,omitempty"`
+	Results       []*PolicyResult              `protobuf:"bytes,2,rep,name=results,proto3" json:"results,omitempty"`
+	Infos         []*PolicyInfo                `protobuf:"bytes,3,rep,name=infos,proto3" json:"infos,omitempty"`
+	Diagnostics   []*PolicyDiagnostic          `protobuf:"bytes,4,rep,name=diagnostics,proto3" json:"diagnostics,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ProviderInstancePolicyEvaluation) Reset() {
+	*x = ProviderInstancePolicyEvaluation{}
+	mi := &file_stacks_proto_msgTypes[30]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ProviderInstancePolicyEvaluation) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ProviderInstancePolicyEvaluation) ProtoMessage() {}
+
+func (x *ProviderInstancePolicyEvaluation) ProtoReflect() protoreflect.Message {
+	mi := &file_stacks_proto_msgTypes[30]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ProviderInstancePolicyEvaluation.ProtoReflect.Descriptor instead.
+func (*ProviderInstancePolicyEvaluation) Descriptor() ([]byte, []int) {
+	return file_stacks_proto_rawDescGZIP(), []int{30}
+}
+
+func (x *ProviderInstancePolicyEvaluation) GetAddr() *ProviderInstanceInStackAddr {
+	if x != nil {
+		return x.Addr
+	}
+	return nil
+}
+
+func (x *ProviderInstancePolicyEvaluation) GetResults() []*PolicyResult {
+	if x != nil {
+		return x.Results
+	}
+	return nil
+}
+
+func (x *ProviderInstancePolicyEvaluation) GetInfos() []*PolicyInfo {
+	if x != nil {
+		return x.Infos
+	}
+	return nil
+}
+
+func (x *ProviderInstancePolicyEvaluation) GetDiagnostics() []*PolicyDiagnostic {
 	if x != nil {
 		return x.Diagnostics
 	}
@@ -2324,7 +2446,7 @@ type PolicyMetaData struct {
 
 func (x *PolicyMetaData) Reset() {
 	*x = PolicyMetaData{}
-	mi := &file_stacks_proto_msgTypes[29]
+	mi := &file_stacks_proto_msgTypes[31]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2336,7 +2458,7 @@ func (x *PolicyMetaData) String() string {
 func (*PolicyMetaData) ProtoMessage() {}
 
 func (x *PolicyMetaData) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[29]
+	mi := &file_stacks_proto_msgTypes[31]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2349,7 +2471,7 @@ func (x *PolicyMetaData) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PolicyMetaData.ProtoReflect.Descriptor instead.
 func (*PolicyMetaData) Descriptor() ([]byte, []int) {
-	return file_stacks_proto_rawDescGZIP(), []int{29}
+	return file_stacks_proto_rawDescGZIP(), []int{31}
 }
 
 func (x *PolicyMetaData) GetPolicyName() string {
@@ -2398,7 +2520,7 @@ type PolicyResult struct {
 
 func (x *PolicyResult) Reset() {
 	*x = PolicyResult{}
-	mi := &file_stacks_proto_msgTypes[30]
+	mi := &file_stacks_proto_msgTypes[32]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2410,7 +2532,7 @@ func (x *PolicyResult) String() string {
 func (*PolicyResult) ProtoMessage() {}
 
 func (x *PolicyResult) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[30]
+	mi := &file_stacks_proto_msgTypes[32]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2423,7 +2545,7 @@ func (x *PolicyResult) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PolicyResult.ProtoReflect.Descriptor instead.
 func (*PolicyResult) Descriptor() ([]byte, []int) {
-	return file_stacks_proto_rawDescGZIP(), []int{30}
+	return file_stacks_proto_rawDescGZIP(), []int{32}
 }
 
 func (x *PolicyResult) GetTargetAddress() string {
@@ -2461,7 +2583,7 @@ type PolicyInfo struct {
 
 func (x *PolicyInfo) Reset() {
 	*x = PolicyInfo{}
-	mi := &file_stacks_proto_msgTypes[31]
+	mi := &file_stacks_proto_msgTypes[33]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2473,7 +2595,7 @@ func (x *PolicyInfo) String() string {
 func (*PolicyInfo) ProtoMessage() {}
 
 func (x *PolicyInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[31]
+	mi := &file_stacks_proto_msgTypes[33]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2486,7 +2608,7 @@ func (x *PolicyInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PolicyInfo.ProtoReflect.Descriptor instead.
 func (*PolicyInfo) Descriptor() ([]byte, []int) {
-	return file_stacks_proto_rawDescGZIP(), []int{31}
+	return file_stacks_proto_rawDescGZIP(), []int{33}
 }
 
 func (x *PolicyInfo) GetTargetAddress() string {
@@ -2544,7 +2666,7 @@ type PolicySnippet struct {
 
 func (x *PolicySnippet) Reset() {
 	*x = PolicySnippet{}
-	mi := &file_stacks_proto_msgTypes[32]
+	mi := &file_stacks_proto_msgTypes[34]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2556,7 +2678,7 @@ func (x *PolicySnippet) String() string {
 func (*PolicySnippet) ProtoMessage() {}
 
 func (x *PolicySnippet) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[32]
+	mi := &file_stacks_proto_msgTypes[34]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2569,7 +2691,7 @@ func (x *PolicySnippet) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PolicySnippet.ProtoReflect.Descriptor instead.
 func (*PolicySnippet) Descriptor() ([]byte, []int) {
-	return file_stacks_proto_rawDescGZIP(), []int{32}
+	return file_stacks_proto_rawDescGZIP(), []int{34}
 }
 
 func (x *PolicySnippet) GetContext() string {
@@ -2622,7 +2744,7 @@ type PolicyDiagnostic struct {
 
 func (x *PolicyDiagnostic) Reset() {
 	*x = PolicyDiagnostic{}
-	mi := &file_stacks_proto_msgTypes[33]
+	mi := &file_stacks_proto_msgTypes[35]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2634,7 +2756,7 @@ func (x *PolicyDiagnostic) String() string {
 func (*PolicyDiagnostic) ProtoMessage() {}
 
 func (x *PolicyDiagnostic) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[33]
+	mi := &file_stacks_proto_msgTypes[35]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2647,7 +2769,7 @@ func (x *PolicyDiagnostic) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PolicyDiagnostic.ProtoReflect.Descriptor instead.
 func (*PolicyDiagnostic) Descriptor() ([]byte, []int) {
-	return file_stacks_proto_rawDescGZIP(), []int{33}
+	return file_stacks_proto_rawDescGZIP(), []int{35}
 }
 
 func (x *PolicyDiagnostic) GetTargetAddress() string {
@@ -2710,7 +2832,7 @@ type ExpressionValue struct {
 
 func (x *ExpressionValue) Reset() {
 	*x = ExpressionValue{}
-	mi := &file_stacks_proto_msgTypes[34]
+	mi := &file_stacks_proto_msgTypes[36]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2722,7 +2844,7 @@ func (x *ExpressionValue) String() string {
 func (*ExpressionValue) ProtoMessage() {}
 
 func (x *ExpressionValue) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[34]
+	mi := &file_stacks_proto_msgTypes[36]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2735,7 +2857,7 @@ func (x *ExpressionValue) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExpressionValue.ProtoReflect.Descriptor instead.
 func (*ExpressionValue) Descriptor() ([]byte, []int) {
-	return file_stacks_proto_rawDescGZIP(), []int{34}
+	return file_stacks_proto_rawDescGZIP(), []int{36}
 }
 
 func (x *ExpressionValue) GetTraversal() *AttributePath {
@@ -2765,7 +2887,7 @@ type OpenTerraformState_Request struct {
 
 func (x *OpenTerraformState_Request) Reset() {
 	*x = OpenTerraformState_Request{}
-	mi := &file_stacks_proto_msgTypes[35]
+	mi := &file_stacks_proto_msgTypes[37]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2777,7 +2899,7 @@ func (x *OpenTerraformState_Request) String() string {
 func (*OpenTerraformState_Request) ProtoMessage() {}
 
 func (x *OpenTerraformState_Request) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[35]
+	mi := &file_stacks_proto_msgTypes[37]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2846,7 +2968,7 @@ type OpenTerraformState_Response struct {
 
 func (x *OpenTerraformState_Response) Reset() {
 	*x = OpenTerraformState_Response{}
-	mi := &file_stacks_proto_msgTypes[36]
+	mi := &file_stacks_proto_msgTypes[38]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2858,7 +2980,7 @@ func (x *OpenTerraformState_Response) String() string {
 func (*OpenTerraformState_Response) ProtoMessage() {}
 
 func (x *OpenTerraformState_Response) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[36]
+	mi := &file_stacks_proto_msgTypes[38]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2897,7 +3019,7 @@ type CloseTerraformState_Request struct {
 
 func (x *CloseTerraformState_Request) Reset() {
 	*x = CloseTerraformState_Request{}
-	mi := &file_stacks_proto_msgTypes[37]
+	mi := &file_stacks_proto_msgTypes[39]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2909,7 +3031,7 @@ func (x *CloseTerraformState_Request) String() string {
 func (*CloseTerraformState_Request) ProtoMessage() {}
 
 func (x *CloseTerraformState_Request) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[37]
+	mi := &file_stacks_proto_msgTypes[39]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2940,7 +3062,7 @@ type CloseTerraformState_Response struct {
 
 func (x *CloseTerraformState_Response) Reset() {
 	*x = CloseTerraformState_Response{}
-	mi := &file_stacks_proto_msgTypes[38]
+	mi := &file_stacks_proto_msgTypes[40]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2952,7 +3074,7 @@ func (x *CloseTerraformState_Response) String() string {
 func (*CloseTerraformState_Response) ProtoMessage() {}
 
 func (x *CloseTerraformState_Response) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[38]
+	mi := &file_stacks_proto_msgTypes[40]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2984,7 +3106,7 @@ type MigrateTerraformState_Request struct {
 
 func (x *MigrateTerraformState_Request) Reset() {
 	*x = MigrateTerraformState_Request{}
-	mi := &file_stacks_proto_msgTypes[39]
+	mi := &file_stacks_proto_msgTypes[41]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2996,7 +3118,7 @@ func (x *MigrateTerraformState_Request) String() string {
 func (*MigrateTerraformState_Request) ProtoMessage() {}
 
 func (x *MigrateTerraformState_Request) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[39]
+	mi := &file_stacks_proto_msgTypes[41]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3080,7 +3202,7 @@ type MigrateTerraformState_Event struct {
 
 func (x *MigrateTerraformState_Event) Reset() {
 	*x = MigrateTerraformState_Event{}
-	mi := &file_stacks_proto_msgTypes[40]
+	mi := &file_stacks_proto_msgTypes[42]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3092,7 +3214,7 @@ func (x *MigrateTerraformState_Event) String() string {
 func (*MigrateTerraformState_Event) ProtoMessage() {}
 
 func (x *MigrateTerraformState_Event) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[40]
+	mi := &file_stacks_proto_msgTypes[42]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3180,7 +3302,7 @@ type MigrateTerraformState_Request_Mapping struct {
 
 func (x *MigrateTerraformState_Request_Mapping) Reset() {
 	*x = MigrateTerraformState_Request_Mapping{}
-	mi := &file_stacks_proto_msgTypes[41]
+	mi := &file_stacks_proto_msgTypes[43]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3192,7 +3314,7 @@ func (x *MigrateTerraformState_Request_Mapping) String() string {
 func (*MigrateTerraformState_Request_Mapping) ProtoMessage() {}
 
 func (x *MigrateTerraformState_Request_Mapping) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[41]
+	mi := &file_stacks_proto_msgTypes[43]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3232,7 +3354,7 @@ type OpenStackConfiguration_Request struct {
 
 func (x *OpenStackConfiguration_Request) Reset() {
 	*x = OpenStackConfiguration_Request{}
-	mi := &file_stacks_proto_msgTypes[44]
+	mi := &file_stacks_proto_msgTypes[46]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3244,7 +3366,7 @@ func (x *OpenStackConfiguration_Request) String() string {
 func (*OpenStackConfiguration_Request) ProtoMessage() {}
 
 func (x *OpenStackConfiguration_Request) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[44]
+	mi := &file_stacks_proto_msgTypes[46]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3284,7 +3406,7 @@ type OpenStackConfiguration_Response struct {
 
 func (x *OpenStackConfiguration_Response) Reset() {
 	*x = OpenStackConfiguration_Response{}
-	mi := &file_stacks_proto_msgTypes[45]
+	mi := &file_stacks_proto_msgTypes[47]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3296,7 +3418,7 @@ func (x *OpenStackConfiguration_Response) String() string {
 func (*OpenStackConfiguration_Response) ProtoMessage() {}
 
 func (x *OpenStackConfiguration_Response) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[45]
+	mi := &file_stacks_proto_msgTypes[47]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3335,7 +3457,7 @@ type CloseStackConfiguration_Request struct {
 
 func (x *CloseStackConfiguration_Request) Reset() {
 	*x = CloseStackConfiguration_Request{}
-	mi := &file_stacks_proto_msgTypes[46]
+	mi := &file_stacks_proto_msgTypes[48]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3347,7 +3469,7 @@ func (x *CloseStackConfiguration_Request) String() string {
 func (*CloseStackConfiguration_Request) ProtoMessage() {}
 
 func (x *CloseStackConfiguration_Request) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[46]
+	mi := &file_stacks_proto_msgTypes[48]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3378,7 +3500,7 @@ type CloseStackConfiguration_Response struct {
 
 func (x *CloseStackConfiguration_Response) Reset() {
 	*x = CloseStackConfiguration_Response{}
-	mi := &file_stacks_proto_msgTypes[47]
+	mi := &file_stacks_proto_msgTypes[49]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3390,7 +3512,7 @@ func (x *CloseStackConfiguration_Response) String() string {
 func (*CloseStackConfiguration_Response) ProtoMessage() {}
 
 func (x *CloseStackConfiguration_Response) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[47]
+	mi := &file_stacks_proto_msgTypes[49]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3417,7 +3539,7 @@ type ValidateStackConfiguration_Request struct {
 
 func (x *ValidateStackConfiguration_Request) Reset() {
 	*x = ValidateStackConfiguration_Request{}
-	mi := &file_stacks_proto_msgTypes[48]
+	mi := &file_stacks_proto_msgTypes[50]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3429,7 +3551,7 @@ func (x *ValidateStackConfiguration_Request) String() string {
 func (*ValidateStackConfiguration_Request) ProtoMessage() {}
 
 func (x *ValidateStackConfiguration_Request) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[48]
+	mi := &file_stacks_proto_msgTypes[50]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3475,7 +3597,7 @@ type ValidateStackConfiguration_Response struct {
 
 func (x *ValidateStackConfiguration_Response) Reset() {
 	*x = ValidateStackConfiguration_Response{}
-	mi := &file_stacks_proto_msgTypes[49]
+	mi := &file_stacks_proto_msgTypes[51]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3487,7 +3609,7 @@ func (x *ValidateStackConfiguration_Response) String() string {
 func (*ValidateStackConfiguration_Response) ProtoMessage() {}
 
 func (x *ValidateStackConfiguration_Response) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[49]
+	mi := &file_stacks_proto_msgTypes[51]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3519,7 +3641,7 @@ type FindStackConfigurationComponents_Request struct {
 
 func (x *FindStackConfigurationComponents_Request) Reset() {
 	*x = FindStackConfigurationComponents_Request{}
-	mi := &file_stacks_proto_msgTypes[50]
+	mi := &file_stacks_proto_msgTypes[52]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3531,7 +3653,7 @@ func (x *FindStackConfigurationComponents_Request) String() string {
 func (*FindStackConfigurationComponents_Request) ProtoMessage() {}
 
 func (x *FindStackConfigurationComponents_Request) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[50]
+	mi := &file_stacks_proto_msgTypes[52]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3563,7 +3685,7 @@ type FindStackConfigurationComponents_Response struct {
 
 func (x *FindStackConfigurationComponents_Response) Reset() {
 	*x = FindStackConfigurationComponents_Response{}
-	mi := &file_stacks_proto_msgTypes[51]
+	mi := &file_stacks_proto_msgTypes[53]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3575,7 +3697,7 @@ func (x *FindStackConfigurationComponents_Response) String() string {
 func (*FindStackConfigurationComponents_Response) ProtoMessage() {}
 
 func (x *FindStackConfigurationComponents_Response) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[51]
+	mi := &file_stacks_proto_msgTypes[53]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3611,7 +3733,7 @@ type FindStackConfigurationComponents_StackConfig struct {
 
 func (x *FindStackConfigurationComponents_StackConfig) Reset() {
 	*x = FindStackConfigurationComponents_StackConfig{}
-	mi := &file_stacks_proto_msgTypes[52]
+	mi := &file_stacks_proto_msgTypes[54]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3623,7 +3745,7 @@ func (x *FindStackConfigurationComponents_StackConfig) String() string {
 func (*FindStackConfigurationComponents_StackConfig) ProtoMessage() {}
 
 func (x *FindStackConfigurationComponents_StackConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[52]
+	mi := &file_stacks_proto_msgTypes[54]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3685,7 +3807,7 @@ type FindStackConfigurationComponents_EmbeddedStack struct {
 
 func (x *FindStackConfigurationComponents_EmbeddedStack) Reset() {
 	*x = FindStackConfigurationComponents_EmbeddedStack{}
-	mi := &file_stacks_proto_msgTypes[53]
+	mi := &file_stacks_proto_msgTypes[55]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3697,7 +3819,7 @@ func (x *FindStackConfigurationComponents_EmbeddedStack) String() string {
 func (*FindStackConfigurationComponents_EmbeddedStack) ProtoMessage() {}
 
 func (x *FindStackConfigurationComponents_EmbeddedStack) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[53]
+	mi := &file_stacks_proto_msgTypes[55]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3745,7 +3867,7 @@ type FindStackConfigurationComponents_Component struct {
 
 func (x *FindStackConfigurationComponents_Component) Reset() {
 	*x = FindStackConfigurationComponents_Component{}
-	mi := &file_stacks_proto_msgTypes[54]
+	mi := &file_stacks_proto_msgTypes[56]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3757,7 +3879,7 @@ func (x *FindStackConfigurationComponents_Component) String() string {
 func (*FindStackConfigurationComponents_Component) ProtoMessage() {}
 
 func (x *FindStackConfigurationComponents_Component) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[54]
+	mi := &file_stacks_proto_msgTypes[56]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3811,7 +3933,7 @@ type FindStackConfigurationComponents_Removed struct {
 
 func (x *FindStackConfigurationComponents_Removed) Reset() {
 	*x = FindStackConfigurationComponents_Removed{}
-	mi := &file_stacks_proto_msgTypes[55]
+	mi := &file_stacks_proto_msgTypes[57]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3823,7 +3945,7 @@ func (x *FindStackConfigurationComponents_Removed) String() string {
 func (*FindStackConfigurationComponents_Removed) ProtoMessage() {}
 
 func (x *FindStackConfigurationComponents_Removed) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[55]
+	mi := &file_stacks_proto_msgTypes[57]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3889,7 +4011,7 @@ type FindStackConfigurationComponents_InputVariable struct {
 
 func (x *FindStackConfigurationComponents_InputVariable) Reset() {
 	*x = FindStackConfigurationComponents_InputVariable{}
-	mi := &file_stacks_proto_msgTypes[56]
+	mi := &file_stacks_proto_msgTypes[58]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3901,7 +4023,7 @@ func (x *FindStackConfigurationComponents_InputVariable) String() string {
 func (*FindStackConfigurationComponents_InputVariable) ProtoMessage() {}
 
 func (x *FindStackConfigurationComponents_InputVariable) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[56]
+	mi := &file_stacks_proto_msgTypes[58]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3948,7 +4070,7 @@ type FindStackConfigurationComponents_OutputValue struct {
 
 func (x *FindStackConfigurationComponents_OutputValue) Reset() {
 	*x = FindStackConfigurationComponents_OutputValue{}
-	mi := &file_stacks_proto_msgTypes[57]
+	mi := &file_stacks_proto_msgTypes[59]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3960,7 +4082,7 @@ func (x *FindStackConfigurationComponents_OutputValue) String() string {
 func (*FindStackConfigurationComponents_OutputValue) ProtoMessage() {}
 
 func (x *FindStackConfigurationComponents_OutputValue) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[57]
+	mi := &file_stacks_proto_msgTypes[59]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4002,7 +4124,7 @@ type FindStackConfigurationComponents_Removed_Block struct {
 
 func (x *FindStackConfigurationComponents_Removed_Block) Reset() {
 	*x = FindStackConfigurationComponents_Removed_Block{}
-	mi := &file_stacks_proto_msgTypes[63]
+	mi := &file_stacks_proto_msgTypes[65]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4014,7 +4136,7 @@ func (x *FindStackConfigurationComponents_Removed_Block) String() string {
 func (*FindStackConfigurationComponents_Removed_Block) ProtoMessage() {}
 
 func (x *FindStackConfigurationComponents_Removed_Block) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[63]
+	mi := &file_stacks_proto_msgTypes[65]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4067,7 +4189,7 @@ type OpenStackState_RequestItem struct {
 
 func (x *OpenStackState_RequestItem) Reset() {
 	*x = OpenStackState_RequestItem{}
-	mi := &file_stacks_proto_msgTypes[64]
+	mi := &file_stacks_proto_msgTypes[66]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4079,7 +4201,7 @@ func (x *OpenStackState_RequestItem) String() string {
 func (*OpenStackState_RequestItem) ProtoMessage() {}
 
 func (x *OpenStackState_RequestItem) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[64]
+	mi := &file_stacks_proto_msgTypes[66]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4111,7 +4233,7 @@ type OpenStackState_Response struct {
 
 func (x *OpenStackState_Response) Reset() {
 	*x = OpenStackState_Response{}
-	mi := &file_stacks_proto_msgTypes[65]
+	mi := &file_stacks_proto_msgTypes[67]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4123,7 +4245,7 @@ func (x *OpenStackState_Response) String() string {
 func (*OpenStackState_Response) ProtoMessage() {}
 
 func (x *OpenStackState_Response) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[65]
+	mi := &file_stacks_proto_msgTypes[67]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4155,7 +4277,7 @@ type CloseStackState_Request struct {
 
 func (x *CloseStackState_Request) Reset() {
 	*x = CloseStackState_Request{}
-	mi := &file_stacks_proto_msgTypes[66]
+	mi := &file_stacks_proto_msgTypes[68]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4167,7 +4289,7 @@ func (x *CloseStackState_Request) String() string {
 func (*CloseStackState_Request) ProtoMessage() {}
 
 func (x *CloseStackState_Request) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[66]
+	mi := &file_stacks_proto_msgTypes[68]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4198,7 +4320,7 @@ type CloseStackState_Response struct {
 
 func (x *CloseStackState_Response) Reset() {
 	*x = CloseStackState_Response{}
-	mi := &file_stacks_proto_msgTypes[67]
+	mi := &file_stacks_proto_msgTypes[69]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4210,7 +4332,7 @@ func (x *CloseStackState_Response) String() string {
 func (*CloseStackState_Response) ProtoMessage() {}
 
 func (x *CloseStackState_Response) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[67]
+	mi := &file_stacks_proto_msgTypes[69]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4246,7 +4368,7 @@ type PlanStackChanges_Request struct {
 
 func (x *PlanStackChanges_Request) Reset() {
 	*x = PlanStackChanges_Request{}
-	mi := &file_stacks_proto_msgTypes[68]
+	mi := &file_stacks_proto_msgTypes[70]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4258,7 +4380,7 @@ func (x *PlanStackChanges_Request) String() string {
 func (*PlanStackChanges_Request) ProtoMessage() {}
 
 func (x *PlanStackChanges_Request) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[68]
+	mi := &file_stacks_proto_msgTypes[70]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4346,6 +4468,7 @@ type PlanStackChanges_Event struct {
 	//	*PlanStackChanges_Event_Diagnostic
 	//	*PlanStackChanges_Event_Progress
 	//	*PlanStackChanges_Event_ComponentInstancePolicyEvaluation
+	//	*PlanStackChanges_Event_ProviderInstancePolicyEvaluation
 	Event         isPlanStackChanges_Event_Event `protobuf_oneof:"event"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -4353,7 +4476,7 @@ type PlanStackChanges_Event struct {
 
 func (x *PlanStackChanges_Event) Reset() {
 	*x = PlanStackChanges_Event{}
-	mi := &file_stacks_proto_msgTypes[69]
+	mi := &file_stacks_proto_msgTypes[71]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4365,7 +4488,7 @@ func (x *PlanStackChanges_Event) String() string {
 func (*PlanStackChanges_Event) ProtoMessage() {}
 
 func (x *PlanStackChanges_Event) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[69]
+	mi := &file_stacks_proto_msgTypes[71]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4415,10 +4538,19 @@ func (x *PlanStackChanges_Event) GetProgress() *StackChangeProgress {
 	return nil
 }
 
-func (x *PlanStackChanges_Event) GetComponentInstancePolicyEvaluation() *PolicyEvaluationResponse {
+func (x *PlanStackChanges_Event) GetComponentInstancePolicyEvaluation() *ComponentInstancePolicyEvaluation {
 	if x != nil {
 		if x, ok := x.Event.(*PlanStackChanges_Event_ComponentInstancePolicyEvaluation); ok {
 			return x.ComponentInstancePolicyEvaluation
+		}
+	}
+	return nil
+}
+
+func (x *PlanStackChanges_Event) GetProviderInstancePolicyEvaluation() *ProviderInstancePolicyEvaluation {
+	if x != nil {
+		if x, ok := x.Event.(*PlanStackChanges_Event_ProviderInstancePolicyEvaluation); ok {
+			return x.ProviderInstancePolicyEvaluation
 		}
 	}
 	return nil
@@ -4442,7 +4574,12 @@ type PlanStackChanges_Event_Progress struct {
 
 type PlanStackChanges_Event_ComponentInstancePolicyEvaluation struct {
 	// Resources and modules evaluate policies for each component instance
-	ComponentInstancePolicyEvaluation *PolicyEvaluationResponse `protobuf:"bytes,11,opt,name=component_instance_policy_evaluation,json=componentInstancePolicyEvaluation,proto3,oneof"`
+	ComponentInstancePolicyEvaluation *ComponentInstancePolicyEvaluation `protobuf:"bytes,11,opt,name=component_instance_policy_evaluation,json=componentInstancePolicyEvaluation,proto3,oneof"`
+}
+
+type PlanStackChanges_Event_ProviderInstancePolicyEvaluation struct {
+	// Providers evaluate policy for each instance in a stack
+	ProviderInstancePolicyEvaluation *ProviderInstancePolicyEvaluation `protobuf:"bytes,12,opt,name=provider_instance_policy_evaluation,json=providerInstancePolicyEvaluation,proto3,oneof"`
 }
 
 func (*PlanStackChanges_Event_PlannedChange) isPlanStackChanges_Event_Event() {}
@@ -4453,6 +4590,8 @@ func (*PlanStackChanges_Event_Progress) isPlanStackChanges_Event_Event() {}
 
 func (*PlanStackChanges_Event_ComponentInstancePolicyEvaluation) isPlanStackChanges_Event_Event() {}
 
+func (*PlanStackChanges_Event_ProviderInstancePolicyEvaluation) isPlanStackChanges_Event_Event() {}
+
 type OpenStackPlan_RequestItem struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Raw           *anypb.Any             `protobuf:"bytes,1,opt,name=raw,proto3" json:"raw,omitempty"`
@@ -4462,7 +4601,7 @@ type OpenStackPlan_RequestItem struct {
 
 func (x *OpenStackPlan_RequestItem) Reset() {
 	*x = OpenStackPlan_RequestItem{}
-	mi := &file_stacks_proto_msgTypes[72]
+	mi := &file_stacks_proto_msgTypes[74]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4474,7 +4613,7 @@ func (x *OpenStackPlan_RequestItem) String() string {
 func (*OpenStackPlan_RequestItem) ProtoMessage() {}
 
 func (x *OpenStackPlan_RequestItem) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[72]
+	mi := &file_stacks_proto_msgTypes[74]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4506,7 +4645,7 @@ type OpenStackPlan_Response struct {
 
 func (x *OpenStackPlan_Response) Reset() {
 	*x = OpenStackPlan_Response{}
-	mi := &file_stacks_proto_msgTypes[73]
+	mi := &file_stacks_proto_msgTypes[75]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4518,7 +4657,7 @@ func (x *OpenStackPlan_Response) String() string {
 func (*OpenStackPlan_Response) ProtoMessage() {}
 
 func (x *OpenStackPlan_Response) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[73]
+	mi := &file_stacks_proto_msgTypes[75]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4550,7 +4689,7 @@ type CloseStackPlan_Request struct {
 
 func (x *CloseStackPlan_Request) Reset() {
 	*x = CloseStackPlan_Request{}
-	mi := &file_stacks_proto_msgTypes[74]
+	mi := &file_stacks_proto_msgTypes[76]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4562,7 +4701,7 @@ func (x *CloseStackPlan_Request) String() string {
 func (*CloseStackPlan_Request) ProtoMessage() {}
 
 func (x *CloseStackPlan_Request) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[74]
+	mi := &file_stacks_proto_msgTypes[76]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4593,7 +4732,7 @@ type CloseStackPlan_Response struct {
 
 func (x *CloseStackPlan_Response) Reset() {
 	*x = CloseStackPlan_Response{}
-	mi := &file_stacks_proto_msgTypes[75]
+	mi := &file_stacks_proto_msgTypes[77]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4605,7 +4744,7 @@ func (x *CloseStackPlan_Response) String() string {
 func (*CloseStackPlan_Response) ProtoMessage() {}
 
 func (x *CloseStackPlan_Response) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[75]
+	mi := &file_stacks_proto_msgTypes[77]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4670,7 +4809,7 @@ type ApplyStackChanges_Request struct {
 
 func (x *ApplyStackChanges_Request) Reset() {
 	*x = ApplyStackChanges_Request{}
-	mi := &file_stacks_proto_msgTypes[76]
+	mi := &file_stacks_proto_msgTypes[78]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4682,7 +4821,7 @@ func (x *ApplyStackChanges_Request) String() string {
 func (*ApplyStackChanges_Request) ProtoMessage() {}
 
 func (x *ApplyStackChanges_Request) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[76]
+	mi := &file_stacks_proto_msgTypes[78]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4770,6 +4909,7 @@ type ApplyStackChanges_Event struct {
 	//	*ApplyStackChanges_Event_Diagnostic
 	//	*ApplyStackChanges_Event_Progress
 	//	*ApplyStackChanges_Event_ComponentInstancePolicyEvaluation
+	//	*ApplyStackChanges_Event_ProviderInstancePolicyEvaluation
 	Event         isApplyStackChanges_Event_Event `protobuf_oneof:"event"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -4777,7 +4917,7 @@ type ApplyStackChanges_Event struct {
 
 func (x *ApplyStackChanges_Event) Reset() {
 	*x = ApplyStackChanges_Event{}
-	mi := &file_stacks_proto_msgTypes[77]
+	mi := &file_stacks_proto_msgTypes[79]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4789,7 +4929,7 @@ func (x *ApplyStackChanges_Event) String() string {
 func (*ApplyStackChanges_Event) ProtoMessage() {}
 
 func (x *ApplyStackChanges_Event) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[77]
+	mi := &file_stacks_proto_msgTypes[79]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4839,10 +4979,19 @@ func (x *ApplyStackChanges_Event) GetProgress() *StackChangeProgress {
 	return nil
 }
 
-func (x *ApplyStackChanges_Event) GetComponentInstancePolicyEvaluation() *PolicyEvaluationResponse {
+func (x *ApplyStackChanges_Event) GetComponentInstancePolicyEvaluation() *ComponentInstancePolicyEvaluation {
 	if x != nil {
 		if x, ok := x.Event.(*ApplyStackChanges_Event_ComponentInstancePolicyEvaluation); ok {
 			return x.ComponentInstancePolicyEvaluation
+		}
+	}
+	return nil
+}
+
+func (x *ApplyStackChanges_Event) GetProviderInstancePolicyEvaluation() *ProviderInstancePolicyEvaluation {
+	if x != nil {
+		if x, ok := x.Event.(*ApplyStackChanges_Event_ProviderInstancePolicyEvaluation); ok {
+			return x.ProviderInstancePolicyEvaluation
 		}
 	}
 	return nil
@@ -4866,7 +5015,12 @@ type ApplyStackChanges_Event_Progress struct {
 
 type ApplyStackChanges_Event_ComponentInstancePolicyEvaluation struct {
 	// Resources and modules evaluate policies for each component instance
-	ComponentInstancePolicyEvaluation *PolicyEvaluationResponse `protobuf:"bytes,4,opt,name=component_instance_policy_evaluation,json=componentInstancePolicyEvaluation,proto3,oneof"`
+	ComponentInstancePolicyEvaluation *ComponentInstancePolicyEvaluation `protobuf:"bytes,4,opt,name=component_instance_policy_evaluation,json=componentInstancePolicyEvaluation,proto3,oneof"`
+}
+
+type ApplyStackChanges_Event_ProviderInstancePolicyEvaluation struct {
+	// Providers evaluate policy for each instance in a stack
+	ProviderInstancePolicyEvaluation *ProviderInstancePolicyEvaluation `protobuf:"bytes,5,opt,name=provider_instance_policy_evaluation,json=providerInstancePolicyEvaluation,proto3,oneof"`
 }
 
 func (*ApplyStackChanges_Event_AppliedChange) isApplyStackChanges_Event_Event() {}
@@ -4876,6 +5030,8 @@ func (*ApplyStackChanges_Event_Diagnostic) isApplyStackChanges_Event_Event() {}
 func (*ApplyStackChanges_Event_Progress) isApplyStackChanges_Event_Event() {}
 
 func (*ApplyStackChanges_Event_ComponentInstancePolicyEvaluation) isApplyStackChanges_Event_Event() {}
+
+func (*ApplyStackChanges_Event_ProviderInstancePolicyEvaluation) isApplyStackChanges_Event_Event() {}
 
 type OpenStackInspector_Request struct {
 	state                 protoimpl.MessageState             `protogen:"open.v1"`
@@ -4890,7 +5046,7 @@ type OpenStackInspector_Request struct {
 
 func (x *OpenStackInspector_Request) Reset() {
 	*x = OpenStackInspector_Request{}
-	mi := &file_stacks_proto_msgTypes[79]
+	mi := &file_stacks_proto_msgTypes[81]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4902,7 +5058,7 @@ func (x *OpenStackInspector_Request) String() string {
 func (*OpenStackInspector_Request) ProtoMessage() {}
 
 func (x *OpenStackInspector_Request) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[79]
+	mi := &file_stacks_proto_msgTypes[81]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4963,7 +5119,7 @@ type OpenStackInspector_Response struct {
 
 func (x *OpenStackInspector_Response) Reset() {
 	*x = OpenStackInspector_Response{}
-	mi := &file_stacks_proto_msgTypes[80]
+	mi := &file_stacks_proto_msgTypes[82]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4975,7 +5131,7 @@ func (x *OpenStackInspector_Response) String() string {
 func (*OpenStackInspector_Response) ProtoMessage() {}
 
 func (x *OpenStackInspector_Response) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[80]
+	mi := &file_stacks_proto_msgTypes[82]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5016,7 +5172,7 @@ type InspectExpressionResult_Request struct {
 
 func (x *InspectExpressionResult_Request) Reset() {
 	*x = InspectExpressionResult_Request{}
-	mi := &file_stacks_proto_msgTypes[83]
+	mi := &file_stacks_proto_msgTypes[85]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5028,7 +5184,7 @@ func (x *InspectExpressionResult_Request) String() string {
 func (*InspectExpressionResult_Request) ProtoMessage() {}
 
 func (x *InspectExpressionResult_Request) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[83]
+	mi := &file_stacks_proto_msgTypes[85]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5081,7 +5237,7 @@ type InspectExpressionResult_Response struct {
 
 func (x *InspectExpressionResult_Response) Reset() {
 	*x = InspectExpressionResult_Response{}
-	mi := &file_stacks_proto_msgTypes[84]
+	mi := &file_stacks_proto_msgTypes[86]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5093,7 +5249,7 @@ func (x *InspectExpressionResult_Response) String() string {
 func (*InspectExpressionResult_Response) ProtoMessage() {}
 
 func (x *InspectExpressionResult_Response) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[84]
+	mi := &file_stacks_proto_msgTypes[86]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5137,7 +5293,7 @@ type AttributePath_Step struct {
 
 func (x *AttributePath_Step) Reset() {
 	*x = AttributePath_Step{}
-	mi := &file_stacks_proto_msgTypes[85]
+	mi := &file_stacks_proto_msgTypes[87]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5149,7 +5305,7 @@ func (x *AttributePath_Step) String() string {
 func (*AttributePath_Step) ProtoMessage() {}
 
 func (x *AttributePath_Step) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[85]
+	mi := &file_stacks_proto_msgTypes[87]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5252,7 +5408,7 @@ type PlannedChange_ChangeDescription struct {
 
 func (x *PlannedChange_ChangeDescription) Reset() {
 	*x = PlannedChange_ChangeDescription{}
-	mi := &file_stacks_proto_msgTypes[86]
+	mi := &file_stacks_proto_msgTypes[88]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5264,7 +5420,7 @@ func (x *PlannedChange_ChangeDescription) String() string {
 func (*PlannedChange_ChangeDescription) ProtoMessage() {}
 
 func (x *PlannedChange_ChangeDescription) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[86]
+	mi := &file_stacks_proto_msgTypes[88]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5277,7 +5433,7 @@ func (x *PlannedChange_ChangeDescription) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PlannedChange_ChangeDescription.ProtoReflect.Descriptor instead.
 func (*PlannedChange_ChangeDescription) Descriptor() ([]byte, []int) {
-	return file_stacks_proto_rawDescGZIP(), []int{23, 0}
+	return file_stacks_proto_rawDescGZIP(), []int{24, 0}
 }
 
 func (x *PlannedChange_ChangeDescription) GetDescription() isPlannedChange_ChangeDescription_Description {
@@ -5449,7 +5605,7 @@ type PlannedChange_ComponentInstance struct {
 
 func (x *PlannedChange_ComponentInstance) Reset() {
 	*x = PlannedChange_ComponentInstance{}
-	mi := &file_stacks_proto_msgTypes[87]
+	mi := &file_stacks_proto_msgTypes[89]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5461,7 +5617,7 @@ func (x *PlannedChange_ComponentInstance) String() string {
 func (*PlannedChange_ComponentInstance) ProtoMessage() {}
 
 func (x *PlannedChange_ComponentInstance) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[87]
+	mi := &file_stacks_proto_msgTypes[89]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5474,7 +5630,7 @@ func (x *PlannedChange_ComponentInstance) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PlannedChange_ComponentInstance.ProtoReflect.Descriptor instead.
 func (*PlannedChange_ComponentInstance) Descriptor() ([]byte, []int) {
-	return file_stacks_proto_rawDescGZIP(), []int{23, 1}
+	return file_stacks_proto_rawDescGZIP(), []int{24, 1}
 }
 
 func (x *PlannedChange_ComponentInstance) GetAddr() *ComponentInstanceInStackAddr {
@@ -5546,7 +5702,7 @@ type PlannedChange_ResourceInstance struct {
 
 func (x *PlannedChange_ResourceInstance) Reset() {
 	*x = PlannedChange_ResourceInstance{}
-	mi := &file_stacks_proto_msgTypes[88]
+	mi := &file_stacks_proto_msgTypes[90]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5558,7 +5714,7 @@ func (x *PlannedChange_ResourceInstance) String() string {
 func (*PlannedChange_ResourceInstance) ProtoMessage() {}
 
 func (x *PlannedChange_ResourceInstance) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[88]
+	mi := &file_stacks_proto_msgTypes[90]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5571,7 +5727,7 @@ func (x *PlannedChange_ResourceInstance) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PlannedChange_ResourceInstance.ProtoReflect.Descriptor instead.
 func (*PlannedChange_ResourceInstance) Descriptor() ([]byte, []int) {
-	return file_stacks_proto_rawDescGZIP(), []int{23, 2}
+	return file_stacks_proto_rawDescGZIP(), []int{24, 2}
 }
 
 func (x *PlannedChange_ResourceInstance) GetAddr() *ResourceInstanceObjectInStackAddr {
@@ -5693,7 +5849,7 @@ type PlannedChange_OutputValue struct {
 
 func (x *PlannedChange_OutputValue) Reset() {
 	*x = PlannedChange_OutputValue{}
-	mi := &file_stacks_proto_msgTypes[89]
+	mi := &file_stacks_proto_msgTypes[91]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5705,7 +5861,7 @@ func (x *PlannedChange_OutputValue) String() string {
 func (*PlannedChange_OutputValue) ProtoMessage() {}
 
 func (x *PlannedChange_OutputValue) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[89]
+	mi := &file_stacks_proto_msgTypes[91]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5718,7 +5874,7 @@ func (x *PlannedChange_OutputValue) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PlannedChange_OutputValue.ProtoReflect.Descriptor instead.
 func (*PlannedChange_OutputValue) Descriptor() ([]byte, []int) {
-	return file_stacks_proto_rawDescGZIP(), []int{23, 3}
+	return file_stacks_proto_rawDescGZIP(), []int{24, 3}
 }
 
 func (x *PlannedChange_OutputValue) GetName() string {
@@ -5752,7 +5908,7 @@ type PlannedChange_ResourceInstanceDeferred struct {
 
 func (x *PlannedChange_ResourceInstanceDeferred) Reset() {
 	*x = PlannedChange_ResourceInstanceDeferred{}
-	mi := &file_stacks_proto_msgTypes[90]
+	mi := &file_stacks_proto_msgTypes[92]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5764,7 +5920,7 @@ func (x *PlannedChange_ResourceInstanceDeferred) String() string {
 func (*PlannedChange_ResourceInstanceDeferred) ProtoMessage() {}
 
 func (x *PlannedChange_ResourceInstanceDeferred) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[90]
+	mi := &file_stacks_proto_msgTypes[92]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5777,7 +5933,7 @@ func (x *PlannedChange_ResourceInstanceDeferred) ProtoReflect() protoreflect.Mes
 
 // Deprecated: Use PlannedChange_ResourceInstanceDeferred.ProtoReflect.Descriptor instead.
 func (*PlannedChange_ResourceInstanceDeferred) Descriptor() ([]byte, []int) {
-	return file_stacks_proto_rawDescGZIP(), []int{23, 4}
+	return file_stacks_proto_rawDescGZIP(), []int{24, 4}
 }
 
 func (x *PlannedChange_ResourceInstanceDeferred) GetResourceInstance() *PlannedChange_ResourceInstance {
@@ -5809,7 +5965,7 @@ type PlannedChange_InputVariable struct {
 
 func (x *PlannedChange_InputVariable) Reset() {
 	*x = PlannedChange_InputVariable{}
-	mi := &file_stacks_proto_msgTypes[91]
+	mi := &file_stacks_proto_msgTypes[93]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5821,7 +5977,7 @@ func (x *PlannedChange_InputVariable) String() string {
 func (*PlannedChange_InputVariable) ProtoMessage() {}
 
 func (x *PlannedChange_InputVariable) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[91]
+	mi := &file_stacks_proto_msgTypes[93]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5834,7 +5990,7 @@ func (x *PlannedChange_InputVariable) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PlannedChange_InputVariable.ProtoReflect.Descriptor instead.
 func (*PlannedChange_InputVariable) Descriptor() ([]byte, []int) {
-	return file_stacks_proto_rawDescGZIP(), []int{23, 5}
+	return file_stacks_proto_rawDescGZIP(), []int{24, 5}
 }
 
 func (x *PlannedChange_InputVariable) GetName() string {
@@ -5887,7 +6043,7 @@ type PlannedChange_ActionInvocationInstance struct {
 
 func (x *PlannedChange_ActionInvocationInstance) Reset() {
 	*x = PlannedChange_ActionInvocationInstance{}
-	mi := &file_stacks_proto_msgTypes[92]
+	mi := &file_stacks_proto_msgTypes[94]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5899,7 +6055,7 @@ func (x *PlannedChange_ActionInvocationInstance) String() string {
 func (*PlannedChange_ActionInvocationInstance) ProtoMessage() {}
 
 func (x *PlannedChange_ActionInvocationInstance) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[92]
+	mi := &file_stacks_proto_msgTypes[94]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5912,7 +6068,7 @@ func (x *PlannedChange_ActionInvocationInstance) ProtoReflect() protoreflect.Mes
 
 // Deprecated: Use PlannedChange_ActionInvocationInstance.ProtoReflect.Descriptor instead.
 func (*PlannedChange_ActionInvocationInstance) Descriptor() ([]byte, []int) {
-	return file_stacks_proto_rawDescGZIP(), []int{23, 6}
+	return file_stacks_proto_rawDescGZIP(), []int{24, 6}
 }
 
 func (x *PlannedChange_ActionInvocationInstance) GetAddr() *ActionInvocationInstanceInStackAddr {
@@ -6002,7 +6158,7 @@ type PlannedChange_ActionInvocationDeferred struct {
 
 func (x *PlannedChange_ActionInvocationDeferred) Reset() {
 	*x = PlannedChange_ActionInvocationDeferred{}
-	mi := &file_stacks_proto_msgTypes[93]
+	mi := &file_stacks_proto_msgTypes[95]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6014,7 +6170,7 @@ func (x *PlannedChange_ActionInvocationDeferred) String() string {
 func (*PlannedChange_ActionInvocationDeferred) ProtoMessage() {}
 
 func (x *PlannedChange_ActionInvocationDeferred) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[93]
+	mi := &file_stacks_proto_msgTypes[95]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6027,7 +6183,7 @@ func (x *PlannedChange_ActionInvocationDeferred) ProtoReflect() protoreflect.Mes
 
 // Deprecated: Use PlannedChange_ActionInvocationDeferred.ProtoReflect.Descriptor instead.
 func (*PlannedChange_ActionInvocationDeferred) Descriptor() ([]byte, []int) {
-	return file_stacks_proto_rawDescGZIP(), []int{23, 7}
+	return file_stacks_proto_rawDescGZIP(), []int{24, 7}
 }
 
 func (x *PlannedChange_ActionInvocationDeferred) GetDeferred() *Deferred {
@@ -6058,7 +6214,7 @@ type PlannedChange_ResourceActionTrigger struct {
 
 func (x *PlannedChange_ResourceActionTrigger) Reset() {
 	*x = PlannedChange_ResourceActionTrigger{}
-	mi := &file_stacks_proto_msgTypes[94]
+	mi := &file_stacks_proto_msgTypes[96]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6070,7 +6226,7 @@ func (x *PlannedChange_ResourceActionTrigger) String() string {
 func (*PlannedChange_ResourceActionTrigger) ProtoMessage() {}
 
 func (x *PlannedChange_ResourceActionTrigger) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[94]
+	mi := &file_stacks_proto_msgTypes[96]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6083,7 +6239,7 @@ func (x *PlannedChange_ResourceActionTrigger) ProtoReflect() protoreflect.Messag
 
 // Deprecated: Use PlannedChange_ResourceActionTrigger.ProtoReflect.Descriptor instead.
 func (*PlannedChange_ResourceActionTrigger) Descriptor() ([]byte, []int) {
-	return file_stacks_proto_rawDescGZIP(), []int{23, 8}
+	return file_stacks_proto_rawDescGZIP(), []int{24, 8}
 }
 
 func (x *PlannedChange_ResourceActionTrigger) GetTriggeringResourceAddress() *ResourceInstanceInStackAddr {
@@ -6124,7 +6280,7 @@ type PlannedChange_InvokeActionTrigger struct {
 
 func (x *PlannedChange_InvokeActionTrigger) Reset() {
 	*x = PlannedChange_InvokeActionTrigger{}
-	mi := &file_stacks_proto_msgTypes[95]
+	mi := &file_stacks_proto_msgTypes[97]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6136,7 +6292,7 @@ func (x *PlannedChange_InvokeActionTrigger) String() string {
 func (*PlannedChange_InvokeActionTrigger) ProtoMessage() {}
 
 func (x *PlannedChange_InvokeActionTrigger) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[95]
+	mi := &file_stacks_proto_msgTypes[97]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6149,7 +6305,7 @@ func (x *PlannedChange_InvokeActionTrigger) ProtoReflect() protoreflect.Message 
 
 // Deprecated: Use PlannedChange_InvokeActionTrigger.ProtoReflect.Descriptor instead.
 func (*PlannedChange_InvokeActionTrigger) Descriptor() ([]byte, []int) {
-	return file_stacks_proto_rawDescGZIP(), []int{23, 9}
+	return file_stacks_proto_rawDescGZIP(), []int{24, 9}
 }
 
 type PlannedChange_ResourceInstance_Index struct {
@@ -6162,7 +6318,7 @@ type PlannedChange_ResourceInstance_Index struct {
 
 func (x *PlannedChange_ResourceInstance_Index) Reset() {
 	*x = PlannedChange_ResourceInstance_Index{}
-	mi := &file_stacks_proto_msgTypes[97]
+	mi := &file_stacks_proto_msgTypes[99]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6174,7 +6330,7 @@ func (x *PlannedChange_ResourceInstance_Index) String() string {
 func (*PlannedChange_ResourceInstance_Index) ProtoMessage() {}
 
 func (x *PlannedChange_ResourceInstance_Index) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[97]
+	mi := &file_stacks_proto_msgTypes[99]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6187,7 +6343,7 @@ func (x *PlannedChange_ResourceInstance_Index) ProtoReflect() protoreflect.Messa
 
 // Deprecated: Use PlannedChange_ResourceInstance_Index.ProtoReflect.Descriptor instead.
 func (*PlannedChange_ResourceInstance_Index) Descriptor() ([]byte, []int) {
-	return file_stacks_proto_rawDescGZIP(), []int{23, 2, 0}
+	return file_stacks_proto_rawDescGZIP(), []int{24, 2, 0}
 }
 
 func (x *PlannedChange_ResourceInstance_Index) GetValue() *DynamicValue {
@@ -6213,7 +6369,7 @@ type PlannedChange_ResourceInstance_Moved struct {
 
 func (x *PlannedChange_ResourceInstance_Moved) Reset() {
 	*x = PlannedChange_ResourceInstance_Moved{}
-	mi := &file_stacks_proto_msgTypes[98]
+	mi := &file_stacks_proto_msgTypes[100]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6225,7 +6381,7 @@ func (x *PlannedChange_ResourceInstance_Moved) String() string {
 func (*PlannedChange_ResourceInstance_Moved) ProtoMessage() {}
 
 func (x *PlannedChange_ResourceInstance_Moved) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[98]
+	mi := &file_stacks_proto_msgTypes[100]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6238,7 +6394,7 @@ func (x *PlannedChange_ResourceInstance_Moved) ProtoReflect() protoreflect.Messa
 
 // Deprecated: Use PlannedChange_ResourceInstance_Moved.ProtoReflect.Descriptor instead.
 func (*PlannedChange_ResourceInstance_Moved) Descriptor() ([]byte, []int) {
-	return file_stacks_proto_rawDescGZIP(), []int{23, 2, 1}
+	return file_stacks_proto_rawDescGZIP(), []int{24, 2, 1}
 }
 
 func (x *PlannedChange_ResourceInstance_Moved) GetPrevAddr() *ResourceInstanceInStackAddr {
@@ -6259,7 +6415,7 @@ type PlannedChange_ResourceInstance_Imported struct {
 
 func (x *PlannedChange_ResourceInstance_Imported) Reset() {
 	*x = PlannedChange_ResourceInstance_Imported{}
-	mi := &file_stacks_proto_msgTypes[99]
+	mi := &file_stacks_proto_msgTypes[101]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6271,7 +6427,7 @@ func (x *PlannedChange_ResourceInstance_Imported) String() string {
 func (*PlannedChange_ResourceInstance_Imported) ProtoMessage() {}
 
 func (x *PlannedChange_ResourceInstance_Imported) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[99]
+	mi := &file_stacks_proto_msgTypes[101]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6284,7 +6440,7 @@ func (x *PlannedChange_ResourceInstance_Imported) ProtoReflect() protoreflect.Me
 
 // Deprecated: Use PlannedChange_ResourceInstance_Imported.ProtoReflect.Descriptor instead.
 func (*PlannedChange_ResourceInstance_Imported) Descriptor() ([]byte, []int) {
-	return file_stacks_proto_rawDescGZIP(), []int{23, 2, 2}
+	return file_stacks_proto_rawDescGZIP(), []int{24, 2, 2}
 }
 
 func (x *PlannedChange_ResourceInstance_Imported) GetImportId() string {
@@ -6318,7 +6474,7 @@ type AppliedChange_RawChange struct {
 
 func (x *AppliedChange_RawChange) Reset() {
 	*x = AppliedChange_RawChange{}
-	mi := &file_stacks_proto_msgTypes[100]
+	mi := &file_stacks_proto_msgTypes[102]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6330,7 +6486,7 @@ func (x *AppliedChange_RawChange) String() string {
 func (*AppliedChange_RawChange) ProtoMessage() {}
 
 func (x *AppliedChange_RawChange) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[100]
+	mi := &file_stacks_proto_msgTypes[102]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6343,7 +6499,7 @@ func (x *AppliedChange_RawChange) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AppliedChange_RawChange.ProtoReflect.Descriptor instead.
 func (*AppliedChange_RawChange) Descriptor() ([]byte, []int) {
-	return file_stacks_proto_rawDescGZIP(), []int{25, 0}
+	return file_stacks_proto_rawDescGZIP(), []int{26, 0}
 }
 
 func (x *AppliedChange_RawChange) GetKey() string {
@@ -6378,7 +6534,7 @@ type AppliedChange_ChangeDescription struct {
 
 func (x *AppliedChange_ChangeDescription) Reset() {
 	*x = AppliedChange_ChangeDescription{}
-	mi := &file_stacks_proto_msgTypes[101]
+	mi := &file_stacks_proto_msgTypes[103]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6390,7 +6546,7 @@ func (x *AppliedChange_ChangeDescription) String() string {
 func (*AppliedChange_ChangeDescription) ProtoMessage() {}
 
 func (x *AppliedChange_ChangeDescription) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[101]
+	mi := &file_stacks_proto_msgTypes[103]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6403,7 +6559,7 @@ func (x *AppliedChange_ChangeDescription) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AppliedChange_ChangeDescription.ProtoReflect.Descriptor instead.
 func (*AppliedChange_ChangeDescription) Descriptor() ([]byte, []int) {
-	return file_stacks_proto_rawDescGZIP(), []int{25, 1}
+	return file_stacks_proto_rawDescGZIP(), []int{26, 1}
 }
 
 func (x *AppliedChange_ChangeDescription) GetKey() string {
@@ -6552,7 +6708,7 @@ type AppliedChange_ResourceInstance struct {
 
 func (x *AppliedChange_ResourceInstance) Reset() {
 	*x = AppliedChange_ResourceInstance{}
-	mi := &file_stacks_proto_msgTypes[102]
+	mi := &file_stacks_proto_msgTypes[104]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6564,7 +6720,7 @@ func (x *AppliedChange_ResourceInstance) String() string {
 func (*AppliedChange_ResourceInstance) ProtoMessage() {}
 
 func (x *AppliedChange_ResourceInstance) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[102]
+	mi := &file_stacks_proto_msgTypes[104]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6577,7 +6733,7 @@ func (x *AppliedChange_ResourceInstance) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AppliedChange_ResourceInstance.ProtoReflect.Descriptor instead.
 func (*AppliedChange_ResourceInstance) Descriptor() ([]byte, []int) {
-	return file_stacks_proto_rawDescGZIP(), []int{25, 2}
+	return file_stacks_proto_rawDescGZIP(), []int{26, 2}
 }
 
 func (x *AppliedChange_ResourceInstance) GetAddr() *ResourceInstanceObjectInStackAddr {
@@ -6633,7 +6789,7 @@ type AppliedChange_ComponentInstance struct {
 
 func (x *AppliedChange_ComponentInstance) Reset() {
 	*x = AppliedChange_ComponentInstance{}
-	mi := &file_stacks_proto_msgTypes[103]
+	mi := &file_stacks_proto_msgTypes[105]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6645,7 +6801,7 @@ func (x *AppliedChange_ComponentInstance) String() string {
 func (*AppliedChange_ComponentInstance) ProtoMessage() {}
 
 func (x *AppliedChange_ComponentInstance) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[103]
+	mi := &file_stacks_proto_msgTypes[105]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6658,7 +6814,7 @@ func (x *AppliedChange_ComponentInstance) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AppliedChange_ComponentInstance.ProtoReflect.Descriptor instead.
 func (*AppliedChange_ComponentInstance) Descriptor() ([]byte, []int) {
-	return file_stacks_proto_rawDescGZIP(), []int{25, 3}
+	return file_stacks_proto_rawDescGZIP(), []int{26, 3}
 }
 
 func (x *AppliedChange_ComponentInstance) GetComponentAddr() string {
@@ -6692,7 +6848,7 @@ type AppliedChange_OutputValue struct {
 
 func (x *AppliedChange_OutputValue) Reset() {
 	*x = AppliedChange_OutputValue{}
-	mi := &file_stacks_proto_msgTypes[104]
+	mi := &file_stacks_proto_msgTypes[106]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6704,7 +6860,7 @@ func (x *AppliedChange_OutputValue) String() string {
 func (*AppliedChange_OutputValue) ProtoMessage() {}
 
 func (x *AppliedChange_OutputValue) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[104]
+	mi := &file_stacks_proto_msgTypes[106]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6717,7 +6873,7 @@ func (x *AppliedChange_OutputValue) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AppliedChange_OutputValue.ProtoReflect.Descriptor instead.
 func (*AppliedChange_OutputValue) Descriptor() ([]byte, []int) {
-	return file_stacks_proto_rawDescGZIP(), []int{25, 4}
+	return file_stacks_proto_rawDescGZIP(), []int{26, 4}
 }
 
 func (x *AppliedChange_OutputValue) GetName() string {
@@ -6744,7 +6900,7 @@ type AppliedChange_InputVariable struct {
 
 func (x *AppliedChange_InputVariable) Reset() {
 	*x = AppliedChange_InputVariable{}
-	mi := &file_stacks_proto_msgTypes[105]
+	mi := &file_stacks_proto_msgTypes[107]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6756,7 +6912,7 @@ func (x *AppliedChange_InputVariable) String() string {
 func (*AppliedChange_InputVariable) ProtoMessage() {}
 
 func (x *AppliedChange_InputVariable) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[105]
+	mi := &file_stacks_proto_msgTypes[107]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6769,7 +6925,7 @@ func (x *AppliedChange_InputVariable) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AppliedChange_InputVariable.ProtoReflect.Descriptor instead.
 func (*AppliedChange_InputVariable) Descriptor() ([]byte, []int) {
-	return file_stacks_proto_rawDescGZIP(), []int{25, 5}
+	return file_stacks_proto_rawDescGZIP(), []int{26, 5}
 }
 
 func (x *AppliedChange_InputVariable) GetName() string {
@@ -6794,7 +6950,7 @@ type AppliedChange_Nothing struct {
 
 func (x *AppliedChange_Nothing) Reset() {
 	*x = AppliedChange_Nothing{}
-	mi := &file_stacks_proto_msgTypes[106]
+	mi := &file_stacks_proto_msgTypes[108]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6806,7 +6962,7 @@ func (x *AppliedChange_Nothing) String() string {
 func (*AppliedChange_Nothing) ProtoMessage() {}
 
 func (x *AppliedChange_Nothing) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[106]
+	mi := &file_stacks_proto_msgTypes[108]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6819,7 +6975,7 @@ func (x *AppliedChange_Nothing) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AppliedChange_Nothing.ProtoReflect.Descriptor instead.
 func (*AppliedChange_Nothing) Descriptor() ([]byte, []int) {
-	return file_stacks_proto_rawDescGZIP(), []int{25, 6}
+	return file_stacks_proto_rawDescGZIP(), []int{26, 6}
 }
 
 // ComponentInstanceStatus describes the current status of a component instance
@@ -6834,7 +6990,7 @@ type StackChangeProgress_ComponentInstanceStatus struct {
 
 func (x *StackChangeProgress_ComponentInstanceStatus) Reset() {
 	*x = StackChangeProgress_ComponentInstanceStatus{}
-	mi := &file_stacks_proto_msgTypes[108]
+	mi := &file_stacks_proto_msgTypes[110]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6846,7 +7002,7 @@ func (x *StackChangeProgress_ComponentInstanceStatus) String() string {
 func (*StackChangeProgress_ComponentInstanceStatus) ProtoMessage() {}
 
 func (x *StackChangeProgress_ComponentInstanceStatus) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[108]
+	mi := &file_stacks_proto_msgTypes[110]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6859,7 +7015,7 @@ func (x *StackChangeProgress_ComponentInstanceStatus) ProtoReflect() protoreflec
 
 // Deprecated: Use StackChangeProgress_ComponentInstanceStatus.ProtoReflect.Descriptor instead.
 func (*StackChangeProgress_ComponentInstanceStatus) Descriptor() ([]byte, []int) {
-	return file_stacks_proto_rawDescGZIP(), []int{26, 0}
+	return file_stacks_proto_rawDescGZIP(), []int{27, 0}
 }
 
 func (x *StackChangeProgress_ComponentInstanceStatus) GetAddr() *ComponentInstanceInStackAddr {
@@ -6889,7 +7045,7 @@ type StackChangeProgress_ResourceInstanceStatus struct {
 
 func (x *StackChangeProgress_ResourceInstanceStatus) Reset() {
 	*x = StackChangeProgress_ResourceInstanceStatus{}
-	mi := &file_stacks_proto_msgTypes[109]
+	mi := &file_stacks_proto_msgTypes[111]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6901,7 +7057,7 @@ func (x *StackChangeProgress_ResourceInstanceStatus) String() string {
 func (*StackChangeProgress_ResourceInstanceStatus) ProtoMessage() {}
 
 func (x *StackChangeProgress_ResourceInstanceStatus) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[109]
+	mi := &file_stacks_proto_msgTypes[111]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6914,7 +7070,7 @@ func (x *StackChangeProgress_ResourceInstanceStatus) ProtoReflect() protoreflect
 
 // Deprecated: Use StackChangeProgress_ResourceInstanceStatus.ProtoReflect.Descriptor instead.
 func (*StackChangeProgress_ResourceInstanceStatus) Descriptor() ([]byte, []int) {
-	return file_stacks_proto_rawDescGZIP(), []int{26, 1}
+	return file_stacks_proto_rawDescGZIP(), []int{27, 1}
 }
 
 func (x *StackChangeProgress_ResourceInstanceStatus) GetAddr() *ResourceInstanceObjectInStackAddr {
@@ -6956,7 +7112,7 @@ type StackChangeProgress_ResourceInstancePlannedChange struct {
 
 func (x *StackChangeProgress_ResourceInstancePlannedChange) Reset() {
 	*x = StackChangeProgress_ResourceInstancePlannedChange{}
-	mi := &file_stacks_proto_msgTypes[110]
+	mi := &file_stacks_proto_msgTypes[112]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6968,7 +7124,7 @@ func (x *StackChangeProgress_ResourceInstancePlannedChange) String() string {
 func (*StackChangeProgress_ResourceInstancePlannedChange) ProtoMessage() {}
 
 func (x *StackChangeProgress_ResourceInstancePlannedChange) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[110]
+	mi := &file_stacks_proto_msgTypes[112]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6981,7 +7137,7 @@ func (x *StackChangeProgress_ResourceInstancePlannedChange) ProtoReflect() proto
 
 // Deprecated: Use StackChangeProgress_ResourceInstancePlannedChange.ProtoReflect.Descriptor instead.
 func (*StackChangeProgress_ResourceInstancePlannedChange) Descriptor() ([]byte, []int) {
-	return file_stacks_proto_rawDescGZIP(), []int{26, 2}
+	return file_stacks_proto_rawDescGZIP(), []int{27, 2}
 }
 
 func (x *StackChangeProgress_ResourceInstancePlannedChange) GetAddr() *ResourceInstanceObjectInStackAddr {
@@ -7031,7 +7187,7 @@ type StackChangeProgress_DeferredResourceInstancePlannedChange struct {
 
 func (x *StackChangeProgress_DeferredResourceInstancePlannedChange) Reset() {
 	*x = StackChangeProgress_DeferredResourceInstancePlannedChange{}
-	mi := &file_stacks_proto_msgTypes[111]
+	mi := &file_stacks_proto_msgTypes[113]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7043,7 +7199,7 @@ func (x *StackChangeProgress_DeferredResourceInstancePlannedChange) String() str
 func (*StackChangeProgress_DeferredResourceInstancePlannedChange) ProtoMessage() {}
 
 func (x *StackChangeProgress_DeferredResourceInstancePlannedChange) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[111]
+	mi := &file_stacks_proto_msgTypes[113]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7056,7 +7212,7 @@ func (x *StackChangeProgress_DeferredResourceInstancePlannedChange) ProtoReflect
 
 // Deprecated: Use StackChangeProgress_DeferredResourceInstancePlannedChange.ProtoReflect.Descriptor instead.
 func (*StackChangeProgress_DeferredResourceInstancePlannedChange) Descriptor() ([]byte, []int) {
-	return file_stacks_proto_rawDescGZIP(), []int{26, 3}
+	return file_stacks_proto_rawDescGZIP(), []int{27, 3}
 }
 
 func (x *StackChangeProgress_DeferredResourceInstancePlannedChange) GetDeferred() *Deferred {
@@ -7088,7 +7244,7 @@ type StackChangeProgress_ActionInvocationPlanned struct {
 
 func (x *StackChangeProgress_ActionInvocationPlanned) Reset() {
 	*x = StackChangeProgress_ActionInvocationPlanned{}
-	mi := &file_stacks_proto_msgTypes[112]
+	mi := &file_stacks_proto_msgTypes[114]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7100,7 +7256,7 @@ func (x *StackChangeProgress_ActionInvocationPlanned) String() string {
 func (*StackChangeProgress_ActionInvocationPlanned) ProtoMessage() {}
 
 func (x *StackChangeProgress_ActionInvocationPlanned) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[112]
+	mi := &file_stacks_proto_msgTypes[114]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7113,7 +7269,7 @@ func (x *StackChangeProgress_ActionInvocationPlanned) ProtoReflect() protoreflec
 
 // Deprecated: Use StackChangeProgress_ActionInvocationPlanned.ProtoReflect.Descriptor instead.
 func (*StackChangeProgress_ActionInvocationPlanned) Descriptor() ([]byte, []int) {
-	return file_stacks_proto_rawDescGZIP(), []int{26, 4}
+	return file_stacks_proto_rawDescGZIP(), []int{27, 4}
 }
 
 func (x *StackChangeProgress_ActionInvocationPlanned) GetAddr() *ActionInvocationInstanceInStackAddr {
@@ -7189,7 +7345,7 @@ type StackChangeProgress_ActionInvocationStatus struct {
 
 func (x *StackChangeProgress_ActionInvocationStatus) Reset() {
 	*x = StackChangeProgress_ActionInvocationStatus{}
-	mi := &file_stacks_proto_msgTypes[113]
+	mi := &file_stacks_proto_msgTypes[115]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7201,7 +7357,7 @@ func (x *StackChangeProgress_ActionInvocationStatus) String() string {
 func (*StackChangeProgress_ActionInvocationStatus) ProtoMessage() {}
 
 func (x *StackChangeProgress_ActionInvocationStatus) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[113]
+	mi := &file_stacks_proto_msgTypes[115]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7214,7 +7370,7 @@ func (x *StackChangeProgress_ActionInvocationStatus) ProtoReflect() protoreflect
 
 // Deprecated: Use StackChangeProgress_ActionInvocationStatus.ProtoReflect.Descriptor instead.
 func (*StackChangeProgress_ActionInvocationStatus) Descriptor() ([]byte, []int) {
-	return file_stacks_proto_rawDescGZIP(), []int{26, 5}
+	return file_stacks_proto_rawDescGZIP(), []int{27, 5}
 }
 
 func (x *StackChangeProgress_ActionInvocationStatus) GetAddr() *ActionInvocationInstanceInStackAddr {
@@ -7297,7 +7453,7 @@ type StackChangeProgress_ActionInvocationProgress struct {
 
 func (x *StackChangeProgress_ActionInvocationProgress) Reset() {
 	*x = StackChangeProgress_ActionInvocationProgress{}
-	mi := &file_stacks_proto_msgTypes[114]
+	mi := &file_stacks_proto_msgTypes[116]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7309,7 +7465,7 @@ func (x *StackChangeProgress_ActionInvocationProgress) String() string {
 func (*StackChangeProgress_ActionInvocationProgress) ProtoMessage() {}
 
 func (x *StackChangeProgress_ActionInvocationProgress) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[114]
+	mi := &file_stacks_proto_msgTypes[116]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7322,7 +7478,7 @@ func (x *StackChangeProgress_ActionInvocationProgress) ProtoReflect() protorefle
 
 // Deprecated: Use StackChangeProgress_ActionInvocationProgress.ProtoReflect.Descriptor instead.
 func (*StackChangeProgress_ActionInvocationProgress) Descriptor() ([]byte, []int) {
-	return file_stacks_proto_rawDescGZIP(), []int{26, 6}
+	return file_stacks_proto_rawDescGZIP(), []int{27, 6}
 }
 
 func (x *StackChangeProgress_ActionInvocationProgress) GetAddr() *ActionInvocationInstanceInStackAddr {
@@ -7403,7 +7559,7 @@ type StackChangeProgress_ResourceActionTrigger struct {
 
 func (x *StackChangeProgress_ResourceActionTrigger) Reset() {
 	*x = StackChangeProgress_ResourceActionTrigger{}
-	mi := &file_stacks_proto_msgTypes[115]
+	mi := &file_stacks_proto_msgTypes[117]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7415,7 +7571,7 @@ func (x *StackChangeProgress_ResourceActionTrigger) String() string {
 func (*StackChangeProgress_ResourceActionTrigger) ProtoMessage() {}
 
 func (x *StackChangeProgress_ResourceActionTrigger) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[115]
+	mi := &file_stacks_proto_msgTypes[117]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7428,7 +7584,7 @@ func (x *StackChangeProgress_ResourceActionTrigger) ProtoReflect() protoreflect.
 
 // Deprecated: Use StackChangeProgress_ResourceActionTrigger.ProtoReflect.Descriptor instead.
 func (*StackChangeProgress_ResourceActionTrigger) Descriptor() ([]byte, []int) {
-	return file_stacks_proto_rawDescGZIP(), []int{26, 7}
+	return file_stacks_proto_rawDescGZIP(), []int{27, 7}
 }
 
 func (x *StackChangeProgress_ResourceActionTrigger) GetTriggeringResourceAddress() *ResourceInstanceInStackAddr {
@@ -7469,7 +7625,7 @@ type StackChangeProgress_InvokeActionTrigger struct {
 
 func (x *StackChangeProgress_InvokeActionTrigger) Reset() {
 	*x = StackChangeProgress_InvokeActionTrigger{}
-	mi := &file_stacks_proto_msgTypes[116]
+	mi := &file_stacks_proto_msgTypes[118]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7481,7 +7637,7 @@ func (x *StackChangeProgress_InvokeActionTrigger) String() string {
 func (*StackChangeProgress_InvokeActionTrigger) ProtoMessage() {}
 
 func (x *StackChangeProgress_InvokeActionTrigger) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[116]
+	mi := &file_stacks_proto_msgTypes[118]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7494,7 +7650,7 @@ func (x *StackChangeProgress_InvokeActionTrigger) ProtoReflect() protoreflect.Me
 
 // Deprecated: Use StackChangeProgress_InvokeActionTrigger.ProtoReflect.Descriptor instead.
 func (*StackChangeProgress_InvokeActionTrigger) Descriptor() ([]byte, []int) {
-	return file_stacks_proto_rawDescGZIP(), []int{26, 8}
+	return file_stacks_proto_rawDescGZIP(), []int{27, 8}
 }
 
 // ProvisionerStatus represents the progress of a given provisioner during its
@@ -7510,7 +7666,7 @@ type StackChangeProgress_ProvisionerStatus struct {
 
 func (x *StackChangeProgress_ProvisionerStatus) Reset() {
 	*x = StackChangeProgress_ProvisionerStatus{}
-	mi := &file_stacks_proto_msgTypes[117]
+	mi := &file_stacks_proto_msgTypes[119]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7522,7 +7678,7 @@ func (x *StackChangeProgress_ProvisionerStatus) String() string {
 func (*StackChangeProgress_ProvisionerStatus) ProtoMessage() {}
 
 func (x *StackChangeProgress_ProvisionerStatus) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[117]
+	mi := &file_stacks_proto_msgTypes[119]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7535,7 +7691,7 @@ func (x *StackChangeProgress_ProvisionerStatus) ProtoReflect() protoreflect.Mess
 
 // Deprecated: Use StackChangeProgress_ProvisionerStatus.ProtoReflect.Descriptor instead.
 func (*StackChangeProgress_ProvisionerStatus) Descriptor() ([]byte, []int) {
-	return file_stacks_proto_rawDescGZIP(), []int{26, 9}
+	return file_stacks_proto_rawDescGZIP(), []int{27, 9}
 }
 
 func (x *StackChangeProgress_ProvisionerStatus) GetAddr() *ResourceInstanceObjectInStackAddr {
@@ -7572,7 +7728,7 @@ type StackChangeProgress_ProvisionerOutput struct {
 
 func (x *StackChangeProgress_ProvisionerOutput) Reset() {
 	*x = StackChangeProgress_ProvisionerOutput{}
-	mi := &file_stacks_proto_msgTypes[118]
+	mi := &file_stacks_proto_msgTypes[120]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7584,7 +7740,7 @@ func (x *StackChangeProgress_ProvisionerOutput) String() string {
 func (*StackChangeProgress_ProvisionerOutput) ProtoMessage() {}
 
 func (x *StackChangeProgress_ProvisionerOutput) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[118]
+	mi := &file_stacks_proto_msgTypes[120]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7597,7 +7753,7 @@ func (x *StackChangeProgress_ProvisionerOutput) ProtoReflect() protoreflect.Mess
 
 // Deprecated: Use StackChangeProgress_ProvisionerOutput.ProtoReflect.Descriptor instead.
 func (*StackChangeProgress_ProvisionerOutput) Descriptor() ([]byte, []int) {
-	return file_stacks_proto_rawDescGZIP(), []int{26, 10}
+	return file_stacks_proto_rawDescGZIP(), []int{27, 10}
 }
 
 func (x *StackChangeProgress_ProvisionerOutput) GetAddr() *ResourceInstanceObjectInStackAddr {
@@ -7648,7 +7804,7 @@ type StackChangeProgress_ComponentInstanceChanges struct {
 
 func (x *StackChangeProgress_ComponentInstanceChanges) Reset() {
 	*x = StackChangeProgress_ComponentInstanceChanges{}
-	mi := &file_stacks_proto_msgTypes[119]
+	mi := &file_stacks_proto_msgTypes[121]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7660,7 +7816,7 @@ func (x *StackChangeProgress_ComponentInstanceChanges) String() string {
 func (*StackChangeProgress_ComponentInstanceChanges) ProtoMessage() {}
 
 func (x *StackChangeProgress_ComponentInstanceChanges) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[119]
+	mi := &file_stacks_proto_msgTypes[121]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7673,7 +7829,7 @@ func (x *StackChangeProgress_ComponentInstanceChanges) ProtoReflect() protorefle
 
 // Deprecated: Use StackChangeProgress_ComponentInstanceChanges.ProtoReflect.Descriptor instead.
 func (*StackChangeProgress_ComponentInstanceChanges) Descriptor() ([]byte, []int) {
-	return file_stacks_proto_rawDescGZIP(), []int{26, 11}
+	return file_stacks_proto_rawDescGZIP(), []int{27, 11}
 }
 
 func (x *StackChangeProgress_ComponentInstanceChanges) GetAddr() *ComponentInstanceInStackAddr {
@@ -7758,7 +7914,7 @@ type StackChangeProgress_ComponentInstances struct {
 
 func (x *StackChangeProgress_ComponentInstances) Reset() {
 	*x = StackChangeProgress_ComponentInstances{}
-	mi := &file_stacks_proto_msgTypes[120]
+	mi := &file_stacks_proto_msgTypes[122]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7770,7 +7926,7 @@ func (x *StackChangeProgress_ComponentInstances) String() string {
 func (*StackChangeProgress_ComponentInstances) ProtoMessage() {}
 
 func (x *StackChangeProgress_ComponentInstances) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[120]
+	mi := &file_stacks_proto_msgTypes[122]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7783,7 +7939,7 @@ func (x *StackChangeProgress_ComponentInstances) ProtoReflect() protoreflect.Mes
 
 // Deprecated: Use StackChangeProgress_ComponentInstances.ProtoReflect.Descriptor instead.
 func (*StackChangeProgress_ComponentInstances) Descriptor() ([]byte, []int) {
-	return file_stacks_proto_rawDescGZIP(), []int{26, 12}
+	return file_stacks_proto_rawDescGZIP(), []int{27, 12}
 }
 
 func (x *StackChangeProgress_ComponentInstances) GetComponentAddr() string {
@@ -7809,7 +7965,7 @@ type StackChangeProgress_ResourceInstancePlannedChange_Moved struct {
 
 func (x *StackChangeProgress_ResourceInstancePlannedChange_Moved) Reset() {
 	*x = StackChangeProgress_ResourceInstancePlannedChange_Moved{}
-	mi := &file_stacks_proto_msgTypes[121]
+	mi := &file_stacks_proto_msgTypes[123]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7821,7 +7977,7 @@ func (x *StackChangeProgress_ResourceInstancePlannedChange_Moved) String() strin
 func (*StackChangeProgress_ResourceInstancePlannedChange_Moved) ProtoMessage() {}
 
 func (x *StackChangeProgress_ResourceInstancePlannedChange_Moved) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[121]
+	mi := &file_stacks_proto_msgTypes[123]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7834,7 +7990,7 @@ func (x *StackChangeProgress_ResourceInstancePlannedChange_Moved) ProtoReflect()
 
 // Deprecated: Use StackChangeProgress_ResourceInstancePlannedChange_Moved.ProtoReflect.Descriptor instead.
 func (*StackChangeProgress_ResourceInstancePlannedChange_Moved) Descriptor() ([]byte, []int) {
-	return file_stacks_proto_rawDescGZIP(), []int{26, 2, 0}
+	return file_stacks_proto_rawDescGZIP(), []int{27, 2, 0}
 }
 
 func (x *StackChangeProgress_ResourceInstancePlannedChange_Moved) GetPrevAddr() *ResourceInstanceInStackAddr {
@@ -7854,7 +8010,7 @@ type StackChangeProgress_ResourceInstancePlannedChange_Imported struct {
 
 func (x *StackChangeProgress_ResourceInstancePlannedChange_Imported) Reset() {
 	*x = StackChangeProgress_ResourceInstancePlannedChange_Imported{}
-	mi := &file_stacks_proto_msgTypes[122]
+	mi := &file_stacks_proto_msgTypes[124]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7866,7 +8022,7 @@ func (x *StackChangeProgress_ResourceInstancePlannedChange_Imported) String() st
 func (*StackChangeProgress_ResourceInstancePlannedChange_Imported) ProtoMessage() {}
 
 func (x *StackChangeProgress_ResourceInstancePlannedChange_Imported) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[122]
+	mi := &file_stacks_proto_msgTypes[124]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7879,7 +8035,7 @@ func (x *StackChangeProgress_ResourceInstancePlannedChange_Imported) ProtoReflec
 
 // Deprecated: Use StackChangeProgress_ResourceInstancePlannedChange_Imported.ProtoReflect.Descriptor instead.
 func (*StackChangeProgress_ResourceInstancePlannedChange_Imported) Descriptor() ([]byte, []int) {
-	return file_stacks_proto_rawDescGZIP(), []int{26, 2, 1}
+	return file_stacks_proto_rawDescGZIP(), []int{27, 2, 1}
 }
 
 func (x *StackChangeProgress_ResourceInstancePlannedChange_Imported) GetImportId() string {
@@ -7907,7 +8063,7 @@ type ListResourceIdentities_Request struct {
 
 func (x *ListResourceIdentities_Request) Reset() {
 	*x = ListResourceIdentities_Request{}
-	mi := &file_stacks_proto_msgTypes[123]
+	mi := &file_stacks_proto_msgTypes[125]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7919,7 +8075,7 @@ func (x *ListResourceIdentities_Request) String() string {
 func (*ListResourceIdentities_Request) ProtoMessage() {}
 
 func (x *ListResourceIdentities_Request) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[123]
+	mi := &file_stacks_proto_msgTypes[125]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7932,7 +8088,7 @@ func (x *ListResourceIdentities_Request) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListResourceIdentities_Request.ProtoReflect.Descriptor instead.
 func (*ListResourceIdentities_Request) Descriptor() ([]byte, []int) {
-	return file_stacks_proto_rawDescGZIP(), []int{27, 0}
+	return file_stacks_proto_rawDescGZIP(), []int{28, 0}
 }
 
 func (x *ListResourceIdentities_Request) GetStateHandle() int64 {
@@ -7965,7 +8121,7 @@ type ListResourceIdentities_Response struct {
 
 func (x *ListResourceIdentities_Response) Reset() {
 	*x = ListResourceIdentities_Response{}
-	mi := &file_stacks_proto_msgTypes[124]
+	mi := &file_stacks_proto_msgTypes[126]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7977,7 +8133,7 @@ func (x *ListResourceIdentities_Response) String() string {
 func (*ListResourceIdentities_Response) ProtoMessage() {}
 
 func (x *ListResourceIdentities_Response) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[124]
+	mi := &file_stacks_proto_msgTypes[126]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7990,7 +8146,7 @@ func (x *ListResourceIdentities_Response) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListResourceIdentities_Response.ProtoReflect.Descriptor instead.
 func (*ListResourceIdentities_Response) Descriptor() ([]byte, []int) {
-	return file_stacks_proto_rawDescGZIP(), []int{27, 1}
+	return file_stacks_proto_rawDescGZIP(), []int{28, 1}
 }
 
 func (x *ListResourceIdentities_Response) GetResource() []*ListResourceIdentities_Resource {
@@ -8016,7 +8172,7 @@ type ListResourceIdentities_Resource struct {
 
 func (x *ListResourceIdentities_Resource) Reset() {
 	*x = ListResourceIdentities_Resource{}
-	mi := &file_stacks_proto_msgTypes[125]
+	mi := &file_stacks_proto_msgTypes[127]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8028,7 +8184,7 @@ func (x *ListResourceIdentities_Resource) String() string {
 func (*ListResourceIdentities_Resource) ProtoMessage() {}
 
 func (x *ListResourceIdentities_Resource) ProtoReflect() protoreflect.Message {
-	mi := &file_stacks_proto_msgTypes[125]
+	mi := &file_stacks_proto_msgTypes[127]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8041,7 +8197,7 @@ func (x *ListResourceIdentities_Resource) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListResourceIdentities_Resource.ProtoReflect.Descriptor instead.
 func (*ListResourceIdentities_Resource) Descriptor() ([]byte, []int) {
-	return file_stacks_proto_rawDescGZIP(), []int{27, 2}
+	return file_stacks_proto_rawDescGZIP(), []int{28, 2}
 }
 
 func (x *ListResourceIdentities_Resource) GetComponentAddr() string {
@@ -8205,7 +8361,8 @@ const file_stacks_proto_rawDesc = "" +
 	"\aRequest\x12!\n" +
 	"\fstate_handle\x18\x01 \x01(\x03R\vstateHandle\x1a\n" +
 	"\n" +
-	"\bResponse\"\x8e\t\n" +
+	"\bResponse\"\x9f\n" +
+	"\n" +
 	"\x10PlanStackChanges\x1a\x95\x06\n" +
 	"\aRequest\x128\n" +
 	"\tplan_mode\x18\x01 \x01(\x0e2\x1b.terraform1.stacks.PlanModeR\bplanMode\x12.\n" +
@@ -8223,15 +8380,16 @@ const file_stacks_proto_rawDesc = "" +
 	"\x10InputValuesEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12?\n" +
 	"\x05value\x18\x02 \x01(\v2).terraform1.stacks.DynamicValueWithSourceR\x05value:\x028\x01B\x17\n" +
-	"\x15_tfpolicy_plugin_path\x1a\xe1\x02\n" +
+	"\x15_tfpolicy_plugin_path\x1a\xf2\x03\n" +
 	"\x05Event\x12I\n" +
 	"\x0eplanned_change\x18\x01 \x01(\v2 .terraform1.stacks.PlannedChangeH\x00R\rplannedChange\x128\n" +
 	"\n" +
 	"diagnostic\x18\x02 \x01(\v2\x16.terraform1.DiagnosticH\x00R\n" +
 	"diagnostic\x12D\n" +
 	"\bprogress\x18\n" +
-	" \x01(\v2&.terraform1.stacks.StackChangeProgressH\x00R\bprogress\x12~\n" +
-	"$component_instance_policy_evaluation\x18\v \x01(\v2+.terraform1.stacks.PolicyEvaluationResponseH\x00R!componentInstancePolicyEvaluationB\a\n" +
+	" \x01(\v2&.terraform1.stacks.StackChangeProgressH\x00R\bprogress\x12\x87\x01\n" +
+	"$component_instance_policy_evaluation\x18\v \x01(\v24.terraform1.stacks.ComponentInstancePolicyEvaluationH\x00R!componentInstancePolicyEvaluation\x12\x84\x01\n" +
+	"#provider_instance_policy_evaluation\x18\f \x01(\v23.terraform1.stacks.ProviderInstancePolicyEvaluationH\x00R providerInstancePolicyEvaluationB\a\n" +
 	"\x05eventJ\x04\b\x03\x10\n" +
 	"\"s\n" +
 	"\rOpenStackPlan\x1a5\n" +
@@ -8245,7 +8403,7 @@ const file_stacks_proto_rawDesc = "" +
 	"\vplan_handle\x18\x01 \x01(\x03R\n" +
 	"planHandle\x1a\n" +
 	"\n" +
-	"\bResponse\"\xf9\a\n" +
+	"\bResponse\"\x8a\t\n" +
 	"\x11ApplyStackChanges\x1a\x85\x05\n" +
 	"\aRequest\x12.\n" +
 	"\x13stack_config_handle\x18\x01 \x01(\x03R\x11stackConfigHandle\x124\n" +
@@ -8262,14 +8420,15 @@ const file_stacks_proto_rawDesc = "" +
 	"\x10InputValuesEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12?\n" +
 	"\x05value\x18\x02 \x01(\v2).terraform1.stacks.DynamicValueWithSourceR\x05value:\x028\x01B\x17\n" +
-	"\x15_tfpolicy_plugin_pathJ\x04\b\x02\x10\x03\x1a\xdb\x02\n" +
+	"\x15_tfpolicy_plugin_pathJ\x04\b\x02\x10\x03\x1a\xec\x03\n" +
 	"\x05Event\x12I\n" +
 	"\x0eapplied_change\x18\x01 \x01(\v2 .terraform1.stacks.AppliedChangeH\x00R\rappliedChange\x128\n" +
 	"\n" +
 	"diagnostic\x18\x02 \x01(\v2\x16.terraform1.DiagnosticH\x00R\n" +
 	"diagnostic\x12D\n" +
-	"\bprogress\x18\x03 \x01(\v2&.terraform1.stacks.StackChangeProgressH\x00R\bprogress\x12~\n" +
-	"$component_instance_policy_evaluation\x18\x04 \x01(\v2+.terraform1.stacks.PolicyEvaluationResponseH\x00R!componentInstancePolicyEvaluationB\a\n" +
+	"\bprogress\x18\x03 \x01(\v2&.terraform1.stacks.StackChangeProgressH\x00R\bprogress\x12\x87\x01\n" +
+	"$component_instance_policy_evaluation\x18\x04 \x01(\v24.terraform1.stacks.ComponentInstancePolicyEvaluationH\x00R!componentInstancePolicyEvaluation\x12\x84\x01\n" +
+	"#provider_instance_policy_evaluation\x18\x05 \x01(\v23.terraform1.stacks.ProviderInstancePolicyEvaluationH\x00R providerInstancePolicyEvaluationB\a\n" +
 	"\x05event\"\xa6\x05\n" +
 	"\x12OpenStackInspector\x1a\x93\x04\n" +
 	"\aRequest\x12.\n" +
@@ -8313,7 +8472,10 @@ const file_stacks_proto_rawDesc = "" +
 	"\x12element_key_string\x18\x02 \x01(\tH\x00R\x10elementKeyString\x12(\n" +
 	"\x0felement_key_int\x18\x03 \x01(\x03H\x00R\relementKeyIntB\n" +
 	"\n" +
-	"\bselector\"}\n" +
+	"\bselector\"x\n" +
+	"\x1bProviderInstanceInStackAddr\x12#\n" +
+	"\rprovider_addr\x18\x01 \x01(\tR\fproviderAddr\x124\n" +
+	"\x16provider_instance_addr\x18\x02 \x01(\tR\x14providerInstanceAddr\"}\n" +
 	"\x1cComponentInstanceInStackAddr\x12%\n" +
 	"\x0ecomponent_addr\x18\x01 \x01(\tR\rcomponentAddr\x126\n" +
 	"\x17component_instance_addr\x18\x02 \x01(\tR\x15componentInstanceAddr\"\xa4\x01\n" +
@@ -8597,9 +8759,14 @@ const file_stacks_proto_rawDesc = "" +
 	"\x0ecomponent_addr\x18\x01 \x01(\tR\rcomponentAddr\x126\n" +
 	"\x17component_instance_addr\x18\x02 \x01(\tR\x15componentInstanceAddr\x124\n" +
 	"\x16resource_instance_addr\x18\x03 \x01(\tR\x14resourceInstanceAddr\x12L\n" +
-	"\x11resource_identity\x18\x04 \x01(\v2\x1f.terraform1.stacks.DynamicValueR\x10resourceIdentity\"\x96\x02\n" +
-	"\x18PolicyEvaluationResponse\x12C\n" +
+	"\x11resource_identity\x18\x04 \x01(\v2\x1f.terraform1.stacks.DynamicValueR\x10resourceIdentity\"\x9f\x02\n" +
+	"!ComponentInstancePolicyEvaluation\x12C\n" +
 	"\x04addr\x18\x01 \x01(\v2/.terraform1.stacks.ComponentInstanceInStackAddrR\x04addr\x129\n" +
+	"\aresults\x18\x02 \x03(\v2\x1f.terraform1.stacks.PolicyResultR\aresults\x123\n" +
+	"\x05infos\x18\x03 \x03(\v2\x1d.terraform1.stacks.PolicyInfoR\x05infos\x12E\n" +
+	"\vdiagnostics\x18\x04 \x03(\v2#.terraform1.stacks.PolicyDiagnosticR\vdiagnostics\"\x9d\x02\n" +
+	" ProviderInstancePolicyEvaluation\x12B\n" +
+	"\x04addr\x18\x01 \x01(\v2..terraform1.stacks.ProviderInstanceInStackAddrR\x04addr\x129\n" +
 	"\aresults\x18\x02 \x03(\v2\x1f.terraform1.stacks.PolicyResultR\aresults\x123\n" +
 	"\x05infos\x18\x03 \x03(\v2\x1d.terraform1.stacks.PolicyInfoR\x05infos\x12E\n" +
 	"\vdiagnostics\x18\x04 \x03(\v2#.terraform1.stacks.PolicyDiagnosticR\vdiagnostics\"\xc8\x01\n" +
@@ -8702,7 +8869,7 @@ func file_stacks_proto_rawDescGZIP() []byte {
 }
 
 var file_stacks_proto_enumTypes = make([]protoimpl.EnumInfo, 12)
-var file_stacks_proto_msgTypes = make([]protoimpl.MessageInfo, 126)
+var file_stacks_proto_msgTypes = make([]protoimpl.MessageInfo, 128)
 var file_stacks_proto_goTypes = []any{
 	(ResourceMode)(0),   // 0: terraform1.stacks.ResourceMode
 	(PlanMode)(0),       // 1: terraform1.stacks.PlanMode
@@ -8735,325 +8902,333 @@ var file_stacks_proto_goTypes = []any{
 	(*DynamicValueChange)(nil),                              // 28: terraform1.stacks.DynamicValueChange
 	(*DynamicValueWithSource)(nil),                          // 29: terraform1.stacks.DynamicValueWithSource
 	(*AttributePath)(nil),                                   // 30: terraform1.stacks.AttributePath
-	(*ComponentInstanceInStackAddr)(nil),                    // 31: terraform1.stacks.ComponentInstanceInStackAddr
-	(*ActionInvocationInstanceInStackAddr)(nil),             // 32: terraform1.stacks.ActionInvocationInstanceInStackAddr
-	(*ResourceInstanceInStackAddr)(nil),                     // 33: terraform1.stacks.ResourceInstanceInStackAddr
-	(*ResourceInstanceObjectInStackAddr)(nil),               // 34: terraform1.stacks.ResourceInstanceObjectInStackAddr
-	(*PlannedChange)(nil),                                   // 35: terraform1.stacks.PlannedChange
-	(*Deferred)(nil),                                        // 36: terraform1.stacks.Deferred
-	(*AppliedChange)(nil),                                   // 37: terraform1.stacks.AppliedChange
-	(*StackChangeProgress)(nil),                             // 38: terraform1.stacks.StackChangeProgress
-	(*ListResourceIdentities)(nil),                          // 39: terraform1.stacks.ListResourceIdentities
-	(*PolicyEvaluationResponse)(nil),                        // 40: terraform1.stacks.PolicyEvaluationResponse
-	(*PolicyMetaData)(nil),                                  // 41: terraform1.stacks.PolicyMetaData
-	(*PolicyResult)(nil),                                    // 42: terraform1.stacks.PolicyResult
-	(*PolicyInfo)(nil),                                      // 43: terraform1.stacks.PolicyInfo
-	(*PolicySnippet)(nil),                                   // 44: terraform1.stacks.PolicySnippet
-	(*PolicyDiagnostic)(nil),                                // 45: terraform1.stacks.PolicyDiagnostic
-	(*ExpressionValue)(nil),                                 // 46: terraform1.stacks.ExpressionValue
-	(*OpenTerraformState_Request)(nil),                      // 47: terraform1.stacks.OpenTerraformState.Request
-	(*OpenTerraformState_Response)(nil),                     // 48: terraform1.stacks.OpenTerraformState.Response
-	(*CloseTerraformState_Request)(nil),                     // 49: terraform1.stacks.CloseTerraformState.Request
-	(*CloseTerraformState_Response)(nil),                    // 50: terraform1.stacks.CloseTerraformState.Response
-	(*MigrateTerraformState_Request)(nil),                   // 51: terraform1.stacks.MigrateTerraformState.Request
-	(*MigrateTerraformState_Event)(nil),                     // 52: terraform1.stacks.MigrateTerraformState.Event
-	(*MigrateTerraformState_Request_Mapping)(nil),           // 53: terraform1.stacks.MigrateTerraformState.Request.Mapping
-	nil,                                      // 54: terraform1.stacks.MigrateTerraformState.Request.Mapping.ResourceAddressMapEntry
-	nil,                                      // 55: terraform1.stacks.MigrateTerraformState.Request.Mapping.ModuleAddressMapEntry
-	(*OpenStackConfiguration_Request)(nil),   // 56: terraform1.stacks.OpenStackConfiguration.Request
-	(*OpenStackConfiguration_Response)(nil),  // 57: terraform1.stacks.OpenStackConfiguration.Response
-	(*CloseStackConfiguration_Request)(nil),  // 58: terraform1.stacks.CloseStackConfiguration.Request
-	(*CloseStackConfiguration_Response)(nil), // 59: terraform1.stacks.CloseStackConfiguration.Response
-	(*ValidateStackConfiguration_Request)(nil),             // 60: terraform1.stacks.ValidateStackConfiguration.Request
-	(*ValidateStackConfiguration_Response)(nil),            // 61: terraform1.stacks.ValidateStackConfiguration.Response
-	(*FindStackConfigurationComponents_Request)(nil),       // 62: terraform1.stacks.FindStackConfigurationComponents.Request
-	(*FindStackConfigurationComponents_Response)(nil),      // 63: terraform1.stacks.FindStackConfigurationComponents.Response
-	(*FindStackConfigurationComponents_StackConfig)(nil),   // 64: terraform1.stacks.FindStackConfigurationComponents.StackConfig
-	(*FindStackConfigurationComponents_EmbeddedStack)(nil), // 65: terraform1.stacks.FindStackConfigurationComponents.EmbeddedStack
-	(*FindStackConfigurationComponents_Component)(nil),     // 66: terraform1.stacks.FindStackConfigurationComponents.Component
-	(*FindStackConfigurationComponents_Removed)(nil),       // 67: terraform1.stacks.FindStackConfigurationComponents.Removed
-	(*FindStackConfigurationComponents_InputVariable)(nil), // 68: terraform1.stacks.FindStackConfigurationComponents.InputVariable
-	(*FindStackConfigurationComponents_OutputValue)(nil),   // 69: terraform1.stacks.FindStackConfigurationComponents.OutputValue
-	nil, // 70: terraform1.stacks.FindStackConfigurationComponents.StackConfig.ComponentsEntry
-	nil, // 71: terraform1.stacks.FindStackConfigurationComponents.StackConfig.EmbeddedStacksEntry
-	nil, // 72: terraform1.stacks.FindStackConfigurationComponents.StackConfig.InputVariablesEntry
-	nil, // 73: terraform1.stacks.FindStackConfigurationComponents.StackConfig.OutputValuesEntry
-	nil, // 74: terraform1.stacks.FindStackConfigurationComponents.StackConfig.RemovedEntry
-	(*FindStackConfigurationComponents_Removed_Block)(nil), // 75: terraform1.stacks.FindStackConfigurationComponents.Removed.Block
-	(*OpenStackState_RequestItem)(nil),                     // 76: terraform1.stacks.OpenStackState.RequestItem
-	(*OpenStackState_Response)(nil),                        // 77: terraform1.stacks.OpenStackState.Response
-	(*CloseStackState_Request)(nil),                        // 78: terraform1.stacks.CloseStackState.Request
-	(*CloseStackState_Response)(nil),                       // 79: terraform1.stacks.CloseStackState.Response
-	(*PlanStackChanges_Request)(nil),                       // 80: terraform1.stacks.PlanStackChanges.Request
-	(*PlanStackChanges_Event)(nil),                         // 81: terraform1.stacks.PlanStackChanges.Event
-	nil,                                                    // 82: terraform1.stacks.PlanStackChanges.Request.PreviousStateEntry
-	nil,                                                    // 83: terraform1.stacks.PlanStackChanges.Request.InputValuesEntry
-	(*OpenStackPlan_RequestItem)(nil),                      // 84: terraform1.stacks.OpenStackPlan.RequestItem
-	(*OpenStackPlan_Response)(nil),                         // 85: terraform1.stacks.OpenStackPlan.Response
-	(*CloseStackPlan_Request)(nil),                         // 86: terraform1.stacks.CloseStackPlan.Request
-	(*CloseStackPlan_Response)(nil),                        // 87: terraform1.stacks.CloseStackPlan.Response
-	(*ApplyStackChanges_Request)(nil),                      // 88: terraform1.stacks.ApplyStackChanges.Request
-	(*ApplyStackChanges_Event)(nil),                        // 89: terraform1.stacks.ApplyStackChanges.Event
-	nil,                                                    // 90: terraform1.stacks.ApplyStackChanges.Request.InputValuesEntry
-	(*OpenStackInspector_Request)(nil),                     // 91: terraform1.stacks.OpenStackInspector.Request
-	(*OpenStackInspector_Response)(nil),                    // 92: terraform1.stacks.OpenStackInspector.Response
-	nil,                                                    // 93: terraform1.stacks.OpenStackInspector.Request.StateEntry
-	nil,                                                    // 94: terraform1.stacks.OpenStackInspector.Request.InputValuesEntry
-	(*InspectExpressionResult_Request)(nil),                // 95: terraform1.stacks.InspectExpressionResult.Request
-	(*InspectExpressionResult_Response)(nil),               // 96: terraform1.stacks.InspectExpressionResult.Response
-	(*AttributePath_Step)(nil),                             // 97: terraform1.stacks.AttributePath.Step
-	(*PlannedChange_ChangeDescription)(nil),                // 98: terraform1.stacks.PlannedChange.ChangeDescription
-	(*PlannedChange_ComponentInstance)(nil),                // 99: terraform1.stacks.PlannedChange.ComponentInstance
-	(*PlannedChange_ResourceInstance)(nil),                 // 100: terraform1.stacks.PlannedChange.ResourceInstance
-	(*PlannedChange_OutputValue)(nil),                      // 101: terraform1.stacks.PlannedChange.OutputValue
-	(*PlannedChange_ResourceInstanceDeferred)(nil),         // 102: terraform1.stacks.PlannedChange.ResourceInstanceDeferred
-	(*PlannedChange_InputVariable)(nil),                    // 103: terraform1.stacks.PlannedChange.InputVariable
-	(*PlannedChange_ActionInvocationInstance)(nil),         // 104: terraform1.stacks.PlannedChange.ActionInvocationInstance
-	(*PlannedChange_ActionInvocationDeferred)(nil),         // 105: terraform1.stacks.PlannedChange.ActionInvocationDeferred
-	(*PlannedChange_ResourceActionTrigger)(nil),            // 106: terraform1.stacks.PlannedChange.ResourceActionTrigger
-	(*PlannedChange_InvokeActionTrigger)(nil),              // 107: terraform1.stacks.PlannedChange.InvokeActionTrigger
-	nil, // 108: terraform1.stacks.PlannedChange.ComponentInstance.OutputValuesEntry
-	(*PlannedChange_ResourceInstance_Index)(nil),                       // 109: terraform1.stacks.PlannedChange.ResourceInstance.Index
-	(*PlannedChange_ResourceInstance_Moved)(nil),                       // 110: terraform1.stacks.PlannedChange.ResourceInstance.Moved
-	(*PlannedChange_ResourceInstance_Imported)(nil),                    // 111: terraform1.stacks.PlannedChange.ResourceInstance.Imported
-	(*AppliedChange_RawChange)(nil),                                    // 112: terraform1.stacks.AppliedChange.RawChange
-	(*AppliedChange_ChangeDescription)(nil),                            // 113: terraform1.stacks.AppliedChange.ChangeDescription
-	(*AppliedChange_ResourceInstance)(nil),                             // 114: terraform1.stacks.AppliedChange.ResourceInstance
-	(*AppliedChange_ComponentInstance)(nil),                            // 115: terraform1.stacks.AppliedChange.ComponentInstance
-	(*AppliedChange_OutputValue)(nil),                                  // 116: terraform1.stacks.AppliedChange.OutputValue
-	(*AppliedChange_InputVariable)(nil),                                // 117: terraform1.stacks.AppliedChange.InputVariable
-	(*AppliedChange_Nothing)(nil),                                      // 118: terraform1.stacks.AppliedChange.Nothing
-	nil,                                                                // 119: terraform1.stacks.AppliedChange.ComponentInstance.OutputValuesEntry
-	(*StackChangeProgress_ComponentInstanceStatus)(nil),                // 120: terraform1.stacks.StackChangeProgress.ComponentInstanceStatus
-	(*StackChangeProgress_ResourceInstanceStatus)(nil),                 // 121: terraform1.stacks.StackChangeProgress.ResourceInstanceStatus
-	(*StackChangeProgress_ResourceInstancePlannedChange)(nil),          // 122: terraform1.stacks.StackChangeProgress.ResourceInstancePlannedChange
-	(*StackChangeProgress_DeferredResourceInstancePlannedChange)(nil),  // 123: terraform1.stacks.StackChangeProgress.DeferredResourceInstancePlannedChange
-	(*StackChangeProgress_ActionInvocationPlanned)(nil),                // 124: terraform1.stacks.StackChangeProgress.ActionInvocationPlanned
-	(*StackChangeProgress_ActionInvocationStatus)(nil),                 // 125: terraform1.stacks.StackChangeProgress.ActionInvocationStatus
-	(*StackChangeProgress_ActionInvocationProgress)(nil),               // 126: terraform1.stacks.StackChangeProgress.ActionInvocationProgress
-	(*StackChangeProgress_ResourceActionTrigger)(nil),                  // 127: terraform1.stacks.StackChangeProgress.ResourceActionTrigger
-	(*StackChangeProgress_InvokeActionTrigger)(nil),                    // 128: terraform1.stacks.StackChangeProgress.InvokeActionTrigger
-	(*StackChangeProgress_ProvisionerStatus)(nil),                      // 129: terraform1.stacks.StackChangeProgress.ProvisionerStatus
-	(*StackChangeProgress_ProvisionerOutput)(nil),                      // 130: terraform1.stacks.StackChangeProgress.ProvisionerOutput
-	(*StackChangeProgress_ComponentInstanceChanges)(nil),               // 131: terraform1.stacks.StackChangeProgress.ComponentInstanceChanges
-	(*StackChangeProgress_ComponentInstances)(nil),                     // 132: terraform1.stacks.StackChangeProgress.ComponentInstances
-	(*StackChangeProgress_ResourceInstancePlannedChange_Moved)(nil),    // 133: terraform1.stacks.StackChangeProgress.ResourceInstancePlannedChange.Moved
-	(*StackChangeProgress_ResourceInstancePlannedChange_Imported)(nil), // 134: terraform1.stacks.StackChangeProgress.ResourceInstancePlannedChange.Imported
-	(*ListResourceIdentities_Request)(nil),                             // 135: terraform1.stacks.ListResourceIdentities.Request
-	(*ListResourceIdentities_Response)(nil),                            // 136: terraform1.stacks.ListResourceIdentities.Response
-	(*ListResourceIdentities_Resource)(nil),                            // 137: terraform1.stacks.ListResourceIdentities.Resource
-	(*terraform1.SourceRange)(nil),                                     // 138: terraform1.SourceRange
-	(*anypb.Any)(nil),                                                  // 139: google.protobuf.Any
-	(*terraform1.Diagnostic)(nil),                                      // 140: terraform1.Diagnostic
-	(*terraform1.SourceAddress)(nil),                                   // 141: terraform1.SourceAddress
+	(*ProviderInstanceInStackAddr)(nil),                     // 31: terraform1.stacks.ProviderInstanceInStackAddr
+	(*ComponentInstanceInStackAddr)(nil),                    // 32: terraform1.stacks.ComponentInstanceInStackAddr
+	(*ActionInvocationInstanceInStackAddr)(nil),             // 33: terraform1.stacks.ActionInvocationInstanceInStackAddr
+	(*ResourceInstanceInStackAddr)(nil),                     // 34: terraform1.stacks.ResourceInstanceInStackAddr
+	(*ResourceInstanceObjectInStackAddr)(nil),               // 35: terraform1.stacks.ResourceInstanceObjectInStackAddr
+	(*PlannedChange)(nil),                                   // 36: terraform1.stacks.PlannedChange
+	(*Deferred)(nil),                                        // 37: terraform1.stacks.Deferred
+	(*AppliedChange)(nil),                                   // 38: terraform1.stacks.AppliedChange
+	(*StackChangeProgress)(nil),                             // 39: terraform1.stacks.StackChangeProgress
+	(*ListResourceIdentities)(nil),                          // 40: terraform1.stacks.ListResourceIdentities
+	(*ComponentInstancePolicyEvaluation)(nil),               // 41: terraform1.stacks.ComponentInstancePolicyEvaluation
+	(*ProviderInstancePolicyEvaluation)(nil),                // 42: terraform1.stacks.ProviderInstancePolicyEvaluation
+	(*PolicyMetaData)(nil),                                  // 43: terraform1.stacks.PolicyMetaData
+	(*PolicyResult)(nil),                                    // 44: terraform1.stacks.PolicyResult
+	(*PolicyInfo)(nil),                                      // 45: terraform1.stacks.PolicyInfo
+	(*PolicySnippet)(nil),                                   // 46: terraform1.stacks.PolicySnippet
+	(*PolicyDiagnostic)(nil),                                // 47: terraform1.stacks.PolicyDiagnostic
+	(*ExpressionValue)(nil),                                 // 48: terraform1.stacks.ExpressionValue
+	(*OpenTerraformState_Request)(nil),                      // 49: terraform1.stacks.OpenTerraformState.Request
+	(*OpenTerraformState_Response)(nil),                     // 50: terraform1.stacks.OpenTerraformState.Response
+	(*CloseTerraformState_Request)(nil),                     // 51: terraform1.stacks.CloseTerraformState.Request
+	(*CloseTerraformState_Response)(nil),                    // 52: terraform1.stacks.CloseTerraformState.Response
+	(*MigrateTerraformState_Request)(nil),                   // 53: terraform1.stacks.MigrateTerraformState.Request
+	(*MigrateTerraformState_Event)(nil),                     // 54: terraform1.stacks.MigrateTerraformState.Event
+	(*MigrateTerraformState_Request_Mapping)(nil),           // 55: terraform1.stacks.MigrateTerraformState.Request.Mapping
+	nil,                                      // 56: terraform1.stacks.MigrateTerraformState.Request.Mapping.ResourceAddressMapEntry
+	nil,                                      // 57: terraform1.stacks.MigrateTerraformState.Request.Mapping.ModuleAddressMapEntry
+	(*OpenStackConfiguration_Request)(nil),   // 58: terraform1.stacks.OpenStackConfiguration.Request
+	(*OpenStackConfiguration_Response)(nil),  // 59: terraform1.stacks.OpenStackConfiguration.Response
+	(*CloseStackConfiguration_Request)(nil),  // 60: terraform1.stacks.CloseStackConfiguration.Request
+	(*CloseStackConfiguration_Response)(nil), // 61: terraform1.stacks.CloseStackConfiguration.Response
+	(*ValidateStackConfiguration_Request)(nil),             // 62: terraform1.stacks.ValidateStackConfiguration.Request
+	(*ValidateStackConfiguration_Response)(nil),            // 63: terraform1.stacks.ValidateStackConfiguration.Response
+	(*FindStackConfigurationComponents_Request)(nil),       // 64: terraform1.stacks.FindStackConfigurationComponents.Request
+	(*FindStackConfigurationComponents_Response)(nil),      // 65: terraform1.stacks.FindStackConfigurationComponents.Response
+	(*FindStackConfigurationComponents_StackConfig)(nil),   // 66: terraform1.stacks.FindStackConfigurationComponents.StackConfig
+	(*FindStackConfigurationComponents_EmbeddedStack)(nil), // 67: terraform1.stacks.FindStackConfigurationComponents.EmbeddedStack
+	(*FindStackConfigurationComponents_Component)(nil),     // 68: terraform1.stacks.FindStackConfigurationComponents.Component
+	(*FindStackConfigurationComponents_Removed)(nil),       // 69: terraform1.stacks.FindStackConfigurationComponents.Removed
+	(*FindStackConfigurationComponents_InputVariable)(nil), // 70: terraform1.stacks.FindStackConfigurationComponents.InputVariable
+	(*FindStackConfigurationComponents_OutputValue)(nil),   // 71: terraform1.stacks.FindStackConfigurationComponents.OutputValue
+	nil, // 72: terraform1.stacks.FindStackConfigurationComponents.StackConfig.ComponentsEntry
+	nil, // 73: terraform1.stacks.FindStackConfigurationComponents.StackConfig.EmbeddedStacksEntry
+	nil, // 74: terraform1.stacks.FindStackConfigurationComponents.StackConfig.InputVariablesEntry
+	nil, // 75: terraform1.stacks.FindStackConfigurationComponents.StackConfig.OutputValuesEntry
+	nil, // 76: terraform1.stacks.FindStackConfigurationComponents.StackConfig.RemovedEntry
+	(*FindStackConfigurationComponents_Removed_Block)(nil), // 77: terraform1.stacks.FindStackConfigurationComponents.Removed.Block
+	(*OpenStackState_RequestItem)(nil),                     // 78: terraform1.stacks.OpenStackState.RequestItem
+	(*OpenStackState_Response)(nil),                        // 79: terraform1.stacks.OpenStackState.Response
+	(*CloseStackState_Request)(nil),                        // 80: terraform1.stacks.CloseStackState.Request
+	(*CloseStackState_Response)(nil),                       // 81: terraform1.stacks.CloseStackState.Response
+	(*PlanStackChanges_Request)(nil),                       // 82: terraform1.stacks.PlanStackChanges.Request
+	(*PlanStackChanges_Event)(nil),                         // 83: terraform1.stacks.PlanStackChanges.Event
+	nil,                                                    // 84: terraform1.stacks.PlanStackChanges.Request.PreviousStateEntry
+	nil,                                                    // 85: terraform1.stacks.PlanStackChanges.Request.InputValuesEntry
+	(*OpenStackPlan_RequestItem)(nil),                      // 86: terraform1.stacks.OpenStackPlan.RequestItem
+	(*OpenStackPlan_Response)(nil),                         // 87: terraform1.stacks.OpenStackPlan.Response
+	(*CloseStackPlan_Request)(nil),                         // 88: terraform1.stacks.CloseStackPlan.Request
+	(*CloseStackPlan_Response)(nil),                        // 89: terraform1.stacks.CloseStackPlan.Response
+	(*ApplyStackChanges_Request)(nil),                      // 90: terraform1.stacks.ApplyStackChanges.Request
+	(*ApplyStackChanges_Event)(nil),                        // 91: terraform1.stacks.ApplyStackChanges.Event
+	nil,                                                    // 92: terraform1.stacks.ApplyStackChanges.Request.InputValuesEntry
+	(*OpenStackInspector_Request)(nil),                     // 93: terraform1.stacks.OpenStackInspector.Request
+	(*OpenStackInspector_Response)(nil),                    // 94: terraform1.stacks.OpenStackInspector.Response
+	nil,                                                    // 95: terraform1.stacks.OpenStackInspector.Request.StateEntry
+	nil,                                                    // 96: terraform1.stacks.OpenStackInspector.Request.InputValuesEntry
+	(*InspectExpressionResult_Request)(nil),                // 97: terraform1.stacks.InspectExpressionResult.Request
+	(*InspectExpressionResult_Response)(nil),               // 98: terraform1.stacks.InspectExpressionResult.Response
+	(*AttributePath_Step)(nil),                             // 99: terraform1.stacks.AttributePath.Step
+	(*PlannedChange_ChangeDescription)(nil),                // 100: terraform1.stacks.PlannedChange.ChangeDescription
+	(*PlannedChange_ComponentInstance)(nil),                // 101: terraform1.stacks.PlannedChange.ComponentInstance
+	(*PlannedChange_ResourceInstance)(nil),                 // 102: terraform1.stacks.PlannedChange.ResourceInstance
+	(*PlannedChange_OutputValue)(nil),                      // 103: terraform1.stacks.PlannedChange.OutputValue
+	(*PlannedChange_ResourceInstanceDeferred)(nil),         // 104: terraform1.stacks.PlannedChange.ResourceInstanceDeferred
+	(*PlannedChange_InputVariable)(nil),                    // 105: terraform1.stacks.PlannedChange.InputVariable
+	(*PlannedChange_ActionInvocationInstance)(nil),         // 106: terraform1.stacks.PlannedChange.ActionInvocationInstance
+	(*PlannedChange_ActionInvocationDeferred)(nil),         // 107: terraform1.stacks.PlannedChange.ActionInvocationDeferred
+	(*PlannedChange_ResourceActionTrigger)(nil),            // 108: terraform1.stacks.PlannedChange.ResourceActionTrigger
+	(*PlannedChange_InvokeActionTrigger)(nil),              // 109: terraform1.stacks.PlannedChange.InvokeActionTrigger
+	nil, // 110: terraform1.stacks.PlannedChange.ComponentInstance.OutputValuesEntry
+	(*PlannedChange_ResourceInstance_Index)(nil),                       // 111: terraform1.stacks.PlannedChange.ResourceInstance.Index
+	(*PlannedChange_ResourceInstance_Moved)(nil),                       // 112: terraform1.stacks.PlannedChange.ResourceInstance.Moved
+	(*PlannedChange_ResourceInstance_Imported)(nil),                    // 113: terraform1.stacks.PlannedChange.ResourceInstance.Imported
+	(*AppliedChange_RawChange)(nil),                                    // 114: terraform1.stacks.AppliedChange.RawChange
+	(*AppliedChange_ChangeDescription)(nil),                            // 115: terraform1.stacks.AppliedChange.ChangeDescription
+	(*AppliedChange_ResourceInstance)(nil),                             // 116: terraform1.stacks.AppliedChange.ResourceInstance
+	(*AppliedChange_ComponentInstance)(nil),                            // 117: terraform1.stacks.AppliedChange.ComponentInstance
+	(*AppliedChange_OutputValue)(nil),                                  // 118: terraform1.stacks.AppliedChange.OutputValue
+	(*AppliedChange_InputVariable)(nil),                                // 119: terraform1.stacks.AppliedChange.InputVariable
+	(*AppliedChange_Nothing)(nil),                                      // 120: terraform1.stacks.AppliedChange.Nothing
+	nil,                                                                // 121: terraform1.stacks.AppliedChange.ComponentInstance.OutputValuesEntry
+	(*StackChangeProgress_ComponentInstanceStatus)(nil),                // 122: terraform1.stacks.StackChangeProgress.ComponentInstanceStatus
+	(*StackChangeProgress_ResourceInstanceStatus)(nil),                 // 123: terraform1.stacks.StackChangeProgress.ResourceInstanceStatus
+	(*StackChangeProgress_ResourceInstancePlannedChange)(nil),          // 124: terraform1.stacks.StackChangeProgress.ResourceInstancePlannedChange
+	(*StackChangeProgress_DeferredResourceInstancePlannedChange)(nil),  // 125: terraform1.stacks.StackChangeProgress.DeferredResourceInstancePlannedChange
+	(*StackChangeProgress_ActionInvocationPlanned)(nil),                // 126: terraform1.stacks.StackChangeProgress.ActionInvocationPlanned
+	(*StackChangeProgress_ActionInvocationStatus)(nil),                 // 127: terraform1.stacks.StackChangeProgress.ActionInvocationStatus
+	(*StackChangeProgress_ActionInvocationProgress)(nil),               // 128: terraform1.stacks.StackChangeProgress.ActionInvocationProgress
+	(*StackChangeProgress_ResourceActionTrigger)(nil),                  // 129: terraform1.stacks.StackChangeProgress.ResourceActionTrigger
+	(*StackChangeProgress_InvokeActionTrigger)(nil),                    // 130: terraform1.stacks.StackChangeProgress.InvokeActionTrigger
+	(*StackChangeProgress_ProvisionerStatus)(nil),                      // 131: terraform1.stacks.StackChangeProgress.ProvisionerStatus
+	(*StackChangeProgress_ProvisionerOutput)(nil),                      // 132: terraform1.stacks.StackChangeProgress.ProvisionerOutput
+	(*StackChangeProgress_ComponentInstanceChanges)(nil),               // 133: terraform1.stacks.StackChangeProgress.ComponentInstanceChanges
+	(*StackChangeProgress_ComponentInstances)(nil),                     // 134: terraform1.stacks.StackChangeProgress.ComponentInstances
+	(*StackChangeProgress_ResourceInstancePlannedChange_Moved)(nil),    // 135: terraform1.stacks.StackChangeProgress.ResourceInstancePlannedChange.Moved
+	(*StackChangeProgress_ResourceInstancePlannedChange_Imported)(nil), // 136: terraform1.stacks.StackChangeProgress.ResourceInstancePlannedChange.Imported
+	(*ListResourceIdentities_Request)(nil),                             // 137: terraform1.stacks.ListResourceIdentities.Request
+	(*ListResourceIdentities_Response)(nil),                            // 138: terraform1.stacks.ListResourceIdentities.Response
+	(*ListResourceIdentities_Resource)(nil),                            // 139: terraform1.stacks.ListResourceIdentities.Resource
+	(*terraform1.SourceRange)(nil),                                     // 140: terraform1.SourceRange
+	(*anypb.Any)(nil),                                                  // 141: google.protobuf.Any
+	(*terraform1.Diagnostic)(nil),                                      // 142: terraform1.Diagnostic
+	(*terraform1.SourceAddress)(nil),                                   // 143: terraform1.SourceAddress
 }
 var file_stacks_proto_depIdxs = []int32{
 	30,  // 0: terraform1.stacks.DynamicValue.sensitive:type_name -> terraform1.stacks.AttributePath
 	27,  // 1: terraform1.stacks.DynamicValueChange.old:type_name -> terraform1.stacks.DynamicValue
 	27,  // 2: terraform1.stacks.DynamicValueChange.new:type_name -> terraform1.stacks.DynamicValue
 	27,  // 3: terraform1.stacks.DynamicValueWithSource.value:type_name -> terraform1.stacks.DynamicValue
-	138, // 4: terraform1.stacks.DynamicValueWithSource.source_range:type_name -> terraform1.SourceRange
-	97,  // 5: terraform1.stacks.AttributePath.steps:type_name -> terraform1.stacks.AttributePath.Step
-	139, // 6: terraform1.stacks.PlannedChange.raw:type_name -> google.protobuf.Any
-	98,  // 7: terraform1.stacks.PlannedChange.descriptions:type_name -> terraform1.stacks.PlannedChange.ChangeDescription
+	140, // 4: terraform1.stacks.DynamicValueWithSource.source_range:type_name -> terraform1.SourceRange
+	99,  // 5: terraform1.stacks.AttributePath.steps:type_name -> terraform1.stacks.AttributePath.Step
+	141, // 6: terraform1.stacks.PlannedChange.raw:type_name -> google.protobuf.Any
+	100, // 7: terraform1.stacks.PlannedChange.descriptions:type_name -> terraform1.stacks.PlannedChange.ChangeDescription
 	6,   // 8: terraform1.stacks.Deferred.reason:type_name -> terraform1.stacks.Deferred.Reason
-	112, // 9: terraform1.stacks.AppliedChange.raw:type_name -> terraform1.stacks.AppliedChange.RawChange
-	113, // 10: terraform1.stacks.AppliedChange.descriptions:type_name -> terraform1.stacks.AppliedChange.ChangeDescription
-	120, // 11: terraform1.stacks.StackChangeProgress.component_instance_status:type_name -> terraform1.stacks.StackChangeProgress.ComponentInstanceStatus
-	121, // 12: terraform1.stacks.StackChangeProgress.resource_instance_status:type_name -> terraform1.stacks.StackChangeProgress.ResourceInstanceStatus
-	122, // 13: terraform1.stacks.StackChangeProgress.resource_instance_planned_change:type_name -> terraform1.stacks.StackChangeProgress.ResourceInstancePlannedChange
-	129, // 14: terraform1.stacks.StackChangeProgress.provisioner_status:type_name -> terraform1.stacks.StackChangeProgress.ProvisionerStatus
-	130, // 15: terraform1.stacks.StackChangeProgress.provisioner_output:type_name -> terraform1.stacks.StackChangeProgress.ProvisionerOutput
-	131, // 16: terraform1.stacks.StackChangeProgress.component_instance_changes:type_name -> terraform1.stacks.StackChangeProgress.ComponentInstanceChanges
-	132, // 17: terraform1.stacks.StackChangeProgress.component_instances:type_name -> terraform1.stacks.StackChangeProgress.ComponentInstances
-	123, // 18: terraform1.stacks.StackChangeProgress.deferred_resource_instance_planned_change:type_name -> terraform1.stacks.StackChangeProgress.DeferredResourceInstancePlannedChange
-	124, // 19: terraform1.stacks.StackChangeProgress.action_invocation_planned:type_name -> terraform1.stacks.StackChangeProgress.ActionInvocationPlanned
-	125, // 20: terraform1.stacks.StackChangeProgress.action_invocation_status:type_name -> terraform1.stacks.StackChangeProgress.ActionInvocationStatus
-	126, // 21: terraform1.stacks.StackChangeProgress.action_invocation_progress:type_name -> terraform1.stacks.StackChangeProgress.ActionInvocationProgress
-	31,  // 22: terraform1.stacks.PolicyEvaluationResponse.addr:type_name -> terraform1.stacks.ComponentInstanceInStackAddr
-	42,  // 23: terraform1.stacks.PolicyEvaluationResponse.results:type_name -> terraform1.stacks.PolicyResult
-	43,  // 24: terraform1.stacks.PolicyEvaluationResponse.infos:type_name -> terraform1.stacks.PolicyInfo
-	45,  // 25: terraform1.stacks.PolicyEvaluationResponse.diagnostics:type_name -> terraform1.stacks.PolicyDiagnostic
-	41,  // 26: terraform1.stacks.PolicyResult.policy_metadata:type_name -> terraform1.stacks.PolicyMetaData
-	3,   // 27: terraform1.stacks.PolicyResult.result:type_name -> terraform1.stacks.EvaluateResult
-	41,  // 28: terraform1.stacks.PolicyInfo.policy_metadata:type_name -> terraform1.stacks.PolicyMetaData
-	138, // 29: terraform1.stacks.PolicyInfo.policy_range:type_name -> terraform1.SourceRange
-	44,  // 30: terraform1.stacks.PolicyInfo.policy_snippet:type_name -> terraform1.stacks.PolicySnippet
-	3,   // 31: terraform1.stacks.PolicyInfo.result:type_name -> terraform1.stacks.EvaluateResult
-	41,  // 32: terraform1.stacks.PolicyDiagnostic.policy_metadata:type_name -> terraform1.stacks.PolicyMetaData
-	3,   // 33: terraform1.stacks.PolicyDiagnostic.result:type_name -> terraform1.stacks.EvaluateResult
-	140, // 34: terraform1.stacks.PolicyDiagnostic.diagnostic:type_name -> terraform1.Diagnostic
-	44,  // 35: terraform1.stacks.PolicyDiagnostic.policy_snippet:type_name -> terraform1.stacks.PolicySnippet
-	138, // 36: terraform1.stacks.PolicyDiagnostic.policy_range:type_name -> terraform1.SourceRange
-	46,  // 37: terraform1.stacks.PolicyDiagnostic.expression_values:type_name -> terraform1.stacks.ExpressionValue
-	30,  // 38: terraform1.stacks.ExpressionValue.traversal:type_name -> terraform1.stacks.AttributePath
-	140, // 39: terraform1.stacks.OpenTerraformState.Response.diagnostics:type_name -> terraform1.Diagnostic
-	53,  // 40: terraform1.stacks.MigrateTerraformState.Request.simple:type_name -> terraform1.stacks.MigrateTerraformState.Request.Mapping
-	140, // 41: terraform1.stacks.MigrateTerraformState.Event.diagnostic:type_name -> terraform1.Diagnostic
-	37,  // 42: terraform1.stacks.MigrateTerraformState.Event.applied_change:type_name -> terraform1.stacks.AppliedChange
-	54,  // 43: terraform1.stacks.MigrateTerraformState.Request.Mapping.resource_address_map:type_name -> terraform1.stacks.MigrateTerraformState.Request.Mapping.ResourceAddressMapEntry
-	55,  // 44: terraform1.stacks.MigrateTerraformState.Request.Mapping.module_address_map:type_name -> terraform1.stacks.MigrateTerraformState.Request.Mapping.ModuleAddressMapEntry
-	141, // 45: terraform1.stacks.OpenStackConfiguration.Request.source_address:type_name -> terraform1.SourceAddress
-	140, // 46: terraform1.stacks.OpenStackConfiguration.Response.diagnostics:type_name -> terraform1.Diagnostic
-	140, // 47: terraform1.stacks.ValidateStackConfiguration.Response.diagnostics:type_name -> terraform1.Diagnostic
-	64,  // 48: terraform1.stacks.FindStackConfigurationComponents.Response.config:type_name -> terraform1.stacks.FindStackConfigurationComponents.StackConfig
-	70,  // 49: terraform1.stacks.FindStackConfigurationComponents.StackConfig.components:type_name -> terraform1.stacks.FindStackConfigurationComponents.StackConfig.ComponentsEntry
-	71,  // 50: terraform1.stacks.FindStackConfigurationComponents.StackConfig.embedded_stacks:type_name -> terraform1.stacks.FindStackConfigurationComponents.StackConfig.EmbeddedStacksEntry
-	72,  // 51: terraform1.stacks.FindStackConfigurationComponents.StackConfig.input_variables:type_name -> terraform1.stacks.FindStackConfigurationComponents.StackConfig.InputVariablesEntry
-	73,  // 52: terraform1.stacks.FindStackConfigurationComponents.StackConfig.output_values:type_name -> terraform1.stacks.FindStackConfigurationComponents.StackConfig.OutputValuesEntry
-	74,  // 53: terraform1.stacks.FindStackConfigurationComponents.StackConfig.removed:type_name -> terraform1.stacks.FindStackConfigurationComponents.StackConfig.RemovedEntry
-	4,   // 54: terraform1.stacks.FindStackConfigurationComponents.EmbeddedStack.instances:type_name -> terraform1.stacks.FindStackConfigurationComponents.Instances
-	64,  // 55: terraform1.stacks.FindStackConfigurationComponents.EmbeddedStack.config:type_name -> terraform1.stacks.FindStackConfigurationComponents.StackConfig
-	4,   // 56: terraform1.stacks.FindStackConfigurationComponents.Component.instances:type_name -> terraform1.stacks.FindStackConfigurationComponents.Instances
-	4,   // 57: terraform1.stacks.FindStackConfigurationComponents.Removed.instances:type_name -> terraform1.stacks.FindStackConfigurationComponents.Instances
-	75,  // 58: terraform1.stacks.FindStackConfigurationComponents.Removed.blocks:type_name -> terraform1.stacks.FindStackConfigurationComponents.Removed.Block
-	66,  // 59: terraform1.stacks.FindStackConfigurationComponents.StackConfig.ComponentsEntry.value:type_name -> terraform1.stacks.FindStackConfigurationComponents.Component
-	65,  // 60: terraform1.stacks.FindStackConfigurationComponents.StackConfig.EmbeddedStacksEntry.value:type_name -> terraform1.stacks.FindStackConfigurationComponents.EmbeddedStack
-	68,  // 61: terraform1.stacks.FindStackConfigurationComponents.StackConfig.InputVariablesEntry.value:type_name -> terraform1.stacks.FindStackConfigurationComponents.InputVariable
-	69,  // 62: terraform1.stacks.FindStackConfigurationComponents.StackConfig.OutputValuesEntry.value:type_name -> terraform1.stacks.FindStackConfigurationComponents.OutputValue
-	67,  // 63: terraform1.stacks.FindStackConfigurationComponents.StackConfig.RemovedEntry.value:type_name -> terraform1.stacks.FindStackConfigurationComponents.Removed
-	4,   // 64: terraform1.stacks.FindStackConfigurationComponents.Removed.Block.instances:type_name -> terraform1.stacks.FindStackConfigurationComponents.Instances
-	112, // 65: terraform1.stacks.OpenStackState.RequestItem.raw:type_name -> terraform1.stacks.AppliedChange.RawChange
-	1,   // 66: terraform1.stacks.PlanStackChanges.Request.plan_mode:type_name -> terraform1.stacks.PlanMode
-	82,  // 67: terraform1.stacks.PlanStackChanges.Request.previous_state:type_name -> terraform1.stacks.PlanStackChanges.Request.PreviousStateEntry
-	83,  // 68: terraform1.stacks.PlanStackChanges.Request.input_values:type_name -> terraform1.stacks.PlanStackChanges.Request.InputValuesEntry
-	35,  // 69: terraform1.stacks.PlanStackChanges.Event.planned_change:type_name -> terraform1.stacks.PlannedChange
-	140, // 70: terraform1.stacks.PlanStackChanges.Event.diagnostic:type_name -> terraform1.Diagnostic
-	38,  // 71: terraform1.stacks.PlanStackChanges.Event.progress:type_name -> terraform1.stacks.StackChangeProgress
-	40,  // 72: terraform1.stacks.PlanStackChanges.Event.component_instance_policy_evaluation:type_name -> terraform1.stacks.PolicyEvaluationResponse
-	139, // 73: terraform1.stacks.PlanStackChanges.Request.PreviousStateEntry.value:type_name -> google.protobuf.Any
-	29,  // 74: terraform1.stacks.PlanStackChanges.Request.InputValuesEntry.value:type_name -> terraform1.stacks.DynamicValueWithSource
-	139, // 75: terraform1.stacks.OpenStackPlan.RequestItem.raw:type_name -> google.protobuf.Any
-	139, // 76: terraform1.stacks.ApplyStackChanges.Request.planned_changes:type_name -> google.protobuf.Any
-	90,  // 77: terraform1.stacks.ApplyStackChanges.Request.input_values:type_name -> terraform1.stacks.ApplyStackChanges.Request.InputValuesEntry
-	37,  // 78: terraform1.stacks.ApplyStackChanges.Event.applied_change:type_name -> terraform1.stacks.AppliedChange
-	140, // 79: terraform1.stacks.ApplyStackChanges.Event.diagnostic:type_name -> terraform1.Diagnostic
-	38,  // 80: terraform1.stacks.ApplyStackChanges.Event.progress:type_name -> terraform1.stacks.StackChangeProgress
-	40,  // 81: terraform1.stacks.ApplyStackChanges.Event.component_instance_policy_evaluation:type_name -> terraform1.stacks.PolicyEvaluationResponse
-	29,  // 82: terraform1.stacks.ApplyStackChanges.Request.InputValuesEntry.value:type_name -> terraform1.stacks.DynamicValueWithSource
-	93,  // 83: terraform1.stacks.OpenStackInspector.Request.state:type_name -> terraform1.stacks.OpenStackInspector.Request.StateEntry
-	94,  // 84: terraform1.stacks.OpenStackInspector.Request.input_values:type_name -> terraform1.stacks.OpenStackInspector.Request.InputValuesEntry
-	140, // 85: terraform1.stacks.OpenStackInspector.Response.diagnostics:type_name -> terraform1.Diagnostic
-	139, // 86: terraform1.stacks.OpenStackInspector.Request.StateEntry.value:type_name -> google.protobuf.Any
-	29,  // 87: terraform1.stacks.OpenStackInspector.Request.InputValuesEntry.value:type_name -> terraform1.stacks.DynamicValueWithSource
-	27,  // 88: terraform1.stacks.InspectExpressionResult.Response.result:type_name -> terraform1.stacks.DynamicValue
-	140, // 89: terraform1.stacks.InspectExpressionResult.Response.diagnostics:type_name -> terraform1.Diagnostic
-	99,  // 90: terraform1.stacks.PlannedChange.ChangeDescription.component_instance_planned:type_name -> terraform1.stacks.PlannedChange.ComponentInstance
-	100, // 91: terraform1.stacks.PlannedChange.ChangeDescription.resource_instance_planned:type_name -> terraform1.stacks.PlannedChange.ResourceInstance
-	101, // 92: terraform1.stacks.PlannedChange.ChangeDescription.output_value_planned:type_name -> terraform1.stacks.PlannedChange.OutputValue
-	102, // 93: terraform1.stacks.PlannedChange.ChangeDescription.resource_instance_deferred:type_name -> terraform1.stacks.PlannedChange.ResourceInstanceDeferred
-	103, // 94: terraform1.stacks.PlannedChange.ChangeDescription.input_variable_planned:type_name -> terraform1.stacks.PlannedChange.InputVariable
-	104, // 95: terraform1.stacks.PlannedChange.ChangeDescription.action_invocation_planned:type_name -> terraform1.stacks.PlannedChange.ActionInvocationInstance
-	105, // 96: terraform1.stacks.PlannedChange.ChangeDescription.action_invocation_deferred:type_name -> terraform1.stacks.PlannedChange.ActionInvocationDeferred
-	31,  // 97: terraform1.stacks.PlannedChange.ComponentInstance.addr:type_name -> terraform1.stacks.ComponentInstanceInStackAddr
-	2,   // 98: terraform1.stacks.PlannedChange.ComponentInstance.actions:type_name -> terraform1.stacks.ChangeType
-	108, // 99: terraform1.stacks.PlannedChange.ComponentInstance.output_values:type_name -> terraform1.stacks.PlannedChange.ComponentInstance.OutputValuesEntry
-	34,  // 100: terraform1.stacks.PlannedChange.ResourceInstance.addr:type_name -> terraform1.stacks.ResourceInstanceObjectInStackAddr
-	2,   // 101: terraform1.stacks.PlannedChange.ResourceInstance.actions:type_name -> terraform1.stacks.ChangeType
-	28,  // 102: terraform1.stacks.PlannedChange.ResourceInstance.values:type_name -> terraform1.stacks.DynamicValueChange
-	110, // 103: terraform1.stacks.PlannedChange.ResourceInstance.moved:type_name -> terraform1.stacks.PlannedChange.ResourceInstance.Moved
-	111, // 104: terraform1.stacks.PlannedChange.ResourceInstance.imported:type_name -> terraform1.stacks.PlannedChange.ResourceInstance.Imported
-	0,   // 105: terraform1.stacks.PlannedChange.ResourceInstance.resource_mode:type_name -> terraform1.stacks.ResourceMode
-	27,  // 106: terraform1.stacks.PlannedChange.ResourceInstance.previous_run_value:type_name -> terraform1.stacks.DynamicValue
-	30,  // 107: terraform1.stacks.PlannedChange.ResourceInstance.replace_paths:type_name -> terraform1.stacks.AttributePath
-	109, // 108: terraform1.stacks.PlannedChange.ResourceInstance.index:type_name -> terraform1.stacks.PlannedChange.ResourceInstance.Index
-	2,   // 109: terraform1.stacks.PlannedChange.OutputValue.actions:type_name -> terraform1.stacks.ChangeType
-	28,  // 110: terraform1.stacks.PlannedChange.OutputValue.values:type_name -> terraform1.stacks.DynamicValueChange
-	100, // 111: terraform1.stacks.PlannedChange.ResourceInstanceDeferred.resource_instance:type_name -> terraform1.stacks.PlannedChange.ResourceInstance
-	36,  // 112: terraform1.stacks.PlannedChange.ResourceInstanceDeferred.deferred:type_name -> terraform1.stacks.Deferred
-	2,   // 113: terraform1.stacks.PlannedChange.InputVariable.actions:type_name -> terraform1.stacks.ChangeType
-	28,  // 114: terraform1.stacks.PlannedChange.InputVariable.values:type_name -> terraform1.stacks.DynamicValueChange
-	32,  // 115: terraform1.stacks.PlannedChange.ActionInvocationInstance.addr:type_name -> terraform1.stacks.ActionInvocationInstanceInStackAddr
-	27,  // 116: terraform1.stacks.PlannedChange.ActionInvocationInstance.config_value:type_name -> terraform1.stacks.DynamicValue
-	106, // 117: terraform1.stacks.PlannedChange.ActionInvocationInstance.resource_action_trigger:type_name -> terraform1.stacks.PlannedChange.ResourceActionTrigger
-	107, // 118: terraform1.stacks.PlannedChange.ActionInvocationInstance.invoke_action_trigger:type_name -> terraform1.stacks.PlannedChange.InvokeActionTrigger
-	36,  // 119: terraform1.stacks.PlannedChange.ActionInvocationDeferred.deferred:type_name -> terraform1.stacks.Deferred
-	104, // 120: terraform1.stacks.PlannedChange.ActionInvocationDeferred.action_invocation:type_name -> terraform1.stacks.PlannedChange.ActionInvocationInstance
-	33,  // 121: terraform1.stacks.PlannedChange.ResourceActionTrigger.triggering_resource_address:type_name -> terraform1.stacks.ResourceInstanceInStackAddr
-	5,   // 122: terraform1.stacks.PlannedChange.ResourceActionTrigger.trigger_event:type_name -> terraform1.stacks.PlannedChange.ActionTriggerEvent
-	27,  // 123: terraform1.stacks.PlannedChange.ComponentInstance.OutputValuesEntry.value:type_name -> terraform1.stacks.DynamicValue
-	27,  // 124: terraform1.stacks.PlannedChange.ResourceInstance.Index.value:type_name -> terraform1.stacks.DynamicValue
-	33,  // 125: terraform1.stacks.PlannedChange.ResourceInstance.Moved.prev_addr:type_name -> terraform1.stacks.ResourceInstanceInStackAddr
-	139, // 126: terraform1.stacks.AppliedChange.RawChange.value:type_name -> google.protobuf.Any
-	118, // 127: terraform1.stacks.AppliedChange.ChangeDescription.deleted:type_name -> terraform1.stacks.AppliedChange.Nothing
-	118, // 128: terraform1.stacks.AppliedChange.ChangeDescription.moved:type_name -> terraform1.stacks.AppliedChange.Nothing
-	114, // 129: terraform1.stacks.AppliedChange.ChangeDescription.resource_instance:type_name -> terraform1.stacks.AppliedChange.ResourceInstance
-	116, // 130: terraform1.stacks.AppliedChange.ChangeDescription.output_value:type_name -> terraform1.stacks.AppliedChange.OutputValue
-	117, // 131: terraform1.stacks.AppliedChange.ChangeDescription.input_variable:type_name -> terraform1.stacks.AppliedChange.InputVariable
-	115, // 132: terraform1.stacks.AppliedChange.ChangeDescription.component_instance:type_name -> terraform1.stacks.AppliedChange.ComponentInstance
-	34,  // 133: terraform1.stacks.AppliedChange.ResourceInstance.addr:type_name -> terraform1.stacks.ResourceInstanceObjectInStackAddr
-	27,  // 134: terraform1.stacks.AppliedChange.ResourceInstance.new_value:type_name -> terraform1.stacks.DynamicValue
-	0,   // 135: terraform1.stacks.AppliedChange.ResourceInstance.resource_mode:type_name -> terraform1.stacks.ResourceMode
-	119, // 136: terraform1.stacks.AppliedChange.ComponentInstance.output_values:type_name -> terraform1.stacks.AppliedChange.ComponentInstance.OutputValuesEntry
-	27,  // 137: terraform1.stacks.AppliedChange.OutputValue.new_value:type_name -> terraform1.stacks.DynamicValue
-	27,  // 138: terraform1.stacks.AppliedChange.InputVariable.new_value:type_name -> terraform1.stacks.DynamicValue
-	27,  // 139: terraform1.stacks.AppliedChange.ComponentInstance.OutputValuesEntry.value:type_name -> terraform1.stacks.DynamicValue
-	31,  // 140: terraform1.stacks.StackChangeProgress.ComponentInstanceStatus.addr:type_name -> terraform1.stacks.ComponentInstanceInStackAddr
-	8,   // 141: terraform1.stacks.StackChangeProgress.ComponentInstanceStatus.status:type_name -> terraform1.stacks.StackChangeProgress.ComponentInstanceStatus.Status
-	34,  // 142: terraform1.stacks.StackChangeProgress.ResourceInstanceStatus.addr:type_name -> terraform1.stacks.ResourceInstanceObjectInStackAddr
-	9,   // 143: terraform1.stacks.StackChangeProgress.ResourceInstanceStatus.status:type_name -> terraform1.stacks.StackChangeProgress.ResourceInstanceStatus.Status
-	34,  // 144: terraform1.stacks.StackChangeProgress.ResourceInstancePlannedChange.addr:type_name -> terraform1.stacks.ResourceInstanceObjectInStackAddr
-	2,   // 145: terraform1.stacks.StackChangeProgress.ResourceInstancePlannedChange.actions:type_name -> terraform1.stacks.ChangeType
-	133, // 146: terraform1.stacks.StackChangeProgress.ResourceInstancePlannedChange.moved:type_name -> terraform1.stacks.StackChangeProgress.ResourceInstancePlannedChange.Moved
-	134, // 147: terraform1.stacks.StackChangeProgress.ResourceInstancePlannedChange.imported:type_name -> terraform1.stacks.StackChangeProgress.ResourceInstancePlannedChange.Imported
-	36,  // 148: terraform1.stacks.StackChangeProgress.DeferredResourceInstancePlannedChange.deferred:type_name -> terraform1.stacks.Deferred
-	122, // 149: terraform1.stacks.StackChangeProgress.DeferredResourceInstancePlannedChange.change:type_name -> terraform1.stacks.StackChangeProgress.ResourceInstancePlannedChange
-	32,  // 150: terraform1.stacks.StackChangeProgress.ActionInvocationPlanned.addr:type_name -> terraform1.stacks.ActionInvocationInstanceInStackAddr
-	127, // 151: terraform1.stacks.StackChangeProgress.ActionInvocationPlanned.resource_action_trigger:type_name -> terraform1.stacks.StackChangeProgress.ResourceActionTrigger
-	128, // 152: terraform1.stacks.StackChangeProgress.ActionInvocationPlanned.invoke_action_trigger:type_name -> terraform1.stacks.StackChangeProgress.InvokeActionTrigger
-	32,  // 153: terraform1.stacks.StackChangeProgress.ActionInvocationStatus.addr:type_name -> terraform1.stacks.ActionInvocationInstanceInStackAddr
-	10,  // 154: terraform1.stacks.StackChangeProgress.ActionInvocationStatus.status:type_name -> terraform1.stacks.StackChangeProgress.ActionInvocationStatus.Status
-	127, // 155: terraform1.stacks.StackChangeProgress.ActionInvocationStatus.resource_action_trigger:type_name -> terraform1.stacks.StackChangeProgress.ResourceActionTrigger
-	128, // 156: terraform1.stacks.StackChangeProgress.ActionInvocationStatus.invoke_action_trigger:type_name -> terraform1.stacks.StackChangeProgress.InvokeActionTrigger
-	32,  // 157: terraform1.stacks.StackChangeProgress.ActionInvocationProgress.addr:type_name -> terraform1.stacks.ActionInvocationInstanceInStackAddr
-	127, // 158: terraform1.stacks.StackChangeProgress.ActionInvocationProgress.resource_action_trigger:type_name -> terraform1.stacks.StackChangeProgress.ResourceActionTrigger
-	128, // 159: terraform1.stacks.StackChangeProgress.ActionInvocationProgress.invoke_action_trigger:type_name -> terraform1.stacks.StackChangeProgress.InvokeActionTrigger
-	33,  // 160: terraform1.stacks.StackChangeProgress.ResourceActionTrigger.triggering_resource_address:type_name -> terraform1.stacks.ResourceInstanceInStackAddr
-	7,   // 161: terraform1.stacks.StackChangeProgress.ResourceActionTrigger.trigger_event:type_name -> terraform1.stacks.StackChangeProgress.ActionTriggerEvent
-	34,  // 162: terraform1.stacks.StackChangeProgress.ProvisionerStatus.addr:type_name -> terraform1.stacks.ResourceInstanceObjectInStackAddr
-	129, // 163: terraform1.stacks.StackChangeProgress.ProvisionerStatus.status:type_name -> terraform1.stacks.StackChangeProgress.ProvisionerStatus
-	34,  // 164: terraform1.stacks.StackChangeProgress.ProvisionerOutput.addr:type_name -> terraform1.stacks.ResourceInstanceObjectInStackAddr
-	31,  // 165: terraform1.stacks.StackChangeProgress.ComponentInstanceChanges.addr:type_name -> terraform1.stacks.ComponentInstanceInStackAddr
-	33,  // 166: terraform1.stacks.StackChangeProgress.ResourceInstancePlannedChange.Moved.prev_addr:type_name -> terraform1.stacks.ResourceInstanceInStackAddr
-	137, // 167: terraform1.stacks.ListResourceIdentities.Response.resource:type_name -> terraform1.stacks.ListResourceIdentities.Resource
-	27,  // 168: terraform1.stacks.ListResourceIdentities.Resource.resource_identity:type_name -> terraform1.stacks.DynamicValue
-	56,  // 169: terraform1.stacks.Stacks.OpenStackConfiguration:input_type -> terraform1.stacks.OpenStackConfiguration.Request
-	58,  // 170: terraform1.stacks.Stacks.CloseStackConfiguration:input_type -> terraform1.stacks.CloseStackConfiguration.Request
-	60,  // 171: terraform1.stacks.Stacks.ValidateStackConfiguration:input_type -> terraform1.stacks.ValidateStackConfiguration.Request
-	62,  // 172: terraform1.stacks.Stacks.FindStackConfigurationComponents:input_type -> terraform1.stacks.FindStackConfigurationComponents.Request
-	76,  // 173: terraform1.stacks.Stacks.OpenState:input_type -> terraform1.stacks.OpenStackState.RequestItem
-	78,  // 174: terraform1.stacks.Stacks.CloseState:input_type -> terraform1.stacks.CloseStackState.Request
-	80,  // 175: terraform1.stacks.Stacks.PlanStackChanges:input_type -> terraform1.stacks.PlanStackChanges.Request
-	84,  // 176: terraform1.stacks.Stacks.OpenPlan:input_type -> terraform1.stacks.OpenStackPlan.RequestItem
-	86,  // 177: terraform1.stacks.Stacks.ClosePlan:input_type -> terraform1.stacks.CloseStackPlan.Request
-	88,  // 178: terraform1.stacks.Stacks.ApplyStackChanges:input_type -> terraform1.stacks.ApplyStackChanges.Request
-	91,  // 179: terraform1.stacks.Stacks.OpenStackInspector:input_type -> terraform1.stacks.OpenStackInspector.Request
-	95,  // 180: terraform1.stacks.Stacks.InspectExpressionResult:input_type -> terraform1.stacks.InspectExpressionResult.Request
-	47,  // 181: terraform1.stacks.Stacks.OpenTerraformState:input_type -> terraform1.stacks.OpenTerraformState.Request
-	49,  // 182: terraform1.stacks.Stacks.CloseTerraformState:input_type -> terraform1.stacks.CloseTerraformState.Request
-	51,  // 183: terraform1.stacks.Stacks.MigrateTerraformState:input_type -> terraform1.stacks.MigrateTerraformState.Request
-	135, // 184: terraform1.stacks.Stacks.ListResourceIdentities:input_type -> terraform1.stacks.ListResourceIdentities.Request
-	57,  // 185: terraform1.stacks.Stacks.OpenStackConfiguration:output_type -> terraform1.stacks.OpenStackConfiguration.Response
-	59,  // 186: terraform1.stacks.Stacks.CloseStackConfiguration:output_type -> terraform1.stacks.CloseStackConfiguration.Response
-	61,  // 187: terraform1.stacks.Stacks.ValidateStackConfiguration:output_type -> terraform1.stacks.ValidateStackConfiguration.Response
-	63,  // 188: terraform1.stacks.Stacks.FindStackConfigurationComponents:output_type -> terraform1.stacks.FindStackConfigurationComponents.Response
-	77,  // 189: terraform1.stacks.Stacks.OpenState:output_type -> terraform1.stacks.OpenStackState.Response
-	79,  // 190: terraform1.stacks.Stacks.CloseState:output_type -> terraform1.stacks.CloseStackState.Response
-	81,  // 191: terraform1.stacks.Stacks.PlanStackChanges:output_type -> terraform1.stacks.PlanStackChanges.Event
-	85,  // 192: terraform1.stacks.Stacks.OpenPlan:output_type -> terraform1.stacks.OpenStackPlan.Response
-	87,  // 193: terraform1.stacks.Stacks.ClosePlan:output_type -> terraform1.stacks.CloseStackPlan.Response
-	89,  // 194: terraform1.stacks.Stacks.ApplyStackChanges:output_type -> terraform1.stacks.ApplyStackChanges.Event
-	92,  // 195: terraform1.stacks.Stacks.OpenStackInspector:output_type -> terraform1.stacks.OpenStackInspector.Response
-	96,  // 196: terraform1.stacks.Stacks.InspectExpressionResult:output_type -> terraform1.stacks.InspectExpressionResult.Response
-	48,  // 197: terraform1.stacks.Stacks.OpenTerraformState:output_type -> terraform1.stacks.OpenTerraformState.Response
-	50,  // 198: terraform1.stacks.Stacks.CloseTerraformState:output_type -> terraform1.stacks.CloseTerraformState.Response
-	52,  // 199: terraform1.stacks.Stacks.MigrateTerraformState:output_type -> terraform1.stacks.MigrateTerraformState.Event
-	136, // 200: terraform1.stacks.Stacks.ListResourceIdentities:output_type -> terraform1.stacks.ListResourceIdentities.Response
-	185, // [185:201] is the sub-list for method output_type
-	169, // [169:185] is the sub-list for method input_type
-	169, // [169:169] is the sub-list for extension type_name
-	169, // [169:169] is the sub-list for extension extendee
-	0,   // [0:169] is the sub-list for field type_name
+	114, // 9: terraform1.stacks.AppliedChange.raw:type_name -> terraform1.stacks.AppliedChange.RawChange
+	115, // 10: terraform1.stacks.AppliedChange.descriptions:type_name -> terraform1.stacks.AppliedChange.ChangeDescription
+	122, // 11: terraform1.stacks.StackChangeProgress.component_instance_status:type_name -> terraform1.stacks.StackChangeProgress.ComponentInstanceStatus
+	123, // 12: terraform1.stacks.StackChangeProgress.resource_instance_status:type_name -> terraform1.stacks.StackChangeProgress.ResourceInstanceStatus
+	124, // 13: terraform1.stacks.StackChangeProgress.resource_instance_planned_change:type_name -> terraform1.stacks.StackChangeProgress.ResourceInstancePlannedChange
+	131, // 14: terraform1.stacks.StackChangeProgress.provisioner_status:type_name -> terraform1.stacks.StackChangeProgress.ProvisionerStatus
+	132, // 15: terraform1.stacks.StackChangeProgress.provisioner_output:type_name -> terraform1.stacks.StackChangeProgress.ProvisionerOutput
+	133, // 16: terraform1.stacks.StackChangeProgress.component_instance_changes:type_name -> terraform1.stacks.StackChangeProgress.ComponentInstanceChanges
+	134, // 17: terraform1.stacks.StackChangeProgress.component_instances:type_name -> terraform1.stacks.StackChangeProgress.ComponentInstances
+	125, // 18: terraform1.stacks.StackChangeProgress.deferred_resource_instance_planned_change:type_name -> terraform1.stacks.StackChangeProgress.DeferredResourceInstancePlannedChange
+	126, // 19: terraform1.stacks.StackChangeProgress.action_invocation_planned:type_name -> terraform1.stacks.StackChangeProgress.ActionInvocationPlanned
+	127, // 20: terraform1.stacks.StackChangeProgress.action_invocation_status:type_name -> terraform1.stacks.StackChangeProgress.ActionInvocationStatus
+	128, // 21: terraform1.stacks.StackChangeProgress.action_invocation_progress:type_name -> terraform1.stacks.StackChangeProgress.ActionInvocationProgress
+	32,  // 22: terraform1.stacks.ComponentInstancePolicyEvaluation.addr:type_name -> terraform1.stacks.ComponentInstanceInStackAddr
+	44,  // 23: terraform1.stacks.ComponentInstancePolicyEvaluation.results:type_name -> terraform1.stacks.PolicyResult
+	45,  // 24: terraform1.stacks.ComponentInstancePolicyEvaluation.infos:type_name -> terraform1.stacks.PolicyInfo
+	47,  // 25: terraform1.stacks.ComponentInstancePolicyEvaluation.diagnostics:type_name -> terraform1.stacks.PolicyDiagnostic
+	31,  // 26: terraform1.stacks.ProviderInstancePolicyEvaluation.addr:type_name -> terraform1.stacks.ProviderInstanceInStackAddr
+	44,  // 27: terraform1.stacks.ProviderInstancePolicyEvaluation.results:type_name -> terraform1.stacks.PolicyResult
+	45,  // 28: terraform1.stacks.ProviderInstancePolicyEvaluation.infos:type_name -> terraform1.stacks.PolicyInfo
+	47,  // 29: terraform1.stacks.ProviderInstancePolicyEvaluation.diagnostics:type_name -> terraform1.stacks.PolicyDiagnostic
+	43,  // 30: terraform1.stacks.PolicyResult.policy_metadata:type_name -> terraform1.stacks.PolicyMetaData
+	3,   // 31: terraform1.stacks.PolicyResult.result:type_name -> terraform1.stacks.EvaluateResult
+	43,  // 32: terraform1.stacks.PolicyInfo.policy_metadata:type_name -> terraform1.stacks.PolicyMetaData
+	140, // 33: terraform1.stacks.PolicyInfo.policy_range:type_name -> terraform1.SourceRange
+	46,  // 34: terraform1.stacks.PolicyInfo.policy_snippet:type_name -> terraform1.stacks.PolicySnippet
+	3,   // 35: terraform1.stacks.PolicyInfo.result:type_name -> terraform1.stacks.EvaluateResult
+	43,  // 36: terraform1.stacks.PolicyDiagnostic.policy_metadata:type_name -> terraform1.stacks.PolicyMetaData
+	3,   // 37: terraform1.stacks.PolicyDiagnostic.result:type_name -> terraform1.stacks.EvaluateResult
+	142, // 38: terraform1.stacks.PolicyDiagnostic.diagnostic:type_name -> terraform1.Diagnostic
+	46,  // 39: terraform1.stacks.PolicyDiagnostic.policy_snippet:type_name -> terraform1.stacks.PolicySnippet
+	140, // 40: terraform1.stacks.PolicyDiagnostic.policy_range:type_name -> terraform1.SourceRange
+	48,  // 41: terraform1.stacks.PolicyDiagnostic.expression_values:type_name -> terraform1.stacks.ExpressionValue
+	30,  // 42: terraform1.stacks.ExpressionValue.traversal:type_name -> terraform1.stacks.AttributePath
+	142, // 43: terraform1.stacks.OpenTerraformState.Response.diagnostics:type_name -> terraform1.Diagnostic
+	55,  // 44: terraform1.stacks.MigrateTerraformState.Request.simple:type_name -> terraform1.stacks.MigrateTerraformState.Request.Mapping
+	142, // 45: terraform1.stacks.MigrateTerraformState.Event.diagnostic:type_name -> terraform1.Diagnostic
+	38,  // 46: terraform1.stacks.MigrateTerraformState.Event.applied_change:type_name -> terraform1.stacks.AppliedChange
+	56,  // 47: terraform1.stacks.MigrateTerraformState.Request.Mapping.resource_address_map:type_name -> terraform1.stacks.MigrateTerraformState.Request.Mapping.ResourceAddressMapEntry
+	57,  // 48: terraform1.stacks.MigrateTerraformState.Request.Mapping.module_address_map:type_name -> terraform1.stacks.MigrateTerraformState.Request.Mapping.ModuleAddressMapEntry
+	143, // 49: terraform1.stacks.OpenStackConfiguration.Request.source_address:type_name -> terraform1.SourceAddress
+	142, // 50: terraform1.stacks.OpenStackConfiguration.Response.diagnostics:type_name -> terraform1.Diagnostic
+	142, // 51: terraform1.stacks.ValidateStackConfiguration.Response.diagnostics:type_name -> terraform1.Diagnostic
+	66,  // 52: terraform1.stacks.FindStackConfigurationComponents.Response.config:type_name -> terraform1.stacks.FindStackConfigurationComponents.StackConfig
+	72,  // 53: terraform1.stacks.FindStackConfigurationComponents.StackConfig.components:type_name -> terraform1.stacks.FindStackConfigurationComponents.StackConfig.ComponentsEntry
+	73,  // 54: terraform1.stacks.FindStackConfigurationComponents.StackConfig.embedded_stacks:type_name -> terraform1.stacks.FindStackConfigurationComponents.StackConfig.EmbeddedStacksEntry
+	74,  // 55: terraform1.stacks.FindStackConfigurationComponents.StackConfig.input_variables:type_name -> terraform1.stacks.FindStackConfigurationComponents.StackConfig.InputVariablesEntry
+	75,  // 56: terraform1.stacks.FindStackConfigurationComponents.StackConfig.output_values:type_name -> terraform1.stacks.FindStackConfigurationComponents.StackConfig.OutputValuesEntry
+	76,  // 57: terraform1.stacks.FindStackConfigurationComponents.StackConfig.removed:type_name -> terraform1.stacks.FindStackConfigurationComponents.StackConfig.RemovedEntry
+	4,   // 58: terraform1.stacks.FindStackConfigurationComponents.EmbeddedStack.instances:type_name -> terraform1.stacks.FindStackConfigurationComponents.Instances
+	66,  // 59: terraform1.stacks.FindStackConfigurationComponents.EmbeddedStack.config:type_name -> terraform1.stacks.FindStackConfigurationComponents.StackConfig
+	4,   // 60: terraform1.stacks.FindStackConfigurationComponents.Component.instances:type_name -> terraform1.stacks.FindStackConfigurationComponents.Instances
+	4,   // 61: terraform1.stacks.FindStackConfigurationComponents.Removed.instances:type_name -> terraform1.stacks.FindStackConfigurationComponents.Instances
+	77,  // 62: terraform1.stacks.FindStackConfigurationComponents.Removed.blocks:type_name -> terraform1.stacks.FindStackConfigurationComponents.Removed.Block
+	68,  // 63: terraform1.stacks.FindStackConfigurationComponents.StackConfig.ComponentsEntry.value:type_name -> terraform1.stacks.FindStackConfigurationComponents.Component
+	67,  // 64: terraform1.stacks.FindStackConfigurationComponents.StackConfig.EmbeddedStacksEntry.value:type_name -> terraform1.stacks.FindStackConfigurationComponents.EmbeddedStack
+	70,  // 65: terraform1.stacks.FindStackConfigurationComponents.StackConfig.InputVariablesEntry.value:type_name -> terraform1.stacks.FindStackConfigurationComponents.InputVariable
+	71,  // 66: terraform1.stacks.FindStackConfigurationComponents.StackConfig.OutputValuesEntry.value:type_name -> terraform1.stacks.FindStackConfigurationComponents.OutputValue
+	69,  // 67: terraform1.stacks.FindStackConfigurationComponents.StackConfig.RemovedEntry.value:type_name -> terraform1.stacks.FindStackConfigurationComponents.Removed
+	4,   // 68: terraform1.stacks.FindStackConfigurationComponents.Removed.Block.instances:type_name -> terraform1.stacks.FindStackConfigurationComponents.Instances
+	114, // 69: terraform1.stacks.OpenStackState.RequestItem.raw:type_name -> terraform1.stacks.AppliedChange.RawChange
+	1,   // 70: terraform1.stacks.PlanStackChanges.Request.plan_mode:type_name -> terraform1.stacks.PlanMode
+	84,  // 71: terraform1.stacks.PlanStackChanges.Request.previous_state:type_name -> terraform1.stacks.PlanStackChanges.Request.PreviousStateEntry
+	85,  // 72: terraform1.stacks.PlanStackChanges.Request.input_values:type_name -> terraform1.stacks.PlanStackChanges.Request.InputValuesEntry
+	36,  // 73: terraform1.stacks.PlanStackChanges.Event.planned_change:type_name -> terraform1.stacks.PlannedChange
+	142, // 74: terraform1.stacks.PlanStackChanges.Event.diagnostic:type_name -> terraform1.Diagnostic
+	39,  // 75: terraform1.stacks.PlanStackChanges.Event.progress:type_name -> terraform1.stacks.StackChangeProgress
+	41,  // 76: terraform1.stacks.PlanStackChanges.Event.component_instance_policy_evaluation:type_name -> terraform1.stacks.ComponentInstancePolicyEvaluation
+	42,  // 77: terraform1.stacks.PlanStackChanges.Event.provider_instance_policy_evaluation:type_name -> terraform1.stacks.ProviderInstancePolicyEvaluation
+	141, // 78: terraform1.stacks.PlanStackChanges.Request.PreviousStateEntry.value:type_name -> google.protobuf.Any
+	29,  // 79: terraform1.stacks.PlanStackChanges.Request.InputValuesEntry.value:type_name -> terraform1.stacks.DynamicValueWithSource
+	141, // 80: terraform1.stacks.OpenStackPlan.RequestItem.raw:type_name -> google.protobuf.Any
+	141, // 81: terraform1.stacks.ApplyStackChanges.Request.planned_changes:type_name -> google.protobuf.Any
+	92,  // 82: terraform1.stacks.ApplyStackChanges.Request.input_values:type_name -> terraform1.stacks.ApplyStackChanges.Request.InputValuesEntry
+	38,  // 83: terraform1.stacks.ApplyStackChanges.Event.applied_change:type_name -> terraform1.stacks.AppliedChange
+	142, // 84: terraform1.stacks.ApplyStackChanges.Event.diagnostic:type_name -> terraform1.Diagnostic
+	39,  // 85: terraform1.stacks.ApplyStackChanges.Event.progress:type_name -> terraform1.stacks.StackChangeProgress
+	41,  // 86: terraform1.stacks.ApplyStackChanges.Event.component_instance_policy_evaluation:type_name -> terraform1.stacks.ComponentInstancePolicyEvaluation
+	42,  // 87: terraform1.stacks.ApplyStackChanges.Event.provider_instance_policy_evaluation:type_name -> terraform1.stacks.ProviderInstancePolicyEvaluation
+	29,  // 88: terraform1.stacks.ApplyStackChanges.Request.InputValuesEntry.value:type_name -> terraform1.stacks.DynamicValueWithSource
+	95,  // 89: terraform1.stacks.OpenStackInspector.Request.state:type_name -> terraform1.stacks.OpenStackInspector.Request.StateEntry
+	96,  // 90: terraform1.stacks.OpenStackInspector.Request.input_values:type_name -> terraform1.stacks.OpenStackInspector.Request.InputValuesEntry
+	142, // 91: terraform1.stacks.OpenStackInspector.Response.diagnostics:type_name -> terraform1.Diagnostic
+	141, // 92: terraform1.stacks.OpenStackInspector.Request.StateEntry.value:type_name -> google.protobuf.Any
+	29,  // 93: terraform1.stacks.OpenStackInspector.Request.InputValuesEntry.value:type_name -> terraform1.stacks.DynamicValueWithSource
+	27,  // 94: terraform1.stacks.InspectExpressionResult.Response.result:type_name -> terraform1.stacks.DynamicValue
+	142, // 95: terraform1.stacks.InspectExpressionResult.Response.diagnostics:type_name -> terraform1.Diagnostic
+	101, // 96: terraform1.stacks.PlannedChange.ChangeDescription.component_instance_planned:type_name -> terraform1.stacks.PlannedChange.ComponentInstance
+	102, // 97: terraform1.stacks.PlannedChange.ChangeDescription.resource_instance_planned:type_name -> terraform1.stacks.PlannedChange.ResourceInstance
+	103, // 98: terraform1.stacks.PlannedChange.ChangeDescription.output_value_planned:type_name -> terraform1.stacks.PlannedChange.OutputValue
+	104, // 99: terraform1.stacks.PlannedChange.ChangeDescription.resource_instance_deferred:type_name -> terraform1.stacks.PlannedChange.ResourceInstanceDeferred
+	105, // 100: terraform1.stacks.PlannedChange.ChangeDescription.input_variable_planned:type_name -> terraform1.stacks.PlannedChange.InputVariable
+	106, // 101: terraform1.stacks.PlannedChange.ChangeDescription.action_invocation_planned:type_name -> terraform1.stacks.PlannedChange.ActionInvocationInstance
+	107, // 102: terraform1.stacks.PlannedChange.ChangeDescription.action_invocation_deferred:type_name -> terraform1.stacks.PlannedChange.ActionInvocationDeferred
+	32,  // 103: terraform1.stacks.PlannedChange.ComponentInstance.addr:type_name -> terraform1.stacks.ComponentInstanceInStackAddr
+	2,   // 104: terraform1.stacks.PlannedChange.ComponentInstance.actions:type_name -> terraform1.stacks.ChangeType
+	110, // 105: terraform1.stacks.PlannedChange.ComponentInstance.output_values:type_name -> terraform1.stacks.PlannedChange.ComponentInstance.OutputValuesEntry
+	35,  // 106: terraform1.stacks.PlannedChange.ResourceInstance.addr:type_name -> terraform1.stacks.ResourceInstanceObjectInStackAddr
+	2,   // 107: terraform1.stacks.PlannedChange.ResourceInstance.actions:type_name -> terraform1.stacks.ChangeType
+	28,  // 108: terraform1.stacks.PlannedChange.ResourceInstance.values:type_name -> terraform1.stacks.DynamicValueChange
+	112, // 109: terraform1.stacks.PlannedChange.ResourceInstance.moved:type_name -> terraform1.stacks.PlannedChange.ResourceInstance.Moved
+	113, // 110: terraform1.stacks.PlannedChange.ResourceInstance.imported:type_name -> terraform1.stacks.PlannedChange.ResourceInstance.Imported
+	0,   // 111: terraform1.stacks.PlannedChange.ResourceInstance.resource_mode:type_name -> terraform1.stacks.ResourceMode
+	27,  // 112: terraform1.stacks.PlannedChange.ResourceInstance.previous_run_value:type_name -> terraform1.stacks.DynamicValue
+	30,  // 113: terraform1.stacks.PlannedChange.ResourceInstance.replace_paths:type_name -> terraform1.stacks.AttributePath
+	111, // 114: terraform1.stacks.PlannedChange.ResourceInstance.index:type_name -> terraform1.stacks.PlannedChange.ResourceInstance.Index
+	2,   // 115: terraform1.stacks.PlannedChange.OutputValue.actions:type_name -> terraform1.stacks.ChangeType
+	28,  // 116: terraform1.stacks.PlannedChange.OutputValue.values:type_name -> terraform1.stacks.DynamicValueChange
+	102, // 117: terraform1.stacks.PlannedChange.ResourceInstanceDeferred.resource_instance:type_name -> terraform1.stacks.PlannedChange.ResourceInstance
+	37,  // 118: terraform1.stacks.PlannedChange.ResourceInstanceDeferred.deferred:type_name -> terraform1.stacks.Deferred
+	2,   // 119: terraform1.stacks.PlannedChange.InputVariable.actions:type_name -> terraform1.stacks.ChangeType
+	28,  // 120: terraform1.stacks.PlannedChange.InputVariable.values:type_name -> terraform1.stacks.DynamicValueChange
+	33,  // 121: terraform1.stacks.PlannedChange.ActionInvocationInstance.addr:type_name -> terraform1.stacks.ActionInvocationInstanceInStackAddr
+	27,  // 122: terraform1.stacks.PlannedChange.ActionInvocationInstance.config_value:type_name -> terraform1.stacks.DynamicValue
+	108, // 123: terraform1.stacks.PlannedChange.ActionInvocationInstance.resource_action_trigger:type_name -> terraform1.stacks.PlannedChange.ResourceActionTrigger
+	109, // 124: terraform1.stacks.PlannedChange.ActionInvocationInstance.invoke_action_trigger:type_name -> terraform1.stacks.PlannedChange.InvokeActionTrigger
+	37,  // 125: terraform1.stacks.PlannedChange.ActionInvocationDeferred.deferred:type_name -> terraform1.stacks.Deferred
+	106, // 126: terraform1.stacks.PlannedChange.ActionInvocationDeferred.action_invocation:type_name -> terraform1.stacks.PlannedChange.ActionInvocationInstance
+	34,  // 127: terraform1.stacks.PlannedChange.ResourceActionTrigger.triggering_resource_address:type_name -> terraform1.stacks.ResourceInstanceInStackAddr
+	5,   // 128: terraform1.stacks.PlannedChange.ResourceActionTrigger.trigger_event:type_name -> terraform1.stacks.PlannedChange.ActionTriggerEvent
+	27,  // 129: terraform1.stacks.PlannedChange.ComponentInstance.OutputValuesEntry.value:type_name -> terraform1.stacks.DynamicValue
+	27,  // 130: terraform1.stacks.PlannedChange.ResourceInstance.Index.value:type_name -> terraform1.stacks.DynamicValue
+	34,  // 131: terraform1.stacks.PlannedChange.ResourceInstance.Moved.prev_addr:type_name -> terraform1.stacks.ResourceInstanceInStackAddr
+	141, // 132: terraform1.stacks.AppliedChange.RawChange.value:type_name -> google.protobuf.Any
+	120, // 133: terraform1.stacks.AppliedChange.ChangeDescription.deleted:type_name -> terraform1.stacks.AppliedChange.Nothing
+	120, // 134: terraform1.stacks.AppliedChange.ChangeDescription.moved:type_name -> terraform1.stacks.AppliedChange.Nothing
+	116, // 135: terraform1.stacks.AppliedChange.ChangeDescription.resource_instance:type_name -> terraform1.stacks.AppliedChange.ResourceInstance
+	118, // 136: terraform1.stacks.AppliedChange.ChangeDescription.output_value:type_name -> terraform1.stacks.AppliedChange.OutputValue
+	119, // 137: terraform1.stacks.AppliedChange.ChangeDescription.input_variable:type_name -> terraform1.stacks.AppliedChange.InputVariable
+	117, // 138: terraform1.stacks.AppliedChange.ChangeDescription.component_instance:type_name -> terraform1.stacks.AppliedChange.ComponentInstance
+	35,  // 139: terraform1.stacks.AppliedChange.ResourceInstance.addr:type_name -> terraform1.stacks.ResourceInstanceObjectInStackAddr
+	27,  // 140: terraform1.stacks.AppliedChange.ResourceInstance.new_value:type_name -> terraform1.stacks.DynamicValue
+	0,   // 141: terraform1.stacks.AppliedChange.ResourceInstance.resource_mode:type_name -> terraform1.stacks.ResourceMode
+	121, // 142: terraform1.stacks.AppliedChange.ComponentInstance.output_values:type_name -> terraform1.stacks.AppliedChange.ComponentInstance.OutputValuesEntry
+	27,  // 143: terraform1.stacks.AppliedChange.OutputValue.new_value:type_name -> terraform1.stacks.DynamicValue
+	27,  // 144: terraform1.stacks.AppliedChange.InputVariable.new_value:type_name -> terraform1.stacks.DynamicValue
+	27,  // 145: terraform1.stacks.AppliedChange.ComponentInstance.OutputValuesEntry.value:type_name -> terraform1.stacks.DynamicValue
+	32,  // 146: terraform1.stacks.StackChangeProgress.ComponentInstanceStatus.addr:type_name -> terraform1.stacks.ComponentInstanceInStackAddr
+	8,   // 147: terraform1.stacks.StackChangeProgress.ComponentInstanceStatus.status:type_name -> terraform1.stacks.StackChangeProgress.ComponentInstanceStatus.Status
+	35,  // 148: terraform1.stacks.StackChangeProgress.ResourceInstanceStatus.addr:type_name -> terraform1.stacks.ResourceInstanceObjectInStackAddr
+	9,   // 149: terraform1.stacks.StackChangeProgress.ResourceInstanceStatus.status:type_name -> terraform1.stacks.StackChangeProgress.ResourceInstanceStatus.Status
+	35,  // 150: terraform1.stacks.StackChangeProgress.ResourceInstancePlannedChange.addr:type_name -> terraform1.stacks.ResourceInstanceObjectInStackAddr
+	2,   // 151: terraform1.stacks.StackChangeProgress.ResourceInstancePlannedChange.actions:type_name -> terraform1.stacks.ChangeType
+	135, // 152: terraform1.stacks.StackChangeProgress.ResourceInstancePlannedChange.moved:type_name -> terraform1.stacks.StackChangeProgress.ResourceInstancePlannedChange.Moved
+	136, // 153: terraform1.stacks.StackChangeProgress.ResourceInstancePlannedChange.imported:type_name -> terraform1.stacks.StackChangeProgress.ResourceInstancePlannedChange.Imported
+	37,  // 154: terraform1.stacks.StackChangeProgress.DeferredResourceInstancePlannedChange.deferred:type_name -> terraform1.stacks.Deferred
+	124, // 155: terraform1.stacks.StackChangeProgress.DeferredResourceInstancePlannedChange.change:type_name -> terraform1.stacks.StackChangeProgress.ResourceInstancePlannedChange
+	33,  // 156: terraform1.stacks.StackChangeProgress.ActionInvocationPlanned.addr:type_name -> terraform1.stacks.ActionInvocationInstanceInStackAddr
+	129, // 157: terraform1.stacks.StackChangeProgress.ActionInvocationPlanned.resource_action_trigger:type_name -> terraform1.stacks.StackChangeProgress.ResourceActionTrigger
+	130, // 158: terraform1.stacks.StackChangeProgress.ActionInvocationPlanned.invoke_action_trigger:type_name -> terraform1.stacks.StackChangeProgress.InvokeActionTrigger
+	33,  // 159: terraform1.stacks.StackChangeProgress.ActionInvocationStatus.addr:type_name -> terraform1.stacks.ActionInvocationInstanceInStackAddr
+	10,  // 160: terraform1.stacks.StackChangeProgress.ActionInvocationStatus.status:type_name -> terraform1.stacks.StackChangeProgress.ActionInvocationStatus.Status
+	129, // 161: terraform1.stacks.StackChangeProgress.ActionInvocationStatus.resource_action_trigger:type_name -> terraform1.stacks.StackChangeProgress.ResourceActionTrigger
+	130, // 162: terraform1.stacks.StackChangeProgress.ActionInvocationStatus.invoke_action_trigger:type_name -> terraform1.stacks.StackChangeProgress.InvokeActionTrigger
+	33,  // 163: terraform1.stacks.StackChangeProgress.ActionInvocationProgress.addr:type_name -> terraform1.stacks.ActionInvocationInstanceInStackAddr
+	129, // 164: terraform1.stacks.StackChangeProgress.ActionInvocationProgress.resource_action_trigger:type_name -> terraform1.stacks.StackChangeProgress.ResourceActionTrigger
+	130, // 165: terraform1.stacks.StackChangeProgress.ActionInvocationProgress.invoke_action_trigger:type_name -> terraform1.stacks.StackChangeProgress.InvokeActionTrigger
+	34,  // 166: terraform1.stacks.StackChangeProgress.ResourceActionTrigger.triggering_resource_address:type_name -> terraform1.stacks.ResourceInstanceInStackAddr
+	7,   // 167: terraform1.stacks.StackChangeProgress.ResourceActionTrigger.trigger_event:type_name -> terraform1.stacks.StackChangeProgress.ActionTriggerEvent
+	35,  // 168: terraform1.stacks.StackChangeProgress.ProvisionerStatus.addr:type_name -> terraform1.stacks.ResourceInstanceObjectInStackAddr
+	131, // 169: terraform1.stacks.StackChangeProgress.ProvisionerStatus.status:type_name -> terraform1.stacks.StackChangeProgress.ProvisionerStatus
+	35,  // 170: terraform1.stacks.StackChangeProgress.ProvisionerOutput.addr:type_name -> terraform1.stacks.ResourceInstanceObjectInStackAddr
+	32,  // 171: terraform1.stacks.StackChangeProgress.ComponentInstanceChanges.addr:type_name -> terraform1.stacks.ComponentInstanceInStackAddr
+	34,  // 172: terraform1.stacks.StackChangeProgress.ResourceInstancePlannedChange.Moved.prev_addr:type_name -> terraform1.stacks.ResourceInstanceInStackAddr
+	139, // 173: terraform1.stacks.ListResourceIdentities.Response.resource:type_name -> terraform1.stacks.ListResourceIdentities.Resource
+	27,  // 174: terraform1.stacks.ListResourceIdentities.Resource.resource_identity:type_name -> terraform1.stacks.DynamicValue
+	58,  // 175: terraform1.stacks.Stacks.OpenStackConfiguration:input_type -> terraform1.stacks.OpenStackConfiguration.Request
+	60,  // 176: terraform1.stacks.Stacks.CloseStackConfiguration:input_type -> terraform1.stacks.CloseStackConfiguration.Request
+	62,  // 177: terraform1.stacks.Stacks.ValidateStackConfiguration:input_type -> terraform1.stacks.ValidateStackConfiguration.Request
+	64,  // 178: terraform1.stacks.Stacks.FindStackConfigurationComponents:input_type -> terraform1.stacks.FindStackConfigurationComponents.Request
+	78,  // 179: terraform1.stacks.Stacks.OpenState:input_type -> terraform1.stacks.OpenStackState.RequestItem
+	80,  // 180: terraform1.stacks.Stacks.CloseState:input_type -> terraform1.stacks.CloseStackState.Request
+	82,  // 181: terraform1.stacks.Stacks.PlanStackChanges:input_type -> terraform1.stacks.PlanStackChanges.Request
+	86,  // 182: terraform1.stacks.Stacks.OpenPlan:input_type -> terraform1.stacks.OpenStackPlan.RequestItem
+	88,  // 183: terraform1.stacks.Stacks.ClosePlan:input_type -> terraform1.stacks.CloseStackPlan.Request
+	90,  // 184: terraform1.stacks.Stacks.ApplyStackChanges:input_type -> terraform1.stacks.ApplyStackChanges.Request
+	93,  // 185: terraform1.stacks.Stacks.OpenStackInspector:input_type -> terraform1.stacks.OpenStackInspector.Request
+	97,  // 186: terraform1.stacks.Stacks.InspectExpressionResult:input_type -> terraform1.stacks.InspectExpressionResult.Request
+	49,  // 187: terraform1.stacks.Stacks.OpenTerraformState:input_type -> terraform1.stacks.OpenTerraformState.Request
+	51,  // 188: terraform1.stacks.Stacks.CloseTerraformState:input_type -> terraform1.stacks.CloseTerraformState.Request
+	53,  // 189: terraform1.stacks.Stacks.MigrateTerraformState:input_type -> terraform1.stacks.MigrateTerraformState.Request
+	137, // 190: terraform1.stacks.Stacks.ListResourceIdentities:input_type -> terraform1.stacks.ListResourceIdentities.Request
+	59,  // 191: terraform1.stacks.Stacks.OpenStackConfiguration:output_type -> terraform1.stacks.OpenStackConfiguration.Response
+	61,  // 192: terraform1.stacks.Stacks.CloseStackConfiguration:output_type -> terraform1.stacks.CloseStackConfiguration.Response
+	63,  // 193: terraform1.stacks.Stacks.ValidateStackConfiguration:output_type -> terraform1.stacks.ValidateStackConfiguration.Response
+	65,  // 194: terraform1.stacks.Stacks.FindStackConfigurationComponents:output_type -> terraform1.stacks.FindStackConfigurationComponents.Response
+	79,  // 195: terraform1.stacks.Stacks.OpenState:output_type -> terraform1.stacks.OpenStackState.Response
+	81,  // 196: terraform1.stacks.Stacks.CloseState:output_type -> terraform1.stacks.CloseStackState.Response
+	83,  // 197: terraform1.stacks.Stacks.PlanStackChanges:output_type -> terraform1.stacks.PlanStackChanges.Event
+	87,  // 198: terraform1.stacks.Stacks.OpenPlan:output_type -> terraform1.stacks.OpenStackPlan.Response
+	89,  // 199: terraform1.stacks.Stacks.ClosePlan:output_type -> terraform1.stacks.CloseStackPlan.Response
+	91,  // 200: terraform1.stacks.Stacks.ApplyStackChanges:output_type -> terraform1.stacks.ApplyStackChanges.Event
+	94,  // 201: terraform1.stacks.Stacks.OpenStackInspector:output_type -> terraform1.stacks.OpenStackInspector.Response
+	98,  // 202: terraform1.stacks.Stacks.InspectExpressionResult:output_type -> terraform1.stacks.InspectExpressionResult.Response
+	50,  // 203: terraform1.stacks.Stacks.OpenTerraformState:output_type -> terraform1.stacks.OpenTerraformState.Response
+	52,  // 204: terraform1.stacks.Stacks.CloseTerraformState:output_type -> terraform1.stacks.CloseTerraformState.Response
+	54,  // 205: terraform1.stacks.Stacks.MigrateTerraformState:output_type -> terraform1.stacks.MigrateTerraformState.Event
+	138, // 206: terraform1.stacks.Stacks.ListResourceIdentities:output_type -> terraform1.stacks.ListResourceIdentities.Response
+	191, // [191:207] is the sub-list for method output_type
+	175, // [175:191] is the sub-list for method input_type
+	175, // [175:175] is the sub-list for extension type_name
+	175, // [175:175] is the sub-list for extension extendee
+	0,   // [0:175] is the sub-list for field type_name
 }
 
 func init() { file_stacks_proto_init() }
@@ -9061,7 +9236,7 @@ func file_stacks_proto_init() {
 	if File_stacks_proto != nil {
 		return
 	}
-	file_stacks_proto_msgTypes[26].OneofWrappers = []any{
+	file_stacks_proto_msgTypes[27].OneofWrappers = []any{
 		(*StackChangeProgress_ComponentInstanceStatus_)(nil),
 		(*StackChangeProgress_ResourceInstanceStatus_)(nil),
 		(*StackChangeProgress_ResourceInstancePlannedChange_)(nil),
@@ -9074,37 +9249,39 @@ func file_stacks_proto_init() {
 		(*StackChangeProgress_ActionInvocationStatus_)(nil),
 		(*StackChangeProgress_ActionInvocationProgress_)(nil),
 	}
-	file_stacks_proto_msgTypes[35].OneofWrappers = []any{
+	file_stacks_proto_msgTypes[37].OneofWrappers = []any{
 		(*OpenTerraformState_Request_ConfigPath)(nil),
 		(*OpenTerraformState_Request_Raw)(nil),
 	}
-	file_stacks_proto_msgTypes[39].OneofWrappers = []any{
+	file_stacks_proto_msgTypes[41].OneofWrappers = []any{
 		(*MigrateTerraformState_Request_Simple)(nil),
 	}
-	file_stacks_proto_msgTypes[40].OneofWrappers = []any{
+	file_stacks_proto_msgTypes[42].OneofWrappers = []any{
 		(*MigrateTerraformState_Event_Diagnostic)(nil),
 		(*MigrateTerraformState_Event_AppliedChange)(nil),
 	}
-	file_stacks_proto_msgTypes[68].OneofWrappers = []any{}
-	file_stacks_proto_msgTypes[69].OneofWrappers = []any{
+	file_stacks_proto_msgTypes[70].OneofWrappers = []any{}
+	file_stacks_proto_msgTypes[71].OneofWrappers = []any{
 		(*PlanStackChanges_Event_PlannedChange)(nil),
 		(*PlanStackChanges_Event_Diagnostic)(nil),
 		(*PlanStackChanges_Event_Progress)(nil),
 		(*PlanStackChanges_Event_ComponentInstancePolicyEvaluation)(nil),
+		(*PlanStackChanges_Event_ProviderInstancePolicyEvaluation)(nil),
 	}
-	file_stacks_proto_msgTypes[76].OneofWrappers = []any{}
-	file_stacks_proto_msgTypes[77].OneofWrappers = []any{
+	file_stacks_proto_msgTypes[78].OneofWrappers = []any{}
+	file_stacks_proto_msgTypes[79].OneofWrappers = []any{
 		(*ApplyStackChanges_Event_AppliedChange)(nil),
 		(*ApplyStackChanges_Event_Diagnostic)(nil),
 		(*ApplyStackChanges_Event_Progress)(nil),
 		(*ApplyStackChanges_Event_ComponentInstancePolicyEvaluation)(nil),
+		(*ApplyStackChanges_Event_ProviderInstancePolicyEvaluation)(nil),
 	}
-	file_stacks_proto_msgTypes[85].OneofWrappers = []any{
+	file_stacks_proto_msgTypes[87].OneofWrappers = []any{
 		(*AttributePath_Step_AttributeName)(nil),
 		(*AttributePath_Step_ElementKeyString)(nil),
 		(*AttributePath_Step_ElementKeyInt)(nil),
 	}
-	file_stacks_proto_msgTypes[86].OneofWrappers = []any{
+	file_stacks_proto_msgTypes[88].OneofWrappers = []any{
 		(*PlannedChange_ChangeDescription_ComponentInstancePlanned)(nil),
 		(*PlannedChange_ChangeDescription_ResourceInstancePlanned)(nil),
 		(*PlannedChange_ChangeDescription_OutputValuePlanned)(nil),
@@ -9114,11 +9291,11 @@ func file_stacks_proto_init() {
 		(*PlannedChange_ChangeDescription_ActionInvocationPlanned)(nil),
 		(*PlannedChange_ChangeDescription_ActionInvocationDeferred)(nil),
 	}
-	file_stacks_proto_msgTypes[92].OneofWrappers = []any{
+	file_stacks_proto_msgTypes[94].OneofWrappers = []any{
 		(*PlannedChange_ActionInvocationInstance_ResourceActionTrigger)(nil),
 		(*PlannedChange_ActionInvocationInstance_InvokeActionTrigger)(nil),
 	}
-	file_stacks_proto_msgTypes[101].OneofWrappers = []any{
+	file_stacks_proto_msgTypes[103].OneofWrappers = []any{
 		(*AppliedChange_ChangeDescription_Deleted)(nil),
 		(*AppliedChange_ChangeDescription_Moved)(nil),
 		(*AppliedChange_ChangeDescription_ResourceInstance)(nil),
@@ -9126,15 +9303,15 @@ func file_stacks_proto_init() {
 		(*AppliedChange_ChangeDescription_InputVariable)(nil),
 		(*AppliedChange_ChangeDescription_ComponentInstance)(nil),
 	}
-	file_stacks_proto_msgTypes[112].OneofWrappers = []any{
+	file_stacks_proto_msgTypes[114].OneofWrappers = []any{
 		(*StackChangeProgress_ActionInvocationPlanned_ResourceActionTrigger)(nil),
 		(*StackChangeProgress_ActionInvocationPlanned_InvokeActionTrigger)(nil),
 	}
-	file_stacks_proto_msgTypes[113].OneofWrappers = []any{
+	file_stacks_proto_msgTypes[115].OneofWrappers = []any{
 		(*StackChangeProgress_ActionInvocationStatus_ResourceActionTrigger)(nil),
 		(*StackChangeProgress_ActionInvocationStatus_InvokeActionTrigger)(nil),
 	}
-	file_stacks_proto_msgTypes[114].OneofWrappers = []any{
+	file_stacks_proto_msgTypes[116].OneofWrappers = []any{
 		(*StackChangeProgress_ActionInvocationProgress_ResourceActionTrigger)(nil),
 		(*StackChangeProgress_ActionInvocationProgress_InvokeActionTrigger)(nil),
 	}
@@ -9144,7 +9321,7 @@ func file_stacks_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_stacks_proto_rawDesc), len(file_stacks_proto_rawDesc)),
 			NumEnums:      12,
-			NumMessages:   126,
+			NumMessages:   128,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/internal/rpcapi/terraform1/stacks/stacks.proto
+++ b/internal/rpcapi/terraform1/stacks/stacks.proto
@@ -271,7 +271,10 @@ message PlanStackChanges {
       StackChangeProgress progress = 10;
       
       // Resources and modules evaluate policies for each component instance
-      PolicyEvaluationResponse component_instance_policy_evaluation = 11;
+      ComponentInstancePolicyEvaluation component_instance_policy_evaluation = 11;
+
+      // Providers evaluate policy for each instance in a stack
+      ProviderInstancePolicyEvaluation provider_instance_policy_evaluation = 12;
     }
     reserved 3 to 9; // formerly used for individual progress events
   }
@@ -348,7 +351,10 @@ message ApplyStackChanges {
       StackChangeProgress progress = 3;
 
       // Resources and modules evaluate policies for each component instance
-      PolicyEvaluationResponse component_instance_policy_evaluation = 4;
+      ComponentInstancePolicyEvaluation component_instance_policy_evaluation = 4;
+
+      // Providers evaluate policy for each instance in a stack
+      ProviderInstancePolicyEvaluation provider_instance_policy_evaluation = 5;
     }
   }
 }
@@ -421,6 +427,14 @@ message AttributePath {
     }
   }
   repeated Step steps = 1;
+}
+
+// Represents the address of a specific provider instance within a stack.
+message ProviderInstanceInStackAddr {
+  // The address of the static provider config that this is an instance of.
+  string provider_addr = 1;
+  // The address of the provider instance config.
+  string provider_instance_addr = 2;
 }
 
 // Represents the address of a specific component instance within a stack.
@@ -1094,10 +1108,15 @@ message ListResourceIdentities {
   }
 }
 
-message PolicyEvaluationResponse {
-  // Policies are only evaluated for component instances
+message ComponentInstancePolicyEvaluation {
   ComponentInstanceInStackAddr addr = 1;
-  
+  repeated PolicyResult results = 2;
+  repeated PolicyInfo infos = 3;
+  repeated PolicyDiagnostic diagnostics = 4;
+}
+
+message ProviderInstancePolicyEvaluation {
+  ProviderInstanceInStackAddr addr = 1;
   repeated PolicyResult results = 2;
   repeated PolicyInfo infos = 3;
   repeated PolicyDiagnostic diagnostics = 4;

--- a/internal/stacks/stackaddrs/provider_config.go
+++ b/internal/stacks/stackaddrs/provider_config.go
@@ -94,3 +94,14 @@ func AbsProviderToInstance(addr AbsProviderConfig, ik addrs.InstanceKey) AbsProv
 		},
 	}
 }
+
+func ConfigProviderConfigForAbsInstance(instAddr AbsProviderConfigInstance) ConfigProviderConfig {
+	configInst := ConfigForAbs(instAddr) // a ConfigProviderConfigInstance
+	return ConfigProviderConfig{
+		Stack: configInst.Stack,
+		Item: ProviderConfig{
+			Name:     configInst.Item.ProviderConfig.Name,
+			Provider: configInst.Item.ProviderConfig.Provider,
+		},
+	}
+}

--- a/internal/stacks/stackruntime/apply_test.go
+++ b/internal/stacks/stackruntime/apply_test.go
@@ -4835,8 +4835,59 @@ func TestApply_WithPolicyResults(t *testing.T) {
 	})
 
 	wantPolicyResults := map[string]map[string]plans.PolicyEvaluation{
-		`component.simple_component["comp1"]`: createExpectedPolicyEvaluation("policy-evaluation"),
-		`component.simple_component["comp2"]`: createExpectedPolicyEvaluation("policy-evaluation"),
+		`component.simple_component["comp1"]`:                                  createExpectedComponentInstancePolicyEvaluation("policy-evaluation"),
+		`component.simple_component["comp2"]`:                                  createExpectedComponentInstancePolicyEvaluation("policy-evaluation"),
+		`provider["registry.terraform.io/hashicorp/testing"].default["comp1"]`: createExpectedProviderInstancePolicyEvaluation("policy-evaluation"),
+		`provider["registry.terraform.io/hashicorp/testing"].default["comp2"]`: createExpectedProviderInstancePolicyEvaluation("policy-evaluation"),
+	}
+
+	if diff := cmp.Diff(gotPolicyResults, wantPolicyResults, cmp.Comparer(simplePolicyDiagCompare)); diff != "" {
+		t.Errorf("wrong policy results\n%s", diff)
+	}
+}
+
+func TestApply_WithPolicyResults_EmbeddedStack(t *testing.T) {
+	ctx := context.Background()
+	cfg := loadMainBundleConfigForTest(t, "policy-evaluation-embedded-stack")
+
+	lock := depsfile.NewLocks()
+	lock.SetProvider(
+		addrs.NewDefaultProvider("testing"),
+		providerreqs.MustParseVersion("0.0.0"),
+		providerreqs.MustParseVersionConstraints("=0.0.0"),
+		providerreqs.PreferredHashes([]providerreqs.Hash{}),
+	)
+
+	plan := planForApplyTest(t, ctx, PlanRequest{
+		PlanMode: plans.NormalMode,
+		// Omit policy client as we're not asserting policy results for the plan phase in this test
+		PolicyClient: nil,
+		Config:       cfg,
+		ProviderFactories: map[addrs.Provider]providers.Factory{
+			addrs.NewDefaultProvider("testing"): func() (providers.Interface, error) {
+				return stacks_testing_provider.NewProvider(t), nil
+			},
+		},
+		DependencyLocks: *lock,
+	})
+
+	gotPolicyResults := applyAndCollectPolicyResults(t, ctx, ApplyRequest{
+		Config: cfg,
+		Plan:   plan,
+		ProviderFactories: map[addrs.Provider]providers.Factory{
+			addrs.NewDefaultProvider("testing"): func() (providers.Interface, error) {
+				return stacks_testing_provider.NewProvider(t), nil
+			},
+		},
+		DependencyLocks: *lock,
+		PolicyClient:    policyEvaluationTestClient(t),
+	})
+
+	wantPolicyResults := map[string]map[string]plans.PolicyEvaluation{
+		`stack.embedded.component.simple_component["comp1"]`:                                  createExpectedComponentInstancePolicyEvaluation("policy-evaluation-embedded-stack/embedded"),
+		`stack.embedded.component.simple_component["comp2"]`:                                  createExpectedComponentInstancePolicyEvaluation("policy-evaluation-embedded-stack/embedded"),
+		`stack.embedded.provider["registry.terraform.io/hashicorp/testing"].default["comp1"]`: createExpectedProviderInstancePolicyEvaluation("policy-evaluation-embedded-stack/embedded"),
+		`stack.embedded.provider["registry.terraform.io/hashicorp/testing"].default["comp2"]`: createExpectedProviderInstancePolicyEvaluation("policy-evaluation-embedded-stack/embedded"),
 	}
 
 	if diff := cmp.Diff(gotPolicyResults, wantPolicyResults, cmp.Comparer(simplePolicyDiagCompare)); diff != "" {
@@ -4882,8 +4933,17 @@ func TestApply_NoPolicyResultsOnRefresh(t *testing.T) {
 		PolicyClient:    policyEvaluationTestClient(t),
 	})
 
-	if len(gotPolicyResults) != 0 {
-		t.Errorf("expected no policy result events for a refresh-only apply, got %d:\n%#v", len(gotPolicyResults), gotPolicyResults)
+	// TODO: This is currently bugged because Apply is using the stackplan Mode field to control running policy evaluation,
+	// but that field is not serialized or deserialized from the plan itself.
+	//
+	// This test may eventually be modified anyways, so we just expect just provider policies to be evaluated for now
+	wantPolicyResults := map[string]map[string]plans.PolicyEvaluation{
+		`provider["registry.terraform.io/hashicorp/testing"].default["comp1"]`: createExpectedProviderInstancePolicyEvaluation("policy-evaluation"),
+		`provider["registry.terraform.io/hashicorp/testing"].default["comp2"]`: createExpectedProviderInstancePolicyEvaluation("policy-evaluation"),
+	}
+
+	if diff := cmp.Diff(gotPolicyResults, wantPolicyResults, cmp.Comparer(simplePolicyDiagCompare)); diff != "" {
+		t.Errorf("wrong policy results\n%s", diff)
 	}
 }
 
@@ -4925,8 +4985,17 @@ func TestApply_NoPolicyResultsOnDestroy(t *testing.T) {
 		PolicyClient:    policyEvaluationTestClient(t),
 	})
 
-	if len(gotPolicyResults) != 0 {
-		t.Errorf("expected no policy result events for a destroy apply, got %d:\n%#v", len(gotPolicyResults), gotPolicyResults)
+	// TODO: This is currently bugged because Apply is using the stackplan Mode field to control running policy evaluation,
+	// but that field is not serialized or deserialized from the plan itself.
+	//
+	// This test may eventually be modified anyways, so we just expect just provider policies to be evaluated for now
+	wantPolicyResults := map[string]map[string]plans.PolicyEvaluation{
+		`provider["registry.terraform.io/hashicorp/testing"].default["comp1"]`: createExpectedProviderInstancePolicyEvaluation("policy-evaluation"),
+		`provider["registry.terraform.io/hashicorp/testing"].default["comp2"]`: createExpectedProviderInstancePolicyEvaluation("policy-evaluation"),
+	}
+
+	if diff := cmp.Diff(gotPolicyResults, wantPolicyResults, cmp.Comparer(simplePolicyDiagCompare)); diff != "" {
+		t.Errorf("wrong policy results\n%s", diff)
 	}
 }
 
@@ -4990,8 +5059,10 @@ func TestApply_NoPolicyResultsOnRemovedComponent(t *testing.T) {
 	})
 
 	wantPolicyResults := map[string]map[string]plans.PolicyEvaluation{
-		`component.simple_component["comp1"]`: createExpectedPolicyEvaluation("policy-evaluation-removed"),
+		`component.simple_component["comp1"]`: createExpectedComponentInstancePolicyEvaluation("policy-evaluation-removed"),
 		// component.simple_component["comp2"] is removed in this config so there should be no policy result for it
+		`provider["registry.terraform.io/hashicorp/testing"].default["comp1"]`: createExpectedProviderInstancePolicyEvaluation("policy-evaluation-removed"),
+		`provider["registry.terraform.io/hashicorp/testing"].default["comp2"]`: createExpectedProviderInstancePolicyEvaluation("policy-evaluation-removed"),
 	}
 
 	if diff := cmp.Diff(gotPolicyResults, wantPolicyResults, cmp.Comparer(simplePolicyDiagCompare)); diff != "" {
@@ -5049,6 +5120,11 @@ func applyAndCollectPolicyResults(t *testing.T, ctx context.Context, req ApplyRe
 	gotPolicyResults := make(map[string]map[string]plans.PolicyEvaluation)
 	applyHooks := &Hooks{
 		ReportComponentInstancePolicyResults: func(ctx context.Context, data *hooks.ComponentInstancePolicyResults) {
+			mu.Lock()
+			defer mu.Unlock()
+			gotPolicyResults[data.Addr.String()] = maps.Collect(data.PolicyResults.Iter())
+		},
+		ReportProviderInstancePolicyResults: func(ctx context.Context, data *hooks.ProviderInstancePolicyResults) {
 			mu.Lock()
 			defer mu.Unlock()
 			gotPolicyResults[data.Addr.String()] = maps.Collect(data.PolicyResults.Iter())

--- a/internal/stacks/stackruntime/hooks/component_instance.go
+++ b/internal/stacks/stackruntime/hooks/component_instance.go
@@ -99,3 +99,10 @@ type ComponentInstancePolicyResults struct {
 	Addr          stackaddrs.AbsComponentInstance
 	PolicyResults *plans.PolicyResults
 }
+
+// ProviderInstancePolicyResults is the argument type for the hook callback which
+// sends policy results back to the client for a provider instance.
+type ProviderInstancePolicyResults struct {
+	Addr          stackaddrs.AbsProviderConfigInstance
+	PolicyResults *plans.PolicyResults
+}

--- a/internal/stacks/stackruntime/internal/stackeval/hooks.go
+++ b/internal/stacks/stackruntime/internal/stackeval/hooks.go
@@ -155,6 +155,10 @@ type Hooks struct {
 	// ReportComponentInstancePolicyResults is called after a component instance is planned or applied. If no policy results are provided
 	// it will not emit an event.
 	ReportComponentInstancePolicyResults hooks.SingleFunc[*hooks.ComponentInstancePolicyResults]
+
+	// ReportProviderInstancePolicyResults is called after a provider instance is configured during plan or apply. If no policy results are provided
+	// it will not emit an event.
+	ReportProviderInstancePolicyResults hooks.SingleFunc[*hooks.ProviderInstancePolicyResults]
 }
 
 // A do-nothing default Hooks that we use when the caller doesn't provide one.

--- a/internal/stacks/stackruntime/internal/stackeval/provider_instance.go
+++ b/internal/stacks/stackruntime/internal/stackeval/provider_instance.go
@@ -12,12 +12,17 @@ import (
 	"github.com/hashicorp/hcl/v2/hcldec"
 	"github.com/zclconf/go-cty/cty"
 
+	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/instances"
 	"github.com/hashicorp/terraform/internal/lang"
+	"github.com/hashicorp/terraform/internal/plans"
+	"github.com/hashicorp/terraform/internal/policy"
+	"github.com/hashicorp/terraform/internal/policy/proto"
 	"github.com/hashicorp/terraform/internal/promising"
 	"github.com/hashicorp/terraform/internal/providers"
 	"github.com/hashicorp/terraform/internal/stacks/stackaddrs"
 	"github.com/hashicorp/terraform/internal/stacks/stackplan"
+	"github.com/hashicorp/terraform/internal/stacks/stackruntime/hooks"
 	"github.com/hashicorp/terraform/internal/stacks/stackruntime/internal/stackeval/stubs"
 	"github.com/hashicorp/terraform/internal/stacks/stackstate"
 	"github.com/hashicorp/terraform/internal/tfdiags"
@@ -236,7 +241,8 @@ func (p *ProviderInstance) CheckClient(ctx context.Context, phase EvalPhase) (pr
 
 			// We unmark the config before making the RPC call, as marks cannot
 			// be serialized.
-			unmarkedArgs, _ := p.ProviderArgs(ctx, phase).UnmarkDeep()
+			configVal := p.ProviderArgs(ctx, phase)
+			unmarkedArgs, _ := configVal.UnmarkDeep()
 			if unmarkedArgs == cty.NilVal {
 				// Then we had an error previously, so we'll rely on that error
 				// being exposed elsewhere.
@@ -256,6 +262,54 @@ func (p *ProviderInstance) CheckClient(ctx context.Context, phase EvalPhase) (pr
 				// gets cleaned up by the cleanup function above, despite being
 				// inaccessible to the caller.)
 				return stubs.ErroredProvider(), diags
+			}
+
+			// If a policy client is configured and the planning mode is normal (i.e. not refresh or destroy), evaluate policy for the provider instance
+			if policyClient := p.main.PolicyClient(); p.main.PlanningMode() == plans.NormalMode && policyClient != nil {
+				providerTypeAddr := providerType.Addr()
+
+				var providerLockVersion string
+				depLocks := p.main.DependencyLocks(phase)
+				if depLocks != nil {
+					if providerLock := depLocks.AllProviders()[providerTypeAddr]; providerLock != nil {
+						providerLockVersion = providerLock.Version().String()
+					}
+				}
+
+				result := policyClient.EvaluateProvider(ctx, policy.EvaluationRequest[*proto.PolicyEvaluateProviderRequest_ProviderMetadata]{
+					Target: providerTypeAddr.Type,
+					// We use the marked "configVal" so that we can send sensitive paths to the
+					// policy plugin. Provider schemas don't have a defined usage/behavior for
+					// the "Sensitive" field, so we don't add sensitive paths from the schema to this value.
+					Attrs: policy.CtyToPolicyValue(configVal),
+					Meta: &proto.PolicyEvaluateProviderRequest_ProviderMetadata{
+						Name:      providerTypeAddr.Type,
+						Alias:     p.addr.Item.ProviderConfig.Name,
+						Namespace: providerTypeAddr.Namespace,
+						Source:    providerTypeAddr.String(),
+						Version:   providerLockVersion,
+					},
+				})
+
+				// This address is only used to share the module runtime policy result struct
+				// and won't be used outside of this method.
+				providerConfigAddr := addrs.AbsProviderConfig{
+					Module:   addrs.RootModule,
+					Provider: p.provider.addr.Item.Provider,
+					Alias:    p.provider.addr.Item.Name,
+				}
+
+				policyResults := plans.NewPolicyResults()
+				policyResults.AddProvider(providerConfigAddr, result, decl.DeclRange.ToHCL())
+
+				// Report policy results if we have any
+				if policyResults.Len() > 0 {
+					h := hooksFromContext(ctx)
+					hookSingle(ctx, h.ReportProviderInstancePolicyResults, &hooks.ProviderInstancePolicyResults{
+						Addr:          p.addr,
+						PolicyResults: policyResults,
+					})
+				}
 			}
 
 			return unconfigurableProvider{

--- a/internal/stacks/stackruntime/plan_test.go
+++ b/internal/stacks/stackruntime/plan_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/zclconf/go-cty-debug/ctydebug"
 	"github.com/zclconf/go-cty/cty"
 	"github.com/zclconf/go-cty/cty/msgpack"
+	"google.golang.org/protobuf/testing/protocmp"
 
 	"github.com/hashicorp/terraform/internal/checks"
 	"github.com/hashicorp/terraform/internal/depsfile"
@@ -6955,8 +6956,46 @@ func TestPlan_WithPolicyResults(t *testing.T) {
 	})
 
 	wantPolicyResults := map[string]map[string]plans.PolicyEvaluation{
-		`component.simple_component["comp1"]`: createExpectedPolicyEvaluation("policy-evaluation"),
-		`component.simple_component["comp2"]`: createExpectedPolicyEvaluation("policy-evaluation"),
+		`component.simple_component["comp1"]`:                                  createExpectedComponentInstancePolicyEvaluation("policy-evaluation"),
+		`component.simple_component["comp2"]`:                                  createExpectedComponentInstancePolicyEvaluation("policy-evaluation"),
+		`provider["registry.terraform.io/hashicorp/testing"].default["comp1"]`: createExpectedProviderInstancePolicyEvaluation("policy-evaluation"),
+		`provider["registry.terraform.io/hashicorp/testing"].default["comp2"]`: createExpectedProviderInstancePolicyEvaluation("policy-evaluation"),
+	}
+
+	if diff := cmp.Diff(gotPolicyResults, wantPolicyResults, cmp.Comparer(simplePolicyDiagCompare)); diff != "" {
+		t.Errorf("wrong policy results\n%s", diff)
+	}
+}
+
+func TestPlan_WithPolicyResults_EmbeddedStack(t *testing.T) {
+	ctx := context.Background()
+	cfg := loadMainBundleConfigForTest(t, "policy-evaluation-embedded-stack")
+
+	lock := depsfile.NewLocks()
+	lock.SetProvider(
+		addrs.NewDefaultProvider("testing"),
+		providerreqs.MustParseVersion("0.0.0"),
+		providerreqs.MustParseVersionConstraints("=0.0.0"),
+		providerreqs.PreferredHashes([]providerreqs.Hash{}),
+	)
+
+	gotPolicyResults := planAndCollectPolicyResults(t, ctx, PlanRequest{
+		PlanMode: plans.NormalMode,
+		Config:   cfg,
+		ProviderFactories: map[addrs.Provider]providers.Factory{
+			addrs.NewDefaultProvider("testing"): func() (providers.Interface, error) {
+				return stacks_testing_provider.NewProvider(t), nil
+			},
+		},
+		DependencyLocks: *lock,
+		PolicyClient:    policyEvaluationTestClient(t),
+	})
+
+	wantPolicyResults := map[string]map[string]plans.PolicyEvaluation{
+		`stack.embedded.component.simple_component["comp1"]`:                                  createExpectedComponentInstancePolicyEvaluation("policy-evaluation-embedded-stack/embedded"),
+		`stack.embedded.component.simple_component["comp2"]`:                                  createExpectedComponentInstancePolicyEvaluation("policy-evaluation-embedded-stack/embedded"),
+		`stack.embedded.provider["registry.terraform.io/hashicorp/testing"].default["comp1"]`: createExpectedProviderInstancePolicyEvaluation("policy-evaluation-embedded-stack/embedded"),
+		`stack.embedded.provider["registry.terraform.io/hashicorp/testing"].default["comp2"]`: createExpectedProviderInstancePolicyEvaluation("policy-evaluation-embedded-stack/embedded"),
 	}
 
 	if diff := cmp.Diff(gotPolicyResults, wantPolicyResults, cmp.Comparer(simplePolicyDiagCompare)); diff != "" {
@@ -7049,8 +7088,10 @@ func TestPlan_NoPolicyResultsOnRemovedComponent(t *testing.T) {
 	})
 
 	wantPolicyResults := map[string]map[string]plans.PolicyEvaluation{
-		`component.simple_component["comp1"]`: createExpectedPolicyEvaluation("policy-evaluation-removed"),
+		`component.simple_component["comp1"]`: createExpectedComponentInstancePolicyEvaluation("policy-evaluation-removed"),
 		// component.simple_component["comp2"] is removed in this config so there should be no policy result for it
+		`provider["registry.terraform.io/hashicorp/testing"].default["comp1"]`: createExpectedProviderInstancePolicyEvaluation("policy-evaluation-removed"),
+		`provider["registry.terraform.io/hashicorp/testing"].default["comp2"]`: createExpectedProviderInstancePolicyEvaluation("policy-evaluation-removed"),
 	}
 
 	if diff := cmp.Diff(gotPolicyResults, wantPolicyResults, cmp.Comparer(simplePolicyDiagCompare)); diff != "" {
@@ -7335,15 +7376,43 @@ func policyEvaluationTestClient(t *testing.T) policy.Client {
 	}
 
 	policyClient.EvaluateProviderFn = func(ctx context.Context, req policy.EvaluationRequest[*policyproto.PolicyEvaluateProviderRequest_ProviderMetadata]) policy.EvaluationResponse {
-		// TODO: Update this test to assert provider policy evaluation when we add it to the stacks runtime (follow-up PR)
-		t.Fatal("unexpected call to provider policy evaluation")
-		return policy.EvaluationResponse{}
+		// Assert provider data
+		expectedMeta := &policyproto.PolicyEvaluateProviderRequest_ProviderMetadata{
+			Name:      "testing",
+			Alias:     "default",
+			Namespace: "hashicorp",
+			Source:    "registry.terraform.io/hashicorp/testing",
+			Version:   "0.0.0",
+		}
+		if diff := cmp.Diff(req.Meta, expectedMeta, protocmp.Transform()); diff != "" {
+			t.Fatalf("unexpected provider metadata\n%s", diff)
+		}
+
+		val := req.Attrs.Raw.GetAttr("ignored")
+		if !strings.HasPrefix(val.AsString(), "comp") {
+			t.Fatalf(`unexpected resource data, wanted: attr.ignored to start with "comp", got: %q`, val.AsString())
+		}
+
+		return policy.EvaluationResponse{
+			Overall:  policy.DenyResult,
+			Policies: []*policy.Policy{policyObj(policy.DenyResult)},
+			Diagnostics: policy.DiagsFromProto([]*policyproto.Diagnostic{
+				{
+					Severity: policyproto.Severity_ERROR,
+					Summary:  "Provider policy violation",
+					Detail:   "testing provider violates policy",
+					Result: &policyproto.DiagnosticResult{
+						Result: policyproto.EvaluateResult_DENY_EVALUATE_RESULT,
+					},
+				},
+			}, nil),
+		}
 	}
 
 	return policyClient
 }
 
-func createExpectedPolicyEvaluation(bundleName string) map[string]plans.PolicyEvaluation {
+func createExpectedComponentInstancePolicyEvaluation(bundlePath string) map[string]plans.PolicyEvaluation {
 	policyObj := func(result policy.EvaluateResult) *policy.Policy {
 		return &policy.Policy{
 			Result:           result,
@@ -7356,17 +7425,17 @@ func createExpectedPolicyEvaluation(bundleName string) map[string]plans.PolicyEv
 	}
 
 	rootModuleRange := hcl.Range{
-		Filename: fmt.Sprintf("git::https://example.com/test.git//%s/main.tf", bundleName),
+		Filename: fmt.Sprintf("git::https://example.com/test.git//%s/main.tf", bundlePath),
 		Start:    hcl.Pos{Line: 14, Column: 1, Byte: 161},
 		End:      hcl.Pos{Line: 14, Column: 46, Byte: 206},
 	}
 	moduleCallRange := hcl.Range{
-		Filename: fmt.Sprintf("git::https://example.com/test.git//%s/main.tf", bundleName),
+		Filename: fmt.Sprintf("git::https://example.com/test.git//%s/main.tf", bundlePath),
 		Start:    hcl.Pos{Line: 18, Column: 1, Byte: 259},
 		End:      hcl.Pos{Line: 18, Column: 15, Byte: 273},
 	}
 	childResourceRange := hcl.Range{
-		Filename: fmt.Sprintf("git::https://example.com/test.git//%s/child/main.tf", bundleName),
+		Filename: fmt.Sprintf("git::https://example.com/test.git//%s/child/main.tf", bundlePath),
 		Start:    hcl.Pos{Line: 14, Column: 1, Byte: 161},
 		End:      hcl.Pos{Line: 14, Column: 45, Byte: 205},
 	}
@@ -7425,6 +7494,45 @@ func createExpectedPolicyEvaluation(bundleName string) map[string]plans.PolicyEv
 	}
 }
 
+func createExpectedProviderInstancePolicyEvaluation(bundlePath string) map[string]plans.PolicyEvaluation {
+	policyObj := func(result policy.EvaluateResult) *policy.Policy {
+		return &policy.Policy{
+			Result:           result,
+			PolicySetName:    "some_policy_set",
+			Address:          "policy_name",
+			Directory:        "some/path/to",
+			Filename:         "policy_file.tfpolicy.hcl",
+			EnforcementLevel: "mandatory",
+		}
+	}
+
+	providerRange := hcl.Range{
+		Filename: fmt.Sprintf("git::https://example.com/test.git//%s/main.tfcomponent.hcl", bundlePath),
+		Start:    hcl.Pos{Line: 8, Column: 1, Byte: 98},
+		End:      hcl.Pos{Line: 8, Column: 29, Byte: 126},
+	}
+
+	return map[string]plans.PolicyEvaluation{
+		`provider["registry.terraform.io/hashicorp/testing"].default`: {
+			EvaluationResponse: policy.EvaluationResponse{
+				Overall:  policy.DenyResult,
+				Policies: []*policy.Policy{policyObj(policy.DenyResult)},
+				Diagnostics: policy.DiagsFromProto([]*policyproto.Diagnostic{
+					{
+						Severity: policyproto.Severity_ERROR,
+						Summary:  "Provider policy violation",
+						Detail:   "testing provider violates policy",
+						Result: &policyproto.DiagnosticResult{
+							Result: policyproto.EvaluateResult_DENY_EVALUATE_RESULT,
+						},
+					},
+				}, nil),
+			},
+			ConfigDeclRange: providerRange,
+		},
+	}
+}
+
 func withLocalRange(diags policy.Diagnostics, rng hcl.Range) policy.Diagnostics {
 	out := make(policy.Diagnostics, len(diags))
 	for i, d := range diags {
@@ -7447,6 +7555,11 @@ func planAndCollectPolicyResults(t *testing.T, ctx context.Context, req PlanRequ
 	gotPolicyResults := make(map[string]map[string]plans.PolicyEvaluation)
 	planHooks := &Hooks{
 		ReportComponentInstancePolicyResults: func(ctx context.Context, data *hooks.ComponentInstancePolicyResults) {
+			mu.Lock()
+			defer mu.Unlock()
+			gotPolicyResults[data.Addr.String()] = maps.Collect(data.PolicyResults.Iter())
+		},
+		ReportProviderInstancePolicyResults: func(ctx context.Context, data *hooks.ProviderInstancePolicyResults) {
 			mu.Lock()
 			defer mu.Unlock()
 			gotPolicyResults[data.Addr.String()] = maps.Collect(data.PolicyResults.Iter())

--- a/internal/stacks/stackruntime/plan_test.go
+++ b/internal/stacks/stackruntime/plan_test.go
@@ -7517,7 +7517,7 @@ func createExpectedProviderInstancePolicyEvaluation(bundlePath string) map[strin
 			EvaluationResponse: policy.EvaluationResponse{
 				Overall:  policy.DenyResult,
 				Policies: []*policy.Policy{policyObj(policy.DenyResult)},
-				Diagnostics: policy.DiagsFromProto([]*policyproto.Diagnostic{
+				Diagnostics: withLocalRange(policy.DiagsFromProto([]*policyproto.Diagnostic{
 					{
 						Severity: policyproto.Severity_ERROR,
 						Summary:  "Provider policy violation",
@@ -7526,7 +7526,7 @@ func createExpectedProviderInstancePolicyEvaluation(bundlePath string) map[strin
 							Result: policyproto.EvaluateResult_DENY_EVALUATE_RESULT,
 						},
 					},
-				}, nil),
+				}, nil), providerRange),
 			},
 			ConfigDeclRange: providerRange,
 		},

--- a/internal/stacks/stackruntime/testdata/mainbundle/test/policy-evaluation-deferred/main.tfcomponent.hcl
+++ b/internal/stacks/stackruntime/testdata/mainbundle/test/policy-evaluation-deferred/main.tfcomponent.hcl
@@ -5,7 +5,13 @@ required_providers {
   }
 }
 
-provider "testing" "default" {}
+provider "testing" "default" {
+  for_each = var.component_names
+  
+  config {
+    ignored = each.key
+  }
+}
 
 variable "component_names" {
   type      = set(string)
@@ -28,6 +34,6 @@ component "simple_component" {
   }
 
   providers = {
-    testing = provider.testing.default
+    testing = provider.testing.default[each.key]
   }
 }

--- a/internal/stacks/stackruntime/testdata/mainbundle/test/policy-evaluation-embedded-stack/embedded/child/main.tf
+++ b/internal/stacks/stackruntime/testdata/mainbundle/test/policy-evaluation-embedded-stack/embedded/child/main.tf
@@ -1,0 +1,16 @@
+terraform {
+  required_providers {
+    testing = {
+      source  = "hashicorp/testing"
+      version = "0.1.0"
+    }
+  }
+}
+
+variable "name" {
+  type = string
+}
+
+resource "testing_resource" "child_resource" {
+  value = "hello from child module in ${var.name}"
+}

--- a/internal/stacks/stackruntime/testdata/mainbundle/test/policy-evaluation-embedded-stack/embedded/main.tf
+++ b/internal/stacks/stackruntime/testdata/mainbundle/test/policy-evaluation-embedded-stack/embedded/main.tf
@@ -1,0 +1,21 @@
+terraform {
+  required_providers {
+    testing = {
+      source  = "hashicorp/testing"
+      version = "0.1.0"
+    }
+  }
+}
+
+variable "name" {
+  type = string
+}
+
+resource "testing_resource" "parent_resource" {
+  value = "hello from the root of ${var.name}"
+}
+
+module "child" {
+  source = "./child"
+  name   = var.name
+}

--- a/internal/stacks/stackruntime/testdata/mainbundle/test/policy-evaluation-embedded-stack/embedded/main.tfcomponent.hcl
+++ b/internal/stacks/stackruntime/testdata/mainbundle/test/policy-evaluation-embedded-stack/embedded/main.tfcomponent.hcl
@@ -15,7 +15,6 @@ provider "testing" "default" {
 
 variable "component_names" {
   type      = set(string)
-  default = ["comp1", "comp2"]
 }
 
 component "simple_component" {

--- a/internal/stacks/stackruntime/testdata/mainbundle/test/policy-evaluation-embedded-stack/main.tfcomponent.hcl
+++ b/internal/stacks/stackruntime/testdata/mainbundle/test/policy-evaluation-embedded-stack/main.tfcomponent.hcl
@@ -1,0 +1,18 @@
+required_providers {
+  testing = {
+    source  = "hashicorp/testing"
+    version = "0.1.0"
+  }
+}
+
+stack "embedded" {
+  source = "./embedded"
+  inputs = {
+    component_names = var.component_names
+  }
+}
+
+variable "component_names" {
+  type      = set(string)
+  default = ["comp1", "comp2"]
+}

--- a/internal/stacks/stackruntime/testdata/mainbundle/test/policy-evaluation-removed/main.tfcomponent.hcl
+++ b/internal/stacks/stackruntime/testdata/mainbundle/test/policy-evaluation-removed/main.tfcomponent.hcl
@@ -5,7 +5,13 @@ required_providers {
   }
 }
 
-provider "testing" "default" {}
+provider "testing" "default" {
+  for_each = var.component_names
+  
+  config {
+    ignored = each.key
+  }
+}
 
 variable "component_names" {
   type    = set(string)
@@ -21,7 +27,7 @@ component "simple_component" {
   }
 
   providers = {
-    testing = provider.testing.default
+    testing = provider.testing.default[each.key]
   }
 }
 
@@ -31,6 +37,6 @@ removed {
   from = component.simple_component["comp2"]
 
   providers = {
-    testing = provider.testing.default
+    testing = provider.testing.default["comp2"]
   }
 }

--- a/internal/stacks/stackruntime/testdata/mainbundle/test/policy-evaluation/main.tfcomponent.hcl
+++ b/internal/stacks/stackruntime/testdata/mainbundle/test/policy-evaluation/main.tfcomponent.hcl
@@ -5,7 +5,13 @@ required_providers {
   }
 }
 
-provider "testing" "default" {}
+provider "testing" "default" {
+  for_each = var.component_names
+  
+  config {
+    ignored = each.key
+  }
+}
 
 variable "component_names" {
   type      = set(string)
@@ -21,6 +27,6 @@ component "simple_component" {
   }
 
   providers = {
-    testing = provider.testing.default
+    testing = provider.testing.default[each.key]
   }
 }

--- a/internal/terraform/node_provider.go
+++ b/internal/terraform/node_provider.go
@@ -242,17 +242,10 @@ func (n *NodeApplyableProvider) EvalPolicy(ctx EvalContext, attrs cty.Value) tfd
 	})
 
 	// if this was an "implicit provider", and we have no configuration
-	// for it, There's going to be no source information for these errors.
+	// for it, there will be no source information for any diagnostics.
 	var rng hcl.Range
 	if n.Config != nil {
 		rng = n.Config.DeclRange
-		ptr := rng.Ptr()
-		for idx, diag := range result.Diagnostics {
-			result.Diagnostics[idx] = diag.WithLocalRange(ptr)
-		}
-		for idx := range result.Enforcements {
-			result.Enforcements[idx].LocalRange = ptr
-		}
 	}
 
 	// always add the result to the policy results

--- a/internal/terraform/node_provider.go
+++ b/internal/terraform/node_provider.go
@@ -243,8 +243,10 @@ func (n *NodeApplyableProvider) EvalPolicy(ctx EvalContext, attrs cty.Value) tfd
 
 	// if this was an "implicit provider", and we have no configuration
 	// for it, There's going to be no source information for these errors.
+	var rng hcl.Range
 	if n.Config != nil {
-		ptr := n.Config.DeclRange.Ptr()
+		rng = n.Config.DeclRange
+		ptr := rng.Ptr()
 		for idx, diag := range result.Diagnostics {
 			result.Diagnostics[idx] = diag.WithLocalRange(ptr)
 		}
@@ -255,7 +257,7 @@ func (n *NodeApplyableProvider) EvalPolicy(ctx EvalContext, attrs cty.Value) tfd
 
 	// always add the result to the policy results
 	if ctx.PolicyResults() != nil {
-		ctx.PolicyResults().AddProvider(n.Addr, result, n.Config)
+		ctx.PolicyResults().AddProvider(n.Addr, result, rng)
 	}
 
 	return nil


### PR DESCRIPTION
This change adds provider policy evaluation to the stacks runtime, which is evaluated immediately following a provider being configured (equivalent to when the module runtime evaluates provider policy). Additional test cases have been added for embedded stacks, which can also configure providers.

-----

Ref #38748

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.17.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
