### PR TITLE
import: return correct error when import target exists in state but not config

### DIFF
--- a/.changes/v1.16/BUG FIXES-20260625-103056.yaml
+++ b/.changes/v1.16/BUG FIXES-20260625-103056.yaml
@@ -1,0 +1,5 @@
+kind: BUG FIXES
+body: return correct error when import target exists in state, but not config
+time: 2026-06-25T10:30:56.385054-04:00
+custom:
+    Issue: "38782"

--- a/internal/terraform/context_apply_import_test.go
+++ b/internal/terraform/context_apply_import_test.go
@@ -5,6 +5,7 @@ package terraform
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/zclconf/go-cty/cty"
@@ -261,5 +262,62 @@ func TestContextApply_import_duplication(t *testing.T) {
 	// the parent module import takes precedence (confirming the comment in refactoring/import_statement.go)
 	if got, want := attrs["id"], "rootimport"; got != want {
 		t.Fatalf("wrong id! got:  %#v  want: %#v\n", got, want)
+	}
+}
+
+func TestContextApply_import_in_state_not_config(t *testing.T) {
+	// regression test for https://github.com/hashicorp/terraform/issues/38660:
+	// ensure a clear error when the requested import resource exists in state
+	// but not config
+	m := testModuleInline(t, map[string]string{
+		"main.tf": `
+			import {
+				to = test_object.foo
+				id = "importable"
+			}
+		`,
+	})
+
+	p := simpleMockProvider()
+	p.ImportResourceStateResponse = &providers.ImportResourceStateResponse{
+		ImportedResources: []providers.ImportedResource{
+			{
+				TypeName: "test_object",
+				State: cty.ObjectVal(map[string]cty.Value{
+					"test_string": cty.StringVal("importable"),
+				}),
+			},
+		},
+	}
+	p.ReadResourceResponse = &providers.ReadResourceResponse{
+		NewState: cty.ObjectVal(map[string]cty.Value{
+			"test_string": cty.StringVal("hi, mom!"),
+		}),
+	}
+
+	state := states.BuildState(func(s *states.SyncState) {
+		s.SetResourceInstanceCurrent(
+			mustResourceInstanceAddr("test_object.foo"),
+			&states.ResourceInstanceObjectSrc{
+				Status:    states.ObjectReady,
+				AttrsJSON: []byte(`{"id":"foo"}`),
+			},
+			mustProviderConfig(`provider["registry.terraform.io/hashicorp/test"]`),
+		)
+	})
+
+	ctx := testContext2(t, &ContextOpts{
+		Providers: map[addrs.Provider]providers.Factory{
+			addrs.NewDefaultProvider("test"): testProviderFuncFixed(p),
+		},
+	})
+
+	// verify the module is valid
+	diags := ctx.Validate(m, &ValidateOpts{})
+	tfdiags.AssertNoDiagnostics(t, diags)
+
+	_, diags = ctx.Plan(m, state, nil)
+	if !strings.Contains(diags.Err().Error(), "Configuration for import target does not exist") {
+		t.Fatalf("wrong error! got %s\n", diags.Err())
 	}
 }

--- a/internal/terraform/node_resource_plan.go
+++ b/internal/terraform/node_resource_plan.go
@@ -303,9 +303,14 @@ func (n *nodeExpandPlannableResource) expandResourceImports(ctx EvalContext, all
 
 	// filter out any known import which already exist in state
 	for _, el := range knownImports.Elements() {
-		if state.ResourceInstance(el.Key) != nil {
-			log.Printf("[DEBUG] expandResourceImports: skipping import address %s already in state", el.Key)
-			knownImports.Remove(el.Key)
+		// if the resource exists in state, but not config, we will not remove
+		// the target and instead let validateImportTargets return the proper
+		// "missing config" error
+		if n.Config != nil {
+			if state.ResourceInstance(el.Key) != nil {
+				log.Printf("[DEBUG] expandResourceImports: skipping import address %s already in state", el.Key)
+				knownImports.Remove(el.Key)
+			}
 		}
 	}
 


### PR DESCRIPTION
Previously, if an import target existed in state, terraform would remove that target from knownImports. This resulted in a confusing error during plan if the target also did not exist in configuration (see #38660)

This PR skips removing the import target from KnownImports so that the missing config can be caught by later validation, in `validateExpandedImportTargets`. We could also return the error directly in `expandResourceImports` - I'm happy to make that change, it just felt (arbitrarily) right to let the caller handle the situation 🤷🏻 .


<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Fixes #38660

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.16.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [ ] This change is not user-facing.
