### PR TITLE
PSS: Make lock handling in the context of PSS in `init` flatter

### DIFF
--- a/internal/command/init.go
+++ b/internal/command/init.go
@@ -590,7 +590,7 @@ func (c *InitCommand) getProvidersFromPSSConfig(ctx context.Context, rootModEarl
 // updated dependency lock data. The dependency lock *file* itself isn't updated here.
 //
 // See getProvidersFromPSSConfig which is equivalent for state store providers.
-func (c *InitCommand) getProviders(ctx context.Context, config *configs.Config, state *states.State, upgrade bool, pssConfigLocks *depsfile.Locks, pluginDirs []string, view views.Init, installerHook providercache.InstallerHook) (output bool, resultingLocks *depsfile.Locks, diags tfdiags.Diagnostics) {
+func (c *InitCommand) getProviders(ctx context.Context, config *configs.Config, state *states.State, upgrade bool, locks *depsfile.Locks, pluginDirs []string, view views.Init, installerHook providercache.InstallerHook) (output bool, resultingLocks *depsfile.Locks, diags tfdiags.Diagnostics) {
 	ctx, span := tracer.Start(ctx, "install providers")
 	defer span.End()
 
@@ -628,18 +628,6 @@ func (c *InitCommand) getProviders(ctx context.Context, config *configs.Config, 
 	if diags.HasErrors() {
 		return false, nil, diags
 	}
-
-	// Create a combination of:
-	// * The 0 or 1 locks from downloading the state store provider earlier in the init command
-	// * Any previous locks from the dependency lock file.
-	// This helps the installer in getProviders re-download locked versions if necessary and avoid re-downloading the state storage provider.
-	var moreDiags tfdiags.Diagnostics
-	previousLocks, moreDiags := c.lockedDependencies()
-	diags = diags.Append(moreDiags)
-	if diags.HasErrors() {
-		return false, nil, diags
-	}
-	inProgressLocks := c.mergeLockedDependencies(pssConfigLocks, previousLocks)
 
 	var inst *providercache.Installer
 	if len(pluginDirs) == 0 {
@@ -704,7 +692,7 @@ func (c *InitCommand) getProviders(ctx context.Context, config *configs.Config, 
 		mode = providercache.InstallUpgrades
 	}
 
-	newLocks, err := inst.EnsureProviderVersions(ctx, inProgressLocks, reqs, mode, installerHook)
+	newLocks, err := inst.EnsureProviderVersions(ctx, locks, reqs, mode, installerHook)
 	if ctx.Err() == context.Canceled {
 		diags = diags.Append(fmt.Errorf("Provider installation was canceled by an interrupt signal."))
 		return true, nil, diags
@@ -726,10 +714,7 @@ func (c *InitCommand) getProviders(ctx context.Context, config *configs.Config, 
 // saveDependencyLockFile overwrites the contents of the dependency lock file.
 // The calling code is expected to provide the previous locks (if any) and the two sets of locks determined from
 // configuration and state data.
-func (c *InitCommand) saveDependencyLockFile(previousLocks, pssLock, providerLocks *depsfile.Locks, flagLockfile string, view views.ProviderInstaller) (output bool, diags tfdiags.Diagnostics) {
-	// Get the combination of locks from both potential provider download steps.
-	newLocks := c.mergeLockedDependencies(pssLock, providerLocks)
-
+func (c *InitCommand) saveDependencyLockFile(previousLocks, newLocks *depsfile.Locks, flagLockfile string, view views.ProviderInstaller) (output bool, diags tfdiags.Diagnostics) {
 	// If the provider dependencies have changed since the last run then we'll
 	// say a little about that in case the reader wasn't expecting a change.
 	// (When we later integrate module dependencies into the lock file we'll

--- a/internal/command/init.go
+++ b/internal/command/init.go
@@ -391,6 +391,10 @@ const (
 // and downloads the provider that isn't already downloaded and then returns
 // updated dependency lock data. The dependency lock file itself isn't updated here.
 //
+// Note: This method gets the required providers in the root module and then creates a new set of requirements
+// that includes only the state store provider. By doing so the provider installation process is guaranteed
+// to only download a single provider, and the method will only return a single lock.
+//
 // Calling code is responsible for validating inputs to this method, e.g. mutually exclusive flags.
 func (c *InitCommand) getProvidersFromPSSConfig(ctx context.Context, rootModEarly *configs.Module, previousLocks *depsfile.Locks, upgrade bool, pluginDirs []string, flagLockfile string, view views.Init) (output bool, resultingLocks *depsfile.Locks, safeInitAction SafeInitAction, authResult *getproviders.PackageAuthenticationResult, diags tfdiags.Diagnostics) {
 	ctx, span := tracer.Start(ctx, "install providers for state store")

--- a/internal/command/init.go
+++ b/internal/command/init.go
@@ -418,7 +418,7 @@ func (c *InitCommand) getProvidersFromPSSConfig(ctx context.Context, rootModEarl
 	// Get the state store provider from the root module's required providers.
 	// The download process is guaranteed to receive a single required provider and return a single lock for that provider.
 	req := make(providerreqs.Requirements, 1)
-	for providerReq := range maps.Values(allReqs.RequiredProviders) {
+	for _, providerReq := range allReqs.RequiredProviders {
 		if providerReq.Type.Equals(rootModEarly.StateStore.ProviderAddr) {
 			con, err := providerreqs.ParseVersionConstraints(providerReq.Requirement.Required.String())
 			if err != nil {

--- a/internal/command/init.go
+++ b/internal/command/init.go
@@ -416,7 +416,8 @@ func (c *InitCommand) getProvidersFromPSSConfig(ctx context.Context, rootModEarl
 	allReqs := rootModEarly.ProviderRequirements
 
 	// Get the state store provider from the root module's required providers.
-	reqs := make(providerreqs.Requirements, 1)
+	// The download process is guaranteed to receive a single required provider and return a single lock for that provider.
+	req := make(providerreqs.Requirements, 1)
 	for providerReq := range maps.Values(allReqs.RequiredProviders) {
 		if providerReq.Type.Equals(rootModEarly.StateStore.ProviderAddr) {
 			con, err := providerreqs.ParseVersionConstraints(providerReq.Requirement.Required.String())
@@ -431,11 +432,11 @@ func (c *InitCommand) getProvidersFromPSSConfig(ctx context.Context, rootModEarl
 					Subject: providerReq.Requirement.DeclRange.Ptr(),
 				})
 			}
-			reqs[providerReq.Type] = con
+			req[providerReq.Type] = con
 		}
 	}
 
-	for providerAddr := range reqs {
+	for providerAddr := range req {
 		if providerAddr.IsLegacy() {
 			diags = diags.Append(tfdiags.Sourceless(
 				tfdiags.Error,
@@ -514,10 +515,10 @@ func (c *InitCommand) getProvidersFromPSSConfig(ctx context.Context, rootModEarl
 			cb := fetchPackageBeginCallback(view)
 			cb(provider, version, location)
 		},
-		QueryPackagesFailure: queryPackagesFailureCallback(&diags, ctx, inst.ProviderSource(), reqs, rootModEarly.StateStore),
+		QueryPackagesFailure: queryPackagesFailureCallback(&diags, ctx, inst.ProviderSource(), req, rootModEarly.StateStore),
 		QueryPackagesWarning: queryPackagesWarningCallback(&diags),
 		LinkFromCacheFailure: linkFromCacheFailureCallback(&diags),
-		FetchPackageFailure:  fetchPackageFailureCallback(&diags, reqs),
+		FetchPackageFailure:  fetchPackageFailureCallback(&diags, req),
 		FetchPackageSuccess: func(provider addrs.Provider, version getproviders.Version, localDir string, authResult *getproviders.PackageAuthenticationResult) {
 			// 1. Capture auth result if this provider is used for state storage.
 			if rootModEarly.StateStore != nil && provider.Equals(rootModEarly.StateStore.ProviderAddr) {
@@ -541,7 +542,7 @@ func (c *InitCommand) getProvidersFromPSSConfig(ctx context.Context, rootModEarl
 
 	// Determine which required providers are already downloaded, and download any
 	// new providers or newer versions of providers
-	configLocks, err := inst.EnsureProviderVersions(ctx, previousLocks, reqs, mode)
+	lock, err := inst.EnsureProviderVersions(ctx, previousLocks, req, mode)
 	if ctx.Err() == context.Canceled {
 		diags = diags.Append(fmt.Errorf("Provider installation was canceled by an interrupt signal."))
 		view.Diagnostics(diags)
@@ -586,7 +587,7 @@ func (c *InitCommand) getProvidersFromPSSConfig(ctx context.Context, rootModEarl
 		}
 	}
 
-	return true, configLocks, safeInitAction, stateStoreProviderAuthResult, diags
+	return true, lock, safeInitAction, stateStoreProviderAuthResult, diags
 }
 
 // getProviders determines what providers are required by the config and state

--- a/internal/command/init_run.go
+++ b/internal/command/init_run.go
@@ -167,7 +167,7 @@ func (c *InitCommand) run(initArgs *arguments.Init, view views.Init) int {
 		return 1
 	}
 
-	var pssLocks *depsfile.Locks // May end up containing 0 or 1 lock, and needs to be able to influence `getProviders` below.
+	var pssLock *depsfile.Locks // May end up containing 0 or 1 lock, and needs to be able to influence `getProviders` below.
 	if rootModEarly.StateStore != nil {
 		// If the user supplies -state-provider-lock-file to init then we need to let those locks influence provider installation.
 		// `alteredPreviousLocks` will only be different from the locks loaded from the working directory if the user supplied a supplementary lock file via -state-provider-lock-file.
@@ -236,7 +236,7 @@ Please use \"terraform state migrate -upgrade\" to upgrade the state store provi
 		var safeInitAction SafeInitAction
 		var stateStoreProviderAuthResult *getproviders.PackageAuthenticationResult
 		var configProviderDiags tfdiags.Diagnostics
-		configProvidersOutput, pssLocks, safeInitAction, stateStoreProviderAuthResult, configProviderDiags = c.getProvidersFromPSSConfig(ctx, rootModEarly, alteredPreviousLocks, allowUpgrade, initArgs.PluginPath, initArgs.Lockfile, view)
+		configProvidersOutput, pssLock, safeInitAction, stateStoreProviderAuthResult, configProviderDiags = c.getProvidersFromPSSConfig(ctx, rootModEarly, alteredPreviousLocks, allowUpgrade, initArgs.PluginPath, initArgs.Lockfile, view)
 		diags = diags.Append(configProviderDiags)
 		if configProviderDiags.HasErrors() {
 			view.Diagnostics(diags)
@@ -255,7 +255,7 @@ Please use \"terraform state migrate -upgrade\" to upgrade the state store provi
 		case SafeInitActionRequireApproval:
 			if c.input {
 				// Prompt the user about trusting the provider used for state storage.
-				diags = diags.Append(c.promptStateStorageProviderApproval(rootModEarly.StateStore.ProviderAddr, pssLocks, stateStoreProviderAuthResult))
+				diags = diags.Append(c.promptStateStorageProviderApproval(rootModEarly.StateStore.ProviderAddr, pssLock, stateStoreProviderAuthResult))
 				if diags.HasErrors() {
 					view.Output(views.StateStoreProviderInteractiveRejectedMessage)
 					view.Diagnostics(diags)
@@ -297,7 +297,7 @@ Please use \"terraform state migrate -upgrade\" to upgrade the state store provi
 	case initArgs.Cloud && rootModEarly.CloudConfig != nil:
 		back, backendOutput, backDiags = c.initCloud(ctx, rootModEarly, initArgs.BackendConfig, initArgs.ViewType, view)
 	case initArgs.Backend:
-		back, backendOutput, backDiags = c.initBackend(ctx, rootModEarly, initArgs, pssLocks, view)
+		back, backendOutput, backDiags = c.initBackend(ctx, rootModEarly, initArgs, pssLock, view)
 	default:
 		// load the previously-stored backend config
 		back, backDiags = c.Meta.backendFromState(ctx)
@@ -436,7 +436,7 @@ Please use \"terraform state migrate -upgrade\" to upgrade the state store provi
 		// If a provider is used for state storage, the lock returned from getProvidersFromPSSConfig
 		// is the only guaranteed source of that lock. We need to ensure its presence to influence
 		// `getProviders`, else that method could download the PSS provider a second time, or download a different version.
-		previousLocksWithPSSOverride = c.mergeLockedDependencies(pssLocks, previousLocksWithPSSOverride)
+		previousLocksWithPSSOverride = c.mergeLockedDependencies(pssLock, previousLocksWithPSSOverride)
 	}
 	stateProvidersOutput, finalLocks, stateProvidersDiags := c.getProviders(ctx, config, state, initArgs.Upgrade, previousLocksWithPSSOverride, initArgs.PluginPath, view, providerHook)
 	diags = diags.Append(stateProvidersDiags)
@@ -457,7 +457,7 @@ Please use \"terraform state migrate -upgrade\" to upgrade the state store provi
 		// then we override the state store provider lock with the pre-upgrade version.
 		// Even if the upgrade process downloaded a newer version of the provider Terraform
 		// will not use it due to the lock file being unchanged.
-		finalLocks = c.mergeLockedDependencies(pssLocks, finalLocks)
+		finalLocks = c.mergeLockedDependencies(pssLock, finalLocks)
 	}
 	lockFileOutput, lockFileDiags := c.saveDependencyLockFile(previousLocks, finalLocks, initArgs.Lockfile, view)
 	diags = diags.Append(lockFileDiags)

--- a/internal/command/init_run.go
+++ b/internal/command/init_run.go
@@ -190,11 +190,11 @@ func (c *InitCommand) run(initArgs *arguments.Init, view views.Init) int {
 			if lock == nil {
 				diags = diags.Append(tfdiags.Sourceless(
 					tfdiags.Error,
-					"State store provider not found in -state-provider-lock-file dependency lock file",
-					fmt.Sprintf("Terraform could not find the state store provider %q (%s) in the dependency lock file %q provided via the -state-provider-lock-file flag. Please ensure the lock file contains a lock for the state store provider and try again.",
+					"State store provider not described in dependency lock file supplied via -state-provider-lock-file flag",
+					fmt.Sprintf("Terraform checked the lock file at %q, supplied via the -state-provider-lock-file flag, but could not find the state store provider %q (%s). To get a sufficient lock file create a minimal configuration with the specific provider and version you want to use described in a required_providers block. Then, perform \"terraform init\" manually to create a dependency lock file describing that provider. After checking the lock file's contents you can retry the original command that produced this error by running: \"terraform init -input=false -state-provider-lock-file=<path to the newly-created lock file>\".",
+						initArgs.StateStoreProviderLockFile,
 						rootModEarly.StateStore.ProviderAddr.Type,
 						rootModEarly.StateStore.ProviderAddr.ForDisplay(),
-						initArgs.StateStoreProviderLockFile,
 					),
 				))
 				view.Diagnostics(diags)

--- a/internal/command/init_run.go
+++ b/internal/command/init_run.go
@@ -159,63 +159,56 @@ func (c *InitCommand) run(initArgs *arguments.Init, view views.Init) int {
 		return 1
 	}
 
-	// If -state-provider-lock-file is set, we'll use that to obtain a new lock used for the state store provider
-	// This will be 'upserted': it may be that the previous locks don't contain the provider being added. potentially due to being empty, or contain a different version.
-	// The lock added will be used in the first step of provider download.
-	//
-	// We load locks from any pre-existing dependency lock file. These may or may not be altered by the -state-provider-lock-file flag.
-	// The altered copy of the locks will be used to influence subsequent provider download steps.
-	// The unaltered copy of the locks will be used at the end of the run to determine whether we need to update the dependency lock file on disk.
+	// Load locks from any pre-existing dependency lock file.
 	previousLocks, locksDiags := c.lockedDependencies()
 	diags = diags.Append(locksDiags)
 	if locksDiags.HasErrors() {
 		view.Diagnostics(diags)
 		return 1
 	}
-	alteredPreviousLocks := previousLocks.DeepCopy()
-	if initArgs.StateStoreProviderLockFile != "" {
-		stateStoreLocks, lockDiags := depsfile.LoadLocksFromFile(initArgs.StateStoreProviderLockFile)
-		if lockDiags.HasErrors() {
-			diags = diags.Append(tfdiags.Sourceless(
-				tfdiags.Error,
-				"Error loading -state-provider-lock-file lock file",
-				fmt.Sprintf("Terraform experienced an error loading the file at %q: %s", initArgs.StateStoreProviderLockFile, lockDiags.Err()),
-			))
-			view.Diagnostics(diags)
-			return 1
-		}
-		diags = diags.Append(lockDiags) // capture any warnings
 
-		lock := stateStoreLocks.Provider(rootModEarly.StateStore.ProviderAddr)
-		if lock == nil {
-			diags = diags.Append(tfdiags.Sourceless(
-				tfdiags.Error,
-				"State store provider not found in -state-provider-lock-file dependency lock file",
-				fmt.Sprintf("Terraform could not find the state store provider %q (%s) in the dependency lock file %q provided via the -state-provider-lock-file flag. Please ensure the lock file contains a lock for the state store provider and try again.",
-					rootModEarly.StateStore.ProviderAddr.Type,
-					rootModEarly.StateStore.ProviderAddr.ForDisplay(),
-					initArgs.StateStoreProviderLockFile,
-				),
-			))
-			view.Diagnostics(diags)
-			return 1
-		}
-
-		// Overwrite or add the state store provider lock to the other locks for this project
-		alteredPreviousLocks.SetProvider(
-			lock.Provider(),
-			lock.Version(),
-			lock.VersionConstraints(),
-			lock.PreferredHashes(),
-		)
-	}
-
-	var pssLocks *depsfile.Locks // May end up containing 0 or 1 lock.
+	var pssLocks *depsfile.Locks // May end up containing 0 or 1 lock, and needs to be able to influence `getProviders` below.
 	if rootModEarly.StateStore != nil {
-		var configProvidersOutput bool
-		var safeInitAction SafeInitAction
-		var stateStoreProviderAuthResult *getproviders.PackageAuthenticationResult
-		var configProviderDiags tfdiags.Diagnostics
+		// If the user supplies -state-provider-lock-file to init then we need to let those locks influence provider installation.
+		// `alteredPreviousLocks` will only be different from the locks loaded from the working directory if the user supplied a supplementary lock file via -state-provider-lock-file.
+		alteredPreviousLocks := previousLocks.DeepCopy()
+
+		if initArgs.StateStoreProviderLockFile != "" {
+			stateStoreLocks, lockDiags := c.readLockedDependenciesFromPath(initArgs.StateStoreProviderLockFile)
+			if lockDiags.HasErrors() {
+				diags = diags.Append(tfdiags.Sourceless(
+					tfdiags.Error,
+					"Error loading -state-provider-lock-file lock file",
+					fmt.Sprintf("Terraform experienced an error loading the file at %q: %s", initArgs.StateStoreProviderLockFile, lockDiags.Err()),
+				))
+				view.Diagnostics(diags)
+				return 1
+			}
+			diags = diags.Append(lockDiags) // capture any warnings
+
+			lock := stateStoreLocks.Provider(rootModEarly.StateStore.ProviderAddr)
+			if lock == nil {
+				diags = diags.Append(tfdiags.Sourceless(
+					tfdiags.Error,
+					"State store provider not found in -state-provider-lock-file dependency lock file",
+					fmt.Sprintf("Terraform could not find the state store provider %q (%s) in the dependency lock file %q provided via the -state-provider-lock-file flag. Please ensure the lock file contains a lock for the state store provider and try again.",
+						rootModEarly.StateStore.ProviderAddr.Type,
+						rootModEarly.StateStore.ProviderAddr.ForDisplay(),
+						initArgs.StateStoreProviderLockFile,
+					),
+				))
+				view.Diagnostics(diags)
+				return 1
+			}
+
+			// Overwrite or add the state store provider lock to the other locks for this project
+			alteredPreviousLocks.SetProvider(
+				lock.Provider(),
+				lock.Version(),
+				lock.VersionConstraints(),
+				lock.PreferredHashes(),
+			)
+		}
 
 		// The init command is not allowed to upgrade the provider used for state storage
 		// We warn that upgrades will not impact the provider, and upgrades will only work via `terraform state migrate -upgrade`.
@@ -239,7 +232,10 @@ Please use \"terraform state migrate -upgrade\" to upgrade the state store provi
 			}
 		}
 
-		// Use alteredPreviousLocks, which may contain an additional lock supplied from the -state-provider-lock-file flag
+		var configProvidersOutput bool
+		var safeInitAction SafeInitAction
+		var stateStoreProviderAuthResult *getproviders.PackageAuthenticationResult
+		var configProviderDiags tfdiags.Diagnostics
 		configProvidersOutput, pssLocks, safeInitAction, stateStoreProviderAuthResult, configProviderDiags = c.getProvidersFromPSSConfig(ctx, rootModEarly, alteredPreviousLocks, allowUpgrade, initArgs.PluginPath, initArgs.Lockfile, view)
 		diags = diags.Append(configProviderDiags)
 		if configProviderDiags.HasErrors() {
@@ -434,7 +430,15 @@ Please use \"terraform state migrate -upgrade\" to upgrade the state store provi
 	}
 
 	// Proceed with downloading providers
-	stateProvidersOutput, providerLocks, stateProvidersDiags := c.getProviders(ctx, config, state, initArgs.Upgrade, pssLocks, initArgs.PluginPath, view, providerHook)
+	var previousLocksWithPSSOverride *depsfile.Locks
+	previousLocksWithPSSOverride = previousLocks.DeepCopy()
+	if rootModEarly.StateStore != nil {
+		// If a provider is used for state storage, the lock returned from getProvidersFromPSSConfig
+		// is the only guaranteed source of that lock. We need to ensure its presence to influence
+		// `getProviders`, else that method could download the PSS provider a second time, or download a different version.
+		previousLocksWithPSSOverride = c.mergeLockedDependencies(pssLocks, previousLocksWithPSSOverride)
+	}
+	stateProvidersOutput, finalLocks, stateProvidersDiags := c.getProviders(ctx, config, state, initArgs.Upgrade, previousLocksWithPSSOverride, initArgs.PluginPath, view, providerHook)
 	diags = diags.Append(stateProvidersDiags)
 	if stateProvidersDiags.HasErrors() {
 		view.PolicyResults(policyResults, nil)
@@ -448,7 +452,14 @@ Please use \"terraform state migrate -upgrade\" to upgrade the state store provi
 	}
 
 	// Update the dependency lock file, if it has changed.
-	lockFileOutput, lockFileDiags := c.saveDependencyLockFile(previousLocks, pssLocks, providerLocks, initArgs.Lockfile, view)
+	if rootModEarly.StateStore != nil && initArgs.Upgrade && !initArgs.Reconfigure {
+		// If there's a provider upgrade happening (outside the context of -reconfigure),
+		// then we override the state store provider lock with the pre-upgrade version.
+		// Even if the upgrade process downloaded a newer version of the provider Terraform
+		// will not use it due to the lock file being unchanged.
+		finalLocks = c.mergeLockedDependencies(pssLocks, finalLocks)
+	}
+	lockFileOutput, lockFileDiags := c.saveDependencyLockFile(previousLocks, finalLocks, initArgs.Lockfile, view)
 	diags = diags.Append(lockFileDiags)
 	if lockFileDiags.HasErrors() {
 		view.Diagnostics(diags)

--- a/internal/command/init_test.go
+++ b/internal/command/init_test.go
@@ -2524,17 +2524,20 @@ func TestInit_getUpgradePlugins(t *testing.T) {
 	})
 
 	t.Run("`init -upgrade` cannot be used to upgrade the state store provider", func(t *testing.T) {
-		// Create a temporary working directory and copy in test fixtures
 		td := t.TempDir()
 		t.Chdir(td)
 
-		// Configuration uses a state store and has other provider requirements.
+		// Configuration uses 2 providers, including one used for a state store.
 		cfg := `
 terraform {
 
   required_providers {
     test = {
       source  = "hashicorp/test"
+      version = "> 1.0.0"
+    }
+    foobar = {
+      source  = "hashicorp/foobar"
       version = "> 1.0.0"
     }
   }
@@ -2550,8 +2553,9 @@ terraform {
 		}
 
 		providerSource := newMockProviderSource(t, map[string][]string{
-			// config requires > 1.0.0
-			"test": {"1.2.3", "9.9.9"},
+			// config requires > 1.0.0 for each of these
+			"test":   {"1.2.3", "9.9.9"},
+			"foobar": {"1.2.3", "9.9.9"},
 		})
 
 		// Mock provider to act as "hashicorp/test"
@@ -2568,14 +2572,24 @@ terraform {
 			AllowExperimentalFeatures: true,
 		}
 
-		// Make Terraform believe that we already have version 1.2.3 installed.
+		// Make Terraform believe that we already have version 1.2.3 installed in a local cache.
 		installFakeProviderPackages(t, &m, map[string][]string{
-			"test": {"1.2.3"},
+			"test":   {"1.2.3"},
+			"foobar": {"1.2.3"},
 		})
-		// Create a dependency lock file describing the hashicorp/test provider at version 1.2.3, to simulate a previous init with that version.
+
+		// Create a dependency lock file describing both providers at version 1.2.3, to simulate a previous init with that version.
 		locks := depsfile.NewLocks()
 		locks.SetProvider(
 			addrs.NewDefaultProvider("test"),
+			getproviders.MustParseVersion("1.2.3"),
+			getproviders.MustParseVersionConstraints("> 1.0.0"),
+			[]getproviders.Hash{
+				getproviders.HashScheme1.New("wlbEC2mChQZ2hhgUhl6SeVLPP7fMqOFUZAQhQ9GIIno="),
+			},
+		)
+		locks.SetProvider(
+			addrs.NewDefaultProvider("foobar"),
 			getproviders.MustParseVersion("1.2.3"),
 			getproviders.MustParseVersionConstraints("> 1.0.0"),
 			[]getproviders.Hash{
@@ -2604,10 +2618,10 @@ terraform {
 			t.Fatalf("expected warning message not found:\n%s", output)
 		}
 
-		// Assert that no providers were upgraded.
+		// What happens in the local cache?
 		//
-		// However, "test" v9.9.9 would be installed in the cache, because the error occurs after the upgrade
-		// process identifies that provider as a candidate for upgrade.
+		// Prior to the upgrade v1.2.3 of both providers was present
+		// After, v9.9.9 of both have been downloaded.
 		cacheDir := m.providerLocalCacheDir()
 		gotPackages := cacheDir.AllAvailablePackages()
 		wantPackages := map[addrs.Provider][]providercache.CachedProvider{
@@ -2623,30 +2637,44 @@ terraform {
 					PackageDir: expectedPackageInstallPath("test", "1.2.3", false),
 				},
 			},
+			addrs.NewDefaultProvider("foobar"): {
+				{
+					Provider:   addrs.NewDefaultProvider("foobar"),
+					Version:    getproviders.MustParseVersion("9.9.9"),
+					PackageDir: expectedPackageInstallPath("foobar", "9.9.9", false),
+				},
+				{
+					Provider:   addrs.NewDefaultProvider("foobar"),
+					Version:    getproviders.MustParseVersion("1.2.3"),
+					PackageDir: expectedPackageInstallPath("foobar", "1.2.3", false),
+				},
+			},
 		}
 		if diff := cmp.Diff(wantPackages, gotPackages); diff != "" {
 			t.Errorf("wrong cache directory contents after upgrade\n%s", diff)
 		}
 
-		// The upgrade process was locked, so the provider locks should not have changed.
-		locks, err := m.lockedDependencies()
-		if err != nil {
-			t.Fatalf("failed to get locked dependencies: %s", err)
-		}
-		gotProviderLocks := locks.AllProviders()
-		wantProviderLocks := map[addrs.Provider]*depsfile.ProviderLock{
-			addrs.NewDefaultProvider("test"): depsfile.NewProviderLock(
-				addrs.NewDefaultProvider("test"),
-				getproviders.MustParseVersion("1.2.3"),
-				getproviders.MustParseVersionConstraints("> 1.0.0"),
-				[]getproviders.Hash{
-					getproviders.HashScheme1.New("wlbEC2mChQZ2hhgUhl6SeVLPP7fMqOFUZAQhQ9GIIno="),
-				},
-			),
-		}
-		if diff := cmp.Diff(gotProviderLocks, wantProviderLocks, depsfile.ProviderLockComparer); diff != "" {
-			t.Errorf("wrong version selections after upgrade\n%s", diff)
-		}
+		// hashicorp/test has not been upgraded in the lock file, while hashicorp/foobar was upgraded.
+		// This is because hashicorp/test is used for state storage.
+		expectedContent := `# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/foobar" {
+  version     = "9.9.9"
+  constraints = "> 1.0.0"
+  hashes = [
+    "h1:cHfrPr8b4Wjf8x014vgi4H3qQ6tOd+vEVchLY0PnuFE=",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/test" {
+  version     = "1.2.3"
+  constraints = "> 1.0.0"
+  hashes = [
+    "h1:wlbEC2mChQZ2hhgUhl6SeVLPP7fMqOFUZAQhQ9GIIno=",
+  ]
+}`
+		assertLockfileContents(t, depsfile.LockFilePath, expectedContent)
 	})
 
 	// A dev_override setting stops a provider being upgraded. That behaviour is tested elsewhere.
@@ -4090,6 +4118,7 @@ func TestInit_stateStore_newWorkingDir_basic(t *testing.T) {
 
 		mockProvider := mockPluggableStateStorageProvider(mockSingleStateStoreSchema("test_store"))
 		mockProviderAddress := addrs.NewDefaultProvider("test")
+
 		providerSource := newMockProviderSource(t, map[string][]string{
 			// The test fixture config has no version constraints, so the latest version will
 			// be used; below is the 'latest' version in the test world.
@@ -8190,4 +8219,18 @@ func mockPluggableStateStorageProvider(schemas map[string]providers.Schema) *tes
 		return resp
 	}
 	return &mock
+}
+
+func assertLockfileContents(t *testing.T, path string, expected string) {
+	t.Helper()
+
+	buf, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("unexpected error accessing lock file: %s", err)
+	}
+	got := bytes.TrimSpace(buf)
+	want := strings.TrimSpace(expected)
+	if diff := cmp.Diff(want, string(got)); diff != "" {
+		t.Errorf("unexpected difference in lock file (%q) content: %s", path, diff)
+	}
 }

--- a/internal/command/init_test.go
+++ b/internal/command/init_test.go
@@ -5213,8 +5213,8 @@ func TestInit_stateStore_newWorkingDir_inAutomationProviderApproval(t *testing.T
 		// Check output via view
 		output := cleanString(testOutput.All())
 		expectedOutputs := []string{
-			"Error: State store provider not found in -state-provider-lock-file dependency lock file",
-			fmt.Sprintf("Terraform could not find the state store provider \"test\" (hashicorp/test) in the dependency lock file \"%s\" provided via the -state-provider-lock-file flag", lockFileName),
+			"Error: State store provider not described in dependency lock file supplied via -state-provider-lock-file flag",
+			fmt.Sprintf("Terraform checked the lock file at %q, supplied via the -state-provider-lock-file flag, but could not find the state store provider", lockFileName),
 		}
 		for _, expected := range expectedOutputs {
 			if !strings.Contains(output, expected) {

--- a/internal/command/meta_dependencies.go
+++ b/internal/command/meta_dependencies.go
@@ -87,7 +87,7 @@ func (m *Meta) mergeLockedDependencies(baseLocks, additionalLocks *depsfile.Lock
 	for _, lock := range additionalLocks.AllProviders() {
 		match := mergedLocks.Provider(lock.Provider())
 		if match != nil {
-			log.Printf("[TRACE] Ignoring provider %s version %s in mergeLockedDependencies; lock file contains %s version %s already",
+			log.Printf("[TRACE] Ignoring provider %s version %s in mergeLockedDependencies; lock file contains %s provider already, at version %s",
 				lock.Provider(),
 				lock.Version(),
 				match.Provider(),


### PR DESCRIPTION
Changed after discussion (can see old description for details).

This PR moves logic for merging groups of provider locks up and out of helper methods on the init command struct, and instead performs those merges inline in the command's Run method. This makes it easier to see what's happening with locks during the command, as there's a lot happening:

- Previous locks (if any) need to be loaded from file - this impacts both download of the PSS provider and download of providers generally.
    - Code: https://github.com/hashicorp/terraform/blob/4516d09e9ce1433b2bb3d6cd93c0dc4f67ea0030/internal/command/init_run.go#L162-L168
- Supplementary locks (via `-state-provider-lock-file`, if any) need to be used alongside previous locks to influence download of the PSS provider via `getProvidersFromPSSConfig`
    - Code in this block: https://github.com/hashicorp/terraform/blob/4516d09e9ce1433b2bb3d6cd93c0dc4f67ea0030/internal/command/init_run.go#L176
- The lock returned from downloading the PSS provider needs to be used for initialising the backend
    - Code: https://github.com/hashicorp/terraform/blob/4516d09e9ce1433b2bb3d6cd93c0dc4f67ea0030/internal/command/init_run.go#L300
-  The lock returned from downloading the PSS provider also needs to be combined with the previous locks from disk to influence the general download of providers via `getProviders`, i.e. make sure the version used for PSS is adhered to in second download step.
    - Code: https://github.com/hashicorp/terraform/blob/4516d09e9ce1433b2bb3d6cd93c0dc4f67ea0030/internal/command/init_run.go#L432-L441
- When saving locks to disk, the lock returned from `getProvidersFromPSSConfig` (if any) needs to be authoritative for that provider. 
    - Code: https://github.com/hashicorp/terraform/blob/4516d09e9ce1433b2bb3d6cd93c0dc4f67ea0030/internal/command/init_run.go#L454-L462 


## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.16.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
