### PR TITLE
Evaluate policies for no-op changes

### DIFF
--- a/internal/policy/proto/types.pb.go
+++ b/internal/policy/proto/types.pb.go
@@ -114,6 +114,7 @@ const (
 	Operation_CREATE Operation = 0
 	Operation_UPDATE Operation = 1
 	Operation_DELETE Operation = 2
+	Operation_NO_OP  Operation = 3
 )
 
 // Enum value maps for Operation.
@@ -122,11 +123,13 @@ var (
 		0: "CREATE",
 		1: "UPDATE",
 		2: "DELETE",
+		3: "NO_OP",
 	}
 	Operation_value = map[string]int32{
 		"CREATE": 0,
 		"UPDATE": 1,
 		"DELETE": 2,
+		"NO_OP":  3,
 	}
 )
 
@@ -380,14 +383,15 @@ const file_types_proto_rawDesc = "" +
 	"\x15ERROR_EVALUATE_RESULT\x10\x02\x12\x19\n" +
 	"\x15ALLOW_EVALUATE_RESULT\x10\x03\x12\x18\n" +
 	"\x14DENY_EVALUATE_RESULT\x10\x04\x12\x1f\n" +
-	"\x1bSETUP_ERROR_EVALUATE_RESULT\x10\x05*/\n" +
+	"\x1bSETUP_ERROR_EVALUATE_RESULT\x10\x05*:\n" +
 	"\tOperation\x12\n" +
 	"\n" +
 	"\x06CREATE\x10\x00\x12\n" +
 	"\n" +
 	"\x06UPDATE\x10\x01\x12\n" +
 	"\n" +
-	"\x06DELETE\x10\x02B4Z2github.com/hashicorp/terraform-policy-plugin/protob\x06proto3"
+	"\x06DELETE\x10\x02\x12\t\n" +
+	"\x05NO_OP\x10\x03B4Z2github.com/hashicorp/terraform-policy-plugin/protob\x06proto3"
 
 var (
 	file_types_proto_rawDescOnce sync.Once

--- a/internal/policy/proto/types.proto
+++ b/internal/policy/proto/types.proto
@@ -51,6 +51,7 @@ enum Operation {
   CREATE = 0;
   UPDATE = 1;
   DELETE = 2;
+  NO_OP = 3;
 }
 
 message ResourceAttributes {

--- a/internal/stacks/stackruntime/plan_test.go
+++ b/internal/stacks/stackruntime/plan_test.go
@@ -7029,10 +7029,8 @@ func TestPlan_WithPolicyResultsOnRefresh(t *testing.T) {
 	})
 
 	wantPolicyResults := map[string]map[string]plans.PolicyEvaluation{
-		// The module runtime currently does not evaluate resource policies during refresh, only module policies
-		`component.simple_component["comp1"]`: createExpectedComponentInstancePolicyEvaluationForModules("policy-evaluation"),
-		`component.simple_component["comp2"]`: createExpectedComponentInstancePolicyEvaluationForModules("policy-evaluation"),
-
+		`component.simple_component["comp1"]`:                                  createExpectedComponentInstancePolicyEvaluation("policy-evaluation"),
+		`component.simple_component["comp2"]`:                                  createExpectedComponentInstancePolicyEvaluation("policy-evaluation"),
 		`provider["registry.terraform.io/hashicorp/testing"].default["comp1"]`: createExpectedProviderInstancePolicyEvaluation("policy-evaluation"),
 		`provider["registry.terraform.io/hashicorp/testing"].default["comp2"]`: createExpectedProviderInstancePolicyEvaluation("policy-evaluation"),
 	}
@@ -7361,7 +7359,7 @@ func policyEvaluationTestClient(t *testing.T) *policy.MockClient {
 			t.Fatalf(`unexpected resource evaluated, wanted: testing_resource, got: %q`, req.Target)
 		}
 
-		// If we're creating, validate the attr data
+		// validate the attr data if it exists
 		if req.PriorAttrs.Raw.IsNull() {
 			if req.Attrs.Raw == cty.NilVal || req.Attrs.Raw.IsNull() {
 				t.Fatal(`unexpected resource data, wanted: attr.value to start with "hello", attrs was <null>`)
@@ -7369,11 +7367,6 @@ func policyEvaluationTestClient(t *testing.T) *policy.MockClient {
 			val := req.Attrs.Raw.GetAttr("value")
 			if !strings.HasPrefix(val.AsString(), "hello") {
 				t.Fatalf(`unexpected resource data, wanted: attr.value to start with "hello", got: %q`, val.AsString())
-			}
-		} else {
-			// Otherwise, assume we're destroying (since we have no tests exercising updates)
-			if !req.Attrs.Raw.IsNull() {
-				t.Fatalf(`unexpected resource data, wanted: <null>, got: %s`, req.Attrs.Raw.GoString())
 			}
 		}
 

--- a/internal/terraform/context_apply_policy_test.go
+++ b/internal/terraform/context_apply_policy_test.go
@@ -5,6 +5,7 @@ package terraform
 
 import (
 	"context"
+	"path/filepath"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -14,13 +15,16 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/terraform/internal/addrs"
+	"github.com/hashicorp/terraform/internal/configs/configload"
 	"github.com/hashicorp/terraform/internal/configs/configschema"
 	"github.com/hashicorp/terraform/internal/plans"
+	"github.com/hashicorp/terraform/internal/plans/planfile"
 	"github.com/hashicorp/terraform/internal/policy"
 	"github.com/hashicorp/terraform/internal/policy/proto"
 	"github.com/hashicorp/terraform/internal/providers"
 	testing_provider "github.com/hashicorp/terraform/internal/providers/testing"
 	"github.com/hashicorp/terraform/internal/states"
+	"github.com/hashicorp/terraform/internal/states/statefile"
 	"github.com/hashicorp/terraform/internal/tfdiags"
 	"github.com/zclconf/go-cty/cty"
 	"go.opentelemetry.io/otel"
@@ -29,6 +33,20 @@ import (
 	"go.opentelemetry.io/otel/trace"
 	"google.golang.org/protobuf/testing/protocmp"
 )
+
+const samplePolicyConfig = `
+		resource_policy "test_resource" "policy_name" {
+					enforce {
+							condition = attrs.sensitive_value == "foo"
+			}
+		}
+
+		resource_policy "test_instance" "policy_with_cb" {
+			enforce {
+				condition = core::getresources("some_resource_type", {})[0].value != null
+			}
+		}
+		`
 
 func TestContext2Apply_PolicyEvaluation_Full(t *testing.T) {
 	mainConfig := `
@@ -80,17 +98,10 @@ func TestContext2Apply_PolicyEvaluation_Full(t *testing.T) {
 		}
 
 		`
-	policyConfig := `
-		resource_policy "test_resource" "policy_name" {
-					enforce {
-							condition = attrs.sensitive_value == "foo"
-			}
-		}
-		`
 	configFiles := map[string]string{
 		"main.tf":           mainConfig,
 		"child/child.tf":    childConfig,
-		"main.tfpolicy.hcl": policyConfig,
+		"main.tfpolicy.hcl": samplePolicyConfig,
 	}
 
 	mod := testModuleInline(t, configFiles)
@@ -358,17 +369,10 @@ func TestContext2Apply_PolicyEvaluationError(t *testing.T) {
 		}
 
 		`
-	policyConfig := `
-		resource_policy "test_resource" "policy_name" {
-					enforce {
-							condition = attrs.sensitive_value == "foo"
-			}
-		}
-		`
 	configFiles := map[string]string{
 		"main.tf":           mainConfig,
 		"child/child.tf":    childConfig,
-		"main.tfpolicy.hcl": policyConfig,
+		"main.tfpolicy.hcl": samplePolicyConfig,
 	}
 
 	mod := testModuleInline(t, configFiles)
@@ -718,17 +722,9 @@ func TestContext2Apply_PolicyEvaluation_NoResourceAfterPolicy(t *testing.T) {
 		}
 	`
 
-	policyConfig := `
-		resource_policy "test_instance" "policy_name" {
-			enforce {
-				condition = true
-			}
-		}
-	`
-
 	mod := testModuleInline(t, map[string]string{
 		"main.tf":           mainConfig,
-		"main.tfpolicy.hcl": policyConfig,
+		"main.tfpolicy.hcl": samplePolicyConfig,
 	})
 
 	providerAddr := addrs.NewDefaultProvider("test")
@@ -864,16 +860,9 @@ resource "test_resource" "test" {
 		}
 ` + tc.configBody
 
-			policyConfig := `
-		resource_policy "test_resource" "policy_name" {
-			enforce {
-				condition = true
-			}
-		}
-`
 			mod := testModuleInline(t, map[string]string{
 				"main.tf":           mainConfig,
-				"main.tfpolicy.hcl": policyConfig,
+				"main.tfpolicy.hcl": samplePolicyConfig,
 			})
 
 			providerAddr := addrs.NewDefaultProvider("test")
@@ -949,6 +938,139 @@ resource "test_resource" "test" {
 	}
 }
 
+func TestContext2Apply_PolicyEvaluation_NoOpOperation(t *testing.T) {
+	mainConfig := `
+		terraform {
+			required_providers {
+				test = {
+					source = "hashicorp/test"
+					version = "1.0.0"
+				}
+			}
+		}
+
+		resource "test_resource" "test" {
+			sensitive_value = "same"
+		}
+	`
+
+	mod := testModuleInline(t, map[string]string{
+		"main.tf":           mainConfig,
+		"main.tfpolicy.hcl": samplePolicyConfig,
+	})
+
+	state := states.BuildState(func(ss *states.SyncState) {
+		ss.SetResourceInstanceCurrent(
+			mustResourceInstanceAddr("test_resource.test"),
+			&states.ResourceInstanceObjectSrc{
+				Status:    states.ObjectReady,
+				AttrsJSON: []byte(`{"id":"existing","sensitive_value":"same"}`),
+			},
+			mustProviderConfig(`provider["registry.terraform.io/hashicorp/test"]`),
+		)
+	})
+
+	providerAddr := addrs.NewDefaultProvider("test")
+	provider := testProvider("test")
+	provider.ApplyResourceChangeFn = func(req providers.ApplyResourceChangeRequest) (resp providers.ApplyResourceChangeResponse) {
+		t.Fatal("apply should not call ApplyResourceChange for a no-op resource")
+		return resp
+	}
+
+	ctx, diags := NewContext(&ContextOpts{
+		Providers: map[addrs.Provider]providers.Factory{
+			providerAddr: testProviderFuncFixed(provider),
+		},
+		Parallelism: 1,
+	})
+	tfdiags.AssertNoDiagnostics(t, diags)
+
+	planPolicyClient := policy.NewTestMockClient(t)
+	plan, diags := ctx.Plan(mod, state, &PlanOpts{
+		Mode:         plans.NormalMode,
+		SetVariables: testInputValuesUnset(mod.Module.Variables),
+		PolicyClient: planPolicyClient,
+	})
+	tfdiags.AssertNoDiagnostics(t, diags)
+
+	cases := []struct {
+		name        string
+		preparePlan func(*testing.T, *plans.Plan) *plans.Plan
+	}{
+		{
+			name: "in-memory plan",
+			preparePlan: func(t *testing.T, plan *plans.Plan) *plans.Plan {
+				return plan
+			},
+		},
+		{
+			name:        "saved plan round trip",
+			preparePlan: asSavedPlan,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			applyPlan := tc.preparePlan(t, plan)
+
+			applyPolicyClient := policy.NewTestMockClient(t)
+			var evaluateCalled int
+			applyPolicyClient.EvaluateFn = func(ctx context.Context, req policy.EvaluationRequest[*proto.PolicyEvaluateResourceRequest_ResourceMetadata]) policy.EvaluationResponse {
+				evaluateCalled++
+				if diff := cmp.Diff(req.Meta, &proto.PolicyEvaluateResourceRequest_ResourceMetadata{
+					ProviderType: "test",
+					Operation:    proto.Operation_NO_OP,
+				}, protocmp.Transform()); diff != "" {
+					t.Fatalf("unexpected resource metadata (-got +want):\n%s", diff)
+				}
+
+				actualAttrs := req.Attrs.Raw
+				if actualAttrs.IsNull() {
+					t.Fatal("expected non-null attrs for no-op evaluation")
+				}
+				actualAttrs = cty.ObjectVal(map[string]cty.Value{
+					"id":              actualAttrs.GetAttr("id"),
+					"sensitive_value": actualAttrs.GetAttr("sensitive_value"),
+				})
+				wantAttrs := cty.ObjectVal(map[string]cty.Value{
+					"id":              cty.StringVal("existing"),
+					"sensitive_value": cty.StringVal("same"),
+				})
+				if diff := cmp.Diff(actualAttrs, wantAttrs, cmp.Comparer(cty.Value.RawEquals)); diff != "" {
+					t.Fatalf("unexpected attrs (-got +want):\n%s", diff)
+				}
+
+				actualPrior := req.PriorAttrs.Raw
+				if actualPrior.IsNull() {
+					t.Fatal("expected non-null prior attrs for no-op evaluation")
+				}
+				actualPrior = cty.ObjectVal(map[string]cty.Value{
+					"id":              actualPrior.GetAttr("id"),
+					"sensitive_value": actualPrior.GetAttr("sensitive_value"),
+				})
+				wantAttrs = cty.ObjectVal(map[string]cty.Value{
+					"id":              cty.StringVal("existing"),
+					"sensitive_value": cty.StringVal("same"),
+				})
+				if diff := cmp.Diff(actualPrior, wantAttrs, cmp.Comparer(cty.Value.RawEquals)); diff != "" {
+					t.Fatalf("unexpected prior attrs (-got +want):\n%s", diff)
+				}
+
+				return policy.EvaluationResponse{Overall: policy.AllowResult}
+			}
+
+			_, diags = ctx.Apply(applyPlan, mod, &ApplyOpts{
+				PolicyClient: applyPolicyClient,
+			})
+			tfdiags.AssertNoDiagnostics(t, diags)
+
+			if evaluateCalled != 1 {
+				t.Fatalf("expected 1 policy evaluation call for no-op resource, got %d", evaluateCalled)
+			}
+		})
+	}
+}
+
 func TestContext2Apply_PolicyEvaluation_PartialApply(t *testing.T) {
 	mainConfig := `
 		terraform {
@@ -968,17 +1090,10 @@ func TestContext2Apply_PolicyEvaluation_PartialApply(t *testing.T) {
 			value = "fail"
 		}
 		`
-	policyConfig := `
-		resource_policy "test_resource" "policy_name" {
-			enforce {
-				condition = true
-			}
-		}
-	`
 
 	mod := testModuleInline(t, map[string]string{
 		"main.tf":           mainConfig,
-		"main.tfpolicy.hcl": policyConfig,
+		"main.tfpolicy.hcl": samplePolicyConfig,
 	})
 	providerAddr := addrs.NewDefaultProvider("test")
 	provider := testProvider("test")
@@ -1061,16 +1176,9 @@ func TestContext2Apply_PolicyEvaluation_Destroy(t *testing.T) {
 			sensitive_value = "foo"
 		}
 		`
-	policyConfig := `
-		resource_policy "test_resource" "policy_name" {
-			enforce {
-				condition = true
-			}
-		}
-		`
 	configFiles := map[string]string{
 		"main.tf":           mainConfig,
-		"main.tfpolicy.hcl": policyConfig,
+		"main.tfpolicy.hcl": samplePolicyConfig,
 	}
 
 	mod := testModuleInline(t, configFiles)
@@ -1214,17 +1322,9 @@ func TestContext2Apply_PolicyCallback(t *testing.T) {
 		}
 	`
 
-	policyConfig := `
-		resource_policy "test_instance" "policy_name" {
-			enforce {
-				condition = core::getresources("some_resource_type", {})[0].value != null
-			}
-		}
-	`
-
 	mod := testModuleInline(t, map[string]string{
 		"main.tf":           mainConfig,
-		"main.tfpolicy.hcl": policyConfig,
+		"main.tfpolicy.hcl": samplePolicyConfig,
 	})
 
 	providerAddr := addrs.NewDefaultProvider("test")
@@ -1745,16 +1845,9 @@ func TestContext2Apply_PolicySpanParentage(t *testing.T) {
 			ami = "bar"
 		}
 	`
-	policyConfig := `
-		resource_policy "test_instance" "policy_name" {
-			enforce {
-				condition = attrs.ami != ""
-			}
-		}
-	`
 	mod := testModuleInline(t, map[string]string{
 		"main.tf":           mainConfig,
-		"main.tfpolicy.hcl": policyConfig,
+		"main.tfpolicy.hcl": samplePolicyConfig,
 	})
 
 	providerAddr := addrs.NewDefaultProvider("test")
@@ -1895,16 +1988,9 @@ func TestContext2Apply_PolicyPhaseSpanOutlivesEvaluations(t *testing.T) {
 			ami = "fresh"
 		}
 	`
-	policyConfig := `
-		resource_policy "test_instance" "policy_name" {
-			enforce {
-				condition = true
-			}
-		}
-	`
 	mod := testModuleInline(t, map[string]string{
 		"main.tf":           mainConfig,
-		"main.tfpolicy.hcl": policyConfig,
+		"main.tfpolicy.hcl": samplePolicyConfig,
 	})
 
 	providerAddr := addrs.NewDefaultProvider("test")
@@ -2053,4 +2139,43 @@ func TestContext2Apply_PolicyPhaseSpanOutlivesEvaluations(t *testing.T) {
 	if checkedDescendants == 0 {
 		t.Fatal("no descendant spans were found under any policy phase span; the test did not exercise nested policy evaluation as intended")
 	}
+}
+
+// asSavedPlan saves the given plan to a temporary file and returns a new plan read from that file.
+func asSavedPlan(t *testing.T, plan *plans.Plan) *plans.Plan {
+	t.Helper()
+
+	planPath := filepath.Join(t.TempDir(), "plan.tfplan")
+	planToSave := *plan
+	if planToSave.Backend == nil && planToSave.StateStore == nil {
+		backendConfig, err := plans.NewDynamicValue(cty.EmptyObjectVal, cty.EmptyObject)
+		if err != nil {
+			t.Fatalf("failed to create backend config value: %s", err)
+		}
+		planToSave.Backend = &plans.Backend{
+			Type:      "local",
+			Config:    backendConfig,
+			Workspace: "default",
+		}
+	}
+	if err := planfile.Create(planPath, planfile.CreateArgs{
+		ConfigSnapshot:       configload.NewEmptySnapshot(),
+		PreviousRunStateFile: statefile.New(plan.PrevRunState.DeepCopy(), "test-lineage", 1),
+		StateFile:            statefile.New(plan.PriorState.DeepCopy(), "test-lineage", 2),
+		Plan:                 &planToSave,
+	}); err != nil {
+		t.Fatalf("failed to create saved plan: %s", err)
+	}
+
+	reader, err := planfile.Open(planPath)
+	if err != nil {
+		t.Fatalf("failed to open saved plan: %s", err)
+	}
+	defer reader.Close()
+
+	roundTripped, err := reader.ReadPlan()
+	if err != nil {
+		t.Fatalf("failed to read saved plan: %s", err)
+	}
+	return roundTripped
 }

--- a/internal/terraform/context_plan_policy_test.go
+++ b/internal/terraform/context_plan_policy_test.go
@@ -248,7 +248,7 @@ func TestContext2Plan_PolicyEvaluation(t *testing.T) {
 		},
 		{
 			name:        "orphaned resource instance: policy is evaluated",
-			expectCalls: 1,
+			expectCalls: 2,
 			mainConfig: `
 				terraform {
 					required_providers {
@@ -331,10 +331,14 @@ func TestContext2Plan_PolicyEvaluation(t *testing.T) {
 						t.Errorf("Unexpected diff (-got +want):\n%s", diff)
 					}
 
-					if diff := cmp.Diff(req.Meta, &proto.PolicyEvaluateResourceRequest_ResourceMetadata{
+					expectedMeta := &proto.PolicyEvaluateResourceRequest_ResourceMetadata{
 						ProviderType: "test",
-						Operation:    proto.Operation_DELETE,
-					}, protocmp.Transform()); diff != "" {
+						Operation:    proto.Operation_NO_OP,
+					}
+					if req.Target == "test_instance" {
+						expectedMeta.Operation = proto.Operation_DELETE
+					}
+					if diff := cmp.Diff(req.Meta, expectedMeta, protocmp.Transform()); diff != "" {
 						t.Errorf("Invalid resource metadata: %s", diff)
 					}
 
@@ -1490,17 +1494,9 @@ func TestContext2Plan_PolicyEvaluation_NoResourceRunsAfterPolicy(t *testing.T) {
 		}
 	`
 
-	policyConfig := `
-		resource_policy "test_instance" "policy_name" {
-			enforce {
-				condition = true
-			}
-		}
-	`
-
 	mod := testModuleInline(t, map[string]string{
 		"main.tf":           mainConfig,
-		"main.tfpolicy.hcl": policyConfig,
+		"main.tfpolicy.hcl": samplePolicyConfig,
 	})
 
 	providerAddr := addrs.NewDefaultProvider("test")
@@ -1704,10 +1700,6 @@ resource_policy "test_resource" "policy_name" {
 	}
 
 	policyClient := policy.NewTestMockClient(t)
-	policyClient.EvaluateFn = func(ctx context.Context, req policy.EvaluationRequest[*proto.PolicyEvaluateResourceRequest_ResourceMetadata]) policy.EvaluationResponse {
-		t.Fatalf("expected policy evaluation to be skipped for import block planning, got request for %s", req.Target)
-		return policy.EvaluationResponse{}
-	}
 
 	ctx, diags := NewContext(&ContextOpts{
 		Providers: map[addrs.Provider]providers.Factory{
@@ -1723,8 +1715,8 @@ resource_policy "test_resource" "policy_name" {
 	})
 	tfdiags.AssertNoDiagnostics(t, diags)
 
-	if policyClient.EvaluateCalled {
-		t.Fatal("expected policy evaluation not to be called for import block planning")
+	if !policyClient.EvaluateCalled {
+		t.Fatal("expected policy evaluation to be called for import block planning")
 	}
 
 	var policyDiags tfdiags.Diagnostics
@@ -1754,17 +1746,9 @@ func TestContext2Plan_PolicyEvaluation_PartialPlan(t *testing.T) {
 		}
 		`
 
-	policyConfig := `
-		resource_policy "test_resource" "policy_name" {
-			enforce {
-				condition = true
-			}
-		}
-	`
-
 	mod := testModuleInline(t, map[string]string{
 		"main.tf":           mainConfig,
-		"main.tfpolicy.hcl": policyConfig,
+		"main.tfpolicy.hcl": samplePolicyConfig,
 	})
 
 	providerAddr := addrs.NewDefaultProvider("test")
@@ -1855,17 +1839,9 @@ func TestContext2Plan_PolicyCallback(t *testing.T) {
 		}
 	`
 
-	policyConfig := `
-		resource_policy "test_instance" "policy_name" {
-			enforce {
-				condition = core::getresources("some_resource_type", {})[0].value != null
-			}
-		}
-	`
-
 	mod := testModuleInline(t, map[string]string{
 		"main.tf":           mainConfig,
-		"main.tfpolicy.hcl": policyConfig,
+		"main.tfpolicy.hcl": samplePolicyConfig,
 	})
 
 	providerAddr := addrs.NewDefaultProvider("test")
@@ -2353,6 +2329,113 @@ func TestContext2Plan_PolicyCallback_GetResources_Deferral(t *testing.T) {
 				t.Errorf("unexpected policy callback results\n%s", diff)
 			}
 		})
+	}
+}
+
+func TestContext2Plan_PolicyEvaluation_NoOpOperation(t *testing.T) {
+	mod := testModuleInline(t, map[string]string{
+		"main.tf": `
+			terraform {
+				required_providers {
+					test = {
+						source = "hashicorp/test"
+						version = "1.0.0"
+					}
+				}
+			}
+
+			resource "test_resource" "test" {
+				sensitive_value = "same"
+			}
+		`,
+		"main.tfpolicy.hcl": `
+			resource_policy "test_resource" "policy_name" {
+				enforce {
+					condition = true
+				}
+			}
+		`,
+	})
+
+	state := states.BuildState(func(ss *states.SyncState) {
+		ss.SetResourceInstanceCurrent(
+			mustResourceInstanceAddr("test_resource.test"),
+			&states.ResourceInstanceObjectSrc{
+				Status:    states.ObjectReady,
+				AttrsJSON: []byte(`{"id":"existing","sensitive_value":"same"}`),
+			},
+			mustProviderConfig(`provider["registry.terraform.io/hashicorp/test"]`),
+		)
+	})
+
+	providerAddr := addrs.NewDefaultProvider("test")
+	provider := testProvider("test")
+	provider.PlanResourceChangeFn = func(req providers.PlanResourceChangeRequest) (resp providers.PlanResourceChangeResponse) {
+		planned := req.ProposedNewState.AsValueMap()
+		if priorID, ok := req.PriorState.AsValueMap()["id"]; ok && priorID.IsKnown() && !priorID.IsNull() {
+			planned["id"] = priorID
+		}
+		resp.PlannedState = cty.ObjectVal(planned)
+		return resp
+	}
+
+	policyClient := policy.NewTestMockClient(t)
+	policyClient.EvaluateFn = func(ctx context.Context, req policy.EvaluationRequest[*proto.PolicyEvaluateResourceRequest_ResourceMetadata]) policy.EvaluationResponse {
+		if diff := cmp.Diff(req.Meta, &proto.PolicyEvaluateResourceRequest_ResourceMetadata{
+			ProviderType: "test",
+			Operation:    proto.Operation_NO_OP,
+		}, protocmp.Transform()); diff != "" {
+			t.Fatalf("unexpected resource metadata (-got +want):\n%s", diff)
+		}
+
+		actualAttrs := req.Attrs.Raw
+		if actualAttrs.IsNull() {
+			t.Fatal("expected non-null attrs for no-op evaluation")
+		}
+		actualAttrs = cty.ObjectVal(map[string]cty.Value{
+			"id":              actualAttrs.GetAttr("id"),
+			"sensitive_value": actualAttrs.GetAttr("sensitive_value"),
+		})
+		wantAttrs := cty.ObjectVal(map[string]cty.Value{
+			"id":              cty.StringVal("existing"),
+			"sensitive_value": cty.StringVal("same"),
+		})
+		if diff := cmp.Diff(actualAttrs, wantAttrs, cmp.Comparer(cty.Value.RawEquals)); diff != "" {
+			t.Fatalf("unexpected attrs (-got +want):\n%s", diff)
+		}
+
+		actualPrior := req.PriorAttrs.Raw
+		if actualPrior.IsNull() {
+			t.Fatal("expected non-null prior attrs for no-op evaluation")
+		}
+		actualPrior = cty.ObjectVal(map[string]cty.Value{
+			"id":              actualPrior.GetAttr("id"),
+			"sensitive_value": actualPrior.GetAttr("sensitive_value"),
+		})
+		if diff := cmp.Diff(actualPrior, wantAttrs, cmp.Comparer(cty.Value.RawEquals)); diff != "" {
+			t.Fatalf("unexpected prior attrs (-got +want):\n%s", diff)
+		}
+
+		return policy.EvaluationResponse{Overall: policy.AllowResult}
+	}
+
+	ctx, diags := NewContext(&ContextOpts{
+		Providers: map[addrs.Provider]providers.Factory{
+			providerAddr: testProviderFuncFixed(provider),
+		},
+		Parallelism: 1,
+	})
+	tfdiags.AssertNoDiagnostics(t, diags)
+
+	_, diags = ctx.Plan(mod, state, &PlanOpts{
+		Mode:         plans.NormalMode,
+		SetVariables: testInputValuesUnset(mod.Module.Variables),
+		PolicyClient: policyClient,
+	})
+	tfdiags.AssertNoDiagnostics(t, diags)
+
+	if !policyClient.EvaluateCalled {
+		t.Fatal("expected policy evaluation to be called for no-op resource")
 	}
 }
 

--- a/internal/terraform/context_plan_policy_test.go
+++ b/internal/terraform/context_plan_policy_test.go
@@ -2439,6 +2439,124 @@ func TestContext2Plan_PolicyEvaluation_NoOpOperation(t *testing.T) {
 	}
 }
 
+func TestContext2Plan_PolicyEvaluation_RefreshOnlyOperation(t *testing.T) {
+	mod := testModuleInline(t, map[string]string{
+		"main.tf": `
+			terraform {
+				required_providers {
+					test = {
+						source = "hashicorp/test"
+						version = "1.0.0"
+					}
+				}
+			}
+
+			resource "test_resource" "test" {
+				sensitive_value = "config"
+			}
+		`,
+		"main.tfpolicy.hcl": `
+			resource_policy "test_resource" "policy_name" {
+				enforce {
+					condition = true
+				}
+			}
+		`,
+	})
+
+	state := states.BuildState(func(ss *states.SyncState) {
+		ss.SetResourceInstanceCurrent(
+			mustResourceInstanceAddr("test_resource.test"),
+			&states.ResourceInstanceObjectSrc{
+				Status:    states.ObjectReady,
+				AttrsJSON: []byte(`{"id":"existing","sensitive_value":"stale"}`),
+			},
+			mustProviderConfig(`provider["registry.terraform.io/hashicorp/test"]`),
+		)
+	})
+
+	providerAddr := addrs.NewDefaultProvider("test")
+	provider := testProvider("test")
+	provider.ReadResourceFn = func(req providers.ReadResourceRequest) (resp providers.ReadResourceResponse) {
+		resp.NewState = cty.ObjectVal(map[string]cty.Value{
+			"id":              cty.StringVal("existing"),
+			"value":           cty.NullVal(cty.String),
+			"sensitive_value": cty.StringVal("current"),
+			"defer":           cty.NullVal(cty.Bool),
+			"random":          cty.NullVal(cty.String),
+			"nesting_single": cty.NullVal(cty.Object(map[string]cty.Type{
+				"value":           cty.String,
+				"sensitive_value": cty.String,
+			})),
+		})
+		return resp
+	}
+
+	policyClient := policy.NewTestMockClient(t)
+	var evaluateCalls int
+	policyClient.EvaluateFn = func(ctx context.Context, req policy.EvaluationRequest[*proto.PolicyEvaluateResourceRequest_ResourceMetadata]) policy.EvaluationResponse {
+		evaluateCalls++
+		if diff := cmp.Diff(req.Meta, &proto.PolicyEvaluateResourceRequest_ResourceMetadata{
+			ProviderType: "test",
+			Operation:    proto.Operation_NO_OP,
+		}, protocmp.Transform()); diff != "" {
+			t.Fatalf("unexpected resource metadata (-got +want):\n%s", diff)
+		}
+
+		actualAttrs := req.Attrs.Raw
+		if actualAttrs.IsNull() {
+			t.Fatal("expected non-null attrs for refresh-only evaluation")
+		}
+		actualAttrs = cty.ObjectVal(map[string]cty.Value{
+			"id":              actualAttrs.GetAttr("id"),
+			"sensitive_value": actualAttrs.GetAttr("sensitive_value"),
+		})
+		wantAttrs := cty.ObjectVal(map[string]cty.Value{
+			"id":              cty.StringVal("existing"),
+			"sensitive_value": cty.StringVal("current"),
+		})
+		if diff := cmp.Diff(actualAttrs, wantAttrs, cmp.Comparer(cty.Value.RawEquals)); diff != "" {
+			t.Fatalf("unexpected attrs (-got +want):\n%s", diff)
+		}
+
+		actualPrior := req.PriorAttrs.Raw
+		if actualPrior.IsNull() {
+			t.Fatal("expected non-null prior attrs for refresh-only evaluation")
+		}
+		actualPrior = cty.ObjectVal(map[string]cty.Value{
+			"id":              actualPrior.GetAttr("id"),
+			"sensitive_value": actualPrior.GetAttr("sensitive_value"),
+		})
+		if diff := cmp.Diff(actualPrior, wantAttrs, cmp.Comparer(cty.Value.RawEquals)); diff != "" {
+			t.Fatalf("unexpected prior attrs (-got +want):\n%s", diff)
+		}
+
+		return policy.EvaluationResponse{Overall: policy.AllowResult}
+	}
+
+	ctx, diags := NewContext(&ContextOpts{
+		Providers: map[addrs.Provider]providers.Factory{
+			providerAddr: testProviderFuncFixed(provider),
+		},
+		Parallelism: 1,
+	})
+	tfdiags.AssertNoDiagnostics(t, diags)
+
+	plan, diags := ctx.Plan(mod, state, &PlanOpts{
+		Mode:         plans.RefreshOnlyMode,
+		SetVariables: testInputValuesUnset(mod.Module.Variables),
+		PolicyClient: policyClient,
+	})
+	tfdiags.AssertNoDiagnostics(t, diags)
+
+	if got := len(plan.Changes.Resources); got != 0 {
+		t.Fatalf("expected refresh-only plan to record no resource changes, got %d", got)
+	}
+	if evaluateCalls != 1 {
+		t.Fatalf("expected 1 policy evaluation call for refresh-only resource, got %d", evaluateCalls)
+	}
+}
+
 func assertPathsEqual(t *testing.T, got, want []cty.Path) {
 	t.Helper()
 

--- a/internal/terraform/eval_context.go
+++ b/internal/terraform/eval_context.go
@@ -183,8 +183,8 @@ type EvalContext interface {
 
 	// PolicyGraph returns the policy subgraph for this context.
 	// It is used to store resource policy nodes that are collected during the resource
-	// graph evaluation. Each resource that produces a plan or state change
-	// will have a corresponding policy node in this graph.
+	// graph evaluation. Each managed resource instance selected for
+	// policy evaluation will have a corresponding policy node in this graph.
 	PolicyGraph() *policySubgraph
 
 	// InstanceExpander returns a helper object for tracking the expansion of

--- a/internal/terraform/graph_builder_apply.go
+++ b/internal/terraform/graph_builder_apply.go
@@ -162,10 +162,11 @@ func (b *ApplyGraphBuilder) Steps() []GraphTransformer {
 		// with dependency edges against the whole-resource nodes added by
 		// ConfigTransformer above.
 		&DiffTransformer{
-			Concrete: concreteResourceInstance,
-			State:    b.State,
-			Changes:  b.Changes,
-			Config:   b.Config,
+			Concrete:     concreteResourceInstance,
+			State:        b.State,
+			Changes:      b.Changes,
+			Config:       b.Config,
+			PolicyClient: b.PolicyClient,
 		},
 
 		&ActionDiffTransformer{

--- a/internal/terraform/node_policy_resource.go
+++ b/internal/terraform/node_policy_resource.go
@@ -54,19 +54,9 @@ func (n *nodeResourcePolicy) Execute(ctx EvalContext, operation walkOperation) t
 
 	modCfg := config.DescendantForInstance(n.ResourceAddr.Module)
 
-	var policyOperation proto.Operation
-	switch action := n.Action; action {
-	case plans.Create:
-		policyOperation = proto.Operation_CREATE
-	case plans.Delete:
-		policyOperation = proto.Operation_DELETE
-	case plans.Update,
-		plans.DeleteThenCreate,
-		plans.CreateThenDelete,
-		plans.CreateThenForget:
-		policyOperation = proto.Operation_UPDATE
-	default:
-		log.Printf("[DEBUG] Unsupported plan action %q, skipping policy evaluation", action)
+	policyOperation, ok := policyOperationForAction(n.Action)
+	if !ok {
+		log.Printf("[DEBUG] Unsupported plan action for policies %q, skipping policy evaluation", n.Action)
 		return nil
 	}
 
@@ -92,6 +82,24 @@ func (n *nodeResourcePolicy) Execute(ctx EvalContext, operation walkOperation) t
 	result := evaluatePolicies(ctx, n.ResourceAddr, resourceConfig, n.After, n.Before, meta, callbacks)
 	ctx.PolicyResults().AddResource(n.ResourceAddr, result, resourceConfig)
 	return diags
+}
+
+func policyOperationForAction(action plans.Action) (proto.Operation, bool) {
+	switch action {
+	case plans.Create:
+		return proto.Operation_CREATE, true
+	case plans.Delete:
+		return proto.Operation_DELETE, true
+	case plans.NoOp:
+		return proto.Operation_NO_OP, true
+	case plans.Update,
+		plans.DeleteThenCreate,
+		plans.CreateThenDelete,
+		plans.CreateThenForget:
+		return proto.Operation_UPDATE, true
+	default:
+		return 0, false
+	}
 }
 
 // policyNodeFromChange creates a nodeResourcePolicy from a ResourceInstanceChange.

--- a/internal/terraform/node_resource_abstract.go
+++ b/internal/terraform/node_resource_abstract.go
@@ -12,9 +12,11 @@ import (
 	"github.com/hashicorp/terraform/internal/configs/configschema"
 	"github.com/hashicorp/terraform/internal/dag"
 	"github.com/hashicorp/terraform/internal/lang/langrefs"
+	"github.com/hashicorp/terraform/internal/plans"
 	"github.com/hashicorp/terraform/internal/providers"
 	"github.com/hashicorp/terraform/internal/states"
 	"github.com/hashicorp/terraform/internal/tfdiags"
+	"github.com/zclconf/go-cty/cty"
 )
 
 // ConcreteResourceNodeFunc is a callback type used to convert an
@@ -641,6 +643,32 @@ func (n *NodeAbstractResource) readResourceInstanceStateDeposed(ctx EvalContext,
 	}
 
 	return obj, diags
+}
+
+func (n *NodeAbstractResource) addPolicyNode(
+	ctx EvalContext,
+	change *plans.ResourceInstanceChange,
+	state *states.ResourceInstanceObject) {
+	if change == nil {
+		return
+	}
+
+	policyGraph := ctx.PolicyGraph()
+	if policyGraph == nil {
+		return
+	}
+
+	after := cty.NilVal
+	if state != nil {
+		after = state.Value
+	}
+	policyGraph.Add(&nodeResourcePolicy{
+		ResourceAddr: change.Addr,
+		ProviderAddr: change.ProviderAddr,
+		Before:       change.Before,
+		After:        after,
+		Action:       change.Action,
+	})
 }
 
 // graphNodesAreResourceInstancesInDifferentInstancesOfSameModule is an

--- a/internal/terraform/node_resource_apply_instance.go
+++ b/internal/terraform/node_resource_apply_instance.go
@@ -267,8 +267,11 @@ func (n *NodeApplyableResourceInstance) managedResourceExecute(ctx EvalContext) 
 	}
 
 	// If there is no change, there was nothing to apply, and we don't need to
-	// re-write the state, but we do need to re-evaluate postconditions.
+	// re-write the state, but we do need to re-evaluate postconditions and
+	// still evaluate policy against the final state.
 	if diffApply.Action == plans.NoOp {
+		n.addPolicyNode(ctx, diffApply, state)
+
 		return diags.Append(n.managedResourcePostconditions(ctx, repData))
 	}
 
@@ -290,17 +293,7 @@ func (n *NodeApplyableResourceInstance) managedResourceExecute(ctx EvalContext) 
 		}
 	} else {
 		// We only add a policy node if the apply was successful.
-		if policyGraph := ctx.PolicyGraph(); policyGraph != nil {
-			// The resource has been applied, so we add a policy node to send its data
-			// for policy evaluation.
-			policyGraph.Add(&nodeResourcePolicy{
-				ResourceAddr: diffApply.Addr,
-				ProviderAddr: diffApply.ProviderAddr,
-				Before:       diffApply.Before,
-				After:        state.Value,
-				Action:       diffApply.Action,
-			})
-		}
+		n.addPolicyNode(ctx, diffApply, state)
 	}
 
 	// We clear the change out here so that future nodes don't see a change

--- a/internal/terraform/node_resource_destroy.go
+++ b/internal/terraform/node_resource_destroy.go
@@ -10,7 +10,6 @@ import (
 	"github.com/hashicorp/terraform/internal/instances"
 	"github.com/hashicorp/terraform/internal/plans"
 	"github.com/hashicorp/terraform/internal/tfdiags"
-	"github.com/zclconf/go-cty/cty"
 
 	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/configs"
@@ -182,21 +181,8 @@ func (n *NodeDestroyResourceInstance) managedResourceExecute(ctx EvalContext) (d
 		return diags.Append(err)
 	}
 
-	if policyGraph := ctx.PolicyGraph(); policyGraph != nil {
-		after := cty.NilVal
-		if state != nil {
-			after = state.Value
-		}
-		// The resource has been destroyed, so we add a policy node to send its data
-		// for policy evaluation.
-		policyGraph.Add(&nodeResourcePolicy{
-			ResourceAddr: changeApply.Addr,
-			ProviderAddr: changeApply.ProviderAddr,
-			Before:       changeApply.Before,
-			After:        after,
-			Action:       changeApply.Action,
-		})
-	}
+	// add a policy node to send the resource data for policy evaluation
+	n.addPolicyNode(ctx, changeApply, state)
 
 	// after destroy we continue to use the before value, since there is no after
 	diags = diags.Append(n.invokeDestroyActions(ctx, configs.AfterDestroy))

--- a/internal/terraform/node_resource_plan_instance.go
+++ b/internal/terraform/node_resource_plan_instance.go
@@ -525,6 +525,21 @@ func (n *NodePlannableResourceInstance) managedResourceExecute(ctx EvalContext) 
 		)
 		diags = diags.Append(checkDiags)
 
+		// We also need to send refreshed objects to the policy.
+		if policyGraph := ctx.PolicyGraph(); policyGraph != nil {
+			value := cty.NilVal
+			if instanceRefreshState != nil {
+				value = instanceRefreshState.Value
+			}
+			policyGraph.Add(&nodeResourcePolicy{
+				ResourceAddr: n.ResourceInstanceAddr(),
+				ProviderAddr: n.ResolvedProvider,
+				Before:       value,
+				After:        value,
+				Action:       plans.NoOp,
+			})
+		}
+
 		// Even if we don't plan changes, we do still need to at least update
 		// the working state to reflect the refresh result. If not, then e.g.
 		// any output values referring to this will not react to the drift.

--- a/internal/terraform/policy_test.go
+++ b/internal/terraform/policy_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform/internal/configs/configschema"
 	"github.com/hashicorp/terraform/internal/plans"
 	"github.com/hashicorp/terraform/internal/plans/deferring"
+	"github.com/hashicorp/terraform/internal/policy/proto"
 	"github.com/hashicorp/terraform/internal/states"
 	"github.com/zclconf/go-cty/cty"
 )
@@ -151,6 +152,40 @@ resource "test_resource" "b" {
 			sort.Strings(wantNames)
 			if diff := cmp.Diff(wantNames, gotNames); diff != "" {
 				t.Fatalf("wrong matched resources (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestPolicyOperationForAction(t *testing.T) {
+	tests := []struct {
+		name      string
+		action    plans.Action
+		want      proto.Operation
+		wantValid bool
+	}{
+		{name: "create", action: plans.Create, want: proto.Operation_CREATE, wantValid: true},
+		{name: "update", action: plans.Update, want: proto.Operation_UPDATE, wantValid: true},
+		{name: "delete-then-create", action: plans.DeleteThenCreate, want: proto.Operation_UPDATE, wantValid: true},
+		{name: "create-then-delete", action: plans.CreateThenDelete, want: proto.Operation_UPDATE, wantValid: true},
+		{name: "create-then-forget", action: plans.CreateThenForget, want: proto.Operation_UPDATE, wantValid: true},
+		{name: "delete", action: plans.Delete, want: proto.Operation_DELETE, wantValid: true},
+		{name: "no-op", action: plans.NoOp, want: proto.Operation_NO_OP, wantValid: true},
+		{name: "read", action: plans.Read, wantValid: false},
+		{name: "forget", action: plans.Forget, wantValid: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := policyOperationForAction(tt.action)
+			if ok != tt.wantValid {
+				t.Fatalf("wrong validity for %s\ngot:  %t\nwant: %t", tt.action, ok, tt.wantValid)
+			}
+			if !tt.wantValid {
+				return
+			}
+			if got != tt.want {
+				t.Fatalf("wrong operation for %s\ngot:  %s\nwant: %s", tt.action, got, tt.want)
 			}
 		})
 	}

--- a/internal/terraform/transform_diff.go
+++ b/internal/terraform/transform_diff.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform/internal/configs"
 	"github.com/hashicorp/terraform/internal/dag"
 	"github.com/hashicorp/terraform/internal/plans"
+	"github.com/hashicorp/terraform/internal/policy"
 	"github.com/hashicorp/terraform/internal/states"
 	"github.com/hashicorp/terraform/internal/tfdiags"
 )
@@ -18,10 +19,11 @@ import (
 // DiffTransformer is a GraphTransformer that adds graph nodes representing
 // each of the resource changes described in the given Changes object.
 type DiffTransformer struct {
-	Concrete ConcreteResourceInstanceNodeFunc
-	State    *states.State
-	Changes  *plans.ChangesSrc
-	Config   *configs.Config
+	Concrete     ConcreteResourceInstanceNodeFunc
+	State        *states.State
+	Changes      *plans.ChangesSrc
+	Config       *configs.Config
+	PolicyClient policy.Client
 }
 
 // return true if the given resource instance has either Preconditions or
@@ -100,7 +102,14 @@ func (t *DiffTransformer) Transform(g *Graph) error {
 			// no reason to process conditions.
 			if dk == states.NotDeposed {
 				update = t.hasConfigConditions(addr)
+
+				// During apply we can also force a node for no-op managed resource changes so that
+				// policy evaluation can still run against unchanged objects.
+				if t.PolicyClient != nil && rc.Addr.Resource.Resource.Mode == addrs.ManagedResourceMode {
+					update = true
+				}
 			}
+
 		case plans.Delete:
 			delete = true
 		case plans.DeleteThenCreate, plans.CreateThenDelete:


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

This change evaluates Terraform Policy for unchanged managed resources by treating `plans.NoOp` as a first-class policy operation during both plan and apply.

Previously, policy evaluation only ran for resources with create, update, or delete actions. That meant unchanged resources could be skipped entirely, potentially leading to policies not being evaluated for plan runs that follow a partial operation. This update closes that gap by ensuring no-op resources are still sent through policy evaluation with explicit `NO_OP` metadata.

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.16.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [ ] This change is not user-facing.
