### PR TITLE
Add tests defining `version` command's handling of unexpected flags or positional arguments

### DIFF
--- a/internal/command/version_test.go
+++ b/internal/command/version_test.go
@@ -105,6 +105,7 @@ func TestVersion_unexpectedArgsOrFlags(t *testing.T) {
 			Platform:          getproviders.Platform{OS: "aros", Arch: "riscv64"},
 		}
 
+		// Human output
 		args := []string{
 			"foo",
 			"bar",
@@ -117,6 +118,39 @@ func TestVersion_unexpectedArgsOrFlags(t *testing.T) {
 		expected := "Terraform v4.5.6-foo\non aros_riscv64"
 		if actual != expected {
 			t.Fatalf("wrong stdout output\ngot: %#v\nwant: %#v", actual, expected)
+		}
+
+		actual = strings.TrimSpace(ui.ErrorWriter.String())
+		expected = ""
+		if actual != expected {
+			t.Fatalf("wrong stderr output\ngot: %#v\nwant: %#v", actual, expected)
+		}
+
+		// Machine-readable / JSON output
+		ui = new(cli.MockUi)
+		c.Meta = Meta{
+			Ui: ui,
+		}
+		args = []string{
+			"-json",
+			"foo",
+			"bar",
+		}
+		if code := c.Run(args); code != 0 {
+			t.Fatalf("bad: \n%s", ui.ErrorWriter.String())
+		}
+
+		actual = strings.TrimSpace(ui.OutputWriter.String())
+		expected = strings.TrimSpace(`
+{
+  "terraform_version": "4.5.6-foo",
+  "platform": "aros_riscv64",
+  "provider_selections": {},
+  "terraform_outdated": false
+}
+`)
+		if diff := cmp.Diff(expected, actual); diff != "" {
+			t.Fatalf("wrong output\n%s", diff)
 		}
 
 		actual = strings.TrimSpace(ui.ErrorWriter.String())
@@ -140,6 +174,7 @@ func TestVersion_unexpectedArgsOrFlags(t *testing.T) {
 			Platform:          getproviders.Platform{OS: "aros", Arch: "riscv64"},
 		}
 
+		// Human output
 		args := []string{
 			"-foobar",
 		}
@@ -147,14 +182,45 @@ func TestVersion_unexpectedArgsOrFlags(t *testing.T) {
 			t.Fatalf("expected code 1 and error output, but got code %d:\nstdout: %s\nstderr: %s", code, ui.OutputWriter.String(), ui.ErrorWriter.String())
 		}
 
-		// Check stdout
 		actual := strings.TrimSpace(ui.OutputWriter.String())
 		expected := ""
 		if actual != expected {
 			t.Fatalf("wrong stdout output\ngot: %#v\nwant: %#v", actual, expected)
 		}
 
-		// Check stderr
+		actual = strings.TrimSpace(ui.ErrorWriter.String())
+		expected = `Usage: terraform [global options] version [options]
+
+  Displays the version of Terraform and all installed plugins
+
+Options:
+
+  -json       Output the version information as a JSON object.
+Error parsing command-line flags: flag provided but not defined: -foobar`
+		if actual != expected {
+			t.Fatalf("wrong stderr output\ngot: %#v\nwant: %#v", actual, expected)
+		}
+
+		// Machine-readable / JSON output
+		ui = new(cli.MockUi)
+		c.Meta = Meta{
+			Ui: ui,
+		}
+		args = []string{
+			"-json",
+			"-foobar",
+		}
+		if code := c.Run(args); code != 1 {
+			t.Fatalf("expected code 1 and error output, but got code %d:\nstdout: %s\nstderr: %s", code, ui.OutputWriter.String(), ui.ErrorWriter.String())
+		}
+
+		actual = strings.TrimSpace(ui.OutputWriter.String())
+		expected = ""
+		if actual != expected {
+			t.Fatalf("wrong stdout output\ngot: %#v\nwant: %#v", actual, expected)
+		}
+
+		// Human error output is rendered despite -json flag when an error occurs
 		actual = strings.TrimSpace(ui.ErrorWriter.String())
 		expected = `Usage: terraform [global options] version [options]
 

--- a/internal/command/version_test.go
+++ b/internal/command/version_test.go
@@ -60,9 +60,11 @@ func TestVersion(t *testing.T) {
 	if actual != expected {
 		t.Fatalf("wrong output\ngot:\n%s\nwant:\n%s", actual, expected)
 	}
-
 }
 
+// terraform version must support (but not use) -v and -version flags.
+// This is because whenever a user runs `terraform <any command name> -version`, etc, main.go
+// will call the version command with all of the supplied flags and arguments.
 func TestVersion_flags(t *testing.T) {
 	ui := new(cli.MockUi)
 	m := Meta{
@@ -77,7 +79,7 @@ func TestVersion_flags(t *testing.T) {
 		Platform:          getproviders.Platform{OS: "aros", Arch: "riscv64"},
 	}
 
-	if code := c.Run([]string{"-v", "-version"}); code != 0 {
+	if code := c.Run([]string{"-v", "-version", "--version"}); code != 0 {
 		t.Fatalf("bad: \n%s", ui.ErrorWriter.String())
 	}
 

--- a/internal/command/version_test.go
+++ b/internal/command/version_test.go
@@ -90,6 +90,86 @@ func TestVersion_flags(t *testing.T) {
 	}
 }
 
+func TestVersion_unexpectedArgsOrFlags(t *testing.T) {
+	t.Run("unexpected positional arguments are ignored without error", func(t *testing.T) {
+		ui := new(cli.MockUi)
+		m := Meta{
+			Ui: ui,
+		}
+
+		// `terraform version`
+		c := &VersionCommand{
+			Meta:              m,
+			Version:           "4.5.6",
+			VersionPrerelease: "foo",
+			Platform:          getproviders.Platform{OS: "aros", Arch: "riscv64"},
+		}
+
+		args := []string{
+			"foo",
+			"bar",
+		}
+		if code := c.Run(args); code != 0 {
+			t.Fatalf("bad: \n%s", ui.ErrorWriter.String())
+		}
+
+		actual := strings.TrimSpace(ui.OutputWriter.String())
+		expected := "Terraform v4.5.6-foo\non aros_riscv64"
+		if actual != expected {
+			t.Fatalf("wrong stdout output\ngot: %#v\nwant: %#v", actual, expected)
+		}
+
+		actual = strings.TrimSpace(ui.ErrorWriter.String())
+		expected = ""
+		if actual != expected {
+			t.Fatalf("wrong stderr output\ngot: %#v\nwant: %#v", actual, expected)
+		}
+	})
+
+	t.Run("incorrect flag", func(t *testing.T) {
+		ui := new(cli.MockUi)
+		m := Meta{
+			Ui: ui,
+		}
+
+		// `terraform version`
+		c := &VersionCommand{
+			Meta:              m,
+			Version:           "4.5.6",
+			VersionPrerelease: "foo",
+			Platform:          getproviders.Platform{OS: "aros", Arch: "riscv64"},
+		}
+
+		args := []string{
+			"-foobar",
+		}
+		if code := c.Run(args); code != 1 {
+			t.Fatalf("expected code 1 and error output, but got code %d:\nstdout: %s\nstderr: %s", code, ui.OutputWriter.String(), ui.ErrorWriter.String())
+		}
+
+		// Check stdout
+		actual := strings.TrimSpace(ui.OutputWriter.String())
+		expected := ""
+		if actual != expected {
+			t.Fatalf("wrong stdout output\ngot: %#v\nwant: %#v", actual, expected)
+		}
+
+		// Check stderr
+		actual = strings.TrimSpace(ui.ErrorWriter.String())
+		expected = `Usage: terraform [global options] version [options]
+
+  Displays the version of Terraform and all installed plugins
+
+Options:
+
+  -json       Output the version information as a JSON object.
+Error parsing command-line flags: flag provided but not defined: -foobar`
+		if actual != expected {
+			t.Fatalf("wrong stderr output\ngot: %#v\nwant: %#v", actual, expected)
+		}
+	})
+}
+
 func TestVersion_outdated(t *testing.T) {
 	ui := new(cli.MockUi)
 	m := Meta{
@@ -195,7 +275,6 @@ func TestVersion_json(t *testing.T) {
 	if diff := cmp.Diff(expected, actual); diff != "" {
 		t.Fatalf("wrong output\n%s", diff)
 	}
-
 }
 
 func TestVersion_jsonoutdated(t *testing.T) {


### PR DESCRIPTION
These tests are preparation for possible future work where this command is updated to use the arguments or views packages. To avoid breaking changes in behaviour during that work we'd need more comprehensive test coverage to identify behaviour changes and determine if they're acceptable or not.

One change is to update an existing test that checks that the `version` command is compatible with the code below. Basically it means if a user runs something like `terraform -v` or `terraform plan --version` etc then the version command will be executed. All flags and arguments are 'forwarded' to the version command, so this test asserts that no errors will occur in a situation like this.

https://github.com/hashicorp/terraform/blob/ef53cc4fb5850ecc1270b0db0bcff8992afe85f7/main.go#L283-L292

The other change is adding a completely new test characterising:
* How unexpected positional arguments are just ignored and don't raise errors
* How unexpected flags do raise errors, and output includes the help text for the command.

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.16.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
