### PR TITLE
suppress deprecation messages from child module outputs when whole resource is output 

### DIFF
--- a/.changes/v1.16/ENHANCEMENTS-20260624-130421.yaml
+++ b/.changes/v1.16/ENHANCEMENTS-20260624-130421.yaml
@@ -1,5 +1,5 @@
 kind: ENHANCEMENTS
-body: deprecations: child module outputs with unreferenced deprecated nested attributes no longer return deprecation warnings.
+body: child module outputs with unreferenced deprecated nested attributes no longer return deprecation warnings.
 time: 2026-06-24T13:04:21.373803-04:00
 custom:
     Issue: "38778"

--- a/.changes/v1.16/ENHANCEMENTS-20260624-130421.yaml
+++ b/.changes/v1.16/ENHANCEMENTS-20260624-130421.yaml
@@ -1,0 +1,5 @@
+kind: ENHANCEMENTS
+body: deprecations: child module outputs with unreferenced deprecated nested attributes no longer return deprecation warnings.
+time: 2026-06-24T13:04:21.373803-04:00
+custom:
+    Issue: "38778"

--- a/internal/deprecation/deprecation.go
+++ b/internal/deprecation/deprecation.go
@@ -7,11 +7,12 @@ import (
 	"sync"
 
 	"github.com/hashicorp/hcl/v2"
+	"github.com/zclconf/go-cty/cty"
+
 	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/configs/configschema"
 	"github.com/hashicorp/terraform/internal/lang/marks"
 	"github.com/hashicorp/terraform/internal/tfdiags"
-	"github.com/zclconf/go-cty/cty"
 )
 
 // Deprecations keeps track of meta-information related to deprecation, e.g. which module calls

--- a/internal/terraform/context_plan2_test.go
+++ b/internal/terraform/context_plan2_test.go
@@ -7935,3 +7935,61 @@ locals {
 		},
 	}))
 }
+
+func TestContext2Plan_deprecated_child_output_attr_in_root(t *testing.T) {
+	// This passes validation (see
+	// TestContext2Validate_deprecatedAttr/referencing nested deprecated attr in
+	// child module output) but should error during plan.
+	m := testModuleInline(t, map[string]string{
+		"main.tf": `
+			module "child" {
+				source = "./child"
+			}
+
+			output "deprecated" {
+				value = module.child.deprecated.foo
+			}
+			`,
+
+		"child/main.tf": `
+            resource "aws_instance" "test" {
+            }
+            output "deprecated" {
+              value = aws_instance.test
+            }
+             `,
+	})
+
+	p := testProvider("aws")
+	p.GetProviderSchemaResponse = getProviderSchemaResponseFromProviderSchema(&providerSchema{
+		ResourceTypes: map[string]*configschema.Block{
+			"aws_instance": {
+				Attributes: map[string]*configschema.Attribute{
+					"foo": {Type: cty.String, Optional: true, Deprecated: true},
+				},
+			},
+		},
+	})
+
+	ctx := testContext2(t, &ContextOpts{
+		Providers: map[addrs.Provider]providers.Factory{
+			addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
+		},
+	})
+
+	_, diags := ctx.Plan(m, nil, SimplePlanOpts(plans.NormalMode, InputValues{}))
+	if !diags.HasWarnings() {
+		t.Fatal("missing expected warnings!")
+	} else {
+		tfdiags.AssertDiagnosticsMatch(t, diags, tfdiags.Diagnostics{}.Append(&hcl.Diagnostic{
+			Severity: hcl.DiagWarning,
+			Summary:  `Deprecated value used`,
+			Detail:   `Deprecated resource attribute "foo" used. Refer to the provider documentation for details.`,
+			Subject: &hcl.Range{
+				Filename: filepath.Join(m.Module.SourceDir, "main.tf"),
+				Start:    hcl.Pos{Line: 7, Column: 13, Byte: 87},
+				End:      hcl.Pos{Line: 7, Column: 40, Byte: 114},
+			},
+		}))
+	}
+}

--- a/internal/terraform/context_validate_test.go
+++ b/internal/terraform/context_validate_test.go
@@ -2497,8 +2497,6 @@ func TestContext2Validate_deprecatedAttr(t *testing.T) {
 		blockSchema             map[string]*configschema.NestedBlock
 		module                  map[string]string
 		expectedValidationDiags func(*configs.Config) tfdiags.Diagnostics
-		expectedPlanDiags       func(*configs.Config) tfdiags.Diagnostics
-		expectedApplyDiags      func(*configs.Config) tfdiags.Diagnostics
 	}{
 		"in locals": {
 			attributeSchema: map[string]*configschema.Attribute{
@@ -2610,9 +2608,6 @@ func TestContext2Validate_deprecatedAttr(t *testing.T) {
 					},
 				})
 			},
-			// During apply we take the planned value for the output. Since the plan
-			// does not contain marks we can not detect this usage at apply time.
-			expectedApplyDiags: func(c *configs.Config) tfdiags.Diagnostics { return tfdiags.Diagnostics{} },
 		},
 
 		"in resource attribute": {
@@ -2663,18 +2658,6 @@ func TestContext2Validate_deprecatedAttr(t *testing.T) {
             }
              `,
 			},
-			expectedPlanDiags: func(c *configs.Config) tfdiags.Diagnostics {
-				return tfdiags.Diagnostics{}.Append(&hcl.Diagnostic{
-					Severity: hcl.DiagWarning,
-					Summary:  `Deprecated value used`,
-					Detail:   `Deprecated resource attribute "foo" used. Refer to the provider documentation for details.`,
-					Subject: &hcl.Range{
-						Filename: filepath.Join(c.Module.SourceDir, "main.tf"),
-						Start:    hcl.Pos{Line: 9, Column: 31, Byte: 245},
-						End:      hcl.Pos{Line: 9, Column: 58, Byte: 272},
-					},
-				})
-			},
 		},
 
 		"in postcondition condition": {
@@ -2693,18 +2676,6 @@ func TestContext2Validate_deprecatedAttr(t *testing.T) {
               }
             }
              `,
-			},
-			expectedPlanDiags: func(c *configs.Config) tfdiags.Diagnostics {
-				return tfdiags.Diagnostics{}.Append(&hcl.Diagnostic{
-					Severity: hcl.DiagWarning,
-					Summary:  `Deprecated value used`,
-					Detail:   `Deprecated resource attribute "foo" used. Refer to the provider documentation for details.`,
-					Subject: &hcl.Range{
-						Filename: filepath.Join(c.Module.SourceDir, "main.tf"),
-						Start:    hcl.Pos{Line: 6, Column: 31, Byte: 160},
-						End:      hcl.Pos{Line: 6, Column: 45, Byte: 174},
-					},
-				})
 			},
 		},
 
@@ -2741,27 +2712,6 @@ func TestContext2Validate_deprecatedAttr(t *testing.T) {
             }
              `,
 			},
-			expectedPlanDiags: func(c *configs.Config) tfdiags.Diagnostics {
-				return tfdiags.Diagnostics{}.Append(&hcl.Diagnostic{
-					Severity: hcl.DiagWarning,
-					Summary:  `Deprecated value used`,
-					Detail:   `Deprecated resource attribute "foo" used. Refer to the provider documentation for details.`,
-					Subject: &hcl.Range{
-						Filename: filepath.Join(c.Module.SourceDir, "main.tf"),
-						Start:    hcl.Pos{Line: 5, Column: 45, Byte: 135},
-						End:      hcl.Pos{Line: 5, Column: 45, Byte: 135},
-					},
-				}).Append(&hcl.Diagnostic{
-					Severity: hcl.DiagWarning,
-					Summary:  `Deprecated value used`,
-					Detail:   `Deprecated resource attribute "foo" used. Refer to the provider documentation for details.`,
-					Subject: &hcl.Range{
-						Filename: filepath.Join(c.Module.SourceDir, "main.tf"),
-						Start:    hcl.Pos{Line: 5, Column: 45, Byte: 135},
-						End:      hcl.Pos{Line: 5, Column: 45, Byte: 135},
-					},
-				})
-			},
 		},
 
 		"in check assertion": {
@@ -2780,18 +2730,6 @@ func TestContext2Validate_deprecatedAttr(t *testing.T) {
               }
             }
              `,
-			},
-			expectedPlanDiags: func(c *configs.Config) tfdiags.Diagnostics {
-				return tfdiags.Diagnostics{}.Append(&hcl.Diagnostic{
-					Severity: hcl.DiagWarning,
-					Summary:  `Deprecated value used`,
-					Detail:   `Deprecated resource attribute "foo" used. Refer to the provider documentation for details.`,
-					Subject: &hcl.Range{
-						Filename: filepath.Join(c.Module.SourceDir, "main.tf"),
-						Start:    hcl.Pos{Line: 7, Column: 29, Byte: 170},
-						End:      hcl.Pos{Line: 7, Column: 56, Byte: 197},
-					},
-				})
 			},
 		},
 
@@ -2868,30 +2806,6 @@ func TestContext2Validate_deprecatedAttr(t *testing.T) {
 					},
 				})
 			},
-			expectedPlanDiags: func(c *configs.Config) tfdiags.Diagnostics {
-				return tfdiags.Diagnostics{} // We can not connect this during planning
-			},
-			expectedApplyDiags: func(c *configs.Config) tfdiags.Diagnostics {
-				return tfdiags.Diagnostics{}.Append(&hcl.Diagnostic{
-					Severity: hcl.DiagWarning,
-					Summary:  `Deprecated value used`,
-					Detail:   `Deprecated resource attribute "foo" used. Refer to the provider documentation for details.`,
-					Subject: &hcl.Range{
-						Filename: filepath.Join(c.Module.SourceDir, "main.tf"),
-						Start:    hcl.Pos{Line: 6, Column: 36, Byte: 177},
-						End:      hcl.Pos{Line: 6, Column: 57, Byte: 198},
-					},
-				}).Append(&hcl.Diagnostic{
-					Severity: hcl.DiagWarning,
-					Summary:  `Deprecated value used`,
-					Detail:   `Deprecated resource attribute "foo" used. Refer to the provider documentation for details.`,
-					Subject: &hcl.Range{
-						Filename: filepath.Join(c.Module.SourceDir, "main.tf"),
-						Start:    hcl.Pos{Line: 9, Column: 26, Byte: 284},
-						End:      hcl.Pos{Line: 9, Column: 47, Byte: 305},
-					},
-				})
-			},
 		},
 
 		"in action config": {
@@ -2922,6 +2836,109 @@ func TestContext2Validate_deprecatedAttr(t *testing.T) {
 				})
 			},
 		},
+
+		"nested deprecated attr in root module output": {
+			attributeSchema: map[string]*configschema.Attribute{
+				"foo": {Type: cty.String, Optional: true, Deprecated: true},
+			},
+			module: map[string]string{
+				"main.tf": `
+            resource "aws_instance" "test" {
+            }
+            output "deprecated" {
+              value = aws_instance.test
+            }
+             `,
+			},
+			expectedValidationDiags: func(c *configs.Config) tfdiags.Diagnostics {
+				return tfdiags.Diagnostics{}.Append(&hcl.Diagnostic{
+					Severity: hcl.DiagWarning,
+					Summary:  `Deprecated value used`,
+					Detail:   `Deprecated resource attribute "foo" used. Refer to the provider documentation for details.`,
+					Subject: &hcl.Range{
+						Filename: filepath.Join(c.Module.SourceDir, "main.tf"),
+						Start:    hcl.Pos{Line: 5, Column: 23, Byte: 116},
+						End:      hcl.Pos{Line: 5, Column: 40, Byte: 133},
+					},
+				})
+			},
+		},
+
+		"nested deprecated attr in child module output": {
+			attributeSchema: map[string]*configschema.Attribute{
+				"foo": {Type: cty.String, Optional: true, Deprecated: true},
+			},
+			module: map[string]string{
+				"main.tf": `
+			module "child" {
+				source = "./child"
+			}`,
+				"child/main.tf": `
+            resource "aws_instance" "test" {
+            }
+            output "deprecated" {
+              value = aws_instance.test
+            }
+             `,
+			},
+			// no diags expected!
+		},
+
+		"explicit deprecated attr in child module output": {
+			attributeSchema: map[string]*configschema.Attribute{
+				"foo": {Type: cty.String, Optional: true, Deprecated: true},
+			},
+			module: map[string]string{
+				"main.tf": `
+			module "child" {
+				source = "./child"
+			}`,
+				"child/main.tf": `
+            resource "aws_instance" "test" {
+            }
+            output "deprecated" {
+              value = aws_instance.test.foo
+            }
+             `,
+			},
+			expectedValidationDiags: func(c *configs.Config) tfdiags.Diagnostics {
+				return tfdiags.Diagnostics{}.Append(&hcl.Diagnostic{
+					Severity: hcl.DiagWarning,
+					Summary:  `Deprecated value used`,
+					Detail:   `Deprecated resource attribute "foo" used. Refer to the provider documentation for details.`,
+					Subject: &hcl.Range{
+						Filename: filepath.Join(c.Module.SourceDir, "child/main.tf"),
+						Start:    hcl.Pos{Line: 5, Column: 23, Byte: 116},
+						End:      hcl.Pos{Line: 5, Column: 44, Byte: 137},
+					},
+				})
+			},
+		},
+
+		"referencing nested deprecated attr in child module output": {
+			attributeSchema: map[string]*configschema.Attribute{
+				"foo": {Type: cty.String, Optional: true, Deprecated: true},
+			},
+			module: map[string]string{
+				"main.tf": `
+			module "child" {
+				source = "./child"
+			}
+
+			output "deprecated" {
+				value = module.child.deprecated.foo
+			}	
+			`,
+				"child/main.tf": `
+            resource "aws_instance" "test" {
+            }
+            output "deprecated" {
+              value = aws_instance.test
+            }
+             `,
+			},
+			// This is not caught by validate.
+		},
 	} {
 		t.Run(name, func(t *testing.T) {
 			// Default values
@@ -2929,14 +2946,6 @@ func TestContext2Validate_deprecatedAttr(t *testing.T) {
 				tc.expectedValidationDiags = func(c *configs.Config) tfdiags.Diagnostics {
 					return tfdiags.Diagnostics{}
 				}
-			}
-			// By default we want the same validations in plan as in validate
-			if tc.expectedPlanDiags == nil {
-				tc.expectedPlanDiags = tc.expectedValidationDiags
-			}
-			// And the same validations in apply as in plan
-			if tc.expectedApplyDiags == nil {
-				tc.expectedApplyDiags = tc.expectedPlanDiags
 			}
 
 			pr := simpleMockProvisioner()
@@ -2969,10 +2978,9 @@ func TestContext2Validate_deprecatedAttr(t *testing.T) {
 				},
 			})
 
-			t.Run("validate", func(t *testing.T) {
-				validateDiags := ctx.Validate(m, nil)
-				tfdiags.AssertDiagnosticsMatch(t, validateDiags, tc.expectedValidationDiags(m))
-			})
+			validateDiags := ctx.Validate(m, nil)
+			tfdiags.AssertDiagnosticsMatch(t, validateDiags, tc.expectedValidationDiags(m))
+
 		})
 	}
 }

--- a/internal/terraform/node_output.go
+++ b/internal/terraform/node_output.go
@@ -532,7 +532,15 @@ If you do intend to export this data, annotate the output value as sensitive by 
 		}
 	} else if n.Config.Expr != nil {
 		var deprecationDiags tfdiags.Diagnostics
-		val, deprecationDiags = ctx.Deprecations().ValidateExpressionDeepAndUnmark(val, n.ModulePath(), n.Config.Expr)
+		if n.ModulePath().IsRoot() {
+			val, deprecationDiags = ctx.Deprecations().ValidateExpressionDeepAndUnmark(val, n.ModulePath(), n.Config.Expr)
+		} else {
+			// If the output is in a child module, only check for deprecations
+			// at the "top level". This avoids deprecation warnings when
+			// outputting an entire resource with a nested deprecated attribute.
+			// (References to said attribute should still incur a warning)
+			val, deprecationDiags = ctx.Deprecations().ValidateAndUnmark(val, n.ModulePath(), n.Config.Expr.Range().Ptr())
+		}
 		diags = diags.Append(deprecationDiags)
 	}
 


### PR DESCRIPTION
(And that resource is not itself deprecated - note to self to add a test for a deprecated resource!)

<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Fixes #

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.16.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [ ] This change is not user-facing.
