### PR TITLE
Enable re-use of provider installation logic by introducing the `views.ProviderInstaller` interface

### DIFF
--- a/internal/command/init.go
+++ b/internal/command/init.go
@@ -300,7 +300,6 @@ func (c *InitCommand) initBackend(ctx context.Context, root *configs.Module, ini
 }
 
 func (c *InitCommand) Validate(args *arguments.Init) (diags tfdiags.Diagnostics) {
-
 	diags = diags.Append(validatePolicyPaths(args.PolicyPaths, c.AllowExperimentalFeatures))
 	return diags
 }
@@ -726,7 +725,7 @@ func (c *InitCommand) getProviders(ctx context.Context, config *configs.Config, 
 // saveDependencyLockFile overwrites the contents of the dependency lock file.
 // The calling code is expected to provide the previous locks (if any) and the two sets of locks determined from
 // configuration and state data.
-func (c *InitCommand) saveDependencyLockFile(previousLocks, pssLock, providerLocks *depsfile.Locks, flagLockfile string, view views.Init) (output bool, diags tfdiags.Diagnostics) {
+func (c *InitCommand) saveDependencyLockFile(previousLocks, pssLock, providerLocks *depsfile.Locks, flagLockfile string, view views.ProviderInstaller) (output bool, diags tfdiags.Diagnostics) {
 	// Get the combination of locks from both potential provider download steps.
 	newLocks := c.mergeLockedDependencies(pssLock, providerLocks)
 
@@ -1035,14 +1034,14 @@ func (c *InitCommand) Synopsis() string {
 }
 
 // Returns a reused callback function for the ProviderAlreadyInstalled event in a providercache.InstallerEvents struct.
-func providerAlreadyInstalledCallback(view views.Init) func(provider addrs.Provider, selectedVersion getproviders.Version) {
+func providerAlreadyInstalledCallback(view views.ProviderInstaller) func(provider addrs.Provider, selectedVersion getproviders.Version) {
 	return func(provider addrs.Provider, selectedVersion getproviders.Version) {
 		view.LogInitMessage(views.ProviderAlreadyInstalledMessage, provider.ForDisplay(), selectedVersion)
 	}
 }
 
 // Returns a reused callback function for the BuiltInProviderAvailable event in a providercache.InstallerEvents struct.
-func builtInProviderAvailableCallback(view views.Init) func(provider addrs.Provider) {
+func builtInProviderAvailableCallback(view views.ProviderInstaller) func(provider addrs.Provider) {
 	return func(provider addrs.Provider) {
 		view.LogInitMessage(views.BuiltInProviderAvailableMessage, provider.ForDisplay())
 	}
@@ -1060,14 +1059,14 @@ func builtInProviderFailureCallback(diags *tfdiags.Diagnostics) func(provider ad
 }
 
 // Returns a reused callback function for the LinkFromCacheBegin event in a providercache.InstallerEvents struct.
-func linkFromCacheBeginCallback(view views.Init) func(provider addrs.Provider, version getproviders.Version, cacheRoot string) {
+func linkFromCacheBeginCallback(view views.ProviderInstaller) func(provider addrs.Provider, version getproviders.Version, cacheRoot string) {
 	return func(provider addrs.Provider, version getproviders.Version, cacheRoot string) {
 		view.LogInitMessage(views.UsingProviderFromCacheDirInfo, provider.ForDisplay(), version)
 	}
 }
 
 // Returns a reused callback function for the FetchPackageBegin event in a providercache.InstallerEvents struct.
-func fetchPackageBeginCallback(view views.Init) func(provider addrs.Provider, version getproviders.Version, location getproviders.PackageLocation) {
+func fetchPackageBeginCallback(view views.ProviderInstaller) func(provider addrs.Provider, version getproviders.Version, location getproviders.PackageLocation) {
 	return func(provider addrs.Provider, version getproviders.Version, location getproviders.PackageLocation) {
 		view.LogInitMessage(views.InstallingProviderMessage, provider.ForDisplay(), version)
 	}
@@ -1308,7 +1307,7 @@ func fetchPackageFailureCallback(diags *tfdiags.Diagnostics, reqs getproviders.R
 }
 
 // Returns a reused callback function for the FetchPackageSuccess event in a providercache.InstallerEvents struct.
-func fetchPackageSuccessCallback(view views.Init) func(provider addrs.Provider, version getproviders.Version, localDir string, authResult *getproviders.PackageAuthenticationResult) {
+func fetchPackageSuccessCallback(view views.ProviderInstaller) func(provider addrs.Provider, version getproviders.Version, localDir string, authResult *getproviders.PackageAuthenticationResult) {
 	return func(provider addrs.Provider, version getproviders.Version, localDir string, authResult *getproviders.PackageAuthenticationResult) {
 		var keyID string
 		if authResult != nil && authResult.ThirdPartySigned() {
@@ -1362,7 +1361,7 @@ func providersLockUpdatedCallback(incompleteProviders *[]string) func(provider a
 }
 
 // Returns a reused callback function for the ProvidersFetched event in a providercache.InstallerEvents struct.
-func providersFetchedCallback(view views.Init) func(authResults map[addrs.Provider]*getproviders.PackageAuthenticationResult) {
+func providersFetchedCallback(view views.ProviderInstaller) func(authResults map[addrs.Provider]*getproviders.PackageAuthenticationResult) {
 	return func(authResults map[addrs.Provider]*getproviders.PackageAuthenticationResult) {
 		thirdPartySigned := false
 		for _, authResult := range authResults {

--- a/internal/command/init.go
+++ b/internal/command/init.go
@@ -705,7 +705,6 @@ func (c *InitCommand) getProviders(ctx context.Context, config *configs.Config, 
 	newLocks, err := inst.EnsureProviderVersions(ctx, inProgressLocks, reqs, mode, installerHook)
 	if ctx.Err() == context.Canceled {
 		diags = diags.Append(fmt.Errorf("Provider installation was canceled by an interrupt signal."))
-		view.Diagnostics(diags)
 		return true, nil, diags
 	}
 	if err != nil {

--- a/internal/command/views/init.go
+++ b/internal/command/views/init.go
@@ -13,6 +13,18 @@ import (
 	"github.com/hashicorp/terraform/internal/tfdiags"
 )
 
+// ProviderInstaller is an interface that describes the methods required by a view that's used
+// with provider installation methods.
+//
+// The method names here are constrained by the Init view interface, which is coupled to the
+// provider installation process. In a future major version of Terraform this could be improved.
+// See: https://github.com/hashicorp/terraform/issues/38763
+type ProviderInstaller interface {
+	LogInitMessage(messageCode InitMessageCode, params ...any)
+	Output(messageCode InitMessageCode, params ...any)
+	PrepareMessage(messageCode InitMessageCode, params ...any) string
+}
+
 // The Init view is used for the init command.
 type Init interface {
 	Diagnostics(diags tfdiags.Diagnostics)
@@ -45,7 +57,10 @@ type InitHuman struct {
 	view *View
 }
 
-var _ Init = (*InitHuman)(nil)
+var (
+	_ Init              = (*InitHuman)(nil)
+	_ ProviderInstaller = (*InitHuman)(nil)
+)
 
 func (v *InitHuman) Diagnostics(diags tfdiags.Diagnostics) {
 	v.view.Diagnostics(diags)
@@ -89,7 +104,10 @@ type InitJSON struct {
 	view *JSONView
 }
 
-var _ Init = (*InitJSON)(nil)
+var (
+	_ Init              = (*InitJSON)(nil)
+	_ ProviderInstaller = (*InitJSON)(nil)
+)
 
 func (v *InitJSON) Diagnostics(diags tfdiags.Diagnostics) {
 	v.view.Diagnostics(diags)


### PR DESCRIPTION
This PR is part of decomposing this work https://github.com/hashicorp/terraform/pull/38761 in smaller, easier to review bits.

In this PR I'm updating some provider download/installation related logic to no longer expect an _init_ view implementation as a parameter. Instead, these methods should accept an interface that describes what a view -any view from any command- can do and that it's capable of creating the output generated by the installation process.

So, I've added the `views.ProviderInstaller` interface for that purpose. This interface is just the subset of methods from the `views.Init` interface that were used in the installation logic that I'm editing. In my future PR updating the `state migrate` command I'll make that command's view implement this interface.

Here's the interface:

```go
type ProviderInstaller interface {
	LogInitMessage(messageCode InitMessageCode, params ...any)
	Output(messageCode InitMessageCode, params ...any)
	PrepareMessage(messageCode InitMessageCode, params ...any) string
}
```

Yeah, it's gross. Ideally there would be methods more specific to installation events, and ideally nothing containing the command name "init" as the whole purpose of this work is trying to avoid logic being coupled to specific commands. But fixing this would be a breaking change, so we get the dodgy looking interface. For more info see: https://github.com/hashicorp/terraform/issues/38763


## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.16.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
