### PR TITLE
Fix submodule variable validation during init

### DIFF
--- a/.changes/v1.15/BUG FIXES-20260624-114503.yaml
+++ b/.changes/v1.15/BUG FIXES-20260624-114503.yaml
@@ -1,0 +1,5 @@
+kind: BUG FIXES
+body: Fix submodule variable validation during init
+time: 2026-06-24T11:45:03.408023+02:00
+custom:
+    Issue: "38770"

--- a/internal/terraform/context_init_test.go
+++ b/internal/terraform/context_init_test.go
@@ -1004,6 +1004,64 @@ module "local" {
 				VersionConstraint: mustVersionContraint(t, "1.0.0"),
 			}},
 		},
+
+		"incomplete module call config": {
+			module: map[string]string{"main.tf": `
+module "example" {
+  source = "./modules/example"
+}
+`,
+			},
+			mockedLoadModuleCalls: map[string]map[string]string{
+				"./modules/example": {
+					"main.tf": `
+variable "name" {
+  type = string
+}
+`,
+				},
+			},
+			expectLoadModuleCalls: []*configs.ModuleRequest{{
+				SourceAddr: mustModuleSource(t, "./modules/example"),
+			}},
+		},
+		"incomplete module call config with const": {
+			module: map[string]string{"main.tf": `
+module "example" {
+  source = "./modules/example"
+}
+`,
+			},
+			mockedLoadModuleCalls: map[string]map[string]string{
+				"./modules/example": {
+					"main.tf": `
+variable "name" {
+  type  = string
+  const = true
+}
+
+module "name" {
+  source = var.name
+}
+`,
+				},
+			},
+			expectLoadModuleCalls: []*configs.ModuleRequest{{
+				SourceAddr: mustModuleSource(t, "./modules/example"),
+			}},
+			expectDiags: func(m *configs.Module, mc map[string]*configs.Module) tfdiags.Diagnostics {
+				return tfdiags.Diagnostics{}.Append(&hcl.Diagnostic{
+					Severity: hcl.DiagError,
+					Summary:  "Missing required argument",
+					Detail:   `The argument "name" is required, but no definition was found.`,
+					Subject: &hcl.Range{
+						Filename: filepath.Join(m.SourceDir, "main.tf"),
+						Start:    hcl.Pos{Line: 2, Column: 18, Byte: 18},
+						End:      hcl.Pos{Line: 2, Column: 18, Byte: 18},
+					},
+				})
+			},
+		},
 	} {
 		t.Run(name, func(t *testing.T) {
 			m := testRootModuleInline(t, tc.module, tc.ignoreParsingErrors)

--- a/internal/terraform/graph_builder_init.go
+++ b/internal/terraform/graph_builder_init.go
@@ -43,7 +43,7 @@ func (b *InitGraphBuilder) Steps() []GraphTransformer {
 	} else {
 		steps = append(steps, &ModuleVariableTransformer{
 			Config:         b.Config,
-			ModuleOnly:     true,
+			Operation:      walkInit,
 			ValidateChecks: true,
 		})
 	}

--- a/internal/terraform/transform_module_variable.go
+++ b/internal/terraform/transform_module_variable.go
@@ -27,13 +27,11 @@ import (
 // position to return errors and so the validate walk should include specific
 // steps for validating module blocks, separate from this transform.
 type ModuleVariableTransformer struct {
-	Config *configs.Config
+	Config    *configs.Config
+	Operation walkOperation
 
-	// ModuleOnly, if true, makes the transformer only process the
-	// variables in the current module, skipping any child modules.
-	ModuleOnly bool
-
-	// ValidateChecks should be set to true if the graph should run the user-defined validations for child module variables
+	// ValidateChecks should be set to true if the graph should run the user
+	// defined validations for child module variables
 	ValidateChecks bool
 
 	// DestroyApply must be set to true when applying a destroy operation and
@@ -42,7 +40,9 @@ type ModuleVariableTransformer struct {
 }
 
 func (t *ModuleVariableTransformer) Transform(g *Graph) error {
-	if t.ModuleOnly && t.Config.Parent != nil {
+	// During init the transformer only processes the
+	// variables in the current module, skipping any child modules.
+	if t.Operation == walkInit && t.Config.Parent != nil {
 		return t.transformSingle(g, t.Config.Parent, t.Config)
 	} else {
 		return t.transform(g, nil, t.Config)
@@ -93,9 +93,15 @@ func (t *ModuleVariableTransformer) transformSingle(g *Graph, parent, c *configs
 	// decode the content of the call block.
 	schema := &hcl.BodySchema{}
 	for _, v := range c.Module.Variables {
+		required := v.Default == cty.NilVal
+		if t.Operation == walkInit {
+			// During init we only want require const variables
+			required = required && v.Const
+		}
+
 		schema.Attributes = append(schema.Attributes, hcl.AttributeSchema{
 			Name:     v.Name,
-			Required: v.Default == cty.NilVal,
+			Required: required,
 		})
 	}
 


### PR DESCRIPTION
This PR fixes a regression introduced in 1.15.x. During init we only care about const variables. Even if a module call is missing a required variable, it shouldn't block init as long as the variable isn't used as a module source.

Later operations like `validate` or `plan` will flag the invalid configuration.

Fixes #38689

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.15.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [x] This change is user-facing and I added a changelog entry.
- [ ] This change is not user-facing.
