### PR TITLE
refactor: Change Terraform Policy code in init to reflect that PSS and Terraform Policy are mutually exclusive.

### DIFF
--- a/internal/command/init_run.go
+++ b/internal/command/init_run.go
@@ -210,8 +210,6 @@ func (c *InitCommand) run(initArgs *arguments.Init, view views.Init) int {
 		)
 	}
 
-	policyResults := plans.NewPolicyResults()
-
 	var pssLocks *depsfile.Locks // May end up containing 0 or 1 lock.
 	if rootModEarly.StateStore != nil {
 		var configProvidersOutput bool
@@ -331,6 +329,7 @@ Please use \"terraform state migrate -upgrade\" to upgrade the state store provi
 			return 1
 		}
 	}
+	policyResults := plans.NewPolicyResults()
 	providerHook := &providerPolicyHook{
 		client:        policyClient,
 		policyResults: policyResults,

--- a/internal/command/init_run.go
+++ b/internal/command/init_run.go
@@ -245,7 +245,6 @@ Please use \"terraform state migrate -upgrade\" to upgrade the state store provi
 		configProvidersOutput, pssLocks, safeInitAction, stateStoreProviderAuthResult, configProviderDiags = c.getProvidersFromPSSConfig(ctx, rootModEarly, alteredPreviousLocks, allowUpgrade, initArgs.PluginPath, initArgs.Lockfile, view)
 		diags = diags.Append(configProviderDiags)
 		if configProviderDiags.HasErrors() {
-			view.PolicyResults(policyResults, nil)
 			view.Diagnostics(diags)
 			return 1
 		}


### PR DESCRIPTION
Users cannot use PSS and Terraform Policy at the same time (latter relies on using `cloud`, which is mutually exclusive with `state_store`). This PR pushes code related to TF Policy to later in init, away from a PSS-specific code path.

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.16.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
