### PR TITLE
PSS: Enable `state migrate` to update the backend state file after successful state migration

### DIFF
--- a/internal/command/state_migrate.go
+++ b/internal/command/state_migrate.go
@@ -67,6 +67,9 @@ func (c *StateMigrateCommand) Run(rawArgs []string) int {
 		stateMigrate.Diagnostics(diags)
 		return 1
 	}
+	if cfg.Module.StateStore != nil {
+		cfg.Module.StateStore.ProviderSupplyMode = c.getProviderSupplyModeForStateStore(cfg.Module)
+	}
 
 	smi := cfg.Module.StateMigrationInstructions
 	if smi == nil {

--- a/internal/command/state_migrate.go
+++ b/internal/command/state_migrate.go
@@ -6,13 +6,16 @@ package command
 import (
 	"context"
 	"fmt"
+	"path/filepath"
 	"sort"
 	"strings"
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/terraform/internal/addrs"
 	"github.com/hashicorp/terraform/internal/command/arguments"
+	"github.com/hashicorp/terraform/internal/command/clistate"
 	"github.com/hashicorp/terraform/internal/command/views"
+	"github.com/hashicorp/terraform/internal/command/workdir"
 	"github.com/hashicorp/terraform/internal/configs"
 	"github.com/hashicorp/terraform/internal/depsfile"
 	"github.com/hashicorp/terraform/internal/getproviders"
@@ -82,8 +85,8 @@ func (c *StateMigrateCommand) Run(rawArgs []string) int {
 		return 1
 	}
 
-	// TODO: Account for cases where lock entries are missing
-
+	// When configuring the source and destination backends,
+	// we prepare options for the migration action.
 	migrateOpts := &backendMigrateOpts{
 		ViewType: args.ViewType,
 	}
@@ -132,15 +135,37 @@ func (c *StateMigrateCommand) Run(rawArgs []string) int {
 	// Load the destination backend
 	rootMod := cfg.Module
 	var destination string
-	var destinationLock *depsfile.Locks // This should only contain a single lock, if non nil. Used to update the dependency lock file on disk.
+	var destinationLock *depsfile.Locks                               // This should only contain a single lock, if non nil. Used to update the dependency lock file on disk.
+	var bsf *workdir.BackendStateFile = workdir.NewBackendStateFile() // Collect data below for updating the backend state file.
 	if rootMod.Backend != nil {
 		destination = fmt.Sprintf("backend %q", rootMod.Backend.Type)
 
-		dstB, _, dstDiags := c.Meta.backendInitFromConfig(rootMod.Backend)
+		dstB, dstConfig, dstDiags := c.Meta.backendInitFromConfig(rootMod.Backend)
 		diags = diags.Append(dstDiags)
 		if !diags.HasErrors() {
+			// Assign migration options for the migration action later in the command
 			migrateOpts.DestinationType = rootMod.Backend.Type
 			migrateOpts.Destination = dstB
+
+			// Capture details of the destination backend for updating the backend state file after a successful migration.
+			_, cHash, bcDiags := c.backendConfig(&BackendOpts{
+				BackendConfig: rootMod.Backend,
+			})
+			diags = diags.Append(bcDiags)
+			if bcDiags.HasErrors() {
+				stateMigrate.Diagnostics(diags)
+				return 1
+			}
+			bsf.Backend = &workdir.BackendConfigState{
+				Type: rootMod.Backend.Type,
+				Hash: uint64(cHash),
+			}
+			err := bsf.Backend.SetConfig(dstConfig, dstB.ConfigSchema())
+			if err != nil {
+				diags = diags.Append(fmt.Errorf("Can't serialize backend configuration as JSON: %s", err))
+				stateMigrate.Diagnostics(diags)
+				return 1
+			}
 		}
 	} else if rootMod.StateStore != nil {
 		destination = fmt.Sprintf("state store %q (%s)", rootMod.StateStore.Type,
@@ -190,12 +215,54 @@ func (c *StateMigrateCommand) Run(rawArgs []string) int {
 			return 1
 		}
 
-		dstB, _, _, dstDiags := c.Meta.stateStoreInitFromConfig(rootMod.StateStore, destinationLock)
+		dstB, stateStoreConfigVal, providerConfigVal, dstDiags := c.Meta.stateStoreInitFromConfig(rootMod.StateStore, destinationLock)
 		diags = diags.Append(dstDiags)
 		if !diags.HasErrors() {
 			migrateOpts.DestinationType = rootMod.StateStore.Type
 			migrateOpts.Destination = dstB
 		}
+
+		// Capture details of the destination state store for updating the backend state file after a successful migration.
+		_, cHash, sscDiags := c.stateStoreConfig(&BackendOpts{
+			StateStoreConfig: rootMod.StateStore,
+			Locks:            destinationLock,
+		})
+		diags = diags.Append(sscDiags)
+		if sscDiags.HasErrors() {
+			stateMigrate.Diagnostics(diags)
+			return 1
+		}
+		v := destinationLock.Provider(rootMod.StateStore.ProviderAddr).Version() // We just downloaded this provider, so the lock wil be present.
+		version, err := providerreqs.GoVersionFromVersion(v)
+		if err != nil {
+			diags = diags.Append(fmt.Errorf("Failed to convert provider version to Go version: %s", err))
+			stateMigrate.Diagnostics(diags)
+			return 1
+		}
+
+		bsf.StateStore = &workdir.StateStoreConfigState{
+			Type: rootMod.StateStore.Type,
+			Hash: uint64(cHash),
+			Provider: &workdir.ProviderConfigState{
+				Source:  &rootMod.StateStore.ProviderAddr,
+				Version: version,
+			},
+			ProviderSupplyMode: rootMod.StateStore.ProviderSupplyMode,
+		}
+		err = bsf.StateStore.SetConfig(stateStoreConfigVal, dstB.ConfigSchema())
+		if err != nil {
+			diags = diags.Append(fmt.Errorf("Failed to set state store configuration: %w", err))
+			stateMigrate.Diagnostics(diags)
+			return 1
+		}
+
+		err = bsf.StateStore.Provider.SetConfig(providerConfigVal, dstB.ProviderSchema())
+		if err != nil {
+			diags = diags.Append(fmt.Errorf("Failed to set state store provider configuration: %w", err))
+			stateMigrate.Diagnostics(diags)
+			return 1
+		}
+
 	} else {
 		diags = diags.Append(tfdiags.Sourceless(
 			tfdiags.Error,
@@ -241,7 +308,15 @@ func (c *StateMigrateCommand) Run(rawArgs []string) int {
 		}
 	}
 
-	stateMigrate.Diagnostics(diags)
+	// Success, so update backend state file to reflect the new location state is stored in.
+	bsfDiags := c.updateBackendStateFile(bsf)
+	diags = diags.Append(bsfDiags)
+	if bsfDiags.HasErrors() {
+		stateMigrate.Diagnostics(diags)
+		return 1
+	}
+
+	stateMigrate.Diagnostics(diags) // Log any warnings
 
 	stateMigrate.Log("Finished migrating state from %s to %s...", source, destination)
 
@@ -281,6 +356,28 @@ const (
 	MigrationSource      = "source"
 	MigrationDestination = "destination"
 )
+
+func (c *StateMigrateCommand) updateBackendStateFile(s *workdir.BackendStateFile) tfdiags.Diagnostics {
+	var diags tfdiags.Diagnostics
+
+	statePath := filepath.Join(c.DataDir(), DefaultStateFilename)
+	sMgr := &clistate.LocalState{Path: statePath}
+	if err := sMgr.RefreshState(); err != nil {
+		diags = diags.Append(fmt.Errorf("Failed to load the backend state file when preparing to update it: %s", err))
+		return diags
+	}
+
+	if err := sMgr.WriteState(s); err != nil {
+		diags = diags.Append(errBackendWriteSavedDiag(err))
+		return diags
+	}
+	if err := sMgr.PersistState(); err != nil {
+		diags = diags.Append(errBackendWriteSavedDiag(err))
+		return diags
+	}
+
+	return diags
+}
 
 func (c *StateMigrateCommand) getDestinationStateStoreProviderRequirements(provider addrs.Provider, configReqs *configs.RequiredProviders) (providerreqs.Requirements, tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics

--- a/internal/command/state_migrate_test.go
+++ b/internal/command/state_migrate_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/cli"
 	"github.com/hashicorp/terraform/internal/addrs"
+	"github.com/hashicorp/terraform/internal/command/clistate"
 	"github.com/hashicorp/terraform/internal/command/workdir"
 	"github.com/hashicorp/terraform/internal/configs/configschema"
 	"github.com/hashicorp/terraform/internal/providers"
@@ -68,6 +69,26 @@ func TestStateMigrate_fromBackendToBackend(t *testing.T) {
 	_, ok := s.State.RootOutputValues["test"]
 	if !ok {
 		t.Fatalf("unable to find test output in migrated state")
+	}
+
+	// Assert the backend state file describes the new backend location,
+	statePath := filepath.Join(c.DataDir(), DefaultStateFilename)
+	sMgr := &clistate.LocalState{Path: statePath}
+	if err := sMgr.RefreshState(); err != nil {
+		t.Fatal(err)
+	}
+	backendState := sMgr.State()
+	if backendState.StateStore != nil {
+		t.Fatalf("expected backend state file to not describe a state_store during backend=>backend, but it's set")
+	}
+	if backendState.Backend == nil {
+		t.Fatalf("expected backend state file to describe a backend during backend=>backend, but it's nil")
+	}
+	if backendState.Backend.Type != "local" {
+		t.Fatalf("expected backend state file to describe the destination backend \"local\", but got %q", backendState.Backend.Type)
+	}
+	if got, want := normalizeJSON(t, backendState.Backend.ConfigRaw), `{"path":"destination-backend.tfstate","workspace_dir":null}`; got != want {
+		t.Errorf("wrong config\ngot:  %s\nwant: %s", got, want)
 	}
 }
 
@@ -127,11 +148,69 @@ func TestStateMigrate_fromBackendToStateStore(t *testing.T) {
 	if !ok {
 		t.Fatalf("unable to find test output in migrated state")
 	}
+
+	// Assert the backend state file describes the new state store location.
+	statePath := filepath.Join(c.DataDir(), DefaultStateFilename)
+	sMgr := &clistate.LocalState{Path: statePath}
+	if err := sMgr.RefreshState(); err != nil {
+		t.Fatal(err)
+	}
+	backendState := sMgr.State()
+	if backendState.Backend != nil {
+		t.Fatalf("expected backend state file to not describe a backend during backend=>state_store migration, but it's set")
+	}
+	if backendState.StateStore == nil {
+		t.Fatalf("expected backend state file to describe a state store during backend=>state_store migration, but it's nil")
+	}
+	if backendState.StateStore.Provider.Source.Type != "test" {
+		t.Fatalf("expected backend state file to describe the destination state store provider \"test\", but got %q", backendState.StateStore.Provider)
+	}
+	if backendState.StateStore.Provider.Version.String() != "1.2.3" {
+		t.Fatalf("expected backend state file to describe the destination state store provider version \"1.2.3\", but got %q", backendState.StateStore.Provider.Version)
+	}
+	if backendState.StateStore.Type != "test_store" {
+		t.Fatalf("expected backend state file to describe the destination state store type \"test_store\", but got %q", backendState.StateStore.Type)
+	}
 }
 
 // Testing migration between two state stores in a single provider.
 // Different cases describe whether the source provider is already in the dependency lock file or not.
 func TestStateMigrate_fromStateStoreToStateStore_inSingleProvider(t *testing.T) {
+	// All test cases perform a migration from test_src to test_dst store implementations in v1.2.3 of hashicorp/test provider.
+	// So a common assertion func can be re-used.
+	assertBackendStateFile := func(t *testing.T, c *StateMigrateCommand) {
+		statePath := filepath.Join(c.DataDir(), DefaultStateFilename)
+		sMgr := &clistate.LocalState{Path: statePath}
+		if err := sMgr.RefreshState(); err != nil {
+			t.Fatal(err)
+		}
+
+		backendState := sMgr.State()
+		if backendState.Backend != nil {
+			t.Fatalf("expected backend state file to not describe a backend during state_store=>state_store migration, but it's set")
+		}
+		if backendState.StateStore == nil {
+			t.Fatalf("expected backend state file to describe a state store during state_store=>state_store migration, but it's nil")
+		}
+		if backendState.StateStore.Provider.Source.Type != "test" {
+			t.Fatalf("expected backend state file to describe the destination state store provider \"test\", but got %q", backendState.StateStore.Provider)
+		}
+		if backendState.StateStore.Provider.Version.String() != "1.2.3" {
+			t.Fatalf("expected backend state file to describe the destination state store provider version \"1.2.3\", but got %q", backendState.StateStore.Provider.Version)
+		}
+		if backendState.StateStore.Type != "test_dst" {
+			t.Fatalf("expected backend state file to describe the destination state store type \"test_dst\", but got %q", backendState.StateStore.Type)
+		}
+		// The state store schema is empty, so not even any null fields in expected JSON
+		if got, want := normalizeJSON(t, backendState.StateStore.ConfigRaw), `{}`; got != want {
+			t.Errorf("wrong config\ngot:  %s\nwant: %s", got, want)
+		}
+		// The provider schema includes a 'region' attr, but it's unset in config; null.
+		if got, want := normalizeJSON(t, backendState.StateStore.Provider.ConfigRaw), `{"region":null}`; got != want {
+			t.Errorf("wrong config\ngot:  %s\nwant: %s", got, want)
+		}
+	}
+
 	t.Run("provider is already in the dependency lock file", func(t *testing.T) {
 		wd := tempWorkingDirFixture(t, "state-migrate-state-store-to-state-store")
 		t.Chdir(wd.RootModuleDir())
@@ -209,6 +288,9 @@ func TestStateMigrate_fromStateStoreToStateStore_inSingleProvider(t *testing.T) 
 		if !ok {
 			t.Fatalf("unable to find test output in migrated state")
 		}
+
+		// Assert the backend state file describes the new state store location.
+		assertBackendStateFile(t, c)
 	})
 
 	t.Run("no existing dependency lock file: provider is downloaded and added to the dependency lock file", func(t *testing.T) {
@@ -306,12 +388,49 @@ func TestStateMigrate_fromStateStoreToStateStore_inSingleProvider(t *testing.T) 
 		if !strings.Contains(string(lockFileBytes), "hashicorp/test") {
 			t.Fatalf("expected provider hashicorp/test to be added to the dependency lock file, got: %s", string(lockFileBytes))
 		}
+
+		// Assert the backend state file describes the new state store location.
+		assertBackendStateFile(t, c)
 	})
 }
 
 // Test migration between two state stores in different providers.
 // Different cases describe whether the source provider is already in the dependency lock file or not.
 func TestStateMigrate_fromStateStoreToStateStore_inDifferentProviders(t *testing.T) {
+	// All test cases perform a migration to hashicorp/test2, version v3.2.1, test2_store store.
+	// So a common assertion func can be re-used.
+	assertBackendStateFile := func(t *testing.T, c *StateMigrateCommand) {
+		statePath := filepath.Join(c.DataDir(), DefaultStateFilename)
+		sMgr := &clistate.LocalState{Path: statePath}
+		if err := sMgr.RefreshState(); err != nil {
+			t.Fatal(err)
+		}
+
+		backendState := sMgr.State()
+		if backendState.Backend != nil {
+			t.Fatalf("expected backend state file to not describe a backend during state_store=>state_store migration, but it's set")
+		}
+		if backendState.StateStore == nil {
+			t.Fatalf("expected backend state file to describe a state store during state_store=>state_store migration, but it's nil")
+		}
+		if backendState.StateStore.Provider.Source.Type != "test2" {
+			t.Fatalf("expected backend state file to describe the destination state store provider \"test2\", but got %q", backendState.StateStore.Provider)
+		}
+		if backendState.StateStore.Provider.Version.String() != "3.2.1" {
+			t.Fatalf("expected backend state file to describe the destination state store provider version \"3.2.1\", but got %q", backendState.StateStore.Provider.Version)
+		}
+		if backendState.StateStore.Type != "test2_store" {
+			t.Fatalf("expected backend state file to describe the destination state store type \"test2_store\", but got %q", backendState.StateStore.Type)
+		}
+		// The state store schema is empty, so not even any null fields in expected JSON
+		if got, want := normalizeJSON(t, backendState.StateStore.ConfigRaw), `{}`; got != want {
+			t.Errorf("wrong config\ngot:  %s\nwant: %s", got, want)
+		}
+		// The provider schema includes a 'region' attr, but it's unset in config; null.
+		if got, want := normalizeJSON(t, backendState.StateStore.Provider.ConfigRaw), `{"region":"foobar"}`; got != want {
+			t.Errorf("wrong config\ngot:  %s\nwant: %s", got, want)
+		}
+	}
 	t.Run("source provider already in the dependency lock file, destination is not", func(t *testing.T) {
 		wd := tempWorkingDirFixture(t, "state-store-changed/provider-used")
 		t.Chdir(wd.RootModuleDir())
@@ -428,6 +547,9 @@ provider "registry.terraform.io/hashicorp/test2" {
 		if diff := cmp.Diff(expectedContents, string(lockFileBytes)); diff != "" {
 			t.Fatalf("unexpected dependency lock file contents, diff:\n%s", diff)
 		}
+
+		// Assert the backend state file describes the new state store location.
+		assertBackendStateFile(t, c)
 	})
 	t.Run("destination provider already in the dependency lock file, source is not", func(t *testing.T) {
 		wd := tempWorkingDirFixture(t, "state-store-changed/provider-used")
@@ -542,6 +664,9 @@ provider "registry.terraform.io/hashicorp/test2" {
 		if diff := cmp.Diff(lockFileContents, string(lockFileBytes)); diff != "" {
 			t.Fatalf("unexpected dependency lock file contents, diff:\n%s", diff)
 		}
+
+		// Assert the backend state file describes the new state store location.
+		assertBackendStateFile(t, c)
 	})
 	t.Run("no existing dependency lock file: only destination provider saved to the dependency lock file", func(t *testing.T) {
 		wd := tempWorkingDirFixture(t, "state-store-changed/provider-used")
@@ -661,6 +786,9 @@ provider "registry.terraform.io/hashicorp/test2" {
 		if diff := cmp.Diff(expectedContents, string(lockFileBytes)); diff != "" {
 			t.Fatalf("unexpected dependency lock file contents, diff:\n%s", diff)
 		}
+
+		// Assert the backend state file describes the new state store location.
+		assertBackendStateFile(t, c)
 	})
 }
 
@@ -734,6 +862,26 @@ func TestStateMigrate_fromStateStoreToBackend(t *testing.T) {
 	_, ok := s.State.RootOutputValues["test"]
 	if !ok {
 		t.Fatalf("unable to find test output in migrated state")
+	}
+
+	// Assert the backend state file describes the new backend location,
+	statePath := filepath.Join(c.DataDir(), DefaultStateFilename)
+	sMgr := &clistate.LocalState{Path: statePath}
+	if err := sMgr.RefreshState(); err != nil {
+		t.Fatal(err)
+	}
+	backendState := sMgr.State()
+	if backendState.StateStore != nil {
+		t.Fatalf("expected backend state file to not describe a state_store during state_store=>backend migration, but it's set")
+	}
+	if backendState.Backend == nil {
+		t.Fatalf("expected backend state file to describe a backend during state_store=>backend migration, but it's nil")
+	}
+	if backendState.Backend.Type != "local" {
+		t.Fatalf("expected backend state file to describe the destination backend \"local\", but got %q", backendState.Backend.Type)
+	}
+	if got, want := normalizeJSON(t, backendState.Backend.ConfigRaw), `{"path":"destination-backend.tfstate","workspace_dir":null}`; got != want {
+		t.Errorf("wrong config\ngot:  %s\nwant: %s", got, want)
 	}
 }
 

--- a/internal/command/testdata/state-migrate-state-store-to-backend/.terraform/terraform.tfstate
+++ b/internal/command/testdata/state-migrate-state-store-to-backend/.terraform/terraform.tfstate
@@ -14,6 +14,7 @@
                 "region": null
             }
         },
-        "hash": 0
+        "hash": 0,
+        "provider_supply_mode": "managed_by_terraform"
     }
 }


### PR DESCRIPTION
This was an oversight! The `state migrate` command currently successfully migrates state to the destination, but as the backend state file isn't updated any subsequent commands are stopped early due to a diff being detected between config and the backend state file. That diff should be what refers users to run the `state migrate` command, and then the command would resolve the diff by performing the migration.

After this PR users will be able to resume normal Terraform workflows after the state migration has been performed.

I've updated integration tests for `state migrate` to assert that the backend state file describes the migration destination after the migration has completed successfully.

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.17.x

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [x] This change is not user-facing.
