### PR TITLE
PSS: Move state store provider download-related logic away from `init` and into reusable methods on `Meta`

### DIFF
--- a/internal/command/init.go
+++ b/internal/command/init.go
@@ -10,7 +10,6 @@ import (
 	"maps"
 	"reflect"
 	"slices"
-	"sort"
 	"strings"
 
 	"github.com/hashicorp/hcl/v2"
@@ -712,72 +711,6 @@ func (c *InitCommand) getProviders(ctx context.Context, config *configs.Config, 
 	}
 
 	return true, newLocks, diags
-}
-
-// saveDependencyLockFile overwrites the contents of the dependency lock file.
-// The calling code is expected to provide the previous locks (if any) and the two sets of locks determined from
-// configuration and state data.
-func (c *InitCommand) saveDependencyLockFile(previousLocks, newLocks *depsfile.Locks, flagLockfile string, view views.ProviderInstaller) (output bool, diags tfdiags.Diagnostics) {
-	// If the provider dependencies have changed since the last run then we'll
-	// say a little about that in case the reader wasn't expecting a change.
-	// (When we later integrate module dependencies into the lock file we'll
-	// probably want to refactor this so that we produce one lock-file related
-	// message for all changes together, but this is here for now just because
-	// it's the smallest change relative to what came before it, which was
-	// a hidden JSON file specifically for tracking providers.)
-	if !newLocks.Equal(previousLocks) {
-		// if readonly mode
-		if flagLockfile == "readonly" {
-			// check if required provider dependencies change
-			if !newLocks.EqualProviderAddress(previousLocks) {
-				diags = diags.Append(tfdiags.Sourceless(
-					tfdiags.Error,
-					`Provider dependency changes detected`,
-					`Changes to the required provider dependencies were detected, but the lock file is read-only. To use and record these requirements, run "terraform init" without the "-lockfile=readonly" flag.`,
-				))
-				return output, diags
-			}
-			// suppress updating the file to record any new information it learned,
-			// such as a hash using a new scheme.
-			diags = diags.Append(tfdiags.Sourceless(
-				tfdiags.Warning,
-				`Provider lock file not updated`,
-				`Changes to the provider selections were detected, but not saved in the .terraform.lock.hcl file. To record these selections, run "terraform init" without the "-lockfile=readonly" flag.`,
-			))
-			return output, diags
-		}
-		// Jump in here and add a warning if any of the providers are incomplete.
-		if len(c.incompleteProviders) > 0 {
-			// We don't really care about the order here, we just want the
-			// output to be deterministic.
-			sort.Slice(c.incompleteProviders, func(i, j int) bool {
-				return c.incompleteProviders[i] < c.incompleteProviders[j]
-			})
-			diags = diags.Append(tfdiags.Sourceless(
-				tfdiags.Warning,
-				incompleteLockFileInformationHeader,
-				fmt.Sprintf(
-					incompleteLockFileInformationBody,
-					strings.Join(c.incompleteProviders, "\n  - "),
-					getproviders.CurrentPlatform.String())))
-		}
-		if previousLocks.Empty() {
-			// A change from empty to non-empty is special because it suggests
-			// we're running "terraform init" for the first time against a
-			// new configuration. In that case we'll take the opportunity to
-			// say a little about what the dependency lock file is, for new
-			// users or those who are upgrading from a previous Terraform
-			// version that didn't have dependency lock files.
-			view.Output(views.LockInfo)
-			output = true
-		} else {
-			view.Output(views.DependenciesLockChangesInfo)
-			output = true
-		}
-		lockFileDiags := c.replaceLockedDependencies(newLocks)
-		diags = diags.Append(lockFileDiags)
-	}
-	return output, diags
 }
 
 // backendConfigOverrideBody interprets the raw values of -backend-config

--- a/internal/command/init.go
+++ b/internal/command/init.go
@@ -382,7 +382,7 @@ the backend configuration is present and valid.
 // to only download a single provider, and the method will only return a single lock.
 //
 // Calling code is responsible for validating inputs to this method, e.g. mutually exclusive flags.
-func (c *InitCommand) getProvidersFromPSSConfig(ctx context.Context, rootModEarly *configs.Module, previousLocks *depsfile.Locks, upgrade bool, pluginDirs []string, flagLockfile string, view views.Init) (output bool, resultingLocks *depsfile.Locks, safeInitAction SafeStateStoreProviderInstallAction, authResult *getproviders.PackageAuthenticationResult, diags tfdiags.Diagnostics) {
+func (c *InitCommand) getProvidersFromPSSConfig(ctx context.Context, rootModEarly *configs.Module, previousLocks *depsfile.Locks, upgrade bool, pluginDirs []string, flagLockfile string, view views.Init) (output bool, resultingLocks *depsfile.Locks, safeInstallAction SafeStateStoreProviderInstallAction, authResult *getproviders.PackageAuthenticationResult, diags tfdiags.Diagnostics) {
 	ctx, span := tracer.Start(ctx, "install providers for state store")
 	defer span.End()
 
@@ -545,35 +545,10 @@ func (c *InitCommand) getProvidersFromPSSConfig(ctx context.Context, rootModEarl
 		return true, nil, Invalid, nil, diags
 	}
 
-	// Return advice to the calling code about what to do regarding safe init feature related to state storage providers
-	location, ok := providerLocations[rootModEarly.StateStore.ProviderAddr]
-	if !ok {
-		// The provider was not processed in the FetchPackageBegin callback.
-		// A provider that wasn't downloaded during this init could be because:
-		// * It was already present from a previous installation.
-		// * If upgrading, no newer version was available that matched version constraints.
-		// * Or, the provider is unmanaged/reattached and so download was skipped.
-		log.Printf("[TRACE] init (getProvidersFromPSSConfig): the state storage provider %s (%q) will not be changed in the dependency lock file after provider installation. Either it was already present and/or there was no available upgrade version that matched version constraints.", rootModEarly.StateStore.ProviderAddr.Type, rootModEarly.StateStore.ProviderAddr)
-		safeInitAction = SafeInitActionProceed
-	} else {
-		// The provider was processed in the FetchPackageBegin callback, so either it's being downloaded for the first time, or upgraded.
-		log.Printf("[TRACE] init (getProvidersFromConfig): the state storage provider %s (%q) will be changed in the dependency lock file during provider installation.", rootModEarly.StateStore.ProviderAddr.Type, rootModEarly.StateStore.ProviderAddr)
+	// Return advice to the calling code about what to do regarding safe state store provider installation
+	safeInstallAction = c.determineSafeProviderInstallAction(rootModEarly.StateStore.ProviderAddr, providerLocations)
 
-		switch location.(type) {
-		case getproviders.PackageLocalArchive, getproviders.PackageLocalDir:
-			// If the provider is downloaded from a local source we assume it's safe.
-			// We don't require presence of the -safe-init flag, or require input from the user to approve its usage.
-			log.Printf("[TRACE] init (getProvidersFromConfig): the state storage provider %s (%q) is downloaded from a local source, so we consider it safe.", rootModEarly.StateStore.ProviderAddr.Type, rootModEarly.StateStore.ProviderAddr)
-			safeInitAction = SafeInitActionProceed
-		case getproviders.PackageHTTPURL:
-			log.Printf("[DEBUG] init (getProvidersFromConfig): the state storage provider %s (%q) is downloaded via HTTP, so we consider it potentially unsafe.", rootModEarly.StateStore.ProviderAddr.Type, rootModEarly.StateStore.ProviderAddr)
-			safeInitAction = SafeInitActionRequireApproval
-		default:
-			panic(fmt.Sprintf("init (getProvidersFromConfig): unexpected provider location type for state storage provider %q: %T", rootModEarly.StateStore.ProviderAddr, location))
-		}
-	}
-
-	return true, lock, safeInitAction, stateStoreProviderAuthResult, diags
+	return true, lock, safeInstallAction, stateStoreProviderAuthResult, diags
 }
 
 // getProviders determines what providers are required by the config and state

--- a/internal/command/init.go
+++ b/internal/command/init.go
@@ -373,17 +373,6 @@ the backend configuration is present and valid.
 	return diags
 }
 
-// SafeInitAction describes the action that should be taken by Terraform based on whether
-// pluggable state storage is in use, if the provider is going to be downloaded via HTTP or not,
-// and whether Terraform is being run in automation or not.
-type SafeInitAction rune
-
-const (
-	SafeInitActionInvalid         SafeInitAction = 0
-	SafeInitActionProceed         SafeInitAction = 'P'
-	SafeInitActionRequireApproval SafeInitAction = 'I'
-)
-
 // getProvidersFromPSSConfig determines what provider is required given state store configuration
 // and downloads the provider that isn't already downloaded and then returns
 // updated dependency lock data. The dependency lock file itself isn't updated here.
@@ -393,7 +382,7 @@ const (
 // to only download a single provider, and the method will only return a single lock.
 //
 // Calling code is responsible for validating inputs to this method, e.g. mutually exclusive flags.
-func (c *InitCommand) getProvidersFromPSSConfig(ctx context.Context, rootModEarly *configs.Module, previousLocks *depsfile.Locks, upgrade bool, pluginDirs []string, flagLockfile string, view views.Init) (output bool, resultingLocks *depsfile.Locks, safeInitAction SafeInitAction, authResult *getproviders.PackageAuthenticationResult, diags tfdiags.Diagnostics) {
+func (c *InitCommand) getProvidersFromPSSConfig(ctx context.Context, rootModEarly *configs.Module, previousLocks *depsfile.Locks, upgrade bool, pluginDirs []string, flagLockfile string, view views.Init) (output bool, resultingLocks *depsfile.Locks, safeInitAction SafeStateStoreProviderInstallAction, authResult *getproviders.PackageAuthenticationResult, diags tfdiags.Diagnostics) {
 	ctx, span := tracer.Start(ctx, "install providers for state store")
 	defer span.End()
 
@@ -446,7 +435,7 @@ func (c *InitCommand) getProvidersFromPSSConfig(ctx context.Context, rootModEarl
 		}
 	}
 	if diags.HasErrors() {
-		return false, nil, SafeInitActionInvalid, nil, diags
+		return false, nil, Invalid, nil, diags
 	}
 
 	var inst *providercache.Installer
@@ -543,7 +532,7 @@ func (c *InitCommand) getProvidersFromPSSConfig(ctx context.Context, rootModEarl
 	if ctx.Err() == context.Canceled {
 		diags = diags.Append(fmt.Errorf("Provider installation was canceled by an interrupt signal."))
 		view.Diagnostics(diags)
-		return true, nil, SafeInitActionInvalid, nil, diags
+		return true, nil, Invalid, nil, diags
 	}
 	if err != nil {
 		// The errors captured in "err" should be redundant with what we
@@ -553,7 +542,7 @@ func (c *InitCommand) getProvidersFromPSSConfig(ctx context.Context, rootModEarl
 			diags = diags.Append(err)
 		}
 
-		return true, nil, SafeInitActionInvalid, nil, diags
+		return true, nil, Invalid, nil, diags
 	}
 
 	// Return advice to the calling code about what to do regarding safe init feature related to state storage providers

--- a/internal/command/init_run.go
+++ b/internal/command/init_run.go
@@ -457,7 +457,7 @@ Please use \"terraform state migrate -upgrade\" to upgrade the state store provi
 		// will not use it due to the lock file being unchanged.
 		finalLocks = c.mergeLockedDependencies(pssLock, finalLocks)
 	}
-	lockFileOutput, lockFileDiags := c.saveDependencyLockFile(previousLocks, finalLocks, initArgs.Lockfile, view)
+	lockFileOutput, lockFileDiags := c.saveDependencyLockFile(previousLocks, finalLocks, c.incompleteProviders, initArgs.Lockfile, view)
 	diags = diags.Append(lockFileDiags)
 	if lockFileDiags.HasErrors() {
 		view.Diagnostics(diags)

--- a/internal/command/init_run.go
+++ b/internal/command/init_run.go
@@ -4,13 +4,11 @@
 package command
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"strings"
 
 	"github.com/hashicorp/hcl/v2"
-	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/backend"
 	"github.com/hashicorp/terraform/internal/cloud"
 	"github.com/hashicorp/terraform/internal/command/arguments"
@@ -248,37 +246,11 @@ Please use \"terraform state migrate -upgrade\" to upgrade the state store provi
 		}
 
 		// Course of action depends on the SafeStateStoreProviderInstallAction returned from getProvidersFromPSSConfig
-		switch safeInstallAction {
-		case Proceed:
-			// do nothing; provider is already trusted and there's no need to notify the user.
-		case RequireApproval:
-			if c.input {
-				// Prompt the user about trusting the provider used for state storage.
-				diags = diags.Append(c.promptStateStorageProviderApproval(rootModEarly.StateStore.ProviderAddr, pssLock, stateStoreProviderAuthResult))
-				if diags.HasErrors() {
-					view.Output(views.StateStoreProviderInteractiveRejectedMessage)
-					view.Diagnostics(diags)
-					return 1
-				}
-				view.Output(views.StateStoreProviderInteractiveApprovedMessage)
-			} else {
-				// Confirm that a lock was used to control download.
-				// Note: we have to wait and do that here because at this point we know the provider was downloaded from a source that requires additional info about trust.
-				if alteredPreviousLocks.Provider(rootModEarly.StateStore.ProviderAddr) == nil {
-					// No lock was provided for the state store provider either through pre-existing locks or through the -state-provider-lock-file flag.
-					diags = diags.Append(tfdiags.Sourceless(
-						tfdiags.Error,
-						"Missing lock for state store provider",
-						"Terraform is initializing a state store for the first time in a non-interactive mode. In this scenario Terraform needs a pre-existing dependency lock for the state store provider to be present in the working directory's dependency lock file, or present in another file supplied via the -state-provider-lock-file flag. No lock was found for the state store provider. Please re-run the command using the -state-provider-lock-file flag.",
-					))
-					view.Diagnostics(diags)
-					return 1
-				}
-				view.Output(views.StateStoreProviderAutomationApprovedMessage)
-			}
-		default:
-			// Handle Invalid or unexpected action types
-			panic(fmt.Sprintf("When installing providers described in the config Terraform couldn't determine what 'safe init' action should be taken and returned action type %T. This is a bug in Terraform and should be reported.", safeInstallAction))
+		safeDiags := c.handleSafeProviderInstallAction(safeInstallAction, rootModEarly.StateStore.ProviderAddr, stateStoreProviderAuthResult, pssLock, alteredPreviousLocks, view)
+		diags = diags.Append(safeDiags)
+		if safeDiags.HasErrors() {
+			view.Diagnostics(diags)
+			return 1
 		}
 
 		// Record how the state store provider is supplied to Terraform
@@ -492,56 +464,4 @@ Please use \"terraform state migrate -upgrade\" to upgrade the state store provi
 		view.Output(output)
 	}
 	return 0
-}
-
-// promptStateStorageProviderApproval is used when Terraform is unsure about the safety of the provider downloaded for state storage
-// purposes, and we need to prompt the user to approve or reject using it.
-func (c *InitCommand) promptStateStorageProviderApproval(stateStorageProvider addrs.Provider, configLocks *depsfile.Locks, authResult *getproviders.PackageAuthenticationResult) tfdiags.Diagnostics {
-	var diags tfdiags.Diagnostics
-
-	// If we can receive input then we prompt for ok from the user
-	lock := configLocks.Provider(stateStorageProvider)
-
-	var hashList strings.Builder
-	for _, hash := range lock.PreferredHashes() {
-		hashList.WriteString(fmt.Sprintf("- %s\n", hash))
-	}
-
-	var authentication string
-	if authResult != nil && authResult.KeyID != "" {
-		authentication = fmt.Sprintf("%s, key ID %s", authResult.String(), authResult.KeyID)
-	} else {
-		authentication = authResult.String()
-	}
-
-	v, err := c.UIInput().Input(context.Background(), &terraform.InputOpts{
-		Id: "approve",
-		Query: fmt.Sprintf(`Do you want to use provider %q (%s), version %s, for managing state?
-Platform: %s
-Authentication: %s
-Hashes:
-%s
-`,
-			lock.Provider().Type,
-			lock.Provider(),
-			lock.Version(),
-			getproviders.CurrentPlatform.String(),
-			authentication,
-			hashList.String(),
-		),
-		Description: fmt.Sprintf(`Check the details above for provider %q and confirm that you trust the provider.
-	Only 'yes' will be accepted to confirm.`, lock.Provider().Type),
-	})
-	if err != nil {
-		return diags.Append(fmt.Errorf("Failed to approve use of state storage provider: %s", err))
-	}
-	if v != "yes" {
-		return diags.Append(
-			fmt.Errorf("State store provider %q (%s) was not approved, so init cannot continue.",
-				lock.Provider().Type,
-				lock.Provider(),
-			),
-		)
-	}
-	return diags
 }

--- a/internal/command/init_run.go
+++ b/internal/command/init_run.go
@@ -232,10 +232,10 @@ Please use \"terraform state migrate -upgrade\" to upgrade the state store provi
 		}
 
 		var configProvidersOutput bool
-		var safeInitAction SafeInitAction
+		var safeInstallAction SafeStateStoreProviderInstallAction
 		var stateStoreProviderAuthResult *getproviders.PackageAuthenticationResult
 		var configProviderDiags tfdiags.Diagnostics
-		configProvidersOutput, pssLock, safeInitAction, stateStoreProviderAuthResult, configProviderDiags = c.getProvidersFromPSSConfig(ctx, rootModEarly, alteredPreviousLocks, allowUpgrade, initArgs.PluginPath, initArgs.Lockfile, view)
+		configProvidersOutput, pssLock, safeInstallAction, stateStoreProviderAuthResult, configProviderDiags = c.getProvidersFromPSSConfig(ctx, rootModEarly, alteredPreviousLocks, allowUpgrade, initArgs.PluginPath, initArgs.Lockfile, view)
 		diags = diags.Append(configProviderDiags)
 		if configProviderDiags.HasErrors() {
 			view.Diagnostics(diags)
@@ -247,11 +247,11 @@ Please use \"terraform state migrate -upgrade\" to upgrade the state store provi
 			view.Output(views.EmptyMessage)
 		}
 
-		// Course of action depends on the safeInitAction returned from getProvidersFromPSSConfig
-		switch safeInitAction {
-		case SafeInitActionProceed:
+		// Course of action depends on the SafeStateStoreProviderInstallAction returned from getProvidersFromPSSConfig
+		switch safeInstallAction {
+		case Proceed:
 			// do nothing; provider is already trusted and there's no need to notify the user.
-		case SafeInitActionRequireApproval:
+		case RequireApproval:
 			if c.input {
 				// Prompt the user about trusting the provider used for state storage.
 				diags = diags.Append(c.promptStateStorageProviderApproval(rootModEarly.StateStore.ProviderAddr, pssLock, stateStoreProviderAuthResult))
@@ -277,8 +277,8 @@ Please use \"terraform state migrate -upgrade\" to upgrade the state store provi
 				view.Output(views.StateStoreProviderAutomationApprovedMessage)
 			}
 		default:
-			// Handle SafeInitActionInvalid or unexpected action types
-			panic(fmt.Sprintf("When installing providers described in the config Terraform couldn't determine what 'safe init' action should be taken and returned action type %T. This is a bug in Terraform and should be reported.", safeInitAction))
+			// Handle Invalid or unexpected action types
+			panic(fmt.Sprintf("When installing providers described in the config Terraform couldn't determine what 'safe init' action should be taken and returned action type %T. This is a bug in Terraform and should be reported.", safeInstallAction))
 		}
 
 		// Record how the state store provider is supplied to Terraform

--- a/internal/command/init_run.go
+++ b/internal/command/init_run.go
@@ -246,7 +246,7 @@ Please use \"terraform state migrate -upgrade\" to upgrade the state store provi
 		}
 
 		// Course of action depends on the SafeStateStoreProviderInstallAction returned from getProvidersFromPSSConfig
-		safeDiags := c.handleSafeProviderInstallAction(safeInstallAction, rootModEarly.StateStore.ProviderAddr, stateStoreProviderAuthResult, pssLock, alteredPreviousLocks, view)
+		safeDiags := c.handleSafeProviderInstallAction(safeInstallAction, rootModEarly.StateStore.ProviderAddr, stateStoreProviderAuthResult, pssLock, alteredPreviousLocks, initArgs.StateStoreProviderLockFile, c, view)
 		diags = diags.Append(safeDiags)
 		if safeDiags.HasErrors() {
 			view.Diagnostics(diags)

--- a/internal/command/init_test.go
+++ b/internal/command/init_test.go
@@ -4272,8 +4272,7 @@ func TestInit_stateStore_newWorkingDir_basic(t *testing.T) {
 
 		// Check output
 		output := testOutput.All()
-		expectedOutputs := []string{
-			`Initializing provider plugin for state store "test_store"...
+		expectedOutput := `Initializing provider plugin for state store "test_store"...
 - Finding latest version of hashicorp/test...
 - Installing hashicorp/test v1.2.3...
 - Installed hashicorp/test v1.2.3 (verified checksum)
@@ -4282,12 +4281,9 @@ Initializing the state store "test_store"...
 
 Initializing provider plugins...
 - Reusing previous version of hashicorp/test from the dependency lock file
-- Using previously-installed hashicorp/test v1.2.3`,
-		}
-		for _, expected := range expectedOutputs {
-			if !strings.Contains(output, expected) {
-				t.Fatalf("expected output to include %q, but got:\n%s", expected, output)
-			}
+- Using previously-installed hashicorp/test v1.2.3`
+		if !strings.Contains(output, expectedOutput) {
+			t.Fatalf("expected output to include %q, but got:\n%s", expectedOutput, output)
 		}
 
 		// Assert the default workspace was not created
@@ -4814,6 +4810,7 @@ func TestInit_stateStore_newWorkingDir_interactiveProviderApproval(t *testing.T)
 		output := testOutput.All()
 		expectedOutputs := []string{
 			"The state store provider was rejected",
+			`Error: State store provider "test" (registry.terraform.io/hashicorp/test) was not approved, so init cannot continue.`,
 		}
 		for _, expected := range expectedOutputs {
 			if !strings.Contains(output, expected) {
@@ -4890,6 +4887,7 @@ func TestInit_stateStore_newWorkingDir_interactiveProviderApproval(t *testing.T)
 		output := testOutput.All()
 		expectedOutputs := []string{
 			"The state store provider was rejected",
+			`Error: State store provider "test" (registry.terraform.io/hashicorp/test) was not approved, so init cannot continue.`,
 		}
 		for _, expectedOutput := range expectedOutputs {
 			if !strings.Contains(output, expectedOutput) {
@@ -5398,7 +5396,8 @@ func TestInit_stateStore_newWorkingDir_inAutomationProviderApproval(t *testing.T
 		output := cleanString(testOutput.All())
 		expectedOutputs := []string{
 			"Error: Missing lock for state store provider",
-			"Terraform is initializing a state store for the first time in a non-interactive mode. In this scenario Terraform needs a pre-existing dependency lock for the state store provider to be present in the working directory's dependency lock file, or present in another file supplied via the -state-provider-lock-file flag. No lock was found for the state store provider. Please re-run the command using the -state-provider-lock-file flag.",
+			"Terraform is initializing a state store for the first time in a non-interactive mode but no lock was found for the state store provider",
+			"If you are performing a \"terraform init\" command in automation, make sure to supply a lock file for the state store provider using the -state-provider-lock-file flag",
 		}
 		for _, expected := range expectedOutputs {
 			if !strings.Contains(output, expected) {

--- a/internal/command/init_test.go
+++ b/internal/command/init_test.go
@@ -5333,7 +5333,7 @@ func TestInit_stateStore_newWorkingDir_inAutomationProviderApproval(t *testing.T
 		output := cleanString(testOutput.All())
 		expectedOutputs := []string{
 			"Error: State store provider not described in dependency lock file supplied via -state-provider-lock-file flag",
-			fmt.Sprintf("Terraform checked the lock file at %q, supplied via the -state-provider-lock-file flag, but could not find the state store provider", lockFileName),
+			fmt.Sprintf(`Terraform checked the lock file at %q, supplied via the -state-provider-lock-file flag, but could not find the state store provider "test" (hashicorp/test).`, lockFileName),
 		}
 		for _, expected := range expectedOutputs {
 			if !strings.Contains(output, expected) {
@@ -5396,8 +5396,8 @@ func TestInit_stateStore_newWorkingDir_inAutomationProviderApproval(t *testing.T
 		output := cleanString(testOutput.All())
 		expectedOutputs := []string{
 			"Error: Missing lock for state store provider",
-			"Terraform is initializing a state store for the first time in a non-interactive mode but no lock was found for the state store provider",
-			"If you are performing a \"terraform init\" command in automation, make sure to supply a lock file for the state store provider using the -state-provider-lock-file flag",
+			`Terraform used the working directory's lock file by default, but it was empty or did not exist.`,
+			`When performing a "terraform init" command in automation, make sure to supply a lock file for the state store provider using the -state-provider-lock-file flag.`,
 		}
 		for _, expected := range expectedOutputs {
 			if !strings.Contains(output, expected) {

--- a/internal/command/meta_backend.go
+++ b/internal/command/meta_backend.go
@@ -24,6 +24,7 @@ import (
 	"github.com/hashicorp/hcl/v2/hcldec"
 	"github.com/zclconf/go-cty/cty"
 
+	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/backend"
 	"github.com/hashicorp/terraform/internal/backend/backendrun"
 	backendInit "github.com/hashicorp/terraform/internal/backend/init"
@@ -3066,6 +3067,37 @@ const (
 	Proceed         SafeStateStoreProviderInstallAction = 'P'
 	RequireApproval SafeStateStoreProviderInstallAction = 'A'
 )
+
+// determineSafeProviderInstallAction returns a `SafeProviderInstallAction` rune that instructs calling code about what to do following download of the state store provider.
+// The `providerLocations` map parameter is expected to be created by the `FetchPackageBegin` callback, which is called during provider download.
+func (m *Meta) determineSafeProviderInstallAction(provider addrs.Provider, providerLocations map[addrs.Provider]getproviders.PackageLocation) SafeStateStoreProviderInstallAction {
+	location, ok := providerLocations[provider]
+	if !ok {
+		// The provider was not processed in the FetchPackageBegin callback.
+		// A provider that wasn't downloaded during this init could be because:
+		// * It was already present from a previous installation.
+		// * If upgrading, no newer version was available that matched version constraints.
+		// * Or, the provider is unmanaged/reattached and so download was skipped.
+		log.Printf("[TRACE] init (getProvidersFromPSSConfig): the state storage provider %s (%q) will not be changed in the dependency lock file after provider installation. Either it was already present and/or there was no available upgrade version that matched version constraints.", provider.Type, provider)
+		return Proceed
+	} else {
+		// The provider was processed in the FetchPackageBegin callback, so either it's being downloaded for the first time, or upgraded.
+		log.Printf("[TRACE] init (getProvidersFromConfig): the state storage provider %s (%q) will be changed in the dependency lock file during provider installation.", provider.Type, provider)
+
+		switch location.(type) {
+		case getproviders.PackageLocalArchive, getproviders.PackageLocalDir:
+			// If the provider is downloaded from a local source we assume it's safe.
+			// We don't require presence of the -safe-init flag, or require input from the user to approve its usage.
+			log.Printf("[TRACE] init (getProvidersFromConfig): the state storage provider %s (%q) is downloaded from a local source, so we consider it safe.", provider.Type, provider)
+			return Proceed
+		case getproviders.PackageHTTPURL:
+			log.Printf("[DEBUG] init (getProvidersFromConfig): the state storage provider %s (%q) is downloaded via HTTP, so we consider it potentially unsafe.", provider.Type, provider)
+			return RequireApproval
+		default:
+			panic(fmt.Sprintf("init (getProvidersFromConfig): unexpected provider location type for state storage provider %q: %T", provider, location))
+		}
+	}
+}
 
 //-------------------------------------------------------------------
 // Output constants and initialization code

--- a/internal/command/meta_backend.go
+++ b/internal/command/meta_backend.go
@@ -19,6 +19,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/hashicorp/cli"
 	version "github.com/hashicorp/go-version"
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hcldec"
@@ -3099,7 +3100,10 @@ func (m *Meta) determineSafeProviderInstallAction(provider addrs.Provider, provi
 	}
 }
 
-func (m *Meta) handleSafeProviderInstallAction(action SafeStateStoreProviderInstallAction, provider addrs.Provider, stateStoreProviderAuthResult *getproviders.PackageAuthenticationResult, locksAfterInstall, locksBeforeInstall *depsfile.Locks, view views.ProviderInstaller) tfdiags.Diagnostics {
+// handleSafeProviderInstallAction takes the action determined by `determineSafeProviderInstallAction` and either prompts the user for approval, or returns an error if something has gone wrong with pre-supplied locks when Terraform was run in automation.
+//
+// NOTE: the command parameter is used to determine which command is being run, so that we can provide more specific guidance to the user. Do not use that parameter for any other purpose!
+func (m *Meta) handleSafeProviderInstallAction(action SafeStateStoreProviderInstallAction, provider addrs.Provider, stateStoreProviderAuthResult *getproviders.PackageAuthenticationResult, stateStoreProviderLock, locksBeforeInstall *depsfile.Locks, flagLockfilePath string, command cli.Command, view views.ProviderInstaller) tfdiags.Diagnostics {
 	var diags tfdiags.Diagnostics
 
 	switch action {
@@ -3108,7 +3112,7 @@ func (m *Meta) handleSafeProviderInstallAction(action SafeStateStoreProviderInst
 	case RequireApproval:
 		if m.input {
 			// Prompt the user about trusting the provider used for state storage.
-			diags = diags.Append(m.promptStateStorageProviderApproval(provider, locksAfterInstall, stateStoreProviderAuthResult))
+			diags = diags.Append(m.promptStateStorageProviderApproval(provider, stateStoreProviderLock, stateStoreProviderAuthResult))
 			if diags.HasErrors() {
 				view.Output(views.StateStoreProviderInteractiveRejectedMessage)
 				view.Output(views.EmptyMessage)
@@ -3122,14 +3126,48 @@ func (m *Meta) handleSafeProviderInstallAction(action SafeStateStoreProviderInst
 			// Note: we have to wait and do that here because at this point we know the provider was downloaded from a source that requires additional info about trust.
 			if locksBeforeInstall.Provider(provider) == nil {
 				// No lock was provided for the state store provider either through pre-existing locks or through CLI flags.
+
+				var lockfileProblem string
+				switch {
+				case flagLockfilePath != "":
+					// CLI-supplied file
+					lockfileProblem = fmt.Sprintf("The lock file at %q (supplied via CLI flag) was empty or did not contain a lock for the state store provider.", flagLockfilePath)
+				case locksBeforeInstall.Empty():
+					// Default lock file used, but it was empty.
+					lockfileProblem = "Terraform used the working directory's lock file by default, but it was empty or did not exist."
+				default:
+					// Default lock file used, and it exists/has locks in it.
+					lockfileProblem = "Terraform used the working directory's lock file by default, but it did not contain a lock for the state store provider."
+				}
+
+				var guidance string
+				var remediationInstructions string
+				switch command.(type) {
+				case *InitCommand:
+					guidance = `When performing a "terraform init" command in automation, make sure to supply a lock file for the state store provider using the -state-provider-lock-file flag.`
+					remediationInstructions = `To fix this, create a minimal configuration containing the specific provider version(s) you need and then perform "terraform init" with input enabled. Check the contents of the lock file created by that command and then retry "terraform init -state-provider-lock-file=<path to lockfile>".
+`
+				case *StateMigrateCommand:
+					guidance = `When performing a "terraform state migrate" command in automation, make sure to supply a lock file for the source and/or destination state store providers using -source-provider-lock-file and/or -destination-provider-lock-file flags.`
+					remediationInstructions = `To fix this, create a minimal configuration(s) containing the specific provider version(s) you need and then perform "terraform init" with input enabled. Check the contents of the lock file created by that command and then retry "terraform state migrate -source-provider-lock-file=<path to lockfile> -destination-provider-lock-file=<path to lockfile>".`
+
+				default:
+					panic("Unexpected command type in handleSafeProviderInstallAction; this is a bug in Terraform and should be reported.")
+				}
+
 				diags = diags.Append(tfdiags.Sourceless(
 					tfdiags.Error,
 					"Missing lock for state store provider",
-					`Terraform is initializing a state store for the first time in a non-interactive mode but no lock was found for the state store provider. In this scenario Terraform needs a pre-existing dependency lock for the state store provider to be present in the working directory's dependency lock file, or present in another file supplied via CLI flags.
-If you are performing a "terraform init" command in automation, make sure to supply a lock file for the state store provider using the -state-provider-lock-file flag.
-If you are performing a "terraform state migrate" command in automation, make sure to supply a lock file for the source and/or destination state store providers using -source-provider-lock-file and/or -destination-provider-lock-file flags.
+					fmt.Sprintf(`Terraform is initializing a state store for the first time in a non-interactive mode but no lock was found for the state store provider.
+%s
 
-To get a sufficient lock file to supply via these flags, create a minimal configuration with the specific provider and version you need to use. Then, perform "terraform init" manually to create a dependency lock file describing that provider. After checking the lock file's contents you can retry the original command that produced this error while supplying the path to that lock file via the appropriate CLI flag.`,
+%s
+
+%s`,
+						lockfileProblem,
+						guidance,
+						remediationInstructions,
+					),
 				))
 				return diags
 			}

--- a/internal/command/meta_backend.go
+++ b/internal/command/meta_backend.go
@@ -3056,6 +3056,17 @@ func (m *Meta) StateStoreProviderFactoryFromConfigState(cfgState *workdir.StateS
 	return factory, diags
 }
 
+// SafeStateStoreProviderInstallAction describes the action that should be taken by Terraform based on whether
+// pluggable state storage is in use, if the provider is going to be downloaded via HTTP or not,
+// and whether Terraform is being run in automation or not.
+type SafeStateStoreProviderInstallAction rune
+
+const (
+	Invalid         SafeStateStoreProviderInstallAction = 0
+	Proceed         SafeStateStoreProviderInstallAction = 'P'
+	RequireApproval SafeStateStoreProviderInstallAction = 'A'
+)
+
 //-------------------------------------------------------------------
 // Output constants and initialization code
 //-------------------------------------------------------------------

--- a/internal/command/meta_backend.go
+++ b/internal/command/meta_backend.go
@@ -3099,6 +3099,104 @@ func (m *Meta) determineSafeProviderInstallAction(provider addrs.Provider, provi
 	}
 }
 
+func (m *Meta) handleSafeProviderInstallAction(action SafeStateStoreProviderInstallAction, provider addrs.Provider, stateStoreProviderAuthResult *getproviders.PackageAuthenticationResult, locksAfterInstall, locksBeforeInstall *depsfile.Locks, view views.ProviderInstaller) tfdiags.Diagnostics {
+	var diags tfdiags.Diagnostics
+
+	switch action {
+	case Proceed:
+		// do nothing; provider is already trusted and there's no need to notify the user.
+	case RequireApproval:
+		if m.input {
+			// Prompt the user about trusting the provider used for state storage.
+			diags = diags.Append(m.promptStateStorageProviderApproval(provider, locksAfterInstall, stateStoreProviderAuthResult))
+			if diags.HasErrors() {
+				view.Output(views.StateStoreProviderInteractiveRejectedMessage)
+				view.Output(views.EmptyMessage)
+				return diags
+			}
+
+			view.Output(views.StateStoreProviderInteractiveApprovedMessage)
+			view.Output(views.EmptyMessage)
+		} else {
+			// Confirm that a lock was used to control download.
+			// Note: we have to wait and do that here because at this point we know the provider was downloaded from a source that requires additional info about trust.
+			if locksBeforeInstall.Provider(provider) == nil {
+				// No lock was provided for the state store provider either through pre-existing locks or through CLI flags.
+				diags = diags.Append(tfdiags.Sourceless(
+					tfdiags.Error,
+					"Missing lock for state store provider",
+					`Terraform is initializing a state store for the first time in a non-interactive mode but no lock was found for the state store provider. In this scenario Terraform needs a pre-existing dependency lock for the state store provider to be present in the working directory's dependency lock file, or present in another file supplied via CLI flags.
+If you are performing a "terraform init" command in automation, make sure to supply a lock file for the state store provider using the -state-provider-lock-file flag.
+If you are performing a "terraform state migrate" command in automation, make sure to supply a lock file for the source and/or destination state store providers using -source-provider-lock-file and/or -destination-provider-lock-file flags.
+
+To get a sufficient lock file to supply via these flags, create a minimal configuration with the specific provider and version you need to use. Then, perform "terraform init" manually to create a dependency lock file describing that provider. After checking the lock file's contents you can retry the original command that produced this error while supplying the path to that lock file via the appropriate CLI flag.`,
+				))
+				return diags
+			}
+
+			view.Output(views.StateStoreProviderAutomationApprovedMessage)
+			view.Output(views.EmptyMessage)
+		}
+	default:
+		// Handle Invalid or unexpected action types
+		panic(fmt.Sprintf("When installing providers described in the config Terraform couldn't determine what 'safe init' action should be taken and returned action type %T. This is a bug in Terraform and should be reported.", action))
+	}
+
+	return diags
+}
+
+// promptStateStorageProviderApproval is used when Terraform is unsure about the safety of the provider downloaded for state storage
+// purposes, and we need to prompt the user to approve or reject using it.
+func (m *Meta) promptStateStorageProviderApproval(stateStorageProvider addrs.Provider, locksAfterInstall *depsfile.Locks, authResult *getproviders.PackageAuthenticationResult) tfdiags.Diagnostics {
+	var diags tfdiags.Diagnostics
+
+	// If we can receive input then we prompt for ok from the user
+	lock := locksAfterInstall.Provider(stateStorageProvider)
+
+	var hashList strings.Builder
+	for _, hash := range lock.PreferredHashes() {
+		hashList.WriteString(fmt.Sprintf("- %s\n", hash))
+	}
+
+	var authentication string
+	if authResult != nil && authResult.KeyID != "" {
+		authentication = fmt.Sprintf("%s, key ID %s", authResult.String(), authResult.KeyID)
+	} else {
+		authentication = authResult.String()
+	}
+
+	v, err := m.UIInput().Input(context.Background(), &terraform.InputOpts{
+		Id: "approve",
+		Query: fmt.Sprintf(`Do you want to use provider %q (%s), version %s, for managing state?
+Platform: %s
+Authentication: %s
+Hashes:
+%s
+`,
+			lock.Provider().Type,
+			lock.Provider(),
+			lock.Version(),
+			getproviders.CurrentPlatform.String(),
+			authentication,
+			hashList.String(),
+		),
+		Description: fmt.Sprintf(`Check the details above for provider %q and confirm that you trust the provider.
+	Only 'yes' will be accepted to confirm.`, lock.Provider().Type),
+	})
+	if err != nil {
+		return diags.Append(fmt.Errorf("Failed to approve use of state storage provider: %s", err))
+	}
+	if v != "yes" {
+		return diags.Append(
+			fmt.Errorf("State store provider %q (%s) was not approved, so init cannot continue.",
+				lock.Provider().Type,
+				lock.Provider(),
+			),
+		)
+	}
+	return diags
+}
+
 //-------------------------------------------------------------------
 // Output constants and initialization code
 //-------------------------------------------------------------------

--- a/internal/command/meta_backend_test.go
+++ b/internal/command/meta_backend_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 
 	"github.com/apparentlymart/go-versions/versions"
+	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/cli"
 	version "github.com/hashicorp/go-version"
 	"github.com/hashicorp/hcl/v2"
@@ -24,6 +25,7 @@ import (
 	"github.com/hashicorp/terraform/internal/cloud"
 	"github.com/hashicorp/terraform/internal/command/arguments"
 	"github.com/hashicorp/terraform/internal/command/clistate"
+	"github.com/hashicorp/terraform/internal/command/views"
 	"github.com/hashicorp/terraform/internal/command/workdir"
 	"github.com/hashicorp/terraform/internal/configs"
 	"github.com/hashicorp/terraform/internal/configs/configschema"
@@ -3175,6 +3177,255 @@ func TestMetaBackend_prepareBackend(t *testing.T) {
 		schema := b.ConfigSchema()
 		if _, ok := schema.Attributes["value"]; !ok {
 			t.Fatalf("expected the operations backend to report the schema of the state_store, but got something unexpected: %#v", schema)
+		}
+	})
+}
+
+// If `state migrate` is run while Terraform in in automation (-input=false) then TF expects a pre-existing lock for the
+// state store provider(s) to be available. Users can give supplementary lock files via the -source-provider-lock-file and
+// -destination-provider-lock-file flags, but otherwise TF will use the working directory lock file by default.
+//
+// This test shows all the different error messages that can be returned when the necessary lock isn't present.
+// The user is told different things based on what inputs affect finding the lock.
+func Test_handleSafeProviderInstallAction_inAutomation(t *testing.T) {
+	// Reused in tests and unchanged
+	m := Meta{
+		input: false,
+	}
+	const action = RequireApproval
+	const flagLockfilePath = ""
+	p := addrs.NewDefaultProvider("test")
+	providerLock := depsfile.NewLocks()
+	providerLock.SetProvider(
+		p,
+		versions.MustParseVersion("1.0.0"),
+		nil,
+		nil,
+	)
+	auth := getproviders.NewPackageAuthenticationResult(1, "test-key-id")
+
+	t.Run("init command in automation, empty default lock file used", func(t *testing.T) {
+		// Scenario involves the init command, and using the working directory lock file by default.
+		c := &InitCommand{
+			Meta: m,
+		}
+		view, _ := testView(t)
+		initView := views.NewInit(arguments.ViewHuman, view)
+		workDirLocks := depsfile.NewLocks() // working directory lock file is empty
+
+		gotDiags := m.handleSafeProviderInstallAction(action, p, auth, providerLock, workDirLocks, flagLockfilePath, c, initView)
+
+		// Expect an error due to the provider download not being controlled by a pre-existing lock
+		if !gotDiags.HasErrors() {
+			t.Fatal("expected an error but got none")
+		}
+		errorDiag := gotDiags[0]
+
+		expectedSummary := "Missing lock for state store provider"
+		expectedDetail := `Terraform is initializing a state store for the first time in a non-interactive mode but no lock was found for the state store provider.
+Terraform used the working directory's lock file by default, but it was empty or did not exist.
+
+When performing a "terraform init" command in automation, make sure to supply a lock file for the state store provider using the -state-provider-lock-file flag.
+
+To fix this, create a minimal configuration containing the specific provider version(s) you need and then perform "terraform init" with input enabled. Check the contents of the lock file created by that command and then retry "terraform init -state-provider-lock-file=<path to lockfile>".
+`
+		if errorDiag.Description().Summary != expectedSummary {
+			t.Fatalf("expected summary %q but got %q", expectedSummary, errorDiag.Description().Summary)
+		}
+		if diff := cmp.Diff(expectedDetail, errorDiag.Description().Detail); diff != "" {
+			t.Fatalf("didn't get expected error diagnostic detail\ndiff:\n%s\n got:\n%s\nwant:\n%s", diff, errorDiag.Description().Detail, expectedDetail)
+		}
+	})
+
+	t.Run("state migrate command in automation, empty default lock file used", func(t *testing.T) {
+		// Scenario involves the state migrate command, and using the working directory lock file by default.
+		c := &StateMigrateCommand{
+			Meta: m,
+		}
+		view, _ := testView(t)
+		smView := views.NewStateMigrate(arguments.ViewHuman, view)
+		workDirLocks := depsfile.NewLocks() // working directory lock file is empty
+
+		gotDiags := m.handleSafeProviderInstallAction(action, p, auth, providerLock, workDirLocks, flagLockfilePath, c, smView)
+
+		// Expect an error due to the provider download not being controlled by a pre-existing lock
+		if !gotDiags.HasErrors() {
+			t.Fatal("expected an error but got none")
+		}
+		errorDiag := gotDiags[0]
+
+		expectedSummary := "Missing lock for state store provider"
+		expectedDetail := `Terraform is initializing a state store for the first time in a non-interactive mode but no lock was found for the state store provider.
+Terraform used the working directory's lock file by default, but it was empty or did not exist.
+
+When performing a "terraform state migrate" command in automation, make sure to supply a lock file for the source and/or destination state store providers using -source-provider-lock-file and/or -destination-provider-lock-file flags.
+
+To fix this, create a minimal configuration(s) containing the specific provider version(s) you need and then perform "terraform init" with input enabled. Check the contents of the lock file created by that command and then retry "terraform state migrate -source-provider-lock-file=<path to lockfile> -destination-provider-lock-file=<path to lockfile>".`
+		if errorDiag.Description().Summary != expectedSummary {
+			t.Fatalf("expected summary %q but got %q", expectedSummary, errorDiag.Description().Summary)
+		}
+		if diff := cmp.Diff(expectedDetail, errorDiag.Description().Detail); diff != "" {
+			t.Fatalf("didn't get expected error diagnostic detail\ndiff:\n%s\n got:\n%s\nwant:\n%s", diff, errorDiag.Description().Detail, expectedDetail)
+		}
+	})
+
+	t.Run("init command in automation, default lock file lacks required lock", func(t *testing.T) {
+		// Scenario involves the init command, and using the working directory lock file by default
+		c := &InitCommand{
+			Meta: m,
+		}
+		view, _ := testView(t)
+		initView := views.NewInit(arguments.ViewHuman, view)
+		// working directory lock file isn't empty, but has no lock for hashicorp/test provider
+		workDirLocks := depsfile.NewLocks()
+		workDirLocks.SetProvider(
+			addrs.NewDefaultProvider("not-pss-provider"),
+			versions.MustParseVersion("1.0.0"),
+			nil,
+			nil,
+		)
+
+		gotDiags := m.handleSafeProviderInstallAction(action, p, auth, providerLock, workDirLocks, flagLockfilePath, c, initView)
+
+		// Expect an error due to the provider download not being controlled by a pre-existing lock
+		if !gotDiags.HasErrors() {
+			t.Fatal("expected an error but got none")
+		}
+		errorDiag := gotDiags[0]
+
+		expectedSummary := "Missing lock for state store provider"
+		expectedDetail := `Terraform is initializing a state store for the first time in a non-interactive mode but no lock was found for the state store provider.
+Terraform used the working directory's lock file by default, but it did not contain a lock for the state store provider.
+
+When performing a "terraform init" command in automation, make sure to supply a lock file for the state store provider using the -state-provider-lock-file flag.
+
+To fix this, create a minimal configuration containing the specific provider version(s) you need and then perform "terraform init" with input enabled. Check the contents of the lock file created by that command and then retry "terraform init -state-provider-lock-file=<path to lockfile>".
+`
+		if errorDiag.Description().Summary != expectedSummary {
+			t.Fatalf("expected summary %q but got %q", expectedSummary, errorDiag.Description().Summary)
+		}
+		if diff := cmp.Diff(expectedDetail, errorDiag.Description().Detail); diff != "" {
+			t.Fatalf("didn't get expected error diagnostic detail\ndiff:\n%s\n got:\n%s\nwant:\n%s", diff, errorDiag.Description().Detail, expectedDetail)
+		}
+	})
+
+	t.Run("state migrate command in automation, default lock file lacks required lock", func(t *testing.T) {
+		// Scenario involves the state migrate command, and using the working directory lock file by default
+		c := &StateMigrateCommand{
+			Meta: m,
+		}
+		view, _ := testView(t)
+		smView := views.NewStateMigrate(arguments.ViewHuman, view)
+		// working directory lock file isn't empty, but has no lock for hashicorp/test provider
+		workDirLocks := depsfile.NewLocks()
+		workDirLocks.SetProvider(
+			addrs.NewDefaultProvider("not-pss-provider"),
+			versions.MustParseVersion("1.0.0"),
+			nil,
+			nil,
+		)
+
+		gotDiags := m.handleSafeProviderInstallAction(action, p, auth, providerLock, workDirLocks, flagLockfilePath, c, smView)
+
+		// Expect an error due to the provider download not being controlled by a pre-existing lock
+		if !gotDiags.HasErrors() {
+			t.Fatal("expected an error but got none")
+		}
+		errorDiag := gotDiags[0]
+
+		expectedSummary := "Missing lock for state store provider"
+		expectedDetail := `Terraform is initializing a state store for the first time in a non-interactive mode but no lock was found for the state store provider.
+Terraform used the working directory's lock file by default, but it did not contain a lock for the state store provider.
+
+When performing a "terraform state migrate" command in automation, make sure to supply a lock file for the source and/or destination state store providers using -source-provider-lock-file and/or -destination-provider-lock-file flags.
+
+To fix this, create a minimal configuration(s) containing the specific provider version(s) you need and then perform "terraform init" with input enabled. Check the contents of the lock file created by that command and then retry "terraform state migrate -source-provider-lock-file=<path to lockfile> -destination-provider-lock-file=<path to lockfile>".`
+		if errorDiag.Description().Summary != expectedSummary {
+			t.Fatalf("expected summary %q but got %q", expectedSummary, errorDiag.Description().Summary)
+		}
+		if diff := cmp.Diff(expectedDetail, errorDiag.Description().Detail); diff != "" {
+			t.Fatalf("didn't get expected error diagnostic detail\ndiff:\n%s\n got:\n%s\nwant:\n%s", diff, errorDiag.Description().Detail, expectedDetail)
+		}
+	})
+
+	t.Run("init command in automation, user-supplied lock file lacks required lock", func(t *testing.T) {
+		// Scenario involves the init command, and using a user-supplied lock file
+		c := &InitCommand{
+			Meta: m,
+		}
+		view, _ := testView(t)
+		initView := views.NewInit(arguments.ViewHuman, view)
+		// user-supplied lock file isn't empty, but has no lock for hashicorp/test provider
+		inputLocks := depsfile.NewLocks()
+		inputLocks.SetProvider(
+			addrs.NewDefaultProvider("not-pss-provider"),
+			versions.MustParseVersion("1.0.0"),
+			nil,
+			nil,
+		)
+
+		setFlagLockfilePath := "./user-supplied-lockfile/terraform.lock.hcl"
+		gotDiags := m.handleSafeProviderInstallAction(action, p, auth, providerLock, inputLocks, setFlagLockfilePath, c, initView)
+
+		// Expect an error due to the provider download not being controlled by a pre-existing lock
+		if !gotDiags.HasErrors() {
+			t.Fatal("expected an error but got none")
+		}
+		errorDiag := gotDiags[0]
+
+		expectedSummary := "Missing lock for state store provider"
+		expectedDetail := `Terraform is initializing a state store for the first time in a non-interactive mode but no lock was found for the state store provider.
+The lock file at "./user-supplied-lockfile/terraform.lock.hcl" (supplied via CLI flag) was empty or did not contain a lock for the state store provider.
+
+When performing a "terraform init" command in automation, make sure to supply a lock file for the state store provider using the -state-provider-lock-file flag.
+
+To fix this, create a minimal configuration containing the specific provider version(s) you need and then perform "terraform init" with input enabled. Check the contents of the lock file created by that command and then retry "terraform init -state-provider-lock-file=<path to lockfile>".
+`
+		if errorDiag.Description().Summary != expectedSummary {
+			t.Fatalf("expected summary %q but got %q", expectedSummary, errorDiag.Description().Summary)
+		}
+		if diff := cmp.Diff(expectedDetail, errorDiag.Description().Detail); diff != "" {
+			t.Fatalf("didn't get expected error diagnostic detail\ndiff:\n%s\n got:\n%s\nwant:\n%s", diff, errorDiag.Description().Detail, expectedDetail)
+		}
+	})
+
+	t.Run("state migrate command in automation, user-supplied lock file lacks required lock", func(t *testing.T) {
+		// Scenario involves the state migrate command, and using the working directory lock file by default
+		c := &StateMigrateCommand{
+			Meta: m,
+		}
+		view, _ := testView(t)
+		smView := views.NewStateMigrate(arguments.ViewHuman, view)
+		// user-supplied lock file isn't empty, but has no lock for hashicorp/test provider
+		inputLocks := depsfile.NewLocks()
+		inputLocks.SetProvider(
+			addrs.NewDefaultProvider("not-pss-provider"),
+			versions.MustParseVersion("1.0.0"),
+			nil,
+			nil,
+		)
+
+		setFlagLockfilePath := "./user-supplied-lockfile/terraform.lock.hcl"
+		gotDiags := m.handleSafeProviderInstallAction(action, p, auth, providerLock, inputLocks, setFlagLockfilePath, c, smView)
+
+		// Expect an error due to the provider download not being controlled by a pre-existing lock
+		if !gotDiags.HasErrors() {
+			t.Fatal("expected an error but got none")
+		}
+		errorDiag := gotDiags[0]
+
+		expectedSummary := "Missing lock for state store provider"
+		expectedDetail := `Terraform is initializing a state store for the first time in a non-interactive mode but no lock was found for the state store provider.
+The lock file at "./user-supplied-lockfile/terraform.lock.hcl" (supplied via CLI flag) was empty or did not contain a lock for the state store provider.
+
+When performing a "terraform state migrate" command in automation, make sure to supply a lock file for the source and/or destination state store providers using -source-provider-lock-file and/or -destination-provider-lock-file flags.
+
+To fix this, create a minimal configuration(s) containing the specific provider version(s) you need and then perform "terraform init" with input enabled. Check the contents of the lock file created by that command and then retry "terraform state migrate -source-provider-lock-file=<path to lockfile> -destination-provider-lock-file=<path to lockfile>".`
+		if errorDiag.Description().Summary != expectedSummary {
+			t.Fatalf("expected summary %q but got %q", expectedSummary, errorDiag.Description().Summary)
+		}
+		if diff := cmp.Diff(expectedDetail, errorDiag.Description().Detail); diff != "" {
+			t.Fatalf("didn't get expected error diagnostic detail\ndiff:\n%s\n got:\n%s\nwant:\n%s", diff, errorDiag.Description().Detail, expectedDetail)
 		}
 	})
 }

--- a/internal/command/meta_dependencies.go
+++ b/internal/command/meta_dependencies.go
@@ -4,10 +4,15 @@
 package command
 
 import (
+	"fmt"
 	"log"
 	"os"
+	"sort"
+	"strings"
 
+	"github.com/hashicorp/terraform/internal/command/views"
 	"github.com/hashicorp/terraform/internal/depsfile"
+	"github.com/hashicorp/terraform/internal/getproviders"
 	"github.com/hashicorp/terraform/internal/tfdiags"
 )
 
@@ -59,6 +64,8 @@ func (m *Meta) readLockedDependenciesFromPath(filename string) (*depsfile.Locks,
 // replaceLockedDependencies creates or overwrites the lock file in the
 // current working directory to contain the information recorded in the given
 // locks object.
+//
+// See saveDependencyLockFile, an opinionated wrapper for this method.
 func (m *Meta) replaceLockedDependencies(new *depsfile.Locks) tfdiags.Diagnostics {
 	return depsfile.SaveLocksToFile(new, dependencyLockFilename)
 }
@@ -131,4 +138,70 @@ func (m *Meta) annotateDependencyLocksWithOverrides(ret *depsfile.Locks) *depsfi
 	}
 
 	return ret
+}
+
+// saveDependencyLockFile can overwrite the contents of the dependency lock file.
+// If the locks match the previous locks, then the file is not updated and no output is produced.
+// If a "readonly" -lockfile flag is supplied then changing the file is blocked.
+func (m *Meta) saveDependencyLockFile(previousLocks, newLocks *depsfile.Locks, incompleteProviders []string, flagLockfile string, view views.ProviderInstaller) (output bool, diags tfdiags.Diagnostics) {
+	// If the provider dependencies have changed since the last run then we'll
+	// say a little about that in case the reader wasn't expecting a change.
+	// (When we later integrate module dependencies into the lock file we'll
+	// probably want to refactor this so that we produce one lock-file related
+	// message for all changes together, but this is here for now just because
+	// it's the smallest change relative to what came before it, which was
+	// a hidden JSON file specifically for tracking providers.)
+	if !newLocks.Equal(previousLocks) {
+		// if readonly mode
+		if flagLockfile == "readonly" {
+			// check if required provider dependencies change
+			if !newLocks.EqualProviderAddress(previousLocks) {
+				diags = diags.Append(tfdiags.Sourceless(
+					tfdiags.Error,
+					`Provider dependency changes detected`,
+					`Changes to the required provider dependencies were detected, but the lock file is read-only. To use and record these requirements, run "terraform init" without the "-lockfile=readonly" flag.`,
+				))
+				return output, diags
+			}
+			// suppress updating the file to record any new information it learned,
+			// such as a hash using a new scheme.
+			diags = diags.Append(tfdiags.Sourceless(
+				tfdiags.Warning,
+				`Provider lock file not updated`,
+				`Changes to the provider selections were detected, but not saved in the .terraform.lock.hcl file. To record these selections, run "terraform init" without the "-lockfile=readonly" flag.`,
+			))
+			return output, diags
+		}
+		// Jump in here and add a warning if any of the providers are incomplete.
+		if len(incompleteProviders) > 0 {
+			// We don't really care about the order here, we just want the
+			// output to be deterministic.
+			sort.Slice(incompleteProviders, func(i, j int) bool {
+				return incompleteProviders[i] < incompleteProviders[j]
+			})
+			diags = diags.Append(tfdiags.Sourceless(
+				tfdiags.Warning,
+				incompleteLockFileInformationHeader,
+				fmt.Sprintf(
+					incompleteLockFileInformationBody,
+					strings.Join(incompleteProviders, "\n  - "),
+					getproviders.CurrentPlatform.String())))
+		}
+		if previousLocks.Empty() {
+			// A change from empty to non-empty is special because it suggests
+			// we're running "terraform init" for the first time against a
+			// new configuration. In that case we'll take the opportunity to
+			// say a little about what the dependency lock file is, for new
+			// users or those who are upgrading from a previous Terraform
+			// version that didn't have dependency lock files.
+			view.Output(views.LockInfo)
+			output = true
+		} else {
+			view.Output(views.DependenciesLockChangesInfo)
+			output = true
+		}
+		lockFileDiags := m.replaceLockedDependencies(newLocks)
+		diags = diags.Append(lockFileDiags)
+	}
+	return output, diags
 }

--- a/internal/command/state_migrate.go
+++ b/internal/command/state_migrate.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"fmt"
 	"path/filepath"
-	"sort"
 	"strings"
 
 	"github.com/hashicorp/hcl/v2"
@@ -415,45 +414,14 @@ func (c *StateMigrateCommand) getDestinationStateStoreProviderRequirements(provi
 // The calling code is expected to provide:
 // 1. the previous locks (if any)
 // 2. the lock for the destination state store provider (if any)
-func (c *StateMigrateCommand) saveDependencyLockFile(previousLocks, locksWithDstProvider *depsfile.Locks, view views.StateMigrate) (output bool, diags tfdiags.Diagnostics) {
+func (c *StateMigrateCommand) saveDependencyLockFile(previousLocks, dstProviderLock *depsfile.Locks, view views.StateMigrate) (output bool, diags tfdiags.Diagnostics) {
 	// Get the combination of locks from both potential provider download steps.
-	newLocks := c.mergeLockedDependencies(previousLocks, locksWithDstProvider)
+	newLocks := c.mergeLockedDependencies(dstProviderLock, previousLocks)
 
-	// If the provider dependencies have changed since the last run then we'll
-	// say a little about that in case the reader wasn't expecting a change.
-	if !newLocks.Equal(previousLocks) {
-		// Jump in here and add a warning if any of the providers are incomplete.
-		if len(c.incompleteProviders) > 0 {
-			// We don't really care about the order here, we just want the
-			// output to be deterministic.
-			sort.Slice(c.incompleteProviders, func(i, j int) bool {
-				return c.incompleteProviders[i] < c.incompleteProviders[j]
-			})
-			diags = diags.Append(tfdiags.Sourceless(
-				tfdiags.Warning,
-				incompleteLockFileInformationHeader,
-				fmt.Sprintf(
-					incompleteLockFileInformationBody,
-					strings.Join(c.incompleteProviders, "\n  - "),
-					getproviders.CurrentPlatform.String())))
-		}
-		if previousLocks.Empty() {
-			// A change from empty to non-empty is special because it suggests
-			// we're running "terraform init" for the first time against a
-			// new configuration. In that case we'll take the opportunity to
-			// say a little about what the dependency lock file is, for new
-			// users or those who are upgrading from a previous Terraform
-			// version that didn't have dependency lock files.
-			view.LogInitMessage(views.LockInfo)
-			output = true
-		} else {
-			view.LogInitMessage(views.DependenciesLockChangesInfo)
-			output = true
-		}
-		lockFileDiags := c.replaceLockedDependencies(newLocks)
-		diags = diags.Append(lockFileDiags)
-	}
-	return output, diags
+	// The state migrate command does not support the -lockfile=readonly flag
+	flagLockfile := ""
+
+	return c.Meta.saveDependencyLockFile(previousLocks, newLocks, c.incompleteProviders, flagLockfile, view)
 }
 
 // getSingleProvider is used to download the source and/or destination state store providers during a state migration.

--- a/internal/command/state_migrate.go
+++ b/internal/command/state_migrate.go
@@ -295,13 +295,20 @@ func (c *StateMigrateCommand) Run(rawArgs []string) int {
 			stateMigrate.Diagnostics(diags)
 			return 1
 		}
-		output, depLockFileDiags := c.saveDependencyLockFile(originalLocks, destinationLock, stateMigrate)
+
+		// Get the combination of locks
+		//
+		// Take the lock from the destination provider download and add in the original locks from the dependency lock file.
+		// This means the lock created from the destination provider download is authoritative (e.g. any hashes from the
+		// installation process are preserved)
+		newLocks := c.mergeLockedDependencies(destinationLock, originalLocks)
+
+		output, depLockFileDiags := c.saveDependencyLockFile(originalLocks, newLocks, stateMigrate)
 		diags = diags.Append(depLockFileDiags)
 		if depLockFileDiags.HasErrors() {
 			stateMigrate.Diagnostics(diags)
 			return 1
 		}
-
 		if output {
 			stateMigrate.LogInitMessage(views.EmptyMessage)
 		}
@@ -411,14 +418,10 @@ func (c *StateMigrateCommand) getDestinationStateStoreProviderRequirements(provi
 }
 
 // saveDependencyLockFile overwrites the contents of the dependency lock file.
-// The calling code is expected to provide:
-// 1. the previous locks (if any)
-// 2. the lock for the destination state store provider (if any)
-func (c *StateMigrateCommand) saveDependencyLockFile(previousLocks, dstProviderLock *depsfile.Locks, view views.StateMigrate) (output bool, diags tfdiags.Diagnostics) {
-	// Get the combination of locks from both potential provider download steps.
-	newLocks := c.mergeLockedDependencies(dstProviderLock, previousLocks)
-
+func (c *StateMigrateCommand) saveDependencyLockFile(previousLocks, newLocks *depsfile.Locks, view views.StateMigrate) (output bool, diags tfdiags.Diagnostics) {
 	// The state migrate command does not support the -lockfile=readonly flag
+	// This flag is specific to the init command, and can only take "" or "readonly" as values.
+	// As state migrate doesn't take this flag, we can safely set it to "" here.
 	flagLockfile := ""
 
 	return c.Meta.saveDependencyLockFile(previousLocks, newLocks, c.incompleteProviders, flagLockfile, view)

--- a/internal/command/state_migrate_test.go
+++ b/internal/command/state_migrate_test.go
@@ -561,7 +561,11 @@ provider "registry.terraform.io/hashicorp/test2" {
 
 provider "registry.terraform.io/hashicorp/test2" {
   version = "3.2.1"
-}`
+  hashes = [
+    "h1:gv1gFnIZulslzchnaoyMJ5KoPvoRgVvSGb3tVS803iw=",
+  ]
+}
+`
 		if err := os.WriteFile(filepath.Join(wd.RootModuleDir(), dependencyLockFilename), []byte(lockFileContents), 0644); err != nil {
 			t.Fatalf("unable to overwrite dependency lock file as part of test setup: %s", err)
 		}


### PR DESCRIPTION
This PR takes some logic implemented as methods on the `init` command and moves them to methods on the `Meta`, as this enables reuse between multiple commands.

Methods that were moved:
* `promptStateStorageProviderApproval` method moved from InitCommand to Meta receiver
* `saveDependencyLockFile` method moved from InitCommand to Meta receiver
    * The equivalent method on StateMigrateCommand still exists but is a shallow wrapper of the new shared method.

Methods that were created:
* Logic for determining whether Terraform should prompt for approval of a provider or not after install => `determineSafeProviderInstallAction` method
* Logic for deciding whether to prompt the user or not => `handleSafeProviderInstallAction` method

This refactoring is part of preparing to add PSS-related security features to the `state migrate` command, and if part of decomposing this draft PR: https://github.com/hashicorp/terraform/pull/38813


## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.16.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
