### PR TITLE
Reliably show the `terraform login` success page

### DIFF
--- a/.changes/v1.16/BUG-FIXES-20260701-140925.yaml
+++ b/.changes/v1.16/BUG-FIXES-20260701-140925.yaml
@@ -1,0 +1,5 @@
+kind: BUG FIXES
+body: "`terraform login` now reliably shows the success page in the browser after authorization completes"
+time: 2026-07-01T14:09:25.589760-04:00
+custom:
+    Issue: "38816"

--- a/internal/command/login.go
+++ b/internal/command/login.go
@@ -508,7 +508,7 @@ func (c *LoginCommand) interactiveGetTokenByCode(hostname svchost.Hostname, cred
 		return nil, diags
 	}
 
-	if err := server.Close(); err != nil {
+	if err := server.Shutdown(context.Background()); err != nil {
 		// The server will close soon enough when our process exits anyway,
 		// so we won't fuss about it for right now.
 		log.Printf("[WARN] login: callback server can't shut down: %s", err)


### PR DESCRIPTION
Fixes #38712.

When completing `terraform login`, the browser sometimes did not show the success page because the temporary local callback server could be shut down before the response finished sending. It now waits for the in-flight response to complete before shutting down, so the success page is shown reliably.

Affected package tests pass locally.