### PR TITLE
Disallow -target when applying a saved plan file

### DIFF
--- a/.changes/v1.16/BUG-FIXES-20260701-092924.yaml
+++ b/.changes/v1.16/BUG-FIXES-20260701-092924.yaml
@@ -1,0 +1,5 @@
+kind: BUG FIXES
+body: "`terraform apply` now returns an error when `-target` is used together with a saved plan file, instead of silently ignoring `-target`"
+time: 2026-07-01T09:29:24.752180-04:00
+custom:
+    Issue: "38807"

--- a/internal/command/apply.go
+++ b/internal/command/apply.go
@@ -73,6 +73,18 @@ func (c *ApplyCommand) Run(rawArgs []string) int {
 		return 1
 	}
 
+	// The -target flag cannot be combined with a saved plan file, because a
+	// saved plan already records the exact set of actions to be applied.
+	if planFile != nil && len(args.Operation.Targets) > 0 {
+		diags = diags.Append(tfdiags.Sourceless(
+			tfdiags.Error,
+			"Can't set targets when applying a saved plan",
+			"The -target option is not allowed when applying a saved plan file, because a saved plan already includes the changes to be applied. To limit the resources affected, use -target when creating the plan with \"terraform plan\".",
+		))
+		view.Diagnostics(diags)
+		return 1
+	}
+
 	// FIXME: the -input flag value is needed to initialize the backend and the
 	// operation, but there is no clear path to pass this value down, so we
 	// continue to mutate the Meta object state for now.


### PR DESCRIPTION
Fixes #38670.

When a saved plan file is passed to `terraform apply`, the plan already contains the exact set of actions to apply, so `-target` has no effect. Today it is silently ignored, which is surprising. This adds a validation in `ApplyCommand.Run` that returns an error when `-target` is combined with a saved plan file, consistent with how Terraform already rejects other plan-incompatible options.

To limit the resources affected, `-target` should be used when creating the plan (`terraform plan -target=...`).

Affected package tests pass locally.