### PR TITLE
Ensure policies only close the state after all other nodes that may mutate the state are complete

### DIFF
--- a/internal/backend/local/backend_apply.go
+++ b/internal/backend/local/backend_apply.go
@@ -450,10 +450,9 @@ func (b *Local) opApply(
 	diags = diags.Append(applyDiags)
 
 	// Print the policy results we found during apply
-	var polRenderSpan trace.Span
 	polRenderSpanEnd := func() {}
 	if policyResultCount := policyResults.Len(); policyResultCount > 0 {
-		_, polRenderSpan = tracer().Start(stopCtx, "terraform.local.apply.render_policy_results",
+		_, polRenderSpan := tracer().Start(stopCtx, "terraform.local.apply.render_policy_results",
 			trace.WithAttributes(
 				attribute.Int("apply.policy_results", policyResultCount),
 			),

--- a/internal/backend/local/backend_apply.go
+++ b/internal/backend/local/backend_apply.go
@@ -427,6 +427,9 @@ func (b *Local) opApply(
 	var applyState *states.State
 	var applyDiags tfdiags.Diagnostics
 
+	// We use a new store for the apply policy results, as objects that failed during the plan policy
+	// evaluation may have updated data which yields a different policy evaluation result.
+	policyResults := plans.NewPolicyResults()
 	doneCh := make(chan struct{})
 	go func() {
 		defer logging.PanicHandler()
@@ -437,7 +440,7 @@ func (b *Local) opApply(
 			SetVariables:  applyTimeValues,
 			ProviderLocks: providerLocksSnapshot(op.DependencyLocks),
 			PolicyClient:  lr.PolicyClient,
-			PolicyResults: plan.PolicyResults,
+			PolicyResults: policyResults,
 		})
 	}()
 
@@ -448,8 +451,8 @@ func (b *Local) opApply(
 
 	// Print the policy results we found during apply
 	policyResultCount := 0
-	if plan.PolicyResults != nil {
-		policyResultCount = plan.PolicyResults.Len()
+	if policyResults != nil {
+		policyResultCount = policyResults.Len()
 	}
 	var polRenderSpan trace.Span
 	polRenderSpanEnd := func() {}
@@ -461,7 +464,7 @@ func (b *Local) opApply(
 		)
 		polRenderSpanEnd = func() { polRenderSpan.End() }
 	}
-	op.View.PolicyResults(plan.PolicyResults, nil)
+	op.View.PolicyResults(policyResults, nil)
 	polRenderSpanEnd()
 
 	// Even on error with an empty state, the state value should not be nil.

--- a/internal/backend/local/backend_apply.go
+++ b/internal/backend/local/backend_apply.go
@@ -450,13 +450,9 @@ func (b *Local) opApply(
 	diags = diags.Append(applyDiags)
 
 	// Print the policy results we found during apply
-	policyResultCount := 0
-	if policyResults != nil {
-		policyResultCount = policyResults.Len()
-	}
 	var polRenderSpan trace.Span
 	polRenderSpanEnd := func() {}
-	if policyResultCount > 0 {
+	if policyResultCount := policyResults.Len(); policyResultCount > 0 {
 		_, polRenderSpan = tracer().Start(stopCtx, "terraform.local.apply.render_policy_results",
 			trace.WithAttributes(
 				attribute.Int("apply.policy_results", policyResultCount),

--- a/internal/command/apply_policy_test.go
+++ b/internal/command/apply_policy_test.go
@@ -155,6 +155,132 @@ func TestApply_WithPolicyDiagnosticsJSON(t *testing.T) {
 	checkGoldenReferenceStr(t, output, expected)
 }
 
+func TestApply_PolicyResultsJSON_WithSavedPlan(t *testing.T) {
+	td := t.TempDir()
+	testCopyDir(t, testFixturePath("plan"), td)
+	t.Chdir(td)
+	policyCode := `		resource_policy "resource_type" "policy_name" {
+		  enforce_attrs {
+		    key = attr.value == "foo"
+		  }
+		}
+	`
+	if err := os.WriteFile("policy.hcl", []byte(policyCode), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	p := planFixtureProvider()
+
+	planView, planDone := testView(t)
+	planOverrides := metaOverridesForProvider(p)
+	planOverrides.PolicyClient = policy.NewTestMockClient(t)
+	planCmd := &PlanCommand{
+		Meta: Meta{
+			testingOverrides:          planOverrides,
+			View:                      planView,
+			AllowExperimentalFeatures: true,
+		},
+	}
+	if code := planCmd.Run([]string{"-policies", td, "-no-color", "-out=planfile"}); code != 0 {
+		output := planDone(t)
+		t.Fatalf("plan failed: %d\n\n%s", code, output.All())
+	}
+	_ = planDone(t)
+
+	applyView, applyDone := testView(t)
+	applyOverrides := metaOverridesForProvider(p)
+	applyPolicyClient := policy.NewTestMockClient(t)
+	applyOverrides.PolicyClient = applyPolicyClient
+	applyCmd := &ApplyCommand{
+		Meta: Meta{
+			testingOverrides:          applyOverrides,
+			View:                      applyView,
+			AllowExperimentalFeatures: true,
+		},
+	}
+
+	resp := policy.EvaluationFromProtoResponse(
+		proto.EvaluateResult_DENY_EVALUATE_RESULT, []*proto.PolicyEvaluationDetail{
+			{
+				Address:              "resource_policy.foo",
+				Result:               proto.EvaluateResult_DENY_EVALUATE_RESULT,
+				File:                 "policy_file.tfpolicy.hcl",
+				PolicySetEnforcement: "mandatory",
+				DefRange: &proto.Range{
+					Filename: "policy_file.tfpolicy.hcl",
+					Start: &proto.Position{
+						Line:   1,
+						Column: 1,
+					},
+					End: &proto.Position{
+						Line:   2,
+						Column: 4,
+					},
+				},
+				EnforceResults: []*proto.EnforceBlockResult{
+					{
+						Result:     proto.EvaluateResult_DENY_EVALUATE_RESULT,
+						BlockIndex: 1,
+						Diagnostics: []*proto.Diagnostic{
+							{
+								Severity: proto.Severity_ERROR,
+								Summary:  "policy denied",
+								Result: &proto.DiagnosticResult{
+									Result: proto.EvaluateResult_DENY_EVALUATE_RESULT,
+								},
+								Subject: &proto.Range{
+									Filename: "policy_file.tfpolicy.hcl",
+									Start: &proto.Position{
+										Line:   1,
+										Column: 1,
+									},
+									End: &proto.Position{
+										Line:   2,
+										Column: 4,
+									},
+								},
+								Context: &proto.Range{
+									Filename: "policy_file.tfpolicy.hcl",
+									Start: &proto.Position{
+										Line:   1,
+										Column: 1,
+									},
+									End: &proto.Position{
+										Line:   4,
+										Column: 10,
+									},
+								},
+								Snippet: &proto.Snippet{
+									Code:                 policyCode,
+									StartLine:            1,
+									HighlightStartOffset: 1,
+									HighlightEndOffset:   100,
+								},
+							},
+						},
+					},
+				},
+			},
+		})
+	applyPolicyClient.EvaluateResponse = &resp
+
+	code := applyCmd.Run([]string{"-policies", td, "-no-color", "-json", "-auto-approve", "planfile"})
+	output := applyDone(t)
+	if code != 0 {
+		t.Fatalf("apply failed: %d\n\n%s", code, output.All())
+	}
+
+	expected := `{"@level":"info","@message":"Terraform 1.16.0-dev","@module":"terraform.ui","terraform":"1.16.0-dev","type":"version","ui":"1.3"}
+{"@level":"info","@message":"test_instance.foo: Plan to create","@module":"terraform.ui","change":{"resource":{"addr":"test_instance.foo","module":"","resource":"test_instance.foo","implied_provider":"test","resource_type":"test_instance","resource_name":"foo","resource_key":null},"action":"create"},"type":"planned_change"}
+{"@level":"info","@message":"test_instance.foo: Creating...","@module":"terraform.ui","hook":{"resource":{"addr":"test_instance.foo","module":"","resource":"test_instance.foo","implied_provider":"test","resource_type":"test_instance","resource_name":"foo","resource_key":null},"action":"create"},"type":"apply_start"}
+{"@level":"info","@message":"test_instance.foo: Creation complete after 0s","@module":"terraform.ui","hook":{"resource":{"addr":"test_instance.foo","module":"","resource":"test_instance.foo","implied_provider":"test","resource_type":"test_instance","resource_name":"foo","resource_key":null},"action":"create","elapsed_seconds":0},"type":"apply_complete"}
+{"@level":"error","@message":"Error: policy denied","@module":"terraform.ui","@policy":"true","policy_diagnostic":{"severity":"error","summary":"policy denied","detail":"","range":{"filename":"main.tf","start":{"line":1,"column":1,"byte":0},"end":{"line":1,"column":31,"byte":30}},"snippet":{"context":null,"code":"resource \"test_instance\" \"foo\" {","start_line":1,"highlight_start_offset":0,"highlight_end_offset":30,"values":[]},"policy_range":{"filename":"policy_file.tfpolicy.hcl","start":{"line":1,"column":1,"byte":0},"end":{"line":2,"column":4,"byte":0}},"policy_snippet":{"context":null,"code":"\t\tresource_policy \"resource_type\" \"policy_name\" {\n\t\t  enforce_attrs {\n\t\t    key = attr.value == \"foo\"\n\t\t  }\n\t\t}\n\t","start_line":1,"highlight_start_offset":1,"highlight_end_offset":100,"values":null}},"policy_metadata":{"policy_set_path":"policy_file.tfpolicy.hcl","policy_name":"resource_policy.foo","file_name":"policy_file.tfpolicy.hcl","enforcement_level":"mandatory","enforce_index":1},"result":"DenyResult","target_address":"test_instance.foo","type":"policy_diagnostic"}
+{"@level":"info","@message":"Policy Result","@module":"terraform.ui","@policy":"true","policy_address":"resource_policy.foo","policy_metadata":{"policy_set_path":"policy_file.tfpolicy.hcl","policy_name":"resource_policy.foo","file_name":"policy_file.tfpolicy.hcl","enforcement_level":"mandatory"},"result":"DenyResult","target_address":"test_instance.foo","type":"policy_result"}
+{"@level":"info","@message":"Apply complete! Resources: 1 added, 0 changed, 0 destroyed.","@module":"terraform.ui","changes":{"add":1,"change":0,"import":0,"remove":0,"action_invocation":0,"operation":"apply"},"type":"change_summary"}
+{"@level":"info","@message":"Outputs: 0","@module":"terraform.ui","outputs":{},"type":"outputs"}`
+	checkGoldenReferenceStr(t, output, expected)
+}
+
 func TestApply_WithPolicyClientStopAfterApply(t *testing.T) {
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("plan"), td)

--- a/internal/plans/policy.go
+++ b/internal/plans/policy.go
@@ -15,7 +15,7 @@ import (
 
 // PolicyResults represents the results of policy evaluation of resources, modules, and providers for a single plan.
 type PolicyResults struct {
-	mu   *sync.Mutex
+	mu   sync.Mutex
 	set  addrs.Map[addrs.AbsResourceInstance, PolicyEvaluation]
 	pset addrs.Map[addrs.AbsProviderConfig, PolicyEvaluation]
 	mset addrs.Map[addrs.Module, PolicyEvaluation]
@@ -29,7 +29,7 @@ type PolicyEvaluation struct {
 
 func NewPolicyResults() *PolicyResults {
 	return &PolicyResults{
-		mu:   &sync.Mutex{},
+		mu:   sync.Mutex{},
 		set:  addrs.MakeMap[addrs.AbsResourceInstance, PolicyEvaluation](),
 		pset: addrs.MakeMap[addrs.AbsProviderConfig, PolicyEvaluation](),
 		mset: addrs.MakeMap[addrs.Module, PolicyEvaluation](),

--- a/internal/terraform/graph_builder_apply_test.go
+++ b/internal/terraform/graph_builder_apply_test.go
@@ -110,6 +110,9 @@ func TestApplyGraphBuilder_PolicyClient(t *testing.T) {
 		if nodes := len(policyNode.Collect()); nodes != 1 {
 			t.Fatalf("expected 1 policy evaluation node in apply graph with policy client, got %d", nodes)
 		}
+
+		testGraphHappensBefore(t, g, "module.child (close)", "(evaluate policies)")
+		testGraphHappensBefore(t, g, "(evaluate policies)", "provider[\"registry.terraform.io/hashicorp/test\"] (close)")
 	})
 
 	t.Run("without policy client", func(t *testing.T) {

--- a/internal/terraform/graph_builder_plan_test.go
+++ b/internal/terraform/graph_builder_plan_test.go
@@ -129,6 +129,8 @@ func TestPlanGraphBuilder_PolicyClient(t *testing.T) {
 		if nodes := len(policyNode.Collect()); nodes != 1 {
 			t.Fatalf("expected 1 policy evaluation node in plan graph with policy client, got %d", nodes)
 		}
+
+		testGraphHappensBefore(t, g, "output.instance_id (expand)", "(evaluate policies)")
 	})
 
 	t.Run("without policy client", func(t *testing.T) {

--- a/internal/terraform/graph_builder_plan_test.go
+++ b/internal/terraform/graph_builder_plan_test.go
@@ -104,6 +104,15 @@ func TestPlanGraphBuilder_PolicyClient(t *testing.T) {
 				"aws_instance":       {Body: simpleTestSchema()},
 				"aws_load_balancer":  {Body: simpleTestSchema()},
 			},
+			DataSources: map[string]providers.Schema{
+				"aws_data_source": {
+					Body: &configschema.Block{
+						Attributes: map[string]*configschema.Attribute{
+							"id": {Type: cty.String, Optional: true, Computed: true},
+						},
+					},
+				},
+			},
 		},
 	}
 	openstackProvider := mockProviderWithResourceTypeSchema("openstack_floating_ip", simpleTestSchema())
@@ -149,6 +158,74 @@ func TestPlanGraphBuilder_PolicyClient(t *testing.T) {
 		if nodes := len(policyNode.Collect()); nodes != 0 {
 			t.Fatalf("expected 0 policy evaluation nodes in plan graph without policy client, got %d", nodes)
 		}
+	})
+
+	t.Run("Data source before policy", func(t *testing.T) {
+		config := testModuleInline(t, map[string]string{
+			"main.tf": `
+resource "aws_instance" "foo" {
+  ami = "bar"
+}
+
+data "aws_data_source" "a" {
+  id = "zzzzz"
+}
+`,
+		})
+
+		b := &PlanGraphBuilder{
+			Config:       config,
+			Plugins:      plugins,
+			PolicyClient: policy.NewTestMockClient(t),
+			Operation:    walkPlan,
+		}
+
+		g, diags := b.Build(addrs.RootModuleInstance)
+		if diags.HasErrors() {
+			t.Fatalf("err: %s", diags.Err())
+		}
+
+		testGraphHappensBefore(t, g, "data.aws_data_source.a (expand)", "(evaluate policies)")
+		testGraphHappensBefore(t, g, "(evaluate policies)", "provider[\"registry.terraform.io/hashicorp/aws\"] (close)")
+	})
+
+	t.Run("Output evaluates before policy", func(t *testing.T) {
+		config := testModuleInline(t, map[string]string{
+			"main.tf": `
+resource "aws_instance" "foo" {
+  ami = "bar"
+}
+
+module "child" {
+  source = "./child"
+}
+`,
+			"child/main.tf": `
+data "aws_data_source" "a" {
+  id = "zzzzz"
+}
+
+output "value" {
+  value = data.aws_data_source.a.id
+}
+`,
+		})
+
+		b := &PlanGraphBuilder{
+			Config:       config,
+			Plugins:      plugins,
+			PolicyClient: policy.NewTestMockClient(t),
+			Operation:    walkPlan,
+		}
+
+		g, diags := b.Build(addrs.RootModuleInstance)
+		if diags.HasErrors() {
+			t.Fatalf("err: %s", diags.Err())
+		}
+
+		testGraphHappensBefore(t, g, "module.child.output.value (expand)", "(evaluate policies)")
+		testGraphHappensBefore(t, g, "module.child.data.aws_data_source.a (expand)", "(evaluate policies)")
+		testGraphHappensBefore(t, g, "module.child (close)", "(evaluate policies)")
 	})
 }
 

--- a/internal/terraform/transform_policy_eval.go
+++ b/internal/terraform/transform_policy_eval.go
@@ -4,6 +4,7 @@
 package terraform
 
 import (
+	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/dag"
 	"github.com/hashicorp/terraform/internal/policy"
 )
@@ -33,7 +34,7 @@ func (t *policyEvalTransformer) Transform(g *Graph) error {
 	var closeProviderNodes []dag.Vertex
 
 	for v := range g.VerticesSeq() {
-		if _, ok := v.(GraphNodeConfigResource); ok {
+		if node, ok := v.(GraphNodeConfigResource); ok && node.ResourceAddr().Resource.Mode == addrs.ManagedResourceMode {
 			terminalNodes = append(terminalNodes, v)
 			hasManagedResourceNode = true
 			continue

--- a/internal/terraform/transform_policy_eval.go
+++ b/internal/terraform/transform_policy_eval.go
@@ -23,34 +23,49 @@ func (t *policyEvalTransformer) Transform(g *Graph) error {
 		return nil
 	}
 
-	// Collect all managed resource instance nodes and all provider closer
-	// nodes that are already in the graph.
-	var resourceNodes []dag.Vertex
+	// Collect all provider closer nodes and all of the terminal nodes in the
+	// main graph, ignoring provider closer nodes. The policy node must wait for
+	// those terminal nodes so that all mutations to changes and state are
+	// complete before policy evaluation closes those objects for read-only
+	// callbacks.
+	var hasManagedResourceNode bool
+	var terminalNodes []dag.Vertex
 	var closeProviderNodes []dag.Vertex
 
 	for v := range g.VerticesSeq() {
 		if _, ok := v.(GraphNodeConfigResource); ok {
-			resourceNodes = append(resourceNodes, v)
+			terminalNodes = append(terminalNodes, v)
+			hasManagedResourceNode = true
+			continue
 		}
 
+		// select close provider nodes
 		if _, ok := v.(GraphNodeCloseProvider); ok {
 			closeProviderNodes = append(closeProviderNodes, v)
+			continue
+		}
+
+		// select terminal nodes
+		if g.UpEdges(v).Len() == 0 {
+			terminalNodes = append(terminalNodes, v)
+			continue
 		}
 	}
 
 	// If there are no managed resources at all, there is nothing to evaluate
 	// policy against.
-	if len(resourceNodes) == 0 {
+	if !hasManagedResourceNode {
 		return nil
 	}
 
 	policyNode := &nodePolicyEval{}
 	g.Add(policyNode)
 
-	// Connect every resource node to the policy node,
-	// so that the policy node executes after every managed resource instance node.
-	for _, rsNode := range resourceNodes {
-		g.Connect(dag.BasicEdge(policyNode, rsNode))
+	// Connect the policy node to every terminal node so that it
+	// executes only after all remaining graph work that can still mutate state
+	// or changes has completed.
+	for _, node := range terminalNodes {
+		g.Connect(dag.BasicEdge(policyNode, node))
 	}
 
 	// We keep the provider open until after policy evaluation so that the

--- a/internal/terraform/transform_policy_eval.go
+++ b/internal/terraform/transform_policy_eval.go
@@ -4,7 +4,6 @@
 package terraform
 
 import (
-	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/dag"
 	"github.com/hashicorp/terraform/internal/policy"
 )
@@ -23,57 +22,26 @@ func (t *policyEvalTransformer) Transform(g *Graph) error {
 	if t.PolicyClient == nil {
 		return nil
 	}
-
-	// Collect all provider closer nodes and all of the terminal nodes in the
-	// main graph, ignoring provider closer nodes. The policy node must wait for
-	// those terminal nodes so that all mutations to changes and state are
-	// complete before policy evaluation closes those objects for read-only
-	// callbacks.
-	var hasManagedResourceNode bool
-	var terminalNodes []dag.Vertex
-	var closeProviderNodes []dag.Vertex
-
-	for v := range g.VerticesSeq() {
-		if node, ok := v.(GraphNodeConfigResource); ok && node.ResourceAddr().Resource.Mode == addrs.ManagedResourceMode {
-			terminalNodes = append(terminalNodes, v)
-			hasManagedResourceNode = true
-			continue
-		}
-
-		// select close provider nodes
-		if _, ok := v.(GraphNodeCloseProvider); ok {
-			closeProviderNodes = append(closeProviderNodes, v)
-			continue
-		}
-
-		// select terminal nodes
-		if g.UpEdges(v).Len() == 0 {
-			terminalNodes = append(terminalNodes, v)
-			continue
-		}
-	}
-
-	// If there are no managed resources at all, there is nothing to evaluate
-	// policy against.
-	if !hasManagedResourceNode {
-		return nil
-	}
-
 	policyNode := &nodePolicyEval{}
 	g.Add(policyNode)
 
-	// Connect the policy node to every terminal node so that it
-	// executes only after all remaining graph work that can still mutate state
-	// or changes has completed.
-	for _, node := range terminalNodes {
-		g.Connect(dag.BasicEdge(policyNode, node))
-	}
+	for v := range g.VerticesSeq() {
+		if v == policyNode {
+			continue
+		}
+		// Connect provider closer nodes to policy so that
+		// we keep all providers open until after policy evaluation so that the
+		// policy engine callbacks can still use them. For example, policies may need to access data
+		// sources of a provider.
+		if _, ok := v.(GraphNodeCloseProvider); ok {
+			g.Connect(dag.BasicEdge(v, policyNode))
+			continue
+		}
 
-	// We keep the provider open until after policy evaluation so that the
-	// policy engine callbacks can still use them. For example, policies may need to access data
-	// sources of a provider.
-	for _, providerNode := range closeProviderNodes {
-		g.Connect(dag.BasicEdge(providerNode, policyNode))
+		// Connect the policy node to every non-provider closer node so that it
+		// executes only after all remaining graph work that can still mutate state
+		// or changes has completed.
+		g.Connect(dag.BasicEdge(policyNode, v))
 	}
 
 	return nil


### PR DESCRIPTION


<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

In previous PRs, To mitigate lock contention during callbacks, we "close" the state and changes object from mutation, allowing reads without locks. That worked because we ensured that the policy only closes the state after all state changes from resource nodes. However, some other nodes (such as outputs) also mutate the state objects, so now we just ensure policy is run after all nodes besides provider closers.

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.16.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [ ] This change is not user-facing.
