### PR TITLE
Refactor the `version` command to use the `arguments` package

### DIFF
--- a/internal/command/arguments/version.go
+++ b/internal/command/arguments/version.go
@@ -24,6 +24,10 @@ func ParseVersion(args []string) (*Version, tfdiags.Diagnostics) {
 	// arguments are -v, -version, or --version, the version command will be called
 	// with the rest of the arguments, so we need to be able to cope with
 	// those.
+	//
+	// If the user runs `terraform init -v` then the `-v` flag is never parsed,
+	// however if the user runs `terraform -v` or `terraform version -v` then the flag IS
+	// parsed here.
 	cmdFlags.Bool("v", true, "version")
 	cmdFlags.Bool("version", true, "version")
 
@@ -35,10 +39,14 @@ func ParseVersion(args []string) (*Version, tfdiags.Diagnostics) {
 		))
 	}
 
+	// We purposefully ignore any remaining arguments (flags or positional args) instead of checking them and returning an error.
+	// This is because in main.go the CLI re-routes all commands run with a `-version` flag to the version command (see above).
+	// This enables `terraform -version`, `terraform init -version`, `terraform plan -version` etc. to all work the same as `terraform version`.
+	// All arguments (including the original non-"version" command) are passed to the version command, so we ignore them here.
+	//
+	// For example if a user runs `terraform init -version -upgrade -get=false`, then it's turned into a `terraform version init -version -upgrade -get=false` command.
+	// If we used cmdFlags.Args() to check for remaining arguments in that example there would be extra arguments ["init", "-version", "-upgrade", "-get=false"].
 	_ = cmdFlags.Args()
-	// If this method call returned >0 values it means a user has supplied unexpected positional arguments
-	// But we don't return an error here to preserve the original behavior of the version command.
-	// In future we could return a warning, or an error if we're able to introduce breaking changes.
 
 	var viewType ViewType
 	if jsonOutput {

--- a/internal/command/arguments/version.go
+++ b/internal/command/arguments/version.go
@@ -1,0 +1,54 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package arguments
+
+import (
+	"github.com/hashicorp/terraform/internal/tfdiags"
+)
+
+// Version represents the command-line arguments for the version command.
+type Version struct {
+	// ViewType specifies which output format to use: human, JSON, or "raw".
+	ViewType ViewType
+}
+
+func ParseVersion(args []string, usageFunc func()) (*Version, tfdiags.Diagnostics) {
+	var diags tfdiags.Diagnostics
+
+	var jsonOutput bool
+	cmdFlags := defaultFlagSet("version")
+	cmdFlags.BoolVar(&jsonOutput, "json", false, "produce JSON output")
+
+	// Enable but ignore the global version flags. In main.go, if any of the
+	// arguments are -v, -version, or --version, the version command will be called
+	// with the rest of the arguments, so we need to be able to cope with
+	// those.
+	cmdFlags.Bool("v", true, "version")
+	cmdFlags.Bool("version", true, "version")
+
+	cmdFlags.Usage = usageFunc
+	if err := cmdFlags.Parse(args); err != nil {
+		diags = diags.Append(tfdiags.Sourceless(
+			tfdiags.Error,
+			"Failed to parse command-line flags",
+			err.Error(),
+		))
+	}
+
+	_ = cmdFlags.Args()
+	// If this method call returned >0 values it means a user has supplied unexpected positional arguments
+	// But we don't return an error here to preserve the original behavior of the version command.
+	// In future we could return a warning, or an error if we're able to introduce breaking changes.
+
+	var viewType ViewType
+	if jsonOutput {
+		viewType = ViewJSON
+	} else {
+		viewType = ViewHuman
+	}
+
+	return &Version{
+		ViewType: viewType,
+	}, diags
+}

--- a/internal/command/arguments/version.go
+++ b/internal/command/arguments/version.go
@@ -13,7 +13,7 @@ type Version struct {
 	ViewType ViewType
 }
 
-func ParseVersion(args []string, usageFunc func()) (*Version, tfdiags.Diagnostics) {
+func ParseVersion(args []string) (*Version, tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
 
 	var jsonOutput bool
@@ -27,7 +27,6 @@ func ParseVersion(args []string, usageFunc func()) (*Version, tfdiags.Diagnostic
 	cmdFlags.Bool("v", true, "version")
 	cmdFlags.Bool("version", true, "version")
 
-	cmdFlags.Usage = usageFunc
 	if err := cmdFlags.Parse(args); err != nil {
 		diags = diags.Append(tfdiags.Sourceless(
 			tfdiags.Error,

--- a/internal/command/arguments/version_test.go
+++ b/internal/command/arguments/version_test.go
@@ -40,9 +40,7 @@ func TestParseVersion_valid(t *testing.T) {
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			got, diags := ParseVersion(tc.args, func() {
-				t.Fatal("unexpected error parsing command flags")
-			})
+			got, diags := ParseVersion(tc.args)
 			if len(diags) > 0 {
 				t.Fatalf("unexpected diags: %v", diags)
 			}
@@ -78,7 +76,7 @@ func TestParseVersion_invalid(t *testing.T) {
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			got, gotDiags := ParseVersion(tc.args, func() {})
+			got, gotDiags := ParseVersion(tc.args)
 			if diff := cmp.Diff(tc.want, got, cmpOpts); diff != "" {
 				t.Fatalf("unexpected result\n got: %#v\nwant: %#v", got, tc.want)
 			}

--- a/internal/command/arguments/version_test.go
+++ b/internal/command/arguments/version_test.go
@@ -1,0 +1,88 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package arguments
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/hashicorp/terraform/internal/tfdiags"
+)
+
+func TestParseVersion_valid(t *testing.T) {
+	testCases := map[string]struct {
+		args []string
+		want *Version
+	}{
+		"defaults": {
+			nil,
+			&Version{
+				ViewType: ViewHuman,
+			},
+		},
+		"json": {
+			[]string{"-json"},
+			&Version{
+				ViewType: ViewJSON,
+			},
+		},
+		"too many arguments": { // Old behavior is to tolerate this, but we don't want to break it yet.
+			[]string{"bar", "baz"},
+			&Version{
+				ViewType: ViewHuman,
+			},
+		},
+	}
+
+	cmpOpts := cmpopts.IgnoreUnexported(Vars{})
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			got, diags := ParseVersion(tc.args, func() {
+				t.Fatal("unexpected error parsing command flags")
+			})
+			if len(diags) > 0 {
+				t.Fatalf("unexpected diags: %v", diags)
+			}
+			if diff := cmp.Diff(tc.want, got, cmpOpts); diff != "" {
+				t.Fatalf("unexpected result\n got: %#v\nwant: %#v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestParseVersion_invalid(t *testing.T) {
+	testCases := map[string]struct {
+		args      []string
+		want      *Version
+		wantDiags tfdiags.Diagnostics
+	}{
+		"unknown flag": {
+			[]string{"-boop"},
+			&Version{
+				ViewType: ViewHuman,
+			},
+			tfdiags.Diagnostics{
+				tfdiags.Sourceless(
+					tfdiags.Error,
+					"Failed to parse command-line flags",
+					"flag provided but not defined: -boop",
+				),
+			},
+		},
+	}
+
+	cmpOpts := cmpopts.IgnoreUnexported(Vars{})
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			got, gotDiags := ParseVersion(tc.args, func() {})
+			if diff := cmp.Diff(tc.want, got, cmpOpts); diff != "" {
+				t.Fatalf("unexpected result\n got: %#v\nwant: %#v", got, tc.want)
+			}
+			tfdiags.AssertDiagnosticsMatch(t, gotDiags, tc.wantDiags)
+		})
+	}
+}

--- a/internal/command/arguments/version_test.go
+++ b/internal/command/arguments/version_test.go
@@ -28,8 +28,32 @@ func TestParseVersion_valid(t *testing.T) {
 				ViewType: ViewJSON,
 			},
 		},
-		"too many arguments": { // Old behavior is to tolerate this, but we don't want to break it yet.
-			[]string{"bar", "baz"},
+		// User may run `terraform -v` which becomes `terraform version -v` due to command rerouting.
+		"-v": {
+			[]string{"-v"},
+			&Version{
+				ViewType: ViewHuman,
+			},
+		},
+		// User may run `terraform -version` which becomes `terraform version -version` due to command rerouting.
+		"-version": {
+			[]string{"-version"},
+			&Version{
+				ViewType: ViewHuman,
+			},
+		},
+		// User may run `terraform --version` which becomes `terraform version --version` due to command rerouting.
+		"--version": {
+			[]string{"--version"},
+			&Version{
+				ViewType: ViewHuman,
+			},
+		},
+		// Old behavior we need to preserve (or address in calling code)
+		// The version command could receive this if a user ran `terraform init -version -upgrade -get=false`
+		// and the CLI rerouted it to the version command: `terraform version init -version -upgrade -get=false`
+		"too many arguments, e.g. due to command rerouting": {
+			[]string{"init", "-version", "-upgrade", "-get=false"},
 			&Version{
 				ViewType: ViewHuman,
 			},
@@ -57,7 +81,7 @@ func TestParseVersion_invalid(t *testing.T) {
 		want      *Version
 		wantDiags tfdiags.Diagnostics
 	}{
-		"unknown flag": {
+		"unknown flag": { // This would happen specifically if the user supplied the non existent flag via `terraform -version -boop` or `terraform version -boop`.
 			[]string{"-boop"},
 			&Version{
 				ViewType: ViewHuman,

--- a/internal/command/e2etest/version_test.go
+++ b/internal/command/e2etest/version_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform/internal/e2e"
+	"github.com/hashicorp/terraform/internal/getproviders"
 	"github.com/hashicorp/terraform/version"
 )
 
@@ -96,5 +97,71 @@ func TestVersionWithProvider(t *testing.T) {
 		if !strings.Contains(stdout, wantMsg) {
 			t.Errorf("output does not contain provider information %q:\n%s", wantMsg, stdout)
 		}
+	}
+}
+
+// If users run any command with a -version or -v flag, we reroute to the version command.
+// This test ensures that this rerouting works as expected and defines how additional flags and arguments are handled.
+func TestVersionReroutingFromOtherCommands(t *testing.T) {
+	t.Parallel()
+
+	fixturePath := filepath.Join("testdata", "full-workflow-null")
+	tf := e2e.NewBinary(t, terraformBin, fixturePath)
+
+	wantVersion := fmt.Sprintf("Terraform v%s\non %s\n", version.String(), getproviders.CurrentPlatform.String())
+
+	// Use version command directly
+	// The version command receives no arguments.
+	stdout, stderr, err := tf.Run("version")
+	if err != nil {
+		t.Errorf("unexpected error: %s", err)
+	}
+	if stderr != "" {
+		t.Errorf("unexpected stderr output:\n%s", stderr)
+	}
+	if stdout != wantVersion {
+		t.Errorf("output does not contain our current version %q:\n%s", wantVersion, stdout)
+	}
+
+	// Use version flag with no command
+	// The version command receives arguments: ["-version"]
+	// and accepts the flag.
+	stdout, stderr, err = tf.Run("-version")
+	if err != nil {
+		t.Errorf("unexpected error: %s", err)
+	}
+	if stderr != "" {
+		t.Errorf("unexpected stderr output:\n%s", stderr)
+	}
+	if stdout != wantVersion {
+		t.Errorf("output does not contain our current version %q:\n%s", wantVersion, stdout)
+	}
+
+	// Get version via init command
+	// The version command receives arguments: ["init", "-version"]
+	// but ignores them all.
+	stdout, stderr, err = tf.Run("init", "-version")
+	if err != nil {
+		t.Errorf("unexpected error: %s", err)
+	}
+	if stderr != "" {
+		t.Errorf("unexpected stderr output:\n%s", stderr)
+	}
+	if stdout != wantVersion {
+		t.Errorf("output does not contain our current version %q:\n%s", wantVersion, stdout)
+	}
+
+	// Get version via init command with additional global and init-specific flags present
+	// The version command receives arguments: ["init", "-version", "-input=false", "-no-color", "-get=false", "-upgrade"]
+	// but ignores them all.
+	stdout, stderr, err = tf.Run("init", "-version", "-input=false", "-no-color", "-get=false", "-upgrade")
+	if err != nil {
+		t.Errorf("unexpected error: %s", err)
+	}
+	if stderr != "" {
+		t.Errorf("unexpected stderr output:\n%s", stderr)
+	}
+	if stdout != wantVersion {
+		t.Errorf("output does not contain our current version %q:\n%s", wantVersion, stdout)
 	}
 }

--- a/internal/command/version.go
+++ b/internal/command/version.go
@@ -64,7 +64,7 @@ func (c *VersionCommand) Run(rawArgs []string) int {
 	var latest string
 	var versionString bytes.Buffer
 
-	args, argDiags := arguments.ParseVersion(rawArgs, func() { c.Ui.Error(c.Help()) })
+	args, argDiags := arguments.ParseVersion(rawArgs)
 	if argDiags.HasErrors() {
 		c.showDiagnostics(argDiags)
 		return 1

--- a/internal/command/version.go
+++ b/internal/command/version.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform/internal/addrs"
+	"github.com/hashicorp/terraform/internal/command/arguments"
 	"github.com/hashicorp/terraform/internal/depsfile"
 	"github.com/hashicorp/terraform/internal/getproviders"
 )
@@ -58,25 +59,17 @@ Options:
 	return strings.TrimSpace(helpText)
 }
 
-func (c *VersionCommand) Run(args []string) int {
+func (c *VersionCommand) Run(rawArgs []string) int {
 	var outdated bool
 	var latest string
 	var versionString bytes.Buffer
-	args = c.Meta.process(args)
-	var jsonOutput bool
-	cmdFlags := c.Meta.defaultFlagSet("version")
-	cmdFlags.BoolVar(&jsonOutput, "json", false, "json")
-	// Enable but ignore the global version flags. In main.go, if any of the
-	// arguments are -v, -version, or --version, this command will be called
-	// with the rest of the arguments, so we need to be able to cope with
-	// those.
-	cmdFlags.Bool("v", true, "version")
-	cmdFlags.Bool("version", true, "version")
-	cmdFlags.Usage = func() { c.Ui.Error(c.Help()) }
-	if err := cmdFlags.Parse(args); err != nil {
-		c.Ui.Error(fmt.Sprintf("Error parsing command-line flags: %s\n", err.Error()))
+
+	args, argDiags := arguments.ParseVersion(rawArgs, func() { c.Ui.Error(c.Help()) })
+	if argDiags.HasErrors() {
+		c.showDiagnostics(argDiags)
 		return 1
 	}
+	jsonOutput := args.ViewType == arguments.ViewJSON
 
 	fmt.Fprintf(&versionString, "Terraform v%s", c.Version)
 	if c.VersionPrerelease != "" {

--- a/internal/command/version_test.go
+++ b/internal/command/version_test.go
@@ -189,15 +189,7 @@ func TestVersion_unexpectedArgsOrFlags(t *testing.T) {
 		}
 
 		actual = strings.TrimSpace(ui.ErrorWriter.String())
-		expected = `Usage: terraform [global options] version [options]
-
-  Displays the version of Terraform and all installed plugins
-
-Options:
-
-  -json       Output the version information as a JSON object.
-
-Error: Failed to parse command-line flags
+		expected = `Error: Failed to parse command-line flags
 
 flag provided but not defined: -foobar`
 		if actual != expected {
@@ -225,15 +217,7 @@ flag provided but not defined: -foobar`
 
 		// Human error output is rendered despite -json flag when an error occurs
 		actual = strings.TrimSpace(ui.ErrorWriter.String())
-		expected = `Usage: terraform [global options] version [options]
-
-  Displays the version of Terraform and all installed plugins
-
-Options:
-
-  -json       Output the version information as a JSON object.
-
-Error: Failed to parse command-line flags
+		expected = `Error: Failed to parse command-line flags
 
 flag provided but not defined: -foobar`
 		if actual != expected {

--- a/internal/command/version_test.go
+++ b/internal/command/version_test.go
@@ -196,7 +196,10 @@ func TestVersion_unexpectedArgsOrFlags(t *testing.T) {
 Options:
 
   -json       Output the version information as a JSON object.
-Error parsing command-line flags: flag provided but not defined: -foobar`
+
+Error: Failed to parse command-line flags
+
+flag provided but not defined: -foobar`
 		if actual != expected {
 			t.Fatalf("wrong stderr output\ngot: %#v\nwant: %#v", actual, expected)
 		}
@@ -229,7 +232,10 @@ Error parsing command-line flags: flag provided but not defined: -foobar`
 Options:
 
   -json       Output the version information as a JSON object.
-Error parsing command-line flags: flag provided but not defined: -foobar`
+
+Error: Failed to parse command-line flags
+
+flag provided but not defined: -foobar`
 		if actual != expected {
 			t.Fatalf("wrong stderr output\ngot: %#v\nwant: %#v", actual, expected)
 		}


### PR DESCRIPTION
Following https://github.com/hashicorp/terraform/pull/38799

This is some mild modernisation of the `version` command, done in a way to minimise any output changes.

The only changes are shown by the diff in `internal/command/version_test.go`. This change in natural language output should be acceptable under our [compatibility promises](https://developer.hashicorp.com/terraform/language/v1-compatibility-promises#workflow):

> Natural language command output or log output is not a stable interface and may change in any new version. If you write software that parses this output then it may need to be updated when you upgrade Terraform. If you need access to data that is not currently available via one of the machine-readable JSON interfaces, we suggest opening a feature request to discuss your use-case.

Using the arguments package means that parsing errors are handled as diagnostics and therefore rendered differently. We've also removed the help text being rendered, see below screenshots.

Before:
<img width="586" height="147" alt="Screenshot 2026-07-24 at 17 50 35" src="https://github.com/user-attachments/assets/9052f1d0-ec24-41fe-aa2d-9d0e0b60914e" />

After:
<img width="388" height="85" alt="Screenshot 2026-07-24 at 17 58 30" src="https://github.com/user-attachments/assets/9c6b0cc9-85f3-4ba1-9bae-27779443b61c" />


## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.16.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
