### PR TITLE
Refactor how we use `cli.Ui` in main.go, add new test helper `testUiWrapped` so integration tests use `cli.Ui` the same way as the overall CLI

### DIFF
--- a/internal/command/apply_destroy_test.go
+++ b/internal/command/apply_destroy_test.go
@@ -157,7 +157,7 @@ func TestApply_destroyApproveNo(t *testing.T) {
 
 	// Do not use the NewMockUi initializer here, as we want to delay
 	// the call to init until after setting up the input mocks
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t, new(cli.MockUi))
 	view, done := testView(t)
 	c := &ApplyCommand{
 		Destroy: true,
@@ -225,7 +225,7 @@ func TestApply_destroyApproveYes(t *testing.T) {
 
 	// Do not use the NewMockUi initializer here, as we want to delay
 	// the call to init until after setting up the input mocks
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t, new(cli.MockUi))
 	view, done := testView(t)
 	c := &ApplyCommand{
 		Destroy: true,

--- a/internal/command/apply_test.go
+++ b/internal/command/apply_test.go
@@ -829,7 +829,7 @@ output "foobar" {
 			"hashicorp/test": {"1.2.3"},
 		})
 
-		ui := new(cli.MockUi)
+		ui := testUiWrapped(t)
 		view, done := testView(t)
 		meta := Meta{
 			Ui:                        ui,
@@ -876,7 +876,7 @@ output "foobar" {
 		// Plan - to produce a plan file.
 		//
 		// The plan file will not include version data, as the provider is considered to be a dev override.
-		ui = new(cli.MockUi)
+		ui = testUiWrapped(t)
 		meta.Ui = ui
 		view, done = testView(t)
 		meta.View = view
@@ -891,7 +891,7 @@ output "foobar" {
 		}
 
 		// Apply - to use the plan file that lacks version data.
-		ui = new(cli.MockUi)
+		ui = testUiWrapped(t)
 		meta.Ui = ui
 		view, done = testView(t)
 		meta.View = view
@@ -951,7 +951,7 @@ output "foobar" {
 			"hashicorp/terraform": {"1.2.3"},
 		})
 
-		ui := new(cli.MockUi)
+		ui := testUiWrapped(t)
 		view, done := testView(t)
 		meta := Meta{
 			Ui:                        ui,
@@ -991,7 +991,7 @@ output "foobar" {
 		// Plan - to produce a plan file.
 		//
 		// The plan file will not include version data, as the provider is considered to be a dev override.
-		ui = new(cli.MockUi)
+		ui = testUiWrapped(t)
 		meta.Ui = ui
 		view, done = testView(t)
 		meta.View = view
@@ -1006,7 +1006,7 @@ output "foobar" {
 		}
 
 		// Apply - to use the plan file that lacks version data.
-		ui = new(cli.MockUi)
+		ui = testUiWrapped(t)
 		meta.Ui = ui
 		view, done = testView(t)
 		meta.View = view
@@ -2914,7 +2914,7 @@ func TestApply_terraformEnvNonDefault(t *testing.T) {
 
 	// Create new env
 	{
-		ui := new(cli.MockUi)
+		ui := testUiWrapped(t)
 		newCmd := &WorkspaceNewCommand{
 			Meta: Meta{
 				Ui: ui,
@@ -2928,7 +2928,7 @@ func TestApply_terraformEnvNonDefault(t *testing.T) {
 	// Switch to it
 	{
 		args := []string{"test"}
-		ui := new(cli.MockUi)
+		ui := testUiWrapped(t)
 		selCmd := &WorkspaceSelectCommand{
 			Meta: Meta{
 				Ui: ui,

--- a/internal/command/apply_test.go
+++ b/internal/command/apply_test.go
@@ -119,7 +119,7 @@ func TestApply_approveNo(t *testing.T) {
 
 	// Do not use the NewMockUi initializer here, as we want to delay
 	// the call to init until after setting up the input mocks
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t, new(cli.MockUi))
 
 	p := applyFixtureProvider()
 	view, done := testView(t)
@@ -164,7 +164,7 @@ func TestApply_approveYes(t *testing.T) {
 
 	// Do not use the NewMockUi initializer here, as we want to delay
 	// the call to init until after setting up the input mocks
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t, new(cli.MockUi))
 
 	view, done := testView(t)
 	c := &ApplyCommand{

--- a/internal/command/autocomplete_test.go
+++ b/internal/command/autocomplete_test.go
@@ -7,7 +7,6 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/hashicorp/cli"
 	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/command/workdir"
 	"github.com/hashicorp/terraform/internal/providers"
@@ -22,7 +21,7 @@ func TestMetaCompletePredictWorkspaceName(t *testing.T) {
 		td := t.TempDir()
 		t.Chdir(td)
 
-		ui := new(cli.MockUi)
+		ui := testUiWrapped(t)
 		meta := &Meta{Ui: ui}
 
 		predictor := meta.completePredictWorkspaceName()
@@ -54,7 +53,7 @@ func TestMetaCompletePredictWorkspaceName(t *testing.T) {
 			"hashicorp/test": {"1.0.0"},
 		})
 
-		ui := new(cli.MockUi)
+		ui := testUiWrapped(t)
 		view, _ := testView(t)
 		wd := workdir.NewDir(".")
 		wd.OverrideOriginalWorkingDir(td)
@@ -95,7 +94,7 @@ func TestMetaCompletePredictWorkspaceName(t *testing.T) {
 			"hashicorp/test": {"1.0.0"},
 		})
 
-		ui := new(cli.MockUi)
+		ui := testUiWrapped(t)
 		view, _ := testView(t)
 		wd := workdir.NewDir(".")
 		wd.OverrideOriginalWorkingDir(td)

--- a/internal/command/cloud_test.go
+++ b/internal/command/cloud_test.go
@@ -16,7 +16,6 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/hashicorp/cli"
 	svchost "github.com/hashicorp/terraform-svchost"
 	"github.com/hashicorp/terraform-svchost/auth"
 	"github.com/hashicorp/terraform-svchost/disco"
@@ -130,7 +129,7 @@ func TestCloud_withBackendConfig(t *testing.T) {
 	backendInit.Set("cloud", func() backend.Backend { return backendCloud.New(disco) })
 	defer backendInit.Set("cloud", previousBackend)
 
-	ui := cli.NewMockUi()
+	ui := testUiWrapped(t)
 	view, _ := testView(t)
 
 	// Initialize the backend
@@ -149,7 +148,7 @@ func TestCloud_withBackendConfig(t *testing.T) {
 	}
 
 	// Run the cloud command
-	ui = cli.NewMockUi()
+	ui = testUiWrapped(t)
 	c := &CloudCommand{
 		Meta: Meta{
 			Ui:               ui,
@@ -186,7 +185,7 @@ func TestCloud_withENVConfig(t *testing.T) {
 	defer os.Unsetenv("TF_CLOUD_HOSTNAME")
 
 	// Run the cloud command
-	ui := cli.NewMockUi()
+	ui := testUiWrapped(t)
 	c := &CloudCommand{
 		Meta: Meta{
 			Ui:               ui,

--- a/internal/command/command_test.go
+++ b/internal/command/command_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/hashicorp/terraform/internal/addrs"
 	backendInit "github.com/hashicorp/terraform/internal/backend/init"
 	backendLocal "github.com/hashicorp/terraform/internal/backend/local"
+	"github.com/hashicorp/terraform/internal/command/ui"
 	"github.com/hashicorp/terraform/internal/command/views"
 	"github.com/hashicorp/terraform/internal/command/workdir"
 	"github.com/hashicorp/terraform/internal/configs"
@@ -1254,7 +1255,28 @@ func fakeRegistryHandler(resp http.ResponseWriter, req *http.Request) {
 	}
 }
 
+func testUiWrapped(t *testing.T, testUi ...*cli.MockUi) *ui.WrappedMockUi {
+	t.Helper()
+
+	// Calling code might be opinionated about whether the mock should be
+	// created using the cli.NewMockUi constructor or not. Therefore we let
+	// the caller either pass in a pre-constructed MockUi or let this function
+	// create one for them.
+	var wrappedMock *cli.MockUi
+	switch len(testUi) {
+	case 0:
+		wrappedMock = cli.NewMockUi()
+	case 1:
+		wrappedMock = testUi[0]
+	default:
+		t.Fatalf("incorrect use of testUiWrapped: only zero or one MockUi instance is allowed")
+	}
+
+	return &ui.WrappedMockUi{MockUi: wrappedMock}
+}
+
 func testView(t *testing.T) (*views.View, func(*testing.T) *terminal.TestOutput) {
+	t.Helper()
 	streams, done := terminal.StreamsForTesting(t)
 	return views.NewView(streams), done
 }

--- a/internal/command/console_test.go
+++ b/internal/command/console_test.go
@@ -29,7 +29,7 @@ func TestConsole_basic(t *testing.T) {
 	t.Chdir(tmp)
 
 	p := testProvider()
-	ui := cli.NewMockUi()
+	ui := testUiWrapped(t)
 	view, _ := testView(t)
 	c := &ConsoleCommand{
 		Meta: Meta{
@@ -79,7 +79,7 @@ func TestConsole_tfvars(t *testing.T) {
 			},
 		},
 	}
-	ui := cli.NewMockUi()
+	ui := testUiWrapped(t)
 	view, _ := testView(t)
 	c := &ConsoleCommand{
 		Meta: Meta{
@@ -131,7 +131,7 @@ func TestConsole_unsetRequiredVars(t *testing.T) {
 			},
 		},
 	}
-	ui := cli.NewMockUi()
+	ui := testUiWrapped(t)
 	view, _ := testView(t)
 	c := &ConsoleCommand{
 		Meta: Meta{
@@ -164,7 +164,7 @@ func TestConsole_variables(t *testing.T) {
 	t.Chdir(td)
 
 	p := testProvider()
-	ui := cli.NewMockUi()
+	ui := testUiWrapped(t)
 	view, _ := testView(t)
 	c := &ConsoleCommand{
 		Meta: Meta{
@@ -206,7 +206,7 @@ func TestConsole_modules(t *testing.T) {
 	t.Chdir(td)
 
 	p := applyFixtureProvider()
-	ui := cli.NewMockUi()
+	ui := testUiWrapped(t)
 	view, _ := testView(t)
 
 	c := &ConsoleCommand{
@@ -248,7 +248,7 @@ func TestConsole_modulesPlan(t *testing.T) {
 	t.Chdir(td)
 
 	p := applyFixtureProvider()
-	ui := cli.NewMockUi()
+	ui := testUiWrapped(t)
 	view, _ := testView(t)
 
 	c := &ConsoleCommand{
@@ -393,7 +393,6 @@ func TestConsole_scope(t *testing.T) {
 	}
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-
 			td := t.TempDir()
 			testCopyDir(t, testFixturePath("console-nested-module-scopes"), td)
 			t.Chdir(td)
@@ -463,7 +462,6 @@ func TestConsole_scope_errors(t *testing.T) {
 	}
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-
 			td := t.TempDir()
 			testCopyDir(t, testFixturePath("console-nested-module-scopes"), td)
 			t.Chdir(td)

--- a/internal/command/experimental_test.go
+++ b/internal/command/experimental_test.go
@@ -6,8 +6,6 @@ package command
 import (
 	"strings"
 	"testing"
-
-	"github.com/hashicorp/cli"
 )
 
 func TestInit_stateStoreBlockIsExperimental(t *testing.T) {
@@ -18,7 +16,7 @@ func TestInit_stateStoreBlockIsExperimental(t *testing.T) {
 		testCopyDir(t, testFixturePath("init-with-state-store"), td)
 		t.Chdir(td)
 
-		ui := new(cli.MockUi)
+		ui := testUiWrapped(t)
 		view, done := testView(t)
 		c := &InitCommand{
 			Meta: Meta{
@@ -48,7 +46,7 @@ func TestInit_stateStoreBlockIsExperimental(t *testing.T) {
 		testCopyDir(t, testFixturePath("init-with-state-store"), td)
 		t.Chdir(td)
 
-		ui := new(cli.MockUi)
+		ui := testUiWrapped(t)
 		view, done := testView(t)
 		c := &PlanCommand{
 			Meta: Meta{
@@ -78,7 +76,7 @@ func TestInit_stateStoreBlockIsExperimental(t *testing.T) {
 		testCopyDir(t, testFixturePath("init-with-state-store"), td)
 		t.Chdir(td)
 
-		ui := new(cli.MockUi)
+		ui := testUiWrapped(t)
 		view, done := testView(t)
 		c := &StateListCommand{
 			Meta: Meta{

--- a/internal/command/fmt_test.go
+++ b/internal/command/fmt_test.go
@@ -57,7 +57,7 @@ func TestFmt_MockDataFiles(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			ui := cli.NewMockUi()
+			ui := testUiWrapped(t)
 			c := &FmtCommand{
 				Meta: Meta{
 					testingOverrides: metaOverridesForProvider(testProvider()),
@@ -123,7 +123,7 @@ func TestFmt_TestFiles(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			ui := cli.NewMockUi()
+			ui := testUiWrapped(t)
 			c := &FmtCommand{
 				Meta: Meta{
 					testingOverrides: metaOverridesForProvider(testProvider()),
@@ -189,7 +189,7 @@ func TestFmt_QueryFiles(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			ui := cli.NewMockUi()
+			ui := testUiWrapped(t)
 			c := &FmtCommand{
 				Meta: Meta{
 					testingOverrides: metaOverridesForProvider(testProvider()),
@@ -255,7 +255,7 @@ func TestFmt(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			ui := cli.NewMockUi()
+			ui := testUiWrapped(t)
 			c := &FmtCommand{
 				Meta: Meta{
 					testingOverrides: metaOverridesForProvider(testProvider()),
@@ -284,7 +284,7 @@ func TestFmt_nonexist(t *testing.T) {
 
 	tempDir := fmtFixtureWriteDir(t)
 
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	c := &FmtCommand{
 		Meta: Meta{
 			testingOverrides: metaOverridesForProvider(testProvider()),
@@ -318,7 +318,7 @@ a = 1 +
 		t.Fatal(err)
 	}
 
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	c := &FmtCommand{
 		Meta: Meta{
 			testingOverrides: metaOverridesForProvider(testProvider()),
@@ -349,7 +349,7 @@ func TestFmt_snippetInError(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	c := &FmtCommand{
 		Meta: Meta{
 			testingOverrides: metaOverridesForProvider(testProvider()),
@@ -386,7 +386,7 @@ func TestFmt_manyArgs(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	c := &FmtCommand{
 		Meta: Meta{
 			testingOverrides: metaOverridesForProvider(testProvider()),
@@ -426,7 +426,7 @@ func TestFmt_workingDirectory(t *testing.T) {
 	}
 	defer os.Chdir(cwd)
 
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	c := &FmtCommand{
 		Meta: Meta{
 			testingOverrides: metaOverridesForProvider(testProvider()),
@@ -449,7 +449,7 @@ func TestFmt_directoryArg(t *testing.T) {
 	t.Parallel()
 	tempDir := fmtFixtureWriteDir(t)
 
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	c := &FmtCommand{
 		Meta: Meta{
 			testingOverrides: metaOverridesForProvider(testProvider()),
@@ -477,7 +477,7 @@ func TestFmt_fileArg(t *testing.T) {
 	t.Parallel()
 	tempDir := fmtFixtureWriteDir(t)
 
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	c := &FmtCommand{
 		Meta: Meta{
 			testingOverrides: metaOverridesForProvider(testProvider()),
@@ -506,7 +506,7 @@ func TestFmt_stdinArg(t *testing.T) {
 	input := new(bytes.Buffer)
 	input.Write(fmtFixture.input)
 
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	c := &FmtCommand{
 		Meta: Meta{
 			testingOverrides: metaOverridesForProvider(testProvider()),
@@ -530,7 +530,7 @@ func TestFmt_nonDefaultOptions(t *testing.T) {
 	t.Parallel()
 	tempDir := fmtFixtureWriteDir(t)
 
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	c := &FmtCommand{
 		Meta: Meta{
 			testingOverrides: metaOverridesForProvider(testProvider()),
@@ -558,7 +558,7 @@ func TestFmt_check(t *testing.T) {
 	t.Parallel()
 	tempDir := fmtFixtureWriteDir(t)
 
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	c := &FmtCommand{
 		Meta: Meta{
 			testingOverrides: metaOverridesForProvider(testProvider()),

--- a/internal/command/fmt_test.go
+++ b/internal/command/fmt_test.go
@@ -588,7 +588,7 @@ func TestFmt_checkStdin(t *testing.T) {
 	input := new(bytes.Buffer)
 	input.Write(fmtFixture.input)
 
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t, new(cli.MockUi))
 	c := &FmtCommand{
 		Meta: Meta{
 			testingOverrides: metaOverridesForProvider(testProvider()),

--- a/internal/command/get_test.go
+++ b/internal/command/get_test.go
@@ -7,8 +7,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/hashicorp/cli"
-
 	"github.com/hashicorp/terraform/internal/backend"
 	backendInit "github.com/hashicorp/terraform/internal/backend/init"
 	backendCloud "github.com/hashicorp/terraform/internal/cloud"
@@ -18,7 +16,7 @@ func TestGet(t *testing.T) {
 	wd := tempWorkingDirFixture(t, "get")
 	t.Chdir(wd.RootModuleDir())
 
-	ui := cli.NewMockUi()
+	ui := testUiWrapped(t)
 	c := &GetCommand{
 		Meta: Meta{
 			testingOverrides: metaOverridesForProvider(testProvider()),
@@ -42,7 +40,7 @@ func TestGet_multipleArgs(t *testing.T) {
 	wd := tempWorkingDir(t)
 	t.Chdir(wd.RootModuleDir())
 
-	ui := cli.NewMockUi()
+	ui := testUiWrapped(t)
 	c := &GetCommand{
 		Meta: Meta{
 			testingOverrides: metaOverridesForProvider(testProvider()),
@@ -64,7 +62,7 @@ func TestGet_update(t *testing.T) {
 	wd := tempWorkingDirFixture(t, "get")
 	t.Chdir(wd.RootModuleDir())
 
-	ui := cli.NewMockUi()
+	ui := testUiWrapped(t)
 	c := &GetCommand{
 		Meta: Meta{
 			testingOverrides: metaOverridesForProvider(testProvider()),
@@ -98,7 +96,7 @@ func TestGet_cancel(t *testing.T) {
 	shutdownCh := make(chan struct{})
 	close(shutdownCh)
 
-	ui := cli.NewMockUi()
+	ui := testUiWrapped(t)
 	c := &GetCommand{
 		Meta: Meta{
 			testingOverrides: metaOverridesForProvider(testProvider()),
@@ -124,7 +122,7 @@ func TestGet_constVariable(t *testing.T) {
 		wd := tempWorkingDirFixture(t, "dynamic-module-sources/get-const-var")
 		t.Chdir(wd.RootModuleDir())
 
-		ui := cli.NewMockUi()
+		ui := testUiWrapped(t)
 		c := &GetCommand{
 			Meta: Meta{
 				testingOverrides: metaOverridesForProvider(testProvider()),
@@ -149,7 +147,7 @@ func TestGet_constVariable(t *testing.T) {
 		wd := tempWorkingDirFixture(t, "dynamic-module-sources/get-const-var")
 		t.Chdir(wd.RootModuleDir())
 
-		ui := cli.NewMockUi()
+		ui := testUiWrapped(t)
 		c := &GetCommand{
 			Meta: Meta{
 				testingOverrides: metaOverridesForProvider(testProvider()),
@@ -182,7 +180,7 @@ func TestGet_constVariable(t *testing.T) {
 		wd := tempWorkingDirFixture(t, "dynamic-module-sources/get-const-var-backend")
 		t.Chdir(wd.RootModuleDir())
 
-		ui := cli.NewMockUi()
+		ui := testUiWrapped(t)
 		c := &GetCommand{
 			Meta: Meta{
 				testingOverrides: metaOverridesForProvider(testProvider()),

--- a/internal/command/graph_test.go
+++ b/internal/command/graph_test.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/hashicorp/cli"
 	"github.com/zclconf/go-cty/cty"
 
 	"github.com/hashicorp/terraform/internal/addrs"
@@ -31,7 +30,7 @@ func TestGraph_planPhase(t *testing.T) {
 	testCopyDir(t, testFixturePath("graph"), td)
 	t.Chdir(td)
 
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	streams, closeStreams := terminal.StreamsForTesting(t)
 	c := &GraphCommand{
 		Meta: Meta{
@@ -132,7 +131,7 @@ func TestGraph_cyclic(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ui := new(cli.MockUi)
+			ui := testUiWrapped(t)
 			streams, closeStreams := terminal.StreamsForTesting(t)
 			c := &GraphCommand{
 				Meta: Meta{
@@ -171,7 +170,7 @@ func TestGraph_cyclic(t *testing.T) {
 }
 
 func TestGraph_multipleArgs(t *testing.T) {
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	c := &GraphCommand{
 		Meta: Meta{
 			testingOverrides: metaOverridesForProvider(applyFixtureProvider()),
@@ -195,7 +194,7 @@ func TestGraph_noConfig(t *testing.T) {
 
 	streams, closeStreams := terminal.StreamsForTesting(t)
 	defer closeStreams(t)
-	ui := cli.NewMockUi()
+	ui := testUiWrapped(t)
 	c := &GraphCommand{
 		Meta: Meta{
 			testingOverrides: metaOverridesForProvider(applyFixtureProvider()),
@@ -248,7 +247,7 @@ func TestGraph_resourcesOnly(t *testing.T) {
 		},
 	}
 
-	ui := cli.NewMockUi()
+	ui := testUiWrapped(t)
 	streams, closeStreams := terminal.StreamsForTesting(t)
 	c := &GraphCommand{
 		Meta: Meta{
@@ -340,7 +339,7 @@ func TestGraph_applyPhaseSavedPlan(t *testing.T) {
 	planPath := testPlanFile(t, configSnap, states.NewState(), plan)
 
 	streams, closeStreams := terminal.StreamsForTesting(t)
-	ui := cli.NewMockUi()
+	ui := testUiWrapped(t)
 	c := &GraphCommand{
 		Meta: Meta{
 			testingOverrides: metaOverridesForProvider(applyFixtureProvider()),
@@ -367,7 +366,7 @@ func TestGraph_constVariable(t *testing.T) {
 		wd := tempWorkingDirFixture(t, "dynamic-module-sources/command-with-const-var")
 		t.Chdir(wd.RootModuleDir())
 
-		ui := cli.NewMockUi()
+		ui := testUiWrapped(t)
 		streams, closeStreams := terminal.StreamsForTesting(t)
 		c := &GraphCommand{
 			Meta: Meta{
@@ -394,7 +393,7 @@ func TestGraph_constVariable(t *testing.T) {
 		wd := tempWorkingDirFixture(t, "dynamic-module-sources/command-with-const-var")
 		t.Chdir(wd.RootModuleDir())
 
-		ui := cli.NewMockUi()
+		ui := testUiWrapped(t)
 		streams, closeStreams := terminal.StreamsForTesting(t)
 		c := &GraphCommand{
 			Meta: Meta{
@@ -432,7 +431,7 @@ func TestGraph_constVariable(t *testing.T) {
 		wd := tempWorkingDirFixture(t, "dynamic-module-sources/command-with-const-var-backend")
 		t.Chdir(wd.RootModuleDir())
 
-		ui := cli.NewMockUi()
+		ui := testUiWrapped(t)
 		streams, closeStreams := terminal.StreamsForTesting(t)
 		c := &GraphCommand{
 			Meta: Meta{

--- a/internal/command/import_test.go
+++ b/internal/command/import_test.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/hashicorp/cli"
 	"github.com/zclconf/go-cty/cty"
 
 	"github.com/hashicorp/terraform/internal/configs/configschema"
@@ -28,7 +27,7 @@ func TestImport(t *testing.T) {
 	statePath := testTempFile(t)
 
 	p := testProvider()
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	view, _ := testView(t)
 	c := &ImportCommand{
 		Meta: Meta{
@@ -85,7 +84,7 @@ func TestImport_providerConfig(t *testing.T) {
 	statePath := testTempFile(t)
 
 	p := testProvider()
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	view, _ := testView(t)
 	c := &ImportCommand{
 		Meta: Meta{
@@ -178,7 +177,7 @@ func TestImport_remoteState(t *testing.T) {
 	})
 
 	// init our backend
-	ui := cli.NewMockUi()
+	ui := testUiWrapped(t)
 	view, _ := testView(t)
 	m := Meta{
 		testingOverrides: metaOverridesForProvider(testProvider()),
@@ -198,7 +197,7 @@ func TestImport_remoteState(t *testing.T) {
 	}
 
 	p := testProvider()
-	ui = new(cli.MockUi)
+	ui = testUiWrapped(t)
 	c := &ImportCommand{
 		Meta: Meta{
 			testingOverrides: metaOverridesForProvider(p),
@@ -289,7 +288,7 @@ func TestImport_initializationErrorShouldUnlock(t *testing.T) {
 	})
 
 	// init our backend
-	ui := cli.NewMockUi()
+	ui := testUiWrapped(t)
 	view, _ := testView(t)
 	m := Meta{
 		testingOverrides: metaOverridesForProvider(testProvider()),
@@ -312,7 +311,7 @@ func TestImport_initializationErrorShouldUnlock(t *testing.T) {
 	copy.CopyFile(filepath.Join(testFixturePath("import-provider-invalid"), "main.tf"), filepath.Join(td, "main.tf"))
 
 	p := testProvider()
-	ui = new(cli.MockUi)
+	ui = testUiWrapped(t)
 	c := &ImportCommand{
 		Meta: Meta{
 			testingOverrides: metaOverridesForProvider(p),
@@ -353,7 +352,7 @@ func TestImport_providerConfigWithVar(t *testing.T) {
 	statePath := testTempFile(t)
 
 	p := testProvider()
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	view, _ := testView(t)
 	c := &ImportCommand{
 		Meta: Meta{
@@ -435,7 +434,7 @@ func TestImport_providerConfigWithDataSource(t *testing.T) {
 	statePath := testTempFile(t)
 
 	p := testProvider()
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	view, _ := testView(t)
 	c := &ImportCommand{
 		Meta: Meta{
@@ -502,7 +501,7 @@ func TestImport_providerConfigWithVarDefault(t *testing.T) {
 	statePath := testTempFile(t)
 
 	p := testProvider()
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	view, _ := testView(t)
 	c := &ImportCommand{
 		Meta: Meta{
@@ -583,7 +582,7 @@ func TestImport_providerConfigWithVarFile(t *testing.T) {
 	statePath := testTempFile(t)
 
 	p := testProvider()
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	view, _ := testView(t)
 	c := &ImportCommand{
 		Meta: Meta{
@@ -665,7 +664,7 @@ func TestImport_emptyConfig(t *testing.T) {
 	statePath := testTempFile(t)
 
 	p := testProvider()
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	view, _ := testView(t)
 	c := &ImportCommand{
 		Meta: Meta{
@@ -699,7 +698,7 @@ func TestImport_missingResourceConfig(t *testing.T) {
 	statePath := testTempFile(t)
 
 	p := testProvider()
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	view, _ := testView(t)
 	c := &ImportCommand{
 		Meta: Meta{
@@ -733,7 +732,7 @@ func TestImport_missingModuleConfig(t *testing.T) {
 	statePath := testTempFile(t)
 
 	p := testProvider()
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	view, _ := testView(t)
 	c := &ImportCommand{
 		Meta: Meta{
@@ -784,7 +783,7 @@ func TestImportModuleVarFile(t *testing.T) {
 	})
 
 	// init to install the module
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	view, _ := testView(t)
 	m := Meta{
 		testingOverrides: metaOverridesForProvider(testProvider()),
@@ -801,7 +800,7 @@ func TestImportModuleVarFile(t *testing.T) {
 	}
 
 	// import
-	ui = new(cli.MockUi)
+	ui = testUiWrapped(t)
 	c := &ImportCommand{
 		Meta: Meta{
 			testingOverrides: metaOverridesForProvider(p),
@@ -857,7 +856,7 @@ func TestImportModuleInputVariableEvaluation(t *testing.T) {
 	})
 
 	// init to install the module
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	view, _ := testView(t)
 	m := Meta{
 		testingOverrides: metaOverridesForProvider(testProvider()),
@@ -874,7 +873,7 @@ func TestImportModuleInputVariableEvaluation(t *testing.T) {
 	}
 
 	// import
-	ui = new(cli.MockUi)
+	ui = testUiWrapped(t)
 	c := &ImportCommand{
 		Meta: Meta{
 			testingOverrides: metaOverridesForProvider(p),
@@ -901,7 +900,7 @@ func TestImport_dataResource(t *testing.T) {
 	statePath := testTempFile(t)
 
 	p := testProvider()
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	view, _ := testView(t)
 	c := &ImportCommand{
 		Meta: Meta{
@@ -935,7 +934,7 @@ func TestImport_invalidResourceAddr(t *testing.T) {
 	statePath := testTempFile(t)
 
 	p := testProvider()
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	view, _ := testView(t)
 	c := &ImportCommand{
 		Meta: Meta{
@@ -969,7 +968,7 @@ func TestImport_targetIsModule(t *testing.T) {
 	statePath := testTempFile(t)
 
 	p := testProvider()
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	view, _ := testView(t)
 	c := &ImportCommand{
 		Meta: Meta{

--- a/internal/command/init2_test.go
+++ b/internal/command/init2_test.go
@@ -8,8 +8,6 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
-
-	"github.com/hashicorp/cli"
 )
 
 func TestInit2_dynamicSourceErrors(t *testing.T) {
@@ -108,7 +106,7 @@ func TestInit2_dynamicSourceErrors(t *testing.T) {
 				"hashicorp/test": {"1.0.0"},
 			})
 
-			ui := new(cli.MockUi)
+			ui := testUiWrapped(t)
 			view, done := testView(t)
 			c := &InitCommand{
 				Meta: Meta{
@@ -191,7 +189,7 @@ func TestInit2_dynamicSourceSuccess(t *testing.T) {
 				"hashicorp/test": {"1.0.0"},
 			})
 
-			ui := new(cli.MockUi)
+			ui := testUiWrapped(t)
 			view, done := testView(t)
 			c := &InitCommand{
 				Meta: Meta{
@@ -217,7 +215,7 @@ func TestInit2_getFalseWithDynamicSource(t *testing.T) {
 	t.Chdir(td)
 
 	// First, run init normally to install the module
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	view, done := testView(t)
 	c := &InitCommand{
 		Meta: Meta{
@@ -235,7 +233,7 @@ func TestInit2_getFalseWithDynamicSource(t *testing.T) {
 	}
 
 	// Now run init with -get=false; should succeed since modules are already installed
-	ui2 := new(cli.MockUi)
+	ui2 := testUiWrapped(t)
 	view2, done2 := testView(t)
 	c2 := &InitCommand{
 		Meta: Meta{
@@ -258,7 +256,7 @@ func TestInit2_getFalseWithDynamicSourceNotInstalled(t *testing.T) {
 	testCopyDir(t, testFixturePath(filepath.Join("dynamic-module-sources", "get-false-with-dynamic-source")), td)
 	t.Chdir(td)
 
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	view, done := testView(t)
 	c := &InitCommand{
 		Meta: Meta{
@@ -283,7 +281,7 @@ func TestInit2_reinitWithDifferentVariable(t *testing.T) {
 	t.Chdir(td)
 
 	// First init with default variable (example)
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	view, done := testView(t)
 	c := &InitCommand{
 		Meta: Meta{
@@ -300,7 +298,7 @@ func TestInit2_reinitWithDifferentVariable(t *testing.T) {
 	}
 
 	// Re-init with different variable
-	ui2 := new(cli.MockUi)
+	ui2 := testUiWrapped(t)
 	view2, done2 := testView(t)
 	c2 := &InitCommand{
 		Meta: Meta{
@@ -326,7 +324,7 @@ func TestInit2_fromModuleWithDynamicSource(t *testing.T) {
 	td := t.TempDir()
 	t.Chdir(td)
 
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	view, done := testView(t)
 	c := &InitCommand{
 		Meta: Meta{
@@ -369,7 +367,7 @@ func TestPlan_dynamicModuleSource(t *testing.T) {
 
 	args := []string{"-var", "module_name=example"}
 
-	initUi := new(cli.MockUi)
+	initUi := testUiWrapped(t)
 	initView, initDone := testView(t)
 	initCmd := &InitCommand{
 		Meta: Meta{
@@ -387,7 +385,7 @@ func TestPlan_dynamicModuleSource(t *testing.T) {
 	}
 
 	// Now run plan
-	planUi := new(cli.MockUi)
+	planUi := testUiWrapped(t)
 	planView, planDone := testView(t)
 	planCmd := &PlanCommand{
 		Meta: Meta{
@@ -420,7 +418,7 @@ func TestPlan_dynamicModuleSourceMismatch(t *testing.T) {
 	})
 	args := []string{"-var", "module_name=example"}
 
-	initUi := new(cli.MockUi)
+	initUi := testUiWrapped(t)
 	initView, initDone := testView(t)
 	initCmd := &InitCommand{
 		Meta: Meta{
@@ -438,7 +436,7 @@ func TestPlan_dynamicModuleSourceMismatch(t *testing.T) {
 	}
 
 	// Now run plan with a different variable value
-	planUi := new(cli.MockUi)
+	planUi := testUiWrapped(t)
 	planView, planDone := testView(t)
 	planCmd := &PlanCommand{
 		Meta: Meta{
@@ -467,7 +465,7 @@ func TestApply_dynamicModuleSource(t *testing.T) {
 	})
 	args := []string{"-var", "module_name=example"}
 
-	initUi := new(cli.MockUi)
+	initUi := testUiWrapped(t)
 	initView, initDone := testView(t)
 	initCmd := &InitCommand{
 		Meta: Meta{
@@ -484,7 +482,7 @@ func TestApply_dynamicModuleSource(t *testing.T) {
 		t.Fatalf("init failed with exit status %d\nstderr:\n%s\n\nstdout:\n%s", initCode, initOutput.Stderr(), initOutput.Stdout())
 	}
 
-	applyUi := new(cli.MockUi)
+	applyUi := testUiWrapped(t)
 	applyView, applyDone := testView(t)
 	applyCmd := &ApplyCommand{
 		Meta: Meta{
@@ -517,7 +515,7 @@ func TestApply_dynamicModuleSourceWithDefaultPlanFile(t *testing.T) {
 		"hashicorp/test": {"1.0.0"},
 	})
 
-	initUi := new(cli.MockUi)
+	initUi := testUiWrapped(t)
 	initView, initDone := testView(t)
 	initCmd := &InitCommand{
 		Meta: Meta{
@@ -536,7 +534,7 @@ func TestApply_dynamicModuleSourceWithDefaultPlanFile(t *testing.T) {
 
 	// Run plan with -out
 	planPath := filepath.Join(td, "saved.plan")
-	planUi := new(cli.MockUi)
+	planUi := testUiWrapped(t)
 	planView, planDone := testView(t)
 	planCmd := &PlanCommand{
 		Meta: Meta{
@@ -559,7 +557,7 @@ func TestApply_dynamicModuleSourceWithDefaultPlanFile(t *testing.T) {
 	}
 
 	// Apply the saved plan
-	applyUi := new(cli.MockUi)
+	applyUi := testUiWrapped(t)
 	applyView, applyDone := testView(t)
 	applyCmd := &ApplyCommand{
 		Meta: Meta{
@@ -594,7 +592,7 @@ func TestPlan_dynamicModuleSourceWithCount(t *testing.T) {
 
 	args := []string{"-var", "module_name=example"}
 
-	initUi := new(cli.MockUi)
+	initUi := testUiWrapped(t)
 	initView, initDone := testView(t)
 	initCmd := &InitCommand{
 		Meta: Meta{
@@ -612,7 +610,7 @@ func TestPlan_dynamicModuleSourceWithCount(t *testing.T) {
 	}
 
 	// Now run plan
-	planUi := new(cli.MockUi)
+	planUi := testUiWrapped(t)
 	planView, planDone := testView(t)
 	planCmd := &PlanCommand{
 		Meta: Meta{
@@ -646,7 +644,7 @@ func TestPlan_dynamicModuleSourceWithForEach(t *testing.T) {
 
 	args := []string{"-var", "module_name=example"}
 
-	initUi := new(cli.MockUi)
+	initUi := testUiWrapped(t)
 	initView, initDone := testView(t)
 	initCmd := &InitCommand{
 		Meta: Meta{
@@ -664,7 +662,7 @@ func TestPlan_dynamicModuleSourceWithForEach(t *testing.T) {
 	}
 
 	// Now run plan
-	planUi := new(cli.MockUi)
+	planUi := testUiWrapped(t)
 	planView, planDone := testView(t)
 	planCmd := &PlanCommand{
 		Meta: Meta{
@@ -695,7 +693,7 @@ func TestPlan_dynamicModuleVersionMismatch(t *testing.T) {
 
 	// Plan should fail because the installed module version (0.0.1 in
 	// modules.json) doesn't satisfy the constraint we provide.
-	planUi := new(cli.MockUi)
+	planUi := testUiWrapped(t)
 	planView, planDone := testView(t)
 	planCmd := &PlanCommand{
 		Meta: Meta{

--- a/internal/command/init_policy_test.go
+++ b/internal/command/init_policy_test.go
@@ -13,7 +13,6 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/hashicorp/cli"
 	"github.com/zclconf/go-cty/cty"
 	"google.golang.org/protobuf/testing/protocmp"
 
@@ -63,7 +62,7 @@ func TestInit_WithModulePolicy(t *testing.T) {
 		testCopyDir(t, testFixturePath("dynamic-module-sources/local-source-with-variable"), td)
 		t.Chdir(td)
 
-		ui := new(cli.MockUi)
+		ui := testUiWrapped(t)
 		view, done := testView(t)
 
 		overrides := metaOverridesForProvider(testProvider())
@@ -125,7 +124,7 @@ func TestInit_WithPolicyClientStopAfterInit(t *testing.T) {
 	testCopyDir(t, testFixturePath("dynamic-module-sources/local-source-with-variable"), td)
 	t.Chdir(td)
 
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	view, done := testView(t)
 
 	overrides := metaOverridesForProvider(testProvider())
@@ -189,7 +188,7 @@ func TestInit_WithModulePolicy_AlreadyInstalled(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	view, done := testView(t)
 
 	overrides := metaOverridesForProvider(testProvider())
@@ -261,7 +260,7 @@ func TestInit_WithPolicySetupFailureJSON(t *testing.T) {
 		"hashicorp/grandchild":                  {"1.0.0"},
 	})
 
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	view, done := testView(t)
 
 	c := &InitCommand{
@@ -290,7 +289,7 @@ func TestInit_WithModulePolicyDiagnostics(t *testing.T) {
 	testCopyDir(t, testFixturePath("dynamic-module-sources/local-source-with-variable"), td)
 	t.Chdir(td)
 
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	view, done := testView(t)
 
 	overrides := metaOverridesForProvider(testProvider())
@@ -366,7 +365,7 @@ func TestInit_WithNestedModulePolicyDiagnostics(t *testing.T) {
 	testCopyDir(t, testFixturePath("init-nested-provider-requirements"), td)
 	t.Chdir(td)
 
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	view, done := testView(t)
 
 	// assert modules are evaluated correctly
@@ -451,7 +450,7 @@ func TestInit_WithModulePolicyJSON(t *testing.T) {
 	testCopyDir(t, testFixturePath("dynamic-module-sources/local-source-with-variable"), td)
 	t.Chdir(td)
 
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	view, done := testView(t)
 
 	overrides := metaOverridesForProvider(testProvider())
@@ -522,7 +521,7 @@ func TestInit_WithProviderPolicy(t *testing.T) {
 		"hashicorp/grandchild":                  {"1.0.0"},
 	})
 
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	view, done := testView(t)
 
 	overrides := metaOverridesForProvider(testProvider())
@@ -619,7 +618,7 @@ func TestInit_WithProviderPolicyDiagnostics(t *testing.T) {
 		"hashicorp/grandchild":                  {"1.0.0"},
 	})
 
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	view, done := testView(t)
 
 	overrides := metaOverridesForProvider(testProvider())
@@ -704,7 +703,7 @@ func TestInit_WithProviderPolicyJSON(t *testing.T) {
 		"hashicorp/grandchild":   {"1.0.0"},
 	})
 
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	view, done := testView(t)
 
 	overrides := metaOverridesForProvider(testProvider())

--- a/internal/command/init_test.go
+++ b/internal/command/init_test.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/davecgh/go-spew/spew"
 	"github.com/google/go-cmp/cmp"
-	"github.com/hashicorp/cli"
 	version "github.com/hashicorp/go-version"
 	tfaddr "github.com/hashicorp/terraform-registry-address"
 	svchost "github.com/hashicorp/terraform-svchost"
@@ -79,7 +78,7 @@ func TestInit_empty(t *testing.T) {
 	os.MkdirAll(td, 0755)
 	t.Chdir(td)
 
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	view, done := testView(t)
 	c := &InitCommand{
 		Meta: Meta{
@@ -110,7 +109,7 @@ func TestInit_only_test_files(t *testing.T) {
 		t.Fatalf("err: %s", err)
 	}
 
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	view, done := testView(t)
 	c := &InitCommand{
 		Meta: Meta{
@@ -226,7 +225,7 @@ func TestInit_two_source_provider_download(t *testing.T) {
 				"hashicorp/random": {"1.0.0", "1.2.3-beta", "9.9.9"},
 				"hashicorp/null":   {"1.0.0", "1.2.3-beta", "9.9.9"},
 			})
-			ui := new(cli.MockUi)
+			ui := testUiWrapped(t)
 			view, done := testView(t)
 			c := &InitCommand{
 				Meta: Meta{
@@ -290,7 +289,7 @@ func TestInit_stateStoreProviderDownload(t *testing.T) {
 
 			mockProvider := mockPluggableStateStorageProvider(mockSingleStateStoreSchema("test_store"))
 
-			ui := new(cli.MockUi)
+			ui := testUiWrapped(t)
 			view, done := testView(t)
 			c := &InitCommand{
 				Meta: Meta{
@@ -331,7 +330,7 @@ func TestInit_cannotUsePreReleaseWithoutConfigConstraint(t *testing.T) {
 		"hashicorp/random": {"1.0.0", "1.2.3-beta", "9.9.9"},
 	})
 
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	view, done := testView(t)
 	c := &InitCommand{
 		Meta: Meta{
@@ -397,7 +396,7 @@ func TestInit_migrateStateAndJSON(t *testing.T) {
 	os.MkdirAll(td, 0755)
 	t.Chdir(td)
 
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	view, done := testView(t)
 	c := &InitCommand{
 		Meta: Meta{
@@ -427,7 +426,7 @@ func TestInit_fromModule_cwdDest(t *testing.T) {
 	os.MkdirAll(td, os.ModePerm)
 	t.Chdir(td)
 
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	view, done := testView(t)
 	c := &InitCommand{
 		Meta: Meta{
@@ -479,7 +478,7 @@ func TestInit_fromModule_dstInSrc(t *testing.T) {
 		t.Fatalf("err: %s", err)
 	}
 
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	view, done := testView(t)
 	c := &InitCommand{
 		Meta: Meta{
@@ -532,7 +531,7 @@ func TestInit_get(t *testing.T) {
 	testCopyDir(t, testFixturePath("init-get"), td)
 	t.Chdir(td)
 
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	view, done := testView(t)
 	c := &InitCommand{
 		Meta: Meta{
@@ -560,7 +559,7 @@ func TestInit_json(t *testing.T) {
 	testCopyDir(t, testFixturePath("init-get"), td)
 	t.Chdir(td)
 
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	view, done := testView(t)
 	c := &InitCommand{
 		Meta: Meta{
@@ -586,7 +585,7 @@ func TestInit_getUpgradeModules(t *testing.T) {
 	testCopyDir(t, testFixturePath("init-get"), td)
 	t.Chdir(td)
 
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	view, done := testView(t)
 	c := &InitCommand{
 		Meta: Meta{
@@ -619,7 +618,7 @@ func TestInit_backend_initFromConfig(t *testing.T) {
 	testCopyDir(t, testFixturePath("init-backend"), td)
 	t.Chdir(td)
 
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	view, done := testView(t)
 	c := &InitCommand{
 		Meta: Meta{
@@ -645,7 +644,7 @@ func TestInit_backend_initFromState(t *testing.T) {
 	testCopyDir(t, testFixturePath("init-backend-config-file-change-to-s3"), td)
 	t.Chdir(td)
 
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	view, done := testView(t)
 	c := &InitCommand{
 		Meta: Meta{
@@ -687,7 +686,7 @@ func TestInit_backend_migration_stateMgr_error(t *testing.T) {
 			t.Fatalf("err: %s", err)
 		}
 
-		ui := new(cli.MockUi)
+		ui := testUiWrapped(t)
 		applyView, done := testView(t)
 		applyCmd := &ApplyCommand{
 			Meta: Meta{
@@ -726,7 +725,7 @@ func TestInit_backend_migration_stateMgr_error(t *testing.T) {
 			t.Fatalf("err: %s", err)
 		}
 
-		ui := new(cli.MockUi)
+		ui := testUiWrapped(t)
 		initView, done := testView(t)
 		initCmd := &InitCommand{
 			Meta: Meta{
@@ -760,7 +759,7 @@ func TestInit_backendUnset(t *testing.T) {
 	{
 		log.Printf("[TRACE] TestInit_backendUnset: beginning first init")
 
-		ui := cli.NewMockUi()
+		ui := testUiWrapped(t)
 		view, done := testView(t)
 		c := &InitCommand{
 			Meta: Meta{
@@ -794,7 +793,7 @@ func TestInit_backendUnset(t *testing.T) {
 			t.Fatalf("err: %s", err)
 		}
 
-		ui := cli.NewMockUi()
+		ui := testUiWrapped(t)
 		view, done := testView(t)
 		c := &InitCommand{
 			Meta: Meta{
@@ -828,7 +827,7 @@ func TestInit_backendConfigFile(t *testing.T) {
 	t.Chdir(td)
 
 	t.Run("good-config-file", func(t *testing.T) {
-		ui := new(cli.MockUi)
+		ui := testUiWrapped(t)
 		view, done := testView(t)
 		c := &InitCommand{
 			Meta: Meta{
@@ -851,7 +850,7 @@ func TestInit_backendConfigFile(t *testing.T) {
 
 	// the backend config file must not be a full terraform block
 	t.Run("full-backend-config-file", func(t *testing.T) {
-		ui := new(cli.MockUi)
+		ui := testUiWrapped(t)
 		view, done := testView(t)
 		c := &InitCommand{
 			Meta: Meta{
@@ -871,7 +870,7 @@ func TestInit_backendConfigFile(t *testing.T) {
 
 	// the backend config file must match the schema for the backend
 	t.Run("invalid-config-file", func(t *testing.T) {
-		ui := new(cli.MockUi)
+		ui := testUiWrapped(t)
 		view, done := testView(t)
 		c := &InitCommand{
 			Meta: Meta{
@@ -891,7 +890,7 @@ func TestInit_backendConfigFile(t *testing.T) {
 
 	// missing file is an error
 	t.Run("missing-config-file", func(t *testing.T) {
-		ui := new(cli.MockUi)
+		ui := testUiWrapped(t)
 		view, done := testView(t)
 		c := &InitCommand{
 			Meta: Meta{
@@ -911,7 +910,7 @@ func TestInit_backendConfigFile(t *testing.T) {
 
 	// blank filename clears the backend config
 	t.Run("blank-config-file", func(t *testing.T) {
-		ui := new(cli.MockUi)
+		ui := testUiWrapped(t)
 		view, done := testView(t)
 		c := &InitCommand{
 			Meta: Meta{
@@ -963,7 +962,7 @@ func TestInit_backendConfigFilePowershellConfusion(t *testing.T) {
 	testCopyDir(t, testFixturePath("init-backend-config-file"), td)
 	t.Chdir(td)
 
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	view, done := testView(t)
 	c := &InitCommand{
 		Meta: Meta{
@@ -1003,7 +1002,7 @@ func TestInit_backendReconfigure(t *testing.T) {
 		"hashicorp/test": {"1.2.3"},
 	})
 
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	view, done := testView(t)
 	c := &InitCommand{
 		Meta: Meta{
@@ -1045,7 +1044,7 @@ func TestInit_backendConfigFileChange(t *testing.T) {
 	testCopyDir(t, testFixturePath("init-backend-config-file-change"), td)
 	t.Chdir(td)
 
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	view, done := testView(t)
 	c := &InitCommand{
 		Meta: Meta{
@@ -1077,7 +1076,7 @@ func TestInit_backendMigrateWhileLocked(t *testing.T) {
 		"hashicorp/test": {"1.2.3"},
 	})
 
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	view, done := testView(t)
 	c := &InitCommand{
 		Meta: Meta{
@@ -1125,7 +1124,7 @@ func TestInit_backendConfigFileChangeWithExistingState(t *testing.T) {
 	testCopyDir(t, testFixturePath("init-backend-config-file-change-migrate-existing"), td)
 	t.Chdir(td)
 
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	view, _ := testView(t)
 
 	c := &InitCommand{
@@ -1162,7 +1161,7 @@ func TestInit_backendConfigKV(t *testing.T) {
 	testCopyDir(t, testFixturePath("init-backend-config-kv"), td)
 	t.Chdir(td)
 
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	view, done := testView(t)
 	c := &InitCommand{
 		Meta: Meta{
@@ -1190,7 +1189,7 @@ func TestInit_backendConfigKVReInit(t *testing.T) {
 	testCopyDir(t, testFixturePath("init-backend-config-kv"), td)
 	t.Chdir(td)
 
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	view, done := testView(t)
 	c := &InitCommand{
 		Meta: Meta{
@@ -1205,7 +1204,7 @@ func TestInit_backendConfigKVReInit(t *testing.T) {
 		t.Fatalf("bad: \n%s", done(t).Stderr())
 	}
 
-	ui = new(cli.MockUi)
+	ui = testUiWrapped(t)
 	c = &InitCommand{
 		Meta: Meta{
 			testingOverrides: metaOverridesForProvider(testProvider()),
@@ -1253,7 +1252,7 @@ func TestInit_backendConfigKVReInitWithConfigDiff(t *testing.T) {
 	testCopyDir(t, testFixturePath("init-backend"), td)
 	t.Chdir(td)
 
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	view, done := testView(t)
 	c := &InitCommand{
 		Meta: Meta{
@@ -1268,7 +1267,7 @@ func TestInit_backendConfigKVReInitWithConfigDiff(t *testing.T) {
 		t.Fatalf("bad: \n%s", done(t).Stderr())
 	}
 
-	ui = new(cli.MockUi)
+	ui = testUiWrapped(t)
 	c = &InitCommand{
 		Meta: Meta{
 			testingOverrides: metaOverridesForProvider(testProvider()),
@@ -1301,7 +1300,7 @@ func TestInit_backendCli_no_config_block(t *testing.T) {
 	testCopyDir(t, testFixturePath("init"), td)
 	t.Chdir(td)
 
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	view, done := testView(t)
 	c := &InitCommand{
 		Meta: Meta{
@@ -1340,7 +1339,7 @@ func TestInit_backendReinitWithExtra(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	view, done := testView(t)
 	c := &InitCommand{
 		Meta: Meta{
@@ -1384,7 +1383,7 @@ func TestInit_backendReinitConfigToExtra(t *testing.T) {
 	testCopyDir(t, testFixturePath("init-backend"), td)
 	t.Chdir(td)
 
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	view, done := testView(t)
 	c := &InitCommand{
 		Meta: Meta{
@@ -1492,7 +1491,7 @@ func TestInit_backendCloudInvalidOptions(t *testing.T) {
 		// operations and state work in that case, and so the Cloud
 		// configuration is only about which workspaces we'll be working
 		// with.
-		ui := cli.NewMockUi()
+		ui := testUiWrapped(t)
 		view, done := testView(t)
 		c := &InitCommand{
 			Meta: Meta{
@@ -1530,7 +1529,7 @@ Cloud configuration block in the root module.
 		// steps to take care of more details automatically, and so
 		// -reconfigure doesn't really make sense in that context, particularly
 		// with its design bug with the handling of the implicit local backend.
-		ui := cli.NewMockUi()
+		ui := testUiWrapped(t)
 		view, done := testView(t)
 		c := &InitCommand{
 			Meta: Meta{
@@ -1568,7 +1567,7 @@ Cloud configuration settings.
 			t.Fatal(err)
 		}
 
-		ui := cli.NewMockUi()
+		ui := testUiWrapped(t)
 		view, done := testView(t)
 		c := &InitCommand{
 			Meta: Meta{
@@ -1598,7 +1597,7 @@ because activating HCP Terraform involves some additional steps.
 		// In Cloud mode, migrating in or out always proposes migrating state
 		// and changing configuration while staying in cloud mode never migrates
 		// state, so this special option isn't relevant.
-		ui := cli.NewMockUi()
+		ui := testUiWrapped(t)
 		view, done := testView(t)
 		c := &InitCommand{
 			Meta: Meta{
@@ -1636,7 +1635,7 @@ storage location is not configurable.
 			t.Fatal(err)
 		}
 
-		ui := cli.NewMockUi()
+		ui := testUiWrapped(t)
 		view, done := testView(t)
 		c := &InitCommand{
 			Meta: Meta{
@@ -1669,7 +1668,7 @@ prompts.
 		// In Cloud mode, migrating in or out always proposes migrating state
 		// and changing configuration while staying in cloud mode never migrates
 		// state, so this special option isn't relevant.
-		ui := cli.NewMockUi()
+		ui := testUiWrapped(t)
 		view, done := testView(t)
 		c := &InitCommand{
 			Meta: Meta{
@@ -1707,7 +1706,7 @@ storage location is not configurable.
 			t.Fatal(err)
 		}
 
-		ui := cli.NewMockUi()
+		ui := testUiWrapped(t)
 		view, done := testView(t)
 		c := &InitCommand{
 			Meta: Meta{
@@ -1748,7 +1747,7 @@ func TestInit_cloudConfigColorTokensProcessed(t *testing.T) {
 	testCopyDir(t, testFixturePath("init-cloud-no-workspaces"), td)
 	t.Chdir(td)
 
-	ui := cli.NewMockUi()
+	ui := testUiWrapped(t)
 	view, done := testView(t)
 	c := &InitCommand{
 		Meta: Meta{
@@ -1807,7 +1806,7 @@ func TestInit_inputFalse(t *testing.T) {
 	testCopyDir(t, testFixturePath("init-backend"), td)
 	t.Chdir(td)
 
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	view, done := testView(t)
 	c := &InitCommand{
 		Meta: Meta{
@@ -1844,7 +1843,7 @@ func TestInit_inputFalse(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	ui = new(cli.MockUi)
+	ui = testUiWrapped(t)
 	c = &InitCommand{
 		Meta: Meta{
 			testingOverrides: metaOverridesForProvider(testProvider()),
@@ -1863,7 +1862,7 @@ func TestInit_inputFalse(t *testing.T) {
 		t.Fatal("expected input disabled error, got", errMsg)
 	}
 
-	ui = new(cli.MockUi)
+	ui = testUiWrapped(t)
 	c = &InitCommand{
 		Meta: Meta{
 			testingOverrides: metaOverridesForProvider(testProvider()),
@@ -1886,7 +1885,7 @@ func TestInit_getProvider(t *testing.T) {
 	t.Chdir(td)
 
 	overrides := metaOverridesForProvider(testProvider())
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	view, done := testView(t)
 	providerSource := newMockProviderSource(t, map[string][]string{
 		// looking for an exact version
@@ -1964,7 +1963,7 @@ func TestInit_getProvider(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		ui := new(cli.MockUi)
+		ui := testUiWrapped(t)
 		view, done := testView(t)
 		m.Ui = ui
 		m.View = view
@@ -1992,7 +1991,7 @@ func TestInit_getProviderSource(t *testing.T) {
 	t.Chdir(td)
 
 	overrides := metaOverridesForProvider(testProvider())
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	view, done := testView(t)
 	providerSource := newMockProviderSource(t, map[string][]string{
 		// looking for an exact version
@@ -2041,7 +2040,7 @@ func TestInit_getProviderLegacyFromState(t *testing.T) {
 	t.Chdir(td)
 
 	overrides := metaOverridesForProvider(testProvider())
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	view, done := testView(t)
 	providerSource := newMockProviderSource(t, map[string][]string{
 		"acme/alpha": {"1.2.3"},
@@ -2082,7 +2081,7 @@ func TestInit_getProviderInvalidPackage(t *testing.T) {
 	t.Chdir(td)
 
 	overrides := metaOverridesForProvider(testProvider())
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	view, done := testView(t)
 
 	// create a provider source which allows installing an invalid package
@@ -2160,7 +2159,7 @@ func TestInit_getProviderDetectedLegacy(t *testing.T) {
 		{Source: registrySource},
 	}
 
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	view, done := testView(t)
 	m := Meta{
 		Ui:             ui,
@@ -2219,7 +2218,7 @@ func TestInit_providerSource(t *testing.T) {
 		"source":    {"1.2.2", "1.2.3", "1.2.1"},
 	})
 
-	ui := cli.NewMockUi()
+	ui := testUiWrapped(t)
 	view, done := testView(t)
 	m := Meta{
 		testingOverrides: metaOverridesForProvider(testProvider()),
@@ -2328,7 +2327,7 @@ func TestInit_cancelModules(t *testing.T) {
 	shutdownCh := make(chan struct{})
 	close(shutdownCh)
 
-	ui := cli.NewMockUi()
+	ui := testUiWrapped(t)
 	view, done := testView(t)
 	m := Meta{
 		testingOverrides: metaOverridesForProvider(testProvider()),
@@ -2371,7 +2370,7 @@ func TestInit_cancelProviders(t *testing.T) {
 	shutdownCh := make(chan struct{})
 	close(shutdownCh)
 
-	ui := cli.NewMockUi()
+	ui := testUiWrapped(t)
 	view, done := testView(t)
 	m := Meta{
 		testingOverrides: metaOverridesForProvider(testProvider()),
@@ -2417,7 +2416,7 @@ func TestInit_getUpgradePlugins(t *testing.T) {
 			"between": {"3.4.5", "2.9.9", "2.3.4", "1.2.3"},
 		})
 
-		ui := new(cli.MockUi)
+		ui := testUiWrapped(t)
 		view, done := testView(t)
 		m := Meta{
 			testingOverrides: metaOverridesForProvider(testProvider()),
@@ -2537,7 +2536,7 @@ func TestInit_getUpgradePlugins(t *testing.T) {
 			"between": {"3.4.5", "2.3.4", "1.2.3"},
 		})
 
-		ui := new(cli.MockUi)
+		ui := testUiWrapped(t)
 		view, done := testView(t)
 		m := Meta{
 			testingOverrides: metaOverridesForProvider(testProvider()),
@@ -2688,7 +2687,7 @@ terraform {
 		mockProvider := mockPluggableStateStorageProvider(mockSingleStateStoreSchema("test_store"))
 		mockProvider.MockStates = testing_provider.NewMockStateBytesWithStateIds("test_store", []string{"default"})
 
-		ui := new(cli.MockUi)
+		ui := testUiWrapped(t)
 		view, done := testView(t)
 		m := Meta{
 			testingOverrides:          metaOverridesForProvider(mockProvider),
@@ -2844,7 +2843,7 @@ terraform {
 		mockProvider := mockPluggableStateStorageProvider(mockSingleStateStoreSchema("test_store"))
 		mockProvider.MockStates = testing_provider.NewMockStateBytesWithStateIds("test_store", []string{"default"})
 		mockProviderAddress := addrs.NewDefaultProvider("test")
-		ui := new(cli.MockUi)
+		ui := testUiWrapped(t)
 		view, done := testView(t)
 		m := Meta{
 			testingOverrides:          metaOverridesForProvider(mockProvider),
@@ -2969,7 +2968,7 @@ terraform {
 		mockProvider := mockPluggableStateStorageProvider(mockSingleStateStoreSchema("test_store"))
 		mockProvider.MockStates = testing_provider.NewMockStateBytesWithStateIds("test_store", []string{"default"})
 
-		ui := new(cli.MockUi)
+		ui := testUiWrapped(t)
 		view, done := testView(t)
 		m := Meta{
 			testingOverrides:          metaOverridesForProvider(mockProvider),
@@ -3101,7 +3100,7 @@ terraform {
 		mockProvider := mockPluggableStateStorageProvider(mockSingleStateStoreSchema("test_store"))
 		mockProvider.MockStates = testing_provider.NewMockStateBytesWithStateIds("test_store", []string{"default"})
 
-		ui := new(cli.MockUi)
+		ui := testUiWrapped(t)
 		view, done := testView(t)
 		m := Meta{
 			testingOverrides:          metaOverridesForProvider(mockProvider),
@@ -3236,7 +3235,7 @@ func TestInit_getProviderMissing(t *testing.T) {
 		"between": {"3.4.5", "2.3.4", "1.2.3"},
 	})
 
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	view, done := testView(t)
 	m := Meta{
 		testingOverrides: metaOverridesForProvider(testProvider()),
@@ -3267,7 +3266,7 @@ func TestInit_checkRequiredVersion(t *testing.T) {
 	testCopyDir(t, testFixturePath("init-check-required-version"), td)
 	t.Chdir(td)
 
-	ui := cli.NewMockUi()
+	ui := testUiWrapped(t)
 	view, done := testView(t)
 	c := &InitCommand{
 		Meta: Meta{
@@ -3298,7 +3297,7 @@ func TestInit_checkRequiredVersionFirst(t *testing.T) {
 		testCopyDir(t, testFixturePath("init-check-required-version-first"), td)
 		t.Chdir(td)
 
-		ui := cli.NewMockUi()
+		ui := testUiWrapped(t)
 		view, done := testView(t)
 		c := &InitCommand{
 			Meta: Meta{
@@ -3322,7 +3321,7 @@ func TestInit_checkRequiredVersionFirst(t *testing.T) {
 		testCopyDir(t, testFixturePath("init-check-required-version-first-module"), td)
 		t.Chdir(td)
 
-		ui := cli.NewMockUi()
+		ui := testUiWrapped(t)
 		view, done := testView(t)
 		c := &InitCommand{
 			Meta: Meta{
@@ -3355,7 +3354,7 @@ func TestInit_providerLockFile(t *testing.T) {
 		"test": {"1.2.3"},
 	})
 
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	view, done := testView(t)
 	m := Meta{
 		testingOverrides: metaOverridesForProvider(testProvider()),
@@ -3539,7 +3538,7 @@ provider "registry.terraform.io/hashicorp/test" {
 
 			providerSource := newMockProviderSource(t, tc.providers)
 
-			ui := new(cli.MockUi)
+			ui := testUiWrapped(t)
 			view, done := testView(t)
 			m := Meta{
 				testingOverrides: metaOverridesForProvider(testProvider()),
@@ -3586,7 +3585,7 @@ func TestInit_pluginDirReset(t *testing.T) {
 	// An empty provider source
 	providerSource := newMockProviderSource(t, nil)
 
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	view, done := testView(t)
 	c := &InitCommand{
 		Meta: Meta{
@@ -3620,7 +3619,7 @@ func TestInit_pluginDirReset(t *testing.T) {
 		t.Fatalf(`expected plugin dir ["a"], got %q`, pluginDirs)
 	}
 
-	ui = new(cli.MockUi)
+	ui = testUiWrapped(t)
 	c = &InitCommand{
 		Meta: Meta{
 			testingOverrides: metaOverridesForProvider(testProvider()),
@@ -3655,7 +3654,7 @@ func TestInit_pluginDirProviders(t *testing.T) {
 	// An empty provider source
 	providerSource := newMockProviderSource(t, nil)
 
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	view, done := testView(t)
 	m := Meta{
 		testingOverrides: metaOverridesForProvider(testProvider()),
@@ -3755,7 +3754,7 @@ func TestInit_pluginDirProvidersDoesNotGet(t *testing.T) {
 		"between": {"2.3.4"},
 	})
 
-	ui := cli.NewMockUi()
+	ui := testUiWrapped(t)
 	view, done := testView(t)
 	m := Meta{
 		testingOverrides: metaOverridesForProvider(testProvider()),
@@ -3829,7 +3828,7 @@ func TestInit_pluginDirWithBuiltIn(t *testing.T) {
 	// An empty provider source
 	providerSource := newMockProviderSource(t, nil)
 
-	ui := cli.NewMockUi()
+	ui := testUiWrapped(t)
 	view, done := testView(t)
 	m := Meta{
 		testingOverrides: metaOverridesForProvider(testProvider()),
@@ -3868,7 +3867,7 @@ func TestInit_invalidBuiltInProviders(t *testing.T) {
 	// An empty provider source
 	providerSource := newMockProviderSource(t, nil)
 
-	ui := cli.NewMockUi()
+	ui := testUiWrapped(t)
 	view, done := testView(t)
 	m := Meta{
 		testingOverrides: metaOverridesForProvider(testProvider()),
@@ -3901,7 +3900,7 @@ func TestInit_invalidSyntaxNoBackend(t *testing.T) {
 	testCopyDir(t, testFixturePath("init-syntax-invalid-no-backend"), td)
 	t.Chdir(td)
 
-	ui := cli.NewMockUi()
+	ui := testUiWrapped(t)
 	view, done := testView(t)
 	m := Meta{
 		Ui:   ui,
@@ -3932,7 +3931,7 @@ func TestInit_invalidSyntaxWithBackend(t *testing.T) {
 	testCopyDir(t, testFixturePath("init-syntax-invalid-with-backend"), td)
 	t.Chdir(td)
 
-	ui := cli.NewMockUi()
+	ui := testUiWrapped(t)
 	view, done := testView(t)
 	m := Meta{
 		Ui:   ui,
@@ -3963,7 +3962,7 @@ func TestInit_invalidSyntaxInvalidBackend(t *testing.T) {
 	testCopyDir(t, testFixturePath("init-syntax-invalid-backend-invalid"), td)
 	t.Chdir(td)
 
-	ui := cli.NewMockUi()
+	ui := testUiWrapped(t)
 	view, done := testView(t)
 	m := Meta{
 		Ui:   ui,
@@ -3997,7 +3996,7 @@ func TestInit_invalidSyntaxBackendAttribute(t *testing.T) {
 	testCopyDir(t, testFixturePath("init-syntax-invalid-backend-attribute-invalid"), td)
 	t.Chdir(td)
 
-	ui := cli.NewMockUi()
+	ui := testUiWrapped(t)
 	view, done := testView(t)
 	m := Meta{
 		Ui:   ui,
@@ -4041,7 +4040,7 @@ func TestInit_testsWithExternalProviders(t *testing.T) {
 	testingConfigureProviderAddress := addrs.NewProvider(addrs.DefaultProviderRegistryHost, "testing", "configure")
 	testingConfigureProvider := new(testing_provider.MockProvider)
 
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	view, done := testView(t)
 	c := &InitCommand{
 		Meta: Meta{
@@ -4075,7 +4074,7 @@ func TestInit_tests(t *testing.T) {
 		"hashicorp/test": {"1.0.0"},
 	})
 
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	view, done := testView(t)
 	c := &InitCommand{
 		Meta: Meta{
@@ -4104,7 +4103,7 @@ func TestInit_testsWithProvider(t *testing.T) {
 		"hashicorp/test": {"1.0.0"},
 	})
 
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	view, done := testView(t)
 	c := &InitCommand{
 		Meta: Meta{
@@ -4150,7 +4149,7 @@ func TestInit_testsWithOverriddenInvalidRequiredProviders(t *testing.T) {
 		"hashicorp/test": {"1.0.0"},
 	})
 
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	view, done := testView(t)
 	c := &InitCommand{
 		Meta: Meta{
@@ -4179,7 +4178,7 @@ func TestInit_testsWithInvalidRequiredProviders(t *testing.T) {
 		"hashicorp/test": {"1.0.0"},
 	})
 
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	view, done := testView(t)
 	c := &InitCommand{
 		Meta: Meta{
@@ -4209,7 +4208,7 @@ func TestInit_testsWithModule(t *testing.T) {
 		"hashicorp/test": {"1.0.0"},
 	})
 
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	view, done := testView(t)
 	c := &InitCommand{
 		Meta: Meta{
@@ -4251,7 +4250,7 @@ func TestInit_stateStore_newWorkingDir_basic(t *testing.T) {
 			"hashicorp/test": {"1.2.3"},
 		})
 
-		ui := new(cli.MockUi)
+		ui := testUiWrapped(t)
 		view, done := testView(t)
 		meta := Meta{
 			Ui:                        ui,
@@ -4348,7 +4347,7 @@ Initializing provider plugins...
 			"hashicorp/test": {"1.0.0"},
 		})
 
-		ui := new(cli.MockUi)
+		ui := testUiWrapped(t)
 		view, done := testView(t)
 		meta := Meta{
 			Ui:                        ui,
@@ -4427,7 +4426,7 @@ Initializing provider plugins...
 			"hashicorp/test": {"1.0.0"},
 		})
 
-		ui := new(cli.MockUi)
+		ui := testUiWrapped(t)
 		view, done := testView(t)
 		meta := Meta{
 			Ui:                        ui,
@@ -4501,7 +4500,7 @@ Initializing provider plugins...
 			"select-workspace": "1", // foobar1 in numbered list
 		})
 
-		ui := new(cli.MockUi)
+		ui := testUiWrapped(t)
 		view, done := testView(t)
 		meta := Meta{
 			Ui:                        ui,
@@ -4556,7 +4555,7 @@ func TestInit_stateStore_newWorkingDir_interactiveProviderApproval(t *testing.T)
 		mockProvider := mockPluggableStateStorageProvider(mockSingleStateStoreSchema("test_store"))
 		mockProviderAddress := addrs.NewDefaultProvider("test")
 
-		ui := new(cli.MockUi)
+		ui := testUiWrapped(t)
 		view, done := testView(t)
 		meta := Meta{
 			Ui:                        ui,
@@ -4623,7 +4622,7 @@ func TestInit_stateStore_newWorkingDir_interactiveProviderApproval(t *testing.T)
 			"approve": "yes",
 		})
 
-		ui := new(cli.MockUi)
+		ui := testUiWrapped(t)
 		view, done := testView(t)
 		meta := Meta{
 			Ui:                        ui,
@@ -4769,7 +4768,7 @@ func TestInit_stateStore_newWorkingDir_interactiveProviderApproval(t *testing.T)
 			"approve": "yes",
 		})
 
-		ui := new(cli.MockUi)
+		ui := testUiWrapped(t)
 		view, done := testView(t)
 		meta := Meta{
 			Ui:                        ui,
@@ -4849,7 +4848,7 @@ func TestInit_stateStore_newWorkingDir_interactiveProviderApproval(t *testing.T)
 			"approve": "no",
 		})
 
-		ui := new(cli.MockUi)
+		ui := testUiWrapped(t)
 		view, done := testView(t)
 		meta := Meta{
 			Ui:                        ui,
@@ -4924,7 +4923,7 @@ func TestInit_stateStore_newWorkingDir_interactiveProviderApproval(t *testing.T)
 		// Set up providers for use in the second init attempt.
 		mockProvider := mockPluggableStateStorageProvider(mockSingleStateStoreSchema("test_store"))
 
-		ui := new(cli.MockUi)
+		ui := testUiWrapped(t)
 		view, done := testView(t)
 		meta := Meta{
 			Ui:                        ui,
@@ -4990,7 +4989,7 @@ func TestInit_stateStore_newWorkingDir_interactiveProviderApproval(t *testing.T)
 		args = []string{
 			"-enable-pluggable-state-storage-experiment=true",
 		}
-		ui = new(cli.MockUi)
+		ui = testUiWrapped(t)
 		view, done = testView(t)
 		c.Ui = ui
 		c.View = view
@@ -5031,7 +5030,7 @@ func TestInit_stateStore_versionConstraintChildModule(t *testing.T) {
 	mockProvider := mockPluggableStateStorageProvider(mockSingleStateStoreSchema("test_store"))
 	mockProviderAddress := addrs.NewDefaultProvider("test")
 
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	view, done := testView(t)
 	meta := Meta{
 		Ui:                        ui,
@@ -5128,7 +5127,7 @@ func TestInit_stateStore_newWorkingDir_inAutomationProviderApproval(t *testing.T
 		mockProvider := mockPluggableStateStorageProvider(mockSingleStateStoreSchema("test_store"))
 		mockProviderAddress := addrs.NewDefaultProvider("test")
 
-		ui := new(cli.MockUi)
+		ui := testUiWrapped(t)
 		view, done := testView(t)
 		meta := Meta{
 			Ui:                        ui,
@@ -5190,7 +5189,7 @@ func TestInit_stateStore_newWorkingDir_inAutomationProviderApproval(t *testing.T
 		})
 		mockProvider := mockPluggableStateStorageProvider(mockSingleStateStoreSchema("test_store"))
 
-		ui := new(cli.MockUi)
+		ui := testUiWrapped(t)
 		view, done := testView(t)
 		meta := Meta{
 			Ui:                        ui,
@@ -5279,7 +5278,7 @@ func TestInit_stateStore_newWorkingDir_inAutomationProviderApproval(t *testing.T
 		})
 		mockProvider := mockPluggableStateStorageProvider(mockSingleStateStoreSchema("test_store"))
 
-		ui := new(cli.MockUi)
+		ui := testUiWrapped(t)
 		view, done := testView(t)
 		meta := Meta{
 			Ui:                        ui,
@@ -5351,7 +5350,7 @@ func TestInit_stateStore_newWorkingDir_inAutomationProviderApproval(t *testing.T
 		})
 		mockProvider := mockPluggableStateStorageProvider(mockSingleStateStoreSchema("test_store"))
 
-		ui := new(cli.MockUi)
+		ui := testUiWrapped(t)
 		view, done := testView(t)
 		meta := Meta{
 			Ui:                        ui,
@@ -5425,7 +5424,7 @@ func TestInit_stateStore_newWorkingDir_inAutomationProviderApproval(t *testing.T
 		})
 		mockProvider := mockPluggableStateStorageProvider(mockSingleStateStoreSchema("test_store"))
 
-		ui := new(cli.MockUi)
+		ui := testUiWrapped(t)
 		view, done := testView(t)
 		meta := Meta{
 			Ui:                        ui,
@@ -5535,7 +5534,7 @@ func TestInit_stateStore_reconfigureLeadingToMigrationOfLocalState(t *testing.T)
 	mockProvider.MockStates = testing_provider.NewMockStateBytesWithStateIds("test_store", []string{"default"})
 	mockProviderAddress := addrs.NewDefaultProvider("test")
 
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	view, done := testView(t)
 	meta := Meta{
 		Ui:                        ui,
@@ -5614,7 +5613,7 @@ func TestInit_stateStore_configUnchanged(t *testing.T) {
 			"hashicorp/test": {"1.2.3"}, // Matches provider version in backend state file fixture
 		})
 
-		ui := new(cli.MockUi)
+		ui := testUiWrapped(t)
 		view, done := testView(t)
 		meta := Meta{
 			Ui:                        ui,
@@ -5710,7 +5709,7 @@ func TestInit_stateStore_configUnchanged(t *testing.T) {
 			"hashicorp/test": {"1.2.3"}, // Matches provider version in backend state file fixture
 		})
 
-		ui := new(cli.MockUi)
+		ui := testUiWrapped(t)
 		view, done := testView(t)
 		meta := Meta{
 			Ui:                        ui,
@@ -5819,7 +5818,7 @@ func TestInit_stateStore_configChanges(t *testing.T) {
 			"hashicorp/test": {"1.2.3"}, // Matches provider version in backend state file fixture
 		})
 
-		ui := new(cli.MockUi)
+		ui := testUiWrapped(t)
 		view, done := testView(t)
 		meta := Meta{
 			Ui:                        ui,
@@ -5912,7 +5911,7 @@ func TestInit_stateStore_configChanges(t *testing.T) {
 			"hashicorp/test": {"1.2.3"}, // Matches provider version in backend state file fixture
 		})
 
-		ui := new(cli.MockUi)
+		ui := testUiWrapped(t)
 		view, done := testView(t)
 		meta := Meta{
 			Ui:                        ui,
@@ -5968,7 +5967,7 @@ func TestInit_stateStore_configChanges(t *testing.T) {
 			"hashicorp/test": {"1.2.3"}, // Matches provider version in backend state file fixture
 		})
 
-		ui := new(cli.MockUi)
+		ui := testUiWrapped(t)
 		view, done := testView(t)
 		meta := Meta{
 			Ui:                        ui,
@@ -6009,7 +6008,7 @@ func TestInit_stateStore_configChanges(t *testing.T) {
 		}
 
 		// 2) When flag is present
-		ui = new(cli.MockUi)
+		ui = testUiWrapped(t)
 		view, done = testView(t)
 		meta.Ui = ui
 		meta.View = view
@@ -6047,7 +6046,7 @@ func TestInit_stateStore_configChanges(t *testing.T) {
 			"hashicorp/test": {"1.2.3"}, // Matches provider version in backend state file fixture
 		})
 
-		ui := new(cli.MockUi)
+		ui := testUiWrapped(t)
 		view, done := testView(t)
 		meta := Meta{
 			Ui:                        ui,
@@ -6114,7 +6113,7 @@ func TestInit_stateStore_changesDetected(t *testing.T) {
 			"hashicorp/test": {"1.2.3"}, // Matches provider version in backend state file fixture
 		})
 
-		ui := cli.NewMockUi()
+		ui := testUiWrapped(t)
 		view, done := testView(t)
 		c := &InitCommand{
 			Meta: Meta{
@@ -6158,7 +6157,7 @@ func TestInit_stateStore_changesDetected(t *testing.T) {
 			"hashicorp/test": {"1.2.3"}, // Matches provider version in backend state file fixture
 		})
 
-		ui := cli.NewMockUi()
+		ui := testUiWrapped(t)
 		view, done := testView(t)
 		c := &InitCommand{
 			Meta: Meta{
@@ -6223,7 +6222,7 @@ func TestInit_stateStore_changesDetected(t *testing.T) {
 			"hashicorp/test": {"1.2.3"}, // Matches provider version in backend state file fixture
 		})
 
-		ui := cli.NewMockUi()
+		ui := testUiWrapped(t)
 		view, done := testView(t)
 		c := &InitCommand{
 			Meta: Meta{
@@ -6266,7 +6265,7 @@ func TestInit_stateStore_changesDetected(t *testing.T) {
 			"hashicorp/test2": {"1.2.3"}, // Matches provider version in backend state file fixture
 		})
 
-		ui := cli.NewMockUi()
+		ui := testUiWrapped(t)
 		view, done := testView(t)
 		c := &InitCommand{
 			Meta: Meta{
@@ -6316,7 +6315,7 @@ func TestInit_stateStore_changesDetected(t *testing.T) {
 			},
 		})
 
-		ui := cli.NewMockUi()
+		ui := testUiWrapped(t)
 		view, done := testView(t)
 		c := &InitCommand{
 			Meta: Meta{
@@ -6375,7 +6374,7 @@ func TestInit_stateStore_backendConfigFlagNoMigrate(t *testing.T) {
 	{
 		log.Printf("[TRACE] TestInit_stateStore_backendConfigFlagNoMigrate: beginning first init")
 
-		ui := cli.NewMockUi()
+		ui := testUiWrapped(t)
 		view, done := testView(t)
 		c := &InitCommand{
 			Meta: Meta{
@@ -6426,7 +6425,7 @@ func TestInit_stateStore_backendConfigFlagNoMigrate(t *testing.T) {
 			t.Fatalf("err: %s", err)
 		}
 
-		ui := cli.NewMockUi()
+		ui := testUiWrapped(t)
 		view, done := testView(t)
 		c := &InitCommand{
 			Meta: Meta{
@@ -6485,7 +6484,7 @@ func TestInit_stateStore_unset(t *testing.T) {
 	{
 		log.Printf("[TRACE] TestInit_stateStore_unset: beginning first init")
 
-		ui := cli.NewMockUi()
+		ui := testUiWrapped(t)
 		view, done := testView(t)
 		c := &InitCommand{
 			Meta: Meta{
@@ -6527,7 +6526,7 @@ func TestInit_stateStore_unset(t *testing.T) {
 			t.Fatalf("err: %s", err)
 		}
 
-		ui := cli.NewMockUi()
+		ui := testUiWrapped(t)
 		view, done := testView(t)
 		c := &InitCommand{
 			Meta: Meta{
@@ -6585,7 +6584,7 @@ func TestInit_stateStore_unset_withoutProviderRequirements(t *testing.T) {
 	{
 		log.Printf("[TRACE] TestInit_stateStore_unset_withoutProviderRequirements: beginning first init")
 
-		ui := cli.NewMockUi()
+		ui := testUiWrapped(t)
 		view, done := testView(t)
 		c := &InitCommand{
 			Meta: Meta{
@@ -6628,7 +6627,7 @@ func TestInit_stateStore_unset_withoutProviderRequirements(t *testing.T) {
 			t.Fatalf("err: %s", err)
 		}
 
-		ui := cli.NewMockUi()
+		ui := testUiWrapped(t)
 		view, done := testView(t)
 		c := &InitCommand{
 			Meta: Meta{
@@ -6689,7 +6688,7 @@ func TestInit_stateStore_to_backend(t *testing.T) {
 	{
 		log.Printf("[TRACE] TestInit_stateStore_to_backend: beginning first init")
 		// Init
-		ui := cli.NewMockUi()
+		ui := testUiWrapped(t)
 		view, done := testView(t)
 		c := &InitCommand{
 			Meta: Meta{
@@ -6720,7 +6719,7 @@ func TestInit_stateStore_to_backend(t *testing.T) {
 		// run apply to ensure state isn't empty
 		// to bypass edge case handling which causes empty state to stop migration
 		log.Printf("[TRACE] TestInit_stateStore_to_backend: beginning apply")
-		ui := cli.NewMockUi()
+		ui := testUiWrapped(t)
 		aView, aDone := testView(t)
 		cApply := &ApplyCommand{
 			Meta: Meta{
@@ -6753,7 +6752,7 @@ func TestInit_stateStore_to_backend(t *testing.T) {
 			t.Fatalf("err: %s", err)
 		}
 
-		ui := cli.NewMockUi()
+		ui := testUiWrapped(t)
 		view, done := testView(t)
 		cApply := &ApplyCommand{
 			Meta: Meta{
@@ -6797,7 +6796,7 @@ func TestInit_stateStore_to_backend(t *testing.T) {
 			t.Fatalf("err: %s", err)
 		}
 
-		ui := cli.NewMockUi()
+		ui := testUiWrapped(t)
 		view, done := testView(t)
 		c := &InitCommand{
 			Meta: Meta{
@@ -6865,7 +6864,7 @@ func TestInit_uninitialized_stateStore(t *testing.T) {
 		}
 		t.Chdir(td)
 
-		ui := cli.NewMockUi()
+		ui := testUiWrapped(t)
 		view, done := testView(t)
 		cApply := &ApplyCommand{
 			Meta: Meta{
@@ -6931,7 +6930,7 @@ func TestInit_backend_to_stateStore_singleWorkspace(t *testing.T) {
 	{
 		log.Printf("[TRACE] %s: beginning first init with backend", t.Name())
 		// Init
-		ui := cli.NewMockUi()
+		ui := testUiWrapped(t)
 		view, done := testView(t)
 		c := &InitCommand{
 			Meta: Meta{
@@ -6972,7 +6971,7 @@ func TestInit_backend_to_stateStore_singleWorkspace(t *testing.T) {
 			t.Fatalf("err: %s", err)
 		}
 
-		ui := cli.NewMockUi()
+		ui := testUiWrapped(t)
 		aView, aDone := testView(t)
 		cApply := &ApplyCommand{
 			Meta: Meta{
@@ -7033,7 +7032,7 @@ func TestInit_backend_to_stateStore_singleWorkspace(t *testing.T) {
 			t.Fatalf("err: %s", err)
 		}
 
-		ui := cli.NewMockUi()
+		ui := testUiWrapped(t)
 		view, done := testView(t)
 		c := &InitCommand{
 			Meta: Meta{
@@ -7110,7 +7109,7 @@ func TestInit_backend_to_stateStore_noState(t *testing.T) {
 	{
 		log.Printf("[TRACE] %s: beginning first init with backend", t.Name())
 		// Init
-		ui := cli.NewMockUi()
+		ui := testUiWrapped(t)
 		view, done := testView(t)
 		c := &InitCommand{
 			Meta: Meta{
@@ -7157,7 +7156,7 @@ func TestInit_backend_to_stateStore_noState(t *testing.T) {
 			t.Fatalf("err: %s", err)
 		}
 
-		ui := cli.NewMockUi()
+		ui := testUiWrapped(t)
 		view, done := testView(t)
 		c := &InitCommand{
 			Meta: Meta{
@@ -7224,7 +7223,7 @@ func TestInit_localBackend_to_stateStore(t *testing.T) {
 	{
 		log.Printf("[TRACE] %s: beginning first init with local backend", t.Name())
 		// Init
-		ui := cli.NewMockUi()
+		ui := testUiWrapped(t)
 		view, done := testView(t)
 		c := &InitCommand{
 			Meta: Meta{
@@ -7258,7 +7257,7 @@ func TestInit_localBackend_to_stateStore(t *testing.T) {
 			t.Fatalf("err: %s", err)
 		}
 
-		ui := cli.NewMockUi()
+		ui := testUiWrapped(t)
 		aView, aDone := testView(t)
 		cApply := &ApplyCommand{
 			Meta: Meta{
@@ -7318,7 +7317,7 @@ func TestInit_localBackend_to_stateStore(t *testing.T) {
 			t.Fatalf("err: %s", err)
 		}
 
-		ui := cli.NewMockUi()
+		ui := testUiWrapped(t)
 		view, done := testView(t)
 		c := &InitCommand{
 			Meta: Meta{
@@ -7386,7 +7385,7 @@ func TestInit_backend_to_stateStore_multipleWorkspaces(t *testing.T) {
 	{
 		log.Printf("[TRACE] %s: beginning first init with backend", t.Name())
 		// Init
-		ui := cli.NewMockUi()
+		ui := testUiWrapped(t)
 		view, done := testView(t)
 		c := &InitCommand{
 			Meta: Meta{
@@ -7420,7 +7419,7 @@ func TestInit_backend_to_stateStore_multipleWorkspaces(t *testing.T) {
 			t.Fatalf("err: %s", err)
 		}
 
-		ui := cli.NewMockUi()
+		ui := testUiWrapped(t)
 		aView, aDone := testView(t)
 		cApply := &ApplyCommand{
 			Meta: Meta{
@@ -7454,7 +7453,7 @@ func TestInit_backend_to_stateStore_multipleWorkspaces(t *testing.T) {
 		}
 	}
 	{
-		ui := cli.NewMockUi()
+		ui := testUiWrapped(t)
 		aView, aDone := testView(t)
 		cSelect := &WorkspaceSelectCommand{
 			Meta: Meta{
@@ -7471,7 +7470,7 @@ func TestInit_backend_to_stateStore_multipleWorkspaces(t *testing.T) {
 		t.Logf("Select workspace output:\n%s", aTestOutput.All())
 	}
 	{
-		ui := cli.NewMockUi()
+		ui := testUiWrapped(t)
 		aView, aDone := testView(t)
 		cApply := &ApplyCommand{
 			Meta: Meta{
@@ -7523,7 +7522,7 @@ func TestInit_backend_to_stateStore_multipleWorkspaces(t *testing.T) {
 			t.Fatalf("err: %s", err)
 		}
 
-		ui := cli.NewMockUi()
+		ui := testUiWrapped(t)
 		view, done := testView(t)
 		c := &InitCommand{
 			Meta: Meta{
@@ -7626,7 +7625,7 @@ func TestInit_cloud_to_stateStore(t *testing.T) {
 	{
 		log.Printf("[TRACE] %s: beginning first init with backend", t.Name())
 		// Init
-		ui := cli.NewMockUi()
+		ui := testUiWrapped(t)
 		view, done := testView(t)
 		c := &InitCommand{
 			Meta: Meta{
@@ -7667,7 +7666,7 @@ func TestInit_cloud_to_stateStore(t *testing.T) {
 			t.Fatalf("err: %s", err)
 		}
 
-		ui := cli.NewMockUi()
+		ui := testUiWrapped(t)
 		view, done := testView(t)
 		c := &InitCommand{
 			Meta: Meta{
@@ -7726,7 +7725,7 @@ func TestInit_configErrorsImpactingStateStore(t *testing.T) {
 		t.Fatalf("err: %s", err)
 	}
 
-	ui := cli.NewMockUi()
+	ui := testUiWrapped(t)
 	view, done := testView(t)
 	initCmd := &InitCommand{
 		Meta: Meta{
@@ -7770,7 +7769,7 @@ func TestInit_varValueWithoutConfig(t *testing.T) {
 		t.Fatalf("err: %s", err)
 	}
 
-	ui := cli.NewMockUi()
+	ui := testUiWrapped(t)
 	view, done := testView(t)
 	initCmd := &InitCommand{
 		Meta: Meta{
@@ -7800,7 +7799,7 @@ func TestInit_invalidConfig(t *testing.T) {
 		t.Fatalf("err: %s", err)
 	}
 
-	ui := cli.NewMockUi()
+	ui := testUiWrapped(t)
 	view, done := testView(t)
 	initCmd := &InitCommand{
 		Meta: Meta{

--- a/internal/command/init_test.go
+++ b/internal/command/init_test.go
@@ -4706,7 +4706,7 @@ func TestInit_stateStore_newWorkingDir_interactiveProviderApproval(t *testing.T)
 		mockProvider := mockPluggableStateStorageProvider(mockSingleStateStoreSchema("test_store"))
 		mockProviderAddress := addrs.NewDefaultProvider("test")
 
-		ui := new(cli.MockUi)
+		ui := testUiWrapped(t)
 		view, done := testView(t)
 		meta := Meta{
 			Ui:                        ui,
@@ -8491,7 +8491,7 @@ func TestInit_backendAliasesRegisteredBeforeProviderDiscovery(t *testing.T) {
 		aliasHost: aliasHost,
 	}
 
-	ui := cli.NewMockUi()
+	ui := testUiWrapped(t)
 	view, done := testView(t)
 	c := &InitCommand{
 		Meta: Meta{

--- a/internal/command/login_test.go
+++ b/internal/command/login_test.go
@@ -46,7 +46,7 @@ func TestLogin(t *testing.T) {
 
 			// Do not use the NewMockUi initializer here, as we want to delay
 			// the call to init until after setting up the input mocks
-			ui := new(cli.MockUi)
+			ui := testUiWrapped(t, new(cli.MockUi))
 
 			browserLauncher := webbrowser.NewMockLauncher(ctx)
 			creds := cliconfig.EmptyCredentialsSourceForTests(filepath.Join(workDir, "credentials.tfrc.json"))

--- a/internal/command/login_test.go
+++ b/internal/command/login_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/hashicorp/terraform/internal/command/cliconfig"
 	oauthserver "github.com/hashicorp/terraform/internal/command/testdata/login-oauth-server"
 	tfeserver "github.com/hashicorp/terraform/internal/command/testdata/login-tfe-server"
+	"github.com/hashicorp/terraform/internal/command/ui"
 	"github.com/hashicorp/terraform/internal/command/webbrowser"
 	"github.com/hashicorp/terraform/internal/httpclient"
 	"github.com/hashicorp/terraform/version"
@@ -34,7 +35,7 @@ func TestLogin(t *testing.T) {
 	ts := httptest.NewServer(tfeserver.Handler)
 	defer ts.Close()
 
-	loginTestCase := func(test func(t *testing.T, c *LoginCommand, ui *cli.MockUi)) func(t *testing.T) {
+	loginTestCase := func(test func(t *testing.T, c *LoginCommand, ui *ui.WrappedMockUi)) func(t *testing.T) {
 		return func(t *testing.T) {
 			t.Helper()
 			workDir := t.TempDir()
@@ -104,7 +105,7 @@ func TestLogin(t *testing.T) {
 		}
 	}
 
-	t.Run("app.terraform.io (no login support)", loginTestCase(func(t *testing.T, c *LoginCommand, ui *cli.MockUi) {
+	t.Run("app.terraform.io (no login support)", loginTestCase(func(t *testing.T, c *LoginCommand, ui *ui.WrappedMockUi) {
 		// Enter "yes" at the consent prompt, then paste a token with some
 		// accidental whitespace.
 		_ = testInputMap(t, map[string]string{
@@ -129,7 +130,7 @@ func TestLogin(t *testing.T) {
 		}
 	}))
 
-	t.Run("example.com with authorization code flow", loginTestCase(func(t *testing.T, c *LoginCommand, ui *cli.MockUi) {
+	t.Run("example.com with authorization code flow", loginTestCase(func(t *testing.T, c *LoginCommand, ui *ui.WrappedMockUi) {
 		// Enter "yes" at the consent prompt.
 		_ = testInputMap(t, map[string]string{
 			"approve": "yes",
@@ -153,7 +154,7 @@ func TestLogin(t *testing.T) {
 		}
 	}))
 
-	t.Run("example.com results in no scopes", loginTestCase(func(t *testing.T, c *LoginCommand, ui *cli.MockUi) {
+	t.Run("example.com results in no scopes", loginTestCase(func(t *testing.T, c *LoginCommand, ui *ui.WrappedMockUi) {
 		host, _ := c.Services.Discover("example.com")
 		client, _ := host.ServiceOAuthClient("login.v1")
 		if len(client.Scopes) != 0 {
@@ -161,7 +162,7 @@ func TestLogin(t *testing.T) {
 		}
 	}))
 
-	t.Run("with-scopes.example.com with authorization code flow and scopes", loginTestCase(func(t *testing.T, c *LoginCommand, ui *cli.MockUi) {
+	t.Run("with-scopes.example.com with authorization code flow and scopes", loginTestCase(func(t *testing.T, c *LoginCommand, ui *ui.WrappedMockUi) {
 		// Enter "yes" at the consent prompt.
 		_ = testInputMap(t, map[string]string{
 			"approve": "yes",
@@ -186,7 +187,7 @@ func TestLogin(t *testing.T) {
 		}
 	}))
 
-	t.Run("with-scopes.example.com results in expected scopes", loginTestCase(func(t *testing.T, c *LoginCommand, ui *cli.MockUi) {
+	t.Run("with-scopes.example.com results in expected scopes", loginTestCase(func(t *testing.T, c *LoginCommand, ui *ui.WrappedMockUi) {
 		host, _ := c.Services.Discover("with-scopes.example.com")
 		client, _ := host.ServiceOAuthClient("login.v1")
 
@@ -200,7 +201,7 @@ func TestLogin(t *testing.T) {
 		}
 	}))
 
-	t.Run("TFE host without login support", loginTestCase(func(t *testing.T, c *LoginCommand, ui *cli.MockUi) {
+	t.Run("TFE host without login support", loginTestCase(func(t *testing.T, c *LoginCommand, ui *ui.WrappedMockUi) {
 		// Enter "yes" at the consent prompt, then paste a token with some
 		// accidental whitespace.
 		_ = testInputMap(t, map[string]string{
@@ -226,7 +227,7 @@ func TestLogin(t *testing.T) {
 		}
 	}))
 
-	t.Run("TFE host without login support, incorrectly pasted token", loginTestCase(func(t *testing.T, c *LoginCommand, ui *cli.MockUi) {
+	t.Run("TFE host without login support, incorrectly pasted token", loginTestCase(func(t *testing.T, c *LoginCommand, ui *ui.WrappedMockUi) {
 		// Enter "yes" at the consent prompt, then paste an invalid token.
 		_ = testInputMap(t, map[string]string{
 			"approve": "yes",
@@ -247,7 +248,7 @@ func TestLogin(t *testing.T) {
 		}
 	}))
 
-	t.Run("host without login or TFE API support", loginTestCase(func(t *testing.T, c *LoginCommand, ui *cli.MockUi) {
+	t.Run("host without login or TFE API support", loginTestCase(func(t *testing.T, c *LoginCommand, ui *ui.WrappedMockUi) {
 		status := c.Run([]string{"unsupported.example.net"})
 		if status == 0 {
 			t.Fatalf("successful exit; want error")
@@ -258,7 +259,7 @@ func TestLogin(t *testing.T) {
 		}
 	}))
 
-	t.Run("answering no cancels", loginTestCase(func(t *testing.T, c *LoginCommand, ui *cli.MockUi) {
+	t.Run("answering no cancels", loginTestCase(func(t *testing.T, c *LoginCommand, ui *ui.WrappedMockUi) {
 		// Enter "no" at the consent prompt
 		_ = testInputMap(t, map[string]string{
 			"approve": "no",
@@ -273,7 +274,7 @@ func TestLogin(t *testing.T) {
 		}
 	}))
 
-	t.Run("answering y cancels", loginTestCase(func(t *testing.T, c *LoginCommand, ui *cli.MockUi) {
+	t.Run("answering y cancels", loginTestCase(func(t *testing.T, c *LoginCommand, ui *ui.WrappedMockUi) {
 		// Enter "y" at the consent prompt
 		_ = testInputMap(t, map[string]string{
 			"approve": "y",

--- a/internal/command/logout_test.go
+++ b/internal/command/logout_test.go
@@ -7,8 +7,6 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/hashicorp/cli"
-
 	svchost "github.com/hashicorp/terraform-svchost"
 	svcauth "github.com/hashicorp/terraform-svchost/auth"
 	"github.com/hashicorp/terraform-svchost/disco"
@@ -19,7 +17,7 @@ func TestLogout(t *testing.T) {
 	t.Parallel()
 	workDir := t.TempDir()
 
-	ui := cli.NewMockUi()
+	ui := testUiWrapped(t)
 	credsSrc := cliconfig.EmptyCredentialsSourceForTests(filepath.Join(workDir, "credentials.tfrc.json"))
 
 	c := &LogoutCommand{

--- a/internal/command/meta_dependencies_test.go
+++ b/internal/command/meta_dependencies_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/hashicorp/cli"
 	tfaddr "github.com/hashicorp/terraform-registry-address"
 	"github.com/hashicorp/terraform/internal/depsfile"
 	"github.com/hashicorp/terraform/internal/getproviders/providerreqs"
@@ -110,7 +109,7 @@ func Test_mergeLockedDependencies(t *testing.T) {
 			td := t.TempDir()
 			t.Chdir(td)
 
-			ui := new(cli.MockUi)
+			ui := testUiWrapped(t)
 			view, _ := testView(t)
 
 			m := Meta{

--- a/internal/command/meta_test.go
+++ b/internal/command/meta_test.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 
-	"github.com/hashicorp/cli"
 	"github.com/hashicorp/terraform/internal/backend"
 	"github.com/hashicorp/terraform/internal/backend/local"
 	"github.com/hashicorp/terraform/internal/terraform"
@@ -443,7 +442,7 @@ func TestCommand_checkRequiredVersion(t *testing.T) {
 	testCopyDir(t, testFixturePath("command-check-required-version"), td)
 	t.Chdir(td)
 
-	ui := cli.NewMockUi()
+	ui := testUiWrapped(t)
 	meta := Meta{
 		Ui: ui,
 	}

--- a/internal/command/metadata_functions_test.go
+++ b/internal/command/metadata_functions_test.go
@@ -6,13 +6,11 @@ package command
 import (
 	"encoding/json"
 	"testing"
-
-	"github.com/hashicorp/cli"
 )
 
 func TestMetadataFunctions_error(t *testing.T) {
 	t.Parallel()
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	c := &MetadataFunctionsCommand{
 		Meta: Meta{
 			Ui: ui,
@@ -27,7 +25,7 @@ func TestMetadataFunctions_error(t *testing.T) {
 
 func TestMetadataFunctions_output(t *testing.T) {
 	t.Parallel()
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	m := Meta{Ui: ui}
 	c := &MetadataFunctionsCommand{Meta: m}
 

--- a/internal/command/modules_test.go
+++ b/internal/command/modules_test.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 
-	"github.com/hashicorp/cli"
 	"github.com/hashicorp/terraform/internal/backend"
 	backendInit "github.com/hashicorp/terraform/internal/backend/init"
 	backendCloud "github.com/hashicorp/terraform/internal/cloud"
@@ -27,7 +26,7 @@ func TestModules_noJsonFlag(t *testing.T) {
 	testCopyDir(t, testFixturePath("modules-nested-dependencies"), dir)
 	t.Chdir(dir)
 
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	view, done := testView(t)
 
 	cmd := &ModulesCommand{
@@ -77,7 +76,7 @@ func TestModules_noJsonFlag_noModules(t *testing.T) {
 	os.MkdirAll(dir, 0755)
 	t.Chdir(dir)
 
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	view, done := testView(t)
 
 	cmd := &ModulesCommand{
@@ -107,7 +106,7 @@ func TestModules_fullCmd(t *testing.T) {
 	testCopyDir(t, testFixturePath("modules-nested-dependencies"), dir)
 	t.Chdir(dir)
 
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	view, done := testView(t)
 
 	cmd := &ModulesCommand{
@@ -134,7 +133,7 @@ func TestModules_fullCmd_unreferencedEntries(t *testing.T) {
 	testCopyDir(t, testFixturePath("modules-unreferenced-entries"), dir)
 	t.Chdir(dir)
 
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	view, done := testView(t)
 
 	cmd := &ModulesCommand{
@@ -160,7 +159,7 @@ func TestModules_uninstalledModules(t *testing.T) {
 	testCopyDir(t, testFixturePath("modules-uninstalled-entries"), dir)
 	t.Chdir(dir)
 
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	view, done := testView(t)
 
 	cmd := &ModulesCommand{
@@ -191,7 +190,7 @@ func TestModules_constVariable(t *testing.T) {
 		wd := tempWorkingDirFixture(t, "dynamic-module-sources/command-with-const-var")
 		t.Chdir(wd.RootModuleDir())
 
-		ui := cli.NewMockUi()
+		ui := testUiWrapped(t)
 		view, done := testView(t)
 
 		cmd := &ModulesCommand{
@@ -219,7 +218,7 @@ func TestModules_constVariable(t *testing.T) {
 		wd := tempWorkingDirFixture(t, "dynamic-module-sources/command-with-const-var")
 		t.Chdir(wd.RootModuleDir())
 
-		ui := cli.NewMockUi()
+		ui := testUiWrapped(t)
 		view, done := testView(t)
 
 		cmd := &ModulesCommand{
@@ -271,7 +270,7 @@ Modules declared by configuration:
 		wd := tempWorkingDirFixture(t, "dynamic-module-sources/command-with-const-var-cloud-backend")
 		t.Chdir(wd.RootModuleDir())
 
-		ui := cli.NewMockUi()
+		ui := testUiWrapped(t)
 		view, done := testView(t)
 
 		cmd := &ModulesCommand{

--- a/internal/command/providers_lock_test.go
+++ b/internal/command/providers_lock_test.go
@@ -29,7 +29,7 @@ func TestProvidersLock(t *testing.T) {
 		os.MkdirAll(td, 0755)
 		t.Chdir(td)
 
-		ui := new(cli.MockUi)
+		ui := testUiWrapped(t)
 		c := &ProvidersLockCommand{
 			Meta: Meta{
 				Ui: ui,
@@ -121,7 +121,7 @@ func runProviderLockGenericTest(t *testing.T, testDirectory, expected string, in
 	}
 
 	p := testProvider()
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	c := &ProvidersLockCommand{
 		Meta: Meta{
 			Ui:               ui,
@@ -150,7 +150,7 @@ func TestProvidersLock_constVariable(t *testing.T) {
 		wd := tempWorkingDirFixture(t, "dynamic-module-sources/get-const-var")
 		t.Chdir(wd.RootModuleDir())
 
-		ui := cli.NewMockUi()
+		ui := testUiWrapped(t)
 		c := &ProvidersLockCommand{
 			Meta: Meta{
 				testingOverrides: metaOverridesForProvider(testProvider()),
@@ -169,7 +169,7 @@ func TestProvidersLock_constVariable(t *testing.T) {
 		wd := tempWorkingDirFixture(t, "dynamic-module-sources/get-const-var")
 		t.Chdir(wd.RootModuleDir())
 
-		ui := cli.NewMockUi()
+		ui := testUiWrapped(t)
 		c := &ProvidersLockCommand{
 			Meta: Meta{
 				testingOverrides: metaOverridesForProvider(testProvider()),
@@ -201,7 +201,7 @@ func TestProvidersLock_constVariable(t *testing.T) {
 		wd := tempWorkingDirFixture(t, "dynamic-module-sources/get-const-var-backend")
 		t.Chdir(wd.RootModuleDir())
 
-		ui := cli.NewMockUi()
+		ui := testUiWrapped(t)
 		c := &ProvidersLockCommand{
 			Meta: Meta{
 				testingOverrides: metaOverridesForProvider(testProvider()),
@@ -226,7 +226,7 @@ func TestProvidersLock_constVariable(t *testing.T) {
 func TestProvidersLock_args(t *testing.T) {
 
 	t.Run("mirror collision", func(t *testing.T) {
-		ui := new(cli.MockUi)
+		ui := testUiWrapped(t)
 		c := &ProvidersLockCommand{
 			Meta: Meta{
 				Ui: ui,
@@ -250,7 +250,7 @@ func TestProvidersLock_args(t *testing.T) {
 	})
 
 	t.Run("invalid platform", func(t *testing.T) {
-		ui := new(cli.MockUi)
+		ui := testUiWrapped(t)
 		c := &ProvidersLockCommand{
 			Meta: Meta{
 				Ui: ui,
@@ -271,7 +271,7 @@ func TestProvidersLock_args(t *testing.T) {
 	})
 
 	t.Run("invalid provider argument", func(t *testing.T) {
-		ui := new(cli.MockUi)
+		ui := testUiWrapped(t)
 		c := &ProvidersLockCommand{
 			Meta: Meta{
 				Ui: ui,

--- a/internal/command/providers_mirror_test.go
+++ b/internal/command/providers_mirror_test.go
@@ -7,8 +7,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/hashicorp/cli"
-
 	"github.com/hashicorp/terraform/internal/backend"
 	backendInit "github.com/hashicorp/terraform/internal/backend/init"
 	backendCloud "github.com/hashicorp/terraform/internal/cloud"
@@ -26,7 +24,7 @@ func TestProvidersMirror(t *testing.T) {
 	})
 
 	t.Run("missing arg error", func(t *testing.T) {
-		ui := new(cli.MockUi)
+		ui := testUiWrapped(t)
 		c := &ProvidersMirrorCommand{
 			Meta: Meta{Ui: ui},
 		}
@@ -47,7 +45,7 @@ func TestProvidersMirror_constVariable(t *testing.T) {
 		wd := tempWorkingDirFixture(t, "dynamic-module-sources/command-with-const-var")
 		t.Chdir(wd.RootModuleDir())
 
-		ui := cli.NewMockUi()
+		ui := testUiWrapped(t)
 		c := &ProvidersMirrorCommand{
 			Meta: Meta{
 				testingOverrides: metaOverridesForProvider(testProvider()),
@@ -76,7 +74,7 @@ func TestProvidersMirror_constVariable(t *testing.T) {
 		wd := tempWorkingDirFixture(t, "dynamic-module-sources/command-with-const-var")
 		t.Chdir(wd.RootModuleDir())
 
-		ui := cli.NewMockUi()
+		ui := testUiWrapped(t)
 		c := &ProvidersMirrorCommand{
 			Meta: Meta{
 				Ui:         ui,
@@ -109,7 +107,7 @@ func TestProvidersMirror_constVariable(t *testing.T) {
 		wd := tempWorkingDirFixture(t, "dynamic-module-sources/command-with-const-var-cloud-backend")
 		t.Chdir(wd.RootModuleDir())
 
-		ui := cli.NewMockUi()
+		ui := testUiWrapped(t)
 		c := &ProvidersMirrorCommand{
 			Meta: Meta{
 				Ui:         ui,

--- a/internal/command/providers_schema_test.go
+++ b/internal/command/providers_schema_test.go
@@ -14,7 +14,6 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/hashicorp/cli"
 	"github.com/zclconf/go-cty/cty"
 
 	"github.com/hashicorp/terraform/internal/addrs"
@@ -31,7 +30,7 @@ import (
 )
 
 func TestProvidersSchema_error(t *testing.T) {
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	c := &ProvidersSchemaCommand{
 		Meta: Meta{
 			testingOverrides: metaOverridesForProvider(testProvider()),
@@ -67,7 +66,7 @@ func TestProvidersSchema_output(t *testing.T) {
 			})
 
 			p := providersSchemaFixtureProvider()
-			ui := new(cli.MockUi)
+			ui := testUiWrapped(t)
 			view, done := testView(t)
 			m := Meta{
 				testingOverrides: metaOverridesForProvider(p),
@@ -123,7 +122,7 @@ func TestProvidersSchema_output_withOverriddenWorkingDir(t *testing.T) {
 	// We don't call t.Chdir, intentionally.
 
 	p := providersSchemaFixtureProvider()
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	c := &ProvidersSchemaCommand{
 		Meta: Meta{
 			Ui:               ui,
@@ -208,7 +207,7 @@ func TestProvidersSchema_output_withStateStore(t *testing.T) {
 	// Mock for the provider in the state
 	mockProviderAddressBaz := addrs.NewDefaultProvider("baz")
 
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	c := &ProvidersSchemaCommand{
 		Meta: Meta{
 			Ui:                        ui,
@@ -274,7 +273,7 @@ func TestProvidersSchema_constVariable(t *testing.T) {
 		wd := tempWorkingDirFixture(t, "dynamic-module-sources/command-with-const-var")
 		t.Chdir(wd.RootModuleDir())
 
-		ui := cli.NewMockUi()
+		ui := testUiWrapped(t)
 		c := &ProvidersSchemaCommand{
 			Meta: Meta{
 				testingOverrides: metaOverridesForProvider(testProvider()),
@@ -298,7 +297,7 @@ func TestProvidersSchema_constVariable(t *testing.T) {
 		wd := tempWorkingDirFixture(t, "dynamic-module-sources/command-with-const-var")
 		t.Chdir(wd.RootModuleDir())
 
-		ui := cli.NewMockUi()
+		ui := testUiWrapped(t)
 		c := &ProvidersSchemaCommand{
 			Meta: Meta{
 				testingOverrides: metaOverridesForProvider(testProvider()),
@@ -336,7 +335,7 @@ func TestProvidersSchema_constVariable(t *testing.T) {
 		wd := tempWorkingDirFixture(t, "dynamic-module-sources/command-with-const-var-cloud-backend")
 		t.Chdir(wd.RootModuleDir())
 
-		ui := cli.NewMockUi()
+		ui := testUiWrapped(t)
 		c := &ProvidersSchemaCommand{
 			Meta: Meta{
 				testingOverrides: metaOverridesForProvider(testProvider()),

--- a/internal/command/providers_test.go
+++ b/internal/command/providers_test.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/hashicorp/cli"
 	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/backend"
 	backendInit "github.com/hashicorp/terraform/internal/backend/init"
@@ -29,7 +28,7 @@ func TestProviders(t *testing.T) {
 	}
 	defer os.Chdir(cwd)
 
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	c := &ProvidersCommand{
 		Meta: Meta{
 			Ui: ui,
@@ -65,7 +64,7 @@ func TestProviders_noConfigs(t *testing.T) {
 	}
 	defer os.Chdir(cwd)
 
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	c := &ProvidersCommand{
 		Meta: Meta{
 			Ui: ui,
@@ -91,7 +90,7 @@ func TestProviders_modules(t *testing.T) {
 	t.Chdir(td)
 
 	// first run init with mock provider sources to install the module
-	initUi := new(cli.MockUi)
+	initUi := testUiWrapped(t)
 	view, _ := testView(t)
 	providerSource := newMockProviderSource(t, map[string][]string{
 		"foo": {"1.0.0"},
@@ -112,7 +111,7 @@ func TestProviders_modules(t *testing.T) {
 	}
 
 	// Providers command
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	c := &ProvidersCommand{
 		Meta: Meta{
 			Ui: ui,
@@ -149,7 +148,7 @@ func TestProviders_state(t *testing.T) {
 	}
 	defer os.Chdir(cwd)
 
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	c := &ProvidersCommand{
 		Meta: Meta{
 			Ui: ui,
@@ -186,7 +185,7 @@ func TestProviders_tests(t *testing.T) {
 	}
 	defer os.Chdir(cwd)
 
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	c := &ProvidersCommand{
 		Meta: Meta{
 			Ui: ui,
@@ -251,7 +250,7 @@ func TestProviders_state_withStateStore(t *testing.T) {
 	)
 	mockProviderAddress := addrs.NewDefaultProvider("test")
 
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	c := &ProvidersCommand{
 		Meta: Meta{
 			Ui:                        ui,
@@ -289,7 +288,7 @@ func TestProviders_constVariable(t *testing.T) {
 		wd := tempWorkingDirFixture(t, "dynamic-module-sources/command-with-const-var")
 		t.Chdir(wd.RootModuleDir())
 
-		ui := cli.NewMockUi()
+		ui := testUiWrapped(t)
 		c := &ProvidersCommand{
 			Meta: Meta{
 				testingOverrides: metaOverridesForProvider(testProvider()),
@@ -313,7 +312,7 @@ func TestProviders_constVariable(t *testing.T) {
 		wd := tempWorkingDirFixture(t, "dynamic-module-sources/command-with-const-var")
 		t.Chdir(wd.RootModuleDir())
 
-		ui := cli.NewMockUi()
+		ui := testUiWrapped(t)
 		c := &ProvidersCommand{
 			Meta: Meta{
 				testingOverrides: metaOverridesForProvider(testProvider()),
@@ -351,7 +350,7 @@ func TestProviders_constVariable(t *testing.T) {
 		wd := tempWorkingDirFixture(t, "dynamic-module-sources/command-with-const-var-backend")
 		t.Chdir(wd.RootModuleDir())
 
-		ui := cli.NewMockUi()
+		ui := testUiWrapped(t)
 		c := &ProvidersCommand{
 			Meta: Meta{
 				testingOverrides: metaOverridesForProvider(testProvider()),

--- a/internal/command/refresh_test.go
+++ b/internal/command/refresh_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/davecgh/go-spew/spew"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/cli"
 	"github.com/zclconf/go-cty/cty"
 
 	"github.com/hashicorp/terraform/internal/addrs"
@@ -559,7 +558,7 @@ func TestRefresh_varsUnset(t *testing.T) {
 	statePath := testStateFile(t, state)
 
 	p := testProvider()
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	view, done := testView(t)
 	c := &RefreshCommand{
 		Meta: Meta{

--- a/internal/command/show_test.go
+++ b/internal/command/show_test.go
@@ -14,7 +14,6 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/hashicorp/cli"
 	"github.com/zclconf/go-cty/cty"
 
 	"github.com/hashicorp/terraform/internal/addrs"
@@ -596,7 +595,7 @@ func TestShow_json_output(t *testing.T) {
 			p := showFixtureProvider()
 
 			// init
-			ui := new(cli.MockUi)
+			ui := testUiWrapped(t)
 			view, _ := testView(t)
 			ic := &InitCommand{
 				Meta: Meta{
@@ -705,7 +704,7 @@ func TestShow_json_output_sensitive(t *testing.T) {
 	p := showFixtureSensitiveProvider()
 
 	// init
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	view, _ := testView(t)
 	ic := &InitCommand{
 		Meta: Meta{
@@ -796,7 +795,7 @@ func TestShow_json_output_actions(t *testing.T) {
 	p := showFixtureProvider()
 
 	// init
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	view, _ := testView(t)
 	ic := &InitCommand{
 		Meta: Meta{
@@ -892,7 +891,7 @@ func TestShow_json_output_conditions_refresh_only(t *testing.T) {
 	p := showFixtureSensitiveProvider()
 
 	// init
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	view, _ := testView(t)
 	ic := &InitCommand{
 		Meta: Meta{
@@ -1002,7 +1001,7 @@ func TestShow_json_output_state(t *testing.T) {
 			p := showFixtureProvider()
 
 			// init
-			ui := new(cli.MockUi)
+			ui := testUiWrapped(t)
 			view, _ := testView(t)
 			ic := &InitCommand{
 				Meta: Meta{

--- a/internal/command/state_identities_test.go
+++ b/internal/command/state_identities_test.go
@@ -11,7 +11,6 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/hashicorp/cli"
 	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/providers"
 	testing_provider "github.com/hashicorp/terraform/internal/providers/testing"
@@ -23,7 +22,7 @@ func TestStateIdentities(t *testing.T) {
 	statePath := testStateFile(t, state)
 
 	p := testProvider()
-	ui := cli.NewMockUi()
+	ui := testUiWrapped(t)
 	c := &StateIdentitiesCommand{
 		Meta: Meta{
 			testingOverrides: metaOverridesForProvider(p),
@@ -65,7 +64,7 @@ func TestStateIdentitiesWithNoIdentityInfo(t *testing.T) {
 	statePath := testStateFile(t, state)
 
 	p := testProvider()
-	ui := cli.NewMockUi()
+	ui := testUiWrapped(t)
 	c := &StateIdentitiesCommand{
 		Meta: Meta{
 			testingOverrides: metaOverridesForProvider(p),
@@ -104,7 +103,7 @@ func TestStateIdentitiesFilterByID(t *testing.T) {
 	statePath := testStateFile(t, state)
 
 	p := testProvider()
-	ui := cli.NewMockUi()
+	ui := testUiWrapped(t)
 	c := &StateIdentitiesCommand{
 		Meta: Meta{
 			testingOverrides: metaOverridesForProvider(p),
@@ -146,7 +145,7 @@ func TestStateIdentitiesWithNonExistentID(t *testing.T) {
 	statePath := testStateFile(t, state)
 
 	p := testProvider()
-	ui := cli.NewMockUi()
+	ui := testUiWrapped(t)
 	c := &StateIdentitiesCommand{
 		Meta: Meta{
 			testingOverrides: metaOverridesForProvider(p),
@@ -177,7 +176,7 @@ func TestStateIdentitiesWithNoJsonFlag(t *testing.T) {
 	statePath := testStateFile(t, state)
 
 	p := testProvider()
-	ui := cli.NewMockUi()
+	ui := testUiWrapped(t)
 	c := &StateIdentitiesCommand{
 		Meta: Meta{
 			testingOverrides: metaOverridesForProvider(p),
@@ -201,7 +200,7 @@ func TestStateIdentities_backendDefaultState(t *testing.T) {
 	t.Chdir(td)
 
 	p := testProvider()
-	ui := cli.NewMockUi()
+	ui := testUiWrapped(t)
 	c := &StateIdentitiesCommand{
 		Meta: Meta{
 			testingOverrides: metaOverridesForProvider(p),
@@ -251,7 +250,7 @@ func TestStateIdentities_backendOverrideState(t *testing.T) {
 	t.Chdir(td)
 
 	p := testProvider()
-	ui := cli.NewMockUi()
+	ui := testUiWrapped(t)
 	c := &StateIdentitiesCommand{
 		Meta: Meta{
 			testingOverrides: metaOverridesForProvider(p),
@@ -294,7 +293,7 @@ func TestStateIdentities_noState(t *testing.T) {
 	t.Chdir(tmp)
 
 	p := testProvider()
-	ui := cli.NewMockUi()
+	ui := testUiWrapped(t)
 	c := &StateIdentitiesCommand{
 		Meta: Meta{
 			testingOverrides: metaOverridesForProvider(p),
@@ -315,7 +314,7 @@ func TestStateIdentities_modules(t *testing.T) {
 	t.Chdir(td)
 
 	p := testProvider()
-	ui := cli.NewMockUi()
+	ui := testUiWrapped(t)
 	c := &StateIdentitiesCommand{
 		Meta: Meta{
 			testingOverrides: metaOverridesForProvider(p),
@@ -452,7 +451,7 @@ func TestStateIdentities_stateStore(t *testing.T) {
 	)
 	mockProviderAddress := addrs.NewDefaultProvider("test")
 
-	ui := cli.NewMockUi()
+	ui := testUiWrapped(t)
 	c := &StateIdentitiesCommand{
 		Meta: Meta{
 			AllowExperimentalFeatures: true,

--- a/internal/command/state_list_test.go
+++ b/internal/command/state_list_test.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/hashicorp/cli"
 	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/providers"
 	testing_provider "github.com/hashicorp/terraform/internal/providers/testing"
@@ -21,7 +20,7 @@ func TestStateList(t *testing.T) {
 	statePath := testStateFile(t, state)
 
 	p := testProvider()
-	ui := cli.NewMockUi()
+	ui := testUiWrapped(t)
 	c := &StateListCommand{
 		Meta: Meta{
 			testingOverrides: metaOverridesForProvider(p),
@@ -49,7 +48,7 @@ func TestStateListWithID(t *testing.T) {
 	statePath := testStateFile(t, state)
 
 	p := testProvider()
-	ui := cli.NewMockUi()
+	ui := testUiWrapped(t)
 	c := &StateListCommand{
 		Meta: Meta{
 			testingOverrides: metaOverridesForProvider(p),
@@ -78,7 +77,7 @@ func TestStateListWithNonExistentID(t *testing.T) {
 	statePath := testStateFile(t, state)
 
 	p := testProvider()
-	ui := cli.NewMockUi()
+	ui := testUiWrapped(t)
 	c := &StateListCommand{
 		Meta: Meta{
 			testingOverrides: metaOverridesForProvider(p),
@@ -110,7 +109,7 @@ func TestStateList_backendDefaultState(t *testing.T) {
 	t.Chdir(td)
 
 	p := testProvider()
-	ui := cli.NewMockUi()
+	ui := testUiWrapped(t)
 	c := &StateListCommand{
 		Meta: Meta{
 			testingOverrides: metaOverridesForProvider(p),
@@ -138,7 +137,7 @@ func TestStateList_backendCustomState(t *testing.T) {
 	t.Chdir(td)
 
 	p := testProvider()
-	ui := cli.NewMockUi()
+	ui := testUiWrapped(t)
 	c := &StateListCommand{
 		Meta: Meta{
 			testingOverrides: metaOverridesForProvider(p),
@@ -207,7 +206,7 @@ func TestStateList_stateStore(t *testing.T) {
 	)
 	mockProviderAddress := addrs.NewDefaultProvider("test")
 
-	ui := cli.NewMockUi()
+	ui := testUiWrapped(t)
 	c := &StateListCommand{
 		Meta: Meta{
 			AllowExperimentalFeatures: true,
@@ -240,7 +239,7 @@ func TestStateList_backendOverrideState(t *testing.T) {
 	t.Chdir(td)
 
 	p := testProvider()
-	ui := cli.NewMockUi()
+	ui := testUiWrapped(t)
 	c := &StateListCommand{
 		Meta: Meta{
 			testingOverrides: metaOverridesForProvider(p),
@@ -267,7 +266,7 @@ func TestStateList_noState(t *testing.T) {
 	t.Chdir(tmp)
 
 	p := testProvider()
-	ui := cli.NewMockUi()
+	ui := testUiWrapped(t)
 	c := &StateListCommand{
 		Meta: Meta{
 			testingOverrides: metaOverridesForProvider(p),
@@ -288,7 +287,7 @@ func TestStateList_modules(t *testing.T) {
 	t.Chdir(td)
 
 	p := testProvider()
-	ui := cli.NewMockUi()
+	ui := testUiWrapped(t)
 	c := &StateListCommand{
 		Meta: Meta{
 			testingOverrides: metaOverridesForProvider(p),

--- a/internal/command/state_migrate_test.go
+++ b/internal/command/state_migrate_test.go
@@ -11,7 +11,6 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/hashicorp/cli"
 	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/command/clistate"
 	"github.com/hashicorp/terraform/internal/command/workdir"
@@ -25,7 +24,7 @@ func TestStateMigrate_fromBackendToBackend(t *testing.T) {
 	wd := tempWorkingDirFixture(t, "state-migrate-backend-to-backend")
 	t.Chdir(wd.RootModuleDir())
 
-	ui := cli.NewMockUi()
+	ui := testUiWrapped(t)
 	view, done := testView(t)
 	c := &StateMigrateCommand{
 		Meta: Meta{
@@ -102,7 +101,7 @@ func TestStateMigrate_fromBackendToStateStore(t *testing.T) {
 		"hashicorp/test": {"1.2.3"},
 	})
 
-	ui := cli.NewMockUi()
+	ui := testUiWrapped(t)
 	view, done := testView(t)
 	c := &StateMigrateCommand{
 		Meta: Meta{
@@ -241,7 +240,7 @@ func TestStateMigrate_fromStateStoreToStateStore_inSingleProvider(t *testing.T) 
 			"hashicorp/test": {"1.2.3"},
 		})
 
-		ui := cli.NewMockUi()
+		ui := testUiWrapped(t)
 		view, done := testView(t)
 		c := &StateMigrateCommand{
 			Meta: Meta{
@@ -329,7 +328,7 @@ func TestStateMigrate_fromStateStoreToStateStore_inSingleProvider(t *testing.T) 
 			"hashicorp/test": {"1.2.3"},
 		})
 
-		ui := cli.NewMockUi()
+		ui := testUiWrapped(t)
 		view, done := testView(t)
 		c := &StateMigrateCommand{
 			Meta: Meta{
@@ -469,7 +468,7 @@ func TestStateMigrate_fromStateStoreToStateStore_inDifferentProviders(t *testing
 			"hashicorp/test2": {"3.2.1"},
 		})
 
-		ui := cli.NewMockUi()
+		ui := testUiWrapped(t)
 		view, done := testView(t)
 		c := &StateMigrateCommand{
 			Meta: Meta{
@@ -604,7 +603,7 @@ provider "registry.terraform.io/hashicorp/test2" {
 			"hashicorp/test2": {"3.2.1"},
 		})
 
-		ui := cli.NewMockUi()
+		ui := testUiWrapped(t)
 		view, done := testView(t)
 		c := &StateMigrateCommand{
 			Meta: Meta{
@@ -715,7 +714,7 @@ provider "registry.terraform.io/hashicorp/test2" {
 			"hashicorp/test2": {"3.2.1"},
 		})
 
-		ui := cli.NewMockUi()
+		ui := testUiWrapped(t)
 		view, done := testView(t)
 		c := &StateMigrateCommand{
 			Meta: Meta{
@@ -815,7 +814,7 @@ func TestStateMigrate_fromStateStoreToBackend(t *testing.T) {
 		"hashicorp/test": {"1.2.3"},
 	})
 
-	ui := cli.NewMockUi()
+	ui := testUiWrapped(t)
 	view, done := testView(t)
 	c := &StateMigrateCommand{
 		Meta: Meta{
@@ -897,7 +896,7 @@ func TestStateMigrate_missingModuleFiles(t *testing.T) {
 		"hashicorp/test": {"1.2.3"},
 	})
 
-	ui := cli.NewMockUi()
+	ui := testUiWrapped(t)
 	view, done := testView(t)
 	c := &StateMigrateCommand{
 		Meta: Meta{
@@ -933,7 +932,7 @@ func TestStateMigrate_emptyModuleFiles(t *testing.T) {
 		"hashicorp/test": {"1.2.3"},
 	})
 
-	ui := cli.NewMockUi()
+	ui := testUiWrapped(t)
 	view, done := testView(t)
 	c := &StateMigrateCommand{
 		Meta: Meta{
@@ -965,7 +964,7 @@ func TestStateMigrate_missingMigrationFiles(t *testing.T) {
 	wd := tempWorkingDirFixture(t, "state-migrate-missing-migrate-files")
 	t.Chdir(wd.RootModuleDir())
 
-	ui := cli.NewMockUi()
+	ui := testUiWrapped(t)
 	view, done := testView(t)
 	c := &StateMigrateCommand{
 		Meta: Meta{
@@ -997,7 +996,7 @@ func TestStateMigrate_nonExistentLockFiles(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Chdir(tmpDir)
 
-	ui := cli.NewMockUi()
+	ui := testUiWrapped(t)
 	view, done := testView(t)
 	c := &StateMigrateCommand{
 		Meta: Meta{

--- a/internal/command/state_mv_test.go
+++ b/internal/command/state_mv_test.go
@@ -13,7 +13,6 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/hashicorp/cli"
 
 	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/backend"
@@ -61,7 +60,7 @@ func TestStateMv(t *testing.T) {
 	statePath := testStateFile(t, state)
 
 	p := testProvider()
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	view, _ := testView(t)
 	c := &StateMvCommand{
 		StateMeta{
@@ -260,7 +259,7 @@ func TestStateMv_stateStore(t *testing.T) {
 		return providers.WriteStateBytesResponse{}
 	}
 
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	c := &StateMvCommand{
 		StateMeta{
 			Meta: Meta{
@@ -318,7 +317,7 @@ func TestStateMv_backupAndBackupOutOptionsWithNonLocalBackend(t *testing.T) {
 		testStateFileRemote(t, dataState)
 
 		p := testProvider()
-		ui := new(cli.MockUi)
+		ui := testUiWrapped(t)
 		view, _ := testView(t)
 		c := &StateMvCommand{
 			StateMeta{
@@ -366,7 +365,7 @@ on a local state file only. You must specify a local state file with the
 		testStateFileRemote(t, dataState)
 
 		p := testProvider()
-		ui := new(cli.MockUi)
+		ui := testUiWrapped(t)
 		view, _ := testView(t)
 		c := &StateMvCommand{
 			StateMeta{
@@ -415,7 +414,7 @@ on a local state file only. You must specify a local state file with the
 		testStateFileRemote(t, dataState)
 
 		p := testProvider()
-		ui := new(cli.MockUi)
+		ui := testUiWrapped(t)
 		view, _ := testView(t)
 		c := &StateMvCommand{
 			StateMeta{
@@ -465,7 +464,7 @@ on a local state file only. You must specify a local state file with the
 		testStateFileRemote(t, dataState)
 
 		p := testProvider()
-		ui := new(cli.MockUi)
+		ui := testUiWrapped(t)
 		view, _ := testView(t)
 		c := &StateMvCommand{
 			StateMeta{
@@ -505,7 +504,7 @@ on a local state file only. You must specify a local state file with the
 		testStateFileRemote(t, dataState)
 
 		p := testProvider()
-		ui := new(cli.MockUi)
+		ui := testUiWrapped(t)
 		view, _ := testView(t)
 		c := &StateMvCommand{
 			StateMeta{
@@ -581,7 +580,7 @@ func TestStateMv_resourceToInstance(t *testing.T) {
 	statePath := testStateFile(t, state)
 
 	p := testProvider()
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	view, _ := testView(t)
 	c := &StateMvCommand{
 		StateMeta{
@@ -629,7 +628,7 @@ func TestStateMv_constVariable(t *testing.T) {
 		wd := tempWorkingDirFixture(t, "dynamic-module-sources/command-with-const-var")
 		t.Chdir(wd.RootModuleDir())
 
-		ui := cli.NewMockUi()
+		ui := testUiWrapped(t)
 		view, _ := testView(t)
 		c := &StateMvCommand{
 			StateMeta{
@@ -657,7 +656,7 @@ func TestStateMv_constVariable(t *testing.T) {
 		wd := tempWorkingDirFixture(t, "dynamic-module-sources/command-with-const-var")
 		t.Chdir(wd.RootModuleDir())
 
-		ui := cli.NewMockUi()
+		ui := testUiWrapped(t)
 		view, _ := testView(t)
 		c := &StateMvCommand{
 			StateMeta{
@@ -696,7 +695,7 @@ module.child:
 		wd := tempWorkingDirFixture(t, "dynamic-module-sources/command-with-const-var-backend")
 		t.Chdir(wd.RootModuleDir())
 
-		ui := cli.NewMockUi()
+		ui := testUiWrapped(t)
 		view, _ := testView(t)
 		c := &StateMvCommand{
 			StateMeta{
@@ -758,7 +757,7 @@ func TestStateMv_resourceToInstanceErr(t *testing.T) {
 	statePath := testStateFile(t, state)
 
 	p := testProvider()
-	ui := cli.NewMockUi()
+	ui := testUiWrapped(t)
 	view, _ := testView(t)
 
 	c := &StateMvCommand{
@@ -827,7 +826,7 @@ func TestStateMv_resourceToInstanceErrInAutomation(t *testing.T) {
 	statePath := testStateFile(t, state)
 
 	p := testProvider()
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	view, _ := testView(t)
 	c := &StateMvCommand{
 		StateMeta{
@@ -901,7 +900,7 @@ func TestStateMv_instanceToResource(t *testing.T) {
 	statePath := testStateFile(t, state)
 
 	p := testProvider()
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	view, _ := testView(t)
 	c := &StateMvCommand{
 		StateMeta{
@@ -976,7 +975,7 @@ func TestStateMv_instanceToNewResource(t *testing.T) {
 	statePath := testStateFile(t, state)
 
 	p := testProvider()
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	view, _ := testView(t)
 	c := &StateMvCommand{
 		StateMeta{
@@ -1049,7 +1048,7 @@ func TestStateMv_differentResourceTypes(t *testing.T) {
 	statePath := testStateFile(t, state)
 
 	p := testProvider()
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	view, _ := testView(t)
 	c := &StateMvCommand{
 		StateMeta{
@@ -1126,7 +1125,7 @@ func TestStateMv_explicitWithBackend(t *testing.T) {
 	statePath := testStateFile(t, state)
 
 	// init our backend
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	view, _ := testView(t)
 	ic := &InitCommand{
 		Meta: Meta{
@@ -1143,7 +1142,7 @@ func TestStateMv_explicitWithBackend(t *testing.T) {
 
 	// only modify statePath
 	p := testProvider()
-	ui = new(cli.MockUi)
+	ui = testUiWrapped(t)
 	c := &StateMvCommand{
 		StateMeta{
 			Meta: Meta{
@@ -1206,7 +1205,7 @@ func TestStateMv_backupExplicit(t *testing.T) {
 	backupPath := statePath + ".backup.test"
 
 	p := testProvider()
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	view, _ := testView(t)
 	c := &StateMvCommand{
 		StateMeta{
@@ -1257,7 +1256,7 @@ func TestStateMv_stateOutNew(t *testing.T) {
 	stateOutPath := statePath + ".out"
 
 	p := testProvider()
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	view, _ := testView(t)
 	c := &StateMvCommand{
 		StateMeta{
@@ -1331,7 +1330,7 @@ func TestStateMv_stateOutExisting(t *testing.T) {
 	stateOutPath := testStateFile(t, stateDst)
 
 	p := testProvider()
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	view, _ := testView(t)
 	c := &StateMvCommand{
 		StateMeta{
@@ -1376,7 +1375,7 @@ func TestStateMv_noState(t *testing.T) {
 	t.Chdir(tmp)
 
 	p := testProvider()
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	view, _ := testView(t)
 	c := &StateMvCommand{
 		StateMeta{
@@ -1446,7 +1445,7 @@ func TestStateMv_stateOutNew_count(t *testing.T) {
 	stateOutPath := statePath + ".out"
 
 	p := testProvider()
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	view, _ := testView(t)
 	c := &StateMvCommand{
 		StateMeta{
@@ -1522,7 +1521,7 @@ func TestStateMv_stateOutNew_largeCount(t *testing.T) {
 	stateOutPath := statePath + ".out"
 
 	p := testProvider()
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	view, _ := testView(t)
 	c := &StateMvCommand{
 		StateMeta{
@@ -1594,7 +1593,7 @@ func TestStateMv_stateOutNew_nestedModule(t *testing.T) {
 	stateOutPath := statePath + ".out"
 
 	p := testProvider()
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	view, _ := testView(t)
 	c := &StateMvCommand{
 		StateMeta{
@@ -1652,7 +1651,7 @@ func TestStateMv_toNewModule(t *testing.T) {
 	stateOutPath2 := statePath + ".out2"
 
 	p := testProvider()
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	view, _ := testView(t)
 	c := &StateMvCommand{
 		StateMeta{
@@ -1752,7 +1751,7 @@ func TestStateMv_withinBackend(t *testing.T) {
 	}
 
 	p := testProvider()
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	view, _ := testView(t)
 	c := &StateMvCommand{
 		StateMeta{
@@ -1823,7 +1822,7 @@ func TestStateMv_fromBackendToLocal(t *testing.T) {
 	}
 
 	p := testProvider()
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	view, _ := testView(t)
 	c := &StateMvCommand{
 		StateMeta{
@@ -1876,7 +1875,7 @@ func TestStateMv_onlyResourceInModule(t *testing.T) {
 	testStateOutput(t, statePath, testStateMvOnlyResourceInModule_original)
 
 	p := testProvider()
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	view, _ := testView(t)
 	c := &StateMvCommand{
 		StateMeta{
@@ -1920,7 +1919,7 @@ func TestStateMvInvalidSourceAddress(t *testing.T) {
 	statePath := testStateFile(t, state)
 
 	p := testProvider()
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	view, _ := testView(t)
 	c := &StateMvCommand{
 		StateMeta{
@@ -1985,7 +1984,7 @@ func TestStateMv_checkRequiredVersion(t *testing.T) {
 	statePath := testStateFile(t, state)
 
 	p := testProvider()
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	view, _ := testView(t)
 	c := &StateMvCommand{
 		StateMeta{

--- a/internal/command/state_pull_test.go
+++ b/internal/command/state_pull_test.go
@@ -8,8 +8,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/hashicorp/cli"
-
 	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/backend"
 	backendInit "github.com/hashicorp/terraform/internal/backend/init"
@@ -27,7 +25,7 @@ func TestStatePull(t *testing.T) {
 	t.Chdir(td)
 
 	p := testProvider()
-	ui := cli.NewMockUi()
+	ui := testUiWrapped(t)
 	c := &StatePullCommand{
 		Meta: Meta{
 			testingOverrides: metaOverridesForProvider(p),
@@ -113,7 +111,7 @@ func TestStatePull_stateStore(t *testing.T) {
 		"hashicorp/test": {"1.0.0"},
 	})
 
-	ui := cli.NewMockUi()
+	ui := testUiWrapped(t)
 	streams, _ := terminal.StreamsForTesting(t)
 	c := &StatePullCommand{
 		Meta: Meta{
@@ -167,7 +165,7 @@ func TestStatePull_noState(t *testing.T) {
 	t.Chdir(tmp)
 
 	p := testProvider()
-	ui := cli.NewMockUi()
+	ui := testUiWrapped(t)
 	c := &StatePullCommand{
 		Meta: Meta{
 			testingOverrides: metaOverridesForProvider(p),
@@ -191,7 +189,7 @@ func TestStatePull_constVariable(t *testing.T) {
 		wd := tempWorkingDirFixture(t, "dynamic-module-sources/command-with-const-var")
 		t.Chdir(wd.RootModuleDir())
 
-		ui := cli.NewMockUi()
+		ui := testUiWrapped(t)
 		c := &StatePullCommand{
 			Meta: Meta{
 				testingOverrides: metaOverridesForProvider(testProvider()),
@@ -215,7 +213,7 @@ func TestStatePull_constVariable(t *testing.T) {
 		wd := tempWorkingDirFixture(t, "dynamic-module-sources/command-with-const-var")
 		t.Chdir(wd.RootModuleDir())
 
-		ui := cli.NewMockUi()
+		ui := testUiWrapped(t)
 		c := &StatePullCommand{
 			Meta: Meta{
 				testingOverrides: metaOverridesForProvider(testProvider()),
@@ -262,7 +260,7 @@ func TestStatePull_constVariable(t *testing.T) {
 		wd := tempWorkingDirFixture(t, "dynamic-module-sources/command-with-const-var-backend")
 		t.Chdir(wd.RootModuleDir())
 
-		ui := cli.NewMockUi()
+		ui := testUiWrapped(t)
 		c := &StatePullCommand{
 			Meta: Meta{
 				testingOverrides: metaOverridesForProvider(testProvider()),
@@ -307,7 +305,7 @@ func TestStatePull_checkRequiredVersion(t *testing.T) {
 	t.Chdir(td)
 
 	p := testProvider()
-	ui := cli.NewMockUi()
+	ui := testUiWrapped(t)
 	c := &StatePullCommand{
 		Meta: Meta{
 			testingOverrides: metaOverridesForProvider(p),

--- a/internal/command/state_push_test.go
+++ b/internal/command/state_push_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/hashicorp/cli"
 	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/backend"
 	backendInit "github.com/hashicorp/terraform/internal/backend/init"
@@ -29,7 +28,7 @@ func TestStatePush_empty(t *testing.T) {
 	expected := testStateRead(t, "replace.tfstate")
 
 	p := testProvider()
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	view, _ := testView(t)
 	c := &StatePushCommand{
 		Meta: Meta{
@@ -63,7 +62,7 @@ func TestStatePush_stateStore(t *testing.T) {
 	mockProvider.MockStates = testing_provider.NewMockStateBytesWithStateIds("test_store", []string{"default"})
 	mockProviderAddress := addrs.NewDefaultProvider("test")
 
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	c := &StatePushCommand{
 		Meta: Meta{
 			AllowExperimentalFeatures: true,
@@ -104,7 +103,7 @@ func TestStatePush_lockedState(t *testing.T) {
 	t.Chdir(td)
 
 	p := testProvider()
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	view, _ := testView(t)
 	c := &StatePushCommand{
 		Meta: Meta{
@@ -138,7 +137,7 @@ func TestStatePush_replaceMatch(t *testing.T) {
 	expected := testStateRead(t, "replace.tfstate")
 
 	p := testProvider()
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	view, _ := testView(t)
 	c := &StatePushCommand{
 		Meta: Meta{
@@ -175,7 +174,7 @@ func TestStatePush_replaceMatchStdin(t *testing.T) {
 	defer testStdinPipe(t, &buf)()
 
 	p := testProvider()
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	view, _ := testView(t)
 	c := &StatePushCommand{
 		Meta: Meta{
@@ -205,7 +204,7 @@ func TestStatePush_lineageMismatch(t *testing.T) {
 	expected := testStateRead(t, "local-state.tfstate")
 
 	p := testProvider()
-	ui := cli.NewMockUi()
+	ui := testUiWrapped(t)
 	view, _ := testView(t)
 	c := &StatePushCommand{
 		Meta: Meta{
@@ -235,7 +234,7 @@ func TestStatePush_serialNewer(t *testing.T) {
 	expected := testStateRead(t, "local-state.tfstate")
 
 	p := testProvider()
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	view, _ := testView(t)
 	c := &StatePushCommand{
 		Meta: Meta{
@@ -265,7 +264,7 @@ func TestStatePush_serialOlder(t *testing.T) {
 	expected := testStateRead(t, "replace.tfstate")
 
 	p := testProvider()
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	view, _ := testView(t)
 	c := &StatePushCommand{
 		Meta: Meta{
@@ -296,7 +295,7 @@ func TestStatePush_forceRemoteState(t *testing.T) {
 	statePath := testStateFile(t, s)
 
 	// init the backend
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	view, _ := testView(t)
 	initCmd := &InitCommand{
 		Meta: Meta{Ui: ui, View: view},
@@ -306,7 +305,7 @@ func TestStatePush_forceRemoteState(t *testing.T) {
 	}
 
 	// create a new workspace
-	ui = new(cli.MockUi)
+	ui = testUiWrapped(t)
 	newCmd := &WorkspaceNewCommand{
 		Meta: Meta{Ui: ui, View: view},
 	}
@@ -328,7 +327,7 @@ func TestStatePush_forceRemoteState(t *testing.T) {
 	}
 
 	// push our local state to that new workspace
-	ui = new(cli.MockUi)
+	ui = testUiWrapped(t)
 	c := &StatePushCommand{
 		Meta: Meta{Ui: ui, View: view},
 	}
@@ -344,7 +343,7 @@ func TestStatePush_constVariable(t *testing.T) {
 		wd := tempWorkingDirFixture(t, "dynamic-module-sources/command-with-const-var")
 		t.Chdir(wd.RootModuleDir())
 
-		ui := cli.NewMockUi()
+		ui := testUiWrapped(t)
 		view, _ := testView(t)
 		c := &StatePushCommand{
 			Meta: Meta{
@@ -370,7 +369,7 @@ func TestStatePush_constVariable(t *testing.T) {
 		wd := tempWorkingDirFixture(t, "dynamic-module-sources/command-with-const-var")
 		t.Chdir(wd.RootModuleDir())
 
-		ui := cli.NewMockUi()
+		ui := testUiWrapped(t)
 		view, _ := testView(t)
 		c := &StatePushCommand{
 			Meta: Meta{
@@ -407,7 +406,7 @@ module.replaced:
 		wd := tempWorkingDirFixture(t, "dynamic-module-sources/command-with-const-var-backend")
 		t.Chdir(wd.RootModuleDir())
 
-		ui := cli.NewMockUi()
+		ui := testUiWrapped(t)
 		view, _ := testView(t)
 		c := &StatePushCommand{
 			Meta: Meta{
@@ -442,7 +441,7 @@ func TestStatePush_checkRequiredVersion(t *testing.T) {
 	t.Chdir(td)
 
 	p := testProvider()
-	ui := cli.NewMockUi()
+	ui := testUiWrapped(t)
 	view, _ := testView(t)
 	c := &StatePushCommand{
 		Meta: Meta{

--- a/internal/command/state_replace_provider_test.go
+++ b/internal/command/state_replace_provider_test.go
@@ -9,8 +9,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/hashicorp/cli"
-
 	"github.com/google/go-cmp/cmp"
 
 	"github.com/hashicorp/terraform/internal/addrs"
@@ -74,7 +72,7 @@ func TestStateReplaceProvider(t *testing.T) {
 	t.Run("happy path", func(t *testing.T) {
 		statePath := testStateFile(t, state)
 
-		ui := new(cli.MockUi)
+		ui := testUiWrapped(t)
 		view, _ := testView(t)
 		c := &StateReplaceProviderCommand{
 			StateMeta{
@@ -110,7 +108,7 @@ func TestStateReplaceProvider(t *testing.T) {
 	t.Run("auto approve", func(t *testing.T) {
 		statePath := testStateFile(t, state)
 
-		ui := new(cli.MockUi)
+		ui := testUiWrapped(t)
 		view, _ := testView(t)
 		c := &StateReplaceProviderCommand{
 			StateMeta{
@@ -146,7 +144,7 @@ func TestStateReplaceProvider(t *testing.T) {
 	t.Run("cancel at approval step", func(t *testing.T) {
 		statePath := testStateFile(t, state)
 
-		ui := new(cli.MockUi)
+		ui := testUiWrapped(t)
 		view, _ := testView(t)
 		c := &StateReplaceProviderCommand{
 			StateMeta{
@@ -181,7 +179,7 @@ func TestStateReplaceProvider(t *testing.T) {
 	t.Run("no matching provider found", func(t *testing.T) {
 		statePath := testStateFile(t, state)
 
-		ui := new(cli.MockUi)
+		ui := testUiWrapped(t)
 		view, _ := testView(t)
 		c := &StateReplaceProviderCommand{
 			StateMeta{
@@ -210,7 +208,7 @@ func TestStateReplaceProvider(t *testing.T) {
 	})
 
 	t.Run("invalid flags", func(t *testing.T) {
-		ui := new(cli.MockUi)
+		ui := testUiWrapped(t)
 		view, _ := testView(t)
 		c := &StateReplaceProviderCommand{
 			StateMeta{
@@ -236,7 +234,7 @@ func TestStateReplaceProvider(t *testing.T) {
 	})
 
 	t.Run("wrong number of arguments", func(t *testing.T) {
-		ui := new(cli.MockUi)
+		ui := testUiWrapped(t)
 		view, _ := testView(t)
 		c := &StateReplaceProviderCommand{
 			StateMeta{
@@ -258,7 +256,7 @@ func TestStateReplaceProvider(t *testing.T) {
 	})
 
 	t.Run("invalid provider strings", func(t *testing.T) {
-		ui := new(cli.MockUi)
+		ui := testUiWrapped(t)
 		view, _ := testView(t)
 		c := &StateReplaceProviderCommand{
 			StateMeta{
@@ -345,7 +343,7 @@ func TestStateReplaceProvider_stateStore(t *testing.T) {
 	)
 	mockProviderAddress := addrs.NewDefaultProvider("test")
 
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	c := &StateReplaceProviderCommand{
 		StateMeta{
 			Meta: Meta{
@@ -390,7 +388,7 @@ func TestStateReplaceProvider_constVariable(t *testing.T) {
 		wd := tempWorkingDirFixture(t, "dynamic-module-sources/command-with-const-var")
 		t.Chdir(wd.RootModuleDir())
 
-		ui := cli.NewMockUi()
+		ui := testUiWrapped(t)
 		view, _ := testView(t)
 		c := &StateReplaceProviderCommand{
 			StateMeta{
@@ -422,7 +420,7 @@ func TestStateReplaceProvider_constVariable(t *testing.T) {
 		wd := tempWorkingDirFixture(t, "dynamic-module-sources/command-with-const-var")
 		t.Chdir(wd.RootModuleDir())
 
-		ui := cli.NewMockUi()
+		ui := testUiWrapped(t)
 		view, _ := testView(t)
 		c := &StateReplaceProviderCommand{
 			StateMeta{
@@ -468,7 +466,7 @@ module.child:
 		wd := tempWorkingDirFixture(t, "dynamic-module-sources/command-with-const-var-backend")
 		t.Chdir(wd.RootModuleDir())
 
-		ui := cli.NewMockUi()
+		ui := testUiWrapped(t)
 		view, _ := testView(t)
 		c := &StateReplaceProviderCommand{
 			StateMeta{
@@ -572,7 +570,7 @@ func TestStateReplaceProvider_checkRequiredVersion(t *testing.T) {
 
 	statePath := testStateFile(t, state)
 
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	view, _ := testView(t)
 	c := &StateReplaceProviderCommand{
 		StateMeta{

--- a/internal/command/state_rm_test.go
+++ b/internal/command/state_rm_test.go
@@ -10,8 +10,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/hashicorp/cli"
-
 	"github.com/google/go-cmp/cmp"
 
 	"github.com/hashicorp/terraform/internal/addrs"
@@ -59,7 +57,7 @@ func TestStateRm(t *testing.T) {
 	statePath := testStateFile(t, state)
 
 	p := testProvider()
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	view, _ := testView(t)
 	c := &StateRmCommand{
 		StateMeta{
@@ -163,7 +161,7 @@ func TestStateRm_stateStore(t *testing.T) {
 		return providers.WriteStateBytesResponse{}
 	}
 
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	c := &StateRmCommand{
 		StateMeta{
 			Meta: Meta{
@@ -227,7 +225,7 @@ func TestStateRmNotChildModule(t *testing.T) {
 	statePath := testStateFile(t, state)
 
 	p := testProvider()
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	view, _ := testView(t)
 	c := &StateRmCommand{
 		StateMeta{
@@ -315,7 +313,7 @@ func TestStateRmNoArgs(t *testing.T) {
 	statePath := testStateFile(t, state)
 
 	p := testProvider()
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	view, _ := testView(t)
 	c := &StateRmCommand{
 		StateMeta{
@@ -376,7 +374,7 @@ func TestStateRmNonExist(t *testing.T) {
 	statePath := testStateFile(t, state)
 
 	p := testProvider()
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	view, _ := testView(t)
 	c := &StateRmCommand{
 		StateMeta{
@@ -434,7 +432,7 @@ func TestStateRm_backupExplicit(t *testing.T) {
 	backupPath := statePath + ".backup.test"
 
 	p := testProvider()
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	view, _ := testView(t)
 	c := &StateRmCommand{
 		StateMeta{
@@ -467,7 +465,7 @@ func TestStateRm_noState(t *testing.T) {
 	t.Chdir(tmp)
 
 	p := testProvider()
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	view, _ := testView(t)
 	c := &StateRmCommand{
 		StateMeta{
@@ -490,7 +488,7 @@ func TestStateRm_constVariable(t *testing.T) {
 		wd := tempWorkingDirFixture(t, "dynamic-module-sources/command-with-const-var")
 		t.Chdir(wd.RootModuleDir())
 
-		ui := cli.NewMockUi()
+		ui := testUiWrapped(t)
 		view, _ := testView(t)
 		c := &StateRmCommand{
 			StateMeta{
@@ -518,7 +516,7 @@ func TestStateRm_constVariable(t *testing.T) {
 		wd := tempWorkingDirFixture(t, "dynamic-module-sources/command-with-const-var")
 		t.Chdir(wd.RootModuleDir())
 
-		ui := cli.NewMockUi()
+		ui := testUiWrapped(t)
 		view, _ := testView(t)
 		c := &StateRmCommand{
 			StateMeta{
@@ -553,7 +551,7 @@ func TestStateRm_constVariable(t *testing.T) {
 		wd := tempWorkingDirFixture(t, "dynamic-module-sources/command-with-const-var-backend")
 		t.Chdir(wd.RootModuleDir())
 
-		ui := cli.NewMockUi()
+		ui := testUiWrapped(t)
 		view, _ := testView(t)
 		c := &StateRmCommand{
 			StateMeta{
@@ -585,7 +583,7 @@ func TestStateRm_needsInit(t *testing.T) {
 	t.Chdir(td)
 
 	p := testProvider()
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	view, _ := testView(t)
 	c := &StateRmCommand{
 		StateMeta{
@@ -660,7 +658,7 @@ func TestStateRm_backendState(t *testing.T) {
 	}
 
 	p := testProvider()
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	view, _ := testView(t)
 	c := &StateRmCommand{
 		StateMeta{
@@ -728,7 +726,7 @@ func TestStateRm_checkRequiredVersion(t *testing.T) {
 	statePath := testStateFile(t, state)
 
 	p := testProvider()
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	view, _ := testView(t)
 	c := &StateRmCommand{
 		StateMeta{

--- a/internal/command/state_show_test.go
+++ b/internal/command/state_show_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/hashicorp/cli"
 	"github.com/zclconf/go-cty/cty"
 
 	"github.com/hashicorp/terraform/internal/addrs"
@@ -382,7 +381,7 @@ func TestStateShow_stateStore(t *testing.T) {
 	)
 	mockProviderAddress := addrs.NewDefaultProvider("test")
 
-	ui := cli.NewMockUi()
+	ui := testUiWrapped(t)
 	view, done := testView(t)
 	c := &StateShowCommand{
 		Meta: Meta{

--- a/internal/command/taint_test.go
+++ b/internal/command/taint_test.go
@@ -477,7 +477,7 @@ func TestTaint_missingAllow(t *testing.T) {
 	}
 
 	// Check for the warning
-	actual := strings.TrimSpace(ui.ErrorWriter.String())
+	actual := strings.TrimSpace(ui.OutputWriter.String())
 	expected := strings.TrimSpace(`
 Warning: No such resource instance
 

--- a/internal/command/taint_test.go
+++ b/internal/command/taint_test.go
@@ -8,8 +8,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/hashicorp/cli"
-
 	"github.com/google/go-cmp/cmp"
 
 	"github.com/hashicorp/terraform/internal/addrs"
@@ -38,7 +36,7 @@ func TestTaint(t *testing.T) {
 	})
 	statePath := testStateFile(t, state)
 
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	view, _ := testView(t)
 	c := &TaintCommand{
 		Meta: Meta{
@@ -83,7 +81,7 @@ func TestTaint_lockedState(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer unlock()
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	view, _ := testView(t)
 	c := &TaintCommand{
 		Meta: Meta{
@@ -131,7 +129,7 @@ func TestTaint_backup(t *testing.T) {
 	})
 	testStateFileDefault(t, state)
 
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	view, _ := testView(t)
 	c := &TaintCommand{
 		Meta: Meta{
@@ -176,7 +174,7 @@ func TestTaint_backupDisable(t *testing.T) {
 	})
 	testStateFileDefault(t, state)
 
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	view, _ := testView(t)
 	c := &TaintCommand{
 		Meta: Meta{
@@ -201,7 +199,7 @@ func TestTaint_backupDisable(t *testing.T) {
 }
 
 func TestTaint_badState(t *testing.T) {
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	view, _ := testView(t)
 	c := &TaintCommand{
 		Meta: Meta{
@@ -244,7 +242,7 @@ func TestTaint_defaultState(t *testing.T) {
 	})
 	testStateFileDefault(t, state)
 
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	view, _ := testView(t)
 	c := &TaintCommand{
 		Meta: Meta{
@@ -268,7 +266,7 @@ func TestTaint_constVariable(t *testing.T) {
 		wd := tempWorkingDirFixture(t, "dynamic-module-sources/command-with-const-var")
 		t.Chdir(wd.RootModuleDir())
 
-		ui := cli.NewMockUi()
+		ui := testUiWrapped(t)
 		view, _ := testView(t)
 		c := &TaintCommand{
 			Meta: Meta{
@@ -294,7 +292,7 @@ func TestTaint_constVariable(t *testing.T) {
 		wd := tempWorkingDirFixture(t, "dynamic-module-sources/command-with-const-var")
 		t.Chdir(wd.RootModuleDir())
 
-		ui := cli.NewMockUi()
+		ui := testUiWrapped(t)
 		view, _ := testView(t)
 		c := &TaintCommand{
 			Meta: Meta{
@@ -331,7 +329,7 @@ module.child:
 		wd := tempWorkingDirFixture(t, "dynamic-module-sources/command-with-const-var-backend")
 		t.Chdir(wd.RootModuleDir())
 
-		ui := cli.NewMockUi()
+		ui := testUiWrapped(t)
 		view, _ := testView(t)
 		c := &TaintCommand{
 			Meta: Meta{
@@ -384,7 +382,7 @@ func TestTaint_defaultWorkspaceState(t *testing.T) {
 	testWorkspace := "development"
 	path := testStateFileWorkspaceDefault(t, testWorkspace, state)
 
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	view, _ := testView(t)
 	meta := Meta{Ui: ui, View: view}
 	meta.SetWorkspace(testWorkspace)
@@ -422,7 +420,7 @@ func TestTaint_missing(t *testing.T) {
 	})
 	statePath := testStateFile(t, state)
 
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	view, _ := testView(t)
 	c := &TaintCommand{
 		Meta: Meta{
@@ -460,7 +458,7 @@ func TestTaint_missingAllow(t *testing.T) {
 	})
 	statePath := testStateFile(t, state)
 
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	view, _ := testView(t)
 	c := &TaintCommand{
 		Meta: Meta{
@@ -517,7 +515,7 @@ func TestTaint_stateOut(t *testing.T) {
 	})
 	testStateFileDefault(t, state)
 
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	view, _ := testView(t)
 	c := &TaintCommand{
 		Meta: Meta{
@@ -573,7 +571,7 @@ func TestTaint_module(t *testing.T) {
 	})
 	statePath := testStateFile(t, state)
 
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	view, _ := testView(t)
 	c := &TaintCommand{
 		Meta: Meta{
@@ -619,7 +617,7 @@ func TestTaint_checkRequiredVersion(t *testing.T) {
 	})
 	path := testStateFile(t, state)
 
-	ui := cli.NewMockUi()
+	ui := testUiWrapped(t)
 	view, _ := testView(t)
 	c := &TaintCommand{
 		Meta: Meta{

--- a/internal/command/test_test.go
+++ b/internal/command/test_test.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/cli"
 	"github.com/zclconf/go-cty/cty"
 
 	"github.com/hashicorp/terraform/internal/addrs"
@@ -495,7 +494,7 @@ func TestTest_Runs(t *testing.T) {
 
 			streams, done := terminal.StreamsForTesting(t)
 			view := views.NewView(streams)
-			ui := new(cli.MockUi)
+			ui := testUiWrapped(t)
 
 			meta := Meta{
 				testingOverrides: &testingOverrides{
@@ -996,7 +995,7 @@ func TestTest_CleanupActuallyCleansUp(t *testing.T) {
 
 	streams, done := terminal.StreamsForTesting(t)
 	view := views.NewView(streams)
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 
 	meta := Meta{
 		testingOverrides:          metaOverridesForProvider(provider.Provider),
@@ -1084,7 +1083,7 @@ func TestTest_SkipCleanup_ConsecutiveTestsFail(t *testing.T) {
 
 	streams, done := terminal.StreamsForTesting(t)
 	view := views.NewView(streams)
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 
 	meta := Meta{
 		testingOverrides:          metaOverridesForProvider(provider.Provider),
@@ -1163,7 +1162,7 @@ func TestTest_SharedState_Order(t *testing.T) {
 
 	streams, done := terminal.StreamsForTesting(t)
 	view := views.NewView(streams)
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 
 	meta := Meta{
 		testingOverrides: metaOverridesForProvider(provider.Provider),
@@ -1234,7 +1233,7 @@ func TestTest_Parallel_Divided_Order(t *testing.T) {
 
 	streams, done := terminal.StreamsForTesting(t)
 	view := views.NewView(streams)
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 
 	meta := Meta{
 		testingOverrides: metaOverridesForProvider(provider.Provider),
@@ -1310,7 +1309,7 @@ func TestTest_Parallel(t *testing.T) {
 
 	streams, done := terminal.StreamsForTesting(t)
 	view := views.NewView(streams)
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 
 	meta := Meta{
 		testingOverrides: metaOverridesForProvider(provider.Provider),
@@ -1672,7 +1671,7 @@ func TestTest_ParallelTeardown(t *testing.T) {
 
 			streams, done := terminal.StreamsForTesting(t)
 			view := views.NewView(streams)
-			ui := new(cli.MockUi)
+			ui := testUiWrapped(t)
 
 			// create a new provider instance for each test run, so that we can
 			// ensure that the test provider locks do not interfere between runs.
@@ -1841,7 +1840,7 @@ func TestTest_ProviderAlias(t *testing.T) {
 
 	streams, done := terminal.StreamsForTesting(t)
 	view := views.NewView(streams)
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 
 	meta := Meta{
 		testingOverrides: &testingOverrides{
@@ -1906,7 +1905,7 @@ func TestTest_ComplexCondition(t *testing.T) {
 
 	streams, done := terminal.StreamsForTesting(t)
 	view := views.NewView(streams)
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 
 	meta := Meta{
 		testingOverrides: metaOverridesForProvider(provider.Provider),
@@ -2075,7 +2074,7 @@ func TestTest_ComplexConditionVerbose(t *testing.T) {
 
 	streams, done := terminal.StreamsForTesting(t)
 	view := views.NewView(streams)
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 
 	meta := Meta{
 		testingOverrides: metaOverridesForProvider(provider.Provider),
@@ -2411,7 +2410,7 @@ func TestTest_ModuleDependencies(t *testing.T) {
 
 	streams, done := terminal.StreamsForTesting(t)
 	view := views.NewView(streams)
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 
 	meta := Meta{
 		testingOverrides: &testingOverrides{
@@ -2486,7 +2485,7 @@ func TestTest_DynamicSourceWithVarFlag(t *testing.T) {
 
 	streams, done := terminal.StreamsForTesting(t)
 	view := views.NewView(streams)
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 
 	meta := Meta{
 		testingOverrides: &testingOverrides{
@@ -2544,7 +2543,7 @@ func TestTest_DynamicSourceWithLocalValue(t *testing.T) {
 
 	streams, done := terminal.StreamsForTesting(t)
 	view := views.NewView(streams)
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 
 	meta := Meta{
 		testingOverrides: &testingOverrides{
@@ -2602,7 +2601,7 @@ func TestTest_DynamicSourceNested(t *testing.T) {
 
 	streams, done := terminal.StreamsForTesting(t)
 	view := views.NewView(streams)
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 
 	meta := Meta{
 		testingOverrides: &testingOverrides{
@@ -2675,7 +2674,7 @@ func TestTest_DynamicSourceWithSetupModule(t *testing.T) {
 
 	streams, done := terminal.StreamsForTesting(t)
 	view := views.NewView(streams)
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 
 	meta := Meta{
 		testingOverrides: &testingOverrides{
@@ -2989,7 +2988,7 @@ can remove the provider configuration again.
 
 			streams, done := terminal.StreamsForTesting(t)
 			view := views.NewView(streams)
-			ui := new(cli.MockUi)
+			ui := testUiWrapped(t)
 
 			meta := Meta{
 				testingOverrides: metaOverridesForProvider(provider.Provider),
@@ -3055,7 +3054,7 @@ func TestTest_NestedSetupModules(t *testing.T) {
 
 	streams, done := terminal.StreamsForTesting(t)
 	view := views.NewView(streams)
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 
 	meta := Meta{
 		testingOverrides: metaOverridesForProvider(provider.Provider),
@@ -3109,7 +3108,7 @@ func TestTest_StatePropagation(t *testing.T) {
 
 	streams, done := terminal.StreamsForTesting(t)
 	view := views.NewView(streams)
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 
 	meta := Meta{
 		testingOverrides: metaOverridesForProvider(provider.Provider),
@@ -3246,7 +3245,7 @@ func TestTest_SkipCleanup(t *testing.T) {
 
 	streams, done := terminal.StreamsForTesting(t)
 	view := views.NewView(streams)
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 
 	meta := Meta{
 		testingOverrides:          metaOverridesForProvider(provider.Provider),
@@ -3350,7 +3349,7 @@ func TestTest_SkipCleanupWithRunDependencies(t *testing.T) {
 
 	streams, done := terminal.StreamsForTesting(t)
 	view := views.NewView(streams)
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 
 	meta := Meta{
 		testingOverrides:          metaOverridesForProvider(provider.Provider),
@@ -3483,7 +3482,7 @@ func TestTest_SkipCleanup_JSON(t *testing.T) {
 
 	streams, done := terminal.StreamsForTesting(t)
 	view := views.NewView(streams)
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 
 	meta := Meta{
 		testingOverrides:          metaOverridesForProvider(provider.Provider),
@@ -3614,7 +3613,7 @@ func TestTest_SkipCleanup_FileLevelFlag(t *testing.T) {
 
 	streams, done := terminal.StreamsForTesting(t)
 	view := views.NewView(streams)
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 
 	meta := Meta{
 		testingOverrides:          metaOverridesForProvider(provider.Provider),
@@ -3745,7 +3744,7 @@ func TestTest_OnlyExternalModules(t *testing.T) {
 
 	streams, done := terminal.StreamsForTesting(t)
 	view := views.NewView(streams)
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 
 	meta := Meta{
 		testingOverrides: metaOverridesForProvider(provider.Provider),
@@ -3879,7 +3878,7 @@ func TestTest_InvalidWarningsInCleanup(t *testing.T) {
 
 	streams, done := terminal.StreamsForTesting(t)
 	view := views.NewView(streams)
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 
 	meta := Meta{
 		testingOverrides: metaOverridesForProvider(provider.Provider),
@@ -4741,7 +4740,7 @@ func TestTest_InvalidOverrides(t *testing.T) {
 
 	streams, done := terminal.StreamsForTesting(t)
 	view := views.NewView(streams)
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 
 	meta := Meta{
 		testingOverrides: metaOverridesForProvider(provider.Provider),
@@ -4840,7 +4839,7 @@ func TestTest_InvalidConfig(t *testing.T) {
 
 	streams, done := terminal.StreamsForTesting(t)
 	view := views.NewView(streams)
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 
 	meta := Meta{
 		Ui:             ui,
@@ -4983,7 +4982,7 @@ There is no backend type named "foobar".
 
 			streams, done := terminal.StreamsForTesting(t)
 			view := views.NewView(streams)
-			ui := new(cli.MockUi)
+			ui := testUiWrapped(t)
 
 			meta := Meta{
 				testingOverrides:          metaOverridesForProvider(provider.Provider),
@@ -5062,7 +5061,7 @@ test_resource_id = 12345`
 
 	streams, done := terminal.StreamsForTesting(t)
 	view := views.NewView(streams)
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 
 	meta := Meta{
 		testingOverrides:          metaOverridesForProvider(provider.Provider),
@@ -5169,7 +5168,7 @@ test_resource_id = %s`, resourceId, resourceId)
 
 	streams, done := terminal.StreamsForTesting(t)
 	view := views.NewView(streams)
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 
 	meta := Meta{
 		testingOverrides:          metaOverridesForProvider(provider.Provider),
@@ -5288,7 +5287,7 @@ func TestTest_UseOfBackends_whenStateArtifactsAreMade(t *testing.T) {
 
 			streams, done := terminal.StreamsForTesting(t)
 			view := views.NewView(streams)
-			ui := new(cli.MockUi)
+			ui := testUiWrapped(t)
 
 			meta := Meta{
 				testingOverrides:          metaOverridesForProvider(provider.Provider),
@@ -5387,7 +5386,7 @@ func TestTest_UseOfBackends_validatesUseOfSkipCleanup(t *testing.T) {
 
 			streams, done := terminal.StreamsForTesting(t)
 			view := views.NewView(streams)
-			ui := new(cli.MockUi)
+			ui := testUiWrapped(t)
 
 			meta := Meta{
 				testingOverrides:          metaOverridesForProvider(provider.Provider),
@@ -5447,7 +5446,7 @@ func TestTest_UseOfBackends_failureDuringApply(t *testing.T) {
 
 	streams, done := terminal.StreamsForTesting(t)
 	view := views.NewView(streams)
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 
 	meta := Meta{
 		testingOverrides:          metaOverridesForProvider(provider.Provider),
@@ -5529,7 +5528,7 @@ func TestTest_RunBlocksInProviders(t *testing.T) {
 
 	streams, done := terminal.StreamsForTesting(t)
 	view := views.NewView(streams)
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 
 	meta := Meta{
 		testingOverrides: metaOverridesForProvider(provider.Provider),
@@ -5597,7 +5596,7 @@ func TestTest_RunBlocksInProviders_BadReferences(t *testing.T) {
 
 	streams, done := terminal.StreamsForTesting(t)
 	view := views.NewView(streams)
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 
 	meta := Meta{
 		testingOverrides: &testingOverrides{
@@ -5762,7 +5761,7 @@ func TestTest_ReferencesIntoIncompletePlan(t *testing.T) {
 
 	streams, done := terminal.StreamsForTesting(t)
 	view := views.NewView(streams)
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 
 	meta := Meta{
 		testingOverrides: metaOverridesForProvider(provider.Provider),
@@ -5831,7 +5830,7 @@ func TestTest_ReferencesIntoTargetedPlan(t *testing.T) {
 
 	streams, done := terminal.StreamsForTesting(t)
 	view := views.NewView(streams)
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 
 	meta := Meta{
 		testingOverrides: metaOverridesForProvider(provider.Provider),
@@ -5885,7 +5884,7 @@ func TestTest_TeardownOrder(t *testing.T) {
 
 	streams, done := terminal.StreamsForTesting(t)
 	view := views.NewView(streams)
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 
 	meta := Meta{
 		testingOverrides: metaOverridesForProvider(provider.Provider),

--- a/internal/command/ui/ui_wrap.go
+++ b/internal/command/ui/ui_wrap.go
@@ -1,0 +1,22 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package ui
+
+import "github.com/hashicorp/cli"
+
+// WrappedUi wraps the primary output cli.Ui, and redirects Warn calls to Output
+// calls. This ensures that warnings are sent to stdout, and are properly
+// serialized within the stdout stream.
+//
+// This behaviour matches the behaviour of the new views package,
+// which also sends warnings to stdout.
+//
+// For more context, see: https://github.com/hashicorp/terraform/pull/27057
+type WrappedUi struct {
+	cli.Ui
+}
+
+func (u *WrappedUi) Warn(msg string) {
+	u.Ui.Output(msg)
+}

--- a/internal/command/ui/ui_wrap.go
+++ b/internal/command/ui/ui_wrap.go
@@ -20,3 +20,14 @@ type WrappedUi struct {
 func (u *WrappedUi) Warn(msg string) {
 	u.Ui.Output(msg)
 }
+
+// WrappedMockUi is specifically for use in tests. By wrapping a MockUi, instead of an interface,
+// calling code in tests are still able to access MockUi exported fields. This enables access to fields
+// such as OutputWriter and ErrorWriter for making assertions about command output.
+type WrappedMockUi struct {
+	*cli.MockUi
+}
+
+func (u *WrappedMockUi) Warn(msg string) {
+	u.MockUi.Output(msg)
+}

--- a/internal/command/unlock_test.go
+++ b/internal/command/unlock_test.go
@@ -35,7 +35,7 @@ func TestUnlock(t *testing.T) {
 	}
 
 	p := testProvider()
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	view, _ := testView(t)
 	c := &UnlockCommand{
 		Meta: Meta{
@@ -74,7 +74,7 @@ func TestUnlock_inmemBackend(t *testing.T) {
 	defer inmem.Reset()
 
 	// init backend
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	view, _ := testView(t)
 	ci := &InitCommand{
 		Meta: Meta{
@@ -86,7 +86,7 @@ func TestUnlock_inmemBackend(t *testing.T) {
 		t.Fatalf("bad: %d\n%s", code, ui.ErrorWriter)
 	}
 
-	ui = new(cli.MockUi)
+	ui = testUiWrapped(t)
 	c := &UnlockCommand{
 		Meta: Meta{
 			Ui:   ui,
@@ -104,7 +104,7 @@ func TestUnlock_inmemBackend(t *testing.T) {
 		t.Fatalf("bad: %d\n%s\n%s", code, ui.OutputWriter.String(), ui.ErrorWriter.String())
 	}
 
-	ui = new(cli.MockUi)
+	ui = testUiWrapped(t)
 	c = &UnlockCommand{
 		Meta: Meta{
 			Ui:   ui,

--- a/internal/command/untaint_test.go
+++ b/internal/command/untaint_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/hashicorp/cli"
 	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/states"
 )
@@ -34,7 +33,7 @@ func TestUntaint(t *testing.T) {
 	})
 	statePath := testStateFile(t, state)
 
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	view, _ := testView(t)
 	c := &UntaintCommand{
 		Meta: Meta{
@@ -84,7 +83,7 @@ func TestUntaint_lockedState(t *testing.T) {
 	}
 	defer unlock()
 
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	view, _ := testView(t)
 	c := &UntaintCommand{
 		Meta: Meta{
@@ -132,7 +131,7 @@ func TestUntaint_backup(t *testing.T) {
 	})
 	testStateFileDefault(t, state)
 
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	view, _ := testView(t)
 	c := &UntaintCommand{
 		Meta: Meta{
@@ -188,7 +187,7 @@ func TestUntaint_backupDisable(t *testing.T) {
 	})
 	testStateFileDefault(t, state)
 
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	view, _ := testView(t)
 	c := &UntaintCommand{
 		Meta: Meta{
@@ -217,7 +216,7 @@ test_instance.foo:
 }
 
 func TestUntaint_badState(t *testing.T) {
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	view, _ := testView(t)
 	c := &UntaintCommand{
 		Meta: Meta{
@@ -260,7 +259,7 @@ func TestUntaint_defaultState(t *testing.T) {
 	})
 	testStateFileDefault(t, state)
 
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	view, _ := testView(t)
 	c := &UntaintCommand{
 		Meta: Meta{
@@ -309,7 +308,7 @@ func TestUntaint_defaultWorkspaceState(t *testing.T) {
 	testWorkspace := "development"
 	path := testStateFileWorkspaceDefault(t, testWorkspace, state)
 
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	view, _ := testView(t)
 	meta := Meta{Ui: ui, View: view}
 	meta.SetWorkspace(testWorkspace)
@@ -351,7 +350,7 @@ func TestUntaint_missing(t *testing.T) {
 	})
 	statePath := testStateFile(t, state)
 
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	view, _ := testView(t)
 	c := &UntaintCommand{
 		Meta: Meta{
@@ -389,7 +388,7 @@ func TestUntaint_missingAllow(t *testing.T) {
 	})
 	statePath := testStateFile(t, state)
 
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	view, _ := testView(t)
 	c := &UntaintCommand{
 		Meta: Meta{
@@ -446,7 +445,7 @@ func TestUntaint_stateOut(t *testing.T) {
 	})
 	testStateFileDefault(t, state)
 
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	view, _ := testView(t)
 	c := &UntaintCommand{
 		Meta: Meta{
@@ -510,7 +509,7 @@ func TestUntaint_module(t *testing.T) {
 	})
 	statePath := testStateFile(t, state)
 
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	view, _ := testView(t)
 	c := &UntaintCommand{
 		Meta: Meta{

--- a/internal/command/untaint_test.go
+++ b/internal/command/untaint_test.go
@@ -407,7 +407,7 @@ func TestUntaint_missingAllow(t *testing.T) {
 	}
 
 	// Check for the warning
-	actual := strings.TrimSpace(ui.ErrorWriter.String())
+	actual := strings.TrimSpace(ui.OutputWriter.String())
 	expected := strings.TrimSpace(`
 Warning: No such resource instance
 

--- a/internal/command/validate_test.go
+++ b/internal/command/validate_test.go
@@ -12,7 +12,6 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/hashicorp/cli"
 	"github.com/zclconf/go-cty/cty"
 
 	"github.com/hashicorp/terraform/internal/backend"
@@ -260,7 +259,7 @@ func TestValidateWithInvalidTestModule(t *testing.T) {
 
 	streams, done := terminal.StreamsForTesting(t)
 	view := views.NewView(streams)
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 
 	provider := testing_command.NewProvider(nil)
 
@@ -446,7 +445,7 @@ func TestValidateWithInvalidOverrides(t *testing.T) {
 
 	streams, done := terminal.StreamsForTesting(t)
 	view := views.NewView(streams)
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 
 	provider := testing_command.NewProvider(nil)
 
@@ -650,7 +649,7 @@ The first step in the traversal for a list resource must be an attribute
 
 			streams, done := terminal.StreamsForTesting(t)
 			view := views.NewView(streams)
-			ui := new(cli.MockUi)
+			ui := testUiWrapped(t)
 
 			provider := queryFixtureProvider()
 			providerSource := newMockProviderSource(t, map[string][]string{

--- a/internal/command/version_test.go
+++ b/internal/command/version_test.go
@@ -39,7 +39,7 @@ func TestVersion(t *testing.T) {
 		nil,
 	)
 
-	ui := cli.NewMockUi()
+	ui := testUiWrapped(t)
 	c := &VersionCommand{
 		Meta: Meta{
 			Ui: ui,
@@ -66,7 +66,7 @@ func TestVersion(t *testing.T) {
 // This is because whenever a user runs `terraform <any command name> -version`, etc, main.go
 // will call the version command with all of the supplied flags and arguments.
 func TestVersion_flags(t *testing.T) {
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	m := Meta{
 		Ui: ui,
 	}
@@ -92,7 +92,7 @@ func TestVersion_flags(t *testing.T) {
 
 func TestVersion_unexpectedArgsOrFlags(t *testing.T) {
 	t.Run("unexpected positional arguments are ignored without error", func(t *testing.T) {
-		ui := new(cli.MockUi)
+		ui := testUiWrapped(t)
 		m := Meta{
 			Ui: ui,
 		}
@@ -127,7 +127,7 @@ func TestVersion_unexpectedArgsOrFlags(t *testing.T) {
 		}
 
 		// Machine-readable / JSON output
-		ui = new(cli.MockUi)
+		ui = testUiWrapped(t)
 		c.Meta = Meta{
 			Ui: ui,
 		}
@@ -161,7 +161,7 @@ func TestVersion_unexpectedArgsOrFlags(t *testing.T) {
 	})
 
 	t.Run("incorrect flag", func(t *testing.T) {
-		ui := new(cli.MockUi)
+		ui := testUiWrapped(t)
 		m := Meta{
 			Ui: ui,
 		}
@@ -202,7 +202,7 @@ Error parsing command-line flags: flag provided but not defined: -foobar`
 		}
 
 		// Machine-readable / JSON output
-		ui = new(cli.MockUi)
+		ui = testUiWrapped(t)
 		c.Meta = Meta{
 			Ui: ui,
 		}
@@ -237,7 +237,7 @@ Error parsing command-line flags: flag provided but not defined: -foobar`
 }
 
 func TestVersion_outdated(t *testing.T) {
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	m := Meta{
 		Ui: ui,
 	}
@@ -264,7 +264,7 @@ func TestVersion_json(t *testing.T) {
 	td := t.TempDir()
 	t.Chdir(td)
 
-	ui := cli.NewMockUi()
+	ui := testUiWrapped(t)
 	meta := Meta{
 		Ui: ui,
 	}
@@ -344,7 +344,7 @@ func TestVersion_json(t *testing.T) {
 }
 
 func TestVersion_jsonoutdated(t *testing.T) {
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	m := Meta{
 		Ui: ui,
 	}

--- a/internal/command/workspace_command_test.go
+++ b/internal/command/workspace_command_test.go
@@ -53,7 +53,7 @@ func TestWorkspace_allCommands_pluggableStateStore(t *testing.T) {
 		"hashicorp/test": {"1.2.3"},
 	})
 
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	view, _ := testView(t)
 	meta := Meta{
 		AllowExperimentalFeatures: true,
@@ -88,7 +88,7 @@ func TestWorkspace_allCommands_pluggableStateStore(t *testing.T) {
 
 	//// Create Workspace
 	newWorkspace := "foobar"
-	ui = new(cli.MockUi)
+	ui = testUiWrapped(t)
 	meta.Ui = ui
 	newCmd := &WorkspaceNewCommand{
 		Meta: meta,
@@ -125,7 +125,7 @@ func TestWorkspace_allCommands_pluggableStateStore(t *testing.T) {
 	}
 
 	//// List Workspaces
-	ui = new(cli.MockUi)
+	ui = testUiWrapped(t)
 	meta.Ui = ui
 	meta.WorkingDir = workdir.NewDir(".")
 	listCmd := &WorkspaceListCommand{
@@ -141,7 +141,7 @@ func TestWorkspace_allCommands_pluggableStateStore(t *testing.T) {
 	}
 
 	//// Select Workspace
-	ui = new(cli.MockUi)
+	ui = testUiWrapped(t)
 	meta.Ui = ui
 	selCmd := &WorkspaceSelectCommand{
 		Meta: meta,
@@ -158,7 +158,7 @@ func TestWorkspace_allCommands_pluggableStateStore(t *testing.T) {
 	}
 
 	//// Show Workspace
-	ui = new(cli.MockUi)
+	ui = testUiWrapped(t)
 	meta.Ui = ui
 	showCmd := &WorkspaceShowCommand{
 		Meta: meta,
@@ -179,7 +179,7 @@ func TestWorkspace_allCommands_pluggableStateStore(t *testing.T) {
 	}
 
 	//// Delete Workspace
-	ui = new(cli.MockUi)
+	ui = testUiWrapped(t)
 	meta.Ui = ui
 	deleteCmd := &WorkspaceDeleteCommand{
 		Meta: meta,
@@ -228,7 +228,7 @@ func TestWorkspace_list_noReturnedWorkspaces(t *testing.T) {
 		"hashicorp/test": {"1.2.3"},
 	})
 
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	view, _ := testView(t)
 	meta := Meta{
 		AllowExperimentalFeatures: true,
@@ -295,7 +295,7 @@ func TestWorkspace_createAndChange(t *testing.T) {
 	}
 
 	args := []string{"test"}
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	view, _ := testView(t)
 	newCmd.Meta = Meta{
 		Ui:         ui,
@@ -313,7 +313,7 @@ func TestWorkspace_createAndChange(t *testing.T) {
 
 	selCmd := &WorkspaceSelectCommand{}
 	args = []string{backend.DefaultStateName}
-	ui = new(cli.MockUi)
+	ui = testUiWrapped(t)
 	selCmd.Meta = Meta{
 		Ui:         ui,
 		View:       view,
@@ -343,7 +343,7 @@ func TestWorkspace_cannotCreateOrSelectEmptyStringWorkspace(t *testing.T) {
 	}
 
 	args := []string{""}
-	ui := cli.NewMockUi()
+	ui := testUiWrapped(t)
 	view, _ := testView(t)
 	newCmd.Meta = Meta{
 		Ui:         ui,
@@ -359,7 +359,7 @@ func TestWorkspace_cannotCreateOrSelectEmptyStringWorkspace(t *testing.T) {
 		t.Errorf("missing expected error message\nwant substring: %s\ngot:\n%s", want, got)
 	}
 
-	ui = cli.NewMockUi()
+	ui = testUiWrapped(t)
 	selectCmd := &WorkspaceSelectCommand{
 		Meta: Meta{
 			Ui:         ui,
@@ -399,7 +399,7 @@ func TestWorkspace_createAndList(t *testing.T) {
 
 	// create multiple workspaces
 	for _, env := range envs {
-		ui := new(cli.MockUi)
+		ui := testUiWrapped(t)
 		newCmd := &WorkspaceNewCommand{
 			Meta: Meta{
 				Ui:         ui,
@@ -412,7 +412,7 @@ func TestWorkspace_createAndList(t *testing.T) {
 	}
 
 	listCmd := &WorkspaceListCommand{}
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	listCmd.Meta = Meta{
 		Ui:         ui,
 		WorkingDir: workdir.NewDir("."),
@@ -449,7 +449,7 @@ func TestWorkspace_createAndShow(t *testing.T) {
 
 	// make sure current workspace show outputs "default"
 	showCmd := &WorkspaceShowCommand{}
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	view, _ := testView(t)
 	showCmd.Meta = Meta{
 		Ui:         ui,
@@ -473,7 +473,7 @@ func TestWorkspace_createAndShow(t *testing.T) {
 	env := []string{"test_a"}
 
 	// create test_a workspace
-	ui = new(cli.MockUi)
+	ui = testUiWrapped(t)
 	newCmd.Meta = Meta{
 		Ui:         ui,
 		View:       view,
@@ -485,7 +485,7 @@ func TestWorkspace_createAndShow(t *testing.T) {
 	}
 
 	selCmd := &WorkspaceSelectCommand{}
-	ui = new(cli.MockUi)
+	ui = testUiWrapped(t)
 	selCmd.Meta = Meta{
 		Ui:         ui,
 		View:       view,
@@ -496,7 +496,7 @@ func TestWorkspace_createAndShow(t *testing.T) {
 	}
 
 	showCmd = &WorkspaceShowCommand{}
-	ui = new(cli.MockUi)
+	ui = testUiWrapped(t)
 	showCmd.Meta = Meta{Ui: ui, View: view}
 
 	if code := showCmd.Run(nil); code != 0 {
@@ -522,7 +522,7 @@ func TestWorkspace_createInvalid(t *testing.T) {
 
 	// create multiple workspaces
 	for _, env := range envs {
-		ui := new(cli.MockUi)
+		ui := testUiWrapped(t)
 		view, _ := testView(t)
 		newCmd := &WorkspaceNewCommand{
 			Meta: Meta{
@@ -538,7 +538,7 @@ func TestWorkspace_createInvalid(t *testing.T) {
 
 	// list workspaces to make sure none were created
 	listCmd := &WorkspaceListCommand{}
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	listCmd.Meta = Meta{
 		Ui:         ui,
 		WorkingDir: workdir.NewDir("."),
@@ -563,7 +563,7 @@ func TestWorkspace_createWithState(t *testing.T) {
 	defer inmem.Reset()
 
 	// init the backend
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	view, _ := testView(t)
 	initCmd := &InitCommand{
 		Meta: Meta{
@@ -602,7 +602,7 @@ func TestWorkspace_createWithState(t *testing.T) {
 	workspace := "test_workspace"
 
 	args := []string{"-state", "test.tfstate", workspace}
-	ui = new(cli.MockUi)
+	ui = testUiWrapped(t)
 	newCmd := &WorkspaceNewCommand{
 		Meta: Meta{
 			Ui:         ui,
@@ -652,7 +652,7 @@ func TestWorkspace_delete(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	view, _ := testView(t)
 	delCmd := &WorkspaceDeleteCommand{
 		Meta: Meta{
@@ -679,7 +679,7 @@ func TestWorkspace_delete(t *testing.T) {
 	}
 
 	// try the delete again
-	ui = new(cli.MockUi)
+	ui = testUiWrapped(t)
 	delCmd.Meta.Ui = ui
 	if code := delCmd.Run(args); code != 0 {
 		t.Fatalf("error deleting workspace: %s", ui.ErrorWriter)
@@ -707,7 +707,7 @@ func TestWorkspace_deleteInvalid(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	view, _ := testView(t)
 	delCmd := &WorkspaceDeleteCommand{
 		Meta: Meta{
@@ -743,7 +743,7 @@ func TestWorkspace_deleteRejectsEmptyString(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	ui := cli.NewMockUi()
+	ui := testUiWrapped(t)
 	view, _ := testView(t)
 	delCmd := &WorkspaceDeleteCommand{
 		Meta: Meta{
@@ -808,7 +808,7 @@ func TestWorkspace_deleteWithState(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	ui := cli.NewMockUi()
+	ui := testUiWrapped(t)
 	view, _ := testView(t)
 	delCmd := &WorkspaceDeleteCommand{
 		Meta: Meta{
@@ -829,7 +829,7 @@ func TestWorkspace_deleteWithState(t *testing.T) {
 		t.Errorf("error message doesn't mention the remaining instance\nwant substring: %s\ngot:\n%s", want, got)
 	}
 
-	ui = new(cli.MockUi)
+	ui = testUiWrapped(t)
 	delCmd.Meta.Ui = ui
 
 	args = []string{"-force", "test"}
@@ -871,7 +871,7 @@ func TestWorkspace_cannotDeleteDefaultWorkspace(t *testing.T) {
 	// Select the non-default "test" workspace
 	selectCmd := &WorkspaceSelectCommand{}
 	args := []string{"test"}
-	ui := cli.NewMockUi()
+	ui := testUiWrapped(t)
 	view, _ := testView(t)
 	selectCmd.Meta = Meta{
 		Ui:         ui,
@@ -884,7 +884,7 @@ func TestWorkspace_cannotDeleteDefaultWorkspace(t *testing.T) {
 
 	// Assert there is a default and "test" workspace, and "test" is selected
 	listCmd := &WorkspaceListCommand{}
-	ui = cli.NewMockUi()
+	ui = testUiWrapped(t)
 	listCmd.Meta = Meta{
 		Ui:         ui,
 		WorkingDir: workdir.NewDir("."),
@@ -902,7 +902,7 @@ func TestWorkspace_cannotDeleteDefaultWorkspace(t *testing.T) {
 	}
 
 	// Attempt to delete the default workspace (not forced)
-	ui = cli.NewMockUi()
+	ui = testUiWrapped(t)
 	delCmd := &WorkspaceDeleteCommand{
 		Meta: Meta{
 			Ui:         ui,
@@ -924,7 +924,7 @@ func TestWorkspace_cannotDeleteDefaultWorkspace(t *testing.T) {
 	}
 
 	// Attempt to force delete the default workspace
-	ui = cli.NewMockUi()
+	ui = testUiWrapped(t)
 	delCmd = &WorkspaceDeleteCommand{
 		Meta: Meta{
 			Ui:         ui,
@@ -958,7 +958,7 @@ func TestWorkspace_selectWithOrCreate(t *testing.T) {
 	}
 
 	args := []string{"-or-create", "test"}
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	view, _ := testView(t)
 	selectCmd.Meta = Meta{
 		Ui:         ui,
@@ -1001,7 +1001,7 @@ func TestWorkspace_envCommandDeprecationWarnings(t *testing.T) {
 	}
 
 	// Assert `terraform env new "foobar"` returns expected deprecation warning
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	view, _ := testView(t)
 	newCmd = &WorkspaceNewCommand{
 		Meta: Meta{
@@ -1024,7 +1024,7 @@ func TestWorkspace_envCommandDeprecationWarnings(t *testing.T) {
 	}
 
 	// Assert `terraform env select "default"` returns expected deprecation warning
-	ui = new(cli.MockUi)
+	ui = testUiWrapped(t)
 	view, _ = testView(t)
 	selectCmd := &WorkspaceSelectCommand{
 		Meta: Meta{
@@ -1047,7 +1047,7 @@ func TestWorkspace_envCommandDeprecationWarnings(t *testing.T) {
 	}
 
 	// Assert `terraform env list` returns expected deprecation warning
-	ui = new(cli.MockUi)
+	ui = testUiWrapped(t)
 	listCmd := &WorkspaceListCommand{
 		Meta: Meta{
 			Ui:         ui,
@@ -1067,7 +1067,7 @@ func TestWorkspace_envCommandDeprecationWarnings(t *testing.T) {
 	}
 
 	// Assert `terraform env list -json` returns expected deprecation warning
-	ui = new(cli.MockUi)
+	ui = testUiWrapped(t)
 	view, done := testView(t)
 	listCmd = &WorkspaceListCommand{
 		Meta: Meta{
@@ -1091,7 +1091,7 @@ func TestWorkspace_envCommandDeprecationWarnings(t *testing.T) {
 	}
 
 	// Assert `terraform env delete` returns expected deprecation warning
-	ui = new(cli.MockUi)
+	ui = testUiWrapped(t)
 	view, _ = testView(t)
 	deleteCmd := &WorkspaceDeleteCommand{
 		Meta: Meta{
@@ -1419,7 +1419,7 @@ func TestWorkspace_list_jsonOutput(t *testing.T) {
 		Diagnostics: nil,
 	}
 
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	view, done := testView(t)
 	meta := Meta{
 		AllowExperimentalFeatures: true,
@@ -1596,7 +1596,7 @@ func TestInvalidWorkspaceSelectedOutOfBand(t *testing.T) {
 	}
 
 	// Initialize the working directory
-	ui := new(cli.MockUi)
+	ui := testUiWrapped(t)
 	view, done := testView(t)
 	meta := Meta{
 		Ui:   ui,
@@ -1611,7 +1611,7 @@ func TestInvalidWorkspaceSelectedOutOfBand(t *testing.T) {
 
 	// Make a custom workspace.
 	customWorkspace := "custom"
-	ui = new(cli.MockUi)
+	ui = testUiWrapped(t)
 	view, done = testView(t)
 	meta.Ui = ui
 	meta.View = view
@@ -1632,7 +1632,7 @@ func TestInvalidWorkspaceSelectedOutOfBand(t *testing.T) {
 	expectedError := "Invalid workspace name"
 
 	// Errors block users from performing init with the invalid workspace selected.
-	ui = new(cli.MockUi)
+	ui = testUiWrapped(t)
 	view, done = testView(t)
 	meta.Ui = ui
 	meta.View = view
@@ -1647,7 +1647,7 @@ func TestInvalidWorkspaceSelectedOutOfBand(t *testing.T) {
 	}
 
 	// Errors block users from performing apply with the invalid workspace selected.
-	ui = new(cli.MockUi)
+	ui = testUiWrapped(t)
 	view, done = testView(t)
 	meta.Ui = ui
 	meta.View = view
@@ -1662,7 +1662,7 @@ func TestInvalidWorkspaceSelectedOutOfBand(t *testing.T) {
 	}
 
 	// Users can select a different workspace to recover from the issue
-	ui = new(cli.MockUi)
+	ui = testUiWrapped(t)
 	view, _ = testView(t)
 	meta.Ui = ui
 	meta.View = view

--- a/internal/command/workspace_command_test.go
+++ b/internal/command/workspace_command_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/hashicorp/terraform/internal/backend/local"
 	"github.com/hashicorp/terraform/internal/backend/remote-state/inmem"
 	"github.com/hashicorp/terraform/internal/command/arguments"
+	"github.com/hashicorp/terraform/internal/command/ui"
 	"github.com/hashicorp/terraform/internal/command/views"
 	"github.com/hashicorp/terraform/internal/command/workdir"
 	"github.com/hashicorp/terraform/internal/providers"
@@ -1118,8 +1119,8 @@ func TestWorkspace_extraArgError(t *testing.T) {
 
 	// No temp directory needed as the tests check argument parsing.
 
-	newMeta := func() (Meta, *cli.MockUi) {
-		ui := new(cli.MockUi)
+	newMeta := func() (Meta, *ui.WrappedMockUi) {
+		ui := testUiWrapped(t)
 		return Meta{
 			Ui: ui,
 		}, ui
@@ -1194,8 +1195,8 @@ func TestWorkspace_extraArgError(t *testing.T) {
 
 // Test human output from commands, with color enabled or disabled
 func TestWorkspace_humanOutput(t *testing.T) {
-	newMeta := func(colourEnabled bool) (Meta, *cli.MockUi, *views.View, func(t *testing.T) *terminal.TestOutput) {
-		ui := new(cli.MockUi)
+	newMeta := func(colourEnabled bool) (Meta, *ui.WrappedMockUi, *views.View, func(t *testing.T) *terminal.TestOutput) {
+		ui := testUiWrapped(t)
 		view, done := testView(t)
 		return Meta{
 			Ui:         ui,

--- a/internal/command/workspace_command_test.go
+++ b/internal/command/workspace_command_test.go
@@ -265,18 +265,18 @@ func TestWorkspace_list_noReturnedWorkspaces(t *testing.T) {
 		"init",
 	}
 	for _, msg := range expectedWarningMessages {
-		if !strings.Contains(ui.ErrorWriter.String(), msg) {
-			t.Fatalf("expected stderr output to include: %s\ngot: %s",
+		if !strings.Contains(ui.OutputWriter.String(), msg) {
+			t.Fatalf("expected stdout output to include: %s\ngot: %s",
 				msg,
-				ui.ErrorWriter,
+				ui.OutputWriter,
 			)
 		}
 	}
 
 	// No other output is present
-	if ui.OutputWriter.String() != "" {
-		t.Fatalf("unexpected stdout: %s",
-			ui.OutputWriter,
+	if ui.ErrorWriter.String() != "" {
+		t.Fatalf("unexpected stderr: %s",
+			ui.ErrorWriter,
 		)
 	}
 }
@@ -1016,10 +1016,10 @@ func TestWorkspace_envCommandDeprecationWarnings(t *testing.T) {
 	if code := newCmd.Run(args); code != 0 {
 		t.Fatalf("bad: %d\n\n%s", code, ui.ErrorWriter)
 	}
-	if !strings.Contains(ui.ErrorWriter.String(), expectedWarning) {
+	if !strings.Contains(ui.OutputWriter.String(), expectedWarning) {
 		t.Fatalf("expected the command to return a warning, but it was missing.\nwanted: %s\ngot: %s",
 			expectedWarning,
-			ui.ErrorWriter.String(),
+			ui.OutputWriter.String(),
 		)
 	}
 
@@ -1039,10 +1039,10 @@ func TestWorkspace_envCommandDeprecationWarnings(t *testing.T) {
 	if code := selectCmd.Run(args); code != 0 {
 		t.Fatalf("bad: %d\n\n%s", code, ui.ErrorWriter)
 	}
-	if !strings.Contains(ui.ErrorWriter.String(), expectedWarning) {
+	if !strings.Contains(ui.OutputWriter.String(), expectedWarning) {
 		t.Fatalf("expected the command to return a warning, but it was missing.\nwanted: %s\ngot: %s",
 			expectedWarning,
-			ui.ErrorWriter.String(),
+			ui.OutputWriter.String(),
 		)
 	}
 
@@ -1059,10 +1059,10 @@ func TestWorkspace_envCommandDeprecationWarnings(t *testing.T) {
 	if code := listCmd.Run(args); code != 0 {
 		t.Fatalf("bad: %d\n\n%s", code, ui.ErrorWriter)
 	}
-	if !strings.Contains(ui.ErrorWriter.String(), expectedWarning) {
+	if !strings.Contains(ui.OutputWriter.String(), expectedWarning) {
 		t.Fatalf("expected the command to return a warning, but it was missing.\nwanted: %s\ngot: %s",
 			expectedWarning,
-			ui.ErrorWriter.String(),
+			ui.OutputWriter.String(),
 		)
 	}
 
@@ -1105,10 +1105,10 @@ func TestWorkspace_envCommandDeprecationWarnings(t *testing.T) {
 	if code := deleteCmd.Run(args); code != 0 {
 		t.Fatalf("bad: %d\n\n%s", code, ui.ErrorWriter)
 	}
-	if !strings.Contains(ui.ErrorWriter.String(), expectedWarning) {
+	if !strings.Contains(ui.OutputWriter.String(), expectedWarning) {
 		t.Fatalf("expected the command to return a warning, but it was missing.\nwanted: %s\ngot: %s",
 			expectedWarning,
-			ui.ErrorWriter.String(),
+			ui.OutputWriter.String(),
 		)
 	}
 }

--- a/main.go
+++ b/main.go
@@ -18,6 +18,7 @@ import (
 	"github.com/hashicorp/terraform-svchost/disco"
 	"github.com/hashicorp/terraform/internal/command/cliconfig"
 	"github.com/hashicorp/terraform/internal/command/format"
+	"github.com/hashicorp/terraform/internal/command/ui"
 	"github.com/hashicorp/terraform/internal/didyoumean"
 	"github.com/hashicorp/terraform/internal/getproviders/reattach"
 	"github.com/hashicorp/terraform/internal/httpclient"
@@ -39,23 +40,14 @@ const (
 	envTmpLogPath = "TF_TEMP_LOG_PATH"
 )
 
-// ui wraps the primary output cli.Ui, and redirects Warn calls to Output
-// calls. This ensures that warnings are sent to stdout, and are properly
-// serialized within the stdout stream.
-type ui struct {
-	cli.Ui
-}
-
-func (u *ui) Warn(msg string) {
-	u.Ui.Output(msg)
-}
-
 func init() {
-	Ui = &ui{&cli.BasicUi{
-		Writer:      os.Stdout,
-		ErrorWriter: os.Stderr,
-		Reader:      os.Stdin,
-	}}
+	Ui = &ui.WrappedUi{
+		Ui: &cli.BasicUi{
+			Writer:      os.Stdout,
+			ErrorWriter: os.Stderr,
+			Reader:      os.Stdin,
+		},
+	}
 }
 
 func main() {

--- a/main_test.go
+++ b/main_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/cli"
+	"github.com/hashicorp/terraform/internal/command/ui"
 )
 
 func TestMain_cliArgsFromEnv(t *testing.T) {
@@ -359,7 +360,7 @@ func (c *testCommandCLI) Help() string     { return "" }
 
 func TestWarnOutput(t *testing.T) {
 	mock := cli.NewMockUi()
-	wrapped := &ui{mock}
+	wrapped := &ui.WrappedUi{Ui: mock}
 	wrapped.Warn("WARNING")
 
 	stderr := mock.ErrorWriter.String()


### PR DESCRIPTION
This PR is intended to enable our integration tests to experience the same Ui behaviour as the overall Terraform CLI.

Currently Terraform's different commands may render output using either the older a `cli.Ui` approach or the newer approach implemented in the `views` package. I've been looking into what it'll take to move all commands to the newer approach so that the migration is completed. See: https://github.com/hashicorp/terraform/issues/37439

Recently I thought that commands still using `cli.Ui` for output sent Warnings to stderr, whereas the new Views sent Warnings to stdout, therefore I believed that converting commands from one to the other was a breaking change. However I recently found that in main.go there is logic that [redirects all calls to the ui's `Warn` method to instead go to the `Output` method, effectively rerouting warnings to stdout](https://github.com/hashicorp/terraform/pull/27057). This means both the old and new output methods both send warnings to stdout and migration to using views doesn't include a breaking change as I first thought. Yay!

However the problem is that our integration tests experience cli.Ui's native behaviour of 'warnings => stderr' whereas end users of Terrform experience warnings going to stdout. Instead, it'd be useful for our integration tests to match what actually happens in the CLI.

Therefore, this PR introduces a new test helper for creating a cli.UI. Whereas before tests would create a `cli.MockUi` directly, now tests will use a wrapped cli.MockUi created via the helper. Some tests are opinionated about whether the mock ui is made using `new(cli.MockUi)` or `cli.NewMockUi()`, so the helper allows callers to optionally provide their own mock ui to be wrapped. If it's not provided then the NewMockUi constructor is used.

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.16.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
