### PR TITLE
New Resource Lifecycle option: destroy = false

### DIFF
--- a/.changes/v1.16/ENHANCEMENTS-20260625-131757.yaml
+++ b/.changes/v1.16/ENHANCEMENTS-20260625-131757.yaml
@@ -1,0 +1,5 @@
+kind: ENHANCEMENTS
+body: Support destroy=false in resource lifecycle blocks.
+time: 2026-06-25T13:17:57.053523-04:00
+custom:
+    Issue: "38784"

--- a/internal/command/e2etest/forget_test.go
+++ b/internal/command/e2etest/forget_test.go
@@ -1,0 +1,71 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package e2etest
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform/internal/e2e"
+)
+
+func TestForget(t *testing.T) {
+	skipIfCannotAccessNetwork(t)
+
+	fixturePath := filepath.Join("testdata", "forget-lifecycle")
+	tf := e2e.NewBinary(t, terraformBin, fixturePath)
+
+	// zero out any existing cli config file by passing in an empty file.
+	configFile := emptyConfigFileForTests(t, tf.WorkDir())
+	tf.AddEnv(fmt.Sprintf("TF_CLI_CONFIG_FILE=%s", configFile))
+
+	_, stderr, err := tf.Run("init")
+	if err != nil {
+		t.Fatalf("unexpected error: %s\nstderr:\n%s", err, stderr)
+	}
+
+	stdout, stderr, err := tf.Run("apply", "--auto-approve")
+	if err != nil {
+		t.Fatalf("unexpected error: %s\nstderr:\n%s", err, stderr)
+	}
+	if !strings.Contains(stdout, "Apply complete! Resources: 2 added, 0 changed, 0 destroyed.") {
+		t.Errorf("missing expected output:\n%s", stdout)
+	}
+
+	stdout, stderr, err = tf.Run("destroy", "--auto-approve")
+	if err != nil {
+		t.Fatalf("unexpected error: %s\nstderr:\n%s", err, stderr)
+	}
+	if !strings.Contains(stdout, "Destroy complete! Resources: 0 destroyed.") {
+		t.Errorf("missing expected output:\n%s", stdout)
+	}
+	if !strings.Contains(stdout, "will no longer be managed by Terraform") {
+		t.Fatalf("missing forget message from output")
+	}
+
+	// recreate
+	_, stderr, err = tf.Run("apply", "--auto-approve")
+	if err != nil {
+		t.Fatalf("unexpected error: %s\nstderr:\n%s", err, stderr)
+	}
+
+	// taint
+	_, stderr, err = tf.Run("taint", "module.child.random_pet.child")
+	if err != nil {
+		t.Fatalf("unexpected error: %s\nstderr:\n%s", err, stderr)
+	}
+
+	stdout, stderr, err = tf.Run("apply", "--auto-approve")
+	if err != nil {
+		t.Fatalf("unexpected error: %s\nstderr:\n%s", err, stderr)
+	}
+	if !strings.Contains(stdout, "Apply complete! Resources: 1 added, 0 changed, 0 destroyed.") {
+		t.Errorf("missing expected output:\n%s", stdout)
+	}
+	if !strings.Contains(stdout, "will no longer be managed by Terraform") {
+		t.Fatalf("missing forget message from output")
+	}
+}

--- a/internal/command/e2etest/testdata/forget-lifecycle/child/main.tf
+++ b/internal/command/e2etest/testdata/forget-lifecycle/child/main.tf
@@ -1,0 +1,5 @@
+resource "random_pet" "child" {
+    lifecycle {
+      destroy = false
+    }
+}

--- a/internal/command/e2etest/testdata/forget-lifecycle/main.tf
+++ b/internal/command/e2etest/testdata/forget-lifecycle/main.tf
@@ -1,0 +1,9 @@
+resource "random_pet" "root" {
+    lifecycle {
+      destroy = false
+    }
+}
+
+module "child" {
+    source = "./child"
+}

--- a/internal/command/jsonformat/plan.go
+++ b/internal/command/jsonformat/plan.go
@@ -246,7 +246,7 @@ func (plan Plan) renderHuman(renderer Renderer, mode plans.Mode, opts ...plans.Q
 			buf.WriteString(fmt.Sprintf("%d to import, ", importingCount))
 		}
 		buf.WriteString(fmt.Sprintf("%d to add, %d to change, %d to destroy.",
-			counts[plans.Create]+counts[plans.DeleteThenCreate]+counts[plans.CreateThenDelete],
+			counts[plans.Create]+counts[plans.DeleteThenCreate]+counts[plans.CreateThenDelete]+counts[plans.CreateThenForget],
 			counts[plans.Update],
 			counts[plans.Delete]+counts[plans.DeleteThenCreate]+counts[plans.CreateThenDelete]),
 		)

--- a/internal/configs/resource.go
+++ b/internal/configs/resource.go
@@ -62,11 +62,13 @@ type ManagedResource struct {
 
 	CreateBeforeDestroy bool
 	PreventDestroy      bool
+	Destroy             bool
 	IgnoreChanges       []hcl.Traversal
 	IgnoreAllChanges    bool
 
 	CreateBeforeDestroySet bool
 	PreventDestroySet      bool
+	DestroySet             bool
 }
 
 type ListResource struct {
@@ -218,6 +220,12 @@ func decodeResourceBlock(block *hcl.Block, override bool, allowExperiments bool)
 				diags = diags.Extend(hclDiags)
 
 				r.TriggersReplacement = append(r.TriggersReplacement, exprs...)
+			}
+
+			if attr, exists := lcContent.Attributes["destroy"]; exists {
+				valDiags := gohcl.DecodeExpression(attr.Expr, nil, &r.Managed.Destroy)
+				diags = append(diags, valDiags...)
+				r.Managed.DestroySet = true
 			}
 
 			if attr, exists := lcContent.Attributes["ignore_changes"]; exists {
@@ -996,6 +1004,9 @@ var resourceLifecycleBlockSchema = &hcl.BodySchema{
 		},
 		{
 			Name: "replace_triggered_by",
+		},
+		{
+			Name: "destroy",
 		},
 	},
 	Blocks: []hcl.BlockHeaderSchema{

--- a/internal/plans/changes.go
+++ b/internal/plans/changes.go
@@ -455,7 +455,7 @@ func (rc *ResourceInstanceChange) Simplify(destroying bool) *ResourceInstanceCha
 		switch rc.Action {
 		case Delete:
 			// We'll fall out and just return rc verbatim, then.
-		case CreateThenDelete, DeleteThenCreate:
+		case CreateThenDelete, DeleteThenCreate, CreateThenForget:
 			return &ResourceInstanceChange{
 				Addr:         rc.Addr,
 				DeposedKey:   rc.DeposedKey,
@@ -506,7 +506,7 @@ func (rc *ResourceInstanceChange) Simplify(destroying bool) *ResourceInstanceCha
 					GeneratedConfig: rc.GeneratedConfig,
 				},
 			}
-		case CreateThenDelete, DeleteThenCreate:
+		case CreateThenDelete, DeleteThenCreate, CreateThenForget:
 			return &ResourceInstanceChange{
 				Addr:         rc.Addr,
 				DeposedKey:   rc.DeposedKey,

--- a/internal/terraform/context_apply2_test.go
+++ b/internal/terraform/context_apply2_test.go
@@ -5193,15 +5193,18 @@ resource test_object default {}
 
 		plan, diags := ctx.Plan(m, state, nil)
 		if len(diags) != 1 {
-			t.Errorf("wrong number of diagnostics. Got %d, expected %d\n", len(diags), 1)
+			t.Fatalf("wrong number of diagnostics. Got %d, expected %d\n", len(diags), 1)
 		}
 		if !strings.Contains(diags.ErrWithWarnings().Error(), "Some objects will no longer be managed by Terraform") {
-			t.Errorf("missing expected diagnostic")
+			t.Fatal("missing expected diagnostic")
 		}
 		assertPlan(t, plan, forget, plans.CreateThenForget)
 
 		state, applyDiags := ctx.Apply(plan, m, nil)
 		assertNoDiagnostics(t, applyDiags)
+		if len(state.AllResourceInstanceObjectAddrs()) != 3 {
+			t.Fatalf("wrong number of resources remaining in state")
+		}
 	})
 
 	t.Run("remember", func(t *testing.T) {

--- a/internal/terraform/context_apply2_test.go
+++ b/internal/terraform/context_apply2_test.go
@@ -17,10 +17,10 @@ import (
 
 	"github.com/davecgh/go-spew/spew"
 	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/hcl/v2"
 	"github.com/zclconf/go-cty-debug/ctydebug"
 	"github.com/zclconf/go-cty/cty"
 
-	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/checks"
 	"github.com/hashicorp/terraform/internal/collections"
@@ -5029,4 +5029,191 @@ resource "test_object" "a" {
 	if diags.HasErrors() {
 		t.Fatalf("apply: %s", diags.Err())
 	}
+}
+
+func TestContext2Apply_forget_resource_lifecycle(t *testing.T) {
+	m := testModuleInline(t, map[string]string{
+		"main.tf": `
+resource test_object forget {
+	lifecycle {
+		destroy = false
+	}
+}
+
+resource test_object destroy {
+	lifecycle {
+		destroy = true
+	}
+}
+
+resource test_object default {}
+`})
+
+	p := simpleMockProvider()
+	hook := new(MockHook)
+	ctx := testContext2(t, &ContextOpts{
+		Hooks: []Hook{hook},
+		Providers: map[addrs.Provider]providers.Factory{
+			addrs.NewDefaultProvider("test"): testProviderFuncFixed(p),
+		},
+	})
+
+	forget := mustResourceInstanceAddr("test_object.forget")
+	destroy := mustResourceInstanceAddr("test_object.destroy")
+	defaultRes := mustResourceInstanceAddr("test_object.default")
+
+	testState := func() *states.State {
+		state := states.NewState()
+		root := state.EnsureModule(addrs.RootModuleInstance)
+		root.SetResourceInstanceCurrent(
+			forget.Resource,
+			&states.ResourceInstanceObjectSrc{
+				Status:    states.ObjectReady,
+				AttrsJSON: []byte(`{"id":"bar"}`),
+			},
+			mustProviderConfig(`provider["registry.terraform.io/hashicorp/test"]`),
+		)
+		root.SetResourceInstanceCurrent(
+			destroy.Resource,
+			&states.ResourceInstanceObjectSrc{
+				Status:    states.ObjectReady,
+				AttrsJSON: []byte(`{"id":"bar"}`),
+			},
+			mustProviderConfig(`provider["registry.terraform.io/hashicorp/test"]`),
+		)
+		root.SetResourceInstanceCurrent(
+			defaultRes.Resource,
+			&states.ResourceInstanceObjectSrc{
+				Status:    states.ObjectReady,
+				AttrsJSON: []byte(`{"id":"bar"}`),
+			},
+			mustProviderConfig(`provider["registry.terraform.io/hashicorp/test"]`),
+		)
+		return state
+	}
+
+	assertPlan := func(t *testing.T, plan *plans.Plan, inst addrs.AbsResourceInstance, action plans.Action) {
+		t.Helper()
+		change := plan.Changes.ResourceInstance(inst)
+		if change == nil {
+			t.Fatal("expected a change")
+		}
+		if change.Action != action {
+			t.Fatalf("wrong change type for %s. Got %s, wanted %s\n", destroy, change.Action, action)
+		}
+	}
+
+	t.Run("destroy all", func(t *testing.T) {
+		state := testState()
+		plan, diags := ctx.Plan(m, state, &PlanOpts{Mode: plans.DestroyMode})
+		if diags.HasErrors() {
+			t.Fatalf("plan: %s", diags.Err())
+		}
+
+		assertPlan(t, plan, forget, plans.Forget)
+		assertPlan(t, plan, destroy, plans.Delete)
+		assertPlan(t, plan, defaultRes, plans.Delete)
+
+		state, applyDiags := ctx.Apply(plan, m, nil)
+		assertNoDiagnostics(t, applyDiags)
+		if !state.Empty() {
+			t.Fatalf("unexected remaining state")
+		}
+	})
+
+	t.Run("targeted destroy", func(t *testing.T) {
+		p.ApplyResourceChangeCalled = false //reset!
+		state := testState()
+		plan, diags := ctx.Plan(m, state, &PlanOpts{Mode: plans.DestroyMode, Targets: []addrs.Targetable{forget}})
+		if len(diags) != 2 { // usual -target diag + warning about forgetting
+			t.Fatalf("wrong number of diagnostics. Got %d, expected %d\n", len(diags), 2)
+		}
+		if !strings.Contains(diags.ErrWithWarnings().Error(), "Some objects will no longer be managed by Terraform") {
+			t.Fatalf("missing expected diagnostic")
+		}
+		assertPlan(t, plan, forget, plans.Forget)
+
+		change := plan.Changes.ResourceInstance(destroy)
+		if change != nil {
+			t.Fatal("unrelated resource change on a targeted plan?")
+		}
+
+		state, applyDiags := ctx.Apply(plan, m, nil)
+		if len(applyDiags) != 1 { // usual diags when using -target
+			t.Errorf("wrong number of diagnostics. Got %d, expected %d\n", len(diags), 1)
+		}
+		if len(state.AllResourceInstanceObjectAddrs()) != 2 {
+			t.Fatalf("wrong number of resources remaining in state")
+		}
+
+		if p.ApplyResourceChangeCalled {
+			t.Fatalf("no changes should have been applied: forget only")
+		}
+	})
+
+	t.Run("tainted instance (destroy)", func(t *testing.T) {
+		state := states.NewState()
+		root := state.EnsureModule(addrs.RootModuleInstance)
+		root.SetResourceInstanceCurrent(
+			forget.Resource,
+			&states.ResourceInstanceObjectSrc{
+				Status:    states.ObjectTainted,
+				AttrsJSON: []byte(`{"id":"bar"}`),
+			},
+			mustProviderConfig(`provider["registry.terraform.io/hashicorp/test"]`),
+		)
+
+		plan, diags := ctx.Plan(m, state, &PlanOpts{Mode: plans.DestroyMode})
+		if len(diags) != 1 {
+			t.Fatalf("wrong number of diagnostics. Got %d, expected %d\n", len(diags), 2)
+		}
+		if !strings.Contains(diags.ErrWithWarnings().Error(), "Some objects will no longer be managed by Terraform") {
+			t.Fatalf("missing expected diagnostic")
+		}
+		assertPlan(t, plan, forget, plans.Forget)
+
+		state, applyDiags := ctx.Apply(plan, m, nil)
+		assertNoDiagnostics(t, applyDiags)
+		if !state.Empty() {
+			t.Fatalf("unexected remaining state")
+		}
+	})
+
+	t.Run("tainted instance (replace)", func(t *testing.T) {
+		state := states.NewState()
+		root := state.EnsureModule(addrs.RootModuleInstance)
+		root.SetResourceInstanceCurrent(
+			forget.Resource,
+			&states.ResourceInstanceObjectSrc{
+				Status:    states.ObjectTainted,
+				AttrsJSON: []byte(`{"id":"bar"}`),
+			},
+			mustProviderConfig(`provider["registry.terraform.io/hashicorp/test"]`),
+		)
+
+		plan, diags := ctx.Plan(m, state, nil)
+		if len(diags) != 1 {
+			t.Errorf("wrong number of diagnostics. Got %d, expected %d\n", len(diags), 1)
+		}
+		if !strings.Contains(diags.ErrWithWarnings().Error(), "Some objects will no longer be managed by Terraform") {
+			t.Errorf("missing expected diagnostic")
+		}
+		assertPlan(t, plan, forget, plans.CreateThenForget)
+
+		state, applyDiags := ctx.Apply(plan, m, nil)
+		assertNoDiagnostics(t, applyDiags)
+	})
+
+	t.Run("remember", func(t *testing.T) {
+		// make sure we're not "forgetting" to create
+		plan, diags := ctx.Plan(m, nil, DefaultPlanOpts)
+		assertNoDiagnostics(t, diags)
+		assertPlan(t, plan, forget, plans.Create)
+
+		state, applyDiags := ctx.Apply(plan, m, nil)
+		assertNoDiagnostics(t, applyDiags)
+		if len(state.AllResourceInstanceObjectAddrs()) != 3 {
+			t.Fatalf("wrong number of resources remaining in state")
+		}
+	})
 }

--- a/internal/terraform/context_plan.go
+++ b/internal/terraform/context_plan.go
@@ -864,7 +864,7 @@ func (c *Context) planWalk(config *configs.Config, prevRunState *states.State, o
 
 	var forgottenResources []string
 	for _, rc := range changes.Resources {
-		if rc.Action == plans.Forget {
+		if rc.Action == plans.Forget || rc.Action == plans.CreateThenForget {
 			// TODO KEM display resource ids
 			forgottenResources = append(forgottenResources, fmt.Sprintf(" - %s", rc.Addr))
 		}

--- a/internal/terraform/node_resource_abstract_instance.go
+++ b/internal/terraform/node_resource_abstract_instance.go
@@ -428,9 +428,11 @@ func (n *NodeAbstractResourceInstance) planDestroy(ctx EvalContext, currentState
 		return nil, deferred, diags
 	}
 
-	// If we are in a context where we forget instead of destroying, we can
-	// just return the forget change without consulting the provider.
-	if ctx.Forget() {
+	// If we have a destroy=false lifecycle rule or are in a context where we
+	// forget instead of destroying, we can just return the forget change
+	// without consulting the provider.
+	forget := resourceLifecycleForget(n.Config)
+	if ctx.Forget() || forget {
 		forget, diags := n.planForget(ctx, currentState, deposedKey)
 		return forget, deferred, diags
 	}
@@ -1319,10 +1321,14 @@ func (n *NodeAbstractResourceInstance) plan(
 	// If our prior value was tainted then we actually want this to appear
 	// as a replace change, even though so far we've been treating it as a
 	// create.
+	forget := resourceLifecycleForget(n.Config)
 	if action == plans.Create && !priorValTainted.IsNull() {
-		if createBeforeDestroy {
+		switch {
+		case forget:
+			action = plans.CreateThenForget
+		case createBeforeDestroy:
 			action = plans.CreateThenDelete
-		} else {
+		default:
 			action = plans.DeleteThenCreate
 		}
 		priorVal = priorValTainted
@@ -3441,4 +3447,13 @@ func (n *NodeAbstractResourceInstance) evalApplyActionCondition(ctx EvalContext,
 	}
 
 	return cond.True(), diags
+}
+
+func resourceLifecycleForget(config *configs.Resource) bool {
+	if config != nil && config.Managed != nil {
+		if config.Managed.DestroySet && !config.Managed.Destroy {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/terraform/node_resource_destroy_deposed.go
+++ b/internal/terraform/node_resource_destroy_deposed.go
@@ -275,8 +275,6 @@ func (n *NodeDestroyDeposedResourceInstanceObject) ModifyCreateBeforeDestroy(v b
 
 // GraphNodeExecutable impl.
 func (n *NodeDestroyDeposedResourceInstanceObject) Execute(ctx EvalContext, op walkOperation) (diags tfdiags.Diagnostics) {
-	var change *plans.ResourceInstanceChange
-
 	// Read the state for the deposed resource instance
 	state, err := n.readResourceInstanceStateDeposed(ctx, n.Addr, n.DeposedKey)
 	if err != nil {
@@ -288,7 +286,14 @@ func (n *NodeDestroyDeposedResourceInstanceObject) Execute(ctx EvalContext, op w
 		return diags
 	}
 
-	change, deferred, destroyPlanDiags := n.planDestroy(ctx, state, n.DeposedKey)
+	var change *plans.ResourceInstanceChange
+	var destroyPlanDiags tfdiags.Diagnostics
+	var deferred *providers.Deferred
+	if resourceLifecycleForget(n.Config) {
+		change, destroyPlanDiags = n.planForget(ctx, state, n.DeposedKey)
+	} else {
+		change, deferred, destroyPlanDiags = n.planDestroy(ctx, state, n.DeposedKey)
+	}
 	diags = diags.Append(destroyPlanDiags)
 	if diags.HasErrors() {
 		return diags

--- a/internal/terraform/node_resource_plan_destroy.go
+++ b/internal/terraform/node_resource_plan_destroy.go
@@ -69,15 +69,15 @@ func (n *NodePlanDestroyableResourceInstance) Execute(ctx EvalContext, op walkOp
 
 	switch addr.Resource.Resource.Mode {
 	case addrs.ManagedResourceMode:
-		return n.managedResourceExecute(ctx, op)
+		return n.managedResourceExecute(ctx)
 	case addrs.DataResourceMode:
-		return n.dataResourceExecute(ctx, op)
+		return n.dataResourceExecute(ctx)
 	default:
 		panic(fmt.Errorf("unsupported resource mode %s", n.Config.Mode))
 	}
 }
 
-func (n *NodePlanDestroyableResourceInstance) managedResourceExecute(ctx EvalContext, op walkOperation) (diags tfdiags.Diagnostics) {
+func (n *NodePlanDestroyableResourceInstance) managedResourceExecute(ctx EvalContext) (diags tfdiags.Diagnostics) {
 	addr := n.ResourceInstanceAddr()
 
 	// Declare a bunch of variables that are used for state during
@@ -144,7 +144,7 @@ func (n *NodePlanDestroyableResourceInstance) managedResourceExecute(ctx EvalCon
 	return diags
 }
 
-func (n *NodePlanDestroyableResourceInstance) dataResourceExecute(ctx EvalContext, op walkOperation) (diags tfdiags.Diagnostics) {
+func (n *NodePlanDestroyableResourceInstance) dataResourceExecute(ctx EvalContext) (diags tfdiags.Diagnostics) {
 
 	// We may not be able to read a prior data source from the state if the
 	// schema was upgraded and we are destroying before ever refreshing that

--- a/internal/terraform/node_resource_plan_orphan.go
+++ b/internal/terraform/node_resource_plan_orphan.go
@@ -144,6 +144,12 @@ func (n *NodePlannableResourceInstanceOrphan) managedResourceExecute(ctx EvalCon
 		}
 	}
 
+	if n.Config != nil && n.Config.Managed != nil {
+		if n.Config.Managed.DestroySet && !n.Config.Managed.Destroy {
+			forget = true
+		}
+	}
+
 	if !n.skipRefresh && !forget {
 		// Refresh this instance even though it is going to be destroyed, in
 		// order to catch missing resources. If this is a normal plan,

--- a/internal/terraform/transform_diff.go
+++ b/internal/terraform/transform_diff.go
@@ -107,6 +107,9 @@ func (t *DiffTransformer) Transform(g *Graph) error {
 			update = true
 			delete = true
 			createBeforeDestroy = (rc.Action == plans.CreateThenDelete)
+		case plans.CreateThenForget:
+			update = true
+			forget = true
 		case plans.Forget:
 			forget = true
 		default:


### PR DESCRIPTION
This PR adds support for `destroy = false` inside the managed resource lifecycle. Resources with destroy set to false will be removed from state instead of destroyed.

 
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Fixes #15485, #34439

(It's possible some people will argue this is not a sufficient fix for #34439. Our theory is that this will be sufficient for normal use cases, and anything more complicated _requires_ manual state manipulation to remove individual instances, however if someone has a clear use case that requires both `removed` and resource instances (that's not  resolved with the new destroy lifecycle option) we can re-open or open a new feature request).

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.16.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [ ] This change is not user-facing.
