### PR TITLE
policy: Update policy callback server functions to handle deferred resources and data sources

### DIFF
--- a/internal/policy/callback/callback.go
+++ b/internal/policy/callback/callback.go
@@ -13,7 +13,7 @@ import (
 
 type Functions struct {
 	GetResources  func(ctx context.Context, resource string, attrs cty.Value) ([]cty.Value, bool, error)
-	GetDataSource func(ctx context.Context, datasource string, attrs cty.Value) (cty.Value, error)
+	GetDataSource func(ctx context.Context, datasource string, attrs cty.Value) (cty.Value, bool, error)
 }
 
 // Registry is an interface for managing callback functions for resources and

--- a/internal/policy/callback/server.go
+++ b/internal/policy/callback/server.go
@@ -70,7 +70,7 @@ func (s *Server) GetDataSource(ctx context.Context, request *proto.GetDataSource
 		err := fmt.Errorf("no callback registered for ID %d (request type: %s)", request.EvaluationRequestId, request.Type)
 		return nil, err
 	}
-	datasource, err := functions.GetDataSource(ctx, request.Type, config)
+	datasource, isDeferred, err := functions.GetDataSource(ctx, request.Type, config)
 	if err != nil {
 		return nil, err
 	}
@@ -82,7 +82,8 @@ func (s *Server) GetDataSource(ctx context.Context, request *proto.GetDataSource
 	}
 
 	return &proto.GetDataSourceResponse{
-		Result: result,
+		Result:   result,
+		Deferred: isDeferred,
 	}, nil
 }
 

--- a/internal/terraform/context_apply_policy_test.go
+++ b/internal/terraform/context_apply_policy_test.go
@@ -5,6 +5,7 @@ package terraform
 
 import (
 	"context"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -1167,7 +1168,169 @@ func TestContext2Apply_PolicyCallback(t *testing.T) {
 	}
 }
 
-func TestContext2Apply_PolicyCallback_Deferral(t *testing.T) {
+func TestContext2Apply_PolicyCallback_GetDataSource(t *testing.T) {
+	t.Parallel()
+
+	type callbackResult struct {
+		DataSourceResult   cty.Value
+		DataSourceDeferred bool
+	}
+
+	testCases := map[string]struct {
+		targetDataSource        string
+		dataSourceReqConfig     cty.Value
+		deferralAllowed         bool
+		deferralResponse        *providers.Deferred
+		expectedCallbackResults []callbackResult
+		expectedErr             string
+	}{
+		"getdatasource returns result": {
+			targetDataSource: "test_data_source",
+			dataSourceReqConfig: cty.ObjectVal(map[string]cty.Value{
+				"id":  cty.NullVal(cty.String), // computed
+				"foo": cty.StringVal("test val"),
+			}),
+			expectedCallbackResults: []callbackResult{
+				{
+					DataSourceResult: cty.ObjectVal(map[string]cty.Value{
+						"id":  cty.StringVal("computed val"),
+						"foo": cty.StringVal("test val"),
+					}),
+					DataSourceDeferred: false,
+				},
+			},
+		},
+		"getdatasource not found": {
+			targetDataSource: "test_non_existent",
+			dataSourceReqConfig: cty.ObjectVal(map[string]cty.Value{
+				"id":  cty.NullVal(cty.String),
+				"foo": cty.StringVal("test val"),
+			}),
+			expectedErr: `no data source found for test_non_existent`,
+		},
+		"getdatasource returns deferred": {
+			targetDataSource: "test_data_source",
+			dataSourceReqConfig: cty.ObjectVal(map[string]cty.Value{
+				"id":  cty.NullVal(cty.String),
+				"foo": cty.StringVal("test val"),
+			}),
+			deferralAllowed: true,
+			deferralResponse: &providers.Deferred{
+				Reason: providers.DeferredReasonAbsentPrereq,
+			},
+			expectedCallbackResults: []callbackResult{
+				{
+					DataSourceResult: cty.ObjectVal(map[string]cty.Value{
+						"id":  cty.NullVal(cty.String),
+						"foo": cty.StringVal("test val"),
+					}),
+					DataSourceDeferred: true,
+				},
+			},
+		},
+	}
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			// The plan policy client allows everything; the callback assertions run during apply only.
+			planPolicyClient := policy.NewTestMockClient(t)
+			planPolicyClient.EvaluateFn = func(ctx context.Context, req policy.EvaluationRequest[*proto.PolicyEvaluateResourceRequest_ResourceMetadata]) policy.EvaluationResponse {
+				return policy.EvaluationResponse{Overall: policy.AllowResult}
+			}
+
+			var gotResults []callbackResult
+			applyPolicyClient := policy.NewTestMockClient(t)
+			applyPolicyClient.EvaluateFn = func(ctx context.Context, req policy.EvaluationRequest[*proto.PolicyEvaluateResourceRequest_ResourceMetadata]) policy.EvaluationResponse {
+				result, deferred, err := req.Callbacks.GetDataSource(t.Context(), tc.targetDataSource, tc.dataSourceReqConfig)
+				if err != nil {
+					if !strings.Contains(err.Error(), tc.expectedErr) {
+						t.Errorf("Unexpected error in callback GetDataSource(test_data_source): %v", err)
+					}
+
+					return policy.EvaluationResponse{Overall: policy.AllowResult}
+				}
+
+				gotResults = append(gotResults, callbackResult{
+					DataSourceResult:   result,
+					DataSourceDeferred: deferred,
+				})
+
+				return policy.EvaluationResponse{Overall: policy.AllowResult}
+			}
+
+			testProvider := testProvider("test")
+			testProvider.ReadDataSourceFn = func(req providers.ReadDataSourceRequest) providers.ReadDataSourceResponse {
+				// We aren't checking the client capability here to enable testing an invalid provider implementation
+				if tc.deferralResponse != nil {
+					return providers.ReadDataSourceResponse{
+						State:    req.Config,
+						Deferred: tc.deferralResponse,
+					}
+				}
+
+				stateVal := req.Config.AsValueMap()
+				stateVal["id"] = cty.StringVal("computed val")
+				return providers.ReadDataSourceResponse{
+					State: cty.ObjectVal(stateVal),
+				}
+			}
+
+			ctx, diags := NewContext(&ContextOpts{
+				Providers: map[addrs.Provider]providers.Factory{
+					addrs.NewDefaultProvider("test"): testProviderFuncFixed(testProvider),
+				},
+			})
+			tfdiags.AssertNoDiagnostics(t, diags)
+
+			mod := testModuleInline(t, map[string]string{
+				// Config isn't as important to this test, since we're just testing the getdatasource callback
+				// which will directly call a configured provider instance.
+				"main.tf": `
+		terraform {
+			required_providers {
+				test = {
+					source = "hashicorp/test"
+					version = "1.0.0"
+				}
+			}
+		}
+
+		resource "test_resource" "foo" {
+			value = "foo"
+			defer = false
+		}
+	`,
+				"main.tfpolicy.hcl": `# policy config is not read by Terraform`,
+			})
+			plan, diags := ctx.Plan(mod, states.NewState(), &PlanOpts{
+				Mode:            plans.NormalMode,
+				DeferralAllowed: tc.deferralAllowed,
+				PolicyClient:    planPolicyClient,
+			})
+			tfdiags.AssertNoDiagnostics(t, diags)
+
+			policyResults := plans.NewPolicyResults()
+			_, diags = ctx.Apply(plan, mod, &ApplyOpts{
+				PolicyClient:  applyPolicyClient,
+				PolicyResults: policyResults,
+			})
+			tfdiags.AssertNoDiagnostics(t, diags)
+
+			var policyDiags tfdiags.Diagnostics
+			for _, result := range policyResults.Iter() {
+				policyDiags = policyDiags.Append(result.EvaluationResponse.Diagnostics.AsTerraformDiags())
+			}
+			tfdiags.AssertNoDiagnostics(t, policyDiags)
+
+			if diff := cmp.Diff(tc.expectedCallbackResults, gotResults, cmp.Comparer(cty.Value.RawEquals)); diff != "" {
+				t.Errorf("unexpected policy callback results\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestContext2Apply_PolicyCallback_GetResources_Deferral(t *testing.T) {
 	t.Parallel()
 
 	type callbackResult struct {

--- a/internal/terraform/context_apply_policy_test.go
+++ b/internal/terraform/context_apply_policy_test.go
@@ -1167,6 +1167,202 @@ func TestContext2Apply_PolicyCallback(t *testing.T) {
 	}
 }
 
+func TestContext2Apply_PolicyCallback_Deferral(t *testing.T) {
+	t.Parallel()
+
+	type callbackResult struct {
+		TestResourceMatches []cty.Value
+		TestResourcePartial bool
+
+		TestInstanceMatches []cty.Value
+		TestInstancePartial bool
+	}
+
+	testCases := map[string]struct {
+		config                  string
+		expectedCallbackResults []callbackResult
+	}{
+		"resource type lookup with deferral return partial result": {
+			config: `
+		terraform {
+			required_providers {
+				test = {
+					source = "hashicorp/test"
+					version = "1.0.0"
+				}
+			}
+		}
+
+		# Deferred (directly)
+		resource "test_resource" "foo" {
+			value = "foo"
+			defer = true
+		}
+
+		# Deferred (by dependency)
+		resource "test_instance" "foo" {
+			value = test_resource.foo.value
+		}
+
+		# Not deferred, policy is evaluated
+		resource "test_resource" "bar" {
+			value = "bar"
+			defer = false
+		}
+	`,
+			expectedCallbackResults: []callbackResult{
+				{
+					// This is the only non-deferred test_resource we can match
+					TestResourceMatches: []cty.Value{
+						cty.ObjectVal(map[string]cty.Value{
+							"id":              cty.StringVal(""),
+							"value":           cty.StringVal("bar"),
+							"sensitive_value": cty.NullVal(cty.String),
+							"defer":           cty.False,
+							"random":          cty.NullVal(cty.String),
+							"nesting_single": cty.NullVal(cty.Object(map[string]cty.Type{
+								"value":           cty.String,
+								"sensitive_value": cty.String,
+							})),
+						}),
+					},
+					TestResourcePartial: true,
+
+					// test_instance is deferred, so the response is partial with no matches
+					TestInstanceMatches: []cty.Value{},
+					TestInstancePartial: true,
+				},
+			},
+		},
+		"resource type lookup without deferral return full result": {
+			config: `
+		terraform {
+			required_providers {
+				test = {
+					source = "hashicorp/test"
+					version = "1.0.0"
+				}
+			}
+		}
+
+		# Deferred (directly)
+		resource "test_resource" "foo" {
+			value = "foo"
+			defer = true
+		}
+
+		# Not deferred, policy is evaluated
+		resource "test_instance" "foo" {
+			value = "foo"
+		}
+	`,
+			expectedCallbackResults: []callbackResult{
+				{
+					// test_resource is deferred, so the response is partial with no matches
+					TestResourceMatches: []cty.Value{},
+					TestResourcePartial: true,
+
+					// There are no test_instance resources being deferred so the response is not partial.
+					TestInstanceMatches: []cty.Value{
+						cty.ObjectVal(map[string]cty.Value{
+							"id":            cty.StringVal(""),
+							"ami":           cty.NullVal(cty.String),
+							"dep":           cty.NullVal(cty.String),
+							"num":           cty.NullVal(cty.Number),
+							"require_new":   cty.NullVal(cty.String),
+							"var":           cty.NullVal(cty.String),
+							"foo":           cty.NullVal(cty.String),
+							"bar":           cty.NullVal(cty.String),
+							"compute":       cty.NullVal(cty.String),
+							"compute_value": cty.NullVal(cty.String),
+							"value":         cty.StringVal("foo"),
+							"output":        cty.NullVal(cty.String),
+							"write":         cty.NullVal(cty.String),
+							"instance":      cty.NullVal(cty.String),
+							"vpc_id":        cty.NullVal(cty.String),
+							"type":          cty.StringVal(""),
+							"unknown":       cty.StringVal(""),
+						}),
+					},
+					TestInstancePartial: false,
+				},
+			},
+		},
+	}
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			// The plan policy client allows everything; the callback assertions run during apply only.
+			planPolicyClient := policy.NewTestMockClient(t)
+			planPolicyClient.EvaluateFn = func(ctx context.Context, req policy.EvaluationRequest[*proto.PolicyEvaluateResourceRequest_ResourceMetadata]) policy.EvaluationResponse {
+				return policy.EvaluationResponse{Overall: policy.AllowResult}
+			}
+
+			gotResults := make([]callbackResult, 0)
+			applyPolicyClient := policy.NewTestMockClient(t)
+			applyPolicyClient.EvaluateFn = func(ctx context.Context, req policy.EvaluationRequest[*proto.PolicyEvaluateResourceRequest_ResourceMetadata]) policy.EvaluationResponse {
+				cr := callbackResult{}
+
+				matches, partial, err := req.Callbacks.GetResources(t.Context(), "test_resource", cty.NullVal(cty.DynamicPseudoType))
+				if err != nil {
+					t.Errorf("Unexpected error in callback GetResources(test_resource): %v", err)
+				} else {
+					cr.TestResourceMatches = matches
+					cr.TestResourcePartial = partial
+				}
+
+				matches, partial, err = req.Callbacks.GetResources(t.Context(), "test_instance", cty.NullVal(cty.DynamicPseudoType))
+				if err != nil {
+					t.Errorf("Unexpected error in callback GetResources(test_instance): %v", err)
+				} else {
+					cr.TestInstanceMatches = matches
+					cr.TestInstancePartial = partial
+				}
+
+				gotResults = append(gotResults, cr)
+
+				return policy.EvaluationResponse{Overall: policy.AllowResult}
+			}
+
+			ctx, diags := NewContext(&ContextOpts{
+				Providers: map[addrs.Provider]providers.Factory{
+					addrs.NewDefaultProvider("test"): testProviderFuncFixed(testProvider("test")),
+				},
+			})
+			tfdiags.AssertNoDiagnostics(t, diags)
+
+			mod := testModuleInline(t, map[string]string{
+				"main.tf":           tc.config,
+				"main.tfpolicy.hcl": `# policy config is not read by Terraform`,
+			})
+			plan, diags := ctx.Plan(mod, states.NewState(), &PlanOpts{
+				Mode:            plans.NormalMode,
+				DeferralAllowed: true,
+				PolicyClient:    planPolicyClient,
+			})
+			tfdiags.AssertNoDiagnostics(t, diags)
+
+			policyResults := plans.NewPolicyResults()
+			_, diags = ctx.Apply(plan, mod, &ApplyOpts{
+				PolicyClient:  applyPolicyClient,
+				PolicyResults: policyResults,
+			})
+			tfdiags.AssertNoDiagnostics(t, diags)
+
+			var policyDiags tfdiags.Diagnostics
+			for _, result := range policyResults.Iter() {
+				policyDiags = policyDiags.Append(result.EvaluationResponse.Diagnostics.AsTerraformDiags())
+			}
+			tfdiags.AssertNoDiagnostics(t, policyDiags)
+
+			if diff := cmp.Diff(tc.expectedCallbackResults, gotResults, cmp.Comparer(cty.Value.RawEquals)); diff != "" {
+				t.Errorf("unexpected policy callback results\n%s", diff)
+			}
+		})
+	}
+}
+
 // TestContext2Apply_PolicySpanParentage verifies the OpenTelemetry wiring that
 // makes per-resource policy spans children of the enclosing "terraform apply"
 // command span.

--- a/internal/terraform/context_plan_policy_test.go
+++ b/internal/terraform/context_plan_policy_test.go
@@ -1828,6 +1828,190 @@ func TestContext2Plan_PolicyCallback(t *testing.T) {
 	}
 }
 
+func TestContext2Plan_PolicyCallback_Deferral(t *testing.T) {
+	t.Parallel()
+
+	type callbackResult struct {
+		TestResourceMatches []cty.Value
+		TestResourcePartial bool
+
+		TestInstanceMatches []cty.Value
+		TestInstancePartial bool
+	}
+
+	testCases := map[string]struct {
+		config                  string
+		expectedCallbackResults []callbackResult
+	}{
+		"resource type lookup with deferral return partial result": {
+			config: `
+		terraform {
+			required_providers {
+				test = {
+					source = "hashicorp/test"
+					version = "1.0.0"
+				}
+			}
+		}
+
+		# Deferred (directly)
+		resource "test_resource" "foo" {
+			value = "foo"
+			defer = true
+		}
+
+		# Deferred (by dependency)
+		resource "test_instance" "foo" {
+			value = test_resource.foo.value
+		}
+
+		# Not deferred, policy is evaluated
+		resource "test_resource" "bar" {
+			value = "bar"
+			defer = false
+		}
+	`,
+			expectedCallbackResults: []callbackResult{
+				{
+					// This is the only non-deferred test_resource we can match
+					TestResourceMatches: []cty.Value{
+						cty.ObjectVal(map[string]cty.Value{
+							"id":              cty.UnknownVal(cty.String),
+							"value":           cty.StringVal("bar"),
+							"sensitive_value": cty.NullVal(cty.String),
+							"defer":           cty.False,
+							"random":          cty.NullVal(cty.String),
+							"nesting_single": cty.NullVal(cty.Object(map[string]cty.Type{
+								"value":           cty.String,
+								"sensitive_value": cty.String,
+							})),
+						}),
+					},
+					TestResourcePartial: true,
+
+					// test_instance is deferred, so the response is partial with no matches
+					TestInstanceMatches: []cty.Value{},
+					TestInstancePartial: true,
+				},
+			},
+		},
+		"resource type lookup without deferral return full result": {
+			config: `
+		terraform {
+			required_providers {
+				test = {
+					source = "hashicorp/test"
+					version = "1.0.0"
+				}
+			}
+		}
+
+		# Deferred (directly)
+		resource "test_resource" "foo" {
+			value = "foo"
+			defer = true
+		}
+
+		# Not deferred, policy is evaluated
+		resource "test_instance" "foo" {
+			value = "foo"
+		}
+	`,
+			expectedCallbackResults: []callbackResult{
+				{
+					// test_resource is deferred, so the response is partial with no matches
+					TestResourceMatches: []cty.Value{},
+					TestResourcePartial: true,
+
+					// There are no test_instance resources being deferred so the response is not partial.
+					TestInstanceMatches: []cty.Value{
+						cty.ObjectVal(map[string]cty.Value{
+							"id":            cty.UnknownVal(cty.String),
+							"ami":           cty.NullVal(cty.String),
+							"dep":           cty.NullVal(cty.String),
+							"num":           cty.NullVal(cty.Number),
+							"require_new":   cty.NullVal(cty.String),
+							"var":           cty.NullVal(cty.String),
+							"foo":           cty.NullVal(cty.String),
+							"bar":           cty.NullVal(cty.String),
+							"compute":       cty.NullVal(cty.String),
+							"compute_value": cty.NullVal(cty.String),
+							"value":         cty.StringVal("foo"),
+							"output":        cty.NullVal(cty.String),
+							"write":         cty.NullVal(cty.String),
+							"instance":      cty.NullVal(cty.String),
+							"vpc_id":        cty.NullVal(cty.String),
+							"type":          cty.UnknownVal(cty.String),
+							"unknown":       cty.UnknownVal(cty.String),
+						}),
+					},
+					TestInstancePartial: false,
+				},
+			},
+		},
+	}
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			mockPolicyClient := policy.NewTestMockClient(t)
+			gotResults := make([]callbackResult, 0)
+
+			mockPolicyClient.EvaluateFn = func(ctx context.Context, req policy.EvaluationRequest[*proto.PolicyEvaluateResourceRequest_ResourceMetadata]) policy.EvaluationResponse {
+				cr := callbackResult{}
+
+				matches, partial, err := req.Callbacks.GetResources(t.Context(), "test_resource", cty.NullVal(cty.DynamicPseudoType))
+				if err != nil {
+					t.Errorf("Unexpected error in callback GetResources(test_resource): %v", err)
+				} else {
+					cr.TestResourceMatches = matches
+					cr.TestResourcePartial = partial
+				}
+
+				matches, partial, err = req.Callbacks.GetResources(t.Context(), "test_instance", cty.NullVal(cty.DynamicPseudoType))
+				if err != nil {
+					t.Errorf("Unexpected error in callback GetResources(test_instance): %v", err)
+				} else {
+					cr.TestInstanceMatches = matches
+					cr.TestInstancePartial = partial
+				}
+
+				gotResults = append(gotResults, cr)
+
+				return policy.EvaluationResponse{Overall: policy.AllowResult}
+			}
+
+			ctx, diags := NewContext(&ContextOpts{
+				Providers: map[addrs.Provider]providers.Factory{
+					addrs.NewDefaultProvider("test"): testProviderFuncFixed(testProvider("test")),
+				},
+			})
+			tfdiags.AssertNoDiagnostics(t, diags)
+
+			mod := testModuleInline(t, map[string]string{
+				"main.tf":           tc.config,
+				"main.tfpolicy.hcl": `# policy config is not read by Terraform`,
+			})
+			plan, diags := ctx.Plan(mod, states.NewState(), &PlanOpts{
+				Mode:            plans.NormalMode,
+				DeferralAllowed: true,
+				PolicyClient:    mockPolicyClient,
+			})
+			tfdiags.AssertNoDiagnostics(t, diags)
+
+			var policyDiags tfdiags.Diagnostics
+			for _, result := range plan.PolicyResults.Iter() {
+				policyDiags = policyDiags.Append(result.EvaluationResponse.Diagnostics.AsTerraformDiags())
+			}
+			tfdiags.AssertNoDiagnostics(t, policyDiags)
+
+			if diff := cmp.Diff(tc.expectedCallbackResults, gotResults, cmp.Comparer(cty.Value.RawEquals)); diff != "" {
+				t.Errorf("unexpected policy callback results\n%s", diff)
+			}
+		})
+	}
+}
+
 func assertPathsEqual(t *testing.T, got, want []cty.Path) {
 	t.Helper()
 

--- a/internal/terraform/context_plan_policy_test.go
+++ b/internal/terraform/context_plan_policy_test.go
@@ -1828,7 +1828,172 @@ func TestContext2Plan_PolicyCallback(t *testing.T) {
 	}
 }
 
-func TestContext2Plan_PolicyCallback_Deferral(t *testing.T) {
+func TestContext2Plan_PolicyCallback_GetDataSource(t *testing.T) {
+	t.Parallel()
+
+	type callbackResult struct {
+		DataSourceResult   cty.Value
+		DataSourceDeferred bool
+	}
+
+	testCases := map[string]struct {
+		targetDataSource        string
+		dataSourceReqConfig     cty.Value
+		deferralAllowed         bool
+		deferralResponse        *providers.Deferred
+		expectedCallbackResults []callbackResult
+		expectedErr             string
+	}{
+		"getdatasource returns result": {
+			targetDataSource: "test_data_source",
+			dataSourceReqConfig: cty.ObjectVal(map[string]cty.Value{
+				"id":  cty.NullVal(cty.String), // computed
+				"foo": cty.StringVal("test val"),
+			}),
+			expectedCallbackResults: []callbackResult{
+				{
+					DataSourceResult: cty.ObjectVal(map[string]cty.Value{
+						"id":  cty.StringVal("computed val"),
+						"foo": cty.StringVal("test val"),
+					}),
+					DataSourceDeferred: false,
+				},
+			},
+		},
+		"getdatasource not found": {
+			targetDataSource: "test_non_existent",
+			dataSourceReqConfig: cty.ObjectVal(map[string]cty.Value{
+				"id":  cty.NullVal(cty.String),
+				"foo": cty.StringVal("test val"),
+			}),
+			expectedErr: `no data source found for test_non_existent`,
+		},
+		"getdatasource returns deferred": {
+			targetDataSource: "test_data_source",
+			dataSourceReqConfig: cty.ObjectVal(map[string]cty.Value{
+				"id":  cty.NullVal(cty.String),
+				"foo": cty.StringVal("test val"),
+			}),
+			deferralAllowed: true,
+			deferralResponse: &providers.Deferred{
+				Reason: providers.DeferredReasonAbsentPrereq,
+			},
+			expectedCallbackResults: []callbackResult{
+				{
+					DataSourceResult: cty.ObjectVal(map[string]cty.Value{
+						"id":  cty.NullVal(cty.String),
+						"foo": cty.StringVal("test val"),
+					}),
+					DataSourceDeferred: true,
+				},
+			},
+		},
+		"getdatasource returns deferred incorrectly": {
+			targetDataSource: "test_data_source",
+			dataSourceReqConfig: cty.ObjectVal(map[string]cty.Value{
+				"id":  cty.NullVal(cty.String),
+				"foo": cty.StringVal("test val"),
+			}),
+			deferralAllowed: false,
+			// Returning this data would be a provider bug, but we still want to provide some information about the problem
+			// to the policy engine.
+			deferralResponse: &providers.Deferred{
+				Reason: providers.DeferredReasonAbsentPrereq,
+			},
+			expectedErr: `The provider signaled a deferred action for test_data_source, ` +
+				`but in this context deferrals are disabled. This is a bug in the provider, please file an issue with the provider developers.`,
+		},
+	}
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			mockPolicyClient := policy.NewTestMockClient(t)
+
+			var gotResults []callbackResult
+			mockPolicyClient.EvaluateFn = func(ctx context.Context, req policy.EvaluationRequest[*proto.PolicyEvaluateResourceRequest_ResourceMetadata]) policy.EvaluationResponse {
+				result, deferred, err := req.Callbacks.GetDataSource(t.Context(), tc.targetDataSource, tc.dataSourceReqConfig)
+				if err != nil {
+					if !strings.Contains(err.Error(), tc.expectedErr) {
+						t.Errorf("Unexpected error in callback GetDataSource(test_data_source): %v", err)
+					}
+
+					return policy.EvaluationResponse{Overall: policy.AllowResult}
+				}
+
+				gotResults = append(gotResults, callbackResult{
+					DataSourceResult:   result,
+					DataSourceDeferred: deferred,
+				})
+
+				return policy.EvaluationResponse{Overall: policy.AllowResult}
+			}
+
+			testProvider := testProvider("test")
+			testProvider.ReadDataSourceFn = func(req providers.ReadDataSourceRequest) providers.ReadDataSourceResponse {
+				// We aren't checking the client capability here to enable testing an invalid provider implementation
+				if tc.deferralResponse != nil {
+					return providers.ReadDataSourceResponse{
+						State:    req.Config,
+						Deferred: tc.deferralResponse,
+					}
+				}
+
+				stateVal := req.Config.AsValueMap()
+				stateVal["id"] = cty.StringVal("computed val")
+				return providers.ReadDataSourceResponse{
+					State: cty.ObjectVal(stateVal),
+				}
+			}
+
+			ctx, diags := NewContext(&ContextOpts{
+				Providers: map[addrs.Provider]providers.Factory{
+					addrs.NewDefaultProvider("test"): testProviderFuncFixed(testProvider),
+				},
+			})
+			tfdiags.AssertNoDiagnostics(t, diags)
+
+			mod := testModuleInline(t, map[string]string{
+				// Config isn't as important to this test, since we're just testing the getdatasource callback
+				// which will directly call a configured provider instance.
+				"main.tf": `
+		terraform {
+			required_providers {
+				test = {
+					source = "hashicorp/test"
+					version = "1.0.0"
+				}
+			}
+		}
+
+		resource "test_resource" "foo" {
+			value = "foo"
+			defer = false
+		}
+	`,
+				"main.tfpolicy.hcl": `# policy config is not read by Terraform`,
+			})
+			plan, diags := ctx.Plan(mod, states.NewState(), &PlanOpts{
+				Mode:            plans.NormalMode,
+				DeferralAllowed: tc.deferralAllowed,
+				PolicyClient:    mockPolicyClient,
+			})
+			tfdiags.AssertNoDiagnostics(t, diags)
+
+			var policyDiags tfdiags.Diagnostics
+			for _, result := range plan.PolicyResults.Iter() {
+				policyDiags = policyDiags.Append(result.EvaluationResponse.Diagnostics.AsTerraformDiags())
+			}
+			tfdiags.AssertNoDiagnostics(t, policyDiags)
+
+			if diff := cmp.Diff(tc.expectedCallbackResults, gotResults, cmp.Comparer(cty.Value.RawEquals)); diff != "" {
+				t.Errorf("unexpected policy callback results\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestContext2Plan_PolicyCallback_GetResources_Deferral(t *testing.T) {
 	t.Parallel()
 
 	type callbackResult struct {

--- a/internal/terraform/node_policy_resource.go
+++ b/internal/terraform/node_policy_resource.go
@@ -76,30 +76,17 @@ func (n *nodeResourcePolicy) Execute(ctx EvalContext, operation walkOperation) t
 		ModulePath:   n.ResourceAddr.Module.String(),
 	}
 
-	providerRef := ProviderRef{
-		Addr:     providerAddr,
-		Resolved: true,
-	}
-
 	// the module config may be nil if the module call has been removed from the configuration
 	// in this case, we are fine with a nil resource config, as that would only mean
-	// that we do not have the terraform config's source information in the diagnostics
-	// and neither do we have provider meta information to include in the policy request.
+	// that we do not have the terraform config's source information in the diagnostics.
 	var resourceConfig *configs.Resource
-	var metaVal cty.Value
 	if modCfg != nil {
 		resourceConfig = modCfg.Module.ResourceByAddr(n.ResourceAddr.Resource.Resource)
-		var metaDiags tfdiags.Diagnostics
-		metaVal, metaDiags = providerRef.getProviderMeta(ctx, n.ResourceAddr.Resource, modCfg.Module.ProviderMetas)
-		diags = diags.Append(metaDiags)
-		if diags.HasErrors() {
-			return diags
-		}
 	}
 
 	callbacks := callback.Functions{
 		GetResources:  getResourcesForPolicyCallback(ctx, operation, provider, schema, config),
-		GetDataSource: getDataSourceForPolicyCallback(ctx, provider, schema, metaVal),
+		GetDataSource: getDataSourceForPolicyCallback(ctx, provider, schema),
 	}
 
 	result := evaluatePolicies(ctx, n.ResourceAddr, resourceConfig, n.After, n.Before, meta, callbacks)

--- a/internal/terraform/policy.go
+++ b/internal/terraform/policy.go
@@ -132,8 +132,8 @@ func getResourcesForPolicyCallback(ctx EvalContext, walkOperation walkOperation,
 	}
 }
 
-func getDataSourceForPolicyCallback(ctx EvalContext, provider providers.Interface, schema providers.GetProviderSchemaResponse, meta cty.Value) func(callbackCtx context.Context, datasource string, attrs cty.Value) (cty.Value, error) {
-	return func(c context.Context, target string, attrs cty.Value) (cty.Value, error) {
+func getDataSourceForPolicyCallback(ctx EvalContext, provider providers.Interface, schema providers.GetProviderSchemaResponse, meta cty.Value) func(callbackCtx context.Context, datasource string, attrs cty.Value) (cty.Value, bool, error) {
+	return func(c context.Context, target string, attrs cty.Value) (cty.Value, bool, error) {
 		_, span := tracer().Start(c, "policy.callback.getDataSource", trace.WithAttributes(
 			attribute.String("policy.callback.getDataSource.type", target),
 		))
@@ -141,7 +141,7 @@ func getDataSourceForPolicyCallback(ctx EvalContext, provider providers.Interfac
 		if datasource, ok := schema.DataSources[target]; ok {
 			configVal, err := datasource.Body.CoerceValue(attrs)
 			if err != nil {
-				return cty.NilVal, fmt.Errorf("invalid attributes for %q: %w", target, err)
+				return cty.NilVal, false, fmt.Errorf("invalid attributes for %q: %w", target, err)
 			}
 
 			validateResp := provider.ValidateDataResourceConfig(providers.ValidateDataResourceConfigRequest{
@@ -149,21 +149,35 @@ func getDataSourceForPolicyCallback(ctx EvalContext, provider providers.Interfac
 				Config:   configVal,
 			})
 			if err := validateResp.Diagnostics.Err(); err != nil {
-				return cty.NilVal, fmt.Errorf("failed to validate data source configuration: %s", err)
+				return cty.NilVal, false, fmt.Errorf("failed to validate data source configuration: %s", err)
 			}
 
 			readResp := provider.ReadDataSource(providers.ReadDataSourceRequest{
-				TypeName:     target,
-				Config:       configVal,
-				ProviderMeta: meta,
+				TypeName:           target,
+				Config:             configVal,
+				ProviderMeta:       meta,
+				ClientCapabilities: ctx.ClientCapabilities(),
 			})
 			if err := readResp.Diagnostics.Err(); err != nil {
-				return cty.NilVal, fmt.Errorf("failed to read data source: %s", err)
+				return cty.NilVal, false, fmt.Errorf("failed to read data source: %s", err)
 			}
 
-			return readResp.State, nil
+			// If the data source indicates deferral (which would be unlikely here), we need to pass that info back to the caller
+			deferred := false
+			if readResp.Deferred != nil {
+				// If we don't support deferrals, but the provider reports a deferral, we should emit an error.
+				if !ctx.Deferrals().DeferralAllowed() {
+					return cty.NilVal, false, fmt.Errorf("failed to read data source: "+
+						"The provider signaled a deferred action for %s, but in this context deferrals are disabled. "+
+						"This is a bug in the provider, please file an issue with the provider developers.", target)
+				}
+
+				deferred = true
+			}
+
+			return readResp.State, deferred, nil
 		}
-		return cty.NilVal, fmt.Errorf("no data source found for %s", target)
+		return cty.NilVal, false, fmt.Errorf("no data source found for %s", target)
 	}
 }
 

--- a/internal/terraform/policy.go
+++ b/internal/terraform/policy.go
@@ -60,9 +60,9 @@ func getResourcesForPolicyCallback(ctx EvalContext, walkOperation walkOperation,
 		_, span := tracer().Start(c, "policy.callback.getResources", trace.WithAttributes(
 			attribute.String("policy.callback.getResources.type", target),
 		))
-
 		defer span.End()
-		var found []cty.Value
+
+		found := make([]cty.Value, 0)
 		var filterMap map[string]cty.Value
 		if !attrs.IsNull() {
 			filterMap = attrs.AsValueMap()
@@ -77,10 +77,19 @@ func getResourcesForPolicyCallback(ctx EvalContext, walkOperation walkOperation,
 				addr := resource.Addr().InModule(c.Path)
 				schema := schema.SchemaForResourceAddr(addr.Resource)
 
+				// Before checking the data to see if there is a match, check if there is a deferral for this address.
+				//
+				// If there is a deferral, we can't use the data to determine if there is a match so we'll indicate
+				// the callback return is a partial result.
+				deferred := ctx.Deferrals().DependenciesDeferred([]addrs.ConfigResource{addr})
+				if deferred {
+					isPartialResult = true
+					continue
+				}
+
 				// Now we implement a generator function that yields resource instances
 				// from either the state or the config, depending on the walk operation.
 				var resourcesSeq iter.Seq[cty.Value]
-				var count int
 				if walkOperation == walkApply {
 					// Read each config resource instance from the state, decoding it into a cty.Value
 					resourcesSeq = states.ReadEachConfigResourceInstance(state, addr, func(inst *states.ResourceInstance) (cty.Value, bool) {
@@ -92,14 +101,12 @@ func getResourcesForPolicyCallback(ctx EvalContext, walkOperation walkOperation,
 							log.Printf("[ERROR] getresources: failed to decode resource %q: %v", addr, err)
 							return cty.NilVal, false
 						}
-						count++
 						return rsc.Value, true
 					})
 				} else {
 					// Read each config resource change from the plan, returning the corresponding cty.Value
 					resourcesSeq = func(yield func(cty.Value) bool) {
 						for change := range plans.ReadInstancesForConfigResource(ctx.Changes(), addr) {
-							count++
 							yield(change.After)
 						}
 					}
@@ -117,7 +124,6 @@ func getResourcesForPolicyCallback(ctx EvalContext, walkOperation walkOperation,
 					// we can't determine whether it matches, so we'll mark the whole callback result as incomplete.
 					// We still continue to the next resource instance, so that we return all known objects as well.
 					isPartialResult = isPartialResult || unknown
-
 				}
 			}
 		})

--- a/internal/terraform/policy.go
+++ b/internal/terraform/policy.go
@@ -132,7 +132,7 @@ func getResourcesForPolicyCallback(ctx EvalContext, walkOperation walkOperation,
 	}
 }
 
-func getDataSourceForPolicyCallback(ctx EvalContext, provider providers.Interface, schema providers.GetProviderSchemaResponse, meta cty.Value) func(callbackCtx context.Context, datasource string, attrs cty.Value) (cty.Value, bool, error) {
+func getDataSourceForPolicyCallback(ctx EvalContext, provider providers.Interface, schema providers.GetProviderSchemaResponse) func(callbackCtx context.Context, datasource string, attrs cty.Value) (cty.Value, bool, error) {
 	return func(c context.Context, target string, attrs cty.Value) (cty.Value, bool, error) {
 		_, span := tracer().Start(c, "policy.callback.getDataSource", trace.WithAttributes(
 			attribute.String("policy.callback.getDataSource.type", target),
@@ -155,7 +155,6 @@ func getDataSourceForPolicyCallback(ctx EvalContext, provider providers.Interfac
 			readResp := provider.ReadDataSource(providers.ReadDataSourceRequest{
 				TypeName:           target,
 				Config:             configVal,
-				ProviderMeta:       meta,
 				ClientCapabilities: ctx.ClientCapabilities(),
 			})
 			if err := readResp.Diagnostics.Err(); err != nil {

--- a/internal/terraform/policy_test.go
+++ b/internal/terraform/policy_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/terraform/internal/configs/configschema"
 	"github.com/hashicorp/terraform/internal/plans"
+	"github.com/hashicorp/terraform/internal/plans/deferring"
 	"github.com/hashicorp/terraform/internal/states"
 	"github.com/zclconf/go-cty/cty"
 )
@@ -87,6 +88,7 @@ resource "test_resource" "b" {
 	ctx := &MockEvalContext{
 		StateState:     state,
 		ChangesChanges: plans.NewChanges().SyncWrapper(),
+		DeferralsState: deferring.NewDeferred(false),
 	}
 
 	callback := getResourcesForPolicyCallback(ctx, walkApply, nil, providerSchema, config)


### PR DESCRIPTION
This PR updates the `getresources` and `getdatasource` callbacks to correctly return `partial` and `deferred` responses respectively when a deferral is encountered.

- For `getresources`: If the target resource type matches a deferred resource's type, then we will mark the callback response as `partial: true` as we can't accurately determine if the deferred resource would match (similar to unknown attributes).
- For `getdatasource`: If the `ReadDataSource` provider response indicates deferral, we will mark the callback response as `deferred: true` as well. 

## Target Release

1.17.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
